### PR TITLE
feat(frontend): add Configure Restore Plan link for missing restore plans

### DIFF
--- a/src/frontend/src/pages/protection/DataProtection.vue
+++ b/src/frontend/src/pages/protection/DataProtection.vue
@@ -2704,6 +2704,28 @@ function onBackupConfigEditPickSelected(config: BackupConfig | BackupConfigDetai
   openBackupConfigEdit([config], backupConfigEditPickSection.value)
 }
 
+async function openConfigureRestorePlanFromMissingRow(row: { backupId: string }) {
+  const configId = realConfigIdFromBackupId(row.backupId)
+  if (!configId) {
+    ElMessage.warning({ message: t('protection.backupsPage.msgSourceNoBackupConfig'), grouping: true })
+    return
+  }
+  let config: BackupConfig | BackupConfigDetail | undefined = backupConfigDetailById.value.get(configId)
+  if (!config) {
+    try {
+      config = await getBackupConfig(configId)
+      backupConfigDetailById.value.set(config.id, config)
+    } catch (e) {
+      showApiError(e)
+      return
+    }
+  }
+  await closeRecoveryWizard()
+  if (recOpen.value) return
+  await nextTick()
+  openBackupConfigEdit([config], 'recovery')
+}
+
 function taskPayload(task: TaskRow): Record<string, unknown> {
   return task.request_payload && typeof task.request_payload === 'object'
     ? task.request_payload as Record<string, unknown>
@@ -10918,6 +10940,13 @@ async function runRecovery(mode: 'plan' | 'manual' = 'manual') {
                       <div class="recovery-plan-missing-cell__desc">
                         {{ t('protection.backupsPage.recoveryPlanMissingDesc') }}
                       </div>
+                      <button
+                        type="button"
+                        class="recovery-plan-missing-cell__action"
+                        @click="openConfigureRestorePlanFromMissingRow(row)"
+                      >
+                        {{ t('protection.backupsPage.flowActionConfigureRecoveryPlan') }}
+                      </button>
                     </div>
                   </template>
                 </el-table-column>
@@ -13304,6 +13333,31 @@ html[data-theme='dark'] .setup-dr-opening-skeleton__footer {
   font-size: 12px;
   font-weight: 600;
   line-height: 1.45;
+}
+
+.recovery-plan-missing-cell__action {
+  align-self: flex-start;
+  margin: 2px 0 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--color-primary);
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.4;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.recovery-plan-missing-cell__action:hover,
+.recovery-plan-missing-cell__action:focus-visible {
+  color: color-mix(in srgb, var(--color-primary) 78%, #0f172a);
+}
+
+.recovery-plan-missing-cell__action:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--color-primary) 45%, transparent);
+  outline-offset: 2px;
 }
 
 .recovery-manual-inline-layout {

--- a/src/frontend/src/pages/protection/DataProtectionRestorePlanConfigureLink.test.ts
+++ b/src/frontend/src/pages/protection/DataProtectionRestorePlanConfigureLink.test.ts
@@ -1,0 +1,42 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const page = readFileSync(resolve(process.cwd(), 'src/pages/protection/DataProtection.vue'), 'utf8')
+const protectionLocale = readFileSync(resolve(process.cwd(), 'src/locales/enProtectionPages.ts'), 'utf8')
+
+function sourceBetween(startMarker: string, endMarker: string) {
+  const start = page.indexOf(startMarker)
+  const end = page.indexOf(endMarker, start + 1)
+
+  expect(start).toBeGreaterThan(-1)
+  expect(end).toBeGreaterThan(start)
+  return page.slice(start, end)
+}
+
+describe('create restore task missing-plan configure link', () => {
+  it('exposes Configure Restore Plan inside the missing-plan warning cell', () => {
+    const missingCell = sourceBetween(
+      'class="recovery-plan-missing-cell"',
+      ':label="t(\'protection.backupsPage.descSnapshot\')"',
+    )
+
+    expect(missingCell).toContain('recoveryPlanMissingTitle')
+    expect(missingCell).toContain('recoveryPlanMissingDesc')
+    expect(missingCell).toContain('recovery-plan-missing-cell__action')
+    expect(missingCell).toContain('@click="openConfigureRestorePlanFromMissingRow(row)"')
+    expect(missingCell).toContain('flowActionConfigureRecoveryPlan')
+    expect(protectionLocale).toContain("flowActionConfigureRecoveryPlan: 'Configure Restore Plan'")
+  })
+
+  it('closes the restore chooser then opens the existing restore-plan editor', () => {
+    const handler = sourceBetween(
+      'async function openConfigureRestorePlanFromMissingRow',
+      'function taskPayload(task: TaskRow)',
+    )
+
+    expect(handler).toContain('await closeRecoveryWizard()')
+    expect(handler).toContain('openBackupConfigEdit([config], \'recovery\')')
+    expect(handler).toContain('getBackupConfig(configId)')
+  })
+})


### PR DESCRIPTION
## Summary
- Add a **Configure Restore Plan** action under the missing-plan warning on Create Restore Task → Run Restore Plan (#248).
- Clicking it closes the restore chooser and opens the existing backup-config Edit Restore Plan editor for that host.
- Add a lightweight smoke test for the CTA wiring.

## Test plan
- [ ] Open Create Restore Task with a host that has no restore plan
- [ ] Confirm warning still shows, plus **Configure Restore Plan** link
- [ ] Click the link → restore dialog closes and Edit Restore Plan opens for that backup config
- [ ] Save a restore plan, reopen Create Restore Task → host shows as configured


Made with [Cursor](https://cursor.com)