### PR TITLE
fix(storage): restore Coming Soon provider options

### DIFF
--- a/src/frontend/src/lib/s3PlatformDisplay.test.ts
+++ b/src/frontend/src/lib/s3PlatformDisplay.test.ts
@@ -35,4 +35,36 @@ describe('S3 object prefix defaults', () => {
     expect(wrapper.findAll('input').map((input) => input.element.value))
       .toContain(DEFAULT_S3_OBJECT_PREFIX)
   })
+
+  it('shows future platform capabilities as disabled Coming Soon options', async () => {
+    const wrapper = mount(AddS3Repo, {
+      global: {
+        plugins: [ElementPlus],
+        stubs: {
+          S3PlatformBrandIcon: true,
+        },
+      },
+    })
+    const platformButtons = wrapper.findAll('.add-s3-platform-btn')
+
+    expect(platformButtons.map((button) => button.text())).toEqual([
+      'addS3Repo.platformAws',
+      'addS3Repo.platformAliyun',
+      'addS3Repo.platformHuawei',
+      'addS3Repo.platformOtherS3',
+      'addS3Repo.platformTencent',
+      'addS3Repo.platformAzure',
+      'addS3Repo.platformGcp',
+    ])
+    expect(platformButtons.filter((button) => button.classes().includes('add-s3-platform-btn--disabled'))
+      .map((button) => button.text())).toEqual([
+      'addS3Repo.platformTencent',
+      'addS3Repo.platformAzure',
+      'addS3Repo.platformGcp',
+    ])
+
+    await platformButtons[4].trigger('click')
+    expect(platformButtons[4].classes()).not.toContain('add-s3-platform-btn--active')
+    expect(platformButtons[3].classes()).toContain('add-s3-platform-btn--active')
+  })
 })

--- a/src/frontend/src/lib/s3ProviderProfiles.test.ts
+++ b/src/frontend/src/lib/s3ProviderProfiles.test.ts
@@ -1,12 +1,35 @@
 import { describe, expect, it } from 'vitest'
 import {
+  S3_PROVIDER_OPTIONS,
   defaultS3UrlStyle,
+  isS3ProviderEnabled,
   normalizeS3StoragePlatform,
   normalizeS3UrlStyle,
   s3ProviderRegions,
 } from './s3ProviderProfiles'
 
 describe('S3 provider profiles', () => {
+  it('orders supported providers and keeps future capabilities disabled', () => {
+    expect(S3_PROVIDER_OPTIONS.map((provider) => provider.value)).toEqual([
+      'aws',
+      'aliyun',
+      'huawei',
+      'other',
+      'tencent',
+      'azure',
+      'gcp',
+    ])
+    expect(S3_PROVIDER_OPTIONS.filter((provider) => provider.enabled).map((provider) => provider.value)).toEqual([
+      'aws',
+      'aliyun',
+      'huawei',
+      'other',
+    ])
+    expect(isS3ProviderEnabled('tencent')).toBe(false)
+    expect(isS3ProviderEnabled('azure')).toBe(false)
+    expect(isS3ProviderEnabled('gcp')).toBe(false)
+  })
+
   it('uses virtual-hosted URLs for Huawei and auto for other providers', () => {
     expect(defaultS3UrlStyle('huawei')).toBe('virtual_hosted')
     expect(defaultS3UrlStyle('aws')).toBe('auto')

--- a/src/frontend/src/lib/s3ProviderProfiles.ts
+++ b/src/frontend/src/lib/s3ProviderProfiles.ts
@@ -1,6 +1,13 @@
 export type S3UrlStyle = 'auto' | 'virtual_hosted' | 'path'
 export type S3StoragePlatform = 'aliyun' | 'huawei' | 'aws' | 'custom'
 export type S3PlatformSelection = Exclude<S3StoragePlatform, 'custom'> | 'other'
+export type S3PlatformCapability = S3PlatformSelection | 'tencent' | 'azure' | 'gcp'
+
+export interface S3ProviderOption {
+  value: S3PlatformCapability
+  labelKey: string
+  enabled: boolean
+}
 
 export interface S3RegionPreset {
   key: string
@@ -46,12 +53,19 @@ const awsRegions: S3RegionPreset[] = [
   { key: 'ap-northeast-1', labelKey: 'addS3Repo.regionLabels.awsApNortheast1', endpoint: 'https://s3.ap-northeast-1.amazonaws.com', region: 'ap-northeast-1' },
 ]
 
-export const S3_PROVIDER_OPTIONS: Array<{ value: S3PlatformSelection; labelKey: string }> = [
-  { value: 'other', labelKey: 'addS3Repo.platformOtherS3' },
-  { value: 'aliyun', labelKey: 'addS3Repo.platformAliyun' },
-  { value: 'huawei', labelKey: 'addS3Repo.platformHuawei' },
-  { value: 'aws', labelKey: 'addS3Repo.platformAws' },
+export const S3_PROVIDER_OPTIONS: S3ProviderOption[] = [
+  { value: 'aws', labelKey: 'addS3Repo.platformAws', enabled: true },
+  { value: 'aliyun', labelKey: 'addS3Repo.platformAliyun', enabled: true },
+  { value: 'huawei', labelKey: 'addS3Repo.platformHuawei', enabled: true },
+  { value: 'other', labelKey: 'addS3Repo.platformOtherS3', enabled: true },
+  { value: 'tencent', labelKey: 'addS3Repo.platformTencent', enabled: false },
+  { value: 'azure', labelKey: 'addS3Repo.platformAzure', enabled: false },
+  { value: 'gcp', labelKey: 'addS3Repo.platformGcp', enabled: false },
 ]
+
+export function isS3ProviderEnabled(platform: S3PlatformCapability): platform is S3PlatformSelection {
+  return S3_PROVIDER_OPTIONS.some((item) => item.value === platform && item.enabled)
+}
 
 export function s3ProviderRegions(platform: S3PlatformSelection | undefined): S3RegionPreset[] {
   if (platform === 'aliyun') return aliyunRegions

--- a/src/frontend/src/pages/node/AddS3Repo.vue
+++ b/src/frontend/src/pages/node/AddS3Repo.vue
@@ -19,8 +19,10 @@ import { buildS3RepositoryName } from '../../lib/s3RepositoryName'
 import {
   S3_PROVIDER_OPTIONS,
   defaultS3UrlStyle,
+  isS3ProviderEnabled,
   normalizeS3StoragePlatform,
   s3ProviderRegions,
+  type S3PlatformCapability as StoragePlatformCapability,
   type S3PlatformSelection as StoragePlatform,
   type S3RegionPreset as RegionPreset,
   type S3UrlStyle,
@@ -214,11 +216,11 @@ function applyRegionPreset(key: string) {
   }
 }
 
-function isPlatformEnabled(platform: StoragePlatform): boolean {
-  return STORAGE_PLATFORMS.some((item) => item.value === platform)
+function isPlatformEnabled(platform: StoragePlatformCapability): platform is StoragePlatform {
+  return isS3ProviderEnabled(platform)
 }
 
-function onPlatformChange(p: StoragePlatform) {
+function onPlatformChange(p: StoragePlatformCapability) {
   if (!isPlatformEnabled(p)) {
     ElMessage.info({
       message: t('addS3Repo.platformComingSoon'),


### PR DESCRIPTION
## Summary
- restore Tencent Cloud COS, Azure Blob, and Google GCS as disabled Coming Soon capability cards
- keep AWS S3, Alibaba Cloud OSS, Huawei Cloud OBS, and S3-compatible storage selectable
- order providers as AWS, Alibaba, Huawei, S3-compatible, Tencent, Azure, and GCS

## Validation
- provider profile ordering and availability unit tests
- Add Object Storage Repository component interaction tests
- frontend TypeScript, production build, ESLint, and diff checks