### PR TITLE
fix(release): harden test deployment and offline bundles

### DIFF
--- a/.github/workflows/artifact_pipeline.yml
+++ b/.github/workflows/artifact_pipeline.yml
@@ -810,7 +810,13 @@ jobs:
         needs.prepare.outputs.channel == 'main' &&
         vars.TEST_DEPLOY_ENABLED == 'true' &&
         needs.prepare.result == 'success' &&
-        (needs.publish-release.result == 'success' || needs.publish-release.result == 'skipped')
+        (
+          needs.publish-release.result == 'success' ||
+          (
+            needs.prepare.outputs.build_required == 'false' &&
+            needs.publish-release.result == 'skipped'
+          )
+        )
       }}
     uses: ./.github/workflows/deploy_target.yml
     with:

--- a/release/ci/verify-ubuntu-agent-bundle.sh
+++ b/release/ci/verify-ubuntu-agent-bundle.sh
@@ -42,8 +42,16 @@ docker run --rm --pull=never --network none \
 printf "#!/bin/sh\nexit 101\n" >/usr/sbin/policy-rc.d
 chmod 0755 /usr/sbin/policy-rc.d
 export DEBIAN_FRONTEND=noninteractive
-dpkg -i /agent/deps/'"${flavor}"'/amd64/*.deb
-[[ -z "$(dpkg --audit)" ]]
+install_ok=0
+for attempt in 1 2 3; do
+  if dpkg -i /agent/deps/'"${flavor}"'/amd64/*.deb; then
+    install_ok=1
+    break
+  fi
+  echo "Offline NAS dependency install pass ${attempt}/3 requires another ordering pass"
+done
+[[ "${install_ok}" -eq 1 ]]
+[[ -z "$(dpkg --audit 2>&1)" ]]
 bash -n /agent/install.sh
 /agent/bin/hfl-agent -version
 /agent/bin/kopia --version

--- a/src/agent/packaging/install/install.sh
+++ b/src/agent/packaging/install/install.sh
@@ -840,10 +840,20 @@ install_nas_deps() {
 	fi
 
 	log_ok "install NAS packages for role=${role} (offline ${ubuntu_flavor}/${arch})"
-	# Offline on standard 24.04 Server: most library debs are already satisfied; dpkg may warn on
-	# duplicates but should still install mount.nfs / mount.cifs helpers.
-	if ! dpkg -i "${deps_dir}"/*.deb; then
-		log_warn "dpkg reported errors (often already-installed libraries on standard Server); rechecking mount helpers..."
+	local -a deb_files=()
+	mapfile -t deb_files < <(find "${deps_dir}" -maxdepth 1 -type f -name '*.deb' -print | sort)
+	local install_ok=0 attempt audit
+	for attempt in 1 2 3; do
+		if DEBIAN_FRONTEND=noninteractive dpkg -i "${deb_files[@]}"; then
+			install_ok=1
+			break
+		fi
+		log_warn "Offline NAS dependency install pass ${attempt}/3 reported unresolved package ordering; retrying..."
+	done
+	audit="$(dpkg --audit 2>&1 || true)"
+	if [[ "${install_ok}" -ne 1 || -n "${audit}" ]]; then
+		[[ -z "${audit}" ]] || printf '%s\n' "${audit}" >&2
+		log_fail "Unable to install the complete Ubuntu ${ubuntu_release} NAS dependency closure offline (${arch})." 2
 	fi
 	if ! nas_mount_helpers_ready; then
 		log_fail "NAS mount helpers are still missing after installing the Ubuntu ${ubuntu_release} bundled packages (${arch})." 2

--- a/src/agent/scripts/fetch-deps.sh
+++ b/src/agent/scripts/fetch-deps.sh
@@ -445,6 +445,8 @@ work="/tmp/hfl-nas-deps"
 mkdir -p "${work}" "${dest}"
 chmod 777 "${work}"
 cd "${work}"
+baseline_status="${work}/dpkg-status.before-bootstrap"
+cp /var/lib/dpkg/status "${baseline_status}"
 
 # Preserve an explicitly configured mirror and its scheme. Without one, use
 # Ubuntu's official HTTPS endpoints.
@@ -508,7 +510,9 @@ echo "  download: nfs-common cifs-utils (+dependencies)"
 rm -f /var/cache/apt/archives/*.deb 2>/dev/null || true
 download_ok=0
 for attempt in 1 2 3; do
-  if "${apt_network[@]}" install -y --download-only --no-install-recommends nfs-common cifs-utils; then
+  if "${apt_network[@]}" \
+    -o Dir::State::status="${baseline_status}" \
+    install -y --download-only --no-install-recommends nfs-common cifs-utils; then
     download_ok=1
     break
   fi

--- a/tools/dependencies/fetch-docker-ce-debs.sh
+++ b/tools/dependencies/fetch-docker-ce-debs.sh
@@ -229,6 +229,8 @@ cat > "${script_file}" <<'INNER'
 set -euo pipefail
 export DEBIAN_FRONTEND=noninteractive
 mkdir -p /out
+baseline_status="/tmp/hfl-dpkg-status.before-bootstrap"
+cp /var/lib/dpkg/status "${baseline_status}"
 
 apt_mirror_url=""
 if [[ -n "${APT_MIRROR:-}" ]]; then
@@ -338,7 +340,9 @@ echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.gpg] ${docker_apt} ${UB
 rm -f /var/cache/apt/archives/*.deb
 download_ok=0
 for attempt in 1 2 3; do
-  if "${apt_network[@]}" install -y --download-only --no-install-recommends \
+  if "${apt_network[@]}" \
+    -o Dir::State::status="${baseline_status}" \
+    install -y --download-only --no-install-recommends \
     "containerd.io=${CONTAINERD_VERSION}" \
     "docker-ce-cli=${CLI_VERSION}" \
     "docker-ce=${ENGINE_VERSION}" \

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -319,6 +319,7 @@ for dependency_fetcher in \
 	grep -F 'Acquire::Retries=5' "${dependency_fetcher}" >/dev/null
 	grep -F 'for attempt in 1 2 3' "${dependency_fetcher}" >/dev/null
 	grep -F 'if [[ -z "${apt_mirror_url}" ]]; then' "${dependency_fetcher}" >/dev/null
+	grep -F 'Dir::State::status="${baseline_status}"' "${dependency_fetcher}" >/dev/null
 done
 if grep -E -n 'apt_mirror_http|default Ubuntu HTTP sources' \
 	"${ROOT}/src/agent/scripts/fetch-deps.sh" \
@@ -502,6 +503,10 @@ grep -F 'verify-host-debs-asset.sh' \
 	"${workflow}" >/dev/null
 grep -F 'verify-ubuntu-agent-bundle.sh' \
 	"${workflow}" >/dev/null
+grep -F 'Offline NAS dependency install pass ${attempt}/3' \
+	"${ROOT}/release/ci/verify-ubuntu-agent-bundle.sh" >/dev/null
+grep -F 'Offline NAS dependency install pass ${attempt}/3' \
+	"${ROOT}/src/agent/packaging/install/install.sh" >/dev/null
 for verification_script in \
 	"${ROOT}/release/ci/verify-host-debs-asset.sh" \
 	"${ROOT}/release/ci/verify-ubuntu-agent-bundle.sh"; do

--- a/tools/quality/test-main-channel-contracts.sh
+++ b/tools/quality/test-main-channel-contracts.sh
@@ -84,6 +84,7 @@ grep -F 'channel: main' "${main_workflow}" >/dev/null
 grep -F 'refs/heads/main' "${main_workflow}" >/dev/null
 grep -F 'vars.TEST_DEPLOY_ENABLED' "${main_workflow}" >/dev/null
 grep -F 'target: test' "${workflow}" >/dev/null
+grep -F "needs.prepare.outputs.build_required == 'false'" "${workflow}" >/dev/null
 grep -F 'test:main|preprod:release|prod:release' "${deploy_workflow}" >/dev/null
 grep -F 'channel: release' "${release_workflow}" >/dev/null
 grep -F 'workflow_dispatch:' "${production_workflow}" >/dev/null


### PR DESCRIPTION
## Summary
- resolve Ubuntu offline dependencies against the pristine base-image package state
- retry strictly audited NAS deb installation to satisfy Ubuntu 24.04 Pre-Depends
- prevent TEST deployment when a new Main artifact failed before publication

## Validation
- release and Main-channel contract checks
- Ubuntu 20.04/24.04 NAS dependency fetch from official sources
- offline NAS installation with Docker network disabled
- Ubuntu 20.04/24.04 Docker CE dependency fetch from official sources
- offline Docker CE installation with Docker network disabled