### PR TITLE
fix(agent): select the matching Ubuntu gateway bundle

### DIFF
--- a/src/agent/internal/enroll/preflight.go
+++ b/src/agent/internal/enroll/preflight.go
@@ -183,11 +183,32 @@ func roleConstraints(role model.Role) error {
 		if runtime.GOOS != "linux" {
 			return fmt.Errorf("role %s is Linux-only", role)
 		}
-		if !isUbuntuMin(20, 4) {
-			return fmt.Errorf("role %s requires Ubuntu 20.04 LTS or newer", role)
+		if !isSupportedGatewayUbuntu() {
+			return fmt.Errorf("role %s requires Ubuntu 20.04 LTS or 24.04 LTS", role)
 		}
 	}
 	return nil
+}
+
+func isSupportedGatewayUbuntu() bool {
+	f, err := os.Open("/etc/os-release")
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+	id := ""
+	versionID := ""
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		line := sc.Text()
+		if strings.HasPrefix(line, "ID=") {
+			id = strings.Trim(strings.TrimPrefix(line, "ID="), `"`)
+		}
+		if strings.HasPrefix(line, "VERSION_ID=") {
+			versionID = strings.Trim(strings.TrimPrefix(line, "VERSION_ID="), `"`)
+		}
+	}
+	return id == "ubuntu" && (versionID == "20.04" || versionID == "24.04")
 }
 
 func detectServiceManager(ctx context.Context) string {

--- a/src/agent/internal/enroll/preflight_network.go
+++ b/src/agent/internal/enroll/preflight_network.go
@@ -114,7 +114,7 @@ func checkWSSReachable(ctx context.Context, wssURL string) reachResult {
 	dialCtx, cancel := context.WithTimeout(ctx, 8*time.Second)
 	defer cancel()
 
-	host := parsed.Host
+	host := websocketDialAddress(parsed)
 	dialer := net.Dialer{Timeout: 8 * time.Second}
 
 	switch parsed.Scheme {
@@ -122,6 +122,11 @@ func checkWSSReachable(ctx context.Context, wssURL string) reachResult {
 		tlsConfig := tlsclient.Config()
 		if tlsConfig == nil {
 			tlsConfig = &tls.Config{MinVersion: tls.VersionTLS12}
+		} else {
+			tlsConfig = tlsConfig.Clone()
+		}
+		if tlsConfig.ServerName == "" {
+			tlsConfig.ServerName = parsed.Hostname()
 		}
 		conn, err := tls.DialWithDialer(&dialer, "tcp", host, tlsConfig)
 		if err != nil {
@@ -158,6 +163,23 @@ func checkWSSReachable(ctx context.Context, wssURL string) reachResult {
 			Title:   "WebSocket reachability inconclusive",
 			Detail:  wssURL,
 		}
+	}
+}
+
+func websocketDialAddress(parsed *url.URL) string {
+	if parsed == nil || parsed.Port() != "" {
+		if parsed == nil {
+			return ""
+		}
+		return parsed.Host
+	}
+	switch parsed.Scheme {
+	case "wss":
+		return net.JoinHostPort(parsed.Hostname(), "443")
+	case "ws":
+		return net.JoinHostPort(parsed.Hostname(), "80")
+	default:
+		return parsed.Host
 	}
 }
 

--- a/src/agent/internal/enroll/preflight_network_test.go
+++ b/src/agent/internal/enroll/preflight_network_test.go
@@ -1,0 +1,29 @@
+package enroll
+
+import (
+	"net/url"
+	"testing"
+)
+
+func TestWebsocketDialAddressUsesDefaultPorts(t *testing.T) {
+	t.Parallel()
+	tests := map[string]string{
+		"wss://hyperfilelens.com/ws/node/agent/":     "hyperfilelens.com:443",
+		"ws://console.example/ws/node/agent/":        "console.example:80",
+		"wss://console.example:11443/ws/node/agent/": "console.example:11443",
+		"wss://[2001:db8::1]/ws/node/agent/":         "[2001:db8::1]:443",
+	}
+	for raw, want := range tests {
+		raw, want := raw, want
+		t.Run(raw, func(t *testing.T) {
+			t.Parallel()
+			parsed, err := url.Parse(raw)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := websocketDialAddress(parsed); got != want {
+				t.Fatalf("websocketDialAddress(%q) = %q, want %q", raw, got, want)
+			}
+		})
+	}
+}

--- a/src/agent/internal/platform/release/release.go
+++ b/src/agent/internal/platform/release/release.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"hyperfilelens/agent/internal/model"
+	"hyperfilelens/agent/internal/platform/hostinfo"
 	"hyperfilelens/agent/internal/platform/tlsclient"
 )
 
@@ -68,14 +69,11 @@ func fetchDownloadURLOnce(ctx context.Context, cfg *model.AgentConfig) (download
 	if runtime.GOARCH == "arm64" {
 		arch = "arm64"
 	}
-	q := url.Values{
-		"org":      {cfg.OrgKey},
-		"role":     {string(cfg.Role)},
-		"token":    {cfg.NodeToken},
-		"platform": {platform},
-		"arch":     {arch},
-		"api_base": {base},
+	osVersion := ""
+	if platform == "linux" {
+		osVersion = strings.TrimSpace(hostinfo.Collect(ctx).OSVersion)
 	}
+	q := releaseQueryValues(cfg, platform, arch, base, osVersion)
 	reqURL := base + "/api/v1/node/enrollment/agent/release?" + q.Encode()
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
 	if err != nil {
@@ -110,6 +108,27 @@ func fetchDownloadURLOnce(ctx context.Context, cfg *model.AgentConfig) (download
 		return "", "", fmt.Errorf("release API missing download_url")
 	}
 	return dl, ver, nil
+}
+
+func releaseQueryValues(
+	cfg *model.AgentConfig,
+	platform string,
+	arch string,
+	apiBase string,
+	osVersion string,
+) url.Values {
+	q := url.Values{
+		"org":      {cfg.OrgKey},
+		"role":     {string(cfg.Role)},
+		"token":    {cfg.NodeToken},
+		"platform": {platform},
+		"arch":     {arch},
+		"api_base": {apiBase},
+	}
+	if platform == "linux" && strings.TrimSpace(osVersion) != "" {
+		q.Set("os_version", strings.TrimSpace(osVersion))
+	}
+	return q
 }
 
 // IsRetryableReleaseError reports whether FetchDownloadURLWithRetry should try again.

--- a/src/agent/internal/platform/release/release_test.go
+++ b/src/agent/internal/platform/release/release_test.go
@@ -1,0 +1,26 @@
+package release
+
+import (
+	"testing"
+
+	"hyperfilelens/agent/internal/model"
+)
+
+func TestReleaseQueryValuesReportsLinuxOSVersion(t *testing.T) {
+	t.Parallel()
+	cfg := &model.AgentConfig{
+		OrgKey:    "org_test",
+		NodeToken: "token",
+		Role:      model.RoleGateway,
+	}
+
+	linux := releaseQueryValues(cfg, "linux", "amd64", "https://console.example", "20.04")
+	if got := linux.Get("os_version"); got != "20.04" {
+		t.Fatalf("linux os_version = %q, want 20.04", got)
+	}
+
+	darwin := releaseQueryValues(cfg, "darwin", "amd64", "https://console.example", "14.5")
+	if got := darwin.Get("os_version"); got != "" {
+		t.Fatalf("darwin os_version = %q, want empty", got)
+	}
+}

--- a/src/backend/apps/node/api/views/artifact_release.py
+++ b/src/backend/apps/node/api/views/artifact_release.py
@@ -25,8 +25,9 @@ from apps.node.services.internal.agent_release import (
     agent_releases_root,
     dist_filename,
     latest_published_agent_version,
+    normalize_ubuntu_bundle_release,
     resolve_agent_version,
-    use_ubuntu2404_bundle,
+    ubuntu_bundle_release,
     version_has_dist,
 )
 
@@ -73,16 +74,17 @@ def _get_agent_artifact(
     *,
     platform: str | None = None,
     arch: str | None = None,
+    os_version: str | None = None,
 ) -> AgentArtifact:
     plat = _normalize_platform(platform) or os.getenv("AGENT_PLATFORM", "linux")
     machine = _normalize_arch(arch) or os.getenv("AGENT_ARCH", "amd64")
-    version = resolve_agent_version(plat, machine, role)
-    ubuntu2404 = use_ubuntu2404_bundle(role, plat)
+    version = resolve_agent_version(plat, machine, role, os_version)
+    ubuntu_release = ubuntu_bundle_release(role, plat, os_version)
     filename = os.getenv("AGENT_FILENAME") or dist_filename(
         version,
         plat,
         machine,
-        ubuntu2404=ubuntu2404,
+        ubuntu_release=ubuntu_release,
     )
     return AgentArtifact(platform=plat, arch=machine, version=version, filename=filename)
 
@@ -219,6 +221,7 @@ class AgentReleaseView(APIView):
         enroll_token = str(request.query_params.get("token") or "").strip()
         plat_raw = str(request.query_params.get("platform") or "").strip()
         arch_raw = str(request.query_params.get("arch") or "").strip()
+        os_version = str(request.query_params.get("os_version") or "").strip()
 
         platform: str | None = None
         if plat_raw:
@@ -231,6 +234,17 @@ class AgentReleaseView(APIView):
             arch = _normalize_arch(arch_raw)
             if arch is None:
                 return Response({"error": "invalid arch"}, status=400)
+
+        if (
+            platform == "linux"
+            and role in {Node.Role.PROXY, Node.Role.GATEWAY}
+            and os_version
+            and normalize_ubuntu_bundle_release(os_version) is None
+        ):
+            return Response(
+                {"error": "gateway/proxy supports Ubuntu 20.04 or 24.04"},
+                status=400,
+            )
 
         if not org_key or role not in dict(Node.Role.choices) or not enroll_token:
             return Response({"error": "org/role/token required"}, status=400)
@@ -247,7 +261,12 @@ class AgentReleaseView(APIView):
             ):
                 return Response({"error": "invalid enrollment token"}, status=401)
 
-        artifact = _get_agent_artifact(role, platform=platform, arch=arch)
+        artifact = _get_agent_artifact(
+            role,
+            platform=platform,
+            arch=arch,
+            os_version=os_version,
+        )
         ttl = int(os.getenv("AGENT_RELEASE_URL_TTL_SECONDS", "600"))
         signed = _make_release_token(
             {
@@ -353,4 +372,4 @@ _agent_releases_root = agent_releases_root
 _resolve_agent_version = resolve_agent_version
 _version_has_dist = version_has_dist
 _dist_filename = dist_filename
-_use_ubuntu2404_bundle = use_ubuntu2404_bundle
+_ubuntu_bundle_release = ubuntu_bundle_release

--- a/src/backend/apps/node/services/internal/agent_release.py
+++ b/src/backend/apps/node/services/internal/agent_release.py
@@ -11,7 +11,8 @@ from django.conf import settings
 from apps.node.models.base import NodeRole
 
 AGENT_RELEASES_URL_PREFIX = "/media/agent-releases"
-UBUNTU2404_LINUX_ROLES = frozenset({"proxy", "gateway"})
+UBUNTU_BUNDLED_LINUX_ROLES = frozenset({"proxy", "gateway"})
+SUPPORTED_UBUNTU_BUNDLE_RELEASES = frozenset({"20.04", "24.04"})
 UPGRADEABLE_AGENT_ROLES = frozenset(
     {
         NodeRole.AGENT,
@@ -58,8 +59,26 @@ def semver_compare(left: str, right: str) -> int:
     return 0
 
 
-def use_ubuntu2404_bundle(role: str | None, platform: str) -> bool:
-    return platform == "linux" and (role or "") in UBUNTU2404_LINUX_ROLES
+def normalize_ubuntu_bundle_release(os_version: str | None) -> str | None:
+    value = str(os_version or "").strip()
+    for release in SUPPORTED_UBUNTU_BUNDLE_RELEASES:
+        if value == release or value.startswith(f"{release}."):
+            return release
+    return None
+
+
+def ubuntu_bundle_release(
+    role: str | None,
+    platform: str,
+    os_version: str | None = None,
+) -> str | None:
+    if platform != "linux" or (role or "") not in UBUNTU_BUNDLED_LINUX_ROLES:
+        return None
+    # Older enrollment helpers did not report the OS version and historically
+    # received the Ubuntu 24.04 bundle. Preserve that behavior during upgrades.
+    if not str(os_version or "").strip():
+        return "24.04"
+    return normalize_ubuntu_bundle_release(os_version)
 
 
 def dist_filename(
@@ -67,10 +86,12 @@ def dist_filename(
     platform: str,
     arch: str,
     *,
-    ubuntu2404: bool = False,
+    ubuntu_release: str | None = None,
 ) -> str:
-    if ubuntu2404 and platform == "linux":
-        return f"hfl-agent-{version}-linux-{arch}-ubuntu2404.tar.gz"
+    ubuntu_release = normalize_ubuntu_bundle_release(ubuntu_release)
+    if ubuntu_release and platform == "linux":
+        suffix = "ubuntu" + ubuntu_release.replace(".", "")
+        return f"hfl-agent-{version}-linux-{arch}-{suffix}.tar.gz"
     ext = "zip" if platform == "windows" else "tar.gz"
     return f"hfl-agent-{version}-{platform}-{arch}.{ext}"
 
@@ -82,9 +103,10 @@ def version_has_dist(
     arch: str,
     *,
     role: str | None = None,
+    os_version: str | None = None,
 ) -> bool:
-    ubuntu2404 = use_ubuntu2404_bundle(role, platform)
-    filename = dist_filename(version, platform, arch, ubuntu2404=ubuntu2404)
+    ubuntu_release = ubuntu_bundle_release(role, platform, os_version)
+    filename = dist_filename(version, platform, arch, ubuntu_release=ubuntu_release)
     return (root / version / filename).is_file()
 
 
@@ -130,11 +152,23 @@ def latest_published_agent_version() -> str:
     return preferred or "0.0.0"
 
 
-def resolve_agent_version(platform: str, arch: str, role: str | None = None) -> str:
+def resolve_agent_version(
+    platform: str,
+    arch: str,
+    role: str | None = None,
+    os_version: str | None = None,
+) -> str:
     """Pick newest release dir that contains a dist archive for platform/arch."""
     root = agent_releases_root()
     preferred = os.getenv("AGENT_VERSION", "").strip()
-    if preferred and version_has_dist(root, preferred, platform, arch, role=role):
+    if preferred and version_has_dist(
+        root,
+        preferred,
+        platform,
+        arch,
+        role=role,
+        os_version=os_version,
+    ):
         return preferred
     candidates = [
         path.name
@@ -142,7 +176,14 @@ def resolve_agent_version(platform: str, arch: str, role: str | None = None) -> 
         if path.is_dir()
         and path.name not in ("dev",)
         and not path.name.startswith(".")
-        and version_has_dist(root, path.name, platform, arch, role=role)
+        and version_has_dist(
+            root,
+            path.name,
+            platform,
+            arch,
+            role=role,
+            os_version=os_version,
+        )
     ]
     if not candidates:
         return preferred or latest_published_agent_version()

--- a/src/backend/apps/node/services/internal/agent_upgrade.py
+++ b/src/backend/apps/node/services/internal/agent_upgrade.py
@@ -9,7 +9,6 @@ from apps.node.services.internal.agent_release import (
     parse_semver,
     resolve_agent_version,
     semver_compare,
-    use_ubuntu2404_bundle,
 )
 
 
@@ -41,6 +40,11 @@ def node_platform_arch(node: Node) -> tuple[str, str]:
     return platform, arch
 
 
+def node_os_version(node: Node) -> str:
+    inv = _merged_inventory(node)
+    return str(inv.get("os_version") or "").strip()
+
+
 def validate_agent_upgrade(*, node: Node) -> str:
     """
     Validate node can receive agent.upgrade.
@@ -57,13 +61,13 @@ def validate_agent_upgrade(*, node: Node) -> str:
         raise AgentUpgradeError("node is offline", code="node_offline")
 
     platform, arch = node_platform_arch(node)
-    if use_ubuntu2404_bundle(node.role, platform) and platform != "linux":
+    if node.role in {Node.Role.PROXY, Node.Role.GATEWAY} and platform != "linux":
         raise AgentUpgradeError(
             f"role {node.role} requires linux",
             code="unsupported_platform",
         )
 
-    target = resolve_agent_version(platform, arch, node.role)
+    target = resolve_agent_version(platform, arch, node.role, node_os_version(node))
     if not parse_semver(target):
         raise AgentUpgradeError(
             "no published agent release available",

--- a/src/backend/apps/node/tests/test_agent_release.py
+++ b/src/backend/apps/node/tests/test_agent_release.py
@@ -10,13 +10,14 @@ from apps.node.services.internal.agent_release import (
     resolve_agent_version,
     semver_compare,
 )
+from apps.node.services.internal import agent_release as release_service
 
 
 @pytest.fixture
-def releases_root(tmp_path, settings, monkeypatch):
+def releases_root(tmp_path, monkeypatch):
     media = tmp_path / "media" / "agent-releases"
     media.mkdir(parents=True)
-    settings.MEDIA_ROOT = tmp_path / "media"
+    monkeypatch.setattr(release_service, "agent_releases_root", lambda: media)
     monkeypatch.delenv("AGENT_VERSION", raising=False)
     return media
 
@@ -38,11 +39,19 @@ def test_latest_published_agent_version_honors_agent_version_env(releases_root, 
     assert latest_published_agent_version() == "1.0.0"
 
 
-def test_resolve_agent_version_prefers_ubuntu2404_for_proxy(releases_root):
+@pytest.mark.parametrize(
+    ("os_version", "suffix"),
+    [("20.04", "ubuntu2004"), ("24.04", "ubuntu2404")],
+)
+def test_resolve_agent_version_uses_matching_ubuntu_bundle(
+    releases_root,
+    os_version,
+    suffix,
+):
     version_dir = releases_root / "1.0.0"
     version_dir.mkdir()
-    (version_dir / "hfl-agent-1.0.0-linux-amd64-ubuntu2404.tar.gz").write_bytes(b"x")
-    assert resolve_agent_version("linux", "amd64", "proxy") == "1.0.0"
+    (version_dir / f"hfl-agent-1.0.0-linux-amd64-{suffix}.tar.gz").write_bytes(b"x")
+    assert resolve_agent_version("linux", "amd64", "proxy", os_version) == "1.0.0"
 
 
 def test_semver_compare_orders_versions():

--- a/src/backend/apps/node/tests/test_agent_upgrade.py
+++ b/src/backend/apps/node/tests/test_agent_upgrade.py
@@ -8,17 +8,19 @@ import pytest
 from apps.node.exceptions import AgentUpgradeError
 from apps.node.models import Node
 from apps.node.services.internal.agent_upgrade import node_platform_arch, validate_agent_upgrade
+from apps.node.services.internal import agent_release as release_service
 
 
 @pytest.fixture
-def releases_root(tmp_path, settings, monkeypatch):
+def releases_root(tmp_path, monkeypatch):
     media = tmp_path / "media" / "agent-releases"
     media.mkdir(parents=True)
     version_dir = media / "1.0.1"
     version_dir.mkdir()
     (version_dir / "hfl-agent-1.0.1-linux-amd64.tar.gz").write_bytes(b"x")
     (version_dir / "hfl-agent-1.0.1-linux-amd64-ubuntu2404.tar.gz").write_bytes(b"x")
-    settings.MEDIA_ROOT = tmp_path / "media"
+    (version_dir / "hfl-agent-1.0.1-linux-amd64-ubuntu2004.tar.gz").write_bytes(b"x")
+    monkeypatch.setattr(release_service, "agent_releases_root", lambda: media)
     monkeypatch.delenv("AGENT_VERSION", raising=False)
     return media
 

--- a/src/backend/apps/node/tests/test_artifact_release.py
+++ b/src/backend/apps/node/tests/test_artifact_release.py
@@ -6,50 +6,72 @@ from __future__ import annotations
 import pytest
 
 from apps.node.api.views import artifact_release as release
+from apps.node.services.internal import agent_release as release_service
 
 
 @pytest.mark.parametrize(
-    ("role", "platform", "arch", "ubuntu2404"),
+    ("role", "platform", "arch", "ubuntu_release"),
     [
-        ("agent", "linux", "amd64", False),
-        ("proxy", "linux", "amd64", True),
-        ("gateway", "linux", "arm64", True),
-        ("proxy", "darwin", "amd64", False),
-        ("gateway", "windows", "amd64", False),
+        ("agent", "linux", "amd64", None),
+        ("proxy", "linux", "amd64", "20.04"),
+        ("gateway", "linux", "arm64", "24.04"),
+        ("proxy", "darwin", "amd64", None),
+        ("gateway", "windows", "amd64", None),
     ],
 )
-def test_dist_filename_by_role(role, platform, arch, ubuntu2404):
-    filename = release._dist_filename("1.0.0", platform, arch, ubuntu2404=ubuntu2404)
-    if ubuntu2404:
-        assert filename == f"hfl-agent-1.0.0-linux-{arch}-ubuntu2404.tar.gz"
+def test_dist_filename_by_role(role, platform, arch, ubuntu_release):
+    filename = release._dist_filename(
+        "1.0.0",
+        platform,
+        arch,
+        ubuntu_release=ubuntu_release,
+    )
+    if ubuntu_release:
+        suffix = "ubuntu" + ubuntu_release.replace(".", "")
+        assert filename == f"hfl-agent-1.0.0-linux-{arch}-{suffix}.tar.gz"
     elif platform == "windows":
         assert filename == "hfl-agent-1.0.0-windows-amd64.zip"
     else:
         assert filename == f"hfl-agent-1.0.0-{platform}-{arch}.tar.gz"
 
 
-def test_use_ubuntu2404_bundle_only_linux_proxy_gateway():
-    assert release._use_ubuntu2404_bundle("proxy", "linux") is True
-    assert release._use_ubuntu2404_bundle("gateway", "linux") is True
-    assert release._use_ubuntu2404_bundle("agent", "linux") is False
-    assert release._use_ubuntu2404_bundle("proxy", "darwin") is False
+def test_ubuntu_bundle_release_uses_reported_host_version():
+    assert release._ubuntu_bundle_release("proxy", "linux", "20.04") == "20.04"
+    assert release._ubuntu_bundle_release("gateway", "linux", "24.04.2") == "24.04"
+    assert release._ubuntu_bundle_release("agent", "linux", "20.04") is None
+    assert release._ubuntu_bundle_release("proxy", "darwin", "24.04") is None
+    assert release._ubuntu_bundle_release("gateway", "linux", "22.04") is None
 
 
-def test_get_agent_artifact_proxy_linux(tmp_path, monkeypatch):
+def test_ubuntu_bundle_release_preserves_legacy_2404_default():
+    assert release._ubuntu_bundle_release("gateway", "linux") == "24.04"
+
+
+@pytest.mark.parametrize(
+    ("os_version", "suffix"),
+    [("20.04", "ubuntu2004"), ("24.04", "ubuntu2404")],
+)
+def test_get_agent_artifact_proxy_linux(tmp_path, monkeypatch, os_version, suffix):
     root = tmp_path / "agent-releases"
     version_dir = root / "1.0.0"
     version_dir.mkdir(parents=True)
     (version_dir / "hfl-agent-1.0.0-linux-amd64-ubuntu2404.tar.gz").write_bytes(b"x")
+    (version_dir / "hfl-agent-1.0.0-linux-amd64-ubuntu2004.tar.gz").write_bytes(b"z")
     (version_dir / "hfl-agent-1.0.0-linux-amd64.tar.gz").write_bytes(b"y")
 
-    monkeypatch.setattr(release, "_agent_releases_root", lambda: root)
+    monkeypatch.setattr(release_service, "agent_releases_root", lambda: root)
     monkeypatch.delenv("AGENT_FILENAME", raising=False)
     monkeypatch.setenv("AGENT_VERSION", "1.0.0")
 
-    artifact = release._get_agent_artifact("proxy", platform="linux", arch="amd64")
-    assert artifact.filename == "hfl-agent-1.0.0-linux-amd64-ubuntu2404.tar.gz"
+    artifact = release._get_agent_artifact(
+        "proxy",
+        platform="linux",
+        arch="amd64",
+        os_version=os_version,
+    )
+    assert artifact.filename == f"hfl-agent-1.0.0-linux-amd64-{suffix}.tar.gz"
     assert artifact.artifact_path == (
-        "/media/agent-releases/1.0.0/hfl-agent-1.0.0-linux-amd64-ubuntu2404.tar.gz"
+        f"/media/agent-releases/1.0.0/hfl-agent-1.0.0-linux-amd64-{suffix}.tar.gz"
     )
 
 
@@ -60,7 +82,7 @@ def test_get_agent_artifact_agent_linux(tmp_path, monkeypatch):
     (version_dir / "hfl-agent-1.0.0-linux-amd64-ubuntu2404.tar.gz").write_bytes(b"x")
     (version_dir / "hfl-agent-1.0.0-linux-amd64.tar.gz").write_bytes(b"y")
 
-    monkeypatch.setattr(release, "_agent_releases_root", lambda: root)
+    monkeypatch.setattr(release_service, "agent_releases_root", lambda: root)
     monkeypatch.delenv("AGENT_FILENAME", raising=False)
     monkeypatch.setenv("AGENT_VERSION", "1.0.0")
 
@@ -92,4 +114,3 @@ def test_try_acquire_slot_reuses_enrollment_id(monkeypatch):
     assert ok1 is True
     assert ok2 is True
     assert ok3 is False
-


### PR DESCRIPTION
## Summary
- report the Linux OS version when resolving Agent release artifacts
- select Ubuntu 20.04 or 24.04 offline Gateway bundles on the backend
- use default WebSocket ports for standard ws/wss URLs
- keep Gateway OS support aligned with the packaged dependency sets

## Validation
- full Agent Go test suite
- 21 targeted backend release/upgrade tests
- backend Ruff checks
- release contract checks
- Platform Gateway auto-deploy and uninstall contract tests
- English-only source and diff checks