### PR TITLE
Fix CentOS 7 enrollment bootstrap failure with empty CURL_TLS under set -u

### DIFF
--- a/.github/workflows/artifact_pipeline.yml
+++ b/.github/workflows/artifact_pipeline.yml
@@ -234,6 +234,7 @@ jobs:
           ./tools/quality/check-release-contracts.sh
           ./tools/quality/test-default-certificates.sh
           ./tools/quality/test-bootstrap-download-progress.sh
+          HFL_TEST_BASH42=1 ./tools/quality/test-bootstrap-curl-tls-nounset.sh
           ./tools/quality/test-gateway-bootstrap-health.sh
           ./tools/quality/test-gateway-lifecycle-upgrade.sh
           ./tools/quality/test-platform-gateway-auto-deploy.sh

--- a/deploy/bootstrap/agent-bootstrap-linux.sh
+++ b/deploy/bootstrap/agent-bootstrap-linux.sh
@@ -52,7 +52,8 @@ hfl_download() {
 	local started=${SECONDS} elapsed bytes rate
 	rm -f "${partial}"
 	hfl_step "Downloading ${label}."
-	if ! curl "${CURL_TLS[@]}" \
+	# ${arr[@]+...} keeps empty CURL_TLS safe under `set -u` on Bash < 4.4 (CentOS 7).
+	if ! curl ${CURL_TLS[@]+"${CURL_TLS[@]}"} \
 		--fail --show-error --location --progress-bar \
 		--retry 3 --retry-connrefused --retry-delay 2 \
 		"${url}" -o "${partial}"; then

--- a/deploy/bootstrap/agent-bootstrap-macos.sh
+++ b/deploy/bootstrap/agent-bootstrap-macos.sh
@@ -52,7 +52,8 @@ hfl_download() {
 	local started=${SECONDS} elapsed bytes rate
 	rm -f "${partial}"
 	hfl_step "Downloading ${label}."
-	if ! curl "${CURL_TLS[@]}" \
+	# ${arr[@]+...} keeps empty CURL_TLS safe under `set -u` on Bash < 4.4.
+	if ! curl ${CURL_TLS[@]+"${CURL_TLS[@]}"} \
 		--fail --show-error --location --progress-bar \
 		--retry 3 --retry-connrefused --retry-delay 2 \
 		"${url}" -o "${partial}"; then

--- a/deploy/bootstrap/gateway-bootstrap-linux.sh
+++ b/deploy/bootstrap/gateway-bootstrap-linux.sh
@@ -62,7 +62,8 @@ hfl_download() {
 	local started=${SECONDS} elapsed bytes rate
 	rm -f "${partial}"
 	hfl_step "Downloading ${label}."
-	if ! curl "${CURL_TLS[@]}" \
+	# ${arr[@]+...} keeps empty CURL_TLS safe under `set -u` on Bash < 4.4 (CentOS 7).
+	if ! curl ${CURL_TLS[@]+"${CURL_TLS[@]}"} \
 		--fail --show-error --location --progress-bar \
 		--retry 3 --retry-connrefused --retry-delay 2 \
 		"${url}" -o "${partial}"; then

--- a/deploy/bootstrap/gateway-install-docker-ubuntu-amd64.sh
+++ b/deploy/bootstrap/gateway-install-docker-ubuntu-amd64.sh
@@ -56,7 +56,8 @@ hfl_download() {
 	local started=${SECONDS} elapsed bytes rate
 	rm -f "${partial}"
 	hfl_step "Downloading ${label}."
-	if ! curl "${CURL_TLS[@]}" \
+	# ${arr[@]+...} keeps empty CURL_TLS safe under `set -u` on Bash < 4.4.
+	if ! curl ${CURL_TLS[@]+"${CURL_TLS[@]}"} \
 		--fail --show-error --location --progress-bar \
 		--retry 3 --retry-connrefused --retry-delay 2 \
 		"${url}" -o "${partial}"; then

--- a/deploy/bootstrap/gateway-install-lensnode-sidecar.sh
+++ b/deploy/bootstrap/gateway-install-lensnode-sidecar.sh
@@ -98,7 +98,8 @@ if [[ "${HFL_INSECURE_TLS}" == "0" ]]; then
 fi
 
 hfl_step "Verifying SourceLens connectivity at ${LENS_HOST_URL}."
-curl "${CURL_TLS[@]}" -fsSL "${LENS_HOST_URL%/}/health" >/dev/null
+# ${arr[@]+...} keeps empty CURL_TLS safe under `set -u` on Bash < 4.4 (CentOS 7).
+curl ${CURL_TLS[@]+"${CURL_TLS[@]}"} -fsSL "${LENS_HOST_URL%/}/health" >/dev/null
 hfl_ok "SourceLens health check passed."
 
 hfl_step "Preparing Gateway workspace mounts for LensNode."
@@ -133,7 +134,7 @@ prepare_sentry_privacy_adapter() {
 		SENTRY_BACKEND_DSN=
 		return 0
 	fi
-	if ! curl "${CURL_TLS[@]}" -fsSL \
+	if ! curl ${CURL_TLS[@]+"${CURL_TLS[@]}"} -fsSL \
 		"${base%/}/media/gateway-bootstrap/hfl-sentry-sitecustomize.py" \
 		-o "${temporary}" \
 		|| ! grep -Fx '# HFL_SENTRY_PRIVACY_ADAPTER=1' "${temporary}" >/dev/null; then

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -934,6 +934,29 @@ for bootstrap in "${gateway_bootstrap_linux}" "${gateway_docker_installer}"; do
 	grep -F -- '--retry 3 --retry-connrefused --retry-delay 2' "${bootstrap}" >/dev/null
 	grep -F 'partial="${destination}.part"' "${bootstrap}" >/dev/null
 done
+# CentOS 7 / Bash < 4.4: empty CURL_TLS + set -u requires ${arr[@]+"${arr[@]}"} (not "${arr[@]}").
+for bootstrap in \
+	"${agent_bootstrap_linux}" \
+	"${agent_bootstrap_macos}" \
+	"${gateway_bootstrap_linux}" \
+	"${gateway_docker_installer}" \
+	"${gateway_sidecar_installer}"; do
+	safe_count="$(grep -cF '${CURL_TLS[@]+"${CURL_TLS[@]}"}' "${bootstrap}" || true)"
+	quoted_count="$(grep -oE '"\$\{CURL_TLS\[@\]\}"' "${bootstrap}" | wc -l | tr -d ' ')"
+	if [[ "${safe_count}" -lt 1 || "${safe_count}" -ne "${quoted_count}" ]]; then
+		printf 'ERROR: %s must expand CURL_TLS via \${CURL_TLS[@]+\"\${CURL_TLS[@]}\"} only (safe=%s quoted=%s)\n' \
+			"${bootstrap}" "${safe_count}" "${quoted_count}" >&2
+		exit 1
+	fi
+done
+# Quality must run the Bash 4.2 probe (not host-smoke-only).
+# Require an active run line; a commented-out copy must not satisfy this gate.
+if ! grep -E '^[[:space:]]+HFL_TEST_BASH42=1 \./tools/quality/test-bootstrap-curl-tls-nounset\.sh[[:space:]]*$' \
+	"${ROOT}/.github/workflows/artifact_pipeline.yml" >/dev/null; then
+	printf 'ERROR: artifact_pipeline Quality must run HFL_TEST_BASH42=1 ./tools/quality/test-bootstrap-curl-tls-nounset.sh\n' >&2
+	exit 1
+fi
+
 grep -F 'HyperFileLens enrollment helper' "${gateway_bootstrap_linux}" >/dev/null
 grep -F 'gateway-install' "${gateway_bootstrap_linux}" >/dev/null
 grep -F 'requires a systemd-based Linux distribution' "${gateway_bootstrap_linux}" >/dev/null
@@ -1198,6 +1221,7 @@ for executable in \
 	"${ROOT}/.github/scripts/remote-deploy.sh" \
 	"${ROOT}/tools/quality/check-python38-runtime.py" \
 	"${ROOT}/tools/quality/test-docker-pull-retry.sh" \
+	"${ROOT}/tools/quality/test-bootstrap-curl-tls-nounset.sh" \
 	"${ROOT}/tools/quality/test-gh-release-upload-retry.sh" \
 	"${ROOT}/release/ci/gh-release-upload.sh" \
 	"${ROOT}/tools/quality/test-main-channel-contracts.sh" \

--- a/tools/quality/test-bootstrap-curl-tls-nounset.sh
+++ b/tools/quality/test-bootstrap-curl-tls-nounset.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Regression for empty CURL_TLS under `set -u` (CentOS 7 / Bash < 4.4).
+#
+# Always:
+#   1) host smoke that hfl_download works with CURL_TLS=()
+#   2) source contract that agent bootstrap uses the Bash < 4.4-safe expansion
+# When HFL_TEST_BASH42=1 (Quality CI sets this):
+#   3) run the same expansion checks inside Docker bash:4.2
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+# shellcheck source=../lib/docker-images.sh
+source "${ROOT}/tools/lib/docker-images.sh"
+
+bootstrap="${ROOT}/deploy/bootstrap/agent-bootstrap-linux.sh"
+
+grep -F '${CURL_TLS[@]+"${CURL_TLS[@]}"}' "${bootstrap}" >/dev/null
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "${tmp}"' EXIT
+mkdir -p "${tmp}/bin"
+
+cat >"${tmp}/bin/curl" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+output=""
+while (($#)); do
+	case "$1" in
+	-o)
+		output=${2-}
+		shift 2
+		;;
+	*) shift ;;
+	esac
+done
+[[ -n "${output}" ]] || exit 2
+printf 'nounset-fixture\n' >"${output}"
+SH
+chmod +x "${tmp}/bin/curl"
+
+# Host Bash smoke: empty CURL_TLS must still drive hfl_download successfully.
+source <(sed -n '/^hfl_now()/,/^hfl_build_enroll_args()/p' "${bootstrap}" | sed '$d')
+CURL_TLS=()
+PATH="${tmp}/bin:${PATH}"
+export PATH
+destination="${tmp}/hfl-enroll"
+hfl_download "HyperFileLens enrollment helper" https://example.invalid/helper "${destination}" >/dev/null
+grep -Fx 'nounset-fixture' "${destination}" >/dev/null
+
+# CentOS 7 class probe. Quality CI sets HFL_TEST_BASH42=1.
+if [[ "${HFL_TEST_BASH42:-0}" == "1" ]]; then
+	if ! command -v docker >/dev/null 2>&1 || ! docker info >/dev/null 2>&1; then
+		printf 'ERROR: HFL_TEST_BASH42=1 requires a working docker daemon.\n' >&2
+		exit 1
+	fi
+	# Pull with the shared retry helper so Hub blips do not flake Quality.
+	if ! hfl_docker_pull_with_retry bash:4.2 "" 180 3 5; then
+		printf 'ERROR: failed to pull bash:4.2: %s\n' "${HFL_DOCKER_LAST_ERROR:-unknown error}" >&2
+		exit 1
+	fi
+	cat >"${tmp}/probe.sh" <<'SH'
+set -euo pipefail
+CURL_TLS=()
+# Old unsafe form must fail on Bash 4.2.
+if (set +e; set -u; : "${CURL_TLS[@]}"; status=$?; set +u; exit "${status}") 2>/dev/null; then
+	echo "ERROR: expected Bash 4.2 unbound failure for \"\${CURL_TLS[@]}\"" >&2
+	exit 1
+fi
+# Fixed form must succeed for empty and -k.
+curl_args=(${CURL_TLS[@]+"${CURL_TLS[@]}"})
+[[ "${#curl_args[@]}" -eq 0 ]]
+CURL_TLS=(-k)
+curl_args=(${CURL_TLS[@]+"${CURL_TLS[@]}"})
+[[ "${#curl_args[@]}" -eq 1 && "${curl_args[0]}" == "-k" ]]
+printf 'ok\n'
+SH
+	docker run --rm -v "${tmp}/probe.sh:/probe.sh:ro" bash:4.2 \
+		bash /probe.sh >/dev/null
+	printf 'Bash 4.2 empty CURL_TLS probe passed.\n'
+fi
+
+printf 'Bootstrap CURL_TLS nounset checks passed.\n'


### PR DESCRIPTION
## Summary
- Expand empty `CURL_TLS` with Bash &lt; 4.4-safe `${arr[@]+"${arr[@]}"}` so CentOS 7 Agent/Gateway enrollment no longer dies under `set -u` when TLS verification is on.
- Add Quality regression coverage: host smoke, Docker Bash 4.2 probe (`HFL_TEST_BASH42=1`), release-contract gates for the safe expansion and active CI workflow line.

## Test plan
- [x] `./tools/quality/test-bootstrap-download-progress.sh`
- [x] `./tools/quality/test-bootstrap-curl-tls-nounset.sh`
- [x] `HFL_TEST_BASH42=1 ./tools/quality/test-bootstrap-curl-tls-nounset.sh`
- [x] Contract checks for safe `CURL_TLS` expansion and uncommented `HFL_TEST_BASH42=1` workflow line
- [ ] CI Quality job on this PR


Made with [Cursor](https://cursor.com)