### PR TITLE
fix(agent): show installation download progress

### DIFF
--- a/.github/scripts/remote-deploy.sh
+++ b/.github/scripts/remote-deploy.sh
@@ -332,22 +332,52 @@ check_disk_capacity() {
 
 download_release_file() {
 	local url=$1 output=$2
+	local partial="${output}.part"
+	local started=${SECONDS}
+	local size_bytes size_human rate_human elapsed downloaded=0
 	local -a curl_args=(
 		-fL
+		--show-error
+		--progress-bar
 		--retry 5
 		--retry-connrefused
 		--retry-delay 2
 		--connect-timeout 20
 	)
+	rm -f -- "${partial}"
 	if [[ -n "${DOWNLOAD_PROXY_URL}" ]]; then
 		if curl "${curl_args[@]}" --proxy "${DOWNLOAD_PROXY_URL}" --noproxy '' \
-			"${url}" -o "${output}"; then
-			return 0
+			"${url}" -o "${partial}"; then
+			downloaded=1
+		else
+			printf 'WARNING: release download through the configured proxy failed; retrying directly\n' >&2
+			rm -f -- "${partial}"
 		fi
-		printf 'WARNING: release download through the configured proxy failed; retrying directly\n' >&2
-		rm -f -- "${output}"
 	fi
-	curl "${curl_args[@]}" --proxy '' "${url}" -o "${output}"
+	if [[ "${downloaded}" -eq 0 ]]; then
+		if ! curl "${curl_args[@]}" --proxy '' "${url}" -o "${partial}"; then
+			rm -f -- "${partial}"
+			return 1
+		fi
+	fi
+	mv -f -- "${partial}" "${output}"
+	size_bytes="$(wc -c <"${output}")"
+	size_human="$(awk -v bytes="${size_bytes}" 'BEGIN {
+		split("B KiB MiB GiB TiB", units, " "); value = bytes + 0; unit = 1
+		while (value >= 1024 && unit < 5) { value /= 1024; unit++ }
+		if (unit == 1) printf "%.0f %s", value, units[unit]
+		else printf "%.1f %s", value, units[unit]
+	}')"
+	elapsed=$((SECONDS - started))
+	((elapsed > 0)) || elapsed=1
+	rate_human="$(awk -v bytes="${size_bytes}" -v elapsed="${elapsed}" 'BEGIN {
+		split("B KiB MiB GiB TiB", units, " "); value = (bytes + 0) / elapsed; unit = 1
+		while (value >= 1024 && unit < 5) { value /= 1024; unit++ }
+		if (unit == 1) printf "%.0f %s/s", value, units[unit]
+		else printf "%.1f %s/s", value, units[unit]
+	}')"
+	printf '[deploy] Downloaded %s (%s in %ss, average %s)\n' \
+		"$(basename "${output}")" "${size_human}" "${elapsed}" "${rate_human}"
 }
 
 if [[ -n "${DOWNLOAD_PROXY_URL}" ]]; then

--- a/.github/workflows/artifact_pipeline.yml
+++ b/.github/workflows/artifact_pipeline.yml
@@ -206,6 +206,7 @@ jobs:
           uv run --isolated --no-project --python 3.8 python tools/quality/check-python38-runtime.py
           ./tools/quality/check-release-contracts.sh
           ./tools/quality/test-default-certificates.sh
+          ./tools/quality/test-bootstrap-download-progress.sh
           ./tools/quality/test-gateway-bootstrap-health.sh
           ./tools/quality/test-platform-gateway-auto-deploy.sh
           ./tools/quality/test-agent-gateway-uninstall.sh

--- a/deploy/bootstrap/agent-bootstrap-linux.sh
+++ b/deploy/bootstrap/agent-bootstrap-linux.sh
@@ -18,6 +18,51 @@ hfl_fail() {
 	exit "${2:-1}"
 }
 
+hfl_step() {
+	printf '[%s] [STEP ] %s\n' "$(hfl_now)" "$1"
+}
+
+hfl_ok() {
+	printf '[%s] [ OK  ] %s\n' "$(hfl_now)" "$1"
+}
+
+hfl_format_bytes() {
+	awk -v bytes="$1" 'BEGIN {
+		split("B KiB MiB GiB TiB", units, " ")
+		value = bytes + 0
+		unit = 1
+		while (value >= 1024 && unit < 5) {
+			value /= 1024
+			unit++
+		}
+		if (unit == 1) printf "%.0f %s", value, units[unit]
+		else printf "%.1f %s", value, units[unit]
+	}'
+}
+
+hfl_download() {
+	local label="$1"
+	local url="$2"
+	local destination="$3"
+	local partial="${destination}.part"
+	local started=${SECONDS} elapsed bytes rate
+	rm -f "${partial}"
+	hfl_step "Downloading ${label}."
+	if ! curl "${CURL_TLS[@]}" \
+		--fail --show-error --location --progress-bar \
+		--retry 3 --retry-connrefused --retry-delay 2 \
+		"${url}" -o "${partial}"; then
+		rm -f "${partial}"
+		hfl_fail "Failed to download ${label}." 3
+	fi
+	mv -f "${partial}" "${destination}"
+	bytes="$(wc -c <"${destination}")"
+	elapsed=$((SECONDS - started))
+	((elapsed > 0)) || elapsed=1
+	rate="$(hfl_format_bytes "$((bytes / elapsed))")/s"
+	hfl_ok "${label} downloaded ($(hfl_format_bytes "${bytes}") in ${elapsed}s, average ${rate})."
+}
+
 hfl_build_enroll_args() {
 	HFL_ENROLL_ARGS=()
 	local has_yes=0
@@ -62,10 +107,13 @@ if ! command -v systemctl >/dev/null 2>&1 \
 fi
 
 BIN="${TMPDIR:-/tmp}/hfl-enroll-$$"
-cleanup() { rm -f "${BIN}"; }
+cleanup() { rm -f "${BIN}" "${BIN}.part"; }
 trap cleanup EXIT
 
-curl "${CURL_TLS[@]}" -fsSL "${HFL_API_BASE}/media/enroll-bootstrap/hfl-enroll-linux-${HFL_ARCH}" -o "${BIN}"
+hfl_download \
+	"HyperFileLens enrollment helper" \
+	"${HFL_API_BASE}/media/enroll-bootstrap/hfl-enroll-linux-${HFL_ARCH}" \
+	"${BIN}"
 chmod +x "${BIN}"
 # Do not exec: trap EXIT must run after install so /tmp/hfl-enroll-* is removed on success or failure.
 hfl_build_enroll_args "$@"

--- a/deploy/bootstrap/agent-bootstrap-macos.sh
+++ b/deploy/bootstrap/agent-bootstrap-macos.sh
@@ -18,6 +18,51 @@ hfl_fail() {
 	exit "${2:-1}"
 }
 
+hfl_step() {
+	printf '[%s] [STEP ] %s\n' "$(hfl_now)" "$1"
+}
+
+hfl_ok() {
+	printf '[%s] [ OK  ] %s\n' "$(hfl_now)" "$1"
+}
+
+hfl_format_bytes() {
+	awk -v bytes="$1" 'BEGIN {
+		split("B KiB MiB GiB TiB", units, " ")
+		value = bytes + 0
+		unit = 1
+		while (value >= 1024 && unit < 5) {
+			value /= 1024
+			unit++
+		}
+		if (unit == 1) printf "%.0f %s", value, units[unit]
+		else printf "%.1f %s", value, units[unit]
+	}'
+}
+
+hfl_download() {
+	local label="$1"
+	local url="$2"
+	local destination="$3"
+	local partial="${destination}.part"
+	local started=${SECONDS} elapsed bytes rate
+	rm -f "${partial}"
+	hfl_step "Downloading ${label}."
+	if ! curl "${CURL_TLS[@]}" \
+		--fail --show-error --location --progress-bar \
+		--retry 3 --retry-connrefused --retry-delay 2 \
+		"${url}" -o "${partial}"; then
+		rm -f "${partial}"
+		hfl_fail "Failed to download ${label}." 3
+	fi
+	mv -f "${partial}" "${destination}"
+	bytes="$(wc -c <"${destination}")"
+	elapsed=$((SECONDS - started))
+	((elapsed > 0)) || elapsed=1
+	rate="$(hfl_format_bytes "$((bytes / elapsed))")/s"
+	hfl_ok "${label} downloaded ($(hfl_format_bytes "${bytes}") in ${elapsed}s, average ${rate})."
+}
+
 CURL_TLS=(-k)
 if [[ "${HFL_INSECURE_TLS}" == "0" ]]; then
 	CURL_TLS=()
@@ -45,10 +90,13 @@ aarch64 | arm64) HFL_ARCH=arm64 ;;
 esac
 
 BIN="${TMPDIR:-/tmp}/hfl-enroll-$$"
-cleanup() { rm -f "${BIN}"; }
+cleanup() { rm -f "${BIN}" "${BIN}.part"; }
 trap cleanup EXIT
 
-curl "${CURL_TLS[@]}" -fsSL "${HFL_API_BASE}/media/enroll-bootstrap/hfl-enroll-darwin-${HFL_ARCH}" -o "${BIN}"
+hfl_download \
+	"HyperFileLens enrollment helper" \
+	"${HFL_API_BASE}/media/enroll-bootstrap/hfl-enroll-darwin-${HFL_ARCH}" \
+	"${BIN}"
 chmod +x "${BIN}"
 # Do not exec: trap EXIT must run after install so /tmp/hfl-enroll-* is removed on success or failure.
 "${BIN}" install "$@"

--- a/deploy/bootstrap/agent-bootstrap-windows.ps1
+++ b/deploy/bootstrap/agent-bootstrap-windows.ps1
@@ -17,6 +17,35 @@ function Write-HflBootstrapLog {
   Write-Host "[$ts] [$Level] $Message"
 }
 
+function Format-HflBytes {
+  param([Parameter(Mandatory = $true)][long]$Bytes)
+  $units = @('B', 'KiB', 'MiB', 'GiB', 'TiB')
+  $value = [double][Math]::Max(0, $Bytes)
+  $unit = 0
+  while ($value -ge 1024 -and $unit -lt ($units.Count - 1)) {
+    $value /= 1024
+    $unit++
+  }
+  if ($unit -eq 0) { return ('{0:N0} {1}' -f $value, $units[$unit]) }
+  return ('{0:N1} {1}' -f $value, $units[$unit])
+}
+
+function Write-HflDownloadProgress {
+  param(
+    [Parameter(Mandatory = $true)][long]$Downloaded,
+    [Parameter(Mandatory = $true)][long]$Total
+  )
+  $ts = [DateTime]::UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffZ")
+  if ($Total -gt 0) {
+    $percent = [Math]::Min(100, [Math]::Round(($Downloaded * 100.0) / $Total))
+    Write-Host -NoNewline ("`r[{0}] [PROG ] Enrollment helper {1}% - {2} / {3}" -f `
+        $ts, $percent, (Format-HflBytes $Downloaded), (Format-HflBytes $Total))
+    return
+  }
+  Write-Host -NoNewline ("`r[{0}] [PROG ] Enrollment helper - {1} downloaded" -f `
+      $ts, (Format-HflBytes $Downloaded))
+}
+
 if (-not (Test-HflAdmin)) {
   Write-HflBootstrapLog "INFO " "Administrator privileges are required. Approve the UAC prompt to continue."
   $argList = @('-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', $PSCommandPath)
@@ -41,12 +70,25 @@ function Get-HflEnrollmentBinary {
     [Parameter(Mandatory = $true)][string]$OutFile
   )
   $skipCert = ($env:HFL_INSECURE_TLS -ne '0')
+  $partial = "$OutFile.part"
+  Remove-Item -Force -LiteralPath $partial -ErrorAction SilentlyContinue
+  Write-HflBootstrapLog "STEP " "Downloading HyperFileLens enrollment helper."
 
   if (Get-Command curl.exe -ErrorAction SilentlyContinue) {
-    $curlArgs = @('-fL', '-o', $OutFile, $Url)
+    $curlArgs = @(
+      '-fL', '--show-error', '--progress-bar',
+      '--retry', '3', '--retry-connrefused', '--retry-delay', '2',
+      '-o', $partial, $Url
+    )
     if ($skipCert) { $curlArgs = @('-k') + $curlArgs }
     & curl.exe @curlArgs
-    if ($LASTEXITCODE -eq 0 -and (Test-Path -LiteralPath $OutFile)) { return }
+    if ($LASTEXITCODE -eq 0 -and (Test-Path -LiteralPath $partial)) {
+      Move-Item -Force -LiteralPath $partial -Destination $OutFile
+      $size = (Get-Item -LiteralPath $OutFile).Length
+      Write-HflBootstrapLog " OK  " "HyperFileLens enrollment helper downloaded ($(Format-HflBytes $size))."
+      return
+    }
+    Remove-Item -Force -LiteralPath $partial -ErrorAction SilentlyContinue
     Write-HflBootstrapLog "WARN " "curl download failed (exit $LASTEXITCODE). Trying PowerShell instead."
   }
 
@@ -55,9 +97,44 @@ function Get-HflEnrollmentBinary {
     if ($skipCert) {
       [Net.ServicePointManager]::ServerCertificateValidationCallback = { [bool]1 }
     }
-    (New-Object Net.WebClient).DownloadFile($Url, $OutFile)
+    $response = $null
+    $inputStream = $null
+    $outputStream = $null
+    $total = [long]-1
+    $downloaded = [long]0
+    try {
+      $request = [Net.HttpWebRequest]::Create($Url)
+      $response = $request.GetResponse()
+      $total = $response.ContentLength
+      $inputStream = $response.GetResponseStream()
+      $outputStream = [IO.File]::Open($partial, [IO.FileMode]::CreateNew, [IO.FileAccess]::Write)
+      $buffer = New-Object byte[] (1024 * 1024)
+      $lastUpdate = [DateTime]::UtcNow
+      while (($read = $inputStream.Read($buffer, 0, $buffer.Length)) -gt 0) {
+        $outputStream.Write($buffer, 0, $read)
+        $downloaded += $read
+        $now = [DateTime]::UtcNow
+        if (($now - $lastUpdate).TotalSeconds -ge 1) {
+          Write-HflDownloadProgress -Downloaded $downloaded -Total $total
+          $lastUpdate = $now
+        }
+      }
+    }
+    finally {
+      if ($null -ne $outputStream) { $outputStream.Dispose() }
+      if ($null -ne $inputStream) { $inputStream.Dispose() }
+      if ($null -ne $response) { $response.Dispose() }
+    }
+    if ($total -ge 0 -and $downloaded -ne $total) {
+      throw "Download size mismatch: received $downloaded bytes, expected $total."
+    }
+    Write-HflDownloadProgress -Downloaded $downloaded -Total $total
+    Write-Host
+    Move-Item -Force -LiteralPath $partial -Destination $OutFile
+    Write-HflBootstrapLog " OK  " "HyperFileLens enrollment helper downloaded ($(Format-HflBytes $downloaded))."
   }
   catch {
+    Remove-Item -Force -LiteralPath $partial -ErrorAction SilentlyContinue
     Write-HflBootstrapLog "FAIL " "Failed to download the enrollment tool: $($_.Exception.Message)"
     throw
   }
@@ -96,6 +173,9 @@ try {
 finally {
   if (Test-Path -LiteralPath $bin) {
     Remove-Item -Force -LiteralPath $bin -ErrorAction SilentlyContinue
+  }
+  if (Test-Path -LiteralPath "$bin.part") {
+    Remove-Item -Force -LiteralPath "$bin.part" -ErrorAction SilentlyContinue
   }
 }
 exit $exitCode

--- a/deploy/bootstrap/gateway-bootstrap-linux.sh
+++ b/deploy/bootstrap/gateway-bootstrap-linux.sh
@@ -27,6 +27,43 @@ hfl_fail() {
 	exit "${2:-1}"
 }
 
+hfl_format_bytes() {
+	awk -v bytes="$1" 'BEGIN {
+		split("B KiB MiB GiB TiB", units, " ")
+		value = bytes + 0
+		unit = 1
+		while (value >= 1024 && unit < 5) {
+			value /= 1024
+			unit++
+		}
+		if (unit == 1) printf "%.0f %s", value, units[unit]
+		else printf "%.1f %s", value, units[unit]
+	}'
+}
+
+hfl_download() {
+	local label="$1"
+	local url="$2"
+	local destination="$3"
+	local partial="${destination}.part"
+	local started=${SECONDS} elapsed bytes rate
+	rm -f "${partial}"
+	hfl_step "Downloading ${label}."
+	if ! curl "${CURL_TLS[@]}" \
+		--fail --show-error --location --progress-bar \
+		--retry 3 --retry-connrefused --retry-delay 2 \
+		"${url}" -o "${partial}"; then
+		rm -f "${partial}"
+		hfl_fail "Failed to download ${label}." 3
+	fi
+	mv -f "${partial}" "${destination}"
+	bytes="$(wc -c <"${destination}")"
+	elapsed=$((SECONDS - started))
+	((elapsed > 0)) || elapsed=1
+	rate="$(hfl_format_bytes "$((bytes / elapsed))")/s"
+	hfl_ok "${label} downloaded ($(hfl_format_bytes "${bytes}") in ${elapsed}s, average ${rate})."
+}
+
 hfl_build_enroll_args() {
 	HFL_ENROLL_ARGS=()
 	local has_yes=0
@@ -187,11 +224,13 @@ hfl_ok "SourceLens is reachable."
 ensure_docker_for_gateway
 
 BIN="${TMPDIR:-/tmp}/hfl-enroll-$$"
-cleanup() { rm -f "${BIN}"; }
+cleanup() { rm -f "${BIN}" "${BIN}.part"; }
 trap cleanup EXIT
 
-hfl_step "Downloading HyperFileLens enrollment helper."
-curl "${CURL_TLS[@]}" -fsSL "${HFL_API_BASE}/media/enroll-bootstrap/hfl-enroll-linux-${HFL_ARCH}" -o "${BIN}"
+hfl_download \
+	"HyperFileLens enrollment helper" \
+	"${HFL_API_BASE}/media/enroll-bootstrap/hfl-enroll-linux-${HFL_ARCH}" \
+	"${BIN}"
 chmod +x "${BIN}"
 # Do not exec: trap EXIT must run after gateway-install so /tmp/hfl-enroll-* is removed.
 hfl_build_enroll_args "$@"

--- a/deploy/bootstrap/gateway-install-docker-ubuntu-amd64.sh
+++ b/deploy/bootstrap/gateway-install-docker-ubuntu-amd64.sh
@@ -33,6 +33,43 @@ hfl_fail() {
 	exit "${2:-1}"
 }
 
+hfl_format_bytes() {
+	awk -v bytes="$1" 'BEGIN {
+		split("B KiB MiB GiB TiB", units, " ")
+		value = bytes + 0
+		unit = 1
+		while (value >= 1024 && unit < 5) {
+			value /= 1024
+			unit++
+		}
+		if (unit == 1) printf "%.0f %s", value, units[unit]
+		else printf "%.1f %s", value, units[unit]
+	}'
+}
+
+hfl_download() {
+	local label="$1"
+	local url="$2"
+	local destination="$3"
+	local partial="${destination}.part"
+	local started=${SECONDS} elapsed bytes rate
+	rm -f "${partial}"
+	hfl_step "Downloading ${label}."
+	if ! curl "${CURL_TLS[@]}" \
+		--fail --show-error --location --progress-bar \
+		--retry 3 --retry-connrefused --retry-delay 2 \
+		"${url}" -o "${partial}"; then
+		rm -f "${partial}"
+		hfl_fail "Failed to download ${label}." 3
+	fi
+	mv -f "${partial}" "${destination}"
+	bytes="$(wc -c <"${destination}")"
+	elapsed=$((SECONDS - started))
+	((elapsed > 0)) || elapsed=1
+	rate="$(hfl_format_bytes "$((bytes / elapsed))")/s"
+	hfl_ok "${label} downloaded ($(hfl_format_bytes "${bytes}") in ${elapsed}s, average ${rate})."
+}
+
 CURL_TLS=(-k)
 if [[ "${HFL_INSECURE_TLS:-1}" == "0" ]]; then
 	CURL_TLS=()
@@ -210,8 +247,10 @@ cleanup() { rm -rf "${work_dir}"; }
 trap cleanup EXIT
 
 archive_url="${base}/${DOCKER_DEBS_ARCHIVE}"
-hfl_step "Downloading Docker CE offline bundle."
-curl "${CURL_TLS[@]}" -fsSL "${archive_url}" -o "${work_dir}/${DOCKER_DEBS_ARCHIVE}"
+hfl_download \
+	"Docker CE offline bundle" \
+	"${archive_url}" \
+	"${work_dir}/${DOCKER_DEBS_ARCHIVE}"
 
 tar -xzf "${work_dir}/${DOCKER_DEBS_ARCHIVE}" -C "${work_dir}"
 deb_count="$(find "${work_dir}" -maxdepth 2 -name '*.deb' | wc -l | tr -d ' ')"

--- a/deploy/bootstrap/gateway-lifecycle.sh
+++ b/deploy/bootstrap/gateway-lifecycle.sh
@@ -160,9 +160,18 @@ compose_down_sidecar() {
 }
 
 download_bootstrap_file() {
-	local name=$1 dest=$2
+	local name=$1 dest=$2 partial="${2}.part"
+	rm -f "${partial}"
 	hfl_log "Downloading ${name} from console."
-	curl "${curl_tls[@]}" -fsSL "${GATEWAY_BOOTSTRAP_BASE}/${name}" -o "${dest}"
+	if ! curl "${curl_tls[@]}" \
+		--fail --show-error --location --progress-bar \
+		--retry 3 --retry-connrefused --retry-delay 2 \
+		"${GATEWAY_BOOTSTRAP_BASE}/${name}" -o "${partial}"; then
+		rm -f "${partial}"
+		hfl_fail "failed to download ${name}" 3
+	fi
+	mv -f "${partial}" "${dest}"
+	hfl_log "Downloaded ${name} ($(wc -c <"${dest}") bytes)."
 	chmod +x "${dest}" 2>/dev/null || true
 }
 

--- a/src/agent/internal/enroll/download_progress.go
+++ b/src/agent/internal/enroll/download_progress.go
@@ -1,0 +1,217 @@
+package enroll
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"net/url"
+	"os"
+	"path"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/mattn/go-isatty"
+
+	"hyperfilelens/agent/internal/model"
+	platforminstall "hyperfilelens/agent/internal/platform/install"
+)
+
+const nonTerminalProgressInterval = 5 * time.Second
+
+type downloadProgressDisplay struct {
+	label          string
+	terminal       bool
+	mu             sync.Mutex
+	lastLogged     time.Duration
+	latest         platforminstall.DownloadProgress
+	terminalActive bool
+}
+
+func newDownloadProgressDisplay(label string) *downloadProgressDisplay {
+	return &downloadProgressDisplay{
+		label:    label,
+		terminal: isatty.IsTerminal(os.Stdout.Fd()),
+	}
+}
+
+func (display *downloadProgressDisplay) report(progress platforminstall.DownloadProgress) {
+	display.mu.Lock()
+	defer display.mu.Unlock()
+	display.latest = progress
+	if !display.terminal && !progress.Completed {
+		if progress.Elapsed-display.lastLogged < nonTerminalProgressInterval {
+			return
+		}
+		display.lastLogged = progress.Elapsed
+	}
+	line := fmt.Sprintf(
+		"[%s] [PROG ] %s %s",
+		logTimestamp(),
+		display.label,
+		formatDownloadProgress(progress),
+	)
+	if display.terminal {
+		fmt.Fprintf(os.Stdout, "\r%s\033[K", line)
+		display.terminalActive = !progress.Completed
+		if progress.Completed {
+			fmt.Fprintln(os.Stdout)
+		}
+		return
+	}
+	fmt.Fprintln(os.Stdout, line)
+}
+
+func (display *downloadProgressDisplay) abort() {
+	display.mu.Lock()
+	defer display.mu.Unlock()
+	if display.terminal && display.terminalActive {
+		fmt.Fprintln(os.Stdout)
+		display.terminalActive = false
+	}
+}
+
+func (display *downloadProgressDisplay) successMessage() string {
+	display.mu.Lock()
+	defer display.mu.Unlock()
+	progress := display.latest
+	average := float64(0)
+	if progress.Elapsed > 0 {
+		average = float64(progress.DownloadedBytes) / progress.Elapsed.Seconds()
+	}
+	return fmt.Sprintf(
+		"%s downloaded (%s in %s, average %s)",
+		display.label,
+		formatByteCount(progress.DownloadedBytes),
+		formatElapsed(progress.Elapsed),
+		formatRate(average),
+	)
+}
+
+func downloadWithProgress(
+	ctx context.Context,
+	rawURL string,
+	destPath string,
+	label string,
+) error {
+	display := newDownloadProgressDisplay(label)
+	err := platforminstall.DownloadURLWithProgress(
+		ctx,
+		rawURL,
+		destPath,
+		display.report,
+	)
+	if err != nil {
+		display.abort()
+		return err
+	}
+	logOK(display.successMessage())
+	return nil
+}
+
+func formatDownloadProgress(progress platforminstall.DownloadProgress) string {
+	downloaded := formatByteCount(progress.DownloadedBytes)
+	elapsed := formatElapsed(progress.Elapsed)
+	if progress.TotalBytes <= 0 {
+		if progress.BytesPerSecond <= 0 && !progress.Completed {
+			return fmt.Sprintf("%s downloaded | waiting for data | elapsed %s", downloaded, elapsed)
+		}
+		return fmt.Sprintf(
+			"%s downloaded | %s | elapsed %s",
+			downloaded,
+			formatRate(progress.BytesPerSecond),
+			elapsed,
+		)
+	}
+	percent := float64(progress.DownloadedBytes) / float64(progress.TotalBytes) * 100
+	percent = math.Max(0, math.Min(100, percent))
+	filled := int(math.Round(percent / 5))
+	filled = max(0, min(20, filled))
+	bar := "[" + strings.Repeat("#", filled) + strings.Repeat("-", 20-filled) + "]"
+	parts := []string{
+		bar,
+		fmt.Sprintf("%3.0f%%", percent),
+		fmt.Sprintf("%s / %s", downloaded, formatByteCount(progress.TotalBytes)),
+	}
+	if progress.BytesPerSecond <= 0 && !progress.Completed {
+		parts = append(parts, "waiting for data", "elapsed "+elapsed)
+		return strings.Join(parts, " | ")
+	}
+	parts = append(parts, formatRate(progress.BytesPerSecond))
+	remaining := progress.TotalBytes - progress.DownloadedBytes
+	if remaining > 0 && progress.BytesPerSecond > 0 && !progress.Completed {
+		eta := time.Duration(float64(remaining)/progress.BytesPerSecond) * time.Second
+		parts = append(parts, "ETA "+formatElapsed(eta))
+	}
+	return strings.Join(parts, " | ")
+}
+
+func formatByteCount(bytes int64) string {
+	if bytes < 0 {
+		bytes = 0
+	}
+	const unit = int64(1024)
+	if bytes < unit {
+		return fmt.Sprintf("%d B", bytes)
+	}
+	units := []string{"KiB", "MiB", "GiB", "TiB"}
+	value := float64(bytes)
+	index := -1
+	for value >= float64(unit) && index < len(units)-1 {
+		value /= float64(unit)
+		index++
+	}
+	return fmt.Sprintf("%.1f %s", value, units[index])
+}
+
+func formatRate(bytesPerSecond float64) string {
+	if bytesPerSecond < 0 {
+		bytesPerSecond = 0
+	}
+	return formatByteCount(int64(bytesPerSecond)) + "/s"
+}
+
+func formatElapsed(duration time.Duration) string {
+	seconds := int64(math.Ceil(duration.Seconds()))
+	if seconds < 1 {
+		seconds = 1
+	}
+	if seconds < 60 {
+		return fmt.Sprintf("%ds", seconds)
+	}
+	minutes := seconds / 60
+	seconds %= 60
+	if minutes < 60 {
+		return fmt.Sprintf("%dm %02ds", minutes, seconds)
+	}
+	hours := minutes / 60
+	minutes %= 60
+	return fmt.Sprintf("%dh %02dm %02ds", hours, minutes, seconds)
+}
+
+func roleDisplayName(role model.Role) string {
+	switch role {
+	case model.RoleProxy:
+		return "Proxy Host"
+	case model.RoleGateway:
+		return "Data Gateway"
+	default:
+		return "Source Host"
+	}
+}
+
+func agentPackageLabel(role model.Role) string {
+	return roleDisplayName(role) + " Agent package"
+}
+
+func safeDownloadFilename(rawURL string) string {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return ""
+	}
+	name := path.Base(parsed.Path)
+	if name == "." || name == "/" || name == "" {
+		return ""
+	}
+	return name
+}

--- a/src/agent/internal/enroll/download_progress_test.go
+++ b/src/agent/internal/enroll/download_progress_test.go
@@ -1,0 +1,64 @@
+package enroll
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"hyperfilelens/agent/internal/model"
+	platforminstall "hyperfilelens/agent/internal/platform/install"
+)
+
+func TestFormatDownloadProgressKnownLength(t *testing.T) {
+	line := formatDownloadProgress(platforminstall.DownloadProgress{
+		DownloadedBytes: 5 * 1024 * 1024,
+		TotalBytes:      10 * 1024 * 1024,
+		Elapsed:         5 * time.Second,
+		BytesPerSecond:  1024 * 1024,
+	})
+	for _, expected := range []string{
+		"50%",
+		"5.0 MiB / 10.0 MiB",
+		"1.0 MiB/s",
+		"ETA 5s",
+	} {
+		if !strings.Contains(line, expected) {
+			t.Fatalf("progress %q does not contain %q", line, expected)
+		}
+	}
+}
+
+func TestFormatDownloadProgressWaitingWithoutLength(t *testing.T) {
+	line := formatDownloadProgress(platforminstall.DownloadProgress{
+		DownloadedBytes: 3 * 1024,
+		TotalBytes:      -1,
+		Elapsed:         7 * time.Second,
+	})
+	for _, expected := range []string{"3.0 KiB downloaded", "waiting for data", "elapsed 7s"} {
+		if !strings.Contains(line, expected) {
+			t.Fatalf("progress %q does not contain %q", line, expected)
+		}
+	}
+}
+
+func TestRoleDownloadLabels(t *testing.T) {
+	cases := map[model.Role]string{
+		model.RoleAgent:   "Source Host Agent package",
+		model.RoleProxy:   "Proxy Host Agent package",
+		model.RoleGateway: "Data Gateway Agent package",
+	}
+	for role, expected := range cases {
+		if got := agentPackageLabel(role); got != expected {
+			t.Fatalf("role %q label=%q, want %q", role, got, expected)
+		}
+	}
+}
+
+func TestSafeDownloadFilenameExcludesQuery(t *testing.T) {
+	got := safeDownloadFilename(
+		"https://console.example/media/agent.tar.gz?token=must-not-appear",
+	)
+	if got != "agent.tar.gz" || strings.Contains(got, "must-not-appear") {
+		t.Fatalf("unsafe download filename: %q", got)
+	}
+}

--- a/src/agent/internal/enroll/install.go
+++ b/src/agent/internal/enroll/install.go
@@ -183,19 +183,31 @@ func installAgentPackage(ctx context.Context, cfg Config, agentVer *string) erro
 		logStep("Downloading the agent package.")
 	}
 
-	archivePath, cleanup, err := downloadReleaseArchive(ctx, dl)
+	if filename := safeDownloadFilename(dl); filename != "" {
+		logInfo("Selected package: " + filename)
+	}
+	archivePath, cleanup, err := downloadReleaseArchive(
+		ctx,
+		dl,
+		agentPackageLabel(cfg.NodeRole),
+	)
 	if err != nil {
 		return err
 	}
 	defer cleanup()
 
+	label := roleDisplayName(cfg.NodeRole) + " Agent package"
+	logStep("Extracting " + label + ".")
 	bundleRoot, err := extractReleaseBundle(ctx, archivePath)
 	if err != nil {
 		return err
 	}
+	logOK(label + " extracted")
+	logStep("Verifying " + label + ".")
 	if err := validateAgentPackage(bundleRoot, cfg.NodeRole, releaseVersion); err != nil {
 		return fmt.Errorf("Agent package validation failed: %w", err)
 	}
+	logOK(label + " verified")
 
 	logStep("Installing agent binaries and service.")
 	if err := RunBundleInstall(ctx, bundleRoot, cfg); err != nil {
@@ -216,18 +228,30 @@ func upgradeAgentPackage(ctx context.Context, cfg Config, downloadURL, releaseVe
 		logStep("Downloading the agent package.")
 	}
 
-	archivePath, cleanup, err := downloadReleaseArchive(ctx, downloadURL)
+	if filename := safeDownloadFilename(downloadURL); filename != "" {
+		logInfo("Selected package: " + filename)
+	}
+	archivePath, cleanup, err := downloadReleaseArchive(
+		ctx,
+		downloadURL,
+		agentPackageLabel(cfg.NodeRole),
+	)
 	if err != nil {
 		return err
 	}
 	defer cleanup()
+	label := roleDisplayName(cfg.NodeRole) + " Agent package"
+	logStep("Extracting " + label + ".")
 	bundleRoot, err := extractReleaseBundle(ctx, archivePath)
 	if err != nil {
 		return err
 	}
+	logOK(label + " extracted")
+	logStep("Verifying " + label + ".")
 	if err := validateAgentPackage(bundleRoot, cfg.NodeRole, releaseVersion); err != nil {
 		return fmt.Errorf("Agent package validation failed: %w", err)
 	}
+	logOK(label + " verified")
 
 	logStep("Upgrading agent binaries.")
 	if err := RunBundleUpgrade(ctx, archivePath); err != nil {
@@ -247,7 +271,11 @@ func resolveRelease(ctx context.Context, cfg Config) (downloadURL, version strin
 	return downloadURL, version, nil
 }
 
-func downloadReleaseArchive(ctx context.Context, downloadURL string) (archivePath string, cleanup func(), err error) {
+func downloadReleaseArchive(
+	ctx context.Context,
+	downloadURL string,
+	label string,
+) (archivePath string, cleanup func(), err error) {
 	workDir, err := os.MkdirTemp("", "hfl-enroll-")
 	if err != nil {
 		return "", nil, fmt.Errorf("temp dir: %w", err)
@@ -259,7 +287,7 @@ func downloadReleaseArchive(ctx context.Context, downloadURL string) (archivePat
 		ext = ".zip"
 	}
 	archivePath = filepath.Join(workDir, "package"+ext)
-	if err := install.DownloadURL(ctx, downloadURL, archivePath); err != nil {
+	if err := downloadWithProgress(ctx, downloadURL, archivePath, label); err != nil {
 		cleanup()
 		return "", nil, fmt.Errorf("Download failed: %w", err)
 	}

--- a/src/agent/internal/enroll/output.go
+++ b/src/agent/internal/enroll/output.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	"github.com/mattn/go-isatty"
+
+	"hyperfilelens/agent/internal/model"
 )
 
 const (
@@ -107,12 +109,19 @@ type SummaryInfo struct {
 	Console     string
 }
 
-func printEnrollmentContext(consoleURL, orgKey, role, platform, hostname string) {
-	logInfo("Starting HyperFileLens agent enrollment.")
+func printEnrollmentContext(
+	consoleURL string,
+	orgKey string,
+	role model.Role,
+	platform string,
+	hostname string,
+) {
+	displayRole := roleDisplayName(role)
+	logInfo("Starting HyperFileLens " + displayRole + " enrollment.")
 	parts := []string{
 		"Console: " + consoleURL,
 		"Organization: " + orgKey,
-		"Role: " + role,
+		"Role: " + displayRole,
 		"Platform: " + platform,
 	}
 	if hostname != "" {

--- a/src/agent/internal/enroll/preflight.go
+++ b/src/agent/internal/enroll/preflight.go
@@ -55,7 +55,7 @@ func RunEnvironmentChecks(ctx context.Context, cfg Config) (*EnvironmentReport, 
 		report.RoleOK = true
 	}
 
-	printEnrollmentContext(cfg.APIBase, cfg.OrgKey, string(cfg.NodeRole), report.Platform, hostname.Name)
+	printEnrollmentContext(cfg.APIBase, cfg.OrgKey, cfg.NodeRole, report.Platform, hostname.Name)
 
 	if report.PrivilegesOK {
 		logOKDetail("Running with administrator privileges", adminPrivilegeDetail())

--- a/src/agent/internal/enroll/sidecar_install_unix.go
+++ b/src/agent/internal/enroll/sidecar_install_unix.go
@@ -203,7 +203,7 @@ func ensureLensnodeImage(ctx context.Context, cfg Config) error {
 	url := strings.TrimRight(cfg.APIBase, "/") + "/media/gateway-bootstrap/" + lensnodeImageArchive
 	archivePath := filepath.Join(workDir, lensnodeImageArchive)
 	logStep("Downloading LensNode container image bundle.")
-	if err := install.DownloadURL(ctx, url, archivePath); err != nil {
+	if err := downloadWithProgress(ctx, url, archivePath, "LensNode image bundle"); err != nil {
 		return fmt.Errorf("download lensnode image bundle: %w", err)
 	}
 

--- a/src/agent/internal/platform/install/download.go
+++ b/src/agent/internal/platform/install/download.go
@@ -1,0 +1,209 @@
+package install
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"time"
+)
+
+const defaultDownloadProgressInterval = time.Second
+
+// DownloadProgress describes one safe, URL-free transfer progress snapshot.
+type DownloadProgress struct {
+	DownloadedBytes int64
+	TotalBytes      int64
+	Elapsed         time.Duration
+	BytesPerSecond  float64
+	Completed       bool
+}
+
+// ProgressReporter receives rate-limited download progress snapshots.
+type ProgressReporter func(DownloadProgress)
+
+// DownloadURL streams url into destPath without interactive progress output.
+func DownloadURL(ctx context.Context, rawURL, destPath string) error {
+	return DownloadURLWithProgress(ctx, rawURL, destPath, nil)
+}
+
+// DownloadURLWithProgress safely downloads one file and reports transfer progress.
+func DownloadURLWithProgress(
+	ctx context.Context,
+	rawURL string,
+	destPath string,
+	reporter ProgressReporter,
+) error {
+	return downloadURLWithInterval(
+		ctx,
+		rawURL,
+		destPath,
+		reporter,
+		defaultDownloadProgressInterval,
+	)
+}
+
+func downloadURLWithInterval(
+	ctx context.Context,
+	rawURL string,
+	destPath string,
+	reporter ProgressReporter,
+	interval time.Duration,
+) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return fmt.Errorf("create download request: %w", sanitizeDownloadError(err))
+	}
+	client := &http.Client{Timeout: 30 * time.Minute}
+	if os.Getenv("HFL_INSECURE_TLS") != "0" {
+		client.Transport = insecureTransport()
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("download request failed: %w", sanitizeDownloadError(err))
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("download HTTP %s", resp.Status)
+	}
+	if err := os.MkdirAll(filepath.Dir(destPath), 0o755); err != nil {
+		return err
+	}
+
+	partPath := destPath + ".part"
+	if err := os.Remove(partPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("remove stale partial download: %w", err)
+	}
+	file, err := os.OpenFile(partPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	if err != nil {
+		return err
+	}
+	completed := false
+	defer func() {
+		_ = file.Close()
+		if !completed {
+			_ = os.Remove(partPath)
+		}
+	}()
+
+	started := time.Now()
+	var downloaded atomic.Int64
+	stopProgress := startDownloadProgress(
+		reporter,
+		&downloaded,
+		resp.ContentLength,
+		started,
+		interval,
+	)
+	written, copyErr := io.Copy(file, io.TeeReader(resp.Body, byteCounter{value: &downloaded}))
+	stopProgress(false)
+	if copyErr != nil {
+		return fmt.Errorf("download stream failed: %w", sanitizeDownloadError(copyErr))
+	}
+	if resp.ContentLength >= 0 && written != resp.ContentLength {
+		return fmt.Errorf(
+			"download size mismatch: received %d bytes, expected %d",
+			written,
+			resp.ContentLength,
+		)
+	}
+	if err := file.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(partPath, destPath); err != nil {
+		return err
+	}
+	completed = true
+	stopProgress(true)
+	return nil
+}
+
+type byteCounter struct {
+	value *atomic.Int64
+}
+
+func (counter byteCounter) Write(p []byte) (int, error) {
+	counter.value.Add(int64(len(p)))
+	return len(p), nil
+}
+
+func startDownloadProgress(
+	reporter ProgressReporter,
+	downloaded *atomic.Int64,
+	total int64,
+	started time.Time,
+	interval time.Duration,
+) func(completed bool) {
+	if reporter == nil {
+		return func(bool) {}
+	}
+	if interval <= 0 {
+		interval = defaultDownloadProgressInterval
+	}
+	done := make(chan struct{})
+	stopped := make(chan struct{})
+	go func() {
+		defer close(stopped)
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		lastBytes := int64(0)
+		lastAt := started
+		for {
+			select {
+			case now := <-ticker.C:
+				current := downloaded.Load()
+				seconds := now.Sub(lastAt).Seconds()
+				rate := float64(0)
+				if seconds > 0 {
+					rate = float64(current-lastBytes) / seconds
+				}
+				reporter(DownloadProgress{
+					DownloadedBytes: current,
+					TotalBytes:      total,
+					Elapsed:         now.Sub(started),
+					BytesPerSecond:  rate,
+				})
+				lastBytes = current
+				lastAt = now
+			case <-done:
+				return
+			}
+		}
+	}()
+	var stoppedOnce atomic.Bool
+	return func(completed bool) {
+		if stoppedOnce.CompareAndSwap(false, true) {
+			close(done)
+			<-stopped
+		}
+		if !completed {
+			return
+		}
+		elapsed := time.Since(started)
+		current := downloaded.Load()
+		rate := float64(0)
+		if elapsed > 0 {
+			rate = float64(current) / elapsed.Seconds()
+		}
+		reporter(DownloadProgress{
+			DownloadedBytes: current,
+			TotalBytes:      total,
+			Elapsed:         elapsed,
+			BytesPerSecond:  rate,
+			Completed:       true,
+		})
+	}
+}
+
+func sanitizeDownloadError(err error) error {
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) && urlErr.Err != nil {
+		return urlErr.Err
+	}
+	return err
+}

--- a/src/agent/internal/platform/install/download_test.go
+++ b/src/agent/internal/platform/install/download_test.go
@@ -1,0 +1,217 @@
+package install
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestDownloadURLWithProgressKnownLength(t *testing.T) {
+	t.Setenv("HFL_INSECURE_TLS", "0")
+	payload := bytes.Repeat([]byte("download-progress-"), 4096)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Length", fmt.Sprint(len(payload)))
+		flusher, _ := w.(http.Flusher)
+		for offset := 0; offset < len(payload); offset += 4096 {
+			end := min(offset+4096, len(payload))
+			_, _ = w.Write(payload[offset:end])
+			if flusher != nil {
+				flusher.Flush()
+			}
+			time.Sleep(time.Millisecond)
+		}
+	}))
+	defer server.Close()
+
+	destination := filepath.Join(t.TempDir(), "artifact.tar.gz")
+	var mu sync.Mutex
+	events := make([]DownloadProgress, 0)
+	err := downloadURLWithInterval(
+		context.Background(),
+		server.URL+"/artifact?token=must-not-be-logged",
+		destination,
+		func(progress DownloadProgress) {
+			mu.Lock()
+			defer mu.Unlock()
+			events = append(events, progress)
+		},
+		2*time.Millisecond,
+	)
+	if err != nil {
+		t.Fatalf("download failed: %v", err)
+	}
+	got, err := os.ReadFile(destination)
+	if err != nil {
+		t.Fatalf("read destination: %v", err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatal("downloaded content does not match payload")
+	}
+	if _, err := os.Stat(destination + ".part"); !os.IsNotExist(err) {
+		t.Fatalf("partial file was not removed: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(events) < 2 {
+		t.Fatalf("expected intermediate and final progress, got %d event(s)", len(events))
+	}
+	final := events[len(events)-1]
+	if !final.Completed {
+		t.Fatal("final progress event is not complete")
+	}
+	if final.DownloadedBytes != int64(len(payload)) || final.TotalBytes != int64(len(payload)) {
+		t.Fatalf("unexpected final progress: %#v", final)
+	}
+}
+
+func TestDownloadURLWithProgressUnknownLength(t *testing.T) {
+	t.Setenv("HFL_INSECURE_TLS", "0")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		flusher := w.(http.Flusher)
+		for range 4 {
+			_, _ = w.Write([]byte("chunked-transfer"))
+			flusher.Flush()
+			time.Sleep(3 * time.Millisecond)
+		}
+	}))
+	defer server.Close()
+
+	destination := filepath.Join(t.TempDir(), "artifact.tar.gz")
+	var final DownloadProgress
+	err := downloadURLWithInterval(
+		context.Background(),
+		server.URL,
+		destination,
+		func(progress DownloadProgress) {
+			if progress.Completed {
+				final = progress
+			}
+		},
+		time.Millisecond,
+	)
+	if err != nil {
+		t.Fatalf("download failed: %v", err)
+	}
+	if !final.Completed || final.TotalBytes != -1 || final.DownloadedBytes == 0 {
+		t.Fatalf("unexpected final progress: %#v", final)
+	}
+}
+
+func TestDownloadURLReportsHeartbeatWhileWaitingForData(t *testing.T) {
+	t.Setenv("HFL_INSECURE_TLS", "0")
+	payload := []byte("delayed payload")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Length", fmt.Sprint(len(payload)))
+		w.WriteHeader(http.StatusOK)
+		w.(http.Flusher).Flush()
+		time.Sleep(25 * time.Millisecond)
+		_, _ = w.Write(payload)
+	}))
+	defer server.Close()
+
+	var mu sync.Mutex
+	events := make([]DownloadProgress, 0)
+	err := downloadURLWithInterval(
+		context.Background(),
+		server.URL,
+		filepath.Join(t.TempDir(), "artifact"),
+		func(progress DownloadProgress) {
+			mu.Lock()
+			defer mu.Unlock()
+			events = append(events, progress)
+		},
+		5*time.Millisecond,
+	)
+	if err != nil {
+		t.Fatalf("download failed: %v", err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	waitingEvents := 0
+	for _, event := range events {
+		if !event.Completed && event.DownloadedBytes == 0 {
+			waitingEvents++
+		}
+	}
+	if waitingEvents == 0 {
+		t.Fatalf("expected a waiting heartbeat, got %#v", events)
+	}
+}
+
+func TestDownloadURLRemovesPartialOnContextCancellation(t *testing.T) {
+	t.Setenv("HFL_INSECURE_TLS", "0")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		w.Header().Set("Content-Length", "1024")
+		w.WriteHeader(http.StatusOK)
+		w.(http.Flusher).Flush()
+		<-request.Context().Done()
+	}))
+	defer server.Close()
+
+	destination := filepath.Join(t.TempDir(), "artifact")
+	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
+	defer cancel()
+	err := DownloadURL(ctx, server.URL, destination)
+	if err == nil {
+		t.Fatal("expected canceled download to fail")
+	}
+	for _, path := range []string{destination, destination + ".part"} {
+		if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
+			t.Fatalf("canceled download left %s: %v", path, statErr)
+		}
+	}
+}
+
+func TestDownloadURLPreservesDestinationAndRemovesPartialOnFailure(t *testing.T) {
+	t.Setenv("HFL_INSECURE_TLS", "0")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Length", "64")
+		_, _ = w.Write([]byte("truncated"))
+	}))
+	defer server.Close()
+
+	destination := filepath.Join(t.TempDir(), "artifact.tar.gz")
+	if err := os.WriteFile(destination, []byte("installed-good-copy"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	err := DownloadURL(context.Background(), server.URL, destination)
+	if err == nil {
+		t.Fatal("expected truncated download to fail")
+	}
+	got, readErr := os.ReadFile(destination)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if string(got) != "installed-good-copy" {
+		t.Fatalf("existing destination was replaced: %q", got)
+	}
+	if _, statErr := os.Stat(destination + ".part"); !os.IsNotExist(statErr) {
+		t.Fatalf("partial file was not removed: %v", statErr)
+	}
+}
+
+func TestDownloadURLErrorDoesNotExposeSignedURL(t *testing.T) {
+	t.Setenv("HFL_INSECURE_TLS", "0")
+	rawURL := "http://127.0.0.1:1/artifact?token=must-not-appear"
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	err := DownloadURL(ctx, rawURL, filepath.Join(t.TempDir(), "artifact"))
+	if err == nil {
+		t.Fatal("expected connection failure")
+	}
+	message := err.Error()
+	for _, secret := range []string{"must-not-appear", rawURL} {
+		if strings.Contains(message, secret) {
+			t.Fatalf("download error exposed signed URL data: %s", message)
+		}
+	}
+}

--- a/src/agent/internal/platform/install/lifecycle.go
+++ b/src/agent/internal/platform/install/lifecycle.go
@@ -3,14 +3,11 @@ package install
 import (
 	"context"
 	"fmt"
-	"io"
-	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
-	"time"
 
 	"hyperfilelens/agent/internal/platform/vfs"
 )
@@ -62,36 +59,6 @@ func uninstallCommand(bundleDir string, keepData bool) (string, []string) {
 		args = append(args, "--purge-all")
 	}
 	return filepath.Join(bundleDir, "install.sh"), args
-}
-
-// DownloadURL streams url into destPath (TLS verify skipped unless HFL_INSECURE_TLS=0).
-func DownloadURL(ctx context.Context, url, destPath string) error {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-	if err != nil {
-		return err
-	}
-	client := &http.Client{Timeout: 30 * time.Minute}
-	if os.Getenv("HFL_INSECURE_TLS") != "0" {
-		client.Transport = insecureTransport()
-	}
-	resp, err := client.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return fmt.Errorf("download HTTP %s", resp.Status)
-	}
-	if err := os.MkdirAll(filepath.Dir(destPath), 0o755); err != nil {
-		return err
-	}
-	f, err := os.Create(destPath)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-	_, err = io.Copy(f, resp.Body)
-	return err
 }
 
 // ExtractArchive unpacks tar.gz (Unix) or zip (Windows) into destDir.

--- a/src/frontend/src/lib/nodeApi.test.ts
+++ b/src/frontend/src/lib/nodeApi.test.ts
@@ -100,6 +100,7 @@ describe('Data Gateway enrollment', () => {
 
     expect(result.command).toContain('TLS certificate verification is disabled')
     expect(result.command).toContain('curl -k --fail --show-error --location')
+    expect(result.command).toContain('--location --progress-bar')
     expect(result.tlsVerify).toBe(false)
   })
 

--- a/src/frontend/src/lib/nodeApi.ts
+++ b/src/frontend/src/lib/nodeApi.ts
@@ -375,7 +375,7 @@ function buildPosixEnrollmentInstallCommand(
   const warning = tlsVerify
     ? ''
     : "echo 'WARNING: TLS certificate verification is disabled. Use only on a trusted private network.' >&2\n"
-  return `${warning}tmp="$(mktemp /tmp/${bootstrapName}.XXXXXX)" && (\n  trap 'rm -f "$tmp"' EXIT\n  curl ${tlsOptions} --fail --show-error --location '${url}' -o "$tmp"\n  sudo bash "$tmp"\n)`
+  return `${warning}tmp="$(mktemp /tmp/${bootstrapName}.XXXXXX)" && (\n  trap 'rm -f "$tmp"' EXIT\n  curl ${tlsOptions} --fail --show-error --location --progress-bar '${url}' -o "$tmp"\n  sudo bash "$tmp"\n)`
 }
 
 /** One-liner for target host (curl pipe / download + run). Shown on deploy pages only. */

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -509,10 +509,31 @@ grep -F 'build/dependencies/docker/ubuntu-${ubuntu_release}/amd64' "${agent_publ
 agent_bootstrap_linux="${ROOT}/deploy/bootstrap/agent-bootstrap-linux.sh"
 agent_bootstrap_macos="${ROOT}/deploy/bootstrap/agent-bootstrap-macos.sh"
 agent_bootstrap_windows="${ROOT}/deploy/bootstrap/agent-bootstrap-windows.ps1"
+gateway_bootstrap_linux="${ROOT}/deploy/bootstrap/gateway-bootstrap-linux.sh"
+gateway_docker_installer="${ROOT}/deploy/bootstrap/gateway-install-docker-ubuntu-amd64.sh"
+gateway_lifecycle="${ROOT}/deploy/bootstrap/gateway-lifecycle.sh"
 grep -F 'requires a systemd-based Linux distribution' "${agent_bootstrap_linux}" >/dev/null
 grep -F 'systemctl show-environment' "${agent_bootstrap_linux}" >/dev/null
 grep -F 'launchd is required to install the agent service on macOS' "${agent_bootstrap_macos}" >/dev/null
 grep -F 'Windows ARM64 is not supported by this release' "${agent_bootstrap_windows}" >/dev/null
+for bootstrap in "${agent_bootstrap_linux}" "${agent_bootstrap_macos}"; do
+	grep -F -- '--fail --show-error --location --progress-bar' "${bootstrap}" >/dev/null
+	grep -F -- '--retry 3 --retry-connrefused --retry-delay 2' "${bootstrap}" >/dev/null
+	grep -F 'HyperFileLens enrollment helper' "${bootstrap}" >/dev/null
+	grep -F 'partial="${destination}.part"' "${bootstrap}" >/dev/null
+done
+for bootstrap in "${gateway_bootstrap_linux}" "${gateway_docker_installer}"; do
+	grep -F -- '--fail --show-error --location --progress-bar' "${bootstrap}" >/dev/null
+	grep -F -- '--retry 3 --retry-connrefused --retry-delay 2' "${bootstrap}" >/dev/null
+	grep -F 'partial="${destination}.part"' "${bootstrap}" >/dev/null
+done
+grep -F -- '--fail --show-error --location --progress-bar' "${gateway_lifecycle}" >/dev/null
+grep -F -- '--retry 3 --retry-connrefused --retry-delay 2' "${gateway_lifecycle}" >/dev/null
+grep -F 'partial="${2}.part"' "${gateway_lifecycle}" >/dev/null
+grep -F 'Docker CE offline bundle' "${gateway_docker_installer}" >/dev/null
+grep -F -- "'--progress-bar'" "${agent_bootstrap_windows}" >/dev/null
+grep -F 'Write-HflDownloadProgress' "${agent_bootstrap_windows}" >/dev/null
+grep -F 'Download size mismatch' "${agent_bootstrap_windows}" >/dev/null
 if grep -F 'hfl-enroll-windows-$archRel.exe' "${agent_bootstrap_windows}" >/dev/null \
 	&& ! grep -F '"ARM64" {' "${agent_bootstrap_windows}" >/dev/null; then
 	printf 'ERROR: Windows bootstrap may request an unsupported ARM64 enrollment binary\n' >&2
@@ -525,6 +546,8 @@ remote_deploy="${ROOT}/.github/scripts/remote-deploy.sh"
 	exit 1
 }
 grep -F 'browser_download_url' "${remote_deploy}" >/dev/null
+grep -F -- '--progress-bar' "${remote_deploy}" >/dev/null
+grep -F 'partial="${output}.part"' "${remote_deploy}" >/dev/null
 grep -F 'bash "${package_root}/install.sh" "${install_args[@]}"' \
 	"${remote_deploy}" >/dev/null
 if grep -F 'install.sh" platform-gateway ensure' "${remote_deploy}" >/dev/null; then

--- a/tools/quality/test-bootstrap-download-progress.sh
+++ b/tools/quality/test-bootstrap-download-progress.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Validate interactive bootstrap download progress, retries, and partial-file cleanup.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+bootstrap="${ROOT}/deploy/bootstrap/agent-bootstrap-linux.sh"
+tmp="$(mktemp -d)"
+trap 'rm -rf "${tmp}"' EXIT
+mkdir -p "${tmp}/bin"
+
+cat >"${tmp}/bin/curl" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+output=""
+while (($#)); do
+	printf '%s\n' "$1" >>"${HFL_TEST_CURL_LOG}"
+	case "$1" in
+	-o)
+		output=${2-}
+		printf '%s\n' "${2-}" >>"${HFL_TEST_CURL_LOG}"
+		shift 2
+		;;
+	*) shift ;;
+	esac
+done
+[[ -n "${output}" ]] || exit 2
+printf 'bootstrap-download-fixture\n' >"${output}"
+if [[ "${HFL_TEST_CURL_FAIL:-0}" == "1" ]]; then
+	exit 7
+fi
+SH
+chmod +x "${tmp}/bin/curl"
+
+# Load only the standalone bootstrap logging and download helpers.
+source <(sed -n '/^hfl_now()/,/^hfl_build_enroll_args()/p' "${bootstrap}" | sed '$d')
+CURL_TLS=()
+PATH="${tmp}/bin:${PATH}"
+export PATH HFL_TEST_CURL_LOG="${tmp}/curl.log"
+
+destination="${tmp}/hfl-enroll"
+output="$(hfl_download "HyperFileLens enrollment helper" https://example.invalid/helper "${destination}" 2>&1)"
+grep -F '[STEP ] Downloading HyperFileLens enrollment helper.' <<<"${output}" >/dev/null
+grep -F '[ OK  ] HyperFileLens enrollment helper downloaded (' <<<"${output}" >/dev/null
+grep -Fx -- '--progress-bar' "${HFL_TEST_CURL_LOG}" >/dev/null
+grep -Fx -- '--retry' "${HFL_TEST_CURL_LOG}" >/dev/null
+grep -Fx -- '--retry-connrefused' "${HFL_TEST_CURL_LOG}" >/dev/null
+grep -Fx 'bootstrap-download-fixture' "${destination}" >/dev/null
+[[ ! -e "${destination}.part" ]]
+
+rm -f "${destination}"
+: >"${HFL_TEST_CURL_LOG}"
+export HFL_TEST_CURL_FAIL=1
+set +e
+(hfl_download "HyperFileLens enrollment helper" https://example.invalid/helper "${destination}") \
+	>"${tmp}/failed.log" 2>&1
+status=$?
+set -e
+[[ "${status}" -eq 3 ]]
+grep -F '[FAIL ] Failed to download HyperFileLens enrollment helper.' "${tmp}/failed.log" >/dev/null
+[[ ! -e "${destination}" ]]
+[[ ! -e "${destination}.part" ]]
+
+printf 'Bootstrap download progress checks passed.\n'

--- a/tools/quality/test-release-download-proxy.sh
+++ b/tools/quality/test-release-download-proxy.sh
@@ -49,7 +49,9 @@ download_release_file https://example.invalid/release "${tmp}/proxied"
 grep -Fx -- '--proxy' "${HFL_TEST_CURL_LOG}" >/dev/null
 grep -Fx -- "${DOWNLOAD_PROXY_URL}" "${HFL_TEST_CURL_LOG}" >/dev/null
 grep -Fx -- '--noproxy' "${HFL_TEST_CURL_LOG}" >/dev/null
+grep -Fx -- '--progress-bar' "${HFL_TEST_CURL_LOG}" >/dev/null
 grep -Fx 'downloaded' "${tmp}/proxied" >/dev/null
+[[ ! -e "${tmp}/proxied.part" ]]
 
 : >"${HFL_TEST_CURL_LOG}"
 export HFL_TEST_PROXY_FAIL=1
@@ -57,6 +59,7 @@ download_release_file https://example.invalid/release "${tmp}/fallback"
 [[ "$(grep -c '^---$' "${HFL_TEST_CURL_LOG}")" -eq 2 ]]
 grep -Fx -- "${DOWNLOAD_PROXY_URL}" "${HFL_TEST_CURL_LOG}" >/dev/null
 grep -Fx 'downloaded' "${tmp}/fallback" >/dev/null
+[[ ! -e "${tmp}/fallback.part" ]]
 
 : >"${HFL_TEST_CURL_LOG}"
 unset HFL_TEST_PROXY_FAIL
@@ -68,5 +71,6 @@ if grep -F '192.168.8.182' "${HFL_TEST_CURL_LOG}" >/dev/null; then
 	exit 1
 fi
 grep -Fx 'downloaded' "${tmp}/direct" >/dev/null
+[[ ! -e "${tmp}/direct.part" ]]
 
 printf 'Target-side Release download proxy checks passed.\n'


### PR DESCRIPTION
## Summary

- add rate-limited download progress, speed, ETA, and stall heartbeats to interactive Agent enrollment
- cover HyperFileLens release deployment, Source Hosts, Proxy Hosts, and Data Gateways, including Docker and LensNode artifacts
- download through partial files, validate declared lengths, preserve installed files on failure, and redact signed URLs from errors
- add Linux, macOS, Windows, frontend command, release-contract, cancellation, truncation, and slow-transfer coverage

## Validation

- complete Agent Go test suite
- focused Go race detector
- Linux amd64, macOS arm64, and Windows amd64 enrollment-helper builds
- 464 frontend tests and production frontend build
- English-only, shell syntax, GitHub Actions YAML, release, proxy, shared-host, Gateway, and offline Docker contract checks

Closes #85
