### PR TITLE
fix(node): accept NodeCredential for remote agent release downloads

### DIFF
--- a/src/backend/apps/node/api/views/artifact_release.py
+++ b/src/backend/apps/node/api/views/artifact_release.py
@@ -22,7 +22,7 @@ from apps.node.api.views.enrollment_helpers import (
     resolve_artifact_download_authorization,
     token_usable_for_artifact_download,
 )
-from apps.node.models import Node, NodeInstallationSession, NodeToken
+from apps.node.models import Node, NodeCredential, NodeInstallationSession, NodeToken
 from apps.node.services.internal.enrollment_auth import (
     INSTALLATION_SESSION_IDLE_SECONDS,
 )
@@ -218,6 +218,25 @@ def _release_authorization_is_valid(
     return True
 
 
+def _release_credential_is_valid(
+    *,
+    org: Organization,
+    role: str,
+    credential_id: int,
+    node_id: int,
+) -> bool:
+    """Validate a signed NodeCredential download without embedding the secret."""
+    if credential_id <= 0 or node_id <= 0:
+        return False
+    return NodeCredential.objects.filter(
+        pk=credential_id,
+        organization=org,
+        role=role,
+        node_id=node_id,
+        is_active=True,
+    ).exists()
+
+
 def _redis_client():
     if redis is None:
         return None
@@ -348,20 +367,23 @@ class AgentReleaseView(APIView):
                 status=status.HTTP_503_SERVICE_UNAVAILABLE,
             )
         ttl = int(os.getenv("AGENT_RELEASE_URL_TTL_SECONDS", "600"))
-        signed = _make_release_token(
-            {
-                "p": artifact.artifact_path,
-                "org": org.key,
-                "role": role,
-                "token_id": authorization.token.id,
-                "session_id": (
-                    authorization.session.id
-                    if authorization.session is not None
-                    else None
-                ),
-            },
-            ttl_seconds=ttl,
-        )
+        signed_payload: dict = {
+            "p": artifact.artifact_path,
+            "org": org.key,
+            "role": role,
+        }
+        if authorization.credential is not None:
+            signed_payload["credential_id"] = authorization.credential.id
+            signed_payload["node_id"] = authorization.credential.node_id
+        else:
+            assert authorization.token is not None
+            signed_payload["token_id"] = authorization.token.id
+            signed_payload["session_id"] = (
+                authorization.session.id
+                if authorization.session is not None
+                else None
+            )
+        signed = _make_release_token(signed_payload, ttl_seconds=ttl)
 
         download_url = _build_download_url(request, artifact, signed)
         try:
@@ -443,11 +465,23 @@ class AgentReleasesAuthView(APIView):
             token_id = int(payload.get("token_id") or 0)
             raw_session_id = payload.get("session_id")
             session_id = int(raw_session_id) if raw_session_id is not None else None
+            credential_id = int(payload.get("credential_id") or 0)
+            node_id = int(payload.get("node_id") or 0)
         except (TypeError, ValueError):
             token_id = 0
             session_id = None
+            credential_id = 0
+            node_id = 0
 
-        if token_id > 0:
+        if credential_id > 0:
+            authorization_valid = _release_credential_is_valid(
+                org=org,
+                role=role,
+                credential_id=credential_id,
+                node_id=node_id,
+            )
+            slot_id = f"credential:{credential_id}"
+        elif token_id > 0:
             authorization_valid = _release_authorization_is_valid(
                 org=org,
                 role=role,

--- a/src/backend/apps/node/api/views/enrollment_helpers.py
+++ b/src/backend/apps/node/api/views/enrollment_helpers.py
@@ -8,7 +8,8 @@ from urllib.parse import urlparse
 from apps.iam.models import Organization
 from apps.node.models import NodeToken
 from apps.node.services.internal.enrollment_auth import (
-    EnrollmentAuthorization,
+    ArtifactDownloadAuthorization,
+    active_node_credential,
     resolve_enrollment_authorization,
 )
 
@@ -57,6 +58,7 @@ def token_usable_for_artifact_download(
 
     Active tokens are always allowed. Legacy one-time tokens that were deactivated
     after first use remain downloadable so existing install links can finish.
+    Registered nodes may also download with their long-lived NodeCredential.
     """
     return (
         resolve_artifact_download_authorization(
@@ -68,20 +70,23 @@ def token_usable_for_artifact_download(
     )
 
 
-def resolve_artifact_download_authorization(
+def _resolve_enrollment_artifact_authorization(
     *,
     org: Organization,
     token: str,
     role: str,
-) -> EnrollmentAuthorization | None:
-    """Resolve active sessions/tokens and used legacy download links."""
+) -> ArtifactDownloadAuthorization | None:
+    """Enrollment/session/legacy-only resolution (no NodeCredential)."""
     authorization = resolve_enrollment_authorization(
         org=org,
         secret=token,
         role=role,
     )
     if authorization is not None:
-        return authorization
+        return ArtifactDownloadAuthorization(
+            token=authorization.token,
+            session=authorization.session,
+        )
     if not token:
         return None
     for row in NodeToken.objects.filter(
@@ -93,7 +98,29 @@ def resolve_artifact_download_authorization(
         "used_at",
     ):
         if secrets.compare_digest(row.token, token) and row.used_at is not None:
-            return EnrollmentAuthorization(token=row)
+            return ArtifactDownloadAuthorization(token=row)
+    return None
+
+
+def resolve_artifact_download_authorization(
+    *,
+    org: Organization,
+    token: str,
+    role: str,
+) -> ArtifactDownloadAuthorization | None:
+    """Resolve enrollment sessions/tokens, used legacy links, or node credentials."""
+    authorization = _resolve_enrollment_artifact_authorization(
+        org=org,
+        token=token,
+        role=role,
+    )
+    if authorization is not None:
+        return authorization
+    if not token:
+        return None
+    credential = active_node_credential(org=org, secret=token, role=role)
+    if credential is not None:
+        return ArtifactDownloadAuthorization(credential=credential)
     return None
 
 
@@ -108,5 +135,13 @@ def token_usable_for_bootstrap(
 
     Used links must still return a shell script so ``curl | bash`` can run ``hfl-enroll``
     and report idempotent success when the agent is already enrolled locally.
+    NodeCredential is intentionally excluded: bootstrap is install-link scoped.
     """
-    return token_usable_for_artifact_download(org=org, token=token, role=role)
+    return (
+        _resolve_enrollment_artifact_authorization(
+            org=org,
+            token=token,
+            role=role,
+        )
+        is not None
+    )

--- a/src/backend/apps/node/services/internal/enrollment_auth.py
+++ b/src/backend/apps/node/services/internal/enrollment_auth.py
@@ -28,6 +28,19 @@ class EnrollmentAuthorization:
     session: NodeInstallationSession | None = None
 
 
+@dataclass(frozen=True)
+class ArtifactDownloadAuthorization:
+    """Authorization for signed agent release downloads.
+
+    Enrollment tokens/sessions cover install-time pulls. Registered nodes use
+    their long-lived NodeCredential for remote upgrades.
+    """
+
+    token: NodeToken | None = None
+    session: NodeInstallationSession | None = None
+    credential: NodeCredential | None = None
+
+
 def _token_matches(row: NodeToken, secret: str) -> bool:
     return bool(secret) and secrets.compare_digest(row.token, secret)
 
@@ -229,6 +242,35 @@ def validate_node_credential(node: Node, secret: str, *, touch: bool = True) -> 
             updated_at=now,
         )
     return True
+
+
+def active_node_credential(
+    *,
+    org: Organization,
+    secret: str,
+    role: str,
+    touch: bool = True,
+) -> NodeCredential | None:
+    """Resolve an active long-lived credential by org, role, and secret."""
+    if not secret:
+        return None
+    rows = NodeCredential.objects.filter(
+        organization=org,
+        role=role,
+        is_active=True,
+        secret_prefix=secret[:12],
+    )
+    for row in rows.iterator():
+        if not row.matches(secret):
+            continue
+        if touch:
+            now = timezone.now()
+            NodeCredential.objects.filter(pk=row.pk).update(
+                last_used_at=now,
+                updated_at=now,
+            )
+        return row
+    return None
 
 
 def legacy_enrollment_token_for_node(

--- a/src/backend/apps/node/tests/test_enrollment_token_reuse.py
+++ b/src/backend/apps/node/tests/test_enrollment_token_reuse.py
@@ -245,3 +245,133 @@ class EnrollmentTokenReuseTests(TestCase):
         self.token_row.save(update_fields=["is_active"])
         denied = AgentReleasesAuthView.as_view()(auth_request)
         self.assertEqual(denied.status_code, 401)
+
+    def test_registered_node_credential_can_issue_and_auth_release_download(self):
+        """Remote upgrade uses durable NodeCredential, not enrollment token."""
+        from apps.node.api.views.enrollment_helpers import (
+            token_usable_for_artifact_download,
+            token_usable_for_bootstrap,
+        )
+        from apps.node.models import NodeCredential
+
+        node = Node.objects.create(
+            organization=self.org,
+            role=NodeRole.AGENT,
+            name="registered-host",
+            installation_id="registered-host",
+        )
+        credential_secret = "hfln_registered-node-credential"
+        credential = NodeCredential(
+            organization=self.org,
+            node=node,
+            role=NodeRole.AGENT,
+            installation_id="registered-host",
+        )
+        credential.set_secret(credential_secret)
+        credential.save()
+
+        self.assertTrue(
+            token_usable_for_artifact_download(
+                org=self.org,
+                token=credential_secret,
+                role=NodeRole.AGENT,
+            )
+        )
+        self.assertFalse(
+            token_usable_for_bootstrap(
+                org=self.org,
+                token=credential_secret,
+                role=NodeRole.AGENT,
+            )
+        )
+
+        request = self.factory.get(
+            "/api/v1/node/enrollment/agent/release",
+            {
+                "org": self.org.key,
+                "role": NodeRole.AGENT,
+                "token": credential_secret,
+                "platform": "linux",
+                "arch": "amd64",
+                "api_base": "https://console.example",
+            },
+        )
+
+        with TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            artifact = AgentArtifact(
+                platform="linux",
+                arch="amd64",
+                version="1.0.0",
+                filename="agent.tar.gz",
+            )
+            artifact_path = root / artifact.version / artifact.filename
+            artifact_path.parent.mkdir(parents=True)
+            artifact_path.write_bytes(b"agent bundle")
+            with (
+                mock.patch(
+                    "apps.node.api.views.artifact_release._get_agent_artifact",
+                    return_value=artifact,
+                ),
+                mock.patch(
+                    "apps.node.api.views.artifact_release.agent_releases_root",
+                    return_value=root,
+                ),
+            ):
+                response = AgentReleaseView.as_view()(request)
+
+        self.assertEqual(response.status_code, 200)
+        signed = parse_qs(urlparse(response.data["download_url"]).query)["t"][0]
+        payload = _load_release_token(signed, max_age=600)
+        self.assertIsNotNone(payload)
+        self.assertNotIn("enroll", payload)
+        self.assertNotIn("token_id", payload)
+        self.assertEqual(payload["credential_id"], credential.id)
+        self.assertEqual(payload["node_id"], node.id)
+
+        auth_request = self.factory.get(
+            "/api/v1/node/enrollment/agent/releases-auth",
+            {"t": signed},
+            HTTP_X_ORIGINAL_URI=payload["p"],
+        )
+        authorized = AgentReleasesAuthView.as_view()(auth_request)
+        self.assertEqual(authorized.status_code, 204)
+
+        credential.is_active = False
+        credential.save(update_fields=["is_active"])
+        denied = AgentReleasesAuthView.as_view()(auth_request)
+        self.assertEqual(denied.status_code, 401)
+
+    def test_wrong_role_node_credential_rejected_for_release(self):
+        from apps.node.models import NodeCredential
+
+        node = Node.objects.create(
+            organization=self.org,
+            role=NodeRole.AGENT,
+            name="wrong-role-host",
+            installation_id="wrong-role-host",
+        )
+        credential_secret = "hfln_wrong-role-credential"
+        credential = NodeCredential(
+            organization=self.org,
+            node=node,
+            role=NodeRole.AGENT,
+            installation_id="wrong-role-host",
+        )
+        credential.set_secret(credential_secret)
+        credential.save()
+
+        request = self.factory.get(
+            "/api/v1/node/enrollment/agent/release",
+            {
+                "org": self.org.key,
+                "role": NodeRole.GATEWAY,
+                "token": credential_secret,
+                "platform": "linux",
+                "arch": "amd64",
+            },
+        )
+        response = AgentReleaseView.as_view()(request)
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.data["error"], "invalid enrollment token")
+


### PR DESCRIPTION
## Summary
- Allow registered nodes to authorize agent release downloads with durable `NodeCredential`, fixing remote upgrade HTTP 401 (`invalid enrollment token`).
- Signed download URLs carry `credential_id`/`node_id` (not the secret); revoked credentials are rejected at nginx auth.
- Keep bootstrap install links enrollment-scoped; add regression coverage for credential issue/auth/revoke and role mismatch.

## Test plan
- [x] `apps.node.tests.test_enrollment_token_reuse` + `test_artifact_release` (keepdb)
- [ ] On 8.69, trigger remote upgrade for a registered source agent and confirm release resolve succeeds


Made with [Cursor](https://cursor.com)