### PR TITLE
fix(release): retry official apt downloads

### DIFF
--- a/src/agent/scripts/fetch-deps.sh
+++ b/src/agent/scripts/fetch-deps.sh
@@ -475,8 +475,14 @@ done
 # Minimal Ubuntu images do not ship ca-certificates. Disable TLS peer checks
 # only while installing that package; APT repository signatures remain
 # enforced. The next update runs with normal strict TLS verification.
-bootstrap_apt=(
+apt_network=(
   apt-get
+  -o Acquire::Retries=5
+  -o Acquire::http::Timeout=30
+  -o Acquire::https::Timeout=30
+)
+bootstrap_apt=(
+  "${apt_network[@]}"
   -o Acquire::https::Verify-Peer=false
   -o Acquire::https::Verify-Host=false
 )
@@ -489,14 +495,26 @@ if ! "${bootstrap_apt[@]}" install -y --no-install-recommends ca-certificates; t
   echo "ERROR: bootstrap ca-certificates install failed (${arch})" >&2
   exit 1
 fi
-if ! apt-get update -qq; then
+if ! "${apt_network[@]}" update -qq; then
   echo "ERROR: apt-get update failed after secure source configuration (${arch})" >&2
   exit 1
 fi
 
 echo "  download: nfs-common cifs-utils (+dependencies)"
 rm -f /var/cache/apt/archives/*.deb 2>/dev/null || true
-apt-get install -y --download-only --no-install-recommends nfs-common cifs-utils
+download_ok=0
+for attempt in 1 2 3; do
+  if "${apt_network[@]}" install -y --download-only --no-install-recommends nfs-common cifs-utils; then
+    download_ok=1
+    break
+  fi
+  echo "WARN: apt dependency download attempt ${attempt}/3 failed; retrying cached remainder" >&2
+  sleep $((attempt * 5))
+done
+if [[ "${download_ok}" -ne 1 ]]; then
+  echo "ERROR: apt dependency download failed after 3 attempts (${arch})" >&2
+  exit 1
+fi
 
 decode_apt_deb_name() {
   local encoded=$1 len i c h decoded=""

--- a/tools/dependencies/fetch-docker-ce-debs.sh
+++ b/tools/dependencies/fetch-docker-ce-debs.sh
@@ -256,14 +256,20 @@ done
 
 # Bootstrap the CA bundle through signed APT metadata, then immediately return
 # to strict TLS verification for every subsequent package and key download.
-bootstrap_apt=(
+apt_network=(
   apt-get
+  -o Acquire::Retries=5
+  -o Acquire::http::Timeout=30
+  -o Acquire::https::Timeout=30
+)
+bootstrap_apt=(
+  "${apt_network[@]}"
   -o Acquire::https::Verify-Peer=false
   -o Acquire::https::Verify-Host=false
 )
 "${bootstrap_apt[@]}" update -qq
 "${bootstrap_apt[@]}" install -y --no-install-recommends ca-certificates curl gnupg apt-utils
-apt-get update -qq
+"${apt_network[@]}" update -qq
 
 docker_apt="${DOCKER_APT_MIRROR:-https://download.docker.com/linux/ubuntu}"
 docker_apt="${docker_apt%/}"
@@ -305,15 +311,27 @@ fi
 chmod a+r /etc/apt/keyrings/docker.gpg
 echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.gpg] ${docker_apt} ${UBUNTU_CODENAME} stable" \
   > /etc/apt/sources.list.d/docker.list
-apt-get update -qq
+"${apt_network[@]}" update -qq
 
 rm -f /var/cache/apt/archives/*.deb
-apt-get install -y --download-only --no-install-recommends \
-  "containerd.io=${CONTAINERD_VERSION}" \
-  "docker-ce-cli=${CLI_VERSION}" \
-  "docker-ce=${ENGINE_VERSION}" \
-  "docker-compose-plugin=${COMPOSE_PLUGIN_VERSION}" \
-  "docker-buildx-plugin=${BUILDX_PLUGIN_VERSION}"
+download_ok=0
+for attempt in 1 2 3; do
+  if "${apt_network[@]}" install -y --download-only --no-install-recommends \
+    "containerd.io=${CONTAINERD_VERSION}" \
+    "docker-ce-cli=${CLI_VERSION}" \
+    "docker-ce=${ENGINE_VERSION}" \
+    "docker-compose-plugin=${COMPOSE_PLUGIN_VERSION}" \
+    "docker-buildx-plugin=${BUILDX_PLUGIN_VERSION}"; then
+    download_ok=1
+    break
+  fi
+  echo "WARN: Docker deb download attempt ${attempt}/3 failed; retrying cached remainder" >&2
+  sleep $((attempt * 5))
+done
+[[ "${download_ok}" -eq 1 ]] || {
+  echo "ERROR: Docker deb download failed after 3 attempts" >&2
+  exit 1
+}
 
 decode_apt_deb_name() {
   local encoded=$1 len i c h decoded=""

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -263,6 +263,8 @@ for dependency_fetcher in \
 	"${ROOT}/tools/dependencies/fetch-docker-ce-debs.sh"; do
 	grep -F 'Acquire::https::Verify-Peer=false' "${dependency_fetcher}" >/dev/null
 	grep -F 'Acquire::https::Verify-Host=false' "${dependency_fetcher}" >/dev/null
+	grep -F 'Acquire::Retries=5' "${dependency_fetcher}" >/dev/null
+	grep -F 'for attempt in 1 2 3' "${dependency_fetcher}" >/dev/null
 done
 if rg -n 'apt_mirror_http|default Ubuntu HTTP sources' \
 	"${ROOT}/src/agent/scripts/fetch-deps.sh" \


### PR DESCRIPTION
## Summary

- add APT-native retries and bounded network timeouts to official dependency downloads
- retry Agent NAS dependency downloads up to three times while reusing cached packages
- apply the same behavior to Docker CE host dependency assets
- extend release contract regression checks

## Root cause

The fourth v0.1.5 run completed HTTPS CA bootstrap, but the official Ubuntu source transiently failed on the final two packages with `Resource temporarily unavailable`.

Failed run: https://github.com/HyperBDR/hyperfilelens/actions/runs/29930404631

## Validation

- Bash syntax checks
- `./tools/quality/check-release-contracts.sh`
- `git diff --check`