### PR TITLE
fix(ci): align analytics checks with web pool

### DIFF
--- a/tools/quality/test-ga-runtime-config.sh
+++ b/tools/quality/test-ga-runtime-config.sh
@@ -30,9 +30,9 @@ grep -F 'WARNING: invalid GA4 measurement ID' <<<"${invalid_output}" >/dev/null
 grep -F "gaMeasurementId: ''" "${tenant}" >/dev/null
 
 grep -F 'alias /usr/share/nginx/runtime/tenant-app-runtime-config.js;' \
-	"${ROOT}/deploy/nginx/snippets/hfl-tenant-spa-locations.conf" >/dev/null
+	"${ROOT}/deploy/nginx/web.conf" >/dev/null
 grep -F 'alias /usr/share/nginx/runtime/admin-app-runtime-config.js;' \
-	"${ROOT}/deploy/nginx/snippets/hfl-ops-spa-locations.conf" >/dev/null
+	"${ROOT}/deploy/nginx/web.conf" >/dev/null
 grep -F '<script src="/app-runtime-config.js"></script>' \
 	"${ROOT}/src/frontend/index.html" >/dev/null
 grep -F 'PROD_GA_MEASUREMENT_ID' \


### PR DESCRIPTION
## Summary

- validate tenant and Admin Console analytics runtime aliases in the internal Web pool configuration
- remove stale assertions against the stable Nginx SPA proxy snippets

## Root cause

Test run [#30726051511](https://github.com/HyperBDR/hyperfilelens/actions/runs/30726051511) stopped in `Quality / Release and source checks` because the GA contract still expected runtime aliases in their pre-blue-green locations.

## Validation

- `tools/quality/test-ga-runtime-config.sh`
- Sentry and payload tree hash contracts
- both synthetic CI release assembly variants
- Kopia build configuration
- development stack upgrade regression checks
- SourceLens Git mirror and submodule recovery checks
- `git diff --check`