### PR TITLE
Fix authoritative host IP reporting for multi-interface agents

### DIFF
--- a/src/agent/internal/platform/networkinventory/inventory.go
+++ b/src/agent/internal/platform/networkinventory/inventory.go
@@ -1,0 +1,418 @@
+// Package networkinventory collects a compact, bounded snapshot of host network interfaces.
+package networkinventory
+
+import (
+	"context"
+	"net"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	SchemaVersion         = 1
+	MaxInterfaces         = 16
+	MaxAddressesPerNIC    = 8
+	MaxAddressesPerHost   = 32
+	routeProbeTimeout     = 2 * time.Second
+	SourceRouteToControl  = "route_to_control_plane"
+	SourceInterfaceBackup = "interface_fallback"
+)
+
+// Address is one usable unicast address assigned to an interface.
+type Address struct {
+	Address      string `json:"address"`
+	Family       string `json:"family"`
+	PrefixLength int    `json:"prefix_length"`
+}
+
+// Interface is the compact current state required for host-address selection and future display.
+type Interface struct {
+	ID           string    `json:"id"`
+	Name         string    `json:"name"`
+	MACAddress   string    `json:"mac_address,omitempty"`
+	Type         string    `json:"type"`
+	Virtual      bool      `json:"virtual"`
+	DefaultRoute bool      `json:"default_route"`
+	Addresses    []Address `json:"addresses"`
+}
+
+// Selection explains the single host address exposed by the current UI.
+type Selection struct {
+	Address     string `json:"address"`
+	Family      string `json:"family"`
+	InterfaceID string `json:"interface_id"`
+	Source      string `json:"source"`
+}
+
+// Snapshot is a bounded current network inventory. It intentionally contains no counters or history.
+type Snapshot struct {
+	SchemaVersion int         `json:"schema_version"`
+	CollectedAt   string      `json:"collected_at"`
+	Selection     Selection   `json:"selection"`
+	Interfaces    []Interface `json:"interfaces"`
+}
+
+type interfaceInfo struct {
+	index      int
+	name       string
+	macAddress string
+	virtual    bool
+	kind       string
+	noise      bool
+	selected   bool
+	addresses  []Address
+}
+
+// Collect returns a normalized, bounded snapshot. Failures are best-effort and yield an empty snapshot.
+func Collect(ctx context.Context, controlPlaneURL string) Snapshot {
+	return CollectWithPreferredAddress(ctx, controlPlaneURL, "")
+}
+
+// CollectWithPreferredAddress uses an active control connection's local address when available.
+func CollectWithPreferredAddress(
+	ctx context.Context,
+	controlPlaneURL string,
+	preferredAddress string,
+) Snapshot {
+	infos := collectInterfaces()
+	routeIP := net.ParseIP(strings.TrimSpace(preferredAddress))
+	if !usableIP(routeIP) {
+		routeIP = routeAddress(ctx, controlPlaneURL)
+	}
+	return buildSnapshot(infos, routeIP, time.Now().UTC())
+}
+
+// PrimaryAddress returns the selected host address.
+func (s Snapshot) PrimaryAddress() string { return strings.TrimSpace(s.Selection.Address) }
+
+// PrimaryMACAddress returns the MAC belonging to the selected address's interface.
+func (s Snapshot) PrimaryMACAddress() string {
+	for _, iface := range s.Interfaces {
+		if iface.ID == s.Selection.InterfaceID {
+			return iface.MACAddress
+		}
+	}
+	return ""
+}
+
+// IPAddresses returns the bounded, de-duplicated usable address list with the primary first.
+func (s Snapshot) IPAddresses() []string {
+	seen := map[string]bool{}
+	out := make([]string, 0, MaxAddressesPerHost)
+	appendAddress := func(value string) {
+		value = strings.TrimSpace(value)
+		if value == "" || seen[value] || len(out) >= MaxAddressesPerHost {
+			return
+		}
+		seen[value] = true
+		out = append(out, value)
+	}
+	appendAddress(s.PrimaryAddress())
+	for _, iface := range s.Interfaces {
+		for _, addr := range iface.Addresses {
+			appendAddress(addr.Address)
+		}
+	}
+	return out
+}
+
+func collectInterfaces() []interfaceInfo {
+	interfaces, err := net.Interfaces()
+	if err != nil {
+		return nil
+	}
+	out := make([]interfaceInfo, 0, len(interfaces))
+	for _, iface := range interfaces {
+		if iface.Flags&net.FlagUp == 0 || iface.Flags&net.FlagLoopback != 0 {
+			continue
+		}
+		addrs, err := iface.Addrs()
+		if err != nil {
+			continue
+		}
+		addresses := normalizeAddresses(addrs)
+		if len(addresses) == 0 {
+			continue
+		}
+		kind, virtual, noise := classifyInterface(iface.Name)
+		out = append(out, interfaceInfo{
+			index:      iface.Index,
+			name:       strings.TrimSpace(iface.Name),
+			macAddress: normalizeMAC(iface.HardwareAddr),
+			virtual:    virtual,
+			kind:       kind,
+			noise:      noise,
+			addresses:  addresses,
+		})
+	}
+	return out
+}
+
+func normalizeAddresses(addrs []net.Addr) []Address {
+	seen := map[string]bool{}
+	out := make([]Address, 0, len(addrs))
+	for _, raw := range addrs {
+		ip, prefix := addressParts(raw)
+		if !usableIP(ip) {
+			continue
+		}
+		value := ip.String()
+		if seen[value] {
+			continue
+		}
+		seen[value] = true
+		family := "ipv6"
+		if ip.To4() != nil {
+			family = "ipv4"
+		}
+		out = append(out, Address{Address: value, Family: family, PrefixLength: prefix})
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Family != out[j].Family {
+			return out[i].Family == "ipv4"
+		}
+		return out[i].Address < out[j].Address
+	})
+	return out
+}
+
+func addressParts(addr net.Addr) (net.IP, int) {
+	switch value := addr.(type) {
+	case *net.IPNet:
+		prefix, _ := value.Mask.Size()
+		return value.IP, prefix
+	case *net.IPAddr:
+		return value.IP, 0
+	default:
+		host := strings.TrimSpace(strings.Split(addr.String(), "/")[0])
+		return net.ParseIP(host), 0
+	}
+}
+
+func usableIP(ip net.IP) bool {
+	return ip != nil &&
+		!ip.IsLoopback() &&
+		!ip.IsLinkLocalUnicast() &&
+		!ip.IsMulticast() &&
+		!ip.IsUnspecified()
+}
+
+func buildSnapshot(infos []interfaceInfo, routeIP net.IP, collectedAt time.Time) Snapshot {
+	routeValue := ""
+	if usableIP(routeIP) {
+		routeValue = routeIP.String()
+	}
+	selectedInfo := -1
+	selectedAddress := ""
+	selectionSource := SourceInterfaceBackup
+	for i := range infos {
+		for _, addr := range infos[i].addresses {
+			if routeValue != "" && addr.Address == routeValue {
+				selectedInfo = i
+				selectedAddress = addr.Address
+				selectionSource = SourceRouteToControl
+				break
+			}
+		}
+		if selectedInfo >= 0 {
+			break
+		}
+	}
+	if selectedInfo >= 0 {
+		infos[selectedInfo].selected = true
+	}
+
+	sort.SliceStable(infos, func(i, j int) bool {
+		leftSelected := infos[i].selected
+		rightSelected := infos[j].selected
+		if leftSelected != rightSelected {
+			return leftSelected
+		}
+		leftRank := interfaceRank(infos[i])
+		rightRank := interfaceRank(infos[j])
+		if leftRank != rightRank {
+			return leftRank < rightRank
+		}
+		if infos[i].name != infos[j].name {
+			return infos[i].name < infos[j].name
+		}
+		return infos[i].index < infos[j].index
+	})
+
+	interfaces := make([]Interface, 0, MaxInterfaces)
+	totalAddresses := 0
+	selectedID := ""
+	for _, info := range infos {
+		isSelected := info.selected
+		if info.noise && !isSelected {
+			continue
+		}
+		if len(interfaces) >= MaxInterfaces || totalAddresses >= MaxAddressesPerHost {
+			break
+		}
+		addresses := append([]Address(nil), info.addresses...)
+		if isSelected {
+			addresses = primaryFirst(addresses, selectedAddress)
+		}
+		if len(addresses) > MaxAddressesPerNIC {
+			addresses = addresses[:MaxAddressesPerNIC]
+		}
+		remaining := MaxAddressesPerHost - totalAddresses
+		if len(addresses) > remaining {
+			addresses = addresses[:remaining]
+		}
+		iface := Interface{
+			ID:           interfaceID(info),
+			Name:         info.name,
+			MACAddress:   info.macAddress,
+			Type:         info.kind,
+			Virtual:      info.virtual,
+			DefaultRoute: isSelected && selectionSource == SourceRouteToControl,
+			Addresses:    addresses,
+		}
+		if isSelected {
+			selectedID = iface.ID
+		}
+		interfaces = append(interfaces, iface)
+		totalAddresses += len(addresses)
+	}
+
+	if selectedAddress == "" && len(interfaces) > 0 && len(interfaces[0].Addresses) > 0 {
+		selectedAddress = interfaces[0].Addresses[0].Address
+		selectedID = interfaces[0].ID
+	}
+	selectionFamily := ""
+	if ip := net.ParseIP(selectedAddress); ip != nil {
+		selectionFamily = "ipv6"
+		if ip.To4() != nil {
+			selectionFamily = "ipv4"
+		}
+	}
+	return Snapshot{
+		SchemaVersion: SchemaVersion,
+		CollectedAt:   collectedAt.UTC().Format(time.RFC3339),
+		Selection: Selection{
+			Address:     selectedAddress,
+			Family:      selectionFamily,
+			InterfaceID: selectedID,
+			Source:      selectionSource,
+		},
+		Interfaces: interfaces,
+	}
+}
+
+func interfaceRank(info interfaceInfo) int {
+	if info.noise {
+		return 4
+	}
+	if !info.virtual {
+		return 0
+	}
+	if info.kind == "vpn" {
+		return 1
+	}
+	return 2
+}
+
+func primaryFirst(addresses []Address, primary string) []Address {
+	out := make([]Address, 0, len(addresses))
+	for _, addr := range addresses {
+		if addr.Address == primary {
+			out = append(out, addr)
+			break
+		}
+	}
+	for _, addr := range addresses {
+		if addr.Address != primary {
+			out = append(out, addr)
+		}
+	}
+	return out
+}
+
+func interfaceID(info interfaceInfo) string {
+	if info.macAddress != "" {
+		return "mac:" + info.macAddress
+	}
+	return "if:" + strconv.Itoa(info.index) + ":" + strings.ToLower(info.name)
+}
+
+func normalizeMAC(hw net.HardwareAddr) string {
+	if len(hw) == 0 {
+		return ""
+	}
+	value := strings.ToLower(hw.String())
+	if value == "00:00:00:00:00:00" {
+		return ""
+	}
+	return value
+}
+
+func classifyInterface(raw string) (kind string, virtual bool, noise bool) {
+	name := strings.ToLower(strings.TrimSpace(raw))
+	switch {
+	case strings.HasPrefix(name, "tun"), strings.HasPrefix(name, "tap"),
+		strings.HasPrefix(name, "wg"), strings.HasPrefix(name, "utun"),
+		strings.Contains(name, "vpn"):
+		return "vpn", true, false
+	case strings.HasPrefix(name, "docker"), strings.HasPrefix(name, "veth"),
+		strings.HasPrefix(name, "br-"), strings.HasPrefix(name, "virbr"),
+		strings.HasPrefix(name, "cni"), strings.HasPrefix(name, "flannel"),
+		strings.Contains(name, "vethernet (wsl"):
+		return "virtual", true, true
+	case strings.HasPrefix(name, "vmnet"), strings.HasPrefix(name, "vboxnet"),
+		strings.HasPrefix(name, "vethernet"), strings.Contains(name, "hyper-v"),
+		strings.HasPrefix(name, "bridge"):
+		return "virtual", true, false
+	case strings.HasPrefix(name, "wl"), strings.Contains(name, "wi-fi"), strings.Contains(name, "wifi"):
+		return "wifi", false, false
+	case strings.HasPrefix(name, "eth"), strings.HasPrefix(name, "en"), strings.Contains(name, "ethernet"):
+		return "ethernet", false, false
+	default:
+		return "unknown", false, false
+	}
+}
+
+func routeAddress(ctx context.Context, controlPlaneURL string) net.IP {
+	u, err := url.Parse(strings.TrimSpace(controlPlaneURL))
+	if err != nil || u.Hostname() == "" {
+		return nil
+	}
+	port := u.Port()
+	if port == "" {
+		if strings.EqualFold(u.Scheme, "http") || strings.EqualFold(u.Scheme, "ws") {
+			port = "80"
+		} else {
+			port = "443"
+		}
+	}
+	lookupCtx, cancel := context.WithTimeout(ctx, routeProbeTimeout)
+	defer cancel()
+	resolved, err := net.DefaultResolver.LookupIPAddr(lookupCtx, u.Hostname())
+	if err != nil {
+		return nil
+	}
+	for _, candidate := range resolved {
+		if !usableIP(candidate.IP) && !candidate.IP.IsLoopback() {
+			continue
+		}
+		network := "udp6"
+		if candidate.IP.To4() != nil {
+			network = "udp4"
+		}
+		dialer := net.Dialer{Timeout: routeProbeTimeout}
+		conn, err := dialer.DialContext(lookupCtx, network, net.JoinHostPort(candidate.IP.String(), port))
+		if err != nil {
+			continue
+		}
+		local := conn.LocalAddr()
+		_ = conn.Close()
+		if udp, ok := local.(*net.UDPAddr); ok {
+			return udp.IP
+		}
+	}
+	return nil
+}

--- a/src/agent/internal/platform/networkinventory/inventory_test.go
+++ b/src/agent/internal/platform/networkinventory/inventory_test.go
@@ -1,0 +1,127 @@
+package networkinventory
+
+import (
+	"net"
+	"testing"
+	"time"
+)
+
+func TestBuildSnapshotSelectsRouteAddressAndMatchingMAC(t *testing.T) {
+	infos := []interfaceInfo{
+		{
+			index:      2,
+			name:       "Ethernet 1",
+			macAddress: "00:11:22:33:44:66",
+			kind:       "ethernet",
+			addresses:  []Address{{Address: "10.20.2.15", Family: "ipv4", PrefixLength: 24}},
+		},
+		{
+			index:      1,
+			name:       "Ethernet 0",
+			macAddress: "00:11:22:33:44:55",
+			kind:       "ethernet",
+			addresses:  []Address{{Address: "10.20.1.15", Family: "ipv4", PrefixLength: 24}},
+		},
+	}
+
+	snapshot := buildSnapshot(infos, net.ParseIP("10.20.1.15"), time.Unix(0, 0))
+	if got := snapshot.PrimaryAddress(); got != "10.20.1.15" {
+		t.Fatalf("PrimaryAddress()=%q", got)
+	}
+	if got := snapshot.PrimaryMACAddress(); got != "00:11:22:33:44:55" {
+		t.Fatalf("PrimaryMACAddress()=%q", got)
+	}
+	if got := snapshot.Selection.Source; got != SourceRouteToControl {
+		t.Fatalf("Selection.Source=%q", got)
+	}
+}
+
+func TestBuildSnapshotKeepsSelectedNoisyVirtualInterface(t *testing.T) {
+	infos := []interfaceInfo{
+		{
+			index:     9,
+			name:      "vEthernet (WSL)",
+			kind:      "virtual",
+			virtual:   true,
+			noise:     true,
+			addresses: []Address{{Address: "172.28.16.1", Family: "ipv4", PrefixLength: 20}},
+		},
+	}
+	snapshot := buildSnapshot(infos, net.ParseIP("172.28.16.1"), time.Unix(0, 0))
+	if len(snapshot.Interfaces) != 1 || snapshot.PrimaryAddress() != "172.28.16.1" {
+		t.Fatalf("unexpected snapshot: %+v", snapshot)
+	}
+}
+
+func TestBuildSnapshotKeepsRouteAddressBeyondPerInterfaceLimit(t *testing.T) {
+	addresses := make([]Address, 0, MaxAddressesPerNIC+1)
+	for index := 1; index <= MaxAddressesPerNIC; index++ {
+		addresses = append(addresses, Address{
+			Address:      net.IPv4(10, 20, 1, byte(index)).String(),
+			Family:       "ipv4",
+			PrefixLength: 24,
+		})
+	}
+	addresses = append(addresses, Address{
+		Address:      "10.20.1.250",
+		Family:       "ipv4",
+		PrefixLength: 24,
+	})
+	snapshot := buildSnapshot([]interfaceInfo{{
+		index:      1,
+		name:       "Ethernet 0",
+		macAddress: "00:11:22:33:44:55",
+		kind:       "ethernet",
+		addresses:  addresses,
+	}}, net.ParseIP("10.20.1.250"), time.Unix(0, 0))
+
+	if snapshot.PrimaryAddress() != "10.20.1.250" {
+		t.Fatalf("PrimaryAddress()=%q", snapshot.PrimaryAddress())
+	}
+	if len(snapshot.Interfaces[0].Addresses) != MaxAddressesPerNIC {
+		t.Fatalf("addresses=%d", len(snapshot.Interfaces[0].Addresses))
+	}
+}
+
+func TestBuildSnapshotDropsUnselectedNoiseAndBoundsInventory(t *testing.T) {
+	infos := make([]interfaceInfo, 0, MaxInterfaces+5)
+	infos = append(infos, interfaceInfo{
+		index:     99,
+		name:      "docker0",
+		kind:      "virtual",
+		virtual:   true,
+		noise:     true,
+		addresses: []Address{{Address: "172.17.0.1", Family: "ipv4", PrefixLength: 16}},
+	})
+	for i := 0; i < MaxInterfaces+5; i++ {
+		infos = append(infos, interfaceInfo{
+			index:     i + 1,
+			name:      "eth" + string(rune('a'+i)),
+			kind:      "ethernet",
+			addresses: []Address{{Address: net.IPv4(10, 0, byte(i), 1).String(), Family: "ipv4", PrefixLength: 24}},
+		})
+	}
+	snapshot := buildSnapshot(infos, nil, time.Unix(0, 0))
+	if len(snapshot.Interfaces) != MaxInterfaces {
+		t.Fatalf("interfaces=%d want=%d", len(snapshot.Interfaces), MaxInterfaces)
+	}
+	for _, iface := range snapshot.Interfaces {
+		if iface.Name == "docker0" {
+			t.Fatal("unselected noise interface was retained")
+		}
+	}
+	if got := len(snapshot.IPAddresses()); got > MaxAddressesPerHost {
+		t.Fatalf("addresses=%d", got)
+	}
+}
+
+func TestNormalizeAddressesRejectsNonUsableAddresses(t *testing.T) {
+	addresses := normalizeAddresses([]net.Addr{
+		&net.IPNet{IP: net.ParseIP("127.0.0.1"), Mask: net.CIDRMask(8, 32)},
+		&net.IPNet{IP: net.ParseIP("169.254.1.1"), Mask: net.CIDRMask(16, 32)},
+		&net.IPNet{IP: net.ParseIP("10.20.1.15"), Mask: net.CIDRMask(24, 32)},
+	})
+	if len(addresses) != 1 || addresses[0].Address != "10.20.1.15" || addresses[0].PrefixLength != 24 {
+		t.Fatalf("addresses=%+v", addresses)
+	}
+}

--- a/src/agent/internal/remote/connector.go
+++ b/src/agent/internal/remote/connector.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"log/slog"
 	"math/big"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -110,6 +111,25 @@ func (c *Connector) TaskResultAckEnabled() bool {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	return c.conn != nil && c.conn.Subprotocol() == wire.TaskResultAckSubprotocol
+}
+
+// LocalIPAddress returns the local address of the active control-plane connection.
+func (c *Connector) LocalIPAddress() string {
+	c.mu.RLock()
+	conn := c.conn
+	c.mu.RUnlock()
+	if conn == nil {
+		return ""
+	}
+	local := conn.UnderlyingConn().LocalAddr()
+	if tcpAddress, ok := local.(*net.TCPAddr); ok && tcpAddress.IP != nil {
+		return tcpAddress.IP.String()
+	}
+	host, _, err := net.SplitHostPort(local.String())
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(host)
 }
 
 func (c *Connector) endpoint() (baseURL, agentID, token string) {

--- a/src/agent/internal/remote/connector_test.go
+++ b/src/agent/internal/remote/connector_test.go
@@ -86,6 +86,9 @@ func TestHeartbeatLoopReportsWriteFailure(t *testing.T) {
 	connector := NewConnector(staticProvider{cfg: &model.AgentConfig{}})
 	connector.heartbeatInterval = time.Millisecond
 	connector.setConn(clientConn)
+	if got := connector.LocalIPAddress(); net.ParseIP(got) == nil {
+		t.Fatalf("LocalIPAddress()=%q, want active socket address", got)
+	}
 
 	done := make(chan struct{})
 	sessionErr := make(chan error, 1)

--- a/src/agent/internal/remote/inventory.go
+++ b/src/agent/internal/remote/inventory.go
@@ -2,10 +2,8 @@ package remote
 
 import (
 	"context"
-	"net"
 	"os"
 	"runtime"
-	"strings"
 
 	"github.com/shirou/gopsutil/v4/cpu"
 	"github.com/shirou/gopsutil/v4/disk"
@@ -16,7 +14,7 @@ import (
 	"hyperfilelens/agent/internal/platform/hostinfo"
 	"hyperfilelens/agent/internal/platform/install"
 	"hyperfilelens/agent/internal/platform/kopia"
-	"hyperfilelens/agent/internal/platform/netmac"
+	"hyperfilelens/agent/internal/platform/networkinventory"
 	"hyperfilelens/agent/internal/platform/vfs"
 	"hyperfilelens/agent/internal/selfupdate"
 	"hyperfilelens/agent/internal/wire"
@@ -48,16 +46,29 @@ func SendInventory(ctx context.Context, sink wire.Sender, provider config.Provid
 			"repository_operation_v1",
 			"repository_cleanup_v1",
 			"backup_prepared_snapshot_v1",
+			"network_inventory_v1",
 		},
 	} {
 		payload[key] = value
 	}
-	if mac := netmac.PrimaryMAC(); mac != "" {
-		payload["mac_address"] = mac
+	preferredAddress := ""
+	if reporter, ok := sink.(interface{ LocalIPAddress() string }); ok {
+		preferredAddress = reporter.LocalIPAddress()
 	}
-	if addresses := hostIPv4Addresses(); len(addresses) > 0 {
+	networkSnapshot := networkinventory.CollectWithPreferredAddress(
+		ctx,
+		cfg.APIBaseURL,
+		preferredAddress,
+	)
+	if mac := networkSnapshot.PrimaryMACAddress(); mac != "" {
+		payload["mac_address"] = mac
+		payload["primary_mac_address"] = mac
+	}
+	if addresses := networkSnapshot.IPAddresses(); len(addresses) > 0 {
 		payload["ip_addresses"] = addresses
-		payload["primary_ip_address"] = addresses[0]
+		payload["primary_ip_address"] = networkSnapshot.PrimaryAddress()
+		payload["primary_ip_source"] = networkSnapshot.Selection.Source
+		payload["network_inventory"] = networkSnapshot
 	}
 	if total, used, free, count, err := agentdisk.HostStorageUsage(); err == nil && count > 0 {
 		payload["disk_total_bytes"] = total
@@ -94,55 +105,4 @@ func hostname() string {
 		return ""
 	}
 	return h
-}
-
-func hostIPv4Addresses() []string {
-	interfaces, err := net.Interfaces()
-	if err != nil {
-		return nil
-	}
-	seen := map[string]bool{}
-	out := make([]string, 0)
-	for _, iface := range interfaces {
-		if iface.Flags&net.FlagUp == 0 || iface.Flags&net.FlagLoopback != 0 {
-			continue
-		}
-		name := strings.ToLower(iface.Name)
-		if strings.HasPrefix(name, "docker") ||
-			strings.HasPrefix(name, "br-") ||
-			strings.HasPrefix(name, "veth") ||
-			strings.HasPrefix(name, "virbr") {
-			continue
-		}
-		addrs, err := iface.Addrs()
-		if err != nil {
-			continue
-		}
-		for _, addr := range addrs {
-			ip := addressIP(addr)
-			if ip == nil {
-				continue
-			}
-			if ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsMulticast() || ip.IsUnspecified() {
-				continue
-			}
-			value := ip.String()
-			if !seen[value] {
-				out = append(out, value)
-				seen[value] = true
-			}
-		}
-	}
-	return out
-}
-
-func addressIP(addr net.Addr) net.IP {
-	switch value := addr.(type) {
-	case *net.IPNet:
-		return value.IP.To4()
-	case *net.IPAddr:
-		return value.IP.To4()
-	default:
-		return nil
-	}
 }

--- a/src/agent/internal/remote/register.go
+++ b/src/agent/internal/remote/register.go
@@ -15,6 +15,7 @@ import (
 	"hyperfilelens/agent/internal/infra/config"
 	"hyperfilelens/agent/internal/model"
 	"hyperfilelens/agent/internal/platform/hostinfo"
+	"hyperfilelens/agent/internal/platform/networkinventory"
 	"hyperfilelens/agent/internal/platform/tlsclient"
 	"hyperfilelens/agent/internal/selfupdate"
 )
@@ -74,6 +75,17 @@ func httpRegisterNode(
 	inventory := platform.Inventory()
 	inventory["hostname"] = hostname
 	inventory["agent_version"] = agentVersion
+	networkSnapshot := networkinventory.Collect(ctx, base)
+	if addresses := networkSnapshot.IPAddresses(); len(addresses) > 0 {
+		inventory["primary_ip_address"] = networkSnapshot.PrimaryAddress()
+		inventory["primary_ip_source"] = networkSnapshot.Selection.Source
+		inventory["ip_addresses"] = addresses
+		inventory["network_inventory"] = networkSnapshot
+	}
+	if mac := networkSnapshot.PrimaryMACAddress(); mac != "" {
+		inventory["mac_address"] = mac
+		inventory["primary_mac_address"] = mac
+	}
 	body := map[string]any{
 		"name":    hostname,
 		"role":    string(cfg.Role),

--- a/src/backend/apps/node/api/serializers/node.py
+++ b/src/backend/apps/node/api/serializers/node.py
@@ -42,6 +42,7 @@ class NodeSerializer(serializers.ModelSerializer):
         ]
         read_only_fields = [
             "id",
+            "ip_address",
             "created_at",
             "updated_at",
             "is_deleted",

--- a/src/backend/apps/node/api/views/node.py
+++ b/src/backend/apps/node/api/views/node.py
@@ -42,6 +42,7 @@ from apps.node.services.internal.node_naming import (
     resolve_registration_node_name,
     uniquify_node_name,
 )
+from apps.node.services.internal.network_inventory import split_network_from_metadata
 from apps.node.services.internal.local_platform_gateway import registration_metadata
 from apps.node.exceptions import NodeLifecycleError
 from apps.node.services.internal.agent_uninstall import ProxyHasBoundResources
@@ -289,6 +290,9 @@ class NodeViewSet(OrgScopedMixin, SoftDeleteDestroyMixin, viewsets.ModelViewSet)
         node_id = payload.get("node_id")
         node = None
         token_row = None
+        metadata_payload, network_state = split_network_from_metadata(
+            payload.get("metadata")
+        )
         if node_id:
             node = list_nodes(organization=org).filter(pk=node_id).first()
 
@@ -313,11 +317,13 @@ class NodeViewSet(OrgScopedMixin, SoftDeleteDestroyMixin, viewsets.ModelViewSet)
                 version=payload.get("version", ""),
                 os_name=payload.get("os_name", ""),
                 metadata=registration_metadata(
-                    payload.get("metadata"),
+                    metadata_payload,
                     token_note=token_row.note,
                 ),
                 last_seen_at=timezone.now(),
-                ip_address=client_ip,
+                ip_address=network_state.primary_ip_address,
+                connection_ip_address=client_ip,
+                network_inventory=network_state.inventory or {},
             )
             unique_name = uniquify_node_name(
                 organization_id=org.id,
@@ -348,11 +354,15 @@ class NodeViewSet(OrgScopedMixin, SoftDeleteDestroyMixin, viewsets.ModelViewSet)
             node.os_name = payload.get("os_name", node.os_name)
             if "metadata" in payload:
                 node.metadata = registration_metadata(
-                    payload.get("metadata"),
+                    metadata_payload,
                     existing_metadata=node.metadata,
                 )
+                if network_state.primary_ip_address:
+                    node.ip_address = network_state.primary_ip_address
+                if network_state.inventory is not None:
+                    node.network_inventory = network_state.inventory
             if client_ip:
-                node.ip_address = client_ip
+                node.connection_ip_address = client_ip
             node.save()
         else:
             return Response(

--- a/src/backend/apps/node/migrations/0006_node_network_inventory.py
+++ b/src/backend/apps/node/migrations/0006_node_network_inventory.py
@@ -1,0 +1,78 @@
+import ipaddress
+
+from django.db import migrations, models
+
+
+def _usable_address(raw):
+    try:
+        address = ipaddress.ip_address(str(raw or "").strip())
+    except ValueError:
+        return None
+    if (
+        address.is_loopback
+        or address.is_link_local
+        or address.is_multicast
+        or address.is_unspecified
+    ):
+        return None
+    return address.compressed
+
+
+def split_host_and_connection_addresses(apps, _schema_editor):
+    Node = apps.get_model("node", "Node")
+    for node in Node.objects.all().iterator():
+        old_connection_address = node.ip_address
+        metadata = node.metadata if isinstance(node.metadata, dict) else {}
+        inventory = metadata.get("inventory")
+        inventory = inventory if isinstance(inventory, dict) else {}
+        primary_address = _usable_address(inventory.get("primary_ip_address"))
+        node.connection_ip_address = old_connection_address
+        node.ip_address = primary_address
+        node.save(update_fields=["connection_ip_address", "ip_address"])
+
+
+def restore_legacy_address_semantics(apps, _schema_editor):
+    Node = apps.get_model("node", "Node")
+    for node in Node.objects.all().iterator():
+        node.ip_address = node.connection_ip_address or node.ip_address
+        node.save(update_fields=["ip_address"])
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("node", "0005_nodetoken_gateway_owner"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="node",
+            name="ip_address",
+            field=models.GenericIPAddressField(
+                blank=True,
+                help_text="Agent-reported primary host address.",
+                null=True,
+            ),
+        ),
+        migrations.AddField(
+            model_name="node",
+            name="connection_ip_address",
+            field=models.GenericIPAddressField(
+                blank=True,
+                help_text="Latest HTTP/WebSocket source address observed by the control plane.",
+                null=True,
+            ),
+        ),
+        migrations.AddField(
+            model_name="node",
+            name="network_inventory",
+            field=models.JSONField(
+                blank=True,
+                default=dict,
+                help_text="Bounded current Agent network-interface snapshot.",
+            ),
+        ),
+        migrations.RunPython(
+            split_host_and_connection_addresses,
+            restore_legacy_address_semantics,
+        ),
+    ]

--- a/src/backend/apps/node/models/node.py
+++ b/src/backend/apps/node/models/node.py
@@ -25,7 +25,21 @@ class Node(OrganizationScopedModel):
     role = models.CharField(max_length=20, choices=Role.choices)
     version = models.CharField(max_length=50, blank=True, default="")
     os_name = models.CharField(max_length=80, blank=True, default="")
-    ip_address = models.GenericIPAddressField(blank=True, null=True)
+    ip_address = models.GenericIPAddressField(
+        blank=True,
+        null=True,
+        help_text="Agent-reported primary host address.",
+    )
+    connection_ip_address = models.GenericIPAddressField(
+        blank=True,
+        null=True,
+        help_text="Latest HTTP/WebSocket source address observed by the control plane.",
+    )
+    network_inventory = models.JSONField(
+        default=dict,
+        blank=True,
+        help_text="Bounded current Agent network-interface snapshot.",
+    )
     status = models.CharField(
         max_length=20,
         choices=Status.choices,

--- a/src/backend/apps/node/services/internal/network_inventory.py
+++ b/src/backend/apps/node/services/internal/network_inventory.py
@@ -1,0 +1,265 @@
+"""Normalize bounded Agent network inventory and resolve its primary host address."""
+
+from __future__ import annotations
+
+import ipaddress
+import json
+import re
+from dataclasses import dataclass
+from typing import Any
+
+MAX_INTERFACES = 16
+MAX_ADDRESSES_PER_INTERFACE = 8
+MAX_ADDRESSES_PER_HOST = 32
+MAX_RAW_INVENTORY_BYTES = 64 * 1024
+NETWORK_INVENTORY_SCHEMA_VERSION = 1
+
+_MAC_RE = re.compile(r"^(?:[0-9a-f]{2}:){5}[0-9a-f]{2}$")
+_INTERFACE_TYPES = frozenset({"ethernet", "wifi", "vpn", "virtual", "unknown"})
+_SELECTION_SOURCES = frozenset(
+    {"route_to_control_plane", "default_route", "interface_fallback"}
+)
+
+
+@dataclass(frozen=True)
+class NormalizedNetworkState:
+    primary_ip_address: str | None
+    primary_mac_address: str
+    inventory: dict[str, Any] | None
+    metadata_inventory: dict[str, Any]
+
+
+def split_network_from_metadata(
+    raw_metadata: object,
+) -> tuple[dict[str, Any], NormalizedNetworkState]:
+    """Return registration metadata without duplicating the dedicated network snapshot."""
+    metadata = dict(raw_metadata) if isinstance(raw_metadata, dict) else {}
+    state = normalize_agent_network_state(metadata.get("inventory"))
+    if isinstance(metadata.get("inventory"), dict):
+        metadata["inventory"] = state.metadata_inventory
+    return metadata, state
+
+
+def normalize_agent_network_state(raw_inventory: object) -> NormalizedNetworkState:
+    """Split compact network state from general Agent inventory and validate the primary IP."""
+    inventory = dict(raw_inventory) if isinstance(raw_inventory, dict) else {}
+    raw_network = inventory.pop("network_inventory", None)
+    normalized_network = normalize_network_inventory(raw_network)
+
+    primary = _normalize_usable_ip(inventory.get("primary_ip_address"))
+    primary_mac = _normalize_mac(
+        inventory.get("primary_mac_address") or inventory.get("mac_address")
+    )
+    announced = _normalize_legacy_addresses(inventory.get("ip_addresses"))
+    if isinstance(inventory.get("ip_addresses"), list):
+        inventory["ip_addresses"] = announced
+
+    if normalized_network:
+        selection = normalized_network["selection"]
+        selected = str(selection.get("address") or "")
+        if selected:
+            primary = selected
+        selected_interface = next(
+            (
+                item
+                for item in normalized_network["interfaces"]
+                if item["id"] == selection.get("interface_id")
+            ),
+            None,
+        )
+        if selected_interface is not None:
+            primary_mac = str(selected_interface.get("mac_address") or "")
+    if not normalized_network and primary:
+        if announced and primary not in announced:
+            primary = None
+
+    if primary:
+        inventory["primary_ip_address"] = primary
+    else:
+        inventory.pop("primary_ip_address", None)
+    if primary_mac:
+        inventory["mac_address"] = primary_mac
+        inventory["primary_mac_address"] = primary_mac
+    if normalized_network:
+        inventory["primary_ip_source"] = normalized_network["selection"]["source"]
+    return NormalizedNetworkState(
+        primary_ip_address=primary,
+        primary_mac_address=primary_mac,
+        inventory=normalized_network,
+        metadata_inventory=inventory,
+    )
+
+
+def normalize_network_inventory(raw: object) -> dict[str, Any] | None:
+    if not isinstance(raw, dict):
+        return None
+    try:
+        if (
+            len(json.dumps(raw, separators=(",", ":"), default=str).encode("utf-8"))
+            > MAX_RAW_INVENTORY_BYTES
+        ):
+            return None
+    except (TypeError, ValueError):
+        return None
+    if _as_int(raw.get("schema_version")) != NETWORK_INVENTORY_SCHEMA_VERSION:
+        return None
+
+    interfaces: list[dict[str, Any]] = []
+    seen_ids: set[str] = set()
+    total_addresses = 0
+    raw_interfaces = raw.get("interfaces")
+    if not isinstance(raw_interfaces, list):
+        return None
+    for raw_interface in raw_interfaces:
+        if (
+            len(interfaces) >= MAX_INTERFACES
+            or total_addresses >= MAX_ADDRESSES_PER_HOST
+        ):
+            break
+        if not isinstance(raw_interface, dict):
+            continue
+        interface_id = _bounded_text(raw_interface.get("id"), 128)
+        name = _bounded_text(raw_interface.get("name"), 200)
+        if not interface_id or not name or interface_id in seen_ids:
+            continue
+        addresses: list[dict[str, Any]] = []
+        seen_addresses: set[str] = set()
+        raw_addresses = raw_interface.get("addresses")
+        if not isinstance(raw_addresses, list):
+            raw_addresses = []
+        address_limit = min(
+            MAX_ADDRESSES_PER_INTERFACE,
+            MAX_ADDRESSES_PER_HOST - total_addresses,
+        )
+        for raw_address in raw_addresses:
+            if len(addresses) >= address_limit:
+                break
+            if not isinstance(raw_address, dict):
+                continue
+            address = _normalize_usable_ip(raw_address.get("address"))
+            if not address or address in seen_addresses:
+                continue
+            parsed = ipaddress.ip_address(address)
+            prefix = _as_int(raw_address.get("prefix_length"))
+            max_prefix = 32 if parsed.version == 4 else 128
+            if prefix < 0 or prefix > max_prefix:
+                prefix = 0
+            seen_addresses.add(address)
+            addresses.append(
+                {
+                    "address": address,
+                    "family": "ipv4" if parsed.version == 4 else "ipv6",
+                    "prefix_length": prefix,
+                }
+            )
+        if not addresses:
+            continue
+        interface_type = _bounded_text(raw_interface.get("type"), 16).lower()
+        if interface_type not in _INTERFACE_TYPES:
+            interface_type = "unknown"
+        seen_ids.add(interface_id)
+        total_addresses += len(addresses)
+        interfaces.append(
+            {
+                "id": interface_id,
+                "name": name,
+                "mac_address": _normalize_mac(raw_interface.get("mac_address")),
+                "type": interface_type,
+                "virtual": bool(raw_interface.get("virtual")),
+                "default_route": bool(raw_interface.get("default_route")),
+                "addresses": addresses,
+            }
+        )
+
+    selection_raw = raw.get("selection")
+    selection_raw = selection_raw if isinstance(selection_raw, dict) else {}
+    selected_address = _normalize_usable_ip(selection_raw.get("address"))
+    selected_interface_id = _bounded_text(selection_raw.get("interface_id"), 128)
+    source = _bounded_text(selection_raw.get("source"), 32)
+    if source not in _SELECTION_SOURCES:
+        source = "interface_fallback"
+    selected_interface = next(
+        (item for item in interfaces if item["id"] == selected_interface_id),
+        None,
+    )
+    if selected_interface is None or selected_address not in {
+        item["address"] for item in selected_interface["addresses"]
+    }:
+        selected_address = ""
+        selected_interface_id = ""
+    if not selected_address and interfaces:
+        selected_interface = interfaces[0]
+        selected_address = selected_interface["addresses"][0]["address"]
+        selected_interface_id = selected_interface["id"]
+        source = "interface_fallback"
+
+    family = ""
+    if selected_address:
+        family = (
+            "ipv4" if ipaddress.ip_address(selected_address).version == 4 else "ipv6"
+        )
+    collected_at = _bounded_text(raw.get("collected_at"), 40)
+    return {
+        "schema_version": NETWORK_INVENTORY_SCHEMA_VERSION,
+        "collected_at": collected_at,
+        "selection": {
+            "address": selected_address,
+            "family": family,
+            "interface_id": selected_interface_id,
+            "source": source,
+        },
+        "interfaces": interfaces,
+    }
+
+
+def same_network_inventory(left: object, right: object) -> bool:
+    """Compare topology while ignoring the collection timestamp."""
+    if not isinstance(left, dict) or not isinstance(right, dict):
+        return left == right
+    left_value = {key: value for key, value in left.items() if key != "collected_at"}
+    right_value = {key: value for key, value in right.items() if key != "collected_at"}
+    return left_value == right_value
+
+
+def _normalize_legacy_addresses(raw: object) -> list[str]:
+    if not isinstance(raw, list):
+        return []
+    result: list[str] = []
+    seen: set[str] = set()
+    for value in raw[:MAX_ADDRESSES_PER_HOST]:
+        address = _normalize_usable_ip(value)
+        if address and address not in seen:
+            seen.add(address)
+            result.append(address)
+    return result
+
+
+def _normalize_usable_ip(raw: object) -> str | None:
+    try:
+        address = ipaddress.ip_address(str(raw or "").strip())
+    except ValueError:
+        return None
+    if (
+        address.is_loopback
+        or address.is_link_local
+        or address.is_multicast
+        or address.is_unspecified
+    ):
+        return None
+    return address.compressed
+
+
+def _normalize_mac(raw: object) -> str:
+    value = str(raw or "").strip().lower().replace("-", ":")
+    return value if _MAC_RE.fullmatch(value) and value != "00:00:00:00:00:00" else ""
+
+
+def _bounded_text(raw: object, length: int) -> str:
+    return str(raw or "").strip()[:length]
+
+
+def _as_int(raw: object) -> int:
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return 0

--- a/src/backend/apps/node/tests/test_network_inventory.py
+++ b/src/backend/apps/node/tests/test_network_inventory.py
@@ -1,0 +1,189 @@
+from importlib import import_module
+
+from django.apps import apps as django_apps
+from django.test import SimpleTestCase, TestCase
+
+from apps.iam.models import Organization
+from apps.node.models import Node
+from apps.node.models.base import NodeRole
+from apps.node.services.internal.network_inventory import (
+    MAX_ADDRESSES_PER_HOST,
+    MAX_INTERFACES,
+    normalize_agent_network_state,
+    normalize_network_inventory,
+    same_network_inventory,
+)
+from apps.node.ws.uplink import apply_heartbeat_inventory_snapshot
+
+
+def network_payload(primary: str = "10.20.1.15") -> dict:
+    return {
+        "schema_version": 1,
+        "collected_at": "2026-07-28T12:00:00Z",
+        "selection": {
+            "address": primary,
+            "family": "ipv4",
+            "interface_id": "mac:00:11:22:33:44:55",
+            "source": "route_to_control_plane",
+        },
+        "interfaces": [
+            {
+                "id": "mac:00:11:22:33:44:55",
+                "name": "Ethernet 0",
+                "mac_address": "00:11:22:33:44:55",
+                "type": "ethernet",
+                "virtual": False,
+                "default_route": True,
+                "addresses": [
+                    {"address": primary, "family": "ipv4", "prefix_length": 24}
+                ],
+            }
+        ],
+    }
+
+
+class NetworkInventoryNormalizationTests(SimpleTestCase):
+    def test_normalizes_primary_ip_and_matching_mac(self):
+        state = normalize_agent_network_state(
+            {
+                "primary_ip_address": "198.51.100.90",
+                "network_inventory": network_payload(),
+            }
+        )
+
+        self.assertEqual(state.primary_ip_address, "10.20.1.15")
+        self.assertEqual(state.primary_mac_address, "00:11:22:33:44:55")
+        self.assertNotIn("network_inventory", state.metadata_inventory)
+
+    def test_bounds_interface_and_address_counts(self):
+        payload = network_payload()
+        payload["interfaces"] = []
+        for index in range(MAX_INTERFACES + 5):
+            payload["interfaces"].append(
+                {
+                    "id": f"if:{index}",
+                    "name": f"eth{index}",
+                    "type": "ethernet",
+                    "addresses": [
+                        {
+                            "address": f"10.{index}.0.{address + 1}",
+                            "prefix_length": 24,
+                        }
+                        for address in range(8)
+                    ],
+                }
+            )
+        payload["selection"] = {
+            "address": "10.0.0.1",
+            "interface_id": "if:0",
+            "source": "route_to_control_plane",
+        }
+
+        normalized = normalize_network_inventory(payload)
+
+        self.assertIsNotNone(normalized)
+        assert normalized is not None
+        self.assertLessEqual(len(normalized["interfaces"]), MAX_INTERFACES)
+        count = sum(len(item["addresses"]) for item in normalized["interfaces"])
+        self.assertLessEqual(count, MAX_ADDRESSES_PER_HOST)
+
+    def test_skips_invalid_entries_without_hiding_later_valid_data(self):
+        payload = network_payload()
+        payload["interfaces"] = [None] * MAX_INTERFACES + payload["interfaces"]
+        payload["interfaces"][-1]["addresses"] = [None] + payload["interfaces"][-1][
+            "addresses"
+        ]
+
+        normalized = normalize_network_inventory(payload)
+
+        self.assertIsNotNone(normalized)
+        assert normalized is not None
+        self.assertEqual(len(normalized["interfaces"]), 1)
+        self.assertEqual(
+            normalized["interfaces"][0]["addresses"][0]["address"],
+            "10.20.1.15",
+        )
+
+    def test_rejects_primary_not_announced_by_legacy_inventory(self):
+        state = normalize_agent_network_state(
+            {
+                "primary_ip_address": "10.20.1.15",
+                "ip_addresses": ["10.20.1.16"],
+            }
+        )
+        self.assertIsNone(state.primary_ip_address)
+
+    def test_ignores_collection_time_when_comparing_snapshots(self):
+        left = network_payload()
+        right = network_payload()
+        right["collected_at"] = "2026-07-28T12:01:00Z"
+        self.assertTrue(same_network_inventory(left, right))
+
+
+class NodeNetworkInventoryHeartbeatTests(TestCase):
+    def setUp(self):
+        self.org = Organization.objects.create(key="network-org", name="Network Org")
+        self.node = Node.objects.create(
+            organization=self.org,
+            name="agent-a",
+            role=NodeRole.AGENT,
+            ip_address="10.20.1.10",
+        )
+
+    def test_inventory_heartbeat_updates_host_ip_and_compact_snapshot(self):
+        apply_heartbeat_inventory_snapshot(
+            node_id=self.node.id,
+            inventory={
+                "agent_version": "1.2.3",
+                "primary_ip_address": "10.20.1.15",
+                "network_inventory": network_payload(),
+            },
+        )
+
+        self.node.refresh_from_db()
+        self.assertEqual(str(self.node.ip_address), "10.20.1.15")
+        self.assertEqual(self.node.network_inventory["schema_version"], 1)
+        self.assertEqual(
+            self.node.metadata["inventory"]["primary_mac_address"],
+            "00:11:22:33:44:55",
+        )
+
+    def test_invalid_inventory_does_not_overwrite_valid_host_ip(self):
+        apply_heartbeat_inventory_snapshot(
+            node_id=self.node.id,
+            inventory={
+                "primary_ip_address": "127.0.0.1",
+                "ip_addresses": ["127.0.0.1"],
+            },
+        )
+
+        self.node.refresh_from_db()
+        self.assertEqual(str(self.node.ip_address), "10.20.1.10")
+
+
+class NodeNetworkInventoryMigrationTests(TestCase):
+    def test_migration_splits_legacy_connection_and_reported_host_ips(self):
+        org = Organization.objects.create(key="migration-org", name="Migration Org")
+        reported = Node.objects.create(
+            organization=org,
+            name="reported-agent",
+            role=NodeRole.AGENT,
+            ip_address="203.0.113.20",
+            metadata={"inventory": {"primary_ip_address": "10.20.1.15"}},
+        )
+        missing = Node.objects.create(
+            organization=org,
+            name="legacy-agent",
+            role=NodeRole.AGENT,
+            ip_address="203.0.113.20",
+        )
+
+        migration = import_module("apps.node.migrations.0006_node_network_inventory")
+        migration.split_host_and_connection_addresses(django_apps, None)
+
+        reported.refresh_from_db()
+        missing.refresh_from_db()
+        self.assertEqual(str(reported.ip_address), "10.20.1.15")
+        self.assertEqual(str(reported.connection_ip_address), "203.0.113.20")
+        self.assertIsNone(missing.ip_address)
+        self.assertEqual(str(missing.connection_ip_address), "203.0.113.20")

--- a/src/backend/apps/node/tests/test_node_client_ip.py
+++ b/src/backend/apps/node/tests/test_node_client_ip.py
@@ -1,14 +1,16 @@
-from django.test import SimpleTestCase, TestCase
+from django.test import SimpleTestCase, TestCase, override_settings
 from rest_framework.test import APIRequestFactory
 
 from apps.iam.models import Organization
 from apps.node.api.views.node import NodeViewSet
+from apps.node.api.serializers.node import NodeSerializer
 from apps.node.models import Node, NodeToken
 from apps.node.models.base import NodeRole
 from common.http.client_ip import client_ip_from_meta, client_ip_from_scope
 
 
 class ClientIpHelperTests(SimpleTestCase):
+    @override_settings(TRUSTED_PROXY=True)
     def test_prefers_x_forwarded_for(self):
         meta = {
             "HTTP_X_FORWARDED_FOR": "203.0.113.10, 172.18.0.7",
@@ -20,6 +22,15 @@ class ClientIpHelperTests(SimpleTestCase):
         meta = {"REMOTE_ADDR": "10.0.0.8"}
         self.assertEqual(client_ip_from_meta(meta), "10.0.0.8")
 
+    @override_settings(TRUSTED_PROXY=False)
+    def test_ignores_forwarded_header_without_trusted_proxy(self):
+        meta = {
+            "HTTP_X_FORWARDED_FOR": "203.0.113.10",
+            "REMOTE_ADDR": "10.0.0.8",
+        }
+        self.assertEqual(client_ip_from_meta(meta), "10.0.0.8")
+
+    @override_settings(TRUSTED_PROXY=True)
     def test_scope_reads_forwarded_header(self):
         scope = {
             "headers": [
@@ -30,6 +41,7 @@ class ClientIpHelperTests(SimpleTestCase):
         self.assertEqual(client_ip_from_scope(scope), "192.168.10.15")
 
 
+@override_settings(TRUSTED_PROXY=True)
 class NodeHeartbeatClientIpTests(TestCase):
     def setUp(self):
         self.org = Organization.objects.create(key="node-ip-org", name="Node IP Org")
@@ -41,7 +53,7 @@ class NodeHeartbeatClientIpTests(TestCase):
         )
         self.factory = APIRequestFactory()
 
-    def test_heartbeat_persists_forwarded_client_ip(self):
+    def test_heartbeat_separates_reported_host_ip_from_forwarded_client_ip(self):
         request = self.factory.post(
             "/api/v1/node/nodes/heartbeat/",
             {
@@ -49,6 +61,12 @@ class NodeHeartbeatClientIpTests(TestCase):
                 "name": "agent-host",
                 "version": "1.0.0",
                 "os_name": "linux",
+                "metadata": {
+                    "inventory": {
+                        "primary_ip_address": "10.20.1.15",
+                        "ip_addresses": ["10.20.1.15"],
+                    }
+                },
             },
             format="json",
             HTTP_X_ORG_KEY=self.org.key,
@@ -60,14 +78,15 @@ class NodeHeartbeatClientIpTests(TestCase):
         self.assertEqual(response.status_code, 200)
 
         node = Node.objects.get(organization=self.org)
-        self.assertEqual(str(node.ip_address), "192.168.10.15")
+        self.assertEqual(str(node.ip_address), "10.20.1.15")
+        self.assertEqual(str(node.connection_ip_address), "192.168.10.15")
 
-    def test_heartbeat_updates_existing_node_ip(self):
+    def test_heartbeat_updates_host_and_connection_addresses_independently(self):
         node = Node.objects.create(
             organization=self.org,
             name="agent-existing",
             role=NodeRole.AGENT,
-            ip_address="172.18.0.7",
+            ip_address="10.20.1.40",
         )
         request = self.factory.post(
             "/api/v1/node/nodes/heartbeat/",
@@ -75,6 +94,12 @@ class NodeHeartbeatClientIpTests(TestCase):
                 "node_id": node.id,
                 "role": "agent",
                 "name": node.name,
+                "metadata": {
+                    "inventory": {
+                        "primary_ip_address": "10.20.1.41",
+                        "ip_addresses": ["10.20.1.41"],
+                    }
+                },
             },
             format="json",
             HTTP_X_ORG_KEY=self.org.key,
@@ -86,4 +111,35 @@ class NodeHeartbeatClientIpTests(TestCase):
         self.assertEqual(response.status_code, 200)
 
         node.refresh_from_db()
-        self.assertEqual(str(node.ip_address), "192.168.7.51")
+        self.assertEqual(str(node.ip_address), "10.20.1.41")
+        self.assertEqual(str(node.connection_ip_address), "192.168.7.51")
+
+    def test_connection_only_heartbeat_does_not_overwrite_host_ip(self):
+        node = Node.objects.create(
+            organization=self.org,
+            name="agent-existing",
+            role=NodeRole.AGENT,
+            ip_address="10.20.1.50",
+        )
+        request = self.factory.post(
+            "/api/v1/node/nodes/heartbeat/",
+            {
+                "node_id": node.id,
+                "role": "agent",
+                "name": node.name,
+            },
+            format="json",
+            HTTP_X_ORG_KEY=self.org.key,
+            HTTP_X_NODE_TOKEN="ignored",
+            HTTP_X_FORWARDED_FOR="203.0.113.20",
+            REMOTE_ADDR="172.18.0.7",
+        )
+
+        response = NodeViewSet.as_view({"post": "heartbeat"})(request)
+        self.assertEqual(response.status_code, 200)
+        node.refresh_from_db()
+        self.assertEqual(str(node.ip_address), "10.20.1.50")
+        self.assertEqual(str(node.connection_ip_address), "203.0.113.20")
+
+    def test_host_ip_is_read_only_in_tenant_serializer(self):
+        self.assertTrue(NodeSerializer().fields["ip_address"].read_only)

--- a/src/backend/apps/node/tests/test_node_online_status.py
+++ b/src/backend/apps/node/tests/test_node_online_status.py
@@ -101,6 +101,20 @@ class AgentNodeOnlineStatusTests(TestCase):
             Node.Status.ONLINE,
         )
 
+    def test_ws_connect_updates_connection_ip_without_overwriting_host_ip(self):
+        self.node.ip_address = "10.20.1.15"
+        self.node.save(update_fields=["ip_address", "updated_at"])
+
+        on_agent_connected(
+            node_id=self.node.id,
+            session_id="session-a",
+            client_ip="203.0.113.20",
+        )
+
+        self.node.refresh_from_db()
+        self.assertEqual(str(self.node.ip_address), "10.20.1.15")
+        self.assertEqual(str(self.node.connection_ip_address), "203.0.113.20")
+
     def test_ws_recovery_hold_requires_live_ws_and_expiry(self):
         self.assertFalse(redis_store.offline_task_finalization_ready())
         self._mark_ws_alive()

--- a/src/backend/apps/node/ws/uplink.py
+++ b/src/backend/apps/node/ws/uplink.py
@@ -17,6 +17,10 @@ from apps.node.services.internal.node_naming import (
     resolve_inventory_node_name,
     uniquify_node_name,
 )
+from apps.node.services.internal.network_inventory import (
+    normalize_agent_network_state,
+    same_network_inventory,
+)
 from apps.node.services.interface import (
     complete_task,
     record_task_progress,
@@ -35,7 +39,7 @@ def on_agent_connected(*, node_id: int, session_id: str, client_ip: str | None =
         "status": Node.Status.ONLINE,
     }
     if client_ip:
-        updates["ip_address"] = client_ip
+        updates["connection_ip_address"] = client_ip
     Node.objects.filter(pk=node_id).update(**updates)
     try:
         sync_agent_source_host_by_id(node_id=node_id)
@@ -101,9 +105,20 @@ def _inventory_throttle_key(*, node_id: int) -> str:
 def _merge_heartbeat_inventory_updates(*, node: Node, inventory: dict) -> dict:
     """Build ``Node.objects.update`` kwargs for inventory snapshot fields (not metrics)."""
     updates: dict = {}
-    inv_only = {k: v for k, v in inventory.items() if k != "metrics"}
+    state = normalize_agent_network_state(inventory)
+    inv_only = {k: v for k, v in state.metadata_inventory.items() if k != "metrics"}
     if ver := str(inventory.get("agent_version") or "").strip():
         updates["version"] = ver
+    if (
+        state.primary_ip_address
+        and str(node.ip_address or "") != state.primary_ip_address
+    ):
+        updates["ip_address"] = state.primary_ip_address
+    if state.inventory is not None and not same_network_inventory(
+        node.network_inventory,
+        state.inventory,
+    ):
+        updates["network_inventory"] = state.inventory
     if inv_only:
         meta = dict(node.metadata or {})
         meta["inventory"] = {**dict(meta.get("inventory") or {}), **inv_only}

--- a/src/backend/common/http/client_ip.py
+++ b/src/backend/common/http/client_ip.py
@@ -2,13 +2,15 @@
 
 from __future__ import annotations
 
+from django.conf import settings
+
 
 def client_ip_from_meta(meta: dict | None) -> str | None:
     """Return the left-most client IP from request META or ASGI-derived headers."""
     if not meta:
         return None
     forwarded = str(meta.get("HTTP_X_FORWARDED_FOR", "") or "").strip()
-    if forwarded:
+    if forwarded and getattr(settings, "TRUSTED_PROXY", False):
         return forwarded.split(",")[0].strip() or None
     remote = meta.get("REMOTE_ADDR")
     return str(remote).strip() if remote else None
@@ -23,7 +25,7 @@ def client_ip_from_scope(scope: dict | None) -> str | None:
         for key, value in scope.get("headers", [])
     }
     forwarded = headers.get("x-forwarded-for", "").strip()
-    if forwarded:
+    if forwarded and getattr(settings, "TRUSTED_PROXY", False):
         return forwarded.split(",")[0].strip() or None
     client = scope.get("client")
     if isinstance(client, (list, tuple)) and client:

--- a/src/backend/project/settings/security.py
+++ b/src/backend/project/settings/security.py
@@ -15,6 +15,7 @@ CSRF_COOKIE_NAME = "hfl_csrftoken"
 _DEBUG = env_bool("DJANGO_DEBUG")
 _FRONTEND_URL = env_str("FRONTEND_URL", "http://localhost:3000")
 _TRUSTED_PROXY = env_bool("TRUSTED_PROXY", default=_FRONTEND_URL.startswith("https://"))
+TRUSTED_PROXY = _TRUSTED_PROXY
 
 if _TRUSTED_PROXY:
     SECURE_PROXY_SSL_HEADER = (

--- a/src/frontend/src/composables/useNasSourceListDisplay.ts
+++ b/src/frontend/src/composables/useNasSourceListDisplay.ts
@@ -60,7 +60,7 @@ export function useNasSourceListDisplay(proxyNodes: Ref<ApiNode[]>) {
   }
 
   function sourceNodeIp(row: SourceResource) {
-    return sourceConfigValue(row, 'host_ip') || boundNodeForRow(row)?.ip_address?.trim() || '—'
+    return proxyNodeStackIpLine(boundNodeForRow(row), sourceConfigValue(row, 'host_ip')) || '—'
   }
 
   function sourceNodeOnlineStatus(row: SourceResource): 'online' | 'reconnecting' | 'offline' {

--- a/src/frontend/src/lib/nodeInventoryDisplay.test.ts
+++ b/src/frontend/src/lib/nodeInventoryDisplay.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+import { proxyNodeStackIpLine } from './nodeInventoryDisplay'
+
+describe('node host IP display', () => {
+  it('prefers the bound Node host IP over a stale cached fallback', () => {
+    expect(
+      proxyNodeStackIpLine(
+        { ip_address: '10.20.1.15' },
+        '203.0.113.20',
+      ),
+    ).toBe('10.20.1.15')
+  })
+
+  it('uses the cached fallback only when no Node host IP is available', () => {
+    expect(proxyNodeStackIpLine({ ip_address: null }, '10.20.1.15')).toBe('10.20.1.15')
+  })
+})

--- a/src/frontend/src/pages/protection/BackupSources.vue
+++ b/src/frontend/src/pages/protection/BackupSources.vue
@@ -736,7 +736,7 @@ function sourceNodeName(row: SourceResource) {
 }
 
 function sourceNodeIp(row: SourceResource) {
-  return sourceConfigValue(row, 'host_ip') || boundNodeForRow(row)?.ip_address?.trim() || '—'
+  return proxyNodeStackIpLine(boundNodeForRow(row), sourceConfigValue(row, 'host_ip')) || '—'
 }
 
 function sourceNodeOnlineStatus(row: SourceResource): 'online' | 'reconnecting' | 'offline' {


### PR DESCRIPTION
## Summary

- separate the Agent-reported host IP from the control-plane connection source IP
- collect and validate a bounded multi-interface network inventory with IPv4 and IPv6 support
- prefer the active control connection source address and its matching interface MAC
- keep the existing UI layout while displaying the bound Node host IP before legacy cached values
- trust forwarded client addresses only when trusted-proxy mode is enabled

## Validation

- Agent: go test ./...
- Backend: 157 Node tests passed
- Backend: Ruff and Django migration drift checks passed
- Frontend: targeted Vitest tests, ESLint, and production build passed

Fixes #126