### PR TITLE
fix(admin): open the console on the overview page

### DIFF
--- a/src/backend/common/deploy/site.py
+++ b/src/backend/common/deploy/site.py
@@ -12,6 +12,9 @@ if TYPE_CHECKING:
     from django.http import HttpRequest
 
 
+PLATFORM_OPS_LANDING_PATH = "/platform-ops/overview"
+
+
 def resolve_site_role(request: HttpRequest) -> str:
     """Return ``tenant`` or ``ops`` from the edge-controlled request header."""
     role = str(request.META.get("HTTP_X_HFL_SITE_ROLE") or "").strip().lower()
@@ -123,5 +126,5 @@ def admin_console_public_url(request: HttpRequest) -> str:
 def default_landing_path(request: HttpRequest) -> str:
     site = resolve_site_role(request)
     if site == "ops" and platform_ops_access_allowed(request):
-        return "/platform-ops/monitoring/host"
+        return PLATFORM_OPS_LANDING_PATH
     return "/"

--- a/src/backend/common/meta/tests/test_deploy_profile.py
+++ b/src/backend/common/meta/tests/test_deploy_profile.py
@@ -63,6 +63,7 @@ class DeployProfileViewTest(TestCase):
         self.assertEqual(response.data["site_role"], "ops")
         self.assertFalse(response.data["admin_console_entry_visible"])
         self.assertTrue(response.data["platform_ops_access_allowed"])
+        self.assertEqual(response.data["landing_path"], "/platform-ops/overview")
 
     @override_settings(FRONTEND_URL="https://app.example.com:11443", HFL_ADMIN_PORT=11444)
     def test_admin_console_url_uses_tenant_host_and_configured_port(self):

--- a/src/frontend/src/app/layout/TopNav.vue
+++ b/src/frontend/src/app/layout/TopNav.vue
@@ -8,7 +8,7 @@ import NavUserMenu from '../../components/NavUserMenu.vue'
 import OrgSwitcher from '../../components/OrgSwitcher.vue'
 import AppLogoMark from '../../components/AppLogoMark.vue'
 import { useLocaleSwitch } from '../../composables/useLocaleSwitch'
-import { fetchDeployProfile } from '../../composables/useDeployProfile'
+import { fetchDeployProfile, platformOpsEntryUrl } from '../../composables/useDeployProfile'
 import { currentUser } from '../../composables/useAuth'
 import { beginRouteRequestScope } from '../../lib/routeRequestAbort'
 import { beginRouteTransition } from '../../lib/routeTransition'
@@ -17,6 +17,7 @@ const { t } = useI18n()
 const { canSwitchLocale, nextLocaleLabel, toggleLocale } = useLocaleSwitch()
 
 const adminConsoleUrl = ref('')
+const adminConsoleHref = computed(() => platformOpsEntryUrl(adminConsoleUrl.value))
 
 async function refreshAdminConsoleEntry() {
   const profile = await fetchDeployProfile(true)
@@ -145,9 +146,9 @@ function handleNavClick(event: MouseEvent, to: string) {
       <OrgSwitcher />
 
       <a
-        v-if="adminConsoleUrl"
+        v-if="adminConsoleHref"
         class="platform-ops-entry"
-        :href="`${adminConsoleUrl}/platform-ops/monitoring/host`"
+        :href="adminConsoleHref"
         target="_blank"
         rel="noopener noreferrer"
       >

--- a/src/frontend/src/composables/useDeployProfile.test.ts
+++ b/src/frontend/src/composables/useDeployProfile.test.ts
@@ -2,6 +2,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   clearDeployProfileCache,
   fetchDeployProfile,
+  platformOpsEntryUrl,
+  resolvePostLoginPath,
   shouldForceDeployProfileRefresh,
 } from './useDeployProfile'
 
@@ -12,7 +14,7 @@ const deployProfile = {
   self_service_password_reset: true,
   tenant_public_url: 'https://example.test:11443',
   admin_console_url: 'https://example.test:11444',
-  landing_path: '/platform-ops/monitoring/host',
+  landing_path: '/platform-ops/overview',
   admin_console_entry_visible: false,
   platform_ops_access_allowed: true,
 }
@@ -52,6 +54,21 @@ describe('deploy profile caching', () => {
     await fetchDeployProfile(false)
 
     expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('lands operations staff on the Admin Overview after login', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(deployProfile), { status: 200 }),
+    ))
+
+    await expect(resolvePostLoginPath()).resolves.toBe('/platform-ops/overview')
+  })
+
+  it('builds the tenant-to-admin entry URL for the Admin Overview', () => {
+    expect(platformOpsEntryUrl('https://example.test:11444/')).toBe(
+      'https://example.test:11444/platform-ops/overview',
+    )
+    expect(platformOpsEntryUrl('')).toBe('')
   })
 })
 

--- a/src/frontend/src/composables/useDeployProfile.ts
+++ b/src/frontend/src/composables/useDeployProfile.ts
@@ -12,6 +12,8 @@ export interface DeployProfile {
   support_org_key?: string | null
 }
 
+export const PLATFORM_OPS_LANDING_PATH = '/platform-ops/overview'
+
 let cachedProfile: DeployProfile | null = null
 let inflight: Promise<DeployProfile | null> | null = null
 
@@ -66,7 +68,12 @@ export function shouldForceDeployProfileRefresh(
   return targetsPlatformOps && !fromPath.startsWith('/platform-ops')
 }
 
-/** Post-login redirect: ops site staff → /platform-ops/users, else tenant home. */
+export function platformOpsEntryUrl(adminConsoleUrl: string): string {
+  const origin = adminConsoleUrl.trim().replace(/\/+$/, '')
+  return origin ? `${origin}${PLATFORM_OPS_LANDING_PATH}` : ''
+}
+
+/** Resolve the deployment-specific post-login landing page. */
 export async function resolvePostLoginPath(): Promise<string> {
   const profile = await fetchDeployProfile(true)
   const path = profile?.landing_path?.trim()


### PR DESCRIPTION
Summary
- open the Admin Console entry directly on Overview
- return Overview as the operations-site post-login landing path
- centralize and test the Admin Console entry URL

Validation
- frontend unit tests: 7 passed
- backend deploy-profile tests: 7 passed
- frontend typecheck, ESLint, and production build