### PR TITLE
fix: use lightweight worker health checks

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -524,6 +524,25 @@ jobs:
           echo "archive=$(realpath "$archive")" >> "$GITHUB_OUTPUT"
       - name: Full offline install and browser login smoke
         run: ./release/ci/verify-release.sh --archive "${{ steps.package.outputs.archive }}" --install
+      - name: Capture failed install diagnostics
+        if: failure()
+        shell: bash
+        run: |
+          set +e
+          if [[ -f /opt/hyperfilelens/docker-compose.yml ]]; then
+            sudo docker compose -f /opt/hyperfilelens/docker-compose.yml \
+              --env-file /opt/hyperfilelens/.env ps -a
+            sudo docker compose -f /opt/hyperfilelens/docker-compose.yml \
+              --env-file /opt/hyperfilelens/.env logs --no-color --tail 200
+          fi
+          if [[ -f /opt/hyperfilelens/sourcelens/docker-compose.yml ]]; then
+            sudo docker compose -f /opt/hyperfilelens/sourcelens/docker-compose.yml \
+              --env-file /opt/hyperfilelens/data/sourcelens/config/.env ps -a
+            sudo docker compose -f /opt/hyperfilelens/sourcelens/docker-compose.yml \
+              --env-file /opt/hyperfilelens/data/sourcelens/config/.env logs --no-color --tail 200
+          fi
+          sudo docker system df
+          df -h
 
   publish-release:
     runs-on: ubuntu-24.04

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -39,9 +39,13 @@ services:
     mem_limit: 320m
     cpus: 0.30
     healthcheck:
-      test: ["CMD-SHELL", "celery -A common inspect ping -t 2 >/dev/null 2>&1 || exit 1"]
+      test:
+        [
+          "CMD-SHELL",
+          "tr '\\0' ' ' </proc/1/cmdline | grep -Eq 'celery .*worker' && python -c \"import os,socket; pg_host=os.getenv('POSTGRES_HOST','postgres'); pg_port=int(os.getenv('POSTGRES_PORT','5432')); s=socket.socket(); s.settimeout(1); s.connect((pg_host,pg_port)); s.close(); s=socket.socket(); s.settimeout(1); s.connect(('redis',6379)); s.close()\"",
+        ]
       interval: 5s
-      timeout: 5s
+      timeout: 3s
       retries: 30
     logging:
       driver: "json-file"

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -90,6 +90,8 @@ workflow="${ROOT}/.github/workflows/build_and_deploy.yml"
 	exit 1
 }
 grep -F 'timeout-minutes: 120' "${ROOT}/.github/workflows/deploy_target.yml" >/dev/null
+grep -F 'Capture failed install diagnostics' "${workflow}" >/dev/null
+grep -F 'logs --no-color --tail 200' "${workflow}" >/dev/null
 if grep -F 'workflow_dispatch:' "${workflow}" >/dev/null; then
 	printf 'ERROR: release workflow must not allow manual dispatch\n' >&2
 	exit 1
@@ -121,6 +123,15 @@ grep -F 'npm run test:ci' "${workflow}" >/dev/null
 grep -F './tools/quality/test-ci-release-assembly.sh' "${workflow}" >/dev/null
 if grep -F 'uv run pytest src/backend' "${workflow}" >/dev/null; then
 	printf 'ERROR: backend CI must initialize Django through manage.py\n' >&2
+	exit 1
+fi
+
+worker_healthcheck="$(sed -n '/^  worker:/,/^  scheduler:/p' "${ROOT}/deploy/docker-compose.yml")"
+grep -F "/proc/1/cmdline" <<<"${worker_healthcheck}" >/dev/null
+grep -F "s.connect((pg_host,pg_port))" <<<"${worker_healthcheck}" >/dev/null
+grep -F "s.connect(('redis',6379))" <<<"${worker_healthcheck}" >/dev/null
+if grep -F 'celery -A common inspect ping' <<<"${worker_healthcheck}" >/dev/null; then
+	printf 'ERROR: worker healthcheck must not start another Django/Celery process\n' >&2
 	exit 1
 fi
 


### PR DESCRIPTION
## Summary
- replace the heavyweight Celery inspect worker health check with process and dependency socket checks
- preserve the 320 MiB worker limit and startup retry window
- capture Docker Compose logs and disk usage when full release verification fails
- enforce the health-check and diagnostics contracts in CI

## Validation
- reproduced the original unhealthy worker with the published 0.1.1 backend image
- verified the revised check becomes healthy under 320 MiB memory and 0.30 CPU with no OOM or restart
- passed release contract checks
- passed shared-host Docker guard checks
- passed synthetic CI release assembly
- parsed the workflow and Compose YAML