### PR TITLE
fix(deploy): unify target-side release downloads

### DIFF
--- a/.github/scripts/remote-deploy.sh
+++ b/.github/scripts/remote-deploy.sh
@@ -9,7 +9,7 @@ INSTALL_DIR="/opt/hyperfilelens"
 PUBLIC_URL=""
 DIRECT_HOST=""
 RUNTIME_ENV_FILE=""
-STAGED_ASSETS_DIR=""
+DOWNLOAD_PROXY_URL=""
 
 usage() {
 	cat <<'USAGE'
@@ -21,7 +21,7 @@ Usage: remote-deploy.sh --tag vX.Y.Z|main-SHA7 --channel release|main --direct-h
   --direct-host HOST       SSH-reachable host used for direct listener URLs
   --public-url URL         Optional canonical browser URL; external checks are non-blocking
   --runtime-env-file PATH  Root-only staged runtime configuration under /var/tmp
-  --staged-assets-dir DIR  Runner-uploaded release assets under /var/tmp
+  --download-proxy-url URL Optional HTTP(S) proxy used only for GitHub Release downloads
 USAGE
 }
 
@@ -34,11 +34,15 @@ while [[ $# -gt 0 ]]; do
 	--repository) REPOSITORY=${2:-}; shift 2 ;;
 	--install-dir) INSTALL_DIR=${2:-}; shift 2 ;;
 	--runtime-env-file) RUNTIME_ENV_FILE=${2:-}; shift 2 ;;
-	--staged-assets-dir) STAGED_ASSETS_DIR=${2:-}; shift 2 ;;
+	--download-proxy-url) DOWNLOAD_PROXY_URL=${2:-}; shift 2 ;;
 	-h | --help) usage; exit 0 ;;
 	*) printf 'ERROR: unknown argument: %s\n' "$1" >&2; exit 2 ;;
 	esac
 done
+
+if [[ "${DOWNLOAD_PROXY_URL}" == "UNCONFIGURED" ]]; then
+	DOWNLOAD_PROXY_URL=""
+fi
 
 case "${CHANNEL}" in
 release) [[ "${TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || { printf 'ERROR: invalid release tag\n' >&2; exit 2; } ;;
@@ -65,16 +69,17 @@ if [[ -n "${RUNTIME_ENV_FILE}" ]]; then
 	}
 	chmod 0600 "${RUNTIME_ENV_FILE}"
 fi
-if [[ -n "${STAGED_ASSETS_DIR}" ]]; then
-	[[ "${STAGED_ASSETS_DIR}" =~ ^/var/tmp/hyperfilelens-assets-[0-9]+$ ]] || {
-		printf 'ERROR: invalid --staged-assets-dir path\n' >&2
+if [[ -n "${DOWNLOAD_PROXY_URL}" ]]; then
+	[[ "${DOWNLOAD_PROXY_URL}" =~ ^https?://[A-Za-z0-9.-]+:[0-9]{1,5}$ ]] || {
+		printf 'ERROR: download proxy must use http://host:port or https://host:port without credentials\n' >&2
 		exit 2
 	}
-	[[ -d "${STAGED_ASSETS_DIR}" && ! -L "${STAGED_ASSETS_DIR}" ]] || {
-		printf 'ERROR: staged release assets are missing or unsafe\n' >&2
+	proxy_address="${DOWNLOAD_PROXY_URL#*://}"
+	proxy_port="${proxy_address##*:}"
+	((proxy_port >= 1 && proxy_port <= 65535)) || {
+		printf 'ERROR: download proxy port is out of range\n' >&2
 		exit 2
 	}
-	chmod 0700 "${STAGED_ASSETS_DIR}"
 fi
 command -v curl >/dev/null || { printf 'ERROR: curl is required\n' >&2; exit 1; }
 command -v python3 >/dev/null || { printf 'ERROR: python3 is required\n' >&2; exit 1; }
@@ -265,9 +270,6 @@ cleanup() {
 	if [[ -n "${RUNTIME_ENV_FILE}" ]]; then
 		rm -f -- "${RUNTIME_ENV_FILE}"
 	fi
-	if [[ -n "${STAGED_ASSETS_DIR}" ]]; then
-		rm -rf -- "${STAGED_ASSETS_DIR}"
-	fi
 	exit "${status}"
 }
 trap cleanup EXIT
@@ -283,35 +285,34 @@ check_disk_capacity() {
 	fi
 }
 
-if [[ -n "${STAGED_ASSETS_DIR}" ]]; then
-	printf '[deploy] Using runner-staged release assets for %s\n' "${TAG}"
-	[[ -f "${STAGED_ASSETS_DIR}/SHA256SUMS" && ! -L "${STAGED_ASSETS_DIR}/SHA256SUMS" ]] || {
-		printf 'ERROR: staged release has no safe SHA256SUMS\n' >&2
-		exit 1
-	}
-	mapfile -t staged_packages < <(
-		find "${STAGED_ASSETS_DIR}" -maxdepth 1 -type f -name 'hyperfilelens-*.tar.gz*' -print | sort
+download_release_file() {
+	local url=$1 output=$2
+	local -a curl_args=(
+		-fL
+		--retry 5
+		--retry-connrefused
+		--retry-delay 2
+		--connect-timeout 20
 	)
-	((${#staged_packages[@]} > 0)) || {
-		printf 'ERROR: staged release package assets are missing\n' >&2
-		exit 1
-	}
-	total_bytes="$(du -cb "${STAGED_ASSETS_DIR}/SHA256SUMS" "${staged_packages[@]}" | awk 'END {print $1}')"
-	check_disk_capacity "${total_bytes}"
-	install -m 0600 "${STAGED_ASSETS_DIR}/SHA256SUMS" "${work}/SHA256SUMS"
-	for asset in "${staged_packages[@]}"; do
-		name="$(basename "${asset}")"
-		[[ "${name}" =~ ^[A-Za-z0-9._-]+$ ]] || { printf 'ERROR: unsafe staged asset name\n' >&2; exit 1; }
-		install -m 0600 "${asset}" "${work}/${name}"
-	done
-	rm -rf -- "${STAGED_ASSETS_DIR}"
-	STAGED_ASSETS_DIR=""
-else
-	api="https://api.github.com/repos/${REPOSITORY}/releases/tags/${TAG}"
-	printf '[deploy] Resolving published release %s\n' "${TAG}"
-	curl -fsSL --retry 5 --connect-timeout 20 "${api}" -o "${work}/release.json"
+	if [[ -n "${DOWNLOAD_PROXY_URL}" ]]; then
+		if curl "${curl_args[@]}" --proxy "${DOWNLOAD_PROXY_URL}" --noproxy '' \
+			"${url}" -o "${output}"; then
+			return 0
+		fi
+		printf 'WARNING: release download through the configured proxy failed; retrying directly\n' >&2
+		rm -f -- "${output}"
+	fi
+	curl "${curl_args[@]}" --proxy '' "${url}" -o "${output}"
+}
 
-	python3 - "${work}/release.json" "${work}/assets.tsv" "${TAG}" <<'PY'
+if [[ -n "${DOWNLOAD_PROXY_URL}" ]]; then
+	printf '[deploy] Target-side Release download proxy is enabled\n'
+fi
+api="https://api.github.com/repos/${REPOSITORY}/releases/tags/${TAG}"
+printf '[deploy] Resolving published release %s\n' "${TAG}"
+download_release_file "${api}" "${work}/release.json"
+
+python3 - "${work}/release.json" "${work}/assets.tsv" "${TAG}" <<'PY'
 import json
 import pathlib
 import re
@@ -352,21 +353,20 @@ pathlib.Path(sys.argv[2]).write_text(
 )
 PY
 
-	total_bytes="$(python3 - "${work}/release.json" "${work}/assets.tsv" <<'PY'
+total_bytes="$(python3 - "${work}/release.json" "${work}/assets.tsv" <<'PY'
 import json, pathlib, sys
 release = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
 selected = {line.split("\t", 1)[0] for line in pathlib.Path(sys.argv[2]).read_text().splitlines()}
 print(sum(int(asset.get("size", 0)) for asset in release.get("assets", []) if asset.get("name") in selected))
 PY
 )"
-	check_disk_capacity "${total_bytes}"
+check_disk_capacity "${total_bytes}"
 
-	while IFS=$'\t' read -r name url; do
-		[[ "${name}" =~ ^[A-Za-z0-9._-]+$ ]] || { printf 'ERROR: unsafe asset name\n' >&2; exit 1; }
-		printf '[deploy] Downloading %s\n' "${name}"
-		curl -fL --retry 5 --connect-timeout 20 "${url}" -o "${work}/${name}"
-	done <"${work}/assets.tsv"
-fi
+while IFS=$'\t' read -r name url; do
+	[[ "${name}" =~ ^[A-Za-z0-9._-]+$ ]] || { printf 'ERROR: unsafe asset name\n' >&2; exit 1; }
+	printf '[deploy] Downloading %s\n' "${name}"
+	download_release_file "${url}" "${work}/${name}"
+done <"${work}/assets.tsv"
 
 package="$(find "${work}" -maxdepth 1 -type f -name 'hyperfilelens-*.tar.gz' -print -quit)"
 if [[ -z "${package}" ]]; then

--- a/.github/workflows/artifact_pipeline.yml
+++ b/.github/workflows/artifact_pipeline.yml
@@ -209,6 +209,7 @@ jobs:
           ./tools/quality/test-upgrade-backup-retention.sh
           ./tools/quality/test-main-channel-contracts.sh
           ./tools/quality/test-shared-host-guard.sh
+          ./tools/quality/test-release-download-proxy.sh
           ./tools/quality/test-deployment-optional-config.sh
           ./tools/quality/test-payload-tree-hash.sh
           ./tools/quality/test-ci-release-assembly.sh
@@ -824,6 +825,7 @@ jobs:
       channel: main
       tag: ${{ needs.prepare.outputs.tag }}
       public_url: ${{ vars.TEST_PUBLIC_URL }}
+      release_download_proxy_url: ${{ vars.TEST_RELEASE_DOWNLOAD_PROXY_URL }}
       ssh_host: ${{ vars.TEST_SSH_HOST }}
       ssh_port: ${{ vars.TEST_SSH_PORT }}
       ssh_user: ${{ vars.TEST_SSH_USER }}
@@ -862,6 +864,7 @@ jobs:
       channel: release
       tag: ${{ needs.prepare.outputs.tag }}
       public_url: ${{ vars.PREPROD_PUBLIC_URL }}
+      release_download_proxy_url: ${{ vars.PREPROD_RELEASE_DOWNLOAD_PROXY_URL }}
       ssh_host: ${{ vars.PREPROD_SSH_HOST }}
       ssh_port: ${{ vars.PREPROD_SSH_PORT }}
       ssh_user: ${{ vars.PREPROD_SSH_USER }}

--- a/.github/workflows/deploy_target.yml
+++ b/.github/workflows/deploy_target.yml
@@ -21,6 +21,11 @@ on:
         required: false
         default: ''
         type: string
+      release_download_proxy_url:
+        description: Optional target-side HTTP(S) proxy; empty or UNCONFIGURED means direct download
+        required: false
+        default: ''
+        type: string
       ssh_host:
         description: SSH deployment hostname or IP address
         required: true
@@ -124,6 +129,7 @@ jobs:
       DEPLOY_SSH_PORT: ${{ inputs.ssh_port }}
       DEPLOY_SSH_USER: ${{ inputs.ssh_user }}
       DEPLOY_SSH_KNOWN_HOSTS: ${{ inputs.ssh_known_hosts }}
+      RELEASE_DOWNLOAD_PROXY_URL: ${{ inputs.release_download_proxy_url }}
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
 
@@ -154,6 +160,15 @@ jobs:
           [[ -n "$DEPLOY_SSH_PRIVATE_KEY" ]]
           [[ "$DEPLOY_TARGET" =~ ^(test|preprod|prod)$ ]]
           [[ "$ARTIFACT_CHANNEL" =~ ^(release|main)$ ]]
+          if [[ -n "$RELEASE_DOWNLOAD_PROXY_URL" && "$RELEASE_DOWNLOAD_PROXY_URL" != "UNCONFIGURED" ]]; then
+            [[ "$RELEASE_DOWNLOAD_PROXY_URL" =~ ^https?://[A-Za-z0-9.-]+:[0-9]{1,5}$ ]] || {
+              echo 'Release download proxy must use http://host:port or https://host:port without credentials' >&2
+              exit 2
+            }
+            proxy_address="${RELEASE_DOWNLOAD_PROXY_URL#*://}"
+            proxy_port="${proxy_address##*:}"
+            ((proxy_port >= 1 && proxy_port <= 65535))
+          fi
           case "$ARTIFACT_CHANNEL" in
             release) [[ "$ARTIFACT_ID" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] ;;
             main) [[ "$ARTIFACT_ID" =~ ^main-[0-9a-f]{7}$ ]] ;;
@@ -221,56 +236,6 @@ jobs:
           printf '%s\n' "$DEPLOY_SSH_KNOWN_HOSTS" > ~/.ssh/known_hosts
           chmod 0600 ~/.ssh/hyperfilelens_deploy ~/.ssh/known_hosts
 
-      - name: Download, verify, and stage the release package
-        id: release-package
-        env:
-          GH_TOKEN: ${{ github.token }}
-          ARTIFACT_ID: ${{ inputs.tag }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          local_dir="$RUNNER_TEMP/hyperfilelens-release"
-          remote_dir="/var/tmp/hyperfilelens-assets-${GITHUB_RUN_ID}"
-          mkdir -p "$local_dir"
-          gh release download "$ARTIFACT_ID" \
-            --repo "$GITHUB_REPOSITORY" \
-            --pattern SHA256SUMS \
-            --pattern 'hyperfilelens-*.tar.gz*' \
-            --dir "$local_dir"
-          [[ -s "$local_dir/SHA256SUMS" ]]
-          mapfile -t package_assets < <(
-            find "$local_dir" -maxdepth 1 -type f -name 'hyperfilelens-*.tar.gz*' -print | sort
-          )
-          ((${#package_assets[@]} > 0))
-          for asset in "${package_assets[@]}"; do
-            name="$(basename "$asset")"
-            expected="$(awk -v file="$name" '$2 == file || $2 == "*" file {print $1; exit}' \
-              "$local_dir/SHA256SUMS")"
-            [[ -n "$expected" ]]
-            printf '%s  %s\n' "$expected" "$asset" | sha256sum -c -
-          done
-          ssh -i ~/.ssh/hyperfilelens_deploy \
-            -o BatchMode=yes \
-            -o StrictHostKeyChecking=yes \
-            -o ConnectTimeout=20 \
-            -o ServerAliveInterval=30 \
-            -o ServerAliveCountMax=20 \
-            -o TCPKeepAlive=yes \
-            -p "$DEPLOY_SSH_PORT" \
-            "$DEPLOY_SSH_USER@$DEPLOY_SSH_HOST" \
-            "rm -rf -- '$remote_dir' && install -d -m 0700 '$remote_dir'"
-          scp -i ~/.ssh/hyperfilelens_deploy \
-            -o BatchMode=yes \
-            -o StrictHostKeyChecking=yes \
-            -o ConnectTimeout=20 \
-            -o ServerAliveInterval=30 \
-            -o ServerAliveCountMax=20 \
-            -o TCPKeepAlive=yes \
-            -P "$DEPLOY_SSH_PORT" \
-            "$local_dir/SHA256SUMS" "${package_assets[@]}" \
-            "$DEPLOY_SSH_USER@$DEPLOY_SSH_HOST:$remote_dir/"
-          echo "remote_dir=$remote_dir" >> "$GITHUB_OUTPUT"
-
       - name: Stage runtime configuration
         env:
           HFL_PLATFORM_GATEWAY_AUTO_DEPLOY: ${{ inputs.platform_gateway_auto_deploy }}
@@ -315,10 +280,14 @@ jobs:
             "umask 077 && cat > /var/tmp/hyperfilelens-runtime-${GITHUB_RUN_ID}.env && chmod 0600 /var/tmp/hyperfilelens-runtime-${GITHUB_RUN_ID}.env" \
             < "$runtime_env"
 
-      - name: Deploy the runner-staged complete release package
+      - name: Download and deploy the complete release package on the target
         shell: bash
         run: |
           set -euo pipefail
+          download_proxy_args=()
+          if [[ -n "$RELEASE_DOWNLOAD_PROXY_URL" && "$RELEASE_DOWNLOAD_PROXY_URL" != "UNCONFIGURED" ]]; then
+            download_proxy_args=(--download-proxy-url "$RELEASE_DOWNLOAD_PROXY_URL")
+          fi
           ssh -i ~/.ssh/hyperfilelens_deploy \
             -o BatchMode=yes \
             -o StrictHostKeyChecking=yes \
@@ -334,7 +303,7 @@ jobs:
               --public-url "$APP_PUBLIC_URL" \
               --direct-host "$DEPLOY_SSH_HOST" \
               --install-dir /opt/hyperfilelens \
-              --staged-assets-dir "${{ steps.release-package.outputs.remote_dir }}" \
+              "${download_proxy_args[@]}" \
               --runtime-env-file "/var/tmp/hyperfilelens-runtime-${GITHUB_RUN_ID}.env" \
             < .github/scripts/remote-deploy.sh
 
@@ -352,7 +321,7 @@ jobs:
               -o TCPKeepAlive=yes \
               -p "$DEPLOY_SSH_PORT" \
               "$DEPLOY_SSH_USER@$DEPLOY_SSH_HOST" \
-              "rm -f -- '/var/tmp/hyperfilelens-runtime-${GITHUB_RUN_ID}.env'; rm -rf -- '/var/tmp/hyperfilelens-assets-${GITHUB_RUN_ID}'"
+              rm -f -- "/var/tmp/hyperfilelens-runtime-${GITHUB_RUN_ID}.env"
           fi
 
       - name: Post-deploy internal health checks

--- a/.github/workflows/production_deploy.yml
+++ b/.github/workflows/production_deploy.yml
@@ -66,6 +66,7 @@ jobs:
       channel: release
       tag: ${{ inputs.tag }}
       public_url: ${{ vars.PROD_PUBLIC_URL }}
+      release_download_proxy_url: ${{ vars.PROD_RELEASE_DOWNLOAD_PROXY_URL }}
       ssh_host: ${{ vars.PROD_SSH_HOST }}
       ssh_port: ${{ vars.PROD_SSH_PORT }}
       ssh_user: ${{ vars.PROD_SSH_USER }}

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -184,6 +184,9 @@ grep -F 'turnstile_enabled: ${{ vars.TEST_TURNSTILE_ENABLED' "${workflow}" >/dev
 grep -F 'public_url: ${{ vars.TEST_PUBLIC_URL }}' "${workflow}" >/dev/null
 grep -F 'turnstile_enabled: ${{ vars.PROD_TURNSTILE_ENABLED' "${production_workflow}" >/dev/null
 grep -F 'public_url: ${{ vars.PROD_PUBLIC_URL }}' "${production_workflow}" >/dev/null
+grep -F 'release_download_proxy_url: ${{ vars.TEST_RELEASE_DOWNLOAD_PROXY_URL }}' "${workflow}" >/dev/null
+grep -F 'release_download_proxy_url: ${{ vars.PREPROD_RELEASE_DOWNLOAD_PROXY_URL }}' "${workflow}" >/dev/null
+grep -F 'release_download_proxy_url: ${{ vars.PROD_RELEASE_DOWNLOAD_PROXY_URL }}' "${production_workflow}" >/dev/null
 if grep -F 'PROD_PUBLIC_HOST' "${workflow}" "${production_workflow}" >/dev/null; then
 	printf 'ERROR: release workflow still uses the ambiguous PROD_PUBLIC_HOST variable\n' >&2
 	exit 1
@@ -275,11 +278,11 @@ grep -F "vars.TEST_DEPLOY_ENABLED == 'true'" "${workflow}" >/dev/null
 grep -F "vars.PREPROD_DEPLOY_ENABLED == 'true'" "${workflow}" >/dev/null
 grep -F 'PROD_DEPLOY_ENABLED' "${production_workflow}" >/dev/null
 deploy_workflow="${ROOT}/.github/workflows/deploy_target.yml"
-[[ "$(grep -c -- '-o ServerAliveInterval=30' "${deploy_workflow}")" -eq 7 ]] || {
+[[ "$(grep -c -- '-o ServerAliveInterval=30' "${deploy_workflow}")" -eq 5 ]] || {
 	printf 'ERROR: every deployment SSH call must enable ServerAliveInterval\n' >&2
 	exit 1
 }
-[[ "$(grep -c -- '-o ServerAliveCountMax=20' "${deploy_workflow}")" -eq 7 ]] || {
+[[ "$(grep -c -- '-o ServerAliveCountMax=20' "${deploy_workflow}")" -eq 5 ]] || {
 	printf 'ERROR: every deployment SSH call must set ServerAliveCountMax\n' >&2
 	exit 1
 }
@@ -422,13 +425,24 @@ fi
 grep -F -- '--public-url) PUBLIC_URL=' "${remote_deploy}" >/dev/null
 grep -F -- '--direct-host) DIRECT_HOST=' "${remote_deploy}" >/dev/null
 grep -F -- '--runtime-env-file "${RUNTIME_ENV_FILE}"' "${remote_deploy}" >/dev/null
-grep -F 'Download, verify, and stage the release package' "${deploy_workflow}" >/dev/null
-grep -F 'gh release download "$ARTIFACT_ID"' "${deploy_workflow}" >/dev/null
-grep -F '"${package_assets[@]}"' "${deploy_workflow}" >/dev/null
-grep -F -- '--staged-assets-dir "${{ steps.release-package.outputs.remote_dir }}"' \
+grep -F 'Download and deploy the complete release package on the target' "${deploy_workflow}" >/dev/null
+grep -F 'download_proxy_args=(--download-proxy-url "$RELEASE_DOWNLOAD_PROXY_URL")' \
 	"${deploy_workflow}" >/dev/null
-grep -F -- '--staged-assets-dir) STAGED_ASSETS_DIR=' "${remote_deploy}" >/dev/null
-grep -F 'Using runner-staged release assets' "${remote_deploy}" >/dev/null
+grep -F '"${download_proxy_args[@]}"' "${deploy_workflow}" >/dev/null
+grep -F -- '--download-proxy-url) DOWNLOAD_PROXY_URL=' "${remote_deploy}" >/dev/null
+grep -F 'Target-side Release download proxy is enabled' "${remote_deploy}" >/dev/null
+grep -F 'retrying directly' "${remote_deploy}" >/dev/null
+grep -F -- '--proxy "${DOWNLOAD_PROXY_URL}"' "${remote_deploy}" >/dev/null
+grep -F 'DOWNLOAD_PROXY_URL}" == "UNCONFIGURED"' "${remote_deploy}" >/dev/null
+[[ "$(grep -c 'RELEASE_DOWNLOAD_PROXY_URL.*!=.*UNCONFIGURED' "${deploy_workflow}")" -eq 2 ]] || {
+	printf 'ERROR: UNCONFIGURED Release proxy placeholders must select direct target downloads\n' >&2
+	exit 1
+}
+if grep -E 'gh release download|(^|[[:space:]])scp([[:space:]]|$)|staged-assets-dir|STAGED_ASSETS_DIR' \
+	"${deploy_workflow}" "${remote_deploy}" >/dev/null; then
+	printf 'ERROR: deployment must download the complete Release package on the target host\n' >&2
+	exit 1
+fi
 if grep -F -- '--force-recreate' "${remote_deploy}" >/dev/null; then
 	printf 'ERROR: production deployment must apply runtime configuration before startup\n' >&2
 	exit 1
@@ -446,6 +460,7 @@ done
 grep -F 'Verified that unrelated Docker containers, networks, and volumes are unchanged' "${remote_deploy}" >/dev/null
 grep -F 'project in {"hyperfilelens-sourcelens", "sourcelens"}' "${remote_deploy}" >/dev/null
 grep -F './tools/quality/test-shared-host-guard.sh' "${workflow}" >/dev/null
+grep -F './tools/quality/test-release-download-proxy.sh' "${workflow}" >/dev/null
 grep -F './tools/quality/test-default-certificates.sh' "${workflow}" >/dev/null
 grep -F './tools/quality/test-gateway-bootstrap-health.sh' "${workflow}" >/dev/null
 grep -F './tools/quality/test-platform-gateway-auto-deploy.sh' "${workflow}" >/dev/null
@@ -558,6 +573,7 @@ for executable in \
 	"${ROOT}/tools/quality/test-main-channel-contracts.sh" \
 	"${ROOT}/tools/quality/test-upgrade-backup-retention.sh" \
 	"${ROOT}/tools/quality/test-shared-host-guard.sh" \
+	"${ROOT}/tools/quality/test-release-download-proxy.sh" \
 	"${ROOT}"/release/ci/*.sh \
 	"${ROOT}/release/ci/write-sbom.py"; do
 	[[ -x "${executable}" ]] || {

--- a/tools/quality/test-release-download-proxy.sh
+++ b/tools/quality/test-release-download-proxy.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Validate target-side Release proxy isolation and direct-download fallback.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+remote_deploy="${ROOT}/.github/scripts/remote-deploy.sh"
+tmp="$(mktemp -d)"
+trap 'rm -rf "${tmp}"' EXIT
+mkdir -p "${tmp}/bin"
+
+cat >"${tmp}/bin/curl" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+output=""
+proxy="unset"
+while (($#)); do
+	printf '%s\n' "$1" >>"${HFL_TEST_CURL_LOG}"
+	case "$1" in
+	--proxy)
+		proxy=${2-}
+		printf '%s\n' "${2-}" >>"${HFL_TEST_CURL_LOG}"
+		shift 2
+		;;
+	-o)
+		output=${2-}
+		printf '%s\n' "${2-}" >>"${HFL_TEST_CURL_LOG}"
+		shift 2
+		;;
+	*) shift ;;
+	esac
+done
+printf '%s\n' '---' >>"${HFL_TEST_CURL_LOG}"
+if [[ "${HFL_TEST_PROXY_FAIL:-0}" == "1" && "${proxy}" != "" ]]; then
+	exit 7
+fi
+[[ -n "${output}" ]] || exit 2
+printf 'downloaded\n' >"${output}"
+SH
+chmod +x "${tmp}/bin/curl"
+
+# Load only the production download helper.
+source <(sed -n '/^download_release_file()/,/^}/p' "${remote_deploy}")
+PATH="${tmp}/bin:${PATH}"
+export PATH HFL_TEST_CURL_LOG="${tmp}/curl.log"
+
+DOWNLOAD_PROXY_URL="http://192.168.8.182:7890"
+download_release_file https://example.invalid/release "${tmp}/proxied"
+[[ "$(grep -c '^---$' "${HFL_TEST_CURL_LOG}")" -eq 1 ]]
+grep -Fx -- '--proxy' "${HFL_TEST_CURL_LOG}" >/dev/null
+grep -Fx -- "${DOWNLOAD_PROXY_URL}" "${HFL_TEST_CURL_LOG}" >/dev/null
+grep -Fx -- '--noproxy' "${HFL_TEST_CURL_LOG}" >/dev/null
+grep -Fx 'downloaded' "${tmp}/proxied" >/dev/null
+
+: >"${HFL_TEST_CURL_LOG}"
+export HFL_TEST_PROXY_FAIL=1
+download_release_file https://example.invalid/release "${tmp}/fallback"
+[[ "$(grep -c '^---$' "${HFL_TEST_CURL_LOG}")" -eq 2 ]]
+grep -Fx -- "${DOWNLOAD_PROXY_URL}" "${HFL_TEST_CURL_LOG}" >/dev/null
+grep -Fx 'downloaded' "${tmp}/fallback" >/dev/null
+
+: >"${HFL_TEST_CURL_LOG}"
+unset HFL_TEST_PROXY_FAIL
+DOWNLOAD_PROXY_URL=""
+download_release_file https://example.invalid/release "${tmp}/direct"
+[[ "$(grep -c '^---$' "${HFL_TEST_CURL_LOG}")" -eq 1 ]]
+if grep -F '192.168.8.182' "${HFL_TEST_CURL_LOG}" >/dev/null; then
+	printf 'ERROR: direct Release download unexpectedly used the TEST proxy\n' >&2
+	exit 1
+fi
+grep -Fx 'downloaded' "${tmp}/direct" >/dev/null
+
+printf 'Target-side Release download proxy checks passed.\n'


### PR DESCRIPTION
## Summary

- download complete Release packages consistently on TEST, PREPROD, and PROD target hosts
- support an optional per-target HTTP(S) download proxy with direct fallback
- remove GitHub Runner package staging and SCP transfer
- treat the explicit UNCONFIGURED placeholder as direct-download mode
- add proxy isolation and fallback contract coverage

## Validation

- release download proxy tests
- release and main-channel contract checks
- shared-host Docker guard checks
- pre-start optional configuration checks
- Shell syntax and workflow YAML parsing
- TEST proxy Release range check: approximately 512 KiB/s