### PR TITLE
fix(ci): use SourceLens seeded email in smoke

### DIFF
--- a/tools/dev/browser-smoke.sh
+++ b/tools/dev/browser-smoke.sh
@@ -45,6 +45,13 @@ fi
 cache_dir="${ROOT}/build/cache/playwright-node-${version}"
 mkdir -p "${cache_dir}"
 source_lens_env="${SMOKE_SOURCELENS_ENV_FILE:-${ROOT}/data/sourcelens/config/.env}"
+source_lens_user="${SOURCELENS_USER:-}"
+if [[ -z "${source_lens_user}" ]]; then
+	source_lens_user="$(read_file_default "${source_lens_env}" DJANGO_SUPERUSER_EMAIL '')"
+fi
+if [[ -z "${source_lens_user}" ]]; then
+	source_lens_user="$(read_file_default "${source_lens_env}" DJANGO_SUPERUSER_USERNAME admin)"
+fi
 smoke_host="${SMOKE_HOST:-host.docker.internal}"
 tenant_port="$(read_default HFL_TENANT_PORT 11443)"
 login_port="$(read_default HFL_LOGIN_PORT "${tenant_port}")"
@@ -62,7 +69,7 @@ docker run --rm \
 	-e SOURCELENS_CONSOLE_PORT="$(read_default SOURCELENS_CONSOLE_PORT 11445)" \
 	-e SEED_ADMIN_EMAIL="$(read_default SEED_ADMIN_EMAIL admin@hyperfilelens.com)" \
 	-e SEED_ADMIN_PASSWORD="$(read_default SEED_ADMIN_PASSWORD 'Admin@123')" \
-	-e SOURCELENS_USER="$(read_file_default "${source_lens_env}" DJANGO_SUPERUSER_USERNAME admin)" \
+	-e SOURCELENS_USER="${source_lens_user}" \
 	-e SOURCELENS_PASSWORD="$(read_file_default "${source_lens_env}" DJANGO_SUPERUSER_PASSWORD adminpassword)" \
 	-e SMOKE_REQUIRE_HMR="${SMOKE_REQUIRE_HMR:-1}" \
 	-e SMOKE_SKIP_SOURCELENS="${SMOKE_SKIP_SOURCELENS:-0}" \

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -1119,6 +1119,8 @@ smoke_runner="${ROOT}/tools/dev/browser-smoke.sh"
 grep -F -- '--add-host host.docker.internal:host-gateway' "${smoke_runner}" >/dev/null
 grep -F 'SMOKE_HOST' "${smoke_runner}" >/dev/null
 grep -F 'HFL_LOGIN_PORT="${login_port}"' "${smoke_runner}" >/dev/null
+grep -F 'DJANGO_SUPERUSER_EMAIL' "${smoke_runner}" >/dev/null
+grep -F 'DJANGO_SUPERUSER_USERNAME' "${smoke_runner}" >/dev/null
 smoke_script="${ROOT}/tools/dev/browser-smoke.mjs"
 grep -F 'host.docker.internal' "${smoke_script}" >/dev/null
 grep -F "submit.waitFor({ state: 'visible'" "${smoke_script}" >/dev/null


### PR DESCRIPTION
## Summary
- authenticate SourceLens v0.20 browser smoke with its seeded superuser email
- retain username fallback for older SourceLens bundles
- preserve an explicit `SOURCELENS_USER` override

## Validation
- `git diff --check`
- `bash -n tools/dev/browser-smoke.sh tools/quality/check-release-contracts.sh`
- `./tools/quality/check-release-contracts.sh`
- `python3 tools/quality/check-english-source.py`
- `shellcheck tools/dev/browser-smoke.sh`