### PR TITLE
fix(frontend): add horizontal padding to el-select dropdown empty state (#326)

### DIFF
--- a/src/frontend/src/index.css
+++ b/src/frontend/src/index.css
@@ -407,6 +407,14 @@ html[data-theme='hybrid'] {
   letter-spacing: 0;
 }
 
+/* Element Plus: add horizontal padding to select dropdown empty state
+   (default padding: 10px 0 leaves text flush against edges) */
+.el-select-dropdown__empty {
+  padding: 10px 12px;
+  white-space: normal;
+  word-break: break-word;
+}
+
 /* Element Plus dark mode — align with --content-bg / --page-bg dark palette */
 html.dark {
   --el-bg-color: #111116;


### PR DESCRIPTION
## Summary

Fix issue #326: Element Plus default `.el-select-dropdown__empty` uses `padding: 10px 0` (no horizontal padding), so empty-state text in every `el-select` dropdown sits flush against the edges.

## Root Cause

Element Plus `el-select-dropdown.css`:

```css
.el-select-dropdown__empty {
  padding: 10px 0;  /* vertical only; horizontal is 0 */
}
```

## Fix

Global override in `src/frontend/src/index.css`:

```css
.el-select-dropdown__empty {
  padding: 10px 12px;
  white-space: normal;
  word-break: break-word;
}
```

Covers about 52 components that use `el-select`.

## Note

The local fix in [BackupCreateWizard.vue](src/frontend/src/pages/protection/BackupCreateWizard.vue#L11688) for `.create-policy-select-popper` is kept unchanged; it still overrides the global rule where that popper is used.

Closes #326
