### PR TITLE
fix(release): include blue-green state in CI packages

### DIFF
--- a/release/build.sh
+++ b/release/build.sh
@@ -1022,6 +1022,10 @@ validate_release_publish_artifacts() {
 	local enroll="${pkg_root}/payload/media/enroll-bootstrap"
 	[[ -f "${pkg_root}/deploy/nginx/web.conf" ]] \
 		|| die "release package missing internal Web pool configuration"
+	[[ -f "${pkg_root}/deploy/nginx/snippets/hfl-active-upstreams.conf" ]] \
+		|| die "release package missing blue/green upstream configuration"
+	[[ -f "${pkg_root}/deploy/blue-green/active-color" ]] \
+		|| die "release package missing blue/green initial state"
 	[[ -d "${releases}" && -n "$(ls -A "${releases}" 2>/dev/null)" ]] \
 		|| die "release package missing agent-releases artifacts"
 	[[ -d "${enroll}" && -n "$(ls -A "${enroll}" 2>/dev/null)" ]] \

--- a/release/ci/assemble-release.sh
+++ b/release/ci/assemble-release.sh
@@ -118,11 +118,16 @@ printf '%s\n' "${version}" >"${pkg_root}/VERSION"
 cp "${ROOT}/deploy/docker-compose.yml" "${pkg_root}/docker-compose.yml"
 cp "${ROOT}/.env.example" "${pkg_root}/.env.example"
 cp "${ROOT}/LICENSE" "${pkg_root}/LICENSE"
-mkdir -p "${pkg_root}/deploy/nginx/certs" "${pkg_root}/deploy/nginx/snippets" "${pkg_root}/deploy/logrotate"
+mkdir -p \
+	"${pkg_root}/deploy/nginx/certs" \
+	"${pkg_root}/deploy/nginx/snippets" \
+	"${pkg_root}/deploy/blue-green" \
+	"${pkg_root}/deploy/logrotate"
 stage_default_tls_bundle "${pkg_root}"
 cp "${ROOT}/deploy/nginx/default.conf" "${pkg_root}/deploy/nginx/default.conf"
 cp "${ROOT}/deploy/nginx/web.conf" "${pkg_root}/deploy/nginx/web.conf"
 rsync -a "${ROOT}/deploy/nginx/snippets/" "${pkg_root}/deploy/nginx/snippets/"
+cp "${ROOT}/deploy/blue-green/active-color" "${pkg_root}/deploy/blue-green/active-color"
 cp "${ROOT}/deploy/logrotate/hyperfilelens.conf" "${pkg_root}/deploy/logrotate/hyperfilelens.conf"
 cp "${ROOT}/deploy/installer/install.sh" "${pkg_root}/install.sh"
 cp "${ROOT}/deploy/installer/apply-runtime-config.py" "${pkg_root}/apply-runtime-config.py"

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -745,6 +745,8 @@ grep -F '/opt/hyperfilelens/install.sh manage ensure_platform_ai_model' \
 	"${ROOT}/.github/workflows/deploy_target.yml" >/dev/null
 grep -F 'deploy/nginx/web.conf' "${ROOT}/deploy/installer/install.sh" >/dev/null
 grep -F 'deploy/blue-green/active-color' "${ROOT}/release/build.sh" >/dev/null
+grep -F 'deploy/blue-green/active-color' "${ROOT}/release/ci/assemble-release.sh" >/dev/null
+grep -F 'release package missing blue/green initial state' "${ROOT}/release/build.sh" >/dev/null
 grep -F 'api:8000' "${ROOT}/deploy/nginx/development-upstreams.conf" >/dev/null
 grep -F 'ws_recovery_gate drain' "${ROOT}/deploy/installer/install.sh" >/dev/null
 grep -F 'args=(reattach --timeout' "${ROOT}/deploy/installer/install.sh" >/dev/null


### PR DESCRIPTION
## Summary
- include the repository-pinned blue/green initial color in CI-assembled offline packages
- validate both the active upstream and initial color before publishing
- extend release contract checks to cover the CI assembly path

## Validation
- `git diff --check`
- `bash -n release/ci/assemble-release.sh release/build.sh tools/quality/check-release-contracts.sh`
- `./tools/quality/check-release-contracts.sh`