### PR TITLE
fix(release): disable Kopia keyring during certification

### DIFF
--- a/release/ci/certify-agent-candidate.py
+++ b/release/ci/certify-agent-candidate.py
@@ -275,6 +275,8 @@ def certify_backup(
             "KOPIA_CACHE_DIRECTORY": str(workspace / "cache"),
             "KOPIA_LOG_DIR": str(workspace / "logs"),
             "KOPIA_CHECK_FOR_UPDATES": "false",
+            "KOPIA_USE_KEYRING": "false",
+            "KOPIA_PERSIST_CREDENTIALS_ON_CONNECT": "false",
         }
     )
     base = [str(kopia), "--config-file", str(config), "--no-progress"]

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -145,6 +145,7 @@ grep -F 'APT_MIRROR_URL: ${DEBIAN_APT_MIRROR_URL:-https://deb.debian.org/debian}
 	"${tmp}/source-patch/docker-compose.yml")" -eq 2 ]]
 
 workflow="${ROOT}/.github/workflows/build_and_deploy.yml"
+agent_certification="${ROOT}/release/ci/certify-agent-candidate.py"
 [[ -f "${workflow}" ]] || {
 	printf 'ERROR: tag release workflow is missing\n' >&2
 	exit 1
@@ -251,6 +252,8 @@ grep -F 'npm run test:ci' "${workflow}" >/dev/null
 grep -F './tools/quality/test-ci-release-assembly.sh' "${workflow}" >/dev/null
 grep -F 'python3 -m unittest tools/quality/test_agent_certification_gate.py' "${workflow}" >/dev/null
 grep -F 'release/ci/certify-agent-candidate.py' "${workflow}" >/dev/null
+grep -F '"KOPIA_USE_KEYRING": "false"' "${agent_certification}" >/dev/null
+grep -F '"KOPIA_PERSIST_CREDENTIALS_ON_CONNECT": "false"' "${agent_certification}" >/dev/null
 grep -F 'release/ci/verify-agent-certifications.py' "${workflow}" >/dev/null
 grep -F 'runner: ubuntu-24.04-arm' "${workflow}" >/dev/null
 grep -F 'runner: macos-15-intel' "${workflow}" >/dev/null


### PR DESCRIPTION
## Summary

- disable Kopia keyring access during native release certification
- prevent credential persistence while using the temporary certification repository
- add release contract assertions to prevent regression

## Root cause

The first v0.1.5 release run timed out on both macOS runners while `kopia repository create filesystem` waited on the non-interactive macOS Keychain `security` process. Linux and Windows certifications passed.

Failed run: https://github.com/HyperBDR/hyperfilelens/actions/runs/29924737538

## Validation

- `./tools/quality/check-release-contracts.sh`
- `python3 -m unittest tools/quality/test_agent_certification_gate.py`
- `uv run ruff check release/ci/certify-agent-candidate.py`
- `git diff --check`