### PR TITLE
Add unified toast error feedback

### DIFF
--- a/src/frontend/src/App.vue
+++ b/src/frontend/src/App.vue
@@ -5,6 +5,8 @@ import { useI18n } from 'vue-i18n'
 import { ElConfigProvider } from 'element-plus'
 import enLocale from 'element-plus/dist/locale/en.mjs'
 import { installedLangPacks } from './lib/langPacks'
+import HflToastViewport from './components/feedback/HflToastViewport.vue'
+import HflErrorDetailsDialog from './components/feedback/HflErrorDetailsDialog.vue'
 
 const { locale } = useI18n()
 const elLocale = shallowRef(enLocale)
@@ -47,6 +49,8 @@ watch(
         </template>
       </Suspense>
     </RouterView>
+    <HflToastViewport />
+    <HflErrorDetailsDialog />
   </ElConfigProvider>
 </template>
 

--- a/src/frontend/src/components/feedback/HflErrorDetailsDialog.vue
+++ b/src/frontend/src/components/feedback/HflErrorDetailsDialog.vue
@@ -1,0 +1,122 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { AlertTriangle, Check, Copy, X } from 'lucide-vue-next'
+import { useI18n } from 'vue-i18n'
+import { copyTextToClipboard } from '../../lib/clipboard'
+import {
+  closeErrorDetails,
+  errorDetailsCopyText,
+  errorDetailsState,
+  safeErrorDetailText,
+} from '../../lib/errors/details'
+
+const { t } = useI18n()
+const copied = ref(false)
+const details = computed(() => errorDetailsState.current)
+const rawText = computed(() => safeErrorDetailText(details.value?.rawDetail))
+
+async function copyDetails() {
+  if (!details.value) return
+  await copyTextToClipboard(errorDetailsCopyText(details.value))
+  copied.value = true
+  window.setTimeout(() => { copied.value = false }, 1600)
+}
+</script>
+
+<template>
+  <ElDialog
+    :model-value="Boolean(details)"
+    width="min(600px, calc(100vw - 32px))"
+    class="hfl-error-details"
+    append-to-body
+    destroy-on-close
+    :show-close="false"
+    @update:model-value="(open: boolean) => { if (!open) closeErrorDetails() }"
+  >
+    <template v-if="details" #header>
+      <div class="hfl-error-details__header">
+        <span class="hfl-error-details__icon" aria-hidden="true"><AlertTriangle :size="24" /></span>
+        <div class="hfl-error-details__heading">
+          <div class="hfl-error-details__title-line">
+            <h2>{{ details.title }}</h2>
+            <span v-if="details.errorCode" class="hfl-error-details__code">{{ details.errorCode }}</span>
+          </div>
+          <p>{{ details.summary }}</p>
+        </div>
+        <button type="button" class="hfl-error-details__close" :aria-label="t('common.close')" @click="closeErrorDetails">
+          <X :size="17" />
+        </button>
+      </div>
+    </template>
+
+    <template v-if="details">
+      <section v-if="details.issue" class="hfl-error-details__section">
+        <h3>{{ t('feedback.errorDetails.issue') }}</h3>
+        <div class="hfl-error-details__issue">{{ details.issue }}</div>
+      </section>
+
+      <section v-if="details.reasons?.length" class="hfl-error-details__section">
+        <h3>{{ t('feedback.errorDetails.reasons') }}</h3>
+        <ol class="hfl-error-details__list">
+          <li v-for="reason in details.reasons" :key="reason">{{ reason }}</li>
+        </ol>
+      </section>
+
+      <section v-if="details.resolutions?.length" class="hfl-error-details__section">
+        <h3>{{ t('feedback.errorDetails.resolutions') }}</h3>
+        <ul class="hfl-error-details__list hfl-error-details__list--resolve">
+          <li v-for="resolution in details.resolutions" :key="resolution">{{ resolution }}</li>
+        </ul>
+      </section>
+
+      <section v-if="details.traceId || rawText" class="hfl-error-details__section">
+        <h3>{{ t('feedback.errorDetails.technical') }}</h3>
+        <div v-if="details.traceId" class="hfl-error-details__trace">
+          <span>{{ t('errors.generic.traceId') }}</span>
+          <code>{{ details.traceId }}</code>
+        </div>
+        <pre v-if="rawText" class="hfl-error-details__raw">{{ rawText }}</pre>
+      </section>
+    </template>
+
+    <template v-if="details" #footer>
+      <div class="hfl-error-details__footer">
+        <button type="button" class="hfl-error-details__copy" @click="copyDetails">
+          <Check v-if="copied" :size="15" />
+          <Copy v-else :size="15" />
+          {{ copied ? t('feedback.toast.copied') : t('feedback.errorDetails.copy') }}
+        </button>
+        <ElButton type="primary" @click="closeErrorDetails">{{ t('common.confirm') }}</ElButton>
+      </div>
+    </template>
+  </ElDialog>
+</template>
+
+<style>
+.hfl-error-details.el-dialog { padding: 0; overflow: hidden; border-radius: 18px; }
+.hfl-error-details .el-dialog__header { padding: 0; margin: 0; }
+.hfl-error-details .el-dialog__body { max-height: min(62vh, 640px); padding: 2px 26px 10px; overflow-y: auto; }
+.hfl-error-details .el-dialog__footer { display: block; width: 100%; padding: 0; margin: 0; }
+.hfl-error-details__header { position: relative; display: flex; gap: 15px; padding: 24px 54px 18px 26px; }
+.hfl-error-details__icon { display: inline-flex; flex: 0 0 auto; width: 46px; height: 46px; align-items: center; justify-content: center; color: var(--color-error); background: var(--color-error-light); border-radius: 13px; }
+.hfl-error-details__heading { min-width: 0; padding-top: 1px; }
+.hfl-error-details__title-line { display: flex; flex-wrap: wrap; gap: 9px; align-items: center; }
+.hfl-error-details__title-line h2 { margin: 0; color: var(--color-text-title); font-size: 18px; font-weight: 700; line-height: 25px; }
+.hfl-error-details__heading p { margin: 4px 0 0; color: var(--color-text-secondary); font-size: 13px; line-height: 20px; }
+.hfl-error-details__code { padding: 3px 7px; color: var(--color-error); background: var(--color-error-light); border-radius: 6px; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 11px; overflow-wrap: anywhere; }
+.hfl-error-details__close { position: absolute; top: 18px; right: 18px; display: inline-flex; width: 30px; height: 30px; padding: 0; align-items: center; justify-content: center; color: var(--color-text-tertiary); background: transparent; border: 0; border-radius: 8px; cursor: pointer; }
+.hfl-error-details__close:hover { color: var(--color-text-primary); background: var(--color-grey-2); }
+.hfl-error-details__section + .hfl-error-details__section { margin-top: 20px; }
+.hfl-error-details__section h3 { margin: 0 0 8px; color: var(--color-text-tertiary); font-size: 11px; font-weight: 700; letter-spacing: .09em; text-transform: uppercase; }
+.hfl-error-details__issue { padding: 12px 14px; color: var(--color-error); background: color-mix(in srgb, var(--color-error-light) 76%, transparent); border: 1px solid color-mix(in srgb, var(--color-error) 20%, transparent); border-radius: 11px; font-size: 13px; line-height: 1.55; white-space: pre-wrap; overflow-wrap: anywhere; user-select: text; }
+.hfl-error-details__list { display: grid; gap: 10px; padding: 0; margin: 0; list-style: none; counter-reset: detail-item; }
+.hfl-error-details__list li { position: relative; min-height: 20px; padding-left: 31px; color: var(--color-text-primary); font-size: 13px; line-height: 20px; counter-increment: detail-item; }
+.hfl-error-details__list li::before { position: absolute; top: 0; left: 0; display: inline-flex; width: 20px; height: 20px; align-items: center; justify-content: center; content: counter(detail-item); color: var(--color-text-primary); background: var(--color-grey-2); border-radius: 6px; font-size: 11px; font-weight: 700; }
+.hfl-error-details__list--resolve li::before { content: '✓'; color: var(--color-success); background: var(--color-success-light); border-radius: 50%; }
+.hfl-error-details__trace { display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 8px; color: var(--color-text-secondary); font-size: 12px; }
+.hfl-error-details__trace code { color: var(--color-text-title); user-select: text; }
+.hfl-error-details__raw { max-height: 220px; padding: 12px 14px; margin: 0; overflow: auto; color: var(--color-text-primary); background: var(--color-grey-2); border: 1px solid var(--color-border-light); border-radius: 10px; font: 12px/1.55 ui-monospace, SFMono-Regular, Menlo, monospace; white-space: pre-wrap; overflow-wrap: anywhere; user-select: text; }
+.hfl-error-details__footer { display: flex; width: 100%; box-sizing: border-box; align-items: center; justify-content: space-between; gap: 12px; padding: 14px 26px; background: var(--color-grey-1); border-top: 1px solid var(--color-border-light); }
+.hfl-error-details__copy { display: inline-flex; gap: 7px; padding: 8px 0; align-items: center; color: var(--color-text-primary); background: transparent; border: 0; font-size: 12.5px; font-weight: 600; cursor: pointer; }
+.hfl-error-details__copy:hover { color: var(--color-primary); }
+</style>

--- a/src/frontend/src/components/feedback/HflToastItem.test.ts
+++ b/src/frontend/src/components/feedback/HflToastItem.test.ts
@@ -1,0 +1,126 @@
+// @vitest-environment jsdom
+
+import { mount } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import HflToastItem from './HflToastItem.vue'
+import { closeErrorDetails, errorDetailsState } from '../../lib/errors/details'
+import { pushToast, resetToastStoreForTests, toastState } from '../../lib/toast/store'
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: {
+    en: {
+      common: { close: 'Close' },
+      feedback: { toast: { copy: 'Copy', copied: 'Copied', viewDetails: 'View details', howToFix: 'How to fix' } },
+    },
+  },
+})
+
+describe('HflToastItem', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    resetToastStoreForTests()
+    closeErrorDetails()
+  })
+
+  afterEach(() => {
+    resetToastStoreForTests()
+    closeErrorDetails()
+    vi.useRealTimers()
+  })
+
+  it('pauses on hover and closes from the close button', async () => {
+    pushToast({ type: 'warning', title: 'Warning', message: 'Read this message' })
+    const toast = toastState.items[0]!
+    const wrapper = mount(HflToastItem, { props: { toast }, global: { plugins: [i18n] } })
+
+    await wrapper.trigger('mouseenter')
+    expect(toastState.items[0]?.paused).toBe(true)
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', bubbles: true }))
+    await wrapper.trigger('focusin')
+    await wrapper.trigger('mouseleave')
+    expect(toastState.items[0]?.paused).toBe(true)
+    await wrapper.trigger('focusout')
+    expect(toastState.items[0]?.paused).toBe(false)
+    await wrapper.get('[aria-label="Close"]').trigger('click')
+    expect(toastState.items).toHaveLength(0)
+  })
+
+  it('does not keep a toast paused after pointer focus leaves the toast', async () => {
+    pushToast({ type: 'info', message: 'Clickable message' })
+    const wrapper = mount(HflToastItem, {
+      props: { toast: toastState.items[0]! },
+      attachTo: document.body,
+      global: { plugins: [i18n] },
+    })
+
+    await wrapper.trigger('mouseenter')
+    wrapper.element.dispatchEvent(new Event('pointerdown', { bubbles: true }))
+    await wrapper.trigger('focusin')
+    await wrapper.trigger('mouseleave')
+    expect(toastState.items[0]?.paused).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('uses centered compact styling only for a single message', () => {
+    pushToast({ type: 'success', message: 'Policy updated.' })
+    const compact = mount(HflToastItem, {
+      props: { toast: toastState.items[0]! },
+      global: { plugins: [i18n] },
+    })
+    expect(compact.classes()).toContain('hfl-toast--compact')
+    compact.unmount()
+
+    resetToastStoreForTests()
+    pushToast({ type: 'error', title: 'Connection failed', message: 'Endpoint timed out' })
+    const detailed = mount(HflToastItem, {
+      props: { toast: toastState.items[0]! },
+      global: { plugins: [i18n] },
+    })
+    expect(detailed.classes()).not.toContain('hfl-toast--compact')
+  })
+
+  it('opens details and removes the summary toast', async () => {
+    pushToast({
+      type: 'error',
+      title: 'Connection failed',
+      message: 'Endpoint timed out',
+      details: {
+        title: 'Connection failed',
+        summary: 'Endpoint timed out',
+        errorCode: 'NETWORK.TIMEOUT',
+      },
+    })
+    const wrapper = mount(HflToastItem, {
+      props: { toast: toastState.items[0]! },
+      global: { plugins: [i18n] },
+    })
+
+    const detailsButton = wrapper.findAll('button').find((button) => button.text() === 'View details')
+    expect(detailsButton).toBeTruthy()
+    await detailsButton!.trigger('click')
+    expect(toastState.items).toHaveLength(0)
+    expect(errorDetailsState.current?.errorCode).toBe('NETWORK.TIMEOUT')
+  })
+
+  it('promotes actionable details as how-to-fix guidance', () => {
+    pushToast({
+      type: 'error',
+      title: 'Connection failed',
+      message: 'Endpoint timed out',
+      details: {
+        title: 'Connection failed',
+        summary: 'Endpoint timed out',
+        resolutions: ['Check the endpoint.'],
+      },
+    })
+    const wrapper = mount(HflToastItem, {
+      props: { toast: toastState.items[0]! },
+      global: { plugins: [i18n] },
+    })
+    expect(wrapper.text()).toContain('How to fix')
+    expect(wrapper.text()).not.toContain('View details')
+  })
+})

--- a/src/frontend/src/components/feedback/HflToastItem.vue
+++ b/src/frontend/src/components/feedback/HflToastItem.vue
@@ -1,0 +1,204 @@
+<script setup lang="ts">
+import { computed, onMounted, onUnmounted, ref } from 'vue'
+import { AlertTriangle, Check, Copy, Info, X } from 'lucide-vue-next'
+import { useI18n } from 'vue-i18n'
+import { copyTextToClipboard } from '../../lib/clipboard'
+import { openErrorDetails } from '../../lib/errors/details'
+import { closeToast, pauseToast, resumeToast, type ToastRecord } from '../../lib/toast/store'
+
+const props = defineProps<{ toast: ToastRecord }>()
+const { t } = useI18n()
+const copied = ref(false)
+const hovered = ref(false)
+const keyboardFocused = ref(false)
+let keyboardModality = false
+
+const icon = computed(() => {
+  if (props.toast.type === 'success') return Check
+  if (props.toast.type === 'warning' || props.toast.type === 'error') return AlertTriangle
+  return Info
+})
+
+const progress = computed(() => {
+  if (props.toast.duration === 0) return 100
+  return Math.max(0, Math.min(100, (props.toast.remainingMs / props.toast.duration) * 100))
+})
+
+const isCompact = computed(() => !props.toast.title && !props.toast.copyText && !props.toast.details)
+const detailsActionLabel = computed(() => (
+  props.toast.details?.resolutions?.length
+    ? t('feedback.toast.howToFix')
+    : t('feedback.toast.viewDetails')
+))
+
+async function copyDetails() {
+  if (!props.toast.copyText) return
+  await copyTextToClipboard(props.toast.copyText)
+  copied.value = true
+  window.setTimeout(() => { copied.value = false }, 1600)
+}
+
+function showDetails() {
+  if (!props.toast.details) return
+  const details = props.toast.details
+  closeToast(props.toast.id)
+  openErrorDetails(details)
+}
+
+function syncPauseState() {
+  if (hovered.value || keyboardFocused.value) pauseToast(props.toast.id)
+  else resumeToast(props.toast.id)
+}
+
+function onMouseEnter() {
+  hovered.value = true
+  syncPauseState()
+}
+
+function onMouseLeave() {
+  hovered.value = false
+  syncPauseState()
+}
+
+function onFocusIn() {
+  keyboardFocused.value = keyboardModality
+  syncPauseState()
+}
+
+function onFocusOut(event: FocusEvent) {
+  const root = event.currentTarget as HTMLElement
+  if (event.relatedTarget instanceof Node && root.contains(event.relatedTarget)) return
+  keyboardFocused.value = false
+  syncPauseState()
+}
+
+function onDocumentKeydown(event: KeyboardEvent) {
+  if (event.key === 'Tab') keyboardModality = true
+}
+
+function onDocumentPointerdown() {
+  keyboardModality = false
+  if (!keyboardFocused.value) return
+  keyboardFocused.value = false
+  syncPauseState()
+}
+
+onMounted(() => {
+  document.addEventListener('keydown', onDocumentKeydown, true)
+  document.addEventListener('pointerdown', onDocumentPointerdown, true)
+})
+
+onUnmounted(() => {
+  document.removeEventListener('keydown', onDocumentKeydown, true)
+  document.removeEventListener('pointerdown', onDocumentPointerdown, true)
+})
+</script>
+
+<template>
+  <article
+    class="hfl-toast"
+    :class="[`hfl-toast--${toast.type}`, { 'hfl-toast--compact': isCompact }]"
+    :data-toast-id="toast.id"
+    :role="toast.type === 'error' || toast.type === 'warning' ? 'alert' : 'status'"
+    tabindex="-1"
+    @mouseenter="onMouseEnter"
+    @mouseleave="onMouseLeave"
+    @focusin="onFocusIn"
+    @focusout="onFocusOut"
+  >
+    <span class="hfl-toast__icon" aria-hidden="true">
+      <component :is="icon" :size="18" />
+    </span>
+    <div class="hfl-toast__content">
+      <div v-if="toast.title" class="hfl-toast__title">
+        <span>{{ toast.title }}</span>
+        <span v-if="toast.repeatCount > 1" class="hfl-toast__repeat">×{{ toast.repeatCount }}</span>
+      </div>
+      <p class="hfl-toast__message">
+        {{ toast.message }}
+        <span v-if="!toast.title && toast.repeatCount > 1" class="hfl-toast__repeat">×{{ toast.repeatCount }}</span>
+      </p>
+      <div v-if="toast.copyText || toast.details" class="hfl-toast__actions">
+        <button v-if="toast.copyText" type="button" @click="copyDetails">
+          <Check v-if="copied" :size="13" />
+          <Copy v-else :size="13" />
+          {{ copied ? t('feedback.toast.copied') : t('feedback.toast.copy') }}
+        </button>
+        <button v-if="toast.details" type="button" @click="showDetails">
+          {{ detailsActionLabel }}
+        </button>
+      </div>
+    </div>
+    <button
+      type="button"
+      class="hfl-toast__close"
+      :aria-label="t('common.close')"
+      @click="closeToast(toast.id)"
+    >
+      <X :size="15" />
+    </button>
+    <span
+      v-if="toast.duration > 0"
+      class="hfl-toast__progress"
+      :style="{ width: `${progress}%` }"
+      aria-hidden="true"
+    />
+  </article>
+</template>
+
+<style scoped>
+.hfl-toast {
+  --toast-accent: var(--color-info, #3b82f6);
+  --toast-accent-soft: var(--color-info-light, #eff6ff);
+  position: relative;
+  display: grid;
+  grid-template-columns: 36px minmax(0, 1fr) 24px;
+  gap: 12px;
+  width: 372px;
+  max-width: calc(100vw - 32px);
+  overflow: hidden;
+  padding: 14px;
+  color: var(--color-text-title, #14233b);
+  background: var(--modal-bg, var(--color-card-bg, #fff));
+  border: 1px solid var(--color-border-light, #e6ebf2);
+  border-radius: 13px;
+  box-shadow: 0 16px 40px -12px rgba(16, 24, 40, 0.28);
+  pointer-events: auto;
+  animation: hfl-toast-in 220ms cubic-bezier(.2, .8, .2, 1);
+}
+
+.hfl-toast--success { --toast-accent: var(--color-success, #15a66a); --toast-accent-soft: var(--color-success-light, #e7f8f0); }
+.hfl-toast--warning { --toast-accent: var(--color-warning, #e7920e); --toast-accent-soft: var(--color-warning-light, #fef3e2); }
+.hfl-toast--error { --toast-accent: var(--color-error, #e5484d); --toast-accent-soft: var(--color-error-light, #fdecec); }
+
+.hfl-toast__icon {
+  display: inline-flex;
+  width: 36px;
+  height: 36px;
+  align-items: center;
+  justify-content: center;
+  color: var(--toast-accent);
+  background: var(--toast-accent-soft);
+  border-radius: 10px;
+}
+
+.hfl-toast__content { min-width: 0; }
+.hfl-toast__title { display: flex; align-items: center; gap: 7px; font-size: 13.5px; font-weight: 700; line-height: 20px; }
+.hfl-toast__message { margin: 0; color: var(--color-text-primary, #5a6b80); font-size: 12.5px; line-height: 1.5; overflow-wrap: anywhere; user-select: text; }
+.hfl-toast__title + .hfl-toast__message { margin-top: 2px; }
+.hfl-toast__repeat { display: inline-flex; flex: none; padding: 1px 6px; color: var(--toast-accent); background: var(--toast-accent-soft); border-radius: 999px; font-size: 10px; font-weight: 700; }
+.hfl-toast__actions { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 7px; }
+.hfl-toast__actions button { display: inline-flex; align-items: center; gap: 4px; padding: 0; color: var(--color-primary, #5c5cff); background: transparent; border: 0; font: inherit; font-size: 12px; font-weight: 600; cursor: pointer; }
+.hfl-toast__actions button:hover { text-decoration: underline; }
+.hfl-toast__close { display: inline-flex; width: 24px; height: 24px; padding: 0; align-items: center; justify-content: center; color: var(--color-text-tertiary, #a6b2c2); background: transparent; border: 0; border-radius: 6px; cursor: pointer; }
+.hfl-toast__close:hover, .hfl-toast__close:focus-visible { color: var(--color-text-primary, #5a6b80); background: var(--color-grey-2, #f2f5fa); }
+.hfl-toast__progress { position: absolute; bottom: 0; left: 0; height: 3px; background: var(--toast-accent); opacity: .58; transition: width 50ms linear; }
+
+.hfl-toast--compact .hfl-toast__icon,
+.hfl-toast--compact .hfl-toast__content,
+.hfl-toast--compact .hfl-toast__close { align-self: center; }
+.hfl-toast--compact .hfl-toast__message { font-weight: 600; line-height: 20px; }
+
+@keyframes hfl-toast-in { from { opacity: 0; transform: translateX(26px) scale(.97); } }
+@media (prefers-reduced-motion: reduce) { .hfl-toast { animation: none; } .hfl-toast__progress { transition: none; } }
+</style>

--- a/src/frontend/src/components/feedback/HflToastViewport.vue
+++ b/src/frontend/src/components/feedback/HflToastViewport.vue
@@ -1,0 +1,43 @@
+<script setup lang="ts">
+import HflToastItem from './HflToastItem.vue'
+import { toastState } from '../../lib/toast/store'
+</script>
+
+<template>
+  <div class="hfl-toast-viewport" aria-live="polite" aria-relevant="additions removals">
+    <TransitionGroup name="hfl-toast-list">
+      <HflToastItem v-for="toast in toastState.items" :key="toast.id" :toast="toast" />
+    </TransitionGroup>
+  </div>
+</template>
+
+<style scoped>
+.hfl-toast-viewport {
+  position: fixed;
+  top: 68px;
+  right: 16px;
+  z-index: 3000;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  align-items: flex-end;
+  max-height: calc(100vh - 84px);
+  pointer-events: none;
+}
+
+.hfl-toast-list-enter-active,
+.hfl-toast-list-leave-active,
+.hfl-toast-list-move { transition: opacity 180ms ease, transform 180ms ease; }
+.hfl-toast-list-enter-from,
+.hfl-toast-list-leave-to { opacity: 0; transform: translateX(20px); }
+
+@media (max-width: 640px) {
+  .hfl-toast-viewport { top: 64px; right: 16px; left: 16px; align-items: stretch; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hfl-toast-list-enter-active,
+  .hfl-toast-list-leave-active,
+  .hfl-toast-list-move { transition: none; }
+}
+</style>

--- a/src/frontend/src/composables/useAiModelForm.ts
+++ b/src/frontend/src/composables/useAiModelForm.ts
@@ -2,6 +2,7 @@ import { computed, reactive, ref, watch, type Ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { ElMessage } from 'element-plus'
 import { apiErrorMessage } from '../lib/api'
+import { openErrorDetails } from '../lib/errors/details'
 import { aiProviderLabel } from '../lib/aiProviderDisplay'
 import { defaultAiModelDisplayName } from '../lib/aiModelDisplay'
 import {
@@ -312,13 +313,31 @@ export function useAiModelForm(editingUuid: Ref<string | null>) {
         (res as { message?: string }).message ||
         (res as { detail?: string }).detail ||
         (ok ? t('insight.aiSettings.connectivityOk') : t('insight.aiSettings.connectivityFail', { detail: '' }))
-      if (ok) ElMessage.success({ message: t('insight.aiSettings.connectivityOk'), grouping: true })
-      else ElMessage.error({ message: testDetail.value, grouping: true })
+      if (ok) {
+        ElMessage.success({ message: t('insight.aiSettings.connectivityOk'), grouping: true })
+      } else {
+        openErrorDetails({
+          error: res,
+          overrides: {
+            title: t('insight.aiSettings.connectivityFail', { detail: '' }),
+            summary: testDetail.value,
+            issue: testDetail.value,
+            rawDetail: res,
+          },
+        })
+      }
       return ok
     } catch (err) {
       testOk.value = false
       testDetail.value = apiErrorMessage(err, t('insight.aiSettings.connectivityFail', { detail: '' }))
-      ElMessage.error({ message: testDetail.value, grouping: true })
+      openErrorDetails({
+        error: err,
+        overrides: {
+          title: t('insight.aiSettings.connectivityFail', { detail: '' }),
+          summary: testDetail.value,
+          issue: testDetail.value,
+        },
+      })
       return false
     } finally {
       testing.value = false

--- a/src/frontend/src/lib/errors/details.test.ts
+++ b/src/frontend/src/lib/errors/details.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  closeErrorDetails,
+  errorDetailsCopyText,
+  errorDetailsState,
+  openErrorDetails,
+  safeErrorDetailText,
+  toErrorDetails,
+} from './details'
+
+describe('error details', () => {
+  afterEach(closeErrorDetails)
+
+  it('maps structured application errors', () => {
+    const details = toErrorDetails({
+      status: 504,
+      message: 'Connection timed out',
+      errorCode: 'STORAGE.TIMEOUT',
+      traceId: 'trace-001',
+      detail: { endpoint: 'https://example.invalid' },
+    })
+
+    expect(details.errorCode).toBe('STORAGE.TIMEOUT')
+    expect(details.traceId).toBe('trace-001')
+    expect(details.issue).toBe('Connection timed out')
+  })
+
+  it('redacts secrets from objects and raw strings', () => {
+    const text = safeErrorDetailText({
+      endpoint: 'https://example.invalid',
+      secret_access_key: 'super-secret',
+      nested: { authorization: 'Bearer abc.def.ghi' },
+      raw: 'password=hunter2 token: abc123',
+    })
+
+    expect(text).toContain('https://example.invalid')
+    expect(text).not.toContain('super-secret')
+    expect(text).not.toContain('abc.def.ghi')
+    expect(text).not.toContain('hunter2')
+    expect(text).not.toContain('abc123')
+    expect(text).toContain('[REDACTED]')
+  })
+
+  it('redacts secrets embedded in the visible issue and copied text', () => {
+    const details = toErrorDetails(new Error('password=hunter2 request failed'))
+    expect(details.issue).not.toContain('hunter2')
+    expect(errorDetailsCopyText(details)).not.toContain('hunter2')
+  })
+
+  it('builds copyable diagnostic text and controls the global dialog state', () => {
+    const payload = {
+      title: 'Connection failed',
+      summary: 'Unable to connect',
+      errorCode: 'NETWORK.TIMEOUT',
+      traceId: 'trace-002',
+      issue: 'The endpoint timed out.',
+      reasons: ['The endpoint is offline.'],
+      resolutions: ['Check the endpoint.'],
+    }
+    openErrorDetails(payload)
+    expect(errorDetailsState.current?.errorCode).toBe('NETWORK.TIMEOUT')
+    expect(errorDetailsCopyText(payload)).toContain('How to resolve')
+    closeErrorDetails()
+    expect(errorDetailsState.current).toBeNull()
+  })
+})

--- a/src/frontend/src/lib/errors/details.ts
+++ b/src/frontend/src/lib/errors/details.ts
@@ -1,0 +1,109 @@
+import { reactive, readonly } from 'vue'
+import { normalizeThrownError } from './normalizer'
+import { resolveErrorMessage } from './resolver'
+
+export type ErrorDetailsPayload = {
+  title: string
+  summary: string
+  errorCode?: string
+  traceId?: string
+  issue?: string
+  reasons?: string[]
+  resolutions?: string[]
+  rawDetail?: unknown
+}
+
+export type ErrorDetailsOverrides = Partial<ErrorDetailsPayload>
+
+const SENSITIVE_KEY = /(authorization|cookie|password|passwd|secret|token|api[_-]?key|access[_-]?key|oauth[_-]?code|captcha)/i
+const MAX_COPY_DEPTH = 8
+
+function redactSensitiveText(value: string): string {
+  return value
+    .replace(/\bBearer\s+[A-Za-z0-9._~+/=-]+/gi, 'Bearer [REDACTED]')
+    .replace(
+      /((?:authorization|cookie|password|passwd|secret|token|api[_-]?key|access[_-]?key|oauth[_-]?code|captcha)\s*["']?\s*[:=]\s*)(["'][^"']*["']|[^\s,;}&]+)/gi,
+      '$1[REDACTED]',
+    )
+}
+
+function redactValue(value: unknown, depth = 0, seen = new WeakSet<object>()): unknown {
+  if (depth > MAX_COPY_DEPTH) return '[Truncated]'
+  if (value == null || typeof value === 'number' || typeof value === 'boolean') return value
+  if (typeof value === 'string') return redactSensitiveText(value)
+  if (typeof value !== 'object') return String(value)
+  if (seen.has(value)) return '[Circular]'
+  seen.add(value)
+
+  if (Array.isArray(value)) return value.map((item) => redactValue(item, depth + 1, seen))
+
+  const output: Record<string, unknown> = {}
+  for (const [key, item] of Object.entries(value as Record<string, unknown>)) {
+    output[key] = SENSITIVE_KEY.test(key) ? '[REDACTED]' : redactValue(item, depth + 1, seen)
+  }
+  return output
+}
+
+export function safeErrorDetailText(value: unknown): string {
+  if (value == null || value === '') return ''
+  if (typeof value === 'string') return redactSensitiveText(value)
+  try {
+    return JSON.stringify(redactValue(value), null, 2)
+  } catch {
+    return String(value)
+  }
+}
+
+export function toErrorDetails(error: unknown, overrides: ErrorDetailsOverrides = {}): ErrorDetailsPayload {
+  const normalized = normalizeThrownError(error)
+  const summary = overrides.summary || resolveErrorMessage(error, undefined, normalized.message || 'Request failed')
+  const normalizedCode = normalized.errorCode || normalized.code
+  return sanitizeErrorDetails({
+    title: overrides.title || summary || 'Operation failed',
+    summary: summary || 'Request failed',
+    errorCode: overrides.errorCode || (normalizedCode === 'UNKNOWN.ERROR' ? undefined : normalizedCode),
+    traceId: overrides.traceId || normalized.traceId,
+    issue: overrides.issue || summary,
+    reasons: overrides.reasons,
+    resolutions: overrides.resolutions,
+    rawDetail: overrides.rawDetail ?? normalized.detail,
+  })
+}
+
+function sanitizeErrorDetails(payload: ErrorDetailsPayload): ErrorDetailsPayload {
+  return {
+    ...payload,
+    title: redactSensitiveText(payload.title),
+    summary: redactSensitiveText(payload.summary),
+    issue: payload.issue ? redactSensitiveText(payload.issue) : undefined,
+    reasons: payload.reasons?.map(redactSensitiveText),
+    resolutions: payload.resolutions?.map(redactSensitiveText),
+  }
+}
+
+const detailsState = reactive<{ current: ErrorDetailsPayload | null }>({ current: null })
+
+export const errorDetailsState = readonly(detailsState)
+
+export function openErrorDetails(payload: ErrorDetailsPayload | { error: unknown; overrides?: ErrorDetailsOverrides }) {
+  detailsState.current = 'error' in payload
+    ? toErrorDetails(payload.error, payload.overrides)
+    : sanitizeErrorDetails(payload)
+}
+
+export function closeErrorDetails() {
+  detailsState.current = null
+}
+
+export function errorDetailsCopyText(payload: ErrorDetailsPayload): string {
+  const sections = [
+    payload.title,
+    payload.errorCode ? `Error code: ${payload.errorCode}` : '',
+    payload.traceId ? `Error ID: ${payload.traceId}` : '',
+    payload.issue ? `Issue:\n${payload.issue}` : '',
+    payload.reasons?.length ? `Possible reasons:\n${payload.reasons.map((item, index) => `${index + 1}. ${item}`).join('\n')}` : '',
+    payload.resolutions?.length ? `How to resolve:\n${payload.resolutions.map((item, index) => `${index + 1}. ${item}`).join('\n')}` : '',
+    safeErrorDetailText(payload.rawDetail) ? `Original details:\n${safeErrorDetailText(payload.rawDetail)}` : '',
+  ]
+  return redactSensitiveText(sections.filter(Boolean).join('\n\n'))
+}

--- a/src/frontend/src/lib/notify.test.ts
+++ b/src/frontend/src/lib/notify.test.ts
@@ -1,0 +1,65 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { closeErrorDetails, errorDetailsState } from './errors/details'
+import { notifyError } from './notify'
+import { resetToastStoreForTests, toastState } from './toast/store'
+
+describe('notify error presentation', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    resetToastStoreForTests()
+    closeErrorDetails()
+  })
+
+  afterEach(() => {
+    resetToastStoreForTests()
+    closeErrorDetails()
+    vi.useRealTimers()
+  })
+
+  const error = {
+    status: 503,
+    message: 'Endpoint unavailable',
+    errorCode: 'ENDPOINT.UNAVAILABLE',
+    traceId: 'trace-001',
+    detail: { endpoint: 'https://example.invalid' },
+  }
+
+  it('keeps supplemental details in a longer-lived toast', () => {
+    notifyError({
+      title: 'Save failed',
+      message: 'Endpoint unavailable',
+      error,
+      showDetails: true,
+    })
+
+    expect(toastState.items).toHaveLength(1)
+    expect(toastState.items[0]?.duration).toBe(12000)
+    expect(toastState.items[0]?.details?.errorCode).toBe('ENDPOINT.UNAVAILABLE')
+    expect(errorDetailsState.current).toBeNull()
+  })
+
+  it('opens blocking details directly without creating a toast', () => {
+    notifyError({
+      title: 'Connection failed',
+      message: 'Endpoint unavailable',
+      error,
+      showDetails: true,
+      detailsPresentation: 'dialog',
+    })
+
+    expect(toastState.items).toHaveLength(0)
+    expect(errorDetailsState.current?.errorCode).toBe('ENDPOINT.UNAVAILABLE')
+  })
+
+  it('avoids repeating the same title and message in a toast', () => {
+    notifyError({
+      title: 'Delete failed',
+      message: 'Delete failed',
+      error,
+      showDetails: true,
+    })
+    expect(toastState.items[0]?.title).toBeUndefined()
+  })
+})

--- a/src/frontend/src/lib/notify.ts
+++ b/src/frontend/src/lib/notify.ts
@@ -1,70 +1,60 @@
-import { ElMessage } from 'element-plus'
-import type {
-  MessageHandler,
-  MessageOptionsWithType,
-  MessageParamsWithType,
-  MessageType,
-} from 'element-plus'
+import type { ErrorDetailsOverrides } from './errors/details'
+import { errorDetailsCopyText, openErrorDetails, toErrorDetails } from './errors/details'
+import { pushToast, type ToastOptions, type ToastType } from './toast/store'
 
-type NotifyType = Extract<MessageType, 'success' | 'warning' | 'error' | 'info'>
-type NotifyDefaults = Pick<MessageOptionsWithType, 'duration' | 'showClose' | 'offset' | 'grouping'>
-
-const DEFAULTS: Record<NotifyType, NotifyDefaults> = {
-  success: { duration: 2200, showClose: false, offset: 72, grouping: true },
-  info: { duration: 2600, showClose: false, offset: 72, grouping: true },
-  warning: { duration: 3600, showClose: true, offset: 72, grouping: true },
-  error: { duration: 5000, showClose: true, offset: 72, grouping: true },
+export type NotifyOptions = Omit<ToastOptions, 'type' | 'message' | 'details'> & {
+  message: string
+  error?: unknown
+  errorDetails?: ErrorDetailsOverrides
+  showDetails?: boolean
+  detailsPresentation?: 'toast' | 'dialog'
 }
 
-const MESSAGE_OPTION_KEYS = [
-  'appendTo',
-  'customClass',
-  'dangerouslyUseHTMLString',
-  'duration',
-  'grouping',
-  'icon',
-  'message',
-  'offset',
-  'onClose',
-  'placement',
-  'plain',
-  'repeatNum',
-  'showClose',
-  'zIndex',
-]
+export type NotifyInput = string | NotifyOptions
+export type NotifyHandler = { close: () => void }
 
-function isMessageOptions(value: MessageParamsWithType): value is MessageOptionsWithType {
-  return Boolean(
-    value
-      && typeof value === 'object'
-      && !Array.isArray(value)
-      && MESSAGE_OPTION_KEYS.some((key) => key in value),
-  )
-}
+function notify(type: ToastType, input: NotifyInput = ''): NotifyHandler {
+  const options: NotifyOptions = typeof input === 'string' ? { message: input } : input
+  const toastTitle = options.title?.trim() === options.message.trim() ? undefined : options.title
+  const details = options.showDetails && options.error !== undefined
+    ? toErrorDetails(options.error, {
+        title: options.title,
+        summary: options.message,
+        ...options.errorDetails,
+      })
+    : undefined
 
-function notify(type: NotifyType, options?: MessageParamsWithType): MessageHandler {
-  const defaults = DEFAULTS[type]
-  if (isMessageOptions(options)) {
-    return ElMessage[type]({ ...defaults, ...options, grouping: true })
+  if (details && options.detailsPresentation === 'dialog') {
+    openErrorDetails(details)
+    return { close: () => undefined }
   }
 
-  return ElMessage[type]({ ...defaults, message: options ?? '', grouping: true })
+  return pushToast({
+    type,
+    title: toastTitle,
+    message: options.message,
+    dedupeKey: options.dedupeKey,
+    duration: options.duration ?? (details ? 12000 : undefined),
+    copyText: options.copyText || (details ? errorDetailsCopyText(details) : undefined),
+    details,
+    onClose: options.onClose,
+  })
 }
 
-export function notifySuccess(options?: MessageParamsWithType): MessageHandler {
-  return notify('success', options)
+export function notifySuccess(input?: NotifyInput): NotifyHandler {
+  return notify('success', input)
 }
 
-export function notifyWarning(options?: MessageParamsWithType): MessageHandler {
-  return notify('warning', options)
+export function notifyWarning(input?: NotifyInput): NotifyHandler {
+  return notify('warning', input)
 }
 
-export function notifyError(options?: MessageParamsWithType): MessageHandler {
-  return notify('error', options)
+export function notifyError(input?: NotifyInput): NotifyHandler {
+  return notify('error', input)
 }
 
-export function notifyInfo(options?: MessageParamsWithType): MessageHandler {
-  return notify('info', options)
+export function notifyInfo(input?: NotifyInput): NotifyHandler {
+  return notify('info', input)
 }
 
 export { notify }

--- a/src/frontend/src/lib/toast/store.test.ts
+++ b/src/frontend/src/lib/toast/store.test.ts
@@ -1,0 +1,94 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  closeToast,
+  pauseToast,
+  pushToast,
+  resetToastStoreForTests,
+  resumeToast,
+  toastState,
+} from './store'
+
+describe('toast store', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-07-20T00:00:00Z'))
+    resetToastStoreForTests()
+  })
+
+  afterEach(() => {
+    resetToastStoreForTests()
+    vi.useRealTimers()
+  })
+
+  it('closes a toast when its remaining time reaches zero', () => {
+    pushToast({ type: 'success', message: 'Saved', duration: 1000 })
+    expect(toastState.items).toHaveLength(1)
+
+    vi.advanceTimersByTime(950)
+    expect(toastState.items).toHaveLength(1)
+    vi.advanceTimersByTime(50)
+    expect(toastState.items).toHaveLength(0)
+  })
+
+  it('pauses and resumes from the actual remaining time', () => {
+    const handler = pushToast({ type: 'error', message: 'Failed', duration: 1000 })
+    const id = toastState.items[0]?.id
+    expect(id).toBeTruthy()
+
+    vi.advanceTimersByTime(400)
+    pauseToast(id!)
+    const remaining = toastState.items[0]?.remainingMs
+    expect(remaining).toBe(600)
+
+    vi.advanceTimersByTime(2000)
+    expect(toastState.items[0]?.remainingMs).toBe(600)
+    resumeToast(id!)
+    vi.advanceTimersByTime(550)
+    expect(toastState.items).toHaveLength(1)
+    vi.advanceTimersByTime(50)
+    expect(toastState.items).toHaveLength(0)
+
+    handler.close()
+  })
+
+  it('merges the same dedupe key, counts it, and resets its duration', () => {
+    pushToast({ type: 'warning', message: 'Still running', dedupeKey: 'task:1', duration: 1000 })
+    vi.advanceTimersByTime(700)
+    pushToast({ type: 'warning', message: 'Still running', dedupeKey: 'task:1', duration: 1000 })
+
+    expect(toastState.items).toHaveLength(1)
+    expect(toastState.items[0]?.repeatCount).toBe(2)
+    expect(toastState.items[0]?.remainingMs).toBe(1000)
+    vi.advanceTimersByTime(950)
+    expect(toastState.items).toHaveLength(1)
+  })
+
+  it('does not merge different resources', () => {
+    pushToast({ type: 'success', message: 'Copied', dedupeKey: 'copy:task-1' })
+    pushToast({ type: 'success', message: 'Copied', dedupeKey: 'copy:task-2' })
+    expect(toastState.items).toHaveLength(2)
+  })
+
+  it('limits the visible stack and prefers removing low-priority messages', () => {
+    pushToast({ type: 'error', message: 'Error 1', dedupeKey: 'e1' })
+    pushToast({ type: 'success', message: 'Success', dedupeKey: 's1' })
+    pushToast({ type: 'warning', message: 'Warning', dedupeKey: 'w1' })
+    pushToast({ type: 'error', message: 'Error 2', dedupeKey: 'e2' })
+    pushToast({ type: 'info', message: 'Newest', dedupeKey: 'i1' })
+
+    expect(toastState.items).toHaveLength(4)
+    expect(toastState.items.some((item) => item.dedupeKey === 's1')).toBe(false)
+    expect(toastState.items.some((item) => item.dedupeKey === 'e1')).toBe(true)
+  })
+
+  it('runs the close callback only when the toast closes', () => {
+    const onClose = vi.fn()
+    pushToast({ type: 'info', message: 'Info', onClose })
+    const id = toastState.items[0]!.id
+    expect(onClose).not.toHaveBeenCalled()
+    closeToast(id)
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/frontend/src/lib/toast/store.ts
+++ b/src/frontend/src/lib/toast/store.ts
@@ -1,0 +1,152 @@
+import { reactive, readonly } from 'vue'
+import type { ErrorDetailsPayload } from '../errors/details'
+
+export type ToastType = 'success' | 'info' | 'warning' | 'error'
+
+export type ToastOptions = {
+  type: ToastType
+  title?: string
+  message: string
+  dedupeKey?: string
+  duration?: number
+  copyText?: string
+  details?: ErrorDetailsPayload
+  onClose?: () => void
+}
+
+export type ToastRecord = ToastOptions & {
+  id: string
+  dedupeKey: string
+  duration: number
+  remainingMs: number
+  repeatCount: number
+  paused: boolean
+  lastTickAt: number
+  createdAt: number
+}
+
+const DEFAULT_DURATION: Record<ToastType, number> = {
+  success: 3000,
+  info: 4000,
+  warning: 6000,
+  error: 8000,
+}
+
+const MAX_VISIBLE = 4
+const state = reactive<{ items: ToastRecord[] }>({ items: [] })
+let sequence = 0
+let ticker: ReturnType<typeof setInterval> | undefined
+
+export const toastState = readonly(state)
+
+function now() {
+  return Date.now()
+}
+
+function stopTickerIfIdle() {
+  if (state.items.length || !ticker) return
+  clearInterval(ticker)
+  ticker = undefined
+}
+
+function tick() {
+  const current = now()
+  const expired: string[] = []
+  for (const item of state.items) {
+    if (item.paused || item.duration === 0) continue
+    const elapsed = Math.max(0, current - item.lastTickAt)
+    item.lastTickAt = current
+    item.remainingMs = Math.max(0, item.remainingMs - elapsed)
+    if (item.remainingMs === 0) expired.push(item.id)
+  }
+  expired.forEach(closeToast)
+}
+
+function ensureTicker() {
+  if (ticker || typeof window === 'undefined') return
+  ticker = window.setInterval(tick, 50)
+}
+
+function defaultDedupeKey(options: ToastOptions) {
+  return `${options.type}:${options.title || ''}:${options.message}`
+}
+
+function removeOverflow() {
+  while (state.items.length >= MAX_VISIBLE) {
+    const disposableIndex = state.items.findIndex((item) => item.type === 'success' || item.type === 'info')
+    const item = state.items[disposableIndex >= 0 ? disposableIndex : 0]
+    if (!item) return
+    closeToast(item.id)
+  }
+}
+
+export function pushToast(options: ToastOptions) {
+  const dedupeKey = options.dedupeKey || defaultDedupeKey(options)
+  const existing = state.items.find((item) => item.dedupeKey === dedupeKey)
+  const duration = options.duration ?? DEFAULT_DURATION[options.type]
+  const current = now()
+
+  if (existing) {
+    existing.title = options.title
+    existing.message = options.message
+    existing.copyText = options.copyText
+    existing.details = options.details
+    existing.duration = duration
+    existing.remainingMs = duration
+    existing.repeatCount += 1
+    existing.lastTickAt = current
+    return { close: () => closeToast(existing.id) }
+  }
+
+  removeOverflow()
+  const record: ToastRecord = {
+    ...options,
+    id: `hfl-toast-${++sequence}`,
+    dedupeKey,
+    duration,
+    remainingMs: duration,
+    repeatCount: 1,
+    paused: false,
+    lastTickAt: current,
+    createdAt: current,
+  }
+  state.items.unshift(record)
+  ensureTicker()
+  return { close: () => closeToast(record.id) }
+}
+
+export function closeToast(id: string) {
+  const index = state.items.findIndex((item) => item.id === id)
+  if (index < 0) return
+  const [item] = state.items.splice(index, 1)
+  item?.onClose?.()
+  stopTickerIfIdle()
+}
+
+export function pauseToast(id: string) {
+  const item = state.items.find((candidate) => candidate.id === id)
+  if (!item || item.paused) return
+  const current = now()
+  if (item.duration !== 0) {
+    item.remainingMs = Math.max(0, item.remainingMs - Math.max(0, current - item.lastTickAt))
+  }
+  item.lastTickAt = current
+  item.paused = true
+}
+
+export function resumeToast(id: string) {
+  const item = state.items.find((candidate) => candidate.id === id)
+  if (!item || !item.paused) return
+  item.paused = false
+  item.lastTickAt = now()
+  ensureTicker()
+}
+
+export function closeAllToasts() {
+  ;[...state.items].forEach((item) => closeToast(item.id))
+}
+
+export function resetToastStoreForTests() {
+  closeAllToasts()
+  sequence = 0
+}

--- a/src/frontend/src/locales/en.ts
+++ b/src/frontend/src/locales/en.ts
@@ -67,6 +67,21 @@ export const en = {
       restoreAlreadyRunning: 'A restore task is already running for this source.',
     },
   },
+  feedback: {
+    toast: {
+      copy: 'Copy',
+      copied: 'Copied',
+      viewDetails: 'View details',
+      howToFix: 'How to fix',
+    },
+    errorDetails: {
+      issue: 'Issue',
+      reasons: 'Possible reasons',
+      resolutions: 'How to resolve',
+      technical: 'Technical details',
+      copy: 'Copy error details',
+    },
+  },
   account: {
     userMenuAria: 'User menu',
     roleSuperAdmin: 'Super Admin',

--- a/src/frontend/src/pages/ops/NotificationChannels.vue
+++ b/src/frontend/src/pages/ops/NotificationChannels.vue
@@ -29,6 +29,8 @@ import { getNotificationTypeIcon } from '../../composables/useNotificationTypeIc
 import { formatLocalDateTime } from '../../lib/dateTime'
 import { booleanStatusTag, lifecycleStatusTagAttrs } from '../../lib/statusTag'
 import { apiErrorMessageI18n } from '../../lib/api'
+import { openErrorDetails } from '../../lib/errors/details'
+import { notifyError, notifySuccess } from '../../lib/notify'
 import {
   bulkDeleteChannels,
   bulkStateChannels,
@@ -458,9 +460,14 @@ async function executeDelete() {
     deleteDialogSource.value = null
     await fetchChannels()
   } catch (e: unknown) {
-    ElMessage.error({
-      message: apiErrorMessageI18n(e, t, t('ops.notification.deleteFailed')),
-      grouping: true,
+    const message = apiErrorMessageI18n(e, t, t('ops.notification.deleteFailed'))
+    notifyError({
+      title: t('ops.notification.deleteFailed'),
+      message,
+      dedupeKey: `notification-channel-delete:${state.row.id}`,
+      error: e,
+      errorDetails: { issue: message },
+      showDetails: true,
     })
   } finally {
     deleteDialogLoading.value = false
@@ -476,12 +483,29 @@ async function runTest(row: NotificationChannel) {
   try {
     const res = await testChannel(row.id)
     const ok = res.status === 'success'
-    if (ok) ElMessage.success({ message: t('ops.notification.testSuccess'), grouping: true })
-    else ElMessage.error({ message: res.error || t('ops.notification.testFailed'), grouping: true })
+    if (ok) {
+      notifySuccess({
+        message: t('ops.notification.testSuccess'),
+        dedupeKey: `notification-channel-test:${row.id}:success`,
+      })
+    } else {
+      const message = res.error || t('ops.notification.testFailed')
+      openErrorDetails({
+        title: t('ops.notification.testFailed'),
+        summary: message,
+        issue: message,
+        rawDetail: res,
+      })
+    }
   } catch (e: unknown) {
-    ElMessage.error({
-      message: apiErrorMessageI18n(e, t, t('ops.notification.testFailed')),
-      grouping: true,
+    const message = apiErrorMessageI18n(e, t, t('ops.notification.testFailed'))
+    openErrorDetails({
+      error: e,
+      overrides: {
+        title: t('ops.notification.testFailed'),
+        summary: message,
+        issue: message,
+      },
     })
   } finally {
     testing.value = false

--- a/src/frontend/src/pages/ops/Tasks.vue
+++ b/src/frontend/src/pages/ops/Tasks.vue
@@ -21,6 +21,7 @@ import { useResponsiveDrawerWidth } from '../../composables/useResponsiveDrawerW
 import { usePageRequestScope } from '../../composables/usePageRequestScope'
 import { apiErrorMessage } from '../../lib/api'
 import { copyTextToClipboard } from '../../lib/clipboard'
+import { notifyError, notifySuccess } from '../../lib/notify'
 import { formatLocalDateTime } from '../../lib/dateTime'
 import { formatTaskProgressBarPercent, formatTaskProgressPercent } from '../../lib/kopiaProgress'
 import { lifecycleStatusTagAttrs } from '../../lib/statusTag'
@@ -608,18 +609,30 @@ async function copyTaskUuid() {
   if (!activeTask.value?.task_uuid) return
   try {
     await copyTextToClipboard(activeTask.value.task_uuid)
-    ElMessage.success({ message: t('ops.task.msgCopied'), grouping: true })
+    notifySuccess({
+      message: t('ops.task.msgCopied'),
+      dedupeKey: `task-copy:${activeTask.value.task_uuid}`,
+    })
   } catch {
-    ElMessage.error({ message: t('ops.task.msgCopyFailed'), grouping: true })
+    notifyError({
+      message: t('ops.task.msgCopyFailed'),
+      dedupeKey: `task-copy-failed:${activeTask.value.task_uuid}`,
+    })
   }
 }
 
 async function copyPayload(value: unknown) {
   try {
     await copyTextToClipboard(formatJson(value))
-    ElMessage.success({ message: t('ops.task.msgCopiedPayload'), grouping: true })
+    notifySuccess({
+      message: t('ops.task.msgCopiedPayload'),
+      dedupeKey: `task-payload-copy:${activeTask.value?.task_uuid || 'unknown'}`,
+    })
   } catch {
-    ElMessage.error({ message: t('ops.task.msgCopyFailed'), grouping: true })
+    notifyError({
+      message: t('ops.task.msgCopyFailed'),
+      dedupeKey: `task-payload-copy-failed:${activeTask.value?.task_uuid || 'unknown'}`,
+    })
   }
 }
 

--- a/src/frontend/src/pages/protection/BackupCreateWizard.vue
+++ b/src/frontend/src/pages/protection/BackupCreateWizard.vue
@@ -53,6 +53,7 @@ import {
 } from '../../lib/resourceIcons'
 import { getEffectiveOrgKey } from '../../composables/useAuth'
 import { apiErrorMessage, apiErrorMessageI18n } from '../../lib/api'
+import { notifyError } from '../../lib/notify'
 import { logger } from '../../lib/logger'
 import {
   createBackupConfig,
@@ -201,12 +202,14 @@ function showBackupConfigCreateError(err: unknown, backupName: string, repositor
   const fallback = t('protection.backupsPage.createFailedWithName', { name: backupName })
   const message = apiErrorMessageI18n(err, t, fallback)
   if (!repositoryId || !isSmbMountNegotiationError(message)) {
-    ElMessage({
-      type: 'error',
+    notifyError({
+      title: t('protection.backupsPage.createFailed'),
       message,
       duration: 10000,
-      showClose: true,
-    grouping: true,
+      dedupeKey: `backup-config-create:${repositoryId || backupName}`,
+      error: err,
+      errorDetails: { issue: message },
+      showDetails: true,
     })
     return
   }

--- a/src/frontend/src/pages/protection/BackupSources.vue
+++ b/src/frontend/src/pages/protection/BackupSources.vue
@@ -37,6 +37,8 @@ import { getEffectiveOrgKey } from '../../composables/useAuth'
 import { apiErrorMessage, isAbortError } from '../../lib/api'
 import { formatAppDateTime } from '../../lib/dateTime'
 import { copyTextToClipboard } from '../../lib/clipboard'
+import { openErrorDetails } from '../../lib/errors/details'
+import { notifyInfo, notifySuccess } from '../../lib/notify'
 import { LIST_ROUTE_REFRESH_KEY, stripListRefreshQuery } from '../../lib/listRouteRefresh'
 import { buildGeneratedNasMountDir, buildGeneratedNasName } from '../../lib/nasMountPath'
 import { hasNasSourceNameConflict, resolveNasSubmitName } from '../../lib/nasSourceNaming'
@@ -563,12 +565,10 @@ async function onTest(row: SourceResource) {
   nasTestingId.value = row.id
   const startedAt = Date.now()
   let runningTitle = t('protection.sourceResources.testConnectionRunning')
-  let loadingMessage = ElMessage({
+  let loadingMessage = notifyInfo({
     message: runningTitle,
-    type: 'info',
     duration: 0,
-    showClose: false,
-  grouping: true,
+    dedupeKey: `source-connection-test:${row.id}`,
   })
   const controller = new AbortController()
   const timeoutId = window.setTimeout(() => controller.abort(), SOURCE_CONNECTION_TEST_TIMEOUT_MS)
@@ -584,12 +584,10 @@ async function onTest(row: SourceResource) {
       closeLoading()
       closedLoading = false
       runningTitle = t('protection.sourceResources.testConnectionRetrying')
-      loadingMessage = ElMessage({
+      loadingMessage = notifyInfo({
         message: runningTitle,
-        type: 'info',
         duration: 0,
-        showClose: false,
-      grouping: true,
+        dedupeKey: `source-connection-test:${row.id}`,
       })
       await sleep(2500)
       r = await testSourceConnection(row.id, { signal: controller.signal })
@@ -597,24 +595,25 @@ async function onTest(row: SourceResource) {
     await waitForMinTestFeedback(startedAt)
     closeLoading()
     if (r.success) {
-      showConnectionTestToast('success', t('protection.sourceResources.testOk'))
+      showConnectionTestSuccess(t('protection.sourceResources.testOk'), row.id)
     } else {
-      showConnectionTestToast('error', connectionTestFailureMessage(r))
+      showConnectionTestError(connectionTestFailureMessage(r), r.details ?? r)
     }
     void load()
   } catch (e) {
     await waitForMinTestFeedback(startedAt)
     closeLoading()
     if (isAbortError(e)) {
-      showConnectionTestToast('error', t('protection.sourceResources.testConnectionTimedOut'))
+      showConnectionTestError(t('protection.sourceResources.testConnectionTimedOut'))
     } else {
       const message = apiErrorMessage(e, t('protection.sourceResources.testFail'))
       const gatewayTimeout = /gateway time/i.test(message)
-      showConnectionTestToast(
-        'error',
+      showConnectionTestError(
         gatewayTimeout
           ? t('protection.sourceResources.testConnectionGatewayTimeout')
           : message,
+        undefined,
+        e,
       )
     }
   } finally {
@@ -863,14 +862,24 @@ async function waitForMinTestFeedback(startedAt: number) {
   if (remain > 0) await sleep(remain)
 }
 
-function showConnectionTestToast(type: 'success' | 'error', message: string) {
-  ElMessage({
-    type,
+function showConnectionTestSuccess(message: string, sourceId: number) {
+  notifySuccess({
     message,
     duration: SOURCE_CONNECTION_TEST_RESULT_TOAST_MS,
-    showClose: false,
-  grouping: true,
+    dedupeKey: `source-connection-test-result:success:${sourceId}`,
   })
+}
+
+function showConnectionTestError(message: string, rawDetail?: unknown, error?: unknown) {
+  const title = t('protection.sourceResources.testFail')
+  if (error !== undefined) {
+    openErrorDetails({
+      error,
+      overrides: { title, summary: message, issue: message, rawDetail },
+    })
+    return
+  }
+  openErrorDetails({ title, summary: message, issue: message, rawDetail })
 }
 const hostMoreActionsOpen = ref(false)
 const nasMoreActionsOpen = ref(false)

--- a/src/frontend/src/plugins/element-plus.ts
+++ b/src/frontend/src/plugins/element-plus.ts
@@ -56,31 +56,62 @@ import {
   ElSegmented,
 } from 'element-plus'
 import type { MessageHandler, MessageParamsWithType } from 'element-plus'
-
-function isEmptyMessage(options?: MessageParamsWithType): boolean {
-  if (options == null) return true
-  if (typeof options === 'string') return options.trim() === ''
-  if (typeof options === 'object' && 'message' in options) {
-    const message = options.message
-    return message == null || String(message).trim() === ''
-  }
-  return false
-}
+import { notifyError, notifyInfo, notifySuccess, notifyWarning, type NotifyHandler } from '../lib/notify'
 
 function noopMessageHandler(): MessageHandler {
   return { close: () => undefined } as MessageHandler
 }
 
-function installEmptyErrorMessageGuard() {
-  const originalError = ElMessage.error.bind(ElMessage)
-  ;(ElMessage as typeof ElMessage & { error: typeof ElMessage.error }).error = ((options?: MessageParamsWithType) => {
-    if (isEmptyMessage(options)) return noopMessageHandler()
-    return originalError(options)
-  }) as typeof ElMessage.error
+function bridgeMessageOptions(options?: MessageParamsWithType) {
+  if (options == null) return null
+  if (typeof options === 'string') return { message: options }
+  if (typeof options === 'object' && 'message' in options && typeof options.message === 'string') {
+    return {
+      message: options.message,
+      duration: options.duration,
+      onClose: options.onClose,
+    }
+  }
+  return null
+}
+
+function asMessageHandler(handler: NotifyHandler): MessageHandler {
+  return handler as MessageHandler
+}
+
+let toastMessageBridgeInstalled = false
+
+function installToastMessageBridge() {
+  if (toastMessageBridgeInstalled) return
+  toastMessageBridgeInstalled = true
+  const originals = {
+    success: ElMessage.success.bind(ElMessage),
+    info: ElMessage.info.bind(ElMessage),
+    warning: ElMessage.warning.bind(ElMessage),
+    error: ElMessage.error.bind(ElMessage),
+  }
+  const bridges = {
+    success: notifySuccess,
+    info: notifyInfo,
+    warning: notifyWarning,
+    error: notifyError,
+  }
+
+  for (const type of ['success', 'info', 'warning', 'error'] as const) {
+    ElMessage[type] = ((options?: MessageParamsWithType) => {
+      const normalized = bridgeMessageOptions(options)
+      if (!normalized) {
+        if (type === 'error' && options != null && String(options).trim() === '') return noopMessageHandler()
+        return originals[type](options)
+      }
+      if (!normalized.message.trim()) return noopMessageHandler()
+      return asMessageHandler(bridges[type](normalized))
+    }) as typeof ElMessage[typeof type]
+  }
 }
 
 export function setupElementPlus(app: App) {
-  installEmptyErrorMessageGuard()
+  installToastMessageBridge()
 
   // Register all Element Plus components
   const components = [


### PR DESCRIPTION
- Add a deduplicated toast stack with pauseable timers and Element Plus bridging
- Add redacted error details with copyable diagnostics and resolution guidance
- Apply richer feedback to connection tests, backups, notification channels, and tasks