### PR TITLE
fix(storage): assert SMB read-only rejection via problem-details errors

### DIFF
--- a/src/backend/apps/storage/tests/test_repository_api.py
+++ b/src/backend/apps/storage/tests/test_repository_api.py
@@ -539,7 +539,14 @@ class StorageRepositoryApiTests(TestCase):
         )
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertIn("config.mount_options", response.data)
+        self.assertIn(
+            {
+                "field": "config.mount_options",
+                "code": "VALIDATION.FIELD_INVALID",
+                "message": "SMB backup repositories cannot use the read-only (ro) mount option.",
+            },
+            response.data["data"]["errors"],
+        )
 
     def test_associated_sources_lists_direct_nas_agent_health(self):
         agent = Node.objects.create(


### PR DESCRIPTION
## Summary
- PREPROD `v0.1.18` Quality failed on `test_create_smb_nas_rejects_read_only_mount_option`.
- The API correctly returns problem-details (`data.errors[].field`), but the test still asserted a flat `response.data["config.mount_options"]` key.
- Align the assertion with the other storage validation tests.

## Test plan
- [ ] PREPROD Quality / backend tests pass after retagging `v0.1.18`

Made with [Cursor](https://cursor.com)