### PR TITLE
fix: enforce development port migration

### DIFF
--- a/src/frontend/vite.config.ts
+++ b/src/frontend/vite.config.ts
@@ -24,6 +24,7 @@ export default defineConfig(() => ({
   },
   server: {
     host: '0.0.0.0',
+    allowedHosts: ['host.docker.internal'],
     port: 5173,
     strictPort: true,
     hmr: {

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -227,6 +227,17 @@ grep -F 'HFL_TENANT_PORT=11443' "${ROOT}/.env.example" >/dev/null
 grep -F 'HFL_ADMIN_PORT=11444' "${ROOT}/.env.example" >/dev/null
 grep -F 'FRONTEND_URL=https://127.0.0.1:11443' "${ROOT}/.env.example" >/dev/null
 grep -F 'SOURCELENS_CONSOLE_PORT=11445' "${ROOT}/.env.example" >/dev/null
+legacy_public_port_pattern='104(43|45|46)'
+if git -C "${ROOT}" grep -n -E "${legacy_public_port_pattern}" -- .; then
+	printf 'ERROR: tracked HFL files must not reference legacy 104xx public ports\n' >&2
+	exit 1
+fi
+for runtime_alias in \
+	'nginx:stable-alpine hyperfilelens-sourcelens-nginx:stable-alpine' \
+	'postgres:17 hyperfilelens-postgres:17' \
+	'redis:alpine hyperfilelens-redis:alpine'; do
+	grep -F "${runtime_alias}" "${ROOT}/tools/sourcelens/common.sh" >/dev/null
+done
 smoke_runner="${ROOT}/tools/dev/browser-smoke.sh"
 grep -F -- '--add-host host.docker.internal:host-gateway' "${smoke_runner}" >/dev/null
 grep -F 'SMOKE_HOST' "${smoke_runner}" >/dev/null
@@ -236,6 +247,7 @@ grep -F 'captchaImage.waitFor' "${smoke_script}" >/dev/null
 grep -F 'captchaRefresh.click' "${smoke_script}" >/dev/null
 grep -F 'waitForPlatformOps' "${smoke_script}" >/dev/null
 grep -F 'const hfl = await browser.newContext' "${smoke_script}" >/dev/null
+grep -F "allowedHosts: ['host.docker.internal']" "${ROOT}/src/frontend/vite.config.ts" >/dev/null
 if grep -F -- '--network host' "${smoke_runner}" >/dev/null; then
 	printf 'ERROR: browser smoke must reach published ports through host-gateway\n' >&2
 	exit 1

--- a/tools/sourcelens/common.sh
+++ b/tools/sourcelens/common.sh
@@ -1013,9 +1013,19 @@ sourcelens_ensure_runtime_image() {
 
 sourcelens_ensure_runtime_images() {
 	local force_pull=${1:-${SOURCELENS_FORCE_PULL}}
-	local image
+	local image source_ref target_ref
 	for image in nginx:stable-alpine postgres:17 redis:alpine; do
 		sourcelens_ensure_runtime_image "${image}" "${force_pull}"
+	done
+	for image in \
+		"nginx:stable-alpine hyperfilelens-sourcelens-nginx:stable-alpine" \
+		"postgres:17 hyperfilelens-postgres:17" \
+		"redis:alpine hyperfilelens-redis:alpine"; do
+		source_ref=${image%% *}
+		target_ref=${image#* }
+		docker tag "${source_ref}" "${target_ref}" \
+			|| sourcelens_die "unable to tag runtime image ${source_ref} as ${target_ref}"
+		sourcelens_log "Tagged runtime image ${source_ref} -> ${target_ref}"
 	done
 }
 


### PR DESCRIPTION
## Summary
- normalize official runtime images to the HFL aliases used by bundled SourceLens dev compose
- allow the pinned Playwright bridge host in Vite without disabling host validation
- fail release contracts if tracked HFL files reintroduce legacy 104xx public ports

## Validation
- `./dev/stack.sh restart`
- `./dev/stack.sh doctor`
- `./dev/stack.sh smoke`
- tenant login on 11443
- Platform Operations session on 11444
- SourceLens login on 11445
- frontend TypeScript/production build
- release contracts, ShellCheck, and `git diff --check`
- no tracked or runtime references to 10443, 10445, or 10446

SourceLens upstream source was not modified.