### PR TITLE
fix(ai): use the bundled SourceLens test endpoint

### DIFF
--- a/src/backend/apps/lens_bridge/services/deployment_ai_model.py
+++ b/src/backend/apps/lens_bridge/services/deployment_ai_model.py
@@ -196,8 +196,12 @@ def _test_connection(config_uuid: uuid.UUID) -> bool:
     try:
         response = sl_client.request_json(
             "POST",
-            f"/api/v1/admin/llm-config/{config_uuid}/test-call/",
-            json_body={},
+            "/api/v1/admin/llm-config/test-call/",
+            json_body={
+                "config_uuid": str(config_uuid),
+                "prompt": "Respond with exactly OK and no explanation.",
+                "max_tokens": 512,
+            },
             timeout=90,
         )
     except sl_client.LensBridgeError:

--- a/src/backend/apps/lens_bridge/tests/test_deployment_ai_model.py
+++ b/src/backend/apps/lens_bridge/tests/test_deployment_ai_model.py
@@ -65,6 +65,16 @@ class DeploymentAiModelServiceTests(TestCase):
         create_payload = request_json.call_args_list[0].kwargs["json_body"]
         self.assertTrue(create_payload["is_default"])
         self.assertEqual(create_payload["config"]["api_key"], "deployment-secret")
+        request_json.assert_any_call(
+            "POST",
+            "/api/v1/admin/llm-config/test-call/",
+            json_body={
+                "config_uuid": str(self.model_uuid),
+                "prompt": "Respond with exactly OK and no explanation.",
+                "max_tokens": 512,
+            },
+            timeout=90,
+        )
         link = LensOrgModelLink.objects.get(
             management_key=deployment_ai_model.DEPLOYMENT_MODEL_MANAGEMENT_KEY
         )


### PR DESCRIPTION
## Summary
- call the SourceLens 0.4.0 saved-model test endpoint
- pass the managed config UUID in the expected request body
- allow enough completion tokens for reasoning models to return visible content
- assert the exact compatibility request in backend tests

## Root cause
The model was created successfully, but HFL called a per-config test-call URL that bundled SourceLens 0.4.0 does not expose, so every deployment reported a false 404 connectivity failure. A production diagnostic against the supported endpoint reached the configured provider and passed with 512 tokens.

## Validation
- production-compatible endpoint returned HFL_TEST_CALL_OK=True without exposing the API key
- Ruff checks passed
- diff checks passed
- full Django suite will run in the PostgreSQL-backed GitHub quality job