### PR TITLE
fix(release): harden CI retries and deployment ordering

### DIFF
--- a/.github/scripts/check-main-freshness.sh
+++ b/.github/scripts/check-main-freshness.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Report whether a Main-channel workflow commit still matches the current remote main tip.
+set -euo pipefail
+
+current_commit=${1:-}
+[[ "${current_commit}" =~ ^[0-9a-f]{40}$ ]] || {
+	printf 'ERROR: current Main commit must be a full lowercase SHA\n' >&2
+	exit 2
+}
+git rev-parse --is-inside-work-tree >/dev/null
+git cat-file -e "${current_commit}^{commit}" 2>/dev/null || {
+	printf 'ERROR: current Main commit is unavailable: %s\n' "${current_commit}" >&2
+	exit 2
+}
+git fetch --quiet origin main --no-tags
+latest_commit="$(git rev-parse --verify 'refs/remotes/origin/main^{commit}')"
+[[ "${latest_commit}" =~ ^[0-9a-f]{40}$ ]] || {
+	printf 'ERROR: origin/main did not resolve to a full commit SHA\n' >&2
+	exit 2
+}
+
+if [[ "${current_commit}" == "${latest_commit}" ]]; then
+	printf 'current\n'
+else
+	printf 'superseded\n'
+fi

--- a/.github/scripts/check-public-endpoint.sh
+++ b/.github/scripts/check-public-endpoint.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Perform a non-blocking public health check only when the configured URL is globally routable.
+set -euo pipefail
+
+write_summary() {
+	[[ -n "${GITHUB_STEP_SUMMARY:-}" ]] || return 0
+	printf '%s\n\n%s\n' "$1" "$2" >>"${GITHUB_STEP_SUMMARY}"
+}
+
+finish_nonblocking() {
+	local status=$1
+	trap - EXIT
+	if [[ "${status}" -ne 0 ]]; then
+		set +e
+		printf '::warning title=Public endpoint check::Check execution failed with status %s; core deployment and host-local health remain authoritative.\n' \
+			"${status}"
+		write_summary '### Public endpoint check' \
+			"Warning: external availability check execution failed with status ${status}. Core deployment and host-local checks passed." \
+			|| true
+	fi
+	exit 0
+}
+trap 'finish_nonblocking "$?"' EXIT
+
+if [[ -z "${APP_PUBLIC_URL:-}" ]]; then
+	printf '%s\n' '::notice title=Public endpoint check::Public URL is not configured; host-local health remains authoritative.'
+	write_summary '### Public endpoint check' \
+		'Skipped: the target public URL is empty. Core deployment and host-local checks passed.'
+	exit 0
+fi
+
+classification="$(python3 - "${APP_PUBLIC_URL}" <<'PY'
+import ipaddress
+import sys
+import urllib.parse
+
+value = sys.argv[1]
+try:
+    parsed = urllib.parse.urlsplit(value)
+    if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+        raise ValueError("URL must include an HTTP(S) scheme and hostname")
+    host = parsed.hostname.rstrip(".").lower()
+    if host == "localhost":
+        print("private")
+    else:
+        try:
+            address = ipaddress.ip_address(host)
+        except ValueError:
+            print("public")
+        else:
+            print("public" if address.is_global else "private")
+except (TypeError, ValueError):
+    print("invalid")
+PY
+)"
+
+case "${classification}" in
+private)
+	printf '%s\n' '::notice title=Public endpoint check::Private endpoint detected; GitHub-hosted connectivity check was skipped.'
+	write_summary '### Public endpoint check' \
+		"Skipped: \`${APP_PUBLIC_URL}\` is private or non-global. Core deployment and host-local checks passed."
+	;;
+invalid)
+	printf '::warning title=Public endpoint check::Configured public URL is invalid: %s\n' "${APP_PUBLIC_URL}"
+	write_summary '### Public endpoint check' \
+		"Warning: \`${APP_PUBLIC_URL}\` is not a valid HTTP(S) URL. Core deployment and host-local checks passed."
+	;;
+public)
+	endpoint="${APP_PUBLIC_URL%/}/health/ready"
+	if ! curl -fsS --connect-timeout 10 --max-time 30 --retry 2 "${endpoint}" >/dev/null; then
+		printf '::warning title=Public endpoint check::Public endpoint is not ready: %s\n' "${endpoint}"
+		write_summary '### Public endpoint check' \
+			"Warning: \`${endpoint}\` is not ready. Core deployment and host-local checks passed."
+	else
+		write_summary '### Public endpoint check' "Passed: \`${endpoint}\`"
+	fi
+	;;
+*)
+	printf 'ERROR: unexpected public URL classification: %s\n' "${classification}" >&2
+	exit 2
+	;;
+esac
+
+exit 0

--- a/.github/scripts/check-release-freshness.sh
+++ b/.github/scripts/check-release-freshness.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Report whether a stable release is the highest successfully published SemVer.
+set -euo pipefail
+
+current_tag=${1:-}
+repository=${GITHUB_REPOSITORY:-}
+retry_delay=${HFL_RELEASE_FRESHNESS_RETRY_DELAY_SECONDS:-2}
+[[ "${current_tag}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+	printf 'ERROR: release freshness requires a stable vMAJOR.MINOR.PATCH tag\n' >&2
+	exit 2
+}
+[[ "${repository}" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] || {
+	printf 'ERROR: GITHUB_REPOSITORY must identify owner/repository\n' >&2
+	exit 2
+}
+[[ "${retry_delay}" =~ ^[0-9]+$ ]] || {
+	printf 'ERROR: release freshness retry delay must be a non-negative integer\n' >&2
+	exit 2
+}
+
+published_tags=
+for attempt in 1 2 3; do
+	if api_tags="$(gh api "repos/${repository}/releases?per_page=100" --paginate \
+		--jq '.[] | select(.draft == false and .prerelease == false) | .tag_name' \
+		2>/dev/null)"; then
+		published_tags="$(awk '/^v[0-9]+\.[0-9]+\.[0-9]+$/' <<<"${api_tags}")"
+		if grep -Fx "${current_tag}" <<<"${published_tags}" >/dev/null; then
+			break
+		fi
+	fi
+	[[ "${attempt}" -eq 3 ]] || sleep "${retry_delay}"
+done
+if ! grep -Fx "${current_tag}" <<<"${published_tags}" >/dev/null; then
+	printf 'ERROR: stable release is not published: %s\n' "${current_tag}" >&2
+	exit 2
+fi
+
+latest_tag="$(LC_ALL=C sort -V <<<"${published_tags}" | tail -n 1)"
+if [[ "${current_tag}" == "${latest_tag}" ]]; then
+	printf 'current\n'
+else
+	printf 'superseded\n'
+fi

--- a/.github/scripts/cleanup-main-builds.sh
+++ b/.github/scripts/cleanup-main-builds.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# Retain retryable Main draft assets on failure and prune superseded Main releases after success.
+set -euo pipefail
+
+: "${ARTIFACT_ID:?ARTIFACT_ID is required}"
+: "${MAIN_COMMIT:?MAIN_COMMIT is required}"
+: "${BUILD_REQUIRED:?BUILD_REQUIRED is required}"
+: "${PUBLISH_RESULT:?PUBLISH_RESULT is required}"
+: "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+PUBLISH_DISPOSITION=${PUBLISH_DISPOSITION:-incomplete}
+
+[[ "${ARTIFACT_ID}" =~ ^main-[0-9a-f]{7}$ ]] || {
+	printf 'ERROR: invalid Main artifact identifier: %s\n' "${ARTIFACT_ID}" >&2
+	exit 2
+}
+[[ "${MAIN_COMMIT}" =~ ^[0-9a-f]{40}$ ]] || {
+	printf 'ERROR: invalid Main commit identity: %s\n' "${MAIN_COMMIT}" >&2
+	exit 2
+}
+[[ "${BUILD_REQUIRED}" == "true" || "${BUILD_REQUIRED}" == "false" ]] || {
+	printf 'ERROR: invalid BUILD_REQUIRED value: %s\n' "${BUILD_REQUIRED}" >&2
+	exit 2
+}
+
+write_summary() {
+	[[ -n "${GITHUB_STEP_SUMMARY:-}" ]] || return 0
+	printf '%s\n\n%s\n' "$1" "$2" >>"${GITHUB_STEP_SUMMARY}"
+}
+
+delete_main_artifact() {
+	local artifact_id=$1
+	[[ "${artifact_id}" =~ ^main-[0-9a-f]{7}$ ]] || return 2
+	if gh release view "${artifact_id}" --repo "${GITHUB_REPOSITORY}" \
+		>/dev/null 2>&1; then
+		if ! gh release delete "${artifact_id}" --repo "${GITHUB_REPOSITORY}" --yes; then
+			gh release view "${artifact_id}" --repo "${GITHUB_REPOSITORY}" \
+				>/dev/null 2>&1 && return 1
+		fi
+	fi
+	if gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${artifact_id}" \
+		--silent >/dev/null 2>&1; then
+		if ! gh api --method DELETE \
+			"repos/${GITHUB_REPOSITORY}/git/refs/tags/${artifact_id}" --silent; then
+			gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${artifact_id}" \
+				--silent >/dev/null 2>&1 && return 1
+		fi
+	fi
+}
+
+publish_complete=0
+if [[ "${PUBLISH_RESULT}" == "success" ]] \
+	|| [[ "${BUILD_REQUIRED}" == "false" && "${PUBLISH_RESULT}" == "skipped" ]]; then
+	publish_complete=1
+fi
+
+if [[ "${PUBLISH_DISPOSITION}" == "superseded" ]]; then
+	printf 'Preserving the authoritative newer Main release; stale artifact %s was not published.\n' \
+		"${ARTIFACT_ID}"
+	write_summary '### Main release cleanup' \
+		"Skipped cleanup for superseded \`${ARTIFACT_ID}\`; the authoritative newer Main release remains unchanged."
+	exit 0
+fi
+
+if [[ "${publish_complete}" -ne 1 ]]; then
+	printf 'Retaining retryable Main draft %s because publish result is %s.\n' \
+		"${ARTIFACT_ID}" "${PUBLISH_RESULT}"
+	write_summary '### Main release cleanup' \
+		"Retained retryable draft \`${ARTIFACT_ID}\` because publishing did not complete. GitHub's **Re-run failed jobs** can reuse its internal assets."
+	exit 0
+fi
+
+if ! freshness="$("$(dirname "${BASH_SOURCE[0]}")/check-main-freshness.sh" "${MAIN_COMMIT}")"; then
+	printf '%s\n' '::warning title=Main release cleanup::Unable to verify the current Main commit; destructive cleanup was skipped.'
+	write_summary '### Main release cleanup' \
+		"Skipped destructive cleanup because current Main freshness could not be verified. Retained \`${ARTIFACT_ID}\` and all other Main releases."
+	exit 0
+fi
+if [[ "${freshness}" == "superseded" ]]; then
+	printf 'Preserving the authoritative newer Main release; cleanup commit %s is stale.\n' \
+		"${MAIN_COMMIT}"
+	write_summary '### Main release cleanup' \
+		"Skipped cleanup for stale commit \`${MAIN_COMMIT}\`; the authoritative newer Main release remains unchanged."
+	exit 0
+fi
+[[ "${freshness}" == "current" ]] || {
+	printf 'ERROR: unexpected Main freshness result: %s\n' "${freshness}" >&2
+	exit 2
+}
+
+all_main_builds="$(mktemp)"
+trap 'rm -f "${all_main_builds}"' EXIT
+gh api "repos/${GITHUB_REPOSITORY}/releases?per_page=100" --paginate \
+	--jq '.[] | select(.tag_name | test("^main-[0-9a-f]{7}$")) | [.tag_name, .target_commitish] | @tsv' \
+	>"${all_main_builds}"
+
+deleted=0
+preserved=0
+while IFS=$'\t' read -r artifact_id target_commit; do
+	[[ -n "${artifact_id}" && "${artifact_id}" != "${ARTIFACT_ID}" ]] || continue
+	if [[ ! "${target_commit}" =~ ^[0-9a-f]{40}$ ]]; then
+		printf 'WARNING: preserving Main release %s with unresolved target %s.\n' \
+			"${artifact_id}" "${target_commit:-<empty>}" >&2
+		preserved=$((preserved + 1))
+		continue
+	fi
+	if ! relation="$(gh api \
+		"repos/${GITHUB_REPOSITORY}/compare/${target_commit}...${MAIN_COMMIT}" \
+		--jq '.status' 2>/dev/null)"; then
+		printf 'WARNING: preserving Main release %s because commit ancestry could not be verified.\n' \
+			"${artifact_id}" >&2
+		preserved=$((preserved + 1))
+		continue
+	fi
+	if [[ "${relation}" == "ahead" ]]; then
+		delete_main_artifact "${artifact_id}"
+		deleted=$((deleted + 1))
+	else
+		printf 'Preserving non-ancestor Main release %s (relationship: %s).\n' \
+			"${artifact_id}" "${relation}"
+		preserved=$((preserved + 1))
+	fi
+done <"${all_main_builds}"
+
+printf 'Retained Main release %s, removed %d ancestor release(s), and preserved %d non-ancestor or unresolved release(s).\n' \
+	"${ARTIFACT_ID}" "${deleted}" "${preserved}"
+write_summary '### Main release cleanup' \
+	"Retained \`${ARTIFACT_ID}\`, removed ${deleted} ancestor Main release(s), and preserved ${preserved} non-ancestor or unresolved release(s)."

--- a/.github/workflows/artifact_pipeline.yml
+++ b/.github/workflows/artifact_pipeline.yml
@@ -14,10 +14,20 @@ on:
         type: boolean
 
 concurrency:
-  group: hyperfilelens-${{ inputs.channel == 'main' && 'main' || 'release' }}
+  group: >-
+    ${{
+      inputs.channel == 'main' &&
+      (
+        github.run_attempt == 1 &&
+        'hyperfilelens-main' ||
+        format('hyperfilelens-main-rerun-{0}-{1}', github.run_id, github.run_attempt)
+      ) ||
+      format('hyperfilelens-release-{0}', github.ref_name)
+    }}
   # Main is a moving development target, while formal release builds must
-  # always run to completion once a version tag has been accepted.
-  cancel-in-progress: ${{ inputs.channel == 'main' }}
+  # always run to completion once a version tag has been accepted. A stale
+  # Main retry must never cancel the active build for a newer commit.
+  cancel-in-progress: ${{ inputs.channel == 'main' && github.run_attempt == 1 }}
 
 permissions:
   contents: read
@@ -70,7 +80,15 @@ jobs:
               exit 2
               ;;
           esac
-          git merge-base --is-ancestor "$GITHUB_SHA" origin/main
+          if [[ "$REQUESTED_CHANNEL" == "main" ]]; then
+            latest_main="$(git rev-parse --verify 'refs/remotes/origin/main^{commit}')"
+            [[ "$GITHUB_SHA" == "$latest_main" ]] || {
+              echo "Main build $GITHUB_SHA is superseded by $latest_main; stale retries stop before package construction" >&2
+              exit 1
+            }
+          else
+            git merge-base --is-ancestor "$GITHUB_SHA" origin/main
+          fi
           {
             echo "version=$VERSION"
             echo "tag=$TAG"
@@ -103,7 +121,16 @@ jobs:
               exit 1
             }
           fi
-          if gh release view "$ARTIFACT_ID" --json isDraft,isPrerelease >/tmp/hfl-release.json 2>/dev/null; then
+          if gh release view "$ARTIFACT_ID" \
+            --json isDraft,isPrerelease,targetCommitish \
+            >/tmp/hfl-release.json 2>/dev/null; then
+            if [[ "$ARTIFACT_CHANNEL" == "main" ]]; then
+              release_target="$(jq -r .targetCommitish /tmp/hfl-release.json)"
+              [[ "$release_target" == "$GITHUB_SHA" ]] || {
+                echo "Main artifact target mismatch: $ARTIFACT_ID targets $release_target, expected $GITHUB_SHA" >&2
+                exit 1
+              }
+            fi
             if [[ "$ARTIFACT_CHANNEL" == "release" ]]; then
               [[ "$(jq -r .isDraft /tmp/hfl-release.json)" == "true" ]] || {
                 echo "Refusing to overwrite an already-published release" >&2
@@ -214,6 +241,7 @@ jobs:
           ./tools/quality/test-installer-image-refresh.sh
           ./tools/quality/test-language-pack-runtime-index.sh
           ./tools/quality/test-docker-image-digest-alias.sh
+          ./tools/quality/test-docker-pull-retry.sh
           ./tools/quality/test-offline-docker-package-plan.sh
           ./tools/quality/test-upgrade-backup-retention.sh
           ./tools/quality/test-blue-green-recovery.sh
@@ -223,8 +251,12 @@ jobs:
           ./tools/quality/test-agent-release-retention.sh
           ./tools/quality/test-managed-image-retention.sh
           ./tools/quality/test-main-channel-contracts.sh
+          ./tools/quality/test-main-release-freshness.sh
+          ./tools/quality/test-main-release-cleanup.sh
+          ./tools/quality/test-release-freshness.sh
           ./tools/quality/test-shared-host-guard.sh
           ./tools/quality/test-release-download-proxy.sh
+          ./tools/quality/test-public-endpoint-check.sh
           ./tools/quality/test-deployment-optional-config.sh
           ./tools/quality/test-website-runtime-config.sh
           ./tools/quality/test-ga-runtime-config.sh
@@ -301,8 +333,8 @@ jobs:
         with:
           go-version-file: src/agent/go.mod
           cache: false
-      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
-      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ env.REGISTRY_HOST }}
           username: ${{ secrets.REGISTRY_USERNAME }}
@@ -322,7 +354,7 @@ jobs:
 
       - name: Build and push image
         id: build
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}
@@ -340,8 +372,7 @@ jobs:
             SENTRY_FRONTEND_PROJECT=${{ vars.SENTRY_FRONTEND_PROJECT }}
             SENTRY_RELEASE=hyperfilelens-frontend@${{ needs.prepare.outputs.version }}
             VITE_SHOW_EULA=false
-          secrets: |
-            sentry_auth_token=${{ secrets.SENTRY_AUTH_TOKEN }}
+          secrets: ${{ matrix.component == 'hfl-frontend' && secrets.SENTRY_AUTH_TOKEN != '' && format('sentry_auth_token={0}', secrets.SENTRY_AUTH_TOKEN) || '' }}
           cache-from: type=gha,scope=${{ matrix.cache_scope }}
           cache-to: type=gha,scope=${{ matrix.cache_scope }},mode=min
 
@@ -379,8 +410,8 @@ jobs:
         component: [backend, frontend, lensnode]
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
-      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
-      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ env.REGISTRY_HOST }}
           username: ${{ secrets.REGISTRY_USERNAME }}
@@ -635,7 +666,7 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
-      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ env.REGISTRY_HOST }}
           username: ${{ secrets.REGISTRY_USERNAME }}
@@ -668,7 +699,7 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
-      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ env.REGISTRY_HOST }}
           username: ${{ secrets.REGISTRY_USERNAME }}
@@ -703,7 +734,7 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
-      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ env.REGISTRY_HOST }}
           username: ${{ secrets.REGISTRY_USERNAME }}
@@ -837,14 +868,43 @@ jobs:
     needs: [prepare, verify-release]
     permissions:
       contents: write
+    outputs:
+      deployable: ${{ steps.publish.outputs.deployable }}
+      disposition: ${{ steps.publish.outputs.disposition }}
     steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
       - name: Remove internal assets and publish release
+        id: publish
         env:
           GH_TOKEN: ${{ github.token }}
           ARTIFACT_CHANNEL: ${{ needs.prepare.outputs.channel }}
+          ARTIFACT_ID: ${{ needs.prepare.outputs.tag }}
         shell: bash
         run: |
           set -euo pipefail
+          release_freshness=not-applicable
+          if [[ "$ARTIFACT_CHANNEL" == "main" ]]; then
+            freshness="$(./.github/scripts/check-main-freshness.sh "$GITHUB_SHA")"
+            if [[ "$freshness" == "superseded" ]]; then
+              if gh release view "$ARTIFACT_ID" --repo "$GITHUB_REPOSITORY" \
+                >/dev/null 2>&1; then
+                gh release delete "$ARTIFACT_ID" --repo "$GITHUB_REPOSITORY" --yes
+              fi
+              if gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${ARTIFACT_ID}" \
+                --silent >/dev/null 2>&1; then
+                gh api --method DELETE \
+                  "repos/${GITHUB_REPOSITORY}/git/refs/tags/${ARTIFACT_ID}" --silent
+              fi
+              {
+                echo 'deployable=false'
+                echo 'disposition=superseded'
+              } >> "$GITHUB_OUTPUT"
+              printf '### Main publish\n\nSkipped `%s`: origin/main advanced beyond `%s`; a stale rerun cannot publish or deploy.\n' \
+                "$ARTIFACT_ID" "$GITHUB_SHA" >> "$GITHUB_STEP_SUMMARY"
+              exit 0
+            fi
+            [[ "$freshness" == "current" ]]
+          fi
           while IFS= read -r asset; do
             [[ -n "$asset" ]] || continue
             gh release delete-asset "${{ needs.prepare.outputs.tag }}" "$asset" \
@@ -856,9 +916,30 @@ jobs:
             gh release edit "${{ needs.prepare.outputs.tag }}" \
               --repo "${GITHUB_REPOSITORY}" --draft=false --prerelease
           else
-            gh release edit "${{ needs.prepare.outputs.tag }}" \
-              --repo "${GITHUB_REPOSITORY}" --draft=false --latest
+            release_api_url="$(gh release view "$ARTIFACT_ID" \
+              --repo "$GITHUB_REPOSITORY" --json apiUrl --jq '.apiUrl')"
+            release_api_prefix="https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/"
+            [[ "$release_api_url" == "$release_api_prefix"* ]]
+            release_id="${release_api_url#"$release_api_prefix"}"
+            [[ "$release_id" =~ ^[0-9]+$ ]]
+            gh api --method PATCH \
+              "$release_api_url" \
+              -F draft=false -F prerelease=false -f make_latest=legacy --silent
+            release_freshness="$(./.github/scripts/check-release-freshness.sh "$ARTIFACT_ID")"
+            [[ "$release_freshness" == "current" || "$release_freshness" == "superseded" ]]
           fi
+          deployable=true
+          disposition=published
+          if [[ "$ARTIFACT_CHANNEL" == "release" && "$release_freshness" == "superseded" ]]; then
+            deployable=false
+            disposition=published-superseded
+            printf '### Release publish\n\nPublished historical release `%s`; a higher SemVer tag exists, so PREPROD deployment was skipped.\n' \
+              "$ARTIFACT_ID" >> "$GITHUB_STEP_SUMMARY"
+          fi
+          {
+            echo "deployable=$deployable"
+            echo "disposition=$disposition"
+          } >> "$GITHUB_OUTPUT"
 
   deploy-test:
     name: Deploy · TEST
@@ -870,7 +951,10 @@ jobs:
         vars.TEST_DEPLOY_ENABLED == 'true' &&
         needs.prepare.result == 'success' &&
         (
-          needs.publish-release.result == 'success' ||
+          (
+            needs.publish-release.result == 'success' &&
+            needs.publish-release.outputs.deployable == 'true'
+          ) ||
           (
             needs.prepare.outputs.build_required == 'false' &&
             needs.publish-release.result == 'skipped'
@@ -926,7 +1010,8 @@ jobs:
         needs.prepare.outputs.channel == 'release' &&
         vars.PREPROD_DEPLOY_ENABLED == 'true' &&
         needs.prepare.result == 'success' &&
-        needs.publish-release.result == 'success'
+        needs.publish-release.result == 'success' &&
+        needs.publish-release.outputs.deployable == 'true'
       }}
     uses: ./.github/workflows/deploy_target.yml
     with:
@@ -982,50 +1067,13 @@ jobs:
     permissions:
       contents: write
     steps:
-      - name: Retain only the current successful Main build
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+      - name: Retain retryable draft or current successful Main build
         env:
           GH_TOKEN: ${{ github.token }}
           ARTIFACT_ID: ${{ needs.prepare.outputs.tag }}
+          MAIN_COMMIT: ${{ needs.prepare.outputs.commit }}
           BUILD_REQUIRED: ${{ needs.prepare.outputs.build_required }}
           PUBLISH_RESULT: ${{ needs.publish-release.result }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          delete_main_artifact() {
-            local artifact_id=$1
-            if gh release view "$artifact_id" --repo "$GITHUB_REPOSITORY" \
-              >/dev/null 2>&1; then
-              gh release delete "$artifact_id" --repo "$GITHUB_REPOSITORY" --yes
-            fi
-            if gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${artifact_id}" \
-              --silent >/dev/null 2>&1; then
-              gh api --method DELETE \
-                "repos/${GITHUB_REPOSITORY}/git/refs/tags/${artifact_id}" --silent
-            fi
-          }
-
-          retained_id="$ARTIFACT_ID"
-          if [[ "$PUBLISH_RESULT" != "success" ]] \
-            && [[ "$BUILD_REQUIRED" != "false" || "$PUBLISH_RESULT" != "skipped" ]]; then
-            if gh release view "$ARTIFACT_ID" --repo "$GITHUB_REPOSITORY" \
-              --json isDraft --jq '.isDraft' 2>/dev/null \
-              | grep -Fx true >/dev/null; then
-              delete_main_artifact "$ARTIFACT_ID"
-            fi
-            retained_id="$(gh api "repos/${GITHUB_REPOSITORY}/releases?per_page=100" --paginate \
-              --jq '.[] | select(.draft == false and .prerelease == true and (.tag_name | test("^main-[0-9a-f]{7}$"))) | [.created_at, .tag_name] | @tsv' \
-              | sort -r | head -1 | cut -f2)"
-          fi
-
-          gh api "repos/${GITHUB_REPOSITORY}/releases?per_page=100" --paginate \
-            --jq '.[] | select(.tag_name | test("^main-[0-9a-f]{7}$")) | .tag_name' \
-            > "$RUNNER_TEMP/all-main-builds.txt"
-          : > "$RUNNER_TEMP/expired-main-builds.txt"
-          while IFS= read -r artifact_id; do
-            [[ -n "$artifact_id" && "$artifact_id" != "$retained_id" ]] || continue
-            printf '%s\n' "$artifact_id" >> "$RUNNER_TEMP/expired-main-builds.txt"
-          done < "$RUNNER_TEMP/all-main-builds.txt"
-          while IFS= read -r artifact_id; do
-            [[ -n "$artifact_id" ]] || continue
-            delete_main_artifact "$artifact_id"
-          done < "$RUNNER_TEMP/expired-main-builds.txt"
+          PUBLISH_DISPOSITION: ${{ needs.publish-release.outputs.disposition }}
+        run: ./.github/scripts/cleanup-main-builds.sh

--- a/.github/workflows/deploy_target.yml
+++ b/.github/workflows/deploy_target.yml
@@ -186,6 +186,35 @@ jobs:
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
 
+      - name: Guard Current Main Deployment
+        if: ${{ inputs.channel == 'main' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          freshness="$(./.github/scripts/check-main-freshness.sh "$GITHUB_SHA")"
+          if [[ "$freshness" != "current" ]]; then
+            echo '::error title=Superseded Main deployment::A newer origin/main commit exists; this deployment will not contact the TEST host.'
+            printf '### Main deployment\n\nBlocked stale Main commit `%s` before any target-host operation.\n' \
+              "$GITHUB_SHA" >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+
+      - name: Guard Current PREPROD Release
+        if: ${{ inputs.target == 'preprod' && inputs.channel == 'release' }}
+        env:
+          ARTIFACT_ID: ${{ inputs.tag }}
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          freshness="$(./.github/scripts/check-release-freshness.sh "$ARTIFACT_ID")"
+          if [[ "$freshness" != "current" ]]; then
+            echo '::error title=Superseded PREPROD release::A higher SemVer tag exists; this deployment will not contact the PREPROD host.'
+            printf '### PREPROD deployment\n\nBlocked historical release `%s` before any target-host operation.\n' \
+              "$ARTIFACT_ID" >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+
       - name: Validate Deployment Inputs
         env:
           DEPLOY_SSH_PRIVATE_KEY: ${{ secrets.ssh_private_key }}
@@ -457,6 +486,35 @@ jobs:
             "umask 077 && cat > /var/tmp/hyperfilelens-runtime-${GITHUB_RUN_ID}.env && chmod 0600 /var/tmp/hyperfilelens-runtime-${GITHUB_RUN_ID}.env" \
             < "$runtime_env"
 
+      - name: Revalidate Current Main Deployment
+        if: ${{ inputs.channel == 'main' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          freshness="$(./.github/scripts/check-main-freshness.sh "$GITHUB_SHA")"
+          if [[ "$freshness" != "current" ]]; then
+            echo '::error title=Superseded Main deployment::origin/main advanced while this deployment was being prepared; installation is blocked.'
+            printf '### Main deployment\n\nBlocked stale Main commit `%s` immediately before installation.\n' \
+              "$GITHUB_SHA" >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+
+      - name: Revalidate Current PREPROD Release
+        if: ${{ inputs.target == 'preprod' && inputs.channel == 'release' }}
+        env:
+          ARTIFACT_ID: ${{ inputs.tag }}
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          freshness="$(./.github/scripts/check-release-freshness.sh "$ARTIFACT_ID")"
+          if [[ "$freshness" != "current" ]]; then
+            echo '::error title=Superseded PREPROD release::A higher SemVer tag appeared while deployment was being prepared; installation is blocked.'
+            printf '### PREPROD deployment\n\nBlocked historical release `%s` immediately before installation.\n' \
+              "$ARTIFACT_ID" >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+
       - name: Download and Install Release
         shell: bash
         run: |
@@ -636,22 +694,7 @@ jobs:
           fi
 
       - name: Check Public Endpoint
-        shell: bash
-        run: |
-          set +e
-          if [[ -z "$APP_PUBLIC_URL" ]]; then
-            echo '::warning::Public URL is not configured; skipping external availability check'
-            printf '### Public endpoint check\n\nSkipped: the target public URL is empty. Core deployment is healthy.\n' >> "$GITHUB_STEP_SUMMARY"
-            exit 0
-          fi
-          endpoint="${APP_PUBLIC_URL%/}/health/ready"
-          if ! curl -fsS --connect-timeout 10 --max-time 30 --retry 2 "$endpoint" >/dev/null; then
-            echo "::warning::Public endpoint is not ready: $endpoint"
-            printf '### Public endpoint check\n\nWarning: `%s` is not ready. Core deployment and host-local checks passed.\n' "$endpoint" >> "$GITHUB_STEP_SUMMARY"
-          else
-            printf '### Public endpoint check\n\nPassed: `%s`\n' "$endpoint" >> "$GITHUB_STEP_SUMMARY"
-          fi
-          exit 0
+        run: ./.github/scripts/check-public-endpoint.sh
 
       - name: Record Sentry Deployment
         env:
@@ -684,7 +727,7 @@ jobs:
           frontend_project = os.environ.get("SENTRY_FRONTEND_PROJECT", "")
           token = os.environ.get("SENTRY_AUTH_TOKEN", "")
           if not all((url, org, backend_project, frontend_project, token)):
-              print("::warning title=Sentry deployment::Deployment marker configuration is incomplete; continuing.")
+              print("::notice title=Sentry deployment::Deployment markers are skipped until organization, project, and token settings are complete; runtime DSN reporting is unaffected.")
               raise SystemExit(0)
 
           artifact = os.environ.get("ARTIFACT_ID", "").removeprefix("v")

--- a/release/ci/export-hfl-images.sh
+++ b/release/ci/export-hfl-images.sh
@@ -6,6 +6,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 # shellcheck source=../../tools/lib/archive.sh
 source "${ROOT}/tools/lib/archive.sh"
+# shellcheck source=../../tools/lib/docker-images.sh
+source "${ROOT}/tools/lib/docker-images.sh"
 
 [[ $# -eq 3 ]] || {
 	printf 'Usage: %s METADATA_DIR VERSION OUTPUT_TAR\n' "$0" >&2
@@ -15,6 +17,7 @@ source "${ROOT}/tools/lib/archive.sh"
 metadata_dir=$1
 version=${2#v}
 output=$3
+hfl_docker_start_pull_budget "${HFL_DOCKER_PULL_BUDGET_SECONDS:-480}"
 backend_meta="${metadata_dir}/hfl-backend.json"
 frontend_meta="${metadata_dir}/hfl-frontend.json"
 
@@ -32,7 +35,7 @@ pull_and_tag() {
 	ref="$(jq -r '.ref' "${metadata}")"
 	digest="$(jq -r '.digest' "${metadata}")"
 	[[ "${digest}" =~ ^sha256:[0-9a-f]{64}$ ]] || return 2
-	docker pull --platform linux/amd64 "${ref%@*}@${digest}"
+	hfl_docker_pull_with_retry "${ref%@*}@${digest}" linux/amd64 180 2 10
 	docker tag "${ref%@*}@${digest}" "${local_repo}:${version}"
 	docker tag "${ref%@*}@${digest}" "${local_repo}:latest"
 }

--- a/release/ci/export-runtime-images.sh
+++ b/release/ci/export-runtime-images.sh
@@ -6,6 +6,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 # shellcheck source=../../tools/lib/archive.sh
 source "${ROOT}/tools/lib/archive.sh"
+# shellcheck source=../../tools/lib/docker-images.sh
+source "${ROOT}/tools/lib/docker-images.sh"
 # shellcheck source=../../tools/dependencies/versions/runtime-images.env
 source "${ROOT}/tools/dependencies/versions/runtime-images.env"
 
@@ -14,13 +16,14 @@ source "${ROOT}/tools/dependencies/versions/runtime-images.env"
 	exit 2
 }
 output=$1
+hfl_docker_start_pull_budget "${HFL_DOCKER_PULL_BUDGET_SECONDS:-480}"
 tmp="$(mktemp -d)"
 trap 'rm -rf "${tmp}"' EXIT
 mkdir -p "${tmp}/images" "${tmp}/metadata"
 
 export_one() {
 	local image=$1 local_ref=$2 archive=$3 key=$4 source_name
-	docker pull --platform linux/amd64 "${image}"
+	hfl_docker_pull_with_retry "${image}" linux/amd64 180 2 10
 	local digest
 	source_name="${image%@*}"
 	source_name="${source_name%%:*}"

--- a/release/ci/export-sourcelens-bundle.sh
+++ b/release/ci/export-sourcelens-bundle.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+# shellcheck source=../../tools/lib/docker-images.sh
+source "${ROOT}/tools/lib/docker-images.sh"
 # shellcheck source=../../tools/dependencies/versions/runtime-images.env
 source "${ROOT}/tools/dependencies/versions/runtime-images.env"
 export SOURCELENS_NGINX_SOURCE_IMAGE="${NGINX_IMAGE}"
@@ -15,6 +17,7 @@ export SOURCELENS_NGINX_SOURCE_IMAGE="${NGINX_IMAGE}"
 metadata_dir=$1
 hfl_version=${2#v}
 output=$3
+hfl_docker_start_pull_budget "${HFL_DOCKER_PULL_BUDGET_SECONDS:-480}"
 
 # shellcheck source=../../tools/lib/version.sh
 source "${ROOT}/tools/lib/version.sh"
@@ -36,7 +39,7 @@ for component in backend frontend lensnode; do
 	[[ -s "${metadata}" ]] || { printf 'ERROR: missing metadata: %s\n' "${metadata}" >&2; exit 1; }
 	ref="$(jq -r '.ref' "${metadata}")"
 	digest="$(jq -r '.digest' "${metadata}")"
-	docker pull --platform linux/amd64 "${ref%@*}@${digest}"
+	hfl_docker_pull_with_retry "${ref%@*}@${digest}" linux/amd64 180 2 10
 	docker tag "${ref%@*}@${digest}" "$(sourcelens_distribution_image_ref "${component}")"
 	docker tag "${ref%@*}@${digest}" "$(sourcelens_distribution_image_ref "${component}" latest)"
 done

--- a/release/ci/upload-sourcelens-sourcemaps.sh
+++ b/release/ci/upload-sourcelens-sourcemaps.sh
@@ -13,7 +13,7 @@ if [[ -z "${release}" ]]; then
 fi
 if [[ -z "${SENTRY_AUTH_TOKEN:-}" || -z "${SENTRY_URL:-}" \
 	|| -z "${SENTRY_ORG:-}" || -z "${SENTRY_FRONTEND_PROJECT:-}" ]]; then
-	printf '::warning title=Sentry Source Maps::Bundled SourceLens Source Map upload is not configured; continuing.\n'
+	printf '::notice title=Sentry Source Maps::Bundled SourceLens Source Map upload is skipped until organization, project, and token settings are complete; runtime DSN reporting is unaffected.\n'
 	exit 0
 fi
 

--- a/release/ci/verify-host-debs-asset.sh
+++ b/release/ci/verify-host-debs-asset.sh
@@ -2,6 +2,11 @@
 # Install one offline Docker CE dependency asset in its matching Ubuntu image.
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+# shellcheck source=../../tools/lib/docker-images.sh
+source "${ROOT}/tools/lib/docker-images.sh"
+
 [[ $# -eq 2 ]] || {
 	printf 'Usage: %s UBUNTU_RELEASE HOST_DEBS_ASSET\n' "$0" >&2
 	exit 2
@@ -28,7 +33,8 @@ compgen -G "${tmp}/debs/*.deb" >/dev/null \
 	|| { printf 'ERROR: Docker deb archive contains no packages\n' >&2; exit 1; }
 
 image="ubuntu:${ubuntu_release}"
-docker image inspect "${image}" >/dev/null 2>&1 || docker pull "${image}"
+docker image inspect "${image}" >/dev/null 2>&1 \
+	|| hfl_docker_pull_with_retry "${image}" linux/amd64 180 2 10
 docker run --rm --pull=never --network none \
 	-v "${tmp}/debs:/offline-debs:ro" \
 	"${image}" bash -euo pipefail -c '

--- a/release/ci/verify-ubuntu-agent-bundle.sh
+++ b/release/ci/verify-ubuntu-agent-bundle.sh
@@ -2,6 +2,11 @@
 # Execute one Ubuntu-specific Agent bundle with its debs and networking disabled.
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+# shellcheck source=../../tools/lib/docker-images.sh
+source "${ROOT}/tools/lib/docker-images.sh"
+
 [[ $# -eq 3 ]] || {
 	printf 'Usage: %s INTERNAL_AGENT_BUNDLE VERSION UBUNTU_RELEASE\n' "$0" >&2
 	exit 2
@@ -36,7 +41,8 @@ compgen -G "${deps}/*.deb" >/dev/null \
 	|| { printf 'ERROR: Ubuntu-specific Agent debs are missing\n' >&2; exit 1; }
 
 image="ubuntu:${ubuntu_release}"
-docker image inspect "${image}" >/dev/null 2>&1 || docker pull "${image}"
+docker image inspect "${image}" >/dev/null 2>&1 \
+	|| hfl_docker_pull_with_retry "${image}" linux/amd64 180 2 10
 docker run --rm --pull=never --network none \
 	-v "${root}:/agent:ro" \
 	"${image}" bash -euo pipefail -c '

--- a/tools/lib/docker-images.sh
+++ b/tools/lib/docker-images.sh
@@ -29,10 +29,27 @@ hfl_docker_mirror_image_ref() {
 }
 
 hfl_docker_validate_pull_settings() {
-	local timeout_seconds=${1:-180} retries=${2:-2}
+	local timeout_seconds=${1:-180} retries=${2:-2} retry_delay=${3:-10}
 	[[ "${timeout_seconds}" =~ ^[1-9][0-9]*$ ]] || return 1
 	[[ "${retries}" =~ ^[1-9][0-9]*$ ]] || return 1
+	[[ "${retry_delay}" =~ ^[0-9]+$ ]] || return 1
 	command -v timeout >/dev/null 2>&1 || return 1
+}
+
+hfl_docker_start_pull_budget() {
+	local budget_seconds=${1:-480}
+	[[ "${budget_seconds}" =~ ^[1-9][0-9]*$ ]] || {
+		HFL_DOCKER_LAST_ERROR="invalid Docker pull budget: ${budget_seconds}"
+		return 2
+	}
+	HFL_DOCKER_PULL_DEADLINE_SECONDS=$((SECONDS + budget_seconds))
+}
+
+hfl_docker_pull_error_is_terminal() {
+	local log_file=$1
+	grep -Eiq \
+		'unauthorized|authentication required|pull access denied|requested access .* denied|denied:|manifest unknown|no matching manifest|does not match the specified platform|unsupported platform|no space left on device|invalid reference format|failed to verify checksum|digest invalid|unexpected commit digest' \
+		"${log_file}"
 }
 
 hfl_docker_image_matches_platform() {
@@ -49,20 +66,60 @@ hfl_docker_image_matches_platform() {
 
 hfl_docker_pull_with_retry() {
 	local image=$1 platform="${2:-}" timeout_seconds=${3:-180} retries=${4:-2}
-	local attempt
-	hfl_docker_validate_pull_settings "${timeout_seconds}" "${retries}" || {
+	local retry_delay=${5:-10} kill_after_seconds=${HFL_DOCKER_PULL_KILL_AFTER_SECONDS:-10}
+	local attempt attempt_timeout remaining pull_status log_file sleep_seconds
+	hfl_docker_validate_pull_settings "${timeout_seconds}" "${retries}" "${retry_delay}" || {
 		HFL_DOCKER_LAST_ERROR="invalid pull timeout/retry settings or timeout command unavailable"
 		return 2
 	}
+	[[ "${kill_after_seconds}" =~ ^[1-9][0-9]*$ ]] || {
+		HFL_DOCKER_LAST_ERROR="invalid Docker pull forced-termination delay: ${kill_after_seconds}"
+		return 2
+	}
+	log_file="$(mktemp)"
 	for attempt in $(seq 1 "${retries}"); do
+		attempt_timeout=${timeout_seconds}
+		if [[ "${HFL_DOCKER_PULL_DEADLINE_SECONDS:-0}" -gt 0 ]]; then
+			remaining=$((HFL_DOCKER_PULL_DEADLINE_SECONDS - SECONDS))
+			if [[ "${remaining}" -le 0 ]]; then
+				HFL_DOCKER_LAST_ERROR="Docker pull budget exhausted before ${image} completed"
+				rm -f "${log_file}"
+				return 1
+			fi
+			[[ "${remaining}" -ge "${attempt_timeout}" ]] || attempt_timeout=${remaining}
+		fi
 		local -a args=(docker pull)
 		[[ -n "${platform}" ]] && args+=(--platform "${platform}")
 		args+=("${image}")
-		if timeout --foreground "${timeout_seconds}s" "${args[@]}"; then
+		: >"${log_file}"
+		if timeout --foreground --kill-after="${kill_after_seconds}s" \
+			"${attempt_timeout}s" "${args[@]}" 2>&1 | tee "${log_file}"; then
+			rm -f "${log_file}"
 			return 0
 		fi
+		pull_status=${PIPESTATUS[0]}
 		HFL_DOCKER_LAST_ERROR="pull ${image} failed (attempt ${attempt}/${retries})"
+		if hfl_docker_pull_error_is_terminal "${log_file}"; then
+			HFL_DOCKER_LAST_ERROR="pull ${image} failed with a non-retryable registry error"
+			rm -f "${log_file}"
+			return "${pull_status}"
+		fi
+		if [[ "${attempt}" -lt "${retries}" ]]; then
+			sleep_seconds=${retry_delay}
+			if [[ "${HFL_DOCKER_PULL_DEADLINE_SECONDS:-0}" -gt 0 ]]; then
+				remaining=$((HFL_DOCKER_PULL_DEADLINE_SECONDS - SECONDS))
+				if [[ "${remaining}" -le 0 ]]; then
+					HFL_DOCKER_LAST_ERROR="Docker pull budget exhausted after ${image} attempt ${attempt}"
+					rm -f "${log_file}"
+					return 1
+				fi
+				[[ "${remaining}" -ge "${sleep_seconds}" ]] || sleep_seconds=${remaining}
+			fi
+			printf 'WARN: %s; retrying in %ss\n' "${HFL_DOCKER_LAST_ERROR}" "${sleep_seconds}" >&2
+			sleep "${sleep_seconds}"
+		fi
 	done
+	rm -f "${log_file}"
 	return 1
 }
 

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -583,20 +583,55 @@ for job in build-hfl-images build-sourcelens-images build-host-debs export-runti
 		exit 1
 	}
 done
-grep -F 'cancel-in-progress: ${{ inputs.channel == '\''main'\'' }}' "${workflow}" >/dev/null
-grep -F 'Retain only the current successful Main build' "${workflow}" >/dev/null
+grep -F "'hyperfilelens-main'" "${workflow}" >/dev/null
+grep -F "format('hyperfilelens-main-rerun-{0}-{1}', github.run_id, github.run_attempt)" \
+	"${workflow}" >/dev/null
+grep -F "format('hyperfilelens-release-{0}', github.ref_name)" "${workflow}" >/dev/null
+grep -F 'cancel-in-progress: ${{ inputs.channel == '\''main'\'' && github.run_attempt == 1 }}' \
+	"${workflow}" >/dev/null
+grep -F '[[ "$GITHUB_SHA" == "$latest_main" ]]' "${workflow}" >/dev/null
+grep -F 'git merge-base --is-ancestor "$GITHUB_SHA" origin/main' "${workflow}" >/dev/null
+grep -F 'Retain retryable draft or current successful Main build' "${workflow}" >/dev/null
 grep -F 'needs: [prepare, publish-release]' "${workflow}" >/dev/null
 grep -F 'BUILD_REQUIRED: ${{ needs.prepare.outputs.build_required }}' "${workflow}" >/dev/null
-grep -F '[[ "$BUILD_REQUIRED" != "false" || "$PUBLISH_RESULT" != "skipped" ]]' "${workflow}" >/dev/null
+grep -F 'MAIN_COMMIT: ${{ needs.prepare.outputs.commit }}' "${workflow}" >/dev/null
+grep -F 'PUBLISH_DISPOSITION: ${{ needs.publish-release.outputs.disposition }}' \
+	"${workflow}" >/dev/null
+grep -F 'freshness="$(./.github/scripts/check-main-freshness.sh "$GITHUB_SHA")"' \
+	"${workflow}" >/dev/null
+grep -F "needs.publish-release.outputs.deployable == 'true'" "${workflow}" >/dev/null
 cleanup_body="$(sed -n '/^  cleanup-main-builds:/,$p' "${workflow}")"
-grep -F 'delete_main_artifact()' <<<"${cleanup_body}" >/dev/null
-grep -F 'gh release delete "$artifact_id" --repo "$GITHUB_REPOSITORY" --yes' \
-  <<<"${cleanup_body}" >/dev/null
-grep -F 'git/ref/tags/${artifact_id}' <<<"${cleanup_body}" >/dev/null
-grep -F 'git/refs/tags/${artifact_id}' <<<"${cleanup_body}" >/dev/null
+grep -F 'run: ./.github/scripts/cleanup-main-builds.sh' <<<"${cleanup_body}" >/dev/null
 if grep -F -- '--cleanup-tag' <<<"${cleanup_body}" >/dev/null; then
   printf 'ERROR: idempotent Main cleanup must not fail when a Release has no Git tag\n' >&2
   exit 1
+fi
+cleanup_script="${ROOT}/.github/scripts/cleanup-main-builds.sh"
+grep -F 'Retaining retryable Main draft' "${cleanup_script}" >/dev/null
+grep -F '"${PUBLISH_DISPOSITION}" == "superseded"' "${cleanup_script}" >/dev/null
+grep -F 'check-main-freshness.sh" "${MAIN_COMMIT}"' "${cleanup_script}" >/dev/null
+grep -F 'compare/${target_commit}...${MAIN_COMMIT}' "${cleanup_script}" >/dev/null
+grep -F '"${BUILD_REQUIRED}" == "false" && "${PUBLISH_RESULT}" == "skipped"' \
+	"${cleanup_script}" >/dev/null
+grep -F 'gh release delete "${artifact_id}" --repo "${GITHUB_REPOSITORY}" --yes' \
+	"${cleanup_script}" >/dev/null
+grep -F 'git/ref/tags/${artifact_id}' "${cleanup_script}" >/dev/null
+grep -F 'git/refs/tags/${artifact_id}' "${cleanup_script}" >/dev/null
+grep -F 'check-release-freshness.sh "$ARTIFACT_ID"' "${workflow}" >/dev/null
+grep -F 'make_latest=legacy' "${workflow}" >/dev/null
+grep -F -- '--json apiUrl --jq '\''.apiUrl'\''' "${workflow}" >/dev/null
+grep -F 'release_api_prefix="https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/"' \
+	"${workflow}" >/dev/null
+if grep -F 'releases/tags/${ARTIFACT_ID}' "${workflow}" >/dev/null; then
+	printf 'ERROR: formal publishing cannot resolve a draft Release through the tag endpoint\n' >&2
+	exit 1
+fi
+grep -F "needs.publish-release.outputs.deployable == 'true'" "${workflow}" >/dev/null
+grep -F "inputs.target == 'preprod' && inputs.channel == 'release'" \
+	"${ROOT}/.github/workflows/deploy_target.yml" >/dev/null
+if grep -F -- '--cleanup-tag' "${cleanup_script}" >/dev/null; then
+	printf 'ERROR: idempotent Main cleanup must not fail when a Release has no Git tag\n' >&2
+	exit 1
 fi
 grep -F 'ubuntu_release: "22.04"' "${workflow}" >/dev/null
 grep -F 'asset: ubuntu2204' "${workflow}" >/dev/null
@@ -604,6 +639,34 @@ grep -F 'asset: ubuntu2204' "${workflow}" >/dev/null
 grep -F 'actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6' "${workflow}" >/dev/null
 grep -F 'actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6' "${workflow}" >/dev/null
 grep -F 'actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6' "${workflow}" >/dev/null
+grep -F 'docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0' \
+	"${workflow}" >/dev/null
+grep -F 'docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0' \
+	"${workflow}" >/dev/null
+grep -F 'docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0' \
+	"${workflow}" >/dev/null
+[[ "$(grep -c 'uses: docker/setup-buildx-action@' "${workflow}")" -eq \
+	"$(grep -c 'uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0' "${workflow}")" ]]
+[[ "$(grep -c 'uses: docker/login-action@' "${workflow}")" -eq \
+	"$(grep -c 'uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0' "${workflow}")" ]]
+[[ "$(grep -c 'uses: docker/build-push-action@' "${workflow}")" -eq \
+	"$(grep -c 'uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0' "${workflow}")" ]]
+
+for export_script in \
+	"${ROOT}/release/ci/export-hfl-images.sh" \
+	"${ROOT}/release/ci/export-runtime-images.sh" \
+	"${ROOT}/release/ci/export-sourcelens-bundle.sh"; do
+	grep -F 'hfl_docker_start_pull_budget "${HFL_DOCKER_PULL_BUDGET_SECONDS:-480}"' \
+		"${export_script}" >/dev/null
+	grep -F 'hfl_docker_pull_with_retry' "${export_script}" >/dev/null
+	if grep -E '^[[:space:]]*docker pull ' "${export_script}" >/dev/null; then
+		printf 'ERROR: release export bypasses bounded Docker pull retry: %s\n' \
+			"${export_script}" >&2
+		exit 1
+	fi
+done
+grep -F -- '--kill-after="${kill_after_seconds}s"' \
+	"${ROOT}/tools/lib/docker-images.sh" >/dev/null
 
 grep -F '_internal-hfl-images.tar' "${workflow}" >/dev/null
 if grep -E '_internal-[^[:space:]"'\'']*\.tar\.gz' "${workflow}" >/dev/null; then
@@ -935,8 +998,12 @@ grep -F 'https://127.0.0.1:11443/health/ready' \
 	"${ROOT}/.github/workflows/deploy_target.yml" >/dev/null
 grep -F 'https://127.0.0.1:11442/en/' \
 	"${ROOT}/.github/workflows/deploy_target.yml" >/dev/null
-grep -F '::warning::Public endpoint is not ready' \
+grep -F 'run: ./.github/scripts/check-public-endpoint.sh' \
 	"${ROOT}/.github/workflows/deploy_target.yml" >/dev/null
+grep -F 'address.is_global' \
+	"${ROOT}/.github/scripts/check-public-endpoint.sh" >/dev/null
+grep -F '::warning title=Public endpoint check::Public endpoint is not ready' \
+	"${ROOT}/.github/scripts/check-public-endpoint.sh" >/dev/null
 if grep -F 'APP_PUBLIC_HOST' "${ROOT}/.github/workflows/deploy_target.yml" >/dev/null; then
 	printf 'ERROR: deployment checks must not append internal ports to a public hostname\n' >&2
 	exit 1
@@ -1037,9 +1104,17 @@ if grep -F 'upstream_ref' <<<"${fingerprint_body}" >/dev/null; then
 fi
 
 for executable in \
+	"${ROOT}/.github/scripts/check-main-freshness.sh" \
+	"${ROOT}/.github/scripts/check-release-freshness.sh" \
+	"${ROOT}/.github/scripts/check-public-endpoint.sh" \
+	"${ROOT}/.github/scripts/cleanup-main-builds.sh" \
 	"${ROOT}/.github/scripts/remote-deploy.sh" \
 	"${ROOT}/tools/quality/check-python38-runtime.py" \
+	"${ROOT}/tools/quality/test-docker-pull-retry.sh" \
 	"${ROOT}/tools/quality/test-main-channel-contracts.sh" \
+	"${ROOT}/tools/quality/test-main-release-freshness.sh" \
+	"${ROOT}/tools/quality/test-main-release-cleanup.sh" \
+	"${ROOT}/tools/quality/test-release-freshness.sh" \
 	"${ROOT}/tools/quality/test-language-pack-runtime-index.sh" \
 	"${ROOT}/tools/quality/test-upgrade-backup-retention.sh" \
 	"${ROOT}/tools/quality/test-redis-rdb-preflight.sh" \
@@ -1047,6 +1122,7 @@ for executable in \
 	"${ROOT}/tools/quality/test-managed-image-retention.sh" \
 	"${ROOT}/tools/quality/test-shared-host-guard.sh" \
 	"${ROOT}/tools/quality/test-release-download-proxy.sh" \
+	"${ROOT}/tools/quality/test-public-endpoint-check.sh" \
 	"${ROOT}/tools/quality/test-sourcelens-git-mirror.sh" \
 	"${ROOT}/tools/quality/test-sourcelens-submodule-recovery.sh" \
 	"${ROOT}"/release/ci/*.sh \

--- a/tools/quality/test-docker-pull-retry.sh
+++ b/tools/quality/test-docker-pull-retry.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Validate bounded Docker pull retries, terminal error handling, and shared time budgets.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+# shellcheck source=../lib/docker-images.sh
+source "${ROOT}/tools/lib/docker-images.sh"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "${tmp}"' EXIT
+mkdir -p "${tmp}/bin" "${tmp}/state"
+
+cat >"${tmp}/bin/docker" <<'MOCK'
+#!/usr/bin/env bash
+set -euo pipefail
+[[ "${1:-}" == "pull" ]] || exit 2
+count_file="${HFL_DOCKER_TEST_STATE}/count"
+count=0
+[[ ! -f "${count_file}" ]] || count="$(cat "${count_file}")"
+count=$((count + 1))
+printf '%s\n' "${count}" >"${count_file}"
+case "${HFL_DOCKER_TEST_MODE}" in
+flaky)
+	if [[ "${count}" -eq 1 ]]; then
+		printf 'net/http: request canceled while waiting for connection\n' >&2
+		exit 1
+	fi
+	;;
+fatal)
+	printf 'unauthorized: authentication required\n' >&2
+	exit 1
+	;;
+hung)
+	trap '' TERM
+	while :; do :; done
+	;;
+success) ;;
+*) exit 2 ;;
+esac
+MOCK
+chmod +x "${tmp}/bin/docker"
+export PATH="${tmp}/bin:${PATH}"
+export HFL_DOCKER_TEST_STATE="${tmp}/state"
+
+export HFL_DOCKER_TEST_MODE=flaky
+hfl_docker_pull_with_retry example.invalid/app@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa \
+	linux/amd64 5 2 0
+[[ "$(cat "${tmp}/state/count")" == "2" ]]
+
+printf '0\n' >"${tmp}/state/count"
+export HFL_DOCKER_TEST_MODE=fatal
+if hfl_docker_pull_with_retry example.invalid/private:latest linux/amd64 5 3 0; then
+	printf 'ERROR: terminal registry failure unexpectedly succeeded\n' >&2
+	exit 1
+fi
+[[ "$(cat "${tmp}/state/count")" == "1" ]]
+grep -F 'non-retryable registry error' <<<"${HFL_DOCKER_LAST_ERROR}" >/dev/null
+
+printf '0\n' >"${tmp}/state/count"
+export HFL_DOCKER_TEST_MODE=success
+SECONDS=100
+HFL_DOCKER_PULL_DEADLINE_SECONDS=99
+if hfl_docker_pull_with_retry example.invalid/app:latest linux/amd64 5 2 0; then
+	printf 'ERROR: exhausted Docker pull budget unexpectedly succeeded\n' >&2
+	exit 1
+fi
+[[ "$(cat "${tmp}/state/count")" == "0" ]]
+grep -F 'budget exhausted' <<<"${HFL_DOCKER_LAST_ERROR}" >/dev/null
+
+printf '0\n' >"${tmp}/state/count"
+export HFL_DOCKER_TEST_MODE=hung
+export HFL_DOCKER_PULL_KILL_AFTER_SECONDS=1
+SECONDS=0
+if hfl_docker_pull_with_retry example.invalid/hung:latest linux/amd64 1 1 0; then
+	printf 'ERROR: Docker pull that ignored TERM unexpectedly succeeded\n' >&2
+	exit 1
+fi
+[[ "${SECONDS}" -le 5 ]] || {
+	printf 'ERROR: Docker pull forced termination exceeded its bound\n' >&2
+	exit 1
+}
+unset HFL_DOCKER_PULL_KILL_AFTER_SECONDS
+
+printf 'Docker pull retry and budget checks passed.\n'

--- a/tools/quality/test-main-channel-contracts.sh
+++ b/tools/quality/test-main-channel-contracts.sh
@@ -77,8 +77,17 @@ remote_deploy="${ROOT_REPO}/.github/scripts/remote-deploy.sh"
 export_sourcelens="${ROOT_REPO}/release/ci/export-sourcelens-bundle.sh"
 
 grep -F 'TAG="main-${GITHUB_SHA:0:7}"' "${workflow}" >/dev/null
+grep -F '[[ "$GITHUB_SHA" == "$latest_main" ]]' "${workflow}" >/dev/null
+grep -F 'stale retries stop before package construction' "${workflow}" >/dev/null
+grep -F "format('hyperfilelens-main-rerun-{0}-{1}', github.run_id, github.run_attempt)" \
+	"${workflow}" >/dev/null
+grep -F "format('hyperfilelens-release-{0}', github.ref_name)" "${workflow}" >/dev/null
 grep -F 'needs.prepare.outputs.channel == '\''release'\''' "${workflow}" >/dev/null
 grep -F 'Main artifact ID collision:' "${workflow}" >/dev/null
+grep -F 'Main artifact target mismatch:' "${workflow}" >/dev/null
+grep -F 'targetCommitish' "${workflow}" >/dev/null
+grep -F 'check-main-freshness.sh "$GITHUB_SHA"' "${workflow}" >/dev/null
+grep -F "needs.publish-release.outputs.deployable == 'true'" "${workflow}" >/dev/null
 grep -F 'gh release delete "$ARTIFACT_ID" --cleanup-tag --yes' "${workflow}" >/dev/null
 grep -F 'channel: main' "${main_workflow}" >/dev/null
 grep -F 'refs/heads/main' "${main_workflow}" >/dev/null
@@ -86,6 +95,28 @@ grep -F 'vars.TEST_DEPLOY_ENABLED' "${main_workflow}" >/dev/null
 grep -F 'target: test' "${workflow}" >/dev/null
 grep -F "needs.prepare.outputs.build_required == 'false'" "${workflow}" >/dev/null
 grep -F 'test:main|preprod:release|prod:release' "${deploy_workflow}" >/dev/null
+python3 - "${deploy_workflow}" <<'PY'
+import pathlib
+import sys
+
+workflow = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
+guard = workflow.index("- name: Guard Current Main Deployment")
+credentials = workflow.index("- name: Install SSH Credentials")
+revalidate = workflow.index("- name: Revalidate Current Main Deployment")
+install = workflow.index("- name: Download and Install Release")
+guard_block = workflow[guard:credentials]
+revalidate_block = workflow[revalidate:install]
+
+if not guard < credentials:
+    raise SystemExit("Main freshness guard must run before SSH credentials are installed")
+if not revalidate < install:
+    raise SystemExit("Main freshness must be revalidated immediately before installation")
+for label, block in (("initial", guard_block), ("pre-install", revalidate_block)):
+    if "if: ${{ inputs.channel == 'main' }}" not in block:
+        raise SystemExit(f"{label} freshness guard must only apply to Main deployments")
+    if 'check-main-freshness.sh "$GITHUB_SHA"' not in block:
+        raise SystemExit(f"{label} Main deployment freshness check is missing")
+PY
 grep -F 'channel: release' "${release_workflow}" >/dev/null
 grep -F 'workflow_dispatch:' "${production_workflow}" >/dev/null
 grep -F 'target: prod' "${production_workflow}" >/dev/null

--- a/tools/quality/test-main-release-cleanup.sh
+++ b/tools/quality/test-main-release-cleanup.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# Validate retryable Main assets and monotonic cleanup under stale or concurrent runs.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+tmp="$(mktemp -d)"
+trap 'rm -rf "${tmp}"' EXIT
+
+git init --bare --quiet "${tmp}/remote.git"
+git init --quiet "${tmp}/seed"
+git -C "${tmp}/seed" config user.name 'HyperFileLens CI'
+git -C "${tmp}/seed" config user.email 'ci@hyperfilelens.invalid'
+printf 'first\n' >"${tmp}/seed/state.txt"
+git -C "${tmp}/seed" add state.txt
+git -C "${tmp}/seed" commit --quiet -m first
+git -C "${tmp}/seed" branch -M main
+first_commit="$(git -C "${tmp}/seed" rev-parse HEAD)"
+printf 'second\n' >>"${tmp}/seed/state.txt"
+git -C "${tmp}/seed" add state.txt
+git -C "${tmp}/seed" commit --quiet -m second
+second_commit="$(git -C "${tmp}/seed" rev-parse HEAD)"
+git -C "${tmp}/seed" remote add origin "${tmp}/remote.git"
+git -C "${tmp}/seed" push --quiet -u origin main
+git --git-dir="${tmp}/remote.git" symbolic-ref HEAD refs/heads/main
+git -C "${tmp}/seed" switch --quiet -c divergent "${first_commit}"
+printf 'divergent\n' >>"${tmp}/seed/state.txt"
+git -C "${tmp}/seed" add state.txt
+git -C "${tmp}/seed" commit --quiet -m divergent
+divergent_commit="$(git -C "${tmp}/seed" rev-parse HEAD)"
+git -C "${tmp}/seed" push --quiet origin divergent
+git clone --quiet "${tmp}/remote.git" "${tmp}/work"
+
+first_artifact="main-${first_commit:0:7}"
+second_artifact="main-${second_commit:0:7}"
+divergent_artifact="main-${divergent_commit:0:7}"
+
+mkdir -p "${tmp}/bin"
+cat >"${tmp}/bin/gh" <<'MOCK'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%q ' "$@" >>"${GH_MOCK_LOG}"
+printf '\n' >>"${GH_MOCK_LOG}"
+
+if [[ "${1:-}" == "release" && "${2:-}" == "view" ]]; then
+	exit 0
+fi
+if [[ "${1:-}" == "release" && "${2:-}" == "delete" ]]; then
+	exit 0
+fi
+if [[ "${1:-}" == "api" && "${2:-}" == *"releases?per_page=100" ]]; then
+	printf '%b\n' "${GH_MOCK_RELEASES:-}"
+	exit 0
+fi
+if [[ "${1:-}" == "api" && "${2:-}" == *"/compare/"* ]]; then
+	[[ "${GH_MOCK_COMPARE_FAIL:-0}" != "1" ]] || exit 1
+	pair="${2##*/compare/}"
+	base="${pair%%...*}"
+	head="${pair#*...}"
+	if [[ "${base}" == "${head}" ]]; then
+		printf 'identical\n'
+	elif git -C "${GH_MOCK_GIT_REPO}" merge-base --is-ancestor "${base}" "${head}"; then
+		printf 'ahead\n'
+	elif git -C "${GH_MOCK_GIT_REPO}" merge-base --is-ancestor "${head}" "${base}"; then
+		printf 'behind\n'
+	else
+		printf 'diverged\n'
+	fi
+	exit 0
+fi
+if [[ "${1:-}" == "api" ]]; then
+	exit 0
+fi
+printf 'unexpected gh invocation: %s\n' "$*" >&2
+exit 2
+MOCK
+chmod +x "${tmp}/bin/gh"
+
+run_cleanup() {
+	local artifact_id=$1 main_commit=$2 build_required=$3 publish_result=$4
+	local releases=$5 disposition=${6:-incomplete} compare_fail=${7:-0}
+	: >"${tmp}/gh.log"
+	: >"${tmp}/summary.md"
+	(
+		cd "${tmp}/work"
+		PATH="${tmp}/bin:${PATH}" \
+			GH_MOCK_LOG="${tmp}/gh.log" \
+			GH_MOCK_RELEASES="${releases}" \
+			GH_MOCK_GIT_REPO="${tmp}/seed" \
+			GH_MOCK_COMPARE_FAIL="${compare_fail}" \
+			GITHUB_REPOSITORY=HyperBDR/hyperfilelens \
+			GITHUB_STEP_SUMMARY="${tmp}/summary.md" \
+			ARTIFACT_ID="${artifact_id}" \
+			MAIN_COMMIT="${main_commit}" \
+			BUILD_REQUIRED="${build_required}" \
+			PUBLISH_RESULT="${publish_result}" \
+			PUBLISH_DISPOSITION="${disposition}" \
+			"${ROOT}/.github/scripts/cleanup-main-builds.sh"
+	)
+}
+
+release_rows="$(printf '%s\t%s\n%s\t%s\n' \
+	"${second_artifact}" "${second_commit}" \
+	"${first_artifact}" "${first_commit}")"
+
+run_cleanup "${first_artifact}" "${first_commit}" true skipped "${release_rows}"
+if [[ -s "${tmp}/gh.log" ]]; then
+	printf 'ERROR: failed Main publish invoked GitHub cleanup APIs\n' >&2
+	exit 1
+fi
+grep -F "Retained retryable draft \`${first_artifact}\`" "${tmp}/summary.md" >/dev/null
+
+run_cleanup "${second_artifact}" "${second_commit}" true success "${release_rows}" published
+grep -Fq "release delete ${first_artifact}" "${tmp}/gh.log"
+grep -Fq "git/refs/tags/${first_artifact}" "${tmp}/gh.log"
+if grep -Fq "release delete ${second_artifact}" "${tmp}/gh.log"; then
+	printf 'ERROR: successful Main cleanup deleted the retained release\n' >&2
+	exit 1
+fi
+
+run_cleanup "${first_artifact}" "${first_commit}" false skipped "${release_rows}"
+if [[ -s "${tmp}/gh.log" ]]; then
+	printf 'ERROR: stale reused Main run invoked GitHub cleanup APIs\n' >&2
+	exit 1
+fi
+grep -F 'authoritative newer Main release remains unchanged' "${tmp}/summary.md" >/dev/null
+
+run_cleanup "${first_artifact}" "${first_commit}" true success "${release_rows}" superseded
+if [[ -s "${tmp}/gh.log" ]]; then
+	printf 'ERROR: superseded Main cleanup changed the authoritative newer release\n' >&2
+	exit 1
+fi
+
+mixed_rows="$(printf '%s\t%s\n%s\t%s\n%s\t%s\n%s\t%s\n' \
+	"${second_artifact}" "${second_commit}" \
+	"${first_artifact}" "${first_commit}" \
+	"${divergent_artifact}" "${divergent_commit}" \
+	'main-fffffff' 'main')"
+run_cleanup "${second_artifact}" "${second_commit}" true success "${mixed_rows}" published
+grep -Fq "release delete ${first_artifact}" "${tmp}/gh.log"
+if grep -Fq "release delete ${divergent_artifact}" "${tmp}/gh.log" \
+	|| grep -Fq 'release delete main-fffffff' "${tmp}/gh.log"; then
+	printf 'ERROR: cleanup deleted a divergent or unresolved Main release\n' >&2
+	exit 1
+fi
+grep -F 'preserved 2 non-ancestor or unresolved release(s)' "${tmp}/summary.md" >/dev/null
+
+run_cleanup "${second_artifact}" "${second_commit}" true success "${release_rows}" published 1
+if grep -Fq "release delete ${first_artifact}" "${tmp}/gh.log"; then
+	printf 'ERROR: cleanup deleted a release after ancestry verification failed\n' >&2
+	exit 1
+fi
+grep -F 'preserved 1 non-ancestor or unresolved release(s)' "${tmp}/summary.md" >/dev/null
+
+git -C "${tmp}/work" remote set-url origin "${tmp}/missing.git"
+run_cleanup "${second_artifact}" "${second_commit}" true success "${release_rows}" published
+if [[ -s "${tmp}/gh.log" ]]; then
+	printf 'ERROR: cleanup invoked GitHub APIs after Main freshness verification failed\n' >&2
+	exit 1
+fi
+grep -F 'current Main freshness could not be verified' "${tmp}/summary.md" >/dev/null
+git -C "${tmp}/work" remote set-url origin "${tmp}/remote.git"
+
+if ARTIFACT_ID=invalid \
+	MAIN_COMMIT="${second_commit}" \
+	BUILD_REQUIRED=true \
+	PUBLISH_RESULT=success \
+	GITHUB_REPOSITORY=HyperBDR/hyperfilelens \
+	"${ROOT}/.github/scripts/cleanup-main-builds.sh" >/dev/null 2>&1; then
+	printf 'ERROR: invalid Main artifact identifier was accepted\n' >&2
+	exit 1
+fi
+
+printf 'Main release cleanup retry and concurrency contracts passed.\n'

--- a/tools/quality/test-main-release-freshness.sh
+++ b/tools/quality/test-main-release-freshness.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Verify that an older failed Main run cannot become authoritative after main advances.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+tmp="$(mktemp -d)"
+trap 'rm -rf "${tmp}"' EXIT
+
+git init --bare --quiet "${tmp}/remote.git"
+git init --quiet "${tmp}/seed"
+git -C "${tmp}/seed" config user.name 'HyperFileLens CI'
+git -C "${tmp}/seed" config user.email 'ci@hyperfilelens.invalid'
+printf 'first\n' >"${tmp}/seed/state.txt"
+git -C "${tmp}/seed" add state.txt
+git -C "${tmp}/seed" commit --quiet -m first
+git -C "${tmp}/seed" branch -M main
+git -C "${tmp}/seed" remote add origin "${tmp}/remote.git"
+git -C "${tmp}/seed" push --quiet -u origin main
+git --git-dir="${tmp}/remote.git" symbolic-ref HEAD refs/heads/main
+git clone --quiet "${tmp}/remote.git" "${tmp}/work"
+
+first_commit="$(git -C "${tmp}/work" rev-parse HEAD)"
+[[ "$(cd "${tmp}/work" && "${ROOT}/.github/scripts/check-main-freshness.sh" "${first_commit}")" \
+	== "current" ]]
+
+printf 'second\n' >>"${tmp}/seed/state.txt"
+git -C "${tmp}/seed" add state.txt
+git -C "${tmp}/seed" commit --quiet -m second
+git -C "${tmp}/seed" push --quiet origin main
+second_commit="$(git -C "${tmp}/seed" rev-parse HEAD)"
+
+[[ "$(cd "${tmp}/work" && "${ROOT}/.github/scripts/check-main-freshness.sh" "${first_commit}")" \
+	== "superseded" ]]
+[[ "$(cd "${tmp}/work" && "${ROOT}/.github/scripts/check-main-freshness.sh" "${second_commit}")" \
+	== "current" ]]
+
+if (cd "${tmp}/work" && "${ROOT}/.github/scripts/check-main-freshness.sh" invalid) \
+	>/dev/null 2>&1; then
+	printf 'ERROR: invalid Main commit identity was accepted\n' >&2
+	exit 1
+fi
+
+printf 'Main release freshness contracts passed.\n'

--- a/tools/quality/test-public-endpoint-check.sh
+++ b/tools/quality/test-public-endpoint-check.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Validate non-blocking public endpoint checks and private-address classification.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+tmp="$(mktemp -d)"
+trap 'rm -rf "${tmp}"' EXIT
+mkdir -p "${tmp}/bin"
+
+cat >"${tmp}/bin/curl" <<'MOCK'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >>"${HFL_CURL_LOG}"
+exit "${HFL_CURL_STATUS:-0}"
+MOCK
+chmod +x "${tmp}/bin/curl"
+
+run_check() {
+	local url=$1 status=${2:-0}
+	: >"${tmp}/curl.log"
+	: >"${tmp}/summary.md"
+	PATH="${tmp}/bin:${PATH}" \
+		APP_PUBLIC_URL="${url}" \
+		GITHUB_STEP_SUMMARY="${tmp}/summary.md" \
+		HFL_CURL_LOG="${tmp}/curl.log" \
+		HFL_CURL_STATUS="${status}" \
+		"${ROOT}/.github/scripts/check-public-endpoint.sh" \
+		>"${tmp}/output.log" 2>&1
+}
+
+run_check 'https://192.168.10.244:11443'
+[[ ! -s "${tmp}/curl.log" ]]
+grep -F 'is private or non-global' "${tmp}/summary.md" >/dev/null
+
+run_check 'https://127.0.0.1:11443'
+[[ ! -s "${tmp}/curl.log" ]]
+
+run_check 'https://[::1]:11443'
+[[ ! -s "${tmp}/curl.log" ]]
+
+run_check 'UNCONFIGURED'
+[[ ! -s "${tmp}/curl.log" ]]
+grep -F 'not a valid HTTP(S) URL' "${tmp}/summary.md" >/dev/null
+
+run_check 'https://app.hyperfilelens.com'
+grep -F 'https://app.hyperfilelens.com/health/ready' "${tmp}/curl.log" >/dev/null
+grep -F 'Passed:' "${tmp}/summary.md" >/dev/null
+
+run_check 'https://app.hyperfilelens.com' 28
+grep -F 'Warning:' "${tmp}/summary.md" >/dev/null
+
+mkdir -p "${tmp}/fail-bin"
+cat >"${tmp}/fail-bin/python3" <<'MOCK'
+#!/usr/bin/env bash
+exit 42
+MOCK
+chmod +x "${tmp}/fail-bin/python3"
+PATH="${tmp}/fail-bin:${PATH}" run_check 'https://app.hyperfilelens.com'
+grep -F 'execution failed with status 42' "${tmp}/summary.md" >/dev/null
+
+printf 'Public endpoint check contracts passed.\n'

--- a/tools/quality/test-release-freshness.sh
+++ b/tools/quality/test-release-freshness.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Validate stable published-release ordering independently of workflow completion order.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+tmp="$(mktemp -d)"
+trap 'rm -rf "${tmp}"' EXIT
+mkdir -p "${tmp}/bin"
+
+cat >"${tmp}/bin/gh" <<'MOCK'
+#!/usr/bin/env bash
+set -euo pipefail
+[[ "${1:-}" == "api" && "${2:-}" == *"/releases?per_page=100" ]] || exit 2
+[[ "${HFL_RELEASE_API_FAIL:-0}" != "1" ]] || exit 1
+tr ' ' '\n' <<<"${HFL_PUBLISHED_RELEASE_TAGS:-}"
+MOCK
+chmod +x "${tmp}/bin/gh"
+
+run_check() {
+	PATH="${tmp}/bin:${PATH}" \
+		GITHUB_REPOSITORY=HyperBDR/hyperfilelens \
+		HFL_RELEASE_FRESHNESS_RETRY_DELAY_SECONDS=0 \
+		HFL_PUBLISHED_RELEASE_TAGS="${HFL_PUBLISHED_RELEASE_TAGS:-}" \
+		HFL_RELEASE_API_FAIL="${HFL_RELEASE_API_FAIL:-0}" \
+		"${ROOT}/.github/scripts/check-release-freshness.sh" "$1"
+}
+
+export HFL_PUBLISHED_RELEASE_TAGS='v0.1.9 v0.2.0 v0.10.0 ignored'
+[[ "$(run_check v0.10.0)" == "current" ]]
+[[ "$(run_check v0.2.0)" == "superseded" ]]
+if run_check v0.3.0 >/dev/null 2>&1; then
+	printf 'ERROR: unpublished stable release was accepted\n' >&2
+	exit 1
+fi
+if run_check invalid >/dev/null 2>&1; then
+	printf 'ERROR: invalid stable release tag was accepted\n' >&2
+	exit 1
+fi
+
+export HFL_RELEASE_API_FAIL=1
+if run_check v0.10.0 >/dev/null 2>&1; then
+	printf 'ERROR: failed release API lookup was accepted\n' >&2
+	exit 1
+fi
+
+artifact_workflow="${ROOT}/.github/workflows/artifact_pipeline.yml"
+deploy_workflow="${ROOT}/.github/workflows/deploy_target.yml"
+python3 - "${artifact_workflow}" "${deploy_workflow}" <<'PY'
+import pathlib
+import sys
+
+artifact = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
+deploy = pathlib.Path(sys.argv[2]).read_text(encoding="utf-8")
+preprod = artifact[
+    artifact.index("  deploy-preprod:") : artifact.index("  cleanup-main-builds:")
+]
+if "needs.publish-release.outputs.deployable == 'true'" not in preprod:
+    raise SystemExit("PREPROD deployment must require the release freshness output")
+if "make_latest=legacy" not in artifact:
+    raise SystemExit("stable releases must use GitHub's SemVer-compatible Latest policy")
+if '--json apiUrl --jq \'.apiUrl\'' not in artifact:
+    raise SystemExit("formal publishing must resolve the draft Release API URL")
+if "releases/tags/${ARTIFACT_ID}" in artifact:
+    raise SystemExit("formal publishing must not use the draft-incompatible tag endpoint")
+
+guard = deploy.index("- name: Guard Current PREPROD Release")
+credentials = deploy.index("- name: Install SSH Credentials")
+revalidate = deploy.index("- name: Revalidate Current PREPROD Release")
+install = deploy.index("- name: Download and Install Release")
+for label, block in (
+    ("initial", deploy[guard:credentials]),
+    ("pre-install", deploy[revalidate:install]),
+):
+    if "inputs.target == 'preprod' && inputs.channel == 'release'" not in block:
+        raise SystemExit(f"{label} PREPROD release guard has the wrong scope")
+    if 'check-release-freshness.sh "$ARTIFACT_ID"' not in block:
+        raise SystemExit(f"{label} PREPROD release freshness check is missing")
+PY
+
+printf 'Stable published-release freshness contracts passed.\n'

--- a/tools/quality/test-sentry-runtime-config.sh
+++ b/tools/quality/test-sentry-runtime-config.sh
@@ -307,5 +307,24 @@ grep -F 'TEST_SENTRY_ENABLED' "${ROOT}/.github/workflows/artifact_pipeline.yml" 
 grep -F 'PREPROD_SENTRY_ENABLED' "${ROOT}/.github/workflows/artifact_pipeline.yml" >/dev/null
 grep -F 'PROD_SENTRY_ENABLED' "${ROOT}/.github/workflows/production_deploy.yml" >/dev/null
 grep -F 'SENTRY_AUTH_TOKEN' "${ROOT}/.github/workflows/artifact_pipeline.yml" >/dev/null
+grep -F "secrets.SENTRY_AUTH_TOKEN != ''" \
+	"${ROOT}/.github/workflows/artifact_pipeline.yml" >/dev/null
+if grep -F 'sentry_auth_token=${{ secrets.SENTRY_AUTH_TOKEN }}' \
+	"${ROOT}/.github/workflows/artifact_pipeline.yml" >/dev/null; then
+	printf 'ERROR: an empty Sentry token can still be passed as a BuildKit secret\n' >&2
+	exit 1
+fi
+
+sourcemap_notice="$(env -u SENTRY_AUTH_TOKEN -u SENTRY_ORG -u SENTRY_FRONTEND_PROJECT \
+	SENTRY_URL=https://sentry.example.com \
+	"${ROOT}/release/ci/upload-sourcelens-sourcemaps.sh" test-release)"
+grep -F '::notice title=Sentry Source Maps::Bundled SourceLens Source Map upload is skipped' \
+	<<<"${sourcemap_notice}" >/dev/null
+if grep -F '::warning' <<<"${sourcemap_notice}" >/dev/null; then
+	printf 'ERROR: incomplete optional Source Map settings emitted a warning\n' >&2
+	exit 1
+fi
+grep -F '::notice title=Sentry deployment::Deployment markers are skipped' \
+	"${ROOT}/.github/workflows/deploy_target.yml" >/dev/null
 
 printf 'Runtime Sentry configuration checks passed.\n'


### PR DESCRIPTION
## Summary

- preserve retryable Main drafts while preventing stale publish, cleanup, and deployment rollback
- bound Docker pulls and modernize Docker Actions without requiring optional Sentry credentials
- keep stable releases SemVer ordered and prevent historical tags from rolling PREPROD back
- make public endpoint and optional Sentry checks resilient and non-blocking

## Validation

- complete CI/Release contract suite
- Main and stable Release concurrency regressions
- Main and Tag synthetic offline package assembly
- Docker pull retry, timeout, and forced-termination tests
- blue/green, SourceLens, Gateway, shared-host, and runtime configuration regressions
- actionlint, ShellCheck, YAML parsing, shell syntax, and git diff checks

Frontend lint and bundle-size debt remains tracked separately in #280.