### PR TITLE
fix(deploy): bootstrap enabled platform gateways

### DIFF
--- a/.github/workflows/deploy_target.yml
+++ b/.github/workflows/deploy_target.yml
@@ -621,6 +621,26 @@ jobs:
             "$DEPLOY_SSH_USER@$DEPLOY_SSH_HOST" \
             'curl -kfsS https://127.0.0.1:11442/en/ >/dev/null && curl -kfsS https://127.0.0.1:11443/health/ready >/dev/null && curl -kfsS https://127.0.0.1:11444/ >/dev/null && curl -kfsS https://127.0.0.1:11445/ >/dev/null'
 
+      - name: Ensure Platform Gateway
+        if: ${{ inputs.platform_gateway_auto_deploy }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          ssh -i ~/.ssh/hyperfilelens_deploy \
+            -o BatchMode=yes \
+            -o StrictHostKeyChecking=yes \
+            -o ConnectTimeout=20 \
+            -o ServerAliveInterval=30 \
+            -o ServerAliveCountMax=20 \
+            -o TCPKeepAlive=yes \
+            -p "$DEPLOY_SSH_PORT" \
+            "$DEPLOY_SSH_USER@$DEPLOY_SSH_HOST" \
+            'if /opt/hyperfilelens/install.sh platform-gateway verify --required --timeout 0; then
+               echo "Installer-managed Platform Gateway is already online; preserving its independent lifecycle."
+             else
+               /opt/hyperfilelens/install.sh platform-gateway ensure
+             fi'
+
       - name: Verify Platform Gateway Readiness
         if: ${{ inputs.platform_gateway_auto_deploy }}
         shell: bash

--- a/deploy/installer/install.sh
+++ b/deploy/installer/install.sh
@@ -2927,6 +2927,10 @@ check_local_platform_gateway_continuity() {
 	if ! platform_gateway_auto_deploy_enabled; then
 		return 0
 	fi
+	if [[ ! -f "${LOCAL_PLATFORM_AGENT_DATA_DIR}/agent.env" ]]; then
+		skip "Installer-managed platform Gateway is not installed; bootstrap follows the control-plane upgrade"
+		return 0
+	fi
 	# A control-plane release must not mutate independently running Gateway,
 	# Agent, or LensNode workloads. Wait only for their existing control channels
 	# to recover; their upgrade remains a separate lifecycle operation.
@@ -2975,7 +2979,7 @@ local_platform_gateway_readiness_once() {
 		LOCAL_PLATFORM_GATEWAY_READINESS_REASON="active HFL API color is unavailable"
 		return 1
 	}
-	query="from apps.lens_bridge.models import LensGatewayLink; from apps.lens_bridge.services.gateway_readiness import gateway_runtime_state; link = LensGatewayLink.objects.select_related('gateway').filter(gateway_id=${node_id}, scope='platform').first(); state = gateway_runtime_state(link); raise SystemExit(0 if link is not None and state['hfl_usable'] and state['copilot_eligible'] else 1)"
+	query="from apps.lens_bridge.models import LensGatewayLink; from apps.lens_bridge.services.gateway_readiness import gateway_runtime_state; from apps.lens_bridge.services.provisioning import sync_gateway_lensnode_status; link = LensGatewayLink.objects.select_related('gateway').filter(gateway_id=${node_id}, scope='platform').first(); link = sync_gateway_lensnode_status(link) if link is not None else None; state = gateway_runtime_state(link); raise SystemExit(0 if link is not None and state['hfl_usable'] and state['copilot_eligible'] else 1)"
 	if ! compose_in_root exec -T "${api_service}" python manage.py shell -c "${query}" \
 		>/dev/null 2>&1; then
 		LOCAL_PLATFORM_GATEWAY_READINESS_REASON="managed platform Gateway link, Agent WebSocket, or LensNode sidecar is not online and usable"

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -1006,10 +1006,24 @@ grep -F 'hfl-sentry-sitecustomize.py' \
 	"${ROOT}/deploy/installer/sourcelens/docker-compose.template.yml" >/dev/null
 grep -F './tools/quality/test-payload-tree-hash.sh' "${workflow}" >/dev/null
 grep -F 'Verify Internal Health' "${ROOT}/.github/workflows/deploy_target.yml" >/dev/null
+grep -F 'Ensure Platform Gateway' \
+	"${ROOT}/.github/workflows/deploy_target.yml" >/dev/null
+grep -F 'platform-gateway ensure' \
+	"${ROOT}/.github/workflows/deploy_target.yml" >/dev/null
+grep -F 'platform-gateway verify --required --timeout 0' \
+	"${ROOT}/.github/workflows/deploy_target.yml" >/dev/null
 grep -F 'Verify Platform Gateway Readiness' \
 	"${ROOT}/.github/workflows/deploy_target.yml" >/dev/null
 grep -F 'platform-gateway verify --required --timeout 180' \
 	"${ROOT}/.github/workflows/deploy_target.yml" >/dev/null
+platform_gateway_ensure_line="$(grep -nF 'platform-gateway ensure' \
+	"${ROOT}/.github/workflows/deploy_target.yml" | head -1 | cut -d: -f1)"
+platform_gateway_verify_line="$(grep -nF 'platform-gateway verify --required --timeout 180' \
+	"${ROOT}/.github/workflows/deploy_target.yml" | head -1 | cut -d: -f1)"
+[[ "${platform_gateway_ensure_line}" -lt "${platform_gateway_verify_line}" ]] || {
+	printf 'ERROR: deployment must ensure the Platform Gateway before readiness verification\n' >&2
+	exit 1
+}
 grep -F 'https://127.0.0.1:11443/health/ready' \
 	"${ROOT}/.github/workflows/deploy_target.yml" >/dev/null
 grep -F 'https://127.0.0.1:11442/en/' \

--- a/tools/quality/test-platform-gateway-auto-deploy.sh
+++ b/tools/quality/test-platform-gateway-auto-deploy.sh
@@ -76,6 +76,7 @@ AGENT_ACTIVE=1
 READINESS_OK=1
 LOCAL_GATEWAY_IS_DEFAULT=0
 READINESS_QUERY=""
+READINESS_WAIT_CALLS=0
 read_env_value() {
 	case "$1" in
 	HFL_PLATFORM_GATEWAY_AUTO_DEPLOY) printf '%s' "${AUTO_DEPLOY}" ;;
@@ -98,6 +99,7 @@ systemctl() {
 converge_local_platform_gateway_lensnode() { :; }
 wait_for_local_platform_gateway_readiness() {
 	[[ "$1" == "180" ]]
+	READINESS_WAIT_CALLS=$((READINESS_WAIT_CALLS + 1))
 	LOCAL_PLATFORM_GATEWAY_READINESS_REASON=""
 	if [[ "${READINESS_OK}" == "1" ]]; then
 		return 0
@@ -123,6 +125,14 @@ ENROLLMENT_ORG=__platform_lens__
 export TEST_DESIRED_VERSION=main-1111111
 printf '%s\n' "${TEST_DESIRED_VERSION}" >"${ROOT}/VERSION"
 
+# Enabling auto-deploy on an existing control plane must not spend the upgrade
+# recovery window waiting for a Gateway that has never been installed.
+AUTO_DEPLOY=true
+READINESS_WAIT_CALLS=0
+check_local_platform_gateway_continuity
+[[ "${READINESS_WAIT_CALLS}" == "0" ]]
+
+AUTO_DEPLOY=false
 ensure_local_platform_gateway
 [[ ! -e "${marker}" ]]
 
@@ -246,6 +256,7 @@ converge_local_platform_gateway_lensnode
 source <(sed -n '/^local_platform_gateway_readiness_once()/,/^local_platform_gateway_installed_agent_version()/p' "${installer}" | sed '$d')
 wait_for_local_platform_gateway_readiness 0
 [[ "${READINESS_QUERY}" == *"gateway_id=99, scope='platform'"* ]]
+[[ "${READINESS_QUERY}" == *"sync_gateway_lensnode_status(link)"* ]]
 if [[ "${READINESS_QUERY}" == *"is_platform_default=True"* ]]; then
 	printf 'ERROR: local Gateway readiness was coupled to platform default selection\n' >&2
 	exit 1


### PR DESCRIPTION
## Summary
- bootstrap a missing installer-managed Platform Gateway when auto-deploy is enabled
- preserve healthy existing Gateway workloads during control-plane deployments
- refresh SourceLens LensNode state inside the readiness loop
- extend release and Gateway automation contract coverage

## Validation
- `./tools/quality/test-platform-gateway-auto-deploy.sh`
- `./tools/quality/check-release-contracts.sh`
- `bash -n deploy/installer/install.sh tools/quality/test-platform-gateway-auto-deploy.sh tools/quality/check-release-contracts.sh`
- workflow YAML parse
- `git diff --check`