### PR TITLE
fix(gateway): isolate writable SourceLens runtime state

### DIFF
--- a/deploy/bootstrap/gateway-install-lensnode-sidecar.sh
+++ b/deploy/bootstrap/gateway-install-lensnode-sidecar.sh
@@ -88,10 +88,18 @@ hfl_ok "SourceLens health check passed."
 hfl_step "Creating protected Gateway filesystem boundary."
 mkdir -p "${HFL_WORKSPACE_ROOT}"
 HFL_GATEWAY_STATE_ROOT="$(dirname "${HFL_WORKSPACE_ROOT}")/.hyperfilelens"
+HFL_SOURCELENS_STATE_ROOT="${HFL_GATEWAY_STATE_ROOT}/sourcelens"
+HFL_SOURCELENS_MOUNTPOINT="${HFL_WORKSPACE_ROOT}/.sourcelens"
 HFL_GATEWAY_TRASH_ROOT="${HFL_WORKSPACE_ROOT}/.hyperfilelens-trash"
-mkdir -p "${HFL_GATEWAY_STATE_ROOT}/identities" "${HFL_GATEWAY_TRASH_ROOT}"
+mkdir -p \
+	"${HFL_GATEWAY_STATE_ROOT}/identities" \
+	"${HFL_SOURCELENS_STATE_ROOT}" \
+	"${HFL_SOURCELENS_MOUNTPOINT}" \
+	"${HFL_GATEWAY_TRASH_ROOT}"
 chmod 0700 "${HFL_GATEWAY_STATE_ROOT}" \
 	"${HFL_GATEWAY_STATE_ROOT}/identities" \
+	"${HFL_SOURCELENS_STATE_ROOT}" \
+	"${HFL_SOURCELENS_MOUNTPOINT}" \
 	"${HFL_GATEWAY_TRASH_ROOT}"
 
 mkdir -p "${COMPOSE_DIR}"
@@ -229,8 +237,10 @@ ${EXTRA_HOSTS_BLOCK}    environment:
     volumes:
 ${sentry_volume_block}
       # LensNode only indexes managed data. The host Agent is the sole writer
-      # and lifecycle owner for this filesystem boundary.
+      # and lifecycle owner for this filesystem boundary. SourceLens receives
+      # one isolated writable mount for its runtime/cache state.
       - ${HFL_WORKSPACE_ROOT}:${HFL_WORKSPACE_ROOT}:ro
+      - ${HFL_SOURCELENS_STATE_ROOT}:${HFL_SOURCELENS_MOUNTPOINT}:rw
     tmpfs:
       # Hide the host Agent's same-filesystem deletion quarantine from LensNode.
       - ${HFL_GATEWAY_TRASH_ROOT}:mode=0700

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -821,6 +821,7 @@ agent_bootstrap_windows="${ROOT}/deploy/bootstrap/agent-bootstrap-windows.ps1"
 gateway_bootstrap_linux="${ROOT}/deploy/bootstrap/gateway-bootstrap-linux.sh"
 gateway_docker_installer="${ROOT}/deploy/bootstrap/gateway-install-docker-ubuntu-amd64.sh"
 gateway_lifecycle="${ROOT}/deploy/bootstrap/gateway-lifecycle.sh"
+gateway_sidecar_installer="${ROOT}/deploy/bootstrap/gateway-install-lensnode-sidecar.sh"
 grep -F 'requires a systemd-based Linux distribution' "${agent_bootstrap_linux}" >/dev/null
 grep -F 'systemctl show-environment' "${agent_bootstrap_linux}" >/dev/null
 grep -F 'launchd is required to install the agent service on macOS' "${agent_bootstrap_macos}" >/dev/null
@@ -840,6 +841,14 @@ grep -F -- '--fail --show-error --location --progress-bar' "${gateway_lifecycle}
 grep -F -- '--continue-at -' "${gateway_lifecycle}" >/dev/null
 grep -F 'HFL_GATEWAY_DOWNLOAD_MAX_ATTEMPTS:-5' "${gateway_lifecycle}" >/dev/null
 grep -F 'partial="${2}.part"' "${gateway_lifecycle}" >/dev/null
+grep -F 'HFL_SOURCELENS_STATE_ROOT="${HFL_GATEWAY_STATE_ROOT}/sourcelens"' \
+	"${gateway_sidecar_installer}" >/dev/null
+grep -F 'HFL_SOURCELENS_MOUNTPOINT="${HFL_WORKSPACE_ROOT}/.sourcelens"' \
+	"${gateway_sidecar_installer}" >/dev/null
+grep -F '${HFL_SOURCELENS_STATE_ROOT}:${HFL_SOURCELENS_MOUNTPOINT}:rw' \
+	"${gateway_sidecar_installer}" >/dev/null
+grep -F '${HFL_WORKSPACE_ROOT}:${HFL_WORKSPACE_ROOT}:ro' \
+	"${gateway_sidecar_installer}" >/dev/null
 grep -F 'script="${INSTALL_SH%/install.sh}/libexec/gateway-lifecycle.sh"' \
 	"${ROOT}/src/agent/internal/platform/install/gateway_hooks_unix.go" >/dev/null
 grep -F 'Docker CE offline bundle' "${gateway_docker_installer}" >/dev/null
@@ -914,7 +923,7 @@ grep -F './tools/quality/test-agent-release-retention.sh' "${workflow}" >/dev/nu
 grep -F './tools/quality/test-agent-gateway-uninstall.sh' "${workflow}" >/dev/null
 grep -F 'HFL_PLATFORM_GATEWAY_AUTO_DEPLOY=false' "${ROOT}/.env.example" >/dev/null
 grep -F 'com.hyperfilelens.component: "gateway-lensnode"' \
-	"${ROOT}/deploy/bootstrap/gateway-install-lensnode-sidecar.sh" >/dev/null
+	"${gateway_sidecar_installer}" >/dev/null
 grep -F './tools/quality/test-deployment-optional-config.sh' "${workflow}" >/dev/null
 grep -F './tools/quality/test-ga-runtime-config.sh' "${workflow}" >/dev/null
 grep -F './tools/quality/test-sentry-runtime-config.sh' "${workflow}" >/dev/null


### PR DESCRIPTION
## Summary
- keep restored Gateway data mounted read-only in LensNode
- provide SourceLens v0.20.0 a dedicated writable .sourcelens runtime/cache child mount
- retain runtime state under the Agent-managed .hyperfilelens boundary for purge-all cleanup
- enforce the read-only data and writable runtime mount contract in release checks

## Validation
- release contract checks
- Gateway resumable-upgrade fault-injection tests
- shell syntax and git diff checks
- reproduced the original read-only runtime failure with a real private Gateway Chat