### PR TITLE
fix(frontend): restyle missing restore-plan cell to match wizard language

### DIFF
--- a/src/frontend/src/pages/protection/DataProtection.vue
+++ b/src/frontend/src/pages/protection/DataProtection.vue
@@ -32,7 +32,6 @@ import {
   MoreHorizontal,
   FolderOpen,
   TextCursorInput,
-  AlertTriangle,
   X,
   ShieldAlert,
   ShieldCheck,
@@ -10930,23 +10929,29 @@ async function runRecovery(mode: 'plan' | 'manual' = 'manual') {
                         </div>
                       </template>
                     </HflPopover>
-                    <div v-else class="recovery-plan-missing-cell">
-                      <div class="recovery-plan-missing-cell__head">
-                        <AlertTriangle :size="15" class="recovery-plan-missing-cell__icon" />
-                        <span class="recovery-plan-missing-cell__title">
+                    <div
+                      v-else
+                      class="create-recovery-plan-cell create-recovery-plan-cell--review create-recovery-plan-cell--pending recovery-plan-missing-cell"
+                    >
+                      <div class="create-recovery-plan-cell__status">
+                        <span class="create-recovery-plan-cell__dot" aria-hidden="true" />
+                        <span class="create-recovery-plan-cell__status-label">
                           {{ t('protection.backupsPage.recoveryPlanMissingTitle') }}
                         </span>
                       </div>
-                      <div class="recovery-plan-missing-cell__desc">
+                      <div class="create-recovery-plan-cell__meta">
                         {{ t('protection.backupsPage.recoveryPlanMissingDesc') }}
                       </div>
-                      <button
-                        type="button"
-                        class="recovery-plan-missing-cell__action"
+                      <ElButton
+                        text
+                        type="primary"
+                        size="small"
+                        class="hfl-btn-with-icon recovery-plan-missing-cell__action"
                         @click="openConfigureRestorePlanFromMissingRow(row)"
                       >
-                        {{ t('protection.backupsPage.flowActionConfigureRecoveryPlan') }}
-                      </button>
+                        <Route :size="14" class="shrink-0" />
+                        <span>{{ t('protection.backupsPage.flowActionConfigureRecoveryPlan') }}</span>
+                      </ElButton>
                     </div>
                   </template>
                 </el-table-column>
@@ -13294,70 +13299,16 @@ html[data-theme='dark'] .setup-dr-opening-skeleton__footer {
 }
 
 .recovery-plan-missing-cell {
-  display: flex;
-  width: 100%;
-  min-width: 0;
-  flex-direction: column;
+  align-items: flex-start;
   gap: 6px;
-  padding: 8px 10px;
-  border: 1px solid rgba(245, 158, 11, 0.34);
-  border-radius: 8px;
-  background: rgba(255, 251, 235, 0.72);
-  color: rgb(120 53 15);
-}
-
-.recovery-plan-missing-cell__head {
-  display: inline-flex;
-  min-width: 0;
-  align-items: center;
-  gap: 6px;
-}
-
-.recovery-plan-missing-cell__icon {
-  flex: 0 0 auto;
-  color: rgb(217 119 6);
-}
-
-.recovery-plan-missing-cell__title {
-  min-width: 0;
-  overflow: hidden;
-  font-size: 13px;
-  font-weight: 700;
-  line-height: 1.35;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.recovery-plan-missing-cell__desc {
-  color: rgb(146 64 14);
-  font-size: 12px;
-  font-weight: 600;
-  line-height: 1.45;
 }
 
 .recovery-plan-missing-cell__action {
-  align-self: flex-start;
-  margin: 2px 0 0;
-  padding: 0;
-  border: 0;
-  background: transparent;
-  color: var(--color-primary);
-  cursor: pointer;
-  font-size: 12px;
-  font-weight: 700;
-  line-height: 1.4;
-  text-decoration: underline;
-  text-underline-offset: 2px;
-}
-
-.recovery-plan-missing-cell__action:hover,
-.recovery-plan-missing-cell__action:focus-visible {
-  color: color-mix(in srgb, var(--color-primary) 78%, #0f172a);
-}
-
-.recovery-plan-missing-cell__action:focus-visible {
-  outline: 2px solid color-mix(in srgb, var(--color-primary) 45%, transparent);
-  outline-offset: 2px;
+  margin-left: -7px;
+  height: auto;
+  min-height: 24px;
+  padding: 0 7px;
+  font-weight: 650;
 }
 
 .recovery-manual-inline-layout {
@@ -13594,6 +13545,12 @@ html[data-theme='dark'] .setup-dr-opening-skeleton__footer {
   line-height: 1.45;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.recovery-plan-missing-cell .create-recovery-plan-cell__meta {
+  overflow: visible;
+  text-overflow: unset;
+  white-space: normal;
 }
 
 .create-recovery-plan-cell__policy {

--- a/src/frontend/src/pages/protection/DataProtectionRestorePlanConfigureLink.test.ts
+++ b/src/frontend/src/pages/protection/DataProtectionRestorePlanConfigureLink.test.ts
@@ -15,18 +15,24 @@ function sourceBetween(startMarker: string, endMarker: string) {
 }
 
 describe('create restore task missing-plan configure link', () => {
-  it('exposes Configure Restore Plan inside the missing-plan warning cell', () => {
+  it('renders missing plans with the shared recovery-plan cell style and configure action', () => {
     const missingCell = sourceBetween(
-      'class="recovery-plan-missing-cell"',
+      'create-recovery-plan-cell--pending recovery-plan-missing-cell',
       ':label="t(\'protection.backupsPage.descSnapshot\')"',
     )
 
+    expect(missingCell).toContain('create-recovery-plan-cell__status')
+    expect(missingCell).toContain('create-recovery-plan-cell__dot')
+    expect(missingCell).toContain('create-recovery-plan-cell__meta')
     expect(missingCell).toContain('recoveryPlanMissingTitle')
     expect(missingCell).toContain('recoveryPlanMissingDesc')
     expect(missingCell).toContain('recovery-plan-missing-cell__action')
     expect(missingCell).toContain('@click="openConfigureRestorePlanFromMissingRow(row)"')
     expect(missingCell).toContain('flowActionConfigureRecoveryPlan')
+    expect(missingCell).toContain('<Route')
+    expect(missingCell).not.toContain('AlertTriangle')
     expect(protectionLocale).toContain("flowActionConfigureRecoveryPlan: 'Configure Restore Plan'")
+    expect(page).toContain('.recovery-plan-missing-cell .create-recovery-plan-cell__meta')
   })
 
   it('closes the restore chooser then opens the existing restore-plan editor', () => {


### PR DESCRIPTION
## Summary
- Restyle the Create Restore Task missing restore-plan cell to reuse the shared `create-recovery-plan-cell` status-dot language instead of the amber warning box.
- Keep the Configure Restore Plan CTA as a text primary button that closes the chooser and opens Edit Restore Plan.
- Update the smoke test to assert the shared cell markup and meta wrapping CSS.

Closes #248

## Test plan
- [ ] Open Create Restore Task for a source without a restore plan and confirm the cell shows status-dot + title + description + Configure Restore Plan.
- [ ] Click Configure Restore Plan and confirm Edit Restore Plan opens after the chooser closes.
- [ ] Confirm configured restore-plan rows still render unchanged.
- [ ] Run `DataProtectionRestorePlanConfigureLink.test.ts`.


Made with [Cursor](https://cursor.com)