### PR TITLE
fix: drop FKs on detached subscription ledger tables

### DIFF
--- a/src/backend/apps/subscription/migrations/0004_detach_ledger_models.py
+++ b/src/backend/apps/subscription/migrations/0004_detach_ledger_models.py
@@ -1,6 +1,7 @@
 # Detach Plan/OrgSubscription/Entitlement/Quota/UsageCounter from Host state.
 # Physical tables remain unused. Commercial plugin copies needed rows into
 # ee_* tables (currently ee_quota only); it does not re-bind all five models.
+# Follow-up 0005 drops their FKs so Community TransactionTestCase flush works.
 
 from django.db import migrations
 

--- a/src/backend/apps/subscription/migrations/0005_drop_detached_ledger_foreign_keys.py
+++ b/src/backend/apps/subscription/migrations/0005_drop_detached_ledger_foreign_keys.py
@@ -1,0 +1,48 @@
+# Host-era ledger tables stay physical and unused (see EE legacy-ledger policy),
+# but their FKs to iam_organization break TransactionTestCase flush: Django's
+# sqlflush no longer knows about the detached models, so TRUNCATE iam_organization
+# fails. Drop only foreign keys; keep tables and rows for Enterprise copy.
+
+from django.db import migrations
+
+_LEDGER_TABLES = (
+    "subscription_org",
+    "subscription_entitlement",
+    "subscription_quota",
+    "subscription_usage",
+)
+
+
+def drop_detached_ledger_foreign_keys(apps, schema_editor):
+    connection = schema_editor.connection
+    if connection.vendor != "postgresql":
+        return
+    with connection.cursor() as cursor:
+        for table in _LEDGER_TABLES:
+            cursor.execute(
+                """
+                SELECT c.conname
+                FROM pg_constraint c
+                JOIN pg_class rel ON rel.oid = c.conrelid
+                JOIN pg_namespace nsp ON nsp.oid = rel.relnamespace
+                WHERE c.contype = 'f'
+                  AND rel.relname = %s
+                  AND nsp.nspname = current_schema()
+                """,
+                [table],
+            )
+            for (conname,) in cursor.fetchall():
+                cursor.execute(f'ALTER TABLE "{table}" DROP CONSTRAINT "{conname}"')
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("subscription", "0004_detach_ledger_models"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            drop_detached_ledger_foreign_keys,
+            migrations.RunPython.noop,
+        ),
+    ]


### PR DESCRIPTION
## Summary
- `#432` detached Host ledger models but left physical `subscription_*` tables with FKs to `iam_organization`
- Django `TransactionTestCase` flush no longer knows those tables → truncate fails (61 errors cascade)
- Add `0005` to drop only those FKs; tables/rows stay for Enterprise copy policy

## Test plan
- [ ] Quality / `manage.py test` passes on TEST workflow
- [ ] Extension image bake continues after Quality


Made with [Cursor](https://cursor.com)