### PR TITLE
fix(frontend): notify for eventless task steps

### DIFF
--- a/src/frontend/src/locales/enProtectionPages.ts
+++ b/src/frontend/src/locales/enProtectionPages.ts
@@ -968,7 +968,7 @@ export const enProtectionPages = {
     flowSourceDetailStepsHint: 'All execution steps are expanded by default',
     flowSourceDetailExpandAll: 'Expand All',
     flowSourceDetailCollapseAll: 'Collapse All',
-    flowSourceDetailEmptyEvents: 'No Events',
+    flowSourceDetailEmptyEvents: 'No events are available for this step.',
     flowSourceDetailEmptySteps: 'No Execution Steps',
     flowSourceDetailEvents: 'Events',
     flowSourceDetailEmptyResources: 'No Related Resources',

--- a/src/frontend/src/pages/protection/components/FlowBackupSourceDetailDrawer.test.ts
+++ b/src/frontend/src/pages/protection/components/FlowBackupSourceDetailDrawer.test.ts
@@ -3,6 +3,7 @@ import { resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
 
 const drawer = readFileSync(resolve(process.cwd(), 'src/pages/protection/components/FlowBackupSourceDetailDrawer.vue'), 'utf8')
+const protectionMessages = readFileSync(resolve(process.cwd(), 'src/locales/enProtectionPages.ts'), 'utf8')
 
 function sourceBetween(start: string, end: string) {
   const startIndex = drawer.indexOf(start)
@@ -63,5 +64,26 @@ describe('FlowBackupSourceDetailDrawer snapshot expansion state', () => {
     expect(paginationWatcher).toContain('selectedSnapshotId.value = null')
     expect(paginationWatcher).toContain('expandedSnapshotRowKeys.value = []')
     expect(paginationWatcher).toContain('snapshotDetails.value = new Map()')
+  })
+})
+
+describe('FlowBackupSourceDetailDrawer task step expansion feedback', () => {
+  it('notifies without expanding when a task step has no events', () => {
+    const toggleStep = sourceBetween(
+      'function toggleStep(stepId: number | string, eventCount: number)',
+      'function setAllStepsExpanded',
+    )
+    const taskSteps = sourceBetween(
+      '<div v-if="stepsWithEvents.length" class="dp-task-detail__step-list">',
+      '<div v-if="unlinkedTaskEvents.length > 0"',
+    )
+
+    expect(toggleStep).toContain('if (eventCount === 0)')
+    expect(toggleStep).toContain("ElMessage.info({ message: t('protection.backupsPage.flowSourceDetailEmptyEvents'), grouping: true })")
+    expect(toggleStep.indexOf('return')).toBeLessThan(toggleStep.indexOf('expandedTaskSteps[key]'))
+    expect(taskSteps).toContain(':aria-expanded="step.events.length > 0 && isStepExpanded(step.id)"')
+    expect(taskSteps).toContain('@click="toggleStep(step.id, step.events.length)"')
+    expect(taskSteps).toContain('v-if="step.events.length > 0 && isStepExpanded(step.id)"')
+    expect(protectionMessages).toContain("flowSourceDetailEmptyEvents: 'No events are available for this step.'")
   })
 })

--- a/src/frontend/src/pages/protection/components/FlowBackupSourceDetailDrawer.vue
+++ b/src/frontend/src/pages/protection/components/FlowBackupSourceDetailDrawer.vue
@@ -1266,7 +1266,11 @@ function isStepExpanded(stepId: number | string) {
   return expandedTaskSteps[stepKey(stepId)] !== false
 }
 
-function toggleStep(stepId: number | string) {
+function toggleStep(stepId: number | string, eventCount: number) {
+  if (eventCount === 0) {
+    ElMessage.info({ message: t('protection.backupsPage.flowSourceDetailEmptyEvents'), grouping: true })
+    return
+  }
   const key = stepKey(stepId)
   expandedTaskSteps[key] = !isStepExpanded(key)
 }
@@ -3841,7 +3845,12 @@ function onClosed() {
             </div>
 
             <article class="dp-task-detail__step-card">
-              <button type="button" class="dp-task-detail__step-card-head" @click="toggleStep(step.id)">
+              <button
+                type="button"
+                class="dp-task-detail__step-card-head"
+                :aria-expanded="step.events.length > 0 && isStepExpanded(step.id)"
+                @click="toggleStep(step.id, step.events.length)"
+              >
                 <span class="dp-task-detail__step-title">
                   {{ stepDisplayName(step.step_name, activeTask.task_type) }}
                   <span class="dp-task-detail__step-executed-at">{{ formatNullableTime(step.created_at || activeTask.created_at) }}</span>
@@ -3851,11 +3860,11 @@ function onClosed() {
                   <Clock3 :size="12" />
                   {{ stepDuration(si) }}
                 </span>
-                <ChevronDown v-if="isStepExpanded(step.id)" :size="16" class="hfl-task-step-chevron" />
+                <ChevronDown v-if="step.events.length > 0 && isStepExpanded(step.id)" :size="16" class="hfl-task-step-chevron" />
                 <ChevronRight v-else :size="16" class="hfl-task-step-chevron" />
               </button>
 
-              <div v-if="isStepExpanded(step.id) && step.events.length > 0" class="dp-task-detail__event-list">
+              <div v-if="step.events.length > 0 && isStepExpanded(step.id)" class="dp-task-detail__event-list">
                 <div v-for="event in step.events" :key="event.id" class="dp-task-detail__event-row">
                   <span class="dp-task-detail__event-dot" :class="`dp-task-detail__event-dot--${eventTone(event)}`">
                     <X v-if="eventTone(event) === 'danger'" :size="9" />


### PR DESCRIPTION
## Problem and root cause

Task steps in the Backup Wizard detail drawer always exposed an expand control,
but the detail body was rendered only when events existed. Clicking an
eventless step therefore changed internal expansion state without showing any
content or feedback, which made the control appear unresponsive.

## Solution

- Keep eventful task steps on the existing expand/collapse path.
- Leave eventless steps visually collapsed and show a grouped informational
  toast when their expand control is clicked.
- Keep the chevron and `aria-expanded` state aligned with the collapsed result.
- Replace the unused inline-style empty copy with concise toast copy and add
  regression coverage for the eventless interaction.

## Validation

- `npm run test -- src/pages/protection/components/FlowBackupSourceDetailDrawer.test.ts` (5 tests passed)
- `npm run test:ci` (112 test files and 507 tests passed on native Node.js 22)
- `npm run lint` (0 errors; 17,091 existing warnings)
- `npm run build` (passed; existing Rollup annotation, dynamic-import, and chunk-size warnings only)
- `git diff --check`
- `python3 tools/quality/check-english-source.py`

## Risks and compatibility

This is a presentation-only change with no API, persistence, permission, or
task-event contract changes. Historical eventless steps now provide immediate
feedback, while steps with events retain their existing behavior. Repeated
clicks use the shared toast grouping behavior to avoid stacking identical
messages.

Fixes #207
