### PR TITLE
fix(build): honor package mirrors while preserving locked dependency integrity

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,10 +193,16 @@ options. For example:
 ./dev/stack.sh up \
   --github-download-mirror https://ghfast.top \
   --docker-download-mirror docker.m.daocloud.io \
-  --apt-mirror https://mirrors.tuna.tsinghua.edu.cn
+  --apt-mirror https://mirrors.tuna.tsinghua.edu.cn \
+  --go-proxy https://goproxy.cn,direct \
+  --go-sumdb sum.golang.google.cn \
+  --pip-index-url https://pypi.tuna.tsinghua.edu.cn/simple \
+  --npm-registry https://registry.npmmirror.com
 ```
 
 Third-party mirrors are examples only and are never enabled automatically.
+The backend keeps `uv.lock` as the single dependency lock and uses the selected
+Python index only to download hash-verified packages exported from that lock.
 
 ## SourceLens Integration
 

--- a/deploy/docker/backend.Dockerfile
+++ b/deploy/docker/backend.Dockerfile
@@ -14,7 +14,6 @@ ENV DEBIAN_FRONTEND=noninteractive \
     PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
     PIP_DISABLE_PIP_VERSION_CHECK=1 \
-    PIP_NO_CACHE_DIR=1 \
     PIP_DEFAULT_TIMEOUT=${PIP_TIMEOUT} \
     TZ=UTC \
     VIRTUAL_ENV=/opt/venv \
@@ -24,8 +23,14 @@ ENV DEBIAN_FRONTEND=noninteractive \
     PATH="/opt/venv/bin:${PATH}"
 
 RUN if [ -n "${APT_MIRROR}" ]; then \
+      apt-get update && \
+      apt-get install -y --no-install-recommends ca-certificates && \
       sed -i "s|http://archive.ubuntu.com/ubuntu/|${APT_MIRROR%/}/ubuntu/|g" /etc/apt/sources.list && \
       sed -i "s|http://security.ubuntu.com/ubuntu/|${APT_MIRROR%/}/ubuntu/|g" /etc/apt/sources.list ; \
+      if [ -f /etc/apt/sources.list.d/ubuntu.sources ]; then \
+        sed -i "s|http://archive.ubuntu.com/ubuntu/|${APT_MIRROR%/}/ubuntu/|g; s|http://security.ubuntu.com/ubuntu/|${APT_MIRROR%/}/ubuntu/|g" \
+          /etc/apt/sources.list.d/ubuntu.sources ; \
+      fi ; \
     fi \
  && apt-get update \
  && apt-get install -y --no-install-recommends \
@@ -61,12 +66,11 @@ RUN --mount=type=cache,target=/root/.cache/pip \
  && pip --version \
  && PIP_CACHE_DIR=/root/.cache/pip pip install --retries 15 --timeout "${PIP_TIMEOUT}" "uv==0.10.2" \
  && cd /tmp/backend-project \
- && if [ -n "${PIP_INDEX_URL}" ]; then export UV_DEFAULT_INDEX="${PIP_INDEX_URL}"; fi \
- && if [ -n "${PIP_TRUSTED_HOST}" ]; then export UV_INSECURE_HOST="${PIP_TRUSTED_HOST}"; fi \
- && uv sync --locked --no-dev --no-install-project --inexact \
+ && uv export --quiet --locked --no-dev --no-emit-project --output-file /tmp/runtime-requirements.txt \
+ && PIP_CACHE_DIR=/root/.cache/pip pip install --retries 15 --timeout "${PIP_TIMEOUT}" --require-hashes -r /tmp/runtime-requirements.txt \
  && uv export --quiet --locked --only-group dev --no-emit-project --output-file /tmp/dev-requirements.txt \
  && pip uninstall -y uv \
- && rm -rf /tmp/backend-project
+ && rm -rf /tmp/backend-project /tmp/runtime-requirements.txt
 
 # Local development keeps dependencies in the image and bind-mounts src/backend.
 # watchfiles restarts API, worker, and scheduler processes after Python changes.

--- a/dev/stack.sh
+++ b/dev/stack.sh
@@ -112,7 +112,14 @@ Examples:
   ./dev/stack.sh down
   ./dev/stack.sh restart
   ./dev/stack.sh restart --force
-  ./dev/stack.sh up --github-download-mirror https://ghfast.top --docker-download-mirror docker.m.daocloud.io --apt-mirror https://mirrors.tuna.tsinghua.edu.cn
+  ./dev/stack.sh up \
+    --github-download-mirror https://ghfast.top \
+    --docker-download-mirror docker.m.daocloud.io \
+    --apt-mirror https://mirrors.tuna.tsinghua.edu.cn \
+    --go-proxy https://goproxy.cn,direct \
+    --go-sumdb sum.golang.google.cn \
+    --pip-index-url https://pypi.tuna.tsinghua.edu.cn/simple \
+    --npm-registry https://registry.npmmirror.com
 USAGE
 }
 

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -135,6 +135,20 @@ if grep -F 'celery -A common inspect ping' <<<"${worker_healthcheck}" >/dev/null
 	exit 1
 fi
 
+backend_dockerfile="${ROOT}/deploy/docker/backend.Dockerfile"
+grep -F '/etc/apt/sources.list.d/ubuntu.sources' "${backend_dockerfile}" >/dev/null
+grep -F 'uv export --quiet --locked --no-dev --no-emit-project --output-file /tmp/runtime-requirements.txt' \
+	"${backend_dockerfile}" >/dev/null
+grep -F -- '--require-hashes -r /tmp/runtime-requirements.txt' "${backend_dockerfile}" >/dev/null
+if grep -F 'UV_DEFAULT_INDEX' "${backend_dockerfile}" >/dev/null; then
+	printf 'ERROR: backend build must not bind the official uv.lock to a download mirror\n' >&2
+	exit 1
+fi
+if grep -F 'PIP_NO_CACHE_DIR' "${backend_dockerfile}" >/dev/null; then
+	printf 'ERROR: backend build must not disable its BuildKit-managed pip cache\n' >&2
+	exit 1
+fi
+
 sourcelens_image_builder="${ROOT}/release/ci/build-sourcelens-image.sh"
 grep -F 'target_ref="${registry_prefix}/hyperfilelens-sourcelens-${component}:${hfl_version}-sl${SOURCELENS_VERSION}"' \
 	"${sourcelens_image_builder}" >/dev/null


### PR DESCRIPTION
## Summary
- keep the official `uv.lock` as the single dependency lock while allowing pip download mirrors
- enable the BuildKit-managed pip cache without embedding it in release images
- support Ubuntu 24.04 deb822 apt mirrors and document the complete domestic mirror command
- add release contract checks for the mirror and cache behavior

## Validation
- `./tools/quality/check-release-contracts.sh`
- `git diff --check`
- `uv export --locked` with the Tsinghua pip index configured
- `docker build --check --network=none -f deploy/docker/backend.Dockerfile .`
- real backend dependency/development Docker builds with Tsinghua apt and PyPI mirrors
- `pip check` inside the verification image