### PR TITLE
fix(frontend): stabilize copilot source path validation

### DIFF
--- a/src/frontend/src/composables/useKnowledgeSourceForm.test.ts
+++ b/src/frontend/src/composables/useKnowledgeSourceForm.test.ts
@@ -1,0 +1,387 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { defineComponent, h, ref } from 'vue'
+import { flushPromises, mount, type VueWrapper } from '@vue/test-utils'
+import type { BackupSourceSnapshot } from '../lib/protectionBackupConfigApi'
+import { useKnowledgeSourceForm } from './useKnowledgeSourceForm'
+
+const mocks = vi.hoisted(() => ({
+  browseBackupSnapshotDirectory: vi.fn(),
+  warning: vi.fn(),
+  error: vi.fn(),
+  success: vi.fn(),
+}))
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}))
+
+vi.mock('element-plus', () => ({
+  ElMessage: {
+    warning: mocks.warning,
+    error: mocks.error,
+    success: mocks.success,
+  },
+}))
+
+vi.mock('../lib/api', () => ({
+  apiErrorMessage: (_error: unknown, fallback: string) => fallback,
+}))
+
+vi.mock('../lib/lensApi', () => ({
+  browseGatewayDirectory: vi.fn(),
+  createKnowledgeSource: vi.fn(),
+  fetchKnowledgeSource: vi.fn(),
+  listLensGateways: vi.fn().mockResolvedValue([]),
+  patchKnowledgeSource: vi.fn(),
+}))
+
+vi.mock('../lib/protectionBackupConfigApi', () => ({
+  browseBackupSnapshotDirectory: mocks.browseBackupSnapshotDirectory,
+  getBackupSourceSnapshot: vi.fn(),
+  listBackupSourceSnapshots: vi.fn().mockResolvedValue({ results: [] }),
+}))
+
+type KnowledgeSourceForm = ReturnType<typeof useKnowledgeSourceForm>
+
+function snapshotFixture(): BackupSourceSnapshot {
+  return {
+    id: 71,
+    snapshot_uid: 'snapshot-71',
+    source_type: 'agent',
+    source_ref_id: 9,
+    source_display_name: 'test-source',
+    backup_config_id: 42,
+    backup_config_name: 'test-config',
+    repository_id: 3,
+    repository_display_name: 'test-repository',
+    repository_endpoint_type: 'internal',
+    repository_endpoint: 'local',
+    task_id: 4,
+    task_uuid: 'task-4',
+    trigger_type: 'manual',
+    status: 'available',
+    created_at: '2026-07-31T00:00:00Z',
+    directory_count: 1,
+    successful_directory_count: 1,
+    failed_directory_count: 0,
+    kopia_snapshot_count: 1,
+    total_size_bytes: 1024,
+    file_count: 2,
+    dir_count: 2,
+    directories: [{
+      id: 31,
+      backup_config_dir_id: 8,
+      source_path: '/root/datatest',
+      path_type: 'directory',
+      display_name: 'datatest',
+      repository_id: 3,
+      status: 'available',
+      created_at: '2026-07-31T00:00:00Z',
+      size_bytes: 1024,
+      file_count: 2,
+      dir_count: 2,
+    }],
+  }
+}
+
+function mountForm(): { form: KnowledgeSourceForm; wrapper: VueWrapper } {
+  let form!: KnowledgeSourceForm
+  const wrapper = mount(defineComponent({
+    setup() {
+      form = useKnowledgeSourceForm(ref(1), ref('backup_source'))
+      return () => h('div')
+    },
+  }))
+  const snapshot = snapshotFixture()
+  form.snapshots.value = [snapshot]
+  form.selectedBackupConfigId.value = snapshot.backup_config_id
+  form.snapshotPickerValue.value = snapshot.id
+  form.snapshotDetail.value = snapshot
+  return { form, wrapper }
+}
+
+describe('knowledge source backup scope validation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+    mocks.browseBackupSnapshotDirectory.mockResolvedValue({ entries: [] })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('does not warn when blur is caused by opening the scope picker', async () => {
+    const { form, wrapper } = mountForm()
+    try {
+      const entryId = form.backupScopeEntries.value[0].id
+      const validation = form.validateBackupScopeEntryOnBlur(entryId)
+      form.setBackupScopePickerOpen(entryId, true)
+
+      await vi.runAllTimersAsync()
+
+      await expect(validation).resolves.toBe(false)
+      expect(mocks.warning).not.toHaveBeenCalled()
+      expect(mocks.browseBackupSnapshotDirectory).not.toHaveBeenCalled()
+    } finally {
+      wrapper.unmount()
+    }
+  })
+
+  it('accepts a tree selection that lands after the input blur event', async () => {
+    const { form, wrapper } = mountForm()
+    try {
+      const entryId = form.backupScopeEntries.value[0].id
+      const validation = form.validateBackupScopeEntryOnBlur(entryId)
+      form.pickBackupScopeForEntry(entryId, {
+        id: '31:dir:/root/datatest',
+        label: 'datatest',
+        path: '/root/datatest',
+        type: 'dir',
+        directoryId: 31,
+        isLeaf: false,
+      })
+
+      await vi.runAllTimersAsync()
+
+      await expect(validation).resolves.toBe(true)
+      expect(form.backupScopeEntries.value[0]).toMatchObject({
+        path: '/root/datatest',
+        directoryId: 31,
+        pathType: 'dir',
+      })
+      expect(mocks.warning).not.toHaveBeenCalled()
+      expect(mocks.browseBackupSnapshotDirectory).not.toHaveBeenCalled()
+    } finally {
+      wrapper.unmount()
+    }
+  })
+
+  it('still validates a manually entered source path after a real blur', async () => {
+    const { form, wrapper } = mountForm()
+    try {
+      const entryId = form.backupScopeEntries.value[0].id
+      form.updateBackupScopeEntryInput(entryId, '/root/datatest/docs')
+      const validation = form.validateBackupScopeEntryOnBlur(entryId)
+
+      await vi.runAllTimersAsync()
+
+      await expect(validation).resolves.toBe(true)
+      expect(mocks.browseBackupSnapshotDirectory).toHaveBeenCalledWith(31, {
+        path: 'docs',
+        limit: 1,
+      })
+      expect(form.backupScopeEntries.value[0]).toMatchObject({
+        path: '/root/datatest/docs',
+        directoryId: 31,
+      })
+    } finally {
+      wrapper.unmount()
+    }
+  })
+
+  it('validates a manual path when the picker closes without a selection', async () => {
+    const { form, wrapper } = mountForm()
+    try {
+      const entryId = form.backupScopeEntries.value[0].id
+      form.updateBackupScopeEntryInput(entryId, '/root/datatest/docs')
+      const blurValidation = form.validateBackupScopeEntryOnBlur(entryId)
+      form.setBackupScopePickerOpen(entryId, true)
+
+      await vi.runAllTimersAsync()
+      await expect(blurValidation).resolves.toBe(false)
+      expect(mocks.browseBackupSnapshotDirectory).not.toHaveBeenCalled()
+
+      form.setBackupScopePickerOpen(entryId, false)
+      await vi.runAllTimersAsync()
+      await flushPromises()
+
+      expect(mocks.browseBackupSnapshotDirectory).toHaveBeenCalledWith(31, {
+        path: 'docs',
+        limit: 1,
+      })
+      expect(form.backupScopeEntries.value[0]).toMatchObject({
+        path: '/root/datatest/docs',
+        directoryId: 31,
+      })
+    } finally {
+      wrapper.unmount()
+    }
+  })
+
+  it('deduplicates picker-close and blur validation from the same outside click', async () => {
+    let resolveBrowse!: (value: { entries: never[] }) => void
+    mocks.browseBackupSnapshotDirectory.mockReturnValueOnce(
+      new Promise((resolve) => { resolveBrowse = resolve }),
+    )
+    const { form, wrapper } = mountForm()
+    try {
+      const entryId = form.backupScopeEntries.value[0].id
+      form.updateBackupScopeEntryInput(entryId, '/root/datatest/docs')
+      form.setBackupScopePickerOpen(entryId, true)
+
+      const blurValidation = form.validateBackupScopeEntryOnBlur(entryId)
+      form.setBackupScopePickerOpen(entryId, false)
+      expect(mocks.browseBackupSnapshotDirectory).not.toHaveBeenCalled()
+
+      await vi.runAllTimersAsync()
+      expect(mocks.browseBackupSnapshotDirectory).toHaveBeenCalledTimes(1)
+      resolveBrowse({ entries: [] })
+
+      await expect(blurValidation).resolves.toBe(false)
+      await flushPromises()
+      expect(mocks.browseBackupSnapshotDirectory).toHaveBeenCalledTimes(1)
+      expect(form.backupScopeEntries.value[0]).toMatchObject({
+        path: '/root/datatest/docs',
+        directoryId: 31,
+      })
+    } finally {
+      wrapper.unmount()
+    }
+  })
+
+  it('deduplicates the same validation when picker-close arrives before blur', async () => {
+    let resolveBrowse!: (value: { entries: never[] }) => void
+    mocks.browseBackupSnapshotDirectory.mockReturnValueOnce(
+      new Promise((resolve) => { resolveBrowse = resolve }),
+    )
+    const { form, wrapper } = mountForm()
+    try {
+      const entryId = form.backupScopeEntries.value[0].id
+      form.updateBackupScopeEntryInput(entryId, '/root/datatest/docs')
+      form.setBackupScopePickerOpen(entryId, true)
+
+      form.setBackupScopePickerOpen(entryId, false)
+      const blurValidation = form.validateBackupScopeEntryOnBlur(entryId)
+      expect(mocks.browseBackupSnapshotDirectory).not.toHaveBeenCalled()
+
+      await vi.runAllTimersAsync()
+      expect(mocks.browseBackupSnapshotDirectory).toHaveBeenCalledTimes(1)
+      resolveBrowse({ entries: [] })
+
+      await expect(blurValidation).resolves.toBe(true)
+      expect(mocks.browseBackupSnapshotDirectory).toHaveBeenCalledTimes(1)
+      expect(form.backupScopeEntries.value[0]).toMatchObject({
+        path: '/root/datatest/docs',
+        directoryId: 31,
+      })
+    } finally {
+      wrapper.unmount()
+    }
+  })
+
+  it('does not let an older async validation overwrite a newer tree selection', async () => {
+    let resolveBrowse!: (value: { entries: never[] }) => void
+    mocks.browseBackupSnapshotDirectory.mockReturnValueOnce(
+      new Promise((resolve) => { resolveBrowse = resolve }),
+    )
+    const { form, wrapper } = mountForm()
+    try {
+      const entryId = form.backupScopeEntries.value[0].id
+      form.updateBackupScopeEntryInput(entryId, '/root/datatest/old')
+      const staleValidation = form.validateBackupScopeEntry(entryId)
+      form.pickBackupScopeForEntry(entryId, {
+        id: '31:dir:/root/datatest/new',
+        label: 'new',
+        path: '/root/datatest/new',
+        type: 'dir',
+        directoryId: 31,
+        isLeaf: false,
+      })
+      resolveBrowse({ entries: [] })
+
+      await expect(staleValidation).resolves.toBe(false)
+      expect(form.backupScopeEntries.value[0]).toMatchObject({
+        path: '/root/datatest/new',
+        directoryId: 31,
+        pathType: 'dir',
+      })
+      expect(mocks.error).not.toHaveBeenCalled()
+    } finally {
+      wrapper.unmount()
+    }
+  })
+
+  it('lets only the latest request report the result for an unchanged path', async () => {
+    let rejectFirst!: (reason: Error) => void
+    let resolveSecond!: (value: { entries: never[] }) => void
+    mocks.browseBackupSnapshotDirectory
+      .mockReturnValueOnce(new Promise((_resolve, reject) => { rejectFirst = reject }))
+      .mockReturnValueOnce(new Promise((resolve) => { resolveSecond = resolve }))
+    const { form, wrapper } = mountForm()
+    try {
+      const entryId = form.backupScopeEntries.value[0].id
+      form.updateBackupScopeEntryInput(entryId, '/root/datatest/docs')
+      const firstValidation = form.validateBackupScopeEntry(entryId)
+      const secondValidation = form.validateBackupScopeEntry(entryId)
+
+      resolveSecond({ entries: [] })
+      await expect(secondValidation).resolves.toBe(true)
+      rejectFirst(new Error('stale request failed'))
+
+      await expect(firstValidation).resolves.toBe(false)
+      expect(form.backupScopeEntries.value[0]).toMatchObject({
+        path: '/root/datatest/docs',
+        directoryId: 31,
+      })
+      expect(mocks.error).not.toHaveBeenCalled()
+    } finally {
+      wrapper.unmount()
+    }
+  })
+
+  it('cancels a scheduled blur validation when the form unmounts', async () => {
+    const { form, wrapper } = mountForm()
+    const entryId = form.backupScopeEntries.value[0].id
+    form.updateBackupScopeEntryInput(entryId, '/root/datatest/docs')
+    const validation = form.validateBackupScopeEntryOnBlur(entryId)
+
+    wrapper.unmount()
+    await vi.runAllTimersAsync()
+
+    await expect(validation).resolves.toBe(false)
+    expect(mocks.browseBackupSnapshotDirectory).not.toHaveBeenCalled()
+    expect(mocks.warning).not.toHaveBeenCalled()
+    expect(mocks.error).not.toHaveBeenCalled()
+  })
+
+  it('ignores a successful validation result after the form unmounts', async () => {
+    let resolveBrowse!: (value: { entries: never[] }) => void
+    mocks.browseBackupSnapshotDirectory.mockReturnValueOnce(
+      new Promise((resolve) => { resolveBrowse = resolve }),
+    )
+    const { form, wrapper } = mountForm()
+    const entryId = form.backupScopeEntries.value[0].id
+    form.updateBackupScopeEntryInput(entryId, '/root/datatest/docs')
+    const validation = form.validateBackupScopeEntry(entryId)
+
+    wrapper.unmount()
+    resolveBrowse({ entries: [] })
+
+    await expect(validation).resolves.toBe(false)
+    expect(form.backupScopeEntries.value[0]).toMatchObject({
+      path: '/root/datatest/docs',
+      directoryId: null,
+    })
+    expect(mocks.error).not.toHaveBeenCalled()
+  })
+
+  it('suppresses a failed validation result after the form unmounts', async () => {
+    let rejectBrowse!: (reason: Error) => void
+    mocks.browseBackupSnapshotDirectory.mockReturnValueOnce(
+      new Promise((_resolve, reject) => { rejectBrowse = reject }),
+    )
+    const { form, wrapper } = mountForm()
+    const entryId = form.backupScopeEntries.value[0].id
+    form.updateBackupScopeEntryInput(entryId, '/root/datatest/docs')
+    const validation = form.validateBackupScopeEntry(entryId)
+
+    wrapper.unmount()
+    rejectBrowse(new Error('request completed after navigation'))
+
+    await expect(validation).resolves.toBe(false)
+    expect(mocks.error).not.toHaveBeenCalled()
+  })
+})

--- a/src/frontend/src/composables/useKnowledgeSourceForm.ts
+++ b/src/frontend/src/composables/useKnowledgeSourceForm.ts
@@ -1,4 +1,4 @@
-import { computed, ref, watch, type Ref } from 'vue'
+import { computed, onScopeDispose, ref, watch, type Ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { ElMessage } from 'element-plus'
 import { apiErrorMessage } from '../lib/api'
@@ -48,6 +48,7 @@ export type BackupScopeEntry = {
   path: string
   directoryId: number | null
   pathType: 'dir' | 'file' | 'unknown'
+  revision: number
 }
 
 export type KnowledgeSourceType = 'backup_source' | 'gateway_local'
@@ -76,6 +77,7 @@ function createBackupScopeEntry(): BackupScopeEntry {
     path: '',
     directoryId: null,
     pathType: 'unknown',
+    revision: 0,
   }
 }
 
@@ -98,6 +100,11 @@ export function useKnowledgeSourceForm(
   const snapshotPickerValue = ref<SnapshotPickerValue>(SNAPSHOT_PICKER_LATEST)
   const snapshotDetail = ref<BackupSourceSnapshot | null>(null)
   const backupScopeEntries = ref<BackupScopeEntry[]>([createBackupScopeEntry()])
+  const latestBackupScopeValidation = new Map<string, number>()
+  const pendingBackupScopeBlurValidation = new Map<string, number>()
+  let backupScopeValidationSequence = 0
+  let backupScopeBlurSequence = 0
+  let scopeDisposed = false
   const openBackupScopePickerId = ref<string | null>(null)
   const backupScopeTreeRevision = ref(0)
   const backupScopeBrowseLoading = ref(false)
@@ -241,6 +248,8 @@ export function useKnowledgeSourceForm(
   const canSubmitCreate = computed(() => canSubmit.value)
 
   function resetBackupScopeState() {
+    latestBackupScopeValidation.clear()
+    pendingBackupScopeBlurValidation.clear()
     backupScopeEntries.value = [createBackupScopeEntry()]
     openBackupScopePickerId.value = null
     backupScopeTreeRevision.value += 1
@@ -417,6 +426,12 @@ export function useKnowledgeSourceForm(
 
   function setBackupScopePickerOpen(entryId: string | null, open: boolean) {
     openBackupScopePickerId.value = open ? entryId : null
+    if (!open && entryId) {
+      const entry = backupScopeEntries.value.find((row) => row.id === entryId)
+      if (entry?.path.trim() && entry.directoryId == null) {
+        void scheduleBackupScopeEntryValidation(entryId)
+      }
+    }
   }
 
   function addBackupScopeEntry() {
@@ -425,6 +440,8 @@ export function useKnowledgeSourceForm(
 
   function removeBackupScopeEntry(entryId: string) {
     if (backupScopeEntries.value.length <= 1) return
+    latestBackupScopeValidation.delete(entryId)
+    pendingBackupScopeBlurValidation.delete(entryId)
     backupScopeEntries.value = backupScopeEntries.value.filter((row) => row.id !== entryId)
     if (openBackupScopePickerId.value === entryId) {
       openBackupScopePickerId.value = null
@@ -433,7 +450,15 @@ export function useKnowledgeSourceForm(
 
   function updateBackupScopeEntryInput(entryId: string, value: string) {
     backupScopeEntries.value = backupScopeEntries.value.map((row) =>
-      row.id === entryId ? { ...row, path: value, directoryId: null, pathType: 'unknown' } : row,
+      row.id === entryId
+        ? {
+            ...row,
+            path: value,
+            directoryId: null,
+            pathType: 'unknown',
+            revision: row.revision + 1,
+          }
+        : row,
     )
   }
 
@@ -441,13 +466,36 @@ export function useKnowledgeSourceForm(
     if (!node.directoryId || !node.path) return
     backupScopeEntries.value = backupScopeEntries.value.map((row) =>
       row.id === entryId
-        ? { ...row, path: node.path, directoryId: node.directoryId ?? null, pathType: node.type }
+        ? {
+            ...row,
+            path: node.path,
+            directoryId: node.directoryId ?? null,
+            pathType: node.type,
+            revision: row.revision + 1,
+          }
         : row,
     )
     openBackupScopePickerId.value = null
   }
 
+  function isCurrentBackupScopeValidation(
+    entryId: string,
+    revision: number,
+    snapshotId: number,
+    requestId: number,
+  ): boolean {
+    const current = backupScopeEntries.value.find((row) => row.id === entryId)
+    return Boolean(
+      !scopeDisposed
+      && current
+      && current.revision === revision
+      && effectiveSnapshotId.value === snapshotId
+      && latestBackupScopeValidation.get(entryId) === requestId
+    )
+  }
+
   async function validateBackupScopeEntry(entryId: string, showMessage = true): Promise<boolean> {
+    if (scopeDisposed) return false
     const entry = backupScopeEntries.value.find((row) => row.id === entryId)
     if (!entry) return false
     const rawPath = entry.path.trim()
@@ -455,10 +503,16 @@ export function useKnowledgeSourceForm(
       if (showMessage) ElMessage.warning({ message: t('protection.backupsPage.msgManualPathRequired'), grouping: true })
       return false
     }
+    if (entry.directoryId != null) return true
     if (!effectiveSnapshotId.value) {
       if (showMessage) ElMessage.warning({ message: t('insight.kb.backupScopePickSnapshotFirst'), grouping: true })
       return false
     }
+    const validationRevision = entry.revision
+    const validationSnapshotId = effectiveSnapshotId.value
+    backupScopeValidationSequence += 1
+    const validationRequestId = backupScopeValidationSequence
+    latestBackupScopeValidation.set(entryId, validationRequestId)
     const directory = findSnapshotDirectoryForPath(rawPath)
     if (!directory?.id) {
       if (showMessage) ElMessage.warning({ message: t('protection.backupsPage.msgRestoreScopeOutsideSnapshot'), grouping: true })
@@ -468,6 +522,14 @@ export function useKnowledgeSourceForm(
     try {
       if (relativePath) {
         await browseBackupSnapshotDirectory(directory.id, { path: relativePath, limit: 1 })
+      }
+      if (!isCurrentBackupScopeValidation(
+        entryId,
+        validationRevision,
+        validationSnapshotId,
+        validationRequestId,
+      )) {
+        return false
       }
       backupScopeEntries.value = backupScopeEntries.value.map((row) =>
         row.id === entryId
@@ -484,11 +546,54 @@ export function useKnowledgeSourceForm(
       openBackupScopePickerId.value = null
       return true
     } catch (err) {
-      if (showMessage) {
+      if (
+        showMessage
+        && isCurrentBackupScopeValidation(
+          entryId,
+          validationRevision,
+          validationSnapshotId,
+          validationRequestId,
+        )
+      ) {
         ElMessage.error({ message: apiErrorMessage(err, t('protection.backupsPage.msgRestoreScopeVerifyFailed')), grouping: true })
       }
       return false
     }
+  }
+
+  async function scheduleBackupScopeEntryValidation(entryId: string): Promise<boolean> {
+    // Popover close and input blur can arrive in either order. Coalesce both
+    // events after the current interaction and keep only the latest schedule.
+    if (scopeDisposed) return false
+    backupScopeBlurSequence += 1
+    const blurRequestId = backupScopeBlurSequence
+    pendingBackupScopeBlurValidation.set(entryId, blurRequestId)
+    try {
+      await new Promise<void>((resolve) => window.setTimeout(resolve, 0))
+      if (
+        scopeDisposed
+        || pendingBackupScopeBlurValidation.get(entryId) !== blurRequestId
+      ) {
+        return false
+      }
+      const entry = backupScopeEntries.value.find((row) => row.id === entryId)
+      if (
+        !entry?.path.trim()
+        || entry.directoryId != null
+        || openBackupScopePickerId.value === entryId
+      ) {
+        return Boolean(entry?.directoryId)
+      }
+      return validateBackupScopeEntry(entryId)
+    } finally {
+      if (pendingBackupScopeBlurValidation.get(entryId) === blurRequestId) {
+        pendingBackupScopeBlurValidation.delete(entryId)
+      }
+    }
+  }
+
+  function validateBackupScopeEntryOnBlur(entryId: string): Promise<boolean> {
+    return scheduleBackupScopeEntryValidation(entryId)
   }
 
   async function validateAllBackupScopeEntries(showMessage = true): Promise<boolean> {
@@ -771,6 +876,12 @@ export function useKnowledgeSourceForm(
     if (id) void loadGatewayBrowse('')
   })
 
+  onScopeDispose(() => {
+    scopeDisposed = true
+    latestBackupScopeValidation.clear()
+    pendingBackupScopeBlurValidation.clear()
+  })
+
   return {
     loading,
     saving,
@@ -824,6 +935,7 @@ export function useKnowledgeSourceForm(
     removeBackupScopeEntry,
     updateBackupScopeEntryInput,
     validateBackupScopeEntry,
+    validateBackupScopeEntryOnBlur,
     validateAllBackupScopeEntries,
     pickBackupScopeForEntry,
     loadGatewayDirTreeNode,

--- a/src/frontend/src/pages/insight/KnowledgeSourceFormPage.vue
+++ b/src/frontend/src/pages/insight/KnowledgeSourceFormPage.vue
@@ -76,6 +76,7 @@ const {
   removeBackupScopeEntry,
   updateBackupScopeEntryInput,
   validateBackupScopeEntry,
+  validateBackupScopeEntryOnBlur,
   pickBackupScopeForEntry,
   loadGatewayDirTreeNode,
   setGatewayDirPickerOpen,
@@ -490,7 +491,7 @@ onMounted(() => {
                                   :placeholder="t('insight.kb.phSelectOrEnterRestoreScope')"
                                   :disabled="isEditing || !effectiveSnapshotId || snapshotDirectories.length === 0"
                                   @update:model-value="updateBackupScopeEntryInput(scopeEntry.id, $event)"
-                                  @blur="validateBackupScopeEntry(scopeEntry.id)"
+                                  @blur="validateBackupScopeEntryOnBlur(scopeEntry.id)"
                                   @keydown.enter.prevent="validateBackupScopeEntry(scopeEntry.id)"
                                 >
                                   <template #prefix>

--- a/src/frontend/src/pages/insight/NewCopilotChat.vue
+++ b/src/frontend/src/pages/insight/NewCopilotChat.vue
@@ -61,6 +61,7 @@ const {
   removeBackupScopeEntry,
   updateBackupScopeEntryInput,
   validateBackupScopeEntry,
+  validateBackupScopeEntryOnBlur,
   validateAllBackupScopeEntries,
   pickBackupScopeForEntry,
 } = useKnowledgeSourceForm(editingId, sourceType)
@@ -275,7 +276,7 @@ onBeforeUnmount(() => backupScopeResizeObserver?.disconnect())
                           placeholder="Select a file or folder"
                           :disabled="!effectiveSnapshotId || snapshotDirectories.length === 0"
                           @update:model-value="updateBackupScopeEntryInput(scopeEntry.id, $event)"
-                          @blur="validateBackupScopeEntry(scopeEntry.id)"
+                          @blur="validateBackupScopeEntryOnBlur(scopeEntry.id)"
                           @keydown.enter.prevent="validateBackupScopeEntry(scopeEntry.id)"
                         >
                           <template #prefix><TextCursorInput :size="14" /></template>


### PR DESCRIPTION
## Summary

- defer source-path blur validation until picker interactions settle, preventing false empty-path warnings
- coalesce picker-close and blur events regardless of browser event order
- reject stale or duplicate async validation results and cancel pending work when the form unmounts
- apply the shared behavior to both New Chat and Knowledge Source forms

## Validation

- focused source-path validation tests: 11 passed
- frontend suite: 536 tests passed
- TypeScript type check passed
- targeted ESLint passed with zero errors
- production Vite build passed
- git diff --check passed

Fixes #217