### PR TITLE
Align recovery drill task metrics

### DIFF
--- a/src/backend/apps/task/api/views/task.py
+++ b/src/backend/apps/task/api/views/task.py
@@ -107,7 +107,12 @@ class TaskViewSet(viewsets.ModelViewSet):
 
     @action(detail=False, methods=["get"], url_path="statistics")
     def statistics(self, request):
-        return Response(task_statistics(organization_id=self._organization_id()))
+        return Response(
+            task_statistics(
+                organization_id=self._organization_id(),
+                queryset=self.get_queryset(),
+            )
+        )
 
     @action(detail=True, methods=["post"], url_path="cancel")
     def cancel(self, request, task_uuid=None):

--- a/src/backend/apps/task/selectors/interface.py
+++ b/src/backend/apps/task/selectors/interface.py
@@ -98,18 +98,15 @@ def list_task_events(*, task: Task, level: str | None = None, after_seq: int | N
     return queryset
 
 
-def task_statistics(*, organization_id: int) -> dict:
+def task_statistics(*, organization_id: int, queryset: QuerySet[Task] | None = None) -> dict:
+    queryset = queryset if queryset is not None else Task.objects.filter(organization_id=organization_id)
     counts = {
         row["status"]: row["count"]
-        for row in Task.objects.filter(organization_id=organization_id)
-        .values("status")
-        .annotate(count=Count("id"))
+        for row in queryset.order_by().values("status").annotate(count=Count("id"))
     }
     by_type = {
         row["task_type"]: row["count"]
-        for row in Task.objects.filter(organization_id=organization_id)
-        .values("task_type")
-        .annotate(count=Count("id"))
+        for row in queryset.order_by().values("task_type").annotate(count=Count("id"))
     }
     return {
         "total": sum(counts.values()),

--- a/src/backend/apps/task/tests/test_api.py
+++ b/src/backend/apps/task/tests/test_api.py
@@ -103,6 +103,37 @@ class TaskApiTests(TestCase):
         self.assertEqual(response.data["failed"], 1)
         self.assertEqual(response.data["by_task_type"], {Task.Type.RESTORE: 2})
 
+    def test_statistics_reports_all_task_statuses(self):
+        for task_status in (
+            Task.Status.PENDING,
+            Task.Status.RUNNING,
+            Task.Status.SUCCESS,
+            Task.Status.FAILED,
+            Task.Status.CANCELLED,
+            Task.Status.TIMEOUT,
+        ):
+            Task.objects.create(
+                organization_id=self.org.id,
+                task_type=Task.Type.BACKUP,
+                display_name=f"{task_status} task",
+                status=task_status,
+            )
+
+        response = self.client.get(
+            "/api/v1/tasks/statistics/",
+            follow=True,
+            **self._headers(),
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+        self.assertEqual(response.data["total"], 6)
+        self.assertEqual(response.data["running"], 1)
+        self.assertEqual(response.data["success"], 1)
+        self.assertEqual(response.data["failed"], 1)
+        self.assertEqual(response.data["cancelled"], 1)
+        self.assertEqual(response.data["timeout"], 1)
+        self.assertEqual(response.data["by_status"][Task.Status.PENDING], 1)
+
     def test_create_task_persists_after_listing_refresh(self):
         response = self.client.post(
             "/api/v1/tasks/",

--- a/src/backend/apps/task/tests/test_api.py
+++ b/src/backend/apps/task/tests/test_api.py
@@ -1,7 +1,9 @@
 from decimal import Decimal
+from datetime import timedelta
 
 from django.contrib.auth import get_user_model
 from django.test import SimpleTestCase, TestCase
+from django.utils import timezone
 from rest_framework import status
 from rest_framework.test import APIClient
 
@@ -54,6 +56,52 @@ class TaskApiTests(TestCase):
 
     def _headers(self, org: Organization | None = None):
         return {"HTTP_X_ORG_KEY": (org or self.org).key}
+
+    def test_statistics_honors_task_type_and_created_range(self):
+        now = timezone.now()
+        recent_restore = Task.objects.create(
+            organization_id=self.org.id,
+            task_type=Task.Type.RESTORE,
+            display_name="Recent restore",
+            status=Task.Status.SUCCESS,
+        )
+        recent_failure = Task.objects.create(
+            organization_id=self.org.id,
+            task_type=Task.Type.RESTORE,
+            display_name="Recent failed restore",
+            status=Task.Status.FAILED,
+        )
+        old_restore = Task.objects.create(
+            organization_id=self.org.id,
+            task_type=Task.Type.RESTORE,
+            display_name="Old restore",
+            status=Task.Status.SUCCESS,
+        )
+        Task.objects.filter(pk=recent_restore.pk).update(created_at=now - timedelta(hours=1))
+        Task.objects.filter(pk=recent_failure.pk).update(created_at=now - timedelta(hours=2))
+        Task.objects.filter(pk=old_restore.pk).update(created_at=now - timedelta(days=2))
+        Task.objects.create(
+            organization_id=self.org.id,
+            task_type=Task.Type.BACKUP,
+            display_name="Recent backup",
+            status=Task.Status.SUCCESS,
+        )
+
+        response = self.client.get(
+            "/api/v1/tasks/statistics/",
+            {
+                "task_type": Task.Type.RESTORE,
+                "created_after": (now - timedelta(hours=24)).isoformat(),
+            },
+            follow=True,
+            **self._headers(),
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+        self.assertEqual(response.data["total"], 2)
+        self.assertEqual(response.data["success"], 1)
+        self.assertEqual(response.data["failed"], 1)
+        self.assertEqual(response.data["by_task_type"], {Task.Type.RESTORE: 2})
 
     def test_create_task_persists_after_listing_refresh(self):
         response = self.client.post(

--- a/src/frontend/src/lib/dashboardApi.ts
+++ b/src/frontend/src/lib/dashboardApi.ts
@@ -3,7 +3,7 @@ import { unwrapApiPayload, asList } from './parse'
 import { getEffectiveOrgKey } from '../composables/useAuth'
 import { listRecords, listPolicies as listAlertPolicies } from './alertApi'
 import { auditStatistics } from './auditApi'
-import { taskStatistics, listTasks, type TaskRow } from './taskApi'
+import { taskStatistics, listTasks, type TaskRow, type TaskStatistics } from './taskApi'
 import { listAllNodes } from './nodeApi'
 import { fetchCurrentLicense } from './subscriptionApi'
 import { buildQuotaRows, type QuotaUsageRow } from './licenseQuotaDisplay'
@@ -93,7 +93,7 @@ export type DashboardOverview = {
     cancelled: number
     byTaskType: Record<string, number>
   }
-  tasks24h: {
+  recoveryDrill24h: {
     total: number
     success: number
     failed: number
@@ -249,18 +249,13 @@ function buildTasks7dBuckets(tasks: TaskRow[]): TaskDayBucket[] {
   return buckets
 }
 
-function summarizeTasks24h(tasks: TaskRow[]) {
-  let success = 0
-  let failed = 0
-  const terminal = new Set(['success', 'failed', 'timeout', 'cancelled'])
-  for (const task of tasks) {
-    if (!terminal.has(task.status)) continue
-    if (task.status === 'success') success += 1
-    else if (task.status === 'failed' || task.status === 'timeout') failed += 1
-  }
+function summarizeRecoveryDrill24h(stats: TaskStatistics) {
+  const success = stats.success
+  const failed = stats.failed + stats.timeout
   const done = success + failed
   return {
-    total: tasks.length,
+    total: stats.total,
+    running: stats.running,
     success,
     failed,
     successRate: done > 0 ? Math.round((success / done) * 1000) / 10 : null,
@@ -358,11 +353,12 @@ export async function loadDashboardOverview(
   t: (key: string, p?: Record<string, unknown>) => string,
 ): Promise<DashboardOverview> {
   const orgKey = getEffectiveOrgKey()
+  const recoveryDrillStartedAfter = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString()
 
   const [
     license,
     taskStats,
-    tasks24hPage,
+    recoveryDrill24hStats,
     tasks7dPage,
     runningTasksPage,
     productionSources,
@@ -395,7 +391,15 @@ export async function loadDashboardOverview(
       timeout: 0,
       by_task_type: {},
     })),
-    listTasks({ time_range: '24h', page_size: 500 }).catch(() => ({ count: 0, results: [] })),
+    taskStatistics({ task_type: 'restore', created_after: recoveryDrillStartedAfter }).catch(() => ({
+      total: 0,
+      running: 0,
+      success: 0,
+      failed: 0,
+      cancelled: 0,
+      timeout: 0,
+      by_task_type: {},
+    })),
     listTasks({ time_range: '7d', page_size: 500 }).catch(() => ({ count: 0, results: [] })),
     listTasks({ status: 'running', page_size: 8 }).catch(() => ({ count: 0, results: [] })),
     productionSourceSummary().catch(() => ({
@@ -495,7 +499,7 @@ export async function loadDashboardOverview(
       cancelled: taskStats.cancelled,
       byTaskType: taskStats.by_task_type || {},
     },
-    tasks24h: summarizeTasks24h(tasks24hPage.results),
+    recoveryDrill24h: summarizeRecoveryDrill24h(recoveryDrill24hStats),
     tasks7dBuckets: buildTasks7dBuckets(tasks7dPage.results),
     runningTasks: runningTasksPage.results,
     alertFiring: alertsFiringPage.count || alertsFiringPage.results.length,

--- a/src/frontend/src/lib/taskApi.ts
+++ b/src/frontend/src/lib/taskApi.ts
@@ -119,8 +119,11 @@ export async function getTask(taskUuid: string, init?: RequestInit) {
   return unwrapApiPayload<TaskRow>(await api<unknown>(`${base}/${taskUuid}/`, init))
 }
 
-export async function taskStatistics(init?: RequestInit) {
-  return unwrapApiPayload<TaskStatistics>(await api<unknown>(`${base}/statistics/`, init))
+export async function taskStatistics(
+  params?: Record<string, string | number | undefined>,
+  init?: RequestInit,
+) {
+  return unwrapApiPayload<TaskStatistics>(await api<unknown>(withQuery(`${base}/statistics/`, params), init))
 }
 
 export async function listTaskSteps(taskUuid: string, init?: RequestInit) {

--- a/src/frontend/src/locales/en.ts
+++ b/src/frontend/src/locales/en.ts
@@ -2708,6 +2708,7 @@ export const en = {
         creating: 'Creating',
         success: 'Succeeded',
         failed: 'Failed',
+        failedTimedOut: 'Failed / Timed out',
         cancelled: 'Cancelled',
         timeout: 'Timed out',
         partial: 'Partial',

--- a/src/frontend/src/pages/Dashboard.vue
+++ b/src/frontend/src/pages/Dashboard.vue
@@ -41,7 +41,7 @@ const routes = {
   sources: '/protection/backup-sources?tab=host',
   policies: '/protection/policies',
   repositories: '/node/repositories',
-  tasks: '/ops/task',
+  tasks: '/ops/task?task_type=restore&time_mode=24h',
   attention: '/ops/attention',
   audit: '/ops/audit',
   subscription: '/node/subscription',
@@ -310,10 +310,10 @@ const storageUsedProgressLabel = computed(() => {
 const slaRibbonBadge = computed(() => {
   const firing = overview.value?.alertFiring ?? 0
   if (firing > 0) return t('dashboard.ribbon.slaAlerts', { n: firing })
-  const success = overview.value?.tasks24h?.success ?? 0
-  const failed = overview.value?.tasks24h?.failed ?? 0
+  const success = overview.value?.recoveryDrill24h?.success ?? 0
+  const failed = overview.value?.recoveryDrill24h?.failed ?? 0
   if (success + failed === 0) return ''
-  const rate = overview.value?.tasks24h?.successRate
+  const rate = overview.value?.recoveryDrill24h?.successRate
   if (rate != null && rate < 90) return t('dashboard.ribbon.slaAtRisk')
   return ''
 })
@@ -636,7 +636,7 @@ onMounted(refresh)
           </div>
           <div class="ribbon-card__value-row">
             <span class="ribbon-card__value">
-              {{ overview?.tasks24h?.successRate != null ? `${overview.tasks24h.successRate}%` : '0%' }}
+              {{ overview?.recoveryDrill24h?.successRate != null ? `${overview.recoveryDrill24h.successRate}%` : '—' }}
             </span>
             <span v-if="slaRibbonBadgeVisible" class="ribbon-card__badge" :class="slaRibbonBadgeClass">
               {{ slaRibbonBadge }}
@@ -650,7 +650,7 @@ onMounted(refresh)
           <div class="ribbon-track">
             <div
               class="ribbon-fill ribbon-fill--indigo"
-              :style="{ width: `${overview?.tasks24h?.successRate ?? 0}%` }"
+              :style="{ width: `${overview?.recoveryDrill24h?.successRate ?? 0}%` }"
             />
           </div>
         </div>
@@ -659,7 +659,7 @@ onMounted(refresh)
             <span>{{ t('dashboard.ribbon.succeeded') }}</span>
             <strong class="text-emerald-600">
               <span class="ribbon-stat-dot ribbon-stat-dot--success" />
-              {{ overview?.tasks24h?.success ?? 0 }}{{ t('dashboard.unitCount') ? ` ${t('dashboard.unitCount')}` : '' }}
+              {{ overview?.recoveryDrill24h?.success ?? 0 }}{{ t('dashboard.unitCount') ? ` ${t('dashboard.unitCount')}` : '' }}
             </strong>
           </div>
           <div>
@@ -669,14 +669,14 @@ onMounted(refresh)
                 <span class="ribbon-stat-pulse__ring" />
                 <span class="ribbon-stat-pulse__dot" />
               </span>
-              {{ overview?.taskStats.running ?? 0 }}{{ t('dashboard.unitCount') ? ` ${t('dashboard.unitCount')}` : '' }}
+              {{ overview?.recoveryDrill24h?.running ?? 0 }}{{ t('dashboard.unitCount') ? ` ${t('dashboard.unitCount')}` : '' }}
             </strong>
           </div>
           <div>
             <span>{{ t('dashboard.ribbon.failed') }}</span>
-            <strong :class="(overview?.tasks24h?.failed ?? 0) > 0 ? 'ribbon-stat--danger' : 'ribbon-stat--muted'">
-              <span class="ribbon-stat-dot" :class="(overview?.tasks24h?.failed ?? 0) > 0 ? 'ribbon-stat-dot--danger ribbon-stat-dot--pulse' : 'ribbon-stat-dot--muted'" />
-              {{ overview?.tasks24h?.failed ?? 0 }}{{ t('dashboard.unitCount') ? ` ${t('dashboard.unitCount')}` : '' }}
+            <strong :class="(overview?.recoveryDrill24h?.failed ?? 0) > 0 ? 'ribbon-stat--danger' : 'ribbon-stat--muted'">
+              <span class="ribbon-stat-dot" :class="(overview?.recoveryDrill24h?.failed ?? 0) > 0 ? 'ribbon-stat-dot--danger ribbon-stat-dot--pulse' : 'ribbon-stat-dot--muted'" />
+              {{ overview?.recoveryDrill24h?.failed ?? 0 }}{{ t('dashboard.unitCount') ? ` ${t('dashboard.unitCount')}` : '' }}
             </strong>
           </div>
         </div>

--- a/src/frontend/src/pages/DashboardRecoveryDrillMetrics.test.ts
+++ b/src/frontend/src/pages/DashboardRecoveryDrillMetrics.test.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const dashboard = readFileSync(resolve(process.cwd(), 'src/pages/Dashboard.vue'), 'utf8')
+const dashboardApi = readFileSync(resolve(process.cwd(), 'src/lib/dashboardApi.ts'), 'utf8')
+const tasks = readFileSync(resolve(process.cwd(), 'src/pages/ops/Tasks.vue'), 'utf8')
+
+describe('Dashboard recovery drill metrics', () => {
+  it('limits recovery drill metrics to restores created in the last 24 hours', () => {
+    expect(dashboardApi).toContain("task_type: 'restore', created_after: recoveryDrillStartedAfter")
+    expect(dashboardApi).toContain('recoveryDrill24h: summarizeRecoveryDrill24h(recoveryDrill24hStats)')
+    expect(dashboard).not.toContain('overview?.taskStats.running')
+  })
+
+  it('opens the task list with the matching recovery drill filters', () => {
+    expect(dashboard).toContain("tasks: '/ops/task?task_type=restore&time_mode=24h'")
+    expect(tasks).toContain("task_type: textQueryValue(route.query.task_type)")
+    expect(tasks).toContain("time_mode: textQueryValue(route.query.time_mode) === '24h' ? '24h' : '7d'")
+    expect(tasks).toContain('stats.value = await taskStatistics(filterParams, { signal })')
+  })
+})

--- a/src/frontend/src/pages/ops/Tasks.vue
+++ b/src/frontend/src/pages/ops/Tasks.vue
@@ -962,7 +962,7 @@ watch(
 <template>
   <ModulePage :title="t('ops.task.title')" :menus="opsMenus" body-fill>
     <div class="hfl-ops-page hfl-ops-page--fill">
-      <div class="hfl-ops-stats-grid hfl-ops-stats-grid--4">
+      <div class="hfl-ops-stats-grid hfl-ops-stats-grid--5">
         <OpsStatCard
           :label="t('ops.task.status.running')"
           :value="stats.running"
@@ -973,6 +973,16 @@ watch(
         >
           <template #icon>
             <Clock3 :size="17" />
+          </template>
+        </OpsStatCard>
+        <OpsStatCard
+          :label="t('ops.task.status.pending')"
+          :value="stats.by_status?.pending ?? 0"
+          accent="gray"
+          accent-side="left"
+        >
+          <template #icon>
+            <Circle :size="15" />
           </template>
         </OpsStatCard>
         <OpsStatCard
@@ -987,8 +997,8 @@ watch(
           </template>
         </OpsStatCard>
         <OpsStatCard
-          :label="t('ops.task.status.failed')"
-          :value="stats.failed"
+          :label="t('ops.task.status.failedTimedOut')"
+          :value="stats.failed + stats.timeout"
           accent="red"
           accent-side="left"
           value-class="text-red-600"
@@ -998,13 +1008,13 @@ watch(
           </template>
         </OpsStatCard>
         <OpsStatCard
-          :label="t('ops.task.status.pending')"
-          :value="stats.by_status?.pending ?? 0"
+          :label="t('ops.task.status.cancelled')"
+          :value="stats.cancelled"
           accent="gray"
           accent-side="left"
         >
           <template #icon>
-            <Circle :size="15" />
+            <CircleStop :size="16" />
           </template>
         </OpsStatCard>
       </div>

--- a/src/frontend/src/pages/ops/Tasks.vue
+++ b/src/frontend/src/pages/ops/Tasks.vue
@@ -90,9 +90,9 @@ const filters = reactive({
   search: '',
   search_field: 'name',
   status: '',
-  task_type: '',
+  task_type: textQueryValue(route.query.task_type),
   trigger_type: '',
-  time_mode: '7d',
+  time_mode: textQueryValue(route.query.time_mode) === '24h' ? '24h' : '7d',
   created_range: null as [Date, Date] | null,
   resource_type: '',
   resource_id: '',
@@ -331,6 +331,21 @@ function taskCreatedRangeParams() {
     }
   }
   return { created_after: undefined, created_before: undefined }
+}
+
+function taskFilterParams() {
+  const timeParams = taskCreatedRangeParams()
+  return {
+    search: appliedSearch.value.trim(),
+    search_field: filters.search_field,
+    status: filters.status,
+    task_type: filters.task_type,
+    trigger_type: filters.trigger_type,
+    resource_type: filters.resource_type,
+    resource_id: filters.resource_id,
+    created_after: timeParams.created_after,
+    created_before: timeParams.created_before,
+  }
 }
 
 function payloadRecord(task?: TaskRow | null) {
@@ -712,23 +727,15 @@ async function load() {
   loading.value = true
   listLoadError.value = null
   try {
-    const timeParams = taskCreatedRangeParams()
+    const filterParams = taskFilterParams()
     const res = await listTasks({
       page: pagination.page,
       page_size: pagination.pageSize,
-      search: appliedSearch.value.trim(),
-      search_field: filters.search_field,
-      status: filters.status,
-      task_type: filters.task_type,
-      trigger_type: filters.trigger_type,
-      resource_type: filters.resource_type,
-      resource_id: filters.resource_id,
-      created_after: timeParams.created_after,
-      created_before: timeParams.created_before,
+      ...filterParams,
     }, { signal })
     rows.value = res.results
     pagination.count = res.count
-    stats.value = await taskStatistics({ signal }).catch((e) => {
+    stats.value = await taskStatistics(filterParams, { signal }).catch((e) => {
       if (pageRequests.isAbortError(e)) throw e
       return stats.value
     })
@@ -909,7 +916,7 @@ async function cancelActiveTask() {
     syncTask(updated)
     const eventPage = await listTaskEvents(updated.task_uuid, { page_size: 50 })
     detailEvents.value = eventPage.results
-    stats.value = await taskStatistics().catch(() => stats.value)
+    stats.value = await taskStatistics(taskFilterParams()).catch(() => stats.value)
     if (syncRepositoryCancellation(updated)) {
       ElMessage.success(t('ops.task.repositoryCancelQueued'))
     }

--- a/src/frontend/src/pages/ops/TasksStatusCards.test.ts
+++ b/src/frontend/src/pages/ops/TasksStatusCards.test.ts
@@ -1,0 +1,23 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const page = readFileSync(resolve(process.cwd(), 'src/pages/ops/Tasks.vue'), 'utf8')
+const locale = readFileSync(resolve(process.cwd(), 'src/locales/en.ts'), 'utf8')
+
+describe('Tasks status cards', () => {
+  it('renders every task status represented by task statistics', () => {
+    expect(page).toContain('hfl-ops-stats-grid--5')
+    expect(page).toContain("t('ops.task.status.running')")
+    expect(page).toContain("t('ops.task.status.pending')")
+    expect(page).toContain("t('ops.task.status.success')")
+    expect(page).toContain("t('ops.task.status.failedTimedOut')")
+    expect(page).toContain("t('ops.task.status.cancelled')")
+    expect(page).toContain(':value="stats.failed + stats.timeout"')
+    expect(page).toContain(':value="stats.cancelled"')
+  })
+
+  it('uses an explicit label when failed and timed out tasks are grouped', () => {
+    expect(locale).toContain("failedTimedOut: 'Failed / Timed out'")
+  })
+})

--- a/src/frontend/src/styles/ops-list-ui.css
+++ b/src/frontend/src/styles/ops-list-ui.css
@@ -45,6 +45,16 @@
   .hfl-ops-stats-grid--4 {
     grid-template-columns: repeat(4, minmax(0, 1fr));
   }
+
+  .hfl-ops-stats-grid--5 {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 1024px) {
+  .hfl-ops-stats-grid--5 {
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+  }
 }
 
 @media (max-width: 767.98px) {
@@ -58,11 +68,13 @@
 
   .hfl-ops-stats-grid--2,
   .hfl-ops-stats-grid--3,
-  .hfl-ops-stats-grid--4 {
+  .hfl-ops-stats-grid--4,
+  .hfl-ops-stats-grid--5 {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
-  .hfl-ops-stats-grid--3 > :last-child:nth-child(odd) {
+  .hfl-ops-stats-grid--3 > :last-child:nth-child(odd),
+  .hfl-ops-stats-grid--5 > :last-child:nth-child(odd) {
     grid-column: 1 / -1;
   }
 

--- a/src/frontend/src/styles/opsStatsResponsive.test.ts
+++ b/src/frontend/src/styles/opsStatsResponsive.test.ts
@@ -12,8 +12,10 @@ describe('operations statistics responsive layout', () => {
     expect(styles).toMatch(/\.hfl-ops-page\s*{[^}]*gap:\s*24px;/s)
     expect(styles).not.toContain('@media (min-width: 768px) and (max-width: 1279.98px)')
     expect(styles).toMatch(/@media \(max-width: 767\.98px\)[\s\S]*?\.hfl-ops-page\s*{[^}]*gap:\s*12px;/)
-    expect(styles).toMatch(/@media \(max-width: 767\.98px\)[\s\S]*?\.hfl-ops-stats-grid--2,[\s\S]*?\.hfl-ops-stats-grid--4\s*{[^}]*grid-template-columns:\s*repeat\(2,/)
+    expect(styles).toMatch(/@media \(max-width: 767\.98px\)[\s\S]*?\.hfl-ops-stats-grid--2,[\s\S]*?\.hfl-ops-stats-grid--5\s*{[^}]*grid-template-columns:\s*repeat\(2,/)
     expect(styles).toContain('.hfl-ops-stats-grid--3 > :last-child:nth-child(odd)')
+    expect(styles).toContain('.hfl-ops-stats-grid--5 > :last-child:nth-child(odd)')
+    expect(styles).toMatch(/@media \(min-width: 1024px\)[\s\S]*?\.hfl-ops-stats-grid--5\s*{[^}]*grid-template-columns:\s*repeat\(5,/)
   })
 
   it('lets the incidents page scroll naturally on phones', () => {


### PR DESCRIPTION
## Summary

- Scope Dashboard Recovery Drill metrics to restore tasks created in the last 24 hours.
- Reuse list filters for task statistics so the Dashboard deep link, task status cards, and table share one result set.
- Render an exhaustive Tasks status distribution: Running, Queued, Succeeded, Failed / Timed out, and Cancelled.
- Cover filtered aggregation, Recovery Drill deep-link behavior, and complete task-status presentation.

Closes #417
Closes #459
Related: #413

## Testing

- `docker compose exec -T api python manage.py test --keepdb apps.task.tests.test_api.TaskApiTests.test_statistics_honors_task_type_and_created_range`
- `cd src/frontend && npm test -- --run src/pages/ops/TasksStatusCards.test.ts src/styles/opsStatsResponsive.test.ts src/pages/DashboardRecoveryDrillMetrics.test.ts`
- `cd src/frontend && npm run build`
- `cd src/frontend && npm run lint`