### PR TITLE
fix(admin): resolve post-merge integration regressions

### DIFF
--- a/release/ci/certify-agent-candidate.py
+++ b/release/ci/certify-agent-candidate.py
@@ -11,7 +11,6 @@ import json
 import os
 import pathlib
 import platform
-import shutil
 import socketserver
 import stat
 import subprocess

--- a/release/ci/verify-agent-certifications.py
+++ b/release/ci/verify-agent-certifications.py
@@ -7,7 +7,6 @@ import argparse
 import json
 import hashlib
 import pathlib
-import sys
 import tarfile
 
 

--- a/src/backend/apps/platform_ops/api/views/system.py
+++ b/src/backend/apps/platform_ops/api/views/system.py
@@ -15,6 +15,7 @@ from rest_framework.views import APIView
 from apps.platform_ops.api.permissions import IsPlatformOpsStaff
 from apps.platform_ops.api.serializers.platform import PlatformAuditLogSerializer
 from apps.platform_ops.api.views._utils import paginated, safe_int
+from apps.platform_ops.models import PlatformAuditLog
 from apps.platform_ops.selectors.internal.security import list_platform_audit_logs
 from apps.platform_ops.selectors.internal.system import (
     migration_status,
@@ -58,8 +59,12 @@ class PlatformOpsSystemAuditView(APIView):
         all_logs = list_platform_audit_logs()
         stats = {
             "total": all_logs.count(),
-            "successful": all_logs.filter(result="success").count(),
-            "failed": all_logs.filter(result="failed").count(),
+            "successful": all_logs.filter(
+                result=PlatformAuditLog.Result.SUCCESS
+            ).count(),
+            "failed": all_logs.filter(
+                result=PlatformAuditLog.Result.FAILURE
+            ).count(),
             "last_24_hours": all_logs.filter(
                 created_at__gte=timezone.now() - timedelta(hours=24)
             ).count(),

--- a/src/backend/apps/platform_ops/selectors/internal/orgs.py
+++ b/src/backend/apps/platform_ops/selectors/internal/orgs.py
@@ -49,7 +49,11 @@ def _with_operational_counts(qs: QuerySet) -> QuerySet:
             filter=Q(memberships__is_active=True),
             distinct=True,
         ),
-        node_count=Count("nodes", distinct=True),
+        node_count=Count(
+            "nodes",
+            filter=Q(nodes__is_deleted=False),
+            distinct=True,
+        ),
         incident_count=Count(
             "alert_records",
             filter=Q(alert_records__status=AlertStatus.FIRING),

--- a/src/backend/apps/platform_ops/tests/test_health_api.py
+++ b/src/backend/apps/platform_ops/tests/test_health_api.py
@@ -12,6 +12,7 @@ from apps.iam.models import Membership, Organization
 from apps.monitor.services.interface import collect_and_persist_sample
 from apps.notification.constants import ChannelType
 from apps.notification.models import NotificationChannel, NotificationDelivery
+from apps.platform_ops.models import PlatformAuditLog
 from apps.task.models import Task
 
 
@@ -229,5 +230,30 @@ class PlatformOpsMonitoringApiTest(TestCase):
         self.assertIn("current", payload)
 
     def test_system_audit_ok(self):
-        response = self.client.get("/api/v1/platform-ops/system/audit")
+        PlatformAuditLog.objects.create(
+            actor=self.staff,
+            action="user.create",
+            target_type="user",
+            target_id="1",
+            result=PlatformAuditLog.Result.SUCCESS,
+        )
+        failed_log = PlatformAuditLog.objects.create(
+            actor=self.staff,
+            action="user.update",
+            target_type="user",
+            target_id="2",
+            result=PlatformAuditLog.Result.FAILURE,
+        )
+
+        response = self.client.get(
+            "/api/v1/platform-ops/system/audit",
+            {"result": PlatformAuditLog.Result.FAILURE},
+        )
+
         self.assertEqual(response.status_code, 200)
+        payload = _payload(response)
+        self.assertEqual(payload["count"], 1)
+        self.assertEqual(payload["results"][0]["id"], failed_log.pk)
+        self.assertEqual(payload["results"][0]["result"], "failure")
+        self.assertEqual(payload["stats"]["successful"], 1)
+        self.assertEqual(payload["stats"]["failed"], 1)

--- a/src/backend/apps/platform_ops/tests/test_orgs_api.py
+++ b/src/backend/apps/platform_ops/tests/test_orgs_api.py
@@ -94,6 +94,26 @@ class PlatformOpsOrgsApiTest(TestCase):
         self.assertEqual(row["incident_count"], 1)
         self.assertEqual(payload["stats"]["with_incidents"], 1)
 
+    def test_list_orgs_excludes_soft_deleted_nodes_from_count(self):
+        Node.objects.create(
+            organization=self.org,
+            name="active-agent",
+            role=NodeRole.AGENT,
+        )
+        deleted_node = Node.objects.create(
+            organization=self.org,
+            name="deleted-agent",
+            role=NodeRole.AGENT,
+        )
+        deleted_node.soft_delete()
+
+        response = self.client.get("/api/v1/platform-ops/orgs")
+
+        self.assertEqual(response.status_code, 200)
+        payload = _payload(response)
+        row = next(item for item in payload["results"] if item["key"] == "acme")
+        self.assertEqual(row["node_count"], 1)
+
     def test_org_detail_includes_memberships(self):
         response = self.client.get(f"/api/v1/platform-ops/orgs/{self.org.pk}")
         self.assertEqual(response.status_code, 200)

--- a/src/frontend/src/components/ModulePage.vue
+++ b/src/frontend/src/components/ModulePage.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, onBeforeUnmount, onMounted, useSlots, type Component } from 'vue'
+import { ref, computed, useSlots, type Component } from 'vue'
 import { useRoute } from 'vue-router'
 const slots = useSlots()
 import Sidebar from './Sidebar.vue'
@@ -47,27 +47,7 @@ const isAdminSettingsShell = computed(
 )
 
 const collapsed = ref(localStorage.getItem('sidebar-collapsed') === 'true')
-const viewportCollapsed = ref(false)
-const responsiveCollapsedOverride = ref<boolean | null>(null)
-const effectiveCollapsed = computed(
-  () => responsiveCollapsedOverride.value ?? (collapsed.value || viewportCollapsed.value),
-)
-
-function updateResponsiveSidebar() {
-  const nextViewportCollapsed = route.path.startsWith('/platform-ops') && window.innerWidth <= 900
-  if (nextViewportCollapsed === viewportCollapsed.value) return
-  viewportCollapsed.value = nextViewportCollapsed
-  responsiveCollapsedOverride.value = null
-}
-
-onMounted(() => {
-  updateResponsiveSidebar()
-  window.addEventListener('resize', updateResponsiveSidebar)
-})
-
-onBeforeUnmount(() => {
-  window.removeEventListener('resize', updateResponsiveSidebar)
-})
+const effectiveCollapsed = computed(() => collapsed.value)
 
 // Convert side items to menu format if side prop is provided
 const menuItems = computed<MenuItem[]>(() => {
@@ -128,10 +108,6 @@ const displayTitle = computed(() => {
 })
 
 function toggleSidebar() {
-  if (viewportCollapsed.value) {
-    responsiveCollapsedOverride.value = !effectiveCollapsed.value
-    return
-  }
   collapsed.value = !collapsed.value
   localStorage.setItem('sidebar-collapsed', String(collapsed.value))
 }

--- a/src/frontend/src/components/ModulePageResponsive.test.ts
+++ b/src/frontend/src/components/ModulePageResponsive.test.ts
@@ -1,5 +1,7 @@
 // @vitest-environment jsdom
 
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
 import { defineComponent, nextTick } from 'vue'
 import { mount } from '@vue/test-utils'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -49,7 +51,7 @@ describe('ModulePage responsive sidebar', () => {
     vi.restoreAllMocks()
   })
 
-  it('allows a responsive sidebar to expand without overwriting the desktop preference', async () => {
+  it('keeps mobile visibility separate from the desktop collapse preference', async () => {
     localStorage.setItem('sidebar-collapsed', 'false')
     setViewportWidth(800)
     const wrapper = mount(ModulePage, {
@@ -63,9 +65,6 @@ describe('ModulePage responsive sidebar', () => {
     await nextTick()
 
     const sidebar = wrapper.get('.sidebar-stub')
-    expect(sidebar.attributes('data-collapsed')).toBe('true')
-
-    await sidebar.trigger('click')
     expect(sidebar.attributes('data-collapsed')).toBe('false')
     expect(localStorage.getItem('sidebar-collapsed')).toBe('false')
 
@@ -78,5 +77,24 @@ describe('ModulePage responsive sidebar', () => {
     expect(localStorage.getItem('sidebar-collapsed')).toBe('true')
 
     wrapper.unmount()
+  })
+
+  it('pairs the hidden mobile sidebar with the shell navigation drawer', () => {
+    const modulePageSource = readFileSync(
+      resolve(process.cwd(), 'src/components/ModulePage.vue'),
+      'utf8',
+    )
+    const shellSource = readFileSync(
+      resolve(process.cwd(), 'src/platform-ops/layout/PlatformOpsShell.vue'),
+      'utf8',
+    )
+
+    expect(modulePageSource).toMatch(
+      /@media \(max-width: 1023\.98px\)[\s\S]*?\.sidebar-wrapper\s*{[\s\S]*?display:\s*none/,
+    )
+    expect(shellSource).toContain('<MobileNavigationDrawer')
+    expect(shellSource).toMatch(
+      /@media \(max-width: 1023\.98px\)[\s\S]*?\.platform-ops-header__menu\s*{[\s\S]*?display:\s*inline-flex/,
+    )
   })
 })

--- a/src/frontend/src/platform-ops/pages/audit/PlatformAuditLogs.vue
+++ b/src/frontend/src/platform-ops/pages/audit/PlatformAuditLogs.vue
@@ -59,7 +59,7 @@ watch(() => [pagination.page, pagination.pageSize], load)
         <template #toolbar><div class="platform-monitoring-page__filters">
           <el-input v-model="filters.search" clearable class="platform-monitoring-page__search" placeholder="Search actor, action, or target"><template #prefix><Search :size="15" /></template></el-input>
           <el-input v-model="filters.action" clearable class="platform-monitoring-page__filter" placeholder="Action" />
-          <el-select v-model="filters.result" clearable class="platform-monitoring-page__filter" placeholder="Result"><el-option value="success" label="Success" /><el-option value="failed" label="Failed" /></el-select>
+          <el-select v-model="filters.result" clearable class="platform-monitoring-page__filter" placeholder="Result"><el-option value="success" label="Success" /><el-option value="failure" label="Failed" /></el-select>
           <el-input v-model="filters.org" clearable class="platform-monitoring-page__filter" placeholder="Account key" />
           <el-button v-if="Object.values(filters).some(Boolean)" text @click="resetFilters">Reset</el-button>
         </div></template>


### PR DESCRIPTION
## Summary
- align audit failure filtering and statistics with the backend enum
- exclude soft-deleted nodes from organization counts
- replace obsolete responsive sidebar state with mobile drawer contract coverage
- remove unused imports from Agent certification scripts

## Verification
- backend regression tests: 16 passed
- frontend tests: 335 passed
- frontend lint and production build
- Ruff checks for backend and certification scripts
- Agent certification gate tests: 3 passed
- git diff --check