### PR TITLE
fix(installer): distinguish staged SourceLens bundles

### DIFF
--- a/deploy/installer/install.sh
+++ b/deploy/installer/install.sh
@@ -2359,7 +2359,13 @@ package_has_sourcelens_dir() {
 }
 
 sourcelens_installed() {
-	[[ -f "${SOURCELENS_INSTALL_DIR}/docker-compose.yml" ]]
+	# Release packages stage the SourceLens Compose file before the bundled
+	# installer has created its runtime configuration.  Treat that bundle as an
+	# installation only after the Compose env symlink (or legacy regular file)
+	# exists; otherwise first install would try to stop a stack that has never
+	# been configured.
+	[[ -f "${SOURCELENS_INSTALL_DIR}/docker-compose.yml" \
+		&& -f "${SOURCELENS_INSTALL_DIR}/.env" ]]
 }
 
 sourcelens_compose() {

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -747,6 +747,11 @@ grep -F 'deploy/nginx/web.conf' "${ROOT}/deploy/installer/install.sh" >/dev/null
 grep -F 'deploy/blue-green/active-color' "${ROOT}/release/build.sh" >/dev/null
 grep -F 'deploy/blue-green/active-color' "${ROOT}/release/ci/assemble-release.sh" >/dev/null
 grep -F 'release package missing blue/green initial state' "${ROOT}/release/build.sh" >/dev/null
+sourcelens_installed_body="$(
+	sed -n '/^sourcelens_installed()/,/^}/p' "${ROOT}/deploy/installer/install.sh"
+)"
+grep -F 'SOURCELENS_INSTALL_DIR}/docker-compose.yml' <<<"${sourcelens_installed_body}" >/dev/null
+grep -F 'SOURCELENS_INSTALL_DIR}/.env' <<<"${sourcelens_installed_body}" >/dev/null
 grep -F 'api:8000' "${ROOT}/deploy/nginx/development-upstreams.conf" >/dev/null
 grep -F 'ws_recovery_gate drain' "${ROOT}/deploy/installer/install.sh" >/dev/null
 grep -F 'args=(reattach --timeout' "${ROOT}/deploy/installer/install.sh" >/dev/null


### PR DESCRIPTION
## Summary
- distinguish a staged SourceLens release bundle from a configured installation
- avoid running Docker Compose against a missing SourceLens runtime environment during first install
- enforce the runtime installation-state contract in release checks

## Validation
- `git diff --check`
- `bash -n deploy/installer/install.sh tools/quality/check-release-contracts.sh`
- `./tools/quality/check-release-contracts.sh`
- sourced installer state matrix: no files, Compose only, Compose + env, removed env