### PR TITLE
fix(ci): make agent certification mock accept WebSocket preflight

### DIFF
--- a/release/ci/certify-agent-candidate.py
+++ b/release/ci/certify-agent-candidate.py
@@ -312,6 +312,11 @@ class CertificationHandler(http.server.BaseHTTPRequestHandler):
 
     def do_GET(self) -> None:  # noqa: N802
         path = urllib.parse.urlsplit(self.path).path
+        # Enrollment preflight dials the control-plane WebSocket before auth.
+        # Real consoles answer 401/403 on this route; 404 means the path is missing.
+        if path.startswith("/ws/"):
+            self.send_error(403, "authentication required")
+            return
         if path == "/api/v1/node/enrollment/agent/release":
             self.send_json(
                 {

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -736,6 +736,9 @@ grep -F 'python3 -m unittest tools/quality/test_agent_certification_gate.py' "${
 grep -F 'release/ci/certify-agent-candidate.py' "${workflow}" >/dev/null
 grep -F '"KOPIA_USE_KEYRING": "false"' "${agent_certification}" >/dev/null
 grep -F '"KOPIA_PERSIST_CREDENTIALS_ON_CONNECT": "false"' "${agent_certification}" >/dev/null
+# Enrollment preflight treats 403 on /ws/ as reachable; mock must not answer 404.
+grep -F 'path.startswith("/ws/")' "${agent_certification}" >/dev/null
+grep -F 'self.send_error(403, "authentication required")' "${agent_certification}" >/dev/null
 grep -F 'apt source: official Ubuntu (HTTPS after CA bootstrap)' \
 	"${ROOT}/src/agent/scripts/fetch-deps.sh" >/dev/null
 grep -F 'using official Ubuntu sources (HTTPS after CA bootstrap)' \


### PR DESCRIPTION
## Summary
- Agent enrollment preflight (from #316) treats WebSocket `404` as unreachable and accepts `401`/`403` as proof the control-plane route exists.
- Certification mock console previously answered every unknown GET with `404`, so all `Certify · Agent · *` jobs failed with `HFL-PREFLIGHT-002`.
- Mock now returns `403` for `/ws/*`, matching real console behavior before node auth; release contracts lock this in.

## Test plan
- [x] Local mock smoke: `/ws/node/agent/` → 403, `/health` → 200, missing → 404
- [ ] CI: `Certify · Agent · *` jobs pass on TEST Build & Deploy after merge

Made with [Cursor](https://cursor.com)