### PR TITLE
fix(installer): initialize Compose before upgrade backup

### DIFF
--- a/deploy/installer/install.sh
+++ b/deploy/installer/install.sh
@@ -919,8 +919,18 @@ backup_env_and_data() {
 
 backup_postgresql_dump() {
 	[[ -f "${ROOT}/.env" ]] || return 0
+	if ! command -v docker >/dev/null 2>&1 \
+		|| ! docker info >/dev/null 2>&1 \
+		|| ! docker compose version >/dev/null 2>&1; then
+		warn "Docker Compose is unavailable; skipping logical database backup before file backup"
+		return 0
+	fi
+	COMPOSE=(docker compose)
 	local cid
-	cid="$(compose_in_root ps -q postgres 2>/dev/null | head -1)"
+	if ! cid="$(compose_in_root ps -q postgres 2>/dev/null | head -1)"; then
+		warn "Unable to inspect PostgreSQL with Docker Compose; skipping logical database backup"
+		return 0
+	fi
 	[[ -n "${cid}" ]] || { warn "PostgreSQL is not running; skipping logical database dump"; return 0; }
 	local stamp dump globals
 	stamp="$(date +%Y%m%d-%H%M%S)"

--- a/release/ci/verify-release.sh
+++ b/release/ci/verify-release.sh
@@ -85,23 +85,29 @@ available_kib="$(df -Pk / | awk 'NR == 2 {print $4}')"
 }
 
 smoke_host="${SMOKE_HOST:-host.docker.internal}"
-sudo env HFL_PUBLIC_HOST="${smoke_host}" HFL_SHOW_GENERATED_CREDENTIALS=0 \
-	bash "${pkg_root}/install.sh" install
-
-deadline=$((SECONDS + 600))
-while ((SECONDS < deadline)); do
-	if curl -kfsS https://127.0.0.1:11443/health/ready >/dev/null \
-		&& curl -kfsS https://127.0.0.1:11444/ >/dev/null \
-		&& curl -kfsS https://127.0.0.1:11445/ >/dev/null; then
-		break
-	fi
-	sleep 5
-done
-((SECONDS < deadline)) || {
+wait_for_release_services() {
+	local deadline=$((SECONDS + 600))
+	while ((SECONDS < deadline)); do
+		if curl -kfsS https://127.0.0.1:11443/health/ready >/dev/null \
+			&& curl -kfsS https://127.0.0.1:11444/ >/dev/null \
+			&& curl -kfsS https://127.0.0.1:11445/ >/dev/null; then
+			return 0
+		fi
+		sleep 5
+	done
 	docker compose -f /opt/hyperfilelens/docker-compose.yml --env-file /opt/hyperfilelens/.env ps || true
 	printf 'ERROR: release services did not become ready\n' >&2
-	exit 1
+	return 1
 }
+
+sudo env HFL_PUBLIC_HOST="${smoke_host}" HFL_SHOW_GENERATED_CREDENTIALS=0 \
+	bash "${pkg_root}/install.sh" install
+wait_for_release_services
+
+printf 'Running same-version in-place upgrade verification\n'
+sudo env HFL_PUBLIC_HOST="${smoke_host}" HFL_SHOW_GENERATED_CREDENTIALS=0 \
+	bash "${pkg_root}/install.sh" upgrade --from "${pkg_root}" --yes
+wait_for_release_services
 
 export HFL_TENANT_PORT=11443
 export HFL_ADMIN_PORT=11444
@@ -123,4 +129,4 @@ sudo env \
 	SMOKE_REQUIRE_HMR="${SMOKE_REQUIRE_HMR}" \
 	SMOKE_SOURCELENS_ENV_FILE="${SMOKE_SOURCELENS_ENV_FILE}" \
 	"${ROOT}/tools/dev/browser-smoke.sh"
-printf 'Full release install and login verification passed\n'
+printf 'Full release install, upgrade, and login verification passed\n'

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -410,6 +410,9 @@ grep -F 'sync_default_tls_bundle "${from_root}/deploy/nginx/certs"' "${installer
 grep -F 'Preserving existing TLS certificate directory' "${installer}" >/dev/null
 grep -F 'apply_upgrade_files "${src_root}" "${remove_sourcelens}"' "${installer}" >/dev/null
 grep -F 'apply_runtime_configuration' "${installer}" >/dev/null
+backup_body="$(sed -n '/^backup_postgresql_dump()/,/^}/p' "${installer}")"
+grep -F 'COMPOSE=(docker compose)' <<<"${backup_body}" >/dev/null
+grep -F 'skipping logical database backup before file backup' <<<"${backup_body}" >/dev/null
 grep -F 'python3 "${sync_script}" --env-file "${env_file}" --example "${example}"' "${installer}" >/dev/null
 grep -F 'host must be Ubuntu 20.04 or 24.04' "${installer}" >/dev/null
 grep -F 'gateway-install-docker-ubuntu-amd64.sh' "${installer}" >/dev/null
@@ -425,6 +428,8 @@ grep -F 'smoke_host="${SMOKE_HOST:-host.docker.internal}"' "${release_verifier}"
 grep -F 'HFL_PUBLIC_HOST="${smoke_host}"' "${release_verifier}" >/dev/null
 grep -F 'export SMOKE_HOST="${smoke_host}"' "${release_verifier}" >/dev/null
 grep -F 'SEED_ADMIN_EMAIL="$(sudo sed' "${release_verifier}" >/dev/null
+grep -F 'upgrade --from "${pkg_root}" --yes' "${release_verifier}" >/dev/null
+grep -F 'Full release install, upgrade, and login verification passed' "${release_verifier}" >/dev/null
 grep -F 'sudo env \' "${release_verifier}" >/dev/null
 grep -F 'cp "${ROOT}/tools/config/sync_env.py" "${pkg_root}/sync-env.py"' \
 	"${ROOT}/release/ci/assemble-release.sh" >/dev/null


### PR DESCRIPTION
## Summary
- initialize Docker Compose before the pre-upgrade PostgreSQL backup
- degrade safely to the file backup when Docker Compose inspection is unavailable
- exercise a real same-version in-place upgrade during full Release verification
- require service health after both fresh install and upgrade before browser login smoke

## Root cause
The upgrade path called compose_in_root before require_docker initialized the COMPOSE array, so Bash attempted to execute --env-file and exited with status 127.

## Validation
- bash -n deploy/installer/install.sh release/ci/verify-release.sh tools/quality/check-release-contracts.sh
- ./tools/quality/check-release-contracts.sh
- git diff --check
- SourceLens source code unchanged