### PR TITLE
fix: align deletion workflows and Source NAS probing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -74,6 +74,9 @@ CELERY_TIMEZONE=UTC
 
 # Default Celery queue name.
 CELERY_TASK_DEFAULT_QUEUE=backend
+# Keep lifecycle and cleanup tasks responsive while one worker process waits
+# for a remote Agent callback. Increase further for larger deployments.
+CELERY_WORKER_CONCURRENCY=2
 
 # Celery logging threshold.
 CELERY_LOG_LEVEL=INFO

--- a/deploy/docker/backend-entrypoint.sh
+++ b/deploy/docker/backend-entrypoint.sh
@@ -102,7 +102,7 @@ run_worker_dev() {
   require_watchfiles
   echo "[entrypoint] watch backend source and restart celery worker"
   exec watchfiles --filter python \
-    "celery -A common worker --loglevel=INFO -Q backend,node.lifecycle,node.ingest,storage.provider-validation" \
+    "celery -A common worker --loglevel=INFO -Q backend,node.lifecycle,node.ingest,source.remote-io,storage.provider-validation" \
     /opt/backend
 }
 
@@ -139,8 +139,8 @@ case "${1:-api}" in
     run_migrations_and_register
     echo "[entrypoint] start celery worker"
     exec celery -A common worker --loglevel=INFO \
-      --concurrency="${CELERY_WORKER_CONCURRENCY:-1}" \
-      -Q backend,node.lifecycle,node.ingest,storage.provider-validation
+      --concurrency="${CELERY_WORKER_CONCURRENCY:-2}" \
+      -Q backend,node.lifecycle,node.ingest,source.remote-io,storage.provider-validation
     ;;
   worker-dev)
     run_worker_dev

--- a/src/agent/internal/platform/install/local_uninstall_unix.go
+++ b/src/agent/internal/platform/install/local_uninstall_unix.go
@@ -124,6 +124,9 @@ CALLBACK_TOKEN=%q
 CALLBACK_INSECURE_TLS=%s
 FORCE_CLEANUP=%s
 CLEANUP_FAILED=0
+GATEWAY_SIDECAR_FAILED=0
+MANAGED_MOUNTS_FAILED=0
+AGENT_ARTIFACTS_FAILED=0
 
 mkdir -p "$(dirname "$LOG_FILE")" 2>/dev/null || true
 umask 022
@@ -133,11 +136,28 @@ uninstall_ts_utc() { date -u +"%%Y-%%m-%%dT%%H:%%M:%%SZ" 2>/dev/null || date -u;
 log() { echo "$(uninstall_ts_utc) $*"; }
 report_uninstall_completion() {
   local rc="$1" complete="true" payload_file
-  local failures='[]' retained='[]'
+  local failures retained
+  local -a failure_items=() retained_items=()
+  if [[ "$GATEWAY_SIDECAR_FAILED" -eq 1 ]]; then
+    failure_items+=('{"code":"gateway_sidecar_uninstall_failed","detail":"LensNode sidecar cleanup did not complete."}')
+    retained_items+=('"lensnode_sidecar"')
+  fi
+  if [[ "$MANAGED_MOUNTS_FAILED" -eq 1 ]]; then
+    failure_items+=('{"code":"managed_mount_cleanup_failed","detail":"One or more Agent-managed NAS mounts could not be unmounted."}')
+    retained_items+=('"managed_nas_mounts"')
+  fi
+  if [[ "$AGENT_ARTIFACTS_FAILED" -eq 1 ]]; then
+    failure_items+=('{"code":"agent_uninstall_failed","detail":"Agent service, files, or data remain after cleanup."}')
+    retained_items+=('"agent_installation"')
+  fi
+  if [[ "${#failure_items[@]}" -eq 0 && ( "$rc" -ne 0 || "$CLEANUP_FAILED" -ne 0 ) ]]; then
+    failure_items+=('{"code":"detached_uninstall_failed","detail":"Detached uninstall exited before all cleanup steps completed."}')
+    retained_items+=('"agent_installation_or_managed_mounts"')
+  fi
+  failures="[$(IFS=,; echo "${failure_items[*]}")]"
+  retained="[$(IFS=,; echo "${retained_items[*]}")]"
   [[ "$rc" -eq 0 && "$CLEANUP_FAILED" -eq 0 ]] || {
     complete="false"
-    failures='[{"code":"detached_uninstall_failed","detail":"Detached uninstall exited before all cleanup steps completed."}]'
-    retained='["agent_installation_or_managed_mounts"]'
   }
   command -v curl >/dev/null 2>&1 || {
     log "curl not found; uninstall completion callback could not be sent"
@@ -215,9 +235,11 @@ log "delay elapsed; running gateway sidecar uninstall when applicable"
 %s
 if ! run_gateway_sidecar_uninstall_if_needed; then
   CLEANUP_FAILED=1
+  GATEWAY_SIDECAR_FAILED=1
   if [[ "$FORCE_CLEANUP" == "1" ]]; then
     log "gateway sidecar uninstall failed; Force Cleanup will continue with Agent cleanup"
   else
+    AGENT_ARTIFACTS_FAILED=1
     log "gateway sidecar uninstall failed; keeping the Agent installed for retry"
     exit 1
   fi
@@ -225,9 +247,11 @@ fi
 log "cleaning Agent-managed NAS mounts before stopping the Agent service"
 if ! unmount_agent_mounts "$DATA_DIR"; then
   CLEANUP_FAILED=1
+  MANAGED_MOUNTS_FAILED=1
   if [[ "$FORCE_CLEANUP" == "1" ]]; then
     log "Agent-managed NAS mount cleanup failed; Force Cleanup will continue with Agent cleanup"
   else
+    AGENT_ARTIFACTS_FAILED=1
     log "Agent-managed NAS mount cleanup failed; preserving Agent files and data for manual retry"
     exit 1
   fi
@@ -339,11 +363,13 @@ if [[ "$KEEP_DATA" == "0" ]]; then
         if rm -rf "$DATA_DIR"; then
           if [[ -e "$DATA_DIR" ]]; then
             log "data directory $DATA_DIR remains after removal"
+            AGENT_ARTIFACTS_FAILED=1
             exit 1
           fi
           log "removed data directory $DATA_DIR"
         else
           log "failed to remove data directory $DATA_DIR (exit=$?)"
+          AGENT_ARTIFACTS_FAILED=1
           exit 1
         fi
       else
@@ -367,6 +393,7 @@ fi
 
 if ! verify_uninstall_artifacts; then
   CLEANUP_FAILED=1
+  AGENT_ARTIFACTS_FAILED=1
   if [[ "$FORCE_CLEANUP" == "1" ]]; then
     log "post-uninstall verification found residue; Force Cleanup will report it and finish"
   else

--- a/src/agent/internal/platform/install/local_uninstall_unix_test.go
+++ b/src/agent/internal/platform/install/local_uninstall_unix_test.go
@@ -57,6 +57,18 @@ func TestWriteUnixUninstallScriptIncludesLogFile(t *testing.T) {
 	if !strings.Contains(body, `gateway sidecar uninstall failed; keeping the Agent installed for retry`) {
 		t.Fatalf("script should fail closed when LensNode removal fails:\n%s", body)
 	}
+	for _, want := range []string{
+		`gateway_sidecar_uninstall_failed`,
+		`"lensnode_sidecar"`,
+		`managed_mount_cleanup_failed`,
+		`"managed_nas_mounts"`,
+		`agent_uninstall_failed`,
+		`"agent_installation"`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("script should report structured cleanup residue %q:\n%s", want, body)
+		}
+	}
 	if strings.Contains(body, `gateway sidecar uninstall reported errors; continuing agent uninstall`) {
 		t.Fatalf("script must not remove the Agent after LensNode removal fails:\n%s", body)
 	}
@@ -90,6 +102,7 @@ func TestWriteUnixUninstallScriptIncludesLogFile(t *testing.T) {
 	}
 	if !strings.Contains(body, `if [[ -e "$DATA_DIR" ]]; then
             log "data directory $DATA_DIR remains after removal"
+            AGENT_ARTIFACTS_FAILED=1
             exit 1`) {
 		t.Fatalf("script must verify data directory removal:\n%s", body)
 	}

--- a/src/backend/apps/node/services/internal/node_lifecycle.py
+++ b/src/backend/apps/node/services/internal/node_lifecycle.py
@@ -473,6 +473,9 @@ def _fail_stale_remove_task(*, node: Node, task: NodeTask) -> bool:
     payload = task.payload if isinstance(task.payload, dict) else {}
     force_cleanup = bool(payload.get("force_cleanup"))
     result = dict(task.result or {})
+    retained_resources = ["unverified_agent_installation"]
+    if node.role == NodeRole.GATEWAY:
+        retained_resources.append("unverified_lensnode_sidecar")
     result.update(
         {
             "mode": "local_detached",
@@ -484,7 +487,7 @@ def _fail_stale_remove_task(*, node: Node, task: NodeTask) -> bool:
                     "detail": "Detached uninstall did not report a terminal cleanup result.",
                 }
             ],
-            "retained_resources": ["unverified_agent_installation"],
+            "retained_resources": retained_resources,
             "force": force_cleanup,
             "outcome": (
                 "force_cleanup_success" if force_cleanup else "cleanup_failed"
@@ -729,6 +732,9 @@ def _start_node_remove_locked(
                 "Node is offline. Strict Cleanup requires the Agent to be reachable.",
                 code="node_offline",
             )
+        retained_resources = ["agent_installation"]
+        if node.role == NodeRole.GATEWAY:
+            retained_resources.append("lensnode_sidecar")
         summary = _purge_agent_server_records(org=org, node=node, user=user)
         return {
             "operation_id": f"offline-remove:{node.id}",
@@ -748,7 +754,7 @@ def _start_node_remove_locked(
                     "detail": "Remote uninstall was not executed because the Agent was offline.",
                 }
             ],
-            "retained_resources": ["agent_installation"],
+            "retained_resources": retained_resources,
             "summary": summary,
         }
 

--- a/src/backend/apps/node/tests/test_node_lifecycle.py
+++ b/src/backend/apps/node/tests/test_node_lifecycle.py
@@ -67,6 +67,23 @@ class NodeLifecycleTests(TestCase):
         self.node.refresh_from_db()
         self.assertTrue(self.node.is_deleted)
 
+    @patch("apps.node.services.internal.node_lifecycle.agent_ws_routable", return_value=False)
+    def test_offline_force_gateway_records_agent_and_sidecar_residue(self, _routable):
+        self.node.role = NodeRole.GATEWAY
+        self.node.save(update_fields=["role", "updated_at"])
+
+        result = start_node_remove(
+            org=self.org,
+            node=self.node,
+            user=self.user,
+            force=True,
+        )
+
+        self.assertEqual(
+            result["retained_resources"],
+            ["agent_installation", "lensnode_sidecar"],
+        )
+
     @patch("apps.node.services.internal.node_lifecycle.run_agent_task_async")
     @patch("apps.node.services.internal.node_lifecycle.agent_ws_routable", return_value=True)
     def test_online_remove_dispatches_uninstall(self, _routable, mock_dispatch):
@@ -416,6 +433,32 @@ class NodeLifecycleTests(TestCase):
         self.assertTrue(task.result["completion_timed_out_at"])
         self.assertNotIn("completion_received_at", task.result)
         self.assertTrue(self.node.is_deleted)
+
+    def test_force_gateway_timeout_records_unverified_agent_and_sidecar(self):
+        self.node.role = NodeRole.GATEWAY
+        self.node.save(update_fields=["role", "updated_at"])
+        detached_at = timezone.now() - timezone.timedelta(
+            seconds=node_conf.LIFECYCLE_DETACHED_TIMEOUT_SECONDS + 1
+        )
+        task = NodeTask.objects.create(
+            organization=self.org,
+            node=self.node,
+            kind="agent.uninstall",
+            status=NodeTask.Status.RUNNING,
+            payload={"force_cleanup": True},
+            result={"mode": "local_detached", "detached_at": detached_at.isoformat()},
+            watchdog_deadline_at=timezone.now() + timezone.timedelta(hours=1),
+            correlation_type=node_conf.LIFECYCLE_CORRELATION_TYPE,
+            correlation_id=f"remove:{self.node.id}",
+        )
+
+        advance_node_lifecycle(org=self.org, node=self.node, user=self.user)
+
+        task.refresh_from_db()
+        self.assertEqual(
+            task.result["retained_resources"],
+            ["unverified_agent_installation", "unverified_lensnode_sidecar"],
+        )
 
     @patch("apps.node.tasks.lifecycle.advance_node_lifecycle_for_node.apply_async")
     def test_detached_remove_queues_callback_timeout_verification(self, apply_async):

--- a/src/backend/apps/source/api/serializers/source_resource.py
+++ b/src/backend/apps/source/api/serializers/source_resource.py
@@ -43,6 +43,7 @@ class SourceResourceSerializer(serializers.ModelSerializer):
             "status_message",
             "last_connection_test",
             "connection_test_result",
+            "connection_test_status",
             "total_size",
             "used_size",
             "free_size",
@@ -61,6 +62,7 @@ class SourceResourceSerializer(serializers.ModelSerializer):
             "mount_error",
             "last_connection_test",
             "connection_test_result",
+            "connection_test_status",
             "total_size",
             "used_size",
             "free_size",
@@ -114,6 +116,7 @@ class SourceResourceListSerializer(SourceResourceSerializer):
             "connection_summary",
             "requires_mount",
             "last_connection_test",
+            "connection_test_status",
             "created_at",
             "updated_at",
         ]

--- a/src/backend/apps/source/constants.py
+++ b/src/backend/apps/source/constants.py
@@ -31,6 +31,24 @@ class MountStatus:
     )
 
 
+class ConnectionTestStatus:
+    IDLE = "idle"
+    PENDING = "pending"
+    RUNNING = "running"
+    SUCCESS = "success"
+    FAILED = "failed"
+
+    CHOICES = (
+        (IDLE, "Idle"),
+        (PENDING, "Pending"),
+        (RUNNING, "Running"),
+        (SUCCESS, "Success"),
+        (FAILED, "Failed"),
+    )
+
+    ACTIVE = frozenset({PENDING, RUNNING})
+
+
 class ResourceStatus:
     ACTIVE = "active"
     INACTIVE = "inactive"

--- a/src/backend/apps/source/migrations/0007_source_resource_connection_probe.py
+++ b/src/backend/apps/source/migrations/0007_source_resource_connection_probe.py
@@ -1,0 +1,31 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("source", "0006_source_resource_removal_lifecycle"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="sourceresource",
+            name="connection_probe_token",
+            field=models.UUIDField(blank=True, editable=False, null=True),
+        ),
+        migrations.AddField(
+            model_name="sourceresource",
+            name="connection_test_status",
+            field=models.CharField(
+                choices=[
+                    ("idle", "Idle"),
+                    ("pending", "Pending"),
+                    ("running", "Running"),
+                    ("success", "Success"),
+                    ("failed", "Failed"),
+                ],
+                db_index=True,
+                default="idle",
+                max_length=20,
+            ),
+        ),
+    ]

--- a/src/backend/apps/source/models/source_resource.py
+++ b/src/backend/apps/source/models/source_resource.py
@@ -5,7 +5,12 @@ from django.db import models
 
 from apps.node import agent_paths
 from apps.node.models.base import OrganizationScopedModel
-from apps.source.constants import MountStatus, ResourceStatus, ResourceType
+from apps.source.constants import (
+    ConnectionTestStatus,
+    MountStatus,
+    ResourceStatus,
+    ResourceType,
+)
 
 
 class SourceResource(OrganizationScopedModel):
@@ -53,6 +58,13 @@ class SourceResource(OrganizationScopedModel):
 
     last_connection_test = models.DateTimeField(null=True, blank=True)
     connection_test_result = models.TextField(blank=True, default="")
+    connection_test_status = models.CharField(
+        max_length=20,
+        choices=ConnectionTestStatus.CHOICES,
+        default=ConnectionTestStatus.IDLE,
+        db_index=True,
+    )
+    connection_probe_token = models.UUIDField(null=True, blank=True, editable=False)
 
     total_size = models.BigIntegerField(default=0)
     used_size = models.BigIntegerField(default=0)

--- a/src/backend/apps/source/periodic_tasks.py
+++ b/src/backend/apps/source/periodic_tasks.py
@@ -5,6 +5,18 @@ from common.scheduling.registry import TASK_REGISTRY
 
 def register_periodic_tasks() -> None:
     TASK_REGISTRY.add(
+        name="source_reconcile_stale_connection_probes",
+        task=(
+            "apps.source.tasks.connection_probe."
+            "reconcile_stale_source_connection_probes_task"
+        ),
+        schedule=60,
+        args=(),
+        kwargs={"limit": 100},
+        queue="source.remote-io",
+        enabled=True,
+    )
+    TASK_REGISTRY.add(
         name="source_reconcile_stuck_source_unregister_tasks",
         task="apps.source.tasks.source_unregister.reconcile_stuck_source_unregister_tasks_task",
         schedule=60,

--- a/src/backend/apps/source/services/interface.py
+++ b/src/backend/apps/source/services/interface.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import logging
+from uuid import uuid4
+
 from django.db import IntegrityError, transaction
 from django.db.models import Sum
 
@@ -8,11 +11,17 @@ from apps.audit.services.interface import write_audit_log
 from apps.iam.models import Organization
 from apps.node import agent_paths
 from apps.node.models import Node
-from apps.source.constants import MountStatus, ResourceStatus, ResourceType, SelectableSourceKind
+from apps.source.constants import (
+    ConnectionTestStatus,
+    MountStatus,
+    ResourceStatus,
+    ResourceType,
+    SelectableSourceKind,
+)
 from apps.source.models import SourceResource
 from apps.source.selectors.interface import source_resource_by_id, source_resources_queryset
 from apps.source.services.internal.connection import (
-    apply_connection_test_result,
+    apply_connection_test_result_if_current,
     mount_resource as _mount_resource,
     schedule_remount_after_proxy_change,
     run_connection_test,
@@ -25,6 +34,15 @@ from apps.source.services.internal.source_pipeline import (
     ensure_pipeline_entry,
     purge_pipeline_entry,
 )
+
+logger = logging.getLogger(__name__)
+
+
+def _cancel_active_connection_probe(resource: SourceResource) -> None:
+    if resource.connection_test_status not in ConnectionTestStatus.ACTIVE:
+        return
+    resource.connection_test_status = ConnectionTestStatus.IDLE
+    resource.connection_probe_token = None
 
 
 def _purge_soft_deleted_name_collision(*, organization_id: int, name: str) -> None:
@@ -99,6 +117,9 @@ def create_source_resource(
         validate_bound_node_role(resource_type=resource_type, node=node)
 
     try:
+        connection_probe_token = (
+            uuid4() if resource_type in ResourceType.REQUIRES_MOUNT else None
+        )
         resource = SourceResource.objects.create(
             organization=organization,
             name=normalized_name,
@@ -108,6 +129,12 @@ def create_source_resource(
             credentials=credentials or {},
             bound_node=node,
             status=status or ResourceStatus.ACTIVE,
+            connection_test_status=(
+                ConnectionTestStatus.PENDING
+                if connection_probe_token is not None
+                else ConnectionTestStatus.IDLE
+            ),
+            connection_probe_token=connection_probe_token,
             created_by=user if user and user.is_authenticated else None,
         )
     except IntegrityError as exc:
@@ -132,22 +159,24 @@ def create_source_resource(
         result=AuditResult.SUCCESS,
     )
     if resource.resource_type in ResourceType.REQUIRES_MOUNT:
-        try_probe_resource_capacity(resource)
+        from apps.source.tasks.connection_probe import (
+            queue_source_resource_capacity_probe,
+        )
+
+        # The create API only queues remote I/O after commit. The task uses this
+        # token to discard stale results after edits, rebinds, or deletion.
+        transaction.on_commit(
+            lambda resource_id=resource.id,
+            probe_token=str(resource.connection_probe_token),
+            expected_bound_node_id=int(resource.bound_node_id or 0): (
+                queue_source_resource_capacity_probe(
+                    resource_id=resource_id,
+                    probe_token=probe_token,
+                    expected_bound_node_id=expected_bound_node_id,
+                )
+            )
+        )
     return resource
-
-
-def try_probe_resource_capacity(resource: SourceResource) -> dict | None:
-    """Best-effort NAS/NFS/CIFS capacity probe when a bound proxy is online."""
-    if resource.resource_type not in ResourceType.REQUIRES_MOUNT:
-        return None
-    node = resource.bound_node
-    if node is None and resource.bound_node_id:
-        node = Node.objects.filter(id=resource.bound_node_id).first()
-    if node is None or node.status != Node.Status.ONLINE:
-        return None
-    result = run_connection_test(resource=resource)
-    apply_connection_test_result(resource, result)
-    return result
 
 
 @transaction.atomic
@@ -217,6 +246,8 @@ def update_source_resource(
     if "status" in fields and fields["status"]:
         resource.status = fields["status"]
 
+    _cancel_active_connection_probe(resource)
+
     validate_resource_payload(
         resource_type=resource.resource_type,
         config=resource.config,
@@ -275,8 +306,34 @@ def delete_source_resource(*, resource: SourceResource, user, force: bool = Fals
 
 
 def test_resource_connection(*, resource: SourceResource) -> dict:
-    result = run_connection_test(resource=resource)
-    apply_connection_test_result(resource, result)
+    probe_token = uuid4()
+    resource.connection_test_status = ConnectionTestStatus.RUNNING
+    resource.connection_probe_token = probe_token
+    resource.save(
+        update_fields=[
+            "connection_test_status",
+            "connection_probe_token",
+            "updated_at",
+        ]
+    )
+    try:
+        result = run_connection_test(resource=resource)
+    except Exception:
+        logger.exception(
+            "manual source connection test failed resource_id=%s",
+            resource.id,
+        )
+        result = {
+            "success": False,
+            "message": "Connection test failed unexpectedly. Try again.",
+        }
+    current, _skip_reason = apply_connection_test_result_if_current(
+        resource_id=resource.id,
+        probe_token=probe_token,
+        result=result,
+    )
+    if current is None:
+        return {**result, "stale": True}
     return result
 
 
@@ -320,7 +377,15 @@ def bind_node(*, resource: SourceResource, node_id: int) -> dict:
         return {"success": False, "message": f'Node "{node.name}" is not online.'}
     old_bound_node_id = resource.bound_node_id
     resource.bound_node = node
-    resource.save(update_fields=["bound_node", "updated_at"])
+    _cancel_active_connection_probe(resource)
+    resource.save(
+        update_fields=[
+            "bound_node",
+            "connection_test_status",
+            "connection_probe_token",
+            "updated_at",
+        ]
+    )
     if resource.resource_type in ResourceType.REQUIRES_MOUNT:
         _queue_remount_after_proxy_binding(
             resource=resource,
@@ -344,8 +409,17 @@ def unbind_node(*, resource: SourceResource) -> dict:
     resource.mount_status = "unmounted"
     resource.mount_point = ""
     resource.mount_error = ""
+    _cancel_active_connection_probe(resource)
     resource.save(
-        update_fields=["bound_node", "mount_status", "mount_point", "mount_error", "updated_at"]
+        update_fields=[
+            "bound_node",
+            "mount_status",
+            "mount_point",
+            "mount_error",
+            "connection_test_status",
+            "connection_probe_token",
+            "updated_at",
+        ]
     )
     return {"success": True, "message": "Resource unbound."}
 

--- a/src/backend/apps/source/services/internal/backup_source_delete.py
+++ b/src/backend/apps/source/services/internal/backup_source_delete.py
@@ -31,7 +31,12 @@ from apps.protection.services.snapshot_delete import (
     run_snapshot_delete_task,
 )
 from apps.restore.models import RestorePlan, RestoreRecord
-from apps.source.constants import ResourceStatus, ResourceType, SelectableSourceKind
+from apps.source.constants import (
+    ConnectionTestStatus,
+    ResourceStatus,
+    ResourceType,
+    SelectableSourceKind,
+)
 from apps.source.models import BackupSourceRepositoryPurgePending, SourceResource
 from apps.source.services.internal.selectable_ids import parse_selectable_id
 from apps.source.services.internal.source_pipeline import delete_pipeline_entry, purge_pipeline_entry
@@ -571,6 +576,39 @@ def _assert_strict_delete_blockers(*, ctx: SourceDeleteContext, force: bool) -> 
         raise BackupSourceDeleteFailed(message="Backup source was not deleted.", reasons=reasons)
 
 
+def _nas_remote_operation_blockers(*, ctx: SourceDeleteContext) -> list[DeleteReason]:
+    resource = ctx.nas_resource
+    if resource is None:
+        return []
+    active_probe = resource.connection_test_status in ConnectionTestStatus.ACTIVE
+    active_node_tasks = 0
+    if resource.bound_node_id:
+        active_node_tasks = NodeTask.objects.filter(
+            organization_id=resource.organization_id,
+            node_id=resource.bound_node_id,
+            correlation_type__in={
+                "source.connection_test",
+                "source.mount",
+                "source.unmount",
+            },
+            correlation_id=str(resource.id),
+            status__in={NodeTask.Status.PENDING, NodeTask.Status.RUNNING},
+        ).count()
+    if not active_probe and active_node_tasks == 0:
+        return []
+    return [
+        DeleteReason(
+            code="source_operation_in_progress",
+            detail=(
+                "A Source NAS connection or mount operation is still running. "
+                "Wait for it to finish before unregistering the source."
+            ),
+            source_id=ctx.selectable_id,
+            source_name=ctx.display_name,
+        )
+    ]
+
+
 def _normalize_delete_ids(ids: list[str]) -> list[str]:
     normalized: list[str] = []
     seen: set[str] = set()
@@ -666,6 +704,12 @@ def _prepare_delete_batch(
                         source_name=ctx.display_name,
                     )
                 ],
+            )
+        nas_operation_blockers = _nas_remote_operation_blockers(ctx=ctx)
+        if nas_operation_blockers:
+            raise BackupSourceDeleteFailed(
+                message="Backup source was not deleted.",
+                reasons=nas_operation_blockers,
             )
         if ctx.is_agent and ctx.agent_node is not None:
             from apps.node.services.internal.node_lifecycle import (
@@ -1032,6 +1076,25 @@ def _execute_source_unregister_work(
             progress=35,
             message="Resetting backup configuration data",
         )
+        # Remote NAS work must run after the preparation transaction commits
+        # and outside the database cleanup transaction below.  Agent task
+        # callbacks use another connection and cannot observe uncommitted
+        # NodeTask rows.
+        for ctx, _blob_stats, warnings in prepared_for_finalize:
+            if ctx.nas_resource is None:
+                continue
+            reasons: list[DeleteReason] = []
+            umount_result = _strict_nas_umount(
+                ctx=ctx,
+                force=force,
+                reasons=reasons,
+                warnings=warnings,
+            )
+            if umount_result.get("failed"):
+                raise BackupSourceDeleteFailed(
+                    message="Backup source was not deleted.",
+                    reasons=reasons,
+                )
         with transaction.atomic():
             for ctx, blob_stats, warnings in prepared_for_finalize:
                 summary = _finalize_single_source_delete(
@@ -1041,6 +1104,7 @@ def _execute_source_unregister_work(
                     warnings=warnings,
                     force=force,
                     user=user,
+                    unregister_task_id=unregister_task.id,
                 )
                 summary["repository_cleanup_tasks"] = direct_cleanup_by_source.get(
                     ctx.selectable_id, []
@@ -1282,27 +1346,61 @@ def _execute_source_unregister_work(
             "status": Task.Status.RUNNING,
         }
 
-    cleanup_failures = [
-        dict(failure)
-        for source in per_source
-        for failure in source.get("cleanup_failures") or []
-        if isinstance(failure, dict)
-    ]
-    retained_resources = [
-        str(resource)
-        for source in per_source
-        for resource in source.get("retained_resources") or []
-        if str(resource).strip()
-    ]
-    if force:
-        cleanup_failures.extend(
-            {
-                "code": str(warning.get("code") or "cleanup_warning"),
-                "detail": str(warning.get("detail") or "Cleanup retained residue."),
-            }
-            for warning in all_warnings
-            if isinstance(warning, dict)
+    cleanup_failures: list[dict[str, Any]] = []
+    seen_cleanup_failures: set[tuple[str, str]] = set()
+
+    def append_cleanup_failure(
+        failure: dict[str, Any],
+        *,
+        source_id: str = "",
+        source_name: str = "",
+    ) -> None:
+        item = dict(failure)
+        if source_id:
+            item.setdefault("source_id", source_id)
+        if source_name:
+            item.setdefault("source_name", source_name)
+        key = (
+            str(item.get("source_id") or ""),
+            str(item.get("code") or "cleanup_failed"),
         )
+        if key in seen_cleanup_failures:
+            return
+        seen_cleanup_failures.add(key)
+        cleanup_failures.append(item)
+
+    for source in per_source:
+        for failure in source.get("cleanup_failures") or []:
+            if not isinstance(failure, dict):
+                continue
+            append_cleanup_failure(
+                failure,
+                source_id=str(source.get("source_id") or ""),
+                source_name=str(source.get("source_name") or ""),
+            )
+
+    retained_resources = list(
+        dict.fromkeys(
+            str(resource)
+            for source in per_source
+            for resource in source.get("retained_resources") or []
+            if str(resource).strip()
+        )
+    )
+    if force:
+        for warning in all_warnings:
+            if not isinstance(warning, dict):
+                continue
+            append_cleanup_failure(
+                {
+                    "code": str(warning.get("code") or "cleanup_warning"),
+                    "detail": str(
+                        warning.get("detail") or "Cleanup retained residue."
+                    ),
+                },
+                source_id=str(warning.get("source_id") or ""),
+                source_name=str(warning.get("source_name") or ""),
+            )
     source_cleanup_complete = all(
         bool(source.get("cleanup_complete", True))
         for source in per_source
@@ -1612,6 +1710,8 @@ def preflight_delete_backup_sources(
             from apps.node.services.internal.node_workload import get_node_workload_blockers
 
             for blocker in get_node_workload_blockers(node=ctx.agent_node):
+                if blocker.code in {"backup_running", "restore_running"}:
+                    continue
                 blocking.append(
                     DeleteReason(
                         code="node_workload_active",
@@ -1632,6 +1732,10 @@ def preflight_delete_backup_sources(
                 )
         if ctx.nas_resource is not None:
             resource = ctx.nas_resource
+            blocking.extend(
+                reason.as_dict()
+                for reason in _nas_remote_operation_blockers(ctx=ctx)
+            )
             config_ids = list(
                 BackupConfig.objects.filter(
                     organization_id=organization_id,
@@ -2149,22 +2253,8 @@ def _finalize_single_source_delete(
     warnings: list[DeleteWarning],
     force: bool,
     user,
+    unregister_task_id: int,
 ) -> dict[str, Any]:
-    reasons: list[DeleteReason] = []
-
-    if ctx.nas_resource is not None:
-        umount_result = _strict_nas_umount(
-            ctx=ctx,
-            force=force,
-            reasons=reasons,
-            warnings=warnings,
-        )
-        if umount_result.get("failed"):
-            raise BackupSourceDeleteFailed(
-                message="Backup source was not deleted.",
-                reasons=reasons,
-            )
-
     config_ids = list(
         BackupConfig.objects.filter(
             organization_id=org.id,
@@ -2206,20 +2296,63 @@ def _finalize_single_source_delete(
         remove_result = (
             dict(remove_task.result or {}) if remove_task is not None else {}
         )
-        if remove_task is not None and remove_task.status in {
-            NodeTask.Status.FAILED,
-            NodeTask.Status.TIMEOUT,
-            NodeTask.Status.CANCELED,
-        }:
+        remove_payload = (
+            remove_task.payload
+            if remove_task is not None and isinstance(remove_task.payload, dict)
+            else {}
+        )
+        belongs_to_unregister = bool(
+            remove_task is not None
+            and int(remove_payload.get("source_unregister_task_id") or 0)
+            == unregister_task_id
+        )
+        if (
+            belongs_to_unregister
+            and remove_task is not None
+            and remove_task.status in {
+                NodeTask.Status.FAILED,
+                NodeTask.Status.TIMEOUT,
+                NodeTask.Status.CANCELED,
+            }
+        ):
+            failure = {
+                "code": "agent_uninstall_failed",
+                "detail": (
+                    remove_task.last_error
+                    or "Agent uninstall did not complete successfully."
+                ),
+            }
+            if force:
+                _soft_delete_identity(org=org, ctx=ctx, user=user)
+                cleanup_failures = [
+                    dict(item)
+                    for item in remove_result.get("cleanup_failures") or []
+                    if isinstance(item, dict)
+                ]
+                if not cleanup_failures:
+                    cleanup_failures = [failure]
+                retained_resources = [
+                    str(item)
+                    for item in remove_result.get("retained_resources") or []
+                    if str(item).strip()
+                ]
+                if not retained_resources:
+                    retained_resources = ["agent_installation"]
+                return {
+                    "source_id": ctx.selectable_id,
+                    "source_name": ctx.display_name,
+                    "cleanup": cleanup,
+                    "cleanup_complete": False,
+                    "cleanup_failures": cleanup_failures,
+                    "retained_resources": retained_resources,
+                    "warnings": [warning.as_dict() for warning in warnings],
+                }
             raise BackupSourceDeleteFailed(
                 message="Agent uninstall failed.",
                 reasons=[
                     DeleteReason(
-                        code="agent_uninstall_failed",
-                        detail=(
-                            remove_task.last_error
-                            or "Agent uninstall did not complete successfully."
-                        ),
+                        code=str(failure["code"]),
+                        detail=str(failure["detail"]),
                         source_id=ctx.selectable_id,
                         source_name=ctx.display_name,
                     )
@@ -2231,6 +2364,11 @@ def _finalize_single_source_delete(
             and (
                 remove_result.get("completion_received_at")
                 or remove_result.get("completion_timed_out_at")
+            )
+            and (
+                belongs_to_unregister
+                or bool(remove_result.get("cleanup_complete"))
+                or force
             )
         ):
             _soft_delete_identity(org=org, ctx=ctx, user=user)
@@ -2246,15 +2384,20 @@ def _finalize_single_source_delete(
         conn = agent_connection_status(node=node)
         if conn == CONNECTION_OFFLINE:
             if not force:
-                reasons.append(
-                    DeleteReason(
-                        code="agent_offline",
-                        detail=f"Agent \"{ctx.display_name}\" is offline — remote uninstall is required in strict mode.",
-                        source_id=ctx.selectable_id,
-                        source_name=ctx.display_name,
-                    )
+                raise BackupSourceDeleteFailed(
+                    message="Backup source was not deleted.",
+                    reasons=[
+                        DeleteReason(
+                            code="agent_offline",
+                            detail=(
+                                f"Agent \"{ctx.display_name}\" is offline — remote "
+                                "uninstall is required in strict mode."
+                            ),
+                            source_id=ctx.selectable_id,
+                            source_name=ctx.display_name,
+                        )
+                    ],
                 )
-                raise BackupSourceDeleteFailed(message="Backup source was not deleted.", reasons=reasons)
             warnings.append(
                 DeleteWarning(
                     code="agent_offline",

--- a/src/backend/apps/source/services/internal/connection.py
+++ b/src/backend/apps/source/services/internal/connection.py
@@ -4,12 +4,18 @@ from __future__ import annotations
 
 import logging
 import threading
+from uuid import UUID
 
 from django.db import transaction
 from django.utils import timezone
 
 from apps.node.models import Node
-from apps.source.constants import MountStatus, ResourceStatus, ResourceType
+from apps.source.constants import (
+    ConnectionTestStatus,
+    MountStatus,
+    ResourceStatus,
+    ResourceType,
+)
 from apps.source.models import SourceResource
 from apps.source.services.internal.nas_agent import (
     _task_error_message,
@@ -133,6 +139,12 @@ def apply_connection_test_result(resource: SourceResource, result: dict) -> None
         ResourceStatus.ACTIVE if result.get("success") else ResourceStatus.ERROR
     )
     resource.status_message = resource.connection_test_result
+    resource.connection_test_status = (
+        ConnectionTestStatus.SUCCESS
+        if result.get("success")
+        else ConnectionTestStatus.FAILED
+    )
+    resource.connection_probe_token = None
 
     details = result.get("details") or {}
     space = details.get("space_info") or {}
@@ -148,6 +160,39 @@ def apply_connection_test_result(resource: SourceResource, result: dict) -> None
         resource.mount_point = mount_point
         resource.mount_error = ""
     resource.save()
+
+
+def apply_connection_test_result_if_current(
+    *,
+    resource_id: int,
+    probe_token: UUID | str,
+    result: dict,
+    expected_bound_node_id: int | None = None,
+    require_mount: bool = False,
+) -> tuple[SourceResource | None, str]:
+    """Apply a probe result only while it still owns the source revision."""
+    with transaction.atomic():
+        resource = (
+            SourceResource.all_objects.select_for_update()
+            .filter(pk=resource_id)
+            .first()
+        )
+        if resource is None or resource.is_deleted:
+            return None, "source_deleted"
+        if resource.status in {ResourceStatus.REMOVING, ResourceStatus.REMOVED}:
+            return None, "source_removing"
+        if require_mount and not resource.requires_mount:
+            return None, "mount_not_required"
+        if (
+            expected_bound_node_id is not None
+            and int(resource.bound_node_id or 0)
+            != int(expected_bound_node_id or 0)
+        ):
+            return None, "proxy_binding_changed"
+        if str(resource.connection_probe_token or "") != str(probe_token or ""):
+            return None, "source_changed"
+        apply_connection_test_result(resource, result)
+        return resource, ""
 
 
 def mount_resource(resource: SourceResource) -> dict:

--- a/src/backend/apps/source/tasks/__init__.py
+++ b/src/backend/apps/source/tasks/__init__.py
@@ -1,5 +1,10 @@
 """Celery tasks for the source app."""
 
+from .connection_probe import (
+    probe_source_resource_capacity,
+    queue_source_resource_capacity_probe,
+    reconcile_stale_source_connection_probes_task,
+)
 from .source_unregister import (
     execute_source_unregister_task,
     reconcile_stuck_source_unregister_tasks_task,
@@ -7,5 +12,8 @@ from .source_unregister import (
 
 __all__ = [
     "execute_source_unregister_task",
+    "probe_source_resource_capacity",
+    "queue_source_resource_capacity_probe",
+    "reconcile_stale_source_connection_probes_task",
     "reconcile_stuck_source_unregister_tasks_task",
 ]

--- a/src/backend/apps/source/tasks/connection_probe.py
+++ b/src/backend/apps/source/tasks/connection_probe.py
@@ -1,0 +1,266 @@
+"""Asynchronous Source NAS connection and capacity discovery."""
+
+from __future__ import annotations
+
+import logging
+from datetime import timedelta
+
+from celery import shared_task
+from django.utils import timezone
+
+from apps.node.models import Node
+from apps.source.constants import (
+    ConnectionTestStatus,
+    ResourceStatus,
+    ResourceType,
+)
+from apps.source.models import SourceResource
+from apps.source.services.internal.connection import (
+    apply_connection_test_result_if_current,
+    run_connection_test,
+)
+
+logger = logging.getLogger(__name__)
+
+SOURCE_REMOTE_IO_QUEUE = "source.remote-io"
+_PROBE_MAX_RETRIES = 2
+_PROBE_STALE_SECONDS = 15 * 60
+
+
+def _probe_target(
+    *,
+    resource_id: int,
+    probe_token: str,
+    expected_bound_node_id: int,
+) -> tuple[SourceResource | None, str]:
+    resource = SourceResource.all_objects.filter(pk=resource_id).first()
+    if resource is None or resource.is_deleted:
+        return None, "source_deleted"
+    if resource.status in {ResourceStatus.REMOVING, ResourceStatus.REMOVED}:
+        return None, "source_removing"
+    if resource.resource_type not in ResourceType.REQUIRES_MOUNT:
+        return None, "mount_not_required"
+    if int(resource.bound_node_id or 0) != int(expected_bound_node_id or 0):
+        return None, "proxy_binding_changed"
+    if str(resource.connection_probe_token or "") != str(probe_token or ""):
+        return None, "source_changed"
+    return resource, ""
+
+
+def run_source_resource_capacity_probe(
+    *,
+    resource_id: int,
+    probe_token: str,
+    expected_bound_node_id: int,
+) -> dict:
+    """Run one probe and discard its result if the source changes meanwhile."""
+    resource, skip_reason = _probe_target(
+        resource_id=resource_id,
+        probe_token=probe_token,
+        expected_bound_node_id=expected_bound_node_id,
+    )
+    if resource is None:
+        return {"status": "skipped", "reason": skip_reason}
+
+    node = resource.bound_node
+    if node is None or node.status != Node.Status.ONLINE:
+        resource, skip_reason = apply_connection_test_result_if_current(
+            resource_id=resource_id,
+            probe_token=probe_token,
+            expected_bound_node_id=expected_bound_node_id,
+            require_mount=True,
+            result={
+                "success": False,
+                "message": "Automatic connection test skipped because the Proxy is offline.",
+            },
+        )
+        if resource is None:
+            return {"status": "discarded", "reason": skip_reason}
+        return {"status": "failed", "reason": "proxy_offline"}
+
+    SourceResource.all_objects.filter(
+        pk=resource.id,
+        connection_probe_token=probe_token,
+    ).update(
+        connection_test_status=ConnectionTestStatus.RUNNING,
+        updated_at=timezone.now(),
+    )
+
+    result = run_connection_test(resource=resource)
+
+    # The remote call may wait for up to 180 seconds. Lock and re-read the row
+    # before applying the result so an edit, rebind, or delete wins the race.
+    resource, skip_reason = apply_connection_test_result_if_current(
+        resource_id=resource_id,
+        probe_token=probe_token,
+        expected_bound_node_id=expected_bound_node_id,
+        require_mount=True,
+        result=result,
+    )
+    if resource is None:
+        return {"status": "discarded", "reason": skip_reason}
+    return {
+        "status": "success" if result.get("success") else "failed",
+        "resource_id": resource.id,
+        "message": str(result.get("message") or result.get("error") or ""),
+    }
+
+
+def _record_terminal_probe_failure(
+    *,
+    resource_id: int,
+    probe_token: str,
+    expected_bound_node_id: int,
+    error: Exception,
+) -> dict:
+    resource, skip_reason = _probe_target(
+        resource_id=resource_id,
+        probe_token=probe_token,
+        expected_bound_node_id=expected_bound_node_id,
+    )
+    if resource is None:
+        return {"status": "discarded", "reason": skip_reason}
+    message = "Automatic Source NAS connection test failed. Retry Test Connection."
+    resource, skip_reason = apply_connection_test_result_if_current(
+        resource_id=resource_id,
+        probe_token=probe_token,
+        expected_bound_node_id=expected_bound_node_id,
+        require_mount=True,
+        result={"success": False, "message": message},
+    )
+    if resource is None:
+        return {"status": "discarded", "reason": skip_reason}
+    logger.error(
+        "source capacity probe exhausted retries resource_id=%s error=%s",
+        resource_id,
+        error,
+    )
+    return {
+        "status": "failed",
+        "resource_id": resource_id,
+        "message": message,
+    }
+
+
+@shared_task(
+    name="apps.source.tasks.connection_probe.probe_source_resource_capacity",
+    bind=True,
+    max_retries=_PROBE_MAX_RETRIES,
+)
+def probe_source_resource_capacity(
+    self,
+    *,
+    resource_id: int,
+    probe_token: str,
+    expected_bound_node_id: int,
+) -> dict:
+    """Run a Source NAS probe without holding up the create API request."""
+    try:
+        return run_source_resource_capacity_probe(
+            resource_id=int(resource_id),
+            probe_token=str(probe_token),
+            expected_bound_node_id=int(expected_bound_node_id or 0),
+        )
+    except Exception as exc:
+        retries = int(getattr(self.request, "retries", 0) or 0)
+        if retries < _PROBE_MAX_RETRIES:
+            raise self.retry(exc=exc, countdown=5 * (2**retries))
+        return _record_terminal_probe_failure(
+            resource_id=int(resource_id),
+            probe_token=str(probe_token),
+            expected_bound_node_id=int(expected_bound_node_id or 0),
+            error=exc,
+        )
+
+
+def queue_source_resource_capacity_probe(
+    *,
+    resource_id: int,
+    probe_token: str,
+    expected_bound_node_id: int,
+) -> bool:
+    """Best-effort enqueue that cannot turn a committed create into an API 500."""
+    try:
+        probe_source_resource_capacity.apply_async(
+            kwargs={
+                "resource_id": int(resource_id),
+                "probe_token": str(probe_token),
+                "expected_bound_node_id": int(expected_bound_node_id or 0),
+            },
+            queue=SOURCE_REMOTE_IO_QUEUE,
+        )
+    except Exception:
+        logger.exception(
+            "source capacity probe enqueue failed resource_id=%s",
+            resource_id,
+        )
+        SourceResource.all_objects.filter(
+            pk=resource_id,
+            is_deleted=False,
+            connection_probe_token=probe_token,
+        ).update(
+            connection_test_status=ConnectionTestStatus.FAILED,
+            connection_probe_token=None,
+            status=ResourceStatus.ERROR,
+            status_message=(
+                "Automatic connection test could not be queued. Retry Test Connection."
+            ),
+            connection_test_result=(
+                "Automatic connection test could not be queued. Retry Test Connection."
+            ),
+            updated_at=timezone.now(),
+        )
+        return False
+    return True
+
+
+def reconcile_stale_source_connection_probes(*, limit: int = 100) -> dict[str, int]:
+    """Fail probes that can no longer be owned by a live Celery execution."""
+    cutoff = timezone.now() - timedelta(seconds=_PROBE_STALE_SECONDS)
+    stale_ids = list(
+        SourceResource.all_objects.filter(
+            is_deleted=False,
+            connection_test_status__in=ConnectionTestStatus.ACTIVE,
+            updated_at__lt=cutoff,
+        )
+        .order_by("updated_at", "id")
+        .values_list("id", flat=True)[: max(1, int(limit))]
+    )
+    if not stale_ids:
+        return {"stale": 0, "failed": 0}
+    message = "Automatic connection test timed out. Retry Test Connection."
+    failed = SourceResource.all_objects.filter(
+        id__in=stale_ids,
+        is_deleted=False,
+        connection_test_status__in=ConnectionTestStatus.ACTIVE,
+        updated_at__lt=cutoff,
+    ).update(
+        connection_test_status=ConnectionTestStatus.FAILED,
+        connection_probe_token=None,
+        status=ResourceStatus.ERROR,
+        status_message=message,
+        connection_test_result=message,
+        updated_at=timezone.now(),
+    )
+    if failed:
+        logger.warning("reconciled stale source capacity probes count=%s", failed)
+    return {"stale": len(stale_ids), "failed": int(failed)}
+
+
+@shared_task(
+    name=(
+        "apps.source.tasks.connection_probe."
+        "reconcile_stale_source_connection_probes_task"
+    )
+)
+def reconcile_stale_source_connection_probes_task(*, limit: int = 100) -> dict[str, int]:
+    return reconcile_stale_source_connection_probes(limit=int(limit))
+
+
+__all__ = [
+    "probe_source_resource_capacity",
+    "queue_source_resource_capacity_probe",
+    "reconcile_stale_source_connection_probes",
+    "reconcile_stale_source_connection_probes_task",
+    "run_source_resource_capacity_probe",
+]

--- a/src/backend/apps/source/tests/test_api.py
+++ b/src/backend/apps/source/tests/test_api.py
@@ -2,6 +2,7 @@
 
 from types import SimpleNamespace
 from unittest.mock import patch
+from uuid import uuid4
 
 from django.contrib.auth import get_user_model
 from django.test import TestCase, override_settings
@@ -21,6 +22,7 @@ from apps.protection.models import (
 from apps.restore.models import RestorePlan
 from apps.source.models import SourceBackupPipelineEntry, SourceResource
 from apps.source.services.internal.agent_host_sync import sync_agent_source_host
+from apps.source.tasks.connection_probe import run_source_resource_capacity_probe
 from apps.storage.repositories.models import Repository
 from apps.task.models import Task, TaskResource
 
@@ -373,24 +375,42 @@ class SourceResourceApiTests(TestCase):
                 },
             },
         )
-        create = self.client.post(
-            "/api/v1/source/resources/",
-            {
-                "name": "nas-capacity-probe",
-                "resource_type": "nas",
-                "config": {
-                    "protocol": "nfs",
-                    "server": "192.168.1.50",
-                    "export_path": "/export/data",
-                    "path": custom_mount("nfs-export"),
-                },
-                "bound_node_id": self.node.id,
-            },
-            format="json",
-            **self._headers(),
-        )
+        with patch(
+            "apps.source.tasks.connection_probe.probe_source_resource_capacity.apply_async"
+        ) as apply_async:
+            with self.captureOnCommitCallbacks(execute=True):
+                create = self.client.post(
+                    "/api/v1/source/resources/",
+                    {
+                        "name": "nas-capacity-probe",
+                        "resource_type": "nas",
+                        "config": {
+                            "protocol": "nfs",
+                            "server": "192.168.1.50",
+                            "export_path": "/export/data",
+                            "path": custom_mount("nfs-export"),
+                        },
+                        "bound_node_id": self.node.id,
+                    },
+                    format="json",
+                    **self._headers(),
+                )
         self.assertEqual(create.status_code, status.HTTP_201_CREATED)
         resource = SourceResource.objects.get(id=create.data["id"])
+        self.assertEqual(resource.total_size, 0)
+        self.assertIsNone(resource.last_connection_test)
+        apply_async.assert_called_once()
+        self.assertEqual(
+            apply_async.call_args.kwargs["queue"],
+            "source.remote-io",
+        )
+
+        result = run_source_resource_capacity_probe(
+            **apply_async.call_args.kwargs["kwargs"]
+        )
+
+        self.assertEqual(result["status"], "success")
+        resource.refresh_from_db()
         self.assertEqual(resource.total_size, 1_000_000_000_000)
         self.assertEqual(resource.used_size, 250_000_000_000)
         self.assertEqual(resource.free_size, 750_000_000_000)
@@ -1609,6 +1629,18 @@ class BackupSourceBulkDeleteTests(TestCase):
             is_primary=True,
         )
 
+        preflight = self.client.post(
+            "/api/v1/source/backup-selectable/delete-preflight/",
+            {"ids": [f"agent:{self.agent.id}"]},
+            format="json",
+            **self._headers(),
+        )
+        self.assertEqual(preflight.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            [item["code"] for item in preflight.data["blocking"]],
+            ["running_tasks"],
+        )
+
         response = self.client.post(
             "/api/v1/source/backup-selectable/bulk-delete/",
             {
@@ -1630,6 +1662,63 @@ class BackupSourceBulkDeleteTests(TestCase):
         )
         self.agent.refresh_from_db()
         self.assertFalse(self.agent.is_deleted)
+
+    def test_bulk_delete_force_does_not_bypass_source_nas_probe(self):
+        proxy = Node.objects.create(
+            organization=self.org,
+            name="probe-proxy",
+            role=Node.Role.PROXY,
+            status=Node.Status.ONLINE,
+        )
+        resource = SourceResource.objects.create(
+            organization=self.org,
+            name="probing-source-nas",
+            resource_type="nas",
+            config={
+                "protocol": "nfs",
+                "server": "192.0.2.30",
+                "export_path": "/source",
+            },
+            bound_node=proxy,
+            connection_test_status="running",
+            connection_probe_token=uuid4(),
+        )
+
+        preflight = self.client.post(
+            "/api/v1/source/backup-selectable/delete-preflight/",
+            {"ids": [f"nas:{resource.id}"]},
+            format="json",
+            **self._headers(),
+        )
+
+        self.assertEqual(preflight.status_code, status.HTTP_200_OK)
+        self.assertTrue(preflight.data["delete_disabled"])
+        self.assertEqual(
+            [item["code"] for item in preflight.data["blocking"]],
+            ["source_operation_in_progress"],
+        )
+
+        response = self.client.post(
+            "/api/v1/source/backup-selectable/bulk-delete/",
+            {
+                "ids": [f"nas:{resource.id}"],
+                "force": True,
+                "confirmation": "UNREGISTER",
+            },
+            format="json",
+            **self._headers(),
+        )
+
+        self.assertEqual(
+            response.status_code,
+            status.HTTP_422_UNPROCESSABLE_ENTITY,
+            response.content,
+        )
+        self.assertFalse(
+            Task.objects.filter(task_type=Task.Type.SOURCE_UNREGISTER).exists()
+        )
+        resource.refresh_from_db()
+        self.assertFalse(resource.is_deleted)
 
     def test_bulk_delete_422_wraps_reasons_in_problem_meta(self):
         agent_key = f"agent:{self.agent.id}"

--- a/src/backend/apps/source/tests/test_connection_probe.py
+++ b/src/backend/apps/source/tests/test_connection_probe.py
@@ -1,0 +1,200 @@
+from datetime import timedelta
+from unittest import mock
+from uuid import uuid4
+
+from django.test import TestCase
+from django.utils import timezone
+
+from apps.iam.models import Organization
+from apps.node.models import Node
+from apps.source.models import SourceResource
+from apps.source.services.interface import (
+    bind_node,
+    test_resource_connection,
+    update_source_resource,
+)
+from apps.source.tasks.connection_probe import (
+    reconcile_stale_source_connection_probes,
+    run_source_resource_capacity_probe,
+)
+
+
+class SourceConnectionProbeTests(TestCase):
+    def setUp(self):
+        self.org = Organization.objects.create(
+            key="source-connection-probe-org",
+            name="Source Connection Probe Org",
+        )
+        self.proxy = Node.objects.create(
+            organization=self.org,
+            name="source-connection-proxy",
+            role=Node.Role.PROXY,
+            status=Node.Status.ONLINE,
+        )
+        self.probe_token = uuid4()
+        self.resource = SourceResource.objects.create(
+            organization=self.org,
+            name="source-connection-nas",
+            resource_type="nas",
+            config={
+                "protocol": "nfs",
+                "server": "192.0.2.20",
+                "export_path": "/source",
+            },
+            bound_node=self.proxy,
+            connection_test_status="pending",
+            connection_probe_token=self.probe_token,
+        )
+
+    @mock.patch("apps.source.tasks.connection_probe.run_connection_test")
+    def test_probe_applies_capacity_for_current_source_revision(self, run_test):
+        run_test.return_value = {
+            "success": True,
+            "message": "Connection test successful",
+            "details": {
+                "mount_point": "/var/lib/hyperfilelens-agent/mounts/custom/source",
+                "space_info": {
+                    "total_bytes": 1000,
+                    "used_bytes": 400,
+                    "free_bytes": 600,
+                },
+            },
+        }
+
+        result = run_source_resource_capacity_probe(
+            resource_id=self.resource.id,
+            probe_token=str(self.probe_token),
+            expected_bound_node_id=self.proxy.id,
+        )
+
+        self.resource.refresh_from_db()
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(self.resource.total_size, 1000)
+        self.assertEqual(self.resource.used_size, 400)
+        self.assertEqual(self.resource.free_size, 600)
+        self.assertIsNotNone(self.resource.last_connection_test)
+
+    @mock.patch("apps.source.tasks.connection_probe.run_connection_test")
+    def test_probe_discards_result_after_source_edit(self, run_test):
+        def edit_source(**_kwargs):
+            update_source_resource(
+                resource=SourceResource.objects.get(pk=self.resource.id),
+                user=None,
+                description="edited while probe was running",
+            )
+            return {
+                "success": True,
+                "message": "Connection test successful",
+                "details": {
+                    "space_info": {
+                        "total_bytes": 1000,
+                        "used_bytes": 400,
+                        "free_bytes": 600,
+                    }
+                },
+            }
+
+        run_test.side_effect = edit_source
+
+        result = run_source_resource_capacity_probe(
+            resource_id=self.resource.id,
+            probe_token=str(self.probe_token),
+            expected_bound_node_id=self.proxy.id,
+        )
+
+        self.resource.refresh_from_db()
+        self.assertEqual(
+            result,
+            {"status": "discarded", "reason": "source_changed"},
+        )
+        self.assertEqual(self.resource.total_size, 0)
+        self.assertIsNone(self.resource.last_connection_test)
+
+    @mock.patch("apps.source.tasks.connection_probe.run_connection_test")
+    def test_probe_discards_result_after_source_delete(self, run_test):
+        def delete_source(**_kwargs):
+            SourceResource.objects.get(pk=self.resource.id).soft_delete()
+            return {"success": True, "message": "Connection test successful"}
+
+        run_test.side_effect = delete_source
+
+        result = run_source_resource_capacity_probe(
+            resource_id=self.resource.id,
+            probe_token=str(self.probe_token),
+            expected_bound_node_id=self.proxy.id,
+        )
+
+        deleted = SourceResource.all_objects.get(pk=self.resource.id)
+        self.assertEqual(
+            result,
+            {"status": "discarded", "reason": "source_deleted"},
+        )
+        self.assertTrue(deleted.is_deleted)
+        self.assertEqual(deleted.total_size, 0)
+
+    @mock.patch("apps.source.tasks.connection_probe.run_connection_test")
+    def test_probe_skips_when_proxy_is_offline(self, run_test):
+        self.proxy.status = Node.Status.OFFLINE
+        self.proxy.save(update_fields=["status", "updated_at"])
+
+        result = run_source_resource_capacity_probe(
+            resource_id=self.resource.id,
+            probe_token=str(self.probe_token),
+            expected_bound_node_id=self.proxy.id,
+        )
+
+        self.assertEqual(result, {"status": "failed", "reason": "proxy_offline"})
+        self.resource.refresh_from_db()
+        self.assertEqual(self.resource.connection_test_status, "failed")
+        run_test.assert_not_called()
+
+    def test_reconcile_fails_stale_probe_and_clears_token(self):
+        SourceResource.objects.filter(pk=self.resource.id).update(
+            updated_at=timezone.now() - timedelta(minutes=20),
+        )
+
+        result = reconcile_stale_source_connection_probes()
+
+        self.resource.refresh_from_db()
+        self.assertEqual(result, {"stale": 1, "failed": 1})
+        self.assertEqual(self.resource.connection_test_status, "failed")
+        self.assertIsNone(self.resource.connection_probe_token)
+        self.assertEqual(self.resource.status, "error")
+
+    @mock.patch("apps.source.services.interface.schedule_remount_after_proxy_change")
+    def test_bind_node_cancels_active_probe_immediately(self, schedule_remount):
+        replacement = Node.objects.create(
+            organization=self.org,
+            name="source-connection-replacement-proxy",
+            role=Node.Role.PROXY,
+            status=Node.Status.ONLINE,
+        )
+
+        result = bind_node(resource=self.resource, node_id=replacement.id)
+
+        self.resource.refresh_from_db()
+        self.assertTrue(result["success"])
+        self.assertEqual(self.resource.bound_node_id, replacement.id)
+        self.assertEqual(self.resource.connection_test_status, "idle")
+        self.assertIsNone(self.resource.connection_probe_token)
+        schedule_remount.assert_called_once()
+
+    @mock.patch("apps.source.services.interface.run_connection_test")
+    def test_manual_probe_discards_result_after_source_edit(self, run_test):
+        def edit_source(**_kwargs):
+            update_source_resource(
+                resource=SourceResource.objects.get(pk=self.resource.id),
+                user=None,
+                description="edited during manual probe",
+            )
+            return {"success": True, "message": "Connection test successful"}
+
+        run_test.side_effect = edit_source
+
+        result = test_resource_connection(resource=self.resource)
+
+        self.resource.refresh_from_db()
+        self.assertTrue(result["stale"])
+        self.assertEqual(self.resource.description, "edited during manual probe")
+        self.assertEqual(self.resource.connection_test_status, "idle")
+        self.assertIsNone(self.resource.last_connection_test)

--- a/src/backend/apps/source/tests/test_direct_nas_cleanup_unregister.py
+++ b/src/backend/apps/source/tests/test_direct_nas_cleanup_unregister.py
@@ -152,6 +152,130 @@ class DirectNasCleanupUnregisterTests(TestCase):
     )
     @mock.patch(
         "apps.storage.services.internal.repository_cleanup._execute_physical_cleanup",
+        return_value={"physical_cleanup": "deleted"},
+    )
+    def test_force_unregister_records_failed_agent_uninstall_as_residue(
+        self,
+        _execute_cleanup,
+        start_node_remove,
+        _agent_status,
+    ):
+        waiting = delete_backup_sources(
+            org=self.org,
+            ids=[f"agent:{self.agent.id}"],
+            force=True,
+        )
+        unregister_task = Task.objects.get(pk=waiting["task_id"])
+        NodeTask.objects.create(
+            organization=self.org,
+            node=self.agent,
+            kind="agent.uninstall",
+            status=NodeTask.Status.TIMEOUT,
+            payload={
+                "source_unregister_task_id": unregister_task.id,
+                "force_cleanup": True,
+            },
+            result={},
+            last_error="Uninstall timed out waiting for its completion callback.",
+            watchdog_deadline_at=timezone.now(),
+            correlation_type="node.lifecycle",
+            correlation_id=f"remove:{self.agent.id}",
+        )
+
+        completed = run_source_unregister_task(
+            organization_id=self.org.id,
+            task_uuid=str(unregister_task.task_uuid),
+        )
+
+        unregister_task.refresh_from_db()
+        self.agent.refresh_from_db()
+        self.assertEqual(completed["result"], "partial_success")
+        self.assertEqual(completed["outcome"], "force_cleanup_success")
+        self.assertFalse(completed["cleanup_complete"])
+        self.assertEqual(
+            completed["cleanup_failures"][0]["code"],
+            "agent_uninstall_failed",
+        )
+        self.assertEqual(completed["retained_resources"], ["agent_installation"])
+        self.assertEqual(unregister_task.status, Task.Status.SUCCESS)
+        self.assertTrue(self.agent.is_deleted)
+        start_node_remove.assert_called_once()
+
+    @mock.patch(
+        "apps.source.services.internal.backup_source_delete.agent_connection_status",
+        return_value="online",
+    )
+    @mock.patch(
+        "apps.node.services.internal.node_lifecycle.start_node_remove",
+        return_value={"task_id": 123, "operation_id": "remove-1", "state": "removing"},
+    )
+    @mock.patch(
+        "apps.storage.services.internal.repository_cleanup._execute_physical_cleanup",
+        return_value={"physical_cleanup": "deleted"},
+    )
+    def test_strict_retry_dispatches_new_uninstall_after_previous_failure(
+        self,
+        _execute_cleanup,
+        start_node_remove,
+        _agent_status,
+    ):
+        first = delete_backup_sources(
+            org=self.org,
+            ids=[f"agent:{self.agent.id}"],
+        )
+        first_unregister = Task.objects.get(pk=first["task_id"])
+        NodeTask.objects.create(
+            organization=self.org,
+            node=self.agent,
+            kind="agent.uninstall",
+            status=NodeTask.Status.FAILED,
+            payload={"source_unregister_task_id": first_unregister.id},
+            result={
+                "cleanup_complete": False,
+                "cleanup_failures": [
+                    {
+                        "code": "agent_uninstall_failed",
+                        "detail": "Agent cleanup failed.",
+                    }
+                ],
+                "retained_resources": ["agent_installation"],
+            },
+            last_error="Agent cleanup failed.",
+            watchdog_deadline_at=timezone.now(),
+            correlation_type="node.lifecycle",
+            correlation_id=f"remove:{self.agent.id}",
+        )
+
+        with self.assertRaises(BackupSourceDeleteFailed):
+            run_source_unregister_task(
+                organization_id=self.org.id,
+                task_uuid=str(first_unregister.task_uuid),
+            )
+
+        first_unregister.refresh_from_db()
+        self.assertEqual(first_unregister.status, Task.Status.FAILED)
+
+        retried = delete_backup_sources(
+            org=self.org,
+            ids=[f"agent:{self.agent.id}"],
+        )
+
+        self.assertEqual(retried["result"], "waiting")
+        self.assertNotEqual(retried["task_id"], first_unregister.id)
+        self.agent.refresh_from_db()
+        self.assertFalse(self.agent.is_deleted)
+        self.assertEqual(start_node_remove.call_count, 2)
+
+    @mock.patch(
+        "apps.source.services.internal.backup_source_delete.agent_connection_status",
+        return_value="online",
+    )
+    @mock.patch(
+        "apps.node.services.internal.node_lifecycle.start_node_remove",
+        return_value={"task_id": 123, "operation_id": "remove-1", "state": "removing"},
+    )
+    @mock.patch(
+        "apps.storage.services.internal.repository_cleanup._execute_physical_cleanup",
         side_effect=[
             RepositoryAgentOperationResult(
                 waiting=True,
@@ -258,6 +382,11 @@ class DirectNasCleanupUnregisterTests(TestCase):
         self.assertEqual(result["pending_removals"], [])
         self.assertEqual(result["deleted"], [f"agent:{self.agent.id}"])
         self.assertFalse(result["cleanup_complete"])
+        self.assertEqual(len(result["cleanup_failures"]), 1)
+        self.assertEqual(
+            result["cleanup_failures"][0]["source_id"],
+            f"agent:{self.agent.id}",
+        )
         self.assertEqual(result["retained_resources"], ["agent_installation"])
         self.assertEqual(unregister_task.status, Task.Status.SUCCESS)
         start_node_remove.assert_called_once()

--- a/src/backend/apps/source/tests/test_periodic_tasks.py
+++ b/src/backend/apps/source/tests/test_periodic_tasks.py
@@ -1,0 +1,25 @@
+from unittest import mock
+
+from django.test import SimpleTestCase
+
+from apps.source.periodic_tasks import register_periodic_tasks
+
+
+class SourcePeriodicTaskTests(SimpleTestCase):
+    @mock.patch("apps.source.periodic_tasks.TASK_REGISTRY.add")
+    def test_registers_probe_and_unregister_reconciliation(self, add):
+        register_periodic_tasks()
+
+        self.assertEqual(add.call_count, 2)
+        add.assert_any_call(
+            name="source_reconcile_stale_connection_probes",
+            task=(
+                "apps.source.tasks.connection_probe."
+                "reconcile_stale_source_connection_probes_task"
+            ),
+            schedule=60,
+            args=(),
+            kwargs={"limit": 100},
+            queue="source.remote-io",
+            enabled=True,
+        )

--- a/src/backend/apps/source/tests/test_remote_transaction_boundaries.py
+++ b/src/backend/apps/source/tests/test_remote_transaction_boundaries.py
@@ -1,0 +1,120 @@
+from unittest import mock
+
+from django.db import connection
+from django.test import TransactionTestCase
+
+from apps.iam.models import Organization
+from apps.node.models import Node
+from apps.source.models import SourceResource
+from apps.source.services.interface import create_source_resource
+from apps.source.services.internal.backup_source_delete import delete_backup_sources
+
+
+class SourceRemoteTransactionBoundaryTests(TransactionTestCase):
+    reset_sequences = True
+
+    def setUp(self):
+        self.org = Organization.objects.create(
+            key="source-remote-transaction-org",
+            name="Source Remote Transaction Org",
+        )
+        self.proxy = Node.objects.create(
+            organization=self.org,
+            name="source-remote-proxy",
+            role=Node.Role.PROXY,
+            status=Node.Status.ONLINE,
+        )
+
+    @mock.patch(
+        "apps.source.tasks.connection_probe.queue_source_resource_capacity_probe"
+    )
+    def test_create_source_probe_queues_after_resource_transaction_commits(
+        self,
+        queue_probe,
+    ):
+        def enqueue(**_kwargs):
+            self.assertFalse(connection.in_atomic_block)
+            return True
+
+        queue_probe.side_effect = enqueue
+
+        resource = create_source_resource(
+            organization=self.org,
+            user=None,
+            name="post-commit-create-nas",
+            resource_type="nas",
+            config={
+                "protocol": "nfs",
+                "server": "192.0.2.10",
+                "export_path": "/source",
+            },
+            bound_node_id=self.proxy.id,
+        )
+
+        self.assertTrue(SourceResource.objects.filter(pk=resource.id).exists())
+        queue_probe.assert_called_once_with(
+            resource_id=resource.id,
+            probe_token=str(resource.connection_probe_token),
+            expected_bound_node_id=self.proxy.id,
+        )
+
+    @mock.patch(
+        "apps.source.tasks.connection_probe.probe_source_resource_capacity.apply_async",
+        side_effect=RuntimeError("broker unavailable"),
+    )
+    def test_create_source_probe_enqueue_failure_keeps_committed_resource(
+        self,
+        apply_async,
+    ):
+        resource = create_source_resource(
+            organization=self.org,
+            user=None,
+            name="post-commit-probe-failure-nas",
+            resource_type="nas",
+            config={
+                "protocol": "nfs",
+                "server": "192.0.2.12",
+                "export_path": "/source",
+            },
+            bound_node_id=self.proxy.id,
+        )
+
+        self.assertTrue(SourceResource.objects.filter(pk=resource.id).exists())
+        apply_async.assert_called_once()
+        resource.refresh_from_db()
+        self.assertEqual(resource.connection_test_status, "failed")
+        self.assertIsNone(resource.connection_probe_token)
+
+    @mock.patch(
+        "apps.source.services.internal.backup_source_delete.unmount_resource"
+    )
+    def test_unregister_unmount_runs_outside_database_cleanup_transaction(self, unmount):
+        resource = SourceResource.objects.create(
+            organization=self.org,
+            name="outside-transaction-unmount-nas",
+            resource_type="nas",
+            config={
+                "protocol": "nfs",
+                "server": "192.0.2.11",
+                "export_path": "/source",
+            },
+            bound_node=self.proxy,
+            mount_status="mounted",
+        )
+        resource_id = resource.id
+
+        def perform_unmount(*, resource):
+            self.assertFalse(connection.in_atomic_block)
+            self.assertEqual(resource.id, resource_id)
+            return {"success": True, "message": "Unmounted"}
+
+        unmount.side_effect = perform_unmount
+
+        result = delete_backup_sources(
+            org=self.org,
+            ids=[f"nas:{resource.id}"],
+        )
+
+        self.assertEqual(result["result"], "success")
+        self.assertTrue(SourceResource.all_objects.get(pk=resource.id).is_deleted)
+        unmount.assert_called_once()

--- a/src/backend/project/settings/celery.py
+++ b/src/backend/project/settings/celery.py
@@ -20,12 +20,14 @@ CELERY_TASK_QUEUES = (
     Queue(CELERY_TASK_DEFAULT_QUEUE),
     Queue("node.lifecycle"),
     Queue("node.ingest"),
+    Queue("source.remote-io"),
     Queue("storage.provider-validation"),
 )
 
 CELERY_TASK_ROUTES = {
     "apps.node.tasks.lifecycle.*": {"queue": "node.lifecycle"},
     "apps.node.tasks.uplink_ingest.*": {"queue": "node.ingest"},
+    "apps.source.tasks.connection_probe.*": {"queue": "source.remote-io"},
     "apps.storage.tasks.*storage_provider*": {
         "queue": "storage.provider-validation"
     },

--- a/src/frontend/src/composables/useNodeLifecycleOps.test.ts
+++ b/src/frontend/src/composables/useNodeLifecycleOps.test.ts
@@ -1,0 +1,169 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { defineComponent, h } from 'vue'
+import { mount } from '@vue/test-utils'
+import { previewNodeOperationsBatch, startNodeOperationsBatch } from '../lib/nodeApi'
+import type { ApiNode } from '../types/node'
+import { useNodeLifecycleOps } from './useNodeLifecycleOps'
+
+vi.mock('../lib/nodeApi', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../lib/nodeApi')>()
+  return {
+    ...actual,
+    previewNodeOperationsBatch: vi.fn(),
+    startNodeOperationsBatch: vi.fn(),
+  }
+})
+
+describe('useNodeLifecycleOps batch start', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    window.sessionStorage.clear()
+  })
+
+  it('does not report success when HTTP 202 contains per-node errors', async () => {
+    const node = {
+      id: 21,
+      name: 'offline-proxy',
+      role: 'proxy',
+      status: 'offline',
+    } as ApiNode
+    vi.mocked(previewNodeOperationsBatch).mockResolvedValue({
+      kind: 'remove',
+      requested: 1,
+      eligible: [{ node_id: node.id, name: node.name }],
+      skipped_offline: [],
+      skipped_workload: [],
+      skipped_in_progress: [],
+      skipped_not_upgradeable: [],
+      skipped_proxy_bound: [],
+      missing_node_ids: [],
+      max_concurrent: 5,
+    })
+    vi.mocked(startNodeOperationsBatch).mockResolvedValue({
+      kind: 'remove',
+      requested: 1,
+      eligible: [{ node_id: node.id, name: node.name }],
+      skipped_offline: [],
+      skipped_workload: [],
+      skipped_in_progress: [],
+      skipped_not_upgradeable: [],
+      skipped_proxy_bound: [],
+      missing_node_ids: [],
+      max_concurrent: 5,
+      started: [],
+      queued: [],
+      errors: [{
+        node_id: node.id,
+        code: 'node_offline',
+        error: 'Node is offline. Strict Cleanup requires the Agent to be reachable.',
+      }],
+    })
+    let lifecycle!: ReturnType<typeof useNodeLifecycleOps>
+    const wrapper = mount(defineComponent({
+      setup() {
+        lifecycle = useNodeLifecycleOps({
+          role: 'proxy',
+          t: ((key: string) => key) as never,
+        })
+        return () => h('div')
+      },
+    }))
+
+    try {
+      const started = await lifecycle.runBatch('remove', [node], { skipConfirm: true })
+
+      expect(started).toBe(false)
+      expect(lifecycle.lastStartErrors.value).toEqual([
+        expect.objectContaining({ code: 'node_offline', node_id: node.id }),
+      ])
+    } finally {
+      wrapper.unmount()
+    }
+  })
+
+  it('keeps preview-blocked nodes as batch errors when eligible nodes start', async () => {
+    const startedNode = {
+      id: 31,
+      name: 'ready-proxy',
+      role: 'proxy',
+      status: 'online',
+    } as ApiNode
+    const blockedNode = {
+      id: 32,
+      name: 'busy-proxy',
+      role: 'proxy',
+      status: 'online',
+    } as ApiNode
+    vi.mocked(previewNodeOperationsBatch).mockResolvedValue({
+      kind: 'remove',
+      requested: 2,
+      eligible: [{ node_id: startedNode.id, name: startedNode.name }],
+      skipped_offline: [],
+      skipped_workload: [{
+        node_id: blockedNode.id,
+        name: blockedNode.name,
+        reason: 'node_workload_active',
+      }],
+      skipped_in_progress: [],
+      skipped_not_upgradeable: [],
+      skipped_proxy_bound: [],
+      missing_node_ids: [],
+      max_concurrent: 5,
+    })
+    vi.mocked(startNodeOperationsBatch).mockResolvedValue({
+      kind: 'remove',
+      requested: 1,
+      eligible: [{ node_id: startedNode.id, name: startedNode.name }],
+      skipped_offline: [],
+      skipped_workload: [],
+      skipped_in_progress: [],
+      skipped_not_upgradeable: [],
+      skipped_proxy_bound: [],
+      missing_node_ids: [],
+      max_concurrent: 5,
+      started: [{
+        operation_id: 'offline-remove:31',
+        task_id: null,
+        node_id: startedNode.id,
+        kind: 'remove',
+        state: 'completed',
+        purged: true,
+      }],
+      queued: [],
+      errors: [],
+    })
+    let lifecycle!: ReturnType<typeof useNodeLifecycleOps>
+    const wrapper = mount(defineComponent({
+      setup() {
+        lifecycle = useNodeLifecycleOps({
+          role: 'proxy',
+          t: ((key: string) => key) as never,
+        })
+        return () => h('div')
+      },
+    }))
+
+    try {
+      const succeeded = await lifecycle.runBatch(
+        'remove',
+        [startedNode, blockedNode],
+        { skipConfirm: true, force: true },
+      )
+
+      expect(succeeded).toBe(false)
+      expect(lifecycle.lastStartErrors.value).toEqual([
+        expect.objectContaining({
+          code: 'node_workload_active',
+          node_id: blockedNode.id,
+        }),
+      ])
+      expect(lifecycle.completed.value).toEqual([
+        expect.objectContaining({ nodeId: startedNode.id }),
+      ])
+    } finally {
+      wrapper.unmount()
+    }
+  })
+})

--- a/src/frontend/src/composables/useNodeLifecycleOps.ts
+++ b/src/frontend/src/composables/useNodeLifecycleOps.ts
@@ -141,6 +141,7 @@ export function useNodeLifecycleOps(options: {
   const completed = ref<LifecycleQueueItem[]>([])
   const failed = ref<LifecycleQueueItem[]>([])
   const skipped = ref<Array<{ nodeId: number; name: string; reason: string }>>([])
+  const lastStartErrors = ref<Array<Record<string, unknown>>>([])
   const polling = ref(false)
   const pollRole = ref<NodeRole | null>(null)
   const upgradeConfirmOpen = ref(false)
@@ -456,6 +457,32 @@ export function useNodeLifecycleOps(options: {
     return t('nodeLifecycle.nothingEligible')
   }
 
+  function previewStartErrors(preview: NodeOperationBatchPreview): Array<Record<string, unknown>> {
+    const fromRows = (
+      rows: Array<{ node_id: number; name: string; reason: string; message?: string }>,
+      fallbackCode: string,
+    ) => rows.map((item) => ({
+      node_id: item.node_id,
+      name: item.name,
+      code: item.reason || fallbackCode,
+      error: item.message || item.reason || fallbackCode,
+    }))
+
+    return [
+      ...fromRows(preview.skipped_offline || [], 'node_offline'),
+      ...fromRows(preview.skipped_workload || [], 'node_workload_active'),
+      ...fromRows(preview.skipped_in_progress || [], 'lifecycle_in_progress'),
+      ...fromRows(preview.skipped_not_upgradeable || [], 'not_upgradeable'),
+      ...fromRows(preview.skipped_proxy_bound || [], 'proxy_has_bindings'),
+      ...fromRows(preview.skipped_disk_full || [], 'disk_full'),
+      ...(preview.missing_node_ids || []).map((nodeId) => ({
+        node_id: nodeId,
+        code: 'node_not_found',
+        error: 'Node was not found.',
+      })),
+    ]
+  }
+
   function runBatch(
     kind: 'remove',
     nodes: ApiNode[],
@@ -472,6 +499,7 @@ export function useNodeLifecycleOps(options: {
     runOptions?: { skipConfirm?: boolean; force?: boolean },
   ): Promise<boolean> {
     if (nodes.length === 0) return false
+    lastStartErrors.value = []
     const nodeIds = nodes.map((n) => n.id)
     try {
       const preview = await previewNodeOperationsBatch({
@@ -480,6 +508,8 @@ export function useNodeLifecycleOps(options: {
         maxConcurrent: maxConcurrent.value,
         scope: resolveScope(),
       })
+      const previewErrors = previewStartErrors(preview)
+      lastStartErrors.value = previewErrors
       if (preview.eligible.length === 0) {
         ElMessage.warning({ message: explainIneligiblePreview(preview), grouping: true })
         return false
@@ -525,6 +555,7 @@ export function useNodeLifecycleOps(options: {
         force: Boolean(runOptions?.force),
         scope: resolveScope(),
       })
+      lastStartErrors.value = [...previewErrors, ...(batchResult.errors || [])]
 
       for (const started of batchResult.started || []) {
         const node = nodes.find((n) => n.id === started.node_id)
@@ -553,6 +584,12 @@ export function useNodeLifecycleOps(options: {
         })
       }
 
+      if (lastStartErrors.value.length) {
+        const first = lastStartErrors.value[0] || {}
+        const message = String(first.error || first.code || 'Node operation could not be started.')
+        ElMessage.error({ message, grouping: true })
+      }
+
       persistQueue()
       if (hasActiveOps.value) {
         startPolling()
@@ -560,7 +597,7 @@ export function useNodeLifecycleOps(options: {
         finishBatch()
         await options.onRefresh?.()
       }
-      return true
+      return lastStartErrors.value.length === 0
     } catch (e) {
       if (e instanceof NodeLifecycleApiError) {
         ElMessage.error({ message: e.message, grouping: true })
@@ -811,6 +848,7 @@ export function useNodeLifecycleOps(options: {
     completed,
     failed,
     skipped,
+    lastStartErrors,
     polling,
     hasActiveOps,
     activeBatchNodeIds,

--- a/src/frontend/src/lib/sourceApi.ts
+++ b/src/frontend/src/lib/sourceApi.ts
@@ -69,6 +69,7 @@ export type SourceResource = {
   status?: string
   status_display?: string
   status_message?: string
+  connection_test_status?: 'idle' | 'pending' | 'running' | 'success' | 'failed'
   connection_summary?: string
   total_size?: number
   used_size?: number

--- a/src/frontend/src/locales/en.ts
+++ b/src/frontend/src/locales/en.ts
@@ -841,6 +841,11 @@ export const en = {
         'Remove {n} data gateway(s)? {offline} gateway(s) are offline, so only their console records can be removed; Agent and LensNode files may remain on those hosts.',
       deleteInstallerManagedConfirm:
         'Remove {n} data gateway(s)? Installer-managed platform gateways are recreated by the next deployment while auto-deploy remains enabled. Offline hosts may retain Agent and LensNode files.',
+      deleteForceTitle: 'Force Cleanup Data Gateway',
+      deleteForceConfirm:
+        'Force Cleanup {n} data gateway(s)? Agent and LensNode cleanup will still be attempted. Failures are recorded as retained resources while control-plane removal continues.',
+      deleteForceHint:
+        'Force Cleanup cannot bypass active tasks or Knowledge Source bindings. It only changes how physical cleanup failures are handled.',
       origin: {
         user: 'User',
         platform: 'Platform',

--- a/src/frontend/src/pages/insight/InsightDataGateways.vue
+++ b/src/frontend/src/pages/insight/InsightDataGateways.vue
@@ -11,7 +11,7 @@ import {
   Search,
   Trash2,
 } from 'lucide-vue-next'
-import { ElMessage, type ElTable } from 'element-plus'
+import { ElCheckbox, ElMessage, type ElTable } from 'element-plus'
 import NodeVersionCell from '../../components/node-lifecycle/NodeVersionCell.vue'
 import NodeLifecycleBanner from '../../components/node-lifecycle/NodeLifecycleBanner.vue'
 import NodeLifecycleUpgradeConfirmDialog from '../../components/NodeLifecycleUpgradeConfirmDialog.vue'
@@ -80,6 +80,7 @@ const latestAgentVersion = ref<string | null>(null)
 const selectedRows = ref<InsightGatewayRow[]>([])
 const deleteOpen = ref(false)
 const deleteLoading = ref(false)
+const deleteForce = ref(false)
 const pendingDelete = ref<InsightGatewayRow[]>([])
 const moreActionsOpen = ref(false)
 const detailOpen = ref(false)
@@ -434,7 +435,31 @@ async function deleteSelected() {
   if (batchDisabled.value) return
   await afterOverlayDismiss()
   pendingDelete.value = [...selectedRows.value]
+  deleteForce.value = false
   deleteOpen.value = true
+}
+
+function gatewayDeleteDialogItem(row: InsightGatewayRow) {
+  return {
+    key: row.id,
+    name: row.name,
+    status: {
+      label: readinessLabel(row),
+      tone: row.hfl_agent_online && row.hfl_sidecar_online ? 'success' as const : 'danger' as const,
+    },
+  }
+}
+
+function gatewayDeleteCanRetryWithForce() {
+  return lifecycleOps.lastStartErrors.value.some((item) =>
+    ['node_offline', 'agent_uninstall_failed', 'completion_callback_timeout']
+      .includes(String(item.code || '')),
+  )
+}
+
+function cancelDelete() {
+  pendingDelete.value = []
+  deleteForce.value = false
 }
 
 async function confirmDelete() {
@@ -442,11 +467,23 @@ async function confirmDelete() {
   if (!targets.length) return
   deleteLoading.value = true
   try {
-    const started = await lifecycleOps.runBatch('remove', targets, { skipConfirm: true })
+    const started = await lifecycleOps.runBatch('remove', targets, {
+      skipConfirm: true,
+      force: deleteForce.value,
+    })
     if (started) {
       clearSelection()
       deleteOpen.value = false
       pendingDelete.value = []
+      deleteForce.value = false
+    } else if (lifecycleOps.lastStartErrors.value.length) {
+      const failedIds = new Set(
+        lifecycleOps.lastStartErrors.value.map((item) => Number(item.node_id || 0)),
+      )
+      pendingDelete.value = targets.filter((node) => failedIds.has(node.id))
+      if (!deleteForce.value && gatewayDeleteCanRetryWithForce()) {
+        deleteForce.value = true
+      }
     }
   } finally {
     deleteLoading.value = false
@@ -611,7 +648,13 @@ onUnmounted(() => {
           @scroll="handleTableScroll"
           @selection-change="onSelectionChange"
         >
-          <el-table-column type="selection" width="35" fixed="left" :selectable="canManageGateway" />
+          <el-table-column
+            type="selection"
+            width="35"
+            fixed="left"
+            :selectable="canManageGateway"
+            :reserve-selection="true"
+          />
           <el-table-column
             :label="t('protection.sourceResources.colName')"
             min-width="200"
@@ -801,17 +844,24 @@ onUnmounted(() => {
     />
     <DangerConfirmDialog
       v-model="deleteOpen"
-      :title="t('nodesPage.deleteTitle')"
-      :message="deleteConfirmationMessage"
-      :items="pendingDelete.map((row) => ({ key: row.id, name: row.name }))"
+      :title="deleteForce ? t('insight.dataGateway.deleteForceTitle') : t('nodesPage.deleteTitle')"
+      :message="deleteForce ? t('insight.dataGateway.deleteForceConfirm', { n: pendingDelete.length }) : deleteConfirmationMessage"
+      :items="pendingDelete.map(gatewayDeleteDialogItem)"
       confirm-mode="keyword"
-      :confirm-keyword="t('common.deleteKeyword')"
+      :confirm-keyword="deleteForce ? 'FORCE CLEANUP' : t('common.deleteKeyword')"
       :cancel-text="t('common.cancel')"
-      :confirm-text="t('nodesPage.actionDelete')"
+      :confirm-text="deleteForce ? t('nodesPage.proxyDeleteForceAction') : t('nodesPage.actionDelete')"
       :loading="deleteLoading"
       @confirm="confirmDelete"
-      @cancel="pendingDelete = []"
-    />
+      @cancel="cancelDelete"
+    >
+      <div class="gateway-delete-force-option">
+        <ElCheckbox v-model="deleteForce">
+          {{ t('nodesPage.proxyDeleteForceAction') }}
+        </ElCheckbox>
+        <p>{{ t('insight.dataGateway.deleteForceHint') }}</p>
+      </div>
+    </DangerConfirmDialog>
   </div>
 </template>
 
@@ -823,6 +873,20 @@ onUnmounted(() => {
   color: var(--color-primary, #2563eb);
   cursor: pointer;
   font-size: 13px;
+}
+
+.gateway-delete-force-option {
+  margin-top: 16px;
+  padding: 12px 14px;
+  border: 1px solid var(--el-border-color-light);
+  border-radius: 8px;
+  background: var(--el-fill-color-lighter);
+}
+
+.gateway-delete-force-option p {
+  margin: 4px 0 0 24px;
+  color: var(--el-text-color-secondary);
+  font-size: 12px;
 }
 
 .dg-muted {

--- a/src/frontend/src/pages/node/Nodes.vue
+++ b/src/frontend/src/pages/node/Nodes.vue
@@ -3,7 +3,7 @@ import { computed, onMounted, reactive, ref, watch } from 'vue'
 import { RouterLink, useRoute, useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { ArrowUpCircle, Plus, RefreshCw, Pencil, ChevronDown, Trash2, TriangleAlert, Search } from 'lucide-vue-next'
-import { ElMessage, type ElTable } from 'element-plus'
+import { ElCheckbox, ElMessage, type ElTable } from 'element-plus'
 import NodeLifecycleStatusCell from '../../components/node-lifecycle/NodeLifecycleStatusCell.vue'
 import NodeVersionCell from '../../components/node-lifecycle/NodeVersionCell.vue'
 import NodeLifecycleBanner from '../../components/node-lifecycle/NodeLifecycleBanner.vue'
@@ -446,6 +446,24 @@ const deleteLoading = ref(false)
 const pendingDeleteNodes = ref<ApiNode[]>([])
 const pendingDeleteForce = ref(false)
 
+function nodeDeleteDialogItem(row: ApiNode) {
+  return {
+    key: row.id,
+    name: row.name,
+    status: {
+      label: statusLabel(row.status, row),
+      tone: statusTagType(debouncedNodeStatus(row)),
+    },
+  }
+}
+
+function nodeDeleteCanRetryWithForce() {
+  return lifecycleOps.lastStartErrors.value.some((item) =>
+    ['node_offline', 'agent_uninstall_failed', 'completion_callback_timeout']
+      .includes(String(item.code || '')),
+  )
+}
+
 async function deleteSelectedNodes() {
   if (batchDisabled.value) return
   await afterOverlayDismiss()
@@ -492,6 +510,14 @@ async function executeNodeDelete() {
       deleteOpen.value = false
       pendingDeleteNodes.value = []
       pendingDeleteForce.value = false
+    } else if (lifecycleOps.lastStartErrors.value.length) {
+      const failedIds = new Set(
+        lifecycleOps.lastStartErrors.value.map((item) => Number(item.node_id || 0)),
+      )
+      pendingDeleteNodes.value = targets.filter((node) => failedIds.has(node.id))
+      if (!pendingDeleteForce.value && nodeDeleteCanRetryWithForce()) {
+        pendingDeleteForce.value = true
+      }
     }
   } finally {
     deleteLoading.value = false
@@ -632,7 +658,12 @@ async function submitRename() {
           @scroll="onTableScroll"
           @selection-change="onSelectionChange"
         >
-          <el-table-column type="selection" width="35" :fixed="isProxyNodesPage ? 'left' : undefined" />
+          <el-table-column
+            type="selection"
+            width="35"
+            :fixed="isProxyNodesPage ? 'left' : undefined"
+            :reserve-selection="true"
+          />
           <el-table-column
             :label="isProxyNodesPage ? t('protection.sourceResources.colName') : t('nodesPage.colName')"
             :min-width="isProxyNodesPage ? 200 : 116"
@@ -867,21 +898,42 @@ async function submitRename() {
           : isProxyNodesPage
             ? t('nodesPage.proxyDeleteSelectedConfirm', { n: pendingDeleteNodes.length })
             : t('nodesPage.deleteSelectedConfirm', { n: pendingDeleteNodes.length }))"
-      :items="pendingDeleteNodes.map((row) => ({ key: row.id, name: row.name }))"
+      :items="pendingDeleteNodes.map(nodeDeleteDialogItem)"
       confirm-mode="keyword"
-      :confirm-keyword="t('common.deleteKeyword')"
+      :confirm-keyword="pendingDeleteForce ? 'FORCE CLEANUP' : t('common.deleteKeyword')"
       :cancel-text="t('common.cancel')"
       :confirm-text="pendingDeleteForce ? t('nodesPage.proxyDeleteForceAction') : t('common.delete')"
       :loading="deleteLoading"
       @confirm="executeNodeDelete"
       @cancel="cancelNodeDelete"
-    />
+    >
+      <div v-if="isProxyNodesPage" class="node-delete-force-option">
+        <ElCheckbox v-model="pendingDeleteForce">
+          {{ t('nodesPage.proxyDeleteForceAction') }}
+        </ElCheckbox>
+        <p>{{ t('nodesPage.proxyDeleteForceNote') }}</p>
+      </div>
+    </DangerConfirmDialog>
   </ModulePage>
 </template>
 
 <style scoped>
 .nodes-role-tag {
   font-weight: 600;
+}
+
+.node-delete-force-option {
+  margin-top: 16px;
+  padding: 12px 14px;
+  border: 1px solid var(--el-border-color-light);
+  border-radius: 8px;
+  background: var(--el-fill-color-lighter);
+}
+
+.node-delete-force-option p {
+  margin: 4px 0 0 24px;
+  color: var(--el-text-color-secondary);
+  font-size: 12px;
 }
 
 </style>

--- a/src/frontend/src/pages/protection/BackupSources.vue
+++ b/src/frontend/src/pages/protection/BackupSources.vue
@@ -39,6 +39,7 @@ import { formatAppDateTime } from '../../lib/dateTime'
 import { copyTextToClipboard } from '../../lib/clipboard'
 import { openErrorDetails } from '../../lib/errors/details'
 import { notifyInfo, notifySuccess } from '../../lib/notify'
+import { getTask } from '../../lib/taskApi'
 import { LIST_ROUTE_REFRESH_KEY, stripListRefreshQuery } from '../../lib/listRouteRefresh'
 import { buildGeneratedNasMountDir, buildGeneratedNasName } from '../../lib/nasMountPath'
 import { hasNasSourceNameConflict, resolveNasSubmitName } from '../../lib/nasSourceNaming'
@@ -486,22 +487,31 @@ function nasShouldRefreshCapacity(row: SourceResource) {
   if (sourceNodeOnlineStatus(row) !== 'online') return false
   if (!row.bound_node && !row.bound_node_name?.trim()) return false
   if (row.id === nasTestingId.value) return false
-  return !row.last_connection_test
+  return row.connection_test_status === 'pending' || row.connection_test_status === 'running'
+}
+
+const NAS_CAPACITY_POLL_MS = 2000
+const NAS_CAPACITY_POLL_TIMEOUT_MS = 3 * 60 * 1000
+
+function waitForNasCapacityPoll(signal?: AbortSignal) {
+  return new Promise<void>((resolve) => {
+    const finish = () => {
+      window.clearTimeout(timer)
+      signal?.removeEventListener('abort', finish)
+      resolve()
+    }
+    const timer = window.setTimeout(finish, NAS_CAPACITY_POLL_MS)
+    signal?.addEventListener('abort', finish, { once: true })
+  })
 }
 
 async function syncNasCapacities(list: SourceResource[], signal?: AbortSignal) {
   const targets = list.filter(nasShouldRefreshCapacity)
   if (!targets.length || signal?.aborted) return
-  nasCapacitySyncing.value = true
-  try {
-    for (const row of targets) {
-      if (signal?.aborted) return
-      try {
-        await testSourceConnection(row.id, { signal })
-      } catch {
-        /* best-effort per NAS row */
-      }
-    }
+  const targetIds = new Set(targets.map((row) => row.id))
+  const deadline = Date.now() + NAS_CAPACITY_POLL_TIMEOUT_MS
+  while (!signal?.aborted && Date.now() < deadline) {
+    await waitForNasCapacityPoll(signal)
     if (signal?.aborted) return
     const params: Record<string, string | number> = {
       page: pagination.page,
@@ -514,8 +524,13 @@ async function syncNasCapacities(list: SourceResource[], signal?: AbortSignal) {
     const refreshed = await listSourceResources(params, { signal })
     rows.value = refreshed.results
     pagination.count = refreshed.count
-  } finally {
-    if (!signal?.aborted) nasCapacitySyncing.value = false
+    const pending = refreshed.results.some(
+      (row) => targetIds.has(row.id) && nasShouldRefreshCapacity(row),
+    )
+    if (!pending) {
+      stats.value = await sourceStatistics({ signal })
+      return
+    }
   }
 }
 
@@ -552,9 +567,11 @@ async function load() {
       busy.value = false
       if (loadingTab === 'nas' && activeTab.value === 'nas') {
         const capacitySignal = pageRequests.nextSignal('nas-capacity')
-        void syncNasCapacities(rows.value.filter((row) => row.resource_type === 'nas'), capacitySignal).finally(() => {
-          pageRequests.releaseSignal('nas-capacity', capacitySignal)
-        })
+        void syncNasCapacities(rows.value.filter((row) => row.resource_type === 'nas'), capacitySignal)
+          .catch(() => undefined)
+          .finally(() => {
+            pageRequests.releaseSignal('nas-capacity', capacitySignal)
+          })
       }
     }
   }
@@ -889,9 +906,70 @@ const backupSourceDeleteRetryAfterFailure = computed(() =>
   backupSourceDeleteIds.value.some((id) => pendingSourceOps.value.get(id)?.kind === 'delete_failed'),
 )
 const pendingSourceOps = ref(new Map<string, SourcePendingOp>())
+const SOURCE_DELETE_TASK_POLL_MS = 2000
+const SOURCE_DELETE_TASK_TIMEOUT_MS = 15 * 60 * 1000
+let sourceDeleteTaskPollTimer: number | null = null
+let sourceDeleteTaskPollInFlight = false
 
 function refreshPendingSourceOps() {
   pendingSourceOps.value = readWizardPendingSourceOps()
+}
+
+function stopPendingSourceDeletePoll() {
+  if (sourceDeleteTaskPollTimer != null) {
+    window.clearTimeout(sourceDeleteTaskPollTimer)
+    sourceDeleteTaskPollTimer = null
+  }
+}
+
+function schedulePendingSourceDeletePoll(delay = SOURCE_DELETE_TASK_POLL_MS) {
+  stopPendingSourceDeletePoll()
+  const hasPendingTask = [...pendingSourceOps.value.values()].some(
+    (op) => op.kind === 'deleting' && Boolean(op.taskUuid),
+  )
+  if (!hasPendingTask) return
+  sourceDeleteTaskPollTimer = window.setTimeout(() => {
+    sourceDeleteTaskPollTimer = null
+    void reconcilePendingSourceDeleteTasks()
+  }, delay)
+}
+
+async function reconcilePendingSourceDeleteTasks() {
+  if (sourceDeleteTaskPollInFlight) return
+  refreshPendingSourceOps()
+  const pending = [...pendingSourceOps.value.entries()].flatMap(([sourceId, op]) =>
+    op.kind === 'deleting' && op.taskUuid ? [{ sourceId, op }] : [],
+  )
+  if (!pending.length) return
+  sourceDeleteTaskPollInFlight = true
+  let changed = false
+  try {
+    const tasks = await Promise.allSettled(pending.map(({ op }) => getTask(op.taskUuid!)))
+    const now = Date.now()
+    tasks.forEach((settled, index) => {
+      const { sourceId, op } = pending[index]
+      if (settled.status === 'rejected') {
+        if (op.startedAt && now - op.startedAt >= SOURCE_DELETE_TASK_TIMEOUT_MS) {
+          markWizardPendingBySourceIds([sourceId], { ...op, kind: 'delete_failed' })
+          changed = true
+        }
+        return
+      }
+      const status = String(settled.value.status || '').toLowerCase()
+      if (status === 'success') {
+        clearWizardPendingBySourceIds([sourceId])
+        changed = true
+      } else if (['failed', 'cancelled', 'timeout'].includes(status)) {
+        markWizardPendingBySourceIds([sourceId], { ...op, kind: 'delete_failed' })
+        changed = true
+      }
+    })
+    refreshPendingSourceOps()
+    if (changed) await load()
+  } finally {
+    sourceDeleteTaskPollInFlight = false
+    schedulePendingSourceDeletePoll()
+  }
 }
 
 type SourcePendingDisplayStatus = {
@@ -1023,13 +1101,28 @@ async function onBackupSourcesDeleted(payload: {
   result: string
   warnings: Array<Record<string, unknown>>
   pending_removals?: Array<{ source_id: string; node_id: number; task_id?: string | null; state?: string }>
+  task_id?: number
+  task_uuid?: string
+  task_ids?: number[]
+  task_uuids?: string[]
   accepted?: boolean
 }) {
   const deletingIds = new Set(backupSourceDeleteIds.value)
   backupSourceDeleteRows.value = []
   if (payload.accepted && payload.result === 'pending') {
-    markWizardPendingBySourceIds([...deletingIds], { kind: 'deleting' })
+    const sourceIds = [...deletingIds]
+    const taskIds = payload.task_ids?.length ? payload.task_ids : [payload.task_id]
+    const taskUuids = payload.task_uuids?.length ? payload.task_uuids : [payload.task_uuid]
+    sourceIds.forEach((sourceId, index) => {
+      markWizardPendingBySourceIds([sourceId], {
+        kind: 'deleting',
+        taskId: taskIds[index],
+        taskUuid: taskUuids[index],
+        startedAt: Date.now(),
+      })
+    })
     refreshPendingSourceOps()
+    schedulePendingSourceDeletePoll(0)
     backupSourceDeleteIds.value = []
     await load()
     ElMessage.info({ message: t('protection.backupsPage.msgDeleteSourcePending'), grouping: true })
@@ -1310,7 +1403,6 @@ watch(agentDeployOpen, (open) => {
 const nasAddOpen = ref(false)
 const nasAddShellRef = ref<HTMLElement | null>(null)
 const nasAddFormRef = ref<InstanceType<typeof NasAddForm> | null>(null)
-const nasCapacitySyncing = ref(false)
 type NasProtocol = 'smb' | 'nfs'
 const nasProtocol = ref<NasProtocol>('smb')
 const nasBindNodeId = ref<number | undefined>(undefined)
@@ -1646,10 +1738,12 @@ onMounted(async () => {
   await load()
   lifecycleOps.restorePersisted()
   refreshPendingSourceOps()
+  schedulePendingSourceDeletePoll(0)
   tryOpenHostFromQuery()
 })
 
 onUnmounted(() => {
+  stopPendingSourceDeletePoll()
   if (typeof window !== 'undefined') {
     window.removeEventListener('focus', handleProxyDeployReturnFocus)
   }
@@ -2008,7 +2102,7 @@ onUnmounted(() => {
                     variant="compact"
                     :format-bytes="formatBytes"
                   />
-                  <span v-else-if="sourceNodeOnlineStatus(row) === 'online' && nasCapacitySyncing" class="source-capacity-pending">
+                  <span v-else-if="nasShouldRefreshCapacity(row)" class="source-capacity-pending">
                     {{ t('protection.sourceResources.capacitySyncing') }}
                   </span>
                   <span v-else>—</span>

--- a/src/frontend/src/pages/protection/DataProtection.vue
+++ b/src/frontend/src/pages/protection/DataProtection.vue
@@ -2402,6 +2402,7 @@ onMounted(async () => {
   } finally {
     flowBootstrapping.value = false
   }
+  resumePendingUnregisterMonitors()
   nextTick(() => {
     updateFlowTableMaxHeight()
     const toolbar = flowToolbarRef.value
@@ -4520,12 +4521,16 @@ function stopUnregisterTaskPolls() {
   unregisterTaskPollTimers.clear()
 }
 
-function monitorPendingUnregister(sourceIds: string[], taskUuids: string[]) {
+function monitorPendingUnregister(
+  sourceIds: string[],
+  taskUuids: string[],
+  monitorStartedAt = Date.now(),
+) {
   const pairs = taskUuids
     .map((taskUuid, index) => ({ taskUuid, sourceId: sourceIds[index] || '' }))
     .filter((item) => item.taskUuid && item.sourceId)
   if (!pairs.length) return
-  const startedAt = Date.now()
+  const startedAt = monitorStartedAt
 
   const poll = async () => {
     if (unregisterTaskPollingStopped) return
@@ -4576,6 +4581,12 @@ function monitorPendingUnregister(sourceIds: string[], taskUuids: string[]) {
   }
 
   void poll()
+}
+
+function resumePendingUnregisterMonitors() {
+  for (const { sourceId, taskUuid, startedAt } of sourcePendingOps.pendingDeleteTasks()) {
+    monitorPendingUnregister([sourceId], [taskUuid], startedAt || Date.now())
+  }
 }
 
 function affectedBackupIdsForSources(sourceIds: string[]): Set<string> {
@@ -4775,6 +4786,10 @@ async function onBackupSourcesDeleted(payload: {
   result: string
   warnings: Array<Record<string, unknown>>
   pending_removals?: Array<{ source_id: string; node_id: number }>
+  task_id?: number
+  task_uuid?: string
+  task_ids?: number[]
+  task_uuids?: string[]
   accepted?: boolean
 }) {
   const idSet = new Set(backupSourceDeleteIds.value)
@@ -4796,9 +4811,27 @@ async function onBackupSourcesDeleted(payload: {
         ])
         if (flowMainStep.value === 0) void loadBackupSelectable()
       }
-      const taskUuids = (payload.task_uuids?.length ? payload.task_uuids : [payload.task_uuid || ''])
-        .filter((taskUuid): taskUuid is string => Boolean(taskUuid))
-      monitorPendingUnregister(Array.from(idSet), taskUuids)
+      const taskUuids = payload.task_uuids?.length ? payload.task_uuids : [payload.task_uuid || '']
+      const monitoredSourceIds: string[] = []
+      const monitoredTaskUuids: string[] = []
+      Array.from(idSet).forEach((sourceId, index) => {
+        const taskUuid = taskUuids[index] || ''
+        sourcePendingOps.mark(
+          [sourceId],
+          {
+            kind: taskUuid ? 'deleting' : 'delete_failed',
+            taskId: payload.task_ids?.[index] ?? payload.task_id,
+            taskUuid,
+            startedAt: Date.now(),
+          },
+          flowRowsForSourceIds([sourceId]),
+        )
+        if (taskUuid) {
+          monitoredSourceIds.push(sourceId)
+          monitoredTaskUuids.push(taskUuid)
+        }
+      })
+      monitorPendingUnregister(monitoredSourceIds, monitoredTaskUuids)
       ElMessage.info({ message: t('protection.backupsPage.msgDeleteSourcePending'), grouping: true })
     } catch (err) {
       sourcePendingOps.clear(Array.from(idSet))

--- a/src/frontend/src/pages/protection/composables/backupWizardPendingStorage.test.ts
+++ b/src/frontend/src/pages/protection/composables/backupWizardPendingStorage.test.ts
@@ -1,0 +1,44 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  markWizardPendingBySourceIds,
+  readWizardPendingSourceOps,
+  WIZARD_PENDING_STORAGE_KEY,
+} from './backupWizardPendingStorage'
+
+describe('backup wizard pending source storage', () => {
+  beforeEach(() => {
+    window.sessionStorage.clear()
+  })
+
+  it('persists the parent unregister task needed to resume reconciliation', () => {
+    markWizardPendingBySourceIds(['nas:42'], {
+      kind: 'deleting',
+      taskId: 17,
+      taskUuid: 'task-uuid-17',
+      startedAt: 1234,
+    })
+
+    expect(readWizardPendingSourceOps().get('nas:42')).toEqual({
+      kind: 'deleting',
+      taskId: 17,
+      taskUuid: 'task-uuid-17',
+      startedAt: 1234,
+    })
+    expect(window.sessionStorage.getItem(WIZARD_PENDING_STORAGE_KEY)).toContain('task-uuid-17')
+  })
+
+  it('allows a terminal asynchronous failure to replace deleting state', () => {
+    markWizardPendingBySourceIds(['agent:9'], {
+      kind: 'deleting',
+      taskUuid: 'task-uuid-9',
+    })
+    markWizardPendingBySourceIds(['agent:9'], {
+      kind: 'delete_failed',
+      taskUuid: 'task-uuid-9',
+    })
+
+    expect(readWizardPendingSourceOps().get('agent:9')?.kind).toBe('delete_failed')
+  })
+})

--- a/src/frontend/src/pages/protection/composables/backupWizardPendingStorage.ts
+++ b/src/frontend/src/pages/protection/composables/backupWizardPendingStorage.ts
@@ -6,6 +6,9 @@ export type SourcePendingOp = {
   kind: SourcePendingKind
   targetStep?: 1 | 2
   nodeId?: number
+  taskId?: number
+  taskUuid?: string
+  startedAt?: number
 }
 
 export const WIZARD_PENDING_STORAGE_KEY = 'hfl-backup-wizard-source-pending'

--- a/src/frontend/src/pages/protection/composables/useBackupWizardSourcePendingOps.ts
+++ b/src/frontend/src/pages/protection/composables/useBackupWizardSourcePendingOps.ts
@@ -71,6 +71,14 @@ export function useBackupWizardSourcePendingOps(options: { t: Composer['t'] }) {
     return ops.value.get(sourceId)
   }
 
+  function pendingDeleteTasks() {
+    return [...ops.value.entries()].flatMap(([sourceId, op]) =>
+      op.kind === 'deleting' && op.taskUuid
+        ? [{ sourceId, taskUuid: op.taskUuid, startedAt: op.startedAt }]
+        : [],
+    )
+  }
+
   function rowPendingLabel(sourceId: string) {
     return pendingLabel(getOp(sourceId))
   }
@@ -168,6 +176,7 @@ export function useBackupWizardSourcePendingOps(options: { t: Composer['t'] }) {
   return {
     isPending,
     getOp,
+    pendingDeleteTasks,
     rowPendingLabel,
     rowPendingSpinning,
     isRowSelectable,


### PR DESCRIPTION
Summary:
- align strict and force cleanup outcomes across source hosts, proxies, and data gateways
- move Source NAS capacity probing to a resilient asynchronous Celery workflow
- block unregister while source operations or configuration dependencies are active
- persist and recover frontend deletion tasks across page refreshes

Validation:
- 143 backend deletion and storage tests passed
- 4 targeted frontend tests passed
- frontend production build passed
- Ruff, migration consistency, and git diff checks passed