### PR TITLE
fix(agent): start process before streaming output

### DIFF
--- a/src/agent/internal/platform/process/stream.go
+++ b/src/agent/internal/platform/process/stream.go
@@ -45,6 +45,10 @@ func RunStreaming(
 		return Result{}, err
 	}
 
+	if err := cmd.Start(); err != nil {
+		return Result{}, err
+	}
+
 	var stdoutBuf, stderrBuf bytes.Buffer
 	var wg sync.WaitGroup
 	capture := func(reader io.Reader, stderr bool, buf *bytes.Buffer) {
@@ -56,9 +60,6 @@ func RunStreaming(
 	go capture(stdoutPipe, false, &stdoutBuf)
 	go capture(stderrPipe, true, &stderrBuf)
 
-	if err := cmd.Start(); err != nil {
-		return Result{}, err
-	}
 	stopKill := startContextProcessGroupKill(ctx, cmd)
 	runErr := cmd.Wait()
 	stopKill()


### PR DESCRIPTION
## Summary
- start the child process before launching stdout and stderr readers
- remove a scheduling race that could drop carriage-return progress lines

## Validation
- process package repeated 100 times
- process package with the race detector repeated 20 times
- complete Agent test suite
- go vet ./...
- git diff --check