### PR TITLE
fix(frontend): switch copy notification from ElMessage to pushToast in backup source detail drawer (#389)

### DIFF
--- a/src/frontend/src/components/feedback/HflToastViewport.vue
+++ b/src/frontend/src/components/feedback/HflToastViewport.vue
@@ -16,7 +16,7 @@ import { toastState } from '../../lib/toast/store'
   position: fixed;
   top: 68px;
   right: 16px;
-  z-index: 3000;
+  z-index: 4000;
   display: flex;
   flex-direction: column;
   gap: 12px;

--- a/src/frontend/src/pages/ops/Tasks.vue
+++ b/src/frontend/src/pages/ops/Tasks.vue
@@ -1729,7 +1729,7 @@ watch(
 .hfl-task-drawer__header-meta {
   display: flex;
   flex-wrap: wrap;
-  align-items: baseline;
+  align-items: center;
   gap: 8px;
   margin-top: 6px;
   min-width: 0;
@@ -1825,7 +1825,7 @@ watch(
 
 .hfl-task-drawer__uuid {
   display: inline-flex;
-  align-items: baseline;
+  align-items: center;
   gap: 4px;
   min-width: 0;
   max-width: 100%;

--- a/src/frontend/src/pages/protection/components/FlowBackupSourceDetailDrawer.vue
+++ b/src/frontend/src/pages/protection/components/FlowBackupSourceDetailDrawer.vue
@@ -31,6 +31,7 @@ import {
   X,
 } from 'lucide-vue-next'
 import { ElMessage } from 'element-plus'
+import { pushToast } from '../../../lib/toast/store'
 import type { ElTable, ElTree } from 'element-plus'
 import HflPopover from '../../../components/HflPopover.vue'
 import HflPagination from '../../../components/HflPagination.vue'
@@ -1353,11 +1354,23 @@ function toggleAllTaskStepsExpanded() {
 }
 
 async function copyText(value: string) {
+  if (!value) return
   try {
     await copyTextToClipboard(value)
-    ElMessage.success({ message: t('protection.backupsPage.flowSourceDetailCopied'), grouping: true })
-  } catch {
-    ElMessage.error({ message: t('protection.backupsPage.flowSourceDetailCopyFailed'), grouping: true })
+    pushToast({
+      type: 'success',
+      message: t('protection.backupsPage.flowSourceDetailCopied'),
+      dedupeKey: 'copy:FlowSourceDetail',
+      duration: 2000,
+    })
+  } catch (err) {
+    console.error('Copy to clipboard failed:', err)
+    pushToast({
+      type: 'error',
+      message: t('protection.backupsPage.flowSourceDetailCopyFailed'),
+      dedupeKey: 'copy:FlowSourceDetail',
+      duration: 3000,
+    })
   }
 }
 
@@ -3818,7 +3831,7 @@ function onClosed() {
             <span>{{ t('protection.backupsPage.flowSourceDetailTaskOwner') }}: {{ source?.name || taskTypeLabel(activeTask.task_type) }}</span>
             <span class="dp-task-detail__header-divider" />
             <span class="dp-task-detail__uuid">
-              {{ activeTask.task_uuid }}
+              <span class="dp-task-detail__uuid-text">{{ activeTask.task_uuid }}</span>
               <ElButton
                 class="dp-task-detail__copy-button"
                 text
@@ -5458,12 +5471,13 @@ function onClosed() {
 .dp-task-detail__header-meta {
   display: flex;
   flex-wrap: wrap;
-  align-items: baseline;
+  align-items: center;
   gap: 8px;
   margin-top: 6px;
   min-width: 0;
   color: rgb(100 116 139);
   font-size: 12px;
+  line-height: 20px;
 }
 
 .dp-task-detail__header-divider {
@@ -5475,14 +5489,18 @@ function onClosed() {
 
 .dp-task-detail__uuid {
   display: inline-flex;
-  align-items: baseline;
+  align-items: center;
   gap: 4px;
   max-width: 100%;
   color: rgb(71 85 105);
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', monospace;
   font-size: 11px;
-  font-weight: 700;
+  font-weight: 600;
   overflow-wrap: anywhere;
+}
+
+.dp-task-detail__uuid-text {
+  line-height: 21px;
 }
 
 .dp-task-detail__copy-button {

--- a/src/frontend/src/pages/protection/components/TaskDetailDrawer.vue
+++ b/src/frontend/src/pages/protection/components/TaskDetailDrawer.vue
@@ -1109,7 +1109,7 @@ watch(
 }
 
 .hfl-task-drawer__header-meta {
-  align-items: baseline;
+  align-items: center;
   flex-wrap: wrap;
   gap: 8px;
   margin-top: 6px;
@@ -1800,7 +1800,7 @@ watch(
 }
 
 .hfl-task-drawer--target-repositories .hfl-task-drawer__uuid {
-  align-items: baseline;
+  align-items: center;
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', monospace;
 }
 


### PR DESCRIPTION
## Summary

Fixes #389 — clicking the copy icon next to the Owner ID in the backup source detail drawer produced no success or failure feedback.

## Root Cause

The copy function used `ElMessage` for notifications, which renders at a lower z-index than the `ElDrawer` overlay, making the toast invisible to the user.

## Changes

- **Switch from `ElMessage` to `pushToast`** in `FlowBackupSourceDetailDrawer.vue` — the toast system renders at a higher z-index and is visible above the drawer
- **Bump toast viewport z-index** from 3000 to 4000 in `HflToastViewport.vue` to ensure toasts always layer above `ElDrawer` (z-index: 3000+)
- **Add early return guard** for empty values in `copyText()` to avoid attempting a clipboard write with no content
- **Fix vertical alignment** of header meta items and UUID rows — changed `align-items: baseline` to `align-items: center` for consistent cross-browser rendering
- **Add `line-height`** on UUID text and header meta to prevent monospace font clipping

## Affected Files

| File | Change |
|------|--------|
| `src/frontend/src/components/feedback/HflToastViewport.vue` | z-index: 3000 → 4000 |
| `src/frontend/src/pages/ops/Tasks.vue` | baseline → center alignment (2 locations) |
| `src/frontend/src/pages/protection/components/FlowBackupSourceDetailDrawer.vue` | ElMessage → pushToast, early return guard, alignment fixes, UUID styling |
| `src/frontend/src/pages/protection/components/TaskDetailDrawer.vue` | baseline → center alignment (2 locations) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)