### PR TITLE
Fix admin monitoring integration regressions

### DIFF
--- a/src/backend/apps/platform_ops/api/views/monitoring.py
+++ b/src/backend/apps/platform_ops/api/views/monitoring.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from django.core.exceptions import ValidationError
+from django.db import transaction
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
 from rest_framework.response import Response
@@ -258,21 +259,28 @@ class PlatformOpsMonitoringNotificationRetryView(APIView):
     permission_classes = [IsPlatformOpsStaff]
 
     def post(self, request, delivery_id):
-        delivery = get_object_or_404(
-            NotificationDelivery.objects.select_related("organization", "channel"),
-            id=delivery_id,
-        )
-        if delivery.status != NotificationDelivery.Status.FAILED:
-            return Response({"detail": "Only failed deliveries can be retried."}, status=400)
-        result = attempt_delivery(delivery=delivery)
-        write_platform_audit_log(
-            request=request,
-            action="monitoring.notification.retry",
-            target_type="notification_delivery",
-            target_id=str(delivery.id),
-            org_key=delivery.organization.key,
-            details={"status": delivery.status, "delivered": result.ok},
-        )
+        with transaction.atomic():
+            delivery = get_object_or_404(
+                NotificationDelivery.objects.select_for_update().select_related(
+                    "organization",
+                    "channel",
+                ),
+                id=delivery_id,
+            )
+            if delivery.status != NotificationDelivery.Status.FAILED:
+                return Response(
+                    {"detail": "Only failed deliveries can be retried."},
+                    status=400,
+                )
+            result = attempt_delivery(delivery=delivery)
+            write_platform_audit_log(
+                request=request,
+                action="monitoring.notification.retry",
+                target_type="notification_delivery",
+                target_id=str(delivery.id),
+                org_key=delivery.organization.key,
+                details={"status": delivery.status, "delivered": result.ok},
+            )
         return Response(
             PlatformNotificationDeliveryRowSerializer(delivery).data,
             status=200 if result.ok else 502,

--- a/src/backend/apps/platform_ops/tests/test_health_api.py
+++ b/src/backend/apps/platform_ops/tests/test_health_api.py
@@ -164,9 +164,16 @@ class PlatformOpsMonitoringApiTest(TestCase):
             delivery.save(update_fields=["status", "sent_at"])
             return SimpleNamespace(ok=True)
 
-        with patch(
-            "apps.platform_ops.api.views.monitoring.attempt_delivery",
-            side_effect=deliver,
+        with (
+            patch.object(
+                NotificationDelivery.objects,
+                "select_for_update",
+                wraps=NotificationDelivery.objects.select_for_update,
+            ) as select_for_update,
+            patch(
+                "apps.platform_ops.api.views.monitoring.attempt_delivery",
+                side_effect=deliver,
+            ),
         ):
             response = self.client.post(
                 f"/api/v1/platform-ops/monitoring/notifications/{delivery.id}/retry",
@@ -174,8 +181,20 @@ class PlatformOpsMonitoringApiTest(TestCase):
                 format="json",
             )
         self.assertEqual(response.status_code, 200)
+        select_for_update.assert_called_once_with()
         delivery.refresh_from_db()
         self.assertEqual(delivery.status, NotificationDelivery.Status.SENT)
+
+        with patch(
+            "apps.platform_ops.api.views.monitoring.attempt_delivery",
+        ) as attempt_again:
+            response = self.client.post(
+                f"/api/v1/platform-ops/monitoring/notifications/{delivery.id}/retry",
+                {},
+                format="json",
+            )
+        self.assertEqual(response.status_code, 400)
+        attempt_again.assert_not_called()
 
     def test_platform_environment_ok(self):
         response = self.client.get("/api/v1/platform-ops/platform/settings/environment")

--- a/src/frontend/src/components/ModulePage.vue
+++ b/src/frontend/src/components/ModulePage.vue
@@ -48,10 +48,16 @@ const isAdminSettingsShell = computed(
 
 const collapsed = ref(localStorage.getItem('sidebar-collapsed') === 'true')
 const viewportCollapsed = ref(false)
-const effectiveCollapsed = computed(() => collapsed.value || viewportCollapsed.value)
+const responsiveCollapsedOverride = ref<boolean | null>(null)
+const effectiveCollapsed = computed(
+  () => responsiveCollapsedOverride.value ?? (collapsed.value || viewportCollapsed.value),
+)
 
 function updateResponsiveSidebar() {
-  viewportCollapsed.value = route.path.startsWith('/platform-ops') && window.innerWidth <= 900
+  const nextViewportCollapsed = route.path.startsWith('/platform-ops') && window.innerWidth <= 900
+  if (nextViewportCollapsed === viewportCollapsed.value) return
+  viewportCollapsed.value = nextViewportCollapsed
+  responsiveCollapsedOverride.value = null
 }
 
 onMounted(() => {
@@ -122,6 +128,10 @@ const displayTitle = computed(() => {
 })
 
 function toggleSidebar() {
+  if (viewportCollapsed.value) {
+    responsiveCollapsedOverride.value = !effectiveCollapsed.value
+    return
+  }
   collapsed.value = !collapsed.value
   localStorage.setItem('sidebar-collapsed', String(collapsed.value))
 }

--- a/src/frontend/src/components/ModulePageResponsive.test.ts
+++ b/src/frontend/src/components/ModulePageResponsive.test.ts
@@ -1,0 +1,82 @@
+// @vitest-environment jsdom
+
+import { defineComponent, nextTick } from 'vue'
+import { mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import ModulePage from './ModulePage.vue'
+
+const route = vi.hoisted(() => ({
+  path: '/platform-ops/monitoring/tasks',
+  query: {},
+}))
+
+vi.mock('vue-router', () => ({
+  useRoute: () => route,
+}))
+
+const SidebarStub = defineComponent({
+  props: {
+    collapsed: { type: Boolean, default: false },
+    menus: { type: Array, required: true },
+  },
+  emits: ['toggle'],
+  template: `
+    <button
+      class="sidebar-stub"
+      :data-collapsed="String(collapsed)"
+      type="button"
+      @click="$emit('toggle')"
+    />
+  `,
+})
+
+function setViewportWidth(width: number) {
+  Object.defineProperty(window, 'innerWidth', {
+    configurable: true,
+    value: width,
+  })
+  window.dispatchEvent(new Event('resize'))
+}
+
+describe('ModulePage responsive sidebar', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    route.path = '/platform-ops/monitoring/tasks'
+    setViewportWidth(1200)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('allows a responsive sidebar to expand without overwriting the desktop preference', async () => {
+    localStorage.setItem('sidebar-collapsed', 'false')
+    setViewportWidth(800)
+    const wrapper = mount(ModulePage, {
+      props: {
+        menus: [{ label: 'Tasks', to: '/platform-ops/monitoring/tasks' }],
+      },
+      global: {
+        stubs: { Sidebar: SidebarStub },
+      },
+    })
+    await nextTick()
+
+    const sidebar = wrapper.get('.sidebar-stub')
+    expect(sidebar.attributes('data-collapsed')).toBe('true')
+
+    await sidebar.trigger('click')
+    expect(sidebar.attributes('data-collapsed')).toBe('false')
+    expect(localStorage.getItem('sidebar-collapsed')).toBe('false')
+
+    setViewportWidth(1200)
+    await nextTick()
+    expect(sidebar.attributes('data-collapsed')).toBe('false')
+
+    await sidebar.trigger('click')
+    expect(sidebar.attributes('data-collapsed')).toBe('true')
+    expect(localStorage.getItem('sidebar-collapsed')).toBe('true')
+
+    wrapper.unmount()
+  })
+})

--- a/src/frontend/src/platform-ops/pages/monitoring/MonitoringDeliveries.vue
+++ b/src/frontend/src/platform-ops/pages/monitoring/MonitoringDeliveries.vue
@@ -2,8 +2,9 @@
 import { onMounted, reactive, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
-import { ElMessage, ElMessageBox } from 'element-plus'
+import { ElMessage } from 'element-plus'
 import { CheckCircle2, CircleX, Clock3, RefreshCw, Search, Send } from 'lucide-vue-next'
+import DangerConfirmDialog from '../../../components/DangerConfirmDialog.vue'
 import ModulePage from '../../../components/ModulePage.vue'
 import HflPagination from '../../../components/HflPagination.vue'
 import HflTablePanel from '../../../components/HflTablePanel.vue'
@@ -33,6 +34,7 @@ const loading = ref(false)
 const retrying = ref(false)
 const selected = ref<MonitoringDelivery | null>(null)
 const drawerOpen = ref(false)
+const retryConfirmOpen = ref(false)
 const pagination = reactive({ page: 1, pageSize: 20, count: 0 })
 const filters = reactive({
   search: String(route.query.search || ''),
@@ -93,19 +95,11 @@ function openDrawer(row: MonitoringDelivery) {
 
 async function retryDelivery() {
   if (!selected.value || selected.value.status !== 'failed') return
-  try {
-    await ElMessageBox.confirm(
-      t('platformOps.monitoring.confirmRetryDeliveryMessage'),
-      t('platformOps.monitoring.confirmRetryDeliveryTitle'),
-      { type: 'warning', confirmButtonText: t('platformOps.monitoring.retryDelivery') },
-    )
-  } catch {
-    return
-  }
   retrying.value = true
   try {
     await retryMonitoringDelivery(selected.value.id)
     ElMessage.success({ message: t('platformOps.monitoring.retryDeliverySuccess'), grouping: true })
+    retryConfirmOpen.value = false
     drawerOpen.value = false
     await load()
   } catch (error) {
@@ -361,7 +355,7 @@ watch(() => [pagination.page, pagination.pageSize], load)
             v-if="selected.status === 'failed'"
             type="primary"
             :loading="retrying"
-            @click="retryDelivery"
+            @click="retryConfirmOpen = true"
           >
             {{ t('platformOps.monitoring.retryDelivery') }}
           </el-button>
@@ -397,5 +391,15 @@ watch(() => [pagination.page, pagination.pageSize], load)
         </section>
       </template>
     </el-drawer>
+    <DangerConfirmDialog
+      v-model="retryConfirmOpen"
+      :title="t('platformOps.monitoring.confirmRetryDeliveryTitle')"
+      :message="t('platformOps.monitoring.confirmRetryDeliveryMessage')"
+      level="low"
+      :cancel-text="t('common.cancel')"
+      :confirm-text="t('platformOps.monitoring.retryDelivery')"
+      :loading="retrying"
+      @confirm="retryDelivery"
+    />
   </ModulePage>
 </template>

--- a/src/frontend/src/platform-ops/pages/monitoring/MonitoringIncidents.vue
+++ b/src/frontend/src/platform-ops/pages/monitoring/MonitoringIncidents.vue
@@ -2,8 +2,9 @@
 import { computed, onMounted, reactive, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
-import { ElMessage, ElMessageBox } from 'element-plus'
+import { ElMessage } from 'element-plus'
 import { AlertTriangle, CheckCircle2, CircleAlert, RefreshCw, Search, ShieldCheck } from 'lucide-vue-next'
+import DangerConfirmDialog, { type DangerConfirmItem } from '../../../components/DangerConfirmDialog.vue'
 import ModulePage from '../../../components/ModulePage.vue'
 import HflPagination from '../../../components/HflPagination.vue'
 import HflTablePanel from '../../../components/HflTablePanel.vue'
@@ -35,6 +36,8 @@ const actionLoading = ref(false)
 const selected = ref<MonitoringIncident | null>(null)
 const drawerOpen = ref(false)
 const selectedRows = ref<MonitoringIncident[]>([])
+const resolveConfirmOpen = ref(false)
+const pendingResolveTargets = ref<MonitoringIncident[]>([])
 const pagination = reactive({ page: 1, pageSize: 20, count: 0 })
 const filters = reactive({
   search: String(route.query.search || ''),
@@ -46,6 +49,12 @@ const { schedule: scheduleSearch, runNow: runSearchNow } = useDebouncedAction(ap
 
 const canAcknowledge = computed(() => selectedRows.value.some((row) => row.status === 'firing'))
 const canResolve = computed(() => selectedRows.value.some((row) => row.status !== 'resolved'))
+const resolveConfirmItems = computed<DangerConfirmItem[]>(() => pendingResolveTargets.value.map((row) => ({
+  key: row.id,
+  name: row.title,
+  description: `${row.organization_key} · ${resourceLabel(row)}`,
+  status: { label: row.status, tone: 'warning' },
+})))
 
 function severityClass(value: string) {
   if (value === 'critical') return 'hfl-ops-severity-pill--critical'
@@ -109,35 +118,51 @@ function openDrawer(row: MonitoringIncident) {
   drawerOpen.value = true
 }
 
-async function performAction(action: 'acknowledge' | 'resolve', targets: MonitoringIncident[]) {
-  if (!targets.length) return
-  if (action === 'resolve') {
-    try {
-      await ElMessageBox.confirm(
-        t('platformOps.monitoring.confirmResolveMessage', { count: targets.length }),
-        t('platformOps.monitoring.confirmResolveTitle'),
-        { type: 'warning', confirmButtonText: t('platformOps.monitoring.resolve') },
-      )
-    } catch {
-      return
-    }
-  }
-  actionLoading.value = true
+async function executeAction(action: 'acknowledge' | 'resolve', targets: MonitoringIncident[]) {
   const validTargets = targets.filter((row) => (
     action === 'acknowledge' ? row.status === 'firing' : row.status !== 'resolved'
   ))
-  const settled = await Promise.allSettled(
-    validTargets.map((row) => runMonitoringIncidentAction(row.id, action)),
-  )
-  const failed = settled.filter((result) => result.status === 'rejected').length
-  actionLoading.value = false
-  if (failed) {
-    ElMessage.warning({ message: t('platformOps.monitoring.partialAction', { failed }), grouping: true })
-  } else {
-    ElMessage.success({ message: t(`platformOps.monitoring.${action}Success`), grouping: true })
+  if (!validTargets.length) return
+  actionLoading.value = true
+  try {
+    const settled = await Promise.allSettled(
+      validTargets.map((row) => runMonitoringIncidentAction(row.id, action)),
+    )
+    const failed = settled.filter((result) => result.status === 'rejected').length
+    if (failed) {
+      ElMessage.warning({ message: t('platformOps.monitoring.partialAction', { failed }), grouping: true })
+    } else {
+      ElMessage.success({ message: t(`platformOps.monitoring.${action}Success`), grouping: true })
+    }
+    drawerOpen.value = false
+    await load()
+  } finally {
+    actionLoading.value = false
   }
-  drawerOpen.value = false
-  await load()
+}
+
+async function performAction(action: 'acknowledge' | 'resolve', targets: MonitoringIncident[]) {
+  const validTargets = targets.filter((row) => (
+    action === 'acknowledge' ? row.status === 'firing' : row.status !== 'resolved'
+  ))
+  if (!validTargets.length) return
+  if (action === 'resolve') {
+    pendingResolveTargets.value = validTargets
+    resolveConfirmOpen.value = true
+    return
+  }
+  await executeAction(action, validTargets)
+}
+
+function cancelResolve() {
+  if (actionLoading.value) return
+  pendingResolveTargets.value = []
+}
+
+async function confirmResolve() {
+  await executeAction('resolve', pendingResolveTargets.value)
+  resolveConfirmOpen.value = false
+  cancelResolve()
 }
 
 onMounted(load)
@@ -442,5 +467,17 @@ watch(() => [pagination.page, pagination.pageSize], load)
         </section>
       </template>
     </el-drawer>
+    <DangerConfirmDialog
+      v-model="resolveConfirmOpen"
+      :title="t('platformOps.monitoring.confirmResolveTitle')"
+      :message="t('platformOps.monitoring.confirmResolveMessage', { count: pendingResolveTargets.length })"
+      :items="resolveConfirmItems"
+      level="high"
+      :cancel-text="t('common.cancel')"
+      :confirm-text="t('platformOps.monitoring.resolve')"
+      :loading="actionLoading"
+      @confirm="confirmResolve"
+      @cancel="cancelResolve"
+    />
   </ModulePage>
 </template>

--- a/src/frontend/src/platform-ops/pages/monitoring/MonitoringNodes.vue
+++ b/src/frontend/src/platform-ops/pages/monitoring/MonitoringNodes.vue
@@ -24,7 +24,7 @@ const sideNav = usePlatformOpsSideNav()
 const { drawerSize } = useResponsiveDrawerWidth(3)
 const rows = ref<MonitoringNode[]>([])
 const stats = ref<NodeStats>({ total: 0, online: 0, offline: 0, outdated: 0, latest_version: '' })
-const loading = ref(false)
+const busy = ref(false)
 const selected = ref<MonitoringNode | null>(null)
 const drawerOpen = ref(false)
 const pagination = reactive({ page: 1, pageSize: 20, count: 0 })
@@ -56,7 +56,7 @@ async function syncQuery() {
 }
 
 async function load() {
-  loading.value = true
+  busy.value = true
   try {
     const data = await fetchMonitoringNodes({ page: pagination.page, page_size: pagination.pageSize, ...filters })
     rows.value = data.results
@@ -65,7 +65,7 @@ async function load() {
   } catch (error) {
     ElMessage.error({ message: apiErrorMessage(error, t('platformOps.monitoring.loadFailed')), grouping: true })
   } finally {
-    loading.value = false
+    busy.value = false
   }
 }
 
@@ -212,18 +212,18 @@ watch(() => [pagination.page, pagination.pageSize], load)
             class="hfl-refresh-button"
             :title="t('common.refresh')"
             :aria-label="t('common.refresh')"
-            :disabled="loading"
+            :disabled="busy"
             @click="load"
           >
             <RefreshCw
               :size="16"
-              :class="{ 'is-spinning': loading }"
+              :class="{ 'is-spinning': busy }"
             />
           </el-button>
         </template>
         <template #table="{ tableMaxHeight }">
           <el-table
-            v-loading="loading"
+            v-loading="busy"
             :data="rows"
             stripe
             flexible

--- a/src/frontend/src/platform-ops/pages/monitoring/MonitoringTasks.vue
+++ b/src/frontend/src/platform-ops/pages/monitoring/MonitoringTasks.vue
@@ -2,8 +2,9 @@
 import { computed, onMounted, reactive, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
-import { ElMessage, ElMessageBox } from 'element-plus'
+import { ElMessage } from 'element-plus'
 import { Activity, CircleCheck, CircleX, Clock3, RefreshCw, Search } from 'lucide-vue-next'
+import DangerConfirmDialog, { type DangerConfirmItem } from '../../../components/DangerConfirmDialog.vue'
 import ModulePage from '../../../components/ModulePage.vue'
 import HflPagination from '../../../components/HflPagination.vue'
 import HflTablePanel from '../../../components/HflTablePanel.vue'
@@ -30,10 +31,13 @@ const sideNav = usePlatformOpsSideNav()
 const { drawerSize } = useResponsiveDrawerWidth(3)
 const rows = ref<MonitoringTask[]>([])
 const stats = ref<TaskStats>({ total: 0, running: 0, failed: 0, timeout: 0, success_rate: 0 })
-const loading = ref(false)
+const busy = ref(false)
 const actionLoading = ref(false)
 const selected = ref<MonitoringTask | null>(null)
 const drawerOpen = ref(false)
+const actionConfirmOpen = ref(false)
+const pendingAction = ref<'cancel' | 'retry' | null>(null)
+const pendingTask = ref<MonitoringTask | null>(null)
 const pagination = reactive({ page: 1, pageSize: 20, count: 0 })
 const filters = reactive({
   search: String(route.query.search || ''),
@@ -44,6 +48,25 @@ const filters = reactive({
 const { schedule: scheduleSearch, runNow: runSearchNow } = useDebouncedAction(applyFilters)
 const canCancel = computed(() => selected.value?.status === 'pending' || selected.value?.status === 'running')
 const canRetry = computed(() => ['failed', 'timeout', 'cancelled'].includes(selected.value?.status || ''))
+const actionConfirmTitle = computed(() => t(
+  `platformOps.monitoring.confirmTask${pendingAction.value === 'cancel' ? 'Cancel' : 'Retry'}Title`,
+))
+const actionConfirmMessage = computed(() => t(
+  `platformOps.monitoring.confirmTask${pendingAction.value === 'cancel' ? 'Cancel' : 'Retry'}Message`,
+))
+const actionConfirmText = computed(() => t(
+  `platformOps.monitoring.${pendingAction.value === 'cancel' ? 'cancel' : 'retry'}Task`,
+))
+const actionConfirmItems = computed<DangerConfirmItem[]>(() => (
+  pendingTask.value
+    ? [{
+        key: pendingTask.value.task_uuid,
+        name: pendingTask.value.display_name,
+        description: pendingTask.value.organization_key,
+        status: { label: pendingTask.value.status, tone: pendingAction.value === 'cancel' ? 'danger' : 'info' },
+      }]
+    : []
+))
 
 function displayTime(value?: string | null) {
   return formatLocalDateTime(value, '—')
@@ -65,7 +88,7 @@ async function syncQuery() {
 }
 
 async function load() {
-  loading.value = true
+  busy.value = true
   try {
     const data = await fetchMonitoringTasks({ page: pagination.page, page_size: pagination.pageSize, ...filters })
     rows.value = data.results
@@ -74,7 +97,7 @@ async function load() {
   } catch (error) {
     ElMessage.error({ message: apiErrorMessage(error, t('platformOps.monitoring.loadFailed')), grouping: true })
   } finally {
-    loading.value = false
+    busy.value = false
   }
 }
 
@@ -94,21 +117,30 @@ function openDrawer(row: MonitoringTask) {
   drawerOpen.value = true
 }
 
-async function performAction(action: 'cancel' | 'retry') {
+function requestAction(action: 'cancel' | 'retry') {
   if (!selected.value) return
-  try {
-    await ElMessageBox.confirm(
-      t(`platformOps.monitoring.confirmTask${action === 'cancel' ? 'Cancel' : 'Retry'}Message`),
-      t(`platformOps.monitoring.confirmTask${action === 'cancel' ? 'Cancel' : 'Retry'}Title`),
-      { type: action === 'cancel' ? 'warning' : 'info', confirmButtonText: t(`platformOps.monitoring.${action}Task`) },
-    )
-  } catch {
-    return
-  }
+  pendingAction.value = action
+  pendingTask.value = selected.value
+  actionConfirmOpen.value = true
+}
+
+function cancelAction() {
+  if (actionLoading.value) return
+  pendingAction.value = null
+  pendingTask.value = null
+}
+
+async function performAction() {
+  const action = pendingAction.value
+  const task = pendingTask.value
+  if (!action || !task) return
   actionLoading.value = true
   try {
-    await runMonitoringTaskAction(selected.value.task_uuid, action)
+    await runMonitoringTaskAction(task.task_uuid, action)
     ElMessage.success({ message: t(`platformOps.monitoring.${action}TaskSuccess`), grouping: true })
+    actionConfirmOpen.value = false
+    pendingAction.value = null
+    pendingTask.value = null
     drawerOpen.value = false
     await load()
   } catch (error) {
@@ -243,18 +275,18 @@ watch(() => [pagination.page, pagination.pageSize], load)
             class="hfl-refresh-button"
             :title="t('common.refresh')"
             :aria-label="t('common.refresh')"
-            :disabled="loading"
+            :disabled="busy"
             @click="load"
           >
             <RefreshCw
               :size="16"
-              :class="{ 'is-spinning': loading }"
+              :class="{ 'is-spinning': busy }"
             />
           </el-button>
         </template>
         <template #table="{ tableMaxHeight }">
           <el-table
-            v-loading="loading"
+            v-loading="busy"
             :data="rows"
             stripe
             flexible
@@ -368,14 +400,14 @@ watch(() => [pagination.page, pagination.pageSize], load)
             type="danger"
             plain
             :loading="actionLoading"
-            @click="performAction('cancel')"
+            @click="requestAction('cancel')"
           >
             {{ t('platformOps.monitoring.cancelTask') }}
           </el-button><el-button
             v-if="canRetry"
             type="primary"
             :loading="actionLoading"
-            @click="performAction('retry')"
+            @click="requestAction('retry')"
           >
             {{ t('platformOps.monitoring.retryTask') }}
           </el-button>
@@ -412,5 +444,17 @@ watch(() => [pagination.page, pagination.pageSize], load)
         </section>
       </template>
     </el-drawer>
+    <DangerConfirmDialog
+      v-model="actionConfirmOpen"
+      :title="actionConfirmTitle"
+      :message="actionConfirmMessage"
+      :items="actionConfirmItems"
+      :level="pendingAction === 'cancel' ? 'high' : 'low'"
+      :cancel-text="t('common.cancel')"
+      :confirm-text="actionConfirmText"
+      :loading="actionLoading"
+      @confirm="performAction"
+      @cancel="cancelAction"
+    />
   </ModulePage>
 </template>


### PR DESCRIPTION
## Summary
- serialize failed notification retries to prevent duplicate delivery
- use the shared confirmation dialog for admin monitoring actions
- restore loading-state contracts and responsive sidebar behavior
- add regression coverage for notification retries and responsive navigation

## Verification
- frontend: 300 tests passed
- backend platform monitoring API: 10 tests passed
- frontend lint and production build passed
- Ruff and git diff checks passed