### PR TITLE
fix(ci): align bootstrap progress checks with [....] log markers

### DIFF
--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -884,8 +884,8 @@ grep -F 'registry prefix must include host and namespace' \
 	"${sourcelens_image_builder}" >/dev/null
 
 agent_publisher="${ROOT}/tools/agent/publish.sh"
-if rg -n '"hyperfilelens/agent/internal/remote"' \
-	"${ROOT}/src/agent/internal/enroll" -g '*.go' >/dev/null; then
+if grep -R -n --include='*.go' '"hyperfilelens/agent/internal/remote"' \
+	"${ROOT}/src/agent/internal/enroll" >/dev/null; then
 	printf 'ERROR: first-stage enrollment code must use the lightweight enrollment client\n' >&2
 	exit 1
 fi

--- a/tools/quality/test-bootstrap-download-progress.sh
+++ b/tools/quality/test-bootstrap-download-progress.sh
@@ -39,7 +39,7 @@ export PATH HFL_TEST_CURL_LOG="${tmp}/curl.log"
 
 destination="${tmp}/hfl-enroll"
 output="$(hfl_download "HyperFileLens enrollment helper" https://example.invalid/helper "${destination}" 2>&1)"
-grep -F '[STEP ] Downloading HyperFileLens enrollment helper.' <<<"${output}" >/dev/null
+grep -F '[....] Downloading HyperFileLens enrollment helper.' <<<"${output}" >/dev/null
 grep -F '[ OK  ] HyperFileLens enrollment helper downloaded (' <<<"${output}" >/dev/null
 grep -Fx -- '--progress-bar' "${HFL_TEST_CURL_LOG}" >/dev/null
 grep -Fx -- '--retry' "${HFL_TEST_CURL_LOG}" >/dev/null


### PR DESCRIPTION
## Summary
- Update `test-bootstrap-download-progress.sh` to expect bootstrap `[....]` / `[ OK  ]` markers (fixes TEST Quality gate failure on main).
- Replace `rg` with `grep -R` in `check-release-contracts.sh` so the lightweight-enrollment contract does not silently pass when ripgrep is missing.

## Test plan
- [x] `./tools/quality/test-bootstrap-download-progress.sh`
- [ ] Re-run `HFL - TEST Build & Deploy` on main after merge


Made with [Cursor](https://cursor.com)