### PR TITLE
fix(quality): respect Git ignores in English source checks

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -133,6 +133,7 @@ jobs:
         run: |
           set -euo pipefail
           python3 tools/quality/check-english-source.py
+          python3 -m unittest tools/quality/test_check_english_source.py
           ./tools/quality/check-release-contracts.sh
           ./tools/quality/test-ci-release-assembly.sh
           git diff --check

--- a/README.md
+++ b/README.md
@@ -293,6 +293,7 @@ The public repository requires English source, comments, and documentation:
 
 ```bash
 python3 tools/quality/check-english-source.py
+python3 -m unittest tools/quality/test_check_english_source.py
 ./tools/quality/check-release-contracts.sh
 ```
 

--- a/tools/quality/check-english-source.py
+++ b/tools/quality/check-english-source.py
@@ -3,7 +3,9 @@
 
 from __future__ import annotations
 
+import os
 import re
+import subprocess
 import sys
 from collections.abc import Iterator
 from pathlib import Path
@@ -23,32 +25,27 @@ CJK_PATTERN = re.compile(
     "\U00020000-\U0002fa1f"
     "]",
 )
-SKIPPED_DIRECTORY_NAMES = {
-    ".git",
-    ".agents",
-    ".codex",
-    ".mypy_cache",
-    ".pytest_cache",
-    ".ruff_cache",
-    ".venv",
-    "__pycache__",
-    "dist",
-    "node_modules",
-}
-SKIPPED_TOP_LEVEL_DIRECTORIES = {"build", "data"}
 
 
 def iter_public_files() -> Iterator[Path]:
-    """Yield public repository files while excluding runtime and generated trees."""
-    for path in REPOSITORY_ROOT.rglob("*"):
-        relative_path = path.relative_to(REPOSITORY_ROOT)
-        if (
-            relative_path.parts
-            and relative_path.parts[0] in SKIPPED_TOP_LEVEL_DIRECTORIES
-        ):
+    """Yield tracked files and untracked files that Git does not ignore."""
+    result = subprocess.run(
+        [
+            "git",
+            "ls-files",
+            "--cached",
+            "--others",
+            "--exclude-standard",
+            "-z",
+        ],
+        cwd=REPOSITORY_ROOT,
+        check=True,
+        stdout=subprocess.PIPE,
+    )
+    for raw_relative_path in result.stdout.split(b"\0"):
+        if not raw_relative_path:
             continue
-        if any(part in SKIPPED_DIRECTORY_NAMES for part in path.parts):
-            continue
+        path = REPOSITORY_ROOT / os.fsdecode(raw_relative_path)
         if path.is_file():
             yield path
 

--- a/tools/quality/test_check_english_source.py
+++ b/tools/quality/test_check_english_source.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Regression tests for the English-only public source checker."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+CHECKER_SOURCE = Path(__file__).with_name("check-english-source.py")
+
+
+class EnglishSourceCheckerTests(unittest.TestCase):
+    """Verify that the checker follows Git's public source boundary."""
+
+    def setUp(self) -> None:
+        """Create an isolated Git repository containing the checker."""
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary_directory.cleanup)
+        self.repository_root = Path(self.temporary_directory.name)
+        checker = self.repository_root / "tools/quality/check-english-source.py"
+        checker.parent.mkdir(parents=True)
+        shutil.copy2(CHECKER_SOURCE, checker)
+        (self.repository_root / ".gitignore").write_text(
+            ".tmp/\n",
+            encoding="utf-8",
+        )
+        self.run_git("init", "--quiet")
+        self.run_git("add", ".gitignore", "tools/quality/check-english-source.py")
+
+    def run_git(self, *arguments: str) -> None:
+        """Run Git in the isolated repository."""
+        subprocess.run(
+            ["git", *arguments],
+            cwd=self.repository_root,
+            check=True,
+            stdout=subprocess.PIPE,
+        )
+
+    def run_checker(self) -> subprocess.CompletedProcess[str]:
+        """Run the copied checker and return its captured result."""
+        return subprocess.run(
+            [sys.executable, "tools/quality/check-english-source.py"],
+            cwd=self.repository_root,
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+
+    def test_ignored_file_is_not_checked(self) -> None:
+        """Ignore local files even when their paths and contents contain CJK."""
+        ignored_directory = self.repository_root / ".tmp"
+        ignored_directory.mkdir()
+        (ignored_directory / "\u4f60\u597d.txt").write_text(
+            "\u4f60\u597d\n",
+            encoding="utf-8",
+        )
+
+        result = self.run_checker()
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("English-only source check passed.", result.stdout)
+
+    def test_untracked_nonignored_file_is_checked(self) -> None:
+        """Check new source files before they are added to Git."""
+        (self.repository_root / "notes.txt").write_text(
+            "\u4f60\n",
+            encoding="utf-8",
+        )
+
+        result = self.run_checker()
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("notes.txt:1:1", result.stdout)
+        self.assertIn("U+4F60", result.stdout)
+
+    def test_tracked_file_is_checked_even_when_ignored(self) -> None:
+        """Keep checking tracked files after an ignore rule is introduced."""
+        tracked_file = self.repository_root / "tracked.txt"
+        tracked_file.write_text("\u4f60\n", encoding="utf-8")
+        self.run_git("add", "tracked.txt")
+        with (self.repository_root / ".gitignore").open(
+            "a",
+            encoding="utf-8",
+        ) as ignore_file:
+            ignore_file.write("tracked.txt\n")
+
+        result = self.run_checker()
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("tracked.txt:1:1", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- enumerate tracked and non-ignored untracked files with Git
- ignore local generated files such as .tmp content
- add regression coverage and run it in CI

## Validation
- python3 tools/quality/check-english-source.py
- python3 -m unittest tools/quality/test_check_english_source.py
- ruff check tools/quality/check-english-source.py tools/quality/test_check_english_source.py
- ./tools/quality/check-release-contracts.sh
- git diff --check