### PR TITLE
fix: deduplicate the New Chat gateway warning

### DIFF
--- a/src/frontend/src/pages/insight/NewCopilotChat.vue
+++ b/src/frontend/src/pages/insight/NewCopilotChat.vue
@@ -11,6 +11,7 @@ import {
   RefreshCw,
   TextCursorInput,
   Trash2,
+  TriangleAlert,
 } from 'lucide-vue-next'
 import { ElMessage } from 'element-plus'
 import { useI18n } from 'vue-i18n'
@@ -29,10 +30,25 @@ import {
 
 const router = useRouter()
 const { t } = useI18n()
+
+type SubmitBlockCode =
+  | 'agent_model'
+  | 'backup_source'
+  | 'snapshot'
+  | 'source_scope'
+  | 'public_gateway'
+  | 'private_gateway'
+
+type SubmitBlocker = {
+  code: SubmitBlockCode
+  message: string
+}
+
 const sourceType = ref<KnowledgeSourceType>('backup_source')
 const editingId = ref<number | null>(null)
 const submitting = ref(false)
 const gatewayRefreshing = ref(false)
+const gatewayOptionsResolved = ref(false)
 const gatewayOptions = ref<LensCopilotGatewayOption[]>([])
 const readiness = ref<LensCopilotReadiness | null>(null)
 const gatewayMode = ref<'auto' | 'manual'>('auto')
@@ -86,6 +102,11 @@ const visualModelReady = computed(() => Boolean(readiness.value?.default_multimo
 const selectedGateway = computed(() => gatewayMode.value === 'auto'
   ? autoGateway.value
   : privateGateways.value.find((row) => row.gateway_link_id === gatewayLinkId.value) ?? null)
+const publicGatewayUnavailable = computed(() => (
+  gatewayOptionsResolved.value
+  && gatewayMode.value === 'auto'
+  && !autoGateway.value
+))
 const selectedBackupSource = computed(() => backupSourceOptions.value.find(
   (row) => row.backupConfigId === selectedBackupConfigId.value,
 ) ?? null)
@@ -102,18 +123,52 @@ const canCreate = computed(() => Boolean(
   && agentModelReady.value
   && !submitting.value,
 ))
-const submitBlockReason = computed(() => {
-  if (!agentModelReady.value) return 'No default Agent model is configured. Contact your administrator.'
-  if (!selectedBackupSource.value) return 'Select a backup source to continue.'
-  if (!effectiveSnapshotId.value) return 'Select a snapshot to continue.'
-  if (sourceScopes.value.length === 0) return 'Select at least one file or folder to continue.'
-  if (!selectedGateway.value) {
-    return gatewayMode.value === 'manual'
-      ? t('insight.copilot.gatewayPrivateRequired')
-      : t('insight.copilot.gatewayPublicUnavailable')
+const submitBlocker = computed<SubmitBlocker | null>(() => {
+  if (!agentModelReady.value) {
+    return {
+      code: 'agent_model',
+      message: 'No default Agent model is configured. Contact your administrator.',
+    }
   }
-  return ''
+  if (!selectedBackupSource.value) {
+    return {
+      code: 'backup_source',
+      message: 'Select a backup source to continue.',
+    }
+  }
+  if (!effectiveSnapshotId.value) {
+    return {
+      code: 'snapshot',
+      message: 'Select a snapshot to continue.',
+    }
+  }
+  if (sourceScopes.value.length === 0) {
+    return {
+      code: 'source_scope',
+      message: 'Select at least one file or folder to continue.',
+    }
+  }
+  if (!selectedGateway.value) {
+    if (gatewayMode.value === 'manual') {
+      return {
+        code: 'private_gateway',
+        message: t('insight.copilot.gatewayPrivateRequired'),
+      }
+    }
+    if (gatewayOptionsResolved.value) {
+      return {
+        code: 'public_gateway',
+        message: t('insight.copilot.gatewayPublicUnavailable'),
+      }
+    }
+  }
+  return null
 })
+const footerSubmitBlockReason = computed(() => (
+  submitBlocker.value?.code === 'public_gateway'
+    ? ''
+    : submitBlocker.value?.message ?? ''
+))
 
 function snapshotOptionLabel(row: { finished_at?: string | null; started_at?: string | null; created_at: string; total_size_bytes: number }) {
   const time = row.finished_at || row.started_at || row.created_at
@@ -151,6 +206,7 @@ async function refreshGatewayOptions(showFeedback = true) {
     if (!showFeedback) throw error
     ElMessage.error({ message: apiErrorMessage(error, t('insight.copilot.gatewayPrivateRefreshFailed')), grouping: true })
   } finally {
+    gatewayOptionsResolved.value = true
     gatewayRefreshing.value = false
   }
 }
@@ -381,7 +437,14 @@ onBeforeUnmount(() => backupScopeResizeObserver?.disconnect())
                     <p v-if="!gatewayRefreshing && privateGateways.length === 0" class="new-chat-hint new-chat-hint--warn">{{ t('insight.copilot.gatewayPrivateNoOnline') }}</p>
                   </div>
                 </div>
-                <p v-if="gatewayMode === 'auto' && !autoGateway" class="new-chat-hint new-chat-hint--warn">{{ t('insight.copilot.gatewayPublicUnavailable') }}</p>
+                <div
+                  v-if="publicGatewayUnavailable"
+                  class="new-chat-gateway-warning"
+                  role="alert"
+                >
+                  <TriangleAlert :size="16" aria-hidden="true" />
+                  <span>{{ t('insight.copilot.gatewayPublicUnavailable') }}</span>
+                </div>
               </div>
             </section></div>
           </div>
@@ -411,7 +474,7 @@ onBeforeUnmount(() => backupScopeResizeObserver?.disconnect())
       </div>
 
       <footer class="fullscreen-form-footer">
-        <p v-if="submitBlockReason" class="form-submit-hint">{{ submitBlockReason }}</p>
+        <p v-if="footerSubmitBlockReason" class="form-submit-hint">{{ footerSubmitBlockReason }}</p>
         <button class="form-action form-action--secondary" type="button" @click="router.push('/insight/copilot')">Cancel</button>
         <button class="form-action form-action--primary" type="button" :disabled="!canCreate" @click="createChat"><span v-if="submitting" class="form-action__loading" />{{ submitting ? 'Starting Chat…' : 'Start Chat' }}</button>
       </footer>
@@ -445,6 +508,9 @@ onBeforeUnmount(() => backupScopeResizeObserver?.disconnect())
 .new-chat-scope-hint { margin-top: 8px; }
 .new-chat-hint { margin: 10px 0 0; color: #86909c; font-size: 12px; line-height: 1.5; }
 .new-chat-hint--warn { color: #d46b08; }
+.new-chat-gateway-warning { display: flex; width: 100%; box-sizing: border-box; align-items: flex-start; gap: 8px; margin-top: 10px; padding: 10px 12px; border: 1px solid color-mix(in srgb, var(--color-warning) 35%, var(--color-card-bg)); border-radius: 8px; background: color-mix(in srgb, var(--color-warning) 10%, var(--color-card-bg)); color: var(--color-warning-text); font-size: 12px; line-height: 1.5; }
+.new-chat-gateway-warning svg { flex: 0 0 auto; margin-top: 1px; color: var(--color-warning); }
+.new-chat-gateway-warning span { min-width: 0; overflow-wrap: anywhere; }
 .new-chat-visual-warning { margin: 14px 0 0; padding: 9px 10px; border: 1px solid #ffe7ba; border-radius: 8px; background: #fffbe6; color: #ad6800; font-size: 12px; line-height: 1.5; }
 .new-chat-choice { display: flex; align-items: flex-start; gap: 12px; margin-top: 12px; padding: 13px; border: 1px solid #e5e6eb; border-radius: 8px; cursor: pointer; transition: border-color .15s, background .15s; }
 .new-chat-choice--selected { border-color: #165dff; background: #f2f6ff; }

--- a/src/frontend/src/pages/insight/NewCopilotChatGatewayWarning.test.ts
+++ b/src/frontend/src/pages/insight/NewCopilotChatGatewayWarning.test.ts
@@ -1,0 +1,324 @@
+// @vitest-environment jsdom
+
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { defineComponent, h, nextTick, ref } from 'vue'
+import { flushPromises, mount, type VueWrapper } from '@vue/test-utils'
+import ElementPlus from 'element-plus'
+import { createI18n } from 'vue-i18n'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { en } from '../../locales/en'
+import type { LensCopilotGatewayOption } from '../../lib/lensApi'
+import NewCopilotChat from './NewCopilotChat.vue'
+
+const componentSource = readFileSync(
+  resolve(process.cwd(), 'src/pages/insight/NewCopilotChat.vue'),
+  'utf8',
+)
+
+const mocks = vi.hoisted(() => ({
+  createCopilotSession: vi.fn(),
+  fetchCopilotReadiness: vi.fn(),
+  listCopilotGatewayOptions: vi.fn(),
+  routerPush: vi.fn(),
+  routerReplace: vi.fn(),
+  routerResolve: vi.fn(),
+  useKnowledgeSourceForm: vi.fn(),
+}))
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({
+    push: mocks.routerPush,
+    replace: mocks.routerReplace,
+    resolve: mocks.routerResolve,
+  }),
+}))
+
+vi.mock('../../composables/useKnowledgeSourceForm', () => ({
+  useKnowledgeSourceForm: mocks.useKnowledgeSourceForm,
+}))
+
+vi.mock('../../lib/api', () => ({
+  apiErrorMessage: (_error: unknown, fallback: string) => fallback,
+}))
+
+vi.mock('../../lib/lensApi', () => ({
+  createCopilotSession: mocks.createCopilotSession,
+  fetchCopilotReadiness: mocks.fetchCopilotReadiness,
+  listCopilotGatewayOptions: mocks.listCopilotGatewayOptions,
+}))
+
+const HflPopoverStub = defineComponent({
+  name: 'HflPopover',
+  setup(_props, { slots }) {
+    return () => h('div', [slots.reference?.(), slots.default?.()])
+  },
+})
+
+const publicGateway: LensCopilotGatewayOption = {
+  gateway_link_id: 11,
+  gateway_id: 101,
+  name: 'public-dg-01',
+  scope: 'platform',
+  is_platform_default: true,
+  sidecar_status: 'online',
+  online: true,
+  hfl_usable: true,
+  copilot_eligible: true,
+}
+
+const privateGateway: LensCopilotGatewayOption = {
+  gateway_link_id: 22,
+  gateway_id: 202,
+  name: 'private-dg-01',
+  scope: 'user',
+  is_platform_default: false,
+  sidecar_status: 'online',
+  online: true,
+  hfl_usable: true,
+  copilot_eligible: true,
+}
+
+type FormScenario = {
+  sourceReady?: boolean
+  snapshotReady?: boolean
+  scopeReady?: boolean
+}
+
+type MountScenario = FormScenario & {
+  agentModelReady?: boolean
+  gatewayResponse?: Promise<LensCopilotGatewayOption[]> | LensCopilotGatewayOption[]
+}
+
+function formState({
+  sourceReady = true,
+  snapshotReady = true,
+  scopeReady = true,
+}: FormScenario = {}) {
+  const selectedBackupConfigId = ref<number | null>(sourceReady ? 7 : null)
+  const effectiveSnapshotId = ref<number | null>(snapshotReady ? 17 : null)
+  return {
+    loading: ref(false),
+    snapshotLoading: ref(false),
+    selectedBackupConfigId,
+    snapshotPickerValue: ref<number | string | null>(snapshotReady ? 17 : null),
+    backupSourceOptions: ref(sourceReady
+      ? [{ backupConfigId: 7, label: 'Production Documents' }]
+      : []),
+    snapshotsForSelectedBackupSource: ref(snapshotReady
+      ? [{
+          id: 17,
+          created_at: '2026-08-03T08:00:00Z',
+          total_size_bytes: 1024,
+        }]
+      : []),
+    SNAPSHOT_PICKER_LATEST: 'latest',
+    effectiveSnapshotId,
+    snapshotDirectories: ref(snapshotReady ? [{ id: 31 }] : []),
+    backupScopeEntries: ref([{
+      id: 'scope-1',
+      path: scopeReady ? '/documents/contracts' : '',
+      directoryId: scopeReady ? 31 : null,
+      pathType: 'dir',
+    }]),
+    openBackupScopePickerId: ref<string | null>(null),
+    backupScopeTreeRevision: ref(0),
+    backupScopeBrowseLoading: ref(false),
+    loadSnapshots: vi.fn().mockResolvedValue(undefined),
+    loadBackupScopePickerNode: vi.fn(),
+    setBackupScopePickerOpen: vi.fn(),
+    addBackupScopeEntry: vi.fn(),
+    removeBackupScopeEntry: vi.fn(),
+    updateBackupScopeEntryInput: vi.fn(),
+    validateBackupScopeEntry: vi.fn(),
+    validateBackupScopeEntryOnBlur: vi.fn(),
+    validateAllBackupScopeEntries: vi.fn().mockResolvedValue(true),
+    pickBackupScopeForEntry: vi.fn(),
+  }
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise
+  })
+  return { promise, resolve }
+}
+
+async function mountNewChat({
+  agentModelReady = true,
+  gatewayResponse = [],
+  sourceReady = true,
+  snapshotReady = true,
+  scopeReady = true,
+}: MountScenario = {}): Promise<VueWrapper> {
+  mocks.useKnowledgeSourceForm.mockReturnValue(formState({
+    sourceReady,
+    snapshotReady,
+    scopeReady,
+  }))
+  mocks.fetchCopilotReadiness.mockResolvedValue({
+    active_models: [],
+    default_agent_model_ref: agentModelReady ? 'agent-model-ref' : null,
+    default_multimodal_model_ref: 'multimodal-model-ref',
+  })
+  mocks.listCopilotGatewayOptions.mockReturnValue(Promise.resolve(gatewayResponse))
+
+  const i18n = createI18n({
+    legacy: false,
+    locale: 'en',
+    messages: { en },
+    missingWarn: false,
+    fallbackWarn: false,
+  })
+  const wrapper = mount(NewCopilotChat, {
+    global: {
+      plugins: [i18n, ElementPlus],
+      stubs: {
+        HflPopover: HflPopoverStub,
+      },
+    },
+  })
+  await flushPromises()
+  await nextTick()
+  return wrapper
+}
+
+function footerHint(wrapper: VueWrapper) {
+  return wrapper.find('.fullscreen-form-footer .form-submit-hint')
+}
+
+function startChatButton(wrapper: VueWrapper) {
+  return wrapper.get('.fullscreen-form-footer .form-action--primary')
+}
+
+describe('New Chat Public Data Gateway warning', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.stubGlobal('ResizeObserver', class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    })
+    Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
+      configurable: true,
+      value: vi.fn(),
+    })
+    mocks.routerResolve.mockReturnValue({ href: '/node/nodes/deploy?role=gateway' })
+    mocks.routerPush.mockResolvedValue(undefined)
+    mocks.routerReplace.mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+    vi.unstubAllGlobals()
+  })
+
+  it('does not announce an unavailable Gateway before the first request resolves', async () => {
+    const gatewayRequest = deferred<LensCopilotGatewayOption[]>()
+    const wrapper = await mountNewChat({ gatewayResponse: gatewayRequest.promise })
+
+    expect(wrapper.find('.new-chat-gateway-warning').exists()).toBe(false)
+    expect(wrapper.find('[role="alert"]').exists()).toBe(false)
+
+    gatewayRequest.resolve([])
+    await flushPromises()
+
+    expect(wrapper.get('.new-chat-gateway-warning').attributes('role')).toBe('alert')
+    wrapper.unmount()
+  })
+
+  it('shows one accessible warning in Data Privacy without repeating it in the footer', async () => {
+    const wrapper = await mountNewChat()
+    const message = en.insight.copilot.gatewayPublicUnavailable
+    const warning = wrapper.get('.new-chat-privacy-options .new-chat-gateway-warning')
+
+    expect(warning.attributes('role')).toBe('alert')
+    expect(warning.text()).toBe(message)
+    expect(warning.get('svg').attributes('aria-hidden')).toBe('true')
+    expect(wrapper.text().split(message)).toHaveLength(2)
+    expect(footerHint(wrapper).exists()).toBe(false)
+    expect(startChatButton(wrapper).attributes('disabled')).toBeDefined()
+    wrapper.unmount()
+  })
+
+  it('removes the warning when a Public Data Gateway becomes available', async () => {
+    const wrapper = await mountNewChat()
+    expect(wrapper.find('.new-chat-gateway-warning').exists()).toBe(true)
+
+    mocks.listCopilotGatewayOptions.mockResolvedValue([publicGateway])
+    await wrapper.get('.new-chat-gateway-select-row__refresh').trigger('click')
+    await flushPromises()
+
+    expect(wrapper.find('.new-chat-gateway-warning').exists()).toBe(false)
+    expect(footerHint(wrapper).exists()).toBe(false)
+    expect(startChatButton(wrapper).attributes('disabled')).toBeUndefined()
+    wrapper.unmount()
+  })
+
+  it('switches to the Private Gateway blocker without retaining the Public warning', async () => {
+    const wrapper = await mountNewChat({ gatewayResponse: [privateGateway] })
+    expect(wrapper.find('.new-chat-gateway-warning').exists()).toBe(true)
+
+    await wrapper.get('input[value="manual"]').setValue(true)
+
+    expect(wrapper.find('.new-chat-gateway-warning').exists()).toBe(false)
+    expect(footerHint(wrapper).text()).toBe(en.insight.copilot.gatewayPrivateRequired)
+    expect(startChatButton(wrapper).attributes('disabled')).toBeDefined()
+    wrapper.unmount()
+  })
+
+  it.each([
+    {
+      name: 'Agent model',
+      scenario: { agentModelReady: false },
+      message: 'No default Agent model is configured. Contact your administrator.',
+    },
+    {
+      name: 'Backup Source',
+      scenario: { sourceReady: false },
+      message: 'Select a backup source to continue.',
+    },
+    {
+      name: 'Snapshot',
+      scenario: { snapshotReady: false },
+      message: 'Select a snapshot to continue.',
+    },
+    {
+      name: 'file or folder scope',
+      scenario: { scopeReady: false },
+      message: 'Select at least one file or folder to continue.',
+    },
+  ])('keeps the $name blocker in the footer', async ({ scenario, message }) => {
+    const wrapper = await mountNewChat(scenario)
+
+    expect(wrapper.get('.new-chat-gateway-warning').text()).toBe(
+      en.insight.copilot.gatewayPublicUnavailable,
+    )
+    expect(footerHint(wrapper).text()).toBe(message)
+    expect(startChatButton(wrapper).attributes('disabled')).toBeDefined()
+    wrapper.unmount()
+  })
+
+  it('enables Start Chat when the form and Public Data Gateway are ready', async () => {
+    const wrapper = await mountNewChat({ gatewayResponse: [publicGateway] })
+
+    expect(wrapper.find('.new-chat-gateway-warning').exists()).toBe(false)
+    expect(footerHint(wrapper).exists()).toBe(false)
+    expect(startChatButton(wrapper).attributes('disabled')).toBeUndefined()
+    wrapper.unmount()
+  })
+
+  it('keeps the warning theme-aware and safe to wrap on narrow screens', () => {
+    expect(componentSource).toContain(
+      'background: color-mix(in srgb, var(--color-warning) 10%, var(--color-card-bg))',
+    )
+    expect(componentSource).toContain(
+      'border: 1px solid color-mix(in srgb, var(--color-warning) 35%, var(--color-card-bg))',
+    )
+    expect(componentSource).toContain('width: 100%')
+    expect(componentSource).toContain('box-sizing: border-box')
+    expect(componentSource).toContain('overflow-wrap: anywhere')
+  })
+})


### PR DESCRIPTION
## Summary

- keep the unavailable Public Data Gateway warning in the Data Privacy section and remove its duplicate footer copy
- add an accessible, theme-aware warning with a Lucide icon after Gateway discovery completes
- preserve every other submit blocker and leave Chat creation eligibility unchanged
- cover loading, Public/Private Gateway, blocker precedence, accessibility, and responsive styling states

## Validation

- `npm run test:ci` — 636 tests passed
- `npm run build`
- focused ESLint checks for the changed files
- `git diff --check`

Closes #202