### PR TITLE
fix(release): stage apt CA bootstrap

### DIFF
--- a/src/agent/scripts/fetch-deps.sh
+++ b/src/agent/scripts/fetch-deps.sh
@@ -457,7 +457,7 @@ if [[ -n "${apt_mirror_url}" ]]; then
   m="${apt_mirror_url}"
   echo "  apt mirror: ${m} (${arch})"
 else
-  echo "  apt source: official Ubuntu HTTPS (${arch})"
+  echo "  apt source: official Ubuntu (HTTPS after CA bootstrap) (${arch})"
 fi
 for source_file in /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources; do
   [[ -f "${source_file}" ]] || continue
@@ -465,10 +465,6 @@ for source_file in /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources;
     sed -E -i "s|https?://ports.ubuntu.com/ubuntu-ports|${m}/ubuntu-ports|g" "${source_file}"
     sed -E -i "s|https?://archive.ubuntu.com/ubuntu|${m}/ubuntu|g" "${source_file}"
     sed -E -i "s|https?://security.ubuntu.com/ubuntu|${m}/ubuntu|g" "${source_file}"
-  else
-    sed -i 's|http://ports.ubuntu.com/ubuntu-ports|https://ports.ubuntu.com/ubuntu-ports|g' "${source_file}"
-    sed -i 's|http://archive.ubuntu.com/ubuntu|https://archive.ubuntu.com/ubuntu|g' "${source_file}"
-    sed -i 's|http://security.ubuntu.com/ubuntu|https://security.ubuntu.com/ubuntu|g' "${source_file}"
   fi
 done
 
@@ -494,6 +490,14 @@ fi
 if ! "${bootstrap_apt[@]}" install -y --no-install-recommends ca-certificates; then
   echo "ERROR: bootstrap ca-certificates install failed (${arch})" >&2
   exit 1
+fi
+if [[ -z "${apt_mirror_url}" ]]; then
+  for source_file in /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources; do
+    [[ -f "${source_file}" ]] || continue
+    sed -i 's|http://ports.ubuntu.com/ubuntu-ports|https://ports.ubuntu.com/ubuntu-ports|g' "${source_file}"
+    sed -i 's|http://archive.ubuntu.com/ubuntu|https://archive.ubuntu.com/ubuntu|g' "${source_file}"
+    sed -i 's|http://security.ubuntu.com/ubuntu|https://security.ubuntu.com/ubuntu|g' "${source_file}"
+  done
 fi
 if ! "${apt_network[@]}" update -qq; then
   echo "ERROR: apt-get update failed after secure source configuration (${arch})" >&2

--- a/tools/dependencies/fetch-docker-ce-debs.sh
+++ b/tools/dependencies/fetch-docker-ce-debs.sh
@@ -239,7 +239,7 @@ if [[ -n "${apt_mirror_url}" ]]; then
   m="${apt_mirror_url}"
   echo "  using Ubuntu apt mirror: ${m}"
 else
-  echo "  using official Ubuntu HTTPS sources"
+  echo "  using official Ubuntu sources (HTTPS after CA bootstrap)"
 fi
 for source_file in /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources; do
   [[ -f "${source_file}" ]] || continue
@@ -247,10 +247,6 @@ for source_file in /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources;
     sed -E -i "s|https?://ports.ubuntu.com/ubuntu-ports|${m}/ubuntu-ports|g" "${source_file}"
     sed -E -i "s|https?://archive.ubuntu.com/ubuntu|${m}/ubuntu|g" "${source_file}"
     sed -E -i "s|https?://security.ubuntu.com/ubuntu|${m}/ubuntu|g" "${source_file}"
-  else
-    sed -i 's|http://ports.ubuntu.com/ubuntu-ports|https://ports.ubuntu.com/ubuntu-ports|g' "${source_file}"
-    sed -i 's|http://archive.ubuntu.com/ubuntu|https://archive.ubuntu.com/ubuntu|g' "${source_file}"
-    sed -i 's|http://security.ubuntu.com/ubuntu|https://security.ubuntu.com/ubuntu|g' "${source_file}"
   fi
 done
 
@@ -269,6 +265,14 @@ bootstrap_apt=(
 )
 "${bootstrap_apt[@]}" update -qq
 "${bootstrap_apt[@]}" install -y --no-install-recommends ca-certificates
+if [[ -z "${apt_mirror_url}" ]]; then
+  for source_file in /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources; do
+    [[ -f "${source_file}" ]] || continue
+    sed -i 's|http://ports.ubuntu.com/ubuntu-ports|https://ports.ubuntu.com/ubuntu-ports|g' "${source_file}"
+    sed -i 's|http://archive.ubuntu.com/ubuntu|https://archive.ubuntu.com/ubuntu|g' "${source_file}"
+    sed -i 's|http://security.ubuntu.com/ubuntu|https://security.ubuntu.com/ubuntu|g' "${source_file}"
+  done
+fi
 "${apt_network[@]}" update -qq
 
 bootstrap_tools_ok=0

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -254,8 +254,9 @@ grep -F 'python3 -m unittest tools/quality/test_agent_certification_gate.py' "${
 grep -F 'release/ci/certify-agent-candidate.py' "${workflow}" >/dev/null
 grep -F '"KOPIA_USE_KEYRING": "false"' "${agent_certification}" >/dev/null
 grep -F '"KOPIA_PERSIST_CREDENTIALS_ON_CONNECT": "false"' "${agent_certification}" >/dev/null
-grep -F 'apt source: official Ubuntu HTTPS' "${ROOT}/src/agent/scripts/fetch-deps.sh" >/dev/null
-grep -F 'using official Ubuntu HTTPS sources' \
+grep -F 'apt source: official Ubuntu (HTTPS after CA bootstrap)' \
+	"${ROOT}/src/agent/scripts/fetch-deps.sh" >/dev/null
+grep -F 'using official Ubuntu sources (HTTPS after CA bootstrap)' \
 	"${ROOT}/tools/dependencies/fetch-docker-ce-debs.sh" >/dev/null
 grep -F 'NAS_DOCKER_TIMEOUT=900' "${ROOT}/src/agent/scripts/fetch-deps.sh" >/dev/null
 for dependency_fetcher in \
@@ -265,6 +266,7 @@ for dependency_fetcher in \
 	grep -F 'Acquire::https::Verify-Host=false' "${dependency_fetcher}" >/dev/null
 	grep -F 'Acquire::Retries=5' "${dependency_fetcher}" >/dev/null
 	grep -F 'for attempt in 1 2 3' "${dependency_fetcher}" >/dev/null
+	grep -F 'if [[ -z "${apt_mirror_url}" ]]; then' "${dependency_fetcher}" >/dev/null
 done
 if rg -n 'apt_mirror_http|default Ubuntu HTTP sources' \
 	"${ROOT}/src/agent/scripts/fetch-deps.sh" \


### PR DESCRIPTION
## Summary

- use official base-image HTTP sources only for the minimal CA bootstrap
- retain APT repository signature verification during bootstrap
- switch official sources to HTTPS immediately after CA installation
- keep strict TLS, retries, and bounded timeouts for all release dependencies

Root cause: Ubuntu 20.04 APT did not reliably honor the pre-CA TLS peer bypass during the sixth v0.1.5 run.

Validation: Bash syntax, release contracts, git diff checks.