### PR TITLE
fix(platform): preserve gateway identity and admin routing

### DIFF
--- a/.github/scripts/remote-deploy.sh
+++ b/.github/scripts/remote-deploy.sh
@@ -7,6 +7,7 @@ TAG=""
 CHANNEL="release"
 INSTALL_DIR="/opt/hyperfilelens"
 PUBLIC_URL=""
+ADMIN_PUBLIC_URL=""
 DIRECT_HOST=""
 RUNTIME_ENV_FILE=""
 DOWNLOAD_PROXY_URL=""
@@ -20,6 +21,7 @@ Usage: remote-deploy.sh --tag vX.Y.Z|main-SHA7 --channel release|main --direct-h
   --install-dir DIR        HFL install directory (default: /opt/hyperfilelens)
   --direct-host HOST       SSH-reachable host used for direct listener URLs
   --public-url URL         Optional canonical browser URL; external checks are non-blocking
+  --admin-public-url URL   Optional Admin Console browser URL; invalid values only warn
   --runtime-env-file PATH  Root-only staged runtime configuration under /var/tmp
   --download-proxy-url URL Optional HTTP(S) proxy used only for GitHub Release downloads
 USAGE
@@ -30,6 +32,7 @@ while [[ $# -gt 0 ]]; do
 	--tag) TAG=${2:-}; shift 2 ;;
 	--channel) CHANNEL=${2:-}; shift 2 ;;
 	--public-url) PUBLIC_URL=${2:-}; shift 2 ;;
+	--admin-public-url) ADMIN_PUBLIC_URL=${2:-}; shift 2 ;;
 	--direct-host) DIRECT_HOST=${2:-}; shift 2 ;;
 	--repository) REPOSITORY=${2:-}; shift 2 ;;
 	--install-dir) INSTALL_DIR=${2:-}; shift 2 ;;
@@ -464,6 +467,7 @@ if [[ -f "${INSTALL_DIR}/.env" && -f "${INSTALL_DIR}/VERSION" ]]; then
 		--yes
 		--direct-host "${DIRECT_HOST}"
 		--public-url "${PUBLIC_URL}"
+		--admin-public-url "${ADMIN_PUBLIC_URL}"
 	)
 	[[ "${CHANNEL}" == "main" ]] && install_args+=(--allow-main-build)
 	if [[ -n "${RUNTIME_ENV_FILE}" ]]; then
@@ -477,6 +481,7 @@ else
 		install
 		--direct-host "${DIRECT_HOST}"
 		--public-url "${PUBLIC_URL}"
+		--admin-public-url "${ADMIN_PUBLIC_URL}"
 	)
 	[[ "${CHANNEL}" == "main" ]] && install_args+=(--allow-main-build)
 	if [[ -n "${RUNTIME_ENV_FILE}" ]]; then

--- a/.github/workflows/artifact_pipeline.yml
+++ b/.github/workflows/artifact_pipeline.yml
@@ -866,6 +866,7 @@ jobs:
       channel: main
       tag: ${{ needs.prepare.outputs.tag }}
       public_url: ${{ vars.TEST_PUBLIC_URL }}
+      admin_public_url: ${{ vars.TEST_ADMIN_PUBLIC_URL }}
       release_download_proxy_url: ${{ vars.TEST_RELEASE_DOWNLOAD_PROXY_URL }}
       ssh_host: ${{ vars.TEST_SSH_HOST }}
       ssh_port: ${{ vars.TEST_SSH_PORT }}
@@ -911,6 +912,7 @@ jobs:
       channel: release
       tag: ${{ needs.prepare.outputs.tag }}
       public_url: ${{ vars.PREPROD_PUBLIC_URL }}
+      admin_public_url: ${{ vars.PREPROD_ADMIN_PUBLIC_URL }}
       release_download_proxy_url: ${{ vars.PREPROD_RELEASE_DOWNLOAD_PROXY_URL }}
       ssh_host: ${{ vars.PREPROD_SSH_HOST }}
       ssh_port: ${{ vars.PREPROD_SSH_PORT }}

--- a/.github/workflows/deploy_target.yml
+++ b/.github/workflows/deploy_target.yml
@@ -21,6 +21,11 @@ on:
         required: false
         default: ''
         type: string
+      admin_public_url:
+        description: Optional canonical Admin Console browser URL
+        required: false
+        default: ''
+        type: string
       release_download_proxy_url:
         description: Optional target-side HTTP(S) proxy; empty or UNCONFIGURED means direct download
         required: false
@@ -148,6 +153,7 @@ jobs:
       cancel-in-progress: false
     env:
       APP_PUBLIC_URL: ${{ inputs.public_url }}
+      ADMIN_PUBLIC_URL: ${{ inputs.admin_public_url }}
       DEPLOY_SSH_HOST: ${{ inputs.ssh_host }}
       DEPLOY_SSH_PORT: ${{ inputs.ssh_port }}
       DEPLOY_SSH_USER: ${{ inputs.ssh_user }}
@@ -387,6 +393,7 @@ jobs:
               --tag "${{ inputs.tag }}" \
               --channel "${{ inputs.channel }}" \
               --public-url "$APP_PUBLIC_URL" \
+              --admin-public-url "$ADMIN_PUBLIC_URL" \
               --direct-host "$DEPLOY_SSH_HOST" \
               --install-dir /opt/hyperfilelens \
               "${download_proxy_args[@]}" \

--- a/.github/workflows/production_deploy.yml
+++ b/.github/workflows/production_deploy.yml
@@ -68,6 +68,7 @@ jobs:
       channel: release
       tag: ${{ inputs.tag }}
       public_url: ${{ vars.PROD_PUBLIC_URL }}
+      admin_public_url: ${{ vars.PROD_ADMIN_PUBLIC_URL }}
       release_download_proxy_url: ${{ vars.PROD_RELEASE_DOWNLOAD_PROXY_URL }}
       ssh_host: ${{ vars.PROD_SSH_HOST }}
       ssh_port: ${{ vars.PROD_SSH_PORT }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,6 +81,7 @@ jobs:
       channel: release
       tag: ${{ inputs.tag }}
       public_url: ${{ vars.PREPROD_PUBLIC_URL }}
+      admin_public_url: ${{ vars.PREPROD_ADMIN_PUBLIC_URL }}
       release_download_proxy_url: ${{ vars.PREPROD_RELEASE_DOWNLOAD_PROXY_URL }}
       ssh_host: ${{ vars.PREPROD_SSH_HOST }}
       ssh_port: ${{ vars.PREPROD_SSH_PORT }}

--- a/deploy/installer/apply-runtime-config.py
+++ b/deploy/installer/apply-runtime-config.py
@@ -252,6 +252,7 @@ def apply_configuration(
     env_path: pathlib.Path,
     direct_host: str,
     public_url: str,
+    admin_public_url: str,
     runtime_path: Optional[pathlib.Path],
 ) -> None:
     require_regular_file(env_path, "environment file")
@@ -315,9 +316,6 @@ def apply_configuration(
         "https://127.0.0.1:11443",
         f"https://{direct_url_host}:11443" if direct_url_host else "",
     )
-    if direct_url_host:
-        updates["HFL_ADMIN_PUBLIC_URL"] = f"https://{direct_url_host}:11444"
-
     public_url = public_url.strip()
     if public_url:
         parsed = parse_public_origin(public_url)
@@ -338,6 +336,21 @@ def apply_configuration(
             )
     else:
         warn("public URL is empty; preserving installed URL configuration")
+
+    admin_public_url = admin_public_url.strip()
+    if admin_public_url:
+        parsed = parse_public_origin(admin_public_url)
+        if parsed:
+            admin_origin = urlunsplit((parsed.scheme, parsed.netloc, "", "", ""))
+            append_unique(allowed_hosts, parsed.hostname or "")
+            append_unique(csrf_origins, admin_origin)
+            append_unique(cors_origins, admin_origin)
+            updates["HFL_ADMIN_PUBLIC_URL"] = admin_origin
+        else:
+            warn(
+                f"invalid Admin Console public URL {admin_public_url!r}; "
+                "preserving installed Admin Console URL"
+            )
 
     updates["DJANGO_ALLOWED_HOSTS"] = ",".join(allowed_hosts)
     updates["CSRF_TRUSTED_ORIGINS"] = ",".join(csrf_origins)
@@ -369,12 +382,14 @@ def main() -> None:
     parser.add_argument("--env-file", required=True, type=pathlib.Path)
     parser.add_argument("--direct-host", default="")
     parser.add_argument("--public-url", default="")
+    parser.add_argument("--admin-public-url", default="")
     parser.add_argument("--runtime-env-file", type=pathlib.Path)
     arguments = parser.parse_args()
     apply_configuration(
         arguments.env_file,
         arguments.direct_host,
         arguments.public_url,
+        arguments.admin_public_url,
         arguments.runtime_env_file,
     )
 

--- a/deploy/installer/install.sh
+++ b/deploy/installer/install.sh
@@ -15,6 +15,7 @@ PRINT_CONFIG=0
 SESSION_STARTED=0
 PUBLIC_HOST="${HFL_PUBLIC_HOST:-}"
 PUBLIC_URL="${HFL_PUBLIC_URL:-}"
+ADMIN_PUBLIC_URL="${HFL_ADMIN_PUBLIC_URL:-}"
 RUNTIME_ENV_FILE="${HFL_RUNTIME_ENV_FILE:-}"
 SHOW_GENERATED_CREDENTIALS="${HFL_SHOW_GENERATED_CREDENTIALS:-auto}"
 UPGRADE_RECOVERY_ARMED=0
@@ -50,6 +51,7 @@ Options:
     --hfl-only              Skip bundled SourceLens even when sourcelens/ is present
     --direct-host HOST      Direct listener host or IP used for local access URLs
     --public-url URL        Optional canonical browser origin; invalid values only warn
+    --admin-public-url URL  Optional Admin Console browser origin; invalid values only warn
     --runtime-env-file FILE Apply staged Turnstile settings from a root-only regular file
 
   upgrade:
@@ -65,6 +67,7 @@ Options:
     --yes                   Non-interactive: continue when target version equals installed version
     --direct-host HOST      Direct listener host or IP used for local access URLs
     --public-url URL        Optional canonical browser origin; invalid values only warn
+    --admin-public-url URL  Optional Admin Console browser origin; invalid values only warn
     --runtime-env-file FILE Apply staged Turnstile settings from a root-only regular file
 
   uninstall:
@@ -186,6 +189,7 @@ upgrade_tmp=${UPGRADE_TMP}
 bridge_network=${HFL_BRIDGE_NETWORK}
 public_host=${PUBLIC_HOST:-<auto>}
 public_url=${PUBLIC_URL:-<none>}
+admin_public_url=${ADMIN_PUBLIC_URL:-<none>}
 runtime_env_file=$([[ -n "${RUNTIME_ENV_FILE}" ]] && printf '<provided>' || printf '<none>')
 show_generated_credentials=${SHOW_GENERATED_CREDENTIALS}
 log_file=${LOG_FILE:-<none>}
@@ -816,7 +820,7 @@ PY
 
 apply_runtime_configuration() {
 	local helper="${ROOT}/apply-runtime-config.py"
-	local -a args=(--env-file "${ROOT}/.env" --direct-host "${PUBLIC_HOST}" --public-url "${PUBLIC_URL}")
+	local -a args=(--env-file "${ROOT}/.env" --direct-host "${PUBLIC_HOST}" --public-url "${PUBLIC_URL}" --admin-public-url "${ADMIN_PUBLIC_URL}")
 	[[ -f "${helper}" ]] || die "missing runtime configuration helper: ${helper}"
 	if [[ -n "${RUNTIME_ENV_FILE}" ]]; then
 		args+=(--runtime-env-file "${RUNTIME_ENV_FILE}")
@@ -2110,6 +2114,7 @@ cmd_install() {
 		--hfl-only) sourcelens_mode=0 ;;
 		--direct-host) [[ $# -ge 2 && -n "${2:-}" ]] || die "--direct-host requires a value" 2; PUBLIC_HOST="$2"; shift ;;
 		--public-url) [[ $# -ge 2 ]] || die "--public-url requires a value" 2; PUBLIC_URL="$2"; shift ;;
+		--admin-public-url) [[ $# -ge 2 ]] || die "--admin-public-url requires a value" 2; ADMIN_PUBLIC_URL="$2"; shift ;;
 		--runtime-env-file) [[ $# -ge 2 && -n "${2:-}" ]] || die "--runtime-env-file requires a path" 2; RUNTIME_ENV_FILE="$2"; shift ;;
 		--allow-main-build) allow_main_build=1 ;;
 		*) die "unknown install option: $1" 2 ;;
@@ -2795,6 +2800,7 @@ cmd_upgrade() {
 		--yes) UPGRADE_YES=1 ;;
 		--direct-host) [[ $# -ge 2 && -n "${2:-}" ]] || die "--direct-host requires a value" 2; PUBLIC_HOST="$2"; shift ;;
 		--public-url) [[ $# -ge 2 ]] || die "--public-url requires a value" 2; PUBLIC_URL="$2"; shift ;;
+		--admin-public-url) [[ $# -ge 2 ]] || die "--admin-public-url requires a value" 2; ADMIN_PUBLIC_URL="$2"; shift ;;
 		--runtime-env-file) [[ $# -ge 2 && -n "${2:-}" ]] || die "--runtime-env-file requires a path" 2; RUNTIME_ENV_FILE="$2"; shift ;;
 		--allow-main-build) allow_main_build=1 ;;
 		*) die "unknown upgrade option: $1" 2 ;;

--- a/src/backend/apps/lens_bridge/api/views.py
+++ b/src/backend/apps/lens_bridge/api/views.py
@@ -822,6 +822,7 @@ class LensCopilotSessionViewSet(OrgScopedMixin, viewsets.ViewSet):
                     "session_id": link.id,
                     "messages": [],
                     "active_run": None,
+                    "run_outcomes": [],
                     "lifecycle_status": link.lifecycle_status,
                     "lifecycle_error": link.lifecycle_error,
                 }

--- a/src/backend/apps/lens_bridge/services/copilot.py
+++ b/src/backend/apps/lens_bridge/services/copilot.py
@@ -300,6 +300,8 @@ def get_active_run_payload(link: LensSessionLink) -> dict[str, Any] | None:
 
 
 def sync_copilot_session(link: LensSessionLink) -> dict[str, Any]:
+    from apps.lens_bridge.services import usage
+
     messages = _fetch_session_messages(link)
     _update_last_assistant_message_at(link, messages)
     active_run = None
@@ -310,6 +312,7 @@ def sync_copilot_session(link: LensSessionLink) -> dict[str, Any]:
         "session_id": link.id,
         "messages": messages,
         "active_run": active_run,
+        "run_outcomes": usage.run_outcomes_for_messages(link, messages),
     }
 
 

--- a/src/backend/apps/lens_bridge/services/provisioning.py
+++ b/src/backend/apps/lens_bridge/services/provisioning.py
@@ -441,22 +441,33 @@ def ensure_lensnode_for_gateway(
     gateway: Node,
     name: str | None = None,
     owner_user=None,
-    scope: str = "",
+    scope: str | None = None,
 ) -> LensGatewayLink:
     """Idempotently associate a SourceLens LensNode with an HFL data gateway."""
     if gateway.role != NodeRole.GATEWAY:
         raise ValidationError({"gateway_id": "Node is not a data gateway."})
 
-    normalized_scope = (scope or "").strip().lower()
-    is_platform = normalized_scope == LensGatewayLink.GatewayScope.PLATFORM
-    desired_scope = (
-        LensGatewayLink.GatewayScope.PLATFORM
-        if is_platform
-        else LensGatewayLink.GatewayScope.USER
+    from apps.node.services.internal.local_platform_gateway import (
+        is_local_platform_gateway_metadata,
     )
+
+    normalized_scope = (scope or "").strip().lower() or None
+    if normalized_scope not in {
+        None,
+        LensGatewayLink.GatewayScope.PLATFORM,
+        LensGatewayLink.GatewayScope.USER,
+    }:
+        raise ValidationError({"scope": "Data gateway scope is invalid."})
+    if normalized_scope is None and is_local_platform_gateway_metadata(gateway.metadata):
+        normalized_scope = LensGatewayLink.GatewayScope.PLATFORM
+
+    desired_scope = normalized_scope or LensGatewayLink.GatewayScope.USER
     desired_origin = (
-        LensGatewayLink.Origin.PLATFORM if is_platform else LensGatewayLink.Origin.USER
+        LensGatewayLink.Origin.PLATFORM
+        if desired_scope == LensGatewayLink.GatewayScope.PLATFORM
+        else LensGatewayLink.Origin.USER
     )
+    is_platform = desired_scope == LensGatewayLink.GatewayScope.PLATFORM
     link, created = LensGatewayLink.objects.get_or_create(
         organization=org,
         gateway=gateway,
@@ -468,7 +479,7 @@ def ensure_lensnode_for_gateway(
         },
     )
 
-    if not created:
+    if not created and normalized_scope is not None:
         update_fields = []
         if link.scope != desired_scope:
             link.scope = desired_scope
@@ -476,17 +487,17 @@ def ensure_lensnode_for_gateway(
         if link.origin != desired_origin:
             link.origin = desired_origin
             update_fields.append("origin")
+        if is_platform and link.owner_user_id is not None:
+            link.owner_user = None
+            update_fields.append("owner_user")
         if not is_platform and owner_user is not None and link.owner_user_id is None:
             link.owner_user = owner_user
             update_fields.append("owner_user")
         if update_fields:
             link.save(update_fields=[*update_fields, "updated_at"])
 
+    is_platform = link.scope == LensGatewayLink.GatewayScope.PLATFORM
     if is_platform and not link.is_platform_default:
-        from apps.node.services.internal.local_platform_gateway import (
-            is_local_platform_gateway_metadata,
-        )
-
         has_platform_default = LensGatewayLink.objects.filter(
             organization=org,
             scope=LensGatewayLink.GatewayScope.PLATFORM,
@@ -540,7 +551,7 @@ def enable_ai_on_gateway(
         org=org,
         gateway=gateway,
         name=name,
-        scope=scope or "",
+        scope=scope,
     )
     if scope:
         desired = scope.strip().lower()
@@ -584,7 +595,7 @@ def provision_gateway_lens_on_register(
     org: Organization,
     gateway: Node,
     owner_user=None,
-    scope: str = "",
+    scope: str | None = None,
 ) -> dict[str, Any] | None:
     """Auto-provision LensNode when a gateway registers; returns enroll config or None."""
     from apps.lens_bridge.deploy import lens_bridge_configured

--- a/src/backend/apps/lens_bridge/services/usage.py
+++ b/src/backend/apps/lens_bridge/services/usage.py
@@ -223,6 +223,79 @@ def capture_run_usage(link: LensSessionLink, run: dict[str, Any]) -> LensUsageLe
     return row
 
 
+def _public_run_failure(status: str, raw_error: str) -> tuple[str, str]:
+    """Return a stable, tenant-safe error code and message for a terminal run."""
+    normalized_status = str(status or "").strip().lower()
+    normalized_error = str(raw_error or "").strip().upper()
+    if normalized_status == "cancelled":
+        return "RUN_CANCELLED", "The AI response was cancelled."
+    if "TIMEOUT" in normalized_error:
+        return (
+            "MODEL_TIMEOUT",
+            "The AI model timed out. Try again or choose another model.",
+        )
+    if any(
+        marker in normalized_error
+        for marker in ("MODEL", "PROVIDER", "QUOTA", "BALANCE", "PAYMENT")
+    ):
+        return (
+            "MODEL_PROVIDER_ERROR",
+            "The AI model provider rejected the request. Check model availability, quota, or account balance, then try again.",
+        )
+    return (
+        "AI_RUN_FAILED",
+        "The AI response failed. Try again or contact your administrator.",
+    )
+
+
+def run_outcomes_for_messages(
+    link: LensSessionLink,
+    messages: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Return durable, sanitized terminal outcomes for runs in this message page."""
+    ordered_run_ids: list[uuid.UUID] = []
+    seen = set()
+    for message in messages:
+        raw_run_id = message.get("run")
+        if not raw_run_id:
+            continue
+        try:
+            run_id = uuid.UUID(str(raw_run_id))
+        except (TypeError, ValueError):
+            continue
+        if run_id in seen:
+            continue
+        seen.add(run_id)
+        ordered_run_ids.append(run_id)
+    if not ordered_run_ids:
+        return []
+
+    rows = {
+        row.sl_run_uuid: row
+        for row in LensUsageLedger.objects.filter(
+            session_link=link,
+            sl_run_uuid__in=ordered_run_ids,
+            run_status__in={"failed", "cancelled"},
+        )
+    }
+    outcomes = []
+    for run_id in ordered_run_ids:
+        row = rows.get(run_id)
+        if row is None:
+            continue
+        error_code, message = _public_run_failure(row.run_status, row.run_error)
+        outcomes.append(
+            {
+                "run_uuid": str(run_id),
+                "status": row.run_status,
+                "error_code": error_code,
+                "message": message,
+                "finished_at": row.finished_at,
+            }
+        )
+    return outcomes
+
+
 def _session_by_assistant_name(org, user) -> dict[str, LensSessionLink]:
     rows = LensSessionLink.objects.filter(
         organization=org,

--- a/src/backend/apps/lens_bridge/tests/test_copilot_sessions.py
+++ b/src/backend/apps/lens_bridge/tests/test_copilot_sessions.py
@@ -1,10 +1,13 @@
+import uuid
+from unittest.mock import patch
+
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 from django.urls import reverse
 from rest_framework.test import APIClient
 
 from apps.iam.services.registration_service import provision_registered_user_tenant
-from apps.lens_bridge.models import LensSessionLink
+from apps.lens_bridge.models import LensSessionLink, LensSlUserLink, LensUsageLedger
 
 
 class CopilotSessionApiTests(TestCase):
@@ -42,3 +45,78 @@ class CopilotSessionApiTests(TestCase):
             payload["lifecycle_status"],
             LensSessionLink.LifecycleStatus.PROVISIONING,
         )
+        self.assertEqual(payload["run_outcomes"], [])
+
+    @patch("apps.lens_bridge.services.sl_client.request_json")
+    def test_sync_returns_a_durable_sanitized_failed_run_outcome(self, request_json):
+        run_uuid = uuid.uuid4()
+        session_uuid = uuid.uuid4()
+        self.session.lifecycle_status = LensSessionLink.LifecycleStatus.READY
+        self.session.provision_phase = LensSessionLink.ProvisionPhase.READY
+        self.session.sl_session_uuid = session_uuid
+        self.session.active_run_uuid = run_uuid
+        self.session.active_run_status = "running"
+        self.session.save(
+            update_fields=[
+                "lifecycle_status",
+                "provision_phase",
+                "sl_session_uuid",
+                "active_run_uuid",
+                "active_run_status",
+                "updated_at",
+            ]
+        )
+        LensSlUserLink.objects.create(
+            hfl_user=self.user,
+            sl_user_id=41,
+            sl_username="hfl-u-41",
+            provision_status=LensSlUserLink.ProvisionStatus.READY,
+        )
+        LensUsageLedger.objects.create(
+            organization=self.org,
+            hfl_user=self.user,
+            session_link=self.session,
+            sl_user_id=41,
+            sl_run_uuid=run_uuid,
+            run_status="running",
+            question="List files",
+            occurred_at=self.session.created_at,
+        )
+
+        def response_for(_method, path, **_kwargs):
+            if path.endswith("/messages/"):
+                return [
+                    {
+                        "uuid": str(uuid.uuid4()),
+                        "role": "user",
+                        "content": "List files",
+                        "run": str(run_uuid),
+                    }
+                ]
+            if path.endswith(f"/runs/{run_uuid}/"):
+                return {
+                    "uuid": str(run_uuid),
+                    "status": "failed",
+                    "error": "MODEL_STREAM_ERROR api_key=must-not-leak",
+                }
+            raise AssertionError(path)
+
+        request_json.side_effect = response_for
+        response = self.client.get(
+            reverse("lens-copilot-session-sync", kwargs={"pk": self.session.pk}),
+            HTTP_X_ORG_KEY=self.org.key,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        payload = payload.get("data", payload)
+        self.assertIsNone(payload["active_run"])
+        self.assertEqual(len(payload["run_outcomes"]), 1)
+        outcome = payload["run_outcomes"][0]
+        self.assertEqual(outcome["run_uuid"], str(run_uuid))
+        self.assertEqual(outcome["status"], "failed")
+        self.assertEqual(outcome["error_code"], "MODEL_PROVIDER_ERROR")
+        self.assertIn("quota", outcome["message"])
+        self.assertNotIn("must-not-leak", str(payload))
+        self.session.refresh_from_db()
+        self.assertIsNone(self.session.active_run_uuid)

--- a/src/backend/apps/node/api/views/node.py
+++ b/src/backend/apps/node/api/views/node.py
@@ -388,7 +388,7 @@ class NodeViewSet(OrgScopedMixin, SoftDeleteDestroyMixin, viewsets.ModelViewSet)
                 org=org,
                 gateway=node,
                 owner_user=token_row.created_by if token_row is not None else None,
-                scope=token_row.gateway_scope if token_row is not None else "",
+                scope=token_row.gateway_scope if token_row is not None else None,
             )
             if lens:
                 payload["lens"] = lens

--- a/src/backend/apps/node/management/commands/ensure_local_platform_gateway_enrollment.py
+++ b/src/backend/apps/node/management/commands/ensure_local_platform_gateway_enrollment.py
@@ -13,6 +13,7 @@ from apps.node.services.internal.local_platform_gateway import (
     LOCAL_PLATFORM_GATEWAY_METADATA,
     ensure_local_platform_gateway_token,
     platform_gateway_api_base,
+    reconcile_local_platform_gateway_links,
 )
 
 OUTPUT_PREFIX = "HFL_LOCAL_PLATFORM_GATEWAY_ENROLLMENT="
@@ -29,6 +30,7 @@ class Command(BaseCommand):
         except ValueError as exc:
             raise CommandError(str(exc)) from exc
         token = ensure_local_platform_gateway_token()
+        reconcile_local_platform_gateway_links()
         managed_node_ids = list(
             Node.objects.filter(
                 organization=token.organization,

--- a/src/backend/apps/node/services/internal/local_platform_gateway.py
+++ b/src/backend/apps/node/services/internal/local_platform_gateway.py
@@ -110,3 +110,77 @@ def registration_metadata(
     if installer_managed:
         metadata.update(LOCAL_PLATFORM_GATEWAY_METADATA)
     return metadata
+
+
+@transaction.atomic
+def reconcile_local_platform_gateway_links() -> int:
+    """Repair installer-managed Gateway links without changing user Gateways."""
+    from apps.node.models import Node
+
+    org = platform_lens.get_or_create_platform_org()
+    managed_gateway_ids = list(
+        Node.objects.filter(
+            organization=org,
+            role=NodeRole.GATEWAY,
+            is_deleted=False,
+            metadata__managed_by=LOCAL_PLATFORM_GATEWAY_METADATA["managed_by"],
+            metadata__deployment_mode=LOCAL_PLATFORM_GATEWAY_METADATA[
+                "deployment_mode"
+            ],
+            metadata__install_key=LOCAL_PLATFORM_GATEWAY_METADATA["install_key"],
+        )
+        .order_by("id")
+        .values_list("id", flat=True)
+    )
+    if not managed_gateway_ids:
+        return 0
+
+    links = list(
+        LensGatewayLink.objects.select_for_update()
+        .filter(
+            organization=org,
+            gateway_id__in=managed_gateway_ids,
+            is_deleted=False,
+        )
+        .order_by("id")
+    )
+    if not links:
+        return 0
+
+    changed = 0
+    for link in links:
+        update_fields = []
+        if link.scope != LensGatewayLink.GatewayScope.PLATFORM:
+            link.scope = LensGatewayLink.GatewayScope.PLATFORM
+            update_fields.append("scope")
+        if link.origin != LensGatewayLink.Origin.PLATFORM:
+            link.origin = LensGatewayLink.Origin.PLATFORM
+            update_fields.append("origin")
+        if link.owner_user_id is not None:
+            link.owner_user = None
+            update_fields.append("owner_user")
+        if update_fields:
+            link.save(update_fields=[*update_fields, "updated_at"])
+            changed += 1
+
+    other_default_exists = LensGatewayLink.objects.filter(
+        organization=org,
+        scope=LensGatewayLink.GatewayScope.PLATFORM,
+        is_platform_default=True,
+        is_deleted=False,
+    ).exclude(gateway_id__in=managed_gateway_ids).exists()
+    preferred_id = None
+    if not other_default_exists:
+        preferred_id = next(
+            (link.id for link in links if link.is_platform_default),
+            links[0].id,
+        )
+
+    for link in links:
+        should_be_default = link.id == preferred_id
+        if link.is_platform_default != should_be_default:
+            link.is_platform_default = should_be_default
+            link.save(update_fields=["is_platform_default", "updated_at"])
+            changed += 1
+
+    return changed

--- a/src/backend/apps/node/tests/test_local_platform_gateway.py
+++ b/src/backend/apps/node/tests/test_local_platform_gateway.py
@@ -80,6 +80,14 @@ class LocalPlatformGatewayEnrollmentTests(TestCase):
             role=NodeRole.GATEWAY,
             metadata=dict(LOCAL_PLATFORM_GATEWAY_METADATA),
         )
+        stale_link = LensGatewayLink.objects.create(
+            organization=org,
+            gateway=managed,
+            scope=LensGatewayLink.GatewayScope.USER,
+            origin=LensGatewayLink.Origin.USER,
+            sl_lensnode_uuid="0d16cf33-5c21-471e-9cbd-b5e9819ff19c",
+            is_platform_default=True,
+        )
         Node.objects.create(
             organization=org,
             name="partial-metadata-gateway",
@@ -102,12 +110,16 @@ class LocalPlatformGatewayEnrollmentTests(TestCase):
         )
         self.assertTrue(payload["token"])
         self.assertEqual(payload["managed_node_ids"], [managed.id])
+        stale_link.refresh_from_db()
+        self.assertEqual(stale_link.scope, LensGatewayLink.GatewayScope.PLATFORM)
+        self.assertEqual(stale_link.origin, LensGatewayLink.Origin.PLATFORM)
+        self.assertTrue(stale_link.is_platform_default)
 
     @mock.patch(
         "apps.lens_bridge.services.provisioning.provision_gateway_lens_on_register",
         return_value=None,
     )
-    def test_installer_metadata_survives_followup_heartbeat(self, _mock_provision):
+    def test_installer_metadata_survives_followup_heartbeat(self, mock_provision):
         token = ensure_local_platform_gateway_token()
         first_request = self.factory.post(
             "/api/v1/node/nodes/heartbeat/",
@@ -146,6 +158,64 @@ class LocalPlatformGatewayEnrollmentTests(TestCase):
         node.refresh_from_db()
         self.assertEqual(node.metadata["install_key"], LOCAL_PLATFORM_GATEWAY_INSTALL_KEY)
         self.assertEqual(node.metadata["agent_version"], "1.0.0")
+        self.assertEqual(
+            mock_provision.call_args_list[0].kwargs["scope"],
+            LensGatewayLink.GatewayScope.PLATFORM,
+        )
+        self.assertIsNone(mock_provision.call_args_list[1].kwargs["scope"])
+
+    def test_managed_gateway_repairs_stale_scope_without_explicit_token_scope(self):
+        org = platform_lens.get_or_create_platform_org()
+        gateway = Node.objects.create(
+            organization=org,
+            name="managed-gateway",
+            role=NodeRole.GATEWAY,
+            metadata=dict(LOCAL_PLATFORM_GATEWAY_METADATA),
+        )
+        link = LensGatewayLink.objects.create(
+            organization=org,
+            gateway=gateway,
+            scope=LensGatewayLink.GatewayScope.USER,
+            origin=LensGatewayLink.Origin.USER,
+            sl_lensnode_uuid="5ed4b4d1-b9b0-456d-8d73-cc88d948877b",
+        )
+
+        result = provisioning.ensure_lensnode_for_gateway(
+            org=org,
+            gateway=gateway,
+            scope=None,
+        )
+
+        result.refresh_from_db()
+        self.assertEqual(result.pk, link.pk)
+        self.assertEqual(result.scope, LensGatewayLink.GatewayScope.PLATFORM)
+        self.assertEqual(result.origin, LensGatewayLink.Origin.PLATFORM)
+        self.assertTrue(result.is_platform_default)
+
+    def test_unknown_scope_preserves_existing_non_platform_identity(self):
+        org = platform_lens.get_or_create_platform_org()
+        gateway = Node.objects.create(
+            organization=org,
+            name="external-gateway",
+            role=NodeRole.GATEWAY,
+        )
+        LensGatewayLink.objects.create(
+            organization=org,
+            gateway=gateway,
+            scope=LensGatewayLink.GatewayScope.USER,
+            origin=LensGatewayLink.Origin.EXTERNAL,
+            sl_lensnode_uuid="a3b9975f-cded-4c0a-a754-ec6f954d2b2c",
+        )
+
+        result = provisioning.ensure_lensnode_for_gateway(
+            org=org,
+            gateway=gateway,
+            scope=None,
+        )
+
+        result.refresh_from_db()
+        self.assertEqual(result.scope, LensGatewayLink.GatewayScope.USER)
+        self.assertEqual(result.origin, LensGatewayLink.Origin.EXTERNAL)
 
     @mock.patch(
         "apps.lens_bridge.services.provisioning.sl_client.request_json",

--- a/src/frontend/src/lib/lensApi.ts
+++ b/src/frontend/src/lib/lensApi.ts
@@ -333,8 +333,17 @@ export type LensCopilotSyncResponse = {
   session_id: number
   messages: LensChatMessage[]
   active_run: LensCopilotActiveRun | null
+  run_outcomes: LensCopilotRunOutcome[]
   last_assistant_message_at?: string | null
   has_unread?: boolean
+}
+
+export type LensCopilotRunOutcome = {
+  run_uuid: string
+  status: 'failed' | 'cancelled' | string
+  error_code: string
+  message: string
+  finished_at?: string | null
 }
 
 export type LensRun = {

--- a/src/frontend/src/pages/insight/InsightCopilot.vue
+++ b/src/frontend/src/pages/insight/InsightCopilot.vue
@@ -26,6 +26,7 @@ import {
   retryCopilotSession,
   type LensChatMessage,
   type LensCopilotActiveRun,
+  type LensCopilotRunOutcome,
   type LensCopilotAssistant,
   type LensGatewayInsight,
   type LensCopilotGatewayOption,
@@ -41,6 +42,7 @@ import CopilotMessageList from './copilot/CopilotMessageList.vue'
 import CopilotSessionSidebar, { type SessionGroupKey, type SessionRow } from './copilot/CopilotSessionSidebar.vue'
 import DangerConfirmDialog from '../../components/DangerConfirmDialog.vue'
 import type { CopilotDisplayMessage } from './copilot/types'
+import { appendRunOutcomeMessages } from './copilot/runOutcomes'
 import { Menu } from 'lucide-vue-next'
 import { useResponsiveLayout } from '../../composables/useResponsiveLayout'
 
@@ -142,9 +144,16 @@ function mapApiMessage(row: LensChatMessage): CopilotDisplayMessage | null {
   }
 }
 
-function applyMessagesFromSync(sessionId: number, rows: LensChatMessage[]) {
+function applyMessagesFromSync(
+  sessionId: number,
+  rows: LensChatMessage[],
+  runOutcomes: LensCopilotRunOutcome[],
+) {
   const list = Array.isArray(rows) ? rows : []
-  const mapped = list.map(mapApiMessage).filter(Boolean) as CopilotDisplayMessage[]
+  const mapped = appendRunOutcomeMessages(
+    list.map(mapApiMessage).filter(Boolean) as CopilotDisplayMessage[],
+    runOutcomes,
+  )
   const session = sessions.value.find((row) => row.id === sessionId)
   messagesBySession.value = {
     ...messagesBySession.value,
@@ -233,11 +242,15 @@ const activeStream = computed(() => {
   return getSessionRunStream(id)
 })
 
-const showLiveStream = computed(() => {
+const runInProgress = computed(() => {
   const stream = activeStream.value
   if (!stream) return false
   return stream.streamAttached || isActiveRunStatus(stream.runStatus)
 })
+
+const showLiveStream = computed(
+  () => runInProgress.value || Boolean(activeStream.value?.streamError),
+)
 
 const composerDisabled = computed(() => {
   if (!bridgeReady.value || activeSessionId.value == null) return true
@@ -245,7 +258,7 @@ const composerDisabled = computed(() => {
   if (session && session.lifecycle_status && session.lifecycle_status !== 'ready') return true
   const stream = activeStream.value
   if (!stream) return false
-  return isActiveRunStatus(stream.runStatus)
+  return runInProgress.value
 })
 
 const bubbleTag = computed(() => activeAssistant.value?.name ?? '')
@@ -667,7 +680,7 @@ onUnmounted(() => {
         <CopilotComposer
           v-if="activeSession?.lifecycle_status === 'ready'"
           v-model="input"
-          :sending="showLiveStream"
+          :sending="runInProgress"
           :disabled="composerDisabled"
           @send="sendMessage"
           @stop="stopStreaming"

--- a/src/frontend/src/pages/insight/copilot/CopilotMessageList.vue
+++ b/src/frontend/src/pages/insight/copilot/CopilotMessageList.vue
@@ -223,7 +223,7 @@ const showLiveRow = computed(() => props.streaming)
               msg.starterChips ? 'message-card--welcome' : '',
             ]"
           >
-            <div v-if="msg.starterChips" class="message-text">{{ msg.text }}</div>
+            <div v-if="msg.starterChips || msg.isError" class="message-text">{{ msg.text }}</div>
             <div v-else-if="msg.role === 'assistant' && msg.text" class="message-markdown">
               <CopilotMarkdown :content="msg.text" />
             </div>

--- a/src/frontend/src/pages/insight/copilot/runOutcomes.test.ts
+++ b/src/frontend/src/pages/insight/copilot/runOutcomes.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import { appendRunOutcomeMessages } from './runOutcomes'
+
+describe('appendRunOutcomeMessages', () => {
+  it('adds a durable failure after the matching user message', () => {
+    const merged = appendRunOutcomeMessages(
+      [{ id: 'question', role: 'user', text: 'List files', runId: 'run-1' }],
+      [{
+        run_uuid: 'run-1',
+        status: 'failed',
+        error_code: 'MODEL_PROVIDER_ERROR',
+        message: 'Check model quota.',
+      }],
+    )
+
+    expect(merged).toHaveLength(2)
+    expect(merged[1]).toMatchObject({
+      id: 'run-outcome-run-1',
+      role: 'assistant',
+      isError: true,
+      text: 'Check model quota.',
+    })
+  })
+
+  it('does not duplicate an outcome when an assistant response exists', () => {
+    const merged = appendRunOutcomeMessages(
+      [
+        { id: 'question', role: 'user', text: 'List files', runId: 'run-1' },
+        { id: 'answer', role: 'assistant', text: 'Done', runId: 'run-1' },
+      ],
+      [{
+        run_uuid: 'run-1',
+        status: 'failed',
+        error_code: 'MODEL_PROVIDER_ERROR',
+        message: 'Check model quota.',
+      }],
+    )
+
+    expect(merged).toHaveLength(2)
+  })
+})

--- a/src/frontend/src/pages/insight/copilot/runOutcomes.ts
+++ b/src/frontend/src/pages/insight/copilot/runOutcomes.ts
@@ -1,0 +1,32 @@
+import type { LensCopilotRunOutcome } from '../../../lib/lensApi'
+import type { CopilotDisplayMessage } from './types'
+
+export function appendRunOutcomeMessages(
+  messages: CopilotDisplayMessage[],
+  outcomes: LensCopilotRunOutcome[],
+): CopilotDisplayMessage[] {
+  const assistantRuns = new Set(
+    messages
+      .filter((message) => message.role === 'assistant' && message.runId)
+      .map((message) => message.runId as string),
+  )
+  const outcomesByRun = new Map(outcomes.map((outcome) => [outcome.run_uuid, outcome]))
+  const merged: CopilotDisplayMessage[] = []
+  for (const message of messages) {
+    merged.push(message)
+    if (message.role !== 'user' || !message.runId || assistantRuns.has(message.runId)) {
+      continue
+    }
+    const outcome = outcomesByRun.get(message.runId)
+    if (!outcome) continue
+    merged.push({
+      id: `run-outcome-${outcome.run_uuid}`,
+      role: 'assistant',
+      text: outcome.message,
+      isError: true,
+      createdAt: outcome.finished_at || message.createdAt,
+      runId: outcome.run_uuid,
+    })
+  }
+  return merged
+}

--- a/src/frontend/src/stores/copilotRunStore.ts
+++ b/src/frontend/src/stores/copilotRunStore.ts
@@ -16,7 +16,11 @@ import {
 } from '../composables/useLensRunStream'
 
 export type CopilotSyncHandlers = {
-  onMessages: (sessionId: number, messages: LensCopilotSyncResponse['messages']) => void
+  onMessages: (
+    sessionId: number,
+    messages: LensCopilotSyncResponse['messages'],
+    runOutcomes: LensCopilotSyncResponse['run_outcomes'],
+  ) => void
   onSessionMeta?: (sessionId: number, activeRun: LensCopilotActiveRun | null) => void
   onSessionSync?: (sessionId: number, payload: LensCopilotSyncResponse) => void
 }
@@ -49,7 +53,7 @@ export function useCopilotRunStore() {
     opts?: { attachStream?: boolean },
   ) {
     const payload = await syncCopilotSession(sessionId)
-    handlers.onMessages(sessionId, payload.messages)
+    handlers.onMessages(sessionId, payload.messages, payload.run_outcomes || [])
     handlers.onSessionMeta?.(sessionId, payload.active_run)
     handlers.onSessionSync?.(sessionId, payload)
     if (payload.active_run && isActiveRunStatus(payload.active_run.status)) {

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -185,10 +185,13 @@ grep -F 'existing Docker daemon is not reachable' \
 	"${ROOT}/.github/scripts/remote-deploy.sh" >/dev/null
 grep -F 'turnstile_enabled: ${{ vars.PREPROD_TURNSTILE_ENABLED' "${workflow}" >/dev/null
 grep -F 'public_url: ${{ vars.PREPROD_PUBLIC_URL }}' "${workflow}" >/dev/null
+grep -F 'admin_public_url: ${{ vars.PREPROD_ADMIN_PUBLIC_URL }}' "${workflow}" >/dev/null
 grep -F 'turnstile_enabled: ${{ vars.TEST_TURNSTILE_ENABLED' "${workflow}" >/dev/null
 grep -F 'public_url: ${{ vars.TEST_PUBLIC_URL }}' "${workflow}" >/dev/null
+grep -F 'admin_public_url: ${{ vars.TEST_ADMIN_PUBLIC_URL }}' "${workflow}" >/dev/null
 grep -F 'turnstile_enabled: ${{ vars.PROD_TURNSTILE_ENABLED' "${production_workflow}" >/dev/null
 grep -F 'public_url: ${{ vars.PROD_PUBLIC_URL }}' "${production_workflow}" >/dev/null
+grep -F 'admin_public_url: ${{ vars.PROD_ADMIN_PUBLIC_URL }}' "${production_workflow}" >/dev/null
 grep -F 'hfl_insecure_tls: ${{ vars.TEST_HFL_INSECURE_TLS }}' "${workflow}" >/dev/null
 grep -F 'hfl_insecure_tls: ${{ vars.PREPROD_HFL_INSECURE_TLS }}' "${workflow}" >/dev/null
 grep -F 'hfl_insecure_tls: ${{ vars.PREPROD_HFL_INSECURE_TLS }}' "${release_workflow}" >/dev/null
@@ -522,6 +525,7 @@ if grep -F 'install.sh" platform-gateway ensure' "${remote_deploy}" >/dev/null; 
 	exit 1
 fi
 grep -F -- '--public-url) PUBLIC_URL=' "${remote_deploy}" >/dev/null
+grep -F -- '--admin-public-url) ADMIN_PUBLIC_URL=' "${remote_deploy}" >/dev/null
 grep -F -- '--direct-host) DIRECT_HOST=' "${remote_deploy}" >/dev/null
 grep -F -- '--runtime-env-file "${RUNTIME_ENV_FILE}"' "${remote_deploy}" >/dev/null
 grep -F 'Download and Install Release' "${deploy_workflow}" >/dev/null

--- a/tools/quality/test-deployment-optional-config.sh
+++ b/tools/quality/test-deployment-optional-config.sh
@@ -52,6 +52,7 @@ runtime_output="$(python3 "${helper}" \
 	--env-file "${env_file}" \
 	--runtime-env-file "${runtime_file}" \
 	--public-url "https://hyperfilelens.com" \
+	--admin-public-url "https://admin.hyperfilelens.com" \
 	--direct-host "47.237.161.194")"
 if grep -E "pa\$\$ word|new-google-secret" <<<"${runtime_output}" >/dev/null; then
 	printf 'ERROR: runtime configuration output exposed the SMTP password\n' >&2
@@ -59,12 +60,12 @@ if grep -E "pa\$\$ word|new-google-secret" <<<"${runtime_output}" >/dev/null; th
 fi
 grep -Fx 'FRONTEND_URL=https://hyperfilelens.com' "${env_file}" >/dev/null
 grep -Fx 'LENS_GATEWAY_BASE_URL=https://hyperfilelens.com/sourcelens' "${env_file}" >/dev/null
-grep -Fx 'HFL_ADMIN_PUBLIC_URL=https://47.237.161.194:11444' "${env_file}" >/dev/null
+grep -Fx 'HFL_ADMIN_PUBLIC_URL=https://admin.hyperfilelens.com' "${env_file}" >/dev/null
 grep -Fx 'HFL_PLATFORM_GATEWAY_AUTO_DEPLOY=true' "${env_file}" >/dev/null
 grep -Fx 'HFL_INSECURE_TLS=0' "${env_file}" >/dev/null
-grep -E '^DJANGO_ALLOWED_HOSTS=.*47\.237\.161\.194.*hyperfilelens\.com' "${env_file}" >/dev/null
-grep -E '^CSRF_TRUSTED_ORIGINS=.*https://47\.237\.161\.194:11443.*https://hyperfilelens\.com' "${env_file}" >/dev/null
-grep -E '^CORS_ALLOWED_ORIGINS=.*https://47\.237\.161\.194:11443.*https://hyperfilelens\.com' "${env_file}" >/dev/null
+grep -E '^DJANGO_ALLOWED_HOSTS=.*47\.237\.161\.194.*hyperfilelens\.com.*admin\.hyperfilelens\.com' "${env_file}" >/dev/null
+grep -E '^CSRF_TRUSTED_ORIGINS=.*https://47\.237\.161\.194:11443.*https://hyperfilelens\.com.*https://admin\.hyperfilelens\.com' "${env_file}" >/dev/null
+grep -E '^CORS_ALLOWED_ORIGINS=.*https://47\.237\.161\.194:11443.*https://hyperfilelens\.com.*https://admin\.hyperfilelens\.com' "${env_file}" >/dev/null
 grep -Fx 'TURNSTILE_ENABLED=true' "${env_file}" >/dev/null
 grep -Fx 'TURNSTILE_SITE_KEY=new-site' "${env_file}" >/dev/null
 grep -Fx 'TURNSTILE_SECRET_KEY=new-secret' "${env_file}" >/dev/null
@@ -106,8 +107,10 @@ python3 "${helper}" \
 	--env-file "${invalid_env}" \
 	--runtime-env-file "${invalid_runtime}" \
 	--public-url "not a public URL" \
+	--admin-public-url "not an admin URL" \
 	--direct-host "47.237.161.194"
 grep -Fx 'FRONTEND_URL=https://hyperfilelens.com' "${invalid_env}" >/dev/null
+grep -Fx 'HFL_ADMIN_PUBLIC_URL=https://admin.hyperfilelens.com' "${invalid_env}" >/dev/null
 grep -Fx 'TURNSTILE_SITE_KEY=new-site' "${invalid_env}" >/dev/null
 grep -Fx 'TURNSTILE_SECRET_KEY=new-secret' "${invalid_env}" >/dev/null
 grep -Fx 'HFL_PLATFORM_GATEWAY_AUTO_DEPLOY=true' "${invalid_env}" >/dev/null


### PR DESCRIPTION
## Summary

- preserve trusted Platform Gateway scope across heartbeats and reconcile stale installer-managed gateway links during deployment
- persist sanitized terminal Copilot run failures and render durable error messages after streaming or page reload
- separate Admin Console browser URLs from SSH deployment hosts across TEST, PREPROD, and PROD workflows
- keep invalid optional Admin Console URLs warning-only so deployment remains resilient

## Validation

- 17 focused Django tests passed with PostgreSQL 17
- 437 frontend CI tests passed
- frontend production build passed
- runtime configuration and Platform Gateway auto-deploy contracts passed
- release contract and workflow YAML checks passed
- English-only source checks passed
- Ruff, shell/Python syntax, and git diff checks passed

## Configuration

Repository Variables TEST_ADMIN_PUBLIC_URL, PREPROD_ADMIN_PUBLIC_URL, and PROD_ADMIN_PUBLIC_URL are configured for their environment-specific port 11444 endpoints.

SourceLens source code is unchanged.