### PR TITLE
fix(ci): teach agent certification mock installation sessions

### DIFF
--- a/release/ci/certify-agent-candidate.py
+++ b/release/ci/certify-agent-candidate.py
@@ -317,6 +317,13 @@ class CertificationHandler(http.server.BaseHTTPRequestHandler):
         if path.startswith("/ws/"):
             self.send_error(403, "authentication required")
             return
+        if path == "/api/v1/node/health":
+            self.send_json({"status": "ok"})
+            return
+        if path == "/api/v1/node/enrollment/node-status":
+            # Post-install verification waits for a routable online node.
+            self.send_json({"node_id": 1, "status": "online", "routable": True})
+            return
         if path == "/api/v1/node/enrollment/agent/release":
             self.send_json(
                 {
@@ -343,15 +350,39 @@ class CertificationHandler(http.server.BaseHTTPRequestHandler):
         length = int(self.headers.get("Content-Length", "0"))
         if length:
             self.rfile.read(length)
+        if path == "/api/v1/node/enrollment/session":
+            # Enrollment opens a resumable installation session before download.
+            self.send_json(
+                {"installation_session": "hfls_certification", "gateway_scope": ""},
+                status=201,
+            )
+            return
         if path == "/api/v1/node/nodes/heartbeat/":
             self.server.heartbeat_count += 1
-            self.send_json({"node_id": 1, "status": "online"})
+            self.send_json(
+                {
+                    "node_id": 1,
+                    "status": "online",
+                    "node_credential": "hfln_certification",
+                }
+            )
             return
         self.send_error(404)
 
-    def send_json(self, value: dict) -> None:
+    def do_DELETE(self) -> None:  # noqa: N802
+        path = urllib.parse.urlsplit(self.path).path
+        length = int(self.headers.get("Content-Length", "0"))
+        if length:
+            self.rfile.read(length)
+        if path == "/api/v1/node/enrollment/session":
+            self.send_response(204)
+            self.end_headers()
+            return
+        self.send_error(404)
+
+    def send_json(self, value: dict, *, status: int = 200) -> None:
         data = json.dumps(value).encode("utf-8")
-        self.send_response(200)
+        self.send_response(status)
         self.send_header("Content-Type", "application/json")
         self.send_header("Content-Length", str(len(data)))
         self.end_headers()

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -739,6 +739,16 @@ grep -F '"KOPIA_PERSIST_CREDENTIALS_ON_CONNECT": "false"' "${agent_certification
 # Enrollment preflight treats 403 on /ws/ as reachable; mock must not answer 404.
 grep -F 'path.startswith("/ws/")' "${agent_certification}" >/dev/null
 grep -F 'self.send_error(403, "authentication required")' "${agent_certification}" >/dev/null
+# Installer overhaul (#316) opens an installation session and waits for node-status.
+grep -F '/api/v1/node/enrollment/session' "${agent_certification}" >/dev/null
+grep -F 'installation_session' "${agent_certification}" >/dev/null
+grep -F '/api/v1/node/enrollment/node-status' "${agent_certification}" >/dev/null
+grep -F '"routable": True' "${agent_certification}" >/dev/null
+# Installer overhaul (#316) opens an installation session and waits for node-status.
+grep -F '/api/v1/node/enrollment/session' "${agent_certification}" >/dev/null
+grep -F 'installation_session' "${agent_certification}" >/dev/null
+grep -F '/api/v1/node/enrollment/node-status' "${agent_certification}" >/dev/null
+grep -F '"routable": True' "${agent_certification}" >/dev/null
 grep -F 'apt source: official Ubuntu (HTTPS after CA bootstrap)' \
 	"${ROOT}/src/agent/scripts/fetch-deps.sh" >/dev/null
 grep -F 'using official Ubuntu sources (HTTPS after CA bootstrap)' \


### PR DESCRIPTION
## Summary
- After WebSocket preflight (#343), certify still failed with `HFL-INSTALL-002` because the mock console had no `/api/v1/node/enrollment/session` route.
- Mock now issues installation sessions (201), accepts session release (DELETE), returns `node_credential` on heartbeat, and reports routable `online` on `node-status`.
- Release contracts lock these endpoints in so certify stays aligned with the #316 installer flow.

## Test plan
- [x] Local mock smoke for session / heartbeat / node-status / DELETE / health / ws
- [ ] CI: all `Certify · Agent · *` jobs pass on TEST Build & Deploy

Made with [Cursor](https://cursor.com)