### PR TITLE
Secure session expiry notices

### DIFF
--- a/src/frontend/src/composables/useAuth.ts
+++ b/src/frontend/src/composables/useAuth.ts
@@ -9,6 +9,11 @@ import {
 import { getCorrelationHeaders } from '../lib/requestContext'
 import { refreshAuthToken } from '../lib/authRefresh'
 import { i18n } from '../i18n'
+import {
+  isSessionInvalidReason,
+  sessionNoticeMessageKey,
+  storeSessionNotice,
+} from '../lib/sessionNotice'
 
 export interface User {
   id: number
@@ -213,16 +218,6 @@ export function clearAuth() {
   })
 }
 
-// Error codes that require redirect to login
-const SESSION_INVALID_CODES = [
-  'OTHER_DEVICE_LOGIN',
-  'PASSWORD_CHANGED',
-  'ACCOUNT_DISABLED',
-  'TOKEN_REUSED',
-  'INVALID_TOKEN',
-  'TOKEN_BLACKLISTED',
-]
-
 const WATCHDOG_INTERVAL_MS = 15_000
 let sessionWatchdogTimer: number | null = null
 let sessionWatchdogChecking = false
@@ -248,10 +243,10 @@ async function redirectToLoginForSession(reason = 'REFRESH_EXPIRED'): Promise<vo
     clearAuth()
 
     if (!isPublicSessionPath(currentRoute.path)) {
+      storeSessionNotice(reason)
       await router.replace({
         path: '/login',
         query: {
-          reason,
           redirect,
         },
       })
@@ -271,7 +266,7 @@ async function checkSessionForWatchdog(): Promise<void> {
     const result = await fetchCurrentUserWithRefresh()
     if (result.user) return
 
-    if (result.errorCode && SESSION_INVALID_CODES.includes(result.errorCode)) {
+    if (isSessionInvalidReason(result.errorCode)) {
       await redirectToLoginForSession(result.errorCode)
       return
     }
@@ -297,7 +292,7 @@ export function useAuth() {
   }
 
   function handleAuthError(error: LoginError) {
-    if (error.errorCode && SESSION_INVALID_CODES.includes(error.errorCode)) {
+    if (isSessionInvalidReason(error.errorCode)) {
       logout()
     }
   }
@@ -319,24 +314,12 @@ export function useAuth() {
   }
 
   function isSessionInvalidError(errorCode?: string): boolean {
-    return errorCode !== undefined && SESSION_INVALID_CODES.includes(errorCode)
+    return isSessionInvalidReason(errorCode)
   }
 
   function getErrorMessage(error: LoginError): string {
-    const errorMessages: Record<string, string> = {
-      'TOKEN_EXPIRED': i18n.global.t('login.sessionExpired'),
-      'REFRESH_EXPIRED': i18n.global.t('login.sessionExpired'),
-      'OTHER_DEVICE_LOGIN': i18n.global.t('login.sessionOtherDevice'),
-      'PASSWORD_CHANGED': i18n.global.t('login.sessionPasswordChanged'),
-      'ACCOUNT_DISABLED': i18n.global.t('login.sessionAccountDisabled'),
-      'TOKEN_REUSED': i18n.global.t('login.sessionTokenReused'),
-      'INVALID_TOKEN': i18n.global.t('login.sessionInvalid'),
-      'TOKEN_BLACKLISTED': i18n.global.t('login.sessionInvalid'),
-    }
-
-    if (error.errorCode && errorMessages[error.errorCode]) {
-      return errorMessages[error.errorCode]
-    }
+    const messageKey = sessionNoticeMessageKey(error.errorCode)
+    if (messageKey) return i18n.global.t(messageKey)
     return error.message
   }
 

--- a/src/frontend/src/composables/useAuthSessionWatchdog.test.ts
+++ b/src/frontend/src/composables/useAuthSessionWatchdog.test.ts
@@ -1,0 +1,99 @@
+// @vitest-environment jsdom
+
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+import { consumeSessionNotice } from '../lib/sessionNotice'
+
+const mocks = vi.hoisted(() => ({
+  currentRoute: {
+    value: {
+      path: '/ops/alerts/incidents',
+      fullPath: '/ops/alerts/incidents?status=open',
+    },
+  },
+  refreshAuthToken: vi.fn().mockResolvedValue({
+    ok: false,
+    errorCode: 'TOKEN_REUSED',
+  }),
+  routerReplace: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('../router', () => ({
+  router: {
+    currentRoute: mocks.currentRoute,
+    beforeEach: vi.fn(),
+    replace: mocks.routerReplace,
+  },
+}))
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+  }),
+}))
+
+vi.mock('../lib/authRefresh', () => ({
+  refreshAuthToken: mocks.refreshAuthToken,
+}))
+
+vi.mock('../lib/requestContext', () => ({
+  getCorrelationHeaders: () => ({}),
+}))
+
+vi.mock('./useDeployProfile', () => ({
+  clearDeployProfileCache: vi.fn(),
+  fetchDeployProfile: vi.fn(),
+  resolvePostLoginPath: vi.fn().mockResolvedValue('/'),
+  shouldForceDeployProfileRefresh: vi.fn().mockReturnValue(false),
+}))
+
+import { setupSessionWatchdog, useAuth } from './useAuth'
+
+describe('session watchdog notice handoff', () => {
+  beforeAll(() => {
+    vi.useFakeTimers()
+    window.sessionStorage.clear()
+  })
+
+  afterAll(() => {
+    vi.clearAllTimers()
+    vi.useRealTimers()
+    window.sessionStorage.clear()
+  })
+
+  it('stores a verified refresh failure without exposing the reason in the URL', async () => {
+    const fetchMock = vi.fn().mockImplementation(async (input: RequestInfo | URL) => {
+      if (String(input).includes('/api/v1/auth/logout')) {
+        return new Response('{}', { status: 200 })
+      }
+      return new Response(JSON.stringify({
+        authenticated: false,
+        refresh_available: true,
+        user: null,
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    useAuth().setUser({
+      id: 1,
+      email: 'person@example.com',
+      username: 'person',
+    })
+    setupSessionWatchdog()
+    window.dispatchEvent(new Event('focus'))
+
+    await vi.waitFor(() => {
+      expect(mocks.routerReplace).toHaveBeenCalledWith({
+        path: '/login',
+        query: {
+          redirect: '/ops/alerts/incidents?status=open',
+        },
+      })
+    })
+    expect(mocks.refreshAuthToken).toHaveBeenCalledOnce()
+    expect(consumeSessionNotice()).toBe('TOKEN_REUSED')
+    expect(consumeSessionNotice()).toBeNull()
+  })
+})

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -12,6 +12,7 @@ import { getCorrelationHeaders } from './requestContext'
 import { getTraceId, logger, setTraceId } from './logger'
 import { refreshAuthToken } from './authRefresh'
 import { getRouteRequestSignal } from './routeRequestAbort'
+import { isSessionInvalidReason, storeSessionNotice } from './sessionNotice'
 
 export type ApiError = {
   status: number
@@ -26,15 +27,6 @@ const API_BASE = import.meta.env.VITE_API_BASE?.toString() || ''
 
 let currentLocale = 'en'
 let isHandlingSessionExpired = false
-
-const SESSION_INVALID_CODES = [
-  'OTHER_DEVICE_LOGIN',
-  'PASSWORD_CHANGED',
-  'ACCOUNT_DISABLED',
-  'TOKEN_REUSED',
-  'INVALID_TOKEN',
-  'TOKEN_BLACKLISTED',
-]
 
 export function setLocale(locale: string) {
   currentLocale = locale
@@ -149,10 +141,10 @@ async function handleSessionExpired(reason = 'REFRESH_EXPIRED'): Promise<void> {
     clearAuth()
 
     if (currentRoute.path !== '/login') {
+      storeSessionNotice(reason)
       await router.replace({
         path: '/login',
         query: {
-          reason,
           redirect,
         },
       })
@@ -161,7 +153,8 @@ async function handleSessionExpired(reason = 'REFRESH_EXPIRED'): Promise<void> {
     clearAuth()
     if (typeof window !== 'undefined' && window.location.pathname !== '/login') {
       const redirect = `${window.location.pathname}${window.location.search}${window.location.hash}`
-      const params = new URLSearchParams({ reason, redirect })
+      storeSessionNotice(reason)
+      const params = new URLSearchParams({ redirect })
       window.location.assign(`/login?${params.toString()}`)
     }
   } finally {
@@ -297,7 +290,7 @@ export async function api<T>(path: string, init?: RequestInit): Promise<T> {
 
       // These security/lifecycle errors cannot be repaired by refreshing.
       // A plain missing/expired access token must still try the refresh endpoint.
-      if (errorCode && SESSION_INVALID_CODES.includes(errorCode)) {
+      if (isSessionInvalidReason(errorCode)) {
         void handleSessionExpired(errorCode)
         throw buildApiError(res, data)
       }

--- a/src/frontend/src/lib/apiSessionNotice.test.ts
+++ b/src/frontend/src/lib/apiSessionNotice.test.ts
@@ -1,0 +1,77 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { consumeSessionNotice } from './sessionNotice'
+
+const mocks = vi.hoisted(() => ({
+  clearAuth: vi.fn(),
+  getRouteRequestSignal: vi.fn(),
+  routerReplace: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('../composables/useAuth', () => ({
+  clearAuth: mocks.clearAuth,
+  currentUser: { value: null },
+  getEffectiveOrgKey: () => '',
+}))
+
+vi.mock('../router', () => ({
+  router: {
+    currentRoute: {
+      value: {
+        path: '/ops/alerts/incidents',
+        fullPath: '/ops/alerts/incidents?status=open',
+      },
+    },
+    replace: mocks.routerReplace,
+  },
+}))
+
+vi.mock('./routeRequestAbort', () => ({
+  getRouteRequestSignal: mocks.getRouteRequestSignal,
+}))
+
+import { api } from './api'
+
+afterEach(() => {
+  window.sessionStorage.clear()
+  vi.clearAllMocks()
+  vi.unstubAllGlobals()
+})
+
+describe('api session expiry handoff', () => {
+  it('stores a backend security reason without exposing it in the login URL', async () => {
+    const fetchMock = vi.fn().mockImplementation(async (input: RequestInfo | URL) => {
+      if (String(input).includes('/api/v1/auth/logout')) {
+        return new Response('{}', { status: 200 })
+      }
+      return new Response(JSON.stringify({
+        code: '1001',
+        error: {
+          error_code: 'TOKEN_REUSED',
+          message: 'Suspicious login activity detected',
+        },
+      }), {
+        status: 401,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(api('/api/v1/ops/alerts/incidents')).rejects.toMatchObject({
+      status: 401,
+      errorCode: 'TOKEN_REUSED',
+    })
+
+    await vi.waitFor(() => {
+      expect(mocks.routerReplace).toHaveBeenCalledWith({
+        path: '/login',
+        query: {
+          redirect: '/ops/alerts/incidents?status=open',
+        },
+      })
+    })
+    expect(mocks.clearAuth).toHaveBeenCalledOnce()
+    expect(consumeSessionNotice()).toBe('TOKEN_REUSED')
+  })
+})

--- a/src/frontend/src/lib/loginNavigation.test.ts
+++ b/src/frontend/src/lib/loginNavigation.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+import { resolveSafeLoginRedirect, withoutLegacySessionReason } from './loginNavigation'
+
+const ORIGIN = 'https://hyperfilelens.com'
+
+describe('login redirect validation', () => {
+  it.each([
+    ['/ops/alerts/incidents', '/ops/alerts/incidents'],
+    ['/search?q=backup#results', '/search?q=backup#results'],
+    ['/foo/../ops/task', '/ops/task'],
+  ])('accepts and canonicalizes a local path: %s', (redirect, expected) => {
+    expect(resolveSafeLoginRedirect(redirect, ORIGIN)).toBe(expected)
+  })
+
+  it.each([
+    'https://example.com/steal',
+    '//example.com/steal',
+    '/\\example.com/steal',
+    '/login',
+    '/login/',
+    '/LOGIN',
+    '/Login/',
+    '/login?redirect=/ops/task',
+    '/foo/../login',
+    '/foo/../LOGIN',
+    '/%2e%2e/login',
+    '/%252e%252e/login',
+    '/%2f%2fexample.com',
+    '/%255cexample.com',
+    '/path\nnext',
+  ])('rejects an unsafe or looping target: %s', (redirect) => {
+    expect(resolveSafeLoginRedirect(redirect, ORIGIN)).toBeNull()
+  })
+
+  it('rejects non-string query values', () => {
+    expect(resolveSafeLoginRedirect(['/ops/task'], ORIGIN)).toBeNull()
+    expect(resolveSafeLoginRedirect(undefined, ORIGIN)).toBeNull()
+  })
+})
+
+describe('legacy session reason cleanup', () => {
+  it('removes reason while preserving valid navigation context', () => {
+    expect(withoutLegacySessionReason({
+      reason: 'TOKEN_REUSED',
+      redirect: '/ops/alerts/incidents',
+      email: 'person@example.com',
+    })).toEqual({
+      redirect: '/ops/alerts/incidents',
+      email: 'person@example.com',
+    })
+  })
+
+  it('does not redirect a clean login route', () => {
+    expect(withoutLegacySessionReason({ redirect: '/ops/task' })).toBeNull()
+  })
+})

--- a/src/frontend/src/lib/loginNavigation.ts
+++ b/src/frontend/src/lib/loginNavigation.ts
@@ -1,0 +1,44 @@
+import type { LocationQuery, LocationQueryRaw } from 'vue-router'
+
+export const LOGIN_ROUTE_NAME = 'login'
+
+const ENCODED_PATH_DELIMITER_PATTERN = /%(?:25)*(?:2e|2f|5c)/i
+
+function containsControlCharacter(value: string): boolean {
+  return Array.from(value).some((character) => {
+    const code = character.charCodeAt(0)
+    return code <= 31 || code === 127
+  })
+}
+
+function currentOrigin(): string {
+  return typeof window !== 'undefined' ? window.location.origin : 'http://localhost'
+}
+
+export function resolveSafeLoginRedirect(
+  redirect: unknown,
+  origin = currentOrigin(),
+): string | null {
+  if (typeof redirect !== 'string') return null
+  if (!redirect.startsWith('/') || redirect.startsWith('//')) return null
+  if (redirect.includes('\\') || containsControlCharacter(redirect)) return null
+
+  try {
+    const expectedOrigin = new URL(origin).origin
+    const target = new URL(redirect, expectedOrigin)
+    if (target.origin !== expectedOrigin) return null
+    if (ENCODED_PATH_DELIMITER_PATTERN.test(target.pathname)) return null
+    const normalizedPath = target.pathname.toLowerCase()
+    if (normalizedPath === '/login' || normalizedPath.startsWith('/login/')) return null
+    return `${target.pathname}${target.search}${target.hash}`
+  } catch {
+    return null
+  }
+}
+
+export function withoutLegacySessionReason(query: LocationQuery): LocationQueryRaw | null {
+  if (!Object.prototype.hasOwnProperty.call(query, 'reason')) return null
+  const sanitized: LocationQueryRaw = { ...query }
+  delete sanitized.reason
+  return sanitized
+}

--- a/src/frontend/src/lib/sessionNotice.test.ts
+++ b/src/frontend/src/lib/sessionNotice.test.ts
@@ -1,0 +1,41 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  consumeSessionNotice,
+  SESSION_NOTICE_TTL_MS,
+  storeSessionNotice,
+} from './sessionNotice'
+
+describe('session notice handoff', () => {
+  beforeEach(() => {
+    window.sessionStorage.clear()
+  })
+
+  it('consumes a verified notice only once', () => {
+    expect(storeSessionNotice('TOKEN_REUSED', window.sessionStorage, 1_000)).toBe(true)
+
+    expect(consumeSessionNotice(window.sessionStorage, 1_500)).toBe('TOKEN_REUSED')
+    expect(consumeSessionNotice(window.sessionStorage, 1_500)).toBeNull()
+  })
+
+  it('rejects expired, future, unknown, and malformed notices', () => {
+    expect(storeSessionNotice('TOKEN_REUSED', window.sessionStorage, 1_000)).toBe(true)
+    expect(consumeSessionNotice(window.sessionStorage, 1_000 + SESSION_NOTICE_TTL_MS + 1)).toBeNull()
+
+    expect(storeSessionNotice('TOKEN_REUSED', window.sessionStorage, 2_000)).toBe(true)
+    expect(consumeSessionNotice(window.sessionStorage, 1_999)).toBeNull()
+
+    expect(storeSessionNotice('FORGED_REASON', window.sessionStorage, 3_000)).toBe(false)
+    expect(consumeSessionNotice(window.sessionStorage, 3_000)).toBeNull()
+
+    window.sessionStorage.setItem('hyperfilelens:auth-session-notice', '{not-json')
+    expect(consumeSessionNotice(window.sessionStorage, 3_000)).toBeNull()
+    expect(window.sessionStorage.length).toBe(0)
+  })
+
+  it('fails closed when storage is unavailable', () => {
+    expect(storeSessionNotice('TOKEN_REUSED', null)).toBe(false)
+    expect(consumeSessionNotice(null)).toBeNull()
+  })
+})

--- a/src/frontend/src/lib/sessionNotice.ts
+++ b/src/frontend/src/lib/sessionNotice.ts
@@ -1,0 +1,111 @@
+export const SESSION_NOTICE_REASONS = [
+  'TOKEN_EXPIRED',
+  'REFRESH_EXPIRED',
+  'OTHER_DEVICE_LOGIN',
+  'PASSWORD_CHANGED',
+  'ACCOUNT_DISABLED',
+  'TOKEN_REUSED',
+  'INVALID_TOKEN',
+  'TOKEN_BLACKLISTED',
+] as const
+
+export type SessionNoticeReason = (typeof SESSION_NOTICE_REASONS)[number]
+
+const SESSION_INVALID_REASONS = new Set<SessionNoticeReason>([
+  'OTHER_DEVICE_LOGIN',
+  'PASSWORD_CHANGED',
+  'ACCOUNT_DISABLED',
+  'TOKEN_REUSED',
+  'INVALID_TOKEN',
+  'TOKEN_BLACKLISTED',
+])
+
+const SESSION_REASON_MESSAGE_KEYS: Record<SessionNoticeReason, string> = {
+  TOKEN_EXPIRED: 'login.sessionExpired',
+  REFRESH_EXPIRED: 'login.sessionExpired',
+  OTHER_DEVICE_LOGIN: 'login.sessionOtherDevice',
+  PASSWORD_CHANGED: 'login.sessionPasswordChanged',
+  ACCOUNT_DISABLED: 'login.sessionAccountDisabled',
+  TOKEN_REUSED: 'login.sessionTokenReused',
+  INVALID_TOKEN: 'login.sessionInvalid',
+  TOKEN_BLACKLISTED: 'login.sessionInvalid',
+}
+
+const SESSION_NOTICE_STORAGE_KEY = 'hyperfilelens:auth-session-notice'
+const SESSION_NOTICE_VERSION = 1
+export const SESSION_NOTICE_TTL_MS = 60_000
+
+type StoredSessionNotice = {
+  version: typeof SESSION_NOTICE_VERSION
+  reason: SessionNoticeReason
+  createdAt: number
+}
+
+function browserSessionStorage(): Storage | null {
+  if (typeof window === 'undefined') return null
+  try {
+    return window.sessionStorage
+  } catch {
+    return null
+  }
+}
+
+export function isSessionNoticeReason(reason: unknown): reason is SessionNoticeReason {
+  return typeof reason === 'string' && SESSION_NOTICE_REASONS.includes(reason as SessionNoticeReason)
+}
+
+export function isSessionInvalidReason(reason: unknown): reason is SessionNoticeReason {
+  return isSessionNoticeReason(reason) && SESSION_INVALID_REASONS.has(reason)
+}
+
+export function sessionNoticeMessageKey(reason: unknown): string | null {
+  return isSessionNoticeReason(reason) ? SESSION_REASON_MESSAGE_KEYS[reason] : null
+}
+
+export function storeSessionNotice(
+  reason: unknown,
+  storage: Storage | null = browserSessionStorage(),
+  now = Date.now(),
+): boolean {
+  if (!storage || !isSessionNoticeReason(reason)) return false
+
+  const notice: StoredSessionNotice = {
+    version: SESSION_NOTICE_VERSION,
+    reason,
+    createdAt: now,
+  }
+
+  try {
+    storage.setItem(SESSION_NOTICE_STORAGE_KEY, JSON.stringify(notice))
+    return true
+  } catch {
+    return false
+  }
+}
+
+export function consumeSessionNotice(
+  storage: Storage | null = browserSessionStorage(),
+  now = Date.now(),
+): SessionNoticeReason | null {
+  if (!storage) return null
+
+  let raw: string | null = null
+  try {
+    raw = storage.getItem(SESSION_NOTICE_STORAGE_KEY)
+    storage.removeItem(SESSION_NOTICE_STORAGE_KEY)
+  } catch {
+    return null
+  }
+  if (!raw) return null
+
+  try {
+    const notice = JSON.parse(raw) as Partial<StoredSessionNotice>
+    if (notice.version !== SESSION_NOTICE_VERSION) return null
+    if (!isSessionNoticeReason(notice.reason)) return null
+    if (typeof notice.createdAt !== 'number' || !Number.isFinite(notice.createdAt)) return null
+    if (notice.createdAt > now || now - notice.createdAt > SESSION_NOTICE_TTL_MS) return null
+    return notice.reason
+  } catch {
+    return null
+  }
+}

--- a/src/frontend/src/pages/account/AccountProfile.vue
+++ b/src/frontend/src/pages/account/AccountProfile.vue
@@ -283,7 +283,7 @@ async function updatePassword() {
     resetPasswordFormState()
     clearAuth()
     ElMessage.success({ message: res.data?.message || t('account.passwordChangedRelogin'), duration: 2500, grouping: true })
-    await router.replace({ path: '/login', query: { reason: 'password_changed' } })
+    await router.replace('/login')
   } catch (err: unknown) {
     const fields = err && typeof err === 'object' ? (err as { fields?: Record<string, string[]> }).fields : undefined
     if (!applyPasswordFieldErrors(fields)) {

--- a/src/frontend/src/pages/auth/Login.vue
+++ b/src/frontend/src/pages/auth/Login.vue
@@ -12,6 +12,11 @@ import AuthTurnstileField from '../../components/auth/AuthTurnstileField.vue'
 import ResetPasswordCard from '../../components/auth/ResetPasswordCard.vue'
 import { fetchDeployProfile, resolvePostLoginPath } from '../../composables/useDeployProfile'
 import { appConfig } from '../../lib/appConfig'
+import { resolveSafeLoginRedirect } from '../../lib/loginNavigation'
+import {
+  consumeSessionNotice,
+  sessionNoticeMessageKey,
+} from '../../lib/sessionNotice'
 
 const emailSignupEnabled = ref(false)
 const passwordResetAvailable = ref(false)
@@ -26,6 +31,7 @@ const {
 const router = useRouter()
 const route = useRoute()
 const sessionNoticeDismissed = ref(false)
+const sessionNoticeReason = ref(consumeSessionNotice())
 
 const {
   turnstileSiteKey,
@@ -45,17 +51,6 @@ const turnstileFieldRef = ref<InstanceType<typeof AuthTurnstileField> | null>(nu
 const googleEnabled = ref(false)
 const googleLoginUrl = ref('/accounts/google/login/?process=login')
 const googleLoading = ref(false)
-
-const SESSION_REASON_MESSAGE_KEYS: Record<string, string> = {
-  TOKEN_EXPIRED: 'login.sessionExpired',
-  REFRESH_EXPIRED: 'login.sessionExpired',
-  OTHER_DEVICE_LOGIN: 'login.sessionOtherDevice',
-  PASSWORD_CHANGED: 'login.sessionPasswordChanged',
-  ACCOUNT_DISABLED: 'login.sessionAccountDisabled',
-  TOKEN_REUSED: 'login.sessionTokenReused',
-  INVALID_TOKEN: 'login.sessionInvalid',
-  TOKEN_BLACKLISTED: 'login.sessionInvalid',
-}
 
 // Session invalid error codes that should show a dialog
 const SESSION_INVALID_CODES = [
@@ -95,9 +90,7 @@ if (typeof emailFromQuery === 'string' && emailFromQuery.trim()) {
 
 const sessionNoticeMessage = computed(() => {
   if (sessionNoticeDismissed.value) return ''
-  const reason = route.query.reason
-  if (typeof reason !== 'string') return ''
-  const key = SESSION_REASON_MESSAGE_KEYS[reason]
+  const key = sessionNoticeMessageKey(sessionNoticeReason.value)
   return key ? t(key) : ''
 })
 
@@ -264,7 +257,7 @@ function validateForm() {
 }
 
 function showSessionErrorDialog(errorCode: string) {
-  const message = t(SESSION_REASON_MESSAGE_KEYS[errorCode] || 'login.sessionExpired')
+  const message = t(sessionNoticeMessageKey(errorCode) || 'login.sessionExpired')
   ElMessageBox.alert(message, t('login.sessionExpired'), {
     confirmButtonText: t('login.btnSubmit'),
     type: 'warning',
@@ -274,15 +267,8 @@ function showSessionErrorDialog(errorCode: string) {
 }
 
 async function resolveLoginTargetPath(): Promise<string> {
-  const redirect = route.query.redirect
-  if (
-    typeof redirect === 'string' &&
-    redirect.startsWith('/') &&
-    !redirect.startsWith('//') &&
-    !redirect.startsWith('/login')
-  ) {
-    return redirect
-  }
+  const redirect = resolveSafeLoginRedirect(route.query.redirect)
+  if (redirect) return redirect
   return resolvePostLoginPath()
 }
 

--- a/src/frontend/src/pages/auth/LoginTurnstileLifecycle.test.ts
+++ b/src/frontend/src/pages/auth/LoginTurnstileLifecycle.test.ts
@@ -7,6 +7,7 @@ import { createI18n } from 'vue-i18n'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { en } from '../../locales/en'
+import { storeSessionNotice } from '../../lib/sessionNotice'
 import Login from './Login.vue'
 
 const mocks = vi.hoisted(() => ({
@@ -17,6 +18,7 @@ const mocks = vi.hoisted(() => ({
   fetchDeployProfile: vi.fn(),
   loadTurnstileConfig: vi.fn(),
   resetWidget: vi.fn(),
+  routeQuery: {} as Record<string, string>,
   routerPush: vi.fn(),
   setStoredOrgKey: vi.fn(),
   setUser: vi.fn(),
@@ -62,7 +64,7 @@ vi.mock('../../lib/appConfig', () => ({
 }))
 
 vi.mock('vue-router', () => ({
-  useRoute: () => ({ query: {} }),
+  useRoute: () => ({ query: mocks.routeQuery }),
   useRouter: () => ({ push: mocks.routerPush }),
 }))
 
@@ -155,6 +157,10 @@ function submittedBody(call: unknown[]) {
 describe('Login Turnstile lifecycle', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    window.sessionStorage.clear()
+    for (const key of Object.keys(mocks.routeQuery)) {
+      delete mocks.routeQuery[key]
+    }
     mocks.fetchDeployProfile.mockResolvedValue({
       email_signup_enabled: false,
       password_reset_available: false,
@@ -164,6 +170,30 @@ describe('Login Turnstile lifecycle', () => {
       token ? { turnstile_token: token } : {}
     ))
     installDefaultApiMock()
+  })
+
+  it('ignores a forged session reason from the public URL', async () => {
+    mocks.routeQuery.reason = 'TOKEN_REUSED'
+    mocks.routeQuery.redirect = '/ops/alerts/incidents'
+
+    const wrapper = await mountLogin(1440)
+
+    expect(wrapper.find('.session-alert').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('shows a backend-produced session notice only once', async () => {
+    expect(storeSessionNotice('TOKEN_REUSED')).toBe(true)
+
+    const firstMount = await mountLogin(1440)
+    expect(firstMount.get('.session-alert').text()).toContain(
+      'Unusual sign-in activity. Sign in again.',
+    )
+    firstMount.unmount()
+
+    const replayMount = await mountLogin(1440)
+    expect(replayMount.find('.session-alert').exists()).toBe(false)
+    replayMount.unmount()
   })
 
   it.each([

--- a/src/frontend/src/router/index.ts
+++ b/src/frontend/src/router/index.ts
@@ -7,6 +7,7 @@ import { beginRouteRequestScope } from '../lib/routeRequestAbort'
 import { beginRouteTransition, finishRouteTransition } from '../lib/routeTransition'
 import { lazyRoute } from './lazyRoute'
 import { isDynamicImportFailure, reloadOnceForChunkLoadFailure } from './chunkLoadRecovery'
+import { LOGIN_ROUTE_NAME, withoutLegacySessionReason } from '../lib/loginNavigation'
 
 import { prefetchAuthTurnstile } from '../composables/useTurnstileConfig'
 
@@ -62,7 +63,7 @@ const GlobalSearchPage = lazyRoute(() => import('../pages/Search.vue'))
 export const router = createRouter({
   history: createWebHistory(),
   routes: [
-    { path: '/login', component: LoginPage, beforeEnter: authTurnstilePrefetch },
+    { path: '/login', name: LOGIN_ROUTE_NAME, component: LoginPage, beforeEnter: authTurnstilePrefetch },
     { path: '/register', component: RegisterPage, beforeEnter: authTurnstilePrefetch },
     { path: '/auth/oauth/callback', component: OAuthCallbackPage },
     { path: '/auth/oauth/error', component: OAuthErrorPage },
@@ -173,6 +174,18 @@ export const router = createRouter({
     },
     { path: '/:pathMatch(.*)*', redirect: '/' },
   ],
+})
+
+router.beforeEach((to) => {
+  if (to.name !== LOGIN_ROUTE_NAME) return
+  const query = withoutLegacySessionReason(to.query)
+  if (!query) return
+  return {
+    path: to.path,
+    query,
+    hash: to.hash,
+    replace: true,
+  }
 })
 
 router.beforeEach((to, from) => {

--- a/src/frontend/src/router/loginRouteSecurity.test.ts
+++ b/src/frontend/src/router/loginRouteSecurity.test.ts
@@ -1,0 +1,36 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../composables/useTurnstileConfig', () => ({
+  prefetchAuthTurnstile: vi.fn(),
+}))
+
+import { router } from './index'
+
+describe('login route security state', () => {
+  beforeEach(async () => {
+    await router.replace('/')
+  })
+
+  it.each([
+    '/login',
+    '/login/',
+    '/LOGIN',
+    '/Login',
+  ])('removes a forged legacy reason from %s without losing a valid redirect', async (path) => {
+    await router.push({
+      path,
+      query: {
+        reason: 'TOKEN_REUSED',
+        redirect: '/ops/alerts/incidents',
+      },
+    })
+
+    expect(router.currentRoute.value.name).toBe('login')
+    expect(router.currentRoute.value.query).toEqual({
+      redirect: '/ops/alerts/incidents',
+    })
+    expect(window.location.search).toBe('?redirect=/ops/alerts/incidents')
+  })
+})


### PR DESCRIPTION
- Pass verified session reasons through short-lived single-use storage instead of public query parameters
- Strip legacy reasons from login URLs and preserve validated local redirects
- Reject absolute, encoded, case-variant, and looping login targets
- Cover API, watchdog, forged URL, replay, and route-variant behavior

Fixes #102