### PR TITLE
fix(frontend): restore release quality checks

### DIFF
--- a/src/frontend/src/lib/lensApi.test.ts
+++ b/src/frontend/src/lib/lensApi.test.ts
@@ -2,12 +2,34 @@
 
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { api } from './api'
+import type { LensIngestPolicy } from './lensApi'
 import {
+  createKnowledgeSource,
+  patchKnowledgeSource,
   setLensApiScope,
   setLensDefaultAgentModel,
   setLensDefaultMultimodalModel,
   testSavedLensModel,
 } from './lensApi'
+
+const ingestPolicy: LensIngestPolicy = {
+  document: true,
+  embedded_image: true,
+  image: true,
+  document_model_ref: 'document-model',
+  vision_model_ref: 'vision-model',
+  max_images: 20,
+  max_file_size_mb: 100,
+  max_pages: 200,
+  pdf_extract_images: true,
+  pdf_extract_images_on_text_pages: false,
+  pdf_render_scanned_pages: true,
+  pdf_max_pages: 200,
+  pdf_max_images_per_page: 10,
+  pdf_render_dpi: 144,
+  pdf_min_text_chars: 80,
+  pdf_min_image_area_ratio: 0.1,
+}
 
 vi.mock('./api', async (importOriginal) => {
   const actual = await importOriginal<typeof import('./api')>()
@@ -79,5 +101,29 @@ describe('AI model role defaults', () => {
         }),
       }),
     )
+  })
+})
+
+describe('knowledge source ingest policy', () => {
+  it.each([
+    ['create', () => createKnowledgeSource({
+      name: 'Documents',
+      gateway: 42,
+      source_path: '/documents',
+      ingest_policy: ingestPolicy,
+    })],
+    ['patch', () => patchKnowledgeSource(7, { ingest_policy: ingestPolicy })],
+  ])('keeps deployment-owned model references out of %s requests', async (_operation, request) => {
+    vi.mocked(api).mockResolvedValue({ id: 7 })
+
+    await request()
+
+    const options = vi.mocked(api).mock.calls[0]?.[1]
+    const body = JSON.parse(String(options?.body))
+    expect(body.ingest_policy).not.toHaveProperty('document_model_ref')
+    expect(body.ingest_policy).not.toHaveProperty('vision_model_ref')
+    expect(body.ingest_policy.document).toBe(true)
+    expect(ingestPolicy.document_model_ref).toBe('document-model')
+    expect(ingestPolicy.vision_model_ref).toBe('vision-model')
   })
 })

--- a/src/frontend/src/lib/lensApi.ts
+++ b/src/frontend/src/lib/lensApi.ts
@@ -504,11 +504,9 @@ function knowledgeSourceRequestBody<
   T extends { ingest_policy?: LensIngestPolicy },
 >(body: T): T {
   if (!body.ingest_policy) return body
-  const {
-    document_model_ref: _documentModelRef,
-    vision_model_ref: _visionModelRef,
-    ...tenantPolicy
-  } = body.ingest_policy
+  const tenantPolicy = { ...body.ingest_policy }
+  delete tenantPolicy.document_model_ref
+  delete tenantPolicy.vision_model_ref
   return { ...body, ingest_policy: tenantPolicy } as T
 }
 

--- a/src/frontend/src/pages/node/AddNasRepositoryProxyDecision.test.ts
+++ b/src/frontend/src/pages/node/AddNasRepositoryProxyDecision.test.ts
@@ -2,6 +2,7 @@
 
 import { flushPromises, mount, type VueWrapper } from '@vue/test-utils'
 import ElementPlus, {
+  ElButton,
   ElFormItem,
   ElInput,
   ElMessage,
@@ -90,6 +91,14 @@ function previewValue(wrapper: VueWrapper, label: string) {
   return row.find('.add-form-preview-row__value').text()
 }
 
+function submitButton(wrapper: VueWrapper) {
+  const button = wrapper
+    .findAllComponents(ElButton)
+    .find((component) => component.props('type') === 'primary')
+  if (!button) throw new Error('Primary submit button was not rendered')
+  return button
+}
+
 describe('AddNasRepository Proxy decision', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -110,7 +119,7 @@ describe('AddNasRepository Proxy decision', () => {
     expect(wrapper.find('.nas-proxy-topology--direct').exists()).toBe(false)
     expect(previewValue(wrapper, en.addNasRepo.fieldSourceProxyNode)).toBe('—')
     expect(previewValue(wrapper, en.repositoriesPage.fieldAccessPath)).toBe(en.addNasRepo.accessPathWithProxy)
-    expect(wrapper.find('.form-action--primary').text()).toContain('Submit and initialize')
+    expect(submitButton(wrapper).text()).toContain('Submit and initialize')
 
     const optionLabels = wrapper.findAllComponents(ElOption).map(option => option.props('label'))
     expect(optionLabels).toEqual([
@@ -126,7 +135,7 @@ describe('AddNasRepository Proxy decision', () => {
     const wrapper = await mountForm({ embedded: true })
     await fillRequiredNfsFields(wrapper)
 
-    await wrapper.find('button.form-action--primary').trigger('click')
+    await submitButton(wrapper).trigger('click')
     await flushPromises()
 
     expect(mocks.createStorageRepository).not.toHaveBeenCalled()
@@ -153,7 +162,7 @@ describe('AddNasRepository Proxy decision', () => {
     )
     await nextTick()
 
-    await wrapper.find('button.form-action--primary').trigger('click')
+    await submitButton(wrapper).trigger('click')
     await flushPromises()
     expect(mocks.createStorageRepository).toHaveBeenCalledWith(expect.objectContaining({
       bind_node_type: 'proxy',
@@ -182,12 +191,12 @@ describe('AddNasRepository Proxy decision', () => {
     expect(wrapper.find('.add-nas-direct-warning').text()).toContain(en.addNasRepo.directAccessRisk)
     expect(previewValue(wrapper, en.addNasRepo.fieldSourceProxyNode)).toBe(en.addNasRepo.notBoundProxy)
     expect(previewValue(wrapper, en.repositoriesPage.fieldAccessPath)).toBe(en.addNasRepo.accessPathDirect)
-    expect(wrapper.find('.form-action--primary').text()).toContain('Save configuration')
+    expect(submitButton(wrapper).text()).toContain('Save configuration')
     expect(wrapper.findAllComponents(ElFormItem).some(
       component => component.props('label') === en.repositoriesPage.fieldRepositoryServerHost,
     )).toBe(false)
 
-    await wrapper.find('button.form-action--primary').trigger('click')
+    await submitButton(wrapper).trigger('click')
     await flushPromises()
 
     expect(mocks.createStorageRepository).toHaveBeenCalledOnce()


### PR DESCRIPTION
## Summary
- remove deployment-owned knowledge-source model references without unused bindings
- cover create and patch request sanitization without mutating the source policy
- make NAS Proxy decision tests target the standardized primary button semantics

## Validation
- ESLint: 0 errors
- focused frontend tests: 9/9 passed
- full frontend suite: 649/649 passed
- production build passed
- git diff --check passed