### PR TITLE
fix(insight): decouple usage refresh from SourceLens reconciliation

### DIFF
--- a/src/backend/apps/lens_bridge/migrations/0029_usage_ledger_reconciliation.py
+++ b/src/backend/apps/lens_bridge/migrations/0029_usage_ledger_reconciliation.py
@@ -1,0 +1,47 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("lens_bridge", "0028_gateway_link_capacity_gb"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="lensusageledger",
+            name="source_synced_at",
+            field=models.DateTimeField(blank=True, db_index=True, null=True),
+        ),
+        migrations.AddField(
+            model_name="lensusageledger",
+            name="reconciliation_attempts",
+            field=models.PositiveIntegerField(default=0),
+        ),
+        migrations.AddField(
+            model_name="lensusageledger",
+            name="reconciliation_claim_token",
+            field=models.UUIDField(blank=True, null=True, unique=True),
+        ),
+        migrations.AddField(
+            model_name="lensusageledger",
+            name="reconciliation_claimed_at",
+            field=models.DateTimeField(blank=True, db_index=True, null=True),
+        ),
+        migrations.AddField(
+            model_name="lensusageledger",
+            name="reconciliation_next_at",
+            field=models.DateTimeField(blank=True, db_index=True, null=True),
+        ),
+        migrations.AddField(
+            model_name="lensusageledger",
+            name="reconciliation_error",
+            field=models.TextField(blank=True, default=""),
+        ),
+        migrations.AddIndex(
+            model_name="lensusageledger",
+            index=models.Index(
+                fields=["run_status", "reconciliation_next_at"],
+                name="lens_busg_st_recon_idx",
+            ),
+        ),
+    ]

--- a/src/backend/apps/lens_bridge/models/links.py
+++ b/src/backend/apps/lens_bridge/models/links.py
@@ -741,7 +741,7 @@ class LensSessionLink(OrganizationScopedModel):
 
 
 class LensUsageLedger(OrganizationScopedModel):
-    """Immutable HFL-facing usage record for one SourceLens Q&A run."""
+    """Authoritative HFL-facing usage record for one SourceLens Q&A run."""
 
     hfl_user = models.ForeignKey(
         settings.AUTH_USER_MODEL,
@@ -783,6 +783,12 @@ class LensUsageLedger(OrganizationScopedModel):
     started_at = models.DateTimeField(null=True, blank=True)
     finished_at = models.DateTimeField(null=True, blank=True)
     occurred_at = models.DateTimeField(db_index=True)
+    source_synced_at = models.DateTimeField(null=True, blank=True, db_index=True)
+    reconciliation_attempts = models.PositiveIntegerField(default=0)
+    reconciliation_claim_token = models.UUIDField(null=True, blank=True, unique=True)
+    reconciliation_claimed_at = models.DateTimeField(null=True, blank=True, db_index=True)
+    reconciliation_next_at = models.DateTimeField(null=True, blank=True, db_index=True)
+    reconciliation_error = models.TextField(blank=True, default="")
 
     class Meta:
         db_table = "lens_bridge_usage_ledger"
@@ -795,5 +801,9 @@ class LensUsageLedger(OrganizationScopedModel):
             models.Index(
                 fields=["organization", "sl_user_id", "occurred_at"],
                 name="lens_busg_org_slusr_time_idx",
+            ),
+            models.Index(
+                fields=["run_status", "reconciliation_next_at"],
+                name="lens_busg_st_recon_idx",
             ),
         ]

--- a/src/backend/apps/lens_bridge/periodic_tasks.py
+++ b/src/backend/apps/lens_bridge/periodic_tasks.py
@@ -5,6 +5,17 @@ from common.scheduling.registry import TASK_REGISTRY
 
 def register_periodic_tasks() -> None:
     TASK_REGISTRY.add(
+        name="lens_bridge_reconcile_usage_ledgers",
+        task=(
+            "apps.lens_bridge.tasks.usage_reconciliation."
+            "reconcile_usage_ledgers_task"
+        ),
+        schedule=30,
+        kwargs={"limit": 100},
+        enabled=True,
+        expire_seconds=25,
+    )
+    TASK_REGISTRY.add(
         name="lens_bridge_reconcile_gateway_lensnode_provisions",
         task=(
             "apps.lens_bridge.tasks.gateway_provisioning."

--- a/src/backend/apps/lens_bridge/services/usage.py
+++ b/src/backend/apps/lens_bridge/services/usage.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta
 from decimal import Decimal, InvalidOperation
-import time
+import logging
 from typing import Any
 import uuid
 
-from django.db.models import Count, F, OrderBy, Q, Sum
+from django.db import transaction
+from django.db.models import Count, F, Max, OrderBy, Q, Sum
 from django.db.models.functions import TruncDate, TruncHour
 from django.utils import timezone
 from django.utils.dateparse import parse_date, parse_datetime
@@ -20,9 +21,14 @@ from apps.protection.models import BackupConfig, BackupSourceSnapshot
 from apps.protection.services.source_identity import resolve_source_display_name
 
 
-MAX_BACKFILL_RUNS = 500
-BACKFILL_TTL_SECONDS = 300
-_BACKFILL_REFRESHED_AT: dict[tuple[int, str, str], float] = {}
+logger = logging.getLogger(__name__)
+
+TERMINAL_RUN_STATUSES = frozenset({"done", "failed", "cancelled"})
+RECONCILIATION_INTERVAL_SECONDS = 30
+RECONCILIATION_CLAIM_TTL_SECONDS = 300
+RECONCILIATION_MAX_BACKOFF_SECONDS = 900
+RECONCILIATION_NOT_FOUND_CONFIRMATIONS = 3
+RECONCILIATION_NOT_FOUND_GRACE_SECONDS = 300
 
 
 def _decimal(value: Any) -> Decimal | None:
@@ -107,6 +113,7 @@ def register_usage_run(
     if sl_user is None:
         return None
     context = _session_context(link)
+    registered_at = timezone.now()
     row, _ = LensUsageLedger.objects.update_or_create(
         sl_run_uuid=run_uuid,
         defaults={
@@ -115,7 +122,8 @@ def register_usage_run(
             "sl_user_id": sl_user.sl_user_id,
             "question": question.strip(),
             "run_status": status or "queued",
-            "occurred_at": timezone.now(),
+            "occurred_at": registered_at,
+            "reconciliation_next_at": registered_at,
             **context,
         },
     )
@@ -132,13 +140,15 @@ def _run_call_details(
         "cached_tokens": 0,
         "reasoning_tokens": 0,
         "total_tokens": 0,
+        "model_calls": 0,
         "estimated_cost": None,
+        "available": False,
     }
     total_cost = Decimal("0")
-    has_cost = False
+    has_missing_cost = False
 
     def add_call(payload: dict[str, Any]) -> None:
-        nonlocal total_cost, has_cost
+        nonlocal total_cost, has_missing_cost
         prompt = int(payload.get("prompt_tokens") or 0)
         completion = int(payload.get("completion_tokens") or 0)
         cached = int(payload.get("cached_tokens") or 0)
@@ -147,21 +157,26 @@ def _run_call_details(
         cost = _decimal(payload.get("cost"))
         if cost is not None:
             total_cost += cost
-            has_cost = True
-        calls.append({
-            "call": len(calls) + 1,
-            "prompt_tokens": prompt,
-            "completion_tokens": completion,
-            "cached_tokens": cached,
-            "reasoning_tokens": reasoning,
-            "total_tokens": total,
-            "estimated_cost": float(cost) if cost is not None else None,
-        })
+        else:
+            has_missing_cost = True
+        calls.append(
+            {
+                "call": len(calls) + 1,
+                "prompt_tokens": prompt,
+                "completion_tokens": completion,
+                "cached_tokens": cached,
+                "reasoning_tokens": reasoning,
+                "total_tokens": total,
+                "estimated_cost": float(cost) if cost is not None else None,
+            }
+        )
         totals["prompt_tokens"] += prompt
         totals["completion_tokens"] += completion
         totals["cached_tokens"] += cached
         totals["reasoning_tokens"] += reasoning
         totals["total_tokens"] += total
+        totals["model_calls"] += 1
+        totals["available"] = True
 
     for step in run.get("steps") or []:
         detail = step.get("detail") if isinstance(step.get("detail"), dict) else step
@@ -171,11 +186,112 @@ def _run_call_details(
         usage = detail.get("usage")
         if isinstance(usage, dict) and usage:
             add_call(usage)
-    totals["estimated_cost"] = total_cost if has_cost else None
+    if calls:
+        totals["estimated_cost"] = total_cost if not has_missing_cost else None
+    else:
+        summary_keys = {
+            "prompt_tokens",
+            "completion_tokens",
+            "cached_tokens",
+            "reasoning_tokens",
+            "total_tokens",
+            "llm_calls",
+            "model_calls",
+            "total_cost",
+        }
+        if summary_keys.intersection(run):
+            prompt = int(run.get("prompt_tokens") or 0)
+            completion = int(run.get("completion_tokens") or 0)
+            totals.update(
+                {
+                    "prompt_tokens": prompt,
+                    "completion_tokens": completion,
+                    "cached_tokens": int(run.get("cached_tokens") or 0),
+                    "reasoning_tokens": int(run.get("reasoning_tokens") or 0),
+                    "total_tokens": int(run.get("total_tokens") or prompt + completion),
+                    "model_calls": int(
+                        run.get("llm_calls") or run.get("model_calls") or 0
+                    ),
+                    "estimated_cost": _decimal(run.get("total_cost")),
+                    "available": True,
+                }
+            )
     return calls, totals
 
 
-def capture_run_usage(link: LensSessionLink, run: dict[str, Any]) -> LensUsageLedger | None:
+def capture_ledger_usage(
+    row: LensUsageLedger,
+    run: dict[str, Any],
+    *,
+    synced_at: datetime | None = None,
+) -> LensUsageLedger:
+    """Persist the latest SourceLens state in the authoritative HFL ledger."""
+
+    calls, totals = _run_call_details(run)
+    row.run_status = str(run.get("status") or row.run_status or "")
+    if not row.question:
+        row.question = str(run.get("question") or "")
+    if totals["available"]:
+        row.prompt_tokens = totals["prompt_tokens"]
+        row.completion_tokens = totals["completion_tokens"]
+        row.cached_tokens = totals["cached_tokens"]
+        row.reasoning_tokens = totals["reasoning_tokens"]
+        row.total_tokens = totals["total_tokens"]
+        row.model_calls = totals["model_calls"]
+        row.estimated_cost = totals["estimated_cost"]
+        row.call_details_json = calls
+    if "error" in run:
+        row.run_error = str(run.get("error") or "")
+    started_at = _datetime(run.get("started_at"))
+    if started_at is not None:
+        row.started_at = started_at
+    finished_at = _datetime(run.get("finished_at"))
+    if finished_at is not None:
+        row.finished_at = finished_at
+    row.occurred_at = row.started_at or row.occurred_at or timezone.now()
+    row.source_synced_at = synced_at or timezone.now()
+    row.reconciliation_attempts = 0
+    row.reconciliation_claim_token = None
+    row.reconciliation_claimed_at = None
+    row.reconciliation_error = ""
+    row.reconciliation_next_at = (
+        None
+        if row.run_status in TERMINAL_RUN_STATUSES
+        else row.source_synced_at + timedelta(seconds=RECONCILIATION_INTERVAL_SECONDS)
+    )
+    row.save(
+        update_fields=[
+            "run_status",
+            "question",
+            "prompt_tokens",
+            "completion_tokens",
+            "cached_tokens",
+            "reasoning_tokens",
+            "total_tokens",
+            "model_calls",
+            "estimated_cost",
+            "call_details_json",
+            "run_error",
+            "started_at",
+            "finished_at",
+            "occurred_at",
+            "source_synced_at",
+            "reconciliation_attempts",
+            "reconciliation_claim_token",
+            "reconciliation_claimed_at",
+            "reconciliation_error",
+            "reconciliation_next_at",
+            "updated_at",
+        ]
+    )
+    return row
+
+
+def capture_run_usage(
+    link: LensSessionLink, run: dict[str, Any]
+) -> LensUsageLedger | None:
+    """Capture SourceLens run usage discovered during the interactive flow."""
+
     raw_uuid = run.get("uuid") or link.active_run_uuid
     if not raw_uuid:
         return None
@@ -190,37 +306,7 @@ def capture_run_usage(link: LensSessionLink, run: dict[str, Any]) -> LensUsageLe
         )
     if row is None:
         return None
-    calls, totals = _run_call_details(run)
-    row.run_status = str(run.get("status") or row.run_status or "")
-    row.prompt_tokens = totals["prompt_tokens"]
-    row.completion_tokens = totals["completion_tokens"]
-    row.cached_tokens = totals["cached_tokens"]
-    row.reasoning_tokens = totals["reasoning_tokens"]
-    row.total_tokens = totals["total_tokens"]
-    row.model_calls = len(calls)
-    row.estimated_cost = totals["estimated_cost"]
-    row.call_details_json = calls
-    row.run_error = str(run.get("error") or "")
-    row.started_at = _datetime(run.get("started_at"))
-    row.finished_at = _datetime(run.get("finished_at"))
-    row.occurred_at = row.started_at or row.occurred_at or timezone.now()
-    row.save(update_fields=[
-        "run_status",
-        "prompt_tokens",
-        "completion_tokens",
-        "cached_tokens",
-        "reasoning_tokens",
-        "total_tokens",
-        "model_calls",
-        "estimated_cost",
-        "call_details_json",
-        "run_error",
-        "started_at",
-        "finished_at",
-        "occurred_at",
-        "updated_at",
-    ])
-    return row
+    return capture_ledger_usage(row, run)
 
 
 def _public_run_failure(status: str, raw_error: str) -> tuple[str, str]:
@@ -296,94 +382,305 @@ def run_outcomes_for_messages(
     return outcomes
 
 
-def _session_by_assistant_name(org, user) -> dict[str, LensSessionLink]:
-    rows = LensSessionLink.objects.filter(
-        organization=org,
-        hfl_user=user,
-    ).select_related("knowledge_source", "gateway_link__gateway")
+def seed_missing_active_run_ledgers(*, limit: int = 100) -> list[int]:
+    """Create ledgers for active runs whose initial local write was interrupted."""
+
+    bounded_limit = max(1, min(int(limit), 500))
+    session_links = list(
+        LensSessionLink.objects.filter(active_run_uuid__isnull=False)
+        .exclude(usage_records__sl_run_uuid=F("active_run_uuid"))
+        .select_related(
+            "organization",
+            "hfl_user",
+            "gateway_link__gateway",
+        )
+        .order_by("updated_at", "id")[:bounded_limit]
+    )
+    seeded_ids: list[int] = []
+    for link in session_links:
+        row = register_usage_run(
+            link,
+            run_uuid=link.active_run_uuid,
+            question="",
+            status=link.active_run_status or "queued",
+        )
+        if row is not None:
+            seeded_ids.append(row.id)
+    return seeded_ids
+
+
+def claim_due_usage_ledgers(
+    *,
+    limit: int,
+    now: datetime,
+) -> list[tuple[int, uuid.UUID]]:
+    """Claim due ledger rows so overlapping workers cannot reconcile them."""
+
+    stale_claim = now - timedelta(seconds=RECONCILIATION_CLAIM_TTL_SECONDS)
+    bounded_limit = max(1, min(int(limit), 500))
+    with transaction.atomic():
+        rows = list(
+            LensUsageLedger.objects.select_for_update(skip_locked=True)
+            .filter(hfl_user__isnull=False)
+            .filter(
+                Q(source_synced_at__isnull=True)
+                | ~Q(run_status__in=TERMINAL_RUN_STATUSES)
+            )
+            .filter(
+                Q(reconciliation_next_at__isnull=True)
+                | Q(reconciliation_next_at__lte=now)
+            )
+            .filter(
+                Q(reconciliation_claimed_at__isnull=True)
+                | Q(reconciliation_claimed_at__lte=stale_claim)
+            )
+            .order_by("reconciliation_next_at", "updated_at", "id")[:bounded_limit]
+        )
+        claims: list[tuple[int, uuid.UUID]] = []
+        for row in rows:
+            claim_token = uuid.uuid4()
+            row.reconciliation_claim_token = claim_token
+            row.reconciliation_claimed_at = now
+            claims.append((row.id, claim_token))
+        if rows:
+            LensUsageLedger.objects.bulk_update(
+                rows,
+                ["reconciliation_claim_token", "reconciliation_claimed_at"],
+            )
+    return claims
+
+
+def record_reconciliation_failure(
+    *,
+    ledger_id: int,
+    claim_token: uuid.UUID,
+    message: str,
+    now: datetime,
+) -> None:
+    """Release a failed claim and persist bounded exponential backoff."""
+
+    row = LensUsageLedger.objects.filter(
+        id=ledger_id,
+        reconciliation_claim_token=claim_token,
+    ).first()
+    if row is None:
+        return
+    attempts = row.reconciliation_attempts + 1
+    delay_seconds = min(
+        RECONCILIATION_INTERVAL_SECONDS * (2 ** min(attempts - 1, 8)),
+        RECONCILIATION_MAX_BACKOFF_SECONDS,
+    )
+    LensUsageLedger.objects.filter(
+        id=ledger_id,
+        reconciliation_claim_token=claim_token,
+    ).update(
+        reconciliation_attempts=attempts,
+        reconciliation_claim_token=None,
+        reconciliation_claimed_at=None,
+        reconciliation_next_at=now + timedelta(seconds=delay_seconds),
+        reconciliation_error=str(message or "Usage reconciliation failed.")[:2000],
+    )
+
+
+def _finalize_missing_source_run(
+    *,
+    ledger_id: int,
+    claim_token: uuid.UUID,
+    now: datetime,
+) -> str | None:
+    """Close a ledger whose SourceLens run has been durably removed."""
+
+    row = LensUsageLedger.objects.filter(
+        id=ledger_id,
+        reconciliation_claim_token=claim_token,
+    ).first()
+    if row is None:
+        return None
+    updates: dict[str, Any] = {
+        "source_synced_at": now,
+        "reconciliation_claim_token": None,
+        "reconciliation_claimed_at": None,
+        "reconciliation_next_at": None,
+        "reconciliation_error": "SourceLens run no longer exists.",
+        "updated_at": now,
+    }
+    if row.run_status not in TERMINAL_RUN_STATUSES:
+        updates.update(
+            {
+                "run_status": "failed",
+                "run_error": "SOURCE_RUN_NOT_FOUND",
+                "finished_at": now,
+            }
+        )
+    LensUsageLedger.objects.filter(
+        id=ledger_id,
+        reconciliation_claim_token=claim_token,
+    ).update(**updates)
+    LensSessionLink.objects.filter(
+        id=row.session_link_id,
+        active_run_uuid=row.sl_run_uuid,
+    ).update(
+        active_run_uuid=None,
+        active_run_status="",
+        updated_at=now,
+    )
+    return str(updates.get("run_status") or row.run_status)
+
+
+def _missing_source_run_is_confirmed(
+    row: LensUsageLedger,
+    *,
+    now: datetime,
+) -> bool:
+    """Return whether repeated 404s are safe to treat as durable removal."""
+
+    observations = row.reconciliation_attempts + 1
+    grace_deadline = row.created_at + timedelta(
+        seconds=RECONCILIATION_NOT_FOUND_GRACE_SECONDS,
+    )
+    return (
+        observations >= RECONCILIATION_NOT_FOUND_CONFIRMATIONS and now >= grace_deadline
+    )
+
+
+def reconcile_claimed_usage_ledger(
+    *,
+    ledger_id: int,
+    claim_token: uuid.UUID,
+) -> dict[str, Any]:
+    """Synchronize one claimed SourceLens run into the HFL ledger."""
+
+    row = (
+        LensUsageLedger.objects.select_related(
+            "hfl_user",
+            "session_link",
+        )
+        .filter(
+            id=ledger_id,
+            reconciliation_claim_token=claim_token,
+        )
+        .first()
+    )
+    if row is None:
+        return {"status": "skipped", "ledger_id": ledger_id}
+    if row.hfl_user is None:
+        message = "The HFL user no longer exists."
+        record_reconciliation_failure(
+            ledger_id=ledger_id,
+            claim_token=claim_token,
+            message=message,
+            now=timezone.now(),
+        )
+        return {"status": "failed", "ledger_id": ledger_id, "error": message}
+    try:
+        run = sl_client.request_json(
+            "GET",
+            f"/api/lens/runs/{row.sl_run_uuid}/",
+            hfl_user=row.hfl_user,
+            timeout=30,
+        )
+        if not isinstance(run, dict):
+            raise ValueError("SourceLens returned an invalid run payload.")
+        returned_uuid = run.get("uuid")
+        if returned_uuid and uuid.UUID(str(returned_uuid)) != row.sl_run_uuid:
+            raise ValueError("SourceLens returned a different run.")
+    except sl_client.LensBridgeError as exc:
+        missing_status = None
+        failure_time = timezone.now()
+        if exc.status_code == 404 and _missing_source_run_is_confirmed(
+            row, now=failure_time
+        ):
+            missing_status = _finalize_missing_source_run(
+                ledger_id=ledger_id,
+                claim_token=claim_token,
+                now=failure_time,
+            )
+        if missing_status is not None:
+            return {
+                "status": missing_status,
+                "ledger_id": ledger_id,
+                "terminal": True,
+                "source_missing": True,
+            }
+        logger.warning(
+            "usage reconciliation failed ledger_id=%s: %s",
+            ledger_id,
+            exc,
+        )
+        record_reconciliation_failure(
+            ledger_id=ledger_id,
+            claim_token=claim_token,
+            message=str(exc),
+            now=failure_time,
+        )
+        return {
+            "status": "failed",
+            "ledger_id": ledger_id,
+            "error": str(exc)[:1000],
+        }
+    except (TypeError, ValueError) as exc:
+        logger.warning(
+            "usage reconciliation failed ledger_id=%s: %s",
+            ledger_id,
+            exc,
+        )
+        record_reconciliation_failure(
+            ledger_id=ledger_id,
+            claim_token=claim_token,
+            message=str(exc),
+            now=timezone.now(),
+        )
+        return {
+            "status": "failed",
+            "ledger_id": ledger_id,
+            "error": str(exc)[:1000],
+        }
+
+    row = LensUsageLedger.objects.filter(
+        id=ledger_id,
+        reconciliation_claim_token=claim_token,
+    ).first()
+    if row is None:
+        return {"status": "skipped", "ledger_id": ledger_id}
+    row = capture_ledger_usage(row, run)
+    if row.run_status in TERMINAL_RUN_STATUSES:
+        LensSessionLink.objects.filter(
+            id=row.session_link_id,
+            active_run_uuid=row.sl_run_uuid,
+        ).update(
+            active_run_uuid=None,
+            active_run_status="",
+            updated_at=timezone.now(),
+        )
     return {
-        row.knowledge_source.name: row
-        for row in rows
-        if row.knowledge_source is not None and row.knowledge_source.name
+        "status": row.run_status,
+        "ledger_id": ledger_id,
+        "terminal": row.run_status in TERMINAL_RUN_STATUSES,
     }
 
 
-def backfill_usage_ledgers(org, user, *, start_date: str, end_date: str) -> None:
-    sl_user = _sl_user_link(user)
-    if sl_user is None:
-        return
-    cache_key = (user.pk, start_date, end_date)
-    refreshed_at = _BACKFILL_REFRESHED_AT.get(cache_key)
-    if refreshed_at is not None and time.monotonic() - refreshed_at < BACKFILL_TTL_SECONDS:
-        return
-    session_map = _session_by_assistant_name(org, user)
-    page = 1
-    imported = 0
-    while imported < MAX_BACKFILL_RUNS:
-        payload = sl_client.request_json(
-            "GET",
-            "/api/lens/admin/runs/",
-            params={
-                "username": sl_user.sl_username,
-                "start_date": start_date,
-                "end_date": end_date,
-                "page": page,
-                "page_size": 100,
-            },
+def reconcile_usage_ledgers(*, limit: int = 100) -> dict[str, Any]:
+    """Synchronize a bounded batch; intended for tests and repair commands."""
+
+    claims = claim_due_usage_ledgers(limit=limit, now=timezone.now())
+    results = [
+        reconcile_claimed_usage_ledger(
+            ledger_id=ledger_id,
+            claim_token=claim_token,
         )
-        results = payload.get("results") if isinstance(payload, dict) else []
-        exact_rows = [
-            item for item in (results or [])
-            if str(item.get("username") or "") == sl_user.sl_username
-        ]
-        for item in exact_rows:
-            raw_uuid = item.get("uuid")
-            if not raw_uuid:
-                continue
-            session = session_map.get(str(item.get("assistant_name") or ""))
-            context = _session_context(session) if session is not None else {
-                "session_link": None,
-                "sl_session_uuid": None,
-                "chat_title": "Deleted Chat",
-                "backup_config_id": None,
-                "backup_source_name": "",
-                "backup_source_snapshot_id": None,
-                "snapshot_created_at": None,
-                "source_scopes_json": [],
-                "gateway_selection_mode": "auto",
-                "gateway_name": "",
-            }
-            defaults = {
-                "organization": org,
-                "hfl_user": user,
-                "sl_user_id": sl_user.sl_user_id,
-                "question": str(item.get("question") or ""),
-                "run_status": str(item.get("status") or ""),
-                "prompt_tokens": int(item.get("prompt_tokens") or 0),
-                "completion_tokens": int(item.get("completion_tokens") or 0),
-                "total_tokens": int(item.get("total_tokens") or 0),
-                "model_calls": int(item.get("llm_calls") or 0),
-                "estimated_cost": _decimal(item.get("total_cost")),
-                "started_at": _datetime(item.get("started_at")),
-                "finished_at": _datetime(item.get("finished_at")),
-                "occurred_at": (
-                    _datetime(item.get("started_at") or item.get("created_at"))
-                    or timezone.now()
-                ),
-                **context,
-            }
-            LensUsageLedger.objects.update_or_create(
-                sl_run_uuid=uuid.UUID(str(raw_uuid)),
-                defaults=defaults,
-            )
-        imported += len(results or [])
-        total = int(payload.get("total") or 0) if isinstance(payload, dict) else 0
-        if not results or page * 100 >= total:
-            break
-        page += 1
-    if len(_BACKFILL_REFRESHED_AT) > 1000:
-        _BACKFILL_REFRESHED_AT.clear()
-    _BACKFILL_REFRESHED_AT[cache_key] = time.monotonic()
+        for ledger_id, claim_token in claims
+    ]
+    return {
+        "claimed": len(claims),
+        "reconciled": sum(
+            row["status"] not in {"failed", "skipped"} for row in results
+        ),
+        "pending": sum(
+            row["status"] not in TERMINAL_RUN_STATUSES | {"failed", "skipped"}
+            for row in results
+        ),
+        "failed": [row for row in results if row["status"] == "failed"],
+    }
 
 
 def _date_range(params) -> tuple[str, str]:
@@ -420,7 +717,8 @@ def _ledger_item(row: LensUsageLedger) -> dict[str, Any]:
         "chat_available": bool(
             row.session_link_id
             and row.session_link
-            and row.session_link.lifecycle_status != LensSessionLink.LifecycleStatus.DELETED
+            and row.session_link.lifecycle_status
+            != LensSessionLink.LifecycleStatus.DELETED
         ),
         "backup_source_name": row.backup_source_name or "Backup Source",
         "scope_summary": _scope_summary(list(row.source_scopes_json or [])),
@@ -431,13 +729,23 @@ def _ledger_item(row: LensUsageLedger) -> dict[str, Any]:
         "reasoning_tokens": row.reasoning_tokens,
         "total_tokens": row.total_tokens,
         "model_calls": row.model_calls,
-        "estimated_cost": float(row.estimated_cost) if row.estimated_cost is not None else None,
+        "estimated_cost": float(row.estimated_cost)
+        if row.estimated_cost is not None
+        else None,
         "cost_currency": row.cost_currency,
         "status": row.run_status,
     }
 
 
 def _trend_item(bucket: str, row: dict[str, Any]) -> dict[str, Any]:
+    request_count = int(row.get("request_count") or 0)
+    costed_requests = int(row.get("costed_requests") or 0)
+    if request_count == 0:
+        total_cost: float | None = 0
+    elif costed_requests == request_count and row.get("total_cost") is not None:
+        total_cost = float(row["total_cost"])
+    else:
+        total_cost = None
     return {
         "bucket": bucket,
         "total_calls": row.get("total_calls") or 0,
@@ -446,11 +754,7 @@ def _trend_item(bucket: str, row: dict[str, Any]) -> dict[str, Any]:
         "total_cached_tokens": row.get("total_cached_tokens") or 0,
         "total_reasoning_tokens": row.get("total_reasoning_tokens") or 0,
         "total_tokens": row.get("total_tokens") or 0,
-        "total_cost": (
-            float(row["total_cost"])
-            if row.get("total_cost") is not None
-            else 0
-        ),
+        "total_cost": total_cost,
     }
 
 
@@ -479,9 +783,11 @@ def usage_overview(org, user, params) -> dict[str, Any]:
             "total": 0,
             "page": 1,
             "page_size": 20,
+            "data_freshness": {
+                "last_source_sync_at": None,
+                "pending_runs": 0,
+            },
         }
-
-    backfill_usage_ledgers(org, user, start_date=start_date, end_date=end_date)
 
     start = parse_date(start_date)
     end = parse_date(end_date)
@@ -515,7 +821,7 @@ def usage_overview(org, user, params) -> dict[str, Any]:
         page_size = 20
     total = queryset.count()
     offset = (page - 1) * page_size
-    results = [_ledger_item(row) for row in queryset[offset:offset + page_size]]
+    results = [_ledger_item(row) for row in queryset[offset : offset + page_size]]
 
     period_rows = LensUsageLedger.objects.filter(
         organization=org,
@@ -531,23 +837,30 @@ def usage_overview(org, user, params) -> dict[str, Any]:
         reasoning_tokens=Sum("reasoning_tokens"),
         total_tokens=Sum("total_tokens"),
         model_calls=Sum("model_calls"),
-        estimated_cost=Sum("estimated_cost"),
+        total_estimated_cost=Sum("estimated_cost"),
+        costed_requests=Count("estimated_cost"),
+        last_source_sync_at=Max("source_synced_at"),
     )
     same_day = start == end
     bucket_expression = (
         TruncHour("occurred_at") if same_day else TruncDate("occurred_at")
     )
-    trend_rows = period_rows.annotate(bucket=bucket_expression).values(
-        "bucket"
-    ).annotate(
-        total_calls=Sum("model_calls"),
-        total_prompt_tokens=Sum("prompt_tokens"),
-        total_completion_tokens=Sum("completion_tokens"),
-        total_cached_tokens=Sum("cached_tokens"),
-        total_reasoning_tokens=Sum("reasoning_tokens"),
-        total_tokens=Sum("total_tokens"),
-        total_cost=Sum("estimated_cost"),
-    ).order_by("bucket")
+    trend_rows = (
+        period_rows.annotate(bucket=bucket_expression)
+        .values("bucket")
+        .annotate(
+            request_count=Count("id"),
+            costed_requests=Count("estimated_cost"),
+            total_calls=Sum("model_calls"),
+            total_prompt_tokens=Sum("prompt_tokens"),
+            total_completion_tokens=Sum("completion_tokens"),
+            total_cached_tokens=Sum("cached_tokens"),
+            total_reasoning_tokens=Sum("reasoning_tokens"),
+            total_tokens=Sum("total_tokens"),
+            total_cost=Sum("estimated_cost"),
+        )
+        .order_by("bucket")
+    )
     trend_index = {
         row["bucket"].isoformat(): row
         for row in trend_rows
@@ -574,18 +887,35 @@ def usage_overview(org, user, params) -> dict[str, Any]:
             row = trend_index.get(bucket) or {}
             trend.append(_trend_item(bucket, row))
             cursor += timedelta(days=1)
-    by_source = period_rows.values("backup_source_name").annotate(
-        q_and_a_requests=Count("id"),
-        model_calls=Sum("model_calls"),
-        total_tokens=Sum("total_tokens"),
-        estimated_cost=Sum("estimated_cost"),
-    ).order_by(
-        OrderBy(F("estimated_cost"), descending=True, nulls_last=True),
-        "-total_tokens",
-        "backup_source_name",
+    by_source = (
+        period_rows.values("backup_source_name")
+        .annotate(
+            q_and_a_requests=Count("id"),
+            costed_requests=Count("estimated_cost"),
+            model_calls=Sum("model_calls"),
+            total_tokens=Sum("total_tokens"),
+            total_estimated_cost=Sum("estimated_cost"),
+        )
+        .order_by(
+            OrderBy(F("total_estimated_cost"), descending=True, nulls_last=True),
+            "-total_tokens",
+            "backup_source_name",
+        )
     )
 
-    total_cost = float(period_totals["estimated_cost"] or 0)
+    costed_requests = int(period_totals["costed_requests"] or 0)
+    if q_and_a_requests == 0:
+        total_cost: float | None = 0
+    elif (
+        costed_requests == q_and_a_requests
+        and period_totals["total_estimated_cost"] is not None
+    ):
+        total_cost = float(period_totals["total_estimated_cost"])
+    else:
+        total_cost = None
+    pending_runs = period_rows.exclude(
+        run_status__in=TERMINAL_RUN_STATUSES,
+    ).count()
     return {
         "period": {"start_date": start_date, "end_date": end_date},
         "summary": {
@@ -599,7 +929,9 @@ def usage_overview(org, user, params) -> dict[str, Any]:
             "model_calls": int(period_totals["model_calls"] or 0),
             "q_and_a_requests": q_and_a_requests,
             "average_cost_per_q_and_a": (
-                total_cost / q_and_a_requests if q_and_a_requests else 0
+                total_cost / q_and_a_requests
+                if q_and_a_requests and total_cost is not None
+                else (0 if not q_and_a_requests else None)
             ),
         },
         "trend": trend,
@@ -610,8 +942,11 @@ def usage_overview(org, user, params) -> dict[str, Any]:
                 "model_calls": row["model_calls"] or 0,
                 "total_tokens": row["total_tokens"] or 0,
                 "estimated_cost": (
-                    float(row["estimated_cost"])
-                    if row["estimated_cost"] is not None
+                    float(row["total_estimated_cost"])
+                    if (
+                        row["total_estimated_cost"] is not None
+                        and row["costed_requests"] == row["q_and_a_requests"]
+                    )
                     else None
                 ),
             }
@@ -627,57 +962,36 @@ def usage_overview(org, user, params) -> dict[str, Any]:
         "total": total,
         "page": page,
         "page_size": page_size,
+        "data_freshness": {
+            "last_source_sync_at": period_totals["last_source_sync_at"],
+            "pending_runs": pending_runs,
+        },
     }
 
 
 def usage_detail(org, user, run_uuid: uuid.UUID) -> dict[str, Any]:
-    row = LensUsageLedger.objects.select_related("session_link").filter(
-        organization=org,
-        hfl_user=user,
-        sl_run_uuid=run_uuid,
-    ).first()
+    row = (
+        LensUsageLedger.objects.select_related("session_link")
+        .filter(
+            organization=org,
+            hfl_user=user,
+            sl_run_uuid=run_uuid,
+        )
+        .first()
+    )
     if row is None:
         raise NotFound()
-    if not row.call_details_json:
-        sl_user = _sl_user_link(user)
-        if sl_user is not None:
-            try:
-                payload = sl_client.request_json("GET", f"/api/lens/admin/runs/{run_uuid}/")
-                if str(payload.get("username") or "") == sl_user.sl_username:
-                    calls, totals = _run_call_details(payload)
-                    row.question = str(payload.get("question") or row.question)
-                    row.call_details_json = calls
-                    row.prompt_tokens = totals["prompt_tokens"] or row.prompt_tokens
-                    row.completion_tokens = totals["completion_tokens"] or row.completion_tokens
-                    row.cached_tokens = totals["cached_tokens"] or row.cached_tokens
-                    row.reasoning_tokens = totals["reasoning_tokens"] or row.reasoning_tokens
-                    row.total_tokens = totals["total_tokens"] or row.total_tokens
-                    row.model_calls = len(calls) or row.model_calls
-                    if totals["estimated_cost"] is not None:
-                        row.estimated_cost = totals["estimated_cost"]
-                    row.save(update_fields=[
-                        "question",
-                        "call_details_json",
-                        "prompt_tokens",
-                        "completion_tokens",
-                        "cached_tokens",
-                        "reasoning_tokens",
-                        "total_tokens",
-                        "model_calls",
-                        "estimated_cost",
-                        "updated_at",
-                    ])
-            except sl_client.LensBridgeError:
-                pass
     payload = _ledger_item(row)
-    payload.update({
-        "snapshot_created_at": row.snapshot_created_at,
-        "source_scopes": list(row.source_scopes_json or []),
-        "gateway_mode": row.gateway_selection_mode,
-        "gateway_name": row.gateway_name,
-        "started_at": row.started_at,
-        "finished_at": row.finished_at,
-        "error": row.run_error,
-        "call_details": list(row.call_details_json or []),
-    })
+    payload.update(
+        {
+            "snapshot_created_at": row.snapshot_created_at,
+            "source_scopes": list(row.source_scopes_json or []),
+            "gateway_mode": row.gateway_selection_mode,
+            "gateway_name": row.gateway_name,
+            "started_at": row.started_at,
+            "finished_at": row.finished_at,
+            "error": row.run_error,
+            "call_details": list(row.call_details_json or []),
+        }
+    )
     return payload

--- a/src/backend/apps/lens_bridge/tasks/__init__.py
+++ b/src/backend/apps/lens_bridge/tasks/__init__.py
@@ -16,6 +16,10 @@ from apps.lens_bridge.tasks.knowledge_source_sync import (
 from apps.lens_bridge.tasks.knowledge_source_teardown import (
     execute_knowledge_source_teardown_task,
 )
+from apps.lens_bridge.tasks.usage_reconciliation import (
+    execute_usage_ledger_reconciliation_task,
+    reconcile_usage_ledgers_task,
+)
 
 __all__ = [
     "execute_knowledge_source_sync_task",
@@ -28,4 +32,6 @@ __all__ = [
     "reconcile_copilot_chat_provisions_task",
     "reconcile_lens_resource_teardowns_task",
     "execute_knowledge_source_teardown_task",
+    "execute_usage_ledger_reconciliation_task",
+    "reconcile_usage_ledgers_task",
 ]

--- a/src/backend/apps/lens_bridge/tasks/usage_reconciliation.py
+++ b/src/backend/apps/lens_bridge/tasks/usage_reconciliation.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import Any
+
+from celery import shared_task
+from django.utils import timezone
+
+from common.observability.celery_context import celery_trace
+
+
+logger = logging.getLogger(__name__)
+
+
+@shared_task(
+    name=(
+        "apps.lens_bridge.tasks.usage_reconciliation."
+        "execute_usage_ledger_reconciliation_task"
+    ),
+    soft_time_limit=90,
+    time_limit=100,
+)
+def execute_usage_ledger_reconciliation_task(
+    *,
+    ledger_id: int,
+    claim_token: str,
+) -> dict[str, Any]:
+    """Reconcile one independently claimed usage ledger row."""
+
+    from apps.lens_bridge.services.usage import reconcile_claimed_usage_ledger
+
+    with celery_trace(
+        f"usage-ledger-reconciliation-{ledger_id}",
+        task_name=(
+            "apps.lens_bridge.tasks.usage_reconciliation."
+            "execute_usage_ledger_reconciliation_task"
+        ),
+    ):
+        result = reconcile_claimed_usage_ledger(
+            ledger_id=int(ledger_id),
+            claim_token=uuid.UUID(str(claim_token)),
+        )
+        logger.info(
+            "usage ledger reconciliation finished ledger_id=%s status=%s",
+            ledger_id,
+            result["status"],
+        )
+        return result
+
+
+@shared_task(
+    name=("apps.lens_bridge.tasks.usage_reconciliation.reconcile_usage_ledgers_task"),
+)
+def reconcile_usage_ledgers_task(*, limit: int = 100) -> dict[str, Any]:
+    """Dispatch due reconciliations without remote I/O in the dispatcher."""
+
+    from apps.lens_bridge.services.usage import (
+        claim_due_usage_ledgers,
+        record_reconciliation_failure,
+        seed_missing_active_run_ledgers,
+    )
+
+    seeded = seed_missing_active_run_ledgers(limit=limit)
+    claims = claim_due_usage_ledgers(limit=limit, now=timezone.now())
+    queued: list[int] = []
+    failed: list[dict[str, str | int]] = []
+    for ledger_id, claim_token in claims:
+        try:
+            execute_usage_ledger_reconciliation_task.delay(
+                ledger_id=ledger_id,
+                claim_token=str(claim_token),
+            )
+            queued.append(ledger_id)
+        except Exception as exc:
+            logger.exception(
+                "usage reconciliation dispatch failed ledger_id=%s",
+                ledger_id,
+            )
+            record_reconciliation_failure(
+                ledger_id=ledger_id,
+                claim_token=claim_token,
+                message=str(exc),
+                now=timezone.now(),
+            )
+            failed.append({"ledger_id": ledger_id, "error": str(exc)[:1000]})
+    return {
+        "seeded": seeded,
+        "claimed": len(claims),
+        "queued": queued,
+        "failed": failed,
+    }

--- a/src/backend/apps/lens_bridge/tests/test_periodic_tasks.py
+++ b/src/backend/apps/lens_bridge/tests/test_periodic_tasks.py
@@ -1,0 +1,23 @@
+from unittest import mock
+
+from django.test import SimpleTestCase
+
+from apps.lens_bridge.periodic_tasks import register_periodic_tasks
+
+
+class LensBridgePeriodicTaskTests(SimpleTestCase):
+    @mock.patch("apps.lens_bridge.periodic_tasks.TASK_REGISTRY.add")
+    def test_registers_usage_reconciliation(self, add):
+        register_periodic_tasks()
+
+        add.assert_any_call(
+            name="lens_bridge_reconcile_usage_ledgers",
+            task=(
+                "apps.lens_bridge.tasks.usage_reconciliation."
+                "reconcile_usage_ledgers_task"
+            ),
+            schedule=30,
+            kwargs={"limit": 100},
+            enabled=True,
+            expire_seconds=25,
+        )

--- a/src/backend/apps/lens_bridge/tests/test_usage.py
+++ b/src/backend/apps/lens_bridge/tests/test_usage.py
@@ -1,4 +1,5 @@
 import uuid
+from datetime import timedelta
 from decimal import Decimal
 from unittest.mock import patch
 
@@ -83,6 +84,68 @@ class UsageCaptureTests(TestCase):
         self.assertEqual(row.estimated_cost, Decimal("0.012"))
         self.assertEqual(len(row.call_details_json), 2)
 
+    def test_partial_model_call_cost_is_kept_unavailable(self):
+        run_uuid = uuid.uuid4()
+        usage.register_usage_run(
+            self.session,
+            run_uuid=run_uuid,
+            question="Summarize finance files",
+            status="running",
+        )
+
+        row = usage.capture_run_usage(
+            self.session,
+            {
+                "uuid": str(run_uuid),
+                "status": "done",
+                "steps": [
+                    {
+                        "detail": {
+                            "events": [
+                                {
+                                    "agent_event": "llm.response",
+                                    "total_tokens": 10,
+                                    "cost": "0.001",
+                                },
+                                {
+                                    "agent_event": "llm.response",
+                                    "total_tokens": 20,
+                                },
+                            ],
+                        },
+                    }
+                ],
+            },
+        )
+
+        self.assertIsNone(row.estimated_cost)
+
+    def test_captures_top_level_usage_summary_when_steps_are_unavailable(self):
+        run_uuid = uuid.uuid4()
+        usage.register_usage_run(
+            self.session,
+            run_uuid=run_uuid,
+            question="Summarize finance files",
+            status="running",
+        )
+
+        row = usage.capture_run_usage(
+            self.session,
+            {
+                "uuid": str(run_uuid),
+                "status": "done",
+                "prompt_tokens": 70,
+                "completion_tokens": 30,
+                "total_tokens": 100,
+                "llm_calls": 2,
+                "total_cost": "0.004",
+            },
+        )
+
+        self.assertEqual(row.total_tokens, 100)
+        self.assertEqual(row.model_calls, 2)
+        self.assertEqual(row.estimated_cost, Decimal("0.004"))
+
 
 class UsageApiIsolationTests(TestCase):
     def setUp(self):
@@ -121,36 +184,20 @@ class UsageApiIsolationTests(TestCase):
         self.client.force_authenticate(user=self.user)
 
     @patch("apps.lens_bridge.services.usage.sl_client.request_json")
-    def test_admin_run_queries_are_forced_to_current_sl_user(self, request_json):
-        exact_uuid = uuid.uuid4()
+    def test_overview_reads_only_the_current_users_hfl_ledger(self, request_json):
+        LensUsageLedger.objects.create(
+            organization=self.org,
+            hfl_user=self.user,
+            sl_user_id=23,
+            sl_run_uuid=uuid.uuid4(),
+            question="My usage",
+            run_status="done",
+            total_tokens=1200,
+            estimated_cost=Decimal("0.25"),
+            occurred_at=timezone.now(),
+            source_synced_at=timezone.now(),
+        )
 
-        def response_for(_method, path, **_kwargs):
-            return {
-                "results": [
-                    {
-                        "uuid": str(exact_uuid),
-                        "username": "hfl-u-23",
-                        "question": "My usage",
-                        "status": "done",
-                        "total_tokens": 1200,
-                        "prompt_tokens": 1000,
-                        "completion_tokens": 200,
-                        "total_cost": 0.25,
-                        "created_at": timezone.now().isoformat(),
-                    },
-                    {
-                        "uuid": str(uuid.uuid4()),
-                        "username": "hfl-u-230",
-                        "question": "Fuzzy username must not leak",
-                        "status": "done",
-                        "total_tokens": 9999,
-                        "created_at": timezone.now().isoformat(),
-                    },
-                ],
-                "total": 2,
-            }
-
-        request_json.side_effect = response_for
         response = self.client.get(
             reverse("lens-copilot-usage"),
             {"user_id": "999", "page_size": 20},
@@ -163,20 +210,40 @@ class UsageApiIsolationTests(TestCase):
         self.assertEqual(payload["total"], 1)
         self.assertEqual(payload["results"][0]["question"], "My usage")
         self.assertNotIn("Private question", str(payload))
-        run_params = request_json.call_args_list[0].kwargs["params"]
-        self.assertEqual(run_params["username"], "hfl-u-23")
-        self.assertNotEqual(run_params["username"], "999")
+        request_json.assert_not_called()
 
     def test_detail_does_not_expose_another_users_ledger(self):
         response = self.client.get(
-            reverse("lens-copilot-usage-detail", kwargs={"run_uuid": self.other_row.sl_run_uuid}),
+            reverse(
+                "lens-copilot-usage-detail",
+                kwargs={"run_uuid": self.other_row.sl_run_uuid},
+            ),
             HTTP_X_ORG_KEY=self.org.key,
         )
 
         self.assertEqual(response.status_code, 404)
 
-    @patch("apps.lens_bridge.services.usage.backfill_usage_ledgers")
-    def test_today_overview_aggregates_model_calls_and_hourly_trend(self, _backfill):
+    @patch("apps.lens_bridge.services.usage.sl_client.request_json")
+    def test_detail_is_also_a_pure_ledger_read(self, request_json):
+        row = LensUsageLedger.objects.create(
+            organization=self.org,
+            hfl_user=self.user,
+            sl_user_id=23,
+            sl_run_uuid=uuid.uuid4(),
+            question="Ledger-only detail",
+            run_status="done",
+            occurred_at=timezone.now(),
+        )
+
+        response = self.client.get(
+            reverse("lens-copilot-usage-detail", kwargs={"run_uuid": row.sl_run_uuid}),
+            HTTP_X_ORG_KEY=self.org.key,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        request_json.assert_not_called()
+
+    def test_today_overview_aggregates_model_calls_and_hourly_trend(self):
         now = timezone.localtime()
         LensUsageLedger.objects.create(
             organization=self.org,
@@ -208,3 +275,263 @@ class UsageApiIsolationTests(TestCase):
         current_hour = payload["trend"][now.hour]
         self.assertEqual(current_hour["total_calls"], 3)
         self.assertEqual(current_hour["total_tokens"], 125)
+
+    def test_unknown_cost_is_not_reported_as_zero(self):
+        now = timezone.now()
+        LensUsageLedger.objects.create(
+            organization=self.org,
+            hfl_user=self.user,
+            sl_user_id=23,
+            sl_run_uuid=uuid.uuid4(),
+            question="Cost unavailable",
+            run_status="done",
+            total_tokens=100,
+            estimated_cost=None,
+            occurred_at=now,
+            source_synced_at=now,
+        )
+
+        payload = usage.usage_overview(self.org, self.user, {})
+
+        self.assertIsNone(payload["summary"]["estimated_cost"])
+        self.assertIsNone(payload["summary"]["average_cost_per_q_and_a"])
+        self.assertIsNone(payload["by_backup_source"][0]["estimated_cost"])
+        self.assertIsNone(payload["trend"][timezone.localtime(now).hour]["total_cost"])
+
+
+class UsageReconciliationTests(TestCase):
+    def setUp(self):
+        self.user = get_user_model().objects.create_user(
+            username="usage-reconciliation",
+            email="usage-reconciliation@example.com",
+            password="test-password",
+        )
+        self.org, _ = provision_registered_user_tenant(self.user)
+        LensSlUserLink.objects.create(
+            hfl_user=self.user,
+            sl_user_id=29,
+            sl_username="hfl-u-29",
+            provision_status=LensSlUserLink.ProvisionStatus.READY,
+        )
+        self.session = LensSessionLink.objects.create(
+            organization=self.org,
+            hfl_user=self.user,
+            title="Reconciliation Chat",
+        )
+
+    @patch("apps.lens_bridge.services.usage.sl_client.request_json")
+    def test_terminal_run_is_reconciled_and_active_run_is_cleared(self, request_json):
+        run_uuid = uuid.uuid4()
+        self.session.active_run_uuid = run_uuid
+        self.session.active_run_status = "running"
+        self.session.save(
+            update_fields=["active_run_uuid", "active_run_status", "updated_at"]
+        )
+        row = usage.register_usage_run(
+            self.session,
+            run_uuid=run_uuid,
+            question="Close the browser",
+            status="running",
+        )
+        request_json.return_value = {
+            "uuid": str(run_uuid),
+            "status": "done",
+            "steps": [
+                {
+                    "detail": {
+                        "usage": {
+                            "prompt_tokens": 80,
+                            "completion_tokens": 20,
+                            "total_tokens": 100,
+                            "cost": "0.004",
+                        },
+                    },
+                }
+            ],
+            "finished_at": timezone.now().isoformat(),
+        }
+
+        result = usage.reconcile_usage_ledgers(limit=10)
+
+        self.assertEqual(result["reconciled"], 1)
+        row.refresh_from_db()
+        self.session.refresh_from_db()
+        self.assertEqual(row.run_status, "done")
+        self.assertEqual(row.total_tokens, 100)
+        self.assertEqual(row.estimated_cost, Decimal("0.004"))
+        self.assertIsNotNone(row.source_synced_at)
+        self.assertIsNone(row.reconciliation_next_at)
+        self.assertIsNone(self.session.active_run_uuid)
+        request_json.assert_called_once_with(
+            "GET",
+            f"/api/lens/runs/{run_uuid}/",
+            hfl_user=self.user,
+            timeout=30,
+        )
+
+    @patch("apps.lens_bridge.services.usage.sl_client.request_json")
+    def test_failure_is_persisted_with_backoff_for_retry(self, request_json):
+        from apps.lens_bridge.services import sl_client
+
+        row = usage.register_usage_run(
+            self.session,
+            run_uuid=uuid.uuid4(),
+            question="Retry me",
+            status="running",
+        )
+        request_json.side_effect = sl_client.LensBridgeUnavailable()
+
+        result = usage.reconcile_usage_ledgers(limit=10)
+
+        self.assertEqual(len(result["failed"]), 1)
+        row.refresh_from_db()
+        self.assertEqual(row.reconciliation_attempts, 1)
+        self.assertIsNone(row.reconciliation_claim_token)
+        self.assertIsNotNone(row.reconciliation_next_at)
+        self.assertTrue(row.reconciliation_error)
+
+    @patch("apps.lens_bridge.services.usage.sl_client.request_json")
+    def test_missing_source_run_is_closed_instead_of_retried_forever(
+        self,
+        request_json,
+    ):
+        from apps.lens_bridge.services import sl_client
+
+        run_uuid = uuid.uuid4()
+        self.session.active_run_uuid = run_uuid
+        self.session.active_run_status = "running"
+        self.session.save(
+            update_fields=["active_run_uuid", "active_run_status", "updated_at"]
+        )
+        row = usage.register_usage_run(
+            self.session,
+            run_uuid=run_uuid,
+            question="Missing upstream run",
+            status="running",
+        )
+        error = sl_client.LensBridgeError("Run not found.")
+        error.status_code = 404
+        request_json.side_effect = error
+        old_time = timezone.now() - timedelta(minutes=10)
+        LensUsageLedger.objects.filter(id=row.id).update(
+            created_at=old_time,
+            reconciliation_attempts=2,
+        )
+
+        result = usage.reconcile_usage_ledgers(limit=10)
+
+        self.assertEqual(result["claimed"], 1)
+        row.refresh_from_db()
+        self.session.refresh_from_db()
+        self.assertEqual(row.run_status, "failed")
+        self.assertEqual(row.run_error, "SOURCE_RUN_NOT_FOUND")
+        self.assertIsNone(row.reconciliation_next_at)
+        self.assertIsNone(self.session.active_run_uuid)
+
+    @patch("apps.lens_bridge.services.usage.sl_client.request_json")
+    def test_missing_historical_source_run_keeps_its_terminal_ledger_status(
+        self,
+        request_json,
+    ):
+        from apps.lens_bridge.services import sl_client
+
+        row = usage.register_usage_run(
+            self.session,
+            run_uuid=uuid.uuid4(),
+            question="Historical completed run",
+            status="done",
+        )
+        error = sl_client.LensBridgeError("Run not found.")
+        error.status_code = 404
+        request_json.side_effect = error
+        old_time = timezone.now() - timedelta(minutes=10)
+        LensUsageLedger.objects.filter(id=row.id).update(
+            created_at=old_time,
+            reconciliation_attempts=2,
+        )
+
+        usage.reconcile_usage_ledgers(limit=10)
+
+        row.refresh_from_db()
+        self.assertEqual(row.run_status, "done")
+        self.assertIsNotNone(row.source_synced_at)
+        self.assertIsNone(row.reconciliation_next_at)
+
+    @patch("apps.lens_bridge.services.usage.sl_client.request_json")
+    def test_first_not_found_response_is_retried_during_grace_period(
+        self,
+        request_json,
+    ):
+        from apps.lens_bridge.services import sl_client
+
+        row = usage.register_usage_run(
+            self.session,
+            run_uuid=uuid.uuid4(),
+            question="Eventually visible run",
+            status="running",
+        )
+        error = sl_client.LensBridgeError("Run not found.")
+        error.status_code = 404
+        request_json.side_effect = error
+
+        usage.reconcile_usage_ledgers(limit=10)
+
+        row.refresh_from_db()
+        self.assertEqual(row.run_status, "running")
+        self.assertEqual(row.reconciliation_attempts, 1)
+        self.assertIsNotNone(row.reconciliation_next_at)
+
+    @patch(
+        "apps.lens_bridge.tasks.usage_reconciliation."
+        "execute_usage_ledger_reconciliation_task.delay"
+    )
+    def test_dispatcher_claims_each_due_row_only_once(self, delay):
+        from apps.lens_bridge.tasks.usage_reconciliation import (
+            reconcile_usage_ledgers_task,
+        )
+
+        row = usage.register_usage_run(
+            self.session,
+            run_uuid=uuid.uuid4(),
+            question="Dispatch me",
+            status="running",
+        )
+
+        first = reconcile_usage_ledgers_task(limit=10)
+        second = reconcile_usage_ledgers_task(limit=10)
+
+        self.assertEqual(first["claimed"], 1)
+        self.assertEqual(second["claimed"], 0)
+        row.refresh_from_db()
+        self.assertIsNotNone(row.reconciliation_claim_token)
+        delay.assert_called_once_with(
+            ledger_id=row.id,
+            claim_token=str(row.reconciliation_claim_token),
+        )
+
+    @patch(
+        "apps.lens_bridge.tasks.usage_reconciliation."
+        "execute_usage_ledger_reconciliation_task.delay"
+    )
+    def test_dispatcher_seeds_a_missing_active_run_ledger(self, delay):
+        from apps.lens_bridge.tasks.usage_reconciliation import (
+            reconcile_usage_ledgers_task,
+        )
+
+        run_uuid = uuid.uuid4()
+        self.session.active_run_uuid = run_uuid
+        self.session.active_run_status = "running"
+        self.session.save(
+            update_fields=["active_run_uuid", "active_run_status", "updated_at"]
+        )
+
+        result = reconcile_usage_ledgers_task(limit=10)
+
+        row = LensUsageLedger.objects.get(sl_run_uuid=run_uuid)
+        self.assertEqual(result["seeded"], [row.id])
+        self.assertEqual(result["claimed"], 1)
+        self.assertEqual(row.run_status, "running")
+        delay.assert_called_once_with(
+            ledger_id=row.id,
+            claim_token=str(row.reconciliation_claim_token),
+        )

--- a/src/frontend/src/lib/lensApi.ts
+++ b/src/frontend/src/lib/lensApi.ts
@@ -87,7 +87,7 @@ export type LensCopilotReadiness = {
 }
 
 export type LensCopilotUsageSummary = {
-  estimated_cost: number
+  estimated_cost: number | null
   cost_currency: string
   total_tokens: number
   prompt_tokens: number
@@ -96,7 +96,7 @@ export type LensCopilotUsageSummary = {
   reasoning_tokens: number
   model_calls: number
   q_and_a_requests: number
-  average_cost_per_q_and_a: number
+  average_cost_per_q_and_a: number | null
 }
 
 export type LensCopilotUsageTrend = {
@@ -107,7 +107,7 @@ export type LensCopilotUsageTrend = {
   total_tokens: number
   total_cached_tokens: number
   total_reasoning_tokens: number
-  total_cost: number
+  total_cost: number | null
 }
 
 export type LensCopilotUsageItem = {
@@ -146,6 +146,10 @@ export type LensCopilotUsageOverview = {
   total: number
   page: number
   page_size: number
+  data_freshness: {
+    last_source_sync_at: string | null
+    pending_runs: number
+  }
 }
 
 export type LensCopilotUsageDetail = LensCopilotUsageItem & {

--- a/src/frontend/src/pages/InsightUsageRefresh.test.ts
+++ b/src/frontend/src/pages/InsightUsageRefresh.test.ts
@@ -1,0 +1,27 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+
+const usagePage = readFileSync(
+  resolve(process.cwd(), 'src/pages/insight/InsightUsage.vue'),
+  'utf8',
+)
+
+
+describe('Insight usage refresh semantics', () => {
+  it('reloads the HFL ledger without claiming that upstream data was synchronized', () => {
+    expect(usagePage).toContain('@click="loadUsage"')
+    expect(usagePage).toContain(':disabled="loading"')
+    expect(usagePage).toContain("'is-spinning': loading")
+    expect(usagePage).not.toContain('Usage refreshed.')
+    expect(usagePage).not.toContain('ElMessage.success')
+  })
+
+  it('shows persisted freshness and preserves unknown cost semantics', () => {
+    expect(usagePage).toContain('usage.value?.data_freshness')
+    expect(usagePage).toContain('updates automatically')
+    expect(usagePage).toContain("if (value == null) return 'Unavailable'")
+    expect(usagePage).toContain('costMode ? row.total_cost')
+  })
+})

--- a/src/frontend/src/pages/insight/InsightUsage.vue
+++ b/src/frontend/src/pages/insight/InsightUsage.vue
@@ -41,6 +41,7 @@ const statusFilter = ref('')
 const page = ref(1)
 const pageSize = ref(20)
 let searchTimer: ReturnType<typeof setTimeout> | null = null
+let loadRequestId = 0
 
 const questionHistoryEmptyDescription = computed(() => (
   searchQuery.value.trim() || backupSourceFilter.value || statusFilter.value
@@ -98,10 +99,11 @@ function changePageSize() {
   void loadUsage()
 }
 
-async function loadUsage(showFeedback = false) {
+async function loadUsage() {
+  const requestId = ++loadRequestId
   loading.value = true
   try {
-    usage.value = await fetchCopilotUsage({
+    const nextUsage = await fetchCopilotUsage({
       start_date: startDate.value,
       end_date: endDate.value,
       q: searchQuery.value.trim(),
@@ -110,11 +112,13 @@ async function loadUsage(showFeedback = false) {
       page: page.value,
       page_size: pageSize.value,
     })
-    if (showFeedback) ElMessage.success({ message: 'Usage refreshed.', grouping: true })
+    if (requestId === loadRequestId) usage.value = nextUsage
   } catch (error) {
-    ElMessage.error({ message: apiErrorMessage(error, 'Unable to load AI usage.'), grouping: true })
+    if (requestId === loadRequestId) {
+      ElMessage.error({ message: apiErrorMessage(error, 'Unable to load AI usage.'), grouping: true })
+    }
   } finally {
-    loading.value = false
+    if (requestId === loadRequestId) loading.value = false
   }
 }
 
@@ -162,7 +166,7 @@ function statusLabel(status: string) {
 }
 
 const summary = computed(() => usage.value?.summary ?? {
-  estimated_cost: 0,
+  estimated_cost: null,
   cost_currency: 'USD',
   total_tokens: 0,
   prompt_tokens: 0,
@@ -171,7 +175,22 @@ const summary = computed(() => usage.value?.summary ?? {
   reasoning_tokens: 0,
   model_calls: 0,
   q_and_a_requests: 0,
-  average_cost_per_q_and_a: 0,
+  average_cost_per_q_and_a: null,
+})
+
+const usageFreshness = computed(() => {
+  const freshness = usage.value?.data_freshness
+  if (!freshness) return ''
+  if (freshness.pending_runs > 0) {
+    return `${formatNumber(freshness.pending_runs)} in progress · updates automatically`
+  }
+  if (freshness.last_source_sync_at) {
+    return `Usage updated ${formatShortDateTime(freshness.last_source_sync_at)}`
+  }
+  if (summary.value.q_and_a_requests > 0) {
+    return 'Usage recorded · updates automatically'
+  }
+  return 'No recorded usage'
 })
 
 const tokenBreakdown = computed(() => {
@@ -215,10 +234,13 @@ const chartOption = computed(() => {
       trigger: 'axis',
       renderMode: 'richText',
       borderWidth: 1,
-      formatter: (params: Array<{ axisValueLabel?: string; value?: number }>) => {
+      formatter: (params: Array<{ axisValueLabel?: string; value?: number | null }>) => {
         const point = params[0]
-        const value = Number(point?.value || 0)
-        const formattedValue = costMode ? formatCost(value) : `${formatNumber(value)} tokens`
+        const rawValue = point?.value
+        const value = rawValue == null ? null : Number(rawValue)
+        const formattedValue = costMode
+          ? formatCost(value)
+          : `${formatNumber(value)} tokens`
         return `${point?.axisValueLabel || ''}\n${formattedValue}`
       },
     },
@@ -259,7 +281,7 @@ const chartOption = computed(() => {
       lineStyle: { width: 2.5, color: '#6d5dfc' },
       itemStyle: { color: '#6d5dfc' },
       areaStyle: { color: 'rgba(109, 93, 252, 0.09)' },
-      data: items.map((row) => costMode ? Number(row.total_cost || 0) : Number(row.total_tokens || 0)),
+      data: items.map((row) => costMode ? row.total_cost : Number(row.total_tokens || 0)),
     }],
   }
 })
@@ -285,6 +307,7 @@ onMounted(() => {
 })
 
 onBeforeUnmount(() => {
+  loadRequestId += 1
   if (searchTimer) clearTimeout(searchTimer)
 })
 </script>
@@ -316,7 +339,8 @@ onBeforeUnmount(() => {
             class="usage-date-picker"
             @change="applyCustomRange"
           />
-          <button class="usage-icon-button" type="button" aria-label="Refresh usage" :disabled="loading" @click="loadUsage(true)">
+          <span v-if="usageFreshness" class="usage-freshness">{{ usageFreshness }}</span>
+          <button class="usage-icon-button" type="button" aria-label="Refresh usage" :disabled="loading" @click="loadUsage">
             <RefreshCw :size="17" :class="{ 'is-spinning': loading }" />
           </button>
         </div>
@@ -502,6 +526,7 @@ onBeforeUnmount(() => {
 .usage-segments button.active { background: var(--color-card-bg); color: var(--color-primary); box-shadow: 0 1px 3px rgb(16 24 40 / 10%); }
 .usage-segments--small button { min-height: 27px; padding: 0 10px; font-size: 11px; }
 .usage-date-picker { width: 250px !important; }
+.usage-freshness { overflow: hidden; color: var(--color-text-tertiary); font-size: 11px; text-overflow: ellipsis; white-space: nowrap; }
 .usage-summary-grid { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 12px; margin-bottom: 14px; }
 .usage-summary-card { display: flex; min-width: 0; align-items: center; gap: 13px; padding: 17px; border: 1px solid var(--color-border-light); border-radius: 10px; background: var(--color-card-bg); }
 .usage-summary-card__icon { display: inline-flex; width: 36px; height: 36px; flex: 0 0 36px; align-items: center; justify-content: center; border-radius: 9px; }
@@ -894,6 +919,10 @@ onBeforeUnmount(() => {
   .usage-period__tail :deep(.usage-date-picker) {
     min-width: 0;
     flex: 1;
+  }
+
+  .usage-freshness {
+    display: none;
   }
 
   .usage-chart,


### PR DESCRIPTION
## Summary

- make usage list and detail reads depend only on the persisted HFL ledger
- reconcile SourceLens usage asynchronously with durable claims, retries, and stale-claim recovery
- make the refresh action reload persisted data with clear loading and freshness states
- preserve unknown costs instead of displaying them as zero

## Validation

- 31 related backend tests passed
- 7 frontend tests passed
- frontend production build passed
- Ruff lint and formatting checks passed
- Django migration consistency check passed
- git diff --check passed

Closes #452