### PR TITLE
Fix Windows agent uninstall cleanup finalization

### DIFF
--- a/src/agent/internal/platform/install/install_ps1_test.go
+++ b/src/agent/internal/platform/install/install_ps1_test.go
@@ -1,0 +1,59 @@
+package install
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestInstallPs1PurgeDoesNotRecreateDataLogDirectory(t *testing.T) {
+	source := readPackagingInstallScript(t)
+	for _, want := range []string{
+		"if (-not `$dir -or -not (Test-Path -LiteralPath `$dir)) { return }",
+		`$uninstallLog = if (-not $PurgeAll -and $uninstallLogPath) { $uninstallLogPath } else { "" }`,
+	} {
+		if !strings.Contains(source, want) {
+			t.Fatalf("install.ps1 missing %q", want)
+		}
+	}
+	if strings.Contains(source, "if (`$dir) { New-Item -ItemType Directory -Force -Path `$dir") {
+		t.Fatal("deferred install-root cleanup must not recreate the uninstall log directory")
+	}
+}
+
+func TestInstallPs1SafeDataPathRequiresHyperFileLensDescendant(t *testing.T) {
+	source := readPackagingInstallScript(t)
+	for _, want := range []string{
+		`$allowedRoot = Join-Path $pd "HyperFileLens"`,
+		`$allowedRoot.TrimEnd('\') + '\'`,
+	} {
+		if !strings.Contains(source, want) {
+			t.Fatalf("install.ps1 safe data path check missing %q", want)
+		}
+	}
+	if strings.Contains(source, `StartsWith($pd.TrimEnd('\') + '\HyperFileLens'`) {
+		t.Fatal("safe data path check must enforce a path-component boundary")
+	}
+}
+
+func readPackagingInstallScript(t *testing.T) string {
+	t.Helper()
+	_, currentFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("resolve current test file")
+	}
+	path := filepath.Clean(filepath.Join(
+		filepath.Dir(currentFile),
+		"..", "..", "..", "packaging", "install", "install.ps1",
+	))
+	raw, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		t.Skipf("packaging source is not available beside the compiled test: %s", path)
+	}
+	if err != nil {
+		t.Fatalf("read install.ps1: %v", err)
+	}
+	return string(raw)
+}

--- a/src/agent/internal/platform/install/local_uninstall_windows.go
+++ b/src/agent/internal/platform/install/local_uninstall_windows.go
@@ -106,11 +106,20 @@ $callbackInsecureTls = %s
 $forceCleanup = %s
 $cleanupFailures = @()
 $retainedResources = @()
+$logEnabled = $true
 
 New-Item -ItemType Directory -Force -Path (Split-Path -Parent $logFile) | Out-Null
 function Log([string]$msg) {
+  if (-not $script:logEnabled) {
+    return
+  }
   $ts = [DateTime]::UtcNow.ToString('yyyy-MM-ddTHH:mm:ss.fffZ')
-  Add-Content -LiteralPath $logFile -Value "$ts $msg" -Encoding UTF8
+  try {
+    New-Item -ItemType Directory -Force -Path (Split-Path -Parent $logFile) | Out-Null
+    Add-Content -LiteralPath $logFile -Value "$ts $msg" -Encoding UTF8
+  } catch {
+    # Logging is best-effort and must not interrupt physical cleanup.
+  }
 }
 
 function Add-CleanupFailure(
@@ -210,11 +219,7 @@ function Remove-InstallDirectoryResidue {
 }
 
 function Confirm-UninstallArtifacts {
-  param(
-    [string]$InstallDir,
-    [string]$DataDir,
-    [string]$KeepFlag
-  )
+  param([string]$InstallDir)
   # Allow Schedule-InstallRootRemoval deferred cleanup to run first.
   Start-Sleep -Seconds 6
   $issues = @()
@@ -224,10 +229,66 @@ function Confirm-UninstallArtifacts {
   if (Test-Path -LiteralPath $InstallDir) {
     $issues += "install directory still present: $InstallDir"
   }
-  if ($KeepFlag -eq '0' -and (Test-Path -LiteralPath $DataDir)) {
-    $issues += "data directory still present: $DataDir"
-  }
   return $issues
+}
+
+function Test-SafeAgentDataPath {
+  param([string]$DataDir)
+  if ([string]::IsNullOrWhiteSpace($DataDir)) {
+    return $false
+  }
+  try {
+    $full = [System.IO.Path]::GetFullPath($DataDir).TrimEnd('\')
+    $programData = [System.IO.Path]::GetFullPath($env:ProgramData).TrimEnd('\')
+    $allowedRoot = Join-Path $programData 'HyperFileLens'
+    return $full.StartsWith(
+      $allowedRoot.TrimEnd('\') + '\',
+      [System.StringComparison]::OrdinalIgnoreCase
+    )
+  } catch {
+    return $false
+  }
+}
+
+function Remove-AgentDataDirectory {
+  param([string]$DataDir)
+
+  if (-not [string]::IsNullOrWhiteSpace($DataDir) -and -not (Test-Path -LiteralPath $DataDir)) {
+    $script:logEnabled = $false
+    return
+  }
+  if (-not (Test-SafeAgentDataPath -DataDir $DataDir)) {
+    Add-CleanupFailure -code 'agent_data_cleanup_refused' -detail "refused to remove data directory outside ProgramData\HyperFileLens: $DataDir" -retained @($DataDir)
+    return
+  }
+
+  # This is the final file log entry. Logging must remain disabled after a
+  # successful removal so the completion callback cannot recreate DataDir.
+  Log "physical cleanup finished; removing data directory $DataDir"
+  $script:logEnabled = $false
+  $lastError = $null
+  foreach ($attempt in 1..3) {
+    try {
+      if (Test-Path -LiteralPath $DataDir) {
+        Remove-Item -LiteralPath $DataDir -Recurse -Force -ErrorAction Stop
+      }
+      if (-not (Test-Path -LiteralPath $DataDir)) {
+        return
+      }
+      $lastError = "data directory still present after remove attempt $attempt"
+    } catch {
+      $lastError = $_.Exception.Message
+    }
+    if ($attempt -lt 3) {
+      Start-Sleep -Seconds 2
+    }
+  }
+
+  # Retain the approved uninstall log only when cleanup itself failed so
+  # Strict Cleanup can report the residue and an idempotent retry can remove it.
+  $script:logEnabled = $true
+  $detail = if ($lastError) { $lastError } else { "data directory still present: $DataDir" }
+  Add-CleanupFailure -code 'agent_data_cleanup_failed' -detail $detail -retained @($DataDir)
 }
 
 Log "detached uninstall script started install_dir=$install data_dir=$data keep_data=$keep"
@@ -244,12 +305,9 @@ try {
 
   $installCmd = Join-Path $install "install.cmd"
   $installPs1 = Join-Path $install "install.ps1"
-  $usedInstallCmd = $false
-  $installerSucceeded = $false
   $failureCountBefore = $cleanupFailures.Count
   try {
     if (Test-Path -LiteralPath $installCmd) {
-      $usedInstallCmd = $true
       Log "running install.cmd uninstall"
       $cmdLine = '"' + $installCmd + '" uninstall'
       if ($keep -eq '0') {
@@ -268,7 +326,6 @@ try {
         Stop-Or-ContinueAfterFailure
       } else {
         Log "install.cmd uninstall succeeded"
-        $installerSucceeded = $true
       }
       Remove-InstallDirectoryResidue -InstallDir $install
     } elseif (Test-Path -LiteralPath $installPs1) {
@@ -290,13 +347,12 @@ try {
         Stop-Or-ContinueAfterFailure
       } else {
         Log "install.ps1 uninstall succeeded"
-        $installerSucceeded = $true
       }
+      Remove-InstallDirectoryResidue -InstallDir $install
     } else {
       Log "install.cmd and install.ps1 missing; running fallback cleanup"
       sc.exe delete HyperFileLensAgent 2>$null | Out-Null
       Start-DeferredRemove $install
-      $installerSucceeded = $true
     }
   } catch {
     if ($cleanupFailures.Count -eq $failureCountBefore) {
@@ -306,18 +362,7 @@ try {
   }
 
   try {
-    if ($keep -eq '0' -and (-not $usedInstallCmd -or ($forceCleanup -and -not $installerSucceeded))) {
-      Start-DeferredRemove $data
-    } elseif ($keep -eq '1') {
-      Log "keep_data=1; preserved data directory $data"
-    }
-  } catch {
-    Add-CleanupFailure -code 'agent_data_cleanup_failed' -detail $_.Exception.Message -retained @('agent_data')
-    Stop-Or-ContinueAfterFailure
-  }
-
-  try {
-    $issues = @(Confirm-UninstallArtifacts -InstallDir $install -DataDir $data -KeepFlag $keep)
+    $issues = @(Confirm-UninstallArtifacts -InstallDir $install)
     if ($issues.Count -gt 0) {
       foreach ($issue in $issues) {
         Log "post-uninstall verify: $issue"
@@ -329,10 +374,18 @@ try {
     Stop-Or-ContinueAfterFailure
   }
 
-  if ($cleanupFailures.Count -gt 0) {
-    Log "detached uninstall script finished with cleanup residue"
+  if ($keep -eq '0') {
+    if ($cleanupFailures.Count -gt 0) {
+      Log "physical cleanup reached final data removal with recorded residue"
+    }
+    Remove-AgentDataDirectory -DataDir $data
   } else {
-    Log "detached uninstall script finished"
+    Log "keep_data=1; preserved data directory $data"
+    if ($cleanupFailures.Count -gt 0) {
+      Log "detached uninstall script finished with cleanup residue"
+    } else {
+      Log "detached uninstall script finished"
+    }
   }
 } catch {
   Log "detached uninstall script failed: $($_.Exception.Message)"

--- a/src/agent/internal/platform/install/local_uninstall_windows_test.go
+++ b/src/agent/internal/platform/install/local_uninstall_windows_test.go
@@ -3,7 +3,9 @@
 package install
 
 import (
+	"fmt"
 	"os"
+	"os/exec"
 	"strings"
 	"testing"
 )
@@ -35,7 +37,7 @@ func TestWriteWindowsUninstallScriptUsesUninstallLogAndInstallPs1(t *testing.T) 
 	}
 	body := string(raw)
 	for _, want := range []string{
-		UninstallLogPath(logDir),
+		`$logFile = ` + fmt.Sprintf("%q", UninstallLogPath(logDir)),
 		`install.cmd uninstall`,
 		`-PurgeAll`,
 		`Stop-HflProcessesForUninstall`,
@@ -43,6 +45,7 @@ func TestWriteWindowsUninstallScriptUsesUninstallLogAndInstallPs1(t *testing.T) 
 		`Remove-InstallDirectoryResidue`,
 		`removed residual install.cmd`,
 		`Confirm-UninstallArtifacts`,
+		`Confirm-UninstallArtifacts -InstallDir $install`,
 		`Get-Service -Name HyperFileLensAgent`,
 		`post-uninstall verify:`,
 		`install.cmd uninstall succeeded`,
@@ -56,6 +59,17 @@ func TestWriteWindowsUninstallScriptUsesUninstallLogAndInstallPs1(t *testing.T) 
 		`cleanup_failures = @($cleanupFailures)`,
 		`retained_resources = @($retainedResources)`,
 		`foreach ($attempt in 1..6)`,
+		`$logEnabled = $true`,
+		`if (-not $script:logEnabled)`,
+		`Test-SafeAgentDataPath`,
+		`$allowedRoot.TrimEnd('\') + '\'`,
+		`agent_data_cleanup_refused`,
+		`outside ProgramData\HyperFileLens`,
+		`Remove-AgentDataDirectory`,
+		`physical cleanup finished; removing data directory`,
+		`$script:logEnabled = $false`,
+		`Remove-Item -LiteralPath $DataDir -Recurse -Force -ErrorAction Stop`,
+		`Add-CleanupFailure -code 'agent_data_cleanup_failed'`,
 		`Remove-Item -LiteralPath $PSCommandPath`,
 		`"signed-test-token"`,
 	} {
@@ -66,6 +80,31 @@ func TestWriteWindowsUninstallScriptUsesUninstallLogAndInstallPs1(t *testing.T) 
 	if strings.Contains(body, ".install.out") {
 		t.Fatalf("script must not reference separate install output log:\n%s", body)
 	}
+	if strings.Contains(body, `$KeepFlag -eq '0'`) {
+		t.Fatalf("general artifact verification must run before final data cleanup:\n%s", body)
+	}
+	if count := strings.Count(body, `Remove-InstallDirectoryResidue -InstallDir $install`); count != 2 {
+		t.Fatalf("install.cmd and install.ps1 must share residue cleanup; got %d calls:\n%s", count, body)
+	}
+	dataCleanup := substringBetween(
+		t,
+		body,
+		"function Remove-AgentDataDirectory",
+		"Log \"detached uninstall script started",
+	)
+	assertOrdered(t, dataCleanup,
+		`Test-SafeAgentDataPath -DataDir $DataDir`,
+		`Log "physical cleanup finished; removing data directory $DataDir"`,
+		`$script:logEnabled = $false`,
+		`Remove-Item -LiteralPath $DataDir -Recurse -Force -ErrorAction Stop`,
+	)
+	assertOrdered(t, body,
+		`Confirm-UninstallArtifacts -InstallDir $install`,
+		`Remove-AgentDataDirectory -DataDir $data`,
+		`Report-UninstallCompletion`,
+	)
+	assertPowerShellParses(t, path)
+	assertPowerShellDataPathSafety(t, dir, body)
 }
 
 func TestWriteWindowsForceCleanupScriptContinuesAfterInstallerFailure(t *testing.T) {
@@ -97,8 +136,8 @@ func TestWriteWindowsForceCleanupScriptContinuesAfterInstallerFailure(t *testing
 		`install_cmd_uninstall_failed`,
 		`Stop-Or-ContinueAfterFailure`,
 		`Remove-InstallDirectoryResidue -InstallDir $install`,
-		`$forceCleanup -and -not $installerSucceeded`,
 		`Confirm-UninstallArtifacts`,
+		`Remove-AgentDataDirectory -DataDir $data`,
 		`Force Cleanup accepted the recorded uninstall residue`,
 	} {
 		if !strings.Contains(text, want) {
@@ -130,10 +169,105 @@ func TestWriteWindowsUninstallScriptKeepDataSkipsPurgeAll(t *testing.T) {
 		t.Fatalf("read script: %v", err)
 	}
 	text := string(body)
-	if strings.Contains(text, "-PurgeAll") {
-		t.Fatalf("keep_data script must not pass -PurgeAll:\n%s", text)
+	if !strings.Contains(text, `$keep = 1`) {
+		t.Fatalf("keep_data script missing keep flag:\n%s", text)
 	}
 	if !strings.Contains(text, "keep_data=1; preserved data directory") {
 		t.Fatalf("keep_data script missing preserve log line:\n%s", text)
+	}
+	assertOrdered(t, text,
+		`if ($keep -eq '0') {`,
+		`Remove-AgentDataDirectory -DataDir $data`,
+		`keep_data=1; preserved data directory`,
+	)
+}
+
+func assertOrdered(t *testing.T, body string, values ...string) {
+	t.Helper()
+	previous := -1
+	for _, value := range values {
+		index := strings.LastIndex(body, value)
+		if index < 0 {
+			t.Fatalf("script missing %q:\n%s", value, body)
+		}
+		if index <= previous {
+			t.Fatalf("script value %q is out of order:\n%s", value, body)
+		}
+		previous = index
+	}
+}
+
+func substringBetween(t *testing.T, body, startMarker, endMarker string) string {
+	t.Helper()
+	start := strings.Index(body, startMarker)
+	if start < 0 {
+		t.Fatalf("script missing start marker %q:\n%s", startMarker, body)
+	}
+	end := strings.Index(body[start:], endMarker)
+	if end < 0 {
+		t.Fatalf("script missing end marker %q:\n%s", endMarker, body)
+	}
+	return body[start : start+end]
+}
+
+func assertPowerShellParses(t *testing.T, path string) {
+	t.Helper()
+	command := fmt.Sprintf(`
+$tokens = $null
+$errors = $null
+[System.Management.Automation.Language.Parser]::ParseFile(%s, [ref]$tokens, [ref]$errors) | Out-Null
+if ($errors.Count -gt 0) {
+  $errors | ForEach-Object { [Console]::Error.WriteLine($_.Message) }
+  exit 1
+}
+`, psSingleQuote(path))
+	output, err := exec.Command(
+		"powershell.exe",
+		"-NoProfile",
+		"-NonInteractive",
+		"-Command",
+		command,
+	).CombinedOutput()
+	if err != nil {
+		t.Fatalf("generated uninstall script does not parse: %v\n%s", err, output)
+	}
+}
+
+func assertPowerShellDataPathSafety(t *testing.T, dir, body string) {
+	t.Helper()
+	safetyFunction := substringBetween(
+		t,
+		body,
+		"function Test-SafeAgentDataPath",
+		"function Remove-AgentDataDirectory",
+	)
+	testBody := safetyFunction + `
+$allowed = Join-Path $env:ProgramData 'HyperFileLens\Agent'
+$allowedChild = Join-Path $allowed 'custom'
+$vendorRoot = Join-Path $env:ProgramData 'HyperFileLens'
+$prefixCollision = Join-Path $env:ProgramData 'HyperFileLens-Other\Agent'
+$outside = Join-Path $env:SystemDrive 'Users'
+if (-not (Test-SafeAgentDataPath -DataDir $allowed)) { throw 'default Agent data path was rejected' }
+if (-not (Test-SafeAgentDataPath -DataDir $allowedChild)) { throw 'Agent data descendant was rejected' }
+if (Test-SafeAgentDataPath -DataDir $vendorRoot) { throw 'vendor root was accepted' }
+if (Test-SafeAgentDataPath -DataDir $prefixCollision) { throw 'prefix collision was accepted' }
+if (Test-SafeAgentDataPath -DataDir $outside) { throw 'outside path was accepted' }
+if (Test-SafeAgentDataPath -DataDir '') { throw 'empty path was accepted' }
+`
+	path := dir + "/test-data-path-safety.ps1"
+	if err := os.WriteFile(path, []byte(testBody), 0o644); err != nil {
+		t.Fatalf("write data path safety test: %v", err)
+	}
+	output, err := exec.Command(
+		"powershell.exe",
+		"-NoProfile",
+		"-NonInteractive",
+		"-ExecutionPolicy",
+		"Bypass",
+		"-File",
+		path,
+	).CombinedOutput()
+	if err != nil {
+		t.Fatalf("PowerShell data path safety test failed: %v\n%s", err, output)
 	}
 }

--- a/src/agent/internal/platform/install/uninstall_log_test.go
+++ b/src/agent/internal/platform/install/uninstall_log_test.go
@@ -2,6 +2,7 @@ package install
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -26,7 +27,7 @@ func TestAppendUninstallLogCreatesFile(t *testing.T) {
 
 func TestUninstallLogPath(t *testing.T) {
 	got := UninstallLogPath("/var/lib/hyperfilelens-agent/logs")
-	want := "/var/lib/hyperfilelens-agent/logs/uninstall.log"
+	want := filepath.Join("/var/lib/hyperfilelens-agent/logs", UninstallLogFileName)
 	if got != want {
 		t.Fatalf("UninstallLogPath() = %q, want %q", got, want)
 	}

--- a/src/agent/packaging/install/install.ps1
+++ b/src/agent/packaging/install/install.ps1
@@ -588,7 +588,11 @@ function Test-SafeDataPath([string]$path) {
   if ([string]::IsNullOrWhiteSpace($path)) { return $false }
   $full = try { [System.IO.Path]::GetFullPath($path) } catch { return $false }
   $pd = [System.IO.Path]::GetFullPath($env:ProgramData)
-  return $full.StartsWith($pd.TrimEnd('\') + '\HyperFileLens', [System.StringComparison]::OrdinalIgnoreCase)
+  $allowedRoot = Join-Path $pd "HyperFileLens"
+  return $full.TrimEnd('\').StartsWith(
+    $allowedRoot.TrimEnd('\') + '\',
+    [System.StringComparison]::OrdinalIgnoreCase
+  )
 }
 
 function Wait-HflServiceStopped {
@@ -689,7 +693,7 @@ function Schedule-InstallRootRemoval {
 function Write-Trace([string]`$msg) {
   if (-not `$logFile) { return }
   `$dir = Split-Path -Parent `$logFile
-  if (`$dir) { New-Item -ItemType Directory -Force -Path `$dir | Out-Null }
+  if (-not `$dir -or -not (Test-Path -LiteralPath `$dir)) { return }
   `$ts = [DateTime]::UtcNow.ToString('yyyy-MM-ddTHH:mm:ss.fffZ')
   Add-Content -LiteralPath `$logFile -Value "`$ts `$msg" -Encoding UTF8 -ErrorAction SilentlyContinue
 }
@@ -1154,7 +1158,9 @@ function Invoke-Uninstall {
     Write-HflSkip "remove data directory (none resolved)"
   }
 
-  $uninstallLog = if ($uninstallLogPath) { $uninstallLogPath } else { "" }
+  # PurgeAll removes the data directory that owns uninstall.log. The detached
+  # install-root remover must never recreate that directory after cleanup.
+  $uninstallLog = if (-not $PurgeAll -and $uninstallLogPath) { $uninstallLogPath } else { "" }
   Schedule-InstallRootRemoval -InstallRoot $InstallRoot -LogFile $uninstallLog
   }
   catch {


### PR DESCRIPTION
## Summary

- finalize Windows Agent data cleanup without recreating the uninstall log directory
- preserve safe-path boundaries and align install.cmd and install.ps1 fallback cleanup
- prevent deferred installer logging from recreating purged Agent data
- add Windows PowerShell syntax, path-safety, and packaging regression coverage

## Validation

- Linux install package tests pass without cache
- Windows install package tests pass
- Windows cross-compilation passes
- generated uninstall script and install.ps1 PowerShell syntax checks pass
- go vet passes for Linux and Windows
- git diff --check passes

Closes #113