### PR TITLE
feat: add privacy-safe Sentry observability

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,11 @@ APP_VERSION=0.1.0
 # Artifact channel: release for vX.Y.Z packages, main for main-<commit> builds.
 HFL_RELEASE_CHANNEL=release
 
+# Deployment ownership used only for observability tags. GitHub-managed targets
+# replace these with managed and test/preprod/prod before services start.
+HFL_DEPLOYMENT_MODE=standalone
+HFL_DEPLOY_TARGET=
+
 # Agent release selected by the control plane. The release installer replaces it.
 AGENT_VERSION=0.1.0
 
@@ -305,26 +310,24 @@ DEFAULT_FROM_EMAIL=HyperFileLens <noreply@hyperfilelens.local>
 # Observability and logging
 # ==============================================================================
 
-# Enable Sentry for backend services and frontend release builds.
+# Enable Sentry for the complete HFL-managed application stack.
 SENTRY_ENABLED=false
 
-# Sentry data source name; required when SENTRY_ENABLED=true.
-SENTRY_DSN=
+# Server-side DSN shared by HFL backend, bundled SourceLens backend, and the
+# installer-managed local Platform Gateway. Never baked into release images.
+SENTRY_BACKEND_DSN=
 
-# Optional deployment label reported to Sentry; release builds default to production.
+# Browser DSN shared by the HFL and bundled SourceLens user interfaces.
+# Browser DSNs are public ingest identifiers, but remain runtime-only so
+# standalone/offline releases do not report to the managed HFL projects.
+SENTRY_FRONTEND_DSN=
+
+# Deployment label reported to Sentry (managed targets use hfl-test,
+# hfl-preprod, or hfl-production).
 SENTRY_ENVIRONMENT=
-
-# Release identifier; empty falls back to APP_VERSION.
-SENTRY_RELEASE=
 
 # Fraction of transactions traced by Sentry, from 0.0 to 1.0.
 SENTRY_TRACES_SAMPLE_RATE=0
-
-# Fraction of traced transactions profiled by the backend, from 0.0 to 1.0.
-SENTRY_PROFILES_SAMPLE_RATE=0
-
-# Include personally identifiable information in Sentry events.
-SENTRY_SEND_DEFAULT_PII=false
 
 # Backend logging threshold.
 LOG_LEVEL=INFO

--- a/.github/workflows/artifact_pipeline.yml
+++ b/.github/workflows/artifact_pipeline.yml
@@ -224,6 +224,7 @@ jobs:
           ./tools/quality/test-deployment-optional-config.sh
           ./tools/quality/test-website-runtime-config.sh
           ./tools/quality/test-ga-runtime-config.sh
+          ./tools/quality/test-sentry-runtime-config.sh
           ./tools/quality/test-payload-tree-hash.sh
           ./tools/quality/test-ci-release-assembly.sh
           HFL_TEST_VERSION=main-0123456 ./tools/quality/test-ci-release-assembly.sh
@@ -329,12 +330,13 @@ jobs:
             IMAGE_VERSION=${{ needs.prepare.outputs.version }}
             IMAGE_REVISION=${{ needs.prepare.outputs.commit }}
             PIP_TIMEOUT=600
-            SENTRY_ENABLED=false
-            SENTRY_ENVIRONMENT=production
-            SENTRY_RELEASE=${{ needs.prepare.outputs.tag }}
-            SENTRY_TRACES_SAMPLE_RATE=0
-            SENTRY_SEND_DEFAULT_PII=false
+            SENTRY_URL=${{ vars.SENTRY_URL }}
+            SENTRY_ORG=${{ vars.SENTRY_ORG }}
+            SENTRY_FRONTEND_PROJECT=${{ vars.SENTRY_FRONTEND_PROJECT }}
+            SENTRY_RELEASE=hyperfilelens-frontend@${{ needs.prepare.outputs.version }}
             VITE_SHOW_EULA=false
+          secrets: |
+            sentry_auth_token=${{ secrets.SENTRY_AUTH_TOKEN }}
           cache-from: type=gha,scope=${{ matrix.cache_scope }}
           cache-to: type=gha,scope=${{ matrix.cache_scope }},mode=min
 
@@ -382,6 +384,10 @@ jobs:
       - name: Build and push bundled SourceLens component
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          SENTRY_URL: ${{ vars.SENTRY_URL }}
+          SENTRY_ORG: ${{ vars.SENTRY_ORG }}
+          SENTRY_FRONTEND_PROJECT: ${{ vars.SENTRY_FRONTEND_PROJECT }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: |
           ./release/ci/build-sourcelens-image.sh \
             "${{ matrix.component }}" \
@@ -884,6 +890,7 @@ jobs:
       email_code_login_enabled: ${{ vars.TEST_EMAIL_CODE_LOGIN_ENABLED != 'false' }}
       google_oauth_enabled: ${{ vars.TEST_GOOGLE_OAUTH_ENABLED == 'true' }}
       google_client_id: ${{ vars.TEST_GOOGLE_CLIENT_ID }}
+      sentry_enabled: ${{ vars.TEST_SENTRY_ENABLED == 'true' }}
       platform_gateway_auto_deploy: ${{ vars.TEST_PLATFORM_GATEWAY_AUTO_DEPLOY == 'true' }}
       hfl_insecure_tls: ${{ vars.TEST_HFL_INSECURE_TLS }}
       smtp_host: ${{ vars.TEST_SMTP_HOST }}
@@ -901,6 +908,9 @@ jobs:
       google_client_secret: ${{ secrets.TEST_GOOGLE_CLIENT_SECRET }}
       ai_model_api_base: ${{ secrets.TEST_AI_MODEL_API_BASE }}
       ai_model_api_key: ${{ secrets.TEST_AI_MODEL_API_KEY }}
+      sentry_backend_dsn: ${{ secrets.SENTRY_BACKEND_DSN }}
+      sentry_frontend_dsn: ${{ secrets.SENTRY_FRONTEND_DSN }}
+      sentry_auth_token: ${{ secrets.SENTRY_AUTH_TOKEN }}
 
   deploy-preprod:
     name: Deploy · PREPROD
@@ -931,6 +941,7 @@ jobs:
       email_code_login_enabled: ${{ vars.PREPROD_EMAIL_CODE_LOGIN_ENABLED != 'false' }}
       google_oauth_enabled: ${{ vars.PREPROD_GOOGLE_OAUTH_ENABLED == 'true' }}
       google_client_id: ${{ vars.PREPROD_GOOGLE_CLIENT_ID }}
+      sentry_enabled: ${{ vars.PREPROD_SENTRY_ENABLED == 'true' }}
       platform_gateway_auto_deploy: ${{ vars.PREPROD_PLATFORM_GATEWAY_AUTO_DEPLOY == 'true' }}
       hfl_insecure_tls: ${{ vars.PREPROD_HFL_INSECURE_TLS }}
       smtp_host: ${{ vars.PREPROD_SMTP_HOST }}
@@ -948,6 +959,9 @@ jobs:
       google_client_secret: ${{ secrets.PREPROD_GOOGLE_CLIENT_SECRET }}
       ai_model_api_base: ${{ secrets.PREPROD_AI_MODEL_API_BASE }}
       ai_model_api_key: ${{ secrets.PREPROD_AI_MODEL_API_KEY }}
+      sentry_backend_dsn: ${{ secrets.SENTRY_BACKEND_DSN }}
+      sentry_frontend_dsn: ${{ secrets.SENTRY_FRONTEND_DSN }}
+      sentry_auth_token: ${{ secrets.SENTRY_AUTH_TOKEN }}
 
   cleanup-main-builds:
     name: Cleanup · Main releases

--- a/.github/workflows/deploy_target.yml
+++ b/.github/workflows/deploy_target.yml
@@ -81,6 +81,11 @@ on:
         required: false
         default: ''
         type: string
+      sentry_enabled:
+        description: Enable HFL-managed Sentry reporting for this deployment target
+        required: false
+        default: false
+        type: boolean
       platform_gateway_auto_deploy:
         description: Automatically deploy an HFL-managed local platform Gateway
         required: false
@@ -149,6 +154,15 @@ on:
       ai_model_api_key:
         description: Optional API key for the deployment-managed model
         required: false
+      sentry_backend_dsn:
+        description: Optional HFL backend Sentry DSN
+        required: false
+      sentry_frontend_dsn:
+        description: Optional HFL browser Sentry DSN
+        required: false
+      sentry_auth_token:
+        description: Optional Sentry API token used only for deployment markers
+        required: false
 
 permissions:
   contents: read
@@ -187,6 +201,9 @@ jobs:
           GOOGLE_CLIENT_ID: ${{ inputs.google_client_id }}
           GOOGLE_CLIENT_SECRET: ${{ secrets.google_client_secret }}
           GA_MEASUREMENT_ID: ${{ inputs.ga_measurement_id }}
+          SENTRY_ENABLED: ${{ inputs.sentry_enabled }}
+          SENTRY_BACKEND_DSN: ${{ secrets.sentry_backend_dsn }}
+          SENTRY_FRONTEND_DSN: ${{ secrets.sentry_frontend_dsn }}
           TURNSTILE_ENABLED: ${{ inputs.turnstile_enabled }}
           TURNSTILE_SITE_KEY: ${{ inputs.turnstile_site_key }}
           TURNSTILE_SECRET_KEY: ${{ secrets.turnstile_secret_key }}
@@ -284,6 +301,10 @@ jobs:
           if [[ "$DEPLOY_TARGET" != "prod" && -n "$GA_MEASUREMENT_ID" ]]; then
             echo '::warning title=Google Analytics configuration::Analytics is only supported for the production SaaS target; the supplied value will be ignored.'
           fi
+          if [[ "$SENTRY_ENABLED" == "true" ]] \
+            && { [[ -z "$SENTRY_BACKEND_DSN" ]] || [[ -z "$SENTRY_FRONTEND_DSN" ]]; }; then
+            echo '::warning title=Sentry configuration::Sentry is enabled without both HFL DSNs; the invalid surface will be disabled and deployment will continue.'
+          fi
           if [[ "$TURNSTILE_ENABLED" == "true" ]] \
             && { [[ -z "$TURNSTILE_SITE_KEY" ]] || [[ -z "$TURNSTILE_SECRET_KEY" ]]; }; then
             echo '::warning title=Turnstile configuration::Turnstile is enabled without complete credentials; deployment will continue.'
@@ -339,6 +360,9 @@ jobs:
           HFL_EMAIL_CODE_LOGIN_ENABLED: ${{ inputs.email_code_login_enabled }}
           HFL_GOOGLE_OAUTH_ENABLED: ${{ inputs.google_oauth_enabled }}
           HFL_GA_MEASUREMENT_ID: ${{ inputs.ga_measurement_id }}
+          SENTRY_ENABLED: ${{ inputs.sentry_enabled }}
+          SENTRY_BACKEND_DSN: ${{ secrets.sentry_backend_dsn }}
+          SENTRY_FRONTEND_DSN: ${{ secrets.sentry_frontend_dsn }}
           GOOGLE_CLIENT_ID: ${{ inputs.google_client_id }}
           GOOGLE_CLIENT_SECRET: ${{ secrets.google_client_secret }}
         shell: bash
@@ -361,6 +385,12 @@ jobs:
               "HFL_GA_MEASUREMENT_ID",
               "HFL_INSECURE_TLS",
               "HFL_PLATFORM_GATEWAY_AUTO_DEPLOY",
+              "HFL_DEPLOY_TARGET",
+              "SENTRY_ENABLED",
+              "SENTRY_BACKEND_DSN",
+              "SENTRY_FRONTEND_DSN",
+              "SENTRY_ENVIRONMENT",
+              "SENTRY_TRACES_SAMPLE_RATE",
               "TURNSTILE_ENABLED",
               "TURNSTILE_SITE_KEY",
               "TURNSTILE_SECRET_KEY",
@@ -376,6 +406,17 @@ jobs:
           lines = []
           for name in names:
               value = os.environ.get(name, "")
+              if name == "HFL_DEPLOY_TARGET":
+                  value = os.environ.get("DEPLOY_TARGET", "")
+              elif name == "SENTRY_ENVIRONMENT":
+                  target = os.environ.get("DEPLOY_TARGET", "")
+                  value = {
+                      "test": "hfl-test",
+                      "preprod": "hfl-preprod",
+                      "prod": "hfl-production",
+                  }.get(target, "")
+              elif name == "SENTRY_TRACES_SAMPLE_RATE":
+                  value = "0.05" if os.environ.get("DEPLOY_TARGET") == "prod" else "0.1"
               if name == "HFL_GA_MEASUREMENT_ID":
                   if os.environ.get("DEPLOY_TARGET") != "prod":
                       value = ""
@@ -610,4 +651,103 @@ jobs:
           else
             printf '### Public endpoint check\n\nPassed: `%s`\n' "$endpoint" >> "$GITHUB_STEP_SUMMARY"
           fi
+          exit 0
+
+      - name: Record Sentry Deployment
+        env:
+          SENTRY_ENABLED: ${{ inputs.sentry_enabled }}
+          SENTRY_URL: ${{ vars.SENTRY_URL }}
+          SENTRY_ORG: ${{ vars.SENTRY_ORG }}
+          SENTRY_BACKEND_PROJECT: ${{ vars.SENTRY_BACKEND_PROJECT }}
+          SENTRY_FRONTEND_PROJECT: ${{ vars.SENTRY_FRONTEND_PROJECT }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.sentry_auth_token }}
+          DEPLOY_TARGET: ${{ inputs.target }}
+          ARTIFACT_ID: ${{ inputs.tag }}
+        shell: bash
+        run: |
+          set +e
+          python3 - <<'PY'
+          import json
+          import os
+          import pathlib
+          import re
+          import urllib.error
+          import urllib.parse
+          import urllib.request
+
+          if os.environ.get("SENTRY_ENABLED", "").lower() != "true":
+              print("Sentry deployment marker skipped: reporting is disabled.")
+              raise SystemExit(0)
+          url = os.environ.get("SENTRY_URL", "").rstrip("/")
+          org = os.environ.get("SENTRY_ORG", "")
+          backend_project = os.environ.get("SENTRY_BACKEND_PROJECT", "")
+          frontend_project = os.environ.get("SENTRY_FRONTEND_PROJECT", "")
+          token = os.environ.get("SENTRY_AUTH_TOKEN", "")
+          if not all((url, org, backend_project, frontend_project, token)):
+              print("::warning title=Sentry deployment::Deployment marker configuration is incomplete; continuing.")
+              raise SystemExit(0)
+
+          artifact = os.environ.get("ARTIFACT_ID", "").removeprefix("v")
+          defaults = pathlib.Path("tools/sourcelens/defaults.env").read_text(encoding="utf-8")
+          match = re.search(r"SOURCELENS_GIT_REF=.*?v(\d+\.\d+\.\d+)", defaults)
+          sl_version = match.group(1) if match else "unknown"
+          releases = (
+              (f"hyperfilelens-backend@{artifact}", backend_project),
+              (f"hyperfilelens-frontend@{artifact}", frontend_project),
+              (f"hyperfilelens-sourcelens@{artifact}-sl{sl_version}", backend_project),
+              (f"hyperfilelens-sourcelens-frontend@{artifact}-sl{sl_version}", frontend_project),
+              (f"hyperfilelens-agent@{artifact}", backend_project),
+              (f"hyperfilelens-lensnode@{artifact}-sl{sl_version}", backend_project),
+          )
+          environment = {
+              "test": "hfl-test",
+              "preprod": "hfl-preprod",
+              "prod": "hfl-production",
+          }[os.environ["DEPLOY_TARGET"]]
+          failed = []
+          release_endpoint = (
+              f"{url}/api/0/organizations/{urllib.parse.quote(org, safe='')}/releases/"
+          )
+          for release, project in releases:
+              create_request = urllib.request.Request(
+                  release_endpoint,
+                  data=json.dumps({"version": release, "projects": [project]}).encode(),
+                  headers={
+                      "Authorization": f"Bearer {token}",
+                      "Content-Type": "application/json",
+                  },
+                  method="POST",
+              )
+              try:
+                  with urllib.request.urlopen(create_request, timeout=15) as response:
+                      response.read()
+              except urllib.error.HTTPError as exc:
+                  if exc.code not in {208, 409}:
+                      failed.append(f"{release} create: HTTP {exc.code}")
+              except (OSError, urllib.error.URLError) as exc:
+                  failed.append(f"{release} create: {type(exc).__name__}")
+              endpoint = (
+                  f"{url}/api/0/organizations/{urllib.parse.quote(org, safe='')}/releases/"
+                  f"{urllib.parse.quote(release, safe='')}/deploys/"
+              )
+              payload = json.dumps({"environment": environment, "name": environment}).encode()
+              request = urllib.request.Request(
+                  endpoint,
+                  data=payload,
+                  headers={
+                      "Authorization": f"Bearer {token}",
+                      "Content-Type": "application/json",
+                  },
+                  method="POST",
+              )
+              try:
+                  with urllib.request.urlopen(request, timeout=15) as response:
+                      response.read()
+              except (OSError, urllib.error.URLError, urllib.error.HTTPError) as exc:
+                  failed.append(f"{release}: {type(exc).__name__}")
+          if failed:
+              print("::warning title=Sentry deployment::Some deployment markers failed; continuing: " + ", ".join(failed))
+          else:
+              print(f"Recorded {len(releases)} Sentry releases in {environment}.")
+          PY
           exit 0

--- a/.github/workflows/production_deploy.yml
+++ b/.github/workflows/production_deploy.yml
@@ -81,6 +81,7 @@ jobs:
       google_oauth_enabled: ${{ vars.PROD_GOOGLE_OAUTH_ENABLED == 'true' }}
       google_client_id: ${{ vars.PROD_GOOGLE_CLIENT_ID }}
       ga_measurement_id: ${{ vars.PROD_GA_MEASUREMENT_ID }}
+      sentry_enabled: ${{ vars.PROD_SENTRY_ENABLED == 'true' }}
       platform_gateway_auto_deploy: ${{ vars.PROD_PLATFORM_GATEWAY_AUTO_DEPLOY == 'true' }}
       hfl_insecure_tls: ${{ vars.PROD_HFL_INSECURE_TLS }}
       smtp_host: ${{ vars.PROD_SMTP_HOST }}
@@ -98,3 +99,6 @@ jobs:
       google_client_secret: ${{ secrets.PROD_GOOGLE_CLIENT_SECRET }}
       ai_model_api_base: ${{ secrets.PROD_AI_MODEL_API_BASE }}
       ai_model_api_key: ${{ secrets.PROD_AI_MODEL_API_KEY }}
+      sentry_backend_dsn: ${{ secrets.SENTRY_BACKEND_DSN }}
+      sentry_frontend_dsn: ${{ secrets.SENTRY_FRONTEND_DSN }}
+      sentry_auth_token: ${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,6 +93,7 @@ jobs:
       email_code_login_enabled: ${{ vars.PREPROD_EMAIL_CODE_LOGIN_ENABLED != 'false' }}
       google_oauth_enabled: ${{ vars.PREPROD_GOOGLE_OAUTH_ENABLED == 'true' }}
       google_client_id: ${{ vars.PREPROD_GOOGLE_CLIENT_ID }}
+      sentry_enabled: ${{ vars.PREPROD_SENTRY_ENABLED == 'true' }}
       platform_gateway_auto_deploy: ${{ vars.PREPROD_PLATFORM_GATEWAY_AUTO_DEPLOY == 'true' }}
       hfl_insecure_tls: ${{ vars.PREPROD_HFL_INSECURE_TLS }}
       smtp_host: ${{ vars.PREPROD_SMTP_HOST }}
@@ -110,3 +111,6 @@ jobs:
       google_client_secret: ${{ secrets.PREPROD_GOOGLE_CLIENT_SECRET }}
       ai_model_api_base: ${{ secrets.PREPROD_AI_MODEL_API_BASE }}
       ai_model_api_key: ${{ secrets.PREPROD_AI_MODEL_API_KEY }}
+      sentry_backend_dsn: ${{ secrets.SENTRY_BACKEND_DSN }}
+      sentry_frontend_dsn: ${{ secrets.SENTRY_FRONTEND_DSN }}
+      sentry_auth_token: ${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/deploy/bootstrap/gateway-install-lensnode-sidecar.sh
+++ b/deploy/bootstrap/gateway-install-lensnode-sidecar.sh
@@ -7,6 +7,7 @@ ENV_FILE="${HFL_LENS_ENV_FILE:-/etc/hyperfilelens/lensnode.env}"
 COMPOSE_DIR="/etc/hyperfilelens/lensnode"
 COMPOSE_PROJECT="hyperfilelens-gateway"
 DEFAULT_LENSNODE_IMAGE="${LENSNODE_IMAGE:-hyperfilelens-sourcelens-lensnode:latest}"
+SENTRY_PRIVACY_FILE="${COMPOSE_DIR}/hfl-sentry-sitecustomize.py"
 
 hfl_now() {
 	date -u +%Y-%m-%dT%H:%M:%S.000Z 2>/dev/null || date -u +%Y-%m-%dT%H:%M:%SZ
@@ -94,6 +95,35 @@ chmod 0700 "${HFL_GATEWAY_STATE_ROOT}" \
 	"${HFL_GATEWAY_TRASH_ROOT}"
 
 mkdir -p "${COMPOSE_DIR}"
+chmod 0700 "${COMPOSE_DIR}"
+
+prepare_sentry_privacy_adapter() {
+	case "${SENTRY_ENABLED:-false}" in
+	1 | true | TRUE | yes | YES | on | ON) ;;
+	*) return 0 ;;
+	esac
+	local base="${HFL_API_BASE:-}" temporary="${SENTRY_PRIVACY_FILE}.tmp.$$"
+	if [[ -z "${base}" ]]; then
+		hfl_warn "Sentry privacy adapter URL is unavailable; LensNode reporting is disabled."
+		SENTRY_ENABLED=false
+		SENTRY_BACKEND_DSN=
+		return 0
+	fi
+	if ! curl "${CURL_TLS[@]}" -fsSL \
+		"${base%/}/media/gateway-bootstrap/hfl-sentry-sitecustomize.py" \
+		-o "${temporary}" \
+		|| ! grep -Fx '# HFL_SENTRY_PRIVACY_ADAPTER=1' "${temporary}" >/dev/null; then
+		rm -f "${temporary}"
+		hfl_warn "Sentry privacy adapter download failed; LensNode reporting is disabled."
+		SENTRY_ENABLED=false
+		SENTRY_BACKEND_DSN=
+		return 0
+	fi
+	chmod 0644 "${temporary}"
+	mv -f "${temporary}" "${SENTRY_PRIVACY_FILE}"
+}
+
+prepare_sentry_privacy_adapter
 
 resolve_lensnode_image() {
 	local candidate
@@ -142,6 +172,9 @@ remove_owned_legacy_gateway_containers() {
 install_docker_sidecar() {
 	local image="$1"
 	local ssl_verify="${LENSNODE_SSL_VERIFY:-}"
+	local sentry_volume_block=""
+	local compose_file="${COMPOSE_DIR}/docker-compose.yml"
+	local compose_temporary="${COMPOSE_DIR}/.docker-compose.yml.tmp.$$"
 	if [[ -z "${ssl_verify}" ]]; then
 		if [[ "${HFL_INSECURE_TLS}" == "1" ]]; then
 			ssl_verify="false"
@@ -157,7 +190,12 @@ install_docker_sidecar() {
 	if lens_url_needs_extra_hosts "${LENS_CONTAINER_URL}"; then
 		EXTRA_HOSTS_BLOCK=$'    extra_hosts:\n      - "host.docker.internal:host-gateway"\n'
 	fi
-	cat >"${COMPOSE_DIR}/docker-compose.yml" <<EOF
+	if [[ -f "${SENTRY_PRIVACY_FILE}" ]]; then
+		sentry_volume_block="      - ${SENTRY_PRIVACY_FILE}:/opt/hfl-sentry/sitecustomize.py:ro"
+	fi
+	(
+		umask 077
+		cat >"${compose_temporary}" <<EOF
 name: ${COMPOSE_PROJECT}
 
 services:
@@ -175,7 +213,18 @@ ${EXTRA_HOSTS_BLOCK}    environment:
       HFL_INSECURE_TLS: "${HFL_INSECURE_TLS}"
       LENSNODE_INSECURE_TLS: "${HFL_INSECURE_TLS}"
       LENSNODE_SSL_VERIFY: "${ssl_verify}"
+      PYTHONPATH: /opt/hfl-sentry
+      SENTRY_COMPONENT: sourcelens-lensnode
+      SENTRY_DEPLOYMENT_MODE: gateway
+      SENTRY_ENABLED: "${SENTRY_ENABLED:-false}"
+      SENTRY_DSN: "${SENTRY_BACKEND_DSN:-}"
+      SENTRY_ENVIRONMENT: "${SENTRY_ENVIRONMENT:-}"
+      SENTRY_RELEASE: "${HFL_SENTRY_LENSNODE_RELEASE:-}"
+      SENTRY_TRACES_SAMPLE_RATE: "${SENTRY_TRACES_SAMPLE_RATE:-0}"
+      SENTRY_SEND_DEFAULT_PII: "false"
+      SENTRY_SERVICE: lensnode
     volumes:
+${sentry_volume_block}
       # LensNode only indexes managed data. The host Agent is the sole writer
       # and lifecycle owner for this filesystem boundary.
       - ${HFL_WORKSPACE_ROOT}:${HFL_WORKSPACE_ROOT}:ro
@@ -185,6 +234,10 @@ ${EXTRA_HOSTS_BLOCK}    environment:
     mem_limit: 512m
     cpus: 0.50
 EOF
+	)
+	chmod 0600 "${compose_temporary}"
+	mv -f "${compose_temporary}" "${compose_file}"
+	chmod 0600 "${compose_file}"
 	if docker compose version >/dev/null 2>&1; then
 		remove_owned_legacy_gateway_containers
 		(

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -26,6 +26,9 @@ services:
     environment:
       TZ: UTC
       LOG_FILE: /var/log/hyperfilelens/worker.log
+      SENTRY_COMPONENT: hfl-backend
+      SENTRY_SERVICE: worker
+      SENTRY_RELEASE: hyperfilelens-backend@${APP_VERSION:-unknown}
     volumes:
       - ./data/lang-packs:/opt/backend/lang-packs:ro
       - ./data/media:/opt/backend/media
@@ -59,6 +62,9 @@ services:
     environment:
       TZ: UTC
       LOG_FILE: /var/log/hyperfilelens/scheduler.log
+      SENTRY_COMPONENT: hfl-backend
+      SENTRY_SERVICE: scheduler
+      SENTRY_RELEASE: hyperfilelens-backend@${APP_VERSION:-unknown}
     volumes:
       - ./data/lang-packs:/opt/backend/lang-packs:ro
       - ./data/media:/opt/backend/media
@@ -95,6 +101,9 @@ services:
       TZ: UTC
       LOG_FILE: /var/log/hyperfilelens/api.log
       API_WORKERS: "1"
+      SENTRY_COMPONENT: hfl-backend
+      SENTRY_SERVICE: api
+      SENTRY_RELEASE: hyperfilelens-backend@${APP_VERSION:-unknown}
     volumes:
       - ./data/lang-packs:/opt/backend/lang-packs:ro
       - ./data/media:/opt/backend/media
@@ -183,6 +192,11 @@ services:
       TZ: UTC
       HFL_WEBSITE_APP_URL: ${FRONTEND_URL:-}
       HFL_GA_MEASUREMENT_ID: ${HFL_GA_MEASUREMENT_ID:-}
+      HFL_SENTRY_ENABLED: ${SENTRY_ENABLED:-false}
+      HFL_SENTRY_DSN: ${SENTRY_FRONTEND_DSN:-}
+      HFL_SENTRY_ENVIRONMENT: ${SENTRY_ENVIRONMENT:-}
+      HFL_SENTRY_RELEASE: hyperfilelens-frontend@${APP_VERSION:-unknown}
+      HFL_SENTRY_TRACES_SAMPLE_RATE: ${SENTRY_TRACES_SAMPLE_RATE:-0}
       LOGROTATE_INTERVAL_SECONDS: "3600"
       LOGROTATE_STATE: /var/log/hyperfilelens/.logrotate.status
       LOGROTATE_LOCK: /var/log/hyperfilelens/.logrotate.lock

--- a/deploy/docker/frontend-runtime-config.sh
+++ b/deploy/docker/frontend-runtime-config.sh
@@ -7,6 +7,11 @@ tenant_output=${HFL_TENANT_CONFIG_OUTPUT:-/usr/share/nginx/runtime/tenant-app-ru
 admin_output=${HFL_ADMIN_CONFIG_OUTPUT:-/usr/share/nginx/runtime/admin-app-runtime-config.js}
 app_url=${HFL_WEBSITE_APP_URL:-}
 ga_measurement_id=${HFL_GA_MEASUREMENT_ID:-}
+sentry_enabled=${HFL_SENTRY_ENABLED:-false}
+sentry_dsn=${HFL_SENTRY_DSN:-}
+sentry_environment=${HFL_SENTRY_ENVIRONMENT:-}
+sentry_release=${HFL_SENTRY_RELEASE:-}
+sentry_traces_sample_rate=${HFL_SENTRY_TRACES_SAMPLE_RATE:-0}
 
 if [ -n "${app_url}" ] && ! printf '%s' "${app_url}" \
   | grep -Eq '^[Hh][Tt][Tt][Pp][Ss]?://(\[[0-9A-Fa-f:]+\]|[A-Za-z0-9.-]+)(:[0-9]{1,5})?/?$'; then
@@ -18,6 +23,36 @@ if [ -n "${ga_measurement_id}" ] && ! printf '%s' "${ga_measurement_id}" \
   | grep -Eq '^G-[A-Z0-9]+$'; then
   printf '%s\n' '[frontend-config] WARNING: invalid GA4 measurement ID; analytics is disabled' >&2
   ga_measurement_id=
+fi
+
+case "$(printf '%s' "${sentry_enabled}" | tr '[:upper:]' '[:lower:]')" in
+  1|true|yes|on) sentry_enabled=true ;;
+  *) sentry_enabled=false ;;
+esac
+if [ "${sentry_enabled}" = true ]; then
+  if [ -z "${sentry_dsn}" ] || ! printf '%s' "${sentry_dsn}" \
+    | grep -Eq '^https?://[^[:space:]:"'"'"'\\]+@[^[:space:]"'"'"'\\/]+(:[0-9]{1,5})?(/[^[:space:]"'"'"'\\]*)?/[0-9]+$'; then
+    printf '%s\n' '[frontend-config] WARNING: invalid Sentry frontend DSN; browser reporting is disabled' >&2
+    sentry_enabled=false
+    sentry_dsn=
+  fi
+fi
+if [ -n "${sentry_environment}" ] && ! printf '%s' "${sentry_environment}" \
+  | grep -Eq '^[A-Za-z0-9._-]+$'; then
+  printf '%s\n' '[frontend-config] WARNING: invalid Sentry environment; browser reporting is disabled' >&2
+  sentry_enabled=false
+  sentry_environment=
+fi
+if [ -n "${sentry_release}" ] && ! printf '%s' "${sentry_release}" \
+  | grep -Eq '^[A-Za-z0-9._@+-]+$'; then
+  printf '%s\n' '[frontend-config] WARNING: invalid Sentry release; browser reporting is disabled' >&2
+  sentry_enabled=false
+  sentry_release=
+fi
+if ! printf '%s' "${sentry_traces_sample_rate}" \
+  | grep -Eq '^(0(\.[0-9]+)?|1(\.0+)?)$'; then
+  printf '%s\n' '[frontend-config] WARNING: invalid Sentry trace sample rate; using 0' >&2
+  sentry_traces_sample_rate=0
 fi
 
 write_config() {
@@ -33,7 +68,7 @@ write_config() {
 write_config "${website_output}" \
   "window.__HFL_WEBSITE_CONFIG__ = Object.freeze({ appUrl: '${app_url%/}', gaMeasurementId: '${ga_measurement_id}' })"
 write_config "${tenant_output}" \
-  "window.__HFL_APP_CONFIG__ = Object.freeze({ gaMeasurementId: '${ga_measurement_id}' })"
+  "window.__HFL_APP_CONFIG__ = Object.freeze({ gaMeasurementId: '${ga_measurement_id}', sentryEnabled: ${sentry_enabled}, sentryDsn: '${sentry_dsn}', sentryEnvironment: '${sentry_environment}', sentryRelease: '${sentry_release}', sentryTracesSampleRate: ${sentry_traces_sample_rate}, sentrySurface: 'tenant' })"
 # Platform Operations and Django Admin must never emit SaaS analytics.
 write_config "${admin_output}" \
-  "window.__HFL_APP_CONFIG__ = Object.freeze({ gaMeasurementId: '' })"
+  "window.__HFL_APP_CONFIG__ = Object.freeze({ gaMeasurementId: '', sentryEnabled: ${sentry_enabled}, sentryDsn: '${sentry_dsn}', sentryEnvironment: '${sentry_environment}', sentryRelease: '${sentry_release}', sentryTracesSampleRate: ${sentry_traces_sample_rate}, sentrySurface: 'admin' })"

--- a/deploy/docker/frontend.Dockerfile
+++ b/deploy/docker/frontend.Dockerfile
@@ -5,13 +5,11 @@ FROM node:22-alpine AS frontend-dependencies
 LABEL org.opencontainers.image.title="hyperfilelens-frontend"
 
 ARG NPM_REGISTRY
-ARG SENTRY_ENABLED=false
-ARG SENTRY_DSN=
-ARG SENTRY_ENVIRONMENT=
-ARG SENTRY_RELEASE=
-ARG SENTRY_TRACES_SAMPLE_RATE=0
-ARG SENTRY_SEND_DEFAULT_PII=false
 ARG VITE_SHOW_EULA=false
+ARG SENTRY_URL=
+ARG SENTRY_ORG=
+ARG SENTRY_FRONTEND_PROJECT=
+ARG SENTRY_RELEASE=
 
 WORKDIR /app
 COPY src/frontend/package.json src/frontend/package-lock.json ./
@@ -32,14 +30,11 @@ ENTRYPOINT ["/usr/local/bin/hfl-frontend-dev"]
 FROM frontend-dependencies AS frontend-build
 
 COPY src/frontend/ ./
-ENV SENTRY_ENABLED=${SENTRY_ENABLED} \
-    SENTRY_DSN=${SENTRY_DSN} \
-    SENTRY_ENVIRONMENT=${SENTRY_ENVIRONMENT} \
-    SENTRY_RELEASE=${SENTRY_RELEASE} \
-    SENTRY_TRACES_SAMPLE_RATE=${SENTRY_TRACES_SAMPLE_RATE} \
-    SENTRY_SEND_DEFAULT_PII=${SENTRY_SEND_DEFAULT_PII} \
-    VITE_SHOW_EULA=${VITE_SHOW_EULA}
-RUN npm run build
+ENV VITE_SHOW_EULA=${VITE_SHOW_EULA}
+RUN --mount=type=secret,id=sentry_auth_token \
+    SENTRY_AUTH_TOKEN="$(cat /run/secrets/sentry_auth_token 2>/dev/null || true)" \
+    npm run build \
+ && find dist -type f -name '*.map' -delete
 
 # Serve the SPA, standalone Website artifact, and reverse proxy through Nginx.
 FROM nginx:stable-alpine

--- a/deploy/installer/apply-runtime-config.py
+++ b/deploy/installer/apply-runtime-config.py
@@ -18,6 +18,12 @@ RUNTIME_KEYS = {
     "HFL_GA_MEASUREMENT_ID",
     "HFL_INSECURE_TLS",
     "HFL_PLATFORM_GATEWAY_AUTO_DEPLOY",
+    "HFL_DEPLOY_TARGET",
+    "SENTRY_ENABLED",
+    "SENTRY_BACKEND_DSN",
+    "SENTRY_FRONTEND_DSN",
+    "SENTRY_ENVIRONMENT",
+    "SENTRY_TRACES_SAMPLE_RATE",
     "TURNSTILE_ENABLED",
     "TURNSTILE_SITE_KEY",
     "TURNSTILE_SECRET_KEY",
@@ -35,6 +41,7 @@ GOOGLE_CLIENT_ID_PATTERN = re.compile(
     r"^[0-9]+-[A-Za-z0-9_-]+\.apps\.googleusercontent\.com$"
 )
 GA4_MEASUREMENT_ID_PATTERN = re.compile(r"^G-[A-Z0-9]+$")
+SENTRY_ENVIRONMENT_PATTERN = re.compile(r"^hfl-(test|preprod|production)$")
 
 
 def warn(message: str) -> None:
@@ -207,6 +214,80 @@ def analytics_runtime_update(values: Dict[str, str]) -> Tuple[bool, str]:
     return True, measurement_id
 
 
+def valid_sentry_dsn(value: str) -> bool:
+    """Return whether a staged value is a structurally valid Sentry DSN."""
+    try:
+        parsed = urlsplit(value)
+        parsed.port
+    except ValueError:
+        return False
+    project_id = parsed.path.rstrip("/").rsplit("/", 1)[-1]
+    return bool(
+        parsed.scheme in {"http", "https"}
+        and parsed.hostname
+        and parsed.username
+        and not parsed.query
+        and not parsed.fragment
+        and project_id.isdigit()
+        and not re.search(r"[\x00\r\n\s]", value)
+    )
+
+
+def valid_frontend_sentry_dsn(value: str) -> bool:
+    """Return whether a DSN is safe to expose in browser runtime config."""
+    if not valid_sentry_dsn(value):
+        return False
+    return urlsplit(value).password is None
+
+
+def sentry_runtime_updates(
+    values: Dict[str, str],
+) -> Tuple[Dict[str, str], Set[str]]:
+    """Validate managed Sentry settings without blocking deployment."""
+    enabled = values.get("SENTRY_ENABLED", "").strip().lower()
+    if enabled not in {"true", "false"}:
+        warn("invalid Sentry enabled value; preserving installed Sentry settings")
+        return {}, set()
+
+    updates = {"SENTRY_ENABLED": enabled}
+    removals: Set[str] = set()
+    if enabled == "false":
+        removals.update({"SENTRY_BACKEND_DSN", "SENTRY_FRONTEND_DSN"})
+        return updates, removals
+
+    environment = values.get("SENTRY_ENVIRONMENT", "").strip()
+    if not SENTRY_ENVIRONMENT_PATTERN.fullmatch(environment):
+        warn("invalid Sentry environment; Sentry is disabled")
+        updates["SENTRY_ENABLED"] = "false"
+        removals.update({"SENTRY_BACKEND_DSN", "SENTRY_FRONTEND_DSN"})
+        return updates, removals
+    updates["SENTRY_ENVIRONMENT"] = environment
+
+    raw_rate = values.get("SENTRY_TRACES_SAMPLE_RATE", "").strip()
+    try:
+        rate = float(raw_rate)
+    except ValueError:
+        rate = -1.0
+    if not 0.0 <= rate <= 1.0:
+        warn("invalid Sentry trace sample rate; using 0")
+        rate = 0.0
+    updates["SENTRY_TRACES_SAMPLE_RATE"] = f"{rate:g}"
+
+    valid_dsn_count = 0
+    for name in ("SENTRY_BACKEND_DSN", "SENTRY_FRONTEND_DSN"):
+        dsn = values.get(name, "").strip()
+        validator = valid_frontend_sentry_dsn if name == "SENTRY_FRONTEND_DSN" else valid_sentry_dsn
+        if validator(dsn):
+            updates[name] = dsn
+            valid_dsn_count += 1
+        else:
+            removals.add(name)
+            warn(f"invalid or missing {name}; that Sentry surface is disabled")
+    if valid_dsn_count == 0:
+        updates["SENTRY_ENABLED"] = "false"
+    return updates, removals
+
+
 def turnstile_runtime_updates(values: Dict[str, str]) -> Dict[str, str]:
     """Apply Turnstile atomically without replacing usable installed credentials."""
     enabled = values.get("TURNSTILE_ENABLED", "").strip().lower()
@@ -303,6 +384,17 @@ def apply_configuration(
         updates["HFL_INSECURE_TLS"] = insecure_tls
         updates.update(smtp_runtime_updates(runtime_values))
         updates.update(google_runtime_updates(runtime_values))
+        sentry_updates, sentry_removals = sentry_runtime_updates(runtime_values)
+        updates.update(sentry_updates)
+        removals.update(sentry_removals)
+        removals.update(
+            {
+                "SENTRY_DSN",
+                "SENTRY_RELEASE",
+                "SENTRY_PROFILES_SAMPLE_RATE",
+                "SENTRY_SEND_DEFAULT_PII",
+            }
+        )
         analytics_staged, measurement_id = analytics_runtime_update(runtime_values)
         if analytics_staged:
             if measurement_id:
@@ -321,6 +413,12 @@ def apply_configuration(
             )
 
         updates.update(turnstile_runtime_updates(runtime_values))
+        deploy_target = runtime_values.get("HFL_DEPLOY_TARGET", "").strip()
+        if deploy_target in {"test", "preprod", "prod"}:
+            updates["HFL_DEPLOY_TARGET"] = deploy_target
+            updates["HFL_DEPLOYMENT_MODE"] = "managed"
+        else:
+            warn("invalid deployment target; preserving installed deployment identity")
 
     direct_host = direct_host.strip()
     if direct_host and (
@@ -396,7 +494,12 @@ def apply_configuration(
             continue
         if key in updates:
             value = updates[key]
-            if key in {"EMAIL_HOST_PASSWORD", "GOOGLE_CLIENT_SECRET"}:
+            if key in {
+                "EMAIL_HOST_PASSWORD",
+                "GOOGLE_CLIENT_SECRET",
+                "SENTRY_BACKEND_DSN",
+                "SENTRY_FRONTEND_DSN",
+            }:
                 value = compose_env_value(value)
             updated.append(f"{key}={value}")
             seen.add(key)
@@ -404,7 +507,12 @@ def apply_configuration(
             updated.append(line)
     for key, value in updates.items():
         if key not in seen:
-            if key in {"EMAIL_HOST_PASSWORD", "GOOGLE_CLIENT_SECRET"}:
+            if key in {
+                "EMAIL_HOST_PASSWORD",
+                "GOOGLE_CLIENT_SECRET",
+                "SENTRY_BACKEND_DSN",
+                "SENTRY_FRONTEND_DSN",
+            }:
                 value = compose_env_value(value)
             updated.append(f"{key}={value}")
     atomic_write(env_path, updated)

--- a/deploy/installer/install.sh
+++ b/deploy/installer/install.sh
@@ -895,7 +895,7 @@ sub_key("HFL_RELEASE_CHANNEL", channel)
 sub_key("SECRET_KEY", secret)
 sub_key("POSTGRES_PASSWORD", db_pass)
 sub_key("DJANGO_DEBUG", "false")
-sub_key("SENTRY_ENVIRONMENT", "production")
+sub_key("SENTRY_ENVIRONMENT", "")
 sub_key("HFL_EMAIL_SIGNUP_ENABLED", "false")
 sub_key("HFL_EMAIL_CODE_LOGIN_ENABLED", "true")
 sub_key("HFL_GOOGLE_OAUTH_ENABLED", "false")
@@ -1911,6 +1911,7 @@ PY
 			gateway-install-lensnode-sidecar.sh
 			gateway-lifecycle.sh
 			gateway-install-docker-ubuntu-amd64.sh
+			hfl-sentry-sitecustomize.py
 			docker-debs-ubuntu2004-amd64.tar.gz
 			docker-debs-ubuntu2204-amd64.tar.gz
 			docker-debs-ubuntu2404-amd64.tar.gz
@@ -2103,6 +2104,7 @@ install_bundled_sourcelens() {
 	SOURCELENS_INSTALL_DIR="${ROOT}/sourcelens" \
 		SOURCELENS_DATA_DIR="${ROOT}/data/sourcelens" \
 		SOURCELENS_CONFIG_DIR="${ROOT}/data/sourcelens/config" \
+		HFL_PARENT_ENV_FILE="${ROOT}/.env" \
 		SOURCELENS_TLS_CERT_DIR="${ROOT}/deploy/nginx/certs" \
 		SOURCELENS_CONSOLE_BIND_ADDRESS="${console_bind}" \
 		SOURCELENS_CONSOLE_PORT="${console_port}" \
@@ -2262,6 +2264,49 @@ wait_for_local_platform_gateway_online() {
 	die "installer-managed local platform Gateway did not reconnect its WebSocket"
 }
 
+read_platform_gateway_sentry_values() {
+	python3 - "${ROOT}/.env" "${ROOT}/sourcelens/BUILD_INFO.json" <<'PY'
+import json
+import pathlib
+import shlex
+import sys
+
+env_path = pathlib.Path(sys.argv[1])
+build_info_path = pathlib.Path(sys.argv[2])
+values = {}
+if env_path.is_file():
+    for line in env_path.read_text(encoding="utf-8").splitlines():
+        if not line or line.lstrip().startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        value = value.strip()
+        if value[:1] in {"'", '"'}:
+            try:
+                decoded = shlex.split(value)
+            except ValueError:
+                decoded = []
+            value = decoded[0] if len(decoded) == 1 else ""
+        values[key.strip()] = value.replace("$$", "$")
+
+sl_version = "unknown"
+if build_info_path.is_file():
+    try:
+        sl_version = str(json.loads(build_info_path.read_text(encoding="utf-8")).get("version") or "unknown")
+    except (OSError, json.JSONDecodeError):
+        pass
+hfl_version = values.get("APP_VERSION", "unknown")
+for value in (
+    values.get("SENTRY_ENABLED", "false"),
+    values.get("SENTRY_BACKEND_DSN", ""),
+    values.get("SENTRY_ENVIRONMENT", ""),
+    values.get("SENTRY_TRACES_SAMPLE_RATE", "0"),
+    f"hyperfilelens-agent@{hfl_version}",
+    f"hyperfilelens-lensnode@{hfl_version}-sl{sl_version}",
+):
+    print(value)
+PY
+}
+
 ensure_local_platform_gateway() {
 	if ! platform_gateway_auto_deploy_enabled; then
 		skip "Local platform Gateway auto-deploy is disabled"
@@ -2314,6 +2359,10 @@ print("\t".join([*(str(payload[key]).strip() for key in required), node_ids]))
 	wss_url="wss://127.0.0.1:${tenant_port}/ws/node/agent/"
 
 	local existing_org existing_role existing_node_id existing_token desired_version installed_version
+	local -a sentry_values=()
+	mapfile -t sentry_values < <(read_platform_gateway_sentry_values)
+	((${#sentry_values[@]} == 6)) \
+		|| die "unable to resolve local Platform Gateway Sentry configuration"
 	existing_org="$(read_agent_env_value HFL_ORG_KEY)"
 	existing_role="$(read_agent_env_value HFL_NODE_ROLE)"
 	existing_node_id="$(read_agent_env_value HFL_NODE_ID)"
@@ -2345,6 +2394,12 @@ print("\t".join([*(str(payload[key]).strip() for key in required), node_ids]))
 		HFL_API_BASE="${api_base}" \
 		HFL_WSS_URL="${wss_url}" \
 		HFL_INSECURE_TLS=1 \
+		SENTRY_ENABLED="${sentry_values[0]}" \
+		SENTRY_BACKEND_DSN="${sentry_values[1]}" \
+		SENTRY_ENVIRONMENT="${sentry_values[2]}" \
+		SENTRY_TRACES_SAMPLE_RATE="${sentry_values[3]}" \
+		SENTRY_RELEASE="${sentry_values[4]}" \
+		HFL_SENTRY_LENSNODE_RELEASE="${sentry_values[5]}" \
 		HFL_FORCE_SIDECAR_INSTALL=1 \
 		"${helper}" gateway-install --yes
 	desired_version="$(read_version)"

--- a/deploy/installer/sourcelens/docker-compose.template.yml
+++ b/deploy/installer/sourcelens/docker-compose.template.yml
@@ -11,6 +11,9 @@ services:
       - ./.env
     environment:
       API_WORKERS: "1"
+      SENTRY_COMPONENT: sourcelens-backend
+      SENTRY_RELEASE: ${SENTRY_RELEASE:-}
+      SENTRY_SERVICE: api
 # HFL_EMBED_BACKEND_ENV_BEGIN
       LENSNODE_NAME: ${LENSNODE_NAME:-local-lensnode}
       LENSNODE_TOKEN: ${LENSNODE_TOKEN:-change-me-lensnode-token}
@@ -21,6 +24,7 @@ services:
       - ./data/logs/api:/var/log/gunicorn
       - ./data/storage:/opt/storage
       - ./data/workspace:/workspace
+      - ./deploy/sentry/hfl-sentry-sitecustomize.py:/opt/backend/sitecustomize.py:ro
       - ${SOURCELENS_TLS_CERT_DIR:-./deploy/nginx/certs}:/opt/certs:ro
     networks:
       sourcelens_network:
@@ -50,10 +54,14 @@ services:
       - ./.env
     environment:
       CELERY_CONCURRENCY: "1"
+      SENTRY_COMPONENT: sourcelens-backend
+      SENTRY_RELEASE: ${SENTRY_RELEASE:-}
+      SENTRY_SERVICE: worker
     volumes:
       - ./data/logs/worker:/var/log/celery
       - ./data/storage:/opt/storage
       - ./data/workspace:/workspace
+      - ./deploy/sentry/hfl-sentry-sitecustomize.py:/opt/backend/sitecustomize.py:ro
     networks:
       - sourcelens_network
     depends_on:
@@ -70,8 +78,13 @@ services:
     stop_grace_period: 30s
     env_file:
       - ./.env
+    environment:
+      SENTRY_COMPONENT: sourcelens-backend
+      SENTRY_RELEASE: ${SENTRY_RELEASE:-}
+      SENTRY_SERVICE: scheduler
     volumes:
       - ./data/logs/scheduler:/var/log/celery
+      - ./deploy/sentry/hfl-sentry-sitecustomize.py:/opt/backend/sitecustomize.py:ro
     networks:
       - sourcelens_network
     depends_on:
@@ -105,8 +118,13 @@ services:
       LENSNODE_CONTROL_WS_URL: ws://api:8000/ws/lens/lensnodes/
       LENSNODE_AI_GATEWAY_URL: http://api:8000/api/lens/lensnode/ai-gateway/
       LENSNODE_WORKSPACE_PATH: /workspace
+      PYTHONPATH: /opt/hfl-sentry
+      SENTRY_COMPONENT: sourcelens-lensnode
+      SENTRY_RELEASE: ${SENTRY_LENSNODE_RELEASE:-${SENTRY_RELEASE:-}}
+      SENTRY_SERVICE: lensnode
     volumes:
       - ./data/workspace:/workspace
+      - ./deploy/sentry/hfl-sentry-sitecustomize.py:/opt/hfl-sentry/sitecustomize.py:ro
     networks:
       - sourcelens_network
     depends_on:
@@ -122,6 +140,8 @@ services:
     restart: unless-stopped
     volumes:
       - ./deploy/nginx/default.conf:/etc/nginx/conf.d/default.conf
+      - ./deploy/nginx/hfl-sentry-config.js:/etc/nginx/hfl-sentry-config.js:ro
+      - ./deploy/nginx/hfl-sentry-loader.js:/etc/nginx/hfl-sentry-loader.js:ro
       - ${SOURCELENS_TLS_CERT_DIR:-./deploy/nginx/certs}:/etc/nginx/certs:ro
       - ./data/django/staticfiles:/staticfiles:ro
       - ./data/storage:/opt/storage:ro

--- a/deploy/installer/sourcelens/hfl-sentry-loader.js
+++ b/deploy/installer/sourcelens/hfl-sentry-loader.js
@@ -1,0 +1,134 @@
+/* HFL-owned runtime Sentry adapter for the bundled SourceLens UI. */
+(function initializeBundledSourceLensSentry() {
+  'use strict'
+
+  var config = window.__HFL_SOURCELENS_SENTRY__ || {}
+  if (!config.enabled || !config.dsn || !config.environment || !config.release) return
+
+  var dsn
+  try {
+    dsn = new URL(config.dsn)
+  } catch (_error) {
+    console.warn('[hfl-sentry] Invalid bundled SourceLens DSN; reporting is disabled.')
+    return
+  }
+  var path = dsn.pathname.replace(/\/+$/, '').split('/')
+  var projectId = path.pop()
+  var publicKey = dsn.username
+  if (!/^https?:$/.test(dsn.protocol) || !/^\d+$/.test(projectId || '')
+    || !publicKey || dsn.password || dsn.search || dsn.hash) return
+  var prefix = path.join('/')
+  var sentrySaas = dsn.hostname === 'sentry.io' || dsn.hostname.endsWith('.sentry.io')
+  var loaderUrl = sentrySaas
+    ? 'https://js.sentry-cdn.com/' + encodeURIComponent(publicKey) + '.min.js'
+    : dsn.origin + prefix + '/js-sdk-loader/' + encodeURIComponent(publicKey) + '.min.js'
+
+  function safeOrigin(value) {
+    try {
+      return new URL(value, window.location.origin).origin
+    } catch (_error) {
+      return undefined
+    }
+  }
+
+  function sanitizeSpan(span) {
+    var safe = { data: {} }
+    var fields = [
+      'is_segment', 'op', 'origin', 'parent_span_id', 'same_process_as_parent',
+      'segment_id', 'span_id', 'start_timestamp', 'status', 'timestamp', 'trace_id'
+    ]
+    fields.forEach(function retainSafeSpanField(key) {
+      var value = span[key]
+      if (['boolean', 'number', 'string'].indexOf(typeof value) !== -1) safe[key] = value
+    })
+    return safe
+  }
+
+  function sanitizeTraceContext(value) {
+    if (!value || typeof value !== 'object') return undefined
+    var safe = { data: {} }
+    var fields = ['op', 'origin', 'parent_span_id', 'span_id', 'status', 'trace_id']
+    fields.forEach(function retainSafeTraceField(key) {
+      if (typeof value[key] === 'string') safe[key] = value[key]
+    })
+    return typeof safe.trace_id === 'string' && typeof safe.span_id === 'string'
+      ? safe
+      : undefined
+  }
+
+  function beforeSend(event) {
+    delete event.user
+    delete event.message
+    delete event.logentry
+    delete event.extra
+    delete event.fingerprint
+    var traceContext = sanitizeTraceContext(event.contexts && event.contexts.trace)
+    event.contexts = traceContext ? { trace: traceContext } : undefined
+    if (event.request) {
+      var origin = safeOrigin(event.request.url)
+      event.request = { headers: {} }
+      if (origin) event.request.url = origin
+    }
+    delete event.transaction
+    delete event.transaction_info
+    if (event.spans) event.spans = event.spans.map(sanitizeSpan)
+    if (event.breadcrumbs) {
+      event.breadcrumbs = event.breadcrumbs.map(function sanitizeBreadcrumb(crumb) {
+        return {
+          category: crumb.category,
+          level: crumb.level,
+          timestamp: crumb.timestamp,
+          type: crumb.type
+        }
+      })
+    }
+    var exceptions = event.exception && event.exception.values || []
+    exceptions.forEach(function sanitizeException(exception) {
+      if (exception.value) exception.value = '[Filtered]'
+      if (exception.mechanism) delete exception.mechanism.data
+      var frames = exception.stacktrace && exception.stacktrace.frames || []
+      frames.forEach(function sanitizeFrame(frame) { delete frame.vars })
+    })
+    event.tags = {
+      component: 'sourcelens-frontend',
+      deployment_mode: 'bundled',
+      product: 'hyperfilelens'
+    }
+    return event
+  }
+
+  window.sentryOnLoad = function configureSentry() {
+    try {
+      var options = {
+        dsn: config.dsn,
+        environment: config.environment,
+        release: config.release,
+        tracesSampleRate: Number(config.tracesSampleRate) || 0,
+        sendDefaultPii: false,
+        beforeSend: beforeSend,
+        beforeSendTransaction: beforeSend,
+        beforeSendSpan: sanitizeSpan,
+        initialScope: {
+          tags: {
+            product: 'hyperfilelens',
+            component: 'sourcelens-frontend',
+            deployment_mode: 'bundled'
+          }
+        }
+      }
+      window.Sentry.init(options)
+    } catch (error) {
+      console.warn('[hfl-sentry] Bundled SourceLens initialization failed.', error)
+    }
+  }
+
+  var script = document.createElement('script')
+  script.async = true
+  script.crossOrigin = 'anonymous'
+  script.src = loaderUrl
+  script.dataset.hflSentryLoader = 'true'
+  script.onerror = function sentryLoaderFailed() {
+    console.warn('[hfl-sentry] Sentry loader is unavailable; SourceLens will continue.')
+  }
+  document.head.appendChild(script)
+})()

--- a/deploy/installer/sourcelens/hfl-sentry-sitecustomize.py
+++ b/deploy/installer/sourcelens/hfl-sentry-sitecustomize.py
@@ -1,0 +1,224 @@
+# HFL_SENTRY_PRIVACY_ADAPTER=1
+"""Apply HFL privacy policy before bundled SourceLens initializes Sentry."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable, Mapping
+from typing import Any
+from urllib.parse import urlsplit, urlunsplit
+
+_FILTERED = "[Filtered]"
+_SAFE_CONTEXT_FIELDS = {
+    "os": frozenset({"build", "kernel_version", "name", "version"}),
+    "runtime": frozenset({"build", "name", "version"}),
+    "trace": frozenset({"op", "origin", "parent_span_id", "span_id", "status", "trace_id"}),
+}
+_SAFE_SPAN_FIELDS = frozenset(
+    {
+        "op",
+        "origin",
+        "parent_span_id",
+        "same_process_as_parent",
+        "span_id",
+        "start_timestamp",
+        "status",
+        "timestamp",
+        "trace_id",
+    }
+)
+
+
+def _safe_url(value: Any) -> str | None:
+    """Return only the origin of an HTTP(S) URL."""
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        parsed = urlsplit(value)
+        port = parsed.port
+    except ValueError:
+        return None
+    if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+        return None
+    host = parsed.hostname
+    if ":" in host:
+        host = f"[{host}]"
+    if port is not None:
+        host = f"{host}:{port}"
+    return urlunsplit((parsed.scheme, host, "", "", ""))
+
+
+def _safe_spans(value: Any) -> list[dict[str, Any]]:
+    """Retain trace topology and timing while dropping span payload content."""
+    if not isinstance(value, list):
+        return []
+    spans: list[dict[str, Any]] = []
+    for span in value:
+        if not isinstance(span, Mapping):
+            continue
+        safe_span = {
+            str(key): field
+            for key, field in span.items()
+            if str(key) in _SAFE_SPAN_FIELDS
+            and isinstance(field, (bool, float, int, str))
+        }
+        if safe_span:
+            spans.append(safe_span)
+    return spans
+
+
+def _scrub_event(event: dict[str, Any], hint: Any) -> dict[str, Any]:  # noqa: ARG001
+    """Retain operational metadata while removing customer-controlled text."""
+    event.pop("user", None)
+    for key in ("breadcrumbs", "extra", "fingerprint", "logentry", "message"):
+        event.pop(key, None)
+
+    request = event.get("request")
+    if isinstance(request, dict):
+        safe_request: dict[str, Any] = {"headers": {}}
+        if safe_request_url := _safe_url(request.get("url")):
+            safe_request["url"] = safe_request_url
+        event["request"] = safe_request
+
+    transaction_info = event.get("transaction_info")
+    route_transaction = (
+        isinstance(transaction_info, Mapping)
+        and transaction_info.get("source") == "route"
+        and isinstance(event.get("transaction"), str)
+    )
+    if route_transaction:
+        event["transaction_info"] = {"source": "route"}
+    else:
+        event.pop("transaction", None)
+        event.pop("transaction_info", None)
+
+    if spans := _safe_spans(event.get("spans")):
+        event["spans"] = spans
+    else:
+        event.pop("spans", None)
+
+    contexts = event.get("contexts")
+    if isinstance(contexts, Mapping):
+        event["contexts"] = {
+            str(name): {
+                str(key): value
+                for key, value in context.items()
+                if str(key) in _SAFE_CONTEXT_FIELDS[str(name)]
+                and isinstance(value, (bool, float, int, str))
+            }
+            for name, context in contexts.items()
+            if str(name) in _SAFE_CONTEXT_FIELDS and isinstance(context, Mapping)
+        }
+    else:
+        event.pop("contexts", None)
+
+    exception = event.get("exception")
+    if isinstance(exception, dict):
+        for value in exception.get("values") or []:
+            if not isinstance(value, dict):
+                continue
+            if value.get("value"):
+                value["value"] = _FILTERED
+            mechanism = value.get("mechanism")
+            if isinstance(mechanism, dict):
+                mechanism.pop("data", None)
+            stacktrace = value.get("stacktrace")
+            if not isinstance(stacktrace, dict):
+                continue
+            for frame in stacktrace.get("frames") or []:
+                if isinstance(frame, dict):
+                    frame.pop("vars", None)
+
+    tags = {
+        "component": (os.getenv("SENTRY_COMPONENT") or "sourcelens").strip(),
+        "deployment_mode": (os.getenv("SENTRY_DEPLOYMENT_MODE") or "bundled").strip(),
+        "product": "hyperfilelens",
+        "service": (os.getenv("SENTRY_SERVICE") or "unknown").strip(),
+    }
+    event["tags"] = {key: value for key, value in tags.items() if value}
+    return event
+
+
+def _scrub_breadcrumb(crumb: dict[str, Any], hint: Any) -> dict[str, Any]:  # noqa: ARG001
+    """Drop breadcrumb text and retain only classification metadata."""
+    return {
+        key: crumb[key]
+        for key in ("category", "level", "timestamp", "type")
+        if key in crumb
+    }
+
+
+def _compose_event_hook(
+    upstream: Callable[[dict[str, Any], Any], dict[str, Any] | None] | None,
+) -> Callable[[dict[str, Any], Any], dict[str, Any] | None]:
+    """Run an upstream filter before enforcing the HFL privacy policy."""
+
+    def callback(event: dict[str, Any], hint: Any) -> dict[str, Any] | None:
+        if upstream is not None:
+            try:
+                event = upstream(event, hint)
+            except Exception:
+                return None
+            if event is None:
+                return None
+        return _scrub_event(event, hint)
+
+    return callback
+
+
+def _compose_breadcrumb_hook(
+    upstream: Callable[[dict[str, Any], Any], dict[str, Any] | None] | None,
+) -> Callable[[dict[str, Any], Any], dict[str, Any] | None]:
+    """Run an upstream breadcrumb filter before removing customer text."""
+
+    def callback(crumb: dict[str, Any], hint: Any) -> dict[str, Any] | None:
+        if upstream is not None:
+            try:
+                crumb = upstream(crumb, hint)
+            except Exception:
+                return None
+            if crumb is None:
+                return None
+        return _scrub_breadcrumb(crumb, hint)
+
+    return callback
+
+
+def _install_sentry_policy() -> None:
+    """Wrap the SDK initializer without making SourceLens startup depend on it."""
+    try:
+        import sentry_sdk
+    except ImportError:
+        return
+    if getattr(sentry_sdk.init, "_hfl_privacy_policy", False):
+        return
+
+    original_init = sentry_sdk.init
+
+    def privacy_init(*args: Any, **options: Any) -> Any:
+        options["before_send"] = _compose_event_hook(options.get("before_send"))
+        options["before_send_transaction"] = _compose_event_hook(
+            options.get("before_send_transaction")
+        )
+        options["before_breadcrumb"] = _compose_breadcrumb_hook(options.get("before_breadcrumb"))
+        options["include_local_variables"] = False
+        options["max_request_body_size"] = "never"
+        options["profiles_sample_rate"] = 0.0
+        options["send_default_pii"] = False
+        try:
+            return original_init(*args, **options)
+        except Exception:
+            os.environ["SENTRY_ENABLED"] = "false"
+            os.environ["SENTRY_DSN"] = ""
+            return None
+
+    privacy_init._hfl_privacy_policy = True  # type: ignore[attr-defined]
+    sentry_sdk.init = privacy_init
+
+
+try:
+    _install_sentry_policy()
+except Exception:
+    # Observability must never prevent SourceLens or LensNode startup.
+    os.environ["SENTRY_ENABLED"] = "false"
+    os.environ["SENTRY_DSN"] = ""

--- a/deploy/installer/sourcelens/install.sh
+++ b/deploy/installer/sourcelens/install.sh
@@ -11,6 +11,7 @@ SOURCELENS_NGINX_HTTPS_PORT="${SOURCELENS_NGINX_HTTPS_PORT:-11445}"
 SOURCELENS_CONSOLE_BIND_ADDRESS="${SOURCELENS_CONSOLE_BIND_ADDRESS:-0.0.0.0}"
 SOURCELENS_CONSOLE_PORT="${SOURCELENS_CONSOLE_PORT:-${SOURCELENS_NGINX_HTTPS_PORT}}"
 HFL_BRIDGE_NETWORK="hyperfilelens-bridge"
+HFL_PARENT_ENV_FILE="${HFL_PARENT_ENV_FILE:-}"
 SKIP_IMAGE_LOAD=0
 LOG_FILE="${HFL_LOG_FILE:-}"
 VERBOSE="${HFL_LOG_VERBOSE:-0}"
@@ -71,7 +72,31 @@ bridge_network=${HFL_BRIDGE_NETWORK}
 skip_image_load=${SKIP_IMAGE_LOAD}
 log_file=${LOG_FILE:-<none>}
 verbose=${VERBOSE}
+hfl_parent_env_file=${HFL_PARENT_ENV_FILE:-<none>}
 EOF
+}
+
+sync_hfl_sentry_configuration() {
+	local root=$1 env_file="${SOURCELENS_CONFIG_DIR}/.env"
+	local parent_env="${HFL_PARENT_ENV_FILE:-$(dirname "${SOURCELENS_INSTALL_DIR}")/.env}"
+	local build_info="${root}/BUILD_INFO.json"
+	local output="${root}/deploy/nginx/hfl-sentry-config.js"
+	local sync_script="${root}/sync-sentry-runtime.py"
+	[[ -f "${parent_env}" && ! -L "${parent_env}" ]] || {
+		warn "HFL parent environment is unavailable; bundled SourceLens Sentry remains disabled"
+		printf '%s\n' 'window.__HFL_SOURCELENS_SENTRY__ = Object.freeze({ enabled: false })' \
+			| run_as_root tee "${output}" >/dev/null
+		return 0
+	}
+	[[ -f "${sync_script}" ]] || die "missing ${sync_script}"
+	run_as_root python3 "${sync_script}" \
+		--parent-env "${parent_env}" \
+		--sourcelens-env "${env_file}" \
+		--build-info "${build_info}" \
+		--frontend-config "${output}"
+	run_as_root chmod 600 "${env_file}"
+	run_as_root chmod 644 "${output}"
+	log "Synchronized HFL Sentry policy for bundled SourceLens (credentials redacted)"
 }
 
 resolve_bundle_root() {
@@ -214,6 +239,7 @@ PY
 		run_as_root rm -f "${root}/.env"
 	fi
 	run_as_root ln -sfn "${env_file}" "${root}/.env"
+	sync_hfl_sentry_configuration "${root}"
 	log "Applied SourceLens runtime env defaults (DJANGO_DEBUG=true)"
 }
 

--- a/deploy/installer/sourcelens/patch-env-runtime.py
+++ b/deploy/installer/sourcelens/patch-env-runtime.py
@@ -17,9 +17,21 @@ def apply_runtime_env(text: str) -> str:
         else:
             text = text.rstrip() + f"\n{replacement}\n"
 
+    def ensure_key(name: str, value: str) -> None:
+        nonlocal text
+        if not re.search(rf"^{re.escape(name)}=.*$", text, flags=re.M):
+            text = text.rstrip() + f"\n{name}={value}\n"
+
     # Skip Turnstile and other production-only gates until explicitly configured.
     set_key("DJANGO_DEBUG", "true")
-    set_key("SENTRY_ENABLED", "false")
+    ensure_key("SENTRY_ENABLED", "false")
+    ensure_key("SENTRY_DSN", "")
+    ensure_key("SENTRY_FRONTEND_DSN", "")
+    ensure_key("SENTRY_ENVIRONMENT", "")
+    ensure_key("SENTRY_RELEASE", "")
+    ensure_key("SENTRY_FRONTEND_RELEASE", "")
+    set_key("SENTRY_PROFILING_SAMPLE_RATE", "0")
+    set_key("SENTRY_SEND_DEFAULT_PII", "false")
     allowed_hosts_match = re.search(r"^ALLOWED_HOSTS=(.*)$", text, flags=re.M)
     allowed_hosts = []
     if allowed_hosts_match:

--- a/deploy/installer/sourcelens/sync-sentry-runtime.py
+++ b/deploy/installer/sourcelens/sync-sentry-runtime.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Map HFL runtime Sentry settings into the bundled SourceLens stack."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import pathlib
+import re
+import shlex
+import tempfile
+from urllib.parse import urlsplit
+
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
+_SAMPLE_RATE = re.compile(r"0(?:\.\d+)?|1(?:\.0+)?")
+
+
+def read_env(path: pathlib.Path) -> dict[str, str]:
+    """Read the Compose-compatible subset used by HFL runtime files."""
+    values: dict[str, str] = {}
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if not line or line.lstrip().startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        value = value.strip()
+        if value[:1] in {"'", '"'}:
+            try:
+                decoded = shlex.split(value)
+            except ValueError:
+                decoded = []
+            value = decoded[0] if len(decoded) == 1 else ""
+        values[key.strip()] = value.replace("$$", "$")
+    return values
+
+
+def valid_dsn(value: str) -> bool:
+    """Return whether *value* is a structurally valid Sentry DSN."""
+    try:
+        parsed = urlsplit(value)
+        parsed.port
+    except ValueError:
+        return False
+    project_id = parsed.path.rstrip("/").rsplit("/", 1)[-1]
+    return bool(
+        parsed.scheme in {"http", "https"}
+        and parsed.hostname
+        and parsed.username
+        and project_id.isdigit()
+        and not parsed.query
+        and not parsed.fragment
+        and not re.search(r"[\x00\r\n\s]", value)
+    )
+
+
+def valid_frontend_dsn(value: str) -> bool:
+    """Return whether a DSN contains only browser-public credentials."""
+    if not valid_dsn(value):
+        return False
+    return urlsplit(value).password is None
+
+
+def set_key(text: str, name: str, value: str) -> str:
+    """Set one Compose environment key with literal-value escaping."""
+    safe = value.replace("\\", "\\\\").replace('"', '\\"').replace("$", "$$")
+    rendered = f'{name}="{safe}"' if value else f"{name}="
+    pattern = rf"^{re.escape(name)}=.*$"
+    if re.search(pattern, text, flags=re.M):
+        return re.sub(pattern, rendered, text, count=1, flags=re.M)
+    return text.rstrip() + f"\n{rendered}\n"
+
+
+def atomic_write(path: pathlib.Path, text: str, mode: int) -> None:
+    """Write text through a same-directory temporary file with fixed permissions."""
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}.", suffix=".tmp", dir=path.parent
+    )
+    temporary = pathlib.Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+            os.fchmod(stream.fileno(), mode)
+            stream.write(text)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, path)
+        path.chmod(mode)
+    finally:
+        if temporary.exists():
+            temporary.unlink()
+
+
+def sync_configuration(
+    parent_path: pathlib.Path,
+    env_path: pathlib.Path,
+    build_info_path: pathlib.Path,
+    output_path: pathlib.Path,
+) -> None:
+    """Synchronize backend settings and generate the browser runtime payload."""
+    parent = read_env(parent_path)
+    build_info = json.loads(build_info_path.read_text(encoding="utf-8"))
+    enabled = parent.get("SENTRY_ENABLED", "").lower() in _TRUTHY
+    backend_dsn = parent.get("SENTRY_BACKEND_DSN", "") if enabled else ""
+    frontend_dsn = parent.get("SENTRY_FRONTEND_DSN", "") if enabled else ""
+    environment = parent.get("SENTRY_ENVIRONMENT", "") if enabled else ""
+    traces = parent.get("SENTRY_TRACES_SAMPLE_RATE", "0") if enabled else "0"
+    if not valid_dsn(backend_dsn):
+        backend_dsn = ""
+    if not valid_frontend_dsn(frontend_dsn):
+        frontend_dsn = ""
+    enabled = enabled and bool(backend_dsn or frontend_dsn) and bool(environment)
+
+    hfl_version = parent.get("APP_VERSION", "unknown")
+    sl_version = str(build_info.get("version") or "unknown")
+    backend_release = f"hyperfilelens-sourcelens@{hfl_version}-sl{sl_version}"
+    frontend_release = f"hyperfilelens-sourcelens-frontend@{hfl_version}-sl{sl_version}"
+    lensnode_release = f"hyperfilelens-lensnode@{hfl_version}-sl{sl_version}"
+
+    text = env_path.read_text(encoding="utf-8")
+    for key, value in {
+        "SENTRY_ENABLED": "true" if enabled else "false",
+        "SENTRY_DSN": backend_dsn,
+        "SENTRY_FRONTEND_DSN": frontend_dsn,
+        "SENTRY_ENVIRONMENT": environment,
+        "SENTRY_RELEASE": backend_release,
+        "SENTRY_FRONTEND_RELEASE": frontend_release,
+        "SENTRY_LENSNODE_RELEASE": lensnode_release,
+        "SENTRY_TRACES_SAMPLE_RATE": traces if _SAMPLE_RATE.fullmatch(traces) else "0",
+        "SENTRY_PROFILING_SAMPLE_RATE": "0",
+        "SENTRY_SEND_DEFAULT_PII": "false",
+    }.items():
+        text = set_key(text, key, value)
+    atomic_write(env_path, text, 0o600)
+
+    payload = {
+        "enabled": bool(enabled and frontend_dsn),
+        "dsn": frontend_dsn,
+        "environment": environment,
+        "release": frontend_release,
+        "tracesSampleRate": float(traces) if _SAMPLE_RATE.fullmatch(traces) else 0,
+    }
+    atomic_write(
+        output_path,
+        "window.__HFL_SOURCELENS_SENTRY__ = Object.freeze("
+        + json.dumps(payload, separators=(",", ":"))
+        + ")\n",
+        0o644,
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--parent-env", required=True, type=pathlib.Path)
+    parser.add_argument("--sourcelens-env", required=True, type=pathlib.Path)
+    parser.add_argument("--build-info", required=True, type=pathlib.Path)
+    parser.add_argument("--frontend-config", required=True, type=pathlib.Path)
+    arguments = parser.parse_args()
+    sync_configuration(
+        arguments.parent_env,
+        arguments.sourcelens_env,
+        arguments.build_info,
+        arguments.frontend_config,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/release/build-sourcelens.sh
+++ b/release/build-sourcelens.sh
@@ -253,11 +253,16 @@ stage_runtime_tree() {
 	upstream_frontend_ref="$(sourcelens_upstream_image_ref frontend)"
 	upstream_lensnode_ref="$(sourcelens_upstream_image_ref lensnode)"
 
-	mkdir -p "${sl_root}/deploy/nginx/certs" "${sl_root}/deploy/postgresql/initdb.d"
+	mkdir -p "${sl_root}/deploy/nginx/certs" "${sl_root}/deploy/postgresql/initdb.d" \
+		"${sl_root}/deploy/sentry"
 
 	log "Using upstream SourceLens nginx configuration"
 	cp "${src}/docker/nginx/default.conf" "${sl_root}/deploy/nginx/default.conf"
 	sourcelens_patch_runtime_nginx "${sl_root}/deploy/nginx/default.conf"
+	cp "${SOURCELENS_INSTALLER_DIR}/sourcelens/hfl-sentry-loader.js" \
+		"${sl_root}/deploy/nginx/hfl-sentry-loader.js"
+	printf '%s\n' 'window.__HFL_SOURCELENS_SENTRY__ = Object.freeze({ enabled: false })' \
+		>"${sl_root}/deploy/nginx/hfl-sentry-config.js"
 	if [[ -d "${src}/docker/postgresql" ]]; then
 		rsync -a "${src}/docker/postgresql/" "${sl_root}/deploy/postgresql/"
 	fi
@@ -269,7 +274,11 @@ stage_runtime_tree() {
 
 	cp "${SOURCELENS_INSTALLER_DIR}/sourcelens/install.sh" "${sl_root}/install.sh"
 	cp "${SOURCELENS_INSTALLER_DIR}/sourcelens/patch-env-runtime.py" "${sl_root}/patch-env-runtime.py"
-	chmod +x "${sl_root}/install.sh" "${sl_root}/patch-env-runtime.py"
+	cp "${SOURCELENS_INSTALLER_DIR}/sourcelens/sync-sentry-runtime.py" "${sl_root}/sync-sentry-runtime.py"
+	cp "${SOURCELENS_INSTALLER_DIR}/sourcelens/hfl-sentry-sitecustomize.py" \
+		"${sl_root}/deploy/sentry/hfl-sentry-sitecustomize.py"
+	chmod 644 "${sl_root}/deploy/sentry/hfl-sentry-sitecustomize.py"
+	chmod +x "${sl_root}/install.sh" "${sl_root}/patch-env-runtime.py" "${sl_root}/sync-sentry-runtime.py"
 
 	sourcelens_write_runtime_compose "${sl_root}/docker-compose.yml"
 

--- a/release/build.sh
+++ b/release/build.sh
@@ -64,7 +64,8 @@ normalize_release_permissions() {
 	chmod 755 "${pkg_root}/install.sh" "${pkg_root}/apply-runtime-config.py"
 	if [[ -d "${pkg_root}/sourcelens" ]]; then
 		chmod 755 "${pkg_root}/sourcelens/install.sh" \
-			"${pkg_root}/sourcelens/patch-env-runtime.py"
+			"${pkg_root}/sourcelens/patch-env-runtime.py" \
+			"${pkg_root}/sourcelens/sync-sentry-runtime.py"
 		find "${pkg_root}/sourcelens/deploy/postgresql/initdb.d" \
 			-type f -name '*.sh' -exec chmod 755 {} +
 	fi
@@ -149,9 +150,7 @@ load_repo_env_defaults() {
 		KOPIA_ARTIFACT_MODE KOPIA_GIT_URL KOPIA_GIT_REF \
 		SOURCELENS_GIT_REF SOURCELENS_GIT_URL SOURCELENS_GIT_TIMEOUT_SECONDS \
 		SOURCELENS_GIT_RETRIES SOURCELENS_GIT_FALLBACK_TIMEOUT_SECONDS \
-		SENTRY_ENABLED SENTRY_DSN \
-		SENTRY_ENVIRONMENT SENTRY_RELEASE SENTRY_TRACES_SAMPLE_RATE \
-		SENTRY_SEND_DEFAULT_PII VITE_SHOW_EULA; do
+		VITE_SHOW_EULA; do
 		hfl_env_load_default "${key}"
 	done
 }
@@ -649,12 +648,6 @@ build_control_plane_images() {
 		-t "hyperfilelens-frontend:${HFL_VERSION}" \
 		-t hyperfilelens-frontend:latest \
 		--build-arg "NPM_REGISTRY=${NPM_REGISTRY:-}" \
-		--build-arg "SENTRY_ENABLED=${SENTRY_ENABLED:-false}" \
-		--build-arg "SENTRY_DSN=${SENTRY_DSN:-}" \
-		--build-arg "SENTRY_ENVIRONMENT=${SENTRY_ENVIRONMENT:-production}" \
-		--build-arg "SENTRY_RELEASE=${SENTRY_RELEASE:-}" \
-		--build-arg "SENTRY_TRACES_SAMPLE_RATE=${SENTRY_TRACES_SAMPLE_RATE:-0}" \
-		--build-arg "SENTRY_SEND_DEFAULT_PII=${SENTRY_SEND_DEFAULT_PII:-false}" \
 		--build-arg "VITE_SHOW_EULA=${VITE_SHOW_EULA:-false}" \
 		--build-arg "IMAGE_VERSION=${HFL_VERSION}" \
 		--build-arg "IMAGE_REVISION=${RELEASE_COMMIT}" \
@@ -1035,6 +1028,7 @@ validate_release_publish_artifacts() {
 		gateway-install-lensnode-sidecar.sh
 		gateway-lifecycle.sh
 		gateway-install-docker-ubuntu-amd64.sh
+		hfl-sentry-sitecustomize.py
 		docker-debs-ubuntu2004-amd64.tar.gz
 		docker-debs-ubuntu2204-amd64.tar.gz
 		docker-debs-ubuntu2404-amd64.tar.gz

--- a/release/ci/assemble-release.sh
+++ b/release/ci/assemble-release.sh
@@ -90,7 +90,10 @@ for required in \
 	images/10-sourcelens-app.tar.gz \
 	images/11-sourcelens-lensnode.tar.gz \
 	images/12-nginx-stable-alpine.tar.gz \
-	sourcelens/BUILD_INFO.json; do
+	sourcelens/BUILD_INFO.json \
+	sourcelens/sync-sentry-runtime.py \
+	sourcelens/deploy/sentry/hfl-sentry-sitecustomize.py \
+	sourcelens/deploy/nginx/hfl-sentry-loader.js; do
 	[[ -s "${pkg_root}/${required}" ]] || die "assembled package is missing ${required}"
 done
 
@@ -106,6 +109,9 @@ for script in \
 	cp "${ROOT}/deploy/bootstrap/${script}" "${gateway_dir}/${script}"
 	chmod 755 "${gateway_dir}/${script}"
 done
+cp "${ROOT}/deploy/installer/sourcelens/hfl-sentry-sitecustomize.py" \
+	"${gateway_dir}/hfl-sentry-sitecustomize.py"
+chmod 644 "${gateway_dir}/hfl-sentry-sitecustomize.py"
 
 log "Staging release runtime files"
 printf '%s\n' "${version}" >"${pkg_root}/VERSION"

--- a/release/ci/build-sourcelens-image.sh
+++ b/release/ci/build-sourcelens-image.sh
@@ -90,6 +90,14 @@ else
 	docker push "${cache_ref}"
 fi
 
+if [[ "${component}" == "frontend" ]]; then
+	if ! SOURCELENS_BUILD_SOURCE_MAPS=1 \
+		"${ROOT}/release/ci/upload-sourcelens-sourcemaps.sh" \
+		"hyperfilelens-sourcelens-frontend@${hfl_version}-sl${SOURCELENS_VERSION}"; then
+		printf '::warning title=Sentry Source Maps::Bundled SourceLens symbol processing failed; the image build will continue.\n'
+	fi
+fi
+
 manifest_json="$(docker buildx imagetools inspect "${target_ref}" --format '{{json .Manifest}}')"
 digest="$(jq -r '.digest // empty' <<<"${manifest_json}")"
 [[ "${digest}" =~ ^sha256:[0-9a-f]{64}$ ]] || {

--- a/release/ci/upload-sourcelens-sourcemaps.sh
+++ b/release/ci/upload-sourcelens-sourcemaps.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Upload hidden SourceLens UI Source Maps without changing or shipping its source tree.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+# shellcheck source=../../tools/sourcelens/common.sh
+source "${ROOT}/tools/sourcelens/common.sh"
+
+release=${1:-}
+if [[ -z "${release}" ]]; then
+	printf 'Usage: %s RELEASE\n' "$0" >&2
+	exit 2
+fi
+if [[ -z "${SENTRY_AUTH_TOKEN:-}" || -z "${SENTRY_URL:-}" \
+	|| -z "${SENTRY_ORG:-}" || -z "${SENTRY_FRONTEND_PROJECT:-}" ]]; then
+	printf '::warning title=Sentry Source Maps::Bundled SourceLens Source Map upload is not configured; continuing.\n'
+	exit 0
+fi
+
+sourcelens_load_config
+sourcelens_resolve_version
+SOURCELENS_BUILD_SOURCE_MAPS=1
+sourcelens_restore_source_dockerfiles "${SOURCELENS_SOURCE_CACHE}"
+sourcelens_patch_frontend_dockerfile_npm_registry "${SOURCELENS_SOURCE_CACHE}"
+sourcelens_patch_frontend_dockerfile_source_maps "${SOURCELENS_SOURCE_CACHE}"
+
+tmp="$(mktemp -d)"
+image="hyperfilelens-sourcelens-symbols:${GITHUB_RUN_ID:-local}"
+container=""
+cleanup() {
+	[[ -z "${container}" ]] || docker rm -f "${container}" >/dev/null 2>&1 || true
+	docker image rm "${image}" >/dev/null 2>&1 || true
+	rm -rf "${tmp}"
+}
+trap cleanup EXIT
+
+docker build \
+	--platform "${SOURCELENS_DOCKER_PLATFORM}" \
+	--target builder \
+	--build-arg "NPM_REGISTRY=${SOURCELENS_NPM_REGISTRY}" \
+	-t "${image}" \
+	"${SOURCELENS_SOURCE_CACHE}/frontend"
+container="$(docker create "${image}")"
+docker cp "${container}:/app/dist/." "${tmp}/"
+find "${tmp}" -type f -name '*.map' -print -quit | grep -q . || {
+	printf '::warning title=Sentry Source Maps::No bundled SourceLens Source Maps were produced; continuing.\n'
+	exit 0
+}
+
+npm ci --prefix "${ROOT}/src/frontend" --ignore-scripts
+if ! SENTRY_URL="${SENTRY_URL}" SENTRY_AUTH_TOKEN="${SENTRY_AUTH_TOKEN}" \
+	"${ROOT}/src/frontend/node_modules/.bin/sentry-cli" sourcemaps upload \
+		--org "${SENTRY_ORG}" \
+		--project "${SENTRY_FRONTEND_PROJECT}" \
+		--release "${release}" \
+		--url-prefix '~/' \
+		"${tmp}"; then
+	printf '::warning title=Sentry Source Maps::Bundled SourceLens Source Map upload failed; continuing.\n'
+	exit 0
+fi
+printf 'Bundled SourceLens Source Maps uploaded for %s.\n' "${release}"

--- a/src/agent/cmd/agent/main.go
+++ b/src/agent/cmd/agent/main.go
@@ -12,6 +12,7 @@ import (
 	"hyperfilelens/agent/internal/app"
 	"hyperfilelens/agent/internal/cli"
 	"hyperfilelens/agent/internal/infra/config"
+	"hyperfilelens/agent/internal/infra/observability"
 	"hyperfilelens/agent/internal/model"
 	"hyperfilelens/agent/internal/platform/svcwrap"
 	"hyperfilelens/agent/internal/selfupdate"
@@ -26,13 +27,19 @@ func main() {
 		}
 		return
 	}
+	shutdownSentry := observability.Initialize()
+	defer shutdownSentry()
+	defer observability.RecoverPanic()
 
 	// Explicit `run` subcommand or bare flags / no args (systemd compatibility).
 	if len(args) > 0 && args[0] == "run" {
 		args = args[1:]
 	}
 	if err := runDaemon(args); err != nil {
+		observability.CaptureException(err)
 		_, _ = fmt.Fprintf(os.Stderr, "%s\n", err)
+		// os.Exit skips deferred functions, so flush the fatal event explicitly.
+		shutdownSentry()
 		os.Exit(1)
 	}
 }

--- a/src/agent/go.mod
+++ b/src/agent/go.mod
@@ -5,6 +5,7 @@ go 1.25.0
 toolchain go1.25.10
 
 require (
+	github.com/getsentry/sentry-go v0.38.0
 	github.com/gorilla/websocket v1.5.3
 	github.com/kardianos/service v1.2.4
 	github.com/mattn/go-isatty v0.0.20
@@ -26,6 +27,7 @@ require (
 	github.com/tklauser/go-sysconf v0.3.16 // indirect
 	github.com/tklauser/numcpus v0.11.0 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
+	golang.org/x/text v0.14.0 // indirect
 	modernc.org/libc v1.55.3 // indirect
 	modernc.org/mathutil v1.6.0 // indirect
 	modernc.org/memory v1.8.0 // indirect

--- a/src/agent/go.sum
+++ b/src/agent/go.sum
@@ -4,6 +4,10 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/ebitengine/purego v0.10.0 h1:QIw4xfpWT6GWTzaW5XEKy3HXoqrJGx1ijYHzTF0/ISU=
 github.com/ebitengine/purego v0.10.0/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
+github.com/getsentry/sentry-go v0.38.0 h1:S8Xui7gLeAvXINVLMOaX94HnsDf1GexnfXGSNC4+KQs=
+github.com/getsentry/sentry-go v0.38.0/go.mod h1:eRXCoh3uvmjQLY6qu63BjUZnaBu5L5WhMV1RwYO8W5s=
+github.com/go-errors/errors v1.4.2 h1:J6MZopCL4uSllY1OfXM374weqZFFItUbrImctkmUxIA=
+github.com/go-errors/errors v1.4.2/go.mod h1:sIVyrIiJhuEF+Pj9Ebtd6P/rEYROXFi3BopGUQ5a5Og=
 github.com/go-ole/go-ole v1.2.6 h1:/Fpf6oFPoeFik9ty7siob0G6Ke8QvQEuVcuChpwXzpY=
 github.com/go-ole/go-ole v1.2.6/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
@@ -23,6 +27,10 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/ncruces/go-strftime v0.1.9 h1:bY0MQC28UADQmHmaF5dgpLmImcShSi2kHU9XLdhx/f4=
 github.com/ncruces/go-strftime v0.1.9/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
+github.com/pingcap/errors v0.11.4 h1:lFuQV/oaUMGcD2tqt+01ROSmJs75VG1ToEOkZIZ4nE4=
+github.com/pingcap/errors v0.11.4/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTwv5KuLY8=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 h1:o4JXh1EVt9k/+g42oCprj/FisM4qX9L3sZB3upGN2ZU=
@@ -39,6 +47,8 @@ github.com/tklauser/numcpus v0.11.0 h1:nSTwhKH5e1dMNsCdVBukSZrURJRoHbSEQjdEbY+9R
 github.com/tklauser/numcpus v0.11.0/go.mod h1:z+LwcLq54uWZTX0u/bGobaV34u6V7KNlTZejzM6/3MQ=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
+go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
+go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 golang.org/x/mod v0.16.0 h1:QX4fJ0Rr5cPQCF7O9lh9Se4pmwfwskqZfq5moyldzic=
 golang.org/x/mod v0.16.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -46,6 +56,8 @@ golang.org/x/sys v0.0.0-20201204225414-ed752295db88/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
 golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=
+golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
 golang.org/x/tools v0.19.0 h1:tfGCXNR1OsFG+sVdLAitlpjAvD/I6dHDKnYrpEZUHkw=
 golang.org/x/tools v0.19.0/go.mod h1:qoJWxmGSIBmAeriMx19ogtrEPrGtDbPK634QFIcLAhc=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/src/agent/internal/enroll/envfile.go
+++ b/src/agent/internal/enroll/envfile.go
@@ -2,6 +2,7 @@ package enroll
 
 import (
 	"bufio"
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -11,6 +12,15 @@ import (
 	"hyperfilelens/agent/internal/platform/install"
 	"hyperfilelens/agent/internal/platform/vfs"
 )
+
+var managedSentryEnvKeys = []string{
+	"SENTRY_ENABLED",
+	"SENTRY_BACKEND_DSN",
+	"SENTRY_ENVIRONMENT",
+	"SENTRY_RELEASE",
+	"SENTRY_TRACES_SAMPLE_RATE",
+	"HFL_SENTRY_LENSNODE_RELEASE",
+}
 
 // WriteNodeID updates or appends HFL_NODE_ID in agent.env.
 func WriteNodeID(envPath, nodeID string) error {
@@ -69,6 +79,11 @@ func WriteEnrollmentEnv(cfg Config) error {
 		"HFL_KOPIA_PATH=" + kopiaPath,
 		"HFL_INSECURE_TLS=" + insecure,
 	}
+	for _, name := range managedSentryEnvKeys {
+		if value := strings.TrimSpace(os.Getenv(name)); value != "" && !strings.ContainsAny(value, "\r\n") {
+			lines = append(lines, name+"="+value)
+		}
+	}
 	if existing := ReadNodeID(envPath); existing != "" {
 		lines = append(lines, "HFL_NODE_ID="+existing)
 	}
@@ -77,6 +92,101 @@ func WriteEnrollmentEnv(cfg Config) error {
 		return err
 	}
 	return os.WriteFile(envPath, []byte(content), 0o600)
+}
+
+// SyncManagedSentryEnv converges only HFL-managed observability settings.
+// Existing node credentials and user-managed Agent settings remain unchanged.
+func SyncManagedSentryEnv() (bool, error) {
+	return syncManagedSentryEnv(EnvFilePath())
+}
+
+func syncManagedSentryEnv(envPath string) (bool, error) {
+	rawEnabled := strings.TrimSpace(os.Getenv("SENTRY_ENABLED"))
+	if rawEnabled == "" {
+		return false, nil
+	}
+	enabled := "false"
+	if sentryEnabledValue(rawEnabled) {
+		enabled = "true"
+	}
+	desired := map[string]string{"SENTRY_ENABLED": enabled}
+	if sentryEnabledValue(enabled) {
+		for _, name := range managedSentryEnvKeys[1:] {
+			value := strings.TrimSpace(os.Getenv(name))
+			if value != "" && !strings.ContainsAny(value, "\r\n") {
+				desired[name] = value
+			}
+		}
+	}
+
+	current, err := os.ReadFile(envPath)
+	if err != nil {
+		return false, err
+	}
+	managed := make(map[string]struct{}, len(managedSentryEnvKeys))
+	for _, name := range managedSentryEnvKeys {
+		managed[name] = struct{}{}
+	}
+	written := make(map[string]bool, len(desired))
+	lines := make([]string, 0, len(strings.Split(string(current), "\n"))+len(desired))
+	for _, raw := range strings.Split(strings.TrimSuffix(string(current), "\n"), "\n") {
+		key, _, found := strings.Cut(raw, "=")
+		if _, controlled := managed[key]; !found || !controlled {
+			lines = append(lines, raw)
+			continue
+		}
+		if value, present := desired[key]; present && !written[key] {
+			lines = append(lines, key+"="+value)
+			written[key] = true
+		}
+	}
+	for _, name := range managedSentryEnvKeys {
+		if value, present := desired[name]; present && !written[name] {
+			lines = append(lines, name+"="+value)
+		}
+	}
+	updated := []byte(strings.Join(lines, "\n") + "\n")
+	if bytes.Equal(current, updated) {
+		return false, nil
+	}
+	if err := writePrivateEnvAtomically(envPath, updated); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func sentryEnabledValue(value string) bool {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
+}
+
+func writePrivateEnvAtomically(path string, content []byte) error {
+	temporary, err := os.CreateTemp(filepath.Dir(path), ".agent.env.*")
+	if err != nil {
+		return err
+	}
+	temporaryPath := temporary.Name()
+	defer os.Remove(temporaryPath)
+	if err := temporary.Chmod(0o600); err != nil {
+		temporary.Close()
+		return err
+	}
+	if _, err := temporary.Write(content); err != nil {
+		temporary.Close()
+		return err
+	}
+	if err := temporary.Sync(); err != nil {
+		temporary.Close()
+		return err
+	}
+	if err := temporary.Close(); err != nil {
+		return err
+	}
+	return os.Rename(temporaryPath, path)
 }
 
 // ReadNodeID returns HFL_NODE_ID from agent.env if present.

--- a/src/agent/internal/enroll/envfile_test.go
+++ b/src/agent/internal/enroll/envfile_test.go
@@ -1,0 +1,92 @@
+package enroll
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSyncManagedSentryEnvPreservesCredentialsAndReplacesManagedValues(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "agent.env")
+	original := strings.Join([]string{
+		"HFL_NODE_ID=42",
+		"HFL_NODE_TOKEN=working-token",
+		"SENTRY_ENABLED=true",
+		"SENTRY_BACKEND_DSN=https://old@sentry.example.com/1",
+		"SENTRY_RELEASE=hyperfilelens-agent@old",
+		"USER_MANAGED=value",
+		"",
+	}, "\n")
+	if err := os.WriteFile(path, []byte(original), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("SENTRY_ENABLED", "true")
+	t.Setenv("SENTRY_BACKEND_DSN", "https://new@sentry.example.com/2")
+	t.Setenv("SENTRY_ENVIRONMENT", "hfl-production")
+	t.Setenv("SENTRY_RELEASE", "hyperfilelens-agent@0.1.8")
+	t.Setenv("SENTRY_TRACES_SAMPLE_RATE", "0.05")
+	t.Setenv("HFL_SENTRY_LENSNODE_RELEASE", "hyperfilelens-lensnode@0.1.8-sl0.4.0")
+
+	changed, err := syncManagedSentryEnv(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed {
+		t.Fatal("syncManagedSentryEnv() changed = false, want true")
+	}
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(content)
+	for _, expected := range []string{
+		"HFL_NODE_ID=42",
+		"HFL_NODE_TOKEN=working-token",
+		"USER_MANAGED=value",
+		"SENTRY_BACKEND_DSN=https://new@sentry.example.com/2",
+		"SENTRY_ENVIRONMENT=hfl-production",
+		"SENTRY_RELEASE=hyperfilelens-agent@0.1.8",
+	} {
+		if !strings.Contains(text, expected+"\n") {
+			t.Fatalf("updated agent.env missing %q:\n%s", expected, text)
+		}
+	}
+	if strings.Contains(text, "https://old@sentry.example.com/1") {
+		t.Fatalf("updated agent.env retained old Sentry DSN:\n%s", text)
+	}
+
+	changed, err = syncManagedSentryEnv(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if changed {
+		t.Fatal("second syncManagedSentryEnv() changed = true, want false")
+	}
+}
+
+func TestSyncManagedSentryEnvDisablesAndRemovesCredentials(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "agent.env")
+	if err := os.WriteFile(path, []byte(
+		"HFL_NODE_TOKEN=working-token\nSENTRY_ENABLED=true\n"+
+			"SENTRY_BACKEND_DSN=https://old@sentry.example.com/1\n",
+	), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("SENTRY_ENABLED", "false")
+
+	changed, err := syncManagedSentryEnv(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed {
+		t.Fatal("syncManagedSentryEnv() changed = false, want true")
+	}
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := string(content); got != "HFL_NODE_TOKEN=working-token\nSENTRY_ENABLED=false\n" {
+		t.Fatalf("updated agent.env = %q", got)
+	}
+}

--- a/src/agent/internal/enroll/gateway_install.go
+++ b/src/agent/internal/enroll/gateway_install.go
@@ -18,11 +18,11 @@ import (
 
 // LensSidecarConfig holds SourceLens LensNode credentials for gateway sidecar install.
 type LensSidecarConfig struct {
-	LensBaseURL       string
-	LensnodeUUID      string
-	LensnodeToken     string
-	LensnodeName      string
-	WorkspaceRoot     string
+	LensBaseURL   string
+	LensnodeUUID  string
+	LensnodeToken string
+	LensnodeName  string
+	WorkspaceRoot string
 }
 
 // RunGatewayInstall installs the HFL agent and SourceLens LensNode sidecar for role=gateway.
@@ -40,6 +40,17 @@ func RunGatewayInstall(ctx context.Context, opts InstallOptions) error {
 
 	if err := RunInstall(ctx, opts); err != nil {
 		return err
+	}
+	// Re-enrollment may short-circuit for an already healthy Agent. Converge
+	// only HFL-managed observability keys; never replace working node credentials.
+	sentryChanged, err := SyncManagedSentryEnv()
+	if err != nil {
+		return fmt.Errorf("refresh Gateway Agent configuration: %w", err)
+	}
+	if sentryChanged {
+		if err := RestartInstalledService(ctx); err != nil {
+			return fmt.Errorf("restart Gateway Agent after configuration refresh: %w", err)
+		}
 	}
 
 	logStep("Continuing Data Gateway setup (AI engine).")
@@ -126,11 +137,11 @@ func FetchGatewayLensConfig(ctx context.Context, cfg Config, nodeID string) (Len
 	}
 
 	cfgOut := LensSidecarConfig{
-		LensBaseURL:       stringField(lensRaw, "lens_base_url"),
-		LensnodeUUID:      stringField(lensRaw, "lensnode_uuid"),
-		LensnodeToken:     stringField(lensRaw, "lensnode_token"),
-		LensnodeName:      stringField(lensRaw, "lensnode_name"),
-		WorkspaceRoot:     stringField(lensRaw, "workspace_root"),
+		LensBaseURL:   stringField(lensRaw, "lens_base_url"),
+		LensnodeUUID:  stringField(lensRaw, "lensnode_uuid"),
+		LensnodeToken: stringField(lensRaw, "lensnode_token"),
+		LensnodeName:  stringField(lensRaw, "lensnode_name"),
+		WorkspaceRoot: stringField(lensRaw, "workspace_root"),
 	}
 	if cfgOut.LensBaseURL == "" || cfgOut.LensnodeToken == "" || cfgOut.LensnodeUUID == "" {
 		return LensSidecarConfig{}, fmt.Errorf("incomplete lens configuration from console")

--- a/src/agent/internal/enroll/service_unix.go
+++ b/src/agent/internal/enroll/service_unix.go
@@ -21,6 +21,11 @@ func StartInstalledService(ctx context.Context) error {
 	return startSystemd(ctx)
 }
 
+// RestartInstalledService reloads the persisted Agent runtime environment.
+func RestartInstalledService(ctx context.Context) error {
+	return startUnixScript(ctx, "restart")
+}
+
 func startUnixScript(ctx context.Context, command string) error {
 	script := filepath.Join(install.DefaultInstallDir(), "install.sh")
 	cmd := exec.CommandContext(ctx, script, command)

--- a/src/agent/internal/enroll/service_windows.go
+++ b/src/agent/internal/enroll/service_windows.go
@@ -16,6 +16,11 @@ func StartInstalledService(ctx context.Context) error {
 	return startWindowsService(ctx)
 }
 
+// RestartInstalledService reloads the persisted Agent runtime environment.
+func RestartInstalledService(ctx context.Context) error {
+	return startWindowsService(ctx)
+}
+
 func startWindowsService(ctx context.Context) error {
 	installRoot := filepath.Join(os.Getenv("ProgramFiles"), "HyperFileLens", "Agent")
 	agentBin := filepath.Join(installRoot, "hfl-agent.exe")

--- a/src/agent/internal/enroll/sidecar_install_unix.go
+++ b/src/agent/internal/enroll/sidecar_install_unix.go
@@ -168,6 +168,17 @@ func writeLensEnvFile(lens LensSidecarConfig) error {
 	if lens.LensnodeName != "" {
 		lines = append(lines, "LENSNODE_NAME="+quoteEnv(lens.LensnodeName))
 	}
+	for _, name := range []string{
+		"SENTRY_ENABLED",
+		"SENTRY_BACKEND_DSN",
+		"SENTRY_ENVIRONMENT",
+		"SENTRY_TRACES_SAMPLE_RATE",
+		"HFL_SENTRY_LENSNODE_RELEASE",
+	} {
+		if value := strings.TrimSpace(os.Getenv(name)); value != "" && !strings.ContainsAny(value, "\r\n") {
+			lines = append(lines, name+"="+quoteEnv(value))
+		}
+	}
 	content := strings.Join(lines, "\n") + "\n"
 	if err := os.WriteFile(lensEnvFilePath, []byte(content), 0o600); err != nil {
 		return fmt.Errorf("write %s: %w", lensEnvFilePath, err)

--- a/src/agent/internal/infra/observability/sentry.go
+++ b/src/agent/internal/infra/observability/sentry.go
@@ -1,0 +1,88 @@
+// Package observability provides optional, privacy-safe Agent error reporting.
+package observability
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/getsentry/sentry-go"
+)
+
+const flushTimeout = 2 * time.Second
+
+func enabled() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("SENTRY_ENABLED"))) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
+}
+
+func sampleRate() float64 {
+	value, err := strconv.ParseFloat(strings.TrimSpace(os.Getenv("SENTRY_TRACES_SAMPLE_RATE")), 64)
+	if err != nil || value < 0 || value > 1 {
+		return 0
+	}
+	return value
+}
+
+// Initialize enables Sentry for an explicitly configured Platform Gateway Agent.
+// It returns a shutdown function that flushes pending events without blocking exit.
+func Initialize() func() {
+	if !enabled() {
+		return func() {}
+	}
+	dsn := strings.TrimSpace(os.Getenv("SENTRY_BACKEND_DSN"))
+	if dsn == "" {
+		_, _ = fmt.Fprintln(os.Stderr, "[sentry] backend DSN is missing; Agent reporting is disabled")
+		return func() {}
+	}
+	err := sentry.Init(sentry.ClientOptions{
+		Dsn:              dsn,
+		Environment:      strings.TrimSpace(os.Getenv("SENTRY_ENVIRONMENT")),
+		Release:          strings.TrimSpace(os.Getenv("SENTRY_RELEASE")),
+		ServerName:       "hfl-platform-gateway",
+		EnableTracing:    sampleRate() > 0,
+		TracesSampleRate: sampleRate(),
+		SendDefaultPII:   false,
+		AttachStacktrace: true,
+		MaxBreadcrumbs:   20,
+		BeforeSend: func(event *sentry.Event, _ *sentry.EventHint) *sentry.Event {
+			event.User = sentry.User{}
+			event.ServerName = "hfl-platform-gateway"
+			delete(event.Contexts, "device")
+			if event.Tags == nil {
+				event.Tags = map[string]string{}
+			}
+			event.Tags["product"] = "hyperfilelens"
+			event.Tags["component"] = "hfl-agent"
+			event.Tags["gateway_type"] = "platform"
+			return event
+		},
+	})
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "[sentry] Agent initialization failed; continuing: %v\n", err)
+		return func() {}
+	}
+	return func() { sentry.Flush(flushTimeout) }
+}
+
+// CaptureException reports an unrecoverable daemon failure without its payload.
+func CaptureException(err error) {
+	if err != nil {
+		sentry.CaptureMessage("Platform Gateway Agent exited unexpectedly")
+	}
+}
+
+// RecoverPanic reports a process panic, flushes it, and preserves panic semantics.
+func RecoverPanic() {
+	if recovered := recover(); recovered != nil {
+		sentry.CaptureMessage("Platform Gateway Agent panicked")
+		sentry.Flush(flushTimeout)
+		panic(recovered)
+	}
+}

--- a/src/agent/internal/infra/observability/sentry_test.go
+++ b/src/agent/internal/infra/observability/sentry_test.go
@@ -1,0 +1,17 @@
+package observability
+
+import "testing"
+
+func TestSampleRateRejectsInvalidValues(t *testing.T) {
+	t.Setenv("SENTRY_TRACES_SAMPLE_RATE", "2")
+	if got := sampleRate(); got != 0 {
+		t.Fatalf("sampleRate() = %v, want 0", got)
+	}
+}
+
+func TestEnabledDefaultsToFalse(t *testing.T) {
+	t.Setenv("SENTRY_ENABLED", "")
+	if enabled() {
+		t.Fatal("enabled() = true, want false")
+	}
+}

--- a/src/agent/packaging/install/install.sh
+++ b/src/agent/packaging/install/install.sh
@@ -619,6 +619,13 @@ merge_agent_env() {
 	local kopia_path="${INSTALL_DIR}/kopia"
 	local -a keys=(HFL_DATA_DIR HFL_KOPIA_PATH HFL_INSECURE_TLS)
 	local -a vals=("${data_dir}" "${kopia_path}" "1")
+	local optional
+	for optional in SENTRY_ENABLED SENTRY_BACKEND_DSN SENTRY_ENVIRONMENT SENTRY_RELEASE SENTRY_TRACES_SAMPLE_RATE HFL_SENTRY_LENSNODE_RELEASE; do
+		if [[ -n "${!optional:-}" && "${!optional}" != *$'\n'* && "${!optional}" != *$'\r'* ]]; then
+			keys+=("${optional}")
+			vals+=("${!optional}")
+		fi
+	done
 	local i key val added=()
 
 	if [[ ! -f "${env_file}" ]]; then
@@ -910,6 +917,7 @@ deploy_binaries() {
 write_agent_env() {
 	local env_file="$1"
 	local kopia_path="${INSTALL_DIR}/kopia"
+	local name
 	mkdir -p "$(dirname "$env_file")"
 	umask 077
 	{
@@ -922,6 +930,9 @@ write_agent_env() {
 		echo "HFL_NODE_ROLE=${NODE_ROLE}"
 		echo "HFL_KOPIA_PATH=${kopia_path}"
 		echo "HFL_INSECURE_TLS=${HFL_INSECURE_TLS:-1}"
+		for name in SENTRY_ENABLED SENTRY_BACKEND_DSN SENTRY_ENVIRONMENT SENTRY_RELEASE SENTRY_TRACES_SAMPLE_RATE HFL_SENTRY_LENSNODE_RELEASE; do
+			[[ -z "${!name:-}" ]] || echo "${name}=${!name}"
+		done
 	} >"${env_file}"
 	chmod 600 "${env_file}"
 	log_ok "wrote ${env_file}"

--- a/src/backend/common/observability/sentry.py
+++ b/src/backend/common/observability/sentry.py
@@ -1,19 +1,40 @@
-"""Optional Sentry integration (no-op unless explicitly enabled with a DSN)."""
+"""Privacy-safe, optional Sentry integration for HFL backend processes."""
 
 from __future__ import annotations
 
+import hashlib
+import hmac
 import logging
 import os
+import re
+from collections.abc import Mapping
+from typing import Any
+from urllib.parse import urlsplit, urlunsplit
 
-from common.observability.context import (
-    get_org_key,
-    get_trace_id,
-    get_user_id,
-)
+from common.observability.context import get_org_key, get_trace_id, get_user_id
 
 logger = logging.getLogger(__name__)
 
 _TRUTHY = frozenset({"1", "true", "yes", "on"})
+_FILTERED = "[Filtered]"
+_SAFE_CONTEXT_FIELDS = {
+    "os": frozenset({"build", "kernel_version", "name", "version"}),
+    "runtime": frozenset({"build", "name", "version"}),
+    "trace": frozenset({"op", "origin", "parent_span_id", "span_id", "status", "trace_id"}),
+}
+_SAFE_SPAN_FIELDS = frozenset(
+    {
+        "op",
+        "origin",
+        "parent_span_id",
+        "same_process_as_parent",
+        "span_id",
+        "start_timestamp",
+        "status",
+        "timestamp",
+        "trace_id",
+    }
+)
 
 
 def _env_bool(name: str, *, default: bool = False) -> bool:
@@ -34,14 +55,176 @@ def _sample_rate(name: str, *, default: float = 0.0) -> float:
     return max(0.0, min(1.0, value))
 
 
+def _valid_dsn(value: str) -> bool:
+    """Return whether *value* is a structurally valid HTTP(S) Sentry DSN."""
+    try:
+        parsed = urlsplit(value)
+        port = parsed.port
+    except ValueError:
+        return False
+    project_id = parsed.path.rstrip("/").rsplit("/", 1)[-1]
+    return bool(
+        parsed.scheme in {"http", "https"}
+        and parsed.hostname
+        and parsed.username
+        and not parsed.query
+        and not parsed.fragment
+        and project_id.isdigit()
+        and (port is None or 1 <= port <= 65535)
+        and not re.search(r"\s", value)
+    )
+
+
+def _safe_url(value: Any) -> str | None:
+    """Remove query, fragment, and resource paths from an event URL."""
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        parsed = urlsplit(value)
+        port = parsed.port
+    except ValueError:
+        return None
+    if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+        return None
+    host = parsed.hostname
+    if ":" in host:
+        host = f"[{host}]"
+    if port is not None:
+        host = f"{host}:{port}"
+    return urlunsplit((parsed.scheme, host, "", "", ""))
+
+
+def _pseudonym(value: str) -> str:
+    """Return a deployment-scoped, irreversible identifier for Sentry tags."""
+    secret = (os.getenv("SECRET_KEY") or "").encode("utf-8")
+    if not value or not secret:
+        return ""
+    digest = hmac.new(secret, value.encode("utf-8"), hashlib.sha256).hexdigest()
+    return digest[:24]
+
+
+def _before_breadcrumb(crumb: dict[str, Any], hint: Any) -> dict[str, Any]:  # noqa: ARG001
+    """Retain breadcrumb classification while dropping user-controlled text."""
+    return {
+        key: crumb[key]
+        for key in ("category", "level", "timestamp", "type")
+        if key in crumb
+    }
+
+
+def _safe_spans(value: Any) -> list[dict[str, Any]]:
+    """Retain trace topology and timing while dropping span payload content."""
+    if not isinstance(value, list):
+        return []
+    spans: list[dict[str, Any]] = []
+    for span in value:
+        if not isinstance(span, Mapping):
+            continue
+        safe_span = {
+            str(key): field
+            for key, field in span.items()
+            if str(key) in _SAFE_SPAN_FIELDS
+            and isinstance(field, (bool, float, int, str))
+        }
+        if safe_span:
+            spans.append(safe_span)
+    return spans
+
+
+def _before_send(event: dict[str, Any], hint: Any) -> dict[str, Any]:  # noqa: ARG001
+    """Enrich an event with non-PII context and remove sensitive payloads."""
+    event.pop("user", None)
+    for key in ("breadcrumbs", "extra", "fingerprint", "logentry", "message"):
+        event.pop(key, None)
+    request = event.get("request")
+    if isinstance(request, dict):
+        safe_request: dict[str, Any] = {"headers": {}}
+        if safe_request_url := _safe_url(request.get("url")):
+            safe_request["url"] = safe_request_url
+        event["request"] = safe_request
+
+    transaction_info = event.get("transaction_info")
+    route_transaction = (
+        isinstance(transaction_info, Mapping)
+        and transaction_info.get("source") == "route"
+        and isinstance(event.get("transaction"), str)
+    )
+    if route_transaction:
+        event["transaction_info"] = {"source": "route"}
+    else:
+        event.pop("transaction", None)
+        event.pop("transaction_info", None)
+
+    if spans := _safe_spans(event.get("spans")):
+        event["spans"] = spans
+    else:
+        event.pop("spans", None)
+
+    contexts = event.get("contexts")
+    if isinstance(contexts, Mapping):
+        event["contexts"] = {
+            str(name): {
+                str(key): value
+                for key, value in context.items()
+                if str(key) in _SAFE_CONTEXT_FIELDS[str(name)]
+                and isinstance(value, (bool, float, int, str))
+            }
+            for name, context in contexts.items()
+            if str(name) in _SAFE_CONTEXT_FIELDS and isinstance(context, Mapping)
+        }
+    else:
+        event.pop("contexts", None)
+
+    exception = event.get("exception")
+    if isinstance(exception, dict):
+        for value in exception.get("values") or []:
+            if not isinstance(value, dict):
+                continue
+            if value.get("value"):
+                value["value"] = _FILTERED
+            mechanism = value.get("mechanism")
+            if isinstance(mechanism, dict):
+                mechanism.pop("data", None)
+            stacktrace = value.get("stacktrace")
+            if not isinstance(stacktrace, dict):
+                continue
+            for frame in stacktrace.get("frames") or []:
+                if isinstance(frame, dict):
+                    frame.pop("vars", None)
+
+    tags: dict[str, str] = {}
+    trace_id = get_trace_id()
+    if trace_id:
+        tags["trace_id"] = trace_id
+    org_hash = _pseudonym(get_org_key())
+    if org_hash:
+        tags["org_hash"] = org_hash
+    user_hash = _pseudonym(get_user_id())
+    if user_hash:
+        tags["user_hash"] = user_hash
+    for env_name, tag_name in (
+        ("SENTRY_COMPONENT", "component"),
+        ("SENTRY_SERVICE", "service"),
+        ("HFL_DEPLOYMENT_MODE", "deployment_mode"),
+        ("HFL_DEPLOY_TARGET", "deploy_target"),
+        ("HFL_RELEASE_CHANNEL", "release_channel"),
+    ):
+        value = (os.getenv(env_name) or "").strip()
+        if value:
+            tags[tag_name] = value
+    tags["product"] = "hyperfilelens"
+    event["tags"] = tags
+    return event
+
+
 def init_sentry() -> None:
-    """Initialize Sentry when ``SENTRY_ENABLED`` is true and ``SENTRY_DSN`` is set."""
+    """Initialize Sentry when enabled; configuration errors never block HFL."""
     if not _env_bool("SENTRY_ENABLED"):
         return
 
-    dsn = (os.getenv("SENTRY_DSN") or "").strip()
-    if not dsn:
-        logger.debug("SENTRY_ENABLED is true but SENTRY_DSN is unset; skipping Sentry init")
+    dsn = (os.getenv("SENTRY_BACKEND_DSN") or "").strip()
+    if not _valid_dsn(dsn):
+        logger.warning("Sentry is enabled without a valid backend DSN; reporting is disabled")
         return
 
     try:
@@ -50,47 +233,25 @@ def init_sentry() -> None:
         from sentry_sdk.integrations.django import DjangoIntegration
         from sentry_sdk.integrations.redis import RedisIntegration
     except ImportError:
-        logger.debug("sentry-sdk not installed; skipping Sentry init")
+        logger.warning("sentry-sdk is unavailable; reporting is disabled")
         return
 
-    environment = (os.getenv("SENTRY_ENVIRONMENT") or os.getenv("ENV") or "").strip()
+    environment = (os.getenv("SENTRY_ENVIRONMENT") or "").strip()
     release = (os.getenv("SENTRY_RELEASE") or os.getenv("APP_VERSION") or "").strip()
-
-    traces_sample_rate = _sample_rate("SENTRY_TRACES_SAMPLE_RATE")
-    profiles_sample_rate = _sample_rate(
-        "SENTRY_PROFILES_SAMPLE_RATE",
-        default=_sample_rate("SENTRY_PROFILING_SAMPLE_RATE"),
-    )
-
-    def _before_send(event, hint):  # noqa: ANN001, ARG001
-        try:
-            tags = event.get("tags") or {}
-            rid = get_trace_id()
-            if rid:
-                tags["trace_id"] = rid
-                tags["request_id"] = rid
-            org_key = get_org_key()
-            if org_key:
-                tags["org_key"] = org_key
-            user_id = get_user_id()
-            if user_id:
-                tags["user_id"] = user_id
-            event["tags"] = tags
-        except Exception:
-            logger.debug("Failed to enrich Sentry event with request context")
-        return event
-
-    sentry_sdk.init(
-        dsn=dsn,
-        integrations=[
-            DjangoIntegration(),
-            CeleryIntegration(),
-            RedisIntegration(),
-        ],
-        environment=environment or None,
-        release=release or None,
-        traces_sample_rate=traces_sample_rate,
-        profiles_sample_rate=profiles_sample_rate,
-        send_default_pii=_env_bool("SENTRY_SEND_DEFAULT_PII"),
-        before_send=_before_send,
-    )
+    try:
+        sentry_sdk.init(
+            dsn=dsn,
+            integrations=[DjangoIntegration(), CeleryIntegration(), RedisIntegration()],
+            environment=environment or None,
+            release=release or None,
+            traces_sample_rate=_sample_rate("SENTRY_TRACES_SAMPLE_RATE"),
+            profiles_sample_rate=0.0,
+            send_default_pii=False,
+            include_local_variables=False,
+            max_request_body_size="never",
+            before_breadcrumb=_before_breadcrumb,
+            before_send=_before_send,
+            before_send_transaction=_before_send,
+        )
+    except Exception as exc:  # Sentry must never prevent process startup.
+        logger.warning("Sentry initialization failed; reporting is disabled: %s", exc)

--- a/src/backend/common/observability/tests/test_sentry.py
+++ b/src/backend/common/observability/tests/test_sentry.py
@@ -1,4 +1,4 @@
-"""Tests for optional Sentry initialization."""
+"""Tests for privacy-safe optional Sentry initialization."""
 
 from __future__ import annotations
 
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from common.observability.context import org_key_var, request_id_var, user_id_var
 from common.observability.sentry import init_sentry
 
 
@@ -13,102 +14,195 @@ from common.observability.sentry import init_sentry
 def _clear_sentry_env(monkeypatch):
     for name in (
         "SENTRY_ENABLED",
+        "SENTRY_BACKEND_DSN",
         "SENTRY_DSN",
         "SENTRY_ENVIRONMENT",
         "SENTRY_RELEASE",
         "SENTRY_TRACES_SAMPLE_RATE",
-        "SENTRY_PROFILES_SAMPLE_RATE",
-        "SENTRY_PROFILING_SAMPLE_RATE",
-        "SENTRY_SEND_DEFAULT_PII",
-        "ENV",
+        "SENTRY_COMPONENT",
+        "SENTRY_SERVICE",
+        "SECRET_KEY",
         "APP_VERSION",
     ):
         monkeypatch.delenv(name, raising=False)
 
 
 def test_init_sentry_skips_when_disabled(monkeypatch):
-    monkeypatch.setenv("SENTRY_DSN", "https://example@sentry.io/1")
-
+    monkeypatch.setenv("SENTRY_BACKEND_DSN", "https://public@sentry.example.com/1")
     with patch("sentry_sdk.init") as mock_init:
         init_sentry()
-
     mock_init.assert_not_called()
 
 
-def test_init_sentry_skips_when_enabled_without_dsn(monkeypatch):
+@pytest.mark.parametrize(
+    "dsn",
+    ["", "not-a-dsn", "ftp://public@sentry.example.com/1", "https://sentry.example.com/1"],
+)
+def test_init_sentry_skips_invalid_dsn(monkeypatch, dsn):
     monkeypatch.setenv("SENTRY_ENABLED", "true")
-
+    monkeypatch.setenv("SENTRY_BACKEND_DSN", dsn)
     with patch("sentry_sdk.init") as mock_init:
         init_sentry()
-
     mock_init.assert_not_called()
 
 
-def test_init_sentry_initializes_with_redis_integration(monkeypatch):
+def test_init_sentry_uses_fixed_privacy_policy(monkeypatch):
     monkeypatch.setenv("SENTRY_ENABLED", "true")
-    monkeypatch.setenv("SENTRY_DSN", "https://example@sentry.io/1")
-    monkeypatch.setenv("SENTRY_ENVIRONMENT", "staging")
-    monkeypatch.setenv("SENTRY_RELEASE", "1.2.3")
+    monkeypatch.setenv("SENTRY_BACKEND_DSN", "https://public@sentry.example.com/42")
+    monkeypatch.setenv("SENTRY_ENVIRONMENT", "hfl-preprod")
+    monkeypatch.setenv("SENTRY_RELEASE", "hyperfilelens-backend@0.1.8")
     monkeypatch.setenv("SENTRY_TRACES_SAMPLE_RATE", "0.25")
-    monkeypatch.setenv("SENTRY_PROFILES_SAMPLE_RATE", "0.1")
-    monkeypatch.setenv("SENTRY_SEND_DEFAULT_PII", "true")
 
     fake_django = MagicMock(name="DjangoIntegration")
     fake_celery = MagicMock(name="CeleryIntegration")
     fake_redis = MagicMock(name="RedisIntegration")
-
     with (
         patch("sentry_sdk.init") as mock_init,
-        patch(
-            "sentry_sdk.integrations.django.DjangoIntegration",
-            return_value=fake_django,
-        ),
-        patch(
-            "sentry_sdk.integrations.celery.CeleryIntegration",
-            return_value=fake_celery,
-        ),
-        patch(
-            "sentry_sdk.integrations.redis.RedisIntegration",
-            return_value=fake_redis,
-        ),
+        patch("sentry_sdk.integrations.django.DjangoIntegration", return_value=fake_django),
+        patch("sentry_sdk.integrations.celery.CeleryIntegration", return_value=fake_celery),
+        patch("sentry_sdk.integrations.redis.RedisIntegration", return_value=fake_redis),
     ):
         init_sentry()
 
-    mock_init.assert_called_once()
     kwargs = mock_init.call_args.kwargs
-    assert kwargs["dsn"] == "https://example@sentry.io/1"
-    assert kwargs["environment"] == "staging"
-    assert kwargs["release"] == "1.2.3"
+    assert kwargs["environment"] == "hfl-preprod"
+    assert kwargs["release"] == "hyperfilelens-backend@0.1.8"
     assert kwargs["traces_sample_rate"] == 0.25
-    assert kwargs["profiles_sample_rate"] == 0.1
-    assert kwargs["send_default_pii"] is True
-    assert kwargs["integrations"] == [fake_django, fake_celery, fake_redis]
-    assert kwargs["before_send"] is not None
-
-
-def test_init_sentry_clamps_sample_rates(monkeypatch):
-    monkeypatch.setenv("SENTRY_ENABLED", "1")
-    monkeypatch.setenv("SENTRY_DSN", "https://example@sentry.io/1")
-    monkeypatch.setenv("SENTRY_TRACES_SAMPLE_RATE", "2")
-    monkeypatch.setenv("SENTRY_PROFILING_SAMPLE_RATE", "-0.5")
-
-    with patch("sentry_sdk.init") as mock_init:
-        init_sentry()
-
-    kwargs = mock_init.call_args.kwargs
-    assert kwargs["traces_sample_rate"] == 1.0
     assert kwargs["profiles_sample_rate"] == 0.0
+    assert kwargs["send_default_pii"] is False
+    assert kwargs["include_local_variables"] is False
+    assert kwargs["max_request_body_size"] == "never"
+    assert kwargs["before_send_transaction"] is kwargs["before_send"]
+    assert kwargs["integrations"] == [fake_django, fake_celery, fake_redis]
 
 
-def test_init_sentry_falls_back_to_env_and_app_version(monkeypatch):
-    monkeypatch.setenv("SENTRY_ENABLED", "yes")
-    monkeypatch.setenv("SENTRY_DSN", "https://example@sentry.io/1")
-    monkeypatch.setenv("ENV", "production")
-    monkeypatch.setenv("APP_VERSION", "9.9.9")
+def test_before_send_scrubs_pii_and_hashes_context(monkeypatch):
+    monkeypatch.setenv("SENTRY_ENABLED", "true")
+    monkeypatch.setenv("SENTRY_BACKEND_DSN", "https://public@sentry.example.com/42")
+    monkeypatch.setenv("SECRET_KEY", "deployment-secret")
+    monkeypatch.setenv("SENTRY_COMPONENT", "hfl-backend")
+    monkeypatch.setenv("SENTRY_SERVICE", "api")
+    request_id_var.set("trace-123")
+    org_key_var.set("raw-organization")
+    user_id_var.set("raw-user")
 
     with patch("sentry_sdk.init") as mock_init:
         init_sentry()
+    before_send = mock_init.call_args.kwargs["before_send"]
+    event = before_send(
+        {
+            "user": {"email": "person@example.com"},
+            "request": {
+                "url": "https://app.example.com/api/source/private?token=secret",
+                "cookies": {"session": "secret"},
+                "data": {"password": "secret"},
+                "query_string": "token=secret",
+                "headers": {"Authorization": "Bearer secret", "User-Agent": "pytest"},
+                "env": {"REMOTE_ADDR": "192.0.2.15", "customer": "private"},
+            },
+            "transaction": "/api/source/private-id",
+            "transaction_info": {"source": "url", "private": "customer"},
+            "spans": [
+                {
+                    "trace_id": "trace-span-1",
+                    "span_id": "span-1",
+                    "op": "db.sql.query",
+                    "description": "SELECT * FROM private_files WHERE owner='customer'",
+                    "data": {"db.statement": "/customer/private"},
+                    "tags": {"customer": "raw-organization"},
+                }
+            ],
+            "message": "customer prompt and response",
+            "logentry": {"message": "customer filename"},
+            "breadcrumbs": [{"message": "customer path"}],
+            "extra": {"args": ["/customer/private"], "safe_count": 2},
+            "contexts": {
+                "customer": {"content": "private"},
+                "runtime": {"name": "CPython", "private": "customer"},
+                "trace": {"trace_id": "abc", "data": {"path": "/customer/private"}},
+            },
+            "exception": {
+                "values": [
+                    {
+                        "value": "open /customer/private failed",
+                        "mechanism": {"type": "generic", "data": {"path": "/customer/private"}},
+                        "stacktrace": {"frames": [{"vars": {"token": "secret"}}]},
+                    }
+                ]
+            },
+        },
+        {},
+    )
 
-    kwargs = mock_init.call_args.kwargs
-    assert kwargs["environment"] == "production"
-    assert kwargs["release"] == "9.9.9"
+    assert "user" not in event
+    assert event["request"] == {
+        "url": "https://app.example.com",
+        "headers": {},
+    }
+    for key in ("breadcrumbs", "extra", "fingerprint", "logentry", "message"):
+        assert key not in event
+    assert event["contexts"] == {
+        "runtime": {"name": "CPython"},
+        "trace": {"trace_id": "abc"},
+    }
+    exception = event["exception"]["values"][0]
+    assert exception["value"] == "[Filtered]"
+    assert "data" not in exception["mechanism"]
+    assert "vars" not in exception["stacktrace"]["frames"][0]
+    assert event["tags"]["trace_id"] == "trace-123"
+    assert event["tags"]["org_hash"] != "raw-organization"
+    assert event["tags"]["user_hash"] != "raw-user"
+    assert event["tags"]["component"] == "hfl-backend"
+    assert event["tags"]["service"] == "api"
+    assert "raw-organization" not in str(event)
+    assert "raw-user" not in str(event)
+    assert "/customer/private" not in str(event)
+    assert "transaction" not in event
+    assert "transaction_info" not in event
+    assert event["spans"] == [
+        {
+            "trace_id": "trace-span-1",
+            "span_id": "span-1",
+            "op": "db.sql.query",
+        }
+    ]
+    assert "192.0.2.15" not in str(event)
+
+
+def test_before_send_retains_only_safe_route_transaction(monkeypatch):
+    monkeypatch.setenv("SENTRY_ENABLED", "true")
+    monkeypatch.setenv("SENTRY_BACKEND_DSN", "https://public@sentry.example.com/42")
+    with patch("sentry_sdk.init") as mock_init:
+        init_sentry()
+    before_send = mock_init.call_args.kwargs["before_send"]
+
+    event = before_send(
+        {
+            "transaction": "/api/sources/<uuid:source_id>",
+            "transaction_info": {"source": "route", "private": "customer"},
+        },
+        {},
+    )
+
+    assert event["transaction"] == "/api/sources/<uuid:source_id>"
+    assert event["transaction_info"] == {"source": "route"}
+
+
+def test_before_send_removes_url_credentials(monkeypatch):
+    monkeypatch.setenv("SENTRY_ENABLED", "true")
+    monkeypatch.setenv("SENTRY_BACKEND_DSN", "https://public@sentry.example.com/42")
+    with patch("sentry_sdk.init") as mock_init:
+        init_sentry()
+    before_send = mock_init.call_args.kwargs["before_send"]
+    event = before_send(
+        {"request": {"url": "https://user:password@example.com:8443/private?token=secret"}},
+        {},
+    )
+    assert event["request"]["url"] == "https://example.com:8443"
+
+
+def test_init_failure_is_non_blocking(monkeypatch):
+    monkeypatch.setenv("SENTRY_ENABLED", "true")
+    monkeypatch.setenv("SENTRY_BACKEND_DSN", "https://public@sentry.example.com/42")
+    with patch("sentry_sdk.init", side_effect=ValueError("bad config")):
+        init_sentry()

--- a/src/backend/project/settings/base.py
+++ b/src/backend/project/settings/base.py
@@ -15,6 +15,8 @@ from .env import BASE_DIR, env_bool, env_csv, env_int, env_str
 # Override in production; default is for local dev only.
 SECRET_KEY = env_str("SECRET_KEY", "dev-only-change-me")
 DEBUG = env_bool("DJANGO_DEBUG", default=False)
+SENTRY_ENABLED = env_bool("SENTRY_ENABLED", default=False)
+SENTRY_ENVIRONMENT = env_str("SENTRY_ENVIRONMENT")
 PROTECTION_BACKUP_EXECUTION_BACKEND = env_str(
     "PROTECTION_BACKUP_EXECUTION_BACKEND",
     "celery",

--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -26,6 +26,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.17.0",
+        "@sentry/vite-plugin": "^5.4.0",
         "@vitejs/plugin-vue": "^5.2.4",
         "@vue/eslint-config-typescript": "^14.6.0",
         "@vue/test-utils": "^2.4.6",
@@ -56,6 +57,175 @@
         "lru-cache": "^10.4.3"
       }
     },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
@@ -74,6 +244,30 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/parser": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
@@ -87,6 +281,40 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/types": {
@@ -1662,6 +1890,306 @@
         "node": ">=18"
       }
     },
+    "node_modules/@sentry/bundler-plugins": {
+      "version": "10.69.0",
+      "resolved": "https://registry.npmjs.org/@sentry/bundler-plugins/-/bundler-plugins-10.69.0.tgz",
+      "integrity": "sha512-I1otnSJIH4IOugLp+kcBbT0Kcex+J8xnHuUyzMAwCYSpZ0FMVvA723uNmkMdW0PxRRw0oEhe0qDB+t+ZjHxUiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.18.5",
+        "@sentry/cli": "^2.58.6",
+        "@sentry/core": "10.69.0",
+        "dotenv": "^17.4.2",
+        "find-up": "^5.0.0",
+        "glob": "^13.0.6",
+        "magic-string": "~0.30.8"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "rollup": ">=3.2.0",
+        "webpack": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        },
+        "webpack": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sentry/bundler-plugins/node_modules/@sentry/core": {
+      "version": "10.69.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.69.0.tgz",
+      "integrity": "sha512-+uuqVEeiDzYuAKjZLqsROKXvRTbl/QeH0gfGRtpYib1cud4rAFWRIkFmcR7Jb7JGFYwmReyQotiTj/hcDszTZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/bundler-plugins/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@sentry/bundler-plugins/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@sentry/bundler-plugins/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@sentry/cli": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-2.58.6.tgz",
+      "integrity": "sha512-baBcNPLLfUi9WuL+Tpri9BFaAdvugZIKelC5X0tt0Zdy+K0K+PCVSrnNmwMWU/HyaF/SEv6b6UHnXIdqanBlcg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "FSL-1.1-MIT",
+      "dependencies": {
+        "https-proxy-agent": "^5.0.0",
+        "node-fetch": "^2.6.7",
+        "progress": "^2.0.3",
+        "proxy-from-env": "^1.1.0",
+        "which": "^2.0.2"
+      },
+      "bin": {
+        "sentry-cli": "bin/sentry-cli"
+      },
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@sentry/cli-darwin": "2.58.6",
+        "@sentry/cli-linux-arm": "2.58.6",
+        "@sentry/cli-linux-arm64": "2.58.6",
+        "@sentry/cli-linux-i686": "2.58.6",
+        "@sentry/cli-linux-x64": "2.58.6",
+        "@sentry/cli-win32-arm64": "2.58.6",
+        "@sentry/cli-win32-i686": "2.58.6",
+        "@sentry/cli-win32-x64": "2.58.6"
+      }
+    },
+    "node_modules/@sentry/cli-darwin": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-darwin/-/cli-darwin-2.58.6.tgz",
+      "integrity": "sha512-udAVvcyfNa0R+95GvPz/+43/N3TC0TYKdkQ7D7jhPSzbcMc7l2fxRNN5yB3UpCA5fWFnW4toeaqwDBhb/Wh3LA==",
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-arm": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm/-/cli-linux-arm-2.58.6.tgz",
+      "integrity": "sha512-pD0LAt5PcUzAinBwvDqc66x9+2CabHEv486yP0gRjWO7SakbaxmfVq/EXd8VLq/Tzi39LAu422UYK1lpW3MILw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-arm64": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm64/-/cli-linux-arm64-2.58.6.tgz",
+      "integrity": "sha512-q8mEcNNmeXMy5i+jWT30TVpH7LcP4HD21CD5XRSPAd/a912HF6EpK0ybf/1USO14WOhoXbAGi9txwaWabSe33g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-i686": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-i686/-/cli-linux-i686-2.58.6.tgz",
+      "integrity": "sha512-q8vNJi1eOV/4vxAFWBsEwLHoSYapaZHIf4j76KJGJXFKTkEbsjCOOsKbwUIBTQQhRgV4DFWh3ryfsPS/que4Kg==",
+      "cpu": [
+        "x86",
+        "ia32"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-x64": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-x64/-/cli-linux-x64-2.58.6.tgz",
+      "integrity": "sha512-DZu956Mhi3ZRjTBe1WdbGV46ldVbA8d2rgp/fh51GsI25zjBHah4wZnPTSzpc+YqxU6pJpg579B/r3jrIK530Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-win32-arm64": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-arm64/-/cli-win32-arm64-2.58.6.tgz",
+      "integrity": "sha512-nj0Ff/kmAB73EPDhR8B4O9r+NUHK5GkPCkGWC+kXVemqAJWL5jcJ5KdxG0l/S0z6RoEoltID8/43/B+TaMlT7A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-win32-i686": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-i686/-/cli-win32-i686-2.58.6.tgz",
+      "integrity": "sha512-WNZiDzPbgsEMQWq4avsQ391v/xWKJDIWWWo9GYl+N/w5qcYKkoDW7wQG7T9FasI6ENn68phChTOAPXXxbfAdOg==",
+      "cpu": [
+        "x86",
+        "ia32"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-win32-x64": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-x64/-/cli-win32-x64-2.58.6.tgz",
+      "integrity": "sha512-R35WJ17oF4D2eqI1DR2sQQqr0fjRTt5xoP16WrTu91XM2lndRMFsnjh+/GttbxapLCBNlrjzia99MJ0PZHZpgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/@sentry/cli/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@sentry/conventions": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@sentry/conventions/-/conventions-0.16.0.tgz",
+      "integrity": "sha512-fO9PLmHdVURcSPUpWCItWAtgKiMwGdJHbovoSEyLplX5sxs2ugvI4CBPTrkkgqhObnZOD0CnWBKDzSVQYBKEyQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@sentry/core": {
       "version": "9.47.1",
       "resolved": "https://registry.npmjs.org/@sentry/core/-/core-9.47.1.tgz",
@@ -1669,6 +2197,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/vite-plugin": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@sentry/vite-plugin/-/vite-plugin-5.4.0.tgz",
+      "integrity": "sha512-fFJgCxs5hDyAm9BbZJ+LbA+LK2tjX5OoD0v0ARU4StR6KQmGUduoPs69yJ9AfqZ0om3Rlp5JDliiwFcNkasORA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/bundler-plugins": "^10.64.0"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/@sentry/vue": {
@@ -3112,6 +3653,13 @@
         "proto-list": "~1.2.1"
       }
     },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/crelt": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.7.tgz",
@@ -3235,6 +3783,19 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/eastasianwidth": {
@@ -3868,6 +4429,16 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/glob": {
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
@@ -4254,6 +4825,19 @@
         "node": ">=18"
       }
     },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -4274,6 +4858,19 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/keyv": {
       "version": "4.5.4",
@@ -4722,6 +5319,52 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.51",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
@@ -5007,12 +5650,29 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/proto-list": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
       "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -6289,6 +6949,13 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -30,9 +30,10 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",
+    "@sentry/vite-plugin": "^5.4.0",
     "@vitejs/plugin-vue": "^5.2.4",
-    "@vue/test-utils": "^2.4.6",
     "@vue/eslint-config-typescript": "^14.6.0",
+    "@vue/test-utils": "^2.4.6",
     "@vue/tsconfig": "^0.7.0",
     "eslint": "^9.39.0",
     "eslint-plugin-vue": "^10.5.1",

--- a/src/frontend/src/lib/analytics.ts
+++ b/src/frontend/src/lib/analytics.ts
@@ -6,7 +6,6 @@ type AppAnalyticsParameters = { method: 'email' | 'google' }
 
 declare global {
   interface Window {
-    __HFL_APP_CONFIG__?: { gaMeasurementId?: string }
     dataLayer?: unknown[]
     gtag?: GoogleTag
   }

--- a/src/frontend/src/lib/sentry.test.ts
+++ b/src/frontend/src/lib/sentry.test.ts
@@ -1,0 +1,171 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { App } from 'vue'
+import type { Router } from 'vue-router'
+
+const sentryInit = vi.fn()
+vi.mock('@sentry/vue', () => ({
+  init: sentryInit,
+  browserTracingIntegration: vi.fn(() => 'browser-tracing'),
+}))
+
+afterEach(() => {
+  sentryInit.mockReset()
+  delete window.__HFL_APP_CONFIG__
+  vi.restoreAllMocks()
+})
+
+describe('runtime Sentry', () => {
+  it('remains disabled when runtime configuration is absent', async () => {
+    const { initSentry } = await import('./sentry')
+    initSentry({} as App, { afterEach: vi.fn() } as unknown as Router)
+    expect(sentryInit).not.toHaveBeenCalled()
+  })
+
+  it('warns and continues for malformed runtime configuration', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    window.__HFL_APP_CONFIG__ = {
+      sentryEnabled: true,
+      sentryDsn: 'not-a-dsn',
+      sentryEnvironment: 'hfl-test',
+      sentryRelease: 'hyperfilelens-frontend@main-1234567',
+    }
+    const { initSentry } = await import('./sentry')
+    initSentry({} as App, { afterEach: vi.fn() } as unknown as Router)
+    expect(sentryInit).not.toHaveBeenCalled()
+    expect(warn).toHaveBeenCalled()
+  })
+
+  it('rejects a browser DSN containing a password', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    window.__HFL_APP_CONFIG__ = {
+      sentryEnabled: true,
+      sentryDsn: 'https://public:secret@sentry.example.com/42',
+      sentryEnvironment: 'hfl-test',
+      sentryRelease: 'hyperfilelens-frontend@main-1234567',
+    }
+    const { initSentry } = await import('./sentry')
+    initSentry({} as App, { afterEach: vi.fn() } as unknown as Router)
+    expect(sentryInit).not.toHaveBeenCalled()
+    expect(warn).toHaveBeenCalled()
+  })
+
+  it('uses runtime identity and removes browser PII from events', async () => {
+    window.__HFL_APP_CONFIG__ = {
+      sentryEnabled: true,
+      sentryDsn: 'https://public@sentry.example.com/42',
+      sentryEnvironment: 'hfl-preprod',
+      sentryRelease: 'hyperfilelens-frontend@0.1.8',
+      sentryTracesSampleRate: 0.1,
+      sentrySurface: 'admin',
+    }
+    const { initSentry } = await import('./sentry')
+    initSentry({} as App, { afterEach: vi.fn() } as unknown as Router)
+
+    const options = sentryInit.mock.calls[0]?.[0]
+    expect(options).toEqual(expect.objectContaining({
+      environment: 'hfl-preprod',
+      release: 'hyperfilelens-frontend@0.1.8',
+      tracesSampleRate: 0.1,
+      sendDefaultPii: false,
+      initialScope: { tags: expect.objectContaining({ surface: 'admin' }) },
+    }))
+    const event = options.beforeSend({
+      user: { email: 'person@example.com' },
+      request: {
+        url: 'https://app.example.com/source/secret-id?token=secret#private',
+        cookies: { session: 'secret' },
+        data: { password: 'secret' },
+        query_string: 'token=secret',
+        headers: { Authorization: 'Bearer secret', 'User-Agent': 'test-browser' },
+        env: { REMOTE_ADDR: '192.0.2.15', customer: 'private' },
+      },
+      transaction: '/source/secret-id',
+      transaction_info: { source: 'url', private: 'customer' },
+      spans: [{
+        is_segment: true,
+        segment_id: 'segment-1',
+        trace_id: 'trace-span-1',
+        span_id: 'span-1',
+        op: 'http.client',
+        description: 'https://app.example.com/api/private?token=secret',
+        data: { 'http.request.header.authorization': 'secret' },
+        tags: { customer: 'private' },
+      }],
+      message: 'customer prompt',
+      logentry: { message: 'customer response' },
+      extra: { args: ['/customer/private'] },
+      contexts: {
+        customer: { filename: 'private.txt' },
+        trace: {
+          trace_id: 'root-trace-1',
+          span_id: 'root-span-1',
+          parent_span_id: 'root-parent-1',
+          op: 'navigation',
+          data: { customer: 'private' },
+        },
+      },
+      breadcrumbs: [{ category: 'console', message: 'customer path', data: { content: 'private' } }],
+      exception: {
+        values: [{
+          value: 'open /customer/private failed',
+          mechanism: { type: 'generic', data: { path: '/customer/private' } },
+          stacktrace: { frames: [{ vars: { token: 'secret' } }] },
+        }],
+      },
+    })
+    expect(event.user).toBeUndefined()
+    expect(event.request).toEqual({
+      url: 'https://app.example.com/',
+      headers: {},
+    })
+    expect(JSON.stringify(event)).not.toContain('secret')
+    expect(JSON.stringify(event)).not.toContain('person@example.com')
+    expect(event.exception.values[0].value).toBe('[Filtered]')
+    expect(event.transaction).toBe('/')
+    expect(event.transaction_info).toEqual({ source: 'route' })
+    expect(event.contexts).toEqual({
+      trace: {
+        trace_id: 'root-trace-1',
+        span_id: 'root-span-1',
+        parent_span_id: 'root-parent-1',
+        op: 'navigation',
+        data: {},
+      },
+    })
+    expect(event.spans).toEqual([{
+      data: {},
+      is_segment: true,
+      segment_id: 'segment-1',
+      trace_id: 'trace-span-1',
+      span_id: 'span-1',
+      op: 'http.client',
+    }])
+    expect(event.breadcrumbs).toEqual([{
+      category: 'console',
+      level: undefined,
+      timestamp: undefined,
+      type: undefined,
+    }])
+    expect(JSON.stringify(event)).not.toContain('/customer/private')
+    expect(JSON.stringify(event)).not.toContain('192.0.2.15')
+    expect(options.beforeSendTransaction).toBeTypeOf('function')
+    expect(options.beforeSendSpan({
+      is_segment: true,
+      segment_id: 'segment-2',
+      trace_id: 'trace-span-2',
+      span_id: 'span-2',
+      op: 'http.client',
+      description: 'https://app.example.com/api/private?token=secret',
+      data: { 'http.request.header.authorization': 'secret' },
+    })).toEqual({
+      data: {},
+      is_segment: true,
+      segment_id: 'segment-2',
+      trace_id: 'trace-span-2',
+      span_id: 'span-2',
+      op: 'http.client',
+    })
+  })
+})

--- a/src/frontend/src/lib/sentry.ts
+++ b/src/frontend/src/lib/sentry.ts
@@ -2,46 +2,160 @@ import * as Sentry from '@sentry/vue'
 import type { App } from 'vue'
 import type { Router } from 'vue-router'
 
-const TRUTHY = new Set(['1', 'true', 'yes', 'on'])
+const FILTERED = '[Filtered]'
+const SAFE_SPAN_FIELDS = [
+  'is_segment',
+  'op',
+  'origin',
+  'parent_span_id',
+  'same_process_as_parent',
+  'segment_id',
+  'span_id',
+  'start_timestamp',
+  'status',
+  'timestamp',
+  'trace_id',
+] as const
+const SAFE_TRACE_CONTEXT_FIELDS = [
+  'op',
+  'origin',
+  'parent_span_id',
+  'span_id',
+  'status',
+  'trace_id',
+] as const
 
-function envBool(value: unknown, defaultValue = false): boolean {
-  const raw = String(value ?? '').trim().toLowerCase()
-  if (!raw) return defaultValue
-  return TRUTHY.has(raw)
+function validBrowserDsn(value: string): boolean {
+  if (!value || /\s/.test(value)) return false
+  try {
+    const parsed = new URL(value)
+    const projectId = parsed.pathname.replace(/\/+$/, '').split('/').at(-1)
+    return ['http:', 'https:'].includes(parsed.protocol)
+      && Boolean(parsed.hostname && parsed.username)
+      && !parsed.password
+      && /^\d+$/.test(projectId || '')
+      && !parsed.search
+      && !parsed.hash
+  } catch {
+    return false
+  }
 }
 
-function sampleRate(value: unknown, defaultValue = 0): number {
+function sampleRate(value: unknown): number {
   const parsed = Number.parseFloat(String(value ?? ''))
-  if (!Number.isFinite(parsed)) return defaultValue
+  if (!Number.isFinite(parsed)) return 0
   return Math.max(0, Math.min(1, parsed))
 }
 
-/** Infer Sentry environment when SENTRY_ENVIRONMENT is unset (one build, pre + prod). */
-export function resolveSentryEnvironment(): string {
-  const configured = import.meta.env.SENTRY_ENVIRONMENT?.toString().trim()
-  if (configured) return configured
+function sanitizedOrigin(value: unknown): string | undefined {
+  if (typeof value !== 'string' || !value.trim()) return undefined
+  try {
+    const parsed = new URL(value, window.location.origin)
+    return parsed.origin
+  } catch {
+    return undefined
+  }
+}
 
-  const host = window.location.hostname
-  if (host === 'localhost' || host === '127.0.0.1') return 'development'
-  if (/pre|staging|uat|test/i.test(host)) return 'pre'
-  return 'production'
+function sanitizeSpan<T>(span: T): T {
+  const source = span as Record<string, unknown>
+  const sanitized: Record<string, unknown> = { data: {} }
+  for (const key of SAFE_SPAN_FIELDS) {
+    const value = source[key]
+    if (['boolean', 'number', 'string'].includes(typeof value)) sanitized[key] = value
+  }
+  return sanitized as T
+}
+
+function sanitizeTraceContext(value: unknown): Record<string, unknown> | undefined {
+  if (!value || typeof value !== 'object') return undefined
+  const source = value as Record<string, unknown>
+  const sanitized: Record<string, unknown> = { data: {} }
+  for (const key of SAFE_TRACE_CONTEXT_FIELDS) {
+    const field = source[key]
+    if (typeof field === 'string') sanitized[key] = field
+  }
+  return typeof sanitized.trace_id === 'string' && typeof sanitized.span_id === 'string'
+    ? sanitized
+    : undefined
+}
+
+function sanitizeEvent(
+  event: Sentry.Event,
+  routePath: string,
+  surface: 'admin' | 'tenant',
+): Sentry.Event {
+  delete event.user
+  delete event.message
+  delete event.logentry
+  delete event.extra
+  delete event.fingerprint
+  const traceContext = sanitizeTraceContext(event.contexts?.trace)
+  event.contexts = traceContext ? { trace: traceContext } : undefined
+  if (event.request) {
+    const origin = sanitizedOrigin(event.request.url)
+    event.request = {
+      headers: {},
+      ...(origin ? { url: `${origin}${routePath}` } : {}),
+    }
+  }
+  event.transaction = routePath
+  event.transaction_info = { source: 'route' }
+  event.spans = event.spans?.map(sanitizeSpan)
+  event.breadcrumbs = event.breadcrumbs?.map((breadcrumb) => ({
+    category: breadcrumb.category,
+    level: breadcrumb.level,
+    timestamp: breadcrumb.timestamp,
+    type: breadcrumb.type,
+  }))
+  for (const exception of event.exception?.values || []) {
+    if (exception.value) exception.value = FILTERED
+    if (exception.mechanism) delete exception.mechanism.data
+    for (const frame of exception.stacktrace?.frames || []) delete frame.vars
+  }
+  event.tags = { component: 'hfl-frontend', product: 'hyperfilelens', surface }
+  return event
 }
 
 export function initSentry(app: App, router: Router): void {
-  if (!envBool(import.meta.env.SENTRY_ENABLED)) return
+  const config = window.__HFL_APP_CONFIG__
+  if (!config?.sentryEnabled) return
 
-  const dsn = import.meta.env.SENTRY_DSN?.toString().trim()
-  if (!dsn) return
+  const dsn = String(config.sentryDsn || '').trim()
+  const environment = String(config.sentryEnvironment || '').trim()
+  const release = String(config.sentryRelease || '').trim()
+  const surface = config.sentrySurface === 'admin' ? 'admin' : 'tenant'
+  if (!validBrowserDsn(dsn) || !environment || !release) {
+    console.warn('[sentry] Invalid runtime configuration; browser reporting is disabled.')
+    return
+  }
 
-  const release = import.meta.env.SENTRY_RELEASE?.toString().trim()
-
-  Sentry.init({
-    app,
-    dsn,
-    environment: resolveSentryEnvironment(),
-    release: release || undefined,
-    integrations: [Sentry.browserTracingIntegration({ router })],
-    tracesSampleRate: sampleRate(import.meta.env.SENTRY_TRACES_SAMPLE_RATE),
-    sendDefaultPii: envBool(import.meta.env.SENTRY_SEND_DEFAULT_PII),
-  })
+  try {
+    let activeRoutePath = '/'
+    router.afterEach?.((route) => {
+      const routeTemplate = route.matched?.at(-1)?.path || '/'
+      activeRoutePath = routeTemplate.startsWith('/') ? routeTemplate : `/${routeTemplate}`
+    })
+    Sentry.init({
+      app,
+      dsn,
+      environment,
+      release,
+      integrations: [Sentry.browserTracingIntegration({ router })],
+      tracesSampleRate: sampleRate(config.sentryTracesSampleRate),
+      sendDefaultPii: false,
+      beforeSend: (event) => sanitizeEvent(event, activeRoutePath, surface),
+      beforeSendTransaction: (event) => sanitizeEvent(event, activeRoutePath, surface),
+      beforeSendSpan: sanitizeSpan,
+      initialScope: {
+        tags: {
+          product: 'hyperfilelens',
+          component: 'hfl-frontend',
+          surface,
+        },
+      },
+    })
+  } catch (error) {
+    console.warn('[sentry] Initialization failed; the application will continue.', error)
+  }
 }

--- a/src/frontend/src/vite-env.d.ts
+++ b/src/frontend/src/vite-env.d.ts
@@ -3,14 +3,22 @@
 interface ImportMetaEnv {
   readonly VITE_API_BASE?: string
   readonly VITE_SHOW_EULA?: string
-  readonly SENTRY_ENABLED?: string
-  readonly SENTRY_DSN?: string
-  readonly SENTRY_ENVIRONMENT?: string
-  readonly SENTRY_RELEASE?: string
-  readonly SENTRY_TRACES_SAMPLE_RATE?: string
-  readonly SENTRY_SEND_DEFAULT_PII?: string
 }
 
 interface ImportMeta {
   readonly env: ImportMetaEnv
+}
+
+interface HFLAppRuntimeConfig {
+  gaMeasurementId?: string
+  sentryEnabled?: boolean
+  sentryDsn?: string
+  sentryEnvironment?: string
+  sentryRelease?: string
+  sentryTracesSampleRate?: number
+  sentrySurface?: 'tenant' | 'admin'
+}
+
+interface Window {
+  __HFL_APP_CONFIG__?: HFLAppRuntimeConfig
 }

--- a/src/frontend/vite.config.ts
+++ b/src/frontend/vite.config.ts
@@ -1,21 +1,48 @@
 import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import tailwindcss from '@tailwindcss/vite'
+import { sentryVitePlugin } from '@sentry/vite-plugin'
 import { fileURLToPath } from 'node:url'
 import { dirname, resolve } from 'node:path'
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
 const devApiTarget = process.env.VITE_DEV_API_TARGET || 'http://api:8000'
 const devWebSocketTarget = process.env.VITE_DEV_WEBSOCKET_TARGET || 'http://api:8001'
+const sentrySourceMapUpload = Boolean(
+  process.env.SENTRY_AUTH_TOKEN
+  && process.env.SENTRY_URL
+  && process.env.SENTRY_ORG
+  && process.env.SENTRY_FRONTEND_PROJECT
+  && process.env.SENTRY_RELEASE,
+)
 
 // https://vite.dev/config/
 export default defineConfig(() => ({
   envDir: repoRoot,
-  // Share repo-root SENTRY_* with backend (.env); VITE_* remains for other frontend-only keys.
-  envPrefix: ['VITE_', 'SENTRY_'],
-  plugins: [vue(), tailwindcss()],
+  plugins: [
+    vue(),
+    tailwindcss(),
+    ...(sentrySourceMapUpload
+      ? [sentryVitePlugin({
+          url: process.env.SENTRY_URL,
+          authToken: process.env.SENTRY_AUTH_TOKEN,
+          org: process.env.SENTRY_ORG,
+          project: process.env.SENTRY_FRONTEND_PROJECT,
+          telemetry: false,
+          release: { name: process.env.SENTRY_RELEASE },
+          sourcemaps: {
+            assets: './dist/**',
+            filesToDeleteAfterUpload: './dist/**/*.map',
+          },
+          errorHandler: (error) => {
+            console.warn(`[sentry] Source Map upload failed; continuing build: ${error.message}`)
+          },
+        })]
+      : []),
+  ],
   build: {
     target: 'es2022',
+    sourcemap: sentrySourceMapUpload ? 'hidden' : false,
   },
   optimizeDeps: {
     esbuildOptions: {

--- a/tools/agent/publish.sh
+++ b/tools/agent/publish.sh
@@ -281,6 +281,7 @@ GATEWAY_BOOTSTRAP_LINUX_SCRIPT=gateway-bootstrap-linux.sh
 GATEWAY_SIDECAR_SCRIPT=gateway-install-lensnode-sidecar.sh
 GATEWAY_LIFECYCLE_SCRIPT=gateway-lifecycle.sh
 GATEWAY_DOCKER_INSTALL_SCRIPT=gateway-install-docker-ubuntu-amd64.sh
+GATEWAY_SENTRY_ADAPTER=hfl-sentry-sitecustomize.py
 GATEWAY_LENSNODE_IMAGE=lensnode-image-linux-amd64.tar.gz
 ENROLL_BOOTSTRAP_DIR="${RELEASES_DIR%/agent-releases}/enroll-bootstrap"
 GATEWAY_BOOTSTRAP_DIR="${RELEASES_DIR%/agent-releases}/gateway-bootstrap"
@@ -338,6 +339,9 @@ if [[ ! -f "${BOOTSTRAP_DIR}/${GATEWAY_LIFECYCLE_SCRIPT}" ]]; then
 fi
 if [[ ! -f "${BOOTSTRAP_DIR}/${GATEWAY_DOCKER_INSTALL_SCRIPT}" ]]; then
 	hfl_die "Missing bootstrap template ${BOOTSTRAP_DIR}/${GATEWAY_DOCKER_INSTALL_SCRIPT}" 3
+fi
+if [[ ! -f "${ROOT}/deploy/installer/sourcelens/${GATEWAY_SENTRY_ADAPTER}" ]]; then
+	hfl_die "Missing Sentry privacy adapter ${GATEWAY_SENTRY_ADAPTER}" 3
 fi
 
 validate_matrix() {
@@ -528,6 +532,10 @@ publish_archives() {
 	cp -f "${docker_install_src}" "${GATEWAY_BOOTSTRAP_DIR}/${GATEWAY_DOCKER_INSTALL_SCRIPT}"
 	chmod 755 "${GATEWAY_BOOTSTRAP_DIR}/${GATEWAY_DOCKER_INSTALL_SCRIPT}"
 	hfl_log_ok "Published ${GATEWAY_DOCKER_INSTALL_SCRIPT}"
+	privacy_adapter_src="${ROOT}/deploy/installer/sourcelens/${GATEWAY_SENTRY_ADAPTER}"
+	cp -f "${privacy_adapter_src}" "${GATEWAY_BOOTSTRAP_DIR}/${GATEWAY_SENTRY_ADAPTER}"
+	chmod 644 "${GATEWAY_BOOTSTRAP_DIR}/${GATEWAY_SENTRY_ADAPTER}"
+	hfl_log_ok "Published ${GATEWAY_SENTRY_ADAPTER}"
 	local ubuntu_release release_id host_debs_dir docker_debs_archive
 	for ubuntu_release in 20.04 22.04 24.04; do
 		case "${ubuntu_release}" in 20.04) release_id=2004 ;; 22.04) release_id=2204 ;; 24.04) release_id=2404 ;; esac

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -610,6 +610,9 @@ grep -F 'com.hyperfilelens.component: "gateway-lensnode"' \
 	"${ROOT}/deploy/bootstrap/gateway-install-lensnode-sidecar.sh" >/dev/null
 grep -F './tools/quality/test-deployment-optional-config.sh' "${workflow}" >/dev/null
 grep -F './tools/quality/test-ga-runtime-config.sh' "${workflow}" >/dev/null
+grep -F './tools/quality/test-sentry-runtime-config.sh' "${workflow}" >/dev/null
+grep -F 'hfl-sentry-sitecustomize.py' \
+	"${ROOT}/deploy/installer/sourcelens/docker-compose.template.yml" >/dev/null
 grep -F './tools/quality/test-payload-tree-hash.sh' "${workflow}" >/dev/null
 grep -F 'Verify Internal Health' "${ROOT}/.github/workflows/deploy_target.yml" >/dev/null
 grep -F 'https://127.0.0.1:11443/health/ready' \
@@ -860,5 +863,11 @@ grep -F 'target: prod' "${production_workflow}" >/dev/null
 grep -F 'channel: release' "${production_workflow}" >/dev/null
 grep -F 'Production deployment requires a manual workflow_dispatch event' \
 	"${ROOT}/.github/workflows/deploy_target.yml" >/dev/null
+grep -F 'if ! SOURCELENS_BUILD_SOURCE_MAPS=1' \
+	"${ROOT}/release/ci/build-sourcelens-image.sh" >/dev/null
+grep -F 'chmod 0700 "${COMPOSE_DIR}"' \
+	"${ROOT}/deploy/bootstrap/gateway-install-lensnode-sidecar.sh" >/dev/null
+grep -F 'chmod 0600 "${compose_file}"' \
+	"${ROOT}/deploy/bootstrap/gateway-install-lensnode-sidecar.sh" >/dev/null
 
 printf 'Release contract checks passed.\n'

--- a/tools/quality/test-ci-release-assembly.sh
+++ b/tools/quality/test-ci-release-assembly.sh
@@ -45,9 +45,14 @@ make_gzip "${sl}/images/11-sourcelens-lensnode.tar.gz" sourcelens-lensnode
 make_gzip "${sl}/images/12-nginx-stable-alpine.tar.gz" nginx
 mkdir -p "${sl}/sourcelens/deploy/postgresql/initdb.d" \
 	"${sl}/sourcelens/deploy/nginx/certs" \
+	"${sl}/sourcelens/deploy/sentry" \
 	"${sl}/payload/media/gateway-bootstrap"
 printf '#!/usr/bin/env bash\nexit 0\n' >"${sl}/sourcelens/install.sh"
 printf '#!/usr/bin/env python3\n' >"${sl}/sourcelens/patch-env-runtime.py"
+printf '#!/usr/bin/env python3\n' >"${sl}/sourcelens/sync-sentry-runtime.py"
+mkdir -p "${sl}/sourcelens/deploy/nginx"
+printf '/* fixture */\n' >"${sl}/sourcelens/deploy/nginx/hfl-sentry-loader.js"
+printf '# fixture\n' >"${sl}/sourcelens/deploy/sentry/hfl-sentry-sitecustomize.py"
 printf 'services: {}\n' >"${sl}/sourcelens/docker-compose.yml"
 printf 'DJANGO_DEBUG=true\n' >"${sl}/sourcelens/.env.example"
 printf 'fixture\n' >"${sl}/sourcelens/deploy/postgresql/initdb.d/fixture.sh"

--- a/tools/quality/test-ga-runtime-config.sh
+++ b/tools/quality/test-ga-runtime-config.sh
@@ -19,18 +19,15 @@ HFL_WEBSITE_CONFIG_OUTPUT="${website}" \
 
 grep -Fx "window.__HFL_WEBSITE_CONFIG__ = Object.freeze({ appUrl: 'https://app.hyperfilelens.com', gaMeasurementId: 'G-0RX9GZJCWF' })" \
 	"${website}" >/dev/null
-grep -Fx "window.__HFL_APP_CONFIG__ = Object.freeze({ gaMeasurementId: 'G-0RX9GZJCWF' })" \
-	"${tenant}" >/dev/null
-grep -Fx "window.__HFL_APP_CONFIG__ = Object.freeze({ gaMeasurementId: '' })" \
-	"${admin}" >/dev/null
+grep -F "gaMeasurementId: 'G-0RX9GZJCWF'" "${tenant}" >/dev/null
+grep -F "gaMeasurementId: ''" "${admin}" >/dev/null
 
 invalid_output="$(HFL_WEBSITE_CONFIG_OUTPUT="${website}" \
 	HFL_TENANT_CONFIG_OUTPUT="${tenant}" \
 	HFL_ADMIN_CONFIG_OUTPUT="${admin}" \
 	HFL_GA_MEASUREMENT_ID="G invalid" sh "${renderer}" 2>&1)"
 grep -F 'WARNING: invalid GA4 measurement ID' <<<"${invalid_output}" >/dev/null
-grep -Fx "window.__HFL_APP_CONFIG__ = Object.freeze({ gaMeasurementId: '' })" \
-	"${tenant}" >/dev/null
+grep -F "gaMeasurementId: ''" "${tenant}" >/dev/null
 
 grep -F 'alias /usr/share/nginx/runtime/tenant-app-runtime-config.js;' \
 	"${ROOT}/deploy/nginx/snippets/hfl-tenant-spa-locations.conf" >/dev/null

--- a/tools/quality/test-sentry-runtime-config.sh
+++ b/tools/quality/test-sentry-runtime-config.sh
@@ -1,0 +1,311 @@
+#!/usr/bin/env bash
+# Validate runtime-only Sentry wiring for HFL and bundled SourceLens.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+tmp="$(mktemp -d)"
+trap 'rm -rf "${tmp}"' EXIT
+
+tenant="${tmp}/tenant.js"
+admin="${tmp}/admin.js"
+website="${tmp}/website.js"
+HFL_WEBSITE_CONFIG_OUTPUT="${website}" \
+	HFL_TENANT_CONFIG_OUTPUT="${tenant}" \
+	HFL_ADMIN_CONFIG_OUTPUT="${admin}" \
+	HFL_SENTRY_ENABLED=true \
+	HFL_SENTRY_DSN=https://public@sentry.example.com/42 \
+	HFL_SENTRY_ENVIRONMENT=hfl-preprod \
+	HFL_SENTRY_RELEASE=hyperfilelens-frontend@0.1.8 \
+	HFL_SENTRY_TRACES_SAMPLE_RATE=0.1 \
+	sh "${ROOT}/deploy/docker/frontend-runtime-config.sh"
+grep -F "sentryEnabled: true" "${tenant}" >/dev/null
+grep -F "sentryEnvironment: 'hfl-preprod'" "${tenant}" >/dev/null
+grep -F "sentrySurface: 'tenant'" "${tenant}" >/dev/null
+grep -F "sentrySurface: 'admin'" "${admin}" >/dev/null
+if grep -F 'sentryDsn' "${website}" >/dev/null; then
+	printf 'ERROR: Website runtime config must not receive an HFL application DSN\n' >&2
+	exit 1
+fi
+
+invalid_output="$(HFL_WEBSITE_CONFIG_OUTPUT="${website}" \
+	HFL_TENANT_CONFIG_OUTPUT="${tenant}" \
+	HFL_ADMIN_CONFIG_OUTPUT="${admin}" \
+	HFL_SENTRY_ENABLED=true \
+	HFL_SENTRY_DSN=invalid \
+	HFL_SENTRY_ENVIRONMENT=hfl-test \
+	HFL_SENTRY_RELEASE=hyperfilelens-frontend@main-0123456 \
+	sh "${ROOT}/deploy/docker/frontend-runtime-config.sh" 2>&1)"
+grep -F 'WARNING: invalid Sentry frontend DSN' <<<"${invalid_output}" >/dev/null
+grep -F 'sentryEnabled: false' "${tenant}" >/dev/null
+
+password_output="$(HFL_WEBSITE_CONFIG_OUTPUT="${website}" \
+	HFL_TENANT_CONFIG_OUTPUT="${tenant}" \
+	HFL_ADMIN_CONFIG_OUTPUT="${admin}" \
+	HFL_SENTRY_ENABLED=true \
+	HFL_SENTRY_DSN=https://public:secret@sentry.example.com/42 \
+	HFL_SENTRY_ENVIRONMENT=hfl-test \
+	HFL_SENTRY_RELEASE=hyperfilelens-frontend@main-0123456 \
+	sh "${ROOT}/deploy/docker/frontend-runtime-config.sh" 2>&1)"
+grep -F 'WARNING: invalid Sentry frontend DSN' <<<"${password_output}" >/dev/null
+grep -F 'sentryEnabled: false' "${tenant}" >/dev/null
+
+env_file="${tmp}/hfl.env"
+runtime_file="${tmp}/runtime.env"
+cat >"${env_file}" <<'EOF'
+SENTRY_ENABLED=false
+SENTRY_BACKEND_DSN=
+SENTRY_FRONTEND_DSN=
+SENTRY_ENVIRONMENT=
+SENTRY_TRACES_SAMPLE_RATE=0
+HFL_DEPLOY_TARGET=
+HFL_DEPLOYMENT_MODE=standalone
+HFL_INSECURE_TLS=1
+DJANGO_ALLOWED_HOSTS=localhost
+CSRF_TRUSTED_ORIGINS=https://localhost:11443
+CORS_ALLOWED_ORIGINS=https://localhost:11443
+EOF
+cat >"${runtime_file}" <<'EOF'
+SENTRY_ENABLED=true
+SENTRY_BACKEND_DSN=https://backend@sentry.example.com/41
+SENTRY_FRONTEND_DSN=https://frontend@sentry.example.com/42
+SENTRY_ENVIRONMENT=hfl-preprod
+SENTRY_TRACES_SAMPLE_RATE=0.1
+HFL_DEPLOY_TARGET=preprod
+HFL_INSECURE_TLS=1
+HFL_PLATFORM_GATEWAY_AUTO_DEPLOY=false
+HFL_EMAIL_SIGNUP_ENABLED=false
+HFL_GOOGLE_OAUTH_ENABLED=false
+HFL_GA_MEASUREMENT_ID=
+TURNSTILE_ENABLED=false
+TURNSTILE_SITE_KEY=
+TURNSTILE_SECRET_KEY=
+SMTP_HOST=
+SMTP_PORT=
+SMTP_USERNAME=
+SMTP_PASSWORD=
+SMTP_SECURITY=
+EMAIL_FROM=
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+EOF
+chmod 600 "${env_file}" "${runtime_file}"
+python3 "${ROOT}/deploy/installer/apply-runtime-config.py" \
+	--env-file "${env_file}" \
+	--direct-host 127.0.0.1 \
+	--public-url https://127.0.0.1:11443 \
+	--runtime-env-file "${runtime_file}" >/dev/null
+grep -Fx 'SENTRY_ENABLED=true' "${env_file}" >/dev/null
+grep -Fx 'SENTRY_BACKEND_DSN="https://backend@sentry.example.com/41"' "${env_file}" >/dev/null
+grep -Fx 'SENTRY_FRONTEND_DSN="https://frontend@sentry.example.com/42"' "${env_file}" >/dev/null
+grep -Fx 'SENTRY_ENVIRONMENT=hfl-preprod' "${env_file}" >/dev/null
+grep -Fx 'HFL_DEPLOY_TARGET=preprod' "${env_file}" >/dev/null
+grep -Fx 'HFL_DEPLOYMENT_MODE=managed' "${env_file}" >/dev/null
+
+sl_env="${tmp}/sl.env"
+cat >"${sl_env}" <<'EOF'
+DJANGO_DEBUG=false
+SENTRY_ENABLED=true
+SENTRY_DSN=https://backend@sentry.example.com/41
+EOF
+python3 "${ROOT}/deploy/installer/sourcelens/patch-env-runtime.py" "${sl_env}"
+grep -Fx 'SENTRY_ENABLED=true' "${sl_env}" >/dev/null
+grep -Fx 'SENTRY_DSN=https://backend@sentry.example.com/41' "${sl_env}" >/dev/null
+grep -Fx 'SENTRY_SEND_DEFAULT_PII=false' "${sl_env}" >/dev/null
+printf '%s\n' '{"version":"0.4.0"}' >"${tmp}/BUILD_INFO.json"
+python3 "${ROOT}/deploy/installer/sourcelens/sync-sentry-runtime.py" \
+	--parent-env "${env_file}" \
+	--sourcelens-env "${sl_env}" \
+	--build-info "${tmp}/BUILD_INFO.json" \
+	--frontend-config "${tmp}/sl-sentry-config.js"
+grep -Fx 'SENTRY_RELEASE="hyperfilelens-sourcelens@unknown-sl0.4.0"' "${sl_env}" >/dev/null
+grep -F '"enabled":true' "${tmp}/sl-sentry-config.js" >/dev/null
+grep -F 'hyperfilelens-sourcelens-frontend@unknown-sl0.4.0' "${tmp}/sl-sentry-config.js" >/dev/null
+[[ "$(stat -c '%a' "${sl_env}")" == "600" ]]
+[[ "$(stat -c '%a' "${tmp}/sl-sentry-config.js")" == "644" ]]
+python3 - "${ROOT}/deploy/installer/apply-runtime-config.py" \
+	"${ROOT}/deploy/installer/sourcelens/sync-sentry-runtime.py" <<'PY'
+import importlib.util
+import pathlib
+import sys
+
+
+def load(path_value, name):
+    path = pathlib.Path(path_value)
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+legacy = "https://public:secret@sentry.example.com/42"
+apply_runtime = load(sys.argv[1], "hfl_apply_runtime_config_test")
+sync_runtime = load(sys.argv[2], "hfl_sync_sentry_runtime_test")
+assert apply_runtime.valid_sentry_dsn(legacy)
+assert not apply_runtime.valid_frontend_sentry_dsn(legacy)
+assert sync_runtime.valid_dsn(legacy)
+assert not sync_runtime.valid_frontend_dsn(legacy)
+PY
+
+sl_nginx="${tmp}/sourcelens-nginx.conf"
+cat >"${sl_nginx}" <<'EOF'
+server {
+    listen 443 ssl;
+    ssl_certificate /etc/nginx/certs/nginx-selfsigned.crt;
+    ssl_certificate_key /etc/nginx/certs/nginx-selfsigned.key;
+    set $ui_upstream http://frontend:80;
+    # Frontend proxy to frontend container
+    location / {
+        proxy_pass $ui_upstream;
+    }
+}
+EOF
+# shellcheck source=../sourcelens/common.sh
+source "${ROOT}/tools/sourcelens/common.sh"
+sourcelens_patch_runtime_nginx "${sl_nginx}"
+grep -F 'location = /hfl-sentry-config.js' "${sl_nginx}" >/dev/null
+grep -F 'sub_filter_once on;' "${sl_nginx}" >/dev/null
+grep -F 'hfl-sentry-loader.js' "${sl_nginx}" >/dev/null
+grep -F 'https://js.sentry-cdn.com/' \
+	"${ROOT}/deploy/installer/sourcelens/hfl-sentry-loader.js" >/dev/null
+grep -F 'hfl-sentry-sitecustomize.py:/opt/backend/sitecustomize.py:ro' \
+	"${ROOT}/deploy/installer/sourcelens/docker-compose.template.yml" >/dev/null
+grep -F 'hfl-sentry-sitecustomize.py:/opt/hfl-sentry/sitecustomize.py:ro' \
+	"${ROOT}/deploy/installer/sourcelens/docker-compose.template.yml" >/dev/null
+
+python3 - "${ROOT}/deploy/installer/sourcelens/hfl-sentry-sitecustomize.py" <<'PY'
+import importlib.util
+import pathlib
+import sys
+import types
+
+captured = {}
+fake_sdk = types.ModuleType("sentry_sdk")
+
+
+def fake_init(*args, **kwargs):
+    captured.update(kwargs)
+
+
+fake_sdk.init = fake_init
+sys.modules["sentry_sdk"] = fake_sdk
+path = pathlib.Path(sys.argv[1])
+spec = importlib.util.spec_from_file_location("hfl_sentry_sitecustomize_test", path)
+module = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(module)
+fake_sdk.init(before_send=lambda event, hint: event, send_default_pii=True)
+assert captured["send_default_pii"] is False
+assert captured["include_local_variables"] is False
+assert captured["max_request_body_size"] == "never"
+event = captured["before_send"](
+    {
+        "message": "customer prompt",
+        "extra": {"args": ["/customer/private"]},
+        "request": {
+            "url": "https://app.example.com/customer/private?token=secret",
+            "env": {"REMOTE_ADDR": "192.0.2.15"},
+        },
+        "transaction": "/customer/private",
+        "transaction_info": {"source": "url"},
+        "spans": [
+            {
+                "trace_id": "trace-span-1",
+                "span_id": "span-1",
+                "op": "db.sql.query",
+                "description": "SELECT * FROM private_customer_files",
+                "data": {"db.statement": "/customer/private"},
+            }
+        ],
+        "exception": {"values": [{"value": "customer filename"}]},
+    },
+    {},
+)
+assert "message" not in event
+assert "extra" not in event
+assert event["exception"]["values"][0]["value"] == "[Filtered]"
+assert event["request"] == {"url": "https://app.example.com", "headers": {}}
+assert "transaction" not in event
+assert "transaction_info" not in event
+assert event["spans"] == [
+    {"trace_id": "trace-span-1", "span_id": "span-1", "op": "db.sql.query"}
+]
+assert "192.0.2.15" not in str(event)
+assert "/customer/private" not in str(event)
+PY
+
+node - "${ROOT}/deploy/installer/sourcelens/hfl-sentry-loader.js" <<'JS'
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const vm = require('node:vm')
+
+let options
+global.window = {
+  __HFL_SOURCELENS_SENTRY__: {
+    enabled: true,
+    dsn: 'https://public@sentry.example.com/42',
+    environment: 'hfl-test',
+    release: 'hyperfilelens-sourcelens-frontend@main-0123456-sl0.4.0',
+    tracesSampleRate: 0.1,
+  },
+  location: { origin: 'https://app.example.com' },
+}
+global.document = {
+  createElement: () => ({ dataset: {} }),
+  head: { appendChild: () => undefined },
+}
+vm.runInThisContext(fs.readFileSync(process.argv[2], 'utf8'))
+window.Sentry = { init: (value) => { options = value } }
+window.sentryOnLoad()
+const event = options.beforeSendTransaction({
+  contexts: {
+    customer: { value: 'private' },
+    trace: {
+      trace_id: 'root-trace-1',
+      span_id: 'root-span-1',
+      op: 'navigation',
+      data: { customer: 'private' },
+    },
+  },
+  spans: [{
+    is_segment: true,
+    segment_id: 'segment-1',
+    trace_id: 'trace-span-1',
+    span_id: 'span-1',
+    op: 'http.client',
+    description: 'https://app.example.com/customer/private?token=secret',
+    data: { authorization: 'secret' },
+  }],
+})
+assert.deepEqual(event.contexts, {
+  trace: {
+    trace_id: 'root-trace-1',
+    span_id: 'root-span-1',
+    op: 'navigation',
+    data: {},
+  },
+})
+assert.deepEqual(event.spans, [{
+  data: {},
+  is_segment: true,
+  segment_id: 'segment-1',
+  trace_id: 'trace-span-1',
+  span_id: 'span-1',
+  op: 'http.client',
+}])
+assert(!JSON.stringify(event).includes('private'))
+assert(!JSON.stringify(event).includes('secret'))
+JS
+
+if rg -n 'ARG SENTRY_DSN|ENV SENTRY_DSN|import\.meta\.env\.SENTRY' \
+	"${ROOT}/deploy/docker/frontend.Dockerfile" \
+	"${ROOT}/src/frontend" >/dev/null; then
+	printf 'ERROR: HFL browser DSN must remain runtime-only\n' >&2
+	exit 1
+fi
+grep -F 'TEST_SENTRY_ENABLED' "${ROOT}/.github/workflows/artifact_pipeline.yml" >/dev/null
+grep -F 'PREPROD_SENTRY_ENABLED' "${ROOT}/.github/workflows/artifact_pipeline.yml" >/dev/null
+grep -F 'PROD_SENTRY_ENABLED' "${ROOT}/.github/workflows/production_deploy.yml" >/dev/null
+grep -F 'SENTRY_AUTH_TOKEN' "${ROOT}/.github/workflows/artifact_pipeline.yml" >/dev/null
+
+printf 'Runtime Sentry configuration checks passed.\n'

--- a/tools/sourcelens/common.sh
+++ b/tools/sourcelens/common.sh
@@ -61,6 +61,7 @@ sourcelens_load_config() {
 	SOURCELENS_PIP_RETRY_DELAY="${SOURCELENS_PIP_RETRY_DELAY:-${HFL_PIP_RETRY_DELAY:-${BUILD_PIP_RETRY_DELAY:-5}}}"
 	SOURCELENS_UV_VERSION="${SOURCELENS_UV_VERSION:-0.10.2}"
 	SOURCELENS_NPM_REGISTRY="${SOURCELENS_NPM_REGISTRY:-${NPM_REGISTRY:-${BUILD_NPM_REGISTRY:-}}}"
+	SOURCELENS_BUILD_SOURCE_MAPS="${SOURCELENS_BUILD_SOURCE_MAPS:-0}"
 	SOURCELENS_DOCKER_MIRROR="${SOURCELENS_DOCKER_MIRROR:-${DOCKER_DOWNLOAD_MIRROR:-}}"
 	SOURCELENS_DOCKER_PULL_TIMEOUT="${SOURCELENS_DOCKER_PULL_TIMEOUT:-${DOCKER_PULL_TIMEOUT_SECONDS:-180}}"
 	SOURCELENS_DOCKER_PULL_RETRIES="${SOURCELENS_DOCKER_PULL_RETRIES:-${DOCKER_PULL_RETRIES:-2}}"
@@ -859,6 +860,37 @@ path.write_text("".join(out), encoding="utf-8")
 PY
 }
 
+sourcelens_patch_frontend_dockerfile_source_maps() {
+	local src=$1
+	local dockerfile="${src}/frontend/Dockerfile"
+	[[ "${SOURCELENS_BUILD_SOURCE_MAPS:-0}" == "1" ]] || return 0
+	[[ -f "${dockerfile}" ]] || return 0
+	python3 - "${dockerfile}" <<'PY'
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+text = path.read_text(encoding="utf-8")
+if "# hfl-hidden-source-maps" in text:
+    raise SystemExit(0)
+build = "RUN npm run build"
+if text.count(build) != 1:
+    raise SystemExit(f"expected one SourceLens frontend build command in {path}")
+text = text.replace(
+    build,
+    "RUN npm run build -- --sourcemap hidden \\\n"
+    " && cp -a dist dist-runtime \\\n"
+    " && find dist-runtime -type f -name '*.map' -delete \\\n"
+    " && printf '%s\\n' '# hfl-hidden-source-maps' > /app/.hfl-source-maps",
+)
+source = "COPY --from=builder /app/dist /usr/share/nginx/html"
+target = "COPY --from=builder /app/dist-runtime /usr/share/nginx/html"
+if source not in text:
+    raise SystemExit(f"SourceLens frontend runtime copy command not found in {path}")
+path.write_text(text.replace(source, target), encoding="utf-8")
+PY
+}
+
 sourcelens_patch_compose_npm_registry() {
 	local src=$1
 	local compose="${src}/docker-compose.yml"
@@ -1096,6 +1128,7 @@ sourcelens_build_app_images() {
 	sourcelens_patch_dockerfile_pip_resilience "${src}" \
 		"${SOURCELENS_PIP_RETRY_MAX}" "${SOURCELENS_PIP_RETRY_DELAY}"
 	sourcelens_patch_frontend_dockerfile_npm_registry "${src}"
+	sourcelens_patch_frontend_dockerfile_source_maps "${src}"
 	sourcelens_patch_compose_lensnode_apt_mirror "${src}" "${debian_apt_mirror_url}"
 	sourcelens_patch_compose_build_sources "${src}" \
 		"${ubuntu_apt_mirror_url}" "${debian_apt_mirror_url}" \
@@ -1236,6 +1269,33 @@ text = text.replace(
 )
 if "/etc/nginx/certs/tls.crt" not in text or "/etc/nginx/certs/tls.key" not in text:
     raise SystemExit(f"SourceLens TLS certificate declarations not found in {path}")
+assets = """    # HFL-owned runtime observability adapter; SourceLens source remains unchanged.
+    location = /hfl-sentry-config.js {
+        alias /etc/nginx/hfl-sentry-config.js;
+        add_header Cache-Control "no-store" always;
+    }
+    location = /hfl-sentry-loader.js {
+        alias /etc/nginx/hfl-sentry-loader.js;
+        add_header Cache-Control "no-store" always;
+    }
+
+"""
+marker = "    # Frontend proxy to frontend container\n"
+if "location = /hfl-sentry-config.js" not in text:
+    if marker in text:
+        text = text.replace(marker, assets + marker)
+location_marker = """    location / {
+        proxy_pass $ui_upstream;
+"""
+location_replacement = """    location / {
+        proxy_set_header Accept-Encoding "";
+        sub_filter_once on;
+        sub_filter '</head>' '<script src="/hfl-sentry-config.js"></script><script src="/hfl-sentry-loader.js"></script></head>';
+        proxy_pass $ui_upstream;
+"""
+if "hfl-sentry-loader.js\"></script></head>" not in text:
+    if location_marker in text:
+        text = text.replace(location_marker, location_replacement)
 path.write_text(text, encoding="utf-8")
 PY
 }
@@ -1316,9 +1376,17 @@ sourcelens_prepare_dev_runtime_tree() {
 	[[ -f "${nginx_config}" ]] \
 		|| sourcelens_die "missing SourceLens nginx config: ${nginx_config}"
 
-	mkdir -p "${dev_root}/deploy/nginx" "${dev_root}/deploy/postgresql"
+	mkdir -p "${dev_root}/deploy/nginx" "${dev_root}/deploy/postgresql" \
+		"${dev_root}/deploy/sentry"
 	cp "${nginx_config}" "${dev_root}/deploy/nginx/default.conf"
 	sourcelens_patch_runtime_nginx "${dev_root}/deploy/nginx/default.conf"
+	cp "${SOURCELENS_INSTALLER_DIR}/sourcelens/hfl-sentry-loader.js" \
+		"${dev_root}/deploy/nginx/hfl-sentry-loader.js"
+	printf '%s\n' 'window.__HFL_SOURCELENS_SENTRY__ = Object.freeze({ enabled: false })' \
+		>"${dev_root}/deploy/nginx/hfl-sentry-config.js"
+	cp "${SOURCELENS_INSTALLER_DIR}/sourcelens/hfl-sentry-sitecustomize.py" \
+		"${dev_root}/deploy/sentry/hfl-sentry-sitecustomize.py"
+	chmod 644 "${dev_root}/deploy/sentry/hfl-sentry-sitecustomize.py"
 	sourcelens_ensure_tls_certs "${HFL_ROOT}/deploy/nginx/certs"
 	rm -rf "${dev_root}/deploy/nginx/certs"
 	ln -s "${HFL_ROOT}/deploy/nginx/certs" "${dev_root}/deploy/nginx/certs"


### PR DESCRIPTION
## Summary

- add runtime-only Sentry reporting for HFL backend, frontend, and installer-managed Platform Gateway services
- integrate bundled SourceLens through HFL-owned runtime adapters without modifying upstream SourceLens source
- enforce fail-closed privacy scrubbing, public-only browser DSNs, atomic configuration updates, and protected Gateway credentials
- upload HFL and bundled SourceLens Source Maps and record deployments without blocking core builds or deployments

## Validation

- backend Sentry tests
- frontend Sentry tests and production build
- Agent observability, enrollment tests, and Linux/Windows/macOS builds
- runtime Sentry and release contracts
- synthetic release assembly and Compose rendering
- Ruff, ESLint, syntax checks, npm audit, and git diff checks