### PR TITLE
test(frontend): align unregister binding expectations

### DIFF
--- a/src/frontend/src/pages/protection/DataProtectionStep3MoreActions.test.ts
+++ b/src/frontend/src/pages/protection/DataProtectionStep3MoreActions.test.ts
@@ -132,9 +132,9 @@ describe('backup wizard step 3 More Actions refresh', () => {
     expect(monitor).toContain('getTask(taskUuid)')
     expect(monitor).toContain("new Set(['success', 'failed', 'cancelled', 'timeout'])")
     expect(monitor).toContain('refreshStep3AfterMoreAction({ preserveSelection: false })')
-    expect(unregister).toContain('if (taskUuid)')
-    expect(unregister).toContain('monitoredSourceIds.push(sourceId)')
-    expect(unregister).toContain('monitoredTaskUuids.push(taskUuid)')
+    expect(unregister).toContain('const bindings = sourceUnregisterTaskBindings(sourceIds, payload)')
+    expect(unregister).toContain('const monitoredSourceIds = bindings.map((binding) => binding.sourceId)')
+    expect(unregister).toContain('const monitoredTaskUuids = bindings.map((binding) => binding.taskUuid)')
     expect(unregister).toContain('monitorPendingUnregister(monitoredSourceIds, monitoredTaskUuids)')
   })
 


### PR DESCRIPTION
## Summary
- align the unregister monitoring source-contract test with the explicit source/task binding helper
- preserve coverage for terminal-state monitoring and final refresh behavior

## Validation
- target Vitest: 11 passed
- full frontend Vitest: 499 passed
- frontend type check and production build
- ESLint: 0 errors (existing warnings only)
- git diff --check