### PR TITLE
test(storage): include AWS in catalog expectations

### DIFF
--- a/src/backend/apps/platform_ops/tests/test_storage_provider_catalog_api.py
+++ b/src/backend/apps/platform_ops/tests/test_storage_provider_catalog_api.py
@@ -442,7 +442,7 @@ class StorageProviderCatalogAPITests(TransactionTestCase):
         self.assertEqual(StorageProviderOverride.objects.count(), 0)
         self.assertEqual(
             response.data["provider_ids"],
-            ["aliyun", "huaweicloud"],
+            ["aliyun", "aws", "huaweicloud"],
         )
 
     def test_reset_token_cannot_cross_single_and_all_endpoints(self):

--- a/src/backend/apps/storage/tests/test_provider_catalog_schema.py
+++ b/src/backend/apps/storage/tests/test_provider_catalog_schema.py
@@ -23,7 +23,7 @@ class ProviderCatalogSchemaTests(SimpleTestCase):
         self.assertEqual(catalog["schema_version"], 1)
         self.assertEqual(
             [provider["id"] for provider in catalog["providers"]],
-            ["huaweicloud", "aliyun"],
+            ["huaweicloud", "aliyun", "aws"],
         )
         self.assertNotIn("custom", [item["id"] for item in catalog["providers"]])
 
@@ -53,7 +53,7 @@ class ProviderCatalogSchemaTests(SimpleTestCase):
 
         self.assertEqual(
             [item["id"] for item in normalized["providers"]],
-            ["aliyun", "huaweicloud"],
+            ["aws", "aliyun", "huaweicloud"],
         )
         for item in normalized["providers"]:
             self.assertEqual(

--- a/src/backend/apps/storage/tests/test_provider_catalog_selectors.py
+++ b/src/backend/apps/storage/tests/test_provider_catalog_selectors.py
@@ -126,7 +126,7 @@ class ProviderCatalogReadAPITests(TransactionTestCase):
         self.assertEqual(response.data["schema_version"], 1)
         self.assertEqual(
             [provider["id"] for provider in response.data["providers"]],
-            ["huaweicloud", "aliyun"],
+            ["huaweicloud", "aliyun", "aws"],
         )
         self.assertNotIn("source", response.data["providers"][0])
         self.assertNotIn("checksum", response.data["providers"][0])


### PR DESCRIPTION
## Summary
- include the newly packaged AWS provider in default catalog schema expectations
- preserve provider ordering assertions during normalization and API reads
- include AWS in the reviewed default-scope reset contract

## Validation
- Ruff passed
- migration drift check passed
- all 874 Django backend tests passed with isolated PostgreSQL and Redis services

Fixes the Backend checks failure in TEST workflow run 30449572337.