### PR TITLE
fix(frontend): prevent pencil icon from wrapping in target repository column (#329)

### DIFF
--- a/src/frontend/src/pages/protection/BackupCreateWizard.vue
+++ b/src/frontend/src/pages/protection/BackupCreateWizard.vue
@@ -12011,7 +12011,7 @@ function preserveShallowestPathOrder(paths: string[]) {
 .target-assignment-summary {
   display: flex;
   min-width: 0;
-  flex: 0 1 auto;
+  flex: 1 1 0%;
   flex-direction: column;
   gap: 4px;
 }
@@ -12187,7 +12187,7 @@ function preserveShallowestPathOrder(paths: string[]) {
 
 .target-assignment-empty {
   min-width: 0;
-  flex: 0 1 auto;
+  flex: 1 1 0%;
   overflow: hidden;
   color: rgb(148 163 184);
   text-overflow: ellipsis;


### PR DESCRIPTION
## Summary

Fixes #329 — the pencil (edit) icon in the Target Repository column of the backup creation wizard no longer wraps to the next line on narrow screens.

## Root Cause

`.target-assignment-summary` and `.target-assignment-empty` used `flex: 0 1 auto`. With `flex-basis: auto`, the browser uses the content size of the nowrap text as the initial size for flex-wrap line-breaking decisions. When content width + button width + gap exceeded the column width, the button wrapped before flex-shrink could apply.

## Fix

Changed both selectors to `flex: 1 1 0%`:
- `flex-basis: 0%` means the item starts at 0 width, so it never triggers wrapping
- `flex-grow: 1` lets the item fill the remaining space after the 32px button

## Changes

| File | Change |
|---|---|
| `src/frontend/src/pages/protection/BackupCreateWizard.vue` | `.target-assignment-summary` flex: `0 1 auto` → `1 1 0%` |
| `src/frontend/src/pages/protection/BackupCreateWizard.vue` | `.target-assignment-empty` flex: `0 1 auto` → `1 1 0%` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)