### PR TITLE
Fix Turnstile recovery flows

### DIFF
--- a/src/frontend/src/components/TurnstileWidget.test.ts
+++ b/src/frontend/src/components/TurnstileWidget.test.ts
@@ -31,9 +31,25 @@ const i18n = createI18n({
 
 type RenderOptions = Parameters<NonNullable<typeof window.turnstile>['render']>[1]
 
-function mountWidget() {
+function appendTurnstileResponse(container: HTMLElement, value = '') {
+  const wrapper = document.createElement('div')
+  const input = document.createElement('input')
+  input.type = 'hidden'
+  input.name = 'cf-turnstile-response'
+  input.value = value
+  wrapper.append(input)
+  container.append(wrapper)
+  return input
+}
+
+function mountWidget(overrides: Partial<{
+  siteKey: string
+  action: string
+  loadTimeoutMs: number
+  slowLoadDelayMs: number
+}> = {}) {
   return mount(TurnstileWidget, {
-    props: { siteKey: 'test-site-key', action: 'login' },
+    props: { siteKey: 'test-site-key', action: 'login', ...overrides },
     global: { plugins: [i18n] },
   })
 }
@@ -52,18 +68,17 @@ describe('TurnstileWidget lifecycle', () => {
     delete window.turnstile
   })
 
-  it('resets expired challenges and accepts replacement tokens repeatedly', async () => {
-    let renderOptions: RenderOptions | undefined
-    const reset = vi.fn()
+  it('rerenders expired challenges and accepts repeated test tokens safely', async () => {
+    const renderOptions: RenderOptions[] = []
     const remove = vi.fn()
     window.turnstile = {
       ready: callback => callback(),
       render: (container, options) => {
-        renderOptions = options
-        container.append(document.createElement('iframe'))
-        return 'widget-1'
+        renderOptions.push(options)
+        appendTurnstileResponse(container)
+        return `widget-${renderOptions.length}`
       },
-      reset,
+      reset: vi.fn(),
       remove,
     }
 
@@ -73,44 +88,50 @@ describe('TurnstileWidget lifecycle', () => {
 
     await vi.advanceTimersByTimeAsync(100)
     expect(wrapper.find('.turnstile-widget__loading').exists()).toBe(false)
-    expect(wrapper.find('iframe').exists()).toBe(true)
+    expect(wrapper.find('input[name="cf-turnstile-response"]').exists()).toBe(true)
+    expect(wrapper.emitted('rendered')).toHaveLength(1)
+    expect(wrapper.emitted('slow-load')).toBeUndefined()
+    expect(wrapper.emitted('success')).toBeUndefined()
+    expect(renderOptions[0]).toMatchObject({
+      'response-field': true,
+      'response-field-name': 'cf-turnstile-response',
+      retry: 'never',
+      'refresh-expired': 'never',
+      'refresh-timeout': 'auto',
+    })
 
-    renderOptions!.callback('verified-token')
-    renderOptions!.callback('duplicate-token')
-    expect(wrapper.emitted('success')).toEqual([['verified-token']])
+    renderOptions[0].callback('fixed-test-token')
+    renderOptions[0].callback('duplicate-token')
+    expect(wrapper.emitted('success')).toEqual([['fixed-test-token']])
 
-    renderOptions!['expired-callback']?.()
+    renderOptions[0]['expired-callback']?.()
+    await flushPromises()
+    expect(wrapper.emitted('success')).toEqual([['fixed-test-token']])
     expect(wrapper.emitted('expire')).toHaveLength(1)
-    expect(reset).toHaveBeenNthCalledWith(1, 'widget-1')
+    expect(remove).toHaveBeenCalledWith('widget-1')
+    expect(renderOptions).toHaveLength(2)
 
-    renderOptions!.callback('replacement-token')
+    renderOptions[0].callback('stale-token')
+    renderOptions[1].callback('fixed-test-token')
     expect(wrapper.emitted('success')).toEqual([
-      ['verified-token'],
-      ['replacement-token'],
-    ])
-
-    renderOptions!['expired-callback']?.()
-    expect(wrapper.emitted('expire')).toHaveLength(2)
-    expect(reset).toHaveBeenNthCalledWith(2, 'widget-1')
-
-    renderOptions!.callback('second-replacement-token')
-    expect(wrapper.emitted('success')).toEqual([
-      ['verified-token'],
-      ['replacement-token'],
-      ['second-replacement-token'],
+      ['fixed-test-token'],
+      ['fixed-test-token'],
     ])
 
     wrapper.vm.reset()
-    expect(reset).toHaveBeenNthCalledWith(3, 'widget-1')
-    renderOptions!.callback('manual-reset-token')
+    await flushPromises()
+    expect(remove).toHaveBeenCalledWith('widget-2')
+    expect(renderOptions).toHaveLength(3)
+
+    renderOptions[1].callback('stale-token')
+    renderOptions[2].callback('fixed-test-token')
     expect(wrapper.emitted('success')).toEqual([
-      ['verified-token'],
-      ['replacement-token'],
-      ['second-replacement-token'],
-      ['manual-reset-token'],
+      ['fixed-test-token'],
+      ['fixed-test-token'],
+      ['fixed-test-token'],
     ])
     wrapper.unmount()
-    expect(remove).toHaveBeenCalledWith('widget-1')
+    expect(remove).toHaveBeenCalledWith('widget-3')
   })
 
   it('emits an error when Cloudflare fails before rendering a challenge', async () => {
@@ -135,6 +156,75 @@ describe('TurnstileWidget lifecycle', () => {
     wrapper.unmount()
   })
 
+  it('reports challenge errors after the response field is mounted', async () => {
+    let renderOptions: RenderOptions | undefined
+    window.turnstile = {
+      ready: callback => callback(),
+      render: (container, options) => {
+        renderOptions = options
+        appendTurnstileResponse(container)
+        return 'widget-error'
+      },
+      reset: vi.fn(),
+      remove: vi.fn(),
+    }
+
+    const wrapper = mountWidget()
+    await flushPromises()
+    await vi.advanceTimersByTimeAsync(100)
+    renderOptions!['error-callback']?.('300030')
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.emitted('error')).toEqual([['300030']])
+    wrapper.unmount()
+  })
+
+  it('drops malformed challenge error codes', async () => {
+    let renderOptions: RenderOptions | undefined
+    window.turnstile = {
+      ready: callback => callback(),
+      render: (_container, options) => {
+        renderOptions = options
+        return 'widget-invalid-error-code'
+      },
+      reset: vi.fn(),
+      remove: vi.fn(),
+    }
+
+    const wrapper = mountWidget()
+    await flushPromises()
+    renderOptions!['error-callback']?.('token=must-not-leak')
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.emitted('error')).toEqual([[undefined]])
+    wrapper.unmount()
+  })
+
+  it('reports an error when no widget DOM appears before timeout', async () => {
+    window.turnstile = {
+      ready: callback => callback(),
+      render: () => 'widget-timeout',
+      reset: vi.fn(),
+      remove: vi.fn(),
+    }
+
+    const wrapper = mountWidget({ loadTimeoutMs: 1_000, slowLoadDelayMs: 500 })
+    await flushPromises()
+
+    await vi.advanceTimersByTimeAsync(499)
+    expect(wrapper.emitted('slow-load')).toBeUndefined()
+
+    await vi.advanceTimersByTimeAsync(1)
+    expect(wrapper.emitted('slow-load')).toHaveLength(1)
+
+    await vi.advanceTimersByTimeAsync(500)
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.emitted('error')).toHaveLength(1)
+    expect(wrapper.find('.turnstile-widget__loading').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
   it('invalidates the token without reporting expiration when language changes', async () => {
     const renderOptions: RenderOptions[] = []
     const remove = vi.fn()
@@ -142,7 +232,7 @@ describe('TurnstileWidget lifecycle', () => {
       ready: callback => callback(),
       render: (container, options) => {
         renderOptions.push(options)
-        container.append(document.createElement('iframe'))
+        appendTurnstileResponse(container)
         return `widget-${renderOptions.length}`
       },
       reset: vi.fn(),
@@ -160,6 +250,44 @@ describe('TurnstileWidget lifecycle', () => {
     expect(wrapper.emitted('expire')).toBeUndefined()
     expect(remove).toHaveBeenCalledWith('widget-1')
     expect(renderOptions.at(-1)?.language).toBe('fr')
+
+    renderOptions[0].callback('stale-language-token')
+    expect(wrapper.emitted('success')).toBeUndefined()
+    renderOptions[1].callback('current-language-token')
+    expect(wrapper.emitted('success')).toEqual([['current-language-token']])
+    wrapper.unmount()
+  })
+
+  it('reports a load failure when rendering a replacement challenge throws', async () => {
+    let renderOptions: RenderOptions | undefined
+    let renderCount = 0
+    const remove = vi.fn()
+    window.turnstile = {
+      ready: callback => callback(),
+      render: (container, options) => {
+        renderCount += 1
+        if (renderCount > 1) throw new Error('replacement render failed')
+        renderOptions = options
+        appendTurnstileResponse(container)
+        return 'widget-reset-error'
+      },
+      reset: vi.fn(),
+      remove,
+    }
+
+    const wrapper = mountWidget()
+    await flushPromises()
+    await vi.advanceTimersByTimeAsync(100)
+    renderOptions!.callback('token-that-must-be-invalidated')
+    wrapper.vm.reset()
+    await flushPromises()
+
+    expect(remove).toHaveBeenCalledWith('widget-reset-error')
+    expect(wrapper.emitted('load-failed')).toHaveLength(1)
+    expect(wrapper.emitted('success')).toEqual([['token-that-must-be-invalidated']])
+
+    renderOptions!.callback('token-that-must-be-invalidated')
+    expect(wrapper.emitted('success')).toEqual([['token-that-must-be-invalidated']])
     wrapper.unmount()
   })
 

--- a/src/frontend/src/components/TurnstileWidget.vue
+++ b/src/frontend/src/components/TurnstileWidget.vue
@@ -19,7 +19,12 @@ declare global {
           sitekey: string
           callback: (token: string) => void
           'expired-callback'?: () => void
-          'error-callback'?: () => void
+          'error-callback'?: (errorCode?: string) => void
+          'response-field'?: boolean
+          'response-field-name'?: string
+          retry?: 'auto' | 'never'
+          'refresh-expired'?: 'auto' | 'manual' | 'never'
+          'refresh-timeout'?: 'auto' | 'manual' | 'never'
           theme?: 'light' | 'dark' | 'auto'
           size?: 'normal' | 'compact' | 'flexible'
           language?: string
@@ -41,6 +46,7 @@ const props = withDefaults(
     /** Override Turnstile language; defaults to the current page locale. */
     language?: string
     loadTimeoutMs?: number
+    slowLoadDelayMs?: number
     action: string
   }>(),
   {
@@ -48,6 +54,7 @@ const props = withDefaults(
     size: 'flexible',
     language: undefined,
     loadTimeoutMs: TURNSTILE_LOAD_TIMEOUT_MS,
+    slowLoadDelayMs: 8_000,
   },
 )
 
@@ -61,24 +68,46 @@ const emit = defineEmits<{
   success: [token: string]
   expire: []
   invalidate: []
-  error: []
+  error: [errorCode?: string]
   'load-failed': []
+  'slow-load': []
+  rendered: []
 }>()
 
 const containerRef = ref<HTMLElement | null>(null)
 const widgetId = ref<string | null>(null)
 const loadTimeoutId = ref<ReturnType<typeof setTimeout> | null>(null)
+const slowLoadTimeoutId = ref<ReturnType<typeof setTimeout> | null>(null)
 const frameCheckId = ref<ReturnType<typeof setInterval> | null>(null)
 const isLoading = ref(true)
 const successEmitted = ref(false)
+const failureEmitted = ref(false)
+let lifecycleGeneration = 0
+let isUnmounted = false
 
-function emitSuccess(token: string) {
-  if (successEmitted.value) return
+function isCurrentGeneration(generation: number): boolean {
+  return !isUnmounted && generation === lifecycleGeneration
+}
+
+function normalizeTurnstileErrorCode(errorCode?: string): string | undefined {
+  const normalized = String(errorCode ?? '').trim()
+  return /^\d{3,10}$/.test(normalized) ? normalized : undefined
+}
+
+function emitSuccess(token: string, generation = lifecycleGeneration) {
+  const normalizedToken = token.trim()
+  if (
+    !normalizedToken
+    || !isCurrentGeneration(generation)
+    || successEmitted.value
+  ) return
   successEmitted.value = true
+  failureEmitted.value = false
   isLoading.value = false
   clearLoadTimeout()
+  clearSlowLoadTimeout()
   clearFrameCheck()
-  emit('success', token)
+  emit('success', normalizedToken)
 }
 
 function readTurnstileTokenFromContainer(): string {
@@ -88,28 +117,53 @@ function readTurnstileTokenFromContainer(): string {
   return input?.value?.trim() ?? ''
 }
 
-function markReadyIfWidgetPresent(): boolean {
+function invalidateTurnstileTokenInContainer(): void {
+  const input = containerRef.value?.querySelector<HTMLInputElement>(
+    'input[name="cf-turnstile-response"]',
+  )
+  if (input) input.value = ''
+}
+
+function markReadyIfWidgetPresent(generation = lifecycleGeneration): boolean {
+  if (!isCurrentGeneration(generation)) return false
   const container = containerRef.value
   if (!container) return false
 
-  const token = readTurnstileTokenFromContainer()
-  if (token) {
-    emitSuccess(token)
+  const responseInput = container.querySelector<HTMLInputElement>(
+    'input[name="cf-turnstile-response"]',
+  )
+  if (responseInput) {
+    const token = responseInput.value.trim()
+    if (token) {
+      emitSuccess(token, generation)
+      return true
+    }
+
+    isLoading.value = false
+    clearLoadTimeout()
+    clearSlowLoadTimeout()
+    clearFrameCheck()
+    emit('rendered')
     return true
   }
 
   if (container.querySelector('iframe')) {
     isLoading.value = false
     clearLoadTimeout()
+    clearSlowLoadTimeout()
     clearFrameCheck()
+    emit('rendered')
     return true
   }
 
   return false
 }
 
-function failLoad() {
+function failLoad(generation = lifecycleGeneration) {
+  if (!isCurrentGeneration(generation) || failureEmitted.value) return
+  failureEmitted.value = true
   clearLoadTimeout()
+  clearSlowLoadTimeout()
   clearFrameCheck()
   isLoading.value = false
   emit('load-failed')
@@ -122,6 +176,28 @@ function clearLoadTimeout() {
   }
 }
 
+function clearSlowLoadTimeout() {
+  if (slowLoadTimeoutId.value !== null) {
+    clearTimeout(slowLoadTimeoutId.value)
+    slowLoadTimeoutId.value = null
+  }
+}
+
+function scheduleSlowLoadNotice(generation: number) {
+  clearSlowLoadTimeout()
+  slowLoadTimeoutId.value = setTimeout(() => {
+    slowLoadTimeoutId.value = null
+    if (
+      isCurrentGeneration(generation)
+      && isLoading.value
+      && !successEmitted.value
+      && !failureEmitted.value
+    ) {
+      emit('slow-load')
+    }
+  }, props.slowLoadDelayMs)
+}
+
 function clearFrameCheck() {
   if (frameCheckId.value !== null) {
     clearInterval(frameCheckId.value)
@@ -129,30 +205,46 @@ function clearFrameCheck() {
   }
 }
 
-function failWidget() {
-  if (markReadyIfWidgetPresent()) return
-  clearLoadTimeout()
-  clearFrameCheck()
-  isLoading.value = false
-  emit('error')
-}
+function failWidget(generation = lifecycleGeneration, errorCode?: string) {
+  if (
+    !isCurrentGeneration(generation)
+    || successEmitted.value
+    || failureEmitted.value
+  ) return
 
-function renderWidget() {
-  if (!containerRef.value || !window.turnstile || !props.siteKey) {
-    failLoad()
+  const token = readTurnstileTokenFromContainer()
+  if (token) {
+    emitSuccess(token, generation)
     return
   }
 
-  if (widgetId.value) {
-    window.turnstile.remove(widgetId.value)
-    widgetId.value = null
+  failureEmitted.value = true
+  clearLoadTimeout()
+  clearSlowLoadTimeout()
+  clearFrameCheck()
+  isLoading.value = false
+  emit('error', errorCode)
+}
+
+function renderWidget(generation: number) {
+  if (!isCurrentGeneration(generation)) return
+  if (!containerRef.value || !window.turnstile || !props.siteKey) {
+    failLoad(generation)
+    return
   }
 
-  containerRef.value.innerHTML = ''
-  isLoading.value = true
-  successEmitted.value = false
-  clearFrameCheck()
   try {
+    if (widgetId.value) {
+      window.turnstile.remove(widgetId.value)
+      widgetId.value = null
+    }
+
+    containerRef.value.innerHTML = ''
+    isLoading.value = true
+    successEmitted.value = false
+    failureEmitted.value = false
+    clearLoadTimeout()
+    clearFrameCheck()
     widgetId.value = window.turnstile.render(containerRef.value, {
       sitekey: props.siteKey,
       theme: props.theme,
@@ -160,68 +252,80 @@ function renderWidget() {
       language: effectiveLanguage.value,
       appearance: 'always',
       action: props.action,
+      'response-field': true,
+      'response-field-name': 'cf-turnstile-response',
+      retry: 'never',
+      'refresh-expired': 'never',
+      'refresh-timeout': 'auto',
       callback: (token: string) => {
-        emitSuccess(token)
+        emitSuccess(token, generation)
       },
-      'expired-callback': handleExpire,
-      'error-callback': () => {
-        if (markReadyIfWidgetPresent()) return
-        failWidget()
+      'expired-callback': () => handleExpire(generation),
+      'error-callback': (errorCode) => {
+        failWidget(generation, normalizeTurnstileErrorCode(errorCode))
       },
     })
+    if (!isCurrentGeneration(generation) || successEmitted.value || failureEmitted.value) return
     frameCheckId.value = setInterval(() => {
-      markReadyIfWidgetPresent()
+      markReadyIfWidgetPresent(generation)
     }, 100)
     loadTimeoutId.value = setTimeout(() => {
-      if (!markReadyIfWidgetPresent()) {
-        failWidget()
+      if (!markReadyIfWidgetPresent(generation)) {
+        failWidget(generation)
       }
     }, props.loadTimeoutMs)
   } catch {
-    failLoad()
+    failLoad(generation)
   }
 }
 
-function mountWidget() {
+function mountWidget(generation: number) {
+  if (!isCurrentGeneration(generation)) return
   if (!window.turnstile?.render) {
     throw new Error('Turnstile API missing')
   }
   // preloadTurnstileScript() already waits for the API; render immediately.
   // turnstile.ready() can fail to invoke callbacks after SPA remounts.
-  renderWidget()
+  renderWidget(generation)
 }
 
-async function initWidget(attempt = 0) {
+async function initWidget(attempt = 0, generation = ++lifecycleGeneration) {
+  if (!isCurrentGeneration(generation)) return
   isLoading.value = true
+  if (attempt === 0) scheduleSlowLoadNotice(generation)
   if (!props.siteKey) {
-    failLoad()
+    failLoad(generation)
     return
   }
   try {
     await preloadTurnstileScript(props.loadTimeoutMs)
-    mountWidget()
+    if (!isCurrentGeneration(generation)) return
+    mountWidget(generation)
   } catch {
+    if (!isCurrentGeneration(generation)) return
     if (attempt < 1) {
       resetTurnstileScriptLoad()
       await new Promise((resolve) => setTimeout(resolve, 300))
-      return initWidget(attempt + 1)
+      if (!isCurrentGeneration(generation)) return
+      return initWidget(attempt + 1, generation)
     }
-    failLoad()
+    failLoad(generation)
   }
 }
 
 function reset() {
+  if (isUnmounted) return
   // A successful token is single-use. Every reset starts a new challenge and
-  // must allow its callback to emit the replacement token.
-  successEmitted.value = false
-  if (widgetId.value && window.turnstile) {
-    window.turnstile.reset(widgetId.value)
-  } else {
-    void initWidget()
-  }
+  // gets a fresh lifecycle generation. This rejects callbacks from the old
+  // widget without rejecting an identical token returned by Cloudflare test
+  // challenges after the new widget is completed.
+  invalidateTurnstileTokenInContainer()
+  void initWidget()
 }
 
-function handleExpire() {
+function handleExpire(generation: number) {
+  if (!isCurrentGeneration(generation)) return
+  clearSlowLoadTimeout()
   emit('expire')
   reset()
 }
@@ -239,7 +343,10 @@ watch(
 )
 
 onBeforeUnmount(() => {
+  isUnmounted = true
+  lifecycleGeneration += 1
   clearLoadTimeout()
+  clearSlowLoadTimeout()
   clearFrameCheck()
   if (widgetId.value && window.turnstile) {
     window.turnstile.remove(widgetId.value)

--- a/src/frontend/src/components/auth/AuthTurnstileField.test.ts
+++ b/src/frontend/src/components/auth/AuthTurnstileField.test.ts
@@ -11,11 +11,14 @@ const baseProps = {
   pending: false,
   ready: false,
   blocked: false,
+  verified: false,
   siteKey: 'test-site-key',
   action: 'login',
   loadingMessage: 'Loading Cloudflare human verification...',
   blockedMessage: 'Cloudflare verification unavailable.',
   retryLabel: 'Retry',
+  manualRetryLabel: 'Verification taking longer than expected? Reload',
+  errorCodeLabel: '',
 }
 
 function mountField(overrides: Partial<typeof baseProps> & { errorMessage?: string } = {}) {
@@ -59,15 +62,44 @@ describe('AuthTurnstileField display states', () => {
     expect(wrapper.emitted('expire')).toBeUndefined()
   })
 
+  it('offers manual recovery only while widget loading is unusually slow', async () => {
+    const wrapper = mountField({ ready: true })
+    const widget = wrapper.getComponent({ name: 'TurnstileWidget' })
+
+    expect(wrapper.find('.auth-turnstile-field__manual-retry').exists()).toBe(false)
+
+    widget.vm.$emit('slow-load')
+    await wrapper.vm.$nextTick()
+
+    const retry = wrapper.get('.auth-turnstile-field__manual-retry')
+    expect(retry.text()).toBe(baseProps.manualRetryLabel)
+    expect(retry.element.tagName).toBe('BUTTON')
+    expect(retry.find('.auth-turnstile-field__manual-retry-icon').exists()).toBe(true)
+
+    await retry.trigger('click')
+    expect(wrapper.emitted('retry')).toHaveLength(1)
+    expect(wrapper.find('.auth-turnstile-field__manual-retry').exists()).toBe(false)
+
+    widget.vm.$emit('slow-load')
+    await wrapper.vm.$nextTick()
+    widget.vm.$emit('rendered')
+    await wrapper.vm.$nextTick()
+    expect(wrapper.find('.auth-turnstile-field__manual-retry').exists()).toBe(false)
+  })
+
   it('shows an unavailable message only once and exposes retry', async () => {
     const wrapper = mountField({
       blocked: true,
       errorMessage: baseProps.blockedMessage,
+      errorCodeLabel: 'Reference code: 300030',
     })
 
     expect(wrapper.find('.auth-turnstile-field__blocked').exists()).toBe(true)
     expect(wrapper.find('.auth-turnstile-field__error').exists()).toBe(false)
     expect(wrapper.text().match(/Cloudflare verification unavailable\./g)).toHaveLength(1)
+    expect(wrapper.get('.auth-turnstile-field__reference-code').text()).toBe(
+      'Reference code: 300030',
+    )
 
     await wrapper.get('.auth-turnstile-field__retry').trigger('click')
     expect(wrapper.emitted('retry')).toHaveLength(1)
@@ -103,6 +135,9 @@ describe('AuthTurnstileField display states', () => {
     )
     expect(fieldSource).toMatch(
       /\.auth-turnstile-field__spinner\s*{[^}]*width:\s*16px;[^}]*height:\s*16px;/s,
+    )
+    expect(fieldSource).toMatch(
+      /\.auth-turnstile-field__manual-retry\s*{[^}]*width:\s*100%;[^}]*background:\s*color-mix\(in srgb, var\(--color-primary\) 6%, transparent\);[^}]*border:\s*1px solid color-mix\(in srgb, var\(--color-primary\) 22%, transparent\);/s,
     )
     expect(widgetSource).toMatch(
       /\.turnstile-widget\s*{[^}]*height:\s*65px;[^}]*min-height:\s*65px;[^}]*position:\s*relative;/s,

--- a/src/frontend/src/components/auth/AuthTurnstileField.vue
+++ b/src/frontend/src/components/auth/AuthTurnstileField.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref } from 'vue'
-import { KeyRound } from 'lucide-vue-next'
+import { KeyRound, RotateCcw } from 'lucide-vue-next'
 
 import TurnstileWidget from '../TurnstileWidget.vue'
 
@@ -8,11 +8,14 @@ defineProps<{
   pending: boolean
   ready: boolean
   blocked: boolean
+  verified: boolean
   siteKey: string
   action: string
   loadingMessage: string
   blockedMessage: string
   retryLabel: string
+  manualRetryLabel: string
+  errorCodeLabel?: string
   errorMessage?: string
 }>()
 
@@ -21,11 +24,46 @@ const emit = defineEmits<{
   success: [token: string]
   expire: []
   invalidate: []
-  error: []
+  error: [errorCode?: string]
   'load-failed': []
 }>()
 
 const turnstileWidgetRef = ref<InstanceType<typeof TurnstileWidget> | null>(null)
+const showManualRetry = ref(false)
+
+function hideManualRetry() {
+  showManualRetry.value = false
+}
+
+function retry() {
+  hideManualRetry()
+  emit('retry')
+}
+
+function onSuccess(token: string) {
+  hideManualRetry()
+  emit('success', token)
+}
+
+function onExpire() {
+  hideManualRetry()
+  emit('expire')
+}
+
+function onInvalidate() {
+  hideManualRetry()
+  emit('invalidate')
+}
+
+function onError(errorCode?: string) {
+  hideManualRetry()
+  emit('error', errorCode)
+}
+
+function onLoadFailed() {
+  hideManualRetry()
+  emit('load-failed')
+}
 
 function reset() {
   turnstileWidgetRef.value?.reset()
@@ -44,7 +82,10 @@ defineExpose({ reset })
       class="auth-turnstile-field__control auth-turnstile-field__loading"
       role="status"
     >
-      <span class="auth-turnstile-field__spinner" aria-hidden="true" />
+      <span
+        class="auth-turnstile-field__spinner"
+        aria-hidden="true"
+      />
       <span>{{ loadingMessage }}</span>
     </div>
 
@@ -59,28 +100,63 @@ defineExpose({ reset })
           :action="action"
           theme="dark"
           size="flexible"
-          @success="emit('success', $event)"
-          @expire="emit('expire')"
-          @invalidate="emit('invalidate')"
-          @error="emit('error')"
-          @load-failed="emit('load-failed')"
+          @success="onSuccess"
+          @expire="onExpire"
+          @invalidate="onInvalidate"
+          @error="onError"
+          @load-failed="onLoadFailed"
+          @slow-load="showManualRetry = true"
+          @rendered="hideManualRetry"
         />
       </div>
     </div>
 
+    <button
+      v-if="ready && siteKey && !verified && showManualRetry"
+      type="button"
+      class="auth-turnstile-field__manual-retry"
+      @click="retry"
+    >
+      <RotateCcw
+        class="auth-turnstile-field__manual-retry-icon"
+        :size="14"
+        aria-hidden="true"
+      />
+      <span class="auth-turnstile-field__manual-retry-label">{{ manualRetryLabel }}</span>
+    </button>
+
     <div
-      v-else-if="blocked"
+      v-if="blocked"
       class="auth-turnstile-field__control auth-turnstile-field__blocked"
       role="alert"
     >
-      <KeyRound :size="18" aria-hidden="true" />
-      <span class="auth-turnstile-field__blocked-text">{{ blockedMessage }}</span>
-      <button type="button" class="auth-turnstile-field__retry" @click="emit('retry')">
+      <KeyRound
+        :size="18"
+        aria-hidden="true"
+      />
+      <span class="auth-turnstile-field__blocked-text">
+        <span>{{ blockedMessage }}</span>
+        <span
+          v-if="errorCodeLabel"
+          class="auth-turnstile-field__reference-code"
+        >
+          {{ errorCodeLabel }}
+        </span>
+      </span>
+      <button
+        type="button"
+        class="auth-turnstile-field__retry"
+        @click="retry"
+      >
         {{ retryLabel }}
       </button>
     </div>
 
-    <p v-if="errorMessage && !blocked" class="auth-turnstile-field__error" role="alert">
+    <p
+      v-if="errorMessage && !blocked"
+      class="auth-turnstile-field__error"
+      role="alert"
+    >
       {{ errorMessage }}
     </p>
   </div>
@@ -157,7 +233,17 @@ defineExpose({ reset })
 .auth-turnstile-field__blocked-text {
   flex: 1;
   min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
   white-space: nowrap;
+}
+
+.auth-turnstile-field__reference-code {
+  color: var(--color-text-secondary, #a0a0a8);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  line-height: 1.25;
 }
 
 .auth-turnstile-field__retry {
@@ -184,6 +270,46 @@ defineExpose({ reset })
   outline-offset: 2px;
 }
 
+.auth-turnstile-field__manual-retry {
+  box-sizing: border-box;
+  width: 100%;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 12px;
+  color: var(--color-brand-violet-soft);
+  background: color-mix(in srgb, var(--color-primary) 6%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-primary) 22%, transparent);
+  border-radius: var(--radius-card);
+  font-size: 12px;
+  line-height: 1.4;
+  text-align: center;
+  cursor: pointer;
+  transition:
+    color 160ms ease-out,
+    background-color 160ms ease-out,
+    border-color 160ms ease-out;
+}
+
+.auth-turnstile-field__manual-retry:hover {
+  color: #fff;
+  background: color-mix(in srgb, var(--color-primary) 12%, transparent);
+  border-color: color-mix(in srgb, var(--color-primary) 48%, transparent);
+}
+
+.auth-turnstile-field__manual-retry:active {
+  background: color-mix(in srgb, var(--color-primary) 18%, transparent);
+}
+
+.auth-turnstile-field__manual-retry:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+.auth-turnstile-field__manual-retry-icon {
+  flex: 0 0 auto;
+}
+
 .auth-turnstile-field__error {
   margin: 0;
   color: var(--color-error);
@@ -192,11 +318,16 @@ defineExpose({ reset })
 }
 
 @keyframes auth-turnstile-spin {
-  to { transform: rotate(360deg); }
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .auth-turnstile-field__spinner { animation: none; }
+  .auth-turnstile-field__spinner {
+    animation: none;
+  }
+
 }
 
 @media (max-width: 479.98px) {

--- a/src/frontend/src/components/auth/ResetPasswordCard.vue
+++ b/src/frontend/src/components/auth/ResetPasswordCard.vue
@@ -31,6 +31,7 @@ const {
   isTurnstileReady,
   isTurnstileBlocked,
   loadTurnstileConfig,
+  retryTurnstileConfig,
   buildTurnstilePayload,
   blockTurnstile,
 } = useTurnstileConfig()
@@ -38,6 +39,7 @@ const {
 const view = ref<'request' | 'reset'>('request')
 const turnstileToken = ref('')
 const turnstileError = ref('')
+const turnstileErrorCode = ref('')
 const turnstileFieldRef = ref<InstanceType<typeof AuthTurnstileField> | null>(null)
 
 const formItems = reactive({
@@ -179,41 +181,47 @@ function startResendCooldown(seconds = 60) {
   }, 1000)
 }
 
-function blockUnavailableTurnstile() {
+function blockUnavailableTurnstile(errorCode = '') {
   blockTurnstile()
   turnstileToken.value = ''
   turnstileError.value = t('login.captchaUnavailable')
+  turnstileErrorCode.value = errorCode
 }
 
 async function retryTurnstile() {
   turnstileToken.value = ''
   turnstileError.value = ''
-  await loadTurnstileConfig(true)
+  turnstileErrorCode.value = ''
+  await retryTurnstileConfig()
 }
 
 function resetTurnstile() {
   if (!isTurnstileReady.value) return
   turnstileToken.value = ''
+  turnstileErrorCode.value = ''
   turnstileFieldRef.value?.reset()
 }
 
 function onTurnstileSuccess(token: string) {
   turnstileToken.value = token
   turnstileError.value = ''
+  turnstileErrorCode.value = ''
 }
 
 function onTurnstileExpire() {
   turnstileToken.value = ''
   turnstileError.value = t('login.captchaExpired')
+  turnstileErrorCode.value = ''
 }
 
 function onTurnstileInvalidate() {
   turnstileToken.value = ''
   turnstileError.value = ''
+  turnstileErrorCode.value = ''
 }
 
-function onTurnstileError() {
-  blockUnavailableTurnstile()
+function onTurnstileError(errorCode?: string) {
+  blockUnavailableTurnstile(errorCode)
 }
 
 function onTurnstileLoadFailed() {
@@ -460,11 +468,14 @@ onUnmounted(() => {
           :pending="isTurnstilePending"
           :ready="isTurnstileReady"
           :blocked="isTurnstileBlocked"
+          :verified="Boolean(turnstileToken)"
           :site-key="turnstileSiteKey"
           action="forgot_password"
           :loading-message="t('login.captchaLoading')"
           :blocked-message="t('login.captchaUnavailable')"
           :retry-label="t('login.captchaRetry')"
+          :manual-retry-label="t('login.captchaManualRetry')"
+          :error-code-label="turnstileErrorCode ? t('login.captchaReferenceCode', { code: turnstileErrorCode }) : ''"
           :error-message="turnstileError"
           @retry="retryTurnstile"
           @success="onTurnstileSuccess"

--- a/src/frontend/src/composables/useTurnstileConfig.test.ts
+++ b/src/frontend/src/composables/useTurnstileConfig.test.ts
@@ -1,0 +1,67 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  api: vi.fn(),
+  preloadTurnstileScript: vi.fn(),
+  resetTurnstileScriptLoad: vi.fn(),
+}))
+
+vi.mock('../lib/api', () => ({ api: mocks.api }))
+vi.mock('../lib/turnstileLoader', () => ({
+  preloadTurnstileScript: mocks.preloadTurnstileScript,
+  resetTurnstileScriptLoad: mocks.resetTurnstileScriptLoad,
+}))
+
+describe('Turnstile configuration retry', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    mocks.preloadTurnstileScript.mockResolvedValue(undefined)
+  })
+
+  it('clears the shared loader and recovers after a configuration failure', async () => {
+    mocks.api
+      .mockRejectedValueOnce(new Error('network unavailable'))
+      .mockResolvedValueOnce({
+        code: '0000',
+        data: {
+          enabled: true,
+          configured: true,
+          site_key: 'test-site-key',
+        },
+      })
+
+    const { useTurnstileConfig } = await import('./useTurnstileConfig')
+    const turnstile = useTurnstileConfig()
+
+    await turnstile.loadTurnstileConfig()
+    expect(turnstile.isTurnstileBlocked.value).toBe(true)
+
+    await Promise.all([
+      turnstile.retryTurnstileConfig(),
+      turnstile.retryTurnstileConfig(),
+    ])
+
+    expect(mocks.resetTurnstileScriptLoad).toHaveBeenCalledTimes(1)
+    expect(turnstile.authTurnstileMountGeneration.value).toBe(1)
+    expect(turnstile.isTurnstileReady.value).toBe(true)
+    expect(turnstile.turnstileSiteKey.value).toBe('test-site-key')
+    expect(mocks.preloadTurnstileScript).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps retry fail-closed when the configuration request still fails', async () => {
+    mocks.api.mockRejectedValue(new Error('network unavailable'))
+
+    const { useTurnstileConfig } = await import('./useTurnstileConfig')
+    const turnstile = useTurnstileConfig()
+
+    await turnstile.loadTurnstileConfig()
+    await turnstile.retryTurnstileConfig()
+
+    expect(mocks.resetTurnstileScriptLoad).toHaveBeenCalledTimes(1)
+    expect(turnstile.isTurnstileBlocked.value).toBe(true)
+    expect(turnstile.turnstileSiteKey.value).toBe('')
+  })
+})

--- a/src/frontend/src/composables/useTurnstileConfig.ts
+++ b/src/frontend/src/composables/useTurnstileConfig.ts
@@ -1,6 +1,9 @@
-import { computed, ref } from 'vue'
+import { computed, nextTick, ref } from 'vue'
 import { api } from '../lib/api'
-import { preloadTurnstileScript } from '../lib/turnstileLoader'
+import {
+  preloadTurnstileScript,
+  resetTurnstileScriptLoad,
+} from '../lib/turnstileLoader'
 
 export type TurnstileState = 'pending' | 'disabled' | 'ready' | 'blocked'
 
@@ -17,6 +20,7 @@ const state = ref<TurnstileState>('pending')
 const siteKey = ref('')
 const configLoaded = ref(false)
 let configLoadPromise: Promise<void> | null = null
+let configRetryPromise: Promise<void> | null = null
 const authTurnstileMountGeneration = ref(0)
 
 async function loadTurnstileConfig(force = false): Promise<void> {
@@ -45,7 +49,10 @@ async function loadTurnstileConfig(force = false): Promise<void> {
 
       siteKey.value = res.data.site_key
       state.value = 'ready'
-      void preloadTurnstileScript()
+      // The mounted widget owns user-visible load failure handling. Prefetch
+      // failures are intentionally swallowed here to avoid an unhandled
+      // rejection before the lazy authentication page finishes mounting.
+      void preloadTurnstileScript().catch(() => undefined)
     } catch {
       state.value = 'blocked'
       siteKey.value = ''
@@ -55,6 +62,27 @@ async function loadTurnstileConfig(force = false): Promise<void> {
     }
   })()
   return configLoadPromise
+}
+
+async function retryTurnstileConfig(): Promise<void> {
+  if (configRetryPromise) return configRetryPromise
+  if (configLoadPromise) return configLoadPromise
+
+  configRetryPromise = (async () => {
+    // Leave the ready state first so any mounted widget is removed before the
+    // shared Turnstile API and script tag are discarded.
+    state.value = 'pending'
+    await nextTick()
+    resetTurnstileScriptLoad()
+    authTurnstileMountGeneration.value += 1
+    await loadTurnstileConfig(true)
+  })()
+
+  try {
+    await configRetryPromise
+  } finally {
+    configRetryPromise = null
+  }
 }
 
 export function resetAuthTurnstileSession(): void {
@@ -90,6 +118,7 @@ export function useTurnstileConfig() {
     isTurnstileReady,
     isTurnstileBlocked,
     loadTurnstileConfig,
+    retryTurnstileConfig,
     buildTurnstilePayload,
     blockTurnstile,
   }

--- a/src/frontend/src/locales/en.ts
+++ b/src/frontend/src/locales/en.ts
@@ -3467,6 +3467,8 @@ export const en = {
     captchaUnavailable: 'Cloudflare verification unavailable.',
     captchaExpired: 'Human verification expired. Please complete the new challenge.',
     captchaRetry: 'Retry',
+    captchaManualRetry: 'Verification taking longer than expected? Reload',
+    captchaReferenceCode: 'Reference code: {code}',
     btnSubmit: 'Sign In',
     btnSubmitLoading: 'Signing in...',
     forgotPwd: 'Forgot Password?',

--- a/src/frontend/src/pages/auth/AuthTurnstileRetryFlows.test.ts
+++ b/src/frontend/src/pages/auth/AuthTurnstileRetryFlows.test.ts
@@ -15,6 +15,7 @@ const mocks = vi.hoisted(() => ({
   blockTurnstile: vi.fn(),
   buildTurnstilePayload: vi.fn(),
   loadTurnstileConfig: vi.fn(),
+  retryTurnstileConfig: vi.fn(),
   resetWidget: vi.fn(),
   routerPush: vi.fn(),
 }))
@@ -38,6 +39,7 @@ vi.mock('../../composables/useTurnstileConfig', () => ({
     isTurnstileBlocked: ref(false),
     authTurnstileMountGeneration: ref(0),
     loadTurnstileConfig: mocks.loadTurnstileConfig,
+    retryTurnstileConfig: mocks.retryTurnstileConfig,
     buildTurnstilePayload: mocks.buildTurnstilePayload,
     blockTurnstile: mocks.blockTurnstile,
   }),
@@ -56,6 +58,9 @@ const AuthTurnstileFieldStub = defineComponent({
   name: 'AuthTurnstileField',
   props: {
     errorMessage: { type: String, default: '' },
+    errorCodeLabel: { type: String, default: '' },
+    verified: { type: Boolean, default: false },
+    manualRetryLabel: { type: String, default: '' },
   },
   emits: ['retry', 'success', 'expire', 'invalidate', 'error', 'load-failed'],
   setup(props, { expose }) {
@@ -123,6 +128,7 @@ describe('authentication Turnstile retry flows', () => {
     vi.clearAllMocks()
     localStorage.clear()
     mocks.loadTurnstileConfig.mockResolvedValue(undefined)
+    mocks.retryTurnstileConfig.mockResolvedValue(undefined)
     mocks.buildTurnstilePayload.mockImplementation((token: string) => (
       token ? { turnstile_token: token } : {}
     ))
@@ -130,6 +136,26 @@ describe('authentication Turnstile retry flows', () => {
 
   afterEach(() => {
     localStorage.clear()
+  })
+
+  it.each([
+    ['registration', mountRegister],
+    ['password reset', mountResetPasswordCard],
+  ])('fully reloads Turnstile from the manual recovery action on %s', async (_name, mountView) => {
+    const wrapper = mountView()
+    await flushPromises()
+    const turnstile = wrapper.getComponent(AuthTurnstileFieldStub)
+
+    turnstile.vm.$emit('success', 'verified-token')
+    await wrapper.vm.$nextTick()
+    expect(turnstile.props('verified')).toBe(true)
+
+    turnstile.vm.$emit('retry')
+    await flushPromises()
+
+    expect(mocks.retryTurnstileConfig).toHaveBeenCalledTimes(1)
+    expect(turnstile.props('verified')).toBe(false)
+    wrapper.unmount()
   })
 
   it('uses a replacement token when registration code sending is retried', async () => {

--- a/src/frontend/src/pages/auth/Login.vue
+++ b/src/frontend/src/pages/auth/Login.vue
@@ -42,6 +42,7 @@ const {
   isTurnstileBlocked,
   authTurnstileMountGeneration,
   loadTurnstileConfig,
+  retryTurnstileConfig,
   buildTurnstilePayload,
   blockTurnstile,
 } = useTurnstileConfig()
@@ -49,6 +50,7 @@ const {
 const { setUser } = useAuth()
 const turnstileToken = ref('')
 const turnstileError = ref('')
+const turnstileErrorCode = ref('')
 const turnstileFieldRef = ref<InstanceType<typeof AuthTurnstileField> | null>(null)
 const googleEnabled = ref(false)
 const googleLoginUrl = ref('/accounts/google/login/?process=login')
@@ -146,41 +148,47 @@ function validatePasswordPresenceOnInput() {
   }
 }
 
-function blockUnavailableTurnstile() {
+function blockUnavailableTurnstile(errorCode = '') {
   blockTurnstile()
   turnstileToken.value = ''
   turnstileError.value = t('login.captchaUnavailable')
+  turnstileErrorCode.value = errorCode
 }
 
 async function retryTurnstile() {
   turnstileToken.value = ''
   turnstileError.value = ''
-  await loadTurnstileConfig(true)
+  turnstileErrorCode.value = ''
+  await retryTurnstileConfig()
 }
 
 function resetTurnstile() {
   if (!isTurnstileReady.value) return
   turnstileToken.value = ''
+  turnstileErrorCode.value = ''
   turnstileFieldRef.value?.reset()
 }
 
 function onTurnstileSuccess(token: string) {
   turnstileToken.value = token
   turnstileError.value = ''
+  turnstileErrorCode.value = ''
 }
 
 function onTurnstileExpire() {
   turnstileToken.value = ''
   turnstileError.value = t('login.captchaExpired')
+  turnstileErrorCode.value = ''
 }
 
 function onTurnstileInvalidate() {
   turnstileToken.value = ''
   turnstileError.value = ''
+  turnstileErrorCode.value = ''
 }
 
-function onTurnstileError() {
-  blockUnavailableTurnstile()
+function onTurnstileError(errorCode?: string) {
+  blockUnavailableTurnstile(errorCode)
 }
 
 function onTurnstileLoadFailed() {
@@ -615,11 +623,14 @@ onMounted(async () => {
           :pending="isTurnstilePending"
           :ready="isTurnstileReady"
           :blocked="isTurnstileBlocked"
+          :verified="Boolean(turnstileToken)"
           :site-key="turnstileSiteKey"
           action="login"
           :loading-message="t('login.captchaLoading')"
           :blocked-message="t('login.captchaUnavailable')"
           :retry-label="t('login.captchaRetry')"
+          :manual-retry-label="t('login.captchaManualRetry')"
+          :error-code-label="turnstileErrorCode ? t('login.captchaReferenceCode', { code: turnstileErrorCode }) : ''"
           :error-message="turnstileError"
           @retry="retryTurnstile"
           @success="onTurnstileSuccess"

--- a/src/frontend/src/pages/auth/LoginTurnstileLifecycle.test.ts
+++ b/src/frontend/src/pages/auth/LoginTurnstileLifecycle.test.ts
@@ -17,6 +17,7 @@ const mocks = vi.hoisted(() => ({
   fetchCurrentUser: vi.fn(),
   fetchDeployProfile: vi.fn(),
   loadTurnstileConfig: vi.fn(),
+  retryTurnstileConfig: vi.fn(),
   resetWidget: vi.fn(),
   routeQuery: {} as Record<string, string>,
   routerPush: vi.fn(),
@@ -49,6 +50,7 @@ vi.mock('../../composables/useTurnstileConfig', () => ({
     isTurnstileBlocked: ref(false),
     authTurnstileMountGeneration: ref(0),
     loadTurnstileConfig: mocks.loadTurnstileConfig,
+    retryTurnstileConfig: mocks.retryTurnstileConfig,
     buildTurnstilePayload: mocks.buildTurnstilePayload,
     blockTurnstile: mocks.blockTurnstile,
   }),
@@ -72,6 +74,9 @@ const AuthTurnstileFieldStub = defineComponent({
   name: 'AuthTurnstileField',
   props: {
     errorMessage: { type: String, default: '' },
+    errorCodeLabel: { type: String, default: '' },
+    verified: { type: Boolean, default: false },
+    manualRetryLabel: { type: String, default: '' },
   },
   emits: ['retry', 'success', 'expire', 'invalidate', 'error', 'load-failed'],
   setup(props, { expose }) {
@@ -166,6 +171,7 @@ describe('Login Turnstile lifecycle', () => {
       password_reset_available: false,
     })
     mocks.loadTurnstileConfig.mockResolvedValue(undefined)
+    mocks.retryTurnstileConfig.mockResolvedValue(undefined)
     mocks.buildTurnstilePayload.mockImplementation((token: string) => (
       token ? { turnstile_token: token } : {}
     ))
@@ -355,6 +361,43 @@ describe('Login Turnstile lifecycle', () => {
 
     expect(emailLoginCalls()).toHaveLength(2)
     expect(submittedBody(emailLoginCalls()[1]).turnstile_token).toBe('accepted-token')
+    wrapper.unmount()
+  })
+
+  it('clears a token and fully reloads Turnstile on manual retry', async () => {
+    const wrapper = await mountLogin(1440)
+    await fillCredentials(wrapper)
+    const turnstile = wrapper.getComponent(AuthTurnstileFieldStub)
+    const submit = wrapper.get('button.submit-btn')
+
+    turnstile.vm.$emit('success', 'verified-token')
+    await wrapper.vm.$nextTick()
+    expect(turnstile.props('verified')).toBe(true)
+    expect(submit.attributes('disabled')).toBeUndefined()
+
+    turnstile.vm.$emit('retry')
+    await flushPromises()
+
+    expect(mocks.retryTurnstileConfig).toHaveBeenCalledTimes(1)
+    expect(turnstile.props('verified')).toBe(false)
+    expect(submit.attributes('disabled')).toBeDefined()
+    wrapper.unmount()
+  })
+
+  it('shows and clears a safe Turnstile reference code', async () => {
+    const wrapper = await mountLogin(1440)
+    const turnstile = wrapper.getComponent(AuthTurnstileFieldStub)
+
+    turnstile.vm.$emit('error', '300030')
+    await wrapper.vm.$nextTick()
+
+    expect(turnstile.props('errorCodeLabel')).toBe('Reference code: 300030')
+    expect(mocks.blockTurnstile).toHaveBeenCalledTimes(1)
+
+    turnstile.vm.$emit('retry')
+    await flushPromises()
+
+    expect(turnstile.props('errorCodeLabel')).toBe('')
     wrapper.unmount()
   })
 

--- a/src/frontend/src/pages/auth/Register.vue
+++ b/src/frontend/src/pages/auth/Register.vue
@@ -30,12 +30,14 @@ const {
   isTurnstileBlocked,
   authTurnstileMountGeneration,
   loadTurnstileConfig,
+  retryTurnstileConfig,
   buildTurnstilePayload,
   blockTurnstile,
 } = useTurnstileConfig()
 
 const turnstileToken = ref('')
 const turnstileError = ref('')
+const turnstileErrorCode = ref('')
 const turnstileFieldRef = ref<InstanceType<typeof AuthTurnstileField> | null>(null)
 
 const formItems = reactive({
@@ -178,41 +180,47 @@ function restoreCooldown() {
   }
 }
 
-function blockUnavailableTurnstile() {
+function blockUnavailableTurnstile(errorCode = '') {
   blockTurnstile()
   turnstileToken.value = ''
   turnstileError.value = t('login.captchaUnavailable')
+  turnstileErrorCode.value = errorCode
 }
 
 async function retryTurnstile() {
   turnstileToken.value = ''
   turnstileError.value = ''
-  await loadTurnstileConfig(true)
+  turnstileErrorCode.value = ''
+  await retryTurnstileConfig()
 }
 
 function resetTurnstile() {
   if (!isTurnstileReady.value) return
   turnstileToken.value = ''
+  turnstileErrorCode.value = ''
   turnstileFieldRef.value?.reset()
 }
 
 function onTurnstileSuccess(token: string) {
   turnstileToken.value = token
   turnstileError.value = ''
+  turnstileErrorCode.value = ''
 }
 
 function onTurnstileExpire() {
   turnstileToken.value = ''
   turnstileError.value = t('login.captchaExpired')
+  turnstileErrorCode.value = ''
 }
 
 function onTurnstileInvalidate() {
   turnstileToken.value = ''
   turnstileError.value = ''
+  turnstileErrorCode.value = ''
 }
 
-function onTurnstileError() {
-  blockUnavailableTurnstile()
+function onTurnstileError(errorCode?: string) {
+  blockUnavailableTurnstile(errorCode)
 }
 
 function onTurnstileLoadFailed() {
@@ -468,11 +476,14 @@ onUnmounted(() => {
           :pending="isTurnstilePending"
           :ready="isTurnstileReady"
           :blocked="isTurnstileBlocked"
+          :verified="Boolean(turnstileToken)"
           :site-key="turnstileSiteKey"
           action="register_send_code"
           :loading-message="t('login.captchaLoading')"
           :blocked-message="t('login.captchaUnavailable')"
           :retry-label="t('login.captchaRetry')"
+          :manual-retry-label="t('login.captchaManualRetry')"
+          :error-code-label="turnstileErrorCode ? t('login.captchaReferenceCode', { code: turnstileErrorCode }) : ''"
           :error-message="turnstileError"
           @retry="retryTurnstile"
           @success="onTurnstileSuccess"


### PR DESCRIPTION
## Summary

- Detect rendered Turnstile challenges through the response field so closed shadow roots no longer leave the loading overlay blocking interaction
- Fully recreate the loader and widget on retry, with a delayed manual recovery action for slow challenges
- Reset stale verification state after credential failures, expiry, invalidation, and retry while rejecting callbacks from old widget lifecycles
- Surface only sanitized numeric Cloudflare client error codes as a secondary reference code

## Testing

- `npm run test -- src/components/TurnstileWidget.test.ts src/components/auth/AuthTurnstileField.test.ts src/composables/useTurnstileConfig.test.ts src/pages/auth/AuthTurnstileRetryFlows.test.ts src/pages/auth/LoginTurnstileLifecycle.test.ts` (33 tests)
- `npm run build`
- Manually previewed the client reference-code state

Fixes #163
Related to #151