### PR TITLE
fix(release): minimize host CA bootstrap

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -453,7 +453,7 @@ jobs:
 
   build-host-debs:
     runs-on: ubuntu-24.04
-    timeout-minutes: 30
+    timeout-minutes: 60
     needs: [prepare, agent-release-gate]
     permissions:
       contents: write

--- a/tools/dependencies/fetch-docker-ce-debs.sh
+++ b/tools/dependencies/fetch-docker-ce-debs.sh
@@ -268,8 +268,22 @@ bootstrap_apt=(
   -o Acquire::https::Verify-Host=false
 )
 "${bootstrap_apt[@]}" update -qq
-"${bootstrap_apt[@]}" install -y --no-install-recommends ca-certificates curl gnupg apt-utils
+"${bootstrap_apt[@]}" install -y --no-install-recommends ca-certificates
 "${apt_network[@]}" update -qq
+
+bootstrap_tools_ok=0
+for attempt in 1 2 3; do
+  if "${apt_network[@]}" install -y --no-install-recommends curl gnupg apt-utils; then
+    bootstrap_tools_ok=1
+    break
+  fi
+  echo "WARN: host dependency tool download attempt ${attempt}/3 failed; retrying cached remainder" >&2
+  sleep $((attempt * 5))
+done
+[[ "${bootstrap_tools_ok}" -eq 1 ]] || {
+  echo "ERROR: host dependency tools failed after 3 attempts" >&2
+  exit 1
+}
 
 docker_apt="${DOCKER_APT_MIRROR:-https://download.docker.com/linux/ubuntu}"
 docker_apt="${docker_apt%/}"

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -277,6 +277,8 @@ grep -F 'runner: ubuntu-24.04-arm' "${workflow}" >/dev/null
 grep -F 'runner: macos-15-intel' "${workflow}" >/dev/null
 grep -F 'runner: macos-15' "${workflow}" >/dev/null
 grep -F 'runner: windows-2022' "${workflow}" >/dev/null
+grep -A2 '^  build-host-debs:' "${workflow}" | grep -F 'timeout-minutes: 60' >/dev/null
+grep -F 'bootstrap_tools_ok=0' "${ROOT}/tools/dependencies/fetch-docker-ce-debs.sh" >/dev/null
 grep -F -- '--required-target linux:arm64' "${workflow}" >/dev/null
 grep -F -- '--required-target darwin:arm64' "${workflow}" >/dev/null
 grep -F -- '--required-target windows:amd64' "${workflow}" >/dev/null


### PR DESCRIPTION
## Summary

- install only ca-certificates during temporary TLS bootstrap
- restore strict TLS before installing curl, gnupg, and apt-utils
- retry host build tool downloads incrementally
- increase host dependency asset timeout to 60 minutes

Root cause: fifth v0.1.5 run attempted the full host build tool dependency closure before CA installation completed on Ubuntu 20.04.

Validation: Bash syntax, release contracts, git diff checks.