### PR TITLE
fix(frontend): restrict NAS restore directories

### DIFF
--- a/src/backend/apps/restore/api/serializers/restore_record.py
+++ b/src/backend/apps/restore/api/serializers/restore_record.py
@@ -1,9 +1,24 @@
 from __future__ import annotations
 
+import posixpath
+
 from rest_framework import serializers
 
 from apps.restore.models import RestoreRecord, RestoreRecordItem
 from apps.task.models import Task
+
+
+def _display_target_path(path: str, share_root: str) -> str:
+    value = str(path or "").strip() or "/"
+    root = str(share_root or "").strip()
+    if not root or root == "/":
+        return value
+    normalized_root = posixpath.normpath(root)
+    if not normalized_root.startswith("/"):
+        normalized_root = f"/{normalized_root}"
+    if value == "/":
+        return normalized_root
+    return posixpath.normpath(f"{normalized_root}/{value.lstrip('/')}")
 
 
 class RestoreRecordTaskSummarySerializer(serializers.ModelSerializer):
@@ -14,6 +29,13 @@ class RestoreRecordTaskSummarySerializer(serializers.ModelSerializer):
 
 
 class RestoreRecordItemSerializer(serializers.ModelSerializer):
+    target_display_path = serializers.SerializerMethodField()
+
+    def get_target_display_path(self, obj: RestoreRecordItem) -> str:
+        roots = self.context.get("nas_share_root_by_record_id")
+        share_root = roots.get(obj.restore_record_id, "") if isinstance(roots, dict) else ""
+        return _display_target_path(obj.target_path, share_root)
+
     class Meta:
         model = RestoreRecordItem
         fields = [
@@ -25,6 +47,7 @@ class RestoreRecordItemSerializer(serializers.ModelSerializer):
             "source_path",
             "selected_paths",
             "target_path",
+            "target_display_path",
             "conflict_mode",
             "status",
             "node_task_id",
@@ -42,6 +65,12 @@ class RestoreRecordSerializer(serializers.ModelSerializer):
     items = RestoreRecordItemSerializer(many=True, read_only=True)
     source_snapshot_uid = serializers.SerializerMethodField()
     task_summary = serializers.SerializerMethodField()
+    target_display_path = serializers.SerializerMethodField()
+
+    def get_target_display_path(self, obj: RestoreRecord) -> str:
+        roots = self.context.get("nas_share_root_by_record_id")
+        share_root = roots.get(obj.id, "") if isinstance(roots, dict) else ""
+        return _display_target_path(obj.target_path, share_root)
 
     def get_source_snapshot_uid(self, obj: RestoreRecord) -> str:
         snapshot_uid_by_id = self.context.get("snapshot_uid_by_id")
@@ -75,6 +104,7 @@ class RestoreRecordSerializer(serializers.ModelSerializer):
             "target_type",
             "target_ref_id",
             "target_path",
+            "target_display_path",
             "scope",
             "conflict_mode",
             "request_payload",

--- a/src/backend/apps/restore/api/views/restore_record.py
+++ b/src/backend/apps/restore/api/views/restore_record.py
@@ -26,6 +26,9 @@ from apps.restore.selectors.interface import (
     restore_records_queryset,
 )
 from apps.restore.services import interface as restore_services
+from apps.source.constants import ResourceType
+from apps.source.models import SourceResource
+from apps.source.services.internal.nas_share_path import share_root_label
 from apps.task.models import Task
 
 
@@ -107,6 +110,32 @@ class RestoreRecordViewSet(viewsets.ModelViewSet):
         ).values_list("id", "snapshot_uid")
         return {int(snapshot_id): str(snapshot_uid) for snapshot_id, snapshot_uid in rows}
 
+    @staticmethod
+    def _nas_share_root_by_record_id(records) -> dict[int, str]:
+        records = list(records)
+        if not records:
+            return {}
+        organization_id = records[0].organization_id
+        nas_ids = {record.target_ref_id for record in records if record.target_type == RestoreRecord.EndpointType.NAS}
+        resources = SourceResource.objects.filter(
+            organization_id=organization_id,
+            resource_type=ResourceType.NAS,
+            id__in=nas_ids,
+            is_deleted=False,
+        )
+        roots = {
+            resource.id: share_root_label(
+                resource_type=resource.resource_type,
+                config=resource.config if isinstance(resource.config, dict) else {},
+            )
+            for resource in resources
+        }
+        return {
+            record.id: roots.get(record.target_ref_id, "")
+            for record in records
+            if record.target_type == RestoreRecord.EndpointType.NAS
+        }
+
     def list(self, request, *args, **kwargs):
         queryset = self.filter_queryset(self.get_queryset())
         page = self.paginate_queryset(queryset)
@@ -114,6 +143,7 @@ class RestoreRecordViewSet(viewsets.ModelViewSet):
         context = self.get_serializer_context()
         context["task_by_uuid"] = self._task_by_uuid(records)
         context["snapshot_uid_by_id"] = self._snapshot_uid_by_id(records)
+        context["nas_share_root_by_record_id"] = self._nas_share_root_by_record_id(records)
         serializer = self.get_serializer(records, many=True, context=context)
         if page is not None:
             return self.get_paginated_response(serializer.data)
@@ -124,6 +154,7 @@ class RestoreRecordViewSet(viewsets.ModelViewSet):
         context = self.get_serializer_context()
         context["task_by_uuid"] = self._task_by_uuid([record])
         context["snapshot_uid_by_id"] = self._snapshot_uid_by_id([record])
+        context["nas_share_root_by_record_id"] = self._nas_share_root_by_record_id([record])
         serializer = self.get_serializer(record, context=context)
         return Response(serializer.data)
 

--- a/src/backend/apps/restore/tests/test_restore_api.py
+++ b/src/backend/apps/restore/tests/test_restore_api.py
@@ -390,6 +390,25 @@ class RestoreApiTests(TestCase):
         )
         record = RestoreRecord.objects.get(target_ref_id=target_nas.id)
         self.assertEqual(record.target_path, "/restored/manual")
+        target_nas.config = {
+            "protocol": "nfs",
+            "server": "10.0.0.20",
+            "export_path": "/nasshare",
+        }
+        target_nas.save(update_fields=["config", "updated_at"])
+
+        detail = self.client.get(
+            f"/api/v1/restore/records/{record.id}/",
+            **self._headers(),
+        )
+
+        self.assertEqual(detail.status_code, status.HTTP_200_OK, detail.content)
+        self.assertEqual(detail.data["target_path"], "/restored/manual")
+        self.assertEqual(detail.data["target_display_path"], "/nasshare/restored/manual")
+        self.assertEqual(
+            detail.data["items"][0]["target_display_path"],
+            "/nasshare/restored/manual/file.txt",
+        )
 
     def _active_restore_task(self, *, source_ref_id: int | None = None, status_value: str = Task.Status.RUNNING) -> Task:
         task = Task.objects.create(

--- a/src/frontend/src/lib/restoreApi.ts
+++ b/src/frontend/src/lib/restoreApi.ts
@@ -110,6 +110,7 @@ export type RestoreRecordItem = {
   source_path: string
   selected_paths: string[]
   target_path: string
+  target_display_path?: string
   conflict_mode: RestoreConflictMode
   status: string
   error_code?: string
@@ -140,6 +141,7 @@ export type RestoreRecord = {
   target_type: RestoreEndpointType
   target_ref_id: number
   target_path: string
+  target_display_path?: string
   scope: RestoreScope
   conflict_mode: RestoreConflictMode
   request_payload?: Record<string, unknown>

--- a/src/frontend/src/lib/restoreDirectoryTarget.test.ts
+++ b/src/frontend/src/lib/restoreDirectoryTarget.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+
+import { restoreDirectoryBrowseSourceId } from './restoreDirectoryTarget'
+
+describe('restoreDirectoryBrowseSourceId', () => {
+  it('preserves the NAS resource identity for mounted directory browsing', () => {
+    expect(restoreDirectoryBrowseSourceId('nas:0012')).toBe('nas:12')
+  })
+
+  it('preserves agent destinations and unknown legacy values', () => {
+    expect(restoreDirectoryBrowseSourceId('agent:8')).toBe('agent:8')
+    expect(restoreDirectoryBrowseSourceId('proxy-directory')).toBe('proxy-directory')
+  })
+})

--- a/src/frontend/src/lib/restoreDirectoryTarget.ts
+++ b/src/frontend/src/lib/restoreDirectoryTarget.ts
@@ -1,0 +1,6 @@
+export function restoreDirectoryBrowseSourceId(targetId: string) {
+  const value = String(targetId || '').trim()
+  const match = /^(agent|nas):(\d+)$/.exec(value)
+  if (!match) return value
+  return `${match[1]}:${Number(match[2])}`
+}

--- a/src/frontend/src/pages/protection/BackupCreateWizard.vue
+++ b/src/frontend/src/pages/protection/BackupCreateWizard.vue
@@ -87,6 +87,7 @@ import {
   selectBackupSourceDirectoryTreeEntries,
   shouldAutoExpandRefreshedDirectory,
 } from '../../lib/backupSourceDirectoryTree'
+import { restoreDirectoryBrowseSourceId } from '../../lib/restoreDirectoryTarget'
 import { useBackupSourcePipeline } from '../../composables/useBackupSourcePipeline'
 import {
   createBackupPolicy,
@@ -2190,7 +2191,7 @@ async function loadCreateRecoveryDestTreeNode(
   const parentPath = node.level === 0 ? '' : String(node.data?.path ?? '')
   setDirectoryLoading(loadingKey, true)
   try {
-    const page = await listRealSourceDirChildren(targetHostId, parentPath, { includeFiles: false }).catch((err) => {
+    const page = await listRealSourceDirChildren(restoreDirectoryBrowseSourceId(targetHostId), parentPath, { includeFiles: false }).catch((err) => {
       ElMessage.error({ message: apiErrorMessageI18n(err, t, t('protection.backupsPage.dirTreeLoadFailed')), grouping: true })
       return { entries: [], hasMore: false, nextCursor: '', limit: SOURCE_TREE_CHILD_LIMIT } as SourceTreePage
     })
@@ -2309,7 +2310,7 @@ function refreshCreateRecoveryDestDirectory(
 ) {
   const treeKey = recoveryDirPlanPickerKey(group, dirPlan, 'dest')
   return refreshCreateRecoveryDirectory(treeKey, data, async () => {
-    const page = await listRealSourceDirChildren(dirPlan.targetHostId, data.path, {
+    const page = await listRealSourceDirChildren(restoreDirectoryBrowseSourceId(dirPlan.targetHostId), data.path, {
       includeFiles: false,
       forceRefresh: true,
     })
@@ -2443,7 +2444,7 @@ async function validateCreateRecoveryDestPathInput(group: WizardSourceGroup, dir
   setDirectoryLoading(key, true)
   try {
     const pathInfo = await getBackupSourcePathInfo({
-      source_id: dirPlan.targetHostId,
+      source_id: restoreDirectoryBrowseSourceId(dirPlan.targetHostId),
       path,
       timeout: 10,
     })

--- a/src/frontend/src/pages/protection/DataProtection.vue
+++ b/src/frontend/src/pages/protection/DataProtection.vue
@@ -89,6 +89,7 @@ import {
   selectBackupSourceDirectoryTreeEntries,
   shouldAutoExpandRefreshedDirectory,
 } from '../../lib/backupSourceDirectoryTree'
+import { restoreDirectoryBrowseSourceId } from '../../lib/restoreDirectoryTarget'
 import { useBackupSourcePipeline } from '../../composables/useBackupSourcePipeline'
 import { isBackupSelectableId } from '../../composables/useDemoFlowStep2Sources'
 import { formatLocalDateTime } from '../../lib/dateTime'
@@ -6249,8 +6250,8 @@ function targetNodeForSource(hostId: string) {
 
 function targetNodeSourceIdForSource(hostId: string) {
   const parsed = parseEndpointUiId(recoveryDestConfiguredEntryForHost(hostId)?.hostId || '')
-  if (parsed) return endpointUiId(parsed.type, parsed.refId)
-  return recoveryDestConfiguredEntryForHost(hostId)?.hostId || ''
+  if (parsed) return restoreDirectoryBrowseSourceId(endpointUiId(parsed.type, parsed.refId))
+  return restoreDirectoryBrowseSourceId(recoveryDestConfiguredEntryForHost(hostId)?.hostId || '')
 }
 
 function hasRecoverySnapshotDirectoryDetail(detail: BackupSourceSnapshot | undefined) {

--- a/src/frontend/src/pages/protection/components/FlowBackupSourceDetailDrawer.vue
+++ b/src/frontend/src/pages/protection/components/FlowBackupSourceDetailDrawer.vue
@@ -91,6 +91,7 @@ import FlowSourceConnectionCell from './FlowSourceConnectionCell.vue'
 import {
   restoreRecordPathMappings,
   restoreRecordSnapshotLabel,
+  restoreRecordTargetDisplayPath,
   restoreRecordTaskStatus,
   shouldShowRestoreRecordProgress,
 } from './restoreRecordDisplay'
@@ -938,12 +939,12 @@ function restoreRecordTargetName(record: RestoreRecord) {
 }
 
 function restoreItemTargetSummary(record: RestoreRecord, item: RestoreRecordItem) {
-  const targetPath = item.target_path || record.target_path || '—'
+  const targetPath = restoreRecordTargetDisplayPath(record, item)
   return `${targetPath} (${restoreRecordTargetName(record)})`
 }
 
 function restoreRecordTargetSummary(record: RestoreRecord) {
-  return `${record.target_path || '—'} (${restoreRecordTargetName(record)})`
+  return `${restoreRecordTargetDisplayPath(record)} (${restoreRecordTargetName(record)})`
 }
 
 function restoreItemSourceKind(item: RestoreRecordItem) {

--- a/src/frontend/src/pages/protection/components/restoreRecordDisplay.test.ts
+++ b/src/frontend/src/pages/protection/components/restoreRecordDisplay.test.ts
@@ -3,6 +3,7 @@ import type { RestoreRecord, RestoreRecordItem } from '../../../lib/restoreApi'
 import {
   restoreRecordPathMappings,
   restoreRecordSnapshotLabel,
+  restoreRecordTargetDisplayPath,
   shouldShowRestoreRecordProgress,
 } from './restoreRecordDisplay'
 
@@ -49,6 +50,19 @@ describe('restore record display', () => {
   it('uses the snapshot UID and falls back to the internal ID', () => {
     expect(restoreRecordSnapshotLabel(record())).toBe('snapshot-uid-81')
     expect(restoreRecordSnapshotLabel(record({ source_snapshot_uid: '' }))).toBe('#81')
+  })
+
+  it('prefers the NAS-visible target path for records and items', () => {
+    const nasRecord = record({
+      target_path: '/restore',
+      target_display_path: '/nasshare/restore',
+    })
+    expect(restoreRecordTargetDisplayPath(nasRecord)).toBe('/nasshare/restore')
+    expect(restoreRecordTargetDisplayPath(nasRecord, {
+      ...item,
+      target_path: '/restore/data',
+      target_display_path: '/nasshare/restore/data',
+    })).toBe('/nasshare/restore/data')
   })
 
   it('flattens selected paths into one-level mappings', () => {

--- a/src/frontend/src/pages/protection/components/restoreRecordDisplay.ts
+++ b/src/frontend/src/pages/protection/components/restoreRecordDisplay.ts
@@ -19,6 +19,14 @@ export function restoreRecordSnapshotLabel(record: RestoreRecord) {
   return String(record.source_snapshot_uid || '').trim() || `#${record.source_snapshot_id}`
 }
 
+export function restoreRecordTargetDisplayPath(record: RestoreRecord, item?: RestoreRecordItem) {
+  return item?.target_display_path
+    || record.target_display_path
+    || item?.target_path
+    || record.target_path
+    || '—'
+}
+
 export function joinRestoreRecordSourcePath(basePath: string, selectedPath: string) {
   const base = String(basePath || '').trim()
   const selected = String(selectedPath || '').trim()


### PR DESCRIPTION
## Problem and root cause

NAS restore destinations could be browsed or validated using the proxy filesystem context. A restore could therefore report success while writing to the proxy instead of the NAS share. Restore records also exposed only the internal path and could not show the NAS-visible share/export prefix.

## Solution

- Preserve `nas:<resource-id>` for all NAS restore-directory browsing and validation in New Restore Task, Edit Restore Plan, and Create Backup Configuration.
- Keep persisted and Agent-dispatched paths share-relative while adding read-only NAS display paths such as `/nasshare/restore`.
- Render NAS display paths in restore records and item mappings, with compatibility fallbacks for existing records.
- Add frontend and backend regression coverage.

## Validation

- Targeted frontend tests: 19 passed.
- Backend restore/source tests: 112 passed.
- Frontend lint and production build passed.
- `git diff --check` and English-source validation passed.
- Full frontend `test:ci` was attempted; 7 unrelated existing tests fail because the test environment exposes no `localStorage`.
- Human testing passed: `人工测试通过`.

## Risks and compatibility

No database migration or Agent wire-contract change. Existing `target_path` values remain unchanged; the additive display fields are used only for NAS-aware presentation.

Fixes #304
Fixes #299
