### PR TITLE
fix(agent): restore cross-platform gateway builds

### DIFF
--- a/src/agent/internal/engine/lens_secure_unsupported.go
+++ b/src/agent/internal/engine/lens_secure_unsupported.go
@@ -9,6 +9,10 @@ import (
 
 var errRestrictedGatewayUnsupported = errors.New("restricted Data Gateway filesystem operations require Linux")
 
+func secureRelativePath(path, allowedRoot string, allowRoot bool) (string, string, error) {
+	return "", "", errRestrictedGatewayUnsupported
+}
+
 func secureOpenDirectory(path, allowedRoot string, allowRoot bool, flags uint64) (int, string, error) {
 	return -1, "", errRestrictedGatewayUnsupported
 }


### PR DESCRIPTION
## Summary

- provide the non-Linux secure path helper required by shared gateway code
- keep restricted Data Gateway filesystem operations Linux-only
- restore macOS and Windows Agent release builds after PR #243

## Validation

- Agent engine unit tests
- hfl-agent and hfl-enroll builds for linux/amd64
- hfl-agent and hfl-enroll builds for linux/arm64
- hfl-agent and hfl-enroll builds for darwin/amd64
- hfl-agent and hfl-enroll builds for darwin/arm64
- hfl-agent and hfl-enroll builds for windows/amd64
- git diff --check