### PR TITLE
feat: add production-scoped Google Analytics

### DIFF
--- a/.github/workflows/artifact_pipeline.yml
+++ b/.github/workflows/artifact_pipeline.yml
@@ -223,6 +223,7 @@ jobs:
           ./tools/quality/test-release-download-proxy.sh
           ./tools/quality/test-deployment-optional-config.sh
           ./tools/quality/test-website-runtime-config.sh
+          ./tools/quality/test-ga-runtime-config.sh
           ./tools/quality/test-payload-tree-hash.sh
           ./tools/quality/test-ci-release-assembly.sh
           HFL_TEST_VERSION=main-0123456 ./tools/quality/test-ci-release-assembly.sh

--- a/.github/workflows/deploy_target.yml
+++ b/.github/workflows/deploy_target.yml
@@ -71,6 +71,11 @@ on:
         required: false
         default: ''
         type: string
+      ga_measurement_id:
+        description: Optional GA4 measurement ID for the official SaaS deployment
+        required: false
+        default: ''
+        type: string
       platform_gateway_auto_deploy:
         description: Automatically deploy an HFL-managed local platform Gateway
         required: false
@@ -175,6 +180,7 @@ jobs:
           GOOGLE_OAUTH_ENABLED: ${{ inputs.google_oauth_enabled }}
           GOOGLE_CLIENT_ID: ${{ inputs.google_client_id }}
           GOOGLE_CLIENT_SECRET: ${{ secrets.google_client_secret }}
+          GA_MEASUREMENT_ID: ${{ inputs.ga_measurement_id }}
           TURNSTILE_ENABLED: ${{ inputs.turnstile_enabled }}
           TURNSTILE_SITE_KEY: ${{ inputs.turnstile_site_key }}
           TURNSTILE_SECRET_KEY: ${{ secrets.turnstile_secret_key }}
@@ -266,6 +272,9 @@ jobs:
               echo '::warning title=Google OAuth configuration::Google OAuth settings are missing or malformed; deployment will preserve the installed Google configuration.'
             fi
           fi
+          if [[ "$DEPLOY_TARGET" != "prod" && -n "$GA_MEASUREMENT_ID" ]]; then
+            echo '::warning title=Google Analytics configuration::Analytics is only supported for the production SaaS target; the supplied value will be ignored.'
+          fi
           if [[ "$TURNSTILE_ENABLED" == "true" ]] \
             && { [[ -z "$TURNSTILE_SITE_KEY" ]] || [[ -z "$TURNSTILE_SECRET_KEY" ]]; }; then
             echo '::warning title=Turnstile configuration::Turnstile is enabled without complete credentials; deployment will continue.'
@@ -305,6 +314,7 @@ jobs:
 
       - name: Stage Runtime Configuration
         env:
+          DEPLOY_TARGET: ${{ inputs.target }}
           HFL_INSECURE_TLS: ${{ inputs.hfl_insecure_tls }}
           HFL_PLATFORM_GATEWAY_AUTO_DEPLOY: ${{ inputs.platform_gateway_auto_deploy }}
           TURNSTILE_SITE_KEY: ${{ inputs.turnstile_site_key }}
@@ -318,6 +328,7 @@ jobs:
           EMAIL_FROM: ${{ inputs.email_from }}
           HFL_EMAIL_SIGNUP_ENABLED: ${{ inputs.email_signup_enabled }}
           HFL_GOOGLE_OAUTH_ENABLED: ${{ inputs.google_oauth_enabled }}
+          HFL_GA_MEASUREMENT_ID: ${{ inputs.ga_measurement_id }}
           GOOGLE_CLIENT_ID: ${{ inputs.google_client_id }}
           GOOGLE_CLIENT_SECRET: ${{ secrets.google_client_secret }}
         shell: bash
@@ -329,11 +340,14 @@ jobs:
           python3 - "$runtime_env" <<'PY'
           import os
           import pathlib
+          import re
           import sys
 
+          ga4_measurement_id_pattern = re.compile(r"^G-[A-Z0-9]+$")
           names = (
               "HFL_EMAIL_SIGNUP_ENABLED",
               "HFL_GOOGLE_OAUTH_ENABLED",
+              "HFL_GA_MEASUREMENT_ID",
               "HFL_INSECURE_TLS",
               "HFL_PLATFORM_GATEWAY_AUTO_DEPLOY",
               "TURNSTILE_ENABLED",
@@ -351,6 +365,25 @@ jobs:
           lines = []
           for name in names:
               value = os.environ.get(name, "")
+              if name == "HFL_GA_MEASUREMENT_ID":
+                  if os.environ.get("DEPLOY_TARGET") != "prod":
+                      value = ""
+                  else:
+                      candidate = value.strip(" \t")
+                      if value and (
+                          "\r" in value
+                          or "\n" in value
+                          or "\x00" in value
+                          or not ga4_measurement_id_pattern.fullmatch(candidate)
+                      ):
+                          print(
+                              "::warning title=Google Analytics configuration::"
+                              "Invalid GA4 measurement ID; analytics will be disabled "
+                              "and deployment will continue."
+                          )
+                          value = ""
+                      else:
+                          value = candidate
               if "\r" in value or "\n" in value or "\x00" in value:
                   print(
                       f"::warning title=Optional deployment configuration::{name} "

--- a/.github/workflows/production_deploy.yml
+++ b/.github/workflows/production_deploy.yml
@@ -79,6 +79,7 @@ jobs:
       email_signup_enabled: ${{ vars.PROD_EMAIL_SIGNUP_ENABLED == 'true' }}
       google_oauth_enabled: ${{ vars.PROD_GOOGLE_OAUTH_ENABLED == 'true' }}
       google_client_id: ${{ vars.PROD_GOOGLE_CLIENT_ID }}
+      ga_measurement_id: ${{ vars.PROD_GA_MEASUREMENT_ID }}
       platform_gateway_auto_deploy: ${{ vars.PROD_PLATFORM_GATEWAY_AUTO_DEPLOY == 'true' }}
       hfl_insecure_tls: ${{ vars.PROD_HFL_INSECURE_TLS }}
       smtp_host: ${{ vars.PROD_SMTP_HOST }}

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -182,6 +182,7 @@ services:
     environment:
       TZ: UTC
       HFL_WEBSITE_APP_URL: ${FRONTEND_URL:-}
+      HFL_GA_MEASUREMENT_ID: ${HFL_GA_MEASUREMENT_ID:-}
       LOGROTATE_INTERVAL_SECONDS: "3600"
       LOGROTATE_STATE: /var/log/hyperfilelens/.logrotate.status
       LOGROTATE_LOCK: /var/log/hyperfilelens/.logrotate.lock

--- a/deploy/docker/frontend-runtime-config.sh
+++ b/deploy/docker/frontend-runtime-config.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+# Generate site-specific public runtime configuration before Nginx starts.
+set -eu
+
+website_output=${HFL_WEBSITE_CONFIG_OUTPUT:-/usr/share/nginx/website/website-runtime-config.js}
+tenant_output=${HFL_TENANT_CONFIG_OUTPUT:-/usr/share/nginx/runtime/tenant-app-runtime-config.js}
+admin_output=${HFL_ADMIN_CONFIG_OUTPUT:-/usr/share/nginx/runtime/admin-app-runtime-config.js}
+app_url=${HFL_WEBSITE_APP_URL:-}
+ga_measurement_id=${HFL_GA_MEASUREMENT_ID:-}
+
+if [ -n "${app_url}" ] && ! printf '%s' "${app_url}" \
+  | grep -Eq '^[Hh][Tt][Tt][Pp][Ss]?://(\[[0-9A-Fa-f:]+\]|[A-Za-z0-9.-]+)(:[0-9]{1,5})?/?$'; then
+  printf '%s\n' '[frontend-config] WARNING: invalid app URL; using the browser host and port 11443 fallback' >&2
+  app_url=
+fi
+
+if [ -n "${ga_measurement_id}" ] && ! printf '%s' "${ga_measurement_id}" \
+  | grep -Eq '^G-[A-Z0-9]+$'; then
+  printf '%s\n' '[frontend-config] WARNING: invalid GA4 measurement ID; analytics is disabled' >&2
+  ga_measurement_id=
+fi
+
+write_config() {
+  output=$1
+  content=$2
+  temporary="${output}.tmp.$$"
+  mkdir -p "$(dirname "${output}")"
+  umask 022
+  printf '%s\n' "${content}" > "${temporary}"
+  mv -f "${temporary}" "${output}"
+}
+
+write_config "${website_output}" \
+  "window.__HFL_WEBSITE_CONFIG__ = Object.freeze({ appUrl: '${app_url%/}', gaMeasurementId: '${ga_measurement_id}' })"
+write_config "${tenant_output}" \
+  "window.__HFL_APP_CONFIG__ = Object.freeze({ gaMeasurementId: '${ga_measurement_id}' })"
+# Platform Operations and Django Admin must never emit SaaS analytics.
+write_config "${admin_output}" \
+  "window.__HFL_APP_CONFIG__ = Object.freeze({ gaMeasurementId: '' })"

--- a/deploy/docker/frontend.Dockerfile
+++ b/deploy/docker/frontend.Dockerfile
@@ -64,10 +64,11 @@ COPY deploy/nginx/default.conf /etc/nginx/conf.d/default.conf
 COPY deploy/nginx/snippets /etc/nginx/snippets
 COPY deploy/logrotate/hyperfilelens.conf /etc/logrotate.d/hyperfilelens
 COPY deploy/docker/frontend-logrotate-loop.sh /usr/local/bin/logrotate-loop.sh
-COPY build/website/runtime-config.sh /docker-entrypoint.d/20-hfl-website-runtime-config.sh
+COPY deploy/docker/frontend-runtime-config.sh /docker-entrypoint.d/20-hfl-frontend-runtime-config.sh
 
-RUN chmod 0644 /etc/logrotate.d/hyperfilelens \
- && chmod 0755 /usr/local/bin/logrotate-loop.sh /docker-entrypoint.d/20-hfl-website-runtime-config.sh \
+RUN mkdir -p /usr/share/nginx/runtime \
+ && chmod 0644 /etc/logrotate.d/hyperfilelens \
+ && chmod 0755 /usr/local/bin/logrotate-loop.sh /docker-entrypoint.d/20-hfl-frontend-runtime-config.sh \
  && printf '%s\n' '#!/bin/sh' 'exec /usr/local/bin/logrotate-loop.sh --daemon' \
     > /docker-entrypoint.d/99-logrotate-loop.sh \
  && chmod 0755 /docker-entrypoint.d/99-logrotate-loop.sh

--- a/deploy/installer/apply-runtime-config.py
+++ b/deploy/installer/apply-runtime-config.py
@@ -7,13 +7,14 @@ import pathlib
 import re
 import stat
 import tempfile
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Set, Tuple
 from urllib.parse import SplitResult, urlsplit, urlunsplit
 
 
 RUNTIME_KEYS = {
     "HFL_EMAIL_SIGNUP_ENABLED",
     "HFL_GOOGLE_OAUTH_ENABLED",
+    "HFL_GA_MEASUREMENT_ID",
     "HFL_INSECURE_TLS",
     "HFL_PLATFORM_GATEWAY_AUTO_DEPLOY",
     "TURNSTILE_ENABLED",
@@ -32,6 +33,7 @@ KEY_PATTERN = re.compile(r"^[A-Za-z0-9_-]+$")
 GOOGLE_CLIENT_ID_PATTERN = re.compile(
     r"^[0-9]+-[A-Za-z0-9_-]+\.apps\.googleusercontent\.com$"
 )
+GA4_MEASUREMENT_ID_PATTERN = re.compile(r"^G-[A-Z0-9]+$")
 
 
 def warn(message: str) -> None:
@@ -191,6 +193,19 @@ def google_runtime_updates(values: Dict[str, str]) -> Dict[str, str]:
     }
 
 
+def analytics_runtime_update(values: Dict[str, str]) -> Tuple[bool, str]:
+    """Return whether SaaS analytics was staged and its validated ID."""
+    if "HFL_GA_MEASUREMENT_ID" not in values:
+        return False, ""
+    measurement_id = values.get("HFL_GA_MEASUREMENT_ID", "").strip()
+    if not measurement_id:
+        return True, ""
+    if not GA4_MEASUREMENT_ID_PATTERN.fullmatch(measurement_id):
+        warn("invalid GA4 measurement ID; analytics is disabled")
+        return True, ""
+    return True, measurement_id
+
+
 def turnstile_runtime_updates(values: Dict[str, str]) -> Dict[str, str]:
     """Apply Turnstile atomically without replacing usable installed credentials."""
     enabled = values.get("TURNSTILE_ENABLED", "").strip().lower()
@@ -264,6 +279,7 @@ def apply_configuration(
             current[key] = value
 
     updates: Dict[str, str] = {}
+    removals: Set[str] = set()
     runtime_values = read_runtime_values(runtime_path)
     if runtime_path is not None:
         signup_enabled = runtime_values.get("HFL_EMAIL_SIGNUP_ENABLED", "").lower()
@@ -277,6 +293,12 @@ def apply_configuration(
         updates["HFL_INSECURE_TLS"] = insecure_tls
         updates.update(smtp_runtime_updates(runtime_values))
         updates.update(google_runtime_updates(runtime_values))
+        analytics_staged, measurement_id = analytics_runtime_update(runtime_values)
+        if analytics_staged:
+            if measurement_id:
+                updates["HFL_GA_MEASUREMENT_ID"] = measurement_id
+            else:
+                removals.add("HFL_GA_MEASUREMENT_ID")
 
         gateway_enabled = runtime_values.get(
             "HFL_PLATFORM_GATEWAY_AUTO_DEPLOY", ""
@@ -360,6 +382,8 @@ def apply_configuration(
     seen = set()
     for line in lines:
         key = line.split("=", 1)[0] if "=" in line else ""
+        if key in removals:
+            continue
         if key in updates:
             value = updates[key]
             if key in {"EMAIL_HOST_PASSWORD", "GOOGLE_CLIENT_SECRET"}:

--- a/deploy/nginx/snippets/hfl-ops-spa-locations.conf
+++ b/deploy/nginx/snippets/hfl-ops-spa-locations.conf
@@ -1,5 +1,10 @@
 # Platform Operations production SPA routes.
 
+    location = /app-runtime-config.js {
+        alias /usr/share/nginx/runtime/admin-app-runtime-config.js;
+        add_header Cache-Control "no-store";
+    }
+
     location ^~ /assets/ {
         root /usr/share/nginx/html;
         try_files $uri =404;

--- a/deploy/nginx/snippets/hfl-tenant-spa-locations.conf
+++ b/deploy/nginx/snippets/hfl-tenant-spa-locations.conf
@@ -1,5 +1,10 @@
 # Tenant-facing production SPA routes.
 
+    location = /app-runtime-config.js {
+        alias /usr/share/nginx/runtime/tenant-app-runtime-config.js;
+        add_header Cache-Control "no-store";
+    }
+
     # Vite emits immutable, content-hashed files here. Do not send a missing
     # module request to the SPA fallback: browsers then receive index.html as
     # text/html and cannot report the real missing-resource condition.

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -112,6 +112,7 @@
         </div>
       </div>
     </div>
+    <script src="/app-runtime-config.js"></script>
     <script type="module" src="/src/main.ts"></script>
   </body>
 </html>

--- a/src/frontend/public/app-runtime-config.js
+++ b/src/frontend/public/app-runtime-config.js
@@ -1,0 +1,1 @@
+window.__HFL_APP_CONFIG__ = Object.freeze({ gaMeasurementId: '' })

--- a/src/frontend/src/lib/analytics.test.ts
+++ b/src/frontend/src/lib/analytics.test.ts
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { RouteLocationNormalizedLoaded, Router } from 'vue-router'
+
+function route(path: string, ...recordPaths: string[]): RouteLocationNormalizedLoaded {
+  return {
+    path,
+    fullPath: path,
+    matched: (recordPaths.length ? recordPaths : [path]).map((recordPath) => ({
+      path: recordPath,
+    })),
+  } as RouteLocationNormalizedLoaded
+}
+
+async function loadAnalytics(measurementId = '') {
+  vi.resetModules()
+  window.__HFL_APP_CONFIG__ = { gaMeasurementId: measurementId }
+  const afterEach = vi.fn()
+  const analytics = await import('./analytics')
+  analytics.initAppAnalytics({ afterEach } as unknown as Router)
+  return { analytics, afterEach }
+}
+
+afterEach(() => {
+  document.head.querySelectorAll('script[data-hfl-google-analytics]').forEach((node) => node.remove())
+  delete window.__HFL_APP_CONFIG__
+  delete window.dataLayer
+  delete window.gtag
+  vi.restoreAllMocks()
+})
+
+describe('runtime Google Analytics', () => {
+  it('does not load Google when the SaaS runtime variable is absent', async () => {
+    const { afterEach } = await loadAnalytics()
+
+    expect(afterEach).not.toHaveBeenCalled()
+    expect(document.querySelector('script[data-hfl-google-analytics]')).toBeNull()
+    expect(window.gtag).toBeUndefined()
+  })
+
+  it('warns and remains disabled for an invalid measurement ID', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const { afterEach } = await loadAnalytics('not-a-measurement-id')
+
+    expect(warn).toHaveBeenCalledWith(
+      '[analytics] Invalid GA4 measurement ID; analytics is disabled.',
+    )
+    expect(afterEach).not.toHaveBeenCalled()
+    expect(document.querySelector('script[data-hfl-google-analytics]')).toBeNull()
+  })
+
+  it('loads gtag and reports only the route template without query or resource IDs', async () => {
+    const { analytics, afterEach } = await loadAnalytics('G-0RX9GZJCWF')
+    const hook = afterEach.mock.calls[0]?.[0] as (to: RouteLocationNormalizedLoaded) => void
+
+    expect(document.querySelector<HTMLScriptElement>('script[data-hfl-google-analytics]')?.src)
+      .toBe('https://www.googletagmanager.com/gtag/js?id=G-0RX9GZJCWF')
+    hook(route(
+      '/protection/backups/customer-backup?token=secret',
+      '/',
+      'protection/backups/:backupId',
+    ))
+
+    expect(window.dataLayer).toEqual(expect.arrayContaining([
+      ['config', 'G-0RX9GZJCWF', { send_page_view: false }],
+      ['event', 'page_view', expect.objectContaining({
+        page_location: `${window.location.origin}/protection/backups/:backupId`,
+        page_path: '/protection/backups/:backupId',
+        page_title: 'HyperFileLens',
+      })],
+    ]))
+    expect(JSON.stringify(window.dataLayer)).not.toContain('customer-backup')
+    expect(JSON.stringify(window.dataLayer)).not.toContain('secret')
+
+    window.history.replaceState({}, '', '/register?email=person@example.com')
+    analytics.trackAppEvent('sign_up', { method: 'email' })
+    expect(window.dataLayer).toContainEqual([
+      'event',
+      'sign_up',
+      expect.objectContaining({
+        method: 'email',
+        page_location: `${window.location.origin}/protection/backups/:backupId`,
+        page_path: '/protection/backups/:backupId',
+      }),
+    ])
+    expect(JSON.stringify(window.dataLayer)).not.toContain('person@example.com')
+  })
+})

--- a/src/frontend/src/lib/analytics.ts
+++ b/src/frontend/src/lib/analytics.ts
@@ -1,0 +1,103 @@
+import type { RouteLocationNormalizedLoaded, Router } from 'vue-router'
+
+type GoogleTag = (...args: unknown[]) => void
+type AppAnalyticsEvent = 'login' | 'sign_up' | 'sign_up_started'
+type AppAnalyticsParameters = { method: 'email' | 'google' }
+
+declare global {
+  interface Window {
+    __HFL_APP_CONFIG__?: { gaMeasurementId?: string }
+    dataLayer?: unknown[]
+    gtag?: GoogleTag
+  }
+}
+
+const GA4_MEASUREMENT_ID = /^G-[A-Z0-9]+$/
+const GOOGLE_TAG_SCRIPT = 'script[data-hfl-google-analytics]'
+
+let activeMeasurementId = ''
+let activePagePath = '/'
+
+function configuredMeasurementId(): string {
+  return String(window.__HFL_APP_CONFIG__?.gaMeasurementId || '').trim()
+}
+
+function sanitizedReferrer(): string {
+  const value = document.referrer.trim()
+  if (!value) return ''
+  try {
+    const parsed = new URL(value)
+    return parsed.origin
+  } catch {
+    return ''
+  }
+}
+
+export function analyticsRoutePath(
+  route: Pick<RouteLocationNormalizedLoaded, 'matched' | 'path'>,
+): string {
+  const matchedPath = route.matched.reduce((path, record) => {
+    const segment = record.path.trim()
+    if (!segment) return path
+    if (segment.startsWith('/')) return segment
+    return `${path.replace(/\/$/, '')}/${segment}`
+  }, '')
+  const path = matchedPath || route.path || '/'
+  return path.startsWith('/') ? path : `/${path}`
+}
+
+function trackPageView(path: string): void {
+  if (!activeMeasurementId || !window.gtag) return
+  activePagePath = path
+  window.gtag('event', 'page_view', {
+    page_location: `${window.location.origin}${path}`,
+    page_path: path,
+    page_referrer: sanitizedReferrer(),
+    page_title: 'HyperFileLens',
+  })
+}
+
+export function trackAppEvent(
+  name: AppAnalyticsEvent,
+  parameters: AppAnalyticsParameters,
+): void {
+  if (!activeMeasurementId || !window.gtag) return
+  window.gtag('event', name, {
+    ...parameters,
+    page_location: `${window.location.origin}${activePagePath}`,
+    page_path: activePagePath,
+    page_referrer: sanitizedReferrer(),
+    page_title: 'HyperFileLens',
+  })
+}
+
+function installGoogleTag(measurementId: string): boolean {
+  if (!measurementId) return false
+  if (!GA4_MEASUREMENT_ID.test(measurementId)) {
+    console.warn('[analytics] Invalid GA4 measurement ID; analytics is disabled.')
+    return false
+  }
+  if (activeMeasurementId === measurementId) return true
+
+  activeMeasurementId = measurementId
+  window.dataLayer = window.dataLayer || []
+  window.gtag = function gtag(...args: unknown[]) {
+    window.dataLayer?.push(args)
+  }
+  window.gtag('js', new Date())
+  window.gtag('config', measurementId, { send_page_view: false })
+
+  if (!document.querySelector(GOOGLE_TAG_SCRIPT)) {
+    const script = document.createElement('script')
+    script.async = true
+    script.dataset.hflGoogleAnalytics = 'true'
+    script.src = `https://www.googletagmanager.com/gtag/js?id=${encodeURIComponent(measurementId)}`
+    document.head.appendChild(script)
+  }
+  return true
+}
+
+export function initAppAnalytics(router: Router): void {
+  if (!installGoogleTag(configuredMeasurementId())) return
+  router.afterEach((route) => trackPageView(analyticsRoutePath(route)))
+}

--- a/src/frontend/src/main.ts
+++ b/src/frontend/src/main.ts
@@ -22,10 +22,12 @@ import { setupElementPlus } from './plugins/element-plus'
 import { setLocale } from './lib/api'
 import { setupAuthGuard, setupSessionWatchdog } from './composables/useAuth'
 import { initSentry } from './lib/sentry'
+import { initAppAnalytics } from './lib/analytics'
 
 function bootstrap() {
   const app = createApp(App)
   initSentry(app, router)
+  initAppAnalytics(router)
   app.use(i18n)
   app.use(router)
   setupElementPlus(app)

--- a/src/frontend/src/pages/auth/Login.vue
+++ b/src/frontend/src/pages/auth/Login.vue
@@ -15,6 +15,7 @@ import ResetPasswordCard from '../../components/auth/ResetPasswordCard.vue'
 import { fetchDeployProfile, resolvePostLoginPath } from '../../composables/useDeployProfile'
 import { appConfig } from '../../lib/appConfig'
 import { resolveSafeLoginRedirect } from '../../lib/loginNavigation'
+import { trackAppEvent } from '../../lib/analytics'
 import {
   consumeSessionNotice,
   sessionNoticeMessageKey,
@@ -326,6 +327,7 @@ async function handleSubmit() {
     if (res.data.user) {
       setUser(res.data.user)
     }
+    trackAppEvent('login', { method: 'email' })
     router.push(await resolveLoginTargetPath())
   } catch (err: unknown) {
     const errObj = err as { status?: number; message?: string; errorCode?: string; code?: string; fields?: Record<string, string[]> }
@@ -385,6 +387,7 @@ async function completeLoginWithOrg(orgKey: string) {
     setStoredOrgKey(orgKey)
     await fetchCurrentUser()
 
+    trackAppEvent('login', { method: 'email' })
     router.push(await resolveLoginTargetPath())
   } catch (err: unknown) {
     const errObj = err as { message?: string; status?: number }

--- a/src/frontend/src/pages/auth/OAuthCallback.vue
+++ b/src/frontend/src/pages/auth/OAuthCallback.vue
@@ -6,6 +6,7 @@ import { ElMessage } from 'element-plus'
 
 import { fetchCurrentUser, setStoredOrgKey } from '../../composables/useAuth'
 import { resolvePostLoginPath } from '../../composables/useDeployProfile'
+import { trackAppEvent } from '../../lib/analytics'
 
 const { t } = useI18n()
 const route = useRoute()
@@ -22,6 +23,7 @@ onMounted(async () => {
   loading.value = false
 
   if (user) {
+    trackAppEvent('login', { method: 'google' })
     router.replace(await resolvePostLoginPath())
     return
   }

--- a/src/frontend/src/pages/auth/Register.vue
+++ b/src/frontend/src/pages/auth/Register.vue
@@ -11,6 +11,7 @@ import AuthBackdrop from '../../components/auth/AuthBackdrop.vue'
 import AuthBrandPanel from '../../components/auth/AuthBrandPanel.vue'
 import AuthTurnstileField from '../../components/auth/AuthTurnstileField.vue'
 import { appConfig } from '../../lib/appConfig'
+import { trackAppEvent } from '../../lib/analytics'
 
 const { t, locale } = useI18n()
 const {
@@ -388,6 +389,7 @@ async function handleSubmit() {
     })
 
     if (res.code === '0000') {
+      trackAppEvent('sign_up', { method: 'email' })
       registerSuccess.value = true
     } else if (res.error?.fields) {
       applyRegisterFieldsError(res.error.fields as Record<string, string[]>)
@@ -416,6 +418,7 @@ function toggleLocale() {
 }
 
 onMounted(async () => {
+  trackAppEvent('sign_up_started', { method: 'email' })
   turnstileToken.value = ''
   restoreCooldown()
   await loadTurnstileConfig()

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -609,6 +609,7 @@ grep -F 'HFL_PLATFORM_GATEWAY_AUTO_DEPLOY=false' "${ROOT}/.env.example" >/dev/nu
 grep -F 'com.hyperfilelens.component: "gateway-lensnode"' \
 	"${ROOT}/deploy/bootstrap/gateway-install-lensnode-sidecar.sh" >/dev/null
 grep -F './tools/quality/test-deployment-optional-config.sh' "${workflow}" >/dev/null
+grep -F './tools/quality/test-ga-runtime-config.sh' "${workflow}" >/dev/null
 grep -F './tools/quality/test-payload-tree-hash.sh' "${workflow}" >/dev/null
 grep -F 'Verify Internal Health' "${ROOT}/.github/workflows/deploy_target.yml" >/dev/null
 grep -F 'https://127.0.0.1:11443/health/ready' \
@@ -766,7 +767,7 @@ for listener in 11442 11443 11444; do
 done
 grep -F 'COPY build/website/public /usr/share/nginx/website' \
 	"${ROOT}/deploy/docker/frontend.Dockerfile" >/dev/null
-grep -F 'COPY build/website/runtime-config.sh /docker-entrypoint.d/20-hfl-website-runtime-config.sh' \
+grep -F 'COPY deploy/docker/frontend-runtime-config.sh /docker-entrypoint.d/20-hfl-frontend-runtime-config.sh' \
 	"${ROOT}/deploy/docker/frontend.Dockerfile" >/dev/null
 if grep -F 'COPY website/' "${ROOT}/deploy/docker/frontend.Dockerfile" >/dev/null; then
 	printf 'ERROR: HFL frontend image must consume the standalone Website artifact only\n' >&2

--- a/tools/quality/test-deployment-optional-config.sh
+++ b/tools/quality/test-deployment-optional-config.sh
@@ -24,6 +24,7 @@ HFL_ADMIN_PUBLIC_URL=
 HFL_INSECURE_TLS=1
 HFL_PLATFORM_GATEWAY_AUTO_DEPLOY=false
 HFL_GOOGLE_OAUTH_ENABLED=false
+HFL_GA_MEASUREMENT_ID=G-OLD123
 GOOGLE_CLIENT_ID=123-old.apps.googleusercontent.com
 GOOGLE_CLIENT_SECRET=old-google-secret
 TURNSTILE_ENABLED=true
@@ -33,6 +34,7 @@ ENV
 cat >"${runtime_file}" <<'ENV'
 HFL_EMAIL_SIGNUP_ENABLED=true
 HFL_GOOGLE_OAUTH_ENABLED=true
+HFL_GA_MEASUREMENT_ID=G-0RX9GZJCWF
 HFL_INSECURE_TLS=0
 TURNSTILE_ENABLED=true
 HFL_PLATFORM_GATEWAY_AUTO_DEPLOY=true
@@ -71,6 +73,7 @@ grep -Fx 'TURNSTILE_SITE_KEY=new-site' "${env_file}" >/dev/null
 grep -Fx 'TURNSTILE_SECRET_KEY=new-secret' "${env_file}" >/dev/null
 grep -Fx 'HFL_EMAIL_SIGNUP_ENABLED=true' "${env_file}" >/dev/null
 grep -Fx 'HFL_GOOGLE_OAUTH_ENABLED=true' "${env_file}" >/dev/null
+grep -Fx 'HFL_GA_MEASUREMENT_ID=G-0RX9GZJCWF' "${env_file}" >/dev/null
 grep -Fx 'GOOGLE_CLIENT_ID=123-new.apps.googleusercontent.com' "${env_file}" >/dev/null
 grep -Fx 'GOOGLE_CLIENT_SECRET="new-google-secret"' "${env_file}" >/dev/null
 grep -Fx 'EMAIL_BACKEND=django.core.mail.backends.smtp.EmailBackend' "${env_file}" >/dev/null
@@ -100,6 +103,7 @@ HFL_EMAIL_SIGNUP_ENABLED=false
 HFL_INSECURE_TLS=0
 TURNSTILE_ENABLED=true
 HFL_PLATFORM_GATEWAY_AUTO_DEPLOY=invalid
+HFL_GA_MEASUREMENT_ID=invalid
 TURNSTILE_SITE_KEY=
 TURNSTILE_SECRET_KEY=invalid secret
 ENV
@@ -114,6 +118,25 @@ grep -Fx 'HFL_ADMIN_PUBLIC_URL=https://admin.hyperfilelens.com' "${invalid_env}"
 grep -Fx 'TURNSTILE_SITE_KEY=new-site' "${invalid_env}" >/dev/null
 grep -Fx 'TURNSTILE_SECRET_KEY=new-secret' "${invalid_env}" >/dev/null
 grep -Fx 'HFL_PLATFORM_GATEWAY_AUTO_DEPLOY=true' "${invalid_env}" >/dev/null
+if grep -F 'HFL_GA_MEASUREMENT_ID=' "${invalid_env}" >/dev/null; then
+	printf 'ERROR: invalid analytics configuration must remove the installed ID\n' >&2
+	exit 1
+fi
+
+disabled_analytics_env="${tmp}/disabled-analytics.env"
+disabled_analytics_runtime="${tmp}/disabled-analytics-runtime.env"
+cp "${env_file}" "${disabled_analytics_env}"
+cat >"${disabled_analytics_runtime}" <<'ENV'
+HFL_EMAIL_SIGNUP_ENABLED=false
+HFL_INSECURE_TLS=1
+HFL_GA_MEASUREMENT_ID=
+ENV
+python3 "${helper}" --env-file "${disabled_analytics_env}" \
+	--runtime-env-file "${disabled_analytics_runtime}" >/dev/null
+if grep -F 'HFL_GA_MEASUREMENT_ID=' "${disabled_analytics_env}" >/dev/null; then
+	printf 'ERROR: disabled analytics must remove the installed ID\n' >&2
+	exit 1
+fi
 
 preserved_env="${tmp}/preserved.env"
 empty_smtp_runtime="${tmp}/empty-smtp-runtime.env"
@@ -137,6 +160,7 @@ python3 "${helper}" \
 	--runtime-env-file "${empty_smtp_runtime}" >/dev/null
 grep -Fx 'EMAIL_HOST=smtp.example.com' "${preserved_env}" >/dev/null
 grep -F 'EMAIL_HOST_PASSWORD="pa$$$$ word' "${preserved_env}" >/dev/null
+grep -Fx 'HFL_GA_MEASUREMENT_ID=G-0RX9GZJCWF' "${preserved_env}" >/dev/null
 
 partial_env="${tmp}/partial.env"
 partial_runtime="${tmp}/partial-runtime.env"

--- a/tools/quality/test-ga-runtime-config.sh
+++ b/tools/quality/test-ga-runtime-config.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Validate site-scoped, runtime-only Google Analytics configuration.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+renderer="${ROOT}/deploy/docker/frontend-runtime-config.sh"
+tmp="$(mktemp -d)"
+trap 'rm -rf "${tmp}"' EXIT
+
+website="${tmp}/website.js"
+tenant="${tmp}/tenant.js"
+admin="${tmp}/admin.js"
+HFL_WEBSITE_CONFIG_OUTPUT="${website}" \
+	HFL_TENANT_CONFIG_OUTPUT="${tenant}" \
+	HFL_ADMIN_CONFIG_OUTPUT="${admin}" \
+	HFL_WEBSITE_APP_URL="https://app.hyperfilelens.com" \
+	HFL_GA_MEASUREMENT_ID="G-0RX9GZJCWF" \
+	sh "${renderer}"
+
+grep -Fx "window.__HFL_WEBSITE_CONFIG__ = Object.freeze({ appUrl: 'https://app.hyperfilelens.com', gaMeasurementId: 'G-0RX9GZJCWF' })" \
+	"${website}" >/dev/null
+grep -Fx "window.__HFL_APP_CONFIG__ = Object.freeze({ gaMeasurementId: 'G-0RX9GZJCWF' })" \
+	"${tenant}" >/dev/null
+grep -Fx "window.__HFL_APP_CONFIG__ = Object.freeze({ gaMeasurementId: '' })" \
+	"${admin}" >/dev/null
+
+invalid_output="$(HFL_WEBSITE_CONFIG_OUTPUT="${website}" \
+	HFL_TENANT_CONFIG_OUTPUT="${tenant}" \
+	HFL_ADMIN_CONFIG_OUTPUT="${admin}" \
+	HFL_GA_MEASUREMENT_ID="G invalid" sh "${renderer}" 2>&1)"
+grep -F 'WARNING: invalid GA4 measurement ID' <<<"${invalid_output}" >/dev/null
+grep -Fx "window.__HFL_APP_CONFIG__ = Object.freeze({ gaMeasurementId: '' })" \
+	"${tenant}" >/dev/null
+
+grep -F 'alias /usr/share/nginx/runtime/tenant-app-runtime-config.js;' \
+	"${ROOT}/deploy/nginx/snippets/hfl-tenant-spa-locations.conf" >/dev/null
+grep -F 'alias /usr/share/nginx/runtime/admin-app-runtime-config.js;' \
+	"${ROOT}/deploy/nginx/snippets/hfl-ops-spa-locations.conf" >/dev/null
+grep -F '<script src="/app-runtime-config.js"></script>' \
+	"${ROOT}/src/frontend/index.html" >/dev/null
+grep -F 'PROD_GA_MEASUREMENT_ID' \
+	"${ROOT}/.github/workflows/production_deploy.yml" >/dev/null
+grep -F 'ga4_measurement_id_pattern.fullmatch(candidate)' \
+	"${ROOT}/.github/workflows/deploy_target.yml" >/dev/null
+grep -F "event_callback: completeNavigation" \
+	"${ROOT}/website/.vitepress/theme/analytics.ts" >/dev/null
+grep -F 'window.setTimeout(completeNavigation, NAVIGATION_FALLBACK_MS)' \
+	"${ROOT}/website/.vitepress/theme/analytics.ts" >/dev/null
+
+python3 - "${ROOT}/.github/workflows/deploy_target.yml" "${tmp}" <<'PY'
+import os
+import pathlib
+import subprocess
+import sys
+import textwrap
+
+workflow = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
+start_marker = '          python3 - "$runtime_env" <<\'PY\'\n'
+end_marker = "\n          PY\n"
+start = workflow.index(start_marker) + len(start_marker)
+end = workflow.index(end_marker, start)
+renderer = textwrap.dedent(workflow[start:end])
+
+
+def render(target: str, measurement_id: str, filename: str) -> str:
+    output = pathlib.Path(sys.argv[2], filename)
+    environment = os.environ.copy()
+    environment.update(
+        DEPLOY_TARGET=target,
+        HFL_GA_MEASUREMENT_ID=measurement_id,
+    )
+    subprocess.run(
+        [sys.executable, "-", str(output)],
+        check=True,
+        env=environment,
+        input=renderer,
+        text=True,
+    )
+    values = dict(
+        line.split("=", 1)
+        for line in output.read_text(encoding="utf-8").splitlines()
+    )
+    return values["HFL_GA_MEASUREMENT_ID"]
+
+
+assert render("prod", "  G-0RX9GZJCWF\t", "trimmed.env") == "G-0RX9GZJCWF"
+assert render("prod", "G-0RX9GZJCWF\ninvalid", "multiline.env") == ""
+assert render("preprod", "G-0RX9GZJCWF", "preprod.env") == ""
+PY
+
+if grep -R -E '(TEST|PREPROD)_GA_MEASUREMENT_ID' "${ROOT}/.github/workflows" >/dev/null; then
+	printf 'ERROR: Google Analytics must be configured only for the PROD SaaS target\n' >&2
+	exit 1
+fi
+if grep -R -F 'VITE_GA_ID' "${ROOT}/src/frontend" "${ROOT}/website" >/dev/null; then
+	printf 'ERROR: HFL analytics must remain runtime-configured, not image-baked\n' >&2
+	exit 1
+fi
+
+printf 'Runtime Google Analytics configuration checks passed.\n'

--- a/tools/quality/test-website-runtime-config.sh
+++ b/tools/quality/test-website-runtime-config.sh
@@ -9,16 +9,24 @@ trap 'rm -rf "${tmp}"' EXIT
 valid="${tmp}/valid.js"
 HFL_WEBSITE_CONFIG_OUTPUT="${valid}" \
 	HFL_WEBSITE_APP_URL="https://app.hyperfilelens.com" \
+	HFL_GA_MEASUREMENT_ID="G-0RX9GZJCWF" \
 	sh "${renderer}"
-grep -Fx "window.__HFL_WEBSITE_CONFIG__ = Object.freeze({ appUrl: 'https://app.hyperfilelens.com' })" \
+grep -Fx "window.__HFL_WEBSITE_CONFIG__ = Object.freeze({ appUrl: 'https://app.hyperfilelens.com', gaMeasurementId: 'G-0RX9GZJCWF' })" \
 	"${valid}" >/dev/null
 
 direct="${tmp}/direct.js"
 output="$(HFL_WEBSITE_CONFIG_OUTPUT="${direct}" \
 	HFL_WEBSITE_APP_URL="not a public origin" sh "${renderer}" 2>&1)"
 grep -F 'WARNING: invalid app URL' <<<"${output}" >/dev/null
-grep -Fx "window.__HFL_WEBSITE_CONFIG__ = Object.freeze({ appUrl: '' })" \
+grep -Fx "window.__HFL_WEBSITE_CONFIG__ = Object.freeze({ appUrl: '', gaMeasurementId: '' })" \
 	"${direct}" >/dev/null
+
+invalid_ga="${tmp}/invalid-ga.js"
+output="$(HFL_WEBSITE_CONFIG_OUTPUT="${invalid_ga}" \
+	HFL_GA_MEASUREMENT_ID="invalid" sh "${renderer}" 2>&1)"
+grep -F 'WARNING: invalid GA4 measurement ID' <<<"${output}" >/dev/null
+grep -Fx "window.__HFL_WEBSITE_CONFIG__ = Object.freeze({ appUrl: '', gaMeasurementId: '' })" \
+	"${invalid_ga}" >/dev/null
 
 grep -F "directAppOrigin()" \
 	"${ROOT}/website/.vitepress/theme/HomeLanding.vue" >/dev/null

--- a/website/.vitepress/theme/HomeLanding.vue
+++ b/website/.vitepress/theme/HomeLanding.vue
@@ -1,11 +1,9 @@
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue'
-
-declare global {
-  interface Window {
-    __HFL_WEBSITE_CONFIG__?: { appUrl?: string }
-  }
-}
+import {
+  trackWebsiteOpenApp,
+  type WebsiteOpenAppPlacement,
+} from './analytics'
 
 const appOrigin = ref('')
 
@@ -33,6 +31,23 @@ onMounted(() => {
 const loginUrl = computed(() => `${appOrigin.value || '#'}${appOrigin.value ? '/login' : ''}`)
 
 const githubUrl = 'https://github.com/HyperBDR/hyperfilelens'
+
+function openApp(event: MouseEvent, placement: WebsiteOpenAppPlacement) {
+  const target = loginUrl.value
+  if (!target || target === '#') return
+  if (
+    event.button !== 0
+    || event.metaKey
+    || event.ctrlKey
+    || event.shiftKey
+    || event.altKey
+  ) {
+    trackWebsiteOpenApp(placement)
+    return
+  }
+  event.preventDefault()
+  trackWebsiteOpenApp(placement, () => window.location.assign(target))
+}
 </script>
 
 <template>
@@ -90,7 +105,7 @@ const githubUrl = 'https://github.com/HyperBDR/hyperfilelens'
             <svg aria-hidden="true"><use href="#icon-github" /></svg>
             <span>GitHub</span>
           </a>
-          <a class="header-cta" :href="loginUrl">Open app</a>
+          <a class="header-cta" :href="loginUrl" @click="openApp($event, 'header')">Open app</a>
         </div>
       </div>
     </header>
@@ -110,7 +125,7 @@ const githubUrl = 'https://github.com/HyperBDR/hyperfilelens'
             recover it with confidence, and turn trusted snapshots into useful AI knowledge.
           </p>
           <div class="hero-actions">
-            <a class="button button-primary" :href="loginUrl">
+            <a class="button button-primary" :href="loginUrl" @click="openApp($event, 'hero')">
               Open HyperFileLens
               <svg aria-hidden="true"><use href="#icon-arrow" /></svg>
             </a>
@@ -319,7 +334,7 @@ const githubUrl = 'https://github.com/HyperBDR/hyperfilelens'
             <span>Fastest start</span>
             <h3>Hosted service</h3>
             <p>Use the managed HyperFileLens control plane and connect your environments through Data Gateways.</p>
-            <a :href="loginUrl">Open the app <svg><use href="#icon-arrow" /></svg></a>
+            <a :href="loginUrl" @click="openApp($event, 'hosted_service')">Open the app <svg><use href="#icon-arrow" /></svg></a>
           </article>
           <article class="featured-deployment">
             <div class="deployment-icon"><svg><use href="#icon-server" /></svg></div>
@@ -345,7 +360,7 @@ const githubUrl = 'https://github.com/HyperBDR/hyperfilelens'
           <h2 id="cta-title">Protect the files you rely on.<br />Put their knowledge to work.</h2>
         </div>
         <div class="cta-actions">
-          <a class="button button-light" :href="loginUrl">Open HyperFileLens <svg aria-hidden="true"><use href="#icon-arrow" /></svg></a>
+          <a class="button button-light" :href="loginUrl" @click="openApp($event, 'cta')">Open HyperFileLens <svg aria-hidden="true"><use href="#icon-arrow" /></svg></a>
           <a class="button button-dark-outline" :href="githubUrl"><svg aria-hidden="true"><use href="#icon-github" /></svg>Explore GitHub</a>
         </div>
       </section>
@@ -359,7 +374,7 @@ const githubUrl = 'https://github.com/HyperBDR/hyperfilelens'
       <div class="footer-links">
         <div><strong>Product</strong><a href="#platform">Platform</a><a href="#how-it-works">How it works</a><a href="#deploy">Deployment</a></div>
         <div><strong>Open source</strong><a :href="githubUrl">GitHub</a><a :href="`${githubUrl}/releases`">Releases</a><a :href="`${githubUrl}/issues`">Issues</a></div>
-        <div><strong>Access</strong><a :href="loginUrl">Open app</a><a href="/en/">English</a></div>
+        <div><strong>Access</strong><a :href="loginUrl" @click="openApp($event, 'footer')">Open app</a><a href="/en/">English</a></div>
       </div>
       <div class="footer-bottom"><span>© 2026 HyperFileLens contributors</span><span>Public beta · Built in the open</span></div>
     </footer>

--- a/website/.vitepress/theme/analytics.ts
+++ b/website/.vitepress/theme/analytics.ts
@@ -1,0 +1,136 @@
+import { inBrowser } from 'vitepress'
+
+type GoogleTag = (...args: unknown[]) => void
+export type WebsiteOpenAppPlacement =
+  | 'header'
+  | 'hero'
+  | 'hosted_service'
+  | 'cta'
+  | 'footer'
+
+declare global {
+  interface Window {
+    __HFL_WEBSITE_CONFIG__?: {
+      appUrl?: string
+      gaMeasurementId?: string
+    }
+    dataLayer?: unknown[]
+    gtag?: GoogleTag
+  }
+}
+
+const GA4_MEASUREMENT_ID = /^G-[A-Z0-9]+$/
+const NAVIGATION_FALLBACK_MS = 400
+let activeMeasurementId = ''
+let activePagePath = '/'
+
+function sanitizedPath(value: string): string {
+  try {
+    const parsed = new URL(value, window.location.origin)
+    return parsed.pathname || '/'
+  } catch {
+    return '/'
+  }
+}
+
+function sanitizedReferrer(): string {
+  if (!document.referrer) return ''
+  try {
+    const parsed = new URL(document.referrer)
+    return parsed.origin
+  } catch {
+    return ''
+  }
+}
+
+function configureGoogleTag(): boolean {
+  if (!inBrowser) return false
+  const measurementId = String(
+    window.__HFL_WEBSITE_CONFIG__?.gaMeasurementId || '',
+  ).trim()
+  if (!measurementId) return false
+  if (!GA4_MEASUREMENT_ID.test(measurementId)) {
+    console.warn('[analytics] Invalid GA4 measurement ID; analytics is disabled.')
+    return false
+  }
+  if (activeMeasurementId === measurementId) return true
+
+  activeMeasurementId = measurementId
+  window.dataLayer = window.dataLayer || []
+  window.gtag = function gtag(...args: unknown[]) {
+    window.dataLayer?.push(args)
+  }
+  window.gtag('js', new Date())
+  window.gtag('config', measurementId, { send_page_view: false })
+
+  const script = document.createElement('script')
+  script.async = true
+  script.dataset.hflGoogleAnalytics = 'true'
+  script.src = `https://www.googletagmanager.com/gtag/js?id=${encodeURIComponent(measurementId)}`
+  document.head.appendChild(script)
+  return true
+}
+
+export function trackWebsitePageView(value: string): void {
+  if (!activeMeasurementId || !window.gtag) return
+  const path = sanitizedPath(value)
+  activePagePath = path
+  window.gtag('event', 'page_view', {
+    page_location: `${window.location.origin}${path}`,
+    page_path: path,
+    page_referrer: sanitizedReferrer(),
+    page_title: 'HyperFileLens Website',
+  })
+}
+
+function websiteEventContext() {
+  return {
+    page_location: `${window.location.origin}${activePagePath}`,
+    page_path: activePagePath,
+    page_referrer: sanitizedReferrer(),
+    page_title: 'HyperFileLens Website',
+  }
+}
+
+export function trackWebsiteOpenApp(
+  placement: WebsiteOpenAppPlacement,
+  navigate?: () => void,
+): void {
+  if (!activeMeasurementId || !window.gtag) {
+    navigate?.()
+    return
+  }
+
+  if (!navigate) {
+    window.gtag('event', 'website_open_app', {
+      placement,
+      ...websiteEventContext(),
+    })
+    return
+  }
+
+  let completed = false
+  const completeNavigation = () => {
+    if (completed) return
+    completed = true
+    window.clearTimeout(fallback)
+    navigate()
+  }
+  const fallback = window.setTimeout(completeNavigation, NAVIGATION_FALLBACK_MS)
+  try {
+    window.gtag('event', 'website_open_app', {
+      placement,
+      ...websiteEventContext(),
+      transport_type: 'beacon',
+      event_callback: completeNavigation,
+      event_timeout: NAVIGATION_FALLBACK_MS - 50,
+    })
+  } catch {
+    completeNavigation()
+  }
+}
+
+export function initWebsiteAnalytics(): void {
+  if (!configureGoogleTag()) return
+  trackWebsitePageView(window.location.pathname)
+}

--- a/website/.vitepress/theme/index.ts
+++ b/website/.vitepress/theme/index.ts
@@ -2,8 +2,16 @@ import type { Theme } from 'vitepress'
 import DefaultTheme from 'vitepress/theme'
 import Layout from './Layout.vue'
 import './custom.css'
+import { initWebsiteAnalytics, trackWebsitePageView } from './analytics'
 
 export default {
   extends: DefaultTheme,
   Layout,
+  enhanceApp({ router }) {
+    if (typeof window === 'undefined') return
+    initWebsiteAnalytics()
+    router.onAfterRouteChange = (to) => {
+      trackWebsitePageView(to)
+    }
+  },
 } satisfies Theme

--- a/website/public/website-runtime-config.js
+++ b/website/public/website-runtime-config.js
@@ -1,1 +1,1 @@
-window.__HFL_WEBSITE_CONFIG__ = Object.freeze({ appUrl: '' })
+window.__HFL_WEBSITE_CONFIG__ = Object.freeze({ appUrl: '', gaMeasurementId: '' })

--- a/website/runtime-config.sh
+++ b/website/runtime-config.sh
@@ -4,6 +4,7 @@ set -eu
 output=${HFL_WEBSITE_CONFIG_OUTPUT:-/usr/share/nginx/website/website-runtime-config.js}
 temporary="${output}.tmp"
 app_url=${HFL_WEBSITE_APP_URL:-}
+ga_measurement_id=${HFL_GA_MEASUREMENT_ID:-}
 
 if [ -n "${app_url}" ] && ! printf '%s' "${app_url}" \
   | grep -Eq '^https?://(\[[0-9A-Fa-f:]+\]|[A-Za-z0-9.-]+)(:[0-9]{1,5})?/?$'; then
@@ -11,6 +12,13 @@ if [ -n "${app_url}" ] && ! printf '%s' "${app_url}" \
   app_url=
 fi
 
+if [ -n "${ga_measurement_id}" ] && ! printf '%s' "${ga_measurement_id}" \
+  | grep -Eq '^G-[A-Z0-9]+$'; then
+  printf '%s\n' '[website-config] WARNING: invalid GA4 measurement ID; analytics is disabled' >&2
+  ga_measurement_id=
+fi
+
 umask 022
-printf "window.__HFL_WEBSITE_CONFIG__ = Object.freeze({ appUrl: '%s' })\n" "${app_url%/}" > "${temporary}"
+printf "window.__HFL_WEBSITE_CONFIG__ = Object.freeze({ appUrl: '%s', gaMeasurementId: '%s' })\n" \
+  "${app_url%/}" "${ga_measurement_id}" > "${temporary}"
 mv -f "${temporary}" "${output}"


### PR DESCRIPTION
Adds runtime-configured GA4 analytics for the production SaaS Website and tenant app while keeping Admin, SourceLens, test, pre-production, and standalone deployments disabled. Includes privacy-safe route tracking, GA4 authentication events, resilient Website CTA tracking, deployment normalization, stale configuration cleanup, and release contract coverage. Validated with frontend tests and production builds, Website build, installer and release contracts, YAML parsing, and English-only source checks.