### PR TITLE
feat(source): synchronize backup pipeline projections

### DIFF
--- a/src/backend/apps/source/apps.py
+++ b/src/backend/apps/source/apps.py
@@ -9,3 +9,4 @@ class SourceConfig(AppConfig):
 
     def ready(self) -> None:
         import apps.source.tasks  # noqa: F401
+        import apps.source.signals  # noqa: F401

--- a/src/backend/apps/source/periodic_tasks.py
+++ b/src/backend/apps/source/periodic_tasks.py
@@ -6,6 +6,15 @@ from common.scheduling.registry import TASK_REGISTRY
 
 def register_periodic_tasks() -> None:
     TASK_REGISTRY.add(
+        name="source_reconcile_backup_pipeline",
+        task="apps.source.tasks.pipeline.reconcile_source_pipeline_task",
+        schedule=60,
+        args=(),
+        kwargs={"limit": source_conf.AVAILABILITY_RECONCILE_BATCH_SIZE},
+        queue=None,
+        enabled=True,
+    )
+    TASK_REGISTRY.add(
         name="source_reconcile_availability",
         task=(
             "apps.source.tasks.connection_probe."

--- a/src/backend/apps/source/services/interface.py
+++ b/src/backend/apps/source/services/interface.py
@@ -35,6 +35,7 @@ from apps.source.services.internal.validators import validate_resource_payload
 from apps.source.services.internal.source_pipeline import (
     delete_pipeline_entry,
     ensure_pipeline_entry,
+    sync_pipeline_projection,
 )
 from apps.source.services.internal.source_credentials import (
     merge_source_credentials,
@@ -271,6 +272,12 @@ def update_source_resource(
         credentials=resolve_source_credentials(resource.credentials),
     )
     resource.save()
+    if resource.resource_type == ResourceType.NAS:
+        sync_pipeline_projection(
+            organization_id=resource.organization_id,
+            source_kind=SelectableSourceKind.NAS,
+            ref_id=resource.id,
+        )
     if bound_node_changed and resource.resource_type in ResourceType.REQUIRES_MOUNT and resource.bound_node:
         _queue_remount_after_proxy_binding(
             resource=resource,
@@ -333,6 +340,12 @@ def test_resource_connection(*, resource: SourceResource) -> dict:
             "updated_at",
         ]
     )
+    if resource.resource_type == ResourceType.NAS:
+        sync_pipeline_projection(
+            organization_id=resource.organization_id,
+            source_kind=SelectableSourceKind.NAS,
+            ref_id=resource.id,
+        )
     try:
         result = run_connection_test(resource=resource)
     except Exception:
@@ -403,6 +416,12 @@ def bind_node(*, resource: SourceResource, node_id: int) -> dict:
             "updated_at",
         ]
     )
+    if resource.resource_type == ResourceType.NAS:
+        sync_pipeline_projection(
+            organization_id=resource.organization_id,
+            source_kind=SelectableSourceKind.NAS,
+            ref_id=resource.id,
+        )
     if resource.resource_type in ResourceType.REQUIRES_MOUNT:
         _queue_remount_after_proxy_binding(
             resource=resource,

--- a/src/backend/apps/source/services/internal/availability.py
+++ b/src/backend/apps/source/services/internal/availability.py
@@ -111,6 +111,14 @@ def project_node_availability(
             availability=node.availability,
             availability_updated_at=node.availability_updated_at,
         )
+        from apps.source.constants import SelectableSourceKind
+        from apps.source.services.internal.source_pipeline import sync_pipeline_projection
+
+        sync_pipeline_projection(
+            organization_id=node.organization_id,
+            source_kind=SelectableSourceKind.AGENT,
+            ref_id=node.id,
+        )
         return
 
     if node.role != NodeRole.PROXY:
@@ -124,6 +132,9 @@ def project_node_availability(
             availability=Availability.OFFLINE,
             availability_updated_at=node.availability_updated_at,
         )
+        from apps.source.services.internal.source_pipeline import sync_bound_proxy_pipeline_projections
+
+        sync_bound_proxy_pipeline_projections(proxy_id=node.id)
         return
     if not transitioned:
         return
@@ -139,3 +150,6 @@ def project_node_availability(
             queue=SOURCE_REMOTE_IO_QUEUE,
         )
     )
+    from apps.source.services.internal.source_pipeline import sync_bound_proxy_pipeline_projections
+
+    sync_bound_proxy_pipeline_projections(proxy_id=node.id)

--- a/src/backend/apps/source/services/internal/connection.py
+++ b/src/backend/apps/source/services/internal/connection.py
@@ -169,6 +169,14 @@ def apply_connection_test_result(resource: SourceResource, result: dict) -> None
         resource.mount_error = ""
     apply_result_availability(resource=resource, result=result)
     resource.save()
+    if resource.resource_type == ResourceType.NAS:
+        from apps.source.services.internal.source_pipeline import sync_pipeline_projection
+
+        sync_pipeline_projection(
+            organization_id=resource.organization_id,
+            source_kind="nas",
+            ref_id=resource.id,
+        )
 
 
 def apply_connection_test_result_if_current(

--- a/src/backend/apps/source/services/internal/source_pipeline.py
+++ b/src/backend/apps/source/services/internal/source_pipeline.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from django.db import transaction
 from django.utils import timezone
 
 from apps.node.models import Node
@@ -96,6 +97,204 @@ def _projection_values(*, organization_id: int, source_kind: str, ref_id: int):
         source_kind=source_kind, source=source, backup_task=backup_task, restore_task=restore_task
     )
     return source, values
+
+
+def _locked_source(*, organization_id: int, source_kind: str, ref_id: int):
+    """Load a source using the projection service lock order."""
+    if source_kind == SelectableSourceKind.AGENT:
+        return Node.objects.select_for_update().filter(
+            organization_id=organization_id,
+            role=NodeRole.AGENT,
+            id=ref_id,
+            is_deleted=False,
+        ).first()
+    if source_kind != SelectableSourceKind.NAS:
+        return None
+
+    binding = SourceResource.objects.filter(
+        organization_id=organization_id,
+        resource_type=ResourceType.NAS,
+        id=ref_id,
+        is_deleted=False,
+    ).values("bound_node_id").first()
+    if binding is None:
+        return None
+    if binding["bound_node_id"]:
+        Node.objects.select_for_update().filter(pk=binding["bound_node_id"]).first()
+    return SourceResource.objects.select_for_update().filter(
+        organization_id=organization_id,
+        resource_type=ResourceType.NAS,
+        id=ref_id,
+        is_deleted=False,
+    ).first()
+
+
+def sync_pipeline_projection(
+    *,
+    organization_id: int,
+    source_kind: str,
+    ref_id: int,
+    minimum_step: int = PipelineStep.SOURCE_POOL,
+) -> SourceBackupPipelineEntry | None:
+    """Synchronize one source read-model row in the caller's transaction."""
+    if minimum_step not in PipelineStep.VALID:
+        raise ValueError(f"invalid pipeline step: {minimum_step}")
+
+    with transaction.atomic():
+        source = _locked_source(
+            organization_id=organization_id,
+            source_kind=source_kind,
+            ref_id=ref_id,
+        )
+        if source is None:
+            return None
+        entry = SourceBackupPipelineEntry.all_objects.select_for_update().filter(
+            organization_id=organization_id,
+            source_kind=source_kind,
+            ref_id=ref_id,
+        ).first()
+        from apps.task.models import Task, TaskResource
+
+        source_type = "agent" if source_kind == SelectableSourceKind.AGENT else source_kind
+        tasks = Task.objects.filter(
+            organization_id=organization_id,
+            resources__resource_type=TaskResource.Type.BACKUP_SOURCE,
+            resources__resource_subtype=source_type,
+            resources__resource_id=ref_id,
+        ).order_by("-created_at", "-id")
+        values, _inconsistency = build_source_projection(
+            source_kind=source_kind,
+            source=source,
+            backup_task=tasks.filter(task_type=Task.Type.BACKUP).first(),
+            restore_task=tasks.filter(task_type=Task.Type.RESTORE).first(),
+        )
+        current_step = (
+            int(entry.step)
+            if entry is not None and not entry.is_deleted
+            else PipelineStep.SOURCE_POOL
+        )
+        step = max(current_step, minimum_step)
+        if entry is None:
+            return SourceBackupPipelineEntry.objects.create(
+                organization_id=organization_id,
+                source_kind=source_kind,
+                ref_id=ref_id,
+                step=step,
+                created_at=source.created_at,
+                **values,
+            )
+        entry.step = step
+        entry.is_deleted = False
+        entry.deleted_at = None
+        for field, value in values.items():
+            setattr(entry, field, value)
+        entry.save(update_fields=["step", "is_deleted", "deleted_at", *values.keys(), "updated_at"])
+        return entry
+
+
+def sync_bound_proxy_pipeline_projections(*, proxy_id: int, limit: int = 200) -> dict[str, int]:
+    """Refresh bounded NAS projections whose displayed identity comes from a Proxy."""
+    rows = list(
+        SourceResource.objects.filter(
+            bound_node_id=proxy_id,
+            resource_type=ResourceType.NAS,
+            is_deleted=False,
+        ).order_by("id").values_list("organization_id", "id")[: max(1, limit)]
+    )
+    updated = 0
+    for organization_id, ref_id in rows:
+        if sync_pipeline_projection(
+            organization_id=organization_id,
+            source_kind=SelectableSourceKind.NAS,
+            ref_id=ref_id,
+        ) is not None:
+            updated += 1
+    return {"candidates": len(rows), "updated": updated}
+
+
+def sync_task_pipeline_projection(*, task_id: int) -> int:
+    """Project Backup/Restore task state without permitting an older task to win."""
+    from apps.task.models import Task, TaskResource
+
+    task = Task.objects.filter(
+        id=task_id,
+        task_type__in=(Task.Type.BACKUP, Task.Type.RESTORE),
+    ).first()
+    if task is None:
+        return 0
+    resources = TaskResource.objects.filter(
+        task_id=task.id,
+        resource_type=TaskResource.Type.BACKUP_SOURCE,
+    ).values_list("resource_subtype", "resource_id")
+    updated = 0
+    for source_type, ref_id in resources:
+        source_kind = SelectableSourceKind.AGENT if source_type in {"", "agent"} else source_type
+        if source_kind not in {SelectableSourceKind.AGENT, SelectableSourceKind.NAS}:
+            continue
+        if sync_pipeline_projection(
+            organization_id=task.organization_id,
+            source_kind=source_kind,
+            ref_id=int(ref_id),
+        ) is not None:
+            updated += 1
+    return updated
+
+
+def reconcile_pipeline_projections(*, limit: int = 200) -> dict[str, int]:
+    """Repair missing and stale active rows in bounded source order."""
+    batch_size = max(1, limit)
+    candidates: list[tuple[int, str, int]] = []
+    candidates.extend(
+        (organization_id, SelectableSourceKind.AGENT, ref_id)
+        for organization_id, ref_id in Node.objects.filter(
+            role=NodeRole.AGENT,
+            is_deleted=False,
+        ).order_by("id").values_list("organization_id", "id")[:batch_size]
+    )
+    remaining = max(0, batch_size - len(candidates))
+    if remaining:
+        candidates.extend(
+            (organization_id, SelectableSourceKind.NAS, ref_id)
+            for organization_id, ref_id in SourceResource.objects.filter(
+                resource_type=ResourceType.NAS,
+                is_deleted=False,
+            ).order_by("id").values_list("organization_id", "id")[:remaining]
+        )
+    repaired = sum(
+        sync_pipeline_projection(
+            organization_id=organization_id,
+            source_kind=source_kind,
+            ref_id=ref_id,
+        ) is not None
+        for organization_id, source_kind, ref_id in candidates
+    )
+    stale = 0
+    for entry in SourceBackupPipelineEntry.objects.order_by("id")[:batch_size]:
+        if not _source_exists(
+            organization_id=entry.organization_id,
+            source_kind=entry.source_kind,
+            ref_id=entry.ref_id,
+        ):
+            delete_pipeline_entry(
+                organization_id=entry.organization_id,
+                source_kind=entry.source_kind,
+                ref_id=entry.ref_id,
+            )
+            stale += 1
+    active_sources = (
+        Node.objects.filter(role=NodeRole.AGENT, is_deleted=False).count()
+        + SourceResource.objects.filter(
+            resource_type=ResourceType.NAS,
+            is_deleted=False,
+        ).count()
+    )
+    return {
+        "scanned": len(candidates),
+        "repaired": repaired,
+        "stale": stale,
+        "active_sources": active_sources,
+        "active_pipeline_rows": SourceBackupPipelineEntry.objects.count(),
+    }
 
 
 def _pipeline_operation_fenced(
@@ -343,32 +542,12 @@ def ensure_pipeline_entry(
         ref_id=ref_id,
     ):
         return entry
-    source, values = _projection_values(
-        organization_id=organization_id, source_kind=source_kind, ref_id=ref_id
+    return sync_pipeline_projection(
+        organization_id=organization_id,
+        source_kind=source_kind,
+        ref_id=ref_id,
+        minimum_step=step,
     )
-    if source is None:
-        return None
-    if entry is None:
-        return SourceBackupPipelineEntry.objects.create(
-            organization_id=organization_id,
-            source_kind=source_kind,
-            ref_id=ref_id,
-            step=step,
-            created_at=source.created_at,
-            **values,
-        )
-
-    current_step = int(entry.step) if not entry.is_deleted else PipelineStep.SOURCE_POOL
-    if step < current_step:
-        return entry
-    entry.step = max(current_step, step)
-    entry.is_deleted = False
-    entry.deleted_at = None
-    entry.updated_at = timezone.now()
-    for field, value in values.items():
-        setattr(entry, field, value)
-    entry.save(update_fields=["step", "is_deleted", "deleted_at", *values.keys(), "updated_at"])
-    return entry
 
 
 def delete_pipeline_entry(*, organization_id: int, source_kind: str, ref_id: int) -> None:

--- a/src/backend/apps/source/signals.py
+++ b/src/backend/apps/source/signals.py
@@ -1,0 +1,46 @@
+"""Keep the source Pipeline projection synchronized with task state."""
+
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+
+from apps.node.models import Node
+from apps.node.models.base import NodeRole
+from apps.source.constants import SelectableSourceKind
+from apps.source.services.internal.source_pipeline import sync_task_pipeline_projection
+from apps.source.services.internal.source_pipeline import (
+    delete_pipeline_entry,
+    sync_bound_proxy_pipeline_projections,
+    sync_pipeline_projection,
+)
+from apps.task.signals import task_updated
+
+
+@receiver(task_updated)
+def sync_source_pipeline_task(sender, task_uuid, **kwargs) -> None:
+    from apps.task.models import Task
+
+    task_id = Task.objects.filter(task_uuid=task_uuid).values_list("id", flat=True).first()
+    if task_id is not None:
+        sync_task_pipeline_projection(task_id=int(task_id))
+
+
+@receiver(post_save, sender=Node)
+def sync_node_pipeline_projection(sender, instance: Node, created: bool, **kwargs) -> None:
+    if instance.role == NodeRole.AGENT:
+        # Enrollment owns initial Agent projection through sync_agent_source_host.
+        if created:
+            return
+        if instance.is_deleted:
+            delete_pipeline_entry(
+                organization_id=instance.organization_id,
+                source_kind=SelectableSourceKind.AGENT,
+                ref_id=instance.id,
+            )
+        else:
+            sync_pipeline_projection(
+                organization_id=instance.organization_id,
+                source_kind=SelectableSourceKind.AGENT,
+                ref_id=instance.id,
+            )
+    elif instance.role == NodeRole.PROXY:
+        sync_bound_proxy_pipeline_projections(proxy_id=instance.id)

--- a/src/backend/apps/source/tasks/__init__.py
+++ b/src/backend/apps/source/tasks/__init__.py
@@ -12,6 +12,7 @@ from .source_unregister import (
     execute_source_unregister_task,
     reconcile_stuck_source_unregister_tasks_task,
 )
+from .pipeline import reconcile_source_pipeline_task
 
 __all__ = [
     "execute_source_unregister_task",
@@ -21,5 +22,6 @@ __all__ = [
     "queue_source_resource_capacity_probe",
     "reconcile_stale_source_connection_probes_task",
     "reconcile_source_availability_task",
+    "reconcile_source_pipeline_task",
     "reconcile_stuck_source_unregister_tasks_task",
 ]

--- a/src/backend/apps/source/tasks/pipeline.py
+++ b/src/backend/apps/source/tasks/pipeline.py
@@ -1,0 +1,10 @@
+"""Periodic repair for the source backup Pipeline read model."""
+
+from celery import shared_task
+
+from apps.source.services.internal.source_pipeline import reconcile_pipeline_projections
+
+
+@shared_task(name="apps.source.tasks.pipeline.reconcile_source_pipeline_task")
+def reconcile_source_pipeline_task(*, limit: int = 100) -> dict[str, int]:
+    return reconcile_pipeline_projections(limit=max(1, int(limit)))

--- a/src/backend/apps/source/tests/test_periodic_tasks.py
+++ b/src/backend/apps/source/tests/test_periodic_tasks.py
@@ -7,10 +7,19 @@ from apps.source.periodic_tasks import register_periodic_tasks
 
 class SourcePeriodicTaskTests(SimpleTestCase):
     @mock.patch("apps.source.periodic_tasks.TASK_REGISTRY.add")
-    def test_registers_probe_and_unregister_reconciliation(self, add):
+    def test_registers_probe_unregister_and_pipeline_reconciliation(self, add):
         register_periodic_tasks()
 
-        self.assertEqual(add.call_count, 3)
+        self.assertEqual(add.call_count, 4)
+        add.assert_any_call(
+            name="source_reconcile_backup_pipeline",
+            task="apps.source.tasks.pipeline.reconcile_source_pipeline_task",
+            schedule=60,
+            args=(),
+            kwargs={"limit": 100},
+            queue=None,
+            enabled=True,
+        )
         add.assert_any_call(
             name="source_reconcile_availability",
             task=(

--- a/src/backend/apps/source/tests/test_source_pipeline_projection.py
+++ b/src/backend/apps/source/tests/test_source_pipeline_projection.py
@@ -10,8 +10,11 @@ from apps.source.constants import PipelineStep, ResourceType, SelectableSourceKi
 from apps.source.models import SourceBackupPipelineEntry, SourceResource
 from apps.source.services.internal.source_pipeline import (
     ensure_pipeline_entry,
+    reconcile_pipeline_projections,
     revert_backup_flow_sources,
 )
+from apps.task.models import Task, TaskResource
+from apps.task.services.interface import complete_task, create_task, start_task
 
 
 class SourcePipelineProjectionTests(TestCase):
@@ -93,6 +96,95 @@ class SourcePipelineProjectionTests(TestCase):
         self.assertEqual(updated, [f"agent:{self.agent.id}"])
         entry.refresh_from_db()
         self.assertEqual(entry.step, PipelineStep.SOURCE_POOL)
+        self.assertFalse(entry.is_deleted)
+
+    def test_newer_task_projection_is_not_overwritten_by_old_terminal_event(self):
+        first = create_task(
+            organization_id=self.org.id,
+            task_type=Task.Type.BACKUP,
+            display_name="older backup",
+            resources=[{
+                "resource_type": TaskResource.Type.BACKUP_SOURCE,
+                "resource_subtype": "agent",
+                "resource_id": self.agent.id,
+                "is_primary": True,
+            }],
+        )
+        second = create_task(
+            organization_id=self.org.id,
+            task_type=Task.Type.BACKUP,
+            display_name="newer backup",
+            resources=[{
+                "resource_type": TaskResource.Type.BACKUP_SOURCE,
+                "resource_subtype": "agent",
+                "resource_id": self.agent.id,
+                "is_primary": True,
+            }],
+        )
+
+        complete_task(
+            task_uuid=first.task_uuid,
+            organization_id=self.org.id,
+            status=Task.Status.SUCCESS,
+        )
+
+        entry = SourceBackupPipelineEntry.objects.get(
+            organization=self.org,
+            source_kind=SelectableSourceKind.AGENT,
+            ref_id=self.agent.id,
+        )
+        self.assertEqual(entry.last_backup_task_id, second.id)
+        self.assertEqual(entry.last_backup_status, "queued")
+
+        start_task(task_uuid=second.task_uuid, organization_id=self.org.id)
+        entry.refresh_from_db()
+        self.assertEqual(entry.last_backup_task_id, second.id)
+        self.assertEqual(entry.last_backup_status, "running")
+
+    def test_proxy_change_fans_out_to_bound_nas_projection(self):
+        proxy = Node.objects.create(
+            organization=self.org,
+            name="proxy-before",
+            role=Node.Role.PROXY,
+            ip_address="198.51.100.20",
+            status=Node.Status.ONLINE,
+            availability=Node.Availability.ONLINE,
+        )
+        nas = SourceResource.objects.create(
+            organization=self.org,
+            name="nas-through-proxy",
+            resource_type=ResourceType.NAS,
+            bound_node=proxy,
+            availability="online",
+        )
+        proxy.name = "proxy-after"
+        proxy.ip_address = "198.51.100.21"
+        proxy.save(update_fields=["name", "ip_address", "updated_at"])
+
+        entry = SourceBackupPipelineEntry.objects.get(
+            organization=self.org,
+            source_kind=SelectableSourceKind.NAS,
+            ref_id=nas.id,
+        )
+        self.assertEqual(entry.source_hostname, "proxy-after")
+        self.assertEqual(entry.source_ip, "198.51.100.21")
+
+    def test_reconciliation_repairs_deleted_projection(self):
+        SourceBackupPipelineEntry.objects.create(
+            organization=self.org,
+            source_kind=SelectableSourceKind.AGENT,
+            ref_id=self.agent.id,
+            is_deleted=True,
+        )
+
+        result = reconcile_pipeline_projections(limit=10)
+
+        entry = SourceBackupPipelineEntry.objects.get(
+            organization=self.org,
+            source_kind=SelectableSourceKind.AGENT,
+            ref_id=self.agent.id,
+        )
+        self.assertGreaterEqual(result["repaired"], 1)
         self.assertFalse(entry.is_deleted)
 
 


### PR DESCRIPTION
## Problem and root cause

The source backup Pipeline was only partially maintained. Source changes and task state could leave stale projection values, while Proxy-derived NAS identity was not consistently refreshed.

## Solution

Add a transactional Pipeline projection synchronizer, task lifecycle projection, bounded Proxy fan-out, and periodic reconciliation. Route NAS updates, binding changes, availability changes, and connection observations through the synchronizer. Add regression coverage for stale task events, Proxy changes, reconciliation repair, and periodic task registration.

## Validation

- Targeted Pipeline, operation-fence, periodic-registration, and NAS compatibility tests passed.
- Ruff, migration dry-run, English-source validation, Python compilation, and diff checks passed.
- Manual testing: passed.
- The post-sync rebase was conflict-free, so product checks were not rerun after synchronization.

## Risks and compatibility

The change preserves the existing Pipeline schema and API contract. Reconciliation is bounded and retains the existing repair command; the remaining operational consideration is monitoring reconciliation throughput on large organizations.

Fixes #294
