### PR TITLE
Keep NAS Production Sites table width within the 1400px budget

### DIFF
--- a/src/frontend/src/pages/protection/BackupSources.vue
+++ b/src/frontend/src/pages/protection/BackupSources.vue
@@ -2264,7 +2264,7 @@ onUnmounted(() => {
                   {{ nasServerAddress(row) }}
                 </template>
               </el-table-column>
-              <el-table-column :label="t('protection.sourceResources.colNasShareExport')" min-width="130">
+              <el-table-column :label="t('protection.sourceResources.colNasShareExport')" min-width="120">
                 <template #default="{ row }">
                   <div class="table-stack-cell">
                     <span class="table-stack-cell__secondary">{{ t(nasPathKindLabelKey(row)) }}</span>
@@ -2272,7 +2272,7 @@ onUnmounted(() => {
                   </div>
                 </template>
               </el-table-column>
-              <el-table-column :label="t('protection.sourceResources.colSourceProxy')" min-width="130">
+              <el-table-column :label="t('protection.sourceResources.colSourceProxy')" min-width="120">
                 <template #header>
                   <span class="hfl-table-header-with-tip">
                     <span>{{ t('protection.sourceResources.colSourceProxy') }}</span>
@@ -2292,7 +2292,7 @@ onUnmounted(() => {
                   </div>
                 </template>
               </el-table-column>
-              <el-table-column :label="t('protection.sourceResources.colProxyMountPoint')" min-width="170">
+              <el-table-column :label="t('protection.sourceResources.colProxyMountPoint')" min-width="165">
                 <template #default="{ row }">
                   <span class="hfl-table-cell-full hfl-table-no-tooltip">{{ nasProxyMountPoint(row) }}</span>
                 </template>


### PR DESCRIPTION
## Summary
- Reclaim 25px from secondary NAS columns so the Production Sites NAS table stays within the desktop 1400px width budget after the status column widen for deregistration labels.
- Keeps NAS status `min-width` at 165 for \"Deregistration Failed\".

## Test plan
- [x] Declared NAS table width sums to 1400
- [ ] `ProductionSitesAvailability.test.ts` passes in CI / TEST Quality


Made with [Cursor](https://cursor.com)