### PR TITLE
Fix chat deletion deadlock when KS teardown waits on a deleting chat

### DIFF
--- a/src/backend/apps/lens_bridge/services/chat_lifecycle.py
+++ b/src/backend/apps/lens_bridge/services/chat_lifecycle.py
@@ -1097,28 +1097,89 @@ def _complete_copilot_chat_provision(
     )
 
 
+def _orphan_knowledge_source_needs_enqueue(knowledge_source_id: int) -> bool:
+    """Return True when no live lease or future retry already covers the KS."""
+    now = timezone.now()
+    knowledge_source = (
+        LensKnowledgeSource.all_objects.filter(pk=knowledge_source_id)
+        .only(
+            "id",
+            "lifecycle_status",
+            "teardown_claimed_at",
+            "teardown_next_retry_at",
+        )
+        .first()
+    )
+    if knowledge_source is None:
+        return False
+    if (
+        knowledge_source.lifecycle_status
+        == LensKnowledgeSource.LifecycleStatus.DELETED
+    ):
+        return False
+    if (
+        knowledge_source.teardown_claimed_at
+        and knowledge_source.teardown_claimed_at
+        > now - timedelta(seconds=TEARDOWN_CLAIM_TTL_SECONDS)
+    ):
+        return False
+    if (
+        knowledge_source.teardown_next_retry_at
+        and knowledge_source.teardown_next_retry_at > now
+    ):
+        return False
+    return True
+
+
+def _enqueue_orphan_knowledge_source_teardown(
+    knowledge_source_id: int,
+) -> None:
+    """Enqueue durable KS teardown when no backoff/lease already covers it."""
+    if not _orphan_knowledge_source_needs_enqueue(knowledge_source_id):
+        return
+    from apps.lens_bridge.services.knowledge_source_teardown import _queue_teardown
+
+    _queue_teardown(knowledge_source_id)
+
+
 def _cleanup_orphan_knowledge_source(
     knowledge_source: LensKnowledgeSource,
     *,
     owner_session_link_id: int,
 ) -> None:
-    """Durably tear down a KS that could not be attached to its Chat."""
-    try:
-        from apps.lens_bridge.services.knowledge_source_teardown import (
-            request_knowledge_source_teardown,
-            run_knowledge_source_teardown,
-        )
+    """Durably tear down a KS that could not be attached to its Chat.
 
-        request_knowledge_source_teardown(knowledge_source)
-        run_knowledge_source_teardown(
+    Prefer an owner-aware inline teardown. ``busy`` / ``scheduled`` already have
+    a live worker or a recorded ``teardown_next_retry_at`` for reconciler, so
+    they are not re-queued. Unexpected failures enqueue only when no live lease
+    or future retry is already recorded (avoids IncompleteError no-op Celery).
+    """
+    from apps.lens_bridge.services.knowledge_source_teardown import (
+        run_knowledge_source_teardown,
+    )
+
+    LensKnowledgeSource.all_objects.filter(pk=knowledge_source.id).exclude(
+        lifecycle_status=LensKnowledgeSource.LifecycleStatus.DELETED
+    ).update(
+        lifecycle_status=LensKnowledgeSource.LifecycleStatus.DELETING,
+        status_detail="Knowledge source deletion is queued.",
+        updated_at=timezone.now(),
+    )
+    try:
+        result = run_knowledge_source_teardown(
             knowledge_source_id=knowledge_source.id,
             owner_session_link_id=owner_session_link_id,
         )
+        status = str(result.get("status") or "")
+        if status in {"deleted", "busy", "scheduled"}:
+            return
+        raise RuntimeError("Knowledge Source teardown is " + status)
     except Exception:
         logger.exception(
             "orphan knowledge source cleanup deferred knowledge_source_id=%s",
             knowledge_source.id,
         )
+        _enqueue_orphan_knowledge_source_teardown(knowledge_source.id)
 
 
 @transaction.atomic

--- a/src/backend/apps/lens_bridge/services/knowledge_source_teardown.py
+++ b/src/backend/apps/lens_bridge/services/knowledge_source_teardown.py
@@ -30,6 +30,30 @@ class KnowledgeSourceTeardownBusyError(RuntimeError):
     """Raised when another worker owns the Knowledge Source lease."""
 
 
+def _session_links_blocking_ks_teardown(
+    knowledge_source: LensKnowledgeSource,
+    *,
+    owner_session_link_id: int | None = None,
+):
+    """Return chats that still own this KS and must be deleted first.
+
+    Chats already in ``deleting``/``deleted`` are not blockers: they are tearing
+    the KS down (or finished). Treating ``deleting`` as active caused a deadlock
+    when Chat teardown and standalone KS teardown raced — KS waited for Chat to
+    become ``deleted``, while Chat waited for KS teardown to finish.
+    """
+
+    blockers = knowledge_source.session_links.exclude(
+        lifecycle_status__in=(
+            LensSessionLink.LifecycleStatus.DELETED,
+            LensSessionLink.LifecycleStatus.DELETING,
+        )
+    )
+    if owner_session_link_id is not None:
+        blockers = blockers.exclude(pk=owner_session_link_id)
+    return blockers
+
+
 def _claimed_update(
     knowledge_source_id: int,
     claim_token: str,
@@ -70,9 +94,7 @@ def request_knowledge_source_teardown(
     """Persist deletion intent and enqueue it after the transaction commits."""
 
     locked = LensKnowledgeSource.objects.select_for_update().get(pk=knowledge_source.pk)
-    if locked.session_links.exclude(
-        lifecycle_status=LensSessionLink.LifecycleStatus.DELETED
-    ).exists():
+    if _session_links_blocking_ks_teardown(locked).exists():
         raise ValidationError(
             {"knowledge_source": "Delete the owning Chat before deleting this knowledge source."}
         )
@@ -261,12 +283,10 @@ def run_knowledge_source_teardown(
             raise ValidationError(
                 {"knowledge_source": "Data gateway restore work is still stopping."}
             )
-        blockers = knowledge_source.session_links.exclude(
-            lifecycle_status=LensSessionLink.LifecycleStatus.DELETED
-        )
-        if owner_session_link_id is not None:
-            blockers = blockers.exclude(pk=owner_session_link_id)
-        if blockers.exists():
+        if _session_links_blocking_ks_teardown(
+            knowledge_source,
+            owner_session_link_id=owner_session_link_id,
+        ).exists():
             raise ValidationError(
                 {"knowledge_source": "Knowledge source still belongs to an active Chat."}
             )

--- a/src/backend/apps/lens_bridge/tests/test_chat_teardown.py
+++ b/src/backend/apps/lens_bridge/tests/test_chat_teardown.py
@@ -301,6 +301,161 @@ class CopilotChatTeardownTests(TestCase):
         self.assertEqual(self.session.status, LensSessionLink.Status.ACTIVE)
         queue_teardown.assert_called_once_with(self.session.id)
 
+    @mock.patch(
+        "apps.lens_bridge.services.sync_queue.queue_knowledge_source_teardown"
+    )
+    def test_orphan_ks_cleanup_returns_without_enqueue_when_deleted(
+        self,
+        queue_ks_teardown,
+    ):
+        with mock.patch(
+            "apps.lens_bridge.services.knowledge_source_teardown."
+            "run_knowledge_source_teardown",
+            return_value={
+                "knowledge_source_id": self.knowledge_source.id,
+                "status": "deleted",
+            },
+        ) as run_teardown:
+            chat_lifecycle._cleanup_orphan_knowledge_source(
+                self.knowledge_source,
+                owner_session_link_id=self.session.id,
+            )
+
+        run_teardown.assert_called_once_with(
+            knowledge_source_id=self.knowledge_source.id,
+            owner_session_link_id=self.session.id,
+        )
+        queue_ks_teardown.assert_not_called()
+        self.knowledge_source.refresh_from_db()
+        self.assertEqual(
+            self.knowledge_source.lifecycle_status,
+            LensKnowledgeSource.LifecycleStatus.DELETING,
+        )
+
+    @mock.patch(
+        "apps.lens_bridge.services.sync_queue.queue_knowledge_source_teardown"
+    )
+    def test_orphan_ks_cleanup_does_not_enqueue_when_busy_or_scheduled(
+        self,
+        queue_ks_teardown,
+    ):
+        for status in ("busy", "scheduled"):
+            queue_ks_teardown.reset_mock()
+            with mock.patch(
+                "apps.lens_bridge.services.knowledge_source_teardown."
+                "run_knowledge_source_teardown",
+                return_value={
+                    "knowledge_source_id": self.knowledge_source.id,
+                    "status": status,
+                },
+            ):
+                chat_lifecycle._cleanup_orphan_knowledge_source(
+                    self.knowledge_source,
+                    owner_session_link_id=self.session.id,
+                )
+
+            queue_ks_teardown.assert_not_called()
+
+    @mock.patch(
+        "apps.lens_bridge.services.sync_queue.queue_knowledge_source_teardown"
+    )
+    def test_orphan_ks_cleanup_enqueues_when_inline_teardown_fails(
+        self,
+        queue_ks_teardown,
+    ):
+        with mock.patch(
+            "apps.lens_bridge.services.knowledge_source_teardown."
+            "run_knowledge_source_teardown",
+            side_effect=RuntimeError("SourceLens unavailable"),
+        ):
+            chat_lifecycle._cleanup_orphan_knowledge_source(
+                self.knowledge_source,
+                owner_session_link_id=self.session.id,
+            )
+
+        queue_ks_teardown.assert_called_once_with(
+            knowledge_source_id=self.knowledge_source.id
+        )
+
+    @mock.patch(
+        "apps.lens_bridge.services.sync_queue.queue_knowledge_source_teardown"
+    )
+    def test_orphan_ks_cleanup_skips_enqueue_when_retry_already_scheduled(
+        self,
+        queue_ks_teardown,
+    ):
+        def fail_and_schedule(**_kwargs):
+            LensKnowledgeSource.all_objects.filter(pk=self.knowledge_source.id).update(
+                teardown_next_retry_at=timezone.now() + timedelta(minutes=5),
+                teardown_claimed_at=None,
+                teardown_claim_token=None,
+                updated_at=timezone.now(),
+            )
+            raise RuntimeError("SourceLens unavailable")
+
+        with mock.patch(
+            "apps.lens_bridge.services.knowledge_source_teardown."
+            "run_knowledge_source_teardown",
+            side_effect=fail_and_schedule,
+        ):
+            chat_lifecycle._cleanup_orphan_knowledge_source(
+                self.knowledge_source,
+                owner_session_link_id=self.session.id,
+            )
+
+        queue_ks_teardown.assert_not_called()
+
+    @mock.patch(
+        "apps.lens_bridge.services.sync_queue.queue_knowledge_source_teardown"
+    )
+    def test_orphan_ks_cleanup_skips_enqueue_when_teardown_lease_is_live(
+        self,
+        queue_ks_teardown,
+    ):
+        def fail_with_live_claim(**_kwargs):
+            LensKnowledgeSource.all_objects.filter(pk=self.knowledge_source.id).update(
+                teardown_claimed_at=timezone.now(),
+                updated_at=timezone.now(),
+            )
+            raise RuntimeError("lease lost mid-teardown")
+
+        with mock.patch(
+            "apps.lens_bridge.services.knowledge_source_teardown."
+            "run_knowledge_source_teardown",
+            side_effect=fail_with_live_claim,
+        ):
+            chat_lifecycle._cleanup_orphan_knowledge_source(
+                self.knowledge_source,
+                owner_session_link_id=self.session.id,
+            )
+
+        queue_ks_teardown.assert_not_called()
+
+    @mock.patch(
+        "apps.lens_bridge.services.sync_queue.queue_knowledge_source_teardown",
+        side_effect=RuntimeError("broker unavailable"),
+    )
+    def test_orphan_ks_cleanup_records_queue_failure_on_status_detail(
+        self,
+        _queue_ks_teardown,
+    ):
+        with mock.patch(
+            "apps.lens_bridge.services.knowledge_source_teardown."
+            "run_knowledge_source_teardown",
+            side_effect=RuntimeError("SourceLens unavailable"),
+        ):
+            chat_lifecycle._cleanup_orphan_knowledge_source(
+                self.knowledge_source,
+                owner_session_link_id=self.session.id,
+            )
+
+        self.knowledge_source.refresh_from_db()
+        self.assertIn(
+            "waiting for the worker queue",
+            self.knowledge_source.status_detail.lower(),
+        )
+        self.assertIn("broker unavailable", self.knowledge_source.status_detail)
+
     @mock.patch("apps.lens_bridge.services.assistant_access.soft_delete_assistant_link")
     @mock.patch("apps.lens_bridge.services.assistants._delete_sl_assistant")
     @mock.patch("apps.node.services.internal.agent_task.run_agent_task_sync")

--- a/src/backend/apps/lens_bridge/tests/test_knowledge_source_teardown.py
+++ b/src/backend/apps/lens_bridge/tests/test_knowledge_source_teardown.py
@@ -117,6 +117,95 @@ class KnowledgeSourceDeleteApiTests(TestCase):
         self.assertEqual(response.status_code, 400)
 
     @mock.patch(
+        "apps.lens_bridge.tasks.knowledge_source_teardown."
+        "execute_knowledge_source_teardown_task.delay"
+    )
+    def test_direct_delete_allowed_when_owning_chat_is_already_deleting(
+        self, delay
+    ):
+        LensSessionLink.objects.create(
+            organization=self.organization,
+            hfl_user=self.user,
+            gateway_link=self.gateway_link,
+            knowledge_source=self.knowledge_source,
+            lifecycle_status=LensSessionLink.LifecycleStatus.DELETING,
+        )
+
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.delete(
+                reverse(
+                    "lens-knowledge-source-detail",
+                    kwargs={"pk": self.knowledge_source.id},
+                ),
+                HTTP_X_ORG_KEY=self.organization.key,
+            )
+
+        self.assertEqual(response.status_code, 202)
+        delay.assert_called_once_with(
+            knowledge_source_id=self.knowledge_source.id
+        )
+
+    @mock.patch(
+        "apps.node.services.internal.node_workload.get_node_workload_blockers",
+        return_value=[],
+    )
+    def test_standalone_teardown_proceeds_while_owner_chat_is_deleting(
+        self, _blockers
+    ):
+        """Chat+KS teardown race must not deadlock on a deleting owner chat."""
+        LensSessionLink.objects.create(
+            organization=self.organization,
+            hfl_user=self.user,
+            gateway_link=self.gateway_link,
+            knowledge_source=self.knowledge_source,
+            lifecycle_status=LensSessionLink.LifecycleStatus.DELETING,
+        )
+        self.knowledge_source.lifecycle_status = (
+            LensKnowledgeSource.LifecycleStatus.DELETING
+        )
+        self.knowledge_source.save(
+            update_fields=["lifecycle_status", "updated_at"]
+        )
+
+        result = knowledge_source_teardown.run_knowledge_source_teardown(
+            knowledge_source_id=self.knowledge_source.id
+        )
+
+        self.assertEqual(result["status"], "deleted")
+        self.knowledge_source.refresh_from_db()
+        self.assertTrue(self.knowledge_source.is_deleted)
+
+    @mock.patch(
+        "apps.node.services.internal.node_workload.get_node_workload_blockers",
+        return_value=[],
+    )
+    def test_standalone_teardown_still_blocked_by_ready_chat(self, _blockers):
+        LensSessionLink.objects.create(
+            organization=self.organization,
+            hfl_user=self.user,
+            gateway_link=self.gateway_link,
+            knowledge_source=self.knowledge_source,
+            lifecycle_status=LensSessionLink.LifecycleStatus.READY,
+        )
+        self.knowledge_source.lifecycle_status = (
+            LensKnowledgeSource.LifecycleStatus.DELETING
+        )
+        self.knowledge_source.save(
+            update_fields=["lifecycle_status", "updated_at"]
+        )
+
+        with self.assertRaises(
+            knowledge_source_teardown.KnowledgeSourceTeardownIncompleteError
+        ) as ctx:
+            knowledge_source_teardown.run_knowledge_source_teardown(
+                knowledge_source_id=self.knowledge_source.id
+            )
+
+        self.assertIn("active Chat", str(ctx.exception))
+        self.knowledge_source.refresh_from_db()
+        self.assertFalse(self.knowledge_source.is_deleted)
+
+    @mock.patch(
         "apps.lens_bridge.tasks.chat_lifecycle."
         "execute_copilot_chat_teardown_task.delay"
     )


### PR DESCRIPTION
## Summary
- Treat chats already in `deleting`/`deleted` as non-blockers for knowledge-source teardown so Chat and KS workers cannot deadlock.
- Prefer owner-aware orphan KS cleanup and enqueue durable follow-up only when no live lease or future retry already covers the KS.
- Add regression coverage for the deadlock path and orphan enqueue control flow.

## Test plan
- [x] `apps.lens_bridge.tests.test_knowledge_source_teardown.KnowledgeSourceDeleteApiTests`
- [x] Orphan KS cleanup cases in `apps.lens_bridge.tests.test_chat_teardown.CopilotChatTeardownTests`
- [ ] After merge/deploy, confirm stuck production `.codex` deleting chats converge via reconciler


Made with [Cursor](https://cursor.com)