### PR TITLE
Unify fullscreen form button loading

### DIFF
--- a/src/frontend/src/pages/insight/AiModelFormPage.vue
+++ b/src/frontend/src/pages/insight/AiModelFormPage.vue
@@ -233,25 +233,24 @@ onMounted(() => {
       </div>
 
       <footer class="fullscreen-form-footer">
-        <button
-          type="button"
-          class="form-action form-action--secondary"
+        <ElButton
+          :loading="testing"
           :disabled="testing || loading"
           @click="runTest"
         >
           {{ t('insight.aiSettings.testConnection') }}
-        </button>
-        <button type="button" class="form-action form-action--secondary" @click="handleBack">
+        </ElButton>
+        <ElButton @click="handleBack">
           {{ t('common.cancel') }}
-        </button>
-        <button
-          type="button"
-          class="form-action form-action--primary"
+        </ElButton>
+        <ElButton
+          type="primary"
+          :loading="saving"
           :disabled="saving || loading"
           @click="handleSubmit"
         >
           {{ isEditing ? t('common.save') : t('insight.aiSettings.btnCreateModel') }}
-        </button>
+        </ElButton>
       </footer>
     </div>
   </div>

--- a/src/frontend/src/pages/insight/AssistantFormPage.vue
+++ b/src/frontend/src/pages/insight/AssistantFormPage.vue
@@ -868,17 +868,17 @@ watch(
       </div>
 
       <footer class="fullscreen-form-footer">
-        <button type="button" class="form-action form-action--secondary" @click="handleBack">
+        <ElButton @click="handleBack">
           {{ t('common.cancel') }}
-        </button>
-        <button
-          type="button"
-          class="form-action form-action--primary"
+        </ElButton>
+        <ElButton
+          type="primary"
+          :loading="saving"
           :disabled="saving || loading || !canSubmit"
           @click="handleSubmit"
         >
           {{ isEditing ? t('common.save') : t('insight.assistants.btnCreate') }}
-        </button>
+        </ElButton>
       </footer>
     </div>
   </div>

--- a/src/frontend/src/pages/insight/KnowledgeSourceFormPage.vue
+++ b/src/frontend/src/pages/insight/KnowledgeSourceFormPage.vue
@@ -689,17 +689,17 @@ onMounted(() => {
           </div>
 
           <footer class="fullscreen-form-footer">
-            <button type="button" class="form-action form-action--secondary" @click="handleBack">
+            <ElButton @click="handleBack">
               {{ t('common.cancel') }}
-            </button>
-            <button
-              type="button"
-              class="form-action form-action--primary"
+            </ElButton>
+            <ElButton
+              type="primary"
+              :loading="saving"
               :disabled="saving || loading || !canSubmit"
               @click="handleSubmit"
             >
               {{ isEditing ? t('common.save') : t('insight.kb.dialogConfirm') }}
-            </button>
+            </ElButton>
           </footer>
         </div>
       </div>

--- a/src/frontend/src/pages/insight/McpServerFormPage.vue
+++ b/src/frontend/src/pages/insight/McpServerFormPage.vue
@@ -229,17 +229,17 @@ watch(
       </div>
 
       <footer class="fullscreen-form-footer">
-        <button type="button" class="form-action form-action--secondary" @click="handleBack">
+        <ElButton @click="handleBack">
           {{ t('common.cancel') }}
-        </button>
-        <button
-          type="button"
-          class="form-action form-action--primary"
+        </ElButton>
+        <ElButton
+          type="primary"
+          :loading="saving"
           :disabled="saving || loading || !canSubmit"
           @click="handleSubmit"
         >
           {{ isEditing ? t('common.save') : t('insight.mcpServers.btnCreate') }}
-        </button>
+        </ElButton>
       </footer>
     </div>
   </div>

--- a/src/frontend/src/pages/insight/NewCopilotChat.vue
+++ b/src/frontend/src/pages/insight/NewCopilotChat.vue
@@ -475,8 +475,10 @@ onBeforeUnmount(() => backupScopeResizeObserver?.disconnect())
 
       <footer class="fullscreen-form-footer">
         <p v-if="footerSubmitBlockReason" class="form-submit-hint">{{ footerSubmitBlockReason }}</p>
-        <button class="form-action form-action--secondary" type="button" @click="router.push('/insight/copilot')">Cancel</button>
-        <button class="form-action form-action--primary" type="button" :disabled="!canCreate" @click="createChat"><span v-if="submitting" class="form-action__loading" />{{ submitting ? 'Starting Chat…' : 'Start Chat' }}</button>
+        <ElButton @click="router.push('/insight/copilot')">Cancel</ElButton>
+        <ElButton type="primary" :loading="submitting" :disabled="!canCreate" @click="createChat">
+          {{ submitting ? 'Starting Chat…' : 'Start Chat' }}
+        </ElButton>
       </footer>
     </div>
   </div>

--- a/src/frontend/src/pages/insight/NewCopilotChatGatewayWarning.test.ts
+++ b/src/frontend/src/pages/insight/NewCopilotChatGatewayWarning.test.ts
@@ -190,7 +190,7 @@ function footerHint(wrapper: VueWrapper) {
 }
 
 function startChatButton(wrapper: VueWrapper) {
-  return wrapper.get('.fullscreen-form-footer .form-action--primary')
+  return wrapper.get('.fullscreen-form-footer .el-button--primary')
 }
 
 describe('New Chat Public Data Gateway warning', () => {

--- a/src/frontend/src/pages/insight/SkillFormPage.vue
+++ b/src/frontend/src/pages/insight/SkillFormPage.vue
@@ -210,17 +210,17 @@ watch(
       </div>
 
       <footer class="fullscreen-form-footer">
-        <button type="button" class="form-action form-action--secondary" @click="handleBack">
+        <ElButton @click="handleBack">
           {{ t('common.cancel') }}
-        </button>
-        <button
-          type="button"
-          class="form-action form-action--primary"
+        </ElButton>
+        <ElButton
+          type="primary"
+          :loading="saving"
           :disabled="saving || loading || !canSubmit"
           @click="handleSubmit"
         >
           {{ isEditing ? t('common.save') : t('insight.skills.btnCreate') }}
-        </button>
+        </ElButton>
       </footer>
     </div>
   </div>

--- a/src/frontend/src/pages/node/AddNasRepository.vue
+++ b/src/frontend/src/pages/node/AddNasRepository.vue
@@ -529,13 +529,12 @@ watch(enableQuotaAlert, (enabled) => {
 
           <div class="fullscreen-form-footer fullscreen-form-action-footer add-nas-footer">
             <div class="flex gap-2">
-              <button class="form-action form-action--secondary" type="button" @click="handleBack">
+              <ElButton @click="handleBack">
                 {{ t('repositoriesPage.btnCancel') }}
-              </button>
-              <button class="form-action form-action--primary" type="button" :disabled="busy" @click="onSubmit">
-                <span v-if="busy" class="form-action__loading" />
+              </ElButton>
+              <ElButton type="primary" :loading="busy" :disabled="busy" @click="onSubmit">
                 {{ submitButtonLabel }}
-              </button>
+              </ElButton>
             </div>
           </div>
         </div>

--- a/src/frontend/src/pages/node/AddProxyFsRepository.vue
+++ b/src/frontend/src/pages/node/AddProxyFsRepository.vue
@@ -864,13 +864,12 @@ watch(enableQuotaAlert, (enabled) => {
 
           <div class="fullscreen-form-footer fullscreen-form-action-footer add-proxy-fs-footer">
             <div class="flex gap-2">
-              <button class="form-action form-action--secondary" type="button" @click="handleBack">
+              <ElButton @click="handleBack">
                 {{ t('repositoriesPage.btnCancel') }}
-              </button>
-              <button class="form-action form-action--primary" type="button" :disabled="busy" @click="onSubmit">
-                <span v-if="busy" class="form-action__loading" />
+              </ElButton>
+              <ElButton type="primary" :loading="busy" :disabled="busy" @click="onSubmit">
                 {{ t('repositoriesPage.btnCreateRepo') }}
-              </button>
+              </ElButton>
             </div>
           </div>
         </div>

--- a/src/frontend/src/pages/node/AddS3Repo.vue
+++ b/src/frontend/src/pages/node/AddS3Repo.vue
@@ -868,13 +868,12 @@ function handleBack() {
           <!-- Footer Actions -->
           <div class="fullscreen-form-footer add-s3-footer">
             <p v-if="submitBlockReason" class="form-submit-hint">{{ submitBlockReason }}</p>
-            <button class="form-action form-action--secondary" @click="handleBack">
+            <ElButton @click="handleBack">
               {{ t('repositoriesPage.btnCancel') }}
-            </button>
-            <button class="form-action form-action--primary" :disabled="!canSubmit" @click="onSubmit">
-              <span v-if="busy" class="form-action__loading" />
+            </ElButton>
+            <ElButton type="primary" :loading="busy" :disabled="!canSubmit" @click="onSubmit">
               {{ t('addS3Repo.btnCreateInit') }}
-            </button>
+            </ElButton>
           </div>
         </div>
 
@@ -1193,11 +1192,11 @@ function handleBack() {
     line-height: 1.4;
   }
 
-  .add-s3-footer .form-action {
+  .add-s3-footer .el-button {
     white-space: nowrap;
   }
 
-  .add-s3-footer .form-action--secondary {
+  .add-s3-footer .el-button:first-of-type {
     margin-left: auto;
   }
 

--- a/src/frontend/src/pages/node/EditProxyFsRepo.vue
+++ b/src/frontend/src/pages/node/EditProxyFsRepo.vue
@@ -382,25 +382,17 @@ watch(repositoryId, (id) => {
 
           <div class="fullscreen-form-footer add-proxy-fs-footer">
             <div class="add-nas-footer__actions">
-              <button
-                class="form-action form-action--secondary"
-                type="button"
-                @click="handleBack"
-              >
+              <ElButton @click="handleBack">
                 {{ t('repositoriesPage.editProxyFsRepo.btnCancel') }}
-              </button>
-              <button
-                class="form-action form-action--primary"
-                type="button"
+              </ElButton>
+              <ElButton
+                type="primary"
+                :loading="busy"
                 :disabled="busy || !dirty"
                 @click="onSave"
               >
-                <span
-                  v-if="busy"
-                  class="form-action__loading"
-                />
                 {{ t('repositoriesPage.editProxyFsRepo.btnSave') }}
-              </button>
+              </ElButton>
             </div>
           </div>
         </div>

--- a/src/frontend/src/pages/node/EditS3Repo.vue
+++ b/src/frontend/src/pages/node/EditS3Repo.vue
@@ -727,22 +727,18 @@ watch(repositoryId, (id) => {
           </div>
 
           <div class="fullscreen-form-footer add-s3-footer">
-            <button
-              class="form-action form-action--secondary"
+            <ElButton
               :disabled="busy"
               @click="handleBack"
             >
               {{ t('repositoriesPage.btnCancel') }}
-            </button>
-            <button
-              class="form-action form-action--primary"
+            </ElButton>
+            <ElButton
+              type="primary"
+              :loading="busy"
               :disabled="busy"
               @click="onSave"
             >
-              <span
-                v-if="busy"
-                class="form-action__loading"
-              />
               <template v-if="busy && savingPhase === 'verifying'">
                 {{ t('repositoriesPage.editS3Repo.savingAndVerifying') }}
               </template>
@@ -752,7 +748,7 @@ watch(repositoryId, (id) => {
               <template v-else>
                 {{ t('repositoriesPage.editS3Repo.btnSave') }}
               </template>
-            </button>
+            </ElButton>
           </div>
         </div>
 
@@ -999,13 +995,12 @@ watch(repositoryId, (id) => {
       v-if="verifyStatus === 'failed'"
       #footer
     >
-      <button
-        type="button"
-        class="form-action form-action--primary"
+      <ElButton
+        type="primary"
         @click="closeVerifyDialog"
       >
         {{ t('repositoriesPage.editS3Repo.verifyDialogClose') }}
-      </button>
+      </ElButton>
     </template>
   </ElDialog>
 </template>

--- a/src/frontend/src/pages/node/NodesDeploy.vue
+++ b/src/frontend/src/pages/node/NodesDeploy.vue
@@ -133,9 +133,9 @@ function handleBack() {
             />
 
             <div class="fullscreen-form-footer fullscreen-form-action-footer">
-              <button type="button" class="form-action form-action--secondary" @click="handleBack">
+              <ElButton @click="handleBack">
                 {{ t('common.back') }}
-              </button>
+              </ElButton>
             </div>
           </div>
         </div>

--- a/src/frontend/src/pages/node/RepairNasRepository.vue
+++ b/src/frontend/src/pages/node/RepairNasRepository.vue
@@ -705,13 +705,12 @@ onMounted(async () => {
 
           <div class="fullscreen-form-footer add-nas-footer">
             <div class="add-nas-footer__actions">
-              <button class="form-action form-action--secondary" type="button" :disabled="busy" @click="handleBack">
+              <ElButton :disabled="busy" @click="handleBack">
                 {{ t('repositoriesPage.btnCancel') }}
-              </button>
-              <button class="form-action form-action--primary" type="button" :disabled="busy" @click="onSubmit">
-                <span v-if="busy" class="form-action__loading" />
+              </ElButton>
+              <ElButton type="primary" :loading="busy" :disabled="busy" @click="onSubmit">
                 {{ submitLabel }}
-              </button>
+              </ElButton>
             </div>
           </div>
         </div>

--- a/src/frontend/src/pages/ops/AlertPolicyEditorPage.vue
+++ b/src/frontend/src/pages/ops/AlertPolicyEditorPage.vue
@@ -1079,18 +1079,17 @@ onMounted(async () => {
           </el-form>
 
           <div class="fullscreen-form-footer fullscreen-form-action-footer alert-policy-editor-footer">
-            <button type="button" class="form-action form-action--secondary" @click="handleBack">
+            <ElButton @click="handleBack">
               {{ t('common.cancel') }}
-            </button>
-            <button
-              type="button"
-              class="form-action form-action--primary"
+            </ElButton>
+            <ElButton
+              type="primary"
+              :loading="saving"
               :disabled="saving"
               @click="savePolicy"
             >
-              <span v-if="saving" class="form-action__loading" />
               {{ t('common.save') }}
-            </button>
+            </ElButton>
           </div>
         </div>
 

--- a/src/frontend/src/pages/ops/NotificationChannelEditorPage.vue
+++ b/src/frontend/src/pages/ops/NotificationChannelEditorPage.vue
@@ -564,28 +564,25 @@ watch(() => form.type, () => {
           </el-form>
 
           <div class="fullscreen-form-footer fullscreen-form-action-footer fullscreen-form-footer--split">
-            <button
-              type="button"
-              class="form-action form-action--secondary"
+            <ElButton
+              :loading="testing"
               :disabled="testing"
               @click="testFromEditor"
             >
-              <span v-if="testing" class="form-action__loading" />
               {{ t('ops.notification.testConnection') }}
-            </button>
+            </ElButton>
             <div class="flex gap-2">
-              <button type="button" class="form-action form-action--secondary" @click="handleBack">
+              <ElButton @click="handleBack">
                 {{ t('common.cancel') }}
-              </button>
-              <button
-                type="button"
-                class="form-action form-action--primary"
+              </ElButton>
+              <ElButton
+                type="primary"
+                :loading="saving"
                 :disabled="saving"
                 @click="saveChannel"
               >
-                <span v-if="saving" class="form-action__loading" />
                 {{ t('common.save') }}
-              </button>
+              </ElButton>
             </div>
           </div>
         </div>

--- a/src/frontend/src/pages/protection/BackupCreateWizard.vue
+++ b/src/frontend/src/pages/protection/BackupCreateWizard.vue
@@ -8825,9 +8825,9 @@ function preserveShallowestPathOrder(paths: string[]) {
                   @copy="copyDeployScript"
                 />
                 <div class="fullscreen-form-footer fullscreen-form-action-footer">
-                  <button type="button" class="form-action form-action--secondary" @click="closeAddSource">
+                  <ElButton @click="closeAddSource">
                     {{ t('common.back') }}
-                  </button>
+                  </ElButton>
                 </div>
               </template>
               <template v-else>
@@ -12383,18 +12383,6 @@ function preserveShallowestPathOrder(paths: string[]) {
   border-top: 1px solid rgba(226, 232, 240, 0.95);
   background: rgba(255, 255, 255, 0.98);
   box-shadow: 0 -8px 18px rgba(15, 23, 42, 0.05);
-}
-
-.repository-add-main--embedded :deep(.resource-add-fullscreen--embedded .form-action--secondary) {
-  color: rgb(51 65 85);
-  border-color: rgb(203 213 225);
-  background: #fff;
-}
-
-.repository-add-main--embedded :deep(.resource-add-fullscreen--embedded .form-action--secondary:hover:not(:disabled)) {
-  color: rgb(15 23 42);
-  border-color: rgb(148 163 184);
-  background: rgb(248 250 252);
 }
 
 .repository-add-steps {

--- a/src/frontend/src/pages/protection/BackupSources.vue
+++ b/src/frontend/src/pages/protection/BackupSources.vue
@@ -2395,9 +2395,9 @@ onUnmounted(() => {
               />
 
               <div class="fullscreen-form-footer fullscreen-form-action-footer">
-                <button type="button" class="form-action form-action--secondary" @click="closeAgentDeploy">
+                <ElButton @click="closeAgentDeploy">
                   {{ t('common.back') }}
-                </button>
+                </ElButton>
               </div>
             </div>
           </div>

--- a/src/frontend/src/pages/protection/DataProtection.vue
+++ b/src/frontend/src/pages/protection/DataProtection.vue
@@ -11811,9 +11811,9 @@ async function runRecovery(mode: 'plan' | 'manual' = 'manual') {
                   @copy="copyDeployScript"
                 />
                 <div class="fullscreen-form-footer fullscreen-form-action-footer">
-                  <button type="button" class="form-action form-action--secondary" @click="closeAddSource">
+                  <ElButton @click="closeAddSource">
                     {{ t('common.back') }}
-                  </button>
+                  </ElButton>
                 </div>
               </template>
               <template v-else>

--- a/src/frontend/src/pages/protection/PolicyEditorPage.vue
+++ b/src/frontend/src/pages/protection/PolicyEditorPage.vue
@@ -323,13 +323,12 @@ onMounted(() => {
           />
 
           <footer class="fullscreen-form-footer fullscreen-form-action-footer">
-            <button class="form-action form-action--secondary" type="button" :disabled="saving" @click="handleBack">
+            <ElButton :disabled="saving" @click="handleBack">
               {{ t('protection.backupsPage.btnCancel') }}
-            </button>
-            <button class="form-action form-action--primary" type="button" :disabled="saving || loading" @click="submitEditor">
-              <span v-if="saving" class="form-action__loading" />
+            </ElButton>
+            <ElButton type="primary" :loading="saving" :disabled="saving || loading" @click="submitEditor">
               {{ editorSaveLabel }}
-            </button>
+            </ElButton>
           </footer>
         </main>
 

--- a/src/frontend/src/pages/protection/components/NasAddForm.vue
+++ b/src/frontend/src/pages/protection/components/NasAddForm.vue
@@ -362,18 +362,17 @@ defineExpose({
     </div>
 
     <div class="fullscreen-form-footer fullscreen-form-action-footer">
-      <button type="button" class="form-action form-action--secondary" @click="emit('cancel')">
+      <ElButton @click="emit('cancel')">
         {{ t('common.back') }}
-      </button>
-      <button
-        type="button"
-        class="form-action form-action--primary"
+      </ElButton>
+      <ElButton
+        type="primary"
+        :loading="busy"
         :disabled="busy || !!nameConflictMessage"
         @click="emit('submit')"
       >
-        <span v-if="busy" class="form-action__loading" />
         {{ t('protection.sourceResources.nasBtnSubmit') }}
-      </button>
+      </ElButton>
     </div>
   </div>
 </template>
@@ -482,7 +481,6 @@ defineExpose({
 
 .nas-add-form :deep(.add-nas-protocol-card__title),
 .nas-add-form :deep(.add-nas-protocol-card .el-radio__label),
-.nas-add-form :deep(.form-action),
 .nas-add-form :deep(.el-button) {
   font-weight: 400;
 }

--- a/src/frontend/src/styles/fullscreen-form-shell.css
+++ b/src/frontend/src/styles/fullscreen-form-shell.css
@@ -583,6 +583,10 @@ html[data-theme='dark'] .fullscreen-form-select__control:focus {
   gap: 8px;
 }
 
+.fullscreen-form-footer .el-button + .el-button {
+  margin-left: 0;
+}
+
 html[data-theme='light'] .fullscreen-form-footer {
   --fullscreen-form-footer-bg: rgba(255, 255, 255, 0.96);
   --fullscreen-form-footer-border: #e5e6eb;
@@ -593,92 +597,6 @@ html[data-theme='dark'] .fullscreen-form-footer {
   --fullscreen-form-footer-bg: rgba(22, 22, 29, 0.96);
   --fullscreen-form-footer-border: #2a2b35;
   --fullscreen-form-footer-shadow: 0 -8px 24px rgba(0, 0, 0, 0.28);
-}
-
-.form-action {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 0;
-  height: 34px;
-  min-height: 34px;
-  padding: 0 16px;
-  border-radius: var(--el-border-radius-base, 8px);
-  font-size: 13px;
-  font-weight: 500;
-  line-height: 34px;
-  cursor: pointer;
-  box-shadow: none;
-  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
-}
-
-.form-action--secondary {
-  border: 1px solid var(--form-action-secondary-border, var(--repo-footer-secondary-border, #e5e6eb));
-  background: var(--form-action-secondary-bg, var(--repo-footer-secondary-bg, #fff));
-  color: var(--form-action-secondary-text, var(--repo-footer-secondary-text, #1d2129));
-}
-
-.form-action--secondary:hover {
-  border-color: var(--form-action-secondary-hover-border, var(--color-primary));
-}
-
-.form-action--primary {
-  border: 1px solid transparent;
-  background-color: var(--form-action-primary-bg, var(--color-primary));
-  background-image: linear-gradient(
-    var(--color-primary-gradient-start, #7E6CEF),
-    var(--color-primary-gradient-end, #6D5EF6)
-  );
-  color: var(--form-action-primary-text, var(--repo-footer-primary-text, #fff));
-  box-shadow: rgba(109, 94, 246, 0.32) 0 6px 16px -8px;
-}
-
-.form-action--primary:hover:not(:disabled) {
-  background-color: var(--form-action-primary-hover-bg, var(--color-primary-hover-gradient-end, var(--color-primary)));
-  background-image: linear-gradient(
-    var(--color-primary-hover-gradient-start, #8876F5),
-    var(--color-primary-hover-gradient-end, #7664FA)
-  );
-  box-shadow: rgba(109, 94, 246, 0.42) 0 8px 18px -8px;
-}
-
-.form-action--primary:active:not(:disabled) {
-  background-color: var(--color-primary-active-gradient-end, #5546D8);
-  background-image: linear-gradient(
-    var(--color-primary-active-gradient-start, #5F50E0),
-    var(--color-primary-active-gradient-end, #5546D8)
-  );
-  box-shadow: rgba(38, 30, 120, 0.22) 0 2px 6px inset;
-}
-
-.form-action:disabled {
-  opacity: 0.65;
-  cursor: not-allowed;
-}
-
-.form-action--primary:disabled {
-  border-color: var(--color-primary-disabled-border, #DCD5FB);
-  background-color: var(--color-primary-disabled-bg, #DCD5FB);
-  background-image: linear-gradient(
-    var(--color-primary-disabled-gradient-start, #E5E1FD),
-    var(--color-primary-disabled-bg, #DCD5FB)
-  );
-  color: var(--color-primary-disabled-text, rgba(255, 255, 255, 0.78));
-  box-shadow: none;
-  opacity: 1;
-}
-
-.form-action__loading {
-  width: 16px;
-  height: 16px;
-  border: 2px solid rgba(255, 255, 255, 0.3);
-  border-top-color: #fff;
-  border-radius: 50%;
-  animation: form-action-spin 0.8s linear infinite;
-}
-
-@keyframes form-action-spin {
-  to { transform: rotate(360deg); }
 }
 
 .form-submit-hint {

--- a/src/frontend/src/styles/fullscreenFormButtons.test.ts
+++ b/src/frontend/src/styles/fullscreenFormButtons.test.ts
@@ -1,0 +1,31 @@
+import { readdirSync, readFileSync } from 'node:fs'
+import { relative, resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+function frontendSourcesBelow(directory: string): string[] {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const path = resolve(directory, entry.name)
+    if (entry.isDirectory()) return frontendSourcesBelow(path)
+    return /\.(?:css|vue)$/.test(path) ? [path] : []
+  })
+}
+
+describe('fullscreen form buttons', () => {
+  it('uses Element Plus buttons instead of the legacy form action spinner', () => {
+    const sourceRoot = resolve(process.cwd(), 'src')
+    const legacyAction = /form-action(?:--|__|\s|")|form-action-spin/
+    const localImplementations = frontendSourcesBelow(sourceRoot)
+      .filter((file) => legacyAction.test(readFileSync(file, 'utf8')))
+      .map((file) => relative(sourceRoot, file))
+      .sort()
+
+    expect(localImplementations).toEqual([])
+  })
+
+  it('binds the Add S3 primary action to the shared loading behavior', () => {
+    const addS3Repo = readFileSync(resolve(process.cwd(), 'src/pages/node/AddS3Repo.vue'), 'utf8')
+
+    expect(addS3Repo).toContain('<ElButton type="primary" :loading="busy" :disabled="!canSubmit" @click="onSubmit">')
+    expect(addS3Repo).not.toContain('form-action__loading')
+  })
+})

--- a/src/frontend/src/styles/resource-add.css
+++ b/src/frontend/src/styles/resource-add.css
@@ -1240,58 +1240,24 @@ html:not([data-theme='dark']) .resource-add-fullscreen :is(.add-s3-platform-btn:
   --fullscreen-form-footer-bg: rgba(43, 45, 54, 0.98);
   --fullscreen-form-footer-border: transparent;
   --fullscreen-form-footer-shadow: 0 -8px 24px rgba(0, 0, 0, 0.12);
-  --repo-footer-secondary-border: rgba(229, 230, 235, 0.5);
-  --repo-footer-secondary-bg: transparent;
-  --repo-footer-secondary-text: #fff;
-  --repo-footer-secondary-hover-border: rgba(229, 230, 235, 0.62);
-  --repo-footer-primary-bg: var(--color-primary, #6D5EF6);
-  --repo-footer-primary-hover-bg: var(--color-primary-hover-gradient-end, #7664FA);
-  --repo-footer-primary-text: #fff;
 }
 
 html[data-theme='light'] .resource-add-fullscreen .fullscreen-form-action-footer {
   --fullscreen-form-footer-bg: rgba(255, 255, 255, 0.96);
   --fullscreen-form-footer-border: #e5e6eb;
   --fullscreen-form-footer-shadow: 0 -4px 16px rgba(29, 33, 41, 0.06);
-  --repo-footer-secondary-border: #e5e6eb;
-  --repo-footer-secondary-bg: #fff;
-  --repo-footer-secondary-text: #1d2129;
-  --repo-footer-secondary-hover-border: #c9cdd4;
-  --repo-footer-secondary-hover-bg: #f7f8fa;
-  --repo-footer-secondary-hover-text: #1d2129;
-  --repo-footer-primary-bg: var(--color-primary, #6D5EF6);
-  --repo-footer-primary-hover-bg: var(--color-primary-hover-gradient-end, #7664FA);
-  --repo-footer-primary-text: #fff;
 }
 
 html[data-theme='dark'] .resource-add-fullscreen .fullscreen-form-action-footer {
   --fullscreen-form-footer-bg: rgba(22, 22, 29, 0.96);
   --fullscreen-form-footer-border: #2a2b35;
   --fullscreen-form-footer-shadow: 0 -8px 24px rgba(0, 0, 0, 0.28);
-  --repo-footer-secondary-border: #3a3b45;
-  --repo-footer-secondary-bg: transparent;
-  --repo-footer-secondary-text: #e2e2e2;
-  --repo-footer-secondary-hover-border: #4b4c5a;
-  --repo-footer-secondary-hover-bg: #2a2b35;
-  --repo-footer-secondary-hover-text: #fff;
-  --repo-footer-primary-bg: var(--color-primary, #6D5EF6);
-  --repo-footer-primary-hover-bg: var(--color-primary-hover-gradient-end, #7664FA);
-  --repo-footer-primary-text: #fff;
 }
 
 html[data-theme='hybrid'] .resource-add-fullscreen .fullscreen-form-action-footer {
   --fullscreen-form-footer-bg: rgba(43, 45, 54, 0.98);
   --fullscreen-form-footer-border: transparent;
   --fullscreen-form-footer-shadow: 0 -8px 24px rgba(0, 0, 0, 0.12);
-  --repo-footer-secondary-border: rgba(229, 230, 235, 0.5);
-  --repo-footer-secondary-bg: transparent;
-  --repo-footer-secondary-text: #fff;
-  --repo-footer-secondary-hover-border: rgba(229, 230, 235, 0.62);
-  --repo-footer-secondary-hover-bg: #3a3c45;
-  --repo-footer-secondary-hover-text: #fff;
-  --repo-footer-primary-bg: var(--color-primary, #6D5EF6);
-  --repo-footer-primary-hover-bg: var(--color-primary-hover-gradient-end, #7664FA);
-  --repo-footer-primary-text: #fff;
 }
 
 .resource-add-fullscreen :deep(.el-form-item__label),
@@ -1510,63 +1476,6 @@ html:not([data-theme='dark']) .fullscreen-form-icon-btn:not(.hfl-refresh-button)
 .resource-add-fullscreen .el-checkbox__input.is-checked .el-checkbox__inner {
   border-color: var(--color-primary, #6D5EF6);
   background-color: var(--color-primary, #6D5EF6);
-}
-
-.resource-add-fullscreen :deep(.el-button),
-.resource-add-fullscreen .el-button {
-  height: 34px;
-  min-height: 34px;
-  padding: 0 16px;
-  border-radius: var(--el-border-radius-base, 8px);
-  border-color: #e5e6eb;
-  background: #fff;
-  color: #1d2129;
-  font-size: 13px;
-}
-
-.resource-add-fullscreen :deep(.el-button:hover),
-.resource-add-fullscreen .el-button:hover {
-  border-color: #c9cdd4;
-  background: #f7f8fa;
-  color: #1d2129;
-}
-
-.resource-add-fullscreen :deep(.el-button--primary:not(.is-disabled):not(:disabled)),
-.resource-add-fullscreen .el-button--primary:not(.is-disabled):not(:disabled) {
-  border-color: var(--color-primary, #6D5EF6);
-  background-color: var(--color-primary, #6D5EF6);
-  background-image: linear-gradient(
-    var(--color-primary-gradient-start, #7E6CEF),
-    var(--color-primary-gradient-end, #6D5EF6)
-  );
-  color: #fff;
-  box-shadow: rgba(109, 94, 246, 0.32) 0 6px 16px -8px;
-}
-
-.resource-add-fullscreen :deep(.el-button--primary:not(.is-disabled):not(:disabled):hover),
-.resource-add-fullscreen .el-button--primary:not(.is-disabled):not(:disabled):hover,
-.resource-add-fullscreen :deep(.el-button--primary:not(.is-disabled):not(:disabled):focus),
-.resource-add-fullscreen .el-button--primary:not(.is-disabled):not(:disabled):focus {
-  border-color: var(--color-primary-hover-gradient-end, #7664FA);
-  background-color: var(--color-primary-hover-gradient-end, #7664FA);
-  background-image: linear-gradient(
-    var(--color-primary-hover-gradient-start, #8876F5),
-    var(--color-primary-hover-gradient-end, #7664FA)
-  );
-  color: #fff;
-  box-shadow: rgba(109, 94, 246, 0.42) 0 8px 18px -8px;
-}
-
-.resource-add-fullscreen :deep(.el-button--primary:not(.is-disabled):not(:disabled):active),
-.resource-add-fullscreen .el-button--primary:not(.is-disabled):not(:disabled):active {
-  border-color: var(--color-primary-active-gradient-end, #5546D8);
-  background-color: var(--color-primary-active-gradient-end, #5546D8);
-  background-image: linear-gradient(
-    var(--color-primary-active-gradient-start, #5F50E0),
-    var(--color-primary-active-gradient-end, #5546D8)
-  );
-  color: #fff;
-  box-shadow: rgba(38, 30, 120, 0.22) 0 2px 6px inset;
 }
 
 .resource-add-fullscreen :deep(.el-alert),

--- a/src/frontend/src/styles/source-deploy-ui.css
+++ b/src/frontend/src/styles/source-deploy-ui.css
@@ -287,15 +287,6 @@
   --fullscreen-form-footer-bg: rgba(43, 45, 54, 0.98);
   --fullscreen-form-footer-border: transparent;
   --fullscreen-form-footer-shadow: 0 -8px 24px rgba(0, 0, 0, 0.12);
-  --repo-footer-secondary-border: rgba(229, 230, 235, 0.5);
-  --repo-footer-secondary-bg: transparent;
-  --repo-footer-secondary-text: #fff;
-  --repo-footer-secondary-hover-border: rgba(229, 230, 235, 0.62);
-  --repo-footer-secondary-hover-bg: #3a3c45;
-  --repo-footer-secondary-hover-text: #fff;
-  --repo-footer-primary-bg: var(--color-primary, #6D5EF6);
-  --repo-footer-primary-hover-bg: var(--color-primary-hover-gradient-end, #7664FA);
-  --repo-footer-primary-text: #fff;
   flex-shrink: 0;
   position: fixed;
   right: 0;
@@ -315,30 +306,12 @@ html[data-theme='light'] .source-fullscreen--form-shell .source-fullscreen__foot
   --fullscreen-form-footer-bg: rgba(255, 255, 255, 0.96);
   --fullscreen-form-footer-border: #e5e6eb;
   --fullscreen-form-footer-shadow: 0 -4px 16px rgba(29, 33, 41, 0.06);
-  --repo-footer-secondary-border: #e5e6eb;
-  --repo-footer-secondary-bg: #fff;
-  --repo-footer-secondary-text: #1d2129;
-  --repo-footer-secondary-hover-border: #c9cdd4;
-  --repo-footer-secondary-hover-bg: #f7f8fa;
-  --repo-footer-secondary-hover-text: #1d2129;
-  --repo-footer-primary-bg: var(--color-primary, #6D5EF6);
-  --repo-footer-primary-hover-bg: var(--color-primary-hover-gradient-end, #7664FA);
-  --repo-footer-primary-text: #fff;
 }
 
 html[data-theme='dark'] .source-fullscreen--form-shell .source-fullscreen__footer--sticky {
   --fullscreen-form-footer-bg: rgba(22, 22, 29, 0.96);
   --fullscreen-form-footer-border: #2a2b35;
   --fullscreen-form-footer-shadow: 0 -8px 24px rgba(0, 0, 0, 0.28);
-  --repo-footer-secondary-border: #3a3b45;
-  --repo-footer-secondary-bg: transparent;
-  --repo-footer-secondary-text: #e2e2e2;
-  --repo-footer-secondary-hover-border: #4b4c5a;
-  --repo-footer-secondary-hover-bg: #2a2b35;
-  --repo-footer-secondary-hover-text: #fff;
-  --repo-footer-primary-bg: var(--color-primary, #6D5EF6);
-  --repo-footer-primary-hover-bg: var(--color-primary-hover-gradient-end, #7664FA);
-  --repo-footer-primary-text: #fff;
 }
 
 .source-fullscreen--form-shell .source-fullscreen__footer-inner {
@@ -349,59 +322,6 @@ html[data-theme='dark'] .source-fullscreen--form-shell .source-fullscreen__foote
   margin-right: auto;
   padding: 0 var(--source-form-h-padding);
   box-sizing: border-box;
-}
-
-.source-fullscreen--form-shell .source-fullscreen__footer-inner .el-button {
-  height: 34px;
-  min-height: 34px;
-  min-width: 78px;
-}
-
-.source-fullscreen--form-shell .source-fullscreen__footer-inner .el-button:not(.el-button--primary) {
-  border-color: var(--repo-footer-secondary-border);
-  background: var(--repo-footer-secondary-bg);
-  color: var(--repo-footer-secondary-text);
-}
-
-.source-fullscreen--form-shell .source-fullscreen__footer-inner .el-button:not(.el-button--primary):hover,
-.source-fullscreen--form-shell .source-fullscreen__footer-inner .el-button:not(.el-button--primary):focus {
-  border-color: var(--repo-footer-secondary-hover-border);
-  background: var(--repo-footer-secondary-hover-bg);
-  color: var(--repo-footer-secondary-hover-text);
-}
-
-.source-fullscreen--form-shell .source-fullscreen__footer-inner .el-button--primary:not(.is-disabled):not(:disabled) {
-  border-color: var(--repo-footer-primary-bg);
-  background-color: var(--repo-footer-primary-bg);
-  background-image: linear-gradient(
-    var(--color-primary-gradient-start, #7E6CEF),
-    var(--color-primary-gradient-end, #6D5EF6)
-  );
-  color: var(--repo-footer-primary-text);
-  box-shadow: rgba(109, 94, 246, 0.32) 0 6px 16px -8px;
-}
-
-.source-fullscreen--form-shell .source-fullscreen__footer-inner .el-button--primary:not(.is-disabled):not(:disabled):hover,
-.source-fullscreen--form-shell .source-fullscreen__footer-inner .el-button--primary:not(.is-disabled):not(:disabled):focus {
-  border-color: var(--repo-footer-primary-hover-bg);
-  background-color: var(--repo-footer-primary-hover-bg);
-  background-image: linear-gradient(
-    var(--color-primary-hover-gradient-start, #8876F5),
-    var(--color-primary-hover-gradient-end, #7664FA)
-  );
-  color: var(--repo-footer-primary-text);
-  box-shadow: rgba(109, 94, 246, 0.42) 0 8px 18px -8px;
-}
-
-.source-fullscreen--form-shell .source-fullscreen__footer-inner .el-button--primary:not(.is-disabled):not(:disabled):active {
-  border-color: var(--color-primary-active-gradient-end, #5546D8);
-  background-color: var(--color-primary-active-gradient-end, #5546D8);
-  background-image: linear-gradient(
-    var(--color-primary-active-gradient-start, #5F50E0),
-    var(--color-primary-active-gradient-end, #5546D8)
-  );
-  color: var(--repo-footer-primary-text);
-  box-shadow: rgba(38, 30, 120, 0.22) 0 2px 6px inset;
 }
 
 .add-source-fullscreen {


### PR DESCRIPTION
## Summary

- replace custom fullscreen and add-page footer buttons with shared Element Plus buttons
- use the global primary, disabled, and loading behavior instead of scoped button skins and spinners
- add regression coverage that prevents legacy form action styles from returning

Closes #189

## Testing

- `npm run build`
- `npm test` (135 files, 638 tests)
- changed-file ESLint (`--quiet`)
- `git diff --check`