### PR TITLE
feat: unify Data Gateway lifecycle management

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -140,6 +140,7 @@ jobs:
           ./tools/quality/test-default-certificates.sh
           ./tools/quality/test-gateway-bootstrap-health.sh
           ./tools/quality/test-platform-gateway-auto-deploy.sh
+          ./tools/quality/test-agent-gateway-uninstall.sh
           ./tools/quality/test-shared-host-guard.sh
           ./tools/quality/test-deployment-optional-config.sh
           ./tools/quality/test-payload-tree-hash.sh

--- a/deploy/bootstrap/gateway-lifecycle.sh
+++ b/deploy/bootstrap/gateway-lifecycle.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 
 ENV_FILE="${HFL_AGENT_ENV_FILE:-/var/lib/hyperfilelens-agent/agent.env}"
 LENS_ENV_FILE="${HFL_LENS_ENV_FILE:-/etc/hyperfilelens/lensnode.env}"
-COMPOSE_DIR="/etc/hyperfilelens/lensnode"
+COMPOSE_DIR="${HFL_GATEWAY_COMPOSE_DIR:-/etc/hyperfilelens/lensnode}"
 GATEWAY_BOOTSTRAP_BASE=""
 HFL_API_BASE=""
 HFL_ORG_KEY=""
@@ -18,6 +18,7 @@ LENSNODE_IMAGE_ARCHIVE="lensnode-image-linux-amd64.tar.gz"
 SIDECAR_INSTALL_SCRIPT="gateway-install-lensnode-sidecar.sh"
 COMPOSE_PROJECT="hyperfilelens-gateway"
 DEFAULT_LENSNODE_IMAGE="hyperfilelens-sourcelens-lensnode:latest"
+OWNED_LENSNODE_IMAGES=("${DEFAULT_LENSNODE_IMAGE}")
 
 hfl_now() {
 	date -u +%Y-%m-%dT%H:%M:%S.000Z 2>/dev/null || date -u +%Y-%m-%dT%H:%M:%SZ
@@ -56,14 +57,19 @@ read_env_value() {
 }
 
 load_agent_credentials() {
-	[[ -f "${ENV_FILE}" ]] || hfl_fail "missing ${ENV_FILE}" 2
+	load_agent_credentials_optional || hfl_fail "missing or incomplete ${ENV_FILE}" 2
+}
+
+load_agent_credentials_optional() {
+	[[ -f "${ENV_FILE}" ]] || return 1
 	HFL_API_BASE="$(read_env_value "${ENV_FILE}" HFL_API_BASE)"
 	HFL_ORG_KEY="$(read_env_value "${ENV_FILE}" HFL_ORG_KEY)"
 	HFL_NODE_TOKEN="$(read_env_value "${ENV_FILE}" HFL_NODE_TOKEN)"
 	HFL_NODE_ID="$(read_env_value "${ENV_FILE}" HFL_NODE_ID)"
 	[[ -n "${HFL_API_BASE}" && -n "${HFL_ORG_KEY}" && -n "${HFL_NODE_TOKEN}" && -n "${HFL_NODE_ID}" ]] \
-		|| hfl_fail "incomplete agent credentials in ${ENV_FILE}" 2
+		|| return 1
 	GATEWAY_BOOTSTRAP_BASE="${HFL_API_BASE%/}/media/gateway-bootstrap"
+	return 0
 }
 
 report_lifecycle_status() {
@@ -93,6 +99,12 @@ ensure_docker_ready() {
 	docker info >/dev/null 2>&1 || hfl_fail "docker daemon not reachable" 3
 }
 
+remember_owned_lensnode_image() {
+	local image=${1:-}
+	[[ -n "${image}" ]] || return 0
+	OWNED_LENSNODE_IMAGES+=("${image}")
+}
+
 remove_owned_legacy_gateway_containers() {
 	local id project service working_dir config_files
 	while IFS= read -r id; do
@@ -106,21 +118,44 @@ remove_owned_legacy_gateway_containers() {
 			&& ",${config_files}," != *",${COMPOSE_DIR}/docker-compose.yml,"* ]]; then
 			continue
 		fi
+		remember_owned_lensnode_image "$(docker inspect --format '{{.Config.Image}}' "${id}" 2>/dev/null || true)"
 		hfl_log "Removing owned legacy Gateway container ${id:0:12} from project sourcelens."
 		docker rm -f "${id}" >/dev/null
 	done < <(docker ps -aq --no-trunc)
 }
 
 compose_down_sidecar() {
+	local id
 	remove_owned_legacy_gateway_containers
-	if [[ ! -f "${COMPOSE_DIR}/docker-compose.yml" ]]; then
-		return 0
-	fi
-	if docker compose version >/dev/null 2>&1; then
+	if [[ -f "${COMPOSE_DIR}/docker-compose.yml" ]]; then
+		docker compose version >/dev/null 2>&1 \
+			|| hfl_fail "Docker Compose v2 is required to remove the LensNode sidecar" 3
+		while IFS= read -r image; do
+			remember_owned_lensnode_image "${image}"
+		done < <(
+			cd "${COMPOSE_DIR}"
+			docker compose -p "${COMPOSE_PROJECT}" config --images 2>/dev/null || true
+		)
 		(
 			cd "${COMPOSE_DIR}"
-			docker compose -p "${COMPOSE_PROJECT}" down || true
+			docker compose -p "${COMPOSE_PROJECT}" down --remove-orphans
 		)
+	fi
+	while IFS= read -r id; do
+		[[ -n "${id}" ]] || continue
+		remember_owned_lensnode_image "$(docker inspect --format '{{.Config.Image}}' "${id}" 2>/dev/null || true)"
+		hfl_log "Removing owned Gateway LensNode container ${id:0:12}."
+		docker rm -f "${id}" >/dev/null
+	done < <(
+		docker ps -aq \
+			--filter 'label=com.hyperfilelens.managed=true' \
+			--filter 'label=com.hyperfilelens.component=gateway-lensnode'
+	)
+	if docker ps -aq \
+		--filter 'label=com.hyperfilelens.managed=true' \
+		--filter 'label=com.hyperfilelens.component=gateway-lensnode' \
+		| grep -q .; then
+		hfl_fail "Gateway LensNode containers remain after uninstall" 4
 	fi
 }
 
@@ -185,7 +220,18 @@ cmd_upgrade_sidecar() {
 }
 
 remove_lensnode_images() {
-	docker image rm -f "${DEFAULT_LENSNODE_IMAGE}" 2>/dev/null || true
+	local image
+	local -A seen=()
+	for image in "${OWNED_LENSNODE_IMAGES[@]}"; do
+		[[ -n "${image}" && -z "${seen[${image}]:-}" ]] || continue
+		seen["${image}"]=1
+		if docker ps -aq --filter "ancestor=${image}" | grep -q .; then
+			hfl_log "Keeping shared LensNode image ${image}; another container still references it."
+			continue
+		fi
+		docker image rm "${image}" >/dev/null 2>&1 \
+			|| hfl_log "LensNode image ${image} was absent or retained by Docker."
+	done
 }
 
 purge_sidecar_artifacts() {
@@ -208,7 +254,10 @@ purge_sidecar_artifacts() {
 }
 
 cmd_uninstall_sidecar() {
-	load_agent_credentials
+	if ! load_agent_credentials_optional; then
+		hfl_log "Agent credentials are unavailable; continuing local LensNode cleanup without status reporting."
+	fi
+	ensure_docker_ready
 	report_lifecycle_status "sidecar_uninstall" "running"
 	if [[ "${PURGE_ALL}" -eq 1 ]]; then
 		purge_sidecar_artifacts

--- a/src/agent/internal/enroll/gateway_lifecycle.go
+++ b/src/agent/internal/enroll/gateway_lifecycle.go
@@ -82,6 +82,7 @@ func RunGatewayUninstall(ctx context.Context, purgeAll bool) error {
 		args = append(args, "--purge-all")
 	}
 	cmd := exec.CommandContext(ctx, "/bin/bash", args...)
+	cmd.Env = append(os.Environ(), "HFL_SKIP_GATEWAY_SIDECAR_UNINSTALL=1")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {

--- a/src/agent/internal/platform/install/gateway_hooks_unix.go
+++ b/src/agent/internal/platform/install/gateway_hooks_unix.go
@@ -38,7 +38,7 @@ run_gateway_sidecar_upgrade_if_needed() {
 
 const unixGatewaySidecarUninstallHook = `
 run_gateway_sidecar_uninstall_if_needed() {
-  local env_file="/var/lib/hyperfilelens-agent/agent.env"
+  local env_file="$DATA_DIR/agent.env"
   local api_base org token node_id insecure bootstrap script tmp curl_tls purge_args
   [[ -f "$env_file" ]] || return 0
   grep -q '^HFL_NODE_ROLE=gateway' "$env_file" || return 0
@@ -53,21 +53,25 @@ run_gateway_sidecar_uninstall_if_needed() {
   }
   curl_tls=()
   [[ "$insecure" != "0" ]] && curl_tls=(-k)
-  bootstrap="${api_base%/}/media/gateway-bootstrap"
-  tmp="$(mktemp -d)"
-  script="${tmp}/gateway-lifecycle.sh"
-  if ! curl "${curl_tls[@]}" -fsSL "${bootstrap}/gateway-lifecycle.sh" -o "$script"; then
-    log "WARN " "Failed to download gateway-lifecycle.sh; continuing agent uninstall."
-    rm -rf "$tmp"
-    return 0
+  script="$INSTALL_DIR/libexec/gateway-lifecycle.sh"
+  tmp=""
+  if [[ ! -x "$script" ]]; then
+    bootstrap="${api_base%/}/media/gateway-bootstrap"
+    tmp="$(mktemp -d)"
+    script="${tmp}/gateway-lifecycle.sh"
+    if ! curl "${curl_tls[@]}" -fsSL "${bootstrap}/gateway-lifecycle.sh" -o "$script"; then
+      log "FAIL " "Failed to obtain gateway-lifecycle.sh; keeping the Agent installed for retry."
+      rm -rf "$tmp"
+      return 1
+    fi
+    chmod +x "$script"
   fi
-  chmod +x "$script"
   purge_args=()
   [[ "$KEEP_DATA" == "0" ]] && purge_args=(--purge-all)
   log "INFO " "Running gateway sidecar uninstall."
   HFL_AGENT_ENV_FILE="$env_file" HFL_INSECURE_TLS="${insecure:-1}" bash "$script" uninstall-sidecar "${purge_args[@]}"
   local rc=$?
-  rm -rf "$tmp"
+  [[ -z "$tmp" ]] || rm -rf "$tmp"
   return $rc
 }
 `

--- a/src/agent/internal/platform/install/local_uninstall_unix.go
+++ b/src/agent/internal/platform/install/local_uninstall_unix.go
@@ -12,6 +12,7 @@ import (
 const (
 	unixServiceUnit      = "hyperfilelens-agent.service"
 	unixUnitPath         = "/etc/systemd/system/hyperfilelens-agent.service"
+	unixResourceDropIn   = "/etc/systemd/system/hyperfilelens-agent.service.d/20-gateway-resources.conf"
 	unixLaunchdPlist     = "/Library/LaunchDaemons/com.hyperfilelens.agent.plist"
 	unixLaunchdLabel     = "com.hyperfilelens.agent"
 	unixDefaultDataRoot  = "/var/lib/hyperfilelens-agent"
@@ -80,6 +81,7 @@ DATA_DIR=%q
 LOG_FILE=%q
 KEEP_DATA=%s
 UNIT_FILE=%q
+RESOURCE_DROPIN=%q
 SERVICE_NAME=%q
 LAUNCHD_PLIST=%q
 LAUNCHD_LABEL=%q
@@ -97,7 +99,10 @@ log "detached uninstall script started install_dir=$INSTALL_DIR data_dir=$DATA_D
 sleep "$SLEEP_SECONDS"
 log "delay elapsed; running gateway sidecar uninstall when applicable"
 %s
-run_gateway_sidecar_uninstall_if_needed || log "gateway sidecar uninstall reported errors; continuing agent uninstall"
+if ! run_gateway_sidecar_uninstall_if_needed; then
+  log "gateway sidecar uninstall failed; keeping the Agent installed for retry"
+  exit 1
+fi
 log "delay elapsed; stopping service"
 
 if [[ "$(uname -s)" == "Darwin" ]]; then
@@ -132,6 +137,15 @@ elif command -v systemctl >/dev/null 2>&1; then
   fi
 else
   log "systemctl not found; skipped service stop/disable"
+fi
+
+if [[ "$(uname -s)" != "Darwin" && -f "$RESOURCE_DROPIN" ]]; then
+  if rm -f "$RESOURCE_DROPIN"; then
+    log "removed gateway resource policy $RESOURCE_DROPIN"
+    rmdir "$(dirname "$RESOURCE_DROPIN")" 2>/dev/null || true
+  else
+    log "failed to remove gateway resource policy $RESOURCE_DROPIN (exit=$?)"
+  fi
 fi
 
 if [[ "$(uname -s)" != "Darwin" && -f "$UNIT_FILE" ]]; then
@@ -224,6 +238,7 @@ log "detached uninstall script finished"
 		logFile,
 		keepFlag,
 		unixUnitPath,
+		unixResourceDropIn,
 		unixServiceUnit,
 		unixLaunchdPlist,
 		unixLaunchdLabel,

--- a/src/agent/internal/platform/install/local_uninstall_unix_test.go
+++ b/src/agent/internal/platform/install/local_uninstall_unix_test.go
@@ -39,4 +39,19 @@ func TestWriteUnixUninstallScriptIncludesLogFile(t *testing.T) {
 	if !strings.Contains(body, `removed install directory tree $INSTALL_DIR (including backup artifacts)`) {
 		t.Fatalf("script should remove install dir tree including backup:\n%s", body)
 	}
+	if !strings.Contains(body, `script="$INSTALL_DIR/libexec/gateway-lifecycle.sh"`) {
+		t.Fatalf("script should prefer the Agent-owned Gateway lifecycle helper:\n%s", body)
+	}
+	if !strings.Contains(body, `local env_file="$DATA_DIR/agent.env"`) {
+		t.Fatalf("script should read Gateway credentials from the resolved data directory:\n%s", body)
+	}
+	if !strings.Contains(body, `removed gateway resource policy $RESOURCE_DROPIN`) {
+		t.Fatalf("script should remove the Data Gateway systemd resource policy:\n%s", body)
+	}
+	if !strings.Contains(body, `gateway sidecar uninstall failed; keeping the Agent installed for retry`) {
+		t.Fatalf("script should fail closed when LensNode removal fails:\n%s", body)
+	}
+	if strings.Contains(body, `gateway sidecar uninstall reported errors; continuing agent uninstall`) {
+		t.Fatalf("script must not remove the Agent after LensNode removal fails:\n%s", body)
+	}
 }

--- a/src/agent/packaging/install/install.sh
+++ b/src/agent/packaging/install/install.sh
@@ -11,11 +11,13 @@ BUNDLE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Unix paths use product slug "hyperfilelens-agent" (see internal/platform/vfs/paths.go).
 INSTALL_DIR="/opt/hyperfilelens-agent"
 UNIT_DST="/etc/systemd/system/hyperfilelens-agent.service"
+GATEWAY_RESOURCE_DROPIN="/etc/systemd/system/hyperfilelens-agent.service.d/20-gateway-resources.conf"
 DEFAULT_DATA="/var/lib/hyperfilelens-agent"
 INSTALLED_VERSION_FILE="${INSTALL_DIR}/INSTALLED_VERSION"
 LAUNCHD_PLIST="/Library/LaunchDaemons/com.hyperfilelens.agent.plist"
 LAUNCHD_LABEL="com.hyperfilelens.agent"
 RUN_AGENT_SCRIPT="${INSTALL_DIR}/run-agent.sh"
+GATEWAY_LIFECYCLE_SCRIPT="${INSTALL_DIR}/libexec/gateway-lifecycle.sh"
 
 if [[ $# -eq 0 ]]; then
 	CMD="install"
@@ -81,10 +83,14 @@ Options:
 
 Install paths:
   /opt/hyperfilelens-agent                         Binaries and installer scripts
+  /opt/hyperfilelens-agent/libexec/gateway-lifecycle.sh
+                                                   Data Gateway LensNode lifecycle helper
   /var/lib/hyperfilelens-agent                     Runtime data, backup, and configuration
   /var/lib/hyperfilelens-agent/backup/state/       Pre-upgrade agent.env/agent.db snapshot (retained until uninstall --purge-all)
   /opt/hyperfilelens-agent/backup/                 Legacy upgrade archives (removed on uninstall)
   /etc/systemd/system/hyperfilelens-agent.service  systemd unit (Linux)
+  /etc/systemd/system/hyperfilelens-agent.service.d/20-gateway-resources.conf
+                                                   Soft resource policy for role=gateway
   /Library/LaunchDaemons/com.hyperfilelens.agent.plist  LaunchDaemon (macOS)
 
 Examples:
@@ -552,6 +558,7 @@ backup_upgrade_binaries() {
 	[[ -f "${INSTALL_DIR}/kopia" ]] && cp -a "${INSTALL_DIR}/kopia" "${UPGRADE_BIN_BACKUP}/"
 	[[ -f "${INSTALL_DIR}/MANIFEST.json" ]] && cp -a "${INSTALL_DIR}/MANIFEST.json" "${UPGRADE_BIN_BACKUP}/"
 	[[ -f "${INSTALLED_VERSION_FILE}" ]] && cp -a "${INSTALLED_VERSION_FILE}" "${UPGRADE_BIN_BACKUP}/"
+	[[ -d "${INSTALL_DIR}/libexec" ]] && cp -a "${INSTALL_DIR}/libexec" "${UPGRADE_BIN_BACKUP}/"
 	log_ok "backed up binaries -> ${UPGRADE_BIN_BACKUP}"
 }
 
@@ -561,6 +568,10 @@ restore_upgrade_binaries() {
 	[[ -f "${UPGRADE_BIN_BACKUP}/kopia" ]] && cp -a "${UPGRADE_BIN_BACKUP}/kopia" "${INSTALL_DIR}/"
 	[[ -f "${UPGRADE_BIN_BACKUP}/MANIFEST.json" ]] && cp -a "${UPGRADE_BIN_BACKUP}/MANIFEST.json" "${INSTALL_DIR}/"
 	[[ -f "${UPGRADE_BIN_BACKUP}/INSTALLED_VERSION" ]] && cp -a "${UPGRADE_BIN_BACKUP}/INSTALLED_VERSION" "${INSTALLED_VERSION_FILE}"
+	rm -rf "${INSTALL_DIR}/libexec"
+	if [[ -d "${UPGRADE_BIN_BACKUP}/libexec" ]]; then
+		cp -a "${UPGRADE_BIN_BACKUP}/libexec" "${INSTALL_DIR}/"
+	fi
 	log_warn "restored binaries from ${UPGRADE_BIN_BACKUP}"
 }
 
@@ -828,12 +839,18 @@ deploy_admin_scripts() {
 	local src_root="${1:-${BUNDLE_ROOT}}"
 	local src_script="${src_root}/install.sh"
 	local src_manifest="${src_root}/MANIFEST.json"
+	local src_gateway_lifecycle="${src_root}/libexec/gateway-lifecycle.sh"
 	[[ -f "$src_script" ]] || log_fail "Missing bundle installer: ${src_script}." 2
 	install -m 755 "$src_script" "${INSTALL_DIR}/install.sh"
 	log_ok "deployed ${INSTALL_DIR}/install.sh"
 	if [[ -f "$src_manifest" ]]; then
 		install -m 644 "$src_manifest" "${INSTALL_DIR}/MANIFEST.json"
 		log_ok "deployed ${INSTALL_DIR}/MANIFEST.json"
+	fi
+	if [[ "$(uname -s)" == "Linux" && -f "${src_gateway_lifecycle}" ]]; then
+		install -d -m 755 "${INSTALL_DIR}/libexec"
+		install -m 755 "${src_gateway_lifecycle}" "${GATEWAY_LIFECYCLE_SCRIPT}"
+		log_ok "deployed ${GATEWAY_LIFECYCLE_SCRIPT}"
 	fi
 }
 
@@ -920,6 +937,61 @@ EOF
 	fi
 }
 
+configure_gateway_resource_policy() {
+	local env_file="$1" role=""
+	[[ "$(uname -s)" == "Linux" ]] || return 0
+	role="$(read_env_value "${env_file}" "HFL_NODE_ROLE" || true)"
+	if [[ "${role}" != "gateway" ]]; then
+		rm -f "${GATEWAY_RESOURCE_DROPIN}"
+		return 0
+	fi
+	install -d -m 755 "$(dirname "${GATEWAY_RESOURCE_DROPIN}")"
+	cat >"${GATEWAY_RESOURCE_DROPIN}" <<'EOF'
+[Service]
+CPUAccounting=true
+CPUWeight=50
+IOAccounting=true
+IOWeight=50
+MemoryAccounting=true
+MemoryHigh=768M
+TasksMax=256
+EOF
+	chmod 644 "${GATEWAY_RESOURCE_DROPIN}"
+	log_ok "installed Data Gateway soft resource policy ${GATEWAY_RESOURCE_DROPIN}"
+}
+
+gateway_resource_preflight() {
+	local role="$1" data_dir="$2" available_kb=0 free_kb=0 check_path=""
+	[[ "${role}" == "gateway" && "$(uname -s)" == "Linux" ]] || return 0
+	available_kb="$(awk '/^MemAvailable:/ {print $2; exit}' /proc/meminfo 2>/dev/null || true)"
+	if [[ "${available_kb}" =~ ^[0-9]+$ ]]; then
+		if [[ "${available_kb}" -lt 1048576 ]]; then
+			log_fail "Data Gateway installation needs at least 1GiB available memory; found $((available_kb / 1024))MiB." 2
+		elif [[ "${available_kb}" -lt 2097152 ]]; then
+			log_warn "Data Gateway has less than 2GiB available memory ($((available_kb / 1024))MiB)."
+		else
+			log_ok "Data Gateway memory preflight passed ($((available_kb / 1024))MiB available)"
+		fi
+	fi
+	check_path="${data_dir}"
+	while [[ ! -e "${check_path}" && "${check_path}" != "/" ]]; do
+		check_path="$(dirname "${check_path}")"
+	done
+	free_kb="$(df -Pk "${check_path}" 2>/dev/null | awk 'NR==2 {print $4}' || true)"
+	if [[ "${free_kb}" =~ ^[0-9]+$ ]]; then
+		if [[ "${free_kb}" -lt 10485760 ]]; then
+			log_fail "Data Gateway installation needs at least 10GiB free disk space; found $((free_kb / 1024))MiB." 2
+		elif [[ "${free_kb}" -lt 20971520 ]]; then
+			log_warn "Data Gateway has less than 20GiB free disk space ($((free_kb / 1024))MiB)."
+		else
+			log_ok "Data Gateway disk preflight passed ($((free_kb / 1024))MiB free)"
+		fi
+	fi
+	if [[ -r /proc/swaps ]] && [[ "$(wc -l </proc/swaps)" -le 1 ]]; then
+		log_warn "No swap is configured; monitor host memory pressure for this Data Gateway."
+	fi
+}
+
 stop_service() {
 	if agent_uses_launchd; then
 		stop_launchd_service
@@ -971,6 +1043,11 @@ disable_service() {
 }
 
 remove_systemd_unit() {
+	if [[ -f "${GATEWAY_RESOURCE_DROPIN}" ]]; then
+		rm -f "${GATEWAY_RESOURCE_DROPIN}"
+		rmdir "$(dirname "${GATEWAY_RESOURCE_DROPIN}")" 2>/dev/null || true
+		log_ok "removed Data Gateway resource policy ${GATEWAY_RESOURCE_DROPIN}"
+	fi
 	if [[ -f "$UNIT_DST" ]]; then
 		rm -f "$UNIT_DST"
 		log_ok "removed unit ${UNIT_DST}"
@@ -987,6 +1064,7 @@ install_systemd_unit_logged() {
 	local env_file="$1"
 	local src_root="${2:-${BUNDLE_ROOT}}"
 	install_systemd_unit "$env_file" "$src_root"
+	configure_gateway_resource_policy "$env_file"
 	log_ok "installed unit ${UNIT_DST}"
 }
 
@@ -1053,6 +1131,7 @@ cmd_install() {
 		log_info "Platform: $(uname -s | tr '[:upper:]' '[:lower:]')/$(bundle_arch) · Role: ${NODE_ROLE} · Install dir: ${INSTALL_DIR} · Data dir: ${DATA_DIR}."
 	fi
 
+	gateway_resource_preflight "${NODE_ROLE}" "${DATA_DIR}"
 	install_nas_deps "${NODE_ROLE}"
 	deploy_binaries
 	write_agent_env "${DATA_DIR}/agent.env"
@@ -1268,17 +1347,35 @@ remove_install_file() {
 	fi
 }
 
+uninstall_gateway_sidecar_if_needed() {
+	local env_file="$1" role="" purge_args=()
+	[[ "${HFL_SKIP_GATEWAY_SIDECAR_UNINSTALL:-0}" != "1" ]] || return 0
+	role="$(read_env_value "${env_file}" "HFL_NODE_ROLE" || true)"
+	[[ "${role}" == "gateway" ]] || return 0
+	[[ "$(uname -s)" == "Linux" ]] \
+		|| log_fail "Data Gateway LensNode uninstall is supported on Linux only." 2
+	[[ -x "${GATEWAY_LIFECYCLE_SCRIPT}" ]] \
+		|| log_fail "Missing ${GATEWAY_LIFECYCLE_SCRIPT}; upgrade the Agent before uninstalling this Data Gateway." 2
+	[[ "${PURGE_ALL}" -eq 0 ]] || purge_args+=(--purge-all)
+	log_step "Removing the Data Gateway LensNode sidecar before the Agent."
+	HFL_AGENT_ENV_FILE="${env_file}" \
+		bash "${GATEWAY_LIFECYCLE_SCRIPT}" uninstall-sidecar "${purge_args[@]}"
+	log_ok "Data Gateway LensNode sidecar removal completed."
+}
+
 cmd_uninstall() {
 	parse_uninstall_flags "$@"
 	require_root
 
-	local resolved_data env_file="${DEFAULT_DATA}/agent.env"
+	local resolved_data env_file
 	resolved_data="$(resolve_data_dir)"
+	env_file="${resolved_data}/agent.env"
 	begin_uninstall_log "${resolved_data}"
 	trap 'finish_uninstall_log $?' EXIT
 
 	log_info "Starting HyperFileLens agent uninstallation."
 	log_info "Install dir: ${INSTALL_DIR} · Data dir: ${resolved_data} · Purge data: $([[ $PURGE_ALL -eq 1 ]] && echo yes || echo no)."
+	uninstall_gateway_sidecar_if_needed "${env_file}"
 
 	stop_service
 	remove_service_unit

--- a/src/agent/scripts/package.sh
+++ b/src/agent/scripts/package.sh
@@ -161,6 +161,7 @@ NAS_DEPS_BASE="${REPO_ROOT}/build/dependencies/agent"
 KOPIA_ROOT="${REPO_ROOT}/build/kopia"
 INSTALL_DIR="${AGENT_ROOT}/packaging/install"
 SYSTEMD_UNIT="${AGENT_ROOT}/packaging/systemd/hyperfilelens-agent.service"
+GATEWAY_LIFECYCLE_SCRIPT="${REPO_ROOT}/deploy/bootstrap/gateway-lifecycle.sh"
 
 case "${BUNDLE}" in
 all) DO_STANDARD=1; UBUNTU_RELEASES="20.04 24.04" ;;
@@ -218,7 +219,9 @@ package_archives() {
 		WORK_ROOT_VALUE="${WORK_ROOT}" PACKAGE_DIR_VALUE="${PACKAGE_DIR}" \
 		KOPIA_ROOT_VALUE="${KOPIA_ROOT}" \
 		NAS_BASE_VALUE="${NAS_DEPS_BASE}" INSTALL_DIR_VALUE="${INSTALL_DIR}" \
-		SYSTEMD_UNIT_VALUE="${SYSTEMD_UNIT}" DO_STANDARD_VALUE="${DO_STANDARD}" \
+		SYSTEMD_UNIT_VALUE="${SYSTEMD_UNIT}" \
+		GATEWAY_LIFECYCLE_SCRIPT_VALUE="${GATEWAY_LIFECYCLE_SCRIPT}" \
+		DO_STANDARD_VALUE="${DO_STANDARD}" \
 		UBUNTU_RELEASES_VALUE="${UBUNTU_RELEASES}" python3 - <<'PY'
 import hashlib
 import json
@@ -243,6 +246,7 @@ package_dir = Path(os.environ["PACKAGE_DIR_VALUE"])
 nas_base = Path(os.environ["NAS_BASE_VALUE"])
 install_dir = Path(os.environ["INSTALL_DIR_VALUE"])
 systemd_unit = Path(os.environ["SYSTEMD_UNIT_VALUE"])
+gateway_lifecycle_script = Path(os.environ["GATEWAY_LIFECYCLE_SCRIPT_VALUE"])
 do_standard = os.environ["DO_STANDARD_VALUE"] == "1"
 ubuntu_releases = os.environ["UBUNTU_RELEASES_VALUE"].split()
 
@@ -407,9 +411,17 @@ def assemble_standard(goos: str, goarch: str, kopia_info: dict) -> None:
             if goos == "linux":
                 if not systemd_unit.is_file():
                     raise PrerequisiteError(f"missing systemd unit: {systemd_unit}")
+                if not gateway_lifecycle_script.is_file():
+                    raise PrerequisiteError(
+                        f"missing Gateway lifecycle script: {gateway_lifecycle_script}"
+                    )
                 unit_destination = root / "systemd" / systemd_unit.name
                 unit_destination.parent.mkdir(parents=True)
                 shutil.copy2(systemd_unit, unit_destination)
+                lifecycle_destination = root / "libexec" / gateway_lifecycle_script.name
+                lifecycle_destination.parent.mkdir(parents=True)
+                shutil.copy2(gateway_lifecycle_script, lifecycle_destination)
+                executable(lifecycle_destination)
 
         manifest = {
             "schema": 1,

--- a/src/backend/apps/platform_ops/api/urls.py
+++ b/src/backend/apps/platform_ops/api/urls.py
@@ -27,6 +27,10 @@ from apps.platform_ops.api.views.lens import (
     PlatformOpsLensGatewayEnableAiView,
     PlatformOpsLensGatewayEnrollmentView,
     PlatformOpsLensGatewayListView,
+    PlatformOpsLensGatewayLifecycleWatchView,
+    PlatformOpsLensGatewayOperationBatchView,
+    PlatformOpsLensGatewayOperationPreviewView,
+    PlatformOpsLensGatewayOperationView,
     PlatformOpsLensGatewaySetDefaultView,
     PlatformOpsLensKnowledgeSourceSyncView,
     PlatformOpsLensKnowledgeSourceView,
@@ -183,6 +187,26 @@ urlpatterns = [
         "lens/gateways/<int:gateway_id>/set-default",
         PlatformOpsLensGatewaySetDefaultView.as_view(),
         name="platform-ops-lens-gateway-set-default",
+    ),
+    path(
+        "lens/gateways/<int:gateway_id>/operations",
+        PlatformOpsLensGatewayOperationView.as_view(),
+        name="platform-ops-lens-gateway-operation",
+    ),
+    path(
+        "lens/gateways/operations/preview",
+        PlatformOpsLensGatewayOperationPreviewView.as_view(),
+        name="platform-ops-lens-gateway-operation-preview",
+    ),
+    path(
+        "lens/gateways/operations/batch",
+        PlatformOpsLensGatewayOperationBatchView.as_view(),
+        name="platform-ops-lens-gateway-operation-batch",
+    ),
+    path(
+        "lens/gateways/lifecycle-watch",
+        PlatformOpsLensGatewayLifecycleWatchView.as_view(),
+        name="platform-ops-lens-gateway-lifecycle-watch",
     ),
     path(
         "lens/gateways/<int:gateway_id>/browse",

--- a/src/backend/apps/platform_ops/api/views/lens.py
+++ b/src/backend/apps/platform_ops/api/views/lens.py
@@ -6,9 +6,11 @@ import uuid
 
 from rest_framework import status
 from rest_framework.exceptions import ValidationError
+from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from apps.audit.services.interface import write_audit_log
 from apps.lens_bridge.api.serializers import (
     LensGatewayEnableAiSerializer,
     LensKnowledgeSourceCreateSerializer,
@@ -36,14 +38,99 @@ from apps.lens_bridge.services.gateway_insights import list_admin_gateway_insigh
 from apps.lens_bridge.services import mcp_servers as mcp_servers_service
 from apps.lens_bridge.services import skills as skills_service
 from apps.lens_bridge.services.skills import beautify_skill
-from apps.node.models import NodeToken
+from apps.node.api.serializers.lifecycle_watch import (
+    NodeLifecycleWatchEntrySerializer,
+    NodeLifecycleWatchRequestSerializer,
+)
+from apps.node.api.serializers.node_operation import (
+    NodeOperationBatchPreviewSerializer,
+    NodeOperationBatchStartSerializer,
+    NodeOperationStartSerializer,
+)
+from apps.node.api.views.node_operation import _lifecycle_error_response
+from apps.node.models import Node, NodeToken
 from apps.node.models.base import NodeRole
+from apps.node.services.internal.node_lifecycle import (
+    LIFECYCLE_KIND_UPGRADE,
+    preview_batch_operations,
+    start_node_remove,
+    start_node_upgrade,
+)
 from apps.node.services.internal.local_platform_gateway import platform_gateway_api_base
 from apps.platform_ops.api.permissions import IsPlatformOpsStaff
 
 
 def _platform_org():
     return platform_lens.get_or_create_platform_org()
+
+
+def _platform_gateway(gateway_id: int) -> Node | None:
+    """Return an active HFL Gateway owned by the hidden platform organization."""
+    return Node.objects.filter(
+        organization=_platform_org(),
+        role=NodeRole.GATEWAY,
+        pk=int(gateway_id),
+    ).first()
+
+
+def _preview_platform_gateway_operations(*, node_ids: list[int], kind: str) -> dict:
+    """Preview only Gateway nodes from the hidden platform organization."""
+    org = _platform_org()
+    gateway_ids = set(
+        Node.objects.filter(
+            organization=org,
+            role=NodeRole.GATEWAY,
+            pk__in=node_ids,
+        ).values_list("id", flat=True)
+    )
+    preview = preview_batch_operations(
+        org=org,
+        node_ids=[node_id for node_id in node_ids if node_id in gateway_ids],
+        kind=kind,
+    )
+    preview["requested"] = len(node_ids)
+    preview["missing_node_ids"] = [
+        node_id for node_id in node_ids if node_id not in gateway_ids
+    ]
+    return preview
+
+
+def _start_platform_gateway_operation(
+    *,
+    request: Request,
+    gateway: Node,
+    kind: str,
+    force: bool = False,
+) -> dict:
+    """Start one platform Gateway lifecycle operation through the shared service."""
+    org = _platform_org()
+    if kind == LIFECYCLE_KIND_UPGRADE:
+        result = start_node_upgrade(org=org, node=gateway, user=request.user)
+    else:
+        result = start_node_remove(
+            org=org,
+            node=gateway,
+            user=request.user,
+            force=force,
+        )
+    write_audit_log(
+        organization=org,
+        user=request.user,
+        action=f"node.lifecycle.{kind}",
+        target_type="node",
+        target_id=str(gateway.id),
+        ip_address=request.META.get("REMOTE_ADDR"),
+        user_agent=str(request.META.get("HTTP_USER_AGENT", "") or ""),
+        metadata={
+            "kind": kind,
+            "role": gateway.role,
+            "operation_id": result.get("operation_id"),
+            "task_id": result.get("task_id"),
+            "state": result.get("state"),
+            "scope": "platform",
+        },
+    )
+    return result
 
 
 class PlatformOpsLensGatewayListView(APIView):
@@ -133,6 +220,120 @@ class PlatformOpsLensGatewaySetDefaultView(APIView):
                 "is_platform_default": link.is_platform_default,
             }
         )
+
+
+class PlatformOpsLensGatewayOperationView(APIView):
+    """Start upgrade/remove for one hidden platform Data Gateway."""
+
+    permission_classes = [IsPlatformOpsStaff]
+
+    def post(self, request, gateway_id: int):
+        gateway = _platform_gateway(gateway_id)
+        if gateway is None:
+            return Response(
+                {"detail": "Platform Data Gateway not found."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+        body = NodeOperationStartSerializer(data=request.data)
+        body.is_valid(raise_exception=True)
+        try:
+            result = _start_platform_gateway_operation(
+                request=request,
+                gateway=gateway,
+                kind=body.validated_data["kind"],
+                force=bool(body.validated_data.get("force")),
+            )
+        except Exception as exc:
+            return _lifecycle_error_response(exc)
+        return Response(result, status=status.HTTP_202_ACCEPTED)
+
+
+class PlatformOpsLensGatewayOperationPreviewView(APIView):
+    """Preview lifecycle eligibility for hidden platform Data Gateways."""
+
+    permission_classes = [IsPlatformOpsStaff]
+
+    def post(self, request):
+        body = NodeOperationBatchPreviewSerializer(data=request.data)
+        body.is_valid(raise_exception=True)
+        return Response(
+            _preview_platform_gateway_operations(
+                node_ids=body.validated_data["node_ids"],
+                kind=body.validated_data["kind"],
+            )
+        )
+
+
+class PlatformOpsLensGatewayOperationBatchView(APIView):
+    """Start a bounded batch of hidden platform Gateway lifecycle operations."""
+
+    permission_classes = [IsPlatformOpsStaff]
+
+    def post(self, request):
+        body = NodeOperationBatchStartSerializer(data=request.data)
+        body.is_valid(raise_exception=True)
+        values = body.validated_data
+        preview = _preview_platform_gateway_operations(
+            node_ids=values["node_ids"],
+            kind=values["kind"],
+        )
+        max_concurrent = int(
+            values.get("max_concurrent") or preview.get("max_concurrent") or 5
+        )
+        eligible = preview.get("eligible") or []
+        started: list[dict] = []
+        errors: list[dict] = []
+        for item in eligible[:max_concurrent]:
+            gateway = _platform_gateway(item["node_id"])
+            if gateway is None:
+                errors.append({"node_id": item["node_id"], "error": "not_found"})
+                continue
+            try:
+                started.append(
+                    _start_platform_gateway_operation(
+                        request=request,
+                        gateway=gateway,
+                        kind=values["kind"],
+                        force=bool(values.get("force")),
+                    )
+                )
+            except Exception as exc:
+                response = _lifecycle_error_response(exc)
+                errors.append({"node_id": gateway.id, **response.data})
+        return Response(
+            {
+                **preview,
+                "max_concurrent": max_concurrent,
+                "started": started,
+                "queued": eligible[max_concurrent:],
+                "errors": errors,
+            },
+            status=status.HTTP_202_ACCEPTED,
+        )
+
+
+class PlatformOpsLensGatewayLifecycleWatchView(APIView):
+    """Poll lifecycle state for platform Gateway operations."""
+
+    permission_classes = [IsPlatformOpsStaff]
+
+    def post(self, request):
+        body = NodeLifecycleWatchRequestSerializer(data=request.data)
+        body.is_valid(raise_exception=True)
+        org = _platform_org()
+        gateways = list(
+            Node.objects.filter(
+                organization=org,
+                role=NodeRole.GATEWAY,
+                pk__in=body.validated_data["node_ids"],
+            ).order_by("id")
+        )
+        payload = NodeLifecycleWatchEntrySerializer(
+            gateways,
+            many=True,
+            context={"org": org},
+        ).data
+        return Response({"nodes": payload})
 
 
 class PlatformOpsLensModelProxyView(APIView):

--- a/src/backend/apps/platform_ops/tests/test_lens_gateway_lifecycle.py
+++ b/src/backend/apps/platform_ops/tests/test_lens_gateway_lifecycle.py
@@ -1,0 +1,133 @@
+"""Platform-scoped Data Gateway lifecycle API tests."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from django.contrib.auth.models import User
+from django.test import TestCase, override_settings
+from rest_framework.response import Response
+from rest_framework.test import APIClient
+
+from apps.iam.models import Organization
+from apps.lens_bridge.services import platform_lens
+from apps.node.models import Node
+from apps.node.models.base import NodeRole
+
+
+@override_settings(HFL_PLATFORM_OPS_ENABLED=True)
+class PlatformOpsLensGatewayLifecycleTests(TestCase):
+    """Ensure Admin Engine lifecycle calls stay in the hidden platform org."""
+
+    def setUp(self) -> None:
+        lifecycle_routable_patcher = patch(
+            "apps.node.services.internal.node_lifecycle.agent_ws_routable",
+            return_value=False,
+        )
+        watch_routable_patcher = patch(
+            "apps.node.api.serializers.lifecycle_watch.agent_ws_routable",
+            return_value=False,
+        )
+        lifecycle_routable_patcher.start()
+        watch_routable_patcher.start()
+        self.addCleanup(lifecycle_routable_patcher.stop)
+        self.addCleanup(watch_routable_patcher.stop)
+        self.client = APIClient()
+        self.staff = User.objects.create_user(
+            username="platform-lifecycle@test.local",
+            email="platform-lifecycle@test.local",
+            password="test-pass",
+            is_staff=True,
+        )
+        self.client.force_authenticate(user=self.staff)
+        self.platform_org = platform_lens.get_or_create_platform_org()
+        self.gateway = Node.objects.create(
+            organization=self.platform_org,
+            name="platform-gateway",
+            role=NodeRole.GATEWAY,
+            status=Node.Status.OFFLINE,
+        )
+
+    def _post(self, path: str, body: dict) -> Response:
+        return self.client.post(
+            path,
+            body,
+            format="json",
+            HTTP_X_HFL_SITE_ROLE="ops",
+        )
+
+    def test_preview_uses_hidden_platform_organization(self) -> None:
+        tenant_org = Organization.objects.create(key="tenant", name="Tenant")
+        tenant_gateway = Node.objects.create(
+            organization=tenant_org,
+            name="tenant-gateway",
+            role=NodeRole.GATEWAY,
+        )
+        platform_agent = Node.objects.create(
+            organization=self.platform_org,
+            name="platform-agent",
+            role=NodeRole.AGENT,
+        )
+
+        response = self._post(
+            "/api/v1/platform-ops/lens/gateways/operations/preview",
+            {
+                "kind": "remove",
+                "node_ids": [
+                    self.gateway.id,
+                    tenant_gateway.id,
+                    platform_agent.id,
+                ],
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            [row["node_id"] for row in response.data["eligible"]],
+            [self.gateway.id],
+        )
+        self.assertEqual(
+            response.data["missing_node_ids"],
+            [tenant_gateway.id, platform_agent.id],
+        )
+
+    @patch(
+        "apps.platform_ops.api.views.lens._start_platform_gateway_operation",
+        return_value={
+            "operation_id": "op-1",
+            "task_id": "task-1",
+            "node_id": 1,
+            "kind": "remove",
+            "state": "removing",
+        },
+    )
+    def test_batch_dispatches_platform_gateway(self, mock_start) -> None:
+        response = self._post(
+            "/api/v1/platform-ops/lens/gateways/operations/batch",
+            {"kind": "remove", "node_ids": [self.gateway.id]},
+        )
+
+        self.assertEqual(response.status_code, 202)
+        self.assertEqual(len(response.data["started"]), 1)
+        mock_start.assert_called_once()
+        self.assertEqual(mock_start.call_args.kwargs["gateway"], self.gateway)
+        self.assertEqual(mock_start.call_args.kwargs["kind"], "remove")
+
+    def test_lifecycle_watch_excludes_tenant_gateways(self) -> None:
+        tenant_org = Organization.objects.create(key="other", name="Other")
+        tenant_gateway = Node.objects.create(
+            organization=tenant_org,
+            name="other-gateway",
+            role=NodeRole.GATEWAY,
+        )
+
+        response = self._post(
+            "/api/v1/platform-ops/lens/gateways/lifecycle-watch",
+            {"node_ids": [self.gateway.id, tenant_gateway.id]},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            [row["id"] for row in response.data["nodes"]],
+            [self.gateway.id],
+        )

--- a/src/frontend/src/composables/useNodeLifecycleOps.ts
+++ b/src/frontend/src/composables/useNodeLifecycleOps.ts
@@ -10,6 +10,7 @@ import {
   startNodeOperationsBatch,
   NodeLifecycleApiError,
 } from '../lib/nodeApi'
+import type { NodeLifecycleScope } from '../lib/nodeApi'
 import { apiErrorMessage } from '../lib/api'
 import { parseSemver, semverCompare } from '../lib/agentVersion'
 import { logger } from '../lib/logger'
@@ -28,6 +29,7 @@ type PersistedQueue = {
   batchId: string
   kind: NodeLifecycleKind
   role: NodeRole
+  scope?: NodeLifecycleScope
   maxConcurrent: number
   queued: LifecycleQueueItem[]
   running: LifecycleQueueItem[]
@@ -121,6 +123,7 @@ function queueItemMeta(
 
 export function useNodeLifecycleOps(options: {
   role: NodeRole | (() => NodeRole)
+  scope?: NodeLifecycleScope | (() => NodeLifecycleScope)
   t: Composer['t']
   onRefresh?: () => Promise<void> | void
   onLifecyclePatch?: (nodes: ApiNode[]) => void
@@ -128,6 +131,8 @@ export function useNodeLifecycleOps(options: {
   const { t } = options
   const resolveRole = (): NodeRole =>
     typeof options.role === 'function' ? options.role() : options.role
+  const resolveScope = (): NodeLifecycleScope =>
+    typeof options.scope === 'function' ? options.scope() : options.scope || 'tenant'
   const batchId = ref<string | null>(null)
   const activeKind = ref<NodeLifecycleKind | null>(null)
   const maxConcurrent = ref(NODE_LIFECYCLE_MAX_CONCURRENT)
@@ -238,6 +243,7 @@ export function useNodeLifecycleOps(options: {
       batchId: batchId.value,
       kind: activeKind.value,
       role: pollRole.value || resolveRole(),
+      scope: resolveScope(),
       maxConcurrent: maxConcurrent.value,
       running: running.value,
       queued: queued.value,
@@ -311,7 +317,7 @@ export function useNodeLifecycleOps(options: {
         return
       }
       const role = pollRole.value || resolveRole()
-      const watched = await fetchLifecycleWatch(nodeIds)
+      const watched = await fetchLifecycleWatch(nodeIds, resolveScope())
       const nodes: ApiNode[] = watched.map((row) => {
         const item = localLifecycleItem(running.value, queued.value, row.id)
         return {
@@ -356,7 +362,9 @@ export function useNodeLifecycleOps(options: {
         kind: item.kind,
         name: item.name,
       })
-      const result = await startNodeOperation(item.nodeId, item.kind)
+      const result = await startNodeOperation(item.nodeId, item.kind, {
+        scope: resolveScope(),
+      })
       item.state = result.state
       item.taskId = result.task_id
       if (result.target_version) {
@@ -470,6 +478,7 @@ export function useNodeLifecycleOps(options: {
         kind,
         nodeIds,
         maxConcurrent: maxConcurrent.value,
+        scope: resolveScope(),
       })
       if (preview.eligible.length === 0) {
         ElMessage.warning({ message: explainIneligiblePreview(preview), grouping: true })
@@ -514,6 +523,7 @@ export function useNodeLifecycleOps(options: {
         nodeIds: preview.eligible.map((x) => x.node_id),
         maxConcurrent: maxConcurrent.value,
         force: Boolean(runOptions?.force),
+        scope: resolveScope(),
       })
 
       for (const started of batchResult.started || []) {
@@ -608,6 +618,7 @@ export function useNodeLifecycleOps(options: {
     const saved = loadPersisted()
     if (!saved) return
     if (saved.role !== resolveRole()) return
+    if ((saved.scope || 'tenant') !== resolveScope()) return
     batchId.value = saved.batchId
     activeKind.value = saved.kind
     pollRole.value = saved.role
@@ -623,7 +634,7 @@ export function useNodeLifecycleOps(options: {
             ...queued.value.map((item) => item.nodeId),
           ]),
         ]
-        const watched = await fetchLifecycleWatch(nodeIds)
+        const watched = await fetchLifecycleWatch(nodeIds, resolveScope())
         const nodes: ApiNode[] = watched.map((row) => {
           const item = localLifecycleItem(running.value, queued.value, row.id)
           return {

--- a/src/frontend/src/lib/nodeApi.test.ts
+++ b/src/frontend/src/lib/nodeApi.test.ts
@@ -2,7 +2,13 @@
 
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { api } from './api'
-import { issuePlatformGatewayEnrollmentInstall } from './nodeApi'
+import {
+  fetchLifecycleWatch,
+  issuePlatformGatewayEnrollmentInstall,
+  previewNodeOperationsBatch,
+  startNodeOperation,
+  startNodeOperationsBatch,
+} from './nodeApi'
 
 vi.mock('./api', async (importOriginal) => {
   const actual = await importOriginal<typeof import('./api')>()
@@ -56,5 +62,31 @@ describe('platform Data Gateway enrollment', () => {
     await expect(issuePlatformGatewayEnrollmentInstall()).rejects.toThrow(
       'Platform gateway enrollment response is incomplete',
     )
+  })
+})
+
+describe('platform Data Gateway lifecycle', () => {
+  it('routes every lifecycle request through Platform Operations', async () => {
+    vi.mocked(api).mockResolvedValue({ nodes: [] })
+
+    await previewNodeOperationsBatch({
+      kind: 'remove',
+      nodeIds: [17],
+      scope: 'platform',
+    })
+    await startNodeOperationsBatch({
+      kind: 'remove',
+      nodeIds: [17],
+      scope: 'platform',
+    })
+    await startNodeOperation(17, 'remove', { scope: 'platform' })
+    await fetchLifecycleWatch([17], 'platform')
+
+    expect(vi.mocked(api).mock.calls.map(([path]) => path)).toEqual([
+      '/api/v1/platform-ops/lens/gateways/operations/preview',
+      '/api/v1/platform-ops/lens/gateways/operations/batch',
+      '/api/v1/platform-ops/lens/gateways/17/operations',
+      '/api/v1/platform-ops/lens/gateways/lifecycle-watch',
+    ])
   })
 })

--- a/src/frontend/src/lib/nodeApi.ts
+++ b/src/frontend/src/lib/nodeApi.ts
@@ -138,6 +138,15 @@ export async function updateNode(nodeId: number, body: UpdateNodeBody): Promise<
 }
 
 export const NODE_LIFECYCLE_MAX_CONCURRENT = 5
+export type NodeLifecycleScope = 'tenant' | 'platform'
+
+function nodeLifecyclePath(scope: NodeLifecycleScope, relative: string): string {
+  const clean = relative.replace(/^\/+|\/+$/g, '')
+  if (scope === 'platform') {
+    return `/api/v1/platform-ops/lens/gateways/${clean}`
+  }
+  return `/api/v1/node/nodes/${clean}/`
+}
 
 export class NodeLifecycleApiError extends Error {
   code: string
@@ -179,9 +188,9 @@ async function postLifecycle<T>(path: string, body: unknown): Promise<T> {
 export async function startNodeOperation(
   nodeId: number,
   kind: NodeLifecycleKind,
-  options?: { force?: boolean },
+  options?: { force?: boolean; scope?: NodeLifecycleScope },
 ): Promise<NodeOperationStartResult> {
-  return postLifecycle(`/api/v1/node/nodes/${nodeId}/operations/`, {
+  return postLifecycle(nodeLifecyclePath(options?.scope ?? 'tenant', `${nodeId}/operations`), {
     kind,
     force: Boolean(options?.force),
   })
@@ -191,8 +200,9 @@ export async function previewNodeOperationsBatch(params: {
   kind: NodeLifecycleKind
   nodeIds: number[]
   maxConcurrent?: number
+  scope?: NodeLifecycleScope
 }): Promise<NodeOperationBatchPreview> {
-  return postLifecycle('/api/v1/node/nodes/operations/preview/', {
+  return postLifecycle(nodeLifecyclePath(params.scope ?? 'tenant', 'operations/preview'), {
     kind: params.kind,
     node_ids: params.nodeIds,
     max_concurrent: params.maxConcurrent ?? NODE_LIFECYCLE_MAX_CONCURRENT,
@@ -204,8 +214,9 @@ export async function startNodeOperationsBatch(params: {
   nodeIds: number[]
   maxConcurrent?: number
   force?: boolean
+  scope?: NodeLifecycleScope
 }): Promise<NodeOperationBatchStartResult> {
-  return postLifecycle('/api/v1/node/nodes/operations/batch/', {
+  return postLifecycle(nodeLifecyclePath(params.scope ?? 'tenant', 'operations/batch'), {
     kind: params.kind,
     node_ids: params.nodeIds,
     max_concurrent: params.maxConcurrent ?? NODE_LIFECYCLE_MAX_CONCURRENT,
@@ -221,11 +232,14 @@ export type NodeLifecycleWatchEntry = Pick<
 }
 
 /** Poll lifecycle state for nodes in an active upgrade/remove batch (read-only). */
-export async function fetchLifecycleWatch(nodeIds: number[]): Promise<NodeLifecycleWatchEntry[]> {
+export async function fetchLifecycleWatch(
+  nodeIds: number[],
+  scope: NodeLifecycleScope = 'tenant',
+): Promise<NodeLifecycleWatchEntry[]> {
   const ids = [...new Set(nodeIds.filter((id) => Number.isFinite(id) && id > 0))]
   if (ids.length === 0) return []
   const raw = await postLifecycle<{ nodes: NodeLifecycleWatchEntry[] }>(
-    '/api/v1/node/nodes/lifecycle-watch/',
+    nodeLifecyclePath(scope, 'lifecycle-watch'),
     { node_ids: ids },
   )
   return Array.isArray(raw.nodes) ? raw.nodes : []

--- a/src/frontend/src/locales/en.ts
+++ b/src/frontend/src/locales/en.ts
@@ -825,6 +825,10 @@ export const en = {
       defaultActive: 'Default',
       defaultSet: 'Set default',
       defaultSetSuccess: 'Platform default data gateway updated.',
+      deleteOfflineConfirm:
+        'Remove {n} data gateway(s)? {offline} gateway(s) are offline, so only their console records can be removed; Agent and LensNode files may remain on those hosts.',
+      deleteInstallerManagedConfirm:
+        'Remove {n} data gateway(s)? Installer-managed platform gateways are recreated by the next deployment while auto-deploy remains enabled. Offline hosts may retain Agent and LensNode files.',
       origin: {
         user: 'User',
         platform: 'Platform',

--- a/src/frontend/src/pages/insight/InsightDataGateways.vue
+++ b/src/frontend/src/pages/insight/InsightDataGateways.vue
@@ -86,6 +86,28 @@ const detailNodeId = ref<number | null>(null)
 const renameDialogOpen = ref(false)
 const renameInput = ref('')
 const renameTarget = ref<InsightGatewayRow | null>(null)
+const offlinePendingDeleteCount = computed(
+  () => pendingDelete.value.filter((row) => row.routable === false || !row.hfl_agent_online).length,
+)
+const installerManagedPendingDelete = computed(() =>
+  pendingDelete.value.some((row) => {
+    const metadata = row.metadata as Record<string, unknown> | undefined
+    return metadata?.managed_by === 'hfl-installer'
+  }),
+)
+const deleteConfirmationMessage = computed(() => {
+  const values = {
+    n: pendingDelete.value.length,
+    offline: offlinePendingDeleteCount.value,
+  }
+  if (installerManagedPendingDelete.value) {
+    return t('insight.dataGateway.deleteInstallerManagedConfirm', values)
+  }
+  if (offlinePendingDeleteCount.value > 0) {
+    return t('insight.dataGateway.deleteOfflineConfirm', values)
+  }
+  return t('nodesPage.deleteSelectedConfirm', values)
+})
 
 const tableRef = ref<InstanceType<typeof ElTable> | null>(null)
 const tableBlockRef = ref<HTMLElement | null>(null)
@@ -105,6 +127,7 @@ const osPlatformLabels = computed((): NodeOsPlatformLabels => ({
 
 const lifecycleOps = useNodeLifecycleOps({
   role: () => 'gateway',
+  scope: () => (isPlatformEngine.value ? 'platform' : 'tenant'),
   t,
   onRefresh: () => load(),
   onLifecyclePatch: (patched) => {
@@ -758,7 +781,7 @@ onUnmounted(() => {
     <DangerConfirmDialog
       v-model="deleteOpen"
       :title="t('nodesPage.deleteTitle')"
-      :message="t('nodesPage.deleteSelectedConfirm', { n: pendingDelete.length })"
+      :message="deleteConfirmationMessage"
       :items="pendingDelete.map((row) => ({ key: row.id, name: row.name }))"
       confirm-mode="keyword"
       :confirm-keyword="t('common.deleteKeyword')"

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -275,6 +275,7 @@ grep -F './tools/quality/test-shared-host-guard.sh' "${workflow}" >/dev/null
 grep -F './tools/quality/test-default-certificates.sh' "${workflow}" >/dev/null
 grep -F './tools/quality/test-gateway-bootstrap-health.sh' "${workflow}" >/dev/null
 grep -F './tools/quality/test-platform-gateway-auto-deploy.sh' "${workflow}" >/dev/null
+grep -F './tools/quality/test-agent-gateway-uninstall.sh' "${workflow}" >/dev/null
 grep -F 'HFL_PLATFORM_GATEWAY_AUTO_DEPLOY=false' "${ROOT}/.env.example" >/dev/null
 grep -F 'com.hyperfilelens.component: "gateway-lensnode"' \
 	"${ROOT}/deploy/bootstrap/gateway-install-lensnode-sidecar.sh" >/dev/null

--- a/tools/quality/test-agent-gateway-uninstall.sh
+++ b/tools/quality/test-agent-gateway-uninstall.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+set -euo pipefail
+umask 077
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+installer="${ROOT}/src/agent/packaging/install/install.sh"
+tmp="$(mktemp -d)"
+trap 'rm -rf "${tmp}"' EXIT
+
+# Load the installed Agent command functions without dispatching the real CLI.
+# shellcheck disable=SC1090
+source <(sed '/^case "$CMD" in/,$d' "${installer}")
+
+INSTALL_DIR="${tmp}/opt/hyperfilelens-agent"
+DEFAULT_DATA="${tmp}/var/lib/hyperfilelens-agent"
+INSTALLED_VERSION_FILE="${INSTALL_DIR}/INSTALLED_VERSION"
+GATEWAY_LIFECYCLE_SCRIPT="${INSTALL_DIR}/libexec/gateway-lifecycle.sh"
+UNIT_DST="${tmp}/hyperfilelens-agent.service"
+GATEWAY_RESOURCE_DROPIN="${tmp}/20-gateway-resources.conf"
+marker="${tmp}/sidecar-removed"
+stop_marker="${tmp}/agent-stopped"
+
+mkdir -p "${INSTALL_DIR}/libexec" "${DEFAULT_DATA}"
+printf '%s\n' \
+	'HFL_NODE_ROLE=gateway' \
+	"HFL_DATA_DIR=${DEFAULT_DATA}" \
+	>"${DEFAULT_DATA}/agent.env"
+printf agent >"${INSTALL_DIR}/hfl-agent"
+printf '%s\n' \
+	'#!/usr/bin/env bash' \
+	'set -euo pipefail' \
+	'[[ "$HFL_AGENT_ENV_FILE" == "$TEST_AGENT_ENV" ]]' \
+	'[[ "$1" == "uninstall-sidecar" && "$2" == "--purge-all" ]]' \
+	'printf removed >"$TEST_SIDECAR_MARKER"' \
+	>"${GATEWAY_LIFECYCLE_SCRIPT}"
+chmod 755 "${GATEWAY_LIFECYCLE_SCRIPT}"
+
+require_root() { :; }
+begin_uninstall_log() { :; }
+finish_uninstall_log() { :; }
+log_info() { :; }
+log_step() { :; }
+log_ok() { :; }
+log_skip() { :; }
+log_warn() { :; }
+agent_uses_launchd() { return 1; }
+stop_service() {
+	[[ -f "${marker}" ]]
+	printf stopped >"${stop_marker}"
+}
+remove_service_unit() { :; }
+data_dir_allowed_for_removal() { [[ "$1" == "${DEFAULT_DATA}" || "$1" == "${INSTALL_DIR}" ]]; }
+unmount_agent_mounts() { :; }
+
+export TEST_AGENT_ENV="${DEFAULT_DATA}/agent.env"
+export TEST_SIDECAR_MARKER="${marker}"
+cmd_uninstall --purge-all
+
+[[ -f "${marker}" ]]
+[[ -f "${stop_marker}" ]]
+[[ ! -e "${INSTALL_DIR}" ]]
+[[ ! -e "${DEFAULT_DATA}" ]]
+
+fake_bin="${tmp}/fake-bin"
+docker_state="${tmp}/docker-state"
+compose_dir="${tmp}/lensnode-compose"
+mkdir -p "${fake_bin}" "${compose_dir}"
+printf 'services: {}\n' >"${compose_dir}/docker-compose.yml"
+cat >"${fake_bin}/docker" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+case "$*" in
+  info|"compose version") exit 0 ;;
+  "ps -aq --no-trunc") exit 0 ;;
+  "compose -p hyperfilelens-gateway config --images")
+    printf '%s\n' 'example/hfl-lensnode:test'
+    ;;
+  "compose -p hyperfilelens-gateway down --remove-orphans")
+    printf down >"${TEST_DOCKER_STATE}.down"
+    ;;
+  "ps -aq --filter label=com.hyperfilelens.managed=true --filter label=com.hyperfilelens.component=gateway-lensnode")
+    [[ -f "${TEST_DOCKER_STATE}.removed" ]] || printf '%s\n' owned-lensnode
+    ;;
+  "inspect --format {{.Config.Image}} owned-lensnode")
+    printf '%s\n' 'example/hfl-lensnode:test'
+    ;;
+  "rm -f owned-lensnode")
+    printf removed >"${TEST_DOCKER_STATE}.removed"
+    ;;
+  "ps -aq --filter ancestor=hyperfilelens-sourcelens-lensnode:latest"|\
+  "ps -aq --filter ancestor=example/hfl-lensnode:test")
+    exit 0
+    ;;
+  "image rm hyperfilelens-sourcelens-lensnode:latest"|\
+  "image rm example/hfl-lensnode:test")
+    printf '%s\n' "$*" >>"${TEST_DOCKER_STATE}.images"
+    ;;
+  *)
+    printf 'unexpected docker invocation: %s\n' "$*" >&2
+    exit 90
+    ;;
+esac
+EOF
+chmod 755 "${fake_bin}/docker"
+
+PATH="${fake_bin}:${PATH}" \
+	TEST_DOCKER_STATE="${docker_state}" \
+	HFL_AGENT_ENV_FILE="${tmp}/missing-agent.env" \
+	HFL_LENS_ENV_FILE="${tmp}/missing-lensnode.env" \
+	HFL_GATEWAY_COMPOSE_DIR="${compose_dir}" \
+	bash "${ROOT}/deploy/bootstrap/gateway-lifecycle.sh" uninstall-sidecar --purge-all
+
+[[ -f "${docker_state}.down" ]]
+[[ -f "${docker_state}.removed" ]]
+[[ ! -e "${compose_dir}" ]]
+grep -Fx 'image rm hyperfilelens-sourcelens-lensnode:latest' "${docker_state}.images" >/dev/null
+grep -Fx 'image rm example/hfl-lensnode:test' "${docker_state}.images" >/dev/null
+
+printf 'Agent-managed Data Gateway uninstall contracts passed.\n'


### PR DESCRIPTION
## Summary

- route tenant and platform Data Gateway operations through the shared node lifecycle
- make Agent uninstall remove its managed LensNode sidecar before removing itself
- ship an offline lifecycle helper with Linux Agent packages and constrain cleanup to HFL-owned Docker resources
- add Gateway resource preflight, soft systemd controls, UI warnings, and release contract coverage

## Validation

- 15 targeted Django tests passed
- full Agent Go test suite passed
- 292 frontend tests passed
- frontend production build passed
- release and Agent uninstall contract checks passed
- Ruff and git diff checks passed