### PR TITLE
feat: extend Sentry observability to platform gateways

### DIFF
--- a/.github/workflows/deploy_target.yml
+++ b/.github/workflows/deploy_target.yml
@@ -445,7 +445,8 @@ jobs:
                       "prod": "hfl-production",
                   }.get(target, "")
               elif name == "SENTRY_TRACES_SAMPLE_RATE":
-                  value = "0.05" if os.environ.get("DEPLOY_TARGET") == "prod" else "0.1"
+                  # Error tracking is enabled by default; performance tracing is opt-in.
+                  value = "0"
               if name == "HFL_GA_MEASUREMENT_ID":
                   if os.environ.get("DEPLOY_TARGET") != "prod":
                       value = ""

--- a/deploy/bootstrap/gateway-install-lensnode-sidecar.sh
+++ b/deploy/bootstrap/gateway-install-lensnode-sidecar.sh
@@ -8,6 +8,7 @@ COMPOSE_DIR="/etc/hyperfilelens/lensnode"
 COMPOSE_PROJECT="hyperfilelens-gateway"
 DEFAULT_LENSNODE_IMAGE="${LENSNODE_IMAGE:-hyperfilelens-sourcelens-lensnode:latest}"
 SENTRY_PRIVACY_FILE="${COMPOSE_DIR}/hfl-sentry-sitecustomize.py"
+SIDECAR_LOCK_FILE="${HFL_GATEWAY_SIDECAR_LOCK_FILE:-/run/lock/hyperfilelens-gateway-sidecar.lock}"
 
 hfl_now() {
 	date -u +%Y-%m-%dT%H:%M:%S.000Z 2>/dev/null || date -u +%Y-%m-%dT%H:%M:%SZ
@@ -30,9 +31,24 @@ hfl_fail() {
 	exit "${2:-1}"
 }
 
+acquire_sidecar_lock() {
+	[[ "${HFL_GATEWAY_SIDECAR_LOCK_HELD:-0}" == "1" ]] && return 0
+	command -v flock >/dev/null 2>&1 \
+		|| hfl_fail "The flock command is required for Gateway lifecycle serialization." 1
+	mkdir -p "$(dirname "${SIDECAR_LOCK_FILE}")" \
+		|| hfl_fail "Could not create the Gateway lifecycle lock directory." 1
+	if ! exec 9>"${SIDECAR_LOCK_FILE}"; then
+		hfl_fail "Could not open the Gateway lifecycle lock." 1
+	fi
+	flock -x 9 || hfl_fail "Could not acquire the Gateway lifecycle lock." 1
+	export HFL_GATEWAY_SIDECAR_LOCK_HELD=1
+}
+
 if [[ "$(id -u)" -ne 0 ]]; then
 	hfl_fail "Administrator privileges are required." 1
 fi
+
+acquire_sidecar_lock
 
 if [[ ! -f "${ENV_FILE}" ]]; then
 	hfl_fail "Missing ${ENV_FILE} (run hfl-enroll gateway-install first)." 2

--- a/deploy/bootstrap/gateway-lifecycle.sh
+++ b/deploy/bootstrap/gateway-lifecycle.sh
@@ -14,6 +14,7 @@ HFL_NODE_ID=""
 HFL_INSECURE_TLS="${HFL_INSECURE_TLS:-1}"
 PURGE_ALL=0
 HFL_LAST_ERROR=""
+SIDECAR_LOCK_FILE="${HFL_GATEWAY_SIDECAR_LOCK_FILE:-/run/lock/hyperfilelens-gateway-sidecar.lock}"
 
 DOWNLOAD_MAX_ATTEMPTS="${HFL_GATEWAY_DOWNLOAD_MAX_ATTEMPTS:-5}"
 DOWNLOAD_RETRY_DELAY_SECONDS="${HFL_GATEWAY_DOWNLOAD_RETRY_DELAY_SECONDS:-2}"
@@ -36,6 +37,19 @@ hfl_fail() {
 	HFL_LAST_ERROR=$1
 	printf '[%s] [FAIL ] %s\n' "$(hfl_now)" "$1" >&2
 	exit "${2:-1}"
+}
+
+acquire_sidecar_lock() {
+	[[ "${HFL_GATEWAY_SIDECAR_LOCK_HELD:-0}" == "1" ]] && return 0
+	command -v flock >/dev/null 2>&1 \
+		|| hfl_fail "The flock command is required for Gateway lifecycle serialization." 1
+	mkdir -p "$(dirname "${SIDECAR_LOCK_FILE}")" \
+		|| hfl_fail "Could not create the Gateway lifecycle lock directory." 1
+	if ! exec 9>"${SIDECAR_LOCK_FILE}"; then
+		hfl_fail "Could not open the Gateway lifecycle lock." 1
+	fi
+	flock -x 9 || hfl_fail "Could not acquire the Gateway lifecycle lock." 1
+	export HFL_GATEWAY_SIDECAR_LOCK_HELD=1
 }
 
 curl_tls=(-k)
@@ -246,6 +260,7 @@ run_sidecar_install_script() {
 
 cmd_upgrade_sidecar() {
 	local tmp="" script
+	acquire_sidecar_lock
 	load_agent_credentials
 	report_lifecycle_status "sidecar_upgrade" "running"
 	trap 'gateway_upgrade_exit "$?" "${tmp}"' EXIT
@@ -323,6 +338,7 @@ purge_sidecar_artifacts() {
 }
 
 cmd_uninstall_sidecar() {
+	acquire_sidecar_lock
 	if ! load_agent_credentials_optional; then
 		hfl_log "Agent credentials are unavailable; continuing local LensNode cleanup without status reporting."
 	fi

--- a/deploy/installer/install.sh
+++ b/deploy/installer/install.sh
@@ -3072,49 +3072,6 @@ wait_for_local_platform_gateway_online() {
 	die "installer-managed local platform Gateway did not reconnect its WebSocket"
 }
 
-read_platform_gateway_sentry_values() {
-	python3 - "${ROOT}/.env" "${ROOT}/sourcelens/BUILD_INFO.json" <<'PY'
-import json
-import pathlib
-import shlex
-import sys
-
-env_path = pathlib.Path(sys.argv[1])
-build_info_path = pathlib.Path(sys.argv[2])
-values = {}
-if env_path.is_file():
-    for line in env_path.read_text(encoding="utf-8").splitlines():
-        if not line or line.lstrip().startswith("#") or "=" not in line:
-            continue
-        key, value = line.split("=", 1)
-        value = value.strip()
-        if value[:1] in {"'", '"'}:
-            try:
-                decoded = shlex.split(value)
-            except ValueError:
-                decoded = []
-            value = decoded[0] if len(decoded) == 1 else ""
-        values[key.strip()] = value.replace("$$", "$")
-
-sl_version = "unknown"
-if build_info_path.is_file():
-    try:
-        sl_version = str(json.loads(build_info_path.read_text(encoding="utf-8")).get("version") or "unknown")
-    except (OSError, json.JSONDecodeError):
-        pass
-hfl_version = values.get("APP_VERSION", "unknown")
-for value in (
-    values.get("SENTRY_ENABLED", "false"),
-    values.get("SENTRY_BACKEND_DSN", ""),
-    values.get("SENTRY_ENVIRONMENT", ""),
-    values.get("SENTRY_TRACES_SAMPLE_RATE", "0"),
-    f"hyperfilelens-agent@{hfl_version}",
-    f"hyperfilelens-lensnode@{hfl_version}-sl{sl_version}",
-):
-    print(value)
-PY
-}
-
 ensure_local_platform_gateway() {
 	if ! platform_gateway_auto_deploy_enabled; then
 		skip "Local platform Gateway auto-deploy is disabled"
@@ -3167,10 +3124,6 @@ print("\t".join([*(str(payload[key]).strip() for key in required), node_ids]))
 	wss_url="wss://127.0.0.1:${tenant_port}/ws/node/agent/"
 
 	local existing_org existing_role existing_node_id existing_token desired_version installed_version
-	local -a sentry_values=()
-	mapfile -t sentry_values < <(read_platform_gateway_sentry_values)
-	((${#sentry_values[@]} == 6)) \
-		|| die "unable to resolve local Platform Gateway Sentry configuration"
 	existing_org="$(read_agent_env_value HFL_ORG_KEY)"
 	existing_role="$(read_agent_env_value HFL_NODE_ROLE)"
 	existing_node_id="$(read_agent_env_value HFL_NODE_ID)"
@@ -3196,18 +3149,19 @@ print("\t".join([*(str(payload[key]).strip() for key in required), node_ids]))
 	fi
 
 	run_as_root env \
+		-u SENTRY_ENABLED \
+		-u SENTRY_BACKEND_DSN \
+		-u SENTRY_ENVIRONMENT \
+		-u SENTRY_RELEASE \
+		-u SENTRY_TRACES_SAMPLE_RATE \
+		-u HFL_SENTRY_LENSNODE_RELEASE \
+		-u HFL_SENTRY_POLICY_MANAGED \
 		HFL_ORG_KEY="${org_key}" \
 		HFL_NODE_ROLE="gateway" \
 		HFL_NODE_TOKEN="${token}" \
 		HFL_API_BASE="${api_base}" \
 		HFL_WSS_URL="${wss_url}" \
 		HFL_INSECURE_TLS=1 \
-		SENTRY_ENABLED="${sentry_values[0]}" \
-		SENTRY_BACKEND_DSN="${sentry_values[1]}" \
-		SENTRY_ENVIRONMENT="${sentry_values[2]}" \
-		SENTRY_TRACES_SAMPLE_RATE="${sentry_values[3]}" \
-		SENTRY_RELEASE="${sentry_values[4]}" \
-		HFL_SENTRY_LENSNODE_RELEASE="${sentry_values[5]}" \
 		HFL_FORCE_SIDECAR_INSTALL=1 \
 		"${helper}" gateway-install --yes
 	desired_version="$(read_version)"

--- a/src/agent/internal/app/agent.go
+++ b/src/agent/internal/app/agent.go
@@ -6,19 +6,24 @@ import (
 	"fmt"
 	"log/slog"
 	"math/rand"
+	"os"
 	"strings"
 	"time"
 
 	"hyperfilelens/agent/internal/controller"
+	"hyperfilelens/agent/internal/enroll"
 	"hyperfilelens/agent/internal/infra/config"
 	"hyperfilelens/agent/internal/infra/database"
 	"hyperfilelens/agent/internal/infra/monitor"
+	"hyperfilelens/agent/internal/infra/observability"
+	"hyperfilelens/agent/internal/model"
 	"hyperfilelens/agent/internal/remote"
 	"hyperfilelens/agent/internal/selfupdate"
 	"hyperfilelens/agent/internal/wire"
 )
 
 const controlPlanePollInterval = 5 * time.Second
+const gatewayObservabilityRefreshInterval = 10 * time.Minute
 
 // Agent is the runtime composition root coordinating module startup and shutdown.
 type Agent struct {
@@ -154,6 +159,9 @@ func (a *Agent) Run(ctx context.Context) error {
 					return err
 				}
 				go a.deferredLifecycleRepair(context.WithoutCancel(ctx))
+				if a.store.Current().Role == model.RoleGateway {
+					go a.gatewayObservabilityLoop(ctx)
+				}
 				return nil
 			},
 		)
@@ -166,6 +174,72 @@ func (a *Agent) Run(ctx context.Context) error {
 
 		if strings.TrimSpace(a.store.Current().WSSURL) == "" {
 			a.connector = nil
+		}
+	}
+}
+
+func (a *Agent) gatewayObservabilityLoop(ctx context.Context) {
+	agentEnvPath, _ := a.store.Paths()
+	refresh := func() {
+		current := a.store.Current()
+		if current.Role != model.RoleGateway {
+			if err := observability.Configure(observability.Policy{}); err != nil {
+				slog.Warn("gateway Agent Sentry disable failed; continuing", "err", err)
+			}
+			return
+		}
+		cfg := enroll.Config{
+			OrgKey:      current.OrgKey,
+			NodeRole:    current.Role,
+			NodeToken:   current.NodeToken,
+			APIBase:     current.APIBaseURL,
+			WSSURL:      current.WSSURL,
+			InsecureTLS: strings.TrimSpace(strings.ToLower(os.Getenv("HFL_INSECURE_TLS"))) != "0",
+		}
+		nodeID := strings.TrimSpace(current.NodeID)
+		if nodeID == "" {
+			nodeID = strings.TrimSpace(enroll.ReadNodeID(agentEnvPath))
+		}
+		lens, err := enroll.FetchGatewayLensConfig(ctx, cfg, nodeID)
+		if err != nil {
+			slog.Warn("gateway observability refresh failed; preserving current policy", "err", err)
+			return
+		}
+		agentChanged, persistErr := enroll.SyncManagedObservabilityPolicyAt(
+			agentEnvPath,
+			lens.Observability,
+		)
+		if persistErr != nil {
+			slog.Warn("gateway Agent observability persistence failed; continuing", "err", persistErr)
+		}
+		configureErr := observability.Configure(observability.Policy{
+			Enabled:          lens.Observability.Enabled,
+			BackendDSN:       lens.Observability.BackendDSN,
+			Environment:      lens.Observability.Environment,
+			Release:          lens.Observability.AgentRelease,
+			TracesSampleRate: lens.Observability.TracesSampleRate,
+		})
+		if configureErr != nil {
+			slog.Warn("gateway Agent Sentry reconfiguration failed; continuing", "err", configureErr)
+		}
+		lensChanged, lensErr := enroll.ConvergeGatewayLensObservability(ctx, cfg, lens)
+		if lensErr != nil {
+			slog.Warn("gateway LensNode observability convergence failed; continuing", "err", lensErr)
+		}
+		if persistErr == nil && configureErr == nil && lensErr == nil && (agentChanged || lensChanged) {
+			slog.Info("gateway observability policy converged", "enabled", lens.Observability.Enabled)
+		}
+	}
+
+	refresh()
+	ticker := time.NewTicker(gatewayObservabilityRefreshInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			refresh()
 		}
 	}
 }

--- a/src/agent/internal/enroll/envfile.go
+++ b/src/agent/internal/enroll/envfile.go
@@ -14,6 +14,7 @@ import (
 )
 
 var managedSentryEnvKeys = []string{
+	"HFL_SENTRY_POLICY_MANAGED",
 	"SENTRY_ENABLED",
 	"SENTRY_BACKEND_DSN",
 	"SENTRY_ENVIRONMENT",
@@ -79,11 +80,6 @@ func WriteEnrollmentEnv(cfg Config) error {
 		"HFL_KOPIA_PATH=" + kopiaPath,
 		"HFL_INSECURE_TLS=" + insecure,
 	}
-	for _, name := range managedSentryEnvKeys {
-		if value := strings.TrimSpace(os.Getenv(name)); value != "" && !strings.ContainsAny(value, "\r\n") {
-			lines = append(lines, name+"="+value)
-		}
-	}
 	if existing := ReadNodeID(envPath); existing != "" {
 		lines = append(lines, "HFL_NODE_ID="+existing)
 	}
@@ -94,31 +90,21 @@ func WriteEnrollmentEnv(cfg Config) error {
 	return os.WriteFile(envPath, []byte(content), 0o600)
 }
 
-// SyncManagedSentryEnv converges only HFL-managed observability settings.
-// Existing node credentials and user-managed Agent settings remain unchanged.
-func SyncManagedSentryEnv() (bool, error) {
-	return syncManagedSentryEnv(EnvFilePath())
+// SyncManagedObservabilityPolicy converges a server-verified platform policy.
+// A disabled/private policy removes all previously managed Sentry credentials.
+func SyncManagedObservabilityPolicy(policy ObservabilityPolicy) (bool, error) {
+	return SyncManagedObservabilityPolicyAt(EnvFilePath(), policy)
 }
 
-func syncManagedSentryEnv(envPath string) (bool, error) {
-	rawEnabled := strings.TrimSpace(os.Getenv("SENTRY_ENABLED"))
-	if rawEnabled == "" {
-		return false, nil
-	}
-	enabled := "false"
-	if sentryEnabledValue(rawEnabled) {
-		enabled = "true"
-	}
-	desired := map[string]string{"SENTRY_ENABLED": enabled}
-	if sentryEnabledValue(enabled) {
-		for _, name := range managedSentryEnvKeys[1:] {
-			value := strings.TrimSpace(os.Getenv(name))
-			if value != "" && !strings.ContainsAny(value, "\r\n") {
-				desired[name] = value
-			}
-		}
-	}
+// SyncManagedObservabilityPolicyAt converges policy in a resolved Agent env file.
+func SyncManagedObservabilityPolicyAt(
+	envPath string,
+	policy ObservabilityPolicy,
+) (bool, error) {
+	return syncManagedSentryValues(envPath, policy.agentEnvValues())
+}
 
+func syncManagedSentryValues(envPath string, desired map[string]string) (bool, error) {
 	current, err := os.ReadFile(envPath)
 	if err != nil {
 		return false, err
@@ -153,15 +139,6 @@ func syncManagedSentryEnv(envPath string) (bool, error) {
 		return false, err
 	}
 	return true, nil
-}
-
-func sentryEnabledValue(value string) bool {
-	switch strings.ToLower(strings.TrimSpace(value)) {
-	case "1", "true", "yes", "on":
-		return true
-	default:
-		return false
-	}
 }
 
 func writePrivateEnvAtomically(path string, content []byte) error {

--- a/src/agent/internal/enroll/envfile_test.go
+++ b/src/agent/internal/enroll/envfile_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-func TestSyncManagedSentryEnvPreservesCredentialsAndReplacesManagedValues(t *testing.T) {
+func TestSyncManagedObservabilityPolicyPreservesCredentials(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "agent.env")
 	original := strings.Join([]string{
 		"HFL_NODE_ID=42",
@@ -21,19 +21,20 @@ func TestSyncManagedSentryEnvPreservesCredentialsAndReplacesManagedValues(t *tes
 	if err := os.WriteFile(path, []byte(original), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	t.Setenv("SENTRY_ENABLED", "true")
-	t.Setenv("SENTRY_BACKEND_DSN", "https://new@sentry.example.com/2")
-	t.Setenv("SENTRY_ENVIRONMENT", "hfl-production")
-	t.Setenv("SENTRY_RELEASE", "hyperfilelens-agent@0.1.8")
-	t.Setenv("SENTRY_TRACES_SAMPLE_RATE", "0.05")
-	t.Setenv("HFL_SENTRY_LENSNODE_RELEASE", "hyperfilelens-lensnode@0.1.8-sl0.20.0")
-
-	changed, err := syncManagedSentryEnv(path)
+	policy := ObservabilityPolicy{
+		Enabled:          true,
+		BackendDSN:       "https://new@sentry.example.com/2",
+		Environment:      "hfl-production",
+		AgentRelease:     "hyperfilelens-agent@0.1.8",
+		LensnodeRelease:  "hyperfilelens-lensnode@0.1.8-sl0.20.0",
+		TracesSampleRate: 0,
+	}
+	changed, err := SyncManagedObservabilityPolicyAt(path, policy)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if !changed {
-		t.Fatal("syncManagedSentryEnv() changed = false, want true")
+		t.Fatal("SyncManagedObservabilityPolicyAt() changed = false, want true")
 	}
 	content, err := os.ReadFile(path)
 	if err != nil {
@@ -44,6 +45,7 @@ func TestSyncManagedSentryEnvPreservesCredentialsAndReplacesManagedValues(t *tes
 		"HFL_NODE_ID=42",
 		"HFL_NODE_TOKEN=working-token",
 		"USER_MANAGED=value",
+		"HFL_SENTRY_POLICY_MANAGED=true",
 		"SENTRY_BACKEND_DSN=https://new@sentry.example.com/2",
 		"SENTRY_ENVIRONMENT=hfl-production",
 		"SENTRY_RELEASE=hyperfilelens-agent@0.1.8",
@@ -56,16 +58,16 @@ func TestSyncManagedSentryEnvPreservesCredentialsAndReplacesManagedValues(t *tes
 		t.Fatalf("updated agent.env retained old Sentry DSN:\n%s", text)
 	}
 
-	changed, err = syncManagedSentryEnv(path)
+	changed, err = SyncManagedObservabilityPolicyAt(path, policy)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if changed {
-		t.Fatal("second syncManagedSentryEnv() changed = true, want false")
+		t.Fatal("second SyncManagedObservabilityPolicyAt() changed = true, want false")
 	}
 }
 
-func TestSyncManagedSentryEnvDisablesAndRemovesCredentials(t *testing.T) {
+func TestDisabledObservabilityPolicyRemovesCredentials(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "agent.env")
 	if err := os.WriteFile(path, []byte(
 		"HFL_NODE_TOKEN=working-token\nSENTRY_ENABLED=true\n"+
@@ -73,20 +75,18 @@ func TestSyncManagedSentryEnvDisablesAndRemovesCredentials(t *testing.T) {
 	), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	t.Setenv("SENTRY_ENABLED", "false")
-
-	changed, err := syncManagedSentryEnv(path)
+	changed, err := SyncManagedObservabilityPolicyAt(path, ObservabilityPolicy{})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if !changed {
-		t.Fatal("syncManagedSentryEnv() changed = false, want true")
+		t.Fatal("SyncManagedObservabilityPolicyAt() changed = false, want true")
 	}
 	content, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got := string(content); got != "HFL_NODE_TOKEN=working-token\nSENTRY_ENABLED=false\n" {
+	if got := string(content); got != "HFL_NODE_TOKEN=working-token\nSENTRY_ENABLED=false\nHFL_SENTRY_POLICY_MANAGED=true\n" {
 		t.Fatalf("updated agent.env = %q", got)
 	}
 }

--- a/src/agent/internal/enroll/gateway_install.go
+++ b/src/agent/internal/enroll/gateway_install.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 	"runtime"
 	"strings"
 	"time"
@@ -23,6 +22,7 @@ type LensSidecarConfig struct {
 	LensnodeToken string
 	LensnodeName  string
 	WorkspaceRoot string
+	Observability ObservabilityPolicy
 }
 
 // RunGatewayInstall installs the HFL agent and SourceLens LensNode sidecar for role=gateway.
@@ -41,18 +41,6 @@ func RunGatewayInstall(ctx context.Context, opts InstallOptions) error {
 	if err := RunInstall(ctx, opts); err != nil {
 		return err
 	}
-	// Re-enrollment may short-circuit for an already healthy Agent. Converge
-	// only HFL-managed observability keys; never replace working node credentials.
-	sentryChanged, err := SyncManagedSentryEnv()
-	if err != nil {
-		return fmt.Errorf("refresh Gateway Agent configuration: %w", err)
-	}
-	if sentryChanged {
-		if err := RestartInstalledService(ctx); err != nil {
-			return fmt.Errorf("restart Gateway Agent after configuration refresh: %w", err)
-		}
-	}
-
 	logStep("Continuing Data Gateway setup (AI engine).")
 
 	nodeID := strings.TrimSpace(ReadNodeID(EnvFilePath()))
@@ -66,18 +54,21 @@ func RunGatewayInstall(ctx context.Context, opts InstallOptions) error {
 		_ = ReportGatewayInstallStatus(ctx, cfg, nodeID, "failed", err.Error())
 		logFail("LensNode configuration is unavailable: "+err.Error(), 6)
 	}
+	// The authenticated console response is authoritative. Platform Gateways
+	// receive the deployment Sentry policy; private Gateways receive disabled.
+	// Observability convergence must never block enrollment or data operations.
+	if changed, syncErr := SyncManagedObservabilityPolicy(lensCfg.Observability); syncErr != nil {
+		logWarn("Could not persist Gateway Agent observability policy; continuing.")
+	} else if changed {
+		if restartErr := RestartInstalledService(ctx); restartErr != nil {
+			logWarn("Could not restart Gateway Agent after observability refresh; the policy will apply on the next restart.")
+		}
+	}
 
 	logStep("Installing AI engine.")
 	if err := ensureGatewayDocker(ctx, cfg); err != nil {
 		_ = ReportGatewayInstallStatus(ctx, cfg, nodeID, "failed", err.Error())
 		logFail("Docker setup failed: "+err.Error(), 7)
-	}
-	if lensSidecarHealthy() && os.Getenv("HFL_FORCE_SIDECAR_INSTALL") != "1" {
-		logOK("AI engine is already running.")
-		_ = ReportGatewayInstallStatus(ctx, cfg, nodeID, "success", "")
-		info := summaryFromState(cfg.APIBase, nodeID, "", serviceState(ctx))
-		printGatewayInstallSuccess(info, lensCfg)
-		return nil
 	}
 	if err := InstallLensSidecar(ctx, cfg, lensCfg); err != nil {
 		_ = ReportGatewayInstallStatus(ctx, cfg, nodeID, "failed", err.Error())
@@ -123,6 +114,10 @@ func FetchGatewayLensConfig(ctx context.Context, cfg Config, nodeID string) (Len
 		return LensSidecarConfig{}, fmt.Errorf("HTTP %s: %s", resp.Status, strings.TrimSpace(string(raw)))
 	}
 
+	return parseGatewayLensConfig(raw)
+}
+
+func parseGatewayLensConfig(raw []byte) (LensSidecarConfig, error) {
 	var parsed map[string]any
 	if err := json.Unmarshal(raw, &parsed); err != nil {
 		return LensSidecarConfig{}, fmt.Errorf("parse response: %w", err)
@@ -142,6 +137,16 @@ func FetchGatewayLensConfig(ctx context.Context, cfg Config, nodeID string) (Len
 		LensnodeToken: stringField(lensRaw, "lensnode_token"),
 		LensnodeName:  stringField(lensRaw, "lensnode_name"),
 		WorkspaceRoot: stringField(lensRaw, "workspace_root"),
+	}
+	if observabilityRaw, ok := data["observability"].(map[string]any); ok {
+		cfgOut.Observability = ObservabilityPolicy{
+			Enabled:          boolField(observabilityRaw, "enabled"),
+			BackendDSN:       stringField(observabilityRaw, "backend_dsn"),
+			Environment:      stringField(observabilityRaw, "environment"),
+			AgentRelease:     stringField(observabilityRaw, "agent_release"),
+			LensnodeRelease:  stringField(observabilityRaw, "lensnode_release"),
+			TracesSampleRate: floatField(observabilityRaw, "traces_sample_rate"),
+		}.Normalized()
 	}
 	if cfgOut.LensBaseURL == "" || cfgOut.LensnodeToken == "" || cfgOut.LensnodeUUID == "" {
 		return LensSidecarConfig{}, fmt.Errorf("incomplete lens configuration from console")
@@ -208,6 +213,30 @@ func stringField(m map[string]any, key string) string {
 		return strings.TrimSpace(s)
 	default:
 		return strings.TrimSpace(fmt.Sprint(v))
+	}
+}
+
+func boolField(m map[string]any, key string) bool {
+	value, ok := m[key]
+	if !ok {
+		return false
+	}
+	result, _ := value.(bool)
+	return result
+}
+
+func floatField(m map[string]any, key string) float64 {
+	value, ok := m[key]
+	if !ok {
+		return 0
+	}
+	switch number := value.(type) {
+	case float64:
+		return number
+	case float32:
+		return float64(number)
+	default:
+		return 0
 	}
 }
 

--- a/src/agent/internal/enroll/observability_policy.go
+++ b/src/agent/internal/enroll/observability_policy.go
@@ -1,0 +1,97 @@
+package enroll
+
+import (
+	"net/url"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+var (
+	observabilityEnvironmentPattern = regexp.MustCompile(`^hfl-(test|preprod|production)$`)
+	observabilityReleasePattern     = regexp.MustCompile(`^[A-Za-z0-9._@+-]+$`)
+)
+
+// ObservabilityPolicy is the bounded control-plane policy for a Data Gateway.
+// Private Gateways receive only Enabled=false; DSNs are distributed exclusively
+// to server-verified platform Gateways.
+type ObservabilityPolicy struct {
+	Enabled          bool
+	BackendDSN       string
+	Environment      string
+	AgentRelease     string
+	LensnodeRelease  string
+	TracesSampleRate float64
+}
+
+func validPublicSentryDSN(value string) bool {
+	parsed, err := url.Parse(strings.TrimSpace(value))
+	if err != nil || (parsed.Scheme != "http" && parsed.Scheme != "https") || parsed.Hostname() == "" {
+		return false
+	}
+	if parsed.User == nil || parsed.User.Username() == "" {
+		return false
+	}
+	if _, hasPassword := parsed.User.Password(); hasPassword {
+		return false
+	}
+	if parsed.RawQuery != "" || parsed.Fragment != "" {
+		return false
+	}
+	projectID := strings.TrimSpace(strings.TrimSuffix(parsed.Path, "/"))
+	projectID = projectID[strings.LastIndex(projectID, "/")+1:]
+	_, err = strconv.ParseUint(projectID, 10, 64)
+	return err == nil
+}
+
+// Normalized returns a fail-closed policy safe to persist and apply locally.
+func (p ObservabilityPolicy) Normalized() ObservabilityPolicy {
+	if !p.Enabled {
+		return ObservabilityPolicy{}
+	}
+	p.BackendDSN = strings.TrimSpace(p.BackendDSN)
+	p.Environment = strings.TrimSpace(p.Environment)
+	p.AgentRelease = strings.TrimSpace(p.AgentRelease)
+	p.LensnodeRelease = strings.TrimSpace(p.LensnodeRelease)
+	if !validPublicSentryDSN(p.BackendDSN) ||
+		!observabilityEnvironmentPattern.MatchString(p.Environment) ||
+		!observabilityReleasePattern.MatchString(p.AgentRelease) ||
+		!observabilityReleasePattern.MatchString(p.LensnodeRelease) ||
+		p.TracesSampleRate < 0 || p.TracesSampleRate > 1 {
+		return ObservabilityPolicy{}
+	}
+	return p
+}
+
+func (p ObservabilityPolicy) agentEnvValues() map[string]string {
+	p = p.Normalized()
+	if !p.Enabled {
+		return map[string]string{
+			"HFL_SENTRY_POLICY_MANAGED": "true",
+			"SENTRY_ENABLED":            "false",
+		}
+	}
+	return map[string]string{
+		"HFL_SENTRY_POLICY_MANAGED":   "true",
+		"SENTRY_ENABLED":              "true",
+		"SENTRY_BACKEND_DSN":          p.BackendDSN,
+		"SENTRY_ENVIRONMENT":          p.Environment,
+		"SENTRY_RELEASE":              p.AgentRelease,
+		"SENTRY_TRACES_SAMPLE_RATE":   strconv.FormatFloat(p.TracesSampleRate, 'g', -1, 64),
+		"HFL_SENTRY_LENSNODE_RELEASE": p.LensnodeRelease,
+	}
+}
+
+func (p ObservabilityPolicy) lensnodeEnvValues() map[string]string {
+	p = p.Normalized()
+	if !p.Enabled {
+		return map[string]string{"SENTRY_ENABLED": "false"}
+	}
+	return map[string]string{
+		"SENTRY_ENABLED":              "true",
+		"SENTRY_BACKEND_DSN":          p.BackendDSN,
+		"SENTRY_ENVIRONMENT":          p.Environment,
+		"SENTRY_TRACES_SAMPLE_RATE":   strconv.FormatFloat(p.TracesSampleRate, 'g', -1, 64),
+		"HFL_SENTRY_LENSNODE_RELEASE": p.LensnodeRelease,
+	}
+}

--- a/src/agent/internal/enroll/observability_policy_test.go
+++ b/src/agent/internal/enroll/observability_policy_test.go
@@ -1,0 +1,86 @@
+package enroll
+
+import (
+	"strings"
+	"testing"
+)
+
+func platformObservabilityPolicy() ObservabilityPolicy {
+	return ObservabilityPolicy{
+		Enabled:          true,
+		BackendDSN:       "https://public@sentry.example.com/25",
+		Environment:      "hfl-test",
+		AgentRelease:     "hyperfilelens-agent@main-123abcd",
+		LensnodeRelease:  "hyperfilelens-lensnode@main-123abcd-sl0.20.0",
+		TracesSampleRate: 0,
+	}
+}
+
+func TestObservabilityPolicyRejectsPrivateCredentialDSN(t *testing.T) {
+	policy := platformObservabilityPolicy()
+	policy.BackendDSN = "https://public:private@sentry.example.com/25"
+
+	if got := policy.Normalized(); got.Enabled {
+		t.Fatalf("Normalized() enabled = true for credential-bearing DSN: %#v", got)
+	}
+}
+
+func TestParseGatewayLensConfigNormalizesObservabilityPolicy(t *testing.T) {
+	raw := `{
+        "node_id": 42,
+        "lens": {
+            "lens_base_url": "https://lens.example.com",
+            "lensnode_uuid": "26d1822b-3ccc-48f8-80f1-f4c0ae99e61e",
+            "lensnode_token": "lens-token",
+            "workspace_root": "/workspace"
+        },
+        "observability": {
+            "enabled": true,
+            "backend_dsn": "https://public@sentry.example.com/25",
+            "environment": "hfl-preprod",
+            "agent_release": "hyperfilelens-agent@0.1.8",
+            "lensnode_release": "hyperfilelens-lensnode@0.1.8-sl0.20.0",
+            "traces_sample_rate": 0
+        }
+    }`
+
+	lens, err := parseGatewayLensConfig([]byte(raw))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !lens.Observability.Enabled {
+		t.Fatalf("observability policy was disabled: %#v", lens.Observability)
+	}
+	if lens.Observability.Environment != "hfl-preprod" {
+		t.Fatalf("environment = %q", lens.Observability.Environment)
+	}
+}
+
+func TestParseGatewayLensConfigFailsClosedForInvalidPolicy(t *testing.T) {
+	raw := `{
+        "lens": {
+            "lens_base_url": "https://lens.example.com",
+            "lensnode_uuid": "26d1822b-3ccc-48f8-80f1-f4c0ae99e61e",
+            "lensnode_token": "lens-token"
+        },
+        "observability": {
+            "enabled": true,
+            "backend_dsn": "https://public:private@sentry.example.com/25",
+            "environment": "hfl-production",
+            "agent_release": "hyperfilelens-agent@0.1.8",
+            "lensnode_release": "hyperfilelens-lensnode@0.1.8-sl0.20.0",
+            "traces_sample_rate": 0
+        }
+    }`
+
+	lens, err := parseGatewayLensConfig([]byte(raw))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lens.Observability.Enabled {
+		t.Fatalf("credential-bearing policy was accepted: %#v", lens.Observability)
+	}
+	if strings.TrimSpace(lens.WorkspaceRoot) != "/workspace" {
+		t.Fatalf("default workspace root = %q", lens.WorkspaceRoot)
+	}
+}

--- a/src/agent/internal/enroll/sidecar_install_unix.go
+++ b/src/agent/internal/enroll/sidecar_install_unix.go
@@ -3,18 +3,26 @@
 package enroll
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha256"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"syscall"
+	"time"
 
 	"hyperfilelens/agent/internal/platform/install"
 )
 
 const (
 	lensEnvFilePath            = "/etc/hyperfilelens/lensnode.env"
+	lensAppliedFingerprintPath = "/etc/hyperfilelens/lensnode/.hfl-applied-config.sha256"
+	lensSidecarLockPath        = "/run/lock/hyperfilelens-gateway-sidecar.lock"
+	lensSidecarLockHeldEnv     = "HFL_GATEWAY_SIDECAR_LOCK_HELD"
 	lensSidecarScript          = "gateway-install-lensnode-sidecar.sh"
 	lensnodeImageArchive       = "lensnode-image-linux-amd64.tar.gz"
 	gatewayDockerInstallScript = "gateway-install-docker-ubuntu-amd64.sh"
@@ -23,39 +31,57 @@ const (
 	gatewayMinDockerCompose    = "2.20.0"
 )
 
+type lensSidecarRuntime struct {
+	envPath        string
+	appliedPath    string
+	lockPath       string
+	healthy        func() bool
+	ensureImage    func(context.Context, Config) error
+	installSidecar func(context.Context, Config) error
+}
+
+func defaultLensSidecarRuntime() lensSidecarRuntime {
+	return lensSidecarRuntime{
+		envPath:        lensEnvFilePath,
+		appliedPath:    lensAppliedFingerprintPath,
+		lockPath:       lensSidecarLockPath,
+		healthy:        lensSidecarHealthy,
+		ensureImage:    ensureLensnodeImage,
+		installSidecar: runLensSidecarInstaller,
+	}
+}
+
 // InstallLensSidecar writes LensNode credentials and runs the bundled sidecar install script.
 func InstallLensSidecar(ctx context.Context, cfg Config, lens LensSidecarConfig) error {
-	if err := writeLensEnvFile(lens); err != nil {
-		return err
-	}
+	return defaultLensSidecarRuntime().install(ctx, cfg, lens)
+}
 
-	if lensSidecarHealthy() && os.Getenv("HFL_FORCE_SIDECAR_INSTALL") != "1" {
-		logStep("LensNode sidecar is already running.")
-		return nil
-	}
+func (runtime lensSidecarRuntime) install(
+	ctx context.Context,
+	cfg Config,
+	lens LensSidecarConfig,
+) error {
+	return withFileLock(ctx, runtime.lockPath, func() error {
+		_, fingerprint, err := writeLensEnvFileAt(runtime.envPath, lens)
+		if err != nil {
+			return err
+		}
 
-	if err := ensureLensnodeImage(ctx, cfg); err != nil {
-		return err
-	}
+		if runtime.healthy() &&
+			os.Getenv("HFL_FORCE_SIDECAR_INSTALL") != "1" &&
+			lensConfigurationApplied(runtime.appliedPath, fingerprint) {
+			logStep("LensNode sidecar is already running.")
+			return nil
+		}
 
-	scriptPath, cleanup, err := downloadSidecarInstallScript(ctx, cfg)
-	if err != nil {
-		return err
-	}
-	defer cleanup()
-
-	cmd := exec.CommandContext(ctx, "/bin/bash", scriptPath)
-	cmd.Env = append(os.Environ(),
-		"HFL_LENS_ENV_FILE="+lensEnvFilePath,
-		"HFL_INSECURE_TLS="+insecureTLSEnv(),
-		"LENSNODE_IMAGE="+defaultLensnodeImage,
-	)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("sidecar install script: %w", err)
-	}
-	return nil
+		if err := runtime.ensureImage(ctx, cfg); err != nil {
+			return err
+		}
+		if err := runtime.installSidecar(ctx, cfg); err != nil {
+			return err
+		}
+		return markLensConfigurationApplied(runtime.appliedPath, fingerprint)
+	})
 }
 
 func ensureGatewayDocker(ctx context.Context, cfg Config) error {
@@ -152,10 +178,10 @@ func lensSidecarHealthy() bool {
 	return false
 }
 
-func writeLensEnvFile(lens LensSidecarConfig) error {
-	dir := filepath.Dir(lensEnvFilePath)
+func writeLensEnvFileAt(path string, lens LensSidecarConfig) (bool, string, error) {
+	dir := filepath.Dir(path)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
-		return fmt.Errorf("create %s: %w", dir, err)
+		return false, "", fmt.Errorf("create %s: %w", dir, err)
 	}
 
 	lines := []string{
@@ -168,6 +194,7 @@ func writeLensEnvFile(lens LensSidecarConfig) error {
 	if lens.LensnodeName != "" {
 		lines = append(lines, "LENSNODE_NAME="+quoteEnv(lens.LensnodeName))
 	}
+	policyValues := lens.Observability.lensnodeEnvValues()
 	for _, name := range []string{
 		"SENTRY_ENABLED",
 		"SENTRY_BACKEND_DSN",
@@ -175,13 +202,126 @@ func writeLensEnvFile(lens LensSidecarConfig) error {
 		"SENTRY_TRACES_SAMPLE_RATE",
 		"HFL_SENTRY_LENSNODE_RELEASE",
 	} {
-		if value := strings.TrimSpace(os.Getenv(name)); value != "" && !strings.ContainsAny(value, "\r\n") {
+		if value, present := policyValues[name]; present {
 			lines = append(lines, name+"="+quoteEnv(value))
 		}
 	}
 	content := strings.Join(lines, "\n") + "\n"
-	if err := os.WriteFile(lensEnvFilePath, []byte(content), 0o600); err != nil {
-		return fmt.Errorf("write %s: %w", lensEnvFilePath, err)
+	fingerprint := fmt.Sprintf("%x", sha256.Sum256([]byte(content)))
+	current, err := os.ReadFile(path)
+	if err == nil && bytes.Equal(current, []byte(content)) {
+		return false, fingerprint, nil
+	}
+	if err != nil && !os.IsNotExist(err) {
+		return false, "", fmt.Errorf("read %s: %w", path, err)
+	}
+	if err := writePrivateEnvAtomically(path, []byte(content)); err != nil {
+		return false, "", fmt.Errorf("write %s: %w", path, err)
+	}
+	return true, fingerprint, nil
+}
+
+// ConvergeGatewayLensObservability refreshes only LensNode Sentry settings.
+// Missing/unhealthy LensNode workloads are left to the explicit Gateway lifecycle.
+func ConvergeGatewayLensObservability(
+	ctx context.Context,
+	cfg Config,
+	lens LensSidecarConfig,
+) (bool, error) {
+	return defaultLensSidecarRuntime().convergeObservability(ctx, cfg, lens)
+}
+
+func (runtime lensSidecarRuntime) convergeObservability(
+	ctx context.Context,
+	cfg Config,
+	lens LensSidecarConfig,
+) (bool, error) {
+	changed := false
+	err := withFileLock(ctx, runtime.lockPath, func() error {
+		var fingerprint string
+		var err error
+		changed, fingerprint, err = writeLensEnvFileAt(runtime.envPath, lens)
+		if err != nil {
+			return err
+		}
+		if lensConfigurationApplied(runtime.appliedPath, fingerprint) ||
+			!runtime.healthy() {
+			return nil
+		}
+		if err := runtime.installSidecar(ctx, cfg); err != nil {
+			return fmt.Errorf("refresh LensNode observability: %w", err)
+		}
+		if err := markLensConfigurationApplied(runtime.appliedPath, fingerprint); err != nil {
+			return err
+		}
+		changed = true
+		return nil
+	})
+	return changed, err
+}
+
+func lensConfigurationApplied(path, fingerprint string) bool {
+	content, err := os.ReadFile(path)
+	return err == nil && strings.TrimSpace(string(content)) == fingerprint
+}
+
+func markLensConfigurationApplied(path, fingerprint string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return fmt.Errorf("create LensNode state directory: %w", err)
+	}
+	if err := writePrivateEnvAtomically(path, []byte(fingerprint+"\n")); err != nil {
+		return fmt.Errorf("record applied LensNode configuration: %w", err)
+	}
+	return nil
+}
+
+func withFileLock(ctx context.Context, path string, action func() error) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create sidecar lock directory: %w", err)
+	}
+	lock, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return fmt.Errorf("open sidecar lock: %w", err)
+	}
+	defer lock.Close()
+
+	for {
+		err = syscall.Flock(int(lock.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+		if err == nil {
+			break
+		}
+		if !errors.Is(err, syscall.EWOULDBLOCK) && !errors.Is(err, syscall.EAGAIN) {
+			return fmt.Errorf("lock sidecar lifecycle: %w", err)
+		}
+		timer := time.NewTimer(250 * time.Millisecond)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return ctx.Err()
+		case <-timer.C:
+		}
+	}
+	defer func() { _ = syscall.Flock(int(lock.Fd()), syscall.LOCK_UN) }()
+	return action()
+}
+
+func runLensSidecarInstaller(ctx context.Context, cfg Config) error {
+	scriptPath, cleanup, err := downloadSidecarInstallScript(ctx, cfg)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+	cmd := exec.CommandContext(ctx, "/bin/bash", scriptPath)
+	cmd.Env = append(os.Environ(),
+		"HFL_LENS_ENV_FILE="+lensEnvFilePath,
+		"HFL_INSECURE_TLS="+insecureTLSEnv(),
+		"LENSNODE_IMAGE="+defaultLensnodeImage,
+		lensSidecarLockHeldEnv+"=1",
+	)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("sidecar install script: %w", err)
 	}
 	return nil
 }

--- a/src/agent/internal/enroll/sidecar_install_windows.go
+++ b/src/agent/internal/enroll/sidecar_install_windows.go
@@ -12,6 +12,15 @@ func InstallLensSidecar(ctx context.Context, cfg Config, lens LensSidecarConfig)
 	return fmt.Errorf("AI engine install is Linux-only")
 }
 
+// ConvergeGatewayLensObservability is Linux-only because full Data Gateways are Linux-only.
+func ConvergeGatewayLensObservability(
+	ctx context.Context,
+	cfg Config,
+	lens LensSidecarConfig,
+) (bool, error) {
+	return false, fmt.Errorf("Gateway observability is Linux-only")
+}
+
 func ensureGatewayDocker(ctx context.Context, cfg Config) error {
 	return fmt.Errorf("gateway-install requires Linux")
 }

--- a/src/agent/internal/enroll/sidecar_observability_unix_test.go
+++ b/src/agent/internal/enroll/sidecar_observability_unix_test.go
@@ -1,0 +1,207 @@
+//go:build !windows
+
+package enroll
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestWriteLensEnvFileAtAppliesPlatformPolicyIdempotently(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "lensnode.env")
+	lens := LensSidecarConfig{
+		LensBaseURL:   "https://lens.example.com",
+		LensnodeUUID:  "26d1822b-3ccc-48f8-80f1-f4c0ae99e61e",
+		LensnodeToken: "lens-token",
+		LensnodeName:  "platform-lens",
+		WorkspaceRoot: "/workspace",
+		Observability: platformObservabilityPolicy(),
+	}
+
+	changed, fingerprint, err := writeLensEnvFileAt(path, lens)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed {
+		t.Fatal("first write changed = false, want true")
+	}
+	if fingerprint == "" {
+		t.Fatal("first write returned an empty fingerprint")
+	}
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(content)
+	for _, expected := range []string{
+		"SENTRY_ENABLED=true",
+		"SENTRY_BACKEND_DSN=https://public@sentry.example.com/25",
+		"SENTRY_ENVIRONMENT=hfl-test",
+		"HFL_SENTRY_LENSNODE_RELEASE=hyperfilelens-lensnode@main-123abcd-sl0.20.0",
+	} {
+		if !strings.Contains(text, expected+"\n") {
+			t.Fatalf("lensnode.env missing %q:\n%s", expected, text)
+		}
+	}
+
+	changed, secondFingerprint, err := writeLensEnvFileAt(path, lens)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if changed {
+		t.Fatal("second write changed = true, want false")
+	}
+	if secondFingerprint != fingerprint {
+		t.Fatalf("fingerprint changed: %q != %q", secondFingerprint, fingerprint)
+	}
+}
+
+func TestWriteLensEnvFileAtDisablesPrivateGateway(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "lensnode.env")
+	lens := LensSidecarConfig{
+		LensBaseURL:   "https://lens.example.com",
+		LensnodeUUID:  "26d1822b-3ccc-48f8-80f1-f4c0ae99e61e",
+		LensnodeToken: "lens-token",
+		WorkspaceRoot: "/workspace",
+	}
+
+	if _, _, err := writeLensEnvFileAt(path, lens); err != nil {
+		t.Fatal(err)
+	}
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(content)
+	if !strings.Contains(text, "SENTRY_ENABLED=false\n") {
+		t.Fatalf("private lensnode.env did not disable Sentry:\n%s", text)
+	}
+	if strings.Contains(text, "SENTRY_BACKEND_DSN=") {
+		t.Fatalf("private lensnode.env contains a DSN field:\n%s", text)
+	}
+}
+
+func TestLensObservabilityRetriesFailedApply(t *testing.T) {
+	root := t.TempDir()
+	attempts := 0
+	runtime := lensSidecarRuntime{
+		envPath:     filepath.Join(root, "lensnode.env"),
+		appliedPath: filepath.Join(root, "state", "applied.sha256"),
+		lockPath:    filepath.Join(root, "sidecar.lock"),
+		healthy:     func() bool { return true },
+		ensureImage: func(context.Context, Config) error { return nil },
+		installSidecar: func(context.Context, Config) error {
+			attempts++
+			if attempts == 1 {
+				return errors.New("simulated compose failure")
+			}
+			return nil
+		},
+	}
+	lens := LensSidecarConfig{
+		LensBaseURL:   "https://lens.example.com",
+		LensnodeUUID:  "26d1822b-3ccc-48f8-80f1-f4c0ae99e61e",
+		LensnodeToken: "lens-token",
+		WorkspaceRoot: "/workspace",
+		Observability: platformObservabilityPolicy(),
+	}
+
+	if _, err := runtime.convergeObservability(context.Background(), Config{}, lens); err == nil {
+		t.Fatal("first convergence unexpectedly succeeded")
+	}
+	if _, err := os.Stat(runtime.appliedPath); !os.IsNotExist(err) {
+		t.Fatalf("failed apply recorded a fingerprint: %v", err)
+	}
+	changed, err := runtime.convergeObservability(context.Background(), Config{}, lens)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed || attempts != 2 {
+		t.Fatalf("retry result changed=%v attempts=%d", changed, attempts)
+	}
+	changed, err = runtime.convergeObservability(context.Background(), Config{}, lens)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if changed || attempts != 2 {
+		t.Fatalf("idempotent result changed=%v attempts=%d", changed, attempts)
+	}
+}
+
+func TestHealthyLensSidecarAppliesChangedConfiguration(t *testing.T) {
+	root := t.TempDir()
+	runs := 0
+	runtime := lensSidecarRuntime{
+		envPath:     filepath.Join(root, "lensnode.env"),
+		appliedPath: filepath.Join(root, "state", "applied.sha256"),
+		lockPath:    filepath.Join(root, "sidecar.lock"),
+		healthy:     func() bool { return true },
+		ensureImage: func(context.Context, Config) error { return nil },
+		installSidecar: func(context.Context, Config) error {
+			runs++
+			return nil
+		},
+	}
+	privateLens := LensSidecarConfig{
+		LensBaseURL:   "https://lens.example.com",
+		LensnodeUUID:  "26d1822b-3ccc-48f8-80f1-f4c0ae99e61e",
+		LensnodeToken: "lens-token",
+		WorkspaceRoot: "/workspace",
+	}
+	_, privateFingerprint, err := writeLensEnvFileAt(runtime.envPath, privateLens)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := markLensConfigurationApplied(runtime.appliedPath, privateFingerprint); err != nil {
+		t.Fatal(err)
+	}
+
+	platformLens := privateLens
+	platformLens.Observability = platformObservabilityPolicy()
+	if err := runtime.install(context.Background(), Config{}, platformLens); err != nil {
+		t.Fatal(err)
+	}
+	if runs != 1 {
+		t.Fatalf("changed configuration installer runs = %d, want 1", runs)
+	}
+	if err := runtime.install(context.Background(), Config{}, platformLens); err != nil {
+		t.Fatal(err)
+	}
+	if runs != 1 {
+		t.Fatalf("unchanged configuration installer runs = %d, want 1", runs)
+	}
+}
+
+func TestFileLockSerializesAndHonorsContext(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "sidecar.lock")
+	locked := make(chan struct{})
+	release := make(chan struct{})
+	firstDone := make(chan error, 1)
+	go func() {
+		firstDone <- withFileLock(context.Background(), path, func() error {
+			close(locked)
+			<-release
+			return nil
+		})
+	}()
+	<-locked
+
+	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
+	defer cancel()
+	unexpectedRun := errors.New("second action ran while the first lock was held")
+	err := withFileLock(ctx, path, func() error {
+		return unexpectedRun
+	})
+	close(release)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("second lock error = %v, want deadline exceeded", err)
+	}
+	if err := <-firstDone; err != nil {
+		t.Fatal(err)
+	}
+}

--- a/src/agent/internal/infra/observability/sentry.go
+++ b/src/agent/internal/infra/observability/sentry.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/getsentry/sentry-go"
@@ -13,8 +14,31 @@ import (
 
 const flushTimeout = 2 * time.Second
 
+// Policy is the runtime-safe subset delivered to a platform Gateway Agent.
+type Policy struct {
+	Enabled          bool
+	BackendDSN       string
+	Environment      string
+	Release          string
+	TracesSampleRate float64
+}
+
+var (
+	policyMu      sync.Mutex
+	currentPolicy Policy
+	configured    bool
+)
+
 func enabled() bool {
-	switch strings.ToLower(strings.TrimSpace(os.Getenv("SENTRY_ENABLED"))) {
+	if !truthy(os.Getenv("HFL_SENTRY_POLICY_MANAGED")) ||
+		strings.TrimSpace(strings.ToLower(os.Getenv("HFL_NODE_ROLE"))) != "gateway" {
+		return false
+	}
+	return truthy(os.Getenv("SENTRY_ENABLED"))
+}
+
+func truthy(value string) bool {
+	switch strings.ToLower(strings.TrimSpace(value)) {
 	case "1", "true", "yes", "on":
 		return true
 	default:
@@ -30,24 +54,40 @@ func sampleRate() float64 {
 	return value
 }
 
-// Initialize enables Sentry for an explicitly configured Platform Gateway Agent.
-// It returns a shutdown function that flushes pending events without blocking exit.
-func Initialize() func() {
-	if !enabled() {
-		return func() {}
+// Configure applies a changed server-verified policy without restarting the Agent.
+func Configure(policy Policy) error {
+	policy.Enabled = policy.Enabled && strings.TrimSpace(policy.BackendDSN) != ""
+	policy.BackendDSN = strings.TrimSpace(policy.BackendDSN)
+	policy.Environment = strings.TrimSpace(policy.Environment)
+	policy.Release = strings.TrimSpace(policy.Release)
+	if policy.TracesSampleRate < 0 || policy.TracesSampleRate > 1 {
+		policy.TracesSampleRate = 0
 	}
-	dsn := strings.TrimSpace(os.Getenv("SENTRY_BACKEND_DSN"))
-	if dsn == "" {
-		_, _ = fmt.Fprintln(os.Stderr, "[sentry] backend DSN is missing; Agent reporting is disabled")
-		return func() {}
+	if !policy.Enabled {
+		policy = Policy{}
+	}
+
+	policyMu.Lock()
+	defer policyMu.Unlock()
+	if configured && policy == currentPolicy {
+		return nil
+	}
+	if configured {
+		sentry.Flush(flushTimeout)
+	}
+	if !policy.Enabled {
+		sentry.CurrentHub().BindClient(nil)
+		currentPolicy = Policy{}
+		configured = true
+		return nil
 	}
 	err := sentry.Init(sentry.ClientOptions{
-		Dsn:              dsn,
-		Environment:      strings.TrimSpace(os.Getenv("SENTRY_ENVIRONMENT")),
-		Release:          strings.TrimSpace(os.Getenv("SENTRY_RELEASE")),
+		Dsn:              policy.BackendDSN,
+		Environment:      policy.Environment,
+		Release:          policy.Release,
 		ServerName:       "hfl-platform-gateway",
-		EnableTracing:    sampleRate() > 0,
-		TracesSampleRate: sampleRate(),
+		EnableTracing:    policy.TracesSampleRate > 0,
+		TracesSampleRate: policy.TracesSampleRate,
 		SendDefaultPII:   false,
 		AttachStacktrace: true,
 		MaxBreadcrumbs:   20,
@@ -65,8 +105,28 @@ func Initialize() func() {
 		},
 	})
 	if err != nil {
+		return err
+	}
+	currentPolicy = policy
+	configured = true
+	return nil
+}
+
+// Initialize enables Sentry for an explicitly configured Platform Gateway Agent.
+// It returns a shutdown function that flushes pending events without blocking exit.
+func Initialize() func() {
+	policy := Policy{
+		Enabled:          enabled(),
+		BackendDSN:       strings.TrimSpace(os.Getenv("SENTRY_BACKEND_DSN")),
+		Environment:      strings.TrimSpace(os.Getenv("SENTRY_ENVIRONMENT")),
+		Release:          strings.TrimSpace(os.Getenv("SENTRY_RELEASE")),
+		TracesSampleRate: sampleRate(),
+	}
+	if policy.Enabled && policy.BackendDSN == "" {
+		_, _ = fmt.Fprintln(os.Stderr, "[sentry] backend DSN is missing; Agent reporting is disabled")
+	}
+	if err := Configure(policy); err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "[sentry] Agent initialization failed; continuing: %v\n", err)
-		return func() {}
 	}
 	return func() { sentry.Flush(flushTimeout) }
 }

--- a/src/agent/internal/infra/observability/sentry_test.go
+++ b/src/agent/internal/infra/observability/sentry_test.go
@@ -1,6 +1,10 @@
 package observability
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/getsentry/sentry-go"
+)
 
 func TestSampleRateRejectsInvalidValues(t *testing.T) {
 	t.Setenv("SENTRY_TRACES_SAMPLE_RATE", "2")
@@ -13,5 +17,61 @@ func TestEnabledDefaultsToFalse(t *testing.T) {
 	t.Setenv("SENTRY_ENABLED", "")
 	if enabled() {
 		t.Fatal("enabled() = true, want false")
+	}
+}
+
+func TestEnabledRequiresServerManagedGatewayPolicy(t *testing.T) {
+	t.Setenv("SENTRY_ENABLED", "true")
+	t.Setenv("HFL_SENTRY_POLICY_MANAGED", "true")
+	t.Setenv("HFL_NODE_ROLE", "agent")
+	if enabled() {
+		t.Fatal("ordinary Agent must not initialize Sentry")
+	}
+
+	t.Setenv("HFL_NODE_ROLE", "gateway")
+	if !enabled() {
+		t.Fatal("server-managed Gateway policy should initialize Sentry")
+	}
+
+	t.Setenv("HFL_SENTRY_POLICY_MANAGED", "")
+	if enabled() {
+		t.Fatal("unverified Gateway environment must not initialize Sentry")
+	}
+}
+
+func TestConfigureEnablesAndDisablesRuntimeClient(t *testing.T) {
+	resetRuntimePolicy := func() {
+		policyMu.Lock()
+		defer policyMu.Unlock()
+		sentry.CurrentHub().BindClient(nil)
+		currentPolicy = Policy{}
+		configured = false
+	}
+	resetRuntimePolicy()
+	t.Cleanup(resetRuntimePolicy)
+
+	err := Configure(Policy{
+		Enabled:          true,
+		BackendDSN:       "https://public@sentry.example.com/25",
+		Environment:      "hfl-test",
+		Release:          "hyperfilelens-agent@main-123abcd",
+		TracesSampleRate: 0,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := sentry.CurrentHub().Client()
+	if client == nil {
+		t.Fatal("Configure() did not bind a Sentry client")
+	}
+	if client.Options().SendDefaultPII {
+		t.Fatal("Configure() enabled default PII collection")
+	}
+
+	if err := Configure(Policy{}); err != nil {
+		t.Fatal(err)
+	}
+	if sentry.CurrentHub().Client() != nil {
+		t.Fatal("disabled policy did not unbind the Sentry client")
 	}
 }

--- a/src/backend/apps/node/api/views/gateway_lens.py
+++ b/src/backend/apps/node/api/views/gateway_lens.py
@@ -8,10 +8,16 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from apps.iam.models import Organization
+from apps.lens_bridge.models import LensGatewayLink
 from apps.lens_bridge.services import provisioning
 from apps.node.api import permissions as node_permissions
 from apps.node.models import Node
 from apps.node.models.base import NodeRole
+from apps.node.services.internal.agent_ws_auth import validate_agent_ws_credentials
+from apps.node.services.internal.gateway_observability import (
+    gateway_observability_policy,
+    is_platform_gateway,
+)
 
 
 class GatewayLensConfigView(APIView):
@@ -52,6 +58,21 @@ class GatewayLensConfigView(APIView):
         ).first()
         if node is None:
             return Response({"error": "gateway not found"}, status=status.HTTP_404_NOT_FOUND)
+        expected_scope = (
+            LensGatewayLink.GatewayScope.PLATFORM
+            if is_platform_gateway(node)
+            else None
+        )
+        if not validate_agent_ws_credentials(
+            node.id,
+            node_token,
+            expected_role=NodeRole.GATEWAY,
+            expected_gateway_scope=expected_scope,
+        ):
+            return Response(
+                {"error": "invalid node credentials"},
+                status=status.HTTP_401_UNAUTHORIZED,
+            )
 
         lens = provisioning.provision_gateway_lens_on_register(org=org, gateway=node)
         if lens is None:
@@ -65,4 +86,12 @@ class GatewayLensConfigView(APIView):
                 status=status.HTTP_503_SERVICE_UNAVAILABLE,
             )
 
-        return Response({"node_id": node.id, "lens": lens})
+        response = Response(
+            {
+                "node_id": node.id,
+                "lens": lens,
+                "observability": gateway_observability_policy(node),
+            }
+        )
+        response["Cache-Control"] = "no-store"
+        return response

--- a/src/backend/apps/node/services/internal/agent_ws_auth.py
+++ b/src/backend/apps/node/services/internal/agent_ws_auth.py
@@ -15,8 +15,14 @@ from django.utils import timezone
 from apps.node.models import Node, NodeToken
 
 
-def validate_agent_ws_credentials(node_pk: int | None, token: str) -> bool:
-    """True when token matches an enrollment token row for the node's organization."""
+def validate_agent_ws_credentials(
+    node_pk: int | None,
+    token: str,
+    *,
+    expected_role: str | None = None,
+    expected_gateway_scope: str | None = None,
+) -> bool:
+    """True when token matches the node organization and requested token bounds."""
     if not token or node_pk is None:
         return False
     node = Node.objects.filter(pk=int(node_pk)).first()
@@ -24,8 +30,22 @@ def validate_agent_ws_credentials(node_pk: int | None, token: str) -> bool:
         return False
     now = timezone.now()
     qs = NodeToken.objects.filter(organization_id=node.organization_id)
-    for row in qs.only("token", "is_active", "expires_at", "used_at").iterator():
+    for row in qs.only(
+        "token",
+        "role",
+        "gateway_scope",
+        "is_active",
+        "expires_at",
+        "used_at",
+    ).iterator():
         if not secrets.compare_digest(row.token, token):
+            continue
+        if expected_role is not None and row.role != expected_role:
+            continue
+        if (
+            expected_gateway_scope is not None
+            and row.gateway_scope != expected_gateway_scope
+        ):
             continue
         if row.is_active:
             if row.expires_at and row.expires_at <= now:

--- a/src/backend/apps/node/services/internal/gateway_observability.py
+++ b/src/backend/apps/node/services/internal/gateway_observability.py
@@ -1,0 +1,89 @@
+"""Trusted observability policy for platform-owned Data Gateways."""
+
+from __future__ import annotations
+
+import os
+import re
+from typing import Any
+from urllib.parse import urlsplit
+
+from django.conf import settings
+
+from apps.lens_bridge.models import LensGatewayLink
+from apps.lens_bridge.services.platform_lens import PLATFORM_ORG_KEY
+from apps.node.models import Node
+from apps.node.models.base import NodeRole
+
+_ENVIRONMENT_RE = re.compile(r"^hfl-(test|preprod|production)$")
+_VERSION_RE = re.compile(r"^[A-Za-z0-9._+-]+$")
+
+
+def _valid_public_dsn(value: str) -> bool:
+    """Accept only public-key HTTP(S) DSNs safe to distribute to platform hosts."""
+    try:
+        parsed = urlsplit(value)
+        port = parsed.port
+    except ValueError:
+        return False
+    project_id = parsed.path.rstrip("/").rsplit("/", 1)[-1]
+    return bool(
+        parsed.scheme in {"http", "https"}
+        and parsed.hostname
+        and parsed.username
+        and parsed.password is None
+        and not parsed.query
+        and not parsed.fragment
+        and project_id.isdigit()
+        and (port is None or 1 <= port <= 65535)
+        and not re.search(r"\s", value)
+    )
+
+
+def _safe_version(value: str, *, fallback: str = "unknown") -> str:
+    normalized = str(value or "").strip()
+    return normalized if _VERSION_RE.fullmatch(normalized) else fallback
+
+
+def is_platform_gateway(node: Node) -> bool:
+    """Return whether *node* is a trusted platform-owned Gateway."""
+    if (
+        node.role != NodeRole.GATEWAY
+        or node.organization.key != PLATFORM_ORG_KEY
+        or node.is_deleted
+    ):
+        return False
+    return LensGatewayLink.objects.filter(
+        organization=node.organization,
+        gateway=node,
+        scope=LensGatewayLink.GatewayScope.PLATFORM,
+        is_deleted=False,
+    ).exists()
+
+
+def gateway_observability_policy(node: Node) -> dict[str, Any]:
+    """Return a bounded Sentry policy; private Gateways are always disabled."""
+    disabled: dict[str, Any] = {"enabled": False}
+    if not is_platform_gateway(node) or not bool(settings.SENTRY_ENABLED):
+        return disabled
+
+    dsn = str(os.getenv("SENTRY_BACKEND_DSN") or "").strip()
+    environment = str(getattr(settings, "SENTRY_ENVIRONMENT", "") or "").strip()
+    if not _valid_public_dsn(dsn) or not _ENVIRONMENT_RE.fullmatch(environment):
+        return disabled
+
+    agent_version = _safe_version(node.version or os.getenv("AGENT_VERSION", ""))
+    sourcelens_version = _safe_version(
+        str(os.getenv("SOURCELENS_GIT_REF") or "").strip().removeprefix("v")
+    )
+    return {
+        "enabled": True,
+        "backend_dsn": dsn,
+        "environment": environment,
+        "agent_release": f"hyperfilelens-agent@{agent_version}",
+        "lensnode_release": (
+            f"hyperfilelens-lensnode@{agent_version}-sl{sourcelens_version}"
+        ),
+        # Error tracking is enabled; performance tracing remains opt-in.
+        "traces_sample_rate": 0.0,
+        "send_default_pii": False,
+    }

--- a/src/backend/apps/node/tests/test_gateway_observability.py
+++ b/src/backend/apps/node/tests/test_gateway_observability.py
@@ -1,0 +1,171 @@
+"""Platform Gateway observability policy and authenticated delivery tests."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from django.contrib.auth.models import User
+from django.test import TestCase, override_settings
+from rest_framework.test import APIRequestFactory
+
+from apps.iam.models import Organization
+from apps.lens_bridge.models import LensGatewayLink
+from apps.lens_bridge.services.platform_lens import PLATFORM_ORG_KEY
+from apps.node.api.views.gateway_lens import GatewayLensConfigView
+from apps.node.models import Node, NodeToken
+from apps.node.models.base import NodeRole
+from apps.node.services.internal.gateway_observability import (
+    gateway_observability_policy,
+)
+
+
+@override_settings(SENTRY_ENABLED=True, SENTRY_ENVIRONMENT="hfl-test")
+class GatewayObservabilityPolicyTests(TestCase):
+    def setUp(self) -> None:
+        self.org = Organization.objects.create(key=PLATFORM_ORG_KEY, name="Platform Lens")
+        self.node = Node.objects.create(
+            organization=self.org,
+            name="platform-gateway",
+            role=NodeRole.GATEWAY,
+            version="main-123abcd",
+        )
+        LensGatewayLink.objects.create(
+            organization=self.org,
+            gateway=self.node,
+            scope=LensGatewayLink.GatewayScope.PLATFORM,
+            origin=LensGatewayLink.Origin.PLATFORM,
+        )
+
+    @patch.dict(
+        "os.environ",
+        {
+            "SENTRY_BACKEND_DSN": "https://public@sentry.example.com/25",
+            "SOURCELENS_GIT_REF": "v0.20.0",
+        },
+        clear=False,
+    )
+    def test_platform_gateway_receives_error_tracking_policy(self) -> None:
+        policy = gateway_observability_policy(self.node)
+
+        self.assertTrue(policy["enabled"])
+        self.assertEqual(policy["environment"], "hfl-test")
+        self.assertEqual(policy["traces_sample_rate"], 0.0)
+        self.assertFalse(policy["send_default_pii"])
+        self.assertEqual(policy["agent_release"], "hyperfilelens-agent@main-123abcd")
+        self.assertEqual(
+            policy["lensnode_release"],
+            "hyperfilelens-lensnode@main-123abcd-sl0.20.0",
+        )
+
+    @patch.dict(
+        "os.environ",
+        {"SENTRY_BACKEND_DSN": "https://public@sentry.example.com/25"},
+        clear=False,
+    )
+    def test_tenant_private_gateway_never_receives_platform_dsn(self) -> None:
+        user = User.objects.create_user(username="tenant@example.com")
+        tenant = Organization.objects.create(key="tenant-org", name="Tenant")
+        gateway = Node.objects.create(
+            organization=tenant,
+            name="private-gateway",
+            role=NodeRole.GATEWAY,
+        )
+        LensGatewayLink.objects.create(
+            organization=tenant,
+            gateway=gateway,
+            owner_user=user,
+            scope=LensGatewayLink.GatewayScope.USER,
+        )
+
+        self.assertEqual(gateway_observability_policy(gateway), {"enabled": False})
+
+    @patch.dict(
+        "os.environ",
+        {"SENTRY_BACKEND_DSN": "https://public:private@sentry.example.com/25"},
+        clear=False,
+    )
+    def test_private_credential_dsn_is_not_distributed(self) -> None:
+        self.assertEqual(gateway_observability_policy(self.node), {"enabled": False})
+
+
+@override_settings(SENTRY_ENABLED=True, SENTRY_ENVIRONMENT="hfl-test")
+class GatewayLensConfigObservabilityTests(TestCase):
+    def setUp(self) -> None:
+        self.factory = APIRequestFactory()
+        self.org = Organization.objects.create(key=PLATFORM_ORG_KEY, name="Platform Lens")
+        self.node = Node.objects.create(
+            organization=self.org,
+            name="platform-gateway",
+            role=NodeRole.GATEWAY,
+            version="0.2.0",
+        )
+        LensGatewayLink.objects.create(
+            organization=self.org,
+            gateway=self.node,
+            scope=LensGatewayLink.GatewayScope.PLATFORM,
+            origin=LensGatewayLink.Origin.PLATFORM,
+        )
+        self.token = NodeToken.objects.create(
+            organization=self.org,
+            role=NodeRole.GATEWAY,
+            token="platform-gateway-token",
+            gateway_scope=LensGatewayLink.GatewayScope.PLATFORM,
+        )
+
+    def _request(self, token: str):
+        request = self.factory.get(
+            "/api/v1/node/enrollment/gateway-lens-config",
+            {"node_id": self.node.id},
+            HTTP_X_ORG_KEY=self.org.key,
+            HTTP_X_NODE_TOKEN=token,
+        )
+        return GatewayLensConfigView.as_view()(request)
+
+    @patch.dict(
+        "os.environ",
+        {
+            "SENTRY_BACKEND_DSN": "https://public@sentry.example.com/25",
+            "SOURCELENS_GIT_REF": "v0.20.0",
+        },
+        clear=False,
+    )
+    @patch("apps.node.api.views.gateway_lens.provisioning.provision_gateway_lens_on_register")
+    def test_authenticated_response_contains_no_store_policy(self, provision) -> None:
+        provision.return_value = {
+            "lens_base_url": "https://lens.example.com",
+            "lensnode_uuid": "26d1822b-3ccc-48f8-80f1-f4c0ae99e61e",
+            "lensnode_token": "lens-token",
+            "lensnode_name": "platform-lens",
+            "workspace_root": "/workspace",
+        }
+
+        response = self._request(self.token.token)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Cache-Control"], "no-store")
+        self.assertTrue(response.data["observability"]["enabled"])
+        self.assertNotIn("frontend_dsn", response.data["observability"])
+
+    def test_invalid_node_token_is_rejected_before_provisioning(self) -> None:
+        with patch(
+            "apps.node.api.views.gateway_lens.provisioning.provision_gateway_lens_on_register"
+        ) as provision:
+            response = self._request("wrong-token")
+
+        self.assertEqual(response.status_code, 401)
+        provision.assert_not_called()
+
+    def test_non_platform_gateway_token_is_rejected(self) -> None:
+        wrong_scope = NodeToken.objects.create(
+            organization=self.org,
+            role=NodeRole.GATEWAY,
+            token="non-platform-gateway-token",
+            gateway_scope=LensGatewayLink.GatewayScope.USER,
+        )
+        with patch(
+            "apps.node.api.views.gateway_lens.provisioning.provision_gateway_lens_on_register"
+        ) as provision:
+            response = self._request(wrong_scope.token)
+
+        self.assertEqual(response.status_code, 401)
+        provision.assert_not_called()

--- a/tools/quality/test-gateway-lifecycle-upgrade.sh
+++ b/tools/quality/test-gateway-lifecycle-upgrade.sh
@@ -6,6 +6,7 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 LIFECYCLE="${ROOT}/deploy/bootstrap/gateway-lifecycle.sh"
 tmp="$(mktemp -d)"
 trap 'rm -rf "${tmp}"' EXIT
+export HFL_GATEWAY_SIDECAR_LOCK_FILE="${tmp}/sidecar.lock"
 
 test_resume_after_interruption() (
 	# shellcheck disable=SC1090

--- a/tools/quality/test-platform-gateway-auto-deploy.sh
+++ b/tools/quality/test-platform-gateway-auto-deploy.sh
@@ -34,6 +34,9 @@ set -euo pipefail
 [[ "$HFL_API_BASE" == "https://127.0.0.1:11443" ]]
 [[ "$HFL_WSS_URL" == "wss://127.0.0.1:11443/ws/node/agent/" ]]
 [[ "$HFL_FORCE_SIDECAR_INSTALL" == "1" ]]
+[[ -z "${SENTRY_ENABLED+x}" ]]
+[[ -z "${SENTRY_BACKEND_DSN+x}" ]]
+[[ -z "${HFL_SENTRY_POLICY_MANAGED+x}" ]]
 [[ "$1" == "gateway-install" && "$2" == "--yes" ]]
 mkdir -p "$TEST_AGENT_INSTALL_DIR" "$TEST_AGENT_DATA_DIR"
 if [[ ! -f "$TEST_AGENT_INSTALL_DIR/INSTALLED_VERSION" ]]; then
@@ -63,6 +66,9 @@ export TEST_PLATFORM_GATEWAY_MARKER="${marker}"
 export TEST_AGENT_UPGRADE_MARKER="${tmp}/agent-upgrade-ran"
 export TEST_AGENT_INSTALL_DIR="${LOCAL_PLATFORM_AGENT_INSTALL_DIR}"
 export TEST_AGENT_DATA_DIR="${LOCAL_PLATFORM_AGENT_DATA_DIR}"
+export SENTRY_ENABLED=true
+export SENTRY_BACKEND_DSN=https://untrusted@sentry.example.com/25
+export HFL_SENTRY_POLICY_MANAGED=true
 
 AUTO_DEPLOY=false
 TLS_MODE=1


### PR DESCRIPTION
## Summary

- deliver a fail-closed Sentry policy only to trusted platform gateways
- dynamically converge Agent and bundled LensNode observability without affecting tenant gateways
- serialize sidecar lifecycle updates and make policy application atomic, idempotent, and retryable
- keep performance tracing disabled by default

## Validation

- backend node test suite
- Go tests, vet, race checks, and cross-platform builds
- release, runtime, auto-deploy, and gateway lifecycle contract tests
- shell syntax and git diff checks