### PR TITLE
fix(release): use official HTTPS apt sources

### DIFF
--- a/src/agent/scripts/fetch-deps.sh
+++ b/src/agent/scripts/fetch-deps.sh
@@ -446,22 +446,14 @@ mkdir -p "${work}" "${dest}"
 chmod 777 "${work}"
 cd "${work}"
 
-# Use HTTP for apt inside the ephemeral container (HTTPS needs ca-certificates first).
-apt_mirror_http=""
+# Preserve an explicitly configured mirror and its scheme. Without one, use
+# Ubuntu's official HTTPS endpoints after bootstrapping ca-certificates.
+apt_mirror_url=""
 if [[ -n "${apt_mirror}" ]]; then
-  apt_mirror_http="${apt_mirror%/}"
-  apt_mirror_http="${apt_mirror_http#https://}"
-  apt_mirror_http="${apt_mirror_http#http://}"
-  apt_mirror_http="http://${apt_mirror_http}"
+  apt_mirror_url="${apt_mirror%/}"
 fi
 
-if [[ -f /etc/apt/sources.list.d/ubuntu.sources ]]; then
-  sed -i 's|https://ports.ubuntu.com/ubuntu-ports|http://ports.ubuntu.com/ubuntu-ports|g' /etc/apt/sources.list.d/ubuntu.sources
-  sed -i 's|https://archive.ubuntu.com/ubuntu|http://archive.ubuntu.com/ubuntu|g' /etc/apt/sources.list.d/ubuntu.sources
-  sed -i 's|https://security.ubuntu.com/ubuntu|http://security.ubuntu.com/ubuntu|g' /etc/apt/sources.list.d/ubuntu.sources
-fi
-
-echo "  bootstrap: ca-certificates (default Ubuntu HTTP sources)"
+echo "  bootstrap: ca-certificates (base-image Ubuntu sources)"
 if ! apt-get update -qq; then
   echo "ERROR: bootstrap apt-get update failed (${arch})" >&2
   exit 1
@@ -471,20 +463,27 @@ if ! apt-get install -y --no-install-recommends ca-certificates; then
   exit 1
 fi
 
-if [[ -n "${apt_mirror_http}" ]]; then
-  m="${apt_mirror_http}"
+if [[ -n "${apt_mirror_url}" ]]; then
+  m="${apt_mirror_url}"
   echo "  apt mirror: ${m} (${arch})"
-  if [[ -f /etc/apt/sources.list.d/ubuntu.sources ]]; then
-    if grep -q 'ports.ubuntu.com/ubuntu-ports' /etc/apt/sources.list.d/ubuntu.sources; then
-      sed -i "s|http://ports.ubuntu.com/ubuntu-ports|${m}/ubuntu-ports|g" /etc/apt/sources.list.d/ubuntu.sources
-    fi
-    sed -i "s|http://archive.ubuntu.com/ubuntu|${m}/ubuntu|g" /etc/apt/sources.list.d/ubuntu.sources
-    sed -i "s|http://security.ubuntu.com/ubuntu|${m}/ubuntu|g" /etc/apt/sources.list.d/ubuntu.sources
+else
+  echo "  apt source: official Ubuntu HTTPS (${arch})"
+fi
+for source_file in /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources; do
+  [[ -f "${source_file}" ]] || continue
+  if [[ -n "${apt_mirror_url}" ]]; then
+    sed -E -i "s|https?://ports.ubuntu.com/ubuntu-ports|${m}/ubuntu-ports|g" "${source_file}"
+    sed -E -i "s|https?://archive.ubuntu.com/ubuntu|${m}/ubuntu|g" "${source_file}"
+    sed -E -i "s|https?://security.ubuntu.com/ubuntu|${m}/ubuntu|g" "${source_file}"
+  else
+    sed -i 's|http://ports.ubuntu.com/ubuntu-ports|https://ports.ubuntu.com/ubuntu-ports|g' "${source_file}"
+    sed -i 's|http://archive.ubuntu.com/ubuntu|https://archive.ubuntu.com/ubuntu|g' "${source_file}"
+    sed -i 's|http://security.ubuntu.com/ubuntu|https://security.ubuntu.com/ubuntu|g' "${source_file}"
   fi
-  if ! apt-get update -qq; then
-    echo "ERROR: apt-get update failed after mirror switch (${arch})" >&2
-    exit 1
-  fi
+done
+if ! apt-get update -qq; then
+  echo "ERROR: apt-get update failed after secure source configuration (${arch})" >&2
+  exit 1
 fi
 
 echo "  download: nfs-common cifs-utils (+dependencies)"

--- a/tools/dependencies/fetch-docker-ce-debs.sh
+++ b/tools/dependencies/fetch-docker-ce-debs.sh
@@ -230,31 +230,33 @@ set -euo pipefail
 export DEBIAN_FRONTEND=noninteractive
 mkdir -p /out
 
-apt_mirror_http=""
+apt_mirror_url=""
 if [[ -n "${APT_MIRROR:-}" ]]; then
-  apt_mirror_http="${APT_MIRROR%/}"
-  apt_mirror_http="${apt_mirror_http#https://}"
-  apt_mirror_http="${apt_mirror_http#http://}"
-  apt_mirror_http="http://${apt_mirror_http}"
-fi
-
-if [[ -f /etc/apt/sources.list.d/ubuntu.sources ]]; then
-  sed -i 's|https://ports.ubuntu.com/ubuntu-ports|http://ports.ubuntu.com/ubuntu-ports|g' /etc/apt/sources.list.d/ubuntu.sources
-  sed -i 's|https://archive.ubuntu.com/ubuntu|http://archive.ubuntu.com/ubuntu|g' /etc/apt/sources.list.d/ubuntu.sources
-  sed -i 's|https://security.ubuntu.com/ubuntu|http://security.ubuntu.com/ubuntu|g' /etc/apt/sources.list.d/ubuntu.sources
+  apt_mirror_url="${APT_MIRROR%/}"
 fi
 
 apt-get update -qq
 apt-get install -y --no-install-recommends ca-certificates curl gnupg apt-utils
 
-if [[ -n "${apt_mirror_http}" ]]; then
-  m="${apt_mirror_http}"
-  if [[ -f /etc/apt/sources.list.d/ubuntu.sources ]]; then
-    sed -i "s|http://archive.ubuntu.com/ubuntu|${m}/ubuntu|g" /etc/apt/sources.list.d/ubuntu.sources
-    sed -i "s|http://security.ubuntu.com/ubuntu|${m}/ubuntu|g" /etc/apt/sources.list.d/ubuntu.sources
-  fi
-  apt-get update -qq
+if [[ -n "${apt_mirror_url}" ]]; then
+  m="${apt_mirror_url}"
+  echo "  using Ubuntu apt mirror: ${m}"
+else
+  echo "  using official Ubuntu HTTPS sources"
 fi
+for source_file in /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources; do
+  [[ -f "${source_file}" ]] || continue
+  if [[ -n "${apt_mirror_url}" ]]; then
+    sed -E -i "s|https?://ports.ubuntu.com/ubuntu-ports|${m}/ubuntu-ports|g" "${source_file}"
+    sed -E -i "s|https?://archive.ubuntu.com/ubuntu|${m}/ubuntu|g" "${source_file}"
+    sed -E -i "s|https?://security.ubuntu.com/ubuntu|${m}/ubuntu|g" "${source_file}"
+  else
+    sed -i 's|http://ports.ubuntu.com/ubuntu-ports|https://ports.ubuntu.com/ubuntu-ports|g' "${source_file}"
+    sed -i 's|http://archive.ubuntu.com/ubuntu|https://archive.ubuntu.com/ubuntu|g' "${source_file}"
+    sed -i 's|http://security.ubuntu.com/ubuntu|https://security.ubuntu.com/ubuntu|g' "${source_file}"
+  fi
+done
+apt-get update -qq
 
 docker_apt="${DOCKER_APT_MIRROR:-https://download.docker.com/linux/ubuntu}"
 docker_apt="${docker_apt%/}"

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -254,6 +254,15 @@ grep -F 'python3 -m unittest tools/quality/test_agent_certification_gate.py' "${
 grep -F 'release/ci/certify-agent-candidate.py' "${workflow}" >/dev/null
 grep -F '"KOPIA_USE_KEYRING": "false"' "${agent_certification}" >/dev/null
 grep -F '"KOPIA_PERSIST_CREDENTIALS_ON_CONNECT": "false"' "${agent_certification}" >/dev/null
+grep -F 'apt source: official Ubuntu HTTPS' "${ROOT}/src/agent/scripts/fetch-deps.sh" >/dev/null
+grep -F 'using official Ubuntu HTTPS sources' \
+	"${ROOT}/tools/dependencies/fetch-docker-ce-debs.sh" >/dev/null
+if rg -n 'apt_mirror_http|default Ubuntu HTTP sources' \
+	"${ROOT}/src/agent/scripts/fetch-deps.sh" \
+	"${ROOT}/tools/dependencies/fetch-docker-ce-debs.sh" >/dev/null; then
+	printf 'ERROR: offline dependency fetchers must not force apt mirrors to HTTP\n' >&2
+	exit 1
+fi
 grep -F 'release/ci/verify-agent-certifications.py' "${workflow}" >/dev/null
 grep -F 'runner: ubuntu-24.04-arm' "${workflow}" >/dev/null
 grep -F 'runner: macos-15-intel' "${workflow}" >/dev/null


### PR DESCRIPTION
## Summary

- switch default Ubuntu dependency downloads to official HTTPS sources after CA bootstrap
- support both Ubuntu 20.04 `sources.list` and Ubuntu 24.04 `ubuntu.sources`
- preserve explicitly configured apt mirror URLs and their protocols
- align Agent NAS dependencies and host Docker CE offline dependencies
- add release contract regression checks

## Root cause

The second v0.1.5 run could not refresh Ubuntu 20.04 package indexes over HTTP/80 on the GitHub runner, leaving `nfs-common` dependencies unresolved.

Failed run: https://github.com/HyperBDR/hyperfilelens/actions/runs/29927792820

## Validation

- Bash syntax checks
- `./tools/quality/check-release-contracts.sh`
- `git diff --check`