### PR TITLE
test(auth): replace CJK login fixture with ASCII data

### DIFF
--- a/src/frontend/src/pages/auth/LoginTurnstileLifecycle.test.ts
+++ b/src/frontend/src/pages/auth/LoginTurnstileLifecycle.test.ts
@@ -222,7 +222,7 @@ describe('Login Turnstile lifecycle', () => {
   it.each([
     ['short legacy password', 'legacy'],
     ['password longer than twenty characters', 'This-password-is-longer-than-twenty-characters'],
-    ['Unicode password', '历史密码-正确'],
+    ['password with spaces and symbols', 'Legacy password ! accepted'],
   ])('submits a %s without applying password-creation rules', async (_name, password) => {
     const wrapper = await mountLogin(1440)
     const inputs = wrapper.findAll('input')


### PR DESCRIPTION
## Summary

- replace the CJK login password fixture with an ASCII-only legacy password containing spaces and a symbol
- preserve coverage that login accepts non-empty legacy passwords without applying password-creation rules
- restore the English-only source release contract

## Validation

- `python3 tools/quality/check-english-source.py`
- `npm run test:ci -- src/pages/auth/LoginTurnstileLifecycle.test.ts` (11 tests passed)
- `git diff --check`

## Pipeline context

Unblocks failed TEST run #30258809009, which stopped before build and deployment.