### PR TITLE
feat: bake Open Core extensions into release control-plane images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,6 +10,9 @@ build/**
 !build/kopia/dist/linux/amd64/kopia
 !build/website/
 !build/website/**
+!build/release/
+!build/release/extensions/
+!build/release/extensions/**
 logs
 *.log
 node_modules

--- a/.env.example
+++ b/.env.example
@@ -119,15 +119,12 @@ HFL_ADMIN_PORT=11444
 # ------------------------------------------------------------------------------
 # Extensions / plugins (optional; Open Core Host socket)
 # ------------------------------------------------------------------------------
-# Prepare-stage sources for stack.sh (local path or git URL[+@ref]). Comma-separated.
-# Example (local checkout of a commercial plugin — path is yours, not a Host default):
-# HFL_EXTENSION_SOURCES=../my-hfl-plugin
-HFL_EXTENSION_SOURCES=
-
-# Runtime: already-materialized extension roots (comma-separated). Usually set by
-# stack.sh from SOURCES; containers receive /opt/hfl/extensions/<id> paths.
-# Empty = Community (empty socket).
-HFL_EXTENSIONS=
+# Do not put HFL_EXTENSION_SOURCES in this file — that is prepare/packaging only:
+#   ./dev/stack.sh up --extension-source ../hyperfilelens-ee
+#   ./release/build.sh --extension-source ../hyperfilelens-ee
+#   CI: repository Variable HFL_EXTENSION_SOURCES (+ Secret HFL_EXTENSION_GIT_TOKEN)
+# Runtime HFL_EXTENSIONS belongs on the image / compose overlay, not in dev .env.
+# Enterprise release packages may ship HFL_EXTENSIONS=/opt/hfl/extensions/<id>.
 
 # Canonical browser URL used in redirects, email links, and gateway enrollment.
 FRONTEND_URL=https://127.0.0.1:11443

--- a/.github/workflows/artifact_pipeline.yml
+++ b/.github/workflows/artifact_pipeline.yml
@@ -354,6 +354,34 @@ jobs:
             --image-tag "hyperfilelens-website-builder:${GITHUB_RUN_ID}" \
             --platform linux/amd64
 
+      - name: Materialize Open Core extensions for image bake
+        env:
+          HFL_EXTENSION_SOURCES: ${{ vars.HFL_EXTENSION_SOURCES }}
+          HFL_EXTENSION_GIT_TOKEN: ${{ secrets.HFL_EXTENSION_GIT_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p build/release/extensions
+          : >build/release/extensions/.gitkeep
+          if [[ -z "${HFL_EXTENSION_SOURCES// }" ]]; then
+            echo "HFL_EXTENSIONS=" >>"${GITHUB_ENV}"
+            echo "Community bake: HFL_EXTENSION_SOURCES empty"
+            exit 0
+          fi
+          # Prefer packaging secret for private plugin repos; do not fall back to
+          # github.token (that token cannot clone other private repositories).
+          # Scope to HFL_EXTENSION_GIT_TOKEN only (materialize reads it first).
+          exts="$(
+            HFL_EXTENSION_GIT_TOKEN="${HFL_EXTENSION_GIT_TOKEN:-}" \
+              python3 tools/extensions/materialize_extensions.py \
+              --repo-root . \
+              --sources "${HFL_EXTENSION_SOURCES}" \
+              --bake-dir build/release/extensions \
+              --print-extensions
+          )"
+          echo "HFL_EXTENSIONS=${exts}" >>"${GITHUB_ENV}"
+          echo "Enterprise bake: HFL_EXTENSIONS=${exts}"
+
       - name: Build and push image
         id: build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
@@ -374,6 +402,7 @@ jobs:
             SENTRY_FRONTEND_PROJECT=${{ vars.SENTRY_FRONTEND_PROJECT }}
             SENTRY_RELEASE=hyperfilelens-frontend@${{ needs.prepare.outputs.version }}
             VITE_SHOW_EULA=false
+            HFL_EXTENSIONS=${{ env.HFL_EXTENSIONS }}
           secrets: ${{ matrix.component == 'hfl-frontend' && secrets.SENTRY_AUTH_TOKEN != '' && format('sentry_auth_token={0}', secrets.SENTRY_AUTH_TOKEN) || '' }}
           cache-from: type=gha,scope=${{ matrix.cache_scope }}
           cache-to: type=gha,scope=${{ matrix.cache_scope }},mode=min
@@ -771,6 +800,10 @@ jobs:
           mkdir -p build/ci-input
           gh release download "${{ needs.prepare.outputs.tag }}" --pattern '_internal-*.tar' --dir build/ci-input
       - name: Assemble canonical offline release
+        env:
+          # Same sources as image bake so packaged .env.example matches image ENV.
+          HFL_EXTENSION_SOURCES: ${{ vars.HFL_EXTENSION_SOURCES }}
+          HFL_EXTENSION_GIT_TOKEN: ${{ secrets.HFL_EXTENSION_GIT_TOKEN }}
         run: |
           ./release/ci/assemble-release.sh \
             --input-dir build/ci-input \

--- a/deploy/docker/backend.Dockerfile
+++ b/deploy/docker/backend.Dockerfile
@@ -101,6 +101,10 @@ RUN rm -f /tmp/dev-requirements.txt
 COPY src/backend /opt/backend
 COPY deploy/bootstrap /opt/bootstrap
 COPY deploy/docker/backend-entrypoint.sh /entrypoint.sh
+# Optional Open Core extensions staged by release/build.sh or CI (may be empty).
+COPY build/release/extensions/ /opt/hfl/extensions/
+ARG HFL_EXTENSIONS=
+ENV HFL_EXTENSIONS=${HFL_EXTENSIONS}
 
 RUN chmod +x /entrypoint.sh
 

--- a/deploy/docker/frontend.Dockerfile
+++ b/deploy/docker/frontend.Dockerfile
@@ -32,6 +32,10 @@ ENTRYPOINT ["/usr/local/bin/hfl-frontend-dev"]
 FROM frontend-dependencies AS frontend-build
 
 COPY src/frontend/ ./
+# Optional Open Core extensions for Vite discovery at build time (may be empty).
+COPY build/release/extensions/ /opt/hfl/extensions/
+ARG HFL_EXTENSIONS=
+ENV HFL_EXTENSIONS=${HFL_EXTENSIONS}
 ENV VITE_SHOW_EULA=${VITE_SHOW_EULA}
 RUN --mount=type=secret,id=sentry_auth_token \
     SENTRY_AUTH_TOKEN="$(cat /run/secrets/sentry_auth_token 2>/dev/null || true)" \

--- a/deploy/installer/install.sh
+++ b/deploy/installer/install.sh
@@ -1457,6 +1457,7 @@ sub_key(
 path.write_text(text, encoding="utf-8")
 PY
 	chmod 600 "${env_file}"
+	reconcile_hfl_extensions_env "${env_file}" "${example}"
 	log ".env created (fixed login credentials, generated internal secrets, DJANGO_DEBUG=false)"
 }
 
@@ -1669,6 +1670,55 @@ sync_env_from_example() {
 	step "Merging missing keys from .env.example into .env ..."
 	python3 "${sync_script}" --env-file "${env_file}" --example "${example}"
 	chmod 600 "${env_file}"
+	reconcile_hfl_extensions_env "${env_file}" "${example}"
+}
+
+reconcile_hfl_extensions_env() {
+	# Empty HFL_EXTENSIONS= in .env overrides Dockerfile ENV and disables baked plugins.
+	# - Example has a non-empty value → fill missing/empty .env from example (Enterprise).
+	# - Example omits the key (Community) → drop empty HFL_EXTENSIONS= so image ENV wins.
+	# Non-empty operator overrides in .env are preserved.
+	local env_file=$1
+	local example=$2
+	[[ -f "${env_file}" ]] || return 0
+	python3 - "${env_file}" "${example}" <<'PY'
+import pathlib
+import re
+import sys
+
+env_path = pathlib.Path(sys.argv[1])
+example_path = pathlib.Path(sys.argv[2])
+env_text = env_path.read_text(encoding="utf-8")
+example_text = example_path.read_text(encoding="utf-8") if example_path.is_file() else ""
+
+def read_key(text, key):
+    m = re.search(rf"(?m)^[ \t]*{re.escape(key)}=(.*)$", text)
+    if not m:
+        return None
+    return m.group(1).strip().strip("'\"")
+
+example_val = read_key(example_text, "HFL_EXTENSIONS")
+env_val = read_key(env_text, "HFL_EXTENSIONS")
+
+if example_val:
+    if env_val is None:
+        env_text = env_text.rstrip() + f"\nHFL_EXTENSIONS={example_val}\n"
+    elif env_val == "":
+        env_text = re.sub(
+            r"(?m)^[ \t]*HFL_EXTENSIONS=.*$",
+            f"HFL_EXTENSIONS={example_val}",
+            env_text,
+            count=1,
+        )
+    else:
+        raise SystemExit(0)
+elif env_val == "":
+    env_text = re.sub(r"(?m)^[ \t]*HFL_EXTENSIONS=.*\n?", "", env_text)
+else:
+    raise SystemExit(0)
+
+env_path.write_text(env_text, encoding="utf-8")
+PY
 }
 
 pin_gateway_version_if_missing() {

--- a/dev/stack.sh
+++ b/dev/stack.sh
@@ -78,6 +78,9 @@ WEBSITE_OUTPUT="${ROOT}/build/website"
 WEBSITE_BUILDER_IMAGE="hyperfilelens-website-builder:dev"
 WEBSITE_BASE_IMAGE="node:22-alpine"
 WEBSITE_ARTIFACT_REBUILT=0
+# Open Core extensions: CLI --extension-source only (not a .env setting).
+EXTENSION_SOURCES=()
+EXTENSION_SOURCES_CSV=""
 
 usage() {
 	cat <<'USAGE'
@@ -115,13 +118,18 @@ SourceLens options (default: enabled for up/restart):
   --sourcelens-git-url URL         Override SourceLens repository URL (env: SOURCELENS_GIT_URL)
 
 Extensions (optional overlay; community default = empty socket):
-  Set HFL_EXTENSION_SOURCES in .env to local plugin path(s) and/or git URL[@ref].
-  stack.sh materializes them and loads build/docker-compose.extensions.yml.
-  Runtime uses HFL_EXTENSIONS only (never git clone inside api/ui).
+  --extension-source SRC           Local path or git/HTTPS URL[+@ref]. Repeatable.
+                                     Not read from .env (prepare/packaging input only).
+                                     Private HTTPS uses --github-token or
+                                     HFL_EXTENSION_GIT_TOKEN (SSH uses your agent).
+  stack.sh materializes sources → build/docker-compose.extensions.yml.
+  Runtime containers see HFL_EXTENSIONS paths only (never git clone in api/ui).
 
 Mirror options (Kopia fetch + Agent publishing + SourceLens git clone; env fallback):
   --github-download-mirror URL     GitHub Git/release mirror (env: GITHUB_DOWNLOAD_MIRROR)
-  --github-token TOKEN             GitHub token for API/release fetch and private SourceLens clone (env: GITHUB_TOKEN)
+  --github-token TOKEN             GitHub token for API/release fetch, private SourceLens
+                                     clone, and private extension git sources (env:
+                                     GITHUB_TOKEN / HFL_EXTENSION_GIT_TOKEN)
   --docker-download-mirror URL     Docker Hub mirror for builds and runtime images (env: DOCKER_DOWNLOAD_MIRROR)
   --apt-mirror URL                 Ubuntu apt mirror for NAS container (env: APT_MIRROR)
   --ubuntu2404-arch ARCH           NAS deb arch for agent bundle: amd64 | arm64 | all (default: amd64)
@@ -146,6 +154,7 @@ Output options:
 
 Examples:
   ./dev/stack.sh up
+  ./dev/stack.sh up --extension-source ../hyperfilelens-ee
   ./dev/stack.sh up --ubuntu2404-arch amd64
   ./dev/stack.sh down
   ./dev/stack.sh restart
@@ -256,6 +265,7 @@ go_sumdb=${GOSUMDB:-<official>}
 pip_index_url=${OPT_PIP_INDEX_URL:-<official>}
 pip_trusted_host=${OPT_PIP_TRUSTED_HOST:-<unset>}
 npm_registry=${OPT_NPM_REGISTRY:-<official>}
+extension_sources=${EXTENSION_SOURCES_CSV:-<none>}
 docker_pull_timeout=${DOCKER_PULL_TIMEOUT}
 docker_pull_retries=${DOCKER_PULL_RETRIES}
 offline=${DEV_OFFLINE}
@@ -324,18 +334,17 @@ require_docker() {
 
 compose() {
 	local files=(-f docker-compose.yml)
-	local sources extensions compose_overlay
-	# Opt-in only: community CI / default stack.sh stay Host-only (empty socket).
-	sources="$(read_env_value_or HFL_EXTENSION_SOURCES "" "${ROOT}/.env" 2>/dev/null || true)"
-	extensions="$(read_env_value_or HFL_EXTENSIONS "" "${ROOT}/.env" 2>/dev/null || true)"
+	local compose_overlay ext_token
+	# CLI --extension-source only; never read prepare sources from .env.
 	compose_overlay="${ROOT}/build/docker-compose.extensions.yml"
-	if [[ -n "${sources}" || -n "${extensions}" ]]; then
-		python3 "${ROOT}/tools/extensions/materialize_extensions.py" \
+	if [[ -n "${EXTENSION_SOURCES_CSV:-}" ]]; then
+		ext_token="${HFL_EXTENSION_GIT_TOKEN:-${MIRROR_GITHUB_TOKEN:-${GITHUB_TOKEN:-}}}"
+		HFL_EXTENSION_GIT_TOKEN="${ext_token}" \
+			python3 "${ROOT}/tools/extensions/materialize_extensions.py" \
 			--repo-root "${ROOT}" \
-			--sources "${sources}" \
-			--extensions "${extensions}" \
+			--sources "${EXTENSION_SOURCES_CSV}" \
 			--compose-out "${compose_overlay}" \
-			|| die "failed to materialize HFL_EXTENSION_SOURCES / HFL_EXTENSIONS"
+			|| die "failed to materialize --extension-source"
 		[[ -f "${compose_overlay}" ]] \
 			|| die "extension compose overlay missing after materialize: ${compose_overlay}"
 		files+=(-f "${compose_overlay}")
@@ -1406,6 +1415,11 @@ main() {
 			LOG_FILE="$2"
 			shift 2
 			;;
+		--extension-source)
+			require_value "$1" "${2:-}"
+			EXTENSION_SOURCES+=("$2")
+			shift 2
+			;;
 		--github-download-mirror | --github-token | --docker-download-mirror | --apt-mirror | --ubuntu2404-arch | --kopia-mode | --kopia-git-url | --kopia-ref | --sourcelens-ref | --sourcelens-git-url | --go-proxy | --go-sumdb | --pip-index-url | --pip-trusted-host | --npm-registry | --pull-timeout | --pull-retries | --no-sourcelens | --hfl-only | --pull | --offline)
 			parse_common_option "$@" || die "failed to parse option: $1"
 			if [[ "$1" == "--no-sourcelens" || "$1" == "--hfl-only" \
@@ -1420,6 +1434,12 @@ main() {
 			;;
 		esac
 	done
+	if [[ ${#EXTENSION_SOURCES[@]} -gt 0 ]]; then
+		local IFS=','
+		EXTENSION_SOURCES_CSV="${EXTENSION_SOURCES[*]}"
+	else
+		EXTENSION_SOURCES_CSV=""
+	fi
 	CMD="${cmd}"
 	hfl_logging_configure dev "${LOG_FILE}" "${VERBOSE}"
 	if [[ "${PRINT_CONFIG}" -eq 1 ]]; then

--- a/release/build.sh
+++ b/release/build.sh
@@ -47,6 +47,10 @@ VERBOSE="${HFL_LOG_VERBOSE:-0}"
 PRINT_CONFIG=0
 OPT_VERSION=""
 SOURCELENS_BUILD_ENV="${ROOT}/tools/sourcelens/defaults.env"
+# Open Core extension bake (packaging only). Repeatable --extension-source.
+EXTENSION_SOURCES=()
+EXTENSION_BAKE_DIR="${ROOT}/build/release/extensions"
+HFL_EXTENSIONS_RUNTIME=""
 
 log() { hfl_log_info "$@"; }
 die() { hfl_die "$1" "${2:-1}"; }
@@ -64,6 +68,9 @@ normalize_release_permissions() {
 	find "${pkg_root}" -type d -exec chmod 755 {} +
 	find "${pkg_root}" -type f -exec chmod 644 {} +
 	chmod 755 "${pkg_root}/install.sh" "${pkg_root}/apply-runtime-config.py"
+	if [[ -f "${pkg_root}/sync-env.py" ]]; then
+		chmod 755 "${pkg_root}/sync-env.py"
+	fi
 	if [[ -d "${pkg_root}/sourcelens" ]]; then
 		chmod 755 "${pkg_root}/sourcelens/install.sh" \
 			"${pkg_root}/sourcelens/patch-env-runtime.py" \
@@ -227,7 +234,9 @@ Version:
 
 Mirror options (Kopia fetch + Agent publishing + SourceLens Git + runtime image pull; env fallback):
   --github-download-mirror URL     GitHub Git/release mirror (env: GITHUB_DOWNLOAD_MIRROR)
-  --github-token TOKEN             GitHub token for API/release fetch and private SourceLens clone (env: GITHUB_TOKEN)
+  --github-token TOKEN             GitHub token for API/release fetch, private SourceLens clone,
+                                     and private extension git sources (env: GITHUB_TOKEN /
+                                     HFL_EXTENSION_GIT_TOKEN)
   --docker-download-mirror URL     Docker Hub mirror for ubuntu:24.04, postgres, redis (env: DOCKER_DOWNLOAD_MIRROR)
   --docker-pull-timeout SECONDS    Timeout for each Docker pull attempt (env: DOCKER_PULL_TIMEOUT_SECONDS)
   --docker-apt-mirror URL          Docker CE apt repo base URL (env: DOCKER_APT_MIRROR / BUILD_DOCKER_APT_MIRROR)
@@ -238,6 +247,14 @@ Mirror options (Kopia fetch + Agent publishing + SourceLens Git + runtime image 
   --pip-index-url URL              Python package index (env: PIP_INDEX_URL)
   --pip-trusted-host HOST          Trusted pip host (env: PIP_TRUSTED_HOST)
   --npm-registry URL               npm registry (env: NPM_REGISTRY)
+
+Open Core extensions (bake into control-plane images at packaging time):
+  --extension-source SRC           Local path or git/HTTPS URL[+@ref]. Repeatable.
+                                     Empty = Community (no plugin). Not read from
+                                     .env. CI may set process env
+                                     HFL_EXTENSION_SOURCES / HFL_EXTENSION_GIT_TOKEN.
+                                     Private HTTPS: --github-token or
+                                     HFL_EXTENSION_GIT_TOKEN (SSH uses your agent).
 
 Kopia artifacts (tools/kopia/defaults.env; default: build patched source):
   --kopia-mode MODE               build or download
@@ -261,6 +278,8 @@ Output options:
 
 Examples:
   ./release/build.sh
+  ./release/build.sh --extension-source ../hyperfilelens-ee
+  ./release/build.sh --extension-source https://github.com/org/hyperfilelens-ee.git@main --github-token "$TOKEN"
   ./release/build.sh --ubuntu2404-arch amd64
   ./release/build.sh --github-download-mirror https://ghfast.top --docker-download-mirror docker.m.daocloud.io --apt-mirror https://mirrors.tuna.tsinghua.edu.cn
 USAGE
@@ -310,6 +329,8 @@ go_sumdb=${GOSUMDB}
 pip_index_url=${PIP_INDEX_URL:-<official>}
 pip_trusted_host=${PIP_TRUSTED_HOST:-<unset>}
 npm_registry=${NPM_REGISTRY:-<official>}
+extension_sources=${EXTENSION_SOURCES_CSV:-<none>}
+hfl_extensions=<resolved at image bake>
 log_file=${LOG_FILE:-<none>}
 verbose=${VERBOSE}
 EOF
@@ -471,11 +492,90 @@ parse_args() {
 			SOURCELENS_FORCE_BUILD=1
 			shift
 			;;
+		--extension-source)
+			require_value "$1" "${2:-}"
+			EXTENSION_SOURCES+=("$2")
+			shift 2
+			;;
 		*)
 			die "unknown argument: $1 (try --help)" 2
 			;;
 		esac
 	done
+	# Process-env / CI fallback only (never loaded from repo .env).
+	if [[ ${#EXTENSION_SOURCES[@]} -eq 0 && -n "${HFL_EXTENSION_SOURCES:-}" ]]; then
+		local _src
+		IFS=',' read -r -a _src <<<"${HFL_EXTENSION_SOURCES}"
+		local _item
+		for _item in "${_src[@]}"; do
+			_item="${_item#"${_item%%[![:space:]]*}"}"
+			_item="${_item%"${_item##*[![:space:]]}"}"
+			[[ -n "${_item}" ]] && EXTENSION_SOURCES+=("${_item}")
+		done
+	fi
+	if [[ ${#EXTENSION_SOURCES[@]} -gt 0 ]]; then
+		local IFS=','
+		EXTENSION_SOURCES_CSV="${EXTENSION_SOURCES[*]}"
+	else
+		EXTENSION_SOURCES_CSV=""
+	fi
+}
+
+stage_release_env_example() {
+	# Package .env.example must not ship HFL_EXTENSIONS= (empty) — compose env_file
+	# would clear the baked image ENV and disable Enterprise plugins at runtime.
+	local pkg_root=$1
+	local example="${pkg_root}/.env.example"
+	cp "${ROOT}/.env.example" "${example}"
+	HFL_EXTENSIONS_RUNTIME="${HFL_EXTENSIONS_RUNTIME:-}" python3 - "${example}" <<'PY'
+import os
+import pathlib
+import re
+import sys
+
+path = pathlib.Path(sys.argv[1])
+text = path.read_text(encoding="utf-8")
+text = re.sub(r"(?m)^[ \t]*HFL_EXTENSIONS=.*\n?", "", text)
+runtime = os.environ.get("HFL_EXTENSIONS_RUNTIME", "").strip()
+if runtime:
+    block = (
+        "\n# Baked into this release's control-plane images (Open Core).\n"
+        f"HFL_EXTENSIONS={runtime}\n"
+    )
+    text = text.rstrip() + "\n" + block
+path.write_text(text, encoding="utf-8")
+PY
+}
+
+prepare_extension_bake() {
+	# Stage extensions into docker context for COPY; Community leaves an empty tree.
+	rm -rf "${EXTENSION_BAKE_DIR}"
+	mkdir -p "${EXTENSION_BAKE_DIR}"
+	: >"${EXTENSION_BAKE_DIR}/.gitkeep"
+	HFL_EXTENSIONS_RUNTIME=""
+	if [[ ${#EXTENSION_SOURCES[@]} -eq 0 ]]; then
+		log "Extension bake: Community (no HFL_EXTENSION_SOURCES)"
+		return 0
+	fi
+	local sources_csv
+	local IFS=','
+	sources_csv="${EXTENSION_SOURCES[*]}"
+	unset IFS
+	# Scope extension token to the materialize subprocess only — never overwrite
+	# global GITHUB_TOKEN (SourceLens / GitHub API may use a different credential).
+	apply_mirror_env_defaults
+	local ext_token="${HFL_EXTENSION_GIT_TOKEN:-${MIRROR_GITHUB_TOKEN:-}}"
+	log "Extension bake: materializing ${sources_csv}"
+	HFL_EXTENSIONS_RUNTIME="$(
+		HFL_EXTENSION_GIT_TOKEN="${ext_token}" \
+			python3 "${ROOT}/tools/extensions/materialize_extensions.py" \
+			--repo-root "${ROOT}" \
+			--sources "${sources_csv}" \
+			--bake-dir "${EXTENSION_BAKE_DIR}" \
+			--print-extensions
+	)"
+	export HFL_EXTENSIONS_RUNTIME
+	log "Extension bake: HFL_EXTENSIONS=${HFL_EXTENSIONS_RUNTIME:-<empty>}"
 }
 
 prepare_kopia_artifacts() {
@@ -630,6 +730,7 @@ build_control_plane_images() {
 		--build-arg "KOPIA_BINARY=${KOPIA_BINARY:-build/kopia/dist/linux/amd64/kopia}" \
 		--build-arg "IMAGE_VERSION=${HFL_VERSION}" \
 		--build-arg "IMAGE_REVISION=${RELEASE_COMMIT}" \
+		--build-arg "HFL_EXTENSIONS=${HFL_EXTENSIONS_RUNTIME:-}" \
 		"${ROOT}"
 
 	log "Building standalone Website artifact for hyperfilelens-frontend:${HFL_VERSION}"
@@ -655,6 +756,7 @@ build_control_plane_images() {
 		--build-arg "VITE_SHOW_EULA=${VITE_SHOW_EULA:-false}" \
 		--build-arg "IMAGE_VERSION=${HFL_VERSION}" \
 		--build-arg "IMAGE_REVISION=${RELEASE_COMMIT}" \
+		--build-arg "HFL_EXTENSIONS=${HFL_EXTENSIONS_RUNTIME:-}" \
 		"${ROOT}"
 }
 
@@ -1220,6 +1322,9 @@ main() {
 	log "Fetching host Docker CE debs (ubuntu 20.04/22.04/24.04 amd64)"
 	fetch_host_docker_debs
 
+	log "Preparing Open Core extension bake for control-plane images"
+	prepare_extension_bake
+
 	log "Building control-plane Docker images"
 	export_build_mirror_env
 	build_control_plane_images
@@ -1248,7 +1353,7 @@ main() {
 	log "Staging package files"
 	printf '%s\n' "${version}" > "${pkg_root}/VERSION"
 	cp "${ROOT}/deploy/docker-compose.yml" "${pkg_root}/docker-compose.yml"
-	cp "${ROOT}/.env.example" "${pkg_root}/.env.example"
+	stage_release_env_example "${pkg_root}"
 	cp "${ROOT}/LICENSE" "${pkg_root}/LICENSE"
 	stage_default_tls_bundle "${pkg_root}"
 	cp "${ROOT}/deploy/nginx/default.conf" "${pkg_root}/deploy/nginx/default.conf"
@@ -1259,7 +1364,8 @@ main() {
 	cp "${ROOT}/deploy/blue-green/active-color" "${pkg_root}/deploy/blue-green/active-color"
 	cp "${ROOT}/deploy/installer/install.sh" "${pkg_root}/install.sh"
 	cp "${ROOT}/deploy/installer/apply-runtime-config.py" "${pkg_root}/apply-runtime-config.py"
-	chmod +x "${pkg_root}/install.sh" "${pkg_root}/apply-runtime-config.py"
+	cp "${ROOT}/tools/config/sync_env.py" "${pkg_root}/sync-env.py"
+	chmod +x "${pkg_root}/install.sh" "${pkg_root}/apply-runtime-config.py" "${pkg_root}/sync-env.py"
 	mkdir -p "${pkg_root}/deploy/logrotate"
 	cp "${ROOT}/deploy/logrotate/hyperfilelens.conf" "${pkg_root}/deploy/logrotate/hyperfilelens.conf"
 

--- a/release/ci/assemble-release.sh
+++ b/release/ci/assemble-release.sh
@@ -179,7 +179,19 @@ chmod 644 "${gateway_dir}/hfl-sentry-sitecustomize.py"
 log "Staging release runtime files"
 printf '%s\n' "${version}" >"${pkg_root}/VERSION"
 cp "${ROOT}/deploy/docker-compose.yml" "${pkg_root}/docker-compose.yml"
-cp "${ROOT}/.env.example" "${pkg_root}/.env.example"
+# Prefer CI/image bake value so packaged .env.example cannot clear image ENV.
+HFL_EXTENSIONS_RUNTIME="${HFL_EXTENSIONS_RUNTIME:-${HFL_EXTENSIONS:-}}"
+if [[ -z "${HFL_EXTENSIONS_RUNTIME}" && -n "${HFL_EXTENSION_SOURCES:-}" ]]; then
+	HFL_EXTENSIONS_RUNTIME="$(
+		python3 "${ROOT}/tools/extensions/materialize_extensions.py" \
+			--repo-root "${ROOT}" \
+			--sources "${HFL_EXTENSION_SOURCES}" \
+			--bake-dir "${RELEASE_BUILD_DIR}/extensions-assemble" \
+			--print-extensions
+	)"
+fi
+export HFL_EXTENSIONS_RUNTIME
+stage_release_env_example "${pkg_root}"
 cp "${ROOT}/LICENSE" "${pkg_root}/LICENSE"
 mkdir -p \
 	"${pkg_root}/deploy/nginx/certs" \

--- a/tools/extensions/materialize_extensions.py
+++ b/tools/extensions/materialize_extensions.py
@@ -1,17 +1,25 @@
 #!/usr/bin/env python3
-"""Materialize HFL_EXTENSION_SOURCES → HFL_EXTENSIONS and emit compose overlay.
+"""Materialize HFL_EXTENSION_SOURCES for stack.dev and release image bake.
 
-Used by ``dev/stack.sh``. Runtime processes only see local paths.
+Prepare stage only: local paths or git URL[+ref]. Runtime reads ``HFL_EXTENSIONS``
+(container/local directories). Never clones inside api/ui processes.
+
+Modes:
+  * compose overlay (``stack.sh``): mount host roots into containers
+  * ``--bake-dir`` (``release/build.sh`` / CI): copy into a docker-context tree
 """
 
 from __future__ import annotations
 
 import argparse
+import base64
 import os
 import re
+import shutil
 import subprocess
 import sys
 from pathlib import Path
+from urllib.parse import urlsplit
 
 
 def _split_list(raw: str) -> list[str]:
@@ -53,23 +61,65 @@ def _parse_source(item: str) -> tuple[str, str | None]:
     return item, None
 
 
+def _git_token() -> str:
+    return (
+        os.environ.get("HFL_EXTENSION_GIT_TOKEN", "").strip()
+        or os.environ.get("GITHUB_TOKEN", "").strip()
+    )
+
+
+def _git_env(url: str) -> dict[str, str]:
+    """Env for git subprocesses: HTTPS auth via GIT_CONFIG_* (not argv / .git/config)."""
+    env = os.environ.copy()
+    env.setdefault("GIT_TERMINAL_PROMPT", "0")
+    token = _git_token()
+    if not token or not url.startswith("https://"):
+        return env
+    parts = urlsplit(url)
+    if not parts.hostname or parts.username:
+        return env
+    basic = base64.b64encode(f"x-access-token:{token}".encode("utf-8")).decode("ascii")
+    # Ephemeral config through the environment — avoids token-in-URL remotes and
+    # keeps the secret out of `ps` argv (unlike `git -c ...extraheader=...`).
+    env["GIT_CONFIG_COUNT"] = "1"
+    env["GIT_CONFIG_KEY_0"] = f"http.https://{parts.hostname}/.extraheader"
+    env["GIT_CONFIG_VALUE_0"] = f"AUTHORIZATION: basic {basic}"
+    return env
+
+
 def _clone(url: str, dest: Path, ref: str | None) -> None:
     dest.parent.mkdir(parents=True, exist_ok=True)
+    env = _git_env(url)
     if dest.exists():
-        subprocess.check_call(["git", "-C", str(dest), "fetch", "--all", "--tags"], stdout=subprocess.DEVNULL)
+        # Ensure origin stays credential-free (clean up older token-in-URL caches).
+        subprocess.check_call(
+            ["git", "-C", str(dest), "remote", "set-url", "origin", url],
+            stdout=subprocess.DEVNULL,
+            env=env,
+        )
+        subprocess.check_call(
+            ["git", "-C", str(dest), "fetch", "--all", "--tags"],
+            stdout=subprocess.DEVNULL,
+            env=env,
+        )
         if ref:
-            subprocess.check_call(["git", "-C", str(dest), "checkout", ref], stdout=subprocess.DEVNULL)
+            subprocess.check_call(
+                ["git", "-C", str(dest), "checkout", ref],
+                stdout=subprocess.DEVNULL,
+                env=env,
+            )
             subprocess.check_call(
                 ["git", "-C", str(dest), "pull", "--ff-only"],
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
+                env=env,
             )
         return
     cmd = ["git", "clone", "--depth", "1"]
     if ref:
         cmd += ["--branch", ref]
     cmd += [url, str(dest)]
-    subprocess.check_call(cmd)
+    subprocess.check_call(cmd, env=env)
 
 
 def materialize(sources: list[str], cache_dir: Path) -> list[Path]:
@@ -77,7 +127,6 @@ def materialize(sources: list[str], cache_dir: Path) -> list[Path]:
     for item in sources:
         location, ref = _parse_source(item)
         if location.startswith("git@") or "://" in location:
-            # Dest folder name from repo basename
             base = location.rstrip("/").rsplit("/", 1)[-1]
             if base.endswith(".git"):
                 base = base[:-4]
@@ -92,23 +141,74 @@ def materialize(sources: list[str], cache_dir: Path) -> list[Path]:
     return roots
 
 
+def _copy_tree(src: Path, dest: Path) -> None:
+    if dest.exists():
+        shutil.rmtree(dest)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(
+        src,
+        dest,
+        ignore=shutil.ignore_patterns(
+            ".git",
+            "__pycache__",
+            "*.pyc",
+            "node_modules",
+            ".venv",
+            "dist",
+            ".tmp",
+            # Never bake local secrets / credentials into release images.
+            ".env",
+            ".env.*",
+            "*.key",
+            "*.pem",
+            "*.p12",
+            "*.pfx",
+            "id_rsa",
+            "id_rsa.*",
+            "credentials.json",
+            ".secrets",
+            "secrets",
+        ),
+    )
+
+
+def bake_extensions(host_roots: list[Path], bake_dir: Path) -> list[tuple[str, Path]]:
+    """Copy each root to bake_dir/<id> and return (runtime_path, host_bake_path)."""
+    if bake_dir.exists():
+        shutil.rmtree(bake_dir)
+    bake_dir.mkdir(parents=True, exist_ok=True)
+    (bake_dir / ".gitkeep").write_text("", encoding="utf-8")
+
+    mounts: list[tuple[str, Path]] = []
+    seen_ids: set[str] = set()
+    for root in host_roots:
+        ext_id = _read_id(root)
+        if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]{0,63}", ext_id):
+            raise SystemExit(f"invalid extension id for bake: {ext_id!r}")
+        if ext_id in seen_ids:
+            raise SystemExit(f"duplicate extension id: {ext_id}")
+        seen_ids.add(ext_id)
+        staged = bake_dir / ext_id
+        _copy_tree(root, staged)
+        mounts.append((f"/opt/hfl/extensions/{ext_id}", staged.resolve()))
+    return mounts
+
+
 def write_compose(out: Path, mounts: list[tuple[str, Path]]) -> None:
     """mounts: (container_path, host_path)."""
     lines = [
         "# Generated by tools/extensions/materialize_extensions.py — do not edit.",
-        "# Loaded by stack.sh when HFL_EXTENSION_SOURCES / HFL_EXTENSIONS is set.",
+        "# Loaded by stack.sh when --extension-source materializes an overlay.",
         "services:",
     ]
     env_val = ",".join(c for c, _ in mounts)
     vol_lines = []
     for container, host in mounts:
         vol_lines.append(f"      - {host}:{container}:ro")
-        # Frontend live-reload for Vite when src/frontend exists
         fe = host / "src" / "frontend" / "src"
         if fe.is_dir():
             vol_lines.append(f"      - {fe}:{container}/src/frontend/src:ro")
 
-    # Deduplicate volume lines while preserving order
     seen: set[str] = set()
     uniq_vols: list[str] = []
     for v in vol_lines:
@@ -145,14 +245,21 @@ def main() -> int:
         help="Write docker-compose overlay (default: <repo>/build/docker-compose.extensions.yml)",
     )
     parser.add_argument(
+        "--bake-dir",
+        type=Path,
+        default=None,
+        help="Stage extension trees for docker COPY (release/CI). Skips compose overlay.",
+    )
+    parser.add_argument(
         "--print-extensions",
         action="store_true",
-        help="Print container HFL_EXTENSIONS value to stdout",
+        help="Print runtime HFL_EXTENSIONS value to stdout",
     )
     args = parser.parse_args()
     repo = args.repo_root.resolve()
     cache = repo / "build" / "extensions"
     compose_out = args.compose_out or (repo / "build" / "docker-compose.extensions.yml")
+    bake_dir = args.bake_dir.resolve() if args.bake_dir else None
 
     sources = _split_list(args.sources)
     extensions = _split_list(args.extensions)
@@ -167,21 +274,35 @@ def main() -> int:
                 raise SystemExit(f"not an extension root: {root}")
             host_roots.append(root)
     else:
-        if compose_out.exists():
+        if bake_dir is not None:
+            if bake_dir.exists():
+                shutil.rmtree(bake_dir)
+            bake_dir.mkdir(parents=True, exist_ok=True)
+            (bake_dir / ".gitkeep").write_text("", encoding="utf-8")
+        elif compose_out.exists():
             compose_out.unlink()
         if args.print_extensions:
             print("")
         return 0
 
-    mounts: list[tuple[str, Path]] = []
+    if bake_dir is not None:
+        mounts = bake_extensions(host_roots, bake_dir)
+        container_list = ",".join(c for c, _ in mounts)
+        if args.print_extensions:
+            print(container_list)
+        print(f"extensions baked: {len(mounts)} → {bake_dir}", file=sys.stderr)
+        for c, h in mounts:
+            print(f"  {c} <= {h}", file=sys.stderr)
+        return 0
+
+    mounts = []
     seen_ids: set[str] = set()
     for root in host_roots:
         ext_id = _read_id(root)
         if ext_id in seen_ids:
             raise SystemExit(f"duplicate extension id: {ext_id}")
         seen_ids.add(ext_id)
-        container = f"/opt/hfl/extensions/{ext_id}"
-        mounts.append((container, root))
+        mounts.append((f"/opt/hfl/extensions/{ext_id}", root))
 
     write_compose(compose_out, mounts)
     container_list = ",".join(c for c, _ in mounts)

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -1201,6 +1201,8 @@ grep -F 'Full release install, upgrade, and login verification passed' "${releas
 grep -F 'sudo env \' "${release_verifier}" >/dev/null
 grep -F 'cp "${ROOT}/tools/config/sync_env.py" "${pkg_root}/sync-env.py"' \
 	"${ROOT}/release/ci/assemble-release.sh" >/dev/null
+grep -F 'cp "${ROOT}/tools/config/sync_env.py" "${pkg_root}/sync-env.py"' \
+	"${ROOT}/release/build.sh" >/dev/null
 grep -F 'cp "${ROOT}/deploy/installer/apply-runtime-config.py" "${pkg_root}/apply-runtime-config.py"' \
 	"${ROOT}/release/ci/assemble-release.sh" >/dev/null
 grep -F 'stage_default_tls_bundle "${pkg_root}"' \


### PR DESCRIPTION
## Summary
- Add packaging-time extension bake via `--extension-source` (stack + release) and CI `HFL_EXTENSION_SOURCES` / `HFL_EXTENSION_GIT_TOKEN`
- Bake extensions into backend/frontend images with `HFL_EXTENSIONS`; keep prepare sources out of `.env`
- Reconcile release `.env` so empty `HFL_EXTENSIONS=` cannot clear the baked image socket

## Test plan
- [ ] `./dev/stack.sh up --extension-source ../hyperfilelens-ee` loads Enterprise overlay
- [ ] `./dev/stack.sh up` (no flag) stays Community empty socket
- [ ] `./release/build.sh --extension-source ../hyperfilelens-ee` sets image `HFL_EXTENSIONS` and packaged `.env.example`
- [ ] Community bake leaves empty extensions tree / omits runtime key from packaged example


Made with [Cursor](https://cursor.com)