### PR TITLE
fix(gateway): harden workspace and upgrade readiness

### DIFF
--- a/deploy/docker/backend-entrypoint.sh
+++ b/deploy/docker/backend-entrypoint.sh
@@ -104,12 +104,15 @@ require_watchfiles() {
   }
 }
 
+DEV_WATCH_IGNORE_PATHS="/opt/backend/media,/opt/backend/staticfiles,/opt/backend/lang-packs"
+
 run_api_dev() {
   ensure_log_dir
   wait_for_postgres
   require_watchfiles
   echo "[entrypoint] watch backend source and restart HTTP/WebSocket API"
-  exec watchfiles --filter python "/entrypoint.sh api" /opt/backend
+  exec watchfiles --filter python --ignore-paths "${DEV_WATCH_IGNORE_PATHS}" \
+    "/entrypoint.sh api" /opt/backend
 }
 
 run_worker_dev() {
@@ -118,7 +121,7 @@ run_worker_dev() {
   run_migrations_and_register
   require_watchfiles
   echo "[entrypoint] watch backend source and restart celery worker"
-  exec watchfiles --filter python \
+  exec watchfiles --filter python --ignore-paths "${DEV_WATCH_IGNORE_PATHS}" \
     "celery -A common worker --loglevel=INFO -Q backend,node.lifecycle,node.ingest,source.remote-io,storage.provider-validation" \
     /opt/backend
 }
@@ -128,7 +131,7 @@ run_scheduler_dev() {
   wait_for_postgres
   require_watchfiles
   echo "[entrypoint] watch backend source and restart celery scheduler"
-  exec watchfiles --filter python \
+  exec watchfiles --filter python --ignore-paths "${DEV_WATCH_IGNORE_PATHS}" \
     "celery -A common beat --scheduler django_celery_beat.schedulers:DatabaseScheduler --loglevel=INFO" \
     /opt/backend
 }

--- a/src/backend/apps/lens_bridge/services/gateway_execution.py
+++ b/src/backend/apps/lens_bridge/services/gateway_execution.py
@@ -176,14 +176,11 @@ def create_workspace_binding(
     )
     root = context.gateway_link.resolved_workspace_root()
     workspace_uid = uuid.uuid4()
-    relative_path = (
-        ""
-        if gateway_local
-        else (
-            f"tenants/{tenant_organization.id}/knowledge-sources/"
-            f"{workspace_uid}"
-        )
-    )
+    # SourceLens advertises and accepts only direct children of the LensNode
+    # workspace root as selectable directories. Keep the immutable UUID in the
+    # directory name so shared Platform Gateways remain collision-free without
+    # nesting tenant data below paths SourceLens cannot select.
+    relative_path = "" if gateway_local else f"hfl-ks-{workspace_uid}"
     binding, created = LensWorkspaceBinding.objects.get_or_create(
         organization=tenant_organization,
         knowledge_source=knowledge_source,

--- a/src/backend/apps/lens_bridge/services/knowledge_source_sync.py
+++ b/src/backend/apps/lens_bridge/services/knowledge_source_sync.py
@@ -561,6 +561,9 @@ def _run_phase_push_assistant(
         provisioning.wait_for_lensnode_ready(
             lensnode_uuid=lensnode_uuid,
             workspace_root=gateway_link.resolved_workspace_root(),
+            selected_dir=(
+                None if is_gateway_local_ks(ks) else ks.workspace_path_on_lensnode
+            ),
         )
     provisioning.sync_linked_assistant_for_ks(
         org=org,

--- a/src/backend/apps/lens_bridge/services/provisioning.py
+++ b/src/backend/apps/lens_bridge/services/provisioning.py
@@ -28,7 +28,7 @@ from apps.node.models.node import Node
 
 logger = logging.getLogger(__name__)
 
-_LENSNODE_DIR_WAIT_SECONDS = 30.0
+_LENSNODE_DIR_WAIT_SECONDS = 60.0
 _LENSNODE_DIR_POLL_SECONDS = 0.5
 LENSNODE_PROVISION_CLAIM_TTL_SECONDS = 300
 
@@ -149,6 +149,7 @@ def _lensnode_matches_workspace(
     *,
     lensnode_uuid: uuid.UUID,
     workspace_root: str,
+    selected_dir: str | None = None,
 ) -> bool:
     reported_uuid = str(lensnode_data.get("uuid") or "").strip().lower()
     reported_status = str(lensnode_data.get("status") or "").strip().lower()
@@ -156,20 +157,35 @@ def _lensnode_matches_workspace(
         str(lensnode_data.get("workspace_path") or "").strip()
     )
     expected_root = posixpath.normpath(str(workspace_root or "").strip())
-    return (
+    matches = (
         reported_uuid == str(lensnode_uuid).lower()
         and reported_status == "online"
         and reported_root == expected_root
     )
+    if not matches or not selected_dir:
+        return matches
+    expected_dir = posixpath.normpath(str(selected_dir).strip())
+    available_dirs = lensnode_data.get("available_dirs") or []
+    reported_dirs = {
+        posixpath.normpath(
+            str(
+                item if isinstance(item, str) else item.get("path") or ""
+            ).strip()
+        )
+        for item in available_dirs
+        if isinstance(item, (str, dict))
+    }
+    return expected_dir in reported_dirs
 
 
 def wait_for_lensnode_ready(
     *,
     lensnode_uuid: uuid.UUID,
     workspace_root: str,
+    selected_dir: str | None = None,
     timeout_s: float = _LENSNODE_DIR_WAIT_SECONDS,
 ) -> None:
-    """Wait for the enrolled LensNode at its configured workspace root."""
+    """Wait for the LensNode and, when provided, one selectable directory."""
 
     deadline = time.monotonic() + timeout_s
     while time.monotonic() < deadline:
@@ -178,16 +194,17 @@ def wait_for_lensnode_ready(
             data,
             lensnode_uuid=lensnode_uuid,
             workspace_root=workspace_root,
+            selected_dir=selected_dir,
         ):
             return
         time.sleep(_LENSNODE_DIR_POLL_SECONDS)
+    detail = (
+        f"LensNode did not advertise selectable workspace: {selected_dir}."
+        if selected_dir
+        else f"LensNode did not become ready at workspace root: {workspace_root}."
+    )
     raise ValidationError(
-        {
-            "workspace": (
-                f"LensNode did not become ready at workspace root: {workspace_root}. "
-                "Ensure the AI engine is online and retry."
-            )
-        }
+        {"workspace": f"{detail} Ensure the AI engine is online and retry."}
     )
 
 
@@ -253,7 +270,11 @@ def ensure_ks_workspace_on_gateway(
         update_fields=["identity_status", "last_error", "updated_at"]
     )
 
-    wait_for_lensnode_ready(lensnode_uuid=lensnode_uuid, workspace_root=root)
+    wait_for_lensnode_ready(
+        lensnode_uuid=lensnode_uuid,
+        workspace_root=root,
+        selected_dir=workspace_path,
+    )
 
 
 def pick_lensnode_task(lensnode_uuid: uuid.UUID) -> str:

--- a/src/backend/apps/lens_bridge/tests/test_knowledge_source_sync.py
+++ b/src/backend/apps/lens_bridge/tests/test_knowledge_source_sync.py
@@ -99,7 +99,11 @@ class PushAssistantPhaseTests(SimpleTestCase):
         sync_assistant,
     ):
         organization = MagicMock()
-        knowledge_source = MagicMock()
+        knowledge_source = MagicMock(
+            backup_source_snapshot_id=1,
+            backup_snapshot_directory_id=1,
+            workspace_path_on_lensnode="/workspace/org-34/data/hfl-ks-ready",
+        )
         gateway_link = MagicMock()
         gateway_link.sl_lensnode_uuid = "de240f46-eccd-4e4b-868f-b1f504fbe67b"
         gateway_link.resolved_workspace_root.return_value = "/workspace/org-34/data"
@@ -114,6 +118,7 @@ class PushAssistantPhaseTests(SimpleTestCase):
         wait_for_ready.assert_called_once_with(
             lensnode_uuid=gateway_link.sl_lensnode_uuid,
             workspace_root="/workspace/org-34/data",
+            selected_dir="/workspace/org-34/data/hfl-ks-ready",
         )
         sync_assistant.assert_called_once_with(
             org=organization,

--- a/src/backend/apps/lens_bridge/tests/test_provisioning.py
+++ b/src/backend/apps/lens_bridge/tests/test_provisioning.py
@@ -242,6 +242,32 @@ class LensnodeWorkspaceReadinessTests(SimpleTestCase):
             )
         )
 
+    def test_requires_selected_directory_to_be_advertised(self):
+        data = {
+            "uuid": self.lensnode_uuid,
+            "status": "online",
+            "workspace_path": "/workspace/org-1",
+            "available_dirs": [
+                {"path": "/workspace/org-1/hfl-ks-ready"},
+            ],
+        }
+        self.assertTrue(
+            _lensnode_matches_workspace(
+                data,
+                lensnode_uuid=self.lensnode_uuid,
+                workspace_root="/workspace/org-1",
+                selected_dir="/workspace/org-1/hfl-ks-ready",
+            )
+        )
+        self.assertFalse(
+            _lensnode_matches_workspace(
+                data,
+                lensnode_uuid=self.lensnode_uuid,
+                workspace_root="/workspace/org-1",
+                selected_dir="/workspace/org-1/nested/hfl-ks-missing",
+            )
+        )
+
 
 class SlLensnodeSnapshotTests(SimpleTestCase):
     def test_extracts_display_fields(self):
@@ -309,7 +335,11 @@ class EnsureKsWorkspaceTests(SimpleTestCase):
         self.assertEqual(kwargs["payload"]["path"], "/workspace/org-1/ks-9")
         self.assertEqual(kwargs["payload"]["workspace_uid"], "workspace-9")
         self.assertEqual(kwargs["requesting_organization_id"], 1)
-        mock_wait.assert_called_once()
+        mock_wait.assert_called_once_with(
+            lensnode_uuid=link.sl_lensnode_uuid,
+            workspace_root="/workspace/org-1",
+            selected_dir="/workspace/org-1/ks-9",
+        )
 
 
 class BrowseGatewayDirectoryTests(SimpleTestCase):

--- a/src/backend/apps/node/services/internal/agent_release.py
+++ b/src/backend/apps/node/services/internal/agent_release.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import json
 import os
 import re
+import tarfile
+import zipfile
 from pathlib import Path
 
 from django.conf import settings
@@ -139,6 +142,63 @@ def version_has_dist(
     ubuntu_release = ubuntu_bundle_release(role, platform, os_version)
     filename = dist_filename(version, platform, arch, ubuntu_release=ubuntu_release)
     return (root / version / filename).is_file()
+
+
+def agent_release_commit(
+    version: str,
+    platform: str,
+    arch: str,
+    *,
+    role: str | None = None,
+    os_version: str | None = None,
+) -> str:
+    """Read the immutable build commit embedded in a published Agent bundle."""
+
+    ubuntu_release = ubuntu_bundle_release(role, platform, os_version)
+    archive = agent_releases_root() / version / dist_filename(
+        version,
+        platform,
+        arch,
+        ubuntu_release=ubuntu_release,
+    )
+    try:
+        if archive.suffix == ".zip":
+            with zipfile.ZipFile(archive) as bundle:
+                names = [
+                    name
+                    for name in bundle.namelist()
+                    if name.endswith("/MANIFEST.json")
+                ]
+                if len(names) != 1:
+                    return ""
+                if bundle.getinfo(names[0]).file_size > 1024 * 1024:
+                    return ""
+                raw = bundle.read(names[0])
+        else:
+            with tarfile.open(archive, "r:gz") as bundle:
+                member = next(
+                    (
+                        item
+                        for item in bundle
+                        if item.isfile() and item.name.endswith("/MANIFEST.json")
+                    ),
+                    None,
+                )
+                if member is None or member.size > 1024 * 1024:
+                    return ""
+                extracted = bundle.extractfile(member)
+                if extracted is None:
+                    return ""
+                raw = extracted.read()
+        manifest = json.loads(raw)
+    except (OSError, tarfile.TarError, zipfile.BadZipFile, json.JSONDecodeError):
+        return ""
+    if not isinstance(manifest, dict):
+        return ""
+    if str(manifest.get("agent_version") or "").strip() != version:
+        return ""
+    commit = str(manifest.get("agent_commit") or "").strip().lower()
+    return commit if re.fullmatch(r"[0-9a-f]{40}", commit) else ""
 
 
 def _dir_has_any_agent_archive(version_dir: Path) -> bool:

--- a/src/backend/apps/node/services/internal/node_lifecycle.py
+++ b/src/backend/apps/node/services/internal/node_lifecycle.py
@@ -17,12 +17,20 @@ from apps.node.models import Node, NodeTask
 from apps.node.models.base import NodeRole
 from apps.node.selectors.interface import get_node_task_runtime_info
 from apps.node.selectors.internal.node_task_query import node_tasks_queryset
-from apps.node.services.internal.agent_release import agent_version_compare, is_agent_artifact_id
+from apps.node.services.internal.agent_release import (
+    agent_release_commit,
+    agent_version_compare,
+    is_agent_artifact_id,
+)
 from apps.node.services.internal.agent_task import run_agent_task_async
 from apps.node.services.internal.agent_uninstall import (
     _purge_agent_server_records,
 )
-from apps.node.services.internal.agent_upgrade import validate_agent_upgrade
+from apps.node.services.internal.agent_upgrade import (
+    node_os_version,
+    node_platform_arch,
+    validate_agent_upgrade,
+)
 from apps.node.services.internal.node_registry import agent_session_registered, agent_ws_routable
 from apps.node.services.internal.node_workload import (
     assert_node_available_for_lifecycle,
@@ -102,6 +110,15 @@ def _target_version_from_task(task: NodeTask) -> str:
     return str(payload.get("target_version") or "").strip()
 
 
+def _target_commit_from_task(task: NodeTask) -> str:
+    result = task.result if isinstance(task.result, dict) else {}
+    target = str(result.get("target_commit") or "").strip().lower()
+    if target:
+        return target
+    payload = task.payload if isinstance(task.payload, dict) else {}
+    return str(payload.get("target_commit") or "").strip().lower()
+
+
 def _node_installed_version(node: Node) -> str:
     version = str(node.version or "").strip()
     if version:
@@ -111,6 +128,14 @@ def _node_installed_version(node: Node) -> str:
     if isinstance(inv, dict):
         return str(inv.get("agent_version") or "").strip()
     return str(meta.get("agent_version") or "").strip()
+
+
+def _node_installed_commit(node: Node) -> str:
+    meta = node.metadata if isinstance(node.metadata, dict) else {}
+    inv = meta.get("inventory")
+    if isinstance(inv, dict):
+        return str(inv.get("agent_commit") or "").strip().lower()
+    return str(meta.get("agent_commit") or "").strip().lower()
 
 
 def _node_capabilities(node: Node) -> set[str]:
@@ -165,11 +190,19 @@ def _force_purge_without_remote_uninstall(
     }
 
 
-def _version_matches_target(*, node: Node, target_version: str) -> bool:
+def _version_matches_target(
+    *,
+    node: Node,
+    target_version: str,
+    target_commit: str = "",
+) -> bool:
     current = _node_installed_version(node)
     if not is_agent_artifact_id(target_version) or not is_agent_artifact_id(current):
         return False
-    return agent_version_compare(current, target_version) >= 0
+    if agent_version_compare(current, target_version) < 0:
+        return False
+    expected_commit = str(target_commit or "").strip().lower()
+    return not expected_commit or _node_installed_commit(node) == expected_commit
 
 
 def _is_detached_lifecycle_task(task: NodeTask) -> bool:
@@ -305,10 +338,44 @@ def _upgrade_verify_ready(*, node: Node, task: NodeTask) -> bool:
         return False
     if node.status != Node.Status.ONLINE:
         return False
+    result = task.result if isinstance(task.result, dict) else {}
+    if not result.get("disconnect_observed_at"):
+        return False
     target_version = _target_version_from_task(task)
     if not target_version:
         return False
-    return _version_matches_target(node=node, target_version=target_version)
+    return _version_matches_target(
+        node=node,
+        target_version=target_version,
+        target_commit=_target_commit_from_task(task),
+    )
+
+
+def record_upgrade_disconnect(*, node_id: int) -> bool:
+    """Durably record the effective WS break required by detached upgrade."""
+
+    with transaction.atomic():
+        node = Node.objects.select_related("organization").filter(pk=node_id).first()
+        if node is None:
+            return False
+        candidate = _running_lifecycle_task(
+            org=node.organization,
+            node=node,
+            kind=LIFECYCLE_KIND_UPGRADE,
+        )
+        if candidate is None:
+            return False
+        task = NodeTask.objects.select_for_update().get(pk=candidate.pk)
+        if task.status not in _ACTIVE_TASK_STATUSES or not _is_detached_lifecycle_task(
+            task
+        ):
+            return False
+        result = dict(task.result or {})
+        result["disconnect_observed_at"] = timezone.now().isoformat()
+        result.pop("verify_started_at", None)
+        task.result = result
+        task.save(update_fields=["result", "updated_at"])
+        return True
 
 
 def _advance_upgrade_verify(*, node: Node, task: NodeTask) -> bool:
@@ -379,7 +446,11 @@ def _fail_stale_upgrade_task(*, node: Node, task: NodeTask) -> bool:
     ):
         return False
     target_version = _target_version_from_task(task)
-    if target_version and _version_matches_target(node=node, target_version=target_version):
+    if target_version and _version_matches_target(
+        node=node,
+        target_version=target_version,
+        target_commit=_target_commit_from_task(task),
+    ):
         if _advance_upgrade_verify(node=node, task=task):
             return True
 
@@ -427,10 +498,7 @@ def _upgrade_lifecycle_payload(
         phase = _task_progress_phase(task) or "dispatching"
         if _is_detached_lifecycle_task(task):
             if agent_session_registered(agent_id=node.id):
-                if target_version and _version_matches_target(
-                    node=node,
-                    target_version=target_version,
-                ):
+                if _upgrade_verify_ready(node=node, task=task):
                     return {**base, "state": "verifying", "phase": "waiting_for_version"}
                 return {**base, "state": "upgrading", "phase": phase}
             return {
@@ -455,7 +523,11 @@ def _upgrade_lifecycle_payload(
     if task.status != NodeTask.Status.SUCCESS:
         return None
 
-    if target_version and _version_matches_target(node=node, target_version=target_version):
+    if target_version and _version_matches_target(
+        node=node,
+        target_version=target_version,
+        target_commit=_target_commit_from_task(task),
+    ):
         return None
 
     return {**base, "state": "verifying", "phase": "waiting_for_version"}
@@ -736,11 +808,22 @@ def start_node_upgrade(
         target_version = validate_agent_upgrade(node=node)
     except AgentUpgradeError as exc:
         raise NodeLifecycleError(str(exc), code=exc.code) from exc
+    platform, arch = node_platform_arch(node)
+    target_commit = agent_release_commit(
+        target_version,
+        platform,
+        arch,
+        role=node.role,
+        os_version=node_os_version(node),
+    )
+    payload = {"target_version": target_version}
+    if target_commit:
+        payload["target_commit"] = target_commit
     handle = run_agent_task_async(
         org=org,
         node_id=node.id,
         kind="agent.upgrade",
-        payload={"target_version": target_version},
+        payload=payload,
         correlation_type=node_conf.LIFECYCLE_CORRELATION_TYPE,
         correlation_id=_correlation_id(node_id=node.id, kind=LIFECYCLE_KIND_UPGRADE),
     )
@@ -760,6 +843,7 @@ def start_node_upgrade(
         "state": "upgrading",
         "phase": "dispatching",
         "target_version": target_version,
+        "target_commit": target_commit,
     }
 
 

--- a/src/backend/apps/node/tests/test_agent_release.py
+++ b/src/backend/apps/node/tests/test_agent_release.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
+import io
+import json
+import tarfile
 
 import pytest
 
 from apps.node.services.internal.agent_release import (
+    agent_release_commit,
     agent_version_compare,
     is_main_build,
     latest_published_agent_version,
@@ -82,3 +86,20 @@ def test_main_build_identity_comparison_uses_exact_commit():
     assert agent_version_compare("main-123abcd", "main-123abcd") == 0
     assert agent_version_compare("main-7654321", "main-123abcd") < 0
     assert agent_version_compare("1.0.0", "main-123abcd") < 0
+
+
+def test_agent_release_commit_reads_bundle_manifest(releases_root):
+    version = "1.0.0"
+    commit = "a" * 40
+    version_dir = releases_root / version
+    version_dir.mkdir()
+    archive = version_dir / f"hfl-agent-{version}-linux-amd64.tar.gz"
+    raw = json.dumps(
+        {"agent_version": version, "agent_commit": commit}
+    ).encode()
+    info = tarfile.TarInfo(f"hfl-agent-{version}-linux-amd64/MANIFEST.json")
+    info.size = len(raw)
+    with tarfile.open(archive, "w:gz") as bundle:
+        bundle.addfile(info, io.BytesIO(raw))
+
+    assert agent_release_commit(version, "linux", "amd64") == commit

--- a/src/backend/apps/node/tests/test_node_lifecycle.py
+++ b/src/backend/apps/node/tests/test_node_lifecycle.py
@@ -347,6 +347,24 @@ class NodeLifecycleTests(TestCase):
         self.node.version = "1.2.1"
         self.assertTrue(_version_matches_target(node=self.node, target_version="1.2.0"))
 
+    def test_release_identity_requires_target_commit_when_supplied(self):
+        self.node.version = "1.2.0"
+        self.node.metadata = {"inventory": {"agent_commit": "a" * 40}}
+        self.assertTrue(
+            _version_matches_target(
+                node=self.node,
+                target_version="1.2.0",
+                target_commit="a" * 40,
+            )
+        )
+        self.assertFalse(
+            _version_matches_target(
+                node=self.node,
+                target_version="1.2.0",
+                target_commit="b" * 40,
+            )
+        )
+
     @patch("apps.node.services.internal.node_lifecycle.agent_session_registered", return_value=False)
     def test_same_version_running_task_not_finalized_on_enrich(self, _session):
         task = NodeTask.objects.create(
@@ -380,6 +398,7 @@ class NodeLifecycleTests(TestCase):
                 "target_version": "1.0.0",
                 "mode": "local_detached",
                 "detached_at": timezone.now().isoformat(),
+                "disconnect_observed_at": timezone.now().isoformat(),
                 "verify_started_at": verify_started.isoformat(),
             },
             watchdog_deadline_at=timezone.now() + timezone.timedelta(hours=1),
@@ -389,6 +408,34 @@ class NodeLifecycleTests(TestCase):
         advance_node_lifecycle(org=self.org, node=self.node, user=self.user)
         task.refresh_from_db()
         self.assertEqual(task.status, NodeTask.Status.SUCCESS)
+
+    @patch("apps.node.services.internal.node_lifecycle.agent_session_registered", return_value=True)
+    def test_same_version_does_not_verify_before_disconnect(self, _session):
+        task = NodeTask.objects.create(
+            organization=self.org,
+            node=self.node,
+            kind="agent.upgrade",
+            status=NodeTask.Status.RUNNING,
+            payload={"target_version": "1.0.0"},
+            result={
+                "target_version": "1.0.0",
+                "mode": "local_detached",
+                "detached_at": timezone.now().isoformat(),
+                "verify_started_at": (
+                    timezone.now()
+                    - timezone.timedelta(seconds=node_conf.UPGRADE_STABLE_SECONDS + 1)
+                ).isoformat(),
+            },
+            watchdog_deadline_at=timezone.now() + timezone.timedelta(hours=1),
+            correlation_type=node_conf.LIFECYCLE_CORRELATION_TYPE,
+            correlation_id=f"upgrade:{self.node.id}",
+        )
+
+        advance_node_lifecycle(org=self.org, node=self.node, user=self.user)
+
+        task.refresh_from_db()
+        self.assertEqual(task.status, NodeTask.Status.RUNNING)
+        self.assertNotIn("verify_started_at", task.result or {})
 
     @patch("apps.node.services.internal.node_lifecycle.agent_session_registered", return_value=True)
     def test_upgrade_verify_waits_for_stable_window(self, _session):
@@ -402,6 +449,7 @@ class NodeLifecycleTests(TestCase):
                 "target_version": "1.0.0",
                 "mode": "local_detached",
                 "detached_at": timezone.now().isoformat(),
+                "disconnect_observed_at": timezone.now().isoformat(),
                 "verify_started_at": timezone.now().isoformat(),
             },
             watchdog_deadline_at=timezone.now() + timezone.timedelta(hours=1),
@@ -426,6 +474,7 @@ class NodeLifecycleTests(TestCase):
                 "target_version": "1.0.0",
                 "mode": "local_detached",
                 "detached_at": timezone.now().isoformat(),
+                "disconnect_observed_at": timezone.now().isoformat(),
             },
             watchdog_deadline_at=timezone.now() + timezone.timedelta(hours=1),
             correlation_type=node_conf.LIFECYCLE_CORRELATION_TYPE,
@@ -450,6 +499,7 @@ class NodeLifecycleTests(TestCase):
                 "target_version": "1.0.0",
                 "mode": "local_detached",
                 "detached_at": timezone.now().isoformat(),
+                "disconnect_observed_at": timezone.now().isoformat(),
                 "verify_started_at": timezone.now().isoformat(),
             },
             watchdog_deadline_at=timezone.now() + timezone.timedelta(hours=1),

--- a/src/backend/apps/node/tests/test_node_online_status.py
+++ b/src/backend/apps/node/tests/test_node_online_status.py
@@ -192,6 +192,29 @@ class AgentNodeOnlineStatusTests(TestCase):
         self.assertEqual(task.status, NodeTask.Status.RUNNING)
         self.assertEqual(task.last_error, "")
 
+    def test_ws_disconnect_is_recorded_for_detached_upgrade(self):
+        self._mark_ws_alive()
+        on_agent_connected(node_id=self.node.id, session_id="session-a")
+        task = NodeTask.objects.create(
+            organization=self.org,
+            node=self.node,
+            kind="agent.upgrade",
+            status=NodeTask.Status.RUNNING,
+            result={
+                "target_version": "1.0.0",
+                "mode": "local_detached",
+                "detached_at": timezone.now().isoformat(),
+            },
+            watchdog_deadline_at=timezone.now(),
+            correlation_type=node_conf.LIFECYCLE_CORRELATION_TYPE,
+            correlation_id=f"upgrade:{self.node.id}",
+        )
+
+        on_agent_disconnected(node_id=self.node.id, session_id="session-a")
+
+        task.refresh_from_db()
+        self.assertIn("disconnect_observed_at", task.result or {})
+
     def test_stale_disconnect_after_reconnect_stays_online(self):
         self._mark_ws_alive()
         on_agent_connected(node_id=self.node.id, session_id="session-a")

--- a/src/backend/apps/node/ws/uplink.py
+++ b/src/backend/apps/node/ws/uplink.py
@@ -76,6 +76,16 @@ def on_agent_disconnected(*, node_id: int, session_id: str) -> None:
         node_id,
         session_id,
     )
+    from apps.node.services.internal.node_lifecycle import record_upgrade_disconnect
+
+    try:
+        record_upgrade_disconnect(node_id=node_id)
+    except DatabaseError:
+        logger.warning(
+            "agent upgrade disconnect marker failed node_id=%s",
+            node_id,
+            exc_info=True,
+        )
     _schedule_lifecycle_advance(node_id=node_id)
 
 

--- a/src/backend/apps/restore/tests/test_restore_api.py
+++ b/src/backend/apps/restore/tests/test_restore_api.py
@@ -187,6 +187,14 @@ class RestoreApiTests(TestCase):
             origin=LensGatewayLink.Origin.PLATFORM,
         )
         workspace_binding = self._workspace_binding(gateway_link)
+        self.assertEqual(
+            workspace_binding.relative_path,
+            f"hfl-ks-{workspace_binding.workspace_uid}",
+        )
+        self.assertEqual(
+            workspace_binding.resolved_path(),
+            f"{gateway_link.resolved_workspace_root()}/hfl-ks-{workspace_binding.workspace_uid}",
+        )
         payload = self._manual_restore_payload()
         payload.update(
             {

--- a/tools/quality/test-dev-stack-upgrade.sh
+++ b/tools/quality/test-dev-stack-upgrade.sh
@@ -136,4 +136,11 @@ cmd_restart_body="$(sed -n '/^cmd_restart()/,/^}/p' "${ROOT_REPO}/dev/stack.sh")
 grep -F 'refresh_website_nginx_mount' <<<"${cmd_up_body}" >/dev/null
 grep -F 'refresh_website_nginx_mount' <<<"${cmd_restart_body}" >/dev/null
 
+# Runtime artifacts are mounted below the backend source root in development.
+# Publishing Python helpers into media must not restart API or Celery processes.
+backend_entrypoint="${ROOT_REPO}/deploy/docker/backend-entrypoint.sh"
+grep -F 'DEV_WATCH_IGNORE_PATHS="/opt/backend/media,/opt/backend/staticfiles,/opt/backend/lang-packs"' \
+	"${backend_entrypoint}" >/dev/null
+[[ "$(grep -Fc -- '--ignore-paths "${DEV_WATCH_IGNORE_PATHS}"' "${backend_entrypoint}")" -eq 3 ]]
+
 printf 'Development stack upgrade regression checks passed.\n'


### PR DESCRIPTION
## Summary
- place managed restore workspaces directly below the LensNode root and wait until SourceLens advertises the exact selectable directory
- require a real Agent disconnect/reconnect plus published build commit match before completing detached upgrades
- exclude runtime media/static/lang-pack mounts from development hot reloads

## Validation
- 161 Lens Bridge tests
- 108 Node lifecycle, online-status, and restore tests
- Ruff, compileall, shell syntax, diff checks, and development stack upgrade regression
- published Agent manifest commit check