### PR TITLE
Propagate Go network settings in development workflows

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -424,10 +424,10 @@ PIP_TIMEOUT=600
 # Optional npm registry, for example https://registry.npmjs.org.
 NPM_REGISTRY=
 
-# Go module proxy used by Agent builds.
+# Go module proxy used by Kopia and Agent builds.
 GOPROXY=https://proxy.golang.org,direct
 
-# Go checksum database used by Agent builds.
+# Go checksum database used by Kopia and Agent builds.
 GOSUMDB=sum.golang.org
 
 # ==============================================================================

--- a/dev/stack.sh
+++ b/dev/stack.sh
@@ -192,6 +192,8 @@ apply_mirror_env_defaults() {
 	OPT_PIP_INDEX_URL="${OPT_PIP_INDEX_URL:-${PIP_INDEX_URL:-}}"
 	OPT_PIP_TRUSTED_HOST="${OPT_PIP_TRUSTED_HOST:-${PIP_TRUSTED_HOST:-}}"
 	OPT_NPM_REGISTRY="${OPT_NPM_REGISTRY:-${NPM_REGISTRY:-}}"
+	[[ -z "${OPT_GO_PROXY}" ]] || export GOPROXY="${OPT_GO_PROXY}"
+	[[ -z "${OPT_GO_SUMDB}" ]] || export GOSUMDB="${OPT_GO_SUMDB}"
 }
 
 print_config() {
@@ -234,8 +236,8 @@ github_download_mirror=${MIRROR_GITHUB_DOWNLOAD:-<official>}
 github_token=$(hfl_redact "${MIRROR_GITHUB_TOKEN}")
 docker_download_mirror=${MIRROR_DOCKER_DOWNLOAD:-<official>}
 apt_mirror=${MIRROR_APT:-<official>}
-go_proxy=${OPT_GO_PROXY:-<official>}
-go_sumdb=${OPT_GO_SUMDB:-<official>}
+go_proxy=${GOPROXY:-<official>}
+go_sumdb=${GOSUMDB:-<official>}
 pip_index_url=${OPT_PIP_INDEX_URL:-<official>}
 pip_trusted_host=${OPT_PIP_TRUSTED_HOST:-<unset>}
 npm_registry=${OPT_NPM_REGISTRY:-<official>}
@@ -282,6 +284,11 @@ def parts(value):
 
 raise SystemExit(0 if parts(sys.argv[1]) >= parts(sys.argv[2]) else 1)
 PY
+}
+
+require_dev_build_tools() {
+	command -v python3 >/dev/null 2>&1 || die "python3 not found in PATH" 2
+	command -v go >/dev/null 2>&1 || die "go not found in PATH (required for Kopia and Agent builds)" 2
 }
 
 require_docker() {
@@ -651,7 +658,6 @@ prepare_dev() {
 	local force=$1
 	apply_mirror_env_defaults
 	apply_ubuntu2404_arch_default
-	command -v python3 >/dev/null 2>&1 || die "python3 not found"
 	log "Checking English-only public source trees"
 	python3 "${ROOT}/tools/quality/check-english-source.py"
 	require_docker
@@ -852,6 +858,7 @@ sync_optional_identity_settings() {
 
 cmd_up() {
 	apply_mirror_env_defaults
+	require_dev_build_tools
 	ensure_env_file
 	require_docker
 	ensure_runtime_images
@@ -878,6 +885,7 @@ cmd_restart() {
 	local force=$1
 
 	apply_mirror_env_defaults
+	require_dev_build_tools
 	ensure_env_file
 	require_docker
 	ensure_runtime_images
@@ -924,7 +932,7 @@ cmd_doctor() {
 	local failures=0 command image mode
 	ensure_env_file
 	apply_mirror_env_defaults
-	for command in docker python3 openssl timeout flock gzip sha256sum realpath; do
+	for command in docker go python3 openssl timeout flock gzip sha256sum realpath; do
 		if command -v "${command}" >/dev/null 2>&1; then
 			printf 'ok      command %s\n' "${command}"
 		else

--- a/tools/quality/test-kopia-build-config.sh
+++ b/tools/quality/test-kopia-build-config.sh
@@ -29,6 +29,31 @@ mirror_config="$(
 grep -F 'git_url=https://github.com/kopia/kopia.git' <<<"${mirror_config}" >/dev/null
 grep -F 'github_download_mirror=https://ghfast.top' <<<"${mirror_config}" >/dev/null
 
+dev_environment_config="$(
+	GOPROXY=https://env-proxy.example.test,direct \
+		GOSUMDB=env-sumdb.example.test \
+		"${ROOT}/dev/stack.sh" up --print-config
+)"
+grep -F 'go_proxy=https://env-proxy.example.test,direct' <<<"${dev_environment_config}" >/dev/null
+grep -F 'go_sumdb=env-sumdb.example.test' <<<"${dev_environment_config}" >/dev/null
+
+dev_cli_config="$(
+	GOPROXY=https://env-proxy.example.test,direct \
+		GOSUMDB=env-sumdb.example.test \
+		"${ROOT}/dev/stack.sh" up \
+		--go-proxy https://cli-proxy.example.test,direct \
+		--go-sumdb cli-sumdb.example.test \
+		--print-config
+)"
+grep -F 'go_proxy=https://cli-proxy.example.test,direct' <<<"${dev_cli_config}" >/dev/null
+grep -F 'go_sumdb=cli-sumdb.example.test' <<<"${dev_cli_config}" >/dev/null
+
+dev_up_body="$(sed -n '/^cmd_up()/,/^}/p' "${ROOT}/dev/stack.sh")"
+[[ "${dev_up_body}" == *'require_dev_build_tools'*'prepare_sourcelens_dev'* ]]
+dev_restart_body="$(sed -n '/^cmd_restart()/,/^}/p' "${ROOT}/dev/stack.sh")"
+[[ "${dev_restart_body}" == *'require_dev_build_tools'*'prepare_sourcelens_dev'* ]]
+grep -F 'for command in docker go python3' "${ROOT}/dev/stack.sh" >/dev/null
+
 # shellcheck source=../kopia/prepare.sh
 source "${ROOT}/tools/kopia/prepare.sh"
 


### PR DESCRIPTION
## Summary

- export the effective Go proxy and checksum database before Kopia and Agent preparation
- preserve CLI precedence over repository and process environment defaults
- check Go before starting the long-running SourceLens preparation path
- include Go in development doctor checks and clarify the shared Kopia and Agent configuration
- add regression coverage for environment fallback, CLI precedence, and preflight ordering

## Testing

- ./tools/quality/test-kopia-build-config.sh
- ./tools/quality/test-sourcelens-git-mirror.sh
- ./tools/quality/test-sourcelens-submodule-recovery.sh
- ./tools/quality/check-release-contracts.sh
- python3 tools/quality/check-english-source.py
- bash syntax checks
- git diff --check