### PR TITLE
fix(release): preserve digest aliases and clean main builds

### DIFF
--- a/.github/workflows/artifact_pipeline.yml
+++ b/.github/workflows/artifact_pipeline.yml
@@ -208,6 +208,7 @@ jobs:
           ./tools/quality/test-platform-gateway-auto-deploy.sh
           ./tools/quality/test-agent-gateway-uninstall.sh
           ./tools/quality/test-installer-image-refresh.sh
+          ./tools/quality/test-docker-image-digest-alias.sh
           ./tools/quality/test-upgrade-backup-retention.sh
           ./tools/quality/test-main-channel-contracts.sh
           ./tools/quality/test-shared-host-guard.sh
@@ -916,9 +917,11 @@ jobs:
           retained_id="$ARTIFACT_ID"
           if [[ "$PUBLISH_RESULT" != "success" ]] \
             && [[ "$BUILD_REQUIRED" != "false" || "$PUBLISH_RESULT" != "skipped" ]]; then
-            if gh release view "$ARTIFACT_ID" --json isDraft --jq '.isDraft' 2>/dev/null \
+            if gh release view "$ARTIFACT_ID" --repo "$GITHUB_REPOSITORY" \
+              --json isDraft --jq '.isDraft' 2>/dev/null \
               | grep -Fx true >/dev/null; then
-              gh release delete "$ARTIFACT_ID" --cleanup-tag --yes
+              gh release delete "$ARTIFACT_ID" --repo "$GITHUB_REPOSITORY" \
+                --cleanup-tag --yes
             fi
             retained_id="$(gh api "repos/${GITHUB_REPOSITORY}/releases?per_page=100" --paginate \
               --jq '.[] | select(.draft == false and .prerelease == true and (.tag_name | test("^main-[0-9a-f]{7}$"))) | [.created_at, .tag_name] | @tsv' \
@@ -935,5 +938,6 @@ jobs:
           done < "$RUNNER_TEMP/all-main-builds.txt"
           while IFS= read -r artifact_id; do
             [[ -n "$artifact_id" ]] || continue
-            gh release delete "$artifact_id" --cleanup-tag --yes
+            gh release delete "$artifact_id" --repo "$GITHUB_REPOSITORY" \
+              --cleanup-tag --yes
           done < "$RUNNER_TEMP/expired-main-builds.txt"

--- a/tools/lib/docker-images.sh
+++ b/tools/lib/docker-images.sh
@@ -66,6 +66,15 @@ hfl_docker_pull_with_retry() {
 	return 1
 }
 
+hfl_docker_tag_local_alias() {
+	local source=$1 alias=$2
+	[[ "${source}" != "${alias}" ]] || return 0
+	if ! docker tag "${source}" "${alias}"; then
+		HFL_DOCKER_LAST_ERROR="unable to tag ${source} as ${alias}"
+		return 1
+	fi
+}
+
 hfl_docker_ensure_image() {
 	local image=$1 mirror="${2:-}" force_pull=${3:-0} offline=${4:-0}
 	local platform="${5:-}" timeout_seconds=${6:-180} retries=${7:-2}
@@ -77,23 +86,25 @@ hfl_docker_ensure_image() {
 	[[ -z "${mirror_host}" ]] || mirrored="$(hfl_docker_mirror_image_ref "${image}" "${mirror_host}")"
 
 	if [[ "${force_pull}" -eq 0 ]] && hfl_docker_image_matches_platform "${image}" "${platform}"; then
+		hfl_docker_tag_local_alias "${image}" "${local_alias}" || return 1
 		HFL_DOCKER_IMAGE_SOURCE="local"
 		return 0
 	fi
 	if [[ "${force_pull}" -eq 0 && -n "${mirrored}" ]] \
 		&& hfl_docker_image_matches_platform "${mirrored}" "${platform}"; then
-		docker tag "${mirrored}" "${local_alias}"
+		hfl_docker_tag_local_alias "${mirrored}" "${local_alias}" || return 1
 		HFL_DOCKER_IMAGE_SOURCE="local-mirror"
 		return 0
 	fi
 
 	if [[ "${offline}" -eq 1 ]]; then
 		if hfl_docker_image_matches_platform "${image}" "${platform}"; then
+			hfl_docker_tag_local_alias "${image}" "${local_alias}" || return 1
 			HFL_DOCKER_IMAGE_SOURCE="local-offline"
 			return 0
 		fi
 		if [[ -n "${mirrored}" ]] && hfl_docker_image_matches_platform "${mirrored}" "${platform}"; then
-			docker tag "${mirrored}" "${local_alias}"
+			hfl_docker_tag_local_alias "${mirrored}" "${local_alias}" || return 1
 			HFL_DOCKER_IMAGE_SOURCE="local-mirror-offline"
 			return 0
 		fi
@@ -103,21 +114,23 @@ hfl_docker_ensure_image() {
 
 	if [[ -n "${mirrored}" ]] \
 		&& hfl_docker_pull_with_retry "${mirrored}" "${platform}" "${timeout_seconds}" "${retries}"; then
-		docker tag "${mirrored}" "${local_alias}"
+		hfl_docker_tag_local_alias "${mirrored}" "${local_alias}" || return 1
 		HFL_DOCKER_IMAGE_SOURCE="mirror"
 		return 0
 	fi
 	if hfl_docker_pull_with_retry "${image}" "${platform}" "${timeout_seconds}" "${retries}"; then
+		hfl_docker_tag_local_alias "${image}" "${local_alias}" || return 1
 		HFL_DOCKER_IMAGE_SOURCE="official"
 		return 0
 	fi
 
 	if hfl_docker_image_matches_platform "${image}" "${platform}"; then
+		hfl_docker_tag_local_alias "${image}" "${local_alias}" || return 1
 		HFL_DOCKER_IMAGE_SOURCE="local-fallback"
 		return 0
 	fi
 	if [[ -n "${mirrored}" ]] && hfl_docker_image_matches_platform "${mirrored}" "${platform}"; then
-		docker tag "${mirrored}" "${local_alias}"
+		hfl_docker_tag_local_alias "${mirrored}" "${local_alias}" || return 1
 		HFL_DOCKER_IMAGE_SOURCE="local-mirror-fallback"
 		return 0
 	fi

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -5,6 +5,9 @@ umask 022
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
+grep -F './tools/quality/test-docker-image-digest-alias.sh' \
+	"${ROOT}/.github/workflows/artifact_pipeline.yml" >/dev/null
+
 # shellcheck source=../lib/version.sh
 source "${ROOT}/tools/lib/version.sh"
 actual="$(release_package_basename_for_version v0.1.0 69F809F)"
@@ -293,6 +296,11 @@ grep -F 'Retain only the current successful Main build' "${workflow}" >/dev/null
 grep -F 'needs: [prepare, publish-release]' "${workflow}" >/dev/null
 grep -F 'BUILD_REQUIRED: ${{ needs.prepare.outputs.build_required }}' "${workflow}" >/dev/null
 grep -F '[[ "$BUILD_REQUIRED" != "false" || "$PUBLISH_RESULT" != "skipped" ]]' "${workflow}" >/dev/null
+cleanup_body="$(sed -n '/^  cleanup-main-builds:/,$p' "${workflow}")"
+[[ "$(grep -Fc -- '--repo "$GITHUB_REPOSITORY"' <<<"${cleanup_body}")" -eq 3 ]] || {
+	printf 'ERROR: every Main Release view/delete must select the repository explicitly\n' >&2
+	exit 1
+}
 grep -F 'ubuntu_release: "22.04"' "${workflow}" >/dev/null
 grep -F 'asset: ubuntu2204' "${workflow}" >/dev/null
 

--- a/tools/quality/test-docker-image-digest-alias.sh
+++ b/tools/quality/test-docker-image-digest-alias.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Verify digest-pinned official pulls also create the mutable local alias expected by consumers.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+# shellcheck source=../lib/docker-images.sh
+source "${ROOT}/tools/lib/docker-images.sh"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "${tmp}"' EXIT
+mkdir -p "${tmp}/bin" "${tmp}/state"
+
+cat >"${tmp}/bin/docker" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+case "${1:-}" in
+image)
+	[[ "${2:-}" == "inspect" ]]
+	[[ -f "${HFL_DOCKER_TEST_STATE}/pulled" ]] || exit 1
+	printf 'linux/amd64\n'
+	;;
+pull)
+	touch "${HFL_DOCKER_TEST_STATE}/pulled"
+	;;
+tag)
+	printf '%s\t%s\n' "$2" "$3" >>"${HFL_DOCKER_TEST_STATE}/tags"
+	;;
+*)
+	printf 'unexpected fake docker command: %s\n' "$*" >&2
+	exit 2
+	;;
+esac
+SH
+chmod +x "${tmp}/bin/docker"
+
+export HFL_DOCKER_TEST_STATE="${tmp}/state"
+PATH="${tmp}/bin:${PATH}"
+export PATH
+
+digest="sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+source_ref="nginx:stable-alpine@${digest}"
+hfl_docker_ensure_image "${source_ref}" "" 0 0 linux/amd64 5 1
+
+[[ "${HFL_DOCKER_IMAGE_SOURCE}" == "official" ]]
+grep -Fx "${source_ref}"$'\t'"nginx:stable-alpine" "${tmp}/state/tags" >/dev/null
+
+printf 'Digest-pinned Docker image alias checks passed.\n'


### PR DESCRIPTION
## Summary
- create mutable local aliases after resolving digest-pinned images from every source path
- add a regression test for official digest pulls used by the SourceLens bundle exporter
- make Main Release cleanup explicitly target the repository when no checkout exists
- enforce both contracts in release quality checks

## Validation
- digest alias regression test
- release contract checks
- actionlint
- Bash syntax and git diff checks

## Failure addressed
TEST run 30067370517 failed because the pinned Nginx digest was pulled without the nginx:stable-alpine alias; its cleanup job also lacked explicit --repo arguments.