### PR TITLE
fix(ci): make source pipeline migration safe for historical models

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -205,9 +205,6 @@ VITE_ENABLE_DEMO_DATA=false
 # Runtime files and Agent publishing
 # ==============================================================================
 
-# Kopia package copied into the development backend image.
-KOPIA_DEB=build/dependencies/kopia/kopia_linux_amd64.deb
-
 # Optional backend media root override; containers default to /opt/backend/media.
 # HFL_MEDIA_ROOT=/opt/backend/media
 

--- a/src/backend/apps/source/migrations/0011_complete_source_backup_pipeline.py
+++ b/src/backend/apps/source/migrations/0011_complete_source_backup_pipeline.py
@@ -40,6 +40,9 @@ def complete_source_backup_pipeline(apps, schema_editor):
     Node = apps.get_model("node", "Node")
     SourceResource = apps.get_model("source", "SourceResource")
     Pipeline = apps.get_model("source", "SourceBackupPipelineEntry")
+    # Historical models do not keep SoftDeleteModel.all_objects unless
+    # use_in_migrations=True; fall back to the default manager.
+    pipeline_rows = getattr(Pipeline, "all_objects", Pipeline.objects)
     Task = apps.get_model("task", "Task")
     TaskResource = apps.get_model("task", "TaskResource")
     BackupConfig = apps.get_model("protection", "BackupConfig")
@@ -54,13 +57,9 @@ def complete_source_backup_pipeline(apps, schema_editor):
             source_ref_id=source.id,
             status__in=("active", "resetting", "reset_failed"),
         ).exists()
-        row = Pipeline.objects.filter(
+        row = pipeline_rows.filter(
             organization_id=source.organization_id, source_kind=kind, ref_id=source.id
         ).first()
-        if row is None:
-            row = Pipeline.all_objects.filter(
-                organization_id=source.organization_id, source_kind=kind, ref_id=source.id
-            ).first()
         if row is None:
             Pipeline.objects.create(
                 organization_id=source.organization_id,

--- a/tools/quality/test-kopia-build-config.sh
+++ b/tools/quality/test-kopia-build-config.sh
@@ -126,12 +126,12 @@ for docker_context_path in \
 	'!build/kopia/dist/linux/amd64/kopia'; do
 	grep -Fx "${docker_context_path}" "${ROOT}/.dockerignore" >/dev/null
 done
-if rg -n 'build/dependencies/kopia|kopia_linux_amd64[.]deb' "${ROOT}/.dockerignore" >/dev/null; then
+if grep -E -n 'build/dependencies/kopia|kopia_linux_amd64[.]deb' "${ROOT}/.dockerignore" >/dev/null; then
 	printf 'ERROR: obsolete Kopia Docker context paths are still configured\n' >&2
 	exit 1
 fi
-if rg -n --glob '!build/**' --glob '!data/**' \
-	--glob '!tools/quality/test-kopia-build-config.sh' -- \
+if grep -R -n -E --exclude-dir=build --exclude-dir=data --exclude-dir=.git \
+	--exclude='test-kopia-build-config.sh' -- \
 	'--kopia-version|KOPIA_DEB|kopia_linux_amd64[.]deb|tools/dependencies/versions/kopia[.]env' \
 	"${ROOT}" >/dev/null; then
 	printf 'ERROR: obsolete Kopia version or deb configuration is still referenced\n' >&2

--- a/tools/quality/test-sentry-runtime-config.sh
+++ b/tools/quality/test-sentry-runtime-config.sh
@@ -297,7 +297,7 @@ assert(!JSON.stringify(event).includes('private'))
 assert(!JSON.stringify(event).includes('secret'))
 JS
 
-if rg -n 'ARG SENTRY_DSN|ENV SENTRY_DSN|import\.meta\.env\.SENTRY' \
+if grep -R -n -E 'ARG SENTRY_DSN|ENV SENTRY_DSN|import\.meta\.env\.SENTRY' \
 	"${ROOT}/deploy/docker/frontend.Dockerfile" \
 	"${ROOT}/src/frontend" >/dev/null; then
 	printf 'ERROR: HFL browser DSN must remain runtime-only\n' >&2


### PR DESCRIPTION
## Summary
- `source.0011` data migration used `Pipeline.all_objects`, which historical migration models do not expose; `AvailabilityMigrationTests` tearDown crashed while re-applying leaf migrations and left the shared test DB without `source_name`.
- Fall back to the default manager for historical models.
- Replace remaining `rg`-only quality checks (`kopia` / `sentry`) and remove obsolete `KOPIA_DEB` from `.env.example` so contracts actually enforce without ripgrep.

## Test plan
- [x] `./tools/quality/test-kopia-build-config.sh`
- [x] `./tools/quality/test-bootstrap-download-progress.sh`
- [ ] Re-run `HFL - TEST Build & Deploy` on main after merge


Made with [Cursor](https://cursor.com)