### PR TITLE
fix(protection): exclude deleting and delete-failed snapshots from snapshot list (#115)

### DIFF
--- a/src/backend/apps/protection/selectors/backup_source_snapshot.py
+++ b/src/backend/apps/protection/selectors/backup_source_snapshot.py
@@ -34,7 +34,11 @@ def backup_source_snapshots_queryset(
     queryset = BackupSourceSnapshot.objects.filter(organization_id=organization_id)
     if not include_deleted:
         queryset = queryset.filter(deleted_at__isnull=True).exclude(
-            status=BackupSourceSnapshot.Status.DELETED
+            status__in=[
+                BackupSourceSnapshot.Status.DELETING,
+                BackupSourceSnapshot.Status.DELETE_FAILED,
+                BackupSourceSnapshot.Status.DELETED,
+            ]
         )
     return queryset.prefetch_related("directories")
 


### PR DESCRIPTION
## Summary

The snapshot list API was excluding only `DELETED` snapshots by default, while the retention policy only considers `AVAILABLE` and `PARTIAL` snapshots. When retention created delete tasks, snapshots transitioned to `DELETING` status and remained visible in the list, causing the snapshot inventory to appear out of sync with the configured retention policy.

## Root Cause

- **Retention policy query** (`policy_execution.py`): filters `status__in=[AVAILABLE, PARTIAL]`
- **Snapshot list API** (`backup_source_snapshot.py`): only excluded `DELETED`, leaving `DELETING` and `DELETE_FAILED` visible

## Fix

Exclude `DELETING` and `DELETE_FAILED` statuses alongside `DELETED` in `backup_source_snapshots_queryset` so the list reflects only usable snapshots.

## Impact

- Snapshot list API no longer returns snapshots in `DELETING` or `DELETE_FAILED` status
- Snapshot detail API returns 404 for snapshots in those statuses
- `include_deleted=True` continues to return all statuses
- Deletion-related code uses direct queries and is unaffected

Closes #115