### PR TITLE
feat(release): automate verified builds and deployments

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -369,6 +369,24 @@ GITHUB_TOKEN=
 # Optional Docker Hub image prefix, for example docker.m.daocloud.io.
 DOCKER_DOWNLOAD_MIRROR=
 
+# Maximum time in seconds for each Docker image pull attempt.
+DOCKER_PULL_TIMEOUT_SECONDS=180
+DOCKER_PULL_RETRIES=2
+
+# Development stack network policy. Set to 1 to require all Git sources,
+# dependencies, and Docker images to be available from local caches.
+DEV_OFFLINE=0
+
+# SourceLens Git network operations use the same finite-wait policy.
+SOURCELENS_GIT_TIMEOUT_SECONDS=120
+SOURCELENS_GIT_RETRIES=2
+
+# Browser image/package version used by ./dev/stack.sh smoke.
+DEV_SMOKE_PLAYWRIGHT_VERSION=1.55.0
+
+# Browser images are much larger than normal runtime images and need a separate bound.
+DEV_SMOKE_PULL_TIMEOUT_SECONDS=900
+
 # Docker CE apt repository used for offline host packages.
 DOCKER_APT_MIRROR=https://download.docker.com/linux/ubuntu
 

--- a/.github/scripts/remote-deploy.sh
+++ b/.github/scripts/remote-deploy.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# Download one published HFL release on the target host and install or upgrade it.
+set -euo pipefail
+
+REPOSITORY="HyperBDR/hyperfilelens"
+TAG=""
+INSTALL_DIR="/opt/hyperfilelens"
+PUBLIC_HOST=""
+
+usage() {
+	cat <<'USAGE'
+Usage: remote-deploy.sh --tag vX.Y.Z --public-host HOST [options]
+
+  --repository OWNER/REPO  Public GitHub repository (default: HyperBDR/hyperfilelens)
+  --install-dir DIR        HFL install directory (default: /opt/hyperfilelens)
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+	--tag) TAG=${2:-}; shift 2 ;;
+	--public-host) PUBLIC_HOST=${2:-}; shift 2 ;;
+	--repository) REPOSITORY=${2:-}; shift 2 ;;
+	--install-dir) INSTALL_DIR=${2:-}; shift 2 ;;
+	-h | --help) usage; exit 0 ;;
+	*) printf 'ERROR: unknown argument: %s\n' "$1" >&2; exit 2 ;;
+	esac
+done
+
+[[ "${TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || { printf 'ERROR: invalid release tag\n' >&2; exit 2; }
+[[ "${REPOSITORY}" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] || { printf 'ERROR: invalid repository\n' >&2; exit 2; }
+[[ "${INSTALL_DIR}" == /opt/hyperfilelens ]] || {
+	printf 'ERROR: current HFL installer supports /opt/hyperfilelens only\n' >&2
+	exit 2
+}
+[[ -n "${PUBLIC_HOST}" && "${PUBLIC_HOST}" != *[[:space:]]* ]] || {
+	printf 'ERROR: --public-host is required\n' >&2
+	exit 2
+}
+command -v curl >/dev/null || { printf 'ERROR: curl is required\n' >&2; exit 1; }
+command -v python3 >/dev/null || { printf 'ERROR: python3 is required\n' >&2; exit 1; }
+command -v flock >/dev/null || { printf 'ERROR: flock is required\n' >&2; exit 1; }
+
+exec 9>/var/lock/hyperfilelens-deploy.lock
+if ! flock -n 9; then
+	printf 'ERROR: another HFL deployment is running\n' >&2
+	exit 1
+fi
+
+work="$(mktemp -d /var/tmp/hyperfilelens-deploy.XXXXXX)"
+trap 'rm -rf "${work}"' EXIT INT TERM
+api="https://api.github.com/repos/${REPOSITORY}/releases/tags/${TAG}"
+printf '[deploy] Resolving published release %s\n' "${TAG}"
+curl -fsSL --retry 5 --retry-all-errors --connect-timeout 20 "${api}" -o "${work}/release.json"
+
+python3 - "${work}/release.json" "${work}/assets.tsv" "${TAG}" <<'PY'
+import json
+import pathlib
+import re
+import sys
+
+release = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+tag = sys.argv[3]
+if release.get("draft"):
+    raise SystemExit("release is still a draft")
+if release.get("tag_name") != tag:
+    raise SystemExit("release tag does not match the requested tag")
+assets = {item["name"]: item["browser_download_url"] for item in release.get("assets", [])}
+selected = {}
+if "SHA256SUMS" not in assets:
+    raise SystemExit("release has no SHA256SUMS")
+selected["SHA256SUMS"] = assets["SHA256SUMS"]
+prefix = re.escape(f"hyperfilelens-{tag.removeprefix('v')}-")
+full = sorted(name for name in assets if re.fullmatch(prefix + r"[0-9a-f]{7}\.tar\.gz", name))
+if len(full) == 1:
+    selected[full[0]] = assets[full[0]]
+else:
+    parts = sorted(
+        name
+        for name in assets
+        if re.fullmatch(prefix + r"[0-9a-f]{7}\.tar\.gz\.part-[0-9]{3}", name)
+    )
+    if not parts:
+        raise SystemExit("release has neither one full package nor package parts")
+    for name in parts:
+        selected[name] = assets[name]
+pathlib.Path(sys.argv[2]).write_text(
+    "".join(f"{name}\t{url}\n" for name, url in selected.items()),
+    encoding="utf-8",
+)
+PY
+
+total_bytes="$(python3 - "${work}/release.json" "${work}/assets.tsv" <<'PY'
+import json, pathlib, sys
+release = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+selected = {line.split("\t", 1)[0] for line in pathlib.Path(sys.argv[2]).read_text().splitlines()}
+print(sum(int(asset.get("size", 0)) for asset in release.get("assets", []) if asset.get("name") in selected))
+PY
+)"
+available_bytes="$(df -PB1 /opt | awk 'NR == 2 {print $4}')"
+required_bytes=$((total_bytes * 4 + 4 * 1024 * 1024 * 1024))
+if ((available_bytes < required_bytes)); then
+	printf 'ERROR: insufficient disk: available=%s required=%s\n' "${available_bytes}" "${required_bytes}" >&2
+	exit 1
+fi
+
+while IFS=$'\t' read -r name url; do
+	[[ "${name}" =~ ^[A-Za-z0-9._-]+$ ]] || { printf 'ERROR: unsafe asset name\n' >&2; exit 1; }
+	printf '[deploy] Downloading %s\n' "${name}"
+	curl -fL --retry 5 --retry-all-errors --connect-timeout 20 "${url}" -o "${work}/${name}"
+done <"${work}/assets.tsv"
+
+package="$(find "${work}" -maxdepth 1 -type f -name 'hyperfilelens-*.tar.gz' -print -quit)"
+if [[ -z "${package}" ]]; then
+	first_part="$(find "${work}" -maxdepth 1 -type f -name 'hyperfilelens-*.tar.gz.part-000' -print -quit)"
+	[[ -n "${first_part}" ]] || { printf 'ERROR: package parts are missing\n' >&2; exit 1; }
+	package="${first_part%.part-000}"
+	cat "${package}.part-"* >"${package}"
+fi
+package_name="$(basename "${package}")"
+expected="$(awk -v file="${package_name}" '$2 == file || $2 == "*" file {print $1; exit}' "${work}/SHA256SUMS")"
+if [[ -n "${expected}" ]]; then
+	printf '%s  %s\n' "${expected}" "${package}" | sha256sum -c -
+else
+	# Split releases checksum every part; validate all downloaded parts before use.
+	while IFS= read -r part; do
+		name="$(basename "${part}")"
+		expected="$(awk -v file="${name}" '$2 == file || $2 == "*" file {print $1; exit}' "${work}/SHA256SUMS")"
+		[[ -n "${expected}" ]] || { printf 'ERROR: no checksum for %s\n' "${name}" >&2; exit 1; }
+		printf '%s  %s\n' "${expected}" "${part}" | sha256sum -c -
+	done < <(find "${work}" -maxdepth 1 -type f -name '*.part-*' | sort)
+fi
+
+mkdir -p "${work}/extract"
+tar -xzf "${package}" -C "${work}/extract"
+package_root="$(find "${work}/extract" -mindepth 1 -maxdepth 1 -type d -name 'hyperfilelens-*' -print -quit)"
+[[ -n "${package_root}" && -x "${package_root}/install.sh" ]] || {
+	printf 'ERROR: invalid HFL package layout\n' >&2
+	exit 1
+}
+
+if [[ -f "${INSTALL_DIR}/.env" && -f "${INSTALL_DIR}/VERSION" ]]; then
+	printf '[deploy] Upgrading installed HFL to %s\n' "${TAG}"
+	HFL_PUBLIC_HOST="${PUBLIC_HOST}" HFL_SHOW_GENERATED_CREDENTIALS=0 \
+		bash "${INSTALL_DIR}/install.sh" upgrade --from "${package_root}" --yes
+else
+	printf '[deploy] Installing HFL %s\n' "${TAG}"
+	HFL_PUBLIC_HOST="${PUBLIC_HOST}" HFL_SHOW_GENERATED_CREDENTIALS=0 \
+		bash "${package_root}/install.sh" install
+fi
+
+mkdir -p "${INSTALL_DIR}/packages"
+install -m 0644 "${package}" "${INSTALL_DIR}/packages/${package_name}"
+mapfile -t old_packages < <(find "${INSTALL_DIR}/packages" -maxdepth 1 -type f -name 'hyperfilelens-*.tar.gz' -printf '%T@ %p\n' | sort -nr | tail -n +3 | cut -d' ' -f2-)
+if ((${#old_packages[@]})); then
+	rm -f -- "${old_packages[@]}"
+fi
+printf '[deploy] HFL %s deployment completed\n' "${TAG}"

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -1,0 +1,580 @@
+name: Build, Release, and Deploy
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+
+concurrency:
+  group: hyperfilelens-production
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  REGISTRY: ${{ vars.REGISTRY }}
+  HFL_DEPLOY_PATH: ${{ vars.HFL_DEPLOY_PATH }}
+  HFL_PUBLIC_HOST: ${{ vars.HFL_PUBLIC_HOST }}
+  HFL_SSH_HOST: ${{ vars.HFL_SSH_HOST }}
+  HFL_SSH_PORT: ${{ vars.HFL_SSH_PORT }}
+  HFL_SSH_USER: ${{ vars.HFL_SSH_USER }}
+
+jobs:
+  prepare:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      tag: ${{ steps.version.outputs.tag }}
+      commit: ${{ steps.version.outputs.commit }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate release tag and commit
+        id: version
+        shell: bash
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF_NAME}"
+          [[ "$TAG" =~ ^v([0-9]+\.[0-9]+\.[0-9]+)$ ]]
+          VERSION="${BASH_REMATCH[1]}"
+          git fetch origin main --no-tags
+          git merge-base --is-ancestor "$GITHUB_SHA" origin/main
+          {
+            echo "version=$VERSION"
+            echo "tag=$TAG"
+            echo "commit=$GITHUB_SHA"
+          } >> "$GITHUB_OUTPUT"
+          [[ "${REGISTRY}" =~ ^[a-z0-9][a-z0-9._-]*$ ]] || {
+            echo "REGISTRY repository variable is missing or invalid" >&2
+            exit 1
+          }
+
+      - name: Create or reuse draft release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if gh release view "$GITHUB_REF_NAME" --json isDraft >/tmp/hfl-release.json 2>/dev/null; then
+            [[ "$(jq -r .isDraft /tmp/hfl-release.json)" == "true" ]] || {
+              echo "Refusing to overwrite an already-published release" >&2
+              exit 1
+            }
+          else
+            gh release create "$GITHUB_REF_NAME" \
+              --verify-tag \
+              --draft \
+              --generate-notes \
+              --title "HyperFileLens $GITHUB_REF_NAME"
+          fi
+
+  quality:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    needs: prepare
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: hyperfilelens
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d hyperfilelens"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+      redis:
+        image: redis:alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/hyperfilelens
+      REDIS_URL: redis://127.0.0.1:6379/0
+      CELERY_BROKER_URL: redis://127.0.0.1:6379/0
+      CACHE_REDIS_URL: redis://127.0.0.1:6379/1
+      SECRET_KEY: ci-only-secret-key-with-at-least-32-bytes
+      DJANGO_DEBUG: "true"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: src/frontend/package-lock.json
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: src/agent/go.mod
+          cache-dependency-path: src/agent/go.sum
+      - uses: astral-sh/setup-uv@v6
+        with:
+          version: "0.10.2"
+          enable-cache: true
+
+      - name: Release and source checks
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 tools/quality/check-english-source.py
+          ./tools/quality/check-release-contracts.sh
+          ./tools/quality/test-ci-release-assembly.sh
+          git diff --check
+          while IFS= read -r script; do bash -n "$script"; done < <(find . -path './build' -prune -o -path './data' -prune -o -type f -name '*.sh' -print)
+
+      - name: Backend checks
+        shell: bash
+        run: |
+          set -euo pipefail
+          uv sync --locked --group dev
+          uv run ruff check src/backend
+          uv run python src/backend/manage.py test
+
+      - name: Frontend checks
+        working-directory: src/frontend
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm ci
+          npm run lint
+          npm run test:ci
+          npm run build
+
+      - name: Agent checks
+        working-directory: src/agent
+        run: go test ./...
+
+  build-hfl-images:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+    needs: [prepare, quality]
+    permissions:
+      contents: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - component: hfl-backend
+            repository: hyperfilelens-backend
+            context: .
+            dockerfile: deploy/docker/backend.Dockerfile
+            cache_scope: hfl-backend
+            needs_kopia: true
+          - component: hfl-frontend
+            repository: hyperfilelens-frontend
+            context: .
+            dockerfile: deploy/docker/frontend.Dockerfile
+            cache_scope: hfl-frontend
+            needs_kopia: false
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: docker.io
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: Fetch pinned Kopia package
+        if: matrix.needs_kopia
+        run: ./tools/dependencies/fetch-kopia-deb.sh
+
+      - name: Build and push image
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
+          platforms: linux/amd64
+          push: true
+          provenance: false
+          tags: ${{ env.REGISTRY }}/${{ matrix.repository }}:${{ needs.prepare.outputs.version }}
+          build-args: |
+            KOPIA_DEB=build/dependencies/kopia/kopia_linux_amd64.deb
+            PIP_TIMEOUT=600
+            SENTRY_ENABLED=false
+            SENTRY_ENVIRONMENT=production
+            SENTRY_RELEASE=${{ needs.prepare.outputs.tag }}
+            SENTRY_TRACES_SAMPLE_RATE=0
+            SENTRY_SEND_DEFAULT_PII=false
+            VITE_SHOW_EULA=false
+          cache-from: type=gha,scope=${{ matrix.cache_scope }}
+          cache-to: type=gha,scope=${{ matrix.cache_scope }},mode=min
+
+      - name: Upload immutable image metadata
+        env:
+          GH_TOKEN: ${{ github.token }}
+          IMAGE_REF: ${{ env.REGISTRY }}/${{ matrix.repository }}:${{ needs.prepare.outputs.version }}
+          IMAGE_DIGEST: ${{ steps.build.outputs.digest }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          output="_internal-${{ matrix.component }}.json"
+          ./release/ci/write-image-metadata.sh \
+            "${{ matrix.component }}" "$IMAGE_REF" "$IMAGE_DIGEST" "$output"
+          gh release upload "${{ needs.prepare.outputs.tag }}" "$output" --clobber
+
+      - name: Disk report
+        if: always()
+        run: |
+          df -h
+          docker system df || true
+
+  build-sourcelens-images:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 120
+    needs: [prepare, quality]
+    permissions:
+      contents: write
+    strategy:
+      fail-fast: false
+      matrix:
+        component: [backend, frontend, lensnode]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: docker.io
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: Build and push bundled SourceLens component
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          ./release/ci/build-sourcelens-image.sh \
+            "${{ matrix.component }}" \
+            "$REGISTRY" \
+            "${{ needs.prepare.outputs.version }}" \
+            "_internal-sourcelens-${{ matrix.component }}.json"
+
+      - name: Upload immutable image metadata
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload "${{ needs.prepare.outputs.tag }}" \
+            "_internal-sourcelens-${{ matrix.component }}.json" --clobber
+
+      - name: Disk report and cleanup
+        if: always()
+        run: |
+          df -h
+          docker system df || true
+          docker builder prune -af || true
+
+  build-agent:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    needs: [prepare, quality]
+    permissions:
+      contents: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: linux:amd64
+            asset: linux-amd64
+          - target: linux:arm64
+            asset: linux-arm64
+          - target: darwin:amd64
+            asset: darwin-amd64
+          - target: darwin:arm64
+            asset: darwin-arm64
+          - target: windows:amd64
+            asset: windows-amd64
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: src/agent/go.mod
+          cache-dependency-path: src/agent/go.sum
+      - name: Build Agent asset
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          ./release/ci/build-agent-asset.sh \
+            "${{ matrix.target }}" \
+            "${{ needs.prepare.outputs.version }}" \
+            "${{ needs.prepare.outputs.commit }}" \
+            "_internal-agent-${{ matrix.asset }}.tar.gz"
+      - name: Upload Agent asset
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload "${{ needs.prepare.outputs.tag }}" \
+            "_internal-agent-${{ matrix.asset }}.tar.gz" --clobber
+
+  build-host-debs:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    needs: [prepare, quality]
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build host dependency asset
+        run: ./release/ci/build-host-debs-asset.sh _internal-host-debs.tar.gz
+      - name: Upload host dependency asset
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload "${{ needs.prepare.outputs.tag }}" _internal-host-debs.tar.gz --clobber
+
+  export-hfl-images:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    needs: [prepare, build-hfl-images]
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/login-action@v3
+        with:
+          registry: docker.io
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+      - name: Download image metadata
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p build/ci-metadata
+          gh release download "${{ needs.prepare.outputs.tag }}" --pattern '_internal-hfl-*.json' --dir build/ci-metadata
+          for file in build/ci-metadata/_internal-*.json; do mv "$file" "${file/_internal-/}"; done
+      - name: Export offline HFL archive
+        run: |
+          ./release/ci/export-hfl-images.sh \
+            build/ci-metadata \
+            "${{ needs.prepare.outputs.version }}" \
+            _internal-hfl-images.tar.gz
+      - name: Upload offline HFL archive
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload "${{ needs.prepare.outputs.tag }}" _internal-hfl-images.tar.gz --clobber
+
+  export-sourcelens-bundle:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+    needs: [prepare, build-sourcelens-images]
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/login-action@v3
+        with:
+          registry: docker.io
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+      - name: Download image metadata
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p build/ci-metadata
+          gh release download "${{ needs.prepare.outputs.tag }}" --pattern '_internal-sourcelens-*.json' --dir build/ci-metadata
+          for file in build/ci-metadata/_internal-*.json; do mv "$file" "${file/_internal-/}"; done
+      - name: Export bundled SourceLens runtime
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          ./release/ci/export-sourcelens-bundle.sh \
+            build/ci-metadata \
+            "${{ needs.prepare.outputs.version }}" \
+            _internal-sourcelens-bundle.tar.gz
+      - name: Upload bundled SourceLens runtime
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload "${{ needs.prepare.outputs.tag }}" _internal-sourcelens-bundle.tar.gz --clobber
+
+  export-runtime-images:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    needs: [prepare, quality]
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/login-action@v3
+        with:
+          registry: docker.io
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+      - run: ./release/ci/export-runtime-images.sh _internal-runtime-images.tar.gz
+      - name: Upload runtime images
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload "${{ needs.prepare.outputs.tag }}" _internal-runtime-images.tar.gz --clobber
+
+  assemble-release:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    needs:
+      - prepare
+      - build-agent
+      - build-host-debs
+      - export-hfl-images
+      - export-sourcelens-bundle
+      - export-runtime-images
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download matrix bundles
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p build/ci-input
+          gh release download "${{ needs.prepare.outputs.tag }}" --pattern '_internal-*.tar.gz' --dir build/ci-input
+      - name: Assemble canonical offline release
+        run: |
+          ./release/ci/assemble-release.sh \
+            --input-dir build/ci-input \
+            --version "${{ needs.prepare.outputs.version }}" \
+            --commit "${{ needs.prepare.outputs.commit }}"
+      - name: Upload final assets to draft release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          while IFS= read -r asset_id; do
+            [[ -n "$asset_id" ]] || continue
+            gh api --method DELETE "/repos/${GITHUB_REPOSITORY}/releases/assets/${asset_id}"
+          done < <(gh api "/repos/${GITHUB_REPOSITORY}/releases/tags/${{ needs.prepare.outputs.tag }}" \
+            --jq '.assets[] | select(.name | startswith("_internal-") | not) | .id')
+          while IFS= read -r asset; do
+            gh release upload "${{ needs.prepare.outputs.tag }}" \
+              "build/release/dist/${asset}" --clobber
+          done < build/release/release-assets.txt
+      - name: Disk report
+        if: always()
+        run: df -h
+
+  verify-release:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    needs: [prepare, assemble-release]
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: Reclaim unused runner toolchains
+        run: |
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc
+          docker system prune -af || true
+          df -h
+      - name: Download public release candidates from draft
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p build/release-candidate
+          gh release download "${{ needs.prepare.outputs.tag }}" \
+            --pattern 'hyperfilelens-*.tar.gz*' \
+            --pattern 'SHA256SUMS' \
+            --pattern 'MANIFEST.json' \
+            --pattern 'SBOM.spdx.json' \
+            --pattern 'assemble-release.*' \
+            --dir build/release-candidate
+      - name: Verify checksums and reconstruct package when split
+        id: package
+        working-directory: build/release-candidate
+        shell: bash
+        run: |
+          set -euo pipefail
+          sha256sum -c SHA256SUMS
+          archive="$(find . -maxdepth 1 -type f -name 'hyperfilelens-*.tar.gz' -print -quit)"
+          if [[ -z "$archive" ]]; then
+            first="$(find . -maxdepth 1 -type f -name 'hyperfilelens-*.tar.gz.part-000' -print -quit)"
+            [[ -n "$first" ]]
+            archive="${first%.part-000}"
+            cat "${archive}.part-"* > "$archive"
+          fi
+          echo "archive=$(realpath "$archive")" >> "$GITHUB_OUTPUT"
+      - name: Full offline install and browser login smoke
+        run: ./release/ci/verify-release.sh --archive "${{ steps.package.outputs.archive }}" --install
+
+  publish-release:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    needs: [prepare, verify-release]
+    permissions:
+      contents: write
+    steps:
+      - name: Remove internal assets and publish release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          while IFS= read -r asset_id; do
+            [[ -n "$asset_id" ]] || continue
+            gh api --method DELETE "/repos/${GITHUB_REPOSITORY}/releases/assets/${asset_id}"
+          done < <(gh api "/repos/${GITHUB_REPOSITORY}/releases/tags/${{ needs.prepare.outputs.tag }}" \
+            --jq '.assets[] | select(.name | startswith("_internal-")) | .id')
+          gh release edit "${{ needs.prepare.outputs.tag }}" --draft=false --latest
+
+  deploy:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    needs: [prepare, publish-release]
+    if: ${{ vars.HFL_AUTO_DEPLOY == 'true' }}
+    environment: production
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate deployment configuration
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ -n "$HFL_SSH_HOST" ]]
+          [[ -n "$HFL_SSH_USER" ]]
+          # HFL_SSH_PORT is supplied by the workflow-level env map.
+          # shellcheck disable=SC2153
+          [[ "$HFL_SSH_PORT" =~ ^[0-9]+$ ]]
+          [[ "$HFL_DEPLOY_PATH" == /opt/hyperfilelens ]]
+          [[ -n "$HFL_PUBLIC_HOST" ]]
+      - name: Install SSH credentials
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+          SSH_KNOWN_HOSTS: ${{ secrets.SSH_KNOWN_HOSTS }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          install -d -m 0700 ~/.ssh
+          printf '%s\n' "$SSH_PRIVATE_KEY" > ~/.ssh/hyperfilelens_deploy
+          printf '%s\n' "$SSH_KNOWN_HOSTS" > ~/.ssh/known_hosts
+          chmod 0600 ~/.ssh/hyperfilelens_deploy ~/.ssh/known_hosts
+      - name: Download and deploy the complete release package on the host
+        shell: bash
+        run: |
+          set -euo pipefail
+          ssh -i ~/.ssh/hyperfilelens_deploy \
+            -o BatchMode=yes \
+            -o StrictHostKeyChecking=yes \
+            -o ConnectTimeout=20 \
+            -p "$HFL_SSH_PORT" \
+            "$HFL_SSH_USER@$HFL_SSH_HOST" \
+            bash -s -- \
+              --tag "${{ needs.prepare.outputs.tag }}" \
+              --public-host "$HFL_PUBLIC_HOST" \
+              --install-dir "$HFL_DEPLOY_PATH" \
+            < .github/scripts/remote-deploy.sh
+      - name: Post-deploy health checks
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl -kfsS --retry 24 --retry-delay 5 "https://${HFL_PUBLIC_HOST}:10443/health/ready"
+          curl -kfsS --retry 12 --retry-delay 5 "https://${HFL_PUBLIC_HOST}:10444/" >/dev/null
+          curl -kfsS --retry 24 --retry-delay 5 "https://${HFL_PUBLIC_HOST}:10446/" >/dev/null

--- a/README.md
+++ b/README.md
@@ -115,10 +115,40 @@ Common lifecycle commands:
 ./dev/stack.sh down --hfl-only
 ./dev/stack.sh restart
 ./dev/stack.sh restart --force
+./dev/stack.sh status
+./dev/stack.sh doctor
+./dev/stack.sh smoke
 ```
 
 Use `restart --force` after changing dependency manifests or Dockerfiles.
 Normal backend and frontend source changes reload automatically.
+Unchanged dependency images, Agent packages, and the Gateway LensNode archive
+are reused through content fingerprints and archive identity checks.
+
+`down` is intentionally non-destructive: it preserves the shared bridge and
+frontend modules volume for the next start. Explicit cleanup is available when
+a genuinely clean runtime or data reset is required:
+
+```bash
+./dev/stack.sh clean --runtime
+./dev/stack.sh clean --cache
+./dev/stack.sh clean --data --yes
+./dev/stack.sh clean --all --yes
+```
+
+The data forms require `--yes` because they delete local databases, logs, and
+generated media. After one successful online preparation, a warm-cache stack
+can be started or restarted without registry or Git access:
+
+```bash
+./dev/stack.sh up --offline
+./dev/stack.sh restart --offline
+```
+
+Use `--pull` for an explicit runtime-image refresh. Docker pulls and SourceLens
+Git operations have configurable finite timeouts and retry limits. The `smoke`
+command uses a pinned Playwright version to verify Tenant, Platform Operations,
+SourceLens login, and the development HMR WebSocket path.
 
 To inspect options without starting services:
 
@@ -262,6 +292,7 @@ The public repository requires English source, comments, and documentation:
 
 ```bash
 python3 tools/quality/check-english-source.py
+./tools/quality/check-release-contracts.sh
 ```
 
 Run the relevant backend, frontend, and Agent tests before opening a pull

--- a/deploy/installer/install.sh
+++ b/deploy/installer/install.sh
@@ -13,6 +13,8 @@ LOG_FILE="${HFL_LOG_FILE:-}"
 VERBOSE="${HFL_LOG_VERBOSE:-0}"
 PRINT_CONFIG=0
 SESSION_STARTED=0
+PUBLIC_HOST="${HFL_PUBLIC_HOST:-}"
+SHOW_GENERATED_CREDENTIALS="${HFL_SHOW_GENERATED_CREDENTIALS:-auto}"
 
 usage() {
 	cat <<'USAGE'
@@ -144,6 +146,8 @@ install_dir=${INSTALL_DIR}
 sourcelens_install_dir=${SOURCELENS_INSTALL_DIR}
 upgrade_tmp=${UPGRADE_TMP}
 bridge_network=${HFL_BRIDGE_NETWORK}
+public_host=${PUBLIC_HOST:-<auto>}
+show_generated_credentials=${SHOW_GENERATED_CREDENTIALS}
 log_file=${LOG_FILE:-<none>}
 verbose=${VERBOSE}
 EOF
@@ -540,6 +544,19 @@ sync_runtime_media() {
 	[[ -d "${packaged_media}" ]] || return 0
 	mkdir -p "${ROOT}/data/media"
 	rsync -a "${packaged_media}/" "${ROOT}/data/media/"
+	local dir
+	for dir in agent-releases enroll-bootstrap gateway-bootstrap; do
+		[[ -d "${ROOT}/data/media/${dir}" ]] || continue
+		find "${ROOT}/data/media/${dir}" -type d -exec chmod 755 {} +
+		find "${ROOT}/data/media/${dir}" -type f -exec chmod 644 {} +
+	done
+	find "${ROOT}/data/media/agent-releases" -type f -name '*.sh' \
+		-exec chmod 755 {} + 2>/dev/null || true
+	if [[ -d "${ROOT}/data/media/enroll-bootstrap" ]]; then
+		find "${ROOT}/data/media/enroll-bootstrap" -type f -exec chmod 755 {} +
+	fi
+	find "${ROOT}/data/media/gateway-bootstrap" -type f -name '*.sh' \
+		-exec chmod 755 {} + 2>/dev/null || true
 }
 
 ensure_tls_certs() {
@@ -589,7 +606,10 @@ ensure_env_file() {
 	secret="$(random_hex)"
 	db_pass="$(random_hex | cut -c1-32)"
 	admin_pass="Hfl-0$(random_hex | cut -c1-20)!"
-	host="$(hostname -I 2>/dev/null | awk '{ for (i = 1; i <= NF; i++) if (!found && $i ~ /^[0-9]+\./) { print $i; found = 1 } }' || true)"
+	host="${PUBLIC_HOST}"
+	if [[ -z "${host}" ]]; then
+		host="$(hostname -I 2>/dev/null | awk '{ for (i = 1; i <= NF; i++) if (!found && $i ~ /^[0-9]+\./) { print $i; found = 1 } }' || true)"
+	fi
 	[[ -n "${host}" ]] || host="127.0.0.1"
 
 	step "Creating .env from .env.example ..."
@@ -661,14 +681,77 @@ stack_containers_present() {
 	[[ "${count}" -gt 0 ]]
 }
 
+wait_for_hfl_health() {
+	local timeout_seconds="${HFL_HEALTH_TIMEOUT_SECONDS:-600}"
+	[[ "${timeout_seconds}" =~ ^[1-9][0-9]*$ ]] || die "HFL_HEALTH_TIMEOUT_SECONDS must be positive"
+	local tenant_port
+	tenant_port="$(read_env_value HFL_TENANT_PORT)"
+	[[ -n "${tenant_port}" ]] || tenant_port=10443
+	local deadline=$((SECONDS + timeout_seconds))
+	local -a services=(postgres redis worker scheduler api nginx)
+	step "Waiting for HyperFileLens health checks (timeout ${timeout_seconds}s) ..."
+	while ((SECONDS < deadline)); do
+		local ready=1 service cid status
+		for service in "${services[@]}"; do
+			cid="$(compose_in_root ps -q "${service}" 2>/dev/null | head -1)"
+			if [[ -z "${cid}" ]]; then
+				ready=0
+				break
+			fi
+			status="$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' "${cid}" 2>/dev/null || true)"
+			if [[ "${status}" != "healthy" && "${status}" != "running" ]]; then
+				ready=0
+				break
+			fi
+		done
+		if [[ "${ready}" -eq 1 ]] \
+			&& curl -kfsS "https://127.0.0.1:${tenant_port}/health/ready" >/dev/null 2>&1; then
+			ok "HyperFileLens health gate passed"
+			return 0
+		fi
+		sleep 5
+	done
+	warn "HyperFileLens health gate timed out"
+	compose_in_root ps || true
+	return 1
+}
+
+wait_for_sourcelens_health() {
+	[[ "$(configured_sourcelens_mode)" == "bundled" ]] || return 0
+	sourcelens_installed || return 0
+	local nginx_cid
+	nginx_cid="$(sourcelens_compose ps -q nginx 2>/dev/null | head -1)"
+	if [[ -z "${nginx_cid}" ]]; then
+		log "Bundled SourceLens is not running; skipping its health gate"
+		return 0
+	fi
+	local timeout_seconds="${SOURCELENS_HEALTH_TIMEOUT_SECONDS:-600}"
+	local port
+	port="$(read_env_value SOURCELENS_CONSOLE_PORT)"
+	[[ -n "${port}" ]] || port=10446
+	step "Waiting for bundled SourceLens HTTPS health (timeout ${timeout_seconds}s) ..."
+	local deadline=$((SECONDS + timeout_seconds))
+	while ((SECONDS < deadline)); do
+		if curl -kfsS "https://127.0.0.1:${port}/" >/dev/null 2>&1; then
+			ok "Bundled SourceLens health gate passed"
+			return 0
+		fi
+		sleep 5
+	done
+	warn "Bundled SourceLens health gate timed out"
+	sourcelens_compose ps || true
+	return 1
+}
+
 load_images_from_manifest() {
 	local skip_sourcelens=${1:-0}
+	local package_root=${2:-${ROOT}}
 	local sourcelens_mode
 	sourcelens_mode="$(configured_sourcelens_mode)"
 	if [[ "${sourcelens_mode}" == "external" ]]; then
 		skip_sourcelens=1
 	fi
-	python3 - "${ROOT}" "${skip_sourcelens}" <<'PY'
+	python3 - "${package_root}" "${skip_sourcelens}" <<'PY'
 import hashlib
 import json
 import pathlib
@@ -795,8 +878,52 @@ backup_env_and_data() {
 	log "Backup complete: ${archive}"
 }
 
+backup_postgresql_dump() {
+	[[ -f "${ROOT}/.env" ]] || return 0
+	local cid
+	cid="$(compose_in_root ps -q postgres 2>/dev/null | head -1)"
+	[[ -n "${cid}" ]] || { warn "PostgreSQL is not running; skipping logical database dump"; return 0; }
+	local stamp dump globals
+	stamp="$(date +%Y%m%d-%H%M%S)"
+	mkdir -p "${ROOT}/backup"
+	dump="${ROOT}/backup/hyperfilelens-postgresql-${stamp}.dump"
+	globals="${ROOT}/backup/hyperfilelens-postgresql-globals-${stamp}.sql"
+	step "Creating consistent PostgreSQL logical backup ..."
+	compose_in_root exec -T postgres sh -ec \
+		'exec pg_dump -U "${POSTGRES_USER:-postgres}" -d "${POSTGRES_DB:-hyperfilelens}" -Fc' \
+		>"${dump}.part"
+	compose_in_root exec -T postgres sh -ec \
+		'exec pg_dumpall -U "${POSTGRES_USER:-postgres}" --globals-only' \
+		>"${globals}.part"
+	mv "${dump}.part" "${dump}"
+	mv "${globals}.part" "${globals}"
+	chmod 600 "${dump}" "${globals}"
+	ok "PostgreSQL logical backup created under ${ROOT}/backup"
+
+	if sourcelens_installed; then
+		local sl_cid sl_dump sl_globals
+		sl_cid="$(sourcelens_compose ps -q postgresql 2>/dev/null | head -1)"
+		if [[ -n "${sl_cid}" ]]; then
+			sl_dump="${ROOT}/backup/sourcelens-postgresql-${stamp}.dump"
+			sl_globals="${ROOT}/backup/sourcelens-postgresql-globals-${stamp}.sql"
+			step "Creating consistent bundled SourceLens PostgreSQL backup ..."
+			sourcelens_compose exec -T postgresql sh -ec \
+				'exec pg_dump -U "${POSTGRES_USER:-postgres}" -d "${POSTGRES_DB:-backend}" -Fc' \
+				>"${sl_dump}.part"
+			sourcelens_compose exec -T postgresql sh -ec \
+				'exec pg_dumpall -U "${POSTGRES_USER:-postgres}" --globals-only' \
+				>"${sl_globals}.part"
+			mv "${sl_dump}.part" "${sl_dump}"
+			mv "${sl_globals}.part" "${sl_globals}"
+			chmod 600 "${sl_dump}" "${sl_globals}"
+			ok "Bundled SourceLens PostgreSQL logical backup created"
+		fi
+	fi
+}
+
 apply_upgrade_files() {
 	local from_root=$1
+	local remove_sourcelens=${2:-0}
 	step "Overwriting application files and release payload ..."
 	mkdir -p "${ROOT}/deploy/nginx" "${ROOT}/images" "${ROOT}/host" "${ROOT}/payload"
 	rsync -a --delete "${from_root}/payload/" "${ROOT}/payload/"
@@ -806,7 +933,10 @@ apply_upgrade_files() {
 		safe_rm_dir "${ROOT}/src"
 		log "Removed legacy host source tree; application code now ships only in images"
 	fi
-	if [[ -d "${from_root}/sourcelens" ]]; then
+	if [[ "${remove_sourcelens}" -eq 1 && -d "${ROOT}/sourcelens" ]]; then
+		safe_assert_path_under_dir "${ROOT}/sourcelens" "${ROOT}" "SourceLens runtime path"
+		safe_rm_dir "${ROOT}/sourcelens"
+	elif [[ -d "${from_root}/sourcelens" ]]; then
 		rsync -a --delete "${from_root}/sourcelens/" "${ROOT}/sourcelens/"
 	fi
 	cp "${from_root}/docker-compose.yml" "${ROOT}/docker-compose.yml"
@@ -982,8 +1112,19 @@ print_console_access_summary() {
 		[[ -n "${seed_email}" ]] || seed_email="admin@hyperfilelens.com"
 		[[ -n "${seed_pass}" ]] || seed_pass="Admin@123"
 		[[ -n "${seed_org}" ]] || seed_org="HyperFileLens"
-		log "Default admin email: ${seed_email} (environment variable SEED_ADMIN_EMAIL)."
-		log "Default admin password: ${seed_pass} (environment variable SEED_ADMIN_PASSWORD)."
+		local show_credentials=0
+		case "${SHOW_GENERATED_CREDENTIALS}" in
+		1 | true | yes | on) show_credentials=1 ;;
+		0 | false | no | off) show_credentials=0 ;;
+		auto) [[ -t 2 ]] && show_credentials=1 || true ;;
+		*) die "invalid HFL_SHOW_GENERATED_CREDENTIALS=${SHOW_GENERATED_CREDENTIALS}" ;;
+		esac
+		if [[ "${show_credentials}" -eq 1 ]]; then
+			log "Default admin email: ${seed_email} (environment variable SEED_ADMIN_EMAIL)."
+			log "Default admin password: ${seed_pass} (environment variable SEED_ADMIN_PASSWORD)."
+		else
+			log "Initial admin credentials are stored in ${env_file}; values are hidden in non-interactive logs."
+		fi
 		log "Default organization: ${seed_org} (environment variable SEED_ORG_NAME)."
 		log "Initial seeding is enabled (SEED_INITIAL_DATA=1); the worker service creates this account on first startup."
 		log "Change the default password after your first login."
@@ -1166,7 +1307,83 @@ should_upgrade_sourcelens() {
 		;;
 	esac
 	[[ "$(configured_sourcelens_mode)" == "bundled" ]] \
-		&& package_has_sourcelens_dir "${src_root}"
+		&& package_has_sourcelens_dir "${src_root}" \
+		&& sourcelens_bundle_changed "${src_root}"
+}
+
+sourcelens_bundle_fingerprint() {
+	local root=$1
+	python3 - "${root}" <<'PY'
+import hashlib
+import json
+import pathlib
+import sys
+
+root = pathlib.Path(sys.argv[1])
+paths = [
+    "docker-compose.yml",
+    ".env.example",
+    "install.sh",
+    "patch-env-runtime.py",
+]
+deploy = root / "deploy"
+if deploy.is_dir():
+    paths.extend(
+        path.relative_to(root).as_posix()
+        for path in sorted(deploy.rglob("*"))
+        if path.is_file() and "certs" not in path.parts
+    )
+digest = hashlib.sha256()
+
+# Registry transit references and rebuilt image IDs can change for every HFL
+# tag even while the bundled SourceLens release remains pinned. Only semantic
+# SourceLens identity belongs in the bundle fingerprint; runtime files below
+# capture HFL-owned integration changes.
+build_info_path = root / "BUILD_INFO.json"
+if build_info_path.is_file():
+    info = json.loads(build_info_path.read_text(encoding="utf-8"))
+    identity = {
+        "git_url": info.get("git_url", ""),
+        "git_ref": info.get("git_ref", ""),
+        "git_commit": info.get("git_commit", ""),
+        "version": info.get("version", ""),
+        "patch_sha256": info.get("patch_sha256", ""),
+        "embed_local_lensnode": info.get("embed_local_lensnode", False),
+    }
+    digest.update(b"BUILD_INFO.identity\0")
+    digest.update(
+        json.dumps(identity, sort_keys=True, separators=(",", ":")).encode()
+    )
+else:
+    digest.update(b"missing:BUILD_INFO.json\0")
+
+for rel in sorted(set(paths)):
+    path = root / rel
+    if not path.is_file():
+        digest.update(f"missing:{rel}\0".encode())
+        continue
+    digest.update(rel.encode() + b"\0")
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+print(digest.hexdigest())
+PY
+}
+
+sourcelens_bundle_changed() {
+	local src_root=$1
+	if ! sourcelens_installed || [[ ! -f "${ROOT}/sourcelens/BUILD_INFO.json" ]]; then
+		return 0
+	fi
+	local current target
+	current="$(sourcelens_bundle_fingerprint "${ROOT}/sourcelens")"
+	target="$(sourcelens_bundle_fingerprint "${src_root}/sourcelens")"
+	if [[ "${current}" == "${target}" ]]; then
+		log "Bundled SourceLens is unchanged (${current:0:12}); keeping 10446 online"
+		return 1
+	fi
+	log "Bundled SourceLens changed (${current:0:12} -> ${target:0:12})"
+	return 0
 }
 
 should_remove_sourcelens() {
@@ -1240,6 +1457,7 @@ install_bundled_sourcelens() {
 	SOURCELENS_INSTALL_DIR="${ROOT}/sourcelens" \
 		SOURCELENS_DATA_DIR="${ROOT}/data/sourcelens" \
 		SOURCELENS_CONFIG_DIR="${ROOT}/data/sourcelens/config" \
+		SOURCELENS_TLS_CERT_DIR="${ROOT}/deploy/nginx/certs" \
 		SOURCELENS_CONSOLE_BIND_ADDRESS="${console_bind}" \
 		SOURCELENS_CONSOLE_PORT="${console_port}" \
 		SOURCELENS_NGINX_HTTPS_PORT="${console_port}" \
@@ -1328,6 +1546,8 @@ cmd_install() {
 	step "[5/6] Starting services ..."
 	log "Log rotation: built into nginx container (hourly; daily or 500M; keep 30)"
 	compose_in_root up -d --no-build --remove-orphans
+	wait_for_hfl_health || die "HyperFileLens failed its post-install health gate"
+	wait_for_sourcelens_health || die "bundled SourceLens failed its post-install health gate"
 
 	step "[6/6] Done"
 	log "Install and startup complete"
@@ -1348,6 +1568,8 @@ cmd_start() {
 	fi
 	step "Starting services (docker compose up -d --no-build) ..."
 	compose_in_root up -d --no-build --remove-orphans
+	wait_for_hfl_health || die "HyperFileLens failed its startup health gate"
+	wait_for_sourcelens_health || die "bundled SourceLens failed its startup health gate"
 	log "Services started"
 	compose_in_root ps
 }
@@ -1881,7 +2103,7 @@ cmd_uninstall() {
 	log "Uninstall complete (services and images removed)"
 	log "Install directory kept: ${ROOT}"
 	log "  Remaining: install.sh, docker-compose.yml, deploy/, images/, payload/, backup/, host/, and other package files"
-	if [[ "${with_sourcelens}" -eq 0 && sourcelens_installed ]]; then
+	if [[ "${with_sourcelens}" -eq 0 ]] && sourcelens_installed; then
 		log "  SourceLens still installed at ${SOURCELENS_INSTALL_DIR} (use --with-sourcelens to remove)"
 	fi
 	if [[ "${purge_data}" -eq 0 ]]; then
@@ -1901,7 +2123,7 @@ cmd_uninstall() {
 cmd_upgrade() {
 	local from="" with_upgrade_docker=0
 	local sourcelens_mode=-1 remove_sourcelens=0 purge_sourcelens_data=0
-	local src_root new_version cur_version
+	local src_root new_version cur_version upgrade_sourcelens=0
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
 		--from)
@@ -1939,6 +2161,7 @@ cmd_upgrade() {
 	log "Upgrading: ${cur_version} -> ${new_version}"
 
 	step "[1/7] Backing up current config and data ..."
+	backup_postgresql_dump
 	backup_env_and_data
 
 	step "[2/7] Validating upgrade package ..."
@@ -1946,17 +2169,26 @@ cmd_upgrade() {
 	if package_has_sourcelens_dir "${src_root}"; then
 		preflight_sourcelens_bundle "${src_root}"
 	fi
+	if should_upgrade_sourcelens "${sourcelens_mode}" "${src_root}"; then
+		upgrade_sourcelens=1
+	fi
+	if [[ "${remove_sourcelens}" -eq 1 ]]; then
+		upgrade_sourcelens=0
+	fi
 
 	step "[3/7] Checking/upgrading Docker ..."
 	upgrade_host_docker_from_source "${ROOT}" "${src_root}" "${with_upgrade_docker}"
 	require_docker
 	ensure_bridge_network
 
+	step "Preloading verified target images before the maintenance window ..."
+	load_images_from_manifest "$([[ "${upgrade_sourcelens}" -eq 0 ]] && echo 1 || echo 0)" "${src_root}"
+
 	step "[4/7] Stopping current services ..."
 	if [[ -f "${ROOT}/.env" ]]; then
 		compose_in_root down || true
 	fi
-	if should_remove_sourcelens "${remove_sourcelens}" || should_upgrade_sourcelens "${sourcelens_mode}" "${src_root}"; then
+	if should_remove_sourcelens "${remove_sourcelens}" || [[ "${upgrade_sourcelens}" -eq 1 ]]; then
 		stop_bundled_sourcelens
 	fi
 	if should_remove_sourcelens "${remove_sourcelens}"; then
@@ -1965,19 +2197,18 @@ cmd_upgrade() {
 
 	step "[5/7] Merging .env and overwriting app files ..."
 	sync_env_from_example "${src_root}/.env.example"
-	apply_upgrade_files "${src_root}"
+	apply_upgrade_files "${src_root}" "${remove_sourcelens}"
 	update_env_versions "${new_version}"
 
-	if should_remove_sourcelens "${remove_sourcelens}" && [[ "${purge_sourcelens_data}" -eq 1 ]]; then
+	if [[ "${remove_sourcelens}" -eq 1 && "${purge_sourcelens_data}" -eq 1 ]]; then
 		purge_sourcelens_data_dir
 	fi
-	if should_remove_sourcelens "${remove_sourcelens}"; then
-		log "SourceLens removed from this host (install dir kept: ${SOURCELENS_INSTALL_DIR})"
+	if [[ "${remove_sourcelens}" -eq 1 ]]; then
+		log "SourceLens application runtime removed from this host"
 	fi
 
 	step "[6/7] Loading images and starting services ..."
-	load_images_from_manifest "$([[ "${sourcelens_mode}" -eq 0 ]] && echo 1 || echo 0)"
-	if should_upgrade_sourcelens "${sourcelens_mode}" "${src_root}"; then
+	if [[ "${upgrade_sourcelens}" -eq 1 ]]; then
 		install_bundled_sourcelens
 	fi
 	if [[ "$(configured_sourcelens_mode)" == "bundled" ]] \
@@ -1987,7 +2218,11 @@ cmd_upgrade() {
 	fi
 	ensure_data_dirs
 	sync_runtime_media
+	compose_in_root up -d postgres redis
+	compose_in_root run --rm worker migrate
 	compose_in_root up -d --no-build --remove-orphans
+	wait_for_hfl_health || die "HyperFileLens failed its post-upgrade health gate"
+	wait_for_sourcelens_health || die "bundled SourceLens failed its post-upgrade health gate"
 
 	step "[7/7] Cleaning up temporary directory ..."
 	cleanup_upgrade_tmp

--- a/deploy/installer/sourcelens/docker-compose.template.yml
+++ b/deploy/installer/sourcelens/docker-compose.template.yml
@@ -5,6 +5,7 @@ name: sourcelens
 services:
   api:
     image: __SOURCELENS_BACKEND_IMAGE__
+    pull_policy: never
     restart: unless-stopped
     env_file:
       - ./.env
@@ -19,7 +20,7 @@ services:
       - ./data/logs/api:/var/log/gunicorn
       - ./data/storage:/opt/storage
       - ./data/workspace:/workspace
-      - ./deploy/nginx/certs:/opt/certs
+      - ${SOURCELENS_TLS_CERT_DIR:-./deploy/nginx/certs}:/opt/certs:ro
     networks:
       sourcelens_network:
         aliases:
@@ -39,6 +40,7 @@ services:
 
   worker:
     image: __SOURCELENS_BACKEND_IMAGE__
+    pull_policy: never
     restart: unless-stopped
     stop_grace_period: 120s
     env_file:
@@ -56,6 +58,7 @@ services:
 
   scheduler:
     image: __SOURCELENS_BACKEND_IMAGE__
+    pull_policy: never
     restart: unless-stopped
     stop_grace_period: 30s
     env_file:
@@ -71,6 +74,7 @@ services:
 
   ui:
     image: __SOURCELENS_FRONTEND_IMAGE__
+    pull_policy: never
     restart: unless-stopped
     expose:
       - "80"
@@ -82,6 +86,7 @@ services:
 # HFL_EMBED_LENSNODE_SERVICE_BEGIN
   local-lensnode:
     image: __SOURCELENS_LENSNODE_IMAGE__
+    pull_policy: never
     restart: unless-stopped
     env_file:
       - ./.env
@@ -100,10 +105,11 @@ services:
 
   nginx:
     image: nginx:stable-alpine
+    pull_policy: never
     restart: unless-stopped
     volumes:
       - ./deploy/nginx/default.conf:/etc/nginx/conf.d/default.conf
-      - ./deploy/nginx/certs:/etc/nginx/certs:ro
+      - ${SOURCELENS_TLS_CERT_DIR:-./deploy/nginx/certs}:/etc/nginx/certs:ro
       - ./data/django/staticfiles:/staticfiles:ro
       - ./data/storage:/opt/storage:ro
       - ./data/logs/nginx:/var/log/nginx
@@ -125,6 +131,7 @@ services:
 
   postgres:
     image: postgres:17
+    pull_policy: never
     restart: unless-stopped
     env_file:
       - ./.env
@@ -139,7 +146,7 @@ services:
       - ./deploy/postgresql/etc/postgresql.conf:/etc/postgresql/postgresql.conf:ro
       - ./data/postgresql/data:/var/lib/postgresql/data
       - ./data/logs/postgresql:/var/log/postgresql
-    entrypoint: ["bash", "-c", "mkdir -p /var/log/postgresql && chown -R postgres:postgres /var/log/postgresql && chmod -R 755 /var/log/postgresql && exec docker-entrypoint.sh \"$$@\""]
+    entrypoint: ["bash", "-c", "mkdir -p /var/lib/postgresql/data /var/log/postgresql && chown postgres:postgres /var/lib/postgresql/data && chmod 700 /var/lib/postgresql/data && chown -R postgres:postgres /var/log/postgresql && chmod -R 755 /var/log/postgresql && exec docker-entrypoint.sh \"$$@\""]
     command:
       - postgres
       - -c
@@ -157,6 +164,7 @@ services:
 
   redis:
     image: redis:alpine
+    pull_policy: never
     restart: unless-stopped
     command: redis-server
     volumes:

--- a/deploy/installer/sourcelens/install.sh
+++ b/deploy/installer/sourcelens/install.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 SOURCELENS_INSTALL_DIR="${SOURCELENS_INSTALL_DIR:-/opt/hyperfilelens/sourcelens}"
 SOURCELENS_DATA_DIR="${SOURCELENS_DATA_DIR:-/opt/hyperfilelens/data/sourcelens}"
 SOURCELENS_CONFIG_DIR="${SOURCELENS_CONFIG_DIR:-${SOURCELENS_DATA_DIR}/config}"
+SOURCELENS_TLS_CERT_DIR="${SOURCELENS_TLS_CERT_DIR:-}"
 SOURCELENS_NGINX_HTTPS_PORT="${SOURCELENS_NGINX_HTTPS_PORT:-10446}"
 SOURCELENS_CONSOLE_BIND_ADDRESS="${SOURCELENS_CONSOLE_BIND_ADDRESS:-0.0.0.0}"
 SOURCELENS_CONSOLE_PORT="${SOURCELENS_CONSOLE_PORT:-${SOURCELENS_NGINX_HTTPS_PORT}}"
@@ -63,6 +64,7 @@ print_config() {
 install_dir=${SOURCELENS_INSTALL_DIR}
 data_dir=${SOURCELENS_DATA_DIR}
 config_dir=${SOURCELENS_CONFIG_DIR}
+tls_cert_dir=${SOURCELENS_TLS_CERT_DIR}
 console_bind_address=${SOURCELENS_CONSOLE_BIND_ADDRESS}
 console_port=${SOURCELENS_CONSOLE_PORT}
 bridge_network=${HFL_BRIDGE_NETWORK}
@@ -86,6 +88,32 @@ resolve_package_root() {
 		return 0
 	fi
 	printf '%s' "${bundle}"
+}
+
+resolve_tls_cert_dir() {
+	if [[ -z "${SOURCELENS_TLS_CERT_DIR}" ]]; then
+		SOURCELENS_TLS_CERT_DIR="$(dirname "${SOURCELENS_INSTALL_DIR}")/deploy/nginx/certs"
+	fi
+}
+
+ensure_tls_certs() {
+	local cert="${SOURCELENS_TLS_CERT_DIR}/tls.crt"
+	local key="${SOURCELENS_TLS_CERT_DIR}/tls.key"
+	run_as_root mkdir -p "${SOURCELENS_TLS_CERT_DIR}"
+	if [[ -s "${cert}" && -s "${key}" ]]; then
+		log "Using existing shared TLS certificates from ${SOURCELENS_TLS_CERT_DIR}"
+		return 0
+	fi
+	command -v openssl >/dev/null 2>&1 \
+		|| die "openssl is required to generate SourceLens TLS certificates"
+	step "Generating self-signed SourceLens TLS certificates"
+	run_as_root openssl req -x509 -newkey rsa:2048 -sha256 -days 3650 -nodes \
+		-keyout "${key}" \
+		-out "${cert}" \
+		-subj "/CN=localhost" \
+		-addext "subjectAltName=DNS:localhost,IP:127.0.0.1,IP:::1"
+	run_as_root chmod 644 "${cert}"
+	run_as_root chmod 600 "${key}"
 }
 
 run_as_root() {
@@ -156,7 +184,8 @@ PY
 	run_as_root python3 "${patch_script}" "${env_file}"
 	run_as_root python3 - "${env_file}" \
 		"${SOURCELENS_CONSOLE_BIND_ADDRESS}" \
-		"${SOURCELENS_CONSOLE_PORT}" <<'PY'
+		"${SOURCELENS_CONSOLE_PORT}" \
+		"${SOURCELENS_TLS_CERT_DIR}" <<'PY'
 import pathlib
 import re
 import sys
@@ -164,12 +193,14 @@ import sys
 path = pathlib.Path(sys.argv[1])
 bind_address = sys.argv[2]
 port = sys.argv[3]
+tls_cert_dir = sys.argv[4]
 text = path.read_text(encoding="utf-8")
 
 for name, value in {
     "SOURCELENS_CONSOLE_BIND_ADDRESS": bind_address,
     "SOURCELENS_CONSOLE_PORT": port,
     "NGINX_HTTPS_PORT": port,
+    "SOURCELENS_TLS_CERT_DIR": tls_cert_dir,
 }.items():
     pattern = rf"^{re.escape(name)}=.*$"
     line = f"{name}={value}"
@@ -344,6 +375,7 @@ cmd_install() {
 	docker info >/dev/null 2>&1 || die "cannot connect to Docker daemon"
 
 	materialize_install_dir "${bundle_root}" "${install_root}"
+	ensure_tls_certs
 	ensure_env_file "${install_root}"
 	ensure_data_dirs "${install_root}"
 
@@ -389,6 +421,7 @@ main() {
 		esac
 	done
 	set -- "${args[@]}"
+	resolve_tls_cert_dir
 	if [[ "${PRINT_CONFIG}" -eq 1 ]]; then
 		print_config
 		return 0

--- a/deploy/nginx/development-spa-locations.conf
+++ b/deploy/nginx/development-spa-locations.conf
@@ -1,5 +1,18 @@
 # Development SPA and Vite HMR proxy. API/media routes are defined before this include.
 
+    # A dedicated path avoids the Platform Ops root redirect intercepting Vite's
+    # default WebSocket handshake at "/?token=...".
+    location = /__vite_hmr {
+        proxy_pass http://ui:5173;
+        proxy_http_version 1.1;
+        proxy_set_header Host $http_host;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_read_timeout 1h;
+        proxy_send_timeout 1h;
+        proxy_buffering off;
+    }
+
     location ^~ /locales/ {
         alias /opt/hyperfilelens/lang-packs/;
         autoindex off;

--- a/dev/sourcelens.sh
+++ b/dev/sourcelens.sh
@@ -27,6 +27,10 @@ Commands:
 
 Options:
   --force-build       Rebuild SourceLens app images even when present locally
+  --pull              Refresh runtime images, with valid local fallback
+  --offline           Forbid registry and SourceLens Git network access
+  --pull-timeout SECONDS  Per-attempt Docker pull timeout
+  --pull-retries COUNT    Docker pull attempts (default: 2)
   --sourcelens-git-url URL  Override SOURCELENS_GIT_URL
   --sourcelens-ref REF      SourceLens release tag in vX.Y.Z form
   --github-token TOKEN  GitHub token for private repo clone/fetch (env: GITHUB_TOKEN)
@@ -67,6 +71,10 @@ frontend_image=$(sourcelens_frontend_image_ref)
 lensnode_image=$(sourcelens_lensnode_image_ref)
 docker_platform=${SOURCELENS_DOCKER_PLATFORM}
 force_build=${FORCE_BUILD}
+offline=${SOURCELENS_OFFLINE}
+force_pull=${SOURCELENS_FORCE_PULL}
+docker_pull_timeout=${SOURCELENS_DOCKER_PULL_TIMEOUT}
+docker_pull_retries=${SOURCELENS_DOCKER_PULL_RETRIES}
 github_token=$(hfl_redact "${GITHUB_TOKEN:-}")
 apt_mirror=${SOURCELENS_APT_MIRROR:-<official>}
 pip_index_url=${SOURCELENS_PIP_INDEX_URL:-<official>}
@@ -93,6 +101,24 @@ parse_args() {
 		--force-build)
 			FORCE_BUILD=1
 			shift
+			;;
+		--pull)
+			SOURCELENS_FORCE_PULL=1
+			shift
+			;;
+		--offline)
+			SOURCELENS_OFFLINE=1
+			shift
+			;;
+		--pull-timeout)
+			require_value "$1" "${2:-}"
+			SOURCELENS_DOCKER_PULL_TIMEOUT="$2"
+			shift 2
+			;;
+		--pull-retries)
+			require_value "$1" "${2:-}"
+			SOURCELENS_DOCKER_PULL_RETRIES="$2"
+			shift 2
 			;;
 		--prepare-only)
 			CMD="prepare"
@@ -164,10 +190,12 @@ require_docker() {
 
 cmd_prepare() {
 	require_docker
+	hfl_docker_validate_pull_settings "${SOURCELENS_DOCKER_PULL_TIMEOUT}" \
+		"${SOURCELENS_DOCKER_PULL_RETRIES}" \
+		|| sourcelens_die "invalid Docker pull timeout/retry settings"
 	sourcelens_sync_source
-	sourcelens_prepare_source_build_env
 	sourcelens_build_app_images "${FORCE_BUILD}"
-	sourcelens_ensure_nginx_image "${FORCE_BUILD}"
+	sourcelens_ensure_runtime_images "${SOURCELENS_FORCE_PULL}"
 	sourcelens_prepare_dev_runtime_tree
 	sourcelens_publish_gateway_lensnode_bundle "${FORCE_BUILD}"
 	sourcelens_configure_hfl_env
@@ -176,7 +204,6 @@ cmd_prepare() {
 cmd_gateway() {
 	require_docker
 	sourcelens_sync_source
-	sourcelens_prepare_source_build_env
 	sourcelens_build_app_images "${FORCE_BUILD}"
 	sourcelens_publish_gateway_lensnode_bundle "${FORCE_BUILD}"
 }
@@ -185,7 +212,7 @@ cmd_up() {
 	cmd_prepare
 	sourcelens_ensure_shared_network
 	sourcelens_log "Starting SourceLens stack (project=${SOURCELENS_COMPOSE_PROJECT})"
-	sourcelens_dev_compose up -d --pull never --force-recreate --remove-orphans
+	sourcelens_dev_compose up -d --pull never --remove-orphans
 	sourcelens_ensure_database_initialized
 	if command -v curl >/dev/null 2>&1; then
 		sourcelens_wait_for_health || true

--- a/dev/stack.sh
+++ b/dev/stack.sh
@@ -19,6 +19,8 @@ ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 source "${ROOT}/tools/lib/logging.sh"
 # shellcheck source=../tools/lib/env-file.sh
 source "${ROOT}/tools/lib/env-file.sh"
+# shellcheck source=../tools/lib/docker-images.sh
+source "${ROOT}/tools/lib/docker-images.sh"
 # shellcheck source=../tools/dependencies/versions/kopia.env
 source "${ROOT}/tools/dependencies/versions/kopia.env"
 
@@ -40,6 +42,13 @@ HFL_ONLY_DOWN=0
 LOG_FILE="${HFL_LOG_FILE:-}"
 VERBOSE="${HFL_LOG_VERBOSE:-0}"
 PRINT_CONFIG=0
+FORCE_PULL=0
+DEV_OFFLINE="${DEV_OFFLINE:-}"
+DOCKER_PULL_TIMEOUT="${DOCKER_PULL_TIMEOUT_SECONDS:-}"
+DOCKER_PULL_RETRIES="${DOCKER_PULL_RETRIES:-}"
+CLEAN_SCOPE=""
+CLEAN_YES=0
+STATE_FILE="${ROOT}/build/state/dev-stack.json"
 
 usage() {
 	cat <<'USAGE'
@@ -51,6 +60,13 @@ Commands:
   down --hfl-only    Stop HyperFileLens only; leave SourceLens running
   restart            Refresh dependencies/configuration and recreate changed services
   restart --force    Clean caches and rebuild development dependency images without cache
+  status             Show HFL and SourceLens service state and published ports
+  doctor             Check host tools, configuration, images, permissions, and ports
+  smoke              Run pinned Playwright login/HMR smoke tests against the running stack
+  clean --runtime    Remove containers, Compose networks, and the frontend modules volume
+  clean --cache      Remove generated build cache and local development images
+  clean --data --yes Remove runtime databases, logs, and generated media
+  clean --all --yes  Remove runtime, cache, and data
 
 Prepare (up / restart) always includes:
   .env (create from .env.example if missing)
@@ -79,6 +95,10 @@ Mirror options (Kopia fetch + Agent publishing + SourceLens git clone; env fallb
   --pip-index-url URL              Python package index (env: PIP_INDEX_URL)
   --pip-trusted-host HOST          Trusted pip host (env: PIP_TRUSTED_HOST)
   --npm-registry URL               npm registry (env: NPM_REGISTRY)
+  --pull                           Refresh runtime images with valid local fallback
+  --offline                        Forbid registry, Git, and dependency network access
+  --pull-timeout SECONDS           Per-attempt Docker pull timeout (default: 180)
+  --pull-retries COUNT             Docker pull attempts (default: 2)
 
 Output options:
   --log-file FILE                  Append runtime logs to FILE; normal output remains on stderr
@@ -112,9 +132,15 @@ load_repo_env_defaults() {
 	for key in \
 		GITHUB_DOWNLOAD_MIRROR GITHUB_TOKEN DOCKER_DOWNLOAD_MIRROR \
 		APT_MIRROR GOPROXY GOSUMDB PIP_INDEX_URL PIP_TRUSTED_HOST \
-		NPM_REGISTRY BUILD_SOURCELENS SOURCELENS_GIT_REF SOURCELENS_GIT_URL; do
+		NPM_REGISTRY BUILD_SOURCELENS SOURCELENS_GIT_REF SOURCELENS_GIT_URL \
+		DOCKER_PULL_TIMEOUT_SECONDS DOCKER_PULL_RETRIES DEV_OFFLINE \
+		DEV_SMOKE_PLAYWRIGHT_VERSION SOURCELENS_GIT_TIMEOUT_SECONDS \
+		SOURCELENS_GIT_RETRIES; do
 		hfl_env_load_default "${key}"
 	done
+	DOCKER_PULL_TIMEOUT="${DOCKER_PULL_TIMEOUT:-${DOCKER_PULL_TIMEOUT_SECONDS:-180}}"
+	DOCKER_PULL_RETRIES="${DOCKER_PULL_RETRIES:-2}"
+	DEV_OFFLINE="${DEV_OFFLINE:-0}"
 }
 
 apply_mirror_env_defaults() {
@@ -162,6 +188,11 @@ go_sumdb=${OPT_GO_SUMDB:-<official>}
 pip_index_url=${OPT_PIP_INDEX_URL:-<official>}
 pip_trusted_host=${OPT_PIP_TRUSTED_HOST:-<unset>}
 npm_registry=${OPT_NPM_REGISTRY:-<official>}
+docker_pull_timeout=${DOCKER_PULL_TIMEOUT}
+docker_pull_retries=${DOCKER_PULL_RETRIES}
+offline=${DEV_OFFLINE}
+force_pull=${FORCE_PULL}
+state_file=${STATE_FILE#${ROOT}/}
 log_file=${LOG_FILE:-<none>}
 verbose=${VERBOSE}
 EOF
@@ -249,9 +280,8 @@ ensure_tls_certs() {
 }
 
 ensure_data_dirs() {
-	mkdir -p \
-		"${ROOT}/data/postgresql" \
-		"${ROOT}/data/redis" \
+	mkdir -p "${ROOT}/data/postgresql" "${ROOT}/data/redis"
+	install -d -m 0755 \
 		"${ROOT}/data/logs" \
 		"${ROOT}/data/lang-packs" \
 		"${ROOT}/data/media/agent-releases" \
@@ -259,10 +289,118 @@ ensure_data_dirs() {
 		"${ROOT}/data/media/gateway-bootstrap" \
 		"${ROOT}/data/media/snapshot-downloads" \
 		"${ROOT}/data/staticfiles"
+	chmod 0755 \
+		"${ROOT}/data/lang-packs" \
+		"${ROOT}/data/media" \
+		"${ROOT}/data/media/agent-releases" \
+		"${ROOT}/data/media/enroll-bootstrap" \
+		"${ROOT}/data/media/gateway-bootstrap" \
+		"${ROOT}/data/media/snapshot-downloads" \
+		"${ROOT}/data/staticfiles"
+	local manifest="${ROOT}/data/lang-packs/installed.json"
+	if [[ ! -f "${manifest}" ]]; then
+		local temporary="${manifest}.tmp.$$"
+		printf '%s\n' '{"packs":[]}' >"${temporary}"
+		chmod 0644 "${temporary}"
+		mv -f "${temporary}" "${manifest}"
+		log "Created empty runtime language-pack manifest"
+	fi
+}
+
+validate_network_policy() {
+	[[ "${DEV_OFFLINE}" =~ ^[01]$ ]] || die "DEV_OFFLINE must be 0 or 1" 2
+	hfl_docker_validate_pull_settings "${DOCKER_PULL_TIMEOUT}" "${DOCKER_PULL_RETRIES}" \
+		|| die "Docker pull timeout/retries must be positive integers and timeout must be installed" 2
+}
+
+ensure_runtime_images() {
+	local image
+	validate_network_policy
+	for image in nginx:stable-alpine postgres:17 redis:alpine; do
+		log "Resolving runtime image ${image} (offline=${DEV_OFFLINE}, force_pull=${FORCE_PULL})"
+		if ! hfl_docker_ensure_image "${image}" "${MIRROR_DOCKER_DOWNLOAD}" \
+			"${FORCE_PULL}" "${DEV_OFFLINE}" "linux/amd64" \
+			"${DOCKER_PULL_TIMEOUT}" "${DOCKER_PULL_RETRIES}"; then
+			die "unable to prepare ${image}: ${HFL_DOCKER_LAST_ERROR}"
+		fi
+		log "Runtime image ${image} ready (source=${HFL_DOCKER_IMAGE_SOURCE})"
+	done
+}
+
+cache_fingerprint() {
+	local args=(fingerprint --root "${ROOT}") item
+	while [[ $# -gt 0 && "$1" != "--" ]]; do
+		args+=(--path "$1")
+		shift
+	done
+	[[ $# -eq 0 ]] || shift
+	for item in "$@"; do
+		args+=(--value "${item}")
+	done
+	python3 "${ROOT}/tools/dev/cache_state.py" "${args[@]}"
+}
+
+cache_matches() {
+	python3 "${ROOT}/tools/dev/cache_state.py" check \
+		--state "${STATE_FILE}" --key "$1" --fingerprint "$2"
+}
+
+cache_update() {
+	python3 "${ROOT}/tools/dev/cache_state.py" update \
+		--state "${STATE_FILE}" --key "$1" --fingerprint "$2"
+}
+
+build_dev_images() {
+	local force=$1 backend_fingerprint frontend_fingerprint
+	backend_fingerprint="$(cache_fingerprint \
+		deploy/docker/backend.Dockerfile deploy/docker/backend-entrypoint.sh deploy/bootstrap \
+		pyproject.toml uv.lock build/dependencies/kopia/kopia_linux_amd64.deb -- \
+		"apt=${MIRROR_APT}" "pip=${OPT_PIP_INDEX_URL}" \
+		"pip_host=${OPT_PIP_TRUSTED_HOST}" "kopia=${KOPIA_VERSION}")"
+	frontend_fingerprint="$(cache_fingerprint \
+		deploy/docker/frontend.Dockerfile deploy/docker/frontend-dev-entrypoint.sh \
+		src/frontend/package.json \
+		src/frontend/package-lock.json -- "npm=${OPT_NPM_REGISTRY}")"
+
+	if [[ "${force}" -eq 1 ]] || ! docker image inspect hyperfilelens-backend:dev >/dev/null 2>&1 \
+		|| ! cache_matches backend-image "${backend_fingerprint}"; then
+		[[ "${DEV_OFFLINE}" -eq 0 ]] \
+			|| die "backend development image is missing or stale in offline mode"
+		log "Building backend development dependency image"
+		if [[ "${force}" -eq 1 ]]; then
+			compose build --no-cache worker
+		else
+			compose build worker
+		fi
+		cache_update backend-image "${backend_fingerprint}"
+	else
+		log "Backend development image fingerprint unchanged; reusing local image"
+	fi
+
+	if [[ "${force}" -eq 1 ]] || ! docker image inspect hyperfilelens-frontend:dev >/dev/null 2>&1 \
+		|| ! cache_matches frontend-image "${frontend_fingerprint}"; then
+		[[ "${DEV_OFFLINE}" -eq 0 ]] \
+			|| die "frontend development image is missing or stale in offline mode"
+		log "Building frontend development dependency image"
+		if [[ "${force}" -eq 1 ]]; then
+			compose build --no-cache ui
+		else
+			compose build ui
+		fi
+		cache_update frontend-image "${frontend_fingerprint}"
+	else
+		log "Frontend development image fingerprint unchanged; reusing local image"
+	fi
 }
 
 fetch_kopia_deb() {
 	local force=$1
+	local cached="${ROOT}/build/dependencies/kopia/kopia_linux_amd64.deb"
+	if [[ "${DEV_OFFLINE}" -eq 1 ]]; then
+		[[ -s "${cached}" ]] || die "Kopia dependency is missing and offline mode forbids downloading it"
+		log "Offline mode: reusing cached Kopia deb"
+		return 0
+	fi
 	local args=(--kopia-version "${KOPIA_VERSION}")
 	[[ "${force}" -eq 1 ]] && args+=(--force)
 	if [[ -n "${MIRROR_GITHUB_DOWNLOAD}" ]]; then
@@ -316,6 +454,9 @@ prepare_sourcelens_dev() {
 		args=(gateway)
 	fi
 	[[ "${force}" -eq 1 ]] && args+=(--force-build)
+	[[ "${FORCE_PULL}" -eq 1 ]] && args+=(--pull)
+	[[ "${DEV_OFFLINE}" -eq 1 ]] && args+=(--offline)
+	args+=(--pull-timeout "${DOCKER_PULL_TIMEOUT}" --pull-retries "${DOCKER_PULL_RETRIES}")
 	[[ -n "${SOURCELENS_GIT_REF}" ]] && args+=(--sourcelens-ref "${SOURCELENS_GIT_REF}")
 	[[ -n "${SOURCELENS_GIT_URL}" ]] && args+=(--sourcelens-git-url "${SOURCELENS_GIT_URL}")
 	[[ -n "${MIRROR_APT}" ]] && export APT_MIRROR="${MIRROR_APT}"
@@ -326,6 +467,10 @@ prepare_sourcelens_dev() {
 	[[ -n "${OPT_PIP_INDEX_URL}" ]] && export PIP_INDEX_URL="${OPT_PIP_INDEX_URL}"
 	[[ -n "${OPT_PIP_TRUSTED_HOST}" ]] && export PIP_TRUSTED_HOST="${OPT_PIP_TRUSTED_HOST}"
 	[[ -n "${OPT_NPM_REGISTRY}" ]] && export NPM_REGISTRY="${OPT_NPM_REGISTRY}"
+	export DEV_OFFLINE="${DEV_OFFLINE}"
+	export DOCKER_PULL_TIMEOUT_SECONDS="${DOCKER_PULL_TIMEOUT}"
+	export DOCKER_PULL_RETRIES
+	export SOURCELENS_GIT_TIMEOUT_SECONDS SOURCELENS_GIT_RETRIES
 	export SOURCELENS_CONSOLE_BIND_ADDRESS SOURCELENS_CONSOLE_PORT SOURCELENS_NGINX_HTTPS_PORT
 	SOURCELENS_CONSOLE_BIND_ADDRESS="$(read_env_value_or SOURCELENS_CONSOLE_BIND_ADDRESS 0.0.0.0 "${ROOT}/.env")"
 	SOURCELENS_CONSOLE_PORT="$(read_env_value_or SOURCELENS_CONSOLE_PORT 10446 "${ROOT}/.env")"
@@ -346,6 +491,24 @@ stop_sourcelens_dev() {
 
 publish_agent() {
 	local force=$1
+	local fingerprint
+	fingerprint="$(cache_fingerprint src/agent tools/agent tools/dependencies/versions deploy/bootstrap \
+		tools/lib/version.sh tools/lib/logging.sh -- \
+		"arch=${UBUNTU2404_ARCH}" "kopia=${KOPIA_VERSION}" \
+		"commit=$(git -C "${ROOT}" rev-parse HEAD)" \
+		"github_mirror=${MIRROR_GITHUB_DOWNLOAD}" \
+		"docker_mirror=${MIRROR_DOCKER_DOWNLOAD}" "apt=${MIRROR_APT}" \
+		"goproxy=${OPT_GO_PROXY}" "gosumdb=${OPT_GO_SUMDB}")"
+	if [[ "${force}" -eq 0 ]] \
+		&& cache_matches agent-publish "${fingerprint}" \
+		&& find "${ROOT}/data/media/agent-releases" -type f \
+			\( -name '*.tar.gz' -o -name '*.zip' \) -print -quit 2>/dev/null | grep -q .; then
+		log "Agent publish fingerprint unchanged; reusing published packages"
+		return 0
+	fi
+	if [[ "${DEV_OFFLINE}" -eq 1 ]]; then
+		die "Agent packages are missing or stale and offline mode forbids rebuilding network dependencies"
+	fi
 	if [[ "${force}" -eq 1 ]]; then
 		log "Cleaning Agent build output"
 		"${ROOT}/src/agent/scripts/build.sh" --clean
@@ -361,6 +524,7 @@ publish_agent() {
 	[[ -n "${OPT_GO_SUMDB}" ]] && args+=(--go-sumdb "${OPT_GO_SUMDB}")
 	log "Publishing Agent packages (bundle=all, ubuntu2404-arch=${UBUNTU2404_ARCH}, force_fetch=${force})"
 	"${ROOT}/tools/agent/publish.sh" "${args[@]}"
+	cache_update agent-publish "${fingerprint}"
 }
 
 prepare_dev() {
@@ -377,6 +541,7 @@ prepare_dev() {
 	fetch_kopia_deb "${force}"
 	strip_bundled_lang_packs "${ROOT}/src/frontend"
 	publish_agent "${force}"
+	build_dev_images "${force}"
 }
 
 read_env_value() {
@@ -519,11 +684,12 @@ cmd_up() {
 	apply_mirror_env_defaults
 	ensure_env_file
 	require_docker
+	ensure_runtime_images
 	ensure_bridge_network
 	prepare_sourcelens_dev 0
 	prepare_dev 0
-	log "Starting hot-reload HFL stack: docker compose up -d --build"
-	compose up -d --build --remove-orphans
+	log "Starting hot-reload HFL stack from explicitly prepared images"
+	compose up -d --no-build --pull never --remove-orphans
 	print_urls
 }
 
@@ -542,20 +708,129 @@ cmd_restart() {
 	apply_mirror_env_defaults
 	ensure_env_file
 	require_docker
+	ensure_runtime_images
 	ensure_bridge_network
 	prepare_sourcelens_dev "${force}"
 	prepare_dev "${force}"
 
 	if [[ "${force}" -eq 1 ]]; then
-		log "Force restart: rebuild development dependency images without cache"
-		compose down || true
-		compose build --no-cache worker ui
-		compose up -d --force-recreate --remove-orphans
+		log "Force restart: recreating services from freshly rebuilt images"
+		compose up -d --no-build --pull never --force-recreate --remove-orphans
 	else
-		log "Refreshing development dependency images and recreating changed services"
-		compose up -d --build --remove-orphans
+		log "Restarting only services whose image or configuration changed"
+		compose up -d --no-build --pull never --remove-orphans
 	fi
 	print_urls
+}
+
+cmd_status() {
+	ensure_env_file
+	require_docker
+	log "HyperFileLens services"
+	compose ps
+	if [[ -f "${ROOT}/build/sourcelens/dev/docker-compose.yml" ]]; then
+		log "SourceLens services"
+		# SourceLens helper resolves the generated Compose project without changing it.
+		(
+			cd "${ROOT}/build/sourcelens/dev"
+			docker compose --env-file "${ROOT}/data/sourcelens/config/.env" \
+				-p "${SOURCELENS_COMPOSE_PROJECT:-sourcelens}" -f docker-compose.yml ps
+		)
+	else
+		log "SourceLens runtime has not been prepared"
+	fi
+}
+
+cmd_doctor() {
+	local failures=0 command image mode
+	ensure_env_file
+	apply_mirror_env_defaults
+	for command in docker python3 openssl timeout flock gzip; do
+		if command -v "${command}" >/dev/null 2>&1; then
+			printf 'ok      command %s\n' "${command}"
+		else
+			printf 'missing command %s\n' "${command}"
+			failures=$((failures + 1))
+		fi
+	done
+	validate_network_policy || failures=$((failures + 1))
+	if command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; then
+		printf 'ok      Docker daemon reachable\n'
+		for image in nginx:stable-alpine postgres:17 redis:alpine \
+			hyperfilelens-backend:dev hyperfilelens-frontend:dev; do
+			if docker image inspect "${image}" >/dev/null 2>&1; then
+				printf 'ok      image %s\n' "${image}"
+			else
+				printf 'pending image %s (prepared by up)\n' "${image}"
+			fi
+		done
+	else
+		printf 'missing Docker daemon is not reachable\n'
+		failures=$((failures + 1))
+	fi
+	if [[ -d "${ROOT}/data/lang-packs" ]]; then
+		mode="$(stat -c '%a' "${ROOT}/data/lang-packs")"
+		if [[ "${mode}" =~ ^(755|775|777)$ && -r "${ROOT}/data/lang-packs/installed.json" ]]; then
+			printf 'ok      language packs mode=%s manifest=readable\n' "${mode}"
+		else
+			printf 'invalid language packs mode=%s or manifest unreadable (run up)\n' "${mode}"
+			failures=$((failures + 1))
+		fi
+	else
+		printf 'pending data directories (created by up)\n'
+	fi
+	if [[ "${failures}" -ne 0 ]]; then
+		die "doctor found ${failures} blocking issue(s)"
+	fi
+	printf 'doctor: no blocking issues found\n'
+}
+
+clean_runtime() {
+	require_docker
+	ensure_env_file
+	compose down --volumes --remove-orphans || true
+	if [[ -x "${ROOT}/dev/sourcelens.sh" ]]; then
+		"${ROOT}/dev/sourcelens.sh" down || true
+	fi
+	docker network rm hyperfilelens-bridge >/dev/null 2>&1 || true
+	log "Removed development containers, Compose networks, and modules volume"
+}
+
+clean_cache() {
+	require_docker
+	local image
+	for image in hyperfilelens-backend:dev hyperfilelens-frontend:dev; do
+		docker image rm "${image}" >/dev/null 2>&1 || true
+	done
+	rm -rf "${ROOT}/build/agent" "${ROOT}/build/state" "${ROOT}/build/sourcelens"
+	log "Removed generated build caches and local HFL development images"
+}
+
+clean_data() {
+	[[ "${CLEAN_YES}" -eq 1 ]] \
+		|| die "clean --data and clean --all require --yes because databases and runtime data are deleted" 2
+	rm -rf "${ROOT}/data"
+	log "Removed runtime data"
+}
+
+cmd_clean() {
+	if [[ "${CLEAN_SCOPE}" == "data" || "${CLEAN_SCOPE}" == "all" ]]; then
+		[[ "${CLEAN_YES}" -eq 1 ]] \
+			|| die "clean --data and clean --all require --yes because databases and runtime data are deleted" 2
+	fi
+	case "${CLEAN_SCOPE}" in
+	runtime) clean_runtime ;;
+	cache) clean_cache ;;
+	data) clean_runtime; clean_data ;;
+	all) clean_runtime; clean_cache; clean_data ;;
+	*) die "clean requires exactly one of --runtime, --cache, --data, or --all" 2 ;;
+	esac
+}
+
+cmd_smoke() {
+	ensure_env_file
+	require_docker
+	"${ROOT}/tools/dev/browser-smoke.sh"
 }
 
 parse_common_option() {
@@ -636,6 +911,24 @@ parse_common_option() {
 		HFL_ONLY_DOWN=1
 		return 0
 		;;
+	--pull)
+		FORCE_PULL=1
+		return 0
+		;;
+	--offline)
+		DEV_OFFLINE=1
+		return 0
+		;;
+	--pull-timeout)
+		require_value "$1" "${2:-}"
+		DOCKER_PULL_TIMEOUT="$2"
+		return 0
+		;;
+	--pull-retries)
+		require_value "$1" "${2:-}"
+		DOCKER_PULL_RETRIES="$2"
+		return 0
+		;;
 	esac
 	return 1
 }
@@ -655,13 +948,22 @@ main() {
 
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
-		up | down | restart)
+		up | down | restart | status | doctor | smoke | clean)
 			[[ -z "${cmd}" ]] || die "multiple commands specified"
 			cmd="$1"
 			shift
 			;;
 		--force)
 			restart_force=1
+			shift
+			;;
+		--runtime | --cache | --data | --all)
+			[[ -z "${CLEAN_SCOPE}" ]] || die "multiple clean scopes specified" 2
+			CLEAN_SCOPE="${1#--}"
+			shift
+			;;
+		--yes)
+			CLEAN_YES=1
 			shift
 			;;
 		-h | --help | help)
@@ -681,9 +983,10 @@ main() {
 			LOG_FILE="$2"
 			shift 2
 			;;
-		--github-download-mirror | --github-token | --docker-download-mirror | --apt-mirror | --ubuntu2404-arch | --kopia-version | --sourcelens-ref | --sourcelens-git-url | --go-proxy | --go-sumdb | --pip-index-url | --pip-trusted-host | --npm-registry | --no-sourcelens | --hfl-only)
+		--github-download-mirror | --github-token | --docker-download-mirror | --apt-mirror | --ubuntu2404-arch | --kopia-version | --sourcelens-ref | --sourcelens-git-url | --go-proxy | --go-sumdb | --pip-index-url | --pip-trusted-host | --npm-registry | --pull-timeout | --pull-retries | --no-sourcelens | --hfl-only | --pull | --offline)
 			parse_common_option "$@" || die "failed to parse option: $1"
-			if [[ "$1" == "--no-sourcelens" || "$1" == "--hfl-only" ]]; then
+			if [[ "$1" == "--no-sourcelens" || "$1" == "--hfl-only" \
+				|| "$1" == "--pull" || "$1" == "--offline" ]]; then
 				shift
 			else
 				shift 2
@@ -713,11 +1016,21 @@ main() {
 	if [[ "${HFL_ONLY_DOWN}" -eq 1 && "${cmd}" != "down" ]]; then
 		die "--hfl-only is only valid with down" 2
 	fi
+	if [[ -n "${CLEAN_SCOPE}" && "${cmd}" != "clean" ]]; then
+		die "clean scope options are only valid with clean" 2
+	fi
+	if [[ "${CLEAN_YES}" -eq 1 && "${cmd}" != "clean" ]]; then
+		die "--yes is only valid with clean" 2
+	fi
 
 	case "${cmd}" in
 	up) cmd_up ;;
 	down) cmd_down ;;
 	restart) cmd_restart "${restart_force}" ;;
+	status) cmd_status ;;
+	doctor) cmd_doctor ;;
+	smoke) cmd_smoke ;;
+	clean) cmd_clean ;;
 	esac
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ x-backend-volumes: &backend-volumes
 
 x-backend-image: &backend-image
   image: hyperfilelens-backend:dev
+  pull_policy: never
   platform: linux/amd64
   env_file:
     - ./.env
@@ -124,6 +125,7 @@ services:
 
   postgres:
     image: postgres:17
+    pull_policy: never
     # Official PostgreSQL image; pin a distribution variant when required.
     env_file:
       - ./.env
@@ -150,6 +152,7 @@ services:
 
   redis:
     image: redis:alpine
+    pull_policy: never
     volumes:
       - ./data/redis:/data
     healthcheck:
@@ -165,6 +168,7 @@ services:
 
   ui:
     image: hyperfilelens-frontend:dev
+    pull_policy: never
     env_file:
       - ./.env
     extra_hosts:
@@ -201,6 +205,7 @@ services:
 
   nginx:
     image: nginx:stable-alpine
+    pull_policy: never
     depends_on:
       api:
         condition: service_healthy

--- a/release/build-sourcelens.sh
+++ b/release/build-sourcelens.sh
@@ -3,6 +3,7 @@
 # Invoked from release/build.sh when BUILD_SOURCELENS=1.
 set -euo pipefail
 export COPYFILE_DISABLE=1
+umask 022
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 # shellcheck source=../tools/sourcelens/common.sh
@@ -14,7 +15,9 @@ die() { hfl_die "$1" "${2:-1}"; }
 PKG_ROOT=""
 IMAGES_DIR=""
 FORCE_PULL=0
+NO_CACHE=0
 FORCE_BUILD="${SOURCELENS_FORCE_BUILD:-0}"
+PREBUILT=0
 LOG_FILE="${HFL_LOG_FILE:-}"
 VERBOSE="${HFL_LOG_VERBOSE:-0}"
 PRINT_CONFIG=0
@@ -32,7 +35,9 @@ Usage: ./release/build-sourcelens.sh --pkg-root DIR --images-dir DIR [options]
   --pkg-root DIR       Release package staging root (hyperfilelens-<version>/)
   --images-dir DIR     images/ directory inside the package root
   --pull               Pull nginx:stable-alpine even when present locally
+  --no-cache           Rebuild SourceLens Docker layers without BuildKit cache
   --force-build        Rebuild SourceLens images even when the build stamp matches
+  --prebuilt           Package normalized images already loaded in Docker
   --sourcelens-git-url URL  Override SOURCELENS_GIT_URL
   --sourcelens-ref REF      SourceLens release tag in vX.Y.Z form
   --github-token TOKEN GitHub token for private repo clone/fetch (env: GITHUB_TOKEN)
@@ -64,6 +69,8 @@ docker_platform=${SOURCELENS_DOCKER_PLATFORM}
 build_sourcelens=${BUILD_SOURCELENS}
 force_build=${FORCE_BUILD}
 force_pull=${FORCE_PULL}
+no_cache=${NO_CACHE}
+prebuilt=${PREBUILT}
 github_token=$(hfl_redact "${GITHUB_TOKEN:-}")
 apt_mirror=${SOURCELENS_APT_MIRROR:-<official>}
 pip_index_url=${SOURCELENS_PIP_INDEX_URL:-<official>}
@@ -95,8 +102,16 @@ parse_args() {
 			FORCE_PULL=1
 			shift
 			;;
+		--no-cache)
+			NO_CACHE=1
+			shift
+			;;
 		--force-build)
 			FORCE_BUILD=1
+			shift
+			;;
+		--prebuilt)
+			PREBUILT=1
 			shift
 			;;
 		--sourcelens-git-url | --git-url)
@@ -237,7 +252,6 @@ stage_runtime_tree() {
 	log "Using upstream SourceLens nginx configuration"
 	cp "${src}/docker/nginx/default.conf" "${sl_root}/deploy/nginx/default.conf"
 	sourcelens_patch_runtime_nginx "${sl_root}/deploy/nginx/default.conf"
-	rsync -a "${src}/docker/nginx/certs/" "${sl_root}/deploy/nginx/certs/"
 	if [[ -d "${src}/docker/postgresql" ]]; then
 		rsync -a "${src}/docker/postgresql/" "${sl_root}/deploy/postgresql/"
 	fi
@@ -343,8 +357,14 @@ main() {
 	command -v python3 >/dev/null 2>&1 || die "python3 not found" 2
 
 	sourcelens_sync_source
-	sourcelens_prepare_source_build_env
-	sourcelens_build_app_images "${FORCE_BUILD}"
+	if [[ "${PREBUILT}" -eq 1 ]]; then
+		sourcelens_app_images_ready \
+			|| die "--prebuilt requires normalized SourceLens backend, frontend, and LensNode images"
+		sourcelens_tag_lensnode_alias
+		log "Using prebuilt SourceLens application images"
+	else
+		sourcelens_build_app_images "${FORCE_BUILD}" "${NO_CACHE}"
+	fi
 	sourcelens_ensure_nginx_image "${FORCE_PULL}"
 	save_image_archives
 	stage_runtime_tree

--- a/release/build.sh
+++ b/release/build.sh
@@ -7,6 +7,7 @@
 #   ./release/build.sh --github-download-mirror https://ghfast.top --docker-download-mirror docker.m.daocloud.io --apt-mirror https://mirrors.tuna.tsinghua.edu.cn
 set -euo pipefail
 export COPYFILE_DISABLE=1
+umask 022
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 RELEASE_DIR="${ROOT}/release"
@@ -28,6 +29,7 @@ MIRROR_DOCKER_DOWNLOAD=""
 MIRROR_DOCKER_APT=""
 MIRROR_APT=""
 FORCE_PULL=0
+NO_CACHE=0
 SOURCELENS_FORCE_BUILD="${SOURCELENS_FORCE_BUILD:-0}"
 BUILD_SOURCELENS="${BUILD_SOURCELENS:-}"
 SOURCELENS_GIT_REF="${SOURCELENS_GIT_REF:-}"
@@ -50,6 +52,41 @@ tar_create_gz() {
 	COPYFILE_DISABLE=1 tar -C "${base_dir}" -czf "${out}" "${entry}"
 }
 
+normalize_release_permissions() {
+	local pkg_root=$1
+	find "${pkg_root}" -type d -exec chmod 755 {} +
+	find "${pkg_root}" -type f -exec chmod 644 {} +
+	chmod 755 "${pkg_root}/install.sh"
+	if [[ -d "${pkg_root}/sourcelens" ]]; then
+		chmod 755 "${pkg_root}/sourcelens/install.sh" \
+			"${pkg_root}/sourcelens/patch-env-runtime.py"
+		find "${pkg_root}/sourcelens/deploy/postgresql/initdb.d" \
+			-type f -name '*.sh' -exec chmod 755 {} +
+	fi
+	find "${pkg_root}/payload/media" -type f -name '*.sh' -exec chmod 755 {} +
+	if [[ -d "${pkg_root}/payload/media/enroll-bootstrap" ]]; then
+		find "${pkg_root}/payload/media/enroll-bootstrap" -type f -exec chmod 755 {} +
+	fi
+}
+
+validate_release_security() {
+	local pkg_root=$1 bad=""
+	bad="$(find "${pkg_root}" \
+		\( -name '.env' -o -name '*.key' -o -name '*.pem' -o -name '*.p12' \
+		-o -name '*.pfx' -o -name 'id_rsa' \) -print -quit)"
+	[[ -z "${bad}" ]] || die "release package contains forbidden secret material: ${bad#${pkg_root}/}"
+	for public_dir in \
+		"${pkg_root}/payload/media/agent-releases" \
+		"${pkg_root}/payload/media/enroll-bootstrap" \
+		"${pkg_root}/payload/media/gateway-bootstrap"; do
+		[[ -d "${public_dir}" ]] || continue
+		bad="$(find "${public_dir}" -type f ! -perm -004 -print -quit)"
+		[[ -z "${bad}" ]] \
+			|| die "release download is not readable by the nginx worker: ${bad#${pkg_root}/}"
+	done
+	log "Release secret and download permission validation passed"
+}
+
 require_value() {
 	if [[ $# -lt 2 || -z "${2:-}" || "${2:0:1}" == "-" ]]; then
 		die "${1} requires a value" 2
@@ -63,6 +100,7 @@ load_repo_env_defaults() {
 		GITHUB_DOWNLOAD_MIRROR GITHUB_TOKEN DOCKER_DOWNLOAD_MIRROR \
 		DOCKER_APT_MIRROR APT_MIRROR PIP_INDEX_URL PIP_TRUSTED_HOST \
 		PIP_TIMEOUT NPM_REGISTRY GOPROXY GOSUMDB BUILD_SOURCELENS \
+		DOCKER_PULL_TIMEOUT_SECONDS \
 		SOURCELENS_GIT_REF SOURCELENS_GIT_URL SENTRY_ENABLED SENTRY_DSN \
 		SENTRY_ENVIRONMENT SENTRY_RELEASE SENTRY_TRACES_SAMPLE_RATE \
 		SENTRY_SEND_DEFAULT_PII VITE_SHOW_EULA; do
@@ -81,6 +119,13 @@ apply_mirror_env_defaults() {
 apply_go_proxy_env_defaults() {
 	export GOPROXY="${GOPROXY:-${BUILD_GOPROXY:-https://proxy.golang.org,direct}}"
 	export GOSUMDB="${GOSUMDB:-${BUILD_GOSUMDB:-sum.golang.org}}"
+}
+
+validate_docker_pull_timeout() {
+	DOCKER_PULL_TIMEOUT_SECONDS="${DOCKER_PULL_TIMEOUT_SECONDS:-180}"
+	[[ "${DOCKER_PULL_TIMEOUT_SECONDS}" =~ ^[1-9][0-9]*$ ]] \
+		|| die "DOCKER_PULL_TIMEOUT_SECONDS must be a positive integer" 2
+	export DOCKER_PULL_TIMEOUT_SECONDS
 }
 
 export_build_mirror_env() {
@@ -136,6 +181,7 @@ Mirror options (Kopia fetch + Agent publishing + runtime image pull; env fallbac
   --github-download-mirror URL     GitHub download mirror (env: GITHUB_DOWNLOAD_MIRROR)
   --github-token TOKEN             GitHub token for API/release fetch and private SourceLens clone (env: GITHUB_TOKEN)
   --docker-download-mirror URL     Docker Hub mirror for ubuntu:24.04, postgres, redis (env: DOCKER_DOWNLOAD_MIRROR)
+  --docker-pull-timeout SECONDS    Timeout for each Docker pull attempt (env: DOCKER_PULL_TIMEOUT_SECONDS)
   --docker-apt-mirror URL          Docker CE apt repo base URL (env: DOCKER_APT_MIRROR / BUILD_DOCKER_APT_MIRROR)
   --apt-mirror URL                 Ubuntu apt mirror for NAS container (env: APT_MIRROR)
   --ubuntu2404-arch ARCH           NAS deb arch for agent bundle: amd64 | arm64 | all (default: amd64)
@@ -146,6 +192,7 @@ Mirror options (Kopia fetch + Agent publishing + runtime image pull; env fallbac
   --npm-registry URL               npm registry (env: NPM_REGISTRY)
 
   --pull                           Re-check registry and pull runtime images (default: use local if present)
+  --no-cache                       Rebuild HFL and SourceLens Docker layers without BuildKit cache
 
 SourceLens bundle (tools/sourcelens/defaults.env; default: enabled):
   --no-sourcelens                  Skip SourceLens clone/build/bundle
@@ -174,6 +221,7 @@ print_config() {
 	sourcelens_version="${BASH_REMATCH[1]}"
 	apply_mirror_env_defaults
 	apply_go_proxy_env_defaults
+	validate_docker_pull_timeout
 	apply_ubuntu2404_arch_default
 	export_build_mirror_env
 	cat <<EOF
@@ -190,10 +238,12 @@ sourcelens_upstream_image_prefix=${SOURCELENS_UPSTREAM_IMAGE_PREFIX}
 sourcelens_image_registry=${SOURCELENS_IMAGE_REGISTRY:-<local>}
 ubuntu2404_arch=${UBUNTU2404_ARCH}
 force_pull=${FORCE_PULL}
+no_cache=${NO_CACHE}
 force_sourcelens_build=${SOURCELENS_FORCE_BUILD}
 github_download_mirror=${MIRROR_GITHUB_DOWNLOAD:-<official>}
 github_token=$(hfl_redact "${MIRROR_GITHUB_TOKEN}")
 docker_download_mirror=${MIRROR_DOCKER_DOWNLOAD:-<official>}
+docker_pull_timeout_seconds=${DOCKER_PULL_TIMEOUT_SECONDS:-180}
 docker_apt_mirror=${MIRROR_DOCKER_APT:-https://download.docker.com/linux/ubuntu}
 apt_mirror=${MIRROR_APT:-<official>}
 go_proxy=${GOPROXY}
@@ -242,6 +292,12 @@ parse_common_option() {
 	--docker-download-mirror)
 		require_value "$1" "${2:-}"
 		MIRROR_DOCKER_DOWNLOAD="$2"
+		return 0
+		;;
+	--docker-pull-timeout)
+		require_value "$1" "${2:-}"
+		[[ "$2" =~ ^[1-9][0-9]*$ ]] || die "$1 requires a positive integer" 2
+		export DOCKER_PULL_TIMEOUT_SECONDS="$2"
 		return 0
 		;;
 	--docker-apt-mirror)
@@ -338,12 +394,16 @@ parse_args() {
 			LOG_FILE="$2"
 			shift 2
 			;;
-		--github-download-mirror | --github-token | --docker-download-mirror | --docker-apt-mirror | --apt-mirror | --ubuntu2404-arch | --go-proxy | --go-sumdb | --pip-index-url | --pip-trusted-host | --npm-registry)
+		--github-download-mirror | --github-token | --docker-download-mirror | --docker-pull-timeout | --docker-apt-mirror | --apt-mirror | --ubuntu2404-arch | --go-proxy | --go-sumdb | --pip-index-url | --pip-trusted-host | --npm-registry)
 			parse_common_option "$@" || die "failed to parse option: $1"
 			shift 2
 			;;
 		--pull)
 			FORCE_PULL=1
+			shift
+			;;
+		--no-cache)
+			NO_CACHE=1
 			shift
 			;;
 		--force-build)
@@ -387,6 +447,7 @@ publish_agent() {
 	args+=(--commit "${RELEASE_COMMIT}")
 	args+=(--version "${HFL_VERSION}")
 	args+=(--kopia-version "${KOPIA_VERSION}")
+	[[ "${FORCE_PULL}" -eq 1 ]] && args+=(--pull)
 	[[ -n "${GOPROXY:-}" ]] && args+=(--go-proxy "${GOPROXY}")
 	[[ -n "${GOSUMDB:-}" ]] && args+=(--go-sumdb "${GOSUMDB}")
 	local mirror
@@ -402,6 +463,7 @@ build_sourcelens_bundle() {
 	local images_dir=$2
 	local args=(--pkg-root "${pkg_root}" --images-dir "${images_dir}")
 	[[ "${FORCE_PULL}" -eq 1 ]] && args+=(--pull)
+	[[ "${NO_CACHE}" -eq 1 ]] && args+=(--no-cache)
 	[[ "${SOURCELENS_FORCE_BUILD}" -eq 1 ]] && args+=(--force-build)
 	[[ -n "${SOURCELENS_GIT_REF:-}" ]] && args+=(--sourcelens-ref "${SOURCELENS_GIT_REF}")
 	if [[ -n "${SOURCELENS_GIT_URL:-}" ]]; then
@@ -453,6 +515,9 @@ build_control_plane_images() {
 	)
 	if [[ "${FORCE_PULL}" -eq 1 ]]; then
 		common_args+=(--pull)
+	fi
+	if [[ "${NO_CACHE}" -eq 1 ]]; then
+		common_args+=(--no-cache)
 	fi
 
 	log "Building hyperfilelens-backend:${HFL_VERSION} (alias: latest)"
@@ -910,6 +975,7 @@ main() {
 	hfl_logging_configure release "${LOG_FILE}" "${VERBOSE}"
 	apply_mirror_env_defaults
 	apply_go_proxy_env_defaults
+	validate_docker_pull_timeout
 	apply_ubuntu2404_arch_default
 	if [[ "${PRINT_CONFIG}" -eq 1 ]]; then
 		print_config
@@ -983,6 +1049,7 @@ main() {
 
 	mkdir -p "${pkg_root}/host/debs"
 	rsync -a "${HOST_DEBS_CACHE}/" "${pkg_root}/host/debs/"
+	normalize_release_permissions "${pkg_root}"
 
 	local payload_sha
 	payload_sha="$(tree_sha256 "${pkg_root}/payload")"
@@ -991,6 +1058,7 @@ main() {
 		"${backend_digest}" "${frontend_digest}" "${postgres_digest}" "${redis_digest}"
 	validate_release_publish_artifacts "${pkg_root}"
 	write_package_readme "${pkg_root}" "${version}"
+	validate_release_security "${pkg_root}"
 
 	mkdir -p "${DIST_DIR}"
 	tar_path="${DIST_DIR}/${tar_basename}"
@@ -999,13 +1067,16 @@ main() {
 	log "Creating ${tar_path}"
 	tar_create_gz "${tar_tmp}" "${STAGING_BASE}" "${pkg_name}"
 	mv -f "${tar_tmp}" "${tar_path}"
+	chmod 644 "${tar_path}"
 
 	log "Package sizes:"
 	du -sh "${pkg_root}/host/debs" "${images_dir}" "${pkg_root}/payload" "${tar_path}" || true
 	log "Done: ${tar_path}"
 }
 
-hfl_logging_configure release
-trap 'rc=$?; hfl_logging_finish "${rc}"' EXIT
-trap 'exit 130' INT TERM
-main "$@"
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+	hfl_logging_configure release
+	trap 'rc=$?; hfl_logging_finish "${rc}"' EXIT
+	trap 'exit 130' INT TERM
+	main "$@"
+fi

--- a/release/ci/assemble-release.ps1.txt
+++ b/release/ci/assemble-release.ps1.txt
@@ -1,0 +1,26 @@
+param([Parameter(Mandatory=$true)][string]$Output)
+$checksums = @{}
+Get-Content "SHA256SUMS" | ForEach-Object {
+    if ($_ -match '^([0-9a-fA-F]{64})\s+\*?(.+)$') {
+        $checksums[$Matches[2]] = $Matches[1].ToLowerInvariant()
+    }
+}
+$parts = Get-ChildItem -File "$Output.part-*" | Sort-Object Name
+if ($parts.Count -eq 0) { throw "No release parts found for $Output" }
+foreach ($part in $parts) {
+    if (-not $checksums.ContainsKey($part.Name)) {
+        throw "No checksum found for $($part.Name)"
+    }
+    $actual = (Get-FileHash -Algorithm SHA256 $part.FullName).Hash.ToLowerInvariant()
+    if ($actual -ne $checksums[$part.Name]) {
+        throw "Checksum mismatch for $($part.Name)"
+    }
+}
+$target = [System.IO.File]::Create($Output)
+try {
+    foreach ($part in $parts) {
+        $source = [System.IO.File]::OpenRead($part.FullName)
+        try { $source.CopyTo($target) } finally { $source.Dispose() }
+    }
+} finally { $target.Dispose() }
+Write-Host "Assembled $Output"

--- a/release/ci/assemble-release.sh
+++ b/release/ci/assemble-release.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+# Assemble matrix outputs into the canonical HFL offline release package.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+# Source packaging helpers without executing release/build.sh's local build.
+# shellcheck source=../build.sh
+source "${ROOT}/release/build.sh"
+
+if [[ -n "${HFL_CI_RELEASE_BUILD_DIR:-}" ]]; then
+	RELEASE_BUILD_DIR="${HFL_CI_RELEASE_BUILD_DIR}"
+	STAGING_BASE="${RELEASE_BUILD_DIR}/staging"
+	DIST_DIR="${RELEASE_BUILD_DIR}/dist"
+fi
+
+usage() {
+	cat <<'USAGE'
+Usage: assemble-release.sh --input-dir DIR --version X.Y.Z --commit SHA
+USAGE
+}
+
+input_dir=""
+version=""
+commit=""
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+	--input-dir) input_dir=${2:-}; shift 2 ;;
+	--version) version=${2#v}; shift 2 ;;
+	--commit) commit=${2:-}; shift 2 ;;
+	-h | --help) usage; exit 0 ;;
+	*) printf 'ERROR: unknown argument: %s\n' "$1" >&2; exit 2 ;;
+	esac
+done
+
+[[ -d "${input_dir}" ]] || { printf 'ERROR: input directory is missing\n' >&2; exit 2; }
+[[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || { printf 'ERROR: invalid version\n' >&2; exit 2; }
+[[ "${commit}" =~ ^[0-9a-f]{40}$ ]] || { printf 'ERROR: invalid commit\n' >&2; exit 2; }
+
+hfl_logging_configure ci-assemble
+hfl_logging_start
+trap 'hfl_logging_finish "$?"' EXIT
+
+commit7=${commit:0:7}
+pkg_name="hyperfilelens-${version}"
+pkg_root="${STAGING_BASE}/${pkg_name}"
+images_dir="${pkg_root}/images"
+tar_basename="$(release_package_basename_for_version "${version}" "${commit7}")"
+safe_assert_package_basename "${tar_basename}"
+safe_assert_staging_pkg_root "${pkg_root}" "${STAGING_BASE}"
+safe_rm_dir "${pkg_root}"
+mkdir -p "${pkg_root}" "${images_dir}" "${pkg_root}/payload/media" "${pkg_root}/metadata"
+
+required_bundles=(
+	_internal-hfl-images.tar.gz
+	_internal-runtime-images.tar.gz
+	_internal-sourcelens-bundle.tar.gz
+	_internal-host-debs.tar.gz
+)
+for bundle in "${required_bundles[@]}"; do
+	[[ -s "${input_dir}/${bundle}" ]] || die "missing CI bundle: ${bundle}"
+	log "Extracting ${bundle}"
+	tar -xzf "${input_dir}/${bundle}" -C "${pkg_root}"
+done
+
+required_agent_bundles=(
+	_internal-agent-linux-amd64.tar.gz
+	_internal-agent-linux-arm64.tar.gz
+	_internal-agent-darwin-amd64.tar.gz
+	_internal-agent-darwin-arm64.tar.gz
+	_internal-agent-windows-amd64.tar.gz
+)
+for bundle_name in "${required_agent_bundles[@]}"; do
+	bundle="${input_dir}/${bundle_name}"
+	[[ -s "${bundle}" ]] || die "missing Agent matrix bundle: ${bundle_name}"
+	log "Merging $(basename "${bundle}")"
+	tar -xzf "${bundle}" -C "${pkg_root}"
+done
+
+for required in \
+	images/00-hyperfilelens.tar.gz \
+	images/01-postgres-17.tar.gz \
+	images/02-redis-alpine.tar.gz \
+	images/10-sourcelens-app.tar.gz \
+	images/11-sourcelens-lensnode.tar.gz \
+	images/12-nginx-stable-alpine.tar.gz \
+	sourcelens/BUILD_INFO.json; do
+	[[ -s "${pkg_root}/${required}" ]] || die "assembled package is missing ${required}"
+done
+
+# Ensure gateway bootstrap receives the same host Docker bundle as the offline
+# control-plane installer. The LensNode archive is already hard-linked by the
+# SourceLens bundling job when the filesystem supports it.
+gateway_dir="${pkg_root}/payload/media/gateway-bootstrap"
+mkdir -p "${gateway_dir}"
+tar -C "${pkg_root}/host/debs" -czf "${gateway_dir}/docker-debs-ubuntu2404-amd64.tar.gz" .
+for script in \
+	gateway-bootstrap-linux.sh \
+	gateway-install-lensnode-sidecar.sh \
+	gateway-lifecycle.sh \
+	gateway-install-docker-ubuntu2404-amd64.sh; do
+	cp "${ROOT}/deploy/bootstrap/${script}" "${gateway_dir}/${script}"
+	chmod 755 "${gateway_dir}/${script}"
+done
+
+log "Staging release runtime files"
+printf '%s\n' "${version}" >"${pkg_root}/VERSION"
+cp "${ROOT}/deploy/docker-compose.yml" "${pkg_root}/docker-compose.yml"
+cp "${ROOT}/.env.example" "${pkg_root}/.env.example"
+cp "${ROOT}/LICENSE" "${pkg_root}/LICENSE"
+mkdir -p "${pkg_root}/deploy/nginx/certs" "${pkg_root}/deploy/nginx/snippets" "${pkg_root}/deploy/logrotate"
+cp "${ROOT}/deploy/nginx/default.conf" "${pkg_root}/deploy/nginx/default.conf"
+rsync -a "${ROOT}/deploy/nginx/snippets/" "${pkg_root}/deploy/nginx/snippets/"
+cp "${ROOT}/deploy/logrotate/hyperfilelens.conf" "${pkg_root}/deploy/logrotate/hyperfilelens.conf"
+cp "${ROOT}/deploy/installer/install.sh" "${pkg_root}/install.sh"
+chmod 755 "${pkg_root}/install.sh"
+
+normalize_release_permissions "${pkg_root}"
+payload_sha="$(tree_sha256 "${pkg_root}/payload")"
+
+image_digest() {
+	local metadata=$1 ref digest
+	ref="$(jq -r '.ref' "${metadata}")"
+	digest="$(jq -r '.digest' "${metadata}")"
+	printf '%s@%s' "${ref%@*}" "${digest}"
+}
+backend_digest="$(image_digest "${pkg_root}/metadata/hfl-backend.json")"
+frontend_digest="$(image_digest "${pkg_root}/metadata/hfl-frontend.json")"
+postgres_digest="$(jq -r '.digest' "${pkg_root}/metadata/postgres.json")"
+redis_digest="$(jq -r '.digest' "${pkg_root}/metadata/redis.json")"
+
+write_manifest "${pkg_root}" "${version}" "${commit}" "${payload_sha}" \
+	"${backend_digest}" "${frontend_digest}" "${postgres_digest}" "${redis_digest}"
+rm -rf "${pkg_root}/metadata"
+validate_release_publish_artifacts "${pkg_root}"
+write_package_readme "${pkg_root}" "${version}"
+validate_release_security "${pkg_root}"
+
+mkdir -p "${DIST_DIR}"
+find "${DIST_DIR}" -maxdepth 1 -type f -delete
+tar_path="${DIST_DIR}/${tar_basename}"
+tar_tmp="${tar_path}.part"
+log "Creating ${tar_path}"
+tar_create_gz "${tar_tmp}" "${STAGING_BASE}" "${pkg_name}"
+mv "${tar_tmp}" "${tar_path}"
+chmod 644 "${tar_path}"
+
+cp "${pkg_root}/MANIFEST.json" "${DIST_DIR}/MANIFEST.json"
+python3 "${SCRIPT_DIR}/write-sbom.py" \
+	--manifest "${pkg_root}/MANIFEST.json" \
+	--output "${DIST_DIR}/SBOM.spdx.json"
+
+max_single_bytes="${HFL_RELEASE_MAX_SINGLE_BYTES:-$((1900 * 1024 * 1024))}"
+part_bytes="${HFL_RELEASE_PART_BYTES:-$((1024 * 1024 * 1024))}"
+[[ "${max_single_bytes}" =~ ^[1-9][0-9]*$ ]] || die "invalid HFL_RELEASE_MAX_SINGLE_BYTES"
+[[ "${part_bytes}" =~ ^[1-9][0-9]*$ ]] || die "invalid HFL_RELEASE_PART_BYTES"
+tar_bytes="$(stat -c '%s' "${tar_path}")"
+if ((tar_bytes >= max_single_bytes)); then
+	log "Release exceeds the single-asset limit; creating split parts"
+	split -b "${part_bytes}" -d -a 3 "${tar_path}" "${tar_path}.part-"
+	rm -f "${tar_path}"
+	cp "${SCRIPT_DIR}/assemble-release.sh.txt" "${DIST_DIR}/assemble-release.sh"
+	cp "${SCRIPT_DIR}/assemble-release.ps1.txt" "${DIST_DIR}/assemble-release.ps1"
+	chmod 755 "${DIST_DIR}/assemble-release.sh"
+fi
+
+(
+	cd "${DIST_DIR}"
+	checksums_tmp="${RELEASE_BUILD_DIR}/SHA256SUMS.tmp"
+	find . -maxdepth 1 -type f ! -name SHA256SUMS -printf '%f\0' \
+		| sort -z \
+		| xargs -0 sha256sum >"${checksums_tmp}"
+	mv "${checksums_tmp}" SHA256SUMS
+	find . -maxdepth 1 -type f -printf '%f\n' | sort >"${RELEASE_BUILD_DIR}/release-assets.txt"
+)
+
+du -sh "${pkg_root}" "${DIST_DIR}"/*
+log "Release assembly complete"

--- a/release/ci/assemble-release.sh.txt
+++ b/release/ci/assemble-release.sh.txt
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+prefix=${1:?Usage: assemble-release.sh hyperfilelens-X.Y.Z-XXXXXXX.tar.gz}
+cat "${prefix}.part-"* >"${prefix}"
+sha256sum -c SHA256SUMS

--- a/release/ci/build-agent-asset.sh
+++ b/release/ci/build-agent-asset.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Build one Agent matrix entry and package its release payload for CI assembly.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+[[ $# -eq 4 ]] || {
+	printf 'Usage: %s GOOS:GOARCH VERSION COMMIT OUTPUT_TAR_GZ\n' "$0" >&2
+	exit 2
+}
+matrix=$1
+version=${2#v}
+commit=$3
+output=$4
+
+case "${matrix}" in
+linux:amd64) bundle=all ;;
+linux:arm64 | darwin:amd64 | darwin:arm64 | windows:amd64) bundle=standard ;;
+*) printf 'ERROR: unsupported Agent matrix entry: %s\n' "${matrix}" >&2; exit 2 ;;
+esac
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "${tmp}"' EXIT
+releases="${tmp}/payload/media/agent-releases"
+args=(
+	--bundle "${bundle}"
+	--version "${version}"
+	--commit "${commit}"
+	--matrix "${matrix}"
+	--releases-dir "${releases}"
+)
+if [[ "${matrix}" == "linux:amd64" ]]; then
+	args+=(--ubuntu2404-arch amd64)
+fi
+"${ROOT}/tools/agent/publish.sh" "${args[@]}"
+
+mkdir -p "$(dirname "${output}")"
+tar -C "${tmp}" -czf "${output}" payload

--- a/release/ci/build-host-debs-asset.sh
+++ b/release/ci/build-host-debs-asset.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Fetch the pinned Ubuntu 24.04 Docker CE packages and export the canonical tree.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+[[ $# -eq 1 ]] || {
+	printf 'Usage: %s OUTPUT_TAR_GZ\n' "$0" >&2
+	exit 2
+}
+output=$1
+"${ROOT}/tools/dependencies/fetch-docker-ce-debs.sh"
+source_dir="${ROOT}/build/dependencies/docker/ubuntu-24.04/amd64"
+[[ -d "${source_dir}" ]] || { printf 'ERROR: Docker deb output is missing\n' >&2; exit 1; }
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "${tmp}"' EXIT
+mkdir -p "${tmp}/host/debs"
+rsync -a "${source_dir}/" "${tmp}/host/debs/"
+mkdir -p "$(dirname "${output}")"
+tar -C "${tmp}" -czf "${output}" host

--- a/release/ci/build-sourcelens-image.sh
+++ b/release/ci/build-sourcelens-image.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Build one HFL-bundled SourceLens component and push it to the HFL registry namespace.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+# shellcheck source=../../tools/sourcelens/common.sh
+source "${ROOT}/tools/sourcelens/common.sh"
+
+usage() {
+	printf 'Usage: %s COMPONENT REGISTRY HFL_VERSION OUTPUT_JSON\n' "$0" >&2
+}
+
+[[ $# -eq 4 ]] || { usage; exit 2; }
+component=$1
+registry=${2%/}
+hfl_version=${3#v}
+output=$4
+
+case "${component}" in
+backend) service=backend-api ;;
+frontend) service=frontend ;;
+lensnode) service=lensnode ;;
+*) printf 'ERROR: unsupported SourceLens component: %s\n' "${component}" >&2; exit 2 ;;
+esac
+[[ "${registry}" =~ ^[a-z0-9][a-z0-9._-]*$ ]] || {
+	printf 'ERROR: Docker Hub registry namespace is invalid: %s\n' "${registry}" >&2
+	exit 2
+}
+[[ "${hfl_version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+	printf 'ERROR: invalid HFL version: %s\n' "${hfl_version}" >&2
+	exit 2
+}
+
+sourcelens_load_config
+sourcelens_resolve_version
+hfl_logging_configure "ci-sourcelens-${component}"
+hfl_logging_start
+trap 'hfl_logging_finish "$?"' EXIT
+
+sourcelens_sync_source
+SOURCELENS_BUILD_SERVICES="${service}" sourcelens_build_app_images 1 0
+
+local_ref="$(sourcelens_upstream_image_ref "${component}")"
+target_ref="${registry}/hyperfilelens-sourcelens-${component}:${hfl_version}-sl${SOURCELENS_VERSION}"
+docker image inspect "${local_ref}" >/dev/null
+docker tag "${local_ref}" "${target_ref}"
+docker push "${target_ref}"
+
+manifest_json="$(docker buildx imagetools inspect "${target_ref}" --format '{{json .Manifest}}')"
+digest="$(jq -r '.digest // empty' <<<"${manifest_json}")"
+[[ "${digest}" =~ ^sha256:[0-9a-f]{64}$ ]] || {
+	printf 'ERROR: unable to resolve pushed digest for %s\n' "${target_ref}" >&2
+	exit 1
+}
+
+mkdir -p "$(dirname "${output}")"
+jq -n \
+	--arg component "sourcelens-${component}" \
+	--arg ref "${target_ref}" \
+	--arg digest "${digest}" \
+	--arg platform linux/amd64 \
+	--arg sourcelens_version "${SOURCELENS_VERSION}" \
+	--arg sourcelens_git_ref "${SOURCELENS_GIT_REF}" \
+	'{
+	  component: $component,
+	  ref: $ref,
+	  digest: $digest,
+	  platform: $platform,
+	  sourcelens_version: $sourcelens_version,
+	  sourcelens_git_ref: $sourcelens_git_ref
+	}' >"${output}"

--- a/release/ci/export-hfl-images.sh
+++ b/release/ci/export-hfl-images.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Export registry-built HFL backend/frontend images into the offline release archive.
+set -euo pipefail
+
+[[ $# -eq 3 ]] || {
+	printf 'Usage: %s METADATA_DIR VERSION OUTPUT_TAR_GZ\n' "$0" >&2
+	exit 2
+}
+
+metadata_dir=$1
+version=${2#v}
+output=$3
+backend_meta="${metadata_dir}/hfl-backend.json"
+frontend_meta="${metadata_dir}/hfl-frontend.json"
+
+for file in "${backend_meta}" "${frontend_meta}"; do
+	[[ -s "${file}" ]] || { printf 'ERROR: missing metadata: %s\n' "${file}" >&2; exit 1; }
+done
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "${tmp}"' EXIT
+mkdir -p "${tmp}/images" "${tmp}/metadata"
+
+pull_and_tag() {
+	local metadata=$1 local_repo=$2
+	local ref digest
+	ref="$(jq -r '.ref' "${metadata}")"
+	digest="$(jq -r '.digest' "${metadata}")"
+	[[ "${digest}" =~ ^sha256:[0-9a-f]{64}$ ]] || return 2
+	docker pull --platform linux/amd64 "${ref%@*}@${digest}"
+	docker tag "${ref%@*}@${digest}" "${local_repo}:${version}"
+	docker tag "${ref%@*}@${digest}" "${local_repo}:latest"
+}
+
+pull_and_tag "${backend_meta}" hyperfilelens-backend
+pull_and_tag "${frontend_meta}" hyperfilelens-frontend
+docker save \
+	"hyperfilelens-backend:${version}" hyperfilelens-backend:latest \
+	"hyperfilelens-frontend:${version}" hyperfilelens-frontend:latest \
+	| gzip -c >"${tmp}/images/00-hyperfilelens.tar.gz"
+gzip -t "${tmp}/images/00-hyperfilelens.tar.gz"
+cp "${backend_meta}" "${tmp}/metadata/hfl-backend.json"
+cp "${frontend_meta}" "${tmp}/metadata/hfl-frontend.json"
+mkdir -p "$(dirname "${output}")"
+tar -C "${tmp}" -czf "${output}" images metadata

--- a/release/ci/export-runtime-images.sh
+++ b/release/ci/export-runtime-images.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Export third-party runtime images used by every offline HFL installation.
+set -euo pipefail
+
+[[ $# -eq 1 ]] || {
+	printf 'Usage: %s OUTPUT_TAR_GZ\n' "$0" >&2
+	exit 2
+}
+output=$1
+tmp="$(mktemp -d)"
+trap 'rm -rf "${tmp}"' EXIT
+mkdir -p "${tmp}/images" "${tmp}/metadata"
+
+export_one() {
+	local image=$1 archive=$2 key=$3
+	docker pull --platform linux/amd64 "${image}"
+	local digest
+	digest="$(docker image inspect "${image}" --format '{{index .RepoDigests 0}}')"
+	docker save "${image}" | gzip -c >"${tmp}/images/${archive}"
+	gzip -t "${tmp}/images/${archive}"
+	jq -n --arg component "${key}" --arg ref "${image}" --arg digest "${digest}" \
+		'{component: $component, ref: $ref, digest: $digest, platform: "linux/amd64"}' \
+		>"${tmp}/metadata/${key}.json"
+	docker image rm "${image}" >/dev/null 2>&1 || true
+}
+
+export_one postgres:17 01-postgres-17.tar.gz postgres
+export_one redis:alpine 02-redis-alpine.tar.gz redis
+mkdir -p "$(dirname "${output}")"
+tar -C "${tmp}" -czf "${output}" images metadata

--- a/release/ci/export-sourcelens-bundle.sh
+++ b/release/ci/export-sourcelens-bundle.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Convert registry-built HFL SourceLens images into the bundled offline runtime tree.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+[[ $# -eq 3 ]] || {
+	printf 'Usage: %s METADATA_DIR HFL_VERSION OUTPUT_TAR_GZ\n' "$0" >&2
+	exit 2
+}
+metadata_dir=$1
+hfl_version=${2#v}
+output=$3
+
+# shellcheck source=../../tools/sourcelens/common.sh
+source "${ROOT}/tools/sourcelens/common.sh"
+sourcelens_load_config
+sourcelens_resolve_version
+
+pkg_root="${ROOT}/build/release/staging/hyperfilelens-${hfl_version}"
+images_dir="${pkg_root}/images"
+rm -rf "${pkg_root}"
+mkdir -p "${images_dir}"
+
+for component in backend frontend lensnode; do
+	metadata="${metadata_dir}/sourcelens-${component}.json"
+	[[ -s "${metadata}" ]] || { printf 'ERROR: missing metadata: %s\n' "${metadata}" >&2; exit 1; }
+	ref="$(jq -r '.ref' "${metadata}")"
+	digest="$(jq -r '.digest' "${metadata}")"
+	docker pull --platform linux/amd64 "${ref%@*}@${digest}"
+	docker tag "${ref%@*}@${digest}" "sourcelens-${component}:${SOURCELENS_VERSION}"
+	docker tag "${ref%@*}@${digest}" "sourcelens-${component}:latest"
+done
+
+BUILD_SOURCELENS=1 "${ROOT}/release/build-sourcelens.sh" \
+	--pkg-root "${pkg_root}" \
+	--images-dir "${images_dir}" \
+	--prebuilt
+
+# Record the actual HFL registry sources rather than the independent SourceLens
+# repositories. The normalized local refs and runtime image IDs remain intact.
+build_info="${pkg_root}/sourcelens/BUILD_INFO.json"
+tmp_info="${build_info}.tmp"
+jq \
+	--arg backend_ref "$(jq -r '.ref' "${metadata_dir}/sourcelens-backend.json")" \
+	--arg frontend_ref "$(jq -r '.ref' "${metadata_dir}/sourcelens-frontend.json")" \
+	--arg lensnode_ref "$(jq -r '.ref' "${metadata_dir}/sourcelens-lensnode.json")" \
+	'.images.backend.upstream_ref = $backend_ref
+	 | .images.frontend.upstream_ref = $frontend_ref
+	 | .images.lensnode.upstream_ref = $lensnode_ref' \
+	"${build_info}" >"${tmp_info}"
+mv "${tmp_info}" "${build_info}"
+
+mkdir -p "$(dirname "${output}")"
+tar -C "${pkg_root}" -czf "${output}" images sourcelens payload

--- a/release/ci/verify-release.sh
+++ b/release/ci/verify-release.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Validate a final release asset and optionally perform a full ephemeral install.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+install=0
+archive=""
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+	--archive) archive=${2:-}; shift 2 ;;
+	--install) install=1; shift ;;
+	*) printf 'ERROR: unknown argument: %s\n' "$1" >&2; exit 2 ;;
+	esac
+done
+[[ -s "${archive}" ]] || { printf 'ERROR: release archive is missing\n' >&2; exit 2; }
+gzip -t "${archive}"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "${tmp}"' EXIT
+tar -xzf "${archive}" -C "${tmp}"
+pkg_root="$(find "${tmp}" -mindepth 1 -maxdepth 1 -type d -name 'hyperfilelens-*' -print -quit)"
+[[ -n "${pkg_root}" && -s "${pkg_root}/MANIFEST.json" ]] || {
+	printf 'ERROR: invalid release package layout\n' >&2
+	exit 1
+}
+
+python3 - "${pkg_root}" <<'PY'
+import hashlib
+import json
+import pathlib
+import sys
+
+root = pathlib.Path(sys.argv[1])
+manifest = json.loads((root / "MANIFEST.json").read_text(encoding="utf-8"))
+for image in manifest.get("images", []):
+    path = root / image["file"]
+    if not path.is_file():
+        raise SystemExit(f"missing image archive: {image['file']}")
+    checksum = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            checksum.update(chunk)
+    digest = checksum.hexdigest()
+    if digest != image.get("sha256"):
+        raise SystemExit(f"image checksum mismatch: {image['file']}")
+print(f"verified {len(manifest.get('images', []))} image archives")
+PY
+
+while IFS= read -r image_archive; do
+	gzip -t "${image_archive}"
+done < <(find "${pkg_root}/images" -maxdepth 1 -type f -name '*.tar.gz' | sort)
+"${ROOT}/tools/quality/check-release-contracts.sh"
+
+if [[ "${install}" -ne 1 ]]; then
+	printf 'Release structure verification passed: %s\n' "${archive}"
+	exit 0
+fi
+
+available_kib="$(df -Pk / | awk 'NR == 2 {print $4}')"
+((available_kib >= 8 * 1024 * 1024)) || {
+	printf 'ERROR: full install verification requires at least 8 GiB free\n' >&2
+	exit 1
+}
+
+sudo env HFL_PUBLIC_HOST=127.0.0.1 HFL_SHOW_GENERATED_CREDENTIALS=0 \
+	bash "${pkg_root}/install.sh" install
+
+deadline=$((SECONDS + 600))
+while ((SECONDS < deadline)); do
+	if curl -kfsS https://127.0.0.1:10443/health/ready >/dev/null \
+		&& curl -kfsS https://127.0.0.1:10444/ >/dev/null \
+		&& curl -kfsS https://127.0.0.1:10446/ >/dev/null; then
+		break
+	fi
+	sleep 5
+done
+((SECONDS < deadline)) || {
+	docker compose -f /opt/hyperfilelens/docker-compose.yml --env-file /opt/hyperfilelens/.env ps || true
+	printf 'ERROR: release services did not become ready\n' >&2
+	exit 1
+}
+
+export HFL_TENANT_PORT=10443
+export HFL_ADMIN_PORT=10444
+export SOURCELENS_CONSOLE_PORT=10446
+export SEED_ADMIN_EMAIL
+export SEED_ADMIN_PASSWORD
+SEED_ADMIN_EMAIL="$(sed -n 's/^SEED_ADMIN_EMAIL=//p' /opt/hyperfilelens/.env | head -1)"
+SEED_ADMIN_PASSWORD="$(sed -n 's/^SEED_ADMIN_PASSWORD=//p' /opt/hyperfilelens/.env | head -1)"
+export SMOKE_REQUIRE_HMR=0
+export SMOKE_SOURCELENS_ENV_FILE=/opt/hyperfilelens/data/sourcelens/config/.env
+"${ROOT}/tools/dev/browser-smoke.sh"
+printf 'Full release install and login verification passed\n'

--- a/release/ci/write-image-metadata.sh
+++ b/release/ci/write-image-metadata.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Write normalized metadata for one registry image built by GitHub Actions.
+set -euo pipefail
+
+[[ $# -eq 4 ]] || {
+	printf 'Usage: %s COMPONENT IMAGE_REF DIGEST OUTPUT\n' "$0" >&2
+	exit 2
+}
+
+component=$1
+image_ref=$2
+digest=$3
+output=$4
+
+[[ "${component}" =~ ^[a-z0-9][a-z0-9-]*$ ]] || {
+	printf 'ERROR: invalid component: %s\n' "${component}" >&2
+	exit 2
+}
+[[ "${image_ref}" == */*:* ]] || {
+	printf 'ERROR: image ref must include registry namespace and tag: %s\n' "${image_ref}" >&2
+	exit 2
+}
+[[ "${digest}" =~ ^sha256:[0-9a-f]{64}$ ]] || {
+	printf 'ERROR: invalid image digest: %s\n' "${digest}" >&2
+	exit 2
+}
+
+mkdir -p "$(dirname "${output}")"
+jq -n \
+	--arg component "${component}" \
+	--arg ref "${image_ref}" \
+	--arg digest "${digest}" \
+	--arg platform linux/amd64 \
+	'{component: $component, ref: $ref, digest: $digest, platform: $platform}' \
+	>"${output}"

--- a/release/ci/write-sbom.py
+++ b/release/ci/write-sbom.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Create a compact SPDX 2.3 document from an HFL release manifest."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import json
+import pathlib
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--manifest", required=True, type=pathlib.Path)
+    parser.add_argument("--output", required=True, type=pathlib.Path)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    manifest = json.loads(args.manifest.read_text(encoding="utf-8"))
+    version = str(manifest["version"])
+    commit = str(manifest["git_commit"])
+    namespace_seed = hashlib.sha256(
+        f"hyperfilelens:{version}:{commit}".encode()
+    ).hexdigest()
+
+    packages = [
+        {
+            "SPDXID": "SPDXRef-Package-HyperFileLens",
+            "name": "hyperfilelens",
+            "versionInfo": version,
+            "downloadLocation": "NOASSERTION",
+            "filesAnalyzed": False,
+            "licenseConcluded": "NOASSERTION",
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "externalRefs": [
+                {
+                    "referenceCategory": "OTHER",
+                    "referenceType": "vcs",
+                    "referenceLocator": (
+                        "https://github.com/HyperBDR/hyperfilelens@" + commit
+                    ),
+                }
+            ],
+        }
+    ]
+    relationships = []
+    for index, image in enumerate(manifest.get("images", []), start=1):
+        image_id = f"SPDXRef-ContainerImage-{index}"
+        refs = image.get("refs") or []
+        digests = image.get("digests") or []
+        packages.append(
+            {
+                "SPDXID": image_id,
+                "name": refs[0] if refs else str(image.get("file", "image")),
+                "versionInfo": version,
+                "downloadLocation": "NOASSERTION",
+                "filesAnalyzed": False,
+                "licenseConcluded": "NOASSERTION",
+                "licenseDeclared": "NOASSERTION",
+                "copyrightText": "NOASSERTION",
+                "checksums": [
+                    {"algorithm": "SHA256", "checksumValue": image["sha256"]}
+                ],
+                "externalRefs": [
+                    {
+                        "referenceCategory": "PACKAGE-MANAGER",
+                        "referenceType": "purl",
+                        "referenceLocator": f"pkg:docker/{refs[0]}",
+                    }
+                    for _ in refs[:1]
+                ],
+                "comment": "Registry/image digests: " + ", ".join(digests),
+            }
+        )
+        relationships.append(
+            {
+                "spdxElementId": "SPDXRef-Package-HyperFileLens",
+                "relationshipType": "CONTAINS",
+                "relatedSpdxElement": image_id,
+            }
+        )
+
+    document = {
+        "spdxVersion": "SPDX-2.3",
+        "dataLicense": "CC0-1.0",
+        "SPDXID": "SPDXRef-DOCUMENT",
+        "name": f"hyperfilelens-{version}",
+        "documentNamespace": (
+            "https://github.com/HyperBDR/hyperfilelens/releases/"
+            f"spdx/{version}/{namespace_seed}"
+        ),
+        "creationInfo": {
+            "created": dt.datetime.now(dt.timezone.utc)
+            .replace(microsecond=0)
+            .isoformat()
+            .replace("+00:00", "Z"),
+            "creators": ["Tool: HyperFileLens release/ci/write-sbom.py"],
+        },
+        "documentDescribes": ["SPDXRef-Package-HyperFileLens"],
+        "packages": packages,
+        "relationships": relationships,
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(document, indent=2) + "\n", encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/agent/scripts/build.sh
+++ b/src/agent/scripts/build.sh
@@ -2,6 +2,7 @@
 # Compile HyperFileLens Agent source only (Go cross-build).
 # Does not fetch runtime resources, run tests, or assemble distribution archives.
 set -euo pipefail
+umask 022
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 AGENT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"

--- a/src/agent/scripts/fetch-deps.sh
+++ b/src/agent/scripts/fetch-deps.sh
@@ -2,6 +2,7 @@
 # Download external Agent runtime resources only (Kopia CLI and Ubuntu NAS debs).
 # Does not compile source or assemble distribution archives.
 set -euo pipefail
+umask 022
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 AGENT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
@@ -92,11 +93,13 @@ Options:
   --version VERSION                Release version (env: RELEASE_VERSION)
   --matrix MATRIX                  Space-separated os:arch list (env: AGENT_MATRIX)
   --force                          Refresh cached inputs (env: AGENT_FORCE_FETCH=1)
+  --pull                           Refresh the NAS Ubuntu image even when a matching local image exists
   --kopia-version VERSION          Kopia version without v prefix (env: KOPIA_VERSION)
   --github-download-mirror URL     Explicit GitHub download mirror (env: GITHUB_DOWNLOAD_MIRROR)
   --github-token TOKEN             GitHub API token (env: GITHUB_TOKEN; environment recommended)
   --ubuntu2404-arch ARCH           amd64 | arm64 | all (env: AGENT_UBUNTU2404_ARCH)
   --docker-download-mirror URL     Docker Hub mirror (env: DOCKER_DOWNLOAD_MIRROR)
+  --docker-pull-timeout SECONDS    Timeout for each Docker pull attempt (env: DOCKER_PULL_TIMEOUT_SECONDS)
   --apt-mirror URL                 Ubuntu apt mirror (env: APT_MIRROR)
   --log-file FILE                  Append console output to FILE (env: AGENT_LOG_FILE)
   --verbose                        Enable detailed source logging (env: AGENT_VERBOSE=1)
@@ -131,6 +134,7 @@ USAGE
 DO_KOPIA=0
 DO_NAS=0
 FORCE=0
+FORCE_PULL=0
 EXPLICIT=0
 OPT_VERSION=""
 OPT_MATRIX=""
@@ -139,6 +143,7 @@ OPT_UBUNTU2404_ARCH=""
 OPT_GITHUB_DOWNLOAD_MIRROR=""
 OPT_GITHUB_TOKEN=""
 OPT_DOCKER_DOWNLOAD_MIRROR=""
+OPT_DOCKER_PULL_TIMEOUT=""
 OPT_APT_MIRROR=""
 
 while [[ $# -gt 0 ]]; do
@@ -161,6 +166,10 @@ while [[ $# -gt 0 ]]; do
 		;;
 	--force)
 		FORCE=1
+		shift
+		;;
+	--pull)
+		FORCE_PULL=1
 		shift
 		;;
 	--log-file)
@@ -211,6 +220,11 @@ while [[ $# -gt 0 ]]; do
 		OPT_DOCKER_DOWNLOAD_MIRROR="$2"
 		shift 2
 		;;
+	--docker-pull-timeout)
+		require_value "$1" "${2:-}"
+		OPT_DOCKER_PULL_TIMEOUT="$2"
+		shift 2
+		;;
 	--apt-mirror)
 		require_value "$1" "${2:-}"
 		OPT_APT_MIRROR="$2"
@@ -244,6 +258,11 @@ case "${AGENT_FORCE_FETCH:-0}" in
 0 | false | no | "") ;;
 *) printf 'ERROR: AGENT_FORCE_FETCH must be 0 or 1\n' >&2; exit 2 ;;
 esac
+case "${AGENT_FORCE_PULL:-0}" in
+1 | true | yes) FORCE_PULL=1 ;;
+0 | false | no | "") ;;
+*) printf 'ERROR: AGENT_FORCE_PULL must be 0 or 1\n' >&2; exit 2 ;;
+esac
 
 AGENT_VERSION="$(normalize_release_version "${OPT_VERSION:-$(resolve_release_version)}")" || exit $?
 # shellcheck source=../../../tools/dependencies/versions/kopia.env
@@ -259,6 +278,9 @@ GITHUB_DOWNLOAD_MIRROR="${OPT_GITHUB_DOWNLOAD_MIRROR:-${GITHUB_DOWNLOAD_MIRROR:-
 GITHUB_TOKEN="${OPT_GITHUB_TOKEN:-${GITHUB_TOKEN:-}}"
 DOCKER_DOWNLOAD_MIRROR="${OPT_DOCKER_DOWNLOAD_MIRROR:-${DOCKER_DOWNLOAD_MIRROR:-}}"
 APT_MIRROR="${OPT_APT_MIRROR:-${APT_MIRROR:-}}"
+DOCKER_PULL_TIMEOUT_SECONDS="${OPT_DOCKER_PULL_TIMEOUT:-${DOCKER_PULL_TIMEOUT_SECONDS:-180}}"
+[[ "${DOCKER_PULL_TIMEOUT_SECONDS}" =~ ^[1-9][0-9]*$ ]] \
+	|| { printf 'ERROR: DOCKER_PULL_TIMEOUT_SECONDS must be a positive integer\n' >&2; exit 2; }
 OPT_UBUNTU2404_ARCH="${OPT_UBUNTU2404_ARCH:-${AGENT_UBUNTU2404_ARCH:-}}"
 KOPIA_GITHUB_REPO="kopia/kopia"
 
@@ -303,6 +325,8 @@ docker_download_mirror=${DOCKER_DOWNLOAD_MIRROR:-<official>}
 apt_mirror=${APT_MIRROR:-<official>}
 ubuntu2404_arch=${OPT_UBUNTU2404_ARCH:-<from-matrix>}
 force=${FORCE}
+force_pull=${FORCE_PULL}
+docker_pull_timeout_seconds=${DOCKER_PULL_TIMEOUT_SECONDS}
 kopia_output=${WORK_ROOT}
 nas_output=${NAS_DEPS_ROOT}
 CONFIG
@@ -912,29 +936,68 @@ normalize_docker_mirror_host() {
 
 pull_nas_image() {
 	local platform=$1
-	local mirror_host img
+	local mirror_host mirrored official="ubuntu:24.04"
 
 	mirror_host="$(normalize_docker_mirror_host "${DOCKER_DOWNLOAD_MIRROR:-}")"
+	mirrored=""
 	if [[ -n "${mirror_host}" ]]; then
-		img="${mirror_host}/library/ubuntu:24.04"
-		log_step "Pulling ${img} for ${platform}"
-		if docker pull --platform "${platform}" "${img}"; then
-			NAS_IMAGE="${img}"
+		mirrored="${mirror_host}/library/ubuntu:24.04"
+	fi
+
+	if [[ "${FORCE_PULL}" -eq 0 ]]; then
+		if [[ -n "${mirrored}" ]] && nas_image_matches_platform "${mirrored}" "${platform}"; then
+			NAS_IMAGE="${mirrored}"
+			log_skip "Using local ${NAS_IMAGE} for ${platform}"
+			return 0
+		fi
+		if nas_image_matches_platform "${official}" "${platform}"; then
+			NAS_IMAGE="${official}"
+			log_skip "Using local ${NAS_IMAGE} for ${platform}"
+			return 0
+		fi
+	fi
+
+	if [[ -n "${mirrored}" ]]; then
+		log_step "Pulling ${mirrored} for ${platform} (timeout=${DOCKER_PULL_TIMEOUT_SECONDS}s)"
+		if timeout --foreground "${DOCKER_PULL_TIMEOUT_SECONDS}s" \
+			docker pull --platform "${platform}" "${mirrored}"; then
+			NAS_IMAGE="${mirrored}"
 			return 0
 		fi
 		log_warn "Docker mirror pull failed; trying the official registry"
 	fi
 
-	img="ubuntu:24.04"
-	log_step "Pulling ${img} for ${platform}"
-	if docker pull --platform "${platform}" "${img}"; then
-		NAS_IMAGE="${img}"
+	log_step "Pulling ${official} for ${platform} (timeout=${DOCKER_PULL_TIMEOUT_SECONDS}s)"
+	if timeout --foreground "${DOCKER_PULL_TIMEOUT_SECONDS}s" \
+		docker pull --platform "${platform}" "${official}"; then
+		NAS_IMAGE="${official}"
+		return 0
+	fi
+	if nas_image_matches_platform "${official}" "${platform}"; then
+		NAS_IMAGE="${official}"
+		log_warn "Registry refresh failed; using existing local ${NAS_IMAGE}"
+		return 0
+	fi
+	if [[ -n "${mirrored}" ]] && nas_image_matches_platform "${mirrored}" "${platform}"; then
+		NAS_IMAGE="${mirrored}"
+		log_warn "Registry refresh failed; using existing local ${NAS_IMAGE}"
 		return 0
 	fi
 
 	log_warn "Failed to pull ubuntu:24.04 for ${platform}"
 	log_info "Optional mirror example: --docker-download-mirror docker.m.daocloud.io --apt-mirror https://mirrors.tuna.tsinghua.edu.cn"
 	return 1
+}
+
+nas_image_matches_platform() {
+	local image=$1 platform=$2 expected_arch actual
+	case "${platform}" in
+	linux/amd64) expected_arch=amd64 ;;
+	linux/arm64) expected_arch=arm64 ;;
+	*) return 1 ;;
+	esac
+	actual="$(docker image inspect "${image}" --format '{{.Os}}/{{.Architecture}}' 2>/dev/null || true)"
+	[[ "${actual}" == "linux/${expected_arch}" ]]
 }
 
 fetch_nas_deps() {
@@ -967,6 +1030,8 @@ fetch_nas_deps() {
 			log_warn "Docker is required to fetch Ubuntu NAS dependencies for ${arch}"
 			return 2
 		fi
+		command -v timeout >/dev/null 2>&1 \
+			|| { log_warn "timeout is required to pull NAS dependency images"; return 2; }
 
 		if ! pull_nas_image "${platform}"; then
 			return 1

--- a/src/agent/scripts/package.sh
+++ b/src/agent/scripts/package.sh
@@ -2,6 +2,7 @@
 # Assemble customer-facing Agent archives from existing build and dependency inputs.
 # This script does not compile source, download dependencies, or call other scripts.
 set -euo pipefail
+umask 022
 export COPYFILE_DISABLE=1
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -385,6 +386,7 @@ def write_archive(root: Path, output: Path, goos: str) -> None:
             with tarfile.open(temporary, "w:gz") as archive:
                 archive.add(root, arcname=root.name)
         os.replace(temporary, output)
+        output.chmod(0o644)
     finally:
         temporary.unlink(missing_ok=True)
 
@@ -470,7 +472,7 @@ def safe_extract_tar(archive_path: Path, destination: Path) -> Path:
             roots.add(parts[0])
         if len(roots) != 1:
             raise PrerequisiteError(f"base archive must contain one root directory: {archive_path}")
-        archive.extractall(destination)
+        archive.extractall(destination, filter="data")
     return destination / next(iter(roots))
 
 

--- a/src/backend/apps/iam/auth/views/login.py
+++ b/src/backend/apps/iam/auth/views/login.py
@@ -20,6 +20,8 @@ from rest_framework_simplejwt.tokens import RefreshToken
 
 from common.http.public_api import AnonymousPublicViewMixin
 
+from apps.iam.auth.authentication import OptionalJWTAuthenticationFromCookies
+from apps.iam.auth.serializers import UserDetailsSerializer
 from apps.iam.profile_models import Profile
 from apps.iam.services.human_verification import (
     credentials_and_human_verification_present,
@@ -440,6 +442,48 @@ class TokenRefreshView(APIView):
 
     permission_classes = [AllowAny]
     authentication_classes = []
+
+    @extend_schema(
+        tags=["auth"],
+        summary="Inspect the cookie session without producing an authentication error",
+        responses={200: OpenApiTypes.OBJECT},
+    )
+    def get(self, request):
+        """Return session availability with HTTP 200 for signed-out clients."""
+        cookie_settings = getattr(settings, "COOKIE_AUTH", {})
+        refresh_cookie_name = cookie_settings.get(
+            "REFRESH_TOKEN_COOKIE_NAME",
+            "refresh_token",
+        )
+        result = OptionalJWTAuthenticationFromCookies().authenticate(request)
+        if result is None:
+            response = Response(
+                {
+                    "authenticated": False,
+                    "refresh_available": bool(
+                        request.COOKIES.get(refresh_cookie_name),
+                    ),
+                    "user": None,
+                },
+                status=status.HTTP_200_OK,
+            )
+            response["Cache-Control"] = "no-store"
+            return response
+
+        user, _validated_token = result
+        serializer = UserDetailsSerializer(user, context={"request": request})
+        response = Response(
+            {
+                "authenticated": True,
+                "refresh_available": bool(
+                    request.COOKIES.get(refresh_cookie_name),
+                ),
+                "user": serializer.data,
+            },
+            status=status.HTTP_200_OK,
+        )
+        response["Cache-Control"] = "no-store"
+        return response
 
     @extend_schema(
         tags=["auth"],

--- a/src/backend/apps/iam/tests/test_token_refresh.py
+++ b/src/backend/apps/iam/tests/test_token_refresh.py
@@ -101,6 +101,41 @@ class TokenRefreshTests(TestCase):
         self.assertIn(b"AUTH_401_UNAUTHORIZED", response.content)
         self.assertNotIn(b"REFRESH_EXPIRED", response.content)
 
+    def test_session_probe_reports_signed_out_without_unauthorized_status(self):
+        response = self.client.get("/api/v1/auth/token/refresh")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+        self.assertFalse(response.data["authenticated"])
+        self.assertFalse(response.data["refresh_available"])
+        self.assertIsNone(response.data["user"])
+        self.assertEqual(response["Cache-Control"], "no-store")
+
+    def test_session_probe_returns_user_for_valid_access_cookie(self):
+        access, refresh = self._token_pair()
+        self.client.cookies["access_token"] = access
+        self.client.cookies["refresh_token"] = refresh
+
+        response = self.client.get("/api/v1/auth/token/refresh")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+        self.assertTrue(response.data["authenticated"])
+        self.assertTrue(response.data["refresh_available"])
+        self.assertEqual(response.data["user"]["id"], self.user.id)
+        self.assertEqual(response["Cache-Control"], "no-store")
+
+    def test_session_probe_marks_expired_access_as_refreshable(self):
+        refresh = self._refresh_token()
+        expired_access = AccessToken.for_user(self.user)
+        expired_access.set_exp(lifetime=-timedelta(seconds=1))
+        self.client.cookies["access_token"] = str(expired_access)
+        self.client.cookies["refresh_token"] = refresh
+
+        response = self.client.get("/api/v1/auth/token/refresh")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+        self.assertFalse(response.data["authenticated"])
+        self.assertTrue(response.data["refresh_available"])
+
     def test_reusing_rotated_refresh_token_is_rejected(self):
         original_refresh = self._refresh_token()
         self.client.cookies["refresh_token"] = original_refresh

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -8,6 +8,7 @@
     "build": "vue-tsc --noEmit && vite build",
     "lint": "eslint .",
     "test": "vitest run",
+    "test:ci": "vitest run --testTimeout=15000",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/src/frontend/src/composables/useAuth.ts
+++ b/src/frontend/src/composables/useAuth.ts
@@ -96,6 +96,7 @@ type CurrentUserFetchResult = {
   status?: number
   errorCode?: string
   refreshFailed?: boolean
+  refreshAvailable?: boolean
 }
 
 function extractSessionErrorCode(data: unknown): string | undefined {
@@ -129,8 +130,8 @@ async function readResponseJson(res: Response): Promise<unknown> {
   }
 }
 
-async function fetchCurrentUserOnce(): Promise<CurrentUserFetchResult> {
-  const res = await fetch('/api/v1/auth/user', {
+async function inspectCurrentSession(): Promise<CurrentUserFetchResult> {
+  const res = await fetch('/api/v1/auth/token/refresh', {
     credentials: 'include',
     headers: getCorrelationHeaders(),
   })
@@ -144,21 +145,31 @@ async function fetchCurrentUserOnce(): Promise<CurrentUserFetchResult> {
     }
   }
 
-  const payload = parseUserPayload(data)
+  const body = data && typeof data === 'object'
+    ? data as Record<string, unknown>
+    : {}
+  const session = body.data && typeof body.data === 'object'
+    ? body.data as Record<string, unknown>
+    : body
+  const payload = parseUserPayload(session.user)
   if (payload?.id) {
     setUser(payload)
-    return { user: payload, status: res.status }
+    return {
+      user: payload,
+      status: res.status,
+      refreshAvailable: session.refresh_available === true,
+    }
   }
-  return { user: null, status: res.status }
+  return {
+    user: null,
+    status: res.status,
+    refreshAvailable: session.refresh_available === true,
+  }
 }
 
 async function fetchCurrentUserWithRefresh(): Promise<CurrentUserFetchResult> {
-  const first = await fetchCurrentUserOnce()
-  if (first.user || first.status !== 401) return first
-
-  if (first.errorCode && SESSION_INVALID_CODES.includes(first.errorCode)) {
-    return first
-  }
+  const first = await inspectCurrentSession()
+  if (first.user || !first.refreshAvailable) return first
 
   const refreshed = await refreshAuthToken()
   if (!refreshed.ok) {
@@ -169,7 +180,7 @@ async function fetchCurrentUserWithRefresh(): Promise<CurrentUserFetchResult> {
     }
   }
 
-  return fetchCurrentUserOnce()
+  return inspectCurrentSession()
 }
 
 /** Load the signed-in user and sync org context from the backend access profile. */

--- a/src/frontend/vite.config.ts
+++ b/src/frontend/vite.config.ts
@@ -26,6 +26,9 @@ export default defineConfig(() => ({
     host: '0.0.0.0',
     port: 5173,
     strictPort: true,
+    hmr: {
+      path: '/__vite_hmr',
+    },
     proxy: {
       '/api': {
         target: devApiTarget,

--- a/tools/agent/publish.sh
+++ b/tools/agent/publish.sh
@@ -11,6 +11,7 @@
 #   ./tools/agent/publish.sh --version 0.1.0
 #
 set -euo pipefail
+umask 022
 
 DEFAULT_MATRIX="linux:amd64 linux:arm64 darwin:amd64 darwin:arm64 windows:amd64"
 
@@ -32,6 +33,7 @@ Options:
   --ubuntu2404-arch ARCH           NAS deb arch when --bundle is all or ubuntu2404: amd64 | arm64 | all
                                    (env: AGENT_UBUNTU2404_ARCH; default: amd64)
   --force-fetch                    Re-download fetch-deps.sh inputs (--force)
+  --pull                           Refresh the NAS Ubuntu image instead of using a matching local image
   --releases-dir DIR               Publish target (default: data/media/agent-releases; env: AGENT_RELEASES_DIR)
 
 Build (passed to build.sh):
@@ -43,6 +45,7 @@ Fetch (passed to fetch-deps.sh):
   --github-download-mirror URL     GitHub download mirror (env: GITHUB_DOWNLOAD_MIRROR)
   --github-token TOKEN             GitHub API token (env: GITHUB_TOKEN)
   --docker-download-mirror URL     Docker Hub mirror for NAS ubuntu:24.04 (env: DOCKER_DOWNLOAD_MIRROR)
+  --docker-pull-timeout SECONDS    Timeout for each Docker pull attempt (env: DOCKER_PULL_TIMEOUT_SECONDS)
   --apt-mirror URL                 Ubuntu apt mirror for NAS container (env: APT_MIRROR)
 
 Output:
@@ -79,6 +82,7 @@ BUILD_DIR="${ROOT}/build/agent"
 DEFAULT_RELEASES_DIR="${ROOT}/data/media/agent-releases"
 BUNDLE="${AGENT_BUNDLE:-all}"
 FORCE_FETCH=0
+FORCE_PULL=0
 UBUNTU2404_ARCH="${AGENT_UBUNTU2404_ARCH:-amd64}"
 MATRIX="${AGENT_MATRIX:-${DEFAULT_MATRIX}}"
 OPT_VERSION=""
@@ -91,6 +95,7 @@ OPT_GO_SUMDB=""
 OPT_GITHUB_DOWNLOAD_MIRROR=""
 OPT_GITHUB_TOKEN=""
 OPT_DOCKER_DOWNLOAD_MIRROR=""
+OPT_DOCKER_PULL_TIMEOUT=""
 OPT_APT_MIRROR=""
 OPT_KOPIA_VERSION=""
 LOG_FILE="${HFL_LOG_FILE:-}"
@@ -111,6 +116,10 @@ while [[ $# -gt 0 ]]; do
 		;;
 	--force-fetch | --refresh-kopia-cache)
 		FORCE_FETCH=1
+		shift
+		;;
+	--pull)
+		FORCE_PULL=1
 		shift
 		;;
 	--matrix)
@@ -161,6 +170,11 @@ while [[ $# -gt 0 ]]; do
 	--docker-download-mirror)
 		require_value "$1" "${2:-}"
 		OPT_DOCKER_DOWNLOAD_MIRROR="$2"
+		shift 2
+		;;
+	--docker-pull-timeout)
+		require_value "$1" "${2:-}"
+		OPT_DOCKER_PULL_TIMEOUT="$2"
 		shift 2
 		;;
 	--apt-mirror)
@@ -222,6 +236,9 @@ esac
 GITHUB_DOWNLOAD_MIRROR="${OPT_GITHUB_DOWNLOAD_MIRROR:-${GITHUB_DOWNLOAD_MIRROR:-}}"
 GITHUB_TOKEN="${OPT_GITHUB_TOKEN:-${GITHUB_TOKEN:-}}"
 DOCKER_DOWNLOAD_MIRROR="${OPT_DOCKER_DOWNLOAD_MIRROR:-${DOCKER_DOWNLOAD_MIRROR:-}}"
+DOCKER_PULL_TIMEOUT_SECONDS="${OPT_DOCKER_PULL_TIMEOUT:-${DOCKER_PULL_TIMEOUT_SECONDS:-180}}"
+[[ "${DOCKER_PULL_TIMEOUT_SECONDS}" =~ ^[1-9][0-9]*$ ]] \
+	|| hfl_die "DOCKER_PULL_TIMEOUT_SECONDS must be a positive integer" 2
 APT_MIRROR="${OPT_APT_MIRROR:-${APT_MIRROR:-}}"
 # shellcheck source=../dependencies/versions/kopia.env
 source "${ROOT}/tools/dependencies/versions/kopia.env"
@@ -264,12 +281,14 @@ ubuntu2404_arch=${UBUNTU2404_ARCH}
 build_dir=${BUILD_DIR}/${VERSION}
 releases_dir=${RELEASES_DIR}
 force_fetch=${FORCE_FETCH}
+force_pull=${FORCE_PULL}
 kopia_version=${KOPIA_VERSION}
 go_proxy=${GO_PROXY:-<official>}
 go_sumdb=${GO_SUMDB:-<official>}
 github_download_mirror=${GITHUB_DOWNLOAD_MIRROR:-<official>}
 github_token=$(hfl_redact "${GITHUB_TOKEN}")
 docker_download_mirror=${DOCKER_DOWNLOAD_MIRROR:-<official>}
+docker_pull_timeout_seconds=${DOCKER_PULL_TIMEOUT_SECONDS}
 apt_mirror=${APT_MIRROR:-<official>}
 log_file=${LOG_FILE:-<none>}
 verbose=${VERBOSE}
@@ -360,6 +379,9 @@ fetch_common_args+=(--kopia-version "${KOPIA_VERSION}")
 if [[ "${FORCE_FETCH}" -eq 1 ]]; then
 	fetch_common_args+=(--force)
 fi
+if [[ "${FORCE_PULL}" -eq 1 ]]; then
+	fetch_common_args+=(--pull)
+fi
 if [[ -n "${GITHUB_DOWNLOAD_MIRROR}" ]]; then
 	fetch_common_args+=(--github-download-mirror "${GITHUB_DOWNLOAD_MIRROR}")
 fi
@@ -369,6 +391,7 @@ fi
 if [[ -n "${DOCKER_DOWNLOAD_MIRROR}" ]]; then
 	fetch_common_args+=(--docker-download-mirror "${DOCKER_DOWNLOAD_MIRROR}")
 fi
+fetch_common_args+=(--docker-pull-timeout "${DOCKER_PULL_TIMEOUT_SECONDS}")
 if [[ -n "${APT_MIRROR}" ]]; then
 	fetch_common_args+=(--apt-mirror "${APT_MIRROR}")
 fi
@@ -386,6 +409,7 @@ publish_archives() {
 			ubuntu2404_archive_matches "${base}" || continue
 			dest="${RELEASES_DIR}/${VERSION}/${base}"
 			cp -f "${archive}" "${dest}"
+			chmod 644 "${dest}"
 			hfl_log_ok "Published ${base}"
 			published=$((published + 1))
 		done
@@ -400,6 +424,7 @@ publish_archives() {
 			fi
 			dest="${RELEASES_DIR}/${VERSION}/$(basename "${archive}")"
 			cp -f "${archive}" "${dest}"
+			chmod 644 "${dest}"
 			hfl_log_ok "Published $(basename "${dest}")"
 			published=$((published + 1))
 		done
@@ -413,6 +438,7 @@ publish_archives() {
 			fi
 			dest="${RELEASES_DIR}/${VERSION}/$(basename "${archive}")"
 			cp -f "${archive}" "${dest}"
+			chmod 644 "${dest}"
 			hfl_log_ok "Published $(basename "${dest}")"
 			published=$((published + 1))
 
@@ -421,6 +447,7 @@ publish_archives() {
 				if [[ -f "${archive}" ]]; then
 					dest="${RELEASES_DIR}/${VERSION}/$(basename "${archive}")"
 					cp -f "${archive}" "${dest}"
+					chmod 644 "${dest}"
 					hfl_log_ok "Published $(basename "${dest}")"
 					published=$((published + 1))
 				fi
@@ -438,6 +465,8 @@ publish_archives() {
 		cp -f "${BOOTSTRAP_DIR}/${name}" "${dest}"
 		if [[ "${name}" == *.sh ]]; then
 			chmod 755 "${dest}"
+		else
+			chmod 644 "${dest}"
 		fi
 		hfl_log_ok "Published ${name}"
 	done
@@ -489,6 +518,7 @@ publish_archives() {
 	done
 	if [[ -n "${host_debs_dir}" ]]; then
 		tar -czf "${GATEWAY_BOOTSTRAP_DIR}/${GATEWAY_DOCKER_DEBS_ARCHIVE}" -C "${host_debs_dir}" .
+		chmod 644 "${GATEWAY_BOOTSTRAP_DIR}/${GATEWAY_DOCKER_DEBS_ARCHIVE}"
 		hfl_log_ok "Published ${GATEWAY_DOCKER_DEBS_ARCHIVE}"
 	else
 		hfl_log_skip "${GATEWAY_DOCKER_DEBS_ARCHIVE}: host debs not found; run release/build.sh or tools/dependencies/fetch-docker-ce-debs.sh"

--- a/tools/dependencies/fetch-docker-ce-debs.sh
+++ b/tools/dependencies/fetch-docker-ce-debs.sh
@@ -7,6 +7,7 @@
 #   ./tools/dependencies/fetch-docker-ce-debs.sh --apt-mirror URL --docker-apt-mirror URL
 #
 set -euo pipefail
+umask 022
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"

--- a/tools/dependencies/fetch-kopia-deb.sh
+++ b/tools/dependencies/fetch-kopia-deb.sh
@@ -8,6 +8,7 @@
 #   ./tools/dependencies/fetch-kopia-deb.sh --kopia-version 0.23.0 --github-download-mirror https://ghfast.top
 #
 set -euo pipefail
+umask 022
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"

--- a/tools/dev/browser-smoke.mjs
+++ b/tools/dev/browser-smoke.mjs
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+/** Browser smoke coverage for the three development-stack login surfaces. */
+
+import { createRequire } from 'node:module'
+
+const require = createRequire('/smoke/package.json')
+const { chromium } = require('playwright')
+
+const tenantPort = process.env.HFL_TENANT_PORT || '10443'
+const adminPort = process.env.HFL_ADMIN_PORT || '10444'
+const sourceLensPort = process.env.SOURCELENS_CONSOLE_PORT || '10446'
+const hflEmail = process.env.SEED_ADMIN_EMAIL || 'admin@hyperfilelens.com'
+const hflPassword = process.env.SEED_ADMIN_PASSWORD || 'Admin@123'
+const sourceLensUser = process.env.SOURCELENS_USER || 'admin'
+const sourceLensPassword = process.env.SOURCELENS_PASSWORD || 'adminpassword'
+const requireHmr = process.env.SMOKE_REQUIRE_HMR !== '0'
+
+function fail(message) {
+  throw new Error(message)
+}
+
+async function waitForHflLogin(page, baseUrl, expectedPathPrefix) {
+  const unauthorized = []
+  const webSockets = []
+  page.on('response', response => {
+    if (response.status() === 401) unauthorized.push(response.url())
+  })
+  page.on('websocket', socket => webSockets.push(socket.url()))
+
+  await page.goto(`${baseUrl}/`, { waitUntil: 'networkidle' })
+  await page.waitForURL(url => url.pathname.startsWith('/login'), { timeout: 30_000 })
+  if (unauthorized.length) {
+    fail(`pre-auth 401 response(s) at ${baseUrl}: ${unauthorized.join(', ')}`)
+  }
+
+  await page.locator('input[autocomplete="email"]').fill(hflEmail)
+  await page.locator('input[autocomplete="current-password"]').fill(hflPassword)
+  const captchaImage = page.locator('.auth-captcha-field__image')
+  if (await captchaImage.isVisible()) {
+    const source = await captchaImage.getAttribute('src')
+    if (!source?.startsWith('data:image/svg+xml;base64,')) {
+      fail(`unexpected captcha image format at ${baseUrl}`)
+    }
+    const svg = Buffer.from(source.split(',', 2)[1], 'base64').toString('utf8')
+    const captcha = [...svg.matchAll(/<text[^>]*>([^<])<\/text>/g)]
+      .map(match => match[1])
+      .join('')
+    if (captcha.length !== 4) {
+      fail(`unable to read the development SVG captcha at ${baseUrl}`)
+    }
+    await page.locator('.auth-captcha-field__input input').fill(captcha)
+  }
+  await page.locator('button.submit-btn').click()
+  await page.waitForURL(url => !url.pathname.startsWith('/login'), { timeout: 60_000 })
+  if (!page.url().includes(expectedPathPrefix)) {
+    fail(`unexpected post-login URL at ${baseUrl}: ${page.url()}`)
+  }
+  await page.waitForTimeout(1_000)
+  if (requireHmr && !webSockets.some(url => url.includes('/__vite_hmr'))) {
+    fail(`dedicated Vite HMR WebSocket was not observed at ${baseUrl}`)
+  }
+}
+
+async function waitForSourceLensLogin(page, baseUrl) {
+  await page.goto(`${baseUrl}/login`, { waitUntil: 'networkidle' })
+  const username = page.locator(
+    'input[name="username"], input[autocomplete="username"], input[type="text"]',
+  ).first()
+  if (!(await username.isVisible())) {
+    const switchButton = page.locator('button.block.w-full.text-center')
+    await switchButton.click()
+  }
+  try {
+    await username.waitFor({ state: 'visible', timeout: 10_000 })
+  } catch {
+    const buttons = await page.locator('button').allTextContents()
+    const body = (await page.locator('body').innerText()).slice(0, 1_500)
+    fail(
+      `SourceLens password form did not appear at ${page.url()}; `
+      + `buttons=${JSON.stringify(buttons)} body=${JSON.stringify(body)}`,
+    )
+  }
+  await username.fill(sourceLensUser)
+  await page.locator(
+    'input[name="password"], input[autocomplete="current-password"], input[type="password"]',
+  ).first().fill(sourceLensPassword)
+  await page.locator('form button[type="submit"]').click()
+  await page.waitForURL(url => !url.pathname.startsWith('/login'), { timeout: 60_000 })
+}
+
+async function run() {
+  const browser = await chromium.launch({ headless: true })
+  try {
+    const tenant = await browser.newContext({ ignoreHTTPSErrors: true })
+    await waitForHflLogin(
+      await tenant.newPage(),
+      `https://127.0.0.1:${tenantPort}`,
+      '/',
+    )
+    await tenant.close()
+
+    const admin = await browser.newContext({ ignoreHTTPSErrors: true })
+    await waitForHflLogin(
+      await admin.newPage(),
+      `https://127.0.0.1:${adminPort}`,
+      '/platform-ops',
+    )
+    await admin.close()
+
+    const sourceLens = await browser.newContext({ ignoreHTTPSErrors: true })
+    await waitForSourceLensLogin(
+      await sourceLens.newPage(),
+      `https://127.0.0.1:${sourceLensPort}`,
+    )
+    await sourceLens.close()
+  } finally {
+    await browser.close()
+  }
+  process.stdout.write(
+    `browser smoke: tenant, Platform Ops, SourceLens${requireHmr ? ', and HMR' : ''} passed\n`,
+  )
+}
+
+await run()

--- a/tools/dev/browser-smoke.sh
+++ b/tools/dev/browser-smoke.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Run a pinned Playwright package against the local development stack.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+# shellcheck source=../lib/env-file.sh
+source "${ROOT}/tools/lib/env-file.sh"
+# shellcheck source=../lib/docker-images.sh
+source "${ROOT}/tools/lib/docker-images.sh"
+
+hfl_env_select_repo_file "${ROOT}"
+read_default() {
+	local key=$1 fallback=$2 value
+	if [[ -n "${!key:-}" ]]; then
+		printf '%s' "${!key}"
+		return 0
+	fi
+	value="$(hfl_env_read "${key}")"
+	printf '%s' "${value:-${fallback}}"
+}
+
+read_file_default() {
+	local env_file=$1 key=$2 fallback=$3 previous="${HFL_ENV_FILE}" value
+	HFL_ENV_FILE="${env_file}"
+	value="$(hfl_env_read "${key}")"
+	HFL_ENV_FILE="${previous}"
+	printf '%s' "${value:-${fallback}}"
+}
+
+version="$(read_default DEV_SMOKE_PLAYWRIGHT_VERSION 1.55.0)"
+[[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] \
+	|| { printf 'ERROR: invalid DEV_SMOKE_PLAYWRIGHT_VERSION=%s\n' "${version}" >&2; exit 2; }
+image="mcr.microsoft.com/playwright:v${version}-noble"
+offline="$(read_default DEV_OFFLINE 0)"
+timeout_seconds="$(read_default DEV_SMOKE_PULL_TIMEOUT_SECONDS 900)"
+retries="$(read_default DOCKER_PULL_RETRIES 2)"
+
+if ! hfl_docker_ensure_image "${image}" "" 0 "${offline}" "linux/amd64" \
+	"${timeout_seconds}" "${retries}"; then
+	printf 'ERROR: unable to prepare Playwright image: %s\n' "${HFL_DOCKER_LAST_ERROR}" >&2
+	exit 1
+fi
+
+cache_dir="${ROOT}/build/cache/playwright-node-${version}"
+mkdir -p "${cache_dir}"
+source_lens_env="${SMOKE_SOURCELENS_ENV_FILE:-${ROOT}/data/sourcelens/config/.env}"
+
+docker run --rm --network host \
+	-v "${ROOT}:/workspace:ro" \
+	-v "${cache_dir}:/smoke" \
+	-e PLAYWRIGHT_VERSION="${version}" \
+	-e DEV_OFFLINE="${offline}" \
+	-e HFL_TENANT_PORT="$(read_default HFL_TENANT_PORT 10443)" \
+	-e HFL_ADMIN_PORT="$(read_default HFL_ADMIN_PORT 10444)" \
+	-e SOURCELENS_CONSOLE_PORT="$(read_default SOURCELENS_CONSOLE_PORT 10446)" \
+	-e SEED_ADMIN_EMAIL="$(read_default SEED_ADMIN_EMAIL admin@hyperfilelens.com)" \
+	-e SEED_ADMIN_PASSWORD="$(read_default SEED_ADMIN_PASSWORD 'Admin@123')" \
+	-e SOURCELENS_USER="$(read_file_default "${source_lens_env}" DJANGO_SUPERUSER_USERNAME admin)" \
+	-e SOURCELENS_PASSWORD="$(read_file_default "${source_lens_env}" DJANGO_SUPERUSER_PASSWORD adminpassword)" \
+	-e SMOKE_REQUIRE_HMR="${SMOKE_REQUIRE_HMR:-1}" \
+	"${image}" bash -euc '
+		cd /smoke
+		if [[ ! -f package.json ]]; then
+			printf "%s\n" "{\"private\":true}" > package.json
+		fi
+		if [[ ! -f node_modules/playwright/package.json ]] \
+			|| [[ "$(node -p "require(\"./node_modules/playwright/package.json\").version")" != "${PLAYWRIGHT_VERSION}" ]]; then
+			if [[ "${DEV_OFFLINE}" == "1" ]]; then
+				printf "%s\n" "ERROR: Playwright package cache is missing in offline mode" >&2
+				exit 1
+			fi
+			npm install --no-audit --no-fund --no-package-lock --no-save "playwright@${PLAYWRIGHT_VERSION}"
+		fi
+		node /workspace/tools/dev/browser-smoke.mjs
+	'

--- a/tools/dev/cache_state.py
+++ b/tools/dev/cache_state.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Content fingerprints and atomic state storage for development workflows."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import tempfile
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Iterable
+
+
+IGNORED_NAMES = {".DS_Store", ".git", "__pycache__"}
+
+
+def iter_input_paths(root: Path, inputs: Iterable[str]) -> Iterable[Path]:
+    """Yield deterministic files and symlinks for the requested repository paths."""
+    for raw_path in sorted(set(inputs)):
+        path = (root / raw_path).resolve(strict=False)
+        try:
+            path.relative_to(root)
+        except ValueError as exc:
+            raise ValueError(f"input path escapes repository root: {raw_path}") from exc
+        if not path.exists() and not path.is_symlink():
+            yield path
+            continue
+        if path.is_file() or path.is_symlink():
+            yield path
+            continue
+        for current_root, directory_names, file_names in os.walk(path):
+            directory_names[:] = sorted(
+                name for name in directory_names if name not in IGNORED_NAMES
+            )
+            for file_name in sorted(file_names):
+                if file_name in IGNORED_NAMES or file_name.endswith((".pyc", ".pyo")):
+                    continue
+                yield Path(current_root) / file_name
+
+
+def content_fingerprint(root: Path, paths: list[str], values: list[str]) -> str:
+    """Return a stable SHA-256 over file paths, modes, contents, and explicit values."""
+    digest = hashlib.sha256()
+    for value in sorted(values):
+        digest.update(b"value\0")
+        digest.update(value.encode("utf-8"))
+        digest.update(b"\0")
+    for path in iter_input_paths(root, paths):
+        relative = path.relative_to(root).as_posix()
+        digest.update(b"path\0")
+        digest.update(relative.encode("utf-8"))
+        digest.update(b"\0")
+        if not path.exists() and not path.is_symlink():
+            digest.update(b"missing\0")
+            continue
+        stat_result = path.lstat()
+        digest.update(f"{stat_result.st_mode & 0o7777:o}".encode("ascii"))
+        digest.update(b"\0")
+        if path.is_symlink():
+            digest.update(b"symlink\0")
+            digest.update(os.readlink(path).encode("utf-8"))
+        else:
+            digest.update(b"file\0")
+            with path.open("rb") as source:
+                for chunk in iter(lambda: source.read(1024 * 1024), b""):
+                    digest.update(chunk)
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def read_state(path: Path) -> dict[str, Any]:
+    """Read a state document, treating a missing file as an empty state."""
+    if not path.exists():
+        return {"schema": 1, "components": {}}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"invalid cache state {path}: {exc}") from exc
+    if data.get("schema") != 1 or not isinstance(data.get("components"), dict):
+        raise ValueError(f"unsupported cache state schema in {path}")
+    return data
+
+
+def update_state(path: Path, key: str, fingerprint: str) -> None:
+    """Atomically store a component fingerprint."""
+    state = read_state(path)
+    state["components"][key] = {
+        "fingerprint": fingerprint,
+        "updated_at": datetime.now(UTC).isoformat(),
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}.", suffix=".tmp", dir=path.parent
+    )
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as destination:
+            json.dump(state, destination, indent=2, sort_keys=True)
+            destination.write("\n")
+        temporary.replace(path)
+    except Exception:
+        temporary.unlink(missing_ok=True)
+        raise
+
+
+def state_matches(path: Path, key: str, fingerprint: str) -> bool:
+    """Return whether a stored component fingerprint matches."""
+    try:
+        state = read_state(path)
+    except ValueError:
+        return False
+    component = state["components"].get(key)
+    return isinstance(component, dict) and component.get("fingerprint") == fingerprint
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    fingerprint_parser = subparsers.add_parser("fingerprint")
+    fingerprint_parser.add_argument("--root", type=Path, required=True)
+    fingerprint_parser.add_argument("--path", action="append", default=[])
+    fingerprint_parser.add_argument("--value", action="append", default=[])
+
+    check_parser = subparsers.add_parser("check")
+    check_parser.add_argument("--state", type=Path, required=True)
+    check_parser.add_argument("--key", required=True)
+    check_parser.add_argument("--fingerprint", required=True)
+
+    update_parser = subparsers.add_parser("update")
+    update_parser.add_argument("--state", type=Path, required=True)
+    update_parser.add_argument("--key", required=True)
+    update_parser.add_argument("--fingerprint", required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Run the selected cache-state operation."""
+    args = parse_args()
+    if args.command == "fingerprint":
+        root = args.root.resolve()
+        print(content_fingerprint(root, args.path, args.value))
+        return 0
+    if args.command == "check":
+        return 0 if state_matches(args.state, args.key, args.fingerprint) else 1
+    if args.command == "update":
+        update_state(args.state, args.key, args.fingerprint)
+        return 0
+    raise AssertionError(f"unhandled command: {args.command}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/lib/docker-images.sh
+++ b/tools/lib/docker-images.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# Shared Docker image resolution with local reuse, mirror fallback, retries, and timeouts.
+
+if [[ "${_hfl_docker_images_loaded:-0}" == "1" ]]; then
+	return 0 2>/dev/null || exit 0
+fi
+_hfl_docker_images_loaded=1
+
+HFL_DOCKER_IMAGE_SOURCE=""
+HFL_DOCKER_LAST_ERROR=""
+
+hfl_docker_normalize_mirror_host() {
+	local mirror="${1:-}"
+	mirror="${mirror#https://}"
+	mirror="${mirror#http://}"
+	mirror="${mirror%/}"
+	printf '%s' "${mirror}"
+}
+
+hfl_docker_mirror_image_ref() {
+	local image=$1 mirror_host=$2
+	if [[ -z "${mirror_host}" ]]; then
+		printf '%s' "${image}"
+	elif [[ "${image}" == */* ]]; then
+		printf '%s/%s' "${mirror_host}" "${image}"
+	else
+		printf '%s/library/%s' "${mirror_host}" "${image}"
+	fi
+}
+
+hfl_docker_validate_pull_settings() {
+	local timeout_seconds=${1:-180} retries=${2:-2}
+	[[ "${timeout_seconds}" =~ ^[1-9][0-9]*$ ]] || return 1
+	[[ "${retries}" =~ ^[1-9][0-9]*$ ]] || return 1
+	command -v timeout >/dev/null 2>&1 || return 1
+}
+
+hfl_docker_image_matches_platform() {
+	local image=$1 platform="${2:-}" actual expected
+	actual="$(docker image inspect "${image}" --format '{{.Os}}/{{.Architecture}}' 2>/dev/null || true)"
+	[[ -n "${actual}" ]] || return 1
+	[[ -z "${platform}" ]] && return 0
+	case "${platform}" in
+	*/*/*) expected="${platform%/*}" ;;
+	*) expected="${platform}" ;;
+	esac
+	[[ "${actual}" == "${expected}" ]]
+}
+
+hfl_docker_pull_with_retry() {
+	local image=$1 platform="${2:-}" timeout_seconds=${3:-180} retries=${4:-2}
+	local attempt
+	hfl_docker_validate_pull_settings "${timeout_seconds}" "${retries}" || {
+		HFL_DOCKER_LAST_ERROR="invalid pull timeout/retry settings or timeout command unavailable"
+		return 2
+	}
+	for attempt in $(seq 1 "${retries}"); do
+		local -a args=(docker pull)
+		[[ -n "${platform}" ]] && args+=(--platform "${platform}")
+		args+=("${image}")
+		if timeout --foreground "${timeout_seconds}s" "${args[@]}"; then
+			return 0
+		fi
+		HFL_DOCKER_LAST_ERROR="pull ${image} failed (attempt ${attempt}/${retries})"
+	done
+	return 1
+}
+
+hfl_docker_ensure_image() {
+	local image=$1 mirror="${2:-}" force_pull=${3:-0} offline=${4:-0}
+	local platform="${5:-}" timeout_seconds=${6:-180} retries=${7:-2}
+	local mirror_host mirrored=""
+	HFL_DOCKER_IMAGE_SOURCE=""
+	HFL_DOCKER_LAST_ERROR=""
+
+	mirror_host="$(hfl_docker_normalize_mirror_host "${mirror}")"
+	[[ -z "${mirror_host}" ]] || mirrored="$(hfl_docker_mirror_image_ref "${image}" "${mirror_host}")"
+
+	if [[ "${force_pull}" -eq 0 ]] && hfl_docker_image_matches_platform "${image}" "${platform}"; then
+		HFL_DOCKER_IMAGE_SOURCE="local"
+		return 0
+	fi
+	if [[ "${force_pull}" -eq 0 && -n "${mirrored}" ]] \
+		&& hfl_docker_image_matches_platform "${mirrored}" "${platform}"; then
+		docker tag "${mirrored}" "${image}"
+		HFL_DOCKER_IMAGE_SOURCE="local-mirror"
+		return 0
+	fi
+
+	if [[ "${offline}" -eq 1 ]]; then
+		if hfl_docker_image_matches_platform "${image}" "${platform}"; then
+			HFL_DOCKER_IMAGE_SOURCE="local-offline"
+			return 0
+		fi
+		if [[ -n "${mirrored}" ]] && hfl_docker_image_matches_platform "${mirrored}" "${platform}"; then
+			docker tag "${mirrored}" "${image}"
+			HFL_DOCKER_IMAGE_SOURCE="local-mirror-offline"
+			return 0
+		fi
+		HFL_DOCKER_LAST_ERROR="${image} is missing and offline mode forbids registry access"
+		return 1
+	fi
+
+	if [[ -n "${mirrored}" ]] \
+		&& hfl_docker_pull_with_retry "${mirrored}" "${platform}" "${timeout_seconds}" "${retries}"; then
+		docker tag "${mirrored}" "${image}"
+		HFL_DOCKER_IMAGE_SOURCE="mirror"
+		return 0
+	fi
+	if hfl_docker_pull_with_retry "${image}" "${platform}" "${timeout_seconds}" "${retries}"; then
+		HFL_DOCKER_IMAGE_SOURCE="official"
+		return 0
+	fi
+
+	if hfl_docker_image_matches_platform "${image}" "${platform}"; then
+		HFL_DOCKER_IMAGE_SOURCE="local-fallback"
+		return 0
+	fi
+	if [[ -n "${mirrored}" ]] && hfl_docker_image_matches_platform "${mirrored}" "${platform}"; then
+		docker tag "${mirrored}" "${image}"
+		HFL_DOCKER_IMAGE_SOURCE="local-mirror-fallback"
+		return 0
+	fi
+	HFL_DOCKER_LAST_ERROR="unable to resolve ${image} from local cache, mirror, or official registry"
+	return 1
+}

--- a/tools/lib/version.sh
+++ b/tools/lib/version.sh
@@ -60,3 +60,12 @@ resolve_commit7() {
 	[[ "${commit7}" =~ ^[0-9a-f]{7,40}$ ]] || version_die "invalid git commit: ${full}"
 	printf '%.7s' "${commit7}"
 }
+
+release_package_basename_for_version() {
+	local version commit7
+	version="$(normalize_release_version "$1")" || return $?
+	commit7="${2,,}"
+	[[ "${commit7}" =~ ^[0-9a-f]{7}$ ]] \
+		|| version_die "invalid short git commit: ${2} (expected 7 hexadecimal characters)" 2
+	printf 'hyperfilelens-%s-%s.tar.gz' "${version}" "${commit7}"
+}

--- a/tools/quality/check-english-source.py
+++ b/tools/quality/check-english-source.py
@@ -30,6 +30,7 @@ SKIPPED_DIRECTORY_NAMES = {
     ".mypy_cache",
     ".pytest_cache",
     ".ruff_cache",
+    ".venv",
     "__pycache__",
     "dist",
     "node_modules",

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# Fast release workflow contract checks that do not require Docker or network access.
+set -euo pipefail
+umask 022
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+# shellcheck source=../lib/version.sh
+source "${ROOT}/tools/lib/version.sh"
+actual="$(release_package_basename_for_version v0.1.0 69F809F)"
+[[ "${actual}" == "hyperfilelens-0.1.0-69f809f.tar.gz" ]] || {
+	printf 'ERROR: unexpected release package basename: %s\n' "${actual}" >&2
+	exit 1
+}
+
+# shellcheck source=../sourcelens/common.sh
+source "${ROOT}/tools/sourcelens/common.sh"
+for function_name in \
+	sourcelens_build_app_images \
+	sourcelens_patch_compose_npm_registry \
+	sourcelens_patch_runtime_nginx; do
+	declare -F "${function_name}" >/dev/null || {
+		printf 'ERROR: missing SourceLens function: %s\n' "${function_name}" >&2
+		exit 1
+	}
+done
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "${tmp}"' EXIT
+
+cat >"${tmp}/docker-compose.yml" <<'YAML'
+services:
+  frontend:
+    build:
+      context: ./frontend
+      args:
+        VITE_GA_ID: ${VITE_GA_ID:-}
+    image: example/frontend:latest
+YAML
+sourcelens_patch_compose_npm_registry "${tmp}"
+sourcelens_patch_compose_npm_registry "${tmp}"
+[[ "$(grep -c 'NPM_REGISTRY:' "${tmp}/docker-compose.yml")" -eq 1 ]] || {
+	printf 'ERROR: SourceLens npm registry Compose patch is not idempotent\n' >&2
+	exit 1
+}
+grep -F 'NPM_REGISTRY: ${NPM_REGISTRY:-}' "${tmp}/docker-compose.yml" >/dev/null
+
+cat >"${tmp}/nginx.conf" <<'NGINX'
+ssl_certificate /etc/nginx/certs/nginx-selfsigned.crt;
+ssl_certificate_key /etc/nginx/certs/nginx-selfsigned.key;
+set $ui_upstream http://frontend:80;
+NGINX
+sourcelens_patch_runtime_nginx "${tmp}/nginx.conf"
+grep -F '/etc/nginx/certs/tls.crt' "${tmp}/nginx.conf" >/dev/null
+grep -F '/etc/nginx/certs/tls.key' "${tmp}/nginx.conf" >/dev/null
+grep -F 'set $ui_upstream http://ui:80;' "${tmp}/nginx.conf" >/dev/null
+
+grep -F 'archive.extractall(destination, filter="data")' \
+	"${ROOT}/src/agent/scripts/package.sh" >/dev/null
+grep -F 'chown postgres:postgres /var/lib/postgresql/data' \
+	"${ROOT}/deploy/installer/sourcelens/docker-compose.template.yml" >/dev/null
+if rg -n 'sourcelens_prepare_source_build_env' \
+	"${ROOT}/release" "${ROOT}/dev" "${ROOT}/tools/sourcelens" >/dev/null; then
+	printf 'ERROR: obsolete SourceLens prepare helper is still referenced\n' >&2
+	exit 1
+fi
+
+config="$(${ROOT}/release/build.sh --no-cache --print-config)"
+grep -F 'no_cache=1' <<<"${config}" >/dev/null
+
+grep -F -- '--prebuilt' "${ROOT}/release/build-sourcelens.sh" >/dev/null
+grep -F 'ln "${source_archive}" "${temporary}"' \
+	"${ROOT}/tools/sourcelens/common.sh" >/dev/null
+grep -F 'SOURCELENS_GIT_REF="${SOURCELENS_GIT_REF:-v0.4.0}"' \
+	"${ROOT}/tools/sourcelens/defaults.env" >/dev/null
+grep -F 'set_key("DJANGO_DEBUG", "true")' \
+	"${ROOT}/deploy/installer/sourcelens/patch-env-runtime.py" >/dev/null
+
+workflow="${ROOT}/.github/workflows/build_and_deploy.yml"
+[[ -f "${workflow}" ]] || {
+	printf 'ERROR: tag release workflow is missing\n' >&2
+	exit 1
+}
+if grep -F 'workflow_dispatch:' "${workflow}" >/dev/null; then
+	printf 'ERROR: release workflow must not allow manual dispatch\n' >&2
+	exit 1
+fi
+grep -F 'tags:' "${workflow}" >/dev/null
+for job in \
+	prepare quality build-hfl-images build-sourcelens-images build-agent \
+	build-host-debs export-hfl-images export-sourcelens-bundle \
+	export-runtime-images assemble-release verify-release publish-release deploy; do
+	grep -F "  ${job}:" "${workflow}" >/dev/null || {
+		printf 'ERROR: release workflow job is missing: %s\n' "${job}" >&2
+		exit 1
+	}
+done
+grep -F "if: \${{ vars.HFL_AUTO_DEPLOY == 'true' }}" "${workflow}" >/dev/null
+grep -F "select(.name | startswith(\"_internal-\") | not)" "${workflow}" >/dev/null
+grep -F 'uv run python src/backend/manage.py test' "${workflow}" >/dev/null
+grep -F 'npm run test:ci' "${workflow}" >/dev/null
+grep -F './tools/quality/test-ci-release-assembly.sh' "${workflow}" >/dev/null
+if grep -F 'uv run pytest src/backend' "${workflow}" >/dev/null; then
+	printf 'ERROR: backend CI must initialize Django through manage.py\n' >&2
+	exit 1
+fi
+
+remote_deploy="${ROOT}/.github/scripts/remote-deploy.sh"
+[[ -x "${remote_deploy}" ]] || {
+	printf 'ERROR: remote deployment script is missing or not executable\n' >&2
+	exit 1
+}
+grep -F 'browser_download_url' "${remote_deploy}" >/dev/null
+grep -F 'bash "${INSTALL_DIR}/install.sh" upgrade --from "${package_root}" --yes' \
+	"${remote_deploy}" >/dev/null
+if grep -E 'docker (pull|compose pull)' "${remote_deploy}" >/dev/null; then
+	printf 'ERROR: production deployment must consume the complete Release package\n' >&2
+	exit 1
+fi
+
+installer="${ROOT}/deploy/installer/install.sh"
+grep -F 'PUBLIC_HOST="${HFL_PUBLIC_HOST:-}"' "${installer}" >/dev/null
+grep -F 'values are hidden in non-interactive logs' "${installer}" >/dev/null
+grep -F 'apply_upgrade_files "${src_root}" "${remove_sourcelens}"' "${installer}" >/dev/null
+fingerprint_body="$(sed -n '/^sourcelens_bundle_fingerprint()/,/^}/p' "${installer}")"
+grep -F 'BUILD_INFO.identity' <<<"${fingerprint_body}" >/dev/null
+if grep -F 'upstream_ref' <<<"${fingerprint_body}" >/dev/null; then
+	printf 'ERROR: SourceLens fingerprint must ignore per-release registry transit refs\n' >&2
+	exit 1
+fi
+
+for executable in \
+	"${ROOT}/.github/scripts/remote-deploy.sh" \
+	"${ROOT}"/release/ci/*.sh \
+	"${ROOT}/release/ci/write-sbom.py"; do
+	[[ -x "${executable}" ]] || {
+		printf 'ERROR: CI entry point is not executable: %s\n' "${executable}" >&2
+		exit 1
+	}
+done
+
+printf 'Release contract checks passed.\n'

--- a/tools/quality/test-ci-release-assembly.sh
+++ b/tools/quality/test-ci-release-assembly.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Exercise CI release assembly with tiny synthetic, non-Docker bundles.
+set -euo pipefail
+umask 022
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+tmp="$(mktemp -d "${ROOT}/build/ci-assembly-test.XXXXXX")"
+trap 'rm -rf "${tmp}"' EXIT
+input="${tmp}/input"
+fixtures="${tmp}/fixtures"
+output="${tmp}/release"
+mkdir -p "${input}" "${fixtures}"
+
+make_gzip() {
+	local output_path=$1 content=$2
+	mkdir -p "$(dirname "${output_path}")"
+	printf '%s\n' "${content}" | gzip -c >"${output_path}"
+}
+
+make_metadata() {
+	local output_path=$1 component=$2 ref=$3 digest_char=$4
+	mkdir -p "$(dirname "${output_path}")"
+	printf '{"component":"%s","ref":"%s","digest":"sha256:%064d","platform":"linux/amd64"}\n' \
+		"${component}" "${ref}" "${digest_char}" >"${output_path}"
+}
+
+hfl="${fixtures}/hfl"
+make_gzip "${hfl}/images/00-hyperfilelens.tar.gz" hfl-images
+make_metadata "${hfl}/metadata/hfl-backend.json" hfl-backend example/hfl-backend:1.2.3 1
+make_metadata "${hfl}/metadata/hfl-frontend.json" hfl-frontend example/hfl-frontend:1.2.3 2
+tar -C "${hfl}" -czf "${input}/_internal-hfl-images.tar.gz" images metadata
+
+runtime="${fixtures}/runtime"
+make_gzip "${runtime}/images/01-postgres-17.tar.gz" postgres
+make_gzip "${runtime}/images/02-redis-alpine.tar.gz" redis
+make_metadata "${runtime}/metadata/postgres.json" postgres postgres:17 3
+make_metadata "${runtime}/metadata/redis.json" redis redis:alpine 4
+tar -C "${runtime}" -czf "${input}/_internal-runtime-images.tar.gz" images metadata
+
+sl="${fixtures}/sourcelens"
+make_gzip "${sl}/images/10-sourcelens-app.tar.gz" sourcelens-app
+make_gzip "${sl}/images/11-sourcelens-lensnode.tar.gz" sourcelens-lensnode
+make_gzip "${sl}/images/12-nginx-stable-alpine.tar.gz" nginx
+mkdir -p "${sl}/sourcelens/deploy/postgresql/initdb.d" \
+	"${sl}/sourcelens/deploy/nginx/certs" \
+	"${sl}/payload/media/gateway-bootstrap"
+printf '#!/usr/bin/env bash\nexit 0\n' >"${sl}/sourcelens/install.sh"
+printf '#!/usr/bin/env python3\n' >"${sl}/sourcelens/patch-env-runtime.py"
+printf 'services: {}\n' >"${sl}/sourcelens/docker-compose.yml"
+printf 'DJANGO_DEBUG=true\n' >"${sl}/sourcelens/.env.example"
+printf 'fixture\n' >"${sl}/sourcelens/deploy/postgresql/initdb.d/fixture.sh"
+cp "${sl}/images/11-sourcelens-lensnode.tar.gz" \
+	"${sl}/payload/media/gateway-bootstrap/lensnode-image-linux-amd64.tar.gz"
+cat >"${sl}/sourcelens/BUILD_INFO.json" <<'JSON'
+{
+  "enabled": true,
+  "git_url": "https://github.com/HyperBDR/sourcelens.git",
+  "git_ref": "v0.4.0",
+  "git_commit": "0000000000000000000000000000000000000000",
+  "git_commit_short": "0000000",
+  "version": "0.4.0",
+  "patch_sha256": "fixture",
+  "network": "hyperfilelens-bridge",
+  "install_dir": "/opt/hyperfilelens/sourcelens",
+  "lensnode_image": "sourcelens-lensnode:latest",
+  "images": {
+    "backend": {"ref": "sourcelens-backend:0.4.0", "upstream_ref": "example/backend:v0.4.0", "digest": "sha256:1111111111111111111111111111111111111111111111111111111111111111"},
+    "frontend": {"ref": "sourcelens-frontend:0.4.0", "upstream_ref": "example/frontend:v0.4.0", "digest": "sha256:2222222222222222222222222222222222222222222222222222222222222222"},
+    "lensnode": {"ref": "sourcelens-lensnode:0.4.0", "upstream_ref": "example/lensnode:v0.4.0", "digest": "sha256:3333333333333333333333333333333333333333333333333333333333333333"},
+    "nginx": {"ref": "nginx:stable-alpine", "digest": "sha256:4444444444444444444444444444444444444444444444444444444444444444"}
+  }
+}
+JSON
+tar -C "${sl}" -czf "${input}/_internal-sourcelens-bundle.tar.gz" images sourcelens payload
+
+host="${fixtures}/host"
+mkdir -p "${host}/host/debs"
+printf 'synthetic deb\n' >"${host}/host/debs/fixture.deb"
+tar -C "${host}" -czf "${input}/_internal-host-debs.tar.gz" host
+
+for asset in linux-amd64 linux-arm64 darwin-amd64 darwin-arm64 windows-amd64; do
+	agent="${fixtures}/agent-${asset}"
+	mkdir -p "${agent}/payload/media/agent-releases/1.2.3" \
+		"${agent}/payload/media/enroll-bootstrap"
+	printf '%s\n' "${asset}" >"${agent}/payload/media/agent-releases/1.2.3/${asset}.fixture"
+	printf '%s\n' "${asset}" >"${agent}/payload/media/enroll-bootstrap/${asset}.fixture"
+	tar -C "${agent}" -czf "${input}/_internal-agent-${asset}.tar.gz" payload
+done
+
+HFL_CI_RELEASE_BUILD_DIR="${output}" \
+	HFL_RELEASE_MAX_SINGLE_BYTES=1024 \
+	HFL_RELEASE_PART_BYTES=4096 \
+	"${ROOT}/release/ci/assemble-release.sh" \
+		--input-dir "${input}" \
+		--version 1.2.3 \
+		--commit 0123456789abcdef0123456789abcdef01234567
+
+(
+	cd "${output}/dist"
+	while IFS= read -r asset; do
+		[[ -f "${asset}" ]]
+	done <"${output}/release-assets.txt"
+	if grep -F 'release-assets.txt' "${output}/release-assets.txt" >/dev/null; then
+		printf 'ERROR: internal release asset list must not publish itself\n' >&2
+		exit 1
+	fi
+	jq -e '.spdxVersion == "SPDX-2.3" and (.packages | length) == 7' \
+		SBOM.spdx.json >/dev/null
+	sha256sum -c SHA256SUMS
+	first="$(find . -maxdepth 1 -type f -name 'hyperfilelens-*.tar.gz.part-000' -print -quit)"
+	[[ -n "${first}" ]]
+	archive="${first%.part-000}"
+	cat "${archive}.part-"* >"${archive}"
+	"${ROOT}/release/ci/verify-release.sh" --archive "$(realpath "${archive}")"
+)
+
+printf 'Synthetic CI release assembly passed.\n'

--- a/tools/sourcelens/common.sh
+++ b/tools/sourcelens/common.sh
@@ -24,6 +24,8 @@ SOURCELENS_COMPOSE=()
 
 # shellcheck source=../lib/logging.sh
 source "${HFL_ROOT}/tools/lib/logging.sh"
+# shellcheck source=../lib/docker-images.sh
+source "${HFL_ROOT}/tools/lib/docker-images.sh"
 sourcelens_log() { hfl_log_info "$@"; }
 sourcelens_die() { hfl_die "$1" "${2:-1}"; }
 
@@ -57,6 +59,13 @@ sourcelens_load_config() {
 	SOURCELENS_PIP_RETRY_MAX="${SOURCELENS_PIP_RETRY_MAX:-${HFL_PIP_RETRY_MAX:-${BUILD_PIP_RETRY_MAX:-5}}}"
 	SOURCELENS_PIP_RETRY_DELAY="${SOURCELENS_PIP_RETRY_DELAY:-${HFL_PIP_RETRY_DELAY:-${BUILD_PIP_RETRY_DELAY:-5}}}"
 	SOURCELENS_NPM_REGISTRY="${SOURCELENS_NPM_REGISTRY:-${NPM_REGISTRY:-${BUILD_NPM_REGISTRY:-}}}"
+	SOURCELENS_DOCKER_MIRROR="${SOURCELENS_DOCKER_MIRROR:-${DOCKER_DOWNLOAD_MIRROR:-}}"
+	SOURCELENS_DOCKER_PULL_TIMEOUT="${SOURCELENS_DOCKER_PULL_TIMEOUT:-${DOCKER_PULL_TIMEOUT_SECONDS:-180}}"
+	SOURCELENS_DOCKER_PULL_RETRIES="${SOURCELENS_DOCKER_PULL_RETRIES:-${DOCKER_PULL_RETRIES:-2}}"
+	SOURCELENS_OFFLINE="${SOURCELENS_OFFLINE:-${DEV_OFFLINE:-0}}"
+	SOURCELENS_FORCE_PULL="${SOURCELENS_FORCE_PULL:-0}"
+	SOURCELENS_GIT_TIMEOUT_SECONDS="${SOURCELENS_GIT_TIMEOUT_SECONDS:-120}"
+	SOURCELENS_GIT_RETRIES="${SOURCELENS_GIT_RETRIES:-2}"
 }
 
 sourcelens_resolve_version() {
@@ -151,6 +160,32 @@ sourcelens_git() {
 	fi
 }
 
+sourcelens_git_network() {
+	local attempt timeout_seconds="${SOURCELENS_GIT_TIMEOUT_SECONDS}" retries="${SOURCELENS_GIT_RETRIES}"
+	local clone_dest=""
+	[[ "${1:-}" != "clone" ]] || clone_dest="${!#}"
+	[[ "${timeout_seconds}" =~ ^[1-9][0-9]*$ && "${retries}" =~ ^[1-9][0-9]*$ ]] \
+		|| sourcelens_die "SourceLens Git timeout and retries must be positive integers" 2
+	for attempt in $(seq 1 "${retries}"); do
+		if [[ -n "${clone_dest}" && "${attempt}" -gt 1 ]]; then
+			rm -rf "${clone_dest}"
+		fi
+		if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+			if timeout --foreground "${timeout_seconds}s" env GIT_TERMINAL_PROMPT=0 git \
+				-c "url.https://x-access-token:${GITHUB_TOKEN}@github.com/.insteadOf=https://github.com/" \
+				-c "url.https://x-access-token:${GITHUB_TOKEN}@github.com/.insteadOf=git@github.com:" "$@"; then
+				return 0
+			fi
+		elif timeout --foreground "${timeout_seconds}s" env GIT_TERMINAL_PROMPT=0 git \
+			-c "url.https://github.com/.insteadOf=https://github.com/" "$@"; then
+			return 0
+		fi
+		sourcelens_log "SourceLens Git command failed or timed out (attempt ${attempt}/${retries})"
+	done
+	[[ -z "${clone_dest}" ]] || rm -rf "${clone_dest}"
+	return 1
+}
+
 sourcelens_image_exists() {
 	docker image inspect "$1" >/dev/null 2>&1
 }
@@ -190,7 +225,14 @@ try:
         with tarfile.open(fileobj=gz, mode="r:") as tar:
             member = tar.getmember("index.json")
             data = json.load(tar.extractfile(member))
-except (OSError, KeyError, json.JSONDecodeError, tarfile.TarError):
+except (
+    EOFError,
+    OSError,
+    KeyError,
+    gzip.BadGzipFile,
+    json.JSONDecodeError,
+    tarfile.TarError,
+):
     sys.exit(0)
 
 manifests = data.get("manifests") or []
@@ -223,6 +265,26 @@ sourcelens_ensure_shared_network() {
 	docker network create "${SOURCELENS_SHARED_NETWORK}" >/dev/null
 }
 
+sourcelens_ensure_tls_certs() {
+	local cert_dir=$1
+	local cert="${cert_dir}/tls.crt"
+	local key="${cert_dir}/tls.key"
+	mkdir -p "${cert_dir}"
+	if [[ -s "${cert}" && -s "${key}" ]]; then
+		return 0
+	fi
+	command -v openssl >/dev/null 2>&1 \
+		|| sourcelens_die "openssl is required to generate SourceLens TLS certificates"
+	sourcelens_log "Generating SourceLens development TLS certificates in ${cert_dir#${HFL_ROOT}/}"
+	openssl req -x509 -newkey rsa:2048 -sha256 -days 3650 -nodes \
+		-keyout "${key}" \
+		-out "${cert}" \
+		-subj "/CN=localhost" \
+		-addext "subjectAltName=DNS:localhost,IP:127.0.0.1,IP:::1" 2>/dev/null
+	chmod 644 "${cert}"
+	chmod 600 "${key}"
+}
+
 sourcelens_sync_source() {
 	command -v git >/dev/null 2>&1 || sourcelens_die "git not found (required to fetch SourceLens)"
 	if sourcelens_git_needs_github_token && [[ -z "${GITHUB_TOKEN:-}" ]]; then
@@ -235,9 +297,12 @@ sourcelens_sync_source() {
 		sourcelens_log "Removing incomplete SourceLens clone at ${SOURCELENS_SOURCE_CACHE#${HFL_ROOT}/}"
 		rm -rf "${SOURCELENS_SOURCE_CACHE}"
 	fi
+	if [[ "${SOURCELENS_OFFLINE}" -eq 1 && ! -d "${SOURCELENS_SOURCE_CACHE}/.git" ]]; then
+		sourcelens_die "SourceLens source cache is missing and offline mode forbids cloning"
+	fi
 	if [[ ! -d "${SOURCELENS_SOURCE_CACHE}/.git" ]]; then
 		sourcelens_log "Cloning ${SOURCELENS_GIT_URL} (${SOURCELENS_GIT_REF})..."
-		sourcelens_git clone "${SOURCELENS_GIT_URL}" "${SOURCELENS_SOURCE_CACHE}"
+		sourcelens_git_network clone "${SOURCELENS_GIT_URL}" "${SOURCELENS_SOURCE_CACHE}"
 	fi
 	git -C "${SOURCELENS_SOURCE_CACHE}" reset --hard HEAD >/dev/null
 	rm -f "${SOURCELENS_SOURCE_CACHE}/.hfl-built-commit"
@@ -249,7 +314,10 @@ sourcelens_sync_source() {
 	sourcelens_log "Checking out SourceLens ref ${SOURCELENS_GIT_REF}..."
 	(
 		cd "${SOURCELENS_SOURCE_CACHE}"
-		if sourcelens_git fetch origin --tags --prune; then
+		if [[ "${SOURCELENS_OFFLINE}" -eq 1 ]]; then
+			fetch_succeeded=0
+			sourcelens_log "Offline mode: using the existing SourceLens source cache"
+		elif sourcelens_git_network fetch origin --tags --prune; then
 			fetch_succeeded=1
 		else
 			fetch_succeeded=0
@@ -258,14 +326,18 @@ sourcelens_sync_source() {
 		if sourcelens_git show-ref --verify --quiet "refs/heads/${SOURCELENS_GIT_REF}"; then
 			sourcelens_git checkout "${SOURCELENS_GIT_REF}"
 			if [[ "${fetch_succeeded}" -eq 1 ]]; then
-				sourcelens_git pull --ff-only origin "${SOURCELENS_GIT_REF}" || true
+				sourcelens_git_network pull --ff-only origin "${SOURCELENS_GIT_REF}" || true
 			fi
 		elif sourcelens_git show-ref --verify --quiet "refs/tags/${SOURCELENS_GIT_REF}"; then
 			sourcelens_git checkout "${SOURCELENS_GIT_REF}"
 		else
 			sourcelens_git checkout "${SOURCELENS_GIT_REF}"
 		fi
-		sourcelens_git submodule update --init --recursive
+		if [[ "${SOURCELENS_OFFLINE}" -eq 1 ]]; then
+			sourcelens_git submodule update --init --recursive --no-fetch
+		else
+			sourcelens_git_network submodule update --init --recursive
+		fi
 	)
 	# shellcheck source=sourcelens-lensnode-patch.sh
 	source "${HFL_ROOT}/tools/sourcelens/lensnode-patch.sh"
@@ -638,6 +710,38 @@ path.write_text("".join(out), encoding="utf-8")
 PY
 }
 
+sourcelens_patch_compose_npm_registry() {
+	local src=$1
+	local compose="${src}/docker-compose.yml"
+	[[ -f "${compose}" ]] || return 0
+	python3 - "${compose}" <<'PY'
+import pathlib
+import re
+import sys
+
+path = pathlib.Path(sys.argv[1])
+text = path.read_text(encoding="utf-8")
+pattern = re.compile(
+    r"(?ms)(^  frontend:\n.*?^    build:\n.*?^      args:\n)(.*?)(?=^    \S)"
+)
+matches = list(pattern.finditer(text))
+if len(matches) != 1:
+    raise SystemExit(
+        f"expected one frontend build args block in {path}, found {len(matches)}"
+    )
+
+match = matches[0]
+args = match.group(2)
+line = "        NPM_REGISTRY: ${NPM_REGISTRY:-}\n"
+if re.search(r"(?m)^        NPM_REGISTRY:.*$", args):
+    args = re.sub(r"(?m)^        NPM_REGISTRY:.*$", line.rstrip(), args, count=1)
+else:
+    args = args.rstrip("\n") + "\n" + line
+text = text[: match.start(2)] + args + text[match.end(2) :]
+path.write_text(text, encoding="utf-8")
+PY
+}
+
 sourcelens_distribution_image_ref() {
 	local component=$1 tag="${2:-${SOURCELENS_VERSION}}"
 	local repository="sourcelens-${component}"
@@ -712,9 +816,28 @@ sourcelens_publish_gateway_lensnode_bundle() {
 	local refs=()
 
 	mkdir -p "${dest_dir}"
+	command -v flock >/dev/null 2>&1 \
+		|| sourcelens_die "flock is required for atomic LensNode bundle publishing"
 
 	if [[ -n "${source_archive}" && -f "${source_archive}" ]]; then
-		cp -f "${source_archive}" "${dest}"
+		(
+			local temporary="${dest}.tmp.$$"
+			exec 9>"${dest}.lock"
+			flock 9
+			trap 'rm -f "${temporary}"' EXIT INT TERM
+			# Release staging exposes the same LensNode archive at two public paths.
+			# A hard link keeps both contracts without storing the 250+ MiB blob
+			# twice; copying remains the safe fallback across filesystems.
+			if ! ln "${source_archive}" "${temporary}" 2>/dev/null; then
+				cp "${source_archive}" "${temporary}"
+			fi
+			gzip -t "${temporary}"
+			[[ -n "$(sourcelens_gateway_lensnode_bundle_image_id "${temporary}")" ]] \
+				|| sourcelens_die "source LensNode archive is missing a valid Docker image index"
+			chmod 0644 "${temporary}"
+			mv -f "${temporary}" "${dest}"
+			trap - EXIT INT TERM
+		)
 		sourcelens_log "Published gateway LensNode bundle -> ${dest#${HFL_ROOT}/}"
 		return 0
 	fi
@@ -753,21 +876,48 @@ sourcelens_publish_gateway_lensnode_bundle() {
 		sourcelens_die "LensNode image ${primary_ref} lacks HFL TLS bypass (lensnode.tls); rebuild SourceLens app images first"
 	fi
 
-	sourcelens_log "Saving gateway LensNode bundle -> ${dest#${HFL_ROOT}/}"
-	docker save "${refs[@]}" | gzip -c >"${dest}"
+	sourcelens_log "Saving gateway LensNode bundle atomically -> ${dest#${HFL_ROOT}/}"
+	(
+		local temporary="${dest}.tmp.$$"
+		exec 9>"${dest}.lock"
+		flock 9
+		trap 'rm -f "${temporary}"' EXIT INT TERM
+		docker save "${refs[@]}" | gzip -c >"${temporary}"
+		gzip -t "${temporary}"
+		local exported_id
+		exported_id="$(sourcelens_gateway_lensnode_bundle_image_id "${temporary}")"
+		[[ -n "${exported_id}" && "${exported_id}" == "$(sourcelens_lensnode_image_id "${primary_ref}")" ]] \
+			|| sourcelens_die "exported LensNode archive failed image identity validation"
+		chmod 0644 "${temporary}"
+		mv -f "${temporary}" "${dest}"
+		trap - EXIT INT TERM
+	)
 	bundle_id="$(sourcelens_gateway_lensnode_bundle_image_id "${dest}")"
 	sourcelens_log "Published gateway LensNode bundle ($(du -h "${dest}" | awk '{print $1}'), ${bundle_id:-unknown id})"
 }
 
 sourcelens_build_app_images() {
 	local force=${1:-0}
+	local no_cache=${2:-0}
+	local requested_services="${SOURCELENS_BUILD_SERVICES:-backend-api frontend lensnode}"
+	local full_build=1
+	if [[ "${requested_services}" != "backend-api frontend lensnode" ]]; then
+		full_build=0
+		local service
+		for service in ${requested_services}; do
+			case "${service}" in
+			backend-api | frontend | lensnode) ;;
+			*) sourcelens_die "unsupported SourceLens build service: ${service}" 2 ;;
+			esac
+		done
+	fi
 	sourcelens_ensure_compose
-	if [[ "${force}" -eq 0 ]] && sourcelens_build_skippable; then
+	if [[ "${full_build}" -eq 1 && "${force}" -eq 0 && "${no_cache}" -eq 0 ]] && sourcelens_build_skippable; then
 		sourcelens_log "SourceLens app images already built for source stamp $(sourcelens_read_built_commit); skipping compose build"
 		sourcelens_tag_lensnode_alias
 		return 0
 	fi
-	if [[ "${force}" -eq 0 \
+	if [[ "${full_build}" -eq 1 && "${force}" -eq 0 && "${no_cache}" -eq 0 \
 		&& "$(sourcelens_read_built_commit)" == "$(sourcelens_current_build_stamp)" ]] \
 		&& sourcelens_upstream_images_ready; then
 		sourcelens_log "SourceLens upstream images match the build stamp; applying normalized distribution tags"
@@ -775,7 +925,7 @@ sourcelens_build_app_images() {
 		sourcelens_tag_lensnode_alias
 		return 0
 	fi
-	if [[ "${force}" -eq 0 ]] && sourcelens_app_images_ready; then
+	if [[ "${full_build}" -eq 1 && "${force}" -eq 0 && "${no_cache}" -eq 0 ]] && sourcelens_app_images_ready; then
 		sourcelens_log "SourceLens app images present but source commit changed; rebuilding"
 	fi
 
@@ -826,8 +976,17 @@ sourcelens_build_app_images() {
 		sourcelens_log "Using SourceLens pip resilience: BuildKit uv/pip cache + retry max=${SOURCELENS_PIP_RETRY_MAX} delay=${SOURCELENS_PIP_RETRY_DELAY}s"
 		sourcelens_log "Using SourceLens uv network: timeout=${UV_HTTP_TIMEOUT}s concurrent=${UV_CONCURRENT_DOWNLOADS} (uv retries=default)"
 		sourcelens_log "Using SourceLens npm registry: ${NPM_REGISTRY}"
-		DOCKER_BUILDKIT=1 "${SOURCELENS_COMPOSE[@]}" build backend-api frontend lensnode
+		local -a build_args=(build)
+		[[ "${no_cache}" -eq 1 ]] && build_args+=(--no-cache)
+		# shellcheck disable=SC2206
+		local -a services=(${requested_services})
+		build_args+=("${services[@]}")
+		DOCKER_BUILDKIT=1 "${SOURCELENS_COMPOSE[@]}" "${build_args[@]}"
 	)
+	if [[ "${full_build}" -eq 0 ]]; then
+		sourcelens_log "Built requested SourceLens service(s): ${requested_services}"
+		return 0
+	fi
 	sourcelens_tag_app_images_latest
 	sourcelens_tag_lensnode_alias
 	sourcelens_write_built_commit "$(sourcelens_current_build_stamp)"
@@ -835,10 +994,26 @@ sourcelens_build_app_images() {
 
 sourcelens_ensure_nginx_image() {
 	local force_pull=${1:-0}
-	if [[ "${force_pull}" -eq 1 ]] || ! sourcelens_image_exists "nginx:stable-alpine"; then
-		sourcelens_log "Pulling nginx:stable-alpine for SourceLens edge proxy..."
-		docker pull nginx:stable-alpine
+	sourcelens_ensure_runtime_image "nginx:stable-alpine" "${force_pull}"
+}
+
+sourcelens_ensure_runtime_image() {
+	local image=$1 force_pull=${2:-${SOURCELENS_FORCE_PULL}}
+	sourcelens_log "Resolving runtime image ${image} (offline=${SOURCELENS_OFFLINE}, force_pull=${force_pull})"
+	if ! hfl_docker_ensure_image "${image}" "${SOURCELENS_DOCKER_MIRROR}" \
+		"${force_pull}" "${SOURCELENS_OFFLINE}" "${SOURCELENS_DOCKER_PLATFORM}" \
+		"${SOURCELENS_DOCKER_PULL_TIMEOUT}" "${SOURCELENS_DOCKER_PULL_RETRIES}"; then
+		sourcelens_die "unable to prepare ${image}: ${HFL_DOCKER_LAST_ERROR}"
 	fi
+	sourcelens_log "Runtime image ${image} ready (source=${HFL_DOCKER_IMAGE_SOURCE})"
+}
+
+sourcelens_ensure_runtime_images() {
+	local force_pull=${1:-${SOURCELENS_FORCE_PULL}}
+	local image
+	for image in nginx:stable-alpine postgres:17 redis:alpine; do
+		sourcelens_ensure_runtime_image "${image}" "${force_pull}"
+	done
 }
 
 sourcelens_patch_env_runtime_defaults() {
@@ -890,6 +1065,16 @@ if target not in text and not any(source in text for source in sources):
     raise SystemExit(f"SourceLens UI upstream declaration not found in {path}")
 for source in sources:
     text = text.replace(source, target)
+text = text.replace(
+    "/etc/nginx/certs/nginx-selfsigned.crt",
+    "/etc/nginx/certs/tls.crt",
+)
+text = text.replace(
+    "/etc/nginx/certs/nginx-selfsigned.key",
+    "/etc/nginx/certs/tls.key",
+)
+if "/etc/nginx/certs/tls.crt" not in text or "/etc/nginx/certs/tls.key" not in text:
+    raise SystemExit(f"SourceLens TLS certificate declarations not found in {path}")
 path.write_text(text, encoding="utf-8")
 PY
 }
@@ -970,12 +1155,12 @@ sourcelens_prepare_dev_runtime_tree() {
 	[[ -f "${nginx_config}" ]] \
 		|| sourcelens_die "missing SourceLens nginx config: ${nginx_config}"
 
-	mkdir -p "${dev_root}/deploy/nginx/certs" "${dev_root}/deploy/postgresql"
+	mkdir -p "${dev_root}/deploy/nginx" "${dev_root}/deploy/postgresql"
 	cp "${nginx_config}" "${dev_root}/deploy/nginx/default.conf"
 	sourcelens_patch_runtime_nginx "${dev_root}/deploy/nginx/default.conf"
-	if [[ -d "${src}/docker/nginx/certs" ]]; then
-		rsync -a "${src}/docker/nginx/certs/" "${dev_root}/deploy/nginx/certs/"
-	fi
+	sourcelens_ensure_tls_certs "${HFL_ROOT}/deploy/nginx/certs"
+	rm -rf "${dev_root}/deploy/nginx/certs"
+	ln -s "${HFL_ROOT}/deploy/nginx/certs" "${dev_root}/deploy/nginx/certs"
 	if [[ -d "${src}/docker/postgresql" ]]; then
 		rsync -a "${src}/docker/postgresql/" "${dev_root}/deploy/postgresql/"
 	fi


### PR DESCRIPTION
## Summary

- harden local development and offline release build flows
- add tag-triggered GitHub release assembly with matrix jobs and disk-aware asset handling
- verify complete release installation and browser logins before publication
- deploy the published complete package through SSH with guarded in-place upgrades
- keep bundled SourceLens pinned at v0.4.0 without modifying its upstream repository

## Validation

- 537 Django tests passed
- 223 frontend tests passed and production build completed
- `go test ./...` passed
- actionlint, ShellCheck, release contracts, and synthetic split-package assembly passed