### PR TITLE
fix(release): harden apt CA bootstrap

### DIFF
--- a/src/agent/scripts/fetch-deps.sh
+++ b/src/agent/scripts/fetch-deps.sh
@@ -428,7 +428,7 @@ docker_platform_for_arch() {
 	esac
 }
 
-NAS_DOCKER_TIMEOUT=300
+NAS_DOCKER_TIMEOUT=900
 NAS_DOCKER_TIMEOUT_ARM64=1800
 NAS_DEPS_MIN_DEBS=30
 NAS_IMAGE="ubuntu:24.04"
@@ -447,20 +447,10 @@ chmod 777 "${work}"
 cd "${work}"
 
 # Preserve an explicitly configured mirror and its scheme. Without one, use
-# Ubuntu's official HTTPS endpoints after bootstrapping ca-certificates.
+# Ubuntu's official HTTPS endpoints.
 apt_mirror_url=""
 if [[ -n "${apt_mirror}" ]]; then
   apt_mirror_url="${apt_mirror%/}"
-fi
-
-echo "  bootstrap: ca-certificates (base-image Ubuntu sources)"
-if ! apt-get update -qq; then
-  echo "ERROR: bootstrap apt-get update failed (${arch})" >&2
-  exit 1
-fi
-if ! apt-get install -y --no-install-recommends ca-certificates; then
-  echo "ERROR: bootstrap ca-certificates install failed (${arch})" >&2
-  exit 1
 fi
 
 if [[ -n "${apt_mirror_url}" ]]; then
@@ -481,6 +471,24 @@ for source_file in /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources;
     sed -i 's|http://security.ubuntu.com/ubuntu|https://security.ubuntu.com/ubuntu|g' "${source_file}"
   fi
 done
+
+# Minimal Ubuntu images do not ship ca-certificates. Disable TLS peer checks
+# only while installing that package; APT repository signatures remain
+# enforced. The next update runs with normal strict TLS verification.
+bootstrap_apt=(
+  apt-get
+  -o Acquire::https::Verify-Peer=false
+  -o Acquire::https::Verify-Host=false
+)
+echo "  bootstrap: ca-certificates (signed APT metadata; temporary TLS peer bypass)"
+if ! "${bootstrap_apt[@]}" update -qq; then
+  echo "ERROR: bootstrap apt-get update failed (${arch})" >&2
+  exit 1
+fi
+if ! "${bootstrap_apt[@]}" install -y --no-install-recommends ca-certificates; then
+  echo "ERROR: bootstrap ca-certificates install failed (${arch})" >&2
+  exit 1
+fi
 if ! apt-get update -qq; then
   echo "ERROR: apt-get update failed after secure source configuration (${arch})" >&2
   exit 1

--- a/tools/dependencies/fetch-docker-ce-debs.sh
+++ b/tools/dependencies/fetch-docker-ce-debs.sh
@@ -235,9 +235,6 @@ if [[ -n "${APT_MIRROR:-}" ]]; then
   apt_mirror_url="${APT_MIRROR%/}"
 fi
 
-apt-get update -qq
-apt-get install -y --no-install-recommends ca-certificates curl gnupg apt-utils
-
 if [[ -n "${apt_mirror_url}" ]]; then
   m="${apt_mirror_url}"
   echo "  using Ubuntu apt mirror: ${m}"
@@ -256,6 +253,16 @@ for source_file in /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources;
     sed -i 's|http://security.ubuntu.com/ubuntu|https://security.ubuntu.com/ubuntu|g' "${source_file}"
   fi
 done
+
+# Bootstrap the CA bundle through signed APT metadata, then immediately return
+# to strict TLS verification for every subsequent package and key download.
+bootstrap_apt=(
+  apt-get
+  -o Acquire::https::Verify-Peer=false
+  -o Acquire::https::Verify-Host=false
+)
+"${bootstrap_apt[@]}" update -qq
+"${bootstrap_apt[@]}" install -y --no-install-recommends ca-certificates curl gnupg apt-utils
 apt-get update -qq
 
 docker_apt="${DOCKER_APT_MIRROR:-https://download.docker.com/linux/ubuntu}"

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -257,6 +257,13 @@ grep -F '"KOPIA_PERSIST_CREDENTIALS_ON_CONNECT": "false"' "${agent_certification
 grep -F 'apt source: official Ubuntu HTTPS' "${ROOT}/src/agent/scripts/fetch-deps.sh" >/dev/null
 grep -F 'using official Ubuntu HTTPS sources' \
 	"${ROOT}/tools/dependencies/fetch-docker-ce-debs.sh" >/dev/null
+grep -F 'NAS_DOCKER_TIMEOUT=900' "${ROOT}/src/agent/scripts/fetch-deps.sh" >/dev/null
+for dependency_fetcher in \
+	"${ROOT}/src/agent/scripts/fetch-deps.sh" \
+	"${ROOT}/tools/dependencies/fetch-docker-ce-debs.sh"; do
+	grep -F 'Acquire::https::Verify-Peer=false' "${dependency_fetcher}" >/dev/null
+	grep -F 'Acquire::https::Verify-Host=false' "${dependency_fetcher}" >/dev/null
+done
 if rg -n 'apt_mirror_http|default Ubuntu HTTP sources' \
 	"${ROOT}/src/agent/scripts/fetch-deps.sh" \
 	"${ROOT}/tools/dependencies/fetch-docker-ce-debs.sh" >/dev/null; then


### PR DESCRIPTION
## Summary

- configure official HTTPS apt sources before any dependency refresh
- bootstrap `ca-certificates` with temporary TLS peer verification bypass while retaining APT repository signature verification
- restore strict TLS immediately after CA installation
- increase the amd64 NAS dependency container timeout from 5 to 15 minutes
- apply the same secure bootstrap to Docker CE host dependency assets
- extend release contract checks

## Root cause

The third v0.1.5 run completed Ubuntu 20.04 over HTTPS but Ubuntu 24.04 spent most of the 300-second container limit refreshing the pre-CA base-image source, then timed out during CA installation.

Failed run: https://github.com/HyperBDR/hyperfilelens/actions/runs/29929069579

## Validation

- Bash syntax checks
- `./tools/quality/check-release-contracts.sh`
- `git diff --check`