### PR TITLE
fix(frontend): unwrap installer metadata API envelope

### DIFF
--- a/src/frontend/src/lib/nodeApi.test.ts
+++ b/src/frontend/src/lib/nodeApi.test.ts
@@ -57,6 +57,19 @@ function decodePowerShellCommand(command: string): string {
 }
 
 describe('Minimal installer metadata', () => {
+  it('accepts the standard API envelope used by local and production consoles', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        code: 0,
+        message: 'success',
+        data: installerManifest,
+      }),
+    }))
+
+    await expect(fetchMinimalInstallerManifest()).resolves.toEqual(installerManifest)
+  })
+
   it('rejects malformed artifact metadata before issuing a command', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
       ok: true,

--- a/src/frontend/src/lib/nodeApi.ts
+++ b/src/frontend/src/lib/nodeApi.ts
@@ -318,7 +318,8 @@ export async function fetchMinimalInstallerManifest(
   if (!response.ok) {
     throw new Error('Minimal installer metadata is unavailable')
   }
-  const payload = await response.json() as MinimalInstallerManifest
+  // Public fetch bypasses api(); still peel the standard { code, data } envelope.
+  const payload = unwrapApiPayload<MinimalInstallerManifest>(await response.json())
   const expected = [
     'linux-amd64',
     'linux-arm64',


### PR DESCRIPTION
## Summary
- Peel the standard `{ code, data }` envelope in `fetchMinimalInstallerManifest` so local/production consoles can build install commands again.
- Add a regression test covering the enveloped installer-metadata response.

## Test plan
- [x] `vitest` `src/lib/nodeApi.test.ts` (12 passed)
- [ ] Open Add Source Host on a local console and confirm the Linux install command renders
- [ ] Confirm Gateway / Platform Gateway install command generation still works


Made with [Cursor](https://cursor.com)