### PR TITLE
fix(lens): archive assistants through SourceLens API

### DIFF
--- a/src/backend/apps/lens_bridge/services/assistants.py
+++ b/src/backend/apps/lens_bridge/services/assistants.py
@@ -602,17 +602,17 @@ def _require_manual_assistant_management(
 
 
 def _delete_sl_assistant(assistant_uuid: uuid_lib.UUID) -> None:
-    """Retire an Assistant through SourceLens' supported DELETE contract.
+    """Retire an Assistant through SourceLens' supported archive contract.
 
-    SourceLens implements this endpoint as a soft retirement. HFL treats an
-    existing 404 as idempotent success but preserves every other error for
-    durable retry.
+    SourceLens 0.20.0 removed DELETE from Assistant CRUD and exposes a POST
+    archive action instead. HFL treats an already archived/missing 404 as
+    idempotent success but preserves every other error for durable retry.
     """
 
     try:
         sl_client.request_json(
-            "DELETE",
-            f"/api/lens/assistants/{assistant_uuid}/",
+            "POST",
+            f"/api/lens/assistants/{assistant_uuid}/archive/",
         )
     except sl_client.LensBridgeError as exc:
         status = getattr(exc, "status_code", None)

--- a/src/backend/apps/lens_bridge/tests/test_assistant_delete.py
+++ b/src/backend/apps/lens_bridge/tests/test_assistant_delete.py
@@ -82,8 +82,8 @@ class SourceLensAssistantRetirementTests(SimpleTestCase):
         assistants._delete_sl_assistant(assistant_uuid)
 
         request_json.assert_called_once_with(
-            "DELETE",
-            f"/api/lens/assistants/{assistant_uuid}/",
+            "POST",
+            f"/api/lens/assistants/{assistant_uuid}/archive/",
         )
 
     @patch("apps.lens_bridge.services.assistants.sl_client.request_json")
@@ -97,6 +97,6 @@ class SourceLensAssistantRetirementTests(SimpleTestCase):
             assistants._delete_sl_assistant(assistant_uuid)
 
         request_json.assert_called_once_with(
-            "DELETE",
-            f"/api/lens/assistants/{assistant_uuid}/",
+            "POST",
+            f"/api/lens/assistants/{assistant_uuid}/archive/",
         )


### PR DESCRIPTION
## Summary
- retire SourceLens v0.20.0 assistants through its supported archive action
- keep missing or already archived assistants idempotent during durable teardown
- align retirement contract tests with the bundled SourceLens API

## Validation
- 34 assistant lifecycle and Chat teardown tests
- Ruff
- git diff --check
- verified against the bundled SourceLens v0.20.0 container contract