### PR TITLE
Show ProxyFS repository server address

### DIFF
--- a/src/frontend/src/locales/en.ts
+++ b/src/frontend/src/locales/en.ts
@@ -1828,6 +1828,7 @@ export const en = {
     phProxyNodeDir: '/proxy-data/backup-repo',
     hintProxyNodeDir: 'Enter an absolute path on the proxy node, which must be read/write for storing repository data. Recommended path format: /proxy-data/{repo-name}',
     fieldRepositoryServerHost: 'Repository Server Address',
+    repositoryServerHostNotConfigured: 'Not configured',
     phRepositoryServerHost: 'repo-proxy.example.internal',
     hintRepositoryServerHost: 'Optional for same-proxy use. For cross-proxy access, enter a reachable DNS name or IP address without a scheme, path, or port.',
     dirSelectTree: 'Tree Select',

--- a/src/frontend/src/pages/node/AddProxyFsRepository.vue
+++ b/src/frontend/src/pages/node/AddProxyFsRepository.vue
@@ -942,6 +942,12 @@ watch(enableQuotaAlert, (enabled) => {
               <div class="add-form-preview-section">
                 <h5 class="add-form-preview-section__title">{{ t('addS3Repo.previewConnection') }}</h5>
                 <div class="add-form-preview-row">
+                  <span class="add-form-preview-row__label">{{ t('repositoriesPage.fieldRepositoryServerHost') }}</span>
+                  <span class="add-form-preview-row__value" :class="{ 'add-form-preview-row__value--empty': !repositoryServerHost }">
+                    {{ repositoryServerHost || t('repositoriesPage.repositoryServerHostNotConfigured') }}
+                  </span>
+                </div>
+                <div class="add-form-preview-row">
                   <span class="add-form-preview-row__label">{{ t('repositoriesPage.fieldProxyNodeDir') }}</span>
                   <span class="add-form-preview-row__value" :class="{ 'add-form-preview-row__value--empty': !proxyNodeDir }">
                     {{ proxyNodeDir || '—' }}

--- a/src/frontend/src/pages/node/AddProxyFsRepositoryAvailability.test.ts
+++ b/src/frontend/src/pages/node/AddProxyFsRepositoryAvailability.test.ts
@@ -13,4 +13,9 @@ describe('Add Local Disk Repository proxy availability', () => {
   it('only offers proxy nodes whose availability is online', () => {
     expect(page).toContain("node.role === 'proxy' && node.availability === 'online'")
   })
+
+  it('includes the optional repository server address in the confirmation summary', () => {
+    expect(page).toContain("t('repositoriesPage.fieldRepositoryServerHost')")
+    expect(page).toContain("repositoryServerHost || t('repositoriesPage.repositoryServerHostNotConfigured')")
+  })
 })

--- a/src/frontend/src/pages/node/Repositories.vue
+++ b/src/frontend/src/pages/node/Repositories.vue
@@ -450,6 +450,7 @@ function mapApiToRow(r: ApiRepository): RepositoryRow {
         proxy_node_name: proxyNodeName || sourceNode.name,
         proxy_node_ip: proxyNodeIp || sourceNode.ip_address,
         proxy_node_dir: proxyNodeDir || loc,
+        proxy_repository_server_host: configString(config, 'proxy_repository_server_host'),
         quota_gb: configNumber(config, 'quota_gb') ?? 0,
         quota_alert_enabled: configBoolean(config, 'quota_alert_enabled') ?? false,
         quota_alert_threshold: configNumber(config, 'quota_alert_threshold') ?? 0,
@@ -1590,6 +1591,11 @@ function localDiskRepositoryPath(row: RepositoryRow) {
 function localDiskHostingProxyNode(row: RepositoryRow) {
   if (row.kind !== 'proxy_fs') return DETAIL_EMPTY
   return proxyNodeLabel(row) || DETAIL_EMPTY
+}
+
+function localDiskRepositoryServerHost(row: RepositoryRow) {
+  if (row.kind !== 'proxy_fs') return DETAIL_EMPTY
+  return row.config.proxy_repository_server_host || t('repositoriesPage.repositoryServerHostNotConfigured')
 }
 
 function nasRepoProxyIp(row: RepositoryRow) {
@@ -2995,6 +3001,10 @@ function s3ObjectPrefixCell(row: RepositoryRow) {
                   <div class="hfl-detail-row">
                     <span class="hfl-detail-row__label">{{ t('repositoriesPage.fieldProxyNodeDir') }}</span>
                     <span class="hfl-detail-row__value hfl-detail-row__value--mono">{{ localDiskRepositoryPath(detailRow) }}</span>
+                  </div>
+                  <div class="hfl-detail-row">
+                    <span class="hfl-detail-row__label">{{ t('repositoriesPage.fieldRepositoryServerHost') }}</span>
+                    <span class="hfl-detail-row__value hfl-detail-row__value--mono">{{ localDiskRepositoryServerHost(detailRow) }}</span>
                   </div>
                 </div>
               </section>


### PR DESCRIPTION
## Summary

- show the optional Repository Server Address in the ProxyFS creation confirmation
- preserve the address when mapping repository API data for the detail view
- display the configured address, or Not configured, in repository details
- add confirmation-summary regression coverage

## Testing

- `npm test -- --run src/pages/node/AddProxyFsRepositoryAvailability.test.ts`
- `npm run lint`
- `npm run build`

Closes #154
