### PR TITLE
test(node): declare uninstall capability in fixture

### DIFF
--- a/src/backend/apps/node/tests/test_agent_uninstall.py
+++ b/src/backend/apps/node/tests/test_agent_uninstall.py
@@ -30,6 +30,7 @@ class AgentUninstallTests(TestCase):
             name="agent-uninstall",
             role=NodeRole.AGENT,
             status=Node.Status.OFFLINE,
+            metadata={"capabilities": ["detached_uninstall_v2"]},
         )
         self.resource = SourceResource.objects.create(
             organization=self.org,


### PR DESCRIPTION
## Summary
- declare the detached uninstall capability on the shared Agent uninstall test fixture
- keep the fixture aligned with Strict Cleanup requirements introduced by PR #185
- leave production lifecycle behavior unchanged

## Validation
- Agent uninstall tests: 3 passed
- Agent uninstall and node lifecycle tests: 33 passed
- git diff --check