### PR TITLE
fix(installer): remove stale release files during materialization

### DIFF
--- a/deploy/installer/install.sh
+++ b/deploy/installer/install.sh
@@ -363,6 +363,7 @@ materialize_to_install_dir() {
 	if command -v rsync >/dev/null 2>&1; then
 		local -a rsync_args=(
 			-a
+			--delete
 			--exclude '.env'
 			--exclude 'data/'
 			--exclude 'backup/'

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -193,6 +193,12 @@ grep -F './tools/quality/test-shared-host-guard.sh' "${workflow}" >/dev/null
 grep -F './tools/quality/test-default-certificates.sh' "${workflow}" >/dev/null
 
 installer="${ROOT}/deploy/installer/install.sh"
+materialize_body="$(sed -n '/^materialize_to_install_dir()/,/^}/p' "${installer}")"
+grep -F -- '--delete' <<<"${materialize_body}" >/dev/null
+if grep -F -- '--delete-excluded' <<<"${materialize_body}" >/dev/null; then
+	printf 'ERROR: release materialization must preserve excluded runtime state\n' >&2
+	exit 1
+fi
 grep -F 'PUBLIC_HOST="${HFL_PUBLIC_HOST:-}"' "${installer}" >/dev/null
 grep -F 'values are hidden in non-interactive logs' "${installer}" >/dev/null
 grep -F 'validate_default_tls_bundle "${src_root}/deploy/nginx/certs"' "${installer}" >/dev/null

--- a/tools/quality/test-default-certificates.sh
+++ b/tools/quality/test-default-certificates.sh
@@ -66,11 +66,21 @@ ensure_tls_certs
 [[ "$(stat -c '%a' "${INSTALL_DIR}/deploy/nginx/certs/tls.key")" == "600" ]]
 
 ROOT="${tmp}/custom"
-mkdir -p "${ROOT}/deploy/nginx/certs"
+mkdir -p \
+	"${ROOT}/deploy/nginx/certs" \
+	"${ROOT}/payload" \
+	"${ROOT}/data" \
+	"${ROOT}/backup" \
+	"${ROOT}/upgrade_tmp"
 openssl req -x509 -newkey rsa:2048 -nodes -sha256 -days 30 \
 	-keyout "${ROOT}/deploy/nginx/certs/tls.key" \
 	-out "${ROOT}/deploy/nginx/certs/tls.crt" \
 	-subj '/CN=custom.example.test' >/dev/null 2>&1
+printf 'stale\n' >"${ROOT}/payload/stale-release-file"
+printf 'preserved env\n' >"${ROOT}/.env"
+printf 'preserved data\n' >"${ROOT}/data/marker"
+printf 'preserved backup\n' >"${ROOT}/backup/marker"
+printf 'preserved upgrade state\n' >"${ROOT}/upgrade_tmp/marker"
 before="$(sha256sum "${ROOT}/deploy/nginx/certs/tls.crt" "${ROOT}/deploy/nginx/certs/tls.key")"
 sync_default_tls_bundle "${source_fixture}/deploy/nginx/certs"
 after="$(sha256sum "${ROOT}/deploy/nginx/certs/tls.crt" "${ROOT}/deploy/nginx/certs/tls.key")"
@@ -79,6 +89,11 @@ INSTALL_DIR="${ROOT}"
 materialize_to_install_dir "${source_fixture}"
 after="$(sha256sum "${ROOT}/deploy/nginx/certs/tls.crt" "${ROOT}/deploy/nginx/certs/tls.key")"
 [[ "${before}" == "${after}" ]]
+[[ ! -e "${ROOT}/payload/stale-release-file" ]]
+[[ "$(<"${ROOT}/.env")" == "preserved env" ]]
+[[ "$(<"${ROOT}/data/marker")" == "preserved data" ]]
+[[ "$(<"${ROOT}/backup/marker")" == "preserved backup" ]]
+[[ "$(<"${ROOT}/upgrade_tmp/marker")" == "preserved upgrade state" ]]
 
 ROOT="${tmp}/incomplete"
 mkdir -p "${ROOT}/deploy/nginx/certs"


### PR DESCRIPTION
Fix production upgrades that fail payload verification when the install directory contains release-controlled files from an older package.

- delete stale release-controlled files during rsync materialization
- preserve excluded runtime state and complete custom TLS certificates
- add regression and release-contract coverage

Failure observed in release run: https://github.com/HyperBDR/hyperfilelens/actions/runs/29802269883

Validation:
- bash -n deploy/installer/install.sh
- ./tools/quality/test-default-certificates.sh
- ./tools/quality/check-release-contracts.sh
- ./tools/quality/test-ci-release-assembly.sh
- git diff --check