### PR TITLE
test(frontend): wait for email code cooldown

### DIFF
--- a/src/frontend/src/components/auth/EmailCodeLoginForm.test.ts
+++ b/src/frontend/src/components/auth/EmailCodeLoginForm.test.ts
@@ -90,6 +90,9 @@ describe('EmailCodeLoginForm', () => {
     const wrapper = mountForm('person@example.com')
     await wrapper.get('.email-code-login-form__send').trigger('click')
     await flushPromises()
+    await vi.waitFor(() => {
+      expect(wrapper.get('.email-code-login-form__send').text()).toContain('60s')
+    })
 
     const codeInput = wrapper.get<HTMLInputElement>('#email-code-login-code')
     await codeInput.setValue('123456')
@@ -141,6 +144,9 @@ describe('EmailCodeLoginForm', () => {
     const wrapper = mountForm('person@example.com')
     await wrapper.get('.email-code-login-form__send').trigger('click')
     await flushPromises()
+    await vi.waitFor(() => {
+      expect(wrapper.get('.email-code-login-form__send').text()).toContain('60s')
+    })
 
     const codeInput = wrapper.get<HTMLInputElement>('#email-code-login-code')
     await codeInput.setValue('123456')


### PR DESCRIPTION
## Summary

- wait for the email-code send lifecycle to finish before asserting that verification is enabled
- align the two racy cases with the existing cooldown restoration tests

## Root cause

Test run [#30727155738](https://github.com/HyperBDR/hyperfilelens/actions/runs/30727155738) intermittently observed the submit button while Web Crypto fingerprinting and cooldown persistence still kept the form in its sending state.

## Validation

- affected test file repeated 20 times successfully
- complete frontend suite: 127 files and 600 tests
- frontend lint
- TypeScript and production build
- `git diff --check`