### PR TITLE
Validate password login email format

### DIFF
--- a/src/frontend/src/pages/auth/Login.vue
+++ b/src/frontend/src/pages/auth/Login.vue
@@ -114,10 +114,14 @@ const showPassword = ref(false)
 const cardView = ref<'login' | 'reset'>('login')
 const authMode = ref<'password' | 'email-code'>('password')
 const resetStep = ref<'request' | 'reset'>('request')
+const regEmail = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/
 
 function checkMail(value: string) {
   if (!value.trim()) {
     return t('login.emailErrRequired')
+  }
+  if (!regEmail.test(value)) {
+    return t('login.emailErrFormat')
   }
   return ''
 }

--- a/src/frontend/src/pages/auth/LoginTurnstileLifecycle.test.ts
+++ b/src/frontend/src/pages/auth/LoginTurnstileLifecycle.test.ts
@@ -266,6 +266,30 @@ describe('Login Turnstile lifecycle', () => {
     wrapper.unmount()
   })
 
+  it('rejects an invalid email format before password login', async () => {
+    const wrapper = await mountLogin(1440)
+    const inputs = wrapper.findAll('input')
+    const turnstile = wrapper.getComponent(AuthTurnstileFieldStub)
+    const submit = wrapper.get('button.submit-btn')
+
+    turnstile.vm.$emit('success', 'verified-token')
+    await inputs[0].setValue('invalid-email')
+    await inputs[1].setValue('ValidPass123')
+
+    expect(wrapper.get('.input-wrapper.has-error .error-msg').text()).toBe('Invalid email format')
+    expect(submit.attributes('disabled')).toBeDefined()
+
+    await inputs[1].trigger('keyup.enter')
+    await flushPromises()
+    expect(emailLoginCalls()).toHaveLength(0)
+
+    await inputs[0].setValue('person@example.com')
+    expect(wrapper.find('.input-wrapper.has-error').exists()).toBe(false)
+    expect(submit.attributes('disabled')).toBeUndefined()
+
+    wrapper.unmount()
+  })
+
   it.each([
     ['short credential', 'short'],
     ['credential longer than the creation limit', 'This-credential-is-longer-than-twenty-characters'],


### PR DESCRIPTION
## Summary

- validate malformed email addresses in the password sign-in flow
- show the existing Invalid email format field message before submission
- cover disabled submission, Enter-key submission, and recovery after correcting the email

## Verification

- npm run test -- --run src/pages/auth/LoginTurnstileLifecycle.test.ts (16 passed)
- npm run build
- ESLint error-level check for the changed files

Fixes #249