### PR TITLE
fix(deploy): keep managed platform gateways local

### DIFF
--- a/.github/workflows/artifact_pipeline.yml
+++ b/.github/workflows/artifact_pipeline.yml
@@ -839,6 +839,7 @@ jobs:
       turnstile_site_key: ${{ vars.TEST_TURNSTILE_SITE_KEY }}
       turnstile_enabled: ${{ vars.TEST_TURNSTILE_ENABLED == 'true' }}
       platform_gateway_auto_deploy: ${{ vars.TEST_PLATFORM_GATEWAY_AUTO_DEPLOY == 'true' }}
+      hfl_insecure_tls: ${{ vars.TEST_HFL_INSECURE_TLS }}
       smtp_host: ${{ vars.TEST_SMTP_HOST }}
       smtp_port: ${{ vars.TEST_SMTP_PORT }}
       smtp_username: ${{ vars.TEST_SMTP_USERNAME }}
@@ -878,6 +879,7 @@ jobs:
       turnstile_site_key: ${{ vars.PREPROD_TURNSTILE_SITE_KEY }}
       turnstile_enabled: ${{ vars.PREPROD_TURNSTILE_ENABLED == 'true' }}
       platform_gateway_auto_deploy: ${{ vars.PREPROD_PLATFORM_GATEWAY_AUTO_DEPLOY == 'true' }}
+      hfl_insecure_tls: ${{ vars.PREPROD_HFL_INSECURE_TLS }}
       smtp_host: ${{ vars.PREPROD_SMTP_HOST }}
       smtp_port: ${{ vars.PREPROD_SMTP_PORT }}
       smtp_username: ${{ vars.PREPROD_SMTP_USERNAME }}

--- a/.github/workflows/deploy_target.yml
+++ b/.github/workflows/deploy_target.yml
@@ -56,6 +56,10 @@ on:
         required: false
         default: false
         type: boolean
+      hfl_insecure_tls:
+        description: Environment-wide TLS policy for remotely enrolled HFL Agents (0 verifies, 1 skips)
+        required: true
+        type: string
       smtp_host:
         description: Optional SMTP server hostname; configure all SMTP inputs together
         required: false
@@ -150,6 +154,7 @@ jobs:
           ARTIFACT_CHANNEL: ${{ inputs.channel }}
           ARTIFACT_ID: ${{ inputs.tag }}
           DEPLOY_TARGET: ${{ inputs.target }}
+          HFL_INSECURE_TLS: ${{ inputs.hfl_insecure_tls }}
         shell: bash
         run: |
           set -euo pipefail
@@ -184,6 +189,17 @@ jobs:
             echo 'Production deployment requires a manual workflow_dispatch event' >&2
             exit 1
           fi
+          [[ "$HFL_INSECURE_TLS" =~ ^[01]$ ]] || {
+            echo 'HFL_INSECURE_TLS must be 0 or 1' >&2
+            exit 1
+          }
+          case "$DEPLOY_TARGET:$HFL_INSECURE_TLS" in
+            test:1|preprod:1|prod:0) ;;
+            *)
+              echo "Deployment target $DEPLOY_TARGET refuses HFL_INSECURE_TLS=$HFL_INSECURE_TLS" >&2
+              exit 1
+              ;;
+          esac
 
           smtp_values=(
             "$SMTP_HOST" "$SMTP_PORT" "$SMTP_USERNAME"
@@ -238,6 +254,7 @@ jobs:
 
       - name: Stage runtime configuration
         env:
+          HFL_INSECURE_TLS: ${{ inputs.hfl_insecure_tls }}
           HFL_PLATFORM_GATEWAY_AUTO_DEPLOY: ${{ inputs.platform_gateway_auto_deploy }}
           TURNSTILE_SITE_KEY: ${{ inputs.turnstile_site_key }}
           TURNSTILE_SECRET_KEY: ${{ secrets.turnstile_secret_key }}
@@ -256,7 +273,7 @@ jobs:
           umask 077
           printf '%s\n' \
             "HFL_EMAIL_SIGNUP_ENABLED=false" \
-            "HFL_INSECURE_TLS=0" \
+            "HFL_INSECURE_TLS=$HFL_INSECURE_TLS" \
             "HFL_PLATFORM_GATEWAY_AUTO_DEPLOY=$HFL_PLATFORM_GATEWAY_AUTO_DEPLOY" \
             "TURNSTILE_ENABLED=$TURNSTILE_ENABLED" \
             "TURNSTILE_SITE_KEY=$TURNSTILE_SITE_KEY" \

--- a/.github/workflows/production_deploy.yml
+++ b/.github/workflows/production_deploy.yml
@@ -74,6 +74,7 @@ jobs:
       turnstile_site_key: ${{ vars.PROD_TURNSTILE_SITE_KEY }}
       turnstile_enabled: ${{ vars.PROD_TURNSTILE_ENABLED == 'true' }}
       platform_gateway_auto_deploy: ${{ vars.PROD_PLATFORM_GATEWAY_AUTO_DEPLOY == 'true' }}
+      hfl_insecure_tls: ${{ vars.PROD_HFL_INSECURE_TLS }}
       smtp_host: ${{ vars.PROD_SMTP_HOST }}
       smtp_port: ${{ vars.PROD_SMTP_PORT }}
       smtp_username: ${{ vars.PROD_SMTP_USERNAME }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,6 +86,7 @@ jobs:
       turnstile_site_key: ${{ vars.PREPROD_TURNSTILE_SITE_KEY }}
       turnstile_enabled: ${{ vars.PREPROD_TURNSTILE_ENABLED == 'true' }}
       platform_gateway_auto_deploy: ${{ vars.PREPROD_PLATFORM_GATEWAY_AUTO_DEPLOY == 'true' }}
+      hfl_insecure_tls: ${{ vars.PREPROD_HFL_INSECURE_TLS }}
       smtp_host: ${{ vars.PREPROD_SMTP_HOST }}
       smtp_port: ${{ vars.PREPROD_SMTP_PORT }}
       smtp_username: ${{ vars.PREPROD_SMTP_USERNAME }}

--- a/deploy/installer/apply-runtime-config.py
+++ b/deploy/installer/apply-runtime-config.py
@@ -201,11 +201,10 @@ def apply_configuration(
                 "SaaS deployment runtime configuration must disable email sign-up"
             )
         updates["HFL_EMAIL_SIGNUP_ENABLED"] = "false"
-        if runtime_values.get("HFL_INSECURE_TLS", "") != "0":
-            raise SystemExit(
-                "SaaS deployment runtime configuration must enforce TLS verification"
-            )
-        updates["HFL_INSECURE_TLS"] = "0"
+        insecure_tls = runtime_values.get("HFL_INSECURE_TLS", "")
+        if insecure_tls not in {"0", "1"}:
+            raise SystemExit("HFL_INSECURE_TLS must be 0 or 1")
+        updates["HFL_INSECURE_TLS"] = insecure_tls
         updates.update(smtp_runtime_updates(runtime_values))
 
         gateway_enabled = runtime_values.get(

--- a/deploy/installer/install.sh
+++ b/deploy/installer/install.sh
@@ -1768,6 +1768,18 @@ print("\t".join([*(str(payload[key]).strip() for key in required), node_ids]))
 '
 	)" || die "failed to parse local platform Gateway enrollment credentials"
 	IFS=$'\t' read -r org_key token api_base wss_url managed_node_ids <<<"${parsed}"
+	[[ "${org_key}" == "__platform_lens__" ]] \
+		|| die "local platform Gateway enrollment returned an unexpected organization"
+
+	local tenant_port
+	tenant_port="$(read_env_value HFL_TENANT_PORT)"
+	[[ -n "${tenant_port}" ]] || tenant_port=11443
+	[[ "${tenant_port}" =~ ^[0-9]+$ ]] && ((tenant_port >= 1 && tenant_port <= 65535)) \
+		|| die "invalid HFL_TENANT_PORT for local platform Gateway: ${tenant_port}"
+	# This installer owns both endpoints on the same host. Keep its Agent off
+	# public/NAT paths and scope the TLS exception to this local managed Gateway.
+	api_base="https://127.0.0.1:${tenant_port}"
+	wss_url="wss://127.0.0.1:${tenant_port}/ws/node/agent/"
 
 	local existing_org existing_role existing_node_id existing_token
 	existing_org="$(read_agent_env_value HFL_ORG_KEY)"
@@ -1787,16 +1799,13 @@ print("\t".join([*(str(payload[key]).strip() for key in required), node_ids]))
 		fi
 	fi
 
-	local insecure_tls
-	insecure_tls="$(read_env_value HFL_INSECURE_TLS)"
-	[[ -n "${insecure_tls}" ]] || insecure_tls=1
 	run_as_root env \
 		HFL_ORG_KEY="${org_key}" \
 		HFL_NODE_ROLE="gateway" \
 		HFL_NODE_TOKEN="${token}" \
 		HFL_API_BASE="${api_base}" \
 		HFL_WSS_URL="${wss_url}" \
-		HFL_INSECURE_TLS="${insecure_tls}" \
+		HFL_INSECURE_TLS=1 \
 		"${helper}" gateway-install --yes
 	ok "Installer-managed local platform Gateway is ready"
 }

--- a/src/backend/apps/lens_bridge/deploy.py
+++ b/src/backend/apps/lens_bridge/deploy.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from project.settings.env import env_str
+from project.settings.env import env_int, env_str
 
 # Public HTTPS path used by bundled SourceLens Data Gateways.
 LENS_GATEWAY_PUBLIC_PATH = "/sourcelens"
@@ -37,6 +37,16 @@ def lens_gateway_base_url() -> str:
     if "host.docker.internal" in base:
         return base.replace("host.docker.internal", "127.0.0.1")
     return base
+
+
+def local_platform_lens_gateway_base_url() -> str:
+    """Return the bundled SourceLens URL for the installer-managed local Gateway."""
+    if sourcelens_mode() != "bundled":
+        return lens_gateway_base_url()
+    port = env_int("HFL_TENANT_PORT", 11443)
+    if port < 1 or port > 65535:
+        port = 11443
+    return f"https://127.0.0.1:{port}{LENS_GATEWAY_PUBLIC_PATH}"
 
 
 def lens_bridge_username() -> str:

--- a/src/backend/apps/lens_bridge/services/provisioning.py
+++ b/src/backend/apps/lens_bridge/services/provisioning.py
@@ -556,13 +556,22 @@ def enable_ai_on_gateway(
 
 def build_lens_enroll_config(link: LensGatewayLink) -> dict[str, Any]:
     """LensNode credentials for gateway enrollment / sidecar install."""
-    from apps.lens_bridge.deploy import lens_gateway_base_url
+    from apps.lens_bridge.deploy import (
+        lens_gateway_base_url,
+        local_platform_lens_gateway_base_url,
+    )
+    from apps.node.services.internal.local_platform_gateway import (
+        is_local_platform_gateway_metadata,
+    )
 
     config = link.config_json or {}
     gateway = link.gateway
     lensnode_name = f"hfl-gw-{gateway.id}-{gateway.name}"[:160]
+    gateway_base_url = lens_gateway_base_url()
+    if is_local_platform_gateway_metadata(gateway.metadata):
+        gateway_base_url = local_platform_lens_gateway_base_url()
     return {
-        "lens_base_url": lens_gateway_base_url(),
+        "lens_base_url": gateway_base_url,
         "lensnode_uuid": str(link.sl_lensnode_uuid) if link.sl_lensnode_uuid else None,
         "lensnode_token": config.get("lensnode_token"),
         "lensnode_name": lensnode_name,

--- a/src/backend/apps/lens_bridge/tests/test_deploy.py
+++ b/src/backend/apps/lens_bridge/tests/test_deploy.py
@@ -80,3 +80,31 @@ class LensDeployUrlTest(unittest.TestCase):
             deploy.lens_gateway_base_url(),
             "https://sourcelens.example.com",
         )
+
+    @patch("apps.lens_bridge.deploy.env_int", return_value=12443)
+    @patch("apps.lens_bridge.deploy.env_str")
+    def test_local_platform_gateway_uses_loopback_for_bundled_mode(
+        self, env_str, _env_int
+    ):
+        env_str.side_effect = lambda key, default="": (
+            "bundled" if key == "SOURCELENS_MODE" else default
+        )
+        self.assertEqual(
+            deploy.local_platform_lens_gateway_base_url(),
+            "https://127.0.0.1:12443/sourcelens",
+        )
+
+    @patch("apps.lens_bridge.deploy.env_str")
+    def test_local_platform_gateway_keeps_external_sourcelens_url(self, env_str):
+        def side_effect(key, default=""):
+            values = {
+                "SOURCELENS_MODE": "external",
+                "LENS_GATEWAY_BASE_URL": "https://sourcelens.example.com",
+            }
+            return values.get(key, default)
+
+        env_str.side_effect = side_effect
+        self.assertEqual(
+            deploy.local_platform_lens_gateway_base_url(),
+            "https://sourcelens.example.com",
+        )

--- a/src/backend/apps/lens_bridge/tests/test_provisioning.py
+++ b/src/backend/apps/lens_bridge/tests/test_provisioning.py
@@ -16,6 +16,69 @@ class SlClientErrorFormatTests(SimpleTestCase):
         self.assertIn("name", sl_client._format_sl_error(body))
 
 
+class BuildLensEnrollConfigTests(SimpleTestCase):
+    @patch(
+        "apps.lens_bridge.deploy.local_platform_lens_gateway_base_url",
+        return_value="https://127.0.0.1:11443/sourcelens",
+    )
+    @patch(
+        "apps.lens_bridge.deploy.lens_gateway_base_url",
+        return_value="https://console.example/sourcelens",
+    )
+    def test_installer_managed_gateway_gets_local_lens_url(
+        self, _public_url, _local_url
+    ):
+        from apps.lens_bridge.services.provisioning import build_lens_enroll_config
+        from apps.node.services.internal.local_platform_gateway import (
+            LOCAL_PLATFORM_GATEWAY_METADATA,
+        )
+
+        gateway = MagicMock(
+            id=7,
+            name="platform-gateway",
+            metadata=dict(LOCAL_PLATFORM_GATEWAY_METADATA),
+        )
+        link = MagicMock(
+            gateway=gateway,
+            config_json={},
+            sl_lensnode_uuid=None,
+        )
+        link.resolved_workspace_root.return_value = "/workspace/platform"
+
+        result = build_lens_enroll_config(link)
+
+        self.assertEqual(
+            result["lens_base_url"],
+            "https://127.0.0.1:11443/sourcelens",
+        )
+
+    @patch(
+        "apps.lens_bridge.deploy.local_platform_lens_gateway_base_url",
+        return_value="https://127.0.0.1:11443/sourcelens",
+    )
+    @patch(
+        "apps.lens_bridge.deploy.lens_gateway_base_url",
+        return_value="https://console.example/sourcelens",
+    )
+    def test_unmanaged_gateway_keeps_public_lens_url(self, _public_url, _local_url):
+        from apps.lens_bridge.services.provisioning import build_lens_enroll_config
+
+        gateway = MagicMock(id=8, name="user-gateway", metadata={})
+        link = MagicMock(
+            gateway=gateway,
+            config_json={},
+            sl_lensnode_uuid=None,
+        )
+        link.resolved_workspace_root.return_value = "/workspace/user"
+
+        result = build_lens_enroll_config(link)
+
+        self.assertEqual(
+            result["lens_base_url"],
+            "https://console.example/sourcelens",
+        )
+
+
 class LensnodeDirPathsTests(SimpleTestCase):
     def test_collects_top_level_and_children(self):
         data = {

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -189,6 +189,10 @@ grep -F 'turnstile_enabled: ${{ vars.TEST_TURNSTILE_ENABLED' "${workflow}" >/dev
 grep -F 'public_url: ${{ vars.TEST_PUBLIC_URL }}' "${workflow}" >/dev/null
 grep -F 'turnstile_enabled: ${{ vars.PROD_TURNSTILE_ENABLED' "${production_workflow}" >/dev/null
 grep -F 'public_url: ${{ vars.PROD_PUBLIC_URL }}' "${production_workflow}" >/dev/null
+grep -F 'hfl_insecure_tls: ${{ vars.TEST_HFL_INSECURE_TLS }}' "${workflow}" >/dev/null
+grep -F 'hfl_insecure_tls: ${{ vars.PREPROD_HFL_INSECURE_TLS }}' "${workflow}" >/dev/null
+grep -F 'hfl_insecure_tls: ${{ vars.PREPROD_HFL_INSECURE_TLS }}' "${release_workflow}" >/dev/null
+grep -F 'hfl_insecure_tls: ${{ vars.PROD_HFL_INSECURE_TLS }}' "${production_workflow}" >/dev/null
 grep -F 'release_download_proxy_url: ${{ vars.TEST_RELEASE_DOWNLOAD_PROXY_URL }}' "${workflow}" >/dev/null
 grep -F 'release_download_proxy_url: ${{ vars.PREPROD_RELEASE_DOWNLOAD_PROXY_URL }}' "${workflow}" >/dev/null
 grep -F 'release_download_proxy_url: ${{ vars.PROD_RELEASE_DOWNLOAD_PROXY_URL }}' "${production_workflow}" >/dev/null
@@ -197,6 +201,10 @@ if grep -F 'PROD_PUBLIC_HOST' "${workflow}" "${production_workflow}" >/dev/null;
 	exit 1
 fi
 grep -F '"TURNSTILE_ENABLED=$TURNSTILE_ENABLED"' \
+	"${ROOT}/.github/workflows/deploy_target.yml" >/dev/null
+grep -F '"HFL_INSECURE_TLS=$HFL_INSECURE_TLS"' \
+	"${ROOT}/.github/workflows/deploy_target.yml" >/dev/null
+grep -F 'test:1|preprod:1|prod:0' \
 	"${ROOT}/.github/workflows/deploy_target.yml" >/dev/null
 for variable in \
 	SMTP_HOST SMTP_PORT SMTP_USERNAME SMTP_SECURITY EMAIL_FROM; do

--- a/tools/quality/test-deployment-optional-config.sh
+++ b/tools/quality/test-deployment-optional-config.sh
@@ -155,14 +155,25 @@ cat >"${insecure_runtime}" <<'ENV'
 HFL_EMAIL_SIGNUP_ENABLED=false
 HFL_INSECURE_TLS=1
 ENV
-before_insecure="$(sha256sum "${insecure_env}" | awk '{print $1}')"
-if python3 "${helper}" --env-file "${insecure_env}" \
-	--runtime-env-file "${insecure_runtime}" >/dev/null 2>&1; then
-	printf 'ERROR: SaaS runtime configuration must reject insecure TLS\n' >&2
+python3 "${helper}" --env-file "${insecure_env}" \
+	--runtime-env-file "${insecure_runtime}" >/dev/null
+grep -Fx 'HFL_INSECURE_TLS=1' "${insecure_env}" >/dev/null
+
+invalid_tls_env="${tmp}/invalid-tls.env"
+invalid_tls_runtime="${tmp}/invalid-tls-runtime.env"
+cp "${env_file}" "${invalid_tls_env}"
+cat >"${invalid_tls_runtime}" <<'ENV'
+HFL_EMAIL_SIGNUP_ENABLED=false
+HFL_INSECURE_TLS=2
+ENV
+before_invalid_tls="$(sha256sum "${invalid_tls_env}" | awk '{print $1}')"
+if python3 "${helper}" --env-file "${invalid_tls_env}" \
+	--runtime-env-file "${invalid_tls_runtime}" >/dev/null 2>&1; then
+	printf 'ERROR: runtime configuration accepted invalid HFL_INSECURE_TLS\n' >&2
 	exit 1
 fi
-after_insecure="$(sha256sum "${insecure_env}" | awk '{print $1}')"
-[[ "${before_insecure}" == "${after_insecure}" ]]
+after_invalid_tls="$(sha256sum "${invalid_tls_env}" | awk '{print $1}')"
+[[ "${before_invalid_tls}" == "${after_invalid_tls}" ]]
 
 ln -s "${runtime_file}" "${tmp}/runtime-link.env"
 if python3 "${helper}" --env-file "${invalid_env}" \

--- a/tools/quality/test-platform-gateway-auto-deploy.sh
+++ b/tools/quality/test-platform-gateway-auto-deploy.sh
@@ -22,10 +22,10 @@ printf '%s\n' \
 	'set -euo pipefail' \
 	'[[ "$HFL_ORG_KEY" == "__platform_lens__" ]]' \
 	'[[ "$HFL_NODE_ROLE" == "gateway" ]]' \
-	'[[ "$HFL_API_BASE" == "https://console.example:11443" ]]' \
-	'[[ "$HFL_WSS_URL" == "wss://console.example:11443/ws/node/agent/" ]]' \
+	'[[ "$HFL_API_BASE" == "https://127.0.0.1:11443" ]]' \
+	'[[ "$HFL_WSS_URL" == "wss://127.0.0.1:11443/ws/node/agent/" ]]' \
 	'[[ "$1" == "gateway-install" && "$2" == "--yes" ]]' \
-	'printf "%s" "$HFL_INSECURE_TLS" >"$TEST_PLATFORM_GATEWAY_MARKER"' \
+	'printf "%s|%s|%s" "$HFL_API_BASE" "$HFL_WSS_URL" "$HFL_INSECURE_TLS" >"$TEST_PLATFORM_GATEWAY_MARKER"' \
 	>"${helper}"
 chmod 755 "${helper}"
 
@@ -35,6 +35,7 @@ read_env_value() {
 	case "$1" in
 	HFL_PLATFORM_GATEWAY_AUTO_DEPLOY) printf '%s' "${AUTO_DEPLOY}" ;;
 	HFL_INSECURE_TLS) printf '%s' "${TLS_MODE}" ;;
+	HFL_TENANT_PORT) printf '11443' ;;
 	esac
 }
 skip() { :; }
@@ -46,8 +47,10 @@ require_docker() { :; }
 read_agent_env_value() { :; }
 run_as_root() { "$@"; }
 compose_in_root() {
-	printf '%s\n' 'HFL_LOCAL_PLATFORM_GATEWAY_ENROLLMENT={"org_key":"__platform_lens__","token":"fixture-token","api_base":"https://console.example:11443","wss_url":"wss://console.example:11443/ws/node/agent/","managed_node_ids":[]}'
+	printf 'HFL_LOCAL_PLATFORM_GATEWAY_ENROLLMENT={"org_key":"%s","token":"fixture-token","api_base":"https://console.example:11443","wss_url":"wss://console.example:11443/ws/node/agent/","managed_node_ids":[]}\n' "${ENROLLMENT_ORG}"
 }
+
+ENROLLMENT_ORG=__platform_lens__
 
 ensure_local_platform_gateway
 [[ ! -e "${marker}" ]]
@@ -55,12 +58,19 @@ ensure_local_platform_gateway
 AUTO_DEPLOY=true
 export TEST_PLATFORM_GATEWAY_MARKER="${marker}"
 ensure_local_platform_gateway
-[[ "$(<"${marker}")" == "1" ]]
+[[ "$(<"${marker}")" == "https://127.0.0.1:11443|wss://127.0.0.1:11443/ws/node/agent/|1" ]]
 
 TLS_MODE=0
 rm -f "${marker}"
 ensure_local_platform_gateway
-[[ "$(<"${marker}")" == "0" ]]
+[[ "$(<"${marker}")" == "https://127.0.0.1:11443|wss://127.0.0.1:11443/ws/node/agent/|1" ]]
+
+ENROLLMENT_ORG=tenant-org
+if (ensure_local_platform_gateway) 2>/dev/null; then
+	printf 'ERROR: local platform Gateway accepted another organization\n' >&2
+	exit 1
+fi
+ENROLLMENT_ORG=__platform_lens__
 
 read_agent_env_value() {
 	case "$1" in


### PR DESCRIPTION
## Summary
- keep installer-managed Platform Gateway Agent and bundled LensNode traffic on host loopback
- propagate explicit environment TLS policy through test, pre-production, and production deployments
- enforce insecure TLS only for test/pre-production while production remains strict
- preserve public URLs for user-managed Data Gateways and external SourceLens

## Validation
- Ruff checks
- 14 focused Django tests
- workflow YAML parsing
- release, runtime configuration, and Platform Gateway deployment contract tests
- Bash syntax and git diff checks