### PR TITLE
fix(release): allow verification to read draft assets

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -470,7 +470,7 @@ jobs:
     timeout-minutes: 60
     needs: [prepare, assemble-release]
     permissions:
-      contents: read
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - name: Reclaim unused runner toolchains


### PR DESCRIPTION
## Summary

- grant the release verification job access to unpublished Draft Release assets
- keep final publication isolated in the existing publish-release gate

## Failure addressed

The v0.1.0 workflow successfully built all images and assembled the complete offline package, but the verification job received `release not found` while downloading the Draft Release with a read-only token.

## Validation

- `./tools/quality/check-release-contracts.sh`
- `git diff --check`