### PR TITLE
fix(installer): preserve SourceLens runtime bindings

### DIFF
--- a/.github/workflows/artifact_pipeline.yml
+++ b/.github/workflows/artifact_pipeline.yml
@@ -216,6 +216,7 @@ jobs:
           ./tools/quality/test-offline-docker-package-plan.sh
           ./tools/quality/test-upgrade-backup-retention.sh
           ./tools/quality/test-blue-green-recovery.sh
+          ./tools/quality/test-sourcelens-runtime-sync.sh
           ./tools/quality/test-redis-rdb-preflight.sh
           ./tools/quality/test-agent-release-retention.sh
           ./tools/quality/test-managed-image-retention.sh

--- a/deploy/installer/install.sh
+++ b/deploy/installer/install.sh
@@ -2117,6 +2117,44 @@ PY
 	done
 }
 
+repair_sourcelens_runtime_bindings() {
+	local runtime_env="${SOURCELENS_INSTALL_DIR}/.env"
+	local runtime_data="${SOURCELENS_INSTALL_DIR}/data"
+	local persisted_env="${ROOT}/data/sourcelens/config/.env"
+	local persisted_data="${ROOT}/data/sourcelens"
+	local repaired=0
+
+	[[ -f "${SOURCELENS_INSTALL_DIR}/docker-compose.yml" ]] || return 0
+	# A staged bundle is not an installed SourceLens runtime.  Only repair the
+	# bindings when the persistent configuration proves that this host already
+	# owns (or previously owned) a bundled installation.
+	[[ -f "${persisted_env}" ]] || return 0
+
+	if [[ -L "${runtime_env}" ]]; then
+		if [[ "$(readlink "${runtime_env}")" != "${persisted_env}" ]]; then
+			ln -sfn "${persisted_env}" "${runtime_env}"
+			repaired=1
+		fi
+	elif [[ ! -e "${runtime_env}" ]]; then
+		ln -s "${persisted_env}" "${runtime_env}"
+		repaired=1
+	fi
+
+	if [[ -L "${runtime_data}" ]]; then
+		if [[ "$(readlink "${runtime_data}")" != "${persisted_data}" ]]; then
+			ln -sfn "${persisted_data}" "${runtime_data}"
+			repaired=1
+		fi
+	elif [[ ! -e "${runtime_data}" ]]; then
+		ln -s "${persisted_data}" "${runtime_data}"
+		repaired=1
+	fi
+
+	if [[ "${repaired}" -eq 1 ]]; then
+		log "Repaired bundled SourceLens runtime bindings before its maintenance gate"
+	fi
+}
+
 apply_upgrade_files() {
 	local from_root=$1
 	local remove_sourcelens=${2:-0}
@@ -2135,7 +2173,13 @@ apply_upgrade_files() {
 		safe_assert_path_under_dir "${ROOT}/sourcelens" "${ROOT}" "SourceLens runtime path"
 		safe_rm_dir "${ROOT}/sourcelens"
 	elif [[ "${sync_sourcelens}" -eq 1 && -d "${from_root}/sourcelens" ]]; then
-		rsync -aH --delete "${from_root}/sourcelens/" "${ROOT}/sourcelens/"
+		# SourceLens application files are replaceable, while these two root
+		# bindings point at installation-owned persistent configuration/data.
+		# Protect them from --delete so the still-running legacy proxy remains
+		# addressable until its independent maintenance gate has been armed.
+		rsync -aH --delete --exclude '/.env' --exclude '/data' \
+			"${from_root}/sourcelens/" "${ROOT}/sourcelens/"
+		repair_sourcelens_runtime_bindings
 	fi
 	cp "${from_root}/docker-compose.yml" "${ROOT}/docker-compose.yml"
 	mkdir -p "${ROOT}/deploy/nginx/snippets"
@@ -3889,6 +3933,9 @@ cmd_upgrade() {
 
 	step "[1/8] Validating persisted Redis recovery requirements ..."
 	require_docker
+	# Heal runtime links before backup/running-state discovery. This also makes a
+	# host recoverable when an older failed upgrade already removed the links.
+	repair_sourcelens_runtime_bindings
 	preflight_redis_recovery
 
 	step "[2/8] Backing up current config and data ..."

--- a/tools/quality/test-sourcelens-runtime-sync.sh
+++ b/tools/quality/test-sourcelens-runtime-sync.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_REPO=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+installer="${ROOT_REPO}/deploy/installer/install.sh"
+tmp=$(mktemp -d)
+trap 'rm -rf "${tmp}"' EXIT
+
+ROOT="${tmp}/installed"
+SOURCELENS_INSTALL_DIR="${ROOT}/sourcelens"
+source_root="${tmp}/release"
+
+step() { :; }
+log() { :; }
+sync_default_tls_bundle() { :; }
+read_version_from_dir() { printf 'main-0123456'; }
+
+source <(
+	sed -n '/^repair_sourcelens_runtime_bindings()/,/^prepare_upgrade_source()/p' \
+		"${installer}" | sed '$d'
+)
+
+mkdir -p \
+	"${ROOT}/data/sourcelens/config" \
+	"${ROOT}/data/sourcelens/workspace" \
+	"${ROOT}/sourcelens" \
+	"${source_root}/payload" \
+	"${source_root}/images" \
+	"${source_root}/sourcelens/data" \
+	"${source_root}/deploy/nginx/snippets" \
+	"${source_root}/deploy/blue-green"
+
+printf 'persisted=true\n' >"${ROOT}/data/sourcelens/config/.env"
+printf 'protected repository data\n' >"${ROOT}/data/sourcelens/workspace/keep.txt"
+ln -s "${ROOT}/data/sourcelens/config/.env" "${ROOT}/sourcelens/.env"
+ln -s "${ROOT}/data/sourcelens" "${ROOT}/sourcelens/data"
+printf 'remove me\n' >"${ROOT}/sourcelens/stale-app-file"
+
+printf 'packaged=true\n' >"${source_root}/sourcelens/.env"
+printf 'do not materialize\n' >"${source_root}/sourcelens/data/package-data"
+printf 'services: {}\n' >"${source_root}/sourcelens/docker-compose.yml"
+printf 'new application file\n' >"${source_root}/sourcelens/new-app-file"
+printf 'services: {}\n' >"${source_root}/docker-compose.yml"
+printf 'server {}\n' >"${source_root}/deploy/nginx/default.conf"
+printf 'server {}\n' >"${source_root}/deploy/nginx/web.conf"
+printf 'upstream api {}\n' >"${source_root}/deploy/nginx/snippets/hfl-active-upstreams.conf"
+printf 'blue\n' >"${source_root}/deploy/blue-green/active-color"
+printf '{}\n' >"${source_root}/MANIFEST.json"
+
+apply_upgrade_files "${source_root}" 0 1
+
+[[ -L "${ROOT}/sourcelens/.env" ]]
+[[ "$(readlink "${ROOT}/sourcelens/.env")" == "${ROOT}/data/sourcelens/config/.env" ]]
+[[ -L "${ROOT}/sourcelens/data" ]]
+[[ "$(readlink "${ROOT}/sourcelens/data")" == "${ROOT}/data/sourcelens" ]]
+grep -F 'persisted=true' "${ROOT}/sourcelens/.env" >/dev/null
+grep -F 'protected repository data' "${ROOT}/sourcelens/data/workspace/keep.txt" >/dev/null
+[[ ! -e "${ROOT}/sourcelens/data/package-data" ]]
+[[ ! -e "${ROOT}/sourcelens/stale-app-file" ]]
+grep -F 'new application file' "${ROOT}/sourcelens/new-app-file" >/dev/null
+
+# Repair the exact partial-upgrade state observed on TEST: persistent state is
+# present, but a previous application sync removed both runtime links.
+rm "${ROOT}/sourcelens/.env" "${ROOT}/sourcelens/data"
+apply_upgrade_files "${source_root}" 0 1
+[[ -L "${ROOT}/sourcelens/.env" ]]
+[[ -L "${ROOT}/sourcelens/data" ]]
+grep -F 'persisted=true' "${ROOT}/sourcelens/.env" >/dev/null
+grep -F 'protected repository data' "${ROOT}/sourcelens/data/workspace/keep.txt" >/dev/null
+
+python3 - "${installer}" <<'PY'
+import pathlib
+import sys
+
+text = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
+upgrade = text[text.index("cmd_upgrade() {") : text.index("\nmain() {")]
+assert upgrade.index("repair_sourcelens_runtime_bindings") < upgrade.index(
+    "create_managed_backup"
+)
+assert upgrade.index("repair_sourcelens_runtime_bindings") < upgrade.index(
+    'if sourcelens_installed && sourcelens_compose ps -q'
+)
+PY
+
+printf 'SourceLens runtime sync checks passed.\n'


### PR DESCRIPTION
## Summary
- preserve the installed SourceLens environment and data bindings during release file synchronization
- repair bindings removed by an earlier interrupted upgrade before backup and runtime discovery
- add a regression test for both preservation and recovery paths

## Validation
- ./tools/quality/test-sourcelens-runtime-sync.sh
- ./tools/quality/test-blue-green-recovery.sh
- ./tools/quality/check-release-contracts.sh
- bash -n deploy/installer/install.sh tools/quality/test-sourcelens-runtime-sync.sh
- git diff --check