### PR TITLE
fix(ci): use Azure-local Ubuntu mirror

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -325,6 +325,7 @@ jobs:
       - name: Build Agent asset
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          APT_MIRROR: ${{ vars.CI_UBUNTU_APT_MIRROR }}
         run: |
           ./release/ci/build-agent-asset.sh \
             "${{ matrix.target }}" \
@@ -468,6 +469,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Build host dependency asset
+        env:
+          APT_MIRROR: ${{ vars.CI_UBUNTU_APT_MIRROR }}
         run: >-
           ./release/ci/build-host-debs-asset.sh
           "${{ matrix.ubuntu_release }}"

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -279,6 +279,7 @@ grep -F 'runner: ubuntu-24.04-arm' "${workflow}" >/dev/null
 grep -F 'runner: macos-15-intel' "${workflow}" >/dev/null
 grep -F 'runner: macos-15' "${workflow}" >/dev/null
 grep -F 'runner: windows-2022' "${workflow}" >/dev/null
+[[ "$(grep -c 'APT_MIRROR: \${{ vars.CI_UBUNTU_APT_MIRROR }}' "${workflow}")" -eq 2 ]]
 grep -A2 '^  build-host-debs:' "${workflow}" | grep -F 'timeout-minutes: 60' >/dev/null
 grep -F 'bootstrap_tools_ok=0' "${ROOT}/tools/dependencies/fetch-docker-ce-debs.sh" >/dev/null
 grep -F 'Dir::Etc::sourcelist=/etc/apt/sources.list.d/docker.list' \


### PR DESCRIPTION
## Summary

- pass a repository-configured Ubuntu apt mirror into Agent and host dependency build jobs
- keep product and local-build defaults on official Ubuntu sources
- use the Azure-local Ubuntu mirror only in GitHub Actions
- add a release contract assertion for both dependency paths

Configured variable: `CI_UBUNTU_APT_MIRROR=https://azure.archive.ubuntu.com`

Root cause: GitHub Azure runners repeatedly transferred from archive.ubuntu.com at tens of KB/s and exhausted the bounded dependency timeout.

Validation: release contracts and git diff checks.