### PR TITLE
fix(release): make main artifact cleanup idempotent

### DIFF
--- a/.github/workflows/artifact_pipeline.yml
+++ b/.github/workflows/artifact_pipeline.yml
@@ -914,14 +914,26 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          delete_main_artifact() {
+            local artifact_id=$1
+            if gh release view "$artifact_id" --repo "$GITHUB_REPOSITORY" \
+              >/dev/null 2>&1; then
+              gh release delete "$artifact_id" --repo "$GITHUB_REPOSITORY" --yes
+            fi
+            if gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${artifact_id}" \
+              --silent >/dev/null 2>&1; then
+              gh api --method DELETE \
+                "repos/${GITHUB_REPOSITORY}/git/refs/tags/${artifact_id}" --silent
+            fi
+          }
+
           retained_id="$ARTIFACT_ID"
           if [[ "$PUBLISH_RESULT" != "success" ]] \
             && [[ "$BUILD_REQUIRED" != "false" || "$PUBLISH_RESULT" != "skipped" ]]; then
             if gh release view "$ARTIFACT_ID" --repo "$GITHUB_REPOSITORY" \
               --json isDraft --jq '.isDraft' 2>/dev/null \
               | grep -Fx true >/dev/null; then
-              gh release delete "$ARTIFACT_ID" --repo "$GITHUB_REPOSITORY" \
-                --cleanup-tag --yes
+              delete_main_artifact "$ARTIFACT_ID"
             fi
             retained_id="$(gh api "repos/${GITHUB_REPOSITORY}/releases?per_page=100" --paginate \
               --jq '.[] | select(.draft == false and .prerelease == true and (.tag_name | test("^main-[0-9a-f]{7}$"))) | [.created_at, .tag_name] | @tsv' \
@@ -938,6 +950,5 @@ jobs:
           done < "$RUNNER_TEMP/all-main-builds.txt"
           while IFS= read -r artifact_id; do
             [[ -n "$artifact_id" ]] || continue
-            gh release delete "$artifact_id" --repo "$GITHUB_REPOSITORY" \
-              --cleanup-tag --yes
+            delete_main_artifact "$artifact_id"
           done < "$RUNNER_TEMP/expired-main-builds.txt"

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -297,10 +297,15 @@ grep -F 'needs: [prepare, publish-release]' "${workflow}" >/dev/null
 grep -F 'BUILD_REQUIRED: ${{ needs.prepare.outputs.build_required }}' "${workflow}" >/dev/null
 grep -F '[[ "$BUILD_REQUIRED" != "false" || "$PUBLISH_RESULT" != "skipped" ]]' "${workflow}" >/dev/null
 cleanup_body="$(sed -n '/^  cleanup-main-builds:/,$p' "${workflow}")"
-[[ "$(grep -Fc -- '--repo "$GITHUB_REPOSITORY"' <<<"${cleanup_body}")" -eq 3 ]] || {
-	printf 'ERROR: every Main Release view/delete must select the repository explicitly\n' >&2
-	exit 1
-}
+grep -F 'delete_main_artifact()' <<<"${cleanup_body}" >/dev/null
+grep -F 'gh release delete "$artifact_id" --repo "$GITHUB_REPOSITORY" --yes' \
+  <<<"${cleanup_body}" >/dev/null
+grep -F 'git/ref/tags/${artifact_id}' <<<"${cleanup_body}" >/dev/null
+grep -F 'git/refs/tags/${artifact_id}' <<<"${cleanup_body}" >/dev/null
+if grep -F -- '--cleanup-tag' <<<"${cleanup_body}" >/dev/null; then
+  printf 'ERROR: idempotent Main cleanup must not fail when a Release has no Git tag\n' >&2
+  exit 1
+fi
 grep -F 'ubuntu_release: "22.04"' "${workflow}" >/dev/null
 grep -F 'asset: ubuntu2204' "${workflow}" >/dev/null
 


### PR DESCRIPTION
## Summary
- delete Main prereleases independently from their optional Git tags
- make stale draft and published artifact cleanup safe to retry
- prevent missing tag references from failing the cleanup job
- enforce the idempotent cleanup contract

## Validation
- release contract checks
- actionlint
- Bash syntax and git diff checks

## Failure addressed
TEST run 30068006108 published successfully but cleanup failed with HTTP 422 when an old draft Release had no corresponding Git tag.