### PR TITLE
fix(agent): support dotfile snapshot downloads

### DIFF
--- a/src/agent/internal/engine/managed_backup.go
+++ b/src/agent/internal/engine/managed_backup.go
@@ -1834,18 +1834,11 @@ func collectRestoredDownload(root string, requestedPath string, forceZip bool) (
 	if err != nil {
 		return nil, "", "", err
 	}
-	visible := make([]os.DirEntry, 0, len(entries))
-	for _, entry := range entries {
-		if strings.HasPrefix(entry.Name(), ".") {
-			continue
-		}
-		visible = append(visible, entry)
-	}
-	if len(visible) == 0 {
+	if len(entries) == 0 {
 		return nil, "", "", fmt.Errorf("restored path not found")
 	}
-	if !forceZip && len(visible) == 1 && !visible[0].IsDir() {
-		filePath := filepath.Join(root, visible[0].Name())
+	if !forceZip && len(entries) == 1 && !entries[0].IsDir() {
+		filePath := filepath.Join(root, entries[0].Name())
 		file, openErr := os.Open(filePath)
 		if openErr != nil {
 			return nil, "", "", openErr

--- a/src/agent/internal/engine/managed_backup_test.go
+++ b/src/agent/internal/engine/managed_backup_test.go
@@ -1001,6 +1001,46 @@ func TestCollectRestoredDownloadReturnsFileForSingleFile(t *testing.T) {
 	}
 }
 
+func TestCollectRestoredDownloadReturnsSingleDotfile(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, ".hidden-note"), []byte("hidden content"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	content, filename, contentType, err := collectRestoredDownload(root, ".hidden-note", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if filename != ".hidden-note" || contentType != "application/octet-stream" {
+		t.Fatalf("expected .hidden-note application/octet-stream, got %q %q", filename, contentType)
+	}
+	if string(content) != "hidden content" {
+		t.Fatalf("unexpected dotfile content %q", string(content))
+	}
+}
+
+func TestCollectRestoredDownloadReturnsZipForDirectoryContainingOnlyDotfile(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, ".hidden-note"), []byte("hidden content"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	content, filename, contentType, err := collectRestoredDownload(root, "hidden-dir", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if filename != "hidden-dir.zip" || contentType != "application/zip" {
+		t.Fatalf("expected hidden-dir.zip application/zip, got %q %q", filename, contentType)
+	}
+	zr, err := zip.NewReader(bytes.NewReader(content), int64(len(content)))
+	if err != nil {
+		t.Fatalf("expected valid zip: %v", err)
+	}
+	if len(zr.File) != 1 || zr.File[0].Name != ".hidden-note" {
+		t.Fatalf("expected zip to contain .hidden-note, got %#v", zr.File)
+	}
+}
+
 func TestParseKopiaPackedBytesJSON(t *testing.T) {
 	got := parseKopiaPackedBytes(`{"totalPackedSize": 2048}`)
 	if got != 2048 {


### PR DESCRIPTION
## Summary

- preserve dot-prefixed restored entries when collecting snapshot downloads
- support direct dotfile downloads and ZIP downloads for dotfile-only directories
- add regression coverage for both download paths

## Validation

- `go test ./... -count=1`
- verified direct `.hidden-note` and `.codex` directory downloads end to end on the 8.69 test environment