### PR TITLE
fix(gateway): use tenant URL for platform enrollment

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -138,6 +138,7 @@ jobs:
           uv run --isolated --no-project --python 3.8 python tools/quality/check-python38-runtime.py
           ./tools/quality/check-release-contracts.sh
           ./tools/quality/test-default-certificates.sh
+          ./tools/quality/test-gateway-bootstrap-health.sh
           ./tools/quality/test-shared-host-guard.sh
           ./tools/quality/test-ci-release-assembly.sh
           git diff --check

--- a/deploy/bootstrap/gateway-bootstrap-linux.sh
+++ b/deploy/bootstrap/gateway-bootstrap-linux.sh
@@ -42,14 +42,16 @@ hfl_build_enroll_args() {
 	fi
 }
 
-hfl_curl_retry() {
+hfl_sourcelens_health_retry() {
 	local url="$1"
 	local label="$2"
 	local attempts="${3:-3}"
 	local delay="${4:-5}"
 	local n=1
+	local response=""
 	while [[ "${n}" -le "${attempts}" ]]; do
-		if curl "${CURL_TLS[@]}" -fsSL "${url}" >/dev/null 2>&1; then
+		if response="$(curl "${CURL_TLS[@]}" -fsSL "${url}" 2>/dev/null)" \
+			&& grep -Eq '"health"[[:space:]]*:[[:space:]]*"OK"' <<<"${response}"; then
 			return 0
 		fi
 		if [[ "${n}" -lt "${attempts}" ]]; then
@@ -59,7 +61,7 @@ hfl_curl_retry() {
 		fi
 		n=$((n + 1))
 	done
-	hfl_fail "${label} unreachable at ${url} after ${attempts} attempts." 3
+	hfl_fail "${label} unreachable or unhealthy at ${url} after ${attempts} attempts." 3
 }
 
 MIN_ENGINE_VERSION="${HFL_DOCKER_MIN_ENGINE:-24.0.0}"
@@ -179,7 +181,7 @@ curl "${CURL_TLS[@]}" -fsSL "${CONSOLE_BASE}/health" >/dev/null
 hfl_ok "Console is reachable."
 
 hfl_step "Checking SourceLens health via console proxy."
-hfl_curl_retry "${CONSOLE_BASE}/sourcelens/health" "SourceLens health" 3 5
+hfl_sourcelens_health_retry "${CONSOLE_BASE}/sourcelens/health" "SourceLens health" 3 5
 hfl_ok "SourceLens is reachable."
 
 ensure_docker_for_gateway

--- a/src/backend/apps/platform_ops/api/views/lens.py
+++ b/src/backend/apps/platform_ops/api/views/lens.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import uuid
+from urllib.parse import urlsplit
 
 from rest_framework import status
 from rest_framework.exceptions import ValidationError
@@ -39,10 +40,26 @@ from apps.lens_bridge.services.skills import beautify_skill
 from apps.node.models import NodeToken
 from apps.node.models.base import NodeRole
 from apps.platform_ops.api.permissions import IsPlatformOpsStaff
+from common.deploy.site import tenant_public_url
 
 
 def _platform_org():
     return platform_lens.get_or_create_platform_org()
+
+
+def _platform_gateway_api_base() -> str | None:
+    """Return the configured tenant origin used by platform Data Gateways."""
+    api_base = tenant_public_url()
+    parsed = urlsplit(api_base)
+    if (
+        parsed.scheme not in {"http", "https"}
+        or not parsed.netloc
+        or parsed.path not in {"", "/"}
+        or parsed.query
+        or parsed.fragment
+    ):
+        return None
+    return api_base.rstrip("/")
 
 
 class PlatformOpsLensGatewayListView(APIView):
@@ -58,6 +75,18 @@ class PlatformOpsLensGatewayEnrollmentView(APIView):
     permission_classes = [IsPlatformOpsStaff]
 
     def post(self, request):
+        api_base = _platform_gateway_api_base()
+        if api_base is None:
+            return Response(
+                {
+                    "detail": (
+                        "FRONTEND_URL must be an absolute HTTP(S) origin "
+                        "for Data Gateway enrollment."
+                    )
+                },
+                status=status.HTTP_503_SERVICE_UNAVAILABLE,
+            )
+
         org = _platform_org()
         token = NodeToken.objects.create(
             organization=org,
@@ -72,6 +101,7 @@ class PlatformOpsLensGatewayEnrollmentView(APIView):
                 "token_id": token.id,
                 "org_key": org.key,
                 "gateway_scope": LensGatewayLink.GatewayScope.PLATFORM,
+                "api_base": api_base,
             },
             status=status.HTTP_201_CREATED,
         )

--- a/src/backend/apps/platform_ops/tests/test_lens_gateway_enrollment.py
+++ b/src/backend/apps/platform_ops/tests/test_lens_gateway_enrollment.py
@@ -1,0 +1,53 @@
+from django.contrib.auth.models import User
+from django.test import TestCase, override_settings
+from rest_framework.test import APIClient
+
+from apps.lens_bridge.models import LensGatewayLink
+from apps.node.models import NodeToken
+
+
+@override_settings(
+    HFL_PLATFORM_OPS_ENABLED=True,
+    FRONTEND_URL="https://console.example.com:11443",
+)
+class PlatformOpsLensGatewayEnrollmentTest(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.staff = User.objects.create_user(
+            username="staff@test.com",
+            email="staff@test.com",
+            password="Pass1234",
+            is_staff=True,
+        )
+        self.client.force_authenticate(user=self.staff)
+
+    def _enroll(self):
+        return self.client.post(
+            "/api/v1/platform-ops/lens/gateways/enrollment",
+            {"note": "platform gateway test"},
+            format="json",
+            HTTP_X_HFL_SITE_ROLE="ops",
+        )
+
+    def test_returns_tenant_origin_for_platform_gateway_install(self):
+        response = self._enroll()
+
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.data["api_base"], "https://console.example.com:11443")
+        self.assertEqual(response.data["org_key"], "__platform_lens__")
+        self.assertEqual(
+            response.data["gateway_scope"],
+            LensGatewayLink.GatewayScope.PLATFORM,
+        )
+
+        token = NodeToken.objects.get(pk=response.data["token_id"])
+        self.assertEqual(token.organization.key, "__platform_lens__")
+        self.assertEqual(token.gateway_scope, LensGatewayLink.GatewayScope.PLATFORM)
+
+    @override_settings(FRONTEND_URL="https://console.example.com:11443/tenant")
+    def test_rejects_invalid_frontend_url_without_creating_token(self):
+        response = self._enroll()
+
+        self.assertEqual(response.status_code, 503)
+        self.assertIn("FRONTEND_URL", response.data["detail"])
+        self.assertFalse(NodeToken.objects.exists())

--- a/src/frontend/src/lib/nodeApi.test.ts
+++ b/src/frontend/src/lib/nodeApi.test.ts
@@ -1,0 +1,60 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { api } from './api'
+import { issuePlatformGatewayEnrollmentInstall } from './nodeApi'
+
+vi.mock('./api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./api')>()
+  return {
+    ...actual,
+    api: vi.fn(),
+  }
+})
+
+vi.mock('../composables/useAuth', () => ({
+  getEffectiveOrgKey: vi.fn(() => ''),
+}))
+
+afterEach(() => {
+  vi.clearAllMocks()
+  vi.unstubAllGlobals()
+})
+
+describe('platform Data Gateway enrollment', () => {
+  it('uses the tenant API base returned by the Admin Console API', async () => {
+    vi.stubGlobal('window', {
+      location: { origin: 'https://console.example.com:11444' },
+    })
+    vi.mocked(api).mockResolvedValue({
+      token: 'platform-token',
+      token_id: 17,
+      org_key: '__platform_lens__',
+      gateway_scope: 'platform',
+      api_base: 'https://console.example.com:11443',
+    })
+
+    const result = await issuePlatformGatewayEnrollmentInstall()
+
+    expect(result.command).toContain(
+      "curl -k 'https://console.example.com:11443/api/v1/node/enrollment/bootstrap-gateway?",
+    )
+    expect(result.command).toContain('api_base=https%3A%2F%2Fconsole.example.com%3A11443')
+    expect(result.command).not.toContain('11444')
+  })
+
+  it('rejects an incomplete response instead of falling back to the Admin origin', async () => {
+    vi.stubGlobal('window', {
+      location: { origin: 'https://console.example.com:11444' },
+    })
+    vi.mocked(api).mockResolvedValue({
+      token: 'platform-token',
+      token_id: 17,
+      org_key: '__platform_lens__',
+    })
+
+    await expect(issuePlatformGatewayEnrollmentInstall()).rejects.toThrow(
+      'Platform gateway enrollment response is incomplete',
+    )
+  })
+})

--- a/src/frontend/src/lib/nodeApi.ts
+++ b/src/frontend/src/lib/nodeApi.ts
@@ -393,14 +393,23 @@ export async function issuePlatformGatewayEnrollmentInstall(params?: {
     method: 'POST',
     body: JSON.stringify({ note: params?.note ?? 'deploy:platform-gateway' }),
   })
-  const payload = unwrapApiPayload<{ token: string; token_id: number; org_key: string }>(raw)
-  if (!payload.token || !payload.org_key) {
+  const payload = unwrapApiPayload<{
+    token: string
+    token_id: number
+    org_key: string
+    api_base: string
+  }>(raw)
+  if (!payload.token || !payload.org_key || !payload.api_base) {
     throw new Error('Platform gateway enrollment response is incomplete')
   }
   return {
     token: payload.token,
     tokenId: payload.token_id,
-    command: buildGatewayEnrollmentInstallCommand({ org: payload.org_key, token: payload.token }),
+    command: buildGatewayEnrollmentInstallCommand({
+      org: payload.org_key,
+      token: payload.token,
+      apiBase: payload.api_base,
+    }),
   }
 }
 

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -191,6 +191,7 @@ grep -F 'Verified that unrelated Docker containers, networks, and volumes are un
 grep -F 'project in {"hyperfilelens-sourcelens", "sourcelens"}' "${remote_deploy}" >/dev/null
 grep -F './tools/quality/test-shared-host-guard.sh' "${workflow}" >/dev/null
 grep -F './tools/quality/test-default-certificates.sh' "${workflow}" >/dev/null
+grep -F './tools/quality/test-gateway-bootstrap-health.sh' "${workflow}" >/dev/null
 
 installer="${ROOT}/deploy/installer/install.sh"
 materialize_body="$(sed -n '/^materialize_to_install_dir()/,/^}/p' "${installer}")"

--- a/tools/quality/test-gateway-bootstrap-health.sh
+++ b/tools/quality/test-gateway-bootstrap-health.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+bootstrap="${ROOT}/deploy/bootstrap/gateway-bootstrap-linux.sh"
+
+# Load only the bootstrap logging and health-check functions, not its installer body.
+# shellcheck disable=SC1090
+source <(
+	sed -n '/^hfl_now()/,/^MIN_ENGINE_VERSION=/p' "${bootstrap}" \
+		| sed '$d'
+)
+
+CURL_TLS=()
+
+run_health_check_with_response() {
+	local mock_response="$1"
+	(
+		curl() {
+			printf '%s' "${mock_response}"
+		}
+		hfl_sourcelens_health_retry "https://console.example/sourcelens/health" \
+			"SourceLens health" 1 0
+	)
+}
+
+run_health_check_with_response '{"health":"OK"}'
+
+if run_health_check_with_response '<!doctype html><title>HyperFileLens</title>' 2>/dev/null; then
+	printf 'ERROR: Gateway bootstrap accepted the Admin SPA as SourceLens health\n' >&2
+	exit 1
+fi
+
+if run_health_check_with_response '{"health":"DOWN"}' 2>/dev/null; then
+	printf 'ERROR: Gateway bootstrap accepted an unhealthy SourceLens response\n' >&2
+	exit 1
+fi
+
+printf 'Gateway bootstrap SourceLens health validation passed\n'


### PR DESCRIPTION
## Summary
- return the configured tenant URL for Admin-created platform Gateway enrollment
- generate Gateway install commands against the tenant data-plane endpoint
- validate SourceLens health JSON and reject Admin SPA false positives
- add backend, frontend, shell, and CI regression coverage

## Tests
- Django Platform Ops and Gateway bootstrap tests: 32 passed
- frontend Vitest suite: 252 passed
- frontend production build
- Ruff and ESLint
- release contract, Bash syntax, and Gateway health behavior checks