### PR TITLE
Replace tenant Usage with platform-wide Admin analytics

### DIFF
--- a/src/backend/apps/platform_ops/api/urls.py
+++ b/src/backend/apps/platform_ops/api/urls.py
@@ -40,6 +40,7 @@ from apps.platform_ops.api.views.lens import (
     PlatformOpsLensMcpServerView,
     PlatformOpsLensModelProxyView,
     PlatformOpsLensSkillView,
+    PlatformOpsLensUsageView,
 )
 from apps.platform_ops.api.views.overview import PlatformOpsOverviewView
 from apps.platform_ops.api.views.platform import (
@@ -205,6 +206,7 @@ urlpatterns = [
     path("system/audit", PlatformOpsSystemAuditView.as_view(), name="platform-ops-system-audit"),
     path("system/logs", PlatformOpsSystemLogsView.as_view(), name="platform-ops-system-logs"),
     path("lens/gateways", PlatformOpsLensGatewayListView.as_view(), name="platform-ops-lens-gateways"),
+    path("lens/usage", PlatformOpsLensUsageView.as_view(), name="platform-ops-lens-usage"),
     path(
         "lens/gateways/enrollment",
         PlatformOpsLensGatewayEnrollmentView.as_view(),

--- a/src/backend/apps/platform_ops/api/views/lens.py
+++ b/src/backend/apps/platform_ops/api/views/lens.py
@@ -63,6 +63,7 @@ from apps.node.services.internal.node_lifecycle import (
 )
 from apps.node.services.internal.local_platform_gateway import platform_gateway_api_base
 from apps.platform_ops.api.permissions import IsPlatformOpsStaff
+from apps.platform_ops.selectors.internal.ai_usage import platform_ai_usage_payload
 from common.deploy.site import enrollment_tls_verify
 
 
@@ -93,6 +94,15 @@ def _deployment_managed_model_error() -> Response:
         },
         status=status.HTTP_409_CONFLICT,
     )
+
+
+class PlatformOpsLensUsageView(APIView):
+    """Cross-account AI usage and cost inventory for platform operators."""
+
+    permission_classes = [IsPlatformOpsStaff]
+
+    def get(self, request):
+        return Response(platform_ai_usage_payload(request.query_params))
 
 
 def _set_platform_default_model_ref(

--- a/src/backend/apps/platform_ops/selectors/internal/ai_usage.py
+++ b/src/backend/apps/platform_ops/selectors/internal/ai_usage.py
@@ -1,0 +1,257 @@
+"""Platform-wide AI usage aggregates for the Admin Console."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import Any
+
+from django.db.models import Count, Q, Sum
+from django.db.models.functions import TruncDate, TruncHour
+from django.utils import timezone
+from django.utils.dateparse import parse_date
+
+from apps.lens_bridge.models import LensUsageLedger
+
+
+SUCCESS_STATUSES = ("done", "success", "completed")
+FAILED_STATUSES = ("failed", "error")
+
+
+def _safe_int(value, default: int, *, max_value: int = 100) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return max(1, min(max_value, parsed))
+
+
+def _date_range(params) -> tuple[Any, Any]:
+    today = timezone.localdate()
+    start = parse_date(str(params.get("start_date") or "")) or today
+    end = parse_date(str(params.get("end_date") or "")) or today
+    if start > end:
+        start, end = end, start
+    return start, end
+
+
+def _filtered_rows(params):
+    start, end = _date_range(params)
+    period_rows = LensUsageLedger.objects.filter(
+        occurred_at__date__gte=start,
+        occurred_at__date__lte=end,
+    )
+    rows = period_rows
+    org_key = str(params.get("org") or "").strip()
+    if org_key:
+        rows = rows.filter(organization__key=org_key)
+    status = str(params.get("status") or "").strip()
+    if status:
+        rows = rows.filter(run_status=status)
+    search = str(params.get("search") or "").strip()
+    if search:
+        rows = rows.filter(
+            Q(organization__key__icontains=search)
+            | Q(organization__name__icontains=search)
+            | Q(hfl_user__email__icontains=search)
+            | Q(question__icontains=search)
+            | Q(chat_title__icontains=search)
+            | Q(backup_source_name__icontains=search)
+        )
+    return start, end, period_rows, rows
+
+
+def _summary(rows) -> dict[str, int | float | str]:
+    totals = rows.aggregate(
+        prompt_tokens=Sum("prompt_tokens"),
+        completion_tokens=Sum("completion_tokens"),
+        cached_tokens=Sum("cached_tokens"),
+        reasoning_tokens=Sum("reasoning_tokens"),
+        total_tokens=Sum("total_tokens"),
+        model_calls=Sum("model_calls"),
+        estimated_cost=Sum("estimated_cost"),
+    )
+    requests = rows.count()
+    successful = rows.filter(run_status__in=SUCCESS_STATUSES).count()
+    failed = rows.filter(run_status__in=FAILED_STATUSES).count()
+    terminal = successful + failed
+    return {
+        "estimated_cost": float(totals["estimated_cost"] or 0),
+        "cost_currency": "USD",
+        "total_tokens": int(totals["total_tokens"] or 0),
+        "prompt_tokens": int(totals["prompt_tokens"] or 0),
+        "completion_tokens": int(totals["completion_tokens"] or 0),
+        "cached_tokens": int(totals["cached_tokens"] or 0),
+        "reasoning_tokens": int(totals["reasoning_tokens"] or 0),
+        "model_calls": int(totals["model_calls"] or 0),
+        "requests": requests,
+        "successful_runs": successful,
+        "failed_runs": failed,
+        "success_rate": round((successful / terminal) * 100, 1) if terminal else 0,
+        "organizations": rows.values("organization_id").distinct().count(),
+        "users": rows.exclude(hfl_user_id=None).values("hfl_user_id").distinct().count(),
+    }
+
+
+def _trend(rows, *, start, end) -> list[dict[str, Any]]:
+    same_day = start == end
+    bucket_expression = TruncHour("occurred_at") if same_day else TruncDate("occurred_at")
+    aggregates = (
+        rows.annotate(bucket=bucket_expression)
+        .values("bucket")
+        .annotate(
+            requests=Count("id"),
+            successful_runs=Count("id", filter=Q(run_status__in=SUCCESS_STATUSES)),
+            failed_runs=Count("id", filter=Q(run_status__in=FAILED_STATUSES)),
+            model_calls=Sum("model_calls"),
+            total_tokens=Sum("total_tokens"),
+            estimated_cost=Sum("estimated_cost"),
+        )
+        .order_by("bucket")
+    )
+    index = {
+        row["bucket"].isoformat(): row
+        for row in aggregates
+        if row["bucket"] is not None
+    }
+    buckets: list[Any] = []
+    if same_day:
+        cursor = timezone.make_aware(
+            datetime.combine(start, datetime.min.time()),
+            timezone.get_current_timezone(),
+        )
+        final_hour = timezone.localtime().hour if end == timezone.localdate() else 23
+        buckets = [cursor + timedelta(hours=hour) for hour in range(final_hour + 1)]
+    else:
+        cursor = start
+        while cursor <= end:
+            buckets.append(cursor)
+            cursor += timedelta(days=1)
+    return [
+        {
+            "bucket": bucket.isoformat(),
+            "requests": int((index.get(bucket.isoformat()) or {}).get("requests") or 0),
+            "successful_runs": int(
+                (index.get(bucket.isoformat()) or {}).get("successful_runs") or 0
+            ),
+            "failed_runs": int(
+                (index.get(bucket.isoformat()) or {}).get("failed_runs") or 0
+            ),
+            "model_calls": int(
+                (index.get(bucket.isoformat()) or {}).get("model_calls") or 0
+            ),
+            "total_tokens": int(
+                (index.get(bucket.isoformat()) or {}).get("total_tokens") or 0
+            ),
+            "estimated_cost": float(
+                (index.get(bucket.isoformat()) or {}).get("estimated_cost") or 0
+            ),
+        }
+        for bucket in buckets
+    ]
+
+
+def _organization_usage(rows) -> list[dict[str, Any]]:
+    aggregates = (
+        rows.values(
+            "organization_id",
+            "organization__key",
+            "organization__name",
+        )
+        .annotate(
+            users=Count("hfl_user_id", distinct=True),
+            requests=Count("id"),
+            successful_runs=Count("id", filter=Q(run_status__in=SUCCESS_STATUSES)),
+            failed_runs=Count("id", filter=Q(run_status__in=FAILED_STATUSES)),
+            model_calls=Sum("model_calls"),
+            total_tokens=Sum("total_tokens"),
+            estimated_cost=Sum("estimated_cost"),
+        )
+        .order_by("-estimated_cost", "-total_tokens", "organization__key")
+    )
+    output = []
+    for row in aggregates:
+        terminal = int(row["successful_runs"] or 0) + int(row["failed_runs"] or 0)
+        output.append(
+            {
+                "organization_id": row["organization_id"],
+                "organization_key": row["organization__key"],
+                "organization_name": row["organization__name"],
+                "users": int(row["users"] or 0),
+                "requests": int(row["requests"] or 0),
+                "model_calls": int(row["model_calls"] or 0),
+                "total_tokens": int(row["total_tokens"] or 0),
+                "estimated_cost": float(row["estimated_cost"] or 0),
+                "failed_runs": int(row["failed_runs"] or 0),
+                "success_rate": round(
+                    (int(row["successful_runs"] or 0) / terminal) * 100,
+                    1,
+                )
+                if terminal
+                else 0,
+            }
+        )
+    return output
+
+
+def platform_ai_usage_payload(params) -> dict[str, Any]:
+    start, end, period_rows, rows = _filtered_rows(params)
+    page = _safe_int(params.get("page"), 1)
+    page_size = _safe_int(params.get("page_size"), 20)
+    total = rows.count()
+    offset = (page - 1) * page_size
+    result_rows = rows.select_related("organization", "hfl_user").order_by(
+        "-occurred_at",
+        "-id",
+    )[offset : offset + page_size]
+    return {
+        "period": {
+            "start_date": start.isoformat(),
+            "end_date": end.isoformat(),
+        },
+        "summary": _summary(rows),
+        "trend": _trend(rows, start=start, end=end),
+        "by_organization": _organization_usage(rows),
+        "organization_options": [
+            {"key": row["organization__key"], "name": row["organization__name"]}
+            for row in period_rows.values(
+                "organization__key",
+                "organization__name",
+            )
+            .order_by("organization__name", "organization__key")
+            .distinct()
+        ],
+        "status_options": list(
+            period_rows.exclude(run_status="")
+            .order_by("run_status")
+            .values_list("run_status", flat=True)
+            .distinct()
+        ),
+        "count": total,
+        "page": page,
+        "page_size": page_size,
+        "results": [
+            {
+                "run_uuid": str(row.sl_run_uuid),
+                "time": row.occurred_at,
+                "organization_id": row.organization_id,
+                "organization_key": row.organization.key,
+                "organization_name": row.organization.name,
+                "user_id": row.hfl_user_id,
+                "user_email": row.hfl_user.email if row.hfl_user else "",
+                "question": row.question,
+                "chat_title": row.chat_title,
+                "backup_source_name": row.backup_source_name,
+                "status": row.run_status,
+                "model_calls": row.model_calls,
+                "total_tokens": row.total_tokens,
+                "estimated_cost": (
+                    float(row.estimated_cost)
+                    if row.estimated_cost is not None
+                    else None
+                ),
+                "cost_currency": row.cost_currency,
+                "error": row.run_error,
+            }
+            for row in result_rows
+        ],
+    }

--- a/src/backend/apps/platform_ops/tests/test_ai_usage.py
+++ b/src/backend/apps/platform_ops/tests/test_ai_usage.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import uuid
+from datetime import timedelta
+from decimal import Decimal
+
+from django.contrib.auth.models import User
+from django.test import TestCase, override_settings
+from django.utils import timezone
+from rest_framework.test import APIClient
+
+from apps.iam.models import Organization
+from apps.lens_bridge.models import LensUsageLedger
+
+
+def _payload(response):
+    data = response.data
+    if isinstance(data, dict) and "data" in data and "code" in data:
+        return data["data"]
+    return data
+
+
+@override_settings(HFL_PLATFORM_OPS_ENABLED=True)
+class PlatformOpsAiUsageTests(TestCase):
+    path = "/api/v1/platform-ops/lens/usage"
+
+    def setUp(self):
+        self.client = APIClient()
+        self.client.defaults["HTTP_X_HFL_SITE_ROLE"] = "ops"
+        self.staff = User.objects.create_user(
+            username="ai-usage-admin@example.com",
+            email="ai-usage-admin@example.com",
+            password="Pass1234",
+            is_staff=True,
+        )
+        self.client.force_authenticate(user=self.staff)
+        self.acme = Organization.objects.create(key="acme", name="Acme")
+        self.beta = Organization.objects.create(key="beta", name="Beta")
+        self.acme_user = User.objects.create_user(
+            username="acme@example.com",
+            email="acme@example.com",
+        )
+        self.beta_user = User.objects.create_user(
+            username="beta@example.com",
+            email="beta@example.com",
+        )
+        now = timezone.now()
+        LensUsageLedger.objects.create(
+            organization=self.acme,
+            hfl_user=self.acme_user,
+            sl_user_id=10,
+            sl_run_uuid=uuid.uuid4(),
+            question="Summarize finance",
+            run_status="done",
+            prompt_tokens=100,
+            completion_tokens=20,
+            total_tokens=120,
+            model_calls=2,
+            estimated_cost=Decimal("0.012"),
+            occurred_at=now,
+        )
+        LensUsageLedger.objects.create(
+            organization=self.beta,
+            hfl_user=self.beta_user,
+            sl_user_id=11,
+            sl_run_uuid=uuid.uuid4(),
+            question="Find failed backups",
+            run_status="failed",
+            prompt_tokens=50,
+            completion_tokens=10,
+            total_tokens=60,
+            model_calls=1,
+            estimated_cost=Decimal("0.006"),
+            occurred_at=now,
+        )
+        LensUsageLedger.objects.create(
+            organization=self.acme,
+            hfl_user=self.acme_user,
+            sl_user_id=10,
+            sl_run_uuid=uuid.uuid4(),
+            question="Old request",
+            run_status="done",
+            total_tokens=999,
+            occurred_at=now - timedelta(days=2),
+        )
+
+    def test_returns_platform_wide_usage(self):
+        response = self.client.get(self.path)
+
+        self.assertEqual(response.status_code, 200)
+        payload = _payload(response)
+        self.assertEqual(payload["summary"]["requests"], 2)
+        self.assertEqual(payload["summary"]["organizations"], 2)
+        self.assertEqual(payload["summary"]["users"], 2)
+        self.assertEqual(payload["summary"]["total_tokens"], 180)
+        self.assertEqual(payload["summary"]["model_calls"], 3)
+        self.assertEqual(payload["summary"]["success_rate"], 50.0)
+        self.assertEqual(payload["count"], 2)
+        self.assertEqual(len(payload["by_organization"]), 2)
+
+    def test_filters_by_organization_and_search(self):
+        response = self.client.get(
+            self.path,
+            {"org": "acme", "search": "finance"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        payload = _payload(response)
+        self.assertEqual(payload["count"], 1)
+        self.assertEqual(payload["results"][0]["organization_key"], "acme")
+        self.assertEqual(payload["results"][0]["user_email"], "acme@example.com")
+        self.assertEqual(payload["summary"]["success_rate"], 100.0)

--- a/src/frontend/src/platform-ops/lib/platformOpsApi.ts
+++ b/src/frontend/src/platform-ops/lib/platformOpsApi.ts
@@ -261,6 +261,78 @@ export interface PlatformIntegration {
   managed_by: string
 }
 
+export interface PlatformAiUsageSummary {
+  estimated_cost: number
+  cost_currency: string
+  total_tokens: number
+  prompt_tokens: number
+  completion_tokens: number
+  cached_tokens: number
+  reasoning_tokens: number
+  model_calls: number
+  requests: number
+  successful_runs: number
+  failed_runs: number
+  success_rate: number
+  organizations: number
+  users: number
+}
+
+export interface PlatformAiUsageTrend {
+  bucket: string
+  requests: number
+  successful_runs: number
+  failed_runs: number
+  model_calls: number
+  total_tokens: number
+  estimated_cost: number
+}
+
+export interface PlatformAiOrganizationUsage {
+  organization_id: number
+  organization_key: string
+  organization_name: string
+  users: number
+  requests: number
+  model_calls: number
+  total_tokens: number
+  estimated_cost: number
+  failed_runs: number
+  success_rate: number
+}
+
+export interface PlatformAiUsageRun {
+  run_uuid: string
+  time: string
+  organization_id: number
+  organization_key: string
+  organization_name: string
+  user_id: number | null
+  user_email: string
+  question: string
+  chat_title: string
+  backup_source_name: string
+  status: string
+  model_calls: number
+  total_tokens: number
+  estimated_cost: number | null
+  cost_currency: string
+  error: string
+}
+
+export interface PlatformAiUsagePayload {
+  period: { start_date: string; end_date: string }
+  summary: PlatformAiUsageSummary
+  trend: PlatformAiUsageTrend[]
+  by_organization: PlatformAiOrganizationUsage[]
+  organization_options: Array<{ key: string; name: string }>
+  status_options: string[]
+  count: number
+  page: number
+  page_size: number
+  results: PlatformAiUsageRun[]
+}
+
 export async function fetchMonitoringIncidents(params: Record<string, string | number | undefined>) {
   return get<Paginated<MonitoringIncident, IncidentStats>>(
     `/api/v1/platform-ops/monitoring/alerts${qs(params)}`,
@@ -336,6 +408,10 @@ export async function fetchPlatformAuditLogs(params: Record<string, string | num
 
 export async function fetchPlatformIntegrations() {
   return get<{ integrations: PlatformIntegration[] }>('/api/v1/platform-ops/platform/integrations')
+}
+
+export async function fetchPlatformAiUsage(params: Record<string, string | number | undefined>) {
+  return get<PlatformAiUsagePayload>(`/api/v1/platform-ops/lens/usage${qs(params)}`)
 }
 
 export type DeploymentHostItem = {

--- a/src/frontend/src/platform-ops/pages/engine/PlatformUsage.vue
+++ b/src/frontend/src/platform-ops/pages/engine/PlatformUsage.vue
@@ -1,0 +1,412 @@
+<script setup lang="ts">
+import { computed, nextTick, onBeforeUnmount, onMounted, reactive, ref, watch } from 'vue'
+import { use } from 'echarts/core'
+import { LineChart } from 'echarts/charts'
+import { GridComponent, TooltipComponent } from 'echarts/components'
+import { CanvasRenderer } from 'echarts/renderers'
+import VChart from 'vue-echarts'
+import { ElMessage } from 'element-plus'
+import {
+  Activity,
+  Building2,
+  CircleDollarSign,
+  Coins,
+  Cpu,
+  RefreshCw,
+  Search,
+} from 'lucide-vue-next'
+import HflPagination from '../../../components/HflPagination.vue'
+import OpsStatCard from '../../../components/ops/OpsStatCard.vue'
+import { useResponsiveDrawerWidth } from '../../../composables/useResponsiveDrawerWidth'
+import { apiErrorMessage } from '../../../lib/api'
+import { formatLocalDateTime } from '../../../lib/dateTime'
+import PlatformOpsOrgLink from '../../components/PlatformOpsOrgLink.vue'
+import PlatformOpsStatusPill from '../../components/PlatformOpsStatusPill.vue'
+import PlatformOpsUserLink from '../../components/PlatformOpsUserLink.vue'
+import {
+  fetchPlatformAiUsage,
+  type PlatformAiOrganizationUsage,
+  type PlatformAiUsagePayload,
+  type PlatformAiUsageRun,
+} from '../../lib/platformOpsApi'
+
+use([CanvasRenderer, LineChart, GridComponent, TooltipComponent])
+
+const emptySummary = {
+  estimated_cost: 0,
+  cost_currency: 'USD',
+  total_tokens: 0,
+  prompt_tokens: 0,
+  completion_tokens: 0,
+  cached_tokens: 0,
+  reasoning_tokens: 0,
+  model_calls: 0,
+  requests: 0,
+  successful_runs: 0,
+  failed_runs: 0,
+  success_rate: 0,
+  organizations: 0,
+  users: 0,
+}
+
+const loading = ref(false)
+const data = ref<PlatformAiUsagePayload | null>(null)
+const chartMetric = ref<'requests' | 'tokens' | 'cost'>('requests')
+const periodPreset = ref<'today' | '7d' | '30d' | 'month' | 'custom'>('today')
+const customRange = ref<[string, string] | null>(null)
+const selected = ref<PlatformAiUsageRun | null>(null)
+const drawerOpen = ref(false)
+const { drawerSize } = useResponsiveDrawerWidth(3)
+const pagination = reactive({ page: 1, pageSize: 20, count: 0 })
+const filters = reactive({ search: '', org: '', status: '' })
+const range = reactive({ startDate: '', endDate: '' })
+let searchTimer: ReturnType<typeof setTimeout> | null = null
+let clearingFilters = false
+
+const summary = computed(() => data.value?.summary || emptySummary)
+const organizationRows = computed(() => data.value?.by_organization || [])
+const runRows = computed(() => data.value?.results || [])
+
+function localDateValue(date: Date) {
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
+function presetRange(preset: 'today' | '7d' | '30d' | 'month') {
+  const end = new Date()
+  const start = new Date(end)
+  if (preset === '7d') start.setDate(end.getDate() - 6)
+  if (preset === '30d') start.setDate(end.getDate() - 29)
+  if (preset === 'month') start.setDate(1)
+  return [localDateValue(start), localDateValue(end)] as const
+}
+
+function selectPreset(preset: 'today' | '7d' | '30d' | 'month') {
+  periodPreset.value = preset
+  const values = presetRange(preset)
+  range.startDate = values[0]
+  range.endDate = values[1]
+  customRange.value = null
+  reloadFromFirstPage()
+}
+
+function applyCustomRange(value: [string, string] | null) {
+  if (!value?.[0] || !value?.[1]) return
+  periodPreset.value = 'custom'
+  range.startDate = value[0]
+  range.endDate = value[1]
+  reloadFromFirstPage()
+}
+
+function formatNumber(value: number | null | undefined) {
+  return new Intl.NumberFormat('en-US').format(Number(value || 0))
+}
+
+function formatCompact(value: number | null | undefined) {
+  return new Intl.NumberFormat('en-US', {
+    notation: 'compact',
+    maximumFractionDigits: 2,
+  }).format(Number(value || 0))
+}
+
+function formatAverage(value: number) {
+  return new Intl.NumberFormat('en-US', { maximumFractionDigits: 2 }).format(value)
+}
+
+function formatCost(value: number | null | undefined, currency = 'USD') {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency,
+    minimumFractionDigits: 2,
+    maximumFractionDigits: Number(value || 0) < 0.01 ? 6 : 4,
+  }).format(Number(value || 0))
+}
+
+function formatTrendLabel(value: string) {
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+  const sameDay = range.startDate === range.endDate
+  return new Intl.DateTimeFormat('en-US', sameDay
+    ? { hour: '2-digit', minute: '2-digit', hour12: false }
+    : { month: 'short', day: 'numeric' }).format(date)
+}
+
+function statusLabel(status: string) {
+  if (['done', 'success', 'completed'].includes(status)) return 'Completed'
+  if (['failed', 'error'].includes(status)) return 'Failed'
+  if (status === 'cancelled') return 'Cancelled'
+  if (status === 'queued') return 'Queued'
+  if (['running', 'streaming'].includes(status)) return 'In Progress'
+  return status || 'Unknown'
+}
+
+const tokenBreakdown = computed(() => {
+  const total = Math.max(summary.value.total_tokens, 1)
+  return [
+    { label: 'Input Tokens', value: summary.value.prompt_tokens, color: '#6d5ef6' },
+    { label: 'Output Tokens', value: summary.value.completion_tokens, color: '#16a085' },
+    { label: 'Cached Input', value: summary.value.cached_tokens, color: '#2f7cf6' },
+    { label: 'Reasoning', value: summary.value.reasoning_tokens, color: '#e39a24' },
+  ].map((row) => ({ ...row, percent: Math.min(100, (row.value / total) * 100) }))
+})
+
+const chartOption = computed(() => {
+  const rows = data.value?.trend || []
+  const color = chartMetric.value === 'cost' ? '#e39a24' : chartMetric.value === 'tokens' ? '#6d5ef6' : '#2f7cf6'
+  return {
+    animationDuration: 240,
+    grid: { left: 20, right: 18, top: 22, bottom: 12, containLabel: true },
+    tooltip: {
+      trigger: 'axis',
+      formatter: (params: Array<{ axisValueLabel?: string; value?: number }>) => {
+        const point = params[0]
+        const value = Number(point?.value || 0)
+        const formatted = chartMetric.value === 'cost'
+          ? formatCost(value)
+          : chartMetric.value === 'tokens'
+            ? `${formatNumber(value)} tokens`
+            : `${formatNumber(value)} requests`
+        return `${point?.axisValueLabel || ''}\n${formatted}`
+      },
+    },
+    xAxis: {
+      type: 'category',
+      boundaryGap: false,
+      data: rows.map((row) => formatTrendLabel(row.bucket)),
+      axisLine: { lineStyle: { color: '#d9dce5' } },
+      axisTick: { show: false },
+      axisLabel: { color: '#85899a', fontSize: 11 },
+    },
+    yAxis: {
+      type: 'value',
+      minInterval: chartMetric.value === 'cost' ? undefined : 1,
+      axisLine: { show: false },
+      axisTick: { show: false },
+      splitLine: { lineStyle: { color: '#eceef4', type: 'dashed' } },
+      axisLabel: {
+        color: '#85899a',
+        fontSize: 11,
+        formatter: (value: number) => chartMetric.value === 'cost' ? `$${value}` : formatCompact(value),
+      },
+    },
+    series: [{
+      type: 'line',
+      smooth: 0.3,
+      symbol: 'circle',
+      symbolSize: 6,
+      showSymbol: rows.length < 16,
+      lineStyle: { width: 2.5, color },
+      itemStyle: { color },
+      areaStyle: { color: `${color}18` },
+      data: rows.map((row) => chartMetric.value === 'cost'
+        ? row.estimated_cost
+        : chartMetric.value === 'tokens'
+          ? row.total_tokens
+          : row.requests),
+    }],
+  }
+})
+
+async function load(showFeedback = false) {
+  loading.value = true
+  try {
+    const payload = await fetchPlatformAiUsage({
+      start_date: range.startDate,
+      end_date: range.endDate,
+      page: pagination.page,
+      page_size: pagination.pageSize,
+      ...filters,
+    })
+    data.value = payload
+    pagination.count = payload.count
+    if (showFeedback) ElMessage.success({ message: 'AI usage refreshed.', grouping: true })
+  } catch (error) {
+    ElMessage.error({ message: apiErrorMessage(error, 'Unable to load platform AI usage.'), grouping: true })
+  } finally {
+    loading.value = false
+  }
+}
+
+function filterOrganization(row: PlatformAiOrganizationUsage) {
+  filters.org = row.organization_key
+}
+
+function reloadFromFirstPage() {
+  if (pagination.page !== 1) {
+    pagination.page = 1
+    return
+  }
+  void load()
+}
+
+function clearFilters() {
+  clearingFilters = true
+  if (searchTimer) clearTimeout(searchTimer)
+  Object.assign(filters, { search: '', org: '', status: '' })
+  void nextTick(() => {
+    clearingFilters = false
+    reloadFromFirstPage()
+  })
+}
+
+function openRun(row: PlatformAiUsageRun) {
+  selected.value = row
+  drawerOpen.value = true
+}
+
+watch(() => [filters.org, filters.status], () => {
+  if (!clearingFilters) reloadFromFirstPage()
+})
+watch(() => filters.search, () => {
+  if (clearingFilters) return
+  if (searchTimer) clearTimeout(searchTimer)
+  searchTimer = setTimeout(() => {
+    reloadFromFirstPage()
+  }, 320)
+})
+watch(() => pagination.page, () => void load())
+watch(() => pagination.pageSize, () => reloadFromFirstPage())
+
+onMounted(() => {
+  const values = presetRange('today')
+  range.startDate = values[0]
+  range.endDate = values[1]
+  void load()
+})
+
+onBeforeUnmount(() => {
+  if (searchTimer) clearTimeout(searchTimer)
+})
+</script>
+
+<template>
+  <div v-loading="loading && !data" class="platform-ai-usage">
+    <div class="platform-ai-usage__lead">
+      <div>
+        <p>Monitor AI requests, tokens, cost, and reliability across all customer accounts.</p>
+        <span>{{ summary.organizations }} active accounts · {{ summary.users }} active users in this period</span>
+      </div>
+      <div class="platform-ai-usage__period">
+        <div class="platform-ai-usage__segments" aria-label="Usage period">
+          <button :class="{ active: periodPreset === 'today' }" type="button" @click="selectPreset('today')">Today</button>
+          <button :class="{ active: periodPreset === '7d' }" type="button" @click="selectPreset('7d')">Last 7 Days</button>
+          <button :class="{ active: periodPreset === '30d' }" type="button" @click="selectPreset('30d')">Last 30 Days</button>
+          <button :class="{ active: periodPreset === 'month' }" type="button" @click="selectPreset('month')">This Month</button>
+        </div>
+        <el-date-picker
+          v-model="customRange"
+          type="daterange"
+          unlink-panels
+          format="YYYY-MM-DD"
+          value-format="YYYY-MM-DD"
+          :name="['platform-usage-start-date', 'platform-usage-end-date']"
+          range-separator="~"
+          start-placeholder="Start date"
+          end-placeholder="End date"
+          @change="applyCustomRange"
+        />
+        <el-button class="hfl-refresh-button" title="Refresh" :disabled="loading" @click="load(true)">
+          <RefreshCw :size="16" :class="{ 'is-spinning': loading }" />
+        </el-button>
+      </div>
+    </div>
+
+    <div class="platform-ai-usage__stats">
+      <OpsStatCard label="Total Cost" :value="formatCost(summary.estimated_cost, summary.cost_currency)" :sub="`${summary.requests} AI requests`" accent="orange" accent-side="left"><template #icon><CircleDollarSign :size="16" /></template></OpsStatCard>
+      <OpsStatCard label="AI Requests" :value="formatNumber(summary.requests)" :sub="`${summary.failed_runs} failed`" accent="blue" accent-side="left" :pulse="summary.failed_runs > 0"><template #icon><Activity :size="16" /></template></OpsStatCard>
+      <OpsStatCard label="Model Calls" :value="formatNumber(summary.model_calls)" :sub="`${formatAverage(summary.requests ? summary.model_calls / summary.requests : 0)} per request`" accent="indigo" accent-side="left"><template #icon><Cpu :size="16" /></template></OpsStatCard>
+      <OpsStatCard label="Total Tokens" :value="formatCompact(summary.total_tokens)" :sub="`${formatCompact(summary.prompt_tokens)} input`" accent="pink" accent-side="left"><template #icon><Coins :size="16" /></template></OpsStatCard>
+      <OpsStatCard label="Success Rate" :value="`${summary.success_rate}%`" :sub="`${summary.successful_runs} successful`" :accent="summary.failed_runs ? 'orange' : 'green'" accent-side="left"><template #icon><Building2 :size="16" /></template></OpsStatCard>
+    </div>
+
+    <div class="platform-ai-usage__analysis-grid">
+      <section class="platform-ai-usage__panel platform-ai-usage__trend">
+        <header><div><h2>Platform Usage Trend</h2><p>Aggregated across all matching accounts</p></div><div class="platform-ai-usage__segments platform-ai-usage__segments--small"><button :class="{ active: chartMetric === 'requests' }" type="button" @click="chartMetric = 'requests'">Requests</button><button :class="{ active: chartMetric === 'tokens' }" type="button" @click="chartMetric = 'tokens'">Tokens</button><button :class="{ active: chartMetric === 'cost' }" type="button" @click="chartMetric = 'cost'">Cost</button></div></header>
+        <VChart v-if="data?.trend.length" class="platform-ai-usage__chart" :option="chartOption" autoresize />
+        <el-empty v-else description="No AI usage for this period" :image-size="68" />
+      </section>
+      <section class="platform-ai-usage__panel platform-ai-usage__tokens">
+        <header><div><h2>Token Breakdown</h2><p>{{ formatNumber(summary.total_tokens) }} total tokens</p></div></header>
+        <div class="platform-ai-usage__token-list"><div v-for="row in tokenBreakdown" :key="row.label"><div><span>{{ row.label }}</span><strong>{{ formatCompact(row.value) }}</strong></div><el-progress :percentage="row.percent" :show-text="false" :stroke-width="6" :color="row.color" /></div></div>
+      </section>
+    </div>
+
+    <section class="platform-ai-usage__panel">
+      <header><div><h2>Usage by Account</h2><p>Compare adoption, cost, and reliability across customer accounts</p></div></header>
+      <el-table :data="organizationRows" stripe class="hfl-list-table" row-key="organization_id">
+        <el-table-column label="Account" min-width="210"><template #default="{ row }"><button type="button" class="platform-ai-usage__account-button" @click="filterOrganization(row)">{{ row.organization_name }}</button><span class="platform-ai-usage__cell-meta">{{ row.organization_key }}</span></template></el-table-column>
+        <el-table-column prop="users" label="Users" width="90" />
+        <el-table-column prop="requests" label="Requests" width="105" />
+        <el-table-column prop="model_calls" label="Model Calls" width="115" />
+        <el-table-column label="Tokens" width="120"><template #default="{ row }">{{ formatCompact(row.total_tokens) }}</template></el-table-column>
+        <el-table-column label="Success Rate" width="130"><template #default="{ row }"><span :class="{ 'is-attention': row.failed_runs > 0 }">{{ row.success_rate }}%</span></template></el-table-column>
+        <el-table-column label="Cost" width="130"><template #default="{ row }">{{ formatCost(row.estimated_cost) }}</template></el-table-column>
+        <template #empty><el-empty description="No account usage for this period" :image-size="68" /></template>
+      </el-table>
+    </section>
+
+    <section class="platform-ai-usage__panel">
+      <header><div><h2>AI Request History</h2><p>Investigate individual platform AI runs</p></div></header>
+      <div class="platform-ai-usage__filters">
+        <el-input v-model="filters.search" clearable placeholder="Search account, user, question, or source"><template #prefix><Search :size="15" /></template></el-input>
+        <el-select v-model="filters.org" clearable filterable placeholder="Account"><el-option v-for="org in data?.organization_options || []" :key="org.key" :label="org.name" :value="org.key" /></el-select>
+        <el-select v-model="filters.status" clearable placeholder="Status"><el-option v-for="status in data?.status_options || []" :key="status" :label="statusLabel(status)" :value="status" /></el-select>
+        <el-button v-if="filters.search || filters.org || filters.status" text @click="clearFilters">Reset</el-button>
+      </div>
+      <el-table :data="runRows" stripe class="hfl-list-table" row-key="run_uuid">
+        <el-table-column label="Time" width="170"><template #default="{ row }">{{ formatLocalDateTime(row.time, '—') }}</template></el-table-column>
+        <el-table-column label="Request" min-width="280"><template #default="{ row }"><button type="button" class="platform-ai-usage__request-button" @click="openRun(row)">{{ row.question || row.chat_title || 'Untitled request' }}</button><span class="platform-ai-usage__cell-meta">{{ row.backup_source_name || row.chat_title || '—' }}</span></template></el-table-column>
+        <el-table-column label="Account" min-width="150"><template #default="{ row }"><PlatformOpsOrgLink :org-id="row.organization_id" :org-key="row.organization_key" /></template></el-table-column>
+        <el-table-column label="User" min-width="190"><template #default="{ row }"><PlatformOpsUserLink :user-id="row.user_id" :display-name="row.user_email || 'Deleted user'" /></template></el-table-column>
+        <el-table-column label="Status" width="115"><template #default="{ row }"><PlatformOpsStatusPill :status="statusLabel(row.status)" /></template></el-table-column>
+        <el-table-column label="Calls" width="80"><template #default="{ row }">{{ formatNumber(row.model_calls) }}</template></el-table-column>
+        <el-table-column label="Tokens" width="105"><template #default="{ row }">{{ formatCompact(row.total_tokens) }}</template></el-table-column>
+        <el-table-column label="Cost" width="120"><template #default="{ row }">{{ formatCost(row.estimated_cost, row.cost_currency) }}</template></el-table-column>
+        <template #empty><el-empty description="No AI requests match the current filters" :image-size="68" /></template>
+      </el-table>
+      <div class="platform-ai-usage__pagination"><HflPagination v-model:current-page="pagination.page" v-model:page-size="pagination.pageSize" :total="pagination.count" /></div>
+    </section>
+
+    <el-drawer v-model="drawerOpen" :size="drawerSize" destroy-on-close>
+      <template #header><div class="platform-monitoring-drawer__header"><h2>AI Request</h2><p>{{ selected?.organization_name }} · {{ selected?.status }}</p></div></template>
+      <template v-if="selected"><section class="platform-monitoring-drawer__section"><h3>Request Context</h3><div class="platform-monitoring-drawer__grid"><div class="platform-monitoring-drawer__field"><span>Time</span><strong>{{ formatLocalDateTime(selected.time, '—') }}</strong></div><div class="platform-monitoring-drawer__field"><span>User</span><strong>{{ selected.user_email || 'Deleted user' }}</strong></div><div class="platform-monitoring-drawer__field"><span>Model Calls</span><strong>{{ formatNumber(selected.model_calls) }}</strong></div><div class="platform-monitoring-drawer__field"><span>Total Tokens</span><strong>{{ formatNumber(selected.total_tokens) }}</strong></div><div class="platform-monitoring-drawer__field"><span>Estimated Cost</span><strong>{{ formatCost(selected.estimated_cost, selected.cost_currency) }}</strong></div><div class="platform-monitoring-drawer__field"><span>Backup Source</span><strong>{{ selected.backup_source_name || '—' }}</strong></div></div></section><section class="platform-monitoring-drawer__section"><h3>Question</h3><p class="platform-monitoring-drawer__message">{{ selected.question || 'No question recorded.' }}</p></section><section v-if="selected.error" class="platform-monitoring-drawer__section"><h3>Error</h3><pre class="platform-monitoring-drawer__message">{{ selected.error }}</pre></section></template>
+    </el-drawer>
+  </div>
+</template>
+
+<style scoped>
+.platform-ai-usage { display: flex; flex: 1 1 auto; min-width: 0; min-height: 0; flex-direction: column; gap: 16px; overflow-y: auto; }
+.platform-ai-usage > * { flex-shrink: 0; }
+.platform-ai-usage__lead { display: flex; align-items: flex-start; justify-content: space-between; gap: 20px; }
+.platform-ai-usage__lead p { margin: 0; color: var(--page-text-secondary, #70707e); font-size: 13px; line-height: 1.5; }
+.platform-ai-usage__lead span { display: block; margin-top: 4px; color: var(--color-text-tertiary, #9c9caa); font-size: 11px; }
+.platform-ai-usage__period { display: flex; align-items: center; gap: 8px; }
+.platform-ai-usage__period :deep(.el-date-editor) { width: 250px; }
+.platform-ai-usage__segments { display: inline-flex; padding: 3px; border-radius: 8px; background: var(--color-grey-2, #f5f5f7); }
+.platform-ai-usage__segments button { min-height: 30px; padding: 0 12px; border: 0; border-radius: 6px; background: transparent; color: var(--color-text-secondary, #70707e); cursor: pointer; font: inherit; font-size: 12px; }
+.platform-ai-usage__segments button.active { background: var(--color-card-bg, #fff); color: var(--color-primary, #6d5ef6); box-shadow: 0 1px 3px rgba(15, 23, 42, 0.08); }
+.platform-ai-usage__segments--small button { min-height: 27px; padding-inline: 10px; }
+.platform-ai-usage__stats { display: grid; grid-template-columns: repeat(5, minmax(0, 1fr)); gap: 12px; }
+.platform-ai-usage__analysis-grid { display: grid; grid-template-columns: minmax(0, 2fr) minmax(280px, 0.8fr); gap: 16px; }
+.platform-ai-usage__panel { min-width: 0; overflow: hidden; border: 1px solid var(--color-border, #e9e9ef); border-radius: 10px; background: var(--color-card-bg, #fff); }
+.platform-ai-usage__panel > header { display: flex; min-height: 58px; align-items: center; justify-content: space-between; gap: 12px; padding: 10px 16px; border-bottom: 1px solid var(--color-border-light, #f2f2f6); }
+.platform-ai-usage__panel h2 { margin: 0; color: var(--color-text-title, #1c1c26); font-size: 14px; font-weight: 650; }
+.platform-ai-usage__panel header p { margin: 3px 0 0; color: var(--color-text-secondary, #70707e); font-size: 11px; }
+.platform-ai-usage__chart { height: 280px; }
+.platform-ai-usage__tokens { min-height: 340px; }
+.platform-ai-usage__token-list { display: grid; gap: 20px; padding: 24px 20px; }
+.platform-ai-usage__token-list > div > div { display: flex; align-items: center; justify-content: space-between; margin-bottom: 8px; color: var(--color-text-secondary, #70707e); font-size: 12px; }
+.platform-ai-usage__token-list strong { color: var(--color-text-title, #1c1c26); font-size: 13px; }
+.platform-ai-usage__filters { display: grid; grid-template-columns: minmax(240px, 1fr) 180px 150px auto; gap: 8px; padding: 12px 16px; border-bottom: 1px solid var(--color-border-light, #f2f2f6); }
+.platform-ai-usage__account-button,.platform-ai-usage__request-button { display: block; max-width: 100%; padding: 0; overflow: hidden; border: 0; background: transparent; color: var(--color-text-title, #1c1c26); cursor: pointer; font: inherit; font-weight: 600; text-align: left; text-overflow: ellipsis; white-space: nowrap; }
+.platform-ai-usage__account-button:hover,.platform-ai-usage__request-button:hover { color: var(--color-primary, #6d5ef6); text-decoration: underline; text-underline-offset: 3px; }
+.platform-ai-usage__cell-meta { display: block; margin-top: 2px; overflow: hidden; color: var(--color-text-secondary, #70707e); font-size: 11px; text-overflow: ellipsis; white-space: nowrap; }
+.platform-ai-usage .is-attention { color: var(--color-warning, #e08b0b); font-weight: 600; }
+.platform-ai-usage__pagination { padding: 10px 16px; border-top: 1px solid var(--color-border-light, #f2f2f6); }
+@media (max-width: 1500px) { .platform-ai-usage__stats { grid-template-columns: repeat(3, minmax(0, 1fr)); } }
+@media (max-width: 1100px) { .platform-ai-usage__lead { flex-direction: column; } .platform-ai-usage__period { width: 100%; flex-wrap: wrap; } .platform-ai-usage__analysis-grid { grid-template-columns: 1fr; } }
+@media (max-width: 760px) { .platform-ai-usage__stats { grid-template-columns: 1fr; } .platform-ai-usage__period,.platform-ai-usage__segments { width: 100%; } .platform-ai-usage__segments button { flex: 1; padding-inline: 4px; } .platform-ai-usage__period :deep(.el-date-editor) { width: calc(100% - 44px); } .platform-ai-usage__filters { grid-template-columns: 1fr; } .platform-ai-usage__panel { overflow-x: auto; } }
+@media (prefers-reduced-motion: reduce) { .platform-ai-usage * { animation-duration: 0.01ms !important; transition-duration: 0.01ms !important; } }
+</style>

--- a/src/frontend/src/platform-ops/routes.ts
+++ b/src/frontend/src/platform-ops/routes.ts
@@ -125,7 +125,7 @@ export const platformOpsRoutes = [
       },
       {
         path: 'usage',
-        component: lazyRoute(() => import('../pages/insight/InsightUsage.vue')),
+        component: lazyRoute(() => import('./pages/engine/PlatformUsage.vue')),
       },
       {
         path: 'gateways',


### PR DESCRIPTION
## Summary
- replace the incorrectly nested tenant Usage page with a dedicated Admin Console analytics page
- add a cross-account AI usage API with costs, requests, model calls, tokens, reliability, account aggregation, and request history
- preserve the ordinary-user Usage page and remove the duplicate inner sidebar from Admin Console
- add responsive account filters, request details, trend visualization, and API coverage

## Validation
- frontend production build and TypeScript check
- 8 related Vitest tests
- ESLint, Ruff, Python compilation, and Django system checks
- responsive visual review at 375, 768, 1280, and 1920 pixels
- database-backed API tests added; local PostgreSQL is not exposed on the host test port