### PR TITLE
Disable repeated task filter applies

### DIFF
--- a/src/frontend/src/pages/ops/Tasks.vue
+++ b/src/frontend/src/pages/ops/Tasks.vue
@@ -1204,7 +1204,7 @@ watch(
           <ElButton @click="cancelAdvancedFilter">{{ t('ops.task.cancelFilter') }}</ElButton>
           <div class="el-drawer__footer-actions">
             <ElButton @click="resetAdvancedFilterDraft">{{ t('ops.task.resetFilter') }}</ElButton>
-            <ElButton type="primary" @click="applyAdvancedFilters">{{ t('ops.task.applyFilter') }}</ElButton>
+            <ElButton type="primary" :disabled="loading" @click="applyAdvancedFilters">{{ t('ops.task.applyFilter') }}</ElButton>
           </div>
         </div>
       </template>


### PR DESCRIPTION
## Summary

- Disable the Tasks advanced-filter Apply button while the task list is loading.
- Preserve the existing immediate drawer close and table loading feedback.

## Testing

- `npm test -- --run src/composables/listSearchCoverage.test.ts src/composables/taskDetailScrollResetCoverage.test.ts src/lib/taskStepEmptyEventsCoverage.test.ts`
- `npm run build`