### PR TITLE
test(frontend): align unregister monitor expectations

### DIFF
--- a/src/frontend/src/pages/protection/DataProtectionStep3MoreActions.test.ts
+++ b/src/frontend/src/pages/protection/DataProtectionStep3MoreActions.test.ts
@@ -132,7 +132,10 @@ describe('backup wizard step 3 More Actions refresh', () => {
     expect(monitor).toContain('getTask(taskUuid)')
     expect(monitor).toContain("new Set(['success', 'failed', 'cancelled', 'timeout'])")
     expect(monitor).toContain('refreshStep3AfterMoreAction({ preserveSelection: false })')
-    expect(unregister).toContain('monitorPendingUnregister(Array.from(idSet), taskUuids)')
+    expect(unregister).toContain('if (taskUuid)')
+    expect(unregister).toContain('monitoredSourceIds.push(sourceId)')
+    expect(unregister).toContain('monitoredTaskUuids.push(taskUuid)')
+    expect(unregister).toContain('monitorPendingUnregister(monitoredSourceIds, monitoredTaskUuids)')
   })
 
   it('refreshes source rows, pipeline membership, configurations, and pagination through one helper', () => {


### PR DESCRIPTION
## Summary
- align the unregister source-contract test with UUID-filtered monitoring
- preserve the production behavior that ignores sources without unregister task UUIDs

## Validation
- ESLint error check
- 110 Vitest files / 496 tests
- Vue and TypeScript type check
- production Vite build
- git diff --check