### PR TITLE
Rename Setup DR action to Backup Setup

### DIFF
--- a/src/frontend/src/locales/enProtectionPages.ts
+++ b/src/frontend/src/locales/enProtectionPages.ts
@@ -48,7 +48,7 @@ export const enProtectionPages = {
     },
   },
   backupsPage: {
-    btnCreateBackup: 'Setup DR',
+    btnCreateBackup: 'Backup Setup',
     btnCreateBackupTask: 'Create Backup Configuration',
     btnCreateRestoreTask: 'Create Restore Task',
     btnPlusCreateBackup: 'Create Backup Configuration',


### PR DESCRIPTION
## Summary

- Rename the Backup Wizard action from `Setup DR` to `Backup Setup`.
- Use clearer product terminology without changing the backup workflow.

## Testing

- `git diff --check`

Closes #171