### PR TITLE
fix: reject unusable extension git tokens and scrub checkout auth

### DIFF
--- a/.github/workflows/artifact_pipeline.yml
+++ b/.github/workflows/artifact_pipeline.yml
@@ -371,8 +371,13 @@ jobs:
           # Prefer packaging secret for private plugin repos; do not fall back to
           # github.token (that token cannot clone other private repositories).
           # Scope to HFL_EXTENSION_GIT_TOKEN only (materialize reads it first).
+          token="${HFL_EXTENSION_GIT_TOKEN:-}"
+          if [[ ${#token} -lt 20 || "${token}" == "-" ]]; then
+            echo "::error::HFL_EXTENSION_GIT_TOKEN is missing or a placeholder; set a PAT with contents:read on the private extension repo"
+            exit 1
+          fi
           exts="$(
-            HFL_EXTENSION_GIT_TOKEN="${HFL_EXTENSION_GIT_TOKEN:-}" \
+            HFL_EXTENSION_GIT_TOKEN="${token}" \
               python3 tools/extensions/materialize_extensions.py \
               --repo-root . \
               --sources "${HFL_EXTENSION_SOURCES}" \

--- a/tools/extensions/materialize_extensions.py
+++ b/tools/extensions/materialize_extensions.py
@@ -68,15 +68,39 @@ def _git_token() -> str:
     )
 
 
-def _git_env(url: str) -> dict[str, str]:
+def _usable_git_token(token: str) -> bool:
+    """Reject empty / placeholder values that look set in CI but cannot auth."""
+    if len(token) < 20:
+        return False
+    if token in {"-", "null", "undefined", "NONE", "changeme"}:
+        return False
+    return True
+
+
+def _git_env(url: str, *, require_https_auth: bool = False) -> dict[str, str]:
     """Env for git subprocesses: HTTPS auth via GIT_CONFIG_* (not argv / .git/config)."""
     env = os.environ.copy()
     env.setdefault("GIT_TERMINAL_PROMPT", "0")
+    # Drop inherited Actions checkout auth slots so a packaging token is the only
+    # http.*.extraheader applied (GITHUB_TOKEN cannot read private sibling repos).
+    for key in list(env):
+        if key == "GIT_CONFIG_COUNT" or key.startswith("GIT_CONFIG_KEY_") or key.startswith(
+            "GIT_CONFIG_VALUE_"
+        ):
+            env.pop(key, None)
     token = _git_token()
-    if not token or not url.startswith("https://"):
+    if not url.startswith("https://"):
         return env
     parts = urlsplit(url)
     if not parts.hostname or parts.username:
+        return env
+    if not _usable_git_token(token):
+        if require_https_auth:
+            raise SystemExit(
+                "HTTPS extension source requires a usable HFL_EXTENSION_GIT_TOKEN "
+                "(GitHub PAT / fine-grained token with contents:read on the private "
+                "extension repo). Placeholder or empty values are rejected."
+            )
         return env
     basic = base64.b64encode(f"x-access-token:{token}".encode("utf-8")).decode("ascii")
     # Ephemeral config through the environment — avoids token-in-URL remotes and
@@ -89,7 +113,7 @@ def _git_env(url: str) -> dict[str, str]:
 
 def _clone(url: str, dest: Path, ref: str | None) -> None:
     dest.parent.mkdir(parents=True, exist_ok=True)
-    env = _git_env(url)
+    env = _git_env(url, require_https_auth=url.startswith("https://"))
     if dest.exists():
         # Ensure origin stays credential-free (clean up older token-in-URL caches).
         subprocess.check_call(


### PR DESCRIPTION
## Summary
- Quality passed; image bake failed cloning private \`hyperfilelens-ee\` (\`could not read Username\`)
- CI logs masked every \`-\`, indicating \`HFL_EXTENSION_GIT_TOKEN\` was the placeholder \`-\`
- Fail fast on unusable tokens; clear inherited checkout \`GIT_CONFIG_*\` so packaging auth is applied
- Secret re-set to a working token with EE read access

## Test plan
- [x] Local materialize clone of private EE with \`HFL_EXTENSION_GIT_TOKEN\`
- [ ] TEST image bake Materialize step succeeds


Made with [Cursor](https://cursor.com)