### PR TITLE
fix(installer): make payload hashes locale-independent

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -141,6 +141,7 @@ jobs:
           ./tools/quality/test-gateway-bootstrap-health.sh
           ./tools/quality/test-shared-host-guard.sh
           ./tools/quality/test-deployment-optional-config.sh
+          ./tools/quality/test-payload-tree-hash.sh
           ./tools/quality/test-ci-release-assembly.sh
           git diff --check
           while IFS= read -r script; do bash -n "$script"; done < <(find . -path './build' -prune -o -path './data' -prune -o -type f -name '*.sh' -print)

--- a/deploy/installer/install.sh
+++ b/deploy/installer/install.sh
@@ -1233,6 +1233,7 @@ uninstall_bundled_sourcelens() {
 tree_sha256() {
 	local dir=$1
 	(
+		export LC_ALL=C
 		cd "${dir}"
 		find . -type f ! -path './__pycache__/*' ! -name '*.pyc' -print0 \
 			| sort -z \

--- a/release/build.sh
+++ b/release/build.sh
@@ -611,6 +611,7 @@ build_control_plane_images() {
 tree_sha256() {
 	local dir=$1
 	(
+		export LC_ALL=C
 		cd "${dir}"
 		find . -type f ! -path './__pycache__/*' ! -name '*.pyc' -print0 \
 			| sort -z \

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -270,6 +270,7 @@ grep -F './tools/quality/test-shared-host-guard.sh' "${workflow}" >/dev/null
 grep -F './tools/quality/test-default-certificates.sh' "${workflow}" >/dev/null
 grep -F './tools/quality/test-gateway-bootstrap-health.sh' "${workflow}" >/dev/null
 grep -F './tools/quality/test-deployment-optional-config.sh' "${workflow}" >/dev/null
+grep -F './tools/quality/test-payload-tree-hash.sh' "${workflow}" >/dev/null
 grep -F 'Post-deploy internal health checks' "${ROOT}/.github/workflows/deploy_target.yml" >/dev/null
 grep -F 'https://127.0.0.1:11443/health/ready' \
 	"${ROOT}/.github/workflows/deploy_target.yml" >/dev/null

--- a/tools/quality/test-payload-tree-hash.sh
+++ b/tools/quality/test-payload-tree-hash.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Verify release payload tree hashes are stable across host locales.
+set -euo pipefail
+umask 022
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+tmp="$(mktemp -d)"
+trap 'rm -rf "${tmp}"' EXIT
+
+fixture="${tmp}/payload"
+mkdir -p "${fixture}/media/agent-releases/0.1.4"
+printf 'standard\n' >"${fixture}/media/agent-releases/0.1.4/hfl-agent-0.1.4-linux-amd64.tar.gz"
+printf 'ubuntu-2004\n' >"${fixture}/media/agent-releases/0.1.4/hfl-agent-0.1.4-linux-amd64-ubuntu2004.tar.gz"
+printf 'ubuntu-2404\n' >"${fixture}/media/agent-releases/0.1.4/hfl-agent-0.1.4-linux-amd64-ubuntu2404.tar.gz"
+
+reference="$({
+	cd "${fixture}"
+	export LC_ALL=C
+	find . -type f ! -path './__pycache__/*' ! -name '*.pyc' -print0 \
+		| sort -z \
+		| xargs -0 sha256sum \
+		| sha256sum \
+		| awk '{print $1}'
+})"
+
+test_locale="$(locale -a | awk 'tolower($0) ~ /^en_us([.]utf-?8)?$/ { print; exit }')"
+[[ -n "${test_locale}" ]] || test_locale=C.UTF-8
+
+for source in "${ROOT}/release/build.sh" "${ROOT}/deploy/installer/install.sh"; do
+	function_file="${tmp}/$(basename "$(dirname "${source}")")-tree-sha256.sh"
+	sed -n '/^tree_sha256()/,/^}/p' "${source}" >"${function_file}"
+	grep -F 'export LC_ALL=C' "${function_file}" >/dev/null || {
+		printf 'ERROR: tree_sha256 does not force C locale in %s\n' "${source}" >&2
+		exit 1
+	}
+	actual="$(
+		# shellcheck disable=SC1090
+		source "${function_file}"
+		LC_ALL="${test_locale}" tree_sha256 "${fixture}"
+	)"
+	[[ "${actual}" == "${reference}" ]] || {
+		printf 'ERROR: locale-dependent tree hash in %s (%s != %s)\n' \
+			"${source}" "${actual}" "${reference}" >&2
+		exit 1
+	}
+done
+
+printf 'Portable payload tree hash checks passed (%s caller locale).\n' "${test_locale}"


### PR DESCRIPTION
## Summary

- force the C locale in both release-build and installer payload tree hash functions
- keep strict payload integrity validation while making path ordering portable across Ubuntu locales
- add a regression test for build/install hash agreement and run it in the release quality gate

## Root cause

The published v0.1.4 package and the production materialized payload were byte-for-byte identical, but the manifest was built under C/C.UTF-8 while the Ubuntu 20.04 production host uses en_US.UTF-8. Locale collation reordered the standard linux-amd64 archive relative to its ubuntu2004/ubuntu2404 variants, producing different aggregate hashes.

Observed on the production host:

- C and C.UTF-8: c1918397... (manifest value)
- en_US.UTF-8: 1d5a3cd2...

The production deployment stopped before container changes, and the shared-host guard passed.

## Validation

- portable payload tree hash regression test
- release contract checks
- synthetic split Release assembly
- Bash syntax checks
- workflow YAML parsing
- git diff --check