### PR TITLE
fix(release): align browser smoke with current layouts

### DIFF
--- a/tools/dev/browser-smoke.mjs
+++ b/tools/dev/browser-smoke.mjs
@@ -9,6 +9,7 @@ const { chromium } = require('playwright')
 const smokeHost = process.env.SMOKE_HOST || 'host.docker.internal'
 const tenantPort = process.env.HFL_TENANT_PORT || '11443'
 const adminPort = process.env.HFL_ADMIN_PORT || '11444'
+const loginPort = process.env.HFL_LOGIN_PORT || tenantPort
 const sourceLensPort = process.env.SOURCELENS_CONSOLE_PORT || '11445'
 const hflEmail = process.env.SEED_ADMIN_EMAIL || 'admin@hyperfilelens.com'
 const hflPassword = process.env.SEED_ADMIN_PASSWORD || 'Admin@123'
@@ -103,16 +104,49 @@ async function assertInsideViewport(page, locator, label) {
   }
 }
 
+async function assertHorizontallyInsideViewport(page, locator, label) {
+  await locator.waitFor({ state: 'visible', timeout: 30_000 })
+  const box = await locator.boundingBox()
+  const viewport = page.viewportSize()
+  if (!box || !viewport) fail(`${label} has no measurable viewport box`)
+  if (box.x < -1 || box.x + box.width > viewport.width + 1) {
+    fail(`${label} is outside the horizontal viewport: box=${JSON.stringify(box)} viewport=${JSON.stringify(viewport)}`)
+  }
+}
+
 async function waitForResponsiveRoute(page, url, label) {
-  await page.goto(url, { waitUntil: 'domcontentloaded' })
-  await page.waitForTimeout(350)
-  await page.locator('.main-content, .platform-ops-main, .login-form-box, .register-form-box').first()
-    .waitFor({ state: 'visible', timeout: 30_000 })
+  const pageErrors = []
+  const failedRequests = []
+  const onPageError = error => pageErrors.push(String(error?.stack || error))
+  const onRequestFailed = request => {
+    failedRequests.push(`${request.method()} ${request.url()}: ${request.failure()?.errorText || 'unknown error'}`)
+  }
+  page.on('pageerror', onPageError)
+  page.on('requestfailed', onRequestFailed)
+  process.stdout.write(`[browser smoke] checking ${label}: ${url}\n`)
+  try {
+    await page.goto(url, { waitUntil: 'domcontentloaded' })
+    await page.waitForTimeout(350)
+    await page.locator(
+      '.dashboard-page, .main-content, .platform-ops-main, .login-form-box, .register-form-box',
+    ).first()
+      .waitFor({ state: 'visible', timeout: 30_000 })
+  } catch (error) {
+    const body = (await page.locator('body').innerText().catch(() => '')).slice(0, 1_500)
+    fail(
+      `${label} did not become ready at ${page.url()}: ${error?.message || error}; `
+      + `pageErrors=${JSON.stringify(pageErrors.slice(-5))} `
+      + `failedRequests=${JSON.stringify(failedRequests.slice(-10))} body=${JSON.stringify(body)}`,
+    )
+  } finally {
+    page.off('pageerror', onPageError)
+    page.off('requestfailed', onRequestFailed)
+  }
   await assertNoDocumentOverflow(page, label)
 
   const table = page.locator('.el-table:visible').first()
   if (await table.count()) {
-    await assertInsideViewport(page, table, `${label} table`)
+    await assertHorizontallyInsideViewport(page, table, `${label} table`)
   }
 }
 
@@ -139,13 +173,16 @@ async function verifyMobilePlatformNavigation(page, baseUrl) {
   await drawer.waitFor({ state: 'hidden' })
 }
 
-async function verifyResponsiveDialogs(page, adminBaseUrl) {
+async function verifyResponsivePlatformPrimaryAction(page, adminBaseUrl) {
   await page.goto(`${adminBaseUrl}/platform-ops/orgs`, { waitUntil: 'domcontentloaded' })
-  await page.locator('.hfl-list-toolbar .el-button').first().click()
-  const dialog = page.locator('.el-dialog:visible').first()
-  await assertInsideViewport(page, dialog, 'Create Organization dialog')
-  await assertNoDocumentOverflow(page, 'Create Organization dialog')
-  await page.keyboard.press('Escape')
+  const createUser = page.locator('.platform-account-page__lead .el-button').first()
+  await createUser.waitFor({ state: 'visible', timeout: 30_000 })
+  await createUser.click()
+  await page.waitForURL(url => (
+    url.pathname === '/platform-ops/users' && url.searchParams.get('create') === '1'
+  ))
+  await page.locator('.platform-ops-main').waitFor({ state: 'visible', timeout: 30_000 })
+  await assertNoDocumentOverflow(page, 'Create User page')
 }
 
 async function verifyAuthenticationViewport(browser, baseUrl, viewport) {
@@ -217,7 +254,9 @@ async function verifyResponsiveConsoles(browser, storageState, tenantBaseUrl, ad
         await verifyMobileTenantNavigation(page, tenantBaseUrl)
         await verifyMobilePlatformNavigation(page, adminBaseUrl)
       }
-      if (profile.name === 'mobile-375') await verifyResponsiveDialogs(page, adminBaseUrl)
+      if (profile.name === 'mobile-375') {
+        await verifyResponsivePlatformPrimaryAction(page, adminBaseUrl)
+      }
     } finally {
       await context.close()
     }
@@ -256,10 +295,11 @@ async function run() {
   try {
     const tenantBaseUrl = `https://${smokeHost}:${tenantPort}`
     const adminBaseUrl = `https://${smokeHost}:${adminPort}`
+    const loginBaseUrl = `https://${smokeHost}:${loginPort}`
     const hfl = await browser.newContext({ ignoreHTTPSErrors: true, viewport: { width: 1280, height: 800 } })
     await waitForHflLogin(
       await hfl.newPage(),
-      tenantBaseUrl,
+      loginBaseUrl,
       '/',
     )
     await waitForPlatformOps(

--- a/tools/dev/browser-smoke.sh
+++ b/tools/dev/browser-smoke.sh
@@ -46,6 +46,8 @@ cache_dir="${ROOT}/build/cache/playwright-node-${version}"
 mkdir -p "${cache_dir}"
 source_lens_env="${SMOKE_SOURCELENS_ENV_FILE:-${ROOT}/data/sourcelens/config/.env}"
 smoke_host="${SMOKE_HOST:-host.docker.internal}"
+tenant_port="$(read_default HFL_TENANT_PORT 11443)"
+login_port="$(read_default HFL_LOGIN_PORT "${tenant_port}")"
 
 docker run --rm \
 	--add-host host.docker.internal:host-gateway \
@@ -54,8 +56,9 @@ docker run --rm \
 	-e PLAYWRIGHT_VERSION="${version}" \
 	-e DEV_OFFLINE="${offline}" \
 	-e SMOKE_HOST="${smoke_host}" \
-	-e HFL_TENANT_PORT="$(read_default HFL_TENANT_PORT 11443)" \
+	-e HFL_TENANT_PORT="${tenant_port}" \
 	-e HFL_ADMIN_PORT="$(read_default HFL_ADMIN_PORT 11444)" \
+	-e HFL_LOGIN_PORT="${login_port}" \
 	-e SOURCELENS_CONSOLE_PORT="$(read_default SOURCELENS_CONSOLE_PORT 11445)" \
 	-e SEED_ADMIN_EMAIL="$(read_default SEED_ADMIN_EMAIL admin@hyperfilelens.com)" \
 	-e SEED_ADMIN_PASSWORD="$(read_default SEED_ADMIN_PASSWORD 'Admin@123')" \

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -252,6 +252,10 @@ grep -F 'npm run test:ci' "${workflow}" >/dev/null
 grep -F './tools/quality/test-ci-release-assembly.sh' "${workflow}" >/dev/null
 grep -F "'.register-form-box, .login-form-box'" \
 	"${ROOT}/tools/dev/browser-smoke.mjs" >/dev/null
+grep -F "'.dashboard-page, .main-content, .platform-ops-main, .login-form-box, .register-form-box'" \
+	"${ROOT}/tools/dev/browser-smoke.mjs" >/dev/null
+grep -F 'verifyResponsivePlatformPrimaryAction' \
+	"${ROOT}/tools/dev/browser-smoke.mjs" >/dev/null
 grep -F 'python3 -m unittest tools/quality/test_agent_certification_gate.py' "${workflow}" >/dev/null
 grep -F 'release/ci/certify-agent-candidate.py' "${workflow}" >/dev/null
 grep -F '"KOPIA_USE_KEYRING": "false"' "${agent_certification}" >/dev/null
@@ -270,7 +274,7 @@ for dependency_fetcher in \
 	grep -F 'for attempt in 1 2 3' "${dependency_fetcher}" >/dev/null
 	grep -F 'if [[ -z "${apt_mirror_url}" ]]; then' "${dependency_fetcher}" >/dev/null
 done
-if rg -n 'apt_mirror_http|default Ubuntu HTTP sources' \
+if grep -E -n 'apt_mirror_http|default Ubuntu HTTP sources' \
 	"${ROOT}/src/agent/scripts/fetch-deps.sh" \
 	"${ROOT}/tools/dependencies/fetch-docker-ce-debs.sh" >/dev/null; then
 	printf 'ERROR: offline dependency fetchers must not force apt mirrors to HTTP\n' >&2
@@ -488,6 +492,7 @@ done
 smoke_runner="${ROOT}/tools/dev/browser-smoke.sh"
 grep -F -- '--add-host host.docker.internal:host-gateway' "${smoke_runner}" >/dev/null
 grep -F 'SMOKE_HOST' "${smoke_runner}" >/dev/null
+grep -F 'HFL_LOGIN_PORT="${login_port}"' "${smoke_runner}" >/dev/null
 smoke_script="${ROOT}/tools/dev/browser-smoke.mjs"
 grep -F 'host.docker.internal' "${smoke_script}" >/dev/null
 grep -F "submit.waitFor({ state: 'visible'" "${smoke_script}" >/dev/null


### PR DESCRIPTION
## Summary
- recognize the dashboard layout as a valid responsive route target
- validate table width without rejecting normal vertical scrolling
- replace the removed organization dialog check with the current create-user flow
- add actionable route diagnostics and optional admin-port login support
- remove the undeclared ripgrep dependency from release contract checks

## Validation
- full local Playwright smoke across tenant and Platform Operations routes at four viewport profiles
- node --check tools/dev/browser-smoke.mjs
- bash -n tools/dev/browser-smoke.sh tools/quality/check-release-contracts.sh
- ./tools/quality/check-release-contracts.sh
- git diff --check