### PR TITLE
fix(frontend): select ProxyFS proxies by availability

### DIFF
--- a/src/frontend/src/pages/node/AddProxyFsRepository.vue
+++ b/src/frontend/src/pages/node/AddProxyFsRepository.vue
@@ -43,7 +43,9 @@ const proxyDirTreeRef = ref<InstanceType<typeof ElTree>>()
 const proxyNodesRefreshing = ref(false)
 const proxyNodes = ref<ApiNode[]>([])
 
-const availableProxyNodes = computed(() => proxyNodes.value.filter((node) => node.role === 'proxy'))
+const availableProxyNodes = computed(() =>
+  proxyNodes.value.filter((node) => node.role === 'proxy' && node.availability === 'online'),
+)
 const selectedProxyNodeName = computed(() =>
   availableProxyNodes.value.find((node) => node.id === proxyNodeId.value)?.name || '',
 )
@@ -388,7 +390,7 @@ async function refreshProxyDirectory(data: TreeNode) {
 }
 
 async function loadProxyNodes() {
-  proxyNodes.value = await listAllNodes({ role: 'proxy', status: 'online' }).catch(() => [])
+  proxyNodes.value = await listAllNodes({ role: 'proxy' }).catch(() => [])
 }
 
 async function refreshProxyNodesManually() {

--- a/src/frontend/src/pages/node/AddProxyFsRepositoryAvailability.test.ts
+++ b/src/frontend/src/pages/node/AddProxyFsRepositoryAvailability.test.ts
@@ -1,0 +1,16 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const page = readFileSync(resolve(process.cwd(), 'src/pages/node/AddProxyFsRepository.vue'), 'utf8')
+
+describe('Add Local Disk Repository proxy availability', () => {
+  it('loads proxy nodes without treating online as a lifecycle status', () => {
+    expect(page).toContain("listAllNodes({ role: 'proxy' })")
+    expect(page).not.toContain("status: 'online'")
+  })
+
+  it('only offers proxy nodes whose availability is online', () => {
+    expect(page).toContain("node.role === 'proxy' && node.availability === 'online'")
+  })
+})

--- a/src/frontend/src/pages/node/Repositories.vue
+++ b/src/frontend/src/pages/node/Repositories.vue
@@ -2278,7 +2278,7 @@ function s3ObjectPrefixCell(row: RepositoryRow) {
             </el-table-column>
             <el-table-column
               :label="t('repositoriesPage.colStatus')"
-              :width="activeTab === 'proxy_fs' ? 148 : 112"
+              :width="activeTab === 'proxy_fs' ? 148 : activeTab === 's3' || activeTab === 'nas' ? 134 : 112"
             >
               <template #default="{ row }">
                 <div class="hfl-table-no-tooltip">
@@ -2309,7 +2309,7 @@ function s3ObjectPrefixCell(row: RepositoryRow) {
             <el-table-column
               v-if="activeTab === 's3'"
               :label="t('repositoriesPage.colRegion')"
-              min-width="100"
+              min-width="120"
             >
               <template #default="{ row }">
                 <span :class="{ 'repo-s3-region-empty': s3RegionCellText(row) === '—' }">
@@ -2338,7 +2338,7 @@ function s3ObjectPrefixCell(row: RepositoryRow) {
             <el-table-column
               v-if="activeTab === 's3'"
               :label="t('repositoriesPage.colS3ObjectPrefix')"
-              min-width="180"
+              min-width="126"
             >
               <template #default="{ row }">
                 <span>{{ s3ObjectPrefixCell(row) }}</span>
@@ -2374,7 +2374,7 @@ function s3ObjectPrefixCell(row: RepositoryRow) {
             <el-table-column
               v-if="activeTab === 'nas' || activeTab === 'proxy_fs'"
               :label="t('repositoriesPage.colSourceProxyIp')"
-              :min-width="activeTab === 'proxy_fs' ? 144 : 180"
+              :min-width="activeTab === 'proxy_fs' ? 144 : 173"
             >
               <template #header>
                 <span class="repo-table-header-with-tip">
@@ -2429,7 +2429,10 @@ function s3ObjectPrefixCell(row: RepositoryRow) {
                 <span>{{ repoListMountPoint(row) }}</span>
               </template>
             </el-table-column>
-            <el-table-column :label="usageColumnLabel" :min-width="activeTab === 's3' ? 200 : 198">
+            <el-table-column
+              :label="usageColumnLabel"
+              :min-width="activeTab === 's3' ? 170 : activeTab === 'nas' ? 190 : 198"
+            >
               <template #default="{ row }">
                 <template v-if="activeTab === 's3'">
                   <HflCapacityCell
@@ -2487,7 +2490,7 @@ function s3ObjectPrefixCell(row: RepositoryRow) {
             <el-table-column
               prop="created_at"
               :label="activeTab === 's3' || activeTab === 'nas' || activeTab === 'proxy_fs' ? t('repositoriesPage.colRegistered') : t('repositoriesPage.colCreated')"
-              :min-width="activeTab === 's3' || activeTab === 'nas' || activeTab === 'proxy_fs' ? 170 : createdAtColumnMinWidth"
+              :min-width="activeTab === 'nas' ? 163 : activeTab === 's3' || activeTab === 'proxy_fs' ? 170 : createdAtColumnMinWidth"
             >
               <template #default="{ row }">
                 <span class="hfl-table-cell-time">{{ formatLocalDateTime(row.created_at) }}</span>


### PR DESCRIPTION
## Problem and root cause

ProxyFS repository creation treated online as a lifecycle status instead of source availability, which could omit usable proxy nodes.

## Solution

Load proxy nodes without a lifecycle filter and offer only online-available proxies. Adjust related repository-table column widths and add regression coverage.

## Validation

- Manual testing: passed
- `npm run lint`, `npm run test:ci`, `npm run build`
- Targeted ProxyFS availability regression test

## Risks and compatibility

The change only corrects client-side proxy eligibility and table layout; API compatibility is unchanged.

Fixes #406
