### PR TITLE
Verify OAuth error events

### DIFF
--- a/src/backend/apps/iam/auth/adapters.py
+++ b/src/backend/apps/iam/auth/adapters.py
@@ -15,6 +15,7 @@ from django.shortcuts import redirect
 from allauth.core.exceptions import ImmediateHttpResponse
 from allauth.socialaccount.adapter import DefaultSocialAccountAdapter
 
+from apps.iam.services.oauth_error_events import build_oauth_error_redirect
 from apps.iam.services.registration_service import complete_social_user_registration
 from apps.platform_ops.services.internal.runtime_settings import google_oauth_enabled
 from common.deploy.site import tenant_public_url
@@ -84,14 +85,20 @@ class CustomSocialAccountAdapter(DefaultSocialAccountAdapter):
             extra,
         )
         raise ImmediateHttpResponse(
-            redirect(f"{tenant_public_url()}/auth/oauth/error?reason={reason}")
+            redirect(build_oauth_error_redirect(tenant_public_url(), reason))
         )
 
     def pre_social_login(self, request, sociallogin):
-        email = (sociallogin.account.extra_data.get("email") or sociallogin.user.email or "").strip().lower()
+        email = (
+            sociallogin.account.extra_data.get("email")
+            or sociallogin.user.email
+            or ""
+        ).strip().lower()
         if not email:
             raise ImmediateHttpResponse(
-                redirect(f"{settings.FRONTEND_URL.rstrip('/')}/auth/oauth/error?reason=no_email")
+                redirect(
+                    build_oauth_error_redirect(settings.FRONTEND_URL, "no_email")
+                )
             )
 
         if sociallogin.user.pk:

--- a/src/backend/apps/iam/auth/urls.py
+++ b/src/backend/apps/iam/auth/urls.py
@@ -14,6 +14,7 @@ from apps.iam.auth.views import (
     ForgotPasswordConfirmView,
     GetAvailableScenesView,
     GoogleOAuthConfigView,
+    GoogleOAuthErrorEventConsumeView,
     OrgSelectView,
     TokenRefreshView,
     TurnstileConfigView,
@@ -28,6 +29,11 @@ class CustomLoginView(LoginView):
 urlpatterns = [
     path("api/v1/auth/turnstile/config", TurnstileConfigView.as_view(), name="turnstile_config"),
     path("api/v1/auth/google/config", GoogleOAuthConfigView.as_view(), name="google_oauth_config"),
+    path(
+        "api/v1/auth/google/error-events/consume",
+        GoogleOAuthErrorEventConsumeView.as_view(),
+        name="google_oauth_error_event_consume",
+    ),
     path("api/v1/auth/email-login", EmailLoginView.as_view(), name="email_login"),
     path("api/v1/auth/org-select", OrgSelectView.as_view(), name="org_select"),
     path("api/v1/auth/email-register/send-code", EmailRegisterSendCodeView.as_view(), name="email_register_send_code"),

--- a/src/backend/apps/iam/auth/views/__init__.py
+++ b/src/backend/apps/iam/auth/views/__init__.py
@@ -4,7 +4,11 @@ Views for user authentication and management.
 
 from .turnstile import TurnstileConfigView
 from .login import EmailLoginView, TokenRefreshView, LogoutView, OrgSelectView
-from .oauth import GoogleOAuthCallbackView, GoogleOAuthConfigView
+from .oauth import (
+    GoogleOAuthCallbackView,
+    GoogleOAuthConfigView,
+    GoogleOAuthErrorEventConsumeView,
+)
 from .registration import (
     ChangePasswordView,
     EmailRegisterView,
@@ -28,6 +32,7 @@ __all__ = [
     "GetAvailableScenesView",
     "GoogleOAuthCallbackView",
     "GoogleOAuthConfigView",
+    "GoogleOAuthErrorEventConsumeView",
     "OrgSelectView",
     "TokenRefreshView",
     "TurnstileConfigView",

--- a/src/backend/apps/iam/auth/views/oauth.py
+++ b/src/backend/apps/iam/auth/views/oauth.py
@@ -12,6 +12,10 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from apps.iam.auth.token_cookies import issue_auth_tokens_for_user, set_auth_cookies
+from apps.iam.services.oauth_error_events import (
+    build_oauth_error_redirect,
+    consume_oauth_error_event,
+)
 from apps.iam.services.registration_service import complete_social_user_registration
 from common.http.public_api import AnonymousPublicViewMixin
 
@@ -52,6 +56,29 @@ class GoogleOAuthConfigView(AnonymousPublicViewMixin, APIView):
         return Response({"code": "0000", "data": data})
 
 
+class GoogleOAuthErrorEventConsumeView(AnonymousPublicViewMixin, APIView):
+    """POST /api/v1/auth/google/error-events/consume"""
+
+    @extend_schema(
+        tags=["auth"],
+        summary="Consume a short-lived OAuth error event",
+        responses={200: OpenApiTypes.OBJECT},
+    )
+    def post(self, request):
+        reason = consume_oauth_error_event(request.data.get("event_id"))
+        response = Response(
+            {
+                "code": "0000",
+                "data": {
+                    "verified": reason is not None,
+                    "reason": reason or "oauth_failed",
+                },
+            }
+        )
+        response["Cache-Control"] = "no-store"
+        return response
+
+
 class GoogleOAuthCallbackView(View):
     """
     Complete Google OAuth: issue JWT cookies and redirect to the SPA.
@@ -66,20 +93,28 @@ class GoogleOAuthCallbackView(View):
 
         if not is_google_oauth_enabled():
             logout(request)
-            return HttpResponseRedirect(f"{frontend}/auth/oauth/error?reason=disabled")
+            return HttpResponseRedirect(
+                build_oauth_error_redirect(frontend, "disabled")
+            )
 
         if not request.user.is_authenticated:
-            return HttpResponseRedirect(f"{frontend}/auth/oauth/error?reason=not_authenticated")
+            return HttpResponseRedirect(
+                build_oauth_error_redirect(frontend, "not_authenticated")
+            )
 
         user = request.user
 
         if not user.is_active:
-            return HttpResponseRedirect(f"{frontend}/auth/oauth/error?reason=account_disabled")
+            return HttpResponseRedirect(
+                build_oauth_error_redirect(frontend, "account_disabled")
+            )
 
         try:
             org = complete_social_user_registration(user)
         except Exception:
-            return HttpResponseRedirect(f"{frontend}/auth/oauth/error?reason=provision_failed")
+            return HttpResponseRedirect(
+                build_oauth_error_redirect(frontend, "provision_failed")
+            )
 
         access_token, refresh_token, family_id, membership = issue_auth_tokens_for_user(user, request)
         if membership is None:

--- a/src/backend/apps/iam/migrations/0011_oautherrorevent.py
+++ b/src/backend/apps/iam/migrations/0011_oautherrorevent.py
@@ -1,0 +1,50 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("iam", "0010_profile_language_packs"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="OAuthErrorEvent",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                (
+                    "token_hash",
+                    models.CharField(db_index=True, max_length=64, unique=True),
+                ),
+                (
+                    "reason",
+                    models.CharField(
+                        choices=[
+                            ("oauth_failed", "OAuth failed"),
+                            ("state_lost", "OAuth state lost"),
+                            ("invalid_grant", "Invalid OAuth grant"),
+                            ("no_email", "Email unavailable"),
+                            ("disabled", "OAuth disabled"),
+                            ("not_authenticated", "Authentication incomplete"),
+                            ("account_disabled", "Account disabled"),
+                            ("provision_failed", "Provisioning failed"),
+                        ],
+                        max_length=32,
+                    ),
+                ),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("expires_at", models.DateTimeField(db_index=True)),
+            ],
+            options={
+                "db_table": "iam_oauth_error_event",
+                "ordering": ["-created_at", "id"],
+            },
+        ),
+    ]

--- a/src/backend/apps/iam/models.py
+++ b/src/backend/apps/iam/models.py
@@ -119,3 +119,25 @@ class PersonalApiKey(models.Model):
             self.token = self.generate_token()
         return super().save(*args, **kwargs)
 
+
+class OAuthErrorEvent(models.Model):
+    """Short-lived, single-use handoff for verified OAuth failures."""
+
+    class Reason(models.TextChoices):
+        OAUTH_FAILED = "oauth_failed", "OAuth failed"
+        STATE_LOST = "state_lost", "OAuth state lost"
+        INVALID_GRANT = "invalid_grant", "Invalid OAuth grant"
+        NO_EMAIL = "no_email", "Email unavailable"
+        DISABLED = "disabled", "OAuth disabled"
+        NOT_AUTHENTICATED = "not_authenticated", "Authentication incomplete"
+        ACCOUNT_DISABLED = "account_disabled", "Account disabled"
+        PROVISION_FAILED = "provision_failed", "Provisioning failed"
+
+    token_hash = models.CharField(max_length=64, unique=True, db_index=True)
+    reason = models.CharField(max_length=32, choices=Reason.choices)
+    created_at = models.DateTimeField(auto_now_add=True)
+    expires_at = models.DateTimeField(db_index=True)
+
+    class Meta:
+        db_table = "iam_oauth_error_event"
+        ordering = ["-created_at", "id"]

--- a/src/backend/apps/iam/services/oauth_error_events.py
+++ b/src/backend/apps/iam/services/oauth_error_events.py
@@ -1,0 +1,72 @@
+"""Trusted, single-use handoff for OAuth error messages."""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import secrets
+from datetime import timedelta
+from urllib.parse import quote
+
+from django.db import transaction
+from django.utils import timezone
+
+from apps.iam.models import OAuthErrorEvent
+
+logger = logging.getLogger(__name__)
+OAUTH_ERROR_EVENT_TTL = timedelta(minutes=2)
+MAX_EVENT_ID_LENGTH = 256
+
+
+def _token_hash(token: str) -> str:
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+def create_oauth_error_event(reason: str) -> str:
+    """Persist a verified OAuth failure and return its unguessable bearer ID."""
+    valid_reasons = OAuthErrorEvent.Reason.values
+    normalized_reason = (
+        reason if reason in valid_reasons else OAuthErrorEvent.Reason.OAUTH_FAILED
+    )
+    now = timezone.now()
+    OAuthErrorEvent.objects.filter(expires_at__lte=now).delete()
+
+    event_id = secrets.token_urlsafe(32)
+    OAuthErrorEvent.objects.create(
+        token_hash=_token_hash(event_id),
+        reason=normalized_reason,
+        expires_at=now + OAUTH_ERROR_EVENT_TTL,
+    )
+    return event_id
+
+
+def build_oauth_error_redirect(frontend_url: str, reason: str) -> str:
+    error_page = f"{frontend_url.rstrip('/')}/auth/oauth/error"
+    try:
+        event_id = create_oauth_error_event(reason)
+    except Exception:
+        logger.exception("Unable to persist OAuth error event")
+        return error_page
+    return f"{error_page}?event_id={quote(event_id, safe='')}"
+
+
+def consume_oauth_error_event(event_id: object) -> str | None:
+    """Atomically consume a valid event, returning ``None`` for every invalid state."""
+    if not isinstance(event_id, str):
+        return None
+    normalized_id = event_id.strip()
+    if not normalized_id or len(normalized_id) > MAX_EVENT_ID_LENGTH:
+        return None
+
+    with transaction.atomic():
+        event = (
+            OAuthErrorEvent.objects.select_for_update()
+            .filter(token_hash=_token_hash(normalized_id))
+            .first()
+        )
+        if event is None:
+            return None
+
+        reason = event.reason if event.expires_at > timezone.now() else None
+        event.delete()
+        return reason

--- a/src/backend/apps/iam/tests/test_google_oauth.py
+++ b/src/backend/apps/iam/tests/test_google_oauth.py
@@ -1,14 +1,22 @@
 """Tests for Google OAuth login and social registration."""
 
+from datetime import timedelta
+from urllib.parse import parse_qs, urlparse
 from unittest.mock import patch
 
 from django.contrib.auth.models import User
 from django.test import Client, override_settings
 from django.urls import reverse
+from django.utils import timezone
 from rest_framework import status
 from rest_framework.test import APITestCase
 
-from apps.iam.models import Membership, Organization
+from apps.iam.models import Membership, OAuthErrorEvent, Organization
+from apps.iam.services.oauth_error_events import (
+    build_oauth_error_redirect,
+    consume_oauth_error_event,
+    create_oauth_error_event,
+)
 from apps.iam.services.registration_service import complete_social_user_registration
 
 
@@ -76,6 +84,79 @@ class SocialRegistrationServiceTests(APITestCase):
         self.assertEqual(Membership.objects.filter(user=user).count(), 1)
 
 
+class OAuthErrorEventTests(APITestCase):
+    def test_event_is_hashed_and_consumed_once(self):
+        event_id = create_oauth_error_event("account_disabled")
+        event = OAuthErrorEvent.objects.get()
+
+        self.assertNotEqual(event.token_hash, event_id)
+        self.assertEqual(len(event.token_hash), 64)
+        self.assertEqual(consume_oauth_error_event(event_id), "account_disabled")
+        self.assertIsNone(consume_oauth_error_event(event_id))
+        self.assertFalse(OAuthErrorEvent.objects.exists())
+
+    def test_expired_unknown_and_oversized_events_fail_closed(self):
+        event_id = create_oauth_error_event("invalid_grant")
+        OAuthErrorEvent.objects.update(expires_at=timezone.now() - timedelta(seconds=1))
+
+        self.assertIsNone(consume_oauth_error_event(event_id))
+        self.assertIsNone(consume_oauth_error_event("unknown"))
+        self.assertIsNone(consume_oauth_error_event("x" * 257))
+        self.assertFalse(OAuthErrorEvent.objects.exists())
+
+    def test_unknown_reason_is_reduced_to_generic(self):
+        event_id = create_oauth_error_event("attacker_controlled")
+
+        self.assertEqual(consume_oauth_error_event(event_id), "oauth_failed")
+
+    def test_consume_endpoint_returns_verified_reason_then_generic_replay(self):
+        event_id = create_oauth_error_event("state_lost")
+        url = reverse("google_oauth_error_event_consume")
+
+        verified = self.client.post(url, {"event_id": event_id}, format="json")
+        replay = self.client.post(url, {"event_id": event_id}, format="json")
+
+        self.assertEqual(verified.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            verified.data["data"],
+            {"verified": True, "reason": "state_lost"},
+        )
+        self.assertEqual(verified["Cache-Control"], "no-store")
+        self.assertEqual(
+            replay.data["data"],
+            {"verified": False, "reason": "oauth_failed"},
+        )
+
+    def test_redirect_contains_only_an_opaque_event_id(self):
+        redirect_url = build_oauth_error_redirect(
+            "https://app.example.com/",
+            "no_email",
+        )
+        parsed = urlparse(redirect_url)
+        query = parse_qs(parsed.query)
+
+        self.assertEqual(parsed.path, "/auth/oauth/error")
+        self.assertNotIn("reason", query)
+        self.assertEqual(len(query["event_id"]), 1)
+        self.assertEqual(
+            consume_oauth_error_event(query["event_id"][0]),
+            "no_email",
+        )
+
+    @patch(
+        "apps.iam.services.oauth_error_events.create_oauth_error_event",
+        side_effect=RuntimeError("database unavailable"),
+    )
+    def test_redirect_falls_back_to_generic_page_when_storage_fails(self, _create):
+        self.assertEqual(
+            build_oauth_error_redirect(
+                "https://app.example.com/",
+                "account_disabled",
+            ),
+            "https://app.example.com/auth/oauth/error",
+        )
+
+
 @override_settings(
     GOOGLE_CLIENT_ID="test-client-id",
     GOOGLE_CLIENT_SECRET="test-client-secret",
@@ -84,6 +165,19 @@ class SocialRegistrationServiceTests(APITestCase):
 )
 @patch.dict("os.environ", {"HFL_GOOGLE_OAUTH_ENABLED": "true"})
 class GoogleOAuthCallbackTests(APITestCase):
+    def test_incomplete_oauth_redirects_with_a_consumable_event(self):
+        response = self.client.get(reverse("oauth_callback"))
+        parsed = urlparse(response["Location"])
+        query = parse_qs(parsed.query)
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(parsed.path, "/auth/oauth/error")
+        self.assertNotIn("reason", query)
+        self.assertEqual(
+            consume_oauth_error_event(query["event_id"][0]),
+            "not_authenticated",
+        )
+
     def test_oauth_callback_issues_cookies_and_redirects(self):
         user = User.objects.create_user(
             username="oauth-callback",

--- a/src/frontend/src/locales/en.ts
+++ b/src/frontend/src/locales/en.ts
@@ -3490,6 +3490,7 @@ export const en = {
     googleRedirecting: 'Redirecting…',
     googleLoginFailed: 'Google sign-in failed. Try again or select your work Google account.',
     googleErrorTitle: 'Google Sign-In Failed',
+    googleErrorChecking: 'Checking sign-in status…',
     googleErrorOAuthDisabled: 'Google sign-in is disabled by the administrator.',
     googleErrorNoEmail: 'Google did not return an email address. Select a work Google account with email enabled.',
     googleErrorDisabled: 'This account is disabled.',

--- a/src/frontend/src/pages/auth/OAuthError.vue
+++ b/src/frontend/src/pages/auth/OAuthError.vue
@@ -1,16 +1,19 @@
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
+import { api } from '../../lib/api'
 
 const { t } = useI18n()
 const route = useRoute()
 const router = useRouter()
 
-const reason = computed(() => String(route.query.reason || 'unknown'))
+const verifiedReason = ref('')
+const checking = ref(true)
 
 const message = computed(() => {
-  switch (reason.value) {
+  if (checking.value) return t('login.googleErrorChecking')
+  switch (verifiedReason.value) {
     case 'disabled':
       return t('login.googleErrorOAuthDisabled')
     case 'no_email':
@@ -33,13 +36,59 @@ const message = computed(() => {
 function backToLogin() {
   router.push('/login')
 }
+
+onMounted(async () => {
+  const eventId = typeof route.query.event_id === 'string'
+    ? route.query.event_id
+    : ''
+  const query = { ...route.query }
+  delete query.event_id
+  delete query.reason
+
+  if (Object.keys(query).length !== Object.keys(route.query).length) {
+    try {
+      await router.replace({
+        path: route.path,
+        query,
+        hash: route.hash,
+      })
+    } catch {
+      // URL cleanup failure must not prevent one-time event consumption.
+    }
+  }
+
+  if (!eventId) {
+    checking.value = false
+    return
+  }
+
+  try {
+    const response = await api<{
+      code: string
+      data?: {
+        verified?: boolean
+        reason?: string
+      }
+    }>('/api/v1/auth/google/error-events/consume', {
+      method: 'POST',
+      body: JSON.stringify({ event_id: eventId }),
+    })
+    if (response.code === '0000' && response.data?.verified === true) {
+      verifiedReason.value = response.data.reason || ''
+    }
+  } catch {
+    verifiedReason.value = ''
+  } finally {
+    checking.value = false
+  }
+})
 </script>
 
 <template>
   <div class="oauth-error">
     <div class="oauth-error-card">
       <h1>{{ t('login.googleErrorTitle') }}</h1>
-      <p>{{ message }}</p>
+      <p aria-live="polite">{{ message }}</p>
       <button type="button" class="back-btn" @click="backToLogin">
         {{ t('login.backToLogin') }}
       </button>

--- a/src/frontend/src/pages/auth/OAuthErrorSecurity.test.ts
+++ b/src/frontend/src/pages/auth/OAuthErrorSecurity.test.ts
@@ -1,0 +1,133 @@
+// @vitest-environment jsdom
+
+import { flushPromises, mount } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { en } from '../../locales/en'
+import OAuthError from './OAuthError.vue'
+
+const mocks = vi.hoisted(() => ({
+  api: vi.fn(),
+  route: {
+    path: '/auth/oauth/error',
+    hash: '',
+    query: {} as Record<string, string>,
+  },
+  routerPush: vi.fn(),
+  routerReplace: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('../../lib/api', () => ({ api: mocks.api }))
+
+vi.mock('vue-router', () => ({
+  useRoute: () => mocks.route,
+  useRouter: () => ({
+    push: mocks.routerPush,
+    replace: mocks.routerReplace,
+  }),
+}))
+
+async function mountOAuthError() {
+  const i18n = createI18n({
+    legacy: false,
+    locale: 'en',
+    messages: { en },
+  })
+  const wrapper = mount(OAuthError, {
+    global: {
+      plugins: [i18n],
+    },
+  })
+  await flushPromises()
+  return wrapper
+}
+
+describe('OAuth error event verification', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.route.path = '/auth/oauth/error'
+    mocks.route.hash = ''
+    mocks.route.query = {}
+    mocks.routerReplace.mockResolvedValue(undefined)
+  })
+
+  it('ignores and removes a forged legacy reason', async () => {
+    mocks.route.query = { reason: 'account_disabled' }
+
+    const wrapper = await mountOAuthError()
+
+    expect(mocks.api).not.toHaveBeenCalled()
+    expect(mocks.routerReplace).toHaveBeenCalledWith({
+      path: '/auth/oauth/error',
+      query: {},
+      hash: '',
+    })
+    expect(wrapper.get('p').text()).toBe(
+      'Google sign-in failed. Try again or select your work Google account.',
+    )
+  })
+
+  it('shows a verified backend event and removes its ID', async () => {
+    mocks.route.query = { event_id: 'verified-event' }
+    mocks.api.mockResolvedValue({
+      code: '0000',
+      data: {
+        verified: true,
+        reason: 'account_disabled',
+      },
+    })
+
+    const wrapper = await mountOAuthError()
+
+    expect(mocks.api).toHaveBeenCalledWith(
+      '/api/v1/auth/google/error-events/consume',
+      {
+        method: 'POST',
+        body: JSON.stringify({ event_id: 'verified-event' }),
+      },
+    )
+    expect(mocks.routerReplace).toHaveBeenCalledWith({
+      path: '/auth/oauth/error',
+      query: {},
+      hash: '',
+    })
+    expect(wrapper.get('p').text()).toBe('This account is disabled.')
+  })
+
+  it('shows only the generic message for unknown or replayed events', async () => {
+    mocks.route.query = { event_id: 'replayed-event' }
+    mocks.api.mockResolvedValue({
+      code: '0000',
+      data: {
+        verified: false,
+        reason: 'account_disabled',
+      },
+    })
+
+    const wrapper = await mountOAuthError()
+
+    expect(wrapper.get('p').text()).toBe(
+      'Google sign-in failed. Try again or select your work Google account.',
+    )
+  })
+
+  it('still consumes a verified event when URL cleanup fails', async () => {
+    mocks.route.query = { event_id: 'verified-event' }
+    mocks.routerReplace.mockRejectedValue(new Error('navigation failed'))
+    mocks.api.mockResolvedValue({
+      code: '0000',
+      data: {
+        verified: true,
+        reason: 'state_lost',
+      },
+    })
+
+    const wrapper = await mountOAuthError()
+
+    expect(mocks.api).toHaveBeenCalledOnce()
+    expect(wrapper.get('p').text()).toBe(
+      'Your sign-in session expired during the Google redirect. Please try again.',
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- issue hashed, short-lived IDs for trusted OAuth failures
- atomically consume each event once before showing a specific error
- remove forged URL reasons and fall back to a generic message

## Validation
- frontend: 86 test files / 383 tests passed
- frontend lint and production build passed
- IAM OAuth: 13 tests passed
- IAM migration check passed

Fixes #134