### PR TITLE
fix(ci): stabilize backend release checks

### DIFF
--- a/src/backend/apps/lens_bridge/tests/test_managed_datasource.py
+++ b/src/backend/apps/lens_bridge/tests/test_managed_datasource.py
@@ -4,6 +4,7 @@ import uuid
 from unittest.mock import MagicMock, patch
 
 from django.test import SimpleTestCase
+from django.utils import timezone
 
 from apps.lens_bridge.services import managed_datasource, sl_client
 
@@ -234,7 +235,7 @@ class ManagedDatasourceTests(SimpleTestCase):
                 "policy_fingerprint": (
                     managed_datasource.conversion_policy_fingerprint(policy)
                 ),
-                "started_at": "2026-08-03T06:00:00Z",
+                "started_at": timezone.now().isoformat(),
             }
         }
 

--- a/src/backend/apps/node/tests/test_agent_task_sync.py
+++ b/src/backend/apps/node/tests/test_agent_task_sync.py
@@ -161,6 +161,9 @@ class AgentTaskSyncWaitTests(TestCase):
             def exists(self, key):
                 return False
 
+            def set(self, *args, **kwargs):
+                return True
+
         NodeTask.objects.filter(pk=self.task.pk).update(
             created_at=timezone.now()
             - timezone.timedelta(seconds=node_conf.TASK_ROUTE_RECONNECT_GRACE_SECONDS + 1),
@@ -193,6 +196,9 @@ class AgentTaskSyncWaitTests(TestCase):
         class RedisClient:
             def exists(self, key):
                 return False
+
+            def set(self, *args, **kwargs):
+                return True
 
         self.node.status = Node.Status.OFFLINE
         self.node.save(update_fields=["status"])


### PR DESCRIPTION
## Summary
- keep Agent task Redis test doubles aligned with task-info projection
- make the missing SourceLens conversion recovery test independent of wall-clock time

## Validation
- focused failed tests: 3/3 passed
- related backend modules: 32/32 passed
- full backend suite: 1200/1200 passed
- Ruff passed
- migration drift check passed
- git diff --check passed