### PR TITLE
fix(build): reuse GitHub mirror for Kopia Git fetches

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,11 @@ options. For example:
 ```
 
 Third-party mirrors are examples only and are never enabled automatically.
+For GitHub HTTPS repositories such as the default Kopia source, the selected
+GitHub download mirror is also tried for Git clone and fetch before falling
+back to the canonical GitHub URL. The canonical URL remains in the Git remote
+and generated build metadata; `--kopia-git-url` is only needed for a different
+upstream or fork.
 The backend keeps `uv.lock` as the single dependency lock and uses the selected
 Python index only to download hash-verified packages exported from that lock.
 

--- a/dev/stack.sh
+++ b/dev/stack.sh
@@ -84,7 +84,7 @@ SourceLens options (default: enabled for up/restart):
   --sourcelens-git-url URL         Override SourceLens repository URL (env: SOURCELENS_GIT_URL)
 
 Mirror options (Kopia fetch + Agent publishing + SourceLens git clone; env fallback):
-  --github-download-mirror URL     GitHub download mirror (env: GITHUB_DOWNLOAD_MIRROR)
+  --github-download-mirror URL     GitHub Git/release mirror (env: GITHUB_DOWNLOAD_MIRROR)
   --github-token TOKEN             GitHub token for API/release fetch and private SourceLens clone (env: GITHUB_TOKEN)
   --docker-download-mirror URL     Docker Hub mirror for NAS ubuntu:24.04 (env: DOCKER_DOWNLOAD_MIRROR)
   --apt-mirror URL                 Ubuntu apt mirror for NAS container (env: APT_MIRROR)

--- a/release/build.sh
+++ b/release/build.sh
@@ -218,7 +218,7 @@ Version:
   - Image-only runtime package: images, payload/media, compose, and deploy config
 
 Mirror options (Kopia fetch + Agent publishing + runtime image pull; env fallback):
-  --github-download-mirror URL     GitHub download mirror (env: GITHUB_DOWNLOAD_MIRROR)
+  --github-download-mirror URL     GitHub Git/release mirror (env: GITHUB_DOWNLOAD_MIRROR)
   --github-token TOKEN             GitHub token for API/release fetch and private SourceLens clone (env: GITHUB_TOKEN)
   --docker-download-mirror URL     Docker Hub mirror for ubuntu:24.04, postgres, redis (env: DOCKER_DOWNLOAD_MIRROR)
   --docker-pull-timeout SECONDS    Timeout for each Docker pull attempt (env: DOCKER_PULL_TIMEOUT_SECONDS)

--- a/src/agent/scripts/fetch-deps.sh
+++ b/src/agent/scripts/fetch-deps.sh
@@ -99,7 +99,7 @@ Options:
   --kopia-mode MODE                build or download
   --kopia-git-url URL              Kopia source repository URL
   --kopia-ref REF                  Kopia release ref in vX.Y.Z form
-  --github-download-mirror URL     Explicit GitHub download mirror (env: GITHUB_DOWNLOAD_MIRROR)
+  --github-download-mirror URL     GitHub Git/release mirror (env: GITHUB_DOWNLOAD_MIRROR)
   --github-token TOKEN             GitHub API token (env: GITHUB_TOKEN; environment recommended)
   --ubuntu2404-arch ARCH           amd64 | arm64 | all (env: AGENT_UBUNTU2404_ARCH)
   --docker-download-mirror URL     Docker Hub mirror (env: DOCKER_DOWNLOAD_MIRROR)

--- a/tools/agent/publish.sh
+++ b/tools/agent/publish.sh
@@ -44,7 +44,7 @@ Fetch (passed to fetch-deps.sh):
   --kopia-mode MODE               build or download
   --kopia-git-url URL             Kopia source repository URL
   --kopia-ref REF                 Kopia release ref in vX.Y.Z form
-  --github-download-mirror URL     GitHub download mirror (env: GITHUB_DOWNLOAD_MIRROR)
+  --github-download-mirror URL     GitHub Git/release mirror (env: GITHUB_DOWNLOAD_MIRROR)
   --github-token TOKEN             GitHub API token (env: GITHUB_TOKEN)
   --docker-download-mirror URL     Docker Hub mirror for NAS Ubuntu images (env: DOCKER_DOWNLOAD_MIRROR)
   --docker-pull-timeout SECONDS    Timeout for each Docker pull attempt (env: DOCKER_PULL_TIMEOUT_SECONDS)

--- a/tools/kopia/prepare.sh
+++ b/tools/kopia/prepare.sh
@@ -30,7 +30,7 @@ Usage: ./tools/kopia/prepare.sh [options]
   --matrix MATRIX               Space-separated os:arch entries
   --force                       Ignore a valid cached matrix
   --offline                     Use only the existing source/download caches
-  --github-download-mirror URL  Optional mirror used by download mode
+  --github-download-mirror URL  Optional mirror for GitHub Git and release downloads
   --github-token TOKEN          Optional GitHub token (environment recommended)
   --print-config                Print resolved non-secret inputs and exit
   -h, --help                    Show this help
@@ -71,7 +71,58 @@ git_with_auth() {
 	fi
 }
 
+github_git_mirror_url() {
+	local url=$1
+	[[ -n "${GITHUB_DOWNLOAD_MIRROR}" && "${url}" == https://github.com/* ]] || return 1
+	printf '%s/%s' "${GITHUB_DOWNLOAD_MIRROR%/}" "${url}"
+}
+
+git_source_candidates() {
+	local url=$1 mirrored
+	if mirrored="$(github_git_mirror_url "${url}")"; then
+		printf '%s\n' "${mirrored}"
+	fi
+	printf '%s\n' "${url}"
+}
+
+clone_source() {
+	local candidate mirrored=""
+	mirrored="$(github_git_mirror_url "${KOPIA_GIT_URL}" || true)"
+	while IFS= read -r candidate; do
+		if [[ -n "${mirrored}" && "${candidate}" == "${mirrored}" ]]; then
+			log "Cloning ${KOPIA_GIT_URL} through ${GITHUB_DOWNLOAD_MIRROR%/}"
+		else
+			[[ -z "${mirrored}" ]] || log "Git mirror unavailable; retrying ${KOPIA_GIT_URL} directly"
+			log "Cloning ${KOPIA_GIT_URL}"
+		fi
+		if git_with_auth clone --no-checkout "${candidate}" "${KOPIA_SOURCE_DIR}"; then
+			git -C "${KOPIA_SOURCE_DIR}" remote set-url origin "${KOPIA_GIT_URL}"
+			return 0
+		fi
+		rm -rf "${KOPIA_SOURCE_DIR}"
+	done < <(git_source_candidates "${KOPIA_GIT_URL}")
+	die "unable to clone Kopia source from the configured mirror or ${KOPIA_GIT_URL}"
+}
+
+fetch_source_ref() {
+	local candidate mirrored=""
+	mirrored="$(github_git_mirror_url "${KOPIA_GIT_URL}" || true)"
+	while IFS= read -r candidate; do
+		if [[ -n "${mirrored}" && "${candidate}" == "${mirrored}" ]]; then
+			log "Fetching ${KOPIA_GIT_REF} through ${GITHUB_DOWNLOAD_MIRROR%/}"
+		else
+			[[ -z "${mirrored}" ]] || log "Git mirror unavailable; retrying ${KOPIA_GIT_REF} directly"
+			log "Fetching ${KOPIA_GIT_REF}"
+		fi
+		if git_with_auth -C "${KOPIA_SOURCE_DIR}" fetch --force --tags "${candidate}" "${KOPIA_GIT_REF}"; then
+			return 0
+		fi
+	done < <(git_source_candidates "${KOPIA_GIT_URL}")
+	die "unable to fetch ${KOPIA_GIT_REF} from the configured mirror or ${KOPIA_GIT_URL}"
+}
+
 sync_source() {
+	local origin_url mirrored_url=""
 	command -v git >/dev/null 2>&1 || die "git is required to prepare Kopia"
 	mkdir -p "${KOPIA_BUILD_DIR}"
 	if [[ -e "${KOPIA_SOURCE_DIR}" && ! -d "${KOPIA_SOURCE_DIR}/.git" ]]; then
@@ -79,12 +130,18 @@ sync_source() {
 	fi
 	if [[ ! -d "${KOPIA_SOURCE_DIR}/.git" ]]; then
 		[[ "${OFFLINE}" -eq 0 ]] || die "Kopia source cache is missing and offline mode forbids cloning"
-		log "Cloning ${KOPIA_GIT_URL}"
-		git_with_auth clone --no-checkout "${KOPIA_GIT_URL}" "${KOPIA_SOURCE_DIR}"
-	elif [[ "$(git -C "${KOPIA_SOURCE_DIR}" remote get-url origin)" != "${KOPIA_GIT_URL}" ]]; then
-		[[ "${FORCE}" -eq 1 ]] || die "Kopia source cache origin differs from KOPIA_GIT_URL; rerun with --force"
-		[[ "${OFFLINE}" -eq 0 ]] || die "offline mode cannot replace the Kopia source cache origin"
-		git -C "${KOPIA_SOURCE_DIR}" remote set-url origin "${KOPIA_GIT_URL}"
+		clone_source
+	else
+		origin_url="$(git -C "${KOPIA_SOURCE_DIR}" config --get remote.origin.url || true)"
+		mirrored_url="$(github_git_mirror_url "${KOPIA_GIT_URL}" || true)"
+		if [[ -n "${mirrored_url}" && "${origin_url}" == "${mirrored_url}" ]]; then
+			log "Normalizing cached Kopia origin to ${KOPIA_GIT_URL}"
+			git -C "${KOPIA_SOURCE_DIR}" remote set-url origin "${KOPIA_GIT_URL}"
+		elif [[ "${origin_url}" != "${KOPIA_GIT_URL}" ]]; then
+			[[ "${FORCE}" -eq 1 ]] || die "Kopia source cache origin differs from KOPIA_GIT_URL; rerun with --force"
+			[[ "${OFFLINE}" -eq 0 ]] || die "offline mode cannot replace the Kopia source cache origin"
+			git -C "${KOPIA_SOURCE_DIR}" remote set-url origin "${KOPIA_GIT_URL}"
+		fi
 	fi
 	if [[ "${OFFLINE}" -eq 1 ]]; then
 		log "Offline mode: resolving ${KOPIA_GIT_REF} from the source cache"
@@ -92,8 +149,7 @@ sync_source() {
 			|| die "Kopia ref ${KOPIA_GIT_REF} is missing from the offline source cache"
 		git -C "${KOPIA_SOURCE_DIR}" reset --hard "${KOPIA_GIT_REF}^{commit}" >/dev/null
 	else
-		log "Fetching ${KOPIA_GIT_REF}"
-		git_with_auth -C "${KOPIA_SOURCE_DIR}" fetch --force --tags origin "${KOPIA_GIT_REF}"
+		fetch_source_ref
 		git -C "${KOPIA_SOURCE_DIR}" reset --hard FETCH_HEAD >/dev/null
 	fi
 	git -C "${KOPIA_SOURCE_DIR}" clean -fdx >/dev/null
@@ -372,4 +428,6 @@ EOF
 	log "Kopia matrix is ready under ${KOPIA_DIST_DIR}"
 }
 
-main "$@"
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+	main "$@"
+fi

--- a/tools/quality/test-kopia-build-config.sh
+++ b/tools/quality/test-kopia-build-config.sh
@@ -22,6 +22,75 @@ cli_config="$(
 grep -F 'mode=build' <<<"${cli_config}" >/dev/null
 grep -F 'version=0.23.1' <<<"${cli_config}" >/dev/null
 
+mirror_config="$(
+	"${ROOT}/tools/kopia/prepare.sh" \
+		--github-download-mirror https://ghfast.top --print-config
+)"
+grep -F 'git_url=https://github.com/kopia/kopia.git' <<<"${mirror_config}" >/dev/null
+grep -F 'github_download_mirror=https://ghfast.top' <<<"${mirror_config}" >/dev/null
+
+# shellcheck source=../kopia/prepare.sh
+source "${ROOT}/tools/kopia/prepare.sh"
+
+GITHUB_DOWNLOAD_MIRROR=https://ghfast.top/
+mirror_candidates="$(git_source_candidates 'https://github.com/kopia/kopia.git')"
+[[ "${mirror_candidates}" == $'https://ghfast.top/https://github.com/kopia/kopia.git\nhttps://github.com/kopia/kopia.git' ]]
+custom_candidates="$(git_source_candidates 'https://git.example.test/kopia.git')"
+[[ "${custom_candidates}" == 'https://git.example.test/kopia.git' ]]
+
+mirror_test_root="$(mktemp -d)"
+trap 'rm -rf "${mirror_test_root}"' EXIT
+fixture_repo="${mirror_test_root}/fixture"
+git init -q "${fixture_repo}"
+git -C "${fixture_repo}" config user.email test@hyperfilelens.local
+git -C "${fixture_repo}" config user.name 'HyperFileLens Test'
+printf '%s\n' 'module example.test/kopia-fixture' >"${fixture_repo}/go.mod"
+git -C "${fixture_repo}" add go.mod
+git -C "${fixture_repo}" commit -q -m fixture
+git -C "${fixture_repo}" tag v0.23.1
+fixture_commit="$(git -C "${fixture_repo}" rev-parse HEAD)"
+
+KOPIA_BUILD_DIR="${mirror_test_root}/build"
+KOPIA_SOURCE_DIR="${KOPIA_BUILD_DIR}/source"
+KOPIA_GIT_URL=https://github.com/kopia/kopia.git
+KOPIA_GIT_REF=v0.23.1
+GITHUB_DOWNLOAD_MIRROR=https://ghfast.top
+GITHUB_TOKEN=
+OFFLINE=0
+FORCE=0
+git_call_log="${mirror_test_root}/git-calls.log"
+mirror_git_url="${GITHUB_DOWNLOAD_MIRROR}/${KOPIA_GIT_URL}"
+
+git_with_auth() {
+	local -a args=("$@")
+	local index
+	printf '%s\n' "$*" >>"${git_call_log}"
+	for index in "${!args[@]}"; do
+		if [[ "${args[${index}]}" == "${mirror_git_url}" ]]; then
+			return 1
+		fi
+		if [[ "${args[${index}]}" == "${KOPIA_GIT_URL}" ]]; then
+			args[${index}]="${fixture_repo}"
+		fi
+	done
+	command git "${args[@]}"
+}
+
+sync_source
+mirror_call_count="$(awk -v url="${mirror_git_url}" '{ for (i = 1; i <= NF; i++) if ($i == url) count++ } END { print count + 0 }' "${git_call_log}")"
+official_call_count="$(awk -v url="${KOPIA_GIT_URL}" '{ for (i = 1; i <= NF; i++) if ($i == url) count++ } END { print count + 0 }' "${git_call_log}")"
+[[ "${mirror_call_count}" -eq 2 ]]
+[[ "${official_call_count}" -eq 2 ]]
+[[ "$(git -C "${KOPIA_SOURCE_DIR}" config --get remote.origin.url)" == "${KOPIA_GIT_URL}" ]]
+[[ "${KOPIA_GIT_COMMIT}" == "${fixture_commit}" ]]
+
+# Normalize caches created by the previous explicit mirror workaround without
+# changing the canonical KOPIA_GIT_URL or requiring network access.
+git -C "${KOPIA_SOURCE_DIR}" remote set-url origin "${mirror_git_url}"
+OFFLINE=1
+sync_source
+[[ "$(git -C "${KOPIA_SOURCE_DIR}" config --get remote.origin.url)" == "${KOPIA_GIT_URL}" ]]
+
 [[ ! -e "${ROOT}/tools/dependencies/versions/kopia.env" ]]
 [[ ! -e "${ROOT}/tools/dependencies/fetch-kopia-deb.sh" ]]
 if rg -n --glob '!build/**' --glob '!data/**' \


### PR DESCRIPTION
## Summary
- reuse the configured GitHub download mirror for Kopia Git clone and fetch operations
- fall back to the canonical GitHub URL while preserving canonical source metadata
- normalize caches created with the previous explicit mirror URL workaround

## Validation
- Kopia mirror/fallback configuration regression tests
- real ghfast.top smart-HTTP tag lookup for Kopia v0.23.1
- release contract, shell syntax, command parsing, English-source, and diff checks