### PR TITLE
fix: preserve external admin port redirects

### DIFF
--- a/deploy/nginx/default.conf
+++ b/deploy/nginx/default.conf
@@ -28,6 +28,8 @@ server {
 server {
     listen 10444 ssl;
     server_name _;
+    # Keep the externally published admin port when redirecting / to Platform Ops.
+    absolute_redirect off;
     access_log /var/log/hyperfilelens/nginx-access.log hfl_access;
     error_log  /var/log/hyperfilelens/nginx-error.log warn;
 

--- a/tools/dev/browser-smoke.mjs
+++ b/tools/dev/browser-smoke.mjs
@@ -37,12 +37,22 @@ async function waitForHflLogin(page, baseUrl, expectedPathPrefix) {
   await page.locator('input[autocomplete="email"]').fill(hflEmail)
   await page.locator('input[autocomplete="current-password"]').fill(hflPassword)
   const captchaImage = page.locator('.auth-captcha-field__image')
-  try {
-    await captchaImage.waitFor({ state: 'visible', timeout: 30_000 })
-  } catch {
-    const captchaField = page.locator('.auth-captcha-field')
-    const details = await captchaField.innerText().catch(() => '')
-    fail(`image captcha did not become ready at ${baseUrl}: ${JSON.stringify(details)}`)
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    try {
+      await captchaImage.waitFor({ state: 'visible', timeout: attempt === 0 ? 15_000 : 30_000 })
+      break
+    } catch {
+      if (attempt === 0) {
+        const captchaRefresh = page.locator('.auth-captcha-field__image-button')
+        if (await captchaRefresh.isVisible()) {
+          await captchaRefresh.click()
+          continue
+        }
+      }
+      const captchaField = page.locator('.auth-captcha-field')
+      const details = await captchaField.innerText().catch(() => '')
+      fail(`image captcha did not become ready at ${baseUrl}: ${JSON.stringify(details)}`)
+    }
   }
   const source = await captchaImage.getAttribute('src')
   if (!source?.startsWith('data:image/svg+xml;base64,')) {
@@ -64,6 +74,29 @@ async function waitForHflLogin(page, baseUrl, expectedPathPrefix) {
   await page.waitForTimeout(1_000)
   if (requireHmr && !webSockets.some(url => url.includes('/__vite_hmr'))) {
     fail(`dedicated Vite HMR WebSocket was not observed at ${baseUrl}`)
+  }
+}
+
+async function waitForPlatformOps(page, baseUrl) {
+  const unauthorized = []
+  page.on('response', response => {
+    if (response.status() === 401) unauthorized.push(response.url())
+  })
+
+  await page.goto(`${baseUrl}/`, { waitUntil: 'domcontentloaded' })
+  try {
+    await page.waitForURL(url => url.pathname.startsWith('/platform-ops'), { timeout: 60_000 })
+    await page.locator('.platform-ops-shell').waitFor({ state: 'visible', timeout: 60_000 })
+  } catch {
+    const body = (await page.locator('body').innerText().catch(() => '')).slice(0, 1_500)
+    const cookies = await page.context().cookies().then(items => items.map(item => item.name))
+    fail(
+      `Platform Operations did not become ready at ${page.url()}; `
+      + `cookies=${JSON.stringify(cookies)} body=${JSON.stringify(body)}`,
+    )
+  }
+  if (unauthorized.length) {
+    fail(`authenticated Platform Operations returned 401 response(s): ${unauthorized.join(', ')}`)
   }
 }
 
@@ -97,21 +130,17 @@ async function waitForSourceLensLogin(page, baseUrl) {
 async function run() {
   const browser = await chromium.launch({ headless: true })
   try {
-    const tenant = await browser.newContext({ ignoreHTTPSErrors: true })
+    const hfl = await browser.newContext({ ignoreHTTPSErrors: true })
     await waitForHflLogin(
-      await tenant.newPage(),
+      await hfl.newPage(),
       `https://${smokeHost}:${tenantPort}`,
       '/',
     )
-    await tenant.close()
-
-    const admin = await browser.newContext({ ignoreHTTPSErrors: true })
-    await waitForHflLogin(
-      await admin.newPage(),
+    await waitForPlatformOps(
+      await hfl.newPage(),
       `https://${smokeHost}:${adminPort}`,
-      '/platform-ops',
     )
-    await admin.close()
+    await hfl.close()
 
     const sourceLens = await browser.newContext({ ignoreHTTPSErrors: true })
     await waitForSourceLensLogin(

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -213,11 +213,15 @@ grep -F 'SMOKE_HOST' "${smoke_runner}" >/dev/null
 smoke_script="${ROOT}/tools/dev/browser-smoke.mjs"
 grep -F 'host.docker.internal' "${smoke_script}" >/dev/null
 grep -F 'captchaImage.waitFor' "${smoke_script}" >/dev/null
+grep -F 'captchaRefresh.click' "${smoke_script}" >/dev/null
+grep -F 'waitForPlatformOps' "${smoke_script}" >/dev/null
+grep -F 'const hfl = await browser.newContext' "${smoke_script}" >/dev/null
 if grep -F -- '--network host' "${smoke_runner}" >/dev/null; then
 	printf 'ERROR: browser smoke must reach published ports through host-gateway\n' >&2
 	exit 1
 fi
 grep -F 'image: hyperfilelens-postgres:17' "${ROOT}/deploy/docker-compose.yml" >/dev/null
+grep -F 'absolute_redirect off;' "${ROOT}/deploy/nginx/default.conf" >/dev/null
 grep -F 'mem_limit: 448m' "${ROOT}/deploy/docker-compose.yml" >/dev/null
 grep -F 'name: hyperfilelens-sourcelens' \
 	"${ROOT}/deploy/installer/sourcelens/docker-compose.template.yml" >/dev/null


### PR DESCRIPTION
## Summary
- keep relative Platform Operations redirects on the externally published 11444 port instead of leaking container port 10444
- retry image captcha loading through the real refresh control when initial loading fails
- reuse the authenticated HFL browser context to verify Platform Operations on the second port
- add detailed login diagnostics and release contracts

## Evidence
- formal 0.1.1 images passed captcha API generation and tenant login
- before the Nginx fix, / redirected to https://host:10444/platform-ops/monitoring/host
- with absolute_redirect off, tenant login and authenticated Platform Operations access both pass locally
- the isolated test then reaches the intentionally absent SourceLens 11445 boundary

## Validation
- Node and shell syntax checks
- release contract checks
- shared-host Docker guard checks
- synthetic CI release assembly
- isolated formal-image HFL tenant and Platform Operations login smoke