### PR TITLE
fix(gateway): stabilize chat readiness and agent CLI

### DIFF
--- a/src/agent/cmd/agent/main.go
+++ b/src/agent/cmd/agent/main.go
@@ -63,6 +63,12 @@ func runDaemon(args []string) error {
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
+	if fs.NArg() != 0 {
+		return fmt.Errorf(
+			"unexpected daemon argument %q; use 'hfl-agent help' for supported commands",
+			fs.Arg(0),
+		)
+	}
 
 	if *printVersion {
 		fmt.Printf("hyperfilelens-agent %s (%s)\n", selfupdate.Version, selfupdate.Commit)

--- a/src/agent/cmd/agent/main_test.go
+++ b/src/agent/cmd/agent/main_test.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRunDaemonRejectsUnexpectedPositionalArgument(t *testing.T) {
+	err := runDaemon([]string{"version"})
+	if err == nil || !strings.Contains(err.Error(), "unexpected daemon argument") {
+		t.Fatalf("unexpected positional argument was not rejected: %v", err)
+	}
+}

--- a/src/agent/internal/cli/root.go
+++ b/src/agent/internal/cli/root.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"hyperfilelens/agent/internal/infra/config"
+	"hyperfilelens/agent/internal/selfupdate"
 )
 
 // Run dispatches `hfl-agent <command> ...` subcommands.
@@ -16,6 +17,17 @@ func Run(args []string) error {
 		return nil
 	}
 	switch args[0] {
+	case "version":
+		if len(args) != 1 {
+			return fmt.Errorf("version does not accept arguments")
+		}
+		_, _ = fmt.Fprintf(
+			os.Stdout,
+			"hyperfilelens-agent %s (%s)\n",
+			selfupdate.Version,
+			selfupdate.Commit,
+		)
+		return nil
 	case "config":
 		return config.RunCLI(context.Background(), args[1:])
 	case "tasks":
@@ -38,6 +50,7 @@ func printRootHelp() {
 
 Usage:
   hfl-agent run [flags]             Run agent daemon (WebSocket control plane)
+  hfl-agent version                 Print version and exit
   hfl-agent help                    Show this help
   hfl-agent config show|set|paths   Manage hot-reloadable configuration
   hfl-agent fs ls [path]            List local directory entries
@@ -117,7 +130,7 @@ func parseWireStatus(s string) (string, error) {
 // IsSubcommand reports whether arg is a CLI subcommand (not daemon flags).
 func IsSubcommand(arg string) bool {
 	switch arg {
-	case "help", "-h", "--help", "config", "tasks", "fs", "snapshot", "restore", "repo":
+	case "help", "-h", "--help", "version", "config", "tasks", "fs", "snapshot", "restore", "repo":
 		return true
 	default:
 		return false

--- a/src/agent/internal/cli/root_test.go
+++ b/src/agent/internal/cli/root_test.go
@@ -1,0 +1,9 @@
+package cli
+
+import "testing"
+
+func TestVersionIsARealSubcommand(t *testing.T) {
+	if !IsSubcommand("version") {
+		t.Fatal("version must be dispatched as a short-lived CLI command")
+	}
+}

--- a/src/backend/apps/lens_bridge/services/knowledge_source_sync.py
+++ b/src/backend/apps/lens_bridge/services/knowledge_source_sync.py
@@ -558,8 +558,10 @@ def _run_phase_push_assistant(
     ).gateway_link
     lensnode_uuid = gateway_link.sl_lensnode_uuid
     if lensnode_uuid:
-        for path in indexed_dir_paths(ks):
-            provisioning.wait_for_lensnode_dir(lensnode_uuid=lensnode_uuid, path=path)
+        provisioning.wait_for_lensnode_ready(
+            lensnode_uuid=lensnode_uuid,
+            workspace_root=gateway_link.resolved_workspace_root(),
+        )
     provisioning.sync_linked_assistant_for_ks(
         org=org,
         ks=ks,

--- a/src/backend/apps/lens_bridge/tests/test_knowledge_source_sync.py
+++ b/src/backend/apps/lens_bridge/tests/test_knowledge_source_sync.py
@@ -1,6 +1,9 @@
+from unittest.mock import MagicMock, patch
+
 from django.test import SimpleTestCase
 
 from apps.lens_bridge.services.knowledge_source_sync import (
+    _run_phase_push_assistant,
     _restore_selected_paths,
     map_scope_to_workspace,
 )
@@ -71,4 +74,49 @@ class MapScopeToWorkspaceTests(SimpleTestCase):
                 scope_path="/data",
             ),
             [],
+        )
+
+
+class PushAssistantPhaseTests(SimpleTestCase):
+    @patch(
+        "apps.lens_bridge.services.knowledge_source_sync."
+        "provisioning.sync_linked_assistant_for_ks"
+    )
+    @patch(
+        "apps.lens_bridge.services.knowledge_source_sync."
+        "provisioning.wait_for_lensnode_ready"
+    )
+    @patch(
+        "apps.lens_bridge.services.knowledge_source_sync."
+        "context_for_knowledge_source"
+    )
+    @patch("apps.lens_bridge.services.knowledge_source_sync._update_sync_phase")
+    def test_waits_for_authoritative_gateway_workspace_root(
+        self,
+        _update_phase,
+        context_for_source,
+        wait_for_ready,
+        sync_assistant,
+    ):
+        organization = MagicMock()
+        knowledge_source = MagicMock()
+        gateway_link = MagicMock()
+        gateway_link.sl_lensnode_uuid = "de240f46-eccd-4e4b-868f-b1f504fbe67b"
+        gateway_link.resolved_workspace_root.return_value = "/workspace/org-34/data"
+        context_for_source.return_value = MagicMock(gateway_link=gateway_link)
+
+        _run_phase_push_assistant(
+            org=organization,
+            ks=knowledge_source,
+            sync_state={},
+        )
+
+        wait_for_ready.assert_called_once_with(
+            lensnode_uuid=gateway_link.sl_lensnode_uuid,
+            workspace_root="/workspace/org-34/data",
+        )
+        sync_assistant.assert_called_once_with(
+            org=organization,
+            ks=knowledge_source,
+            gateway_link=gateway_link,
         )


### PR DESCRIPTION
## Summary
- align knowledge-source push with the authoritative LensNode workspace-root readiness check
- add a real `hfl-agent version` command and reject unexpected daemon arguments
- cover Gateway readiness and Agent CLI dispatch with regression tests

## Validation
- 53 targeted backend Gateway/Workspace/Restore tests
- complete Agent Go test suite
- private Gateway prepare/cleanup verification on 192.168.14.137 with a single Agent process
- English-only source check and `git diff --check`