### PR TITLE
fix(frontend): unify restore target discovery

### DIFF
--- a/src/frontend/src/composables/useRestoreTargetCatalog.test.ts
+++ b/src/frontend/src/composables/useRestoreTargetCatalog.test.ts
@@ -1,0 +1,210 @@
+// @vitest-environment jsdom
+
+import { effectScope, nextTick } from 'vue'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { listBackupSelectableSources, type BackupSelectableSource } from '../lib/sourceApi'
+import {
+  RESTORE_TARGET_SEARCH_DELAY_MS,
+  restoreTargetIsSelectable,
+  useRestoreTargetCatalog,
+} from './useRestoreTargetCatalog'
+
+vi.mock('../lib/sourceApi', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../lib/sourceApi')>()
+  return { ...actual, listBackupSelectableSources: vi.fn() }
+})
+
+const listMock = vi.mocked(listBackupSelectableSources)
+
+function source(id: string, overrides: Partial<BackupSelectableSource> = {}): BackupSelectableSource {
+  const [kind, refId] = id.split(':')
+  return {
+    id,
+    kind: kind === 'nas' ? 'nas' : 'agent',
+    ref_id: Number(refId),
+    type: kind === 'nas' ? 'nas' : 'host',
+    name: id,
+    hostname: id,
+    node_name: id,
+    node_ip: '192.0.2.1',
+    status: 'active',
+    availability: 'online',
+    ...overrides,
+  }
+}
+
+function catalog() {
+  const scope = effectScope()
+  const value = scope.run(() => useRestoreTargetCatalog())
+  if (!value) throw new Error('catalog scope was not created')
+  return { scope, value }
+}
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.clearAllMocks()
+})
+
+describe('useRestoreTargetCatalog', () => {
+  it('uses the online paged contract and deduplicates subsequent pages', async () => {
+    listMock
+      .mockResolvedValueOnce({ count: 3, results: [source('agent:1'), source('agent:2')] })
+      .mockResolvedValueOnce({ count: 3, results: [source('agent:2'), source('nas:3')] })
+    const { scope, value } = catalog()
+
+    await value.reset(' target ')
+    await value.loadMore()
+
+    expect(listMock).toHaveBeenNthCalledWith(1, {
+      page: 1,
+      page_size: 100,
+      search: 'target',
+      availability: 'online',
+    }, expect.objectContaining({ signal: expect.any(AbortSignal) }))
+    expect(listMock).toHaveBeenNthCalledWith(2, {
+      page: 2,
+      page_size: 100,
+      search: 'target',
+      availability: 'online',
+    }, expect.objectContaining({ signal: expect.any(AbortSignal) }))
+    expect(value.rows.value.map((row) => row.id)).toEqual(['agent:1', 'agent:2', 'nas:3'])
+    expect(value.hasMore.value).toBe(false)
+    scope.stop()
+  })
+
+  it('debounces search and keeps only the latest response', async () => {
+    vi.useFakeTimers()
+    let resolveOld!: (value: { count: number; results: BackupSelectableSource[] }) => void
+    listMock
+      .mockImplementationOnce(() => new Promise((resolve) => { resolveOld = resolve }))
+      .mockResolvedValueOnce({ count: 1, results: [source('agent:2')] })
+    const { scope, value } = catalog()
+
+    const oldRequest = value.reset('old')
+    value.setSearch('new')
+    await vi.advanceTimersByTimeAsync(RESTORE_TARGET_SEARCH_DELAY_MS)
+    resolveOld({ count: 1, results: [source('agent:1')] })
+    await oldRequest
+    await nextTick()
+
+    expect(value.rows.value.map((row) => row.id)).toEqual(['agent:2'])
+    expect(value.search.value).toBe('new')
+    scope.stop()
+  })
+
+  it('distinguishes request failure from an empty result and retries', async () => {
+    listMock
+      .mockRejectedValueOnce(new Error('network'))
+      .mockResolvedValueOnce({ count: 0, results: [] })
+    const { scope, value } = catalog()
+
+    await value.reset()
+    expect(value.error.value).toBe('initial')
+    await value.retry()
+    expect(value.error.value).toBeNull()
+    expect(value.rows.value).toEqual([])
+    scope.stop()
+  })
+
+  it('keeps prior rows when loading another page fails', async () => {
+    listMock
+      .mockResolvedValueOnce({ count: 2, results: [source('agent:1')] })
+      .mockRejectedValueOnce(new Error('network'))
+    const { scope, value } = catalog()
+
+    await value.reset()
+    await value.loadMore()
+
+    expect(value.rows.value.map((row) => row.id)).toEqual(['agent:1'])
+    expect(value.error.value).toBe('more')
+    scope.stop()
+  })
+
+  it('hydrates and pins an unavailable saved target without making it selectable', async () => {
+    listMock.mockResolvedValue({ count: 1, results: [source('nas:7', { availability: 'offline' })] })
+    const { scope, value } = catalog()
+
+    await value.ensureByIds(['nas:7'])
+    const options = value.options(['nas:7'])
+
+    expect(listMock).toHaveBeenCalledWith({ ids: 'nas:7', page_size: 100 }, expect.objectContaining({ signal: expect.any(AbortSignal) }))
+    expect(options).toHaveLength(1)
+    expect(options[0]).toMatchObject({ selectable: false, unavailableReason: 'offline', pinned: true })
+    scope.stop()
+  })
+
+  it('hydrates more than one API page of exact IDs in bounded batches', async () => {
+    const ids = Array.from({ length: 101 }, (_, index) => `agent:${index + 1}`)
+    listMock
+      .mockResolvedValueOnce({ count: 100, results: ids.slice(0, 100).map((id) => source(id)) })
+      .mockResolvedValueOnce({ count: 1, results: [source(ids[100]!)] })
+    const { scope, value } = catalog()
+
+    const rows = await value.ensureByIds(ids)
+
+    expect(listMock).toHaveBeenCalledTimes(2)
+    expect(listMock.mock.calls[0]?.[0]).toMatchObject({ page_size: 100 })
+    expect(listMock.mock.calls[1]?.[0]).toEqual({ ids: 'agent:101', page_size: 100 })
+    expect(rows).toHaveLength(101)
+    scope.stop()
+  })
+
+  it('keeps a hydration failure visible until the missing target retries successfully', async () => {
+    listMock
+      .mockRejectedValueOnce(new Error('hydration failed'))
+      .mockResolvedValueOnce({ count: 0, results: [] })
+      .mockResolvedValueOnce({ count: 0, results: [] })
+      .mockResolvedValueOnce({ count: 1, results: [source('nas:7', { availability: 'offline' })] })
+    const { scope, value } = catalog()
+
+    await value.ensureByIds(['nas:7'])
+    await value.reset()
+    expect(value.error.value).toBe('initial')
+
+    await value.retry()
+    expect(value.error.value).toBeNull()
+    expect(value.options(['nas:7'])[0]).toMatchObject({ selectable: false, pinned: true })
+    scope.stop()
+  })
+
+  it('retries a failed next page without discarding prior rows', async () => {
+    listMock
+      .mockResolvedValueOnce({ count: 2, results: [source('agent:1')] })
+      .mockRejectedValueOnce(new Error('network'))
+      .mockResolvedValueOnce({ count: 2, results: [source('agent:2')] })
+    const { scope, value } = catalog()
+
+    await value.reset()
+    await value.loadMore()
+    await value.retry()
+
+    expect(listMock).toHaveBeenNthCalledWith(3, {
+      page: 2,
+      page_size: 100,
+      search: undefined,
+      availability: 'online',
+    }, expect.objectContaining({ signal: expect.any(AbortSignal) }))
+    expect(value.rows.value.map((row) => row.id)).toEqual(['agent:1', 'agent:2'])
+    scope.stop()
+  })
+
+  it('prefers a fresh discovery row over an older hydrated copy', async () => {
+    listMock
+      .mockResolvedValueOnce({ count: 1, results: [source('agent:1', { availability: 'offline' })] })
+      .mockResolvedValueOnce({ count: 1, results: [source('agent:1', { availability: 'online' })] })
+    const { scope, value } = catalog()
+
+    await value.ensureByIds(['agent:1'])
+    await value.reset()
+
+    expect(value.isSelectable('agent:1')).toBe(true)
+    expect(value.options(['agent:1'])[0]?.source.availability).toBe('online')
+    scope.stop()
+  })
+
+  it('rejects online targets owned by a blocking lifecycle operation', () => {
+    expect(restoreTargetIsSelectable(source('agent:1'))).toBe(true)
+    expect(restoreTargetIsSelectable(source('agent:1', { status: 'upgrading' }))).toBe(false)
+    expect(restoreTargetIsSelectable(source('agent:1', { status: 'probing' }))).toBe(false)
+  })
+})

--- a/src/frontend/src/composables/useRestoreTargetCatalog.ts
+++ b/src/frontend/src/composables/useRestoreTargetCatalog.ts
@@ -1,0 +1,257 @@
+import { computed, onScopeDispose, ref } from 'vue'
+import { isAbortError } from '../lib/api'
+import {
+  listBackupSelectableSources,
+  type BackupSelectableSource,
+} from '../lib/sourceApi'
+
+export const RESTORE_TARGET_PAGE_SIZE = 100
+export const RESTORE_TARGET_SEARCH_DELAY_MS = 180
+
+const RESTORE_TARGET_BLOCKING_STATUSES = new Set([
+  'upgrading',
+  'restarting',
+  'verifying',
+  'verification_pending',
+  'removing',
+  'cleaning_up',
+  'probing',
+])
+
+export type RestoreTargetUnavailableReason = 'offline' | 'busy' | null
+
+export type RestoreTargetCatalogOption = {
+  source: BackupSelectableSource
+  selectable: boolean
+  unavailableReason: RestoreTargetUnavailableReason
+  pinned: boolean
+}
+
+export function restoreTargetUnavailableReason(source: BackupSelectableSource): RestoreTargetUnavailableReason {
+  if (source.availability !== 'online') return 'offline'
+  return RESTORE_TARGET_BLOCKING_STATUSES.has(source.status) ? 'busy' : null
+}
+
+export function restoreTargetIsSelectable(source: BackupSelectableSource) {
+  return restoreTargetUnavailableReason(source) === null
+}
+
+export function useRestoreTargetCatalog() {
+  const rows = ref<BackupSelectableSource[]>([])
+  const hydratedRows = ref(new Map<string, BackupSelectableSource>())
+  const count = ref(0)
+  const page = ref(0)
+  const search = ref('')
+  const loading = ref(false)
+  const loadingMore = ref(false)
+  const discoveryError = ref<'initial' | 'more' | null>(null)
+  const hydrationError = ref(false)
+  const requestedIds = new Set<string>()
+  const failedHydrationIds = new Set<string>()
+  const hydrationControllers = new Set<AbortController>()
+  let activeController: AbortController | null = null
+  let requestSeq = 0
+  let searchTimer: ReturnType<typeof setTimeout> | null = null
+
+  const allRecords = computed(() => {
+    const merged = new Map<string, BackupSelectableSource>()
+    for (const row of hydratedRows.value.values()) merged.set(row.id, row)
+    for (const row of rows.value) merged.set(row.id, row)
+    return [...merged.values()]
+  })
+
+  const recordById = computed(() => new Map(allRecords.value.map((row) => [row.id, row])))
+  const hasMore = computed(() => rows.value.length < count.value)
+  const error = computed<'initial' | 'more' | null>(() => hydrationError.value ? 'initial' : discoveryError.value)
+
+  function cancelSearchTimer() {
+    if (!searchTimer) return
+    clearTimeout(searchTimer)
+    searchTimer = null
+  }
+
+  function abortActiveRequest() {
+    activeController?.abort()
+    activeController = null
+  }
+
+  async function loadPage(nextPage: number, reset: boolean) {
+    if (!reset && (loading.value || loadingMore.value || !hasMore.value)) return
+    if (reset) {
+      abortActiveRequest()
+      loading.value = true
+      loadingMore.value = false
+    } else {
+      loadingMore.value = true
+    }
+    const seq = ++requestSeq
+    const controller = new AbortController()
+    activeController = controller
+    if (reset) discoveryError.value = null
+
+    try {
+      const result = await listBackupSelectableSources({
+        page: nextPage,
+        page_size: RESTORE_TARGET_PAGE_SIZE,
+        search: search.value || undefined,
+        availability: 'online',
+      }, { signal: controller.signal })
+      if (seq !== requestSeq || controller.signal.aborted) return
+      if (reset) {
+        rows.value = result.results
+      } else {
+        const merged = new Map(rows.value.map((row) => [row.id, row]))
+        for (const row of result.results) merged.set(row.id, row)
+        rows.value = [...merged.values()]
+      }
+      count.value = result.count
+      page.value = nextPage
+      discoveryError.value = null
+    } catch (err) {
+      if (isAbortError(err) || seq !== requestSeq) return
+      if (reset) {
+        rows.value = []
+        count.value = 0
+        page.value = 0
+        discoveryError.value = 'initial'
+      } else {
+        discoveryError.value = 'more'
+      }
+    } finally {
+      if (seq === requestSeq) {
+        if (activeController === controller) activeController = null
+        loading.value = false
+        loadingMore.value = false
+      }
+    }
+  }
+
+  async function reset(query = search.value) {
+    cancelSearchTimer()
+    search.value = query.trim()
+    await loadPage(1, true)
+  }
+
+  async function loadMore() {
+    await loadPage(page.value + 1, false)
+  }
+
+  function setSearch(query: string) {
+    const normalized = query.trim()
+    if (normalized === search.value) {
+      if (!rows.value.length && !loading.value && !loadingMore.value) void reset(normalized)
+      return
+    }
+    search.value = normalized
+    cancelSearchTimer()
+    searchTimer = setTimeout(() => {
+      searchTimer = null
+      void loadPage(1, true)
+    }, RESTORE_TARGET_SEARCH_DELAY_MS)
+  }
+
+  async function ensureByIds(ids: string[]) {
+    const normalized = [...new Set(ids.map((id) => id.trim()).filter(Boolean))]
+    for (const id of normalized) requestedIds.add(id)
+    for (const id of normalized) {
+      if (recordById.value.has(id)) failedHydrationIds.delete(id)
+    }
+    hydrationError.value = failedHydrationIds.size > 0
+    const missing = normalized.filter((id) => !recordById.value.has(id))
+    if (!missing.length) return normalized.map((id) => recordById.value.get(id)).filter(Boolean) as BackupSelectableSource[]
+
+    const chunks: string[][] = []
+    for (let offset = 0; offset < missing.length; offset += RESTORE_TARGET_PAGE_SIZE) {
+      chunks.push(missing.slice(offset, offset + RESTORE_TARGET_PAGE_SIZE))
+    }
+    const requests = chunks.map(async (chunk) => {
+      const controller = new AbortController()
+      hydrationControllers.add(controller)
+      try {
+        return await listBackupSelectableSources({
+          ids: chunk.join(','),
+          page_size: RESTORE_TARGET_PAGE_SIZE,
+        }, { signal: controller.signal })
+      } finally {
+        hydrationControllers.delete(controller)
+      }
+    })
+    const results = await Promise.allSettled(requests)
+    const next = new Map(hydratedRows.value)
+    results.forEach((result, index) => {
+      const chunk = chunks[index] ?? []
+      if (result.status === 'fulfilled') {
+        for (const row of result.value.results) next.set(row.id, row)
+        for (const id of chunk) failedHydrationIds.delete(id)
+      } else if (!isAbortError(result.reason)) {
+        for (const id of chunk) failedHydrationIds.add(id)
+      }
+    })
+    hydratedRows.value = next
+    hydrationError.value = failedHydrationIds.size > 0
+    return normalized.map((id) => recordById.value.get(id)).filter(Boolean) as BackupSelectableSource[]
+  }
+
+  async function retry() {
+    const retryKind = error.value
+    discoveryError.value = null
+    if (retryKind === 'more') await loadMore()
+    else await reset(search.value)
+    await ensureByIds([...requestedIds])
+  }
+
+  function getRecord(id: string) {
+    return recordById.value.get(id)
+  }
+
+  function isSelectable(id: string) {
+    const source = getRecord(id)
+    return Boolean(source && restoreTargetIsSelectable(source))
+  }
+
+  function options(pinnedIds: string[] = []): RestoreTargetCatalogOption[] {
+    const pinned = new Set(pinnedIds.filter(Boolean))
+    const ordered = new Map<string, BackupSelectableSource>()
+    for (const row of rows.value) ordered.set(row.id, row)
+    for (const id of pinned) {
+      const row = getRecord(id)
+      if (row) ordered.set(id, row)
+    }
+    return [...ordered.values()].map((source) => ({
+      source,
+      selectable: restoreTargetIsSelectable(source),
+      unavailableReason: restoreTargetUnavailableReason(source),
+      pinned: pinned.has(source.id),
+    }))
+  }
+
+  function dispose() {
+    cancelSearchTimer()
+    abortActiveRequest()
+    for (const controller of hydrationControllers) controller.abort()
+    hydrationControllers.clear()
+  }
+
+  onScopeDispose(dispose)
+
+  return {
+    rows,
+    allRecords,
+    count,
+    page,
+    search,
+    loading,
+    loadingMore,
+    error,
+    hasMore,
+    reset,
+    loadMore,
+    setSearch,
+    ensureByIds,
+    retry,
+    getRecord,
+    isSelectable,
+    options,
+    dispose,
+  }
+}

--- a/src/frontend/src/locales/enProtectionPages.ts
+++ b/src/frontend/src/locales/enProtectionPages.ts
@@ -443,6 +443,8 @@ export const enProtectionPages = {
     recStepConfirm: 'Review',
     recoveryUseSourceHost: 'Restore to Source',
     recoverySourceHostUnavailable: 'Source target is unavailable.',
+    recoveryTargetEmpty: 'No online restore targets available.',
+    recoveryTargetLoadFailed: 'Failed to load restore targets.',
     recWizardHintRestoreNode: 'Pick the destination node for the restore',
     recWizardHintBackupAndSnapshot: 'Pick a snapshot version for each backup source',
     recWizardHintBackup: 'Pick the backup to restore from',

--- a/src/frontend/src/pages/protection/BackupCreateWizard.vue
+++ b/src/frontend/src/pages/protection/BackupCreateWizard.vue
@@ -43,6 +43,7 @@ import ProtectionPolicyEditorForm from './components/ProtectionPolicyEditorForm.
 import NasSourceDetailDrawer from './components/NasSourceDetailDrawer.vue'
 import { useProtectionSideNav } from '../../composables/useProtectionSideNav'
 import { useListSearch } from '../../composables/useListSearch'
+import { useRestoreTargetCatalog } from '../../composables/useRestoreTargetCatalog'
 import {
   backupFlowSourceStepIcon,
   backupSourceTypeIcon,
@@ -77,7 +78,6 @@ import {
 } from '../../lib/protectionBackupTargetValidationApi'
 import {
   createSourceResource,
-  listBackupSelectableSources,
   listBackupSourceDirectories,
   getBackupSourcePathInfo,
   getSourceResource,
@@ -336,6 +336,10 @@ type WizardFilter = {
 }
 
 const realSourceById = ref(new Map<string, RealSourceRow>())
+const restoreTargetCatalog = useRestoreTargetCatalog()
+const recoveryTargetLoading = restoreTargetCatalog.loading
+const recoveryTargetLoadingMore = restoreTargetCatalog.loadingMore
+const recoveryTargetError = restoreTargetCatalog.error
 const realPolicies = ref<WizardPolicy[]>([])
 const realFilters = ref<WizardFilter[]>([])
 const realTargets = ref<WizardTarget[]>([])
@@ -1514,8 +1518,9 @@ const wizardSourceGroups = computed<WizardSourceGroup[]>(() => {
 })
 
 const createRecoveryTargetOptions = computed(() =>
-  Array.from(realSourceById.value.values())
-    .filter((source) => source.availability === 'online')
+  restoreTargetCatalog.rows.value
+    .filter((source) => restoreTargetCatalog.isSelectable(source.id))
+    .map(mapSelectableSource)
 )
 
 const createRecoveryPlanGroups = computed(() =>
@@ -1798,6 +1803,8 @@ type CreateRecoveryTargetOption = {
   ipLabel: string
   typeLabel: string
   isSource: boolean
+  selectable: boolean
+  unavailableReason: 'offline' | 'busy' | null
   summary: CreateRecoveryTargetSummary
 }
 
@@ -1825,12 +1832,14 @@ function createRecoveryTargetOptionFromSource(source: RealSourceRow, group: Wiza
     ipLabel: summary.ipLine,
     typeLabel: summary.typeLabel,
     isSource: source.id === group.sourceId,
+    selectable: restoreTargetCatalog.isSelectable(source.id),
+    unavailableReason: source.availability !== 'online' ? 'offline' : restoreTargetCatalog.isSelectable(source.id) ? null : 'busy',
     summary,
   }
 }
 
 function createRecoverySourceTargetAvailable(group: WizardSourceGroup) {
-  return realSourceById.value.get(group.sourceId)?.availability === 'online'
+  return restoreTargetCatalog.isSelectable(group.sourceId)
 }
 
 function createRecoverySourceTargetActionValue(group: WizardSourceGroup) {
@@ -1845,22 +1854,21 @@ function isCreateRecoverySourceTargetSelected(group: WizardSourceGroup, dirPlan:
   return dirPlan.targetHostId === group.sourceId
 }
 
-function createRecoveryTargetOptionsForGroup(group: WizardSourceGroup): CreateRecoveryTargetOption[] {
-  const options: CreateRecoveryTargetOption[] = []
-  const seen = new Set<string>()
-  for (const source of createRecoveryTargetOptions.value) {
-    if (seen.has(source.id)) continue
-    seen.add(source.id)
-    options.push(createRecoveryTargetOptionFromSource(source, group))
+function createRecoveryTargetOptionsForGroup(group: WizardSourceGroup, dirPlan: CreateRecoveryDirPlanConfig): CreateRecoveryTargetOption[] {
+  return restoreTargetCatalog.options([group.sourceId, dirPlan.targetHostId])
+    .map(({ source }) => createRecoveryTargetOptionFromSource(mapSelectableSource(source), group))
+}
+
+function onCreateRecoveryTargetVisible(visible: boolean) {
+  if (visible && !restoreTargetCatalog.rows.value.length && !recoveryTargetLoading.value) {
+    void restoreTargetCatalog.reset()
   }
-  const source = realSourceById.value.get(group.sourceId)
-  if (source?.availability === 'online' && !seen.has(source.id)) {
-    options.push({
-      ...createRecoveryTargetOptionFromSource(source, group),
-      isSource: true,
-    })
-  }
-  return options
+}
+
+function onCreateRecoveryTargetPopupScroll(event: Event | { scrollTop?: number; clientHeight?: number; scrollHeight?: number }) {
+  const target = (event instanceof Event ? event.target : event) as HTMLElement | null
+  if (!target) return
+  if (target.scrollHeight - target.scrollTop - target.clientHeight <= 48) void restoreTargetCatalog.loadMore()
 }
 
 function selectCreateRecoverySourceTarget(group: WizardSourceGroup, dirPlan: CreateRecoveryDirPlanConfig) {
@@ -1932,7 +1940,7 @@ function recoveryDirPlanMissingFields(group: WizardSourceGroup, dirPlan: CreateR
   if (!dirPlan.sourcePath || dirPlan.sourcePathValidation === 'pending' || dirPlan.sourcePathValidation === 'invalid') {
     missing.push('sourcePath')
   }
-  if (!dirPlan.targetHostId) missing.push('targetHostId')
+  if (!dirPlan.targetHostId || !restoreTargetCatalog.isSelectable(dirPlan.targetHostId)) missing.push('targetHostId')
   if (!dirPlan.restoreDir || dirPlan.restoreDirValidation === 'pending' || dirPlan.restoreDirValidation === 'invalid') {
     missing.push('restoreDir')
   }
@@ -2958,20 +2966,17 @@ function fmtBytes(n: number) {
 async function loadWizardSources(ids: string[]) {
   const realIds = normalizeSourceIdList(ids.filter(isBackupSelectableSourceId))
   if (!realIds.length) return
-  const list = await listBackupSelectableSources({ ids: realIds.join(',') })
+  const rows = await restoreTargetCatalog.ensureByIds(realIds)
   const next = new Map(realSourceById.value)
-  for (const row of list.results.map(mapSelectableSource)) next.set(row.id, row)
+  for (const row of rows.map(mapSelectableSource)) next.set(row.id, row)
   realSourceById.value = next
 }
 
-async function loadOnlineRecoveryTargets() {
-  const list = await listBackupSelectableSources({ page: 1, page_size: 500, availability: 'online' })
+watch(restoreTargetCatalog.allRecords, (records) => {
   const next = new Map(realSourceById.value)
-  for (const row of list.results.map(mapSelectableSource)) {
-    if (row.availability === 'online') next.set(row.id, row)
-  }
+  for (const row of records.map(mapSelectableSource)) next.set(row.id, row)
   realSourceById.value = next
-}
+}, { flush: 'sync' })
 
 async function refreshWizardTargets() {
   targetsRefreshing.value = true
@@ -3181,7 +3186,8 @@ async function openEditConfigs(configIds: number[], section: BackupConfigEditSec
   editConfigs.value = configs
   editSection.value = section
   const sourceIds = [...new Set(configs.map(sourceIdFromConfig))]
-  await loadWizardSources(sourceIds)
+  const savedTargetIds = configs.flatMap((config) => (config.recovery_plans || []).map(targetIdFromPlan)).filter(Boolean)
+  await loadWizardSources([...sourceIds, ...savedTargetIds])
   const existingSourceIds = sourceIds.filter((sourceId) => realSourceById.value.has(sourceId))
   if (!existingSourceIds.length) {
     ElMessage.error({ message: t('protection.backupsPage.msgSourceNoBackupConfig'), grouping: true })
@@ -3227,7 +3233,7 @@ onMounted(async () => {
   try {
     await Promise.all([
       loadWizardSources(sourceIds),
-      loadOnlineRecoveryTargets(),
+      restoreTargetCatalog.reset(),
       loadWizardReferences(),
     ])
   } catch (err) {
@@ -7530,9 +7536,15 @@ function preserveShallowestPathOrder(paths: string[]) {
                               :ref="(el) => setCreateRecoveryTargetSelectRef(group, dirPlan, el)"
                               :model-value="dirPlan.targetHostId"
                               filterable
+                              remote
+                              reserve-keyword
                               class="w-full"
+                              :remote-method="restoreTargetCatalog.setSearch"
+                              :loading="recoveryTargetLoading || recoveryTargetLoadingMore"
                               popper-class="create-recovery-target-node-select-popper"
                               :placeholder="t('protection.backupsPage.createRecoveryTargetHostPlaceholder')"
+                              @visible-change="onCreateRecoveryTargetVisible"
+                              @popup-scroll="onCreateRecoveryTargetPopupScroll"
                               @update:model-value="(value) => onCreateRecoveryTargetHostChange(group, dirPlan, value)"
                             >
                               <template #header>
@@ -7569,10 +7581,11 @@ function preserveShallowestPathOrder(paths: string[]) {
                                 </div>
                               </template>
                               <el-option
-                                v-for="option in createRecoveryTargetOptionsForGroup(group)"
+                                v-for="option in createRecoveryTargetOptionsForGroup(group, dirPlan)"
                                 :key="option.value"
                                 :label="option.label"
                                 :value="option.value"
+                                :disabled="!option.selectable"
                               >
                                 <div class="create-recovery-target-node-option">
                                   <div class="create-recovery-target-node-option__main">
@@ -7619,6 +7632,32 @@ function preserveShallowestPathOrder(paths: string[]) {
                                   </div>
                                 </div>
                               </el-option>
+                              <el-option
+                                v-if="recoveryTargetLoadingMore"
+                                key="create-recovery-target-loading-more"
+                                disabled
+                                value="__loading_more__"
+                                :label="t('common.loading')"
+                              />
+                              <el-option
+                                v-else-if="recoveryTargetError"
+                                key="create-recovery-target-load-more-error"
+                                disabled
+                                value="__load_more_error__"
+                                :label="t('protection.backupsPage.recoveryTargetLoadFailed')"
+                              >
+                                <ElButton link type="primary" @click.stop="restoreTargetCatalog.retry">
+                                  {{ t('common.retry') }}
+                                </ElButton>
+                              </el-option>
+                              <template #empty>
+                                <div class="py-3 text-center text-xs text-slate-500">
+                                  <span>{{ recoveryTargetError ? t('protection.backupsPage.recoveryTargetLoadFailed') : t('protection.backupsPage.recoveryTargetEmpty') }}</span>
+                                  <ElButton v-if="recoveryTargetError" link type="primary" @click.stop="restoreTargetCatalog.retry">
+                                    {{ t('common.retry') }}
+                                  </ElButton>
+                                </div>
+                              </template>
                             </el-select>
                           </div>
                           <div

--- a/src/frontend/src/pages/protection/DataProtection.vue
+++ b/src/frontend/src/pages/protection/DataProtection.vue
@@ -68,6 +68,7 @@ import { useNodeLifecycleOps } from '../../composables/useNodeLifecycleOps'
 import { flowSourceReadyStatus } from '../../lib/flowSourceDisplay'
 import { useResponsiveDrawerWidth } from '../../composables/useResponsiveDrawerWidth'
 import { usePageRequestScope } from '../../composables/usePageRequestScope'
+import { useRestoreTargetCatalog } from '../../composables/useRestoreTargetCatalog'
 import {
   useProtectionDemoStore,
   type DemoBackup,
@@ -1506,18 +1507,6 @@ function syncStep2WizardCountFromPipeline() {
   step2SelectableCount.value = pipelineStep2Count.value
 }
 
-async function ensureSelectableCatalog(ids: string[], signal?: AbortSignal) {
-  const missing = ids.filter((id) => isBackupSelectableId(id) && !backupSelectableById.value.has(id))
-  if (!missing.length) return
-  try {
-    const list = await listBackupSelectableSources({ ids: missing.join(',') }, { signal })
-    rememberSelectableRows(list.results.map(mapBackupSelectableToFlowRow))
-  } catch (e) {
-    if (pageRequests.isAbortError(e)) throw e
-    /* best-effort for step2 display */
-  }
-}
-
 async function refreshSelectableCatalog(ids: string[], signal?: AbortSignal) {
   const realIds = normalizeSourceIdList(ids.filter(isBackupSelectableId))
   if (!realIds.length) return
@@ -1743,6 +1732,7 @@ function openRecoveryWithBackupIds(backupIds: string[]) {
     ElMessage.warning({ message: t('protection.backupsPage.msgPickBackupForRecovery'), grouping: true })
     return
   }
+  void restoreTargetCatalog.ensureByIds(backupIds.map(backupSourceHostId).filter(Boolean))
   invalidateRecoverySnapshotLists(backupIds)
   recOpen.value = true
   ensureRecoveryNodes()
@@ -2055,15 +2045,14 @@ const proxyNodesRefreshing = ref(false)
 const recoveryNodeRows = ref<ApiNode[]>([])
 const recoveryNodeLoading = ref(false)
 const recoveryNodeLoaded = ref(false)
-const RECOVERY_TARGET_HOST_PAGE_SIZE = 100
-const recoveryTargetHostRows = ref<FlowSourceRow[]>([])
-const recoveryTargetHostCount = ref(0)
-const recoveryTargetHostPage = ref(0)
-const recoveryTargetHostSearch = ref('')
-const recoveryTargetHostLoading = ref(false)
-const recoveryTargetHostLoadingMore = ref(false)
-let recoveryTargetHostRequestSeq = 0
-let recoveryTargetHostSearchTimer: ReturnType<typeof setTimeout> | null = null
+const restoreTargetCatalog = useRestoreTargetCatalog()
+const recoveryTargetHostRows = computed(() => restoreTargetCatalog.rows.value.map(mapBackupSelectableToFlowRow))
+const recoveryTargetHostLoading = restoreTargetCatalog.loading
+const recoveryTargetHostLoadingMore = restoreTargetCatalog.loadingMore
+const recoveryTargetHostError = restoreTargetCatalog.error
+watch(restoreTargetCatalog.allRecords, (records) => {
+  rememberSelectableRows(records.map(mapBackupSelectableToFlowRow))
+}, { flush: 'sync' })
 const inlineEditorMode = computed<'recovery' | null>(() => {
   if (recOpen.value) return 'recovery'
   return null
@@ -2103,62 +2092,13 @@ function ensureRecoveryNodes() {
 }
 
 async function loadRecoveryTargetHostOptions(opts: { reset?: boolean } = {}) {
-  const reset = opts.reset === true
-  if (recoveryTargetHostLoading.value || recoveryTargetHostLoadingMore.value) return
-  const nextPage = reset ? 1 : recoveryTargetHostPage.value + 1
-  if (!reset && recoveryTargetHostCount.value > 0 && recoveryTargetHostRows.value.length >= recoveryTargetHostCount.value) return
-  const seq = ++recoveryTargetHostRequestSeq
-  if (reset) recoveryTargetHostLoading.value = true
-  else recoveryTargetHostLoadingMore.value = true
-  try {
-    const page = await listBackupSelectableSources({
-      page: nextPage,
-      page_size: RECOVERY_TARGET_HOST_PAGE_SIZE,
-      search: recoveryTargetHostSearch.value.trim(),
-      status: 'online',
-    })
-    if (seq !== recoveryTargetHostRequestSeq) return
-    const rows = page.results.map(mapBackupSelectableToFlowRow)
-    rememberSelectableRows(rows)
-    if (reset) {
-      recoveryTargetHostRows.value = rows
-    } else {
-      const merged = new Map(recoveryTargetHostRows.value.map((row) => [row.id, row]))
-      for (const row of rows) merged.set(row.id, row)
-      recoveryTargetHostRows.value = [...merged.values()]
-    }
-    recoveryTargetHostCount.value = page.count
-    recoveryTargetHostPage.value = nextPage
-  } catch (e) {
-    if (!pageRequests.isAbortError(e)) {
-      if (reset) recoveryTargetHostRows.value = []
-      if (reset) recoveryTargetHostCount.value = 0
-    }
-  } finally {
-    if (seq === recoveryTargetHostRequestSeq) {
-      // Keep the popper open until newly fetched options have registered with ElSelect.
-      await nextTick()
-      recoveryTargetHostLoading.value = false
-      recoveryTargetHostLoadingMore.value = false
-    }
-  }
+  if (opts.reset === true) await restoreTargetCatalog.reset()
+  else await restoreTargetCatalog.loadMore()
+  rememberSelectableRows(restoreTargetCatalog.allRecords.value.map(mapBackupSelectableToFlowRow))
 }
 
 function searchRecoveryTargetHostOptions(query: string) {
-  const normalizedQuery = query.trim()
-  if (normalizedQuery === recoveryTargetHostSearch.value) {
-    // Element Plus invokes remote-method with an empty query whenever the
-    // dropdown opens. Reuse the step's initial fetch instead of starting it again.
-    if (!recoveryTargetHostRows.value.length && !recoveryTargetHostLoading.value && !recoveryTargetHostLoadingMore.value) {
-      void loadRecoveryTargetHostOptions({ reset: true })
-    }
-    return
-  }
-  recoveryTargetHostSearch.value = normalizedQuery
-  if (recoveryTargetHostSearchTimer) clearTimeout(recoveryTargetHostSearchTimer)
-  recoveryTargetHostSearchTimer = setTimeout(() => {
-    void loadRecoveryTargetHostOptions({ reset: true })
-  }, 180)
+  restoreTargetCatalog.setSearch(query)
 }
 
 function onRecoveryTargetNodeSelectVisible(visible: boolean) {
@@ -2170,7 +2110,7 @@ function onRecoveryTargetNodePopupScroll(event: Event | { scrollTop?: number; cl
   const target = (event instanceof Event ? event.target : event) as HTMLElement | null
   if (!target) return
   const remaining = target.scrollHeight - target.scrollTop - target.clientHeight
-  if (remaining <= 48) void loadRecoveryTargetHostOptions()
+  if (remaining <= 48) void restoreTargetCatalog.loadMore()
 }
 
 async function refreshProxyNodesManually() {
@@ -2625,10 +2565,6 @@ onUnmounted(() => {
   if (taskSearchDebounceTimer) {
     clearTimeout(taskSearchDebounceTimer)
     taskSearchDebounceTimer = null
-  }
-  if (recoveryTargetHostSearchTimer) {
-    clearTimeout(recoveryTargetHostSearchTimer)
-    recoveryTargetHostSearchTimer = null
   }
   flowTableZoneObserver?.disconnect()
   flowTableZoneObserver = null
@@ -5601,7 +5537,8 @@ async function initializeFixedSnapshotRestore() {
     }
     fixedRestoreSnapshot.value = detail
     const sourceId = endpointUiId(detail.source_type, Number(detail.source_ref_id))
-    await ensureSelectableCatalog([sourceId])
+    await restoreTargetCatalog.ensureByIds([sourceId])
+    rememberSelectableRows(restoreTargetCatalog.allRecords.value.map(mapBackupSelectableToFlowRow))
 
     let config = backupConfigDetailById.value.get(Number(detail.backup_config_id))
     if (!config) {
@@ -6580,11 +6517,16 @@ type RecoveryTargetNodeOption = {
   sourceSummary: RecoverySourceSummary
   node?: ApiNode
   source?: FlowSourceRow
+  selectable: boolean
+  unavailableReason: 'offline' | 'busy' | null
 }
 
 const recRecoveryDestStepReady = computed(() => {
   if (!recBackupSourceGroups.value.length) return false
-  return recBackupSourceGroups.value.every((group) => !!recoveryDestConfiguredEntryForHost(group.hostId))
+  return recBackupSourceGroups.value.every((group) => {
+    const targetId = recoveryDestConfiguredEntryForHost(group.hostId)?.hostId || ''
+    return Boolean(targetId && restoreTargetCatalog.isSelectable(targetId))
+  })
 })
 
 const recRecoveryDestSourceRows = computed<RecRecoveryDestSourceRow[]>(() =>
@@ -6653,18 +6595,21 @@ function recoverySourceTargetOption(source: FlowSourceRow, sourceHostId: string)
     sourceType: source.type,
     sourceSummary,
     source,
+    selectable: restoreTargetCatalog.isSelectable(source.id),
+    unavailableReason: source.availability !== 'online' ? 'offline' : restoreTargetCatalog.isSelectable(source.id) ? null : 'busy',
   }
 }
 
 function recoveryOriginalTargetOptions(sourceHostId: string): RecoveryTargetNodeOption[] {
   const source = backupSelectableById.value.get(sourceHostId) ?? recoveryOriginalSourceById(sourceHostId)
-  if (!source || !flowSourceCanOperate(source)) return []
+  if (!source || !restoreTargetCatalog.isSelectable(sourceHostId)) return []
   return [recoverySourceTargetOption(source, sourceHostId)]
 }
 
 function recoveryTargetNodeOptionsForSource(sourceHostId: string): RecoveryTargetNodeOption[] {
-  return recoveryTargetHostRows.value
-    .map((source) => recoverySourceTargetOption(source, sourceHostId))
+  const currentTargetId = recoveryTargetNodeModelForSource(sourceHostId)
+  return restoreTargetCatalog.options([currentTargetId])
+    .map(({ source }) => recoverySourceTargetOption(mapBackupSelectableToFlowRow(source), sourceHostId))
 }
 
 
@@ -6710,6 +6655,7 @@ function setRecoveryTargetNodeForSource(hostId: string, optionValue: string | nu
     return
   }
   const value = String(optionValue)
+  if (!restoreTargetCatalog.isSelectable(value)) return
   const parsed = parseEndpointUiId(value)
   if (!parsed && !backupSelectableById.value.get(value)) return
   const entry: RecoveryDestinationEntry = {
@@ -8452,6 +8398,7 @@ function onRecoveryEntryModeChange(mode: string | number | boolean | undefined) 
 
 function applyRecoveryPlans(plans: RecoveryPlanSummary[]) {
   if (!plans.length) return
+  void restoreTargetCatalog.ensureByIds(plans.map((plan) => plan.destHostId).filter(Boolean))
   recBackupIds.value = uniqueBackupIds(plans.map((plan) => plan.backupId))
   recBackupId.value = plans[0].backupId
   recSnapshotMap.value = Object.fromEntries(plans.map((plan) => [plan.backupId, plan.snapshotId]))
@@ -11374,6 +11321,7 @@ async function runRecovery(mode: 'plan' | 'manual' = 'manual') {
                         :key="option.value"
                         :label="option.label"
                         :value="option.value"
+                        :disabled="!option.selectable"
                       >
                         <div class="recovery-target-node-option">
                           <div class="recovery-target-node-option__main">
@@ -11416,6 +11364,25 @@ async function runRecovery(mode: 'plan' | 'manual' = 'manual') {
                       >
                         <span class="recovery-target-node-option__loading">{{ t('common.loading') }}</span>
                       </el-option>
+                      <el-option
+                        v-else-if="recoveryTargetHostError"
+                        key="recovery-target-load-more-error"
+                        disabled
+                        value="__load_more_error__"
+                        :label="t('protection.backupsPage.recoveryTargetLoadFailed')"
+                      >
+                        <ElButton link type="primary" @click.stop="restoreTargetCatalog.retry">
+                          {{ t('common.retry') }}
+                        </ElButton>
+                      </el-option>
+                      <template #empty>
+                        <div class="py-3 text-center text-xs text-slate-500">
+                          <span>{{ recoveryTargetHostError ? t('protection.backupsPage.recoveryTargetLoadFailed') : t('protection.backupsPage.recoveryTargetEmpty') }}</span>
+                          <ElButton v-if="recoveryTargetHostError" link type="primary" @click.stop="restoreTargetCatalog.retry">
+                            {{ t('common.retry') }}
+                          </ElButton>
+                        </div>
+                      </template>
                     </el-select>
                   </div>
                 </template>

--- a/src/frontend/src/pages/protection/DataProtectionAvailabilityColumns.test.ts
+++ b/src/frontend/src/pages/protection/DataProtectionAvailabilityColumns.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from 'vitest'
 
 const page = readFileSync(resolve(process.cwd(), 'src/pages/protection/DataProtection.vue'), 'utf8')
 const createWizard = readFileSync(resolve(process.cwd(), 'src/pages/protection/BackupCreateWizard.vue'), 'utf8')
+const restoreTargetCatalog = readFileSync(resolve(process.cwd(), 'src/composables/useRestoreTargetCatalog.ts'), 'utf8')
 
 function tableForStep(step: number) {
   const startMarker = `<div v-if="flowMainStep === ${step}"`
@@ -69,11 +70,34 @@ describe('Backup Wizard availability columns', () => {
     expect(page).toContain('flowSourceAvailabilityLabel(row.availability)')
   })
 
+  it('delegates recovery targets to the shared online catalog', () => {
+    const start = page.indexOf('async function loadRecoveryTargetHostOptions')
+    const end = page.indexOf('function searchRecoveryTargetHostOptions', start)
+    const loader = page.slice(start, end)
+
+    expect(start).toBeGreaterThan(-1)
+    expect(end).toBeGreaterThan(start)
+    expect(loader).toContain('restoreTargetCatalog.reset()')
+    expect(loader).toContain('restoreTargetCatalog.loadMore()')
+    expect(loader).not.toContain("status: 'online'")
+    expect(restoreTargetCatalog).toContain("availability: 'online'")
+    expect(restoreTargetCatalog).toContain('page_size: RESTORE_TARGET_PAGE_SIZE')
+    expect(page).toContain(':remote-method="searchRecoveryTargetHostOptions"')
+    expect(page).toContain('@popup-scroll="onRecoveryTargetNodePopupScroll"')
+    expect(page).toContain('restoreTargetCatalog.ensureByIds(plans.map((plan) => plan.destHostId).filter(Boolean))')
+    expect(page).not.toContain('recoveryTargetHostRequestSeq')
+    expect(page).not.toContain('recoveryTargetHostSearchTimer')
+  })
+
   it('uses availability rather than lifecycle status for Backup Setup connectivity checks', () => {
     expect(createWizard).toContain("availability: item.availability === 'online' ? 'online' : 'offline'")
     expect(createWizard).toContain(".filter((row): row is NonNullable<ReturnType<typeof sourceRecord>> => row != null && row.availability !== 'online')")
     expect(createWizard).toContain("const availability = sourceRecord(sourceId)?.availability")
-    expect(createWizard).toContain("page: 1, page_size: 500, availability: 'online'")
+    expect(createWizard).toContain('const restoreTargetCatalog = useRestoreTargetCatalog()')
+    expect(createWizard).toContain('restoreTargetCatalog.reset()')
+    expect(createWizard).toContain(':remote-method="restoreTargetCatalog.setSearch"')
+    expect(createWizard).toContain('@popup-scroll="onCreateRecoveryTargetPopupScroll"')
+    expect(createWizard).not.toContain('loadOnlineRecoveryTargets')
     expect(createWizard).not.toContain("item.status === 'online' || item.status === 'reconnecting' ? item.status : 'offline'")
   })
 


### PR DESCRIPTION
## Problem and root cause

Restore Target discovery was implemented independently across the protection workflows. The standalone restore flow filtered the shared source catalog with `status=online`, even though connectivity is represented by `availability=online`, which excluded valid active Agent and NAS targets. The separate loaders also had inconsistent pagination, saved-target hydration, and failure behavior.

## Solution

- Add a shared restore-target catalog composable using the existing backup-selectable endpoint with online availability, remote search, paged loading, deduplication, stale-request cancellation, and retry handling.
- Use the shared catalog in Create Backup Configuration, Edit Restore Plan, Create New Restore Task, and Restore Snapshot.
- Hydrate source and saved target IDs explicitly, keep unavailable saved targets visible but disabled, and prevent unavailable targets from being submitted.
- Add focused catalog and page-contract regression coverage.

## Validation

- Focused Vitest coverage: 22 tests passed.
- Frontend lint: passed with 0 errors.
- Frontend test suite: 759 tests passed.
- Frontend CI test suite: 759 tests passed.
- TypeScript check and production build: passed.
- `git diff --check`: passed.
- English-source check: passed.
- Manual testing: passed.
- Post-sync product checks were skipped because both canonical-base rebases were conflict-free and range-diff confirmed an identical patch.

## Risks and compatibility

The change keeps the existing authenticated, organization-scoped endpoint and restore submission contracts. No backend, database, migration, or deployment behavior changes. The backend remains the final restore-target eligibility authority.

Fixes #391
