### PR TITLE
Fix login readiness and OAuth error contrast

### DIFF
--- a/src/frontend/src/pages/auth/Login.vue
+++ b/src/frontend/src/pages/auth/Login.vue
@@ -484,8 +484,14 @@ const cardTitle = computed(() => {
   return t('findPwd.welcomeTitle')
 })
 
+const credentialsValid = computed(() => (
+  checkMail(formItems.email.value) === '' &&
+  checkPassword(formItems.password.value) === ''
+))
+
 const canSubmitLogin = computed(() => {
   if (submitLoading.value) return false
+  if (!credentialsValid.value) return false
   if (isTurnstilePending.value) return false
   if (isTurnstileBlocked.value) return false
   if (isTurnstileReady.value) return Boolean(turnstileToken.value)

--- a/src/frontend/src/pages/auth/LoginTurnstileLifecycle.test.ts
+++ b/src/frontend/src/pages/auth/LoginTurnstileLifecycle.test.ts
@@ -196,6 +196,32 @@ describe('Login Turnstile lifecycle', () => {
     replayMount.unmount()
   })
 
+  it('requires valid credentials after Turnstile succeeds', async () => {
+    const wrapper = await mountLogin(1440)
+    const inputs = wrapper.findAll('input')
+    const turnstile = wrapper.getComponent(AuthTurnstileFieldStub)
+    const submit = wrapper.get('button.submit-btn')
+
+    turnstile.vm.$emit('success', 'verified-token')
+    await wrapper.vm.$nextTick()
+    expect(submit.attributes('disabled')).toBeDefined()
+    await submit.trigger('click')
+    await flushPromises()
+    expect(emailLoginCalls()).toHaveLength(0)
+
+    await inputs[0].setValue('person@example.com')
+    expect(submit.attributes('disabled')).toBeDefined()
+
+    await inputs[1].setValue('invalid')
+    expect(submit.attributes('disabled')).toBeDefined()
+
+    await inputs[1].setValue('ValidPass123')
+    expect(submit.attributes('disabled')).toBeUndefined()
+    expect(emailLoginCalls()).toHaveLength(0)
+
+    wrapper.unmount()
+  })
+
   it.each([
     ['mobile', 390],
     ['tablet', 820],

--- a/src/frontend/src/pages/auth/OAuthError.vue
+++ b/src/frontend/src/pages/auth/OAuthError.vue
@@ -117,6 +117,7 @@ onMounted(async () => {
 
 .oauth-error-card h1 {
   margin: 0 0 12px;
+  color: inherit;
   font-size: 20px;
 }
 

--- a/src/frontend/src/pages/auth/OAuthErrorSecurity.test.ts
+++ b/src/frontend/src/pages/auth/OAuthErrorSecurity.test.ts
@@ -1,5 +1,7 @@
 // @vitest-environment jsdom
 
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
 import { flushPromises, mount } from '@vue/test-utils'
 import { createI18n } from 'vue-i18n'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -128,6 +130,20 @@ describe('OAuth error event verification', () => {
     expect(mocks.api).toHaveBeenCalledOnce()
     expect(wrapper.get('p').text()).toBe(
       'Your sign-in session expired during the Google redirect. Please try again.',
+    )
+  })
+
+  it('keeps the heading readable on the dark error page', () => {
+    const source = readFileSync(
+      resolve(process.cwd(), 'src/pages/auth/OAuthError.vue'),
+      'utf8',
+    )
+
+    expect(source).toMatch(
+      /\.oauth-error\s*{[^}]*background:\s*#08090c;[^}]*color:\s*#fff;/s,
+    )
+    expect(source).toMatch(
+      /\.oauth-error-card h1\s*{[^}]*color:\s*inherit;/s,
     )
   })
 })


### PR DESCRIPTION
## Summary

- Require valid email and password values before enabling Sign In while preserving the Turnstile lifecycle
- Keep the OAuth error heading readable on its dark background
- Add regression coverage for credential gating and heading presentation

## Regression coverage

Preserves the fixes for #84, #86, #102, and #134.

## Testing

- `npm test -- src/pages/auth/LoginTurnstileLifecycle.test.ts src/pages/auth/AuthTurnstileRetryFlows.test.ts src/router/loginRouteSecurity.test.ts src/lib/sessionNotice.test.ts src/lib/loginNavigation.test.ts src/lib/apiSessionNotice.test.ts src/composables/useAuthSessionWatchdog.test.ts src/pages/auth/OAuthErrorSecurity.test.ts` (45 tests passed)
- `npm run build`