### PR TITLE
fix(frontend): refresh snapshots for each restore session

### DIFF
--- a/src/frontend/src/pages/protection/DataProtection.vue
+++ b/src/frontend/src/pages/protection/DataProtection.vue
@@ -1642,6 +1642,7 @@ function openRecoveryWithBackupIds(backupIds: string[]) {
     ElMessage.warning({ message: t('protection.backupsPage.msgPickBackupForRecovery'), grouping: true })
     return
   }
+  invalidateRecoverySnapshotLists(backupIds)
   recOpen.value = true
   ensureRecoveryNodes()
   recEntryStage.value = 'chooser'
@@ -6336,6 +6337,16 @@ function recoverySnapshotSourceKey(hostId: string) {
   const parsed = parseEndpointUiId(hostId)
   if (!parsed || (parsed.type !== 'agent' && parsed.type !== 'nas')) return ''
   return `${parsed.type}:${parsed.refId}`
+}
+
+function invalidateRecoverySnapshotLists(backupIds: string[]) {
+  const sourceKeys = new Set(
+    backupIds
+      .map((backupId) => recoverySnapshotSourceKey(backupSourceHostId(backupId)))
+      .filter(Boolean),
+  )
+  for (const sourceKey of sourceKeys) delete recoverySnapshotLists[sourceKey]
+  recoveryPlanSnapshotMap.value = {}
 }
 
 function recoverySnapshotListState(sourceKey: string): RecoverySnapshotListState {

--- a/src/frontend/src/pages/protection/DataProtectionRecoverySnapshots.test.ts
+++ b/src/frontend/src/pages/protection/DataProtectionRecoverySnapshots.test.ts
@@ -1,0 +1,51 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const page = readFileSync(resolve(process.cwd(), 'src/pages/protection/DataProtection.vue'), 'utf8')
+
+function sourceBetween(startMarker: string, endMarker: string) {
+  const start = page.indexOf(startMarker)
+  const end = page.indexOf(endMarker, start + 1)
+
+  expect(start).toBeGreaterThan(-1)
+  expect(end).toBeGreaterThan(start)
+  return page.slice(start, end)
+}
+
+describe('restore snapshot list freshness', () => {
+  it('invalidates selected-source state before opening a new restore session', () => {
+    const opener = sourceBetween(
+      'function openRecoveryWithBackupIds',
+      'function openRecoveryForSource',
+    )
+    const invalidation = sourceBetween(
+      'function invalidateRecoverySnapshotLists',
+      'function recoverySnapshotListState',
+    )
+
+    expect(opener).toContain('invalidateRecoverySnapshotLists(backupIds)')
+    expect(opener.indexOf('invalidateRecoverySnapshotLists(backupIds)'))
+      .toBeLessThan(opener.indexOf('recOpen.value = true'))
+    expect(invalidation).toContain('recoverySnapshotSourceKey(backupSourceHostId(backupId))')
+    expect(invalidation).toContain('delete recoverySnapshotLists[sourceKey]')
+    expect(invalidation).toContain('recoveryPlanSnapshotMap.value = {}')
+  })
+
+  it('recreates invalidated state and reloads snapshots from page one', () => {
+    const stateFactory = sourceBetween(
+      'function recoverySnapshotListState',
+      'function recoverySnapshotListStateForHost',
+    )
+    const loader = sourceBetween(
+      'async function loadRecoverySnapshotsForSource',
+      'function sourceSnapshotFallbackOptions',
+    )
+
+    expect(stateFactory).toContain('page: 0')
+    expect(stateFactory).toContain('loaded: false')
+    expect(loader).toContain('const reset = opts.reset || !state.loaded')
+    expect(loader).toContain('const nextPage = reset ? 1 : state.page + 1')
+    expect(loader).toContain('state.items = reset ? result.results : mergeSnapshotListItems')
+  })
+})


### PR DESCRIPTION
## Problem and root cause

The restore wizard retained each source's loaded snapshot list for the lifetime
of the page. Backup completion refreshed the main protection view but did not
invalidate that restore-specific state, so reopening Restore could skip the API
request and omit a newly completed snapshot until the browser was refreshed.

## Solution

- Invalidate cached recovery snapshot lists for the selected sources before a
  new restore wizard session opens.
- Reset session-scoped recovery-plan snapshot selections so defaults are
  reconciled against the freshly loaded snapshot list.
- Add regression coverage for invalidation ordering and page-one reload state.

## Validation

- Targeted Vitest regression: passed
- Frontend lint: passed
- Frontend CI tests: 142 files and 670 tests passed
- Frontend default tests: 142 files and 670 tests passed
- Frontend type check and production build: passed
- English-only source check: passed
- Git diff check: passed
- Manual testing: passed
- Post-sync product checks: skipped because the rebase onto the latest base was conflict-free

## Risks and compatibility

The change adds one fresh page-one snapshot request per selected source when a
new restore session starts. Existing pagination remains unchanged, and there
are no API, persistence, permission, or migration changes.

Fixes #252
