### PR TITLE
fix(auth): make Google OAuth configuration deployment-safe

### DIFF
--- a/.github/workflows/deploy_target.yml
+++ b/.github/workflows/deploy_target.yml
@@ -461,6 +461,34 @@ jobs:
           fi
           exit 0
 
+      - name: Check Google OAuth Readiness
+        shell: bash
+        run: |
+          set +e
+          output="$(ssh -i ~/.ssh/hyperfilelens_deploy \
+            -o BatchMode=yes \
+            -o StrictHostKeyChecking=yes \
+            -o ConnectTimeout=20 \
+            -o ServerAliveInterval=30 \
+            -o ServerAliveCountMax=20 \
+            -o TCPKeepAlive=yes \
+            -p "$DEPLOY_SSH_PORT" \
+            "$DEPLOY_SSH_USER@$DEPLOY_SSH_HOST" \
+            'cd /opt/hyperfilelens && docker compose exec -T api python manage.py check_google_oauth_readiness' \
+            2>&1)"
+          command_status=$?
+          set -e
+          printf '%s\n' "$output"
+          if (( command_status != 0 )); then
+            echo '::warning title=Google OAuth readiness::The local Google OAuth route or callback is not ready; core deployment remains healthy.'
+            printf '### Google OAuth readiness\n\nWarning: the local OAuth route or generated callback is not ready. Google Cloud callback authorization was not tested.\n' >> "$GITHUB_STEP_SUMMARY"
+          elif grep -F 'HFL_GOOGLE_OAUTH_STATUS=disabled' <<<"$output" >/dev/null; then
+            printf '### Google OAuth readiness\n\nSkipped: Google OAuth is disabled.\n' >> "$GITHUB_STEP_SUMMARY"
+          else
+            printf '### Google OAuth readiness\n\nPassed: the local OAuth route redirects to Google with the configured callback. Google Cloud callback authorization was not tested.\n' >> "$GITHUB_STEP_SUMMARY"
+          fi
+          exit 0
+
       - name: Configure Default AI Model
         env:
           AI_MODEL_PROVIDER: ${{ inputs.ai_model_provider }}

--- a/deploy/installer/install.sh
+++ b/deploy/installer/install.sh
@@ -2104,6 +2104,44 @@ print("\t".join([*(str(payload[key]).strip() for key in required), node_ids]))
 	ok "Installer-managed local platform Gateway is ready"
 }
 
+sync_optional_identity_settings() {
+	step "Synchronizing optional identity and email settings"
+	local output command_status
+	set +e
+	output="$(
+		compose_in_root exec -T api \
+			python manage.py ensure_deployment_identity_settings 2>&1
+	)"
+	command_status=$?
+	set -e
+	if [[ -n "${output}" ]]; then
+		printf '%s\n' "${output}"
+	fi
+	if [[ "${command_status}" -ne 0 ]]; then
+		warn "Optional identity or email settings could not be synchronized; core services remain available"
+		return 0
+	fi
+	if grep -F 'HFL_IDENTITY_STATUS=warning' <<<"${output}" >/dev/null; then
+		warn "Invalid optional identity or email settings were preserved"
+	else
+		ok "Optional identity and email settings synchronized"
+	fi
+
+	set +e
+	output="$(
+		compose_in_root exec -T api \
+			python manage.py check_google_oauth_readiness 2>&1
+	)"
+	command_status=$?
+	set -e
+	if [[ -n "${output}" ]]; then
+		printf '%s\n' "${output}"
+	fi
+	if [[ "${command_status}" -ne 0 ]]; then
+		warn "Google OAuth local route or generated callback is not ready; core services remain available"
+	fi
+}
+
 # --- Commands ---
 
 cmd_install() {
@@ -2177,6 +2215,7 @@ cmd_install() {
 	compose_in_root up -d --no-build --remove-orphans
 	wait_for_hfl_health || die "HyperFileLens failed its post-install health gate"
 	wait_for_sourcelens_health || die "bundled SourceLens failed its post-install health gate"
+	sync_optional_identity_settings
 	ensure_local_platform_gateway
 
 	step "[6/6] Done"
@@ -2211,6 +2250,7 @@ cmd_start() {
 	compose_in_root up -d --no-build --remove-orphans
 	wait_for_hfl_health || die "HyperFileLens failed its startup health gate"
 	wait_for_sourcelens_health || die "bundled SourceLens failed its startup health gate"
+	sync_optional_identity_settings
 	log "Services started"
 	compose_in_root ps
 }
@@ -2920,6 +2960,7 @@ cmd_upgrade() {
 	compose_in_root up -d --no-build --remove-orphans
 	wait_for_hfl_health || die "HyperFileLens failed its post-upgrade health gate"
 	wait_for_sourcelens_health || die "bundled SourceLens failed its post-upgrade health gate"
+	sync_optional_identity_settings
 	ensure_local_platform_gateway
 	UPGRADE_RECOVERY_ARMED=0
 	prune_old_managed_image_refs

--- a/dev/stack.sh
+++ b/dev/stack.sh
@@ -790,6 +790,51 @@ Notes
 EOF
 }
 
+sync_optional_identity_settings() {
+	local api_container health attempt output command_status
+	for ((attempt = 1; attempt <= 90; attempt++)); do
+		api_container="$(compose ps -q api 2>/dev/null || true)"
+		health=""
+		if [[ -n "${api_container}" ]]; then
+			health="$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' "${api_container}" 2>/dev/null || true)"
+		fi
+		[[ "${health}" == "healthy" ]] && break
+		sleep 1
+	done
+	if [[ "${health}" != "healthy" ]]; then
+		warn "Skipping optional identity settings sync because the API is not healthy yet"
+		return 0
+	fi
+
+	log "Synchronizing optional identity and email settings"
+	set +e
+	output="$(compose exec -T api python manage.py ensure_deployment_identity_settings 2>&1)"
+	command_status=$?
+	set -e
+	if [[ -n "${output}" ]]; then
+		printf '%s\n' "${output}"
+	fi
+	if [[ "${command_status}" -ne 0 ]]; then
+		warn "Optional identity or email settings could not be synchronized; the dev stack remains available"
+		return 0
+	elif grep -F 'HFL_IDENTITY_STATUS=warning' <<<"${output}" >/dev/null; then
+		warn "Invalid optional identity or email settings were preserved"
+	else
+		log "Optional identity and email settings synchronized"
+	fi
+
+	set +e
+	output="$(compose exec -T api python manage.py check_google_oauth_readiness 2>&1)"
+	command_status=$?
+	set -e
+	if [[ -n "${output}" ]]; then
+		printf '%s\n' "${output}"
+	fi
+	if [[ "${command_status}" -ne 0 ]]; then
+		warn "Google OAuth local route or generated callback is not ready; the dev stack remains available"
+	fi
+}
+
 cmd_up() {
 	apply_mirror_env_defaults
 	ensure_env_file
@@ -801,6 +846,7 @@ cmd_up() {
 	prepare_dev 0
 	log "Starting hot-reload HFL stack from explicitly prepared images"
 	compose up -d --no-build --pull never --remove-orphans
+	sync_optional_identity_settings
 	print_urls
 }
 
@@ -832,6 +878,7 @@ cmd_restart() {
 		log "Restarting only services whose image or configuration changed"
 		compose up -d --no-build --pull never --remove-orphans
 	fi
+	sync_optional_identity_settings
 	print_urls
 }
 

--- a/src/backend/apps/iam/auth/adapters.py
+++ b/src/backend/apps/iam/auth/adapters.py
@@ -9,7 +9,7 @@ import uuid
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
-from django.core.exceptions import PermissionDenied
+from django.core.exceptions import MultipleObjectsReturned, ObjectDoesNotExist, PermissionDenied
 from django.shortcuts import redirect
 
 from allauth.core.exceptions import ImmediateHttpResponse
@@ -17,7 +17,7 @@ from allauth.socialaccount.adapter import DefaultSocialAccountAdapter
 
 from apps.iam.services.oauth_error_events import build_oauth_error_redirect
 from apps.iam.services.registration_service import complete_social_user_registration
-from apps.platform_ops.services.internal.runtime_settings import google_oauth_enabled
+from apps.platform_ops.services.internal.runtime_settings import google_oauth_ready
 from common.deploy.site import tenant_public_url
 
 User = get_user_model()
@@ -26,12 +26,21 @@ logger = logging.getLogger(__name__)
 
 class CustomSocialAccountAdapter(DefaultSocialAccountAdapter):
     def is_open_for_signup(self, request, sociallogin):
-        return google_oauth_enabled()
+        return google_oauth_ready()
 
     def get_provider(self, request, provider, client_id=None):
-        if provider == "google" and not google_oauth_enabled():
-            raise PermissionDenied("Google OAuth is disabled")
-        return super().get_provider(request, provider, client_id=client_id)
+        if provider != "google":
+            return super().get_provider(request, provider, client_id=client_id)
+        if not google_oauth_ready():
+            raise PermissionDenied("Google OAuth is unavailable")
+        try:
+            return super().get_provider(request, provider, client_id=client_id)
+        except (MultipleObjectsReturned, ObjectDoesNotExist) as exc:
+            logger.error(
+                "Google OAuth provider configuration is not ready (%s)",
+                type(exc).__name__,
+            )
+            raise PermissionDenied("Google OAuth is not configured") from exc
 
     def get_login_redirect_url(self, request):
         return settings.LOGIN_REDIRECT_URL

--- a/src/backend/apps/iam/auth/views/oauth.py
+++ b/src/backend/apps/iam/auth/views/oauth.py
@@ -25,9 +25,9 @@ def google_login_url() -> str:
 
 
 def is_google_oauth_enabled() -> bool:
-    from apps.platform_ops.services.internal.runtime_settings import google_oauth_enabled
+    from apps.platform_ops.services.internal.runtime_settings import google_oauth_ready
 
-    return google_oauth_enabled()
+    return google_oauth_ready()
 
 
 def absolute_google_login_url() -> str:

--- a/src/backend/apps/iam/tests/test_google_oauth.py
+++ b/src/backend/apps/iam/tests/test_google_oauth.py
@@ -1,10 +1,16 @@
 """Tests for Google OAuth login and social registration."""
 
 from datetime import timedelta
+from io import StringIO
 from urllib.parse import parse_qs, urlparse
 from unittest.mock import patch
 
+from allauth.socialaccount.models import SocialApp
+from django.conf import settings
 from django.contrib.auth.models import User
+from django.contrib.sites.models import Site
+from django.core.management import call_command
+from django.core.management.base import CommandError
 from django.test import Client, override_settings
 from django.urls import reverse
 from django.utils import timezone
@@ -18,6 +24,7 @@ from apps.iam.services.oauth_error_events import (
     create_oauth_error_event,
 )
 from apps.iam.services.registration_service import complete_social_user_registration
+from apps.platform_ops.services.internal.runtime_settings import sync_google_social_app
 
 
 @override_settings(
@@ -25,9 +32,18 @@ from apps.iam.services.registration_service import complete_social_user_registra
     GOOGLE_CLIENT_SECRET="test-client-secret",
     HFL_GOOGLE_OAUTH_ENABLED=True,
     FRONTEND_URL="https://app.example.com",
+    CACHES={
+        "default": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        }
+    },
 )
 @patch.dict("os.environ", {"HFL_GOOGLE_OAUTH_ENABLED": "true"})
 class GoogleOAuthConfigTests(APITestCase):
+    def setUp(self):
+        super().setUp()
+        sync_google_social_app()
+
     def test_google_config_enabled(self):
         response = self.client.get(reverse("google_oauth_config"))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -38,12 +54,118 @@ class GoogleOAuthConfigTests(APITestCase):
             "https://app.example.com/accounts/google/login/",
         )
 
+    def test_google_provider_has_no_second_settings_application(self):
+        self.assertNotIn("APP", settings.SOCIALACCOUNT_PROVIDERS["google"])
+        self.assertEqual(SocialApp.objects.filter(provider="google").count(), 1)
+
+    def test_google_login_redirects_with_the_canonical_callback(self):
+        response = self.client.get(
+            reverse("google_login"),
+            secure=True,
+            HTTP_HOST="app.example.com",
+            HTTP_X_FORWARDED_PROTO="https",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_302_FOUND)
+        location = urlparse(response["Location"])
+        self.assertEqual(location.hostname, "accounts.google.com")
+        self.assertEqual(
+            parse_qs(location.query)["redirect_uri"],
+            ["https://app.example.com/accounts/google/login/callback/"],
+        )
+
+    def test_legacy_duplicate_is_reported_as_unavailable_instead_of_500(self):
+        duplicate = SocialApp.objects.create(
+            provider="google",
+            name="Duplicate Google",
+            client_id="duplicate-client",
+            secret="duplicate-secret",
+        )
+        duplicate.sites.add(Site.objects.get_current())
+
+        config = self.client.get(reverse("google_oauth_config"))
+        login = self.client.get(reverse("google_login"))
+
+        self.assertEqual(config.status_code, status.HTTP_200_OK)
+        self.assertFalse(config.data["data"]["enabled"])
+        self.assertEqual(login.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_stale_database_credentials_are_reported_as_unavailable(self):
+        app = SocialApp.objects.get(provider="google")
+        app.client_id = "stale-client-id"
+        app.secret = "stale-client-secret"
+        app.save(update_fields=["client_id", "secret"])
+
+        config = self.client.get(reverse("google_oauth_config"))
+        login = self.client.get(reverse("google_login"))
+
+        self.assertEqual(config.status_code, status.HTTP_200_OK)
+        self.assertFalse(config.data["data"]["enabled"])
+        self.assertEqual(login.status_code, status.HTTP_403_FORBIDDEN)
+
     @override_settings(GOOGLE_CLIENT_ID="", GOOGLE_CLIENT_SECRET="")
     @patch.dict("os.environ", {"GOOGLE_CLIENT_ID": "", "GOOGLE_CLIENT_SECRET": ""})
     def test_google_config_requires_credentials(self):
         response = self.client.get(reverse("google_oauth_config"))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertFalse(response.data["data"]["enabled"])
+
+
+@override_settings(
+    GOOGLE_CLIENT_ID="test-client-id",
+    GOOGLE_CLIENT_SECRET="test-client-secret",
+    HFL_GOOGLE_OAUTH_ENABLED=True,
+    FRONTEND_URL="https://127.0.0.1:11443",
+)
+@patch.dict("os.environ", {"HFL_GOOGLE_OAUTH_ENABLED": "true"})
+class GoogleOAuthReadinessCommandTests(APITestCase):
+    def setUp(self):
+        super().setUp()
+        sync_google_social_app()
+
+    def test_local_callback_is_ready(self):
+        stdout = StringIO()
+
+        call_command("check_google_oauth_readiness", stdout=stdout)
+
+        self.assertIn(
+            "Google OAuth callback: "
+            "https://127.0.0.1:11443/accounts/google/login/callback/",
+            stdout.getvalue(),
+        )
+        self.assertIn("HFL_GOOGLE_OAUTH_STATUS=ready", stdout.getvalue())
+
+    @override_settings(FRONTEND_URL="https://app.hyperfilelens.com")
+    def test_production_callback_is_ready(self):
+        sync_google_social_app()
+        stdout = StringIO()
+
+        call_command("check_google_oauth_readiness", stdout=stdout)
+
+        self.assertIn(
+            "Google OAuth callback: "
+            "https://app.hyperfilelens.com/accounts/google/login/callback/",
+            stdout.getvalue(),
+        )
+
+    def test_duplicate_application_fails_readiness_without_exposing_secret(self):
+        duplicate = SocialApp.objects.create(
+            provider="google",
+            name="Duplicate Google",
+            client_id="duplicate-client",
+            secret="must-not-be-printed",
+        )
+        duplicate.sites.add(Site.objects.get_current())
+        stderr = StringIO()
+
+        with self.assertRaises(CommandError):
+            call_command(
+                "check_google_oauth_readiness",
+                stdout=StringIO(),
+                stderr=stderr,
+            )
+
+        self.assertNotIn("must-not-be-printed", stderr.getvalue())
 
 
 @override_settings(
@@ -65,7 +187,11 @@ class GoogleOAuthDisabledTests(APITestCase):
 
 
 class SocialRegistrationServiceTests(APITestCase):
-    def test_complete_social_user_registration_provisions_org(self):
+    @patch(
+        "apps.lens_bridge.services.chat_user_provisioning."
+        "enqueue_sl_chat_user_provision"
+    )
+    def test_complete_social_user_registration_provisions_org(self, _enqueue):
         user = User.objects.create_user(
             username="google-user",
             email="google-user@example.com",
@@ -162,9 +288,18 @@ class OAuthErrorEventTests(APITestCase):
     GOOGLE_CLIENT_SECRET="test-client-secret",
     HFL_GOOGLE_OAUTH_ENABLED=True,
     FRONTEND_URL="https://app.example.com",
+    CACHES={
+        "default": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        }
+    },
 )
 @patch.dict("os.environ", {"HFL_GOOGLE_OAUTH_ENABLED": "true"})
 class GoogleOAuthCallbackTests(APITestCase):
+    def setUp(self):
+        super().setUp()
+        sync_google_social_app()
+
     def test_incomplete_oauth_redirects_with_a_consumable_event(self):
         response = self.client.get(reverse("oauth_callback"))
         parsed = urlparse(response["Location"])
@@ -178,7 +313,11 @@ class GoogleOAuthCallbackTests(APITestCase):
             "not_authenticated",
         )
 
-    def test_oauth_callback_issues_cookies_and_redirects(self):
+    @patch(
+        "apps.lens_bridge.services.chat_user_provisioning."
+        "enqueue_sl_chat_user_provision"
+    )
+    def test_oauth_callback_issues_cookies_and_redirects(self, _enqueue):
         user = User.objects.create_user(
             username="oauth-callback",
             email="oauth-callback@example.com",

--- a/src/backend/apps/platform_ops/management/commands/check_google_oauth_readiness.py
+++ b/src/backend/apps/platform_ops/management/commands/check_google_oauth_readiness.py
@@ -1,0 +1,74 @@
+"""Validate the configured Google OAuth entry point without contacting Google."""
+
+from __future__ import annotations
+
+from typing import Any
+from urllib.parse import parse_qs, urlsplit, urlunsplit
+
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandError
+from django.test import Client, override_settings
+from django.urls import reverse
+
+from apps.platform_ops.services.internal.runtime_settings import (
+    google_oauth_enabled,
+    google_oauth_ready,
+)
+from common.deploy.site import tenant_public_url
+
+
+class Command(BaseCommand):
+    """Check the local OAuth route and its canonical Google callback."""
+
+    help = "Validate Google OAuth readiness without external connectivity."
+
+    def handle(self, *args: Any, **options: Any) -> None:
+        if not google_oauth_enabled():
+            self.stdout.write("HFL_GOOGLE_OAUTH_STATUS=disabled")
+            return
+        if not google_oauth_ready():
+            raise CommandError(
+                "Google OAuth is enabled but a unique site-bound application is unavailable."
+            )
+
+        public_url = tenant_public_url()
+        parsed_public = urlsplit(public_url)
+        if parsed_public.scheme not in {"http", "https"} or not parsed_public.hostname:
+            raise CommandError("FRONTEND_URL must be an absolute HTTP(S) URL.")
+
+        allowed_hosts = list(getattr(settings, "ALLOWED_HOSTS", []))
+        if parsed_public.hostname not in allowed_hosts:
+            allowed_hosts.append(parsed_public.hostname)
+        with override_settings(ALLOWED_HOSTS=allowed_hosts):
+            response = Client().get(
+                reverse("google_login"),
+                secure=parsed_public.scheme == "https",
+                HTTP_HOST=parsed_public.netloc,
+                HTTP_X_FORWARDED_PROTO=parsed_public.scheme,
+                HTTP_X_HFL_SITE_ROLE="tenant",
+            )
+
+        if response.status_code != 302:
+            raise CommandError(
+                "Google OAuth login did not return the expected HTTP 302 redirect."
+            )
+        location = str(response.headers.get("Location") or "")
+        parsed_location = urlsplit(location)
+        if parsed_location.scheme != "https" or parsed_location.hostname != "accounts.google.com":
+            raise CommandError("Google OAuth login did not redirect to accounts.google.com.")
+
+        callback = parse_qs(parsed_location.query).get("redirect_uri", [""])[0]
+        expected_callback = urlunsplit(
+            (
+                parsed_public.scheme,
+                parsed_public.netloc,
+                "/accounts/google/login/callback/",
+                "",
+                "",
+            )
+        )
+        if callback != expected_callback:
+            raise CommandError("Google OAuth generated an unexpected callback URI.")
+
+        self.stdout.write(f"Google OAuth callback: {expected_callback}")
+        self.stdout.write("HFL_GOOGLE_OAUTH_STATUS=ready")

--- a/src/backend/apps/platform_ops/management/commands/ensure_deployment_identity_settings.py
+++ b/src/backend/apps/platform_ops/management/commands/ensure_deployment_identity_settings.py
@@ -6,8 +6,9 @@ import os
 import re
 from typing import Any
 
+from django.core.exceptions import ImproperlyConfigured
 from django.core.management.base import BaseCommand
-from django.db import transaction
+from django.db import DatabaseError, transaction
 
 from apps.platform_ops.services.internal.runtime_settings import (
     KEY_EMAIL_BACKEND,
@@ -60,6 +61,7 @@ class Command(BaseCommand):
         google_client_secret = os.getenv("GOOGLE_CLIENT_SECRET", "")
         turnstile_enabled = _parse_bool("TURNSTILE_ENABLED")
         warnings: list[str] = []
+        removed_google_duplicates = 0
 
         with transaction.atomic():
             if signup_enabled is None:
@@ -86,10 +88,27 @@ class Command(BaseCommand):
                     "Invalid Google OAuth client secret; preserved the installed Google settings."
                 )
             else:
-                set_value(key=KEY_IDENTITY_GOOGLE_CLIENT_ID, value=google_client_id)
-                set_value(key=SECRET_KEY_GOOGLE, secret=google_client_secret)
-                set_bool(KEY_IDENTITY_GOOGLE_OAUTH, True)
-                sync_google_social_app()
+                try:
+                    with transaction.atomic():
+                        set_value(
+                            key=KEY_IDENTITY_GOOGLE_CLIENT_ID,
+                            value=google_client_id,
+                        )
+                        set_value(key=SECRET_KEY_GOOGLE, secret=google_client_secret)
+                        set_bool(KEY_IDENTITY_GOOGLE_OAUTH, True)
+                        sync_result = sync_google_social_app()
+                        removed_google_duplicates = sync_result.removed_duplicates
+                except (DatabaseError, ImproperlyConfigured, ValueError) as exc:
+                    warnings.append(
+                        "Google OAuth settings could not be synchronized; preserved "
+                        "the installed Google settings."
+                    )
+                    self.stderr.write(
+                        self.style.WARNING(
+                            "Google OAuth synchronization failed "
+                            f"({type(exc).__name__})."
+                        )
+                    )
 
             self._sync_turnstile(turnstile_enabled, warnings)
             self._sync_email(warnings)
@@ -110,6 +129,11 @@ class Command(BaseCommand):
             )
             else "Google OAuth: preserved"
         )
+        if removed_google_duplicates:
+            self.stdout.write(
+                "Google OAuth duplicate applications removed: "
+                f"{removed_google_duplicates}"
+            )
         self.stdout.write(
             "HFL_IDENTITY_STATUS=" + ("warning" if warnings else "applied")
         )

--- a/src/backend/apps/platform_ops/services/internal/runtime_settings.py
+++ b/src/backend/apps/platform_ops/services/internal/runtime_settings.py
@@ -3,14 +3,21 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
+from dataclasses import dataclass
 from typing import Any
+from urllib.parse import urlsplit
 
 from django.conf import settings
 from django.contrib.auth.models import AbstractBaseUser
+from django.core.exceptions import ImproperlyConfigured
+from django.db import DatabaseError, transaction
 
 from apps.platform_ops.models.platform_runtime_setting import PlatformRuntimeSetting
 from apps.storage.crypto import decrypt_text, encrypt_text
+
+logger = logging.getLogger(__name__)
 
 KEY_EMAIL_BACKEND = "email.backend"
 KEY_EMAIL_HOST = "email.host"
@@ -73,6 +80,16 @@ EMAIL_RUNTIME_KEYS = (
     SECRET_KEY_EMAIL_PASSWORD,
     KEY_EMAIL_FROM,
 )
+
+
+@dataclass(frozen=True)
+class GoogleSocialAppSyncResult:
+    """Describe one idempotent django-allauth Google application sync."""
+
+    configured: bool
+    app_id: int | None = None
+    site_domain: str = ""
+    removed_duplicates: int = 0
 
 
 def invalidate_runtime_settings_cache() -> None:
@@ -342,6 +359,29 @@ def google_oauth_enabled() -> bool:
     return bool(policy_enabled and google_client_id() and google_client_secret())
 
 
+def google_oauth_ready() -> bool:
+    """Return whether one site-bound Google SocialApp is ready for login."""
+    if not google_oauth_enabled():
+        return False
+    try:
+        from allauth.socialaccount.models import SocialApp
+        from django.contrib.sites.models import Site
+
+        site = Site.objects.get_current()
+        apps = list(
+            SocialApp.objects.filter(provider="google", sites=site)
+            .distinct()
+            .values_list("client_id", "secret")[:2]
+        )
+        return apps == [(google_client_id(), google_client_secret())]
+    except (DatabaseError, ImproperlyConfigured, Site.DoesNotExist) as exc:
+        logger.warning(
+            "Google OAuth readiness check failed (%s)",
+            type(exc).__name__,
+        )
+        return False
+
+
 def _settings_email_connection_kwargs() -> dict[str, Any]:
     """Return process environment-backed Django mail settings without DB overlays."""
     return {
@@ -516,25 +556,72 @@ def langfuse_enabled() -> bool:
     return _parse_bool(_env_str("LANGFUSE_ENABLED"), default=False)
 
 
-def sync_google_social_app() -> None:
-    """Keep django-allauth SocialApp in sync with runtime Google OAuth credentials."""
+def _google_site_domain() -> str:
+    """Return the canonical django.contrib.sites domain for the tenant URL."""
+    from common.deploy.site import tenant_public_url
+
+    public_url = tenant_public_url()
+    parsed = urlsplit(public_url)
+    if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+        raise ValueError("FRONTEND_URL must be an absolute HTTP(S) URL")
+    return parsed.netloc
+
+
+def sync_google_social_app() -> GoogleSocialAppSyncResult:
+    """Converge runtime Google OAuth credentials into one site-bound SocialApp."""
     client_id = google_client_id()
     secret = google_client_secret()
     if not client_id or not secret:
-        return
-    try:
-        from allauth.socialaccount.models import SocialApp
-        from django.contrib.sites.models import Site
+        return GoogleSocialAppSyncResult(configured=False)
 
-        site = Site.objects.get_current()
-        app, _created = SocialApp.objects.update_or_create(
-            provider="google",
-            defaults={
-                "name": "Google",
-                "client_id": client_id,
-                "secret": secret,
-            },
+    from allauth.socialaccount.models import SocialApp
+    from django.contrib.sites.models import Site
+
+    site_domain = _google_site_domain()
+    site_id = int(getattr(settings, "SITE_ID", 1))
+    with transaction.atomic():
+        site, _created = Site.objects.select_for_update().get_or_create(
+            pk=site_id,
+            defaults={"domain": site_domain, "name": site_domain},
         )
-        app.sites.add(site)
-    except Exception:
-        pass
+        site_updates: list[str] = []
+        if site.domain != site_domain:
+            site.domain = site_domain
+            site_updates.append("domain")
+        if site.name != site_domain:
+            site.name = site_domain
+            site_updates.append("name")
+        if site_updates:
+            site.save(update_fields=site_updates)
+
+        existing = list(
+            SocialApp.objects.select_for_update()
+            .filter(provider="google")
+            .order_by("pk")
+        )
+        app = next(
+            (candidate for candidate in existing if candidate.client_id == client_id),
+            existing[0] if existing else None,
+        )
+        if app is None:
+            app = SocialApp(provider="google")
+        app.name = "Google"
+        app.client_id = client_id
+        app.secret = secret
+        app.save()
+        app.sites.set([site])
+
+        duplicate_ids = [
+            candidate.pk
+            for candidate in existing
+            if candidate.pk is not None and candidate.pk != app.pk
+        ]
+        if duplicate_ids:
+            SocialApp.objects.filter(pk__in=duplicate_ids).delete()
+
+    return GoogleSocialAppSyncResult(
+        configured=True,
+        app_id=app.pk,
+        site_domain=site_domain,
+        removed_duplicates=len(duplicate_ids),
+    )

--- a/src/backend/apps/platform_ops/tests/test_ensure_deployment_identity_settings_command.py
+++ b/src/backend/apps/platform_ops/tests/test_ensure_deployment_identity_settings_command.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 import io
 from unittest.mock import patch
 
+from allauth.socialaccount.models import SocialApp
+from django.contrib.sites.models import Site
 from django.core.management import call_command
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 from apps.platform_ops.models.platform_runtime_setting import PlatformRuntimeSetting
 from apps.platform_ops.services.internal.runtime_settings import (
@@ -26,6 +28,7 @@ from apps.platform_ops.services.internal.runtime_settings import (
 )
 
 
+@override_settings(FRONTEND_URL="https://127.0.0.1:11443", SITE_ID=1)
 class EnsureDeploymentIdentitySettingsCommandTests(TestCase):
     @staticmethod
     def complete_env(**overrides: str) -> dict[str, str]:
@@ -52,16 +55,13 @@ class EnsureDeploymentIdentitySettingsCommandTests(TestCase):
     def run_command(self, env: dict[str, str]):
         stdout = io.StringIO()
         stderr = io.StringIO()
-        with patch.dict("os.environ", env, clear=False), patch(
-            "apps.platform_ops.management.commands."
-            "ensure_deployment_identity_settings.sync_google_social_app"
-        ) as sync_social_app:
+        with patch.dict("os.environ", env, clear=False):
             call_command(
                 "ensure_deployment_identity_settings",
                 stdout=stdout,
                 stderr=stderr,
             )
-        return stdout.getvalue(), stderr.getvalue(), sync_social_app
+        return stdout.getvalue(), stderr.getvalue()
 
     def test_applies_configuration_idempotently_without_echoing_secret(self):
         env = self.complete_env(
@@ -70,8 +70,8 @@ class EnsureDeploymentIdentitySettingsCommandTests(TestCase):
             EMAIL_HOST_PASSWORD="never-print-smtp-secret",
         )
 
-        first_stdout, first_stderr, first_sync = self.run_command(env)
-        second_stdout, second_stderr, second_sync = self.run_command(env)
+        first_stdout, first_stderr = self.run_command(env)
+        second_stdout, second_stderr = self.run_command(env)
 
         self.assertEqual(
             PlatformRuntimeSetting.objects.filter(
@@ -102,8 +102,13 @@ class EnsureDeploymentIdentitySettingsCommandTests(TestCase):
         ):
             self.assertNotIn(env[secret_name], output)
         self.assertIn("HFL_IDENTITY_STATUS=applied", second_stdout)
-        first_sync.assert_called_once_with()
-        second_sync.assert_called_once_with()
+        self.assertEqual(SocialApp.objects.filter(provider="google").count(), 1)
+        app = SocialApp.objects.get(provider="google")
+        self.assertEqual(app.client_id, env["GOOGLE_CLIENT_ID"])
+        self.assertEqual(list(app.sites.values_list("pk", flat=True)), [1])
+        site = Site.objects.get(pk=1)
+        self.assertEqual(site.domain, "127.0.0.1:11443")
+        self.assertEqual(site.name, "127.0.0.1:11443")
 
     def test_invalid_google_configuration_warns_and_preserves_existing_values(self):
         existing = self.complete_env(
@@ -113,7 +118,7 @@ class EnsureDeploymentIdentitySettingsCommandTests(TestCase):
         )
         self.run_command(existing)
 
-        stdout, stderr, sync_social_app = self.run_command(
+        stdout, stderr = self.run_command(
             self.complete_env(
                 GOOGLE_CLIENT_ID="invalid-client",
                 GOOGLE_CLIENT_SECRET="replacement-secret",
@@ -124,10 +129,39 @@ class EnsureDeploymentIdentitySettingsCommandTests(TestCase):
         self.assertEqual(google_client_secret(), existing["GOOGLE_CLIENT_SECRET"])
         self.assertIn("HFL_IDENTITY_STATUS=warning", stdout)
         self.assertIn("preserved the installed Google settings", stderr)
-        sync_social_app.assert_not_called()
+        self.assertEqual(SocialApp.objects.get(provider="google").client_id, existing["GOOGLE_CLIENT_ID"])
+
+    def test_google_sync_failure_warns_and_preserves_existing_values(self):
+        existing = self.complete_env(
+            GOOGLE_CLIENT_ID="123-existing.apps.googleusercontent.com",
+            GOOGLE_CLIENT_SECRET="existing-secret",
+        )
+        self.run_command(existing)
+
+        with patch(
+            "apps.platform_ops.management.commands."
+            "ensure_deployment_identity_settings.sync_google_social_app",
+            side_effect=ValueError("invalid public URL"),
+        ):
+            stdout, stderr = self.run_command(
+                self.complete_env(
+                    GOOGLE_CLIENT_ID="123-replacement.apps.googleusercontent.com",
+                    GOOGLE_CLIENT_SECRET="replacement-secret",
+                )
+            )
+
+        self.assertEqual(google_client_id(), existing["GOOGLE_CLIENT_ID"])
+        self.assertEqual(google_client_secret(), existing["GOOGLE_CLIENT_SECRET"])
+        self.assertEqual(
+            SocialApp.objects.get(provider="google").client_id,
+            existing["GOOGLE_CLIENT_ID"],
+        )
+        self.assertIn("HFL_IDENTITY_STATUS=warning", stdout)
+        self.assertIn("Google OAuth synchronization failed (ValueError)", stderr)
+        self.assertNotIn("replacement-secret", stdout + stderr)
 
     def test_production_policy_disables_email_signup_and_enables_google(self):
-        stdout, _stderr, _sync = self.run_command(
+        stdout, _stderr = self.run_command(
             self.complete_env(
                 HFL_EMAIL_SIGNUP_ENABLED="false",
                 GOOGLE_CLIENT_ID="6436338978-prod.apps.googleusercontent.com",
@@ -148,7 +182,7 @@ class EnsureDeploymentIdentitySettingsCommandTests(TestCase):
         )
         self.run_command(existing)
 
-        stdout, stderr, _sync = self.run_command(
+        stdout, stderr = self.run_command(
             self.complete_env(
                 TURNSTILE_ENABLED="true",
                 TURNSTILE_SITE_KEY="replacement-site",
@@ -169,7 +203,7 @@ class EnsureDeploymentIdentitySettingsCommandTests(TestCase):
         )
         self.run_command(existing)
 
-        stdout, stderr, _sync = self.run_command(
+        stdout, stderr = self.run_command(
             self.complete_env(
                 EMAIL_HOST="smtp.replacement.example.com",
                 EMAIL_PORT="invalid",
@@ -188,3 +222,31 @@ class EnsureDeploymentIdentitySettingsCommandTests(TestCase):
         self.assertIn("HFL_IDENTITY_STATUS=warning", stdout)
         self.assertIn("preserved the installed email configuration", stderr)
         self.assertNotIn("replacement-smtp-secret", stdout + stderr)
+
+    def test_converges_legacy_google_duplicates_to_matching_application(self):
+        site = Site.objects.get_current()
+        legacy = SocialApp.objects.create(
+            provider="google",
+            name="Legacy Google",
+            client_id="123-legacy.apps.googleusercontent.com",
+            secret="legacy-secret",
+        )
+        desired = SocialApp.objects.create(
+            provider="google",
+            name="Desired Google",
+            client_id="123-example.apps.googleusercontent.com",
+            secret="stale-secret",
+        )
+        legacy.sites.add(site)
+        desired.sites.add(site)
+
+        stdout, stderr = self.run_command(self.complete_env())
+
+        self.assertEqual(stderr, "")
+        self.assertEqual(SocialApp.objects.filter(provider="google").count(), 1)
+        remaining = SocialApp.objects.get(provider="google")
+        self.assertEqual(remaining.pk, desired.pk)
+        self.assertEqual(remaining.name, "Google")
+        self.assertEqual(remaining.secret, "google-test-secret")
+        self.assertEqual(list(remaining.sites.values_list("pk", flat=True)), [1])
+        self.assertIn("Google OAuth duplicate applications removed: 1", stdout)

--- a/src/backend/project/settings/iam.py
+++ b/src/backend/project/settings/iam.py
@@ -48,11 +48,6 @@ SOCIALACCOUNT_PROVIDERS = {
             # Enterprise SaaS: always show Google account picker (work vs personal).
             "prompt": "select_account",
         },
-        "APP": {
-            "client_id": GOOGLE_CLIENT_ID,
-            "secret": GOOGLE_CLIENT_SECRET,
-            "key": "",
-        },
     },
 }
 

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -265,6 +265,12 @@ grep -F 'No SMTP settings were staged' \
 	"${ROOT}/.github/workflows/deploy_target.yml" >/dev/null
 grep -F 'python manage.py ensure_deployment_identity_settings' \
 	"${ROOT}/.github/workflows/deploy_target.yml" >/dev/null
+grep -F 'python manage.py check_google_oauth_readiness' \
+	"${ROOT}/.github/workflows/deploy_target.yml" >/dev/null
+grep -F 'python manage.py check_google_oauth_readiness' \
+	"${ROOT}/deploy/installer/install.sh" "${ROOT}/dev/stack.sh" >/dev/null
+grep -F '::warning title=Google OAuth readiness::' \
+	"${ROOT}/.github/workflows/deploy_target.yml" >/dev/null
 grep -F 'HFL_IDENTITY_STATUS=warning' \
 	"${ROOT}/.github/workflows/deploy_target.yml" >/dev/null
 grep -F 'umask 077 && cat > /var/tmp/hyperfilelens-runtime-' \
@@ -380,11 +386,12 @@ grep -F 'DOCKER_DEFAULT_PLATFORM="${DOCKER_DEFAULT_PLATFORM:-linux/amd64}"' \
 	"${ROOT}/dev/stack.sh" >/dev/null
 [[ -x "${ROOT}/dev/bootstrap-macos.sh" && -f "${ROOT}/dev/Brewfile" ]]
 deploy_workflow="${ROOT}/.github/workflows/deploy_target.yml"
-[[ "$(grep -c -- '-o ServerAliveInterval=30' "${deploy_workflow}")" -eq 6 ]] || {
+deploy_ssh_calls="$(grep -c 'ssh -i ~/.ssh/hyperfilelens_deploy' "${deploy_workflow}")"
+[[ "$(grep -c -- '-o ServerAliveInterval=30' "${deploy_workflow}")" -eq "${deploy_ssh_calls}" ]] || {
 	printf 'ERROR: every deployment SSH call must enable ServerAliveInterval\n' >&2
 	exit 1
 }
-[[ "$(grep -c -- '-o ServerAliveCountMax=20' "${deploy_workflow}")" -eq 6 ]] || {
+[[ "$(grep -c -- '-o ServerAliveCountMax=20' "${deploy_workflow}")" -eq "${deploy_ssh_calls}" ]] || {
 	printf 'ERROR: every deployment SSH call must set ServerAliveCountMax\n' >&2
 	exit 1
 }

--- a/tools/quality/test-deployment-optional-config.sh
+++ b/tools/quality/test-deployment-optional-config.sh
@@ -209,17 +209,21 @@ if python3 "${helper}" --env-file "${invalid_env}" \
 fi
 
 install_body="$(sed -n '/^cmd_install()/,/^cmd_start()/p' "${installer}")"
+start_body="$(sed -n '/^cmd_start()/,/^cmd_stop()/p' "${installer}")"
 upgrade_body="$(sed -n '/^cmd_upgrade()/,/^main()/p' "${installer}")"
-python3 - "${install_body}" "${upgrade_body}" <<'PY'
+python3 - "${install_body}" "${start_body}" "${upgrade_body}" <<'PY'
 import sys
 
-install, upgrade = sys.argv[1:]
+install, start, upgrade = sys.argv[1:]
 assert install.index("ensure_env_file") < install.index("apply_runtime_configuration")
 assert install.index("apply_runtime_configuration") < install.index("load_images_from_manifest")
 assert install.index("apply_runtime_configuration") < install.index("install_bundled_sourcelens")
+assert install.index("wait_for_hfl_health") < install.index("sync_optional_identity_settings")
+assert start.index("wait_for_hfl_health") < start.index("sync_optional_identity_settings")
 assert upgrade.index("apply_upgrade_files") < upgrade.index("apply_runtime_configuration")
 assert upgrade.index("apply_runtime_configuration") < upgrade.index("install_bundled_sourcelens")
 assert upgrade.index("apply_runtime_configuration") < upgrade.index("compose_in_root up -d postgres redis")
+assert upgrade.index("wait_for_hfl_health") < upgrade.index("sync_optional_identity_settings")
 PY
 
 grep -F 'bash "${package_root}/install.sh" "${install_args[@]}"' \


### PR DESCRIPTION
Converge Google OAuth onto one database-backed SocialApp, reconcile optional identity settings before deployment readiness checks, and keep invalid optional configuration non-blocking. Validation: 791 backend tests, focused OAuth tests, Ruff, English-only checks, workflow YAML parsing, shell syntax, release contracts, deployment configuration contracts, and git diff checks all passed.