### PR TITLE
fix(deploy): converge managed gateways and retain release media

### DIFF
--- a/.github/workflows/artifact_pipeline.yml
+++ b/.github/workflows/artifact_pipeline.yml
@@ -191,7 +191,7 @@ jobs:
         with:
           go-version-file: src/agent/go.mod
           cache-dependency-path: src/agent/go.sum
-      - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           version: "0.10.2"
           enable-cache: true
@@ -215,6 +215,7 @@ jobs:
           ./tools/quality/test-offline-docker-package-plan.sh
           ./tools/quality/test-upgrade-backup-retention.sh
           ./tools/quality/test-redis-rdb-preflight.sh
+          ./tools/quality/test-agent-release-retention.sh
           ./tools/quality/test-managed-image-retention.sh
           ./tools/quality/test-main-channel-contracts.sh
           ./tools/quality/test-shared-host-guard.sh

--- a/deploy/installer/install.sh
+++ b/deploy/installer/install.sh
@@ -21,6 +21,10 @@ SHOW_GENERATED_CREDENTIALS="${HFL_SHOW_GENERATED_CREDENTIALS:-auto}"
 UPGRADE_RECOVERY_ARMED=0
 UPGRADE_HFL_WAS_RUNNING=0
 UPGRADE_SOURCELENS_WAS_RUNNING=0
+LOCAL_PLATFORM_AGENT_INSTALL_DIR="/opt/hyperfilelens-agent"
+LOCAL_PLATFORM_AGENT_DATA_DIR="/var/lib/hyperfilelens-agent"
+LOCAL_PLATFORM_LENSNODE_ENV_FILE="/etc/hyperfilelens/lensnode.env"
+LOCAL_PLATFORM_LENSNODE_IMAGE="hyperfilelens-sourcelens-lensnode:latest"
 
 usage() {
 	cat <<'USAGE'
@@ -657,6 +661,98 @@ sync_runtime_media() {
 	fi
 	find "${ROOT}/data/media/gateway-bootstrap" -type f -name '*.sh' \
 		-exec chmod 755 {} + 2>/dev/null || true
+}
+
+prune_agent_release_media() {
+	local releases="${ROOT}/data/media/agent-releases"
+	local desired="" installed="" marker="${ROOT}/data/.platform-gateway-agent-upgrade"
+	local action name target
+	[[ -d "${releases}" ]] || return 0
+	desired="$(read_version 2>/dev/null || true)"
+	if [[ -f "${LOCAL_PLATFORM_AGENT_INSTALL_DIR}/INSTALLED_VERSION" ]]; then
+		installed="$(tr -d ' \t\r\n' <"${LOCAL_PLATFORM_AGENT_INSTALL_DIR}/INSTALLED_VERSION")"
+	fi
+
+	while IFS=$'\t' read -r action name; do
+		[[ -n "${action}" ]] || continue
+		case "${action}" in
+		REMOVE)
+			target="${releases}/${name}"
+			if [[ ! -d "${target}" || -L "${target}" ]]; then
+				warn "Skipping unsafe Agent release retention candidate ${target}"
+				continue
+			fi
+			safe_assert_path_under_dir "${target}" "${releases}" "Agent release path"
+			safe_rm_dir "${target}"
+			log "Removed expired Agent release media ${name}"
+			;;
+		RETAIN_INVALID)
+			warn "Retaining unrecognized or unsafe Agent release media entry ${name}"
+			;;
+		esac
+	done < <(python3 - "${releases}" "${desired}" "${installed}" "${marker}" <<'PY'
+from __future__ import annotations
+
+import os
+import pathlib
+import re
+import sys
+
+root = pathlib.Path(sys.argv[1])
+desired = sys.argv[2].strip()
+installed = sys.argv[3].strip()
+marker_path = pathlib.Path(sys.argv[4])
+main_pattern = re.compile(r"^main-[0-9a-f]{7}$")
+semver_pattern = re.compile(r"^(\d+)\.(\d+)\.(\d+)$")
+
+protected = {value for value in (desired, installed) if value}
+try:
+    marker_version = marker_path.read_text(encoding="utf-8").strip()
+except OSError:
+    marker_version = ""
+if marker_version:
+    protected.add(marker_version)
+
+main_entries = []
+semver_entries = []
+invalid_entries = []
+with os.scandir(root) as entries:
+    for entry in entries:
+        try:
+            if entry.is_symlink() or not entry.is_dir(follow_symlinks=False):
+                invalid_entries.append(entry.name)
+                continue
+            stat = entry.stat(follow_symlinks=False)
+        except OSError:
+            invalid_entries.append(entry.name)
+            continue
+        if main_pattern.fullmatch(entry.name):
+            main_entries.append((stat.st_mtime_ns, entry.name))
+            continue
+        match = semver_pattern.fullmatch(entry.name)
+        if match:
+            semver_entries.append((tuple(map(int, match.groups())), entry.name))
+            continue
+        invalid_entries.append(entry.name)
+
+keep = set(protected)
+semver_entries.sort(reverse=True)
+keep.update(name for _, name in semver_entries[:3])
+
+main_entries.sort(reverse=True)
+ordered_main = [name for _, name in main_entries]
+if desired in ordered_main:
+    ordered_main.remove(desired)
+    ordered_main.insert(0, desired)
+keep.update(ordered_main[:3])
+
+for _, name in [*main_entries, *semver_entries]:
+    if name not in keep:
+        print(f"REMOVE\t{name}")
+for name in sorted(invalid_entries):
+    print(f"RETAIN_INVALID\t{name}")
+PY
+	)
 }
 
 ensure_tls_certs() {
@@ -1353,6 +1449,22 @@ for line in sys.stdin:
 	fi
 }
 
+managed_image_ref_is_in_use() {
+	local ref=$1 image_id container_id container_image_id
+	local -a containers=()
+	image_id="$(docker image inspect "${ref}" --format '{{.Id}}' 2>/dev/null || true)"
+	[[ -n "${image_id}" ]] || return 1
+	mapfile -t containers < <(docker ps -aq --no-trunc 2>/dev/null || true)
+	for container_id in "${containers[@]}"; do
+		[[ -n "${container_id}" ]] || continue
+		container_image_id="$(docker inspect --format '{{.Image}}' "${container_id}" 2>/dev/null || true)"
+		if [[ "${container_image_id}" == "${image_id}" ]]; then
+			return 0
+		fi
+	done
+	return 1
+}
+
 prune_old_managed_image_refs() {
 	local backup_manifest="" ref output
 	local -a removable=()
@@ -1421,7 +1533,9 @@ PY
 	fi
 	for ref in "${removable[@]}"; do
 		[[ -n "${ref}" ]] || continue
-		if docker image rm "${ref}" >/dev/null 2>&1; then
+		if managed_image_ref_is_in_use "${ref}"; then
+			log "Retained in-use old HFL image tag ${ref}"
+		elif docker image rm "${ref}" >/dev/null 2>&1; then
 			log "Removed unreferenced old HFL image tag ${ref}"
 		else
 			warn "Unable to remove old HFL image tag ${ref}; deployment remains healthy"
@@ -2018,10 +2132,129 @@ platform_gateway_auto_deploy_enabled() {
 }
 
 read_agent_env_value() {
-	local key=$1 env_file="/var/lib/hyperfilelens-agent/agent.env"
+	local key=$1 env_file="${LOCAL_PLATFORM_AGENT_DATA_DIR}/agent.env"
 	[[ -f "${env_file}" ]] || return 0
 	grep -E "^${key}=" "${env_file}" 2>/dev/null \
 		| head -1 | cut -d= -f2- | tr -d '\r' || true
+}
+
+local_platform_gateway_installed_agent_version() {
+	local version_file="${LOCAL_PLATFORM_AGENT_INSTALL_DIR}/INSTALLED_VERSION"
+	[[ -f "${version_file}" ]] || return 0
+	tr -d ' \t\r\n' <"${version_file}"
+}
+
+local_platform_gateway_agent_archive() {
+	local version=$1 release_dir="${ROOT}/data/media/agent-releases/${1}"
+	local ubuntu_release="" candidate
+	local -a candidates=()
+	if [[ -f /etc/os-release ]]; then
+		ubuntu_release="$(awk -F= '$1 == "VERSION_ID" {gsub(/"/, "", $2); print $2; exit}' /etc/os-release)"
+	fi
+	case "${ubuntu_release}" in
+	20.04) ubuntu_release=ubuntu2004 ;;
+	22.04) ubuntu_release=ubuntu2204 ;;
+	24.04) ubuntu_release=ubuntu2404 ;;
+	*) ubuntu_release="" ;;
+	esac
+	if [[ -n "${ubuntu_release}" ]]; then
+		candidates+=("${release_dir}/hfl-agent-${version}-linux-amd64-${ubuntu_release}.tar.gz")
+	fi
+	candidates+=("${release_dir}/hfl-agent-${version}-linux-amd64.tar.gz")
+	for candidate in "${candidates[@]}"; do
+		if [[ -f "${candidate}" && ! -L "${candidate}" ]]; then
+			printf '%s' "${candidate}"
+			return 0
+		fi
+	done
+	return 1
+}
+
+upgrade_local_platform_gateway_agent() {
+	local desired=$1 archive install_script marker
+	archive="$(local_platform_gateway_agent_archive "${desired}")" \
+		|| die "no exact local platform Gateway Agent archive exists for ${desired}"
+	install_script="${LOCAL_PLATFORM_AGENT_INSTALL_DIR}/install.sh"
+	marker="${ROOT}/data/.platform-gateway-agent-upgrade"
+	[[ -f "${install_script}" && ! -L "${install_script}" ]] \
+		|| die "installer-managed local platform Gateway has no trusted Agent installer"
+
+	step "Upgrading installer-managed local platform Gateway Agent to ${desired}"
+	printf '%s\n' "${desired}" | run_as_root tee "${marker}" >/dev/null
+	if ! run_as_root /bin/bash "${install_script}" upgrade \
+		--from "${archive}" --yes --quiet-footer; then
+		die "installer-managed local platform Gateway Agent upgrade failed; its rollback was requested"
+	fi
+	if [[ "$(local_platform_gateway_installed_agent_version)" != "${desired}" ]]; then
+		die "installer-managed local platform Gateway Agent did not converge to ${desired}"
+	fi
+	run_as_root rm -f "${marker}"
+	ok "Installer-managed local platform Gateway Agent upgraded to ${desired}"
+}
+
+verify_local_platform_gateway_agent() {
+	local desired=$1 installed
+	installed="$(local_platform_gateway_installed_agent_version)"
+	[[ "${installed}" == "${desired}" ]] \
+		|| die "installer-managed local platform Gateway Agent is ${installed:-unknown}, expected ${desired}"
+	run_as_root systemctl is-active --quiet hyperfilelens-agent.service \
+		|| die "installer-managed local platform Gateway Agent service is not active"
+}
+
+converge_local_platform_gateway_lensnode() {
+	local desired_id current_id container_id running script
+	desired_id="$(docker image inspect --format '{{.Id}}' \
+		"${LOCAL_PLATFORM_LENSNODE_IMAGE}" 2>/dev/null || true)"
+	[[ -n "${desired_id}" ]] \
+		|| die "local platform Gateway LensNode image is unavailable: ${LOCAL_PLATFORM_LENSNODE_IMAGE}"
+	container_id="$(docker ps -aq --no-trunc \
+		--filter 'label=com.hyperfilelens.managed=true' \
+		--filter 'label=com.hyperfilelens.component=gateway-lensnode' \
+		--filter 'label=com.docker.compose.project=hyperfilelens-gateway' \
+		--filter 'label=com.docker.compose.service=lensnode' | head -1)"
+	[[ -n "${container_id}" ]] \
+		|| die "installer-managed local platform Gateway LensNode container is missing"
+	current_id="$(docker inspect --format '{{.Image}}' "${container_id}" 2>/dev/null || true)"
+	if [[ "${current_id}" == "${desired_id}" ]]; then
+		skip "Local platform Gateway LensNode already uses the desired image"
+	else
+		script="${ROOT}/data/media/gateway-bootstrap/gateway-install-lensnode-sidecar.sh"
+		[[ -f "${script}" && ! -L "${script}" ]] \
+			|| die "local platform Gateway LensNode installer is missing: ${script}"
+		step "Recreating local platform Gateway LensNode for a changed image"
+		run_as_root env \
+			HFL_LENS_ENV_FILE="${LOCAL_PLATFORM_LENSNODE_ENV_FILE}" \
+			HFL_INSECURE_TLS=1 \
+			LENSNODE_IMAGE="${LOCAL_PLATFORM_LENSNODE_IMAGE}" \
+			/bin/bash "${script}"
+		container_id="$(docker ps -aq --no-trunc \
+			--filter 'label=com.hyperfilelens.managed=true' \
+			--filter 'label=com.hyperfilelens.component=gateway-lensnode' \
+			--filter 'label=com.docker.compose.project=hyperfilelens-gateway' \
+			--filter 'label=com.docker.compose.service=lensnode' | head -1)"
+		current_id="$(docker inspect --format '{{.Image}}' "${container_id}" 2>/dev/null || true)"
+		[[ "${current_id}" == "${desired_id}" ]] \
+			|| die "local platform Gateway LensNode did not converge to the desired image"
+	fi
+	running="$(docker inspect --format '{{.State.Running}}' "${container_id}" 2>/dev/null || true)"
+	[[ "${running}" == "true" ]] \
+		|| die "installer-managed local platform Gateway LensNode is not running"
+}
+
+wait_for_local_platform_gateway_online() {
+	local node_id=$1 attempt
+	[[ "${node_id}" =~ ^[0-9]+$ ]] \
+		|| die "installer-managed local platform Gateway has no valid node ID"
+	for attempt in $(seq 1 12); do
+		if compose_in_root exec -T api python manage.py shell -c \
+			"from apps.node.models import Node; from apps.node.services.internal.node_registry import agent_ws_routable; node = Node.objects.filter(pk=${node_id}, status=Node.Status.ONLINE).first(); raise SystemExit(0 if node is not None and agent_ws_routable(agent_id=node.id) else 1)" \
+			>/dev/null 2>&1; then
+			ok "Installer-managed local platform Gateway WebSocket is online"
+			return 0
+		fi
+		((attempt < 12)) && sleep 2
+	done
+	die "installer-managed local platform Gateway did not reconnect its WebSocket"
 }
 
 ensure_local_platform_gateway() {
@@ -2075,7 +2308,7 @@ print("\t".join([*(str(payload[key]).strip() for key in required), node_ids]))
 	api_base="https://127.0.0.1:${tenant_port}"
 	wss_url="wss://127.0.0.1:${tenant_port}/ws/node/agent/"
 
-	local existing_org existing_role existing_node_id existing_token
+	local existing_org existing_role existing_node_id existing_token desired_version installed_version
 	existing_org="$(read_agent_env_value HFL_ORG_KEY)"
 	existing_role="$(read_agent_env_value HFL_NODE_ROLE)"
 	existing_node_id="$(read_agent_env_value HFL_NODE_ID)"
@@ -2091,6 +2324,13 @@ print("\t".join([*(str(payload[key]).strip() for key in required), node_ids]))
 		elif [[ "${existing_token}" != "${token}" ]]; then
 			die "the partially enrolled platform Gateway Agent was not created by the HFL installer"
 		fi
+		desired_version="$(read_version)"
+		installed_version="$(local_platform_gateway_installed_agent_version)"
+		if [[ "${installed_version}" == "${desired_version}" ]]; then
+			skip "Local platform Gateway Agent already uses ${desired_version}"
+		else
+			upgrade_local_platform_gateway_agent "${desired_version}"
+		fi
 	fi
 
 	run_as_root env \
@@ -2101,6 +2341,11 @@ print("\t".join([*(str(payload[key]).strip() for key in required), node_ids]))
 		HFL_WSS_URL="${wss_url}" \
 		HFL_INSECURE_TLS=1 \
 		"${helper}" gateway-install --yes
+	desired_version="$(read_version)"
+	verify_local_platform_gateway_agent "${desired_version}"
+	converge_local_platform_gateway_lensnode
+	existing_node_id="$(read_agent_env_value HFL_NODE_ID)"
+	wait_for_local_platform_gateway_online "${existing_node_id}"
 	ok "Installer-managed local platform Gateway is ready"
 }
 
@@ -2217,6 +2462,7 @@ cmd_install() {
 	wait_for_sourcelens_health || die "bundled SourceLens failed its post-install health gate"
 	sync_optional_identity_settings
 	ensure_local_platform_gateway
+	prune_agent_release_media
 
 	step "[6/6] Done"
 	log "Install and startup complete"
@@ -2962,6 +3208,7 @@ cmd_upgrade() {
 	wait_for_sourcelens_health || die "bundled SourceLens failed its post-upgrade health gate"
 	sync_optional_identity_settings
 	ensure_local_platform_gateway
+	prune_agent_release_media
 	UPGRADE_RECOVERY_ARMED=0
 	prune_old_managed_image_refs
 

--- a/release/build.sh
+++ b/release/build.sh
@@ -1120,9 +1120,11 @@ sudo ./install.sh upgrade --from /path/to/new.tar.gz --remove-sourcelens
 \`\`\`
 
 When the package includes \`sourcelens/\`, upgrade also refreshes SourceLens under \`/opt/hyperfilelens/sourcelens\` and updates
-\`data/media/gateway-bootstrap/\` / \`data/media/enroll-bootstrap/\` publish artifacts on this host. Existing enrolled nodes and
-installed Data Gateways are not upgraded automatically; new enrollments and offline DG installs use the updated files.
-\`data/media/agent-releases/\` versions are merged (older versions are kept).
+\`data/media/gateway-bootstrap/\` / \`data/media/enroll-bootstrap/\` publish artifacts on this host. User-managed Data Gateways
+are not upgraded automatically; new enrollments and offline DG installs use the updated files. The installer-managed local
+Platform Gateway converges to the control-plane Agent version and only recreates LensNode when its image changes.
+Agent release media retention keeps the desired and locally installed versions, the latest three Main builds, and the latest
+three formal releases. An interrupted local Agent upgrade is also protected until a later successful deployment.
 
 ## Uninstall
 

--- a/src/backend/apps/task/api/serializers/task.py
+++ b/src/backend/apps/task/api/serializers/task.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from decimal import Decimal
+
 from django.core.exceptions import ObjectDoesNotExist
 from rest_framework import serializers
 
@@ -191,10 +193,10 @@ class TaskStepInputSerializer(serializers.Serializer):
     progress = serializers.DecimalField(
         max_digits=5,
         decimal_places=2,
-        min_value=0,
-        max_value=100,
+        min_value=Decimal("0.00"),
+        max_value=Decimal("100.00"),
         required=False,
-        default=0,
+        default=Decimal("0.00"),
     )
 
 

--- a/src/backend/apps/task/tests/test_api.py
+++ b/src/backend/apps/task/tests/test_api.py
@@ -1,11 +1,38 @@
+from decimal import Decimal
+
 from django.contrib.auth import get_user_model
-from django.test import TestCase
+from django.test import SimpleTestCase, TestCase
 from rest_framework import status
 from rest_framework.test import APIClient
 
 from apps.iam.models import Membership, Organization
+from apps.task.api.serializers.task import TaskStepInputSerializer
 from apps.task.models import Task, TaskEvent, TaskResource, TaskStep
 from apps.task.services.interface import complete_task, create_task
+
+
+class TaskStepInputSerializerTests(SimpleTestCase):
+    def test_progress_uses_decimal_bounds_and_default(self):
+        default_serializer = TaskStepInputSerializer(data={"step_name": "snapshot"})
+        self.assertTrue(default_serializer.is_valid(), default_serializer.errors)
+        self.assertEqual(default_serializer.validated_data["progress"], Decimal("0.00"))
+
+        for value, expected in (("0", Decimal("0.00")), ("100", Decimal("100.00"))):
+            with self.subTest(value=value):
+                serializer = TaskStepInputSerializer(
+                    data={"step_name": "snapshot", "progress": value}
+                )
+                self.assertTrue(serializer.is_valid(), serializer.errors)
+                self.assertEqual(serializer.validated_data["progress"], expected)
+
+    def test_progress_rejects_values_outside_decimal_bounds(self):
+        for value in ("-0.01", "100.01"):
+            with self.subTest(value=value):
+                serializer = TaskStepInputSerializer(
+                    data={"step_name": "snapshot", "progress": value}
+                )
+                self.assertFalse(serializer.is_valid())
+                self.assertIn("progress", serializer.errors)
 
 
 class TaskApiTests(TestCase):

--- a/src/frontend/src/App.vue
+++ b/src/frontend/src/App.vue
@@ -38,12 +38,21 @@ watch(
           </div>
         </template>
         <template #fallback>
-          <div class="app-route-loading" role="status" aria-label="Loading">
-            <div class="app-route-loading__panel" aria-hidden="true">
-              <i class="app-route-loading__mark"></i>
-              <div class="app-route-loading__brand"><span>Hyper</span>FileLens</div>
-              <div class="app-route-loading__sub"></div>
-              <div class="app-route-loading__bar"></div>
+          <div
+            class="app-route-loading"
+            role="status"
+            aria-label="Loading"
+          >
+            <div
+              class="app-route-loading__panel"
+              aria-hidden="true"
+            >
+              <i class="app-route-loading__mark" />
+              <div class="app-route-loading__brand">
+                <span>Hyper</span>FileLens
+              </div>
+              <div class="app-route-loading__sub" />
+              <div class="app-route-loading__bar" />
             </div>
           </div>
         </template>

--- a/src/frontend/src/app/layout/AppShell.vue
+++ b/src/frontend/src/app/layout/AppShell.vue
@@ -460,9 +460,13 @@ function applyThemeVars(t: string) {
       {{ t('common.supportModeBanner', { org: supportOrgKey }) }}
     </div>
     <main class="content-wrapper">
-      <RouterView v-slot="{ Component, route }">
+      <RouterView v-slot="{ Component, route: matchedRoute }">
         <Suspense
-          :key="route.path === '/protection/backups' || route.path === '/ops/task' ? route.path : route.fullPath"
+          :key="
+            matchedRoute.path === '/protection/backups' || matchedRoute.path === '/ops/task'
+              ? matchedRoute.path
+              : matchedRoute.fullPath
+          "
           timeout="0"
         >
           <component :is="Component" />

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -597,6 +597,7 @@ grep -F './tools/quality/test-release-download-proxy.sh' "${workflow}" >/dev/nul
 grep -F './tools/quality/test-default-certificates.sh' "${workflow}" >/dev/null
 grep -F './tools/quality/test-gateway-bootstrap-health.sh' "${workflow}" >/dev/null
 grep -F './tools/quality/test-platform-gateway-auto-deploy.sh' "${workflow}" >/dev/null
+grep -F './tools/quality/test-agent-release-retention.sh' "${workflow}" >/dev/null
 grep -F './tools/quality/test-agent-gateway-uninstall.sh' "${workflow}" >/dev/null
 grep -F 'HFL_PLATFORM_GATEWAY_AUTO_DEPLOY=false' "${ROOT}/.env.example" >/dev/null
 grep -F 'com.hyperfilelens.component: "gateway-lensnode"' \
@@ -715,6 +716,7 @@ for executable in \
 	"${ROOT}/tools/quality/test-main-channel-contracts.sh" \
 	"${ROOT}/tools/quality/test-upgrade-backup-retention.sh" \
 	"${ROOT}/tools/quality/test-redis-rdb-preflight.sh" \
+	"${ROOT}/tools/quality/test-agent-release-retention.sh" \
 	"${ROOT}/tools/quality/test-managed-image-retention.sh" \
 	"${ROOT}/tools/quality/test-shared-host-guard.sh" \
 	"${ROOT}/tools/quality/test-release-download-proxy.sh" \

--- a/tools/quality/test-agent-release-retention.sh
+++ b/tools/quality/test-agent-release-retention.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+installer="${ROOT_REPO}/deploy/installer/install.sh"
+tmp="$(mktemp -d)"
+trap 'rm -rf "${tmp}"' EXIT
+
+ROOT="${tmp}/install"
+LOCAL_PLATFORM_AGENT_INSTALL_DIR="${tmp}/agent-install"
+releases="${ROOT}/data/media/agent-releases"
+mkdir -p "${releases}" "${LOCAL_PLATFORM_AGENT_INSTALL_DIR}"
+printf 'main-1111111\n' >"${ROOT}/VERSION"
+printf '0.1.0\n' >"${LOCAL_PLATFORM_AGENT_INSTALL_DIR}/INSTALLED_VERSION"
+printf 'main-2222222\n' >"${ROOT}/data/.platform-gateway-agent-upgrade"
+
+for version in main-1111111 main-2222222 main-3333333 main-4444444 main-5555555; do
+	mkdir -p "${releases}/${version}"
+	printf '%s\n' "${version}" >"${releases}/${version}/fixture"
+done
+touch -d '5 days ago' "${releases}/main-1111111"
+touch -d '4 days ago' "${releases}/main-2222222"
+touch -d '3 days ago' "${releases}/main-3333333"
+touch -d '2 days ago' "${releases}/main-4444444"
+touch -d '1 day ago' "${releases}/main-5555555"
+
+for version in 0.1.0 0.1.1 0.1.2 0.1.3 0.1.4; do
+	mkdir -p "${releases}/${version}"
+	printf '%s\n' "${version}" >"${releases}/${version}/fixture"
+done
+mkdir -p "${releases}/unrecognized"
+ln -s "${releases}/0.1.4" "${releases}/main-abcdef0-link"
+
+read_version() { tr -d ' \t\r\n' <"${ROOT}/VERSION"; }
+warn() { printf 'WARN: %s\n' "$*" >>"${tmp}/retention.log"; }
+log() { printf 'INFO: %s\n' "$*" >>"${tmp}/retention.log"; }
+die() { printf 'ERROR: %s\n' "$1" >&2; return "${2:-1}"; }
+# shellcheck disable=SC1090
+source <(sed -n '/^safe_normalize_dir()/,/^# --- Host \/ Docker ---/p' "${installer}" | sed '$d')
+# shellcheck disable=SC1090
+source <(sed -n '/^prune_agent_release_media()/,/^ensure_tls_certs()/p' "${installer}" | sed '$d')
+
+prune_agent_release_media
+
+for retained in \
+	main-1111111 main-2222222 main-4444444 main-5555555 \
+	0.1.0 0.1.2 0.1.3 0.1.4 unrecognized main-abcdef0-link; do
+	[[ -e "${releases}/${retained}" || -L "${releases}/${retained}" ]]
+done
+for removed in main-3333333 0.1.1; do
+	[[ ! -e "${releases}/${removed}" ]]
+done
+grep -F 'Retaining unrecognized or unsafe Agent release media entry unrecognized' \
+	"${tmp}/retention.log" >/dev/null
+grep -F 'Retaining unrecognized or unsafe Agent release media entry main-abcdef0-link' \
+	"${tmp}/retention.log" >/dev/null
+
+printf 'Agent release media retention checks passed.\n'

--- a/tools/quality/test-managed-image-retention.sh
+++ b/tools/quality/test-managed-image-retention.sh
@@ -22,6 +22,7 @@ case "$*" in
 "info") ;;
 "ps -aq --no-trunc") printf 'foreign-container\n' ;;
 "inspect --format {{.Config.Image}} foreign-container") printf 'hyperfilelens-backend:0.1.6\n' ;;
+"inspect --format {{.Image}} foreign-container") printf 'sha256:in-use\n' ;;
 "image ls --format {{.Repository}}:{{.Tag}}")
 	printf '%s\n' \
 		hyperfilelens-backend:latest \
@@ -29,8 +30,11 @@ case "$*" in
 		hyperfilelens-backend:0.1.7 \
 		hyperfilelens-backend:0.1.6 \
 		hyperfilelens-backend:0.1.5 \
+		hyperfilelens-backend:0.1.4 \
 		customer-backend:0.1.5
 	;;
+"image inspect hyperfilelens-backend:0.1.5 --format {{.Id}}") printf 'sha256:unused\n' ;;
+"image inspect hyperfilelens-backend:0.1.4 --format {{.Id}}") printf 'sha256:in-use\n' ;;
 "image rm hyperfilelens-backend:0.1.5")
 	printf '%s\n' 'hyperfilelens-backend:0.1.5' >>"${HFL_TEST_REMOVED_IMAGES}"
 	;;
@@ -43,7 +47,7 @@ export HFL_TEST_REMOVED_IMAGES="${tmp}/removed-images"
 
 warn() { printf 'WARN: %s\n' "$*"; }
 log() { printf 'INFO: %s\n' "$*"; }
-source <(sed -n '/^prune_old_managed_image_refs()/,/^apply_upgrade_files()/p' "${installer}" | sed '$d')
+source <(sed -n '/^managed_image_ref_is_in_use()/,/^apply_upgrade_files()/p' "${installer}" | sed '$d')
 
 prune_old_managed_image_refs
 [[ "$(<"${HFL_TEST_REMOVED_IMAGES}")" == "hyperfilelens-backend:0.1.5" ]]

--- a/tools/quality/test-platform-gateway-auto-deploy.sh
+++ b/tools/quality/test-platform-gateway-auto-deploy.sh
@@ -14,20 +14,54 @@ source <(sed -n '/^read_env_value()/,/^resolve_console_host()/p' "${installer}" 
 source <(sed -n '/^platform_gateway_auto_deploy_enabled()/,/^# --- Commands ---/p' "${installer}" | sed '$d')
 
 ROOT="${tmp}/install"
-mkdir -p "${ROOT}/data/media/enroll-bootstrap"
+LOCAL_PLATFORM_AGENT_INSTALL_DIR="${tmp}/agent-install"
+LOCAL_PLATFORM_AGENT_DATA_DIR="${tmp}/agent-data"
+LOCAL_PLATFORM_LENSNODE_ENV_FILE="${tmp}/lensnode.env"
+LOCAL_PLATFORM_LENSNODE_IMAGE="hyperfilelens-sourcelens-lensnode:latest"
+mkdir -p \
+	"${ROOT}/data/media/enroll-bootstrap" \
+	"${ROOT}/data/media/agent-releases" \
+	"${ROOT}/data/media/gateway-bootstrap" \
+	"${LOCAL_PLATFORM_AGENT_INSTALL_DIR}" \
+	"${LOCAL_PLATFORM_AGENT_DATA_DIR}"
 helper="${ROOT}/data/media/enroll-bootstrap/hfl-enroll-linux-amd64"
 marker="${tmp}/helper-ran"
-printf '%s\n' \
-	'#!/usr/bin/env bash' \
-	'set -euo pipefail' \
-	'[[ "$HFL_ORG_KEY" == "__platform_lens__" ]]' \
-	'[[ "$HFL_NODE_ROLE" == "gateway" ]]' \
-	'[[ "$HFL_API_BASE" == "https://127.0.0.1:11443" ]]' \
-	'[[ "$HFL_WSS_URL" == "wss://127.0.0.1:11443/ws/node/agent/" ]]' \
-	'[[ "$1" == "gateway-install" && "$2" == "--yes" ]]' \
-	'printf "%s|%s|%s" "$HFL_API_BASE" "$HFL_WSS_URL" "$HFL_INSECURE_TLS" >"$TEST_PLATFORM_GATEWAY_MARKER"' \
-	>"${helper}"
+cat >"${helper}" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+[[ "$HFL_ORG_KEY" == "__platform_lens__" ]]
+[[ "$HFL_NODE_ROLE" == "gateway" ]]
+[[ "$HFL_API_BASE" == "https://127.0.0.1:11443" ]]
+[[ "$HFL_WSS_URL" == "wss://127.0.0.1:11443/ws/node/agent/" ]]
+[[ "$1" == "gateway-install" && "$2" == "--yes" ]]
+mkdir -p "$TEST_AGENT_INSTALL_DIR" "$TEST_AGENT_DATA_DIR"
+if [[ ! -f "$TEST_AGENT_INSTALL_DIR/INSTALLED_VERSION" ]]; then
+	printf '%s\n' "$TEST_DESIRED_VERSION" >"$TEST_AGENT_INSTALL_DIR/INSTALLED_VERSION"
+fi
+cat >"$TEST_AGENT_DATA_DIR/agent.env" <<EOF
+HFL_ORG_KEY=__platform_lens__
+HFL_NODE_ROLE=gateway
+HFL_NODE_ID=99
+HFL_NODE_TOKEN=fixture-token
+EOF
+printf '%s|%s|%s' "$HFL_API_BASE" "$HFL_WSS_URL" "$HFL_INSECURE_TLS" >"$TEST_PLATFORM_GATEWAY_MARKER"
+SH
 chmod 755 "${helper}"
+
+cat >"${LOCAL_PLATFORM_AGENT_INSTALL_DIR}/install.sh" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+[[ "$1" == "upgrade" && "$2" == "--from" ]]
+[[ "${TEST_AGENT_UPGRADE_FAIL:-0}" != "1" ]] || exit 42
+printf '%s\n' "$3" >"$TEST_AGENT_UPGRADE_MARKER"
+printf '%s\n' "$TEST_DESIRED_VERSION" >"$TEST_AGENT_INSTALL_DIR/INSTALLED_VERSION"
+SH
+chmod 755 "${LOCAL_PLATFORM_AGENT_INSTALL_DIR}/install.sh"
+
+export TEST_PLATFORM_GATEWAY_MARKER="${marker}"
+export TEST_AGENT_UPGRADE_MARKER="${tmp}/agent-upgrade-ran"
+export TEST_AGENT_INSTALL_DIR="${LOCAL_PLATFORM_AGENT_INSTALL_DIR}"
+export TEST_AGENT_DATA_DIR="${LOCAL_PLATFORM_AGENT_DATA_DIR}"
 
 AUTO_DEPLOY=false
 TLS_MODE=1
@@ -38,27 +72,51 @@ read_env_value() {
 	HFL_TENANT_PORT) printf '11443' ;;
 	esac
 }
+read_version() { tr -d ' \t\r\n' <"${ROOT}/VERSION"; }
 skip() { :; }
 step() { :; }
 ok() { :; }
 die() { printf 'FAIL: %s\n' "$1" >&2; exit "${2:-1}"; }
 require_root_or_sudo() { :; }
 require_docker() { :; }
-read_agent_env_value() { :; }
 run_as_root() { "$@"; }
+systemctl() { [[ "$*" == "is-active --quiet hyperfilelens-agent.service" ]]; }
+converge_local_platform_gateway_lensnode() { :; }
+wait_for_local_platform_gateway_online() { [[ "$1" == "99" ]]; }
 compose_in_root() {
-	printf 'HFL_LOCAL_PLATFORM_GATEWAY_ENROLLMENT={"org_key":"%s","token":"fixture-token","api_base":"https://console.example:11443","wss_url":"wss://console.example:11443/ws/node/agent/","managed_node_ids":[]}\n' "${ENROLLMENT_ORG}"
+	printf 'HFL_LOCAL_PLATFORM_GATEWAY_ENROLLMENT={"org_key":"%s","token":"fixture-token","api_base":"https://console.example:11443","wss_url":"wss://console.example:11443/ws/node/agent/","managed_node_ids":[99]}\n' "${ENROLLMENT_ORG}"
 }
 
 ENROLLMENT_ORG=__platform_lens__
+export TEST_DESIRED_VERSION=main-1111111
+printf '%s\n' "${TEST_DESIRED_VERSION}" >"${ROOT}/VERSION"
 
 ensure_local_platform_gateway
 [[ ! -e "${marker}" ]]
 
 AUTO_DEPLOY=true
-export TEST_PLATFORM_GATEWAY_MARKER="${marker}"
 ensure_local_platform_gateway
 [[ "$(<"${marker}")" == "https://127.0.0.1:11443|wss://127.0.0.1:11443/ws/node/agent/|1" ]]
+[[ "$(local_platform_gateway_installed_agent_version)" == "main-1111111" ]]
+[[ ! -e "${TEST_AGENT_UPGRADE_MARKER}" ]]
+
+# An equal desired version must not restart or upgrade the Agent.
+rm -f "${marker}"
+ensure_local_platform_gateway
+[[ -e "${marker}" ]]
+[[ ! -e "${TEST_AGENT_UPGRADE_MARKER}" ]]
+
+# Main builds are identities, not ordered hashes: any unequal desired identity converges.
+export TEST_DESIRED_VERSION=main-2222222
+printf '%s\n' "${TEST_DESIRED_VERSION}" >"${ROOT}/VERSION"
+release_dir="${ROOT}/data/media/agent-releases/${TEST_DESIRED_VERSION}"
+mkdir -p "${release_dir}"
+archive="${release_dir}/hfl-agent-${TEST_DESIRED_VERSION}-linux-amd64.tar.gz"
+printf 'fixture\n' >"${archive}"
+rm -f "${TEST_AGENT_UPGRADE_MARKER}"
+ensure_local_platform_gateway
+[[ "$(<"${TEST_AGENT_UPGRADE_MARKER}")" == "${archive}" ]]
+[[ "$(local_platform_gateway_installed_agent_version)" == "main-2222222" ]]
 
 TLS_MODE=0
 rm -f "${marker}"
@@ -72,23 +130,74 @@ if (ensure_local_platform_gateway) 2>/dev/null; then
 fi
 ENROLLMENT_ORG=__platform_lens__
 
-read_agent_env_value() {
-	case "$1" in
-	HFL_ORG_KEY) printf '__platform_lens__' ;;
-	HFL_NODE_ROLE) printf 'gateway' ;;
-	HFL_NODE_ID) printf '99' ;;
-	HFL_NODE_TOKEN) printf 'manual-token' ;;
-	esac
-}
+sed -i 's/HFL_NODE_ID=99/HFL_NODE_ID=100/' "${LOCAL_PLATFORM_AGENT_DATA_DIR}/agent.env"
 if (ensure_local_platform_gateway) 2>/dev/null; then
 	printf 'ERROR: auto-deploy claimed a platform Gateway not managed by the installer\n' >&2
 	exit 1
 fi
+sed -i 's/HFL_NODE_ID=100/HFL_NODE_ID=99/' "${LOCAL_PLATFORM_AGENT_DATA_DIR}/agent.env"
+
+# A failed exact upgrade preserves the previous Agent and leaves a retention marker.
+export TEST_DESIRED_VERSION=main-3333333
+printf '%s\n' "${TEST_DESIRED_VERSION}" >"${ROOT}/VERSION"
+release_dir="${ROOT}/data/media/agent-releases/${TEST_DESIRED_VERSION}"
+mkdir -p "${release_dir}"
+printf 'fixture\n' >"${release_dir}/hfl-agent-${TEST_DESIRED_VERSION}-linux-amd64.tar.gz"
+export TEST_AGENT_UPGRADE_FAIL=1
+if (ensure_local_platform_gateway) 2>/dev/null; then
+	printf 'ERROR: failed local Agent upgrade was accepted\n' >&2
+	exit 1
+fi
+unset TEST_AGENT_UPGRADE_FAIL
+[[ "$(local_platform_gateway_installed_agent_version)" == "main-2222222" ]]
+[[ "$(<"${ROOT}/data/.platform-gateway-agent-upgrade")" == "main-3333333" ]]
 
 AUTO_DEPLOY=invalid
 if (platform_gateway_auto_deploy_enabled) 2>/dev/null; then
 	printf 'ERROR: invalid platform Gateway auto-deploy value was accepted\n' >&2
 	exit 1
 fi
+
+# Exercise LensNode image convergence separately from Agent enrollment.
+# shellcheck disable=SC1090
+source <(sed -n '/^converge_local_platform_gateway_lensnode()/,/^wait_for_local_platform_gateway_online()/p' "${installer}" | sed '$d')
+CURRENT_LENSNODE_IMAGE_ID=sha256:desired
+DESIRED_LENSNODE_IMAGE_ID=sha256:desired
+SIDECAR_RECREATED=0
+script="${ROOT}/data/media/gateway-bootstrap/gateway-install-lensnode-sidecar.sh"
+printf '#!/usr/bin/env bash\nexit 99\n' >"${script}"
+chmod 755 "${script}"
+docker() {
+	case "$*" in
+	"image inspect --format {{.Id}} hyperfilelens-sourcelens-lensnode:latest")
+		printf '%s\n' "${DESIRED_LENSNODE_IMAGE_ID}"
+		;;
+	"ps -aq --no-trunc --filter label=com.hyperfilelens.managed=true --filter label=com.hyperfilelens.component=gateway-lensnode --filter label=com.docker.compose.project=hyperfilelens-gateway --filter label=com.docker.compose.service=lensnode")
+		printf 'lensnode-container\n'
+		;;
+	"inspect --format {{.Image}} lensnode-container")
+		printf '%s\n' "${CURRENT_LENSNODE_IMAGE_ID}"
+		;;
+	"inspect --format {{.State.Running}} lensnode-container")
+		printf 'true\n'
+		;;
+	*) printf 'unexpected fake Docker invocation: %s\n' "$*" >&2; return 1 ;;
+	esac
+}
+run_as_root() {
+	if [[ "$1" == "env" ]]; then
+		SIDECAR_RECREATED=$((SIDECAR_RECREATED + 1))
+		CURRENT_LENSNODE_IMAGE_ID="${DESIRED_LENSNODE_IMAGE_ID}"
+		return 0
+	fi
+	"$@"
+}
+
+converge_local_platform_gateway_lensnode
+[[ "${SIDECAR_RECREATED}" == "0" ]]
+CURRENT_LENSNODE_IMAGE_ID=sha256:old
+converge_local_platform_gateway_lensnode
+[[ "${SIDECAR_RECREATED}" == "1" ]]
+[[ "${CURRENT_LENSNODE_IMAGE_ID}" == "${DESIRED_LENSNODE_IMAGE_ID}" ]]
 
 printf 'Platform Gateway auto-deploy contracts passed.\n'


### PR DESCRIPTION
## Summary
- converge the installer-managed local Platform Gateway Agent to the exact control-plane version
- recreate LensNode only when its image changes and verify Agent, sidecar, and WebSocket readiness
- retain bounded Agent release media and preserve in-use managed images
- clean targeted backend/frontend warnings and update the Node 24-compatible setup-uv action
- add release-contract and retention regression coverage

## Validation
- Platform Gateway auto-deploy, Agent release retention, managed image retention, shared-host, Main channel, and release contract checks
- Agent Go test suite
- focused Django serializer tests and Ruff
- frontend lint error check and production build
- Python 3.8 compatibility and English-only source checks
- synthetic formal and Main release assembly