### PR TITLE
fix: use a single curl install one-liner and unwrap session API data

### DIFF
--- a/src/agent/internal/enrollmentclient/enrollment_status.go
+++ b/src/agent/internal/enrollmentclient/enrollment_status.go
@@ -2,7 +2,6 @@ package enrollmentclient
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -62,12 +61,11 @@ func fetchNodeOnline(ctx context.Context, cfg *model.AgentConfig, nodeID string)
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return false, "", fmt.Errorf("node status HTTP %s: %s", resp.Status, strings.TrimSpace(string(raw)))
 	}
-	var payload struct {
-		Status   string `json:"status"`
-		Routable bool   `json:"routable"`
-	}
-	if err := json.Unmarshal(raw, &payload); err != nil {
+	data, err := decodeAPIData(raw)
+	if err != nil {
 		return false, "", err
 	}
-	return payload.Routable && payload.Status == "online", payload.Status, nil
+	status := strings.TrimSpace(stringField(data, "status"))
+	routable := boolField(data, "routable")
+	return routable && status == "online", status, nil
 }

--- a/src/agent/internal/enrollmentclient/installation_session.go
+++ b/src/agent/internal/enrollmentclient/installation_session.go
@@ -62,19 +62,17 @@ func OpenInstallationSession(
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return InstallationSession{}, fmt.Errorf("installation session HTTP %s: %s", resp.Status, strings.TrimSpace(string(raw)))
 	}
-	var payload struct {
-		InstallationSession string `json:"installation_session"`
-		GatewayScope        string `json:"gateway_scope"`
-	}
-	if err := json.Unmarshal(raw, &payload); err != nil {
+	data, err := decodeAPIData(raw)
+	if err != nil {
 		return InstallationSession{}, fmt.Errorf("installation session response: %w", err)
 	}
-	if strings.TrimSpace(payload.InstallationSession) == "" {
+	secret := strings.TrimSpace(stringField(data, "installation_session"))
+	if secret == "" {
 		return InstallationSession{}, fmt.Errorf("installation session response is incomplete")
 	}
 	return InstallationSession{
-		Secret:       strings.TrimSpace(payload.InstallationSession),
-		GatewayScope: strings.TrimSpace(payload.GatewayScope),
+		Secret:       secret,
+		GatewayScope: strings.TrimSpace(stringField(data, "gateway_scope")),
 	}, nil
 }
 

--- a/src/agent/internal/enrollmentclient/installation_session_test.go
+++ b/src/agent/internal/enrollmentclient/installation_session_test.go
@@ -1,0 +1,91 @@
+package enrollmentclient
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"hyperfilelens/agent/internal/model"
+)
+
+func TestOpenInstallationSessionAcceptsAPIEnvelope(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/api/v1/node/enrollment/session" {
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		if r.Header.Get("X-Org-Key") != "org-a" || r.Header.Get("X-Node-Token") != "token-a" {
+			t.Fatal("missing enrollment credentials")
+		}
+		var body map[string]string
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatal(err)
+		}
+		if body["role"] != "gateway" || body["installation_id"] != "hfli_host" {
+			t.Fatalf("body=%v", body)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"code":0,"message":"success","data":{"installation_session":"hfls_secret","gateway_scope":"private"}}`))
+	}))
+	defer server.Close()
+
+	session, err := OpenInstallationSession(context.Background(), &model.AgentConfig{
+		APIBaseURL: server.URL,
+		OrgKey:     "org-a",
+		NodeToken:  "token-a",
+		Role:       model.RoleGateway,
+	}, "hfli_host")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if session.Secret != "hfls_secret" || session.GatewayScope != "private" {
+		t.Fatalf("session=%+v", session)
+	}
+}
+
+func TestOpenInstallationSessionAcceptsUnwrappedPayload(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"installation_session":"hfls_direct","gateway_scope":""}`))
+	}))
+	defer server.Close()
+
+	session, err := OpenInstallationSession(context.Background(), &model.AgentConfig{
+		APIBaseURL: server.URL,
+		OrgKey:     "org-a",
+		NodeToken:  "token-a",
+		Role:       model.RoleAgent,
+	}, "hfli_host")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if session.Secret != "hfls_direct" {
+		t.Fatalf("session=%+v", session)
+	}
+}
+
+func TestFetchNodeOnlineAcceptsAPIEnvelope(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/node/enrollment/node-status" {
+			t.Fatalf("path=%s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"code":0,"message":"success","data":{"node_id":42,"status":"online","routable":true}}`))
+	}))
+	defer server.Close()
+
+	online, status, err := fetchNodeOnline(context.Background(), &model.AgentConfig{
+		APIBaseURL: server.URL,
+		OrgKey:     "org-a",
+		NodeToken:  "cred-a",
+	}, "42")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !online || status != "online" {
+		t.Fatalf("online=%v status=%q", online, status)
+	}
+}

--- a/src/agent/internal/enrollmentclient/register.go
+++ b/src/agent/internal/enrollmentclient/register.go
@@ -200,13 +200,9 @@ func httpRegisterNode(
 		return RegistrationResult{}, fmt.Errorf("heartbeat HTTP %s: %s", resp.Status, strings.TrimSpace(string(raw)))
 	}
 
-	var parsed map[string]any
-	if err := json.Unmarshal(raw, &parsed); err != nil {
+	data, err := decodeAPIData(raw)
+	if err != nil {
 		return RegistrationResult{}, fmt.Errorf("heartbeat response: %w", err)
-	}
-	data := parsed
-	if nested, ok := parsed["data"].(map[string]any); ok {
-		data = nested
 	}
 	result := RegistrationResult{}
 	if credential, ok := data["node_credential"].(string); ok {

--- a/src/agent/internal/enrollmentclient/response.go
+++ b/src/agent/internal/enrollmentclient/response.go
@@ -1,0 +1,25 @@
+package enrollmentclient
+
+import "encoding/json"
+
+// decodeAPIData peels the standard console {code,message,data} envelope when present.
+func decodeAPIData(raw []byte) (map[string]any, error) {
+	var parsed map[string]any
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		return nil, err
+	}
+	if nested, ok := parsed["data"].(map[string]any); ok {
+		return nested, nil
+	}
+	return parsed, nil
+}
+
+func stringField(data map[string]any, key string) string {
+	value, _ := data[key].(string)
+	return value
+}
+
+func boolField(data map[string]any, key string) bool {
+	value, _ := data[key].(bool)
+	return value
+}

--- a/src/frontend/src/lib/nodeApi.test.ts
+++ b/src/frontend/src/lib/nodeApi.test.ts
@@ -96,9 +96,10 @@ describe('Data Gateway enrollment', () => {
 
     expect(result.command).toContain("curl --proto '=https' --tlsv1.2")
     expect(result.command).toContain('/api/v1/node/enrollment/bootstrap-gateway?')
-    expect(result.command).toContain('sudo bash "$tmp"')
+    expect(result.command).toContain('| sudo bash -s')
     expect(result.command).not.toContain('curl -k')
     expect(result.command).not.toContain('installer.tar.gz')
+    expect(result.command.split('\n')).toHaveLength(1)
     expect(result.tlsVerify).toBe(true)
   })
 
@@ -146,10 +147,10 @@ describe('Data Gateway enrollment', () => {
 
     const result = await issuePlatformGatewayEnrollmentInstall()
 
-    expect(result.command).toContain('TLS certificate verification is disabled')
-    expect(result.command).toContain('curl -k --fail --show-error --location')
-    expect(result.command).toContain('--location --progress-bar')
-    expect(result.command).toContain('sudo bash "$tmp"')
+    expect(result.command).toMatch(/^curl -k --fail --show-error --location --progress-bar '/)
+    expect(result.command).toContain('| sudo bash -s')
+    expect(result.command).not.toContain('WARNING:')
+    expect(result.command.split('\n')).toHaveLength(1)
     expect(result.tlsVerify).toBe(false)
   })
 
@@ -198,7 +199,7 @@ describe('Data Gateway enrollment', () => {
     expect(command).not.toContain('Write-Warning')
   })
 
-  it('keeps the Linux copy-paste command short and bootstrap-based', () => {
+  it('keeps the Linux copy-paste command as a single curl one-liner', () => {
     const command = buildEnrollmentInstallCommand({
       org: 'tenant-a',
       role: 'agent',
@@ -208,11 +209,13 @@ describe('Data Gateway enrollment', () => {
       tlsVerify: true,
     })
 
+    expect(command).toMatch(/^curl --proto '=https' --tlsv1\.2 --fail --show-error --location --progress-bar '/)
     expect(command).toContain('/api/v1/node/enrollment/bootstrap?')
-    expect(command).toContain('sudo bash "$tmp"')
+    expect(command).toContain('| sudo bash -s')
     expect(command).not.toContain('installer.tar.gz')
-    expect(command).not.toContain('sha256sum')
-    expect(command.split('\n').length).toBeLessThanOrEqual(6)
+    expect(command).not.toContain('mktemp')
+    expect(command).not.toContain('WARNING:')
+    expect(command.split('\n')).toHaveLength(1)
   })
 
   it('retains the explicit Windows bypass for self-hosted deployments', () => {

--- a/src/frontend/src/lib/nodeApi.ts
+++ b/src/frontend/src/lib/nodeApi.ts
@@ -418,21 +418,14 @@ function buildWindowsEnrollmentInstallCommand(url: string, tlsVerify: boolean): 
 }
 
 /**
- * POSIX short command: curl the rendered bootstrap stub, then sudo bash.
+ * POSIX one-liner: curl the rendered bootstrap stub into sudo bash.
  * The bootstrap script downloads one slim enroll helper and runs install.
  */
-function buildPosixEnrollmentInstallCommand(
-  url: string,
-  bootstrapName: string,
-  tlsVerify: boolean,
-): string {
+function buildPosixEnrollmentInstallCommand(url: string, tlsVerify: boolean): string {
   const tlsOptions = tlsVerify
     ? "--proto '=https' --tlsv1.2"
     : '-k'
-  const warning = tlsVerify
-    ? ''
-    : "echo 'WARNING: TLS certificate verification is disabled. Use only on a trusted private network.' >&2\n"
-  return `${warning}tmp="$(mktemp /tmp/${bootstrapName}.XXXXXX)" && (\n  trap 'rm -f "$tmp"' EXIT\n  curl ${tlsOptions} --fail --show-error --location --progress-bar '${url}' -o "$tmp"\n  sudo bash "$tmp"\n)`
+  return `curl ${tlsOptions} --fail --show-error --location --progress-bar '${url}' | sudo bash -s`
 }
 
 /** Short copy-paste command for the target host. Shown on deploy pages only. */
@@ -449,7 +442,7 @@ export function buildEnrollmentInstallCommand(params: {
   if (params.os === 'windows') {
     return buildWindowsEnrollmentInstallCommand(url, tlsVerify)
   }
-  return buildPosixEnrollmentInstallCommand(url, 'hfl-agent-bootstrap', tlsVerify)
+  return buildPosixEnrollmentInstallCommand(url, tlsVerify)
 }
 
 /** Short copy-paste command for Data Gateway hosts (Linux). */
@@ -460,11 +453,7 @@ export function buildGatewayEnrollmentInstallCommand(params: {
   tlsVerify?: boolean
 }): string {
   const url = buildGatewayEnrollmentDownloadUrl(params)
-  return buildPosixEnrollmentInstallCommand(
-    url,
-    'hfl-gateway-bootstrap',
-    params.tlsVerify !== false,
-  )
+  return buildPosixEnrollmentInstallCommand(url, params.tlsVerify !== false)
 }
 
 /** Create gateway token + build copy-paste install command. */


### PR DESCRIPTION
## Summary
- Replace the multi-line clipboard install text with one command: `curl ... | sudo bash -s`.
- Peel the standard `{ code, data }` envelope in installation-session and node-status client parsing so enroll can start a session successfully.
- Keep unwrapped payload support for compatibility.

## Test plan
- [x] `go test ./internal/enrollmentclient/ ./internal/remote/`
- [x] `vitest` `src/lib/nodeApi.test.ts`
- [ ] Refresh Add Source Host / Gateway install and confirm a single `curl` line is shown
- [ ] Run the command on a local host and confirm installation session opens without `HFL-INSTALL-002`


Made with [Cursor](https://cursor.com)