### PR TITLE
fix(release): select current assets and valid credentials

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -452,11 +452,11 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          while IFS= read -r asset_id; do
-            [[ -n "$asset_id" ]] || continue
-            gh api --method DELETE "/repos/${GITHUB_REPOSITORY}/releases/assets/${asset_id}"
-          done < <(gh api "/repos/${GITHUB_REPOSITORY}/releases/tags/${{ needs.prepare.outputs.tag }}" \
-            --jq '.assets[] | select(.name | startswith("_internal-") | not) | .id')
+          while IFS= read -r asset; do
+            [[ -n "$asset" ]] || continue
+            gh release delete-asset "${{ needs.prepare.outputs.tag }}" "$asset" --yes
+          done < <(gh release view "${{ needs.prepare.outputs.tag }}" --json assets \
+            --jq '.assets[] | select(.name | startswith("_internal-") | not) | .name')
           while IFS= read -r asset; do
             gh release upload "${{ needs.prepare.outputs.tag }}" \
               "build/release/dist/${asset}" --clobber
@@ -497,12 +497,14 @@ jobs:
         run: |
           set -euo pipefail
           sha256sum -c SHA256SUMS
-          archive="$(find . -maxdepth 1 -type f -name 'hyperfilelens-*.tar.gz' -print -quit)"
+          archive="$(awk '$2 ~ /^hyperfilelens-.*\.tar\.gz$/ { print $2; exit }' SHA256SUMS)"
           if [[ -z "$archive" ]]; then
-            first="$(find . -maxdepth 1 -type f -name 'hyperfilelens-*.tar.gz.part-000' -print -quit)"
+            first="$(awk '$2 ~ /^hyperfilelens-.*\.tar\.gz\.part-000$/ { print $2; exit }' SHA256SUMS)"
             [[ -n "$first" ]]
             archive="${first%.part-000}"
             cat "${archive}.part-"* > "$archive"
+          else
+            [[ -f "$archive" ]]
           fi
           echo "archive=$(realpath "$archive")" >> "$GITHUB_OUTPUT"
       - name: Full offline install and browser login smoke
@@ -521,11 +523,11 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          while IFS= read -r asset_id; do
-            [[ -n "$asset_id" ]] || continue
-            gh api --method DELETE "/repos/${GITHUB_REPOSITORY}/releases/assets/${asset_id}"
-          done < <(gh api "/repos/${GITHUB_REPOSITORY}/releases/tags/${{ needs.prepare.outputs.tag }}" \
-            --jq '.assets[] | select(.name | startswith("_internal-")) | .id')
+          while IFS= read -r asset; do
+            [[ -n "$asset" ]] || continue
+            gh release delete-asset "${{ needs.prepare.outputs.tag }}" "$asset" --yes
+          done < <(gh release view "${{ needs.prepare.outputs.tag }}" --json assets \
+            --jq '.assets[] | select(.name | startswith("_internal-")) | .name')
           gh release edit "${{ needs.prepare.outputs.tag }}" --draft=false --latest
 
   deploy-preprod:

--- a/deploy/installer/install.sh
+++ b/deploy/installer/install.sh
@@ -605,7 +605,7 @@ ensure_env_file() {
 	version="$(read_version)"
 	secret="$(random_hex)"
 	db_pass="$(random_hex | cut -c1-32)"
-	admin_pass="Hfl-0$(random_hex | cut -c1-20)!"
+	admin_pass="Hfl-0$(random_hex | cut -c1-14)!"
 	host="${PUBLIC_HOST}"
 	if [[ -z "${host}" ]]; then
 		host="$(hostname -I 2>/dev/null | awk '{ for (i = 1; i <= NF; i++) if (!found && $i ~ /^[0-9]+\./) { print $i; found = 1 } }' || true)"

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -59,7 +59,7 @@ grep -F 'archive.extractall(destination, filter="data")' \
 	"${ROOT}/src/agent/scripts/package.sh" >/dev/null
 grep -F 'chown postgres:postgres /var/lib/postgresql/data' \
 	"${ROOT}/deploy/installer/sourcelens/docker-compose.template.yml" >/dev/null
-if rg -n 'sourcelens_prepare_source_build_env' \
+if grep -R -n 'sourcelens_prepare_source_build_env' \
 	"${ROOT}/release" "${ROOT}/dev" "${ROOT}/tools/sourcelens" >/dev/null; then
 	printf 'ERROR: obsolete SourceLens prepare helper is still referenced\n' >&2
 	exit 1
@@ -102,6 +102,8 @@ grep -F 'repository: hyperfilelens-backend' "${workflow}" >/dev/null
 grep -F 'repository: hyperfilelens-frontend' "${workflow}" >/dev/null
 grep -F '"$REGISTRY_PREFIX"' "${workflow}" >/dev/null
 grep -F "select(.name | startswith(\"_internal-\") | not)" "${workflow}" >/dev/null
+grep -F 'gh release delete-asset' "${workflow}" >/dev/null
+grep -F "awk '\$2 ~ /^hyperfilelens-.*\\.tar\\.gz\$/" "${workflow}" >/dev/null
 grep -F 'uv run python src/backend/manage.py test' "${workflow}" >/dev/null
 grep -F 'npm run test:ci' "${workflow}" >/dev/null
 grep -F './tools/quality/test-ci-release-assembly.sh' "${workflow}" >/dev/null
@@ -132,6 +134,7 @@ fi
 installer="${ROOT}/deploy/installer/install.sh"
 grep -F 'PUBLIC_HOST="${HFL_PUBLIC_HOST:-}"' "${installer}" >/dev/null
 grep -F 'values are hidden in non-interactive logs' "${installer}" >/dev/null
+grep -F 'admin_pass="Hfl-0$(random_hex | cut -c1-14)!"' "${installer}" >/dev/null
 grep -F 'apply_upgrade_files "${src_root}" "${remove_sourcelens}"' "${installer}" >/dev/null
 fingerprint_body="$(sed -n '/^sourcelens_bundle_fingerprint()/,/^}/p' "${installer}")"
 grep -F 'BUILD_INFO.identity' <<<"${fingerprint_body}" >/dev/null


### PR DESCRIPTION
## Summary

- generate the initial administrator password within the supported 8-20 character policy
- remove stale Draft Release assets with draft-aware GitHub CLI commands
- select the exact verified package listed in SHA256SUMS
- make release contract checks portable when ripgrep is unavailable

## Failures addressed

The full offline installation succeeded, but browser login was blocked because the installer generated a 26-character password while the login policy accepts at most 20 characters. The Draft Release also retained both old and current package archives, allowing the verifier to choose a stale file.

## Validation

- `./tools/quality/check-release-contracts.sh`
- `./tools/quality/test-ci-release-assembly.sh`
- Shell syntax checks
- Workflow YAML parsing
- `git diff --check`