### PR TITLE
fix(protection): async directory du precache on backup config save

### DIFF
--- a/src/backend/apps/protection/api/serializers/backup_config.py
+++ b/src/backend/apps/protection/api/serializers/backup_config.py
@@ -18,6 +18,11 @@ class BackupConfigDirectorySerializer(serializers.ModelSerializer):
             "sort_order",
         ]
 
+    def to_representation(self, instance):
+        data = super().to_representation(instance)
+        data["estimated_size_bytes"] = max(0, int(data.get("estimated_size_bytes") or 0))
+        return data
+
 
 class BackupConfigListSerializer(serializers.ModelSerializer):
     directory_count = serializers.SerializerMethodField()

--- a/src/backend/apps/protection/api/views/backup_config.py
+++ b/src/backend/apps/protection/api/views/backup_config.py
@@ -24,6 +24,12 @@ from apps.protection.selectors.backup_config import (
     get_backup_config,
 )
 from apps.protection import services as protection_services
+from apps.protection.services.directory_size_estimate import (
+    backup_config_needs_directory_estimate_refresh,
+)
+from apps.protection.tasks.directory_size_estimate import (
+    refresh_backup_config_directory_estimates_task,
+)
 from apps.protection.tasks.repository_policy import sync_backup_config_repository_policy_task
 
 
@@ -31,6 +37,24 @@ def _validation_error(exc: DjangoValidationError) -> ValidationError:
     if hasattr(exc, "message_dict"):
         return ValidationError(exc.message_dict)
     return ValidationError({"detail": exc.messages})
+
+
+def _queue_directory_estimate_precache(config: BackupConfig) -> None:
+    if not backup_config_needs_directory_estimate_refresh(config):
+        return
+    transaction.on_commit(
+        lambda config_id=config.id: refresh_backup_config_directory_estimates_task.delay(
+            config_id=config_id
+        )
+    )
+
+
+def _update_touches_directory_estimate_inputs(data: dict) -> bool:
+    """True when update may require (re)caching directory du estimates."""
+    return any(
+        field in data
+        for field in ("directories", "source_type", "source_ref_id")
+    )
 
 
 class BackupConfigViewSet(viewsets.ModelViewSet):
@@ -84,8 +108,11 @@ class BackupConfigViewSet(viewsets.ModelViewSet):
         except DjangoValidationError as exc:
             raise _validation_error(exc) from exc
         transaction.on_commit(
-            lambda config_id=config.id: sync_backup_config_repository_policy_task.delay(config_id=config_id)
+            lambda config_id=config.id: sync_backup_config_repository_policy_task.delay(
+                config_id=config_id
+            )
         )
+        _queue_directory_estimate_precache(config)
         return Response(
             BackupConfigDetailSerializer(config).data,
             status=status.HTTP_201_CREATED,
@@ -108,8 +135,14 @@ class BackupConfigViewSet(viewsets.ModelViewSet):
         except DjangoValidationError as exc:
             raise _validation_error(exc) from exc
         transaction.on_commit(
-            lambda config_id=config.id: sync_backup_config_repository_policy_task.delay(config_id=config_id)
+            lambda config_id=config.id: sync_backup_config_repository_policy_task.delay(
+                config_id=config_id
+            )
         )
+        # Name/remark-only edits must not re-hammer path.size for leftover pending
+        # estimates; create and directory/source changes still enqueue.
+        if _update_touches_directory_estimate_inputs(serializer.validated_data):
+            _queue_directory_estimate_precache(config)
         return Response(BackupConfigDetailSerializer(config).data)
 
     def partial_update(self, request, *args, **kwargs):

--- a/src/backend/apps/protection/services/backup_config.py
+++ b/src/backend/apps/protection/services/backup_config.py
@@ -125,7 +125,7 @@ def create_backup_config(
                 path=d["path"],
                 path_type=d.get("path_type", BackupConfigDirectory.PathType.UNKNOWN),
                 display_name=d.get("display_name", ""),
-                estimated_size_bytes=d.get("estimated_size_bytes", 0),
+                estimated_size_bytes=max(0, int(d.get("estimated_size_bytes", 0) or 0)),
                 sort_order=idx,
             ))
         created_dirs = BackupConfigDirectory.objects.bulk_create(dirs)
@@ -1016,9 +1016,41 @@ def _sync_backup_config_directories(
                 backup_config=config,
                 path=path,
             )
-        directory.path_type = directory_data.get("path_type", BackupConfigDirectory.PathType.UNKNOWN)
+        previous_path_type = str(directory.path_type or "").strip().lower() if directory.pk else ""
+        incoming_path_type = str(
+            directory_data.get("path_type", BackupConfigDirectory.PathType.UNKNOWN)
+            or BackupConfigDirectory.PathType.UNKNOWN
+        ).strip().lower()
+        # Clients often omit path_type; validator then sends "unknown". Keep the
+        # stored concrete type so we do not falsely invalidate du caches.
+        if (
+            directory.pk is not None
+            and incoming_path_type in {"", "unknown"}
+            and previous_path_type in {"directory", "file"}
+        ):
+            directory.path_type = previous_path_type
+        else:
+            directory.path_type = incoming_path_type or BackupConfigDirectory.PathType.UNKNOWN
         directory.display_name = directory_data.get("display_name", "")
-        directory.estimated_size_bytes = directory_data.get("estimated_size_bytes", 0)
+        # Preserve cached du estimates when the client omits/zeros the field on
+        # unchanged paths. New paths and explicit directory<->file changes
+        # invalidate the cache so async pre-cache can refresh them.
+        incoming_estimate = directory_data.get("estimated_size_bytes", None)
+        next_path_type = str(directory.path_type or "").strip().lower()
+        if incoming_estimate is not None and int(incoming_estimate or 0) > 0:
+            directory.estimated_size_bytes = int(incoming_estimate)
+        elif directory.pk is None:
+            directory.estimated_size_bytes = max(0, int(incoming_estimate or 0))
+        elif (
+            previous_path_type in {"directory", "file"}
+            and next_path_type in {"directory", "file"}
+            and previous_path_type != next_path_type
+        ):
+            directory.estimated_size_bytes = 0
+        elif int(directory.estimated_size_bytes or 0) < 0:
+            # Unavailable marker from a failed precache: an explicit directories
+            # sync re-opens async retry (positive caches above stay intact).
+            directory.estimated_size_bytes = 0
         directory.sort_order = idx
         directory.save()
         created_or_updated.append(directory)
@@ -1158,6 +1190,16 @@ def update_backup_config(
                 config=config,
                 directories_data=directories_data,
             )
+        source_changed = (
+            str(payload["source_type"]) != str(previous_source_type)
+            or int(payload["source_ref_id"]) != int(previous_source_ref_id)
+        )
+        if source_changed:
+            from apps.protection.services.directory_size_estimate import (
+                invalidate_backup_config_directory_estimates,
+            )
+
+            invalidate_backup_config_directory_estimates(config=config)
         config.refresh_from_db()
     logger.info(
         "backup config update ok config_id=%s org_id=%s repository_id=%s",

--- a/src/backend/apps/protection/services/backup_orchestrator.py
+++ b/src/backend/apps/protection/services/backup_orchestrator.py
@@ -1977,6 +1977,10 @@ def advance_backup(
             "status": Task.Status.FAILED,
         }
 
+    # Directory size estimates are pre-cached asynchronously on backup-config save.
+    # Do not sync path.size here: it contends with Celery soft limits and can load
+    # the source host at backup start. Progress degrades when du_total is still 0.
+
     try:
         repository_payload = _repository_payload_for_backup(
             task=task,

--- a/src/backend/apps/protection/services/backup_task.py
+++ b/src/backend/apps/protection/services/backup_task.py
@@ -621,16 +621,8 @@ def start_backup_tasks(
                         source_ref_id=source.source_ref_id,
                         repository_id=repository.id,
                     )
-                from apps.protection.services.directory_size_estimate import (
-                    ensure_backup_config_directory_estimates,
-                )
-
-                ensure_backup_config_directory_estimates(
-                    organization_id=organization_id,
-                    config=config,
-                    source_type=source.source_type,
-                    source_ref_id=source.source_ref_id,
-                )
+                # Directory size (du) is pre-cached asynchronously on config save.
+                # Progress degrades when estimates are still missing. Never block Backup Now.
             except ValidationError as exc:
                 skipped_count += 1
                 results.append(

--- a/src/backend/apps/protection/services/directory_size_estimate.py
+++ b/src/backend/apps/protection/services/directory_size_estimate.py
@@ -1,26 +1,45 @@
-"""Ensure backup config directories have du-based size estimates before backup."""
+"""Directory size (du) estimates for backup progress — never a sync start gate."""
 
 from __future__ import annotations
 
 import logging
 from typing import Any
 
+from celery.exceptions import SoftTimeLimitExceeded
 from django.core.exceptions import ValidationError
 
 from apps.node.services.interface import run_agent_task_sync
-from apps.protection.models import BackupConfig, BackupConfigDirectory
+from apps.protection.models import BackupConfig, BackupConfigDirectory, BackupSourceSnapshot
 from apps.protection.services.backup_task import ExecutionTarget, _resolve_execution_target
-from apps.protection.models import BackupSourceSnapshot
 from apps.source.services.internal.nas_share_path import to_mount_path
 
 logger = logging.getLogger(__name__)
 
 _PATH_SIZE_KIND = "path.size"
+# Legacy sync callers (if any) may still use a long wait; async precache uses a
+# shorter per-path budget so multiple directories fit under the Celery soft limit.
 _PATH_SIZE_TIMEOUT_SECONDS = 300
+_PRECACHE_PATH_TIMEOUT_SECONDS = 60
+_PRECACHE_MAX_ATTEMPTS = 5
+# Stored when path.size was attempted but failed/empty. Progress treats as 0;
+# gating skips re-queue until the cache is invalidated back to 0.
+_ESTIMATE_UNAVAILABLE = -1
 
 
 class DirectorySizeEstimateError(ValidationError):
-    """Raised when directory size cannot be estimated."""
+    """Raised when directory size cannot be estimated.
+
+    permanent=True means the path should not be retried until cache invalidation
+    (e.g. empty/zero result). Timeouts and transient agent errors stay retryable.
+    """
+
+    def __init__(self, message, *, permanent: bool = False, code=None, params=None):
+        super().__init__(message, code=code, params=params)
+        self.permanent = bool(permanent)
+
+
+class DirectorySizeEstimateResolveError(Exception):
+    """Raised when the backup execution target cannot be resolved for du precache."""
 
 
 def _agent_path_for_directory(
@@ -41,7 +60,13 @@ def estimate_directory_size_bytes(
     path_type: str = "directory",
     organization_id: int,
     execution_target: ExecutionTarget,
+    wait_timeout_seconds: int | None = None,
 ) -> int:
+    timeout = (
+        _PATH_SIZE_TIMEOUT_SECONDS
+        if wait_timeout_seconds is None
+        else max(1, int(wait_timeout_seconds))
+    )
     payload: dict[str, Any] = {
         "path": path,
         "path_type": path_type,
@@ -53,64 +78,244 @@ def estimate_directory_size_bytes(
         node_id=node_id,
         kind=_PATH_SIZE_KIND,
         payload=payload,
-        wait_timeout_seconds=_PATH_SIZE_TIMEOUT_SECONDS,
+        wait_timeout_seconds=timeout,
     )
     if outcome.timed_out:
-        raise DirectorySizeEstimateError(f"Path size estimation timed out for {path}")
+        raise DirectorySizeEstimateError(
+            f"Path size estimation timed out for {path}",
+            permanent=False,
+        )
     if not outcome.ok:
         error = str(outcome.task.last_error or "").strip()
         if not error and isinstance(outcome.stream_message, dict):
-            error = str(outcome.stream_message.get("error") or outcome.stream_message.get("message") or "")
+            error = str(
+                outcome.stream_message.get("error")
+                or outcome.stream_message.get("message")
+                or ""
+            )
         if not error:
             error = "path size estimation failed"
-        raise DirectorySizeEstimateError(error)
+        # Agent/host blips are retryable; leave estimate pending for requeue.
+        raise DirectorySizeEstimateError(error, permanent=False)
     result = outcome.result
     size_bytes = int(result.get("size_bytes") or 0)
     if size_bytes <= 0:
-        raise DirectorySizeEstimateError(f"Path size estimate returned zero for {path}")
+        raise DirectorySizeEstimateError(
+            f"Path size estimate returned zero for {path}",
+            permanent=True,
+        )
     return size_bytes
 
 
-def ensure_backup_config_directory_estimates(
+def _raw_estimate(directory: BackupConfigDirectory) -> int:
+    return int(directory.estimated_size_bytes or 0)
+
+
+def _directory_estimate_pending(directory: BackupConfigDirectory) -> bool:
+    """True when estimate has never been successfully cached or marked unavailable."""
+    return _raw_estimate(directory) == 0
+
+
+def _du_total_from_directories(directories) -> int:
+    total = 0
+    for directory in directories:
+        total += max(0, _raw_estimate(directory))
+    return total
+
+
+def _du_total(config: BackupConfig) -> int:
+    return _du_total_from_directories(config.directories.all())
+
+
+def backup_config_needs_directory_estimate_refresh(config: BackupConfig) -> bool:
+    """True when at least one directory still needs a path.size attempt."""
+    return any(
+        _directory_estimate_pending(directory)
+        for directory in config.directories.all()
+    )
+
+
+def invalidate_backup_config_directory_estimates(*, config: BackupConfig) -> int:
+    """Clear cached estimates so async precache will retry (e.g. source rebinding)."""
+    return int(
+        config.directories.exclude(estimated_size_bytes=0).update(estimated_size_bytes=0)
+    )
+
+
+def _mark_pending_directory_estimates_unavailable(*, config: BackupConfig) -> int:
+    """Stop retrying pending paths until an explicit cache invalidation."""
+    return int(
+        config.directories.filter(estimated_size_bytes=0).update(
+            estimated_size_bytes=_ESTIMATE_UNAVAILABLE
+        )
+    )
+
+
+def refresh_missing_backup_config_directory_estimates(
     *,
     organization_id: int,
     config: BackupConfig,
     source_type: str,
     source_ref_id: int,
+    wait_timeout_seconds: int | None = None,
 ) -> int:
-    """Refresh missing estimates via Agent; return du_total. Raises if any path stays zero."""
+    """Best-effort refresh of missing directory estimates.
+
+    Failures are logged and skipped. Returns the sum of known estimates (may be 0).
+    Progress UI degrades when the total is 0; backup must not fail because of this.
+
+    Raises DirectorySizeEstimateResolveError when the execution target cannot be
+    resolved (caller may requeue within the attempt budget).
+    """
+    directories = list(config.directories.all())
+    if not any(_directory_estimate_pending(directory) for directory in directories):
+        return _du_total_from_directories(directories)
+
     snapshot_stub = BackupSourceSnapshot(
         organization_id=organization_id,
         source_type=source_type,
         source_ref_id=source_ref_id,
         backup_config_id=config.id,
     )
-    execution_target = _resolve_execution_target(source_snapshot=snapshot_stub)
+    try:
+        execution_target = _resolve_execution_target(source_snapshot=snapshot_stub)
+    except Exception as exc:
+        logger.exception(
+            "directory_size_estimate_resolve_failed config_id=%s source=%s:%s",
+            config.id,
+            source_type,
+            source_ref_id,
+        )
+        raise DirectorySizeEstimateResolveError(str(exc) or "resolve failed") from exc
+
     node_id = int(execution_target.node.id)
     du_total = 0
-    for directory in config.directories.all():
-        current = max(0, int(directory.estimated_size_bytes or 0))
-        if current <= 0:
-            agent_path = _agent_path_for_directory(directory=directory, execution_target=execution_target)
-            path_type = str(directory.path_type or "directory").strip().lower() or "directory"
-            estimated = estimate_directory_size_bytes(
-                node_id=node_id,
-                path=agent_path,
-                path_type=path_type,
-                organization_id=organization_id,
+    for directory in directories:
+        current = max(0, _raw_estimate(directory))
+        if _directory_estimate_pending(directory):
+            agent_path = _agent_path_for_directory(
+                directory=directory,
                 execution_target=execution_target,
             )
+            path_type = (
+                str(directory.path_type or "directory").strip().lower() or "directory"
+            )
+            try:
+                estimated = estimate_directory_size_bytes(
+                    node_id=node_id,
+                    path=agent_path,
+                    path_type=path_type,
+                    organization_id=organization_id,
+                    execution_target=execution_target,
+                    wait_timeout_seconds=wait_timeout_seconds,
+                )
+            except SoftTimeLimitExceeded:
+                raise
+            except DirectorySizeEstimateError as exc:
+                logger.warning(
+                    "directory_size_estimate_failed config_id=%s directory_id=%s "
+                    "path=%s permanent=%s error=%s",
+                    config.id,
+                    directory.id,
+                    agent_path,
+                    exc.permanent,
+                    exc,
+                )
+                if exc.permanent:
+                    directory.estimated_size_bytes = _ESTIMATE_UNAVAILABLE
+                    directory.save(update_fields=["estimated_size_bytes", "updated_at"])
+                continue
+            except Exception as exc:
+                # Unexpected errors stay retryable (estimate remains 0).
+                logger.warning(
+                    "directory_size_estimate_failed config_id=%s directory_id=%s "
+                    "path=%s error=%s",
+                    config.id,
+                    directory.id,
+                    agent_path,
+                    exc,
+                )
+                continue
             directory.estimated_size_bytes = estimated
             directory.save(update_fields=["estimated_size_bytes", "updated_at"])
             current = estimated
             logger.info(
-                "directory_size_estimated config_id=%s directory_id=%s path=%s size_bytes=%s",
+                "directory_size_estimated config_id=%s directory_id=%s path=%s "
+                "size_bytes=%s",
                 config.id,
                 directory.id,
                 agent_path,
                 estimated,
             )
         du_total += current
-    if du_total <= 0:
-        raise DirectorySizeEstimateError("Backup cannot start without directory size estimates (du).")
     return du_total
+
+
+def refresh_backup_config_directory_estimates_by_id(
+    *,
+    config_id: int,
+    attempt: int = 1,
+) -> dict[str, Any]:
+    """Celery entry: pre-cache missing estimates for one backup config."""
+    attempt_n = max(1, int(attempt or 1))
+    config = BackupConfig.objects.filter(id=int(config_id)).first()
+    if config is None:
+        return {
+            "config_id": int(config_id),
+            "status": "missing",
+            "du_total": 0,
+            "attempt": attempt_n,
+            "should_requeue": False,
+        }
+
+    timed_out = False
+    resolve_failed = False
+    try:
+        du_total = refresh_missing_backup_config_directory_estimates(
+            organization_id=int(config.organization_id),
+            config=config,
+            source_type=str(config.source_type),
+            source_ref_id=int(config.source_ref_id),
+            wait_timeout_seconds=_PRECACHE_PATH_TIMEOUT_SECONDS,
+        )
+    except SoftTimeLimitExceeded:
+        timed_out = True
+        logger.warning(
+            "directory_size_estimate_soft_time_limit config_id=%s attempt=%s",
+            config.id,
+            attempt_n,
+        )
+        du_total = _du_total(config)
+    except DirectorySizeEstimateResolveError:
+        resolve_failed = True
+        du_total = _du_total(config)
+
+    still_pending = backup_config_needs_directory_estimate_refresh(config)
+    should_requeue = bool(still_pending and attempt_n < _PRECACHE_MAX_ATTEMPTS)
+    # Only freeze when the source/target cannot be resolved: retryable path.size
+    # timeouts stay at 0 so a later directories/source save can precache again.
+    # Name-only updates do not enqueue (see backup_config views).
+    if resolve_failed and still_pending and not should_requeue:
+        _mark_pending_directory_estimates_unavailable(config=config)
+
+    if timed_out and should_requeue:
+        status = "soft_time_limit"
+    elif timed_out and still_pending:
+        status = "soft_time_limit_exhausted"
+    elif resolve_failed and should_requeue:
+        status = "resolve_failed"
+    elif resolve_failed:
+        status = "resolve_exhausted"
+    elif should_requeue:
+        status = "partial"
+    elif still_pending:
+        status = "exhausted"
+    else:
+        status = "ok"
+    return {
+        "config_id": int(config.id),
+        "status": status,
+        "du_total": int(du_total),
+        "attempt": attempt_n,
+        "should_requeue": should_requeue,
+    }

--- a/src/backend/apps/protection/tasks/__init__.py
+++ b/src/backend/apps/protection/tasks/__init__.py
@@ -9,6 +9,7 @@ from .backup_config_reset import (
     reconcile_stuck_backup_config_reset_tasks_task,
 )
 from .policy_execution import run_backup_policy_maintenance_task
+from .directory_size_estimate import refresh_backup_config_directory_estimates_task
 from .repository_policy import sync_backup_config_repository_policy_task
 from .snapshot_delete import execute_snapshot_delete_task, reconcile_snapshot_delete_tasks_task
 from .snapshot_download import execute_snapshot_download_task
@@ -23,6 +24,7 @@ __all__ = [
     "execute_snapshot_download_task",
     "reconcile_backup_tasks_task",
     "reconcile_interrupted_backup_tasks_task",
+    "refresh_backup_config_directory_estimates_task",
     "run_backup_policy_maintenance_task",
     "sync_backup_config_repository_policy_task",
 ]

--- a/src/backend/apps/protection/tasks/directory_size_estimate.py
+++ b/src/backend/apps/protection/tasks/directory_size_estimate.py
@@ -1,0 +1,30 @@
+from celery import shared_task
+
+from apps.protection.services.directory_size_estimate import (
+    refresh_backup_config_directory_estimates_by_id,
+)
+
+_REQUEUE_COUNTDOWN_SECONDS = 5
+
+
+@shared_task(
+    name="apps.protection.tasks.directory_size_estimate.refresh_backup_config_directory_estimates",
+    soft_time_limit=360,
+    time_limit=420,
+)
+def refresh_backup_config_directory_estimates_task(
+    *,
+    config_id: int,
+    attempt: int = 1,
+) -> dict:
+    result = refresh_backup_config_directory_estimates_by_id(
+        config_id=int(config_id),
+        attempt=int(attempt or 1),
+    )
+    if result.get("should_requeue"):
+        next_attempt = int(result.get("attempt") or 1) + 1
+        refresh_backup_config_directory_estimates_task.apply_async(
+            kwargs={"config_id": int(config_id), "attempt": next_attempt},
+            countdown=_REQUEUE_COUNTDOWN_SECONDS,
+        )
+    return result

--- a/src/backend/apps/protection/tests/test_backup_config_api.py
+++ b/src/backend/apps/protection/tests/test_backup_config_api.py
@@ -205,6 +205,30 @@ class ProtectionBackupConfigApiTests(TestCase):
         })
         return payload
 
+    @mock.patch(
+        "apps.protection.api.views.backup_config."
+        "refresh_backup_config_directory_estimates_task.delay"
+    )
+    @mock.patch(
+        "apps.protection.api.views.backup_config."
+        "sync_backup_config_repository_policy_task.delay"
+    )
+    def test_create_backup_config_queues_directory_size_precache(
+        self,
+        mock_policy_delay,
+        mock_estimate_delay,
+    ):
+        with self.captureOnCommitCallbacks(execute=True):
+            create = self.client.post(
+                "/api/v1/protection/backup-configs/",
+                self._payload(name="Precache estimates config"),
+                format="json",
+                **self._headers(),
+            )
+        self.assertEqual(create.status_code, status.HTTP_201_CREATED, create.content)
+        mock_policy_delay.assert_called_once_with(config_id=create.data["id"])
+        mock_estimate_delay.assert_called_once_with(config_id=create.data["id"])
+
     def test_create_backup_config_advances_source_pipeline_to_step3(self):
         source_key = f"agent:{self.agent.id}"
         step2 = self.client.post(

--- a/src/backend/apps/protection/tests/test_backup_task_api.py
+++ b/src/backend/apps/protection/tests/test_backup_task_api.py
@@ -293,6 +293,29 @@ class ProtectionBackupTaskApiTests(TestCase):
         self.assertEqual(source_resource.resource_id, self.agent.id)
         mock_queue.assert_called_once()
 
+    @patch("apps.protection.services.directory_size_estimate.run_agent_task_sync")
+    @patch("apps.protection.services.backup_task._queue_backup_execution")
+    def test_start_backup_task_does_not_sync_directory_size_estimate(
+        self,
+        mock_queue,
+        mock_path_size,
+    ):
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.post(
+                "/api/v1/protection/backup-tasks/",
+                {
+                    "source_ids": [f"agent:{self.agent.id}"],
+                    "trigger_type": "manual",
+                },
+                format="json",
+                **self._headers(),
+            )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.content)
+        self.assertEqual(response.data["created_count"], 1)
+        mock_queue.assert_called_once()
+        mock_path_size.assert_not_called()
+
     @patch("apps.protection.services.backup_task._queue_backup_execution")
     def test_start_backup_task_api_accepts_backup_config_ids_without_source_ids(self, mock_queue):
         with self.captureOnCommitCallbacks(execute=True):

--- a/src/backend/apps/protection/tests/test_backup_task_concurrency.py
+++ b/src/backend/apps/protection/tests/test_backup_task_concurrency.py
@@ -72,11 +72,7 @@ class BackupTaskConcurrencyTests(TransactionTestCase):
             step=3,
         )
 
-    @patch(
-        "apps.protection.services.directory_size_estimate."
-        "ensure_backup_config_directory_estimates"
-    )
-    def test_simultaneous_starts_create_one_active_backup(self, _estimate_sizes):
+    def test_simultaneous_starts_create_one_active_backup(self):
         barrier = threading.Barrier(2)
         outcomes: queue.Queue[dict] = queue.Queue()
         errors: queue.Queue[BaseException] = queue.Queue()

--- a/src/backend/apps/protection/tests/test_directory_size_estimate.py
+++ b/src/backend/apps/protection/tests/test_directory_size_estimate.py
@@ -1,0 +1,408 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from apps.iam.models import Organization
+from apps.node.models import Node
+from apps.protection.models import BackupConfig, BackupConfigDirectory
+from apps.protection.services.backup_config import (
+    _sync_backup_config_directories,
+    update_backup_config,
+)
+from apps.protection.services.directory_size_estimate import (
+    DirectorySizeEstimateError,
+    DirectorySizeEstimateResolveError,
+    _ESTIMATE_UNAVAILABLE,
+    backup_config_needs_directory_estimate_refresh,
+    refresh_backup_config_directory_estimates_by_id,
+    refresh_missing_backup_config_directory_estimates,
+)
+from apps.storage.repositories.models import Repository
+
+
+class DirectorySizeEstimateTests(TestCase):
+    def setUp(self):
+        self.org = Organization.objects.create(
+            key="dir-size-org",
+            name="Directory Size Org",
+        )
+        self.agent = Node.objects.create(
+            organization=self.org,
+            name="dir-size-agent",
+            role=Node.Role.AGENT,
+            status=Node.Status.ONLINE,
+            ip_address="10.0.0.81",
+        )
+        self.agent_b = Node.objects.create(
+            organization=self.org,
+            name="dir-size-agent-b",
+            role=Node.Role.AGENT,
+            status=Node.Status.ONLINE,
+            ip_address="10.0.0.82",
+        )
+        self.repository = Repository.objects.create(
+            organization_id=self.org.id,
+            name="dir-size-repo",
+            repo_type=Repository.Type.S3,
+            status=Repository.Status.CREATED,
+            health=Repository.Health.ONLINE,
+            s3_platform=Repository.S3Platform.CUSTOM,
+            s3_bucket="dir-size-bucket",
+            config={
+                "endpoint": "s3.example.internal:9000",
+                "region": "cn-test-1",
+                "prefix": "kopia/dir-size",
+                "access_key_id": "ak-test",
+                "secret_access_key": "sk-test",
+                "kopia_password": "repo-password",
+                "use_tls": False,
+            },
+        )
+        self.config = BackupConfig.objects.create(
+            organization_id=self.org.id,
+            name="Dir size config",
+            source_type="agent",
+            source_ref_id=self.agent.id,
+            repository_id=self.repository.id,
+            compression_level=BackupConfig.CompressionLevel.BALANCED,
+        )
+        self.directory = BackupConfigDirectory.objects.create(
+            organization_id=self.org.id,
+            backup_config=self.config,
+            path="/home/ubuntu",
+            estimated_size_bytes=0,
+            sort_order=0,
+        )
+
+    @patch(
+        "apps.protection.services.directory_size_estimate.estimate_directory_size_bytes",
+        return_value=4096,
+    )
+    @patch("apps.protection.services.directory_size_estimate._resolve_execution_target")
+    def test_refresh_missing_persists_estimate(self, mock_resolve, mock_estimate):
+        mock_resolve.return_value = SimpleNamespace(
+            node=self.agent,
+            source_type="agent",
+            root_path="",
+            nas_payload=None,
+        )
+        total = refresh_missing_backup_config_directory_estimates(
+            organization_id=self.org.id,
+            config=self.config,
+            source_type="agent",
+            source_ref_id=self.agent.id,
+        )
+        self.directory.refresh_from_db()
+        self.assertEqual(total, 4096)
+        self.assertEqual(self.directory.estimated_size_bytes, 4096)
+        mock_estimate.assert_called_once()
+
+    @patch(
+        "apps.protection.services.directory_size_estimate.estimate_directory_size_bytes",
+        side_effect=DirectorySizeEstimateError("timed out", permanent=False),
+    )
+    @patch("apps.protection.services.directory_size_estimate._resolve_execution_target")
+    def test_refresh_timeout_stays_retryable(self, mock_resolve, _mock_estimate):
+        mock_resolve.return_value = SimpleNamespace(
+            node=self.agent,
+            source_type="agent",
+            root_path="",
+            nas_payload=None,
+        )
+        total = refresh_missing_backup_config_directory_estimates(
+            organization_id=self.org.id,
+            config=self.config,
+            source_type="agent",
+            source_ref_id=self.agent.id,
+        )
+        self.directory.refresh_from_db()
+        self.assertEqual(total, 0)
+        self.assertEqual(self.directory.estimated_size_bytes, 0)
+        self.assertTrue(backup_config_needs_directory_estimate_refresh(self.config))
+
+    @patch(
+        "apps.protection.services.directory_size_estimate.estimate_directory_size_bytes",
+        side_effect=DirectorySizeEstimateError("returned zero", permanent=True),
+    )
+    @patch("apps.protection.services.directory_size_estimate._resolve_execution_target")
+    def test_refresh_permanent_failure_marks_unavailable(
+        self, mock_resolve, _mock_estimate
+    ):
+        mock_resolve.return_value = SimpleNamespace(
+            node=self.agent,
+            source_type="agent",
+            root_path="",
+            nas_payload=None,
+        )
+        total = refresh_missing_backup_config_directory_estimates(
+            organization_id=self.org.id,
+            config=self.config,
+            source_type="agent",
+            source_ref_id=self.agent.id,
+        )
+        self.directory.refresh_from_db()
+        self.assertEqual(total, 0)
+        self.assertEqual(self.directory.estimated_size_bytes, _ESTIMATE_UNAVAILABLE)
+        self.assertFalse(backup_config_needs_directory_estimate_refresh(self.config))
+
+    @patch(
+        "apps.protection.services.directory_size_estimate.estimate_directory_size_bytes"
+    )
+    @patch("apps.protection.services.directory_size_estimate._resolve_execution_target")
+    def test_refresh_skips_cached_estimates(self, mock_resolve, mock_estimate):
+        self.directory.estimated_size_bytes = 2048
+        self.directory.save(update_fields=["estimated_size_bytes", "updated_at"])
+        mock_resolve.return_value = SimpleNamespace(
+            node=self.agent,
+            source_type="agent",
+            root_path="",
+            nas_payload=None,
+        )
+        total = refresh_missing_backup_config_directory_estimates(
+            organization_id=self.org.id,
+            config=self.config,
+            source_type="agent",
+            source_ref_id=self.agent.id,
+        )
+        self.assertEqual(total, 2048)
+        mock_estimate.assert_not_called()
+
+    @patch(
+        "apps.protection.services.directory_size_estimate.estimate_directory_size_bytes"
+    )
+    @patch("apps.protection.services.directory_size_estimate._resolve_execution_target")
+    def test_refresh_skips_unavailable_marker(self, mock_resolve, mock_estimate):
+        self.directory.estimated_size_bytes = _ESTIMATE_UNAVAILABLE
+        self.directory.save(update_fields=["estimated_size_bytes", "updated_at"])
+        total = refresh_missing_backup_config_directory_estimates(
+            organization_id=self.org.id,
+            config=self.config,
+            source_type="agent",
+            source_ref_id=self.agent.id,
+        )
+        self.assertEqual(total, 0)
+        mock_resolve.assert_not_called()
+        mock_estimate.assert_not_called()
+
+    def test_path_type_change_invalidates_cached_estimate(self):
+        self.directory.path_type = BackupConfigDirectory.PathType.DIRECTORY
+        self.directory.estimated_size_bytes = 4096
+        self.directory.save(
+            update_fields=["path_type", "estimated_size_bytes", "updated_at"]
+        )
+        _sync_backup_config_directories(
+            config=self.config,
+            directories_data=[
+                {
+                    "path": "/home/ubuntu",
+                    "path_type": BackupConfigDirectory.PathType.FILE,
+                }
+            ],
+        )
+        self.directory.refresh_from_db()
+        self.assertEqual(
+            self.directory.path_type,
+            BackupConfigDirectory.PathType.FILE,
+        )
+        self.assertEqual(self.directory.estimated_size_bytes, 0)
+
+    def test_unknown_path_type_omission_keeps_cached_estimate(self):
+        self.directory.path_type = BackupConfigDirectory.PathType.DIRECTORY
+        self.directory.estimated_size_bytes = 4096
+        self.directory.save(
+            update_fields=["path_type", "estimated_size_bytes", "updated_at"]
+        )
+        _sync_backup_config_directories(
+            config=self.config,
+            directories_data=[
+                {
+                    "path": "/home/ubuntu",
+                    "path_type": BackupConfigDirectory.PathType.UNKNOWN,
+                    "display_name": "Home",
+                    "estimated_size_bytes": 0,
+                }
+            ],
+        )
+        self.directory.refresh_from_db()
+        self.assertEqual(
+            self.directory.path_type,
+            BackupConfigDirectory.PathType.DIRECTORY,
+        )
+        self.assertEqual(self.directory.estimated_size_bytes, 4096)
+        self.assertEqual(self.directory.display_name, "Home")
+
+    def test_unchanged_path_keeps_cached_estimate(self):
+        self.directory.path_type = BackupConfigDirectory.PathType.DIRECTORY
+        self.directory.estimated_size_bytes = 4096
+        self.directory.save(
+            update_fields=["path_type", "estimated_size_bytes", "updated_at"]
+        )
+        _sync_backup_config_directories(
+            config=self.config,
+            directories_data=[
+                {
+                    "path": "/home/ubuntu",
+                    "path_type": BackupConfigDirectory.PathType.DIRECTORY,
+                    "display_name": "Home",
+                }
+            ],
+        )
+        self.directory.refresh_from_db()
+        self.assertEqual(self.directory.estimated_size_bytes, 4096)
+        self.assertEqual(self.directory.display_name, "Home")
+
+    def test_directory_sync_reopens_unavailable_estimate(self):
+        self.directory.path_type = BackupConfigDirectory.PathType.DIRECTORY
+        self.directory.estimated_size_bytes = _ESTIMATE_UNAVAILABLE
+        self.directory.save(
+            update_fields=["path_type", "estimated_size_bytes", "updated_at"]
+        )
+        _sync_backup_config_directories(
+            config=self.config,
+            directories_data=[
+                {
+                    "path": "/home/ubuntu",
+                    "path_type": BackupConfigDirectory.PathType.DIRECTORY,
+                }
+            ],
+        )
+        self.directory.refresh_from_db()
+        self.assertEqual(self.directory.estimated_size_bytes, 0)
+        self.assertTrue(backup_config_needs_directory_estimate_refresh(self.config))
+
+    @patch("apps.protection.services.directory_size_estimate._resolve_execution_target")
+    def test_refresh_skips_resolve_when_estimates_cached(self, mock_resolve):
+        self.directory.estimated_size_bytes = 2048
+        self.directory.save(update_fields=["estimated_size_bytes", "updated_at"])
+        self.assertFalse(backup_config_needs_directory_estimate_refresh(self.config))
+        total = refresh_missing_backup_config_directory_estimates(
+            organization_id=self.org.id,
+            config=self.config,
+            source_type="agent",
+            source_ref_id=self.agent.id,
+        )
+        self.assertEqual(total, 2048)
+        mock_resolve.assert_not_called()
+
+    @patch(
+        "apps.protection.services.directory_size_estimate."
+        "refresh_missing_backup_config_directory_estimates",
+        return_value=1024,
+    )
+    def test_by_id_requeues_when_still_pending(self, mock_refresh):
+        BackupConfigDirectory.objects.create(
+            organization_id=self.org.id,
+            backup_config=self.config,
+            path="/data/other",
+            estimated_size_bytes=0,
+            sort_order=1,
+        )
+        self.directory.estimated_size_bytes = 1024
+        self.directory.save(update_fields=["estimated_size_bytes", "updated_at"])
+
+        result = refresh_backup_config_directory_estimates_by_id(
+            config_id=self.config.id,
+            attempt=1,
+        )
+        self.assertEqual(result["status"], "partial")
+        self.assertTrue(result["should_requeue"])
+        self.assertEqual(result["attempt"], 1)
+        mock_refresh.assert_called_once()
+
+    @patch(
+        "apps.protection.services.directory_size_estimate."
+        "refresh_missing_backup_config_directory_estimates",
+        return_value=0,
+    )
+    def test_by_id_stops_requeue_at_max_attempts(self, _mock_refresh):
+        result = refresh_backup_config_directory_estimates_by_id(
+            config_id=self.config.id,
+            attempt=5,
+        )
+        self.assertEqual(result["status"], "exhausted")
+        self.assertFalse(result["should_requeue"])
+        # Retryable leftovers stay pending for a later directories/source save.
+        self.directory.refresh_from_db()
+        self.assertEqual(self.directory.estimated_size_bytes, 0)
+        self.assertTrue(backup_config_needs_directory_estimate_refresh(self.config))
+
+    @patch(
+        "apps.protection.services.directory_size_estimate."
+        "refresh_missing_backup_config_directory_estimates",
+        side_effect=DirectorySizeEstimateResolveError("source offline"),
+    )
+    def test_by_id_requeues_resolve_failures(self, _mock_refresh):
+        result = refresh_backup_config_directory_estimates_by_id(
+            config_id=self.config.id,
+            attempt=1,
+        )
+        self.assertEqual(result["status"], "resolve_failed")
+        self.assertTrue(result["should_requeue"])
+        self.directory.refresh_from_db()
+        self.assertEqual(self.directory.estimated_size_bytes, 0)
+
+    @patch(
+        "apps.protection.services.directory_size_estimate."
+        "refresh_missing_backup_config_directory_estimates",
+        side_effect=DirectorySizeEstimateResolveError("source offline"),
+    )
+    def test_by_id_freezes_pending_after_resolve_exhausted(self, _mock_refresh):
+        result = refresh_backup_config_directory_estimates_by_id(
+            config_id=self.config.id,
+            attempt=5,
+        )
+        self.assertEqual(result["status"], "resolve_exhausted")
+        self.assertFalse(result["should_requeue"])
+        self.directory.refresh_from_db()
+        self.assertEqual(self.directory.estimated_size_bytes, _ESTIMATE_UNAVAILABLE)
+
+    def test_source_change_invalidates_cached_estimates(self):
+        self.directory.estimated_size_bytes = 4096
+        self.directory.save(update_fields=["estimated_size_bytes", "updated_at"])
+        update_backup_config(
+            config=self.config,
+            data={
+                "name": self.config.name,
+                "source_type": "agent",
+                "source_ref_id": self.agent_b.id,
+                "repository_id": self.repository.id,
+            },
+        )
+        self.directory.refresh_from_db()
+        self.config.refresh_from_db()
+        self.assertEqual(self.config.source_ref_id, self.agent_b.id)
+        self.assertEqual(self.directory.estimated_size_bytes, 0)
+        self.assertTrue(backup_config_needs_directory_estimate_refresh(self.config))
+
+    @patch(
+        "apps.protection.tasks.directory_size_estimate."
+        "refresh_backup_config_directory_estimates_by_id"
+    )
+    def test_task_requeues_when_service_requests(self, mock_by_id):
+        from apps.protection.tasks.directory_size_estimate import (
+            refresh_backup_config_directory_estimates_task,
+        )
+
+        mock_by_id.return_value = {
+            "config_id": self.config.id,
+            "status": "partial",
+            "du_total": 0,
+            "attempt": 2,
+            "should_requeue": True,
+        }
+        with patch.object(
+            refresh_backup_config_directory_estimates_task,
+            "apply_async",
+        ) as mock_async:
+            result = refresh_backup_config_directory_estimates_task.run(
+                config_id=self.config.id,
+                attempt=2,
+            )
+        self.assertTrue(result["should_requeue"])
+        mock_async.assert_called_once_with(
+            kwargs={"config_id": self.config.id, "attempt": 3},
+            countdown=5,
+        )

--- a/src/backend/apps/protection/tests/test_step3_progress.py
+++ b/src/backend/apps/protection/tests/test_step3_progress.py
@@ -61,6 +61,25 @@ class Step3ProgressTests(SimpleTestCase):
         self.assertEqual(transfer["bytes_total"], 2_000_000)
         self.assertTrue(transfer["bytes_total_estimated"])
 
+    def test_backup_without_du_total_degrades_progress(self):
+        transfer = enrich_step3_backup_transfer(
+            transfer={"phase": "estimating", "upload_speed_bps": 0},
+            previous={},
+            aggregate={
+                "uploaded_bytes": 0,
+                "uploaded_count": 0,
+                "hashed_count": 0,
+                "estimated_bytes": 0,
+            },
+            du_total=0,
+        )
+        self.assertFalse(transfer["switch_latched"])
+        self.assertFalse(transfer["bytes_total_known"])
+        self.assertFalse(transfer["bytes_total_estimated"])
+        self.assertNotIn("bytes_total", transfer)
+        self.assertIsNone(transfer.get("step3_display_percent"))
+        self.assertIsNone(transfer.get("eta_seconds"))
+
     def test_should_latch_requires_uploaded_and_stable_estimate(self):
         now = timezone.now()
         history = [{"at": (now - timedelta(seconds=index)).isoformat(), "estimated_bytes": 1_050_000} for index in range(12)]


### PR DESCRIPTION
## Summary
- Remove synchronous `path.size` / directory du from Backup Now so start only admits/queues tasks
- Enqueue Celery directory-size precache on backup-config create and on update when directories or source inputs change
- Keep cached estimates on unchanged paths; invalidate on path_type/source changes; degrade step-3 progress when `du_total` is still 0

## Test plan
- [ ] Create backup config → Celery precache task is queued; Backup Now returns quickly without sync du
- [ ] Name/remark-only PATCH does not enqueue precache; directories or source change does
- [ ] Backup with missing estimates still runs; step-3 progress degrades (no fake %)
- [ ] Multi-directory precache requeues within attempt budget; resolve exhaustion freezes pending estimates
- [ ] CI: protection unit tests for directory size estimate / backup task start / step3 progress


Made with [Cursor](https://cursor.com)