### PR TITLE
fix(frontend): keep install-flow step titles readable outside fullscreen layouts

### DIFF
--- a/src/frontend/src/components/NodeLifecycleCopy.test.ts
+++ b/src/frontend/src/components/NodeLifecycleCopy.test.ts
@@ -55,4 +55,19 @@ describe('Node lifecycle copy', () => {
     expect(locale).not.toContain('installs left')
     expect(locale).not.toContain("generateNewInstallCommand: 'New command'")
   })
+
+  it('styles install-flow steps outside resource-add fullscreen layouts', () => {
+    const wizard = source('src/components/NodeLifecycleWizard.vue')
+    const css = source('src/styles/agent-install-wizard.css')
+
+    expect(wizard).toContain("t('nodeLifecycle.installFlowStepDownload')")
+    expect(wizard).toMatch(
+      /installFlowStepDownload[\s\S]*?<\/strong>\s*\n\s*\{\{ t\('nodeLifecycle\.installFlowDownload'\) \}\}/,
+    )
+    expect(css).toContain('.agent-install-wizard--source-host .install-flow-note__step strong')
+    expect(css).toContain('display: block')
+    expect(css).not.toContain(
+      '.resource-add-fullscreen .agent-install-wizard--source-host .install-flow-note__step strong',
+    )
+  })
 })

--- a/src/frontend/src/components/NodeLifecycleWizard.vue
+++ b/src/frontend/src/components/NodeLifecycleWizard.vue
@@ -741,13 +741,16 @@ defineExpose({ clearInstallCommand })
               <p class="install-flow-note__label">{{ t('nodeLifecycle.installFlowLabel') }}</p>
               <div class="install-flow-note__steps">
                 <p class="install-flow-note__step">
-                  <strong>{{ t('nodeLifecycle.installFlowStepDownload') }}</strong>{{ t('nodeLifecycle.installFlowDownload') }}
+                  <strong>{{ t('nodeLifecycle.installFlowStepDownload') }}</strong>
+                  {{ t('nodeLifecycle.installFlowDownload') }}
                 </p>
                 <p class="install-flow-note__step">
-                  <strong>{{ t('nodeLifecycle.installFlowStepInstall') }}</strong>{{ t('nodeLifecycle.installFlowInstall') }}
+                  <strong>{{ t('nodeLifecycle.installFlowStepInstall') }}</strong>
+                  {{ t('nodeLifecycle.installFlowInstall') }}
                 </p>
                 <p class="install-flow-note__step">
-                  <strong>{{ t('nodeLifecycle.installFlowStepRegister') }}</strong>{{ installFlowRegisterText }}
+                  <strong>{{ t('nodeLifecycle.installFlowStepRegister') }}</strong>
+                  {{ installFlowRegisterText }}
                 </p>
               </div>
             </div>

--- a/src/frontend/src/styles/agent-install-wizard.css
+++ b/src/frontend/src/styles/agent-install-wizard.css
@@ -666,7 +666,7 @@
   justify-content: flex-end;
 }
 
-.resource-add-fullscreen .agent-install-wizard--source-host .install-flow-note {
+.agent-install-wizard--source-host .install-flow-note {
   margin-top: 12px;
   padding: 12px 14px;
   border: 1px solid #f2f3f5;
@@ -674,7 +674,7 @@
   background: #f7f8fa;
 }
 
-.resource-add-fullscreen .agent-install-wizard--source-host .install-flow-note__label {
+.agent-install-wizard--source-host .install-flow-note__label {
   margin: 0 0 10px;
   color: #1d2129;
   font-size: 13px;
@@ -683,25 +683,25 @@
   text-transform: none;
 }
 
-.resource-add-fullscreen .agent-install-wizard--source-host .install-flow-note__steps {
+.agent-install-wizard--source-host .install-flow-note__steps {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 10px 16px;
 }
 
-.resource-add-fullscreen .agent-install-wizard--source-host .install-flow-note__step {
+.agent-install-wizard--source-host .install-flow-note__step {
   margin: 0;
   color: #4e5969;
   font-size: 12px;
   line-height: 1.5;
 }
 
-.resource-add-fullscreen .agent-install-wizard--source-host .install-flow-note__step:not(:first-child) {
+.agent-install-wizard--source-host .install-flow-note__step:not(:first-child) {
   border-left: 1px solid #e5e6eb;
   padding-left: 16px;
 }
 
-.resource-add-fullscreen .agent-install-wizard--source-host .install-flow-note__step strong {
+.agent-install-wizard--source-host .install-flow-note__step strong {
   display: block;
   margin-bottom: 2px;
   color: #1d2129;
@@ -728,12 +728,12 @@
     grid-template-columns: 1fr;
   }
 
-  .resource-add-fullscreen .agent-install-wizard--source-host .install-flow-note__steps {
+  .agent-install-wizard--source-host .install-flow-note__steps {
     grid-template-columns: 1fr;
     gap: 8px;
   }
 
-  .resource-add-fullscreen .agent-install-wizard--source-host .install-flow-note__step:not(:first-child) {
+  .agent-install-wizard--source-host .install-flow-note__step:not(:first-child) {
     border-left: none;
     padding-left: 0;
     border-top: 1px solid #e5e6eb;


### PR DESCRIPTION
## Summary
- Scope install-flow note styles to `.agent-install-wizard--source-host` so Platform Ops gateway add (no `.resource-add-fullscreen`) keeps Prepare / Install / Register as separate titles.
- Separate step title and description markup so labels cannot concatenate if styles miss.
- Cover the layout contract in `NodeLifecycleCopy.test.ts`.

## Test plan
- [x] Source assertions for CSS selector + wizard markup
- [ ] Refresh Admin `platform-ops/engine/gateways/add` and confirm three-step note is readable
- [ ] Confirm org console Source Host install-flow note still looks correct


Made with [Cursor](https://cursor.com)