### PR TITLE
fix: declare Vite __HFL_EXTENSIONS_FRONTEND__ for eslint

### DIFF
--- a/src/frontend/eslint.config.js
+++ b/src/frontend/eslint.config.js
@@ -24,7 +24,11 @@ export default tseslint.config(
   },
   {
     languageOptions: {
-      globals: globals.browser,
+      globals: {
+        ...globals.browser,
+        // Vite `define` compile-time flag (see vite.config.ts / vite-env.d.ts).
+        __HFL_EXTENSIONS_FRONTEND__: 'readonly',
+      },
     },
     rules: {
       '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],


### PR DESCRIPTION
## Summary
- Open Core compile-time flag is defined by Vite and typed in \`vite-env.d.ts\`, but eslint \`no-undef\` did not know about it
- Register it as a readonly global in the flat eslint config

## Test plan
- [ ] Quality Frontend \`npm run lint\` passes


Made with [Cursor](https://cursor.com)