### PR TITLE
fix(lens): harden gateway restore and workspace recovery

### DIFF
--- a/src/agent/go.mod
+++ b/src/agent/go.mod
@@ -7,6 +7,7 @@ toolchain go1.25.10
 require (
 	github.com/getsentry/sentry-go v0.38.0
 	github.com/gorilla/websocket v1.5.3
+	github.com/google/uuid v1.6.0
 	github.com/kardianos/service v1.2.4
 	github.com/mattn/go-isatty v0.0.20
 	github.com/shirou/gopsutil/v4 v4.26.4
@@ -19,7 +20,6 @@ require (
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/ebitengine/purego v0.10.0 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/ncruces/go-strftime v0.1.9 // indirect
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect

--- a/src/agent/internal/engine/lens_prepare.go
+++ b/src/agent/internal/engine/lens_prepare.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/google/uuid"
 )
 
 const lensWorkspaceIdentityKind = "managed_restore"
@@ -49,10 +51,11 @@ func lensWorkspaceIdentityFromPayload(p Payload) (lensWorkspaceIdentity, error) 
 	if identity.WorkspaceKind != lensWorkspaceIdentityKind {
 		return lensWorkspaceIdentity{}, errors.New("unsupported managed workspace kind")
 	}
-	if strings.ContainsAny(identity.WorkspaceUID, `/\\\x00`) ||
-		identity.WorkspaceUID == "." || identity.WorkspaceUID == ".." {
+	workspaceUID, err := uuid.Parse(identity.WorkspaceUID)
+	if err != nil || workspaceUID.String() != strings.ToLower(identity.WorkspaceUID) {
 		return lensWorkspaceIdentity{}, errors.New("managed workspace UID is invalid")
 	}
+	identity.WorkspaceUID = workspaceUID.String()
 	return identity, nil
 }
 
@@ -239,27 +242,44 @@ func (e *Engine) runLensKsPrepare(ctx context.Context, p Payload) (string, map[s
 	if err := ensureLensMetadataLayout(paths); err != nil {
 		return "failed", nil, err.Error()
 	}
-	cleanPath, created, err := secureEnsureDirectory(paths.Workspace, paths.Root, 0o755)
-	if err != nil {
-		return "failed", nil, err.Error()
-	}
 	existing, err := readLensWorkspaceIdentity(paths.Identity)
 	if err == nil {
 		if existing != identity {
 			return "failed", nil, "managed workspace identity does not match"
 		}
-		return "success", map[string]any{"path": cleanPath, "created": false}, ""
+		cleanPath, created, ensureErr := secureEnsureDirectory(
+			paths.Workspace,
+			paths.Root,
+			0o755,
+		)
+		if ensureErr != nil {
+			return "failed", nil, ensureErr.Error()
+		}
+		return "success", map[string]any{"path": cleanPath, "created": created}, ""
 	}
 	if !os.IsNotExist(err) {
 		return "failed", nil, err.Error()
 	}
+	if _, statErr := os.Lstat(paths.Workspace); statErr == nil {
+		return "failed", nil, "refusing to claim an existing workspace without identity"
+	} else if !os.IsNotExist(statErr) {
+		return "failed", nil, statErr.Error()
+	}
+	// The durable identity is the creation journal. If the process exits before
+	// the directory is created, a retry can safely complete the matching claim.
 	if err := writeLensWorkspaceIdentity(paths.Identity, identity); err != nil {
 		if os.IsExist(err) {
 			existing, readErr := readLensWorkspaceIdentity(paths.Identity)
-			if readErr == nil && existing == identity {
-				return "success", map[string]any{"path": cleanPath, "created": false}, ""
+			if readErr != nil || existing != identity {
+				return "failed", nil, "managed workspace identity does not match"
 			}
+		} else {
+			return "failed", nil, err.Error()
 		}
+	}
+	cleanPath, created, err := secureEnsureDirectory(paths.Workspace, paths.Root, 0o755)
+	if err != nil {
+		// Keep the matching identity as a recovery journal for the next retry.
 		return "failed", nil, err.Error()
 	}
 	return "success", map[string]any{"path": cleanPath, "created": created}, ""

--- a/src/agent/internal/engine/lens_prepare_test.go
+++ b/src/agent/internal/engine/lens_prepare_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 )
 
+const testWorkspaceUID = "de240f46-eccd-4e4b-868f-b1f504fbe67b"
+
 func newLensTestRoot(t *testing.T) string {
 	t.Helper()
 	root := filepath.Join(t.TempDir(), "data")
@@ -30,7 +32,7 @@ func TestLensWorkspaceTrashStaysInsideWorkspaceFilesystem(t *testing.T) {
 	paths, err := resolveLensWorkspacePaths(
 		filepath.Join(root, "tenants", "61", "knowledge-sources", "workspace-42"),
 		root,
-		"workspace-42",
+		testWorkspaceUID,
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -49,7 +51,7 @@ func TestRunLensKsPrepareCreatesDirectory(t *testing.T) {
 		Path: target,
 		Extra: map[string]any{
 			"workspace_root":         root,
-			"workspace_uid":          "workspace-42",
+			"workspace_uid":          testWorkspaceUID,
 			"tenant_organization_id": 61,
 			"gateway_link_id":        7,
 			"knowledge_source_id":    42,
@@ -66,7 +68,7 @@ func TestRunLensKsPrepareCreatesDirectory(t *testing.T) {
 	if !info.IsDir() {
 		t.Fatalf("expected directory")
 	}
-	if _, err := os.Stat(testIdentityPath(root, "workspace-42")); err != nil {
+	if _, err := os.Stat(testIdentityPath(root, testWorkspaceUID)); err != nil {
 		t.Fatalf("workspace identity: %v", err)
 	}
 	if _, err := os.Stat(filepath.Join(target, ".hfl-workspace.json")); !os.IsNotExist(err) {
@@ -82,7 +84,7 @@ func TestRunLensKsPrepareRejectsPathOutsideRoot(t *testing.T) {
 		Path: "/tmp/outside",
 		Extra: map[string]any{
 			"workspace_root":         root,
-			"workspace_uid":          "workspace-outside",
+			"workspace_uid":          testWorkspaceUID,
 			"tenant_organization_id": 61,
 			"gateway_link_id":        7,
 			"knowledge_source_id":    42,
@@ -103,7 +105,7 @@ func TestRunLensKsPrepareRejectsManagedTrashPath(t *testing.T) {
 		Path: filepath.Join(root, lensWorkspaceTrashDirectory, "workspace-42"),
 		Extra: map[string]any{
 			"workspace_root":         root,
-			"workspace_uid":          "workspace-42",
+			"workspace_uid":          testWorkspaceUID,
 			"tenant_organization_id": 61,
 			"gateway_link_id":        7,
 			"knowledge_source_id":    42,
@@ -115,6 +117,82 @@ func TestRunLensKsPrepareRejectsManagedTrashPath(t *testing.T) {
 	}
 }
 
+func TestRunLensKsPrepareRejectsExistingDirectoryWithoutIdentity(t *testing.T) {
+	root := newLensTestRoot(t)
+	target := filepath.Join(root, "existing-user-data")
+	if err := os.MkdirAll(target, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	marker := filepath.Join(target, "keep.txt")
+	if err := os.WriteFile(marker, []byte("keep"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	status, _, errMsg := New(nil).runLensKsPrepare(context.Background(), Payload{
+		Path: target,
+		Extra: map[string]any{
+			"workspace_root":         root,
+			"workspace_uid":          testWorkspaceUID,
+			"tenant_organization_id": 61,
+			"gateway_link_id":        7,
+			"knowledge_source_id":    42,
+			"workspace_kind":         "managed_restore",
+		},
+	})
+
+	if status != "failed" || errMsg == "" {
+		t.Fatalf("expected unowned workspace rejection, status=%q err=%q", status, errMsg)
+	}
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("existing workspace was modified: %v", err)
+	}
+	if _, err := os.Stat(testIdentityPath(root, testWorkspaceUID)); !os.IsNotExist(err) {
+		t.Fatalf("unexpected identity claim, err=%v", err)
+	}
+}
+
+func TestRunLensKsPrepareRecoversIdentityWithoutDirectory(t *testing.T) {
+	root := newLensTestRoot(t)
+	target := filepath.Join(root, "interrupted-workspace")
+	payload := Payload{
+		Path: target,
+		Extra: map[string]any{
+			"workspace_root":         root,
+			"workspace_uid":          testWorkspaceUID,
+			"tenant_organization_id": 61,
+			"gateway_link_id":        7,
+			"knowledge_source_id":    42,
+			"workspace_kind":         "managed_restore",
+		},
+	}
+	identity, err := lensWorkspaceIdentityFromPayload(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	paths, err := resolveLensWorkspacePaths(target, root, identity.WorkspaceUID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := ensureLensMetadataLayout(paths); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeLensWorkspaceIdentity(paths.Identity, identity); err != nil {
+		t.Fatal(err)
+	}
+
+	status, result, errMsg := New(nil).runLensKsPrepare(context.Background(), payload)
+
+	if status != "success" {
+		t.Fatalf("status=%q err=%q", status, errMsg)
+	}
+	if created, _ := result["created"].(bool); !created {
+		t.Fatalf("expected interrupted directory creation to resume: %v", result)
+	}
+	if info, statErr := os.Stat(target); statErr != nil || !info.IsDir() {
+		t.Fatalf("workspace was not recovered: info=%v err=%v", info, statErr)
+	}
+}
+
 func TestRunLensKsCleanupRemovesOnlyMatchingManagedWorkspace(t *testing.T) {
 	root := newLensTestRoot(t)
 	target := filepath.Join(root, "tenant-61-ks-42")
@@ -123,7 +201,7 @@ func TestRunLensKsCleanupRemovesOnlyMatchingManagedWorkspace(t *testing.T) {
 		Path: target,
 		Extra: map[string]any{
 			"workspace_root":         root,
-			"workspace_uid":          "workspace-42",
+			"workspace_uid":          testWorkspaceUID,
 			"tenant_organization_id": 61,
 			"gateway_link_id":        7,
 			"knowledge_source_id":    42,
@@ -153,7 +231,7 @@ func TestRunLensKsCleanupRejectsUnmanagedDirectory(t *testing.T) {
 		Path: target,
 		Extra: map[string]any{
 			"workspace_root":         root,
-			"workspace_uid":          "workspace-unmanaged",
+			"workspace_uid":          testWorkspaceUID,
 			"tenant_organization_id": 61,
 			"gateway_link_id":        7,
 			"knowledge_source_id":    42,
@@ -171,7 +249,7 @@ func TestRunLensKsCleanupRejectsUnmanagedDirectory(t *testing.T) {
 func TestRunLensKsCleanupRejectsUnverifiedTrashDirectory(t *testing.T) {
 	root := newLensTestRoot(t)
 	target := filepath.Join(root, "missing-workspace")
-	trash := testTrashPath(root, "workspace-42")
+	trash := testTrashPath(root, testWorkspaceUID)
 	if err := os.MkdirAll(trash, 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -184,7 +262,7 @@ func TestRunLensKsCleanupRejectsUnverifiedTrashDirectory(t *testing.T) {
 		Path: target,
 		Extra: map[string]any{
 			"workspace_root":         root,
-			"workspace_uid":          "workspace-42",
+			"workspace_uid":          testWorkspaceUID,
 			"tenant_organization_id": 61,
 			"gateway_link_id":        7,
 			"knowledge_source_id":    42,
@@ -207,7 +285,7 @@ func TestRunLensKsPrepareRejectsIdentityOverwrite(t *testing.T) {
 		Path: target,
 		Extra: map[string]any{
 			"workspace_root":         root,
-			"workspace_uid":          "workspace-42",
+			"workspace_uid":          testWorkspaceUID,
 			"tenant_organization_id": 61,
 			"gateway_link_id":        7,
 			"knowledge_source_id":    42,
@@ -222,7 +300,7 @@ func TestRunLensKsPrepareRejectsIdentityOverwrite(t *testing.T) {
 	if status != "failed" || errMsg == "" {
 		t.Fatalf("expected identity mismatch, status=%q err=%q", status, errMsg)
 	}
-	identity, err := readLensWorkspaceIdentity(testIdentityPath(root, "workspace-42"))
+	identity, err := readLensWorkspaceIdentity(testIdentityPath(root, testWorkspaceUID))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -239,7 +317,7 @@ func TestRunLensKsCleanupIdentityMismatchNeverDeletes(t *testing.T) {
 		Path: target,
 		Extra: map[string]any{
 			"workspace_root":         root,
-			"workspace_uid":          "workspace-42",
+			"workspace_uid":          testWorkspaceUID,
 			"tenant_organization_id": 61,
 			"gateway_link_id":        7,
 			"knowledge_source_id":    42,
@@ -270,7 +348,7 @@ func TestRunLensKsPrepareRejectsSymlinkEscape(t *testing.T) {
 		Path: filepath.Join(root, "escape", "ks-42"),
 		Extra: map[string]any{
 			"workspace_root":         root,
-			"workspace_uid":          "workspace-42",
+			"workspace_uid":          testWorkspaceUID,
 			"tenant_organization_id": 61,
 			"gateway_link_id":        7,
 			"knowledge_source_id":    42,
@@ -292,7 +370,7 @@ func TestValidateLensManagedRestoreTargetRejectsWorkspaceEscapeAndSymlink(t *tes
 		Path: workspace,
 		Extra: map[string]any{
 			"workspace_root":         root,
-			"workspace_uid":          "workspace-42",
+			"workspace_uid":          testWorkspaceUID,
 			"tenant_organization_id": 61,
 			"gateway_link_id":        7,
 			"knowledge_source_id":    42,
@@ -325,7 +403,7 @@ func TestRunLensKsPrepareRejectsTraversalComponents(t *testing.T) {
 		Path: filepath.Join(root, "tenant") + "/../../etc",
 		Extra: map[string]any{
 			"workspace_root":         root,
-			"workspace_uid":          "workspace-42",
+			"workspace_uid":          testWorkspaceUID,
 			"tenant_organization_id": 61,
 			"gateway_link_id":        7,
 			"knowledge_source_id":    42,
@@ -345,7 +423,7 @@ func TestRestoredLegacyMarkerCannotChangeExternalIdentity(t *testing.T) {
 		Path: target,
 		Extra: map[string]any{
 			"workspace_root":         root,
-			"workspace_uid":          "workspace-42",
+			"workspace_uid":          testWorkspaceUID,
 			"tenant_organization_id": 61,
 			"gateway_link_id":        7,
 			"knowledge_source_id":    42,
@@ -371,7 +449,7 @@ func TestRunLensKsCleanupRetriesAfterPartialTrashRemoval(t *testing.T) {
 		Path: target,
 		Extra: map[string]any{
 			"workspace_root":         root,
-			"workspace_uid":          "workspace-42",
+			"workspace_uid":          testWorkspaceUID,
 			"tenant_organization_id": 61,
 			"gateway_link_id":        7,
 			"knowledge_source_id":    42,
@@ -397,14 +475,14 @@ func TestRunLensKsCleanupRetriesAfterPartialTrashRemoval(t *testing.T) {
 	if status != "failed" {
 		t.Fatalf("expected injected failure, got %q", status)
 	}
-	if _, err := os.Stat(testIdentityPath(root, "workspace-42")); err != nil {
+	if _, err := os.Stat(testIdentityPath(root, testWorkspaceUID)); err != nil {
 		t.Fatalf("identity must survive partial removal: %v", err)
 	}
 	status, _, errMsg := engine.runLensKsCleanup(context.Background(), payload)
 	if status != "success" {
 		t.Fatalf("retry status=%q err=%q", status, errMsg)
 	}
-	if _, err := os.Stat(testIdentityPath(root, "workspace-42")); !os.IsNotExist(err) {
+	if _, err := os.Stat(testIdentityPath(root, testWorkspaceUID)); !os.IsNotExist(err) {
 		t.Fatalf("identity should be removed last, err=%v", err)
 	}
 }

--- a/src/agent/internal/engine/managed_backup.go
+++ b/src/agent/internal/engine/managed_backup.go
@@ -1492,6 +1492,16 @@ func (e *Engine) runManagedRestore(
 	if targetPath == "" {
 		return "failed", nil, "target_path is required"
 	}
+	if err := e.ensureNASMounted(ctx, p); err != nil {
+		return "failed", nil, err.Error()
+	}
+	targetPath, nasMountRoot, err := resolveNASRestoreTarget(p, targetPath)
+	if err != nil {
+		return "failed", nil, err.Error()
+	}
+	if err := validateNASRestoreTarget(p, targetPath); err != nil {
+		return "failed", nil, err.Error()
+	}
 	if err := validateLensManagedRestoreTarget(p, targetPath); err != nil {
 		return "failed", nil, err.Error()
 	}
@@ -1520,6 +1530,9 @@ func (e *Engine) runManagedRestore(
 	for pathIndex, selectedPath := range selectedPaths {
 		source := snapshotObjectPath(p.SnapshotID, selectedPath)
 		restoreTarget := restoreTargetPathForSelection(p, targetPath, selectedPath)
+		if err := validateNASRestoreTarget(p, restoreTarget); err != nil {
+			return "failed", result, err.Error()
+		}
 		if err := validateLensManagedRestoreTarget(p, restoreTarget); err != nil {
 			return "failed", result, err.Error()
 		}
@@ -1546,7 +1559,12 @@ func (e *Engine) runManagedRestore(
 		preparePath := restorePrepareTargetPathForSelection(p, targetPath, len(selectedPaths), sourceIsDir)
 		restoreEntry["prepare_path"] = preparePath
 		cleanupFileTargetDir := restoreTargetPathSemantics(p) == "final" && len(selectedPaths) == 1 && !sourceIsDir
-		if mkErr := prepareRestoreTargetPath(preparePath, restoreTarget, cleanupFileTargetDir); mkErr != nil {
+		if mkErr := prepareRestoreTargetPath(
+			preparePath,
+			restoreTarget,
+			cleanupFileTargetDir,
+			nasMountRoot,
+		); mkErr != nil {
 			restoreEntry["prepare_error"] = mkErr.Error()
 			restored = append(restored, restoreEntry)
 			result["restore_results"] = restored
@@ -1742,11 +1760,26 @@ func restoreTargetParentPath(targetPath string) string {
 	return parent
 }
 
-func prepareRestoreTargetPath(preparePath string, restoreTarget string, cleanupFileTargetDir bool) error {
+func prepareRestoreTargetPath(
+	preparePath string,
+	restoreTarget string,
+	cleanupFileTargetDir bool,
+	allowedRoot string,
+) error {
 	if cleanupFileTargetDir {
 		if err := removeEmptyRestoreTargetDirectory(restoreTarget); err != nil {
 			return err
 		}
+	}
+	if strings.TrimSpace(allowedRoot) != "" {
+		allowedRoot = filepath.Clean(strings.TrimSpace(allowedRoot))
+		if filepath.Clean(preparePath) == allowedRoot {
+			return nil
+		}
+		if _, _, err := secureEnsureDirectory(preparePath, allowedRoot, 0o755); err != nil {
+			return err
+		}
+		return nil
 	}
 	if err := os.MkdirAll(preparePath, 0o755); err != nil {
 		return err

--- a/src/agent/internal/engine/managed_backup_test.go
+++ b/src/agent/internal/engine/managed_backup_test.go
@@ -875,7 +875,7 @@ func TestPrepareRestoreTargetPathRemovesEmptyDirectoryForFileTarget(t *testing.T
 		t.Fatal(err)
 	}
 
-	if err := prepareRestoreTargetPath(root, target, true); err != nil {
+	if err := prepareRestoreTargetPath(root, target, true, ""); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := os.Stat(target); !os.IsNotExist(err) {
@@ -893,7 +893,7 @@ func TestPrepareRestoreTargetPathRejectsNonEmptyDirectoryForFileTarget(t *testin
 		t.Fatal(err)
 	}
 
-	err := prepareRestoreTargetPath(root, target, true)
+	err := prepareRestoreTargetPath(root, target, true, "")
 	if err == nil {
 		t.Fatal("expected non-empty directory target to be rejected")
 	}

--- a/src/agent/internal/engine/nas_handlers.go
+++ b/src/agent/internal/engine/nas_handlers.go
@@ -2,7 +2,12 @@ package engine
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
 
 	"hyperfilelens/agent/internal/service/nas"
 )
@@ -57,6 +62,83 @@ func (e *Engine) ensureNASMounted(ctx context.Context, p Payload) error {
 		return nil
 	}
 	return nas.NewService().EnsureMounted(ctx, spec)
+}
+
+func validateNASRestoreTarget(p Payload, targetPath string) error {
+	spec, ok, err := parseNASSpec(p.Extra["nas"])
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return nil
+	}
+	mountRoot := filepath.Clean(strings.TrimSpace(spec.MountPoint))
+	target := filepath.Clean(strings.TrimSpace(targetPath))
+	_, relative, err := secureRelativePath(target, mountRoot, true)
+	if err != nil {
+		return errors.New("NAS restore target must be inside its mount point")
+	}
+	rootFD, _, err := secureOpenDirectory(
+		mountRoot,
+		mountRoot,
+		true,
+		uint64(os.O_RDONLY),
+	)
+	if err != nil {
+		return fmt.Errorf("NAS mount point is not a safe directory: %w", err)
+	}
+	rootDirectory := secureDirectoryFile(rootFD, mountRoot)
+	if rootDirectory == nil {
+		return errors.New("restricted Data Gateway filesystem operations require Linux")
+	}
+	_ = rootDirectory.Close()
+
+	current := mountRoot
+	for _, component := range strings.Split(relative, string(os.PathSeparator)) {
+		if component == "." || component == "" {
+			continue
+		}
+		current = filepath.Join(current, component)
+		info, statErr := os.Lstat(current)
+		if os.IsNotExist(statErr) {
+			break
+		}
+		if statErr != nil {
+			return statErr
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("NAS restore target contains a symlink: %s", current)
+		}
+	}
+	return nil
+}
+
+func resolveNASRestoreTarget(p Payload, logicalPath string) (string, string, error) {
+	spec, ok, err := parseNASSpec(p.Extra["nas"])
+	if err != nil {
+		return "", "", err
+	}
+	if !ok {
+		return strings.TrimSpace(logicalPath), "", nil
+	}
+	raw := strings.TrimSpace(logicalPath)
+	if raw == "" || strings.ContainsRune(raw, '\x00') || strings.Contains(raw, `\`) {
+		return "", "", errors.New("NAS restore target is invalid")
+	}
+	for _, component := range strings.Split(raw, "/") {
+		if component == "." || component == ".." {
+			return "", "", errors.New("NAS restore target contains an unsafe path component")
+		}
+	}
+	relative := strings.TrimPrefix(raw, "/")
+	if relative == "" {
+		relative = "."
+	}
+	target := filepath.Join(spec.MountPoint, filepath.FromSlash(relative))
+	if err := validateNASRestoreTarget(p, target); err != nil {
+		return "", "", err
+	}
+	return target, spec.MountPoint, nil
 }
 
 func (e *Engine) runNasMount(ctx context.Context, p Payload) (string, map[string]any, string) {

--- a/src/agent/internal/engine/nas_handlers_test.go
+++ b/src/agent/internal/engine/nas_handlers_test.go
@@ -1,0 +1,79 @@
+package engine
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"hyperfilelens/agent/internal/platform/vfs"
+)
+
+func nasRestoreTestPayload(t *testing.T) (Payload, string) {
+	t.Helper()
+	dataDir := t.TempDir()
+	t.Setenv("HFL_DATA_DIR", dataDir)
+	mountRoot := vfs.SourceMountPoint(dataDir, 4)
+	if err := os.MkdirAll(mountRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return Payload{Extra: map[string]any{
+		"nas": map[string]any{
+			"resource_id": 4,
+			"protocol":    "nfs",
+			"server":      "10.0.0.20",
+			"export_path": "/restore",
+			"mount_point": vfs.SourceMountPoint(vfs.UnixDataDir(), 4),
+		},
+	}}, mountRoot
+}
+
+func TestResolveNASRestoreTargetUsesRuntimeDataDirectory(t *testing.T) {
+	payload, mountRoot := nasRestoreTestPayload(t)
+
+	target, resolvedRoot, err := resolveNASRestoreTarget(
+		payload,
+		"/restored/data",
+	)
+
+	if err != nil {
+		t.Fatalf("valid NAS restore target rejected: %v", err)
+	}
+	if resolvedRoot != mountRoot {
+		t.Fatalf("resolved mount root = %q want %q", resolvedRoot, mountRoot)
+	}
+	want := filepath.Join(mountRoot, "restored", "data")
+	if target != want {
+		t.Fatalf("resolved target = %q want %q", target, want)
+	}
+}
+
+func TestValidateNASRestoreTargetRequiresMountContainment(t *testing.T) {
+	payload, mountRoot := nasRestoreTestPayload(t)
+
+	if err := validateNASRestoreTarget(
+		payload,
+		filepath.Join(mountRoot, "restored", "data"),
+	); err != nil {
+		t.Fatalf("valid NAS restore target rejected: %v", err)
+	}
+	if err := validateNASRestoreTarget(payload, "/tmp/outside"); err == nil {
+		t.Fatal("expected NAS restore target escape rejection")
+	}
+}
+
+func TestValidateNASRestoreTargetRejectsSymlinkEscape(t *testing.T) {
+	payload, mountRoot := nasRestoreTestPayload(t)
+	outside := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(mountRoot, "escape")); err != nil {
+		t.Fatal(err)
+	}
+
+	err := validateNASRestoreTarget(
+		payload,
+		filepath.Join(mountRoot, "escape", "restored.txt"),
+	)
+
+	if err == nil {
+		t.Fatal("expected NAS restore symlink escape rejection")
+	}
+}

--- a/src/backend/apps/lens_bridge/services/chat_lifecycle.py
+++ b/src/backend/apps/lens_bridge/services/chat_lifecycle.py
@@ -40,6 +40,8 @@ logger = logging.getLogger(__name__)
 
 _ASSISTANT_CREATE_OPERATION = "assistant_create"
 _SESSION_CREATE_OPERATION = "session_create"
+_TEARDOWN_INTENT_DELETE = "delete_session"
+_TEARDOWN_INTENT_RESET_FOR_RETRY = "reset_for_retry"
 
 
 class ChatProvisionLeaseLostError(RuntimeError):
@@ -246,7 +248,14 @@ def request_copilot_chat_teardown(link: LensSessionLink) -> LensSessionLink:
     if locked.lifecycle_status == LensSessionLink.LifecycleStatus.DELETED:
         return locked
 
-    if locked.lifecycle_status != LensSessionLink.LifecycleStatus.DELETING:
+    teardown_intent = str(
+        (locked.teardown_state_json or {}).get("intent") or ""
+    )
+    delete_intent_already_active = (
+        locked.lifecycle_status == LensSessionLink.LifecycleStatus.DELETING
+        and teardown_intent == _TEARDOWN_INTENT_DELETE
+    )
+    if not delete_intent_already_active:
         locked.lifecycle_status = LensSessionLink.LifecycleStatus.DELETING
         locked.provision_phase = LensSessionLink.ProvisionPhase.DELETING
         locked.provision_detail = "Deleting chat resources."
@@ -259,7 +268,7 @@ def request_copilot_chat_teardown(link: LensSessionLink) -> LensSessionLink:
         locked.teardown_claim_token = None
         locked.teardown_claimed_at = None
         locked.teardown_next_retry_at = None
-        locked.teardown_state_json = {}
+        locked.teardown_state_json = {"intent": _TEARDOWN_INTENT_DELETE}
         locked.save(
             update_fields=[
                 "lifecycle_status",
@@ -1263,6 +1272,9 @@ def run_copilot_chat_teardown(*, session_link_id: int) -> dict[str, Any]:
     critical_errors: list[str] = []
     warnings: list[str] = []
     teardown_state = dict(link.teardown_state_json or {})
+    teardown_intent = str(
+        teardown_state.get("intent") or _TEARDOWN_INTENT_DELETE
+    )
 
     if link.active_run_uuid:
         try:
@@ -1487,23 +1499,32 @@ def run_copilot_chat_teardown(*, session_link_id: int) -> dict[str, Any]:
             error=dependency,
         )
 
-    link.lifecycle_status = (
-        LensSessionLink.LifecycleStatus.DELETING
-        if critical_errors
-        else LensSessionLink.LifecycleStatus.DELETED
-    )
-    link.status = LensSessionLink.Status.ARCHIVED
-    link.provision_phase = (
-        LensSessionLink.ProvisionPhase.CLEANING_UP
-        if critical_errors
-        else LensSessionLink.ProvisionPhase.DELETED
-    )
-    link.provision_detail = (
-        "Chat cleanup is incomplete and will be retried."
-        if critical_errors
-        else "Chat resources deleted."
-    )
-    link.lifecycle_error = "; ".join([*critical_errors, *warnings])[:2000]
+    reset_for_retry = teardown_intent == _TEARDOWN_INTENT_RESET_FOR_RETRY
+    if critical_errors:
+        link.lifecycle_status = LensSessionLink.LifecycleStatus.DELETING
+        link.status = (
+            LensSessionLink.Status.ACTIVE
+            if reset_for_retry
+            else LensSessionLink.Status.ARCHIVED
+        )
+        link.provision_phase = LensSessionLink.ProvisionPhase.CLEANING_UP
+        link.provision_detail = "Chat cleanup is incomplete and will be retried."
+        link.lifecycle_error = "; ".join([*critical_errors, *warnings])[:2000]
+    elif reset_for_retry:
+        link.lifecycle_status = LensSessionLink.LifecycleStatus.FAILED
+        link.status = LensSessionLink.Status.ACTIVE
+        link.provision_phase = LensSessionLink.ProvisionPhase.QUEUED
+        link.provision_detail = "Chat preparation failed. Retry to try again."
+        provision_error = str(teardown_state.get("provision_error") or "")
+        link.lifecycle_error = "; ".join(
+            item for item in [provision_error, *warnings] if item
+        )[:2000]
+    else:
+        link.lifecycle_status = LensSessionLink.LifecycleStatus.DELETED
+        link.status = LensSessionLink.Status.ARCHIVED
+        link.provision_phase = LensSessionLink.ProvisionPhase.DELETED
+        link.provision_detail = "Chat resources deleted."
+        link.lifecycle_error = "; ".join(warnings)[:2000]
     link.active_run_uuid = None
     link.active_run_status = ""
     link.teardown_state_json = teardown_state
@@ -1542,7 +1563,7 @@ def run_copilot_chat_teardown(*, session_link_id: int) -> dict[str, Any]:
         raise ChatTeardownIncompleteError("; ".join(critical_errors))
     return {
         "session_link_id": link.id,
-        "status": "deleted",
+        "status": "retryable" if reset_for_retry else "deleted",
         "warnings": warnings,
         "gateway_untouched": True,
     }
@@ -1589,7 +1610,7 @@ def _transition_failed_provision_to_teardown(
     if link is None:
         return False
     link.lifecycle_status = LensSessionLink.LifecycleStatus.DELETING
-    link.status = LensSessionLink.Status.ARCHIVED
+    link.status = LensSessionLink.Status.ACTIVE
     link.provision_phase = LensSessionLink.ProvisionPhase.CLEANING_UP
     link.provision_detail = "Provisioning cleanup is incomplete and will be retried."
     link.lifecycle_error = message[:2000]
@@ -1600,6 +1621,10 @@ def _transition_failed_provision_to_teardown(
     link.teardown_claim_token = None
     link.teardown_claimed_at = None
     link.teardown_next_retry_at = None
+    link.teardown_state_json = {
+        "intent": _TEARDOWN_INTENT_RESET_FOR_RETRY,
+        "provision_error": message[:2000],
+    }
     link.save(
         update_fields=[
             "lifecycle_status",
@@ -1614,6 +1639,7 @@ def _transition_failed_provision_to_teardown(
             "teardown_claim_token",
             "teardown_claimed_at",
             "teardown_next_retry_at",
+            "teardown_state_json",
             "updated_at",
         ]
     )
@@ -1643,6 +1669,11 @@ def retry_copilot_chat_provision(link: LensSessionLink) -> LensSessionLink:
     locked.provision_claim_token = None
     locked.provision_claimed_at = None
     locked.provision_next_retry_at = None
+    locked.teardown_attempts = 0
+    locked.teardown_claim_token = None
+    locked.teardown_claimed_at = None
+    locked.teardown_next_retry_at = None
+    locked.teardown_state_json = {}
     locked.save(
         update_fields=[
             "lifecycle_status",
@@ -1652,6 +1683,11 @@ def retry_copilot_chat_provision(link: LensSessionLink) -> LensSessionLink:
             "provision_claim_token",
             "provision_claimed_at",
             "provision_next_retry_at",
+            "teardown_attempts",
+            "teardown_claim_token",
+            "teardown_claimed_at",
+            "teardown_next_retry_at",
+            "teardown_state_json",
             "updated_at",
         ]
     )

--- a/src/backend/apps/lens_bridge/services/gateway_execution.py
+++ b/src/backend/apps/lens_bridge/services/gateway_execution.py
@@ -230,7 +230,12 @@ def context_for_workspace_binding(
     require_ready: bool = True,
     allow_deleting: bool = False,
 ) -> tuple[GatewayExecutionContext, LensWorkspaceBinding]:
-    """Resolve a trusted execution context from a persisted workspace binding."""
+    """Resolve a trusted execution context from a persisted workspace binding.
+
+    ``allow_deleting`` is reserved for identity-aware cleanup, which must also
+    converge after prepare failed before the identity became ready. Restore
+    callers retain the default READY-only checks.
+    """
 
     binding = (
         LensWorkspaceBinding.objects.select_related(
@@ -251,13 +256,21 @@ def context_for_workspace_binding(
     if binding.workspace_kind != LensWorkspaceBinding.WorkspaceKind.MANAGED_RESTORE:
         raise ValidationError({"workspace_binding_id": "Gateway-local directories cannot receive managed restores."})
     allowed_states = (
-        {LensWorkspaceBinding.State.READY, LensWorkspaceBinding.State.DELETING}
+        {
+            LensWorkspaceBinding.State.PREPARING,
+            LensWorkspaceBinding.State.READY,
+            LensWorkspaceBinding.State.DELETING,
+            LensWorkspaceBinding.State.ERROR,
+        }
         if allow_deleting
         else {LensWorkspaceBinding.State.READY}
     )
     if binding.state not in allowed_states:
         raise ValidationError({"workspace_binding_id": "Workspace binding is not executable."})
-    if binding.identity_status != LensWorkspaceBinding.IdentityStatus.READY:
+    if (
+        not allow_deleting
+        and binding.identity_status != LensWorkspaceBinding.IdentityStatus.READY
+    ):
         raise ValidationError(
             {"workspace_binding_id": "Managed workspace identity is not verified."}
         )

--- a/src/backend/apps/lens_bridge/services/provisioning.py
+++ b/src/backend/apps/lens_bridge/services/provisioning.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import posixpath
 import re
 import time
 import uuid
@@ -143,41 +144,47 @@ def require_gateway_node(org: Organization, gateway_id: int) -> Node:
     raise ValidationError({"gateway_id": "Data gateway not found."})
 
 
-def _lensnode_dir_paths(lensnode_data: dict[str, Any]) -> set[str]:
-    paths: set[str] = set()
-    for item in lensnode_data.get("available_dirs") or []:
-        if isinstance(item, str):
-            paths.add(item)
-            continue
-        if not isinstance(item, dict):
-            continue
-        path = item.get("path")
-        if path:
-            paths.add(str(path))
-        for child in item.get("children") or []:
-            if isinstance(child, dict) and child.get("path"):
-                paths.add(str(child["path"]))
-    return paths
-
-
-def wait_for_lensnode_dir(
+def _lensnode_matches_workspace(
+    lensnode_data: dict[str, Any],
     *,
     lensnode_uuid: uuid.UUID,
-    path: str,
+    workspace_root: str,
+) -> bool:
+    reported_uuid = str(lensnode_data.get("uuid") or "").strip().lower()
+    reported_status = str(lensnode_data.get("status") or "").strip().lower()
+    reported_root = posixpath.normpath(
+        str(lensnode_data.get("workspace_path") or "").strip()
+    )
+    expected_root = posixpath.normpath(str(workspace_root or "").strip())
+    return (
+        reported_uuid == str(lensnode_uuid).lower()
+        and reported_status == "online"
+        and reported_root == expected_root
+    )
+
+
+def wait_for_lensnode_ready(
+    *,
+    lensnode_uuid: uuid.UUID,
+    workspace_root: str,
     timeout_s: float = _LENSNODE_DIR_WAIT_SECONDS,
 ) -> None:
-    """Wait until a LensNode heartbeat reports the given workspace path."""
+    """Wait for the enrolled LensNode at its configured workspace root."""
 
     deadline = time.monotonic() + timeout_s
     while time.monotonic() < deadline:
         data = sl_client.request_json("GET", f"/api/lens/admin/lensnodes/{lensnode_uuid}/")
-        if path in _lensnode_dir_paths(data):
+        if _lensnode_matches_workspace(
+            data,
+            lensnode_uuid=lensnode_uuid,
+            workspace_root=workspace_root,
+        ):
             return
         time.sleep(_LENSNODE_DIR_POLL_SECONDS)
     raise ValidationError(
         {
             "workspace": (
-                f"LensNode did not report workspace path in time: {path}. "
+                f"LensNode did not become ready at workspace root: {workspace_root}. "
                 "Ensure the AI engine is online and retry."
             )
         }
@@ -246,7 +253,7 @@ def ensure_ks_workspace_on_gateway(
         update_fields=["identity_status", "last_error", "updated_at"]
     )
 
-    wait_for_lensnode_dir(lensnode_uuid=lensnode_uuid, path=workspace_path)
+    wait_for_lensnode_ready(lensnode_uuid=lensnode_uuid, workspace_root=root)
 
 
 def pick_lensnode_task(lensnode_uuid: uuid.UUID) -> str:

--- a/src/backend/apps/lens_bridge/tests/test_chat_teardown.py
+++ b/src/backend/apps/lens_bridge/tests/test_chat_teardown.py
@@ -227,6 +227,84 @@ class CopilotChatTeardownTests(TestCase):
     @mock.patch("apps.lens_bridge.services.assistants._delete_sl_assistant")
     @mock.patch("apps.node.services.internal.agent_task.run_agent_task_sync")
     @mock.patch("apps.lens_bridge.services.chat_lifecycle.sl_client.request_json")
+    def test_failed_provision_cleanup_keeps_chat_retryable(
+        self,
+        request_json,
+        run_agent_task,
+        _delete_assistant,
+        _soft_delete_assistant,
+    ):
+        request_json.side_effect = self._not_found()
+        run_agent_task.return_value = mock.MagicMock(
+            ok=True,
+            timed_out=False,
+            task=mock.MagicMock(id=uuid.uuid4(), last_error=""),
+        )
+        self.session.lifecycle_status = LensSessionLink.LifecycleStatus.DELETING
+        self.session.status = LensSessionLink.Status.ACTIVE
+        self.session.teardown_state_json = {
+            "intent": "reset_for_retry",
+            "provision_error": "LensNode was unavailable",
+        }
+        self.session.save(
+            update_fields=[
+                "lifecycle_status",
+                "status",
+                "teardown_state_json",
+                "updated_at",
+            ]
+        )
+
+        result = chat_lifecycle.run_copilot_chat_teardown(
+            session_link_id=self.session.id
+        )
+
+        self.assertEqual(result["status"], "retryable")
+        self.session.refresh_from_db()
+        self.assertEqual(
+            self.session.lifecycle_status,
+            LensSessionLink.LifecycleStatus.FAILED,
+        )
+        self.assertEqual(self.session.status, LensSessionLink.Status.ACTIVE)
+        self.assertIsNone(self.session.knowledge_source_id)
+        self.assertIn("LensNode was unavailable", self.session.lifecycle_error)
+
+    @mock.patch(
+        "apps.lens_bridge.services.chat_lifecycle."
+        "_queue_teardown_or_record_error"
+    )
+    def test_failed_provision_records_reset_for_retry_intent(self, queue_teardown):
+        claim_token = uuid.uuid4()
+        self.session.lifecycle_status = LensSessionLink.LifecycleStatus.PROVISIONING
+        self.session.provision_claim_token = claim_token
+        self.session.save(
+            update_fields=[
+                "lifecycle_status",
+                "provision_claim_token",
+                "updated_at",
+            ]
+        )
+
+        with self.captureOnCommitCallbacks(execute=True):
+            changed = chat_lifecycle._transition_failed_provision_to_teardown(
+                self.session.id,
+                str(claim_token),
+                message="workspace cleanup failed",
+            )
+
+        self.assertTrue(changed)
+        self.session.refresh_from_db()
+        self.assertEqual(
+            self.session.teardown_state_json["intent"],
+            "reset_for_retry",
+        )
+        self.assertEqual(self.session.status, LensSessionLink.Status.ACTIVE)
+        queue_teardown.assert_called_once_with(self.session.id)
+
+    @mock.patch("apps.lens_bridge.services.assistant_access.soft_delete_assistant_link")
+    @mock.patch("apps.lens_bridge.services.assistants._delete_sl_assistant")
+    @mock.patch("apps.node.services.internal.agent_task.run_agent_task_sync")
+    @mock.patch("apps.lens_bridge.services.chat_lifecycle.sl_client.request_json")
     def test_teardown_persists_partial_success_and_retry_converges(
         self,
         request_json,
@@ -647,6 +725,7 @@ class CopilotChatTeardownTests(TestCase):
         self.assertIsNone(result.provision_claim_token)
         self.assertIsNone(result.provision_claimed_at)
         self.assertIsNone(result.provision_next_retry_at)
+        self.assertEqual(result.teardown_state_json["intent"], "delete_session")
         queue_teardown.assert_called_once_with(self.session.id)
 
     @mock.patch(
@@ -662,6 +741,7 @@ class CopilotChatTeardownTests(TestCase):
         self.session.teardown_claim_token = teardown_token
         self.session.teardown_claimed_at = claimed_at
         self.session.teardown_next_retry_at = next_retry_at
+        self.session.teardown_state_json = {"intent": "delete_session"}
         self.session.save(
             update_fields=[
                 "lifecycle_status",
@@ -669,6 +749,7 @@ class CopilotChatTeardownTests(TestCase):
                 "teardown_claim_token",
                 "teardown_claimed_at",
                 "teardown_next_retry_at",
+                "teardown_state_json",
                 "updated_at",
             ]
         )
@@ -681,6 +762,56 @@ class CopilotChatTeardownTests(TestCase):
         self.assertEqual(result.teardown_claim_token, teardown_token)
         self.assertEqual(result.teardown_claimed_at, claimed_at)
         self.assertEqual(result.teardown_next_retry_at, next_retry_at)
+        queue_teardown.assert_called_once_with(self.session.id)
+
+    @mock.patch(
+        "apps.lens_bridge.services.chat_lifecycle."
+        "_queue_teardown_or_record_error"
+    )
+    def test_delete_overrides_retry_cleanup_and_fences_live_claim(
+        self,
+        queue_teardown,
+    ):
+        teardown_token = uuid.uuid4()
+        self.session.lifecycle_status = LensSessionLink.LifecycleStatus.DELETING
+        self.session.status = LensSessionLink.Status.ACTIVE
+        self.session.teardown_attempts = 2
+        self.session.teardown_claim_token = teardown_token
+        self.session.teardown_claimed_at = timezone.now()
+        self.session.teardown_next_retry_at = timezone.now() + timedelta(minutes=5)
+        self.session.teardown_state_json = {
+            "intent": "reset_for_retry",
+            "provision_error": "prepare failed",
+        }
+        self.session.save(
+            update_fields=[
+                "lifecycle_status",
+                "status",
+                "teardown_attempts",
+                "teardown_claim_token",
+                "teardown_claimed_at",
+                "teardown_next_retry_at",
+                "teardown_state_json",
+                "updated_at",
+            ]
+        )
+
+        with self.captureOnCommitCallbacks(execute=True):
+            result = chat_lifecycle.request_copilot_chat_teardown(self.session)
+
+        result.refresh_from_db()
+        self.assertEqual(result.status, LensSessionLink.Status.ARCHIVED)
+        self.assertEqual(result.teardown_attempts, 0)
+        self.assertIsNone(result.teardown_claim_token)
+        self.assertIsNone(result.teardown_claimed_at)
+        self.assertIsNone(result.teardown_next_retry_at)
+        self.assertEqual(result.teardown_state_json, {"intent": "delete_session"})
+        with self.assertRaises(chat_lifecycle.ChatTeardownIncompleteError):
+            chat_lifecycle._update_chat_claim(
+                result,
+                str(teardown_token),
+                "teardown_state_json",
+            )
         queue_teardown.assert_called_once_with(self.session.id)
 
     @mock.patch(

--- a/src/backend/apps/lens_bridge/tests/test_gateway_execution.py
+++ b/src/backend/apps/lens_bridge/tests/test_gateway_execution.py
@@ -5,9 +5,16 @@ from django.test import TestCase
 from rest_framework.exceptions import ValidationError
 
 from apps.iam.models import Organization
-from apps.lens_bridge.models import LensGatewayLink, LensKnowledgeSource
+from apps.lens_bridge.models import (
+    LensGatewayLink,
+    LensKnowledgeSource,
+    LensWorkspaceBinding,
+)
 from apps.lens_bridge.services import platform_lens
-from apps.lens_bridge.services.gateway_execution import context_for_gateway_link
+from apps.lens_bridge.services.gateway_execution import (
+    context_for_gateway_link,
+    context_for_workspace_binding,
+)
 from apps.node.models import Node
 from apps.node.models.base import NodeRole
 from apps.node.services.internal.node_workload import get_node_remove_blockers
@@ -119,3 +126,54 @@ class GatewayExecutionContextTests(TestCase):
         blockers = get_node_remove_blockers(node=node)
 
         self.assertIn("knowledge_source_bound", {blocker.code for blocker in blockers})
+
+    def test_cleanup_context_accepts_failed_identity_without_relaxing_restore(self):
+        node = Node.objects.create(
+            organization=self.tenant,
+            name="failed-prepare-gateway",
+            role=NodeRole.GATEWAY,
+        )
+        link = LensGatewayLink.objects.create(
+            organization=self.tenant,
+            gateway=node,
+            owner_user=self.user,
+            scope=LensGatewayLink.GatewayScope.USER,
+            workspace_root="/workspace/tenant/data",
+        )
+        knowledge_source = LensKnowledgeSource.objects.create(
+            organization=self.tenant,
+            name="Failed managed workspace",
+            gateway=node,
+            gateway_link=link,
+            source_path="/source/data",
+            created_by=self.user,
+        )
+        binding = LensWorkspaceBinding.objects.create(
+            organization=self.tenant,
+            knowledge_source=knowledge_source,
+            gateway_link=link,
+            execution_organization_id=self.tenant.id,
+            execution_node_id=node.id,
+            workspace_kind=LensWorkspaceBinding.WorkspaceKind.MANAGED_RESTORE,
+            workspace_root="/workspace/tenant/data",
+            relative_path="tenants/1/knowledge-sources/failed",
+            state=LensWorkspaceBinding.State.ERROR,
+            identity_status=LensWorkspaceBinding.IdentityStatus.ERROR,
+        )
+
+        with self.assertRaises(ValidationError):
+            context_for_workspace_binding(
+                tenant_organization=self.tenant,
+                workspace_binding_id=binding.id,
+                require_ready=False,
+            )
+
+        context, resolved = context_for_workspace_binding(
+            tenant_organization=self.tenant,
+            workspace_binding_id=binding.id,
+            require_ready=False,
+            allow_deleting=True,
+        )
+
+        self.assertEqual(context.gateway.id, node.id)
+        self.assertEqual(resolved.id, binding.id)

--- a/src/backend/apps/lens_bridge/tests/test_provisioning.py
+++ b/src/backend/apps/lens_bridge/tests/test_provisioning.py
@@ -4,7 +4,7 @@ from django.test import SimpleTestCase
 from rest_framework.exceptions import ValidationError
 
 from apps.lens_bridge.services import sl_client
-from apps.lens_bridge.services.provisioning import _lensnode_dir_paths
+from apps.lens_bridge.services.provisioning import _lensnode_matches_workspace
 
 
 class SlClientErrorFormatTests(SimpleTestCase):
@@ -80,19 +80,46 @@ class BuildLensEnrollConfigTests(SimpleTestCase):
         )
 
 
-class LensnodeDirPathsTests(SimpleTestCase):
-    def test_collects_top_level_and_children(self):
+class LensnodeWorkspaceReadinessTests(SimpleTestCase):
+    lensnode_uuid = "de240f46-eccd-4e4b-868f-b1f504fbe67b"
+
+    def test_accepts_online_lensnode_at_workspace_root_without_deep_dirs(self):
         data = {
-            "available_dirs": [
-                {
-                    "path": "/workspace/org-1/ks-1",
-                    "children": [{"path": "/workspace/org-1/ks-1/data"}],
-                }
-            ]
+            "uuid": self.lensnode_uuid,
+            "status": "online",
+            "workspace_path": "/workspace/org-1/",
+            "available_dirs": [],
         }
-        paths = _lensnode_dir_paths(data)
-        self.assertIn("/workspace/org-1/ks-1", paths)
-        self.assertIn("/workspace/org-1/ks-1/data", paths)
+        self.assertTrue(
+            _lensnode_matches_workspace(
+                data,
+                lensnode_uuid=self.lensnode_uuid,
+                workspace_root="/workspace/org-1",
+            )
+        )
+
+    def test_rejects_offline_or_wrong_workspace_lensnode(self):
+        base = {
+            "uuid": self.lensnode_uuid,
+            "status": "offline",
+            "workspace_path": "/workspace/org-1",
+        }
+        self.assertFalse(
+            _lensnode_matches_workspace(
+                base,
+                lensnode_uuid=self.lensnode_uuid,
+                workspace_root="/workspace/org-1",
+            )
+        )
+        base["status"] = "online"
+        base["workspace_path"] = "/workspace/another-root"
+        self.assertFalse(
+            _lensnode_matches_workspace(
+                base,
+                lensnode_uuid=self.lensnode_uuid,
+                workspace_root="/workspace/org-1",
+            )
+        )
 
 
 class SlLensnodeSnapshotTests(SimpleTestCase):
@@ -119,7 +146,7 @@ class SlLensnodeSnapshotTests(SimpleTestCase):
 
 class EnsureKsWorkspaceTests(SimpleTestCase):
     @patch("apps.lens_bridge.services.gateway_execution.context_for_gateway_link")
-    @patch("apps.lens_bridge.services.provisioning.wait_for_lensnode_dir")
+    @patch("apps.lens_bridge.services.provisioning.wait_for_lensnode_ready")
     @patch("apps.node.services.internal.agent_task.run_agent_task_sync")
     def test_dispatches_prepare_task(self, mock_sync, mock_wait, mock_context):
         from apps.lens_bridge.services import provisioning

--- a/src/backend/apps/node/services/internal/agent_task.py
+++ b/src/backend/apps/node/services/internal/agent_task.py
@@ -28,6 +28,7 @@ from apps.node.services.internal.task import (
     create_agent_task,
     deliver_agent_task,
     dispatch_task,
+    protect_task_delivery_payload,
 )
 
 logger = logging.getLogger(__name__)
@@ -104,6 +105,7 @@ def run_agent_task_async(
     node_id: int,
     kind: str,
     payload: dict | None = None,
+    persisted_payload: dict | None = None,
     correlation_type: str = "",
     correlation_id: str = "",
     requesting_organization_id: int | None = None,
@@ -123,11 +125,17 @@ def run_agent_task_async(
         "agent task async dispatch %s",
         task_log_context(node_id=node.id, kind=kind, correlation_type=correlation_type, correlation_id=correlation_id),
     )
+    task_payload = payload
+    if persisted_payload is not None:
+        task_payload = protect_task_delivery_payload(
+            delivery_payload=payload or {},
+            persisted_payload=persisted_payload,
+        )
     task = dispatch_task(
         org=org,
         node=node,
         kind=kind,
-        payload=payload,
+        payload=task_payload,
         correlation_type=correlation_type,
         correlation_id=correlation_id,
         requesting_organization_id=requesting_organization_id,

--- a/src/backend/apps/node/services/internal/task.py
+++ b/src/backend/apps/node/services/internal/task.py
@@ -4,6 +4,7 @@ NodeTask write path: create, deliver, progress, complete, and watchdog sweep.
 
 from __future__ import annotations
 
+import json
 import logging
 import uuid
 from dataclasses import dataclass
@@ -21,6 +22,7 @@ from apps.node.models import Node, NodeTask
 from apps.node.models.base import NodeRole
 from apps.node.services.internal import redis_store
 from apps.node.services.internal.agent_log import task_log_context
+from apps.storage.crypto import decrypt_text, encrypt_text
 
 logger = logging.getLogger(__name__)
 
@@ -34,6 +36,7 @@ _TERMINAL_STATUSES = frozenset(
     },
 )
 _TASK_COMMAND_ACK_CAPABILITY = "task_command_ack_v1"
+_DELIVERY_SECRET_KEY = "_delivery_secret"
 _ACK_BACKUP_TASKS = frozenset(
     {
         ("protection.backup", "backup.run"),
@@ -52,6 +55,42 @@ class _RouteState(StrEnum):
     ONLINE = "online"
     RECONNECTING = "reconnecting"
     OFFLINE = "offline"
+
+
+def protect_task_delivery_payload(
+    *,
+    delivery_payload: dict[str, Any],
+    persisted_payload: dict[str, Any],
+) -> dict[str, Any]:
+    """Persist a redeliverable payload without storing its plaintext form."""
+
+    encoded = json.dumps(
+        delivery_payload,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    protected = dict(persisted_payload)
+    protected[_DELIVERY_SECRET_KEY] = {
+        "alg": "fernet-json-v1",
+        "ciphertext": encrypt_text(encoded),
+    }
+    return protected
+
+
+def _resolve_task_delivery_payload(payload: dict[str, Any]) -> dict[str, Any] | None:
+    envelope = payload.get(_DELIVERY_SECRET_KEY)
+    if envelope is None:
+        return None
+    if not isinstance(envelope, dict) or envelope.get("alg") != "fernet-json-v1":
+        raise RuntimeError("agent task delivery envelope is invalid")
+    try:
+        decoded = json.loads(decrypt_text(str(envelope.get("ciphertext") or "")))
+    except Exception as exc:
+        raise RuntimeError("agent task delivery envelope cannot be decrypted") from exc
+    if not isinstance(decoded, dict):
+        raise RuntimeError("agent task delivery envelope is invalid")
+    return decoded
 
 
 def _watchdog_deadline(*, from_time: datetime | None = None) -> datetime:
@@ -395,9 +434,12 @@ def deliver_agent_task(*, task: NodeTask, delivery_payload: dict | None = None) 
     )
     uses_ack = task_uses_command_ack(task)
     try:
+        ephemeral_delivery_payload = delivery_payload is not None
+        if delivery_payload is None:
+            delivery_payload = _resolve_task_delivery_payload(task.payload)
         route_state = _node_route_state(task=task)
         if route_state == _RouteState.RECONNECTING:
-            if delivery_payload is not None:
+            if ephemeral_delivery_payload:
                 return _fail_task_delivery(
                     task=task,
                     reason="agent websocket is reconnecting; retry the credential-bearing task",

--- a/src/backend/apps/node/tests/test_agent_task_sync.py
+++ b/src/backend/apps/node/tests/test_agent_task_sync.py
@@ -14,7 +14,11 @@ from apps.node.models import Node, NodeTask
 from apps.node.models.base import NodeRole
 from apps.node.services.internal import redis_store
 from apps.node.services.internal.agent_task import wait_for_agent_task
-from apps.node.services.internal.task import deliver_agent_task, redeliver_pending_agent_task
+from apps.node.services.internal.task import (
+    deliver_agent_task,
+    protect_task_delivery_payload,
+    redeliver_pending_agent_task,
+)
 
 
 class AgentTaskSyncWaitTests(TestCase):
@@ -232,6 +236,45 @@ class AgentTaskSyncWaitTests(TestCase):
         self.assertIsNotNone(task)
         self.assertEqual(task.status, NodeTask.Status.RUNNING)
         mock_send_task_command.assert_called_once()
+
+    @patch("apps.node.services.internal.task._send_task_command")
+    @patch("apps.node.services.internal.task.redis_store.get_agent_location")
+    @patch("apps.node.services.internal.task.redis_store.get_redis")
+    def test_redelivery_decrypts_delivery_payload_without_persisting_plaintext(
+        self,
+        mock_get_redis,
+        mock_get_agent_location,
+        mock_send_task_command,
+    ):
+        class RedisClient:
+            def exists(self, key):
+                return key != redis_store.ws_recovery_hold_key()
+
+            def set(self, *_args, **_kwargs):
+                return True
+
+        delivered_payload = {}
+
+        def capture_payload(*, task):
+            delivered_payload.update(task.payload)
+
+        self.task.status = NodeTask.Status.PENDING
+        self.task.payload = protect_task_delivery_payload(
+            delivery_payload={"nas": {"username": "user", "password": "plain-secret"}},
+            persisted_payload={"nas": {"username": "user"}},
+        )
+        self.task.save(update_fields=["status", "payload"])
+        mock_get_agent_location.return_value = "live-ws"
+        mock_get_redis.return_value = RedisClient()
+        mock_send_task_command.side_effect = capture_payload
+
+        task = redeliver_pending_agent_task(task_id=self.task.id)
+
+        self.assertIsNotNone(task)
+        self.assertEqual(delivered_payload["nas"]["password"], "plain-secret")
+        self.task.refresh_from_db()
+        self.assertNotIn("password", self.task.payload["nas"])
+        self.assertNotIn("plain-secret", str(self.task.payload))
 
     @patch("apps.node.services.internal.task._send_task_command")
     def test_redeliver_terminal_task_is_noop(self, mock_send_task_command):

--- a/src/backend/apps/restore/services/interface.py
+++ b/src/backend/apps/restore/services/interface.py
@@ -1440,6 +1440,23 @@ def _dispatch_restore_items(*, organization_id: int, record: RestoreRecord, task
         raise ValidationError({"target_ref_id": "Restore execution node not found."})
     if node.status != Node.Status.ONLINE:
         raise ValidationError({"target_ref_id": "Restore execution node is offline."})
+    target_nas_payload: dict[str, Any] = {}
+    if record.target_type == RestoreRecord.EndpointType.NAS:
+        target_nas = (
+            SourceResource.objects.filter(
+                organization_id=record.organization_id,
+                resource_type=ResourceType.NAS,
+                id=record.target_ref_id,
+                bound_node_id=node.id,
+                is_deleted=False,
+            )
+            .first()
+        )
+        if target_nas is None:
+            raise ValidationError({"target_ref_id": "Restore target NAS is not available."})
+        from apps.source.services.internal.nas_agent import nas_payload_for_resource
+
+        target_nas_payload = {"nas": nas_payload_for_resource(target_nas)}
     all_items = list(record.items.all())
     items = [
         item
@@ -1550,13 +1567,27 @@ def _dispatch_restore_items(*, organization_id: int, record: RestoreRecord, task
                 "repository": repository_payload,
                 "repository_reader_node_id": repository_access.node.id,
                 "restore_transfer_mode": restore_transfer_mode,
+                **target_nas_payload,
                 **managed_workspace_payload,
             }
+            persisted_payload = payload
+            if target_nas_payload:
+                from apps.source.services.internal.source_credentials import (
+                    scrub_source_secrets,
+                )
+
+                persisted_payload = {
+                    **payload,
+                    "nas": scrub_source_secrets(payload["nas"]),
+                }
             handle = run_agent_task_async(
                 organization_id=record.target_execution_organization_id,
                 node_id=node.id,
                 kind="restore.run",
                 payload=payload,
+                persisted_payload=(
+                    persisted_payload if target_nas_payload else None
+                ),
                 correlation_type="restore.record",
                 correlation_id=str(record.task_uuid),
                 requesting_organization_id=record.requesting_organization_id,

--- a/src/backend/apps/restore/tests/test_restore_api.py
+++ b/src/backend/apps/restore/tests/test_restore_api.py
@@ -29,6 +29,8 @@ from apps.restore.services.task_events import (
     append_restore_execution_started_event,
     append_restore_item_terminal_event,
 )
+from apps.source.constants import ResourceType
+from apps.source.models import SourceResource
 from apps.storage.repositories.models import Repository
 from apps.task.models import Task, TaskEvent, TaskResource
 
@@ -329,6 +331,57 @@ class RestoreApiTests(TestCase):
         )
         self.assertEqual(node_task.organization_id, self.org.id)
         self.assertEqual(node_task.requesting_organization_id, self.org.id)
+
+    def test_nas_restore_dispatches_mount_payload_and_execution_path(self):
+        proxy = Node.objects.create(
+            organization=self.org,
+            name="restore-nas-proxy",
+            role=Node.Role.PROXY,
+            status=Node.Status.ONLINE,
+            ip_address="10.0.0.53",
+        )
+        target_nas = SourceResource.objects.create(
+            organization=self.org,
+            name="restore-target-nas",
+            resource_type=ResourceType.NAS,
+            bound_node=proxy,
+            config={"server": "10.0.0.20", "share": "restore"},
+        )
+        target_nas.set_credentials(
+            {"username": "restore-user", "password": "nas-plain-secret"}
+        )
+        target_nas.save(update_fields=["credentials", "updated_at"])
+        payload = self._manual_restore_payload()
+        payload.update(
+            {
+                "target_type": "nas",
+                "target_ref_id": target_nas.id,
+                "target_path": "/restored/manual",
+            }
+        )
+
+        response = self.client.post(
+            "/api/v1/restore/records/",
+            payload,
+            format="json",
+            **self._headers(),
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.content)
+        node_task = NodeTask.objects.get(kind="restore.run")
+        mount_root = target_nas.effective_mount_point()
+        self.assertEqual(node_task.organization_id, self.org.id)
+        self.assertEqual(node_task.node_id, proxy.id)
+        self.assertEqual(node_task.payload["nas"]["mount_point"], mount_root)
+        self.assertNotIn("password", node_task.payload["nas"])
+        self.assertNotIn("nas-plain-secret", str(node_task.payload))
+        self.assertIn("_delivery_secret", node_task.payload)
+        self.assertEqual(
+            node_task.payload["target_path"],
+            "/restored/manual/file.txt",
+        )
+        record = RestoreRecord.objects.get(target_ref_id=target_nas.id)
+        self.assertEqual(record.target_path, "/restored/manual")
 
     def _active_restore_task(self, *, source_ref_id: int | None = None, status_value: str = Task.Status.RUNNING) -> Task:
         task = Task.objects.create(


### PR DESCRIPTION
## Summary
- enforce trusted Gateway workspace identity and LensNode readiness for cross-organization Chat restores
- make failed Chat provisioning cleanup retryable while preserving explicit delete intent
- securely mount and validate NAS restore targets, including custom data roots and symlink containment
- encrypt redeliverable NAS credentials instead of persisting plaintext task payloads
- recover interrupted workspace preparation without claiming unknown directories

## Validation
- `go test ./...`
- `go test -race ./internal/engine ./internal/service/nas`
- `go vet ./...`
- 106 targeted Django tests
- Ruff and `git diff --check`