### PR TITLE
fix(installer): use bundled SourceLens postgres service

### DIFF
--- a/deploy/installer/install.sh
+++ b/deploy/installer/install.sh
@@ -951,15 +951,18 @@ backup_postgresql_dump() {
 
 	if sourcelens_installed; then
 		local sl_cid sl_dump sl_globals
-		sl_cid="$(sourcelens_compose ps -q postgresql 2>/dev/null | head -1)"
+		if ! sl_cid="$(sourcelens_compose ps -q postgres 2>/dev/null | head -1)"; then
+			warn "Unable to inspect bundled SourceLens PostgreSQL; skipping its logical database backup"
+			return 0
+		fi
 		if [[ -n "${sl_cid}" ]]; then
 			sl_dump="${ROOT}/backup/sourcelens-postgresql-${stamp}.dump"
 			sl_globals="${ROOT}/backup/sourcelens-postgresql-globals-${stamp}.sql"
 			step "Creating consistent bundled SourceLens PostgreSQL backup ..."
-			sourcelens_compose exec -T postgresql sh -ec \
+			sourcelens_compose exec -T postgres sh -ec \
 				'exec pg_dump -U "${POSTGRES_USER:-postgres}" -d "${POSTGRES_DB:-backend}" -Fc' \
 				>"${sl_dump}.part"
-			sourcelens_compose exec -T postgresql sh -ec \
+			sourcelens_compose exec -T postgres sh -ec \
 				'exec pg_dumpall -U "${POSTGRES_USER:-postgres}" --globals-only' \
 				>"${sl_globals}.part"
 			mv "${sl_dump}.part" "${sl_dump}"

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -413,6 +413,11 @@ grep -F 'apply_runtime_configuration' "${installer}" >/dev/null
 backup_body="$(sed -n '/^backup_postgresql_dump()/,/^}/p' "${installer}")"
 grep -F 'COMPOSE=(docker compose)' <<<"${backup_body}" >/dev/null
 grep -F 'skipping logical database backup before file backup' <<<"${backup_body}" >/dev/null
+[[ "$(grep -Fc 'sourcelens_compose exec -T postgres' <<<"${backup_body}")" -eq 2 ]]
+if grep -E 'sourcelens_compose (ps -q|exec -T) postgresql' <<<"${backup_body}" >/dev/null; then
+	printf 'ERROR: bundled SourceLens PostgreSQL Compose service is named postgres\n' >&2
+	exit 1
+fi
 grep -F 'python3 "${sync_script}" --env-file "${env_file}" --example "${example}"' "${installer}" >/dev/null
 grep -F 'host must be Ubuntu 20.04 or 24.04' "${installer}" >/dev/null
 grep -F 'gateway-install-docker-ubuntu-amd64.sh' "${installer}" >/dev/null


### PR DESCRIPTION
## Summary
- use the current bundled SourceLens Compose service name for logical backups
- make SourceLens database inspection explicitly non-fatal before the file backup
- prevent the obsolete postgresql service name from returning to the upgrade path

## Validation
- bash -n deploy/installer/install.sh tools/quality/check-release-contracts.sh
- ./tools/quality/check-release-contracts.sh
- git diff --check
- SourceLens source code unchanged