### PR TITLE
chore: ignore repository worktree directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ src/backend/staticfiles/
 
 # --- Other ---
 *.mo
+.worktrees/
 .tmp/
 .tools/
 /src/frontend/AGENTS.md


### PR DESCRIPTION
## Summary

- ignore the repository-root `.worktrees/` directory
- prevent task worktree contents from appearing as untracked files

## Validation

- `git check-ignore -v .worktrees/placeholder`
- `git diff --check`
