### PR TITLE
fix(deploy): stage gateway preflight after enroll and mount workspace writable

### DIFF
--- a/deploy/bootstrap/gateway-bootstrap-linux.sh
+++ b/deploy/bootstrap/gateway-bootstrap-linux.sh
@@ -3,11 +3,13 @@
 # Rendered by GET /enrollment/bootstrap-gateway.
 #
 # Stage order (matches Agent bootstrap):
-#   1) minimal connectivity / platform gates
+#   1) local platform gates only (curl / arch / root / systemd)
 #   2) download lightweight hfl-enroll
-#   3) hfl-enroll runs full preflight, then Agent package install + register
+#   3) hfl-enroll runs full preflight (console, SourceLens, packages, …),
+#      then Agent package install + register
 #   4) hfl-enroll installs Docker (if needed) and LensNode during AI engine setup
-# Docker CE must not be installed here — that would mutate the host before preflight.
+# Network checks and Docker CE must not run here — that would mutate or probe
+# before the enrollment helper's full preflight.
 set -euo pipefail
 
 # Avoid getcwd / job-working-directory noise when the caller cwd was removed
@@ -90,28 +92,6 @@ hfl_build_enroll_args() {
 	fi
 }
 
-hfl_sourcelens_health_retry() {
-	local url="$1"
-	local label="$2"
-	local attempts="${3:-3}"
-	local delay="${4:-5}"
-	local n=1
-	local response=""
-	while [[ "${n}" -le "${attempts}" ]]; do
-		if response="$(curl "${CURL_TLS[@]}" -fsSL "${url}" 2>/dev/null)" \
-			&& grep -Eq '"health"[[:space:]]*:[[:space:]]*"OK"' <<<"${response}"; then
-			return 0
-		fi
-		if [[ "${n}" -lt "${attempts}" ]]; then
-			printf '[%s] [WARN ] %s not ready (attempt %s/%s); retrying in %ss.\n' \
-				"$(hfl_now)" "${label}" "${n}" "${attempts}" "${delay}" >&2
-			sleep "${delay}"
-		fi
-		n=$((n + 1))
-	done
-	hfl_fail "${label} unreachable or unhealthy at ${url} after ${attempts} attempts." 3
-}
-
 CURL_TLS=(-k)
 if [[ "${HFL_INSECURE_TLS}" == "0" ]]; then
 	CURL_TLS=()
@@ -138,15 +118,11 @@ if [[ "$(id -u)" -ne 0 ]]; then
 	hfl_fail "Administrator privileges are required. Re-run with sudo." 1
 fi
 
-CONSOLE_BASE="${HFL_API_BASE%/}"
-
-hfl_step "Checking console connectivity."
-curl "${CURL_TLS[@]}" -fsSL "${CONSOLE_BASE}/health" >/dev/null
-hfl_ok "Console is reachable."
-
-hfl_step "Checking SourceLens health via console proxy."
-hfl_sourcelens_health_retry "${CONSOLE_BASE}/sourcelens/health" "SourceLens health" 3 5
-hfl_ok "SourceLens is reachable."
+if ! command -v systemctl >/dev/null 2>&1 \
+	|| [[ ! -d /run/systemd/system ]] \
+	|| ! systemctl show-environment >/dev/null 2>&1; then
+	hfl_fail "This release requires a systemd-based Linux distribution. OpenRC, non-systemd, and container deployments are not supported." 2
+fi
 
 BIN="${TMPDIR:-/tmp}/hfl-enroll-$$"
 cleanup() { rm -f "${BIN}" "${BIN}.part"; }

--- a/deploy/bootstrap/gateway-install-lensnode-sidecar.sh
+++ b/deploy/bootstrap/gateway-install-lensnode-sidecar.sh
@@ -101,7 +101,7 @@ hfl_step "Verifying SourceLens connectivity at ${LENS_HOST_URL}."
 curl "${CURL_TLS[@]}" -fsSL "${LENS_HOST_URL%/}/health" >/dev/null
 hfl_ok "SourceLens health check passed."
 
-hfl_step "Creating protected Gateway filesystem boundary."
+hfl_step "Preparing Gateway workspace mounts for LensNode."
 mkdir -p "${HFL_WORKSPACE_ROOT}"
 HFL_GATEWAY_STATE_ROOT="$(dirname "${HFL_WORKSPACE_ROOT}")/.hyperfilelens"
 HFL_SOURCELENS_STATE_ROOT="${HFL_GATEWAY_STATE_ROOT}/sourcelens"
@@ -253,10 +253,11 @@ ${EXTRA_HOSTS_BLOCK}    environment:
       SENTRY_SERVICE: lensnode
     volumes:
 ${sentry_volume_block}
-      # LensNode only indexes managed data. The host Agent is the sole writer
-      # and lifecycle owner for this filesystem boundary. SourceLens receives
-      # one isolated writable mount for its runtime/cache state.
-      - ${HFL_WORKSPACE_ROOT}:${HFL_WORKSPACE_ROOT}:ro
+      # Workspace must be writable: LensNode document conversion writes
+      # "*.sourcelens" sidecars beside restored source files. The host Agent
+      # remains lifecycle owner; checkpoints/cache stay on the isolated state
+      # mount below, and the Agent trash path stays hidden via tmpfs.
+      - ${HFL_WORKSPACE_ROOT}:${HFL_WORKSPACE_ROOT}:rw
       - ${HFL_SOURCELENS_STATE_ROOT}:${HFL_SOURCELENS_MOUNTPOINT}:rw
     tmpfs:
       # Hide the host Agent's same-filesystem deletion quarantine from LensNode.

--- a/src/agent/internal/enroll/download_progress.go
+++ b/src/agent/internal/enroll/download_progress.go
@@ -221,7 +221,11 @@ func roleDisplayName(role model.Role, gatewayScope ...string) string {
 	case model.RoleProxy:
 		return "Proxy Host"
 	case model.RoleGateway:
-		if len(gatewayScope) > 0 && strings.EqualFold(strings.TrimSpace(gatewayScope[0]), "public") {
+		scope := ""
+		if len(gatewayScope) > 0 {
+			scope = gatewayScope[0]
+		}
+		if isPublicGatewayScope(scope) {
 			return "Public Data Gateway"
 		}
 		return "Private Data Gateway"
@@ -230,8 +234,17 @@ func roleDisplayName(role model.Role, gatewayScope ...string) string {
 	}
 }
 
-func agentPackageLabel(role model.Role) string {
-	return roleDisplayName(role) + " Agent package"
+func isPublicGatewayScope(scope string) bool {
+	switch strings.ToLower(strings.TrimSpace(scope)) {
+	case "public", "platform":
+		return true
+	default:
+		return false
+	}
+}
+
+func agentPackageLabel(role model.Role, gatewayScope ...string) string {
+	return roleDisplayName(role, gatewayScope...) + " Agent package"
 }
 
 func safeDownloadFilename(rawURL string) string {

--- a/src/agent/internal/enroll/download_progress_test.go
+++ b/src/agent/internal/enroll/download_progress_test.go
@@ -52,6 +52,34 @@ func TestRoleDownloadLabels(t *testing.T) {
 			t.Fatalf("role %q label=%q, want %q", role, got, expected)
 		}
 	}
+	if got := agentPackageLabel(model.RoleGateway, "platform"); got != "Public Data Gateway Agent package" {
+		t.Fatalf("platform gateway label=%q", got)
+	}
+	if got := agentPackageLabel(model.RoleGateway, "public"); got != "Public Data Gateway Agent package" {
+		t.Fatalf("public gateway label=%q", got)
+	}
+}
+
+func TestIsPublicGatewayScope(t *testing.T) {
+	for _, scope := range []string{"platform", "PLATFORM", "public", " Public "} {
+		if !isPublicGatewayScope(scope) {
+			t.Fatalf("expected public scope %q", scope)
+		}
+	}
+	for _, scope := range []string{"", "user", "private", "tenant"} {
+		if isPublicGatewayScope(scope) {
+			t.Fatalf("expected private scope %q", scope)
+		}
+	}
+	if got := roleDisplayName(model.RoleGateway, "platform"); got != "Public Data Gateway" {
+		t.Fatalf("platform display=%q", got)
+	}
+	if got := gatewayDisplayName("platform"); got != "Public Data Gateway" {
+		t.Fatalf("gatewayDisplayName(platform)=%q", got)
+	}
+	if got := gatewayDisplayName("user"); got != "Private Data Gateway" {
+		t.Fatalf("gatewayDisplayName(user)=%q", got)
+	}
 }
 
 func TestSafeDownloadFilenameExcludesQuery(t *testing.T) {

--- a/src/agent/internal/enroll/gateway_install.go
+++ b/src/agent/internal/enroll/gateway_install.go
@@ -260,7 +260,7 @@ func printGatewayInstallSuccess(info SummaryInfo, lens LensSidecarConfig) {
 }
 
 func gatewayDisplayName(scope string) string {
-	if strings.EqualFold(strings.TrimSpace(scope), "public") {
+	if isPublicGatewayScope(scope) {
 		return "Public Data Gateway"
 	}
 	return "Private Data Gateway"

--- a/src/agent/internal/enroll/install.go
+++ b/src/agent/internal/enroll/install.go
@@ -436,14 +436,14 @@ func installAgentPackage(ctx context.Context, cfg Config, agentVer *string) erro
 	archivePath, cleanup, err := downloadReleaseArchive(
 		ctx,
 		dl,
-		agentPackageLabel(cfg.NodeRole),
+		agentPackageLabel(cfg.NodeRole, cfg.GatewayScope),
 	)
 	if err != nil {
 		return err
 	}
 	defer cleanup()
 
-	label := roleDisplayName(cfg.NodeRole) + " Agent package"
+	label := agentPackageLabel(cfg.NodeRole, cfg.GatewayScope)
 	logStep("Extracting " + label + ".")
 	bundleRoot, err := extractReleaseBundle(ctx, archivePath)
 	if err != nil {
@@ -481,13 +481,13 @@ func upgradeAgentPackage(ctx context.Context, cfg Config, downloadURL, releaseVe
 	archivePath, cleanup, err := downloadReleaseArchive(
 		ctx,
 		downloadURL,
-		agentPackageLabel(cfg.NodeRole),
+		agentPackageLabel(cfg.NodeRole, cfg.GatewayScope),
 	)
 	if err != nil {
 		return err
 	}
 	defer cleanup()
-	label := roleDisplayName(cfg.NodeRole) + " Agent package"
+	label := agentPackageLabel(cfg.NodeRole, cfg.GatewayScope)
 	logStep("Extracting " + label + ".")
 	bundleRoot, err := extractReleaseBundle(ctx, archivePath)
 	if err != nil {

--- a/src/agent/internal/enroll/sidecar_install_unix.go
+++ b/src/agent/internal/enroll/sidecar_install_unix.go
@@ -8,10 +8,12 @@ import (
 	"crypto/sha256"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"syscall"
 	"time"
@@ -33,6 +35,37 @@ const (
 	gatewayMinDockerCompose    = "2.20.0"
 )
 
+var sourceLensHealthOK = regexp.MustCompile(`"health"\s*:\s*"OK"`)
+
+func checkSourceLensHealthViaConsole(ctx context.Context, cfg Config) error {
+	base := strings.TrimRight(strings.TrimSpace(cfg.APIBase), "/")
+	if base == "" {
+		return fmt.Errorf("SourceLens health check requires console API base URL")
+	}
+	url := base + "/sourcelens/health"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return fmt.Errorf("SourceLens health request: %w", err)
+	}
+	client := &http.Client{Timeout: 20 * time.Second}
+	if tlsclient.InsecureTLSEnabled() {
+		client.Transport = tlsclient.Transport()
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("SourceLens unreachable at %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	if resp.StatusCode < 200 || resp.StatusCode >= 400 {
+		return fmt.Errorf("SourceLens health returned HTTP %s", resp.Status)
+	}
+	if !sourceLensHealthOK.Match(body) {
+		return fmt.Errorf("SourceLens unhealthy at %s", url)
+	}
+	return nil
+}
+
 type lensSidecarRuntime struct {
 	envPath        string
 	appliedPath    string
@@ -43,6 +76,10 @@ type lensSidecarRuntime struct {
 }
 
 func checkGatewayRuntimePreflight(ctx context.Context, cfg Config) gatewayRuntimePreflightResult {
+	if err := checkSourceLensHealthViaConsole(ctx, cfg); err != nil {
+		return gatewayRuntimePreflightResult{Err: err}
+	}
+
 	dockerReady := dockerRuntimeReady()
 	if !dockerReady {
 		if _, err := exec.LookPath("docker"); err == nil {

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -923,15 +923,20 @@ for bootstrap in "${gateway_bootstrap_linux}" "${gateway_docker_installer}"; do
 done
 grep -F 'HyperFileLens enrollment helper' "${gateway_bootstrap_linux}" >/dev/null
 grep -F 'gateway-install' "${gateway_bootstrap_linux}" >/dev/null
-# Gateway bootstrap must stay lightweight: Docker CE install belongs in hfl-enroll
-# after full preflight / Agent registration, not before downloading the helper.
-if grep -E 'ensure_docker_for_gateway|Installing Docker CE from console offline bundle' \
+grep -F 'requires a systemd-based Linux distribution' "${gateway_bootstrap_linux}" >/dev/null
+# Gateway bootstrap must stay lightweight: no console/SourceLens probes and no Docker
+# install before downloading the enrollment helper (matches Agent bootstrap staging).
+if grep -E 'Checking console connectivity|Checking SourceLens health|hfl_sourcelens_health_retry|ensure_docker_for_gateway|Installing Docker CE from console offline bundle' \
 	"${gateway_bootstrap_linux}" >/dev/null; then
-	printf 'ERROR: gateway bootstrap must not install Docker before enrollment preflight\n' >&2
+	printf 'ERROR: gateway bootstrap must not probe console/SourceLens or install Docker before enrollment preflight\n' >&2
 	exit 1
 fi
 grep -F 'ensureGatewayDocker' \
 	"${ROOT}/src/agent/internal/enroll/gateway_install.go" >/dev/null
+grep -F 'checkSourceLensHealthViaConsole' \
+	"${ROOT}/src/agent/internal/enroll/sidecar_install_unix.go" >/dev/null
+grep -F 'isPublicGatewayScope' \
+	"${ROOT}/src/agent/internal/enroll/download_progress.go" >/dev/null
 grep -F -- '--fail --show-error --location --progress-bar' "${gateway_lifecycle}" >/dev/null
 grep -F -- '--continue-at -' "${gateway_lifecycle}" >/dev/null
 grep -F 'HFL_GATEWAY_DOWNLOAD_MAX_ATTEMPTS:-5' "${gateway_lifecycle}" >/dev/null
@@ -944,8 +949,14 @@ grep -F '${HFL_SOURCELENS_STATE_ROOT}:${HFL_SOURCELENS_MOUNTPOINT}:rw' \
 	"${gateway_sidecar_installer}" >/dev/null
 grep -F 'LENSNODE_CHECKPOINT_DIR: ${HFL_SOURCELENS_MOUNTPOINT}/checkpoints' \
 	"${gateway_sidecar_installer}" >/dev/null
-grep -F '${HFL_WORKSPACE_ROOT}:${HFL_WORKSPACE_ROOT}:ro' \
+# Conversion writes "*.sourcelens" beside sources; workspace cannot stay :ro.
+grep -F '${HFL_WORKSPACE_ROOT}:${HFL_WORKSPACE_ROOT}:rw' \
 	"${gateway_sidecar_installer}" >/dev/null
+if grep -F '${HFL_WORKSPACE_ROOT}:${HFL_WORKSPACE_ROOT}:ro' \
+	"${gateway_sidecar_installer}" >/dev/null; then
+	printf 'ERROR: gateway LensNode workspace mount must be :rw for document conversion\n' >&2
+	exit 1
+fi
 grep -F 'script="${INSTALL_SH%/install.sh}/libexec/gateway-lifecycle.sh"' \
 	"${ROOT}/src/agent/internal/platform/install/gateway_hooks_unix.go" >/dev/null
 grep -F 'Docker CE offline bundle' "${gateway_docker_installer}" >/dev/null

--- a/tools/quality/test-gateway-bootstrap-health.sh
+++ b/tools/quality/test-gateway-bootstrap-health.sh
@@ -4,36 +4,25 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 bootstrap="${ROOT}/deploy/bootstrap/gateway-bootstrap-linux.sh"
 
-# Load only the bootstrap logging and health-check functions, not its installer body.
-# shellcheck disable=SC1090
-source <(
-	sed -n '/^hfl_now()/,/^CURL_TLS=/p' "${bootstrap}" \
-		| sed '$d'
-)
-
-CURL_TLS=()
-
-run_health_check_with_response() {
-	local mock_response="$1"
-	(
-		curl() {
-			printf '%s' "${mock_response}"
-		}
-		hfl_sourcelens_health_retry "https://console.example/sourcelens/health" \
-			"SourceLens health" 1 0
-	)
-}
-
-run_health_check_with_response '{"health":"OK"}'
-
-if run_health_check_with_response '<!doctype html><title>HyperFileLens</title>' 2>/dev/null; then
-	printf 'ERROR: Gateway bootstrap accepted the Admin SPA as SourceLens health\n' >&2
+# Gateway bootstrap must stay Agent-shaped: local gates, then enrollment helper.
+# Console / SourceLens probes belong in hfl-enroll preflight after the helper download.
+if grep -E 'Checking console connectivity|Checking SourceLens health|hfl_sourcelens_health_retry' \
+	"${bootstrap}" >/dev/null; then
+	printf 'ERROR: gateway bootstrap must not probe console/SourceLens before downloading hfl-enroll\n' >&2
 	exit 1
 fi
 
-if run_health_check_with_response '{"health":"DOWN"}' 2>/dev/null; then
-	printf 'ERROR: Gateway bootstrap accepted an unhealthy SourceLens response\n' >&2
+grep -F 'HyperFileLens enrollment helper' "${bootstrap}" >/dev/null
+grep -F 'gateway-install' "${bootstrap}" >/dev/null
+grep -F 'requires a systemd-based Linux distribution' "${bootstrap}" >/dev/null
+grep -F 'systemctl show-environment' "${bootstrap}" >/dev/null
+
+# Ensure helper download appears before gateway-install invocation.
+helper_line="$(grep -n 'HyperFileLens enrollment helper' "${bootstrap}" | head -1 | cut -d: -f1)"
+install_line="$(grep -n 'gateway-install' "${bootstrap}" | tail -1 | cut -d: -f1)"
+if [[ -z "${helper_line}" || -z "${install_line}" || "${helper_line}" -ge "${install_line}" ]]; then
+	printf 'ERROR: gateway bootstrap must download hfl-enroll before invoking gateway-install\n' >&2
 	exit 1
 fi
 
-printf 'Gateway bootstrap SourceLens health validation passed\n'
+printf 'Gateway bootstrap preflight order validation passed\n'


### PR DESCRIPTION
## Summary
- Keep the Gateway bootstrap stub Agent-shaped: local gates only, then download `hfl-enroll`; move console/SourceLens probes into enrollment preflight.
- Mount the LensNode workspace `:rw` so document conversion can write `*.sourcelens` sidecars beside restored sources (fixes `DATASOURCE_CONVERSION_FAILED` / read-only FS).
- Treat `platform` and `public` gateway scopes as Public in install progress labels.

## Test plan
- [x] `bash tools/quality/check-release-contracts.sh`
- [x] `bash tools/quality/test-gateway-bootstrap-health.sh`
- [x] `go test ./internal/enroll/` (from `src/agent`)
- [ ] After merge: republish `gateway-bootstrap` / sidecar scripts to console media
- [ ] Manually recreate or upgrade existing Gateway LensNode compose so workspace mounts become `:rw` (Actions deploy alone does not upgrade user-managed gateways)


Made with [Cursor](https://cursor.com)