### PR TITLE
fix(protection): accept zero-byte backup sources (#156)

### DIFF
--- a/src/agent/internal/engine/engine.go
+++ b/src/agent/internal/engine/engine.go
@@ -462,9 +462,6 @@ func (e *Engine) runPathSize(ctx context.Context, p Payload) (string, map[string
 		}
 		return "failed", map[string]any{"path": path}, sizeErr.Error()
 	}
-	if sizeBytes <= 0 {
-		return "failed", map[string]any{"path": path, "size_bytes": 0}, "path size estimate returned zero"
-	}
 	return "success", map[string]any{
 		"path":       path,
 		"path_type":  pathType,

--- a/src/agent/internal/engine/path_size_test.go
+++ b/src/agent/internal/engine/path_size_test.go
@@ -1,0 +1,27 @@
+package engine
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRunPathSizeAcceptsZeroByteFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "empty")
+	if err := os.WriteFile(path, nil, 0o600); err != nil {
+		t.Fatalf("create empty file: %v", err)
+	}
+
+	status, result, message := New(nil).runPathSize(context.Background(), Payload{
+		Path:  path,
+		Extra: map[string]any{"path_type": "file"},
+	})
+
+	if status != "success" {
+		t.Fatalf("status = %q, message = %q", status, message)
+	}
+	if got := result["size_bytes"]; got != uint64(0) {
+		t.Fatalf("size_bytes = %#v, want 0", got)
+	}
+}

--- a/src/agent/scripts/package.sh
+++ b/src/agent/scripts/package.sh
@@ -225,6 +225,8 @@ package_archives() {
 		GATEWAY_LIFECYCLE_SCRIPT_VALUE="${GATEWAY_LIFECYCLE_SCRIPT}" \
 		DO_STANDARD_VALUE="${DO_STANDARD}" \
 		UBUNTU_RELEASES_VALUE="${UBUNTU_RELEASES}" python3 - <<'PY'
+from __future__ import annotations
+
 import hashlib
 import json
 import os

--- a/src/backend/apps/protection/migrations/0017_backup_directory_size_estimated_at.py
+++ b/src/backend/apps/protection/migrations/0017_backup_directory_size_estimated_at.py
@@ -1,0 +1,25 @@
+from django.db import migrations, models
+from django.db.models import F
+
+
+def preserve_verified_legacy_estimates(apps, _schema_editor):
+    BackupConfigDirectory = apps.get_model("protection", "BackupConfigDirectory")
+    BackupConfigDirectory.objects.filter(estimated_size_bytes__gt=0).update(
+        size_estimated_at=F("updated_at")
+    )
+
+
+class Migration(migrations.Migration):
+    dependencies = [("protection", "0016_backup_config_repository_endpoint")]
+
+    operations = [
+        migrations.AddField(
+            model_name="backupconfigdirectory",
+            name="size_estimated_at",
+            field=models.DateTimeField(blank=True, null=True),
+        ),
+        migrations.RunPython(
+            preserve_verified_legacy_estimates,
+            migrations.RunPython.noop,
+        ),
+    ]

--- a/src/backend/apps/protection/models/backup_config.py
+++ b/src/backend/apps/protection/models/backup_config.py
@@ -99,6 +99,7 @@ class BackupConfigDirectory(models.Model):
     )
     display_name = models.CharField(max_length=300, blank=True, default="")
     estimated_size_bytes = models.BigIntegerField(default=0)
+    size_estimated_at = models.DateTimeField(blank=True, null=True)
     sort_order = models.IntegerField(default=0)
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)

--- a/src/backend/apps/protection/services/backup_config.py
+++ b/src/backend/apps/protection/services/backup_config.py
@@ -1010,6 +1010,7 @@ def _sync_backup_config_directories(
     for idx, directory_data in enumerate(directories_data):
         path = directory_data["path"]
         directory = existing_by_path.get(path)
+        is_new = directory is None
         if directory is None:
             directory = BackupConfigDirectory(
                 organization_id=config.organization_id,
@@ -1033,24 +1034,41 @@ def _sync_backup_config_directories(
             directory.path_type = incoming_path_type or BackupConfigDirectory.PathType.UNKNOWN
         directory.display_name = directory_data.get("display_name", "")
         # Preserve cached du estimates when the client omits/zeros the field on
-        # unchanged paths. New paths and explicit directory<->file changes
-        # invalidate the cache so async pre-cache can refresh them.
+        # unchanged paths. New paths, explicit directory<->file changes, and
+        # verified positive->zero changes invalidate the cache so async
+        # pre-cache can refresh them. Verified zero estimates are tracked by
+        # size_estimated_at and remain valid across unchanged saves.
         incoming_estimate = directory_data.get("estimated_size_bytes", None)
         next_path_type = str(directory.path_type or "").strip().lower()
-        if incoming_estimate is not None and int(incoming_estimate or 0) > 0:
-            directory.estimated_size_bytes = int(incoming_estimate)
-        elif directory.pk is None:
-            directory.estimated_size_bytes = max(0, int(incoming_estimate or 0))
-        elif (
+        previous_estimate = int(directory.estimated_size_bytes or 0)
+        path_type_changed = (
             previous_path_type in {"directory", "file"}
             and next_path_type in {"directory", "file"}
             and previous_path_type != next_path_type
-        ):
+        )
+        if incoming_estimate is not None and int(incoming_estimate or 0) > 0:
+            directory.estimated_size_bytes = int(incoming_estimate)
+            if is_new or path_type_changed or previous_estimate != int(incoming_estimate):
+                directory.size_estimated_at = None
+        elif directory.pk is None:
+            directory.estimated_size_bytes = max(0, int(incoming_estimate or 0))
+            directory.size_estimated_at = None
+        elif path_type_changed:
             directory.estimated_size_bytes = 0
+            directory.size_estimated_at = None
         elif int(directory.estimated_size_bytes or 0) < 0:
             # Unavailable marker from a failed precache: an explicit directories
             # sync re-opens async retry (positive caches above stay intact).
             directory.estimated_size_bytes = 0
+            directory.size_estimated_at = None
+        elif (
+            incoming_estimate is not None
+            and int(incoming_estimate or 0) <= 0
+            and previous_estimate > 0
+            and directory.size_estimated_at is not None
+        ):
+            directory.estimated_size_bytes = 0
+            directory.size_estimated_at = None
         directory.sort_order = idx
         directory.save()
         created_or_updated.append(directory)

--- a/src/backend/apps/protection/services/directory_size_estimate.py
+++ b/src/backend/apps/protection/services/directory_size_estimate.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from celery.exceptions import SoftTimeLimitExceeded
 from django.core.exceptions import ValidationError
+from django.utils import timezone
 
 from apps.node.services.interface import run_agent_task_sync
 from apps.protection.models import BackupConfig, BackupConfigDirectory, BackupSourceSnapshot
@@ -21,7 +22,7 @@ _PATH_SIZE_KIND = "path.size"
 _PATH_SIZE_TIMEOUT_SECONDS = 300
 _PRECACHE_PATH_TIMEOUT_SECONDS = 60
 _PRECACHE_MAX_ATTEMPTS = 5
-# Stored when path.size was attempted but failed/empty. Progress treats as 0;
+# Stored when path.size was attempted but failed. Progress treats as 0;
 # gating skips re-queue until the cache is invalidated back to 0.
 _ESTIMATE_UNAVAILABLE = -1
 
@@ -29,8 +30,8 @@ _ESTIMATE_UNAVAILABLE = -1
 class DirectorySizeEstimateError(ValidationError):
     """Raised when directory size cannot be estimated.
 
-    permanent=True means the path should not be retried until cache invalidation
-    (e.g. empty/zero result). Timeouts and transient agent errors stay retryable.
+    permanent=True means the path should not be retried until cache invalidation.
+    Timeouts and transient agent errors stay retryable.
     """
 
     def __init__(self, message, *, permanent: bool = False, code=None, params=None):
@@ -98,12 +99,17 @@ def estimate_directory_size_bytes(
         # Agent/host blips are retryable; leave estimate pending for requeue.
         raise DirectorySizeEstimateError(error, permanent=False)
     result = outcome.result
-    size_bytes = int(result.get("size_bytes") or 0)
-    if size_bytes <= 0:
-        raise DirectorySizeEstimateError(
-            f"Path size estimate returned zero for {path}",
-            permanent=True,
-        )
+    if not isinstance(result, dict) or "size_bytes" not in result:
+        raise DirectorySizeEstimateError("Agent returned an invalid path size response.")
+    raw_size_bytes = result["size_bytes"]
+    if isinstance(raw_size_bytes, bool):
+        raise DirectorySizeEstimateError("Agent returned an invalid path size response.")
+    try:
+        size_bytes = int(raw_size_bytes)
+    except (TypeError, ValueError):
+        raise DirectorySizeEstimateError("Agent returned an invalid path size response.") from None
+    if size_bytes < 0:
+        raise DirectorySizeEstimateError("Agent returned an invalid path size response.")
     return size_bytes
 
 
@@ -113,7 +119,7 @@ def _raw_estimate(directory: BackupConfigDirectory) -> int:
 
 def _directory_estimate_pending(directory: BackupConfigDirectory) -> bool:
     """True when estimate has never been successfully cached or marked unavailable."""
-    return _raw_estimate(directory) == 0
+    return _raw_estimate(directory) == 0 and directory.size_estimated_at is None
 
 
 def _du_total_from_directories(directories) -> int:
@@ -138,14 +144,20 @@ def backup_config_needs_directory_estimate_refresh(config: BackupConfig) -> bool
 def invalidate_backup_config_directory_estimates(*, config: BackupConfig) -> int:
     """Clear cached estimates so async precache will retry (e.g. source rebinding)."""
     return int(
-        config.directories.exclude(estimated_size_bytes=0).update(estimated_size_bytes=0)
+        config.directories.exclude(
+            estimated_size_bytes=0,
+            size_estimated_at__isnull=True,
+        ).update(estimated_size_bytes=0, size_estimated_at=None)
     )
 
 
 def _mark_pending_directory_estimates_unavailable(*, config: BackupConfig) -> int:
     """Stop retrying pending paths until an explicit cache invalidation."""
     return int(
-        config.directories.filter(estimated_size_bytes=0).update(
+        config.directories.filter(
+            estimated_size_bytes=0,
+            size_estimated_at__isnull=True,
+        ).update(
             estimated_size_bytes=_ESTIMATE_UNAVAILABLE
         )
     )
@@ -237,7 +249,10 @@ def refresh_missing_backup_config_directory_estimates(
                 )
                 continue
             directory.estimated_size_bytes = estimated
-            directory.save(update_fields=["estimated_size_bytes", "updated_at"])
+            directory.size_estimated_at = timezone.now()
+            directory.save(
+                update_fields=["estimated_size_bytes", "size_estimated_at", "updated_at"]
+            )
             current = estimated
             logger.info(
                 "directory_size_estimated config_id=%s directory_id=%s path=%s "

--- a/src/backend/apps/protection/services/progress/step3_progress.py
+++ b/src/backend/apps/protection/services/progress/step3_progress.py
@@ -501,5 +501,8 @@ def missing_directory_estimates(config: BackupConfig) -> list[BackupConfigDirect
     return [
         directory
         for directory in config.directories.all()
-        if max(0, int(directory.estimated_size_bytes or 0)) <= 0
+        if (
+            max(0, int(directory.estimated_size_bytes or 0)) <= 0
+            and directory.size_estimated_at is None
+        )
     ]

--- a/src/backend/apps/protection/tests/test_directory_size_estimate.py
+++ b/src/backend/apps/protection/tests/test_directory_size_estimate.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 from types import SimpleNamespace
 from unittest.mock import patch
 
+from django.core.exceptions import ValidationError
 from django.test import TestCase
+from django.utils import timezone
 
 from apps.iam.models import Organization
 from apps.node.models import Node
@@ -17,6 +19,7 @@ from apps.protection.services.directory_size_estimate import (
     DirectorySizeEstimateResolveError,
     _ESTIMATE_UNAVAILABLE,
     backup_config_needs_directory_estimate_refresh,
+    estimate_directory_size_bytes,
     refresh_backup_config_directory_estimates_by_id,
     refresh_missing_backup_config_directory_estimates,
 )
@@ -77,18 +80,57 @@ class DirectorySizeEstimateTests(TestCase):
             sort_order=0,
         )
 
+    def _target(self):
+        return SimpleNamespace(
+            source_type="agent",
+            root_path="",
+            nas_payload=None,
+            node=self.agent,
+        )
+
+    def _agent_outcome(self, result):
+        return SimpleNamespace(
+            timed_out=False,
+            ok=True,
+            result=result,
+            task=SimpleNamespace(last_error=""),
+            stream_message=None,
+        )
+
+    @patch("apps.protection.services.directory_size_estimate.run_agent_task_sync")
+    def test_zero_size_is_a_valid_agent_estimate(self, run_agent_task_sync):
+        run_agent_task_sync.return_value = self._agent_outcome({"size_bytes": 0})
+
+        self.assertEqual(
+            estimate_directory_size_bytes(
+                node_id=self.agent.id,
+                path="/empty",
+                path_type="file",
+                organization_id=self.org.id,
+                execution_target=self._target(),
+            ),
+            0,
+        )
+
+    @patch("apps.protection.services.directory_size_estimate.run_agent_task_sync")
+    def test_missing_size_is_not_treated_as_an_empty_path(self, run_agent_task_sync):
+        run_agent_task_sync.return_value = self._agent_outcome({})
+
+        with self.assertRaisesMessage(ValidationError, "invalid path size response"):
+            estimate_directory_size_bytes(
+                node_id=self.agent.id,
+                path="/empty",
+                organization_id=self.org.id,
+                execution_target=self._target(),
+            )
+
     @patch(
         "apps.protection.services.directory_size_estimate.estimate_directory_size_bytes",
         return_value=4096,
     )
     @patch("apps.protection.services.directory_size_estimate._resolve_execution_target")
     def test_refresh_missing_persists_estimate(self, mock_resolve, mock_estimate):
-        mock_resolve.return_value = SimpleNamespace(
-            node=self.agent,
-            source_type="agent",
-            root_path="",
-            nas_payload=None,
-        )
+        mock_resolve.return_value = self._target()
         total = refresh_missing_backup_config_directory_estimates(
             organization_id=self.org.id,
             config=self.config,
@@ -98,7 +140,41 @@ class DirectorySizeEstimateTests(TestCase):
         self.directory.refresh_from_db()
         self.assertEqual(total, 4096)
         self.assertEqual(self.directory.estimated_size_bytes, 4096)
+        self.assertIsNotNone(self.directory.size_estimated_at)
         mock_estimate.assert_called_once()
+
+    @patch(
+        "apps.protection.services.directory_size_estimate.estimate_directory_size_bytes",
+        return_value=0,
+    )
+    @patch("apps.protection.services.directory_size_estimate._resolve_execution_target")
+    def test_verified_zero_size_is_not_reestimated(self, mock_resolve, mock_estimate):
+        mock_resolve.return_value = self._target()
+
+        self.assertEqual(
+            refresh_missing_backup_config_directory_estimates(
+                organization_id=self.org.id,
+                config=self.config,
+                source_type="agent",
+                source_ref_id=self.agent.id,
+            ),
+            0,
+        )
+        self.directory.refresh_from_db()
+        self.assertEqual(self.directory.estimated_size_bytes, 0)
+        self.assertIsNotNone(self.directory.size_estimated_at)
+        self.assertFalse(backup_config_needs_directory_estimate_refresh(self.config))
+
+        self.assertEqual(
+            refresh_missing_backup_config_directory_estimates(
+                organization_id=self.org.id,
+                config=self.config,
+                source_type="agent",
+                source_ref_id=self.agent.id,
+            ),
+            0,
+        )
+        self.assertEqual(mock_estimate.call_count, 1)
 
     @patch(
         "apps.protection.services.directory_size_estimate.estimate_directory_size_bytes",
@@ -106,12 +182,7 @@ class DirectorySizeEstimateTests(TestCase):
     )
     @patch("apps.protection.services.directory_size_estimate._resolve_execution_target")
     def test_refresh_timeout_stays_retryable(self, mock_resolve, _mock_estimate):
-        mock_resolve.return_value = SimpleNamespace(
-            node=self.agent,
-            source_type="agent",
-            root_path="",
-            nas_payload=None,
-        )
+        mock_resolve.return_value = self._target()
         total = refresh_missing_backup_config_directory_estimates(
             organization_id=self.org.id,
             config=self.config,
@@ -121,22 +192,18 @@ class DirectorySizeEstimateTests(TestCase):
         self.directory.refresh_from_db()
         self.assertEqual(total, 0)
         self.assertEqual(self.directory.estimated_size_bytes, 0)
+        self.assertIsNone(self.directory.size_estimated_at)
         self.assertTrue(backup_config_needs_directory_estimate_refresh(self.config))
 
     @patch(
         "apps.protection.services.directory_size_estimate.estimate_directory_size_bytes",
-        side_effect=DirectorySizeEstimateError("returned zero", permanent=True),
+        side_effect=DirectorySizeEstimateError("permanent", permanent=True),
     )
     @patch("apps.protection.services.directory_size_estimate._resolve_execution_target")
     def test_refresh_permanent_failure_marks_unavailable(
         self, mock_resolve, _mock_estimate
     ):
-        mock_resolve.return_value = SimpleNamespace(
-            node=self.agent,
-            source_type="agent",
-            root_path="",
-            nas_payload=None,
-        )
+        mock_resolve.return_value = self._target()
         total = refresh_missing_backup_config_directory_estimates(
             organization_id=self.org.id,
             config=self.config,
@@ -155,12 +222,7 @@ class DirectorySizeEstimateTests(TestCase):
     def test_refresh_skips_cached_estimates(self, mock_resolve, mock_estimate):
         self.directory.estimated_size_bytes = 2048
         self.directory.save(update_fields=["estimated_size_bytes", "updated_at"])
-        mock_resolve.return_value = SimpleNamespace(
-            node=self.agent,
-            source_type="agent",
-            root_path="",
-            nas_payload=None,
-        )
+        mock_resolve.return_value = self._target()
         total = refresh_missing_backup_config_directory_estimates(
             organization_id=self.org.id,
             config=self.config,
@@ -190,8 +252,14 @@ class DirectorySizeEstimateTests(TestCase):
     def test_path_type_change_invalidates_cached_estimate(self):
         self.directory.path_type = BackupConfigDirectory.PathType.DIRECTORY
         self.directory.estimated_size_bytes = 4096
+        self.directory.size_estimated_at = timezone.now()
         self.directory.save(
-            update_fields=["path_type", "estimated_size_bytes", "updated_at"]
+            update_fields=[
+                "path_type",
+                "estimated_size_bytes",
+                "size_estimated_at",
+                "updated_at",
+            ]
         )
         _sync_backup_config_directories(
             config=self.config,
@@ -208,6 +276,7 @@ class DirectorySizeEstimateTests(TestCase):
             BackupConfigDirectory.PathType.FILE,
         )
         self.assertEqual(self.directory.estimated_size_bytes, 0)
+        self.assertIsNone(self.directory.size_estimated_at)
 
     def test_unknown_path_type_omission_keeps_cached_estimate(self):
         self.directory.path_type = BackupConfigDirectory.PathType.DIRECTORY
@@ -253,6 +322,34 @@ class DirectorySizeEstimateTests(TestCase):
         self.directory.refresh_from_db()
         self.assertEqual(self.directory.estimated_size_bytes, 4096)
         self.assertEqual(self.directory.display_name, "Home")
+
+    def test_changing_verified_positive_estimate_to_zero_invalidates_it(self):
+        self.directory.path_type = BackupConfigDirectory.PathType.FILE
+        self.directory.estimated_size_bytes = 1024
+        self.directory.size_estimated_at = timezone.now()
+        self.directory.save(
+            update_fields=[
+                "path_type",
+                "estimated_size_bytes",
+                "size_estimated_at",
+                "updated_at",
+            ]
+        )
+
+        _sync_backup_config_directories(
+            config=self.config,
+            directories_data=[
+                {
+                    "path": "/home/ubuntu",
+                    "path_type": BackupConfigDirectory.PathType.FILE,
+                    "estimated_size_bytes": 0,
+                }
+            ],
+        )
+
+        self.directory.refresh_from_db()
+        self.assertEqual(self.directory.estimated_size_bytes, 0)
+        self.assertIsNone(self.directory.size_estimated_at)
 
     def test_directory_sync_reopens_unavailable_estimate(self):
         self.directory.path_type = BackupConfigDirectory.PathType.DIRECTORY
@@ -324,7 +421,6 @@ class DirectorySizeEstimateTests(TestCase):
         )
         self.assertEqual(result["status"], "exhausted")
         self.assertFalse(result["should_requeue"])
-        # Retryable leftovers stay pending for a later directories/source save.
         self.directory.refresh_from_db()
         self.assertEqual(self.directory.estimated_size_bytes, 0)
         self.assertTrue(backup_config_needs_directory_estimate_refresh(self.config))
@@ -361,7 +457,10 @@ class DirectorySizeEstimateTests(TestCase):
 
     def test_source_change_invalidates_cached_estimates(self):
         self.directory.estimated_size_bytes = 4096
-        self.directory.save(update_fields=["estimated_size_bytes", "updated_at"])
+        self.directory.size_estimated_at = timezone.now()
+        self.directory.save(
+            update_fields=["estimated_size_bytes", "size_estimated_at", "updated_at"]
+        )
         update_backup_config(
             config=self.config,
             data={
@@ -375,6 +474,7 @@ class DirectorySizeEstimateTests(TestCase):
         self.config.refresh_from_db()
         self.assertEqual(self.config.source_ref_id, self.agent_b.id)
         self.assertEqual(self.directory.estimated_size_bytes, 0)
+        self.assertIsNone(self.directory.size_estimated_at)
         self.assertTrue(backup_config_needs_directory_estimate_refresh(self.config))
 
     @patch(

--- a/tools/quality/check-python38-runtime.py
+++ b/tools/quality/check-python38-runtime.py
@@ -13,6 +13,7 @@ SHELL_FILES = [
     ROOT / "deploy/installer/install.sh",
     ROOT / "deploy/installer/sourcelens/install.sh",
     ROOT / "src/agent/packaging/install/install.sh",
+    ROOT / "src/agent/scripts/package.sh",
 ]
 PYTHON_FILES = [
     ROOT / "deploy/installer/apply-runtime-config.py",


### PR DESCRIPTION
## Summary

- Accept zero-byte path size estimates as valid Agent results instead of treating them as failures.
- Track confirmed zero estimates with a `size_estimated_at` timestamp so they are not rechecked unnecessarily.
- Preserve cache invalidation for path-type changes and verified positive-to-zero transitions.
- Add Python 3.8 compatibility for the agent packaging script and enforce it in CI.

## Testing

- [x] Agent engine: zero-byte file path size returns success (new unit test)
- [x] Backend: verified zero estimates are not re-estimated on refresh
- [x] Backend: path-type changes correctly invalidate cached estimates
- [x] Backend: changing a verified positive estimate to zero invalidates the cache
- [x] CI: Python 3.8 runtime compatibility check passes with package.sh included

Closes #156