### PR TITLE
fix(gateway): resume interrupted sidecar upgrades

### DIFF
--- a/.github/workflows/artifact_pipeline.yml
+++ b/.github/workflows/artifact_pipeline.yml
@@ -208,6 +208,7 @@ jobs:
           ./tools/quality/test-default-certificates.sh
           ./tools/quality/test-bootstrap-download-progress.sh
           ./tools/quality/test-gateway-bootstrap-health.sh
+          ./tools/quality/test-gateway-lifecycle-upgrade.sh
           ./tools/quality/test-platform-gateway-auto-deploy.sh
           ./tools/quality/test-agent-gateway-uninstall.sh
           ./tools/quality/test-installer-image-refresh.sh

--- a/deploy/bootstrap/gateway-lifecycle.sh
+++ b/deploy/bootstrap/gateway-lifecycle.sh
@@ -13,6 +13,10 @@ HFL_NODE_TOKEN=""
 HFL_NODE_ID=""
 HFL_INSECURE_TLS="${HFL_INSECURE_TLS:-1}"
 PURGE_ALL=0
+HFL_LAST_ERROR=""
+
+DOWNLOAD_MAX_ATTEMPTS="${HFL_GATEWAY_DOWNLOAD_MAX_ATTEMPTS:-5}"
+DOWNLOAD_RETRY_DELAY_SECONDS="${HFL_GATEWAY_DOWNLOAD_RETRY_DELAY_SECONDS:-2}"
 
 LENSNODE_IMAGE_ARCHIVE="lensnode-image-linux-amd64.tar.gz"
 SIDECAR_INSTALL_SCRIPT="gateway-install-lensnode-sidecar.sh"
@@ -29,7 +33,8 @@ hfl_log() {
 }
 
 hfl_fail() {
-	printf '[%s] [FAIL ] %s\n' "$(hfl_now)" "$*" >&2
+	HFL_LAST_ERROR=$1
+	printf '[%s] [FAIL ] %s\n' "$(hfl_now)" "$1" >&2
 	exit "${2:-1}"
 }
 
@@ -161,18 +166,42 @@ compose_down_sidecar() {
 
 download_bootstrap_file() {
 	local name=$1 dest=$2 partial="${2}.part"
-	rm -f "${partial}"
+	local attempt curl_rc delay
+	[[ "${DOWNLOAD_MAX_ATTEMPTS}" =~ ^[1-9][0-9]*$ ]] \
+		|| hfl_fail "HFL_GATEWAY_DOWNLOAD_MAX_ATTEMPTS must be a positive integer" 2
+	[[ "${DOWNLOAD_RETRY_DELAY_SECONDS}" =~ ^[0-9]+$ ]] \
+		|| hfl_fail "HFL_GATEWAY_DOWNLOAD_RETRY_DELAY_SECONDS must be a non-negative integer" 2
+	mkdir -p "$(dirname "${dest}")"
 	hfl_log "Downloading ${name} from console."
-	if ! curl "${curl_tls[@]}" \
-		--fail --show-error --location --progress-bar \
-		--retry 3 --retry-connrefused --retry-delay 2 \
-		"${GATEWAY_BOOTSTRAP_BASE}/${name}" -o "${partial}"; then
-		rm -f "${partial}"
-		hfl_fail "failed to download ${name}" 3
-	fi
-	mv -f "${partial}" "${dest}"
-	hfl_log "Downloaded ${name} ($(wc -c <"${dest}") bytes)."
-	chmod +x "${dest}" 2>/dev/null || true
+	for ((attempt = 1; attempt <= DOWNLOAD_MAX_ATTEMPTS; attempt++)); do
+		curl_rc=0
+		if curl "${curl_tls[@]}" \
+			--fail --show-error --location --progress-bar \
+			--continue-at - \
+			"${GATEWAY_BOOTSTRAP_BASE}/${name}" -o "${partial}"; then
+			if [[ ! -s "${partial}" ]]; then
+				hfl_log "warning: ${name} download produced an empty file (attempt ${attempt}/${DOWNLOAD_MAX_ATTEMPTS})"
+			else
+				mv -f "${partial}" "${dest}"
+				hfl_log "Downloaded ${name} ($(wc -c <"${dest}") bytes)."
+				chmod +x "${dest}" 2>/dev/null || true
+				return 0
+			fi
+		else
+			curl_rc=$?
+			hfl_log "warning: ${name} download interrupted (attempt ${attempt}/${DOWNLOAD_MAX_ATTEMPTS}, curl=${curl_rc}, partial=$(wc -c <"${partial}" 2>/dev/null || printf 0) bytes)"
+		fi
+
+		if [[ ("${curl_rc}" -eq 33 || "${curl_rc}" -eq 36) && -s "${partial}" ]]; then
+			hfl_log "warning: server rejected the resume request for ${name}; retrying once from byte zero"
+			rm -f "${partial}"
+		fi
+		if ((attempt < DOWNLOAD_MAX_ATTEMPTS)); then
+			delay=$((DOWNLOAD_RETRY_DELAY_SECONDS * attempt))
+			((delay == 0)) || sleep "${delay}"
+		fi
+	done
+	hfl_fail "failed to download ${name} after ${DOWNLOAD_MAX_ATTEMPTS} attempts" 3
 }
 
 lensnode_image_supports_insecure_tls() {
@@ -216,19 +245,34 @@ run_sidecar_install_script() {
 }
 
 cmd_upgrade_sidecar() {
-	local tmp script
+	local tmp="" script
 	load_agent_credentials
 	report_lifecycle_status "sidecar_upgrade" "running"
-	ensure_docker_ready
+	trap 'gateway_upgrade_exit "$?" "${tmp}"' EXIT
 	tmp="$(mktemp -d)"
-	load_lensnode_image "${tmp}"
-	compose_down_sidecar
+	ensure_docker_ready
 	script="${tmp}/${SIDECAR_INSTALL_SCRIPT}"
 	download_bootstrap_file "${SIDECAR_INSTALL_SCRIPT}" "${script}"
+	load_lensnode_image "${tmp}"
+	compose_down_sidecar
 	run_sidecar_install_script "${script}"
 	rm -rf "${tmp}"
 	report_lifecycle_status "sidecar_upgrade" "success"
+	trap - EXIT
 	hfl_log "LensNode sidecar upgrade completed."
+}
+
+gateway_upgrade_exit() {
+	local rc=$1 tmp=${2:-}
+	trap - EXIT
+	if [[ "${rc}" -ne 0 ]]; then
+		report_lifecycle_status \
+			"sidecar_upgrade" \
+			"failed" \
+			"${HFL_LAST_ERROR:-LensNode sidecar upgrade failed (exit ${rc})}"
+	fi
+	[[ -z "${tmp}" ]] || rm -rf "${tmp}"
+	return "${rc}"
 }
 
 remove_lensnode_images() {

--- a/src/agent/internal/platform/install/gateway_hooks_unix.go
+++ b/src/agent/internal/platform/install/gateway_hooks_unix.go
@@ -19,19 +19,23 @@ run_gateway_sidecar_upgrade_if_needed() {
   }
   curl_tls=()
   [[ "$insecure" != "0" ]] && curl_tls=(-k)
-  bootstrap="${api_base%/}/media/gateway-bootstrap"
-  tmp="$(mktemp -d)"
-  script="${tmp}/gateway-lifecycle.sh"
-  if ! curl "${curl_tls[@]}" -fsSL "${bootstrap}/gateway-lifecycle.sh" -o "$script"; then
-    log "FAIL " "Failed to download gateway-lifecycle.sh for sidecar upgrade."
-    rm -rf "$tmp"
-    return 1
+  script="${INSTALL_SH%/install.sh}/libexec/gateway-lifecycle.sh"
+  tmp=""
+  if [[ ! -x "$script" ]]; then
+    bootstrap="${api_base%/}/media/gateway-bootstrap"
+    tmp="$(mktemp -d)"
+    script="${tmp}/gateway-lifecycle.sh"
+    if ! curl "${curl_tls[@]}" -fsSL "${bootstrap}/gateway-lifecycle.sh" -o "$script"; then
+      log "FAIL " "Failed to obtain gateway-lifecycle.sh for sidecar upgrade."
+      rm -rf "$tmp"
+      return 1
+    fi
+    chmod +x "$script"
   fi
-  chmod +x "$script"
   log "INFO " "Running gateway sidecar upgrade."
   HFL_AGENT_ENV_FILE="$env_file" HFL_INSECURE_TLS="${insecure:-1}" bash "$script" upgrade-sidecar
   local rc=$?
-  rm -rf "$tmp"
+  [[ -z "$tmp" ]] || rm -rf "$tmp"
   return $rc
 }
 `

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -835,8 +835,11 @@ for bootstrap in "${gateway_bootstrap_linux}" "${gateway_docker_installer}"; do
 	grep -F 'partial="${destination}.part"' "${bootstrap}" >/dev/null
 done
 grep -F -- '--fail --show-error --location --progress-bar' "${gateway_lifecycle}" >/dev/null
-grep -F -- '--retry 3 --retry-connrefused --retry-delay 2' "${gateway_lifecycle}" >/dev/null
+grep -F -- '--continue-at -' "${gateway_lifecycle}" >/dev/null
+grep -F 'HFL_GATEWAY_DOWNLOAD_MAX_ATTEMPTS:-5' "${gateway_lifecycle}" >/dev/null
 grep -F 'partial="${2}.part"' "${gateway_lifecycle}" >/dev/null
+grep -F 'script="${INSTALL_SH%/install.sh}/libexec/gateway-lifecycle.sh"' \
+	"${ROOT}/src/agent/internal/platform/install/gateway_hooks_unix.go" >/dev/null
 grep -F 'Docker CE offline bundle' "${gateway_docker_installer}" >/dev/null
 grep -F -- "'--progress-bar'" "${agent_bootstrap_windows}" >/dev/null
 grep -F 'Write-HflDownloadProgress' "${agent_bootstrap_windows}" >/dev/null
@@ -903,6 +906,7 @@ grep -F './tools/quality/test-shared-host-guard.sh' "${workflow}" >/dev/null
 grep -F './tools/quality/test-release-download-proxy.sh' "${workflow}" >/dev/null
 grep -F './tools/quality/test-default-certificates.sh' "${workflow}" >/dev/null
 grep -F './tools/quality/test-gateway-bootstrap-health.sh' "${workflow}" >/dev/null
+grep -F './tools/quality/test-gateway-lifecycle-upgrade.sh' "${workflow}" >/dev/null
 grep -F './tools/quality/test-platform-gateway-auto-deploy.sh' "${workflow}" >/dev/null
 grep -F './tools/quality/test-agent-release-retention.sh' "${workflow}" >/dev/null
 grep -F './tools/quality/test-agent-gateway-uninstall.sh' "${workflow}" >/dev/null

--- a/tools/quality/test-gateway-lifecycle-upgrade.sh
+++ b/tools/quality/test-gateway-lifecycle-upgrade.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+set -euo pipefail
+umask 077
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+LIFECYCLE="${ROOT}/deploy/bootstrap/gateway-lifecycle.sh"
+tmp="$(mktemp -d)"
+trap 'rm -rf "${tmp}"' EXIT
+
+test_resume_after_interruption() (
+	# shellcheck disable=SC1090
+	source "${LIFECYCLE}"
+	local destination="${tmp}/resumed.bin" calls="${tmp}/resume-calls"
+	local expected='Aurora Glass|37 days|BLUE-ORBIT-731'
+	GATEWAY_BOOTSTRAP_BASE=https://console.example/media/gateway-bootstrap
+	DOWNLOAD_MAX_ATTEMPTS=3
+	DOWNLOAD_RETRY_DELAY_SECONDS=0
+	curl() {
+		local output="" resume="" arg
+		while [[ $# -gt 0 ]]; do
+			arg=$1
+			shift
+			case "${arg}" in
+			-o) output=$1; shift ;;
+			--continue-at) resume=$1; shift ;;
+			esac
+		done
+		[[ "${resume}" == "-" && -n "${output}" ]]
+		if [[ ! -f "${calls}" ]]; then
+			printf 1 >"${calls}"
+			printf '%s' "${expected:0:17}" >"${output}"
+			return 18
+		fi
+		[[ "$(wc -c <"${output}")" -eq 17 ]]
+		printf '%s' "${expected:17}" >>"${output}"
+		printf 2 >"${calls}"
+	}
+
+	download_bootstrap_file payload.bin "${destination}"
+	[[ "$(<"${destination}")" == "${expected}" ]]
+	[[ "$(<"${calls}")" == 2 ]]
+	[[ ! -e "${destination}.part" ]]
+)
+
+test_retry_exhaustion_keeps_partial() {
+	local destination="${tmp}/exhausted.bin"
+	if (
+		# shellcheck disable=SC1090
+		source "${LIFECYCLE}"
+		GATEWAY_BOOTSTRAP_BASE=https://console.example/media/gateway-bootstrap
+		DOWNLOAD_MAX_ATTEMPTS=3
+		DOWNLOAD_RETRY_DELAY_SECONDS=0
+		curl() {
+			local output="" arg
+			while [[ $# -gt 0 ]]; do
+				arg=$1
+				shift
+				if [[ "${arg}" == "-o" ]]; then
+					output=$1
+					shift
+				fi
+			done
+			printf x >>"${output}"
+			return 18
+		}
+		download_bootstrap_file payload.bin "${destination}"
+	) 2>"${tmp}/exhausted.log"; then
+		printf 'download unexpectedly succeeded after retry exhaustion\n' >&2
+		return 1
+	fi
+	[[ "$(wc -c <"${destination}.part")" -eq 3 ]]
+	grep -F 'failed to download payload.bin after 3 attempts' "${tmp}/exhausted.log" >/dev/null
+}
+
+test_failed_staging_reports_and_preserves_sidecar() {
+	local env_file="${tmp}/agent.env"
+	local status_file="${tmp}/lifecycle-status" down_marker="${tmp}/sidecar-down"
+	printf '%s\n' \
+		'HFL_API_BASE=https://console.example' \
+		'HFL_ORG_KEY=org-test' \
+		'HFL_NODE_TOKEN=node-test' \
+		'HFL_NODE_ID=42' \
+		>"${env_file}"
+	if (
+		HFL_AGENT_ENV_FILE="${env_file}"
+		# shellcheck disable=SC1090
+		source "${LIFECYCLE}"
+		report_lifecycle_status() {
+			printf '%s:%s:%s\n' "$1" "$2" "${3:-}" >>"${status_file}"
+		}
+		ensure_docker_ready() { :; }
+		download_bootstrap_file() { hfl_fail 'simulated staging download failure' 23; }
+		compose_down_sidecar() { printf down >"${down_marker}"; }
+		cmd_upgrade_sidecar
+	); then
+		printf 'Gateway sidecar staging failure unexpectedly succeeded\n' >&2
+		return 1
+	fi
+	[[ ! -e "${down_marker}" ]]
+	grep -Fx 'sidecar_upgrade:running:' "${status_file}" >/dev/null
+	grep -Fx 'sidecar_upgrade:failed:simulated staging download failure' "${status_file}" >/dev/null
+}
+
+test_resume_after_interruption
+test_retry_exhaustion_keeps_partial
+test_failed_staging_reports_and_preserves_sidecar
+
+printf 'Gateway sidecar resumable upgrade contracts passed.\n'


### PR DESCRIPTION
## Summary
- resume interrupted LensNode sidecar downloads with bounded retries
- stage the install script and image before stopping the existing sidecar
- report sidecar upgrade failures and prefer the lifecycle helper bundled with the upgraded Agent
- cover resume, retry exhaustion, failure reporting, and sidecar preservation in release quality checks

## Validation
- full Agent Go test suite
- gateway lifecycle fault-injection test
- gateway uninstall contract test
- release contract checks
- shell syntax, shellcheck, and git diff checks

SourceLens code is unchanged.