### PR TITLE
fix(frontend): count dashboard nodes by availability

### DIFF
--- a/src/backend/apps/monitor/tests/test_api.py
+++ b/src/backend/apps/monitor/tests/test_api.py
@@ -83,3 +83,40 @@ class SystemMonitorApiTests(TestCase):
         self.assertEqual(response.data["count"], 11)
         self.assertEqual(len(response.data["results"]), 10)
         self.assertIn("node", {row["kind"] for row in response.data["results"]})
+
+    def test_node_attention_excludes_online_active_nodes(self):
+        now = timezone.now()
+        online = Node.objects.create(
+            organization=self.org,
+            name="Online agent",
+            role=Node.Role.AGENT,
+            status=Node.Status.ACTIVE,
+            availability=Node.Availability.ONLINE,
+            availability_updated_at=now,
+        )
+        offline = Node.objects.create(
+            organization=self.org,
+            name="Offline agent",
+            role=Node.Role.AGENT,
+            status=Node.Status.ACTIVE,
+            availability=Node.Availability.OFFLINE,
+            availability_updated_at=now - timedelta(minutes=1),
+        )
+
+        response = self.client.get(
+            "/api/v1/monitors/attention/",
+            {"type": "node"},
+            HTTP_X_ORG_KEY=self.org.key,
+            secure=True,
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 1)
+        self.assertEqual(
+            [row["id"] for row in response.data["results"]],
+            [f"node-{offline.id}"],
+        )
+        self.assertNotIn(
+            f"node-{online.id}",
+            {row["id"] for row in response.data["results"]},
+        )

--- a/src/frontend/src/lib/dashboardApi.ts
+++ b/src/frontend/src/lib/dashboardApi.ts
@@ -10,6 +10,7 @@ import { buildQuotaRows, type QuotaUsageRow } from './licenseQuotaDisplay'
 import { productionSourceSummary, type ProductionSourceSummary } from './sourceApi'
 import { listBackupConfigs } from './protectionBackupConfigApi'
 import { listRestorePlans } from './restoreApi'
+import { summarizeNodeAvailability } from './nodeAvailability'
 import type { ApiNode } from '../types/node'
 
 export type StorageSummary = {
@@ -426,7 +427,7 @@ export async function loadDashboardOverview(
     loadAttentionPage().catch(() => ({ count: 0, results: [] })),
   ])
 
-  const nodesOnline = nodes.filter((n) => n.status === 'online').length
+  const nodeAvailability = summarizeNodeAvailability(nodes)
   const nodesTotal = nodes.length
   const orgName =
     license.organization_name ||
@@ -507,9 +508,9 @@ export async function loadDashboardOverview(
       successRate: auditStats.success_rate,
       failureCount: auditStats.failure_count,
     },
-    nodesOnline,
+    nodesOnline: nodeAvailability.online,
     nodesTotal,
-    nodesOffline: nodesTotal - nodesOnline,
+    nodesOffline: nodeAvailability.offline,
     nodesByRole: countNodesByRole(nodes),
     productionSources,
     protectionPolicies,

--- a/src/frontend/src/lib/nodeAvailability.test.ts
+++ b/src/frontend/src/lib/nodeAvailability.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+import { summarizeNodeAvailability } from './nodeAvailability'
+
+describe('Dashboard node availability summary', () => {
+  it('counts connectivity availability independently from lifecycle status', () => {
+    expect(
+      summarizeNodeAvailability([
+        { availability: 'online' },
+        { availability: 'offline' },
+        { availability: 'online' },
+        {},
+      ]),
+    ).toEqual({ online: 2, offline: 1 })
+  })
+})

--- a/src/frontend/src/lib/nodeAvailability.ts
+++ b/src/frontend/src/lib/nodeAvailability.ts
@@ -1,0 +1,13 @@
+import type { ApiNode } from '../types/node'
+
+export function summarizeNodeAvailability(
+  nodes: Array<Pick<ApiNode, 'availability'>>,
+): { online: number; offline: number } {
+  let online = 0
+  let offline = 0
+  for (const node of nodes) {
+    if (node.availability === 'online') online += 1
+    if (node.availability === 'offline') offline += 1
+  }
+  return { online, offline }
+}


### PR DESCRIPTION
## Problem and root cause

Dashboard node summaries compared the lifecycle `status` field with `online` even though connectivity is represented by `availability`. A healthy node with `status=active` and `availability=online` could therefore be counted as offline. The Attention API now uses availability correctly, but it lacked regression coverage for excluding active online nodes.

## Solution

- Count Dashboard online and offline nodes from explicit availability values.
- Keep missing availability values out of both connectivity counts instead of treating them as offline.
- Add backend coverage proving that the node attention stream excludes active online nodes.
- Add focused frontend coverage for online, offline, and missing availability values.

## Validation

- Manual testing: passed
- Backend monitor tests: 19 passed
- Full backend tests: 1,273 passed
- Ruff: passed
- Django migration check: no changes detected
- Frontend tests: 748 passed
- Frontend CI tests: 748 passed
- Frontend lint: passed with zero errors
- Frontend production build: passed
- Git diff check: passed
- English-only source check: passed
- Post-sync product checks: skipped because the canonical-base rebase was conflict-free and preserved the tested patch exactly

## Risks and compatibility

The change does not modify models, migrations, REST payloads, permissions, or heartbeat behavior. Unknown availability values are no longer reported as offline in Dashboard summary data.

Fixes #409
