### PR TITLE
fix(release): align smoke test with disabled signup

### DIFF
--- a/tools/dev/browser-smoke.mjs
+++ b/tools/dev/browser-smoke.mjs
@@ -160,7 +160,12 @@ async function verifyAuthenticationViewport(browser, baseUrl, viewport) {
     const page = await context.newPage()
     for (const path of ['/login', '/register']) {
       await page.goto(`${baseUrl}${path}`, { waitUntil: 'domcontentloaded' })
-      const form = page.locator(path === '/login' ? '.login-form-box' : '.register-form-box')
+      // Self-service signup is disabled in release and SaaS deployments, so
+      // /register legitimately redirects to the login form. When signup is
+      // enabled, keep validating the dedicated registration form.
+      const form = page.locator(
+        path === '/login' ? '.login-form-box' : '.register-form-box, .login-form-box',
+      ).first()
       await form.waitFor({ state: 'visible' })
       await assertNoDocumentOverflow(page, `${path} at ${viewport.width}x${viewport.height}`)
       await assertInsideViewport(page, form, `${path} form at ${viewport.width}x${viewport.height}`)

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -250,6 +250,8 @@ grep -F 'uv run --isolated --no-project --python 3.8 python tools/quality/check-
 	"${workflow}" >/dev/null
 grep -F 'npm run test:ci' "${workflow}" >/dev/null
 grep -F './tools/quality/test-ci-release-assembly.sh' "${workflow}" >/dev/null
+grep -F "'.register-form-box, .login-form-box'" \
+	"${ROOT}/tools/dev/browser-smoke.mjs" >/dev/null
 grep -F 'python3 -m unittest tools/quality/test_agent_certification_gate.py' "${workflow}" >/dev/null
 grep -F 'release/ci/certify-agent-candidate.py' "${workflow}" >/dev/null
 grep -F '"KOPIA_USE_KEYRING": "false"' "${agent_certification}" >/dev/null


### PR DESCRIPTION
## Summary

- keep strict login form viewport validation
- accept the registration form when self-service signup is enabled
- accept the login form redirect when self-service signup is disabled
- add a release contract regression assertion

Root cause: the complete v0.1.5 install was healthy and login succeeded, but browser smoke always required `.register-form-box` even though release deployment sets `HFL_EMAIL_SIGNUP_ENABLED=false`.

Validation: Node syntax, release contracts, git diff checks.