### PR TITLE
fix(frontend): prevent tag text vertical clipping from inherited line-height: 1 (#379)

### DIFF
--- a/src/frontend/src/components/TaskStatusTag.vue
+++ b/src/frontend/src/components/TaskStatusTag.vue
@@ -41,6 +41,7 @@ const label = computed(() => {
 
 .hfl-task-status-tag :deep(.el-tag__content) {
   min-width: 0;
+  line-height: 16px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;


### PR DESCRIPTION
## Summary

Add `line-height: 16px` to the `.el-tag__content` scoped rule in `TaskStatusTag.vue` to prevent text from being vertically clipped.

## Root Cause

Element Plus sets `line-height: 1` on `.el-tag` by default. At `font-size: 12px`, the line box is only 12px tall. The `TaskStatusTag` scoped style sets `overflow: hidden` on `.el-tag__content` for text truncation, but without overriding `line-height`, the inherited value of `1` (12px) is too tight — CJK glyphs and Latin descenders extend beyond the line box and get clipped.

## Fix

Add `line-height: 16px` to match the existing override already present in `list-page-ui.css` L206-214, which prevents this same issue in table-cell contexts.

## Affected File

- `src/frontend/src/components/TaskStatusTag.vue`

Closes: #379

🤖 Generated with [Claude Code](https://claude.com/claude-code)