### PR TITLE
fix: quiet install cwd noise and keep a single curl one-liner

### DIFF
--- a/deploy/bootstrap/agent-bootstrap-linux.sh
+++ b/deploy/bootstrap/agent-bootstrap-linux.sh
@@ -2,6 +2,10 @@
 # HyperFileLens Agent enrollment bootstrap (Linux). Rendered by GET /enrollment/bootstrap.
 set -euo pipefail
 
+# Avoid getcwd / job-working-directory noise when the caller cwd was removed
+# (common if the user ran the one-liner from a stale /opt/hyperfilelens-agent).
+cd / || cd /tmp || true
+
 export HFL_ORG_KEY="__HFL_ORG_KEY__"
 export HFL_NODE_ROLE="__HFL_NODE_ROLE__"
 export HFL_NODE_TOKEN="__HFL_NODE_TOKEN__"
@@ -19,7 +23,7 @@ hfl_fail() {
 }
 
 hfl_step() {
-	printf '[%s] [STEP ] %s\n' "$(hfl_now)" "$1"
+	printf '[%s] [....] %s\n' "$(hfl_now)" "$1"
 }
 
 hfl_ok() {

--- a/deploy/bootstrap/agent-bootstrap-macos.sh
+++ b/deploy/bootstrap/agent-bootstrap-macos.sh
@@ -2,6 +2,10 @@
 # HyperFileLens Agent enrollment bootstrap (macOS). Rendered by GET /enrollment/bootstrap.
 set -euo pipefail
 
+# Avoid getcwd / job-working-directory noise when the caller cwd was removed
+# (common if the user ran the one-liner from a stale /opt/hyperfilelens-agent).
+cd / || cd /tmp || true
+
 export HFL_ORG_KEY="__HFL_ORG_KEY__"
 export HFL_NODE_ROLE="__HFL_NODE_ROLE__"
 export HFL_NODE_TOKEN="__HFL_NODE_TOKEN__"
@@ -19,7 +23,7 @@ hfl_fail() {
 }
 
 hfl_step() {
-	printf '[%s] [STEP ] %s\n' "$(hfl_now)" "$1"
+	printf '[%s] [....] %s\n' "$(hfl_now)" "$1"
 }
 
 hfl_ok() {

--- a/deploy/bootstrap/agent-bootstrap-windows.ps1
+++ b/deploy/bootstrap/agent-bootstrap-windows.ps1
@@ -1,5 +1,7 @@
 # HyperFileLens Agent enrollment bootstrap (Windows). Rendered by GET /enrollment/bootstrap.
 $ErrorActionPreference = "Stop"
+# Keep a stable working directory if the caller launched from a removed install path.
+Set-Location -LiteralPath $env:SystemDrive\
 
 function Test-HflAdmin {
   $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
@@ -72,7 +74,7 @@ function Get-HflEnrollmentBinary {
   $skipCert = ($env:HFL_INSECURE_TLS -ne '0')
   $partial = "$OutFile.part"
   Remove-Item -Force -LiteralPath $partial -ErrorAction SilentlyContinue
-  Write-HflBootstrapLog "STEP " "Downloading HyperFileLens enrollment helper."
+  Write-HflBootstrapLog ".... " "Downloading HyperFileLens enrollment helper."
 
   if (Get-Command curl.exe -ErrorAction SilentlyContinue) {
     $curlArgs = @(

--- a/deploy/bootstrap/gateway-bootstrap-linux.sh
+++ b/deploy/bootstrap/gateway-bootstrap-linux.sh
@@ -3,6 +3,10 @@
 # Rendered by GET /enrollment/bootstrap-gateway — installs agent + SourceLens sidecar.
 set -euo pipefail
 
+# Avoid getcwd / job-working-directory noise when the caller cwd was removed
+# (common if the user ran the one-liner from a stale /opt/hyperfilelens-agent).
+cd / || cd /tmp || true
+
 export HFL_ORG_KEY="__HFL_ORG_KEY__"
 export HFL_NODE_ROLE="gateway"
 export HFL_NODE_TOKEN="__HFL_NODE_TOKEN__"
@@ -15,7 +19,7 @@ hfl_now() {
 }
 
 hfl_step() {
-	printf '[%s] [STEP ] %s\n' "$(hfl_now)" "$1"
+	printf '[%s] [....] %s\n' "$(hfl_now)" "$1"
 }
 
 hfl_ok() {

--- a/deploy/bootstrap/gateway-install-docker-ubuntu-amd64.sh
+++ b/deploy/bootstrap/gateway-install-docker-ubuntu-amd64.sh
@@ -17,7 +17,7 @@ hfl_now() {
 }
 
 hfl_step() {
-	printf '[%s] [STEP ] %s\n' "$(hfl_now)" "$1"
+	printf '[%s] [....] %s\n' "$(hfl_now)" "$1"
 }
 
 hfl_ok() {

--- a/deploy/bootstrap/gateway-install-lensnode-sidecar.sh
+++ b/deploy/bootstrap/gateway-install-lensnode-sidecar.sh
@@ -15,7 +15,7 @@ hfl_now() {
 }
 
 hfl_step() {
-	printf '[%s] [STEP ] %s\n' "$(hfl_now)" "$1"
+	printf '[%s] [....] %s\n' "$(hfl_now)" "$1"
 }
 
 hfl_ok() {

--- a/src/agent/cmd/enroll/main.go
+++ b/src/agent/cmd/enroll/main.go
@@ -31,6 +31,7 @@ func run() int {
 	defer stop()
 	switch os.Args[1] {
 	case "install":
+		stabilizeInstallWorkingDirectory()
 		opts := enroll.ParseInstallOptions(os.Args[2:])
 		if err := enroll.WithInstallLock(ctx, func() error {
 			return enroll.RunInstall(ctx, opts)
@@ -39,6 +40,7 @@ func run() int {
 			return 1
 		}
 	case "gateway-install":
+		stabilizeInstallWorkingDirectory()
 		opts := enroll.ParseInstallOptions(os.Args[2:])
 		if err := enroll.WithInstallLock(ctx, func() error {
 			return enroll.RunGatewayInstall(ctx, opts)
@@ -47,6 +49,7 @@ func run() int {
 			return 1
 		}
 	case "gateway-upgrade":
+		stabilizeInstallWorkingDirectory()
 		fromArchive := parseFromFlag(os.Args[2:])
 		if err := enroll.WithInstallLock(ctx, func() error {
 			return enroll.RunGatewayUpgrade(ctx, fromArchive)
@@ -55,6 +58,7 @@ func run() int {
 			return 1
 		}
 	case "gateway-uninstall":
+		stabilizeInstallWorkingDirectory()
 		purgeAll := !hasFlag(os.Args[2:], "--keep-data")
 		if err := enroll.WithInstallLock(ctx, func() error {
 			return enroll.RunGatewayUninstall(ctx, purgeAll)
@@ -63,6 +67,7 @@ func run() int {
 			return 1
 		}
 	case "register":
+		stabilizeInstallWorkingDirectory()
 		opts := enroll.ParseInstallOptions(os.Args[2:])
 		if err := enroll.WithInstallLock(ctx, func() error {
 			return enroll.RunRegister(ctx, opts)
@@ -114,6 +119,15 @@ Environment (set by bootstrap stub from console):
   HFL_ORG_KEY, HFL_NODE_ROLE, HFL_NODE_TOKEN, HFL_API_BASE, HFL_WSS_URL
   HFL_INSECURE_TLS       Default 1 (skip TLS verify for dev/self-signed)
 `)
+}
+
+// stabilizeInstallWorkingDirectory moves off a deleted install path so the shell
+// and child tools do not spam getcwd / job-working-directory errors.
+func stabilizeInstallWorkingDirectory() {
+	if err := os.Chdir("/"); err == nil {
+		return
+	}
+	_ = os.Chdir(os.TempDir())
 }
 
 func parseFromFlag(args []string) string {

--- a/src/frontend/src/lib/nodeApi.test.ts
+++ b/src/frontend/src/lib/nodeApi.test.ts
@@ -96,8 +96,9 @@ describe('Data Gateway enrollment', () => {
 
     expect(result.command).toContain("curl --proto '=https' --tlsv1.2")
     expect(result.command).toContain('/api/v1/node/enrollment/bootstrap-gateway?')
-    expect(result.command).toContain('| sudo bash -s')
+    expect(result.command).toContain("| sudo bash -c 'cd / || cd /tmp; exec bash -s'")
     expect(result.command).not.toContain('curl -k')
+    expect(result.command).not.toContain('--progress-bar')
     expect(result.command).not.toContain('installer.tar.gz')
     expect(result.command.split('\n')).toHaveLength(1)
     expect(result.tlsVerify).toBe(true)
@@ -147,8 +148,9 @@ describe('Data Gateway enrollment', () => {
 
     const result = await issuePlatformGatewayEnrollmentInstall()
 
-    expect(result.command).toMatch(/^curl -k --fail --show-error --location --progress-bar '/)
-    expect(result.command).toContain('| sudo bash -s')
+    expect(result.command).toMatch(/^curl -k --fail --show-error --location '/)
+    expect(result.command).toContain("| sudo bash -c 'cd / || cd /tmp; exec bash -s'")
+    expect(result.command).not.toContain('--progress-bar')
     expect(result.command).not.toContain('WARNING:')
     expect(result.command.split('\n')).toHaveLength(1)
     expect(result.tlsVerify).toBe(false)
@@ -209,9 +211,10 @@ describe('Data Gateway enrollment', () => {
       tlsVerify: true,
     })
 
-    expect(command).toMatch(/^curl --proto '=https' --tlsv1\.2 --fail --show-error --location --progress-bar '/)
+    expect(command).toMatch(/^curl --proto '=https' --tlsv1\.2 --fail --show-error --location '/)
     expect(command).toContain('/api/v1/node/enrollment/bootstrap?')
-    expect(command).toContain('| sudo bash -s')
+    expect(command).toContain("| sudo bash -c 'cd / || cd /tmp; exec bash -s'")
+    expect(command).not.toContain('--progress-bar')
     expect(command).not.toContain('installer.tar.gz')
     expect(command).not.toContain('mktemp')
     expect(command).not.toContain('WARNING:')

--- a/src/frontend/src/lib/nodeApi.ts
+++ b/src/frontend/src/lib/nodeApi.ts
@@ -420,12 +420,15 @@ function buildWindowsEnrollmentInstallCommand(url: string, tlsVerify: boolean): 
 /**
  * POSIX one-liner: curl the rendered bootstrap stub into sudo bash.
  * The bootstrap script downloads one slim enroll helper and runs install.
+ *
+ * --chdir avoids getcwd noise when the caller is sitting in a deleted install dir.
+ * No --progress-bar here: the bootstrap stub is tiny; real download progress comes later.
  */
 function buildPosixEnrollmentInstallCommand(url: string, tlsVerify: boolean): string {
   const tlsOptions = tlsVerify
     ? "--proto '=https' --tlsv1.2"
     : '-k'
-  return `curl ${tlsOptions} --fail --show-error --location --progress-bar '${url}' | sudo bash -s`
+  return `curl ${tlsOptions} --fail --show-error --location '${url}' | sudo bash -c 'cd / || cd /tmp; exec bash -s'`
 }
 
 /** Short copy-paste command for the target host. Shown on deploy pages only. */


### PR DESCRIPTION
## Summary
- Move bootstrap and enroll onto a stable working directory so installs started from a removed `/opt/hyperfilelens-agent` path no longer spam `getcwd` / `job-working-directory` errors.
- Align bootstrap step markers to `[....]` and keep the clipboard command as one `curl | sudo bash` line without a progress meter for the tiny bootstrap stub.

## Test plan
- [x] Frontend `nodeApi` tests pass
- [x] Agent enroll package builds
- [ ] Fresh Source Host / Proxy / Gateway install from `/` shows a clean banner and no getcwd noise
- [ ] Install started from a stale install directory still completes cleanly


Made with [Cursor](https://cursor.com)