### PR TITLE
fix: route browser smoke through host gateway

### DIFF
--- a/tools/dev/browser-smoke.mjs
+++ b/tools/dev/browser-smoke.mjs
@@ -6,6 +6,7 @@ import { createRequire } from 'node:module'
 const require = createRequire('/smoke/package.json')
 const { chromium } = require('playwright')
 
+const smokeHost = process.env.SMOKE_HOST || 'host.docker.internal'
 const tenantPort = process.env.HFL_TENANT_PORT || '11443'
 const adminPort = process.env.HFL_ADMIN_PORT || '11444'
 const sourceLensPort = process.env.SOURCELENS_CONSOLE_PORT || '11445'
@@ -94,7 +95,7 @@ async function run() {
     const tenant = await browser.newContext({ ignoreHTTPSErrors: true })
     await waitForHflLogin(
       await tenant.newPage(),
-      `https://127.0.0.1:${tenantPort}`,
+      `https://${smokeHost}:${tenantPort}`,
       '/',
     )
     await tenant.close()
@@ -102,7 +103,7 @@ async function run() {
     const admin = await browser.newContext({ ignoreHTTPSErrors: true })
     await waitForHflLogin(
       await admin.newPage(),
-      `https://127.0.0.1:${adminPort}`,
+      `https://${smokeHost}:${adminPort}`,
       '/platform-ops',
     )
     await admin.close()
@@ -110,7 +111,7 @@ async function run() {
     const sourceLens = await browser.newContext({ ignoreHTTPSErrors: true })
     await waitForSourceLensLogin(
       await sourceLens.newPage(),
-      `https://127.0.0.1:${sourceLensPort}`,
+      `https://${smokeHost}:${sourceLensPort}`,
     )
     await sourceLens.close()
   } finally {

--- a/tools/dev/browser-smoke.sh
+++ b/tools/dev/browser-smoke.sh
@@ -45,12 +45,15 @@ fi
 cache_dir="${ROOT}/build/cache/playwright-node-${version}"
 mkdir -p "${cache_dir}"
 source_lens_env="${SMOKE_SOURCELENS_ENV_FILE:-${ROOT}/data/sourcelens/config/.env}"
+smoke_host="${SMOKE_HOST:-host.docker.internal}"
 
-docker run --rm --network host \
+docker run --rm \
+	--add-host host.docker.internal:host-gateway \
 	-v "${ROOT}:/workspace:ro" \
 	-v "${cache_dir}:/smoke" \
 	-e PLAYWRIGHT_VERSION="${version}" \
 	-e DEV_OFFLINE="${offline}" \
+	-e SMOKE_HOST="${smoke_host}" \
 	-e HFL_TENANT_PORT="$(read_default HFL_TENANT_PORT 11443)" \
 	-e HFL_ADMIN_PORT="$(read_default HFL_ADMIN_PORT 11444)" \
 	-e SOURCELENS_CONSOLE_PORT="$(read_default SOURCELENS_CONSOLE_PORT 11445)" \

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -207,6 +207,14 @@ grep -F 'HFL_TENANT_PORT=11443' "${ROOT}/.env.example" >/dev/null
 grep -F 'HFL_ADMIN_PORT=11444' "${ROOT}/.env.example" >/dev/null
 grep -F 'FRONTEND_URL=https://127.0.0.1:11443' "${ROOT}/.env.example" >/dev/null
 grep -F 'SOURCELENS_CONSOLE_PORT=11445' "${ROOT}/.env.example" >/dev/null
+smoke_runner="${ROOT}/tools/dev/browser-smoke.sh"
+grep -F -- '--add-host host.docker.internal:host-gateway' "${smoke_runner}" >/dev/null
+grep -F 'SMOKE_HOST' "${smoke_runner}" >/dev/null
+grep -F 'host.docker.internal' "${ROOT}/tools/dev/browser-smoke.mjs" >/dev/null
+if grep -F -- '--network host' "${smoke_runner}" >/dev/null; then
+	printf 'ERROR: browser smoke must reach published ports through host-gateway\n' >&2
+	exit 1
+fi
 grep -F 'image: hyperfilelens-postgres:17' "${ROOT}/deploy/docker-compose.yml" >/dev/null
 grep -F 'mem_limit: 448m' "${ROOT}/deploy/docker-compose.yml" >/dev/null
 grep -F 'name: hyperfilelens-sourcelens' \


### PR DESCRIPTION
## Summary
- run the Playwright smoke container on its default bridge network
- reach HFL and SourceLens published ports through Docker host-gateway
- keep all tenant, Platform Operations, and SourceLens login assertions unchanged
- add a release contract preventing a regression to host networking

## Evidence
- two clean GitHub verification runners completed the offline install and all service health gates, then failed identically when the Playwright host-network container opened port 11444
- same-version Playwright validated ports 11443, 11444, and 11445 through host.docker.internal mapped to host-gateway

## Validation
- shell and Node syntax checks
- release contract checks
- shared-host Docker guard checks
- synthetic CI release assembly