### PR TITLE
fix: wait for captcha in browser smoke

### DIFF
--- a/tools/dev/browser-smoke.mjs
+++ b/tools/dev/browser-smoke.mjs
@@ -37,20 +37,25 @@ async function waitForHflLogin(page, baseUrl, expectedPathPrefix) {
   await page.locator('input[autocomplete="email"]').fill(hflEmail)
   await page.locator('input[autocomplete="current-password"]').fill(hflPassword)
   const captchaImage = page.locator('.auth-captcha-field__image')
-  if (await captchaImage.isVisible()) {
-    const source = await captchaImage.getAttribute('src')
-    if (!source?.startsWith('data:image/svg+xml;base64,')) {
-      fail(`unexpected captcha image format at ${baseUrl}`)
-    }
-    const svg = Buffer.from(source.split(',', 2)[1], 'base64').toString('utf8')
-    const captcha = [...svg.matchAll(/<text[^>]*>([^<])<\/text>/g)]
-      .map(match => match[1])
-      .join('')
-    if (captcha.length !== 4) {
-      fail(`unable to read the development SVG captcha at ${baseUrl}`)
-    }
-    await page.locator('.auth-captcha-field__input input').fill(captcha)
+  try {
+    await captchaImage.waitFor({ state: 'visible', timeout: 30_000 })
+  } catch {
+    const captchaField = page.locator('.auth-captcha-field')
+    const details = await captchaField.innerText().catch(() => '')
+    fail(`image captcha did not become ready at ${baseUrl}: ${JSON.stringify(details)}`)
   }
+  const source = await captchaImage.getAttribute('src')
+  if (!source?.startsWith('data:image/svg+xml;base64,')) {
+    fail(`unexpected captcha image format at ${baseUrl}`)
+  }
+  const svg = Buffer.from(source.split(',', 2)[1], 'base64').toString('utf8')
+  const captcha = [...svg.matchAll(/<text[^>]*>([^<])<\/text>/g)]
+    .map(match => match[1])
+    .join('')
+  if (captcha.length !== 4) {
+    fail(`unable to read the development SVG captcha at ${baseUrl}`)
+  }
+  await page.locator('.auth-captcha-field__input input').fill(captcha)
   await page.locator('button.submit-btn').click()
   await page.waitForURL(url => !url.pathname.startsWith('/login'), { timeout: 60_000 })
   if (!page.url().includes(expectedPathPrefix)) {

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -210,7 +210,9 @@ grep -F 'SOURCELENS_CONSOLE_PORT=11445' "${ROOT}/.env.example" >/dev/null
 smoke_runner="${ROOT}/tools/dev/browser-smoke.sh"
 grep -F -- '--add-host host.docker.internal:host-gateway' "${smoke_runner}" >/dev/null
 grep -F 'SMOKE_HOST' "${smoke_runner}" >/dev/null
-grep -F 'host.docker.internal' "${ROOT}/tools/dev/browser-smoke.mjs" >/dev/null
+smoke_script="${ROOT}/tools/dev/browser-smoke.mjs"
+grep -F 'host.docker.internal' "${smoke_script}" >/dev/null
+grep -F 'captchaImage.waitFor' "${smoke_script}" >/dev/null
 if grep -F -- '--network host' "${smoke_runner}" >/dev/null; then
 	printf 'ERROR: browser smoke must reach published ports through host-gateway\n' >&2
 	exit 1


### PR DESCRIPTION
## Summary
- wait for the image captcha to become visible before reading and filling it
- fail with useful captcha-field details if it never becomes ready
- keep CAPTCHA_PROVIDER, Turnstile, login, and backend validation behavior unchanged
- enforce the readiness wait in release contracts

## Evidence
- v0.1.1 offline install completed with all services healthy
- host-gateway fixed the prior 11444 connection refusal
- Playwright reached the tenant form but raced captcha loading and skipped the one-time visibility check, leaving submit disabled

## Validation
- Node and shell syntax checks
- release contract checks
- shared-host Docker guard checks
- synthetic CI release assembly