### PR TITLE
fix(ci): retry draft Release uploads on temporary not-found errors

### DIFF
--- a/.github/workflows/artifact_pipeline.yml
+++ b/.github/workflows/artifact_pipeline.yml
@@ -242,6 +242,7 @@ jobs:
           ./tools/quality/test-language-pack-runtime-index.sh
           ./tools/quality/test-docker-image-digest-alias.sh
           ./tools/quality/test-docker-pull-retry.sh
+          ./tools/quality/test-gh-release-upload-retry.sh
           ./tools/quality/test-offline-docker-package-plan.sh
           ./tools/quality/test-upgrade-backup-retention.sh
           ./tools/quality/test-blue-green-recovery.sh
@@ -387,7 +388,7 @@ jobs:
           output="_internal-${{ matrix.component }}.json"
           ./release/ci/write-image-metadata.sh \
             "${{ matrix.component }}" "$IMAGE_REF" "$IMAGE_DIGEST" "$output"
-          gh release upload "${{ needs.prepare.outputs.tag }}" "$output" --clobber
+          ./release/ci/gh-release-upload.sh "${{ needs.prepare.outputs.tag }}" "$output" --clobber
 
       - name: Disk report
         if: always()
@@ -435,7 +436,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release upload "${{ needs.prepare.outputs.tag }}" \
+          ./release/ci/gh-release-upload.sh "${{ needs.prepare.outputs.tag }}" \
             "_internal-sourcelens-${{ matrix.component }}.json" --clobber
 
       - name: Disk report and cleanup
@@ -487,7 +488,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release upload "${{ needs.prepare.outputs.tag }}" \
+          ./release/ci/gh-release-upload.sh "${{ needs.prepare.outputs.tag }}" \
             "_internal-agent-${{ matrix.asset }}.tar" --clobber
 
   certify-source-host:
@@ -569,7 +570,7 @@ jobs:
         run: |
           report="build/certification/_internal-agent-cert-${{ matrix.asset }}.json"
           if [[ -s "$report" ]]; then
-            gh release upload "${{ needs.prepare.outputs.tag }}" "$report" --clobber
+            ./release/ci/gh-release-upload.sh "${{ needs.prepare.outputs.tag }}" "$report" --clobber
           fi
 
   agent-release-gate:
@@ -614,7 +615,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: >-
-          gh release upload "${{ needs.prepare.outputs.tag }}"
+          ./release/ci/gh-release-upload.sh "${{ needs.prepare.outputs.tag }}"
           build/certification/_internal-agent-certification-summary.json --clobber
 
   build-host-debs:
@@ -653,7 +654,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: >-
-          gh release upload "${{ needs.prepare.outputs.tag }}"
+          ./release/ci/gh-release-upload.sh "${{ needs.prepare.outputs.tag }}"
           "_internal-host-debs-${{ matrix.asset }}.tar" --clobber
 
   export-hfl-images:
@@ -687,7 +688,7 @@ jobs:
       - name: Upload offline HFL archive
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release upload "${{ needs.prepare.outputs.tag }}" _internal-hfl-images.tar --clobber
+        run: ./release/ci/gh-release-upload.sh "${{ needs.prepare.outputs.tag }}" _internal-hfl-images.tar --clobber
 
   export-sourcelens-bundle:
     name: Package · SourceLens
@@ -722,7 +723,7 @@ jobs:
       - name: Upload bundled SourceLens runtime
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release upload "${{ needs.prepare.outputs.tag }}" _internal-sourcelens-bundle.tar --clobber
+        run: ./release/ci/gh-release-upload.sh "${{ needs.prepare.outputs.tag }}" _internal-sourcelens-bundle.tar --clobber
 
   export-runtime-images:
     name: Package · Runtime images
@@ -743,7 +744,7 @@ jobs:
       - name: Upload runtime images
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release upload "${{ needs.prepare.outputs.tag }}" _internal-runtime-images.tar --clobber
+        run: ./release/ci/gh-release-upload.sh "${{ needs.prepare.outputs.tag }}" _internal-runtime-images.tar --clobber
 
   assemble-release:
     name: Assemble · Release
@@ -786,7 +787,7 @@ jobs:
           done < <(gh release view "${{ needs.prepare.outputs.tag }}" --json assets \
             --jq '.assets[] | select(.name | startswith("_internal-") | not) | .name')
           while IFS= read -r asset; do
-            gh release upload "${{ needs.prepare.outputs.tag }}" \
+            ./release/ci/gh-release-upload.sh "${{ needs.prepare.outputs.tag }}" \
               "build/release/dist/${asset}" --clobber
           done < build/release/release-assets.txt
       - name: Disk report

--- a/release/ci/gh-release-upload.sh
+++ b/release/ci/gh-release-upload.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Upload assets to a GitHub Release with a short bound for draft visibility races.
+#
+# Usage:
+#   gh-release-upload.sh TAG FILE [FILE...] [--clobber]
+#
+# Retries only when gh reports "release not found" (draft Main releases can lag
+# briefly after prepare). Defaults stay small: 5 attempts, 3s delay (~15s max).
+set -euo pipefail
+
+tag=${1:-}
+shift || true
+if [[ -z "${tag}" || $# -lt 1 ]]; then
+	printf 'usage: gh-release-upload.sh TAG FILE [FILE...] [--clobber]\n' >&2
+	exit 2
+fi
+
+attempts="${HFL_RELEASE_UPLOAD_ATTEMPTS:-5}"
+delay_s="${HFL_RELEASE_UPLOAD_DELAY_S:-3}"
+if ! [[ "${attempts}" =~ ^[1-9][0-9]*$ ]]; then
+	printf 'ERROR: HFL_RELEASE_UPLOAD_ATTEMPTS must be a positive integer\n' >&2
+	exit 2
+fi
+if ! [[ "${delay_s}" =~ ^[0-9]+$ ]]; then
+	printf 'ERROR: HFL_RELEASE_UPLOAD_DELAY_S must be a non-negative integer\n' >&2
+	exit 2
+fi
+
+is_retryable() {
+	local log=$1
+	# Match the gh CLI message seen when a just-created draft Release is not
+	# visible yet. Do not broaden this to generic HTTP 404s.
+	grep -Fiq 'release not found' "${log}"
+}
+
+tmp="$(mktemp)"
+trap 'rm -f "${tmp}"' EXIT
+
+attempt=1
+while ((attempt <= attempts)); do
+	set +e
+	gh release upload "${tag}" "$@" >"${tmp}" 2>&1
+	rc=$?
+	set -e
+	if [[ "${rc}" -eq 0 ]]; then
+		[[ ! -s "${tmp}" ]] || cat "${tmp}"
+		exit 0
+	fi
+	cat "${tmp}" >&2
+	if ! is_retryable "${tmp}" || ((attempt == attempts)); then
+		exit "${rc}"
+	fi
+	printf 'Release %s upload not ready (attempt %s/%s); retrying in %ss.\n' \
+		"${tag}" "${attempt}" "${attempts}" "${delay_s}" >&2
+	sleep "${delay_s}"
+	attempt=$((attempt + 1))
+done
+
+exit 1

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -1037,6 +1037,16 @@ grep -F 'project in {"hyperfilelens-sourcelens", "sourcelens"}' "${remote_deploy
 grep -F './tools/quality/test-shared-host-guard.sh' "${workflow}" >/dev/null
 grep -F './tools/quality/test-release-download-proxy.sh' "${workflow}" >/dev/null
 grep -F './tools/quality/test-default-certificates.sh' "${workflow}" >/dev/null
+grep -F './tools/quality/test-gh-release-upload-retry.sh' "${workflow}" >/dev/null
+grep -F './release/ci/gh-release-upload.sh' "${workflow}" >/dev/null
+grep -F 'HFL_RELEASE_UPLOAD_ATTEMPTS:-5' \
+	"${ROOT}/release/ci/gh-release-upload.sh" >/dev/null
+grep -F 'HFL_RELEASE_UPLOAD_DELAY_S:-3' \
+	"${ROOT}/release/ci/gh-release-upload.sh" >/dev/null
+if grep -E '(^|[[:space:]])gh release upload[[:space:]]' "${workflow}" >/dev/null; then
+	printf 'ERROR: artifact pipeline must upload Release assets through gh-release-upload.sh\n' >&2
+	exit 1
+fi
 grep -F './tools/quality/test-gateway-bootstrap-health.sh' "${workflow}" >/dev/null
 grep -F './tools/quality/test-gateway-lifecycle-upgrade.sh' "${workflow}" >/dev/null
 grep -F './tools/quality/test-platform-gateway-auto-deploy.sh' "${workflow}" >/dev/null
@@ -1188,6 +1198,8 @@ for executable in \
 	"${ROOT}/.github/scripts/remote-deploy.sh" \
 	"${ROOT}/tools/quality/check-python38-runtime.py" \
 	"${ROOT}/tools/quality/test-docker-pull-retry.sh" \
+	"${ROOT}/tools/quality/test-gh-release-upload-retry.sh" \
+	"${ROOT}/release/ci/gh-release-upload.sh" \
 	"${ROOT}/tools/quality/test-main-channel-contracts.sh" \
 	"${ROOT}/tools/quality/test-main-release-freshness.sh" \
 	"${ROOT}/tools/quality/test-main-release-cleanup.sh" \

--- a/tools/quality/test-gh-release-upload-retry.sh
+++ b/tools/quality/test-gh-release-upload-retry.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Validate bounded GitHub Release upload retries for draft visibility races.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+upload="${ROOT}/release/ci/gh-release-upload.sh"
+tmp="$(mktemp -d)"
+trap 'rm -rf "${tmp}"' EXIT
+mkdir -p "${tmp}/bin" "${tmp}/state"
+: >"${tmp}/asset.bin"
+
+cat >"${tmp}/bin/gh" <<'MOCK'
+#!/usr/bin/env bash
+set -euo pipefail
+[[ "${1:-}" == "release" && "${2:-}" == "upload" ]] || exit 2
+count_file="${HFL_GH_TEST_STATE}/count"
+count=0
+[[ ! -f "${count_file}" ]] || count="$(cat "${count_file}")"
+count=$((count + 1))
+printf '%s\n' "${count}" >"${count_file}"
+case "${HFL_GH_TEST_MODE}" in
+flaky)
+	if [[ "${count}" -eq 1 ]]; then
+		printf 'release not found\n' >&2
+		exit 1
+	fi
+	;;
+missing)
+	printf 'release not found\n' >&2
+	exit 1
+	;;
+fatal)
+	printf 'HTTP 403: Resource not accessible by integration\n' >&2
+	exit 1
+	;;
+success) ;;
+*) exit 2 ;;
+esac
+MOCK
+chmod +x "${tmp}/bin/gh"
+export PATH="${tmp}/bin:${PATH}"
+export HFL_GH_TEST_STATE="${tmp}/state"
+export HFL_RELEASE_UPLOAD_DELAY_S=0
+
+printf '0\n' >"${tmp}/state/count"
+export HFL_GH_TEST_MODE=flaky
+HFL_RELEASE_UPLOAD_ATTEMPTS=3 bash "${upload}" main-deadbeef "${tmp}/asset.bin" --clobber
+[[ "$(cat "${tmp}/state/count")" == "2" ]]
+
+printf '0\n' >"${tmp}/state/count"
+export HFL_GH_TEST_MODE=fatal
+if HFL_RELEASE_UPLOAD_ATTEMPTS=3 bash "${upload}" main-deadbeef "${tmp}/asset.bin" --clobber; then
+	printf 'ERROR: non-retryable upload failure unexpectedly succeeded\n' >&2
+	exit 1
+fi
+[[ "$(cat "${tmp}/state/count")" == "1" ]]
+
+printf '0\n' >"${tmp}/state/count"
+export HFL_GH_TEST_MODE=missing
+if HFL_RELEASE_UPLOAD_ATTEMPTS=3 bash "${upload}" main-deadbeef "${tmp}/asset.bin" --clobber; then
+	printf 'ERROR: exhausted release-not-found retries unexpectedly succeeded\n' >&2
+	exit 1
+fi
+[[ "$(cat "${tmp}/state/count")" == "3" ]]
+
+printf 'GitHub Release upload retry checks passed.\n'


### PR DESCRIPTION
## Summary
- Add `release/ci/gh-release-upload.sh` with a short bound (5 attempts, 3s delay) that retries only `release not found`.
- Route all artifact-pipeline Release uploads through the helper.
- Cover the retry behavior with a quality test and release-contract checks.

## Test plan
- [x] `bash tools/quality/test-gh-release-upload-retry.sh`
- [x] `bash tools/quality/check-release-contracts.sh`
- [ ] Next scheduled/manual TEST build should no longer fail solely on draft Release upload races


Made with [Cursor](https://cursor.com)