### PR TITLE
fix(backup): initialize direct NAS repositories for proxies

### DIFF
--- a/src/agent/internal/engine/managed_backup.go
+++ b/src/agent/internal/engine/managed_backup.go
@@ -29,7 +29,6 @@ import (
 const (
 	managedRepositoryFSOperationTimeout  = 30 * time.Second
 	managedRepositoryKopiaCommandTimeout = 2 * time.Minute
-	managedRepositoryReadyTTL            = 30 * time.Second
 	kopiaEstimatedUsageFactor            = 1.05
 	repositoryAlreadyExistsCode          = "STORAGE.REPOSITORY_ALREADY_EXISTS"
 	repositoryAlreadyExistsMessage       = "A Kopia repository already exists at the selected location. Import is not supported in this version. Choose a different storage location."
@@ -66,14 +65,8 @@ type repositorySpec struct {
 	SessionID       string
 }
 
-type repositoryReadyEntry struct {
-	fingerprint string
-	readyAt     time.Time
-}
-
 var (
 	kopiaS3URLStyleCapabilities sync.Map
-	managedRepositoryReadiness  sync.Map
 )
 
 func parseRepositorySpec(raw any) (repositorySpec, bool, error) {
@@ -196,51 +189,6 @@ func kopiaCapabilityCacheKey(bin string) string {
 		return filepath.Clean(bin)
 	}
 	return fmt.Sprintf("%s\x00%d\x00%d", filepath.Clean(bin), info.Size(), info.ModTime().UnixNano())
-}
-
-func repositoryConnectionFingerprint(spec repositorySpec) (string, error) {
-	raw, err := json.Marshal(spec)
-	if err != nil {
-		return "", err
-	}
-	sum := sha256.Sum256(raw)
-	return hex.EncodeToString(sum[:]), nil
-}
-
-func repositoryReady(configFile string, spec repositorySpec) bool {
-	if _, err := os.Stat(configFile); err != nil {
-		invalidateRepositoryReady(configFile)
-		return false
-	}
-	fingerprint, err := repositoryConnectionFingerprint(spec)
-	if err != nil {
-		return false
-	}
-	value, ok := managedRepositoryReadiness.Load(filepath.Clean(configFile))
-	if !ok {
-		return false
-	}
-	entry := value.(repositoryReadyEntry)
-	if entry.fingerprint != fingerprint || time.Since(entry.readyAt) > managedRepositoryReadyTTL {
-		managedRepositoryReadiness.Delete(filepath.Clean(configFile))
-		return false
-	}
-	return true
-}
-
-func markRepositoryReady(configFile string, spec repositorySpec) {
-	fingerprint, err := repositoryConnectionFingerprint(spec)
-	if err != nil {
-		return
-	}
-	managedRepositoryReadiness.Store(filepath.Clean(configFile), repositoryReadyEntry{
-		fingerprint: fingerprint,
-		readyAt:     time.Now(),
-	})
-}
-
-func invalidateRepositoryReady(configFile string) {
-	managedRepositoryReadiness.Delete(filepath.Clean(configFile))
 }
 
 func s3ConnectionFingerprint(spec repositorySpec) (string, error) {
@@ -568,19 +516,6 @@ func (e *Engine) prepareManagedRepositoryLocked(
 	if spec.Type == "kopia_server" && mode == repositoryPrepareInitialize {
 		return "", nil, result, spec, "kopia_server repositories cannot be initialized"
 	}
-	backupDirectoryID, managedBackupDirectory := payloadIntValue(p.Extra["backup_config_dir_id"])
-	managedBackupDirectory = managedBackupDirectory && backupDirectoryID > 0
-	if mode == repositoryPrepareConnect && managedBackupDirectory && repositoryReady(configFile, spec) {
-		result["repository_cached"] = true
-		slog.Info("managed_repository", "event", "ready_cache_hit", "task_id", taskID, "repo_type", spec.Type)
-		_ = sendProgress(ctx, rep, taskID, orchestrationProgressPayload(
-			"repository_ready",
-			"Repository ready",
-			map[string]any{"config_file": configFile, "cached": true},
-		))
-		return configFile, env, result, spec, ""
-	}
-
 	statusArgs := []string{"--config-file=" + configFile, "repository", "status"}
 	runStatus := func(event string) (process.Result, error) {
 		started := time.Now()
@@ -624,7 +559,6 @@ func (e *Engine) prepareManagedRepositoryLocked(
 	} else {
 		if _, statErr := os.Stat(configFile); statErr == nil {
 			if _, statusErr := runStatus("status_first"); statusErr == nil {
-				markRepositoryReady(configFile, spec)
 				slog.Info("managed_repository", "event", "status_first_ok", "task_id", taskID, "repo_type", spec.Type)
 				_ = sendProgress(ctx, rep, taskID, orchestrationProgressPayload(
 					"repository_ready",
@@ -633,7 +567,6 @@ func (e *Engine) prepareManagedRepositoryLocked(
 				))
 				return configFile, env, result, spec, ""
 			}
-			invalidateRepositoryReady(configFile)
 		} else if !errors.Is(statErr, os.ErrNotExist) {
 			return "", nil, result, spec, statErr.Error()
 		}
@@ -677,8 +610,6 @@ func (e *Engine) prepareManagedRepositoryLocked(
 			return "", nil, result, spec, err.Error()
 		}
 	}
-	markRepositoryReady(configFile, spec)
-
 	_ = sendProgress(ctx, rep, taskID, orchestrationProgressPayload(
 		"repository_ready",
 		"Repository ready",
@@ -1097,10 +1028,8 @@ func (e *Engine) runManagedPolicyApply(
 		result[key] = value
 	}
 	if policyErr != nil {
-		invalidateRepositoryReady(configFile)
 		return "failed", result, policyErr.Error()
 	}
-	markRepositoryReady(configFile, repository)
 	return "success", result, ""
 }
 
@@ -1146,7 +1075,6 @@ func (e *Engine) runManagedPreparedSnapshot(
 		ctx, rep, taskID, bin, configFile, env, p.Path, result,
 	)
 	if status != "success" {
-		invalidateRepositoryReady(configFile)
 	}
 	return status, snapshotResult, errMsg
 }

--- a/src/agent/internal/engine/managed_backup_test.go
+++ b/src/agent/internal/engine/managed_backup_test.go
@@ -416,16 +416,17 @@ func TestManagedRepositoryStatusHealthOnlyControlsUsageMetrics(t *testing.T) {
 	}
 }
 
-func TestManagedRepositoryReadyCacheSkipsRepeatedConnectAndStatus(t *testing.T) {
+func TestManagedRepositoryRechecksRepeatedConnectAndStatus(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("fake Kopia shell script is Unix-only")
 	}
 	tempDir := t.TempDir()
 	commandLog := filepath.Join(tempDir, "commands.log")
+	connectedPath := filepath.Join(tempDir, "connected")
 	kopiaPath := filepath.Join(tempDir, "kopia")
 	script := fmt.Sprintf(
-		"#!/bin/sh\nprintf '%%s\\n' \"$*\" >> %q\ncase \"$*\" in *\"repository connect\"*) touch \"${1#--config-file=}\" ;; esac\nexit 0\n",
-		commandLog,
+		"#!/bin/sh\nprintf '%%s\\n' \"$*\" >> %q\ncase \"$*\" in\n  *\"repository connect\"*) touch \"${1#--config-file=}\" %q; exit 0 ;;\n  *\"repository status\"*) if [ -f %q ]; then rm %q; exit 0; fi; exit 1 ;;\nesac\nexit 0\n",
+		commandLog, connectedPath, connectedPath, connectedPath,
 	)
 	if err := os.WriteFile(kopiaPath, []byte(script), 0o700); err != nil {
 		t.Fatal(err)
@@ -458,11 +459,11 @@ func TestManagedRepositoryReadyCacheSkipsRepeatedConnectAndStatus(t *testing.T) 
 		t.Fatal(err)
 	}
 	commands := string(raw)
-	if got := strings.Count(commands, "repository connect filesystem"); got != 1 {
-		t.Fatalf("connect ran %d times, want 1: %q", got, commands)
+	if got := strings.Count(commands, "repository connect filesystem"); got != 2 {
+		t.Fatalf("connect ran %d times, want 2: %q", got, commands)
 	}
-	if got := strings.Count(commands, "repository status"); got != 1 {
-		t.Fatalf("status ran %d times, want 1: %q", got, commands)
+	if got := strings.Count(commands, "repository status"); got != 3 {
+		t.Fatalf("status ran %d times, want 3: %q", got, commands)
 	}
 }
 

--- a/src/backend/apps/protection/services/backup_config.py
+++ b/src/backend/apps/protection/services/backup_config.py
@@ -107,7 +107,7 @@ def create_backup_config(
         payload["name"],
         len(directories_data),
     )
-    _initialize_direct_nas_repository_for_agent(
+    _initialize_direct_nas_repository(
         organization_id=organization_id,
         source_type=payload["source_type"],
         source_ref_id=payload["source_ref_id"],
@@ -496,15 +496,47 @@ def _validate_unique_source_config(
         raise ValidationError({"source_ref_id": "Backup source already has a backup configuration."})
 
 
-def _initialize_direct_nas_repository_for_agent(
+def _direct_nas_execution_node(
+    *,
+    organization_id: int,
+    source_type: str,
+    source_ref_id: int,
+) -> Node:
+    if source_type == "agent":
+        node = Node.objects.filter(
+            organization_id=organization_id,
+            role=NodeRole.AGENT,
+            id=source_ref_id,
+            status=Node.Status.ONLINE,
+            is_deleted=False,
+        ).first()
+        if node is None:
+            raise ValidationError({"source_ref_id": "Agent source is offline."})
+        return node
+    if source_type == "nas":
+        source = SourceResource.objects.filter(
+            organization_id=organization_id,
+            id=source_ref_id,
+            resource_type=ResourceType.NAS,
+            is_deleted=False,
+        ).select_related("bound_node").first()
+        node = source.bound_node if source is not None else None
+        if node is None or node.role != NodeRole.PROXY:
+            raise ValidationError({"source_ref_id": "NAS source is not bound to a proxy node."})
+        if node.status != Node.Status.ONLINE:
+            raise ValidationError({"source_ref_id": "NAS bound proxy node is offline."})
+        return node
+    raise ValidationError({"source_type": "Unsupported backup source type."})
+
+
+def _initialize_direct_nas_repository(
     *,
     organization_id: int,
     source_type: str,
     source_ref_id: int,
     repository_id: int,
+    verify_existing: bool = True,
 ) -> None:
-    if source_type != "agent":
-        return
     repository = Repository.objects.filter(
         organization_id=organization_id,
         id=repository_id,
@@ -515,15 +547,11 @@ def _initialize_direct_nas_repository_for_agent(
     ).exclude(status=Repository.Status.REMOVED).first()
     if repository is None:
         return
-    node = Node.objects.filter(
+    node = _direct_nas_execution_node(
         organization_id=organization_id,
-        role=NodeRole.AGENT,
-        id=source_ref_id,
-        status=Node.Status.ONLINE,
-        is_deleted=False,
-    ).first()
-    if node is None:
-        raise ValidationError({"source_ref_id": "Agent source is offline."})
+        source_type=source_type,
+        source_ref_id=source_ref_id,
+    )
     payload = nas_repository_payload(
         repository=repository,
         subdir=nas_agent_repository_subdir(node.id),
@@ -538,6 +566,8 @@ def _initialize_direct_nas_repository_for_agent(
         repository_subdir=repository_subdir,
         last_success_checked_at__isnull=False,
     ).exists()
+    if previously_initialized and not verify_existing:
+        return
     task_kind = "repo.status" if previously_initialized else "repo.initialize"
     correlation_id = f"{source_type}:{source_ref_id}:{repository_id}"
     log_agent_dispatch(
@@ -608,6 +638,23 @@ def _initialize_direct_nas_repository_for_agent(
         repository.health = Repository.Health.ONLINE
         repository.last_checked_at = checked_at
         repository.save(update_fields=["health", "last_checked_at", "updated_at"])
+
+
+def ensure_direct_nas_repository_for_backup(
+    *,
+    organization_id: int,
+    source_type: str,
+    source_ref_id: int,
+    repository_id: int,
+) -> None:
+    """Initialize a legacy direct-NAS backup config on its execution node."""
+    _initialize_direct_nas_repository(
+        organization_id=organization_id,
+        source_type=source_type,
+        source_ref_id=source_ref_id,
+        repository_id=repository_id,
+        verify_existing=False,
+    )
 
 
 def _should_initialize_direct_nas_repository(
@@ -1041,7 +1088,7 @@ def update_backup_config(
     if _should_initialize_direct_nas_repository(
         current=config, payload=preflight_payload
     ):
-        _initialize_direct_nas_repository_for_agent(
+        _initialize_direct_nas_repository(
             organization_id=config.organization_id,
             source_type=preflight_payload["source_type"],
             source_ref_id=preflight_payload["source_ref_id"],

--- a/src/backend/apps/protection/services/backup_orchestrator.py
+++ b/src/backend/apps/protection/services/backup_orchestrator.py
@@ -138,7 +138,10 @@ def _node_task_error_code(node_task: NodeTask) -> tuple[str, str]:
         if str(result.get("error_code") or "") == "POLICY_APPLY_FAILED":
             phase = str(result.get("policy_phase") or "apply")
             message = bt.extract_kopia_failure_message(result, last_error=last_error)
-            return "POLICY_APPLY_FAILED", (message or f"Kopia policy {phase} failed.")[:2000]
+            public_message = bt.public_repository_failure_message(message)
+            return "POLICY_APPLY_FAILED", (
+                public_message or f"Backup repository policy {phase} failed."
+            )[:2000]
         message = bt.extract_kopia_failure_message(result, last_error=last_error)
         if not message:
             message = last_error or "Agent backup command failed."

--- a/src/backend/apps/protection/services/backup_task.py
+++ b/src/backend/apps/protection/services/backup_task.py
@@ -602,6 +602,25 @@ def start_backup_tasks(
                     source_ref_id=source.source_ref_id,
                     repository_id=config.repository_id,
                 )
+                repository = Repository.objects.get(
+                    organization_id=organization_id,
+                    id=config.repository_id,
+                )
+                if (
+                    repository.repo_type == Repository.Type.NAS
+                    and not repository.bind_node_type
+                    and not repository.bind_node_id
+                ):
+                    from apps.protection.services.backup_config import (
+                        ensure_direct_nas_repository_for_backup,
+                    )
+
+                    ensure_direct_nas_repository_for_backup(
+                        organization_id=organization_id,
+                        source_type=source.source_type,
+                        source_ref_id=source.source_ref_id,
+                        repository_id=repository.id,
+                    )
                 from apps.protection.services.directory_size_estimate import (
                     ensure_backup_config_directory_estimates,
                 )
@@ -1030,6 +1049,7 @@ def extract_kopia_failure_message(result: dict[str, Any] | None, *, last_error: 
             or "access denied" in lower
             or "rpc error:" in lower
             or "failed to open repository" in lower
+            or "error connecting to repository" in lower
             or lower.startswith("error:")
             or "unable to get policy tree" in lower
             or "policy not found" in lower
@@ -1069,6 +1089,18 @@ def extract_kopia_failure_message(result: dict[str, Any] | None, *, last_error: 
         if tail:
             return tail[:2000]
     return cleaned_error[:2000]
+
+
+def public_repository_failure_message(message: str) -> str:
+    """Return an actionable repository error without backend implementation details."""
+    text = re.sub(r"https?://\S+", "", str(message or "")).strip()
+    lower = text.lower()
+    if "not initialized" in lower:
+        return "Backup repository is not initialized. Initialize or repair the repository before retrying."
+    if "repository is not connected" in lower or "not connected" in lower:
+        return "Backup repository is not connected. Check the repository and retry."
+    text = re.sub(r"\bKopia\b", "backup repository", text, flags=re.IGNORECASE)
+    return re.sub(r"\s{2,}", " ", text).strip(" ;")[:2000]
 
 
 def _is_generic_exit_message(message: str) -> bool:

--- a/src/backend/apps/protection/tests/test_backup_config_api.py
+++ b/src/backend/apps/protection/tests/test_backup_config_api.py
@@ -557,6 +557,30 @@ class ProtectionBackupConfigApiTests(TestCase):
 
     @mock.patch("apps.storage.services.internal.repository_usage.enqueue_repository_usage_refresh")
     @mock.patch("apps.protection.services.backup_config.run_agent_task_sync")
+    def test_create_backup_config_initializes_direct_nas_source_on_bound_proxy(
+        self, run_agent_task_sync, enqueue_usage,
+    ):
+        run_agent_task_sync.return_value = self._successful_agent_task()
+        proxy = self._proxy(name="direct-nas-source-proxy")
+        source = self._nas_source(proxy=proxy, name="direct-nas-source")
+        nas_repo = self._direct_nas_repository(name="direct-nas-source-repo")
+
+        create = self.client.post(
+            "/api/v1/protection/backup-configs/",
+            self._nas_payload(source=source, repository=nas_repo),
+            format="json",
+            **self._headers(),
+        )
+
+        self.assertEqual(create.status_code, status.HTTP_201_CREATED, create.content)
+        call = run_agent_task_sync.call_args.kwargs
+        self.assertEqual(call["node_id"], proxy.id)
+        self.assertEqual(call["kind"], "repo.initialize")
+        self.assertEqual(call["payload"]["repository"]["subdir"], f"hp-repos/agent-{proxy.id}")
+        enqueue_usage.assert_called_once()
+
+    @mock.patch("apps.storage.services.internal.repository_usage.enqueue_repository_usage_refresh")
+    @mock.patch("apps.protection.services.backup_config.run_agent_task_sync")
     def test_create_backup_config_rejects_existing_direct_nas_repository(
         self, run_agent_task_sync, _enqueue_usage,
     ):

--- a/src/backend/apps/protection/tests/test_kopia_progress.py
+++ b/src/backend/apps/protection/tests/test_kopia_progress.py
@@ -358,6 +358,30 @@ class KopiaFailureMessageTests(SimpleTestCase):
         self.assertIn("access denied", message)
         self.assertIn("PermissionDenied", message)
 
+    def test_extract_kopia_failure_message_keeps_repository_connect_failure(self):
+        from apps.protection.services.backup_task import extract_kopia_failure_message
+
+        result = {
+            "repository_connect": {
+                "stderr": "error connecting to repository: repository not initialized in the provided storage"
+            },
+            "repository_status": {
+                "stderr": "open repository: repository is not connected. See https://kopia.io/docs/repositories/"
+            },
+        }
+        message = extract_kopia_failure_message(result, last_error="exit 1: exit status 1")
+        self.assertIn("repository not initialized", message)
+
+    def test_public_repository_failure_message_hides_internal_details(self):
+        from apps.protection.services.backup_task import public_repository_failure_message
+
+        message = public_repository_failure_message(
+            "open repository: repository is not connected. See https://kopia.io/docs/repositories/"
+        )
+        self.assertEqual(message, "Backup repository is not connected. Check the repository and retry.")
+        self.assertNotIn("kopia", message.lower())
+        self.assertNotIn("http", message.lower())
+
     def test_is_generic_exit_message(self):
         from apps.protection.services.backup_task import _is_generic_exit_message
 

--- a/src/backend/apps/storage/repositories/views.py
+++ b/src/backend/apps/storage/repositories/views.py
@@ -351,10 +351,19 @@ def _associated_sources_payload(
             )
         else:
             source = _nas_source_payload(nas_sources.get(config.source_ref_id), config=config)
-            subdir = ""
-            shard = None
-            probe_status = ""
-            health = repository.health
+            bound_node = nas_sources.get(config.source_ref_id)
+            bound_node = bound_node.bound_node if bound_node is not None else None
+            node_id = int(bound_node.id) if bound_node is not None else 0
+            subdir = nas_agent_repository_subdir(node_id) if node_id > 0 else ""
+            shard = shards.get((node_id, subdir)) if subdir else None
+            probe_status = shard.status if shard else ""
+            health = (
+                Repository.Health.ONLINE
+                if probe_status == RepositoryUsageShard.Status.SUCCESS
+                else Repository.Health.OFFLINE
+                if probe_status in {RepositoryUsageShard.Status.FAILED, RepositoryUsageShard.Status.SKIPPED}
+                else repository.health
+            )
         rows.append({
             "backup_config_id": config.id,
             "backup_config_name": config.name,

--- a/src/backend/apps/storage/services/internal/repository_usage.py
+++ b/src/backend/apps/storage/services/internal/repository_usage.py
@@ -445,17 +445,28 @@ def _is_unbound_nas_repository(repository: Repository) -> bool:
 
 def _direct_nas_agent_config_groups(repository: Repository) -> dict[int, list[int]]:
     backup_config_model = apps.get_model("protection", "BackupConfig")
+    source_resource_model = apps.get_model("source", "SourceResource")
     groups: dict[int, list[int]] = {}
     rows = (
         backup_config_model.objects.filter(
             organization_id=repository.organization_id,
             repository_id=repository.id,
-            source_type="agent",
         )
         .order_by("source_ref_id", "id")
-        .values_list("id", "source_ref_id")
+        .values_list("id", "source_type", "source_ref_id")
     )
-    for config_id, source_ref_id in rows:
+    nas_nodes = {
+        int(row["id"]): int(row["bound_node_id"])
+        for row in source_resource_model.objects.filter(
+            organization_id=repository.organization_id,
+            resource_type="nas",
+            is_deleted=False,
+            bound_node_id__isnull=False,
+        ).values("id", "bound_node_id")
+    }
+    for config_id, source_type, source_ref_id in rows:
+        if source_type == "nas":
+            source_ref_id = nas_nodes.get(int(source_ref_id), 0)
         try:
             node_id = int(source_ref_id)
         except (TypeError, ValueError):
@@ -583,7 +594,7 @@ def _sync_direct_nas_agent_usage_shards(repository: Repository) -> tuple[int | N
         node.id: node
         for node in Node.objects.filter(
             organization_id=repository.organization_id,
-            role=NodeRole.AGENT,
+            role__in=[NodeRole.AGENT, NodeRole.PROXY],
             id__in=list(groups.keys()),
             is_deleted=False,
         )

--- a/src/backend/apps/storage/tests/test_repository_api.py
+++ b/src/backend/apps/storage/tests/test_repository_api.py
@@ -548,6 +548,61 @@ class StorageRepositoryApiTests(TestCase):
         self.assertEqual(row["repository_mount_point"], f"/mnt/hfl/storage-repositories/repo-{repo.id}-node-{agent.id}")
         self.assertEqual(row["health"], Repository.Health.ONLINE)
 
+    def test_associated_sources_lists_direct_nas_source_health(self):
+        proxy = Node.objects.create(
+            organization=self.org,
+            name="nas-proxy",
+            role=Node.Role.PROXY,
+            status=Node.Status.ONLINE,
+            ip_address="10.0.8.12",
+        )
+        source = SourceResource.objects.create(
+            organization=self.org,
+            name="source-nas",
+            resource_type=ResourceType.NAS,
+            bound_node=proxy,
+            config={"protocol": "nfs", "server": "192.168.10.35", "share": "/"},
+        )
+        repo = Repository.objects.create(
+            organization_id=self.org.id,
+            name="direct-nas-source",
+            repo_type=Repository.Type.NAS,
+            nas_protocol=Repository.NasProtocol.NFS,
+            status=Repository.Status.CREATED,
+            health=Repository.Health.UNVERIFIED,
+            config={"server_address": "192.168.10.35", "share_path": "/"},
+        )
+        config = BackupConfig.objects.create(
+            organization_id=self.org.id,
+            name="nas backup",
+            source_type="nas",
+            source_ref_id=source.id,
+            repository_id=repo.id,
+        )
+        RepositoryUsageShard.objects.create(
+            organization_id=self.org.id,
+            repository_id=repo.id,
+            usage_scope=RepositoryUsageShard.Scope.DIRECT_NAS_AGENT,
+            node_id=proxy.id,
+            repository_subdir=f"hp-repos/agent-{proxy.id}",
+            mount_point=f"/mnt/hfl/storage-repositories/repo-{repo.id}-node-{proxy.id}",
+            source_config_count=1,
+            source_config_ids=[config.id],
+            status=RepositoryUsageShard.Status.SUCCESS,
+            is_active=True,
+        )
+
+        response = self.client.get(
+            f"/api/v1/storage/repositories/{repo.id}/associated-sources/",
+            **self._headers(),
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+        row = response.data["results"][0]
+        self.assertEqual(row["repository_subdir"], f"hp-repos/agent-{proxy.id}")
+        self.assertEqual(row["repository_mount_point"], f"/mnt/hfl/storage-repositories/repo-{repo.id}-node-{proxy.id}")
+        self.assertEqual(row["health"], Repository.Health.ONLINE)
+
     def test_associated_sources_exposes_nas_registration_and_missing_source_fallback(self):
         repo = Repository.objects.create(
             organization_id=self.org.id,


### PR DESCRIPTION
## Problem and root cause

Direct NAS repositories used by NAS sources were not initialized on their bound proxy. Legacy configurations then failed during policy preparation even after the Agent rechecked repository connectivity. The displayed error also obscured the repository-connect cause with internal implementation details.

## Solution

Initialize and track direct NAS repository shards on the execution proxy for both Agent and NAS sources. Bootstrap legacy repositories before a backup task is created, preserve per-task repository verification in the Agent, and report repository-policy failures with actionable public messages.

## Validation

- `git diff --check`
- `python3 tools/quality/check-english-source.py`
- Focused backend regression suite (7 tests)
- Focused Agent engine regression tests
- Manual testing: passed
- Real NFS backup succeeded for `NFS_192.168.10.35_data` (task `6c971781-5024-4eda-89f1-8ce58a7b9a27`)
- No post-sync product retest was needed because the rebase onto latest `main` was conflict-free.

## Risks and compatibility

Direct NAS bootstrap now runs when a backup task is created for a legacy configuration. It uses the existing proxy task and repository-shard contracts; no API or database migration is required.

Fixes #300
