### PR TITLE
fix(auth): bypass Turnstile on the ops console

### DIFF
--- a/src/backend/apps/iam/auth/views/login.py
+++ b/src/backend/apps/iam/auth/views/login.py
@@ -26,7 +26,7 @@ from apps.iam.services.turnstile_verification import (
     invalid_turnstile_fields,
     missing_turnstile_fields,
     turnstile_configured,
-    turnstile_enabled,
+    turnstile_required,
     verify_turnstile_for_action,
 )
 from apps.iam.services.token_service import (
@@ -201,8 +201,9 @@ class EmailLoginView(AnonymousPublicViewMixin, APIView):
         if not credentials_and_turnstile_present(
             request.data,
             ["email", "password"],
+            request,
         ):
-            missing_fields = missing_turnstile_fields(request.data)
+            missing_fields = missing_turnstile_fields(request.data, request)
             return _build_error_response(
                 "VALIDATION_ERROR",
                 _("Missing required fields"),
@@ -213,7 +214,7 @@ class EmailLoginView(AnonymousPublicViewMixin, APIView):
                 },
             )
 
-        if turnstile_enabled() and not turnstile_configured():
+        if turnstile_required(request) and not turnstile_configured():
             return _build_error_response(
                 "TURNSTILE_MISCONFIGURED",
                 _("Human verification is temporarily unavailable"),

--- a/src/backend/apps/iam/auth/views/registration.py
+++ b/src/backend/apps/iam/auth/views/registration.py
@@ -14,6 +14,7 @@ from drf_spectacular.utils import extend_schema
 from rest_framework import status
 from rest_framework.exceptions import AuthenticationFailed
 from rest_framework.permissions import IsAuthenticated
+from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -24,7 +25,7 @@ from apps.iam.services.turnstile_verification import (
     invalid_turnstile_fields,
     missing_turnstile_fields,
     turnstile_configured,
-    turnstile_enabled,
+    turnstile_required,
     verify_turnstile_for_action,
 )
 from apps.iam.services.verification_code_service import verify_email_verification_code
@@ -75,9 +76,9 @@ def _email_signup_disabled_response() -> Response:
     )
 
 
-def _turnstile_misconfigured_response() -> Response | None:
-    """Fail closed when Turnstile is enabled without a complete key pair."""
-    if not turnstile_enabled() or turnstile_configured():
+def _turnstile_misconfigured_response(request: Request) -> Response | None:
+    """Fail closed when this request requires Turnstile without complete keys."""
+    if not turnstile_required(request) or turnstile_configured():
         return None
     return _build_error_response(
         "TURNSTILE_MISCONFIGURED",
@@ -178,13 +179,13 @@ class EmailRegisterSendCodeView(AnonymousPublicViewMixin, APIView):
         if not email_signup_enabled():
             return _email_signup_disabled_response()
 
-        configuration_error = _turnstile_misconfigured_response()
+        configuration_error = _turnstile_misconfigured_response(request)
         if configuration_error is not None:
             return configuration_error
 
         email = (request.data.get("email") or "").strip().lower()
 
-        if not email or missing_turnstile_fields(request.data):
+        if not email or missing_turnstile_fields(request.data, request):
             return Response(
                 {
                     "code": "1001",
@@ -192,7 +193,7 @@ class EmailRegisterSendCodeView(AnonymousPublicViewMixin, APIView):
                         "error_code": "VALIDATION_ERROR",
                         "message": _("Missing required fields"),
                         "fields": {
-                            **missing_turnstile_fields(request.data),
+                            **missing_turnstile_fields(request.data, request),
                             "email": [_('Required')] if not email else [],
                         },
                     },
@@ -295,7 +296,7 @@ class EmailRegisterView(AnonymousPublicViewMixin, APIView):
         if not email_signup_enabled():
             return _email_signup_disabled_response()
 
-        configuration_error = _turnstile_misconfigured_response()
+        configuration_error = _turnstile_misconfigured_response(request)
         if configuration_error is not None:
             return configuration_error
 
@@ -303,7 +304,10 @@ class EmailRegisterView(AnonymousPublicViewMixin, APIView):
         last_name = request.data.get("last_name")
         email = request.data.get("email")
 
-        if not all([first_name, last_name, email]) or missing_turnstile_fields(request.data):
+        if not all([first_name, last_name, email]) or missing_turnstile_fields(
+            request.data,
+            request,
+        ):
             return Response(
                 {
                     "code": "1001",
@@ -311,7 +315,7 @@ class EmailRegisterView(AnonymousPublicViewMixin, APIView):
                         "error_code": "VALIDATION_ERROR",
                         "message": _("Missing required fields"),
                         "fields": {
-                            **missing_turnstile_fields(request.data),
+                            **missing_turnstile_fields(request.data, request),
                             "first_name": [_('Required')] if not first_name else [],
                             "last_name": [_('Required')] if not last_name else [],
                             "email": [_('Required')] if not email else [],
@@ -545,13 +549,13 @@ class ForgotPasswordView(AnonymousPublicViewMixin, APIView):
         responses={200: OpenApiTypes.OBJECT},
     )
     def post(self, request):
-        configuration_error = _turnstile_misconfigured_response()
+        configuration_error = _turnstile_misconfigured_response(request)
         if configuration_error is not None:
             return configuration_error
 
         email = (request.data.get("email") or "").strip().lower()
 
-        if not email or missing_turnstile_fields(request.data):
+        if not email or missing_turnstile_fields(request.data, request):
             return Response(
                 {
                     "code": "1001",
@@ -559,7 +563,7 @@ class ForgotPasswordView(AnonymousPublicViewMixin, APIView):
                         "error_code": "VALIDATION_ERROR",
                         "message": _("Missing required fields"),
                         "fields": {
-                            **missing_turnstile_fields(request.data),
+                            **missing_turnstile_fields(request.data, request),
                             "email": [_('Required')] if not email else [],
                         },
                     },

--- a/src/backend/apps/iam/auth/views/turnstile.py
+++ b/src/backend/apps/iam/auth/views/turnstile.py
@@ -11,7 +11,7 @@ from common.i18n.client_lang import activate_request_language
 
 from apps.iam.services.turnstile_verification import (
     turnstile_configured,
-    turnstile_enabled,
+    turnstile_required,
 )
 from apps.platform_ops.services.internal.runtime_settings import turnstile_site_key
 
@@ -26,7 +26,7 @@ class TurnstileConfigView(AnonymousPublicViewMixin, APIView):
     )
     def get(self, request):
         activate_request_language(request)
-        enabled = turnstile_enabled()
+        enabled = turnstile_required(request)
         configured = turnstile_configured() if enabled else False
         data: dict[str, str | bool] = {
             "enabled": enabled,

--- a/src/backend/apps/iam/services/__init__.py
+++ b/src/backend/apps/iam/services/__init__.py
@@ -8,6 +8,7 @@ from .turnstile_verification import (
     missing_turnstile_fields,
     turnstile_configured,
     turnstile_enabled,
+    turnstile_required,
     verify_turnstile_for_action,
 )
 from .verification_code_service import verify_email_verification_code
@@ -18,6 +19,7 @@ __all__ = [
     "missing_turnstile_fields",
     "turnstile_configured",
     "turnstile_enabled",
+    "turnstile_required",
     "verify_turnstile_for_action",
     "verify_email_verification_code",
 ]

--- a/src/backend/apps/iam/services/turnstile_verification.py
+++ b/src/backend/apps/iam/services/turnstile_verification.py
@@ -10,6 +10,7 @@ from django.conf import settings
 from django.utils.translation import gettext_lazy as _
 
 from apps.iam.services.turnstile_service import get_client_ip, validate_turnstile
+from common.deploy.site import resolve_site_role
 
 TURNSTILE_FIELD = "turnstile_token"
 
@@ -29,21 +30,30 @@ def turnstile_configured() -> bool:
     return bool(turnstile_site_key() and turnstile_secret_key())
 
 
-def missing_turnstile_fields(data: Mapping[str, Any]) -> dict[str, list[str]]:
-    """Return required-field errors when Turnstile is enabled."""
-    if not turnstile_enabled() or str(data.get(TURNSTILE_FIELD) or "").strip():
+def turnstile_required(request: Any) -> bool:
+    """Require Turnstile only on the tenant-facing authentication endpoint."""
+    return turnstile_enabled() and resolve_site_role(request) == "tenant"
+
+
+def missing_turnstile_fields(
+    data: Mapping[str, Any],
+    request: Any,
+) -> dict[str, list[str]]:
+    """Return required-field errors when this request requires Turnstile."""
+    if not turnstile_required(request) or str(data.get(TURNSTILE_FIELD) or "").strip():
         return {}
-    return {TURNSTILE_FIELD: [_('Required')]}
+    return {TURNSTILE_FIELD: [_("Required")]}
 
 
 def credentials_and_turnstile_present(
     data: Mapping[str, Any],
     credential_fields: list[str],
+    request: Any,
 ) -> bool:
     """Return whether credentials and any required Turnstile token are present."""
     if any(not data.get(field) for field in credential_fields):
         return False
-    return not missing_turnstile_fields(data)
+    return not missing_turnstile_fields(data, request)
 
 
 def expected_turnstile_hostname(request) -> str:
@@ -61,7 +71,7 @@ def verify_turnstile_for_action(
     action: str,
 ) -> bool:
     """Verify Turnstile for an action, or allow it when explicitly disabled."""
-    if not turnstile_enabled():
+    if not turnstile_required(request):
         return True
     if not turnstile_configured():
         return False
@@ -79,4 +89,4 @@ def verify_turnstile_for_action(
 
 def invalid_turnstile_fields() -> dict[str, list[str]]:
     """Return a consistent validation error for rejected Turnstile tokens."""
-    return {TURNSTILE_FIELD: [_('Invalid or expired human verification')]}
+    return {TURNSTILE_FIELD: [_("Invalid or expired human verification")]}

--- a/src/backend/apps/iam/tests/test_email_login.py
+++ b/src/backend/apps/iam/tests/test_email_login.py
@@ -76,3 +76,28 @@ class EmailLoginApiTests(APITestCase):
             response.data["error"]["error_code"],
             "TURNSTILE_MISCONFIGURED",
         )
+
+    @override_settings(
+        TURNSTILE_ENABLED=True,
+        TURNSTILE_SITE_KEY="site-key",
+        TURNSTILE_SECRET_KEY="",
+    )
+    def test_ops_site_login_bypasses_turnstile(self):
+        email = "ops-login@example.com"
+        User.objects.create_user(
+            username=email,
+            email=email,
+            password="CorrectPass123",
+            is_active=True,
+            is_staff=True,
+        )
+
+        response = self.client.post(
+            reverse("email_login"),
+            self._payload(email, password="CorrectPass123"),
+            format="json",
+            HTTP_X_HFL_SITE_ROLE="ops",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["code"], "0000")

--- a/src/backend/apps/iam/tests/test_forgot_password.py
+++ b/src/backend/apps/iam/tests/test_forgot_password.py
@@ -68,3 +68,27 @@ class ForgotPasswordApiTests(APITestCase):
         self.assertEqual(response.data["error"]["error_code"], "EMAIL_NOT_REGISTERED")
         self.assertIn("email", response.data["error"]["fields"])
         self.assertEqual(len(mail.outbox), 0)
+
+    @override_settings(
+        TURNSTILE_ENABLED=True,
+        TURNSTILE_SITE_KEY="site-key",
+        TURNSTILE_SECRET_KEY="",
+    )
+    def test_ops_site_password_reset_bypasses_turnstile(self):
+        email = "ops-reset@example.com"
+        User.objects.create_user(
+            username=email,
+            email=email,
+            password="Pass1234",
+            is_active=True,
+        )
+
+        response = self.client.post(
+            reverse("forgot_password"),
+            self._payload(email),
+            format="json",
+            HTTP_X_HFL_SITE_ROLE="ops",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["code"], "0000")

--- a/src/backend/apps/iam/tests/test_registration.py
+++ b/src/backend/apps/iam/tests/test_registration.py
@@ -164,6 +164,22 @@ class RegistrationApiTests(APITestCase):
         self.assertEqual(response.data["error"]["error_code"], "VALIDATION_ERROR")
         self.assertIn("turnstile_token", response.data["error"]["fields"])
 
+    @override_settings(
+        TURNSTILE_ENABLED=True,
+        TURNSTILE_SITE_KEY="site-key",
+        TURNSTILE_SECRET_KEY="",
+    )
+    def test_ops_site_registration_bypasses_turnstile(self):
+        response = self.client.post(
+            reverse("email_register_send_code"),
+            {"email": "ops-register@example.com"},
+            format="json",
+            HTTP_X_HFL_SITE_ROLE="ops",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["code"], "0000")
+
 
 @override_settings(HFL_EMAIL_SIGNUP_ENABLED=False)
 @patch.dict("os.environ", {"HFL_EMAIL_SIGNUP_ENABLED": "false"})

--- a/src/backend/apps/iam/tests/test_turnstile_config.py
+++ b/src/backend/apps/iam/tests/test_turnstile_config.py
@@ -43,6 +43,23 @@ class TurnstileConfigViewTests(TestCase):
         self.assertFalse(payload["data"]["configured"])
         self.assertNotIn("site_key", payload["data"])
 
+    @override_settings(
+        TURNSTILE_ENABLED=True,
+        TURNSTILE_SITE_KEY="test-site-key",
+        TURNSTILE_SECRET_KEY="test-secret-key",
+    )
+    def test_ops_site_reports_turnstile_disabled(self):
+        response = self.client.get(
+            "/api/v1/auth/turnstile/config",
+            HTTP_X_HFL_SITE_ROLE="ops",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertFalse(payload["data"]["enabled"])
+        self.assertFalse(payload["data"]["configured"])
+        self.assertNotIn("site_key", payload["data"])
+
     def test_public_config_ignores_invalid_access_token_cookie(self):
         self.client.cookies["access_token"] = "not-a-valid-jwt"
         response = self.client.get("/api/v1/auth/turnstile/config")

--- a/src/backend/apps/iam/tests/test_turnstile_verification.py
+++ b/src/backend/apps/iam/tests/test_turnstile_verification.py
@@ -8,27 +8,50 @@ from apps.iam.services.turnstile_verification import (
     missing_turnstile_fields,
     turnstile_configured,
     turnstile_enabled,
+    turnstile_required,
     verify_turnstile_for_action,
 )
 
 
 class TurnstileVerificationTests(SimpleTestCase):
+    @staticmethod
+    def _request(site_role: str = "tenant") -> MagicMock:
+        request = MagicMock()
+        request.META = {
+            "HTTP_X_HFL_SITE_ROLE": site_role,
+            "REMOTE_ADDR": "127.0.0.1",
+        }
+        return request
+
     @override_settings(TURNSTILE_ENABLED=False)
     def test_disabled_mode_requires_no_token(self):
+        request = self._request()
         self.assertFalse(turnstile_enabled())
-        self.assertEqual(missing_turnstile_fields({}), {})
+        self.assertEqual(missing_turnstile_fields({}, request), {})
         self.assertTrue(
-            verify_turnstile_for_action({}, MagicMock(), action="login"),
+            verify_turnstile_for_action({}, request, action="login"),
         )
 
     @override_settings(TURNSTILE_ENABLED=True)
     def test_enabled_mode_requires_token(self):
+        request = self._request()
         self.assertTrue(turnstile_enabled())
-        self.assertIn("turnstile_token", missing_turnstile_fields({}))
+        self.assertTrue(turnstile_required(request))
+        self.assertIn("turnstile_token", missing_turnstile_fields({}, request))
         self.assertEqual(
-            missing_turnstile_fields({"turnstile_token": "tok"}),
+            missing_turnstile_fields({"turnstile_token": "tok"}, request),
             {},
         )
+
+    @override_settings(TURNSTILE_ENABLED=True)
+    @patch("apps.iam.services.turnstile_verification.validate_turnstile")
+    def test_ops_site_never_requires_or_verifies_turnstile(self, mock_validate):
+        request = self._request("ops")
+
+        self.assertFalse(turnstile_required(request))
+        self.assertEqual(missing_turnstile_fields({}, request), {})
+        self.assertTrue(verify_turnstile_for_action({}, request, action="login"))
+        mock_validate.assert_not_called()
 
     @override_settings(
         TURNSTILE_ENABLED=True,
@@ -41,17 +64,26 @@ class TurnstileVerificationTests(SimpleTestCase):
         return_value=True,
     )
     def test_enabled_mode_binds_token_to_action_and_hostname(self, mock_validate):
-        request = MagicMock()
-        request.META = {"REMOTE_ADDR": "127.0.0.1"}
+        request = self._request()
 
-        self.assertTrue(turnstile_configured())
-        self.assertTrue(
-            verify_turnstile_for_action(
-                {"turnstile_token": "token-value"},
-                request,
-                action="login",
+        with (
+            patch(
+                "apps.platform_ops.services.internal.runtime_settings.turnstile_site_key",
+                return_value="site-key",
             ),
-        )
+            patch(
+                "apps.platform_ops.services.internal.runtime_settings.turnstile_secret_key",
+                return_value="secret-key",
+            ),
+        ):
+            self.assertTrue(turnstile_configured())
+            self.assertTrue(
+                verify_turnstile_for_action(
+                    {"turnstile_token": "token-value"},
+                    request,
+                    action="login",
+                ),
+            )
         mock_validate.assert_called_once_with(
             "token-value",
             "127.0.0.1",
@@ -65,11 +97,21 @@ class TurnstileVerificationTests(SimpleTestCase):
         TURNSTILE_SECRET_KEY="",
     )
     def test_enabled_mode_rejects_incomplete_configuration(self):
-        self.assertFalse(turnstile_configured())
-        self.assertFalse(
-            verify_turnstile_for_action(
-                {"turnstile_token": "token-value"},
-                MagicMock(),
-                action="login",
+        with (
+            patch(
+                "apps.platform_ops.services.internal.runtime_settings.turnstile_site_key",
+                return_value="site-key",
             ),
-        )
+            patch(
+                "apps.platform_ops.services.internal.runtime_settings.turnstile_secret_key",
+                return_value="",
+            ),
+        ):
+            self.assertFalse(turnstile_configured())
+            self.assertFalse(
+                verify_turnstile_for_action(
+                    {"turnstile_token": "token-value"},
+                    self._request(),
+                    action="login",
+                ),
+            )

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -402,6 +402,12 @@ if grep -F -- '--network host' "${smoke_runner}" >/dev/null; then
 fi
 grep -F 'image: hyperfilelens-postgres:17' "${ROOT}/deploy/docker-compose.yml" >/dev/null
 grep -F 'absolute_redirect off;' "${ROOT}/deploy/nginx/default.conf" >/dev/null
+grep -F 'map $server_port $hfl_site {' \
+	"${ROOT}/deploy/nginx/snippets/hfl-log-format.conf" >/dev/null
+grep -E '^[[:space:]]*10444[[:space:]]+ops;' \
+	"${ROOT}/deploy/nginx/snippets/hfl-log-format.conf" >/dev/null
+grep -F 'proxy_set_header X-HFL-Site-Role $hfl_site;' \
+	"${ROOT}/deploy/nginx/snippets/hfl-backend-proxy-headers.inc" >/dev/null
 grep -F 'mem_limit: 448m' "${ROOT}/deploy/docker-compose.yml" >/dev/null
 grep -F 'name: hyperfilelens-sourcelens' \
 	"${ROOT}/deploy/installer/sourcelens/docker-compose.template.yml" >/dev/null


### PR DESCRIPTION
## Summary

- keep Turnstile enabled for tenant authentication on port 11443
- always bypass Turnstile for the security-group-protected ops console on port 11444
- preserve fail-closed tenant behavior and enforce the trusted Nginx site-role header contract
- add request-aware IAM coverage without introducing a new environment variable

## Validation

- `uv run ruff check src/backend`
- 30 focused IAM tests passed
- `bash tools/quality/check-release-contracts.sh`
- Ubuntu 20.04 / Python 3.8 compatibility checks
- `git diff --check`