### PR TITLE
fix(frontend): distinguish file browser icons

### DIFF
--- a/src/frontend/src/pages/insight/KnowledgeSourceFormPage.vue
+++ b/src/frontend/src/pages/insight/KnowledgeSourceFormPage.vue
@@ -529,12 +529,12 @@ onMounted(() => {
                                     <FolderOpen
                                       v-if="data.type === 'dir'"
                                       :size="15"
-                                      class="hfl-dir-tree-node__icon"
+                                      class="hfl-dir-tree-node__icon hfl-dir-tree-node__icon--dir"
                                     />
                                     <File
                                       v-else
                                       :size="15"
-                                      class="hfl-dir-tree-node__icon"
+                                      class="hfl-dir-tree-node__icon hfl-dir-tree-node__icon--file"
                                     />
                                     <div class="hfl-dir-tree-node__text">
                                       <span class="hfl-dir-tree-node__label">{{ data.label }}</span>

--- a/src/frontend/src/pages/insight/NewCopilotChat.vue
+++ b/src/frontend/src/pages/insight/NewCopilotChat.vue
@@ -299,8 +299,8 @@ onBeforeUnmount(() => backupScopeResizeObserver?.disconnect())
                         >
                           <template #default="{ data }">
                             <div class="hfl-dir-tree-node">
-                              <FolderOpen v-if="data.type === 'dir'" :size="15" class="hfl-dir-tree-node__icon" />
-                              <File v-else :size="15" class="hfl-dir-tree-node__icon" />
+                              <FolderOpen v-if="data.type === 'dir'" :size="15" class="hfl-dir-tree-node__icon hfl-dir-tree-node__icon--dir" />
+                              <File v-else :size="15" class="hfl-dir-tree-node__icon hfl-dir-tree-node__icon--file" />
                               <div class="hfl-dir-tree-node__text"><span class="hfl-dir-tree-node__label">{{ data.label }}</span><span v-if="data.path" class="hfl-dir-tree-node__path">{{ data.path }}</span></div>
                             </div>
                           </template>

--- a/src/frontend/src/styles/directory-tree.css
+++ b/src/frontend/src/styles/directory-tree.css
@@ -78,6 +78,14 @@
   color: #d97706;
 }
 
+.hfl-dir-tree-node__icon--dir {
+  color: #d97706;
+}
+
+.hfl-dir-tree-node__icon--file {
+  color: #2563eb;
+}
+
 .hfl-dir-tree-node__text {
   display: flex;
   flex: 1 1 auto;

--- a/src/frontend/src/styles/directoryTreeIconTypes.test.ts
+++ b/src/frontend/src/styles/directoryTreeIconTypes.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const styles = readFileSync(resolve(process.cwd(), 'src/styles/directory-tree.css'), 'utf8')
+const newCopilotChat = readFileSync(resolve(process.cwd(), 'src/pages/insight/NewCopilotChat.vue'), 'utf8')
+const knowledgeSourceForm = readFileSync(resolve(process.cwd(), 'src/pages/insight/KnowledgeSourceFormPage.vue'), 'utf8')
+
+const directoryIconClass = 'class="hfl-dir-tree-node__icon hfl-dir-tree-node__icon--dir"'
+const fileIconClass = 'class="hfl-dir-tree-node__icon hfl-dir-tree-node__icon--file"'
+
+describe('shared directory tree icon types', () => {
+  it('uses the established folder and file colors', () => {
+    expect(styles).toMatch(/\.hfl-dir-tree-node__icon--dir\s*{[^}]*color:\s*#d97706;/s)
+    expect(styles).toMatch(/\.hfl-dir-tree-node__icon--file\s*{[^}]*color:\s*#2563eb;/s)
+  })
+
+  it.each([
+    ['New Chat', newCopilotChat],
+    ['Knowledge Source form', knowledgeSourceForm],
+  ])('distinguishes folders and files in the %s backup scope picker', (_name, source) => {
+    expect(source).toContain(directoryIconClass)
+    expect(source).toContain(fileIconClass)
+  })
+})


### PR DESCRIPTION
## Problem and root cause

The snapshot file browser distinguishes directories and files with orange and
blue icons, but the New Chat and Knowledge Source backup-scope trees applied the
same orange shared icon class to both types. The data mapping already supplied
the correct `dir` or `file` type; the inconsistency was limited to the shared
CSS class contract used by these mixed trees.

## Solution

- Add shared directory and file icon modifiers using the established colors.
- Apply the type-specific modifiers in the New Chat backup-scope picker.
- Apply the same modifiers in the Knowledge Source backup-scope picker.
- Add regression coverage for the shared colors and both consumers.

## Validation

- `npm run test -- src/styles/directoryTreeIconTypes.test.ts` — passed, 3 tests
- `npm run lint` — passed with 0 errors
- `npm run test:ci` — passed, 112 files and 506 tests
- `npm run build` — passed with Node.js 22.23.2
- `git diff --check` — passed
- `python3 tools/quality/check-english-source.py` — passed

The active Compose UI is mounted from another worktree, so no manual browser
check was claimed for this branch. Frontend validation ran in an isolated
Node.js 22 environment against this branch's source.

## Risks and compatibility

This is a presentation-only change. It preserves the existing glyphs, data
types, selection behavior, API contracts, accessibility labels, and folder-only
tree styling. No migration or operational change is required.

Fixes #203
