### PR TITLE
feat: manage optional identity services during deployment

### DIFF
--- a/.github/workflows/artifact_pipeline.yml
+++ b/.github/workflows/artifact_pipeline.yml
@@ -854,6 +854,9 @@ jobs:
       ssh_known_hosts: ${{ vars.TEST_SSH_KNOWN_HOSTS }}
       turnstile_site_key: ${{ vars.TEST_TURNSTILE_SITE_KEY }}
       turnstile_enabled: ${{ vars.TEST_TURNSTILE_ENABLED == 'true' }}
+      email_signup_enabled: ${{ vars.TEST_EMAIL_SIGNUP_ENABLED == 'true' }}
+      google_oauth_enabled: ${{ vars.TEST_GOOGLE_OAUTH_ENABLED == 'true' }}
+      google_client_id: ${{ vars.TEST_GOOGLE_CLIENT_ID }}
       platform_gateway_auto_deploy: ${{ vars.TEST_PLATFORM_GATEWAY_AUTO_DEPLOY == 'true' }}
       hfl_insecure_tls: ${{ vars.TEST_HFL_INSECURE_TLS }}
       smtp_host: ${{ vars.TEST_SMTP_HOST }}
@@ -868,6 +871,7 @@ jobs:
       ssh_private_key: ${{ secrets.TEST_SSH_PRIVATE_KEY }}
       turnstile_secret_key: ${{ secrets.TEST_TURNSTILE_SECRET_KEY }}
       smtp_password: ${{ secrets.TEST_SMTP_PASSWORD }}
+      google_client_secret: ${{ secrets.TEST_GOOGLE_CLIENT_SECRET }}
       ai_model_api_base: ${{ secrets.TEST_AI_MODEL_API_BASE }}
       ai_model_api_key: ${{ secrets.TEST_AI_MODEL_API_KEY }}
 
@@ -895,6 +899,9 @@ jobs:
       ssh_known_hosts: ${{ vars.PREPROD_SSH_KNOWN_HOSTS }}
       turnstile_site_key: ${{ vars.PREPROD_TURNSTILE_SITE_KEY }}
       turnstile_enabled: ${{ vars.PREPROD_TURNSTILE_ENABLED == 'true' }}
+      email_signup_enabled: ${{ vars.PREPROD_EMAIL_SIGNUP_ENABLED == 'true' }}
+      google_oauth_enabled: ${{ vars.PREPROD_GOOGLE_OAUTH_ENABLED == 'true' }}
+      google_client_id: ${{ vars.PREPROD_GOOGLE_CLIENT_ID }}
       platform_gateway_auto_deploy: ${{ vars.PREPROD_PLATFORM_GATEWAY_AUTO_DEPLOY == 'true' }}
       hfl_insecure_tls: ${{ vars.PREPROD_HFL_INSECURE_TLS }}
       smtp_host: ${{ vars.PREPROD_SMTP_HOST }}
@@ -909,6 +916,7 @@ jobs:
       ssh_private_key: ${{ secrets.PREPROD_SSH_PRIVATE_KEY }}
       turnstile_secret_key: ${{ secrets.PREPROD_TURNSTILE_SECRET_KEY }}
       smtp_password: ${{ secrets.PREPROD_SMTP_PASSWORD }}
+      google_client_secret: ${{ secrets.PREPROD_GOOGLE_CLIENT_SECRET }}
       ai_model_api_base: ${{ secrets.PREPROD_AI_MODEL_API_BASE }}
       ai_model_api_key: ${{ secrets.PREPROD_AI_MODEL_API_KEY }}
 

--- a/.github/workflows/deploy_target.yml
+++ b/.github/workflows/deploy_target.yml
@@ -51,6 +51,21 @@ on:
         description: Require Turnstile on the SaaS deployment target
         required: true
         type: boolean
+      email_signup_enabled:
+        description: Allow anonymous email/password registration
+        required: false
+        default: false
+        type: boolean
+      google_oauth_enabled:
+        description: Allow Google OAuth sign-in when credentials are valid
+        required: false
+        default: false
+        type: boolean
+      google_client_id:
+        description: Optional Google OAuth web client ID
+        required: false
+        default: ''
+        type: string
       platform_gateway_auto_deploy:
         description: Automatically deploy an HFL-managed local platform Gateway
         required: false
@@ -110,6 +125,9 @@ on:
       smtp_password:
         description: Optional SMTP account password
         required: false
+      google_client_secret:
+        description: Optional Google OAuth web client secret
+        required: false
       ai_model_api_base:
         description: Optional HTTPS API base for the deployment-managed model
         required: false
@@ -147,6 +165,13 @@ jobs:
           SMTP_PASSWORD: ${{ secrets.smtp_password }}
           SMTP_SECURITY: ${{ inputs.smtp_security }}
           EMAIL_FROM: ${{ inputs.email_from }}
+          EMAIL_SIGNUP_ENABLED: ${{ inputs.email_signup_enabled }}
+          GOOGLE_OAUTH_ENABLED: ${{ inputs.google_oauth_enabled }}
+          GOOGLE_CLIENT_ID: ${{ inputs.google_client_id }}
+          GOOGLE_CLIENT_SECRET: ${{ secrets.google_client_secret }}
+          TURNSTILE_ENABLED: ${{ inputs.turnstile_enabled }}
+          TURNSTILE_SITE_KEY: ${{ inputs.turnstile_site_key }}
+          TURNSTILE_SECRET_KEY: ${{ secrets.turnstile_secret_key }}
           AI_MODEL_PROVIDER: ${{ inputs.ai_model_provider }}
           AI_MODEL_ID: ${{ inputs.ai_model_id }}
           AI_MODEL_DISPLAY_NAME: ${{ inputs.ai_model_display_name }}
@@ -210,15 +235,34 @@ jobs:
           for value in "${smtp_values[@]}"; do
             [[ -z "$value" ]] || smtp_configured=$((smtp_configured + 1))
           done
-          if (( smtp_configured != 0 && smtp_configured != ${#smtp_values[@]} )); then
-            echo 'SMTP deployment configuration is partial; configure all SMTP variables and the password secret, or leave all of them empty' >&2
-            exit 1
+          if (( smtp_configured == 0 )); then
+            echo '::warning title=SMTP configuration::No SMTP settings were staged; deployment will preserve installed email settings, and password-reset delivery was not verified.'
+          elif (( smtp_configured != ${#smtp_values[@]} )); then
+            echo '::warning title=SMTP configuration::SMTP settings are partial; deployment will preserve the installed email configuration.'
           fi
-          if (( smtp_configured > 0 )); then
-            [[ "$SMTP_HOST" != *[[:space:]]* ]]
-            [[ "$SMTP_PORT" =~ ^[0-9]+$ ]] && (( SMTP_PORT >= 1 && SMTP_PORT <= 65535 ))
-            [[ "$SMTP_SECURITY" =~ ^(ssl|starttls|none)$ ]]
-            [[ "$SMTP_PASSWORD" != *$'\n'* && "$SMTP_PASSWORD" != *$'\r'* ]]
+          if (( smtp_configured == ${#smtp_values[@]} )); then
+            if [[ "$SMTP_HOST" == *[[:space:]]* ]] \
+              || [[ ! "$SMTP_PORT" =~ ^[0-9]+$ ]] \
+              || (( SMTP_PORT < 1 || SMTP_PORT > 65535 )) \
+              || [[ ! "$SMTP_SECURITY" =~ ^(ssl|starttls|none)$ ]] \
+              || [[ "$SMTP_PASSWORD" == *$'\n'* || "$SMTP_PASSWORD" == *$'\r'* ]]; then
+              echo '::warning title=SMTP configuration::SMTP settings are malformed; deployment will preserve the installed email configuration.'
+            fi
+          fi
+          if [[ "$EMAIL_SIGNUP_ENABLED" == "true" && "$smtp_configured" -ne "${#smtp_values[@]}" ]]; then
+            echo '::warning title=Email sign-up::Email sign-up is enabled without a complete staged SMTP configuration; deployment will continue.'
+          fi
+
+          if [[ "$GOOGLE_OAUTH_ENABLED" == "true" ]]; then
+            if [[ ! "$GOOGLE_CLIENT_ID" =~ ^[0-9]+-[A-Za-z0-9_-]+\.apps\.googleusercontent\.com$ ]] \
+              || [[ -z "$GOOGLE_CLIENT_SECRET" ]] \
+              || [[ "$GOOGLE_CLIENT_SECRET" == *$'\n'* || "$GOOGLE_CLIENT_SECRET" == *$'\r'* ]]; then
+              echo '::warning title=Google OAuth configuration::Google OAuth settings are missing or malformed; deployment will preserve the installed Google configuration.'
+            fi
+          fi
+          if [[ "$TURNSTILE_ENABLED" == "true" ]] \
+            && { [[ -z "$TURNSTILE_SITE_KEY" ]] || [[ -z "$TURNSTILE_SECRET_KEY" ]]; }; then
+            echo '::warning title=Turnstile configuration::Turnstile is enabled without complete credentials; deployment will continue.'
           fi
 
           ai_model_values=(
@@ -266,26 +310,50 @@ jobs:
           SMTP_PASSWORD: ${{ secrets.smtp_password }}
           SMTP_SECURITY: ${{ inputs.smtp_security }}
           EMAIL_FROM: ${{ inputs.email_from }}
+          HFL_EMAIL_SIGNUP_ENABLED: ${{ inputs.email_signup_enabled }}
+          HFL_GOOGLE_OAUTH_ENABLED: ${{ inputs.google_oauth_enabled }}
+          GOOGLE_CLIENT_ID: ${{ inputs.google_client_id }}
+          GOOGLE_CLIENT_SECRET: ${{ secrets.google_client_secret }}
         shell: bash
         run: |
           set -euo pipefail
           runtime_env="$RUNNER_TEMP/hyperfilelens-runtime.env"
           trap 'rm -f -- "$runtime_env"' EXIT
           umask 077
-          printf '%s\n' \
-            "HFL_EMAIL_SIGNUP_ENABLED=false" \
-            "HFL_INSECURE_TLS=$HFL_INSECURE_TLS" \
-            "HFL_PLATFORM_GATEWAY_AUTO_DEPLOY=$HFL_PLATFORM_GATEWAY_AUTO_DEPLOY" \
-            "TURNSTILE_ENABLED=$TURNSTILE_ENABLED" \
-            "TURNSTILE_SITE_KEY=$TURNSTILE_SITE_KEY" \
-            "TURNSTILE_SECRET_KEY=$TURNSTILE_SECRET_KEY" \
-            "SMTP_HOST=$SMTP_HOST" \
-            "SMTP_PORT=$SMTP_PORT" \
-            "SMTP_USERNAME=$SMTP_USERNAME" \
-            "SMTP_PASSWORD=$SMTP_PASSWORD" \
-            "SMTP_SECURITY=$SMTP_SECURITY" \
-            "EMAIL_FROM=$EMAIL_FROM" \
-            > "$runtime_env"
+          python3 - "$runtime_env" <<'PY'
+          import os
+          import pathlib
+          import sys
+
+          names = (
+              "HFL_EMAIL_SIGNUP_ENABLED",
+              "HFL_GOOGLE_OAUTH_ENABLED",
+              "HFL_INSECURE_TLS",
+              "HFL_PLATFORM_GATEWAY_AUTO_DEPLOY",
+              "TURNSTILE_ENABLED",
+              "TURNSTILE_SITE_KEY",
+              "TURNSTILE_SECRET_KEY",
+              "SMTP_HOST",
+              "SMTP_PORT",
+              "SMTP_USERNAME",
+              "SMTP_PASSWORD",
+              "SMTP_SECURITY",
+              "EMAIL_FROM",
+              "GOOGLE_CLIENT_ID",
+              "GOOGLE_CLIENT_SECRET",
+          )
+          lines = []
+          for name in names:
+              value = os.environ.get(name, "")
+              if "\r" in value or "\n" in value or "\x00" in value:
+                  print(
+                      f"::warning title=Optional deployment configuration::{name} "
+                      "is not single-line and was omitted; installed configuration will be preserved."
+                  )
+                  continue
+              lines.append(f"{name}={value}")
+          pathlib.Path(sys.argv[1]).write_text("\n".join(lines) + "\n", encoding="utf-8")
+          PY
           ssh -i ~/.ssh/hyperfilelens_deploy \
             -o BatchMode=yes \
             -o StrictHostKeyChecking=yes \
@@ -356,6 +424,35 @@ jobs:
             -p "$DEPLOY_SSH_PORT" \
             "$DEPLOY_SSH_USER@$DEPLOY_SSH_HOST" \
             'curl -kfsS https://127.0.0.1:11443/health/ready >/dev/null && curl -kfsS https://127.0.0.1:11444/ >/dev/null && curl -kfsS https://127.0.0.1:11445/ >/dev/null'
+
+      - name: Configure Optional Identity and Email Services
+        shell: bash
+        run: |
+          set +e
+          output="$(ssh -i ~/.ssh/hyperfilelens_deploy \
+            -o BatchMode=yes \
+            -o StrictHostKeyChecking=yes \
+            -o ConnectTimeout=20 \
+            -o ServerAliveInterval=30 \
+            -o ServerAliveCountMax=20 \
+            -o TCPKeepAlive=yes \
+            -p "$DEPLOY_SSH_PORT" \
+            "$DEPLOY_SSH_USER@$DEPLOY_SSH_HOST" \
+            'cd /opt/hyperfilelens && docker compose exec -T api python manage.py ensure_deployment_identity_settings' \
+            2>&1)"
+          command_status=$?
+          set -e
+          printf '%s\n' "$output"
+          if (( command_status != 0 )); then
+            echo '::warning title=Optional service configuration::Unable to synchronize optional signup, Google OAuth, Turnstile, or SMTP settings; core deployment remains healthy.'
+            printf '### Optional service configuration\n\nWarning: optional identity or email settings could not be synchronized. Core deployment remains healthy.\n' >> "$GITHUB_STEP_SUMMARY"
+          elif grep -F 'HFL_IDENTITY_STATUS=warning' <<<"$output" >/dev/null; then
+            echo '::warning title=Optional service configuration::One or more optional settings were invalid and the installed values were preserved.'
+            printf '### Optional service configuration\n\nWarning: invalid optional settings were preserved without blocking deployment.\n' >> "$GITHUB_STEP_SUMMARY"
+          else
+            printf '### Optional service configuration\n\nPassed: deployment-managed signup, Google OAuth, Turnstile, and SMTP settings were synchronized without external connectivity checks.\n' >> "$GITHUB_STEP_SUMMARY"
+          fi
+          exit 0
 
       - name: Configure Default AI Model
         env:

--- a/.github/workflows/production_deploy.yml
+++ b/.github/workflows/production_deploy.yml
@@ -75,6 +75,9 @@ jobs:
       ssh_known_hosts: ${{ vars.PROD_SSH_KNOWN_HOSTS }}
       turnstile_site_key: ${{ vars.PROD_TURNSTILE_SITE_KEY }}
       turnstile_enabled: ${{ vars.PROD_TURNSTILE_ENABLED == 'true' }}
+      email_signup_enabled: ${{ vars.PROD_EMAIL_SIGNUP_ENABLED == 'true' }}
+      google_oauth_enabled: ${{ vars.PROD_GOOGLE_OAUTH_ENABLED == 'true' }}
+      google_client_id: ${{ vars.PROD_GOOGLE_CLIENT_ID }}
       platform_gateway_auto_deploy: ${{ vars.PROD_PLATFORM_GATEWAY_AUTO_DEPLOY == 'true' }}
       hfl_insecure_tls: ${{ vars.PROD_HFL_INSECURE_TLS }}
       smtp_host: ${{ vars.PROD_SMTP_HOST }}
@@ -89,5 +92,6 @@ jobs:
       ssh_private_key: ${{ secrets.PROD_SSH_PRIVATE_KEY }}
       turnstile_secret_key: ${{ secrets.PROD_TURNSTILE_SECRET_KEY }}
       smtp_password: ${{ secrets.PROD_SMTP_PASSWORD }}
+      google_client_secret: ${{ secrets.PROD_GOOGLE_CLIENT_SECRET }}
       ai_model_api_base: ${{ secrets.PROD_AI_MODEL_API_BASE }}
       ai_model_api_key: ${{ secrets.PROD_AI_MODEL_API_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,6 +88,9 @@ jobs:
       ssh_known_hosts: ${{ vars.PREPROD_SSH_KNOWN_HOSTS }}
       turnstile_site_key: ${{ vars.PREPROD_TURNSTILE_SITE_KEY }}
       turnstile_enabled: ${{ vars.PREPROD_TURNSTILE_ENABLED == 'true' }}
+      email_signup_enabled: ${{ vars.PREPROD_EMAIL_SIGNUP_ENABLED == 'true' }}
+      google_oauth_enabled: ${{ vars.PREPROD_GOOGLE_OAUTH_ENABLED == 'true' }}
+      google_client_id: ${{ vars.PREPROD_GOOGLE_CLIENT_ID }}
       platform_gateway_auto_deploy: ${{ vars.PREPROD_PLATFORM_GATEWAY_AUTO_DEPLOY == 'true' }}
       hfl_insecure_tls: ${{ vars.PREPROD_HFL_INSECURE_TLS }}
       smtp_host: ${{ vars.PREPROD_SMTP_HOST }}
@@ -102,5 +105,6 @@ jobs:
       ssh_private_key: ${{ secrets.PREPROD_SSH_PRIVATE_KEY }}
       turnstile_secret_key: ${{ secrets.PREPROD_TURNSTILE_SECRET_KEY }}
       smtp_password: ${{ secrets.PREPROD_SMTP_PASSWORD }}
+      google_client_secret: ${{ secrets.PREPROD_GOOGLE_CLIENT_SECRET }}
       ai_model_api_base: ${{ secrets.PREPROD_AI_MODEL_API_BASE }}
       ai_model_api_key: ${{ secrets.PREPROD_AI_MODEL_API_KEY }}

--- a/deploy/installer/apply-runtime-config.py
+++ b/deploy/installer/apply-runtime-config.py
@@ -13,6 +13,7 @@ from urllib.parse import SplitResult, urlsplit, urlunsplit
 
 RUNTIME_KEYS = {
     "HFL_EMAIL_SIGNUP_ENABLED",
+    "HFL_GOOGLE_OAUTH_ENABLED",
     "HFL_INSECURE_TLS",
     "HFL_PLATFORM_GATEWAY_AUTO_DEPLOY",
     "TURNSTILE_ENABLED",
@@ -24,8 +25,13 @@ RUNTIME_KEYS = {
     "SMTP_PASSWORD",
     "SMTP_SECURITY",
     "EMAIL_FROM",
+    "GOOGLE_CLIENT_ID",
+    "GOOGLE_CLIENT_SECRET",
 }
 KEY_PATTERN = re.compile(r"^[A-Za-z0-9_-]+$")
+GOOGLE_CLIENT_ID_PATTERN = re.compile(
+    r"^[0-9]+-[A-Za-z0-9_-]+\.apps\.googleusercontent\.com$"
+)
 
 
 def warn(message: str) -> None:
@@ -111,12 +117,15 @@ def smtp_runtime_updates(values: Dict[str, str]) -> Dict[str, str]:
     )
     present = [name for name in names if values.get(name, "") != ""]
     if not present:
+        warn("SMTP deployment configuration is empty; preserving installed email settings")
         return {}
     missing = [name for name in names if values.get(name, "") == ""]
     if missing:
-        raise SystemExit(
-            "partial SMTP deployment configuration; missing: " + ", ".join(missing)
+        warn(
+            "partial SMTP deployment configuration; preserving installed email "
+            "settings (missing: " + ", ".join(missing) + ")"
         )
+        return {}
 
     host = values["SMTP_HOST"].strip()
     username = values["SMTP_USERNAME"].strip()
@@ -124,21 +133,28 @@ def smtp_runtime_updates(values: Dict[str, str]) -> Dict[str, str]:
     security = values["SMTP_SECURITY"].strip().lower()
     from_email = values["EMAIL_FROM"].strip()
     if not host or re.search(r"\s", host):
-        raise SystemExit("SMTP_HOST must be a non-empty hostname without whitespace")
+        warn("invalid SMTP host; preserving installed email settings")
+        return {}
     if not username or re.search(r"[\r\n]", username):
-        raise SystemExit("SMTP_USERNAME must be non-empty and single-line")
+        warn("invalid SMTP username; preserving installed email settings")
+        return {}
     if not password or re.search(r"[\x00\r\n]", password):
-        raise SystemExit("SMTP_PASSWORD must be non-empty and single-line")
+        warn("invalid SMTP password; preserving installed email settings")
+        return {}
     if not from_email or re.search(r"[\r\n]", from_email):
-        raise SystemExit("EMAIL_FROM must be non-empty and single-line")
+        warn("invalid sender identity; preserving installed email settings")
+        return {}
     try:
         port = int(values["SMTP_PORT"])
-    except ValueError as exc:
-        raise SystemExit("SMTP_PORT must be an integer between 1 and 65535") from exc
+    except ValueError:
+        warn("invalid SMTP port; preserving installed email settings")
+        return {}
     if port < 1 or port > 65535:
-        raise SystemExit("SMTP_PORT must be an integer between 1 and 65535")
+        warn("SMTP port is outside 1-65535; preserving installed email settings")
+        return {}
     if security not in {"ssl", "starttls", "none"}:
-        raise SystemExit("SMTP_SECURITY must be one of: ssl, starttls, none")
+        warn("invalid SMTP security mode; preserving installed email settings")
+        return {}
 
     return {
         "EMAIL_BACKEND": "django.core.mail.backends.smtp.EmailBackend",
@@ -149,6 +165,60 @@ def smtp_runtime_updates(values: Dict[str, str]) -> Dict[str, str]:
         "EMAIL_USE_TLS": "true" if security == "starttls" else "false",
         "EMAIL_USE_SSL": "true" if security == "ssl" else "false",
         "DEFAULT_FROM_EMAIL": from_email,
+    }
+
+
+def google_runtime_updates(values: Dict[str, str]) -> Dict[str, str]:
+    """Apply Google OAuth as one optional group, preserving installed values on errors."""
+    enabled = values.get("HFL_GOOGLE_OAUTH_ENABLED", "").strip().lower()
+    client_id = values.get("GOOGLE_CLIENT_ID", "").strip()
+    client_secret = values.get("GOOGLE_CLIENT_SECRET", "")
+    if enabled not in {"true", "false"}:
+        warn("invalid Google OAuth enabled value; preserving installed Google settings")
+        return {}
+    if enabled == "false":
+        return {"HFL_GOOGLE_OAUTH_ENABLED": "false"}
+    if not GOOGLE_CLIENT_ID_PATTERN.fullmatch(client_id):
+        warn("invalid Google OAuth client ID; preserving installed Google settings")
+        return {}
+    if not client_secret or re.search(r"[\x00\r\n]", client_secret):
+        warn("invalid Google OAuth client secret; preserving installed Google settings")
+        return {}
+    return {
+        "HFL_GOOGLE_OAUTH_ENABLED": "true",
+        "GOOGLE_CLIENT_ID": client_id,
+        "GOOGLE_CLIENT_SECRET": client_secret,
+    }
+
+
+def turnstile_runtime_updates(values: Dict[str, str]) -> Dict[str, str]:
+    """Apply Turnstile atomically without replacing usable installed credentials."""
+    enabled = values.get("TURNSTILE_ENABLED", "").strip().lower()
+    site_key = values.get("TURNSTILE_SITE_KEY", "").strip()
+    secret_key = values.get("TURNSTILE_SECRET_KEY", "")
+    if enabled not in {"true", "false"}:
+        warn("invalid Turnstile enabled value; preserving installed settings")
+        return {}
+
+    credentials_present = bool(site_key or secret_key)
+    credentials_valid = bool(
+        KEY_PATTERN.fullmatch(site_key)
+        and secret_key
+        and KEY_PATTERN.fullmatch(secret_key)
+    )
+    if enabled == "false" and not credentials_present:
+        return {"TURNSTILE_ENABLED": "false"}
+    if not credentials_valid:
+        warn("incomplete or malformed Turnstile credentials; preserving installed settings")
+        return (
+            {"TURNSTILE_ENABLED": "false"}
+            if enabled == "false"
+            else {}
+        )
+    return {
+        "TURNSTILE_ENABLED": enabled,
+        "TURNSTILE_SITE_KEY": site_key,
+        "TURNSTILE_SECRET_KEY": secret_key,
     }
 
 
@@ -196,16 +266,16 @@ def apply_configuration(
     runtime_values = read_runtime_values(runtime_path)
     if runtime_path is not None:
         signup_enabled = runtime_values.get("HFL_EMAIL_SIGNUP_ENABLED", "").lower()
-        if signup_enabled != "false":
-            raise SystemExit(
-                "SaaS deployment runtime configuration must disable email sign-up"
-            )
-        updates["HFL_EMAIL_SIGNUP_ENABLED"] = "false"
+        if signup_enabled in {"true", "false"}:
+            updates["HFL_EMAIL_SIGNUP_ENABLED"] = signup_enabled
+        else:
+            warn("invalid email sign-up value; preserving installed sign-up setting")
         insecure_tls = runtime_values.get("HFL_INSECURE_TLS", "")
         if insecure_tls not in {"0", "1"}:
             raise SystemExit("HFL_INSECURE_TLS must be 0 or 1")
         updates["HFL_INSECURE_TLS"] = insecure_tls
         updates.update(smtp_runtime_updates(runtime_values))
+        updates.update(google_runtime_updates(runtime_values))
 
         gateway_enabled = runtime_values.get(
             "HFL_PLATFORM_GATEWAY_AUTO_DEPLOY", ""
@@ -217,18 +287,7 @@ def apply_configuration(
                 "invalid platform Gateway auto-deploy value; preserving installed value"
             )
 
-        enabled = runtime_values.get("TURNSTILE_ENABLED", "").lower()
-        if enabled in {"true", "false"}:
-            updates["TURNSTILE_ENABLED"] = enabled
-        else:
-            warn("invalid Turnstile enabled value; preserving installed value")
-
-        for name in ("TURNSTILE_SITE_KEY", "TURNSTILE_SECRET_KEY"):
-            value = runtime_values.get(name, "")
-            if value and KEY_PATTERN.fullmatch(value):
-                updates[name] = value
-            else:
-                warn(f"{name} is empty or malformed; preserving installed value")
+        updates.update(turnstile_runtime_updates(runtime_values))
 
     direct_host = direct_host.strip()
     if direct_host and (
@@ -290,7 +349,7 @@ def apply_configuration(
         key = line.split("=", 1)[0] if "=" in line else ""
         if key in updates:
             value = updates[key]
-            if key == "EMAIL_HOST_PASSWORD":
+            if key in {"EMAIL_HOST_PASSWORD", "GOOGLE_CLIENT_SECRET"}:
                 value = compose_env_value(value)
             updated.append(f"{key}={value}")
             seen.add(key)
@@ -298,7 +357,7 @@ def apply_configuration(
             updated.append(line)
     for key, value in updates.items():
         if key not in seen:
-            if key == "EMAIL_HOST_PASSWORD":
+            if key in {"EMAIL_HOST_PASSWORD", "GOOGLE_CLIENT_SECRET"}:
                 value = compose_env_value(value)
             updated.append(f"{key}={value}")
     atomic_write(env_path, updated)

--- a/src/backend/apps/platform_ops/management/__init__.py
+++ b/src/backend/apps/platform_ops/management/__init__.py
@@ -1,0 +1,1 @@
+"""Platform Operations management commands."""

--- a/src/backend/apps/platform_ops/management/commands/__init__.py
+++ b/src/backend/apps/platform_ops/management/commands/__init__.py
@@ -1,0 +1,1 @@
+"""Deployment and maintenance commands for Platform Operations."""

--- a/src/backend/apps/platform_ops/management/commands/ensure_deployment_identity_settings.py
+++ b/src/backend/apps/platform_ops/management/commands/ensure_deployment_identity_settings.py
@@ -1,0 +1,189 @@
+"""Apply deployment-managed optional identity and email settings."""
+
+from __future__ import annotations
+
+import os
+import re
+from typing import Any
+
+from django.core.management.base import BaseCommand
+from django.db import transaction
+
+from apps.platform_ops.services.internal.runtime_settings import (
+    KEY_EMAIL_BACKEND,
+    KEY_EMAIL_FROM,
+    KEY_EMAIL_HOST,
+    KEY_EMAIL_HOST_USER,
+    KEY_EMAIL_PORT,
+    KEY_EMAIL_USE_SSL,
+    KEY_EMAIL_USE_TLS,
+    KEY_IDENTITY_EMAIL_SIGNUP,
+    KEY_IDENTITY_GOOGLE_CLIENT_ID,
+    KEY_IDENTITY_GOOGLE_OAUTH,
+    KEY_IDENTITY_TURNSTILE_SITE,
+    SECRET_KEY_EMAIL_PASSWORD,
+    SECRET_KEY_GOOGLE,
+    SECRET_KEY_TURNSTILE,
+    SMTP_EMAIL_BACKEND,
+    set_bool,
+    set_value,
+    sync_google_social_app,
+)
+
+GOOGLE_CLIENT_ID_PATTERN = re.compile(
+    r"^[0-9]+-[A-Za-z0-9_-]+\.apps\.googleusercontent\.com$"
+)
+TURNSTILE_KEY_PATTERN = re.compile(r"^[A-Za-z0-9_-]+$")
+
+
+def _parse_bool(name: str) -> bool | None:
+    value = os.getenv(name, "").strip().lower()
+    if value == "true":
+        return True
+    if value == "false":
+        return False
+    return None
+
+
+class Command(BaseCommand):
+    """Synchronize deployment identity settings without external connectivity tests."""
+
+    help = (
+        "Synchronize deployment-managed sign-up, Google OAuth, Turnstile, "
+        "and SMTP settings."
+    )
+
+    def handle(self, *args: Any, **options: Any) -> None:
+        signup_enabled = _parse_bool("HFL_EMAIL_SIGNUP_ENABLED")
+        google_enabled = _parse_bool("HFL_GOOGLE_OAUTH_ENABLED")
+        google_client_id = os.getenv("GOOGLE_CLIENT_ID", "").strip()
+        google_client_secret = os.getenv("GOOGLE_CLIENT_SECRET", "")
+        turnstile_enabled = _parse_bool("TURNSTILE_ENABLED")
+        warnings: list[str] = []
+
+        with transaction.atomic():
+            if signup_enabled is None:
+                warnings.append(
+                    "Invalid email sign-up flag; preserved the installed runtime setting."
+                )
+            else:
+                set_bool(KEY_IDENTITY_EMAIL_SIGNUP, signup_enabled)
+
+            if google_enabled is None:
+                warnings.append(
+                    "Invalid Google OAuth flag; preserved the installed Google settings."
+                )
+            elif not google_enabled:
+                set_bool(KEY_IDENTITY_GOOGLE_OAUTH, False)
+            elif not GOOGLE_CLIENT_ID_PATTERN.fullmatch(google_client_id):
+                warnings.append(
+                    "Invalid Google OAuth client ID; preserved the installed Google settings."
+                )
+            elif not google_client_secret or re.search(
+                r"[\x00\r\n]", google_client_secret
+            ):
+                warnings.append(
+                    "Invalid Google OAuth client secret; preserved the installed Google settings."
+                )
+            else:
+                set_value(key=KEY_IDENTITY_GOOGLE_CLIENT_ID, value=google_client_id)
+                set_value(key=SECRET_KEY_GOOGLE, secret=google_client_secret)
+                set_bool(KEY_IDENTITY_GOOGLE_OAUTH, True)
+                sync_google_social_app()
+
+            self._sync_turnstile(turnstile_enabled, warnings)
+            self._sync_email(warnings)
+
+        for warning in warnings:
+            self.stderr.write(self.style.WARNING(warning))
+        self.stdout.write(
+            "Email sign-up: "
+            + ("enabled" if signup_enabled else "disabled")
+            if signup_enabled is not None
+            else "Email sign-up: preserved"
+        )
+        self.stdout.write(
+            "Google OAuth: "
+            + ("enabled" if google_enabled else "disabled")
+            if google_enabled is not None and not any(
+                "Google OAuth" in warning for warning in warnings
+            )
+            else "Google OAuth: preserved"
+        )
+        self.stdout.write(
+            "HFL_IDENTITY_STATUS=" + ("warning" if warnings else "applied")
+        )
+
+    @staticmethod
+    def _sync_turnstile(
+        enabled: bool | None,
+        warnings: list[str],
+    ) -> None:
+        site_key = os.getenv("TURNSTILE_SITE_KEY", "").strip()
+        secret_key = os.getenv("TURNSTILE_SECRET_KEY", "")
+        if enabled is None:
+            warnings.append(
+                "Invalid Turnstile flag; preserved the installed Turnstile settings."
+            )
+            return
+        if not site_key and not secret_key and not enabled:
+            return
+        if not TURNSTILE_KEY_PATTERN.fullmatch(
+            site_key
+        ) or not TURNSTILE_KEY_PATTERN.fullmatch(secret_key):
+            warnings.append(
+                "Invalid Turnstile credentials; preserved the installed Turnstile settings."
+            )
+            return
+        set_value(key=KEY_IDENTITY_TURNSTILE_SITE, value=site_key)
+        set_value(key=SECRET_KEY_TURNSTILE, secret=secret_key)
+
+    @staticmethod
+    def _sync_email(
+        warnings: list[str],
+    ) -> None:
+        backend = os.getenv("EMAIL_BACKEND", "").strip()
+        if backend != SMTP_EMAIL_BACKEND:
+            warnings.append(
+                "Deployment-managed SMTP is unavailable; preserved the installed "
+                "email settings."
+            )
+            return
+
+        host = os.getenv("EMAIL_HOST", "").strip()
+        port = os.getenv("EMAIL_PORT", "").strip()
+        username = os.getenv("EMAIL_HOST_USER", "").strip()
+        password = os.getenv("EMAIL_HOST_PASSWORD", "")
+        from_email = os.getenv("DEFAULT_FROM_EMAIL", "").strip()
+        use_tls = _parse_bool("EMAIL_USE_TLS")
+        use_ssl = _parse_bool("EMAIL_USE_SSL")
+        try:
+            parsed_port = int(port)
+        except ValueError:
+            parsed_port = 0
+        if (
+            not host
+            or re.search(r"\s", host)
+            or parsed_port < 1
+            or parsed_port > 65535
+            or not username
+            or not password
+            or re.search(r"[\x00\r\n]", password)
+            or not from_email
+            or use_tls is None
+            or use_ssl is None
+            or (use_tls and use_ssl)
+        ):
+            warnings.append(
+                "Invalid SMTP settings; preserved the installed email configuration."
+            )
+            return
+
+        set_value(key=KEY_EMAIL_BACKEND, value=SMTP_EMAIL_BACKEND)
+        set_value(key=KEY_EMAIL_HOST, value=host)
+        set_value(key=KEY_EMAIL_PORT, value=str(parsed_port))
+        set_bool(KEY_EMAIL_USE_TLS, use_tls)
+        set_bool(KEY_EMAIL_USE_SSL, use_ssl)
+        set_value(key=KEY_EMAIL_HOST_USER, value=username)
+        set_value(key=SECRET_KEY_EMAIL_PASSWORD, secret=password)
+        set_value(key=KEY_EMAIL_FROM, value=from_email)

--- a/src/backend/apps/platform_ops/tests/test_ensure_deployment_identity_settings_command.py
+++ b/src/backend/apps/platform_ops/tests/test_ensure_deployment_identity_settings_command.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+import io
+from unittest.mock import patch
+
+from django.core.management import call_command
+from django.test import TestCase
+
+from apps.platform_ops.models.platform_runtime_setting import PlatformRuntimeSetting
+from apps.platform_ops.services.internal.runtime_settings import (
+    KEY_EMAIL_HOST,
+    KEY_IDENTITY_EMAIL_SIGNUP,
+    KEY_IDENTITY_GOOGLE_CLIENT_ID,
+    KEY_IDENTITY_GOOGLE_OAUTH,
+    KEY_IDENTITY_TURNSTILE_SITE,
+    SECRET_KEY_EMAIL_PASSWORD,
+    SECRET_KEY_GOOGLE,
+    SECRET_KEY_TURNSTILE,
+    email_connection_kwargs,
+    get_secret,
+    google_client_id,
+    google_client_secret,
+    google_oauth_enabled,
+    turnstile_secret_key,
+    turnstile_site_key,
+)
+
+
+class EnsureDeploymentIdentitySettingsCommandTests(TestCase):
+    @staticmethod
+    def complete_env(**overrides: str) -> dict[str, str]:
+        env = {
+            "HFL_EMAIL_SIGNUP_ENABLED": "true",
+            "HFL_GOOGLE_OAUTH_ENABLED": "true",
+            "GOOGLE_CLIENT_ID": "123-example.apps.googleusercontent.com",
+            "GOOGLE_CLIENT_SECRET": "google-test-secret",
+            "TURNSTILE_ENABLED": "false",
+            "TURNSTILE_SITE_KEY": "turnstile-test-site",
+            "TURNSTILE_SECRET_KEY": "turnstile-test-secret",
+            "EMAIL_BACKEND": "django.core.mail.backends.smtp.EmailBackend",
+            "EMAIL_HOST": "smtp.example.com",
+            "EMAIL_PORT": "465",
+            "EMAIL_HOST_USER": "mailer@example.com",
+            "EMAIL_HOST_PASSWORD": "smtp-test-secret",
+            "EMAIL_USE_TLS": "false",
+            "EMAIL_USE_SSL": "true",
+            "DEFAULT_FROM_EMAIL": "HyperFileLens <mailer@example.com>",
+        }
+        env.update(overrides)
+        return env
+
+    def run_command(self, env: dict[str, str]):
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        with patch.dict("os.environ", env, clear=False), patch(
+            "apps.platform_ops.management.commands."
+            "ensure_deployment_identity_settings.sync_google_social_app"
+        ) as sync_social_app:
+            call_command(
+                "ensure_deployment_identity_settings",
+                stdout=stdout,
+                stderr=stderr,
+            )
+        return stdout.getvalue(), stderr.getvalue(), sync_social_app
+
+    def test_applies_configuration_idempotently_without_echoing_secret(self):
+        env = self.complete_env(
+            GOOGLE_CLIENT_SECRET="never-print-google-secret",
+            TURNSTILE_SECRET_KEY="never-print-turnstile-secret",
+            EMAIL_HOST_PASSWORD="never-print-smtp-secret",
+        )
+
+        first_stdout, first_stderr, first_sync = self.run_command(env)
+        second_stdout, second_stderr, second_sync = self.run_command(env)
+
+        self.assertEqual(
+            PlatformRuntimeSetting.objects.filter(
+                key__in=(
+                    KEY_IDENTITY_EMAIL_SIGNUP,
+                    KEY_IDENTITY_GOOGLE_CLIENT_ID,
+                    KEY_IDENTITY_GOOGLE_OAUTH,
+                    KEY_IDENTITY_TURNSTILE_SITE,
+                    SECRET_KEY_GOOGLE,
+                    SECRET_KEY_TURNSTILE,
+                )
+            ).count(),
+            6,
+        )
+        self.assertTrue(google_oauth_enabled())
+        self.assertEqual(google_client_id(), env["GOOGLE_CLIENT_ID"])
+        self.assertEqual(google_client_secret(), env["GOOGLE_CLIENT_SECRET"])
+        self.assertEqual(turnstile_site_key(), env["TURNSTILE_SITE_KEY"])
+        self.assertEqual(turnstile_secret_key(), env["TURNSTILE_SECRET_KEY"])
+        email = email_connection_kwargs()
+        self.assertEqual(email["host"], env["EMAIL_HOST"])
+        self.assertEqual(email["password"], env["EMAIL_HOST_PASSWORD"])
+        output = first_stdout + first_stderr + second_stdout + second_stderr
+        for secret_name in (
+            "GOOGLE_CLIENT_SECRET",
+            "TURNSTILE_SECRET_KEY",
+            "EMAIL_HOST_PASSWORD",
+        ):
+            self.assertNotIn(env[secret_name], output)
+        self.assertIn("HFL_IDENTITY_STATUS=applied", second_stdout)
+        first_sync.assert_called_once_with()
+        second_sync.assert_called_once_with()
+
+    def test_invalid_google_configuration_warns_and_preserves_existing_values(self):
+        existing = self.complete_env(
+            HFL_EMAIL_SIGNUP_ENABLED="false",
+            GOOGLE_CLIENT_ID="123-existing.apps.googleusercontent.com",
+            GOOGLE_CLIENT_SECRET="existing-secret",
+        )
+        self.run_command(existing)
+
+        stdout, stderr, sync_social_app = self.run_command(
+            self.complete_env(
+                GOOGLE_CLIENT_ID="invalid-client",
+                GOOGLE_CLIENT_SECRET="replacement-secret",
+            )
+        )
+
+        self.assertEqual(google_client_id(), existing["GOOGLE_CLIENT_ID"])
+        self.assertEqual(google_client_secret(), existing["GOOGLE_CLIENT_SECRET"])
+        self.assertIn("HFL_IDENTITY_STATUS=warning", stdout)
+        self.assertIn("preserved the installed Google settings", stderr)
+        sync_social_app.assert_not_called()
+
+    def test_production_policy_disables_email_signup_and_enables_google(self):
+        stdout, _stderr, _sync = self.run_command(
+            self.complete_env(
+                HFL_EMAIL_SIGNUP_ENABLED="false",
+                GOOGLE_CLIENT_ID="6436338978-prod.apps.googleusercontent.com",
+                GOOGLE_CLIENT_SECRET="production-secret",
+            )
+        )
+
+        signup = PlatformRuntimeSetting.objects.get(key=KEY_IDENTITY_EMAIL_SIGNUP)
+        self.assertEqual(signup.value_text, "false")
+        self.assertIn("Email sign-up: disabled", stdout)
+        self.assertTrue(google_oauth_enabled())
+
+    def test_invalid_turnstile_preserves_existing_credentials_without_failing(self):
+        existing = self.complete_env(
+            TURNSTILE_ENABLED="true",
+            TURNSTILE_SITE_KEY="existing-turnstile-site",
+            TURNSTILE_SECRET_KEY="existing-turnstile-secret",
+        )
+        self.run_command(existing)
+
+        stdout, stderr, _sync = self.run_command(
+            self.complete_env(
+                TURNSTILE_ENABLED="true",
+                TURNSTILE_SITE_KEY="replacement-site",
+                TURNSTILE_SECRET_KEY="invalid secret",
+            )
+        )
+
+        self.assertEqual(turnstile_site_key(), existing["TURNSTILE_SITE_KEY"])
+        self.assertEqual(turnstile_secret_key(), existing["TURNSTILE_SECRET_KEY"])
+        self.assertIn("HFL_IDENTITY_STATUS=warning", stdout)
+        self.assertIn("preserved the installed Turnstile settings", stderr)
+        self.assertNotIn("invalid secret", stdout + stderr)
+
+    def test_invalid_smtp_preserves_existing_configuration_without_failing(self):
+        existing = self.complete_env(
+            EMAIL_HOST="smtp.existing.example.com",
+            EMAIL_HOST_PASSWORD="existing-smtp-secret",
+        )
+        self.run_command(existing)
+
+        stdout, stderr, _sync = self.run_command(
+            self.complete_env(
+                EMAIL_HOST="smtp.replacement.example.com",
+                EMAIL_PORT="invalid",
+                EMAIL_HOST_PASSWORD="replacement-smtp-secret",
+            )
+        )
+
+        self.assertEqual(
+            PlatformRuntimeSetting.objects.get(key=KEY_EMAIL_HOST).value_text,
+            existing["EMAIL_HOST"],
+        )
+        self.assertEqual(
+            get_secret(SECRET_KEY_EMAIL_PASSWORD),
+            existing["EMAIL_HOST_PASSWORD"],
+        )
+        self.assertIn("HFL_IDENTITY_STATUS=warning", stdout)
+        self.assertIn("preserved the installed email configuration", stderr)
+        self.assertNotIn("replacement-smtp-secret", stdout + stderr)

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -200,9 +200,9 @@ if grep -F 'PROD_PUBLIC_HOST' "${workflow}" "${production_workflow}" >/dev/null;
 	printf 'ERROR: release workflow still uses the ambiguous PROD_PUBLIC_HOST variable\n' >&2
 	exit 1
 fi
-grep -F '"TURNSTILE_ENABLED=$TURNSTILE_ENABLED"' \
+grep -F '"TURNSTILE_ENABLED"' \
 	"${ROOT}/.github/workflows/deploy_target.yml" >/dev/null
-grep -F '"HFL_INSECURE_TLS=$HFL_INSECURE_TLS"' \
+grep -F '"HFL_INSECURE_TLS"' \
 	"${ROOT}/.github/workflows/deploy_target.yml" >/dev/null
 grep -F 'test:1|preprod:1|prod:0' \
 	"${ROOT}/.github/workflows/deploy_target.yml" >/dev/null
@@ -236,9 +236,33 @@ if grep -F '"AI_MODEL_API_KEY=$AI_MODEL_API_KEY"' \
 	printf 'ERROR: AI model API key must not be persisted in the runtime .env\n' >&2
 	exit 1
 fi
-grep -F '"HFL_EMAIL_SIGNUP_ENABLED=false"' \
+for variable in EMAIL_SIGNUP_ENABLED GOOGLE_OAUTH_ENABLED GOOGLE_CLIENT_ID; do
+	grep -F "vars.TEST_${variable}" "${workflow}" >/dev/null
+	grep -F "vars.PREPROD_${variable}" "${workflow}" >/dev/null
+	grep -F "vars.PROD_${variable}" "${production_workflow}" >/dev/null
+done
+grep -F 'secrets.TEST_GOOGLE_CLIENT_SECRET' "${workflow}" >/dev/null
+grep -F 'secrets.PREPROD_GOOGLE_CLIENT_SECRET' "${workflow}" "${release_workflow}" >/dev/null
+grep -F 'secrets.PROD_GOOGLE_CLIENT_SECRET' "${production_workflow}" >/dev/null
+for runtime_key in \
+	HFL_EMAIL_SIGNUP_ENABLED HFL_GOOGLE_OAUTH_ENABLED \
+	GOOGLE_CLIENT_ID GOOGLE_CLIENT_SECRET SMTP_PASSWORD; do
+	grep -F "\"${runtime_key}\"" "${ROOT}/.github/workflows/deploy_target.yml" >/dev/null
+done
+if grep -F 'HFL_EMAIL_SIGNUP_ENABLED=false' \
+	"${ROOT}/.github/workflows/deploy_target.yml" >/dev/null; then
+	printf 'ERROR: reusable deployment must not hardcode email sign-up off\n' >&2
+	exit 1
+fi
+grep -F 'Google OAuth settings are missing or malformed' \
 	"${ROOT}/.github/workflows/deploy_target.yml" >/dev/null
-grep -F '"SMTP_PASSWORD=$SMTP_PASSWORD"' \
+grep -F 'SMTP settings are partial; deployment will preserve' \
+	"${ROOT}/.github/workflows/deploy_target.yml" >/dev/null
+grep -F 'No SMTP settings were staged' \
+	"${ROOT}/.github/workflows/deploy_target.yml" >/dev/null
+grep -F 'python manage.py ensure_deployment_identity_settings' \
+	"${ROOT}/.github/workflows/deploy_target.yml" >/dev/null
+grep -F 'HFL_IDENTITY_STATUS=warning' \
 	"${ROOT}/.github/workflows/deploy_target.yml" >/dev/null
 grep -F 'umask 077 && cat > /var/tmp/hyperfilelens-runtime-' \
 	"${ROOT}/.github/workflows/deploy_target.yml" >/dev/null
@@ -353,11 +377,11 @@ grep -F 'DOCKER_DEFAULT_PLATFORM="${DOCKER_DEFAULT_PLATFORM:-linux/amd64}"' \
 	"${ROOT}/dev/stack.sh" >/dev/null
 [[ -x "${ROOT}/dev/bootstrap-macos.sh" && -f "${ROOT}/dev/Brewfile" ]]
 deploy_workflow="${ROOT}/.github/workflows/deploy_target.yml"
-[[ "$(grep -c -- '-o ServerAliveInterval=30' "${deploy_workflow}")" -eq 5 ]] || {
+[[ "$(grep -c -- '-o ServerAliveInterval=30' "${deploy_workflow}")" -eq 6 ]] || {
 	printf 'ERROR: every deployment SSH call must enable ServerAliveInterval\n' >&2
 	exit 1
 }
-[[ "$(grep -c -- '-o ServerAliveCountMax=20' "${deploy_workflow}")" -eq 5 ]] || {
+[[ "$(grep -c -- '-o ServerAliveCountMax=20' "${deploy_workflow}")" -eq 6 ]] || {
 	printf 'ERROR: every deployment SSH call must set ServerAliveCountMax\n' >&2
 	exit 1
 }

--- a/tools/quality/test-deployment-optional-config.sh
+++ b/tools/quality/test-deployment-optional-config.sh
@@ -23,12 +23,16 @@ LENS_GATEWAY_BASE_URL=https://47.237.161.194:11443/sourcelens
 HFL_ADMIN_PUBLIC_URL=
 HFL_INSECURE_TLS=1
 HFL_PLATFORM_GATEWAY_AUTO_DEPLOY=false
+HFL_GOOGLE_OAUTH_ENABLED=false
+GOOGLE_CLIENT_ID=123-old.apps.googleusercontent.com
+GOOGLE_CLIENT_SECRET=old-google-secret
 TURNSTILE_ENABLED=true
 TURNSTILE_SITE_KEY=old-site
 TURNSTILE_SECRET_KEY=old-secret
 ENV
 cat >"${runtime_file}" <<'ENV'
-HFL_EMAIL_SIGNUP_ENABLED=false
+HFL_EMAIL_SIGNUP_ENABLED=true
+HFL_GOOGLE_OAUTH_ENABLED=true
 HFL_INSECURE_TLS=0
 TURNSTILE_ENABLED=true
 HFL_PLATFORM_GATEWAY_AUTO_DEPLOY=true
@@ -40,6 +44,8 @@ SMTP_USERNAME=mailer@example.com
 SMTP_PASSWORD=pa$$ word'with\slashes
 SMTP_SECURITY=ssl
 EMAIL_FROM=HyperFileLens <mailer@example.com>
+GOOGLE_CLIENT_ID=123-new.apps.googleusercontent.com
+GOOGLE_CLIENT_SECRET=new-google-secret
 ENV
 
 runtime_output="$(python3 "${helper}" \
@@ -47,7 +53,7 @@ runtime_output="$(python3 "${helper}" \
 	--runtime-env-file "${runtime_file}" \
 	--public-url "https://hyperfilelens.com" \
 	--direct-host "47.237.161.194")"
-if grep -F "pa\$\$ word" <<<"${runtime_output}" >/dev/null; then
+if grep -E "pa\$\$ word|new-google-secret" <<<"${runtime_output}" >/dev/null; then
 	printf 'ERROR: runtime configuration output exposed the SMTP password\n' >&2
 	exit 1
 fi
@@ -62,7 +68,10 @@ grep -E '^CORS_ALLOWED_ORIGINS=.*https://47\.237\.161\.194:11443.*https://hyperf
 grep -Fx 'TURNSTILE_ENABLED=true' "${env_file}" >/dev/null
 grep -Fx 'TURNSTILE_SITE_KEY=new-site' "${env_file}" >/dev/null
 grep -Fx 'TURNSTILE_SECRET_KEY=new-secret' "${env_file}" >/dev/null
-grep -Fx 'HFL_EMAIL_SIGNUP_ENABLED=false' "${env_file}" >/dev/null
+grep -Fx 'HFL_EMAIL_SIGNUP_ENABLED=true' "${env_file}" >/dev/null
+grep -Fx 'HFL_GOOGLE_OAUTH_ENABLED=true' "${env_file}" >/dev/null
+grep -Fx 'GOOGLE_CLIENT_ID=123-new.apps.googleusercontent.com' "${env_file}" >/dev/null
+grep -Fx 'GOOGLE_CLIENT_SECRET="new-google-secret"' "${env_file}" >/dev/null
 grep -Fx 'EMAIL_BACKEND=django.core.mail.backends.smtp.EmailBackend' "${env_file}" >/dev/null
 grep -Fx 'EMAIL_HOST=smtp.example.com' "${env_file}" >/dev/null
 grep -Fx 'EMAIL_PORT=465' "${env_file}" >/dev/null
@@ -139,14 +148,28 @@ SMTP_PASSWORD=
 SMTP_SECURITY=ssl
 EMAIL_FROM=HyperFileLens <mailer@example.com>
 ENV
-before_partial="$(sha256sum "${partial_env}" | awk '{print $1}')"
-if python3 "${helper}" --env-file "${partial_env}" \
-	--runtime-env-file "${partial_runtime}" >/dev/null 2>&1; then
-	printf 'ERROR: partial SMTP deployment configuration must fail\n' >&2
-	exit 1
-fi
-after_partial="$(sha256sum "${partial_env}" | awk '{print $1}')"
-[[ "${before_partial}" == "${after_partial}" ]]
+partial_output="$(python3 "${helper}" --env-file "${partial_env}" \
+	--runtime-env-file "${partial_runtime}")"
+grep -F 'WARNING: partial SMTP deployment configuration' <<<"${partial_output}" >/dev/null
+grep -Fx 'EMAIL_HOST=smtp.example.com' "${partial_env}" >/dev/null
+grep -Fx 'EMAIL_PORT=465' "${partial_env}" >/dev/null
+grep -F 'EMAIL_HOST_PASSWORD="pa$$$$ word' "${partial_env}" >/dev/null
+
+invalid_google_env="${tmp}/invalid-google.env"
+invalid_google_runtime="${tmp}/invalid-google-runtime.env"
+cp "${env_file}" "${invalid_google_env}"
+cat >"${invalid_google_runtime}" <<'ENV'
+HFL_EMAIL_SIGNUP_ENABLED=true
+HFL_GOOGLE_OAUTH_ENABLED=true
+HFL_INSECURE_TLS=0
+GOOGLE_CLIENT_ID=invalid-client
+GOOGLE_CLIENT_SECRET=replacement-secret
+ENV
+google_output="$(python3 "${helper}" --env-file "${invalid_google_env}" \
+	--runtime-env-file "${invalid_google_runtime}")"
+grep -F 'WARNING: invalid Google OAuth client ID' <<<"${google_output}" >/dev/null
+grep -Fx 'GOOGLE_CLIENT_ID=123-new.apps.googleusercontent.com' "${invalid_google_env}" >/dev/null
+grep -Fx 'GOOGLE_CLIENT_SECRET="new-google-secret"' "${invalid_google_env}" >/dev/null
 
 insecure_env="${tmp}/insecure.env"
 insecure_runtime="${tmp}/insecure-runtime.env"


### PR DESCRIPTION
## Summary
- map per-environment email signup and Google OAuth configuration into every deployment path
- apply Google OAuth, Turnstile, and SMTP settings atomically while preserving installed values on malformed optional input
- keep optional service configuration warnings non-blocking and synchronize effective runtime settings after deployment

## Validation
- targeted Django management-command tests (5 passed)
- full backend Ruff checks
- release and installer contract suite
- Ubuntu 20.04 Python 3.8 compatibility check
- workflow YAML parsing and git diff checks