### PR TITLE
fix(ci): select SourceLens password login mode

### DIFF
--- a/tools/dev/browser-smoke.mjs
+++ b/tools/dev/browser-smoke.mjs
@@ -278,12 +278,21 @@ async function waitForSourceLensLogin(page, baseUrl) {
     'input[name="username"], input[name="email"], input[autocomplete="username"], '
     + 'input[autocomplete="email"], input[type="email"], input[type="text"]',
   ).first()
-  if (!(await username.isVisible())) {
+  const password = page.locator(
+    'input[name="password"], input[autocomplete="current-password"], input[type="password"]',
+  ).first()
+  // SourceLens v0.20 opens in email-code mode, where the email field is already
+  // visible.  Password visibility is the stable signal that password mode is
+  // active across old and new SourceLens releases.
+  if (!(await password.isVisible())) {
     const switchButton = page.locator('button.block.w-full.text-center')
     await switchButton.click()
   }
   try {
-    await username.waitFor({ state: 'visible', timeout: 10_000 })
+    await Promise.all([
+      username.waitFor({ state: 'visible', timeout: 10_000 }),
+      password.waitFor({ state: 'visible', timeout: 10_000 }),
+    ])
   } catch {
     const buttons = await page.locator('button').allTextContents()
     const body = (await page.locator('body').innerText()).slice(0, 1_500)
@@ -293,9 +302,7 @@ async function waitForSourceLensLogin(page, baseUrl) {
     )
   }
   await username.fill(sourceLensUser)
-  await page.locator(
-    'input[name="password"], input[autocomplete="current-password"], input[type="password"]',
-  ).first().fill(sourceLensPassword)
+  await password.fill(sourceLensPassword)
   await page.locator('form button[type="submit"]').click()
   await page.waitForURL(url => !url.pathname.startsWith('/login'), { timeout: 60_000 })
 }

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -1124,6 +1124,7 @@ grep -F 'host.docker.internal' "${smoke_script}" >/dev/null
 grep -F "submit.waitFor({ state: 'visible'" "${smoke_script}" >/dev/null
 grep -F 'input[autocomplete="email"]' "${smoke_script}" >/dev/null
 grep -F 'input[type="email"]' "${smoke_script}" >/dev/null
+grep -F 'if (!(await password.isVisible()))' "${smoke_script}" >/dev/null
 if grep -F 'captchaImage' "${smoke_script}" >/dev/null; then
 	printf 'ERROR: local browser smoke must not depend on image captcha\n' >&2
 	exit 1


### PR DESCRIPTION
## Summary
- detect SourceLens password-login mode by password visibility instead of the shared email field
- switch from the v0.20 default email-code mode before filling credentials
- wait for both login fields and retain older SourceLens compatibility

## Validation
- `git diff --check`
- `node --check tools/dev/browser-smoke.mjs`
- `bash -n tools/quality/check-release-contracts.sh`
- `./tools/quality/check-release-contracts.sh`
- `python3 tools/quality/check-english-source.py`