### PR TITLE
chore: clarify GitHub Actions workflow names

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -1,4 +1,5 @@
-name: Build, Release, and Deploy
+name: HFL - Release Pipeline
+run-name: Release ${{ github.ref_name }}
 
 on:
   push:

--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -1,4 +1,5 @@
-name: Deploy Published Release
+name: HFL - Manual Release Deployment
+run-name: Deploy ${{ inputs.tag }} to ${{ inputs.target }}
 
 on:
   workflow_dispatch:

--- a/.github/workflows/deploy_target.yml
+++ b/.github/workflows/deploy_target.yml
@@ -1,4 +1,4 @@
-name: Deploy HFL target
+name: HFL - Target Deployment (Reusable)
 
 on:
   workflow_call:


### PR DESCRIPTION
## Summary

- rename the tag-triggered workflow to `HFL - Release Pipeline`
- identify the deployment building block as `HFL - Target Deployment (Reusable)`
- rename the manual entry point to `HFL - Manual Release Deployment`
- add dynamic run names for tag releases and manual deployments
- preserve workflow file paths, triggers, jobs, inputs, and deployment behavior

## Validation

- parsed all workflow YAML files
- passed release contract checks
- passed `git diff --check`

No release tag is created by this PR.