### PR TITLE
feat(node): separate lifecycle status from availability

### DIFF
--- a/src/backend/apps/alert/services/internal/evaluation.py
+++ b/src/backend/apps/alert/services/internal/evaluation.py
@@ -201,7 +201,7 @@ def _evaluate_availability_policy(policy: AlertPolicy) -> None:
         last_seen = node.last_seen_at
         stale = last_seen is None or (now - last_seen).total_seconds() > timeout_seconds
         stub = _ResourceStub(str(node.id), node.name)
-        if stale or node.status != Node.Status.ONLINE:
+        if stale or node.availability != Node.Availability.ONLINE:
             fire_alert(
                 policy,
                 resource=stub,

--- a/src/backend/apps/alert/tests/test_evaluation.py
+++ b/src/backend/apps/alert/tests/test_evaluation.py
@@ -53,7 +53,7 @@ def test_availability_policy_fires_on_stale_node(db):
         organization=org,
         name="stale-node",
         role=NodeRole.PROXY,
-        status=Node.Status.OFFLINE,
+        status=Node.Status.ACTIVE, availability=Node.Availability.OFFLINE,
         last_seen_at=timezone.now() - timedelta(hours=2),
     )
     AlertPolicy.objects.create(

--- a/src/backend/apps/lens_bridge/services/knowledge_source_sync.py
+++ b/src/backend/apps/lens_bridge/services/knowledge_source_sync.py
@@ -336,7 +336,7 @@ def request_knowledge_source_sync(
             }
         )
 
-    if ks.gateway.status != Node.Status.ONLINE:
+    if ks.gateway.availability != Node.Availability.ONLINE:
         raise ValidationError({"gateway": "Data gateway must be online to sync."})
 
     from apps.node.services.internal.node_lifecycle import _active_lifecycle_task

--- a/src/backend/apps/lens_bridge/services/provisioning.py
+++ b/src/backend/apps/lens_bridge/services/provisioning.py
@@ -1302,7 +1302,7 @@ def browse_gateway_directory(
     )
 
     gateway = require_gateway_node(org, gateway_id)
-    if gateway.status != Node.Status.ONLINE:
+    if gateway.availability != Node.Availability.ONLINE:
         raise ValidationError({"gateway": "Data gateway must be online to browse directories."})
 
     link = get_gateway_link(org, gateway.id)

--- a/src/backend/apps/lens_bridge/tests/test_chat_teardown.py
+++ b/src/backend/apps/lens_bridge/tests/test_chat_teardown.py
@@ -45,7 +45,7 @@ class CopilotChatTeardownTests(TestCase):
             organization=self.platform_org,
             name="platform-gateway",
             role=Node.Role.GATEWAY,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
         )
         self.gateway_link = LensGatewayLink.objects.create(
             organization=self.platform_org,
@@ -1375,7 +1375,7 @@ class CopilotChatTeardownTests(TestCase):
             organization=self.tenant,
             name="private-gateway",
             role=Node.Role.GATEWAY,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
         )
         private_link = LensGatewayLink.objects.create(
             organization=self.tenant,

--- a/src/backend/apps/lens_bridge/tests/test_gateway_authorization.py
+++ b/src/backend/apps/lens_bridge/tests/test_gateway_authorization.py
@@ -32,7 +32,7 @@ class PrivateGatewayApiAuthorizationTests(TestCase):
             organization=self.org,
             name="Private gateway",
             role=NodeRole.GATEWAY,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
         )
         self.link = LensGatewayLink.objects.create(
             organization=self.org,

--- a/src/backend/apps/lens_bridge/tests/test_gateway_execution.py
+++ b/src/backend/apps/lens_bridge/tests/test_gateway_execution.py
@@ -35,7 +35,7 @@ class GatewayExecutionContextTests(TestCase):
             organization=platform_org,
             name="shared-platform-gateway",
             role=NodeRole.GATEWAY,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
         )
         link = LensGatewayLink.objects.create(
             organization=platform_org,
@@ -61,7 +61,7 @@ class GatewayExecutionContextTests(TestCase):
             organization=other_org,
             name="other-private-gateway",
             role=NodeRole.GATEWAY,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
         )
         link = LensGatewayLink.objects.create(
             organization=other_org,
@@ -82,7 +82,7 @@ class GatewayExecutionContextTests(TestCase):
             organization=self.tenant,
             name="private-user-gateway",
             role=NodeRole.GATEWAY,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
         )
         link = LensGatewayLink.objects.create(
             organization=self.tenant,

--- a/src/backend/apps/lens_bridge/tests/test_knowledge_source_sync.py
+++ b/src/backend/apps/lens_bridge/tests/test_knowledge_source_sync.py
@@ -27,7 +27,7 @@ class KnowledgeSourceSyncLeaseTests(TransactionTestCase):
             organization=self.organization,
             name="sync-gateway",
             role=Node.Role.GATEWAY,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
         )
         gateway_link = LensGatewayLink.objects.create(
             organization=self.organization,
@@ -320,7 +320,7 @@ class ManagedRestorePipelineOrderTests(TestCase):
             organization=gateway_org,
             name="gateway",
             role=Node.Role.GATEWAY,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
         )
         gateway_link = LensGatewayLink.objects.create(
             organization=gateway_org,

--- a/src/backend/apps/lens_bridge/tests/test_provisioning.py
+++ b/src/backend/apps/lens_bridge/tests/test_provisioning.py
@@ -518,7 +518,7 @@ class BrowseGatewayDirectoryTests(SimpleTestCase):
     ):
         from apps.lens_bridge.services.provisioning import browse_gateway_directory
 
-        gateway = MagicMock(id=7, status="online")
+        gateway = MagicMock(id=7, status="active", availability="online")
         require_gateway.return_value = gateway
         link = MagicMock()
         link.resolved_workspace_root.return_value = "/workspace/org-1/data"

--- a/src/backend/apps/monitor/selectors/internal/platform_summary.py
+++ b/src/backend/apps/monitor/selectors/internal/platform_summary.py
@@ -18,7 +18,7 @@ def offline_node_count() -> int:
     try:
         from apps.node.models import Node
 
-        return Node.objects.filter(status=Node.Status.OFFLINE).count()
+        return Node.objects.filter(availability=Node.Availability.OFFLINE).count()
     except Exception:
         return 0
 

--- a/src/backend/apps/monitor/tests/test_node_monitor_api.py
+++ b/src/backend/apps/monitor/tests/test_node_monitor_api.py
@@ -33,7 +33,7 @@ class NodeMonitorApiTests(TestCase):
             organization=self.org,
             name="agent-01",
             role=NodeRole.AGENT,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             metadata={"inventory": {"hostname": "agent-host", "os": "linux", "arch": "amd64"}},
         )
 

--- a/src/backend/apps/node/api/serializers/lifecycle_watch.py
+++ b/src/backend/apps/node/api/serializers/lifecycle_watch.py
@@ -4,10 +4,7 @@ from rest_framework import serializers
 
 from apps.node.models import Node
 from apps.node.services.internal.node_lifecycle import compute_node_lifecycle
-from apps.node.services.internal.node_registry import (
-    agent_connection_status,
-    agent_ws_routable,
-)
+from apps.node.services.internal.node_registry import agent_ws_routable
 
 
 class NodeLifecycleWatchRequestSerializer(serializers.Serializer):
@@ -20,20 +17,15 @@ class NodeLifecycleWatchRequestSerializer(serializers.Serializer):
 
 class NodeLifecycleWatchEntrySerializer(serializers.Serializer):
     id = serializers.IntegerField(read_only=True)
-    status = serializers.SerializerMethodField()
     routable = serializers.SerializerMethodField()
     version = serializers.CharField(read_only=True)
     is_deleted = serializers.BooleanField(read_only=True)
     lifecycle = serializers.SerializerMethodField()
 
     @staticmethod
-    def get_status(obj: Node) -> str:
-        return agent_connection_status(obj)
-
-    @staticmethod
     def get_routable(obj: Node) -> bool:
         if obj.role not in (Node.Role.AGENT, Node.Role.PROXY, Node.Role.GATEWAY):
-            return obj.status == Node.Status.ONLINE
+            return obj.availability == Node.Availability.ONLINE
         return agent_ws_routable(agent_id=obj.id)
 
     def get_lifecycle(self, obj: Node):

--- a/src/backend/apps/node/api/serializers/node.py
+++ b/src/backend/apps/node/api/serializers/node.py
@@ -3,17 +3,13 @@
 from rest_framework import serializers
 
 from apps.node.models import Node
-from apps.node.services.internal.node_registry import (
-    agent_connection_status,
-    agent_ws_routable,
-)
+from apps.node.services.internal.node_registry import agent_ws_routable
 
 
 class NodeSerializer(serializers.ModelSerializer):
     """Console REST representation of a registered Agent node."""
 
     agent_control_ws_path = serializers.SerializerMethodField(read_only=True)
-    status = serializers.SerializerMethodField()
     routable = serializers.SerializerMethodField()
     lifecycle = serializers.SerializerMethodField(read_only=True)
     workload = serializers.SerializerMethodField(read_only=True)
@@ -61,13 +57,9 @@ class NodeSerializer(serializers.ModelSerializer):
         return "/ws/node/agent/"
 
     @staticmethod
-    def get_status(obj: Node) -> str:
-        return agent_connection_status(obj)
-
-    @staticmethod
     def get_routable(obj: Node) -> bool:
         if obj.role not in (Node.Role.AGENT, Node.Role.PROXY, Node.Role.GATEWAY):
-            return obj.status == Node.Status.ONLINE
+            return obj.availability == Node.Availability.ONLINE
         return agent_ws_routable(agent_id=obj.id)
 
     def get_lifecycle(self, obj: Node):

--- a/src/backend/apps/node/migrations/0011_node_lifecycle_status.py
+++ b/src/backend/apps/node/migrations/0011_node_lifecycle_status.py
@@ -1,0 +1,34 @@
+from django.db import migrations, models
+
+
+def promote_connection_status_to_lifecycle(apps, schema_editor):
+    del schema_editor
+    Node = apps.get_model("node", "Node")
+    Node.objects.filter(status__in=("online", "offline")).update(status="active")
+
+
+class Migration(migrations.Migration):
+    dependencies = [("node", "0010_enrollment_sessions_and_credentials")]
+
+    operations = [
+        migrations.RunPython(promote_connection_status_to_lifecycle, migrations.RunPython.noop),
+        migrations.AlterField(
+            model_name="node",
+            name="status",
+            field=models.CharField(
+                choices=[
+                    ("active", "Active"),
+                    ("upgrading", "Upgrading"),
+                    ("restarting", "Restarting"),
+                    ("verifying", "Verifying"),
+                    ("verification_pending", "Verification pending"),
+                    ("removing", "Removing"),
+                    ("cleaning_up", "Cleaning up"),
+                    ("failed", "Failed"),
+                ],
+                db_index=True,
+                default="active",
+                max_length=20,
+            ),
+        ),
+    ]

--- a/src/backend/apps/node/migrations/0012_node_operation_failure_statuses.py
+++ b/src/backend/apps/node/migrations/0012_node_operation_failure_statuses.py
@@ -1,0 +1,29 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [("node", "0011_node_lifecycle_status")]
+
+    operations = [
+        migrations.AlterField(
+            model_name="node",
+            name="status",
+            field=models.CharField(
+                choices=[
+                    ("active", "Active"),
+                    ("upgrading", "Upgrading"),
+                    ("restarting", "Restarting"),
+                    ("verifying", "Verifying"),
+                    ("verification_pending", "Verification pending"),
+                    ("removing", "Removing"),
+                    ("cleaning_up", "Cleaning up"),
+                    ("failed", "Failed"),
+                    ("upgrade_failed", "Upgrade Failed"),
+                    ("deregistration_failed", "Deregistration Failed"),
+                ],
+                db_index=True,
+                default="active",
+                max_length=32,
+            ),
+        ),
+    ]

--- a/src/backend/apps/node/models/node.py
+++ b/src/backend/apps/node/models/node.py
@@ -10,8 +10,16 @@ class Node(OrganizationScopedModel):
     """Registered Agent endpoint (agent, proxy, or gateway)."""
 
     class Status(models.TextChoices):
-        ONLINE = "online", "Online"
-        OFFLINE = "offline", "Offline"
+        ACTIVE = "active", "Active"
+        UPGRADING = "upgrading", "Upgrading"
+        RESTARTING = "restarting", "Restarting"
+        VERIFYING = "verifying", "Verifying"
+        VERIFICATION_PENDING = "verification_pending", "Verification pending"
+        REMOVING = "removing", "Removing"
+        CLEANING_UP = "cleaning_up", "Cleaning up"
+        FAILED = "failed", "Failed"
+        UPGRADE_FAILED = "upgrade_failed", "Upgrade Failed"
+        DEREGISTRATION_FAILED = "deregistration_failed", "Deregistration Failed"
 
     class Availability(models.TextChoices):
         ONLINE = "online", "Online"
@@ -49,9 +57,9 @@ class Node(OrganizationScopedModel):
         help_text="Bounded current Agent network-interface snapshot.",
     )
     status = models.CharField(
-        max_length=20,
+        max_length=32,
         choices=Status.choices,
-        default=Status.OFFLINE,
+        default=Status.ACTIVE,
         db_index=True,
     )
     availability = models.CharField(

--- a/src/backend/apps/node/services/internal/agent_upgrade.py
+++ b/src/backend/apps/node/services/internal/agent_upgrade.py
@@ -58,7 +58,7 @@ def validate_agent_upgrade(*, node: Node) -> str:
             code="role_not_upgradeable",
         )
 
-    if node.status != Node.Status.ONLINE:
+    if node.availability != Node.Availability.ONLINE:
         raise AgentUpgradeError("node is offline", code="node_offline")
 
     platform, arch = node_platform_arch(node)

--- a/src/backend/apps/node/services/internal/node_lifecycle.py
+++ b/src/backend/apps/node/services/internal/node_lifecycle.py
@@ -353,7 +353,7 @@ def _upgrade_verify_ready(*, node: Node, task: NodeTask) -> bool:
         return False
     if not agent_session_registered(agent_id=node.id):
         return False
-    if node.status != Node.Status.ONLINE:
+    if node.availability != Node.Availability.ONLINE:
         return False
     result = task.result if isinstance(task.result, dict) else {}
     if not result.get("disconnect_observed_at"):
@@ -1088,7 +1088,7 @@ def preview_batch_operations(
             continue
 
         if kind == LIFECYCLE_KIND_UPGRADE:
-            if node.status != Node.Status.ONLINE or not agent_ws_routable(agent_id=node.id):
+            if node.availability != Node.Availability.ONLINE or not agent_ws_routable(agent_id=node.id):
                 skipped_offline.append({**item, "reason": "offline"})
                 continue
             if _disk_blocks_upgrade(node):

--- a/src/backend/apps/node/services/internal/node_registry.py
+++ b/src/backend/apps/node/services/internal/node_registry.py
@@ -17,9 +17,25 @@ from apps.node.services.internal.task import fail_active_tasks_for_node
 
 logger = logging.getLogger(__name__)
 
-CONNECTION_ONLINE = Node.Status.ONLINE
+CONNECTION_ONLINE = Node.Availability.ONLINE
 CONNECTION_RECONNECTING = "reconnecting"
-CONNECTION_OFFLINE = Node.Status.OFFLINE
+CONNECTION_OFFLINE = Node.Availability.OFFLINE
+NODE_OPERATION_BLOCKING_STATUSES = frozenset({
+    Node.Status.UPGRADING,
+    Node.Status.RESTARTING,
+    Node.Status.VERIFYING,
+    Node.Status.VERIFICATION_PENDING,
+    Node.Status.REMOVING,
+    Node.Status.CLEANING_UP,
+})
+
+
+def node_is_available_for_work(node: Node) -> bool:
+    """A reachable node can execute work unless a lifecycle operation owns it."""
+    return (
+        node.availability == Node.Availability.ONLINE
+        and node.status not in NODE_OPERATION_BLOCKING_STATUSES
+    )
 
 
 def _agent_lease_grace_seconds() -> int:
@@ -34,41 +50,27 @@ def _last_seen_within_grace(node: Node) -> bool:
 
 
 def effective_agent_node_status(node: Node) -> str:
-    """
-    Agent / Proxy nodes are online only when DB status is online and Redis has a live WSS session.
-    """
+    """Return the effective availability of a node, including WSS lease health."""
     if node.role not in (NodeRole.AGENT, NodeRole.PROXY):
-        return node.status
-    if node.status != Node.Status.ONLINE:
-        return Node.Status.OFFLINE
+        return node.availability
+    if node.availability != Node.Availability.ONLINE:
+        return Node.Availability.OFFLINE
     if _agent_routable(agent_id=node.id):
-        return Node.Status.ONLINE
+        return Node.Availability.ONLINE
     if _last_seen_within_grace(node):
-        return Node.Status.ONLINE
-    return Node.Status.OFFLINE
+        return Node.Availability.ONLINE
+    return Node.Availability.OFFLINE
 
 
 def agent_connection_status(node: Node) -> str:
-    """
-    Display-oriented connectivity state.
-
-    ``online`` means the agent still holds a live WSS lease (``agent_loc``) or is
-    fully routable. ``reconnecting`` means the lease was cleared but ``last_seen_at``
-    is still within grace (expected during agent restarts). Shared ``node_alive:*``
-    keys are *not* used here — a flicker on one WS worker must not mark unrelated
-    agents as reconnecting while their own ``agent_loc`` is still refreshed.
-    """
+    """Internal task-reconciliation connection state; never expose it via APIs."""
     if node.role not in (NodeRole.AGENT, NodeRole.PROXY):
-        return node.status
-    if node.status != Node.Status.ONLINE:
+        return str(node.availability or CONNECTION_OFFLINE)
+    if node.availability != Node.Availability.ONLINE:
         return CONNECTION_OFFLINE
-    if agent_ws_routable(agent_id=node.id):
+    if agent_ws_routable(agent_id=node.id) or _agent_loc_key_exists(agent_id=node.id):
         return CONNECTION_ONLINE
-    if _agent_loc_key_exists(agent_id=node.id):
-        return CONNECTION_ONLINE
-    if _last_seen_within_grace(node):
-        return CONNECTION_RECONNECTING
-    return CONNECTION_OFFLINE
+    return CONNECTION_RECONNECTING if _last_seen_within_grace(node) else CONNECTION_OFFLINE
 
 
 def _within_reconnect_grace(node: Node) -> bool:
@@ -246,7 +248,7 @@ def reconcile_node_availability(*, limit: int = 200) -> dict[str, int | bool | s
 
 def reconcile_stale_online_nodes(*, limit: int = 200) -> dict[str, int]:
     """
-    Mark ``online`` nodes without fresh Redis routing as ``offline``.
+    Mark available nodes without fresh Redis routing as unavailable.
 
     Fails in-flight ``NodeTask`` rows on affected nodes (ghost-task cleanup).
     """
@@ -255,7 +257,7 @@ def reconcile_stale_online_nodes(*, limit: int = 200) -> dict[str, int]:
     task_failure_held = not redis_store.offline_task_finalization_ready()
 
     node_ids = list(
-        Node.objects.filter(status=Node.Status.ONLINE)
+        Node.objects.filter(availability=Node.Availability.ONLINE)
         .order_by("last_seen_at", "id")
         .values_list("pk", flat=True)[: max(1, int(limit))]
     )
@@ -264,7 +266,7 @@ def reconcile_stale_online_nodes(*, limit: int = 200) -> dict[str, int]:
         with transaction.atomic():
             node = (
                 Node.objects.select_for_update()
-                .filter(pk=node_id, status=Node.Status.ONLINE)
+                .filter(pk=node_id, availability=Node.Availability.ONLINE)
                 .first()
             )
             if node is None:
@@ -274,8 +276,9 @@ def reconcile_stale_online_nodes(*, limit: int = 200) -> dict[str, int]:
             if _last_seen_within_grace(node):
                 continue
 
-            node.status = Node.Status.OFFLINE
-            node.save(update_fields=["status", "updated_at"])
+            node.availability = Node.Availability.OFFLINE
+            node.availability_updated_at = timezone.now()
+            node.save(update_fields=["availability", "availability_updated_at", "updated_at"])
             nodes_marked_offline += 1
             try:
                 from apps.source.services.internal.agent_host_sync import sync_agent_source_host

--- a/src/backend/apps/node/services/internal/proxy_decommission.py
+++ b/src/backend/apps/node/services/internal/proxy_decommission.py
@@ -91,7 +91,7 @@ def force_cleanup_proxy_bindings(
             details=preflight["blocking"],
         )
 
-    if proxy.status != Node.Status.ONLINE:
+    if proxy.availability != Node.Availability.ONLINE:
         raise ProxyDecommissionBlocked(
             message="Proxy must be online to force-delete with NAS cleanup.",
             code="proxy_offline",

--- a/src/backend/apps/node/services/internal/task.py
+++ b/src/backend/apps/node/services/internal/task.py
@@ -291,7 +291,7 @@ def _node_route_state(*, task: NodeTask) -> _RouteState:
     if _node_ws_routable(node_id=node.id):
         return _RouteState.ONLINE
     if (
-        node.status == Node.Status.ONLINE
+        node.availability == Node.Availability.ONLINE
         and _last_seen_within_task_route_grace(node)
         and _task_within_route_grace(task)
     ):
@@ -334,13 +334,35 @@ def _sync_task_info(task: NodeTask) -> None:
 
 
 def project_node_lifecycle_task(*, node_task: NodeTask) -> None:
-    """Safely project direct node removal without affecting the Agent task."""
+    """Project lifecycle task progress into the persisted Node state machine."""
     payload = node_task.payload if isinstance(node_task.payload, dict) else {}
-    if (
-        node_task.correlation_type != node_conf.LIFECYCLE_CORRELATION_TYPE
-        or node_task.kind != "agent.uninstall"
-        or payload.get("source_unregister_task_id")
-    ):
+    if node_task.correlation_type != node_conf.LIFECYCLE_CORRELATION_TYPE:
+        return
+    if node_task.kind == "agent.upgrade":
+        status = (
+            Node.Status.UPGRADING
+            if node_task.status in {NodeTask.Status.PENDING, NodeTask.Status.RUNNING}
+            else Node.Status.ACTIVE
+            if node_task.status == NodeTask.Status.SUCCESS
+            else Node.Status.UPGRADE_FAILED
+        )
+        updated = Node.objects.filter(pk=node_task.node_id).exclude(status=status).update(status=status)
+        if updated:
+            _sync_agent_source_pipeline_status(node_id=node_task.node_id)
+        return
+    if node_task.kind != "agent.uninstall":
+        return
+    status = (
+        Node.Status.REMOVING
+        if node_task.status in {NodeTask.Status.PENDING, NodeTask.Status.RUNNING}
+        else Node.Status.CLEANING_UP
+        if node_task.status == NodeTask.Status.SUCCESS
+        else Node.Status.DEREGISTRATION_FAILED
+    )
+    updated = Node.objects.filter(pk=node_task.node_id).exclude(status=status).update(status=status)
+    if updated:
+        _sync_agent_source_pipeline_status(node_id=node_task.node_id)
+    if payload.get("source_unregister_task_id"):
         return
     try:
         from apps.node.services.internal.node_lifecycle_task import (
@@ -352,6 +374,27 @@ def project_node_lifecycle_task(*, node_task: NodeTask) -> None:
         logger.exception(
             "failed to project node lifecycle task node_task_id=%s",
             node_task.pk,
+        )
+
+
+def _sync_agent_source_pipeline_status(*, node_id: int) -> None:
+    """Refresh the Backup Wizard read model after a Node lifecycle transition."""
+    node = Node.objects.filter(pk=node_id, role=NodeRole.AGENT, is_deleted=False).first()
+    if node is None:
+        return
+    try:
+        from apps.source.services.internal.source_pipeline import sync_pipeline_projection
+
+        sync_pipeline_projection(
+            organization_id=node.organization_id,
+            source_kind="agent",
+            ref_id=node.id,
+        )
+    except Exception:
+        logger.warning(
+            "agent source pipeline status projection failed node_id=%s",
+            node_id,
+            exc_info=True,
         )
 
 

--- a/src/backend/apps/node/tests/test_agent_task_sync.py
+++ b/src/backend/apps/node/tests/test_agent_task_sync.py
@@ -28,7 +28,7 @@ class AgentTaskSyncWaitTests(TestCase):
             organization=self.org,
             name="agent-task-sync",
             role=NodeRole.AGENT,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             last_seen_at=timezone.now(),
         )
         self.task = NodeTask.objects.create(
@@ -178,7 +178,7 @@ class AgentTaskSyncWaitTests(TestCase):
         self.assertEqual(task.status, NodeTask.Status.FAILED)
         self.assertEqual(task.last_error, "agent websocket is not routable")
         self.node.refresh_from_db()
-        self.assertEqual(self.node.status, Node.Status.ONLINE)
+        self.assertEqual(self.node.availability, Node.Availability.ONLINE)
         mock_clear_agent_location.assert_called_once_with(agent_id=self.node.id)
         mock_push_task_stream.assert_called_once()
 
@@ -200,8 +200,8 @@ class AgentTaskSyncWaitTests(TestCase):
             def set(self, *args, **kwargs):
                 return True
 
-        self.node.status = Node.Status.OFFLINE
-        self.node.save(update_fields=["status"])
+        self.node.availability = Node.Availability.OFFLINE
+        self.node.save(update_fields=["availability"])
         self.task.status = NodeTask.Status.PENDING
         self.task.save(update_fields=["status"])
         self.task.refresh_from_db()

--- a/src/backend/apps/node/tests/test_agent_uninstall.py
+++ b/src/backend/apps/node/tests/test_agent_uninstall.py
@@ -29,7 +29,7 @@ class AgentUninstallTests(TestCase):
             organization=self.org,
             name="agent-uninstall",
             role=NodeRole.AGENT,
-            status=Node.Status.OFFLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.OFFLINE,
             metadata={"capabilities": ["detached_uninstall_v2"]},
         )
         self.resource = SourceResource.objects.create(
@@ -62,7 +62,7 @@ class AgentUninstallTests(TestCase):
             organization=self.org,
             name="gateway-uninstall",
             role=NodeRole.GATEWAY,
-            status=Node.Status.OFFLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.OFFLINE,
         )
         summary = remove_agent_node(
             org=self.org,

--- a/src/backend/apps/node/tests/test_agent_upgrade.py
+++ b/src/backend/apps/node/tests/test_agent_upgrade.py
@@ -27,7 +27,7 @@ def releases_root(tmp_path, monkeypatch):
 
 
 def test_validate_agent_upgrade_rejects_offline(releases_root):
-    node = Node(role=Node.Role.AGENT, status=Node.Status.OFFLINE, version="1.0.0")
+    node = Node(role=Node.Role.AGENT, status=Node.Status.ACTIVE, availability=Node.Availability.OFFLINE, version="1.0.0")
     with pytest.raises(AgentUpgradeError, match="offline") as exc:
         validate_agent_upgrade(node=node)
     assert exc.value.code == "node_offline"
@@ -36,7 +36,7 @@ def test_validate_agent_upgrade_rejects_offline(releases_root):
 def test_validate_agent_upgrade_accepts_same_version(releases_root):
     node = Node(
         role=Node.Role.AGENT,
-        status=Node.Status.ONLINE,
+        status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
         version="1.0.1",
         metadata={"inventory": {"os": "linux", "arch": "amd64"}},
     )
@@ -46,7 +46,7 @@ def test_validate_agent_upgrade_accepts_same_version(releases_root):
 def test_validate_agent_upgrade_rejects_downgrade(releases_root):
     node = Node(
         role=Node.Role.AGENT,
-        status=Node.Status.ONLINE,
+        status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
         version="9.9.9",
         metadata={"inventory": {"os": "linux", "arch": "amd64"}},
     )
@@ -58,7 +58,7 @@ def test_validate_agent_upgrade_rejects_downgrade(releases_root):
 def test_validate_agent_upgrade_accepts_lower_current(releases_root):
     node = Node(
         role=Node.Role.PROXY,
-        status=Node.Status.ONLINE,
+        status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
         version="1.0.0",
         metadata={"inventory": {"os": "linux", "arch": "amd64"}},
     )
@@ -73,7 +73,7 @@ def test_validate_agent_upgrade_accepts_main_build(releases_root, monkeypatch):
     monkeypatch.setenv("AGENT_VERSION", version)
     node = Node(
         role=Node.Role.AGENT,
-        status=Node.Status.ONLINE,
+        status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
         version="main-7654321",
         metadata={"inventory": {"os": "linux", "arch": "amd64"}},
     )
@@ -84,7 +84,7 @@ def test_validate_agent_upgrade_accepts_main_build(releases_root, monkeypatch):
 def test_node_platform_arch_treats_darwin_as_macos_not_windows():
     node = Node(
         role=Node.Role.AGENT,
-        status=Node.Status.ONLINE,
+        status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
         os_name="darwin arm64",
         metadata={"inventory": {"os": "darwin", "arch": "arm64"}},
     )

--- a/src/backend/apps/node/tests/test_complete_task_idempotency.py
+++ b/src/backend/apps/node/tests/test_complete_task_idempotency.py
@@ -18,7 +18,7 @@ class CompleteTaskIdempotencyTests(TestCase):
             organization=self.org,
             name="complete-task-node",
             role=NodeRole.AGENT,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
         )
         self.task = NodeTask.objects.create(
             organization=self.org,

--- a/src/backend/apps/node/tests/test_node_enrichment_api.py
+++ b/src/backend/apps/node/tests/test_node_enrichment_api.py
@@ -31,7 +31,7 @@ class NodeEnrichmentReadOnlyTests(TestCase):
             organization=self.org,
             name="agent-enrich",
             role=NodeRole.AGENT,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             version="1.0.0",
         )
 
@@ -65,7 +65,7 @@ class NodeLifecycleWatchApiTests(TestCase):
             organization=self.org,
             name="agent-watch",
             role=NodeRole.AGENT,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             version="1.0.0",
             last_seen_at=timezone.now(),
         )

--- a/src/backend/apps/node/tests/test_node_lifecycle.py
+++ b/src/backend/apps/node/tests/test_node_lifecycle.py
@@ -27,6 +27,7 @@ from apps.node.services.internal.task import (
     complete_task,
     create_agent_task,
     deliver_agent_task,
+    project_node_lifecycle_task,
 )
 from apps.task.models import Task, TaskResource
 
@@ -44,7 +45,7 @@ class NodeLifecycleTests(TestCase):
             organization=self.org,
             name="agent-lifecycle",
             role=NodeRole.AGENT,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             version="1.0.0",
             metadata={"capabilities": ["detached_uninstall_v2"]},
         )
@@ -64,6 +65,31 @@ class NodeLifecycleTests(TestCase):
             is_primary=True,
         )
         return task
+
+    def test_lifecycle_failure_projects_operation_specific_node_status(self):
+        cases = (
+            ("agent.upgrade", Node.Status.UPGRADE_FAILED),
+            ("agent.uninstall", Node.Status.DEREGISTRATION_FAILED),
+        )
+        for kind, expected_status in cases:
+            with self.subTest(kind=kind):
+                task = NodeTask.objects.create(
+                    organization=self.org,
+                    node=self.node,
+                    kind=kind,
+                    status=NodeTask.Status.FAILED,
+                    watchdog_deadline_at=timezone.now(),
+                    correlation_type=node_conf.LIFECYCLE_CORRELATION_TYPE,
+                    correlation_id=f"{kind}:{self.node.id}",
+                )
+
+                project_node_lifecycle_task(node_task=task)
+
+                self.node.refresh_from_db()
+                self.assertEqual(self.node.status, expected_status)
+                self.assertEqual(self.node.availability, Node.Availability.ONLINE)
+                self.node.status = Node.Status.ACTIVE
+                self.node.save(update_fields=["status", "updated_at"])
 
     def test_upgrade_is_blocked_by_active_source_unregister(self):
         self._create_active_source_unregister()
@@ -426,7 +452,7 @@ class NodeLifecycleTests(TestCase):
             organization=self.org,
             name="gateway-with-knowledge-source",
             role=NodeRole.GATEWAY,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
         )
         gateway_link = LensGatewayLink.objects.create(
             organization=self.org,

--- a/src/backend/apps/node/tests/test_node_online_status.py
+++ b/src/backend/apps/node/tests/test_node_online_status.py
@@ -84,7 +84,7 @@ class AgentNodeOnlineStatusTests(TestCase):
             organization=self.org,
             name="agent-1",
             role=NodeRole.AGENT,
-            status=Node.Status.OFFLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.OFFLINE,
         )
         self.redis = _FakeRedis()
         self._redis_patcher = self._patch_redis(self.redis)
@@ -117,12 +117,12 @@ class AgentNodeOnlineStatusTests(TestCase):
         on_agent_connected(node_id=self.node.id, session_id="session-a")
 
         self.node.refresh_from_db()
-        self.assertEqual(self.node.status, Node.Status.ONLINE)
+        self.assertEqual(self.node.availability, Node.Availability.ONLINE)
         self.assertEqual(self.node.availability, Node.Availability.ONLINE)
         self.assertIsNotNone(self.node.availability_updated_at)
         self.assertEqual(
             effective_agent_node_status(self.node),
-            Node.Status.ONLINE,
+            Node.Availability.ONLINE,
         )
 
     def test_ws_connect_updates_connection_ip_without_overwriting_host_ip(self):
@@ -155,13 +155,13 @@ class AgentNodeOnlineStatusTests(TestCase):
         on_agent_disconnected(node_id=self.node.id, session_id="session-a")
 
         self.node.refresh_from_db()
-        self.assertEqual(self.node.status, Node.Status.ONLINE)
+        self.assertEqual(self.node.availability, Node.Availability.ONLINE)
         self.assertEqual(self.node.availability, Node.Availability.ONLINE)
         self.assertEqual(agent_connection_status(self.node), CONNECTION_RECONNECTING)
         self.assertIsNone(redis_store.get_agent_location(agent_id=self.node.id))
         self.assertEqual(
             effective_agent_node_status(self.node),
-            Node.Status.ONLINE,
+            Node.Availability.ONLINE,
         )
 
     def test_ws_disconnect_effective_offline_after_grace(self):
@@ -177,7 +177,7 @@ class AgentNodeOnlineStatusTests(TestCase):
 
         self.assertEqual(
             effective_agent_node_status(self.node),
-            Node.Status.OFFLINE,
+            Node.Availability.OFFLINE,
         )
 
     def test_ws_disconnect_does_not_fail_active_task(self):
@@ -227,36 +227,36 @@ class AgentNodeOnlineStatusTests(TestCase):
         on_agent_disconnected(node_id=self.node.id, session_id="session-a")
 
         self.node.refresh_from_db()
-        self.assertEqual(self.node.status, Node.Status.ONLINE)
+        self.assertEqual(self.node.availability, Node.Availability.ONLINE)
         self.assertEqual(
             effective_agent_node_status(self.node),
-            Node.Status.ONLINE,
+            Node.Availability.ONLINE,
         )
         raw = self.redis.get(redis_store.agent_loc_key(self.node.id))
         assert raw is not None
         self.assertEqual(json.loads(raw)["session"], "session-b")
 
     def test_effective_status_offline_without_ws_route(self):
-        self.node.status = Node.Status.ONLINE
+        self.node.availability = Node.Availability.ONLINE
         self.node.last_seen_at = timezone.now() - timezone.timedelta(
             seconds=node_conf.AGENT_LOC_TTL_SECONDS + 5,
         )
-        self.node.save(update_fields=["status", "last_seen_at", "updated_at"])
+        self.node.save(update_fields=["availability", "last_seen_at", "updated_at"])
 
         self.assertEqual(
             effective_agent_node_status(self.node),
-            Node.Status.OFFLINE,
+            Node.Availability.OFFLINE,
         )
-        self.assertEqual(agent_connection_status(self.node), Node.Status.OFFLINE)
+        self.assertEqual(agent_connection_status(self.node), Node.Availability.OFFLINE)
 
     def test_effective_status_grace_without_ws_route(self):
-        self.node.status = Node.Status.ONLINE
+        self.node.availability = Node.Availability.ONLINE
         self.node.last_seen_at = timezone.now()
-        self.node.save(update_fields=["status", "last_seen_at", "updated_at"])
+        self.node.save(update_fields=["availability", "last_seen_at", "updated_at"])
 
         self.assertEqual(
             effective_agent_node_status(self.node),
-            Node.Status.ONLINE,
+            Node.Availability.ONLINE,
         )
 
     def test_reconcile_marks_stale_online_offline(self):
@@ -271,7 +271,7 @@ class AgentNodeOnlineStatusTests(TestCase):
         summary = reconcile_stale_online_nodes(limit=10)
 
         self.node.refresh_from_db()
-        self.assertEqual(self.node.status, Node.Status.OFFLINE)
+        self.assertEqual(self.node.availability, Node.Availability.OFFLINE)
         self.assertEqual(summary["nodes_marked_offline"], 1)
 
     def test_reconcile_skips_recent_last_seen(self):
@@ -282,7 +282,7 @@ class AgentNodeOnlineStatusTests(TestCase):
         summary = reconcile_stale_online_nodes(limit=10)
 
         self.node.refresh_from_db()
-        self.assertEqual(self.node.status, Node.Status.ONLINE)
+        self.assertEqual(self.node.availability, Node.Availability.ONLINE)
         self.assertEqual(summary["nodes_marked_offline"], 0)
 
     def test_availability_reconcile_marks_stale_node_offline(self):
@@ -409,13 +409,13 @@ class AgentNodeOnlineStatusTests(TestCase):
 
         self.assertEqual(redis_store.get_agent_location(agent_id=self.node.id), ws_id)
 
-        self.node.status = Node.Status.ONLINE
-        self.node.save(update_fields=["status", "updated_at"])
+        self.node.availability = Node.Availability.ONLINE
+        self.node.save(update_fields=["availability", "updated_at"])
         self.assertEqual(
             effective_agent_node_status(self.node),
-            Node.Status.ONLINE,
+            Node.Availability.ONLINE,
         )
-        self.assertEqual(agent_connection_status(self.node), Node.Status.ONLINE)
+        self.assertEqual(agent_connection_status(self.node), Node.Availability.ONLINE)
 
     def test_connection_status_online_when_agent_loc_present_without_ws_alive(self):
         """Other agents must not show reconnecting when only shared ws_alive flickers."""
@@ -425,12 +425,12 @@ class AgentNodeOnlineStatusTests(TestCase):
             session_id="session-z",
             ws_instance_id=ws_id,
         )
-        self.node.status = Node.Status.ONLINE
+        self.node.availability = Node.Availability.ONLINE
         self.node.last_seen_at = timezone.now()
-        self.node.save(update_fields=["status", "last_seen_at", "updated_at"])
+        self.node.save(update_fields=["availability", "last_seen_at", "updated_at"])
 
         self.assertFalse(redis_store.get_redis().exists(redis_store.ws_alive_key(ws_id)))
-        self.assertEqual(agent_connection_status(self.node), Node.Status.ONLINE)
+        self.assertEqual(agent_connection_status(self.node), Node.Availability.ONLINE)
 
     def test_session_payload_round_trip(self):
         ws_id = node_conf.WS_INSTANCE_ID
@@ -457,7 +457,7 @@ class AgentNodeOnlineStatusTests(TestCase):
             organization=self.org,
             name="agent-2",
             role=NodeRole.AGENT,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
         )
         redis_store.set_agent_location(
             agent_id=other_node.id,
@@ -489,9 +489,9 @@ class AgentNodeOnlineStatusTests(TestCase):
 
     def test_ensure_agent_location_on_heartbeat_recreates_expired_lease(self):
         ws_id = node_conf.WS_INSTANCE_ID
-        self.node.status = Node.Status.ONLINE
+        self.node.availability = Node.Availability.ONLINE
         self.node.last_seen_at = timezone.now()
-        self.node.save(update_fields=["status", "last_seen_at", "updated_at"])
+        self.node.save(update_fields=["availability", "last_seen_at", "updated_at"])
         redis_store.set_agent_location(
             agent_id=self.node.id,
             session_id="session-old",
@@ -509,4 +509,4 @@ class AgentNodeOnlineStatusTests(TestCase):
         raw = self.redis.get(redis_store.agent_loc_key(self.node.id))
         payload = json.loads(raw)
         self.assertEqual(payload["session"], "session-live")
-        self.assertEqual(agent_connection_status(self.node), Node.Status.ONLINE)
+        self.assertEqual(agent_connection_status(self.node), Node.Availability.ONLINE)

--- a/src/backend/apps/node/tests/test_node_operations_api.py
+++ b/src/backend/apps/node/tests/test_node_operations_api.py
@@ -25,7 +25,7 @@ class NodeOperationsApiTests(APITestCase):
             organization=self.org,
             name="agent-ops",
             role=NodeRole.AGENT,
-            status=Node.Status.OFFLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.OFFLINE,
             version="1.0.0",
         )
 

--- a/src/backend/apps/node/tests/test_node_workload.py
+++ b/src/backend/apps/node/tests/test_node_workload.py
@@ -16,7 +16,7 @@ class NodeWorkloadTests(TestCase):
             organization=self.org,
             name="proxy-1",
             role=NodeRole.PROXY,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             version="1.0.0",
         )
 

--- a/src/backend/apps/node/tests/test_proxy_bindings.py
+++ b/src/backend/apps/node/tests/test_proxy_bindings.py
@@ -37,7 +37,7 @@ class ProxyBindingsTests(TestCase):
             organization=self.org,
             name="proxy-1",
             role=NodeRole.PROXY,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             ip_address="10.0.0.50",
         )
 

--- a/src/backend/apps/node/tests/test_task_cancel_grace.py
+++ b/src/backend/apps/node/tests/test_task_cancel_grace.py
@@ -18,7 +18,7 @@ class NodeTaskCancelGraceTests(TestCase):
             organization=self.org,
             name="cancel-grace-agent",
             role=NodeRole.AGENT,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
         )
 
     def create_task(self, *, status=NodeTask.Status.RUNNING) -> NodeTask:

--- a/src/backend/apps/node/tests/test_task_command_ack.py
+++ b/src/backend/apps/node/tests/test_task_command_ack.py
@@ -24,7 +24,7 @@ class TaskCommandAckTests(TestCase):
             organization=self.org,
             name="ack-agent",
             role=Node.Role.AGENT,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             last_seen_at=timezone.now(),
             metadata={"inventory": {"capabilities": ["task_command_ack_v1"]}},
         )

--- a/src/backend/apps/node/tests/test_task_offline_reconcile.py
+++ b/src/backend/apps/node/tests/test_task_offline_reconcile.py
@@ -32,7 +32,7 @@ class TaskExecutionStateTests(TestCase):
             organization=self.org,
             name="agent-offline",
             role=NodeRole.AGENT,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             last_seen_at=timezone.now() - timedelta(seconds=300),
         )
         self.task = Task.objects.create(
@@ -55,9 +55,9 @@ class TaskExecutionStateTests(TestCase):
         self.assertTrue(is_node_offline_stale(self.node))
 
     def test_reconnecting_state_within_grace(self):
-        self.node.status = Node.Status.ONLINE
+        self.node.availability = Node.Availability.ONLINE
         self.node.last_seen_at = timezone.now() - timedelta(seconds=30)
-        self.node.save(update_fields=["status", "last_seen_at", "updated_at"])
+        self.node.save(update_fields=["availability", "last_seen_at", "updated_at"])
         self.assertEqual(task_execution_state(node=self.node, task=self.task), "reconnecting")
         self.assertTrue(product_task_blocks_cleanup(task=self.task))
 
@@ -66,11 +66,11 @@ class TaskExecutionStateTests(TestCase):
         return_value=True,
     )
     def test_offline_pending_blocks_cleanup(self, _mock_ready):
-        self.node.status = Node.Status.OFFLINE
+        self.node.availability = Node.Availability.OFFLINE
         self.node.last_seen_at = timezone.now() - timedelta(
             seconds=node_conf.NODE_RECONNECT_GRACE_SECONDS + 10
         )
-        self.node.save(update_fields=["status", "last_seen_at", "updated_at"])
+        self.node.save(update_fields=["availability", "last_seen_at", "updated_at"])
         self.assertEqual(task_execution_state(node=self.node, task=self.task), "offline_pending")
         self.assertTrue(product_task_blocks_cleanup(task=self.task))
 

--- a/src/backend/apps/node/tests/test_uninstall_completion.py
+++ b/src/backend/apps/node/tests/test_uninstall_completion.py
@@ -26,7 +26,7 @@ class UninstallCompletionTests(TestCase):
             organization=self.org,
             name="uninstall-completion-agent",
             role=Node.Role.AGENT,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
         )
 
     def _task(self, *, force: bool = False) -> NodeTask:

--- a/src/backend/apps/node/tests/test_uplink_queue.py
+++ b/src/backend/apps/node/tests/test_uplink_queue.py
@@ -200,7 +200,7 @@ class UplinkQueueTests(TestCase):
             organization=self.org,
             name="agent-uplink",
             role=NodeRole.AGENT,
-            status=Node.Status.OFFLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.OFFLINE,
             last_seen_at=timezone.now(),
         )
         self.redis = _StreamRedis()

--- a/src/backend/apps/node/tests/test_watchdog_projection_grace.py
+++ b/src/backend/apps/node/tests/test_watchdog_projection_grace.py
@@ -22,7 +22,7 @@ class WatchdogProjectionGraceTests(TestCase):
             organization=self.org,
             name="projection-agent",
             role=NodeRole.AGENT,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             last_seen_at=timezone.now(),
         )
 

--- a/src/backend/apps/node/ws/uplink.py
+++ b/src/backend/apps/node/ws/uplink.py
@@ -39,7 +39,6 @@ def on_agent_connected(*, node_id: int, session_id: str, client_ip: str | None =
     observed_at = timezone.now()
     updates: dict = {
         "last_seen_at": observed_at,
-        "status": Node.Status.ONLINE,
     }
     if client_ip:
         updates["connection_ip_address"] = client_ip
@@ -162,7 +161,6 @@ def apply_heartbeat_inventory_snapshot(*, node_id: int, inventory: dict | None) 
         return
     observed_at = timezone.now()
     updates["last_seen_at"] = observed_at
-    updates["status"] = Node.Status.ONLINE
     Node.objects.filter(pk=node_id).update(**updates)
     record_node_available(node_id=node_id, observed_at=observed_at)
 
@@ -189,7 +187,6 @@ def _process_heartbeat_followup(*, node_id: int, inventory: dict | None = None) 
     observed_at = timezone.now()
     updates: dict = {
         "last_seen_at": observed_at,
-        "status": Node.Status.ONLINE,
     }
     if full_inventory:
         updates.update(_merge_heartbeat_inventory_updates(node=node, inventory=inventory))

--- a/src/backend/apps/platform_ops/selectors/internal/health.py
+++ b/src/backend/apps/platform_ops/selectors/internal/health.py
@@ -147,8 +147,8 @@ def platform_node_stats() -> dict[str, int | str]:
     )
     return {
         "total": Node.objects.count(),
-        "online": Node.objects.filter(status=Node.Status.ONLINE).count(),
-        "offline": Node.objects.filter(status=Node.Status.OFFLINE).count(),
+        "online": Node.objects.filter(availability=Node.Availability.ONLINE).count(),
+        "offline": Node.objects.filter(availability=Node.Availability.OFFLINE).count(),
         "outdated": outdated,
         "latest_version": latest,
     }

--- a/src/backend/apps/platform_ops/tests/test_lens_gateway_lifecycle.py
+++ b/src/backend/apps/platform_ops/tests/test_lens_gateway_lifecycle.py
@@ -45,7 +45,7 @@ class PlatformOpsLensGatewayLifecycleTests(TestCase):
             organization=self.platform_org,
             name="platform-gateway",
             role=NodeRole.GATEWAY,
-            status=Node.Status.OFFLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.OFFLINE,
         )
 
     def _post(self, path: str, body: dict) -> Response:

--- a/src/backend/apps/platform_ops/tests/test_orgs_api.py
+++ b/src/backend/apps/platform_ops/tests/test_orgs_api.py
@@ -63,7 +63,7 @@ class PlatformOpsOrgsApiTest(TestCase):
             organization=self.org,
             name="agent-1",
             role=NodeRole.AGENT,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
         )
         Task.objects.create(
             organization_id=self.org.pk,

--- a/src/backend/apps/protection/services/backup_config.py
+++ b/src/backend/apps/protection/services/backup_config.py
@@ -12,6 +12,7 @@ from django.utils import timezone
 
 from apps.node.models import Node
 from apps.node.models.base import NodeRole
+from apps.node.services.internal.node_registry import node_is_available_for_work
 from apps.node.services.internal.agent_log import log_agent_dispatch, log_agent_outcome
 from apps.node.services.interface import run_agent_task_sync
 from apps.protection.models import (
@@ -507,11 +508,11 @@ def _direct_nas_execution_node(
             organization_id=organization_id,
             role=NodeRole.AGENT,
             id=source_ref_id,
-            status=Node.Status.ONLINE,
+            availability=Node.Availability.ONLINE,
             is_deleted=False,
         ).first()
-        if node is None:
-            raise ValidationError({"source_ref_id": "Agent source is offline."})
+        if node is None or not node_is_available_for_work(node):
+            raise ValidationError({"source_ref_id": "Agent source is unavailable or busy."})
         return node
     if source_type == "nas":
         source = SourceResource.objects.filter(
@@ -523,8 +524,8 @@ def _direct_nas_execution_node(
         node = source.bound_node if source is not None else None
         if node is None or node.role != NodeRole.PROXY:
             raise ValidationError({"source_ref_id": "NAS source is not bound to a proxy node."})
-        if node.status != Node.Status.ONLINE:
-            raise ValidationError({"source_ref_id": "NAS bound proxy node is offline."})
+        if source.availability != "online" or not node_is_available_for_work(node):
+            raise ValidationError({"source_ref_id": "NAS source or bound proxy node is unavailable or busy."})
         return node
     raise ValidationError({"source_type": "Unsupported backup source type."})
 

--- a/src/backend/apps/protection/services/backup_orchestrator.py
+++ b/src/backend/apps/protection/services/backup_orchestrator.py
@@ -1794,7 +1794,7 @@ def _refresh_stale_directories_for_snapshot(
     except Exception:
         return
     total_dirs = max(int(source_snapshot.directory_count or 0), 1)
-    node_online = effective_agent_node_status(execution_target.node) == Node.Status.ONLINE
+    node_online = effective_agent_node_status(execution_target.node) == Node.Availability.ONLINE
     for stale_index, directory_row in enumerate(
         BackupSourceSnapshotDirectory.objects.filter(source_snapshot=source_snapshot), start=1
     ):
@@ -2077,7 +2077,7 @@ def advance_backup(
     compression_payload = runtime_policy["compression"]
 
     total_dirs = len(directories)
-    node_online = effective_agent_node_status(execution_target.node) == Node.Status.ONLINE
+    node_online = effective_agent_node_status(execution_target.node) == Node.Availability.ONLINE
     backup_protocol = _backup_protocol(task=task, node=execution_target.node)
     if backup_protocol == _BACKUP_PROTOCOL_PREPARED:
         policies_ready = _prepare_directory_policies(

--- a/src/backend/apps/protection/services/repository_compatibility.py
+++ b/src/backend/apps/protection/services/repository_compatibility.py
@@ -82,7 +82,7 @@ def _validate_proxy_bound_repository(
     ).first()
     if repository_node is None:
         raise ValidationError({"repository_id": "Repository bound proxy node not found."})
-    if repository_node.status != Node.Status.ONLINE:
+    if repository_node.availability != Node.Availability.ONLINE:
         raise ValidationError({"repository_id": "Repository bound proxy node is offline."})
 
     host, _source = explicit_repository_server_host(

--- a/src/backend/apps/protection/services/snapshot_browser.py
+++ b/src/backend/apps/protection/services/snapshot_browser.py
@@ -199,7 +199,11 @@ def _run_snapshot_agent_task(
             _agent_result_error(outcome, "snapshot browser task failed")[:500],
         )
     else:
-        logger.info("snapshot browser agent ok %s task_id=%s", ctx, outcome.task.id)
+        logger.info(
+            "snapshot browser agent ok %s task_id=%s",
+            ctx,
+            getattr(outcome.task, "id", "-"),
+        )
     return outcome
 
 

--- a/src/backend/apps/protection/services/source_execution.py
+++ b/src/backend/apps/protection/services/source_execution.py
@@ -6,6 +6,7 @@ from typing import Any
 from django.core.exceptions import ValidationError
 
 from apps.node.models import Node
+from apps.node.services.internal.node_registry import node_is_available_for_work
 from apps.node.models.base import NodeRole
 from apps.source.constants import ResourceType
 from apps.source.models import SourceResource
@@ -38,8 +39,10 @@ def resolve_source_execution_target(
         ).first()
         if node is None:
             raise ValidationError({"source_ref_id": "Agent source not found."})
-        if node.status != Node.Status.ONLINE:
+        if node.availability != Node.Availability.ONLINE:
             raise ValidationError({"source_ref_id": "Agent source is offline."})
+        if not node_is_available_for_work(node):
+            raise ValidationError({"source_ref_id": "Agent source is busy."})
         return ExecutionTarget(
             node=node,
             source_type="agent",
@@ -62,8 +65,12 @@ def resolve_source_execution_target(
         raise ValidationError({"source_ref_id": "NAS source not found."})
     if resource.bound_node is None or resource.bound_node.role != NodeRole.PROXY:
         raise ValidationError({"source_ref_id": "NAS source is not bound to a proxy node."})
-    if resource.bound_node.status != Node.Status.ONLINE:
-        raise ValidationError({"source_ref_id": "NAS bound proxy node is offline."})
+    if resource.availability != "online":
+        raise ValidationError({"source_ref_id": "NAS source is offline."})
+    if resource.bound_node.availability != Node.Availability.ONLINE:
+        raise ValidationError({"source_ref_id": "Bound proxy node is offline."})
+    if not node_is_available_for_work(resource.bound_node):
+        raise ValidationError({"source_ref_id": "Bound proxy node is busy."})
     root_path = str(resource.effective_mount_point() or "").strip()
     if not root_path:
         raise ValidationError({"source_ref_id": "NAS source mount point is empty."})

--- a/src/backend/apps/protection/tests/test_backup_config_api.py
+++ b/src/backend/apps/protection/tests/test_backup_config_api.py
@@ -47,7 +47,7 @@ class ProtectionBackupConfigApiTests(TestCase):
             organization=self.org,
             name="agent-backup-config-1",
             role=Node.Role.AGENT,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             ip_address="10.0.0.41",
         )
         self.repository = Repository.objects.create(
@@ -145,7 +145,7 @@ class ProtectionBackupConfigApiTests(TestCase):
             organization=self.org,
             name=name,
             role=Node.Role.PROXY,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             ip_address="10.0.0.42",
         )
 
@@ -192,6 +192,7 @@ class ProtectionBackupConfigApiTests(TestCase):
             name=name,
             resource_type=ResourceType.NAS,
             bound_node=proxy,
+            availability="online",
             config={"protocol": "smb", "server": server, "share": share},
         )
 
@@ -509,7 +510,7 @@ class ProtectionBackupConfigApiTests(TestCase):
             organization=self.org,
             name="agent-backup-config-2",
             role=Node.Role.AGENT,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             ip_address="10.0.0.43",
         )
         first = self.client.post(
@@ -762,8 +763,8 @@ class ProtectionBackupConfigApiTests(TestCase):
     def test_create_backup_config_rejects_cross_proxy_repository_when_proxy_offline(self):
         source_proxy = self._proxy(name="source-proxy-repo-offline")
         repository_proxy = self._proxy(name="repository-proxy-offline")
-        repository_proxy.status = Node.Status.OFFLINE
-        repository_proxy.save(update_fields=["status", "updated_at"])
+        repository_proxy.availability = Node.Availability.OFFLINE
+        repository_proxy.save(update_fields=["availability", "updated_at"])
         source = self._nas_source(proxy=source_proxy, name="nas-source-repo-offline")
         repository = self._proxy_bound_nas_repository(proxy=repository_proxy, name="repo-offline")
         repository.config = {**repository.config, "proxy_repository_server_host": "repo.example.internal"}

--- a/src/backend/apps/protection/tests/test_backup_target_validation_api.py
+++ b/src/backend/apps/protection/tests/test_backup_target_validation_api.py
@@ -44,7 +44,7 @@ class BackupTargetValidationApiTests(TransactionTestCase):
             organization=self.org,
             name="validation-agent",
             role=Node.Role.AGENT,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             ip_address="10.0.0.20",
         )
         self.s3_repository = Repository.objects.create(
@@ -247,7 +247,7 @@ class BackupTargetValidationApiTests(TransactionTestCase):
             organization=self.org,
             name="shared-source-repository-proxy",
             role=Node.Role.PROXY,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             ip_address="10.0.0.41",
         )
         source = SourceResource.objects.create(
@@ -255,6 +255,7 @@ class BackupTargetValidationApiTests(TransactionTestCase):
             name="same-proxy-nas-source",
             resource_type=ResourceType.NAS,
             bound_node=proxy,
+            availability="online",
             config={
                 "protocol": "nfs",
                 "server": "10.0.0.50",
@@ -309,14 +310,14 @@ class BackupTargetValidationApiTests(TransactionTestCase):
             organization=self.org,
             name="repository-proxy",
             role=Node.Role.PROXY,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             ip_address="10.0.0.40",
         )
         agent_two = Node.objects.create(
             organization=self.org,
             name="validation-agent-two",
             role=Node.Role.AGENT,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             ip_address="10.0.0.21",
         )
         repository = Repository.objects.create(
@@ -393,8 +394,8 @@ class BackupTargetValidationApiTests(TransactionTestCase):
         "apps.protection.services.backup_target_validation._execute_agent_task"
     )
     def test_offline_source_returns_row_failure_without_dispatch(self, execute):
-        self.agent.status = Node.Status.OFFLINE
-        self.agent.save(update_fields=["status"])
+        self.agent.availability = Node.Availability.OFFLINE
+        self.agent.save(update_fields=["availability"])
 
         result = validate_backup_targets(
             organization_id=self.org.id,
@@ -417,7 +418,7 @@ class BackupTargetValidationApiTests(TransactionTestCase):
             organization=other_org,
             name="other-validation-agent",
             role=Node.Role.AGENT,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
         )
         other_repository = Repository.objects.create(
             organization_id=other_org.id,

--- a/src/backend/apps/protection/tests/test_backup_task_api.py
+++ b/src/backend/apps/protection/tests/test_backup_task_api.py
@@ -61,7 +61,7 @@ class ProtectionBackupTaskApiTests(TestCase):
             organization=self.org,
             name="agent-backup-task-1",
             role=Node.Role.AGENT,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             ip_address="10.0.0.61",
         )
         self.repository = Repository.objects.create(
@@ -188,7 +188,7 @@ class ProtectionBackupTaskApiTests(TestCase):
     def _run_orchestrated_backup(self, *, task, snapshot):
         with patch(
             "apps.protection.services.backup_orchestrator.effective_agent_node_status",
-            return_value=Node.Status.ONLINE,
+            return_value=Node.Availability.ONLINE,
         ):
             return run_backup_task(
                 organization_id=self.org.id,
@@ -416,7 +416,7 @@ class ProtectionBackupTaskApiTests(TestCase):
             organization=self.org,
             name="proxy-backup-task-incompatible",
             role=Node.Role.PROXY,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             ip_address="10.0.0.63",
         )
         proxy_repo = Repository.objects.create(
@@ -477,7 +477,7 @@ class ProtectionBackupTaskApiTests(TestCase):
             organization=self.org,
             name="proxy-backup-task-nas",
             role=Node.Role.PROXY,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             ip_address="10.0.0.64",
         )
         proxy_repo = Repository.objects.create(
@@ -876,7 +876,7 @@ class ProtectionBackupTaskApiTests(TestCase):
 
     @patch(
         "apps.protection.services.backup_orchestrator.effective_agent_node_status",
-        return_value=Node.Status.ONLINE,
+        return_value=Node.Availability.ONLINE,
     )
     @patch("apps.protection.services.backup_orchestrator.enqueue_repository_usage_refresh")
     @patch("apps.protection.services.backup_orchestrator.run_agent_task_async")
@@ -936,7 +936,7 @@ class ProtectionBackupTaskApiTests(TestCase):
 
     @patch(
         "apps.protection.services.backup_orchestrator.effective_agent_node_status",
-        return_value=Node.Status.ONLINE,
+        return_value=Node.Availability.ONLINE,
     )
     @patch("apps.protection.services.backup_orchestrator.run_agent_task_async")
     def test_reconcile_backup_tasks_advances_pending_backup_idempotently(
@@ -1049,7 +1049,7 @@ class ProtectionBackupTaskApiTests(TestCase):
 
     @patch(
         "apps.protection.services.backup_orchestrator.effective_agent_node_status",
-        return_value=Node.Status.ONLINE,
+        return_value=Node.Availability.ONLINE,
     )
     @patch("apps.protection.services.backup_orchestrator.run_agent_task_async")
     def test_agent_restart_retries_once_inside_same_logical_snapshot(
@@ -1094,7 +1094,7 @@ class ProtectionBackupTaskApiTests(TestCase):
 
     @patch(
         "apps.protection.services.backup_orchestrator.effective_agent_node_status",
-        return_value=Node.Status.ONLINE,
+        return_value=Node.Availability.ONLINE,
     )
     @patch("apps.protection.services.backup_orchestrator.run_agent_task_async")
     def test_prepared_snapshot_protocol_serializes_policy_then_dispatches_uploads_in_parallel(
@@ -1168,7 +1168,7 @@ class ProtectionBackupTaskApiTests(TestCase):
     @patch("apps.protection.services.backup_orchestrator.enqueue_repository_usage_refresh")
     @patch(
         "apps.protection.services.backup_orchestrator.effective_agent_node_status",
-        return_value=Node.Status.ONLINE,
+        return_value=Node.Availability.ONLINE,
     )
     @patch("apps.protection.services.backup_orchestrator.run_agent_task_async")
     def test_policy_prepare_retries_before_failing_directory(
@@ -1235,7 +1235,7 @@ class ProtectionBackupTaskApiTests(TestCase):
     @patch("apps.protection.services.backup_orchestrator.enqueue_repository_usage_refresh")
     @patch(
         "apps.protection.services.backup_orchestrator.effective_agent_node_status",
-        return_value=Node.Status.ONLINE,
+        return_value=Node.Availability.ONLINE,
     )
     @patch("apps.protection.services.backup_orchestrator.run_agent_task_async")
     def test_policy_prepare_failure_does_not_block_other_parallel_uploads(
@@ -1310,7 +1310,7 @@ class ProtectionBackupTaskApiTests(TestCase):
     @patch("apps.protection.services.backup_orchestrator.enqueue_repository_usage_refresh")
     @patch(
         "apps.protection.services.backup_orchestrator.effective_agent_node_status",
-        return_value=Node.Status.ONLINE,
+        return_value=Node.Availability.ONLINE,
     )
     @patch("apps.protection.services.backup_orchestrator.run_agent_task_async")
     def test_policy_not_found_repairs_after_parallel_siblings_finish(
@@ -1500,7 +1500,7 @@ class ProtectionBackupTaskApiTests(TestCase):
             organization=self.org,
             name="proxy-backup-task-1",
             role=Node.Role.PROXY,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             ip_address="10.0.0.62",
         )
         repository = Repository.objects.create(
@@ -1535,7 +1535,7 @@ class ProtectionBackupTaskApiTests(TestCase):
             organization=self.org,
             name="proxy-backup-task-inventory-host",
             role=Node.Role.PROXY,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             ip_address="192.168.65.1",
             metadata={"inventory": {"ip_addresses": ["10.0.0.65"]}},
         )
@@ -1572,7 +1572,7 @@ class ProtectionBackupTaskApiTests(TestCase):
             organization=self.org,
             name="proxy-backup-task-nas-runtime",
             role=Node.Role.PROXY,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             ip_address="192.168.65.1",
         )
         repository = Repository.objects.create(
@@ -1740,7 +1740,7 @@ class ProtectionBackupTaskApiTests(TestCase):
             organization=self.org,
             name="proxy-backup-task-nas-probe-fail",
             role=Node.Role.PROXY,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             ip_address="192.168.65.1",
         )
         repository = Repository.objects.create(

--- a/src/backend/apps/protection/tests/test_backup_task_concurrency.py
+++ b/src/backend/apps/protection/tests/test_backup_task_concurrency.py
@@ -30,7 +30,7 @@ class BackupTaskConcurrencyTests(TransactionTestCase):
             organization=self.org,
             name="backup-concurrency-agent",
             role=Node.Role.AGENT,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             ip_address="10.0.0.71",
         )
         self.repository = Repository.objects.create(

--- a/src/backend/apps/protection/tests/test_directory_size_estimate.py
+++ b/src/backend/apps/protection/tests/test_directory_size_estimate.py
@@ -36,14 +36,14 @@ class DirectorySizeEstimateTests(TestCase):
             organization=self.org,
             name="dir-size-agent",
             role=Node.Role.AGENT,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             ip_address="10.0.0.81",
         )
         self.agent_b = Node.objects.create(
             organization=self.org,
             name="dir-size-agent-b",
             role=Node.Role.AGENT,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             ip_address="10.0.0.82",
         )
         self.repository = Repository.objects.create(

--- a/src/backend/apps/protection/tests/test_policy_execution.py
+++ b/src/backend/apps/protection/tests/test_policy_execution.py
@@ -33,7 +33,7 @@ class PolicyExecutionTests(TestCase):
             organization=self.org,
             name="policy-exec-agent",
             role=Node.Role.AGENT,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
         )
         self.repository = Repository.objects.create(
             organization_id=self.org.id,

--- a/src/backend/apps/protection/tests/test_snapshot_browser_api.py
+++ b/src/backend/apps/protection/tests/test_snapshot_browser_api.py
@@ -44,7 +44,7 @@ class SnapshotBrowserApiTests(TestCase):
             organization=self.org,
             name="snapshot-browser-agent",
             role=Node.Role.AGENT,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
         )
         self.repository = Repository.objects.create(
             organization_id=self.org.id,
@@ -145,10 +145,10 @@ class SnapshotBrowserApiTests(TestCase):
             organization=self.org,
             name="snapshot-browser-proxy",
             role=Node.Role.PROXY,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
         )
-        self.agent.status = Node.Status.OFFLINE
-        self.agent.save(update_fields=["status"])
+        self.agent.availability = Node.Availability.OFFLINE
+        self.agent.save(update_fields=["availability"])
         self.repository.repo_type = Repository.Type.NAS
         self.repository.nas_protocol = Repository.NasProtocol.NFS
         self.repository.s3_bucket = ""

--- a/src/backend/apps/protection/tests/test_snapshot_delete_task.py
+++ b/src/backend/apps/protection/tests/test_snapshot_delete_task.py
@@ -47,7 +47,7 @@ class SnapshotDeleteTaskTests(TestCase):
             organization=self.org,
             name="snapshot-delete-agent",
             role=Node.Role.AGENT,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
         )
         self.repository = Repository.objects.create(
             organization_id=self.org.id,
@@ -272,8 +272,8 @@ class SnapshotDeleteTaskTests(TestCase):
     @patch("apps.protection.services.snapshot_delete.run_agent_task_sync")
     def test_offline_source_is_closed_as_retryable_business_failure(self, mock_run_agent_task_sync):
         task = create_snapshot_delete_task(source_snapshot=self.snapshot)
-        self.agent.status = Node.Status.OFFLINE
-        self.agent.save(update_fields=["status", "updated_at"])
+        self.agent.availability = Node.Availability.OFFLINE
+        self.agent.save(update_fields=["availability", "updated_at"])
 
         result = run_snapshot_delete_task(
             organization_id=self.org.id,

--- a/src/backend/apps/restore/services/interface.py
+++ b/src/backend/apps/restore/services/interface.py
@@ -16,6 +16,7 @@ from django.utils import timezone
 from common.errors import AppError
 from apps.iam.models import Organization
 from apps.node.models import Node, NodeTask
+from apps.node.services.internal.node_registry import node_is_available_for_work
 from apps.node.services.interface import cancel_agent_task, run_agent_task_async
 from apps.node.models.base import NodeRole
 from apps.node.services.internal.agent_log import log_agent_dispatch, log_agent_exception, task_log_context
@@ -1374,8 +1375,8 @@ def _target_execution_node(*, organization_id: int, target_type: str, target_ref
         ).first()
         if node is None:
             raise ValidationError({"target_ref_id": "Target agent not found."})
-        if node.status != Node.Status.ONLINE:
-            raise ValidationError({"target_ref_id": "Target agent is offline."})
+        if not node_is_available_for_work(node):
+            raise ValidationError({"target_ref_id": "Target agent is unavailable or busy."})
         return node
     resource = (
         SourceResource.objects.filter(
@@ -1391,8 +1392,8 @@ def _target_execution_node(*, organization_id: int, target_type: str, target_ref
         raise ValidationError({"target_ref_id": "Target NAS not found."})
     if resource.bound_node is None or resource.bound_node.role != NodeRole.PROXY:
         raise ValidationError({"target_ref_id": "Target NAS is not bound to a proxy node."})
-    if resource.bound_node.status != Node.Status.ONLINE:
-        raise ValidationError({"target_ref_id": "Target NAS proxy node is offline."})
+    if resource.availability != "online" or not node_is_available_for_work(resource.bound_node):
+        raise ValidationError({"target_ref_id": "Target NAS or proxy node is unavailable or busy."})
     return resource.bound_node
 
 
@@ -1439,8 +1440,8 @@ def _dispatch_restore_items(*, organization_id: int, record: RestoreRecord, task
     ).first()
     if node is None:
         raise ValidationError({"target_ref_id": "Restore execution node not found."})
-    if node.status != Node.Status.ONLINE:
-        raise ValidationError({"target_ref_id": "Restore execution node is offline."})
+    if not node_is_available_for_work(node):
+        raise ValidationError({"target_ref_id": "Restore execution node is unavailable or busy."})
     target_nas_payload: dict[str, Any] = {}
     if record.target_type == RestoreRecord.EndpointType.NAS:
         target_nas = (

--- a/src/backend/apps/restore/services/snapshot_browser.py
+++ b/src/backend/apps/restore/services/snapshot_browser.py
@@ -53,7 +53,7 @@ def _target_node(*, organization_id: int, target_node_id: int) -> Node:
     ).first()
     if node is None:
         raise ValidationError({"target_node_id": "Target node not found."})
-    if node.status != Node.Status.ONLINE:
+    if node.availability != Node.Availability.ONLINE:
         raise ValidationError({"target_node_id": "Target node is offline."})
     return node
 

--- a/src/backend/apps/restore/tests/test_restore_api.py
+++ b/src/backend/apps/restore/tests/test_restore_api.py
@@ -50,14 +50,14 @@ class RestoreApiTests(TestCase):
             organization=self.org,
             name="restore-agent-1",
             role=Node.Role.AGENT,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             ip_address="10.0.0.51",
         )
         self.target = Node.objects.create(
             organization=self.org,
             name="restore-target-1",
             role=Node.Role.AGENT,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             ip_address="10.0.0.52",
         )
         self.repository = Repository.objects.create(
@@ -178,7 +178,7 @@ class RestoreApiTests(TestCase):
             organization=platform_org,
             name="platform-restore-gateway",
             role=Node.Role.GATEWAY,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
         )
         gateway_link = LensGatewayLink.objects.create(
             organization=platform_org,
@@ -250,7 +250,7 @@ class RestoreApiTests(TestCase):
             organization=platform_org,
             name="forbidden-platform-target",
             role=Node.Role.GATEWAY,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
         )
         payload = self._manual_restore_payload()
         payload["target_ref_id"] = platform_gateway.id
@@ -272,7 +272,7 @@ class RestoreApiTests(TestCase):
             organization=platform_org,
             name="platform-path-boundary-gateway",
             role=Node.Role.GATEWAY,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
         )
         gateway_link = LensGatewayLink.objects.create(
             organization=platform_org,
@@ -308,7 +308,7 @@ class RestoreApiTests(TestCase):
             organization=self.org,
             name="private-lens-gateway",
             role=Node.Role.GATEWAY,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
         )
         gateway_link = LensGatewayLink.objects.create(
             organization=self.org,
@@ -345,7 +345,7 @@ class RestoreApiTests(TestCase):
             organization=self.org,
             name="restore-nas-proxy",
             role=Node.Role.PROXY,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             ip_address="10.0.0.53",
         )
         target_nas = SourceResource.objects.create(
@@ -353,6 +353,7 @@ class RestoreApiTests(TestCase):
             name="restore-target-nas",
             resource_type=ResourceType.NAS,
             bound_node=proxy,
+            availability="online",
             config={"server": "10.0.0.20", "share": "restore"},
         )
         target_nas.set_credentials(
@@ -674,7 +675,7 @@ class RestoreApiTests(TestCase):
             organization=self.org,
             name="restore-proxy",
             role=Node.Role.PROXY,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             ip_address="10.0.0.53",
         )
         self.repository.repo_type = Repository.Type.NAS
@@ -722,7 +723,7 @@ class RestoreApiTests(TestCase):
             organization=self.org,
             name="restore-proxy",
             role=Node.Role.PROXY,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             ip_address="10.0.0.53",
         )
         self.repository.repo_type = Repository.Type.NAS
@@ -1732,7 +1733,7 @@ class RestoreApiTests(TestCase):
             organization=self.org,
             name="restore-agent-2",
             role=Node.Role.AGENT,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             ip_address="10.0.0.53",
         )
         other_config = BackupConfig.objects.create(
@@ -2048,8 +2049,8 @@ class RestoreApiTests(TestCase):
 
     @patch("apps.restore.services.snapshot_browser.run_agent_task_sync")
     def test_browse_restore_snapshot_directory_rejects_offline_target(self, mock_run_agent_task_sync):
-        self.target.status = Node.Status.OFFLINE
-        self.target.save(update_fields=["status"])
+        self.target.availability = Node.Availability.OFFLINE
+        self.target.save(update_fields=["availability"])
 
         response = self.client.get(
             f"/api/v1/restore/snapshot-directories/{self.snapshot_dir.id}/browse/"

--- a/src/backend/apps/source/api/serializers/source_resource.py
+++ b/src/backend/apps/source/api/serializers/source_resource.py
@@ -1,8 +1,7 @@
 from rest_framework import serializers
 
-from apps.node.services.internal.node_registry import agent_connection_status
 from apps.source.models import SourceResource
-from apps.source.constants import ConnectionTestStatus, MountStatus, ResourceStatus
+from apps.source.constants import ResourceStatus
 from apps.source.services.internal.nas_display import connection_summary_for_resource
 from apps.source.services.internal.source_credentials import (
     scrub_source_secrets,
@@ -90,7 +89,7 @@ class SourceResourceSerializer(serializers.ModelSerializer):
         node = obj.bound_node
         if node is None:
             return None
-        return agent_connection_status(node)
+        return node.status
 
     def get_requires_mount(self, obj):
         return obj.requires_mount
@@ -113,38 +112,23 @@ class SourceResourceSerializer(serializers.ModelSerializer):
         return scrub_source_secrets(obj.config or {})
 
     def get_effective_status(self, obj):
-        if obj.status == ResourceStatus.REMOVING:
-            return "removing"
-        if obj.status == ResourceStatus.REMOVE_FAILED:
-            return "remove_failed"
-        if obj.status == ResourceStatus.ERROR:
-            return "error"
-        if obj.connection_test_status in ConnectionTestStatus.ACTIVE:
-            return "probing"
-        if obj.connection_test_status == ConnectionTestStatus.FAILED:
-            return "error"
-        if obj.mount_status == MountStatus.ERROR:
-            return "error"
-        if (
-            obj.mount_status == MountStatus.MOUNTED
-            or obj.connection_test_status == ConnectionTestStatus.SUCCESS
-        ):
-            return "online"
-        return "unverified"
+        # Status is the NAS lifecycle state. Connection reachability belongs to
+        # the separate ``availability`` field and must never be folded back here.
+        return str(obj.status or ResourceStatus.ACTIVE)
 
     def get_effective_status_message(self, obj):
         status = self.get_effective_status(obj)
         if status == "remove_failed":
-            return "Deregistration failed"
+            return "Deregistration Failed"
         if status == "error":
             return "NAS connection error"
         if status == "probing":
             return "Checking NAS connection"
-        if status == "online":
-            return "NAS online"
+        if status == "active":
+            return "NAS active"
         if status == "removing":
             return "Deregistering"
-        return "NAS connection not verified"
+        return "NAS inactive"
 
 
 class SourceResourceListSerializer(SourceResourceSerializer):

--- a/src/backend/apps/source/constants.py
+++ b/src/backend/apps/source/constants.py
@@ -63,6 +63,7 @@ class ResourceStatus:
     ACTIVE = "active"
     INACTIVE = "inactive"
     ERROR = "error"
+    PROBING = "probing"
     REMOVING = "removing"
     REMOVE_FAILED = "remove_failed"
     REMOVED = "removed"
@@ -71,6 +72,7 @@ class ResourceStatus:
         (ACTIVE, "Active"),
         (INACTIVE, "Inactive"),
         (ERROR, "Error"),
+        (PROBING, "Probing"),
         (REMOVING, "Removing"),
         (REMOVE_FAILED, "Remove failed"),
         (REMOVED, "Removed"),

--- a/src/backend/apps/source/migrations/0013_source_resource_probing_status.py
+++ b/src/backend/apps/source/migrations/0013_source_resource_probing_status.py
@@ -1,0 +1,26 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [("source", "0012_backup_pipeline_query_indexes")]
+
+    operations = [
+        migrations.AlterField(
+            model_name="sourceresource",
+            name="status",
+            field=models.CharField(
+                choices=[
+                    ("active", "Active"),
+                    ("inactive", "Inactive"),
+                    ("error", "Error"),
+                    ("probing", "Probing"),
+                    ("removing", "Removing"),
+                    ("remove_failed", "Remove failed"),
+                    ("removed", "Removed"),
+                ],
+                db_index=True,
+                default="active",
+                max_length=20,
+            ),
+        ),
+    ]

--- a/src/backend/apps/source/services/interface.py
+++ b/src/backend/apps/source/services/interface.py
@@ -245,7 +245,7 @@ def update_source_resource(
             if node is None:
                 raise ValueError("Bound node not found.")
             validate_bound_node_role(resource_type=resource.resource_type, node=node)
-            if node.status != Node.Status.ONLINE:
+            if node.availability != Node.Availability.ONLINE:
                 raise ValueError(f'Node "{node.name}" is not online.')
             resource.bound_node = node
             bound_node_changed = old_bound_node_id != node.id
@@ -403,7 +403,7 @@ def bind_node(*, resource: SourceResource, node_id: int) -> dict:
         validate_bound_node_role(resource_type=resource.resource_type, node=node)
     except ValueError as exc:
         return {"success": False, "message": str(exc)}
-    if node.status != Node.Status.ONLINE:
+    if node.availability != Node.Availability.ONLINE:
         return {"success": False, "message": f'Node "{node.name}" is not online.'}
     old_bound_node_id = resource.bound_node_id
     resource.bound_node = node

--- a/src/backend/apps/source/services/internal/agent_host_sync.py
+++ b/src/backend/apps/source/services/internal/agent_host_sync.py
@@ -7,7 +7,6 @@ from typing import Any
 from apps.node.models import Node
 from apps.node.models.base import NodeRole
 from apps.node.services.internal.agent_release import latest_published_agent_version
-from apps.node.services.internal.node_registry import effective_agent_node_status
 from apps.node.services.internal.node_naming import is_auto_assigned_node_name
 from apps.source.constants import ResourceStatus, ResourceType, SelectableSourceKind
 from apps.source.models import SourceResource
@@ -67,11 +66,8 @@ def sync_agent_source_host(*, node: Node) -> SourceResource | None:
         "kopia_version": str(inv.get("kopia_version") or ""),
     }
 
-    status = (
-        ResourceStatus.ACTIVE
-        if effective_agent_node_status(node) == Node.Status.ONLINE
-        else ResourceStatus.INACTIVE
-    )
+    # The source lifecycle is independent from the Agent connection state.
+    status = ResourceStatus.ACTIVE
 
     qs = SourceResource.objects.filter(
         organization_id=node.organization_id,

--- a/src/backend/apps/source/services/internal/backup_selectable.py
+++ b/src/backend/apps/source/services/internal/backup_selectable.py
@@ -33,8 +33,13 @@ from apps.protection.services import (
     file_filter_summary,
 )
 from apps.restore.models import RestorePlan, RestoreRecord
-from apps.node.services.internal.node_registry import agent_connection_status
-from apps.source.constants import PipelineStep, PipelineTaskStatus, ResourceType, SelectableSourceKind
+from apps.source.constants import (
+    Availability,
+    PipelineStep,
+    PipelineTaskStatus,
+    ResourceType,
+    SelectableSourceKind,
+)
 from apps.source.metrics import (
     BACKUP_SELECTABLE_QUERY_DURATION,
     BACKUP_SELECTABLE_QUERY_REQUESTS,
@@ -133,7 +138,6 @@ def _inventory_int(inv: dict[str, Any], *keys: str) -> int | None:
 def _agent_item(node: Node) -> dict[str, Any]:
     inv = _merged_inventory(node)
     hostname = str(inv.get("hostname") or node.name or "").strip()
-    status = agent_connection_status(node)
     item: dict[str, Any] = {
         "id": f"agent:{node.id}",
         "kind": "agent",
@@ -143,7 +147,8 @@ def _agent_item(node: Node) -> dict[str, Any]:
         "hostname": hostname,
         "node_name": hostname or node.name,
         "node_ip": str(node.ip_address or "").strip(),
-        "status": status if status in ("online", "reconnecting") else "offline",
+        "status": str(node.status or Node.Status.ACTIVE),
+        "availability": str(node.availability or Node.Availability.OFFLINE),
         "platform": _agent_platform(node),
         "registered_at": node.created_at.isoformat() if node.created_at else None,
     }
@@ -162,11 +167,6 @@ def _agent_item(node: Node) -> dict[str, Any]:
 def _nas_item(resource: SourceResource) -> dict[str, Any]:
     cfg = resource.config if isinstance(resource.config, dict) else {}
     node = resource.bound_node
-    if node is not None:
-        node_status = agent_connection_status(node)
-        status = node_status if node_status in ("online", "reconnecting") else "offline"
-    else:
-        status = "online" if resource.status == "active" else "offline"
     return {
         "id": f"nas:{resource.id}",
         "kind": "nas",
@@ -176,7 +176,8 @@ def _nas_item(resource: SourceResource) -> dict[str, Any]:
         "hostname": str(cfg.get("server") or "").strip(),
         "node_name": (node.name if node else "") or str(cfg.get("server") or "").strip(),
         "node_ip": str(node.ip_address or "").strip() if node else "",
-        "status": status,
+        "status": str(resource.status or Availability.OFFLINE),
+        "availability": str(resource.availability or Availability.OFFLINE),
         "protocol": _nas_protocol(cfg),
         "connection_uri": nas_mount_source_uri(resource_type=resource.resource_type, config=cfg),
         "bound_node_id": node.id if node else None,
@@ -982,9 +983,7 @@ def _pipeline_queryset(
     if source_status:
         queryset = queryset.filter(source_status=source_status)
     elif status:
-        # The legacy `status=online` contract represented reachability. The
-        # Pipeline's availability projection is the compatible indexed field.
-        queryset = queryset.filter(source_availability=status)
+        queryset = queryset.filter(source_status=status)
     if availability:
         queryset = queryset.filter(source_availability=availability)
 

--- a/src/backend/apps/source/services/internal/backup_source_delete.py
+++ b/src/backend/apps/source/services/internal/backup_source_delete.py
@@ -590,7 +590,7 @@ def _assert_strict_delete_blockers(
             )
     if ctx.nas_resource is not None:
         proxy = ctx.nas_resource.bound_node
-        if proxy is None or proxy.status != Node.Status.ONLINE:
+        if proxy is None or proxy.availability != Node.Availability.ONLINE:
             reasons.append(
                 DeleteReason(
                     code="proxy_offline",
@@ -2912,7 +2912,7 @@ def preflight_delete_backup_sources(
                     ).as_dict()
                 )
             proxy = resource.bound_node
-            if proxy is None or proxy.status != Node.Status.ONLINE:
+            if proxy is None or proxy.availability != Node.Availability.ONLINE:
                 risks.append(
                     DeleteReason(
                         code="proxy_offline",

--- a/src/backend/apps/source/services/internal/connection.py
+++ b/src/backend/apps/source/services/internal/connection.py
@@ -53,7 +53,7 @@ def run_connection_test(
 
     if node is None:
         return {"success": False, "message": "No bound node configured. Please bind a node first."}
-    if node.status != Node.Status.ONLINE:
+    if node.availability != Node.Availability.ONLINE:
         return {
             "success": False,
             "message": f'Bound node "{node.name}" is not online.',

--- a/src/backend/apps/source/services/internal/nas_agent.py
+++ b/src/backend/apps/source/services/internal/nas_agent.py
@@ -165,7 +165,7 @@ def _validate_proxy_node(node: Node | None, *, resource: SourceResource | None =
         return "No bound node configured. Please bind a proxy node first."
     if node.role != NodeRole.PROXY:
         return "NAS source must be bound to a proxy node."
-    if node.status != Node.Status.ONLINE:
+    if node.availability != Node.Availability.ONLINE:
         return f'Bound node "{node.name}" is not online.'
     if resource is not None and resource.organization_id != node.organization_id:
         return "Bound node does not belong to this organization."

--- a/src/backend/apps/source/tasks/connection_probe.py
+++ b/src/backend/apps/source/tasks/connection_probe.py
@@ -68,7 +68,7 @@ def run_source_resource_capacity_probe(
         return {"status": "skipped", "reason": skip_reason}
 
     node = resource.bound_node
-    if node is None or node.status != Node.Status.ONLINE:
+    if node is None or node.availability != Node.Availability.ONLINE:
         resource, skip_reason = apply_connection_test_result_if_current(
             resource_id=resource_id,
             probe_token=probe_token,
@@ -88,6 +88,7 @@ def run_source_resource_capacity_probe(
         connection_probe_token=probe_token,
     ).update(
         connection_test_status=ConnectionTestStatus.RUNNING,
+        status=ResourceStatus.PROBING,
         updated_at=timezone.now(),
     )
 
@@ -260,10 +261,12 @@ def _queue_availability_probe(
 
         probe_token = uuid4()
         resource.connection_test_status = ConnectionTestStatus.PENDING
+        resource.status = ResourceStatus.PROBING
         resource.connection_probe_token = probe_token
         resource.save(
             update_fields=[
                 "connection_test_status",
+                "status",
                 "connection_probe_token",
                 "updated_at",
             ]

--- a/src/backend/apps/source/tests/test_api.py
+++ b/src/backend/apps/source/tests/test_api.py
@@ -55,8 +55,7 @@ class SourceResourceApiTests(TestCase):
             organization=self.org,
             name="proxy-1",
             role=Node.Role.PROXY,
-            status=Node.Status.ONLINE,
-            availability=Node.Availability.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
         )
         self.client.force_authenticate(user=self.user)
 
@@ -193,7 +192,7 @@ class SourceResourceApiTests(TestCase):
             organization=self.org,
             name="agent-local-connection",
             role=Node.Role.AGENT,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
         )
         create = self.client.post(
             "/api/v1/source/resources/",
@@ -492,7 +491,7 @@ class SourceResourceApiTests(TestCase):
             organization=self.org,
             name="agent-host-1",
             role=Node.Role.AGENT,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             ip_address="10.0.0.21",
             os_name="darwin arm64",
             metadata={
@@ -565,8 +564,7 @@ class SourceResourceApiTests(TestCase):
             organization=self.org,
             name="query-contract-agent",
             role=Node.Role.AGENT,
-            status=Node.Status.ONLINE,
-            availability=Node.Availability.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             ip_address="198.51.100.42",
             metadata={"inventory": {"hostname": "contract-host"}},
         )
@@ -618,7 +616,7 @@ class SourceResourceApiTests(TestCase):
             organization=self.org,
             name="agent-step3-expand-1",
             role=Node.Role.AGENT,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             ip_address="10.0.0.25",
         )
         repository = Repository.objects.create(
@@ -746,14 +744,14 @@ class SourceResourceApiTests(TestCase):
             organization=self.org,
             name="agent-runtime-1",
             role=Node.Role.AGENT,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             ip_address="10.0.0.26",
         )
         other_agent = Node.objects.create(
             organization=self.org,
             name="agent-runtime-2",
             role=Node.Role.AGENT,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             ip_address="10.0.0.27",
         )
         task = Task.objects.create(
@@ -800,7 +798,7 @@ class SourceResourceApiTests(TestCase):
             organization=self.org,
             name="agent-runtime-history",
             role=Node.Role.AGENT,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             ip_address="10.0.0.28",
         )
         failed_task = Task.objects.create(
@@ -850,7 +848,7 @@ class SourceResourceApiTests(TestCase):
             organization=self.org,
             name="agent-runtime-restorable",
             role=Node.Role.AGENT,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             ip_address="10.0.0.29",
         )
         config = self._create_backup_config_for_agent(agent, name="runtime-restorable-config")
@@ -901,21 +899,21 @@ class SourceResourceApiTests(TestCase):
             organization=self.org,
             name="agent-runtime-partial",
             role=Node.Role.AGENT,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             ip_address="10.0.0.30",
         )
         failed_agent = Node.objects.create(
             organization=self.org,
             name="agent-runtime-failed-only",
             role=Node.Role.AGENT,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             ip_address="10.0.0.31",
         )
         empty_agent = Node.objects.create(
             organization=self.org,
             name="agent-runtime-empty",
             role=Node.Role.AGENT,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             ip_address="10.0.0.32",
         )
         partial_config = self._create_backup_config_for_agent(partial_agent, name="runtime-partial-config")
@@ -961,7 +959,7 @@ class SourceResourceApiTests(TestCase):
             organization=self.org,
             name="agent-mac-1",
             role=Node.Role.AGENT,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             os_name="darwin arm64",
             metadata={"inventory": {"os": "darwin", "arch": "arm64"}},
         )
@@ -977,7 +975,7 @@ class SourceResourceApiTests(TestCase):
             organization=self.org,
             name="agent-dir-1",
             role=Node.Role.AGENT,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             ip_address="10.0.0.41",
         )
         mock_run_task.return_value = SimpleNamespace(
@@ -1022,7 +1020,7 @@ class SourceResourceApiTests(TestCase):
             organization=self.org,
             name="agent-file-1",
             role=Node.Role.AGENT,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             ip_address="10.0.0.43",
         )
         mock_run_task.return_value = SimpleNamespace(
@@ -1065,7 +1063,7 @@ class SourceResourceApiTests(TestCase):
             organization=self.org,
             name="agent-type-fields-1",
             role=Node.Role.AGENT,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             ip_address="10.0.0.45",
         )
         mock_run_task.return_value = SimpleNamespace(
@@ -1105,7 +1103,7 @@ class SourceResourceApiTests(TestCase):
             organization=self.org,
             name="agent-path-info",
             role=Node.Role.AGENT,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             ip_address="10.0.0.44",
         )
         mock_run_task.return_value = SimpleNamespace(
@@ -1144,7 +1142,7 @@ class SourceResourceApiTests(TestCase):
             organization=self.org,
             name="agent-path-info-lite",
             role=Node.Role.AGENT,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             ip_address="10.0.0.46",
         )
         mock_run_task.return_value = SimpleNamespace(
@@ -1181,7 +1179,7 @@ class SourceResourceApiTests(TestCase):
             organization=self.org,
             name="agent-dir-root",
             role=Node.Role.AGENT,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             ip_address="10.0.0.42",
         )
         mock_run_task.return_value = SimpleNamespace(
@@ -1219,7 +1217,7 @@ class SourceResourceApiTests(TestCase):
             organization=self.org,
             name="agent-dir-root-files",
             role=Node.Role.AGENT,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             ip_address="10.0.0.45",
         )
         mock_run_task.return_value = SimpleNamespace(
@@ -1393,7 +1391,7 @@ class SourceResourceApiTests(TestCase):
             organization=self.org,
             name="agent-dir-limit",
             role=Node.Role.AGENT,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
         )
         mock_run_task.return_value = SimpleNamespace(
             timed_out=False,
@@ -1432,7 +1430,7 @@ class SourceResourceApiTests(TestCase):
             organization=self.org,
             name="agent-dir-cursor",
             role=Node.Role.AGENT,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
         )
         mock_run_task.return_value = SimpleNamespace(
             timed_out=False,
@@ -1503,7 +1501,7 @@ class SourceResourceApiTests(TestCase):
             organization=self.org,
             name="agent-for-nas",
             role=Node.Role.AGENT,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
         )
         resource = SourceResource.objects.create(
             organization=self.org,
@@ -1531,7 +1529,7 @@ class SourceResourceApiTests(TestCase):
             organization=self.org,
             name="agent-pipeline-1",
             role=Node.Role.AGENT,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             ip_address="10.0.0.31",
         )
         sync_agent_source_host(node=agent)
@@ -1602,7 +1600,7 @@ class SourceResourceApiTests(TestCase):
             organization=self.org,
             name="agent-pipeline-revert-1",
             role=Node.Role.AGENT,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             ip_address="10.0.0.32",
         )
         sync_agent_source_host(node=agent)
@@ -1671,7 +1669,7 @@ class BackupSourceBulkDeleteTests(TestCase):
             organization=self.org,
             name="agent-offline-1",
             role=Node.Role.AGENT,
-            status=Node.Status.OFFLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.OFFLINE,
         )
         self.client.force_authenticate(user=self.user)
 
@@ -1807,7 +1805,7 @@ class BackupSourceBulkDeleteTests(TestCase):
             organization=self.org,
             name="probe-proxy",
             role=Node.Role.PROXY,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
         )
         resource = SourceResource.objects.create(
             organization=self.org,
@@ -1949,7 +1947,7 @@ class BackupSourceBulkDeleteTests(TestCase):
             organization=self.org,
             name="agent-offline-2",
             role=Node.Role.AGENT,
-            status=Node.Status.OFFLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.OFFLINE,
         )
 
         response = self.client.post(
@@ -2002,7 +2000,7 @@ class BackupSourceBulkDeleteTests(TestCase):
             organization=self.org,
             name="proxy-nas-delete",
             role=Node.Role.PROXY,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
         )
         resource = SourceResource.objects.create(
             organization=self.org,
@@ -2068,7 +2066,7 @@ class BackupSourceBulkDeleteTests(TestCase):
             organization=self.org,
             name="delete-nas-proxy",
             role=Node.Role.PROXY,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
         )
         resource = SourceResource.objects.create(
             organization=self.org,
@@ -2140,7 +2138,7 @@ class BackupSourceBulkDeleteTests(TestCase):
             organization=self.org,
             name="strict-unmount-proxy",
             role=Node.Role.PROXY,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
         )
         resource = SourceResource.objects.create(
             organization=self.org,

--- a/src/backend/apps/source/tests/test_backup_selectable_pipeline_query.py
+++ b/src/backend/apps/source/tests/test_backup_selectable_pipeline_query.py
@@ -23,8 +23,7 @@ class BackupSelectablePipelineQueryTests(TestCase):
             organization=self.org,
             name="Alpha Host",
             role=Node.Role.AGENT,
-            status=Node.Status.ONLINE,
-            availability=Node.Availability.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             ip_address="198.51.100.10",
             metadata={"inventory": {"hostname": "alpha-executor"}},
         )
@@ -32,8 +31,7 @@ class BackupSelectablePipelineQueryTests(TestCase):
             organization=self.org,
             name="NAS Proxy",
             role=Node.Role.PROXY,
-            status=Node.Status.ONLINE,
-            availability=Node.Availability.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             ip_address="203.0.113.20",
         )
         self.nas = SourceResource.objects.create(
@@ -76,6 +74,22 @@ class BackupSelectablePipelineQueryTests(TestCase):
         ids, count = self.ids(search="198.51.100.10", search_field="source_ip", pipeline_step=3)
         self.assertEqual(ids, [f"agent:{self.agent.id}"])
         self.assertEqual(count, 1)
+
+    def test_materialized_rows_include_source_availability(self):
+        self.nas.availability = "offline"
+        self.nas.save(update_fields=["availability", "updated_at"])
+
+        results, count = list_backup_selectable_sources(
+            organization_id=self.org.id,
+            page=1,
+            page_size=20,
+            pipeline_step=3,
+        )
+
+        rows = {row["id"]: row for row in results}
+        self.assertEqual(count, 2)
+        self.assertEqual(rows[f"agent:{self.agent.id}"]["availability"], "online")
+        self.assertEqual(rows[f"nas:{self.nas.id}"]["availability"], "offline")
 
     def test_filters_are_combined_before_count_and_pagination(self):
         config = BackupConfig.objects.create(
@@ -223,8 +237,7 @@ class BackupSelectableShadowQueryTests(TestCase):
             organization=self.org,
             name="Shadow Agent",
             role=Node.Role.AGENT,
-            status=Node.Status.ONLINE,
-            availability=Node.Availability.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
         )
         entry = ensure_pipeline_entry(
             organization_id=self.org.id,
@@ -259,8 +272,7 @@ class BackupSelectablePipelineScaleTests(TestCase):
                 organization=org,
                 name=f"Scale Agent {index:05d}",
                 role=Node.Role.AGENT,
-                status=Node.Status.ONLINE,
-                availability=Node.Availability.ONLINE,
+                status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             )
             for index in range(10_000)
         ])

--- a/src/backend/apps/source/tests/test_backup_source_delete_snapshots.py
+++ b/src/backend/apps/source/tests/test_backup_source_delete_snapshots.py
@@ -70,7 +70,7 @@ class BackupSourceDeleteSnapshotTaskTests(TestCase):
             organization=self.org,
             name="proxy-delete-snap",
             role=Node.Role.PROXY,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
         )
         self.resource = SourceResource.objects.create(
             organization_id=self.org.id,
@@ -83,6 +83,7 @@ class BackupSourceDeleteSnapshotTaskTests(TestCase):
                 "path": custom_mount("nfs-delete-snap"),
             },
             bound_node=self.proxy,
+            availability="online",
             mount_status="mounted",
             mount_point=custom_mount("nfs-delete-snap"),
         )
@@ -371,7 +372,7 @@ class BackupSourceDeleteSnapshotTaskTests(TestCase):
             organization=self.org,
             name="agent-delete-snap",
             role=Node.Role.AGENT,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
         )
         self.config.source_type = "agent"
         self.config.source_ref_id = agent.id

--- a/src/backend/apps/source/tests/test_connection_probe.py
+++ b/src/backend/apps/source/tests/test_connection_probe.py
@@ -36,8 +36,7 @@ class SourceConnectionProbeTests(TestCase):
             organization=self.org,
             name="source-connection-proxy",
             role=Node.Role.PROXY,
-            status=Node.Status.ONLINE,
-            availability=Node.Availability.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
         )
         self.probe_token = uuid4()
         self.resource = SourceResource.objects.create(
@@ -144,8 +143,8 @@ class SourceConnectionProbeTests(TestCase):
 
     @mock.patch("apps.source.tasks.connection_probe.run_connection_test")
     def test_probe_skips_when_proxy_is_offline(self, run_test):
-        self.proxy.status = Node.Status.OFFLINE
-        self.proxy.save(update_fields=["status", "updated_at"])
+        self.proxy.availability = Node.Availability.OFFLINE
+        self.proxy.save(update_fields=["availability", "updated_at"])
 
         result = run_source_resource_capacity_probe(
             resource_id=self.resource.id,
@@ -339,7 +338,7 @@ class SourceConnectionProbeTests(TestCase):
             organization=self.org,
             name="source-connection-replacement-proxy",
             role=Node.Role.PROXY,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
         )
 
         result = bind_node(resource=self.resource, node_id=replacement.id)

--- a/src/backend/apps/source/tests/test_direct_nas_cleanup_unregister.py
+++ b/src/backend/apps/source/tests/test_direct_nas_cleanup_unregister.py
@@ -38,7 +38,7 @@ class DirectNasCleanupUnregisterTests(TestCase):
             organization=self.org,
             name="direct-nas-agent",
             role=Node.Role.AGENT,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             metadata={"inventory": {"capabilities": ["repository_cleanup_v1"]}},
         )
         self.repository = Repository.objects.create(

--- a/src/backend/apps/source/tests/test_proxy_bindings.py
+++ b/src/backend/apps/source/tests/test_proxy_bindings.py
@@ -36,14 +36,14 @@ class SourceProxyBindingTests(TestCase):
             organization=self.org,
             name="proxy-a",
             role=NodeRole.PROXY,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             ip_address="10.0.0.41",
         )
         self.proxy_b = Node.objects.create(
             organization=self.org,
             name="proxy-b",
             role=NodeRole.PROXY,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             ip_address="10.0.0.42",
         )
 

--- a/src/backend/apps/source/tests/test_remote_transaction_boundaries.py
+++ b/src/backend/apps/source/tests/test_remote_transaction_boundaries.py
@@ -22,7 +22,7 @@ class SourceRemoteTransactionBoundaryTests(TransactionTestCase):
             organization=self.org,
             name="source-remote-proxy",
             role=Node.Role.PROXY,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
         )
 
     @mock.patch(

--- a/src/backend/apps/source/tests/test_source_mount_point.py
+++ b/src/backend/apps/source/tests/test_source_mount_point.py
@@ -151,14 +151,14 @@ class SourceMountPointAfterProxyChangeTests(TestCase):
             organization=self.org,
             name="proxy-a",
             role=NodeRole.PROXY,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             ip_address="10.0.0.41",
         )
         self.proxy_b = Node.objects.create(
             organization=self.org,
             name="proxy-b",
             role=NodeRole.PROXY,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             ip_address="10.0.0.42",
         )
 

--- a/src/backend/apps/source/tests/test_source_pipeline_fence.py
+++ b/src/backend/apps/source/tests/test_source_pipeline_fence.py
@@ -22,7 +22,7 @@ class SourcePipelineOperationFenceTests(TestCase):
             organization=self.org,
             name="pipeline-fence-agent",
             role=Node.Role.AGENT,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
         )
         self.entry = SourceBackupPipelineEntry.objects.create(
             organization=self.org,

--- a/src/backend/apps/source/tests/test_source_pipeline_projection.py
+++ b/src/backend/apps/source/tests/test_source_pipeline_projection.py
@@ -5,7 +5,9 @@ from django.core.management.base import CommandError
 from django.test import TestCase
 
 from apps.iam.models import Organization
-from apps.node.models import Node
+from apps.node import conf as node_conf
+from apps.node.models import Node, NodeTask
+from apps.node.services.internal.task import complete_task as complete_node_task
 from apps.source.constants import PipelineStep, ResourceType, SelectableSourceKind
 from apps.source.models import SourceBackupPipelineEntry, SourceResource
 from apps.source.services.internal.source_pipeline import (
@@ -24,8 +26,7 @@ class SourcePipelineProjectionTests(TestCase):
             organization=self.org,
             name="agent-display",
             role=Node.Role.AGENT,
-            status=Node.Status.ONLINE,
-            availability=Node.Availability.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             connection_ip_address="198.51.100.10",
             metadata={"inventory": {"hostname": "agent-reported"}},
         )
@@ -39,9 +40,39 @@ class SourcePipelineProjectionTests(TestCase):
         self.assertEqual(entry.source_name, "agent-display")
         self.assertEqual(entry.source_hostname, "agent-reported")
         self.assertEqual(entry.source_ip, "198.51.100.10")
-        self.assertEqual(entry.source_status, Node.Status.ONLINE)
+        self.assertEqual(entry.source_status, Node.Status.ACTIVE)
         self.assertEqual(entry.source_availability, Node.Availability.ONLINE)
         self.assertEqual(entry.created_at, self.agent.created_at)
+
+    def test_upgrade_failure_refreshes_agent_pipeline_status_without_changing_availability(self):
+        entry = ensure_pipeline_entry(
+            organization_id=self.org.id,
+            source_kind=SelectableSourceKind.AGENT,
+            ref_id=self.agent.id,
+        )
+        task = NodeTask.objects.create(
+            organization=self.org,
+            node=self.agent,
+            kind="agent.upgrade",
+            status=NodeTask.Status.PENDING,
+            watchdog_deadline_at=self.agent.created_at,
+            correlation_type=node_conf.LIFECYCLE_CORRELATION_TYPE,
+            correlation_id=f"upgrade:{self.agent.id}",
+        )
+
+        complete_node_task(
+            task_id=task.id,
+            node_id=self.agent.id,
+            status=NodeTask.Status.FAILED,
+            error="upgrade package verification failed",
+        )
+
+        self.agent.refresh_from_db()
+        entry.refresh_from_db()
+        self.assertEqual(self.agent.status, Node.Status.UPGRADE_FAILED)
+        self.assertEqual(self.agent.availability, Node.Availability.ONLINE)
+        self.assertEqual(entry.source_status, Node.Status.UPGRADE_FAILED)
+        self.assertEqual(entry.source_availability, Node.Availability.ONLINE)
 
     def test_nas_without_proxy_projects_empty_identity_and_offline(self):
         source = SourceResource.objects.create(
@@ -147,8 +178,7 @@ class SourcePipelineProjectionTests(TestCase):
             name="proxy-before",
             role=Node.Role.PROXY,
             ip_address="198.51.100.20",
-            status=Node.Status.ONLINE,
-            availability=Node.Availability.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
         )
         nas = SourceResource.objects.create(
             organization=self.org,

--- a/src/backend/apps/storage/repositories/serializers.py
+++ b/src/backend/apps/storage/repositories/serializers.py
@@ -159,7 +159,7 @@ class RepositorySerializer(serializers.ModelSerializer):
         ).first()
         if node is None:
             return {"enabled": True, "ready": False, "host": None, "reason": "proxy_missing"}
-        if node.status != Node.Status.ONLINE:
+        if node.availability != Node.Availability.ONLINE:
             return {"enabled": True, "ready": False, "host": None, "reason": "proxy_offline"}
         host, _source = explicit_repository_server_host(repository=obj, node=node)
         if not host:

--- a/src/backend/apps/storage/services/internal/nas_repair.py
+++ b/src/backend/apps/storage/services/internal/nas_repair.py
@@ -124,7 +124,7 @@ def _validate_proxy_node(*, organization_id: int, node_id: int) -> Node:
         raise DRFValidationError(
             {"bind_node_id": "Bound proxy node not found in this organization."}
         )
-    if node.status != Node.Status.ONLINE:
+    if node.availability != Node.Availability.ONLINE:
         raise DRFValidationError(
             {"bind_node_id": 'Proxy node "%s" is not online.' % node.name}
         )

--- a/src/backend/apps/storage/services/internal/nas_repository.py
+++ b/src/backend/apps/storage/services/internal/nas_repository.py
@@ -125,7 +125,7 @@ def validate_proxy_for_repository(repository: Repository) -> Node:
     ).first()
     if node is None:
         raise ValidationError("Bound proxy node not found.")
-    if node.status != Node.Status.ONLINE:
+    if node.availability != Node.Availability.ONLINE:
         raise ValidationError(f'Bound proxy node "{node.name}" is not online.')
     return node
 

--- a/src/backend/apps/storage/services/internal/proxy_fs_repository.py
+++ b/src/backend/apps/storage/services/internal/proxy_fs_repository.py
@@ -49,7 +49,7 @@ def validate_proxy_for_proxy_fs(repository: Repository) -> Node:
     ).first()
     if node is None:
         raise ValidationError("Bound proxy node not found.")
-    if node.status != Node.Status.ONLINE:
+    if node.availability != Node.Availability.ONLINE:
         raise ValidationError(f'Bound proxy node "{node.name}" is not online.')
     return node
 

--- a/src/backend/apps/storage/services/internal/repository_access.py
+++ b/src/backend/apps/storage/services/internal/repository_access.py
@@ -212,7 +212,7 @@ def _bound_proxy(*, repository: Repository, message_prefix: str) -> Node:
     ).first()
     if node is None:
         raise ValidationError({"repository_id": f"{message_prefix} bound proxy node not found."})
-    if node.status != Node.Status.ONLINE:
+    if node.availability != Node.Availability.ONLINE:
         raise ValidationError({"repository_id": f'{message_prefix} bound proxy node "{node.name}" is offline.'})
     return node
 

--- a/src/backend/apps/storage/services/internal/repository_cleanup.py
+++ b/src/backend/apps/storage/services/internal/repository_cleanup.py
@@ -1437,7 +1437,7 @@ def _cleanup_target_payloads(
             "owner_node_id": target.owner_node_id,
             "owner_node_name": nodes[target.owner_node_id].name if target.owner_node_id in nodes else "",
             "owner_online": (
-                nodes[target.owner_node_id].status == Node.Status.ONLINE
+                nodes[target.owner_node_id].availability == Node.Availability.ONLINE
                 if target.owner_node_id in nodes
                 else target.owner_type == RepositoryExecutionTarget.OwnerType.CONTROLLER
             ),

--- a/src/backend/apps/storage/services/internal/repository_create.py
+++ b/src/backend/apps/storage/services/internal/repository_create.py
@@ -502,7 +502,7 @@ def _run_repair_remount(repository_task: RepositoryTask) -> None:
     ).first()
     if new_node is None:
         raise ValidationError("Bound proxy node not found.")
-    if new_node.status != Node.Status.ONLINE:
+    if new_node.availability != Node.Availability.ONLINE:
         raise ValidationError(f'Bound proxy node "{new_node.name}" is not online.')
 
     _remount_on_new_proxy(

--- a/src/backend/apps/storage/services/internal/repository_health.py
+++ b/src/backend/apps/storage/services/internal/repository_health.py
@@ -67,7 +67,7 @@ def probe_unbound_nas_repository_health(repository: Repository) -> str:
         return Repository.Health.UNVERIFIED
 
     for node in nodes:
-        if node.status != Node.Status.ONLINE:
+        if node.availability != Node.Availability.ONLINE:
             continue
         if _probe_unbound_nas_from_node(repository=repository, node=node):
             return Repository.Health.ONLINE

--- a/src/backend/apps/storage/services/internal/repository_usage.py
+++ b/src/backend/apps/storage/services/internal/repository_usage.py
@@ -176,7 +176,7 @@ def agent_path_usage_bytes(
     node = Node.objects.filter(
         id=node_id,
         organization_id=organization_id,
-        status=Node.Status.ONLINE,
+        availability=Node.Availability.ONLINE,
     ).first()
     if node is None:
         logger.info("path.usage skipped node offline node_id=%s path=%s", node_id, clean_path)
@@ -613,7 +613,7 @@ def _sync_direct_nas_agent_usage_shards(repository: Repository) -> tuple[int | N
                 last_error="Agent source not found.",
             )
             continue
-        if node.status != Node.Status.ONLINE:
+        if node.availability != Node.Availability.ONLINE:
             _upsert_direct_nas_agent_shard(
                 repository=repository,
                 node_id=node_id,

--- a/src/backend/apps/storage/tests/test_nas_repair_api.py
+++ b/src/backend/apps/storage/tests/test_nas_repair_api.py
@@ -56,21 +56,21 @@ class NasRepairApiTests(TestCase):
             organization=self.org,
             name="proxy-a",
             role=NodeRole.PROXY,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             ip_address="10.0.0.31",
         )
         self.proxy_b = Node.objects.create(
             organization=self.org,
             name="proxy-b",
             role=NodeRole.PROXY,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             ip_address="10.0.0.32",
         )
         self.proxy_offline = Node.objects.create(
             organization=self.org,
             name="proxy-c",
             role=NodeRole.PROXY,
-            status=Node.Status.OFFLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.OFFLINE,
             ip_address="10.0.0.33",
         )
 

--- a/src/backend/apps/storage/tests/test_repository_api.py
+++ b/src/backend/apps/storage/tests/test_repository_api.py
@@ -524,7 +524,7 @@ class StorageRepositoryApiTests(TestCase):
             organization=self.org,
             name="source-agent",
             role=Node.Role.AGENT,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             ip_address="10.0.8.10",
             metadata={"inventory": {"hostname": "source-host", "os": "linux"}},
         )
@@ -580,7 +580,7 @@ class StorageRepositoryApiTests(TestCase):
             organization=self.org,
             name="nas-proxy",
             role=Node.Role.PROXY,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             ip_address="10.0.8.12",
         )
         source = SourceResource.objects.create(
@@ -675,7 +675,7 @@ class StorageRepositoryApiTests(TestCase):
             organization=self.org,
             name="source-agent-a",
             role=Node.Role.AGENT,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             ip_address="10.0.8.11",
             metadata={"inventory": {"hostname": "source-a", "os": "linux"}},
         )
@@ -683,7 +683,7 @@ class StorageRepositoryApiTests(TestCase):
             organization=self.org,
             name="source-agent-b",
             role=Node.Role.AGENT,
-            status=Node.Status.OFFLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.OFFLINE,
             ip_address="10.0.8.12",
             metadata={"inventory": {"hostname": "source-b", "os": "linux"}},
         )
@@ -691,7 +691,7 @@ class StorageRepositoryApiTests(TestCase):
             organization=self.org,
             name="source-agent-c",
             role=Node.Role.AGENT,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             ip_address="10.0.8.13",
             metadata={"inventory": {"hostname": "source-c", "os": "linux"}},
         )
@@ -772,7 +772,7 @@ class StorageRepositoryApiTests(TestCase):
             organization=self.org,
             name="proxy-node",
             role=Node.Role.PROXY,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             ip_address="10.0.0.99",
         )
 
@@ -829,7 +829,7 @@ class StorageRepositoryApiTests(TestCase):
             organization=self.org,
             name="proxy-invalid-server-host",
             role=Node.Role.PROXY,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
         )
         response = self.client.post(
             "/api/v1/storage/repositories/",
@@ -883,7 +883,7 @@ class StorageRepositoryApiTests(TestCase):
             organization=self.org,
             name="proxy-fs-node",
             role=Node.Role.PROXY,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             ip_address="10.0.0.100",
         )
         initialize.side_effect = RepositoryAlreadyExistsError("repository already exists")
@@ -914,7 +914,7 @@ class StorageRepositoryApiTests(TestCase):
             organization=self.org,
             name="proxy-fs-nested-conflict",
             role=Node.Role.PROXY,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             ip_address="10.0.0.101",
         )
         run_agent_task_sync.return_value = SimpleNamespace(
@@ -963,7 +963,7 @@ class StorageRepositoryApiTests(TestCase):
             organization=self.org,
             name="proxy-fs-nested-failure",
             role=Node.Role.PROXY,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             ip_address="10.0.0.102",
         )
         run_agent_task_sync.return_value = SimpleNamespace(
@@ -1190,13 +1190,13 @@ class StorageRepositoryApiTests(TestCase):
             organization=self.org,
             name="repo-proxy",
             role=Node.Role.PROXY,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
         )
         agent = Node.objects.create(
             organization=self.org,
             name="source-agent",
             role=Node.Role.AGENT,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
         )
         repo = Repository.objects.create(
             organization_id=self.org.id,

--- a/src/backend/apps/storage/tests/test_repository_cleanup.py
+++ b/src/backend/apps/storage/tests/test_repository_cleanup.py
@@ -270,7 +270,7 @@ class RepositoryCleanupTests(TestCase):
                 organization=self.org,
                 name=f"agent-{index}",
                 role=Node.Role.AGENT,
-                status=Node.Status.ONLINE,
+                status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
                 metadata={"inventory": {"capabilities": ["repository_cleanup_v1"]}},
             )
             nodes.append(node)
@@ -384,7 +384,7 @@ class RepositoryCleanupTests(TestCase):
             organization=self.org,
             name="historical-owner",
             role=Node.Role.AGENT,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             metadata={"inventory": {"capabilities": ["repository_cleanup_v1"]}},
         )
         shard = RepositoryUsageShard.objects.create(
@@ -432,7 +432,7 @@ class RepositoryCleanupTests(TestCase):
             organization=self.org,
             name="force-historical-owner",
             role=Node.Role.AGENT,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             metadata={"inventory": {"capabilities": ["repository_cleanup_v1"]}},
         )
         RepositoryUsageShard.objects.create(

--- a/src/backend/apps/storage/tests/test_repository_create.py
+++ b/src/backend/apps/storage/tests/test_repository_create.py
@@ -126,7 +126,7 @@ class RepositoryCreateTaskTests(TestCase):
             organization=self.org,
             name="repair-proxy",
             role=Node.Role.PROXY,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             ip_address="10.0.0.40",
         )
         repository = Repository.objects.create(
@@ -214,7 +214,7 @@ class RepositoryCreateTaskTests(TestCase):
             organization=self.org,
             name="repair-proxy-resume",
             role=Node.Role.PROXY,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             ip_address="10.0.0.43",
         )
         repository = Repository.objects.create(
@@ -260,14 +260,14 @@ class RepositoryCreateTaskTests(TestCase):
             organization=self.org,
             name="old-proxy",
             role=Node.Role.PROXY,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             ip_address="10.0.0.41",
         )
         new_proxy = Node.objects.create(
             organization=self.org,
             name="new-proxy",
             role=Node.Role.PROXY,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             ip_address="10.0.0.42",
         )
         repository = Repository.objects.create(
@@ -330,14 +330,14 @@ class RepositoryCreateTaskTests(TestCase):
             organization=self.org,
             name="old-proxy-step",
             role=Node.Role.PROXY,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             ip_address="10.0.0.48",
         )
         new_proxy = Node.objects.create(
             organization=self.org,
             name="new-proxy-step",
             role=Node.Role.PROXY,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             ip_address="10.0.0.49",
         )
         repository = Repository.objects.create(
@@ -387,14 +387,14 @@ class RepositoryCreateTaskTests(TestCase):
             organization=self.org,
             name="old-proxy-finalize",
             role=Node.Role.PROXY,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             ip_address="10.0.0.46",
         )
         new_proxy = Node.objects.create(
             organization=self.org,
             name="new-proxy-finalize",
             role=Node.Role.PROXY,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             ip_address="10.0.0.47",
         )
         repository = Repository.objects.create(
@@ -439,14 +439,14 @@ class RepositoryCreateTaskTests(TestCase):
             organization=self.org,
             name="old-proxy-resume",
             role=Node.Role.PROXY,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             ip_address="10.0.0.44",
         )
         new_proxy = Node.objects.create(
             organization=self.org,
             name="new-proxy-resume",
             role=Node.Role.PROXY,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             ip_address="10.0.0.45",
         )
         repository = Repository.objects.create(

--- a/src/backend/apps/storage/tests/test_repository_health_tasks.py
+++ b/src/backend/apps/storage/tests/test_repository_health_tasks.py
@@ -308,7 +308,7 @@ class UnboundNASRepositoryHealthTests(TestCase):
             organization=self.organization,
             name=name,
             role=role,
-            status=Node.Status.ONLINE if online else Node.Status.OFFLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE if online else Node.Availability.OFFLINE,
             ip_address="10.0.1.1",
         )
 
@@ -484,7 +484,7 @@ class RepositoryHealthProbeTests(TestCase):
             organization=self.organization,
             name="proxy",
             role=Node.Role.PROXY,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
         )
         repository = Repository.objects.create(
             organization_id=self.organization.id,

--- a/src/backend/apps/storage/tests/test_repository_operation_recovery.py
+++ b/src/backend/apps/storage/tests/test_repository_operation_recovery.py
@@ -47,7 +47,7 @@ class RepositoryOperationRecoveryTests(TestCase):
             organization=self.org,
             name="recovery-proxy",
             role=NodeRole.PROXY,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             ip_address="10.0.0.50",
             metadata={
                 "inventory": {

--- a/src/backend/apps/storage/tests/test_repository_proxy_bindings.py
+++ b/src/backend/apps/storage/tests/test_repository_proxy_bindings.py
@@ -39,14 +39,14 @@ class StorageRepositoryProxyBindingTests(TestCase):
             organization=self.org,
             name="proxy-a",
             role=NodeRole.PROXY,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             ip_address="10.0.0.31",
         )
         self.proxy_b = Node.objects.create(
             organization=self.org,
             name="proxy-b",
             role=NodeRole.PROXY,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             ip_address="10.0.0.32",
         )
 
@@ -212,7 +212,7 @@ class StorageRepositoryProxyBindingTests(TestCase):
             organization=self.org,
             name="agent-x",
             role=NodeRole.AGENT,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             ip_address="10.0.0.33",
         )
         repo = Repository.objects.create(

--- a/src/backend/apps/storage/tests/test_repository_tasks.py
+++ b/src/backend/apps/storage/tests/test_repository_tasks.py
@@ -75,7 +75,7 @@ class RepositoryTaskTests(TestCase):
             organization=self.org,
             name="storage-proxy",
             role=Node.Role.PROXY,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
         )
         repository = Repository.objects.create(
             organization_id=self.org.id,
@@ -110,7 +110,7 @@ class RepositoryTaskTests(TestCase):
                 organization=self.org,
                 name=name,
                 role=Node.Role.AGENT,
-                status=Node.Status.ONLINE,
+                status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             )
             for name in ("Finance-Server", "HR-Server")
         ]
@@ -154,7 +154,7 @@ class RepositoryTaskTests(TestCase):
                 organization=self.org,
                 name="Finance-Server",
                 role=Node.Role.AGENT,
-                status=Node.Status.ONLINE,
+                status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             )
             for _ in range(2)
         ]
@@ -195,7 +195,7 @@ class RepositoryTaskTests(TestCase):
             organization=self.org,
             name="Archived-Server",
             role=Node.Role.AGENT,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
         )
         for node_id in (node.id, 999999):
             RepositoryUsageShard.objects.create(

--- a/src/backend/apps/storage/tests/test_repository_usage.py
+++ b/src/backend/apps/storage/tests/test_repository_usage.py
@@ -203,14 +203,14 @@ class RepositoryUsageTests(TestCase):
             organization=org,
             name="agent-a",
             role=Node.Role.AGENT,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             ip_address="10.0.1.1",
         )
         agent_b = Node.objects.create(
             organization=org,
             name="agent-b",
             role=Node.Role.AGENT,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             ip_address="10.0.1.2",
         )
         repo = Repository.objects.create(
@@ -262,7 +262,7 @@ class RepositoryUsageTests(TestCase):
             organization=org,
             name="agent-a",
             role=Node.Role.AGENT,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             ip_address="10.0.2.1",
         )
         repo = Repository.objects.create(
@@ -308,7 +308,7 @@ class RepositoryUsageTests(TestCase):
             organization=org,
             name="agent-a",
             role=Node.Role.AGENT,
-            status=Node.Status.ONLINE,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
             ip_address="10.0.3.1",
         )
         repo = Repository.objects.create(

--- a/src/frontend/src/components/ChangeProxyHostDialog.vue
+++ b/src/frontend/src/components/ChangeProxyHostDialog.vue
@@ -52,13 +52,13 @@ function normalizeNodeId(value: unknown): number | undefined {
 }
 
 function proxyNodeStatusLabel(node: ApiNode) {
-  return node.status === 'online'
+  return node.availability === 'online'
     ? t('protection.sourceResources.nodeStatusOnline')
     : t('protection.sourceResources.nodeStatusOffline')
 }
 
 function proxyNodeStatusTagType(node: ApiNode): 'success' | 'danger' | 'warning' | 'info' {
-  if (node.status === 'online') return 'success'
+  if (node.availability === 'online') return 'success'
   if (node.status === 'offline') return 'danger'
   return 'info'
 }

--- a/src/frontend/src/components/NodeBasicInfoPanel.vue
+++ b/src/frontend/src/components/NodeBasicInfoPanel.vue
@@ -102,7 +102,7 @@ const capacityParts = computed(() => {
 })
 
 const uptimeLabel = computed(() => {
-  if (props.node.status !== 'online') return ''
+  if (props.node.availability !== 'online') return ''
   const seconds = nodeUptimeSeconds(props.node, true)
   if (seconds == null) return ''
   const days = Math.floor(seconds / 86400)
@@ -117,7 +117,7 @@ const uptimeLabel = computed(() => {
 
 function resolveNodeDisplayStatus(node: ApiNode): NodeDisplayStatus {
   if (props.resolveDisplayStatus) return props.resolveDisplayStatus(node)
-  if (node.status === 'online') {
+  if (node.status === 'active') {
     return { labelKey: 'protection.sourceResources.nodeStatusOnline', tagType: 'success' }
   }
   if (node.status === 'reconnecting') {

--- a/src/frontend/src/composables/useKnowledgeSourceForm.ts
+++ b/src/frontend/src/composables/useKnowledgeSourceForm.ts
@@ -126,16 +126,16 @@ export function useKnowledgeSourceForm(
 
   const aiReadyGateways = computed(() =>
     gateways.value.filter(
-      (row) => row.ai_enabled && row.sidecar_status === 'online' && row.status === 'online',
+      (row) => row.ai_enabled && row.sidecar_status === 'online' && row.availability === 'online',
     ),
   )
 
   const onlineGateways = computed(() =>
-    gateways.value.filter((row) => row.status === 'online'),
+    gateways.value.filter((row) => row.availability === 'online'),
   )
 
   const offlineGatewayCount = computed(() =>
-    gateways.value.filter((row) => row.status !== 'online').length,
+    gateways.value.filter((row) => row.availability !== 'online').length,
   )
 
   const gatewaysForPicker = computed(() => {

--- a/src/frontend/src/composables/useNodeConnectionDisplay.ts
+++ b/src/frontend/src/composables/useNodeConnectionDisplay.ts
@@ -1,63 +1,20 @@
-/** Debounce transient reconnecting for node connection status display. */
+/** Connection presentation is sourced exclusively from Availability. */
 
-import type { NodeStatus, ApiNode } from '../types/node'
+import type { Availability, ApiNode } from '../types/node'
 
-const RECONNECT_DEBOUNCE_POLLS = 2
-
-type NodeStreak = {
-  lastStable: NodeStatus
-  reconnectPolls: number
-}
-
-const streakByNodeId = new Map<number, NodeStreak>()
-
-function defaultStableStatus(): NodeStatus {
-  return 'online'
-}
-
-/**
- * Return UI-facing connection status with reconnecting debounce.
- * ``online`` / ``offline`` apply immediately; ``reconnecting`` requires two polls.
- */
-export function debouncedNodeStatus(node: Pick<ApiNode, 'id' | 'status'>): NodeStatus {
-  const raw = node.status
-  const nodeId = node.id
-
-  if (raw === 'online' || raw === 'offline') {
-    streakByNodeId.set(nodeId, { lastStable: raw, reconnectPolls: 0 })
-    return raw
-  }
-
-  if (raw !== 'reconnecting') {
-    return raw
-  }
-
-  const prev = streakByNodeId.get(nodeId) ?? {
-    lastStable: defaultStableStatus(),
-    reconnectPolls: 0,
-  }
-  const reconnectPolls = prev.reconnectPolls + 1
-  if (reconnectPolls >= RECONNECT_DEBOUNCE_POLLS) {
-    streakByNodeId.set(nodeId, { lastStable: 'reconnecting', reconnectPolls })
-    return 'reconnecting'
-  }
-  streakByNodeId.set(nodeId, { ...prev, reconnectPolls })
-  return prev.lastStable
+export function debouncedNodeStatus(node: Pick<ApiNode, 'availability'>): Availability {
+  return node.availability === 'online' ? 'online' : 'offline'
 }
 
 export function resetNodeConnectionDisplay(nodeId?: number) {
-  if (nodeId == null) {
-    streakByNodeId.clear()
-    return
-  }
-  streakByNodeId.delete(nodeId)
+  void nodeId
 }
 
 /**
  * While another node is in a lifecycle batch, ignore transient reconnecting flicker
  * from full list refreshes on unrelated agents that stayed online.
  */
-export function mergeNodeListDuringLifecycleBatch<T extends Pick<ApiNode, 'id' | 'status' | 'routable'>>(
+export function mergeNodeListDuringLifecycleBatch<T extends Pick<ApiNode, 'id' | 'availability' | 'routable'>>(
   next: T[],
   prev: T[],
   batchNodeIds: ReadonlySet<number>,
@@ -71,13 +28,12 @@ export function mergeNodeListDuringLifecycleBatch<T extends Pick<ApiNode, 'id' |
       return node
     }
     const old = prevById.get(node.id)
-    if (!old || old.status !== 'online' || node.status !== 'reconnecting') {
-      return node
-    }
-    return { ...node, status: 'online' as const, routable: old.routable ?? node.routable }
+    return old?.availability === 'online' && node.availability === 'offline'
+      ? { ...node, availability: old.availability, routable: old.routable ?? node.routable }
+      : node
   })
 }
 
-export function connectionStatusForLifecycle(node: Pick<ApiNode, 'id' | 'status'>): NodeStatus {
-  return node.status
+export function connectionStatusForLifecycle(node: Pick<ApiNode, 'availability'>): Availability {
+  return debouncedNodeStatus(node)
 }

--- a/src/frontend/src/composables/useNodeLifecycleOps.ts
+++ b/src/frontend/src/composables/useNodeLifecycleOps.ts
@@ -21,7 +21,7 @@ import type {
   NodeLifecycleKind,
   NodeOperationBatchPreview,
 } from '../types/nodeLifecycle'
-import { debouncedNodeStatus, mergeNodeListDuringLifecycleBatch } from './useNodeConnectionDisplay'
+import { mergeNodeListDuringLifecycleBatch } from './useNodeConnectionDisplay'
 
 const STORAGE_KEY = 'hfl-node-lifecycle-queue'
 
@@ -106,7 +106,7 @@ function lifecycleDone(
   if (!target || !versionReachedTarget(node, target)) {
     return false
   }
-  return node.status === 'online' && node.routable === true
+  return node.availability === 'online' && node.routable === true
 }
 
 function queueItemMeta(
@@ -729,7 +729,11 @@ export function useNodeLifecycleOps(options: {
           spinning: true,
         }
       }
-      const key = `nodeLifecycle.state.${lc.state}`
+      const key = lc.state === 'failed'
+        ? lc.kind === 'upgrade'
+          ? 'nodeLifecycle.state.upgrade_failed'
+          : 'nodeLifecycle.state.deregistration_failed'
+        : `nodeLifecycle.state.${lc.state}`
       const spinning = LIFECYCLE_SPINNING_STATES.includes(
         lc.state as (typeof LIFECYCLE_SPINNING_STATES)[number],
       )
@@ -751,42 +755,30 @@ export function useNodeLifecycleOps(options: {
       const spinning = LIFECYCLE_SPINNING_STATES.includes(
         state as (typeof LIFECYCLE_SPINNING_STATES)[number],
       )
+      const labelKey = state === 'failed'
+        ? activeKind.value === 'upgrade'
+          ? 'nodeLifecycle.state.upgrade_failed'
+          : 'nodeLifecycle.state.deregistration_failed'
+        : `nodeLifecycle.state.${state}`
       return {
-        labelKey: `nodeLifecycle.state.${state}`,
-        tagType: 'info',
+        labelKey,
+        tagType: state === 'failed' ? 'danger' : 'info',
         tagClass: state === 'queued' ? 'hfl-tag--neutral' : undefined,
         spinning,
       }
     }
 
-    if (node.status === 'online') {
-      return { labelKey: 'protection.sourceResources.nodeStatusOnline', tagType: 'success' }
+    // Old rows may be read before the data migration runs. The migration maps
+    // both legacy connection values to Active, so present the same semantics.
+    const status = node.status === 'online' || node.status === 'offline' ? 'active' : node.status
+    return {
+      labelKey: `nodeLifecycle.state.${status}`,
+      tagType: status === 'active'
+        ? 'success'
+        : status === 'failed' || status === 'upgrade_failed' || status === 'deregistration_failed'
+          ? 'danger'
+          : 'info',
     }
-    const displayStatus = debouncedNodeStatus(node)
-    if (displayStatus === 'reconnecting') {
-      const local = localLifecycleItem(running.value, queued.value, node.id)
-      if (local && activeKind.value) {
-        const state =
-          local.state && LIFECYCLE_SPINNING_STATES.includes(
-            local.state as (typeof LIFECYCLE_SPINNING_STATES)[number],
-          )
-            ? local.state
-            : activeKind.value === 'upgrade'
-              ? 'restarting'
-              : 'removing'
-        return {
-          labelKey: `nodeLifecycle.state.${state}`,
-          tagType: 'info',
-          spinning: true,
-        }
-      }
-      return {
-        labelKey: 'protection.sourceResources.nodeStatusReconnecting',
-        tagType: 'info',
-        spinning: true,
-      }
-    }
-    return { labelKey: 'protection.sourceResources.nodeStatusOffline', tagType: 'danger' }
   }
 
   function resolveVersionDisplay(node: ApiNode, versionLabel: string) {

--- a/src/frontend/src/lib/flowSourceDisplay.ts
+++ b/src/frontend/src/lib/flowSourceDisplay.ts
@@ -81,11 +81,19 @@ export function flowSourceNasAccessTitle(row: FlowSourceRow) {
 
 export function flowSourceReadyStatus(
   row: FlowSourceRow,
-  labels: Pick<FlowSourceDisplayLabels, 'online' | 'offline'>,
+  _labels: Pick<FlowSourceDisplayLabels, 'online' | 'offline'>,
 ): FlowReadyStatus {
+  const label = row.status
+    .split('_')
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ')
   return {
-    label: row.status === 'online' ? labels.online : labels.offline,
-    tag: row.status === 'online' ? 'success' : 'neutral',
+    label: row.status === 'active' ? 'Active' : label,
+    tag: row.status === 'active'
+      ? 'success'
+      : row.status === 'failed' || row.status === 'upgrade_failed' || row.status === 'deregistration_failed' || row.status === 'error'
+        ? 'danger'
+        : 'neutral',
   }
 }
 

--- a/src/frontend/src/lib/sourceApi.ts
+++ b/src/frontend/src/lib/sourceApi.ts
@@ -107,7 +107,8 @@ export type BackupSelectableSource = {
   hostname: string
   node_name: string
   node_ip: string
-  status: 'online' | 'reconnecting' | 'offline'
+  status: 'active' | 'inactive' | 'error' | 'probing' | 'removing' | 'remove_failed' | 'removed' | 'upgrading' | 'restarting' | 'verifying' | 'verification_pending' | 'cleaning_up' | 'failed' | 'upgrade_failed' | 'deregistration_failed'
+  availability?: BackupSelectableAvailability
   protocol?: 'nfs' | 'smb'
   platform?: 'linux' | 'windows' | 'macos'
   connection_uri?: string
@@ -155,8 +156,8 @@ export type BackupSelectableQueryParams = {
   source_name?: string
   source_hostname?: string
   source_ip?: string
-  status?: 'online' | 'reconnecting' | 'offline'
-  source_status?: 'active' | 'error' | 'inactive' | 'offline' | 'online' | 'reconnecting' | 'remove_failed' | 'removing'
+  status?: BackupSelectableSource['status']
+  source_status?: BackupSelectableSource['status']
   availability?: BackupSelectableAvailability
   type?: 'host' | 'nas'
   running_task?: BackupSelectableRunningTask

--- a/src/frontend/src/lib/sourceNasDisplay.ts
+++ b/src/frontend/src/lib/sourceNasDisplay.ts
@@ -13,6 +13,8 @@ export type NasLikeResource = {
 
 export type SourceNasProxyStatus = 'online' | 'reconnecting' | 'offline'
 export type SourceNasRuntimeStatus =
+  | 'active'
+  | 'inactive'
   | 'removing'
   | 'remove_failed'
   | 'error'
@@ -31,6 +33,14 @@ const SOURCE_NAS_STATUS_PRESENTATIONS: Record<
   SourceNasRuntimeStatus,
   Omit<SourceNasStatusPresentation, 'status'>
 > = {
+  active: {
+    labelKey: 'nodeLifecycle.state.active',
+    tone: 'success',
+  },
+  inactive: {
+    labelKey: 'protection.sourceResources.nodeStatusOffline',
+    tone: 'warning',
+  },
   removing: {
     labelKey: 'protection.backupsPage.sourcePendingDeleting',
     tone: 'info',
@@ -84,7 +94,9 @@ export function sourceNasStatusPresentation(
   const mountStatus = normalizedStatus(row.mount_status)
   const resourceStatus = normalizedStatus(row.status)
   let status: SourceNasRuntimeStatus = proxyStatus
-  if (
+  if (resourceStatus === 'removing' || resourceStatus === 'remove_failed' || resourceStatus === 'error' || resourceStatus === 'probing' || resourceStatus === 'active' || resourceStatus === 'inactive') {
+    status = resourceStatus as SourceNasRuntimeStatus
+  } else if (
     connectionTestStatus === 'failed'
     || mountStatus === 'error'
     || resourceStatus === 'error'

--- a/src/frontend/src/locales/en.ts
+++ b/src/frontend/src/locales/en.ts
@@ -1426,6 +1426,7 @@ export const en = {
     bannerRemove:
       'Batch removal · Running {running} · Queued {queued} · Done {done}/{total} · Failed {failed}',
     state: {
+      active: 'Active',
       queued: 'Queued',
       upgrading: 'Upgrading',
       restarting: 'Restarting',
@@ -1434,6 +1435,8 @@ export const en = {
       removing: 'Removing',
       cleaning_up: 'Cleaning up',
       failed: 'Failed',
+      upgrade_failed: 'Upgrade Failed',
+      deregistration_failed: 'Deregistration Failed',
       completed: 'Completed',
     },
     osStep: 'Select Target Operating System',

--- a/src/frontend/src/locales/enProtectionPages.ts
+++ b/src/frontend/src/locales/enProtectionPages.ts
@@ -886,7 +886,7 @@ export const enProtectionPages = {
     deleteReasonNasUmountFailed: 'Could not unmount NAS share for [{name}]. {detail}',
     msgDeleteSourcePending: 'Source deregistration task submitted. Agent uninstall is in progress.',
     sourcePendingDeleting: 'Deregistering...',
-    sourcePendingDeleteFailed: 'Deregistration failed',
+    sourcePendingDeleteFailed: 'Deregistration Failed',
     sourcePendingRemoving: 'Removing Agent…',
     sourcePendingRevertStep3: 'Reverting Backup…',
     sourcePendingRevertStep2: 'Reverting to Step 1…',

--- a/src/frontend/src/pages/node/Nodes.vue
+++ b/src/frontend/src/pages/node/Nodes.vue
@@ -84,6 +84,16 @@ function proxyPlatformLabel(row: ApiNode) {
   return nodePlatformLabel(nodeEnrollmentOs(row), osPlatformLabels.value)
 }
 
+function availabilityLabel(value?: ApiNode['availability']) {
+  return value === 'online'
+    ? t('protection.sourceResources.nodeStatusOnline')
+    : t('protection.sourceResources.nodeStatusOffline')
+}
+
+function availabilityTagType(value?: ApiNode['availability']): 'success' | 'danger' {
+  return value === 'online' ? 'success' : 'danger'
+}
+
 
 const protectionMenus = useProtectionSideNav()
 
@@ -696,7 +706,7 @@ async function submitRename() {
           />
           <el-table-column
             :label="isProxyNodesPage ? t('protection.sourceResources.colName') : t('nodesPage.colName')"
-            :min-width="isProxyNodesPage ? 200 : 116"
+            :min-width="isProxyNodesPage ? 170 : 116"
             :fixed="isProxyNodesPage ? 'left' : undefined"
             class-name="hfl-table-name-col"
           >
@@ -720,47 +730,7 @@ async function submitRename() {
             </template>
           </el-table-column>
           <template v-if="isProxyNodesPage">
-            <el-table-column :label="t('protection.sourceResources.colHostIp')" min-width="140">
-              <template #default="{ row }">
-                <span>{{ ipLine(row) }}</span>
-              </template>
-            </el-table-column>
-            <el-table-column label="OS" min-width="120">
-              <template #default="{ row }">
-                <div class="source-os-cell source-os-cell--compact hfl-table-no-tooltip">
-                  <span class="source-os-cell__icon-wrap">
-                    <AgentPlatformBrandIcon :os="nodeEnrollmentOs(row)" />
-                  </span>
-                  <span class="source-os-cell__platform">{{ proxyPlatformLabel(row) }}</span>
-                </div>
-              </template>
-            </el-table-column>
-            <el-table-column :label="t('protection.sourceResources.colCpu')" min-width="88">
-              <template #default="{ row }">
-                <span>{{ nodeCpuCores(row) != null ? t('protection.sourceResources.cpuCoresValue', { n: nodeCpuCores(row) }) : '—' }}</span>
-              </template>
-            </el-table-column>
-            <el-table-column :label="t('protection.sourceResources.colMemory')" min-width="100">
-              <template #default="{ row }">
-                <span>{{ nodeMemoryTotalBytes(row) != null ? formatNodeBytes(nodeMemoryTotalBytes(row)!) : '—' }}</span>
-              </template>
-            </el-table-column>
-            <el-table-column :label="t('protection.sourceResources.colDiskCount')" min-width="96">
-              <template #default="{ row }">
-                <span>{{ nodeDiskCount(row) ?? '—' }}</span>
-              </template>
-            </el-table-column>
-            <el-table-column :label="t('protection.sourceResources.colCapacity')" min-width="200">
-              <template #default="{ row }">
-                <HflCapacityCell
-                  :used-bytes="nodeDiskUsageParts(row).used"
-                  :total-bytes="nodeDiskUsageParts(row).total"
-                  variant="compact"
-                  :format-bytes="formatNodeBytes"
-                />
-              </template>
-            </el-table-column>
-            <el-table-column :label="t('protection.sourceResources.colStatus')" width="120">
+            <el-table-column :label="t('protection.sourceResources.colStatus')" width="126" align="center" header-align="center">
               <template #default="{ row }">
                 <div class="hfl-table-no-tooltip">
                   <NodeLifecycleStatusCell
@@ -770,7 +740,56 @@ async function submitRename() {
                 </div>
               </template>
             </el-table-column>
-            <el-table-column :label="t('protection.sourceResources.colVersion')" min-width="130">
+            <el-table-column :label="t('protection.sourceResources.colHostIp')" min-width="120">
+              <template #default="{ row }">
+                <span>{{ ipLine(row) }}</span>
+              </template>
+            </el-table-column>
+            <el-table-column label="OS" min-width="105">
+              <template #default="{ row }">
+                <div class="source-os-cell source-os-cell--compact hfl-table-no-tooltip">
+                  <span class="source-os-cell__icon-wrap">
+                    <AgentPlatformBrandIcon :os="nodeEnrollmentOs(row)" />
+                  </span>
+                  <span class="source-os-cell__platform">{{ proxyPlatformLabel(row) }}</span>
+                </div>
+              </template>
+            </el-table-column>
+            <el-table-column :label="t('protection.sourceResources.colCpu')" min-width="76">
+              <template #default="{ row }">
+                <span>{{ nodeCpuCores(row) != null ? t('protection.sourceResources.cpuCoresValue', { n: nodeCpuCores(row) }) : '—' }}</span>
+              </template>
+            </el-table-column>
+            <el-table-column :label="t('protection.sourceResources.colMemory')" min-width="90">
+              <template #default="{ row }">
+                <span>{{ nodeMemoryTotalBytes(row) != null ? formatNodeBytes(nodeMemoryTotalBytes(row)!) : '—' }}</span>
+              </template>
+            </el-table-column>
+            <el-table-column :label="t('protection.sourceResources.colDiskCount')" min-width="78">
+              <template #default="{ row }">
+                <span>{{ nodeDiskCount(row) ?? '—' }}</span>
+              </template>
+            </el-table-column>
+            <el-table-column :label="t('protection.sourceResources.colCapacity')" min-width="170">
+              <template #default="{ row }">
+                <HflCapacityCell
+                  :used-bytes="nodeDiskUsageParts(row).used"
+                  :total-bytes="nodeDiskUsageParts(row).total"
+                  variant="compact"
+                  :format-bytes="formatNodeBytes"
+                />
+              </template>
+            </el-table-column>
+            <el-table-column :label="t('protection.sourceResources.colAvailability')" min-width="110" align="center" header-align="center">
+              <template #default="{ row }">
+                <div class="hfl-table-no-tooltip">
+                  <ElTag :type="availabilityTagType(row.availability)" size="small">
+                    {{ availabilityLabel(row.availability) }}
+                  </ElTag>
+                </div>
+              </template>
+            </el-table-column>
+            <el-table-column :label="t('protection.sourceResources.colVersion')" min-width="115">
               <template #default="{ row }">
                 <NodeVersionCell
                   :node="row"
@@ -779,7 +798,7 @@ async function submitRename() {
                 />
               </template>
             </el-table-column>
-            <el-table-column :label="t('protection.sourceResources.colRegistered')" min-width="170">
+            <el-table-column :label="t('protection.sourceResources.colRegistered')" min-width="145">
               <template #default="{ row }">
                 <span class="hfl-table-cell-time">{{ formatNodeDate(row.created_at) }}</span>
               </template>

--- a/src/frontend/src/pages/node/RepairNasRepository.vue
+++ b/src/frontend/src/pages/node/RepairNasRepository.vue
@@ -65,7 +65,7 @@ const initialProxyNodeId = ref<number | null>(null)
 const busyWithBackups = ref(false)
 
 const availableProxyNodes = computed(() =>
-  proxyNodes.value.filter((node) => node.role === 'proxy' && node.status === 'online'),
+  proxyNodes.value.filter((node) => node.role === 'proxy' && node.availability === 'online'),
 )
 const isCurrentlyBound = computed(() => initialProxyNodeId.value != null)
 const hasAssociatedSources = computed(() => associatedSourcesCount.value > 0)

--- a/src/frontend/src/pages/protection/BackupCreateWizard.vue
+++ b/src/frontend/src/pages/protection/BackupCreateWizard.vue
@@ -1990,6 +1990,8 @@ function recoveryPlanConflictIssue(group: WizardSourceGroup) {
 function recoveryPlanIncompleteReason(group: WizardSourceGroup) {
   const plan = recoveryPlanForGroup(group)
   if (!plan.enabled || isRecoveryPlanComplete(group)) return ''
+  const conflictIssue = recoveryPlanConflictIssue(group)
+  if (conflictIssue) return conflictIssue
 
   for (const dirPlan of plan.dirPlans) {
     const dirMissing = recoveryDirPlanMissingFields(group, dirPlan)

--- a/src/frontend/src/pages/protection/BackupSources.vue
+++ b/src/frontend/src/pages/protection/BackupSources.vue
@@ -813,19 +813,6 @@ function sourceNodeOnlineTagType(row: SourceResource): 'success' | 'warning' | '
   return sourceNasStatusPresentation(row, sourceNodeOnlineStatus(row)).tone
 }
 
-function sourceProxyStatusLabel(row: SourceResource) {
-  const status = sourceNodeOnlineStatus(row)
-  const label = status === 'online'
-    ? t('protection.sourceResources.nodeStatusOnline')
-    : status === 'reconnecting'
-      ? t('protection.sourceResources.nodeStatusReconnecting')
-      : t('protection.sourceResources.nodeStatusOffline')
-  return t('protection.sourceResources.proxyStatus', { status: label })
-}
-
-
-
-
 function sourceRegisteredAt(row: SourceResource) {
   const node = boundNodeForRow(row)
   return node?.created_at || row.created_at || row.updated_at || null
@@ -1361,8 +1348,8 @@ function nasBoundNodeId(row: SourceResource): number | undefined {
   return normalizeProxyNodeId(row.bound_node)
 }
 
-const onlineProxyNodes = computed(() => proxyNodes.value.filter((n) => n.status === 'online'))
-const offlineProxyNodeCount = computed(() => proxyNodes.value.filter((n) => n.status !== 'online').length)
+const onlineProxyNodes = computed(() => proxyNodes.value.filter((n) => n.availability === 'online'))
+const offlineProxyNodeCount = computed(() => proxyNodes.value.filter((n) => n.availability !== 'online').length)
 
 function sharedNasBoundNodeId(): number | undefined {
   if (selectedNas.value.length === 0) return undefined
@@ -1478,7 +1465,7 @@ function openNasRebindDialog() {
   if (nasBatchDisabled.value) return
   const shared = sharedNasBoundNodeId()
   const preset = shared != null ? proxyNodes.value.find((n) => n.id === shared) : undefined
-  rebindNodeId.value = preset?.status === 'online' ? shared : undefined
+  rebindNodeId.value = preset?.availability === 'online' ? shared : undefined
   rebindDialogOpen.value = true
 }
 
@@ -1491,7 +1478,7 @@ watch(rebindDialogOpen, (open) => {
       const shared = sharedNasBoundNodeId()
       if (rebindNodeId.value == null && shared != null) {
         const node = proxyNodes.value.find((n) => n.id === shared)
-        if (node?.status === 'online') rebindNodeId.value = shared
+        if (node?.availability === 'online') rebindNodeId.value = shared
       }
     } finally {
       proxyNodesRefreshing.value = false
@@ -1508,7 +1495,7 @@ async function submitNasRebind() {
     return
   }
   const target = proxyNodes.value.find((n) => n.id === nodeId)
-  if (!target || target.status !== 'online') {
+  if (!target || target.availability !== 'online') {
     ElMessage.warning({ message: t('protection.sourceResources.rebindProxyNodeOffline'), grouping: true })
     return
   }
@@ -2248,6 +2235,19 @@ onUnmounted(() => {
                   </button>
                 </template>
               </el-table-column>
+              <el-table-column :label="t('protection.sourceResources.colStatus')" min-width="135" align="center" header-align="center">
+                <template #default="{ row }">
+                  <div class="hfl-table-no-tooltip">
+                    <FlowSourceReadyStatusCell
+                      v-if="resolveSourcePendingStatus(nasSelectableId(row))"
+                      v-bind="resolveSourcePendingStatus(nasSelectableId(row))!"
+                    />
+                    <el-tag v-else :type="sourceNodeOnlineTagType(row)" size="small">
+                      {{ sourceNodeOnlineLabel(row) }}
+                    </el-tag>
+                  </div>
+                </template>
+              </el-table-column>
               <el-table-column :label="t('protection.sourceResources.colProtocol')" width="85">
                 <template #default="{ row }">
                   <span v-if="nasProtocolType(row) !== 'nas'" :class="nasProtocolPillClass(row)">
@@ -2308,23 +2308,6 @@ onUnmounted(() => {
                     {{ t('protection.sourceResources.capacitySyncing') }}
                   </span>
                   <span v-else>—</span>
-                </template>
-              </el-table-column>
-              <el-table-column :label="t('protection.sourceResources.colStatus')" min-width="135" align="center" header-align="center">
-                <template #default="{ row }">
-                  <div class="hfl-table-no-tooltip">
-                    <FlowSourceReadyStatusCell
-                      v-if="resolveSourcePendingStatus(nasSelectableId(row))"
-                      v-bind="resolveSourcePendingStatus(nasSelectableId(row))!"
-                      @click="openSourcePendingFailureDetails(nasSelectableId(row))"
-                    />
-                    <div v-else class="source-nas-status-stack">
-                      <el-tag :type="sourceNodeOnlineTagType(row)" size="small">
-                        {{ sourceNodeOnlineLabel(row) }}
-                      </el-tag>
-                      <span class="source-nas-status-stack__proxy">{{ sourceProxyStatusLabel(row) }}</span>
-                    </div>
-                  </div>
                 </template>
               </el-table-column>
               <el-table-column :label="t('protection.sourceResources.colAvailability')" min-width="110" align="center" header-align="center">
@@ -2727,19 +2710,6 @@ onUnmounted(() => {
 <style src="../../styles/source-deploy-ui.css"></style>
 <style src="../../styles/agent-install-wizard.css"></style>
 <style scoped>
-.source-nas-status-stack {
-  display: inline-flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 3px;
-}
-
-.source-nas-status-stack__proxy {
-  color: var(--el-text-color-secondary);
-  font-size: 11px;
-  line-height: 1.2;
-}
-
 .hfl-table-header-with-tip {
   display: inline-flex;
   align-items: center;

--- a/src/frontend/src/pages/protection/DataProtection.vue
+++ b/src/frontend/src/pages/protection/DataProtection.vue
@@ -818,10 +818,10 @@ const TABLE_HEADER_STYLE: Record<string, string> = {
 
 const FLOW_PICK_TABLE_COL_MIN = {
   source: 168,
-  connection: 260,
-  cpu: 88,
-  memory: 100,
-  diskCount: 96,
+  connection: 118,
+  cpu: 79,
+  memory: 90,
+  diskCount: 87,
 } as const
 
 const FLOW_START_BACKUP_TABLE_COL_MIN = {
@@ -1019,7 +1019,8 @@ function mapBackupSelectableToFlowRow(item: BackupSelectableSource): FlowSourceR
     hostname: item.hostname || item.name,
     nodeName: item.node_name || item.name,
     nodeIp: item.node_ip || '',
-    status: item.status === 'online' ? 'online' : 'offline',
+    status: item.status,
+    availability: item.availability === 'online' ? 'online' : 'offline',
     registeredAt: item.registered_at || '',
     type: item.type,
     protocol: item.protocol === 'smb' ? 'smb' : item.protocol === 'nfs' ? 'nfs' : undefined,
@@ -1516,7 +1517,7 @@ function flowRowFromSourceId(id: string): FlowSourceRow | null {
 function offlineFlowSourcesFromIds(ids: string[]) {
   return ids
     .map((id) => flowRowFromSourceId(id))
-    .filter((row): row is FlowSourceRow => row != null && row.status !== 'online')
+    .filter((row): row is FlowSourceRow => row != null && !flowSourceCanOperate(row))
 }
 
 const step1Selection = ref<string[]>([])
@@ -1771,6 +1772,25 @@ function syncStep2TableSelection() {
 
 function flowSourceRegisteredAt(value?: string) {
   return formatLocalDateTime(value, '—')
+}
+
+function flowSourceAvailabilityLabel(value?: FlowSourceRow['availability']) {
+  return value === 'online'
+    ? t('protection.sourceResources.nodeStatusOnline')
+    : t('protection.sourceResources.nodeStatusOffline')
+}
+
+function flowSourceAvailabilityTagType(value?: FlowSourceRow['availability']): 'success' | 'danger' {
+  return value === 'online' ? 'success' : 'danger'
+}
+
+const FLOW_SOURCE_BLOCKING_STATUSES = new Set([
+  'upgrading', 'restarting', 'verifying', 'verification_pending',
+  'removing', 'cleaning_up', 'probing',
+])
+
+function flowSourceCanOperate(row: FlowSourceRow) {
+  return row.availability === 'online' && !FLOW_SOURCE_BLOCKING_STATUSES.has(row.status)
 }
 
 function onSourceSelectionChange(rows: Array<{ id: string }>) {
@@ -4211,7 +4231,7 @@ async function submitDisplayNameEdit() {
 const step3SourceActionsEnabled = computed(() => {
   if (!step3SourceSelection.value.length) return false
   if (step3SourceSelection.value.some((row) => sourceResetRunning(row.id))) return false
-  return step3SourceSelection.value.some((row) => row.status === 'online')
+  return step3SourceSelection.value.some((row) => flowSourceCanOperate(row))
 })
 const step3LifecycleActionsEnabled = computed(() => {
   if (!step3SourceSelection.value.length) return false
@@ -4475,7 +4495,8 @@ function flowRowToApiNode(row: FlowSourceRow): ApiNode | null {
     name: row.name,
     role: 'agent',
     status: row.status,
-    routable: row.status === 'online',
+    availability: row.availability,
+    routable: row.availability === 'online',
     version: '',
     is_deleted: false,
     ip_address: row.nodeIp || null,
@@ -6446,7 +6467,7 @@ function recoveryOriginalSourceById(id: string) {
 function recoveryOriginalSourceRows(): FlowSourceRow[] {
   const rows = new Map<string, FlowSourceRow>()
   for (const row of backupSelectableById.value.values()) {
-    if (row.status !== 'online') continue
+    if (!flowSourceCanOperate(row)) continue
     if (row.pipeline_step && row.pipeline_step !== 3) continue
     rows.set(row.id, row)
   }
@@ -6470,7 +6491,7 @@ function recoverySourceTargetOption(source: FlowSourceRow, sourceHostId: string)
 
 function recoveryOriginalTargetOptions(sourceHostId: string): RecoveryTargetNodeOption[] {
   const source = backupSelectableById.value.get(sourceHostId) ?? recoveryOriginalSourceById(sourceHostId)
-  if (!source || source.status !== 'online') return []
+  if (!source || !flowSourceCanOperate(source)) return []
   return [recoverySourceTargetOption(source, sourceHostId)]
 }
 
@@ -9320,36 +9341,8 @@ async function runRecovery(mode: 'plan' | 'manual' = 'manual') {
           </template>
         </el-table-column>
         <el-table-column
-          :label="t('protection.sourceResources.colCpu')"
-          :min-width="FLOW_PICK_TABLE_COL_MIN.cpu"
-        >
-          <template #default="{ row }">
-            <span>{{
-              flowSourceCpuCores(row) != null
-                ? t('protection.sourceResources.cpuCoresValue', { n: flowSourceCpuCores(row) })
-                : '—'
-            }}</span>
-          </template>
-        </el-table-column>
-        <el-table-column
-          :label="t('protection.sourceResources.colMemory')"
-          :min-width="FLOW_PICK_TABLE_COL_MIN.memory"
-        >
-          <template #default="{ row }">
-            <span>{{ flowSourceMemoryText(row) }}</span>
-          </template>
-        </el-table-column>
-        <el-table-column
-          :label="t('protection.sourceResources.colDiskCount')"
-          :min-width="FLOW_PICK_TABLE_COL_MIN.diskCount"
-        >
-          <template #default="{ row }">
-            <span>{{ flowSourceDiskCountText(row) }}</span>
-          </template>
-        </el-table-column>
-        <el-table-column
           :label="t('protection.backupsPage.colStatus')"
-          width="108"
+          width="168"
           align="center"
           header-align="center"
         >
@@ -9386,6 +9379,48 @@ async function runRecovery(mode: 'plan' | 'manual' = 'manual') {
               neutral-as-danger
               @click="openSourcePendingFailureDetails(row.id)"
             />
+          </template>
+        </el-table-column>
+        <el-table-column
+          :label="t('protection.sourceResources.colCpu')"
+          :min-width="FLOW_PICK_TABLE_COL_MIN.cpu"
+        >
+          <template #default="{ row }">
+            <span>{{
+              flowSourceCpuCores(row) != null
+                ? t('protection.sourceResources.cpuCoresValue', { n: flowSourceCpuCores(row) })
+                : '—'
+            }}</span>
+          </template>
+        </el-table-column>
+        <el-table-column
+          :label="t('protection.sourceResources.colMemory')"
+          :min-width="FLOW_PICK_TABLE_COL_MIN.memory"
+        >
+          <template #default="{ row }">
+            <span>{{ flowSourceMemoryText(row) }}</span>
+          </template>
+        </el-table-column>
+        <el-table-column
+          :label="t('protection.sourceResources.colDiskCount')"
+          :min-width="FLOW_PICK_TABLE_COL_MIN.diskCount"
+        >
+          <template #default="{ row }">
+            <span>{{ flowSourceDiskCountText(row) }}</span>
+          </template>
+        </el-table-column>
+        <el-table-column
+          :label="t('protection.sourceResources.colAvailability')"
+          width="110"
+          align="center"
+          header-align="center"
+        >
+          <template #default="{ row }">
+            <div class="hfl-table-no-tooltip">
+              <ElTag :type="flowSourceAvailabilityTagType(row.availability)" size="small">
+                {{ flowSourceAvailabilityLabel(row.availability) }}
+              </ElTag>
+            </div>
           </template>
         </el-table-column>
         <el-table-column :label="t('protection.backupsPage.colRegistered')" width="154">
@@ -9487,36 +9522,8 @@ async function runRecovery(mode: 'plan' | 'manual' = 'manual') {
           </template>
         </el-table-column>
         <el-table-column
-          :label="t('protection.sourceResources.colCpu')"
-          :min-width="FLOW_PICK_TABLE_COL_MIN.cpu"
-        >
-          <template #default="{ row }">
-            <span>{{
-              flowSourceCpuCores(row) != null
-                ? t('protection.sourceResources.cpuCoresValue', { n: flowSourceCpuCores(row) })
-                : '—'
-            }}</span>
-          </template>
-        </el-table-column>
-        <el-table-column
-          :label="t('protection.sourceResources.colMemory')"
-          :min-width="FLOW_PICK_TABLE_COL_MIN.memory"
-        >
-          <template #default="{ row }">
-            <span>{{ flowSourceMemoryText(row) }}</span>
-          </template>
-        </el-table-column>
-        <el-table-column
-          :label="t('protection.sourceResources.colDiskCount')"
-          :min-width="FLOW_PICK_TABLE_COL_MIN.diskCount"
-        >
-          <template #default="{ row }">
-            <span>{{ flowSourceDiskCountText(row) }}</span>
-          </template>
-        </el-table-column>
-        <el-table-column
           :label="t('protection.backupsPage.colStatus')"
-          width="108"
+          width="168"
           align="center"
           header-align="center"
         >
@@ -9553,6 +9560,48 @@ async function runRecovery(mode: 'plan' | 'manual' = 'manual') {
               neutral-as-danger
               @click="openSourcePendingFailureDetails(row.id)"
             />
+          </template>
+        </el-table-column>
+        <el-table-column
+          :label="t('protection.sourceResources.colCpu')"
+          :min-width="FLOW_PICK_TABLE_COL_MIN.cpu"
+        >
+          <template #default="{ row }">
+            <span>{{
+              flowSourceCpuCores(row) != null
+                ? t('protection.sourceResources.cpuCoresValue', { n: flowSourceCpuCores(row) })
+                : '—'
+            }}</span>
+          </template>
+        </el-table-column>
+        <el-table-column
+          :label="t('protection.sourceResources.colMemory')"
+          :min-width="FLOW_PICK_TABLE_COL_MIN.memory"
+        >
+          <template #default="{ row }">
+            <span>{{ flowSourceMemoryText(row) }}</span>
+          </template>
+        </el-table-column>
+        <el-table-column
+          :label="t('protection.sourceResources.colDiskCount')"
+          :min-width="FLOW_PICK_TABLE_COL_MIN.diskCount"
+        >
+          <template #default="{ row }">
+            <span>{{ flowSourceDiskCountText(row) }}</span>
+          </template>
+        </el-table-column>
+        <el-table-column
+          :label="t('protection.sourceResources.colAvailability')"
+          width="110"
+          align="center"
+          header-align="center"
+        >
+          <template #default="{ row }">
+            <div class="hfl-table-no-tooltip">
+              <ElTag :type="flowSourceAvailabilityTagType(row.availability)" size="small">
+                {{ flowSourceAvailabilityLabel(row.availability) }}
+              </ElTag>
+            </div>
           </template>
         </el-table-column>
         <el-table-column :label="t('protection.backupsPage.colRegistered')" width="154">
@@ -9658,7 +9707,7 @@ async function runRecovery(mode: 'plan' | 'manual' = 'manual') {
         </el-table-column>
         <el-table-column
           :label="t('protection.backupsPage.colStatus')"
-          width="108"
+          width="168"
           align="center"
           header-align="center"
         >
@@ -9808,6 +9857,20 @@ async function runRecovery(mode: 'plan' | 'manual' = 'manual') {
                 :fallback="latestRestoreRecordForSource(row.id)?.task_summary"
               />
             </button>
+          </template>
+        </el-table-column>
+        <el-table-column
+          :label="t('protection.sourceResources.colAvailability')"
+          width="110"
+          align="center"
+          header-align="center"
+        >
+          <template #default="{ row }">
+            <div class="hfl-table-no-tooltip">
+              <ElTag :type="flowSourceAvailabilityTagType(row.availability)" size="small">
+                {{ flowSourceAvailabilityLabel(row.availability) }}
+              </ElTag>
+            </div>
           </template>
         </el-table-column>
         <el-table-column

--- a/src/frontend/src/pages/protection/DataProtectionAvailabilityColumns.test.ts
+++ b/src/frontend/src/pages/protection/DataProtectionAvailabilityColumns.test.ts
@@ -1,0 +1,70 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const page = readFileSync(resolve(process.cwd(), 'src/pages/protection/DataProtection.vue'), 'utf8')
+
+function tableForStep(step: number) {
+  const startMarker = `<div v-if="flowMainStep === ${step}"`
+  const start = page.indexOf(startMarker)
+  const end = page.indexOf('</el-table>', start)
+  expect(start).toBeGreaterThan(-1)
+  expect(end).toBeGreaterThan(start)
+  return page.slice(start, end)
+}
+
+function expectOrdered(text: string, markers: string[]) {
+  let cursor = -1
+  for (const marker of markers) {
+    const next = text.indexOf(marker, cursor + 1)
+    expect(next, `expected ${marker} after ${markers[Math.max(0, markers.indexOf(marker) - 1)]}`).toBeGreaterThan(cursor)
+    cursor = next
+  }
+}
+
+describe('Backup Wizard availability columns', () => {
+  it.each([0, 1])('places Status after Endpoint and Availability before Registered in step %i', (step) => {
+    expectOrdered(tableForStep(step), [
+      'colConnectionAddress',
+      'colStatus',
+      'colCpu',
+      'colMemory',
+      'colDiskCount',
+      'colAvailability',
+      'colRegistered',
+    ])
+  })
+
+  it('funds the first two wider Status columns from CPU, Memory, and Disks', () => {
+    const connectionWidth = Number(page.match(/connection:\s*(\d+),/)?.[1])
+    const statusWidths = [0, 1].map(step =>
+      Number(tableForStep(step).match(/colStatus'[\s\S]*?width="(\d+)"/)?.[1]),
+    )
+    const pickWidths = page.match(/const FLOW_PICK_TABLE_COL_MIN = \{[\s\S]*?\} as const/)?.[0] ?? ''
+    const cpuWidth = Number(pickWidths.match(/cpu:\s*(\d+),/)?.[1])
+    const memoryWidth = Number(pickWidths.match(/memory:\s*(\d+),/)?.[1])
+    const diskWidth = Number(pickWidths.match(/diskCount:\s*(\d+),/)?.[1])
+
+    expect(connectionWidth).toBe(118)
+    expect(statusWidths).toEqual([168, 168])
+    expect([cpuWidth, memoryWidth, diskWidth]).toEqual([79, 90, 87])
+    expect(cpuWidth + memoryWidth + diskWidth + statusWidths[0]).toBe(424)
+  })
+
+  it('places Availability immediately after Restore Task in step 3', () => {
+    const step3Table = tableForStep(2)
+
+    expectOrdered(step3Table, [
+      'flowBackupColRestoreTaskStatus',
+      'colAvailability',
+      'flowBackupColTargetRepo',
+    ])
+    expect(Number(step3Table.match(/colStatus'[\s\S]*?width="(\d+)"/)?.[1])).toBe(168)
+    expect(page).toContain('const FLOW_START_BACKUP_TABLE_COL_MIN = {\n  connection: 220,\n  backupDirs: 260,\n  compression: 190,\n  targetRepo: 280,\n  binding: 210,\n}')
+  })
+
+  it('maps the API availability field into each wizard row', () => {
+    expect(page).toContain("availability: item.availability === 'online' ? 'online' : 'offline'")
+    expect(page).toContain('flowSourceAvailabilityLabel(row.availability)')
+  })
+})

--- a/src/frontend/src/pages/protection/ProductionSitesAvailability.test.ts
+++ b/src/frontend/src/pages/protection/ProductionSitesAvailability.test.ts
@@ -22,10 +22,13 @@ function declaredTableWidth(text: string): number {
 
 describe('Production Sites availability presentation', () => {
   const list = source('pages/protection/BackupSources.vue')
+  const proxyList = source('pages/node/Nodes.vue')
   const hostStart = list.indexOf(':data="pagedHostAgents"')
   const nasStart = list.indexOf(':data="nasRows"')
+  const proxyStart = proxyList.indexOf('v-table-column-resize="isProxyNodesPage')
   const hostTable = list.slice(hostStart, list.indexOf('</el-table>', hostStart))
   const nasTable = list.slice(nasStart, list.indexOf('</el-table>', nasStart))
+  const proxyTable = proxyList.slice(proxyStart, proxyList.indexOf('<template v-else>', proxyStart))
 
   it('keeps host lifecycle status separate and places availability before version', () => {
     expect(ordered(hostTable, [
@@ -39,10 +42,28 @@ describe('Production Sites availability presentation', () => {
     ])).toBe(true)
   })
 
-  it('places NAS availability immediately before registration', () => {
+  it('places NAS lifecycle status immediately after name and keeps availability before registration', () => {
     expect(ordered(nasTable, [
+      'colName',
       'colStatus',
+      'colProtocol',
       'colAvailability',
+      'colRegistered',
+    ])).toBe(true)
+  })
+
+  it('does not repeat proxy availability in the NAS status column', () => {
+    expect(nasTable).not.toContain('proxyStatus')
+  })
+
+  it('places Proxy Hosts status after name and availability before version', () => {
+    expect(ordered(proxyTable, [
+      'colName',
+      'colStatus',
+      'colHostIp',
+      'colCapacity',
+      'colAvailability',
+      'colVersion',
       'colRegistered',
     ])).toBe(true)
   })

--- a/src/frontend/src/pages/protection/components/NasAddForm.vue
+++ b/src/frontend/src/pages/protection/components/NasAddForm.vue
@@ -55,16 +55,16 @@ const emit = defineEmits<{
 const { t } = useI18n()
 const bindSectionRef = ref<HTMLElement | null>(null)
 
-const onlineProxyNodes = computed(() => props.proxyNodes.filter((n) => n.status === 'online'))
+const onlineProxyNodes = computed(() => props.proxyNodes.filter((n) => n.availability === 'online'))
 
 function proxyNodeStatusLabel(node: ApiNode) {
-  return node.status === 'online'
+  return node.availability === 'online'
     ? t('protection.sourceResources.nodeStatusOnline')
     : t('protection.sourceResources.nodeStatusOffline')
 }
 
 function proxyNodeStatusTagType(node: ApiNode): 'success' | 'danger' | 'warning' | 'info' {
-  if (node.status === 'online') return 'success'
+  if (node.availability === 'online') return 'success'
   if (node.status === 'offline') return 'danger'
   return 'info'
 }

--- a/src/frontend/src/pages/protection/components/NasSourceDetailDrawer.vue
+++ b/src/frontend/src/pages/protection/components/NasSourceDetailDrawer.vue
@@ -119,16 +119,16 @@ const sourceTypeLabel = computed(() => t('protection.sourceResources.addSourceTy
 const connectionUri = computed(() => (row.value ? nasMountSourceUri(row.value) : DETAIL_EMPTY))
 
 const proxyNode = computed(() => boundProxyNode())
-const onlineProxyNodes = computed(() => props.proxyNodes.filter((node) => node.status === 'online'))
+const onlineProxyNodes = computed(() => props.proxyNodes.filter((node) => node.availability === 'online'))
 
 function proxyNodeStatusLabel(node: ApiNode) {
-  return node.status === 'online'
+  return node.availability === 'online'
     ? t('protection.sourceResources.nodeStatusOnline')
     : t('protection.sourceResources.nodeStatusOffline')
 }
 
 function proxyNodeStatusTagType(node: ApiNode): 'success' | 'danger' | 'warning' | 'info' {
-  if (node.status === 'online') return 'success'
+  if (node.availability === 'online') return 'success'
   if (node.status === 'offline') return 'danger'
   return 'info'
 }
@@ -775,7 +775,12 @@ onUnmounted(() => {
                 <div class="hfl-detail-row">
                   <span class="hfl-detail-row__label">{{ t('protection.sourceResources.fieldConnectionStatus') }}</span>
                   <span class="hfl-detail-row__value">
-                    <ElTag v-bind="connectionStatusTagAttrs" size="small">
+                    <ElTag
+                      v-bind="connectionStatusTagAttrs"
+                      size="small"
+                      class="nas-detail-status-tag"
+                      :title="connectionStatusLabel"
+                    >
                       {{ connectionStatusLabel }}
                     </ElTag>
                   </span>
@@ -822,6 +827,22 @@ onUnmounted(() => {
 <style scoped>
 .hfl-detail-row__value--stacked > .hfl-detail-row__text {
   width: 100%;
+}
+
+.nas-detail-status-tag {
+  display: inline-flex;
+  min-width: 0;
+  max-width: 100%;
+  vertical-align: middle;
+  white-space: nowrap;
+}
+
+.nas-detail-status-tag :deep(.el-tag__content) {
+  min-width: 0;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .nas-detail-proxy-option {

--- a/src/frontend/src/pages/protection/composables/useFlowSourceAggregate.ts
+++ b/src/frontend/src/pages/protection/composables/useFlowSourceAggregate.ts
@@ -18,7 +18,8 @@ export type FlowSourceRow = {
   hostname: string
   nodeName: string
   nodeIp: string
-  status: 'online' | 'offline'
+  status: 'active' | 'inactive' | 'error' | 'probing' | 'removing' | 'remove_failed' | 'removed' | 'upgrading' | 'restarting' | 'verifying' | 'verification_pending' | 'cleaning_up' | 'failed' | 'upgrade_failed' | 'deregistration_failed'
+  availability?: 'online' | 'offline'
   registeredAt: string
   type: 'host' | 'nas'
   protocol?: 'nfs' | 'smb'

--- a/src/frontend/src/types/node.ts
+++ b/src/frontend/src/types/node.ts
@@ -1,7 +1,17 @@
 import type { NodeLifecycleInfo, NodeWorkloadInfo } from './nodeLifecycle'
 
 export type NodeRole = 'agent' | 'proxy' | 'gateway'
-export type NodeStatus = 'online' | 'reconnecting' | 'offline'
+export type NodeStatus =
+  | 'active'
+  | 'upgrading'
+  | 'restarting'
+  | 'verifying'
+  | 'verification_pending'
+  | 'removing'
+  | 'cleaning_up'
+  | 'failed'
+  | 'upgrade_failed'
+  | 'deregistration_failed'
 export type Availability = 'online' | 'offline'
 
 export type ApiNode = {


### PR DESCRIPTION
## Problem and root cause

Node lifecycle state and connection availability were both represented by `status`. This caused lifecycle operations to be displayed as Online/Offline, and left Production Sites and Backup Wizard unable to distinguish an operational transition from connectivity.

## Solution

- Split node lifecycle state from Online/Offline availability with schema migrations and operation-specific failure states.
- Project upgrade and deregistration task outcomes into lifecycle status and refresh the Backup Wizard source projection.
- Render Status and Availability independently across Source Hosts, Source NAS, Proxy Hosts, and Backup Wizard tables.
- Keep NAS Status beside Name, place Availability before Version where applicable, and remove the redundant Proxy availability text.
- Correct stale status-field test fixtures and add coverage for the table layout and split-state behavior.

## Validation

- `git diff --check`
- `python3 tools/quality/check-english-source.py`
- `python manage.py makemigrations --check --dry-run`
- Backend targeted tests: 222 passed
- Backend full suite: 1279 passed
- Frontend lint: passed with existing warnings
- Frontend tests: 149 files / 719 tests passed
- Frontend build: passed
- Manual testing: passed

## Risks and compatibility

The migrations convert legacy node and source status values into lifecycle state and availability fields. Consumers must use `availability` for connectivity and `status` for lifecycle operations. Existing API fields remain available with their clarified semantics.

Fixes #366
