### PR TITLE
Fix legacy curl compatibility in bootstrap downloads

### DIFF
--- a/deploy/bootstrap/agent-bootstrap-linux.sh
+++ b/deploy/bootstrap/agent-bootstrap-linux.sh
@@ -50,12 +50,17 @@ hfl_download() {
 	local destination="$3"
 	local partial="${destination}.part"
 	local started=${SECONDS} elapsed bytes rate
+	local -a retry_connrefused=()
 	rm -f "${partial}"
 	hfl_step "Downloading ${label}."
+	# CentOS 7 ships curl 7.29, which predates --retry-connrefused.
+	if curl --retry-connrefused --version >/dev/null 2>&1; then
+		retry_connrefused=(--retry-connrefused)
+	fi
 	# ${arr[@]+...} keeps empty CURL_TLS safe under `set -u` on Bash < 4.4 (CentOS 7).
 	if ! curl ${CURL_TLS[@]+"${CURL_TLS[@]}"} \
 		--fail --show-error --location --progress-bar \
-		--retry 3 --retry-connrefused --retry-delay 2 \
+		--retry 3 ${retry_connrefused[@]+"${retry_connrefused[@]}"} --retry-delay 2 \
 		"${url}" -o "${partial}"; then
 		rm -f "${partial}"
 		hfl_fail "Failed to download ${label}." 3

--- a/deploy/bootstrap/agent-bootstrap-macos.sh
+++ b/deploy/bootstrap/agent-bootstrap-macos.sh
@@ -50,12 +50,17 @@ hfl_download() {
 	local destination="$3"
 	local partial="${destination}.part"
 	local started=${SECONDS} elapsed bytes rate
+	local -a retry_connrefused=()
 	rm -f "${partial}"
 	hfl_step "Downloading ${label}."
+	# Older system curl builds may predate --retry-connrefused.
+	if curl --retry-connrefused --version >/dev/null 2>&1; then
+		retry_connrefused=(--retry-connrefused)
+	fi
 	# ${arr[@]+...} keeps empty CURL_TLS safe under `set -u` on Bash < 4.4.
 	if ! curl ${CURL_TLS[@]+"${CURL_TLS[@]}"} \
 		--fail --show-error --location --progress-bar \
-		--retry 3 --retry-connrefused --retry-delay 2 \
+		--retry 3 ${retry_connrefused[@]+"${retry_connrefused[@]}"} --retry-delay 2 \
 		"${url}" -o "${partial}"; then
 		rm -f "${partial}"
 		hfl_fail "Failed to download ${label}." 3

--- a/deploy/bootstrap/gateway-bootstrap-linux.sh
+++ b/deploy/bootstrap/gateway-bootstrap-linux.sh
@@ -60,12 +60,17 @@ hfl_download() {
 	local destination="$3"
 	local partial="${destination}.part"
 	local started=${SECONDS} elapsed bytes rate
+	local -a retry_connrefused=()
 	rm -f "${partial}"
 	hfl_step "Downloading ${label}."
+	# CentOS 7 ships curl 7.29, which predates --retry-connrefused.
+	if curl --retry-connrefused --version >/dev/null 2>&1; then
+		retry_connrefused=(--retry-connrefused)
+	fi
 	# ${arr[@]+...} keeps empty CURL_TLS safe under `set -u` on Bash < 4.4 (CentOS 7).
 	if ! curl ${CURL_TLS[@]+"${CURL_TLS[@]}"} \
 		--fail --show-error --location --progress-bar \
-		--retry 3 --retry-connrefused --retry-delay 2 \
+		--retry 3 ${retry_connrefused[@]+"${retry_connrefused[@]}"} --retry-delay 2 \
 		"${url}" -o "${partial}"; then
 		rm -f "${partial}"
 		hfl_fail "Failed to download ${label}." 3

--- a/deploy/bootstrap/gateway-install-docker-ubuntu-amd64.sh
+++ b/deploy/bootstrap/gateway-install-docker-ubuntu-amd64.sh
@@ -54,12 +54,17 @@ hfl_download() {
 	local destination="$3"
 	local partial="${destination}.part"
 	local started=${SECONDS} elapsed bytes rate
+	local -a retry_connrefused=()
 	rm -f "${partial}"
 	hfl_step "Downloading ${label}."
+	# Older system curl builds may predate --retry-connrefused.
+	if curl --retry-connrefused --version >/dev/null 2>&1; then
+		retry_connrefused=(--retry-connrefused)
+	fi
 	# ${arr[@]+...} keeps empty CURL_TLS safe under `set -u` on Bash < 4.4.
 	if ! curl ${CURL_TLS[@]+"${CURL_TLS[@]}"} \
 		--fail --show-error --location --progress-bar \
-		--retry 3 --retry-connrefused --retry-delay 2 \
+		--retry 3 ${retry_connrefused[@]+"${retry_connrefused[@]}"} --retry-delay 2 \
 		"${url}" -o "${partial}"; then
 		rm -f "${partial}"
 		hfl_fail "Failed to download ${label}." 3

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -925,13 +925,15 @@ grep -F 'launchd is required to install the agent service on macOS' "${agent_boo
 grep -F 'Windows ARM64 is not supported by this release' "${agent_bootstrap_windows}" >/dev/null
 for bootstrap in "${agent_bootstrap_linux}" "${agent_bootstrap_macos}"; do
 	grep -F -- '--fail --show-error --location --progress-bar' "${bootstrap}" >/dev/null
-	grep -F -- '--retry 3 --retry-connrefused --retry-delay 2' "${bootstrap}" >/dev/null
+	grep -F 'curl --retry-connrefused --version' "${bootstrap}" >/dev/null
+	grep -F -- '--retry 3 ${retry_connrefused[@]+"${retry_connrefused[@]}"} --retry-delay 2' "${bootstrap}" >/dev/null
 	grep -F 'HyperFileLens enrollment helper' "${bootstrap}" >/dev/null
 	grep -F 'partial="${destination}.part"' "${bootstrap}" >/dev/null
 done
 for bootstrap in "${gateway_bootstrap_linux}" "${gateway_docker_installer}"; do
 	grep -F -- '--fail --show-error --location --progress-bar' "${bootstrap}" >/dev/null
-	grep -F -- '--retry 3 --retry-connrefused --retry-delay 2' "${bootstrap}" >/dev/null
+	grep -F 'curl --retry-connrefused --version' "${bootstrap}" >/dev/null
+	grep -F -- '--retry 3 ${retry_connrefused[@]+"${retry_connrefused[@]}"} --retry-delay 2' "${bootstrap}" >/dev/null
 	grep -F 'partial="${destination}.part"' "${bootstrap}" >/dev/null
 done
 # CentOS 7 / Bash < 4.4: empty CURL_TLS + set -u requires ${arr[@]+"${arr[@]}"} (not "${arr[@]}").

--- a/tools/quality/test-bootstrap-curl-tls-nounset.sh
+++ b/tools/quality/test-bootstrap-curl-tls-nounset.sh
@@ -72,6 +72,13 @@ curl_args=(${CURL_TLS[@]+"${CURL_TLS[@]}"})
 CURL_TLS=(-k)
 curl_args=(${CURL_TLS[@]+"${CURL_TLS[@]}"})
 [[ "${#curl_args[@]}" -eq 1 && "${curl_args[0]}" == "-k" ]]
+# The optional retry flag uses the same safe expansion on Bash 4.2.
+retry_connrefused=()
+curl_args=(${retry_connrefused[@]+"${retry_connrefused[@]}"})
+[[ "${#curl_args[@]}" -eq 0 ]]
+retry_connrefused=(--retry-connrefused)
+curl_args=(${retry_connrefused[@]+"${retry_connrefused[@]}"})
+[[ "${#curl_args[@]}" -eq 1 && "${curl_args[0]}" == "--retry-connrefused" ]]
 printf 'ok\n'
 SH
 	docker run --rm -v "${tmp}/probe.sh:/probe.sh:ro" bash:4.2 \

--- a/tools/quality/test-bootstrap-download-progress.sh
+++ b/tools/quality/test-bootstrap-download-progress.sh
@@ -11,6 +11,13 @@ mkdir -p "${tmp}/bin"
 cat >"${tmp}/bin/curl" <<'SH'
 #!/usr/bin/env bash
 set -euo pipefail
+if [[ "${1:-}" == "--retry-connrefused" && "${2:-}" == "--version" ]]; then
+	if [[ "${HFL_TEST_CURL_SUPPORT_RETRY_CONNREFUSED:-0}" == "1" ]]; then
+		exit 0
+	fi
+	printf 'curl: option --retry-connrefused: is unknown\n' >&2
+	exit 2
+fi
 output=""
 while (($#)); do
 	printf '%s\n' "$1" >>"${HFL_TEST_CURL_LOG}"
@@ -36,6 +43,7 @@ source <(sed -n '/^hfl_now()/,/^hfl_build_enroll_args()/p' "${bootstrap}" | sed 
 CURL_TLS=()
 PATH="${tmp}/bin:${PATH}"
 export PATH HFL_TEST_CURL_LOG="${tmp}/curl.log"
+export HFL_TEST_CURL_SUPPORT_RETRY_CONNREFUSED=1
 
 destination="${tmp}/hfl-enroll"
 output="$(hfl_download "HyperFileLens enrollment helper" https://example.invalid/helper "${destination}" 2>&1)"
@@ -44,6 +52,21 @@ grep -F '[ OK  ] HyperFileLens enrollment helper downloaded (' <<<"${output}" >/
 grep -Fx -- '--progress-bar' "${HFL_TEST_CURL_LOG}" >/dev/null
 grep -Fx -- '--retry' "${HFL_TEST_CURL_LOG}" >/dev/null
 grep -Fx -- '--retry-connrefused' "${HFL_TEST_CURL_LOG}" >/dev/null
+grep -Fx 'bootstrap-download-fixture' "${destination}" >/dev/null
+[[ ! -e "${destination}.part" ]]
+
+# curl 7.29 (CentOS 7) must download without the unsupported optional flag.
+rm -f "${destination}"
+: >"${HFL_TEST_CURL_LOG}"
+export HFL_TEST_CURL_SUPPORT_RETRY_CONNREFUSED=0
+output="$(hfl_download "HyperFileLens enrollment helper" https://example.invalid/helper "${destination}" 2>&1)"
+grep -F '[ OK  ] HyperFileLens enrollment helper downloaded (' <<<"${output}" >/dev/null
+grep -Fx -- '--retry' "${HFL_TEST_CURL_LOG}" >/dev/null
+grep -Fx -- '--retry-delay' "${HFL_TEST_CURL_LOG}" >/dev/null
+if grep -Fx -- '--retry-connrefused' "${HFL_TEST_CURL_LOG}" >/dev/null; then
+	printf 'ERROR: unsupported --retry-connrefused was passed to a legacy curl\n' >&2
+	exit 1
+fi
 grep -Fx 'bootstrap-download-fixture' "${destination}" >/dev/null
 [[ ! -e "${destination}.part" ]]
 


### PR DESCRIPTION
## Summary
- Detect whether the host curl supports `--retry-connrefused` before using it.
- Preserve standard retries on CentOS 7 curl 7.29 while retaining connection-refused retries on newer curl versions.
- Apply the behavior consistently to Agent and Gateway bootstrap downloads.
- Add legacy curl, Bash 4.2, and release-contract regression coverage.

## Validation
- `./tools/quality/test-bootstrap-download-progress.sh`
- `./tools/quality/test-bootstrap-curl-tls-nounset.sh`
- `HFL_TEST_BASH42=1 ./tools/quality/test-bootstrap-curl-tls-nounset.sh`
- `./tools/quality/check-release-contracts.sh`
- `git diff --check`

Closes #424