### PR TITLE
fix(deploy): keep long-running agent installs alive

### DIFF
--- a/.github/workflows/deploy_target.yml
+++ b/.github/workflows/deploy_target.yml
@@ -225,6 +225,9 @@ jobs:
             -o BatchMode=yes \
             -o StrictHostKeyChecking=yes \
             -o ConnectTimeout=20 \
+            -o ServerAliveInterval=30 \
+            -o ServerAliveCountMax=20 \
+            -o TCPKeepAlive=yes \
             -p "$DEPLOY_SSH_PORT" \
             "$DEPLOY_SSH_USER@$DEPLOY_SSH_HOST" \
             "umask 077 && cat > /var/tmp/hyperfilelens-runtime-${GITHUB_RUN_ID}.env && chmod 0600 /var/tmp/hyperfilelens-runtime-${GITHUB_RUN_ID}.env" \
@@ -238,6 +241,9 @@ jobs:
             -o BatchMode=yes \
             -o StrictHostKeyChecking=yes \
             -o ConnectTimeout=20 \
+            -o ServerAliveInterval=30 \
+            -o ServerAliveCountMax=20 \
+            -o TCPKeepAlive=yes \
             -p "$DEPLOY_SSH_PORT" \
             "$DEPLOY_SSH_USER@$DEPLOY_SSH_HOST" \
             bash -s -- \
@@ -257,6 +263,9 @@ jobs:
               -o BatchMode=yes \
               -o StrictHostKeyChecking=yes \
               -o ConnectTimeout=20 \
+              -o ServerAliveInterval=30 \
+              -o ServerAliveCountMax=20 \
+              -o TCPKeepAlive=yes \
               -p "$DEPLOY_SSH_PORT" \
               "$DEPLOY_SSH_USER@$DEPLOY_SSH_HOST" \
               rm -f -- "/var/tmp/hyperfilelens-runtime-${GITHUB_RUN_ID}.env"
@@ -270,6 +279,9 @@ jobs:
             -o BatchMode=yes \
             -o StrictHostKeyChecking=yes \
             -o ConnectTimeout=20 \
+            -o ServerAliveInterval=30 \
+            -o ServerAliveCountMax=20 \
+            -o TCPKeepAlive=yes \
             -p "$DEPLOY_SSH_PORT" \
             "$DEPLOY_SSH_USER@$DEPLOY_SSH_HOST" \
             'curl -kfsS https://127.0.0.1:11443/health/ready >/dev/null && curl -kfsS https://127.0.0.1:11444/ >/dev/null && curl -kfsS https://127.0.0.1:11445/ >/dev/null'
@@ -314,6 +326,9 @@ jobs:
             -o BatchMode=yes \
             -o StrictHostKeyChecking=yes \
             -o ConnectTimeout=20 \
+            -o ServerAliveInterval=30 \
+            -o ServerAliveCountMax=20 \
+            -o TCPKeepAlive=yes \
             -p "$DEPLOY_SSH_PORT" \
             "$DEPLOY_SSH_USER@$DEPLOY_SSH_HOST" \
             'cd /opt/hyperfilelens && docker compose exec -T api python manage.py ensure_platform_ai_model' \

--- a/src/agent/internal/enroll/bundle.go
+++ b/src/agent/internal/enroll/bundle.go
@@ -1,8 +1,10 @@
 package enroll
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -22,19 +24,11 @@ func RunBundleUpgrade(ctx context.Context, archivePath string) error {
 			"upgrade", "-From", archivePath, "-QuietFooter",
 		}
 		cmd := exec.CommandContext(ctx, "powershell.exe", args...)
-		out, err := cmd.CombinedOutput()
-		if err != nil {
-			return commandError("Agent upgrade", err, out)
-		}
-		return nil
+		return runStreamingCommand(cmd, "Agent upgrade")
 	}
 	script := filepath.Join(installDir, "install.sh")
 	cmd := exec.CommandContext(ctx, script, "upgrade", "--from", archivePath, "--yes", "--quiet-footer")
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		return commandError("Agent upgrade", err, out)
-	}
-	return nil
+	return runStreamingCommand(cmd, "Agent upgrade")
 }
 
 // RunBundleInstall invokes the distribution install script with --no-start.
@@ -62,11 +56,7 @@ func runBundleInstallUnix(ctx context.Context, bundleRoot string, cfg Config) er
 	}
 	cmd := exec.CommandContext(ctx, script, args...)
 	cmd.Dir = bundleRoot
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		return commandError("Agent installation", err, out)
-	}
-	return nil
+	return runStreamingCommand(cmd, "Agent installation")
 }
 
 func runBundleInstallWindows(ctx context.Context, bundleRoot string, cfg Config) error {
@@ -86,9 +76,17 @@ func runBundleInstallWindows(ctx context.Context, bundleRoot string, cfg Config)
 	}
 	cmd := exec.CommandContext(ctx, "powershell.exe", args...)
 	cmd.Dir = bundleRoot
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		return commandError("Agent installation", err, out)
+	return runStreamingCommand(cmd, "Agent installation")
+}
+
+func runStreamingCommand(cmd *exec.Cmd, action string) error {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = io.MultiWriter(os.Stdout, &stdout)
+	cmd.Stderr = io.MultiWriter(os.Stderr, &stderr)
+	if err := cmd.Run(); err != nil {
+		captured := append(append([]byte{}, stdout.Bytes()...), stderr.Bytes()...)
+		return commandError(action, err, captured)
 	}
 	return nil
 }

--- a/src/agent/internal/enroll/bundle_test.go
+++ b/src/agent/internal/enroll/bundle_test.go
@@ -1,0 +1,27 @@
+package enroll
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestRunStreamingCommandReturnsCapturedFailureDetail(t *testing.T) {
+	t.Parallel()
+	cmd := exec.Command("sh", "-c", "printf 'visible output\\n'; printf 'install detail\\n' >&2; exit 7")
+	err := runStreamingCommand(cmd, "fixture install")
+	if err == nil {
+		t.Fatal("runStreamingCommand returned nil for a failing command")
+	}
+	if !strings.Contains(err.Error(), "install detail") {
+		t.Fatalf("error %q does not contain captured stderr detail", err)
+	}
+}
+
+func TestRunStreamingCommandReturnsSuccess(t *testing.T) {
+	t.Parallel()
+	cmd := exec.Command("sh", "-c", "printf 'streamed success\\n'")
+	if err := runStreamingCommand(cmd, "fixture install"); err != nil {
+		t.Fatalf("runStreamingCommand returned %v", err)
+	}
+}

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -238,6 +238,15 @@ for job in \
 done
 grep -F "if: \${{ vars.PREPROD_DEPLOY_ENABLED == 'true' }}" "${workflow}" >/dev/null
 grep -F "vars.PROD_DEPLOY_ENABLED == 'true'" "${workflow}" >/dev/null
+deploy_workflow="${ROOT}/.github/workflows/deploy_target.yml"
+[[ "$(grep -c -- '-o ServerAliveInterval=30' "${deploy_workflow}")" -eq 5 ]] || {
+	printf 'ERROR: every deployment SSH call must enable ServerAliveInterval\n' >&2
+	exit 1
+}
+[[ "$(grep -c -- '-o ServerAliveCountMax=20' "${deploy_workflow}")" -eq 5 ]] || {
+	printf 'ERROR: every deployment SSH call must set ServerAliveCountMax\n' >&2
+	exit 1
+}
 grep -F 'repository: hyperfilelens-backend' "${workflow}" >/dev/null
 grep -F 'repository: hyperfilelens-frontend' "${workflow}" >/dev/null
 grep -F '"$REGISTRY_PREFIX"' "${workflow}" >/dev/null


### PR DESCRIPTION
## Summary
- stream Agent install/upgrade subprocess output while retaining failure details
- enable SSH server keepalives for every automated deployment SSH call
- enforce the keepalive contract in release checks
- add tests for streamed success and captured failure output

## Root cause
The corrected Ubuntu 20.04 Agent package reached its NAS dependency installation, but the enrollment helper buffered all installer output. After about five idle minutes the GitHub-to-production SSH connection was dropped with exit 255.

## Validation
- full Agent Go test suite
- release contract checks
- English-only source and diff checks