### PR TITLE
fix(deploy): stage release packages through GitHub runners

### DIFF
--- a/.github/scripts/remote-deploy.sh
+++ b/.github/scripts/remote-deploy.sh
@@ -9,6 +9,7 @@ INSTALL_DIR="/opt/hyperfilelens"
 PUBLIC_URL=""
 DIRECT_HOST=""
 RUNTIME_ENV_FILE=""
+STAGED_ASSETS_DIR=""
 
 usage() {
 	cat <<'USAGE'
@@ -20,6 +21,7 @@ Usage: remote-deploy.sh --tag vX.Y.Z|main-SHA7 --channel release|main --direct-h
   --direct-host HOST       SSH-reachable host used for direct listener URLs
   --public-url URL         Optional canonical browser URL; external checks are non-blocking
   --runtime-env-file PATH  Root-only staged runtime configuration under /var/tmp
+  --staged-assets-dir DIR  Runner-uploaded release assets under /var/tmp
 USAGE
 }
 
@@ -32,6 +34,7 @@ while [[ $# -gt 0 ]]; do
 	--repository) REPOSITORY=${2:-}; shift 2 ;;
 	--install-dir) INSTALL_DIR=${2:-}; shift 2 ;;
 	--runtime-env-file) RUNTIME_ENV_FILE=${2:-}; shift 2 ;;
+	--staged-assets-dir) STAGED_ASSETS_DIR=${2:-}; shift 2 ;;
 	-h | --help) usage; exit 0 ;;
 	*) printf 'ERROR: unknown argument: %s\n' "$1" >&2; exit 2 ;;
 	esac
@@ -61,6 +64,17 @@ if [[ -n "${RUNTIME_ENV_FILE}" ]]; then
 		exit 2
 	}
 	chmod 0600 "${RUNTIME_ENV_FILE}"
+fi
+if [[ -n "${STAGED_ASSETS_DIR}" ]]; then
+	[[ "${STAGED_ASSETS_DIR}" =~ ^/var/tmp/hyperfilelens-assets-[0-9]+$ ]] || {
+		printf 'ERROR: invalid --staged-assets-dir path\n' >&2
+		exit 2
+	}
+	[[ -d "${STAGED_ASSETS_DIR}" && ! -L "${STAGED_ASSETS_DIR}" ]] || {
+		printf 'ERROR: staged release assets are missing or unsafe\n' >&2
+		exit 2
+	}
+	chmod 0700 "${STAGED_ASSETS_DIR}"
 fi
 command -v curl >/dev/null || { printf 'ERROR: curl is required\n' >&2; exit 1; }
 command -v python3 >/dev/null || { printf 'ERROR: python3 is required\n' >&2; exit 1; }
@@ -251,16 +265,53 @@ cleanup() {
 	if [[ -n "${RUNTIME_ENV_FILE}" ]]; then
 		rm -f -- "${RUNTIME_ENV_FILE}"
 	fi
+	if [[ -n "${STAGED_ASSETS_DIR}" ]]; then
+		rm -rf -- "${STAGED_ASSETS_DIR}"
+	fi
 	exit "${status}"
 }
 trap cleanup EXIT
 trap 'exit 130' INT
 trap 'exit 143' TERM
-api="https://api.github.com/repos/${REPOSITORY}/releases/tags/${TAG}"
-printf '[deploy] Resolving published release %s\n' "${TAG}"
-curl -fsSL --retry 5 --connect-timeout 20 "${api}" -o "${work}/release.json"
+check_disk_capacity() {
+	local total_bytes=$1 available_bytes required_bytes
+	available_bytes="$(df -PB1 /opt | awk 'NR == 2 {print $4}')"
+	required_bytes=$((total_bytes * 4 + 4 * 1024 * 1024 * 1024))
+	if ((available_bytes < required_bytes)); then
+		printf 'ERROR: insufficient disk: available=%s required=%s\n' "${available_bytes}" "${required_bytes}" >&2
+		exit 1
+	fi
+}
 
-python3 - "${work}/release.json" "${work}/assets.tsv" "${TAG}" <<'PY'
+if [[ -n "${STAGED_ASSETS_DIR}" ]]; then
+	printf '[deploy] Using runner-staged release assets for %s\n' "${TAG}"
+	[[ -f "${STAGED_ASSETS_DIR}/SHA256SUMS" && ! -L "${STAGED_ASSETS_DIR}/SHA256SUMS" ]] || {
+		printf 'ERROR: staged release has no safe SHA256SUMS\n' >&2
+		exit 1
+	}
+	mapfile -t staged_packages < <(
+		find "${STAGED_ASSETS_DIR}" -maxdepth 1 -type f -name 'hyperfilelens-*.tar.gz*' -print | sort
+	)
+	((${#staged_packages[@]} > 0)) || {
+		printf 'ERROR: staged release package assets are missing\n' >&2
+		exit 1
+	}
+	total_bytes="$(du -cb "${STAGED_ASSETS_DIR}/SHA256SUMS" "${staged_packages[@]}" | awk 'END {print $1}')"
+	check_disk_capacity "${total_bytes}"
+	install -m 0600 "${STAGED_ASSETS_DIR}/SHA256SUMS" "${work}/SHA256SUMS"
+	for asset in "${staged_packages[@]}"; do
+		name="$(basename "${asset}")"
+		[[ "${name}" =~ ^[A-Za-z0-9._-]+$ ]] || { printf 'ERROR: unsafe staged asset name\n' >&2; exit 1; }
+		install -m 0600 "${asset}" "${work}/${name}"
+	done
+	rm -rf -- "${STAGED_ASSETS_DIR}"
+	STAGED_ASSETS_DIR=""
+else
+	api="https://api.github.com/repos/${REPOSITORY}/releases/tags/${TAG}"
+	printf '[deploy] Resolving published release %s\n' "${TAG}"
+	curl -fsSL --retry 5 --connect-timeout 20 "${api}" -o "${work}/release.json"
+
+	python3 - "${work}/release.json" "${work}/assets.tsv" "${TAG}" <<'PY'
 import json
 import pathlib
 import re
@@ -301,25 +352,21 @@ pathlib.Path(sys.argv[2]).write_text(
 )
 PY
 
-total_bytes="$(python3 - "${work}/release.json" "${work}/assets.tsv" <<'PY'
+	total_bytes="$(python3 - "${work}/release.json" "${work}/assets.tsv" <<'PY'
 import json, pathlib, sys
 release = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
 selected = {line.split("\t", 1)[0] for line in pathlib.Path(sys.argv[2]).read_text().splitlines()}
 print(sum(int(asset.get("size", 0)) for asset in release.get("assets", []) if asset.get("name") in selected))
 PY
 )"
-available_bytes="$(df -PB1 /opt | awk 'NR == 2 {print $4}')"
-required_bytes=$((total_bytes * 4 + 4 * 1024 * 1024 * 1024))
-if ((available_bytes < required_bytes)); then
-	printf 'ERROR: insufficient disk: available=%s required=%s\n' "${available_bytes}" "${required_bytes}" >&2
-	exit 1
-fi
+	check_disk_capacity "${total_bytes}"
 
-while IFS=$'\t' read -r name url; do
-	[[ "${name}" =~ ^[A-Za-z0-9._-]+$ ]] || { printf 'ERROR: unsafe asset name\n' >&2; exit 1; }
-	printf '[deploy] Downloading %s\n' "${name}"
-	curl -fL --retry 5 --connect-timeout 20 "${url}" -o "${work}/${name}"
-done <"${work}/assets.tsv"
+	while IFS=$'\t' read -r name url; do
+		[[ "${name}" =~ ^[A-Za-z0-9._-]+$ ]] || { printf 'ERROR: unsafe asset name\n' >&2; exit 1; }
+		printf '[deploy] Downloading %s\n' "${name}"
+		curl -fL --retry 5 --connect-timeout 20 "${url}" -o "${work}/${name}"
+	done <"${work}/assets.tsv"
+fi
 
 package="$(find "${work}" -maxdepth 1 -type f -name 'hyperfilelens-*.tar.gz' -print -quit)"
 if [[ -z "${package}" ]]; then

--- a/.github/workflows/deploy_target.yml
+++ b/.github/workflows/deploy_target.yml
@@ -142,6 +142,7 @@ jobs:
           AI_MODEL_API_BASE: ${{ secrets.ai_model_api_base }}
           AI_MODEL_API_KEY: ${{ secrets.ai_model_api_key }}
           ARTIFACT_CHANNEL: ${{ inputs.channel }}
+          ARTIFACT_ID: ${{ inputs.tag }}
           DEPLOY_TARGET: ${{ inputs.target }}
         shell: bash
         run: |
@@ -153,6 +154,10 @@ jobs:
           [[ -n "$DEPLOY_SSH_PRIVATE_KEY" ]]
           [[ "$DEPLOY_TARGET" =~ ^(test|preprod|prod)$ ]]
           [[ "$ARTIFACT_CHANNEL" =~ ^(release|main)$ ]]
+          case "$ARTIFACT_CHANNEL" in
+            release) [[ "$ARTIFACT_ID" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] ;;
+            main) [[ "$ARTIFACT_ID" =~ ^main-[0-9a-f]{7}$ ]] ;;
+          esac
           case "$DEPLOY_TARGET:$ARTIFACT_CHANNEL" in
             test:main|preprod:release|prod:release) ;;
             *)
@@ -216,6 +221,56 @@ jobs:
           printf '%s\n' "$DEPLOY_SSH_KNOWN_HOSTS" > ~/.ssh/known_hosts
           chmod 0600 ~/.ssh/hyperfilelens_deploy ~/.ssh/known_hosts
 
+      - name: Download, verify, and stage the release package
+        id: release-package
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ARTIFACT_ID: ${{ inputs.tag }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          local_dir="$RUNNER_TEMP/hyperfilelens-release"
+          remote_dir="/var/tmp/hyperfilelens-assets-${GITHUB_RUN_ID}"
+          mkdir -p "$local_dir"
+          gh release download "$ARTIFACT_ID" \
+            --repo "$GITHUB_REPOSITORY" \
+            --pattern SHA256SUMS \
+            --pattern 'hyperfilelens-*.tar.gz*' \
+            --dir "$local_dir"
+          [[ -s "$local_dir/SHA256SUMS" ]]
+          mapfile -t package_assets < <(
+            find "$local_dir" -maxdepth 1 -type f -name 'hyperfilelens-*.tar.gz*' -print | sort
+          )
+          ((${#package_assets[@]} > 0))
+          for asset in "${package_assets[@]}"; do
+            name="$(basename "$asset")"
+            expected="$(awk -v file="$name" '$2 == file || $2 == "*" file {print $1; exit}' \
+              "$local_dir/SHA256SUMS")"
+            [[ -n "$expected" ]]
+            printf '%s  %s\n' "$expected" "$asset" | sha256sum -c -
+          done
+          ssh -i ~/.ssh/hyperfilelens_deploy \
+            -o BatchMode=yes \
+            -o StrictHostKeyChecking=yes \
+            -o ConnectTimeout=20 \
+            -o ServerAliveInterval=30 \
+            -o ServerAliveCountMax=20 \
+            -o TCPKeepAlive=yes \
+            -p "$DEPLOY_SSH_PORT" \
+            "$DEPLOY_SSH_USER@$DEPLOY_SSH_HOST" \
+            "rm -rf -- '$remote_dir' && install -d -m 0700 '$remote_dir'"
+          scp -i ~/.ssh/hyperfilelens_deploy \
+            -o BatchMode=yes \
+            -o StrictHostKeyChecking=yes \
+            -o ConnectTimeout=20 \
+            -o ServerAliveInterval=30 \
+            -o ServerAliveCountMax=20 \
+            -o TCPKeepAlive=yes \
+            -P "$DEPLOY_SSH_PORT" \
+            "$local_dir/SHA256SUMS" "${package_assets[@]}" \
+            "$DEPLOY_SSH_USER@$DEPLOY_SSH_HOST:$remote_dir/"
+          echo "remote_dir=$remote_dir" >> "$GITHUB_OUTPUT"
+
       - name: Stage runtime configuration
         env:
           HFL_PLATFORM_GATEWAY_AUTO_DEPLOY: ${{ inputs.platform_gateway_auto_deploy }}
@@ -260,7 +315,7 @@ jobs:
             "umask 077 && cat > /var/tmp/hyperfilelens-runtime-${GITHUB_RUN_ID}.env && chmod 0600 /var/tmp/hyperfilelens-runtime-${GITHUB_RUN_ID}.env" \
             < "$runtime_env"
 
-      - name: Download and deploy the complete release package on the host
+      - name: Deploy the runner-staged complete release package
         shell: bash
         run: |
           set -euo pipefail
@@ -279,6 +334,7 @@ jobs:
               --public-url "$APP_PUBLIC_URL" \
               --direct-host "$DEPLOY_SSH_HOST" \
               --install-dir /opt/hyperfilelens \
+              --staged-assets-dir "${{ steps.release-package.outputs.remote_dir }}" \
               --runtime-env-file "/var/tmp/hyperfilelens-runtime-${GITHUB_RUN_ID}.env" \
             < .github/scripts/remote-deploy.sh
 
@@ -296,7 +352,7 @@ jobs:
               -o TCPKeepAlive=yes \
               -p "$DEPLOY_SSH_PORT" \
               "$DEPLOY_SSH_USER@$DEPLOY_SSH_HOST" \
-              rm -f -- "/var/tmp/hyperfilelens-runtime-${GITHUB_RUN_ID}.env"
+              "rm -f -- '/var/tmp/hyperfilelens-runtime-${GITHUB_RUN_ID}.env'; rm -rf -- '/var/tmp/hyperfilelens-assets-${GITHUB_RUN_ID}'"
           fi
 
       - name: Post-deploy internal health checks

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -275,11 +275,11 @@ grep -F "vars.TEST_DEPLOY_ENABLED == 'true'" "${workflow}" >/dev/null
 grep -F "vars.PREPROD_DEPLOY_ENABLED == 'true'" "${workflow}" >/dev/null
 grep -F 'PROD_DEPLOY_ENABLED' "${production_workflow}" >/dev/null
 deploy_workflow="${ROOT}/.github/workflows/deploy_target.yml"
-[[ "$(grep -c -- '-o ServerAliveInterval=30' "${deploy_workflow}")" -eq 5 ]] || {
+[[ "$(grep -c -- '-o ServerAliveInterval=30' "${deploy_workflow}")" -eq 7 ]] || {
 	printf 'ERROR: every deployment SSH call must enable ServerAliveInterval\n' >&2
 	exit 1
 }
-[[ "$(grep -c -- '-o ServerAliveCountMax=20' "${deploy_workflow}")" -eq 5 ]] || {
+[[ "$(grep -c -- '-o ServerAliveCountMax=20' "${deploy_workflow}")" -eq 7 ]] || {
 	printf 'ERROR: every deployment SSH call must set ServerAliveCountMax\n' >&2
 	exit 1
 }
@@ -422,6 +422,13 @@ fi
 grep -F -- '--public-url) PUBLIC_URL=' "${remote_deploy}" >/dev/null
 grep -F -- '--direct-host) DIRECT_HOST=' "${remote_deploy}" >/dev/null
 grep -F -- '--runtime-env-file "${RUNTIME_ENV_FILE}"' "${remote_deploy}" >/dev/null
+grep -F 'Download, verify, and stage the release package' "${deploy_workflow}" >/dev/null
+grep -F 'gh release download "$ARTIFACT_ID"' "${deploy_workflow}" >/dev/null
+grep -F '"${package_assets[@]}"' "${deploy_workflow}" >/dev/null
+grep -F -- '--staged-assets-dir "${{ steps.release-package.outputs.remote_dir }}"' \
+	"${deploy_workflow}" >/dev/null
+grep -F -- '--staged-assets-dir) STAGED_ASSETS_DIR=' "${remote_deploy}" >/dev/null
+grep -F 'Using runner-staged release assets' "${remote_deploy}" >/dev/null
 if grep -F -- '--force-recreate' "${remote_deploy}" >/dev/null; then
 	printf 'ERROR: production deployment must apply runtime configuration before startup\n' >&2
 	exit 1


### PR DESCRIPTION
## Summary

- download and checksum-verify published release assets on the GitHub-hosted runner
- transfer verified assets directly from the runner to the target over SCP
- retain remote checksum and manifest verification plus direct-download fallback
- clean staged packages and runtime secrets on success or failure

## Validation

- bash -n .github/scripts/remote-deploy.sh
- git diff --check
- bash tools/quality/test-main-channel-contracts.sh
- bash tools/quality/check-release-contracts.sh
- bash tools/quality/test-deployment-optional-config.sh
- bash tools/quality/test-shared-host-guard.sh