### PR TITLE
fix: align Source NAS status and unregister failure propagation

### DIFF
--- a/src/backend/apps/node/services/internal/node_lifecycle.py
+++ b/src/backend/apps/node/services/internal/node_lifecycle.py
@@ -552,12 +552,39 @@ def _fail_stale_remove_task(*, node: Node, task: NodeTask) -> bool:
 
 
 def queue_detached_remove_verification(*, node_task: NodeTask) -> bool:
-    """Schedule remove verification without relying exclusively on Celery Beat."""
+    """Queue the next remove step without relying exclusively on Celery Beat."""
     if node_task.kind != _LIFECYCLE_TASK_KINDS[LIFECYCLE_KIND_REMOVE]:
         return False
-    if node_task.status != NodeTask.Status.RUNNING:
-        return False
     if node_task.correlation_type != node_conf.LIFECYCLE_CORRELATION_TYPE:
+        return False
+
+    task_payload = node_task.payload if isinstance(node_task.payload, dict) else {}
+    try:
+        source_unregister_task_id = int(
+            task_payload.get("source_unregister_task_id") or 0
+        )
+    except (TypeError, ValueError):
+        source_unregister_task_id = 0
+
+    if source_unregister_task_id > 0 and node_task.status in {
+        NodeTask.Status.FAILED,
+        NodeTask.Status.TIMEOUT,
+        NodeTask.Status.CANCELED,
+    }:
+        from apps.source.tasks.source_unregister import queue_source_unregister_task
+
+        queue_source_unregister_task(task_id=source_unregister_task_id)
+        logger.info(
+            "source unregister parent queued after Agent uninstall terminal failure "
+            "node_id=%s node_task_id=%s source_unregister_task_id=%s status=%s",
+            node_task.node_id,
+            node_task.id,
+            source_unregister_task_id,
+            node_task.status,
+        )
+        return True
+
+    if node_task.status != NodeTask.Status.RUNNING:
         return False
     if not _is_detached_lifecycle_task(node_task):
         return False

--- a/src/backend/apps/node/tests/test_node_lifecycle.py
+++ b/src/backend/apps/node/tests/test_node_lifecycle.py
@@ -514,6 +514,52 @@ class NodeLifecycleTests(TestCase):
             countdown=node_conf.LIFECYCLE_DETACHED_TIMEOUT_SECONDS + 1,
         )
 
+    @patch("apps.source.tasks.source_unregister.queue_source_unregister_task")
+    def test_failed_remove_immediately_queues_source_unregister_parent(
+        self,
+        queue_parent,
+    ):
+        for status in (
+            NodeTask.Status.FAILED,
+            NodeTask.Status.TIMEOUT,
+            NodeTask.Status.CANCELED,
+        ):
+            with self.subTest(status=status):
+                task = NodeTask.objects.create(
+                    organization=self.org,
+                    node=self.node,
+                    kind="agent.uninstall",
+                    status=status,
+                    payload={"source_unregister_task_id": 42},
+                    watchdog_deadline_at=timezone.now() + timezone.timedelta(hours=1),
+                    correlation_type=node_conf.LIFECYCLE_CORRELATION_TYPE,
+                    correlation_id=f"remove:{self.node.id}",
+                )
+
+                queued = queue_detached_remove_verification(node_task=task)
+
+                self.assertTrue(queued)
+                queue_parent.assert_called_once_with(task_id=42)
+                queue_parent.reset_mock()
+
+    @patch("apps.source.tasks.source_unregister.queue_source_unregister_task")
+    def test_successful_remove_waits_for_signed_completion_callback(self, queue_parent):
+        task = NodeTask.objects.create(
+            organization=self.org,
+            node=self.node,
+            kind="agent.uninstall",
+            status=NodeTask.Status.SUCCESS,
+            payload={"source_unregister_task_id": 42},
+            watchdog_deadline_at=timezone.now() + timezone.timedelta(hours=1),
+            correlation_type=node_conf.LIFECYCLE_CORRELATION_TYPE,
+            correlation_id=f"remove:{self.node.id}",
+        )
+
+        queued = queue_detached_remove_verification(node_task=task)
+
+        self.assertFalse(queued)
+        queue_parent.assert_not_called()
+
     @patch("apps.node.services.internal.node_lifecycle.agent_ws_routable", return_value=False)
     def test_pending_remove_does_not_finalize_when_ws_gone(self, _routable):
         task = NodeTask.objects.create(

--- a/src/frontend/src/lib/sourceNasDisplay.test.ts
+++ b/src/frontend/src/lib/sourceNasDisplay.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
+import { enProtectionPages } from '../locales/enProtectionPages'
 import { customMountPath } from './nasMountPath'
 import {
   nasMountProtocol,
@@ -7,6 +8,7 @@ import {
   nasProxyMountPoint,
   nasServerAddress,
   nasShareOrExport,
+  sourceNasStatusPresentation,
 } from './sourceNasDisplay'
 
 describe('nasMountSourceUri', () => {
@@ -100,5 +102,52 @@ describe('nas list column helpers', () => {
         config: {},
       }),
     ).toBe(smbMount)
+  })
+})
+
+describe('sourceNasStatusPresentation', () => {
+  it('defines NAS error and Proxy labels in the active locale namespace', () => {
+    expect(enProtectionPages.sourceResources.mountStatus.error).toBe('Mount Error')
+    expect(enProtectionPages.sourceResources.proxyStatus).toBe('Proxy: {status}')
+  })
+
+  it('prioritizes a NAS error over an online Proxy', () => {
+    expect(
+      sourceNasStatusPresentation(
+        {
+          effective_status: 'error',
+          mount_status: 'unmounted',
+          connection_test_status: 'failed',
+        },
+        'online',
+      ),
+    ).toEqual({
+      status: 'error',
+      labelKey: 'protection.sourceResources.mountStatus.error',
+      tone: 'danger',
+    })
+  })
+
+  it('keeps unmounted and probing NAS states distinct from Proxy health', () => {
+    expect(
+      sourceNasStatusPresentation({ effective_status: 'unverified' }, 'online'),
+    ).toMatchObject({
+      status: 'unverified',
+      tone: 'warning',
+    })
+    expect(
+      sourceNasStatusPresentation({ connection_test_status: 'running' }, 'online'),
+    ).toMatchObject({
+      status: 'probing',
+      tone: 'warning',
+    })
+  })
+
+  it('falls back to the Proxy connection only when NAS health is unavailable', () => {
+    expect(sourceNasStatusPresentation({}, 'reconnecting')).toEqual({
+      status: 'reconnecting',
+      labelKey: 'protection.sourceResources.nodeStatusReconnecting',
+      tone: 'info',
+    })
   })
 })

--- a/src/frontend/src/lib/sourceNasDisplay.ts
+++ b/src/frontend/src/lib/sourceNasDisplay.ts
@@ -5,6 +5,99 @@ export type NasLikeResource = {
   config?: Record<string, unknown>
   connection_summary?: string
   mount_point?: string
+  mount_status?: string
+  status?: string
+  effective_status?: string
+  connection_test_status?: string
+}
+
+export type SourceNasProxyStatus = 'online' | 'reconnecting' | 'offline'
+export type SourceNasRuntimeStatus =
+  | 'removing'
+  | 'remove_failed'
+  | 'error'
+  | 'probing'
+  | 'online'
+  | 'unverified'
+  | SourceNasProxyStatus
+
+export type SourceNasStatusPresentation = {
+  status: SourceNasRuntimeStatus
+  labelKey: string
+  tone: 'success' | 'warning' | 'danger' | 'info'
+}
+
+const SOURCE_NAS_STATUS_PRESENTATIONS: Record<
+  SourceNasRuntimeStatus,
+  Omit<SourceNasStatusPresentation, 'status'>
+> = {
+  removing: {
+    labelKey: 'protection.backupsPage.sourcePendingDeleting',
+    tone: 'info',
+  },
+  remove_failed: {
+    labelKey: 'protection.backupsPage.sourcePendingDeleteFailed',
+    tone: 'danger',
+  },
+  error: {
+    labelKey: 'protection.sourceResources.mountStatus.error',
+    tone: 'danger',
+  },
+  probing: {
+    labelKey: 'protection.sourceResources.capacitySyncing',
+    tone: 'warning',
+  },
+  online: {
+    labelKey: 'protection.sourceResources.nodeStatusOnline',
+    tone: 'success',
+  },
+  unverified: {
+    labelKey: 'protection.sourceResources.mountStatus.unmounted',
+    tone: 'warning',
+  },
+  reconnecting: {
+    labelKey: 'protection.sourceResources.nodeStatusReconnecting',
+    tone: 'info',
+  },
+  offline: {
+    labelKey: 'protection.sourceResources.nodeStatusOffline',
+    tone: 'danger',
+  },
+}
+
+function normalizedStatus(value?: string | null): string {
+  return String(value || '').trim().toLowerCase()
+}
+
+/** Resolve NAS health before falling back to the bound Proxy connection state. */
+export function sourceNasStatusPresentation(
+  row: NasLikeResource,
+  proxyStatus: SourceNasProxyStatus,
+): SourceNasStatusPresentation {
+  const effectiveStatus = normalizedStatus(row.effective_status)
+  if (effectiveStatus in SOURCE_NAS_STATUS_PRESENTATIONS) {
+    const status = effectiveStatus as SourceNasRuntimeStatus
+    return { status, ...SOURCE_NAS_STATUS_PRESENTATIONS[status] }
+  }
+
+  const connectionTestStatus = normalizedStatus(row.connection_test_status)
+  const mountStatus = normalizedStatus(row.mount_status)
+  const resourceStatus = normalizedStatus(row.status)
+  let status: SourceNasRuntimeStatus = proxyStatus
+  if (
+    connectionTestStatus === 'failed'
+    || mountStatus === 'error'
+    || resourceStatus === 'error'
+  ) {
+    status = 'error'
+  } else if (connectionTestStatus === 'pending' || connectionTestStatus === 'running') {
+    status = 'probing'
+  } else if (mountStatus === 'mounted' || connectionTestStatus === 'success') {
+    status = 'online'
+  } else if (mountStatus === 'unmounted') {
+    status = 'unverified'
+  }
+  return { status, ...SOURCE_NAS_STATUS_PRESENTATIONS[status] }
 }
 
 function configString(config: Record<string, unknown> | undefined, key: string): string {

--- a/src/frontend/src/locales/enProtectionPages.ts
+++ b/src/frontend/src/locales/enProtectionPages.ts
@@ -1989,6 +1989,7 @@ sourceResources: {
     nodeStatusOnline: 'Online',
     nodeStatusReconnecting: 'Reconnecting',
     nodeStatusOffline: 'Offline',
+    proxyStatus: 'Proxy: {status}',
     mountStatus: {
       mounted: 'Mounted',
       unmounted: 'Unmounted',

--- a/src/frontend/src/pages/protection/BackupSources.vue
+++ b/src/frontend/src/pages/protection/BackupSources.vue
@@ -63,7 +63,13 @@ import {
   type SourceResource,
   type SourceStats,
 } from '../../lib/sourceApi'
-import { nasMountProtocol, nasProxyMountPoint, nasServerAddress, nasShareOrExport } from '../../lib/sourceNasDisplay'
+import {
+  nasMountProtocol,
+  nasProxyMountPoint,
+  nasServerAddress,
+  nasShareOrExport,
+  sourceNasStatusPresentation,
+} from '../../lib/sourceNasDisplay'
 import {
   nodeCpuCores,
   nodeDiskCount,
@@ -775,27 +781,14 @@ function sourceNodeOnlineStatus(row: SourceResource): 'online' | 'reconnecting' 
 function sourceNodeOnlineLabel(row: SourceResource) {
   const pending = resolveSourcePendingStatus(nasSelectableId(row))
   if (pending) return pending.label
-  if (row.effective_status === 'remove_failed') return t('protection.backupsPage.sourcePendingDeleteFailed')
-  if (row.effective_status === 'error') return t('protection.sourceResources.mountStatusError')
-  if (row.effective_status === 'probing') return t('protection.sourceResources.capacitySyncing')
-  if (row.effective_status === 'online') return t('protection.sourceResources.nodeStatusOnline')
-  if (row.effective_status === 'unverified') return t('protection.sourceResources.mountStatusUnmounted')
-  const status = sourceNodeOnlineStatus(row)
-  if (status === 'online') return t('protection.sourceResources.nodeStatusOnline')
-  if (status === 'reconnecting') return t('protection.sourceResources.nodeStatusReconnecting')
-  return t('protection.sourceResources.nodeStatusOffline')
+  const presentation = sourceNasStatusPresentation(row, sourceNodeOnlineStatus(row))
+  return t(presentation.labelKey)
 }
 
 function sourceNodeOnlineTagType(row: SourceResource): 'success' | 'warning' | 'info' | 'danger' {
   const pending = resolveSourcePendingStatus(nasSelectableId(row))
   if (pending) return pending.tag
-  if (row.effective_status === 'remove_failed' || row.effective_status === 'error') return 'danger'
-  if (row.effective_status === 'probing' || row.effective_status === 'unverified') return 'warning'
-  if (row.effective_status === 'online') return 'success'
-  const status = sourceNodeOnlineStatus(row)
-  if (status === 'online') return 'success'
-  if (status === 'reconnecting') return 'info'
-  return 'danger'
+  return sourceNasStatusPresentation(row, sourceNodeOnlineStatus(row)).tone
 }
 
 function sourceProxyStatusLabel(row: SourceResource) {

--- a/src/frontend/src/pages/protection/components/NasSourceDetailDrawer.vue
+++ b/src/frontend/src/pages/protection/components/NasSourceDetailDrawer.vue
@@ -10,6 +10,7 @@ import {
   nasMountProtocol,
   nasMountSourceUri,
   nasProxyMountPoint,
+  sourceNasStatusPresentation,
   sourceExternalId,
 } from '../../../lib/sourceNasDisplay'
 import { formatAppTime } from '../../../lib/dateTime'
@@ -27,7 +28,7 @@ import { useResponsiveDrawerWidth } from '../../../composables/useResponsiveDraw
 import { debouncedNodeStatus } from '../../../composables/useNodeConnectionDisplay'
 import type { ApiNode } from '../../../types/node'
 import HflCapacityCell from '../../../components/HflCapacityCell.vue'
-import { lifecycleStatusTagAttrs } from '../../../lib/statusTag'
+import { statusTagAttrs } from '../../../lib/statusTag'
 
 type NasProtocol = 'smb' | 'nfs'
 
@@ -160,7 +161,7 @@ const capacityParts = computed(() => {
   return { used, total, pct }
 })
 
-const connectionStatus = computed((): 'online' | 'reconnecting' | 'offline' => {
+const proxyConnectionStatus = computed((): 'online' | 'reconnecting' | 'offline' => {
   const explicit = (row.value?.bound_node_status || '').trim().toLowerCase()
   if (explicit === 'online' || explicit === 'reconnecting' || explicit === 'offline') return explicit
   const status = proxyNode.value ? debouncedNodeStatus(proxyNode.value) : undefined
@@ -168,13 +169,11 @@ const connectionStatus = computed((): 'online' | 'reconnecting' | 'offline' => {
   return 'offline'
 })
 
-const connectionStatusLabel = computed(() => {
-  if (connectionStatus.value === 'online') return t('protection.sourceResources.nodeStatusOnline')
-  if (connectionStatus.value === 'reconnecting') return t('protection.sourceResources.nodeStatusReconnecting')
-  return t('protection.sourceResources.nodeStatusOffline')
-})
-
-const connectionStatusTagAttrs = computed(() => lifecycleStatusTagAttrs(connectionStatus.value))
+const runtimeStatus = computed(() =>
+  sourceNasStatusPresentation(row.value || {}, proxyConnectionStatus.value),
+)
+const connectionStatusLabel = computed(() => t(runtimeStatus.value.labelKey))
+const connectionStatusTagAttrs = computed(() => statusTagAttrs(runtimeStatus.value.tone))
 
 const lastHeartbeatText = computed(() => formatLastHeartbeat(proxyNode.value?.last_seen_at))
 


### PR DESCRIPTION
## Summary

- unify Source NAS runtime status presentation across the list, detail drawer, and unregister dialogs
- add the missing Source NAS proxy status translation
- immediately resume parent source unregister tasks after Agent uninstall failure, timeout, or cancellation

## Validation

- frontend Vitest: 111 files / 503 tests passed
- frontend production build passed
- Node lifecycle tests: 32 passed
- Source unregister tests: 7 passed
- Ruff, ESLint error check, and git diff checks passed