### PR TITLE
fix(frontend): guard against null scheduleStartsAt in policyFormToWritePayload and tighten TypeError network classification

### DIFF
--- a/src/frontend/src/lib/errors/normalizer.ts
+++ b/src/frontend/src/lib/errors/normalizer.ts
@@ -101,7 +101,7 @@ export function normalizeThrownError(err: unknown): AppErrorShape {
     return networkUnavailableError()
   }
 
-  if (err instanceof TypeError || (err instanceof Error && isBrowserNetworkMessage(err.message))) {
+  if ((err instanceof TypeError && isBrowserNetworkMessage(err.message)) || (err instanceof Error && isBrowserNetworkMessage(err.message))) {
     return networkUnavailableError()
   }
 

--- a/src/frontend/src/lib/protectionPolicyFormModel.ts
+++ b/src/frontend/src/lib/protectionPolicyFormModel.ts
@@ -1143,7 +1143,7 @@ export function policyFormToWritePayload(policyForm: BackupPolicyForm): BackupPo
   const scheduleBase = {
     enabled: policyForm.sectionScheduleEnabled,
     timezone: policyForm.scheduleTimezone.trim() || 'UTC',
-    starts_at: policyForm.scheduleStartsAt.trim() || null,
+    starts_at: (policyForm.scheduleStartsAt || '').trim() || null,
   }
   let schedule: BackupPolicySchedule
   if (policyForm.freqMode === 'advanced') {


### PR DESCRIPTION
## Summary

Fixes the bug where clearing the Start Time field in the backup policy form and clicking Save shows a misleading "Unable to connect. Check your network and try again." error.

## Root Cause

When the user clears the ElDatePicker, the v-model value becomes `null`. The `policyFormToWritePayload` function unconditionally calls `.trim()` on `scheduleStartsAt`, which throws a TypeError. The error normalizer then maps all TypeErrors to `NETWORK_UNAVAILABLE`, showing the misleading network error message.

## Changes

1. `src/frontend/src/lib/protectionPolicyFormModel.ts`: Guard against null before calling `.trim()` — `(policyForm.scheduleStartsAt || '').trim()` instead of `policyForm.scheduleStartsAt.trim()`

2. `src/frontend/src/lib/errors/normalizer.ts`: Tighten TypeError classification — only treat TypeErrors whose message matches known browser network patterns as network errors, instead of treating all TypeErrors as network errors

Closes #383