### PR TITLE
fix(frontend): restore short bootstrap install one-liner

### DIFF
--- a/src/frontend/src/lib/nodeApi.test.ts
+++ b/src/frontend/src/lib/nodeApi.test.ts
@@ -1,6 +1,5 @@
 // @vitest-environment jsdom
 
-import { Buffer } from 'node:buffer'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { api } from './api'
 import {
@@ -44,18 +43,6 @@ const installerManifest = {
   },
 }
 
-function stubInstallerManifest() {
-  vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
-    ok: true,
-    json: async () => installerManifest,
-  }))
-}
-
-function decodePowerShellCommand(command: string): string {
-  const encoded = command.split(' ').at(-1) ?? ''
-  return Buffer.from(encoded, 'base64').toString('utf16le')
-}
-
 describe('Minimal installer metadata', () => {
   it('accepts the standard API envelope used by local and production consoles', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
@@ -93,8 +80,7 @@ describe('Minimal installer metadata', () => {
 })
 
 describe('Data Gateway enrollment', () => {
-  it('uses strict TLS for a tenant Gateway when required by the backend', async () => {
-    stubInstallerManifest()
+  it('uses a short bootstrap one-liner with strict TLS for tenant Gateways', async () => {
     vi.stubGlobal('window', {
       location: { origin: 'https://hyperfilelens.com' },
     })
@@ -109,14 +95,14 @@ describe('Data Gateway enrollment', () => {
     const result = await issueGatewayEnrollmentInstall({ orgKey: 'tenant-a' })
 
     expect(result.command).toContain("curl --proto '=https' --tlsv1.2")
-    expect(result.command).toContain("base='https://hyperfilelens.com'")
-    expect(result.command).toContain('"$base/media/enroll-bootstrap/$file"')
+    expect(result.command).toContain('/api/v1/node/enrollment/bootstrap-gateway?')
+    expect(result.command).toContain('sudo bash "$tmp"')
     expect(result.command).not.toContain('curl -k')
+    expect(result.command).not.toContain('installer.tar.gz')
     expect(result.tlsVerify).toBe(true)
   })
 
   it('uses the tenant API base returned by the Admin Console API', async () => {
-    stubInstallerManifest()
     vi.stubGlobal('window', {
       location: { origin: 'https://console.example.com:11444' },
     })
@@ -133,9 +119,8 @@ describe('Data Gateway enrollment', () => {
     const result = await issuePlatformGatewayEnrollmentInstall()
 
     expect(result.command).toContain("curl --proto '=https' --tlsv1.2")
-    expect(result.command).toContain("base='https://console.example.com:11443'")
-    expect(result.command).toContain('"$base/media/enroll-bootstrap/$file"')
-    expect(result.command).toContain("HFL_API_BASE='https://console.example.com:11443'")
+    expect(result.command).toContain('api_base=https%3A%2F%2Fconsole.example.com%3A11443')
+    expect(result.command).toContain('/api/v1/node/enrollment/bootstrap-gateway?')
     expect(result.command).not.toContain('curl -k')
     expect(result.tlsVerify).toBe(true)
     expect(result.expiresAt).toBe('2026-07-28T06:00:00Z')
@@ -150,7 +135,6 @@ describe('Data Gateway enrollment', () => {
   })
 
   it('keeps the explicit insecure mode for self-hosted deployments', async () => {
-    stubInstallerManifest()
     vi.mocked(api).mockResolvedValue({
       token: 'platform-token',
       token_id: 17,
@@ -165,11 +149,11 @@ describe('Data Gateway enrollment', () => {
     expect(result.command).toContain('TLS certificate verification is disabled')
     expect(result.command).toContain('curl -k --fail --show-error --location')
     expect(result.command).toContain('--location --progress-bar')
+    expect(result.command).toContain('sudo bash "$tmp"')
     expect(result.tlsVerify).toBe(false)
   })
 
   it('rejects an incomplete response instead of falling back to the Admin origin', async () => {
-    stubInstallerManifest()
     vi.stubGlobal('window', {
       location: { origin: 'https://console.example.com:11444' },
     })
@@ -177,6 +161,8 @@ describe('Data Gateway enrollment', () => {
       token: 'platform-token',
       token_id: 17,
       org_key: '__platform_lens__',
+      gateway_scope: 'platform',
+      tls_verify: true,
     })
 
     await expect(issuePlatformGatewayEnrollmentInstall()).rejects.toThrow(
@@ -204,15 +190,15 @@ describe('Data Gateway enrollment', () => {
       apiBase: 'https://console.example.com',
       os: 'windows',
       tlsVerify: true,
-      manifest: installerManifest,
     })
 
-    const script = decodePowerShellCommand(command)
-    expect(script).not.toContain('ServerCertificateValidationCallback')
-    expect(script).not.toContain('Write-Warning')
+    expect(command).toContain('powershell -NoProfile -ExecutionPolicy Bypass -Command')
+    expect(command).toContain('/api/v1/node/enrollment/bootstrap?')
+    expect(command).not.toContain('ServerCertificateValidationCallback')
+    expect(command).not.toContain('Write-Warning')
   })
 
-  it('runs directly as root and only falls back to sudo for non-root users', () => {
+  it('keeps the Linux copy-paste command short and bootstrap-based', () => {
     const command = buildEnrollmentInstallCommand({
       org: 'tenant-a',
       role: 'agent',
@@ -220,22 +206,13 @@ describe('Data Gateway enrollment', () => {
       apiBase: 'https://console.example.com',
       os: 'linux',
       tlsVerify: true,
-      manifest: installerManifest,
     })
 
-    expect(command).toContain('if [ "$(id -u)" -eq 0 ]')
-    expect(command).toContain('elif command -v sudo >/dev/null 2>&1')
-    expect(command).toContain("echo 'Administrator privileges are required. Re-run as root or install sudo.'")
-  })
-
-  it('does not issue a token when installer metadata is unavailable', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 503 }))
-
-    await expect(issueGatewayEnrollmentInstall({ orgKey: 'tenant-a' })).rejects.toThrow(
-      'Minimal installer metadata is unavailable',
-    )
-
-    expect(vi.mocked(api)).not.toHaveBeenCalled()
+    expect(command).toContain('/api/v1/node/enrollment/bootstrap?')
+    expect(command).toContain('sudo bash "$tmp"')
+    expect(command).not.toContain('installer.tar.gz')
+    expect(command).not.toContain('sha256sum')
+    expect(command.split('\n').length).toBeLessThanOrEqual(6)
   })
 
   it('retains the explicit Windows bypass for self-hosted deployments', () => {
@@ -246,12 +223,11 @@ describe('Data Gateway enrollment', () => {
       apiBase: 'https://console.example.com',
       os: 'windows',
       tlsVerify: false,
-      manifest: installerManifest,
     })
 
-    const script = decodePowerShellCommand(command)
-    expect(script).toContain('ServerCertificateValidationCallback')
-    expect(script).toContain('Write-Warning')
+    expect(command).toContain('ServerCertificateValidationCallback')
+    expect(command).toContain('Write-Warning')
+    expect(command).toContain('/api/v1/node/enrollment/bootstrap?')
   })
 })
 

--- a/src/frontend/src/lib/nodeApi.ts
+++ b/src/frontend/src/lib/nodeApi.ts
@@ -396,107 +396,46 @@ function psSingleQuoted(value: string): string {
   return `'${value.replace(/'/g, "''")}'`
 }
 
-function shellSingleQuoted(value: string): string {
-  return `'${value.replace(/'/g, `'"'"'`)}'`
-}
-
-function controlPlaneWssURL(apiBase: string): string {
-  const url = new URL(apiBase)
-  url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:'
-  url.pathname = '/ws/node/agent/'
-  url.search = ''
-  url.hash = ''
-  return url.toString()
-}
-
-function powershellEncodedCommand(script: string): string {
-  const bytes = new Uint8Array(script.length * 2)
-  for (let i = 0; i < script.length; i += 1) {
-    const code = script.charCodeAt(i)
-    bytes[i * 2] = code & 0xff
-    bytes[i * 2 + 1] = code >> 8
-  }
-  let binary = ''
-  for (const byte of bytes) binary += String.fromCharCode(byte)
-  return `powershell -NoProfile -ExecutionPolicy Bypass -EncodedCommand ${btoa(binary)}`
-}
-
 /**
- * Windows one-liner: pure PowerShell download + run (no curl).
- * Avoids $variables so pasting works from elevated CMD or PowerShell.
+ * Windows short command: download the rendered bootstrap stub, then run it.
+ * Arch/checksum/download of the slim installer stays inside the bootstrap script.
  */
-function buildWindowsEnrollmentInstallCommand(params: {
-  apiBase: string
-  org: string
-  role: NodeRole
-  token: string
-  tlsVerify: boolean
-  artifact: MinimalInstallerArtifact
-  operation: 'install' | 'gateway-install'
-}): string {
-  const archiveUrl = `${params.apiBase.replace(/\/$/, '')}/media/enroll-bootstrap/${params.artifact.filename}`
+function buildWindowsEnrollmentInstallCommand(url: string, tlsVerify: boolean): string {
+  const bootstrapPath =
+    "[System.IO.Path]::Combine([System.IO.Path]::GetTempPath(),'hfl-bootstrap.ps1')"
   const psBody = [
     '[Net.ServicePointManager]::SecurityProtocol=[Net.SecurityProtocolType]::Tls12',
-    ...(params.tlsVerify
+    ...(tlsVerify
       ? []
       : [
           "Write-Warning 'TLS certificate verification is disabled. Use only on a trusted private network.'",
           '[Net.ServicePointManager]::ServerCertificateValidationCallback={[bool]1}',
         ]),
-    '$work=Join-Path ([System.IO.Path]::GetTempPath()) ("hfl-installer-"+[guid]::NewGuid().ToString("n"))',
-    'New-Item -ItemType Directory -Path $work -Force|Out-Null',
-    'try {',
-    '$archive=Join-Path $work "installer.zip"',
-    `(New-Object Net.WebClient).DownloadFile(${psSingleQuoted(archiveUrl)},$archive)`,
-    `if((Get-FileHash -Algorithm SHA256 $archive).Hash.ToLower() -ne ${psSingleQuoted(params.artifact.sha256.toLowerCase())}){throw 'Minimal installer checksum verification failed'}`,
-    'Expand-Archive -LiteralPath $archive -DestinationPath $work -Force',
-    `$env:HFL_ORG_KEY=${psSingleQuoted(params.org)}`,
-    `$env:HFL_NODE_ROLE=${psSingleQuoted(params.role)}`,
-    `$env:HFL_NODE_TOKEN=${psSingleQuoted(params.token)}`,
-    `$env:HFL_API_BASE=${psSingleQuoted(params.apiBase)}`,
-    `$env:HFL_WSS_URL=${psSingleQuoted(controlPlaneWssURL(params.apiBase))}`,
-    `$env:HFL_INSECURE_TLS=${psSingleQuoted(params.tlsVerify ? '0' : '1')}`,
-    `& (Join-Path $work 'hfl-enroll.exe') ${params.operation}`,
-    'if($LASTEXITCODE -ne 0){exit $LASTEXITCODE}',
-    '} finally { Remove-Item -LiteralPath $work -Recurse -Force -ErrorAction SilentlyContinue }',
+    `(New-Object Net.WebClient).DownloadFile(${psSingleQuoted(url)},${bootstrapPath})`,
+    `& (${bootstrapPath})`,
   ].join(';')
-  return powershellEncodedCommand(psBody)
+  return `powershell -NoProfile -ExecutionPolicy Bypass -Command "${psBody}"`
 }
 
-function buildPosixEnrollmentInstallCommand(params: {
-  apiBase: string
-  org: string
-  role: NodeRole
-  token: string
-  tlsVerify: boolean
-  goos: 'linux' | 'darwin'
-  artifacts: Record<string, MinimalInstallerArtifact>
-  operation: 'install' | 'gateway-install'
-  gatewayScope?: 'public' | 'private'
-}): string {
-  const amd64 = params.artifacts[`${params.goos}-amd64`]
-  const arm64 = params.artifacts[`${params.goos}-arm64`]
-  if (!amd64 || !arm64) throw new Error('Minimal installer metadata is incomplete')
-  const tlsOptions = params.tlsVerify
+/**
+ * POSIX short command: curl the rendered bootstrap stub, then sudo bash.
+ * The bootstrap script downloads one slim enroll helper and runs install.
+ */
+function buildPosixEnrollmentInstallCommand(
+  url: string,
+  bootstrapName: string,
+  tlsVerify: boolean,
+): string {
+  const tlsOptions = tlsVerify
     ? "--proto '=https' --tlsv1.2"
     : '-k'
-  const warning = params.tlsVerify
+  const warning = tlsVerify
     ? ''
     : "echo 'WARNING: TLS certificate verification is disabled. Use only on a trusted private network.' >&2\n"
-  const base = params.apiBase.replace(/\/$/, '')
-  const env = [
-    `HFL_ORG_KEY=${shellSingleQuoted(params.org)}`,
-    `HFL_NODE_ROLE=${shellSingleQuoted(params.role)}`,
-    `HFL_NODE_TOKEN=${shellSingleQuoted(params.token)}`,
-    `HFL_API_BASE=${shellSingleQuoted(params.apiBase)}`,
-    `HFL_WSS_URL=${shellSingleQuoted(controlPlaneWssURL(params.apiBase))}`,
-    `HFL_INSECURE_TLS=${params.tlsVerify ? '0' : '1'}`,
-    ...(params.gatewayScope ? [`HFL_GATEWAY_SCOPE=${params.gatewayScope}`] : []),
-  ].join(' ')
-  return `${warning}work="$(mktemp -d /tmp/hfl-installer.XXXXXX)" && (\n  trap 'rm -rf "$work"' EXIT\n  base=${shellSingleQuoted(base)}\n  case "$(uname -m)" in\n    x86_64|amd64) file=${shellSingleQuoted(amd64.filename)}; expected=${shellSingleQuoted(amd64.sha256)} ;;\n    arm64|aarch64) file=${shellSingleQuoted(arm64.filename)}; expected=${shellSingleQuoted(arm64.sha256)} ;;\n    *) echo 'Unsupported CPU architecture.' >&2; exit 4 ;;\n  esac\n  curl ${tlsOptions} --fail --show-error --location --progress-bar "$base/media/enroll-bootstrap/$file" -o "$work/installer.tar.gz"\n  if command -v sha256sum >/dev/null 2>&1; then actual="$(sha256sum "$work/installer.tar.gz" | awk '{print $1}')"; else actual="$(shasum -a 256 "$work/installer.tar.gz" | awk '{print $1}')"; fi\n  [ "$actual" = "$expected" ] || { echo 'Minimal installer checksum verification failed.' >&2; exit 3; }\n  tar -xzf "$work/installer.tar.gz" -C "$work"\n  if [ "$(id -u)" -eq 0 ]; then\n    env ${env} "$work/hfl-enroll" ${params.operation}\n  elif command -v sudo >/dev/null 2>&1; then\n    sudo env ${env} "$work/hfl-enroll" ${params.operation}\n  else\n    echo 'Administrator privileges are required. Re-run as root or install sudo.' >&2\n    exit 1\n  fi\n)`
+  return `${warning}tmp="$(mktemp /tmp/${bootstrapName}.XXXXXX)" && (\n  trap 'rm -f "$tmp"' EXIT\n  curl ${tlsOptions} --fail --show-error --location --progress-bar '${url}' -o "$tmp"\n  sudo bash "$tmp"\n)`
 }
 
-/** One-liner for target host (curl pipe / download + run). Shown on deploy pages only. */
+/** Short copy-paste command for the target host. Shown on deploy pages only. */
 export function buildEnrollmentInstallCommand(params: {
   org: string
   role: NodeRole
@@ -504,54 +443,28 @@ export function buildEnrollmentInstallCommand(params: {
   apiBase?: string
   os: EnrollmentOs
   tlsVerify?: boolean
-  manifest: MinimalInstallerManifest
 }): string {
+  const url = buildEnrollmentDownloadUrl({ ...params, os: params.os })
   const tlsVerify = params.tlsVerify !== false
   if (params.os === 'windows') {
-    const artifact = params.manifest.artifacts['windows-amd64']
-    if (!artifact) throw new Error('Windows minimal installer metadata is unavailable')
-    return buildWindowsEnrollmentInstallCommand({
-      apiBase: params.apiBase ?? publicApiBase(),
-      org: params.org,
-      role: params.role,
-      token: params.token,
-      tlsVerify,
-      artifact,
-      operation: 'install',
-    })
+    return buildWindowsEnrollmentInstallCommand(url, tlsVerify)
   }
-  return buildPosixEnrollmentInstallCommand({
-    apiBase: params.apiBase ?? publicApiBase(),
-    org: params.org,
-    role: params.role,
-    token: params.token,
-    tlsVerify,
-    goos: params.os === 'macos' ? 'darwin' : 'linux',
-    artifacts: params.manifest.artifacts,
-    operation: 'install',
-  })
+  return buildPosixEnrollmentInstallCommand(url, 'hfl-agent-bootstrap', tlsVerify)
 }
 
-/** One-liner for Data Gateway host (Linux): installs agent + LensNode sidecar. */
+/** Short copy-paste command for Data Gateway hosts (Linux). */
 export function buildGatewayEnrollmentInstallCommand(params: {
   org: string
   token: string
   apiBase?: string
   tlsVerify?: boolean
-  manifest: MinimalInstallerManifest
-  gatewayScope: 'public' | 'private'
 }): string {
-  return buildPosixEnrollmentInstallCommand({
-    apiBase: params.apiBase ?? publicApiBase(),
-    org: params.org,
-    role: 'gateway',
-    token: params.token,
-    tlsVerify: params.tlsVerify !== false,
-    goos: 'linux',
-    artifacts: params.manifest.artifacts,
-    operation: 'gateway-install',
-    gatewayScope: params.gatewayScope,
-  })
+  const url = buildGatewayEnrollmentDownloadUrl(params)
+  return buildPosixEnrollmentInstallCommand(
+    url,
+    'hfl-gateway-bootstrap',
+    params.tlsVerify !== false,
+  )
 }
 
 /** Create gateway token + build copy-paste install command. */
@@ -563,24 +476,15 @@ export async function issueGatewayEnrollmentInstall(params: {
   if (!org) {
     throw new Error('Missing organization key')
   }
-  const manifest = await fetchMinimalInstallerManifest()
   const row = await createNodeToken({
     role: 'gateway',
     note: params.note ?? 'deploy:gateway',
   })
-  let command: string
-  try {
-    command = buildGatewayEnrollmentInstallCommand({
-      org,
-      token: row.token,
-      tlsVerify: row.tls_verify,
-      manifest,
-      gatewayScope: 'private',
-    })
-  } catch (error) {
-    await revokeEnrollmentToken(row.id).catch(() => undefined)
-    throw error
-  }
+  const command = buildGatewayEnrollmentInstallCommand({
+    org,
+    token: row.token,
+    tlsVerify: row.tls_verify,
+  })
   return {
     token: row.token,
     tokenId: row.id,
@@ -599,7 +503,6 @@ export async function issuePlatformGatewayEnrollmentInstall(params?: {
   tlsVerify: boolean
   expiresAt: string | null
 }> {
-  const manifest = await fetchMinimalInstallerManifest()
   const raw = await api<unknown>('/api/v1/platform-ops/lens/gateways/enrollment', {
     method: 'POST',
     body: JSON.stringify({
@@ -631,8 +534,6 @@ export async function issuePlatformGatewayEnrollmentInstall(params?: {
         token: payload.token,
         apiBase: payload.api_base,
         tlsVerify: payload.tls_verify,
-        manifest,
-        gatewayScope: 'public',
       }),
       tlsVerify: payload.tls_verify,
       expiresAt: payload.expires_at ?? null,
@@ -671,22 +572,14 @@ export async function issueEnrollmentInstall(params: {
   if (!org) {
     throw new Error('Missing organization key')
   }
-  const manifest = await fetchMinimalInstallerManifest()
   const row = await createNodeToken({ role: params.role, note: params.note })
-  let command: string
-  try {
-    command = buildEnrollmentInstallCommand({
-      org,
-      role: params.role,
-      token: row.token,
-      os: params.os,
-      tlsVerify: row.tls_verify,
-      manifest,
-    })
-  } catch (error) {
-    await revokeEnrollmentToken(row.id).catch(() => undefined)
-    throw error
-  }
+  const command = buildEnrollmentInstallCommand({
+    org,
+    role: params.role,
+    token: row.token,
+    os: params.os,
+    tlsVerify: row.tls_verify,
+  })
   return {
     token: row.token,
     tokenId: row.id,


### PR DESCRIPTION
## Summary
- Restore the short copy-paste install command (`curl` bootstrap stub + `sudo bash`) agreed in the installer experience plan.
- Move arch/checksum/slim-package complexity back out of the clipboard text; bootstrap scripts already download one enroll helper and run install.
- Update frontend regression tests for the short command shape.

## Test plan
- [x] `vitest` `nodeApi.test.ts` + `NodeLifecycleCopy.test.ts` (15 passed)
- [ ] Refresh Add Source Host and confirm the Linux command is a short bootstrap one-liner
- [ ] Run the command on a host and confirm install still proceeds through preflight/register


Made with [Cursor](https://cursor.com)