### PR TITLE
fix(installer): verify release file contents during sync

### DIFF
--- a/deploy/installer/install.sh
+++ b/deploy/installer/install.sh
@@ -363,6 +363,7 @@ materialize_to_install_dir() {
 	if command -v rsync >/dev/null 2>&1; then
 		local -a rsync_args=(
 			-a
+			--checksum
 			--delete
 			--exclude '.env'
 			--exclude 'data/'

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -194,6 +194,7 @@ grep -F './tools/quality/test-default-certificates.sh' "${workflow}" >/dev/null
 
 installer="${ROOT}/deploy/installer/install.sh"
 materialize_body="$(sed -n '/^materialize_to_install_dir()/,/^}/p' "${installer}")"
+grep -F -- '--checksum' <<<"${materialize_body}" >/dev/null
 grep -F -- '--delete' <<<"${materialize_body}" >/dev/null
 if grep -F -- '--delete-excluded' <<<"${materialize_body}" >/dev/null; then
 	printf 'ERROR: release materialization must preserve excluded runtime state\n' >&2

--- a/tools/quality/test-default-certificates.sh
+++ b/tools/quality/test-default-certificates.sh
@@ -81,6 +81,10 @@ printf 'preserved env\n' >"${ROOT}/.env"
 printf 'preserved data\n' >"${ROOT}/data/marker"
 printf 'preserved backup\n' >"${ROOT}/backup/marker"
 printf 'preserved upgrade state\n' >"${ROOT}/upgrade_tmp/marker"
+# Rsync's size+mtime quick check must not preserve stale release-controlled
+# content. Match both attributes while deliberately changing the bytes.
+printf 'outdate\n' >"${ROOT}/docker-compose.yml"
+touch -r "${source_fixture}/docker-compose.yml" "${ROOT}/docker-compose.yml"
 before="$(sha256sum "${ROOT}/deploy/nginx/certs/tls.crt" "${ROOT}/deploy/nginx/certs/tls.key")"
 sync_default_tls_bundle "${source_fixture}/deploy/nginx/certs"
 after="$(sha256sum "${ROOT}/deploy/nginx/certs/tls.crt" "${ROOT}/deploy/nginx/certs/tls.key")"
@@ -94,6 +98,7 @@ after="$(sha256sum "${ROOT}/deploy/nginx/certs/tls.crt" "${ROOT}/deploy/nginx/ce
 [[ "$(<"${ROOT}/data/marker")" == "preserved data" ]]
 [[ "$(<"${ROOT}/backup/marker")" == "preserved backup" ]]
 [[ "$(<"${ROOT}/upgrade_tmp/marker")" == "preserved upgrade state" ]]
+[[ "$(<"${ROOT}/docker-compose.yml")" == "fixture" ]]
 
 ROOT="${tmp}/incomplete"
 mkdir -p "${ROOT}/deploy/nginx/certs"


### PR DESCRIPTION
Fix production materialization when an existing release-controlled file has the same size and mtime as the new package file but different content.

- enable rsync checksum comparison during package materialization
- retain stale-path deletion and protected runtime-state exclusions
- add a regression fixture with identical size/mtime and different bytes
- enforce the checksum contract in release quality checks

Observed in v0.1.3 deployment: https://github.com/HyperBDR/hyperfilelens/actions/runs/29804139665

Validation:
- bash -n deploy/installer/install.sh
- ./tools/quality/test-default-certificates.sh
- ./tools/quality/check-release-contracts.sh
- ./tools/quality/test-ci-release-assembly.sh
- git diff --check