### PR TITLE
fix(frontend): use spinning loader icon for running backup task step status (#194)

### DIFF
--- a/src/frontend/src/pages/protection/components/FlowBackupSourceDetailDrawer.vue
+++ b/src/frontend/src/pages/protection/components/FlowBackupSourceDetailDrawer.vue
@@ -20,6 +20,7 @@ import {
   FolderOpen,
   Globe,
   Link2,
+  LoaderCircle,
   RefreshCw,
   RotateCcw,
   Scale,
@@ -3970,7 +3971,7 @@ function onClosed() {
             <div class="dp-task-detail__step-anchor" :class="timelineIconClass(step.status)">
               <Check v-if="step.status === 'success'" :size="15" />
               <X v-else-if="step.status === 'failed' || step.status === 'timeout'" :size="15" />
-              <Clock3 v-else-if="step.status === 'running'" :size="15" />
+              <LoaderCircle v-else-if="step.status === 'running'" :size="15" />
               <Circle v-else :size="9" />
             </div>
 
@@ -5757,6 +5758,18 @@ function onClosed() {
   border-color: var(--color-info);
   background-color: var(--color-info);
   color: #fff;
+}
+
+.dp-task-detail__timeline-icon--running > svg {
+  animation: dp-task-step-spin 0.8s linear infinite;
+  transform-origin: center center;
+  will-change: transform;
+}
+
+@keyframes dp-task-step-spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 .dp-task-detail__timeline-icon--muted {

--- a/src/frontend/src/pages/protection/components/TaskDetailDrawer.vue
+++ b/src/frontend/src/pages/protection/components/TaskDetailDrawer.vue
@@ -12,6 +12,7 @@ import {
   Copy,
   Globe,
   Link2,
+  LoaderCircle,
   RefreshCw,
   RotateCcw,
   X,
@@ -806,7 +807,7 @@ watch(
             <div class="hfl-task-drawer__step-anchor" :class="timelineIconClass(step.status)">
               <Check v-if="step.status === 'success'" :size="15" />
               <X v-else-if="step.status === 'failed' || step.status === 'timeout'" :size="15" />
-              <Clock3 v-else-if="step.status === 'running'" :size="15" />
+              <LoaderCircle v-else-if="step.status === 'running'" :size="15" />
               <Circle v-else :size="9" />
             </div>
             <article class="hfl-task-drawer__step-card">
@@ -1613,6 +1614,18 @@ watch(
   border-color: var(--color-info);
   background-color: var(--color-info);
   color: #fff;
+}
+
+.hfl-task-drawer__timeline-icon--running > svg {
+  animation: hfl-task-step-spin 0.8s linear infinite;
+  transform-origin: center center;
+  will-change: transform;
+}
+
+@keyframes hfl-task-step-spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 .hfl-task-drawer__timeline-icon--muted {


### PR DESCRIPTION
## Summary

Replace static `Clock3` icon with animated `LoaderCircle` for step timeline entries whose status is `running`, so the icon visually matches the Running status label.

## Changes

- **TaskDetailDrawer.vue**: Added `LoaderCircle` import, replaced `<Clock3>` with `<LoaderCircle>` for running steps, added CSS spin animation targeting only the SVG child
- **FlowBackupSourceDetailDrawer.vue**: Same changes

## Before

Static clock icon with Running text — visual mismatch.

## After

Spinning `LoaderCircle` icon rotates smoothly inside the anchor circle, matching the Running status.

Closes #194