### PR TITLE
fix(deploy): defer Gateway Docker install until after enrollment preflight

### DIFF
--- a/deploy/bootstrap/gateway-bootstrap-linux.sh
+++ b/deploy/bootstrap/gateway-bootstrap-linux.sh
@@ -1,6 +1,13 @@
 #!/usr/bin/env bash
 # HyperFileLens Data Gateway enrollment bootstrap (Linux only).
-# Rendered by GET /enrollment/bootstrap-gateway — installs agent + SourceLens sidecar.
+# Rendered by GET /enrollment/bootstrap-gateway.
+#
+# Stage order (matches Agent bootstrap):
+#   1) minimal connectivity / platform gates
+#   2) download lightweight hfl-enroll
+#   3) hfl-enroll runs full preflight, then Agent package install + register
+#   4) hfl-enroll installs Docker (if needed) and LensNode during AI engine setup
+# Docker CE must not be installed here — that would mutate the host before preflight.
 set -euo pipefail
 
 # Avoid getcwd / job-working-directory noise when the caller cwd was removed
@@ -105,89 +112,6 @@ hfl_sourcelens_health_retry() {
 	hfl_fail "${label} unreachable or unhealthy at ${url} after ${attempts} attempts." 3
 }
 
-MIN_ENGINE_VERSION="${HFL_DOCKER_MIN_ENGINE:-24.0.0}"
-MIN_COMPOSE_VERSION="${HFL_COMPOSE_MIN_VERSION:-2.20.0}"
-
-docker_engine_version() {
-	docker version --format '{{.Server.Version}}' 2>/dev/null || true
-}
-
-docker_compose_version() {
-	if docker compose version >/dev/null 2>&1; then
-		docker compose version --short 2>/dev/null || docker compose version 2>/dev/null | awk '{print $NF}'
-		return 0
-	fi
-	printf ''
-}
-
-docker_version_ge() {
-	local have="$1"
-	local want="$2"
-	[[ -n "${have}" && -n "${want}" ]] || return 1
-	dpkg --compare-versions "${have#v}" ge "${want#v}" 2>/dev/null
-}
-
-docker_runtime_ready() {
-	local min_version="${1:-${MIN_ENGINE_VERSION}}"
-	command -v docker >/dev/null 2>&1 || return 1
-	docker info >/dev/null 2>&1 || return 1
-	local engine compose
-	engine="$(docker_engine_version)"
-	[[ -n "${engine}" ]] || return 1
-	docker_version_ge "${engine}" "${min_version}" || return 1
-	compose="$(docker_compose_version)"
-	[[ -n "${compose}" ]] || return 1
-	docker_version_ge "${compose}" "${MIN_COMPOSE_VERSION}" || return 1
-	return 0
-}
-
-docker_existing_not_ready_reason() {
-	local min_version="${1:-${MIN_ENGINE_VERSION}}"
-	local engine compose
-	engine="$(docker_engine_version)"
-	compose="$(docker_compose_version)"
-	if ! docker info >/dev/null 2>&1; then
-		printf '%s' "Docker daemon is not running (try: sudo systemctl start docker)"
-		return 0
-	fi
-	if [[ -z "${engine}" ]]; then
-		printf '%s' "Docker engine version could not be determined"
-		return 0
-	fi
-	if ! docker_version_ge "${engine}" "${min_version}"; then
-		printf '%s' "Docker engine ${engine} is below required ${min_version}"
-		return 0
-	fi
-	if [[ -z "${compose}" ]]; then
-		printf '%s' "Docker Compose v2 is missing or below ${MIN_COMPOSE_VERSION}"
-		return 0
-	fi
-	printf '%s' "Docker is installed but not ready"
-}
-
-ensure_docker_for_gateway() {
-	hfl_step "Checking Docker environment."
-	if docker_runtime_ready "${MIN_ENGINE_VERSION}"; then
-		hfl_ok "Using existing Docker (engine $(docker_engine_version), compose $(docker_compose_version))."
-		return 0
-	fi
-	if command -v docker >/dev/null 2>&1; then
-		hfl_fail "$(docker_existing_not_ready_reason "${MIN_ENGINE_VERSION}"). HFL never repairs or replaces an existing Docker installation." 3
-	fi
-	hfl_step "Installing Docker CE from console offline bundle."
-	docker_script="${TMPDIR:-/tmp}/hfl-install-docker-$$"
-	curl "${CURL_TLS[@]}" -fsSL "${HFL_GATEWAY_BOOTSTRAP_BASE}/gateway-install-docker-ubuntu-amd64.sh" -o "${docker_script}"
-	chmod +x "${docker_script}"
-	HFL_GATEWAY_BOOTSTRAP_BASE="${HFL_GATEWAY_BOOTSTRAP_BASE}" HFL_API_BASE="${HFL_API_BASE}" \
-	HFL_INSECURE_TLS="${HFL_INSECURE_TLS}" HFL_DOCKER_MIN_ENGINE="${MIN_ENGINE_VERSION}" \
-		HFL_COMPOSE_MIN_VERSION="${MIN_COMPOSE_VERSION}" \
-		bash "${docker_script}"
-	rm -f "${docker_script}"
-	docker_runtime_ready "${MIN_ENGINE_VERSION}" \
-		|| hfl_fail "Docker is not ready after offline install." 5
-	hfl_ok "Docker CE ready (engine $(docker_engine_version), compose $(docker_compose_version))."
-}
-
 CURL_TLS=(-k)
 if [[ "${HFL_INSECURE_TLS}" == "0" ]]; then
 	CURL_TLS=()
@@ -214,7 +138,6 @@ if [[ "$(id -u)" -ne 0 ]]; then
 	hfl_fail "Administrator privileges are required. Re-run with sudo." 1
 fi
 
-HFL_GATEWAY_BOOTSTRAP_BASE="${HFL_API_BASE}/media/gateway-bootstrap"
 CONSOLE_BASE="${HFL_API_BASE%/}"
 
 hfl_step "Checking console connectivity."
@@ -224,8 +147,6 @@ hfl_ok "Console is reachable."
 hfl_step "Checking SourceLens health via console proxy."
 hfl_sourcelens_health_retry "${CONSOLE_BASE}/sourcelens/health" "SourceLens health" 3 5
 hfl_ok "SourceLens is reachable."
-
-ensure_docker_for_gateway
 
 BIN="${TMPDIR:-/tmp}/hfl-enroll-$$"
 cleanup() { rm -f "${BIN}" "${BIN}.part"; }

--- a/deploy/bootstrap/gateway-install-docker-ubuntu-amd64.sh
+++ b/deploy/bootstrap/gateway-install-docker-ubuntu-amd64.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Offline Docker CE install for HyperFileLens Data Gateways (Ubuntu 20.04/22.04/24.04 amd64).
-# Bundled under /media/gateway-bootstrap/ and invoked by gateway-bootstrap-linux.sh.
+# Bundled under /media/gateway-bootstrap/ and invoked by hfl-enroll gateway-install
+# after full preflight and Agent registration (AI engine setup).
 #
 # Host-safe policy: only install packages from the bundled .deb archive. Never run
 # apt-get --fix-broken or other apt operations that can remove or upgrade unrelated

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -921,6 +921,17 @@ for bootstrap in "${gateway_bootstrap_linux}" "${gateway_docker_installer}"; do
 	grep -F -- '--retry 3 --retry-connrefused --retry-delay 2' "${bootstrap}" >/dev/null
 	grep -F 'partial="${destination}.part"' "${bootstrap}" >/dev/null
 done
+grep -F 'HyperFileLens enrollment helper' "${gateway_bootstrap_linux}" >/dev/null
+grep -F 'gateway-install' "${gateway_bootstrap_linux}" >/dev/null
+# Gateway bootstrap must stay lightweight: Docker CE install belongs in hfl-enroll
+# after full preflight / Agent registration, not before downloading the helper.
+if grep -E 'ensure_docker_for_gateway|Installing Docker CE from console offline bundle' \
+	"${gateway_bootstrap_linux}" >/dev/null; then
+	printf 'ERROR: gateway bootstrap must not install Docker before enrollment preflight\n' >&2
+	exit 1
+fi
+grep -F 'ensureGatewayDocker' \
+	"${ROOT}/src/agent/internal/enroll/gateway_install.go" >/dev/null
 grep -F -- '--fail --show-error --location --progress-bar' "${gateway_lifecycle}" >/dev/null
 grep -F -- '--continue-at -' "${gateway_lifecycle}" >/dev/null
 grep -F 'HFL_GATEWAY_DOWNLOAD_MAX_ATTEMPTS:-5' "${gateway_lifecycle}" >/dev/null

--- a/tools/quality/test-gateway-bootstrap-health.sh
+++ b/tools/quality/test-gateway-bootstrap-health.sh
@@ -7,7 +7,7 @@ bootstrap="${ROOT}/deploy/bootstrap/gateway-bootstrap-linux.sh"
 # Load only the bootstrap logging and health-check functions, not its installer body.
 # shellcheck disable=SC1090
 source <(
-	sed -n '/^hfl_now()/,/^MIN_ENGINE_VERSION=/p' "${bootstrap}" \
+	sed -n '/^hfl_now()/,/^CURL_TLS=/p' "${bootstrap}" \
 		| sed '$d'
 )
 


### PR DESCRIPTION
## Summary
- Remove early Docker CE install from `gateway-bootstrap-linux.sh` so the one-liner stays lightweight.
- Full preflight and Agent package install/register run first via `hfl-enroll gateway-install`; Docker is installed later during AI engine setup (`ensureGatewayDocker`).
- Add release-contract guards so bootstrap cannot reintroduce pre-preflight Docker install.

## Test plan
- [x] `./tools/quality/test-gateway-bootstrap-health.sh`
- [x] Focused release-contract checks for gateway bootstrap / `ensureGatewayDocker`
- [ ] Re-publish gateway bootstrap on a console host and re-run Private Gateway enrollment on a Docker-less Ubuntu 24.04 host; confirm order is helper → preflight → agent → Docker/LensNode


Made with [Cursor](https://cursor.com)