### PR TITLE
fix(installer): reconcile managed gateway sidecar

### DIFF
--- a/deploy/installer/install.sh
+++ b/deploy/installer/install.sh
@@ -376,6 +376,8 @@ ensure_host_docker() {
 	min_version="$(manifest_min_engine_version)"
 	installer="${root}/payload/media/gateway-bootstrap/gateway-install-docker-ubuntu-amd64.sh"
 	[[ -x "${installer}" ]] || die "release package is missing the offline Docker installer"
+	# The helper normally preserves a healthy sidecar. This installer owns the
+	# local Gateway and must refresh its URL, credentials, and image together.
 	run_as_root env \
 		HFL_GATEWAY_BOOTSTRAP_BASE="file://${root}/payload/media/gateway-bootstrap" \
 		HFL_INSECURE_TLS=0 HFL_DOCKER_MIN_ENGINE="${min_version}" \
@@ -2342,6 +2344,7 @@ print("\t".join([*(str(payload[key]).strip() for key in required), node_ids]))
 		HFL_API_BASE="${api_base}" \
 		HFL_WSS_URL="${wss_url}" \
 		HFL_INSECURE_TLS=1 \
+		HFL_FORCE_SIDECAR_INSTALL=1 \
 		"${helper}" gateway-install --yes
 	desired_version="$(read_version)"
 	verify_local_platform_gateway_agent "${desired_version}"

--- a/tools/quality/test-platform-gateway-auto-deploy.sh
+++ b/tools/quality/test-platform-gateway-auto-deploy.sh
@@ -33,6 +33,7 @@ set -euo pipefail
 [[ "$HFL_NODE_ROLE" == "gateway" ]]
 [[ "$HFL_API_BASE" == "https://127.0.0.1:11443" ]]
 [[ "$HFL_WSS_URL" == "wss://127.0.0.1:11443/ws/node/agent/" ]]
+[[ "$HFL_FORCE_SIDECAR_INSTALL" == "1" ]]
 [[ "$1" == "gateway-install" && "$2" == "--yes" ]]
 mkdir -p "$TEST_AGENT_INSTALL_DIR" "$TEST_AGENT_DATA_DIR"
 if [[ ! -f "$TEST_AGENT_INSTALL_DIR/INSTALLED_VERSION" ]]; then


### PR DESCRIPTION
## Summary
- force the installer-owned local Platform Gateway to reapply LensNode configuration during convergence
- refresh the local SourceLens URL, credentials, and image as one managed unit
- preserve behavior for user-installed Data Gateways

## Validation
- Platform Gateway auto-deploy contracts
- Gateway SourceLens health validation
- release contract checks
- shell syntax checks
- git diff --check

## Production incident
The v0.1.12 production promotion upgraded the core stack and Agent, then failed while recreating LensNode because the healthy-sidecar fast path preserved a stale public SourceLens URL.