### PR TITLE
fix(installer): preserve installed Docker dependencies

### DIFF
--- a/.github/workflows/artifact_pipeline.yml
+++ b/.github/workflows/artifact_pipeline.yml
@@ -209,6 +209,7 @@ jobs:
           ./tools/quality/test-agent-gateway-uninstall.sh
           ./tools/quality/test-installer-image-refresh.sh
           ./tools/quality/test-docker-image-digest-alias.sh
+          ./tools/quality/test-offline-docker-package-plan.sh
           ./tools/quality/test-upgrade-backup-retention.sh
           ./tools/quality/test-main-channel-contracts.sh
           ./tools/quality/test-shared-host-guard.sh

--- a/deploy/bootstrap/gateway-install-docker-ubuntu-amd64.sh
+++ b/deploy/bootstrap/gateway-install-docker-ubuntu-amd64.sh
@@ -100,6 +100,56 @@ run_quiet() {
 	fi
 }
 
+select_offline_docker_debs() {
+	local root="$1"
+	local deb package status filename normalized
+	local -a bundled_debs=()
+	deb_files=()
+
+	mapfile -d '' -t bundled_debs < <(find "${root}" -name '*.deb' -type f -print0 | sort -z)
+	for deb in "${bundled_debs[@]}"; do
+		# APT treats the epoch separator in an absolute local filename as a URI
+		# delimiter and can silently ignore that package. Verify the archive before
+		# this function, then give every deb an APT-safe local filename.
+		filename="${deb##*/}"
+		normalized="${deb%/*}/${filename//:/_}"
+		if [[ "${normalized}" != "${deb}" ]]; then
+			[[ ! -e "${normalized}" ]] \
+				|| hfl_fail "Docker offline package filename collision: ${normalized##*/}" 3
+			mv -- "${deb}" "${normalized}"
+			deb="${normalized}"
+		fi
+
+		package="$(dpkg-deb --field "${deb}" Package 2>/dev/null || true)"
+		[[ "${package}" =~ ^[a-z0-9][a-z0-9+.-]+$ ]] \
+			|| hfl_fail "Docker offline bundle contains an invalid deb: ${filename}" 3
+		status="$(dpkg-query -W -f='${db:Status-Abbrev}' -- "${package}" 2>/dev/null || true)"
+		if [[ "${status}" == "ii " ]]; then
+			hfl_ok "Using installed host dependency ${package}."
+			continue
+		fi
+		deb_files+=("${deb}")
+	done
+
+	((${#deb_files[@]} > 0)) \
+		|| hfl_fail "Docker offline bundle has no packages left to install." 3
+}
+
+validate_offline_docker_plan() {
+	local apt_plan="$1"
+	shift
+	if ! apt-get --simulate --no-download --no-install-recommends install "$@" \
+		>"${apt_plan}" 2>&1; then
+		tail -n 12 "${apt_plan}" >&2 || true
+		hfl_fail "Docker offline package plan could not be resolved without downloads." 3
+	fi
+	if grep -Eq '^The following packages will be (REMOVED|upgraded):|^[1-9][0-9]* upgraded,' "${apt_plan}"; then
+		cat "${apt_plan}" >&2
+		hfl_fail "Docker offline install would upgrade or remove existing host packages." 3
+	fi
+}
+
+main() {
 if [[ "$(id -u)" -ne 0 ]]; then
 	hfl_fail "Administrator privileges are required." 1
 fi
@@ -177,20 +227,14 @@ for package in manifest.get("packages", []):
 PY
 
 hfl_step "Installing Docker CE from offline packages (${deb_count} debs)."
-mapfile -t deb_files < <(find "${work_dir}" -name '*.deb' -type f | sort)
-
 command -v apt-get >/dev/null 2>&1 \
 	|| hfl_fail "apt-get is required for the verified offline Docker install." 2
+command -v dpkg-deb >/dev/null 2>&1 \
+	|| hfl_fail "dpkg-deb is required for the verified offline Docker install." 2
+select_offline_docker_debs "${work_dir}"
+hfl_step "Selected ${#deb_files[@]} new packages; installed host dependencies will remain unchanged."
 apt_plan="${work_dir}/apt-plan.log"
-if ! apt-get --simulate --no-download --no-install-recommends install "${deb_files[@]}" \
-	>"${apt_plan}" 2>&1; then
-	tail -n 12 "${apt_plan}" >&2 || true
-	hfl_fail "Docker offline package plan could not be resolved without downloads." 3
-fi
-if grep -Eq '^The following packages will be (REMOVED|upgraded):|^[1-9][0-9]* upgraded,' "${apt_plan}"; then
-	cat "${apt_plan}" >&2
-	hfl_fail "Docker offline install would upgrade or remove existing host packages." 3
-fi
+validate_offline_docker_plan "${apt_plan}" "${deb_files[@]}"
 apt_log="${work_dir}/apt-install.log"
 if ! run_quiet "${apt_log}" apt-get -y --no-download --no-install-recommends install "${deb_files[@]}"; then
 	[[ -s "${apt_log}" ]] && tail -n 12 "${apt_log}" >&2
@@ -207,3 +251,8 @@ docker_runtime_ready "${MIN_ENGINE_VERSION}" \
 	|| hfl_fail "Docker post-install check failed (need engine >= ${MIN_ENGINE_VERSION} and Compose v2 >= ${MIN_COMPOSE_VERSION})." 5
 
 hfl_ok "Docker CE installed (engine $(docker_engine_version), compose $(docker_compose_version))."
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+	main "$@"
+fi

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -7,6 +7,8 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
 grep -F './tools/quality/test-docker-image-digest-alias.sh' \
 	"${ROOT}/.github/workflows/artifact_pipeline.yml" >/dev/null
+grep -F './tools/quality/test-offline-docker-package-plan.sh' \
+	"${ROOT}/.github/workflows/artifact_pipeline.yml" >/dev/null
 
 # shellcheck source=../lib/version.sh
 source "${ROOT}/tools/lib/version.sh"

--- a/tools/quality/test-offline-docker-package-plan.sh
+++ b/tools/quality/test-offline-docker-package-plan.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Verify host-safe offline Docker package selection and APT planning.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+tmp="$(mktemp -d)"
+trap 'rm -rf "${tmp}"' EXIT
+mkdir -p "${tmp}/bin" "${tmp}/debs"
+
+cat >"${tmp}/bin/dpkg-deb" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+file="${2:-}"
+case "${file##*/}" in
+docker-ce-cli_*) printf 'docker-ce-cli\n' ;;
+docker-ce_*) printf 'docker-ce\n' ;;
+docker-compose-plugin_*) printf 'docker-compose-plugin\n' ;;
+containerd.io_*) printf 'containerd.io\n' ;;
+libnftables1_*) printf 'libnftables1\n' ;;
+nftables_*) printf 'nftables\n' ;;
+*) exit 2 ;;
+esac
+SH
+cat >"${tmp}/bin/dpkg-query" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+package="${*: -1}"
+case "${package}" in
+libnftables1|nftables) printf 'ii ' ;;
+*) exit 1 ;;
+esac
+SH
+cat >"${tmp}/bin/apt-get" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${HFL_FAKE_APT_RESULT:-ok}" == "unresolved" ]]; then
+	printf 'docker-ce: Depends: nftables (>= 9.9) but 1.0 is installed\n' >&2
+	exit 100
+fi
+printf '0 upgraded, 4 newly installed, 0 to remove and 0 not upgraded.\n'
+SH
+chmod +x "${tmp}/bin/"*
+
+for package in \
+	'docker-ce_5:29.2.1_amd64.deb' \
+	'docker-ce-cli_5:29.2.1_amd64.deb' \
+	'docker-compose-plugin_5.0.2_amd64.deb' \
+	'containerd.io_2.2.1_amd64.deb' \
+	'libnftables1_1.1.0_amd64.deb' \
+	'nftables_1.1.0_amd64.deb'; do
+	: >"${tmp}/debs/${package}"
+done
+
+PATH="${tmp}/bin:${PATH}"
+export PATH
+# shellcheck source=../../deploy/bootstrap/gateway-install-docker-ubuntu-amd64.sh
+source "${ROOT}/deploy/bootstrap/gateway-install-docker-ubuntu-amd64.sh"
+
+select_offline_docker_debs "${tmp}/debs"
+[[ "${#deb_files[@]}" -eq 4 ]]
+for deb in "${deb_files[@]}"; do
+	[[ "${deb##*/}" != *:* ]]
+done
+[[ -f "${tmp}/debs/docker-ce_5_29.2.1_amd64.deb" ]]
+[[ -f "${tmp}/debs/docker-ce-cli_5_29.2.1_amd64.deb" ]]
+[[ " $(printf '%s ' "${deb_files[@]##*/}") " != *'nftables_1.1.0_amd64.deb'* ]]
+[[ " $(printf '%s ' "${deb_files[@]##*/}") " != *'libnftables1_1.1.0_amd64.deb'* ]]
+
+validate_offline_docker_plan "${tmp}/apt-plan.log" "${deb_files[@]}"
+grep -F '0 upgraded, 4 newly installed' "${tmp}/apt-plan.log" >/dev/null
+
+set +e
+(
+	HFL_FAKE_APT_RESULT=unresolved \
+		validate_offline_docker_plan "${tmp}/unsafe-plan.log" "${deb_files[@]}"
+) >/dev/null 2>&1
+status=$?
+set -e
+[[ "${status}" -eq 3 ]]
+
+printf 'Offline Docker package plan checks passed.\n'


### PR DESCRIPTION
## Summary
- normalize epoch-bearing deb filenames after checksum verification
- reuse already-installed Ubuntu dependencies instead of upgrading the host
- add regression coverage for package selection and unresolved dependency safety

## Verification
- offline Docker package plan regression test
- release contract checks
- Bash syntax and git diff checks
- TEST host real-package APT simulation: 0 upgraded, 4 newly installed