### PR TITLE
fix(frontend): prevent status tag text wrapping and vertical clipping after source deregistration (#392)

### DIFF
--- a/src/frontend/src/components/node-lifecycle/NodeLifecycleStatusCell.vue
+++ b/src/frontend/src/components/node-lifecycle/NodeLifecycleStatusCell.vue
@@ -53,9 +53,6 @@ const label = computed(() => {
   animation: node-lifecycle-spin 0.8s linear infinite;
 }
 
-.node-lifecycle-status__label {
-  line-height: 1.2;
-}
 
 @keyframes node-lifecycle-spin {
   to {

--- a/src/frontend/src/pages/insight/GatewayCompositeStatusCell.vue
+++ b/src/frontend/src/pages/insight/GatewayCompositeStatusCell.vue
@@ -59,9 +59,6 @@ const label = computed(() => {
   animation: dg-composite-status-spin 0.8s linear infinite;
 }
 
-.dg-composite-status__label {
-  line-height: 1.2;
-}
 
 @keyframes dg-composite-status-spin {
   to {

--- a/src/frontend/src/pages/protection/BackupSources.vue
+++ b/src/frontend/src/pages/protection/BackupSources.vue
@@ -2119,7 +2119,7 @@ onUnmounted(() => {
                   </button>
                 </template>
               </el-table-column>
-              <el-table-column :label="t('protection.sourceResources.colStatus')" min-width="126" align="center" header-align="center">
+              <el-table-column :label="t('protection.sourceResources.colStatus')" min-width="155" align="center" header-align="center">
                 <template #default="{ row }">
                   <div class="hfl-table-no-tooltip">
                     <FlowSourceReadyStatusCell
@@ -2237,7 +2237,7 @@ onUnmounted(() => {
                   </button>
                 </template>
               </el-table-column>
-              <el-table-column :label="t('protection.sourceResources.colStatus')" min-width="135" align="center" header-align="center">
+              <el-table-column :label="t('protection.sourceResources.colStatus')" min-width="165" align="center" header-align="center">
                 <template #default="{ row }">
                   <div class="hfl-table-no-tooltip">
                     <FlowSourceReadyStatusCell

--- a/src/frontend/src/pages/protection/components/FlowSourceReadyStatusCell.vue
+++ b/src/frontend/src/pages/protection/components/FlowSourceReadyStatusCell.vue
@@ -83,10 +83,6 @@ function onActivate(event: MouseEvent) {
   animation: flow-source-status-spin 0.8s linear infinite;
 }
 
-.flow-source-status-tag__label {
-  line-height: 1.2;
-}
-
 @keyframes flow-source-status-spin {
   to {
     transform: rotate(360deg);

--- a/src/frontend/src/styles/list-page-ui.css
+++ b/src/frontend/src/styles/list-page-ui.css
@@ -221,29 +221,42 @@
 }
 
 .hfl-list-table td.el-table__cell:not(.el-table-column--selection):not(.el-table__expand-column) > .cell:has(.flow-source-status-cell),
-.hfl-list-table td.el-table__cell:not(.el-table-column--selection):not(.el-table__expand-column) > .cell:has(.node-lifecycle-status) {
+.hfl-list-table td.el-table__cell:not(.el-table-column--selection):not(.el-table__expand-column) > .cell:has(.node-lifecycle-status),
+.hfl-list-table td.el-table__cell:not(.el-table-column--selection):not(.el-table__expand-column) > .cell:has(.dg-composite-status) {
   overflow: visible;
   text-overflow: clip;
 }
 
 .hfl-list-table td.el-table__cell:not(.el-table-column--selection):not(.el-table__expand-column) > .cell:has(.flow-source-status-cell) > *,
-.hfl-list-table td.el-table__cell:not(.el-table-column--selection):not(.el-table__expand-column) > .cell:has(.node-lifecycle-status) > * {
+.hfl-list-table td.el-table__cell:not(.el-table-column--selection):not(.el-table__expand-column) > .cell:has(.node-lifecycle-status) > *,
+.hfl-list-table td.el-table__cell:not(.el-table-column--selection):not(.el-table__expand-column) > .cell:has(.dg-composite-status) > * {
   min-width: auto;
   max-width: none;
 }
 
 .hfl-list-table td.el-table__cell:not(.el-table-column--selection):not(.el-table__expand-column) > .cell:has(.flow-source-status-cell) .el-tag,
-.hfl-list-table td.el-table__cell:not(.el-table-column--selection):not(.el-table__expand-column) > .cell:has(.node-lifecycle-status) .el-tag {
+.hfl-list-table td.el-table__cell:not(.el-table-column--selection):not(.el-table__expand-column) > .cell:has(.node-lifecycle-status) .el-tag,
+.hfl-list-table td.el-table__cell:not(.el-table-column--selection):not(.el-table__expand-column) > .cell:has(.dg-composite-status) .el-tag {
   max-width: none;
 }
 
 .hfl-list-table td.el-table__cell:not(.el-table-column--selection):not(.el-table__expand-column) > .cell:has(.flow-source-status-cell) .el-tag__content,
 .hfl-list-table td.el-table__cell:not(.el-table-column--selection):not(.el-table__expand-column) > .cell:has(.node-lifecycle-status) .el-tag__content,
+.hfl-list-table td.el-table__cell:not(.el-table-column--selection):not(.el-table__expand-column) > .cell:has(.dg-composite-status) .el-tag__content {
+  display: inline-flex;
+  overflow: hidden;
+  line-height: normal;
+  max-width: 100%;
+}
+
 .hfl-list-table td.el-table__cell:not(.el-table-column--selection):not(.el-table__expand-column) > .cell:has(.flow-source-status-cell) .el-tag__content > span,
-.hfl-list-table td.el-table__cell:not(.el-table-column--selection):not(.el-table__expand-column) > .cell:has(.node-lifecycle-status) .el-tag__content > span {
-  overflow: visible;
-  text-overflow: clip;
-  max-width: none;
+.hfl-list-table td.el-table__cell:not(.el-table-column--selection):not(.el-table__expand-column) > .cell:has(.node-lifecycle-status) .el-tag__content > span,
+.hfl-list-table td.el-table__cell:not(.el-table-column--selection):not(.el-table__expand-column) > .cell:has(.dg-composite-status) .el-tag__content > span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+  max-width: 100%;
 }
 
 .hfl-list-table td.el-table__cell:not(.el-table-column--selection):not(.el-table__expand-column) > .cell > span:not(.el-tag):not(.hfl-table-type-label):not(.repo-protocol-pill):not(.repo-s3-platform-pill):not(.hfl-ops-user-chip):not(.hfl-ops-result-chip):not(.hfl-ops-response-chip):not(.source-os-cell):not(.backup-source-cell):not(.dp-source-task-type-pill):not(.dp-source-task-trigger-pill):not(.flow-binding-empty):not(.recovery-confirm-policy-cell):not(.platform-account-page__cell-meta) {


### PR DESCRIPTION
## Summary

Fixes #392: after deregistering a source, the status tag text (e.g. "Deregistration Failed", "Deregistering...") was wrapping to a new line and had descenders vertically clipped.

## Root Cause

Three issues combined:

1. **CSS specificity conflict**: The base rule in `list-page-ui.css` sets `display: block` on `.el-tag__content` (specificity 0,7,0), which overrides the component scoped `display: inline-flex` (specificity 0,2,1). This causes the icon and label to stack vertically instead of sitting side-by-side.

2. **Tight line-height**: The base rule sets `line-height: 16px` on `.el-tag__content`. Additionally, three status cell components had scoped `line-height: 1.2` on their label spans (~14.4px at 12px font), which clipped descenders like "g" in "Deregistering".

3. **Narrow column width**: The BackupSources status column min-width (126px host, 135px NAS) was too narrow for the 21-character "Deregistration Failed" text.

## Changes

### `src/frontend/src/styles/list-page-ui.css`
- Added `display: inline-flex` to the `:has()` override for `.el-tag__content` inside status cells, restoring the icon+label side-by-side layout
- Added `line-height: normal` to prevent descender clipping
- Changed span overrides from `overflow: visible` to `overflow: hidden; text-overflow: ellipsis` so long text truncates gracefully when the column is resized narrower
- Added `.dg-composite-status` to all `:has()` override rules so `GatewayCompositeStatusCell` benefits from the same fix

### `src/frontend/src/pages/protection/components/FlowSourceReadyStatusCell.vue`
- Removed `line-height: 1.2` from `.flow-source-status-tag__label`

### `src/frontend/src/components/node-lifecycle/NodeLifecycleStatusCell.vue`
- Removed `line-height: 1.2` from `.node-lifecycle-status__label`

### `src/frontend/src/pages/insight/GatewayCompositeStatusCell.vue`
- Removed `line-height: 1.2` from `.dg-composite-status__label`

### `src/frontend/src/pages/protection/BackupSources.vue`
- Increased host status column `min-width` from 126 to 155
- Increased NAS status column `min-width` from 135 to 165

## Behavior

| Scenario | Before | After |
|----------|--------|-------|
| Default column width | Text wraps to new line | Full text displayed on one line |
| Narrow column (user resized) | Text overflows column edge | Text truncates with ellipsis |
| Descenders (g, j, p, q, y) | Clipped vertically | Fully visible |