### PR TITLE
fix(frontend): resolve task detail owner from immutable payload for source_unregister tasks (#235)

### DIFF
--- a/src/frontend/src/lib/taskBackupSourceResource.ts
+++ b/src/frontend/src/lib/taskBackupSourceResource.ts
@@ -1,6 +1,6 @@
 import { getNode } from './nodeApi'
 import { getSourceResource } from './sourceApi'
-import type { TaskResourceRow } from './taskApi'
+import type { TaskResourceRow, TaskRow } from './taskApi'
 import type { FlowSourceRow } from '../pages/protection/composables/useFlowSourceAggregate'
 
 export type TaskBackupSourceResourceDisplay = {
@@ -14,6 +14,122 @@ export type TaskBackupSourceResourceDisplay = {
 }
 
 const EMPTY = '—'
+
+function payloadRecord(task: TaskRow): Record<string, unknown> {
+  return task.request_payload && typeof task.request_payload === 'object'
+    ? task.request_payload as Record<string, unknown>
+    : {}
+}
+
+function resultRecord(task: TaskRow): Record<string, unknown> {
+  return task.result_payload && typeof task.result_payload === 'object'
+    ? task.result_payload as Record<string, unknown>
+    : {}
+}
+
+/**
+ * Resolve backup source display info purely from task payload data,
+ * without any live API calls. Returns null when no historical data is available.
+ */
+export function resolveTaskBackupSourceResourceFromPayload(
+  resource: TaskResourceRow,
+  task: TaskRow,
+): TaskBackupSourceResourceDisplay | null {
+  const request = payloadRecord(task)
+  const result = resultRecord(task)
+
+  // 1. request_payload.cleanup_plan.source
+  const cleanupPlan = request.cleanup_plan && typeof request.cleanup_plan === 'object'
+    ? request.cleanup_plan as Record<string, unknown>
+    : null
+  const cleanupSource = cleanupPlan?.source && typeof cleanupPlan.source === 'object'
+    ? cleanupPlan.source as Record<string, unknown>
+    : null
+  if (cleanupSource?.name) {
+    const sourceName = String(cleanupSource.name)
+    const sourceKind = String(cleanupSource.kind || resource.resource_subtype || '')
+    const flowSource: FlowSourceRow = {
+      id: `${sourceKind === 'agent' ? 'agent' : 'nas'}:${resource.resource_id}`,
+      refId: resource.resource_id,
+      name: sourceName,
+      hostname: sourceName,
+      nodeName: sourceName,
+      nodeIp: '',
+      status: 'offline',
+      registeredAt: String(cleanupSource.registered_at || ''),
+      type: sourceKind === 'agent' ? 'host' : 'nas',
+    }
+    return {
+      backupSource: sourceName,
+      endpointName: sourceName,
+      endpointIp: '',
+      registeredAt: String(cleanupSource.registered_at || ''),
+      status: 'unregistered',
+      statusValue: 'unregistered',
+      flowSource,
+    }
+  }
+
+  // 2. request_payload.source_orphan_display_name
+  const orphanName = typeof request.source_orphan_display_name === 'string'
+    ? request.source_orphan_display_name.trim()
+    : ''
+  if (orphanName) {
+    const sourceKind = resource.resource_subtype || 'agent'
+    const flowSource: FlowSourceRow = {
+      id: `${sourceKind === 'agent' ? 'agent' : 'nas'}:${resource.resource_id}`,
+      refId: resource.resource_id,
+      name: orphanName,
+      hostname: orphanName,
+      nodeName: orphanName,
+      nodeIp: '',
+      status: 'offline',
+      registeredAt: '',
+      type: sourceKind === 'agent' ? 'host' : 'nas',
+    }
+    return {
+      backupSource: orphanName,
+      endpointName: orphanName,
+      endpointIp: '',
+      registeredAt: '',
+      status: 'unregistered',
+      statusValue: 'unregistered',
+      flowSource,
+    }
+  }
+
+  // 3. result_payload.sources[].source_name
+  const sources = Array.isArray(result.sources) ? result.sources : []
+  const matchedSource = sources.find(
+    (s: unknown) => s && typeof s === 'object' && (s as Record<string, unknown>).source_name,
+  ) as Record<string, unknown> | undefined
+  if (matchedSource?.source_name) {
+    const sourceName = String(matchedSource.source_name)
+    const sourceKind = resource.resource_subtype || 'agent'
+    const flowSource: FlowSourceRow = {
+      id: `${sourceKind === 'agent' ? 'agent' : 'nas'}:${resource.resource_id}`,
+      refId: resource.resource_id,
+      name: sourceName,
+      hostname: sourceName,
+      nodeName: sourceName,
+      nodeIp: '',
+      status: 'offline',
+      registeredAt: '',
+      type: sourceKind === 'agent' ? 'host' : 'nas',
+    }
+    return {
+      backupSource: sourceName,
+      endpointName: sourceName,
+      endpointIp: '',
+      registeredAt: '',
+      status: 'unregistered',
+      statusValue: 'unregistered',
+      flowSource,
+    }
+  }
+
+  return null
+}
 
 export async function resolveTaskBackupSourceResource(
   resource: TaskResourceRow,

--- a/src/frontend/src/lib/taskOutcomeDisplay.ts
+++ b/src/frontend/src/lib/taskOutcomeDisplay.ts
@@ -142,6 +142,31 @@ export function taskResourceSnapshot(task: TaskRow | null | undefined, resource:
         config: source.config,
       }
     }
+    // Fallback: source_orphan_display_name (available on source_unregister tasks)
+    const orphanName = typeof request.source_orphan_display_name === 'string'
+      ? request.source_orphan_display_name.trim()
+      : ''
+    if (orphanName) {
+      return {
+        id: resource.resource_id,
+        name: orphanName,
+        resource_type: resource.resource_subtype || 'agent',
+        created_at: '',
+      }
+    }
+    // Fallback: result_payload.sources[].source_name
+    const sources = Array.isArray(result.sources) ? result.sources : []
+    const matchedSource = sources.find(
+      (s: unknown) => s && typeof s === 'object' && (s as JsonRecord).source_name,
+    ) as JsonRecord | undefined
+    if (matchedSource?.source_name) {
+      return {
+        id: resource.resource_id,
+        name: String(matchedSource.source_name),
+        resource_type: resource.resource_subtype || 'agent',
+        created_at: '',
+      }
+    }
   }
   if (resource.resource_type === 'repository' || resource.resource_type === 'target_repository') {
     const repository = record(record(request.cleanup_plan).repository)

--- a/src/frontend/src/pages/ops/Tasks.vue
+++ b/src/frontend/src/pages/ops/Tasks.vue
@@ -44,7 +44,7 @@ import {
 import {
   canCancelRepositoryTask,
 } from '../../lib/repositoryTaskCancellation'
-import { resolveTaskBackupSourceResource } from '../../lib/taskBackupSourceResource'
+import { resolveTaskBackupSourceResource, resolveTaskBackupSourceResourceFromPayload } from '../../lib/taskBackupSourceResource'
 import { parseTaskStepStatusEvent, taskEventMessageKey, taskEventObjectText } from '../../lib/taskEventDisplay'
 import { hasExpandableTaskStep, hasExpandedTaskStep } from '../../lib/taskStepExpansion'
 import {
@@ -596,6 +596,15 @@ async function loadTaskOwner(task: TaskRow, signal?: AbortSignal) {
     taskOwner.value = t('ops.task.emptyMark')
     return
   }
+  // For source_unregister tasks, resolve the owner from immutable task payload
+  // data first, since the live resource has already been removed.
+  if (task.task_type === 'source_unregister' && resource.resource_type === 'backup_source') {
+    const fromPayload = resolveTaskBackupSourceResourceFromPayload(resource, task)
+    if (activeTask.value?.task_uuid === task.task_uuid) {
+      taskOwner.value = fromPayload?.backupSource || t('ops.task.emptyMark')
+    }
+    return
+  }
   try {
     const detail = await fetchResourceDetail(resource, signal)
     if (activeTask.value?.task_uuid === task.task_uuid) {
@@ -622,6 +631,14 @@ async function loadResourceType(type: string) {
   try {
     const results = await Promise.allSettled(resources.map(async (resource) => {
       try {
+        // For source_unregister tasks with backup_source resources,
+        // resolve from immutable task payload data first to avoid 404s.
+        if (activeTask.value?.task_type === 'source_unregister' && resource.resource_type === 'backup_source') {
+          const fromPayload = resolveTaskBackupSourceResourceFromPayload(resource, activeTask.value)
+          if (fromPayload) {
+            return normalizeResourceDetail(resource.resource_type, resource.resource_id, {}, fromPayload)
+          }
+        }
         const raw = await fetchResourceDetail(resource, signal)
         const source = resource.resource_type === 'backup_source'
           ? await resolveTaskBackupSourceResource(resource, resourceSubtype(resource), signal)

--- a/src/frontend/src/pages/protection/components/FlowBackupSourceDetailDrawer.vue
+++ b/src/frontend/src/pages/protection/components/FlowBackupSourceDetailDrawer.vue
@@ -110,9 +110,10 @@ import { getTask, listTaskEvents, listTasks } from '../../../lib/taskApi'
 import type { RestoreEndpointType, RestoreRecord, RestoreRecordItem } from '../../../lib/restoreApi'
 import { listRestoreRecords, fetchRestoreRecordRuntime } from '../../../lib/restoreApi'
 import { formatLocalDateTime } from '../../../lib/dateTime'
-import { resolveTaskBackupSourceResource } from '../../../lib/taskBackupSourceResource'
+import { resolveTaskBackupSourceResource, resolveTaskBackupSourceResourceFromPayload } from '../../../lib/taskBackupSourceResource'
 import { parseTaskStepStatusEvent, taskEventMessageKey, taskEventObjectText } from '../../../lib/taskEventDisplay'
 import { hasExpandableTaskStep, hasExpandedTaskStep } from '../../../lib/taskStepExpansion'
+import { taskResourceSnapshot } from '../../../lib/taskOutcomeDisplay'
 import {
   useFlowSourceAggregate,
   type DemoFlowTask,
@@ -1152,14 +1153,45 @@ async function loadResourceType(type: string) {
   resourceLoading.value = true
   delete resourceErrors[type]
   try {
-    const rows = await Promise.all(resources.map(async (resource) => {
-      const raw = await fetchResourceDetail(resource, signal)
-      const source = resource.resource_type === 'backup_source'
-        ? await resolveTaskBackupSourceResource(resource, taskResourceSubtype(resource), signal)
-        : undefined
-      return normalizeResourceDetail(resource.resource_type, resource.resource_id, raw, source)
+    const results = await Promise.allSettled(resources.map(async (resource) => {
+      try {
+        // For source_unregister tasks with backup_source resources,
+        // resolve from immutable task payload data first to avoid 404s.
+        if (activeTask.value?.task_type === 'source_unregister' && resource.resource_type === 'backup_source') {
+          const fromPayload = resolveTaskBackupSourceResourceFromPayload(resource, activeTask.value)
+          if (fromPayload) {
+            return normalizeResourceDetail(resource.resource_type, resource.resource_id, {}, fromPayload)
+          }
+        }
+        const raw = await fetchResourceDetail(resource, signal)
+        const source = resource.resource_type === 'backup_source'
+          ? await resolveTaskBackupSourceResource(resource, taskResourceSubtype(resource), signal)
+          : undefined
+        return normalizeResourceDetail(resource.resource_type, resource.resource_id, raw, source)
+      } catch (error) {
+        // Fallback: try to resolve from task payload snapshot
+        if (activeTask.value) {
+          const snapshot = taskResourceSnapshot(activeTask.value, resource)
+          if (snapshot) {
+            return normalizeResourceDetail(resource.resource_type, resource.resource_id, snapshot)
+          }
+        }
+        throw error
+      }
     }))
+    const rows = results.map((result, index) => {
+      if (result.status === 'fulfilled') return result.value
+      const resource = resources[index]
+      return normalizeResourceDetail(resource.resource_type, resource.resource_id, resource)
+    })
     resourceDetails[type] = rows
+    const failedCount = results.filter((r) => r.status === 'rejected').length
+    if (failedCount > 0) {
+      const firstError = results.find((r) => r.status === 'rejected')
+      if (firstError && firstError.status === 'rejected') {
+        resourceErrors[type] = `${failedCount} resource(s) failed to load: ${apiErrorMessage(firstError.reason)}`
+      }
+    }
   } catch (err) {
     if (requests.isAbortError(err)) return
     resourceErrors[type] = apiErrorMessage(err)

--- a/src/frontend/src/pages/protection/components/TaskDetailDrawer.vue
+++ b/src/frontend/src/pages/protection/components/TaskDetailDrawer.vue
@@ -40,8 +40,9 @@ import {
 import {
   canCancelRepositoryTask,
 } from '../../../lib/repositoryTaskCancellation'
+import { taskResourceSnapshot } from '../../../lib/taskOutcomeDisplay'
 import { lifecycleStatusTagAttrs } from '../../../lib/statusTag'
-import { resolveTaskBackupSourceResource } from '../../../lib/taskBackupSourceResource'
+import { resolveTaskBackupSourceResource, resolveTaskBackupSourceResourceFromPayload } from '../../../lib/taskBackupSourceResource'
 import { parseTaskStepStatusEvent, taskEventMessageKey, taskEventObjectText } from '../../../lib/taskEventDisplay'
 import { hasExpandableTaskStep, hasExpandedTaskStep } from '../../../lib/taskStepExpansion'
 import TaskStatusTag from '../../../components/TaskStatusTag.vue'
@@ -267,12 +268,27 @@ async function loadTaskOwner(task: TaskRow) {
     taskOwner.value = t('ops.task.emptyMark')
     return
   }
+  // For source_unregister tasks, resolve the owner from immutable task payload
+  // data first, since the live resource has already been removed.
+  if (task.task_type === 'source_unregister' && resource.resource_type === 'backup_source') {
+    const fromPayload = resolveTaskBackupSourceResourceFromPayload(resource, task)
+    if (fromPayload && activeTask.value?.task_uuid === task.task_uuid) {
+      taskOwner.value = fromPayload.backupSource || t('ops.task.emptyMark')
+      return
+    }
+  }
   try {
     const detail = await fetchResourceDetail(resource, task)
     const name = objectValue(detail as Record<string, unknown>, ['name', 'display_name', 'hostname', 'snapshot_uid'])
     if (activeTask.value?.task_uuid === task.task_uuid) taskOwner.value = name || t('ops.task.emptyMark')
   } catch {
-    if (activeTask.value?.task_uuid === task.task_uuid) taskOwner.value = t('ops.task.emptyMark')
+    // Fallback: try to resolve from task payload snapshot
+    const snapshot = taskResourceSnapshot(task, resource)
+    if (activeTask.value?.task_uuid === task.task_uuid) {
+      taskOwner.value = snapshot
+        ? objectValue(snapshot, ['name', 'display_name', 'hostname'])
+        : t('ops.task.emptyMark')
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

Opening the details of a completed **Source Unregister** task previously triggered live API requests for resources that had already been removed, resulting in 404 errors and displaying the owner as `-` instead of the original source name.

## Changes

### 1. `taskOutcomeDisplay.ts` — Extend `taskResourceSnapshot()`
Add two new fallback paths for `backup_source` resources:
- `request_payload.source_orphan_display_name`
- `result_payload.sources[].source_name`

### 2. `taskBackupSourceResource.ts` — Add `resolveTaskBackupSourceResourceFromPayload()`
A new history-only resolver that extracts backup source display info from immutable task payload data without any live API calls. Fallback order:
1. `request_payload.cleanup_plan.source.name`
2. `request_payload.source_orphan_display_name`
3. `result_payload.sources[].source_name`

Returns `status: 'unregistered'` to clearly indicate the resource has been removed.

### 3. `Tasks.vue` — Operations task list
- `loadTaskOwner()`: Short-circuits for `source_unregister` tasks, using `resolveTaskBackupSourceResourceFromPayload()` instead of live API calls.
- `loadResourceType()`: Prioritizes payload-based resolution for `source_unregister` tasks with `backup_source` resources.

### 4. `TaskDetailDrawer.vue` — Protection task drawer
- `loadTaskOwner()`: Adds `taskResourceSnapshot` fallback on live API failure (previously just showed `-`). For `source_unregister` tasks, resolves from payload first.

### 5. `FlowBackupSourceDetailDrawer.vue` — Backup source detail drawer
- `loadResourceType()`: Switches to `Promise.allSettled()` so one failed resource does not block others. Adds per-resource fallback to `taskResourceSnapshot` and payload-based resolution for `source_unregister` tasks.

## Verification
- TypeScript compilation: clean
- All 740 tests: passing

Closes #235