### PR TITLE
fix: extend timeouts for large release assets

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -437,7 +437,7 @@ jobs:
 
   assemble-release:
     runs-on: ubuntu-24.04
-    timeout-minutes: 45
+    timeout-minutes: 90
     needs:
       - prepare
       - build-agent
@@ -482,7 +482,7 @@ jobs:
 
   verify-release:
     runs-on: ubuntu-24.04
-    timeout-minutes: 60
+    timeout-minutes: 120
     needs: [prepare, assemble-release]
     permissions:
       contents: write

--- a/.github/workflows/deploy_target.yml
+++ b/.github/workflows/deploy_target.yml
@@ -45,7 +45,7 @@ permissions:
 jobs:
   deploy:
     runs-on: ubuntu-24.04
-    timeout-minutes: 45
+    timeout-minutes: 120
     env:
       APP_PUBLIC_HOST: ${{ inputs.public_host }}
       DEPLOY_SSH_HOST: ${{ inputs.ssh_host }}

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -81,6 +81,15 @@ workflow="${ROOT}/.github/workflows/build_and_deploy.yml"
 	printf 'ERROR: tag release workflow is missing\n' >&2
 	exit 1
 }
+[[ "$(awk '/^  assemble-release:/{job=1} job && /timeout-minutes:/{print $2; exit}' "${workflow}")" == "90" ]] || {
+	printf 'ERROR: release assembly timeout must cover large GitHub asset uploads\n' >&2
+	exit 1
+}
+[[ "$(awk '/^  verify-release:/{job=1} job && /timeout-minutes:/{print $2; exit}' "${workflow}")" == "120" ]] || {
+	printf 'ERROR: release verification timeout must cover package download and offline install\n' >&2
+	exit 1
+}
+grep -F 'timeout-minutes: 120' "${ROOT}/.github/workflows/deploy_target.yml" >/dev/null
 if grep -F 'workflow_dispatch:' "${workflow}" >/dev/null; then
 	printf 'ERROR: release workflow must not allow manual dispatch\n' >&2
 	exit 1


### PR DESCRIPTION
## Summary
- allow 90 minutes for assembling and uploading the complete release package
- allow 120 minutes for package download, offline verification, and target deployment
- enforce these timeout budgets in release contract checks

## Evidence
The v0.1.1 assembly completed with 84 GB free, then its 1.5 GB upload ran from 10:04:58 to 10:48:51 and was canceled by the previous 45-minute job timeout.