### PR TITLE
Improve backup schedule timezone picker

### DIFF
--- a/src/frontend/src/lib/protectionPolicyFormModel.test.ts
+++ b/src/frontend/src/lib/protectionPolicyFormModel.test.ts
@@ -3,6 +3,7 @@ import type { BackupPolicy } from './protectionPolicyApi'
 import {
   backupPolicyToForm,
   createEmptyPolicyForm,
+  getScheduleTimezoneOptions,
   policyFormToWritePayload,
   quickScheduleToCron,
   summarizeSchedule,
@@ -45,6 +46,19 @@ function policyWithSchedule(schedule: BackupPolicy['schedule']): BackupPolicy {
 }
 
 describe('protection policy schedule mapping', () => {
+  it('labels timezones with their current GMT offsets and sorts by offset', () => {
+    const options = getScheduleTimezoneOptions('Asia/Shanghai', new Date('2026-08-08T00:00:00Z'))
+    const shanghai = options.find((option) => option.value === 'Asia/Shanghai')
+    const newYork = options.find((option) => option.value === 'America/New_York')
+    const utc = options.find((option) => option.value === 'UTC')
+
+    expect(shanghai).toMatchObject({ label: '(GMT+08:00) Asia/Shanghai', offsetMinutes: 480 })
+    expect(newYork).toMatchObject({ label: '(GMT-04:00) America/New_York', offsetMinutes: -240 })
+    expect(utc).toMatchObject({ label: '(GMT+00:00) UTC', offsetMinutes: 0 })
+    expect(options.indexOf(newYork!)).toBeLessThan(options.indexOf(utc!))
+    expect(options.indexOf(utc!)).toBeLessThan(options.indexOf(shanghai!))
+  })
+
   it('serializes hour and day intervals through the shared mapper', () => {
     const form = createEmptyPolicyForm()
     form.scheduleTimezone = 'UTC'

--- a/src/frontend/src/lib/protectionPolicyFormModel.ts
+++ b/src/frontend/src/lib/protectionPolicyFormModel.ts
@@ -22,13 +22,58 @@ export type ScheduleWeekday = 1 | 2 | 3 | 4 | 5 | 6 | 7
 const SCHEDULE_TIME_RE = /^([01]\d|2[0-3]):([0-5]\d)$/
 const SCHEDULE_START_RE = /^\d{4}-\d{2}-\d{2}T([01]\d|2[0-3]):([0-5]\d)$/
 
-export function getScheduleTimezoneOptions(): string[] {
+export interface ScheduleTimezoneOption {
+  value: string
+  label: string
+  offsetMinutes: number
+}
+
+function timezoneOffsetMinutes(timezoneName: string, now: Date): number | null {
+  try {
+    const offset = new Intl.DateTimeFormat('en-US', {
+      timeZone: timezoneName,
+      timeZoneName: 'longOffset',
+    }).formatToParts(now).find((part) => part.type === 'timeZoneName')?.value
+    if (offset === 'GMT') return 0
+    const matched = /^GMT([+-])(\d{1,2}):(\d{2})$/.exec(offset || '')
+    if (!matched) return null
+    const minutes = Number(matched[2]) * 60 + Number(matched[3])
+    return matched[1] === '-' ? -minutes : minutes
+  } catch {
+    return null
+  }
+}
+
+function formatTimezoneOffset(offsetMinutes: number): string {
+  const sign = offsetMinutes < 0 ? '-' : '+'
+  const absoluteMinutes = Math.abs(offsetMinutes)
+  const hours = String(Math.floor(absoluteMinutes / 60)).padStart(2, '0')
+  const minutes = String(absoluteMinutes % 60).padStart(2, '0')
+  return `GMT${sign}${hours}:${minutes}`
+}
+
+export function getScheduleTimezoneOptions(
+  selectedTimezone?: string,
+  now = new Date(),
+): ScheduleTimezoneOption[] {
   const supportedValuesOf = (
     Intl as typeof Intl & { supportedValuesOf?: (key: 'timeZone') => string[] }
   ).supportedValuesOf
   const browserTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC'
   const values = supportedValuesOf ? supportedValuesOf('timeZone') : []
-  return [...new Set(['UTC', browserTimezone, ...values])]
+  return [...new Set(['UTC', browserTimezone, selectedTimezone, ...values].filter(Boolean))]
+    .map((value) => {
+      const offsetMinutes = timezoneOffsetMinutes(value, now)
+      return {
+        value,
+        label: offsetMinutes === null ? value : `(${formatTimezoneOffset(offsetMinutes)}) ${value}`,
+        offsetMinutes: offsetMinutes ?? Number.POSITIVE_INFINITY,
+      }
+    })
+    .sort((left, right) => (
+      left.offsetMinutes - right.offsetMinutes
+      || (left.value === 'UTC' ? -1 : right.value === 'UTC' ? 1 : left.value.localeCompare(right.value))
+    ))
 }
 
 function defaultScheduleTimezone(): string {

--- a/src/frontend/src/pages/protection/components/ProtectionPolicyEditorForm.vue
+++ b/src/frontend/src/pages/protection/components/ProtectionPolicyEditorForm.vue
@@ -40,7 +40,7 @@ const { t } = useI18n()
 const router = useRouter()
 const messageLocale = computed<MessageLocale>(() => 'en')
 const simpleIntervalOptions = computed(() => getSimpleIntervalUnitOptions(messageLocale.value))
-const scheduleTimezoneOptions = computed(() => getScheduleTimezoneOptions())
+const scheduleTimezoneOptions = computed(() => getScheduleTimezoneOptions(policyForm.value.scheduleTimezone))
 const quickScheduleTypeOptions = computed(() => [
   { value: 'interval' as const, label: t('protection.policiesPage.scheduleTypeInterval') },
   { value: 'daily' as const, label: t('protection.policiesPage.scheduleTypeDaily') },
@@ -336,10 +336,10 @@ function toggleScheduleMonthDay(day: number) {
               :placeholder="t('protection.policiesPage.scheduleTimezonePlaceholder')"
             >
               <el-option
-                v-for="timezoneName in scheduleTimezoneOptions"
-                :key="timezoneName"
-                :label="timezoneName"
-                :value="timezoneName"
+                v-for="timezone in scheduleTimezoneOptions"
+                :key="timezone.value"
+                :label="timezone.label"
+                :value="timezone.value"
               />
             </el-select>
           </ElFormItem>
@@ -953,7 +953,7 @@ function toggleScheduleMonthDay(day: number) {
 }
 
 .schedule-interval-unit {
-  width: 200px;
+  width: 240px !important;
 }
 
 .schedule-picker-block {

--- a/src/frontend/src/pages/protection/components/ProtectionPolicyScheduleEditor.test.ts
+++ b/src/frontend/src/pages/protection/components/ProtectionPolicyScheduleEditor.test.ts
@@ -20,6 +20,7 @@ describe('protection policy quick schedule editor', () => {
     expect(editorSource).toContain('policyForm.scheduleMonthDays.includes(day)')
     expect(editorSource).toContain('v-model="policyForm.scheduleTime"')
     expect(editorSource).toContain("policyForm.scheduleMonthEnd = !policyForm.scheduleMonthEnd")
+    expect(editorSource).toContain('.schedule-interval-unit {\n  width: 240px !important;')
   })
 
   it('uses the shared policy payload mapper in the backup wizard', () => {


### PR DESCRIPTION
## Summary
- Show each backup schedule timezone with its current GMT offset and sort choices by offset
- Preserve saved IANA timezone values while widening the repeat interval selector
- Add picker and layout regression coverage

## Testing
- npm run test -- src/lib/protectionPolicyFormModel.test.ts src/pages/protection/components/ProtectionPolicyScheduleEditor.test.ts
- npm run build

Closes #422