### PR TITLE
fix: align release smoke host validation

### DIFF
--- a/release/ci/verify-release.sh
+++ b/release/ci/verify-release.sh
@@ -64,7 +64,8 @@ available_kib="$(df -Pk / | awk 'NR == 2 {print $4}')"
 	exit 1
 }
 
-sudo env HFL_PUBLIC_HOST=127.0.0.1 HFL_SHOW_GENERATED_CREDENTIALS=0 \
+smoke_host="${SMOKE_HOST:-host.docker.internal}"
+sudo env HFL_PUBLIC_HOST="${smoke_host}" HFL_SHOW_GENERATED_CREDENTIALS=0 \
 	bash "${pkg_root}/install.sh" install
 
 deadline=$((SECONDS + 600))
@@ -85,6 +86,7 @@ done
 export HFL_TENANT_PORT=11443
 export HFL_ADMIN_PORT=11444
 export SOURCELENS_CONSOLE_PORT=11445
+export SMOKE_HOST="${smoke_host}"
 export SEED_ADMIN_EMAIL
 export SEED_ADMIN_PASSWORD
 SEED_ADMIN_EMAIL="$(sed -n 's/^SEED_ADMIN_EMAIL=//p' /opt/hyperfilelens/.env | head -1)"

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -182,6 +182,11 @@ if grep -E 'tomllib|extractall\([^)]*filter=' "${installer}" >/dev/null; then
 	printf 'ERROR: installer contains Python APIs unavailable on Ubuntu 20.04\n' >&2
 	exit 1
 fi
+
+release_verifier="${ROOT}/release/ci/verify-release.sh"
+grep -F 'smoke_host="${SMOKE_HOST:-host.docker.internal}"' "${release_verifier}" >/dev/null
+grep -F 'HFL_PUBLIC_HOST="${smoke_host}"' "${release_verifier}" >/dev/null
+grep -F 'export SMOKE_HOST="${smoke_host}"' "${release_verifier}" >/dev/null
 grep -F 'cp "${ROOT}/tools/config/sync_env.py" "${pkg_root}/sync-env.py"' \
 	"${ROOT}/release/ci/assemble-release.sh" >/dev/null
 fingerprint_body="$(sed -n '/^sourcelens_bundle_fingerprint()/,/^}/p' "${installer}")"


### PR DESCRIPTION
## Summary
- configure the release installer with the same host used by the containerized browser smoke
- export the resolved smoke host for the browser runner
- add release contract coverage for the host alignment

## Validation
- `bash -n release/ci/verify-release.sh tools/quality/check-release-contracts.sh`
- `./tools/quality/check-release-contracts.sh`
- `shellcheck release/ci/verify-release.sh tools/quality/check-release-contracts.sh` (when installed)
- `git diff --check`

## Failure evidence
Run 29750398496 completed the offline install and all health gates, then Django rejected `Host: host.docker.internal:11443` with `DisallowedHost` because verification installed with `HFL_PUBLIC_HOST=127.0.0.1`.