### PR TITLE
fix(installer): install verified Docker debs directly

### DIFF
--- a/deploy/bootstrap/gateway-install-docker-ubuntu-amd64.sh
+++ b/deploy/bootstrap/gateway-install-docker-ubuntu-amd64.sh
@@ -149,6 +149,19 @@ validate_offline_docker_plan() {
 	fi
 }
 
+install_offline_docker_debs() {
+	local install_log="$1"
+	shift
+	# APT has already proved that the exact local package set is dependency-safe
+	# and requires no upgrades, removals, or downloads. Install those verified
+	# files directly: apt-get --no-download can lose the directory of local debs
+	# and fail with "Pathname to install is not absolute" on Ubuntu 24.04.
+	if ! run_quiet "${install_log}" env DEBIAN_FRONTEND=noninteractive dpkg --install "$@"; then
+		[[ -s "${install_log}" ]] && tail -n 12 "${install_log}" >&2
+		hfl_fail "Docker offline package installation failed." 3
+	fi
+}
+
 main() {
 if [[ "$(id -u)" -ne 0 ]]; then
 	hfl_fail "Administrator privileges are required." 1
@@ -236,10 +249,7 @@ hfl_step "Selected ${#deb_files[@]} new packages; installed host dependencies wi
 apt_plan="${work_dir}/apt-plan.log"
 validate_offline_docker_plan "${apt_plan}" "${deb_files[@]}"
 apt_log="${work_dir}/apt-install.log"
-if ! run_quiet "${apt_log}" apt-get -y --no-download --no-install-recommends install "${deb_files[@]}"; then
-	[[ -s "${apt_log}" ]] && tail -n 12 "${apt_log}" >&2
-	hfl_fail "Docker offline package installation failed." 3
-fi
+install_offline_docker_debs "${apt_log}" "${deb_files[@]}"
 
 if command -v systemctl >/dev/null 2>&1; then
 	systemctl enable --now docker >/dev/null 2>&1 \

--- a/tools/quality/test-offline-docker-package-plan.sh
+++ b/tools/quality/test-offline-docker-package-plan.sh
@@ -39,6 +39,12 @@ if [[ "${HFL_FAKE_APT_RESULT:-ok}" == "unresolved" ]]; then
 fi
 printf '0 upgraded, 4 newly installed, 0 to remove and 0 not upgraded.\n'
 SH
+cat >"${tmp}/bin/dpkg" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+[[ "${1:-}" == "--install" ]]
+printf '%s\n' "${@:2}" >"${HFL_DOCKER_TEST_STATE}/installed"
+SH
 chmod +x "${tmp}/bin/"*
 
 for package in \
@@ -53,6 +59,7 @@ done
 
 PATH="${tmp}/bin:${PATH}"
 export PATH
+export HFL_DOCKER_TEST_STATE="${tmp}"
 # shellcheck source=../../deploy/bootstrap/gateway-install-docker-ubuntu-amd64.sh
 source "${ROOT}/deploy/bootstrap/gateway-install-docker-ubuntu-amd64.sh"
 
@@ -68,6 +75,9 @@ done
 
 validate_offline_docker_plan "${tmp}/apt-plan.log" "${deb_files[@]}"
 grep -F '0 upgraded, 4 newly installed' "${tmp}/apt-plan.log" >/dev/null
+install_offline_docker_debs "${tmp}/install.log" "${deb_files[@]}"
+[[ "$(wc -l <"${tmp}/installed")" -eq 4 ]]
+grep -F '/docker-ce_5_29.2.1_amd64.deb' "${tmp}/installed" >/dev/null
 
 set +e
 (


### PR DESCRIPTION
## Summary
- retain APT simulation as the dependency and host-safety gate
- install the verified local deb set directly with dpkg
- cover the real install command in the offline package regression test

## Verification
- offline Docker package plan regression test
- release contract checks
- Bash syntax and git diff checks
- TEST host real-package APT simulation: 0 upgraded, 4 newly installed
- TEST host real-package dpkg dry-run: successful