### PR TITLE
fix(installer): refresh verified images during upgrades

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -142,6 +142,7 @@ jobs:
           ./tools/quality/test-gateway-bootstrap-health.sh
           ./tools/quality/test-platform-gateway-auto-deploy.sh
           ./tools/quality/test-agent-gateway-uninstall.sh
+          ./tools/quality/test-installer-image-refresh.sh
           ./tools/quality/test-shared-host-guard.sh
           ./tools/quality/test-deployment-optional-config.sh
           ./tools/quality/test-payload-tree-hash.sh
@@ -224,6 +225,8 @@ jobs:
           tags: ${{ env.REGISTRY_PREFIX }}/${{ matrix.repository }}:${{ needs.prepare.outputs.version }}
           build-args: |
             KOPIA_BINARY=build/kopia/dist/linux/amd64/kopia
+            IMAGE_VERSION=${{ needs.prepare.outputs.version }}
+            IMAGE_REVISION=${{ needs.prepare.outputs.commit }}
             PIP_TIMEOUT=600
             SENTRY_ENABLED=false
             SENTRY_ENVIRONMENT=production

--- a/deploy/docker/backend.Dockerfile
+++ b/deploy/docker/backend.Dockerfile
@@ -88,6 +88,12 @@ ENTRYPOINT ["/entrypoint.sh"]
 # Production/release image: application source is immutable inside the image.
 FROM backend-dependencies AS backend-runtime
 
+ARG IMAGE_VERSION=dev
+ARG IMAGE_REVISION=unknown
+
+LABEL org.opencontainers.image.version="${IMAGE_VERSION}" \
+    org.opencontainers.image.revision="${IMAGE_REVISION}"
+
 RUN rm -f /tmp/dev-requirements.txt
 
 COPY src/backend /opt/backend

--- a/deploy/docker/frontend.Dockerfile
+++ b/deploy/docker/frontend.Dockerfile
@@ -44,6 +44,12 @@ RUN npm run build
 # Stage 2: Serve the SPA and reverse proxy through the official stable Nginx Alpine image.
 FROM nginx:stable-alpine
 
+ARG IMAGE_VERSION=dev
+ARG IMAGE_REVISION=unknown
+
+LABEL org.opencontainers.image.version="${IMAGE_VERSION}" \
+    org.opencontainers.image.revision="${IMAGE_REVISION}"
+
 ENV TZ=UTC \
     LOGROTATE_INTERVAL_SECONDS=3600 \
     LOGROTATE_CONF=/etc/logrotate.d/hyperfilelens \

--- a/deploy/installer/install.sh
+++ b/deploy/installer/install.sh
@@ -829,13 +829,23 @@ def sha256_file(path: pathlib.Path) -> str:
     return digest.hexdigest()
 
 
-def image_present(ref: str) -> bool:
+def inspect_image(ref: str) -> dict:
     tag = ref.split("@", 1)[0]
-    return subprocess.run(
+    completed = subprocess.run(
         ["docker", "image", "inspect", tag],
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-    ).returncode == 0
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode != 0:
+        return {}
+    try:
+        inspected = json.loads(completed.stdout)
+    except json.JSONDecodeError:
+        return {}
+    if not isinstance(inspected, list) or len(inspected) != 1:
+        return {}
+    return inspected[0] if isinstance(inspected[0], dict) else {}
 
 for entry in manifest.get("images", []):
     if skip_sourcelens and str(entry.get("role", "")).startswith("sourcelens"):
@@ -850,11 +860,32 @@ for entry in manifest.get("images", []):
     if expected and sha256_file(path) != expected:
         print(f"[install.sh] ERROR: sha256 mismatch for {rel}", file=sys.stderr)
         sys.exit(1)
-    if refs and all(image_present(ref) for ref in refs):
-        print(f"[install.sh] skipping {rel} (image already loaded)")
-        continue
     print(f"[install.sh] loading image {rel} ...")
     subprocess.run(["docker", "load", "-i", str(path)], check=True)
+    missing = [ref for ref in refs if not inspect_image(ref)]
+    if missing:
+        print(
+            f"[install.sh] ERROR: archive {rel} did not load expected refs: "
+            + ", ".join(missing),
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    if entry.get("role") == "hyperfilelens":
+        expected_revision = str(manifest.get("git_commit", "")).strip()
+        if not expected_revision:
+            print("[install.sh] ERROR: release manifest has no git_commit", file=sys.stderr)
+            sys.exit(1)
+        for ref in refs:
+            config = inspect_image(ref).get("Config") or {}
+            labels = config.get("Labels") or {}
+            actual_revision = str(labels.get("org.opencontainers.image.revision", ""))
+            if actual_revision != expected_revision:
+                print(
+                    f"[install.sh] ERROR: image {ref} revision {actual_revision or '<missing>'} "
+                    f"does not match release {expected_revision}",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
 PY
 }
 
@@ -2496,4 +2527,6 @@ main() {
 	esac
 }
 
-main "$@"
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+	main "$@"
+fi

--- a/release/build.sh
+++ b/release/build.sh
@@ -607,6 +607,8 @@ build_control_plane_images() {
 		--build-arg "PIP_TRUSTED_HOST=${PIP_TRUSTED_HOST:-}" \
 		--build-arg "PIP_TIMEOUT=${PIP_TIMEOUT:-600}" \
 		--build-arg "KOPIA_BINARY=${KOPIA_BINARY:-build/kopia/dist/linux/amd64/kopia}" \
+		--build-arg "IMAGE_VERSION=${HFL_VERSION}" \
+		--build-arg "IMAGE_REVISION=${RELEASE_COMMIT}" \
 		"${ROOT}"
 
 	log "Building hyperfilelens-frontend:${HFL_VERSION} (alias: latest)"
@@ -622,6 +624,8 @@ build_control_plane_images() {
 		--build-arg "SENTRY_TRACES_SAMPLE_RATE=${SENTRY_TRACES_SAMPLE_RATE:-0}" \
 		--build-arg "SENTRY_SEND_DEFAULT_PII=${SENTRY_SEND_DEFAULT_PII:-false}" \
 		--build-arg "VITE_SHOW_EULA=${VITE_SHOW_EULA:-false}" \
+		--build-arg "IMAGE_VERSION=${HFL_VERSION}" \
+		--build-arg "IMAGE_REVISION=${RELEASE_COMMIT}" \
 		"${ROOT}"
 }
 

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -250,6 +250,7 @@ grep -F 'uv run --isolated --no-project --python 3.8 python tools/quality/check-
 	"${workflow}" >/dev/null
 grep -F 'npm run test:ci' "${workflow}" >/dev/null
 grep -F './tools/quality/test-ci-release-assembly.sh' "${workflow}" >/dev/null
+grep -F './tools/quality/test-installer-image-refresh.sh' "${workflow}" >/dev/null
 grep -F "'.register-form-box, .login-form-box'" \
 	"${ROOT}/tools/dev/browser-smoke.mjs" >/dev/null
 grep -F "'.dashboard-page, .main-content, .platform-ops-main, .login-form-box, .register-form-box'" \
@@ -308,6 +309,7 @@ if grep -F 'celery -A common inspect ping' <<<"${worker_healthcheck}" >/dev/null
 fi
 
 backend_dockerfile="${ROOT}/deploy/docker/backend.Dockerfile"
+frontend_dockerfile="${ROOT}/deploy/docker/frontend.Dockerfile"
 grep -F 'ARG KOPIA_BINARY=build/kopia/dist/linux/amd64/kopia' "${backend_dockerfile}" >/dev/null
 grep -F 'COPY --chmod=0755 ${KOPIA_BINARY} /usr/local/bin/kopia' "${backend_dockerfile}" >/dev/null
 grep -F '/etc/apt/sources.list.d/ubuntu.sources' "${backend_dockerfile}" >/dev/null
@@ -320,6 +322,18 @@ if grep -F 'UV_DEFAULT_INDEX' "${backend_dockerfile}" >/dev/null; then
 fi
 if grep -F 'PIP_NO_CACHE_DIR' "${backend_dockerfile}" >/dev/null; then
 	printf 'ERROR: backend build must not disable its BuildKit-managed pip cache\n' >&2
+	exit 1
+fi
+grep -F 'org.opencontainers.image.revision="${IMAGE_REVISION}"' "${backend_dockerfile}" >/dev/null
+grep -F 'org.opencontainers.image.revision="${IMAGE_REVISION}"' "${frontend_dockerfile}" >/dev/null
+grep -F 'IMAGE_REVISION=${{ needs.prepare.outputs.commit }}' "${workflow}" >/dev/null
+
+installer="${ROOT}/deploy/installer/install.sh"
+grep -F 'loading image {rel}' "${installer}" >/dev/null
+grep -F 'org.opencontainers.image.revision' "${installer}" >/dev/null
+grep -F 'does not match release' "${installer}" >/dev/null
+if grep -F 'image already loaded' "${installer}" >/dev/null; then
+	printf 'ERROR: installer must refresh verified release images even when tags already exist\n' >&2
 	exit 1
 fi
 

--- a/tools/quality/test-installer-image-refresh.sh
+++ b/tools/quality/test-installer-image-refresh.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+tmp="$(mktemp -d)"
+trap 'rm -rf "${tmp}"' EXIT
+
+package_root="${tmp}/package"
+fake_bin="${tmp}/bin"
+marker="${tmp}/docker-load-called"
+mkdir -p "${package_root}/images" "${fake_bin}"
+printf 'verified image archive fixture\n' >"${package_root}/images/hfl.tar.gz"
+archive_sha="$(sha256sum "${package_root}/images/hfl.tar.gz" | awk '{print $1}')"
+
+write_manifest() {
+	local revision=$1
+	python3 - "${package_root}/MANIFEST.json" "${archive_sha}" "${revision}" <<'PY'
+import json
+import pathlib
+import sys
+
+path, archive_sha, revision = sys.argv[1:4]
+pathlib.Path(path).write_text(
+    json.dumps(
+        {
+            "git_commit": revision,
+            "images": [
+                {
+                    "file": "images/hfl.tar.gz",
+                    "refs": [
+                        "hyperfilelens-backend:0.1.5",
+                        "hyperfilelens-frontend:0.1.5",
+                    ],
+                    "role": "hyperfilelens",
+                    "sha256": archive_sha,
+                }
+            ],
+        }
+    ),
+    encoding="utf-8",
+)
+PY
+}
+
+cat >"${fake_bin}/docker" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+case "${1:-} ${2:-}" in
+"load -i")
+	: >"${HFL_TEST_LOAD_MARKER}"
+	printf 'Loaded image fixture\n'
+	;;
+"image inspect")
+	revision="${HFL_TEST_OLD_REVISION}"
+	[[ -f "${HFL_TEST_LOAD_MARKER}" ]] && revision="${HFL_TEST_NEW_REVISION}"
+	printf '[{"Config":{"Labels":{"org.opencontainers.image.revision":"%s"}}}]\n' "${revision}"
+	;;
+*)
+	printf 'unexpected fake docker invocation: %s\n' "$*" >&2
+	exit 2
+	;;
+esac
+SH
+chmod 755 "${fake_bin}/docker"
+
+new_revision="$(printf 'a%.0s' {1..40})"
+old_revision="$(printf 'b%.0s' {1..40})"
+export HFL_TEST_LOAD_MARKER="${marker}"
+export HFL_TEST_NEW_REVISION="${new_revision}"
+export HFL_TEST_OLD_REVISION="${old_revision}"
+export PATH="${fake_bin}:${PATH}"
+
+write_manifest "${new_revision}"
+source "${ROOT}/deploy/installer/install.sh"
+load_images_from_manifest 0 "${package_root}"
+[[ -f "${marker}" ]] || {
+	printf 'ERROR: installer skipped the verified archive when stale tags existed\n' >&2
+	exit 1
+}
+
+rm -f "${marker}"
+write_manifest "${old_revision}"
+if load_images_from_manifest 0 "${package_root}" 2>"${tmp}/mismatch.log"; then
+	printf 'ERROR: installer accepted an image revision that differed from the release\n' >&2
+	exit 1
+fi
+grep -F 'does not match release' "${tmp}/mismatch.log" >/dev/null
+
+printf 'Installer image refresh contracts passed.\n'


### PR DESCRIPTION
## Summary
- always load checksum-verified release image archives during install and upgrade
- stamp HFL backend/frontend images with their release version and source revision
- reject HFL images whose OCI revision does not match the Release manifest commit
- add a regression test for stale same-tag images and revision mismatches

## Root cause
A rebuilt v0.1.5 package contained the new backend digest, but the production installer skipped its archive because the same image tags already existed locally. The containers therefore restarted from the stale pre-fix image.

## Validation
- installer image refresh regression test
- Release contracts and synthetic CI release assembly
- Platform Gateway auto-deploy contracts
- shared-host Docker guard checks
- deployment optional configuration contracts
- English-only source and diff checks