### PR TITLE
fix(build): include Kopia binary in Docker context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,9 +3,11 @@
 .env.*
 data
 build/**
-!build/dependencies/
-!build/dependencies/kopia/
-!build/dependencies/kopia/*.deb
+!build/kopia/
+!build/kopia/dist/
+!build/kopia/dist/linux/
+!build/kopia/dist/linux/amd64/
+!build/kopia/dist/linux/amd64/kopia
 logs
 *.log
 node_modules

--- a/dev/stack.sh
+++ b/dev/stack.sh
@@ -369,12 +369,12 @@ cache_update() {
 build_dev_images() {
 	local force=$1 backend_fingerprint frontend_fingerprint
 	backend_fingerprint="$(cache_fingerprint \
-		deploy/docker/backend.Dockerfile deploy/docker/backend-entrypoint.sh deploy/bootstrap \
+		.dockerignore deploy/docker/backend.Dockerfile deploy/docker/backend-entrypoint.sh deploy/bootstrap \
 		pyproject.toml uv.lock build/kopia/KOPIA_INFO.json build/kopia/dist/linux/amd64/kopia -- \
 		"apt=${MIRROR_APT}" "pip=${OPT_PIP_INDEX_URL}" \
 		"pip_host=${OPT_PIP_TRUSTED_HOST}" "kopia=${KOPIA_GIT_REF}" "kopia_mode=${KOPIA_ARTIFACT_MODE}")"
 	frontend_fingerprint="$(cache_fingerprint \
-		deploy/docker/frontend.Dockerfile deploy/docker/frontend-dev-entrypoint.sh \
+		.dockerignore deploy/docker/frontend.Dockerfile deploy/docker/frontend-dev-entrypoint.sh \
 		src/frontend/package.json \
 		src/frontend/package-lock.json -- "npm=${OPT_NPM_REGISTRY}")"
 

--- a/tools/quality/test-kopia-build-config.sh
+++ b/tools/quality/test-kopia-build-config.sh
@@ -93,6 +93,18 @@ sync_source
 
 [[ ! -e "${ROOT}/tools/dependencies/versions/kopia.env" ]]
 [[ ! -e "${ROOT}/tools/dependencies/fetch-kopia-deb.sh" ]]
+for docker_context_path in \
+	'!build/kopia/' \
+	'!build/kopia/dist/' \
+	'!build/kopia/dist/linux/' \
+	'!build/kopia/dist/linux/amd64/' \
+	'!build/kopia/dist/linux/amd64/kopia'; do
+	grep -Fx "${docker_context_path}" "${ROOT}/.dockerignore" >/dev/null
+done
+if rg -n 'build/dependencies/kopia|kopia_linux_amd64[.]deb' "${ROOT}/.dockerignore" >/dev/null; then
+	printf 'ERROR: obsolete Kopia Docker context paths are still configured\n' >&2
+	exit 1
+fi
 if rg -n --glob '!build/**' --glob '!data/**' \
 	--glob '!tools/quality/test-kopia-build-config.sh' -- \
 	'--kopia-version|KOPIA_DEB|kopia_linux_amd64[.]deb|tools/dependencies/versions/kopia[.]env' \


### PR DESCRIPTION
## Summary
- expose only the canonical linux/amd64 Kopia binary through the Docker build context
- remove obsolete Kopia deb context exceptions
- include .dockerignore in development image cache fingerprints

## Validation
- successful local deployment with the patched Kopia 0.23.1 binary
- real minimal BuildKit COPY test transferred the 52.50 MB Kopia binary
- Kopia configuration, release contract, shell syntax, and diff checks