### PR TITLE
fix(storage): harden async repository create resume and remount rollback

### DIFF
--- a/src/backend/apps/storage/services/interface.py
+++ b/src/backend/apps/storage/services/interface.py
@@ -317,6 +317,10 @@ def update_repository(
     bind_node_id: int | None = None,
     credential_payload: dict | None = None,
 ) -> Repository:
+    if repository.status == Repository.Status.CREATING:
+        raise DRFValidationError(
+            {"detail": "Repository create or remount is still in progress."}
+        )
     with transaction.atomic():
         if name is not None:
             repository.name = name

--- a/src/backend/apps/storage/services/internal/nas_repair.py
+++ b/src/backend/apps/storage/services/internal/nas_repair.py
@@ -334,12 +334,19 @@ def repair_nas_repository(
         raise DRFValidationError(
             {"detail": "Repair is only supported for NAS repositories."}
         )
+    if repository.status == Repository.Status.CREATING:
+        raise DRFValidationError(
+            {"detail": "Repository create or remount is still in progress."}
+        )
 
     organization_id = repository.organization_id
     currently_bound = bool(
         repository.bind_node_type == Repository.BindNodeType.PROXY and repository.bind_node_id
     )
     initial_bind_node_id = repository.bind_node_id
+    initial_proxy_mount_path = str(
+        (repository.config or {}).get("proxy_mount_path") or ""
+    ).strip()
     bind_node_provided = bind_node_id is not _UNSET
     if bind_node_provided:
         new_bind_node_id = bind_node_id
@@ -454,5 +461,6 @@ def repair_nas_repository(
         remount_previous_node_id=(
             int(initial_bind_node_id) if initial_bind_node_id else None
         ),
+        remount_previous_mount_path=initial_proxy_mount_path or None,
     )
     return repository

--- a/src/backend/apps/storage/services/internal/repository_create.py
+++ b/src/backend/apps/storage/services/internal/repository_create.py
@@ -10,7 +10,9 @@ from __future__ import annotations
 
 import logging
 from typing import Any
+from uuid import uuid4
 
+from django.core.cache import cache
 from django.core.exceptions import ValidationError
 from django.db import transaction
 from django.utils import timezone
@@ -27,6 +29,7 @@ from apps.storage.repositories.models import (
 from apps.storage.services.internal.nas_repository import (
     NASRepositoryError,
     initialize_proxy_nas_repository,
+    nas_mount_point,
     validate_proxy_for_repository,
 )
 from apps.storage.services.internal.proxy_fs_repository import (
@@ -75,6 +78,12 @@ CREATE_OPERATION_TYPES = frozenset(
     }
 )
 
+# Covers the longest create/remount path: NAS remount (180s) + old-proxy unmount
+# (60s) plus finalize overhead. Prevents reconcile from overlapping a still-running
+# create after the short repository-operation advance lock expires.
+_CREATE_RUN_LOCK_TIMEOUT_SECONDS = 300
+_INITIALIZE_COMPLETE_PROGRESS = 85
+
 
 def repository_create_task_payload(repository_task: RepositoryTask) -> dict[str, Any]:
     task = repository_task.task
@@ -117,9 +126,17 @@ def enqueue_repository_create_task(
     requested_by=None,
     dispatch: bool = True,
     remount_previous_node_id: int | None = None,
+    remount_previous_mount_path: str | None = None,
 ) -> RepositoryTask:
     if operation_type not in CREATE_OPERATION_TYPES:
         raise ValidationError({"operation_type": "Unsupported repository create operation."})
+    if (
+        operation_type == RepositoryTask.OperationType.REPAIR_REMOUNT
+        and remount_previous_node_id is None
+    ):
+        raise ValidationError(
+            {"detail": "Remount requires the previous proxy node id for rollback."}
+        )
 
     existing = active_repository_create_task(repository)
     if existing is not None:
@@ -169,6 +186,10 @@ def enqueue_repository_create_task(
         }
         if remount_previous_node_id is not None:
             request_payload["previous_bind_node_id"] = int(remount_previous_node_id)
+        if remount_previous_mount_path is not None:
+            request_payload["previous_proxy_mount_path"] = str(
+                remount_previous_mount_path or ""
+            ).strip()
 
         task = create_task(
             organization_id=locked.organization_id,
@@ -231,6 +252,22 @@ def enqueue_repository_create_task(
 
 
 def run_repository_create_task(*, repository_task_id: int) -> dict[str, Any]:
+    lock_key = f"storage:repository-create:run:{int(repository_task_id)}"
+    owner_token = str(uuid4())
+    if not cache.add(lock_key, owner_token, timeout=_CREATE_RUN_LOCK_TIMEOUT_SECONDS):
+        return {
+            "status": "locked",
+            "repository_task_id": repository_task_id,
+            "idempotent": True,
+        }
+    try:
+        return _run_repository_create_task_locked(repository_task_id=repository_task_id)
+    finally:
+        if cache.get(lock_key) == owner_token:
+            cache.delete(lock_key)
+
+
+def _run_repository_create_task_locked(*, repository_task_id: int) -> dict[str, Any]:
     repository_task = RepositoryTask.objects.select_related(
         "task", "repository", "execution_target"
     ).get(pk=repository_task_id)
@@ -243,41 +280,79 @@ def run_repository_create_task(*, repository_task_id: int) -> dict[str, Any]:
     }:
         return {"status": task.status, "idempotent": True}
 
-    if task.status == Task.Status.PENDING:
+    started_now = task.status == Task.Status.PENDING
+    if started_now:
         start_task(task_uuid=task.task_uuid, organization_id=task.organization_id)
         task.refresh_from_db()
+    elif task.status != Task.Status.RUNNING:
+        return {"status": task.status, "idempotent": True}
 
-    repository = repository_task.repository
-    _set_create_step(task, "prepare_repository_create", TaskStep.Status.SUCCESS, 10)
-    _set_create_step(task, "verify_repository_owner", TaskStep.Status.RUNNING, 20)
-
-    try:
-        if repository_task.operation_type != RepositoryTask.OperationType.REPAIR_REMOUNT:
-            if repository.repo_type in {Repository.Type.NAS, Repository.Type.PROXY_FS}:
-                preflight_bound_proxy(repository=repository)
-        _set_create_step(task, "verify_repository_owner", TaskStep.Status.SUCCESS, 35)
-        _set_create_step(task, "initialize_repository", TaskStep.Status.RUNNING, 45)
-
-        if repository_task.operation_type == RepositoryTask.OperationType.REPAIR_REMOUNT:
-            _run_repair_remount(repository_task)
-        else:
-            _run_initialize(repository)
-
-        _set_create_step(task, "initialize_repository", TaskStep.Status.SUCCESS, 85)
-        _set_create_step(task, "finalize_repository_create", TaskStep.Status.RUNNING, 90)
-        _finalize_create_success(repository_task)
-        _set_create_step(task, "finalize_repository_create", TaskStep.Status.SUCCESS, 100)
-        complete_task(
-            task_uuid=task.task_uuid,
-            organization_id=task.organization_id,
-            status=Task.Status.SUCCESS,
-            progress=100,
-            result_payload={"repository_id": repository.id, "status": "created"},
+    repository = Repository.objects.get(pk=repository_task.repository_id)
+    if (
+        repository.status == Repository.Status.CREATED
+        and repository.health == Repository.Health.ONLINE
+        and task.status == Task.Status.RUNNING
+    ):
+        # Worker died after repository finalize but before task completion.
+        return _complete_create_success(repository_task)
+    if (
+        task.status == Task.Status.RUNNING
+        and _remount_failure_rollback_applied(repository_task, repository)
+    ):
+        # Failure rollback persisted, but the task never reached a terminal status.
+        return _complete_create_failure_already_applied(
+            repository_task,
+            error_code="REPOSITORY_CREATE_FAILED",
+            message="Repository remount failed; previous proxy binding was restored.",
         )
-        _clear_target_active_task(repository_task)
-        return {"status": "success", "repository_task_id": repository_task.id}
+
+    initialize_done = _initialize_step_complete(task)
+    # In-process latch: step rows may fail to persist after physical work returns.
+    # Fail paths must not unwind bind/remount once this flips true.
+    physical_initialize_done = initialize_done
+    try:
+        if not initialize_done:
+            _set_create_step(task, "prepare_repository_create", TaskStep.Status.SUCCESS, 10)
+            _set_create_step(task, "verify_repository_owner", TaskStep.Status.RUNNING, 20)
+            if repository_task.operation_type != RepositoryTask.OperationType.REPAIR_REMOUNT:
+                if repository.repo_type in {Repository.Type.NAS, Repository.Type.PROXY_FS}:
+                    preflight_bound_proxy(repository=repository)
+            _set_create_step(task, "verify_repository_owner", TaskStep.Status.SUCCESS, 35)
+            _set_create_step(task, "initialize_repository", TaskStep.Status.RUNNING, 45)
+
+            if repository_task.operation_type == RepositoryTask.OperationType.REPAIR_REMOUNT:
+                _run_repair_remount(repository_task)
+            else:
+                _run_initialize(repository)
+            physical_initialize_done = True
+
+            _set_create_step(
+                task,
+                "initialize_repository",
+                TaskStep.Status.SUCCESS,
+                _INITIALIZE_COMPLETE_PROGRESS,
+            )
+
+        _set_create_step(task, "finalize_repository_create", TaskStep.Status.RUNNING, 90)
+        return _complete_create_success(repository_task)
     except RepositoryAlreadyExistsError as exc:
         message = _safe_error_message(repository, str(exc))
+        # CREATE re-entry after a successful physical init must finalize, not
+        # delete. REPAIR_BIND conflicts still mean "target already occupied" and
+        # must restore the unbound NAS row instead of marking it online.
+        if (
+            not started_now
+            and repository.status == Repository.Status.CREATING
+            and repository_task.operation_type
+            == RepositoryTask.OperationType.CREATE_REPOSITORY
+        ):
+            logger.warning(
+                "repository create resume treating already-exists as success "
+                "repository_id=%s repository_task_id=%s",
+                repository.id,
+                repository_task.id,
+            )
+            return _complete_create_success(repository_task)
         if repository_task.operation_type == RepositoryTask.OperationType.REPAIR_BIND:
             _fail_repair_bind_already_exists(repository_task, message=message)
         else:
@@ -291,13 +366,68 @@ def run_repository_create_task(*, repository_task_id: int) -> dict[str, Any]:
     except Exception as exc:
         message = _safe_error_message(repository, _exception_message(exc))
         error_code = _create_error_code(exc)
-        _fail_create_keep_row(repository_task, error_code=error_code, message=message)
+        _fail_create_keep_row(
+            repository_task,
+            error_code=error_code,
+            message=message,
+            physical_initialize_done=physical_initialize_done,
+        )
         return {
             "status": "failed",
             "repository_task_id": repository_task.id,
             "error_code": error_code,
             "error": message,
         }
+
+
+def _initialize_step_complete(task: Task) -> bool:
+    current_step = str(task.current_step or "")
+    progress = int(task.progress or 0)
+    if current_step == "finalize_repository_create":
+        return True
+    if current_step == "initialize_repository" and progress >= _INITIALIZE_COMPLETE_PROGRESS:
+        return True
+    return False
+
+
+def _complete_create_success(repository_task: RepositoryTask) -> dict[str, Any]:
+    task = repository_task.task
+    with transaction.atomic():
+        repository = Repository.objects.select_for_update().get(
+            pk=repository_task.repository_id
+        )
+        repository.status = Repository.Status.CREATED
+        repository.health = Repository.Health.ONLINE
+        repository.last_checked_at = timezone.now()
+        repository.save(
+            update_fields=["status", "health", "last_checked_at", "updated_at"]
+        )
+        _set_create_step(task, "finalize_repository_create", TaskStep.Status.SUCCESS, 100)
+        complete_task(
+            task_uuid=task.task_uuid,
+            organization_id=task.organization_id,
+            status=Task.Status.SUCCESS,
+            progress=100,
+            result_payload={"repository_id": repository.id, "status": "created"},
+        )
+    _clear_target_active_task(repository_task)
+    repository = Repository.objects.get(pk=repository_task.repository_id)
+    try:
+        if repository.repo_type == Repository.Type.PROXY_FS:
+            sync_repository_usage(repository)
+        else:
+            enqueue_repository_usage_refresh(
+                organization_id=repository.organization_id,
+                repository_ids=[repository.id],
+                force=True,
+                trigger="storage.repository.create_async",
+            )
+    except Exception:
+        logger.exception(
+            "repository create usage refresh failed repository_id=%s",
+            repository.id,
+        )
+    return {"status": "success", "repository_task_id": repository_task.id}
 
 
 def _resolve_create_owner(
@@ -355,11 +485,17 @@ def _run_repair_remount(repository_task: RepositoryTask) -> None:
         _unmount_on_old_proxy,
     )
 
-    repository = repository_task.repository
+    repository = Repository.objects.get(pk=repository_task.repository_id)
     payload = repository_task.task.request_payload or {}
     previous_node_id = payload.get("previous_bind_node_id")
+    # Prefer the bind frozen at enqueue time. After a failure rollback the live
+    # repository.bind_node_id points at the previous proxy and must not be used
+    # as the remount target on resume.
+    intended_new_node_id = payload.get("bind_node_id") or repository.bind_node_id
+    if not intended_new_node_id:
+        raise ValidationError("Bound proxy node not found.")
     new_node = Node.objects.filter(
-        id=repository.bind_node_id,
+        id=int(intended_new_node_id),
         organization_id=repository.organization_id,
         role=NodeRole.PROXY,
         is_deleted=False,
@@ -382,63 +518,31 @@ def _run_repair_remount(repository_task: RepositoryTask) -> None:
         )
 
 
-def _finalize_create_success(repository_task: RepositoryTask) -> None:
-    with transaction.atomic():
-        repository = Repository.objects.select_for_update().get(
-            pk=repository_task.repository_id
-        )
-        repository.status = Repository.Status.CREATED
-        repository.health = Repository.Health.ONLINE
-        repository.last_checked_at = timezone.now()
-        repository.save(update_fields=["status", "health", "last_checked_at", "updated_at"])
-    repository = Repository.objects.get(pk=repository_task.repository_id)
-    if repository.repo_type == Repository.Type.PROXY_FS:
-        sync_repository_usage(repository)
-    else:
-        enqueue_repository_usage_refresh(
-            organization_id=repository.organization_id,
-            repository_ids=[repository.id],
-            force=True,
-            trigger="storage.repository.create_async",
-        )
-
-
 def _fail_repair_bind_already_exists(repository_task: RepositoryTask, *, message: str) -> None:
     """Keep the unbound NAS row when bind discovers an existing Kopia repository."""
     task = repository_task.task
-    repository = Repository.objects.filter(pk=repository_task.repository_id).first()
-    _set_create_step(
-        task,
-        str(task.current_step or "initialize_repository"),
-        TaskStep.Status.FAILED,
-        max(1, int(task.progress or 0)),
-    )
-    if repository is not None:
-        config = dict(repository.config or {})
-        config.pop("proxy_mount_path", None)
-        repository.config = config
-        repository.bind_node_type = None
-        repository.bind_node_id = None
-        repository.status = Repository.Status.CREATED
-        repository.health = Repository.Health.UNVERIFIED
-        repository.save(
-            update_fields=[
-                "config",
-                "bind_node_type",
-                "bind_node_id",
-                "status",
-                "health",
-                "updated_at",
-            ]
+    with transaction.atomic():
+        repository = (
+            Repository.objects.select_for_update()
+            .filter(pk=repository_task.repository_id)
+            .first()
         )
-    complete_task(
-        task_uuid=task.task_uuid,
-        organization_id=task.organization_id,
-        status=Task.Status.FAILED,
-        progress=max(1, int(task.progress or 0)),
-        error_code=REPOSITORY_ALREADY_EXISTS_CODE,
-        error_message=message[:2000],
-    )
+        _set_create_step(
+            task,
+            str(task.current_step or "initialize_repository"),
+            TaskStep.Status.FAILED,
+            max(1, int(task.progress or 0)),
+        )
+        if repository is not None:
+            _restore_unbound_nas(repository)
+        complete_task(
+            task_uuid=task.task_uuid,
+            organization_id=task.organization_id,
+            status=Task.Status.FAILED,
+            progress=max(1, int(task.progress or 0)),
+            error_code=REPOSITORY_ALREADY_EXISTS_CODE,
+            error_message=message[:2000],
+        )
     _clear_target_active_task(repository_task)
 
 
@@ -478,36 +582,185 @@ def _fail_create_keep_row(
     *,
     error_code: str,
     message: str,
+    physical_initialize_done: bool | None = None,
 ) -> None:
     task = repository_task.task
-    repository = Repository.objects.filter(pk=repository_task.repository_id).first()
-    _set_create_step(
-        task,
-        str(task.current_step or "initialize_repository"),
-        TaskStep.Status.FAILED,
-        max(1, int(task.progress or 0)),
-    )
-    if repository is not None:
-        if repository_task.operation_type == RepositoryTask.OperationType.REPAIR_REMOUNT:
-            # Remount operates on an already-initialized repository identity.
-            repository.status = Repository.Status.CREATED
-            repository.health = Repository.Health.OFFLINE
-        else:
-            repository.status = Repository.Status.CREATE_FAILED
-            repository.health = Repository.Health.OFFLINE
-        repository.last_checked_at = timezone.now()
-        repository.save(
-            update_fields=["status", "health", "last_checked_at", "updated_at"]
+    # Prefer the in-process latch from the runner: step persistence can lag
+    # behind a successful remount/initialize return. Persisted step progress is
+    # only the fallback for callers that omit the latch.
+    if physical_initialize_done is None:
+        initialize_done = _initialize_step_complete(task)
+    else:
+        initialize_done = physical_initialize_done
+    with transaction.atomic():
+        repository = (
+            Repository.objects.select_for_update()
+            .filter(pk=repository_task.repository_id)
+            .first()
         )
-    complete_task(
-        task_uuid=task.task_uuid,
-        organization_id=task.organization_id,
-        status=Task.Status.FAILED,
-        progress=max(1, int(task.progress or 0)),
-        error_code=error_code,
-        error_message=message[:2000],
-    )
+        _set_create_step(
+            task,
+            str(task.current_step or "initialize_repository"),
+            TaskStep.Status.FAILED,
+            max(1, int(task.progress or 0)),
+        )
+        if repository is not None:
+            if (
+                not initialize_done
+                and repository_task.operation_type
+                == RepositoryTask.OperationType.REPAIR_BIND
+            ):
+                _restore_unbound_nas(repository)
+            elif (
+                not initialize_done
+                and repository_task.operation_type
+                == RepositoryTask.OperationType.REPAIR_REMOUNT
+            ):
+                _restore_previous_proxy_binding(repository_task, repository)
+            elif repository_task.operation_type in {
+                RepositoryTask.OperationType.REPAIR_BIND,
+                RepositoryTask.OperationType.REPAIR_REMOUNT,
+            }:
+                repository.status = Repository.Status.CREATED
+                repository.health = Repository.Health.OFFLINE
+                repository.last_checked_at = timezone.now()
+                repository.save(
+                    update_fields=["status", "health", "last_checked_at", "updated_at"]
+                )
+            else:
+                repository.status = Repository.Status.CREATE_FAILED
+                repository.health = Repository.Health.OFFLINE
+                repository.last_checked_at = timezone.now()
+                repository.save(
+                    update_fields=["status", "health", "last_checked_at", "updated_at"]
+                )
+        complete_task(
+            task_uuid=task.task_uuid,
+            organization_id=task.organization_id,
+            status=Task.Status.FAILED,
+            progress=max(1, int(task.progress or 0)),
+            error_code=error_code,
+            error_message=message[:2000],
+        )
     _clear_target_active_task(repository_task)
+
+
+def _remount_failure_rollback_applied(
+    repository_task: RepositoryTask,
+    repository: Repository,
+) -> bool:
+    if repository_task.operation_type != RepositoryTask.OperationType.REPAIR_REMOUNT:
+        return False
+    if repository.status != Repository.Status.CREATED:
+        return False
+    if repository.health != Repository.Health.OFFLINE:
+        return False
+    payload = repository_task.task.request_payload or {}
+    previous_node_id = payload.get("previous_bind_node_id")
+    intended_new_node_id = payload.get("bind_node_id")
+    if not previous_node_id or not intended_new_node_id:
+        return False
+    return (
+        int(repository.bind_node_id or 0) == int(previous_node_id)
+        and int(intended_new_node_id) != int(previous_node_id)
+    )
+
+
+def _complete_create_failure_already_applied(
+    repository_task: RepositoryTask,
+    *,
+    error_code: str,
+    message: str,
+) -> dict[str, Any]:
+    task = repository_task.task
+    with transaction.atomic():
+        _set_create_step(
+            task,
+            str(task.current_step or "initialize_repository"),
+            TaskStep.Status.FAILED,
+            max(1, int(task.progress or 0)),
+        )
+        complete_task(
+            task_uuid=task.task_uuid,
+            organization_id=task.organization_id,
+            status=Task.Status.FAILED,
+            progress=max(1, int(task.progress or 0)),
+            error_code=error_code,
+            error_message=message[:2000],
+        )
+    _clear_target_active_task(repository_task)
+    return {
+        "status": "failed",
+        "repository_task_id": repository_task.id,
+        "error_code": error_code,
+        "error": message,
+        "idempotent": True,
+    }
+
+
+def _restore_unbound_nas(repository: Repository) -> None:
+    config = dict(repository.config or {})
+    config.pop("proxy_mount_path", None)
+    repository.config = config
+    repository.bind_node_type = None
+    repository.bind_node_id = None
+    repository.status = Repository.Status.CREATED
+    repository.health = Repository.Health.UNVERIFIED
+    repository.save(
+        update_fields=[
+            "config",
+            "bind_node_type",
+            "bind_node_id",
+            "status",
+            "health",
+            "updated_at",
+        ]
+    )
+
+
+def _restore_previous_proxy_binding(
+    repository_task: RepositoryTask,
+    repository: Repository,
+) -> None:
+    payload = repository_task.task.request_payload or {}
+    previous_node_id = payload.get("previous_bind_node_id")
+    previous_mount = str(payload.get("previous_proxy_mount_path") or "").strip()
+    config = dict(repository.config or {})
+    if previous_node_id:
+        repository.bind_node_type = Repository.BindNodeType.PROXY
+        repository.bind_node_id = int(previous_node_id)
+        if previous_mount:
+            config["proxy_mount_path"] = previous_mount
+        else:
+            config["proxy_mount_path"] = nas_mount_point(
+                repository, node_id=int(previous_node_id)
+            )
+    else:
+        # Without the prior binding we cannot safely invent a rollback target.
+        # Keep the failed remount binding visible as offline so operators can
+        # repair explicitly instead of silently keeping a half-swapped proxy.
+        logger.error(
+            "repository remount failure missing previous_bind_node_id "
+            "repository_id=%s repository_task_id=%s bind_node_id=%s",
+            repository.id,
+            repository_task.id,
+            repository.bind_node_id,
+        )
+    repository.config = config
+    repository.status = Repository.Status.CREATED
+    repository.health = Repository.Health.OFFLINE
+    repository.last_checked_at = timezone.now()
+    repository.save(
+        update_fields=[
+            "config",
+            "bind_node_type",
+            "bind_node_id",
+            "status",
+            "health",
+            "last_checked_at",
+            "updated_at",
+        ]
+    )
 
 
 def _clear_target_active_task(repository_task: RepositoryTask) -> None:

--- a/src/backend/apps/storage/tests/test_repository_create.py
+++ b/src/backend/apps/storage/tests/test_repository_create.py
@@ -15,6 +15,7 @@ from apps.storage.services.internal.repository_errors import (
     RepositoryAlreadyExistsError,
 )
 from apps.storage.services.internal.repository_initializer import RepositoryInitializationError
+from apps.task.models import Task
 
 
 class RepositoryCreateTaskTests(TestCase):
@@ -160,3 +161,359 @@ class RepositoryCreateTaskTests(TestCase):
         self.assertEqual(repository.health, Repository.Health.UNVERIFIED)
         self.assertNotIn("proxy_mount_path", repository.config)
         initialize.assert_called_once()
+
+    @mock.patch(
+        "apps.storage.services.internal.repository_create.enqueue_repository_usage_refresh"
+    )
+    @mock.patch("apps.storage.services.internal.repository_create.initialize_s3_repository")
+    def test_resume_skips_initialize_after_step_complete(self, initialize, _enqueue):
+        repository = self._s3_repository()
+        repository_task = self._enqueue_create(repository)
+        task = repository_task.task
+        task.status = Task.Status.RUNNING
+        task.current_step = "initialize_repository"
+        task.progress = 85
+        task.save(update_fields=["status", "current_step", "progress", "updated_at"])
+
+        result = run_repository_create_task(repository_task_id=repository_task.id)
+
+        self.assertEqual(result["status"], "success")
+        initialize.assert_not_called()
+        repository.refresh_from_db()
+        self.assertEqual(repository.status, Repository.Status.CREATED)
+        self.assertEqual(repository.health, Repository.Health.ONLINE)
+
+    @mock.patch(
+        "apps.storage.services.internal.repository_create.enqueue_repository_usage_refresh"
+    )
+    @mock.patch("apps.storage.services.internal.repository_create.initialize_s3_repository")
+    def test_resume_already_exists_finalizes_instead_of_delete(self, initialize, _enqueue):
+        initialize.side_effect = RepositoryAlreadyExistsError("repository already exists")
+        repository = self._s3_repository()
+        repository_task = self._enqueue_create(repository)
+        task = repository_task.task
+        task.status = Task.Status.RUNNING
+        task.current_step = "initialize_repository"
+        task.progress = 45
+        task.save(update_fields=["status", "current_step", "progress", "updated_at"])
+
+        result = run_repository_create_task(repository_task_id=repository_task.id)
+
+        self.assertEqual(result["status"], "success")
+        self.assertTrue(Repository.objects.filter(id=repository.id).exists())
+        repository.refresh_from_db()
+        self.assertEqual(repository.status, Repository.Status.CREATED)
+        self.assertEqual(repository.health, Repository.Health.ONLINE)
+
+    @mock.patch(
+        "apps.storage.services.internal.repository_create.initialize_proxy_nas_repository"
+    )
+    def test_repair_bind_resume_already_exists_still_restores_unbound(self, initialize):
+        initialize.side_effect = RepositoryAlreadyExistsError("repository already exists")
+        proxy = Node.objects.create(
+            organization=self.org,
+            name="repair-proxy-resume",
+            role=Node.Role.PROXY,
+            status=Node.Status.ONLINE,
+            ip_address="10.0.0.43",
+        )
+        repository = Repository.objects.create(
+            organization_id=self.org.id,
+            name="repair-bind-resume-nas",
+            repo_type=Repository.Type.NAS,
+            nas_protocol=Repository.NasProtocol.SMB,
+            status=Repository.Status.CREATING,
+            health=Repository.Health.OFFLINE,
+            bind_node_type=Repository.BindNodeType.PROXY,
+            bind_node_id=proxy.id,
+            config={
+                "server_address": "10.0.0.10",
+                "share_path": "/backup",
+                "proxy_mount_path": "/mnt/hfl/storage-repositories/repo-resume",
+            },
+        )
+        repository_task = self._enqueue_create(
+            repository,
+            operation_type=RepositoryTask.OperationType.REPAIR_BIND,
+        )
+        task = repository_task.task
+        task.status = Task.Status.RUNNING
+        task.current_step = "initialize_repository"
+        task.progress = 45
+        task.save(update_fields=["status", "current_step", "progress", "updated_at"])
+
+        result = run_repository_create_task(repository_task_id=repository_task.id)
+
+        self.assertEqual(result["status"], "failed")
+        self.assertEqual(result["error_code"], REPOSITORY_ALREADY_EXISTS_CODE)
+        repository.refresh_from_db()
+        self.assertIsNone(repository.bind_node_type)
+        self.assertIsNone(repository.bind_node_id)
+        self.assertEqual(repository.status, Repository.Status.CREATED)
+        self.assertEqual(repository.health, Repository.Health.UNVERIFIED)
+        self.assertNotIn("proxy_mount_path", repository.config)
+
+    @mock.patch("apps.storage.services.internal.repository_create._run_repair_remount")
+    def test_repair_remount_failure_restores_previous_proxy(self, remount):
+        remount.side_effect = RuntimeError("remount failed")
+        old_proxy = Node.objects.create(
+            organization=self.org,
+            name="old-proxy",
+            role=Node.Role.PROXY,
+            status=Node.Status.ONLINE,
+            ip_address="10.0.0.41",
+        )
+        new_proxy = Node.objects.create(
+            organization=self.org,
+            name="new-proxy",
+            role=Node.Role.PROXY,
+            status=Node.Status.ONLINE,
+            ip_address="10.0.0.42",
+        )
+        repository = Repository.objects.create(
+            organization_id=self.org.id,
+            name="remount-nas",
+            repo_type=Repository.Type.NAS,
+            nas_protocol=Repository.NasProtocol.NFS,
+            status=Repository.Status.CREATING,
+            health=Repository.Health.OFFLINE,
+            bind_node_type=Repository.BindNodeType.PROXY,
+            bind_node_id=new_proxy.id,
+            config={
+                "server_address": "10.0.0.10",
+                "share_path": "/export",
+                "proxy_mount_path": "/mnt/hfl/storage-repositories/repo-new",
+            },
+        )
+        repository_task = enqueue_repository_create_task(
+            repository=repository,
+            operation_type=RepositoryTask.OperationType.REPAIR_REMOUNT,
+            remount_previous_node_id=old_proxy.id,
+            remount_previous_mount_path="/mnt/hfl/storage-repositories/repo-old",
+            dispatch=False,
+        )
+
+        result = run_repository_create_task(repository_task_id=repository_task.id)
+
+        self.assertEqual(result["status"], "failed")
+        repository.refresh_from_db()
+        self.assertEqual(repository.bind_node_id, old_proxy.id)
+        self.assertEqual(repository.status, Repository.Status.CREATED)
+        self.assertEqual(repository.health, Repository.Health.OFFLINE)
+        self.assertEqual(
+            repository.config.get("proxy_mount_path"),
+            "/mnt/hfl/storage-repositories/repo-old",
+        )
+
+    @mock.patch("apps.storage.services.internal.repository_create._set_create_step")
+    @mock.patch("apps.storage.services.internal.repository_create._run_repair_remount")
+    def test_remount_step_persist_failure_after_physical_keeps_new_proxy(
+        self, remount, set_step
+    ):
+        from apps.storage.services.internal.repository_operations import set_task_step
+        from apps.task.models import TaskStep
+
+        remount.return_value = None
+
+        def _set_real(task, step_name, status, progress):
+            if (
+                step_name == "initialize_repository"
+                and status == TaskStep.Status.SUCCESS
+                and int(progress) >= 85
+            ):
+                raise RuntimeError("initialize step persist failed")
+            task.refresh_from_db(fields=["current_step", "progress"])
+            set_task_step(task, step_name, status=status, progress=progress)
+
+        set_step.side_effect = _set_real
+        old_proxy = Node.objects.create(
+            organization=self.org,
+            name="old-proxy-step",
+            role=Node.Role.PROXY,
+            status=Node.Status.ONLINE,
+            ip_address="10.0.0.48",
+        )
+        new_proxy = Node.objects.create(
+            organization=self.org,
+            name="new-proxy-step",
+            role=Node.Role.PROXY,
+            status=Node.Status.ONLINE,
+            ip_address="10.0.0.49",
+        )
+        repository = Repository.objects.create(
+            organization_id=self.org.id,
+            name="remount-step-nas",
+            repo_type=Repository.Type.NAS,
+            nas_protocol=Repository.NasProtocol.NFS,
+            status=Repository.Status.CREATING,
+            health=Repository.Health.OFFLINE,
+            bind_node_type=Repository.BindNodeType.PROXY,
+            bind_node_id=new_proxy.id,
+            config={
+                "server_address": "10.0.0.10",
+                "share_path": "/export",
+                "proxy_mount_path": "/mnt/hfl/storage-repositories/repo-new",
+            },
+        )
+        repository_task = enqueue_repository_create_task(
+            repository=repository,
+            operation_type=RepositoryTask.OperationType.REPAIR_REMOUNT,
+            remount_previous_node_id=old_proxy.id,
+            remount_previous_mount_path="/mnt/hfl/storage-repositories/repo-old",
+            dispatch=False,
+        )
+
+        result = run_repository_create_task(repository_task_id=repository_task.id)
+
+        self.assertEqual(result["status"], "failed")
+        remount.assert_called_once()
+        repository.refresh_from_db()
+        self.assertEqual(repository.bind_node_id, new_proxy.id)
+        self.assertEqual(
+            repository.config.get("proxy_mount_path"),
+            "/mnt/hfl/storage-repositories/repo-new",
+        )
+        self.assertEqual(repository.status, Repository.Status.CREATED)
+        self.assertEqual(repository.health, Repository.Health.OFFLINE)
+
+    @mock.patch(
+        "apps.storage.services.internal.repository_create._complete_create_success"
+    )
+    @mock.patch("apps.storage.services.internal.repository_create._run_repair_remount")
+    def test_remount_finalize_failure_keeps_new_proxy(self, remount, complete):
+        remount.return_value = None
+        complete.side_effect = RuntimeError("finalize failed")
+        old_proxy = Node.objects.create(
+            organization=self.org,
+            name="old-proxy-finalize",
+            role=Node.Role.PROXY,
+            status=Node.Status.ONLINE,
+            ip_address="10.0.0.46",
+        )
+        new_proxy = Node.objects.create(
+            organization=self.org,
+            name="new-proxy-finalize",
+            role=Node.Role.PROXY,
+            status=Node.Status.ONLINE,
+            ip_address="10.0.0.47",
+        )
+        repository = Repository.objects.create(
+            organization_id=self.org.id,
+            name="remount-finalize-nas",
+            repo_type=Repository.Type.NAS,
+            nas_protocol=Repository.NasProtocol.NFS,
+            status=Repository.Status.CREATING,
+            health=Repository.Health.OFFLINE,
+            bind_node_type=Repository.BindNodeType.PROXY,
+            bind_node_id=new_proxy.id,
+            config={
+                "server_address": "10.0.0.10",
+                "share_path": "/export",
+                "proxy_mount_path": "/mnt/hfl/storage-repositories/repo-new",
+            },
+        )
+        repository_task = enqueue_repository_create_task(
+            repository=repository,
+            operation_type=RepositoryTask.OperationType.REPAIR_REMOUNT,
+            remount_previous_node_id=old_proxy.id,
+            remount_previous_mount_path="/mnt/hfl/storage-repositories/repo-old",
+            dispatch=False,
+        )
+
+        result = run_repository_create_task(repository_task_id=repository_task.id)
+
+        self.assertEqual(result["status"], "failed")
+        remount.assert_called_once()
+        repository.refresh_from_db()
+        self.assertEqual(repository.bind_node_id, new_proxy.id)
+        self.assertEqual(
+            repository.config.get("proxy_mount_path"),
+            "/mnt/hfl/storage-repositories/repo-new",
+        )
+        self.assertEqual(repository.status, Repository.Status.CREATED)
+        self.assertEqual(repository.health, Repository.Health.OFFLINE)
+
+    @mock.patch("apps.storage.services.internal.repository_create._run_repair_remount")
+    def test_remount_resume_after_rollback_does_not_rerun_remount(self, remount):
+        old_proxy = Node.objects.create(
+            organization=self.org,
+            name="old-proxy-resume",
+            role=Node.Role.PROXY,
+            status=Node.Status.ONLINE,
+            ip_address="10.0.0.44",
+        )
+        new_proxy = Node.objects.create(
+            organization=self.org,
+            name="new-proxy-resume",
+            role=Node.Role.PROXY,
+            status=Node.Status.ONLINE,
+            ip_address="10.0.0.45",
+        )
+        repository = Repository.objects.create(
+            organization_id=self.org.id,
+            name="remount-resume-nas",
+            repo_type=Repository.Type.NAS,
+            nas_protocol=Repository.NasProtocol.NFS,
+            status=Repository.Status.CREATED,
+            health=Repository.Health.OFFLINE,
+            bind_node_type=Repository.BindNodeType.PROXY,
+            bind_node_id=old_proxy.id,
+            config={
+                "server_address": "10.0.0.10",
+                "share_path": "/export",
+                "proxy_mount_path": "/mnt/hfl/storage-repositories/repo-old",
+            },
+        )
+        repository_task = enqueue_repository_create_task(
+            repository=Repository.objects.get(pk=repository.id),
+            operation_type=RepositoryTask.OperationType.REPAIR_REMOUNT,
+            remount_previous_node_id=old_proxy.id,
+            remount_previous_mount_path="/mnt/hfl/storage-repositories/repo-old",
+            dispatch=False,
+        )
+        # Simulate enqueue-time payload pointing at the intended new proxy, while
+        # the live row already rolled back to the previous proxy.
+        task = repository_task.task
+        payload = dict(task.request_payload or {})
+        payload["bind_node_id"] = new_proxy.id
+        task.request_payload = payload
+        task.status = Task.Status.RUNNING
+        task.current_step = "initialize_repository"
+        task.progress = 45
+        task.save(
+            update_fields=[
+                "request_payload",
+                "status",
+                "current_step",
+                "progress",
+                "updated_at",
+            ]
+        )
+        # Keep live binding rolled back (enqueue temporarily set CREATING + new bind).
+        repository.bind_node_id = old_proxy.id
+        repository.status = Repository.Status.CREATED
+        repository.health = Repository.Health.OFFLINE
+        repository.config = {
+            "server_address": "10.0.0.10",
+            "share_path": "/export",
+            "proxy_mount_path": "/mnt/hfl/storage-repositories/repo-old",
+        }
+        repository.save(
+            update_fields=[
+                "bind_node_id",
+                "status",
+                "health",
+                "config",
+                "updated_at",
+            ]
+        )
+
+        result = run_repository_create_task(repository_task_id=repository_task.id)
+
+        self.assertEqual(result["status"], "failed")
+        self.assertTrue(result.get("idempotent"))
+        remount.assert_not_called()
+        repository.refresh_from_db()
+        self.assertEqual(repository.bind_node_id, old_proxy.id)
+        task.refresh_from_db()
+        self.assertEqual(task.status, Task.Status.FAILED)

--- a/src/frontend/src/pages/node/Repositories.vue
+++ b/src/frontend/src/pages/node/Repositories.vue
@@ -2106,6 +2106,10 @@ onMounted(() => {
   const pendingCreateTask = String(route.query.pending_create_task || '').trim()
   if (pendingCreateId > 0 && pendingCreateTask) {
     trackRepositoryCreatePending(pendingCreateId, pendingCreateTask, t('repositoriesPage.statusCreating'))
+    const nextQuery = { ...route.query }
+    delete nextQuery.pending_create_id
+    delete nextQuery.pending_create_task
+    void router.replace({ path: route.path, query: nextQuery })
   }
   void load()
   scheduleRepositoryCleanupPoll(0)


### PR DESCRIPTION
## Summary
- Harden async repository create/bind/remount against reconcile re-entry and partial finalize
- Atomic fail/success finalize; remount rollback only before physical initialize completes
- Block update/repair while creating; clear pending_create query after tracking

## Test plan
- [x] apps.storage.tests.test_repository_create
- [x] apps.storage.tests.test_repository_api
- [x] apps.storage.tests.test_nas_repair_api


Made with [Cursor](https://cursor.com)