### PR TITLE
Add icons to primary navigation

### DIFF
--- a/src/frontend/src/app/layout/PrimaryNavigationIcons.test.ts
+++ b/src/frontend/src/app/layout/PrimaryNavigationIcons.test.ts
@@ -1,0 +1,52 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const primaryNavSource = readFileSync(
+  resolve(process.cwd(), 'src/composables/useAppPrimaryNav.ts'),
+  'utf8',
+)
+const topNavSource = readFileSync(resolve(process.cwd(), 'src/app/layout/TopNav.vue'), 'utf8')
+const mobileNavSource = readFileSync(
+  resolve(process.cwd(), 'src/components/MobileNavigationDrawer.vue'),
+  'utf8',
+)
+
+describe('primary navigation icons', () => {
+  it('defines one shared Lucide icon for every primary destination', () => {
+    expect(primaryNavSource).toContain("{ to: '/', label: t('nav.overview'), icon: LayoutDashboard }")
+    expect(primaryNavSource).toContain(
+      "{ to: '/protection', label: t('nav.protection'), icon: ShieldCheck }",
+    )
+    expect(primaryNavSource).toContain(
+      "{ to: '/insight', label: t('nav.insight'), icon: ChartNoAxesCombined }",
+    )
+    expect(primaryNavSource).toContain("{ to: '/node', label: t('nav.node'), icon: Settings }")
+    expect(primaryNavSource).toContain("{ to: '/ops', label: t('nav.ops'), icon: Activity }")
+  })
+
+  it('renders decorative icons alongside labels in desktop and mobile navigation', () => {
+    expect(topNavSource).toMatch(
+      /:is="item\.icon"[\s\S]*?class="nav-item__icon"[\s\S]*?:size="16"[\s\S]*?aria-hidden="true"/,
+    )
+    expect(topNavSource).toContain('<span>{{ item.label }}</span>')
+
+    expect(mobileNavSource).toMatch(
+      /:is="item\.icon"[\s\S]*?:size="17"[\s\S]*?:stroke-width="2"[\s\S]*?aria-hidden="true"/,
+    )
+    expect(mobileNavSource).toContain('<span>{{ item.label }}</span>')
+  })
+
+  it('compacts icons and timezone text at constrained desktop widths', () => {
+    expect(topNavSource).toMatch(
+      /@media \(min-width: 1024px\) and \(max-width: 1279\.98px\)[\s\S]*?\.nav-item__icon\s*{[\s\S]*?display:\s*none/,
+    )
+    expect(topNavSource).toMatch(
+      /@media \(min-width: 1024px\) and \(max-width: 1439\.98px\)[\s\S]*?\.timezone-display__label\s*{[\s\S]*?display:\s*none/,
+    )
+    expect(topNavSource).toContain('class="timezone-display__label"')
+    expect(topNavSource).toMatch(
+      /@media \(max-width: 1023\.98px\)[\s\S]*?\.nav-menu,[\s\S]*?display:\s*none/,
+    )
+  })
+})

--- a/src/frontend/src/app/layout/TopNav.vue
+++ b/src/frontend/src/app/layout/TopNav.vue
@@ -50,14 +50,16 @@ const route = useRoute()
 const router = useRouter()
 const { items: navItems, isActive: navActive } = useAppPrimaryNav()
 
-const timezoneDisplay = computed(() => {
+const timezoneOffsetDisplay = computed(() => {
   const offset = new Date().getTimezoneOffset()
   const sign = offset <= 0 ? '+' : '-'
   const absOffset = Math.abs(offset)
   const hours = String(Math.floor(absOffset / 60)).padStart(2, '0')
   const minutes = String(absOffset % 60).padStart(2, '0')
-  return `${t('nav.timezone')}GMT${sign}${hours}:${minutes}`
+  return `GMT${sign}${hours}:${minutes}`
 })
+
+const timezoneDisplay = computed(() => `${t('nav.timezone')}${timezoneOffsetDisplay.value}`)
 
 function navigateImmediately(to: string) {
   if (to === route.fullPath) return
@@ -99,13 +101,24 @@ function handleNavClick(event: MouseEvent, to: string) {
         class="nav-item"
         @click="handleNavClick($event, item.to)"
       >
-        {{ item.label }}
+        <component
+          :is="item.icon"
+          class="nav-item__icon"
+          :size="16"
+          :stroke-width="2"
+          aria-hidden="true"
+        />
+        <span>{{ item.label }}</span>
       </RouterLink>
     </nav>
 
     <div class="right-menu">
-      <span class="timezone-display desktop-navigation-control">
-        {{ timezoneDisplay }}
+      <span
+        class="timezone-display desktop-navigation-control"
+        :title="timezoneDisplay"
+      >
+        <span class="timezone-display__label">{{ t('nav.timezone') }}</span>
+        <span>{{ timezoneOffsetDisplay }}</span>
       </span>
 
       <ElButton
@@ -236,8 +249,13 @@ function handleNavClick(event: MouseEvent, to: string) {
   display: flex;
   align-items: center;
   justify-content: center;
+  gap: 6px;
   border-radius: 8px 8px 0 0;
   transition: color 150ms ease, background-color 150ms ease;
+}
+
+.nav-item__icon {
+  flex: 0 0 auto;
 }
 
 .nav-item:hover {
@@ -325,6 +343,18 @@ function handleNavClick(event: MouseEvent, to: string) {
 
 .alerts-btn {
   position: relative;
+}
+
+@media (min-width: 1024px) and (max-width: 1279.98px) {
+  .nav-item__icon {
+    display: none;
+  }
+}
+
+@media (min-width: 1024px) and (max-width: 1439.98px) {
+  .timezone-display__label {
+    display: none;
+  }
 }
 
 @media (max-width: 1023.98px) {

--- a/src/frontend/src/components/MobileNavigationDrawer.vue
+++ b/src/frontend/src/components/MobileNavigationDrawer.vue
@@ -107,7 +107,13 @@ function moduleItemActive(to?: string) {
             :aria-current="item.active ? 'page' : undefined"
             @click="close"
           >
-            {{ item.label }}
+            <component
+              :is="item.icon"
+              :size="17"
+              :stroke-width="2"
+              aria-hidden="true"
+            />
+            <span>{{ item.label }}</span>
           </RouterLink>
         </section>
 

--- a/src/frontend/src/composables/useAppPrimaryNav.ts
+++ b/src/frontend/src/composables/useAppPrimaryNav.ts
@@ -1,10 +1,18 @@
-import { computed } from 'vue'
+import { computed, type Component } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRoute } from 'vue-router'
+import {
+  Activity,
+  ChartNoAxesCombined,
+  LayoutDashboard,
+  Settings,
+  ShieldCheck,
+} from 'lucide-vue-next'
 
 export interface AppPrimaryNavItem {
   to: string
   label: string
+  icon: Component
   active?: boolean
 }
 
@@ -27,11 +35,11 @@ export function useAppPrimaryNav() {
   const route = useRoute()
 
   const items = computed<AppPrimaryNavItem[]>(() => [
-    { to: '/', label: t('nav.overview') },
-    { to: '/protection', label: t('nav.protection') },
-    { to: '/insight', label: t('nav.insight') },
-    { to: '/node', label: t('nav.node') },
-    { to: '/ops', label: t('nav.ops') },
+    { to: '/', label: t('nav.overview'), icon: LayoutDashboard },
+    { to: '/protection', label: t('nav.protection'), icon: ShieldCheck },
+    { to: '/insight', label: t('nav.insight'), icon: ChartNoAxesCombined },
+    { to: '/node', label: t('nav.node'), icon: Settings },
+    { to: '/ops', label: t('nav.ops'), icon: Activity },
   ])
 
   function isActive(to: string) {


### PR DESCRIPTION
## Summary

- Add semantic Lucide icons to all five primary navigation destinations.
- Reuse the shared icon definitions in desktop and mobile navigation while retaining visible labels and existing active states.
- Keep 1024-1279px navigation text-only, show icons from 1280px, and keep the time-zone label compact until 1440px.

## Testing

- npm run test -- src/app/layout/PrimaryNavigationIcons.test.ts
- npx vue-tsc --noEmit
- npx eslint src/composables/useAppPrimaryNav.ts src/app/layout/TopNav.vue src/components/MobileNavigationDrawer.vue src/app/layout/PrimaryNavigationIcons.test.ts (0 errors; existing formatting warnings)
- npm run build

Closes #187

Mobile replacements for hidden header utilities are tracked in #290.