### PR TITLE
fix(frontend): allow horizontal scroll and word-wrap in directory tree paths (#204)

### DIFF
--- a/src/frontend/src/pages/node/AddProxyFsRepository.vue
+++ b/src/frontend/src/pages/node/AddProxyFsRepository.vue
@@ -1194,7 +1194,7 @@ watch(enableQuotaAlert, (enabled) => {
 .proxy-dir-tree {
   max-height: 260px;
   overflow-y: auto;
-  overflow-x: hidden;
+  overflow-x: auto;
   border: 0;
   border-radius: 0;
   padding: 2px 0;
@@ -1249,12 +1249,10 @@ watch(enableQuotaAlert, (enabled) => {
 }
 
 .tree-node-content__path {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
   font-size: 12px;
   line-height: 15px;
   color: rgb(100 116 139);
+  word-break: break-word;
 }
 
 .tree-node-content__status {

--- a/src/frontend/src/pages/protection/BackupCreateWizard.vue
+++ b/src/frontend/src/pages/protection/BackupCreateWizard.vue
@@ -11041,7 +11041,7 @@ function preserveShallowestPathOrder(paths: string[]) {
   max-height: 260px;
   min-height: 0;
   overflow-y: auto;
-  overflow-x: hidden;
+  overflow-x: auto;
   border: 0;
   border-radius: 0;
   padding: 2px 0;
@@ -11280,12 +11280,10 @@ function preserveShallowestPathOrder(paths: string[]) {
 }
 
 .create-dir-row__path {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
   font-size: 12px;
   line-height: 14px;
   color: rgb(100 116 139);
+  word-break: break-word;
 }
 
 .create-dir-row__meta {
@@ -12881,7 +12879,7 @@ function preserveShallowestPathOrder(paths: string[]) {
   max-height: 260px;
   min-height: 0;
   overflow-y: auto;
-  overflow-x: hidden;
+  overflow-x: auto;
   border: 0;
   border-radius: 0;
   padding: 2px 0;
@@ -12917,12 +12915,10 @@ function preserveShallowestPathOrder(paths: string[]) {
 }
 
 .repository-tree-node__path {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
   font-size: 12px;
   line-height: 15px;
   color: rgb(100 116 139);
+  word-break: break-word;
 }
 
 .repository-add-form--quota {

--- a/src/frontend/src/pages/protection/DataProtection.vue
+++ b/src/frontend/src/pages/protection/DataProtection.vue
@@ -14484,7 +14484,7 @@ html[data-theme='dark'] .setup-dr-opening-skeleton__footer {
   max-height: 260px;
   min-height: 0;
   overflow-y: auto;
-  overflow-x: hidden;
+  overflow-x: auto;
   border: 0;
   border-radius: 0;
   padding: 2px 0;
@@ -14613,12 +14613,10 @@ html[data-theme='dark'] .setup-dr-opening-skeleton__footer {
 }
 
 .create-tree-node-content__path {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
   font-size: 12px;
   line-height: 15px;
   color: rgb(100 116 139);
+  word-break: break-word;
 }
 
 .dp-added-dir-path {
@@ -15475,7 +15473,7 @@ html[data-theme='dark'] .setup-dr-opening-skeleton__footer {
   max-height: 260px;
   min-height: 0;
   overflow-y: auto;
-  overflow-x: hidden;
+  overflow-x: auto;
   border: 0;
   border-radius: 0;
   padding: 2px 0;
@@ -15511,12 +15509,10 @@ html[data-theme='dark'] .setup-dr-opening-skeleton__footer {
 }
 
 .repository-tree-node__path {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
   font-size: 12px;
   line-height: 15px;
   color: rgb(100 116 139);
+  word-break: break-word;
 }
 
 .repository-add-form--quota {

--- a/src/frontend/src/pages/protection/components/FlowBackupSourceDetailDrawer.vue
+++ b/src/frontend/src/pages/protection/components/FlowBackupSourceDetailDrawer.vue
@@ -4062,7 +4062,7 @@ function onClosed() {
   width: calc(100% - 49px);
   min-width: 0;
   max-width: calc(100% - 49px);
-  overflow-x: hidden;
+  overflow-x: auto;
   margin-left: 35px;
   padding: 8px 0 10px 14px;
   border-left: 2px solid rgb(226 232 240);

--- a/src/frontend/src/styles/directory-tree.css
+++ b/src/frontend/src/styles/directory-tree.css
@@ -22,7 +22,7 @@
   max-height: 260px;
   min-height: 0;
   overflow-y: auto;
-  overflow-x: hidden;
+  overflow-x: auto;
   border: 0;
   border-radius: 0;
   padding: 2px 0;
@@ -105,12 +105,10 @@
 }
 
 .hfl-dir-tree-node__path {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
   font-size: 12px;
   line-height: 15px;
   color: rgb(100 116 139);
+  word-break: break-word;
 }
 
 .hfl-dir-tree-node__refresh {

--- a/src/frontend/src/styles/resource-add.css
+++ b/src/frontend/src/styles/resource-add.css
@@ -999,12 +999,10 @@ html:not([data-theme='dark']) .resource-add-fullscreen :is(.add-s3-platform-btn:
 }
 
 .resource-add-fullscreen :is(.tree-node-content__path) {
-  overflow: hidden;
   color: #86909c;
   font-size: 11px;
   line-height: 14px;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  word-break: break-word;
 }
 
 .resource-add-fullscreen .add-form-preview-sidebar {


### PR DESCRIPTION
## Summary

Fix issue #204: directory tree paths are truncated with `text-overflow: ellipsis` and `overflow-x: hidden` prevents horizontal scrolling on mobile.

## Changes

Two-layer fix applied to all directory tree components:

| Layer | Before | After |
|-------|--------|-------|
| Container | `overflow-x: hidden` | `overflow-x: auto` |
| Path text | `overflow: hidden` + `text-overflow: ellipsis` + `white-space: nowrap` | `word-break: break-word` |

### Files changed

- [directory-tree.css](src/frontend/src/styles/directory-tree.css) — shared `.hfl-dir-tree` + `.hfl-dir-tree-node__path`
- [BackupCreateWizard.vue](src/frontend/src/pages/protection/BackupCreateWizard.vue) — `.source-dir-tree`, `.create-dir-row__path`, `.repository-dir-tree`, `.repository-tree-node__path`
- [DataProtection.vue](src/frontend/src/pages/protection/DataProtection.vue) — same 4 selectors + `.create-tree-node-content__path`
- [AddProxyFsRepository.vue](src/frontend/src/pages/node/AddProxyFsRepository.vue) — `.proxy-dir-tree` + `.tree-node-content__path`
- [resource-add.css](src/frontend/src/styles/resource-add.css) — `.tree-node-content__path`
- [FlowBackupSourceDetailDrawer.vue](src/frontend/src/pages/protection/components/FlowBackupSourceDetailDrawer.vue) — `.snapshot-directory-expand-panel`

Closes #204

🤖 Generated with [Claude Code](https://claude.com/claude-code)