### PR TITLE
fix(protection): show Backup Configuration rows after Reset Backup Config (#362)

### DIFF
--- a/src/frontend/src/pages/protection/DataProtection.vue
+++ b/src/frontend/src/pages/protection/DataProtection.vue
@@ -177,6 +177,10 @@ import BackupSourceStep3DeleteDialog from '../../components/BackupSourceStep3Del
 import DangerConfirmDialog from '../../components/DangerConfirmDialog.vue'
 import ProtectionStopConfirmDialog from '../../components/ProtectionStopConfirmDialog.vue'
 import { BACKUP_SOURCE_RESET_CONFIRMATION } from '../../lib/backupSourceResetDialog'
+import {
+  selectFinishedResetSourceIds,
+  selectTerminalFailedResetSourceIds,
+} from './resetPipelineRefresh'
 import HostAddForm from './components/HostAddForm.vue'
 import NasAddForm from './components/NasAddForm.vue'
 import type {
@@ -443,7 +447,7 @@ function parseEndpointUiId(id: string): { type: 'agent' | 'nas' | 'proxy'; refId
   return { type, refId }
 }
 
-async function refreshBackupConfigs(signal?: AbortSignal) {
+async function refreshBackupConfigs(signal?: AbortSignal): Promise<boolean> {
   try {
     const result = await listBackupConfigs({ page: 1, page_size: 200 }, { signal })
     backupConfigRows.value = result.results
@@ -496,6 +500,7 @@ async function refreshBackupConfigs(signal?: AbortSignal) {
     restoreRecordRows.value = restoreRecords.results
     syncRealBackupConfigsToDemoStore(details, snapshots.results)
     syncRestoreRecordsToFlowTasks(restoreRecords.results, restoreTasks.results)
+    return true
   } catch (e) {
     if (pageRequests.isAbortError(e)) throw e
     ElMessage.error({
@@ -512,6 +517,7 @@ async function refreshBackupConfigs(signal?: AbortSignal) {
     resetTaskRows.value = []
     restoreTaskRows.value = []
     restoreRecordRows.value = []
+    return false
   }
 }
 
@@ -1457,6 +1463,10 @@ function syncWizardCountsFromPipeline() {
   step3SelectableCount.value = pipelineStep3Count.value
 }
 
+function syncStep2WizardCountFromPipeline() {
+  step2SelectableCount.value = pipelineStep2Count.value
+}
+
 async function ensureSelectableCatalog(ids: string[], signal?: AbortSignal) {
   const missing = ids.filter((id) => isBackupSelectableId(id) && !backupSelectableById.value.has(id))
   if (!missing.length) return
@@ -1496,6 +1506,10 @@ async function refreshFlowStepData(
   if (showLoading) setFlowStepDataLoading(step, true)
   try {
     if (step === 1) {
+      // Refresh pipeline ids so stale step-3 caches cannot hide step=2 rows.
+      // Keep loadStep2Selectable's filtered count for the table pager / search.
+      await refreshPipelineStep2PlusIds(signal)
+      if (!pageRequests.isCurrentSignal(scope, signal)) return
       await loadStep2Selectable({ signal })
       return
     }
@@ -1548,9 +1562,13 @@ function sourceHasBackupConfig(sourceId: string) {
   return step3PipelineSourceIds.value.includes(sourceId) || backupConfigSourceIds.value.has(sourceId)
 }
 
-const step2PendingSourceList = computed(() =>
-  step2SourceList.value.filter((row) => !sourceHasBackupConfig(row.id)),
-)
+const step2PendingSourceList = computed(() => {
+  // On the Backup Configuration step the table is backed by step=2 API rows.
+  // Do not hide those rows via stale step-3 pipeline / backup-config caches
+  // (Reset Backup Config moves the source to step 2 before the caches catch up).
+  if (flowMainStep.value === 1) return step2SourceList.value
+  return step2SourceList.value.filter((row) => !sourceHasBackupConfig(row.id))
+})
 
 const step3ConfiguredSourceIds = computed(() =>
   normalizeSourceIdList([
@@ -3929,14 +3947,33 @@ async function refreshStep3SourceList() {
   if (flowMainStep.value !== 2 || step3RefreshInFlight || step3ActionRefreshInFlight) return
   const scope = flowStepScope(2)
   const signal = pageRequests.nextSignal(scope)
-  const hasResetRows = step3SourceList.value.some((row) => Boolean(sourceResetState(row.id)))
+  const resetTrackedIds = collectResetTrackedIds()
   step3RefreshInFlight = true
   try {
     await refreshStep3RuntimeRows(signal)
-    if (hasResetRows) {
-      await refreshBackupConfigs(signal)
-      await loadStep3Selectable({ signal })
-    }
+    if (!resetTrackedIds.length) return
+    const configsLoaded = await refreshBackupConfigs(signal)
+    if (!pageRequests.isCurrentSignal(scope, signal)) return
+    // Soft-failure clears config/task rows; do not treat empty reset state as success.
+    if (!configsLoaded) return
+    await loadStep3Selectable({ signal })
+    if (!pageRequests.isCurrentSignal(scope, signal)) return
+    const finishedIds = selectFinishedResetSourceIds(
+      resetTrackedIds,
+      (id) => sourceResetState(id),
+    )
+    const failedIds = selectTerminalFailedResetSourceIds(
+      resetTrackedIds,
+      (id) => sourceResetState(id),
+    )
+    // Drop terminal failures immediately; keep finished ids tracked until the
+    // pipeline refresh succeeds so an abort/failure can retry next poll.
+    untrackResetPipelineSources(failedIds)
+    if (!finishedIds.length) return
+    await refreshPipelineStep2PlusIds(signal)
+    if (!pageRequests.isCurrentSignal(scope, signal)) return
+    syncStep2WizardCountFromPipeline()
+    untrackResetPipelineSources(finishedIds)
   } catch {
     // Auto-refresh is best-effort; keep the last known runtime state and retry
     // on the next interval without creating an unhandled promise rejection.
@@ -4891,9 +4928,33 @@ const resetBackupFromStep3Submitting = ref(false)
 const resetBackupConfigDialogOpen = ref(false)
 const resetBackupConfigConfirmText = ref('')
 const pendingResetSources = ref<FlowSourceRow[]>([])
+/** Reset source ids queued this session — survives step3 pagination so completion can refresh pipeline. */
+const pendingResetPipelineSourceIds = ref<string[]>([])
 const resetSnapshotCountBySourceId = ref(new Map<string, number>())
 const resetSnapshotCountLoading = ref(false)
 let resetSnapshotCountRequestSeq = 0
+
+function trackResetPipelineSources(ids: string[]) {
+  pendingResetPipelineSourceIds.value = normalizeSourceIdList([
+    ...pendingResetPipelineSourceIds.value,
+    ...ids,
+  ])
+}
+
+function untrackResetPipelineSources(ids: string[]) {
+  if (!ids.length) return
+  const done = new Set(ids)
+  pendingResetPipelineSourceIds.value = pendingResetPipelineSourceIds.value.filter((id) => !done.has(id))
+}
+
+function collectResetTrackedIds() {
+  return normalizeSourceIdList([
+    ...pendingResetPipelineSourceIds.value,
+    ...step3SourceList.value
+      .filter((row) => Boolean(sourceResetState(row.id)))
+      .map((row) => row.id),
+  ])
+}
 
 const resetBackupConfigDisplayRows = computed(() =>
   pendingResetSources.value.map((row) =>
@@ -4976,6 +5037,7 @@ async function confirmResetBackupConfiguration() {
   try {
     const sourceIdList = sources.map((source) => source.id).filter(isBackupSelectableId)
     const result = await resetBackupConfigs(sourceIdList, BACKUP_SOURCE_RESET_CONFIRMATION)
+    trackResetPipelineSources(sourceIdList)
 
     if (activeFlowSource.value && sourceIds.has(activeFlowSource.value.id)) {
       flowSourceDetailOpen.value = false

--- a/src/frontend/src/pages/protection/DataProtectionResetBackupConfigList.test.ts
+++ b/src/frontend/src/pages/protection/DataProtectionResetBackupConfigList.test.ts
@@ -1,0 +1,67 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const page = readFileSync(resolve(process.cwd(), 'src/pages/protection/DataProtection.vue'), 'utf8')
+
+function sourceBetween(startMarker: string, endMarker: string) {
+  const start = page.indexOf(startMarker)
+  const end = page.indexOf(endMarker, start + 1)
+  expect(start).toBeGreaterThan(-1)
+  expect(end).toBeGreaterThan(start)
+  return page.slice(start, end)
+}
+
+describe('backup wizard reset → Backup Configuration list (#362)', () => {
+  it('shows step=2 API rows on Backup Configuration without filtering by stale step-3 caches', () => {
+    const pendingList = sourceBetween(
+      'const step2PendingSourceList = computed(() => {',
+      'const step3ConfiguredSourceIds = computed(() =>',
+    )
+    expect(pendingList).toContain('if (flowMainStep.value === 1) return step2SourceList.value')
+    expect(pendingList).toContain('sourceHasBackupConfig(row.id)')
+  })
+
+  it('refreshes pipeline ids when loading Backup Configuration without overwriting filtered pager totals', () => {
+    const refreshFlow = sourceBetween(
+      'async function refreshFlowStepData(',
+      'function flowRowFromSourceId(id: string)',
+    )
+    expect(refreshFlow).toContain('if (step === 1) {')
+    expect(refreshFlow).toContain('await refreshPipelineStep2PlusIds(signal)')
+    expect(refreshFlow).toContain('await loadStep2Selectable({ signal })')
+    expect(refreshFlow).not.toContain('syncWizardCountsFromPipeline()')
+    expect(refreshFlow).not.toContain('syncStep2WizardCountFromPipeline()')
+  })
+
+  it('tracks queued reset source ids across step3 pages and refreshes pipeline only when finished', () => {
+    expect(page).toContain('const pendingResetPipelineSourceIds = ref<string[]>([])')
+    expect(page).toContain('trackResetPipelineSources(sourceIdList)')
+
+    const refreshStep3 = sourceBetween(
+      'async function refreshStep3SourceList()',
+      'function syncStep3AutoRefresh()',
+    )
+    expect(refreshStep3).toContain('const resetTrackedIds = collectResetTrackedIds()')
+    expect(refreshStep3).toContain('const configsLoaded = await refreshBackupConfigs(signal)')
+    expect(refreshStep3).toContain('if (!configsLoaded) return')
+    expect(refreshStep3).toContain('selectFinishedResetSourceIds(')
+    expect(refreshStep3).toContain('selectTerminalFailedResetSourceIds(')
+    expect(refreshStep3).toContain('untrackResetPipelineSources(failedIds)')
+    expect(refreshStep3).toContain('if (!finishedIds.length) return')
+    expect(refreshStep3).toContain('await refreshPipelineStep2PlusIds(signal)')
+    expect(refreshStep3).toContain('syncStep2WizardCountFromPipeline()')
+    expect(refreshStep3).toContain('untrackResetPipelineSources(finishedIds)')
+    expect(refreshStep3).not.toContain('syncWizardCountsFromPipeline()')
+    expect(refreshStep3).not.toContain('step3Ids')
+  })
+
+  it('returns false from refreshBackupConfigs soft-failure so reset completion is not inferred', () => {
+    const refreshConfigs = sourceBetween(
+      'async function refreshBackupConfigs(signal?: AbortSignal): Promise<boolean> {',
+      'function displayNameForSource(type: string, refId: number, fallback: string)',
+    )
+    expect(refreshConfigs).toContain('return true')
+    expect(refreshConfigs).toContain('return false')
+  })
+})

--- a/src/frontend/src/pages/protection/resetPipelineRefresh.test.ts
+++ b/src/frontend/src/pages/protection/resetPipelineRefresh.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import {
+  selectFinishedResetSourceIds,
+  selectTerminalFailedResetSourceIds,
+} from './resetPipelineRefresh'
+
+describe('resetPipelineRefresh', () => {
+  it('treats cleared reset state as finished regardless of step-3 page membership', () => {
+    expect(
+      selectFinishedResetSourceIds(
+        ['nas:1', 'nas:2'],
+        (id) => (id === 'nas:2' ? 'resetting' : ''),
+      ),
+    ).toEqual(['nas:1'])
+  })
+
+  it('does not treat off-page resetting sources as finished', () => {
+    expect(
+      selectFinishedResetSourceIds(
+        ['nas:1'],
+        () => 'resetting',
+      ),
+    ).toEqual([])
+  })
+
+  it('does not treat reset_failed as finished for pipeline refresh', () => {
+    expect(
+      selectFinishedResetSourceIds(
+        ['nas:1'],
+        () => 'reset_failed',
+      ),
+    ).toEqual([])
+  })
+
+  it('identifies terminal reset_failed sources for tracking cleanup', () => {
+    expect(
+      selectTerminalFailedResetSourceIds(
+        ['nas:1', 'nas:2'],
+        (id) => (id === 'nas:1' ? 'reset_failed' : 'resetting'),
+      ),
+    ).toEqual(['nas:1'])
+  })
+})

--- a/src/frontend/src/pages/protection/resetPipelineRefresh.ts
+++ b/src/frontend/src/pages/protection/resetPipelineRefresh.ts
@@ -1,0 +1,17 @@
+/** Source ids whose Reset Backup Config finished successfully (no active/failed reset state). */
+export function selectFinishedResetSourceIds(
+  trackedIds: string[],
+  resetStateOf: (id: string) => string,
+): string[] {
+  // Use global reset state only — never infer completion from the current step-3
+  // page/filter membership (a still-resetting source can be off the current page).
+  return trackedIds.filter((id) => !resetStateOf(id))
+}
+
+/** Terminal failed resets should stop pipeline tracking without a step-2 refresh. */
+export function selectTerminalFailedResetSourceIds(
+  trackedIds: string[],
+  resetStateOf: (id: string) => string,
+): string[] {
+  return trackedIds.filter((id) => resetStateOf(id) === 'reset_failed')
+}


### PR DESCRIPTION
## Summary
- Fixes #362: after **Reset Backup Config**, Backup Wizard step **02 Backup Configuration** no longer shows an empty list while Pending setup count updates.
- On the Backup Configuration step, render `step=2` API rows directly instead of hiding them with stale step-3 pipeline / backup-config caches.
- Track reset source ids for the session; when reset finishes, refresh pipeline step-2 ids and sync the wizard step-2 count (skip soft-fail config refresh so cleared rows are not treated as success).

## Test plan
- [ ] Reset Backup Config on a configured source; without hard refresh, open step 02 and confirm the source appears under Pending setup with a matching count.
- [ ] While reset is in progress, confirm step 03 still shows resetting status; after success, Pending setup count/list stay consistent across step switches.
- [ ] Soft-fail path: if backup-config refresh fails mid-poll, do not mark the reset finished or drop pipeline tracking.
- [ ] `cd src/frontend && npm test -- --run src/pages/protection/resetPipelineRefresh.test.ts src/pages/protection/DataProtectionResetBackupConfigList.test.ts`


Made with [Cursor](https://cursor.com)