### PR TITLE
fix(release): scope Docker apt refresh

### DIFF
--- a/tools/dependencies/fetch-docker-ce-debs.sh
+++ b/tools/dependencies/fetch-docker-ce-debs.sh
@@ -329,7 +329,11 @@ fi
 chmod a+r /etc/apt/keyrings/docker.gpg
 echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.gpg] ${docker_apt} ${UBUNTU_CODENAME} stable" \
   > /etc/apt/sources.list.d/docker.list
-"${apt_network[@]}" update -qq
+"${apt_network[@]}" \
+  -o Dir::Etc::sourcelist=/etc/apt/sources.list.d/docker.list \
+  -o Dir::Etc::sourceparts=- \
+  -o APT::Get::List-Cleanup=0 \
+  update -qq
 
 rm -f /var/cache/apt/archives/*.deb
 download_ok=0

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -281,6 +281,8 @@ grep -F 'runner: macos-15' "${workflow}" >/dev/null
 grep -F 'runner: windows-2022' "${workflow}" >/dev/null
 grep -A2 '^  build-host-debs:' "${workflow}" | grep -F 'timeout-minutes: 60' >/dev/null
 grep -F 'bootstrap_tools_ok=0' "${ROOT}/tools/dependencies/fetch-docker-ce-debs.sh" >/dev/null
+grep -F 'Dir::Etc::sourcelist=/etc/apt/sources.list.d/docker.list' \
+	"${ROOT}/tools/dependencies/fetch-docker-ce-debs.sh" >/dev/null
 grep -F -- '--required-target linux:arm64' "${workflow}" >/dev/null
 grep -F -- '--required-target darwin:arm64' "${workflow}" >/dev/null
 grep -F -- '--required-target windows:amd64' "${workflow}" >/dev/null


### PR DESCRIPTION
## Summary

- refresh only the newly added Docker apt source
- retain the already validated Ubuntu package indexes
- avoid a redundant full Ubuntu source refresh before Docker deb resolution
- add a release contract regression check

Root cause: seventh v0.1.5 host-debs refreshed all Ubuntu sources again after adding Docker and hit a transient metadata failure.

Validation: Bash syntax, release contracts, git diff checks.