### PR TITLE
fix(lens): include restored hidden files in Chat retrieval

### DIFF
--- a/src/backend/apps/lens_bridge/services/provisioning.py
+++ b/src/backend/apps/lens_bridge/services/provisioning.py
@@ -22,7 +22,7 @@ from apps.lens_bridge.models import (
     LensOrgLink,
     LensWorkspaceBinding,
 )
-from apps.lens_bridge.services import ingest_policy, org_models, sl_client
+from apps.lens_bridge.services import ingest_policy, org_models, retrieval_policy, sl_client
 from apps.node.models.base import NodeRole
 from apps.node.models.node import Node
 
@@ -371,6 +371,21 @@ def assistant_uuid_for_ks(ks: LensKnowledgeSource) -> uuid.UUID | None:
     return None
 
 
+def _assistant_is_chat_managed(
+    *,
+    org: Organization,
+    assistant_uuid: uuid.UUID,
+) -> bool:
+    """Return whether HFL Chat owns this SourceLens assistant lifecycle."""
+    from apps.lens_bridge.models import LensAssistantLink
+
+    return LensAssistantLink.objects.filter(
+        organization=org,
+        sl_assistant_uuid=assistant_uuid,
+        lifecycle_owner=LensAssistantLink.LifecycleOwner.CHAT,
+    ).exists()
+
+
 def sync_linked_assistant_for_ks(
     *,
     org: Organization,
@@ -407,6 +422,10 @@ def update_sl_assistant_for_ks(
     settings["ingestion"] = {
         "conversion": ingest_policy.conversion_payload_for_sl(policy),
     }
+    # Chat-owned workspaces are user restore data: keep every restored path
+    # searchable. Manual Insight assistants keep operator-configured excludes.
+    if _assistant_is_chat_managed(org=org, assistant_uuid=ks.sl_assistant_uuid):
+        settings["retrieval_policy"] = retrieval_policy.managed_chat_retrieval_policy()
     sl_client.request_json(
         "PATCH",
         f"/api/lens/assistants/{ks.sl_assistant_uuid}/",
@@ -464,7 +483,9 @@ def create_sl_assistant_for_ks(
     payload["settings"] = {
         "ingestion": {
             "conversion": ingest_policy.conversion_payload_for_sl(policy),
-        }
+        },
+        # Chat workspace is user data: keep restored dotfiles searchable.
+        "retrieval_policy": retrieval_policy.managed_chat_retrieval_policy(),
     }
     data = sl_client.request_json("POST", "/api/lens/assistants/", json_body=payload)
     assistant_uuid = data.get("uuid")

--- a/src/backend/apps/lens_bridge/services/retrieval_policy.py
+++ b/src/backend/apps/lens_bridge/services/retrieval_policy.py
@@ -1,0 +1,22 @@
+"""Retrieval-policy helpers for HFL-managed SourceLens assistants."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def managed_chat_retrieval_policy() -> dict[str, Any]:
+    """Return retrieval_policy for HFL Chat / managed KS assistants.
+
+    The Chat workspace is the user's restored data. LensNode skips every path
+    component that starts with "." unless include_hidden is true, so enable it.
+    Pass empty exclude lists explicitly so LensNode does not fall back to its
+    built-in DEFAULT_EXCLUDED_DIRS / DEFAULT_EXCLUDED_EXTENSIONS. Filesystem
+    entries "." and ".." are never yielded by directory iteration and need no
+    extra rule.
+    """
+    return {
+        "include_hidden": True,
+        "exclude_dirs": [],
+        "exclude_extensions": [],
+    }

--- a/src/backend/apps/lens_bridge/tests/test_provisioning.py
+++ b/src/backend/apps/lens_bridge/tests/test_provisioning.py
@@ -403,6 +403,107 @@ class CreateAssistantModelBindingTests(SimpleTestCase):
             ],
             multimodal_ref,
         )
+        self.assertEqual(
+            payload["settings"]["retrieval_policy"],
+            {
+                "include_hidden": True,
+                "exclude_dirs": [],
+                "exclude_extensions": [],
+            },
+        )
+
+
+class UpdateAssistantRetrievalPolicyTests(SimpleTestCase):
+    @patch("apps.lens_bridge.services.provisioning._assistant_is_chat_managed")
+    @patch("apps.lens_bridge.services.provisioning.indexed_dirs_for_ks")
+    @patch("apps.lens_bridge.services.provisioning.sl_client.request_json")
+    def test_chat_sync_forces_include_hidden_without_excludes(
+        self,
+        request_json,
+        indexed_dirs,
+        is_chat_managed,
+    ):
+        from apps.lens_bridge.services import provisioning
+
+        is_chat_managed.return_value = True
+        indexed_dirs.return_value = [{"path": "/workspace/org-1/ks-42"}]
+        request_json.side_effect = [
+            {
+                "settings": {
+                    "retrieval_policy": {
+                        "include_hidden": False,
+                        "exclude_dirs": [".git"],
+                        "exclude_extensions": [".lock"],
+                    }
+                }
+            },
+            {"uuid": "50b5d33c-7028-4c0b-a3bb-b907db06dfc4"},
+        ]
+        knowledge_source = MagicMock(
+            sl_assistant_uuid="50b5d33c-7028-4c0b-a3bb-b907db06dfc4",
+            ingest_policy_json={"document": True},
+        )
+        gateway_link = MagicMock(
+            sl_lensnode_uuid="de240f46-eccd-4e4b-868f-b1f504fbe67b"
+        )
+
+        provisioning.update_sl_assistant_for_ks(
+            org=MagicMock(key="tenant-one"),
+            ks=knowledge_source,
+            gateway_link=gateway_link,
+        )
+
+        patch_body = request_json.call_args_list[1].kwargs["json_body"]
+        self.assertEqual(
+            patch_body["settings"]["retrieval_policy"],
+            {
+                "include_hidden": True,
+                "exclude_dirs": [],
+                "exclude_extensions": [],
+            },
+        )
+
+    @patch("apps.lens_bridge.services.provisioning._assistant_is_chat_managed")
+    @patch("apps.lens_bridge.services.provisioning.indexed_dirs_for_ks")
+    @patch("apps.lens_bridge.services.provisioning.sl_client.request_json")
+    def test_manual_sync_preserves_operator_retrieval_policy(
+        self,
+        request_json,
+        indexed_dirs,
+        is_chat_managed,
+    ):
+        from apps.lens_bridge.services import provisioning
+
+        is_chat_managed.return_value = False
+        indexed_dirs.return_value = [{"path": "/workspace/org-1/ks-42"}]
+        existing_policy = {
+            "include_hidden": False,
+            "exclude_dirs": [".git", "node_modules"],
+            "exclude_extensions": [".lock"],
+        }
+        request_json.side_effect = [
+            {"settings": {"retrieval_policy": existing_policy}},
+            {"uuid": "50b5d33c-7028-4c0b-a3bb-b907db06dfc4"},
+        ]
+        knowledge_source = MagicMock(
+            sl_assistant_uuid="50b5d33c-7028-4c0b-a3bb-b907db06dfc4",
+            ingest_policy_json={"document": True},
+        )
+        gateway_link = MagicMock(
+            sl_lensnode_uuid="de240f46-eccd-4e4b-868f-b1f504fbe67b"
+        )
+
+        provisioning.update_sl_assistant_for_ks(
+            org=MagicMock(key="tenant-one"),
+            ks=knowledge_source,
+            gateway_link=gateway_link,
+        )
+
+        patch_body = request_json.call_args_list[1].kwargs["json_body"]
+        self.assertEqual(
+            patch_body["settings"]["retrieval_policy"],
+            existing_policy,
+        )
 
 
 class BrowseGatewayDirectoryTests(SimpleTestCase):

--- a/src/backend/apps/lens_bridge/tests/test_retrieval_policy.py
+++ b/src/backend/apps/lens_bridge/tests/test_retrieval_policy.py
@@ -1,0 +1,16 @@
+from django.test import SimpleTestCase
+
+from apps.lens_bridge.services import retrieval_policy
+
+
+class ManagedChatRetrievalPolicyTests(SimpleTestCase):
+    def test_enables_hidden_and_clears_builtin_excludes(self):
+        policy = retrieval_policy.managed_chat_retrieval_policy()
+        self.assertEqual(
+            policy,
+            {
+                "include_hidden": True,
+                "exclude_dirs": [],
+                "exclude_extensions": [],
+            },
+        )


### PR DESCRIPTION
## Summary
- Enable LensNode `include_hidden` for Chat-managed assistants with empty exclude lists so restored user dotfiles remain searchable.
- Apply the policy on Chat assistant create and Chat-owned KS sync only; preserve manual Insight assistant retrieval settings.

## Test plan
- [x] `python manage.py test apps.lens_bridge.tests.test_retrieval_policy apps.lens_bridge.tests.test_provisioning.CreateAssistantModelBindingTests apps.lens_bridge.tests.test_provisioning.UpdateAssistantRetrievalPolicyTests`
- [ ] Create a new Chat with a restored `.`-prefixed file and confirm Copilot can find/answer about it
- [ ] Sync a manual Insight Assistant and confirm custom exclude dirs are preserved


Made with [Cursor](https://cursor.com)