### PR TITLE
fix(admin): align list pagination with application views

### DIFF
--- a/src/frontend/src/platform-ops/components/PlatformOpsPagination.test.ts
+++ b/src/frontend/src/platform-ops/components/PlatformOpsPagination.test.ts
@@ -1,0 +1,68 @@
+// @vitest-environment jsdom
+
+import { defineComponent } from 'vue'
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import PlatformOpsPagination from './PlatformOpsPagination.vue'
+
+const HflPaginationStub = defineComponent({
+  name: 'HflPagination',
+  props: {
+    currentPage: { type: Number, required: true },
+    pageSize: { type: Number, required: true },
+    pageSizes: { type: Array, required: true },
+    total: { type: Number, required: true },
+    layout: { type: String, required: true },
+  },
+  emits: ['update:currentPage', 'update:pageSize'],
+  template: '<div class="pagination-stub" />',
+})
+
+function mountPagination(currentPage = 3) {
+  return mount(PlatformOpsPagination, {
+    props: {
+      currentPage,
+      pageSize: 20,
+      total: 120,
+    },
+    global: {
+      stubs: { HflPagination: HflPaginationStub },
+    },
+  })
+}
+
+describe('PlatformOpsPagination', () => {
+  it('applies the ordinary-user list pagination standard', () => {
+    const wrapper = mountPagination()
+    const pagination = wrapper.getComponent(HflPaginationStub)
+
+    expect(pagination.classes()).toContain('hfl-list-footer__pagination')
+    expect(pagination.props()).toMatchObject({
+      currentPage: 3,
+      pageSize: 20,
+      pageSizes: [20, 30, 50, 100],
+      total: 120,
+      layout: 'total, sizes, prev, pager, next',
+    })
+  })
+
+  it('returns to the first page before changing page size', async () => {
+    const wrapper = mountPagination()
+
+    wrapper.getComponent(HflPaginationStub).vm.$emit('update:pageSize', 50)
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.emitted('update:currentPage')).toEqual([[1]])
+    expect(wrapper.emitted('update:pageSize')).toEqual([[50]])
+  })
+
+  it('does not emit a redundant page update when already on the first page', async () => {
+    const wrapper = mountPagination(1)
+
+    wrapper.getComponent(HflPaginationStub).vm.$emit('update:pageSize', 30)
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.emitted('update:currentPage')).toBeUndefined()
+    expect(wrapper.emitted('update:pageSize')).toEqual([[30]])
+  })
+})

--- a/src/frontend/src/platform-ops/components/PlatformOpsPagination.vue
+++ b/src/frontend/src/platform-ops/components/PlatformOpsPagination.vue
@@ -1,0 +1,46 @@
+<script setup lang="ts">
+import HflPagination from '../../components/HflPagination.vue'
+
+defineOptions({
+  name: 'PlatformOpsPagination',
+  inheritAttrs: false,
+})
+
+const props = withDefaults(
+  defineProps<{
+    currentPage: number
+    pageSize: number
+    total: number
+    pageSizes?: number[]
+  }>(),
+  {
+    pageSizes: () => [20, 30, 50, 100],
+  },
+)
+
+const emit = defineEmits<{
+  'update:currentPage': [value: number]
+  'update:pageSize': [value: number]
+}>()
+
+function updatePageSize(value: number) {
+  if (props.currentPage !== 1) {
+    emit('update:currentPage', 1)
+  }
+  emit('update:pageSize', value)
+}
+</script>
+
+<template>
+  <HflPagination
+    v-bind="$attrs"
+    class="hfl-list-footer__pagination"
+    :current-page="currentPage"
+    :page-size="pageSize"
+    :page-sizes="pageSizes"
+    :total="total"
+    layout="total, sizes, prev, pager, next"
+    @update:current-page="emit('update:currentPage', $event)"
+    @update:page-size="updatePageSize"
+  />
+</template>

--- a/src/frontend/src/platform-ops/pages/alert-center/AlertPolicies.vue
+++ b/src/frontend/src/platform-ops/pages/alert-center/AlertPolicies.vue
@@ -3,9 +3,9 @@ import { onMounted, reactive, ref, watch } from 'vue'
 import { ElMessage } from 'element-plus'
 import { BellRing, CircleCheck, CircleOff, RefreshCw, Search, ShieldAlert } from 'lucide-vue-next'
 import ModulePage from '../../../components/ModulePage.vue'
-import HflPagination from '../../../components/HflPagination.vue'
 import HflTablePanel from '../../../components/HflTablePanel.vue'
 import OpsStatCard from '../../../components/ops/OpsStatCard.vue'
+import PlatformOpsPagination from '../../components/PlatformOpsPagination.vue'
 import { useDebouncedAction } from '../../../composables/useDebouncedAction'
 import { useResponsiveDrawerWidth } from '../../../composables/useResponsiveDrawerWidth'
 import { apiErrorMessage } from '../../../lib/api'
@@ -103,7 +103,7 @@ watch(() => [pagination.page, pagination.pageSize], load)
             <template #empty><el-empty description="No alert policies found" :image-size="72" /></template>
           </el-table>
         </template>
-        <template #footer><HflPagination v-model:current-page="pagination.page" v-model:page-size="pagination.pageSize" :total="pagination.count" /></template>
+        <template #footer><PlatformOpsPagination v-model:current-page="pagination.page" v-model:page-size="pagination.pageSize" :total="pagination.count" /></template>
       </HflTablePanel>
     </div>
     <el-drawer v-model="drawerOpen" :size="drawerSize" destroy-on-close>

--- a/src/frontend/src/platform-ops/pages/alert-center/NotificationChannels.vue
+++ b/src/frontend/src/platform-ops/pages/alert-center/NotificationChannels.vue
@@ -3,9 +3,9 @@ import { onMounted, reactive, ref, watch } from 'vue'
 import { ElMessage } from 'element-plus'
 import { BellRing, CircleCheck, CircleOff, RefreshCw, Search, Send } from 'lucide-vue-next'
 import ModulePage from '../../../components/ModulePage.vue'
-import HflPagination from '../../../components/HflPagination.vue'
 import HflTablePanel from '../../../components/HflTablePanel.vue'
 import OpsStatCard from '../../../components/ops/OpsStatCard.vue'
+import PlatformOpsPagination from '../../components/PlatformOpsPagination.vue'
 import { useDebouncedAction } from '../../../composables/useDebouncedAction'
 import { apiErrorMessage } from '../../../lib/api'
 import { formatLocalDateTime } from '../../../lib/dateTime'
@@ -71,7 +71,7 @@ watch(() => [pagination.page, pagination.pageSize], load)
           <el-table-column label="Updated" width="170"><template #default="{ row }">{{ formatLocalDateTime(row.updated_at, '—') }}</template></el-table-column>
           <template #empty><el-empty description="No notification channels found" :image-size="72" /></template>
         </el-table></template>
-        <template #footer><HflPagination v-model:current-page="pagination.page" v-model:page-size="pagination.pageSize" :total="pagination.count" /></template>
+        <template #footer><PlatformOpsPagination v-model:current-page="pagination.page" v-model:page-size="pagination.pageSize" :total="pagination.count" /></template>
       </HflTablePanel>
     </div>
   </ModulePage>

--- a/src/frontend/src/platform-ops/pages/audit/PlatformAuditLogs.vue
+++ b/src/frontend/src/platform-ops/pages/audit/PlatformAuditLogs.vue
@@ -3,9 +3,9 @@ import { onMounted, reactive, ref, watch } from 'vue'
 import { ElMessage } from 'element-plus'
 import { Activity, CheckCircle2, CircleX, Clock3, RefreshCw, Search } from 'lucide-vue-next'
 import ModulePage from '../../../components/ModulePage.vue'
-import HflPagination from '../../../components/HflPagination.vue'
 import HflTablePanel from '../../../components/HflTablePanel.vue'
 import OpsStatCard from '../../../components/ops/OpsStatCard.vue'
+import PlatformOpsPagination from '../../components/PlatformOpsPagination.vue'
 import { useDebouncedAction } from '../../../composables/useDebouncedAction'
 import { useResponsiveDrawerWidth } from '../../../composables/useResponsiveDrawerWidth'
 import { apiErrorMessage } from '../../../lib/api'
@@ -73,7 +73,7 @@ watch(() => [pagination.page, pagination.pageSize], load)
           <el-table-column label="Result" width="110"><template #default="{ row }"><PlatformOpsStatusPill :status="row.result" /></template></el-table-column>
           <template #empty><el-empty description="No audit events found" :image-size="72" /></template>
         </el-table></template>
-        <template #footer><HflPagination v-model:current-page="pagination.page" v-model:page-size="pagination.pageSize" :total="pagination.count" /></template>
+        <template #footer><PlatformOpsPagination v-model:current-page="pagination.page" v-model:page-size="pagination.pageSize" :total="pagination.count" /></template>
       </HflTablePanel>
     </div>
     <el-drawer v-model="drawerOpen" :size="drawerSize" destroy-on-close><template #header><div class="platform-monitoring-drawer__header"><h2>{{ selected?.action }}</h2><p>{{ selected?.actor_email || 'System' }} · {{ selected?.result }}</p></div></template><template v-if="selected"><section class="platform-monitoring-drawer__section"><h3>Audit Context</h3><div class="platform-monitoring-drawer__grid"><div class="platform-monitoring-drawer__field"><span>Time</span><strong>{{ formatLocalDateTime(selected.created_at, '—') }}</strong></div><div class="platform-monitoring-drawer__field"><span>IP Address</span><strong>{{ selected.ip_address || '—' }}</strong></div><div class="platform-monitoring-drawer__field"><span>Target</span><strong>{{ selected.target_type }} · {{ selected.target_id }}</strong></div><div class="platform-monitoring-drawer__field"><span>Account</span><strong>{{ selected.org_key || 'Platform' }}</strong></div></div></section><section class="platform-monitoring-drawer__section"><h3>Details</h3><pre class="platform-monitoring-drawer__message">{{ JSON.stringify(selected.details, null, 2) }}</pre></section></template></el-drawer>

--- a/src/frontend/src/platform-ops/pages/engine/PlatformUsage.vue
+++ b/src/frontend/src/platform-ops/pages/engine/PlatformUsage.vue
@@ -15,9 +15,9 @@ import {
   RefreshCw,
   Search,
 } from 'lucide-vue-next'
-import HflPagination from '../../../components/HflPagination.vue'
 import OpsStatCard from '../../../components/ops/OpsStatCard.vue'
 import { useResponsiveDrawerWidth } from '../../../composables/useResponsiveDrawerWidth'
+import PlatformOpsPagination from '../../components/PlatformOpsPagination.vue'
 import { apiErrorMessage } from '../../../lib/api'
 import { formatLocalDateTime } from '../../../lib/dateTime'
 import PlatformOpsOrgLink from '../../components/PlatformOpsOrgLink.vue'
@@ -266,8 +266,7 @@ watch(() => filters.search, () => {
     reloadFromFirstPage()
   }, 320)
 })
-watch(() => pagination.page, () => void load())
-watch(() => pagination.pageSize, () => reloadFromFirstPage())
+watch(() => [pagination.page, pagination.pageSize], () => void load())
 
 onMounted(() => {
   const values = presetRange('today')
@@ -366,7 +365,7 @@ onBeforeUnmount(() => {
         <el-table-column label="Cost" width="120"><template #default="{ row }">{{ formatCost(row.estimated_cost, row.cost_currency) }}</template></el-table-column>
         <template #empty><el-empty description="No AI requests match the current filters" :image-size="68" /></template>
       </el-table>
-      <div class="platform-ai-usage__pagination"><HflPagination v-model:current-page="pagination.page" v-model:page-size="pagination.pageSize" :total="pagination.count" /></div>
+      <div class="hfl-list-footer"><PlatformOpsPagination v-model:current-page="pagination.page" v-model:page-size="pagination.pageSize" :total="pagination.count" /></div>
     </section>
 
     <el-drawer v-model="drawerOpen" :size="drawerSize" destroy-on-close>
@@ -404,7 +403,6 @@ onBeforeUnmount(() => {
 .platform-ai-usage__account-button:hover,.platform-ai-usage__request-button:hover { color: var(--color-primary, #6d5ef6); text-decoration: underline; text-underline-offset: 3px; }
 .platform-ai-usage__cell-meta { display: block; margin-top: 2px; overflow: hidden; color: var(--color-text-secondary, #70707e); font-size: 11px; text-overflow: ellipsis; white-space: nowrap; }
 .platform-ai-usage .is-attention { color: var(--color-warning, #e08b0b); font-weight: 600; }
-.platform-ai-usage__pagination { padding: 10px 16px; border-top: 1px solid var(--color-border-light, #f2f2f6); }
 @media (max-width: 1500px) { .platform-ai-usage__stats { grid-template-columns: repeat(3, minmax(0, 1fr)); } }
 @media (max-width: 1100px) { .platform-ai-usage__lead { flex-direction: column; } .platform-ai-usage__period { width: 100%; flex-wrap: wrap; } .platform-ai-usage__analysis-grid { grid-template-columns: 1fr; } }
 @media (max-width: 760px) { .platform-ai-usage__stats { grid-template-columns: 1fr; } .platform-ai-usage__period,.platform-ai-usage__segments { width: 100%; } .platform-ai-usage__segments button { flex: 1; padding-inline: 4px; } .platform-ai-usage__period :deep(.el-date-editor) { width: calc(100% - 44px); } .platform-ai-usage__filters { grid-template-columns: 1fr; } .platform-ai-usage__panel { overflow-x: auto; } }

--- a/src/frontend/src/platform-ops/pages/monitoring/MonitoringDeliveries.vue
+++ b/src/frontend/src/platform-ops/pages/monitoring/MonitoringDeliveries.vue
@@ -6,9 +6,9 @@ import { ElMessage } from 'element-plus'
 import { CheckCircle2, CircleX, Clock3, RefreshCw, Search, Send } from 'lucide-vue-next'
 import DangerConfirmDialog from '../../../components/DangerConfirmDialog.vue'
 import ModulePage from '../../../components/ModulePage.vue'
-import HflPagination from '../../../components/HflPagination.vue'
 import HflTablePanel from '../../../components/HflTablePanel.vue'
 import OpsStatCard from '../../../components/ops/OpsStatCard.vue'
+import PlatformOpsPagination from '../../components/PlatformOpsPagination.vue'
 import { useDebouncedAction } from '../../../composables/useDebouncedAction'
 import { useResponsiveDrawerWidth } from '../../../composables/useResponsiveDrawerWidth'
 import { apiErrorMessage } from '../../../lib/api'
@@ -330,7 +330,7 @@ watch(() => [pagination.page, pagination.pageSize], load)
           </el-table>
         </template>
         <template #footer>
-          <HflPagination
+          <PlatformOpsPagination
             v-model:current-page="pagination.page"
             v-model:page-size="pagination.pageSize"
             :total="pagination.count"

--- a/src/frontend/src/platform-ops/pages/monitoring/MonitoringIncidents.vue
+++ b/src/frontend/src/platform-ops/pages/monitoring/MonitoringIncidents.vue
@@ -6,9 +6,9 @@ import { ElMessage } from 'element-plus'
 import { AlertTriangle, CheckCircle2, CircleAlert, RefreshCw, Search, ShieldCheck } from 'lucide-vue-next'
 import DangerConfirmDialog, { type DangerConfirmItem } from '../../../components/DangerConfirmDialog.vue'
 import ModulePage from '../../../components/ModulePage.vue'
-import HflPagination from '../../../components/HflPagination.vue'
 import HflTablePanel from '../../../components/HflTablePanel.vue'
 import OpsStatCard from '../../../components/ops/OpsStatCard.vue'
+import PlatformOpsPagination from '../../components/PlatformOpsPagination.vue'
 import { useDebouncedAction } from '../../../composables/useDebouncedAction'
 import { useResponsiveDrawerWidth } from '../../../composables/useResponsiveDrawerWidth'
 import { apiErrorMessage } from '../../../lib/api'
@@ -400,7 +400,7 @@ watch(() => [pagination.page, pagination.pageSize], load)
           </el-table>
         </template>
         <template #footer>
-          <HflPagination
+          <PlatformOpsPagination
             v-model:current-page="pagination.page"
             v-model:page-size="pagination.pageSize"
             :total="pagination.count"

--- a/src/frontend/src/platform-ops/pages/monitoring/MonitoringLogs.vue
+++ b/src/frontend/src/platform-ops/pages/monitoring/MonitoringLogs.vue
@@ -3,9 +3,9 @@ import { onMounted, reactive, ref, watch } from 'vue'
 import { ElMessage } from 'element-plus'
 import { AlertTriangle, CircleX, Layers3, RefreshCw, ScrollText, Search } from 'lucide-vue-next'
 import ModulePage from '../../../components/ModulePage.vue'
-import HflPagination from '../../../components/HflPagination.vue'
 import HflTablePanel from '../../../components/HflTablePanel.vue'
 import OpsStatCard from '../../../components/ops/OpsStatCard.vue'
+import PlatformOpsPagination from '../../components/PlatformOpsPagination.vue'
 import { useDebouncedAction } from '../../../composables/useDebouncedAction'
 import { useResponsiveDrawerWidth } from '../../../composables/useResponsiveDrawerWidth'
 import { apiErrorMessage } from '../../../lib/api'
@@ -72,7 +72,7 @@ watch(() => [pagination.page, pagination.pageSize], load)
           <el-table-column label="Message" min-width="420"><template #default="{ row }"><button type="button" class="platform-monitoring-page__title-button platform-log-table__message" @click="openDrawer(row)">{{ row.message }}</button></template></el-table-column>
           <template #empty><el-empty description="No log events found" :image-size="72" /></template>
         </el-table></template>
-        <template #footer><HflPagination v-model:current-page="pagination.page" v-model:page-size="pagination.pageSize" :total="pagination.count" /></template>
+        <template #footer><PlatformOpsPagination v-model:current-page="pagination.page" v-model:page-size="pagination.pageSize" :total="pagination.count" /></template>
       </HflTablePanel>
     </div>
     <el-drawer v-model="drawerOpen" :size="drawerSize" destroy-on-close><template #header><div class="platform-monitoring-drawer__header"><h2>Log Event</h2><p>{{ selected?.service }} · {{ selected?.level }}</p></div></template><template v-if="selected"><section class="platform-monitoring-drawer__section"><h3>Event Details</h3><div class="platform-monitoring-drawer__grid"><div class="platform-monitoring-drawer__field"><span>Time</span><strong>{{ selected.timestamp || '—' }}</strong></div><div class="platform-monitoring-drawer__field"><span>Service</span><strong>{{ selected.service }}</strong></div></div></section><section class="platform-monitoring-drawer__section"><h3>Message</h3><pre class="platform-monitoring-drawer__message">{{ selected.message }}</pre></section></template></el-drawer>

--- a/src/frontend/src/platform-ops/pages/monitoring/MonitoringNodes.vue
+++ b/src/frontend/src/platform-ops/pages/monitoring/MonitoringNodes.vue
@@ -5,9 +5,9 @@ import { useI18n } from 'vue-i18n'
 import { ElMessage } from 'element-plus'
 import { CircleCheck, CircleX, RefreshCw, Search, Server, ShieldAlert } from 'lucide-vue-next'
 import ModulePage from '../../../components/ModulePage.vue'
-import HflPagination from '../../../components/HflPagination.vue'
 import HflTablePanel from '../../../components/HflTablePanel.vue'
 import OpsStatCard from '../../../components/ops/OpsStatCard.vue'
+import PlatformOpsPagination from '../../components/PlatformOpsPagination.vue'
 import { useDebouncedAction } from '../../../composables/useDebouncedAction'
 import { useResponsiveDrawerWidth } from '../../../composables/useResponsiveDrawerWidth'
 import { apiErrorMessage } from '../../../lib/api'
@@ -297,7 +297,7 @@ watch(() => [pagination.page, pagination.pageSize], load)
           </el-table>
         </template>
         <template #footer>
-          <HflPagination
+          <PlatformOpsPagination
             v-model:current-page="pagination.page"
             v-model:page-size="pagination.pageSize"
             :total="pagination.count"

--- a/src/frontend/src/platform-ops/pages/monitoring/MonitoringTasks.vue
+++ b/src/frontend/src/platform-ops/pages/monitoring/MonitoringTasks.vue
@@ -6,9 +6,9 @@ import { ElMessage } from 'element-plus'
 import { Activity, CircleCheck, CircleX, Clock3, RefreshCw, Search } from 'lucide-vue-next'
 import DangerConfirmDialog, { type DangerConfirmItem } from '../../../components/DangerConfirmDialog.vue'
 import ModulePage from '../../../components/ModulePage.vue'
-import HflPagination from '../../../components/HflPagination.vue'
 import HflTablePanel from '../../../components/HflTablePanel.vue'
 import OpsStatCard from '../../../components/ops/OpsStatCard.vue'
+import PlatformOpsPagination from '../../components/PlatformOpsPagination.vue'
 import TaskTypeLabel from '../../../components/TaskTypeLabel.vue'
 import { useDebouncedAction } from '../../../composables/useDebouncedAction'
 import { useResponsiveDrawerWidth } from '../../../composables/useResponsiveDrawerWidth'
@@ -374,7 +374,7 @@ watch(() => [pagination.page, pagination.pageSize], load)
           </el-table>
         </template>
         <template #footer>
-          <HflPagination
+          <PlatformOpsPagination
             v-model:current-page="pagination.page"
             v-model:page-size="pagination.pageSize"
             :total="pagination.count"

--- a/src/frontend/src/platform-ops/pages/orgs/OrgList.vue
+++ b/src/frontend/src/platform-ops/pages/orgs/OrgList.vue
@@ -12,10 +12,10 @@ import {
   Search,
   Server,
 } from 'lucide-vue-next'
-import HflPagination from '../../../components/HflPagination.vue'
 import HflTablePanel from '../../../components/HflTablePanel.vue'
 import DangerConfirmDialog from '../../../components/DangerConfirmDialog.vue'
 import ModulePage from '../../../components/ModulePage.vue'
+import PlatformOpsPagination from '../../components/PlatformOpsPagination.vue'
 import OpsStatCard from '../../../components/ops/OpsStatCard.vue'
 import { useDebouncedAction } from '../../../composables/useDebouncedAction'
 import { apiErrorMessage } from '../../../lib/api'
@@ -295,7 +295,7 @@ watch(() => [pagination.page, pagination.pageSize], load)
           </el-table>
         </template>
         <template #footer>
-          <HflPagination
+          <PlatformOpsPagination
             v-model:current-page="pagination.page"
             v-model:page-size="pagination.pageSize"
             :total="pagination.count"

--- a/src/frontend/src/platform-ops/pages/platform/PlatformAgentReleases.vue
+++ b/src/frontend/src/platform-ops/pages/platform/PlatformAgentReleases.vue
@@ -4,8 +4,8 @@ import { useI18n } from 'vue-i18n'
 import { ElMessage } from 'element-plus'
 import { RefreshCw } from 'lucide-vue-next'
 import ModulePage from '../../../components/ModulePage.vue'
-import HflPagination from '../../../components/HflPagination.vue'
 import { usePlatformOpsSideNav } from '../../composables/usePlatformOpsSideNav'
+import PlatformOpsPagination from '../../components/PlatformOpsPagination.vue'
 import { fetchAgentReleases } from '../../lib/platformOpsApi'
 import { PLATFORM_OPS_LIST_TABLE_MAX_HEIGHT, PLATFORM_OPS_TABLE_HEADER_STYLE } from '../../lib/tableUi'
 import { apiErrorMessage } from '../../../lib/api'
@@ -155,10 +155,9 @@ watch([currentPage, pageSize], load)
         </el-table>
 
         <div class="hfl-list-footer">
-          <HflPagination
+          <PlatformOpsPagination
             v-model:current-page="currentPage"
             v-model:page-size="pageSize"
-            class="hfl-list-footer__pagination"
             :total="totalCount"
           />
         </div>

--- a/src/frontend/src/platform-ops/pages/users/UserList.vue
+++ b/src/frontend/src/platform-ops/pages/users/UserList.vue
@@ -14,10 +14,10 @@ import {
   UserX,
   Users,
 } from 'lucide-vue-next'
-import HflPagination from '../../../components/HflPagination.vue'
 import HflTablePanel from '../../../components/HflTablePanel.vue'
 import HflTypeLabel from '../../../components/HflTypeLabel.vue'
 import DangerConfirmDialog from '../../../components/DangerConfirmDialog.vue'
+import PlatformOpsPagination from '../../components/PlatformOpsPagination.vue'
 import ModulePage from '../../../components/ModulePage.vue'
 import OpsStatCard from '../../../components/ops/OpsStatCard.vue'
 import { useDebouncedAction } from '../../../composables/useDebouncedAction'
@@ -413,7 +413,7 @@ watch(() => [pagination.page, pagination.pageSize], load)
           </el-table>
         </template>
         <template #footer>
-          <HflPagination
+          <PlatformOpsPagination
             v-model:current-page="pagination.page"
             v-model:page-size="pagination.pageSize"
             :total="pagination.count"


### PR DESCRIPTION
Align all Admin Console list pagination with the ordinary application views, standardize responsive behavior and page-size options, reset to page one after size changes, and add focused component coverage. Validation: component tests, vue-tsc, ESLint, production build, and browser checks at 375, 768, 1280, and 1920 pixels.