### PR TITLE
fix(release): read protected env during smoke validation

### DIFF
--- a/release/ci/verify-release.sh
+++ b/release/ci/verify-release.sh
@@ -109,9 +109,18 @@ export SOURCELENS_CONSOLE_PORT=11445
 export SMOKE_HOST="${smoke_host}"
 export SEED_ADMIN_EMAIL
 export SEED_ADMIN_PASSWORD
-SEED_ADMIN_EMAIL="$(sed -n 's/^SEED_ADMIN_EMAIL=//p' /opt/hyperfilelens/.env | head -1)"
-SEED_ADMIN_PASSWORD="$(sed -n 's/^SEED_ADMIN_PASSWORD=//p' /opt/hyperfilelens/.env | head -1)"
+SEED_ADMIN_EMAIL="$(sudo sed -n 's/^SEED_ADMIN_EMAIL=//p' /opt/hyperfilelens/.env | head -1)"
+SEED_ADMIN_PASSWORD="$(sudo sed -n 's/^SEED_ADMIN_PASSWORD=//p' /opt/hyperfilelens/.env | head -1)"
 export SMOKE_REQUIRE_HMR=0
 export SMOKE_SOURCELENS_ENV_FILE=/opt/hyperfilelens/data/sourcelens/config/.env
-"${ROOT}/tools/dev/browser-smoke.sh"
+sudo env \
+	HFL_TENANT_PORT="${HFL_TENANT_PORT}" \
+	HFL_ADMIN_PORT="${HFL_ADMIN_PORT}" \
+	SOURCELENS_CONSOLE_PORT="${SOURCELENS_CONSOLE_PORT}" \
+	SMOKE_HOST="${SMOKE_HOST}" \
+	SEED_ADMIN_EMAIL="${SEED_ADMIN_EMAIL}" \
+	SEED_ADMIN_PASSWORD="${SEED_ADMIN_PASSWORD}" \
+	SMOKE_REQUIRE_HMR="${SMOKE_REQUIRE_HMR}" \
+	SMOKE_SOURCELENS_ENV_FILE="${SMOKE_SOURCELENS_ENV_FILE}" \
+	"${ROOT}/tools/dev/browser-smoke.sh"
 printf 'Full release install and login verification passed\n'

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -204,6 +204,8 @@ release_verifier="${ROOT}/release/ci/verify-release.sh"
 grep -F 'smoke_host="${SMOKE_HOST:-host.docker.internal}"' "${release_verifier}" >/dev/null
 grep -F 'HFL_PUBLIC_HOST="${smoke_host}"' "${release_verifier}" >/dev/null
 grep -F 'export SMOKE_HOST="${smoke_host}"' "${release_verifier}" >/dev/null
+grep -F 'SEED_ADMIN_EMAIL="$(sudo sed' "${release_verifier}" >/dev/null
+grep -F 'sudo env \' "${release_verifier}" >/dev/null
 grep -F 'cp "${ROOT}/tools/config/sync_env.py" "${pkg_root}/sync-env.py"' \
 	"${ROOT}/release/ci/assemble-release.sh" >/dev/null
 grep -F 'stage_default_tls_bundle "${pkg_root}"' \


### PR DESCRIPTION
## Problem

The v0.1.2 release package installed successfully and all HFL/SourceLens health gates passed, but `verify-release` then failed because the unprivileged GitHub runner tried to read `/opt/hyperfilelens/.env` after its permissions were correctly hardened to mode 0600 root.

## Fix

- read the CI smoke credentials through `sudo`
- run only the browser smoke wrapper through an explicit, restricted `sudo env` so it can read the protected bundled SourceLens env
- keep production `.env` and SourceLens env permissions unchanged
- add release contract guards for the protected-env behavior

## Validation

- `bash -n release/ci/verify-release.sh`
- `./tools/quality/check-release-contracts.sh`
- `git diff --check`

The failed v0.1.2 run already proved package assembly, public asset download, checksums, image loading, migrations, all containers, and ports 11443/11444/11445. This PR fixes the final browser-smoke invocation only.