### PR TITLE
fix: generate valid DNS certificate SANs

### DIFF
--- a/deploy/installer/install.sh
+++ b/deploy/installer/install.sh
@@ -537,7 +537,7 @@ ensure_tls_certs() {
 			san_ip="IP:127.0.0.1,IP:::1,IP:${env_ip}"
 		fi
 		if [[ -n "${env_dns}" ]]; then
-			san_dns="DNS:localhost,${env_dns}"
+			san_dns="DNS:localhost,DNS:${env_dns}"
 		fi
 	fi
 	openssl req -x509 -newkey rsa:2048 -sha256 -days 3650 -nodes \

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -172,6 +172,7 @@ installer="${ROOT}/deploy/installer/install.sh"
 grep -F 'PUBLIC_HOST="${HFL_PUBLIC_HOST:-}"' "${installer}" >/dev/null
 grep -F 'values are hidden in non-interactive logs' "${installer}" >/dev/null
 grep -F 'admin_pass="Hfl-0$(random_hex | cut -c1-14)!"' "${installer}" >/dev/null
+grep -F 'san_dns="DNS:localhost,DNS:${env_dns}"' "${installer}" >/dev/null
 grep -F 'apply_upgrade_files "${src_root}" "${remove_sourcelens}"' "${installer}" >/dev/null
 grep -F 'python3 "${sync_script}" --env-file "${env_file}" --example "${example}"' "${installer}" >/dev/null
 grep -F 'host must be Ubuntu 20.04 or 24.04' "${installer}" >/dev/null


### PR DESCRIPTION
## Summary
- prefix every configured DNS subject alternative name with `DNS:`
- add release contract coverage for DNS SAN formatting

## Validation
- installer and release-contract shell syntax
- `./tools/quality/check-release-contracts.sh`
- real OpenSSL certificate generation and SAN inspection
- `git diff --check`

## Failure evidence
Release run 29752740666 reached certificate generation with `HFL_PUBLIC_HOST=host.docker.internal`, where OpenSSL rejected `DNS:localhost,host.docker.internal`. The valid extension is `DNS:localhost,DNS:host.docker.internal`.