### PR TITLE
fix: assign Platform Admin role when seeding staff under EE AuthZ

### DIFF
--- a/src/backend/apps/iam/management/commands/seed_initial_data.py
+++ b/src/backend/apps/iam/management/commands/seed_initial_data.py
@@ -11,6 +11,7 @@ from apps.iam.models import Membership, Organization
 from apps.iam.profile_models import Profile
 from apps.iam.services.registration_service import unique_org_key_for_email
 from apps.storage.config import seed_global_config
+from common.platform_authz import ensure_platform_role
 from common.platform_staff import apply_platform_staff
 
 
@@ -53,6 +54,8 @@ class Command(BaseCommand):
         if created:
             user.set_password(admin_password)
         user.save()
+        # EE AuthZ: bare is_staff is not enough for Admin Console / smoke verify.
+        ensure_platform_role(user)
 
         Profile.objects.update_or_create(
             user=user,

--- a/src/backend/apps/iam/tests/test_seed_initial_data.py
+++ b/src/backend/apps/iam/tests/test_seed_initial_data.py
@@ -38,6 +38,18 @@ class SeedInitialDataCommandTests(TestCase):
         profile = Profile.objects.get(user=user)
         self.assertTrue(profile.registration_completed)
 
+        # EE AuthZ (when loaded): seed must attach PlatformStaffRole for Console.
+        try:
+            from apps.membership.models import PlatformStaffRole
+            from common.platform_authz import ROLE_PLATFORM_ADMIN
+
+            self.assertEqual(
+                PlatformStaffRole.objects.get(user=user).role,
+                ROLE_PLATFORM_ADMIN,
+            )
+        except ImportError:
+            pass
+
     def test_rerun_is_idempotent_when_org_exists(self):
         call_command(
             "seed_initial_data",

--- a/src/backend/common/extension_spi.py
+++ b/src/backend/common/extension_spi.py
@@ -56,6 +56,10 @@ class AuthzProvider(Protocol):
         """Actions granted to ``user`` for deploy-profile / UI gating."""
         ...
 
+    def ensure_platform_role(self, user: Any, role: str) -> None:
+        """Idempotently assign a platform role (bootstrap / seed paths)."""
+        ...
+
 
 class QuotaProvider(Protocol):
     """Quota enforcement and EffectiveQuota surface (commercial plugin).

--- a/src/backend/common/platform_authz.py
+++ b/src/backend/common/platform_authz.py
@@ -127,6 +127,25 @@ def get_platform_role(user: Any) -> str | None:
     return None
 
 
+def ensure_platform_role(
+    user: Any, role: str = ROLE_PLATFORM_ADMIN
+) -> None:
+    """Assign a platform role when EE AuthZ is loaded (seed / bootstrap).
+
+    Community (no AuthzProvider): no-op; bare ``is_staff`` remains sufficient.
+    Enterprise: requires an explicit ``PlatformStaffRole`` row for Console access.
+    """
+    if not user or not getattr(user, "is_staff", False):
+        return
+    provider = get_authz_provider()
+    if provider is None:
+        return
+    ensurer = getattr(provider, "ensure_platform_role", None)
+    if not callable(ensurer):
+        return
+    ensurer(user, role)
+
+
 def authorize_platform(user: Any, action: str) -> None:
     """Raise AppError when the user lacks ``action``."""
     if has_platform_permission(user, action):

--- a/src/backend/common/tests/test_platform_authz.py
+++ b/src/backend/common/tests/test_platform_authz.py
@@ -18,6 +18,7 @@ from common.platform_authz import (
     ROLE_INFRA_OPERATOR,
     ROLE_PLATFORM_ADMIN,
     authorize_platform,
+    ensure_platform_role,
     has_platform_permission,
     list_platform_permissions,
     permissions_for_role,
@@ -91,3 +92,25 @@ class PlatformAuthzFacadeTest(TestCase):
         from common.platform_authz import get_platform_role
 
         self.assertIsNone(get_platform_role(self.staff))
+
+    def test_ensure_platform_role_delegates_to_provider(self):
+        seen: list[tuple[int, str]] = []
+
+        class _Stub:
+            def has_platform_permission(self, user, action):
+                return False
+
+            def list_platform_permissions(self, user):
+                return []
+
+            def get_platform_role(self, user):
+                return None
+
+            def ensure_platform_role(self, user, role):
+                seen.append((user.pk, role))
+
+        register_authz_provider(_Stub())
+        ensure_platform_role(self.staff, ROLE_PLATFORM_ADMIN)
+        self.assertEqual(seen, [(self.staff.pk, ROLE_PLATFORM_ADMIN)])
+        ensure_platform_role(self.user, ROLE_PLATFORM_ADMIN)
+        self.assertEqual(seen, [(self.staff.pk, ROLE_PLATFORM_ADMIN)])


### PR DESCRIPTION
## Summary
- Seeded `is_staff` admins now receive an explicit Platform Admin role when EE AuthZ is loaded.
- Fixes TEST offline install browser smoke: Platform Ops was denied and redirected to the tenant UI.

## Test plan
- [x] `common.tests.test_platform_authz`
- [x] `apps.iam.tests.test_seed_initial_data`
- [ ] Re-run `HFL - TEST Build & Deploy` after merge (pair with EE ensure_platform_role PR)


Made with [Cursor](https://cursor.com)