### PR TITLE
https://github.com/HyperBDR/hyperfilelens/issues

### DIFF
--- a/src/frontend/src/pages/protection/BackupConfigCreateWizard.vue
+++ b/src/frontend/src/pages/protection/BackupConfigCreateWizard.vue
@@ -238,6 +238,7 @@ watch(
   flex-direction: column;
   gap: 0;
   min-height: 0;
+  padding: 20px;
 }
 
 .create-backup-loading-pane {

--- a/src/frontend/src/pages/protection/BackupCreateWizard.vue
+++ b/src/frontend/src/pages/protection/BackupCreateWizard.vue
@@ -6073,6 +6073,7 @@ function preserveShallowestPathOrder(paths: string[]) {
                     clearable
                     :placeholder="t('protection.backupsPage.phPolicyForDir')"
                     class="w-full"
+                    placement="bottom-start"
                     popper-class="create-policy-select-popper"
                     @visible-change="handleOptionSelectVisibleChange"
                   >
@@ -6082,7 +6083,7 @@ function preserveShallowestPathOrder(paths: string[]) {
                       :label="pol.name"
                       :value="pol.id"
                     >
-                      <HflPopover ref="optionPopoverRefs" trigger="hover" placement="right-start" :width="420" :persistent="false" popper-class="create-policy-option-popper">
+                      <HflPopover ref="optionPopoverRefs" trigger="hover" placement="bottom-start" :fallback-placements="['top-start', 'right-start']" :width="420" :persistent="false" popper-class="create-policy-option-popper">
                         <template #reference>
                           <div class="create-policy-option" @pointerdown.capture="hideOptionPopovers">
                             <div class="create-policy-option__head">
@@ -6156,6 +6157,7 @@ function preserveShallowestPathOrder(paths: string[]) {
                     :max-collapse-tags="1"
                     :placeholder="t('protection.backupsPage.phBatchFilters')"
                     class="w-full file-filter-multi-select"
+                    placement="bottom-start"
                     popper-class="create-policy-select-popper"
                     @change="closeBatchFilterSelect"
                     @visible-change="handleOptionSelectVisibleChange"
@@ -6166,7 +6168,7 @@ function preserveShallowestPathOrder(paths: string[]) {
                       :label="gf.name"
                       :value="gf.id"
                     >
-                      <HflPopover ref="optionPopoverRefs" trigger="hover" placement="right-start" :width="460" :persistent="false" popper-class="create-policy-option-popper">
+                      <HflPopover ref="optionPopoverRefs" trigger="hover" placement="bottom-start" :fallback-placements="['top-start', 'right-start']" :width="460" :persistent="false" popper-class="create-policy-option-popper">
                         <template #reference>
                           <div class="create-policy-option" @pointerdown.capture="hideOptionPopovers">
                             <div class="create-policy-option__head">
@@ -6356,6 +6358,7 @@ function preserveShallowestPathOrder(paths: string[]) {
                                 clearable
                                 :placeholder="t('protection.backupsPage.phPolicyForDir')"
                                 class="target-picker-grid__target"
+                                placement="bottom-start"
                                 popper-class="create-policy-select-popper"
                                 @update:model-value="setGroupPolicyId(group, String($event ?? ''))"
                                 @visible-change="handleConfigSelectVisibleChange"
@@ -6366,7 +6369,7 @@ function preserveShallowestPathOrder(paths: string[]) {
                                   :label="pol.name"
                                   :value="pol.id"
                                 >
-                                  <HflPopover ref="optionPopoverRefs" trigger="hover" placement="right-start" :width="420" :persistent="false" popper-class="create-policy-option-popper">
+                                  <HflPopover ref="optionPopoverRefs" trigger="hover" placement="bottom-start" :fallback-placements="['top-start', 'right-start']" :width="420" :persistent="false" popper-class="create-policy-option-popper">
                                     <template #reference>
                                       <div class="create-policy-option" @pointerdown.capture="hideOptionPopovers">
                                         <div class="create-policy-option__head">
@@ -6541,6 +6544,7 @@ function preserveShallowestPathOrder(paths: string[]) {
                                 clearable
                                 :placeholder="t('protection.backupsPage.phFilterForDir')"
                                 class="target-picker-grid__target"
+                                placement="bottom-start"
                                 popper-class="create-policy-select-popper"
                                 @update:model-value="(value) => setGroupFilterId(group, String(value || ''))"
                                 @visible-change="handleConfigSelectVisibleChange"
@@ -6551,7 +6555,7 @@ function preserveShallowestPathOrder(paths: string[]) {
                                   :label="gf.name"
                                   :value="gf.id"
                                 >
-                                  <HflPopover ref="optionPopoverRefs" trigger="hover" placement="right-start" :width="460" :persistent="false" popper-class="create-policy-option-popper">
+                                  <HflPopover ref="optionPopoverRefs" trigger="hover" placement="bottom-start" :fallback-placements="['top-start', 'right-start']" :width="460" :persistent="false" popper-class="create-policy-option-popper">
                                     <template #reference>
                                       <div class="create-policy-option" @pointerdown.capture="hideOptionPopovers">
                                         <div class="create-policy-option__head">
@@ -11618,15 +11622,29 @@ function preserveShallowestPathOrder(paths: string[]) {
   white-space: normal;
 }
 
+:global(.create-policy-select-popper) {
+  max-width: min(560px, calc(100vw - 32px));
+}
+
 :global(.create-policy-select-popper .el-select-dropdown__item) {
   height: auto;
   min-height: 44px;
   padding: 6px 10px;
   line-height: normal;
+  max-width: 100%;
+  overflow: hidden;
 }
 
 :global(.create-policy-select-popper .el-select-dropdown__item.selected) {
   font-weight: 500;
+}
+
+:global(.create-policy-select-popper .el-select-dropdown__empty) {
+  padding: 12px 10px;
+  font-size: 13px;
+  line-height: 1.5;
+  white-space: normal;
+  word-break: break-word;
 }
 
 :global(.create-policy-option-popper) {
@@ -11636,16 +11654,20 @@ function preserveShallowestPathOrder(paths: string[]) {
 .create-policy-option {
   display: flex;
   min-width: 0;
+  max-width: 100%;
   flex-direction: column;
   gap: 4px;
+  overflow: hidden;
 }
 
 .create-policy-option__head {
   display: flex;
   min-width: 0;
+  max-width: 100%;
   align-items: center;
   justify-content: space-between;
   gap: 8px;
+  overflow: hidden;
 }
 
 .create-policy-option__name {
@@ -11672,8 +11694,10 @@ function preserveShallowestPathOrder(paths: string[]) {
 .create-filter-rules-option {
   display: flex;
   min-width: 0;
+  max-width: 100%;
   align-items: center;
   gap: 6px;
+  overflow: hidden;
 }
 
 .create-filter-rules-option__prefix {


### PR DESCRIPTION
## Summary

Fixes #172 - Backup policy templates unavailable and UI text alignment issue.

### Changes

**BackupConfigCreateWizard.vue**
- Add `padding: 20px` to `.create-backup-step-body` to prevent text from hitting the container edge

**BackupCreateWizard.vue**
- Add `max-width: min(560px, calc(100vw - 32px))` to `create-policy-select-popper` to prevent dropdown from exceeding screen width
- Add `max-width: 100%` and `overflow: hidden` to `.create-policy-option`, `.create-policy-option__head`, `.create-filter-rules-option` to clip overflowing content
- Add empty state styles for `.el-select-dropdown__empty` to prevent text cutoff
- Change HflPopover `placement` from `right-start` to `bottom-start` with `:fallback-placements` to avoid horizontal overflow
- Add explicit `placement="bottom-start"` to el-select components to prevent auto-flip to left side
