### PR TITLE
Recover incomplete SourceLens submodule worktrees

### DIFF
--- a/.github/workflows/artifact_pipeline.yml
+++ b/.github/workflows/artifact_pipeline.yml
@@ -228,6 +228,7 @@ jobs:
           HFL_TEST_VERSION=main-0123456 ./tools/quality/test-ci-release-assembly.sh
           ./tools/quality/test-kopia-build-config.sh
           ./tools/quality/test-sourcelens-git-mirror.sh
+          ./tools/quality/test-sourcelens-submodule-recovery.sh
           git diff --check
           while IFS= read -r script; do bash -n "$script"; done < <(find . -path './build' -prune -o -path './data' -prune -o -type f -name '*.sh' -print)
 

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -13,6 +13,8 @@ grep -F './tools/quality/test-language-pack-runtime-index.sh' \
 	"${ROOT}/.github/workflows/artifact_pipeline.yml" >/dev/null
 grep -F './tools/quality/test-sourcelens-git-mirror.sh' \
 	"${ROOT}/.github/workflows/artifact_pipeline.yml" >/dev/null
+grep -F './tools/quality/test-sourcelens-submodule-recovery.sh' \
+	"${ROOT}/.github/workflows/artifact_pipeline.yml" >/dev/null
 
 # shellcheck source=../lib/version.sh
 source "${ROOT}/tools/lib/version.sh"
@@ -726,6 +728,7 @@ for executable in \
 	"${ROOT}/tools/quality/test-shared-host-guard.sh" \
 	"${ROOT}/tools/quality/test-release-download-proxy.sh" \
 	"${ROOT}/tools/quality/test-sourcelens-git-mirror.sh" \
+	"${ROOT}/tools/quality/test-sourcelens-submodule-recovery.sh" \
 	"${ROOT}"/release/ci/*.sh \
 	"${ROOT}/release/ci/write-sbom.py"; do
 	[[ -x "${executable}" ]] || {

--- a/tools/quality/test-sourcelens-submodule-recovery.sh
+++ b/tools/quality/test-sourcelens-submodule-recovery.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+# shellcheck source=../sourcelens/common.sh
+source "${ROOT}/tools/sourcelens/common.sh"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "${tmp}"' EXIT
+call_log="${tmp}/calls.log"
+original_git="$(declare -f sourcelens_git)"
+original_git_network="$(declare -f sourcelens_git_network)"
+
+sourcelens_log() { :; }
+sourcelens_git() {
+	printf 'local|%s\n' "$*" >>"${call_log}"
+}
+sourcelens_git_network() {
+	printf 'network|%s\n' "$*" >>"${call_log}"
+}
+
+SOURCELENS_OFFLINE=0
+sourcelens_sync_submodules
+[[ "$(sed -n '1p' "${call_log}")" == 'local|submodule sync --recursive' ]]
+[[ "$(sed -n '2p' "${call_log}")" == 'network|submodule update --init --recursive --force' ]]
+
+: >"${call_log}"
+SOURCELENS_OFFLINE=1
+sourcelens_sync_submodules
+[[ "$(sed -n '1p' "${call_log}")" == 'local|submodule sync --recursive' ]]
+[[ "$(sed -n '2p' "${call_log}")" == 'local|submodule update --init --recursive --force --no-fetch' ]]
+
+eval "${original_git}"
+eval "${original_git_network}"
+
+module_repo="${tmp}/module"
+super_repo="${tmp}/super"
+source_cache="${tmp}/source"
+
+git init -q "${module_repo}"
+git -C "${module_repo}" config user.email test@hyperfilelens.local
+git -C "${module_repo}" config user.name 'HyperFileLens Test'
+printf '%s\n' \
+	'[project]' \
+	'name = "agentcore-task-fixture"' \
+	'version = "0.0.1"' >"${module_repo}/pyproject.toml"
+git -C "${module_repo}" add pyproject.toml
+git -C "${module_repo}" commit -q -m fixture
+
+git init -q "${super_repo}"
+git -C "${super_repo}" config user.email test@hyperfilelens.local
+git -C "${super_repo}" config user.name 'HyperFileLens Test'
+git -C "${super_repo}" -c protocol.file.allow=always \
+	submodule add -q "${module_repo}" backend/agentcore/agentcore-task
+git -C "${super_repo}" commit -q -am fixture
+
+git clone -q "${super_repo}" "${source_cache}"
+git -C "${source_cache}" -c protocol.file.allow=always \
+	submodule update --init --recursive
+module_path="${source_cache}/backend/agentcore/agentcore-task"
+expected_commit="$(git -C "${module_path}" rev-parse HEAD)"
+rm "${module_path}/pyproject.toml"
+[[ ! -e "${module_path}/pyproject.toml" ]]
+[[ "$(git -C "${module_path}" rev-parse HEAD)" == "${expected_commit}" ]]
+
+(
+	cd "${source_cache}"
+	SOURCELENS_OFFLINE=1
+	sourcelens_sync_submodules
+)
+
+[[ -f "${module_path}/pyproject.toml" ]]
+grep -F 'name = "agentcore-task-fixture"' "${module_path}/pyproject.toml" >/dev/null
+[[ "$(git -C "${module_path}" rev-parse HEAD)" == "${expected_commit}" ]]
+git -C "${module_path}" diff --quiet
+
+printf 'SourceLens submodule recovery checks passed.\n'

--- a/tools/sourcelens/common.sh
+++ b/tools/sourcelens/common.sh
@@ -238,6 +238,16 @@ sourcelens_git_network() {
 	return 1
 }
 
+sourcelens_sync_submodules() {
+	sourcelens_log "Synchronizing SourceLens submodules with forced worktree recovery"
+	sourcelens_git submodule sync --recursive
+	if [[ "${SOURCELENS_OFFLINE}" -eq 1 ]]; then
+		sourcelens_git submodule update --init --recursive --force --no-fetch
+	else
+		sourcelens_git_network submodule update --init --recursive --force
+	fi
+}
+
 sourcelens_image_exists() {
 	docker image inspect "$1" >/dev/null 2>&1
 }
@@ -380,11 +390,7 @@ sourcelens_sync_source() {
 		else
 			sourcelens_git checkout "${SOURCELENS_GIT_REF}"
 		fi
-		if [[ "${SOURCELENS_OFFLINE}" -eq 1 ]]; then
-			sourcelens_git submodule update --init --recursive --no-fetch
-		else
-			sourcelens_git_network submodule update --init --recursive
-		fi
+		sourcelens_sync_submodules
 	)
 	# shellcheck source=sourcelens-lensnode-patch.sh
 	source "${HFL_ROOT}/tools/sourcelens/lensnode-patch.sh"


### PR DESCRIPTION
## Summary

- synchronize SourceLens submodule URLs before updating cached worktrees
- force online and offline submodule checkouts so missing tracked files are restored even when HEAD already matches
- add a functional regression test that deletes a tracked submodule file without changing its commit
- run the recovery test in the release and source validation workflow

## Testing

- ./tools/quality/test-sourcelens-submodule-recovery.sh
- ./tools/quality/test-sourcelens-git-mirror.sh
- ./tools/quality/check-release-contracts.sh
- ./tools/quality/test-kopia-build-config.sh
- python3 tools/quality/check-english-source.py
- bash syntax checks
- git diff --check