### PR TITLE
Reset expired Turnstile challenges

### DIFF
--- a/src/frontend/src/components/TurnstileWidget.test.ts
+++ b/src/frontend/src/components/TurnstileWidget.test.ts
@@ -23,6 +23,9 @@ const i18n = createI18n({
     en: {
       login: { captchaLoading: 'Loading Cloudflare human verification...' },
     },
+    fr: {
+      login: { captchaLoading: 'Chargement de la vérification humaine...' },
+    },
   },
 })
 
@@ -40,6 +43,7 @@ describe('TurnstileWidget lifecycle', () => {
     vi.useFakeTimers()
     vi.mocked(preloadTurnstileScript).mockReset().mockResolvedValue(undefined)
     vi.mocked(resetTurnstileScriptLoad).mockReset()
+    i18n.global.locale.value = 'en'
     delete window.turnstile
   })
 
@@ -48,7 +52,7 @@ describe('TurnstileWidget lifecycle', () => {
     delete window.turnstile
   })
 
-  it('moves from loading to challenge, success, expiration, and reset', async () => {
+  it('resets expired challenges and accepts replacement tokens repeatedly', async () => {
     let renderOptions: RenderOptions | undefined
     const reset = vi.fn()
     const remove = vi.fn()
@@ -77,9 +81,34 @@ describe('TurnstileWidget lifecycle', () => {
 
     renderOptions!['expired-callback']?.()
     expect(wrapper.emitted('expire')).toHaveLength(1)
+    expect(reset).toHaveBeenNthCalledWith(1, 'widget-1')
+
+    renderOptions!.callback('replacement-token')
+    expect(wrapper.emitted('success')).toEqual([
+      ['verified-token'],
+      ['replacement-token'],
+    ])
+
+    renderOptions!['expired-callback']?.()
+    expect(wrapper.emitted('expire')).toHaveLength(2)
+    expect(reset).toHaveBeenNthCalledWith(2, 'widget-1')
+
+    renderOptions!.callback('second-replacement-token')
+    expect(wrapper.emitted('success')).toEqual([
+      ['verified-token'],
+      ['replacement-token'],
+      ['second-replacement-token'],
+    ])
 
     wrapper.vm.reset()
-    expect(reset).toHaveBeenCalledWith('widget-1')
+    expect(reset).toHaveBeenNthCalledWith(3, 'widget-1')
+    renderOptions!.callback('manual-reset-token')
+    expect(wrapper.emitted('success')).toEqual([
+      ['verified-token'],
+      ['replacement-token'],
+      ['second-replacement-token'],
+      ['manual-reset-token'],
+    ])
     wrapper.unmount()
     expect(remove).toHaveBeenCalledWith('widget-1')
   })
@@ -103,6 +132,34 @@ describe('TurnstileWidget lifecycle', () => {
 
     expect(wrapper.emitted('error')).toHaveLength(1)
     expect(wrapper.find('.turnstile-widget__loading').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('invalidates the token without reporting expiration when language changes', async () => {
+    const renderOptions: RenderOptions[] = []
+    const remove = vi.fn()
+    window.turnstile = {
+      ready: callback => callback(),
+      render: (container, options) => {
+        renderOptions.push(options)
+        container.append(document.createElement('iframe'))
+        return `widget-${renderOptions.length}`
+      },
+      reset: vi.fn(),
+      remove,
+    }
+
+    const wrapper = mountWidget()
+    await flushPromises()
+    await vi.advanceTimersByTimeAsync(100)
+
+    i18n.global.locale.value = 'fr'
+    await flushPromises()
+
+    expect(wrapper.emitted('invalidate')).toHaveLength(1)
+    expect(wrapper.emitted('expire')).toBeUndefined()
+    expect(remove).toHaveBeenCalledWith('widget-1')
+    expect(renderOptions.at(-1)?.language).toBe('fr')
     wrapper.unmount()
   })
 

--- a/src/frontend/src/components/TurnstileWidget.vue
+++ b/src/frontend/src/components/TurnstileWidget.vue
@@ -60,6 +60,7 @@ const effectiveLanguage = computed(() =>
 const emit = defineEmits<{
   success: [token: string]
   expire: []
+  invalidate: []
   error: []
   'load-failed': []
 }>()
@@ -162,7 +163,7 @@ function renderWidget() {
       callback: (token: string) => {
         emitSuccess(token)
       },
-      'expired-callback': () => emit('expire'),
+      'expired-callback': handleExpire,
       'error-callback': () => {
         if (markReadyIfWidgetPresent()) return
         failWidget()
@@ -210,11 +211,19 @@ async function initWidget(attempt = 0) {
 }
 
 function reset() {
+  // A successful token is single-use. Every reset starts a new challenge and
+  // must allow its callback to emit the replacement token.
+  successEmitted.value = false
   if (widgetId.value && window.turnstile) {
     window.turnstile.reset(widgetId.value)
   } else {
     void initWidget()
   }
+}
+
+function handleExpire() {
+  emit('expire')
+  reset()
 }
 
 onMounted(() => {
@@ -224,13 +233,10 @@ onMounted(() => {
 watch(
   () => [props.siteKey, props.action, props.theme, props.size, props.language, effectiveLanguage.value] as const,
   () => {
+    emit('invalidate')
     void initWidget()
   },
 )
-
-watch(effectiveLanguage, () => {
-  emit('expire')
-})
 
 onBeforeUnmount(() => {
   clearLoadTimeout()
@@ -268,6 +274,7 @@ defineExpose({ reset })
 <style scoped>
 .turnstile-widget {
   width: 100%;
+  height: 65px;
   min-height: 65px;
   display: block;
   position: relative;
@@ -275,6 +282,7 @@ defineExpose({ reset })
 
 .turnstile-widget__container {
   width: 100%;
+  height: 100%;
   min-height: 65px;
 }
 

--- a/src/frontend/src/components/auth/AuthTurnstileField.test.ts
+++ b/src/frontend/src/components/auth/AuthTurnstileField.test.ts
@@ -45,6 +45,18 @@ describe('AuthTurnstileField display states', () => {
     expect(wrapper.find('.auth-turnstile-field__widget').exists()).toBe(true)
     expect(wrapper.find('.auth-turnstile-field__viewport').exists()).toBe(true)
     expect(wrapper.get('.auth-turnstile-field__error').text()).toBe('Human verification failed or expired')
+    expect(wrapper.get('.auth-turnstile-field__error').attributes('role')).toBe('alert')
+  })
+
+  it('forwards challenge invalidation separately from expiration', async () => {
+    const wrapper = mountField({ ready: true })
+    const widget = wrapper.getComponent({ name: 'TurnstileWidget' })
+
+    widget.vm.$emit('invalidate')
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.emitted('invalidate')).toHaveLength(1)
+    expect(wrapper.emitted('expire')).toBeUndefined()
   })
 
   it('shows an unavailable message only once and exposes retry', async () => {
@@ -91,6 +103,12 @@ describe('AuthTurnstileField display states', () => {
     )
     expect(fieldSource).toMatch(
       /\.auth-turnstile-field__spinner\s*{[^}]*width:\s*16px;[^}]*height:\s*16px;/s,
+    )
+    expect(widgetSource).toMatch(
+      /\.turnstile-widget\s*{[^}]*height:\s*65px;[^}]*min-height:\s*65px;[^}]*position:\s*relative;/s,
+    )
+    expect(widgetSource).toMatch(
+      /\.turnstile-widget__container\s*{[^}]*height:\s*100%;[^}]*min-height:\s*65px;/s,
     )
     expect(widgetSource).toMatch(
       /\.turnstile-widget__loading\s*{[^}]*gap:\s*10px;[^}]*background:\s*#313131;[^}]*border:\s*1px solid #3A3B40;[^}]*border-radius:/s,

--- a/src/frontend/src/components/auth/AuthTurnstileField.vue
+++ b/src/frontend/src/components/auth/AuthTurnstileField.vue
@@ -20,6 +20,7 @@ const emit = defineEmits<{
   retry: []
   success: [token: string]
   expire: []
+  invalidate: []
   error: []
   'load-failed': []
 }>()
@@ -60,6 +61,7 @@ defineExpose({ reset })
           size="flexible"
           @success="emit('success', $event)"
           @expire="emit('expire')"
+          @invalidate="emit('invalidate')"
           @error="emit('error')"
           @load-failed="emit('load-failed')"
         />

--- a/src/frontend/src/components/auth/ResetPasswordCard.vue
+++ b/src/frontend/src/components/auth/ResetPasswordCard.vue
@@ -204,6 +204,12 @@ function onTurnstileSuccess(token: string) {
 
 function onTurnstileExpire() {
   turnstileToken.value = ''
+  turnstileError.value = t('login.captchaExpired')
+}
+
+function onTurnstileInvalidate() {
+  turnstileToken.value = ''
+  turnstileError.value = ''
 }
 
 function onTurnstileError() {
@@ -463,6 +469,7 @@ onUnmounted(() => {
           @retry="retryTurnstile"
           @success="onTurnstileSuccess"
           @expire="onTurnstileExpire"
+          @invalidate="onTurnstileInvalidate"
           @error="onTurnstileError"
           @load-failed="onTurnstileLoadFailed"
         />

--- a/src/frontend/src/locales/en.ts
+++ b/src/frontend/src/locales/en.ts
@@ -3479,6 +3479,7 @@ export const en = {
     captchaErrRequired: 'Please complete human verification',
     captchaLoading: 'Loading Cloudflare human verification...',
     captchaUnavailable: 'Cloudflare verification unavailable.',
+    captchaExpired: 'Human verification expired. Please complete the new challenge.',
     captchaRetry: 'Retry',
     btnSubmit: 'Sign In',
     btnSubmitLoading: 'Signing in...',

--- a/src/frontend/src/pages/auth/AuthTurnstileRetryFlows.test.ts
+++ b/src/frontend/src/pages/auth/AuthTurnstileRetryFlows.test.ts
@@ -1,0 +1,233 @@
+// @vitest-environment jsdom
+
+import { defineComponent, h, ref } from 'vue'
+import { flushPromises, mount } from '@vue/test-utils'
+import ElementPlus from 'element-plus'
+import { createI18n } from 'vue-i18n'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import ResetPasswordCard from '../../components/auth/ResetPasswordCard.vue'
+import { en } from '../../locales/en'
+import Register from './Register.vue'
+
+const mocks = vi.hoisted(() => ({
+  api: vi.fn(),
+  blockTurnstile: vi.fn(),
+  buildTurnstilePayload: vi.fn(),
+  loadTurnstileConfig: vi.fn(),
+  resetWidget: vi.fn(),
+  routerPush: vi.fn(),
+}))
+
+vi.mock('../../lib/api', () => ({ api: mocks.api }))
+
+vi.mock('../../composables/useLocaleSwitch', () => ({
+  useLocaleSwitch: () => ({
+    canSwitchLocale: ref(false),
+    nextLocaleCode: ref('en'),
+    nextLocaleLabel: ref('English'),
+    toggleLocale: vi.fn(),
+  }),
+}))
+
+vi.mock('../../composables/useTurnstileConfig', () => ({
+  useTurnstileConfig: () => ({
+    turnstileSiteKey: ref('test-site-key'),
+    isTurnstilePending: ref(false),
+    isTurnstileReady: ref(true),
+    isTurnstileBlocked: ref(false),
+    authTurnstileMountGeneration: ref(0),
+    loadTurnstileConfig: mocks.loadTurnstileConfig,
+    buildTurnstilePayload: mocks.buildTurnstilePayload,
+    blockTurnstile: mocks.blockTurnstile,
+  }),
+}))
+
+vi.mock('../../lib/appConfig', () => ({
+  appConfig: { showEula: false },
+}))
+
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ query: {} }),
+  useRouter: () => ({ push: mocks.routerPush }),
+}))
+
+const AuthTurnstileFieldStub = defineComponent({
+  name: 'AuthTurnstileField',
+  props: {
+    errorMessage: { type: String, default: '' },
+  },
+  emits: ['retry', 'success', 'expire', 'invalidate', 'error', 'load-failed'],
+  setup(props, { expose }) {
+    expose({ reset: mocks.resetWidget })
+    return () => h('div', {
+      class: 'turnstile-field-stub',
+      role: props.errorMessage ? 'alert' : undefined,
+    }, props.errorMessage)
+  },
+})
+
+function createI18nPlugin() {
+  return createI18n({
+    legacy: false,
+    locale: 'en',
+    messages: { en },
+    missingWarn: false,
+    fallbackWarn: false,
+  })
+}
+
+function mountRegister() {
+  return mount(Register, {
+    global: {
+      plugins: [createI18nPlugin(), ElementPlus],
+      stubs: {
+        AuthTurnstileField: AuthTurnstileFieldStub,
+        CheckCircle2: true,
+        Eye: true,
+        EyeOff: true,
+        Globe: true,
+        Key: true,
+        Lock: true,
+        Mail: true,
+      },
+    },
+  })
+}
+
+function mountResetPasswordCard() {
+  return mount(ResetPasswordCard, {
+    props: { initialEmail: 'person@example.com' },
+    global: {
+      plugins: [createI18nPlugin(), ElementPlus],
+      stubs: {
+        AuthTurnstileField: AuthTurnstileFieldStub,
+        CheckCircle2: true,
+        Eye: true,
+        EyeOff: true,
+        Key: true,
+        Lock: true,
+        Mail: true,
+      },
+    },
+  })
+}
+
+function submittedBody(call: unknown[]) {
+  const init = call[1] as RequestInit
+  return JSON.parse(String(init.body)) as Record<string, string>
+}
+
+describe('authentication Turnstile retry flows', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorage.clear()
+    mocks.loadTurnstileConfig.mockResolvedValue(undefined)
+    mocks.buildTurnstilePayload.mockImplementation((token: string) => (
+      token ? { turnstile_token: token } : {}
+    ))
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+  })
+
+  it('uses a replacement token when registration code sending is retried', async () => {
+    let sendAttempt = 0
+    mocks.api.mockImplementation(async (path: string) => {
+      if (path !== '/api/v1/auth/email-register/send-code') {
+        throw new Error(`Unexpected API path: ${path}`)
+      }
+      sendAttempt += 1
+      if (sendAttempt === 1) {
+        return {
+          code: '1001',
+          error: {
+            fields: {
+              turnstile_token: ['Invalid or expired human verification'],
+            },
+          },
+        }
+      }
+      return { code: '0000' }
+    })
+
+    const wrapper = mountRegister()
+    await flushPromises()
+    await wrapper.find('input[type="text"]').setValue('person@example.com')
+    const turnstile = wrapper.getComponent(AuthTurnstileFieldStub)
+    const sendCode = wrapper.get('button.send-code-btn')
+
+    turnstile.vm.$emit('success', 'registration-token-1')
+    await wrapper.vm.$nextTick()
+    await sendCode.trigger('click')
+    await flushPromises()
+
+    expect(mocks.resetWidget).toHaveBeenCalledTimes(1)
+    expect(mocks.api).toHaveBeenCalledTimes(1)
+
+    await sendCode.trigger('click')
+    await flushPromises()
+    expect(mocks.api).toHaveBeenCalledTimes(1)
+
+    turnstile.vm.$emit('success', 'registration-token-2')
+    await wrapper.vm.$nextTick()
+    await sendCode.trigger('click')
+    await flushPromises()
+
+    expect(mocks.api).toHaveBeenCalledTimes(2)
+    expect(submittedBody(mocks.api.mock.calls[0]).turnstile_token).toBe('registration-token-1')
+    expect(submittedBody(mocks.api.mock.calls[1]).turnstile_token).toBe('registration-token-2')
+    wrapper.unmount()
+  })
+
+  it('reenables password reset requests after receiving a replacement token', async () => {
+    let resetAttempt = 0
+    mocks.api.mockImplementation(async (path: string) => {
+      if (path !== '/api/v1/auth/forgot-password') {
+        throw new Error(`Unexpected API path: ${path}`)
+      }
+      resetAttempt += 1
+      if (resetAttempt === 1) {
+        return {
+          code: '1001',
+          error: {
+            fields: {
+              turnstile_token: ['Invalid or expired human verification'],
+            },
+          },
+        }
+      }
+      return { code: '0000', data: {} }
+    })
+
+    const wrapper = mountResetPasswordCard()
+    await flushPromises()
+    const turnstile = wrapper.getComponent(AuthTurnstileFieldStub)
+    const sendResetCode = wrapper.get('button.submit-btn')
+
+    expect(sendResetCode.attributes('disabled')).toBeDefined()
+    turnstile.vm.$emit('success', 'reset-token-1')
+    await wrapper.vm.$nextTick()
+    expect(sendResetCode.attributes('disabled')).toBeUndefined()
+
+    await sendResetCode.trigger('click')
+    await flushPromises()
+
+    expect(mocks.resetWidget).toHaveBeenCalledTimes(1)
+    expect(sendResetCode.attributes('disabled')).toBeDefined()
+    expect(mocks.api).toHaveBeenCalledTimes(1)
+
+    turnstile.vm.$emit('success', 'reset-token-2')
+    await wrapper.vm.$nextTick()
+    expect(sendResetCode.attributes('disabled')).toBeUndefined()
+
+    await sendResetCode.trigger('click')
+    await flushPromises()
+
+    expect(mocks.api).toHaveBeenCalledTimes(2)
+    expect(submittedBody(mocks.api.mock.calls[0]).turnstile_token).toBe('reset-token-1')
+    expect(submittedBody(mocks.api.mock.calls[1]).turnstile_token).toBe('reset-token-2')
+    wrapper.unmount()
+  })
+})

--- a/src/frontend/src/pages/auth/Login.vue
+++ b/src/frontend/src/pages/auth/Login.vue
@@ -204,6 +204,12 @@ function onTurnstileSuccess(token: string) {
 
 function onTurnstileExpire() {
   turnstileToken.value = ''
+  turnstileError.value = t('login.captchaExpired')
+}
+
+function onTurnstileInvalidate() {
+  turnstileToken.value = ''
+  turnstileError.value = ''
 }
 
 function onTurnstileError() {
@@ -673,6 +679,7 @@ onMounted(async () => {
           @retry="retryTurnstile"
           @success="onTurnstileSuccess"
           @expire="onTurnstileExpire"
+          @invalidate="onTurnstileInvalidate"
           @error="onTurnstileError"
           @load-failed="onTurnstileLoadFailed"
         />

--- a/src/frontend/src/pages/auth/LoginTurnstileLifecycle.test.ts
+++ b/src/frontend/src/pages/auth/LoginTurnstileLifecycle.test.ts
@@ -267,4 +267,63 @@ describe('Login Turnstile lifecycle', () => {
     expect(submittedBody(emailLoginCalls()[1]).turnstile_token).toBe('accepted-token')
     wrapper.unmount()
   })
+
+  it('accepts corrected credentials after a password error resets Turnstile', async () => {
+    let loginAttempt = 0
+    mocks.api.mockImplementation(async (path: string) => {
+      if (path === '/api/v1/auth/google/config') {
+        return { code: '0000', data: { enabled: false } }
+      }
+      if (path === '/api/v1/auth/email-login') {
+        loginAttempt += 1
+        if (loginAttempt === 1) {
+          return {
+            code: '1001',
+            data: {},
+            error: {
+              fields: {
+                password: ['Incorrect password'],
+              },
+            },
+          }
+        }
+        return successfulLoginResponse
+      }
+      throw new Error(`Unexpected API path: ${path}`)
+    })
+
+    const wrapper = await mountLogin(1440)
+    const credentials = await fillCredentials(wrapper)
+    const turnstile = wrapper.getComponent(AuthTurnstileFieldStub)
+    const submit = wrapper.get('button.submit-btn')
+
+    turnstile.vm.$emit('success', 'initial-token')
+    await wrapper.vm.$nextTick()
+    await submit.trigger('click')
+    await flushPromises()
+
+    expect(mocks.resetWidget).toHaveBeenCalledTimes(1)
+    expect(submit.attributes('disabled')).toBeDefined()
+    expect(wrapper.get('.input-wrapper.has-error .error-msg').text()).toBe('Incorrect password')
+
+    await wrapper.findAll('input')[1].setValue('CorrectPass123')
+    turnstile.vm.$emit('success', 'replacement-token')
+    await wrapper.vm.$nextTick()
+
+    expect(submit.attributes('disabled')).toBeUndefined()
+    await submit.trigger('click')
+    await flushPromises()
+
+    expect(emailLoginCalls()).toHaveLength(2)
+    expect(submittedBody(emailLoginCalls()[0])).toMatchObject({
+      password: 'ValidPass123',
+      turnstile_token: 'initial-token',
+    })
+    expect(submittedBody(emailLoginCalls()[1])).toMatchObject({
+      password: 'CorrectPass123',
+      turnstile_token: 'replacement-token',
+    })
+    expect(credentials.password.value).toBe('CorrectPass123')
+    wrapper.unmount()
+  })
 })

--- a/src/frontend/src/pages/auth/LoginTurnstileLifecycle.test.ts
+++ b/src/frontend/src/pages/auth/LoginTurnstileLifecycle.test.ts
@@ -1,0 +1,270 @@
+// @vitest-environment jsdom
+
+import { defineComponent, h, ref } from 'vue'
+import { flushPromises, mount } from '@vue/test-utils'
+import ElementPlus from 'element-plus'
+import { createI18n } from 'vue-i18n'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { en } from '../../locales/en'
+import Login from './Login.vue'
+
+const mocks = vi.hoisted(() => ({
+  api: vi.fn(),
+  blockTurnstile: vi.fn(),
+  buildTurnstilePayload: vi.fn(),
+  fetchCurrentUser: vi.fn(),
+  fetchDeployProfile: vi.fn(),
+  loadTurnstileConfig: vi.fn(),
+  resetWidget: vi.fn(),
+  routerPush: vi.fn(),
+  setStoredOrgKey: vi.fn(),
+  setUser: vi.fn(),
+}))
+
+vi.mock('../../lib/api', () => ({ api: mocks.api }))
+
+vi.mock('../../composables/useAuth', () => ({
+  fetchCurrentUser: mocks.fetchCurrentUser,
+  setStoredOrgKey: mocks.setStoredOrgKey,
+  useAuth: () => ({ setUser: mocks.setUser }),
+}))
+
+vi.mock('../../composables/useLocaleSwitch', () => ({
+  useLocaleSwitch: () => ({
+    canSwitchLocale: ref(false),
+    nextLocaleCode: ref('en'),
+    nextLocaleLabel: ref('English'),
+    toggleLocale: vi.fn(),
+  }),
+}))
+
+vi.mock('../../composables/useTurnstileConfig', () => ({
+  useTurnstileConfig: () => ({
+    turnstileSiteKey: ref('test-site-key'),
+    isTurnstilePending: ref(false),
+    isTurnstileReady: ref(true),
+    isTurnstileBlocked: ref(false),
+    authTurnstileMountGeneration: ref(0),
+    loadTurnstileConfig: mocks.loadTurnstileConfig,
+    buildTurnstilePayload: mocks.buildTurnstilePayload,
+    blockTurnstile: mocks.blockTurnstile,
+  }),
+}))
+
+vi.mock('../../composables/useDeployProfile', () => ({
+  fetchDeployProfile: mocks.fetchDeployProfile,
+  resolvePostLoginPath: vi.fn().mockResolvedValue('/'),
+}))
+
+vi.mock('../../lib/appConfig', () => ({
+  appConfig: { showEula: false },
+}))
+
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ query: {} }),
+  useRouter: () => ({ push: mocks.routerPush }),
+}))
+
+const AuthTurnstileFieldStub = defineComponent({
+  name: 'AuthTurnstileField',
+  props: {
+    errorMessage: { type: String, default: '' },
+  },
+  emits: ['retry', 'success', 'expire', 'invalidate', 'error', 'load-failed'],
+  setup(props, { expose }) {
+    expose({ reset: mocks.resetWidget })
+    return () => h('div', {
+      class: 'turnstile-field-stub',
+      role: props.errorMessage ? 'alert' : undefined,
+    }, props.errorMessage)
+  },
+})
+
+const successfulLoginResponse = {
+  code: '0000',
+  data: {
+    user: { id: 1, email: 'person@example.com', username: 'person' },
+    available_orgs: [],
+  },
+}
+
+function installDefaultApiMock() {
+  mocks.api.mockImplementation(async (path: string) => {
+    if (path === '/api/v1/auth/google/config') {
+      return { code: '0000', data: { enabled: false } }
+    }
+    if (path === '/api/v1/auth/email-login') {
+      return successfulLoginResponse
+    }
+    throw new Error(`Unexpected API path: ${path}`)
+  })
+}
+
+async function mountLogin(viewportWidth: number) {
+  Object.defineProperty(window, 'innerWidth', {
+    configurable: true,
+    value: viewportWidth,
+  })
+  window.dispatchEvent(new Event('resize'))
+
+  const i18n = createI18n({
+    legacy: false,
+    locale: 'en',
+    messages: { en },
+    missingWarn: false,
+    fallbackWarn: false,
+  })
+  const wrapper = mount(Login, {
+    global: {
+      plugins: [i18n, ElementPlus],
+      stubs: {
+        AuthTurnstileField: AuthTurnstileFieldStub,
+        ResetPasswordCard: true,
+        Globe: true,
+        Mail: true,
+        Lock: true,
+        Eye: true,
+        EyeOff: true,
+      },
+    },
+  })
+  await flushPromises()
+  return wrapper
+}
+
+async function fillCredentials(wrapper: Awaited<ReturnType<typeof mountLogin>>) {
+  const inputs = wrapper.findAll('input')
+  await inputs[0].setValue('person@example.com')
+  await inputs[1].setValue('ValidPass123')
+  return {
+    email: inputs[0].element as HTMLInputElement,
+    password: inputs[1].element as HTMLInputElement,
+  }
+}
+
+function emailLoginCalls() {
+  return mocks.api.mock.calls.filter(([path]) => path === '/api/v1/auth/email-login')
+}
+
+function submittedBody(call: unknown[]) {
+  const init = call[1] as RequestInit
+  return JSON.parse(String(init.body)) as Record<string, string>
+}
+
+describe('Login Turnstile lifecycle', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.fetchDeployProfile.mockResolvedValue({
+      email_signup_enabled: false,
+      password_reset_available: false,
+    })
+    mocks.loadTurnstileConfig.mockResolvedValue(undefined)
+    mocks.buildTurnstilePayload.mockImplementation((token: string) => (
+      token ? { turnstile_token: token } : {}
+    ))
+    installDefaultApiMock()
+  })
+
+  it.each([
+    ['mobile', 390],
+    ['tablet', 820],
+    ['desktop', 1440],
+  ])('recovers from invalidation and repeated expiration on %s', async (_name, width) => {
+    const wrapper = await mountLogin(width)
+    const credentials = await fillCredentials(wrapper)
+    const turnstile = wrapper.getComponent(AuthTurnstileFieldStub)
+    const submit = wrapper.get('button.submit-btn')
+
+    expect(submit.attributes('disabled')).toBeDefined()
+
+    turnstile.vm.$emit('success', 'initial-token')
+    await wrapper.vm.$nextTick()
+    expect(submit.attributes('disabled')).toBeUndefined()
+
+    turnstile.vm.$emit('invalidate')
+    await wrapper.vm.$nextTick()
+    expect(submit.attributes('disabled')).toBeDefined()
+    expect(turnstile.props('errorMessage')).toBe('')
+    expect(credentials.email.value).toBe('person@example.com')
+    expect(credentials.password.value).toBe('ValidPass123')
+
+    turnstile.vm.$emit('success', 'language-refresh-token')
+    await wrapper.vm.$nextTick()
+    turnstile.vm.$emit('expire')
+    await wrapper.vm.$nextTick()
+    expect(submit.attributes('disabled')).toBeDefined()
+    expect(turnstile.props('errorMessage')).toBe(
+      'Human verification expired. Please complete the new challenge.',
+    )
+
+    turnstile.vm.$emit('success', 'replacement-token')
+    await wrapper.vm.$nextTick()
+    turnstile.vm.$emit('expire')
+    await wrapper.vm.$nextTick()
+    turnstile.vm.$emit('success', 'final-token')
+    await wrapper.vm.$nextTick()
+    expect(submit.attributes('disabled')).toBeUndefined()
+
+    await submit.trigger('click')
+    await flushPromises()
+
+    expect(emailLoginCalls()).toHaveLength(1)
+    expect(submittedBody(emailLoginCalls()[0])).toMatchObject({
+      email: 'person@example.com',
+      password: 'ValidPass123',
+      turnstile_token: 'final-token',
+    })
+    expect(credentials.email.value).toBe('person@example.com')
+    expect(credentials.password.value).toBe('ValidPass123')
+    wrapper.unmount()
+  })
+
+  it('accepts a new token after the backend rejects an expired token', async () => {
+    let loginAttempt = 0
+    mocks.api.mockImplementation(async (path: string) => {
+      if (path === '/api/v1/auth/google/config') {
+        return { code: '0000', data: { enabled: false } }
+      }
+      if (path === '/api/v1/auth/email-login') {
+        loginAttempt += 1
+        if (loginAttempt === 1) {
+          throw {
+            status: 400,
+            message: 'Invalid or expired human verification',
+            fields: {
+              turnstile_token: ['Invalid or expired human verification'],
+            },
+          }
+        }
+        return successfulLoginResponse
+      }
+      throw new Error(`Unexpected API path: ${path}`)
+    })
+
+    const wrapper = await mountLogin(1440)
+    await fillCredentials(wrapper)
+    const turnstile = wrapper.getComponent(AuthTurnstileFieldStub)
+    const submit = wrapper.get('button.submit-btn')
+
+    turnstile.vm.$emit('success', 'rejected-token')
+    await wrapper.vm.$nextTick()
+    await submit.trigger('click')
+    await flushPromises()
+
+    expect(mocks.resetWidget).toHaveBeenCalledTimes(1)
+    expect(submit.attributes('disabled')).toBeDefined()
+    expect(turnstile.props('errorMessage')).toBe('Human verification failed or expired')
+
+    turnstile.vm.$emit('success', 'accepted-token')
+    await wrapper.vm.$nextTick()
+    expect(submit.attributes('disabled')).toBeUndefined()
+
+    await submit.trigger('click')
+    await flushPromises()
+
+    expect(emailLoginCalls()).toHaveLength(2)
+    expect(submittedBody(emailLoginCalls()[1]).turnstile_token).toBe('accepted-token')
+    wrapper.unmount()
+  })
+})

--- a/src/frontend/src/pages/auth/Register.vue
+++ b/src/frontend/src/pages/auth/Register.vue
@@ -201,6 +201,12 @@ function onTurnstileSuccess(token: string) {
 
 function onTurnstileExpire() {
   turnstileToken.value = ''
+  turnstileError.value = t('login.captchaExpired')
+}
+
+function onTurnstileInvalidate() {
+  turnstileToken.value = ''
+  turnstileError.value = ''
 }
 
 function onTurnstileError() {
@@ -479,6 +485,7 @@ onUnmounted(() => {
           @retry="retryTurnstile"
           @success="onTurnstileSuccess"
           @expire="onTurnstileExpire"
+          @invalidate="onTurnstileInvalidate"
           @error="onTurnstileError"
           @load-failed="onTurnstileLoadFailed"
         />


### PR DESCRIPTION
- Automatically reset expired widgets and accept replacement tokens
- Distinguish expiration from config or language invalidation across auth forms
- Cover responsive login lifecycles and backend token rejection

Fixes #84
Fixes #86