### PR TITLE
fix(protection): mask NAS passwords and keep website redirects relative

### DIFF
--- a/deploy/nginx/web.conf
+++ b/deploy/nginx/web.conf
@@ -41,6 +41,9 @@ server {
 server {
     listen 8082;
     server_name _;
+    # Keep redirects relative so the public gateway (:11442) is not rewritten to
+    # this internal listen port (which is never published on the host).
+    absolute_redirect off;
     root /usr/share/nginx/website;
     index index.html;
 

--- a/src/frontend/src/lib/sourceNasDisplay.test.ts
+++ b/src/frontend/src/lib/sourceNasDisplay.test.ts
@@ -9,7 +9,9 @@ import {
   nasProxyMountPoint,
   nasServerAddress,
   nasShareOrExport,
+  SOURCE_PASSWORD_MASK,
   sourceNasStatusPresentation,
+  sourcePasswordDisplay,
 } from './sourceNasDisplay'
 
 describe('nasMountSourceUri', () => {
@@ -188,5 +190,31 @@ describe('sourceNasStatusPresentation', () => {
       labelKey: 'protection.sourceResources.nodeStatusReconnecting',
       tone: 'info',
     })
+  })
+})
+
+describe('sourcePasswordDisplay', () => {
+  it('masks when API returns has_password without the secret (#354)', () => {
+    expect(
+      sourcePasswordDisplay({
+        username: 'backup',
+        has_password: true,
+        has_secret_key: false,
+      }),
+    ).toBe(SOURCE_PASSWORD_MASK)
+  })
+
+  it('shows empty when no password is stored', () => {
+    expect(
+      sourcePasswordDisplay({
+        username: 'backup',
+        has_password: false,
+        has_secret_key: false,
+      }),
+    ).toBe('—')
+  })
+
+  it('still masks if a plaintext password is present (legacy)', () => {
+    expect(sourcePasswordDisplay({ password: 'secret' })).toBe(SOURCE_PASSWORD_MASK)
   })
 })

--- a/src/frontend/src/lib/sourceNasDisplay.ts
+++ b/src/frontend/src/lib/sourceNasDisplay.ts
@@ -213,6 +213,24 @@ export function nasProxyMountPoint(row: NasLikeResource): string {
   return mountPoint || '—'
 }
 
+/** Mask shown when a NAS source has a stored password (API never returns the secret). */
+export const SOURCE_PASSWORD_MASK = '••••••••'
+
+export function sourceHasPassword(credentials?: Record<string, unknown> | null): boolean {
+  if (!credentials || typeof credentials !== 'object') return false
+  // Public credential hint from source_credential_hint(); password itself is never serialized.
+  if (credentials.has_password === true) return true
+  const password = credentials.password
+  return typeof password === 'string' && Boolean(password.trim())
+}
+
+export function sourcePasswordDisplay(
+  credentials?: Record<string, unknown> | null,
+  emptyLabel = '—',
+): string {
+  return sourceHasPassword(credentials) ? SOURCE_PASSWORD_MASK : emptyLabel
+}
+
 export function sourceExternalId(row: { id: number; resource_type?: string }): string {
   const type = (row.resource_type || 'nas').toLowerCase()
   const prefix = type === 'local' ? 'AGT' : 'NAS'

--- a/src/frontend/src/pages/protection/components/NasSourceDetailDrawer.vue
+++ b/src/frontend/src/pages/protection/components/NasSourceDetailDrawer.vue
@@ -12,6 +12,7 @@ import {
   nasProxyMountPoint,
   sourceNasStatusPresentation,
   sourceExternalId,
+  sourcePasswordDisplay,
 } from '../../../lib/sourceNasDisplay'
 import { formatAppTime } from '../../../lib/dateTime'
 import {
@@ -298,7 +299,7 @@ const hasDetailChanges = computed(() => {
 })
 
 function passwordDisplay() {
-  return cred('password') ? '••••••••' : DETAIL_EMPTY
+  return sourcePasswordDisplay(row.value?.credentials, DETAIL_EMPTY)
 }
 
 async function saveDetailChanges() {

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -1320,6 +1320,9 @@ if grep -F -- '--network host' "${smoke_runner}" >/dev/null; then
 fi
 grep -F 'image: hyperfilelens-postgres:17' "${ROOT}/deploy/docker-compose.yml" >/dev/null
 grep -F 'absolute_redirect off;' "${ROOT}/deploy/nginx/default.conf" >/dev/null
+# Website pool (:8082) must keep / → /en/ relative; absolute redirects leak the
+# unpublished internal listen port through the public :11442 gateway.
+grep -F 'absolute_redirect off;' "${ROOT}/deploy/nginx/web.conf" >/dev/null
 grep -F 'map $server_port $hfl_site {' \
 	"${ROOT}/deploy/nginx/snippets/hfl-log-format.conf" >/dev/null
 grep -E '^[[:space:]]*11442[[:space:]]+website;' \


### PR DESCRIPTION
## Summary
- Mask NAS source passwords using the API `has_password` hint instead of looking for a never-serialized plaintext `password` (#354).
- Keep the internal website pool (`:8082`) redirects relative so public `:11442` does not leak an unpublished host port.
- Add unit coverage and a release-contract check for `absolute_redirect off` on `web.conf`.

## Test plan
- [x] `sourceNasDisplay.test.ts` (13 passed)
- [x] Local `127.0.0.1`: NAS detail drawer shows `••••••••` when `has_password` is true
- [x] Local `https://127.0.0.1:11442/` redirects with relative `Location: /en/`
- [ ] After release deploy: `https://192.168.10.244:11442/` roots to `/en/` on the same host/port (not `:8082`)


Made with [Cursor](https://cursor.com)