### PR TITLE
fix(release): harden deployment and upgrade safeguards

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -466,6 +466,15 @@ GOSUMDB=sum.golang.org
 # Kopia command timeout in seconds.
 # HFL_KOPIA_TIMEOUT_SECONDS=120
 
+# Maximum number of timestamped upgrade backup sets to retain.
+# HFL_BACKUP_RETENTION_COUNT=3
+
+# Maximum age of upgrade backup sets in days.
+# HFL_BACKUP_RETENTION_DAYS=30
+
+# Maximum combined upgrade backup size in bytes (default: 10 GiB).
+# HFL_BACKUP_RETENTION_BYTES=10737418240
+
 # Enable periodic storage maintenance.
 # STORAGE_MAINTENANCE_ENABLED=true
 

--- a/.github/scripts/remote-deploy.sh
+++ b/.github/scripts/remote-deploy.sh
@@ -362,8 +362,6 @@ if [[ -n "${RUNTIME_ENV_FILE}" ]]; then
 	RUNTIME_ENV_FILE=""
 fi
 
-bash "${INSTALL_DIR}/install.sh" platform-gateway ensure
-
 if verify_unrelated_state "${work}/unrelated-before.json" "${work}/unrelated-after.json"; then
 	shared_host_guard_verified=1
 else

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -29,7 +29,7 @@ jobs:
       tag: ${{ steps.version.outputs.tag }}
       commit: ${{ steps.version.outputs.commit }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           fetch-depth: 0
 
@@ -111,20 +111,20 @@ jobs:
       SECRET_KEY: ci-only-secret-key-with-at-least-32-bytes
       DJANGO_DEBUG: "true"
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "22"
           cache: npm
           cache-dependency-path: src/frontend/package-lock.json
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: src/agent/go.mod
           cache-dependency-path: src/agent/go.sum
-      - uses: astral-sh/setup-uv@v6
+      - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
         with:
           version: "0.10.2"
           enable-cache: true
@@ -143,6 +143,7 @@ jobs:
           ./tools/quality/test-platform-gateway-auto-deploy.sh
           ./tools/quality/test-agent-gateway-uninstall.sh
           ./tools/quality/test-installer-image-refresh.sh
+          ./tools/quality/test-upgrade-backup-retention.sh
           ./tools/quality/test-shared-host-guard.sh
           ./tools/quality/test-deployment-optional-config.sh
           ./tools/quality/test-payload-tree-hash.sh
@@ -196,14 +197,14 @@ jobs:
             cache_scope: hfl-frontend
             needs_kopia: false
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         if: matrix.needs_kopia
         with:
           go-version: stable
           cache: false
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY_HOST }}
           username: ${{ secrets.REGISTRY_USERNAME }}
@@ -215,7 +216,7 @@ jobs:
 
       - name: Build and push image
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}
@@ -267,9 +268,9 @@ jobs:
       matrix:
         component: [backend, frontend, lensnode]
     steps:
-      - uses: actions/checkout@v4
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY_HOST }}
           username: ${{ secrets.REGISTRY_USERNAME }}
@@ -320,8 +321,8 @@ jobs:
           - target: windows:amd64
             asset: windows-amd64
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: src/agent/go.mod
           cache-dependency-path: src/agent/go.sum
@@ -379,8 +380,8 @@ jobs:
             asset: windows-amd64
             runner: windows-2022
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
       - name: Download immutable Agent candidate
@@ -401,6 +402,17 @@ jobs:
           --expected-platform "${{ matrix.platform }}"
           --expected-arch "${{ matrix.arch }}"
           --report "build/certification/_internal-agent-cert-${{ matrix.asset }}.json"
+      - name: Verify Ubuntu Agent bundles offline
+        if: ${{ matrix.target == 'linux:amd64' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          for ubuntu_release in 20.04 24.04; do
+            ./release/ci/verify-ubuntu-agent-bundle.sh \
+              "build/agent-candidate/_internal-agent-${{ matrix.asset }}.tar.gz" \
+              "${{ needs.prepare.outputs.version }}" \
+              "$ubuntu_release"
+          done
       - name: Upload certification evidence
         if: always()
         env:
@@ -419,8 +431,8 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
       - name: Download Agent candidates and certification evidence
@@ -470,12 +482,17 @@ jobs:
           - ubuntu_release: "24.04"
             asset: ubuntu2404
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
       - name: Build host dependency asset
         env:
           APT_MIRROR: ${{ vars.CI_UBUNTU_APT_MIRROR }}
         run: >-
           ./release/ci/build-host-debs-asset.sh
+          "${{ matrix.ubuntu_release }}"
+          "_internal-host-debs-${{ matrix.asset }}.tar.gz"
+      - name: Verify host dependencies install offline
+        run: >-
+          ./release/ci/verify-host-debs-asset.sh
           "${{ matrix.ubuntu_release }}"
           "_internal-host-debs-${{ matrix.asset }}.tar.gz"
       - name: Upload host dependency asset
@@ -492,8 +509,8 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: docker/login-action@v3
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY_HOST }}
           username: ${{ secrets.REGISTRY_USERNAME }}
@@ -523,8 +540,8 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: docker/login-action@v3
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY_HOST }}
           username: ${{ secrets.REGISTRY_USERNAME }}
@@ -556,8 +573,8 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: docker/login-action@v3
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY_HOST }}
           username: ${{ secrets.REGISTRY_USERNAME }}
@@ -582,7 +599,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
       - name: Download matrix bundles
         env:
           GH_TOKEN: ${{ github.token }}
@@ -621,7 +638,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
       - name: Reclaim unused runner toolchains
         run: |
           sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc

--- a/.github/workflows/deploy_target.yml
+++ b/.github/workflows/deploy_target.yml
@@ -113,7 +113,7 @@ jobs:
       DEPLOY_SSH_USER: ${{ inputs.ssh_user }}
       DEPLOY_SSH_KNOWN_HOSTS: ${{ inputs.ssh_known_hosts }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
 
       - name: Validate deployment configuration
         env:
@@ -337,15 +337,15 @@ jobs:
           set -e
           printf '%s\n' "$output"
           if (( command_status != 0 )); then
-            echo '::warning title=AI model deployment::Unable to apply the deployment-managed model; core deployment remains healthy.'
-            printf '### AI model deployment\n\nWarning: model configuration could not be applied. Core deployment remains healthy.\n' >> "$GITHUB_STEP_SUMMARY"
+            echo '::error title=AI model deployment::Unable to apply the configured deployment-managed model.'
+            printf '### AI model deployment\n\nFailed: configured model could not be created or updated.\n' >> "$GITHUB_STEP_SUMMARY"
+            exit "$command_status"
           elif grep -F 'HFL_AI_MODEL_CONNECTIVITY=failed' <<<"$output" >/dev/null; then
             echo '::warning title=AI model connectivity::The model was saved, but its connectivity test failed.'
             printf '### AI model deployment\n\nWarning: model configuration was applied, but the connectivity test failed.\n' >> "$GITHUB_STEP_SUMMARY"
           else
             printf '### AI model deployment\n\nPassed: deployment-managed model was applied and tested successfully.\n' >> "$GITHUB_STEP_SUMMARY"
           fi
-          exit 0
 
       - name: Optional public endpoint check
         shell: bash

--- a/deploy/installer/install.sh
+++ b/deploy/installer/install.sh
@@ -922,11 +922,10 @@ PY
 }
 
 backup_env_and_data() {
-	local stamp archive rc
-	stamp="$(date +%Y%m%d-%H%M%S)"
+	local stamp=$1 archive rc
 	mkdir -p "${ROOT}/backup"
 	archive="${ROOT}/backup/hyperfilelens-backup-${stamp}.tar.gz"
-	step "Backing up .env, TLS certificates, and data/ -> ${archive} ..."
+	step "Backing up config and non-database data -> ${archive} ..."
 	local -a items=()
 	[[ -f "${ROOT}/.env" ]] && items+=(".env")
 	[[ -d "${ROOT}/deploy/nginx/certs" ]] && items+=("deploy/nginx/certs")
@@ -936,7 +935,14 @@ backup_env_and_data() {
 		return 0
 	fi
 	set +e
-	tar -czf "${archive}" -C "${ROOT}" "${items[@]}"
+	tar -czf "${archive}" \
+		--exclude='data/postgresql' \
+		--exclude='data/sourcelens/postgresql' \
+		--exclude='data/redis' \
+		--exclude='data/sourcelens/redis' \
+		--exclude='data/logs' \
+		--exclude='data/sourcelens/logs' \
+		-C "${ROOT}" "${items[@]}"
 	rc=$?
 	set -e
 	if [[ "${rc}" -gt 1 ]]; then
@@ -949,6 +955,7 @@ backup_env_and_data() {
 }
 
 backup_postgresql_dump() {
+	local stamp=$1
 	[[ -f "${ROOT}/.env" ]] || return 0
 	if ! command -v docker >/dev/null 2>&1 \
 		|| ! docker info >/dev/null 2>&1 \
@@ -963,8 +970,7 @@ backup_postgresql_dump() {
 		return 0
 	fi
 	[[ -n "${cid}" ]] || { warn "PostgreSQL is not running; skipping logical database dump"; return 0; }
-	local stamp dump globals
-	stamp="$(date +%Y%m%d-%H%M%S)"
+	local dump globals
 	mkdir -p "${ROOT}/backup"
 	dump="${ROOT}/backup/hyperfilelens-postgresql-${stamp}.dump"
 	globals="${ROOT}/backup/hyperfilelens-postgresql-globals-${stamp}.sql"
@@ -1002,6 +1008,70 @@ backup_postgresql_dump() {
 			ok "Bundled SourceLens PostgreSQL logical backup created"
 		fi
 	fi
+}
+
+prune_upgrade_backups() {
+	local retention_count retention_days retention_bytes
+	retention_count="${HFL_BACKUP_RETENTION_COUNT:-$(read_env_value HFL_BACKUP_RETENTION_COUNT)}"
+	retention_days="${HFL_BACKUP_RETENTION_DAYS:-$(read_env_value HFL_BACKUP_RETENTION_DAYS)}"
+	retention_bytes="${HFL_BACKUP_RETENTION_BYTES:-$(read_env_value HFL_BACKUP_RETENTION_BYTES)}"
+	retention_count="${retention_count:-3}"
+	retention_days="${retention_days:-30}"
+	retention_bytes="${retention_bytes:-10737418240}"
+	[[ "${retention_count}" =~ ^[1-9][0-9]*$ ]] \
+		|| die "HFL_BACKUP_RETENTION_COUNT must be a positive integer"
+	[[ "${retention_days}" =~ ^[1-9][0-9]*$ ]] \
+		|| die "HFL_BACKUP_RETENTION_DAYS must be a positive integer"
+	[[ "${retention_bytes}" =~ ^[1-9][0-9]*$ ]] \
+		|| die "HFL_BACKUP_RETENTION_BYTES must be a positive integer"
+
+	python3 - "${ROOT}/backup" "${retention_count}" "${retention_days}" "${retention_bytes}" <<'PY'
+import datetime as dt
+import pathlib
+import re
+import sys
+
+root = pathlib.Path(sys.argv[1])
+retention_count = int(sys.argv[2])
+retention_days = int(sys.argv[3])
+retention_bytes = int(sys.argv[4])
+pattern = re.compile(
+    r"^(?:hyperfilelens-backup|hyperfilelens-postgresql(?:-globals)?|"
+    r"sourcelens-postgresql(?:-globals)?)-"
+    r"(?P<stamp>\d{8}-\d{6})\.(?:tar\.gz|dump|sql)(?:\.part)?$"
+)
+groups = {}
+paths = root.iterdir() if root.is_dir() else ()
+for path in paths:
+    match = pattern.fullmatch(path.name)
+    if match and path.is_file():
+        groups.setdefault(match.group("stamp"), []).append(path)
+
+if not groups:
+    raise SystemExit(0)
+
+ordered = sorted(groups, reverse=True)
+newest = ordered[0]
+cutoff = dt.datetime.now() - dt.timedelta(days=retention_days)
+keep = set(ordered[:retention_count])
+for stamp in ordered:
+    created = dt.datetime.strptime(stamp, "%Y%m%d-%H%M%S")
+    if created < cutoff and stamp != newest:
+        keep.discard(stamp)
+
+def group_size(stamp):
+    return sum(path.stat().st_size for path in groups[stamp] if path.exists())
+
+while sum(group_size(stamp) for stamp in keep) > retention_bytes and len(keep) > 1:
+    keep.remove(min(keep))
+
+for stamp in ordered:
+    if stamp in keep:
+        continue
+    for path in groups[stamp]:
+        print(f"[install.sh] pruning expired upgrade backup {path.name}")
+        path.unlink(missing_ok=True)
+PY
 }
 
 apply_upgrade_files() {
@@ -2328,7 +2398,7 @@ cmd_uninstall() {
 cmd_upgrade() {
 	local from=""
 	local sourcelens_mode=-1 remove_sourcelens=0 purge_sourcelens_data=0
-	local src_root new_version cur_version upgrade_sourcelens=0
+	local src_root new_version cur_version upgrade_sourcelens=0 backup_stamp
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
 		--from)
@@ -2368,8 +2438,10 @@ cmd_upgrade() {
 	log "Upgrading: ${cur_version} -> ${new_version}"
 
 	step "[1/7] Backing up current config and data ..."
-	backup_postgresql_dump
-	backup_env_and_data
+	backup_stamp="$(date +%Y%m%d-%H%M%S)"
+	backup_postgresql_dump "${backup_stamp}"
+	backup_env_and_data "${backup_stamp}"
+	prune_upgrade_backups
 
 	step "[2/7] Validating upgrade package ..."
 	validate_publish_artifacts "${src_root}"

--- a/release/ci/verify-host-debs-asset.sh
+++ b/release/ci/verify-host-debs-asset.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Install one offline Docker CE dependency asset in its matching Ubuntu image.
+set -euo pipefail
+
+[[ $# -eq 2 ]] || {
+	printf 'Usage: %s UBUNTU_RELEASE HOST_DEBS_ASSET\n' "$0" >&2
+	exit 2
+}
+ubuntu_release=$1
+asset=$2
+case "${ubuntu_release}" in
+20.04) release_id=2004 ;;
+24.04) release_id=2404 ;;
+*) printf 'ERROR: unsupported Ubuntu release: %s\n' "${ubuntu_release}" >&2; exit 2 ;;
+esac
+[[ -s "${asset}" ]] || { printf 'ERROR: host dependency asset is missing\n' >&2; exit 2; }
+command -v docker >/dev/null 2>&1 || { printf 'ERROR: docker is required\n' >&2; exit 2; }
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "${tmp}"' EXIT
+tar -xzf "${asset}" -C "${tmp}"
+archive="${tmp}/payload/media/gateway-bootstrap/docker-debs-ubuntu${release_id}-amd64.tar.gz"
+[[ -s "${archive}" ]] || { printf 'ERROR: nested Docker deb archive is missing\n' >&2; exit 1; }
+mkdir -p "${tmp}/debs"
+tar -xzf "${archive}" -C "${tmp}/debs"
+compgen -G "${tmp}/debs/*.deb" >/dev/null \
+	|| { printf 'ERROR: Docker deb archive contains no packages\n' >&2; exit 1; }
+
+image="ubuntu:${ubuntu_release}"
+docker image inspect "${image}" >/dev/null 2>&1 || docker pull "${image}"
+docker run --rm --pull=never --network none \
+	-v "${tmp}/debs:/offline-debs:ro" \
+	"${image}" bash -euo pipefail -c '
+printf "#!/bin/sh\nexit 101\n" >/usr/sbin/policy-rc.d
+chmod 0755 /usr/sbin/policy-rc.d
+export DEBIAN_FRONTEND=noninteractive
+dpkg -i /offline-debs/*.deb
+[[ -z "$(dpkg --audit)" ]]
+docker --version
+dockerd --version
+containerd --version
+docker compose version
+docker buildx version
+'
+printf 'Offline Docker dependency verification passed for Ubuntu %s\n' "${ubuntu_release}"

--- a/release/ci/verify-ubuntu-agent-bundle.sh
+++ b/release/ci/verify-ubuntu-agent-bundle.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Execute one Ubuntu-specific Agent bundle with its debs and networking disabled.
+set -euo pipefail
+
+[[ $# -eq 3 ]] || {
+	printf 'Usage: %s INTERNAL_AGENT_BUNDLE VERSION UBUNTU_RELEASE\n' "$0" >&2
+	exit 2
+}
+internal_bundle=$1
+version=${2#v}
+ubuntu_release=$3
+case "${ubuntu_release}" in
+20.04) flavor=ubuntu2004 ;;
+24.04) flavor=ubuntu2404 ;;
+*) printf 'ERROR: unsupported Ubuntu release: %s\n' "${ubuntu_release}" >&2; exit 2 ;;
+esac
+[[ -s "${internal_bundle}" ]] \
+	|| { printf 'ERROR: internal Agent bundle is missing\n' >&2; exit 2; }
+command -v docker >/dev/null 2>&1 || { printf 'ERROR: docker is required\n' >&2; exit 2; }
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "${tmp}"' EXIT
+tar -xzf "${internal_bundle}" -C "${tmp}"
+archive="${tmp}/payload/media/agent-releases/${version}/hfl-agent-${version}-linux-amd64-${flavor}.tar.gz"
+[[ -s "${archive}" ]] \
+	|| { printf 'ERROR: Ubuntu-specific Agent archive is missing: %s\n' "${archive}" >&2; exit 1; }
+mkdir -p "${tmp}/agent"
+tar -xzf "${archive}" -C "${tmp}/agent"
+mapfile -t roots < <(find "${tmp}/agent" -mindepth 1 -maxdepth 1 -type d -print)
+[[ "${#roots[@]}" -eq 1 ]] \
+	|| { printf 'ERROR: Agent archive must contain one root directory\n' >&2; exit 1; }
+root="${roots[0]}"
+deps="${root}/deps/${flavor}/amd64"
+compgen -G "${deps}/*.deb" >/dev/null \
+	|| { printf 'ERROR: Ubuntu-specific Agent debs are missing\n' >&2; exit 1; }
+
+image="ubuntu:${ubuntu_release}"
+docker image inspect "${image}" >/dev/null 2>&1 || docker pull "${image}"
+docker run --rm --pull=never --network none \
+	-v "${root}:/agent:ro" \
+	"${image}" bash -euo pipefail -c '
+printf "#!/bin/sh\nexit 101\n" >/usr/sbin/policy-rc.d
+chmod 0755 /usr/sbin/policy-rc.d
+export DEBIAN_FRONTEND=noninteractive
+dpkg -i /agent/deps/'"${flavor}"'/amd64/*.deb
+[[ -z "$(dpkg --audit)" ]]
+bash -n /agent/install.sh
+/agent/bin/hfl-agent -version
+/agent/bin/kopia --version
+'
+printf 'Offline Agent bundle verification passed for Ubuntu %s\n' "${ubuntu_release}"

--- a/src/backend/apps/iam/tests/test_turnstile_service.py
+++ b/src/backend/apps/iam/tests/test_turnstile_service.py
@@ -2,13 +2,21 @@
 
 from unittest.mock import MagicMock, patch
 
-from django.test import SimpleTestCase, override_settings
+from django.test import SimpleTestCase
 
 from apps.iam.services.turnstile_service import validate_turnstile
 
 
-@override_settings(TURNSTILE_SECRET_KEY="secret-key")
 class TurnstileServiceTests(SimpleTestCase):
+    def setUp(self):
+        super().setUp()
+        secret_patcher = patch(
+            "apps.platform_ops.services.internal.runtime_settings.turnstile_secret_key",
+            return_value="secret-key",
+        )
+        secret_patcher.start()
+        self.addCleanup(secret_patcher.stop)
+
     def _response(self, *, action: str = "login", hostname: str = "app.example.com"):
         response = MagicMock()
         response.json.return_value = {

--- a/src/backend/apps/platform_ops/api/views/system.py
+++ b/src/backend/apps/platform_ops/api/views/system.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import re
 from collections import Counter, deque
@@ -88,22 +89,54 @@ _LOG_LINE = re.compile(
     r"(?P<message>.*)$"
 )
 _LOG_LEVEL = re.compile(r"\b(DEBUG|INFO|WARNING|WARN|ERROR|CRITICAL|FATAL)\b", re.I)
-_SENSITIVE_VALUE = re.compile(
-    r"(?i)(password|secret|token|api[_-]?key)"
-    r"(\s*[:=]\s*)([^\s,;]+)"
-)
+_SENSITIVE_KEY = re.compile(r"(?i)(password|passwd|secret|token|api[_-]?key)")
+_SENSITIVE_HEADER_KEY = frozenset({"authorization", "cookie", "set-cookie"})
 _SENSITIVE_HEADER = re.compile(
-    r"(?i)(authorization|cookie)(\s*[:=]\s*)(.+)$"
+    r"(?i)([\"']?(?:authorization|cookie|set-cookie)[\"']?\s*[:=]\s*)"
+    r"(?:\"[^\"]*\"|'[^']*'|[^\r\n]+)"
 )
+_SENSITIVE_VALUE = re.compile(
+    r"(?i)([\"']?[A-Za-z0-9_-]*"
+    r"(?:password|passwd|secret|token|api[_-]?key)"
+    r"[A-Za-z0-9_-]*[\"']?\s*[:=]\s*)"
+    r"(?:\"[^\"]*\"|'[^']*'|[^\s,;]+)"
+)
+
+
+def _sensitive_log_key(value: object) -> bool:
+    normalized = str(value).strip().lower()
+    return normalized in _SENSITIVE_HEADER_KEY or bool(_SENSITIVE_KEY.search(normalized))
+
+
+def _redact_structured_log(value: object) -> object:
+    if isinstance(value, dict):
+        return {
+            key: "[REDACTED]" if _sensitive_log_key(key) else _redact_structured_log(item)
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [_redact_structured_log(item) for item in value]
+    return value
 
 
 def _redact_log_message(value: str) -> str:
+    try:
+        structured = json.loads(value)
+    except (TypeError, json.JSONDecodeError):
+        structured = None
+    if isinstance(structured, (dict, list)):
+        return json.dumps(
+            _redact_structured_log(structured),
+            ensure_ascii=False,
+            separators=(",", ":"),
+        )
+
     redacted = _SENSITIVE_HEADER.sub(
-        lambda match: f"{match.group(1)}{match.group(2)}[REDACTED]",
+        lambda match: f"{match.group(1)}[REDACTED]",
         value,
     )
     return _SENSITIVE_VALUE.sub(
-        lambda match: f"{match.group(1)}{match.group(2)}[REDACTED]",
+        lambda match: f"{match.group(1)}[REDACTED]",
         redacted,
     )
 

--- a/src/backend/apps/platform_ops/selectors/internal/overview.py
+++ b/src/backend/apps/platform_ops/selectors/internal/overview.py
@@ -255,6 +255,18 @@ def _activity_series(*, since: datetime, until: datetime, hours: int) -> list[di
     ]
 
 
+def _failed_task_count(*, since: datetime, until: datetime) -> int:
+    """Count failed and timed-out tasks whose terminal update is in range."""
+    return (
+        Task.objects.filter(
+            status__in=[Task.Status.FAILED, Task.Status.TIMEOUT],
+        )
+        .annotate(activity_at=Coalesce("finished_at", "updated_at"))
+        .filter(activity_at__gte=since, activity_at__lte=until)
+        .count()
+    )
+
+
 def platform_overview_payload(*, hours: int) -> dict[str, Any]:
     """Build the complete read-only Admin Console overview response."""
 
@@ -277,7 +289,7 @@ def platform_overview_payload(*, hours: int) -> dict[str, Any]:
         "alerts_firing": summary["alerts_firing"],
         "alerts_acknowledged": summary["alerts_acknowledged"],
         "tasks_running": summary["tasks_running"],
-        "tasks_failed_in_range": summary["tasks_failed_24h"],
+        "tasks_failed_in_range": _failed_task_count(since=since, until=now),
         "tasks_failed_24h": summary["tasks_failed_24h"],
         "tasks_failed_total": summary["tasks_failed_total"],
         "notifications_failed_in_range": notification_failures,

--- a/src/backend/apps/platform_ops/services/internal/runtime_settings.py
+++ b/src/backend/apps/platform_ops/services/internal/runtime_settings.py
@@ -54,8 +54,6 @@ SECRET_KEY_GEMINI = "ai.gemini_api_key"
 SECRET_KEY_LANGFUSE_PUBLIC = "ai.langfuse_public_key"
 SECRET_KEY_LANGFUSE_SECRET = "ai.langfuse_secret_key"
 
-_CACHE: dict[str, PlatformRuntimeSetting] | None = None
-
 SMTP_EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
 CONSOLE_EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 DUMMY_EMAIL_BACKEND = "django.core.mail.backends.dummy.EmailBackend"
@@ -78,19 +76,17 @@ EMAIL_RUNTIME_KEYS = (
 
 
 def invalidate_runtime_settings_cache() -> None:
-    global _CACHE
-    _CACHE = None
+    """Retained compatibility hook for callers that update runtime settings.
 
-
-def _rows_by_key() -> dict[str, PlatformRuntimeSetting]:
-    global _CACHE
-    if _CACHE is None:
-        _CACHE = {row.key: row for row in PlatformRuntimeSetting.objects.all()}
-    return _CACHE
+    Runtime settings are intentionally read from PostgreSQL on every access.
+    Process-local caching made security and AI settings remain stale in Celery,
+    Daphne, additional Gunicorn workers, and horizontally scaled API replicas.
+    """
 
 
 def _row(key: str) -> PlatformRuntimeSetting | None:
-    return _rows_by_key().get(key)
+    """Read one current setting without process-local caching."""
+    return PlatformRuntimeSetting.objects.filter(key=key).first()
 
 
 def _env_str(name: str, default: str = "") -> str:
@@ -118,10 +114,9 @@ def _runtime_raw(key: str) -> tuple[str, bool]:
 
 
 def get_source(key: str) -> str:
-    if _row(key) is not None:
-        row = _row(key)
-        if row and (row.secret_ciphertext or (row.value_text or "").strip()):
-            return "runtime"
+    row = _row(key)
+    if row and (row.secret_ciphertext or (row.value_text or "").strip()):
+        return "runtime"
     return "env"
 
 
@@ -452,7 +447,7 @@ def email_settings_managed_by_deployment() -> bool:
 
 
 def _runtime_email_configured() -> bool:
-    return any(_row(key) is not None for key in EMAIL_RUNTIME_KEYS)
+    return PlatformRuntimeSetting.objects.filter(key__in=EMAIL_RUNTIME_KEYS).exists()
 
 
 def email_connection_kwargs() -> dict[str, Any]:

--- a/src/backend/apps/platform_ops/tests/test_overview_ranges.py
+++ b/src/backend/apps/platform_ops/tests/test_overview_ranges.py
@@ -1,0 +1,33 @@
+from datetime import timedelta
+
+from django.test import TestCase
+from django.utils import timezone
+
+from apps.platform_ops.selectors.internal.overview import _failed_task_count
+from apps.task.models import Task
+
+
+class PlatformOverviewRangeTests(TestCase):
+    def _task(self, *, status: str, finished_at) -> Task:
+        return Task.objects.create(
+            organization_id=1,
+            task_type=Task.Type.BACKUP,
+            display_name=f"Task {status}",
+            status=status,
+            finished_at=finished_at,
+        )
+
+    def test_failed_task_count_uses_requested_time_range(self):
+        now = timezone.now()
+        self._task(status=Task.Status.FAILED, finished_at=now - timedelta(minutes=30))
+        self._task(status=Task.Status.TIMEOUT, finished_at=now - timedelta(hours=2))
+        self._task(status=Task.Status.SUCCESS, finished_at=now - timedelta(minutes=10))
+
+        self.assertEqual(
+            _failed_task_count(since=now - timedelta(hours=1), until=now),
+            1,
+        )
+        self.assertEqual(
+            _failed_task_count(since=now - timedelta(hours=3), until=now),
+            2,
+        )

--- a/src/backend/apps/platform_ops/tests/test_runtime_settings_consistency.py
+++ b/src/backend/apps/platform_ops/tests/test_runtime_settings_consistency.py
@@ -1,0 +1,21 @@
+from django.test import TestCase, override_settings
+
+from apps.platform_ops.models import PlatformRuntimeSetting
+from apps.platform_ops.services.internal.runtime_settings import (
+    KEY_IDENTITY_PLATFORM_OPS,
+    platform_ops_enabled,
+)
+
+
+@override_settings(HFL_PLATFORM_OPS_ENABLED=True)
+class RuntimeSettingsConsistencyTests(TestCase):
+    def test_external_database_update_is_visible_without_local_invalidation(self):
+        setting = PlatformRuntimeSetting.objects.create(
+            key=KEY_IDENTITY_PLATFORM_OPS,
+            value_text="false",
+        )
+        self.assertFalse(platform_ops_enabled())
+
+        PlatformRuntimeSetting.objects.filter(pk=setting.pk).update(value_text="true")
+
+        self.assertTrue(platform_ops_enabled())

--- a/src/backend/apps/platform_ops/tests/test_system_logs.py
+++ b/src/backend/apps/platform_ops/tests/test_system_logs.py
@@ -24,6 +24,31 @@ class PlatformSystemLogTests(SimpleTestCase):
         self.assertNotIn("provider-key", redacted)
         self.assertIn("authorization: [REDACTED]", redacted)
 
+    def test_nested_json_secrets_are_redacted(self):
+        message = (
+            '{"request":{"api_key":"provider-key","safe":"visible"},'
+            '"Authorization":"Bearer live-token","items":[{"password":"secret"}]}'
+        )
+
+        redacted = _redact_log_message(message)
+
+        self.assertNotIn("provider-key", redacted)
+        self.assertNotIn("live-token", redacted)
+        self.assertNotIn("secret", redacted)
+        self.assertIn('"safe":"visible"', redacted)
+        self.assertEqual(redacted.count("[REDACTED]"), 3)
+
+    def test_embedded_json_style_secret_is_redacted(self):
+        redacted = _redact_log_message(
+            'request payload={"turnstile_secret_key":"provider-key",'
+            '"accessToken":"live-token"} status=failed'
+        )
+
+        self.assertNotIn("provider-key", redacted)
+        self.assertNotIn("live-token", redacted)
+        self.assertIn('"turnstile_secret_key":[REDACTED]', redacted)
+        self.assertIn('"accessToken":[REDACTED]', redacted)
+
     def test_reads_and_orders_recent_log_rows(self):
         with TemporaryDirectory() as root:
             log_path = Path(root) / "api.log"

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -195,6 +195,8 @@ grep -F 'python manage.py ensure_platform_ai_model' \
 	"${ROOT}/.github/workflows/deploy_target.yml" >/dev/null
 grep -F 'HFL_AI_MODEL_CONNECTIVITY=failed' \
 	"${ROOT}/.github/workflows/deploy_target.yml" >/dev/null
+grep -F 'exit "$command_status"' \
+	"${ROOT}/.github/workflows/deploy_target.yml" >/dev/null
 if grep -F '"AI_MODEL_API_KEY=$AI_MODEL_API_KEY"' \
 	"${ROOT}/.github/workflows/deploy_target.yml" >/dev/null; then
 	printf 'ERROR: AI model API key must not be persisted in the runtime .env\n' >&2
@@ -378,6 +380,10 @@ remote_deploy="${ROOT}/.github/scripts/remote-deploy.sh"
 grep -F 'browser_download_url' "${remote_deploy}" >/dev/null
 grep -F 'bash "${package_root}/install.sh" "${install_args[@]}"' \
 	"${remote_deploy}" >/dev/null
+if grep -F 'install.sh" platform-gateway ensure' "${remote_deploy}" >/dev/null; then
+	printf 'ERROR: remote deployment must not repeat installer-owned Gateway ensure\n' >&2
+	exit 1
+fi
 grep -F -- '--public-url) PUBLIC_URL=' "${remote_deploy}" >/dev/null
 grep -F -- '--direct-host) DIRECT_HOST=' "${remote_deploy}" >/dev/null
 grep -F -- '--runtime-env-file "${RUNTIME_ENV_FILE}"' "${remote_deploy}" >/dev/null
@@ -441,6 +447,13 @@ if grep -E 'sourcelens_compose (ps -q|exec -T) postgresql' <<<"${backup_body}" >
 	printf 'ERROR: bundled SourceLens PostgreSQL Compose service is named postgres\n' >&2
 	exit 1
 fi
+file_backup_body="$(sed -n '/^backup_env_and_data()/,/^}/p' "${installer}")"
+grep -F -- "--exclude='data/postgresql'" <<<"${file_backup_body}" >/dev/null
+grep -F -- "--exclude='data/sourcelens/postgresql'" <<<"${file_backup_body}" >/dev/null
+grep -F 'prune_upgrade_backups' "${installer}" >/dev/null
+grep -F 'HFL_BACKUP_RETENTION_COUNT' "${installer}" >/dev/null
+grep -F 'HFL_BACKUP_RETENTION_DAYS' "${installer}" >/dev/null
+grep -F 'HFL_BACKUP_RETENTION_BYTES' "${installer}" >/dev/null
 grep -F 'python3 "${sync_script}" --env-file "${env_file}" --example "${example}"' "${installer}" >/dev/null
 grep -F 'host must be Ubuntu 20.04 or 24.04' "${installer}" >/dev/null
 grep -F 'gateway-install-docker-ubuntu-amd64.sh' "${installer}" >/dev/null
@@ -448,6 +461,26 @@ grep -F 'docker-debs-ubuntu2004-amd64.tar.gz' "${installer}" >/dev/null
 grep -F 'docker-debs-ubuntu2404-amd64.tar.gz' "${installer}" >/dev/null
 if grep -E 'tomllib|extractall\([^)]*filter=' "${installer}" >/dev/null; then
 	printf 'ERROR: installer contains Python APIs unavailable on Ubuntu 20.04\n' >&2
+	exit 1
+fi
+
+grep -F 'verify-host-debs-asset.sh' \
+	"${ROOT}/.github/workflows/build_and_deploy.yml" >/dev/null
+grep -F 'verify-ubuntu-agent-bundle.sh' \
+	"${ROOT}/.github/workflows/build_and_deploy.yml" >/dev/null
+for verification_script in \
+	"${ROOT}/release/ci/verify-host-debs-asset.sh" \
+	"${ROOT}/release/ci/verify-ubuntu-agent-bundle.sh"; do
+	[[ -x "${verification_script}" ]] || {
+		printf 'ERROR: Ubuntu verification script is not executable: %s\n' "${verification_script}" >&2
+		exit 1
+	}
+done
+
+if grep -ER 'uses:[[:space:]]+[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+@' \
+	"${ROOT}/.github/workflows" \
+	| grep -Ev '@[0-9a-f]{40}([[:space:]]|$)' >/dev/null; then
+	printf 'ERROR: external GitHub Actions must be pinned to full commit SHAs\n' >&2
 	exit 1
 fi
 
@@ -476,6 +509,7 @@ fi
 for executable in \
 	"${ROOT}/.github/scripts/remote-deploy.sh" \
 	"${ROOT}/tools/quality/check-python38-runtime.py" \
+	"${ROOT}/tools/quality/test-upgrade-backup-retention.sh" \
 	"${ROOT}/tools/quality/test-shared-host-guard.sh" \
 	"${ROOT}"/release/ci/*.sh \
 	"${ROOT}/release/ci/write-sbom.py"; do

--- a/tools/quality/test-upgrade-backup-retention.sh
+++ b/tools/quality/test-upgrade-backup-retention.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+installer="${ROOT_REPO}/deploy/installer/install.sh"
+tmp="$(mktemp -d)"
+trap 'rm -rf "${tmp}"' EXIT
+
+ROOT="${tmp}/install"
+mkdir -p \
+	"${ROOT}/data/postgresql" \
+	"${ROOT}/data/sourcelens/postgresql" \
+	"${ROOT}/data/redis" \
+	"${ROOT}/data/sourcelens/redis" \
+	"${ROOT}/data/logs" \
+	"${ROOT}/data/sourcelens/logs" \
+	"${ROOT}/data/sourcelens/workspace"
+printf 'config\n' >"${ROOT}/.env"
+printf 'exclude\n' >"${ROOT}/data/postgresql/PG_VERSION"
+printf 'exclude\n' >"${ROOT}/data/sourcelens/postgresql/PG_VERSION"
+printf 'exclude\n' >"${ROOT}/data/redis/dump.rdb"
+printf 'exclude\n' >"${ROOT}/data/logs/api.log"
+printf 'retain\n' >"${ROOT}/data/sourcelens/workspace/document.txt"
+
+step() { :; }
+warn() { :; }
+log() { :; }
+die() { printf 'ERROR: %s\n' "$1" >&2; return "${2:-1}"; }
+read_env_value() { :; }
+source <(sed -n '/^backup_env_and_data()/,/^apply_upgrade_files()/p' "${installer}" | sed '$d')
+
+backup_env_and_data 20260723-010000
+archive="${ROOT}/backup/hyperfilelens-backup-20260723-010000.tar.gz"
+tar -tzf "${archive}" >"${tmp}/contents.txt"
+grep -F 'data/sourcelens/workspace/document.txt' "${tmp}/contents.txt" >/dev/null
+if grep -E 'data/(postgresql|redis|logs)|data/sourcelens/(postgresql|redis|logs)' \
+	"${tmp}/contents.txt" >/dev/null; then
+	printf 'ERROR: live database, cache, or log data entered the upgrade archive\n' >&2
+	exit 1
+fi
+
+for stamp in 20260720-010000 20260721-010000 20260722-010000; do
+	printf 'dump\n' >"${ROOT}/backup/hyperfilelens-postgresql-${stamp}.dump"
+	printf 'globals\n' >"${ROOT}/backup/hyperfilelens-postgresql-globals-${stamp}.sql"
+done
+HFL_BACKUP_RETENTION_COUNT=2 \
+HFL_BACKUP_RETENTION_DAYS=3650 \
+HFL_BACKUP_RETENTION_BYTES=10737418240 \
+	prune_upgrade_backups
+
+[[ ! -e "${ROOT}/backup/hyperfilelens-postgresql-20260720-010000.dump" ]]
+[[ ! -e "${ROOT}/backup/hyperfilelens-postgresql-20260721-010000.dump" ]]
+[[ -e "${ROOT}/backup/hyperfilelens-postgresql-20260722-010000.dump" ]]
+[[ -e "${ROOT}/backup/hyperfilelens-backup-20260723-010000.tar.gz" ]]
+printf 'Upgrade backup retention checks passed.\n'


### PR DESCRIPTION
## Summary

- redact structured and embedded secrets from platform logs and make runtime settings consistent across processes
- fix overview time-range metrics and deployment-managed AI model failure handling
- make upgrade backups bounded and exclude live database, cache, and log data
- add Ubuntu 20.04/24.04 offline execution gates and pin external GitHub Actions to immutable SHAs
- remove the duplicate deployment-time Platform Gateway ensure

## Validation

- 661 backend tests
- Agent Go test suite
- frontend lint, unit tests, and production build
- release quality and contract checks
- Ruff, Shell syntax, workflow YAML parsing, and git diff checks