### PR TITLE
test(frontend): await email cooldown reset

### DIFF
--- a/src/frontend/src/components/auth/EmailCodeLoginForm.test.ts
+++ b/src/frontend/src/components/auth/EmailCodeLoginForm.test.ts
@@ -135,7 +135,9 @@ describe('EmailCodeLoginForm', () => {
     expect(wrapper.get('#email-code-login-code').attributes('disabled')).toBeDefined()
     expect(codeInput.element.value).toBe('')
     expect(wrapper.get('button.submit-btn').attributes('disabled')).toBeDefined()
-    expect(wrapper.get('.email-code-login-form__send').attributes('disabled')).toBeUndefined()
+    await vi.waitFor(() => {
+      expect(wrapper.get('.email-code-login-form__send').attributes('disabled')).toBeUndefined()
+    })
 
     wrapper.unmount()
   })


### PR DESCRIPTION
## Summary
- wait for the asynchronous per-email cooldown lookup before asserting that resend is enabled
- remove a WebCrypto timing race from the email-change test without changing production behavior

## Validation
- EmailCodeLoginForm test repeated 10 times (50/50 tests passed)
- full frontend suite: 127 files, 600 tests passed
- git diff --check