### PR TITLE
Fix backup path edit save

### DIFF
--- a/src/frontend/src/locales/enProtectionPages.ts
+++ b/src/frontend/src/locales/enProtectionPages.ts
@@ -591,6 +591,7 @@ export const enProtectionPages = {
     msgBatchRecoveryPlanDisabled: 'Disabled restore plans for {n} source(s).',
     msgTargetCreated: 'Target added.',
     msgSaveEditDemo: 'Saved.',
+    msgEditConfigUnavailable: 'No editable backup configuration is available. Refresh the page and try again.',
     msgManualStarted: 'Backup task started.',
     msgManualDone: 'Backup finished: {name}',
     msgSelectBackupsToDelete: 'Select backups to delete first.',

--- a/src/frontend/src/pages/protection/BackupCreateWizard.vue
+++ b/src/frontend/src/pages/protection/BackupCreateWizard.vue
@@ -4013,9 +4013,14 @@ function addPickedSourceFor(sourceId: string) {
 
 function editBackupConfigIdForSource(sourceId: string) {
   const ids = [...new Set(
-    wizardSourceGroups.value
-      .filter((group) => group.sourceId === sourceId && group.backupConfigId)
-      .map((group) => group.backupConfigId as number),
+    [
+      ...editConfigs.value
+        .filter((config) => sourceIdFromConfig(config) === sourceId)
+        .map((config) => Number(config.id)),
+      ...wizardSourceGroups.value
+        .filter((group) => group.sourceId === sourceId && group.backupConfigId)
+        .map((group) => Number(group.backupConfigId)),
+    ].filter((id) => Number.isFinite(id) && id > 0),
   )]
   return ids.length === 1 ? ids[0] : undefined
 }
@@ -5434,10 +5439,11 @@ async function runCreateBackup() {
 function editableGroupPayloads() {
   const backups = buildCreateBackupPayload().backups
   const groupByKey = new Map(wizardSourceGroups.value.map((group) => [group.key, group]))
-  const configById = new Map(editConfigs.value.map((config) => [config.id, config]))
+  const configById = new Map(editConfigs.value.map((config) => [Number(config.id), config]))
   return backups.flatMap((backup) => {
     const group = groupByKey.get(backup.key)
-    const config = backup.backupConfigId ? configById.get(backup.backupConfigId) : undefined
+    const configId = Number(backup.backupConfigId)
+    const config = Number.isFinite(configId) && configId > 0 ? configById.get(configId) : undefined
     return group && config ? [{ backup, group, config }] : []
   })
 }
@@ -5534,10 +5540,16 @@ async function syncEditRecoveryPlans(config: BackupConfigDetail, backup: ReturnT
 }
 
 async function runEditBackupConfig() {
-  const section = editSection.value
+  const section = activeEditSection.value
   const editables = editableGroupPayloads()
-  if (!section || !editables.length) return
-  if (!validateCreateStep(createStep.value)) return
+  if (!editables.length) {
+    createPhase.value = 'form'
+    ElMessage.error({ message: t('protection.backupsPage.msgEditConfigUnavailable'), grouping: true })
+    return
+  }
+  const step = editStepForSection(section)
+  if (createStep.value !== step) createStep.value = step
+  if (!validateCreateStep(step)) return
   createPhase.value = 'waiting'
   try {
     for (const { backup, group, config } of editables) {

--- a/src/frontend/src/pages/protection/DataProtectionStep3MoreActions.test.ts
+++ b/src/frontend/src/pages/protection/DataProtectionStep3MoreActions.test.ts
@@ -78,8 +78,30 @@ describe('backup wizard step 3 More Actions refresh', () => {
     const editHandlerEnd = wizard.indexOf('function submitCreateWizard', editHandlerStart)
     const editHandler = wizard.slice(editHandlerStart, editHandlerEnd)
 
+    expect(editHandler).toContain('const section = activeEditSection.value')
+    expect(editHandler).toContain("t('protection.backupsPage.msgEditConfigUnavailable')")
+    expect(editHandler).toContain('const step = editStepForSection(section)')
+    expect(editHandler).toContain('if (createStep.value !== step) createStep.value = step')
+    expect(editHandler).toContain('if (!validateCreateStep(step)) return')
     expect(editHandler).toContain('apiErrorMessage(err, editorFailureText.value)')
     expect(protectionLocale).toContain("editFailed: 'Failed to save backup configuration'")
+    expect(protectionLocale).toContain("msgEditConfigUnavailable: 'No editable backup configuration is available. Refresh the page and try again.'")
+  })
+
+  it('keeps new edit-mode paths attached to the original backup config', () => {
+    const editConfigIdStart = wizard.indexOf('function editBackupConfigIdForSource')
+    const editConfigIdEnd = wizard.indexOf('function wizardDirEntryKey', editConfigIdStart)
+    const editConfigIdSource = wizard.slice(editConfigIdStart, editConfigIdEnd)
+    const editablesStart = wizard.indexOf('function editableGroupPayloads')
+    const editablesEnd = wizard.indexOf('function directoryPayloadFromGroup', editablesStart)
+    const editablesSource = wizard.slice(editablesStart, editablesEnd)
+
+    expect(editConfigIdSource).toContain('...editConfigs.value')
+    expect(editConfigIdSource).toContain('sourceIdFromConfig(config) === sourceId')
+    expect(editConfigIdSource).toContain('Number(config.id)')
+    expect(editConfigIdSource).toContain('...wizardSourceGroups.value')
+    expect(editablesSource).toContain('new Map(editConfigs.value.map((config) => [Number(config.id), config]))')
+    expect(editablesSource).toContain('const configId = Number(backup.backupConfigId)')
   })
 
   it('does not show a success notification after manually refreshing the step 3 list', () => {


### PR DESCRIPTION
## Summary
- Preserve backup config ownership when replacing paths in Edit Backup Paths
- Validate edit saves against the active edit section and show an explicit error when no editable config can be matched
- Add regression coverage for edit-mode path replacement save behavior

Closes #351

## Testing
- npm run test -- DataProtectionStep3MoreActions.test.ts
- npm run test -- BackupTargetValidationFlow.test.ts
- npm run build