### PR TITLE
fix(ci): support SourceLens email login fields

### DIFF
--- a/tools/dev/browser-smoke.mjs
+++ b/tools/dev/browser-smoke.mjs
@@ -275,7 +275,8 @@ async function verifyResponsiveConsoles(browser, storageState, tenantBaseUrl, ad
 async function waitForSourceLensLogin(page, baseUrl) {
   await page.goto(`${baseUrl}/login`, { waitUntil: 'networkidle' })
   const username = page.locator(
-    'input[name="username"], input[autocomplete="username"], input[type="text"]',
+    'input[name="username"], input[name="email"], input[autocomplete="username"], '
+    + 'input[autocomplete="email"], input[type="email"], input[type="text"]',
   ).first()
   if (!(await username.isVisible())) {
     const switchButton = page.locator('button.block.w-full.text-center')

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -1122,6 +1122,8 @@ grep -F 'HFL_LOGIN_PORT="${login_port}"' "${smoke_runner}" >/dev/null
 smoke_script="${ROOT}/tools/dev/browser-smoke.mjs"
 grep -F 'host.docker.internal' "${smoke_script}" >/dev/null
 grep -F "submit.waitFor({ state: 'visible'" "${smoke_script}" >/dev/null
+grep -F 'input[autocomplete="email"]' "${smoke_script}" >/dev/null
+grep -F 'input[type="email"]' "${smoke_script}" >/dev/null
 if grep -F 'captchaImage' "${smoke_script}" >/dev/null; then
 	printf 'ERROR: local browser smoke must not depend on image captcha\n' >&2
 	exit 1


### PR DESCRIPTION
## Summary
- recognize the email input semantics used by the SourceLens v0.20 login page
- retain compatibility with older username/text login fields
- enforce both email selectors in the release smoke contract

## Validation
- `git diff --check`
- `node --check tools/dev/browser-smoke.mjs`
- `bash -n tools/quality/check-release-contracts.sh`
- `./tools/quality/check-release-contracts.sh`
- `python3 tools/quality/check-english-source.py`