### PR TITLE
fix(release): provide repository context when publishing

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -525,10 +525,13 @@ jobs:
           set -euo pipefail
           while IFS= read -r asset; do
             [[ -n "$asset" ]] || continue
-            gh release delete-asset "${{ needs.prepare.outputs.tag }}" "$asset" --yes
-          done < <(gh release view "${{ needs.prepare.outputs.tag }}" --json assets \
+            gh release delete-asset "${{ needs.prepare.outputs.tag }}" "$asset" \
+              --repo "${GITHUB_REPOSITORY}" --yes
+          done < <(gh release view "${{ needs.prepare.outputs.tag }}" \
+            --repo "${GITHUB_REPOSITORY}" --json assets \
             --jq '.assets[] | select(.name | startswith("_internal-")) | .name')
-          gh release edit "${{ needs.prepare.outputs.tag }}" --draft=false --latest
+          gh release edit "${{ needs.prepare.outputs.tag }}" \
+            --repo "${GITHUB_REPOSITORY}" --draft=false --latest
 
   deploy-preprod:
     needs: [prepare, publish-release]

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -103,6 +103,7 @@ grep -F 'repository: hyperfilelens-frontend' "${workflow}" >/dev/null
 grep -F '"$REGISTRY_PREFIX"' "${workflow}" >/dev/null
 grep -F "select(.name | startswith(\"_internal-\") | not)" "${workflow}" >/dev/null
 grep -F 'gh release delete-asset' "${workflow}" >/dev/null
+grep -F -- '--repo "${GITHUB_REPOSITORY}"' "${workflow}" >/dev/null
 grep -F "awk '\$2 ~ /^hyperfilelens-.*\\.tar\\.gz\$/" "${workflow}" >/dev/null
 grep -F 'uv run python src/backend/manage.py test' "${workflow}" >/dev/null
 grep -F 'npm run test:ci' "${workflow}" >/dev/null


### PR DESCRIPTION
## Summary

- pass the explicit GitHub repository to release CLI commands in the checkout-free publication job
- preserve the separate verification and publication gates

## Failure addressed

The complete offline package and all three login surfaces passed, but the final publication job could not infer a repository because it intentionally has no checkout.

## Validation

- `./tools/quality/check-release-contracts.sh`
- workflow YAML parsing
- `git diff --check`