### PR TITLE
fix(frontend): align policy overflow contract with metadata layout

### DIFF
--- a/src/frontend/src/styles/policyRelatedSourceOverflow.test.ts
+++ b/src/frontend/src/styles/policyRelatedSourceOverflow.test.ts
@@ -5,9 +5,12 @@ import { describe, expect, it } from 'vitest'
 const policiesPage = readFileSync(resolve(process.cwd(), 'src/pages/protection/Policies.vue'), 'utf8')
 
 describe('policy related source overflow styles', () => {
-  it('renders both source lines with independent ellipses', () => {
+  it('truncates long source names without collapsing the metadata row', () => {
     expect(policiesPage).toMatch(
-      /\.policy-related-source-cell__name,\s*\.policy-related-source-cell__type\s*{[^}]*min-width:\s*0;[^}]*max-width:\s*100%;[^}]*overflow:\s*hidden;[^}]*text-overflow:\s*ellipsis;[^}]*white-space:\s*nowrap;/s,
+      /\.policy-related-source-cell__name\s*{[^}]*min-width:\s*0;[^}]*max-width:\s*100%;[^}]*overflow:\s*hidden;[^}]*text-overflow:\s*ellipsis;[^}]*white-space:\s*nowrap;/s,
+    )
+    expect(policiesPage).toMatch(
+      /\.policy-related-source-cell__meta\s*{[^}]*display:\s*flex;[^}]*min-width:\s*0;[^}]*align-items:\s*center;/s,
     )
   })
 })


### PR DESCRIPTION
## Summary

- update the stale policy source overflow contract after PR #30 replaced the plain source-type line with an ElTag and trait metadata row
- continue validating ellipsis behavior for long source names
- validate that the new metadata row remains flex-constrained without reverting the current UI

This fixes the Frontend checks failure in v0.1.4 release run 29810991872.

## Validation

- npm run lint: passed with existing warnings only
- targeted Vitest contract: 1 passed
- full frontend Vitest suite: 50 files, 271 tests passed
- npm run build: passed
- git diff --check: passed