### PR TITLE
fix(frontend): distinguish snapshot action labels

### DIFF
--- a/src/frontend/src/locales/enProtectionPages.ts
+++ b/src/frontend/src/locales/enProtectionPages.ts
@@ -995,6 +995,7 @@ export const enProtectionPages = {
     snapshotBrowserDirectories: 'Directory Snapshot Points',
     snapshotBrowserBackToSnapshots: 'Back to Directories',
     snapshotBrowserDirectorySnapshotId: 'Directory Snapshot ID',
+    snapshotViewAction: 'View',
     snapshotBrowserBrowse: 'Browse',
     snapshotBrowserFileDirCount: 'Files/Dirs',
     snapshotBrowserEmptyDirectories: 'No browsable directories for this snapshot',

--- a/src/frontend/src/pages/protection/components/FlowBackupSourceDetailDrawer.test.ts
+++ b/src/frontend/src/pages/protection/components/FlowBackupSourceDetailDrawer.test.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
+import { enProtectionPages } from '../../../locales/enProtectionPages'
 
 const drawer = readFileSync(resolve(process.cwd(), 'src/pages/protection/components/FlowBackupSourceDetailDrawer.vue'), 'utf8')
 
@@ -10,6 +11,20 @@ function sourceBetween(start: string, end: string) {
   expect(startIndex).toBeGreaterThanOrEqual(0)
   expect(endIndex).toBeGreaterThan(startIndex)
   return drawer.slice(startIndex, endIndex)
+}
+
+function buttonWithHandler(source: string, handler: string, marker: string) {
+  let handlerIndex = source.indexOf(handler)
+  while (handlerIndex >= 0) {
+    const startIndex = source.lastIndexOf('<button', handlerIndex)
+    const endIndex = source.indexOf('</button>', handlerIndex)
+    expect(startIndex).toBeGreaterThanOrEqual(0)
+    expect(endIndex).toBeGreaterThan(handlerIndex)
+    const button = source.slice(startIndex, endIndex)
+    if (button.includes(marker)) return button
+    handlerIndex = source.indexOf(handler, handlerIndex + handler.length)
+  }
+  throw new Error(`Unable to find button containing ${handler} and ${marker}`)
 }
 
 describe('FlowBackupSourceDetailDrawer task columns', () => {
@@ -32,6 +47,30 @@ describe('FlowBackupSourceDetailDrawer task columns', () => {
 })
 
 describe('FlowBackupSourceDetailDrawer snapshot expansion state', () => {
+  it('distinguishes viewing a snapshot from browsing a directory', () => {
+    const snapshotTab = sourceBetween(
+      '<el-tab-pane :label="t(\'protection.backupsPage.flowSourceDetailTabSnapshots\')" name="snapshots">',
+      '<el-tab-pane :label="t(\'protection.backupsPage.flowSourceDetailTabRestoreRecords\')" name="restoreRecords">',
+    )
+    const snapshotAction = buttonWithHandler(
+      snapshotTab,
+      '@click.stop="toggleSnapshot(row)"',
+      'snapshot-point-actions__button',
+    )
+    const directoryAction = buttonWithHandler(
+      snapshotTab,
+      '@click.stop="openSnapshotDirectory(dir)"',
+      'snapshot-point-actions__button',
+    )
+
+    expect(snapshotAction).toContain("t('protection.backupsPage.snapshotViewAction')")
+    expect(snapshotAction).not.toContain("t('protection.backupsPage.snapshotBrowserBrowse')")
+    expect(directoryAction).toContain("t('protection.backupsPage.snapshotBrowserBrowse')")
+    expect(directoryAction).not.toContain("t('protection.backupsPage.snapshotViewAction')")
+    expect(enProtectionPages.backupsPage.snapshotViewAction).toBe('View')
+    expect(enProtectionPages.backupsPage.snapshotBrowserBrowse).toBe('Browse')
+  })
+
   it('allocates enough width for both snapshot timestamps', () => {
     const snapshotTab = sourceBetween(
       '<el-tab-pane :label="t(\'protection.backupsPage.flowSourceDetailTabSnapshots\')" name="snapshots">',

--- a/src/frontend/src/pages/protection/components/FlowBackupSourceDetailDrawer.vue
+++ b/src/frontend/src/pages/protection/components/FlowBackupSourceDetailDrawer.vue
@@ -2961,11 +2961,11 @@ function onClosed() {
                     <button
                       type="button"
                       class="snapshot-point-actions__button snapshot-point-actions__button--browse"
-                      :title="t('protection.backupsPage.snapshotBrowserBrowse')"
+                      :title="t('protection.backupsPage.snapshotViewAction')"
                       @click.stop="toggleSnapshot(row)"
                     >
                       <FolderOpen :size="14" class="snapshot-point-actions__icon" aria-hidden="true" />
-                      <span>{{ t('protection.backupsPage.snapshotBrowserBrowse') }}</span>
+                      <span>{{ t('protection.backupsPage.snapshotViewAction') }}</span>
                     </button>
                   </div>
                 </template>


### PR DESCRIPTION
## Problem and root cause

The Snapshot Points table showed `Browse` for both the snapshot-detail toggle and the nested directory browser. These actions perform different operations, but the outer toggle reused the locale key intended for directory browsing.

## Solution

- Add a dedicated `View` label for the outer snapshot action.
- Keep the nested directory action labelled `Browse`.
- Add handler-specific regression coverage so the two actions cannot silently share copy again.

## Validation

- `npm ci` (Node.js 22.23.2, npm 10.9.8)
- `npm run test -- src/pages/protection/components/FlowBackupSourceDetailDrawer.test.ts` (5 tests passed)
- `npm run lint` (0 errors; existing repository warnings remain)
- `npm run test:ci -- --maxWorkers=1 --minWorkers=1` (112 files, 507 tests passed)
- `npm run build`
- `git diff --check origin/main...HEAD`
- `python3 tools/quality/check-english-source.py`

## Risks and compatibility

This changes only the English action copy; snapshot expansion, directory browsing, API calls, and eligibility rules are unchanged. Runtime language packs that do not yet define the new key will use the configured English fallback.

Fixes #199
