### PR TITLE
feat(agent): enforce native Source Host release certification

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -135,6 +135,7 @@ jobs:
           set -euo pipefail
           python3 tools/quality/check-english-source.py
           python3 -m unittest tools/quality/test_check_english_source.py
+          python3 -m unittest tools/quality/test_agent_certification_gate.py
           uv run --isolated --no-project --python 3.8 python tools/quality/check-python38-runtime.py
           ./tools/quality/check-release-contracts.sh
           ./tools/quality/test-default-certificates.sh
@@ -174,7 +175,7 @@ jobs:
   build-hfl-images:
     runs-on: ubuntu-24.04
     timeout-minutes: 90
-    needs: [prepare, quality]
+    needs: [prepare, agent-release-gate]
     permissions:
       contents: write
     strategy:
@@ -255,7 +256,7 @@ jobs:
   build-sourcelens-images:
     runs-on: ubuntu-24.04
     timeout-minutes: 120
-    needs: [prepare, quality]
+    needs: [prepare, agent-release-gate]
     permissions:
       contents: write
     strategy:
@@ -337,10 +338,123 @@ jobs:
           gh release upload "${{ needs.prepare.outputs.tag }}" \
             "_internal-agent-${{ matrix.asset }}.tar.gz" --clobber
 
+  certify-source-host:
+    name: Certify Source Host (${{ matrix.target }})
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 45
+    needs: [prepare, build-agent]
+    permissions:
+      contents: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: linux:amd64
+            platform: linux
+            arch: amd64
+            asset: linux-amd64
+            runner: ubuntu-24.04
+          - target: linux:arm64
+            platform: linux
+            arch: arm64
+            asset: linux-arm64
+            runner: ubuntu-24.04-arm
+          - target: darwin:amd64
+            platform: darwin
+            arch: amd64
+            asset: darwin-amd64
+            runner: macos-15-intel
+          - target: darwin:arm64
+            platform: darwin
+            arch: arm64
+            asset: darwin-arm64
+            runner: macos-15
+          - target: windows:amd64
+            platform: windows
+            arch: amd64
+            asset: windows-amd64
+            runner: windows-2022
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Download immutable Agent candidate
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: >-
+          gh release download "${{ needs.prepare.outputs.tag }}"
+          --pattern "_internal-agent-${{ matrix.asset }}.tar.gz"
+          --dir build/agent-candidate
+      - name: Run native Source Host certification
+        shell: bash
+        run: >-
+          python release/ci/certify-agent-candidate.py
+          --internal-bundle "build/agent-candidate/_internal-agent-${{ matrix.asset }}.tar.gz"
+          --version "${{ needs.prepare.outputs.version }}"
+          --commit "${{ needs.prepare.outputs.commit }}"
+          --expected-platform "${{ matrix.platform }}"
+          --expected-arch "${{ matrix.arch }}"
+          --report "build/certification/_internal-agent-cert-${{ matrix.asset }}.json"
+      - name: Upload certification evidence
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          report="build/certification/_internal-agent-cert-${{ matrix.asset }}.json"
+          if [[ -s "$report" ]]; then
+            gh release upload "${{ needs.prepare.outputs.tag }}" "$report" --clobber
+          fi
+
+  agent-release-gate:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    needs: [prepare, certify-source-host]
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Download Agent candidates and certification evidence
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          mkdir -p build/agent-candidates build/certification
+          gh release download "${{ needs.prepare.outputs.tag }}" \
+            --pattern '_internal-agent-*.tar.gz' \
+            --dir build/agent-candidates
+          gh release download "${{ needs.prepare.outputs.tag }}" \
+            --pattern '_internal-agent-cert-*.json' \
+            --dir build/certification
+      - name: Enforce Source Host release gate
+        run: |
+          python3 release/ci/verify-agent-certifications.py \
+            --candidates-dir build/agent-candidates \
+            --reports-dir build/certification \
+            --version "${{ needs.prepare.outputs.version }}" \
+            --commit "${{ needs.prepare.outputs.commit }}" \
+            --required-target linux:amd64 \
+            --required-target linux:arm64 \
+            --required-target darwin:amd64 \
+            --required-target darwin:arm64 \
+            --required-target windows:amd64 \
+            --output build/certification/_internal-agent-certification-summary.json
+      - name: Upload certification summary
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >-
+          gh release upload "${{ needs.prepare.outputs.tag }}"
+          build/certification/_internal-agent-certification-summary.json --clobber
+
   build-host-debs:
     runs-on: ubuntu-24.04
     timeout-minutes: 30
-    needs: [prepare, quality]
+    needs: [prepare, agent-release-gate]
     permissions:
       contents: write
     strategy:
@@ -432,7 +546,7 @@ jobs:
   export-runtime-images:
     runs-on: ubuntu-24.04
     timeout-minutes: 30
-    needs: [prepare, quality]
+    needs: [prepare, agent-release-gate]
     permissions:
       contents: write
     steps:
@@ -454,6 +568,7 @@ jobs:
     needs:
       - prepare
       - build-agent
+      - agent-release-gate
       - build-host-debs
       - export-hfl-images
       - export-sourcelens-bundle

--- a/deploy/bootstrap/agent-bootstrap-linux.sh
+++ b/deploy/bootstrap/agent-bootstrap-linux.sh
@@ -55,6 +55,12 @@ if [[ "$(id -u)" -ne 0 ]]; then
 	hfl_fail "Administrator privileges are required. Re-run with sudo." 1
 fi
 
+if ! command -v systemctl >/dev/null 2>&1 \
+	|| [[ ! -d /run/systemd/system ]] \
+	|| ! systemctl show-environment >/dev/null 2>&1; then
+	hfl_fail "This release requires a systemd-based Linux distribution. OpenRC, non-systemd, and container deployments are not supported." 2
+fi
+
 BIN="${TMPDIR:-/tmp}/hfl-enroll-$$"
 cleanup() { rm -f "${BIN}"; }
 trap cleanup EXIT

--- a/deploy/bootstrap/agent-bootstrap-macos.sh
+++ b/deploy/bootstrap/agent-bootstrap-macos.sh
@@ -27,6 +27,14 @@ if ! command -v curl >/dev/null 2>&1; then
 	hfl_fail "curl is required but not installed." 2
 fi
 
+if [[ "$(id -u)" -ne 0 ]]; then
+	hfl_fail "Administrator privileges are required. Re-run with sudo." 1
+fi
+
+if ! command -v launchctl >/dev/null 2>&1; then
+	hfl_fail "launchd is required to install the agent service on macOS." 2
+fi
+
 RAW_ARCH="$(uname -m)"
 case "${RAW_ARCH}" in
 x86_64 | amd64) HFL_ARCH=amd64 ;;

--- a/deploy/bootstrap/agent-bootstrap-windows.ps1
+++ b/deploy/bootstrap/agent-bootstrap-windows.ps1
@@ -63,7 +63,27 @@ function Get-HflEnrollmentBinary {
   }
 }
 
-$archRel = if ($env:PROCESSOR_ARCHITECTURE -eq "ARM64") { "arm64" } else { "amd64" }
+$nativeArch = if ($env:PROCESSOR_ARCHITEW6432) {
+  $env:PROCESSOR_ARCHITEW6432
+}
+else {
+  $env:PROCESSOR_ARCHITECTURE
+}
+$archRel = switch ($nativeArch) {
+  "AMD64" { "amd64"; break }
+  "ARM64" {
+    Write-HflBootstrapLog "FAIL " "Windows ARM64 is not supported by this release."
+    exit 4
+  }
+  "x86" {
+    Write-HflBootstrapLog "FAIL " "32-bit Windows is not supported by this release."
+    exit 4
+  }
+  default {
+    Write-HflBootstrapLog "FAIL " "Unsupported Windows architecture $nativeArch."
+    exit 4
+  }
+}
 $bin = Join-Path $env:TEMP ("hfl-enroll-" + [guid]::NewGuid().ToString("n") + ".exe")
 
 $enrollUrl = "$($env:HFL_API_BASE)/media/enroll-bootstrap/hfl-enroll-windows-$archRel.exe"

--- a/release/ci/certify-agent-candidate.py
+++ b/release/ci/certify-agent-candidate.py
@@ -1,0 +1,505 @@
+#!/usr/bin/env python3
+"""Certify one immutable Agent candidate on the current native runner."""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import hashlib
+import http.server
+import json
+import os
+import pathlib
+import platform
+import shutil
+import socketserver
+import stat
+import subprocess
+import sys
+import tarfile
+import tempfile
+import threading
+import urllib.parse
+import zipfile
+
+
+def fail(message: str) -> None:
+    raise RuntimeError(message)
+
+
+def sha256_file(path: pathlib.Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def safe_target(root: pathlib.Path, name: str) -> pathlib.Path:
+    target = (root / name).resolve()
+    if target != root.resolve() and root.resolve() not in target.parents:
+        fail(f"unsafe archive entry: {name}")
+    return target
+
+
+def extract_tar(path: pathlib.Path, destination: pathlib.Path) -> None:
+    with tarfile.open(path, "r:gz") as archive:
+        for member in archive.getmembers():
+            safe_target(destination, member.name)
+            if member.issym() or member.islnk():
+                fail(f"archive links are not allowed: {member.name}")
+        archive.extractall(destination, filter="data")
+
+
+def extract_zip(path: pathlib.Path, destination: pathlib.Path) -> None:
+    with zipfile.ZipFile(path) as archive:
+        for member in archive.infolist():
+            safe_target(destination, member.filename)
+        archive.extractall(destination)
+
+
+def extract_archive(path: pathlib.Path, destination: pathlib.Path) -> None:
+    destination.mkdir(parents=True, exist_ok=True)
+    if path.suffix.lower() == ".zip":
+        extract_zip(path, destination)
+    else:
+        extract_tar(path, destination)
+
+
+def normalize_platform(value: str) -> str:
+    return {
+        "linux": "linux",
+        "darwin": "darwin",
+        "windows": "windows",
+        "win32": "windows",
+        "cygwin": "windows",
+    }.get(value.lower(), value.lower())
+
+
+def normalize_arch(value: str) -> str:
+    lowered = value.lower()
+    if lowered in {"x86_64", "amd64", "x64"}:
+        return "amd64"
+    if lowered in {"aarch64", "arm64"}:
+        return "arm64"
+    return lowered
+
+
+def load_candidate(
+    internal_bundle: pathlib.Path,
+    workspace: pathlib.Path,
+    version: str,
+    expected_platform: str,
+    expected_arch: str,
+) -> tuple[pathlib.Path, pathlib.Path, pathlib.Path, dict]:
+    payload = workspace / "payload"
+    extract_tar(internal_bundle, workspace)
+    releases = payload / "media" / "agent-releases" / version
+    extension = ".zip" if expected_platform == "windows" else ".tar.gz"
+    candidate_name = (
+        f"hfl-agent-{version}-{expected_platform}-{expected_arch}{extension}"
+    )
+    candidate = releases / candidate_name
+    if not candidate.is_file():
+        fail(f"candidate package is missing: {candidate}")
+
+    enroll_name = f"hfl-enroll-{expected_platform}-{expected_arch}"
+    if expected_platform == "windows":
+        enroll_name += ".exe"
+    enroll = payload / "media" / "enroll-bootstrap" / enroll_name
+    if not enroll.is_file():
+        fail(f"enrollment binary is missing: {enroll}")
+    if expected_platform != "windows":
+        enroll.chmod(enroll.stat().st_mode | stat.S_IXUSR)
+
+    extracted = workspace / "candidate"
+    extract_archive(candidate, extracted)
+    roots = [path for path in extracted.iterdir() if path.is_dir()]
+    if len(roots) != 1:
+        fail("candidate package must contain exactly one root directory")
+    root = roots[0]
+    manifest_path = root / "MANIFEST.json"
+    if not manifest_path.is_file():
+        fail("candidate package does not contain MANIFEST.json")
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    if manifest.get("platform") != expected_platform:
+        fail(f"manifest platform mismatch: {manifest.get('platform')}")
+    if manifest.get("arch") != expected_arch:
+        fail(f"manifest architecture mismatch: {manifest.get('arch')}")
+    if manifest.get("agent_version") != version:
+        fail(f"manifest version mismatch: {manifest.get('agent_version')}")
+    if manifest.get("bundle_flavor") != "standard":
+        fail("Source Host certification requires the standard package")
+    verify_manifest(root, manifest)
+    return candidate, enroll, root, manifest
+
+
+def verify_manifest(root: pathlib.Path, manifest: dict) -> None:
+    files = manifest.get("files")
+    if not isinstance(files, dict) or not files:
+        fail("manifest files are missing")
+    actual_files: set[str] = set()
+    for path in root.rglob("*"):
+        if not path.is_file() or path.name == "MANIFEST.json":
+            continue
+        relative = path.relative_to(root).as_posix()
+        actual_files.add(relative)
+        expected = str(files.get(relative) or "").removeprefix("sha256:")
+        if not expected:
+            fail(f"manifest does not cover {relative}")
+        if sha256_file(path) != expected:
+            fail(f"checksum mismatch for {relative}")
+    if actual_files != set(files):
+        missing = sorted(set(files) - actual_files)
+        extra = sorted(actual_files - set(files))
+        fail(f"manifest file-set mismatch: missing={missing}, extra={extra}")
+
+
+def run(
+    command: list[str],
+    *,
+    env: dict[str, str] | None = None,
+    cwd: pathlib.Path | None = None,
+    timeout: int = 300,
+) -> subprocess.CompletedProcess[str]:
+    print("+", " ".join(command), flush=True)
+    result = subprocess.run(
+        command,
+        cwd=cwd,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        timeout=timeout,
+        check=False,
+    )
+    if result.stdout:
+        print(result.stdout, end="" if result.stdout.endswith("\n") else "\n")
+    if result.returncode != 0:
+        fail(f"command failed with exit code {result.returncode}: {' '.join(command)}")
+    return result
+
+
+def run_cleanup(command: list[str]) -> bool:
+    try:
+        run(command, timeout=300)
+        return True
+    except Exception as exc:  # noqa: BLE001
+        print(f"cleanup warning: {exc}", file=sys.stderr)
+        return False
+
+
+def create_fixture(root: pathlib.Path) -> None:
+    (root / "nested" / "deep").mkdir(parents=True)
+    (root / "empty-directory").mkdir()
+    (root / "empty.txt").write_bytes(b"")
+    (root / "hello.txt").write_text("HyperFileLens\n", encoding="utf-8")
+    (root / "unicode-\u6587\u4ef6.txt").write_text("backup-\u9a8c\u8bc1\n", encoding="utf-8")
+    (root / "nested" / "deep" / "data.bin").write_bytes(bytes(range(256)) * 4096)
+    if os.name != "nt":
+        os.link(root / "hello.txt", root / "hello-hardlink.txt")
+        os.symlink("hello.txt", root / "hello-symlink.txt")
+
+        (root / "hello.txt").chmod(0o640)
+        (root / "nested" / "deep" / "data.bin").chmod(0o600)
+        (root / "nested" / "deep").chmod(0o750)
+        timestamp_ns = 1_700_000_000_123_456_789
+        for path in sorted(root.rglob("*"), reverse=True):
+            os.utime(path, ns=(timestamp_ns, timestamp_ns), follow_symlinks=False)
+        os.utime(root, ns=(timestamp_ns, timestamp_ns))
+
+
+def tree_evidence(root: pathlib.Path) -> dict[str, dict[str, str | int]]:
+    evidence: dict[str, dict[str, str | int]] = {}
+    for path in sorted(root.rglob("*")):
+        relative = path.relative_to(root).as_posix()
+        metadata: dict[str, str | int] = {}
+        if os.name != "nt":
+            file_stat = path.lstat()
+            metadata = {
+                "mode": format(stat.S_IMODE(file_stat.st_mode), "04o"),
+                # Millisecond precision is portable across Linux and macOS
+                # restore implementations while still detecting metadata loss.
+                "mtime_ms": file_stat.st_mtime_ns // 1_000_000,
+            }
+        if path.is_symlink():
+            evidence[relative] = {
+                "type": "symlink",
+                "target": os.readlink(path),
+                **metadata,
+            }
+        elif path.is_dir():
+            evidence[relative] = {"type": "directory", **metadata}
+        elif path.is_file():
+            evidence[relative] = {
+                "type": "file",
+                "size": path.stat().st_size,
+                "sha256": sha256_file(path),
+                **metadata,
+            }
+    return evidence
+
+
+def certify_backup(
+    root: pathlib.Path,
+    workspace: pathlib.Path,
+    platform_name: str,
+    tests: dict[str, str],
+) -> None:
+    suffix = ".exe" if platform_name == "windows" else ""
+    agent = root / "bin" / f"hfl-agent{suffix}"
+    kopia = root / "bin" / f"kopia{suffix}"
+    if platform_name != "windows":
+        agent.chmod(agent.stat().st_mode | stat.S_IXUSR)
+        kopia.chmod(kopia.stat().st_mode | stat.S_IXUSR)
+    run([str(agent), "-version"])
+    run([str(kopia), "--version"])
+    tests["native_binaries"] = "passed"
+
+    source = workspace / "source"
+    repository = workspace / "repository"
+    restore = workspace / "restore"
+    source.mkdir()
+    repository.mkdir()
+    create_fixture(source)
+    expected = tree_evidence(source)
+
+    home = workspace / "home"
+    home.mkdir()
+    config = workspace / "repository.config"
+    env = os.environ.copy()
+    env.update(
+        {
+            "HOME": str(home),
+            "USERPROFILE": str(home),
+            "KOPIA_PASSWORD": "hfl-release-certification",
+            "KOPIA_CACHE_DIRECTORY": str(workspace / "cache"),
+            "KOPIA_LOG_DIR": str(workspace / "logs"),
+            "KOPIA_CHECK_FOR_UPDATES": "false",
+        }
+    )
+    base = [str(kopia), "--config-file", str(config), "--no-progress"]
+    run(base + ["repository", "create", "filesystem", f"--path={repository}"], env=env)
+    run(base + ["snapshot", "create", str(source), "--json"], env=env)
+    tests["backup"] = "passed"
+    run(base + ["snapshot", "verify", "--verify-files-percent=100"], env=env)
+    tests["verify"] = "passed"
+    run(base + ["snapshot", "restore", str(source), str(restore)], env=env)
+    tests["restore"] = "passed"
+    actual = tree_evidence(restore)
+    if actual != expected:
+        fail(f"restored tree mismatch\nexpected={expected}\nactual={actual}")
+    tests["metadata"] = "passed"
+
+
+class CertificationServer(socketserver.ThreadingMixIn, http.server.HTTPServer):
+    daemon_threads = True
+
+    def __init__(self, address: tuple[str, int], package: pathlib.Path, version: str):
+        self.package = package
+        self.version = version
+        self.heartbeat_count = 0
+        super().__init__(address, CertificationHandler)
+
+
+class CertificationHandler(http.server.BaseHTTPRequestHandler):
+    server: CertificationServer
+
+    def do_GET(self) -> None:  # noqa: N802
+        path = urllib.parse.urlsplit(self.path).path
+        if path == "/api/v1/node/enrollment/agent/release":
+            self.send_json(
+                {
+                    "version": self.server.version,
+                    "download_url": f"http://127.0.0.1:{self.server.server_port}/package",
+                }
+            )
+            return
+        if path == "/package":
+            data = self.server.package.read_bytes()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/octet-stream")
+            self.send_header("Content-Length", str(len(data)))
+            self.end_headers()
+            self.wfile.write(data)
+            return
+        if path in {"/health", "/health/ready"}:
+            self.send_json({"status": "ok"})
+            return
+        self.send_error(404)
+
+    def do_POST(self) -> None:  # noqa: N802
+        path = urllib.parse.urlsplit(self.path).path
+        length = int(self.headers.get("Content-Length", "0"))
+        if length:
+            self.rfile.read(length)
+        if path == "/api/v1/node/nodes/heartbeat/":
+            self.server.heartbeat_count += 1
+            self.send_json({"node_id": 1, "status": "online"})
+            return
+        self.send_error(404)
+
+    def send_json(self, value: dict) -> None:
+        data = json.dumps(value).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+    def log_message(self, format: str, *args: object) -> None:
+        print(f"mock-console: {format % args}", flush=True)
+
+
+@contextlib.contextmanager
+def mock_console(package: pathlib.Path, version: str):
+    server = CertificationServer(("127.0.0.1", 0), package, version)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield server
+    finally:
+        server.shutdown()
+        thread.join(timeout=10)
+        server.server_close()
+
+
+def installed_uninstall_command(platform_name: str) -> list[str]:
+    if platform_name == "windows":
+        script = pathlib.Path(os.environ.get("ProgramFiles", r"C:\Program Files")) / "HyperFileLens" / "Agent" / "install.ps1"
+        return [
+            "powershell.exe",
+            "-NoProfile",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            str(script),
+            "uninstall",
+            "-PurgeAll",
+        ]
+    return ["sudo", "/opt/hyperfilelens-agent/install.sh", "uninstall", "--purge-all"]
+
+
+def certify_enrollment(
+    enroll: pathlib.Path,
+    package: pathlib.Path,
+    version: str,
+    platform_name: str,
+) -> None:
+    with mock_console(package, version) as server:
+        base = f"http://127.0.0.1:{server.server_port}"
+        values = {
+            "HFL_ORG_KEY": "certification-org",
+            "HFL_NODE_ROLE": "agent",
+            "HFL_NODE_TOKEN": "certification-token",
+            "HFL_API_BASE": base,
+            "HFL_WSS_URL": f"ws://127.0.0.1:{server.server_port}/ws/node/agent/",
+            "HFL_INSECURE_TLS": "1",
+            "HFL_ENROLL_NO_COLOR": "1",
+        }
+        env = os.environ.copy()
+        env.update(values)
+        command = [str(enroll), "install", "--yes"]
+        if platform_name != "windows":
+            command = ["sudo", "env"] + [f"{key}={value}" for key, value in values.items()] + command
+        run(command, env=env, timeout=600)
+        if server.heartbeat_count < 1:
+            fail("enrollment helper did not register the Source Host")
+
+
+def os_evidence() -> dict[str, str]:
+    return {
+        "system": platform.system(),
+        "release": platform.release(),
+        "version": platform.version(),
+        "machine": platform.machine(),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--internal-bundle", required=True, type=pathlib.Path)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--commit", required=True)
+    parser.add_argument("--expected-platform", required=True)
+    parser.add_argument("--expected-arch", required=True)
+    parser.add_argument("--report", required=True, type=pathlib.Path)
+    parser.add_argument("--skip-enrollment", action="store_true")
+    args = parser.parse_args()
+
+    expected_platform = normalize_platform(args.expected_platform)
+    expected_arch = normalize_arch(args.expected_arch)
+    actual_platform = normalize_platform(sys.platform.split("-")[0])
+    actual_arch = normalize_arch(platform.machine())
+    if actual_platform != expected_platform:
+        fail(f"native runner mismatch: expected {expected_platform}, got {actual_platform}")
+    if actual_arch != expected_arch:
+        fail(f"native runner architecture mismatch: expected {expected_arch}, got {actual_arch}")
+
+    tests = {
+        "candidate_manifest": "pending",
+        "native_binaries": "pending",
+        "backup": "pending",
+        "verify": "pending",
+        "restore": "pending",
+        "metadata": "pending",
+        "enrollment": "pending",
+        "service_start": "pending",
+        "uninstall": "pending",
+    }
+    candidate_hash = ""
+    candidate_name = ""
+    error = ""
+    try:
+        with tempfile.TemporaryDirectory(prefix="hfl-agent-cert-") as temporary:
+            workspace = pathlib.Path(temporary)
+            candidate, enroll, root, _manifest = load_candidate(
+                args.internal_bundle,
+                workspace,
+                args.version,
+                expected_platform,
+                expected_arch,
+            )
+            candidate_name = candidate.name
+            candidate_hash = sha256_file(candidate)
+            tests["candidate_manifest"] = "passed"
+            certify_backup(root, workspace, expected_platform, tests)
+            if args.skip_enrollment:
+                tests["enrollment"] = "skipped"
+                tests["service_start"] = "skipped"
+                tests["uninstall"] = "skipped"
+            else:
+                try:
+                    certify_enrollment(enroll, candidate, args.version, expected_platform)
+                    tests["enrollment"] = "passed"
+                    tests["service_start"] = "passed"
+                finally:
+                    if run_cleanup(installed_uninstall_command(expected_platform)):
+                        tests["uninstall"] = "passed"
+    except Exception as exc:  # noqa: BLE001
+        error = str(exc)
+        raise
+    finally:
+        report = {
+            "schema": 1,
+            "tag": f"v{args.version}",
+            "version": args.version,
+            "commit": args.commit,
+            "artifact": {"name": candidate_name, "sha256": candidate_hash},
+            "platform": {
+                "os_family": expected_platform,
+                "arch": expected_arch,
+                **os_evidence(),
+            },
+            "consistency": "file-level",
+            "tests": tests,
+            "error": error,
+        }
+        args.report.parent.mkdir(parents=True, exist_ok=True)
+        args.report.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/release/ci/verify-agent-certifications.py
+++ b/release/ci/verify-agent-certifications.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Gate a tagged release on native Source Host certification reports."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import hashlib
+import pathlib
+import sys
+import tarfile
+
+
+REQUIRED_TESTS = {
+    "candidate_manifest",
+    "native_binaries",
+    "backup",
+    "verify",
+    "restore",
+    "metadata",
+    "enrollment",
+    "service_start",
+    "uninstall",
+}
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f"ERROR: {message}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--reports-dir", required=True, type=pathlib.Path)
+    parser.add_argument("--candidates-dir", required=True, type=pathlib.Path)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--commit", required=True)
+    parser.add_argument("--required-target", action="append", default=[])
+    parser.add_argument("--output", required=True, type=pathlib.Path)
+    args = parser.parse_args()
+
+    candidate_hashes: dict[str, str] = {}
+    for bundle in sorted(args.candidates_dir.glob("_internal-agent-*.tar.gz")):
+        with tarfile.open(bundle, "r:gz") as archive:
+            for member in archive.getmembers():
+                if not member.isfile() or "/agent-releases/" not in member.name:
+                    continue
+                name = pathlib.PurePosixPath(member.name).name
+                if not (name.endswith(".tar.gz") or name.endswith(".zip")):
+                    continue
+                stream = archive.extractfile(member)
+                if stream is None:
+                    fail(f"cannot read {member.name} from {bundle.name}")
+                digest = hashlib.sha256()
+                for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+                    digest.update(chunk)
+                actual = digest.hexdigest()
+                if name in candidate_hashes and candidate_hashes[name] != actual:
+                    fail(f"conflicting candidate package bytes for {name}")
+                candidate_hashes[name] = actual
+
+    reports: dict[str, dict] = {}
+    for path in sorted(args.reports_dir.glob("_internal-agent-cert-*.json")):
+        value = json.loads(path.read_text(encoding="utf-8"))
+        platform_info = value.get("platform") or {}
+        target = f"{platform_info.get('os_family')}:{platform_info.get('arch')}"
+        if target in reports:
+            fail(f"duplicate certification report for {target}")
+        if value.get("schema") != 1:
+            fail(f"unsupported report schema in {path.name}")
+        if value.get("version") != args.version or value.get("tag") != f"v{args.version}":
+            fail(f"version mismatch in {path.name}")
+        if value.get("commit") != args.commit:
+            fail(f"commit mismatch in {path.name}")
+        artifact = value.get("artifact") or {}
+        if not artifact.get("name") or len(str(artifact.get("sha256") or "")) != 64:
+            fail(f"invalid artifact evidence in {path.name}")
+        expected_hash = candidate_hashes.get(str(artifact["name"]))
+        if not expected_hash:
+            fail(f"tested artifact is not present in candidate bundles: {artifact['name']}")
+        if artifact["sha256"] != expected_hash:
+            fail(f"tested artifact digest mismatch for {artifact['name']}")
+        tests = value.get("tests") or {}
+        missing = sorted(REQUIRED_TESTS - set(tests))
+        failed = sorted(name for name in REQUIRED_TESTS if tests.get(name) != "passed")
+        if missing or failed:
+            fail(f"certification failed for {target}: missing={missing}, failed={failed}")
+        reports[target] = value
+
+    required = set(args.required_target)
+    missing_targets = sorted(required - set(reports))
+    if missing_targets:
+        fail(f"required certification reports are missing: {', '.join(missing_targets)}")
+
+    summary = {
+        "schema": 1,
+        "tag": f"v{args.version}",
+        "version": args.version,
+        "commit": args.commit,
+        "required_targets": sorted(required),
+        "reports": [reports[target] for target in sorted(reports)],
+        "status": "passed",
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(f"Source Host release gate passed for {len(reports)} native targets")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/agent/internal/enroll/install.go
+++ b/src/agent/internal/enroll/install.go
@@ -85,7 +85,7 @@ func RunInstall(ctx context.Context, opts InstallOptions) error {
 				logFail("Failed to resolve the agent release: "+fetchErr.Error(), 3)
 			}
 		}
-		if err := upgradeAgentPackage(ctx, dl, releaseVer); err != nil {
+		if err := upgradeAgentPackage(ctx, cfg, dl, releaseVer); err != nil {
 			logFail(err.Error(), 3)
 		}
 		if ver, verErr := InstalledAgentVersion(ctx); verErr == nil && ver != "" {
@@ -193,7 +193,9 @@ func installAgentPackage(ctx context.Context, cfg Config, agentVer *string) erro
 	if err != nil {
 		return err
 	}
-	_ = bundleRoot
+	if err := validateAgentPackage(bundleRoot, cfg.NodeRole, releaseVersion); err != nil {
+		return fmt.Errorf("Agent package validation failed: %w", err)
+	}
 
 	logStep("Installing agent binaries and service.")
 	if err := RunBundleInstall(ctx, bundleRoot, cfg); err != nil {
@@ -207,7 +209,7 @@ func installAgentPackage(ctx context.Context, cfg Config, agentVer *string) erro
 	return nil
 }
 
-func upgradeAgentPackage(ctx context.Context, downloadURL, releaseVersion string) error {
+func upgradeAgentPackage(ctx context.Context, cfg Config, downloadURL, releaseVersion string) error {
 	if releaseVersion != "" {
 		logStep(fmt.Sprintf("Downloading agent version %s.", releaseVersion))
 	} else {
@@ -219,6 +221,13 @@ func upgradeAgentPackage(ctx context.Context, downloadURL, releaseVersion string
 		return err
 	}
 	defer cleanup()
+	bundleRoot, err := extractReleaseBundle(ctx, archivePath)
+	if err != nil {
+		return err
+	}
+	if err := validateAgentPackage(bundleRoot, cfg.NodeRole, releaseVersion); err != nil {
+		return fmt.Errorf("Agent package validation failed: %w", err)
+	}
 
 	logStep("Upgrading agent binaries.")
 	if err := RunBundleUpgrade(ctx, archivePath); err != nil {

--- a/src/agent/internal/enroll/package_manifest.go
+++ b/src/agent/internal/enroll/package_manifest.go
@@ -1,0 +1,139 @@
+package enroll
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"hyperfilelens/agent/internal/model"
+)
+
+type agentPackageManifest struct {
+	Schema          int               `json:"schema"`
+	AgentVersion    string            `json:"agent_version"`
+	Platform        string            `json:"platform"`
+	Arch            string            `json:"arch"`
+	BundleFlavor    string            `json:"bundle_flavor"`
+	KopiaBinaryHash string            `json:"kopia_binary_sha256"`
+	Files           map[string]string `json:"files"`
+}
+
+func validateAgentPackage(root string, role model.Role, expectedVersion string) error {
+	return validateAgentPackageFor(root, runtime.GOOS, runtime.GOARCH, role, expectedVersion)
+}
+
+func validateAgentPackageFor(root, platform, arch string, role model.Role, expectedVersion string) error {
+	manifestPath := filepath.Join(root, "MANIFEST.json")
+	raw, err := os.ReadFile(manifestPath)
+	if err != nil {
+		return fmt.Errorf("read package manifest: %w", err)
+	}
+	var manifest agentPackageManifest
+	if err := json.Unmarshal(raw, &manifest); err != nil {
+		return fmt.Errorf("parse package manifest: %w", err)
+	}
+	if manifest.Schema != 1 {
+		return fmt.Errorf("unsupported package manifest schema %d", manifest.Schema)
+	}
+	if manifest.Platform != platform || manifest.Arch != arch {
+		return fmt.Errorf(
+			"package platform mismatch: package is %s/%s, host is %s/%s",
+			manifest.Platform, manifest.Arch, platform, arch,
+		)
+	}
+	if expectedVersion = strings.TrimPrefix(strings.TrimSpace(expectedVersion), "v"); expectedVersion != "" && manifest.AgentVersion != expectedVersion {
+		return fmt.Errorf("package version mismatch: expected %s, got %s", expectedVersion, manifest.AgentVersion)
+	}
+	if role == model.RoleAgent && manifest.BundleFlavor != "standard" {
+		return fmt.Errorf("Source Host requires a standard Agent package, got %q", manifest.BundleFlavor)
+	}
+	if len(manifest.Files) == 0 {
+		return fmt.Errorf("package manifest does not contain file checksums")
+	}
+
+	required := []string{"bin/hfl-agent", "bin/kopia"}
+	if platform == "windows" {
+		required = []string{"bin/hfl-agent.exe", "bin/kopia.exe", "install.ps1", "install.cmd"}
+	} else {
+		required = append(required, "install.sh")
+	}
+	for _, name := range required {
+		if _, ok := manifest.Files[name]; !ok {
+			return fmt.Errorf("package manifest is missing required file %s", name)
+		}
+	}
+
+	seen := map[string]bool{}
+	err = filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		if entry.Type()&os.ModeSymlink != 0 {
+			return fmt.Errorf("package contains unsupported symlink %s", path)
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		rel = filepath.ToSlash(rel)
+		if rel == "MANIFEST.json" {
+			return nil
+		}
+		expected, ok := manifest.Files[rel]
+		if !ok {
+			return fmt.Errorf("package file is not covered by the manifest: %s", rel)
+		}
+		actual, err := fileSHA256(path)
+		if err != nil {
+			return fmt.Errorf("checksum %s: %w", rel, err)
+		}
+		expected = strings.TrimPrefix(strings.ToLower(strings.TrimSpace(expected)), "sha256:")
+		if expected != actual {
+			return fmt.Errorf("package checksum mismatch for %s", rel)
+		}
+		seen[rel] = true
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	for name := range manifest.Files {
+		if !seen[name] {
+			return fmt.Errorf("package manifest references missing file %s", name)
+		}
+	}
+
+	kopiaName := "bin/kopia"
+	if platform == "windows" {
+		kopiaName = "bin/kopia.exe"
+	}
+	manifestKopiaHash := strings.TrimPrefix(strings.ToLower(strings.TrimSpace(manifest.KopiaBinaryHash)), "sha256:")
+	fileKopiaHash := strings.TrimPrefix(strings.ToLower(strings.TrimSpace(manifest.Files[kopiaName])), "sha256:")
+	if manifestKopiaHash == "" || manifestKopiaHash != fileKopiaHash {
+		return fmt.Errorf("Kopia checksum metadata does not match %s", kopiaName)
+	}
+	return nil
+}
+
+func fileSHA256(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	hash := sha256.New()
+	if _, err := io.Copy(hash, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(hash.Sum(nil)), nil
+}

--- a/src/agent/internal/enroll/package_manifest_test.go
+++ b/src/agent/internal/enroll/package_manifest_test.go
@@ -1,0 +1,97 @@
+package enroll
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"hyperfilelens/agent/internal/model"
+)
+
+func TestValidateAgentPackageFor(t *testing.T) {
+	root := writeTestAgentPackage(t, "linux", "amd64", "standard")
+	if err := validateAgentPackageFor(root, "linux", "amd64", model.RoleAgent, "1.2.3"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestValidateAgentPackageRejectsPlatformMismatch(t *testing.T) {
+	root := writeTestAgentPackage(t, "linux", "amd64", "standard")
+	if err := validateAgentPackageFor(root, "darwin", "amd64", model.RoleAgent, "1.2.3"); err == nil {
+		t.Fatal("expected platform mismatch")
+	}
+}
+
+func TestValidateAgentPackageRejectsTampering(t *testing.T) {
+	root := writeTestAgentPackage(t, "linux", "amd64", "standard")
+	if err := os.WriteFile(filepath.Join(root, "bin", "kopia"), []byte("tampered"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateAgentPackageFor(root, "linux", "amd64", model.RoleAgent, "1.2.3"); err == nil {
+		t.Fatal("expected checksum failure")
+	}
+}
+
+func TestValidateAgentPackageForWindows(t *testing.T) {
+	root := writeTestAgentPackage(t, "windows", "amd64", "standard")
+	if err := validateAgentPackageFor(root, "windows", "amd64", model.RoleAgent, "v1.2.3"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestValidateAgentPackageRejectsNonStandardSourceHost(t *testing.T) {
+	root := writeTestAgentPackage(t, "linux", "amd64", "ubuntu2404")
+	if err := validateAgentPackageFor(root, "linux", "amd64", model.RoleAgent, "1.2.3"); err == nil {
+		t.Fatal("expected non-standard Source Host package to be rejected")
+	}
+}
+
+func writeTestAgentPackage(t *testing.T, platform, arch, flavor string) string {
+	t.Helper()
+	root := t.TempDir()
+	files := map[string][]byte{}
+	kopiaName := "bin/kopia"
+	if platform == "windows" {
+		files["bin/hfl-agent.exe"] = []byte("agent")
+		files["bin/kopia.exe"] = []byte("kopia")
+		files["install.ps1"] = []byte("# installer\n")
+		files["install.cmd"] = []byte("@echo off\r\n")
+		kopiaName = "bin/kopia.exe"
+	} else {
+		files["bin/hfl-agent"] = []byte("agent")
+		files[kopiaName] = []byte("kopia")
+		files["install.sh"] = []byte("#!/bin/sh\n")
+	}
+	checksums := map[string]string{}
+	for name, data := range files {
+		path := filepath.Join(root, filepath.FromSlash(name))
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, data, 0o700); err != nil {
+			t.Fatal(err)
+		}
+		sum := sha256.Sum256(data)
+		checksums[name] = "sha256:" + hex.EncodeToString(sum[:])
+	}
+	manifest := agentPackageManifest{
+		Schema:          1,
+		AgentVersion:    "1.2.3",
+		Platform:        platform,
+		Arch:            arch,
+		BundleFlavor:    flavor,
+		KopiaBinaryHash: checksums[kopiaName],
+		Files:           checksums,
+	}
+	raw, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "MANIFEST.json"), raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return root
+}

--- a/src/agent/internal/enroll/preflight.go
+++ b/src/agent/internal/enroll/preflight.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"hyperfilelens/agent/internal/model"
+	"hyperfilelens/agent/internal/platform/hostinfo"
 )
 
 // EnvironmentReport is the result of pre-install environment checks.
@@ -28,7 +29,7 @@ type EnvironmentReport struct {
 func RunEnvironmentChecks(ctx context.Context, cfg Config) (*EnvironmentReport, error) {
 	report := &EnvironmentReport{
 		Platform: platformDescription(),
-		ArchOK:   runtime.GOARCH == "amd64" || runtime.GOARCH == "arm64",
+		ArchOK:   supportedRuntimeArch(),
 		Existing: DetectInstallState(),
 	}
 
@@ -38,13 +39,16 @@ func RunEnvironmentChecks(ctx context.Context, cfg Config) (*EnvironmentReport, 
 		report.PrivilegesOK = true
 	}
 
-	report.ServiceMgr = detectServiceManager()
+	report.ServiceMgr = detectServiceManager(ctx)
 	consoleReach := checkConsoleReachable(ctx, cfg.APIBase)
 	wssReach := checkWSSReachable(ctx, resolveWSSURL(cfg))
 	hostname := checkHostname()
 	clock := checkClockSync(ctx, cfg.APIBase)
 
 	if err := roleConstraints(cfg.NodeRole); err != nil {
+		report.RoleOK = false
+		report.RoleError = err.Error()
+	} else if err := serviceManagerConstraint(report.ServiceMgr); err != nil {
 		report.RoleOK = false
 		report.RoleError = err.Error()
 	} else {
@@ -62,7 +66,7 @@ func RunEnvironmentChecks(ctx context.Context, cfg Config) (*EnvironmentReport, 
 	if report.ArchOK {
 		logOKDetail("CPU architecture is supported", runtime.GOARCH)
 	} else {
-		logFailDetail("CPU architecture is not supported", runtime.GOARCH+" (only amd64/arm64)", 4)
+		logFailDetail("CPU architecture is not supported", runtime.GOARCH+" ("+supportedArchDescription()+")", 4)
 	}
 
 	if report.RoleOK {
@@ -147,12 +151,31 @@ func Preflight(role model.Role) error {
 	if err := requireAdmin(); err != nil {
 		return err
 	}
-	switch runtime.GOARCH {
-	case "amd64", "arm64":
-	default:
-		return fmt.Errorf("unsupported arch %s (only amd64/arm64)", runtime.GOARCH)
+	if !supportedRuntimeArch() {
+		return fmt.Errorf("unsupported arch %s (%s)", runtime.GOARCH, supportedArchDescription())
 	}
-	return roleConstraints(role)
+	if err := roleConstraints(role); err != nil {
+		return err
+	}
+	return serviceManagerConstraint(detectServiceManager(context.Background()))
+}
+
+func supportedRuntimeArch() bool {
+	switch runtime.GOOS {
+	case "linux", "darwin":
+		return runtime.GOARCH == "amd64" || runtime.GOARCH == "arm64"
+	case "windows":
+		return runtime.GOARCH == "amd64"
+	default:
+		return false
+	}
+}
+
+func supportedArchDescription() string {
+	if runtime.GOOS == "windows" {
+		return "only amd64"
+	}
+	return "only amd64/arm64"
 }
 
 func roleConstraints(role model.Role) error {
@@ -167,23 +190,28 @@ func roleConstraints(role model.Role) error {
 	return nil
 }
 
-func detectServiceManager() string {
+func detectServiceManager(ctx context.Context) string {
+	return hostinfo.DetectServiceManager(ctx)
+}
+
+func serviceManagerConstraint(manager string) error {
 	switch runtime.GOOS {
 	case "linux":
-		if _, err := exec.LookPath("systemctl"); err == nil {
-			return "systemd"
+		if manager != "systemd" {
+			return fmt.Errorf("this release requires a systemd-based Linux distribution; OpenRC, non-systemd, and container deployments are not supported")
 		}
-		return "none"
 	case "darwin":
-		if _, err := exec.LookPath("launchctl"); err == nil {
-			return "launchd"
+		if manager != "launchd" {
+			return fmt.Errorf("launchd is required to install the agent service on macOS")
 		}
-		return "none"
 	case "windows":
-		return "windows-service"
+		if manager != "windows-service" {
+			return fmt.Errorf("Windows Service Manager is required to install the agent service")
+		}
 	default:
-		return "unknown"
+		return fmt.Errorf("operating system %s is not supported", runtime.GOOS)
 	}
+	return nil
 }
 
 func requireAdmin() error {

--- a/src/agent/internal/enroll/preflight_cmds.go
+++ b/src/agent/internal/enroll/preflight_cmds.go
@@ -26,11 +26,17 @@ func missingRequiredCommands() []string {
 }
 
 func requiredCommands() []string {
-	switch runtime.GOOS {
+	return requiredCommandsFor(runtime.GOOS)
+}
+
+func requiredCommandsFor(goos string) []string {
+	switch goos {
 	case "windows":
-		return []string{"curl.exe"}
+		// Enrollment and release downloads use the Go HTTP client. The Windows
+		// bootstrap can also fall back to PowerShell when curl.exe is absent.
+		return nil
 	default:
-		return []string{"curl", "tar"}
+		return []string{"bash", "curl", "tar"}
 	}
 }
 

--- a/src/agent/internal/enroll/preflight_os.go
+++ b/src/agent/internal/enroll/preflight_os.go
@@ -1,63 +1,16 @@
 package enroll
 
 import (
-	"bufio"
+	"context"
 	"fmt"
-	"os"
-	"runtime"
-	"strings"
+
+	"hyperfilelens/agent/internal/platform/hostinfo"
 )
 
 func platformDescription() string {
-	detail := osPrettyName()
-	if detail == "" {
-		return fmt.Sprintf("%s/%s", runtime.GOOS, runtimeArch())
+	info := hostinfo.Collect(context.Background())
+	if description := info.Description(); description != "" {
+		return description
 	}
-	return fmt.Sprintf("%s/%s (%s)", runtime.GOOS, runtimeArch(), detail)
-}
-
-func osPrettyName() string {
-	switch runtime.GOOS {
-	case "linux", "darwin":
-		return readOSReleasePrettyName()
-	case "windows":
-		return readWindowsCaption()
-	default:
-		return ""
-	}
-}
-
-func readOSReleasePrettyName() string {
-	f, err := os.Open("/etc/os-release")
-	if err != nil {
-		return ""
-	}
-	defer f.Close()
-
-	pretty := ""
-	name := ""
-	versionID := ""
-	sc := bufio.NewScanner(f)
-	for sc.Scan() {
-		line := sc.Text()
-		switch {
-		case strings.HasPrefix(line, "PRETTY_NAME="):
-			pretty = strings.Trim(strings.TrimPrefix(line, "PRETTY_NAME="), `"`)
-		case strings.HasPrefix(line, "NAME="):
-			name = strings.Trim(strings.TrimPrefix(line, "NAME="), `"`)
-		case strings.HasPrefix(line, "VERSION_ID="):
-			versionID = strings.Trim(strings.TrimPrefix(line, "VERSION_ID="), `"`)
-		}
-	}
-	if pretty != "" {
-		return pretty
-	}
-	if name != "" && versionID != "" {
-		return name + " " + versionID
-	}
-	return name
-}
-
-func readWindowsCaption() string {
-	return "Windows"
+	return fmt.Sprintf("%s/%s", info.OSFamily, info.Arch)
 }

--- a/src/agent/internal/enroll/preflight_test.go
+++ b/src/agent/internal/enroll/preflight_test.go
@@ -1,6 +1,7 @@
 package enroll
 
 import (
+	"runtime"
 	"testing"
 
 	"hyperfilelens/agent/internal/model"
@@ -9,6 +10,45 @@ import (
 func TestIsUbuntuMinSkipsNonLinux(t *testing.T) {
 	if isUbuntuMin(20, 4) && testing.Short() {
 		t.Skip("environment-specific")
+	}
+}
+
+func TestServiceManagerConstraint(t *testing.T) {
+	switch runtime.GOOS {
+	case "linux":
+		if err := serviceManagerConstraint("systemd"); err != nil {
+			t.Fatal(err)
+		}
+		if err := serviceManagerConstraint("none"); err == nil {
+			t.Fatal("expected non-systemd Linux to be rejected")
+		}
+	case "darwin":
+		if err := serviceManagerConstraint("launchd"); err != nil {
+			t.Fatal(err)
+		}
+	case "windows":
+		if err := serviceManagerConstraint("windows-service"); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func TestRequiredCommandsForWindows(t *testing.T) {
+	if commands := requiredCommandsFor("windows"); len(commands) != 0 {
+		t.Fatalf("Windows required commands=%v, want none", commands)
+	}
+	commands := requiredCommandsFor("linux")
+	for _, required := range []string{"bash", "curl", "tar"} {
+		found := false
+		for _, command := range commands {
+			if command == required {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("Linux required commands=%v, missing %q", commands, required)
+		}
 	}
 }
 

--- a/src/agent/internal/platform/hostinfo/hostinfo.go
+++ b/src/agent/internal/platform/hostinfo/hostinfo.go
@@ -1,0 +1,188 @@
+// Package hostinfo collects normalized operating-system facts for enrollment
+// preflight checks, node registration, and recurring inventory heartbeats.
+package hostinfo
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+
+	goshost "github.com/shirou/gopsutil/v4/host"
+)
+
+// Info describes the operating system that is actually running the Agent.
+type Info struct {
+	OSFamily       string `json:"os_family"`
+	OSName         string `json:"os_name"`
+	OSVersion      string `json:"os_version"`
+	OSBuild        string `json:"os_build,omitempty"`
+	OSEdition      string `json:"os_edition,omitempty"`
+	KernelVersion  string `json:"kernel_version,omitempty"`
+	Arch           string `json:"arch"`
+	ServiceManager string `json:"service_manager"`
+}
+
+// Collect returns best-effort platform facts without making support-policy
+// decisions. Missing optional values do not prevent enrollment.
+func Collect(ctx context.Context) Info {
+	info := Info{
+		OSFamily:       runtime.GOOS,
+		OSName:         runtime.GOOS,
+		Arch:           runtime.GOARCH,
+		ServiceManager: DetectServiceManager(ctx),
+	}
+
+	if system, err := goshost.InfoWithContext(ctx); err == nil {
+		info.OSName = firstNonEmpty(system.Platform, system.OS, info.OSName)
+		info.OSVersion = strings.TrimSpace(system.PlatformVersion)
+		info.KernelVersion = strings.TrimSpace(system.KernelVersion)
+	}
+
+	switch runtime.GOOS {
+	case "linux":
+		applyLinuxOSRelease(&info, "/etc/os-release")
+	case "darwin":
+		applyMacOSVersion(ctx, &info)
+	case "windows":
+		applyWindowsVersion(&info)
+	}
+
+	return info
+}
+
+// Description returns a concise human-readable platform value for installer
+// and enrollment logs.
+func (i Info) Description() string {
+	name := strings.TrimSpace(i.OSName)
+	version := strings.TrimSpace(i.OSVersion)
+	if name == "" {
+		name = i.OSFamily
+	}
+	detail := name
+	if version != "" && !strings.Contains(strings.ToLower(name), strings.ToLower(version)) {
+		detail = strings.TrimSpace(name + " " + version)
+	}
+	if detail == "" || strings.EqualFold(detail, i.OSFamily) {
+		return fmt.Sprintf("%s/%s", i.OSFamily, i.Arch)
+	}
+	return fmt.Sprintf("%s/%s (%s)", i.OSFamily, i.Arch, detail)
+}
+
+// Inventory returns stable keys for registration and heartbeat payloads.
+func (i Info) Inventory() map[string]any {
+	return map[string]any{
+		"os":              i.OSFamily,
+		"os_family":       i.OSFamily,
+		"os_name":         i.OSName,
+		"os_version":      i.OSVersion,
+		"os_build":        i.OSBuild,
+		"os_edition":      i.OSEdition,
+		"kernel_version":  i.KernelVersion,
+		"arch":            i.Arch,
+		"service_manager": i.ServiceManager,
+	}
+}
+
+// DetectServiceManager reports the native service manager available to the
+// installer. Linux is intentionally systemd-only for the P0 Source Host.
+func DetectServiceManager(ctx context.Context) string {
+	switch runtime.GOOS {
+	case "linux":
+		if SystemdAvailable(ctx) {
+			return "systemd"
+		}
+		return "none"
+	case "darwin":
+		if _, err := exec.LookPath("launchctl"); err == nil {
+			return "launchd"
+		}
+		return "none"
+	case "windows":
+		return "windows-service"
+	default:
+		return "unknown"
+	}
+}
+
+// SystemdAvailable verifies both the systemd runtime directory and a working
+// connection to the service manager. A systemctl binary alone is insufficient
+// in containers and chroots.
+func SystemdAvailable(ctx context.Context) bool {
+	if runtime.GOOS != "linux" {
+		return false
+	}
+	if _, err := exec.LookPath("systemctl"); err != nil {
+		return false
+	}
+	if info, err := os.Stat("/run/systemd/system"); err != nil || !info.IsDir() {
+		return false
+	}
+	cmd := exec.CommandContext(ctx, "systemctl", "show-environment")
+	return cmd.Run() == nil
+}
+
+func applyLinuxOSRelease(info *Info, path string) {
+	f, err := os.Open(path)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+
+	values := map[string]string{}
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		key, value, ok := strings.Cut(scanner.Text(), "=")
+		if !ok {
+			continue
+		}
+		values[strings.TrimSpace(key)] = strings.Trim(strings.TrimSpace(value), `"'`)
+	}
+	info.OSName = firstNonEmpty(values["PRETTY_NAME"], values["NAME"], info.OSName)
+	info.OSVersion = firstNonEmpty(values["VERSION_ID"], info.OSVersion)
+}
+
+func applyMacOSVersion(ctx context.Context, info *Info) {
+	for key, target := range map[string]*string{
+		"-productName":    &info.OSName,
+		"-productVersion": &info.OSVersion,
+		"-buildVersion":   &info.OSBuild,
+	} {
+		out, err := exec.CommandContext(ctx, "sw_vers", key).Output()
+		if err == nil && strings.TrimSpace(string(out)) != "" {
+			*target = strings.TrimSpace(string(out))
+		}
+	}
+}
+
+func applyWindowsVersion(info *Info) {
+	// gopsutil uses Windows version APIs and WMI internally. Keep the raw
+	// platform version as the canonical version/build evidence without invoking
+	// PowerShell, which is important on Server Core and older Server releases.
+	if info.OSName == "windows" {
+		info.OSName = "Windows"
+	}
+	if info.OSBuild == "" {
+		info.OSBuild = lastNumericComponent(info.KernelVersion)
+	}
+}
+
+func lastNumericComponent(value string) string {
+	parts := strings.FieldsFunc(value, func(r rune) bool { return r < '0' || r > '9' })
+	if len(parts) == 0 {
+		return ""
+	}
+	return parts[len(parts)-1]
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value = strings.TrimSpace(value); value != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/src/agent/internal/platform/hostinfo/hostinfo_test.go
+++ b/src/agent/internal/platform/hostinfo/hostinfo_test.go
@@ -1,0 +1,33 @@
+package hostinfo
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestApplyLinuxOSRelease(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "os-release")
+	content := "ID=ubuntu\nNAME=Ubuntu\nPRETTY_NAME=\"Ubuntu 24.04.2 LTS\"\nVERSION_ID=\"24.04\"\n"
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	info := Info{OSName: "linux"}
+	applyLinuxOSRelease(&info, path)
+	if info.OSName != "Ubuntu 24.04.2 LTS" || info.OSVersion != "24.04" {
+		t.Fatalf("unexpected info: %+v", info)
+	}
+}
+
+func TestDescription(t *testing.T) {
+	info := Info{OSFamily: "linux", OSName: "Ubuntu", OSVersion: "24.04", Arch: "arm64"}
+	if got, want := info.Description(), "linux/arm64 (Ubuntu 24.04)"; got != want {
+		t.Fatalf("Description()=%q want %q", got, want)
+	}
+}
+
+func TestLastNumericComponent(t *testing.T) {
+	if got := lastNumericComponent("10.0.20348 Build 20348"); got != "20348" {
+		t.Fatalf("got %q", got)
+	}
+}

--- a/src/agent/internal/remote/inventory.go
+++ b/src/agent/internal/remote/inventory.go
@@ -13,6 +13,7 @@ import (
 
 	"hyperfilelens/agent/internal/infra/config"
 	agentdisk "hyperfilelens/agent/internal/platform/disk"
+	"hyperfilelens/agent/internal/platform/hostinfo"
 	"hyperfilelens/agent/internal/platform/install"
 	"hyperfilelens/agent/internal/platform/kopia"
 	"hyperfilelens/agent/internal/platform/netmac"
@@ -27,11 +28,13 @@ func SendInventory(ctx context.Context, sink wire.Sender, provider config.Provid
 		return nil
 	}
 	cfg := provider.Current()
+	platform := hostinfo.Collect(ctx)
 	dataDir := cfg.DataDir
 	if dataDir == "" {
 		dataDir = vfs.DefaultAgentDataDir()
 	}
-	payload := map[string]any{
+	payload := platform.Inventory()
+	for key, value := range map[string]any{
 		"agent_version": selfupdate.Version,
 		"agent_commit":  selfupdate.Commit,
 		"role":          string(cfg.Role),
@@ -42,6 +45,8 @@ func SendInventory(ctx context.Context, sink wire.Sender, provider config.Provid
 		"root_path":     dataDir,
 		"install_path":  install.DefaultInstallDir(),
 		"capabilities":  []string{"repository_operation_v1", "repository_cleanup_v1"},
+	} {
+		payload[key] = value
 	}
 	if mac := netmac.PrimaryMAC(); mac != "" {
 		payload["mac_address"] = mac

--- a/src/agent/internal/remote/register.go
+++ b/src/agent/internal/remote/register.go
@@ -8,13 +8,13 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"runtime"
 	"strconv"
 	"strings"
 	"time"
 
 	"hyperfilelens/agent/internal/infra/config"
 	"hyperfilelens/agent/internal/model"
+	"hyperfilelens/agent/internal/platform/hostinfo"
 	"hyperfilelens/agent/internal/platform/tlsclient"
 	"hyperfilelens/agent/internal/selfupdate"
 )
@@ -70,23 +70,22 @@ func httpRegisterNode(
 	base, org, token, agentVersion string,
 ) (string, error) {
 	hostname, _ := os.Hostname()
+	platform := hostinfo.Collect(ctx)
+	inventory := platform.Inventory()
+	inventory["hostname"] = hostname
+	inventory["agent_version"] = agentVersion
 	body := map[string]any{
 		"name":    hostname,
 		"role":    string(cfg.Role),
 		"version": agentVersion,
-		"os_name": runtime.GOOS + " " + runtime.GOARCH,
+		"os_name": platform.Description(),
 		"metadata": map[string]any{
-			"hostname": hostname,
-			"inventory": map[string]any{
-				"hostname":      hostname,
-				"agent_version": agentVersion,
-				"platform":      runtime.GOOS,
-				"arch":          runtime.GOARCH,
-			},
+			"hostname":      hostname,
+			"inventory":     inventory,
 			"install":       "hfl-enroll",
 			"agent_version": agentVersion,
-			"platform":      runtime.GOOS,
-			"arch":          runtime.GOARCH,
+			"platform":      platform.OSFamily,
+			"arch":          platform.Arch,
 		},
 	}
 	if id := strings.TrimSpace(cfg.NodeID); id != "" {

--- a/src/agent/internal/remote/register_test.go
+++ b/src/agent/internal/remote/register_test.go
@@ -1,0 +1,67 @@
+package remote
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"hyperfilelens/agent/internal/model"
+)
+
+func TestHTTPRegisterNodeIncludesPlatformInventory(t *testing.T) {
+	var payload map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/node/nodes/heartbeat/" {
+			t.Errorf("unexpected request path %q", r.URL.Path)
+		}
+		if got := r.Header.Get("X-Org-Key"); got != "test-org" {
+			t.Errorf("X-Org-Key=%q", got)
+		}
+		if got := r.Header.Get("X-Node-Token"); got != "test-token" {
+			t.Errorf("X-Node-Token=%q", got)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"node_id":42}`))
+	}))
+	defer server.Close()
+
+	cfg := &model.AgentConfig{
+		APIBaseURL: server.URL,
+		OrgKey:     "test-org",
+		NodeToken:  "test-token",
+		Role:       model.RoleAgent,
+	}
+	nodeID, err := httpRegisterNode(
+		context.Background(), cfg, server.URL, cfg.OrgKey, cfg.NodeToken, "1.2.3",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if nodeID != "42" {
+		t.Fatalf("nodeID=%q", nodeID)
+	}
+
+	metadata, ok := payload["metadata"].(map[string]any)
+	if !ok {
+		t.Fatalf("metadata=%T", payload["metadata"])
+	}
+	inventory, ok := metadata["inventory"].(map[string]any)
+	if !ok {
+		t.Fatalf("inventory=%T", metadata["inventory"])
+	}
+	for _, key := range []string{
+		"os_family", "os_name", "os_version", "kernel_version", "arch", "service_manager",
+	} {
+		if _, exists := inventory[key]; !exists {
+			t.Errorf("inventory is missing %q", key)
+		}
+	}
+	if got := inventory["agent_version"]; got != "1.2.3" {
+		t.Errorf("agent_version=%v", got)
+	}
+}

--- a/src/agent/packaging/install/install.ps1
+++ b/src/agent/packaging/install/install.ps1
@@ -301,6 +301,21 @@ function Get-HflServiceStatusLine {
   return "$($svc.Status.ToString().ToLower()) ($startType)"
 }
 
+function Get-HflSupportedArchitecture {
+  $nativeArch = if ($env:PROCESSOR_ARCHITEW6432) {
+    $env:PROCESSOR_ARCHITEW6432
+  }
+  else {
+    $env:PROCESSOR_ARCHITECTURE
+  }
+  switch ($nativeArch) {
+    "AMD64" { return "amd64" }
+    "ARM64" { throw "Windows ARM64 is not supported by this release." }
+    "x86" { throw "32-bit Windows is not supported by this release." }
+    default { throw "Unsupported Windows architecture: $nativeArch" }
+  }
+}
+
 function Read-HflEnvValue {
   param(
     [Parameter(Mandatory = $true)][string]$EnvFile,
@@ -953,11 +968,10 @@ function Invoke-Install {
   if (Test-Installed) {
     throw "Agent already installed. Use: install.cmd upgrade -From <package.zip>"
   }
+  $archRel = Get-HflSupportedArchitecture
   $dataRoot = if ($DataDir) { $DataDir } else { $DefaultDataRoot }
   Start-HflInstallLog -DataRoot $dataRoot
   try {
-    $archRel = if ($env:PROCESSOR_ARCHITECTURE -eq "ARM64") { "arm64" } else { "amd64" }
-
     if (-not $QuietFooter) {
       Write-HflBanner "install v$(Get-BundleVersion)"
       Write-HflSection "Preflight"
@@ -1023,6 +1037,7 @@ function Invoke-Upgrade {
     throw "upgrade requires -From <directory-or.zip>"
   }
 
+  $null = Get-HflSupportedArchitecture
   $dataRoot = Get-ResolvedDataRoot -Override $DataDir
   $envFile = Join-Path $dataRoot "agent.env"
   $workspace = Get-UpgradeWorkspace -DataRoot $dataRoot

--- a/src/agent/packaging/install/install.sh
+++ b/src/agent/packaging/install/install.sh
@@ -202,6 +202,19 @@ agent_manages_service() {
 	agent_uses_systemd || agent_uses_launchd
 }
 
+require_service_manager() {
+	if is_darwin; then
+		command -v launchctl >/dev/null 2>&1 \
+			|| log_fail "launchd is required to install the agent service on macOS." 2
+		return 0
+	fi
+	if ! command -v systemctl >/dev/null 2>&1 \
+		|| [[ ! -d /run/systemd/system ]] \
+		|| ! hfl_systemctl show-environment >/dev/null 2>&1; then
+		log_fail "This release requires a systemd-based Linux distribution. OpenRC, non-systemd, and container deployments are not supported." 2
+	fi
+}
+
 service_display_name() {
 	if agent_uses_launchd; then
 		echo "${LAUNCHD_LABEL}"
@@ -1116,6 +1129,7 @@ start_service_only() {
 cmd_install() {
 	parse_install_flags "$@"
 	require_root
+	require_service_manager
 	verify_bundle
 
 	if is_installed; then
@@ -1183,6 +1197,7 @@ cmd_install() {
 cmd_upgrade() {
 	parse_upgrade_flags "$@"
 	require_root
+	require_service_manager
 
 	[[ -n "${UPGRADE_FROM}" ]] || log_fail "Upgrade requires --from <directory-or.tar.gz>." 2
 

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -226,6 +226,7 @@ fi
 grep -F 'tags:' "${workflow}" >/dev/null
 for job in \
 	prepare quality build-hfl-images build-sourcelens-images build-agent \
+	certify-source-host agent-release-gate \
 	build-host-debs export-hfl-images export-sourcelens-bundle \
 	export-runtime-images assemble-release verify-release publish-release \
 	deploy-preprod deploy-prod; do
@@ -248,6 +249,16 @@ grep -F 'uv run --isolated --no-project --python 3.8 python tools/quality/check-
 	"${workflow}" >/dev/null
 grep -F 'npm run test:ci' "${workflow}" >/dev/null
 grep -F './tools/quality/test-ci-release-assembly.sh' "${workflow}" >/dev/null
+grep -F 'python3 -m unittest tools/quality/test_agent_certification_gate.py' "${workflow}" >/dev/null
+grep -F 'release/ci/certify-agent-candidate.py' "${workflow}" >/dev/null
+grep -F 'release/ci/verify-agent-certifications.py' "${workflow}" >/dev/null
+grep -F 'runner: ubuntu-24.04-arm' "${workflow}" >/dev/null
+grep -F 'runner: macos-15-intel' "${workflow}" >/dev/null
+grep -F 'runner: macos-15' "${workflow}" >/dev/null
+grep -F 'runner: windows-2022' "${workflow}" >/dev/null
+grep -F -- '--required-target linux:arm64' "${workflow}" >/dev/null
+grep -F -- '--required-target darwin:arm64' "${workflow}" >/dev/null
+grep -F -- '--required-target windows:amd64' "${workflow}" >/dev/null
 if grep -F 'uv run pytest src/backend' "${workflow}" >/dev/null; then
 	printf 'ERROR: backend CI must initialize Django through manage.py\n' >&2
 	exit 1
@@ -288,6 +299,19 @@ agent_publisher="${ROOT}/tools/agent/publish.sh"
 grep -F 'all | standard | ubuntu2004 | ubuntu2404' "${agent_publisher}" >/dev/null
 grep -F 'for ubuntu_flavor in ubuntu2004 ubuntu2404' "${agent_publisher}" >/dev/null
 grep -F 'build/dependencies/docker/ubuntu-${ubuntu_release}/amd64' "${agent_publisher}" >/dev/null
+
+agent_bootstrap_linux="${ROOT}/deploy/bootstrap/agent-bootstrap-linux.sh"
+agent_bootstrap_macos="${ROOT}/deploy/bootstrap/agent-bootstrap-macos.sh"
+agent_bootstrap_windows="${ROOT}/deploy/bootstrap/agent-bootstrap-windows.ps1"
+grep -F 'requires a systemd-based Linux distribution' "${agent_bootstrap_linux}" >/dev/null
+grep -F 'systemctl show-environment' "${agent_bootstrap_linux}" >/dev/null
+grep -F 'launchd is required to install the agent service on macOS' "${agent_bootstrap_macos}" >/dev/null
+grep -F 'Windows ARM64 is not supported by this release' "${agent_bootstrap_windows}" >/dev/null
+if grep -F 'hfl-enroll-windows-$archRel.exe' "${agent_bootstrap_windows}" >/dev/null \
+	&& ! grep -F '"ARM64" {' "${agent_bootstrap_windows}" >/dev/null; then
+	printf 'ERROR: Windows bootstrap may request an unsupported ARM64 enrollment binary\n' >&2
+	exit 1
+fi
 
 remote_deploy="${ROOT}/.github/scripts/remote-deploy.sh"
 [[ -x "${remote_deploy}" ]] || {

--- a/tools/quality/test_agent_certification_gate.py
+++ b/tools/quality/test_agent_certification_gate.py
@@ -1,0 +1,146 @@
+"""Tests for the tagged Agent native-certification release gate."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import pathlib
+import subprocess
+import sys
+import tarfile
+import tempfile
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+GATE = ROOT / "release" / "ci" / "verify-agent-certifications.py"
+
+
+class AgentCertificationGateTests(unittest.TestCase):
+    def test_accepts_report_bound_to_candidate_bytes(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = pathlib.Path(temporary)
+            candidates = root / "candidates"
+            reports = root / "reports"
+            candidates.mkdir()
+            reports.mkdir()
+            package_name, package_hash = self._write_candidate(candidates)
+            self._write_report(reports, package_name, package_hash)
+            output = root / "summary.json"
+
+            result = self._run_gate(candidates, reports, output)
+            self.assertEqual(result.returncode, 0, result.stdout)
+            summary = json.loads(output.read_text(encoding="utf-8"))
+            self.assertEqual(summary["status"], "passed")
+
+    def test_rejects_report_for_different_candidate_bytes(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = pathlib.Path(temporary)
+            candidates = root / "candidates"
+            reports = root / "reports"
+            candidates.mkdir()
+            reports.mkdir()
+            package_name, _package_hash = self._write_candidate(candidates)
+            self._write_report(reports, package_name, "0" * 64)
+
+            result = self._run_gate(candidates, reports, root / "summary.json")
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("digest mismatch", result.stdout)
+
+    def test_rejects_skipped_native_certification_step(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = pathlib.Path(temporary)
+            candidates = root / "candidates"
+            reports = root / "reports"
+            candidates.mkdir()
+            reports.mkdir()
+            package_name, package_hash = self._write_candidate(candidates)
+            self._write_report(reports, package_name, package_hash)
+            report_path = reports / "_internal-agent-cert-linux-amd64.json"
+            report = json.loads(report_path.read_text(encoding="utf-8"))
+            report["tests"]["enrollment"] = "skipped"
+            report_path.write_text(json.dumps(report), encoding="utf-8")
+
+            result = self._run_gate(candidates, reports, root / "summary.json")
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("enrollment", result.stdout)
+
+    def _write_candidate(self, destination: pathlib.Path) -> tuple[str, str]:
+        package_name = "hfl-agent-1.2.3-linux-amd64.tar.gz"
+        package_data = b"immutable-agent-package"
+        package_hash = hashlib.sha256(package_data).hexdigest()
+        bundle = destination / "_internal-agent-linux-amd64.tar.gz"
+        with tempfile.TemporaryDirectory() as staging_value:
+            staging = pathlib.Path(staging_value)
+            package = (
+                staging
+                / "payload"
+                / "media"
+                / "agent-releases"
+                / "1.2.3"
+                / package_name
+            )
+            package.parent.mkdir(parents=True)
+            package.write_bytes(package_data)
+            with tarfile.open(bundle, "w:gz") as archive:
+                archive.add(staging / "payload", arcname="payload")
+        return package_name, package_hash
+
+    def _write_report(
+        self, destination: pathlib.Path, package_name: str, package_hash: str
+    ) -> None:
+        tests = {
+            name: "passed"
+            for name in (
+                "candidate_manifest",
+                "native_binaries",
+                "backup",
+                "verify",
+                "restore",
+                "metadata",
+                "enrollment",
+                "service_start",
+                "uninstall",
+            )
+        }
+        report = {
+            "schema": 1,
+            "tag": "v1.2.3",
+            "version": "1.2.3",
+            "commit": "a" * 40,
+            "artifact": {"name": package_name, "sha256": package_hash},
+            "platform": {"os_family": "linux", "arch": "amd64"},
+            "tests": tests,
+        }
+        path = destination / "_internal-agent-cert-linux-amd64.json"
+        path.write_text(json.dumps(report), encoding="utf-8")
+
+    def _run_gate(
+        self, candidates: pathlib.Path, reports: pathlib.Path, output: pathlib.Path
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [
+                sys.executable,
+                str(GATE),
+                "--candidates-dir",
+                str(candidates),
+                "--reports-dir",
+                str(reports),
+                "--version",
+                "1.2.3",
+                "--commit",
+                "a" * 40,
+                "--required-target",
+                "linux:amd64",
+                "--output",
+                str(output),
+            ],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            check=False,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- enforce the P0 Source Host OS, architecture, and native service-manager contract
- validate immutable Agent package manifests and checksums before install or upgrade
- add tag-only native certification for Linux amd64/arm64, macOS amd64/arm64, and Windows amd64
- gate release assembly, image builds, and publishing on backup, verification, restore, metadata, enrollment, service, and uninstall evidence

## Validation

- full Agent Go test suite
- cross-platform Go builds for Linux arm64, macOS amd64/arm64, and Windows amd64
- five-platform standard Agent package assembly
- Linux candidate backup, 100% verification, restore, and metadata certification
- release contracts, Python unit/syntax, Shell syntax, YAML parse, English-source, and diff checks