### PR TITLE
fix: enforce durable data gateway execution boundaries

### DIFF
--- a/deploy/bootstrap/gateway-install-lensnode-sidecar.sh
+++ b/deploy/bootstrap/gateway-install-lensnode-sidecar.sh
@@ -84,8 +84,14 @@ hfl_step "Verifying SourceLens connectivity at ${LENS_HOST_URL}."
 curl "${CURL_TLS[@]}" -fsSL "${LENS_HOST_URL%/}/health" >/dev/null
 hfl_ok "SourceLens health check passed."
 
-hfl_step "Creating workspace ${HFL_WORKSPACE_ROOT}."
+hfl_step "Creating protected Gateway filesystem boundary."
 mkdir -p "${HFL_WORKSPACE_ROOT}"
+HFL_GATEWAY_STATE_ROOT="$(dirname "${HFL_WORKSPACE_ROOT}")/.hyperfilelens"
+HFL_GATEWAY_TRASH_ROOT="${HFL_WORKSPACE_ROOT}/.hyperfilelens-trash"
+mkdir -p "${HFL_GATEWAY_STATE_ROOT}/identities" "${HFL_GATEWAY_TRASH_ROOT}"
+chmod 0700 "${HFL_GATEWAY_STATE_ROOT}" \
+	"${HFL_GATEWAY_STATE_ROOT}/identities" \
+	"${HFL_GATEWAY_TRASH_ROOT}"
 
 mkdir -p "${COMPOSE_DIR}"
 
@@ -170,7 +176,12 @@ ${EXTRA_HOSTS_BLOCK}    environment:
       LENSNODE_INSECURE_TLS: "${HFL_INSECURE_TLS}"
       LENSNODE_SSL_VERIFY: "${ssl_verify}"
     volumes:
-      - ${HFL_WORKSPACE_ROOT}:${HFL_WORKSPACE_ROOT}
+      # LensNode only indexes managed data. The host Agent is the sole writer
+      # and lifecycle owner for this filesystem boundary.
+      - ${HFL_WORKSPACE_ROOT}:${HFL_WORKSPACE_ROOT}:ro
+    tmpfs:
+      # Hide the host Agent's same-filesystem deletion quarantine from LensNode.
+      - ${HFL_GATEWAY_TRASH_ROOT}:mode=0700
     mem_limit: 512m
     cpus: 0.50
 EOF

--- a/deploy/bootstrap/gateway-lifecycle.sh
+++ b/deploy/bootstrap/gateway-lifecycle.sh
@@ -243,22 +243,35 @@ remove_lensnode_images() {
 	done
 }
 
+validate_gateway_workspace_path() {
+	local candidate=${1:-} canonical normalized
+	[[ -n "${candidate}" ]] || return 1
+	canonical="$(readlink -m -- "${candidate}")" || return 1
+	normalized="${candidate%/}"
+	[[ "${normalized}" == "${canonical}" ]] || return 1
+	[[ "${canonical}" =~ ^/workspace/org-[1-9][0-9]*/data$ ]] || return 1
+	printf '%s\n' "${canonical}"
+}
+
 purge_sidecar_artifacts() {
-	local workspace=""
+	local workspace="" state_root=""
 	if [[ -f "${LENS_ENV_FILE}" ]]; then
-		# shellcheck disable=SC1090
-		set -a
-		source "${LENS_ENV_FILE}"
-		set +a
-		workspace="${HFL_WORKSPACE_ROOT:-}"
+		workspace="$(read_env_value "${LENS_ENV_FILE}" HFL_WORKSPACE_ROOT)"
+	fi
+	if [[ -n "${workspace}" ]]; then
+		workspace="$(validate_gateway_workspace_path "${workspace}")" \
+			|| hfl_fail "refusing to purge unsafe Gateway workspace path from ${LENS_ENV_FILE}" 6
 	fi
 	compose_down_sidecar
 	remove_lensnode_images
 	rm -f "${LENS_ENV_FILE}"
 	rm -rf "${COMPOSE_DIR}"
-	if [[ -n "${workspace}" && "${workspace}" == /workspace/* ]]; then
+	if [[ -n "${workspace}" ]]; then
 		hfl_log "Removing gateway workspace ${workspace}."
 		rm -rf "${workspace}"
+		state_root="$(dirname "${workspace}")/.hyperfilelens"
+		hfl_log "Removing protected gateway state ${state_root}."
+		rm -rf "${state_root}"
 	fi
 }
 
@@ -295,4 +308,6 @@ main() {
 	esac
 }
 
-main "$@"
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+	main "$@"
+fi

--- a/src/agent/internal/engine/engine.go
+++ b/src/agent/internal/engine/engine.go
@@ -59,6 +59,10 @@ func (e *Engine) Run(ctx context.Context, cmd Command, sink ExecutionSink) Resul
 	switch kind {
 	case "browse":
 		status, result, errMsg = e.runBrowse(ctx, rep, cmd.ID, p)
+	case "lens.gateway.browse":
+		status, result, errMsg = e.runLensGatewayBrowse(ctx, p)
+	case "lens.workspace.validate-local":
+		status, result, errMsg = e.runLensWorkspaceValidateLocal(ctx, p)
 	case "backup":
 		if _, ok, parseErr := parseRepositorySpec(p.Extra["repository"]); parseErr != nil {
 			status, result, errMsg = "failed", nil, parseErr.Error()
@@ -172,6 +176,8 @@ func (e *Engine) Run(ctx context.Context, cmd Command, sink ExecutionSink) Resul
 		status, result, errMsg = e.runPathSize(ctx, p)
 	case "lens.ks.prepare", "lens.workspace.prepare":
 		status, result, errMsg = e.runLensKsPrepare(ctx, p)
+	case "lens.ks.cleanup", "lens.workspace.cleanup":
+		status, result, errMsg = e.runLensKsCleanup(ctx, p)
 	case "maintenance.gc":
 		status, result, errMsg = e.runKopia(ctx, rep, cmd.ID, p, []string{"maintenance", "run", "--full"})
 	case "repository.operation":

--- a/src/agent/internal/engine/lens_gateway.go
+++ b/src/agent/internal/engine/lens_gateway.go
@@ -1,0 +1,110 @@
+package engine
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+const lensWorkspaceTrashDirectory = ".hyperfilelens-trash"
+
+func isLensReservedWorkspacePath(path, allowedRoot string) bool {
+	_, relative, err := secureRelativePath(path, allowedRoot, true)
+	if err != nil || relative == "." {
+		return false
+	}
+	return strings.Split(relative, string(os.PathSeparator))[0] == lensWorkspaceTrashDirectory
+}
+
+func (e *Engine) runLensWorkspaceValidateLocal(ctx context.Context, p Payload) (string, map[string]any, string) {
+	if err := ctx.Err(); err != nil {
+		return "failed", nil, "canceled"
+	}
+	allowedRoot := payloadStringValue(p.Extra["allowed_root"])
+	if isLensReservedWorkspacePath(p.Path, allowedRoot) {
+		return "failed", nil, "path is reserved for managed workspace cleanup"
+	}
+	fd, cleanPath, err := secureOpenDirectory(p.Path, allowedRoot, true, uint64(os.O_RDONLY))
+	if err != nil {
+		return "failed", nil, err.Error()
+	}
+	file := secureDirectoryFile(fd, cleanPath)
+	if file == nil {
+		return "failed", nil, "restricted Data Gateway filesystem operations require Linux"
+	}
+	_ = file.Close()
+	return "success", map[string]any{"path": cleanPath, "allowed_root": allowedRoot}, ""
+}
+
+func (e *Engine) runLensGatewayBrowse(ctx context.Context, p Payload) (string, map[string]any, string) {
+	if err := ctx.Err(); err != nil {
+		return "failed", nil, "canceled"
+	}
+	allowedRoot := payloadStringValue(p.Extra["allowed_root"])
+	if isLensReservedWorkspacePath(p.Path, allowedRoot) {
+		return "failed", nil, "path is reserved for managed workspace cleanup"
+	}
+	fd, cleanPath, err := secureOpenDirectory(p.Path, allowedRoot, true, uint64(os.O_RDONLY))
+	if err != nil {
+		return "failed", nil, err.Error()
+	}
+	directory := secureDirectoryFile(fd, cleanPath)
+	if directory == nil {
+		return "failed", nil, "restricted Data Gateway filesystem operations require Linux"
+	}
+	defer directory.Close()
+
+	offset, _ := strconv.Atoi(p.Cursor)
+	if offset < 0 {
+		offset = 0
+	}
+	rows := make([]map[string]any, 0)
+	matched := 0
+	hasMore := false
+	for {
+		entries, readErr := directory.ReadDir(128)
+		if readErr != nil && !errors.Is(readErr, io.EOF) {
+			return "failed", nil, readErr.Error()
+		}
+		for _, entry := range entries {
+			if cleanPath == filepath.Clean(allowedRoot) && entry.Name() == lensWorkspaceTrashDirectory {
+				continue
+			}
+			if !entry.IsDir() || entry.Type()&os.ModeSymlink != 0 {
+				continue
+			}
+			if matched < offset {
+				matched++
+				continue
+			}
+			rows = append(rows, map[string]any{
+				"name":   entry.Name(),
+				"path":   filepath.Join(cleanPath, entry.Name()),
+				"is_dir": true,
+			})
+			matched++
+			if p.Limit > 0 && len(rows) >= p.Limit {
+				hasMore = true
+				break
+			}
+		}
+		if hasMore || errors.Is(readErr, io.EOF) {
+			break
+		}
+	}
+	nextCursor := ""
+	if hasMore {
+		nextCursor = strconv.Itoa(matched)
+	}
+	return "success", map[string]any{
+		"path":        cleanPath,
+		"entries":     rows,
+		"count":       len(rows),
+		"has_more":    hasMore,
+		"next_cursor": nextCursor,
+	}, ""
+}

--- a/src/agent/internal/engine/lens_gateway_test.go
+++ b/src/agent/internal/engine/lens_gateway_test.go
@@ -1,0 +1,93 @@
+//go:build linux
+
+package engine
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLensGatewayBrowseRejectsTraversal(t *testing.T) {
+	root := t.TempDir()
+	status, _, errMsg := New(nil).runLensGatewayBrowse(context.Background(), Payload{
+		Path:  root + "/../../etc",
+		Extra: map[string]any{"allowed_root": root},
+	})
+	if status != "failed" || errMsg == "" {
+		t.Fatalf("expected traversal rejection, status=%q err=%q", status, errMsg)
+	}
+}
+
+func TestLensGatewayBrowseRejectsSymlinkEscape(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	link := filepath.Join(root, "escape")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Fatal(err)
+	}
+	status, _, errMsg := New(nil).runLensGatewayBrowse(context.Background(), Payload{
+		Path:  link,
+		Extra: map[string]any{"allowed_root": root},
+	})
+	if status != "failed" || errMsg == "" {
+		t.Fatalf("expected symlink rejection, status=%q err=%q", status, errMsg)
+	}
+}
+
+func TestLensWorkspaceValidateLocalAcceptsRealDirectory(t *testing.T) {
+	root := t.TempDir()
+	target := filepath.Join(root, "documents")
+	if err := os.Mkdir(target, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	status, result, errMsg := New(nil).runLensWorkspaceValidateLocal(
+		context.Background(),
+		Payload{
+			Path:  target,
+			Extra: map[string]any{"allowed_root": root},
+		},
+	)
+	if status != "success" {
+		t.Fatalf("status=%q err=%q result=%v", status, errMsg, result)
+	}
+}
+
+func TestLensGatewayBrowseHidesManagedTrash(t *testing.T) {
+	root := t.TempDir()
+	if err := os.Mkdir(filepath.Join(root, lensWorkspaceTrashDirectory), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(root, "documents"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	status, result, errMsg := New(nil).runLensGatewayBrowse(
+		context.Background(),
+		Payload{Path: root, Extra: map[string]any{"allowed_root": root}},
+	)
+	if status != "success" {
+		t.Fatalf("status=%q err=%q result=%v", status, errMsg, result)
+	}
+	entries, ok := result["entries"].([]map[string]any)
+	if !ok || len(entries) != 1 || entries[0]["name"] != "documents" {
+		t.Fatalf("reserved trash leaked into browse result: %#v", result["entries"])
+	}
+}
+
+func TestLensWorkspaceValidateLocalRejectsManagedTrash(t *testing.T) {
+	root := t.TempDir()
+	trash := filepath.Join(root, lensWorkspaceTrashDirectory)
+	if err := os.Mkdir(trash, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	status, _, errMsg := New(nil).runLensWorkspaceValidateLocal(
+		context.Background(),
+		Payload{Path: trash, Extra: map[string]any{"allowed_root": root}},
+	)
+	if status != "failed" || errMsg == "" {
+		t.Fatalf("expected reserved trash rejection, status=%q err=%q", status, errMsg)
+	}
+}

--- a/src/agent/internal/engine/lens_prepare.go
+++ b/src/agent/internal/engine/lens_prepare.go
@@ -2,37 +2,328 @@ package engine
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 )
 
+const lensWorkspaceIdentityKind = "managed_restore"
+
+var removeLensWorkspaceTrash = os.RemoveAll
+
+type lensWorkspaceIdentity struct {
+	Version              int    `json:"version"`
+	WorkspaceUID         string `json:"workspace_uid"`
+	TenantOrganizationID string `json:"tenant_organization_id"`
+	GatewayLinkID        string `json:"gateway_link_id"`
+	KnowledgeSourceID    string `json:"knowledge_source_id"`
+	WorkspaceKind        string `json:"workspace_kind"`
+}
+
+type lensWorkspacePaths struct {
+	Root         string
+	Workspace    string
+	MetadataRoot string
+	IdentityRoot string
+	Identity     string
+	TrashRoot    string
+	Trash        string
+}
+
+func lensWorkspaceIdentityFromPayload(p Payload) (lensWorkspaceIdentity, error) {
+	identity := lensWorkspaceIdentity{
+		Version:              1,
+		WorkspaceUID:         payloadStringValue(p.Extra["workspace_uid"]),
+		TenantOrganizationID: payloadStringValue(p.Extra["tenant_organization_id"]),
+		GatewayLinkID:        payloadStringValue(p.Extra["gateway_link_id"]),
+		KnowledgeSourceID:    payloadStringValue(p.Extra["knowledge_source_id"]),
+		WorkspaceKind:        payloadStringValue(p.Extra["workspace_kind"]),
+	}
+	if identity.WorkspaceUID == "" || identity.TenantOrganizationID == "" ||
+		identity.GatewayLinkID == "" || identity.KnowledgeSourceID == "" {
+		return lensWorkspaceIdentity{}, errors.New("managed workspace identity is incomplete")
+	}
+	if identity.WorkspaceKind != lensWorkspaceIdentityKind {
+		return lensWorkspaceIdentity{}, errors.New("unsupported managed workspace kind")
+	}
+	if strings.ContainsAny(identity.WorkspaceUID, `/\\\x00`) ||
+		identity.WorkspaceUID == "." || identity.WorkspaceUID == ".." {
+		return lensWorkspaceIdentity{}, errors.New("managed workspace UID is invalid")
+	}
+	return identity, nil
+}
+
+func resolveLensWorkspacePaths(path, workspaceRoot, workspaceUID string) (lensWorkspacePaths, error) {
+	rawRoot := strings.TrimSpace(workspaceRoot)
+	rawPath := strings.TrimSpace(path)
+	for field, value := range map[string]string{"path": rawPath, "workspace_root": rawRoot} {
+		if strings.ContainsRune(value, '\x00') || strings.Contains(value, `\`) {
+			return lensWorkspacePaths{}, fmt.Errorf("%s contains an unsupported character", field)
+		}
+		for _, component := range strings.Split(value, "/") {
+			if component == "." || component == ".." {
+				return lensWorkspacePaths{}, fmt.Errorf("%s contains an unsafe path component", field)
+			}
+		}
+	}
+	cleanRoot := filepath.Clean(rawRoot)
+	cleanPath := filepath.Clean(rawPath)
+	if cleanRoot == "." || cleanPath == "." || !filepath.IsAbs(cleanRoot) || !filepath.IsAbs(cleanPath) {
+		return lensWorkspacePaths{}, errors.New("path and workspace_root must be absolute")
+	}
+	relative, err := filepath.Rel(cleanRoot, cleanPath)
+	if err != nil || relative == "." || filepath.IsAbs(relative) || relative == ".." || strings.HasPrefix(relative, ".."+string(os.PathSeparator)) {
+		return lensWorkspacePaths{}, errors.New("path must be a child of workspace_root")
+	}
+	if strings.Split(relative, string(os.PathSeparator))[0] == lensWorkspaceTrashDirectory {
+		return lensWorkspacePaths{}, errors.New("path is reserved for managed workspace cleanup")
+	}
+	metadataRoot := filepath.Join(filepath.Dir(cleanRoot), ".hyperfilelens")
+	identityRoot := filepath.Join(metadataRoot, "identities")
+	// Quarantine must stay below the workspace root so rename remains atomic
+	// when the workspace root is a dedicated filesystem mount.
+	trashRoot := filepath.Join(cleanRoot, lensWorkspaceTrashDirectory)
+	return lensWorkspacePaths{
+		Root:         cleanRoot,
+		Workspace:    cleanPath,
+		MetadataRoot: metadataRoot,
+		IdentityRoot: identityRoot,
+		Identity:     filepath.Join(identityRoot, workspaceUID+".json"),
+		TrashRoot:    trashRoot,
+		Trash:        filepath.Join(trashRoot, workspaceUID),
+	}, nil
+}
+
+func ensureLensMetadataLayout(paths lensWorkspacePaths) error {
+	base := filepath.Dir(paths.Root)
+	for _, path := range []string{paths.MetadataRoot, paths.IdentityRoot, paths.TrashRoot} {
+		if _, _, err := secureEnsureDirectory(path, base, 0o700); err != nil {
+			return fmt.Errorf("create protected gateway metadata: %w", err)
+		}
+		if err := os.Chmod(path, 0o700); err != nil {
+			return fmt.Errorf("protect gateway metadata: %w", err)
+		}
+	}
+	return nil
+}
+
+func readLensWorkspaceIdentity(identityPath string) (lensWorkspaceIdentity, error) {
+	info, err := os.Lstat(identityPath)
+	if err != nil {
+		return lensWorkspaceIdentity{}, err
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+		return lensWorkspaceIdentity{}, errors.New("managed workspace identity is not a regular file")
+	}
+	identityBytes, err := os.ReadFile(identityPath)
+	if err != nil {
+		return lensWorkspaceIdentity{}, err
+	}
+	var identity lensWorkspaceIdentity
+	if err := json.Unmarshal(identityBytes, &identity); err != nil {
+		return lensWorkspaceIdentity{}, errors.New("managed workspace identity is invalid")
+	}
+	return identity, nil
+}
+
+func writeLensWorkspaceIdentity(identityPath string, identity lensWorkspaceIdentity) error {
+	encoded, err := json.Marshal(identity)
+	if err != nil {
+		return err
+	}
+	file, err := os.OpenFile(identityPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return err
+	}
+	complete := false
+	defer func() {
+		_ = file.Close()
+		if !complete {
+			_ = os.Remove(identityPath)
+		}
+	}()
+	if _, err := file.Write(encoded); err != nil {
+		return err
+	}
+	if err := file.Sync(); err != nil {
+		return err
+	}
+	if err := file.Close(); err != nil {
+		return err
+	}
+	complete = true
+	return nil
+}
+
+func validateLensWorkspaceIdentity(identityPath string, expected lensWorkspaceIdentity) error {
+	existing, err := readLensWorkspaceIdentity(identityPath)
+	if err != nil {
+		return errors.New("managed workspace identity is missing or invalid")
+	}
+	if existing != expected {
+		return errors.New("managed workspace identity does not match")
+	}
+	return nil
+}
+
+func validateLensManagedRestoreTarget(p Payload, targetPath string) error {
+	managedPath := payloadStringValue(p.Extra["managed_workspace_path"])
+	if managedPath == "" {
+		return nil
+	}
+	identity, err := lensWorkspaceIdentityFromPayload(p)
+	if err != nil {
+		return err
+	}
+	paths, err := resolveLensWorkspacePaths(
+		managedPath,
+		payloadStringValue(p.Extra["workspace_root"]),
+		identity.WorkspaceUID,
+	)
+	if err != nil {
+		return err
+	}
+	fd, cleanWorkspace, err := secureOpenDirectory(paths.Workspace, paths.Root, false, uint64(os.O_RDONLY))
+	if err != nil {
+		return err
+	}
+	workspaceDirectory := secureDirectoryFile(fd, cleanWorkspace)
+	if workspaceDirectory == nil {
+		return errors.New("restricted Data Gateway filesystem operations require Linux")
+	}
+	_ = workspaceDirectory.Close()
+	if err := validateLensWorkspaceIdentity(paths.Identity, identity); err != nil {
+		return err
+	}
+
+	cleanTarget := filepath.Clean(strings.TrimSpace(targetPath))
+	relativeTarget, err := filepath.Rel(paths.Workspace, cleanTarget)
+	if err != nil || filepath.IsAbs(relativeTarget) || relativeTarget == ".." || strings.HasPrefix(relativeTarget, ".."+string(os.PathSeparator)) {
+		return errors.New("restore target must be inside its managed workspace")
+	}
+	current := paths.Workspace
+	for _, component := range strings.Split(relativeTarget, string(os.PathSeparator)) {
+		if component == "." || component == "" {
+			continue
+		}
+		current = filepath.Join(current, component)
+		info, statErr := os.Lstat(current)
+		if os.IsNotExist(statErr) {
+			break
+		}
+		if statErr != nil {
+			return statErr
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("managed restore target contains a symlink: %s", current)
+		}
+	}
+	return nil
+}
+
 func (e *Engine) runLensKsPrepare(ctx context.Context, p Payload) (string, map[string]any, string) {
 	if err := ctx.Err(); err != nil {
 		return "failed", nil, "canceled"
 	}
-
-	path := strings.TrimSpace(p.Path)
-	workspaceRoot := payloadStringValue(p.Extra["workspace_root"])
-	if path == "" {
-		return "failed", nil, "path is required"
+	identity, err := lensWorkspaceIdentityFromPayload(p)
+	if err != nil {
+		return "failed", nil, err.Error()
 	}
-	if workspaceRoot == "" {
-		return "failed", nil, "workspace_root is required"
+	paths, err := resolveLensWorkspacePaths(p.Path, payloadStringValue(p.Extra["workspace_root"]), identity.WorkspaceUID)
+	if err != nil {
+		return "failed", nil, err.Error()
 	}
-
-	cleanPath := filepath.Clean(path)
-	cleanRoot := filepath.Clean(strings.TrimRight(workspaceRoot, "/"))
-	if cleanPath != cleanRoot && !strings.HasPrefix(cleanPath, cleanRoot+string(os.PathSeparator)) {
-		return "failed", nil, "path must be under workspace_root"
+	if err := ensureLensMetadataLayout(paths); err != nil {
+		return "failed", nil, err.Error()
 	}
+	cleanPath, created, err := secureEnsureDirectory(paths.Workspace, paths.Root, 0o755)
+	if err != nil {
+		return "failed", nil, err.Error()
+	}
+	existing, err := readLensWorkspaceIdentity(paths.Identity)
+	if err == nil {
+		if existing != identity {
+			return "failed", nil, "managed workspace identity does not match"
+		}
+		return "success", map[string]any{"path": cleanPath, "created": false}, ""
+	}
+	if !os.IsNotExist(err) {
+		return "failed", nil, err.Error()
+	}
+	if err := writeLensWorkspaceIdentity(paths.Identity, identity); err != nil {
+		if os.IsExist(err) {
+			existing, readErr := readLensWorkspaceIdentity(paths.Identity)
+			if readErr == nil && existing == identity {
+				return "success", map[string]any{"path": cleanPath, "created": false}, ""
+			}
+		}
+		return "failed", nil, err.Error()
+	}
+	return "success", map[string]any{"path": cleanPath, "created": created}, ""
+}
 
-	if err := os.MkdirAll(cleanPath, 0o755); err != nil {
+func (e *Engine) runLensKsCleanup(ctx context.Context, p Payload) (string, map[string]any, string) {
+	if err := ctx.Err(); err != nil {
+		return "failed", nil, "canceled"
+	}
+	identity, err := lensWorkspaceIdentityFromPayload(p)
+	if err != nil {
+		return "failed", nil, err.Error()
+	}
+	paths, err := resolveLensWorkspacePaths(p.Path, payloadStringValue(p.Extra["workspace_root"]), identity.WorkspaceUID)
+	if err != nil {
+		return "failed", nil, err.Error()
+	}
+	workspaceMissing := pathMissing(paths.Workspace)
+	trashMissing := pathMissing(paths.Trash)
+	identityMissing := pathMissing(paths.Identity)
+	if workspaceMissing && trashMissing && identityMissing {
+		return "success", map[string]any{"path": paths.Workspace, "removed": false}, ""
+	}
+	if err := validateLensWorkspaceIdentity(paths.Identity, identity); err != nil {
+		return "failed", nil, err.Error()
+	}
+	if err := ensureLensMetadataLayout(paths); err != nil {
 		return "failed", nil, err.Error()
 	}
 
-	return "success", map[string]any{
-		"path":    cleanPath,
-		"created": true,
-	}, ""
+	workspaceExists := !workspaceMissing
+	trashExists := !trashMissing
+	if workspaceExists && trashExists {
+		return "failed", nil, "managed workspace and trash both exist"
+	}
+	if workspaceExists {
+		fd, _, openErr := secureOpenDirectory(paths.Workspace, paths.Root, false, uint64(os.O_RDONLY))
+		if openErr != nil {
+			return "failed", nil, openErr.Error()
+		}
+		workspaceDirectory := secureDirectoryFile(fd, paths.Workspace)
+		if workspaceDirectory == nil {
+			return "failed", nil, "restricted Data Gateway filesystem operations require Linux"
+		}
+		_ = workspaceDirectory.Close()
+		if err := os.Rename(paths.Workspace, paths.Trash); err != nil {
+			return "failed", nil, err.Error()
+		}
+		trashExists = true
+	}
+	if trashExists {
+		if err := removeLensWorkspaceTrash(paths.Trash); err != nil {
+			// The external identity intentionally survives partial deletion so a
+			// retry can safely finish removing the quarantined workspace.
+			return "failed", nil, err.Error()
+		}
+	}
+	if err := os.Remove(paths.Identity); err != nil && !os.IsNotExist(err) {
+		return "failed", nil, err.Error()
+	}
+	return "success", map[string]any{"path": paths.Workspace, "removed": workspaceExists || trashExists}, ""
+}
+
+func pathMissing(path string) bool {
+	_, err := os.Lstat(path)
+	return os.IsNotExist(err)
 }

--- a/src/agent/internal/engine/lens_prepare_test.go
+++ b/src/agent/internal/engine/lens_prepare_test.go
@@ -2,20 +2,58 @@ package engine
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
 )
 
+func newLensTestRoot(t *testing.T) string {
+	t.Helper()
+	root := filepath.Join(t.TempDir(), "data")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
+func testIdentityPath(root, workspaceUID string) string {
+	return filepath.Join(filepath.Dir(root), ".hyperfilelens", "identities", workspaceUID+".json")
+}
+
+func testTrashPath(root, workspaceUID string) string {
+	return filepath.Join(root, ".hyperfilelens-trash", workspaceUID)
+}
+
+func TestLensWorkspaceTrashStaysInsideWorkspaceFilesystem(t *testing.T) {
+	root := newLensTestRoot(t)
+	paths, err := resolveLensWorkspacePaths(
+		filepath.Join(root, "tenants", "61", "knowledge-sources", "workspace-42"),
+		root,
+		"workspace-42",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if filepath.Dir(paths.TrashRoot) != root {
+		t.Fatalf("trash root must stay inside workspace root: %s", paths.TrashRoot)
+	}
+}
+
 func TestRunLensKsPrepareCreatesDirectory(t *testing.T) {
-	root := t.TempDir()
+	root := newLensTestRoot(t)
 	target := filepath.Join(root, "ks-42")
 	eng := New(nil)
 
 	status, result, errMsg := eng.runLensKsPrepare(context.Background(), Payload{
 		Path: target,
 		Extra: map[string]any{
-			"workspace_root": root,
+			"workspace_root":         root,
+			"workspace_uid":          "workspace-42",
+			"tenant_organization_id": 61,
+			"gateway_link_id":        7,
+			"knowledge_source_id":    42,
+			"workspace_kind":         "managed_restore",
 		},
 	})
 	if status != "success" {
@@ -28,16 +66,27 @@ func TestRunLensKsPrepareCreatesDirectory(t *testing.T) {
 	if !info.IsDir() {
 		t.Fatalf("expected directory")
 	}
+	if _, err := os.Stat(testIdentityPath(root, "workspace-42")); err != nil {
+		t.Fatalf("workspace identity: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(target, ".hfl-workspace.json")); !os.IsNotExist(err) {
+		t.Fatalf("identity must not be stored in restored data, err=%v", err)
+	}
 }
 
 func TestRunLensKsPrepareRejectsPathOutsideRoot(t *testing.T) {
-	root := t.TempDir()
+	root := newLensTestRoot(t)
 	eng := New(nil)
 
 	status, _, errMsg := eng.runLensKsPrepare(context.Background(), Payload{
 		Path: "/tmp/outside",
 		Extra: map[string]any{
-			"workspace_root": root,
+			"workspace_root":         root,
+			"workspace_uid":          "workspace-outside",
+			"tenant_organization_id": 61,
+			"gateway_link_id":        7,
+			"knowledge_source_id":    42,
+			"workspace_kind":         "managed_restore",
 		},
 	})
 	if status != "failed" {
@@ -45,5 +94,317 @@ func TestRunLensKsPrepareRejectsPathOutsideRoot(t *testing.T) {
 	}
 	if errMsg == "" {
 		t.Fatal("expected error message")
+	}
+}
+
+func TestRunLensKsPrepareRejectsManagedTrashPath(t *testing.T) {
+	root := newLensTestRoot(t)
+	status, _, errMsg := New(nil).runLensKsPrepare(context.Background(), Payload{
+		Path: filepath.Join(root, lensWorkspaceTrashDirectory, "workspace-42"),
+		Extra: map[string]any{
+			"workspace_root":         root,
+			"workspace_uid":          "workspace-42",
+			"tenant_organization_id": 61,
+			"gateway_link_id":        7,
+			"knowledge_source_id":    42,
+			"workspace_kind":         "managed_restore",
+		},
+	})
+	if status != "failed" || errMsg == "" {
+		t.Fatalf("expected reserved trash rejection, status=%q err=%q", status, errMsg)
+	}
+}
+
+func TestRunLensKsCleanupRemovesOnlyMatchingManagedWorkspace(t *testing.T) {
+	root := newLensTestRoot(t)
+	target := filepath.Join(root, "tenant-61-ks-42")
+	eng := New(nil)
+	payload := Payload{
+		Path: target,
+		Extra: map[string]any{
+			"workspace_root":         root,
+			"workspace_uid":          "workspace-42",
+			"tenant_organization_id": 61,
+			"gateway_link_id":        7,
+			"knowledge_source_id":    42,
+			"workspace_kind":         "managed_restore",
+		},
+	}
+	if status, _, errMsg := eng.runLensKsPrepare(context.Background(), payload); status != "success" {
+		t.Fatalf("prepare status=%q err=%q", status, errMsg)
+	}
+	status, result, errMsg := eng.runLensKsCleanup(context.Background(), payload)
+	if status != "success" {
+		t.Fatalf("cleanup status=%q err=%q result=%v", status, errMsg, result)
+	}
+	if _, err := os.Stat(target); !os.IsNotExist(err) {
+		t.Fatalf("expected workspace removal, err=%v", err)
+	}
+}
+
+func TestRunLensKsCleanupRejectsUnmanagedDirectory(t *testing.T) {
+	root := newLensTestRoot(t)
+	target := filepath.Join(root, "user-data")
+	if err := os.MkdirAll(target, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	eng := New(nil)
+	status, _, errMsg := eng.runLensKsCleanup(context.Background(), Payload{
+		Path: target,
+		Extra: map[string]any{
+			"workspace_root":         root,
+			"workspace_uid":          "workspace-unmanaged",
+			"tenant_organization_id": 61,
+			"gateway_link_id":        7,
+			"knowledge_source_id":    42,
+			"workspace_kind":         "managed_restore",
+		},
+	})
+	if status != "failed" || errMsg == "" {
+		t.Fatalf("expected unmanaged cleanup rejection, status=%q err=%q", status, errMsg)
+	}
+	if _, err := os.Stat(target); err != nil {
+		t.Fatalf("unmanaged directory was modified: %v", err)
+	}
+}
+
+func TestRunLensKsCleanupRejectsUnverifiedTrashDirectory(t *testing.T) {
+	root := newLensTestRoot(t)
+	target := filepath.Join(root, "missing-workspace")
+	trash := testTrashPath(root, "workspace-42")
+	if err := os.MkdirAll(trash, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(trash, "unrelated.txt"), []byte("keep"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	eng := New(nil)
+	status, _, errMsg := eng.runLensKsCleanup(context.Background(), Payload{
+		Path: target,
+		Extra: map[string]any{
+			"workspace_root":         root,
+			"workspace_uid":          "workspace-42",
+			"tenant_organization_id": 61,
+			"gateway_link_id":        7,
+			"knowledge_source_id":    42,
+			"workspace_kind":         "managed_restore",
+		},
+	})
+	if status != "failed" || errMsg == "" {
+		t.Fatalf("expected unverified trash rejection, status=%q err=%q", status, errMsg)
+	}
+	if _, err := os.Stat(filepath.Join(trash, "unrelated.txt")); err != nil {
+		t.Fatalf("unverified trash was removed: %v", err)
+	}
+}
+
+func TestRunLensKsPrepareRejectsIdentityOverwrite(t *testing.T) {
+	root := newLensTestRoot(t)
+	target := filepath.Join(root, "tenant-61-ks-42")
+	eng := New(nil)
+	payload := Payload{
+		Path: target,
+		Extra: map[string]any{
+			"workspace_root":         root,
+			"workspace_uid":          "workspace-42",
+			"tenant_organization_id": 61,
+			"gateway_link_id":        7,
+			"knowledge_source_id":    42,
+			"workspace_kind":         "managed_restore",
+		},
+	}
+	if status, _, errMsg := eng.runLensKsPrepare(context.Background(), payload); status != "success" {
+		t.Fatalf("prepare status=%q err=%q", status, errMsg)
+	}
+	payload.Extra["tenant_organization_id"] = 62
+	status, _, errMsg := eng.runLensKsPrepare(context.Background(), payload)
+	if status != "failed" || errMsg == "" {
+		t.Fatalf("expected identity mismatch, status=%q err=%q", status, errMsg)
+	}
+	identity, err := readLensWorkspaceIdentity(testIdentityPath(root, "workspace-42"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if identity.TenantOrganizationID != "61" {
+		t.Fatalf("identity was overwritten: %+v", identity)
+	}
+}
+
+func TestRunLensKsCleanupIdentityMismatchNeverDeletes(t *testing.T) {
+	root := newLensTestRoot(t)
+	target := filepath.Join(root, "tenant-61-ks-42")
+	engine := New(nil)
+	payload := Payload{
+		Path: target,
+		Extra: map[string]any{
+			"workspace_root":         root,
+			"workspace_uid":          "workspace-42",
+			"tenant_organization_id": 61,
+			"gateway_link_id":        7,
+			"knowledge_source_id":    42,
+			"workspace_kind":         "managed_restore",
+		},
+	}
+	if status, _, errMsg := engine.runLensKsPrepare(context.Background(), payload); status != "success" {
+		t.Fatalf("prepare status=%q err=%q", status, errMsg)
+	}
+	payload.Extra["tenant_organization_id"] = 62
+	status, _, errMsg := engine.runLensKsCleanup(context.Background(), payload)
+	if status != "failed" || errMsg == "" {
+		t.Fatalf("expected identity mismatch, status=%q err=%q", status, errMsg)
+	}
+	if _, err := os.Stat(target); err != nil {
+		t.Fatalf("mismatched workspace was deleted: %v", err)
+	}
+}
+
+func TestRunLensKsPrepareRejectsSymlinkEscape(t *testing.T) {
+	root := newLensTestRoot(t)
+	outside := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(root, "escape")); err != nil {
+		t.Fatal(err)
+	}
+	eng := New(nil)
+	status, _, errMsg := eng.runLensKsPrepare(context.Background(), Payload{
+		Path: filepath.Join(root, "escape", "ks-42"),
+		Extra: map[string]any{
+			"workspace_root":         root,
+			"workspace_uid":          "workspace-42",
+			"tenant_organization_id": 61,
+			"gateway_link_id":        7,
+			"knowledge_source_id":    42,
+			"workspace_kind":         "managed_restore",
+		},
+	})
+	if status != "failed" || errMsg == "" {
+		t.Fatalf("expected symlink rejection, status=%q err=%q", status, errMsg)
+	}
+	if _, err := os.Stat(filepath.Join(outside, "ks-42")); !os.IsNotExist(err) {
+		t.Fatalf("outside directory was modified, err=%v", err)
+	}
+}
+
+func TestValidateLensManagedRestoreTargetRejectsWorkspaceEscapeAndSymlink(t *testing.T) {
+	root := newLensTestRoot(t)
+	workspace := filepath.Join(root, "tenants", "61", "knowledge-sources", "workspace-42")
+	payload := Payload{
+		Path: workspace,
+		Extra: map[string]any{
+			"workspace_root":         root,
+			"workspace_uid":          "workspace-42",
+			"tenant_organization_id": 61,
+			"gateway_link_id":        7,
+			"knowledge_source_id":    42,
+			"workspace_kind":         "managed_restore",
+			"managed_workspace_path": workspace,
+		},
+	}
+	eng := New(nil)
+	if status, _, errMsg := eng.runLensKsPrepare(context.Background(), payload); status != "success" {
+		t.Fatalf("prepare status=%q err=%q", status, errMsg)
+	}
+	if err := validateLensManagedRestoreTarget(payload, filepath.Join(workspace, "docs", "file.txt")); err != nil {
+		t.Fatalf("valid managed target rejected: %v", err)
+	}
+	if err := validateLensManagedRestoreTarget(payload, filepath.Join(root, "another-tenant")); err == nil {
+		t.Fatal("expected workspace escape rejection")
+	}
+	outside := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(workspace, "escape")); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateLensManagedRestoreTarget(payload, filepath.Join(workspace, "escape", "file.txt")); err == nil {
+		t.Fatal("expected restore symlink rejection")
+	}
+}
+
+func TestRunLensKsPrepareRejectsTraversalComponents(t *testing.T) {
+	root := newLensTestRoot(t)
+	payload := Payload{
+		Path: filepath.Join(root, "tenant") + "/../../etc",
+		Extra: map[string]any{
+			"workspace_root":         root,
+			"workspace_uid":          "workspace-42",
+			"tenant_organization_id": 61,
+			"gateway_link_id":        7,
+			"knowledge_source_id":    42,
+			"workspace_kind":         "managed_restore",
+		},
+	}
+	status, _, errMsg := New(nil).runLensKsPrepare(context.Background(), payload)
+	if status != "failed" || errMsg == "" {
+		t.Fatalf("expected traversal rejection, status=%q err=%q", status, errMsg)
+	}
+}
+
+func TestRestoredLegacyMarkerCannotChangeExternalIdentity(t *testing.T) {
+	root := newLensTestRoot(t)
+	target := filepath.Join(root, "tenant-61-ks-42")
+	payload := Payload{
+		Path: target,
+		Extra: map[string]any{
+			"workspace_root":         root,
+			"workspace_uid":          "workspace-42",
+			"tenant_organization_id": 61,
+			"gateway_link_id":        7,
+			"knowledge_source_id":    42,
+			"workspace_kind":         "managed_restore",
+			"managed_workspace_path": target,
+		},
+	}
+	if status, _, errMsg := New(nil).runLensKsPrepare(context.Background(), payload); status != "success" {
+		t.Fatalf("prepare status=%q err=%q", status, errMsg)
+	}
+	if err := os.WriteFile(filepath.Join(target, ".hfl-workspace.json"), []byte(`{"tenant_organization_id":"attacker"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateLensManagedRestoreTarget(payload, target); err != nil {
+		t.Fatalf("restored legacy marker affected external identity: %v", err)
+	}
+}
+
+func TestRunLensKsCleanupRetriesAfterPartialTrashRemoval(t *testing.T) {
+	root := newLensTestRoot(t)
+	target := filepath.Join(root, "tenant-61-ks-42")
+	payload := Payload{
+		Path: target,
+		Extra: map[string]any{
+			"workspace_root":         root,
+			"workspace_uid":          "workspace-42",
+			"tenant_organization_id": 61,
+			"gateway_link_id":        7,
+			"knowledge_source_id":    42,
+			"workspace_kind":         "managed_restore",
+		},
+	}
+	engine := New(nil)
+	if status, _, errMsg := engine.runLensKsPrepare(context.Background(), payload); status != "success" {
+		t.Fatalf("prepare status=%q err=%q", status, errMsg)
+	}
+	if err := os.WriteFile(filepath.Join(target, "data.txt"), []byte("data"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	originalRemove := removeLensWorkspaceTrash
+	removeLensWorkspaceTrash = func(path string) error {
+		if err := os.Remove(filepath.Join(path, "data.txt")); err != nil {
+			return err
+		}
+		return errors.New("injected partial removal")
+	}
+	status, _, _ := engine.runLensKsCleanup(context.Background(), payload)
+	removeLensWorkspaceTrash = originalRemove
+	if status != "failed" {
+		t.Fatalf("expected injected failure, got %q", status)
+	}
+	if _, err := os.Stat(testIdentityPath(root, "workspace-42")); err != nil {
+		t.Fatalf("identity must survive partial removal: %v", err)
+	}
+	status, _, errMsg := engine.runLensKsCleanup(context.Background(), payload)
+	if status != "success" {
+		t.Fatalf("retry status=%q err=%q", status, errMsg)
+	}
+	if _, err := os.Stat(testIdentityPath(root, "workspace-42")); !os.IsNotExist(err) {
+		t.Fatalf("identity should be removed last, err=%v", err)
 	}
 }

--- a/src/agent/internal/engine/lens_secure_linux.go
+++ b/src/agent/internal/engine/lens_secure_linux.go
@@ -1,0 +1,180 @@
+//go:build linux
+
+package engine
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/sys/unix"
+)
+
+const secureResolveFlags = unix.RESOLVE_BENEATH | unix.RESOLVE_NO_SYMLINKS
+
+func secureOpenatBeneath(dirFD int, relative string, flags uint64) (int, error) {
+	fd, err := unix.Openat2(dirFD, relative, &unix.OpenHow{
+		Flags:   flags,
+		Resolve: secureResolveFlags,
+	})
+	if err == nil || (!errors.Is(err, unix.ENOSYS) && !errors.Is(err, unix.EINVAL)) {
+		return fd, err
+	}
+	// Ubuntu 20.04 may use a pre-openat2 5.4 kernel. Preserve the same
+	// no-symlink, component-by-component boundary with directory FDs.
+	components := strings.Split(relative, "/")
+	currentFD := dirFD
+	ownedCurrent := false
+	for index, component := range components {
+		if component == "" || component == "." {
+			component = "."
+		}
+		componentFlags := uint64(unix.O_PATH | unix.O_DIRECTORY | unix.O_CLOEXEC | unix.O_NOFOLLOW)
+		if index == len(components)-1 {
+			componentFlags = flags
+		}
+		nextFD, openErr := unix.Openat(currentFD, component, int(componentFlags), 0)
+		if ownedCurrent {
+			_ = unix.Close(currentFD)
+		}
+		if openErr != nil {
+			return -1, openErr
+		}
+		currentFD = nextFD
+		ownedCurrent = true
+	}
+	return currentFD, nil
+}
+
+func validateLinuxAbsolutePath(path, field string) (string, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return "", fmt.Errorf("%s is required", field)
+	}
+	if strings.ContainsRune(path, '\x00') || strings.Contains(path, `\`) || !filepath.IsAbs(path) {
+		return "", fmt.Errorf("%s must be an absolute Linux path", field)
+	}
+	for _, component := range strings.Split(path, "/") {
+		if component == "." || component == ".." {
+			return "", fmt.Errorf("%s contains an unsafe path component", field)
+		}
+	}
+	return filepath.Clean(path), nil
+}
+
+func secureRelativePath(path, allowedRoot string, allowRoot bool) (string, string, error) {
+	cleanRoot, err := validateLinuxAbsolutePath(allowedRoot, "allowed_root")
+	if err != nil {
+		return "", "", err
+	}
+	cleanPath, err := validateLinuxAbsolutePath(path, "path")
+	if err != nil {
+		return "", "", err
+	}
+	relative, err := filepath.Rel(cleanRoot, cleanPath)
+	if err != nil || filepath.IsAbs(relative) || relative == ".." || strings.HasPrefix(relative, "../") {
+		return "", "", errors.New("path must be contained by allowed_root")
+	}
+	if relative == "." && !allowRoot {
+		return "", "", errors.New("path must be a child of allowed_root")
+	}
+	return cleanRoot, relative, nil
+}
+
+func secureOpenAbsoluteDirectory(path string) (int, error) {
+	cleanPath, err := validateLinuxAbsolutePath(path, "path")
+	if err != nil {
+		return -1, err
+	}
+	rootFD, err := unix.Open("/", unix.O_PATH|unix.O_DIRECTORY|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return -1, err
+	}
+	defer unix.Close(rootFD)
+	relative := strings.TrimPrefix(cleanPath, "/")
+	if relative == "" {
+		relative = "."
+	}
+	return secureOpenatBeneath(
+		rootFD,
+		relative,
+		unix.O_PATH|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW,
+	)
+}
+
+func secureOpenDirectory(path, allowedRoot string, allowRoot bool, flags uint64) (int, string, error) {
+	cleanRoot, relative, err := secureRelativePath(path, allowedRoot, allowRoot)
+	if err != nil {
+		return -1, "", err
+	}
+	rootFD, err := secureOpenAbsoluteDirectory(cleanRoot)
+	if err != nil {
+		return -1, "", fmt.Errorf("allowed_root is not a safe directory: %w", err)
+	}
+	defer unix.Close(rootFD)
+	if relative == "." {
+		relative = "."
+	}
+	fd, err := secureOpenatBeneath(
+		rootFD,
+		relative,
+		flags|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW,
+	)
+	if err != nil {
+		return -1, "", err
+	}
+	cleanPath := cleanRoot
+	if relative != "." {
+		cleanPath = filepath.Join(cleanRoot, relative)
+	}
+	return fd, cleanPath, nil
+}
+
+func secureEnsureDirectory(path, allowedRoot string, mode uint32) (string, bool, error) {
+	cleanRoot, relative, err := secureRelativePath(path, allowedRoot, false)
+	if err != nil {
+		return "", false, err
+	}
+	rootFD, err := secureOpenAbsoluteDirectory(cleanRoot)
+	if err != nil {
+		return "", false, fmt.Errorf("allowed_root is not a safe directory: %w", err)
+	}
+	defer unix.Close(rootFD)
+
+	currentFD, err := unix.Dup(rootFD)
+	if err != nil {
+		return "", false, err
+	}
+	defer func() { _ = unix.Close(currentFD) }()
+	created := false
+	for _, component := range strings.Split(relative, "/") {
+		nextFD, openErr := secureOpenatBeneath(
+			currentFD,
+			component,
+			unix.O_PATH|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW,
+		)
+		if errors.Is(openErr, unix.ENOENT) {
+			if mkdirErr := unix.Mkdirat(currentFD, component, mode); mkdirErr != nil && !errors.Is(mkdirErr, unix.EEXIST) {
+				return "", false, mkdirErr
+			}
+			created = true
+			nextFD, openErr = secureOpenatBeneath(
+				currentFD,
+				component,
+				unix.O_PATH|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW,
+			)
+		}
+		if openErr != nil {
+			return "", false, openErr
+		}
+		_ = unix.Close(currentFD)
+		currentFD = nextFD
+	}
+	return filepath.Join(cleanRoot, relative), created, nil
+}
+
+func secureDirectoryFile(fd int, name string) *os.File {
+	return os.NewFile(uintptr(fd), name)
+}

--- a/src/agent/internal/engine/lens_secure_unsupported.go
+++ b/src/agent/internal/engine/lens_secure_unsupported.go
@@ -1,0 +1,22 @@
+//go:build !linux
+
+package engine
+
+import (
+	"errors"
+	"os"
+)
+
+var errRestrictedGatewayUnsupported = errors.New("restricted Data Gateway filesystem operations require Linux")
+
+func secureOpenDirectory(path, allowedRoot string, allowRoot bool, flags uint64) (int, string, error) {
+	return -1, "", errRestrictedGatewayUnsupported
+}
+
+func secureEnsureDirectory(path, allowedRoot string, mode uint32) (string, bool, error) {
+	return "", false, errRestrictedGatewayUnsupported
+}
+
+func secureDirectoryFile(fd int, name string) *os.File {
+	return nil
+}

--- a/src/agent/internal/engine/managed_backup.go
+++ b/src/agent/internal/engine/managed_backup.go
@@ -1492,6 +1492,9 @@ func (e *Engine) runManagedRestore(
 	if targetPath == "" {
 		return "failed", nil, "target_path is required"
 	}
+	if err := validateLensManagedRestoreTarget(p, targetPath); err != nil {
+		return "failed", nil, err.Error()
+	}
 	bin, err := e.kopiaBin(ctx)
 	if err != nil {
 		return "failed", nil, err.Error()
@@ -1517,6 +1520,9 @@ func (e *Engine) runManagedRestore(
 	for pathIndex, selectedPath := range selectedPaths {
 		source := snapshotObjectPath(p.SnapshotID, selectedPath)
 		restoreTarget := restoreTargetPathForSelection(p, targetPath, selectedPath)
+		if err := validateLensManagedRestoreTarget(p, restoreTarget); err != nil {
+			return "failed", result, err.Error()
+		}
 		sourceIsDir, inspectRes, inspectErr := snapshotDownloadTargetIsDir(ctx, bin, configFile, env, source)
 		sourceObjectType := "directory"
 		if inspectErr != nil {
@@ -1593,6 +1599,9 @@ func (e *Engine) runManagedRestore(
 		if lastPathTotal > 0 {
 			completedBytes += lastPathTotal
 		}
+	}
+	if err := validateLensManagedRestoreTarget(p, targetPath); err != nil {
+		return "failed", result, "managed workspace identity changed during restore: " + err.Error()
 	}
 	result["snapshot_id"] = p.SnapshotID
 	result["target_path"] = targetPath

--- a/src/agent/internal/engine/payload.go
+++ b/src/agent/internal/engine/payload.go
@@ -194,6 +194,10 @@ func NormalizeKind(kind string) string {
 		return "nas.test"
 	case "lens.workspace.prepare":
 		return "lens.ks.prepare"
+	case "lens.workspace.cleanup":
+		return "lens.ks.cleanup"
+	case "lens.gateway.browse", "lens.workspace.validate-local":
+		return k
 	default:
 		return k
 	}

--- a/src/backend/apps/lens_bridge/api/serializers.py
+++ b/src/backend/apps/lens_bridge/api/serializers.py
@@ -1,6 +1,10 @@
 from rest_framework import serializers
 
-from apps.lens_bridge.models import LensKnowledgeSource, LensSessionLink
+from apps.lens_bridge.models import (
+    LensGatewayLink,
+    LensKnowledgeSource,
+    LensSessionLink,
+)
 from apps.lens_bridge.services import gateway_readiness, ingest_policy, provisioning
 from apps.protection.models import BackupConfig, BackupSourceSnapshot
 from apps.protection.services.source_identity import resolve_source_display_name
@@ -31,6 +35,7 @@ class LensKnowledgeSourceSerializer(serializers.ModelSerializer):
             "sl_lensnode_uuid",
             "status",
             "status_detail",
+            "lifecycle_status",
             "sync_phase",
             "sync_state_json",
             "last_restore_record_id",
@@ -49,6 +54,7 @@ class LensKnowledgeSourceSerializer(serializers.ModelSerializer):
             "sl_lensnode_uuid",
             "status",
             "status_detail",
+            "lifecycle_status",
             "sync_phase",
             "sync_state_json",
             "last_restore_record_id",
@@ -108,7 +114,32 @@ class LensKnowledgeSourceCreateSerializer(serializers.ModelSerializer):
             return attrs
         gateway = attrs["gateway"]
         provisioning.require_gateway_node(org, gateway.id)
-        link = provisioning.get_gateway_link(org, gateway.id)
+        expected_scope = self.context.get(
+            "gateway_scope",
+            LensGatewayLink.GatewayScope.USER,
+        )
+        if expected_scope == LensGatewayLink.GatewayScope.USER:
+            from apps.lens_bridge.services.gateway_execution import (
+                require_user_gateway_link,
+            )
+
+            owner_user_id = self.context.get("gateway_owner_user_id")
+            if owner_user_id is None:
+                raise serializers.ValidationError(
+                    {"gateway": "Private data gateway owner is required."}
+                )
+            link = require_user_gateway_link(
+                tenant_organization=org,
+                gateway_id=gateway.id,
+                owner_user_id=owner_user_id,
+                require_ready=False,
+            )
+        else:
+            link = provisioning.get_gateway_link(org, gateway.id)
+            if link.scope != expected_scope:
+                raise serializers.ValidationError(
+                    {"gateway": "Data gateway scope is invalid for this operation."}
+                )
         gateway_readiness.require_hfl_usable_gateway(link, field="gateway")
 
         source_scopes = attrs.pop("source_scopes", None)
@@ -155,11 +186,23 @@ class LensKnowledgeSourceCreateSerializer(serializers.ModelSerializer):
         attrs["source_path"] = source_path
 
         if is_gateway_local:
-            root = link.resolved_workspace_root().rstrip("/") or "/"
-            if source_path != root and not source_path.startswith(f"{root}/"):
+            from apps.lens_bridge.services.gateway_paths import (
+                GatewayPathError,
+                path_within_root,
+            )
+
+            try:
+                source_path = path_within_root(
+                    source_path,
+                    link.resolved_workspace_root(),
+                    allow_root=True,
+                    field="source_path",
+                )
+            except GatewayPathError as exc:
                 raise serializers.ValidationError(
                     {"source_path": "Directory must be under the gateway workspace root."}
-                )
+                ) from exc
+            attrs["source_path"] = source_path
         else:
             if not attrs.get("backup_source_snapshot_id"):
                 raise serializers.ValidationError(

--- a/src/backend/apps/lens_bridge/api/views.py
+++ b/src/backend/apps/lens_bridge/api/views.py
@@ -1,6 +1,7 @@
 from django.http import JsonResponse, StreamingHttpResponse
 import uuid
 
+from django.db import transaction
 from rest_framework import status, viewsets
 from rest_framework.decorators import action
 from rest_framework.exceptions import NotFound, ValidationError
@@ -220,6 +221,8 @@ class LensKnowledgeSourceViewSet(OrgScopedMixin, viewsets.ModelViewSet):
     def get_serializer_context(self):
         ctx = super().get_serializer_context()
         ctx["org"] = self.org
+        ctx["gateway_scope"] = LensGatewayLink.GatewayScope.USER
+        ctx["gateway_owner_user_id"] = self.request.user.id
         return ctx
 
     def list(self, request, *args, **kwargs):
@@ -236,26 +239,62 @@ class LensKnowledgeSourceViewSet(OrgScopedMixin, viewsets.ModelViewSet):
         return Response(serializer.data)
 
     def perform_create(self, serializer):
-        gateway = provisioning.require_gateway_node(self.org, serializer.validated_data["gateway"].id)
-        gateway_link = provisioning.get_gateway_link(self.org, gateway.id)
-        ks = serializer.save(
-            organization=self.org,
-            created_by=self.request.user,
-            sl_lensnode_uuid=gateway_link.sl_lensnode_uuid,
-        )
-        ks = knowledge_source_sync.prepare_new_knowledge_source(org=self.org, ks=ks)
-        knowledge_source_sync.enqueue_knowledge_source_sync(
-            organization_id=self.org.id,
-            knowledge_source_id=ks.id,
-            mode="full",
+        from apps.lens_bridge.services.gateway_execution import (
+            require_user_gateway_link,
         )
 
+        with transaction.atomic():
+            gateway_link = require_user_gateway_link(
+                tenant_organization=self.org,
+                gateway_id=serializer.validated_data["gateway"].id,
+                owner_user_id=self.request.user.id,
+                lock=True,
+            )
+            ks = serializer.save(
+                organization=self.org,
+                created_by=self.request.user,
+                gateway_link=gateway_link,
+                sl_lensnode_uuid=gateway_link.sl_lensnode_uuid,
+            )
+            ks = knowledge_source_sync.prepare_new_knowledge_source(
+                org=self.org,
+                ks=ks,
+            )
+            transaction.on_commit(
+                lambda organization_id=self.org.id, knowledge_source_id=ks.id: (
+                    knowledge_source_sync.enqueue_knowledge_source_sync(
+                        organization_id=organization_id,
+                        knowledge_source_id=knowledge_source_id,
+                        mode="full",
+                    )
+                )
+            )
+
     def perform_update(self, serializer):
+        if (
+            serializer.instance.lifecycle_status
+            != LensKnowledgeSource.LifecycleStatus.READY
+        ):
+            raise ValidationError(
+                {"lifecycle_status": "Knowledge source is being deleted."}
+            )
         scan_changed = "scan_enabled" in serializer.validated_data
         ks = serializer.save()
         if scan_changed and not ks.scan_enabled:
             ks.status = LensKnowledgeSource.Status.PAUSED
             ks.save(update_fields=["status", "updated_at"])
+
+    def destroy(self, request, *args, **kwargs):
+        from apps.lens_bridge.services.knowledge_source_teardown import (
+            request_knowledge_source_teardown,
+        )
+
+        instance = self.get_object()
+        request_knowledge_source_teardown(instance)
+        return Response(
+            {"id": instance.id, "lifecycle_status": "deleting"},
+            status=status.HTTP_202_ACCEPTED,
+        )
 
     @action(detail=True, methods=["post"])
     def sync(self, request, pk=None):
@@ -302,6 +341,7 @@ class LensGatewayViewSet(OrgScopedMixin, viewsets.ViewSet):
             organization=self.org,
             gateway=gateway,
             scope=LensGatewayLink.GatewayScope.USER,
+            owner_user=request.user,
         ).first()
         if link and link.sl_lensnode_uuid:
             provisioning.sync_gateway_lensnode_status(link)
@@ -309,6 +349,7 @@ class LensGatewayViewSet(OrgScopedMixin, viewsets.ViewSet):
             org=self.org,
             gateway=gateway,
             name=body.validated_data.get("name") or None,
+            owner_user=request.user,
             scope=LensGatewayLink.GatewayScope.USER,
         )
         payload = provisioning.build_gateway_ai_payload(
@@ -321,11 +362,16 @@ class LensGatewayViewSet(OrgScopedMixin, viewsets.ViewSet):
     @action(detail=True, methods=["get"], url_path="ai")
     def ai_status(self, request, pk=None):
         gateway = provisioning.require_gateway_node(self.org, int(pk))
-        link = LensGatewayLink.objects.filter(
-            organization=self.org,
-            gateway=gateway,
-            scope=LensGatewayLink.GatewayScope.USER,
-        ).first()
+        from apps.lens_bridge.services.gateway_execution import (
+            require_user_gateway_link,
+        )
+
+        link = require_user_gateway_link(
+            tenant_organization=self.org,
+            gateway_id=gateway.id,
+            owner_user_id=request.user.id,
+            require_ready=False,
+        )
         if link and link.sl_lensnode_uuid:
             provisioning.sync_gateway_lensnode_status(link)
         return Response(
@@ -344,6 +390,8 @@ class LensGatewayViewSet(OrgScopedMixin, viewsets.ViewSet):
                 org=self.org,
                 gateway_id=int(pk),
                 path=path,
+                expected_scope=LensGatewayLink.GatewayScope.USER,
+                expected_owner_user_id=request.user.id,
             )
         except ValidationError as exc:
             return Response(exc.detail, status=status.HTTP_400_BAD_REQUEST)
@@ -441,13 +489,12 @@ class LensAssistantViewSet(OrgScopedMixin, viewsets.ViewSet):
 
     def list(self, request):
         membership = get_membership(request)
-        manage = assistant_access.can_manage_all_assistants(membership)
+        can_manage_all = assistant_access.can_manage_all_assistants(membership)
         try:
             rows = list_org_assistants(
                 self.org,
                 user=request.user,
-                membership=membership,
-                manage=manage,
+                can_manage_all=can_manage_all,
             )
         except sl_client.LensBridgeError as exc:
             return Response({"detail": str(exc)}, status=status.HTTP_502_BAD_GATEWAY)
@@ -455,14 +502,13 @@ class LensAssistantViewSet(OrgScopedMixin, viewsets.ViewSet):
 
     def retrieve(self, request, pk=None):
         membership = get_membership(request)
-        manage = assistant_access.can_manage_all_assistants(membership)
+        can_manage_all = assistant_access.can_manage_all_assistants(membership)
         try:
             data = get_org_assistant(
                 self.org,
                 uuid.UUID(str(pk)),
                 user=request.user,
-                membership=membership,
-                manage=manage,
+                can_manage_all=can_manage_all,
             )
         except NotFound:
             raise
@@ -480,12 +526,15 @@ class LensAssistantViewSet(OrgScopedMixin, viewsets.ViewSet):
         return Response(data, status=status.HTTP_201_CREATED)
 
     def partial_update(self, request, pk=None):
+        membership = get_membership(request)
+        can_manage_all = assistant_access.can_manage_all_assistants(membership)
         try:
             data = update_org_assistant(
                 self.org,
                 uuid.UUID(str(pk)),
                 dict(request.data),
                 user=request.user,
+                can_manage_all=can_manage_all,
             )
         except NotFound:
             raise
@@ -496,8 +545,15 @@ class LensAssistantViewSet(OrgScopedMixin, viewsets.ViewSet):
         return Response(data)
 
     def destroy(self, request, pk=None):
+        membership = get_membership(request)
+        can_manage_all = assistant_access.can_manage_all_assistants(membership)
         try:
-            delete_org_assistant(self.org, uuid.UUID(str(pk)))
+            delete_org_assistant(
+                self.org,
+                uuid.UUID(str(pk)),
+                user=request.user,
+                can_manage_all=can_manage_all,
+            )
         except NotFound:
             raise
         except sl_client.LensBridgeError as exc:
@@ -507,7 +563,7 @@ class LensAssistantViewSet(OrgScopedMixin, viewsets.ViewSet):
     @action(detail=False, methods=["get"], url_path="form-options")
     def form_options(self, request):
         try:
-            data = assistant_form_options(self.org)
+            data = assistant_form_options(self.org, user=request.user)
         except sl_client.LensBridgeError as exc:
             return Response({"detail": str(exc)}, status=status.HTTP_502_BAD_GATEWAY)
         return Response(data)
@@ -752,7 +808,7 @@ class LensCopilotSessionViewSet(OrgScopedMixin, viewsets.ViewSet):
         link = self._get_user_link(pk)
         from apps.lens_bridge.services import chat_lifecycle
 
-        chat_lifecycle.request_copilot_chat_teardown(link)
+        link = chat_lifecycle.request_copilot_chat_teardown(link)
         return Response(LensSessionLinkSerializer(link).data, status=status.HTTP_202_ACCEPTED)
 
     @action(detail=True, methods=["post"], url_path="retry")

--- a/src/backend/apps/lens_bridge/migrations/0021_knowledge_source_gateway_link.py
+++ b/src/backend/apps/lens_bridge/migrations/0021_knowledge_source_gateway_link.py
@@ -1,0 +1,128 @@
+from django.conf import settings
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+def _resolve_gateway_link(gateway_links, knowledge_source):
+    """Resolve the only authoritative link for one historical KS row."""
+
+    exact = list(
+        gateway_links.filter(
+            organization_id=knowledge_source.organization_id,
+            gateway_id=knowledge_source.gateway_id,
+        ).values_list("id", flat=True)
+    )
+    if len(exact) == 1:
+        return exact[0]
+
+    platform = list(
+        gateway_links.filter(
+            gateway_id=knowledge_source.gateway_id,
+            scope="platform",
+        ).values_list("id", flat=True)
+    )
+    if len(platform) == 1:
+        return platform[0]
+
+    candidates = list(
+        gateway_links.filter(
+            gateway_id=knowledge_source.gateway_id,
+        ).values_list("id", flat=True)
+    )
+    if len(candidates) == 1:
+        return candidates[0]
+
+    raise RuntimeError(
+        "Cannot resolve an authoritative data gateway link for existing "
+        f"knowledge source id={knowledge_source.id}; "
+        f"candidate_link_ids={candidates}."
+    )
+
+
+def backfill_gateway_identity(apps, schema_editor):
+    """Backfill KS execution links and validate existing Gateway ownership."""
+
+    LensGatewayLink = apps.get_model("lens_bridge", "LensGatewayLink")
+    LensKnowledgeSource = apps.get_model("lens_bridge", "LensKnowledgeSource")
+    LensSessionLink = apps.get_model("lens_bridge", "LensSessionLink")
+    database_alias = schema_editor.connection.alias
+
+    gateway_links = LensGatewayLink.objects.using(database_alias)
+    knowledge_sources = LensKnowledgeSource.objects.using(database_alias)
+    session_links = LensSessionLink.objects.using(database_alias)
+
+    for knowledge_source in knowledge_sources.filter(
+        gateway_link_id__isnull=True
+    ).iterator():
+        link_id = _resolve_gateway_link(gateway_links, knowledge_source)
+        knowledge_sources.filter(pk=knowledge_source.pk).update(
+            gateway_link_id=link_id
+        )
+
+    unresolved_owner_links = []
+    for link in gateway_links.filter(scope="user", owner_user_id__isnull=True).iterator():
+        owner_ids = set(
+            knowledge_sources.filter(
+                gateway_link_id=link.id,
+                created_by_id__isnull=False,
+            ).values_list("created_by_id", flat=True)
+        )
+        owner_ids.update(
+            session_links.filter(
+                knowledge_source__gateway_link_id=link.id,
+                hfl_user_id__isnull=False,
+            ).values_list("hfl_user_id", flat=True)
+        )
+        if len(owner_ids) != 1:
+            unresolved_owner_links.append(
+                {"link_id": link.id, "candidate_owner_ids": sorted(owner_ids)}
+            )
+            continue
+        gateway_links.filter(pk=link.pk).update(owner_user_id=owner_ids.pop())
+
+    if unresolved_owner_links:
+        raise RuntimeError(
+            "Cannot determine one owner for existing private data gateway "
+            f"links: {unresolved_owner_links}."
+        )
+
+    gateway_links.filter(
+        scope="platform",
+        owner_user_id__isnull=False,
+    ).update(owner_user_id=None)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ("lens_bridge", "0020_alter_lensgatewaylink_sidecar_status"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="lensgatewaylink",
+            name="owner_user",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.PROTECT,
+                related_name="lens_gateway_links_owned",
+                to=settings.AUTH_USER_MODEL,
+            ),
+        ),
+        migrations.AddField(
+            model_name="lensknowledgesource",
+            name="gateway_link",
+            field=models.ForeignKey(
+                null=True,
+                help_text="Authoritative gateway authorization used for execution.",
+                on_delete=django.db.models.deletion.PROTECT,
+                related_name="knowledge_sources",
+                to="lens_bridge.lensgatewaylink",
+            ),
+        ),
+        migrations.RunPython(
+            backfill_gateway_identity,
+            migrations.RunPython.noop,
+        ),
+    ]

--- a/src/backend/apps/lens_bridge/migrations/0022_workspace_binding.py
+++ b/src/backend/apps/lens_bridge/migrations/0022_workspace_binding.py
@@ -1,0 +1,170 @@
+import uuid
+
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("lens_bridge", "0021_knowledge_source_gateway_link"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="lensknowledgesource",
+            name="gateway_link",
+            field=models.ForeignKey(
+                help_text="Authoritative gateway authorization used for execution.",
+                on_delete=django.db.models.deletion.PROTECT,
+                related_name="knowledge_sources",
+                to="lens_bridge.lensgatewaylink",
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name="lensgatewaylink",
+            constraint=models.CheckConstraint(
+                condition=(
+                    models.Q(scope="platform", owner_user_id__isnull=True)
+                    | models.Q(scope="user", owner_user_id__isnull=False)
+                ),
+                name="lens_brgw_scope_owner_ck",
+            ),
+        ),
+        migrations.CreateModel(
+            name="LensWorkspaceBinding",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("is_deleted", models.BooleanField(db_index=True, default=False)),
+                (
+                    "deleted_at",
+                    models.DateTimeField(blank=True, db_index=True, null=True),
+                ),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                (
+                    "workspace_uid",
+                    models.UUIDField(default=uuid.uuid4, editable=False, unique=True),
+                ),
+                ("execution_organization_id", models.BigIntegerField(db_index=True)),
+                ("execution_node_id", models.BigIntegerField(db_index=True)),
+                (
+                    "workspace_kind",
+                    models.CharField(
+                        choices=[
+                            ("managed_restore", "Managed restore"),
+                            ("gateway_local", "Gateway local"),
+                        ],
+                        db_index=True,
+                        max_length=24,
+                    ),
+                ),
+                ("workspace_root", models.CharField(max_length=500)),
+                (
+                    "relative_path",
+                    models.CharField(blank=True, default="", max_length=500),
+                ),
+                (
+                    "state",
+                    models.CharField(
+                        choices=[
+                            ("preparing", "Preparing"),
+                            ("ready", "Ready"),
+                            ("deleting", "Deleting"),
+                            ("deleted", "Deleted"),
+                            ("error", "Error"),
+                        ],
+                        db_index=True,
+                        default="preparing",
+                        max_length=16,
+                    ),
+                ),
+                (
+                    "identity_status",
+                    models.CharField(
+                        choices=[
+                            ("pending", "Pending"),
+                            ("ready", "Ready"),
+                            ("not_applicable", "Not applicable"),
+                            ("error", "Error"),
+                        ],
+                        db_index=True,
+                        default="pending",
+                        max_length=24,
+                    ),
+                ),
+                ("last_error", models.TextField(blank=True, default="")),
+                (
+                    "gateway_link",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name="workspace_bindings",
+                        to="lens_bridge.lensgatewaylink",
+                    ),
+                ),
+                (
+                    "knowledge_source",
+                    models.OneToOneField(
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name="workspace_binding",
+                        to="lens_bridge.lensknowledgesource",
+                    ),
+                ),
+                (
+                    "organization",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        to="iam.organization",
+                    ),
+                ),
+            ],
+            options={"db_table": "lens_bridge_workspace_binding"},
+        ),
+        migrations.AddConstraint(
+            model_name="lensworkspacebinding",
+            constraint=models.UniqueConstraint(
+                condition=~models.Q(relative_path=""),
+                fields=("gateway_link", "relative_path"),
+                name="uniq_lens_workspace_link_path",
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name="lensworkspacebinding",
+            constraint=models.CheckConstraint(
+                condition=(
+                    models.Q(
+                        workspace_kind="managed_restore",
+                        relative_path__gt="",
+                        identity_status__in=["pending", "ready", "error"],
+                    )
+                    | models.Q(
+                        workspace_kind="gateway_local",
+                        relative_path="",
+                        identity_status="not_applicable",
+                    )
+                ),
+                name="lens_bws_kind_path_identity_ck",
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="lensworkspacebinding",
+            index=models.Index(
+                fields=["organization", "state"],
+                name="lens_bws_org_state_idx",
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="lensworkspacebinding",
+            index=models.Index(
+                fields=["execution_node_id", "state"],
+                name="lens_bws_node_state_idx",
+            ),
+        ),
+    ]

--- a/src/backend/apps/lens_bridge/migrations/0023_session_teardown_state.py
+++ b/src/backend/apps/lens_bridge/migrations/0023_session_teardown_state.py
@@ -1,0 +1,99 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("lens_bridge", "0022_workspace_binding"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="lensknowledgesource",
+            name="lifecycle_status",
+            field=models.CharField(
+                choices=[
+                    ("ready", "Ready"),
+                    ("deleting", "Deleting"),
+                    ("deleted", "Deleted"),
+                ],
+                db_index=True,
+                default="ready",
+                max_length=16,
+            ),
+        ),
+        migrations.AddField(
+            model_name="lensknowledgesource",
+            name="teardown_attempts",
+            field=models.PositiveIntegerField(default=0),
+        ),
+        migrations.AddField(
+            model_name="lensknowledgesource",
+            name="teardown_claim_token",
+            field=models.UUIDField(blank=True, null=True, unique=True),
+        ),
+        migrations.AddField(
+            model_name="lensknowledgesource",
+            name="teardown_claimed_at",
+            field=models.DateTimeField(blank=True, db_index=True, null=True),
+        ),
+        migrations.AddField(
+            model_name="lensknowledgesource",
+            name="teardown_next_retry_at",
+            field=models.DateTimeField(blank=True, db_index=True, null=True),
+        ),
+        migrations.AddField(
+            model_name="lensknowledgesource",
+            name="teardown_state_json",
+            field=models.JSONField(blank=True, default=dict),
+        ),
+        migrations.AddField(
+            model_name="lenssessionlink",
+            name="provision_state_json",
+            field=models.JSONField(blank=True, default=dict),
+        ),
+        migrations.AddField(
+            model_name="lenssessionlink",
+            name="provision_attempts",
+            field=models.PositiveIntegerField(default=0),
+        ),
+        migrations.AddField(
+            model_name="lenssessionlink",
+            name="provision_claim_token",
+            field=models.UUIDField(blank=True, null=True, unique=True),
+        ),
+        migrations.AddField(
+            model_name="lenssessionlink",
+            name="provision_claimed_at",
+            field=models.DateTimeField(blank=True, db_index=True, null=True),
+        ),
+        migrations.AddField(
+            model_name="lenssessionlink",
+            name="provision_next_retry_at",
+            field=models.DateTimeField(blank=True, db_index=True, null=True),
+        ),
+        migrations.AddField(
+            model_name="lenssessionlink",
+            name="teardown_attempts",
+            field=models.PositiveIntegerField(default=0),
+        ),
+        migrations.AddField(
+            model_name="lenssessionlink",
+            name="teardown_claim_token",
+            field=models.UUIDField(blank=True, null=True, unique=True),
+        ),
+        migrations.AddField(
+            model_name="lenssessionlink",
+            name="teardown_claimed_at",
+            field=models.DateTimeField(blank=True, db_index=True, null=True),
+        ),
+        migrations.AddField(
+            model_name="lenssessionlink",
+            name="teardown_next_retry_at",
+            field=models.DateTimeField(blank=True, db_index=True, null=True),
+        ),
+        migrations.AddField(
+            model_name="lenssessionlink",
+            name="teardown_state_json",
+            field=models.JSONField(blank=True, default=dict),
+        ),
+    ]

--- a/src/backend/apps/lens_bridge/migrations/0024_gateway_default_constraints.py
+++ b/src/backend/apps/lens_bridge/migrations/0024_gateway_default_constraints.py
@@ -1,0 +1,32 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("lens_bridge", "0023_session_teardown_state"),
+    ]
+
+    operations = [
+        migrations.AddConstraint(
+            model_name="lensgatewaylink",
+            constraint=models.CheckConstraint(
+                condition=(
+                    models.Q(is_platform_default=False)
+                    | models.Q(scope="platform")
+                ),
+                name="lens_brgw_default_scope_ck",
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name="lensgatewaylink",
+            constraint=models.UniqueConstraint(
+                fields=("organization",),
+                condition=models.Q(
+                    scope="platform",
+                    is_platform_default=True,
+                    is_deleted=False,
+                ),
+                name="uniq_lens_brgw_org_default",
+            ),
+        ),
+    ]

--- a/src/backend/apps/lens_bridge/migrations/0025_gateway_provision_and_assistant_lifecycle.py
+++ b/src/backend/apps/lens_bridge/migrations/0025_gateway_provision_and_assistant_lifecycle.py
@@ -1,0 +1,43 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("lens_bridge", "0024_gateway_default_constraints"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="lensgatewaylink",
+            name="lensnode_provision_state_json",
+            field=models.JSONField(blank=True, default=dict),
+        ),
+        migrations.AddField(
+            model_name="lensgatewaylink",
+            name="lensnode_provision_attempts",
+            field=models.PositiveIntegerField(default=0),
+        ),
+        migrations.AddField(
+            model_name="lensgatewaylink",
+            name="lensnode_provision_claim_token",
+            field=models.UUIDField(blank=True, null=True, unique=True),
+        ),
+        migrations.AddField(
+            model_name="lensgatewaylink",
+            name="lensnode_provision_claimed_at",
+            field=models.DateTimeField(blank=True, db_index=True, null=True),
+        ),
+        migrations.AddField(
+            model_name="lensassistantlink",
+            name="lifecycle_owner",
+            field=models.CharField(
+                choices=[
+                    ("manual", "Manual assistant management"),
+                    ("chat", "Chat lifecycle"),
+                ],
+                db_index=True,
+                default="manual",
+                max_length=16,
+            ),
+        ),
+    ]

--- a/src/backend/apps/lens_bridge/models/__init__.py
+++ b/src/backend/apps/lens_bridge/models/__init__.py
@@ -10,6 +10,7 @@ from apps.lens_bridge.models.links import (
     LensSessionLink,
     LensSlUserLink,
     LensUsageLedger,
+    LensWorkspaceBinding,
 )
 
 __all__ = [
@@ -24,4 +25,5 @@ __all__ = [
     "LensSessionLink",
     "LensSlUserLink",
     "LensUsageLedger",
+    "LensWorkspaceBinding",
 ]

--- a/src/backend/apps/lens_bridge/models/links.py
+++ b/src/backend/apps/lens_bridge/models/links.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import uuid
+
 from django.conf import settings
 from django.db import models
 
@@ -167,7 +169,7 @@ class LensGatewayLink(OrganizationScopedModel):
     sl_lensnode_uuid = models.UUIDField(null=True, blank=True, unique=True)
     owner_user = models.ForeignKey(
         settings.AUTH_USER_MODEL,
-        on_delete=models.SET_NULL,
+        on_delete=models.PROTECT,
         null=True,
         blank=True,
         related_name="lens_gateway_links_owned",
@@ -186,6 +188,18 @@ class LensGatewayLink(OrganizationScopedModel):
         db_index=True,
     )
     config_json = models.JSONField(default=dict, blank=True)
+    lensnode_provision_state_json = models.JSONField(default=dict, blank=True)
+    lensnode_provision_attempts = models.PositiveIntegerField(default=0)
+    lensnode_provision_claim_token = models.UUIDField(
+        null=True,
+        blank=True,
+        unique=True,
+    )
+    lensnode_provision_claimed_at = models.DateTimeField(
+        null=True,
+        blank=True,
+        db_index=True,
+    )
     scope = models.CharField(
         max_length=16,
         choices=GatewayScope.choices,
@@ -200,6 +214,29 @@ class LensGatewayLink(OrganizationScopedModel):
             models.UniqueConstraint(
                 fields=["organization", "gateway"],
                 name="uniq_lens_bridge_gw_link_org_gw",
+            ),
+            models.CheckConstraint(
+                condition=(
+                    models.Q(scope="platform", owner_user_id__isnull=True)
+                    | models.Q(scope="user", owner_user_id__isnull=False)
+                ),
+                name="lens_brgw_scope_owner_ck",
+            ),
+            models.CheckConstraint(
+                condition=(
+                    models.Q(is_platform_default=False)
+                    | models.Q(scope="platform")
+                ),
+                name="lens_brgw_default_scope_ck",
+            ),
+            models.UniqueConstraint(
+                fields=["organization"],
+                condition=models.Q(
+                    scope="platform",
+                    is_platform_default=True,
+                    is_deleted=False,
+                ),
+                name="uniq_lens_brgw_org_default",
             ),
         ]
         indexes = [
@@ -216,7 +253,7 @@ class LensGatewayLink(OrganizationScopedModel):
     def resolved_workspace_root(self) -> str:
         if self.workspace_root:
             return self.workspace_root.rstrip("/")
-        return f"/workspace/org-{self.organization_id}"
+        return f"/workspace/org-{self.organization_id}/data"
 
 
 class LensKnowledgeSource(OrganizationScopedModel):
@@ -233,11 +270,22 @@ class LensKnowledgeSource(OrganizationScopedModel):
         ERROR = "error", "Error"
         PAUSED = "paused", "Paused"
 
+    class LifecycleStatus(models.TextChoices):
+        READY = "ready", "Ready"
+        DELETING = "deleting", "Deleting"
+        DELETED = "deleted", "Deleted"
+
     name = models.CharField(max_length=160)
     gateway = models.ForeignKey(
         "node.Node",
         on_delete=models.PROTECT,
         related_name="lens_knowledge_sources",
+    )
+    gateway_link = models.ForeignKey(
+        LensGatewayLink,
+        on_delete=models.PROTECT,
+        related_name="knowledge_sources",
+        help_text="Authoritative gateway authorization used for execution.",
     )
     backup_source_snapshot_id = models.BigIntegerField(null=True, blank=True, db_index=True)
     backup_snapshot_directory_id = models.BigIntegerField(null=True, blank=True, db_index=True)
@@ -264,6 +312,17 @@ class LensKnowledgeSource(OrganizationScopedModel):
     last_restore_record_id = models.BigIntegerField(null=True, blank=True, db_index=True)
     ingest_policy_json = models.JSONField(default=dict, blank=True)
     scan_enabled = models.BooleanField(default=True)
+    lifecycle_status = models.CharField(
+        max_length=16,
+        choices=LifecycleStatus.choices,
+        default=LifecycleStatus.READY,
+        db_index=True,
+    )
+    teardown_state_json = models.JSONField(default=dict, blank=True)
+    teardown_attempts = models.PositiveIntegerField(default=0)
+    teardown_claim_token = models.UUIDField(null=True, blank=True, unique=True)
+    teardown_claimed_at = models.DateTimeField(null=True, blank=True, db_index=True)
+    teardown_next_retry_at = models.DateTimeField(null=True, blank=True, db_index=True)
     created_by = models.ForeignKey(
         settings.AUTH_USER_MODEL,
         on_delete=models.SET_NULL,
@@ -287,12 +346,125 @@ class LensKnowledgeSource(OrganizationScopedModel):
         ]
 
 
+class LensWorkspaceBinding(OrganizationScopedModel):
+    """Immutable authorization and filesystem identity for one KS workspace."""
+
+    class WorkspaceKind(models.TextChoices):
+        MANAGED_RESTORE = "managed_restore", "Managed restore"
+        GATEWAY_LOCAL = "gateway_local", "Gateway local"
+
+    class State(models.TextChoices):
+        PREPARING = "preparing", "Preparing"
+        READY = "ready", "Ready"
+        DELETING = "deleting", "Deleting"
+        DELETED = "deleted", "Deleted"
+        ERROR = "error", "Error"
+
+    class IdentityStatus(models.TextChoices):
+        PENDING = "pending", "Pending"
+        READY = "ready", "Ready"
+        NOT_APPLICABLE = "not_applicable", "Not applicable"
+        ERROR = "error", "Error"
+
+    workspace_uid = models.UUIDField(default=uuid.uuid4, unique=True, editable=False)
+    knowledge_source = models.OneToOneField(
+        LensKnowledgeSource,
+        on_delete=models.PROTECT,
+        related_name="workspace_binding",
+    )
+    gateway_link = models.ForeignKey(
+        LensGatewayLink,
+        on_delete=models.PROTECT,
+        related_name="workspace_bindings",
+    )
+    execution_organization_id = models.BigIntegerField(db_index=True)
+    execution_node_id = models.BigIntegerField(db_index=True)
+    workspace_kind = models.CharField(
+        max_length=24,
+        choices=WorkspaceKind.choices,
+        db_index=True,
+    )
+    workspace_root = models.CharField(max_length=500)
+    relative_path = models.CharField(max_length=500, blank=True, default="")
+    state = models.CharField(
+        max_length=16,
+        choices=State.choices,
+        default=State.PREPARING,
+        db_index=True,
+    )
+    identity_status = models.CharField(
+        max_length=24,
+        choices=IdentityStatus.choices,
+        default=IdentityStatus.PENDING,
+        db_index=True,
+    )
+    last_error = models.TextField(blank=True, default="")
+
+    class Meta:
+        db_table = "lens_bridge_workspace_binding"
+        constraints = [
+            models.UniqueConstraint(
+                fields=["gateway_link", "relative_path"],
+                condition=~models.Q(relative_path=""),
+                name="uniq_lens_workspace_link_path",
+            ),
+            models.CheckConstraint(
+                condition=(
+                    models.Q(
+                        workspace_kind="managed_restore",
+                        relative_path__gt="",
+                        identity_status__in=["pending", "ready", "error"],
+                    )
+                    | models.Q(
+                        workspace_kind="gateway_local",
+                        relative_path="",
+                        identity_status="not_applicable",
+                    )
+                ),
+                name="lens_bws_kind_path_identity_ck",
+            ),
+        ]
+        indexes = [
+            models.Index(
+                fields=["organization", "state"],
+                name="lens_bws_org_state_idx",
+            ),
+            models.Index(
+                fields=["execution_node_id", "state"],
+                name="lens_bws_node_state_idx",
+            ),
+        ]
+
+    def resolved_path(self) -> str:
+        from apps.lens_bridge.services.gateway_paths import path_within_root
+
+        root = str(self.workspace_root or "").strip()
+        if not self.relative_path:
+            return path_within_root(root, root, allow_root=True, field="workspace_root")
+        relative = str(self.relative_path).strip()
+        if relative.startswith("/"):
+            raise ValueError("relative_path must be relative")
+        parts = relative.split("/")
+        if any(part in {"", ".", ".."} for part in parts):
+            raise ValueError("relative_path contains an unsafe path component")
+        return path_within_root(
+            f"{root.rstrip('/')}/{relative}",
+            root,
+            allow_root=False,
+            field="workspace_path",
+        )
+
+
 class LensAssistantLink(OrganizationScopedModel):
     """HFL-side visibility and ownership for a SourceLens assistant."""
 
     class VisibilityScope(models.TextChoices):
         USER = "user", "Only me"
         ORGANIZATION = "organization", "Organization"
+
+    class LifecycleOwner(models.TextChoices):
+        MANUAL = "manual", "Manual assistant management"
+        CHAT = "chat", "Chat lifecycle"
 
     sl_assistant_uuid = models.UUIDField(db_index=True)
     knowledge_source = models.ForeignKey(
@@ -306,6 +478,12 @@ class LensAssistantLink(OrganizationScopedModel):
         max_length=16,
         choices=VisibilityScope.choices,
         default=VisibilityScope.ORGANIZATION,
+        db_index=True,
+    )
+    lifecycle_owner = models.CharField(
+        max_length=16,
+        choices=LifecycleOwner.choices,
+        default=LifecycleOwner.MANUAL,
         db_index=True,
     )
     owner_user = models.ForeignKey(
@@ -509,6 +687,16 @@ class LensSessionLink(OrganizationScopedModel):
         db_index=True,
     )
     provision_detail = models.CharField(max_length=300, blank=True, default="")
+    provision_state_json = models.JSONField(default=dict, blank=True)
+    provision_attempts = models.PositiveIntegerField(default=0)
+    provision_claim_token = models.UUIDField(null=True, blank=True, unique=True)
+    provision_claimed_at = models.DateTimeField(null=True, blank=True, db_index=True)
+    provision_next_retry_at = models.DateTimeField(null=True, blank=True, db_index=True)
+    teardown_state_json = models.JSONField(default=dict, blank=True)
+    teardown_attempts = models.PositiveIntegerField(default=0)
+    teardown_claim_token = models.UUIDField(null=True, blank=True, unique=True)
+    teardown_claimed_at = models.DateTimeField(null=True, blank=True, db_index=True)
+    teardown_next_retry_at = models.DateTimeField(null=True, blank=True, db_index=True)
 
     class Meta:
         db_table = "lens_bridge_session_link"

--- a/src/backend/apps/lens_bridge/periodic_tasks.py
+++ b/src/backend/apps/lens_bridge/periodic_tasks.py
@@ -1,0 +1,36 @@
+from celery.schedules import crontab
+
+from common.scheduling.registry import TASK_REGISTRY
+
+
+def register_periodic_tasks() -> None:
+    TASK_REGISTRY.add(
+        name="lens_bridge_reconcile_gateway_lensnode_provisions",
+        task=(
+            "apps.lens_bridge.tasks.gateway_provisioning."
+            "reconcile_gateway_lensnode_provisions_task"
+        ),
+        schedule=crontab(minute="*/5"),
+        kwargs={"limit": 100},
+        enabled=True,
+    )
+    TASK_REGISTRY.add(
+        name="lens_bridge_reconcile_chat_provisions",
+        task=(
+            "apps.lens_bridge.tasks.chat_lifecycle."
+            "reconcile_copilot_chat_provisions_task"
+        ),
+        schedule=crontab(minute="*/5"),
+        kwargs={"limit": 100},
+        enabled=True,
+    )
+    TASK_REGISTRY.add(
+        name="lens_bridge_reconcile_resource_teardowns",
+        task=(
+            "apps.lens_bridge.tasks.chat_lifecycle."
+            "reconcile_lens_resource_teardowns_task"
+        ),
+        schedule=crontab(minute="*/5"),
+        kwargs={"limit": 100},
+        enabled=True,
+    )

--- a/src/backend/apps/lens_bridge/services/assistant_access.py
+++ b/src/backend/apps/lens_bridge/services/assistant_access.py
@@ -33,10 +33,9 @@ def assistant_visible_to(
     *,
     user: AbstractBaseUser,
     link: LensAssistantLink,
-    manage: bool = False,
-    membership: Membership | None = None,
+    can_manage_all: bool = False,
 ) -> bool:
-    if manage and can_manage_all_assistants(membership):
+    if can_manage_all:
         return True
     if link.visibility_scope == LensAssistantLink.VisibilityScope.ORGANIZATION:
         return True
@@ -72,6 +71,7 @@ def ensure_assistant_link(
     visibility_scope: str | None = None,
     owner_user: AbstractBaseUser | None = None,
     created_by: AbstractBaseUser | None = None,
+    lifecycle_owner: str = LensAssistantLink.LifecycleOwner.MANUAL,
 ) -> LensAssistantLink:
     scope = visibility_scope or LensAssistantLink.VisibilityScope.ORGANIZATION
     ks = knowledge_source
@@ -87,6 +87,7 @@ def ensure_assistant_link(
         "visibility_scope": scope,
         "knowledge_source": ks,
         "created_by": created_by or (ks.created_by if ks else None),
+        "lifecycle_owner": lifecycle_owner,
     }
     if scope == LensAssistantLink.VisibilityScope.USER:
         defaults["owner_user"] = owner_user or created_by or (ks.created_by if ks else None)
@@ -105,6 +106,10 @@ def ensure_assistant_link(
             existing.deleted_at = None
             existing.save()
             return existing
+        if existing.lifecycle_owner != lifecycle_owner:
+            raise ValueError(
+                "Assistant lifecycle ownership conflicts with its existing link."
+            )
         return existing
 
     return LensAssistantLink.objects.create(

--- a/src/backend/apps/lens_bridge/services/assistants.py
+++ b/src/backend/apps/lens_bridge/services/assistants.py
@@ -8,8 +8,13 @@ from typing import Any
 from django.contrib.auth.models import AbstractBaseUser
 from rest_framework.exceptions import NotFound, ValidationError
 
-from apps.iam.models import Membership, Organization
-from apps.lens_bridge.models import LensAssistantLink, LensGatewayLink, LensKnowledgeSource
+from apps.iam.models import Organization
+from apps.lens_bridge.models import (
+    LensAssistantLink,
+    LensGatewayLink,
+    LensKnowledgeSource,
+    LensSessionLink,
+)
 from apps.lens_bridge.services import assistant_access, sl_client
 from apps.lens_bridge.services.provisioning import _slugify_assistant, get_or_create_org_link
 
@@ -170,8 +175,7 @@ def list_org_assistants(
     org: Organization,
     *,
     user: AbstractBaseUser,
-    membership: Membership | None = None,
-    manage: bool = False,
+    can_manage_all: bool = False,
 ) -> list[dict[str, Any]]:
     raw = sl_client.request_json("GET", "/api/lens/assistants/")
     items = _unwrap_list(raw)
@@ -198,8 +202,7 @@ def list_org_assistants(
         if not assistant_access.assistant_visible_to(
             user=user,
             link=link,
-            manage=manage,
-            membership=membership,
+            can_manage_all=can_manage_all,
         ):
             continue
         rows.append(row)
@@ -213,8 +216,7 @@ def get_org_assistant(
     assistant_uuid: uuid_lib.UUID,
     *,
     user: AbstractBaseUser | None = None,
-    membership: Membership | None = None,
-    manage: bool = False,
+    can_manage_all: bool = False,
 ) -> dict[str, Any]:
     data = sl_client.request_json("GET", f"/api/lens/assistants/{assistant_uuid}/")
     if not isinstance(data, dict) or not _belongs_to_org(org, data):
@@ -226,8 +228,7 @@ def get_org_assistant(
     if user is not None and not assistant_access.assistant_visible_to(
         user=user,
         link=link,
-        manage=manage,
-        membership=membership,
+        can_manage_all=can_manage_all,
     ):
         raise NotFound("Assistant not found.")
     merged = assistant_access.merge_link_fields(dict(data), link)
@@ -259,11 +260,12 @@ def _apply_retrieval_include_paths(
 
 
 def _knowledge_source_execution(org: Organization, ks: LensKnowledgeSource) -> dict[str, Any]:
-    link = (
-        LensGatewayLink.objects.filter(organization=org, gateway=ks.gateway)
-        .exclude(sl_lensnode_uuid__isnull=True)
-        .first()
-    )
+    from apps.lens_bridge.services.gateway_execution import context_for_knowledge_source
+
+    link = context_for_knowledge_source(
+        tenant_organization=org,
+        knowledge_source=ks,
+    ).gateway_link
     lensnode_uuid = ks.sl_lensnode_uuid or (link.sl_lensnode_uuid if link else None)
     if not lensnode_uuid:
         raise ValidationError(
@@ -285,13 +287,41 @@ def _knowledge_source_execution(org: Organization, ks: LensKnowledgeSource) -> d
     }
 
 
-def _apply_knowledge_source_payload(org: Organization, payload: dict[str, Any]) -> dict[str, Any]:
+_TENANT_EXECUTION_FIELDS = frozenset({"lensnode", "lensnode_uuid", "selected_dirs"})
+
+
+def _apply_knowledge_source_payload(
+    org: Organization,
+    payload: dict[str, Any],
+    *,
+    user: AbstractBaseUser | None = None,
+    platform_passthrough: bool = False,
+    require_knowledge_source: bool = False,
+) -> dict[str, Any]:
+    """Derive tenant Assistant execution fields from an authorized KS."""
+
     ks_id = payload.pop("knowledge_source_id", None)
     include_paths = payload.pop("retrieval_include_paths", None)
     if include_paths is not None and not isinstance(include_paths, list):
         raise ValidationError({"retrieval_include_paths": "Must be a list of path rules."})
 
+    if not platform_passthrough:
+        supplied_execution_fields = sorted(_TENANT_EXECUTION_FIELDS.intersection(payload))
+        if supplied_execution_fields:
+            raise ValidationError(
+                {
+                    "knowledge_source_id": (
+                        "Tenant Assistants must derive LensNode and directory settings "
+                        "from a knowledge source."
+                    )
+                }
+            )
+
     if ks_id in (None, ""):
+        if require_knowledge_source and not platform_passthrough:
+            raise ValidationError(
+                {"knowledge_source_id": "Knowledge source is required."}
+            )
         if include_paths is not None and payload.get("selected_dirs"):
             payload["selected_dirs"] = _apply_retrieval_include_paths(
                 payload["selected_dirs"],
@@ -301,13 +331,49 @@ def _apply_knowledge_source_payload(org: Organization, payload: dict[str, Any]) 
 
     ks = (
         LensKnowledgeSource.objects.filter(organization=org, pk=ks_id)
-        .select_related("gateway")
+        .select_related("gateway", "gateway_link", "gateway_link__gateway", "gateway_link__organization")
         .first()
     )
     if ks is None:
         raise ValidationError({"knowledge_source_id": "Knowledge source not found."})
+    if not platform_passthrough:
+        if user is None:
+            raise ValidationError(
+                {"knowledge_source_id": "Knowledge source owner is required."}
+            )
+        if ks.created_by_id != user.id:
+            raise ValidationError(
+                {
+                    "knowledge_source_id": (
+                        "Knowledge source is not owned by the current user."
+                    )
+                }
+            )
+        gateway_link = ks.gateway_link
+        if (
+            gateway_link.scope == LensGatewayLink.GatewayScope.USER
+            and gateway_link.owner_user_id != user.id
+        ):
+            raise ValidationError(
+                {
+                    "knowledge_source_id": (
+                        "Knowledge source data gateway is not owned by the current user."
+                    )
+                }
+            )
+    if ks.session_links.exclude(
+        lifecycle_status=LensSessionLink.LifecycleStatus.DELETED
+    ).exists():
+        raise ValidationError(
+            {
+                "knowledge_source_id": (
+                    "Chat-managed knowledge sources cannot be rebound through "
+                    "the Assistant API."
+                )
+            }
+        )
     execution = _knowledge_source_execution(org, ks)
-    payload.setdefault("lensnode_uuid", execution["lensnode_uuid"])
+    payload["lensnode_uuid"] = execution["lensnode_uuid"]
     payload["selected_dirs"] = _apply_retrieval_include_paths(
         execution["selected_dirs"],
         include_paths,
@@ -318,11 +384,7 @@ def _apply_knowledge_source_payload(org: Organization, payload: dict[str, Any]) 
 def _serialize_knowledge_source_option(org: Organization, ks: LensKnowledgeSource) -> dict[str, Any]:
     from apps.lens_bridge.services.knowledge_source_sync import indexed_dir_paths, scope_entries
 
-    link = (
-        LensGatewayLink.objects.filter(organization=org, gateway=ks.gateway)
-        .exclude(sl_lensnode_uuid__isnull=True)
-        .first()
-    )
+    link = ks.gateway_link
     lensnode_uuid = ks.sl_lensnode_uuid or (link.sl_lensnode_uuid if link else None)
     scope_paths = [
         str(item.get("source_path") or "").strip()
@@ -352,6 +414,7 @@ def create_org_assistant(
     body: dict[str, Any],
     *,
     user: AbstractBaseUser | None = None,
+    platform_passthrough: bool = False,
 ) -> dict[str, Any]:
     payload, visibility_scope_raw, ks_id = _strip_hfl_visibility(body)
     visibility_scope = _resolve_visibility_scope(
@@ -365,7 +428,13 @@ def create_org_assistant(
         raise ValidationError({"name": "Name is required."})
     slug = str(payload.get("slug") or "").strip()
     payload["slug"] = slug or _slugify_assistant(name, org)
-    payload = _apply_knowledge_source_payload(org, payload)
+    payload = _apply_knowledge_source_payload(
+        org,
+        payload,
+        user=user,
+        platform_passthrough=platform_passthrough,
+        require_knowledge_source=True,
+    )
     if not payload.get("lensnode_uuid"):
         raise ValidationError({"lensnode_uuid": "LensNode is required."})
     if not payload.get("selected_task"):
@@ -400,12 +469,29 @@ def update_org_assistant(
     body: dict[str, Any],
     *,
     user: AbstractBaseUser | None = None,
+    can_manage_all: bool = False,
+    platform_passthrough: bool = False,
 ) -> dict[str, Any]:
-    get_org_assistant(org, assistant_uuid, user=user, manage=True)
+    if user is None and not can_manage_all:
+        raise ValidationError(
+            {"assistant": "Assistant management authorization is required."}
+        )
+    get_org_assistant(
+        org,
+        assistant_uuid,
+        user=user,
+        can_manage_all=can_manage_all,
+    )
+    _require_manual_assistant_management(org, assistant_uuid)
     payload, visibility_scope_raw, ks_id = _strip_hfl_visibility(body)
     if ks_id not in (None, ""):
         payload["knowledge_source_id"] = ks_id
-    payload = _apply_knowledge_source_payload(org, payload)
+    payload = _apply_knowledge_source_payload(
+        org,
+        payload,
+        user=user,
+        platform_passthrough=platform_passthrough,
+    )
     _validate_assistant_tool_bindings(org, payload)
     data = sl_client.request_json(
         "PATCH",
@@ -422,10 +508,14 @@ def update_org_assistant(
         created_by=user,
     )
     link = assistant_access.get_assistant_link(org, assistant_uuid)
-    if visibility_scope_raw is not None:
+    if visibility_scope_raw is not None or ks_id not in (None, ""):
         visibility_scope = _resolve_visibility_scope(
             visibility_scope_raw,
-            default=LensAssistantLink.VisibilityScope.USER,
+            default=(
+                link.visibility_scope
+                if link is not None
+                else LensAssistantLink.VisibilityScope.USER
+            ),
         )
         link = _upsert_assistant_link(
             org=org,
@@ -447,8 +537,24 @@ def update_org_assistant(
     return assistant_access.merge_link_fields(data, link)
 
 
-def delete_org_assistant(org: Organization, assistant_uuid: uuid_lib.UUID) -> None:
-    get_org_assistant(org, assistant_uuid, manage=True)
+def delete_org_assistant(
+    org: Organization,
+    assistant_uuid: uuid_lib.UUID,
+    *,
+    user: AbstractBaseUser | None = None,
+    can_manage_all: bool = False,
+) -> None:
+    if user is None and not can_manage_all:
+        raise ValidationError(
+            {"assistant": "Assistant management authorization is required."}
+        )
+    get_org_assistant(
+        org,
+        assistant_uuid,
+        user=user,
+        can_manage_all=can_manage_all,
+    )
+    _require_manual_assistant_management(org, assistant_uuid)
     _delete_sl_assistant(assistant_uuid)
     assistant_access.soft_delete_assistant_link(org, assistant_uuid)
     affected_ks_ids = list(
@@ -465,23 +571,54 @@ def delete_org_assistant(org: Organization, assistant_uuid: uuid_lib.UUID) -> No
         _reassign_ks_primary_assistant(org, ks_id)
 
 
-def _delete_sl_assistant(assistant_uuid: uuid_lib.UUID) -> None:
-    """Best-effort real SL DELETE (chat path then admin path). 404 = success."""
-    last_exc: Exception | None = None
-    for path in (
-        f"/api/lens/assistants/{assistant_uuid}/",
-        f"/api/lens/admin/assistants/{assistant_uuid}/",
+def _require_manual_assistant_management(
+    org: Organization,
+    assistant_uuid: uuid_lib.UUID,
+) -> LensAssistantLink:
+    """Reject mutations owned by the durable Chat lifecycle."""
+
+    link = assistant_access.get_assistant_link(org, assistant_uuid)
+    if link is None:
+        raise NotFound("Assistant not found.")
+    has_live_chat = LensSessionLink.objects.filter(
+        organization=org,
+        sl_assistant_uuid=assistant_uuid,
+    ).exclude(
+        lifecycle_status=LensSessionLink.LifecycleStatus.DELETED
+    ).exists()
+    if (
+        link.lifecycle_owner == LensAssistantLink.LifecycleOwner.CHAT
+        or has_live_chat
     ):
-        try:
-            sl_client.request_json("DELETE", path)
+        raise ValidationError(
+            {
+                "assistant": (
+                    "Chat-managed assistants must be changed by deleting and "
+                    "recreating the owning Chat."
+                )
+            }
+        )
+    return link
+
+
+def _delete_sl_assistant(assistant_uuid: uuid_lib.UUID) -> None:
+    """Retire an Assistant through SourceLens' supported DELETE contract.
+
+    Bundled SourceLens 0.4.0 implements this endpoint as a soft retirement by
+    setting the Assistant status to ``disabled``. HFL treats an existing 404 as
+    idempotent success but preserves every other error for durable retry.
+    """
+
+    try:
+        sl_client.request_json(
+            "DELETE",
+            f"/api/lens/assistants/{assistant_uuid}/",
+        )
+    except sl_client.LensBridgeError as exc:
+        status = getattr(exc, "status_code", None)
+        if status == 404 or "404" in str(exc):
             return
-        except sl_client.LensBridgeError as exc:
-            status = getattr(exc, "status_code", None)
-            if status == 404 or "404" in str(exc):
-                return
-            last_exc = exc
-    if last_exc is not None:
-        raise last_exc
+        raise
 
 
 def _reassign_ks_primary_assistant(org: Organization, ks_id: int) -> None:
@@ -504,13 +641,23 @@ def _reassign_ks_primary_assistant(org: Organization, ks_id: int) -> None:
     )
 
 
-def list_org_lensnodes(org: Organization) -> list[dict[str, Any]]:
+def list_org_lensnodes(
+    org: Organization,
+    *,
+    owner_user: AbstractBaseUser | None = None,
+) -> list[dict[str, Any]]:
+    links = LensGatewayLink.objects.filter(
+        organization=org,
+        sl_lensnode_uuid__isnull=False,
+    )
+    if owner_user is not None:
+        links = links.filter(
+            scope=LensGatewayLink.GatewayScope.USER,
+            owner_user=owner_user,
+        )
     linked = {
         str(link.sl_lensnode_uuid)
-        for link in LensGatewayLink.objects.filter(
-            organization=org,
-            sl_lensnode_uuid__isnull=False,
-        )
+        for link in links
     }
     if not linked:
         return []
@@ -522,6 +669,7 @@ def list_org_lensnodes(org: Organization) -> list[dict[str, Any]]:
 def assistant_form_options(
     org: Organization,
     *,
+    user: AbstractBaseUser | None = None,
     platform_passthrough: bool = False,
 ) -> dict[str, Any]:
     from apps.lens_bridge.services import provisioning
@@ -532,9 +680,15 @@ def assistant_form_options(
 
         links = platform_lens.platform_gateway_links().filter(sl_lensnode_uuid__isnull=False)
     else:
+        if user is None:
+            raise ValidationError(
+                {"assistant": "Assistant form option owner is required."}
+            )
         links = LensGatewayLink.objects.filter(
             organization=org,
             sl_lensnode_uuid__isnull=False,
+            scope=LensGatewayLink.GatewayScope.USER,
+            owner_user=user,
         ).select_related("gateway")
 
     for link in links:
@@ -576,7 +730,10 @@ def assistant_form_options(
         mcps = []
 
     ks_org = org
-    ks_qs = LensKnowledgeSource.objects.filter(organization=org)
+    ks_qs = LensKnowledgeSource.objects.filter(
+        organization=org,
+        created_by=user,
+    )
     if platform_passthrough:
         from apps.lens_bridge.services import platform_lens as pl
 
@@ -585,7 +742,10 @@ def assistant_form_options(
         ks_qs = LensKnowledgeSource.objects.filter(organization=platform_org)
 
     return {
-        "lensnodes": list_org_lensnodes(ks_org),
+        "lensnodes": list_org_lensnodes(
+            ks_org,
+            owner_user=None if platform_passthrough else user,
+        ),
         "gateways": gateway_rows,
         "knowledge_sources": [
             _serialize_knowledge_source_option(ks_org, ks)

--- a/src/backend/apps/lens_bridge/services/chat_binding.py
+++ b/src/backend/apps/lens_bridge/services/chat_binding.py
@@ -173,7 +173,10 @@ def list_gateway_options(org: Organization, *, user) -> list[dict[str, Any]]:
         )
         seen.add(link.id)
 
-    for link in platform_lens.user_gateway_links(user=user).select_related("gateway"):
+    for link in platform_lens.user_gateway_links(
+        user=user,
+        organization=org,
+    ).select_related("gateway"):
         if not link.sl_lensnode_uuid or link.id in seen:
             continue
         provisioning.sync_gateway_lensnode_status(link)

--- a/src/backend/apps/lens_bridge/services/chat_lifecycle.py
+++ b/src/backend/apps/lens_bridge/services/chat_lifecycle.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import uuid as uuid_lib
+from datetime import timedelta
 from typing import Any
 
 from django.contrib.auth.models import AbstractBaseUser
@@ -12,20 +13,41 @@ from django.utils import timezone
 from rest_framework.exceptions import ValidationError
 
 from apps.iam.models import Organization
-from apps.lens_bridge.models import LensChatBinding, LensKnowledgeSource, LensSessionLink
+from apps.lens_bridge.models import (
+    LensAssistantLink,
+    LensChatBinding,
+    LensKnowledgeSource,
+    LensSessionLink,
+)
 from apps.lens_bridge.services import (
     assistant_access,
     chat_user_provisioning,
     knowledge_source_sync,
+    platform_lens,
     provisioning,
     sl_client,
 )
 from apps.lens_bridge.services.chat_binding import _grant_assistant_to_chat_user
-from apps.lens_bridge.services import platform_lens
+from apps.lens_bridge.services.teardown_claims import (
+    PROVISION_CLAIM_TTL_SECONDS,
+    TEARDOWN_CLAIM_TTL_SECONDS,
+    next_retry_at,
+)
 from apps.protection.models import BackupConfig, BackupSourceSnapshot, BackupSourceSnapshotDirectory
 from apps.protection.services.source_identity import resolve_source_display_name
 
 logger = logging.getLogger(__name__)
+
+_ASSISTANT_CREATE_OPERATION = "assistant_create"
+_SESSION_CREATE_OPERATION = "session_create"
+
+
+class ChatProvisionLeaseLostError(RuntimeError):
+    """Raised when provisioning no longer owns the Chat lifecycle lease."""
+
+
+class ChatTeardownIncompleteError(RuntimeError):
+    """Raised after durable teardown state is saved so Celery retries it."""
 
 
 def _source_path_basename(path: str) -> str:
@@ -169,9 +191,17 @@ def create_copilot_chat(
             }
         )
 
-    from apps.lens_bridge.services.gateway_readiness import require_copilot_gateway
+    from apps.lens_bridge.services.gateway_execution import context_for_gateway_link
 
-    require_copilot_gateway(gateway_link)
+    context_for_gateway_link(
+        tenant_organization=org,
+        gateway_link=gateway_link,
+        expected_owner_user_id=(
+            user.id
+            if gateway_link.scope == gateway_link.GatewayScope.USER
+            else None
+        ),
+    )
     model_ref = provisioning.default_model_ref_for_org(org)
     if not model_ref:
         raise ValidationError({"model": "Configure an active AI model before creating a chat."})
@@ -209,41 +239,157 @@ def create_copilot_chat(
     return link
 
 
+@transaction.atomic
 def request_copilot_chat_teardown(link: LensSessionLink) -> LensSessionLink:
     """Mark chat deleting and enqueue teardown. Never touches DG."""
-    if link.lifecycle_status == LensSessionLink.LifecycleStatus.DELETED:
-        return link
+    locked = LensSessionLink.objects.select_for_update().get(pk=link.pk)
+    if locked.lifecycle_status == LensSessionLink.LifecycleStatus.DELETED:
+        return locked
 
-    if link.lifecycle_status == LensSessionLink.LifecycleStatus.DELETING:
-        _queue_teardown_or_record_error(link.id)
-        return link
+    if locked.lifecycle_status != LensSessionLink.LifecycleStatus.DELETING:
+        locked.lifecycle_status = LensSessionLink.LifecycleStatus.DELETING
+        locked.provision_phase = LensSessionLink.ProvisionPhase.DELETING
+        locked.provision_detail = "Deleting chat resources."
+        locked.lifecycle_error = ""
+        locked.status = LensSessionLink.Status.ARCHIVED
+        locked.provision_claim_token = None
+        locked.provision_claimed_at = None
+        locked.provision_next_retry_at = None
+        locked.teardown_attempts = 0
+        locked.teardown_claim_token = None
+        locked.teardown_claimed_at = None
+        locked.teardown_next_retry_at = None
+        locked.teardown_state_json = {}
+        locked.save(
+            update_fields=[
+                "lifecycle_status",
+                "provision_phase",
+                "provision_detail",
+                "lifecycle_error",
+                "status",
+                "provision_claim_token",
+                "provision_claimed_at",
+                "provision_next_retry_at",
+                "teardown_attempts",
+                "teardown_claim_token",
+                "teardown_claimed_at",
+                "teardown_next_retry_at",
+                "teardown_state_json",
+                "updated_at",
+            ]
+        )
+    transaction.on_commit(lambda: _queue_teardown_or_record_error(locked.id))
+    return locked
 
-    link.lifecycle_status = LensSessionLink.LifecycleStatus.DELETING
-    link.provision_phase = LensSessionLink.ProvisionPhase.DELETING
-    link.provision_detail = "Deleting chat resources."
-    link.lifecycle_error = ""
-    link.status = LensSessionLink.Status.ARCHIVED
-    link.save(update_fields=["lifecycle_status", "provision_phase", "provision_detail", "lifecycle_error", "status", "updated_at"])
 
+def _claim_copilot_chat_provision(
+    session_link_id: int,
+) -> tuple[str | None, str]:
+    """Claim one queued or stale Chat provisioning execution."""
+    now = timezone.now()
+    with transaction.atomic():
+        link = (
+            LensSessionLink.objects.select_for_update()
+            .filter(pk=session_link_id)
+            .first()
+        )
+        if link is None:
+            return None, "missing"
+        if link.lifecycle_status != LensSessionLink.LifecycleStatus.PROVISIONING:
+            return None, str(link.lifecycle_status)
+        if (
+            link.provision_claimed_at
+            and link.provision_claimed_at
+            > now - timedelta(seconds=PROVISION_CLAIM_TTL_SECONDS)
+        ):
+            return None, "busy"
+        if (
+            link.provision_next_retry_at
+            and link.provision_next_retry_at > now
+        ):
+            return None, "scheduled"
 
-    _queue_teardown_or_record_error(link.id)
-    return link
+        claim_token = uuid_lib.uuid4()
+        link.provision_attempts += 1
+        link.provision_claim_token = claim_token
+        link.provision_claimed_at = now
+        link.provision_next_retry_at = next_retry_at(link.provision_attempts)
+        link.lifecycle_error = ""
+        link.save(
+            update_fields=[
+                "provision_attempts",
+                "provision_claim_token",
+                "provision_claimed_at",
+                "provision_next_retry_at",
+                "lifecycle_error",
+                "updated_at",
+            ]
+        )
+    return str(claim_token), "claimed"
 
 
 def run_copilot_chat_provision(*, session_link_id: int) -> dict[str, Any]:
     """Provision one chat and persist failures from every execution stage."""
+    claim_token, claim_status = _claim_copilot_chat_provision(session_link_id)
+    if claim_token is None:
+        return {"session_link_id": session_link_id, "status": claim_status}
     try:
-        return _run_copilot_chat_provision(session_link_id=session_link_id)
+        return _run_copilot_chat_provision(
+            session_link_id=session_link_id,
+            claim_token=claim_token,
+        )
+    except ChatProvisionLeaseLostError:
+        current_status = (
+            LensSessionLink.objects.filter(pk=session_link_id)
+            .values_list("lifecycle_status", flat=True)
+            .first()
+        )
+        logger.info(
+            "copilot chat provision fenced session_link_id=%s status=%s",
+            session_link_id,
+            current_status,
+        )
+        return {
+            "session_link_id": session_link_id,
+            "status": current_status or "missing",
+        }
     except Exception as exc:
         logger.exception(
             "copilot chat provision failed session_link_id=%s",
             session_link_id,
         )
-        _mark_provision_failed_by_id(session_link_id, str(exc))
+        link = LensSessionLink.objects.filter(pk=session_link_id).first()
+        cleanup_errors: list[str] = []
+        if link is not None:
+            try:
+                cleanup_errors = _cleanup_failed_provision(link, claim_token)
+            except ChatProvisionLeaseLostError:
+                logger.info(
+                    "copilot cleanup fenced session_link_id=%s",
+                    session_link_id,
+                )
+            except Exception as cleanup_exc:
+                logger.exception(
+                    "copilot cleanup failed session_link_id=%s",
+                    session_link_id,
+                )
+                cleanup_errors = [f"cleanup_failed_provision: {cleanup_exc}"]
+        if cleanup_errors:
+            _transition_failed_provision_to_teardown(
+                session_link_id,
+                claim_token,
+                message=f"{exc}; {'; '.join(cleanup_errors)}",
+            )
+        else:
+            _mark_provision_failed_by_id(session_link_id, claim_token, str(exc))
         raise
 
 
-def _run_copilot_chat_provision(*, session_link_id: int) -> dict[str, Any]:
+def _run_copilot_chat_provision(
+    *,
+    session_link_id: int,
+    claim_token: str,
+) -> dict[str, Any]:
     link = (
         LensSessionLink.objects.select_related(
             "chat_binding",
@@ -259,15 +405,11 @@ def _run_copilot_chat_provision(*, session_link_id: int) -> dict[str, Any]:
     )
     if link is None:
         raise ValidationError({"session": "Session not found."})
-    if link.lifecycle_status == LensSessionLink.LifecycleStatus.READY and link.sl_session_uuid:
-        return {"session_link_id": link.id, "status": "ready"}
-    if link.lifecycle_status == LensSessionLink.LifecycleStatus.DELETING:
-        return {"session_link_id": link.id, "status": "deleting"}
+    _require_provision_claim(link.id, claim_token)
 
     binding = link.chat_binding
     gateway_link = link.gateway_link or (binding.gateway_link if binding else None)
     if gateway_link is None:
-        _mark_failed(link, "Data gateway is missing.")
         raise ValidationError({"gateway_link": "Data gateway is missing."})
     scopes = list(link.source_scopes_json or [])
     if not scopes and binding is not None:
@@ -277,133 +419,835 @@ def _run_copilot_chat_provision(*, session_link_id: int) -> dict[str, Any]:
             "path_type": "unknown",
         }]
     if not scopes:
-        _mark_failed(link, "Backup content selection is missing.")
         raise ValidationError({"source_scopes": "Backup content selection is missing."})
     snapshot_id = link.backup_source_snapshot_id or (binding.backup_source_snapshot_id if binding else None)
     if not snapshot_id:
-        _mark_failed(link, "Backup snapshot is missing.")
         raise ValidationError({"backup_source_snapshot_id": "Backup snapshot is missing."})
     org = link.organization
     user = link.hfl_user
 
-    try:
-        _set_phase(link, LensSessionLink.ProvisionPhase.RESTORING, "Restoring selected backup data.")
-        sl_user_link = chat_user_provisioning.ensure_sl_chat_user(user)
+    _set_phase(
+        link,
+        claim_token,
+        LensSessionLink.ProvisionPhase.RESTORING,
+        "Restoring selected backup data.",
+    )
+    sl_user_link = chat_user_provisioning.ensure_sl_chat_user(user)
 
-        # 1) Always create a fresh KS for this chat (no reuse).
-        ks = link.knowledge_source
-        if ks is None:
-            first_path = str(scopes[0].get("source_path") or "Copilot")
-            ks_name = f"{first_path.rstrip('/').split('/')[-1] or 'Copilot'} · Chat {link.id}"
-            first_directory_id = scopes[0].get("backup_snapshot_directory_id")
-            ks = LensKnowledgeSource.objects.create(
-                organization=org,
-                name=ks_name[:160],
-                gateway=gateway_link.gateway,
-                backup_source_snapshot_id=snapshot_id,
-                backup_snapshot_directory_id=first_directory_id,
-                source_path=first_path,
-                source_scopes_json=scopes,
-                sl_lensnode_uuid=gateway_link.sl_lensnode_uuid,
-                created_by=user,
-            )
-            ks = knowledge_source_sync.prepare_new_knowledge_source(org=org, ks=ks)
-            link.knowledge_source = ks
-            link.save(update_fields=["knowledge_source", "updated_at"])
-
-        # 2) Restore + index synchronously inside this worker (DG unchanged).
-        sync_result = knowledge_source_sync.run_knowledge_source_sync(
-            organization_id=org.id,
-            knowledge_source_id=ks.id,
+    # 1) Always create a fresh KS for this chat (no reuse).
+    ks = link.knowledge_source
+    if ks is None:
+        first_path = str(scopes[0].get("source_path") or "Copilot")
+        ks_name = f"{first_path.rstrip('/').split('/')[-1] or 'Copilot'} · Chat {link.id}"
+        first_directory_id = scopes[0].get("backup_snapshot_directory_id")
+        ks = LensKnowledgeSource.objects.create(
+            organization=org,
+            name=ks_name[:160],
+            gateway=gateway_link.gateway,
+            gateway_link=gateway_link,
+            backup_source_snapshot_id=snapshot_id,
+            backup_snapshot_directory_id=first_directory_id,
+            source_path=first_path,
+            source_scopes_json=scopes,
+            sl_lensnode_uuid=gateway_link.sl_lensnode_uuid,
+            created_by=user,
         )
-        ks.refresh_from_db()
-        if ks.status not in (
-            LensKnowledgeSource.Status.READY,
-            LensKnowledgeSource.Status.DEGRADED,
-        ):
-            raise ValidationError(
-                {"knowledge_source": f"Knowledge source sync did not complete ({ks.status})."}
-            )
+        ks = knowledge_source_sync.prepare_new_knowledge_source(org=org, ks=ks)
+        link.knowledge_source = ks
+        try:
+            _update_provision_claim(link, claim_token, "knowledge_source")
+        except ChatProvisionLeaseLostError:
+            _cleanup_orphan_knowledge_source(ks, owner_session_link_id=link.id)
+            raise
 
-        # 3) Create Assistant (SL Admin) and grant to Chat User.
-        _set_phase(
+    # 2) Restore + index synchronously inside this worker (DG unchanged).
+    sync_result = knowledge_source_sync.run_knowledge_source_sync(
+        organization_id=org.id,
+        knowledge_source_id=ks.id,
+    )
+    ks.refresh_from_db()
+    if ks.status not in (
+        LensKnowledgeSource.Status.READY,
+        LensKnowledgeSource.Status.DEGRADED,
+    ):
+        raise ValidationError(
+            {"knowledge_source": f"Knowledge source sync did not complete ({ks.status})."}
+        )
+
+    # 3) Create Assistant (SL Admin) and grant to Chat User.
+    _set_phase(
+        link,
+        claim_token,
+        LensSessionLink.ProvisionPhase.CREATING_KNOWLEDGE_SOURCE,
+        "Finalizing the private knowledge source.",
+    )
+    _set_phase(
+        link,
+        claim_token,
+        LensSessionLink.ProvisionPhase.CREATING_ASSISTANT,
+        "Creating the private assistant.",
+    )
+    assistant_uuid = link.sl_assistant_uuid or ks.sl_assistant_uuid
+    if assistant_uuid is None:
+        assistant_slug = provisioning.assistant_slug_for_ks(org=org, ks=ks)
+        operation = _prepare_remote_operation(
             link,
-            LensSessionLink.ProvisionPhase.CREATING_KNOWLEDGE_SOURCE,
-            "Finalizing the private knowledge source.",
+            claim_token,
+            kind=_ASSISTANT_CREATE_OPERATION,
+            lookup_key=assistant_slug,
         )
-        _set_phase(link, LensSessionLink.ProvisionPhase.CREATING_ASSISTANT, "Creating the private assistant.")
-        assistant_uuid = link.sl_assistant_uuid or ks.sl_assistant_uuid
+        stored_remote_uuid = str(operation.get("remote_uuid") or "").strip()
+        assistant_uuid = (
+            uuid_lib.UUID(stored_remote_uuid)
+            if stored_remote_uuid
+            else _find_remote_uuid(
+                path="/api/lens/assistants/",
+                field="slug",
+                value=assistant_slug,
+            )
+        )
         if assistant_uuid is None:
             assistant_uuid = provisioning.create_sl_assistant_for_ks(
                 org=org,
                 ks=ks,
                 gateway_link=gateway_link,
                 model_ref=link.agent_model_ref,
+                slug=assistant_slug,
             )
-            ks.sl_assistant_uuid = assistant_uuid
-            ks.save(update_fields=["sl_assistant_uuid", "updated_at"])
-            link.sl_assistant_uuid = assistant_uuid
-            link.save(update_fields=["sl_assistant_uuid", "updated_at"])
-        assistant_access.ensure_assistant_link(
-            org=org,
-            sl_assistant_uuid=assistant_uuid,
+    try:
+        _bind_assistant_to_provision_claim(
+            link,
+            claim_token,
             knowledge_source=ks,
-            created_by=user,
-            owner_user=user,
-            visibility_scope="user",
+            assistant_uuid=assistant_uuid,
         )
-        _set_phase(link, LensSessionLink.ProvisionPhase.GRANTING_ASSISTANT, "Granting assistant access.")
-        _grant_assistant_to_chat_user(assistant_uuid=assistant_uuid, sl_user_id=sl_user_link.sl_user_id)
+    except ChatProvisionLeaseLostError:
+        _compensate_late_assistant(link.id, assistant_uuid)
+        raise
+    _set_phase(
+        link,
+        claim_token,
+        LensSessionLink.ProvisionPhase.GRANTING_ASSISTANT,
+        "Granting assistant access.",
+    )
+    _grant_assistant_to_chat_user(
+        assistant_uuid=assistant_uuid,
+        sl_user_id=sl_user_link.sl_user_id,
+    )
 
-        # 4) Create SL session as Chat User.
-        _set_phase(link, LensSessionLink.ProvisionPhase.CREATING_SESSION, "Opening the chat session.")
-        session_uuid = link.sl_session_uuid
+    # 4) Create SL session as Chat User.
+    _set_phase(
+        link,
+        claim_token,
+        LensSessionLink.ProvisionPhase.CREATING_SESSION,
+        "Opening the chat session.",
+    )
+    session_uuid = link.sl_session_uuid
+    if session_uuid is None:
+        operation = _prepare_remote_operation(
+            link,
+            claim_token,
+            kind=_SESSION_CREATE_OPERATION,
+        )
+        session_marker = str(operation["lookup_key"])
+        stored_remote_uuid = str(operation.get("remote_uuid") or "").strip()
+        session_uuid = (
+            uuid_lib.UUID(stored_remote_uuid)
+            if stored_remote_uuid
+            else _find_remote_uuid(
+                path="/api/lens/sessions/",
+                field="title",
+                value=session_marker,
+                hfl_user=user,
+            )
+        )
         if session_uuid is None:
             sl_session = sl_client.request_json(
                 "POST",
                 "/api/lens/sessions/",
-                json_body={"assistant_uuid": str(assistant_uuid), "title": link.title},
+                json_body={
+                    "assistant_uuid": str(assistant_uuid),
+                    "title": session_marker,
+                },
                 hfl_user=user,
             )
             session_uuid = uuid_lib.UUID(str(sl_session["uuid"]))
+        try:
+            _record_remote_operation_resource(
+                link,
+                claim_token,
+                kind=_SESSION_CREATE_OPERATION,
+                field="sl_session_uuid",
+                remote_uuid=session_uuid,
+            )
+        except ChatProvisionLeaseLostError:
+            _compensate_late_session(link.id, session_uuid, user=user)
+            raise
 
-        link.sl_assistant_uuid = assistant_uuid
-        link.sl_session_uuid = session_uuid
-        link.lifecycle_status = LensSessionLink.LifecycleStatus.READY
-        link.provision_phase = LensSessionLink.ProvisionPhase.READY
-        link.provision_detail = "Chat is ready."
-        link.lifecycle_error = ""
-        ks.status = LensKnowledgeSource.Status.READY
-        ks.status_detail = "Restored data and Assistant are ready for chat."
-        ks.save(update_fields=["status", "status_detail", "updated_at"])
-        link.save(
-            update_fields=[
-                "sl_assistant_uuid",
-                "sl_session_uuid",
+    sl_client.request_json(
+        "PATCH",
+        f"/api/lens/sessions/{session_uuid}/",
+        json_body={"title": link.title},
+        hfl_user=user,
+    )
+    _require_provision_claim(link.id, claim_token)
+
+    _complete_copilot_chat_provision(
+        link_id=link.id,
+        claim_token=claim_token,
+        knowledge_source_id=ks.id,
+        assistant_uuid=assistant_uuid,
+        session_uuid=session_uuid,
+    )
+    return {
+        "session_link_id": link.id,
+        "status": "ready",
+        "knowledge_source_id": ks.id,
+        "sync": sync_result,
+    }
+
+
+def _require_provision_claim(link_id: int, claim_token: str) -> None:
+    if not LensSessionLink.objects.filter(
+        pk=link_id,
+        lifecycle_status=LensSessionLink.LifecycleStatus.PROVISIONING,
+        provision_claim_token=claim_token,
+    ).exists():
+        raise ChatProvisionLeaseLostError("Chat provisioning lease was lost.")
+
+
+def _update_provision_claim(
+    link: LensSessionLink,
+    claim_token: str,
+    *fields: str,
+) -> None:
+    """Persist provisioning progress only while the current lease is valid."""
+    now = timezone.now()
+    values = {field: getattr(link, field) for field in fields}
+    values.update(provision_claimed_at=now, updated_at=now)
+    updated = LensSessionLink.objects.filter(
+        pk=link.id,
+        lifecycle_status=LensSessionLink.LifecycleStatus.PROVISIONING,
+        provision_claim_token=claim_token,
+    ).update(**values)
+    if updated != 1:
+        raise ChatProvisionLeaseLostError("Chat provisioning lease was lost.")
+    link.provision_claimed_at = now
+
+
+def _remote_items(raw: Any) -> list[dict[str, Any]]:
+    """Normalize SourceLens list and paginated-list responses."""
+    if isinstance(raw, list):
+        return [item for item in raw if isinstance(item, dict)]
+    if isinstance(raw, dict):
+        for key in ("results", "items", "data"):
+            value = raw.get(key)
+            if isinstance(value, list):
+                return [item for item in value if isinstance(item, dict)]
+            if isinstance(value, dict):
+                nested = _remote_items(value)
+                if nested:
+                    return nested
+    return []
+
+
+def _prepare_remote_operation(
+    link: LensSessionLink,
+    claim_token: str,
+    *,
+    kind: str,
+    lookup_key: str = "",
+) -> dict[str, Any]:
+    """Persist remote-create intent before SourceLens receives the request."""
+    state = dict(link.provision_state_json or {})
+    operation = dict(state.get(kind) or {})
+    if operation.get("status") in {"compensated", "not_created"}:
+        operation = {}
+    if not operation:
+        operation_id = uuid_lib.uuid4()
+        if kind == _SESSION_CREATE_OPERATION:
+            lookup_key = f"__hfl_provision_{operation_id.hex}__"
+        operation = {
+            "operation_id": str(operation_id),
+            "kind": kind,
+            "lookup_key": lookup_key,
+            "remote_uuid": "",
+            "status": "intent",
+            "created_at": timezone.now().isoformat(),
+            "updated_at": timezone.now().isoformat(),
+        }
+    elif lookup_key and operation.get("lookup_key") != lookup_key:
+        raise RuntimeError(f"Remote operation lookup key changed for {kind}.")
+    state[kind] = operation
+    link.provision_state_json = state
+    _update_provision_claim(link, claim_token, "provision_state_json")
+    return operation
+
+
+def _record_remote_operation_resource(
+    link: LensSessionLink,
+    claim_token: str,
+    *,
+    kind: str,
+    field: str,
+    remote_uuid: uuid_lib.UUID,
+) -> None:
+    """Atomically bind a returned UUID to its journal and Chat field."""
+    state = dict(link.provision_state_json or {})
+    operation = dict(state.get(kind) or {})
+    if not operation:
+        raise RuntimeError(f"Remote operation intent is missing for {kind}.")
+    operation["remote_uuid"] = str(remote_uuid)
+    operation["status"] = "remote_created"
+    operation["updated_at"] = timezone.now().isoformat()
+    state[kind] = operation
+    link.provision_state_json = state
+    setattr(link, field, remote_uuid)
+    _update_provision_claim(
+        link,
+        claim_token,
+        "provision_state_json",
+        field,
+    )
+
+
+@transaction.atomic
+def _bind_assistant_to_provision_claim(
+    link: LensSessionLink,
+    claim_token: str,
+    *,
+    knowledge_source: LensKnowledgeSource,
+    assistant_uuid: uuid_lib.UUID,
+) -> None:
+    """Atomically bind Assistant ownership while provisioning owns the Chat."""
+
+    locked = (
+        LensSessionLink.objects.select_for_update()
+        .select_related("organization", "hfl_user")
+        .filter(
+            pk=link.id,
+            lifecycle_status=LensSessionLink.LifecycleStatus.PROVISIONING,
+            provision_claim_token=claim_token,
+        )
+        .first()
+    )
+    if locked is None:
+        raise ChatProvisionLeaseLostError("Chat provisioning lease was lost.")
+    locked_knowledge_source = (
+        LensKnowledgeSource.objects.select_for_update()
+        .filter(
+            pk=knowledge_source.id,
+            organization_id=locked.organization_id,
+            lifecycle_status=LensKnowledgeSource.LifecycleStatus.READY,
+        )
+        .first()
+    )
+    if locked_knowledge_source is None:
+        raise ChatProvisionLeaseLostError(
+            "Knowledge Source was deleted during Chat provisioning."
+        )
+
+    state = dict(locked.provision_state_json or {})
+    operation = dict(state.get(_ASSISTANT_CREATE_OPERATION) or {})
+    if operation:
+        recorded_uuid = str(operation.get("remote_uuid") or "").strip()
+        if recorded_uuid and recorded_uuid != str(assistant_uuid):
+            raise RuntimeError("Assistant create journal references another resource.")
+        operation["remote_uuid"] = str(assistant_uuid)
+        operation["status"] = "remote_created"
+        operation["updated_at"] = timezone.now().isoformat()
+        state[_ASSISTANT_CREATE_OPERATION] = operation
+
+    locked.provision_state_json = state
+    locked.sl_assistant_uuid = assistant_uuid
+    locked_knowledge_source.sl_assistant_uuid = assistant_uuid
+    locked_knowledge_source.save(
+        update_fields=["sl_assistant_uuid", "updated_at"]
+    )
+    assistant_access.ensure_assistant_link(
+        org=locked.organization,
+        sl_assistant_uuid=assistant_uuid,
+        knowledge_source=locked_knowledge_source,
+        created_by=locked.hfl_user,
+        owner_user=locked.hfl_user,
+        visibility_scope="user",
+        lifecycle_owner=LensAssistantLink.LifecycleOwner.CHAT,
+    )
+    now = timezone.now()
+    locked.provision_claimed_at = now
+    locked.save(
+        update_fields=[
+            "provision_state_json",
+            "sl_assistant_uuid",
+            "provision_claimed_at",
+            "updated_at",
+        ]
+    )
+    link.provision_state_json = state
+    link.sl_assistant_uuid = assistant_uuid
+    link.provision_claimed_at = now
+    knowledge_source.sl_assistant_uuid = assistant_uuid
+
+
+def _operation_remote_uuid(
+    link: LensSessionLink,
+    kind: str,
+) -> uuid_lib.UUID | None:
+    operation = dict((link.provision_state_json or {}).get(kind) or {})
+    value = str(operation.get("remote_uuid") or "").strip()
+    return uuid_lib.UUID(value) if value else None
+
+
+def _set_operation_status(
+    link: LensSessionLink,
+    kind: str,
+    *,
+    status: str,
+    error: str = "",
+) -> None:
+    state = dict(link.provision_state_json or {})
+    operation = dict(state.get(kind) or {})
+    if not operation:
+        return
+    operation["status"] = status
+    operation["last_error"] = error[:1000]
+    operation["updated_at"] = timezone.now().isoformat()
+    state[kind] = operation
+    link.provision_state_json = state
+
+
+def _late_remote_uuids(
+    link: LensSessionLink,
+    resource_kind: str,
+) -> set[uuid_lib.UUID]:
+    state = dict(link.provision_state_json or {})
+    return {
+        uuid_lib.UUID(str(item["remote_uuid"]))
+        for item in state.get("late_resources") or []
+        if isinstance(item, dict)
+        and item.get("kind") == resource_kind
+        and item.get("remote_uuid")
+    }
+
+
+def _retain_failed_late_resources(
+    link: LensSessionLink,
+    resource_kind: str,
+    failed_uuids: list[uuid_lib.UUID],
+) -> None:
+    state = dict(link.provision_state_json or {})
+    retained = [
+        item
+        for item in state.get("late_resources") or []
+        if isinstance(item, dict) and item.get("kind") != resource_kind
+    ]
+    retained.extend(
+        {
+            "kind": resource_kind,
+            "remote_uuid": str(remote_uuid),
+            "updated_at": timezone.now().isoformat(),
+        }
+        for remote_uuid in failed_uuids
+    )
+    state["late_resources"] = retained
+    link.provision_state_json = state
+
+
+def _find_remote_uuid(
+    *,
+    path: str,
+    field: str,
+    value: str,
+    hfl_user: AbstractBaseUser | None = None,
+) -> uuid_lib.UUID | None:
+    page_size = 100
+    seen_pages: set[tuple[str, ...]] = set()
+    for page in range(1, 1001):
+        raw = sl_client.request_json(
+            "GET",
+            path,
+            params={"page": page, "page_size": page_size},
+            hfl_user=hfl_user,
+        )
+        items = _remote_items(raw)
+        matches = [
+            item
+            for item in items
+            if str(item.get(field) or "") == value
+        ]
+        if len(matches) > 1:
+            raise sl_client.LensBridgeError(
+                f"SourceLens returned multiple {field}={value!r} resources."
+            )
+        if matches:
+            remote_uuid = matches[0].get("uuid")
+            if not remote_uuid:
+                raise sl_client.LensBridgeError(
+                    f"SourceLens {field}={value!r} resource has no uuid."
+                )
+            return uuid_lib.UUID(str(remote_uuid))
+        if isinstance(raw, list) or not items or len(items) < page_size:
+            return None
+        signature = tuple(
+            str(item.get("uuid") or item.get(field) or "")
+            for item in items
+        )
+        if signature in seen_pages:
+            raise sl_client.LensBridgeError(
+                "SourceLens pagination did not advance while finding "
+                f"{field}={value!r}."
+            )
+        seen_pages.add(signature)
+    raise sl_client.LensBridgeError(
+        f"SourceLens pagination limit reached while finding {field}={value!r}."
+    )
+
+
+def _recover_journal_resource(
+    link: LensSessionLink,
+    kind: str,
+    *,
+    hfl_user: AbstractBaseUser | None = None,
+) -> uuid_lib.UUID | None:
+    """Resolve an intent whose worker may have crashed after remote creation."""
+    known_uuid = _operation_remote_uuid(link, kind)
+    if known_uuid is not None:
+        return known_uuid
+    state = dict(link.provision_state_json or {})
+    operation = dict(state.get(kind) or {})
+    if not operation:
+        return None
+    lookup_key = str(operation.get("lookup_key") or "").strip()
+    if not lookup_key:
+        raise RuntimeError(f"Remote operation lookup key is missing for {kind}.")
+    if kind == _ASSISTANT_CREATE_OPERATION:
+        remote_uuid = _find_remote_uuid(
+            path="/api/lens/assistants/",
+            field="slug",
+            value=lookup_key,
+        )
+    elif kind == _SESSION_CREATE_OPERATION:
+        remote_uuid = _find_remote_uuid(
+            path="/api/lens/sessions/",
+            field="title",
+            value=lookup_key,
+            hfl_user=hfl_user,
+        )
+    else:
+        raise ValueError(f"Unsupported remote operation kind: {kind}.")
+    operation["status"] = "remote_created" if remote_uuid else "not_created"
+    operation["remote_uuid"] = str(remote_uuid) if remote_uuid else ""
+    operation["updated_at"] = timezone.now().isoformat()
+    state[kind] = operation
+    link.provision_state_json = state
+    return remote_uuid
+
+
+def _set_phase(
+    link: LensSessionLink,
+    claim_token: str,
+    phase: str,
+    detail: str,
+) -> None:
+    link.provision_phase = phase
+    link.provision_detail = detail[:300]
+    _update_provision_claim(
+        link,
+        claim_token,
+        "provision_phase",
+        "provision_detail",
+    )
+
+
+@transaction.atomic
+def _complete_copilot_chat_provision(
+    *,
+    link_id: int,
+    claim_token: str,
+    knowledge_source_id: int,
+    assistant_uuid: uuid_lib.UUID,
+    session_uuid: uuid_lib.UUID,
+) -> None:
+    """Commit READY only if provisioning still owns the lifecycle lease."""
+    link = (
+        LensSessionLink.objects.select_for_update()
+        .filter(
+            pk=link_id,
+            lifecycle_status=LensSessionLink.LifecycleStatus.PROVISIONING,
+            provision_claim_token=claim_token,
+        )
+        .first()
+    )
+    if link is None:
+        raise ChatProvisionLeaseLostError("Chat provisioning lease was lost.")
+    if link.knowledge_source_id != knowledge_source_id:
+        raise RuntimeError("Chat knowledge source changed during provisioning.")
+    updated_ks = LensKnowledgeSource.objects.filter(
+        pk=knowledge_source_id,
+        lifecycle_status=LensKnowledgeSource.LifecycleStatus.READY,
+    ).update(
+        status=LensKnowledgeSource.Status.READY,
+        status_detail="Restored data and Assistant are ready for chat.",
+        updated_at=timezone.now(),
+    )
+    if updated_ks != 1:
+        raise ChatProvisionLeaseLostError(
+            "Knowledge Source was deleted during Chat provisioning."
+        )
+    link.sl_assistant_uuid = assistant_uuid
+    link.sl_session_uuid = session_uuid
+    link.lifecycle_status = LensSessionLink.LifecycleStatus.READY
+    link.provision_phase = LensSessionLink.ProvisionPhase.READY
+    link.provision_detail = "Chat is ready."
+    link.lifecycle_error = ""
+    provision_state = dict(link.provision_state_json or {})
+    for kind in (_ASSISTANT_CREATE_OPERATION, _SESSION_CREATE_OPERATION):
+        operation = dict(provision_state.get(kind) or {})
+        if operation:
+            operation["status"] = "bound"
+            operation["updated_at"] = timezone.now().isoformat()
+            provision_state[kind] = operation
+    link.provision_state_json = provision_state
+    link.provision_claim_token = None
+    link.provision_claimed_at = None
+    link.provision_next_retry_at = None
+    link.save(
+        update_fields=[
+            "sl_assistant_uuid",
+            "sl_session_uuid",
+            "lifecycle_status",
+            "provision_phase",
+            "provision_detail",
+            "lifecycle_error",
+            "provision_state_json",
+            "provision_claim_token",
+            "provision_claimed_at",
+            "provision_next_retry_at",
+            "updated_at",
+        ]
+    )
+
+
+def _cleanup_orphan_knowledge_source(
+    knowledge_source: LensKnowledgeSource,
+    *,
+    owner_session_link_id: int,
+) -> None:
+    """Durably tear down a KS that could not be attached to its Chat."""
+    try:
+        from apps.lens_bridge.services.knowledge_source_teardown import (
+            request_knowledge_source_teardown,
+            run_knowledge_source_teardown,
+        )
+
+        request_knowledge_source_teardown(knowledge_source)
+        run_knowledge_source_teardown(
+            knowledge_source_id=knowledge_source.id,
+            owner_session_link_id=owner_session_link_id,
+        )
+    except Exception:
+        logger.exception(
+            "orphan knowledge source cleanup deferred knowledge_source_id=%s",
+            knowledge_source.id,
+        )
+
+
+@transaction.atomic
+def _record_late_source_lens_resource(
+    link_id: int,
+    *,
+    field: str,
+    resource_uuid: uuid_lib.UUID,
+    error: str,
+) -> None:
+    """Reopen teardown when immediate compensation cannot delete a late resource."""
+    if field not in {"sl_session_uuid", "sl_assistant_uuid"}:
+        raise ValueError("Unsupported late SourceLens resource field.")
+    link = LensSessionLink.objects.select_for_update().get(pk=link_id)
+    existing = getattr(link, field)
+    if existing not in {None, resource_uuid}:
+        resource_kind = (
+            "session" if field == "sl_session_uuid" else "assistant"
+        )
+        late_resources = _late_remote_uuids(link, resource_kind)
+        late_resources.add(resource_uuid)
+        _retain_failed_late_resources(
+            link,
+            resource_kind,
+            sorted(late_resources, key=str),
+        )
+        update_fields = [
+            "provision_state_json",
+            "lifecycle_error",
+            "updated_at",
+        ]
+    else:
+        setattr(link, field, resource_uuid)
+        update_fields = [field, "lifecycle_error", "updated_at"]
+    link.lifecycle_error = error[:2000]
+    if link.lifecycle_status != LensSessionLink.LifecycleStatus.DELETING:
+        link.lifecycle_status = LensSessionLink.LifecycleStatus.DELETING
+        link.status = LensSessionLink.Status.ARCHIVED
+        link.provision_phase = LensSessionLink.ProvisionPhase.CLEANING_UP
+        link.provision_detail = "Deleting a resource returned after Chat deletion."
+        link.provision_claim_token = None
+        link.provision_claimed_at = None
+        link.provision_next_retry_at = None
+        link.teardown_claim_token = None
+        link.teardown_claimed_at = None
+        link.teardown_next_retry_at = None
+        update_fields.extend(
+            [
                 "lifecycle_status",
+                "status",
                 "provision_phase",
                 "provision_detail",
-                "lifecycle_error",
+                "provision_claim_token",
+                "provision_claimed_at",
+                "provision_next_retry_at",
+                "teardown_claim_token",
+                "teardown_claimed_at",
+                "teardown_next_retry_at",
+            ]
+        )
+    link.save(update_fields=update_fields)
+    transaction.on_commit(lambda: _queue_teardown_or_record_error(link.id))
+
+
+def _compensate_late_session(
+    link_id: int,
+    session_uuid: uuid_lib.UUID,
+    *,
+    user: AbstractBaseUser,
+) -> None:
+    try:
+        sl_client.request_json(
+            "DELETE",
+            f"/api/lens/sessions/{session_uuid}/",
+            hfl_user=user,
+        )
+    except Exception as exc:
+        if _source_lens_not_found(exc):
+            return
+        _record_late_source_lens_resource(
+            link_id,
+            field="sl_session_uuid",
+            resource_uuid=session_uuid,
+            error=f"Late session compensation failed: {exc}",
+        )
+
+
+def _compensate_late_assistant(
+    link_id: int,
+    assistant_uuid: uuid_lib.UUID,
+) -> None:
+    link = (
+        LensSessionLink.objects.select_related("organization")
+        .filter(pk=link_id)
+        .first()
+    )
+    if link is None:
+        return
+    try:
+        from apps.lens_bridge.services.assistants import _delete_sl_assistant
+
+        _delete_sl_assistant(assistant_uuid)
+        assistant_access.soft_delete_assistant_link(
+            link.organization,
+            assistant_uuid,
+        )
+    except Exception as exc:
+        if _source_lens_not_found(exc):
+            return
+        _record_late_source_lens_resource(
+            link_id,
+            field="sl_assistant_uuid",
+            resource_uuid=assistant_uuid,
+            error=f"Late assistant compensation failed: {exc}",
+        )
+
+
+def _claim_copilot_chat_teardown(session_link_id: int) -> tuple[str | None, str]:
+    now = timezone.now()
+    with transaction.atomic():
+        link = LensSessionLink.objects.select_for_update().filter(pk=session_link_id).first()
+        if link is None:
+            return None, "missing"
+        if link.lifecycle_status == LensSessionLink.LifecycleStatus.DELETED:
+            return None, "deleted"
+        if link.lifecycle_status != LensSessionLink.LifecycleStatus.DELETING:
+            return None, str(link.lifecycle_status)
+        if (
+            link.teardown_claimed_at
+            and link.teardown_claimed_at
+            > now - timedelta(seconds=TEARDOWN_CLAIM_TTL_SECONDS)
+        ):
+            return None, "busy"
+        if link.teardown_next_retry_at and link.teardown_next_retry_at > now:
+            return None, "scheduled"
+        claim_token = uuid_lib.uuid4()
+        link.lifecycle_status = LensSessionLink.LifecycleStatus.DELETING
+        link.teardown_attempts += 1
+        link.teardown_claim_token = claim_token
+        link.teardown_claimed_at = now
+        link.teardown_next_retry_at = next_retry_at(link.teardown_attempts)
+        link.save(
+            update_fields=[
+                "teardown_attempts",
+                "lifecycle_status",
+                "teardown_claim_token",
+                "teardown_claimed_at",
+                "teardown_next_retry_at",
                 "updated_at",
             ]
         )
-        return {
-            "session_link_id": link.id,
-            "status": "ready",
-            "knowledge_source_id": ks.id,
-            "sync": sync_result,
-        }
-    except Exception as exc:
-        logger.exception("copilot chat provision failed session_link_id=%s", session_link_id)
-        _cleanup_failed_provision(link)
-        _mark_failed(link, str(exc))
-        raise
+    return str(claim_token), "claimed"
+
+
+def _source_lens_not_found(exc: Exception) -> bool:
+    return isinstance(exc, sl_client.LensBridgeError) and getattr(exc, "status_code", None) == 404
+
+
+def _teardown_step(
+    state: dict[str, Any],
+    step: str,
+    *,
+    status: str,
+    error: str = "",
+) -> None:
+    state[step] = {
+        "status": status,
+        "error": error[:1000],
+        "updated_at": timezone.now().isoformat(),
+    }
+
+
+def _update_chat_claim(
+    link: LensSessionLink,
+    claim_token: str,
+    *fields: str,
+) -> None:
+    """Persist intermediate Chat teardown state under the current lease."""
+
+    values = {field: getattr(link, field) for field in fields}
+    values["updated_at"] = timezone.now()
+    updated = LensSessionLink.objects.filter(
+        pk=link.id,
+        teardown_claim_token=claim_token,
+        lifecycle_status=LensSessionLink.LifecycleStatus.DELETING,
+    ).update(**values)
+    if updated != 1:
+        raise ChatTeardownIncompleteError("Chat teardown lease was lost.")
 
 
 def run_copilot_chat_teardown(*, session_link_id: int) -> dict[str, Any]:
+    claim_token, claim_status = _claim_copilot_chat_teardown(session_link_id)
+    if claim_token is None:
+        return {"session_link_id": session_link_id, "status": claim_status}
     link = (
         LensSessionLink.objects.select_related(
             "knowledge_source",
+            "knowledge_source__workspace_binding",
             "hfl_user",
             "organization",
             "chat_binding",
@@ -413,14 +1257,13 @@ def run_copilot_chat_teardown(*, session_link_id: int) -> dict[str, Any]:
     )
     if link is None:
         return {"session_link_id": session_link_id, "status": "missing"}
-    if link.lifecycle_status == LensSessionLink.LifecycleStatus.DELETED:
-        return {"session_link_id": link.id, "status": "deleted"}
 
     org = link.organization
     user = link.hfl_user
-    errors: list[str] = []
+    critical_errors: list[str] = []
+    warnings: list[str] = []
+    teardown_state = dict(link.teardown_state_json or {})
 
-    # Cancel active run (best-effort).
     if link.active_run_uuid:
         try:
             sl_client.request_json(
@@ -429,53 +1272,334 @@ def run_copilot_chat_teardown(*, session_link_id: int) -> dict[str, Any]:
                 hfl_user=user,
             )
         except Exception as exc:
-            errors.append(f"cancel_run: {exc}")
+            if not _source_lens_not_found(exc):
+                warnings.append(f"cancel_run: {exc}")
+                _teardown_step(teardown_state, "cancel_run", status="warning", error=str(exc))
+            else:
+                _teardown_step(teardown_state, "cancel_run", status="success")
+        else:
+            _teardown_step(teardown_state, "cancel_run", status="success")
 
-    # Delete SL session (Chat User). Never touches DG.
-    if link.sl_session_uuid:
+    session_recovery_failed = False
+    try:
+        journal_session_uuid = _recover_journal_resource(
+            link,
+            _SESSION_CREATE_OPERATION,
+            hfl_user=user,
+        )
+    except Exception as exc:
+        journal_session_uuid = None
+        session_recovery_failed = True
+        critical_errors.append(f"recover_session_operation: {exc}")
+    session_uuids = {
+        item
+        for item in (link.sl_session_uuid, journal_session_uuid)
+        if item is not None
+    }
+    session_uuids.update(_late_remote_uuids(link, "session"))
+    failed_session_uuids: list[uuid_lib.UUID] = []
+    for session_uuid in sorted(session_uuids, key=str):
         try:
             sl_client.request_json(
                 "DELETE",
-                f"/api/lens/sessions/{link.sl_session_uuid}/",
+                f"/api/lens/sessions/{session_uuid}/",
                 hfl_user=user,
             )
         except Exception as exc:
-            errors.append(f"delete_session: {exc}")
+            if not _source_lens_not_found(exc):
+                failed_session_uuids.append(session_uuid)
+                critical_errors.append(f"delete_session {session_uuid}: {exc}")
+    link.sl_session_uuid = (
+        failed_session_uuids[0] if failed_session_uuids else None
+    )
+    if journal_session_uuid and journal_session_uuid not in failed_session_uuids:
+        _set_operation_status(
+            link,
+            _SESSION_CREATE_OPERATION,
+            status="compensated",
+        )
+    _retain_failed_late_resources(
+        link,
+        "session",
+        failed_session_uuids,
+    )
+    if failed_session_uuids or session_recovery_failed:
+        detail = "; ".join(
+            error
+            for error in critical_errors
+            if error.startswith(("delete_session ", "recover_session_operation:"))
+        )
+        _teardown_step(
+            teardown_state,
+            "delete_session",
+            status="retry",
+            error=detail,
+        )
+    else:
+        _teardown_step(teardown_state, "delete_session", status="success")
+    _update_chat_claim(
+        link,
+        claim_token,
+        "sl_session_uuid",
+        "provision_state_json",
+    )
 
-    assistant_uuid = link.sl_assistant_uuid
+    session_cleanup_complete = not failed_session_uuids and not session_recovery_failed
+    assistant_recovery_failed = False
+    journal_assistant_uuid: uuid_lib.UUID | None = None
+    failed_assistant_uuids: list[uuid_lib.UUID] = []
     ks = link.knowledge_source
-
-    # Delete SL Assistant (Admin token) — real DELETE, then HFL link cleanup.
-    if assistant_uuid:
+    assistant_uuids: set[uuid_lib.UUID] = set()
+    if session_cleanup_complete:
         try:
-            from apps.lens_bridge.services.assistants import _delete_sl_assistant
-
-            _delete_sl_assistant(assistant_uuid)
+            journal_assistant_uuid = _recover_journal_resource(
+                link,
+                _ASSISTANT_CREATE_OPERATION,
+            )
         except Exception as exc:
-            errors.append(f"delete_assistant_sl: {exc}")
-        try:
-            assistant_access.soft_delete_assistant_link(org, assistant_uuid)
-        except Exception as exc:
-            errors.append(f"delete_assistant_link: {exc}")
+            assistant_recovery_failed = True
+            critical_errors.append(f"recover_assistant_operation: {exc}")
+        assistant_uuids = {
+            item
+            for item in (link.sl_assistant_uuid, journal_assistant_uuid)
+            if item is not None
+        }
+        assistant_uuids.update(_late_remote_uuids(link, "assistant"))
+        for assistant_uuid in sorted(assistant_uuids, key=str):
+            try:
+                from apps.lens_bridge.services.assistants import (
+                    _delete_sl_assistant,
+                )
 
-    # Soft-delete KS owned by this chat. DG itself is never deleted.
-    if ks is not None:
-        try:
-            _cleanup_ks_workspace_marker(ks)
-            if ks.sl_assistant_uuid == assistant_uuid:
+                _delete_sl_assistant(assistant_uuid)
+                assistant_access.soft_delete_assistant_link(org, assistant_uuid)
+            except Exception as exc:
+                failed_assistant_uuids.append(assistant_uuid)
+                critical_errors.append(
+                    f"delete_assistant {assistant_uuid}: {exc}"
+                )
+        link.sl_assistant_uuid = (
+            failed_assistant_uuids[0] if failed_assistant_uuids else None
+        )
+        if (
+            journal_assistant_uuid
+            and journal_assistant_uuid not in failed_assistant_uuids
+        ):
+            _set_operation_status(
+                link,
+                _ASSISTANT_CREATE_OPERATION,
+                status="compensated",
+            )
+        _retain_failed_late_resources(
+            link,
+            "assistant",
+            failed_assistant_uuids,
+        )
+        if ks is not None:
+            deleted_assistant_uuids = assistant_uuids.difference(
+                failed_assistant_uuids
+            )
+            if ks.sl_assistant_uuid in deleted_assistant_uuids:
+                LensKnowledgeSource.objects.filter(
+                    pk=ks.id,
+                    sl_assistant_uuid=ks.sl_assistant_uuid,
+                ).update(sl_assistant_uuid=None, updated_at=timezone.now())
                 ks.sl_assistant_uuid = None
-                ks.save(update_fields=["sl_assistant_uuid", "updated_at"])
-            ks.soft_delete()
-        except Exception as exc:
-            errors.append(f"delete_ks: {exc}")
+        if failed_assistant_uuids or assistant_recovery_failed:
+            detail = "; ".join(
+                error
+                for error in critical_errors
+                if error.startswith(
+                    ("delete_assistant ", "recover_assistant_operation:")
+                )
+            )
+            _teardown_step(
+                teardown_state,
+                "delete_assistant",
+                status="retry",
+                error=detail,
+            )
+        else:
+            _teardown_step(
+                teardown_state,
+                "delete_assistant",
+                status="success",
+            )
+    else:
+        _teardown_step(
+            teardown_state,
+            "delete_assistant",
+            status="blocked",
+            error="Session deletion must finish before Assistant deletion.",
+        )
+    _update_chat_claim(
+        link,
+        claim_token,
+        "sl_assistant_uuid",
+        "provision_state_json",
+    )
 
-    link.lifecycle_status = LensSessionLink.LifecycleStatus.DELETED
+    if (
+        ks is not None
+        and session_cleanup_complete
+        and not failed_assistant_uuids
+        and not assistant_recovery_failed
+    ):
+        try:
+            from apps.lens_bridge.services.knowledge_source_teardown import (
+                run_knowledge_source_teardown,
+            )
+
+            result = run_knowledge_source_teardown(
+                knowledge_source_id=ks.id,
+                owner_session_link_id=link.id,
+            )
+            if result.get("status") not in {"deleted"}:
+                raise RuntimeError(
+                    "Knowledge Source teardown is " + str(result.get("status"))
+                )
+            link.knowledge_source = None
+            link.sl_assistant_uuid = None
+            _update_chat_claim(
+                link,
+                claim_token,
+                "knowledge_source",
+                "sl_assistant_uuid",
+                "provision_state_json",
+            )
+            _teardown_step(teardown_state, "delete_assistant", status="success")
+            _teardown_step(teardown_state, "cleanup_workspace", status="success")
+        except Exception as exc:
+            critical_errors.append(f"cleanup_workspace: {exc}")
+            _teardown_step(teardown_state, "cleanup_workspace", status="retry", error=str(exc))
+    elif ks is None:
+        _teardown_step(teardown_state, "cleanup_workspace", status="success")
+    else:
+        dependency = (
+            "Session deletion must finish before workspace cleanup."
+            if not session_cleanup_complete
+            else "Assistant deletion must finish before workspace cleanup."
+        )
+        _teardown_step(
+            teardown_state,
+            "cleanup_workspace",
+            status="blocked",
+            error=dependency,
+        )
+
+    link.lifecycle_status = (
+        LensSessionLink.LifecycleStatus.DELETING
+        if critical_errors
+        else LensSessionLink.LifecycleStatus.DELETED
+    )
     link.status = LensSessionLink.Status.ARCHIVED
-    link.provision_phase = LensSessionLink.ProvisionPhase.DELETED
-    link.provision_detail = "Chat resources deleted."
-    link.lifecycle_error = "; ".join(errors)[:2000]
+    link.provision_phase = (
+        LensSessionLink.ProvisionPhase.CLEANING_UP
+        if critical_errors
+        else LensSessionLink.ProvisionPhase.DELETED
+    )
+    link.provision_detail = (
+        "Chat cleanup is incomplete and will be retried."
+        if critical_errors
+        else "Chat resources deleted."
+    )
+    link.lifecycle_error = "; ".join([*critical_errors, *warnings])[:2000]
     link.active_run_uuid = None
     link.active_run_status = ""
+    link.teardown_state_json = teardown_state
+    link.teardown_claim_token = None
+    link.teardown_claimed_at = None
+    if not critical_errors:
+        link.teardown_next_retry_at = None
+    final_query = LensSessionLink.objects.filter(
+        pk=link.id,
+        teardown_claim_token=claim_token,
+        lifecycle_status=LensSessionLink.LifecycleStatus.DELETING,
+    )
+    if not critical_errors:
+        final_query = final_query.filter(
+            sl_session_uuid__isnull=True,
+            sl_assistant_uuid__isnull=True,
+            knowledge_source__isnull=True,
+        )
+    updated = final_query.update(
+        lifecycle_status=link.lifecycle_status,
+        status=link.status,
+        provision_phase=link.provision_phase,
+        provision_detail=link.provision_detail,
+        lifecycle_error=link.lifecycle_error,
+        active_run_uuid=None,
+        active_run_status="",
+        teardown_state_json=teardown_state,
+        teardown_claim_token=None,
+        teardown_claimed_at=None,
+        teardown_next_retry_at=link.teardown_next_retry_at,
+        updated_at=timezone.now(),
+    )
+    if updated != 1:
+        raise ChatTeardownIncompleteError("Chat teardown lease was lost.")
+    if critical_errors:
+        raise ChatTeardownIncompleteError("; ".join(critical_errors))
+    return {
+        "session_link_id": link.id,
+        "status": "deleted",
+        "warnings": warnings,
+        "gateway_untouched": True,
+    }
+
+
+def _mark_provision_failed_by_id(
+    session_link_id: int,
+    claim_token: str,
+    message: str,
+) -> None:
+    LensSessionLink.objects.filter(
+        pk=session_link_id,
+        lifecycle_status=LensSessionLink.LifecycleStatus.PROVISIONING,
+        provision_claim_token=claim_token,
+    ).update(
+        lifecycle_status=LensSessionLink.LifecycleStatus.FAILED,
+        provision_phase=LensSessionLink.ProvisionPhase.QUEUED,
+        provision_detail="Chat preparation failed.",
+        lifecycle_error=(message or "provision failed")[:2000],
+        provision_claim_token=None,
+        provision_claimed_at=None,
+        provision_next_retry_at=None,
+        updated_at=timezone.now(),
+    )
+
+
+@transaction.atomic
+def _transition_failed_provision_to_teardown(
+    session_link_id: int,
+    claim_token: str,
+    *,
+    message: str,
+) -> bool:
+    """Fence retry and hand incomplete compensation to durable teardown."""
+    link = (
+        LensSessionLink.objects.select_for_update()
+        .filter(
+            pk=session_link_id,
+            lifecycle_status=LensSessionLink.LifecycleStatus.PROVISIONING,
+            provision_claim_token=claim_token,
+        )
+        .first()
+    )
+    if link is None:
+        return False
+    link.lifecycle_status = LensSessionLink.LifecycleStatus.DELETING
+    link.status = LensSessionLink.Status.ARCHIVED
+    link.provision_phase = LensSessionLink.ProvisionPhase.CLEANING_UP
+    link.provision_detail = "Provisioning cleanup is incomplete and will be retried."
+    link.lifecycle_error = message[:2000]
+    link.provision_claim_token = None
+    link.provision_claimed_at = None
+    link.provision_next_retry_at = None
+    link.teardown_attempts = 0
+    link.teardown_claim_token = None
+    link.teardown_claimed_at = None
+    link.teardown_next_retry_at = None
     link.save(
         update_fields=[
             "lifecycle_status",
@@ -483,80 +1607,54 @@ def run_copilot_chat_teardown(*, session_link_id: int) -> dict[str, Any]:
             "provision_phase",
             "provision_detail",
             "lifecycle_error",
-            "active_run_uuid",
-            "active_run_status",
+            "provision_claim_token",
+            "provision_claimed_at",
+            "provision_next_retry_at",
+            "teardown_attempts",
+            "teardown_claim_token",
+            "teardown_claimed_at",
+            "teardown_next_retry_at",
             "updated_at",
         ]
     )
-    return {
-        "session_link_id": link.id,
-        "status": "deleted",
-        "errors": errors,
-        # Explicit: DG lifecycle is independent of chat teardown.
-        "gateway_untouched": True,
-    }
-
-
-def _cleanup_ks_workspace_marker(ks: LensKnowledgeSource) -> None:
-    """Mark KS workspace for cleanup without touching the DG itself.
-
-    Full agent-side RemoveAll for ``lens.ks.cleanup`` can land later; record
-    intent so ops/reconcile jobs can reclaim {workspace_root}/ks-{id}.
-    """
-    sync_state = dict(ks.sync_state_json or {})
-    sync_state["teardown_requested_at"] = timezone.now().isoformat()
-    sync_state["teardown_workspace_path"] = ks.workspace_path_on_lensnode or ""
-    ks.sync_state_json = sync_state
-    ks.save(update_fields=["sync_state_json", "updated_at"])
-
-
-def _mark_failed(link: LensSessionLink, message: str) -> None:
-    link.lifecycle_status = LensSessionLink.LifecycleStatus.FAILED
-    link.provision_phase = LensSessionLink.ProvisionPhase.QUEUED
-    link.provision_detail = "Chat preparation failed."
-    link.lifecycle_error = (message or "provision failed")[:2000]
-    link.save(update_fields=["lifecycle_status", "provision_phase", "provision_detail", "lifecycle_error", "updated_at"])
-
-
-def _mark_provision_failed_by_id(session_link_id: int, message: str) -> None:
-    LensSessionLink.objects.filter(pk=session_link_id).exclude(
-        lifecycle_status__in=(
-            LensSessionLink.LifecycleStatus.DELETING,
-            LensSessionLink.LifecycleStatus.DELETED,
-        )
-    ).update(
-        lifecycle_status=LensSessionLink.LifecycleStatus.FAILED,
-        provision_phase=LensSessionLink.ProvisionPhase.QUEUED,
-        provision_detail="Chat preparation failed.",
-        lifecycle_error=(message or "provision failed")[:2000],
-        updated_at=timezone.now(),
-    )
-
-
-def _set_phase(link: LensSessionLink, phase: str, detail: str) -> None:
-    link.refresh_from_db(fields=["lifecycle_status"])
-    if link.lifecycle_status == LensSessionLink.LifecycleStatus.DELETING:
-        raise ValidationError({"lifecycle_status": "Chat deletion was requested."})
-    link.provision_phase = phase
-    link.provision_detail = detail[:300]
-    link.save(update_fields=["provision_phase", "provision_detail", "updated_at"])
+    transaction.on_commit(lambda: _queue_teardown_or_record_error(link.id))
+    return True
 
 
 @transaction.atomic
 def retry_copilot_chat_provision(link: LensSessionLink) -> LensSessionLink:
     locked = LensSessionLink.objects.select_for_update().get(pk=link.pk)
-    if locked.lifecycle_status in (
-        LensSessionLink.LifecycleStatus.READY,
-        LensSessionLink.LifecycleStatus.PROVISIONING,
-    ):
+    if locked.lifecycle_status == LensSessionLink.LifecycleStatus.READY:
         return locked
-    if locked.lifecycle_status != LensSessionLink.LifecycleStatus.FAILED:
+    if locked.lifecycle_status == LensSessionLink.LifecycleStatus.PROVISIONING:
+        claim_is_live = (
+            locked.provision_claimed_at is not None
+            and locked.provision_claimed_at
+            > timezone.now() - timedelta(seconds=PROVISION_CLAIM_TTL_SECONDS)
+        )
+        if claim_is_live:
+            return locked
+    elif locked.lifecycle_status != LensSessionLink.LifecycleStatus.FAILED:
         raise ValidationError({"lifecycle_status": "Session is not retryable."})
     locked.lifecycle_status = LensSessionLink.LifecycleStatus.PROVISIONING
     locked.provision_phase = LensSessionLink.ProvisionPhase.QUEUED
     locked.provision_detail = "Chat creation is queued."
     locked.lifecycle_error = ""
-    locked.save(update_fields=["lifecycle_status", "provision_phase", "provision_detail", "lifecycle_error", "updated_at"])
+    locked.provision_claim_token = None
+    locked.provision_claimed_at = None
+    locked.provision_next_retry_at = None
+    locked.save(
+        update_fields=[
+            "lifecycle_status",
+            "provision_phase",
+            "provision_detail",
+            "lifecycle_error",
+            "provision_claim_token",
+            "provision_claimed_at",
+            "provision_next_retry_at",
+            "updated_at",
+        ]
+    )
     transaction.on_commit(lambda: _queue_provision_or_mark_failed(locked.id))
     return locked
 
@@ -571,11 +1669,14 @@ def _queue_provision_or_mark_failed(session_link_id: int) -> None:
         LensSessionLink.objects.filter(
             pk=session_link_id,
             lifecycle_status=LensSessionLink.LifecycleStatus.PROVISIONING,
+            provision_claim_token__isnull=True,
         ).update(
-            lifecycle_status=LensSessionLink.LifecycleStatus.FAILED,
             provision_phase=LensSessionLink.ProvisionPhase.QUEUED,
-            provision_detail="Chat preparation could not be queued. Retry when the worker is available.",
+            provision_detail=(
+                "Chat preparation is waiting for the worker queue."
+            ),
             lifecycle_error=str(exc)[:2000],
+            provision_next_retry_at=timezone.now() + timedelta(seconds=60),
             updated_at=timezone.now(),
         )
 
@@ -597,38 +1698,137 @@ def _queue_teardown_or_record_error(session_link_id: int) -> None:
         )
 
 
-def _cleanup_failed_provision(link: LensSessionLink) -> None:
+def _cleanup_failed_provision(
+    link: LensSessionLink,
+    claim_token: str,
+) -> list[str]:
     """Best-effort compensation before a failed chat can be retried.
 
     The identifiers are retained when a remote deletion fails, allowing a
     retry to resume rather than create another orphaned SourceLens resource.
     """
-    _set_phase(link, LensSessionLink.ProvisionPhase.CLEANING_UP, "Cleaning up incomplete chat resources.")
+    _set_phase(
+        link,
+        claim_token,
+        LensSessionLink.ProvisionPhase.CLEANING_UP,
+        "Cleaning up incomplete chat resources.",
+    )
+    link.refresh_from_db()
     errors: list[str] = []
+    for kind in (_ASSISTANT_CREATE_OPERATION, _SESSION_CREATE_OPERATION):
+        operation = dict((link.provision_state_json or {}).get(kind) or {})
+        if (
+            operation
+            and not operation.get("remote_uuid")
+            and operation.get("status") not in {"not_created", "compensated"}
+        ):
+            errors.append(f"{kind}: remote create outcome is unknown")
+    journal_assistant_uuid = _operation_remote_uuid(
+        link,
+        _ASSISTANT_CREATE_OPERATION,
+    )
+    journal_session_uuid = _operation_remote_uuid(
+        link,
+        _SESSION_CREATE_OPERATION,
+    )
+    if journal_assistant_uuid and journal_assistant_uuid != link.sl_assistant_uuid:
+        errors.append("assistant_create: journaled resource requires teardown")
+    if journal_session_uuid and journal_session_uuid != link.sl_session_uuid:
+        errors.append("session_create: journaled resource requires teardown")
+    if _late_remote_uuids(link, "assistant") or _late_remote_uuids(link, "session"):
+        errors.append("late_resources: durable teardown is required")
+    if errors:
+        _update_provision_claim(
+            link,
+            claim_token,
+            "provision_state_json",
+        )
+        return errors
+    session_cleanup_complete = True
     if link.sl_session_uuid:
+        session_uuid = link.sl_session_uuid
         try:
-            sl_client.request_json("DELETE", f"/api/lens/sessions/{link.sl_session_uuid}/", hfl_user=link.hfl_user)
+            sl_client.request_json(
+                "DELETE",
+                f"/api/lens/sessions/{session_uuid}/",
+                hfl_user=link.hfl_user,
+            )
             link.sl_session_uuid = None
         except Exception as exc:
-            errors.append(f"delete_session: {exc}")
-    if link.sl_assistant_uuid:
+            if _source_lens_not_found(exc):
+                link.sl_session_uuid = None
+                if _operation_remote_uuid(link, _SESSION_CREATE_OPERATION) == session_uuid:
+                    _set_operation_status(
+                        link,
+                        _SESSION_CREATE_OPERATION,
+                        status="compensated",
+                    )
+            else:
+                errors.append(f"delete_session: {exc}")
+                session_cleanup_complete = False
+        else:
+            if _operation_remote_uuid(link, _SESSION_CREATE_OPERATION) == session_uuid:
+                _set_operation_status(
+                    link,
+                    _SESSION_CREATE_OPERATION,
+                    status="compensated",
+                )
+    assistant_cleanup_complete = session_cleanup_complete
+    if session_cleanup_complete and link.sl_assistant_uuid:
+        assistant_uuid = link.sl_assistant_uuid
         try:
             from apps.lens_bridge.services.assistants import _delete_sl_assistant
 
-            _delete_sl_assistant(link.sl_assistant_uuid)
-            assistant_access.soft_delete_assistant_link(link.organization, link.sl_assistant_uuid)
+            _delete_sl_assistant(assistant_uuid)
+            assistant_access.soft_delete_assistant_link(link.organization, assistant_uuid)
             link.sl_assistant_uuid = None
+            if _operation_remote_uuid(link, _ASSISTANT_CREATE_OPERATION) == assistant_uuid:
+                _set_operation_status(
+                    link,
+                    _ASSISTANT_CREATE_OPERATION,
+                    status="compensated",
+                )
+            ks = link.knowledge_source
+            if ks is not None and ks.sl_assistant_uuid == assistant_uuid:
+                LensKnowledgeSource.objects.filter(
+                    pk=ks.id,
+                    sl_assistant_uuid=assistant_uuid,
+                ).update(sl_assistant_uuid=None, updated_at=timezone.now())
+                ks.sl_assistant_uuid = None
         except Exception as exc:
             errors.append(f"delete_assistant: {exc}")
-    if link.knowledge_source_id:
+            assistant_cleanup_complete = False
+    if (
+        link.knowledge_source_id
+        and session_cleanup_complete
+        and assistant_cleanup_complete
+    ):
         try:
             ks = link.knowledge_source
             if ks is not None:
-                _cleanup_ks_workspace_marker(ks)
-                ks.soft_delete()
+                from apps.lens_bridge.services.knowledge_source_teardown import (
+                    run_knowledge_source_teardown,
+                )
+
+                result = run_knowledge_source_teardown(
+                    knowledge_source_id=ks.id,
+                    owner_session_link_id=link.id,
+                )
+                if result.get("status") != "deleted":
+                    raise RuntimeError(
+                        "Knowledge Source teardown is " + str(result.get("status"))
+                    )
             link.knowledge_source = None
         except Exception as exc:
             errors.append(f"delete_knowledge_source: {exc}")
-    link.save(update_fields=["sl_session_uuid", "sl_assistant_uuid", "knowledge_source", "updated_at"])
+    _update_provision_claim(
+        link,
+        claim_token,
+        "sl_session_uuid",
+        "sl_assistant_uuid",
+        "knowledge_source",
+        "provision_state_json",
+    )
     if errors:
         logger.warning("partial Copilot cleanup session_link_id=%s errors=%s", link.id, errors)
+    return errors

--- a/src/backend/apps/lens_bridge/services/copilot.py
+++ b/src/backend/apps/lens_bridge/services/copilot.py
@@ -73,8 +73,7 @@ def list_copilot_assistants(
     rows = list_org_assistants(
         org,
         user=user,
-        membership=membership,
-        manage=False,
+        can_manage_all=False,
     )
     ks_by_uuid = _ks_by_assistant_uuid(org)
     ks_by_id = _ks_by_id(org)
@@ -108,7 +107,7 @@ def create_copilot_session(
         org,
         assistant_uuid,
         user=user,
-        manage=False,
+        can_manage_all=False,
     )
     if assistant.get("status") != "active":
         raise ValidationError({"assistant_uuid": "Assistant is not active."})
@@ -145,7 +144,11 @@ def create_copilot_session(
             sl_assistant_uuid=assistant_uuid,
             knowledge_source=ks,
         )
-    if not assistant_access.assistant_visible_to(user=user, link=link, manage=False):
+    if not assistant_access.assistant_visible_to(
+        user=user,
+        link=link,
+        can_manage_all=False,
+    ):
         raise NotFound("Assistant not found.")
 
     model_ref_raw = assistant.get("agent_model_ref")

--- a/src/backend/apps/lens_bridge/services/gateway_execution.py
+++ b/src/backend/apps/lens_bridge/services/gateway_execution.py
@@ -1,0 +1,289 @@
+"""Validated execution identity for private and shared Platform gateways."""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+
+from rest_framework.exceptions import ValidationError
+
+from apps.iam.models import Organization
+from apps.lens_bridge.models import (
+    LensGatewayLink,
+    LensKnowledgeSource,
+    LensWorkspaceBinding,
+)
+from apps.lens_bridge.services import gateway_readiness
+
+
+@dataclass(frozen=True)
+class GatewayExecutionContext:
+    """Separates tenant data ownership from the Agent execution identity."""
+
+    tenant_organization: Organization
+    execution_organization: Organization
+    gateway_link: LensGatewayLink
+
+    @property
+    def gateway(self):
+        return self.gateway_link.gateway
+
+    @property
+    def is_platform(self) -> bool:
+        return self.gateway_link.scope == LensGatewayLink.GatewayScope.PLATFORM
+
+
+def workspace_identity_payload(binding: LensWorkspaceBinding) -> dict[str, object]:
+    """Return the JSON-safe immutable identity verified by the Agent."""
+
+    return {
+        "workspace_root": binding.workspace_root,
+        "workspace_uid": str(binding.workspace_uid),
+        "tenant_organization_id": binding.organization_id,
+        "gateway_link_id": binding.gateway_link_id,
+        "knowledge_source_id": binding.knowledge_source_id,
+        "workspace_kind": binding.workspace_kind,
+    }
+
+def context_for_gateway_link(
+    *,
+    tenant_organization: Organization,
+    gateway_link: LensGatewayLink,
+    expected_owner_user_id: int | None = None,
+    require_ready: bool = True,
+) -> GatewayExecutionContext:
+    """Build a trusted execution context from an already-authorized link.
+
+    Public request data must never provide an execution organization. The
+    execution identity is derived from the link and its gateway Node.
+    """
+
+    link = (
+        LensGatewayLink.objects.select_related("organization", "gateway")
+        .filter(pk=gateway_link.pk)
+        .first()
+    )
+    if link is None:
+        raise ValidationError({"gateway_link_id": "Data gateway is not available."})
+    if link.gateway.organization_id != link.organization_id:
+        raise ValidationError({"gateway_link_id": "Data gateway ownership is inconsistent."})
+
+    if link.scope == LensGatewayLink.GatewayScope.PLATFORM:
+        from apps.lens_bridge.services.platform_lens import PLATFORM_ORG_KEY
+
+        if link.organization.key != PLATFORM_ORG_KEY or link.owner_user_id is not None:
+            raise ValidationError({"gateway_link_id": "Platform gateway identity is invalid."})
+    elif link.scope == LensGatewayLink.GatewayScope.USER:
+        if link.organization_id != tenant_organization.id:
+            raise ValidationError({"gateway_link_id": "Private data gateway belongs to another organization."})
+        if link.owner_user_id is None:
+            raise ValidationError({"gateway_link_id": "Private data gateway has no owner."})
+        if expected_owner_user_id is not None and link.owner_user_id != expected_owner_user_id:
+            raise ValidationError({"gateway_link_id": "Private data gateway belongs to another user."})
+    else:
+        raise ValidationError({"gateway_link_id": "Unsupported data gateway scope."})
+
+    if require_ready:
+        gateway_readiness.require_copilot_gateway(link)
+
+    return GatewayExecutionContext(
+        tenant_organization=tenant_organization,
+        execution_organization=link.organization,
+        gateway_link=link,
+    )
+
+
+def require_user_gateway_link(
+    *,
+    tenant_organization: Organization,
+    gateway_id: int,
+    owner_user_id: int,
+    require_ready: bool = True,
+    lock: bool = False,
+) -> LensGatewayLink:
+    """Resolve one private Gateway through its organization and user owner."""
+
+    queryset = LensGatewayLink.objects.select_related("organization", "gateway")
+    if lock:
+        queryset = queryset.select_for_update()
+    link = queryset.filter(
+        organization=tenant_organization,
+        gateway_id=gateway_id,
+        scope=LensGatewayLink.GatewayScope.USER,
+        owner_user_id=owner_user_id,
+        is_deleted=False,
+    ).first()
+    if link is None:
+        raise ValidationError(
+            {"gateway_id": "Private data gateway is not owned by this user."}
+        )
+    context_for_gateway_link(
+        tenant_organization=tenant_organization,
+        gateway_link=link,
+        expected_owner_user_id=owner_user_id,
+        require_ready=require_ready,
+    )
+    return link
+
+
+def context_for_knowledge_source(
+    *,
+    tenant_organization: Organization,
+    knowledge_source,
+    require_ready: bool = True,
+):
+    if knowledge_source.organization_id != tenant_organization.id:
+        raise ValidationError(
+            {"knowledge_source": "Knowledge source belongs to another organization."}
+        )
+    if knowledge_source.gateway_link_id is None:
+        raise ValidationError({"gateway_link_id": "Knowledge source has no authoritative data gateway link."})
+    expected_owner_user_id = None
+    if knowledge_source.gateway_link.scope == LensGatewayLink.GatewayScope.USER:
+        expected_owner_user_id = knowledge_source.created_by_id
+    context = context_for_gateway_link(
+        tenant_organization=tenant_organization,
+        gateway_link=knowledge_source.gateway_link,
+        expected_owner_user_id=expected_owner_user_id,
+        require_ready=require_ready,
+    )
+    if context.gateway.id != knowledge_source.gateway_id:
+        raise ValidationError({"gateway_link_id": "Knowledge source data gateway binding is inconsistent."})
+    return context
+
+
+def create_workspace_binding(
+    *,
+    tenant_organization: Organization,
+    knowledge_source: LensKnowledgeSource,
+    require_ready: bool = True,
+) -> LensWorkspaceBinding:
+    """Create the immutable execution and filesystem identity for a new KS."""
+
+    context = context_for_knowledge_source(
+        tenant_organization=tenant_organization,
+        knowledge_source=knowledge_source,
+        require_ready=require_ready,
+    )
+    gateway_local = not (
+        knowledge_source.backup_source_snapshot_id
+        or knowledge_source.backup_snapshot_directory_id
+    )
+    kind = (
+        LensWorkspaceBinding.WorkspaceKind.GATEWAY_LOCAL
+        if gateway_local
+        else LensWorkspaceBinding.WorkspaceKind.MANAGED_RESTORE
+    )
+    root = context.gateway_link.resolved_workspace_root()
+    workspace_uid = uuid.uuid4()
+    relative_path = (
+        ""
+        if gateway_local
+        else (
+            f"tenants/{tenant_organization.id}/knowledge-sources/"
+            f"{workspace_uid}"
+        )
+    )
+    binding, created = LensWorkspaceBinding.objects.get_or_create(
+        organization=tenant_organization,
+        knowledge_source=knowledge_source,
+        defaults={
+            "gateway_link": context.gateway_link,
+            "execution_organization_id": context.execution_organization.id,
+            "execution_node_id": context.gateway.id,
+            "workspace_kind": kind,
+            "workspace_root": root,
+            "workspace_uid": workspace_uid,
+            "relative_path": relative_path,
+            "state": LensWorkspaceBinding.State.PREPARING,
+            "identity_status": (
+                LensWorkspaceBinding.IdentityStatus.NOT_APPLICABLE
+                if gateway_local
+                else LensWorkspaceBinding.IdentityStatus.PENDING
+            ),
+        },
+    )
+    if not created:
+        expected = (
+            context.gateway_link.id,
+            context.execution_organization.id,
+            context.gateway.id,
+            kind,
+            root,
+        )
+        actual = (
+            binding.gateway_link_id,
+            binding.execution_organization_id,
+            binding.execution_node_id,
+            binding.workspace_kind,
+            binding.workspace_root,
+        )
+        if actual != expected:
+            raise ValidationError({"workspace": "Knowledge source workspace authorization is inconsistent."})
+    return binding
+
+
+def context_for_workspace_binding(
+    *,
+    tenant_organization: Organization,
+    workspace_binding_id: int,
+    require_ready: bool = True,
+    allow_deleting: bool = False,
+) -> tuple[GatewayExecutionContext, LensWorkspaceBinding]:
+    """Resolve a trusted execution context from a persisted workspace binding."""
+
+    binding = (
+        LensWorkspaceBinding.objects.select_related(
+            "knowledge_source",
+            "gateway_link",
+            "gateway_link__gateway",
+            "gateway_link__organization",
+        )
+        .filter(
+            pk=workspace_binding_id,
+            organization=tenant_organization,
+            is_deleted=False,
+        )
+        .first()
+    )
+    if binding is None:
+        raise ValidationError({"workspace_binding_id": "Workspace binding is not available."})
+    if binding.workspace_kind != LensWorkspaceBinding.WorkspaceKind.MANAGED_RESTORE:
+        raise ValidationError({"workspace_binding_id": "Gateway-local directories cannot receive managed restores."})
+    allowed_states = (
+        {LensWorkspaceBinding.State.READY, LensWorkspaceBinding.State.DELETING}
+        if allow_deleting
+        else {LensWorkspaceBinding.State.READY}
+    )
+    if binding.state not in allowed_states:
+        raise ValidationError({"workspace_binding_id": "Workspace binding is not executable."})
+    if binding.identity_status != LensWorkspaceBinding.IdentityStatus.READY:
+        raise ValidationError(
+            {"workspace_binding_id": "Managed workspace identity is not verified."}
+        )
+    context = context_for_knowledge_source(
+        tenant_organization=tenant_organization,
+        knowledge_source=binding.knowledge_source,
+        require_ready=require_ready,
+    )
+    expected = (
+        context.gateway_link.id,
+        context.execution_organization.id,
+        context.gateway.id,
+        context.gateway_link.resolved_workspace_root(),
+    )
+    actual = (
+        binding.gateway_link_id,
+        binding.execution_organization_id,
+        binding.execution_node_id,
+        binding.workspace_root,
+    )
+    try:
+        binding.resolved_path()
+    except ValueError as exc:
+        raise ValidationError(
+            {"workspace_binding_id": "Workspace path is not safely contained by its root."}
+        ) from exc
+    if actual != expected or not binding.relative_path:
+        raise ValidationError({"workspace_binding_id": "Workspace execution identity is inconsistent."})
+    return context, binding

--- a/src/backend/apps/lens_bridge/services/gateway_paths.py
+++ b/src/backend/apps/lens_bridge/services/gateway_paths.py
@@ -1,0 +1,51 @@
+"""Strict POSIX path validation for Data Gateway filesystem boundaries."""
+
+from __future__ import annotations
+
+import posixpath
+
+
+class GatewayPathError(ValueError):
+    """Raised when a gateway path can escape its declared filesystem root."""
+
+
+def normalize_absolute_posix_path(path: str, *, field: str = "path") -> str:
+    """Return a canonical absolute POSIX path without ambiguous components."""
+
+    raw = str(path or "").strip()
+    if not raw:
+        raise GatewayPathError(f"{field} is required")
+    if "\x00" in raw or "\\" in raw:
+        raise GatewayPathError(f"{field} contains an unsupported character")
+    if not raw.startswith("/"):
+        raise GatewayPathError(f"{field} must be an absolute POSIX path")
+    parts = raw.split("/")
+    if any(part in {".", ".."} for part in parts):
+        raise GatewayPathError(f"{field} contains an unsafe path component")
+    normalized = posixpath.normpath(raw)
+    if not normalized.startswith("/"):
+        raise GatewayPathError(f"{field} must be an absolute POSIX path")
+    return normalized
+
+
+def path_within_root(
+    path: str,
+    root: str,
+    *,
+    allow_root: bool,
+    field: str = "path",
+) -> str:
+    """Validate and return ``path`` contained by ``root`` using components."""
+
+    normalized_root = normalize_absolute_posix_path(root, field="root")
+    normalized_path = normalize_absolute_posix_path(path, field=field)
+    try:
+        common = posixpath.commonpath((normalized_root, normalized_path))
+    except ValueError as exc:
+        raise GatewayPathError(f"{field} is outside the gateway root") from exc
+    if common != normalized_root or (
+        normalized_path == normalized_root and not allow_root
+    ):
+        relation = "at or under" if allow_root else "under"
+        raise GatewayPathError(f"{field} must be {relation} the gateway root")
+    return normalized_path

--- a/src/backend/apps/lens_bridge/services/knowledge_source_sync.py
+++ b/src/backend/apps/lens_bridge/services/knowledge_source_sync.py
@@ -10,8 +10,13 @@ from django.utils import timezone
 from rest_framework.exceptions import ValidationError
 
 from apps.iam.models import Organization
-from apps.lens_bridge.models import LensGatewayLink, LensKnowledgeSource
+from apps.lens_bridge.models import (
+    LensGatewayLink,
+    LensKnowledgeSource,
+    LensWorkspaceBinding,
+)
 from apps.lens_bridge.services import gateway_readiness, ingest_policy, provisioning
+from apps.lens_bridge.services.gateway_execution import context_for_knowledge_source
 from apps.node.models.node import Node
 from apps.node.services.internal.node_workload import get_node_workload_blockers
 from apps.protection.models import BackupSourceSnapshot, BackupSourceSnapshotDirectory
@@ -51,6 +56,12 @@ _TERMINAL_TASK_STATUSES = frozenset(
 
 class KnowledgeSourceSyncError(Exception):
     """Non-validation failure during knowledge source sync."""
+
+
+def _require_active_lifecycle(ks: LensKnowledgeSource) -> None:
+    ks.refresh_from_db(fields=["lifecycle_status"])
+    if ks.lifecycle_status != LensKnowledgeSource.LifecycleStatus.READY:
+        raise KnowledgeSourceSyncError("Knowledge source deletion was requested.")
 
 
 def is_gateway_local_ks(ks: LensKnowledgeSource) -> bool:
@@ -212,10 +223,16 @@ def request_knowledge_source_sync(
     ks: LensKnowledgeSource,
     mode: str = "resume",
 ) -> LensKnowledgeSource:
+    if ks.lifecycle_status != LensKnowledgeSource.LifecycleStatus.READY:
+        raise ValidationError({"lifecycle_status": "Knowledge source is being deleted."})
     if ks.status == LensKnowledgeSource.Status.SYNCING:
         raise ValidationError({"status": "Knowledge source sync is already in progress."})
 
-    blockers = get_node_workload_blockers(node=ks.gateway)
+    execution = context_for_knowledge_source(
+        tenant_organization=org,
+        knowledge_source=ks,
+    )
+    blockers = get_node_workload_blockers(node=execution.gateway)
     if blockers:
         raise ValidationError(
             {
@@ -231,10 +248,13 @@ def request_knowledge_source_sync(
 
     from apps.node.services.internal.node_lifecycle import _active_lifecycle_task
 
-    if _active_lifecycle_task(org=org, node=ks.gateway):
+    if _active_lifecycle_task(
+        org=execution.execution_organization,
+        node=execution.gateway,
+    ):
         raise ValidationError({"gateway": "Data gateway lifecycle operation is in progress."})
 
-    gateway_link = provisioning.get_gateway_link(org, ks.gateway_id)
+    gateway_link = execution.gateway_link
     if gateway_link.sidecar_status in {
         LensGatewayLink.SidecarStatus.UPGRADING,
         LensGatewayLink.SidecarStatus.REMOVING,
@@ -244,12 +264,14 @@ def request_knowledge_source_sync(
 
     sync_state = dict(ks.sync_state_json or {})
     if mode == "full":
+        next_generation = max(1, int(sync_state.get("restore_generation") or 0) + 1)
         sync_state = {
             "mode": "full",
             "started_at": timezone.now().isoformat(),
             "completed_phases": [],
             "phase": "prepare_workspace",
             "restore_scope_status": {},
+            "restore_generation": next_generation,
             "last_error": None,
         }
     else:
@@ -275,7 +297,13 @@ def run_knowledge_source_sync(*, organization_id: int, knowledge_source_id: int)
     from django.db import close_old_connections
 
     close_old_connections()
-    ks = LensKnowledgeSource.objects.select_related("gateway").filter(
+    ks = LensKnowledgeSource.objects.select_related(
+        "gateway",
+        "gateway_link",
+        "gateway_link__gateway",
+        "gateway_link__organization",
+        "workspace_binding",
+    ).filter(
         organization_id=organization_id,
         pk=knowledge_source_id,
     ).first()
@@ -302,6 +330,7 @@ def _run_sync_pipeline(*, org: Organization, ks: LensKnowledgeSource) -> dict[st
     sync_state = dict(ks.sync_state_json or {})
     completed = set(sync_state.get("completed_phases") or [])
 
+    _require_active_lifecycle(ks)
     if "prepare_workspace" not in completed:
         _run_phase_prepare_workspace(org=org, ks=ks, sync_state=sync_state)
         completed.add("prepare_workspace")
@@ -309,6 +338,7 @@ def _run_sync_pipeline(*, org: Organization, ks: LensKnowledgeSource) -> dict[st
         ks.sync_state_json = sync_state
         ks.save(update_fields=["sync_state_json", "updated_at"])
 
+    _require_active_lifecycle(ks)
     if should_run_restore_phase(ks=ks, sync_state=sync_state):
         _run_phase_restore_snapshot(org=org, ks=ks, sync_state=sync_state)
         completed.add("restore_snapshot")
@@ -318,6 +348,7 @@ def _run_sync_pipeline(*, org: Organization, ks: LensKnowledgeSource) -> dict[st
     ks.sync_state_json = sync_state
     ks.save(update_fields=["sync_state_json", "updated_at"])
 
+    _require_active_lifecycle(ks)
     if "push_assistant" not in completed:
         _run_phase_push_assistant(org=org, ks=ks, sync_state=sync_state)
         completed.add("push_assistant")
@@ -325,6 +356,7 @@ def _run_sync_pipeline(*, org: Organization, ks: LensKnowledgeSource) -> dict[st
         ks.sync_state_json = sync_state
         ks.save(update_fields=["sync_state_json", "updated_at"])
 
+    _require_active_lifecycle(ks)
     if "trigger_ingest" not in completed:
         _run_phase_trigger_ingest(org=org, ks=ks, sync_state=sync_state)
         completed.add("trigger_ingest")
@@ -332,6 +364,7 @@ def _run_sync_pipeline(*, org: Organization, ks: LensKnowledgeSource) -> dict[st
         ks.sync_state_json = sync_state
         ks.save(update_fields=["sync_state_json", "updated_at"])
 
+    _require_active_lifecycle(ks)
     _run_phase_finalize(org=org, ks=ks, sync_state=sync_state)
     completed.add("finalize")
 
@@ -351,17 +384,53 @@ def _run_phase_prepare_workspace(
     sync_state: dict[str, Any],
 ) -> None:
     _update_sync_phase(ks=ks, sync_state=sync_state, phase="prepare_workspace")
-    gateway = ks.gateway
-    gateway_link = provisioning.get_gateway_link(org, gateway.id)
+    execution = context_for_knowledge_source(
+        tenant_organization=org,
+        knowledge_source=ks,
+    )
+    gateway = execution.gateway
+    gateway_link = execution.gateway_link
+    try:
+        workspace_binding = ks.workspace_binding
+    except LensWorkspaceBinding.DoesNotExist as exc:
+        raise KnowledgeSourceSyncError(
+            "Knowledge source has no authoritative workspace binding."
+        ) from exc
 
     if is_gateway_local_ks(ks):
+        if workspace_binding.workspace_kind != LensWorkspaceBinding.WorkspaceKind.GATEWAY_LOCAL:
+            raise KnowledgeSourceSyncError("Gateway-local knowledge source binding is inconsistent.")
+        from apps.node.services.internal.agent_task import run_agent_task_sync
+
+        for scope in scope_entries(ks):
+            source_path = str(scope.get("source_path") or "").strip()
+            outcome = run_agent_task_sync(
+                org=execution.execution_organization,
+                node_id=gateway.id,
+                kind="lens.workspace.validate-local",
+                payload={
+                    "path": source_path,
+                    "allowed_root": gateway_link.resolved_workspace_root(),
+                },
+                correlation_type="lens_knowledge_source.validate_local",
+                correlation_id=str(ks.id),
+                requesting_organization_id=org.id,
+                wait_timeout_seconds=30,
+            )
+            if not outcome.ok:
+                detail = outcome.task.last_error or "Gateway directory validation failed."
+                raise KnowledgeSourceSyncError(detail)
         ks.workspace_path_on_lensnode = ks.source_path
         ks.mount_path_on_gateway = ks.source_path
         ks.save(update_fields=["workspace_path_on_lensnode", "mount_path_on_gateway", "updated_at"])
+        if workspace_binding.state != LensWorkspaceBinding.State.READY:
+            workspace_binding.state = LensWorkspaceBinding.State.READY
+            workspace_binding.last_error = ""
+            workspace_binding.save(update_fields=["state", "last_error", "updated_at"])
     else:
-        workspace_path = ks.workspace_path_on_lensnode or provisioning.workspace_path_for_ks(
-            org, gateway_link, ks.id
-        )
+        if workspace_binding.workspace_kind != LensWorkspaceBinding.WorkspaceKind.MANAGED_RESTORE:
+            raise KnowledgeSourceSyncError("Managed knowledge source binding is inconsistent.")
+        workspace_path = workspace_binding.resolved_path()
         ks.workspace_path_on_lensnode = workspace_path
         ks.mount_path_on_gateway = workspace_path
         ks.save(update_fields=["workspace_path_on_lensnode", "mount_path_on_gateway", "updated_at"])
@@ -369,8 +438,12 @@ def _run_phase_prepare_workspace(
             org=org,
             gateway=gateway,
             gateway_link=gateway_link,
-            workspace_path=workspace_path,
+            workspace_binding=workspace_binding,
         )
+        if workspace_binding.state != LensWorkspaceBinding.State.READY:
+            workspace_binding.state = LensWorkspaceBinding.State.READY
+            workspace_binding.last_error = ""
+            workspace_binding.save(update_fields=["state", "last_error", "updated_at"])
 
 
 def _run_phase_restore_snapshot(
@@ -380,6 +453,15 @@ def _run_phase_restore_snapshot(
     sync_state: dict[str, Any],
 ) -> None:
     _update_sync_phase(ks=ks, sync_state=sync_state, phase="restore_snapshot")
+    generation = max(1, int(sync_state.get("restore_generation") or 1))
+    previous_record_id = sync_state.get("restore_record_id")
+    if previous_record_id and _restore_record_failed(
+        record_id=int(previous_record_id),
+        organization_id=org.id,
+    ):
+        generation += 1
+        sync_state["restore_generation"] = generation
+        sync_state["restore_scope_status"] = {}
     snapshot_id = resolve_snapshot_id_for_sync(ks=ks)
     snapshot = BackupSourceSnapshot.objects.filter(
         organization_id=org.id,
@@ -428,8 +510,9 @@ def _run_phase_restore_snapshot(
         ks.save(update_fields=["sync_state_json", "updated_at"])
         return
 
-    record = restore_services.create_manual_restore_record(
+    record = restore_services.create_lens_workspace_restore_record(
         organization_id=org.id,
+        workspace_binding_id=ks.workspace_binding.id,
         data={
             "source_type": snapshot.source_type,
             "source_ref_id": snapshot.source_ref_id,
@@ -440,7 +523,9 @@ def _run_phase_restore_snapshot(
             "scope": "paths",
             "conflict_mode": "overwrite",
             "items": items,
-            "idempotency_key": f"ks-sync-{ks.id}-{snapshot_id}-{int(time.time())}",
+            "idempotency_key": (
+                f"lens-workspace:{ks.id}:generation:{generation}:snapshot:{snapshot_id}"
+            ),
         },
     )
     ks.last_restore_record_id = record.id
@@ -467,7 +552,10 @@ def _run_phase_push_assistant(
     sync_state: dict[str, Any],
 ) -> None:
     _update_sync_phase(ks=ks, sync_state=sync_state, phase="push_assistant")
-    gateway_link = provisioning.get_gateway_link(org, ks.gateway_id)
+    gateway_link = context_for_knowledge_source(
+        tenant_organization=org,
+        knowledge_source=ks,
+    ).gateway_link
     lensnode_uuid = gateway_link.sl_lensnode_uuid
     if lensnode_uuid:
         for path in indexed_dir_paths(ks):
@@ -643,13 +731,19 @@ def maybe_refresh_degraded_status(*, ks: LensKnowledgeSource) -> LensKnowledgeSo
 
 def prepare_new_knowledge_source(*, org: Organization, ks: LensKnowledgeSource) -> LensKnowledgeSource:
     """Allocate workspace paths and mark the row syncing before async pipeline starts."""
-    gateway_link = provisioning.get_gateway_link(org, ks.gateway_id)
+    from apps.lens_bridge.services.gateway_execution import create_workspace_binding
+
+    workspace_binding = create_workspace_binding(
+        tenant_organization=org,
+        knowledge_source=ks,
+    )
+    gateway_link = workspace_binding.gateway_link
     ks.sl_lensnode_uuid = gateway_link.sl_lensnode_uuid
     if is_gateway_local_ks(ks):
         ks.workspace_path_on_lensnode = ks.source_path
         ks.mount_path_on_gateway = ks.source_path
     else:
-        ks.workspace_path_on_lensnode = provisioning.workspace_path_for_ks(org, gateway_link, ks.id)
+        ks.workspace_path_on_lensnode = workspace_binding.resolved_path()
         ks.mount_path_on_gateway = ks.workspace_path_on_lensnode
 
     ks.status = LensKnowledgeSource.Status.SYNCING
@@ -660,6 +754,7 @@ def prepare_new_knowledge_source(*, org: Organization, ks: LensKnowledgeSource) 
         "started_at": timezone.now().isoformat(),
         "completed_phases": [],
         "restore_scope_status": {},
+        "restore_generation": 1,
         "last_error": None,
     }
     ks.save(

--- a/src/backend/apps/lens_bridge/services/knowledge_source_teardown.py
+++ b/src/backend/apps/lens_bridge/services/knowledge_source_teardown.py
@@ -1,0 +1,352 @@
+"""Durable asynchronous teardown for HFL Knowledge Sources."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import timedelta
+from typing import Any
+
+from django.db import transaction
+from django.utils import timezone
+from rest_framework.exceptions import ValidationError
+
+from apps.lens_bridge.models import (
+    LensKnowledgeSource,
+    LensSessionLink,
+    LensWorkspaceBinding,
+)
+from apps.lens_bridge.services import assistant_access
+from apps.lens_bridge.services.teardown_claims import (
+    TEARDOWN_CLAIM_TTL_SECONDS,
+    next_retry_at,
+)
+
+
+class KnowledgeSourceTeardownIncompleteError(RuntimeError):
+    """Raised after durable failure state is stored for Celery retry."""
+
+
+class KnowledgeSourceTeardownBusyError(RuntimeError):
+    """Raised when another worker owns the Knowledge Source lease."""
+
+
+def _claimed_update(
+    knowledge_source_id: int,
+    claim_token: str,
+    **values: Any,
+) -> None:
+    """Persist state only while this worker still owns the lease."""
+
+    values["updated_at"] = timezone.now()
+    updated = LensKnowledgeSource.all_objects.filter(
+        pk=knowledge_source_id,
+        teardown_claim_token=claim_token,
+        lifecycle_status=LensKnowledgeSource.LifecycleStatus.DELETING,
+    ).update(**values)
+    if updated != 1:
+        raise KnowledgeSourceTeardownBusyError(
+            "Knowledge Source teardown lease was lost."
+        )
+
+
+def _queue_teardown(knowledge_source_id: int) -> None:
+    from apps.lens_bridge.services.sync_queue import queue_knowledge_source_teardown
+
+    try:
+        queue_knowledge_source_teardown(knowledge_source_id=knowledge_source_id)
+    except Exception as exc:
+        LensKnowledgeSource.all_objects.filter(pk=knowledge_source_id).update(
+            status_detail=(
+                "Deletion is waiting for the worker queue: " + str(exc)
+            )[:300],
+            updated_at=timezone.now(),
+        )
+
+
+@transaction.atomic
+def request_knowledge_source_teardown(
+    knowledge_source: LensKnowledgeSource,
+) -> LensKnowledgeSource:
+    """Persist deletion intent and enqueue it after the transaction commits."""
+
+    locked = LensKnowledgeSource.objects.select_for_update().get(pk=knowledge_source.pk)
+    if locked.session_links.exclude(
+        lifecycle_status=LensSessionLink.LifecycleStatus.DELETED
+    ).exists():
+        raise ValidationError(
+            {"knowledge_source": "Delete the owning Chat before deleting this knowledge source."}
+        )
+    if locked.lifecycle_status == LensKnowledgeSource.LifecycleStatus.DELETED:
+        return locked
+    locked.lifecycle_status = LensKnowledgeSource.LifecycleStatus.DELETING
+    locked.status_detail = "Knowledge source deletion is queued."
+    locked.save(update_fields=["lifecycle_status", "status_detail", "updated_at"])
+    transaction.on_commit(lambda: _queue_teardown(locked.id))
+    return locked
+
+
+def _claim(knowledge_source_id: int) -> tuple[str | None, str]:
+    now = timezone.now()
+    with transaction.atomic():
+        knowledge_source = (
+            LensKnowledgeSource.all_objects.select_for_update()
+            .filter(pk=knowledge_source_id)
+            .first()
+        )
+        if knowledge_source is None:
+            return None, "missing"
+        if knowledge_source.lifecycle_status == LensKnowledgeSource.LifecycleStatus.DELETED:
+            return None, "deleted"
+        if (
+            knowledge_source.teardown_claimed_at
+            and knowledge_source.teardown_claimed_at
+            > now - timedelta(seconds=TEARDOWN_CLAIM_TTL_SECONDS)
+        ):
+            return None, "busy"
+        if (
+            knowledge_source.teardown_next_retry_at
+            and knowledge_source.teardown_next_retry_at > now
+        ):
+            return None, "scheduled"
+        token = uuid.uuid4()
+        knowledge_source.lifecycle_status = LensKnowledgeSource.LifecycleStatus.DELETING
+        knowledge_source.teardown_attempts += 1
+        knowledge_source.teardown_claim_token = token
+        knowledge_source.teardown_claimed_at = now
+        knowledge_source.teardown_next_retry_at = next_retry_at(
+            knowledge_source.teardown_attempts
+        )
+        knowledge_source.save(
+            update_fields=[
+                "lifecycle_status",
+                "teardown_attempts",
+                "teardown_claim_token",
+                "teardown_claimed_at",
+                "teardown_next_retry_at",
+                "updated_at",
+            ]
+        )
+    return str(token), "claimed"
+
+
+def _renew(knowledge_source_id: int, claim_token: str) -> None:
+    _claimed_update(
+        knowledge_source_id,
+        claim_token,
+        teardown_claimed_at=timezone.now(),
+    )
+
+
+def _save_step(
+    knowledge_source_id: int,
+    claim_token: str,
+    state: dict[str, Any],
+    step: str,
+    *,
+    status: str,
+    error: str = "",
+) -> None:
+    state[step] = {
+        "status": status,
+        "error": error[:1000],
+        "updated_at": timezone.now().isoformat(),
+    }
+    _claimed_update(
+        knowledge_source_id,
+        claim_token,
+        teardown_state_json=state,
+    )
+
+
+def cleanup_knowledge_source_workspace(
+    knowledge_source: LensKnowledgeSource,
+    *,
+    claim_token: str,
+) -> None:
+    """Identity-check managed data cleanup; detach gateway-local directories."""
+
+    sync_state = dict(knowledge_source.sync_state_json or {})
+    sync_state["teardown_requested_at"] = timezone.now().isoformat()
+    try:
+        workspace_binding = knowledge_source.workspace_binding
+    except LensWorkspaceBinding.DoesNotExist as exc:
+        raise ValidationError(
+            {"workspace": "Knowledge source has no workspace binding."}
+        ) from exc
+    sync_state["teardown_workspace_path"] = workspace_binding.resolved_path()
+    if workspace_binding.workspace_kind == LensWorkspaceBinding.WorkspaceKind.MANAGED_RESTORE:
+        from apps.lens_bridge.services.gateway_execution import (
+            context_for_workspace_binding,
+            workspace_identity_payload,
+        )
+        from apps.node.services.internal.agent_task import run_agent_task_sync
+
+        if workspace_binding.state == LensWorkspaceBinding.State.DELETED:
+            return
+        workspace_binding.state = LensWorkspaceBinding.State.DELETING
+        workspace_binding.last_error = ""
+        workspace_binding.save(update_fields=["state", "last_error", "updated_at"])
+        execution, workspace_binding = context_for_workspace_binding(
+            tenant_organization=knowledge_source.organization,
+            workspace_binding_id=workspace_binding.id,
+            require_ready=False,
+            allow_deleting=True,
+        )
+        _renew(knowledge_source.id, claim_token)
+        outcome = run_agent_task_sync(
+            org=execution.execution_organization,
+            node_id=execution.gateway.id,
+            kind="lens.ks.cleanup",
+            payload={
+                "path": workspace_binding.resolved_path(),
+                **workspace_identity_payload(workspace_binding),
+            },
+            correlation_type="lens_knowledge_source.cleanup",
+            correlation_id=str(knowledge_source.id),
+            requesting_organization_id=knowledge_source.organization_id,
+            wait_timeout_seconds=300,
+        )
+        _renew(knowledge_source.id, claim_token)
+        sync_state["teardown_node_task_id"] = str(outcome.task.id)
+        _claimed_update(
+            knowledge_source.id,
+            claim_token,
+            sync_state_json=sync_state,
+        )
+        if not outcome.ok:
+            detail = outcome.task.last_error or (
+                "Workspace cleanup timed out."
+                if outcome.timed_out
+                else "Workspace cleanup failed."
+            )
+            workspace_binding.last_error = detail
+            workspace_binding.save(update_fields=["last_error", "updated_at"])
+            raise ValidationError({"workspace": detail})
+    workspace_binding.state = LensWorkspaceBinding.State.DELETED
+    workspace_binding.last_error = ""
+    workspace_binding.save(update_fields=["state", "last_error", "updated_at"])
+    _claimed_update(
+        knowledge_source.id,
+        claim_token,
+        sync_state_json=sync_state,
+    )
+
+
+def run_knowledge_source_teardown(
+    *,
+    knowledge_source_id: int,
+    owner_session_link_id: int | None = None,
+) -> dict[str, Any]:
+    """Execute idempotent Assistant-before-Workspace teardown under a lease."""
+
+    claim_token, claim_status = _claim(knowledge_source_id)
+    if claim_token is None:
+        return {"knowledge_source_id": knowledge_source_id, "status": claim_status}
+    knowledge_source = (
+        LensKnowledgeSource.all_objects.select_related(
+            "organization", "workspace_binding", "gateway", "gateway_link"
+        )
+        .filter(pk=knowledge_source_id)
+        .first()
+    )
+    if knowledge_source is None:
+        return {"knowledge_source_id": knowledge_source_id, "status": "missing"}
+    state = dict(knowledge_source.teardown_state_json or {})
+    try:
+        from apps.node.services.internal.node_workload import (
+            get_node_workload_blockers,
+        )
+
+        if get_node_workload_blockers(node=knowledge_source.gateway):
+            raise ValidationError(
+                {"knowledge_source": "Data gateway restore work is still stopping."}
+            )
+        blockers = knowledge_source.session_links.exclude(
+            lifecycle_status=LensSessionLink.LifecycleStatus.DELETED
+        )
+        if owner_session_link_id is not None:
+            blockers = blockers.exclude(pk=owner_session_link_id)
+        if blockers.exists():
+            raise ValidationError(
+                {"knowledge_source": "Knowledge source still belongs to an active Chat."}
+            )
+
+        from apps.lens_bridge.services.assistants import _delete_sl_assistant
+
+        assistant_uuids = {
+            link.sl_assistant_uuid
+            for link in knowledge_source.assistant_links.filter(is_deleted=False).only(
+                "sl_assistant_uuid"
+            )
+        }
+        if knowledge_source.sl_assistant_uuid:
+            assistant_uuids.add(knowledge_source.sl_assistant_uuid)
+        for assistant_uuid in sorted(assistant_uuids, key=str):
+            _renew(knowledge_source.id, claim_token)
+            _delete_sl_assistant(assistant_uuid)
+            assistant_access.soft_delete_assistant_link(
+                knowledge_source.organization, assistant_uuid
+            )
+        _claimed_update(
+            knowledge_source.id,
+            claim_token,
+            sl_assistant_uuid=None,
+        )
+        _save_step(
+            knowledge_source.id,
+            claim_token,
+            state,
+            "delete_assistants",
+            status="success",
+        )
+
+        cleanup_knowledge_source_workspace(
+            knowledge_source,
+            claim_token=claim_token,
+        )
+        _save_step(
+            knowledge_source.id,
+            claim_token,
+            state,
+            "cleanup_workspace",
+            status="success",
+        )
+        now = timezone.now()
+        updated = LensKnowledgeSource.all_objects.filter(
+            pk=knowledge_source.id,
+            teardown_claim_token=claim_token,
+        ).update(
+            lifecycle_status=LensKnowledgeSource.LifecycleStatus.DELETED,
+            is_deleted=True,
+            deleted_at=now,
+            status_detail="Knowledge source resources deleted.",
+            teardown_claim_token=None,
+            teardown_claimed_at=None,
+            teardown_next_retry_at=None,
+            teardown_state_json=state,
+            updated_at=now,
+        )
+        if updated != 1:
+            raise KnowledgeSourceTeardownBusyError(
+                "Knowledge Source teardown lease was lost."
+            )
+        return {"knowledge_source_id": knowledge_source.id, "status": "deleted"}
+    except Exception as exc:
+        _save_step(
+            knowledge_source.id,
+            claim_token,
+            state,
+            "failure",
+            status="retry",
+            error=str(exc),
+        )
+        LensKnowledgeSource.all_objects.filter(
+            pk=knowledge_source.id,
+            teardown_claim_token=claim_token,
+        ).update(
+            status_detail="Knowledge source cleanup is incomplete and will be retried.",
+            teardown_claim_token=None,
+            teardown_claimed_at=None,
+            updated_at=timezone.now(),
+        )
+        raise KnowledgeSourceTeardownIncompleteError(str(exc)) from exc

--- a/src/backend/apps/lens_bridge/services/platform_lens.py
+++ b/src/backend/apps/lens_bridge/services/platform_lens.py
@@ -8,7 +8,6 @@ from apps.iam.models import Organization
 from apps.lens_bridge.models import LensGatewayLink
 from apps.lens_bridge.services.gateway_readiness import (
     gateway_runtime_state,
-    require_copilot_gateway,
     require_hfl_usable_gateway,
 )
 
@@ -27,11 +26,14 @@ def get_or_create_platform_org() -> Organization:
     return org
 
 
-def user_gateway_links(*, user):
-    return LensGatewayLink.objects.filter(
+def user_gateway_links(*, user, organization: Organization | None = None):
+    links = LensGatewayLink.objects.filter(
         owner_user=user,
         scope=LensGatewayLink.GatewayScope.USER,
     ).select_related("gateway")
+    if organization is not None:
+        links = links.filter(organization=organization)
+    return links
 
 
 def platform_gateway_links():
@@ -97,13 +99,18 @@ def resolve_gateway_link_for_copilot(
         )
         if link is None:
             link = (
-                user_gateway_links(user=user)
+                user_gateway_links(user=user, organization=org)
                 .filter(pk=gateway_link_id, sl_lensnode_uuid__isnull=False)
                 .first()
             )
         if link is None:
             raise ValidationError({"gateway_link_id": "Data gateway is not available."})
-        require_copilot_gateway(link)
+        from apps.lens_bridge.services.gateway_execution import context_for_gateway_link
+
+        context_for_gateway_link(
+            tenant_organization=org,
+            gateway_link=link,
+        )
         return link
 
     platform_default = resolve_auto_gateway_link_for_copilot(user=user)
@@ -118,6 +125,7 @@ def resolve_gateway_link_for_copilot(
 @transaction.atomic
 def set_platform_default_gateway(*, gateway_link_id: int) -> LensGatewayLink:
     org = get_or_create_platform_org()
+    Organization.objects.select_for_update().get(pk=org.pk)
     link = LensGatewayLink.objects.select_for_update().get(
         pk=gateway_link_id,
         organization=org,

--- a/src/backend/apps/lens_bridge/services/provisioning.py
+++ b/src/backend/apps/lens_bridge/services/provisioning.py
@@ -6,13 +6,21 @@ import logging
 import re
 import time
 import uuid
+from datetime import timedelta
 from typing import Any
 
+from django.db import IntegrityError, transaction
+from django.utils import timezone
 from django.utils.text import slugify
 from rest_framework.exceptions import ValidationError
 
 from apps.iam.models import Organization
-from apps.lens_bridge.models import LensGatewayLink, LensKnowledgeSource, LensOrgLink
+from apps.lens_bridge.models import (
+    LensGatewayLink,
+    LensKnowledgeSource,
+    LensOrgLink,
+    LensWorkspaceBinding,
+)
 from apps.lens_bridge.services import ingest_policy, org_models, sl_client
 from apps.node.models.base import NodeRole
 from apps.node.models.node import Node
@@ -21,6 +29,15 @@ logger = logging.getLogger(__name__)
 
 _LENSNODE_DIR_WAIT_SECONDS = 30.0
 _LENSNODE_DIR_POLL_SECONDS = 0.5
+LENSNODE_PROVISION_CLAIM_TTL_SECONDS = 300
+
+
+class LensNodeProvisionBusyError(sl_client.LensBridgeError):
+    """Raised when another caller owns the durable provisioning lease."""
+
+    status_code = 409
+    default_detail = "LensNode provisioning is already in progress."
+    default_code = "lensnode_provision_busy"
 
 
 def get_or_create_org_link(org: Organization) -> LensOrgLink:
@@ -35,6 +52,22 @@ def _slugify_assistant(name: str, org: Organization) -> str:
     slug = f"{prefix}-{base}"[:160]
     slug = re.sub(r"[^a-z0-9-]", "-", slug.lower())
     return slug.strip("-") or f"{prefix}-source"
+
+
+def assistant_slug_for_ks(*, org: Organization, ks: LensKnowledgeSource) -> str:
+    """Return a deterministic, collision-resistant slug for one HFL KS."""
+    suffix = f"-ks-{ks.id}"
+    max_prefix_length = max(1, 160 - len(suffix) - 2)
+    org_prefix = (
+        get_or_create_org_link(org)
+        .resolved_prefix()[:max_prefix_length]
+        .strip("-")
+        or "org"
+    )
+    max_base_length = max(1, 160 - len(org_prefix) - len(suffix) - 1)
+    base = (slugify(ks.name) or "source")[:max_base_length]
+    base = re.sub(r"[^a-z0-9-]", "-", base.lower()).strip("-") or "source"
+    return f"{org_prefix}-{base}{suffix}"
 
 
 def default_model_ref_for_org(org: Organization) -> str | None:
@@ -83,9 +116,11 @@ def default_model_ref_for_org(org: Organization) -> str | None:
 
 
 def get_gateway_link(org: Organization, gateway_id: int) -> LensGatewayLink:
-    """Resolve gateway link for tenant org, falling back to platform-scoped DG."""
-    from apps.lens_bridge.services import platform_lens
+    """Resolve an existing gateway link owned by ``org``.
 
+    Platform gateway access is intentionally handled by the Copilot gateway
+    execution service; tenant-facing APIs must never fall back across orgs.
+    """
     existing = (
         LensGatewayLink.objects.filter(organization=org, gateway_id=gateway_id)
         .select_related("gateway")
@@ -93,32 +128,10 @@ def get_gateway_link(org: Organization, gateway_id: int) -> LensGatewayLink:
     )
     if existing is not None:
         return existing
-
-    platform_org = platform_lens.get_or_create_platform_org()
-    platform_link = (
-        LensGatewayLink.objects.filter(
-            organization=platform_org,
-            gateway_id=gateway_id,
-            scope=LensGatewayLink.GatewayScope.PLATFORM,
-        )
-        .select_related("gateway")
-        .first()
-    )
-    if platform_link is not None:
-        return platform_link
-
-    gateway = require_gateway_node(org, gateway_id)
-    link, _ = LensGatewayLink.objects.get_or_create(
-        organization=org,
-        gateway=gateway,
-        defaults={"workspace_root": f"/workspace/org-{org.id}"},
-    )
-    return link
+    raise ValidationError({"gateway_id": "Data gateway link not found."})
 
 
 def require_gateway_node(org: Organization, gateway_id: int) -> Node:
-    from apps.lens_bridge.services import platform_lens
-
     node = Node.objects.filter(
         organization=org,
         id=gateway_id,
@@ -127,23 +140,7 @@ def require_gateway_node(org: Organization, gateway_id: int) -> Node:
     ).first()
     if node is not None:
         return node
-
-    platform_org = platform_lens.get_or_create_platform_org()
-    node = Node.objects.filter(
-        organization=platform_org,
-        id=gateway_id,
-        role=NodeRole.GATEWAY,
-        is_deleted=False,
-    ).first()
-    if node is not None:
-        return node
-
     raise ValidationError({"gateway_id": "Data gateway not found."})
-
-
-def workspace_path_for_ks(org: Organization, gateway_link: LensGatewayLink, ks_id: int) -> str:
-    root = gateway_link.resolved_workspace_root()
-    return f"{root}/ks-{ks_id}"
 
 
 def _lensnode_dir_paths(lensnode_data: dict[str, Any]) -> set[str]:
@@ -192,7 +189,7 @@ def ensure_ks_workspace_on_gateway(
     org: Organization,
     gateway: Node,
     gateway_link: LensGatewayLink,
-    workspace_path: str,
+    workspace_binding: LensWorkspaceBinding,
 ) -> None:
     """Create the KS workspace directory on the gateway host and wait for LensNode."""
 
@@ -202,18 +199,52 @@ def ensure_ks_workspace_on_gateway(
     if not lensnode_uuid:
         raise ValidationError({"gateway_id": "LensNode is not linked to this gateway."})
 
+    from apps.lens_bridge.services.gateway_execution import (
+        context_for_gateway_link,
+        workspace_identity_payload,
+    )
+
+    context = context_for_gateway_link(
+        tenant_organization=org,
+        gateway_link=gateway_link,
+    )
+    if context.gateway.id != gateway.id:
+        raise ValidationError({"gateway_id": "Data gateway link does not match the execution node."})
     root = gateway_link.resolved_workspace_root()
+    workspace_path = workspace_binding.resolved_path()
+    if (
+        workspace_binding.gateway_link_id != gateway_link.id
+        or workspace_binding.execution_node_id != gateway.id
+        or workspace_binding.execution_organization_id != context.execution_organization.id
+        or workspace_binding.workspace_root != root
+    ):
+        raise ValidationError({"workspace": "Workspace execution binding is inconsistent."})
     outcome = run_agent_task_sync(
-        org=org,
+        org=context.execution_organization,
         node_id=gateway.id,
         kind="lens.ks.prepare",
-        payload={"path": workspace_path, "workspace_root": root},
+        payload={
+            "path": workspace_path,
+            **workspace_identity_payload(workspace_binding),
+        },
         correlation_type="lens_knowledge_source",
+        requesting_organization_id=org.id,
         wait_timeout_seconds=60,
     )
     if not outcome.ok:
         detail = outcome.task.last_error or "Failed to prepare knowledge source workspace on gateway."
+        workspace_binding.identity_status = LensWorkspaceBinding.IdentityStatus.ERROR
+        workspace_binding.last_error = detail
+        workspace_binding.save(
+            update_fields=["identity_status", "last_error", "updated_at"]
+        )
         raise ValidationError({"gateway": detail})
+
+    workspace_binding.identity_status = LensWorkspaceBinding.IdentityStatus.READY
+    workspace_binding.last_error = ""
+    workspace_binding.save(
+        update_fields=["identity_status", "last_error", "updated_at"]
+    )
 
     wait_for_lensnode_dir(lensnode_uuid=lensnode_uuid, path=workspace_path)
 
@@ -306,7 +337,9 @@ def create_sl_assistant_for_ks(
     ks: LensKnowledgeSource,
     gateway_link: LensGatewayLink,
     model_ref: str | uuid.UUID | None = None,
+    slug: str | None = None,
 ) -> uuid.UUID:
+    """Create the remote Assistant without mutating HFL ownership state."""
     lensnode_uuid = gateway_link.sl_lensnode_uuid
     if not lensnode_uuid:
         raise ValidationError({"gateway_id": "LensNode is not linked to this gateway."})
@@ -317,22 +350,19 @@ def create_sl_assistant_for_ks(
             {"model": "Set a default AI model in Insights → AI Models before creating knowledge sources."}
         )
 
-    workspace_path = ks.workspace_path_on_lensnode or workspace_path_for_ks(
-        org, gateway_link, ks.id
-    )
+    workspace_path = (ks.workspace_path_on_lensnode or "").strip()
+    if not workspace_path:
+        raise ValidationError({"workspace": "Knowledge source workspace is not prepared."})
     selected_task = pick_lensnode_task(lensnode_uuid)
-    slug = _slugify_assistant(ks.name, org)
+    resolved_slug = (slug or "").strip() or _slugify_assistant(ks.name, org)
 
     selected_dirs = indexed_dirs_for_ks(ks)
     if not selected_dirs:
-        workspace_path = ks.workspace_path_on_lensnode or workspace_path_for_ks(
-            org, gateway_link, ks.id
-        )
         selected_dirs = [{"path": workspace_path}]
 
     payload: dict[str, Any] = {
         "name": ks.name,
-        "slug": slug,
+        "slug": resolved_slug,
         "lensnode_uuid": str(lensnode_uuid),
         "selected_task": selected_task,
         "selected_dirs": selected_dirs,
@@ -351,16 +381,7 @@ def create_sl_assistant_for_ks(
     assistant_uuid = data.get("uuid")
     if not assistant_uuid:
         raise sl_client.LensBridgeError("SourceLens assistant create returned no uuid.")
-    assistant_uuid_obj = uuid.UUID(str(assistant_uuid))
-    from apps.lens_bridge.services import assistant_access
-
-    assistant_access.ensure_assistant_link(
-        org=org,
-        sl_assistant_uuid=assistant_uuid_obj,
-        knowledge_source=ks,
-        created_by=ks.created_by,
-    )
-    return assistant_uuid_obj
+    return uuid.UUID(str(assistant_uuid))
 
 
 def sync_assistant_agent_model(
@@ -435,6 +456,354 @@ def refresh_ks_status_from_sl(ks: LensKnowledgeSource) -> LensKnowledgeSource:
     return ks
 
 
+def _lensnode_lookup_name(
+    *,
+    link: LensGatewayLink,
+    gateway: Node,
+    requested_name: str | None,
+) -> str:
+    """Return a stable remote identity unique to one HFL Gateway link."""
+
+    suffix = f"-hfl-gateway-link-{link.id}"
+    max_base_length = max(1, 160 - len(suffix))
+    base = slugify(requested_name or gateway.name or "gateway")
+    base = (base or "gateway")[:max_base_length].strip("-") or "gateway"
+    return f"{base}{suffix}"
+
+
+def _source_lens_lensnodes() -> list[dict[str, Any]]:
+    """Return all SourceLens LensNodes through bounded pagination."""
+
+    rows: list[dict[str, Any]] = []
+    seen_pages: set[tuple[str, ...]] = set()
+    page_size = 100
+    for page in range(1, 1001):
+        raw = sl_client.request_json(
+            "GET",
+            "/api/lens/admin/lensnodes/",
+            params={"page": page, "page_size": page_size},
+        )
+        if isinstance(raw, list):
+            items = raw
+        elif isinstance(raw, dict):
+            items = raw.get("results", raw.get("items", []))
+        else:
+            items = []
+        page_rows = [item for item in items if isinstance(item, dict)]
+        rows.extend(page_rows)
+        if isinstance(raw, list) or not page_rows or len(page_rows) < page_size:
+            return rows
+        signature = tuple(
+            str(item.get("uuid") or item.get("name") or "")
+            for item in page_rows
+        )
+        if signature in seen_pages:
+            raise sl_client.LensBridgeError(
+                "SourceLens pagination did not advance while finding a LensNode."
+            )
+        seen_pages.add(signature)
+    raise sl_client.LensBridgeError(
+        "SourceLens pagination limit reached while finding a LensNode."
+    )
+
+
+def _find_source_lens_lensnode(*, lookup_name: str) -> dict[str, Any] | None:
+    matches = [
+        row
+        for row in _source_lens_lensnodes()
+        if str(row.get("name") or "").strip() == lookup_name
+    ]
+    if len(matches) > 1:
+        raise sl_client.LensBridgeError(
+            f"SourceLens returned multiple LensNodes named {lookup_name!r}."
+        )
+    return matches[0] if matches else None
+
+
+@transaction.atomic
+def _claim_lensnode_provision(
+    *,
+    link_id: int,
+    gateway: Node,
+    requested_name: str | None,
+) -> tuple[LensGatewayLink, str, str]:
+    """Persist remote-create intent and acquire the provisioning lease."""
+
+    link = LensGatewayLink.objects.select_for_update().get(pk=link_id)
+    if link.sl_lensnode_uuid:
+        return link, "", "ready"
+    now = timezone.now()
+    if (
+        link.lensnode_provision_claim_token
+        and link.lensnode_provision_claimed_at
+        and link.lensnode_provision_claimed_at
+        > now - timedelta(seconds=LENSNODE_PROVISION_CLAIM_TTL_SECONDS)
+    ):
+        return link, "", "busy"
+
+    state = dict(link.lensnode_provision_state_json or {})
+    lookup_name = str(state.get("lookup_name") or "").strip()
+    if not lookup_name:
+        lookup_name = _lensnode_lookup_name(
+            link=link,
+            gateway=gateway,
+            requested_name=requested_name,
+        )
+    claim_token = uuid.uuid4()
+    state.update(
+        {
+            "lookup_name": lookup_name,
+            "status": "provisioning",
+            "last_error": "",
+            "updated_at": now.isoformat(),
+        }
+    )
+    link.lensnode_provision_state_json = state
+    link.lensnode_provision_attempts += 1
+    link.lensnode_provision_claim_token = claim_token
+    link.lensnode_provision_claimed_at = now
+    link.save(
+        update_fields=[
+            "lensnode_provision_state_json",
+            "lensnode_provision_attempts",
+            "lensnode_provision_claim_token",
+            "lensnode_provision_claimed_at",
+            "updated_at",
+        ]
+    )
+    return link, str(claim_token), "claimed"
+
+
+@transaction.atomic
+def _complete_lensnode_provision(
+    *,
+    link_id: int,
+    claim_token: str,
+    lensnode_uuid: uuid.UUID,
+    token: str,
+) -> LensGatewayLink:
+    """Commit recovered credentials only while the caller owns the lease."""
+
+    link = (
+        LensGatewayLink.objects.select_for_update()
+        .filter(
+            pk=link_id,
+            lensnode_provision_claim_token=claim_token,
+            sl_lensnode_uuid__isnull=True,
+        )
+        .first()
+    )
+    if link is None:
+        raise LensNodeProvisionBusyError(
+            "LensNode provisioning lease was lost before completion."
+        )
+    config = dict(link.config_json or {})
+    config["lensnode_token_issued"] = True
+    config["lensnode_token"] = token
+    state = dict(link.lensnode_provision_state_json or {})
+    state.update(
+        {
+            "remote_uuid": str(lensnode_uuid),
+            "status": "ready",
+            "last_error": "",
+            "updated_at": timezone.now().isoformat(),
+        }
+    )
+    link.sl_lensnode_uuid = lensnode_uuid
+    link.sidecar_status = LensGatewayLink.SidecarStatus.OFFLINE
+    link.config_json = config
+    link.lensnode_provision_state_json = state
+    link.lensnode_provision_claim_token = None
+    link.lensnode_provision_claimed_at = None
+    link.save(
+        update_fields=[
+            "sl_lensnode_uuid",
+            "sidecar_status",
+            "config_json",
+            "lensnode_provision_state_json",
+            "lensnode_provision_claim_token",
+            "lensnode_provision_claimed_at",
+            "updated_at",
+        ]
+    )
+    return link
+
+
+def _record_lensnode_provision_failure(
+    *,
+    link_id: int,
+    claim_token: str,
+    error: Exception,
+) -> None:
+    """Retain a failed lease until expiry to avoid timeout duplication."""
+
+    with transaction.atomic():
+        link = (
+            LensGatewayLink.objects.select_for_update()
+            .filter(pk=link_id, lensnode_provision_claim_token=claim_token)
+            .first()
+        )
+        if link is None:
+            return
+        state = dict(link.lensnode_provision_state_json or {})
+        state.update(
+            {
+                "status": "error",
+                "last_error": str(error)[:1000],
+                "updated_at": timezone.now().isoformat(),
+            }
+        )
+        link.lensnode_provision_state_json = state
+        link.save(
+            update_fields=["lensnode_provision_state_json", "updated_at"]
+        )
+
+
+def _provision_source_lens_lensnode(
+    *,
+    link: LensGatewayLink,
+    gateway: Node,
+    requested_name: str | None,
+) -> LensGatewayLink:
+    """Create or recover one SourceLens LensNode under a durable lease."""
+
+    claimed_link, claim_token, claim_status = _claim_lensnode_provision(
+        link_id=link.id,
+        gateway=gateway,
+        requested_name=requested_name,
+    )
+    if claim_status == "ready":
+        return claimed_link
+    if claim_status == "busy":
+        raise LensNodeProvisionBusyError()
+
+    state = dict(claimed_link.lensnode_provision_state_json or {})
+    lookup_name = str(state["lookup_name"])
+    try:
+        remote = _find_source_lens_lensnode(lookup_name=lookup_name)
+        if remote is None:
+            remote = sl_client.request_json(
+                "POST",
+                "/api/lens/admin/lensnodes/",
+                json_body={"name": lookup_name},
+            )
+            token = str(remote.get("token") or "")
+        else:
+            remote_uuid = remote.get("uuid")
+            if not remote_uuid:
+                raise sl_client.LensBridgeError(
+                    "Recovered SourceLens LensNode has no uuid."
+                )
+            if (
+                LensGatewayLink.objects.exclude(pk=link.id)
+                .filter(sl_lensnode_uuid=remote_uuid)
+                .exists()
+            ):
+                raise sl_client.LensBridgeError(
+                    "Recovered SourceLens LensNode is already bound to another "
+                    "HFL data gateway."
+                )
+            issued = sl_client.request_json(
+                "POST",
+                f"/api/lens/admin/lensnodes/{remote_uuid}/issue-token/",
+            )
+            token = str(issued.get("token") or "")
+        remote_uuid = remote.get("uuid")
+        if not remote_uuid or not token:
+            raise sl_client.LensBridgeError(
+                "SourceLens LensNode provisioning returned incomplete credentials."
+            )
+        return _complete_lensnode_provision(
+            link_id=link.id,
+            claim_token=claim_token,
+            lensnode_uuid=uuid.UUID(str(remote_uuid)),
+            token=token,
+        )
+    except Exception as exc:
+        _record_lensnode_provision_failure(
+            link_id=link.id,
+            claim_token=claim_token,
+            error=exc,
+        )
+        raise
+
+
+@transaction.atomic
+def _resolve_gateway_link_identity(
+    *,
+    org: Organization,
+    gateway: Node,
+    owner_user,
+    normalized_scope: str | None,
+) -> LensGatewayLink:
+    """Create or verify an immutable Gateway identity under a row lock."""
+
+    existing = (
+        LensGatewayLink.objects.select_for_update()
+        .filter(organization=org, gateway=gateway)
+        .first()
+    )
+    desired_scope = (
+        existing.scope
+        if existing is not None and normalized_scope is None
+        else normalized_scope or LensGatewayLink.GatewayScope.USER
+    )
+    if (
+        desired_scope == LensGatewayLink.GatewayScope.USER
+        and owner_user is None
+        and existing is None
+    ):
+        raise ValidationError(
+            {"owner_user": "Private data gateway requires an owner."}
+        )
+    desired_origin = (
+        existing.origin
+        if existing is not None and normalized_scope is None
+        else (
+            LensGatewayLink.Origin.PLATFORM
+            if desired_scope == LensGatewayLink.GatewayScope.PLATFORM
+            else LensGatewayLink.Origin.USER
+        )
+    )
+    is_platform = desired_scope == LensGatewayLink.GatewayScope.PLATFORM
+    if existing is None:
+        link, created = LensGatewayLink.objects.get_or_create(
+            organization=org,
+            gateway=gateway,
+            defaults={
+                "workspace_root": f"/workspace/org-{org.id}/data",
+                "owner_user": None if is_platform else owner_user,
+                "scope": desired_scope,
+                "origin": desired_origin,
+            },
+        )
+        if created:
+            return link
+        existing = LensGatewayLink.objects.select_for_update().get(pk=link.pk)
+
+    link = existing
+    requested_owner_id = getattr(owner_user, "id", None)
+    if (
+        not is_platform
+        and link.scope == desired_scope
+        and requested_owner_id is not None
+        and link.owner_user_id != requested_owner_id
+    ):
+        raise ValidationError(
+            {"owner_user": "Private data gateway belongs to another user."}
+        )
+    if link.scope != desired_scope:
+        raise ValidationError(
+            {
+                "scope": (
+                    "Data gateway scope is immutable after registration. "
+                    "Uninstall and register the data gateway again to change it."
+                )
+            }
+        )
+    return link
+
+
 def ensure_lensnode_for_gateway(
     *,
     org: Organization,
@@ -446,6 +815,10 @@ def ensure_lensnode_for_gateway(
     """Idempotently associate a SourceLens LensNode with an HFL data gateway."""
     if gateway.role != NodeRole.GATEWAY:
         raise ValidationError({"gateway_id": "Node is not a data gateway."})
+    if gateway.organization_id != org.id:
+        raise ValidationError(
+            {"gateway_id": "Data gateway belongs to another organization."}
+        )
 
     from apps.node.services.internal.local_platform_gateway import (
         is_local_platform_gateway_metadata,
@@ -461,83 +834,51 @@ def ensure_lensnode_for_gateway(
     if normalized_scope is None and is_local_platform_gateway_metadata(gateway.metadata):
         normalized_scope = LensGatewayLink.GatewayScope.PLATFORM
 
-    desired_scope = normalized_scope or LensGatewayLink.GatewayScope.USER
-    desired_origin = (
-        LensGatewayLink.Origin.PLATFORM
-        if desired_scope == LensGatewayLink.GatewayScope.PLATFORM
-        else LensGatewayLink.Origin.USER
-    )
-    is_platform = desired_scope == LensGatewayLink.GatewayScope.PLATFORM
-    link, created = LensGatewayLink.objects.get_or_create(
-        organization=org,
+    link = _resolve_gateway_link_identity(
+        org=org,
         gateway=gateway,
-        defaults={
-            "workspace_root": f"/workspace/org-{org.id}",
-            "owner_user": None if is_platform else owner_user,
-            "scope": desired_scope,
-            "origin": desired_origin,
-        },
+        owner_user=owner_user,
+        normalized_scope=normalized_scope,
     )
-
-    if not created and normalized_scope is not None:
-        update_fields = []
-        if link.scope != desired_scope:
-            link.scope = desired_scope
-            update_fields.append("scope")
-        if link.origin != desired_origin:
-            link.origin = desired_origin
-            update_fields.append("origin")
-        if is_platform and link.owner_user_id is not None:
-            link.owner_user = None
-            update_fields.append("owner_user")
-        if not is_platform and owner_user is not None and link.owner_user_id is None:
-            link.owner_user = owner_user
-            update_fields.append("owner_user")
-        if update_fields:
-            link.save(update_fields=[*update_fields, "updated_at"])
 
     is_platform = link.scope == LensGatewayLink.GatewayScope.PLATFORM
-    if is_platform and not link.is_platform_default:
-        has_platform_default = LensGatewayLink.objects.filter(
-            organization=org,
-            scope=LensGatewayLink.GatewayScope.PLATFORM,
-            is_platform_default=True,
-        ).exclude(pk=link.pk).exists()
-        if is_local_platform_gateway_metadata(gateway.metadata) and not has_platform_default:
-            link.is_platform_default = True
-            link.save(update_fields=["is_platform_default", "updated_at"])
+    if (
+        is_platform
+        and not link.is_platform_default
+        and is_local_platform_gateway_metadata(gateway.metadata)
+    ):
+        try:
+            with transaction.atomic():
+                locked_link = LensGatewayLink.objects.select_for_update().get(
+                    pk=link.pk
+                )
+                has_platform_default = (
+                    LensGatewayLink.objects.filter(
+                        organization=org,
+                        scope=LensGatewayLink.GatewayScope.PLATFORM,
+                        is_platform_default=True,
+                    )
+                    .exclude(pk=locked_link.pk)
+                    .exists()
+                )
+                if not has_platform_default:
+                    locked_link.is_platform_default = True
+                    locked_link.save(
+                        update_fields=["is_platform_default", "updated_at"]
+                    )
+                link.is_platform_default = locked_link.is_platform_default
+        except IntegrityError:
+            # Another registration won the conditional unique constraint.
+            # The link remains valid and simply is not the platform default.
+            link.refresh_from_db(fields=["is_platform_default"])
 
     if link.sl_lensnode_uuid:
         return link
-
-    node_name = name or f"hfl-gw-{gateway.id}-{gateway.name}"[:160]
-    data = sl_client.request_json(
-        "POST",
-        "/api/lens/admin/lensnodes/",
-        json_body={"name": node_name},
+    return _provision_source_lens_lensnode(
+        link=link,
+        gateway=gateway,
+        requested_name=name,
     )
-    lensnode_uuid = data.get("uuid")
-    token = data.get("token")
-    if not lensnode_uuid:
-        raise sl_client.LensBridgeError("LensNode create returned no uuid.")
-
-    config = dict(link.config_json or {})
-    if token:
-        config["lensnode_token_issued"] = True
-        config["lensnode_token"] = token
-
-    link.sl_lensnode_uuid = uuid.UUID(str(lensnode_uuid))
-    link.sidecar_status = LensGatewayLink.SidecarStatus.OFFLINE
-    link.config_json = config
-    link.save(
-        update_fields=[
-            "sl_lensnode_uuid",
-            "sidecar_status",
-            "config_json",
-            "updated_at",
-        ]
-    )
-    return link
 
 
 def enable_ai_on_gateway(
@@ -545,24 +886,16 @@ def enable_ai_on_gateway(
     org: Organization,
     gateway: Node,
     name: str | None = None,
+    owner_user=None,
     scope: str | None = None,
 ) -> LensGatewayLink:
-    link = ensure_lensnode_for_gateway(
+    return ensure_lensnode_for_gateway(
         org=org,
         gateway=gateway,
         name=name,
+        owner_user=owner_user,
         scope=scope,
     )
-    if scope:
-        desired = scope.strip().lower()
-        if desired in (
-            LensGatewayLink.GatewayScope.PLATFORM,
-            LensGatewayLink.GatewayScope.USER,
-        ):
-            if link.scope != desired:
-                link.scope = desired
-                link.save(update_fields=["scope", "updated_at"])
-    return link
 
 
 def build_lens_enroll_config(link: LensGatewayLink) -> dict[str, Any]:
@@ -635,13 +968,6 @@ def record_gateway_install_status(
     status = str(status or "").strip().lower()
 
     link = LensGatewayLink.objects.filter(organization=org, gateway=gateway).first()
-    if link is None and status == "failed":
-        link, _ = LensGatewayLink.objects.get_or_create(
-            organization=org,
-            gateway=gateway,
-            defaults={"workspace_root": f"/workspace/org-{org.id}"},
-        )
-
     if link is None:
         return None
 
@@ -822,7 +1148,16 @@ def _entry_is_dir(item: dict[str, Any]) -> bool:
     return bool(item.get("isLeaf") is False)
 
 
-def _normalize_gateway_browse_entries(raw_entries: Any) -> list[dict[str, Any]]:
+def _normalize_gateway_browse_entries(
+    raw_entries: Any,
+    *,
+    workspace_root: str,
+) -> list[dict[str, Any]]:
+    from apps.lens_bridge.services.gateway_paths import (
+        GatewayPathError,
+        path_within_root,
+    )
+
     if not isinstance(raw_entries, list):
         return []
     rows: list[dict[str, Any]] = []
@@ -835,6 +1170,15 @@ def _normalize_gateway_browse_entries(raw_entries: Any) -> list[dict[str, Any]]:
             continue
         path = str(item.get("path") or "").strip()
         if not path or path in seen:
+            continue
+        try:
+            path = path_within_root(
+                path,
+                workspace_root,
+                allow_root=False,
+                field="entry_path",
+            )
+        except GatewayPathError:
             continue
         seen.add(path)
         name = str(item.get("name") or item.get("label") or "").strip() or path.rstrip("/").split("/")[-1]
@@ -857,35 +1201,55 @@ def browse_gateway_directory(
     org: Organization,
     gateway_id: int,
     path: str = "",
+    expected_scope: str | None = None,
+    expected_owner_user_id: int | None = None,
     limit: int = 200,
     wait_timeout_seconds: int = 15,
 ) -> dict[str, Any]:
-    import posixpath
-
     from apps.node.services.interface import run_agent_task_sync
+    from apps.lens_bridge.services.gateway_paths import (
+        GatewayPathError,
+        path_within_root,
+    )
 
     gateway = require_gateway_node(org, gateway_id)
     if gateway.status != Node.Status.ONLINE:
         raise ValidationError({"gateway": "Data gateway must be online to browse directories."})
 
-    link, _ = LensGatewayLink.objects.get_or_create(
-        organization=org,
-        gateway=gateway,
-        defaults={"workspace_root": f"/workspace/org-{org.id}"},
-    )
+    link = get_gateway_link(org, gateway.id)
+    if expected_scope is not None and link.scope != expected_scope:
+        raise ValidationError({"gateway_id": "Data gateway scope is invalid."})
+    if expected_scope is not None or expected_owner_user_id is not None:
+        from apps.lens_bridge.services.gateway_execution import (
+            context_for_gateway_link,
+        )
 
-    root = link.resolved_workspace_root().rstrip("/") or "/"
-    browse_path = str(path or "").strip() or root
-    normalized_root = root.rstrip("/") or "/"
-    if browse_path != normalized_root and not browse_path.startswith(f"{normalized_root}/"):
-        raise ValidationError({"path": "Path must be under the gateway workspace root."})
+        context_for_gateway_link(
+            tenant_organization=org,
+            gateway_link=link,
+            expected_owner_user_id=expected_owner_user_id,
+            require_ready=False,
+        )
+
+    normalized_root = link.resolved_workspace_root()
+    try:
+        browse_path = path_within_root(
+            str(path or "").strip() or normalized_root,
+            normalized_root,
+            allow_root=True,
+        )
+    except GatewayPathError as exc:
+        raise ValidationError(
+            {"path": "Path must be under the gateway workspace root."}
+        ) from exc
 
     outcome = run_agent_task_sync(
         organization_id=org.id,
         node_id=gateway.id,
-        kind="explorer.list",
+        kind="lens.gateway.browse",
         payload={
             "path": browse_path,
+            "allowed_root": normalized_root,
             "dirs_only": True,
             "include_metadata": False,
             "limit": limit,
@@ -908,8 +1272,26 @@ def browse_gateway_directory(
         result = {}
 
     listed_path = str(result.get("path") or browse_path).strip() or browse_path
+    try:
+        listed_path = path_within_root(
+            listed_path,
+            normalized_root,
+            allow_root=True,
+            field="listed_path",
+        )
+    except GatewayPathError:
+        listed_path = browse_path
+    import posixpath
+
     parent_path = posixpath.dirname(listed_path.rstrip("/")) or normalized_root
-    if parent_path != normalized_root and not parent_path.startswith(f"{normalized_root}/"):
+    try:
+        parent_path = path_within_root(
+            parent_path,
+            normalized_root,
+            allow_root=True,
+            field="parent_path",
+        )
+    except GatewayPathError:
         parent_path = normalized_root
 
     return {
@@ -917,7 +1299,10 @@ def browse_gateway_directory(
         "path": listed_path,
         "root_path": normalized_root,
         "parent_path": parent_path,
-        "entries": _normalize_gateway_browse_entries(result.get("entries")),
+        "entries": _normalize_gateway_browse_entries(
+            result.get("entries"),
+            workspace_root=normalized_root,
+        ),
         "has_more": bool(result.get("has_more")),
         "next_cursor": str(result.get("next_cursor") or ""),
     }

--- a/src/backend/apps/lens_bridge/services/sync_queue.py
+++ b/src/backend/apps/lens_bridge/services/sync_queue.py
@@ -124,6 +124,25 @@ def queue_copilot_chat_teardown(*, session_link_id: int) -> None:
         raise RuntimeError("Unable to queue chat teardown.") from exc
 
 
+def queue_knowledge_source_teardown(*, knowledge_source_id: int) -> None:
+    """Queue durable KS teardown without an in-process fallback."""
+
+    from apps.lens_bridge.tasks.knowledge_source_teardown import (
+        execute_knowledge_source_teardown_task,
+    )
+
+    try:
+        execute_knowledge_source_teardown_task.delay(
+            knowledge_source_id=knowledge_source_id
+        )
+    except Exception as exc:
+        logger.exception(
+            "Failed to queue knowledge source teardown ks_id=%s",
+            knowledge_source_id,
+        )
+        raise RuntimeError("Unable to queue knowledge source teardown.") from exc
+
+
 def _run_chat_user_provision_in_thread(*, user_id: int, gateway_operator: bool) -> None:
     close_old_connections()
     from django.contrib.auth import get_user_model

--- a/src/backend/apps/lens_bridge/services/teardown_claims.py
+++ b/src/backend/apps/lens_bridge/services/teardown_claims.py
@@ -1,0 +1,22 @@
+"""Shared durable lease policy for Lens lifecycle workers."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+from django.conf import settings
+from django.utils import timezone
+
+TEARDOWN_TASK_HARD_LIMIT_SECONDS = int(
+    getattr(settings, "LENS_KS_SYNC_TIME_LIMIT", 7200)
+)
+TEARDOWN_CLAIM_TTL_SECONDS = TEARDOWN_TASK_HARD_LIMIT_SECONDS + 300
+PROVISION_TASK_HARD_LIMIT_SECONDS = TEARDOWN_TASK_HARD_LIMIT_SECONDS
+PROVISION_CLAIM_TTL_SECONDS = PROVISION_TASK_HARD_LIMIT_SECONDS + 300
+
+
+def next_retry_at(attempts: int) -> datetime:
+    """Return bounded exponential retry time for a teardown attempt."""
+
+    delay_seconds = min(3600, 60 * (2 ** min(max(attempts - 1, 0), 6)))
+    return timezone.now() + timedelta(seconds=delay_seconds)

--- a/src/backend/apps/lens_bridge/tasks/__init__.py
+++ b/src/backend/apps/lens_bridge/tasks/__init__.py
@@ -1,13 +1,27 @@
 from apps.lens_bridge.tasks.chat_lifecycle import (
     execute_copilot_chat_provision_task,
     execute_copilot_chat_teardown_task,
+    reconcile_copilot_chat_provisions_task,
+    reconcile_lens_resource_teardowns_task,
 )
 from apps.lens_bridge.tasks.chat_user_provision import execute_chat_user_provision_task
+from apps.lens_bridge.tasks.gateway_provisioning import (
+    execute_gateway_lensnode_provision_task,
+    reconcile_gateway_lensnode_provisions_task,
+)
 from apps.lens_bridge.tasks.knowledge_source_sync import execute_knowledge_source_sync_task
+from apps.lens_bridge.tasks.knowledge_source_teardown import (
+    execute_knowledge_source_teardown_task,
+)
 
 __all__ = [
     "execute_knowledge_source_sync_task",
     "execute_chat_user_provision_task",
+    "execute_gateway_lensnode_provision_task",
+    "reconcile_gateway_lensnode_provisions_task",
     "execute_copilot_chat_provision_task",
     "execute_copilot_chat_teardown_task",
+    "reconcile_copilot_chat_provisions_task",
+    "reconcile_lens_resource_teardowns_task",
+    "execute_knowledge_source_teardown_task",
 ]

--- a/src/backend/apps/lens_bridge/tasks/chat_lifecycle.py
+++ b/src/backend/apps/lens_bridge/tasks/chat_lifecycle.py
@@ -1,16 +1,26 @@
 from __future__ import annotations
 
 import logging
+from datetime import timedelta
 
 from celery import shared_task
-from django.conf import settings
+from django.db.models import Q
+from django.utils import timezone
 
+from apps.lens_bridge.services.teardown_claims import (
+    PROVISION_CLAIM_TTL_SECONDS,
+    PROVISION_TASK_HARD_LIMIT_SECONDS,
+    TEARDOWN_CLAIM_TTL_SECONDS,
+    TEARDOWN_TASK_HARD_LIMIT_SECONDS,
+)
 from common.observability.celery_context import celery_trace
 
 logger = logging.getLogger(__name__)
 
-_SOFT_LIMIT = int(getattr(settings, "LENS_KS_SYNC_SOFT_TIME_LIMIT", 3600))
-_TIME_LIMIT = int(getattr(settings, "LENS_KS_SYNC_TIME_LIMIT", 7200))
+_PROVISION_TIME_LIMIT = PROVISION_TASK_HARD_LIMIT_SECONDS
+_PROVISION_SOFT_LIMIT = max(60, _PROVISION_TIME_LIMIT - 300)
+_TEARDOWN_TIME_LIMIT = TEARDOWN_TASK_HARD_LIMIT_SECONDS
+_TEARDOWN_SOFT_LIMIT = max(60, _TEARDOWN_TIME_LIMIT - 300)
 
 
 @shared_task(
@@ -19,8 +29,8 @@ _TIME_LIMIT = int(getattr(settings, "LENS_KS_SYNC_TIME_LIMIT", 7200))
     autoretry_for=(Exception,),
     retry_backoff=True,
     retry_kwargs={"max_retries": 1},
-    soft_time_limit=_SOFT_LIMIT,
-    time_limit=_TIME_LIMIT,
+    soft_time_limit=_PROVISION_SOFT_LIMIT,
+    time_limit=_PROVISION_TIME_LIMIT,
 )
 def execute_copilot_chat_provision_task(self, *, session_link_id: int) -> dict:
     with celery_trace(
@@ -45,8 +55,8 @@ def execute_copilot_chat_provision_task(self, *, session_link_id: int) -> dict:
     autoretry_for=(Exception,),
     retry_backoff=True,
     retry_kwargs={"max_retries": 2},
-    soft_time_limit=_SOFT_LIMIT,
-    time_limit=_TIME_LIMIT,
+    soft_time_limit=_TEARDOWN_SOFT_LIMIT,
+    time_limit=_TEARDOWN_TIME_LIMIT,
 )
 def execute_copilot_chat_teardown_task(self, *, session_link_id: int) -> dict:
     with celery_trace(
@@ -63,3 +73,131 @@ def execute_copilot_chat_teardown_task(self, *, session_link_id: int) -> dict:
             result.get("status"),
         )
         return result
+
+
+@shared_task(
+    name=(
+        "apps.lens_bridge.tasks.chat_lifecycle."
+        "reconcile_copilot_chat_provisions_task"
+    ),
+)
+def reconcile_copilot_chat_provisions_task(*, limit: int = 100) -> dict:
+    """Requeue Chat provisioning work whose durable lease is absent or stale."""
+    from apps.lens_bridge.models import LensSessionLink
+
+    now = timezone.now()
+    stale_claim = now - timedelta(seconds=PROVISION_CLAIM_TTL_SECONDS)
+    session_ids = list(
+        LensSessionLink.objects.filter(
+            lifecycle_status=LensSessionLink.LifecycleStatus.PROVISIONING,
+        )
+        .filter(
+            Q(provision_next_retry_at__isnull=True)
+            | Q(provision_next_retry_at__lte=now)
+        )
+        .filter(
+            Q(provision_claimed_at__isnull=True)
+            | Q(provision_claimed_at__lte=stale_claim)
+        )
+        .order_by("provision_next_retry_at", "id")
+        .values_list("id", flat=True)[: max(1, min(int(limit), 500))]
+    )
+    queued_session_ids: list[int] = []
+    failures: list[dict[str, str | int]] = []
+    for session_id in session_ids:
+        try:
+            execute_copilot_chat_provision_task.delay(session_link_id=session_id)
+            queued_session_ids.append(session_id)
+        except Exception as exc:
+            logger.exception(
+                "copilot provision reconcile dispatch failed session_link_id=%s",
+                session_id,
+            )
+            failures.append(
+                {
+                    "resource": "session",
+                    "id": session_id,
+                    "error": str(exc)[:1000],
+                }
+            )
+    return {
+        "queued": len(queued_session_ids),
+        "session_ids": queued_session_ids,
+        "failed": failures,
+    }
+
+
+@shared_task(
+    name="apps.lens_bridge.tasks.chat_lifecycle.reconcile_lens_resource_teardowns_task",
+)
+def reconcile_lens_resource_teardowns_task(*, limit: int = 100) -> dict:
+    """Requeue durable Chat and Knowledge Source teardowns that are due."""
+
+    from apps.lens_bridge.models import LensSessionLink
+
+    now = timezone.now()
+    stale_claim = now - timedelta(seconds=TEARDOWN_CLAIM_TTL_SECONDS)
+    session_ids = list(
+        LensSessionLink.objects.filter(
+            lifecycle_status=LensSessionLink.LifecycleStatus.DELETING,
+        )
+        .filter(
+            Q(teardown_next_retry_at__isnull=True)
+            | Q(teardown_next_retry_at__lte=now)
+        )
+        .filter(Q(teardown_claimed_at__isnull=True) | Q(teardown_claimed_at__lte=stale_claim))
+        .order_by("teardown_next_retry_at", "id")
+        .values_list("id", flat=True)[: max(1, min(int(limit), 500))]
+    )
+    queued_session_ids: list[int] = []
+    failures: list[dict[str, str | int]] = []
+    for session_id in session_ids:
+        try:
+            execute_copilot_chat_teardown_task.delay(session_link_id=session_id)
+            queued_session_ids.append(session_id)
+        except Exception as exc:
+            logger.exception(
+                "copilot teardown reconcile dispatch failed session_link_id=%s",
+                session_id,
+            )
+            failures.append(
+                {
+                    "resource": "session",
+                    "id": session_id,
+                    "error": str(exc)[:1000],
+                }
+            )
+    from apps.lens_bridge.tasks.knowledge_source_teardown import (
+        due_knowledge_source_teardown_ids,
+        execute_knowledge_source_teardown_task,
+    )
+
+    knowledge_source_ids = due_knowledge_source_teardown_ids(
+        limit=limit,
+        now=now,
+    )
+    queued_knowledge_source_ids: list[int] = []
+    for knowledge_source_id in knowledge_source_ids:
+        try:
+            execute_knowledge_source_teardown_task.delay(
+                knowledge_source_id=knowledge_source_id
+            )
+            queued_knowledge_source_ids.append(knowledge_source_id)
+        except Exception as exc:
+            logger.exception(
+                "knowledge source teardown reconcile dispatch failed knowledge_source_id=%s",
+                knowledge_source_id,
+            )
+            failures.append(
+                {
+                    "resource": "knowledge_source",
+                    "id": knowledge_source_id,
+                    "error": str(exc)[:1000],
+                }
+            )
+    return {
+        "queued": len(queued_session_ids) + len(queued_knowledge_source_ids),
+        "session_ids": queued_session_ids,
+        "knowledge_source_ids": queued_knowledge_source_ids,
+        "failed": failures,
+    }

--- a/src/backend/apps/lens_bridge/tasks/gateway_provisioning.py
+++ b/src/backend/apps/lens_bridge/tasks/gateway_provisioning.py
@@ -1,0 +1,114 @@
+"""Celery recovery for durable SourceLens LensNode provisioning."""
+
+from __future__ import annotations
+
+import logging
+from datetime import timedelta
+
+from celery import shared_task
+from django.db.models import Q
+from django.utils import timezone
+
+from common.observability.celery_context import celery_trace
+
+logger = logging.getLogger(__name__)
+
+
+@shared_task(
+    name=(
+        "apps.lens_bridge.tasks.gateway_provisioning."
+        "execute_gateway_lensnode_provision_task"
+    ),
+    autoretry_for=(Exception,),
+    retry_backoff=True,
+    retry_kwargs={"max_retries": 1},
+    soft_time_limit=240,
+    time_limit=300,
+)
+def execute_gateway_lensnode_provision_task(*, gateway_link_id: int) -> dict:
+    """Resume one missing LensNode from its persisted lookup identity."""
+
+    from apps.lens_bridge.models import LensGatewayLink
+    from apps.lens_bridge.services import provisioning
+
+    link = (
+        LensGatewayLink.objects.select_related(
+            "organization",
+            "gateway",
+            "owner_user",
+        )
+        .filter(pk=gateway_link_id, is_deleted=False)
+        .first()
+    )
+    if link is None:
+        return {"gateway_link_id": gateway_link_id, "status": "missing"}
+    if link.sl_lensnode_uuid:
+        return {"gateway_link_id": gateway_link_id, "status": "ready"}
+    with celery_trace(
+        f"gateway-lensnode-provision-{gateway_link_id}",
+        task_name=(
+            "apps.lens_bridge.tasks.gateway_provisioning."
+            "execute_gateway_lensnode_provision_task"
+        ),
+    ):
+        result = provisioning.ensure_lensnode_for_gateway(
+            org=link.organization,
+            gateway=link.gateway,
+            owner_user=(
+                link.owner_user
+                if link.scope == LensGatewayLink.GatewayScope.USER
+                else None
+            ),
+            scope=link.scope,
+        )
+    return {
+        "gateway_link_id": gateway_link_id,
+        "status": "ready",
+        "sl_lensnode_uuid": str(result.sl_lensnode_uuid),
+    }
+
+
+@shared_task(
+    name=(
+        "apps.lens_bridge.tasks.gateway_provisioning."
+        "reconcile_gateway_lensnode_provisions_task"
+    ),
+)
+def reconcile_gateway_lensnode_provisions_task(*, limit: int = 100) -> dict:
+    """Requeue missing LensNodes whose durable lease is absent or stale."""
+
+    from apps.lens_bridge.models import LensGatewayLink
+    from apps.lens_bridge.services.provisioning import (
+        LENSNODE_PROVISION_CLAIM_TTL_SECONDS,
+    )
+
+    stale_claim = timezone.now() - timedelta(
+        seconds=LENSNODE_PROVISION_CLAIM_TTL_SECONDS
+    )
+    link_ids = list(
+        LensGatewayLink.objects.filter(
+            is_deleted=False,
+            sl_lensnode_uuid__isnull=True,
+        )
+        .filter(
+            Q(lensnode_provision_claimed_at__isnull=True)
+            | Q(lensnode_provision_claimed_at__lte=stale_claim)
+        )
+        .order_by("lensnode_provision_claimed_at", "id")
+        .values_list("id", flat=True)[: max(1, min(int(limit), 500))]
+    )
+    queued: list[int] = []
+    failures: list[dict[str, int | str]] = []
+    for link_id in link_ids:
+        try:
+            execute_gateway_lensnode_provision_task.delay(
+                gateway_link_id=link_id
+            )
+            queued.append(link_id)
+        except Exception as exc:
+            logger.exception(
+                "gateway LensNode reconcile dispatch failed link_id=%s",
+                link_id,
+            )
+            failures.append({"id": link_id, "error": str(exc)[:1000]})
+    return {"queued_gateway_link_ids": queued, "failures": failures}

--- a/src/backend/apps/lens_bridge/tasks/knowledge_source_teardown.py
+++ b/src/backend/apps/lens_bridge/tasks/knowledge_source_teardown.py
@@ -1,0 +1,86 @@
+"""Celery entrypoints for durable Knowledge Source teardown."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta
+
+from celery import shared_task
+from django.db.models import Q
+from django.utils import timezone
+
+from apps.lens_bridge.services.teardown_claims import (
+    TEARDOWN_CLAIM_TTL_SECONDS,
+    TEARDOWN_TASK_HARD_LIMIT_SECONDS,
+)
+from common.observability.celery_context import celery_trace
+
+logger = logging.getLogger(__name__)
+
+
+@shared_task(
+    name="apps.lens_bridge.tasks.knowledge_source_teardown.execute_knowledge_source_teardown_task",
+    bind=True,
+    autoretry_for=(Exception,),
+    retry_backoff=True,
+    retry_kwargs={"max_retries": 2},
+    soft_time_limit=max(60, TEARDOWN_TASK_HARD_LIMIT_SECONDS - 300),
+    time_limit=TEARDOWN_TASK_HARD_LIMIT_SECONDS,
+)
+def execute_knowledge_source_teardown_task(
+    self,
+    *,
+    knowledge_source_id: int,
+) -> dict:
+    from apps.lens_bridge.services.knowledge_source_teardown import (
+        run_knowledge_source_teardown,
+    )
+
+    with celery_trace(
+        f"knowledge-source-teardown-{knowledge_source_id}",
+        task_name=(
+            "apps.lens_bridge.tasks.knowledge_source_teardown."
+            "execute_knowledge_source_teardown_task"
+        ),
+    ):
+        logger.info(
+            "knowledge source teardown celery started ks_id=%s",
+            knowledge_source_id,
+        )
+        result = run_knowledge_source_teardown(
+            knowledge_source_id=int(knowledge_source_id)
+        )
+        logger.info(
+            "knowledge source teardown celery finished ks_id=%s status=%s",
+            knowledge_source_id,
+            result.get("status"),
+        )
+        return result
+
+
+def due_knowledge_source_teardown_ids(
+    *,
+    limit: int,
+    now: datetime | None = None,
+) -> list[int]:
+    """Return due rows with no live worker lease."""
+
+    from apps.lens_bridge.models import LensKnowledgeSource
+
+    now = now or timezone.now()
+    stale_claim = now - timedelta(seconds=TEARDOWN_CLAIM_TTL_SECONDS)
+    return list(
+        LensKnowledgeSource.all_objects.filter(
+            lifecycle_status=LensKnowledgeSource.LifecycleStatus.DELETING,
+        )
+        .filter(
+            Q(teardown_next_retry_at__isnull=True)
+            | Q(teardown_next_retry_at__lte=now)
+        )
+        .filter(
+            Q(teardown_claimed_at__isnull=True)
+            | Q(teardown_claimed_at__lte=stale_claim)
+        )
+        .order_by("teardown_next_retry_at", "id")
+        .values_list("id", flat=True)[: max(1, min(int(limit), 500))]
+    )

--- a/src/backend/apps/lens_bridge/tests/test_assistant_delete.py
+++ b/src/backend/apps/lens_bridge/tests/test_assistant_delete.py
@@ -3,7 +3,7 @@ from uuid import UUID
 
 from django.test import SimpleTestCase
 
-from apps.lens_bridge.services import assistant_access, assistants
+from apps.lens_bridge.services import assistant_access, assistants, sl_client
 
 
 class SoftDeleteAssistantLinkTests(SimpleTestCase):
@@ -34,6 +34,9 @@ class SoftDeleteAssistantLinkTests(SimpleTestCase):
 
 
 class DeleteOrgAssistantKsReassignTests(SimpleTestCase):
+    @patch(
+        "apps.lens_bridge.services.assistants._require_manual_assistant_management"
+    )
     @patch("apps.lens_bridge.services.assistants._delete_sl_assistant")
     @patch("apps.lens_bridge.services.assistants._reassign_ks_primary_assistant")
     @patch("apps.lens_bridge.services.assistants.LensKnowledgeSource")
@@ -46,12 +49,17 @@ class DeleteOrgAssistantKsReassignTests(SimpleTestCase):
         mock_ks_model,
         mock_reassign,
         mock_delete,
+        _require_manual,
     ):
         deleted = UUID("22222222-2222-2222-2222-222222222222")
         mock_ks_model.objects.filter.return_value.values_list.return_value = [7, 8]
         org = MagicMock()
 
-        assistants.delete_org_assistant(org, deleted)
+        assistants.delete_org_assistant(
+            org,
+            deleted,
+            can_manage_all=True,
+        )
 
         mock_delete.assert_called_once_with(deleted)
         mock_access.soft_delete_assistant_link.assert_called_once_with(org, deleted)
@@ -61,3 +69,34 @@ class DeleteOrgAssistantKsReassignTests(SimpleTestCase):
         mock_reassign.assert_any_call(org, 7)
         mock_reassign.assert_any_call(org, 8)
         self.assertEqual(mock_reassign.call_count, 2)
+
+
+class SourceLensAssistantRetirementTests(SimpleTestCase):
+    @patch("apps.lens_bridge.services.assistants.sl_client.request_json")
+    def test_missing_remote_assistant_is_idempotent_success(self, request_json):
+        error = sl_client.LensBridgeError("not found")
+        error.status_code = 404
+        request_json.side_effect = error
+        assistant_uuid = UUID("33333333-3333-3333-3333-333333333333")
+
+        assistants._delete_sl_assistant(assistant_uuid)
+
+        request_json.assert_called_once_with(
+            "DELETE",
+            f"/api/lens/assistants/{assistant_uuid}/",
+        )
+
+    @patch("apps.lens_bridge.services.assistants.sl_client.request_json")
+    def test_remote_failure_is_preserved_for_durable_retry(self, request_json):
+        error = sl_client.LensBridgeError("temporarily unavailable")
+        error.status_code = 503
+        request_json.side_effect = error
+        assistant_uuid = UUID("44444444-4444-4444-4444-444444444444")
+
+        with self.assertRaises(sl_client.LensBridgeError):
+            assistants._delete_sl_assistant(assistant_uuid)
+
+        request_json.assert_called_once_with(
+            "DELETE",
+            f"/api/lens/assistants/{assistant_uuid}/",
+        )

--- a/src/backend/apps/lens_bridge/tests/test_assistant_lifecycle_boundary.py
+++ b/src/backend/apps/lens_bridge/tests/test_assistant_lifecycle_boundary.py
@@ -1,0 +1,330 @@
+import uuid
+from unittest import mock
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from rest_framework.exceptions import ValidationError
+
+from apps.iam.models import Organization
+from apps.lens_bridge.models import (
+    LensAssistantLink,
+    LensGatewayLink,
+    LensKnowledgeSource,
+    LensSessionLink,
+)
+from apps.lens_bridge.services import assistants
+from apps.node.models import Node
+from apps.node.models.base import NodeRole
+
+
+class AssistantLifecycleBoundaryTests(TestCase):
+    def setUp(self):
+        self.org = Organization.objects.create(
+            key="assistant-lifecycle",
+            name="Assistant lifecycle",
+        )
+        self.user = get_user_model().objects.create_user(
+            username="assistant-owner@example.test",
+            email="assistant-owner@example.test",
+        )
+        self.gateway = Node.objects.create(
+            organization=self.org,
+            name="Assistant gateway",
+            role=NodeRole.GATEWAY,
+        )
+        self.gateway_link = LensGatewayLink.objects.create(
+            organization=self.org,
+            gateway=self.gateway,
+            owner_user=self.user,
+            scope=LensGatewayLink.GatewayScope.USER,
+        )
+        self.knowledge_source = LensKnowledgeSource.objects.create(
+            organization=self.org,
+            name="Chat source",
+            gateway=self.gateway,
+            gateway_link=self.gateway_link,
+            source_path="/workspace/chat-source",
+            created_by=self.user,
+        )
+        self.assistant_uuid = uuid.uuid4()
+        self.assistant_link = LensAssistantLink.objects.create(
+            organization=self.org,
+            sl_assistant_uuid=self.assistant_uuid,
+            knowledge_source=self.knowledge_source,
+            owner_user=self.user,
+            created_by=self.user,
+            visibility_scope=LensAssistantLink.VisibilityScope.USER,
+            lifecycle_owner=LensAssistantLink.LifecycleOwner.CHAT,
+        )
+        LensSessionLink.objects.create(
+            organization=self.org,
+            hfl_user=self.user,
+            gateway_link=self.gateway_link,
+            knowledge_source=self.knowledge_source,
+            sl_assistant_uuid=self.assistant_uuid,
+            lifecycle_status=LensSessionLink.LifecycleStatus.READY,
+        )
+
+    def _create_private_source_for_other_user(self):
+        other_user = get_user_model().objects.create_user(
+            username="other-assistant-owner@example.test",
+            email="other-assistant-owner@example.test",
+        )
+        other_gateway = Node.objects.create(
+            organization=self.org,
+            name="Other Assistant gateway",
+            role=NodeRole.GATEWAY,
+        )
+        other_link = LensGatewayLink.objects.create(
+            organization=self.org,
+            gateway=other_gateway,
+            owner_user=other_user,
+            scope=LensGatewayLink.GatewayScope.USER,
+            sl_lensnode_uuid=uuid.uuid4(),
+        )
+        other_source = LensKnowledgeSource.objects.create(
+            organization=self.org,
+            name="Other private source",
+            gateway=other_gateway,
+            gateway_link=other_link,
+            source_path="/workspace/other-private-source",
+            created_by=other_user,
+        )
+        return other_user, other_link, other_source
+
+    @mock.patch("apps.lens_bridge.services.assistants.sl_client.request_json")
+    def test_tenant_assistant_rejects_raw_execution_identity(self, request_json):
+        with self.assertRaises(ValidationError):
+            assistants.create_org_assistant(
+                self.org,
+                {
+                    "name": "Raw execution bypass",
+                    "lensnode_uuid": str(uuid.uuid4()),
+                    "selected_task": "document_review",
+                    "selected_dirs": [{"path": "/workspace/other-user"}],
+                },
+                user=self.user,
+            )
+
+        request_json.assert_not_called()
+
+    @mock.patch("apps.lens_bridge.services.assistants.sl_client.request_json")
+    def test_tenant_assistant_rejects_another_users_knowledge_source(
+        self,
+        request_json,
+    ):
+        _other_user, _other_link, other_source = (
+            self._create_private_source_for_other_user()
+        )
+
+        with self.assertRaisesMessage(
+            ValidationError,
+            "Knowledge source is not owned by the current user.",
+        ):
+            assistants.create_org_assistant(
+                self.org,
+                {
+                    "name": "Owner bypass",
+                    "knowledge_source_id": other_source.id,
+                    "selected_task": "document_review",
+                },
+                user=self.user,
+            )
+
+        request_json.assert_not_called()
+
+    @mock.patch(
+        "apps.lens_bridge.services.provisioning.sl_lensnode_snapshot_from_link",
+        return_value={},
+    )
+    @mock.patch(
+        "apps.lens_bridge.services.org_mcp_servers.list_org_mcp_servers",
+        return_value=[],
+    )
+    @mock.patch(
+        "apps.lens_bridge.services.org_skills.list_org_skills",
+        return_value=[],
+    )
+    @mock.patch("apps.lens_bridge.services.assistants.sl_client.request_json")
+    def test_tenant_form_options_only_return_owned_private_resources(
+        self,
+        request_json,
+        _list_skills,
+        _list_mcps,
+        _lensnode_snapshot,
+    ):
+        self.gateway_link.sl_lensnode_uuid = uuid.uuid4()
+        self.gateway_link.save(update_fields=["sl_lensnode_uuid", "updated_at"])
+        _other_user, other_link, other_source = (
+            self._create_private_source_for_other_user()
+        )
+        request_json.return_value = [
+            {"uuid": str(self.gateway_link.sl_lensnode_uuid), "name": "Mine"},
+            {"uuid": str(other_link.sl_lensnode_uuid), "name": "Other"},
+        ]
+
+        options = assistants.assistant_form_options(self.org, user=self.user)
+
+        self.assertEqual(
+            [row["gateway_id"] for row in options["gateways"]],
+            [self.gateway.id],
+        )
+        self.assertEqual(
+            [row["uuid"] for row in options["lensnodes"]],
+            [str(self.gateway_link.sl_lensnode_uuid)],
+        )
+        self.assertEqual(
+            [row["id"] for row in options["knowledge_sources"]],
+            [self.knowledge_source.id],
+        )
+        self.assertNotIn(
+            other_source.id,
+            [row["id"] for row in options["knowledge_sources"]],
+        )
+
+    @mock.patch(
+        "apps.lens_bridge.services.org_skills.sync_assistant_skill_links"
+    )
+    @mock.patch(
+        "apps.lens_bridge.services.assistants._knowledge_source_execution",
+        return_value={
+            "lensnode_uuid": "37941d34-a8bf-49d7-bfab-f8e61a350645",
+            "selected_dirs": [{"path": "/workspace/manual-source"}],
+        },
+    )
+    @mock.patch("apps.lens_bridge.services.assistants.sl_client.request_json")
+    def test_tenant_assistant_rebind_updates_hfl_knowledge_source_link(
+        self,
+        request_json,
+        _knowledge_source_execution,
+        _sync_skills,
+    ):
+        self.assistant_link.lifecycle_owner = LensAssistantLink.LifecycleOwner.MANUAL
+        self.assistant_link.save(update_fields=["lifecycle_owner", "updated_at"])
+        LensSessionLink.objects.all().delete()
+        replacement_source = LensKnowledgeSource.objects.create(
+            organization=self.org,
+            name="Manual source",
+            gateway=self.gateway,
+            gateway_link=self.gateway_link,
+            source_path="/workspace/manual-source",
+            created_by=self.user,
+        )
+        prefix = assistants._org_prefix(self.org)
+        request_json.return_value = {
+            "uuid": str(self.assistant_uuid),
+            "slug": f"{prefix}-manual",
+            "name": "Manual",
+        }
+
+        assistants.update_org_assistant(
+            self.org,
+            self.assistant_uuid,
+            {"knowledge_source_id": replacement_source.id},
+            user=self.user,
+        )
+
+        self.assistant_link.refresh_from_db()
+        self.assertEqual(
+            self.assistant_link.knowledge_source_id,
+            replacement_source.id,
+        )
+
+    @mock.patch("apps.lens_bridge.services.assistants._delete_sl_assistant")
+    @mock.patch("apps.lens_bridge.services.assistants.get_org_assistant")
+    def test_chat_assistant_cannot_be_deleted_directly(
+        self,
+        get_assistant,
+        delete_remote,
+    ):
+        get_assistant.return_value = {"uuid": str(self.assistant_uuid)}
+
+        with self.assertRaises(ValidationError):
+            assistants.delete_org_assistant(
+                self.org,
+                self.assistant_uuid,
+                user=self.user,
+                can_manage_all=True,
+            )
+
+        delete_remote.assert_not_called()
+
+    @mock.patch("apps.lens_bridge.services.assistants.sl_client.request_json")
+    @mock.patch("apps.lens_bridge.services.assistants.get_org_assistant")
+    def test_chat_assistant_cannot_be_updated_directly(
+        self,
+        get_assistant,
+        request_json,
+    ):
+        get_assistant.return_value = {"uuid": str(self.assistant_uuid)}
+
+        with self.assertRaises(ValidationError):
+            assistants.update_org_assistant(
+                self.org,
+                self.assistant_uuid,
+                {"name": "Bypass update"},
+                user=self.user,
+                can_manage_all=True,
+            )
+
+        request_json.assert_not_called()
+
+    @mock.patch("apps.lens_bridge.services.assistants.sl_client.request_json")
+    def test_chat_knowledge_source_cannot_receive_manual_assistant(
+        self,
+        request_json,
+    ):
+        with self.assertRaises(ValidationError):
+            assistants.create_org_assistant(
+                self.org,
+                {
+                    "name": "Bypass assistant",
+                    "knowledge_source_id": self.knowledge_source.id,
+                },
+                user=self.user,
+            )
+
+        request_json.assert_not_called()
+
+    @mock.patch("apps.lens_bridge.services.assistants.sl_client.request_json")
+    def test_org_manager_can_update_another_users_manual_assistant(
+        self,
+        request_json,
+    ):
+        self.assistant_link.lifecycle_owner = (
+            LensAssistantLink.LifecycleOwner.MANUAL
+        )
+        self.assistant_link.save(update_fields=["lifecycle_owner", "updated_at"])
+        LensSessionLink.objects.all().delete()
+        prefix = assistants._org_prefix(self.org)
+
+        def response_for(method, _path, **_kwargs):
+            if method == "GET":
+                return {
+                    "uuid": str(self.assistant_uuid),
+                    "slug": f"{prefix}-manual",
+                    "name": "Manual",
+                }
+            return {
+                "uuid": str(self.assistant_uuid),
+                "slug": f"{prefix}-manual",
+                "name": "Updated",
+            }
+
+        request_json.side_effect = response_for
+        manager = get_user_model().objects.create_user(
+            username="assistant-manager@example.test",
+            email="assistant-manager@example.test",
+        )
+        with mock.patch(
+            "apps.lens_bridge.services.org_skills.sync_assistant_skill_links"
+        ):
+            result = assistants.update_org_assistant(
+                self.org,
+                self.assistant_uuid,
+                {"name": "Updated"},
+                user=manager,
+                can_manage_all=True,
+            )
+
+        self.assertEqual(result["name"], "Updated")

--- a/src/backend/apps/lens_bridge/tests/test_chat_lifecycle_queue.py
+++ b/src/backend/apps/lens_bridge/tests/test_chat_lifecycle_queue.py
@@ -1,7 +1,10 @@
+import uuid
+from datetime import timedelta
 from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
 from django.test import SimpleTestCase, TestCase
+from django.utils import timezone
 from rest_framework.exceptions import ValidationError
 
 from apps.iam.models import Organization
@@ -14,16 +17,32 @@ from apps.lens_bridge.services import chat_lifecycle
 
 
 class CopilotLifecycleQueueTests(SimpleTestCase):
+    @patch("apps.lens_bridge.services.chat_lifecycle.LensSessionLink.objects.filter")
     @patch("apps.lens_bridge.services.chat_lifecycle._mark_provision_failed_by_id")
+    @patch(
+        "apps.lens_bridge.services.chat_lifecycle._claim_copilot_chat_provision",
+        return_value=("claim-token", "claimed"),
+    )
     @patch(
         "apps.lens_bridge.services.chat_lifecycle._run_copilot_chat_provision",
         side_effect=RuntimeError("database schema mismatch"),
     )
-    def test_provision_records_failures_before_pipeline_starts(self, _run, mark_failed):
+    def test_provision_records_failures_before_pipeline_starts(
+        self,
+        _run,
+        _claim,
+        mark_failed,
+        filter_sessions,
+    ):
+        filter_sessions.return_value.first.return_value = None
         with self.assertRaisesRegex(RuntimeError, "database schema mismatch"):
             chat_lifecycle.run_copilot_chat_provision(session_link_id=42)
 
-        mark_failed.assert_called_once_with(42, "database schema mismatch")
+        mark_failed.assert_called_once_with(
+            42,
+            "claim-token",
+            "database schema mismatch",
+        )
 
     @patch("apps.lens_bridge.tasks.chat_lifecycle.execute_copilot_chat_provision_task.delay")
     def test_provision_dispatches_to_celery(self, delay):
@@ -116,12 +135,36 @@ class CopilotRetryTests(TestCase):
         queue_provision.assert_called_once_with(session.id)
 
     @patch("apps.lens_bridge.services.chat_lifecycle._queue_provision_or_mark_failed")
-    def test_provisioning_session_retry_is_idempotent(self, queue_provision):
+    def test_unclaimed_provisioning_session_retry_is_requeued(self, queue_provision):
         session = self.create_session(LensSessionLink.LifecycleStatus.PROVISIONING)
+
+        with self.captureOnCommitCallbacks(execute=True):
+            updated = chat_lifecycle.retry_copilot_chat_provision(session)
+
+        self.assertEqual(updated.lifecycle_status, LensSessionLink.LifecycleStatus.PROVISIONING)
+        queue_provision.assert_called_once_with(session.id)
+
+    @patch("apps.lens_bridge.services.chat_lifecycle._queue_provision_or_mark_failed")
+    def test_live_provisioning_session_retry_is_idempotent(self, queue_provision):
+        session = self.create_session(LensSessionLink.LifecycleStatus.PROVISIONING)
+        session.provision_claim_token = uuid.uuid4()
+        session.provision_claimed_at = timezone.now()
+        session.provision_next_retry_at = timezone.now() + timedelta(minutes=1)
+        session.save(
+            update_fields=[
+                "provision_claim_token",
+                "provision_claimed_at",
+                "provision_next_retry_at",
+                "updated_at",
+            ]
+        )
 
         updated = chat_lifecycle.retry_copilot_chat_provision(session)
 
-        self.assertEqual(updated.lifecycle_status, LensSessionLink.LifecycleStatus.PROVISIONING)
+        self.assertEqual(
+            updated.lifecycle_status,
+            LensSessionLink.LifecycleStatus.PROVISIONING,
+        )
         queue_provision.assert_not_called()
 
     @patch("apps.lens_bridge.services.chat_lifecycle._queue_provision_or_mark_failed")

--- a/src/backend/apps/lens_bridge/tests/test_chat_teardown.py
+++ b/src/backend/apps/lens_bridge/tests/test_chat_teardown.py
@@ -1,0 +1,1239 @@
+import uuid
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from datetime import timedelta
+from unittest import mock
+
+from django.contrib.auth import get_user_model
+from django.db import close_old_connections
+from django.test import TestCase, TransactionTestCase
+from django.utils import timezone
+
+from apps.iam.models import Organization
+from apps.lens_bridge.models import (
+    LensAssistantLink,
+    LensGatewayLink,
+    LensKnowledgeSource,
+    LensSessionLink,
+    LensWorkspaceBinding,
+)
+from apps.lens_bridge.services import (
+    assistant_access,
+    chat_lifecycle,
+    knowledge_source_teardown,
+    sl_client,
+)
+from apps.lens_bridge.tasks.chat_lifecycle import (
+    reconcile_copilot_chat_provisions_task,
+    reconcile_lens_resource_teardowns_task,
+)
+from apps.node.models import Node
+
+
+class CopilotChatTeardownTests(TestCase):
+    def setUp(self):
+        self.tenant = Organization.objects.create(key="teardown-tenant", name="Tenant")
+        self.platform_org = Organization.objects.create(
+            key="__platform_lens__",
+            name="Platform Lens",
+        )
+        self.user = get_user_model().objects.create_user(
+            username="teardown@example.test",
+            email="teardown@example.test",
+        )
+        self.gateway = Node.objects.create(
+            organization=self.platform_org,
+            name="platform-gateway",
+            role=Node.Role.GATEWAY,
+            status=Node.Status.ONLINE,
+        )
+        self.gateway_link = LensGatewayLink.objects.create(
+            organization=self.platform_org,
+            gateway=self.gateway,
+            scope=LensGatewayLink.GatewayScope.PLATFORM,
+            origin=LensGatewayLink.Origin.PLATFORM,
+            workspace_root="/workspace/platform/data",
+        )
+        self.knowledge_source = LensKnowledgeSource.objects.create(
+            organization=self.tenant,
+            name="Chat workspace",
+            gateway=self.gateway,
+            gateway_link=self.gateway_link,
+            backup_source_snapshot_id=11,
+            backup_snapshot_directory_id=12,
+            source_path="/data",
+            workspace_path_on_lensnode="/workspace/platform/data/tenants/1/ks/workspace",
+            sl_assistant_uuid=uuid.uuid4(),
+            status=LensKnowledgeSource.Status.READY,
+            created_by=self.user,
+        )
+        self.workspace_binding = LensWorkspaceBinding.objects.create(
+            organization=self.tenant,
+            knowledge_source=self.knowledge_source,
+            gateway_link=self.gateway_link,
+            execution_organization_id=self.platform_org.id,
+            execution_node_id=self.gateway.id,
+            workspace_kind=LensWorkspaceBinding.WorkspaceKind.MANAGED_RESTORE,
+            workspace_root="/workspace/platform/data",
+            relative_path=f"tenants/{self.tenant.id}/knowledge-sources/workspace",
+            state=LensWorkspaceBinding.State.READY,
+            identity_status=LensWorkspaceBinding.IdentityStatus.READY,
+        )
+        self.session = LensSessionLink.objects.create(
+            organization=self.tenant,
+            hfl_user=self.user,
+            gateway_link=self.gateway_link,
+            knowledge_source=self.knowledge_source,
+            sl_session_uuid=uuid.uuid4(),
+            sl_assistant_uuid=self.knowledge_source.sl_assistant_uuid,
+            lifecycle_status=LensSessionLink.LifecycleStatus.READY,
+        )
+
+    @staticmethod
+    def _not_found() -> sl_client.LensBridgeError:
+        error = sl_client.LensBridgeError("not found")
+        error.status_code = 404
+        return error
+
+    def test_assistant_binding_is_atomic_under_the_provision_claim(self):
+        assistant_uuid = uuid.uuid4()
+        claim_token = uuid.uuid4()
+        self.session.lifecycle_status = LensSessionLink.LifecycleStatus.PROVISIONING
+        self.session.provision_claim_token = claim_token
+        self.session.provision_state_json = {
+            "assistant_create": {
+                "operation_id": str(uuid.uuid4()),
+                "kind": "assistant_create",
+                "lookup_key": "tenant-chat-ks",
+                "remote_uuid": "",
+                "status": "intent",
+            }
+        }
+        self.session.sl_assistant_uuid = None
+        self.session.save(
+            update_fields=[
+                "lifecycle_status",
+                "provision_claim_token",
+                "provision_state_json",
+                "sl_assistant_uuid",
+                "updated_at",
+            ]
+        )
+        self.knowledge_source.sl_assistant_uuid = None
+        self.knowledge_source.save(
+            update_fields=["sl_assistant_uuid", "updated_at"]
+        )
+
+        chat_lifecycle._bind_assistant_to_provision_claim(
+            self.session,
+            str(claim_token),
+            knowledge_source=self.knowledge_source,
+            assistant_uuid=assistant_uuid,
+        )
+
+        self.session.refresh_from_db()
+        self.knowledge_source.refresh_from_db()
+        assistant_link = LensAssistantLink.objects.get(
+            organization=self.tenant,
+            sl_assistant_uuid=assistant_uuid,
+        )
+        self.assertEqual(self.session.sl_assistant_uuid, assistant_uuid)
+        self.assertEqual(self.knowledge_source.sl_assistant_uuid, assistant_uuid)
+        self.assertEqual(assistant_link.knowledge_source, self.knowledge_source)
+        self.assertEqual(assistant_link.owner_user, self.user)
+        self.assertEqual(
+            self.session.provision_state_json["assistant_create"]["remote_uuid"],
+            str(assistant_uuid),
+        )
+
+    @mock.patch(
+        "apps.lens_bridge.services.chat_lifecycle._queue_teardown_or_record_error"
+    )
+    def test_lost_provision_claim_cannot_revive_assistant_tombstone(
+        self,
+        _queue_teardown,
+    ):
+        assistant_uuid = uuid.uuid4()
+        claim_token = uuid.uuid4()
+        self.session.lifecycle_status = LensSessionLink.LifecycleStatus.PROVISIONING
+        self.session.provision_claim_token = claim_token
+        self.session.sl_assistant_uuid = None
+        self.session.save(
+            update_fields=[
+                "lifecycle_status",
+                "provision_claim_token",
+                "sl_assistant_uuid",
+                "updated_at",
+            ]
+        )
+        assistant_access.soft_delete_assistant_link(self.tenant, assistant_uuid)
+        chat_lifecycle.request_copilot_chat_teardown(self.session)
+
+        with self.assertRaises(chat_lifecycle.ChatProvisionLeaseLostError):
+            chat_lifecycle._bind_assistant_to_provision_claim(
+                self.session,
+                str(claim_token),
+                knowledge_source=self.knowledge_source,
+                assistant_uuid=assistant_uuid,
+            )
+
+        tombstone = LensAssistantLink.all_objects.get(
+            organization=self.tenant,
+            sl_assistant_uuid=assistant_uuid,
+        )
+        self.assertTrue(tombstone.is_deleted)
+
+    @mock.patch("apps.lens_bridge.services.assistant_access.soft_delete_assistant_link")
+    @mock.patch("apps.lens_bridge.services.assistants._delete_sl_assistant")
+    @mock.patch("apps.node.services.internal.agent_task.run_agent_task_sync")
+    @mock.patch("apps.lens_bridge.services.chat_lifecycle.sl_client.request_json")
+    def test_teardown_treats_missing_session_as_success_and_cleans_workspace(
+        self,
+        request_json,
+        run_agent_task,
+        _delete_assistant,
+        _soft_delete_assistant,
+    ):
+        request_json.side_effect = self._not_found()
+        run_agent_task.return_value = mock.MagicMock(
+            ok=True,
+            timed_out=False,
+            task=mock.MagicMock(id=uuid.uuid4(), last_error=""),
+        )
+        self.session.lifecycle_status = LensSessionLink.LifecycleStatus.DELETING
+        self.session.save(update_fields=["lifecycle_status", "updated_at"])
+
+        result = chat_lifecycle.run_copilot_chat_teardown(
+            session_link_id=self.session.id
+        )
+
+        self.assertEqual(result["status"], "deleted")
+        self.session.refresh_from_db()
+        self.workspace_binding.refresh_from_db()
+        self.assertEqual(
+            self.session.lifecycle_status,
+            LensSessionLink.LifecycleStatus.DELETED,
+        )
+        self.assertIsNone(self.session.sl_session_uuid)
+        self.assertIsNone(self.session.sl_assistant_uuid)
+        self.assertIsNone(self.session.knowledge_source_id)
+        self.assertEqual(
+            self.workspace_binding.state,
+            LensWorkspaceBinding.State.DELETED,
+        )
+        self.assertEqual(run_agent_task.call_args.kwargs["kind"], "lens.ks.cleanup")
+
+    @mock.patch("apps.lens_bridge.services.assistant_access.soft_delete_assistant_link")
+    @mock.patch("apps.lens_bridge.services.assistants._delete_sl_assistant")
+    @mock.patch("apps.node.services.internal.agent_task.run_agent_task_sync")
+    @mock.patch("apps.lens_bridge.services.chat_lifecycle.sl_client.request_json")
+    def test_teardown_persists_partial_success_and_retry_converges(
+        self,
+        request_json,
+        run_agent_task,
+        _delete_assistant,
+        _soft_delete_assistant,
+    ):
+        transient = sl_client.LensBridgeError("temporarily unavailable")
+        transient.status_code = 503
+        request_json.side_effect = transient
+        run_agent_task.return_value = mock.MagicMock(
+            ok=True,
+            timed_out=False,
+            task=mock.MagicMock(id=uuid.uuid4(), last_error=""),
+        )
+        self.session.lifecycle_status = LensSessionLink.LifecycleStatus.DELETING
+        self.session.save(update_fields=["lifecycle_status", "updated_at"])
+
+        with self.assertRaises(chat_lifecycle.ChatTeardownIncompleteError):
+            chat_lifecycle.run_copilot_chat_teardown(session_link_id=self.session.id)
+
+        self.session.refresh_from_db()
+        self.assertEqual(
+            self.session.lifecycle_status,
+            LensSessionLink.LifecycleStatus.DELETING,
+        )
+        self.assertIsNotNone(self.session.sl_session_uuid)
+        self.assertIsNotNone(self.session.sl_assistant_uuid)
+        self.assertEqual(
+            self.session.knowledge_source_id,
+            self.knowledge_source.id,
+        )
+        self.assertIsNone(self.session.teardown_claimed_at)
+        _delete_assistant.assert_not_called()
+        run_agent_task.assert_not_called()
+
+        request_json.side_effect = self._not_found()
+        self.session.teardown_next_retry_at = timezone.now() - timedelta(seconds=1)
+        self.session.save(update_fields=["teardown_next_retry_at", "updated_at"])
+        result = chat_lifecycle.run_copilot_chat_teardown(
+            session_link_id=self.session.id
+        )
+
+        self.assertEqual(result["status"], "deleted")
+        self.session.refresh_from_db()
+        self.assertIsNone(self.session.sl_session_uuid)
+        self.assertEqual(
+            self.session.lifecycle_status,
+            LensSessionLink.LifecycleStatus.DELETED,
+        )
+
+    @mock.patch(
+        "apps.lens_bridge.services.chat_lifecycle."
+        "_queue_teardown_or_record_error"
+    )
+    @mock.patch(
+        "apps.lens_bridge.services.chat_lifecycle._cleanup_failed_provision",
+        return_value=["assistant_create: remote create outcome is unknown"],
+    )
+    @mock.patch(
+        "apps.lens_bridge.services.chat_lifecycle._run_copilot_chat_provision",
+        side_effect=RuntimeError("provision failed"),
+    )
+    def test_failed_provision_with_incomplete_compensation_becomes_teardown(
+        self,
+        _run_provision,
+        _cleanup,
+        queue_teardown,
+    ):
+        claim_token = uuid.uuid4()
+        self.session.lifecycle_status = LensSessionLink.LifecycleStatus.PROVISIONING
+        self.session.provision_claim_token = claim_token
+        self.session.provision_claimed_at = timezone.now()
+        self.session.save(
+            update_fields=[
+                "lifecycle_status",
+                "provision_claim_token",
+                "provision_claimed_at",
+                "updated_at",
+            ]
+        )
+
+        with mock.patch(
+            "apps.lens_bridge.services.chat_lifecycle."
+            "_claim_copilot_chat_provision",
+            return_value=(str(claim_token), "claimed"),
+        ), self.captureOnCommitCallbacks(execute=True), self.assertRaisesRegex(
+            RuntimeError,
+            "provision failed",
+        ):
+            chat_lifecycle.run_copilot_chat_provision(
+                session_link_id=self.session.id
+            )
+
+        self.session.refresh_from_db()
+        self.assertEqual(
+            self.session.lifecycle_status,
+            LensSessionLink.LifecycleStatus.DELETING,
+        )
+        self.assertEqual(
+            self.session.provision_phase,
+            LensSessionLink.ProvisionPhase.CLEANING_UP,
+        )
+        self.assertIsNone(self.session.provision_claim_token)
+        queue_teardown.assert_called_once_with(self.session.id)
+
+    @mock.patch(
+        "apps.lens_bridge.services.knowledge_source_teardown."
+        "run_knowledge_source_teardown"
+    )
+    @mock.patch("apps.lens_bridge.services.assistants._delete_sl_assistant")
+    @mock.patch("apps.lens_bridge.services.chat_lifecycle.sl_client.request_json")
+    def test_failed_provision_cleanup_respects_dependency_order(
+        self,
+        request_json,
+        delete_assistant,
+        teardown_knowledge_source,
+    ):
+        claim_token = uuid.uuid4()
+        self.session.lifecycle_status = LensSessionLink.LifecycleStatus.PROVISIONING
+        self.session.provision_claim_token = claim_token
+        self.session.provision_claimed_at = timezone.now()
+        self.session.save(
+            update_fields=[
+                "lifecycle_status",
+                "provision_claim_token",
+                "provision_claimed_at",
+                "updated_at",
+            ]
+        )
+        transient = sl_client.LensBridgeError("temporarily unavailable")
+        transient.status_code = 503
+        request_json.side_effect = transient
+
+        errors = chat_lifecycle._cleanup_failed_provision(
+            self.session,
+            str(claim_token),
+        )
+
+        self.assertEqual(
+            errors,
+            ["delete_session: temporarily unavailable"],
+        )
+        self.session.refresh_from_db()
+        self.assertIsNotNone(self.session.sl_session_uuid)
+        self.assertIsNotNone(self.session.sl_assistant_uuid)
+        self.assertEqual(
+            self.session.knowledge_source_id,
+            self.knowledge_source.id,
+        )
+        delete_assistant.assert_not_called()
+        teardown_knowledge_source.assert_not_called()
+
+    @mock.patch("apps.lens_bridge.services.chat_lifecycle.sl_client.request_json")
+    def test_remote_recovery_scans_paginated_results(self, request_json):
+        target_uuid = uuid.uuid4()
+        request_json.side_effect = [
+            {
+                "results": [
+                    {
+                        "uuid": str(uuid.uuid4()),
+                        "slug": f"unrelated-{index}",
+                    }
+                    for index in range(100)
+                ]
+            },
+            {
+                "results": [
+                    {
+                        "uuid": str(target_uuid),
+                        "slug": "target-assistant",
+                    }
+                ]
+            },
+        ]
+
+        recovered_uuid = chat_lifecycle._find_remote_uuid(
+            path="/api/lens/assistants/",
+            field="slug",
+            value="target-assistant",
+        )
+
+        self.assertEqual(recovered_uuid, target_uuid)
+        self.assertEqual(
+            request_json.call_args_list,
+            [
+                mock.call(
+                    "GET",
+                    "/api/lens/assistants/",
+                    params={"page": 1, "page_size": 100},
+                    hfl_user=None,
+                ),
+                mock.call(
+                    "GET",
+                    "/api/lens/assistants/",
+                    params={"page": 2, "page_size": 100},
+                    hfl_user=None,
+                ),
+            ],
+        )
+
+    def test_assistant_recovery_slug_preserves_unique_ks_suffix(self):
+        long_name = "very-long-knowledge-source-" * 5 + "final-tail-123456789"
+        self.knowledge_source.name = long_name
+        self.knowledge_source.save(update_fields=["name", "updated_at"])
+        second_knowledge_source = LensKnowledgeSource.objects.create(
+            organization=self.tenant,
+            name=long_name,
+            gateway=self.gateway,
+            gateway_link=self.gateway_link,
+            source_path="/another-path",
+            status=LensKnowledgeSource.Status.READY,
+            created_by=self.user,
+        )
+
+        first_slug = chat_lifecycle.provisioning.assistant_slug_for_ks(
+            org=self.tenant,
+            ks=self.knowledge_source,
+        )
+        second_slug = chat_lifecycle.provisioning.assistant_slug_for_ks(
+            org=self.tenant,
+            ks=second_knowledge_source,
+        )
+
+        self.assertLessEqual(len(first_slug), 160)
+        self.assertLessEqual(len(second_slug), 160)
+        self.assertTrue(first_slug.endswith(f"-ks-{self.knowledge_source.id}"))
+        self.assertTrue(
+            second_slug.endswith(f"-ks-{second_knowledge_source.id}")
+        )
+        self.assertNotEqual(first_slug, second_slug)
+
+    @mock.patch("apps.lens_bridge.services.chat_lifecycle._grant_assistant_to_chat_user")
+    @mock.patch("apps.lens_bridge.services.chat_lifecycle.assistant_access.ensure_assistant_link")
+    @mock.patch("apps.lens_bridge.services.chat_lifecycle.sl_client.request_json")
+    @mock.patch("apps.lens_bridge.services.chat_lifecycle._find_remote_uuid")
+    @mock.patch("apps.lens_bridge.services.chat_lifecycle.chat_user_provisioning.ensure_sl_chat_user")
+    @mock.patch("apps.lens_bridge.services.chat_lifecycle.knowledge_source_sync.run_knowledge_source_sync")
+    @mock.patch("apps.lens_bridge.services.chat_lifecycle.provisioning.create_sl_assistant_for_ks")
+    def test_journal_recovers_remote_creates_without_reposting(
+        self,
+        create_assistant,
+        run_sync,
+        ensure_sl_user,
+        find_remote_uuid,
+        request_json,
+        _ensure_assistant_link,
+        _grant_assistant,
+    ):
+        claim_token = uuid.uuid4()
+        assistant_uuid = uuid.uuid4()
+        session_uuid = uuid.uuid4()
+        session_operation_id = uuid.uuid4()
+        session_marker = f"__hfl_provision_{session_operation_id.hex}__"
+        assistant_slug = chat_lifecycle.provisioning.assistant_slug_for_ks(
+            org=self.tenant,
+            ks=self.knowledge_source,
+        )
+        self.knowledge_source.sl_assistant_uuid = None
+        self.knowledge_source.save(
+            update_fields=["sl_assistant_uuid", "updated_at"]
+        )
+        self.session.lifecycle_status = LensSessionLink.LifecycleStatus.PROVISIONING
+        self.session.provision_claim_token = claim_token
+        self.session.provision_claimed_at = timezone.now()
+        self.session.provision_next_retry_at = timezone.now()
+        self.session.sl_session_uuid = None
+        self.session.sl_assistant_uuid = None
+        self.session.backup_source_snapshot_id = 11
+        self.session.source_scopes_json = [
+            {
+                "source_path": "/data",
+                "backup_snapshot_directory_id": 12,
+            }
+        ]
+        self.session.agent_model_ref = uuid.uuid4()
+        self.session.title = "Recovered Chat"
+        self.session.provision_state_json = {
+            "assistant_create": {
+                "operation_id": str(uuid.uuid4()),
+                "kind": "assistant_create",
+                "lookup_key": assistant_slug,
+                "remote_uuid": "",
+                "status": "intent",
+            },
+            "session_create": {
+                "operation_id": str(session_operation_id),
+                "kind": "session_create",
+                "lookup_key": session_marker,
+                "remote_uuid": "",
+                "status": "intent",
+            },
+        }
+        self.session.save(
+            update_fields=[
+                "lifecycle_status",
+                "provision_claim_token",
+                "provision_claimed_at",
+                "provision_next_retry_at",
+                "sl_session_uuid",
+                "sl_assistant_uuid",
+                "backup_source_snapshot_id",
+                "source_scopes_json",
+                "agent_model_ref",
+                "title",
+                "provision_state_json",
+                "updated_at",
+            ]
+        )
+        run_sync.return_value = {"status": "ready"}
+        ensure_sl_user.return_value = mock.MagicMock(sl_user_id=37)
+
+        def find_resource(**kwargs):
+            if kwargs["field"] == "slug":
+                self.assertEqual(kwargs["value"], assistant_slug)
+                return assistant_uuid
+            self.assertEqual(kwargs["field"], "title")
+            self.assertEqual(kwargs["value"], session_marker)
+            return session_uuid
+
+        find_remote_uuid.side_effect = find_resource
+        request_json.return_value = {}
+
+        result = chat_lifecycle._run_copilot_chat_provision(
+            session_link_id=self.session.id,
+            claim_token=str(claim_token),
+        )
+
+        self.assertEqual(result["status"], "ready")
+        create_assistant.assert_not_called()
+        self.assertFalse(
+            any(call.args[:2] == ("POST", "/api/lens/sessions/") for call in request_json.call_args_list)
+        )
+        request_json.assert_called_once_with(
+            "PATCH",
+            f"/api/lens/sessions/{session_uuid}/",
+            json_body={"title": "Recovered Chat"},
+            hfl_user=self.user,
+        )
+        self.session.refresh_from_db()
+        self.assertEqual(self.session.sl_assistant_uuid, assistant_uuid)
+        self.assertEqual(self.session.sl_session_uuid, session_uuid)
+        self.assertEqual(
+            self.session.lifecycle_status,
+            LensSessionLink.LifecycleStatus.READY,
+        )
+
+    @mock.patch(
+        "apps.lens_bridge.tasks.chat_lifecycle."
+        "execute_copilot_chat_teardown_task.delay"
+    )
+    def test_reconciler_requeues_due_teardown(self, delay):
+        self.session.lifecycle_status = LensSessionLink.LifecycleStatus.DELETING
+        self.session.teardown_next_retry_at = timezone.now()
+        self.session.save(
+            update_fields=[
+                "lifecycle_status",
+                "teardown_next_retry_at",
+                "updated_at",
+            ]
+        )
+
+        result = reconcile_lens_resource_teardowns_task(limit=10)
+
+        self.assertEqual(result["queued"], 1)
+        delay.assert_called_once_with(session_link_id=self.session.id)
+
+    @mock.patch(
+        "apps.lens_bridge.tasks.chat_lifecycle."
+        "execute_copilot_chat_teardown_task.delay"
+    )
+    def test_reconciler_does_not_requeue_live_long_running_claim(self, delay):
+        self.session.lifecycle_status = LensSessionLink.LifecycleStatus.DELETING
+        self.session.teardown_next_retry_at = timezone.now()
+        self.session.teardown_claimed_at = timezone.now() - timedelta(minutes=15)
+        self.session.save(
+            update_fields=[
+                "lifecycle_status",
+                "teardown_next_retry_at",
+                "teardown_claimed_at",
+                "updated_at",
+            ]
+        )
+
+        result = reconcile_lens_resource_teardowns_task(limit=10)
+
+        self.assertEqual(result["queued"], 0)
+        delay.assert_not_called()
+
+    @mock.patch(
+        "apps.lens_bridge.services.chat_lifecycle."
+        "_queue_teardown_or_record_error"
+    )
+    def test_teardown_request_atomically_fences_provisioning(self, queue_teardown):
+        provision_token = uuid.uuid4()
+        self.session.lifecycle_status = LensSessionLink.LifecycleStatus.PROVISIONING
+        self.session.provision_claim_token = provision_token
+        self.session.provision_claimed_at = timezone.now()
+        self.session.provision_next_retry_at = timezone.now() + timedelta(minutes=5)
+        self.session.save(
+            update_fields=[
+                "lifecycle_status",
+                "provision_claim_token",
+                "provision_claimed_at",
+                "provision_next_retry_at",
+                "updated_at",
+            ]
+        )
+
+        with self.captureOnCommitCallbacks(execute=True):
+            result = chat_lifecycle.request_copilot_chat_teardown(self.session)
+
+        result.refresh_from_db()
+        self.assertEqual(
+            result.lifecycle_status,
+            LensSessionLink.LifecycleStatus.DELETING,
+        )
+        self.assertIsNone(result.provision_claim_token)
+        self.assertIsNone(result.provision_claimed_at)
+        self.assertIsNone(result.provision_next_retry_at)
+        queue_teardown.assert_called_once_with(self.session.id)
+
+    @mock.patch(
+        "apps.lens_bridge.services.chat_lifecycle."
+        "_queue_teardown_or_record_error"
+    )
+    def test_repeated_teardown_request_preserves_live_claim(self, queue_teardown):
+        teardown_token = uuid.uuid4()
+        claimed_at = timezone.now()
+        next_retry_at = claimed_at + timedelta(minutes=10)
+        self.session.lifecycle_status = LensSessionLink.LifecycleStatus.DELETING
+        self.session.teardown_attempts = 3
+        self.session.teardown_claim_token = teardown_token
+        self.session.teardown_claimed_at = claimed_at
+        self.session.teardown_next_retry_at = next_retry_at
+        self.session.save(
+            update_fields=[
+                "lifecycle_status",
+                "teardown_attempts",
+                "teardown_claim_token",
+                "teardown_claimed_at",
+                "teardown_next_retry_at",
+                "updated_at",
+            ]
+        )
+
+        with self.captureOnCommitCallbacks(execute=True):
+            result = chat_lifecycle.request_copilot_chat_teardown(self.session)
+
+        result.refresh_from_db()
+        self.assertEqual(result.teardown_attempts, 3)
+        self.assertEqual(result.teardown_claim_token, teardown_token)
+        self.assertEqual(result.teardown_claimed_at, claimed_at)
+        self.assertEqual(result.teardown_next_retry_at, next_retry_at)
+        queue_teardown.assert_called_once_with(self.session.id)
+
+    @mock.patch(
+        "apps.lens_bridge.services.chat_lifecycle."
+        "_queue_teardown_or_record_error"
+    )
+    @mock.patch("apps.lens_bridge.services.chat_lifecycle.sl_client.request_json")
+    def test_late_session_is_compensated_and_cannot_resurrect_chat(
+        self,
+        request_json,
+        _queue_teardown,
+    ):
+        provision_token = uuid.uuid4()
+        late_session_uuid = uuid.uuid4()
+        self.session.lifecycle_status = LensSessionLink.LifecycleStatus.PROVISIONING
+        self.session.sl_session_uuid = None
+        self.session.provision_claim_token = provision_token
+        self.session.provision_claimed_at = timezone.now()
+        self.session.save(
+            update_fields=[
+                "lifecycle_status",
+                "sl_session_uuid",
+                "provision_claim_token",
+                "provision_claimed_at",
+                "updated_at",
+            ]
+        )
+        chat_lifecycle.request_copilot_chat_teardown(self.session)
+
+        chat_lifecycle._compensate_late_session(
+            self.session.id,
+            late_session_uuid,
+            user=self.user,
+        )
+        with self.assertRaises(chat_lifecycle.ChatProvisionLeaseLostError):
+            chat_lifecycle._complete_copilot_chat_provision(
+                link_id=self.session.id,
+                claim_token=str(provision_token),
+                knowledge_source_id=self.knowledge_source.id,
+                assistant_uuid=self.knowledge_source.sl_assistant_uuid,
+                session_uuid=late_session_uuid,
+            )
+
+        request_json.assert_called_once_with(
+            "DELETE",
+            f"/api/lens/sessions/{late_session_uuid}/",
+            hfl_user=self.user,
+        )
+        self.session.refresh_from_db()
+        self.assertEqual(
+            self.session.lifecycle_status,
+            LensSessionLink.LifecycleStatus.DELETING,
+        )
+        self.assertIsNone(self.session.sl_session_uuid)
+
+    @mock.patch(
+        "apps.lens_bridge.services.chat_lifecycle."
+        "_queue_teardown_or_record_error"
+    )
+    @mock.patch("apps.lens_bridge.services.chat_lifecycle.sl_client.request_json")
+    def test_failed_late_compensation_reopens_durable_teardown(
+        self,
+        request_json,
+        queue_teardown,
+    ):
+        late_session_uuid = uuid.uuid4()
+        transient = sl_client.LensBridgeError("temporarily unavailable")
+        transient.status_code = 503
+        request_json.side_effect = transient
+        self.session.lifecycle_status = LensSessionLink.LifecycleStatus.DELETED
+        self.session.sl_session_uuid = None
+        self.session.save(
+            update_fields=[
+                "lifecycle_status",
+                "sl_session_uuid",
+                "updated_at",
+            ]
+        )
+
+        with self.captureOnCommitCallbacks(execute=True):
+            chat_lifecycle._compensate_late_session(
+                self.session.id,
+                late_session_uuid,
+                user=self.user,
+            )
+
+        self.session.refresh_from_db()
+        self.assertEqual(
+            self.session.lifecycle_status,
+            LensSessionLink.LifecycleStatus.DELETING,
+        )
+        self.assertEqual(self.session.sl_session_uuid, late_session_uuid)
+        self.assertIsNone(self.session.provision_claim_token)
+        queue_teardown.assert_called_once_with(self.session.id)
+
+    @mock.patch(
+        "apps.lens_bridge.services.chat_lifecycle."
+        "_queue_provision_or_mark_failed"
+    )
+    def test_manual_retry_recovers_stale_provision_claim(self, queue_provision):
+        self.session.lifecycle_status = LensSessionLink.LifecycleStatus.PROVISIONING
+        self.session.provision_claim_token = uuid.uuid4()
+        self.session.provision_claimed_at = timezone.now() - timedelta(hours=3)
+        self.session.provision_next_retry_at = timezone.now() + timedelta(hours=1)
+        self.session.save(
+            update_fields=[
+                "lifecycle_status",
+                "provision_claim_token",
+                "provision_claimed_at",
+                "provision_next_retry_at",
+                "updated_at",
+            ]
+        )
+
+        with self.captureOnCommitCallbacks(execute=True):
+            result = chat_lifecycle.retry_copilot_chat_provision(self.session)
+
+        result.refresh_from_db()
+        self.assertEqual(
+            result.lifecycle_status,
+            LensSessionLink.LifecycleStatus.PROVISIONING,
+        )
+        self.assertIsNone(result.provision_claim_token)
+        self.assertIsNone(result.provision_claimed_at)
+        self.assertIsNone(result.provision_next_retry_at)
+        queue_provision.assert_called_once_with(self.session.id)
+
+    @mock.patch(
+        "apps.lens_bridge.tasks.chat_lifecycle."
+        "execute_copilot_chat_provision_task.delay"
+    )
+    def test_provision_reconciler_requeues_unclaimed_work(self, delay):
+        self.session.lifecycle_status = LensSessionLink.LifecycleStatus.PROVISIONING
+        self.session.provision_claim_token = None
+        self.session.provision_claimed_at = None
+        self.session.provision_next_retry_at = None
+        self.session.save(
+            update_fields=[
+                "lifecycle_status",
+                "provision_claim_token",
+                "provision_claimed_at",
+                "provision_next_retry_at",
+                "updated_at",
+            ]
+        )
+
+        result = reconcile_copilot_chat_provisions_task(limit=10)
+
+        self.assertEqual(result["session_ids"], [self.session.id])
+        delay.assert_called_once_with(session_link_id=self.session.id)
+
+    @mock.patch(
+        "apps.lens_bridge.tasks.chat_lifecycle."
+        "execute_copilot_chat_provision_task.delay"
+    )
+    def test_provision_reconciler_preserves_live_claim(self, delay):
+        self.session.lifecycle_status = LensSessionLink.LifecycleStatus.PROVISIONING
+        self.session.provision_claim_token = uuid.uuid4()
+        self.session.provision_claimed_at = timezone.now()
+        self.session.provision_next_retry_at = timezone.now()
+        self.session.save(
+            update_fields=[
+                "lifecycle_status",
+                "provision_claim_token",
+                "provision_claimed_at",
+                "provision_next_retry_at",
+                "updated_at",
+            ]
+        )
+
+        result = reconcile_copilot_chat_provisions_task(limit=10)
+
+        self.assertEqual(result["queued"], 0)
+        delay.assert_not_called()
+
+    @mock.patch(
+        "apps.lens_bridge.tasks.chat_lifecycle."
+        "execute_copilot_chat_teardown_task.delay"
+    )
+    def test_teardown_reconciler_isolates_dispatch_failures(self, delay):
+        second_session = LensSessionLink.objects.create(
+            organization=self.tenant,
+            hfl_user=self.user,
+            lifecycle_status=LensSessionLink.LifecycleStatus.DELETING,
+        )
+        self.session.lifecycle_status = LensSessionLink.LifecycleStatus.DELETING
+        self.session.teardown_next_retry_at = timezone.now()
+        self.session.save(
+            update_fields=[
+                "lifecycle_status",
+                "teardown_next_retry_at",
+                "updated_at",
+            ]
+        )
+
+        def enqueue(*, session_link_id):
+            if session_link_id == self.session.id:
+                raise ConnectionError("broker unavailable")
+
+        delay.side_effect = enqueue
+
+        result = reconcile_lens_resource_teardowns_task(limit=10)
+
+        self.assertEqual(result["session_ids"], [second_session.id])
+        self.assertEqual(
+            result["failed"],
+            [
+                {
+                    "resource": "session",
+                    "id": self.session.id,
+                    "error": "broker unavailable",
+                }
+            ],
+        )
+        self.assertEqual(delay.call_count, 2)
+
+    @mock.patch("apps.node.services.internal.agent_task.run_agent_task_sync")
+    @mock.patch("apps.lens_bridge.services.assistant_access.soft_delete_assistant_link")
+    @mock.patch("apps.lens_bridge.services.assistants._delete_sl_assistant")
+    def test_failed_late_assistant_blocks_workspace_until_retry(
+        self,
+        delete_assistant,
+        _soft_delete_assistant,
+        run_agent_task,
+    ):
+        primary_uuid = self.session.sl_assistant_uuid
+        late_uuid = uuid.uuid4()
+        self.session.lifecycle_status = LensSessionLink.LifecycleStatus.DELETING
+        self.session.sl_session_uuid = None
+        self.session.provision_state_json = {
+            "late_resources": [
+                {
+                    "kind": "assistant",
+                    "remote_uuid": str(late_uuid),
+                }
+            ]
+        }
+        self.session.save(
+            update_fields=[
+                "lifecycle_status",
+                "sl_session_uuid",
+                "provision_state_json",
+                "updated_at",
+            ]
+        )
+        transient = sl_client.LensBridgeError("temporarily unavailable")
+        transient.status_code = 503
+
+        def delete_with_failure(assistant_uuid):
+            if assistant_uuid == late_uuid:
+                raise transient
+
+        delete_assistant.side_effect = delete_with_failure
+
+        with self.assertRaises(chat_lifecycle.ChatTeardownIncompleteError):
+            chat_lifecycle.run_copilot_chat_teardown(
+                session_link_id=self.session.id
+            )
+
+        self.session.refresh_from_db()
+        self.knowledge_source.refresh_from_db()
+        self.workspace_binding.refresh_from_db()
+        self.assertEqual(
+            self.session.lifecycle_status,
+            LensSessionLink.LifecycleStatus.DELETING,
+        )
+        self.assertEqual(self.session.sl_assistant_uuid, late_uuid)
+        self.assertEqual(
+            chat_lifecycle._late_remote_uuids(self.session, "assistant"),
+            {late_uuid},
+        )
+        self.assertEqual(
+            self.session.knowledge_source_id,
+            self.knowledge_source.id,
+        )
+        self.assertIsNone(self.knowledge_source.sl_assistant_uuid)
+        self.assertEqual(
+            self.workspace_binding.state,
+            LensWorkspaceBinding.State.READY,
+        )
+        self.assertIn(mock.call(primary_uuid), delete_assistant.call_args_list)
+        self.assertIn(mock.call(late_uuid), delete_assistant.call_args_list)
+        run_agent_task.assert_not_called()
+
+        events: list[tuple[str, uuid.UUID | None]] = []
+        delete_assistant.side_effect = lambda assistant_uuid: events.append(
+            ("assistant", assistant_uuid)
+        )
+        run_agent_task.side_effect = lambda **_kwargs: (
+            events.append(("workspace", None))
+            or mock.MagicMock(
+                ok=True,
+                timed_out=False,
+                task=mock.MagicMock(id=uuid.uuid4(), last_error=""),
+            )
+        )
+        self.session.teardown_next_retry_at = timezone.now() - timedelta(seconds=1)
+        self.session.save(
+            update_fields=["teardown_next_retry_at", "updated_at"]
+        )
+
+        result = chat_lifecycle.run_copilot_chat_teardown(
+            session_link_id=self.session.id
+        )
+
+        self.assertEqual(result["status"], "deleted")
+        self.assertEqual(events[0], ("assistant", late_uuid))
+        self.assertEqual(events[-1], ("workspace", None))
+
+    @mock.patch("apps.node.services.internal.agent_task.run_agent_task_sync")
+    @mock.patch("apps.lens_bridge.services.assistants._delete_sl_assistant")
+    @mock.patch("apps.lens_bridge.services.chat_lifecycle._find_remote_uuid")
+    def test_unknown_assistant_intent_blocks_workspace_cleanup(
+        self,
+        find_remote_uuid,
+        delete_assistant,
+        run_agent_task,
+    ):
+        self.session.lifecycle_status = LensSessionLink.LifecycleStatus.DELETING
+        self.session.sl_session_uuid = None
+        self.session.sl_assistant_uuid = None
+        self.session.provision_state_json = {
+            "assistant_create": {
+                "operation_id": str(uuid.uuid4()),
+                "kind": "assistant_create",
+                "lookup_key": "tenant-chat-ks-1",
+                "remote_uuid": "",
+                "status": "intent",
+            }
+        }
+        self.session.save(
+            update_fields=[
+                "lifecycle_status",
+                "sl_session_uuid",
+                "sl_assistant_uuid",
+                "provision_state_json",
+                "updated_at",
+            ]
+        )
+        find_remote_uuid.side_effect = sl_client.LensBridgeError(
+            "SourceLens unavailable"
+        )
+
+        with self.assertRaises(chat_lifecycle.ChatTeardownIncompleteError):
+            chat_lifecycle.run_copilot_chat_teardown(
+                session_link_id=self.session.id
+            )
+
+        self.session.refresh_from_db()
+        self.assertEqual(
+            self.session.lifecycle_status,
+            LensSessionLink.LifecycleStatus.DELETING,
+        )
+        self.assertEqual(
+            self.session.knowledge_source_id,
+            self.knowledge_source.id,
+        )
+        self.assertIn(
+            "recover_assistant_operation",
+            self.session.lifecycle_error,
+        )
+        delete_assistant.assert_not_called()
+        run_agent_task.assert_not_called()
+
+    @mock.patch(
+        "apps.lens_bridge.services.chat_lifecycle."
+        "_queue_teardown_or_record_error"
+    )
+    def test_conflicting_late_uuid_is_preserved_in_journal(self, queue_teardown):
+        original_uuid = self.session.sl_assistant_uuid
+        late_uuid = uuid.uuid4()
+        self.session.lifecycle_status = LensSessionLink.LifecycleStatus.DELETED
+        self.session.save(
+            update_fields=["lifecycle_status", "updated_at"]
+        )
+
+        with self.captureOnCommitCallbacks(execute=True):
+            chat_lifecycle._record_late_source_lens_resource(
+                self.session.id,
+                field="sl_assistant_uuid",
+                resource_uuid=late_uuid,
+                error="late delete failed",
+            )
+
+        self.session.refresh_from_db()
+        self.assertEqual(self.session.sl_assistant_uuid, original_uuid)
+        self.assertEqual(
+            chat_lifecycle._late_remote_uuids(self.session, "assistant"),
+            {late_uuid},
+        )
+        self.assertEqual(
+            self.session.lifecycle_status,
+            LensSessionLink.LifecycleStatus.DELETING,
+        )
+        queue_teardown.assert_called_once_with(self.session.id)
+
+    @mock.patch("apps.lens_bridge.services.assistants._delete_sl_assistant")
+    @mock.patch("apps.node.services.internal.agent_task.run_agent_task_sync")
+    def test_knowledge_source_teardown_deletes_assistant_before_workspace(
+        self,
+        run_agent_task,
+        delete_assistant,
+    ):
+        assistant_link = LensAssistantLink.objects.create(
+            organization=self.tenant,
+            sl_assistant_uuid=self.knowledge_source.sl_assistant_uuid,
+            knowledge_source=self.knowledge_source,
+            owner_user=self.user,
+            created_by=self.user,
+            visibility_scope=LensAssistantLink.VisibilityScope.USER,
+        )
+        outcome = mock.MagicMock(
+            ok=True,
+            timed_out=False,
+            task=mock.MagicMock(id=uuid.uuid4(), last_error=""),
+        )
+
+        def agent_cleanup(**_kwargs):
+            self.assertTrue(delete_assistant.called)
+            return outcome
+
+        run_agent_task.side_effect = agent_cleanup
+
+        result = knowledge_source_teardown.run_knowledge_source_teardown(
+            knowledge_source_id=self.knowledge_source.id,
+            owner_session_link_id=self.session.id,
+        )
+
+        self.assertEqual(result["status"], "deleted")
+        delete_assistant.assert_called_once_with(assistant_link.sl_assistant_uuid)
+        assistant_link.refresh_from_db()
+        self.knowledge_source.refresh_from_db()
+        self.workspace_binding.refresh_from_db()
+        self.assertTrue(assistant_link.is_deleted)
+        self.assertTrue(self.knowledge_source.is_deleted)
+        self.assertEqual(
+            self.workspace_binding.state,
+            LensWorkspaceBinding.State.DELETED,
+        )
+
+    @mock.patch("apps.node.services.internal.agent_task.run_agent_task_sync")
+    def test_gateway_local_workspace_cleanup_never_deletes_source_path(
+        self,
+        run_agent_task,
+    ):
+        private_gateway = Node.objects.create(
+            organization=self.tenant,
+            name="private-gateway",
+            role=Node.Role.GATEWAY,
+            status=Node.Status.ONLINE,
+        )
+        private_link = LensGatewayLink.objects.create(
+            organization=self.tenant,
+            gateway=private_gateway,
+            owner_user=self.user,
+            scope=LensGatewayLink.GatewayScope.USER,
+        )
+        knowledge_source = LensKnowledgeSource.objects.create(
+            organization=self.tenant,
+            name="Local directory",
+            gateway=private_gateway,
+            gateway_link=private_link,
+            source_path="/workspace/user-data",
+            status=LensKnowledgeSource.Status.READY,
+            created_by=self.user,
+        )
+        binding = LensWorkspaceBinding.objects.create(
+            organization=self.tenant,
+            knowledge_source=knowledge_source,
+            gateway_link=private_link,
+            execution_organization_id=self.tenant.id,
+            execution_node_id=private_gateway.id,
+            workspace_kind=LensWorkspaceBinding.WorkspaceKind.GATEWAY_LOCAL,
+            workspace_root="/workspace",
+            state=LensWorkspaceBinding.State.READY,
+            identity_status=LensWorkspaceBinding.IdentityStatus.NOT_APPLICABLE,
+        )
+
+        result = knowledge_source_teardown.run_knowledge_source_teardown(
+            knowledge_source_id=knowledge_source.id,
+        )
+
+        self.assertEqual(result["status"], "deleted")
+        binding.refresh_from_db()
+        self.assertEqual(binding.state, LensWorkspaceBinding.State.DELETED)
+        run_agent_task.assert_not_called()
+
+
+class CopilotChatTeardownConcurrencyTests(TransactionTestCase):
+    reset_sequences = True
+
+    def test_only_one_worker_claims_the_same_provision(self):
+        organization = Organization.objects.create(
+            key="provision-concurrency",
+            name="Provision concurrency",
+        )
+        user = get_user_model().objects.create_user(
+            username="provision-concurrency@example.test",
+            email="provision-concurrency@example.test",
+        )
+        session = LensSessionLink.objects.create(
+            organization=organization,
+            hfl_user=user,
+            lifecycle_status=LensSessionLink.LifecycleStatus.PROVISIONING,
+        )
+        barrier = threading.Barrier(2)
+
+        def claim():
+            close_old_connections()
+            try:
+                barrier.wait(timeout=5)
+                return chat_lifecycle._claim_copilot_chat_provision(session.id)
+            finally:
+                close_old_connections()
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            results = list(executor.map(lambda _index: claim(), range(2)))
+
+        self.assertEqual(sum(1 for claimed, _status in results if claimed), 1)
+        self.assertEqual(
+            {status for claimed, status in results if not claimed},
+            {"busy"},
+        )
+
+    def test_only_one_worker_claims_the_same_teardown(self):
+        organization = Organization.objects.create(
+            key="teardown-concurrency",
+            name="Teardown concurrency",
+        )
+        user = get_user_model().objects.create_user(
+            username="teardown-concurrency@example.test",
+            email="teardown-concurrency@example.test",
+        )
+        session = LensSessionLink.objects.create(
+            organization=organization,
+            hfl_user=user,
+            lifecycle_status=LensSessionLink.LifecycleStatus.DELETING,
+        )
+        barrier = threading.Barrier(2)
+
+        def claim():
+            close_old_connections()
+            try:
+                barrier.wait(timeout=5)
+                return chat_lifecycle._claim_copilot_chat_teardown(session.id)
+            finally:
+                close_old_connections()
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            results = list(executor.map(lambda _index: claim(), range(2)))
+
+        self.assertEqual(sum(1 for claimed, _status in results if claimed), 1)
+        self.assertEqual(
+            {status for claimed, status in results if not claimed},
+            {"busy"},
+        )

--- a/src/backend/apps/lens_bridge/tests/test_copilot_sessions.py
+++ b/src/backend/apps/lens_bridge/tests/test_copilot_sessions.py
@@ -47,6 +47,24 @@ class CopilotSessionApiTests(TestCase):
         )
         self.assertEqual(payload["run_outcomes"], [])
 
+    @patch(
+        "apps.lens_bridge.services.chat_lifecycle._queue_teardown_or_record_error"
+    )
+    def test_delete_returns_the_persisted_deleting_state(self, _queue_teardown):
+        response = self.client.delete(
+            reverse("lens-copilot-session-detail", kwargs={"pk": self.session.pk}),
+            HTTP_X_ORG_KEY=self.org.key,
+        )
+
+        self.assertEqual(response.status_code, 202)
+        payload = response.json()
+        payload = payload.get("data", payload)
+        self.assertEqual(
+            payload["lifecycle_status"],
+            LensSessionLink.LifecycleStatus.DELETING,
+        )
+        self.assertEqual(payload["status"], LensSessionLink.Status.ARCHIVED)
+
     @patch("apps.lens_bridge.services.sl_client.request_json")
     def test_sync_returns_a_durable_sanitized_failed_run_outcome(self, request_json):
         run_uuid = uuid.uuid4()

--- a/src/backend/apps/lens_bridge/tests/test_gateway_authorization.py
+++ b/src/backend/apps/lens_bridge/tests/test_gateway_authorization.py
@@ -1,0 +1,105 @@
+from unittest import mock
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+from rest_framework.test import APIClient
+
+from apps.iam.models import Membership
+from apps.iam.services.registration_service import provision_registered_user_tenant
+from apps.lens_bridge.models import LensGatewayLink, LensKnowledgeSource
+from apps.node.models import Node
+from apps.node.models.base import NodeRole
+
+
+class PrivateGatewayApiAuthorizationTests(TestCase):
+    def setUp(self):
+        self.owner = get_user_model().objects.create_user(
+            username="private-gateway-owner@example.test",
+            email="private-gateway-owner@example.test",
+        )
+        self.org, _ = provision_registered_user_tenant(self.owner)
+        self.other_admin = get_user_model().objects.create_user(
+            username="other-gateway-admin@example.test",
+            email="other-gateway-admin@example.test",
+        )
+        Membership.objects.create(
+            user=self.other_admin,
+            organization=self.org,
+            role=Membership.Role.ADMIN,
+        )
+        self.gateway = Node.objects.create(
+            organization=self.org,
+            name="Private gateway",
+            role=NodeRole.GATEWAY,
+            status=Node.Status.ONLINE,
+        )
+        self.link = LensGatewayLink.objects.create(
+            organization=self.org,
+            gateway=self.gateway,
+            owner_user=self.owner,
+            scope=LensGatewayLink.GatewayScope.USER,
+            origin=LensGatewayLink.Origin.USER,
+            workspace_root=f"/workspace/org-{self.org.id}/data",
+        )
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.other_admin)
+
+    @mock.patch("apps.lens_bridge.services.provisioning.sl_client.request_json")
+    def test_other_admin_cannot_enable_ai_or_receive_token(self, request_json):
+        response = self.client.post(
+            reverse(
+                "lens-gateway-enable-ai",
+                kwargs={"pk": self.gateway.id},
+            ),
+            {},
+            format="json",
+            HTTP_X_ORG_KEY=self.org.key,
+        )
+
+        self.assertEqual(response.status_code, 400)
+        request_json.assert_not_called()
+
+    def test_other_admin_cannot_read_ai_status(self):
+        response = self.client.get(
+            reverse(
+                "lens-gateway-ai-status",
+                kwargs={"pk": self.gateway.id},
+            ),
+            HTTP_X_ORG_KEY=self.org.key,
+        )
+
+        self.assertEqual(response.status_code, 400)
+
+    @mock.patch("apps.node.services.interface.run_agent_task_sync")
+    def test_other_admin_cannot_browse_private_gateway(self, run_agent_task):
+        response = self.client.get(
+            reverse(
+                "lens-gateway-browse",
+                kwargs={"pk": self.gateway.id},
+            ),
+            HTTP_X_ORG_KEY=self.org.key,
+        )
+
+        self.assertEqual(response.status_code, 400)
+        run_agent_task.assert_not_called()
+
+    def test_cross_user_knowledge_source_request_never_persists_row(self):
+        response = self.client.post(
+            reverse("lens-knowledge-source-list"),
+            {
+                "name": "Unauthorized source",
+                "gateway": self.gateway.id,
+                "source_path": self.link.resolved_workspace_root(),
+            },
+            format="json",
+            HTTP_X_ORG_KEY=self.org.key,
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertFalse(
+            LensKnowledgeSource.objects.filter(
+                organization=self.org,
+                name="Unauthorized source",
+            ).exists()
+        )

--- a/src/backend/apps/lens_bridge/tests/test_gateway_execution.py
+++ b/src/backend/apps/lens_bridge/tests/test_gateway_execution.py
@@ -1,0 +1,121 @@
+from unittest import mock
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from rest_framework.exceptions import ValidationError
+
+from apps.iam.models import Organization
+from apps.lens_bridge.models import LensGatewayLink, LensKnowledgeSource
+from apps.lens_bridge.services import platform_lens
+from apps.lens_bridge.services.gateway_execution import context_for_gateway_link
+from apps.node.models import Node
+from apps.node.models.base import NodeRole
+from apps.node.services.internal.node_workload import get_node_remove_blockers
+
+
+class GatewayExecutionContextTests(TestCase):
+    def setUp(self):
+        self.tenant = Organization.objects.create(key="tenant-exec", name="Tenant")
+        self.user = get_user_model().objects.create_user(
+            username="gateway-exec@example.test",
+            email="gateway-exec@example.test",
+        )
+
+    @mock.patch("apps.lens_bridge.services.gateway_execution.gateway_readiness.require_copilot_gateway")
+    def test_platform_gateway_keeps_tenant_data_and_uses_platform_execution(self, _ready):
+        platform_org = platform_lens.get_or_create_platform_org()
+        node = Node.objects.create(
+            organization=platform_org,
+            name="shared-platform-gateway",
+            role=NodeRole.GATEWAY,
+            status=Node.Status.ONLINE,
+        )
+        link = LensGatewayLink.objects.create(
+            organization=platform_org,
+            gateway=node,
+            scope=LensGatewayLink.GatewayScope.PLATFORM,
+            origin=LensGatewayLink.Origin.PLATFORM,
+            workspace_root="/workspace/org-platform/data",
+        )
+
+        context = context_for_gateway_link(
+            tenant_organization=self.tenant,
+            gateway_link=link,
+        )
+
+        self.assertEqual(context.tenant_organization, self.tenant)
+        self.assertEqual(context.execution_organization, platform_org)
+        self.assertTrue(context.is_platform)
+
+    @mock.patch("apps.lens_bridge.services.gateway_execution.gateway_readiness.require_copilot_gateway")
+    def test_private_gateway_cannot_cross_tenant_boundary(self, _ready):
+        other_org = Organization.objects.create(key="other-exec", name="Other")
+        node = Node.objects.create(
+            organization=other_org,
+            name="other-private-gateway",
+            role=NodeRole.GATEWAY,
+            status=Node.Status.ONLINE,
+        )
+        link = LensGatewayLink.objects.create(
+            organization=other_org,
+            gateway=node,
+            owner_user=self.user,
+            scope=LensGatewayLink.GatewayScope.USER,
+        )
+
+        with self.assertRaises(ValidationError):
+            context_for_gateway_link(
+                tenant_organization=self.tenant,
+                gateway_link=link,
+            )
+
+    @mock.patch("apps.lens_bridge.services.gateway_execution.gateway_readiness.require_copilot_gateway")
+    def test_private_gateway_cannot_cross_user_boundary(self, _ready):
+        node = Node.objects.create(
+            organization=self.tenant,
+            name="private-user-gateway",
+            role=NodeRole.GATEWAY,
+            status=Node.Status.ONLINE,
+        )
+        link = LensGatewayLink.objects.create(
+            organization=self.tenant,
+            gateway=node,
+            owner_user=self.user,
+            scope=LensGatewayLink.GatewayScope.USER,
+        )
+        another_user = get_user_model().objects.create_user(
+            username="another-gateway-user@example.test",
+            email="another-gateway-user@example.test",
+        )
+
+        with self.assertRaises(ValidationError):
+            context_for_gateway_link(
+                tenant_organization=self.tenant,
+                gateway_link=link,
+                expected_owner_user_id=another_user.id,
+            )
+
+    def test_platform_gateway_removal_sees_tenant_knowledge_sources(self):
+        platform_org = platform_lens.get_or_create_platform_org()
+        node = Node.objects.create(
+            organization=platform_org,
+            name="platform-gateway-with-tenant-ks",
+            role=NodeRole.GATEWAY,
+        )
+        link = LensGatewayLink.objects.create(
+            organization=platform_org,
+            gateway=node,
+            scope=LensGatewayLink.GatewayScope.PLATFORM,
+            origin=LensGatewayLink.Origin.PLATFORM,
+        )
+        LensKnowledgeSource.objects.create(
+            organization=self.tenant,
+            name="Tenant workspace",
+            gateway=node,
+            gateway_link=link,
+            source_path="/backup/data",
+        )
+
+        blockers = get_node_remove_blockers(node=node)
+
+        self.assertIn("knowledge_source_bound", {blocker.code for blocker in blockers})

--- a/src/backend/apps/lens_bridge/tests/test_gateway_identity_migration.py
+++ b/src/backend/apps/lens_bridge/tests/test_gateway_identity_migration.py
@@ -1,0 +1,135 @@
+from django.conf import settings
+from django.db import IntegrityError, connection, transaction
+from django.db.migrations.executor import MigrationExecutor
+from django.test import TransactionTestCase
+
+
+class GatewayIdentityMigrationTests(TransactionTestCase):
+    migrate_from = [
+        ("lens_bridge", "0020_alter_lensgatewaylink_sidecar_status"),
+        ("node", "0006_node_network_inventory"),
+        ("restore", "0004_alter_restorerecorditem_status"),
+    ]
+    migrate_to = [
+        ("lens_bridge", "0022_workspace_binding"),
+        ("node", "0006_node_network_inventory"),
+        ("restore", "0004_alter_restorerecorditem_status"),
+    ]
+
+    def setUp(self):
+        super().setUp()
+        executor = MigrationExecutor(connection)
+        executor.migrate(self.migrate_from)
+        old_apps = executor.loader.project_state(self.migrate_from).apps
+        self._seed_existing_gateway_data(old_apps)
+
+        executor = MigrationExecutor(connection)
+        executor.migrate(self.migrate_to)
+        self.apps = executor.loader.project_state(self.migrate_to).apps
+
+    def tearDown(self):
+        executor = MigrationExecutor(connection)
+        executor.migrate(executor.loader.graph.leaf_nodes())
+        super().tearDown()
+
+    def _seed_existing_gateway_data(self, apps):
+        app_label, model_name = settings.AUTH_USER_MODEL.split(".")
+        User = apps.get_model(app_label, model_name)
+        Organization = apps.get_model("iam", "Organization")
+        LensGatewayLink = apps.get_model("lens_bridge", "LensGatewayLink")
+        LensKnowledgeSource = apps.get_model(
+            "lens_bridge",
+            "LensKnowledgeSource",
+        )
+        Node = apps.get_model("node", "Node")
+
+        owner = User.objects.create(
+            username="migration-owner@example.test",
+            email="migration-owner@example.test",
+        )
+        tenant = Organization.objects.create(
+            key="migration-tenant",
+            name="Migration tenant",
+        )
+        platform = Organization.objects.create(
+            key="migration-platform",
+            name="Migration platform",
+        )
+
+        private_gateway = Node.objects.create(
+            organization=tenant,
+            name="Migration private gateway",
+            role="gateway",
+        )
+        private_link = LensGatewayLink.objects.create(
+            organization=tenant,
+            gateway=private_gateway,
+            scope="user",
+            origin="user",
+            owner_user=None,
+        )
+        private_source = LensKnowledgeSource.objects.create(
+            organization=tenant,
+            gateway=private_gateway,
+            name="Migration private source",
+            source_path="/data/private",
+            created_by=owner,
+        )
+
+        platform_gateway = Node.objects.create(
+            organization=platform,
+            name="Migration platform gateway",
+            role="gateway",
+        )
+        platform_link = LensGatewayLink.objects.create(
+            organization=platform,
+            gateway=platform_gateway,
+            scope="platform",
+            origin="platform",
+            owner_user=owner,
+        )
+        platform_source = LensKnowledgeSource.objects.create(
+            organization=tenant,
+            gateway=platform_gateway,
+            name="Migration platform source",
+            source_path="/data/platform",
+            created_by=owner,
+        )
+
+        self.owner_id = owner.id
+        self.private_link_id = private_link.id
+        self.private_source_id = private_source.id
+        self.platform_link_id = platform_link.id
+        self.platform_source_id = platform_source.id
+
+    def test_existing_sources_and_gateway_owners_are_backfilled(self):
+        LensGatewayLink = self.apps.get_model(
+            "lens_bridge",
+            "LensGatewayLink",
+        )
+        LensKnowledgeSource = self.apps.get_model(
+            "lens_bridge",
+            "LensKnowledgeSource",
+        )
+
+        private_source = LensKnowledgeSource.objects.get(pk=self.private_source_id)
+        platform_source = LensKnowledgeSource.objects.get(pk=self.platform_source_id)
+        private_link = LensGatewayLink.objects.get(pk=self.private_link_id)
+        platform_link = LensGatewayLink.objects.get(pk=self.platform_link_id)
+
+        self.assertEqual(private_source.gateway_link_id, self.private_link_id)
+        self.assertEqual(platform_source.gateway_link_id, self.platform_link_id)
+        self.assertEqual(private_link.owner_user_id, self.owner_id)
+        self.assertIsNone(platform_link.owner_user_id)
+        self.assertFalse(
+            LensKnowledgeSource._meta.get_field("gateway_link").null
+        )
+
+        with self.assertRaises(IntegrityError), transaction.atomic():
+            LensGatewayLink.objects.create(
+                organization_id=private_link.organization_id,
+                gateway_id=platform_link.gateway_id,
+                scope="user",
+                origin="user",
+                owner_user_id=None,
+            )

--- a/src/backend/apps/lens_bridge/tests/test_gateway_lensnode_provisioning.py
+++ b/src/backend/apps/lens_bridge/tests/test_gateway_lensnode_provisioning.py
@@ -1,0 +1,189 @@
+import uuid
+from datetime import timedelta
+from unittest import mock
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.utils import timezone
+
+from apps.iam.models import Organization
+from apps.lens_bridge.models import LensGatewayLink
+from apps.lens_bridge.services import provisioning
+from apps.node.models import Node
+from apps.node.models.base import NodeRole
+
+
+class DurableGatewayLensNodeProvisioningTests(TestCase):
+    def setUp(self):
+        self.org = Organization.objects.create(
+            key="lensnode-provision",
+            name="LensNode provision",
+        )
+        self.user = get_user_model().objects.create_user(
+            username="lensnode-provision@example.test",
+            email="lensnode-provision@example.test",
+        )
+        self.gateway = Node.objects.create(
+            organization=self.org,
+            name="Provision gateway",
+            role=NodeRole.GATEWAY,
+        )
+        self.link = LensGatewayLink.objects.create(
+            organization=self.org,
+            gateway=self.gateway,
+            owner_user=self.user,
+            scope=LensGatewayLink.GatewayScope.USER,
+            origin=LensGatewayLink.Origin.USER,
+        )
+
+    @mock.patch("apps.lens_bridge.services.provisioning.sl_client.request_json")
+    def test_records_intent_and_credentials_atomically(self, request_json):
+        remote_uuid = uuid.uuid4()
+
+        def response_for(method, path, **kwargs):
+            if method == "GET":
+                return []
+            self.assertEqual(path, "/api/lens/admin/lensnodes/")
+            lookup_name = kwargs["json_body"]["name"]
+            self.assertIn(f"hfl-gateway-link-{self.link.id}", lookup_name)
+            return {"uuid": str(remote_uuid), "token": "issued-token"}
+
+        request_json.side_effect = response_for
+
+        result = provisioning.ensure_lensnode_for_gateway(
+            org=self.org,
+            gateway=self.gateway,
+            owner_user=self.user,
+            scope=LensGatewayLink.GatewayScope.USER,
+        )
+
+        self.assertEqual(result.sl_lensnode_uuid, remote_uuid)
+        self.assertEqual(result.config_json["lensnode_token"], "issued-token")
+        self.assertEqual(
+            result.lensnode_provision_state_json["status"],
+            "ready",
+        )
+        self.assertIsNone(result.lensnode_provision_claim_token)
+
+    @mock.patch("apps.lens_bridge.services.provisioning.sl_client.request_json")
+    def test_recovers_remote_create_and_reissues_plaintext_token(
+        self,
+        request_json,
+    ):
+        remote_uuid = uuid.uuid4()
+        lookup_name = f"gateway-hfl-gateway-link-{self.link.id}"
+        self.link.lensnode_provision_state_json = {
+            "lookup_name": lookup_name,
+            "status": "error",
+        }
+        self.link.lensnode_provision_claim_token = uuid.uuid4()
+        self.link.lensnode_provision_claimed_at = timezone.now() - timedelta(
+            minutes=10
+        )
+        self.link.save()
+
+        def response_for(method, path, **_kwargs):
+            if method == "GET":
+                return [{"uuid": str(remote_uuid), "name": lookup_name}]
+            self.assertEqual(
+                path,
+                f"/api/lens/admin/lensnodes/{remote_uuid}/issue-token/",
+            )
+            return {"lensnode_uuid": str(remote_uuid), "token": "rotated-token"}
+
+        request_json.side_effect = response_for
+
+        result = provisioning.ensure_lensnode_for_gateway(
+            org=self.org,
+            gateway=self.gateway,
+            owner_user=self.user,
+            scope=LensGatewayLink.GatewayScope.USER,
+        )
+
+        self.assertEqual(result.sl_lensnode_uuid, remote_uuid)
+        self.assertEqual(result.config_json["lensnode_token"], "rotated-token")
+        self.assertFalse(
+            any(
+                call.args[:2]
+                == ("POST", "/api/lens/admin/lensnodes/")
+                for call in request_json.call_args_list
+            )
+        )
+
+    @mock.patch("apps.lens_bridge.services.provisioning.sl_client.request_json")
+    def test_live_lease_prevents_a_second_remote_create(self, request_json):
+        self.link.lensnode_provision_claim_token = uuid.uuid4()
+        self.link.lensnode_provision_claimed_at = timezone.now()
+        self.link.lensnode_provision_state_json = {
+            "lookup_name": f"gateway-hfl-gateway-link-{self.link.id}",
+            "status": "provisioning",
+        }
+        self.link.save()
+
+        with self.assertRaises(provisioning.LensNodeProvisionBusyError):
+            provisioning.ensure_lensnode_for_gateway(
+                org=self.org,
+                gateway=self.gateway,
+                owner_user=self.user,
+                scope=LensGatewayLink.GatewayScope.USER,
+            )
+
+        request_json.assert_not_called()
+
+    @mock.patch("apps.lens_bridge.services.provisioning.sl_client.request_json")
+    def test_recovery_never_rotates_token_owned_by_another_link(
+        self,
+        request_json,
+    ):
+        remote_uuid = uuid.uuid4()
+        lookup_name = f"gateway-hfl-gateway-link-{self.link.id}"
+        other_gateway = Node.objects.create(
+            organization=self.org,
+            name="Other gateway",
+            role=NodeRole.GATEWAY,
+        )
+        LensGatewayLink.objects.create(
+            organization=self.org,
+            gateway=other_gateway,
+            owner_user=self.user,
+            scope=LensGatewayLink.GatewayScope.USER,
+            sl_lensnode_uuid=remote_uuid,
+        )
+        self.link.lensnode_provision_state_json = {
+            "lookup_name": lookup_name,
+            "status": "error",
+        }
+        self.link.save(update_fields=["lensnode_provision_state_json"])
+        request_json.return_value = [
+            {"uuid": str(remote_uuid), "name": lookup_name}
+        ]
+
+        with self.assertRaises(provisioning.sl_client.LensBridgeError):
+            provisioning.ensure_lensnode_for_gateway(
+                org=self.org,
+                gateway=self.gateway,
+                owner_user=self.user,
+                scope=LensGatewayLink.GatewayScope.USER,
+            )
+
+        request_json.assert_called_once()
+
+    @mock.patch("apps.lens_bridge.services.provisioning.sl_client.request_json")
+    def test_private_gateway_owner_cannot_be_replaced(self, request_json):
+        another_user = get_user_model().objects.create_user(
+            username="other-lensnode-owner@example.test",
+            email="other-lensnode-owner@example.test",
+        )
+
+        with self.assertRaisesMessage(
+            Exception,
+            "Private data gateway belongs to another user.",
+        ):
+            provisioning.ensure_lensnode_for_gateway(
+                org=self.org,
+                gateway=self.gateway,
+                owner_user=another_user,
+                scope=LensGatewayLink.GatewayScope.USER,
+            )
+
+        request_json.assert_not_called()

--- a/src/backend/apps/lens_bridge/tests/test_gateway_paths.py
+++ b/src/backend/apps/lens_bridge/tests/test_gateway_paths.py
@@ -1,0 +1,46 @@
+from django.test import SimpleTestCase
+
+from apps.lens_bridge.services.gateway_paths import (
+    GatewayPathError,
+    path_within_root,
+)
+from apps.lens_bridge.models import LensGatewayLink
+
+
+class GatewayPathTests(SimpleTestCase):
+    def test_gateway_default_mount_exposes_data_only(self):
+        link = LensGatewayLink(organization_id=7)
+
+        self.assertEqual(link.resolved_workspace_root(), "/workspace/org-7/data")
+
+    def test_rejects_parent_traversal_before_normalization(self):
+        with self.assertRaises(GatewayPathError):
+            path_within_root(
+                "/workspace/org-7/data/../../etc",
+                "/workspace/org-7/data",
+                allow_root=True,
+            )
+
+    def test_rejects_sibling_prefix(self):
+        with self.assertRaises(GatewayPathError):
+            path_within_root(
+                "/workspace/org-7/database",
+                "/workspace/org-7/data",
+                allow_root=True,
+            )
+
+    def test_managed_workspace_must_be_strict_child(self):
+        with self.assertRaises(GatewayPathError):
+            path_within_root(
+                "/workspace/org-7/data",
+                "/workspace/org-7/data",
+                allow_root=False,
+            )
+
+    def test_browse_may_use_root_itself(self):
+        path = path_within_root(
+            "/workspace/org-7/data/",
+            "/workspace/org-7/data",
+            allow_root=True,
+        )
+        self.assertEqual(path, "/workspace/org-7/data")

--- a/src/backend/apps/lens_bridge/tests/test_knowledge_source_teardown.py
+++ b/src/backend/apps/lens_bridge/tests/test_knowledge_source_teardown.py
@@ -1,0 +1,232 @@
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from unittest import mock
+
+from django.contrib.auth import get_user_model
+from django.db import close_old_connections
+from django.test import TestCase, TransactionTestCase
+from django.urls import reverse
+from django.utils import timezone
+from rest_framework.test import APIClient
+
+from apps.iam.models import Membership, Organization
+from apps.lens_bridge.models import (
+    LensGatewayLink,
+    LensKnowledgeSource,
+    LensSessionLink,
+    LensWorkspaceBinding,
+)
+from apps.lens_bridge.services import knowledge_source_teardown
+from apps.node.models import Node
+from apps.lens_bridge.tasks.chat_lifecycle import (
+    reconcile_lens_resource_teardowns_task,
+)
+
+
+class KnowledgeSourceDeleteApiTests(TestCase):
+    def setUp(self):
+        self.organization = Organization.objects.create(
+            key="ks-delete-api",
+            name="KS delete API",
+        )
+        self.user = get_user_model().objects.create_user(
+            username="ks-delete-api@example.test",
+            email="ks-delete-api@example.test",
+        )
+        Membership.objects.create(
+            organization=self.organization,
+            user=self.user,
+            role=Membership.Role.OWNER,
+        )
+        self.gateway = Node.objects.create(
+            organization=self.organization,
+            name="private-gateway",
+            role=Node.Role.GATEWAY,
+        )
+        self.gateway_link = LensGatewayLink.objects.create(
+            organization=self.organization,
+            gateway=self.gateway,
+            owner_user=self.user,
+            scope=LensGatewayLink.GatewayScope.USER,
+            workspace_root="/workspace/org-1/data",
+        )
+        self.knowledge_source = LensKnowledgeSource.objects.create(
+            organization=self.organization,
+            name="Local KS",
+            gateway=self.gateway,
+            gateway_link=self.gateway_link,
+            source_path="/workspace/org-1/data/documents",
+            status=LensKnowledgeSource.Status.READY,
+            created_by=self.user,
+        )
+        LensWorkspaceBinding.objects.create(
+            organization=self.organization,
+            knowledge_source=self.knowledge_source,
+            gateway_link=self.gateway_link,
+            execution_organization_id=self.organization.id,
+            execution_node_id=self.gateway.id,
+            workspace_kind=LensWorkspaceBinding.WorkspaceKind.GATEWAY_LOCAL,
+            workspace_root="/workspace/org-1/data",
+            state=LensWorkspaceBinding.State.READY,
+            identity_status=LensWorkspaceBinding.IdentityStatus.NOT_APPLICABLE,
+        )
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.user)
+
+    @mock.patch(
+        "apps.lens_bridge.tasks.knowledge_source_teardown."
+        "execute_knowledge_source_teardown_task.delay"
+    )
+    def test_delete_returns_202_without_running_teardown_in_request(self, delay):
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.delete(
+                reverse(
+                    "lens-knowledge-source-detail",
+                    kwargs={"pk": self.knowledge_source.id},
+                ),
+                HTTP_X_ORG_KEY=self.organization.key,
+            )
+
+        self.assertEqual(response.status_code, 202)
+        self.knowledge_source.refresh_from_db()
+        self.assertEqual(
+            self.knowledge_source.lifecycle_status,
+            LensKnowledgeSource.LifecycleStatus.DELETING,
+        )
+        delay.assert_called_once_with(
+            knowledge_source_id=self.knowledge_source.id
+        )
+
+    def test_direct_delete_is_blocked_while_chat_owns_knowledge_source(self):
+        LensSessionLink.objects.create(
+            organization=self.organization,
+            hfl_user=self.user,
+            gateway_link=self.gateway_link,
+            knowledge_source=self.knowledge_source,
+            lifecycle_status=LensSessionLink.LifecycleStatus.READY,
+        )
+
+        response = self.client.delete(
+            reverse(
+                "lens-knowledge-source-detail",
+                kwargs={"pk": self.knowledge_source.id},
+            ),
+            HTTP_X_ORG_KEY=self.organization.key,
+        )
+
+        self.assertEqual(response.status_code, 400)
+
+    @mock.patch(
+        "apps.lens_bridge.tasks.chat_lifecycle."
+        "execute_copilot_chat_teardown_task.delay"
+    )
+    @mock.patch(
+        "apps.lens_bridge.tasks.knowledge_source_teardown."
+        "execute_knowledge_source_teardown_task.delay"
+    )
+    def test_reconciler_queues_due_knowledge_source(self, ks_delay, chat_delay):
+        self.knowledge_source.lifecycle_status = (
+            LensKnowledgeSource.LifecycleStatus.DELETING
+        )
+        self.knowledge_source.teardown_next_retry_at = timezone.now()
+        self.knowledge_source.save(
+            update_fields=[
+                "lifecycle_status",
+                "teardown_next_retry_at",
+                "updated_at",
+            ]
+        )
+
+        result = reconcile_lens_resource_teardowns_task(limit=10)
+
+        self.assertEqual(result["queued"], 1)
+        ks_delay.assert_called_once_with(
+            knowledge_source_id=self.knowledge_source.id
+        )
+        chat_delay.assert_not_called()
+
+    @mock.patch(
+        "apps.node.services.internal.node_workload.get_node_workload_blockers"
+    )
+    def test_teardown_waits_for_active_restore_then_converges(self, blockers):
+        blockers.return_value = [mock.MagicMock(code="restore_active")]
+        self.knowledge_source.lifecycle_status = (
+            LensKnowledgeSource.LifecycleStatus.DELETING
+        )
+        self.knowledge_source.save(
+            update_fields=["lifecycle_status", "updated_at"]
+        )
+
+        with self.assertRaises(
+            knowledge_source_teardown.KnowledgeSourceTeardownIncompleteError
+        ):
+            knowledge_source_teardown.run_knowledge_source_teardown(
+                knowledge_source_id=self.knowledge_source.id
+            )
+
+        self.knowledge_source.refresh_from_db()
+        self.knowledge_source.teardown_next_retry_at = timezone.now()
+        self.knowledge_source.save(
+            update_fields=["teardown_next_retry_at", "updated_at"]
+        )
+        blockers.return_value = []
+        result = knowledge_source_teardown.run_knowledge_source_teardown(
+            knowledge_source_id=self.knowledge_source.id
+        )
+
+        self.assertEqual(result["status"], "deleted")
+
+
+class KnowledgeSourceTeardownConcurrencyTests(TransactionTestCase):
+    reset_sequences = True
+
+    def test_two_workers_receive_only_one_claim(self):
+        organization = Organization.objects.create(
+            key="ks-teardown-concurrency",
+            name="KS teardown concurrency",
+        )
+        user = get_user_model().objects.create_user(
+            username="ks-teardown-concurrency@example.test",
+            email="ks-teardown-concurrency@example.test",
+        )
+        gateway = Node.objects.create(
+            organization=organization,
+            name="gateway",
+            role=Node.Role.GATEWAY,
+        )
+        gateway_link = LensGatewayLink.objects.create(
+            organization=organization,
+            gateway=gateway,
+            owner_user=user,
+            scope=LensGatewayLink.GatewayScope.USER,
+        )
+        knowledge_source = LensKnowledgeSource.objects.create(
+            organization=organization,
+            name="Concurrent KS",
+            gateway=gateway,
+            gateway_link=gateway_link,
+            source_path="/workspace/data",
+            status=LensKnowledgeSource.Status.READY,
+            lifecycle_status=LensKnowledgeSource.LifecycleStatus.DELETING,
+        )
+        barrier = threading.Barrier(2)
+
+        def claim():
+            close_old_connections()
+            try:
+                barrier.wait(timeout=5)
+                return knowledge_source_teardown._claim(knowledge_source.id)
+            finally:
+                close_old_connections()
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            results = list(executor.map(lambda _index: claim(), range(2)))
+
+        self.assertEqual(
+            sum(1 for token, _status in results if token is not None),
+            1,
+        )
+        self.assertEqual(
+            {status for token, status in results if token is None},
+            {"busy"},
+        )

--- a/src/backend/apps/lens_bridge/tests/test_platform_lens.py
+++ b/src/backend/apps/lens_bridge/tests/test_platform_lens.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from unittest import mock
 
+from django.db import IntegrityError, transaction
 from django.test import TestCase
 
 from apps.lens_bridge.models import LensGatewayLink
@@ -50,3 +51,68 @@ class PlatformGatewaySelectionTests(TestCase):
             resolved = platform_lens.resolve_platform_default_gateway_link()
 
         self.assertEqual(resolved, selected)
+
+    def test_database_rejects_multiple_live_platform_defaults(self):
+        org = platform_lens.get_or_create_platform_org()
+        first_gateway = Node.objects.create(
+            organization=org,
+            name="first-default",
+            role=NodeRole.GATEWAY,
+        )
+        second_gateway = Node.objects.create(
+            organization=org,
+            name="second-default",
+            role=NodeRole.GATEWAY,
+        )
+        LensGatewayLink.objects.create(
+            organization=org,
+            gateway=first_gateway,
+            scope=LensGatewayLink.GatewayScope.PLATFORM,
+            owner_user=None,
+            is_platform_default=True,
+        )
+
+        with self.assertRaises(IntegrityError), transaction.atomic():
+            LensGatewayLink.objects.create(
+                organization=org,
+                gateway=second_gateway,
+                scope=LensGatewayLink.GatewayScope.PLATFORM,
+                owner_user=None,
+                is_platform_default=True,
+            )
+
+    @mock.patch(
+        "apps.lens_bridge.services.platform_lens.require_hfl_usable_gateway"
+    )
+    def test_setting_a_new_default_clears_the_previous_default(self, _ready):
+        org = platform_lens.get_or_create_platform_org()
+        first_gateway = Node.objects.create(
+            organization=org,
+            name="previous-default",
+            role=NodeRole.GATEWAY,
+        )
+        second_gateway = Node.objects.create(
+            organization=org,
+            name="replacement-default",
+            role=NodeRole.GATEWAY,
+        )
+        previous = LensGatewayLink.objects.create(
+            organization=org,
+            gateway=first_gateway,
+            scope=LensGatewayLink.GatewayScope.PLATFORM,
+            owner_user=None,
+            is_platform_default=True,
+        )
+        replacement = LensGatewayLink.objects.create(
+            organization=org,
+            gateway=second_gateway,
+            scope=LensGatewayLink.GatewayScope.PLATFORM,
+            owner_user=None,
+        )
+
+        platform_lens.set_platform_default_gateway(gateway_link_id=replacement.id)
+
+        previous.refresh_from_db()
+        replacement.refresh_from_db()
+        self.assertFalse(previous.is_platform_default)
+        self.assertTrue(replacement.is_platform_default)

--- a/src/backend/apps/lens_bridge/tests/test_provisioning.py
+++ b/src/backend/apps/lens_bridge/tests/test_provisioning.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock, patch
 
 from django.test import SimpleTestCase
+from rest_framework.exceptions import ValidationError
 
 from apps.lens_bridge.services import sl_client
 from apps.lens_bridge.services.provisioning import _lensnode_dir_paths
@@ -117,30 +118,123 @@ class SlLensnodeSnapshotTests(SimpleTestCase):
 
 
 class EnsureKsWorkspaceTests(SimpleTestCase):
+    @patch("apps.lens_bridge.services.gateway_execution.context_for_gateway_link")
     @patch("apps.lens_bridge.services.provisioning.wait_for_lensnode_dir")
     @patch("apps.node.services.internal.agent_task.run_agent_task_sync")
-    def test_dispatches_prepare_task(self, mock_sync, mock_wait):
+    def test_dispatches_prepare_task(self, mock_sync, mock_wait, mock_context):
         from apps.lens_bridge.services import provisioning
 
         task = MagicMock()
         task.last_error = ""
         mock_sync.return_value = MagicMock(ok=True, task=task)
 
-        org = MagicMock()
+        org = MagicMock(id=1)
         gateway = MagicMock(id=134)
-        link = MagicMock()
+        link = MagicMock(id=7)
         link.sl_lensnode_uuid = "de240f46-eccd-4e4b-868f-b1f504fbe67b"
         link.resolved_workspace_root.return_value = "/workspace/org-1"
+        mock_context.return_value = MagicMock(
+            gateway=gateway,
+            execution_organization=MagicMock(id=99),
+        )
+        workspace_binding = MagicMock(
+            gateway_link_id=7,
+            execution_node_id=134,
+            execution_organization_id=99,
+            workspace_root="/workspace/org-1",
+            workspace_uid="workspace-9",
+            knowledge_source_id=9,
+            workspace_kind="managed_restore",
+        )
+        workspace_binding.resolved_path.return_value = "/workspace/org-1/ks-9"
 
         provisioning.ensure_ks_workspace_on_gateway(
             org=org,
             gateway=gateway,
             gateway_link=link,
-            workspace_path="/workspace/org-1/ks-9",
+            workspace_binding=workspace_binding,
         )
 
         mock_sync.assert_called_once()
         kwargs = mock_sync.call_args.kwargs
         self.assertEqual(kwargs["kind"], "lens.ks.prepare")
         self.assertEqual(kwargs["payload"]["path"], "/workspace/org-1/ks-9")
+        self.assertEqual(kwargs["payload"]["workspace_uid"], "workspace-9")
+        self.assertEqual(kwargs["requesting_organization_id"], 1)
         mock_wait.assert_called_once()
+
+
+class BrowseGatewayDirectoryTests(SimpleTestCase):
+    @patch("apps.node.services.interface.run_agent_task_sync")
+    @patch("apps.lens_bridge.services.provisioning.get_gateway_link")
+    @patch("apps.lens_bridge.services.provisioning.require_gateway_node")
+    def test_dispatches_restricted_gateway_browse(
+        self,
+        require_gateway,
+        get_gateway_link,
+        run_agent_task,
+    ):
+        from apps.lens_bridge.services.provisioning import browse_gateway_directory
+
+        gateway = MagicMock(id=7, status="online")
+        require_gateway.return_value = gateway
+        link = MagicMock()
+        link.resolved_workspace_root.return_value = "/workspace/org-1/data"
+        get_gateway_link.return_value = link
+        run_agent_task.return_value = MagicMock(
+            ok=True,
+            timed_out=False,
+            result={
+                "path": "/workspace/org-1/data/documents",
+                "entries": [
+                    {
+                        "name": "reports",
+                        "path": "/workspace/org-1/data/documents/reports",
+                        "is_dir": True,
+                    },
+                    {
+                        "name": "escape",
+                        "path": "/etc",
+                        "is_dir": True,
+                    },
+                ],
+            },
+        )
+
+        result = browse_gateway_directory(
+            org=MagicMock(id=1),
+            gateway_id=7,
+            path="/workspace/org-1/data/documents",
+        )
+
+        kwargs = run_agent_task.call_args.kwargs
+        self.assertEqual(kwargs["kind"], "lens.gateway.browse")
+        self.assertEqual(
+            kwargs["payload"]["allowed_root"],
+            "/workspace/org-1/data",
+        )
+        self.assertEqual(
+            [entry["path"] for entry in result["entries"]],
+            ["/workspace/org-1/data/documents/reports"],
+        )
+
+    @patch("apps.lens_bridge.services.provisioning.get_gateway_link")
+    @patch("apps.lens_bridge.services.provisioning.require_gateway_node")
+    def test_rejects_traversal_without_dispatching(
+        self,
+        require_gateway,
+        get_gateway_link,
+    ):
+        from apps.lens_bridge.services.provisioning import browse_gateway_directory
+
+        require_gateway.return_value = MagicMock(id=7, status="online")
+        link = MagicMock()
+        link.resolved_workspace_root.return_value = "/workspace/org-1/data"
+        get_gateway_link.return_value = link
+
+        with self.assertRaises(ValidationError):
+            browse_gateway_directory(
+                org=MagicMock(id=1),
+                gateway_id=7,
+                path="/workspace/org-1/data/../../etc",
+            )

--- a/src/backend/apps/lens_bridge/tests/test_workspace_migrations.py
+++ b/src/backend/apps/lens_bridge/tests/test_workspace_migrations.py
@@ -1,0 +1,126 @@
+import json
+
+from django.contrib.auth import get_user_model
+from django.db import IntegrityError, transaction
+from django.test import TestCase
+
+from apps.iam.models import Organization
+from apps.lens_bridge.models import (
+    LensGatewayLink,
+    LensKnowledgeSource,
+    LensWorkspaceBinding,
+)
+from apps.node.models import Node
+from apps.node.services.internal.task import create_agent_task
+
+
+class WorkspaceInvariantTests(TestCase):
+    def setUp(self):
+        self.organization = Organization.objects.create(
+            key="workspace-invariant-org",
+            name="Workspace invariant",
+        )
+        self.user = get_user_model().objects.create_user(
+            username="workspace-invariant@example.test",
+            email="workspace-invariant@example.test",
+        )
+        self.gateway = Node.objects.create(
+            organization=self.organization,
+            name="private-gateway",
+            role=Node.Role.GATEWAY,
+        )
+        self.link = LensGatewayLink.objects.create(
+            organization=self.organization,
+            gateway=self.gateway,
+            owner_user=self.user,
+            scope=LensGatewayLink.GatewayScope.USER,
+            workspace_root="/workspace/tenant/data",
+        )
+
+    def _knowledge_source(self, *, name: str = "Managed KS") -> LensKnowledgeSource:
+        return LensKnowledgeSource.objects.create(
+            organization=self.organization,
+            name=name,
+            gateway=self.gateway,
+            gateway_link=self.link,
+            backup_source_snapshot_id=7,
+            backup_snapshot_directory_id=8,
+            source_path="/data",
+            created_by=self.user,
+        )
+
+    def test_resolved_path_rejects_parent_traversal(self):
+        binding = LensWorkspaceBinding(
+            organization=self.organization,
+            knowledge_source=self._knowledge_source(),
+            gateway_link=self.link,
+            execution_organization_id=self.organization.id,
+            execution_node_id=self.gateway.id,
+            workspace_kind=LensWorkspaceBinding.WorkspaceKind.MANAGED_RESTORE,
+            workspace_root="/workspace/tenant/data",
+            relative_path="../another-tenant",
+        )
+
+        with self.assertRaises(ValueError):
+            binding.resolved_path()
+
+    def test_database_rejects_managed_workspace_without_relative_path(self):
+        with self.assertRaises(IntegrityError), transaction.atomic():
+            LensWorkspaceBinding.objects.create(
+                organization=self.organization,
+                knowledge_source=self._knowledge_source(),
+                gateway_link=self.link,
+                execution_organization_id=self.organization.id,
+                execution_node_id=self.gateway.id,
+                workspace_kind=LensWorkspaceBinding.WorkspaceKind.MANAGED_RESTORE,
+                workspace_root="/workspace/tenant/data",
+                relative_path="",
+                state=LensWorkspaceBinding.State.PREPARING,
+                identity_status=LensWorkspaceBinding.IdentityStatus.PENDING,
+            )
+
+    def test_database_rejects_private_gateway_without_owner(self):
+        another_gateway = Node.objects.create(
+            organization=self.organization,
+            name="ownerless-gateway",
+            role=Node.Role.GATEWAY,
+        )
+        with self.assertRaises(IntegrityError), transaction.atomic():
+            LensGatewayLink.objects.create(
+                organization=self.organization,
+                gateway=another_gateway,
+                scope=LensGatewayLink.GatewayScope.USER,
+            )
+
+    def test_workspace_identity_payload_persists_as_json(self):
+        from apps.lens_bridge.services.gateway_execution import (
+            workspace_identity_payload,
+        )
+
+        binding = LensWorkspaceBinding.objects.create(
+            organization=self.organization,
+            knowledge_source=self._knowledge_source(name="JSON-safe KS"),
+            gateway_link=self.link,
+            execution_organization_id=self.organization.id,
+            execution_node_id=self.gateway.id,
+            workspace_kind=LensWorkspaceBinding.WorkspaceKind.MANAGED_RESTORE,
+            workspace_root="/workspace/tenant/data",
+            relative_path="tenants/1/knowledge-sources/json-safe",
+            state=LensWorkspaceBinding.State.PREPARING,
+            identity_status=LensWorkspaceBinding.IdentityStatus.PENDING,
+        )
+        payload = {
+            "path": binding.resolved_path(),
+            **workspace_identity_payload(binding),
+        }
+
+        json.dumps(payload)
+        task = create_agent_task(
+            org=self.organization,
+            node=self.gateway,
+            kind="lens.ks.prepare",
+            payload=payload,
+        )
+
+        self.assertEqual(task.payload["workspace_uid"], str(binding.workspace_uid))
+        self.assertEqual(task.requesting_organization_id, self.organization.id)

--- a/src/backend/apps/node/migrations/0008_nodetask_requesting_organization.py
+++ b/src/backend/apps/node/migrations/0008_nodetask_requesting_organization.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("node", "0007_nodetask_delivery_ack"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="nodetask",
+            name="requesting_organization_id",
+            field=models.BigIntegerField(db_index=True, default=0),
+            preserve_default=False,
+        ),
+    ]

--- a/src/backend/apps/node/models/node_task.py
+++ b/src/backend/apps/node/models/node_task.py
@@ -27,6 +27,7 @@ class NodeTask(OrganizationScopedModel):
         on_delete=models.CASCADE,
         related_name="node_tasks",
     )
+    requesting_organization_id = models.BigIntegerField(db_index=True)
     node = models.ForeignKey(
         "node.Node",
         on_delete=models.CASCADE,
@@ -87,3 +88,8 @@ class NodeTask(OrganizationScopedModel):
 
     def __str__(self) -> str:
         return f"{self.kind}@{self.pk} ({self.status})"
+
+    def save(self, *args, **kwargs) -> None:
+        if self.requesting_organization_id is None:
+            self.requesting_organization_id = self.organization_id
+        super().save(*args, **kwargs)

--- a/src/backend/apps/node/services/internal/agent_task.py
+++ b/src/backend/apps/node/services/internal/agent_task.py
@@ -106,6 +106,7 @@ def run_agent_task_async(
     payload: dict | None = None,
     correlation_type: str = "",
     correlation_id: str = "",
+    requesting_organization_id: int | None = None,
 ) -> AgentTaskHandle:
     """
     Long-running work: dispatch and return immediately; caller polls status.
@@ -129,6 +130,7 @@ def run_agent_task_async(
         payload=payload,
         correlation_type=correlation_type,
         correlation_id=correlation_id,
+        requesting_organization_id=requesting_organization_id,
     )
     return AgentTaskHandle(task_id=str(task.id), task=task)
 
@@ -223,6 +225,7 @@ def run_agent_task_sync(
     persisted_payload: dict | None = None,
     correlation_type: str = "",
     correlation_id: str = "",
+    requesting_organization_id: int | None = None,
     wait_timeout_seconds: int | None = None,
     on_stream_message: Callable[[dict[str, Any]], None] | None = None,
 ) -> AgentTaskSyncResult:
@@ -250,6 +253,7 @@ def run_agent_task_sync(
             payload=persisted_payload if persisted_payload is not None else payload,
             correlation_type=correlation_type,
             correlation_id=correlation_id,
+            requesting_organization_id=requesting_organization_id,
         )
         task_id = task.id
 

--- a/src/backend/apps/node/services/internal/agent_uninstall.py
+++ b/src/backend/apps/node/services/internal/agent_uninstall.py
@@ -182,11 +182,14 @@ def _purge_agent_server_records(
 
 
 def _purge_gateway_lens_records(*, org: Organization, gateway: Node, user) -> None:
-    from apps.lens_bridge.models import LensGatewayLink, LensKnowledgeSource
+    from apps.lens_bridge.models import (
+        LensGatewayLink,
+        LensKnowledgeSource,
+        LensWorkspaceBinding,
+    )
     from apps.node.exceptions import NodeLifecycleError
 
     knowledge_sources = LensKnowledgeSource.objects.filter(
-        organization_id=org.id,
         gateway=gateway,
         is_deleted=False,
     )
@@ -201,6 +204,24 @@ def _purge_gateway_lens_records(*, org: Organization, gateway: Node, user) -> No
                     "detail": f'Knowledge Source "{source.name}" is still bound.',
                 }
                 for source in knowledge_sources.order_by("id")
+            ],
+        )
+
+    pending_bindings = LensWorkspaceBinding.objects.filter(
+        execution_node_id=gateway.id,
+        is_deleted=False,
+    ).exclude(state=LensWorkspaceBinding.State.DELETED)
+    if pending_bindings.exists():
+        raise NodeLifecycleError(
+            "Data Gateway still has managed workspaces awaiting cleanup.",
+            code="node_remove_blocked",
+            blockers=[
+                {
+                    "code": "workspace_cleanup_pending",
+                    "workspace_binding_id": binding.id,
+                    "detail": f"Managed workspace {binding.workspace_uid} is not deleted.",
+                }
+                for binding in pending_bindings.order_by("id")
             ],
         )
 

--- a/src/backend/apps/node/services/internal/local_platform_gateway.py
+++ b/src/backend/apps/node/services/internal/local_platform_gateway.py
@@ -8,6 +8,7 @@ from django.db import transaction
 from django.db.models import Q
 from django.utils import timezone
 
+from apps.iam.models import Organization
 from apps.lens_bridge.models import LensGatewayLink
 from apps.lens_bridge.services import platform_lens
 from apps.node.models import NodeToken
@@ -59,6 +60,7 @@ def platform_gateway_api_base() -> str:
 def ensure_local_platform_gateway_token() -> NodeToken:
     """Return a reusable enrollment token for the installer-managed Gateway."""
     org = platform_lens.get_or_create_platform_org()
+    Organization.objects.select_for_update().get(pk=org.pk)
     now = timezone.now()
     token = (
         NodeToken.objects.select_for_update()
@@ -118,6 +120,7 @@ def reconcile_local_platform_gateway_links() -> int:
     from apps.node.models import Node
 
     org = platform_lens.get_or_create_platform_org()
+    Organization.objects.select_for_update().get(pk=org.pk)
     managed_gateway_ids = list(
         Node.objects.filter(
             organization=org,
@@ -140,6 +143,7 @@ def reconcile_local_platform_gateway_links() -> int:
         .filter(
             organization=org,
             gateway_id__in=managed_gateway_ids,
+            scope=LensGatewayLink.GatewayScope.PLATFORM,
             is_deleted=False,
         )
         .order_by("id")
@@ -150,9 +154,6 @@ def reconcile_local_platform_gateway_links() -> int:
     changed = 0
     for link in links:
         update_fields = []
-        if link.scope != LensGatewayLink.GatewayScope.PLATFORM:
-            link.scope = LensGatewayLink.GatewayScope.PLATFORM
-            update_fields.append("scope")
         if link.origin != LensGatewayLink.Origin.PLATFORM:
             link.origin = LensGatewayLink.Origin.PLATFORM
             update_fields.append("origin")

--- a/src/backend/apps/node/services/internal/node_workload.py
+++ b/src/backend/apps/node/services/internal/node_workload.py
@@ -166,10 +166,9 @@ def get_node_remove_blockers(*, node: Node) -> list[NodeWorkloadBlocker]:
     if node.role != NodeRole.GATEWAY:
         return blockers
 
-    from apps.lens_bridge.models import LensKnowledgeSource
+    from apps.lens_bridge.models import LensKnowledgeSource, LensWorkspaceBinding
 
     knowledge_sources = LensKnowledgeSource.objects.filter(
-        organization_id=node.organization_id,
         gateway_id=node.id,
         is_deleted=False,
     ).order_by("id")
@@ -181,6 +180,19 @@ def get_node_remove_blockers(*, node: Node) -> list[NodeWorkloadBlocker]:
             label=f'Knowledge Source · {source.name}',
         )
         for source in knowledge_sources
+    )
+    active_bindings = LensWorkspaceBinding.objects.filter(
+        execution_node_id=node.id,
+        is_deleted=False,
+    ).exclude(state=LensWorkspaceBinding.State.DELETED)
+    blockers.extend(
+        NodeWorkloadBlocker(
+            code="workspace_cleanup_pending",
+            task_uuid=f"workspace_binding:{binding.id}",
+            task_type="lens_workspace_binding",
+            label=f"Managed Workspace · {binding.workspace_uid}",
+        )
+        for binding in active_bindings.order_by("id")
     )
     return blockers
 

--- a/src/backend/apps/node/services/internal/task.py
+++ b/src/backend/apps/node/services/internal/task.py
@@ -348,6 +348,7 @@ def create_agent_task(
     payload: dict | None = None,
     correlation_type: str = "",
     correlation_id: str = "",
+    requesting_organization_id: int | None = None,
 ) -> NodeTask:
     if node.organization_id != org.id:
         raise ValueError("node/org mismatch")
@@ -355,6 +356,7 @@ def create_agent_task(
     now = timezone.now()
     task = NodeTask.objects.create(
         organization=org,
+        requesting_organization_id=requesting_organization_id or org.id,
         node=node,
         correlation_type=correlation_type or "",
         correlation_id=str(correlation_id or ""),
@@ -627,6 +629,7 @@ def dispatch_task(
     payload: dict | None = None,
     correlation_type: str = "",
     correlation_id: str = "",
+    requesting_organization_id: int | None = None,
 ) -> NodeTask:
     task = create_agent_task(
         org=org,
@@ -635,6 +638,7 @@ def dispatch_task(
         payload=payload,
         correlation_type=correlation_type,
         correlation_id=correlation_id,
+        requesting_organization_id=requesting_organization_id,
     )
     transaction.on_commit(
         lambda bound_task=task: deliver_agent_task(task=bound_task),

--- a/src/backend/apps/node/tests/test_local_platform_gateway.py
+++ b/src/backend/apps/node/tests/test_local_platform_gateway.py
@@ -6,8 +6,10 @@ import io
 import json
 from unittest import mock
 
+from django.contrib.auth import get_user_model
 from django.core.management import call_command
 from django.test import SimpleTestCase, TestCase, override_settings
+from rest_framework.exceptions import ValidationError
 from rest_framework.test import APIRequestFactory
 
 from apps.lens_bridge.models import LensGatewayLink
@@ -62,6 +64,10 @@ class LocalPlatformGatewayConfigTests(SimpleTestCase):
 class LocalPlatformGatewayEnrollmentTests(TestCase):
     def setUp(self):
         self.factory = APIRequestFactory()
+        self.user = get_user_model().objects.create_user(
+            username="gateway-owner@example.test",
+            email="gateway-owner@example.test",
+        )
 
     def test_token_is_reused(self):
         first = ensure_local_platform_gateway_token()
@@ -79,14 +85,6 @@ class LocalPlatformGatewayEnrollmentTests(TestCase):
             name="managed-gateway",
             role=NodeRole.GATEWAY,
             metadata=dict(LOCAL_PLATFORM_GATEWAY_METADATA),
-        )
-        stale_link = LensGatewayLink.objects.create(
-            organization=org,
-            gateway=managed,
-            scope=LensGatewayLink.GatewayScope.USER,
-            origin=LensGatewayLink.Origin.USER,
-            sl_lensnode_uuid="0d16cf33-5c21-471e-9cbd-b5e9819ff19c",
-            is_platform_default=True,
         )
         Node.objects.create(
             organization=org,
@@ -110,10 +108,6 @@ class LocalPlatformGatewayEnrollmentTests(TestCase):
         )
         self.assertTrue(payload["token"])
         self.assertEqual(payload["managed_node_ids"], [managed.id])
-        stale_link.refresh_from_db()
-        self.assertEqual(stale_link.scope, LensGatewayLink.GatewayScope.PLATFORM)
-        self.assertEqual(stale_link.origin, LensGatewayLink.Origin.PLATFORM)
-        self.assertTrue(stale_link.is_platform_default)
 
     @mock.patch(
         "apps.lens_bridge.services.provisioning.provision_gateway_lens_on_register",
@@ -164,34 +158,6 @@ class LocalPlatformGatewayEnrollmentTests(TestCase):
         )
         self.assertIsNone(mock_provision.call_args_list[1].kwargs["scope"])
 
-    def test_managed_gateway_repairs_stale_scope_without_explicit_token_scope(self):
-        org = platform_lens.get_or_create_platform_org()
-        gateway = Node.objects.create(
-            organization=org,
-            name="managed-gateway",
-            role=NodeRole.GATEWAY,
-            metadata=dict(LOCAL_PLATFORM_GATEWAY_METADATA),
-        )
-        link = LensGatewayLink.objects.create(
-            organization=org,
-            gateway=gateway,
-            scope=LensGatewayLink.GatewayScope.USER,
-            origin=LensGatewayLink.Origin.USER,
-            sl_lensnode_uuid="5ed4b4d1-b9b0-456d-8d73-cc88d948877b",
-        )
-
-        result = provisioning.ensure_lensnode_for_gateway(
-            org=org,
-            gateway=gateway,
-            scope=None,
-        )
-
-        result.refresh_from_db()
-        self.assertEqual(result.pk, link.pk)
-        self.assertEqual(result.scope, LensGatewayLink.GatewayScope.PLATFORM)
-        self.assertEqual(result.origin, LensGatewayLink.Origin.PLATFORM)
-        self.assertTrue(result.is_platform_default)
-
     def test_unknown_scope_preserves_existing_non_platform_identity(self):
         org = platform_lens.get_or_create_platform_org()
         gateway = Node.objects.create(
@@ -202,6 +168,7 @@ class LocalPlatformGatewayEnrollmentTests(TestCase):
         LensGatewayLink.objects.create(
             organization=org,
             gateway=gateway,
+            owner_user=self.user,
             scope=LensGatewayLink.GatewayScope.USER,
             origin=LensGatewayLink.Origin.EXTERNAL,
             sl_lensnode_uuid="a3b9975f-cded-4c0a-a754-ec6f954d2b2c",
@@ -216,6 +183,35 @@ class LocalPlatformGatewayEnrollmentTests(TestCase):
         result.refresh_from_db()
         self.assertEqual(result.scope, LensGatewayLink.GatewayScope.USER)
         self.assertEqual(result.origin, LensGatewayLink.Origin.EXTERNAL)
+
+    def test_platform_to_private_conversion_is_rejected(self):
+        org = platform_lens.get_or_create_platform_org()
+        gateway = Node.objects.create(
+            organization=org,
+            name="converted-private-gateway",
+            role=NodeRole.GATEWAY,
+        )
+        LensGatewayLink.objects.create(
+            organization=org,
+            gateway=gateway,
+            scope=LensGatewayLink.GatewayScope.PLATFORM,
+            origin=LensGatewayLink.Origin.PLATFORM,
+            sl_lensnode_uuid="d896d7ee-9903-4d55-9050-44e3f93c0103",
+            is_platform_default=True,
+        )
+
+        with self.assertRaises(ValidationError):
+            provisioning.ensure_lensnode_for_gateway(
+                org=org,
+                gateway=gateway,
+                owner_user=self.user,
+                scope=LensGatewayLink.GatewayScope.USER,
+            )
+
+        link = LensGatewayLink.objects.get(gateway=gateway)
+        self.assertEqual(link.scope, LensGatewayLink.GatewayScope.PLATFORM)
+        self.assertIsNone(link.owner_user)
+        self.assertTrue(link.is_platform_default)
 
     @mock.patch(
         "apps.lens_bridge.services.provisioning.sl_client.request_json",

--- a/src/backend/apps/node/tests/test_node_lifecycle.py
+++ b/src/backend/apps/node/tests/test_node_lifecycle.py
@@ -173,7 +173,7 @@ class NodeLifecycleTests(TestCase):
         self.assertEqual(ctx.exception.code, "node_workload_active")
 
     def test_force_gateway_remove_does_not_bypass_knowledge_source_binding(self):
-        from apps.lens_bridge.models import LensKnowledgeSource
+        from apps.lens_bridge.models import LensGatewayLink, LensKnowledgeSource
 
         gateway = Node.objects.create(
             organization=self.org,
@@ -181,9 +181,16 @@ class NodeLifecycleTests(TestCase):
             role=NodeRole.GATEWAY,
             status=Node.Status.ONLINE,
         )
+        gateway_link = LensGatewayLink.objects.create(
+            organization=self.org,
+            gateway=gateway,
+            owner_user=self.user,
+            scope=LensGatewayLink.GatewayScope.USER,
+        )
         LensKnowledgeSource.objects.create(
             organization=self.org,
             gateway=gateway,
+            gateway_link=gateway_link,
             name="Bound knowledge source",
             source_path="/protected/source",
         )

--- a/src/backend/apps/platform_ops/api/views/lens.py
+++ b/src/backend/apps/platform_ops/api/views/lens.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import uuid
 from datetime import timedelta
 
+from django.db import transaction
 from django.utils import timezone
 from rest_framework import status
 from rest_framework.exceptions import ValidationError
@@ -591,16 +592,25 @@ class PlatformOpsLensAssistantView(APIView):
                 org,
                 uuid.UUID(str(assistant_uuid)),
                 user=request.user,
-                manage=True,
+                can_manage_all=True,
             )
             return Response(data)
-        rows = list_org_assistants(org, user=request.user, manage=True)
+        rows = list_org_assistants(
+            org,
+            user=request.user,
+            can_manage_all=True,
+        )
         return Response(rows)
 
     def post(self, request):
         org = _platform_org()
         try:
-            data = create_org_assistant(org, dict(request.data), user=request.user)
+            data = create_org_assistant(
+                org,
+                dict(request.data),
+                user=request.user,
+                platform_passthrough=True,
+            )
         except ValidationError:
             raise
         except sl_client.LensBridgeError as exc:
@@ -615,6 +625,8 @@ class PlatformOpsLensAssistantView(APIView):
                 uuid.UUID(str(assistant_uuid)),
                 dict(request.data),
                 user=request.user,
+                can_manage_all=True,
+                platform_passthrough=True,
             )
         except ValidationError:
             raise
@@ -624,7 +636,12 @@ class PlatformOpsLensAssistantView(APIView):
 
     def delete(self, request, assistant_uuid):
         org = _platform_org()
-        delete_org_assistant(org, uuid.UUID(str(assistant_uuid)))
+        delete_org_assistant(
+            org,
+            uuid.UUID(str(assistant_uuid)),
+            user=request.user,
+            can_manage_all=True,
+        )
         return Response(status=status.HTTP_204_NO_CONTENT)
 
 
@@ -709,24 +726,57 @@ class PlatformOpsLensKnowledgeSourceView(APIView):
 
     def post(self, request):
         org = _platform_org()
-        body = LensKnowledgeSourceCreateSerializer(data=request.data, context={"org": org})
+        body = LensKnowledgeSourceCreateSerializer(
+            data=request.data,
+            context={
+                "org": org,
+                "gateway_scope": LensGatewayLink.GatewayScope.PLATFORM,
+            },
+        )
         body.is_valid(raise_exception=True)
-        gateway = provisioning.require_gateway_node(org, body.validated_data["gateway"].id)
-        gateway_link = provisioning.get_gateway_link(org, gateway.id)
-        if gateway_link.scope != LensGatewayLink.GatewayScope.PLATFORM:
-            gateway_link.scope = LensGatewayLink.GatewayScope.PLATFORM
-            gateway_link.save(update_fields=["scope", "updated_at"])
-        ks = body.save(
-            organization=org,
-            created_by=request.user,
-            sl_lensnode_uuid=gateway_link.sl_lensnode_uuid,
-        )
-        ks = knowledge_source_sync.prepare_new_knowledge_source(org=org, ks=ks)
-        knowledge_source_sync.enqueue_knowledge_source_sync(
-            organization_id=org.id,
-            knowledge_source_id=ks.id,
-            mode="full",
-        )
+        with transaction.atomic():
+            gateway = provisioning.require_gateway_node(
+                org,
+                body.validated_data["gateway"].id,
+            )
+            gateway_link = (
+                LensGatewayLink.objects.select_for_update()
+                .filter(
+                    organization=org,
+                    gateway=gateway,
+                    scope=LensGatewayLink.GatewayScope.PLATFORM,
+                    is_deleted=False,
+                )
+                .first()
+            )
+            if gateway_link is None:
+                raise ValidationError(
+                    {
+                        "gateway_id": (
+                            "Platform knowledge sources require a platform "
+                            "data gateway."
+                        )
+                    }
+                )
+            ks = body.save(
+                organization=org,
+                created_by=request.user,
+                gateway_link=gateway_link,
+                sl_lensnode_uuid=gateway_link.sl_lensnode_uuid,
+            )
+            ks = knowledge_source_sync.prepare_new_knowledge_source(
+                org=org,
+                ks=ks,
+            )
+            transaction.on_commit(
+                lambda organization_id=org.id, knowledge_source_id=ks.id: (
+                    knowledge_source_sync.enqueue_knowledge_source_sync(
+                        organization_id=organization_id,
+                        knowledge_source_id=knowledge_source_id,
+                        mode="full",
+                    )
+                )
+            )
         return Response(
             LensKnowledgeSourceSerializer(ks, context={"org": org}).data,
             status=status.HTTP_201_CREATED,
@@ -737,6 +787,10 @@ class PlatformOpsLensKnowledgeSourceView(APIView):
         ks = LensKnowledgeSource.objects.filter(organization=org, pk=ks_id).first()
         if ks is None:
             return Response({"detail": "Not found."}, status=status.HTTP_404_NOT_FOUND)
+        if ks.lifecycle_status != LensKnowledgeSource.LifecycleStatus.READY:
+            raise ValidationError(
+                {"lifecycle_status": "Knowledge source is being deleted."}
+            )
         body = LensKnowledgeSourceUpdateSerializer(ks, data=request.data, partial=True, context={"org": org})
         body.is_valid(raise_exception=True)
         scan_changed = "scan_enabled" in body.validated_data
@@ -747,12 +801,19 @@ class PlatformOpsLensKnowledgeSourceView(APIView):
         return Response(LensKnowledgeSourceSerializer(ks, context={"org": org}).data)
 
     def delete(self, request, ks_id: int):
+        from apps.lens_bridge.services.knowledge_source_teardown import (
+            request_knowledge_source_teardown,
+        )
+
         org = _platform_org()
         ks = LensKnowledgeSource.objects.filter(organization=org, pk=ks_id).first()
         if ks is None:
             return Response({"detail": "Not found."}, status=status.HTTP_404_NOT_FOUND)
-        ks.delete()
-        return Response(status=status.HTTP_204_NO_CONTENT)
+        request_knowledge_source_teardown(ks)
+        return Response(
+            {"id": ks.id, "lifecycle_status": "deleting"},
+            status=status.HTTP_202_ACCEPTED,
+        )
 
 
 class PlatformOpsLensKnowledgeSourceSyncView(APIView):
@@ -790,6 +851,7 @@ class PlatformOpsLensGatewayBrowseView(APIView):
                 org=org,
                 gateway_id=int(gateway_id),
                 path=path,
+                expected_scope=LensGatewayLink.GatewayScope.PLATFORM,
             )
         except ValidationError as exc:
             return Response(exc.detail, status=status.HTTP_400_BAD_REQUEST)

--- a/src/backend/apps/platform_ops/tests/test_lens_knowledge_source.py
+++ b/src/backend/apps/platform_ops/tests/test_lens_knowledge_source.py
@@ -1,0 +1,81 @@
+"""Platform Ops Knowledge Source lifecycle tests."""
+
+from unittest.mock import patch
+
+from django.contrib.auth.models import User
+from django.test import TestCase, override_settings
+from rest_framework.test import APIClient
+
+from apps.lens_bridge.models import (
+    LensGatewayLink,
+    LensKnowledgeSource,
+    LensWorkspaceBinding,
+)
+from apps.lens_bridge.services import platform_lens
+from apps.node.models import Node
+
+
+@override_settings(HFL_PLATFORM_OPS_ENABLED=True)
+class PlatformOpsKnowledgeSourceTests(TestCase):
+    def setUp(self) -> None:
+        self.client = APIClient()
+        self.staff = User.objects.create_user(
+            username="platform-ks@example.test",
+            email="platform-ks@example.test",
+            is_staff=True,
+        )
+        self.client.force_authenticate(user=self.staff)
+        self.client.defaults["HTTP_X_HFL_SITE_ROLE"] = "ops"
+        organization = platform_lens.get_or_create_platform_org()
+        gateway = Node.objects.create(
+            organization=organization,
+            name="platform-gateway",
+            role=Node.Role.GATEWAY,
+        )
+        gateway_link = LensGatewayLink.objects.create(
+            organization=organization,
+            gateway=gateway,
+            scope=LensGatewayLink.GatewayScope.PLATFORM,
+            origin=LensGatewayLink.Origin.PLATFORM,
+            workspace_root=f"/workspace/org-{organization.id}/data",
+        )
+        self.knowledge_source = LensKnowledgeSource.objects.create(
+            organization=organization,
+            name="Platform KS",
+            gateway=gateway,
+            gateway_link=gateway_link,
+            source_path=f"/workspace/org-{organization.id}/data/documents",
+            status=LensKnowledgeSource.Status.READY,
+        )
+        LensWorkspaceBinding.objects.create(
+            organization=organization,
+            knowledge_source=self.knowledge_source,
+            gateway_link=gateway_link,
+            execution_organization_id=organization.id,
+            execution_node_id=gateway.id,
+            workspace_kind=LensWorkspaceBinding.WorkspaceKind.GATEWAY_LOCAL,
+            workspace_root=gateway_link.workspace_root,
+            state=LensWorkspaceBinding.State.READY,
+            identity_status=LensWorkspaceBinding.IdentityStatus.NOT_APPLICABLE,
+        )
+
+    @patch(
+        "apps.lens_bridge.tasks.knowledge_source_teardown."
+        "execute_knowledge_source_teardown_task.delay"
+    )
+    def test_delete_is_asynchronous(self, delay) -> None:
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.delete(
+                "/api/v1/platform-ops/lens/knowledge-sources/"
+                f"{self.knowledge_source.id}"
+            )
+
+        self.assertEqual(response.status_code, 202)
+        self.knowledge_source.refresh_from_db()
+        self.assertEqual(
+            self.knowledge_source.lifecycle_status,
+            LensKnowledgeSource.LifecycleStatus.DELETING,
+        )
+        delay.assert_called_once_with(
+            knowledge_source_id=self.knowledge_source.id
+        )

--- a/src/backend/apps/restore/migrations/0005_restore_execution_identity.py
+++ b/src/backend/apps/restore/migrations/0005_restore_execution_identity.py
@@ -1,0 +1,70 @@
+from django.db import migrations, models
+from django.db.models import Q
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("restore", "0004_alter_restorerecorditem_status"),
+        ("lens_bridge", "0022_workspace_binding"),
+        ("node", "0006_node_network_inventory"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="restorerecord",
+            name="requesting_organization_id",
+            field=models.BigIntegerField(db_index=True, default=0),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name="restorerecord",
+            name="target_execution_organization_id",
+            field=models.BigIntegerField(db_index=True, default=0),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name="restorerecord",
+            name="target_execution_node_id",
+            field=models.BigIntegerField(db_index=True, default=0),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name="restorerecord",
+            name="purpose",
+            field=models.CharField(
+                choices=[("user_data", "User data"), ("lens_workspace", "Lens workspace")],
+                db_index=True,
+                default="user_data",
+                max_length=24,
+            ),
+        ),
+        migrations.AddField(
+            model_name="restorerecord",
+            name="idempotency_key",
+            field=models.CharField(blank=True, default="", max_length=160),
+        ),
+        migrations.AddField(
+            model_name="restorerecord",
+            name="workspace_binding_id",
+            field=models.BigIntegerField(blank=True, db_index=True, null=True),
+        ),
+        migrations.AddConstraint(
+            model_name="restorerecord",
+            constraint=models.UniqueConstraint(
+                condition=Q(purpose="lens_workspace") & ~Q(idempotency_key=""),
+                fields=("organization_id", "purpose", "idempotency_key"),
+                name="uniq_restore_org_purpose_idem",
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name="restorerecord",
+            constraint=models.CheckConstraint(
+                condition=(
+                    Q(purpose="lens_workspace", workspace_binding_id__isnull=False)
+                    & ~Q(idempotency_key="")
+                    | Q(purpose="user_data", workspace_binding_id__isnull=True)
+                ),
+                name="restore_purpose_workspace_ck",
+            ),
+        ),
+    ]

--- a/src/backend/apps/restore/models/restore_record.py
+++ b/src/backend/apps/restore/models/restore_record.py
@@ -6,6 +6,10 @@ from django.db import models
 
 
 class RestoreRecord(models.Model):
+    class Purpose(models.TextChoices):
+        USER_DATA = "user_data", "User data"
+        LENS_WORKSPACE = "lens_workspace", "Lens workspace"
+
     class SourceMode(models.TextChoices):
         PLAN = "plan", "Plan"
         MANUAL = "manual", "Manual"
@@ -23,6 +27,17 @@ class RestoreRecord(models.Model):
         OVERWRITE = "overwrite", "Overwrite"
 
     organization_id = models.BigIntegerField(db_index=True)
+    requesting_organization_id = models.BigIntegerField(db_index=True)
+    target_execution_organization_id = models.BigIntegerField(db_index=True)
+    target_execution_node_id = models.BigIntegerField(db_index=True)
+    purpose = models.CharField(
+        max_length=24,
+        choices=Purpose.choices,
+        default=Purpose.USER_DATA,
+        db_index=True,
+    )
+    idempotency_key = models.CharField(max_length=160, blank=True, default="")
+    workspace_binding_id = models.BigIntegerField(null=True, blank=True, db_index=True)
     restore_uid = models.CharField(max_length=64)
     source_mode = models.CharField(max_length=16, choices=SourceMode.choices, db_index=True)
     plan_id = models.BigIntegerField(blank=True, null=True, db_index=True)
@@ -61,6 +76,28 @@ class RestoreRecord(models.Model):
             models.UniqueConstraint(
                 fields=["organization_id", "restore_uid"],
                 name="uniq_restore_record_uid",
+            ),
+            models.UniqueConstraint(
+                fields=["organization_id", "purpose", "idempotency_key"],
+                condition=(
+                    models.Q(purpose="lens_workspace")
+                    & ~models.Q(idempotency_key="")
+                ),
+                name="uniq_restore_org_purpose_idem",
+            ),
+            models.CheckConstraint(
+                condition=(
+                    models.Q(
+                        purpose="lens_workspace",
+                        workspace_binding_id__isnull=False,
+                    )
+                    & ~models.Q(idempotency_key="")
+                    | models.Q(
+                        purpose="user_data",
+                        workspace_binding_id__isnull=True,
+                    )
+                ),
+                name="restore_purpose_workspace_ck",
             ),
         ]
 

--- a/src/backend/apps/restore/selectors/interface.py
+++ b/src/backend/apps/restore/selectors/interface.py
@@ -34,7 +34,10 @@ def get_restore_plan(*, organization_id: int, plan_id: int) -> RestorePlan | Non
 
 def restore_records_queryset(*, organization_id: int) -> QuerySet[RestoreRecord]:
     return (
-        RestoreRecord.objects.filter(organization_id=organization_id)
+        RestoreRecord.objects.filter(
+            organization_id=organization_id,
+            purpose=RestoreRecord.Purpose.USER_DATA,
+        )
         .prefetch_related("items")
         .order_by("-created_at", "-id")
     )

--- a/src/backend/apps/restore/services/interface.py
+++ b/src/backend/apps/restore/services/interface.py
@@ -10,9 +10,10 @@ from typing import Any
 from uuid import uuid4
 
 from django.core.exceptions import ValidationError
-from django.db import transaction
+from django.db import IntegrityError, transaction
 
 from common.errors import AppError
+from apps.iam.models import Organization
 from apps.node.models import Node, NodeTask
 from apps.node.services.interface import cancel_agent_task, run_agent_task_async
 from apps.node.models.base import NodeRole
@@ -385,6 +386,25 @@ def create_manual_restore_record(
     data: dict[str, Any],
     user_id: int | None = None,
 ) -> RestoreRecord:
+    return _create_manual_restore_record(
+        organization_id=organization_id,
+        data=data,
+        user_id=user_id,
+        purpose=RestoreRecord.Purpose.USER_DATA,
+    )
+
+
+def _create_manual_restore_record(
+    *,
+    organization_id: int,
+    data: dict[str, Any],
+    user_id: int | None,
+    purpose: str,
+    target_execution_organization_id: int | None = None,
+    target_execution_node_id: int | None = None,
+    workspace_binding_id: int | None = None,
+    expected_target_path: str | None = None,
+) -> RestoreRecord:
     source_type = _choice(data, "source_type", SOURCE_TYPES)
     target_type = _choice(data, "target_type", SOURCE_TYPES)
     source_ref_id = _int(data, "source_ref_id")
@@ -399,12 +419,35 @@ def create_manual_restore_record(
         ref_id=source_ref_id,
         field="source_ref_id",
     )
-    _validate_endpoint_exists(
-        organization_id=organization_id,
-        endpoint_type=target_type,
-        ref_id=target_ref_id,
-        field="target_ref_id",
-    )
+    if purpose == RestoreRecord.Purpose.USER_DATA:
+        if target_execution_organization_id is not None or target_execution_node_id is not None:
+            raise ValueError("public restore cannot override its execution identity")
+        _validate_endpoint_exists(
+            organization_id=organization_id,
+            endpoint_type=target_type,
+            ref_id=target_ref_id,
+            field="target_ref_id",
+        )
+        execution_node = _target_execution_node(
+            organization_id=organization_id,
+            target_type=target_type,
+            target_ref_id=target_ref_id,
+        )
+        target_execution_organization_id = organization_id
+        target_execution_node_id = execution_node.id
+    else:
+        if purpose != RestoreRecord.Purpose.LENS_WORKSPACE:
+            raise ValueError("unsupported restore purpose")
+        if target_execution_organization_id is None or target_execution_node_id is None:
+            raise ValueError("lens workspace restore requires a validated execution binding")
+        if workspace_binding_id is None or expected_target_path is None:
+            raise ValueError("lens workspace restore requires an authoritative workspace binding")
+        if target_type != RestoreRecord.EndpointType.AGENT:
+            raise ValidationError({"target_type": "Lens workspace restore requires a data gateway."})
+        if target_execution_node_id != target_ref_id:
+            raise ValidationError({"target_ref_id": "Lens workspace target does not match its gateway binding."})
+        if target_path != expected_target_path:
+            raise ValidationError({"target_path": "Lens workspace target path is not authoritative."})
     snapshot = BackupSourceSnapshot.objects.filter(
         organization_id=organization_id,
         pk=source_snapshot_id,
@@ -434,6 +477,12 @@ def create_manual_restore_record(
                 "target_path": _path(item, "target_path", default=target_path),
                 "conflict_mode": _choice(item, "conflict_mode", CONFLICT_MODES, default=conflict_mode),
             }
+        )
+    if purpose == RestoreRecord.Purpose.LENS_WORKSPACE and any(
+        item["target_path"] != expected_target_path for item in item_inputs
+    ):
+        raise ValidationError(
+            {"items": "Lens workspace restore item paths must match the workspace binding."}
         )
     logger.info(
         "restore manual create started org_id=%s source_snapshot_id=%s source_type=%s source_ref_id=%s target_type=%s target_ref_id=%s item_count=%s user_id=%s",
@@ -466,6 +515,12 @@ def create_manual_restore_record(
             "idempotency_key": str(data.get("idempotency_key") or ""),
         },
         created_by_id=user_id,
+        purpose=purpose,
+        requesting_organization_id=organization_id,
+        target_execution_organization_id=target_execution_organization_id,
+        target_execution_node_id=target_execution_node_id,
+        idempotency_key=str(data.get("idempotency_key") or ""),
+        workspace_binding_id=workspace_binding_id,
     )
     logger.info(
         "restore manual create ok restore_record_id=%s restore_uid=%s task_uuid=%s",
@@ -474,6 +529,98 @@ def create_manual_restore_record(
         record.task_uuid,
     )
     return record
+
+
+@transaction.atomic
+def create_lens_workspace_restore_record(
+    *,
+    organization_id: int,
+    workspace_binding_id: int,
+    data: dict[str, Any],
+) -> RestoreRecord:
+    """Create the only restore type allowed to execute on a Platform gateway."""
+
+    tenant_organization = Organization.objects.select_for_update().filter(
+        pk=organization_id
+    ).first()
+    if tenant_organization is None:
+        raise ValidationError({"organization_id": "Organization is not available."})
+    from apps.lens_bridge.services.gateway_execution import (
+        context_for_workspace_binding,
+    )
+
+    execution_context, workspace_binding = context_for_workspace_binding(
+        tenant_organization=tenant_organization,
+        workspace_binding_id=workspace_binding_id,
+    )
+    expected_target_path = workspace_binding.resolved_path()
+    idempotency_key = str(data.get("idempotency_key") or "").strip()
+    if not idempotency_key:
+        raise ValidationError({"idempotency_key": "Lens workspace restore requires an idempotency key."})
+    existing = RestoreRecord.objects.filter(
+        organization_id=organization_id,
+        purpose=RestoreRecord.Purpose.LENS_WORKSPACE,
+        idempotency_key=idempotency_key,
+    ).first()
+    if existing is not None:
+        expected = (
+            int(execution_context.execution_organization.id),
+            int(execution_context.gateway.id),
+            workspace_binding.id,
+            _int(data, "source_snapshot_id"),
+            expected_target_path,
+        )
+        actual = (
+            existing.target_execution_organization_id,
+            existing.target_execution_node_id,
+            existing.workspace_binding_id,
+            existing.source_snapshot_id,
+            existing.target_path,
+        )
+        if actual != expected:
+            raise ValidationError(
+                {"idempotency_key": "Lens workspace idempotency key is bound to another execution request."}
+            )
+        return existing
+    try:
+        with transaction.atomic():
+            return _create_manual_restore_record(
+                organization_id=organization_id,
+                data=data,
+                user_id=None,
+                purpose=RestoreRecord.Purpose.LENS_WORKSPACE,
+                target_execution_organization_id=execution_context.execution_organization.id,
+                target_execution_node_id=execution_context.gateway.id,
+                workspace_binding_id=workspace_binding.id,
+                expected_target_path=expected_target_path,
+            )
+    except IntegrityError:
+        existing = RestoreRecord.objects.filter(
+            organization_id=organization_id,
+            purpose=RestoreRecord.Purpose.LENS_WORKSPACE,
+            idempotency_key=idempotency_key,
+        ).first()
+        if existing is None:
+            raise
+        expected = (
+            execution_context.execution_organization.id,
+            execution_context.gateway.id,
+            workspace_binding.id,
+            _int(data, "source_snapshot_id"),
+            expected_target_path,
+        )
+        actual = (
+            existing.target_execution_organization_id,
+            existing.target_execution_node_id,
+            existing.workspace_binding_id,
+            existing.source_snapshot_id,
+            existing.target_path,
+        )
+        if actual != expected:
+            raise ValidationError(
+                {"idempotency_key": "Lens workspace idempotency key is bound to another execution request."}
+            )
+        return existing
 
 
 def _create_restore_record(
@@ -493,13 +640,33 @@ def _create_restore_record(
     item_inputs: list[dict[str, Any]],
     request_payload: dict[str, Any],
     created_by_id: int | None,
+    purpose: str = RestoreRecord.Purpose.USER_DATA,
+    requesting_organization_id: int | None = None,
+    target_execution_organization_id: int | None = None,
+    target_execution_node_id: int | None = None,
+    idempotency_key: str = "",
+    workspace_binding_id: int | None = None,
 ) -> RestoreRecord:
-    _validate_endpoint_exists(
-        organization_id=organization_id,
-        endpoint_type=target_type,
-        ref_id=target_ref_id,
-        field="target_ref_id",
-    )
+    if target_execution_node_id is None or target_execution_organization_id is None:
+        _validate_endpoint_exists(
+            organization_id=organization_id,
+            endpoint_type=target_type,
+            ref_id=target_ref_id,
+            field="target_ref_id",
+        )
+        execution_node = _target_execution_node(
+            organization_id=organization_id,
+            target_type=target_type,
+            target_ref_id=target_ref_id,
+        )
+        target_execution_node_id = execution_node.id
+        target_execution_organization_id = execution_node.organization_id
+    elif not Node.objects.filter(
+        id=target_execution_node_id,
+        organization_id=target_execution_organization_id,
+        is_deleted=False,
+    ).exists():
+        raise ValidationError({"target_ref_id": "Restore execution node not found."})
     _ensure_no_active_restore_for_source(
         organization_id=organization_id,
         source_type=source_type,
@@ -538,6 +705,12 @@ def _create_restore_record(
     )
     record = RestoreRecord.objects.create(
         organization_id=organization_id,
+        requesting_organization_id=requesting_organization_id or organization_id,
+        target_execution_organization_id=target_execution_organization_id,
+        target_execution_node_id=target_execution_node_id,
+        purpose=purpose,
+        idempotency_key=idempotency_key,
+        workspace_binding_id=workspace_binding_id,
         restore_uid=restore_uid,
         source_mode=source_mode,
         plan_id=plan_id,
@@ -1212,11 +1385,50 @@ def _target_execution_node(*, organization_id: int, target_type: str, target_ref
 
 
 def _dispatch_restore_items(*, organization_id: int, record: RestoreRecord, task: Task) -> None:
-    node = _target_execution_node(
-        organization_id=organization_id,
-        target_type=record.target_type,
-        target_ref_id=record.target_ref_id,
-    )
+    managed_workspace_payload: dict[str, Any] = {}
+    if record.purpose == RestoreRecord.Purpose.LENS_WORKSPACE:
+        if record.workspace_binding_id is None:
+            raise ValidationError(
+                {"workspace_binding_id": "Lens workspace restore has no execution binding."}
+            )
+        tenant_organization = Organization.objects.filter(pk=record.organization_id).first()
+        if tenant_organization is None:
+            raise ValidationError({"organization_id": "Restore organization is not available."})
+        from apps.lens_bridge.services.gateway_execution import (
+            context_for_workspace_binding,
+            workspace_identity_payload,
+        )
+
+        execution_context, workspace_binding = context_for_workspace_binding(
+            tenant_organization=tenant_organization,
+            workspace_binding_id=record.workspace_binding_id,
+        )
+        if (
+            record.target_execution_organization_id
+            != execution_context.execution_organization.id
+            or record.target_execution_node_id != execution_context.gateway.id
+            or record.target_path != workspace_binding.resolved_path()
+            or any(
+                not _same_or_ancestor_path(record.target_path, item_path)
+                for item_path in record.items.values_list("target_path", flat=True)
+            )
+        ):
+            raise ValidationError(
+                {"workspace_binding_id": "Restore execution no longer matches its workspace binding."}
+            )
+        managed_workspace_payload = {
+            "managed_workspace_path": workspace_binding.resolved_path(),
+            **workspace_identity_payload(workspace_binding),
+        }
+    node = Node.objects.filter(
+        organization_id=record.target_execution_organization_id,
+        id=record.target_execution_node_id,
+        is_deleted=False,
+    ).first()
+    if node is None:
+        raise ValidationError({"target_ref_id": "Restore execution node not found."})
+    if node.status != Node.Status.ONLINE:
+        raise ValidationError({"target_ref_id": "Restore execution node is offline."})
     all_items = list(record.items.all())
     items = [
         item
@@ -1327,14 +1539,16 @@ def _dispatch_restore_items(*, organization_id: int, record: RestoreRecord, task
                 "repository": repository_payload,
                 "repository_reader_node_id": repository_access.node.id,
                 "restore_transfer_mode": restore_transfer_mode,
+                **managed_workspace_payload,
             }
             handle = run_agent_task_async(
-                organization_id=organization_id,
+                organization_id=record.target_execution_organization_id,
                 node_id=node.id,
                 kind="restore.run",
                 payload=payload,
                 correlation_type="restore.record",
                 correlation_id=str(record.task_uuid),
+                requesting_organization_id=record.requesting_organization_id,
             )
             log_agent_dispatch(
                 "restore item",
@@ -1753,8 +1967,11 @@ def cancel_restore(*, organization_id: int, task_uuid: str, reason: str = "") ->
                 ]
             )
 
+    execution_org_ids = {organization_id}
+    if record is not None:
+        execution_org_ids.add(record.target_execution_organization_id)
     for node_task in NodeTask.objects.filter(
-        organization_id=organization_id,
+        organization_id__in=execution_org_ids,
         correlation_id=str(task.task_uuid),
         status__in=_ACTIVE_NODE_STATUSES,
     ):
@@ -1798,8 +2015,15 @@ def cancel_restore(*, organization_id: int, task_uuid: str, reason: str = "") ->
 def restore_task_is_stopping(*, task: Task) -> bool:
     if task.status != Task.Status.CANCELLED:
         return False
-    return NodeTask.objects.filter(
+    record = RestoreRecord.objects.filter(
         organization_id=task.organization_id,
+        task_uuid=task.task_uuid,
+    ).first()
+    organization_ids = {task.organization_id}
+    if record is not None:
+        organization_ids.add(record.target_execution_organization_id)
+    return NodeTask.objects.filter(
+        organization_id__in=organization_ids,
         correlation_id=str(task.task_uuid),
         status__in=_ACTIVE_NODE_STATUSES,
     ).exists()

--- a/src/backend/apps/restore/services/restore_progress.py
+++ b/src/backend/apps/restore/services/restore_progress.py
@@ -18,21 +18,19 @@ _RESTORE_CORRELATION = "restore.record"
 def maybe_trigger_restore_progress(*, node_task: NodeTask) -> None:
     if node_task.correlation_type != _RESTORE_CORRELATION or not node_task.correlation_id:
         return
-    record = RestoreRecord.objects.filter(
-        organization_id=node_task.organization_id,
-        task_uuid=node_task.correlation_id,
-    ).first()
-    if record is None:
-        return
     item_id = _payload_int(node_task.payload, "restore_record_item_id")
     if not item_id:
         return
-    item = RestoreRecordItem.objects.filter(
-        organization_id=record.organization_id,
-        restore_record=record,
-        id=item_id,
-    ).first()
+    item = RestoreRecordItem.objects.select_related("restore_record").filter(id=item_id).first()
     if item is None:
+        return
+    record = item.restore_record
+    if str(record.task_uuid) != str(node_task.correlation_id):
+        return
+    if (
+        record.target_execution_organization_id != node_task.organization_id
+        or record.target_execution_node_id != node_task.node_id
+    ):
         return
     progress = _node_task_progress(node_task)
     if progress:
@@ -47,7 +45,10 @@ def maybe_trigger_restore_progress(*, node_task: NodeTask) -> None:
 
 def sync_restore_items_from_node_tasks(*, record: RestoreRecord) -> None:
     for item in record.items.order_by("id"):
-        node_task = _node_task_for_restore_item(item=item, organization_id=record.organization_id)
+        node_task = _node_task_for_restore_item(
+            item=item,
+            organization_id=record.target_execution_organization_id,
+        )
         if node_task is None:
             continue
         progress = _node_task_progress(node_task)

--- a/src/backend/apps/restore/signals.py
+++ b/src/backend/apps/restore/signals.py
@@ -26,11 +26,22 @@ def sync_restore_record_from_node_task(sender: type[NodeTask], instance: NodeTas
         return
     if instance.correlation_type != "restore.record" or not instance.correlation_id:
         return
-    record = RestoreRecord.objects.filter(
-        organization_id=instance.organization_id,
-        task_uuid=instance.correlation_id,
-    ).first()
+    item_id = _payload_int(instance.payload, "restore_record_item_id")
+    item = (
+        RestoreRecordItem.objects.select_related("restore_record")
+        .filter(id=item_id)
+        .first()
+        if item_id
+        else None
+    )
+    record = item.restore_record if item is not None else None
     if record is None:
+        return
+    if (
+        str(record.task_uuid) != str(instance.correlation_id)
+        or record.target_execution_organization_id != instance.organization_id
+        or record.target_execution_node_id != instance.node_id
+    ):
         return
     product_task = Task.objects.filter(
         organization_id=record.organization_id,
@@ -52,7 +63,6 @@ def sync_restore_record_from_node_task(sender: type[NodeTask], instance: NodeTas
         return
     if instance.status not in _TERMINAL_NODE_STATUSES:
         return
-    item_id = _payload_int(instance.payload, "restore_record_item_id")
     if item_id:
         _sync_restore_item(record=record, item_id=item_id, node_task=instance)
     from apps.restore.services.restore_progress import sync_restore_record_progress

--- a/src/backend/apps/restore/tests/test_restore_api.py
+++ b/src/backend/apps/restore/tests/test_restore_api.py
@@ -4,12 +4,16 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
+from django.core.exceptions import ValidationError
 from django.test import TestCase
 from django.utils import timezone
 from rest_framework import status
 from rest_framework.test import APIClient
 
 from apps.iam.models import Membership, Organization
+from apps.lens_bridge.models import LensGatewayLink, LensKnowledgeSource
+from apps.lens_bridge.services import platform_lens
+from apps.lens_bridge.services.gateway_execution import create_workspace_binding
 from apps.node.models import Node, NodeTask
 from apps.protection.models import (
     BackupConfig,
@@ -138,6 +142,187 @@ class RestoreApiTests(TestCase):
                 }
             ],
         }
+
+    def _workspace_binding(self, gateway_link: LensGatewayLink):
+        knowledge_source = LensKnowledgeSource.objects.create(
+            organization=self.org,
+            name="Restore test KS",
+            gateway=gateway_link.gateway,
+            gateway_link=gateway_link,
+            backup_source_snapshot_id=self.snapshot.id,
+            backup_snapshot_directory_id=self.snapshot_dir.id,
+            source_path="/data",
+            created_by=self.user,
+        )
+        binding = create_workspace_binding(
+            tenant_organization=self.org,
+            knowledge_source=knowledge_source,
+        )
+        binding.state = binding.State.READY
+        binding.identity_status = binding.IdentityStatus.READY
+        binding.save(update_fields=["state", "identity_status", "updated_at"])
+        return binding
+
+    @patch("apps.lens_bridge.services.gateway_execution.gateway_readiness.require_copilot_gateway")
+    def test_lens_workspace_restore_uses_platform_execution_identity(self, _ready):
+        platform_org = platform_lens.get_or_create_platform_org()
+        platform_gateway = Node.objects.create(
+            organization=platform_org,
+            name="platform-restore-gateway",
+            role=Node.Role.GATEWAY,
+            status=Node.Status.ONLINE,
+        )
+        gateway_link = LensGatewayLink.objects.create(
+            organization=platform_org,
+            gateway=platform_gateway,
+            scope=LensGatewayLink.GatewayScope.PLATFORM,
+            origin=LensGatewayLink.Origin.PLATFORM,
+        )
+        workspace_binding = self._workspace_binding(gateway_link)
+        payload = self._manual_restore_payload()
+        payload.update(
+            {
+                "target_ref_id": platform_gateway.id,
+                "target_path": workspace_binding.resolved_path(),
+                "idempotency_key": "lens-workspace:test:1",
+            }
+        )
+
+        record = restore_service.create_lens_workspace_restore_record(
+            organization_id=self.org.id,
+            workspace_binding_id=workspace_binding.id,
+            data=payload,
+        )
+
+        self.assertEqual(record.organization_id, self.org.id)
+        self.assertEqual(record.purpose, RestoreRecord.Purpose.LENS_WORKSPACE)
+        self.assertEqual(record.target_execution_organization_id, platform_org.id)
+        self.assertEqual(record.target_execution_node_id, platform_gateway.id)
+        product_task = Task.objects.get(pk=record.task_id)
+        self.assertEqual(product_task.organization_id, self.org.id)
+        node_task = NodeTask.objects.get(
+            kind="restore.run",
+            correlation_id=str(record.task_uuid),
+        )
+        self.assertEqual(node_task.organization_id, platform_org.id)
+        self.assertEqual(node_task.requesting_organization_id, self.org.id)
+        retried = restore_service.create_lens_workspace_restore_record(
+            organization_id=self.org.id,
+            workspace_binding_id=workspace_binding.id,
+            data=payload,
+        )
+        self.assertEqual(retried.id, record.id)
+        self.assertEqual(
+            RestoreRecord.objects.filter(
+                purpose=RestoreRecord.Purpose.LENS_WORKSPACE,
+                idempotency_key="lens-workspace:test:1",
+            ).count(),
+            1,
+        )
+        node_task.status = NodeTask.Status.SUCCESS
+        node_task.result = {"restored": True}
+        node_task.save(update_fields=["status", "result", "updated_at"])
+        item = record.items.get()
+        item.refresh_from_db()
+        self.assertEqual(item.status, RestoreRecordItem.Status.SUCCESS)
+        product_task.refresh_from_db()
+        self.assertEqual(product_task.status, Task.Status.SUCCESS)
+
+    def test_public_restore_cannot_target_platform_gateway(self):
+        platform_org = platform_lens.get_or_create_platform_org()
+        platform_gateway = Node.objects.create(
+            organization=platform_org,
+            name="forbidden-platform-target",
+            role=Node.Role.GATEWAY,
+            status=Node.Status.ONLINE,
+        )
+        payload = self._manual_restore_payload()
+        payload["target_ref_id"] = platform_gateway.id
+
+        response = self.client.post(
+            "/api/v1/restore/records/",
+            payload,
+            format="json",
+            **self._headers(),
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertFalse(RestoreRecord.objects.exists())
+
+    @patch("apps.lens_bridge.services.gateway_execution.gateway_readiness.require_copilot_gateway")
+    def test_lens_workspace_restore_rejects_nonbinding_target_path(self, _ready):
+        platform_org = platform_lens.get_or_create_platform_org()
+        platform_gateway = Node.objects.create(
+            organization=platform_org,
+            name="platform-path-boundary-gateway",
+            role=Node.Role.GATEWAY,
+            status=Node.Status.ONLINE,
+        )
+        gateway_link = LensGatewayLink.objects.create(
+            organization=platform_org,
+            gateway=platform_gateway,
+            scope=LensGatewayLink.GatewayScope.PLATFORM,
+            origin=LensGatewayLink.Origin.PLATFORM,
+        )
+        workspace_binding = self._workspace_binding(gateway_link)
+        payload = self._manual_restore_payload()
+        payload.update(
+            {
+                "target_ref_id": platform_gateway.id,
+                "target_path": "/workspace/platform/another-tenant",
+                "idempotency_key": "lens-workspace:path-boundary",
+            }
+        )
+
+        with self.assertRaisesMessage(
+            ValidationError,
+            "Lens workspace target path is not authoritative",
+        ):
+            restore_service.create_lens_workspace_restore_record(
+                organization_id=self.org.id,
+                workspace_binding_id=workspace_binding.id,
+                data=payload,
+            )
+
+        self.assertFalse(RestoreRecord.objects.exists())
+
+    @patch("apps.lens_bridge.services.gateway_execution.gateway_readiness.require_copilot_gateway")
+    def test_lens_workspace_restore_on_private_gateway_remains_in_tenant(self, _ready):
+        private_gateway = Node.objects.create(
+            organization=self.org,
+            name="private-lens-gateway",
+            role=Node.Role.GATEWAY,
+            status=Node.Status.ONLINE,
+        )
+        gateway_link = LensGatewayLink.objects.create(
+            organization=self.org,
+            gateway=private_gateway,
+            owner_user=self.user,
+            scope=LensGatewayLink.GatewayScope.USER,
+        )
+        workspace_binding = self._workspace_binding(gateway_link)
+        payload = self._manual_restore_payload()
+        payload.update(
+            {
+                "target_ref_id": private_gateway.id,
+                "target_path": workspace_binding.resolved_path(),
+                "idempotency_key": "lens-workspace:private:1",
+            }
+        )
+
+        record = restore_service.create_lens_workspace_restore_record(
+            organization_id=self.org.id,
+            workspace_binding_id=workspace_binding.id,
+            data=payload,
+        )
+
+        self.assertEqual(record.target_execution_organization_id, self.org.id)
+        node_task = NodeTask.objects.get(
+            kind="restore.run",
+            correlation_id=str(record.task_uuid),
+        )
+        self.assertEqual(node_task.organization_id, self.org.id)
+        self.assertEqual(node_task.requesting_organization_id, self.org.id)
 
     def _active_restore_task(self, *, source_ref_id: int | None = None, status_value: str = Task.Status.RUNNING) -> Task:
         task = Task.objects.create(
@@ -1737,6 +1922,9 @@ class RestoreApiTests(TestCase):
         task.save(update_fields=["status", "updated_at"])
         record = RestoreRecord.objects.create(
             organization_id=self.org.id,
+            requesting_organization_id=self.org.id,
+            target_execution_organization_id=self.org.id,
+            target_execution_node_id=self.target.id,
             restore_uid="rst-cancel-test",
             source_mode=RestoreRecord.SourceMode.PLAN,
             plan_id=None,

--- a/src/backend/apps/storage/tests/test_repository_cleanup.py
+++ b/src/backend/apps/storage/tests/test_repository_cleanup.py
@@ -466,6 +466,9 @@ class RepositoryCleanupTests(TestCase):
         restore_task.save(update_fields=["status", "updated_at"])
         record = RestoreRecord.objects.create(
             organization_id=self.org.id,
+            requesting_organization_id=self.org.id,
+            target_execution_organization_id=self.org.id,
+            target_execution_node_id=102,
             restore_uid="restore-bound-record",
             source_mode=RestoreRecord.SourceMode.MANUAL,
             task_id=restore_task.id,

--- a/tools/quality/test-agent-gateway-uninstall.sh
+++ b/tools/quality/test-agent-gateway-uninstall.sh
@@ -116,4 +116,25 @@ PATH="${fake_bin}:${PATH}" \
 grep -Fx 'image rm hyperfilelens-sourcelens-lensnode:latest' "${docker_state}.images" >/dev/null
 grep -Fx 'image rm example/hfl-lensnode:test' "${docker_state}.images" >/dev/null
 
+validate_workspace() {
+	bash -c 'source "$1"; validate_gateway_workspace_path "$2"' \
+		_ "${ROOT}/deploy/bootstrap/gateway-lifecycle.sh" "$1"
+}
+
+[[ "$(validate_workspace /workspace/org-42/data)" == "/workspace/org-42/data" ]]
+[[ "$(validate_workspace /workspace/org-42/data/)" == "/workspace/org-42/data" ]]
+for unsafe_workspace in \
+	/workspace/org-0/data \
+	/workspace/org-alpha/data \
+	/workspace/org-42 \
+	/workspace/org-42/data/child \
+	/workspace/org-42/data/../secrets \
+	/workspace/../etc \
+	/; do
+	if validate_workspace "${unsafe_workspace}" >/dev/null 2>&1; then
+		printf 'unsafe Gateway workspace path accepted: %s\n' "${unsafe_workspace}" >&2
+		exit 1
+	fi
+done
+
 printf 'Agent-managed Data Gateway uninstall contracts passed.\n'


### PR DESCRIPTION
## Summary

- establish explicit platform and private gateway execution identities across chat, knowledge-source, workspace, assistant, and restore flows
- make gateway provisioning and teardown durable, claim-based, retry-safe, and reconciled by periodic workers
- keep LensNode lifecycle under the Agent and enforce immutable gateway scope and ownership boundaries
- add upgrade-safe database migrations and end-to-end contract coverage for gateway execution and cleanup

## Validation

- backend focused regression suite: 246 tests passed
- agent: go test ./...
- Ruff checks passed
- Django makemigrations --check --dry-run: no changes detected
- gateway uninstall contract checks passed

Fixes #201
Fixes #214
Related to #217