### PR TITLE
Fix tablet authentication layouts and Turnstile loading visuals

### DIFF
--- a/src/frontend/src/components/TurnstileWidget.vue
+++ b/src/frontend/src/components/TurnstileWidget.vue
@@ -288,18 +288,14 @@ defineExpose({ reset })
 
 .turnstile-widget__loading {
   position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  height: 65px;
+  inset: 0;
+  z-index: 1;
   display: flex;
   align-items: center;
   justify-content: left !important;
   gap: 15px;
   padding: 0 14px;
   box-sizing: border-box;
-  border: 1px solid #3A3B40;
-  border-radius: var(--radius-card);
   background: #313131;
   color: #D4D7DD;
   font-size: 13px;

--- a/src/frontend/src/pages/auth/Login.vue
+++ b/src/frontend/src/pages/auth/Login.vue
@@ -1212,7 +1212,7 @@ onMounted(async () => {
   transform: translateX(-12px);
 }
 
-@media (max-width: 1023.98px) {
+@media (max-width: 1279.98px) {
   .login-container {
     min-height: var(--app-viewport-height);
     height: auto;

--- a/src/frontend/src/pages/auth/Register.vue
+++ b/src/frontend/src/pages/auth/Register.vue
@@ -1163,7 +1163,7 @@ onUnmounted(() => {
   opacity: 0;
 }
 
-@media (max-width: 1023.98px) {
+@media (max-width: 1279.98px) {
   .register-container {
     min-height: var(--app-viewport-height);
     height: auto;

--- a/tools/dev/browser-smoke.mjs
+++ b/tools/dev/browser-smoke.mjs
@@ -160,8 +160,10 @@ async function verifyAuthenticationViewport(browser, baseUrl, viewport) {
     const page = await context.newPage()
     for (const path of ['/login', '/register']) {
       await page.goto(`${baseUrl}${path}`, { waitUntil: 'domcontentloaded' })
-      await page.locator(path === '/login' ? '.login-form-box' : '.register-form-box').waitFor({ state: 'visible' })
+      const form = page.locator(path === '/login' ? '.login-form-box' : '.register-form-box')
+      await form.waitFor({ state: 'visible' })
       await assertNoDocumentOverflow(page, `${path} at ${viewport.width}x${viewport.height}`)
+      await assertInsideViewport(page, form, `${path} form at ${viewport.width}x${viewport.height}`)
     }
   } finally {
     await context.close()
@@ -187,6 +189,7 @@ async function verifyResponsiveConsoles(browser, storageState, tenantBaseUrl, ad
 
   await verifyAuthenticationViewport(browser, tenantBaseUrl, profiles[0].viewport)
   await verifyAuthenticationViewport(browser, tenantBaseUrl, profiles[2].viewport)
+  await verifyAuthenticationViewport(browser, tenantBaseUrl, { width: 1024, height: 768 })
 
   for (const profile of profiles) {
     const context = await browser.newContext({


### PR DESCRIPTION
Fixes authentication form clipping at tablet landscape widths, removes Turnstile loading-border artifacts, and adds a 1024x768 viewport regression assertion. Tests: npm run test:ci (333 passed); npm run build.