### PR TITLE
fix(insight): preserve snapshot repository locations across recovery workflows

### DIFF
--- a/src/agent/internal/engine/managed_backup.go
+++ b/src/agent/internal/engine/managed_backup.go
@@ -380,10 +380,17 @@ func (e *Engine) repositoryConfigPath(spec repositorySpec) string {
 		} else {
 			filename = fmt.Sprintf("server-%s.config", token)
 		}
+	} else if spec.Type == "nas" && spec.ID > 0 && strings.TrimSpace(spec.Subdir) != "" {
+		filename = fmt.Sprintf("repo-%d-nas-%s.config", spec.ID, repositoryNamespaceToken(spec.Subdir))
 	} else if spec.ID > 0 {
 		filename = fmt.Sprintf("repo-%d.config", spec.ID)
 	}
 	return filepath.Join(base, "kopia", "repositories", filename)
+}
+
+func repositoryNamespaceToken(namespace string) string {
+	sum := sha256.Sum256([]byte(strings.TrimSpace(namespace)))
+	return hex.EncodeToString(sum[:])[:16]
 }
 
 func repositoryServerConfigToken(spec repositorySpec) string {

--- a/src/agent/internal/engine/managed_backup_test.go
+++ b/src/agent/internal/engine/managed_backup_test.go
@@ -606,9 +606,14 @@ func TestRepositoryConfigPathSeparatesKopiaServerSessions(t *testing.T) {
 		t.Fatalf("expected different server sessions to use different config files: %q", got)
 	}
 
-	direct := engine.repositoryConfigPath(repositorySpec{ID: 50, Type: "nas"})
-	if filepath.Base(direct) != "repo-50.config" {
-		t.Fatalf("expected direct repository config path to stay stable, got %q", direct)
+	direct := engine.repositoryConfigPath(repositorySpec{ID: 50, Type: "nas", Subdir: "hp-repos/agent-22"})
+	if !strings.HasPrefix(filepath.Base(direct), "repo-50-nas-") {
+		t.Fatalf("expected NAS repository config path to include its namespace, got %q", direct)
+	}
+
+	otherShard := engine.repositoryConfigPath(repositorySpec{ID: 50, Type: "nas", Subdir: "hp-repos/agent-53"})
+	if otherShard == direct {
+		t.Fatalf("expected different NAS shards to use different config files: %q", direct)
 	}
 }
 

--- a/src/agent/internal/engine/repository_cleanup.go
+++ b/src/agent/internal/engine/repository_cleanup.go
@@ -75,16 +75,24 @@ func (e *Engine) runManagedRepositoryCleanup(
 		result["physical_cleanup"] = "already_absent"
 	}
 
-	configFile := e.repositoryConfigPath(spec)
-	removedConfigCount, err := removeRepositoryLocalState(configFile)
-	if err != nil {
-		return "failed", result, redactRepositoryCleanupPaths(err.Error(), filepath.Dir(configFile))
+	configFiles := e.repositoryCleanupConfigPaths(spec)
+	removedConfigCount := 0
+	for _, configFile := range configFiles {
+		removed, err := removeRepositoryLocalState(configFile)
+		if err != nil {
+			return "failed", result, redactRepositoryCleanupPaths(err.Error(), filepath.Dir(configFile))
+		}
+		removedConfigCount += removed
 	}
 	result["removed_config_file_count"] = removedConfigCount
-	cacheDir := managedRepositoryCacheDir(e.current(), configFile)
-	_, cacheExisted, err := deleteManagedRepositoryPath(ctx, cacheDir, managedRepositoryCacheRoot(e.current()))
-	if err != nil {
-		return "failed", result, redactRepositoryCleanupPaths(err.Error(), cacheDir)
+	cacheExisted := false
+	for _, configFile := range configFiles {
+		cacheDir := managedRepositoryCacheDir(e.current(), configFile)
+		_, existed, err := deleteManagedRepositoryPath(ctx, cacheDir, managedRepositoryCacheRoot(e.current()))
+		if err != nil {
+			return "failed", result, redactRepositoryCleanupPaths(err.Error(), cacheDir)
+		}
+		cacheExisted = cacheExisted || existed
 	}
 	result["repository_cache_existed"] = cacheExisted
 	if spec.Type == "nas" {
@@ -102,6 +110,22 @@ func (e *Engine) runManagedRepositoryCleanup(
 		return "failed", result, "canceled"
 	}
 	return "success", result, ""
+}
+
+func (e *Engine) repositoryCleanupConfigPaths(spec repositorySpec) []string {
+	primary := e.repositoryConfigPath(spec)
+	paths := []string{primary}
+	if spec.Type != "nas" || spec.ID <= 0 || strings.TrimSpace(spec.Subdir) == "" {
+		return paths
+	}
+	legacy := filepath.Join(
+		filepath.Dir(primary),
+		fmt.Sprintf("repo-%d.config", spec.ID),
+	)
+	if legacy != primary {
+		paths = append(paths, legacy)
+	}
+	return paths
 }
 
 func deleteManagedRepositoryPath(ctx context.Context, path string, allowedRoot string) (string, bool, error) {

--- a/src/agent/internal/engine/repository_cleanup_test.go
+++ b/src/agent/internal/engine/repository_cleanup_test.go
@@ -85,6 +85,25 @@ func TestRemoveRepositoryLocalStateReturnsCountWithoutPaths(t *testing.T) {
 	}
 }
 
+func TestRepositoryCleanupConfigPathsIncludesLegacyNASConfig(t *testing.T) {
+	engine := New(staticConfigProvider{cfg: &model.AgentConfig{DataDir: t.TempDir()}})
+	paths := engine.repositoryCleanupConfigPaths(repositorySpec{
+		ID:     50,
+		Type:   "nas",
+		Subdir: "hp-repos/agent-22",
+	})
+
+	if len(paths) != 2 {
+		t.Fatalf("cleanup config paths = %v, want current and legacy paths", paths)
+	}
+	if filepath.Base(paths[0]) == filepath.Base(paths[1]) {
+		t.Fatalf("cleanup paths must be distinct: %v", paths)
+	}
+	if filepath.Base(paths[1]) != "repo-50.config" {
+		t.Fatalf("legacy config path = %q, want repo-50.config", paths[1])
+	}
+}
+
 func TestManagedRepositoryCleanupRemovesOnlyOwnedCache(t *testing.T) {
 	dataDir := t.TempDir()
 	engine := New(staticConfigProvider{cfg: &model.AgentConfig{DataDir: dataDir}})

--- a/src/backend/apps/protection/migrations/0018_backup_directory_repository_locator.py
+++ b/src/backend/apps/protection/migrations/0018_backup_directory_repository_locator.py
@@ -1,0 +1,13 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [("protection", "0017_backup_directory_size_estimated_at")]
+
+    operations = [
+        migrations.AddField(
+            model_name="backupsourcesnapshotdirectory",
+            name="repository_locator",
+            field=models.JSONField(blank=True, default=dict),
+        ),
+    ]

--- a/src/backend/apps/protection/models/backup_source_snapshot.py
+++ b/src/backend/apps/protection/models/backup_source_snapshot.py
@@ -127,6 +127,7 @@ class BackupSourceSnapshotDirectory(models.Model):
     )
     display_name = models.CharField(max_length=300, blank=True, default="")
     repository_id = models.BigIntegerField(db_index=True)
+    repository_locator = models.JSONField(default=dict, blank=True)
     kopia_snapshot_id = models.CharField(max_length=128, blank=True, null=True, db_index=True)
     node_task_id = models.UUIDField(blank=True, null=True, db_index=True)
     retry_count = models.IntegerField(default=0)

--- a/src/backend/apps/protection/services/backup_config_reset.py
+++ b/src/backend/apps/protection/services/backup_config_reset.py
@@ -11,16 +11,19 @@ from django.utils import timezone
 from apps.protection.models import BackupConfig, BackupSourceSnapshot, BackupSourceSnapshotDirectory
 from apps.protection.services.kopia_snapshot_delete import (
     classify_kopia_snapshot_delete_results,
+    normalize_kopia_snapshot_id,
 )
 from apps.protection.services.backup_task import (
     _resolve_execution_target,
     _set_step_status,
 )
 from apps.protection.services.repository_compatibility import validate_backup_repository_compatible
-from apps.storage.services.internal.repository_access import (
-    repository_uses_bound_proxy,
-    resolve_repository_reader,
+from apps.protection.services.snapshot_repository_locator import (
+    group_snapshot_directories_by_repository_locator,
+    resolve_snapshot_repository_reader,
 )
+from apps.storage.repositories.models import Repository
+from apps.storage.services.internal.repository_access import repository_uses_bound_proxy
 from apps.source.constants import PipelineStep
 from apps.source.services.internal.selectable_ids import parse_selectable_id
 from apps.source.services.internal.source_pipeline import force_set_pipeline_steps
@@ -97,7 +100,7 @@ def _kopia_snapshot_ids(rows: list[BackupSourceSnapshotDirectory]) -> list[str]:
     seen: set[str] = set()
     ids: list[str] = []
     for row in rows:
-        snapshot_id = str(row.kopia_snapshot_id or "").strip()
+        snapshot_id = normalize_kopia_snapshot_id(row.kopia_snapshot_id)
         if not snapshot_id or snapshot_id in seen:
             continue
         seen.add(snapshot_id)
@@ -609,52 +612,95 @@ def _delete_physical_snapshots(*, task: Task, organization_id: int, config_ids: 
                 "kopia_snapshot_ids": kopia_ids,
             },
         )
-        outcome = _run_kopia_snapshot_delete(
+        repository = validate_backup_repository_compatible(
             organization_id=organization_id,
-            task=task,
-            source_snapshot=snapshot,
-            kopia_ids=kopia_ids,
+            source_type=snapshot.source_type,
+            source_ref_id=snapshot.source_ref_id,
+            repository_id=snapshot.repository_id,
         )
-        result = outcome.result if isinstance(outcome.result, dict) else {}
-        item_results = result.get("results") if isinstance(result.get("results"), list) else []
-        deleted_ids, already_absent_ids, hard_failures = classify_kopia_snapshot_delete_results(
-            [item for item in item_results if isinstance(item, dict)],
+        physical_rows = [
+            row
+            for row in rows
+            if normalize_kopia_snapshot_id(row.kopia_snapshot_id)
+        ]
+        groups = group_snapshot_directories_by_repository_locator(
+            directories=physical_rows,
+            repository=repository,
         )
-        reconciled_ids = deleted_ids | already_absent_ids
-        if already_absent_ids:
-            append_task_step_event(
+        for group in groups:
+            group_kopia_ids = _kopia_snapshot_ids(group)
+            outcome = _run_kopia_snapshot_delete(
+                organization_id=organization_id,
                 task=task,
-                step_name="delete_kopia_snapshots",
-                level=TaskEvent.Level.WARN,
-                message="Kopia snapshot already absent; continuing reset cleanup",
-                metadata={
-                    "source_snapshot_id": snapshot.id,
-                    "kopia_snapshot_ids": sorted(already_absent_ids),
-                },
-            )
-        if reconciled_ids:
-            BackupSourceSnapshotDirectory.objects.filter(
                 source_snapshot=snapshot,
-                kopia_snapshot_id__in=list(reconciled_ids),
-            ).update(status=BackupSourceSnapshotDirectory.Status.DELETED)
-        if outcome.timed_out or hard_failures:
-            failed_count += max(len(hard_failures), 1 if outcome.timed_out else 0)
-            detail = str(getattr(outcome.task, "last_error", "") or "").strip()
-            if not detail and hard_failures:
-                first = hard_failures[0]
-                detail = str(first.get("error_message") or "")
-                delete = first.get("delete")
-                if isinstance(delete, dict):
-                    detail = str(delete.get("stderr_tail") or delete.get("stderr") or detail)
-            raise ValidationError({
-                "detail": detail or "One or more Kopia snapshots failed to delete.",
-            })
-        if not outcome.ok and not reconciled_ids:
-            failed_count += int(result.get("failed_count") or 1)
-            raise ValidationError({
-                "detail": str(getattr(outcome.task, "last_error", "") or "One or more Kopia snapshots failed to delete.")
-            })
-        deleted_count += len(reconciled_ids)
+                directory=group[0],
+                repository=repository,
+                kopia_ids=group_kopia_ids,
+            )
+            result = outcome.result if isinstance(outcome.result, dict) else {}
+            item_results = (
+                result.get("results")
+                if isinstance(result.get("results"), list)
+                else []
+            )
+            deleted_ids, already_absent_ids, hard_failures = (
+                classify_kopia_snapshot_delete_results(
+                    [item for item in item_results if isinstance(item, dict)],
+                )
+            )
+            reconciled_ids = deleted_ids | already_absent_ids
+            if already_absent_ids:
+                append_task_step_event(
+                    task=task,
+                    step_name="delete_kopia_snapshots",
+                    level=TaskEvent.Level.WARN,
+                    message="Kopia snapshot already absent; continuing reset cleanup",
+                    metadata={
+                        "source_snapshot_id": snapshot.id,
+                        "kopia_snapshot_ids": sorted(already_absent_ids),
+                    },
+                )
+            if reconciled_ids:
+                BackupSourceSnapshotDirectory.objects.filter(
+                    source_snapshot=snapshot,
+                    id__in=[row.id for row in group],
+                    kopia_snapshot_id__in=list(reconciled_ids),
+                ).update(status=BackupSourceSnapshotDirectory.Status.DELETED)
+            if outcome.timed_out or hard_failures:
+                failed_count += max(
+                    len(hard_failures),
+                    1 if outcome.timed_out else 0,
+                )
+                detail = str(
+                    getattr(outcome.task, "last_error", "") or ""
+                ).strip()
+                if not detail and hard_failures:
+                    first = hard_failures[0]
+                    detail = str(first.get("error_message") or "")
+                    delete = first.get("delete")
+                    if isinstance(delete, dict):
+                        detail = str(
+                            delete.get("stderr_tail")
+                            or delete.get("stderr")
+                            or detail
+                        )
+                raise ValidationError(
+                    {
+                        "detail": detail
+                        or "One or more Kopia snapshots failed to delete."
+                    }
+                )
+            if not outcome.ok and not reconciled_ids:
+                failed_count += int(result.get("failed_count") or 1)
+                raise ValidationError(
+                    {
+                        "detail": str(
+                            getattr(outcome.task, "last_error", "")
+                            or "One or more Kopia snapshots failed to delete."
+                        )
+                    }
+                )
+            deleted_count += len(reconciled_ids)
         _mark_snapshot_rows_deleted(snapshot)
         _update_delete_progress(task=task, index=index, total=total)
 
@@ -673,20 +719,17 @@ def _run_kopia_snapshot_delete(
     organization_id: int,
     task: Task,
     source_snapshot: BackupSourceSnapshot,
+    directory: BackupSourceSnapshotDirectory,
+    repository: Repository,
     kopia_ids: list[str],
 ):
     from apps.node.services.interface import run_agent_task_sync
 
-    repository = validate_backup_repository_compatible(
-        organization_id=organization_id,
-        source_type=source_snapshot.source_type,
-        source_ref_id=source_snapshot.source_ref_id,
-        repository_id=source_snapshot.repository_id,
-    )
     fallback_target = None
     if not repository_uses_bound_proxy(repository):
         fallback_target = _resolve_execution_target(source_snapshot=source_snapshot)
-    repository_access = resolve_repository_reader(
+    repository_access = resolve_snapshot_repository_reader(
+        directory=directory,
         repository=repository,
         fallback_node=fallback_target.node if fallback_target is not None else None,
         source_type=source_snapshot.source_type,

--- a/src/backend/apps/protection/services/backup_orchestrator.py
+++ b/src/backend/apps/protection/services/backup_orchestrator.py
@@ -42,6 +42,9 @@ from apps.protection.services.progress.orchestrated_progress import (
     BACKUP_PREPARE_END,
     BACKUP_TRANSFER_END,
 )
+from apps.protection.services.snapshot_repository_locator import (
+    ensure_snapshot_repository_locator,
+)
 from apps.storage.repositories.models import Repository
 from apps.storage.services.internal.repository_access import (
     explicit_repository_server_host,
@@ -858,6 +861,11 @@ def _dispatch_directory_backup(
         node_id=execution_target.node.id,
     )
     if existing is not None and existing.status == NodeTask.Status.SUCCESS:
+        ensure_snapshot_repository_locator(
+            directory=directory_row,
+            repository=repository,
+            writer_node_id=existing.node_id,
+        )
         snapshot_id, size_bytes, file_count, dir_count, stats = bt._extract_snapshot_metrics(
             existing.result if isinstance(existing.result, dict) else {}
         )
@@ -897,6 +905,11 @@ def _dispatch_directory_backup(
         directory_row.save(update_fields=["status", "node_task_id", "updated_at"])
         return
     if existing is not None and existing.status not in _NODE_TASK_TERMINAL:
+        ensure_snapshot_repository_locator(
+            directory=directory_row,
+            repository=repository,
+            writer_node_id=existing.node_id,
+        )
         directory_row.status = (
             BackupSourceSnapshotDirectory.Status.RUNNING
             if existing.status == NodeTask.Status.RUNNING
@@ -912,6 +925,11 @@ def _dispatch_directory_backup(
             deliver_agent_task(task=existing)
         return
 
+    ensure_snapshot_repository_locator(
+        directory=directory_row,
+        repository=repository,
+        writer_node_id=execution_target.node.id,
+    )
     handle = run_agent_task_async(
         organization_id=task.organization_id,
         node_id=execution_target.node.id,
@@ -1010,6 +1028,16 @@ def _maybe_adopt_late_success(
     )
     if not snapshot_id:
         return False
+    repository = Repository.objects.filter(
+        organization_id=directory_row.organization_id,
+        id=directory_row.repository_id,
+    ).first()
+    if repository is not None:
+        ensure_snapshot_repository_locator(
+            directory=directory_row,
+            repository=repository,
+            writer_node_id=node_task.node_id,
+        )
     record_source_snapshot_directory_result(
         source_snapshot=source_snapshot,
         backup_config_dir_id=directory_row.backup_config_dir_id,
@@ -2683,6 +2711,16 @@ def project_backup_node_task_result(*, node_task_id) -> dict[str, Any]:
         return {"status": "ignored", "reason": "kopia_snapshot_id_missing"}
 
     previous_error_code = directory.error_code
+    repository = Repository.objects.filter(
+        organization_id=directory.organization_id,
+        id=directory.repository_id,
+    ).first()
+    if repository is not None:
+        ensure_snapshot_repository_locator(
+            directory=directory,
+            repository=repository,
+            writer_node_id=node_task.node_id,
+        )
     projected_directory = record_source_snapshot_directory_result(
         source_snapshot=source_snapshot,
         backup_config_dir_id=directory.backup_config_dir_id,

--- a/src/backend/apps/protection/services/kopia_snapshot_delete.py
+++ b/src/backend/apps/protection/services/kopia_snapshot_delete.py
@@ -42,7 +42,7 @@ def classify_kopia_snapshot_delete_results(
     for item in item_results:
         if not isinstance(item, dict):
             continue
-        snapshot_id = str(item.get("kopia_snapshot_id") or "").strip()
+        snapshot_id = normalize_kopia_snapshot_id(item.get("kopia_snapshot_id"))
         if not snapshot_id:
             continue
         status = str(item.get("status") or "").strip().lower()

--- a/src/backend/apps/protection/services/snapshot_browser.py
+++ b/src/backend/apps/protection/services/snapshot_browser.py
@@ -13,11 +13,11 @@ from apps.node.services.internal.agent_log import task_log_context
 from apps.node.services.interface import run_agent_task_sync
 from apps.protection.models import BackupSourceSnapshot, BackupSourceSnapshotDirectory
 from apps.protection.services.backup_task import _resolve_execution_target
-from apps.storage.repositories.models import Repository
-from apps.storage.services.internal.repository_access import (
-    repository_uses_bound_proxy,
-    resolve_repository_reader,
+from apps.protection.services.snapshot_repository_locator import (
+    resolve_snapshot_repository_reader,
 )
+from apps.storage.repositories.models import Repository
+from apps.storage.services.internal.repository_access import repository_uses_bound_proxy
 
 DEFAULT_SNAPSHOT_BROWSE_LIMIT = 200
 DEFAULT_SNAPSHOT_BROWSER_TIMEOUT_SECONDS = 120
@@ -157,7 +157,8 @@ def _run_snapshot_agent_task(
     fallback_target = None
     if not repository_uses_bound_proxy(repository):
         fallback_target = _resolve_execution_target(source_snapshot=snapshot)
-    repository_access = resolve_repository_reader(
+    repository_access = resolve_snapshot_repository_reader(
+        directory=row,
         repository=repository,
         fallback_node=fallback_target.node if fallback_target is not None else None,
         source_type=snapshot.source_type,

--- a/src/backend/apps/protection/services/snapshot_delete.py
+++ b/src/backend/apps/protection/services/snapshot_delete.py
@@ -17,12 +17,14 @@ from apps.protection.services.backup_task import (
 )
 from apps.protection.services.kopia_snapshot_delete import (
     classify_kopia_snapshot_delete_results,
+    normalize_kopia_snapshot_id,
 )
 from apps.protection.services.repository_compatibility import validate_backup_repository_compatible
-from apps.storage.services.internal.repository_access import (
-    repository_uses_bound_proxy,
-    resolve_repository_reader,
+from apps.protection.services.snapshot_repository_locator import (
+    group_snapshot_directories_by_repository_locator,
+    resolve_snapshot_repository_reader,
 )
+from apps.storage.services.internal.repository_access import repository_uses_bound_proxy
 from apps.task.models import Task, TaskEvent, TaskResource, TaskStep
 from apps.task.services.interface import (
     append_task_step_event,
@@ -98,7 +100,7 @@ def _kopia_snapshot_ids(rows: list[BackupSourceSnapshotDirectory]) -> list[str]:
     seen: set[str] = set()
     ids: list[str] = []
     for row in rows:
-        snapshot_id = str(row.kopia_snapshot_id or "").strip()
+        snapshot_id = normalize_kopia_snapshot_id(row.kopia_snapshot_id)
         if not snapshot_id or snapshot_id in seen:
             continue
         seen.add(snapshot_id)
@@ -120,7 +122,7 @@ def _kopia_snapshot_display(snapshot_id: str, directories: list[str]) -> str:
 def _kopia_snapshot_directories_by_id(rows: list[BackupSourceSnapshotDirectory]) -> dict[str, list[str]]:
     directories_by_id: dict[str, list[str]] = {}
     for row in rows:
-        snapshot_id = str(row.kopia_snapshot_id or "").strip()
+        snapshot_id = normalize_kopia_snapshot_id(row.kopia_snapshot_id)
         if not snapshot_id:
             continue
         directory = _snapshot_directory_label(row)
@@ -522,7 +524,9 @@ def _run_snapshot_delete_task_locked(
     kopia_ids = _kopia_snapshot_ids(rows)
     kopia_directories_by_id = _kopia_snapshot_directories_by_id(rows)
     rows_without_physical_snapshot = [
-        row.id for row in rows if not str(row.kopia_snapshot_id or "").strip()
+        row.id
+        for row in rows
+        if not normalize_kopia_snapshot_id(row.kopia_snapshot_id)
     ]
 
     _set_step_status(
@@ -559,12 +563,6 @@ def _run_snapshot_delete_task_locked(
     fallback_target = None
     if not repository_uses_bound_proxy(repository):
         fallback_target = _resolve_execution_target(source_snapshot=source_snapshot)
-    repository_access = resolve_repository_reader(
-        repository=repository,
-        fallback_node=fallback_target.node if fallback_target is not None else None,
-        source_type=source_snapshot.source_type,
-        source_ref_id=source_snapshot.source_ref_id,
-    )
     _set_step_status(
         task=task,
         step_name="delete_kopia_snapshots",
@@ -588,31 +586,76 @@ def _run_snapshot_delete_task_locked(
                 "object_names": directories,
             },
         )
-    outcome = run_agent_task_sync(
-        organization_id=organization_id,
-        node_id=repository_access.node.id,
-        kind="snapshot.delete",
-        payload={
-            "repository": repository_access.repository_payload,
-            "kopia_snapshot_ids": kopia_ids,
-        },
-        correlation_type="protection.snapshot_delete",
-        correlation_id=str(task.task_uuid),
-        wait_timeout_seconds=3600,
+    physical_rows = [
+        row for row in rows if normalize_kopia_snapshot_id(row.kopia_snapshot_id)
+    ]
+    groups = group_snapshot_directories_by_repository_locator(
+        directories=physical_rows,
+        repository=repository,
     )
-    result = outcome.result if isinstance(outcome.result, dict) else {}
-    item_results = result.get("results") if isinstance(result.get("results"), list) else []
-    deleted_ids, already_absent_ids, hard_failures = classify_kopia_snapshot_delete_results(
-        [item for item in item_results if isinstance(item, dict)],
-    )
-    reconciled_ids = deleted_ids | already_absent_ids
-    hard_failed = bool(outcome.timed_out or hard_failures or (not outcome.ok and not reconciled_ids))
+    item_results: list[dict[str, Any]] = []
+    already_absent_ids: set[str] = set()
+    hard_failed = False
+    failure_messages: list[str] = []
     now = timezone.now()
-    if reconciled_ids:
-        BackupSourceSnapshotDirectory.objects.filter(
-            source_snapshot=source_snapshot,
-            kopia_snapshot_id__in=list(reconciled_ids),
-        ).update(status=BackupSourceSnapshotDirectory.Status.DELETED, updated_at=now)
+    for group in groups:
+        group_kopia_ids = _kopia_snapshot_ids(group)
+        repository_access = resolve_snapshot_repository_reader(
+            directory=group[0],
+            repository=repository,
+            fallback_node=(
+                fallback_target.node if fallback_target is not None else None
+            ),
+            source_type=source_snapshot.source_type,
+            source_ref_id=source_snapshot.source_ref_id,
+        )
+        outcome = run_agent_task_sync(
+            organization_id=organization_id,
+            node_id=repository_access.node.id,
+            kind="snapshot.delete",
+            payload={
+                "repository": repository_access.repository_payload,
+                "kopia_snapshot_ids": group_kopia_ids,
+            },
+            correlation_type="protection.snapshot_delete",
+            correlation_id=str(task.task_uuid),
+            wait_timeout_seconds=3600,
+        )
+        result = outcome.result if isinstance(outcome.result, dict) else {}
+        group_results = (
+            result.get("results") if isinstance(result.get("results"), list) else []
+        )
+        normalized_results = [
+            item for item in group_results if isinstance(item, dict)
+        ]
+        item_results.extend(normalized_results)
+        deleted_ids, group_absent_ids, hard_failures = (
+            classify_kopia_snapshot_delete_results(normalized_results)
+        )
+        already_absent_ids.update(group_absent_ids)
+        reconciled_ids = deleted_ids | group_absent_ids
+        if reconciled_ids:
+            BackupSourceSnapshotDirectory.objects.filter(
+                source_snapshot=source_snapshot,
+                id__in=[row.id for row in group],
+                kopia_snapshot_id__in=list(reconciled_ids),
+            ).update(
+                status=BackupSourceSnapshotDirectory.Status.DELETED,
+                updated_at=now,
+            )
+        group_failed = bool(
+            outcome.timed_out
+            or hard_failures
+            or (not outcome.ok and not reconciled_ids)
+        )
+        hard_failed = hard_failed or group_failed
+        if group_failed:
+            failure_messages.append(
+                str(
+                    getattr(outcome.task, "last_error", "")
+                    or "One or more physical snapshots failed to delete."
+                )[:2000]
+            )
     if not hard_failed:
         BackupSourceSnapshotDirectory.objects.filter(
             source_snapshot=source_snapshot,
@@ -669,10 +712,11 @@ def _run_snapshot_delete_task_locked(
         _queue_source_unregister_followup_on_commit(task=task)
         return task_result
 
-    error_message = str(
-        getattr(outcome.task, "last_error", "")
-        or "One or more physical snapshots failed to delete."
-    )[:2000]
+    error_message = (
+        failure_messages[0]
+        if failure_messages
+        else "One or more physical snapshots failed to delete."
+    )
     return fail_snapshot_delete_task(
         task=task,
         source_snapshot=source_snapshot,

--- a/src/backend/apps/protection/services/snapshot_repository_locator.py
+++ b/src/backend/apps/protection/services/snapshot_repository_locator.py
@@ -1,0 +1,378 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import asdict, dataclass, replace
+from typing import Any
+
+from django.core.exceptions import ValidationError
+from django.db import transaction
+
+from apps.node.models import Node, NodeTask
+from apps.node.models.base import NodeRole
+from apps.protection import conf as protection_conf
+from apps.protection.models import BackupSourceSnapshotDirectory
+from apps.source.constants import ResourceType
+from apps.source.models import SourceResource
+from apps.storage.repositories.models import Repository
+from apps.storage.services.internal.nas_repository import (
+    nas_agent_repository_subdir,
+    nas_proxy_repository_subdir,
+)
+from apps.storage.services.internal.repository_access import (
+    RepositoryAccess,
+    resolve_repository_reader,
+)
+
+
+SNAPSHOT_REPOSITORY_LOCATOR_VERSION = 1
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class SnapshotRepositoryLocator:
+    """Immutable, non-secret location of one physical snapshot."""
+
+    version: int
+    repository_id: int
+    repository_type: str
+    repository_subdir: str = ""
+    writer_node_id: int | None = None
+    access_node_id: int | None = None
+
+    def payload(self) -> dict[str, Any]:
+        """Return the JSON-compatible representation stored with the snapshot."""
+
+        return asdict(self)
+
+
+def build_snapshot_repository_locator(
+    *,
+    repository: Repository,
+    writer_node_id: int | None,
+) -> SnapshotRepositoryLocator:
+    """Build the physical snapshot location known at backup dispatch time."""
+
+    normalized_writer_node_id = _positive_int(writer_node_id)
+    repository_subdir = ""
+    access_node_id: int | None = None
+
+    if repository.repo_type == Repository.Type.NAS:
+        if repository.bind_node_type == Repository.BindNodeType.PROXY:
+            repository_subdir = nas_proxy_repository_subdir(repository)
+            access_node_id = _positive_int(repository.bind_node_id)
+        else:
+            if normalized_writer_node_id is None:
+                raise ValidationError(
+                    {
+                        "repository_id": "Direct NAS snapshot location requires its backup execution node."
+                    }
+                )
+            repository_subdir = nas_agent_repository_subdir(normalized_writer_node_id)
+    elif repository.repo_type == Repository.Type.PROXY_FS:
+        access_node_id = _positive_int(repository.bind_node_id)
+        if access_node_id is None:
+            raise ValidationError(
+                {
+                    "repository_id": "Proxy filesystem snapshot location requires its bound proxy node."
+                }
+            )
+
+    return SnapshotRepositoryLocator(
+        version=SNAPSHOT_REPOSITORY_LOCATOR_VERSION,
+        repository_id=int(repository.id),
+        repository_type=str(repository.repo_type),
+        repository_subdir=repository_subdir,
+        writer_node_id=normalized_writer_node_id,
+        access_node_id=access_node_id,
+    )
+
+
+def ensure_snapshot_repository_locator(
+    *,
+    directory: BackupSourceSnapshotDirectory,
+    repository: Repository,
+    writer_node_id: int | None,
+) -> SnapshotRepositoryLocator:
+    """Persist the current physical location without storing credentials.
+
+    Dispatch retries may move before a physical snapshot exists. Once Kopia
+    has produced the snapshot, its locator is immutable.
+    """
+
+    locator = build_snapshot_repository_locator(
+        repository=repository,
+        writer_node_id=writer_node_id,
+    )
+    with transaction.atomic():
+        locked = BackupSourceSnapshotDirectory.objects.select_for_update().get(
+            pk=directory.pk,
+        )
+        existing = _stored_locator(directory=locked, repository=repository)
+        if existing is not None and (
+            existing == locator or locked.kopia_snapshot_id
+        ):
+            resolved = existing
+        else:
+            locked.repository_locator = locator.payload()
+            locked.save(update_fields=["repository_locator", "updated_at"])
+            resolved = locator
+
+    # Keep callers that hold an older model instance consistent with the
+    # serialized row. In particular, a delayed retry must not carry its stale
+    # locator into subsequent work in the same request.
+    directory.repository_locator = resolved.payload()
+    return resolved
+
+
+def resolve_snapshot_repository_locator(
+    *,
+    directory: BackupSourceSnapshotDirectory,
+    repository: Repository,
+) -> SnapshotRepositoryLocator:
+    """Resolve a stored locator or derive one for a legacy snapshot."""
+
+    existing = _stored_locator(directory=directory, repository=repository)
+    if existing is not None:
+        return existing
+    locator = _build_legacy_snapshot_repository_locator(
+        directory=directory,
+        repository=repository,
+    )
+    if not directory.kopia_snapshot_id:
+        return locator
+
+    stored = BackupSourceSnapshotDirectory.objects.filter(
+        pk=directory.pk,
+        repository_locator={},
+    ).update(repository_locator=locator.payload())
+    if stored:
+        directory.repository_locator = locator.payload()
+        return locator
+
+    directory.refresh_from_db(fields=["repository_locator"])
+    concurrent = _stored_locator(directory=directory, repository=repository)
+    return concurrent if concurrent is not None else locator
+
+
+def resolve_snapshot_repository_reader(
+    *,
+    directory: BackupSourceSnapshotDirectory,
+    repository: Repository,
+    fallback_node: Node | None,
+    source_type: str = "agent",
+    source_ref_id: int | None = None,
+) -> RepositoryAccess:
+    """Resolve repository access while preserving the snapshot's original shard."""
+
+    locator = resolve_snapshot_repository_locator(
+        directory=directory,
+        repository=repository,
+    )
+    return resolve_repository_reader(
+        repository=repository,
+        fallback_node=fallback_node,
+        source_type=source_type,
+        source_ref_id=source_ref_id,
+        repository_subdir=locator.repository_subdir,
+        repository_access_node_id=(
+            locator.access_node_id
+            if locator.repository_type == Repository.Type.PROXY_FS
+            else None
+        ),
+    )
+
+
+def group_snapshot_directories_by_repository_locator(
+    *,
+    directories: list[BackupSourceSnapshotDirectory],
+    repository: Repository,
+) -> list[list[BackupSourceSnapshotDirectory]]:
+    """Group physical snapshot rows that share one repository access context."""
+
+    grouped: dict[
+        SnapshotRepositoryLocator,
+        list[BackupSourceSnapshotDirectory],
+    ] = {}
+    for directory in directories:
+        locator = resolve_snapshot_repository_locator(
+            directory=directory,
+            repository=repository,
+        )
+        grouped.setdefault(locator, []).append(directory)
+    return list(grouped.values())
+
+
+def _stored_locator(
+    *,
+    directory: BackupSourceSnapshotDirectory,
+    repository: Repository,
+) -> SnapshotRepositoryLocator | None:
+    raw = directory.repository_locator
+    if raw == {}:
+        return None
+    if not isinstance(raw, dict):
+        raise ValidationError(
+            {"repository_locator": "Snapshot repository locator must be an object."}
+        )
+    try:
+        locator = SnapshotRepositoryLocator(
+            version=int(raw.get("version") or 0),
+            repository_id=int(raw.get("repository_id") or 0),
+            repository_type=str(raw.get("repository_type") or "").strip(),
+            repository_subdir=str(raw.get("repository_subdir") or "").strip(),
+            writer_node_id=_positive_int(raw.get("writer_node_id")),
+            access_node_id=_positive_int(raw.get("access_node_id")),
+        )
+    except (TypeError, ValueError) as exc:
+        raise ValidationError(
+            {"repository_locator": "Snapshot repository locator is invalid."}
+        ) from exc
+    if locator.version != SNAPSHOT_REPOSITORY_LOCATOR_VERSION:
+        raise ValidationError(
+            {"repository_locator": "Snapshot repository locator version is not supported."}
+        )
+    if (
+        locator.repository_id != int(repository.id)
+        or locator.repository_type != str(repository.repo_type)
+    ):
+        raise ValidationError(
+            {"repository_locator": "Snapshot repository locator does not match its repository."}
+        )
+    if repository.repo_type == Repository.Type.NAS and not locator.repository_subdir:
+        raise ValidationError(
+            {"repository_locator": "NAS snapshot repository locator has no subdirectory."}
+        )
+    if (
+        repository.repo_type == Repository.Type.PROXY_FS
+        and locator.access_node_id is None
+    ):
+        raise ValidationError(
+            {"repository_locator": "Proxy filesystem snapshot locator has no access node."}
+        )
+    return locator
+
+
+def _build_legacy_snapshot_repository_locator(
+    *,
+    directory: BackupSourceSnapshotDirectory,
+    repository: Repository,
+) -> SnapshotRepositoryLocator:
+    locator = build_snapshot_repository_locator(
+        repository=repository,
+        writer_node_id=_legacy_writer_node_id(directory),
+    )
+    if repository.repo_type != Repository.Type.PROXY_FS:
+        return locator
+
+    historical_access_node_id = _legacy_proxy_fs_access_node_id(directory)
+    if historical_access_node_id is not None:
+        return replace(locator, access_node_id=historical_access_node_id)
+
+    logger.warning(
+        "Legacy ProxyFS snapshot locator fell back to current repository binding "
+        "directory_id=%s repository_id=%s bind_node_id=%s",
+        directory.id,
+        repository.id,
+        repository.bind_node_id,
+    )
+    return locator
+
+
+def _legacy_proxy_fs_access_node_id(
+    directory: BackupSourceSnapshotDirectory,
+) -> int | None:
+    """Recover the Proxy that exposed a legacy ProxyFS snapshot to its writer."""
+
+    snapshot = directory.source_snapshot
+    repository_server_tasks = (
+        NodeTask.objects.filter(
+            organization_id=directory.organization_id,
+            kind="repository.server.start",
+            correlation_type=protection_conf.PROTECTION_BACKUP_CORRELATION_TYPE,
+            correlation_id=str(snapshot.task_uuid),
+            status=NodeTask.Status.SUCCESS,
+        )
+        .order_by("-created_at", "-id")
+        .values("node_id", "payload")
+    )
+    legacy_node_id: int | None = None
+    for task in repository_server_tasks:
+        payload = task.get("payload")
+        repository_payload = (
+            payload.get("repository") if isinstance(payload, dict) else None
+        )
+        task_repository_id = (
+            _positive_int(repository_payload.get("id"))
+            if isinstance(repository_payload, dict)
+            else None
+        )
+        if task_repository_id == int(snapshot.repository_id):
+            return _positive_int(task.get("node_id"))
+        if task_repository_id is None and legacy_node_id is None:
+            legacy_node_id = _positive_int(task.get("node_id"))
+    if legacy_node_id is not None:
+        return legacy_node_id
+
+    if not directory.node_task_id:
+        return None
+    backup_proxy_node_id = (
+        NodeTask.objects.filter(
+            organization_id=directory.organization_id,
+            id=directory.node_task_id,
+            kind="backup.run",
+            node__role=NodeRole.PROXY,
+        )
+        .values_list("node_id", flat=True)
+        .first()
+    )
+    return _positive_int(backup_proxy_node_id)
+
+
+def _legacy_writer_node_id(directory: BackupSourceSnapshotDirectory) -> int | None:
+    if directory.node_task_id:
+        node_id = (
+            NodeTask.objects.filter(
+                organization_id=directory.organization_id,
+                id=directory.node_task_id,
+            )
+            .values_list("node_id", flat=True)
+            .first()
+        )
+        if node_id:
+            return int(node_id)
+
+    snapshot = directory.source_snapshot
+    if snapshot.source_type == "agent":
+        return _positive_int(snapshot.source_ref_id)
+    if snapshot.source_type != "nas":
+        return None
+    node_id = (
+        SourceResource.objects.filter(
+            organization_id=directory.organization_id,
+            id=snapshot.source_ref_id,
+            resource_type=ResourceType.NAS,
+            is_deleted=False,
+        )
+        .values_list("bound_node_id", flat=True)
+        .first()
+    )
+    return _positive_int(node_id)
+
+
+def _positive_int(value: object) -> int | None:
+    try:
+        parsed = int(value or 0)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+__all__ = [
+    "SnapshotRepositoryLocator",
+    "build_snapshot_repository_locator",
+    "ensure_snapshot_repository_locator",
+    "group_snapshot_directories_by_repository_locator",
+    "resolve_snapshot_repository_locator",
+    "resolve_snapshot_repository_reader",
+]

--- a/src/backend/apps/protection/tests/test_backup_config_api.py
+++ b/src/backend/apps/protection/tests/test_backup_config_api.py
@@ -722,9 +722,11 @@ class ProtectionBackupConfigApiTests(TestCase):
 
         self.assertEqual(create.status_code, status.HTTP_201_CREATED, create.content)
 
-    def test_create_backup_config_rejects_cross_proxy_repository_without_explicit_host(self):
+    def test_create_backup_config_rejects_cross_proxy_repository_without_reachable_host(self):
         source_proxy = self._proxy(name="source-proxy-no-host")
         repository_proxy = self._proxy(name="repository-proxy-no-host")
+        repository_proxy.ip_address = ""
+        repository_proxy.save(update_fields=["ip_address", "updated_at"])
         source = self._nas_source(proxy=source_proxy, name="nas-source-no-host")
         repository = self._proxy_bound_nas_repository(proxy=repository_proxy, name="repo-no-host")
 

--- a/src/backend/apps/protection/tests/test_backup_task_api.py
+++ b/src/backend/apps/protection/tests/test_backup_task_api.py
@@ -1558,7 +1558,7 @@ class ProtectionBackupTaskApiTests(TestCase):
         host, source = _repository_public_host(repository=repository, node=proxy)
 
         self.assertEqual(host, "10.0.0.65")
-        self.assertEqual(source, "node.metadata.ip_addresses")
+        self.assertEqual(source, "node.metadata.inventory.ip_addresses")
 
     @patch("apps.protection.services.backup_orchestrator.enqueue_repository_usage_refresh")
     @patch("apps.protection.services.backup_orchestrator.run_agent_task_async")
@@ -1707,6 +1707,17 @@ class ProtectionBackupTaskApiTests(TestCase):
         self.assertEqual(snapshot.status, BackupSourceSnapshot.Status.AVAILABLE)
         self.assertEqual(task.status, Task.Status.SUCCESS)
         self.assertEqual(directory.kopia_snapshot_id, "proxy-nas-snap-1")
+        self.assertEqual(
+            directory.repository_locator,
+            {
+                "version": 1,
+                "repository_id": repository.id,
+                "repository_type": Repository.Type.NAS,
+                "repository_subdir": f"hp-repos/storage-{repository.id}",
+                "writer_node_id": self.agent.id,
+                "access_node_id": proxy.id,
+            },
+        )
         backup_calls = [
             call.kwargs
             for call in mock_run_agent_task_async.call_args_list

--- a/src/backend/apps/protection/tests/test_snapshot_browser_api.py
+++ b/src/backend/apps/protection/tests/test_snapshot_browser_api.py
@@ -189,6 +189,62 @@ class SnapshotBrowserApiTests(TestCase):
         self.assertEqual(payload["repository"]["subdir"], f"hp-repos/storage-{self.repository.id}")
 
     @patch("apps.protection.services.snapshot_browser.run_agent_task_sync")
+    def test_browse_proxy_filesystem_snapshot_uses_original_proxy(
+        self,
+        mock_run_agent_task_sync,
+    ):
+        original_proxy = Node.objects.create(
+            organization=self.org,
+            name="snapshot-browser-original-proxy",
+            role=Node.Role.PROXY,
+            status=Node.Status.ACTIVE,
+            availability=Node.Availability.ONLINE,
+        )
+        replacement_proxy = Node.objects.create(
+            organization=self.org,
+            name="snapshot-browser-replacement-proxy",
+            role=Node.Role.PROXY,
+            status=Node.Status.ACTIVE,
+            availability=Node.Availability.ONLINE,
+        )
+        self.repository.repo_type = Repository.Type.PROXY_FS
+        self.repository.s3_bucket = ""
+        self.repository.bind_node_type = Repository.BindNodeType.PROXY
+        self.repository.bind_node_id = replacement_proxy.id
+        self.repository.config = {
+            "proxy_node_dir": "/srv/hfl-repository",
+            "kopia_password": "repo-pass",
+        }
+        self.repository.save()
+        self.directory.repository_locator = {
+            "version": 1,
+            "repository_id": self.repository.id,
+            "repository_type": Repository.Type.PROXY_FS,
+            "repository_subdir": "",
+            "writer_node_id": self.agent.id,
+            "access_node_id": original_proxy.id,
+        }
+        self.directory.save(update_fields=["repository_locator", "updated_at"])
+        mock_run_agent_task_sync.return_value = SimpleNamespace(
+            ok=True,
+            timed_out=False,
+            result={"entries": []},
+            task=SimpleNamespace(last_error=""),
+        )
+
+        response = self.client.get(
+            f"/api/v1/protection/backup-source-snapshot-directories/"
+            f"{self.directory.id}/browse/",
+            **self._headers(),
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+        self.assertEqual(
+            mock_run_agent_task_sync.call_args.kwargs["node_id"],
+            original_proxy.id,
+        )
+
+    @patch("apps.protection.services.snapshot_browser.run_agent_task_sync")
     def test_browse_snapshot_directory_normalizes_kopia_directory_type(self, mock_run_agent_task_sync):
         mock_run_agent_task_sync.return_value = SimpleNamespace(
             ok=True,

--- a/src/backend/apps/protection/tests/test_snapshot_delete_task.py
+++ b/src/backend/apps/protection/tests/test_snapshot_delete_task.py
@@ -173,6 +173,112 @@ class SnapshotDeleteTaskTests(TestCase):
         self.assertEqual(events[1].metadata["object_names"], ["/data/b"])
 
     @patch("apps.protection.services.snapshot_delete.run_agent_task_sync")
+    def test_snapshot_delete_groups_by_locator_and_preserves_partial_results(
+        self,
+        mock_run_agent_task_sync,
+    ):
+        original_proxy = Node.objects.create(
+            organization=self.org,
+            name="snapshot-delete-original-proxy",
+            role=Node.Role.PROXY,
+            status=Node.Status.ACTIVE,
+            availability=Node.Availability.ONLINE,
+        )
+        replacement_proxy = Node.objects.create(
+            organization=self.org,
+            name="snapshot-delete-replacement-proxy",
+            role=Node.Role.PROXY,
+            status=Node.Status.ACTIVE,
+            availability=Node.Availability.ONLINE,
+        )
+        self.repository.repo_type = Repository.Type.PROXY_FS
+        self.repository.s3_bucket = ""
+        self.repository.bind_node_type = Repository.BindNodeType.PROXY
+        self.repository.bind_node_id = replacement_proxy.id
+        self.repository.config = {
+            "proxy_node_dir": "/srv/hfl-repository",
+            "kopia_password": "repo-pass",
+        }
+        self.repository.save()
+        rows = list(
+            BackupSourceSnapshotDirectory.objects.filter(
+                source_snapshot=self.snapshot,
+            ).order_by("id")
+        )
+        for row, access_node in zip(
+            rows,
+            (original_proxy, replacement_proxy),
+            strict=True,
+        ):
+            row.repository_locator = {
+                "version": 1,
+                "repository_id": self.repository.id,
+                "repository_type": Repository.Type.PROXY_FS,
+                "repository_subdir": "",
+                "writer_node_id": self.agent.id,
+                "access_node_id": access_node.id,
+            }
+            row.save(update_fields=["repository_locator", "updated_at"])
+
+        def _delete_group(**kwargs):
+            snapshot_ids = kwargs["payload"]["kopia_snapshot_ids"]
+            failed = kwargs["node_id"] == replacement_proxy.id
+            return SimpleNamespace(
+                task=SimpleNamespace(
+                    id="node-delete-group",
+                    status="failed" if failed else "success",
+                    last_error="delete failed" if failed else "",
+                ),
+                result={
+                    "deleted_count": 0 if failed else len(snapshot_ids),
+                    "failed_count": len(snapshot_ids) if failed else 0,
+                    "results": [
+                        {
+                            "kopia_snapshot_id": snapshot_id,
+                            "status": "failed" if failed else "success",
+                            **({"error_message": "boom"} if failed else {}),
+                        }
+                        for snapshot_id in snapshot_ids
+                    ],
+                },
+                ok=not failed,
+                timed_out=False,
+            )
+
+        mock_run_agent_task_sync.side_effect = _delete_group
+        task = create_snapshot_delete_task(source_snapshot=self.snapshot)
+
+        result = run_snapshot_delete_task(
+            organization_id=self.org.id,
+            task_uuid=str(task.task_uuid),
+            source_snapshot_id=self.snapshot.id,
+        )
+
+        task.refresh_from_db()
+        self.snapshot.refresh_from_db()
+        rows = list(
+            BackupSourceSnapshotDirectory.objects.filter(
+                source_snapshot=self.snapshot,
+            ).order_by("id")
+        )
+        self.assertEqual(result["deleted_count"], 1)
+        self.assertEqual(task.status, Task.Status.FAILED)
+        self.assertEqual(
+            self.snapshot.status,
+            BackupSourceSnapshot.Status.DELETE_FAILED,
+        )
+        self.assertEqual(rows[0].status, BackupSourceSnapshotDirectory.Status.DELETED)
+        self.assertEqual(rows[1].status, BackupSourceSnapshotDirectory.Status.AVAILABLE)
+        self.assertEqual(mock_run_agent_task_sync.call_count, 2)
+        self.assertEqual(
+            {
+                call.kwargs["node_id"]
+                for call in mock_run_agent_task_sync.call_args_list
+            },
+            {original_proxy.id, replacement_proxy.id},
+        )
+
+    @patch("apps.protection.services.snapshot_delete.run_agent_task_sync")
     def test_run_snapshot_delete_task_keeps_logical_snapshot_when_partial_delete_fails(self, mock_run_agent_task_sync):
         task = create_snapshot_delete_task(source_snapshot=self.snapshot)
         mock_run_agent_task_sync.return_value = SimpleNamespace(
@@ -244,6 +350,40 @@ class SnapshotDeleteTaskTests(TestCase):
         self.assertEqual(self.snapshot.status, BackupSourceSnapshot.Status.DELETED)
         self.assertEqual(task.status, Task.Status.SUCCESS)
         self.assertEqual(result["already_absent_count"], 2)
+
+    @patch("apps.protection.services.snapshot_delete.run_agent_task_sync")
+    def test_legacy_sentinel_row_is_not_dispatched(self, mock_run_agent_task_sync):
+        BackupSourceSnapshotDirectory.objects.filter(
+            source_snapshot=self.snapshot,
+            backup_config_dir_id=self.dir_b.id,
+        ).update(kopia_snapshot_id="None")
+        mock_run_agent_task_sync.return_value = SimpleNamespace(
+            task=SimpleNamespace(id="node-delete-sentinel", status="success", last_error=""),
+            result={
+                "deleted_count": 1,
+                "failed_count": 0,
+                "results": [
+                    {"kopia_snapshot_id": "kopia-a", "status": "success"},
+                ],
+            },
+            ok=True,
+            timed_out=False,
+        )
+        task = create_snapshot_delete_task(source_snapshot=self.snapshot)
+
+        result = run_snapshot_delete_task(
+            organization_id=self.org.id,
+            task_uuid=str(task.task_uuid),
+            source_snapshot_id=self.snapshot.id,
+        )
+
+        task.refresh_from_db()
+        self.assertEqual(task.status, Task.Status.SUCCESS)
+        self.assertEqual(result["deleted_count"], 2)
+        self.assertEqual(
+            mock_run_agent_task_sync.call_args.kwargs["payload"]["kopia_snapshot_ids"],
+            ["kopia-a"],
+        )
 
     def test_retry_delay_sequence_caps_at_two_hours(self):
         self.assertEqual(

--- a/src/backend/apps/protection/tests/test_snapshot_repository_locator.py
+++ b/src/backend/apps/protection/tests/test_snapshot_repository_locator.py
@@ -1,0 +1,356 @@
+from __future__ import annotations
+
+from django.core.exceptions import ValidationError
+from django.test import TestCase
+from django.utils import timezone
+
+from apps.iam.models import Organization
+from apps.node.models import Node, NodeTask
+from apps.protection.models import BackupSourceSnapshot, BackupSourceSnapshotDirectory
+from apps.protection.services.snapshot_repository_locator import (
+    ensure_snapshot_repository_locator,
+    resolve_snapshot_repository_locator,
+    resolve_snapshot_repository_reader,
+)
+from apps.storage.repositories.models import Repository
+
+
+class SnapshotRepositoryLocatorTests(TestCase):
+    def setUp(self) -> None:
+        self.organization = Organization.objects.create(
+            key="snapshot-locator-org",
+            name="Snapshot Locator Org",
+        )
+        self.writer = Node.objects.create(
+            organization=self.organization,
+            name="snapshot-writer",
+            role=Node.Role.AGENT,
+            status=Node.Status.ACTIVE,
+            availability=Node.Availability.ONLINE,
+        )
+        self.reader = Node.objects.create(
+            organization=self.organization,
+            name="snapshot-reader",
+            role=Node.Role.GATEWAY,
+            status=Node.Status.ACTIVE,
+            availability=Node.Availability.ONLINE,
+        )
+        self.repository = Repository.objects.create(
+            organization_id=self.organization.id,
+            name="snapshot-direct-nas",
+            repo_type=Repository.Type.NAS,
+            status=Repository.Status.CREATED,
+            health=Repository.Health.ONLINE,
+            nas_protocol=Repository.NasProtocol.NFS,
+            config={
+                "server_address": "10.0.0.20",
+                "share_path": "/volume1/backup",
+                "kopia_password": "repo-pass",
+            },
+        )
+        self.snapshot = BackupSourceSnapshot.objects.create(
+            organization_id=self.organization.id,
+            snapshot_uid="snapshot-locator-1",
+            idempotency_key="snapshot-locator-1",
+            source_type="agent",
+            source_ref_id=self.writer.id,
+            backup_config_id=101,
+            repository_id=self.repository.id,
+            task_id=201,
+            status=BackupSourceSnapshot.Status.AVAILABLE,
+        )
+        self.directory = BackupSourceSnapshotDirectory.objects.create(
+            source_snapshot=self.snapshot,
+            organization_id=self.organization.id,
+            backup_config_id=101,
+            backup_config_dir_id=102,
+            source_path="/data",
+            repository_id=self.repository.id,
+            kopia_snapshot_id="kopia-locator-1",
+            status=BackupSourceSnapshotDirectory.Status.AVAILABLE,
+        )
+
+    def test_persisted_direct_nas_locator_uses_writer_shard(self) -> None:
+        locator = ensure_snapshot_repository_locator(
+            directory=self.directory,
+            repository=self.repository,
+            writer_node_id=self.writer.id,
+        )
+
+        self.directory.refresh_from_db()
+        self.assertEqual(locator.repository_subdir, f"hp-repos/agent-{self.writer.id}")
+        self.assertEqual(
+            self.directory.repository_locator["repository_subdir"],
+            f"hp-repos/agent-{self.writer.id}",
+        )
+
+    def test_pending_locator_tracks_retry_node_then_becomes_immutable(self) -> None:
+        self.directory.kopia_snapshot_id = None
+        self.directory.save(update_fields=["kopia_snapshot_id", "updated_at"])
+        ensure_snapshot_repository_locator(
+            directory=self.directory,
+            repository=self.repository,
+            writer_node_id=self.writer.id,
+        )
+        ensure_snapshot_repository_locator(
+            directory=self.directory,
+            repository=self.repository,
+            writer_node_id=self.reader.id,
+        )
+
+        self.directory.refresh_from_db()
+        self.assertEqual(
+            self.directory.repository_locator["repository_subdir"],
+            f"hp-repos/agent-{self.reader.id}",
+        )
+
+        self.directory.kopia_snapshot_id = "kopia-final"
+        self.directory.save(update_fields=["kopia_snapshot_id", "updated_at"])
+        ensure_snapshot_repository_locator(
+            directory=self.directory,
+            repository=self.repository,
+            writer_node_id=self.writer.id,
+        )
+
+        self.directory.refresh_from_db()
+        self.assertEqual(
+            self.directory.repository_locator["repository_subdir"],
+            f"hp-repos/agent-{self.reader.id}",
+        )
+
+    def test_stale_retry_cannot_replace_locator_after_snapshot_exists(self) -> None:
+        stale_directory = BackupSourceSnapshotDirectory.objects.get(
+            pk=self.directory.pk,
+        )
+        ensure_snapshot_repository_locator(
+            directory=self.directory,
+            repository=self.repository,
+            writer_node_id=self.writer.id,
+        )
+        self.directory.kopia_snapshot_id = "kopia-created-by-writer"
+        self.directory.save(update_fields=["kopia_snapshot_id", "updated_at"])
+
+        locator = ensure_snapshot_repository_locator(
+            directory=stale_directory,
+            repository=self.repository,
+            writer_node_id=self.reader.id,
+        )
+
+        stale_directory.refresh_from_db()
+        self.assertEqual(locator.writer_node_id, self.writer.id)
+        self.assertEqual(
+            stale_directory.repository_locator["repository_subdir"],
+            f"hp-repos/agent-{self.writer.id}",
+        )
+
+    def test_legacy_locator_prefers_original_backup_node_task(self) -> None:
+        original_writer = Node.objects.create(
+            organization=self.organization,
+            name="original-snapshot-writer",
+            role=Node.Role.AGENT,
+            status=Node.Status.ACTIVE,
+            availability=Node.Availability.OFFLINE,
+        )
+        node_task = NodeTask.objects.create(
+            organization=self.organization,
+            node=original_writer,
+            kind="backup.run",
+            correlation_type="protection.backup",
+            correlation_id="snapshot-locator-backup",
+            status=NodeTask.Status.SUCCESS,
+            payload={},
+            result={},
+            watchdog_deadline_at=timezone.now(),
+        )
+        self.directory.node_task_id = node_task.id
+        self.directory.save(update_fields=["node_task_id", "updated_at"])
+
+        locator = resolve_snapshot_repository_locator(
+            directory=self.directory,
+            repository=self.repository,
+        )
+
+        self.directory.refresh_from_db()
+        self.assertEqual(locator.writer_node_id, original_writer.id)
+        self.assertEqual(
+            locator.repository_subdir,
+            f"hp-repos/agent-{original_writer.id}",
+        )
+        self.assertEqual(self.directory.repository_locator, locator.payload())
+
+    def test_invalid_stored_locator_is_rejected_instead_of_derived(self) -> None:
+        self.directory.repository_locator = {
+            "version": 1,
+            "repository_id": self.repository.id + 1,
+            "repository_type": Repository.Type.NAS,
+            "repository_subdir": f"hp-repos/agent-{self.writer.id}",
+            "writer_node_id": self.writer.id,
+            "access_node_id": None,
+        }
+        self.directory.save(update_fields=["repository_locator", "updated_at"])
+
+        with self.assertRaisesMessage(
+            ValidationError,
+            "Snapshot repository locator does not match its repository.",
+        ):
+            resolve_snapshot_repository_locator(
+                directory=self.directory,
+                repository=self.repository,
+            )
+
+    def test_reader_runs_on_gateway_without_changing_snapshot_shard(self) -> None:
+        ensure_snapshot_repository_locator(
+            directory=self.directory,
+            repository=self.repository,
+            writer_node_id=self.writer.id,
+        )
+
+        access = resolve_snapshot_repository_reader(
+            directory=self.directory,
+            repository=self.repository,
+            fallback_node=self.reader,
+            source_type="agent",
+            source_ref_id=self.reader.id,
+        )
+
+        self.assertEqual(access.node.id, self.reader.id)
+        self.assertEqual(
+            access.repository_payload["subdir"],
+            f"hp-repos/agent-{self.writer.id}",
+        )
+
+    def test_proxy_filesystem_snapshot_keeps_original_access_node(self) -> None:
+        original_proxy = Node.objects.create(
+            organization=self.organization,
+            name="original-repository-proxy",
+            role=Node.Role.PROXY,
+            status=Node.Status.ACTIVE,
+            availability=Node.Availability.ONLINE,
+        )
+        replacement_proxy = Node.objects.create(
+            organization=self.organization,
+            name="replacement-repository-proxy",
+            role=Node.Role.PROXY,
+            status=Node.Status.ACTIVE,
+            availability=Node.Availability.ONLINE,
+        )
+        self.repository.repo_type = Repository.Type.PROXY_FS
+        self.repository.nas_protocol = None
+        self.repository.bind_node_type = Repository.BindNodeType.PROXY
+        self.repository.bind_node_id = original_proxy.id
+        self.repository.config = {
+            "proxy_node_dir": "/srv/hfl-repository",
+            "kopia_password": "repo-pass",
+        }
+        self.repository.save()
+        ensure_snapshot_repository_locator(
+            directory=self.directory,
+            repository=self.repository,
+            writer_node_id=self.writer.id,
+        )
+        self.repository.bind_node_id = replacement_proxy.id
+        self.repository.save(update_fields=["bind_node_id", "updated_at"])
+
+        access = resolve_snapshot_repository_reader(
+            directory=self.directory,
+            repository=self.repository,
+            fallback_node=self.reader,
+        )
+
+        self.assertEqual(access.node.id, original_proxy.id)
+
+    def test_legacy_proxy_filesystem_locator_uses_repository_server_task(self) -> None:
+        original_proxy = Node.objects.create(
+            organization=self.organization,
+            name="legacy-original-repository-proxy",
+            role=Node.Role.PROXY,
+            status=Node.Status.ACTIVE,
+            availability=Node.Availability.ONLINE,
+        )
+        replacement_proxy = Node.objects.create(
+            organization=self.organization,
+            name="legacy-replacement-repository-proxy",
+            role=Node.Role.PROXY,
+            status=Node.Status.ACTIVE,
+            availability=Node.Availability.ONLINE,
+        )
+        self.repository.repo_type = Repository.Type.PROXY_FS
+        self.repository.nas_protocol = None
+        self.repository.bind_node_type = Repository.BindNodeType.PROXY
+        self.repository.bind_node_id = replacement_proxy.id
+        self.repository.config = {
+            "proxy_node_dir": "/srv/hfl-repository",
+            "kopia_password": "repo-pass",
+        }
+        self.repository.save()
+        NodeTask.objects.create(
+            organization=self.organization,
+            node=original_proxy,
+            kind="repository.server.start",
+            correlation_type="protection.backup",
+            correlation_id=str(self.snapshot.task_uuid),
+            status=NodeTask.Status.SUCCESS,
+            payload={"repository": {"id": self.repository.id}},
+            result={},
+            watchdog_deadline_at=timezone.now(),
+        )
+        NodeTask.objects.create(
+            organization=self.organization,
+            node=replacement_proxy,
+            kind="repository.server.start",
+            correlation_type="protection.backup",
+            correlation_id=str(self.snapshot.task_uuid),
+            status=NodeTask.Status.SUCCESS,
+            payload={"repository": {"id": self.repository.id + 1}},
+            result={},
+            watchdog_deadline_at=timezone.now(),
+        )
+
+        access = resolve_snapshot_repository_reader(
+            directory=self.directory,
+            repository=self.repository,
+            fallback_node=self.reader,
+        )
+
+        self.directory.refresh_from_db()
+        self.assertEqual(access.node.id, original_proxy.id)
+        self.assertEqual(
+            self.directory.repository_locator["access_node_id"],
+            original_proxy.id,
+        )
+
+    def test_proxy_filesystem_locator_requires_access_node(self) -> None:
+        proxy = Node.objects.create(
+            organization=self.organization,
+            name="missing-locator-access-proxy",
+            role=Node.Role.PROXY,
+            status=Node.Status.ACTIVE,
+            availability=Node.Availability.ONLINE,
+        )
+        self.repository.repo_type = Repository.Type.PROXY_FS
+        self.repository.nas_protocol = None
+        self.repository.bind_node_type = Repository.BindNodeType.PROXY
+        self.repository.bind_node_id = proxy.id
+        self.repository.config = {
+            "proxy_node_dir": "/srv/hfl-repository",
+            "kopia_password": "repo-pass",
+        }
+        self.repository.save()
+        self.directory.repository_locator = {
+            "version": 1,
+            "repository_id": self.repository.id,
+            "repository_type": Repository.Type.PROXY_FS,
+            "repository_subdir": "",
+            "writer_node_id": self.writer.id,
+            "access_node_id": None,
+        }
+        self.directory.save(update_fields=["repository_locator", "updated_at"])
+
+        with self.assertRaisesMessage(
+            ValidationError,
+            "Proxy filesystem snapshot locator has no access node.",
+        ):
+            resolve_snapshot_repository_locator(
+                directory=self.directory,
+                repository=self.repository,
+            )

--- a/src/backend/apps/restore/services/interface.py
+++ b/src/backend/apps/restore/services/interface.py
@@ -26,6 +26,9 @@ from apps.protection.services.progress.orchestrated_progress import (
     RESTORE_FINALIZE_START,
     RESTORE_PREPARE_END,
 )
+from apps.protection.services.snapshot_repository_locator import (
+    resolve_snapshot_repository_reader,
+)
 from apps.protection.models import (
     BackupConfig,
     BackupConfigDirectory,
@@ -44,7 +47,6 @@ from apps.source.models import SourceResource
 from apps.storage.repositories.models import Repository
 from apps.storage.services.internal.repository_access import (
     explicit_repository_server_host,
-    resolve_repository_reader,
 )
 from apps.task.models import Task, TaskEvent, TaskResource, TaskStep
 from apps.task.services.interface import append_task_step_event, cancel_task, complete_task, create_task, start_task
@@ -1531,7 +1533,12 @@ def _dispatch_restore_items(*, organization_id: int, record: RestoreRecord, task
                 if snapshot_directory is not None
                 else BackupSourceSnapshotDirectory.PathType.UNKNOWN
             )
-            repository_access = resolve_repository_reader(
+            if snapshot_directory is None:
+                raise ValidationError(
+                    {"source_snapshot_directory_id": "Snapshot directory not found."}
+                )
+            repository_access = resolve_snapshot_repository_reader(
+                directory=snapshot_directory,
                 repository=repository,
                 fallback_node=node,
                 source_type=record.target_type,

--- a/src/backend/apps/restore/services/snapshot_browser.py
+++ b/src/backend/apps/restore/services/snapshot_browser.py
@@ -21,7 +21,9 @@ from apps.protection.services.snapshot_browser import (
     _parent_path,
     _repository_for_directory,
 )
-from apps.storage.services.internal.repository_access import resolve_repository_reader
+from apps.protection.services.snapshot_repository_locator import (
+    resolve_snapshot_repository_reader,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -71,7 +73,8 @@ def browse_snapshot_directory_from_target(
     row = _get_directory(organization_id=organization_id, directory_id=directory_id)
     node = _target_node(organization_id=organization_id, target_node_id=target_node_id)
     repository = _repository_for_directory(row)
-    repository_access = resolve_repository_reader(
+    repository_access = resolve_snapshot_repository_reader(
+        directory=row,
         repository=repository,
         fallback_node=node,
         source_type="agent",

--- a/src/backend/apps/restore/tests/test_restore_api.py
+++ b/src/backend/apps/restore/tests/test_restore_api.py
@@ -171,6 +171,71 @@ class RestoreApiTests(TestCase):
         binding.save(update_fields=["state", "identity_status", "updated_at"])
         return binding
 
+    def _bound_repository_lens_restore(self, *, repository_type: str):
+        private_gateway = Node.objects.create(
+            organization=self.org,
+            name=f"private-{repository_type}-lens-gateway",
+            role=Node.Role.GATEWAY,
+            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
+        )
+        repository_proxy = Node.objects.create(
+            organization=self.org,
+            name=f"chat-{repository_type}-repository-proxy",
+            role=Node.Role.PROXY,
+            status=Node.Status.ACTIVE,
+            availability=Node.Availability.ONLINE,
+            ip_address="10.0.0.65",
+        )
+        gateway_link = LensGatewayLink.objects.create(
+            organization=self.org,
+            gateway=private_gateway,
+            owner_user=self.user,
+            scope=LensGatewayLink.GatewayScope.USER,
+        )
+        workspace_binding = self._workspace_binding(gateway_link)
+        self.repository.repo_type = repository_type
+        self.repository.s3_bucket = ""
+        self.repository.nas_protocol = (
+            Repository.NasProtocol.NFS
+            if repository_type == Repository.Type.NAS
+            else None
+        )
+        self.repository.bind_node_type = Repository.BindNodeType.PROXY
+        self.repository.bind_node_id = repository_proxy.id
+        self.repository.config = (
+            {
+                "server_address": "10.0.0.20",
+                "share_path": "/volume1/backup",
+                "kopia_password": "repo-pass",
+                "proxy_repository_server_host": "10.0.0.65",
+            }
+            if repository_type == Repository.Type.NAS
+            else {
+                "proxy_node_dir": "/srv/hfl-repository",
+                "kopia_password": "repo-pass",
+                "proxy_repository_server_host": "10.0.0.65",
+            }
+        )
+        self.repository.save()
+        payload = self._manual_restore_payload()
+        payload.update(
+            {
+                "target_ref_id": private_gateway.id,
+                "target_path": workspace_binding.resolved_path(),
+                "idempotency_key": f"lens-workspace:{repository_type}:1",
+            }
+        )
+        record = restore_service.create_lens_workspace_restore_record(
+            organization_id=self.org.id,
+            workspace_binding_id=workspace_binding.id,
+            data=payload,
+        )
+        server_task = NodeTask.objects.get(
+            kind="repository.server.start",
+            correlation_id=str(record.task_uuid),
+        )
+        return record, server_task, repository_proxy
+
     @patch("apps.lens_bridge.services.gateway_execution.gateway_readiness.require_copilot_gateway")
     def test_lens_workspace_restore_uses_platform_execution_identity(self, _ready):
         platform_org = platform_lens.get_or_create_platform_org()
@@ -339,6 +404,121 @@ class RestoreApiTests(TestCase):
         )
         self.assertEqual(node_task.organization_id, self.org.id)
         self.assertEqual(node_task.requesting_organization_id, self.org.id)
+
+    @patch(
+        "apps.lens_bridge.services.gateway_execution.gateway_readiness.require_copilot_gateway"
+    )
+    def test_lens_workspace_restore_from_direct_nas_preserves_backup_shard(
+        self, _ready
+    ):
+        private_gateway = Node.objects.create(
+            organization=self.org,
+            name="private-nas-lens-gateway",
+            role=Node.Role.GATEWAY,
+            status=Node.Status.ACTIVE,
+            availability=Node.Availability.ONLINE,
+        )
+        gateway_link = LensGatewayLink.objects.create(
+            organization=self.org,
+            gateway=private_gateway,
+            owner_user=self.user,
+            scope=LensGatewayLink.GatewayScope.USER,
+        )
+        workspace_binding = self._workspace_binding(gateway_link)
+        backup_node_task = NodeTask.objects.create(
+            organization=self.org,
+            node=self.agent,
+            kind="backup.run",
+            correlation_type="protection.backup",
+            correlation_id="chat-direct-nas-backup",
+            status=NodeTask.Status.SUCCESS,
+            payload={},
+            result={},
+            watchdog_deadline_at=timezone.now(),
+        )
+        self.snapshot_dir.node_task_id = backup_node_task.id
+        self.snapshot_dir.save(update_fields=["node_task_id", "updated_at"])
+        self.repository.repo_type = Repository.Type.NAS
+        self.repository.nas_protocol = Repository.NasProtocol.NFS
+        self.repository.s3_bucket = ""
+        self.repository.config = {
+            "server_address": "10.0.0.20",
+            "share_path": "/volume1/backup",
+            "kopia_password": "repo-pass",
+        }
+        self.repository.save(
+            update_fields=["repo_type", "nas_protocol", "s3_bucket", "config"]
+        )
+        payload = self._manual_restore_payload()
+        payload.update(
+            {
+                "target_ref_id": private_gateway.id,
+                "target_path": workspace_binding.resolved_path(),
+                "idempotency_key": "lens-workspace:direct-nas:1",
+            }
+        )
+
+        record = restore_service.create_lens_workspace_restore_record(
+            organization_id=self.org.id,
+            workspace_binding_id=workspace_binding.id,
+            data=payload,
+        )
+
+        node_task = NodeTask.objects.get(
+            kind="restore.run",
+            correlation_id=str(record.task_uuid),
+        )
+        self.assertEqual(node_task.node_id, private_gateway.id)
+        self.assertEqual(node_task.payload["repository"]["type"], Repository.Type.NAS)
+        self.assertEqual(
+            node_task.payload["repository"]["subdir"],
+            f"hp-repos/agent-{self.agent.id}",
+        )
+        self.assertNotEqual(
+            node_task.payload["repository"]["subdir"],
+            f"hp-repos/agent-{private_gateway.id}",
+        )
+
+    @patch(
+        "apps.lens_bridge.services.gateway_execution.gateway_readiness.require_copilot_gateway"
+    )
+    def test_lens_workspace_restore_from_proxy_bound_nas_starts_server(self, _ready):
+        record, server_task, repository_proxy = self._bound_repository_lens_restore(
+            repository_type=Repository.Type.NAS
+        )
+
+        self.assertEqual(server_task.node_id, repository_proxy.id)
+        self.assertEqual(server_task.payload["repository"]["type"], Repository.Type.NAS)
+        self.assertEqual(
+            server_task.payload["repository"]["subdir"],
+            f"hp-repos/storage-{self.repository.id}",
+        )
+        self.assertFalse(
+            NodeTask.objects.filter(
+                kind="restore.run",
+                correlation_id=str(record.task_uuid),
+            ).exists()
+        )
+
+    @patch(
+        "apps.lens_bridge.services.gateway_execution.gateway_readiness.require_copilot_gateway"
+    )
+    def test_lens_workspace_restore_from_proxy_fs_starts_server(self, _ready):
+        record, server_task, repository_proxy = self._bound_repository_lens_restore(
+            repository_type=Repository.Type.PROXY_FS
+        )
+
+        self.assertEqual(server_task.node_id, repository_proxy.id)
+        self.assertEqual(
+            server_task.payload["repository"]["type"],
+            Repository.Type.PROXY_FS,
+        )
+        self.assertFalse(
+            NodeTask.objects.filter(
+                kind="restore.run",
+                correlation_id=str(record.task_uuid),
+            ).exists()
+        )
 
     def test_nas_restore_dispatches_mount_payload_and_execution_path(self):
         proxy = Node.objects.create(
@@ -2023,7 +2203,7 @@ class RestoreApiTests(TestCase):
                         "type": "file",
                         "is_dir": False,
                         "size_bytes": 12,
-                    }
+                    },
                 ]
             },
             task=SimpleNamespace(last_error=""),
@@ -2048,7 +2228,63 @@ class RestoreApiTests(TestCase):
         self.assertEqual(payload["path"], "docs")
 
     @patch("apps.restore.services.snapshot_browser.run_agent_task_sync")
-    def test_browse_restore_snapshot_directory_rejects_offline_target(self, mock_run_agent_task_sync):
+    def test_browse_direct_nas_snapshot_uses_target_node_and_backup_shard(
+        self, mock_run_agent_task_sync
+    ):
+        backup_node_task = NodeTask.objects.create(
+            organization=self.org,
+            node=self.agent,
+            kind="backup.run",
+            correlation_type="protection.backup",
+            correlation_id="browse-direct-nas-backup",
+            status=NodeTask.Status.SUCCESS,
+            payload={},
+            result={},
+            watchdog_deadline_at=timezone.now(),
+        )
+        self.snapshot_dir.node_task_id = backup_node_task.id
+        self.snapshot_dir.save(update_fields=["node_task_id", "updated_at"])
+        self.repository.repo_type = Repository.Type.NAS
+        self.repository.nas_protocol = Repository.NasProtocol.NFS
+        self.repository.s3_bucket = ""
+        self.repository.config = {
+            "server_address": "10.0.0.20",
+            "share_path": "/volume1/backup",
+            "kopia_password": "repo-pass",
+        }
+        self.repository.save(
+            update_fields=["repo_type", "nas_protocol", "s3_bucket", "config"]
+        )
+        mock_run_agent_task_sync.return_value = SimpleNamespace(
+            ok=True,
+            timed_out=False,
+            result={"entries": []},
+            task=SimpleNamespace(last_error=""),
+        )
+
+        response = self.client.get(
+            f"/api/v1/restore/snapshot-directories/{self.snapshot_dir.id}/browse/"
+            f"?target_node_id={self.target.id}",
+            **self._headers(),
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+        self.assertEqual(
+            mock_run_agent_task_sync.call_args.kwargs["node_id"],
+            self.target.id,
+        )
+        repository_payload = mock_run_agent_task_sync.call_args.kwargs["payload"][
+            "repository"
+        ]
+        self.assertEqual(
+            repository_payload["subdir"],
+            f"hp-repos/agent-{self.agent.id}",
+        )
+
+    @patch("apps.restore.services.snapshot_browser.run_agent_task_sync")
+    def test_browse_restore_snapshot_directory_rejects_offline_target(
+        self, mock_run_agent_task_sync
+    ):
         self.target.availability = Node.Availability.OFFLINE
         self.target.save(update_fields=["availability"])
 

--- a/src/backend/apps/storage/repositories/serializers.py
+++ b/src/backend/apps/storage/repositories/serializers.py
@@ -278,16 +278,37 @@ class RepositoryWriteSerializer(serializers.ModelSerializer):
                 locked_errors["s3_bucket_mode"] = "S3 bucket mode cannot be modified."
             incoming_config = attrs.get("config") or {}
             if isinstance(incoming_config, dict):
-                for field in (
-                    "endpoint",
-                    "endpoint_type",
-                    "external_endpoint",
-                    "internal_endpoint",
+                if instance.repo_type == Repository.Type.S3:
+                    for field in (
+                        "endpoint",
+                        "endpoint_type",
+                        "external_endpoint",
+                        "internal_endpoint",
+                        "region",
+                    ):
+                        if field in incoming_config:
+                            locked_errors[f"config.{field}"] = (
+                                "S3 repository location cannot be modified."
+                            )
+                    if "prefix" in incoming_config:
+                        locked_errors["config.prefix"] = (
+                            "S3 object prefix cannot be modified."
+                        )
+                elif instance.repo_type == Repository.Type.NAS:
+                    for field in ("server_address", "share_path"):
+                        if field in incoming_config:
+                            locked_errors[f"config.{field}"] = (
+                                "NAS repository location cannot be modified."
+                            )
+                elif (
+                    instance.repo_type == Repository.Type.PROXY_FS
+                    and "proxy_node_dir" in incoming_config
                 ):
-                    if field in incoming_config:
-                        locked_errors[f"config.{field}"] = "S3 endpoint cannot be modified."
-                if "prefix" in incoming_config:
-                    locked_errors["config.prefix"] = "S3 object prefix cannot be modified."
+                    locked_errors["config.proxy_node_dir"] = (
+                        "Proxy filesystem repository path cannot be modified."
+                    )
+            if instance.repo_type == Repository.Type.NAS and "nas_protocol" in attrs:
+                locked_errors["nas_protocol"] = "NAS protocol cannot be modified."
             if locked_errors:
                 raise serializers.ValidationError(locked_errors)
 

--- a/src/backend/apps/storage/services/internal/repository_access.py
+++ b/src/backend/apps/storage/services/internal/repository_access.py
@@ -43,6 +43,8 @@ def resolve_repository_reader(
     source_ref_id: int | None = None,
     repository_endpoint_type: object = "external",
     repository_endpoint: object = None,
+    repository_subdir: str = "",
+    repository_access_node_id: int | None = None,
 ) -> RepositoryAccess:
     """Resolve the node that is allowed to read/write the repository.
 
@@ -52,7 +54,11 @@ def resolve_repository_reader(
     """
 
     if repository.repo_type == Repository.Type.NAS and repository.bind_node_type == Repository.BindNodeType.PROXY:
-        node = _bound_proxy(repository=repository, message_prefix="NAS repository")
+        node = _bound_proxy(
+            repository=repository,
+            message_prefix="NAS repository",
+            node_id=repository_access_node_id,
+        )
         return _access(
             repository=repository,
             node=node,
@@ -61,10 +67,16 @@ def resolve_repository_reader(
             mode="bound_proxy",
             repository_endpoint_type=repository_endpoint_type,
             repository_endpoint=repository_endpoint,
+            repository_subdir=repository_subdir,
+            repository_access_node_id=repository_access_node_id,
         )
 
     if repository.repo_type == Repository.Type.PROXY_FS:
-        node = _bound_proxy(repository=repository, message_prefix="Proxy filesystem repository")
+        node = _bound_proxy(
+            repository=repository,
+            message_prefix="Proxy filesystem repository",
+            node_id=repository_access_node_id,
+        )
         return _access(
             repository=repository,
             node=node,
@@ -73,6 +85,8 @@ def resolve_repository_reader(
             mode="bound_proxy",
             repository_endpoint_type=repository_endpoint_type,
             repository_endpoint=repository_endpoint,
+            repository_subdir=repository_subdir,
+            repository_access_node_id=repository_access_node_id,
         )
 
     if fallback_node is None:
@@ -85,6 +99,7 @@ def resolve_repository_reader(
         mode="fallback_node",
         repository_endpoint_type=repository_endpoint_type,
         repository_endpoint=repository_endpoint,
+        repository_subdir=repository_subdir,
     )
 
 
@@ -96,6 +111,7 @@ def repository_payload_for_node(
     source_ref_id: int | None = None,
     repository_endpoint_type: object = "external",
     repository_endpoint: object = None,
+    authorized_bind_node_id: int | None = None,
 ) -> dict[str, Any]:
     """Build a repository payload for a specific execution node.
 
@@ -113,6 +129,7 @@ def repository_payload_for_node(
         execution_target=target,
         repository_endpoint_type=repository_endpoint_type,
         repository_endpoint=repository_endpoint,
+        authorized_bind_node_id=authorized_bind_node_id,
     )
 
 
@@ -196,26 +213,45 @@ def _access(
     mode: str,
     repository_endpoint_type: object = "external",
     repository_endpoint: object = None,
+    repository_subdir: str = "",
+    repository_access_node_id: int | None = None,
 ) -> RepositoryAccess:
+    repository_payload = repository_payload_for_node(
+        repository=repository,
+        node=node,
+        source_type=source_type,
+        source_ref_id=source_ref_id,
+        repository_endpoint_type=repository_endpoint_type,
+        repository_endpoint=repository_endpoint,
+        authorized_bind_node_id=repository_access_node_id,
+    )
+    normalized_subdir = str(repository_subdir or "").strip()
+    if normalized_subdir:
+        if repository.repo_type != Repository.Type.NAS:
+            raise ValidationError(
+                {
+                    "repository_id": "Only NAS repositories support snapshot subdirectories."
+                }
+            )
+        repository_payload["subdir"] = normalized_subdir
     return RepositoryAccess(
         node=node,
-        repository_payload=repository_payload_for_node(
-            repository=repository,
-            node=node,
-            source_type=source_type,
-            source_ref_id=source_ref_id,
-            repository_endpoint_type=repository_endpoint_type,
-            repository_endpoint=repository_endpoint,
-        ),
+        repository_payload=repository_payload,
         mode=mode,
     )
 
 
-def _bound_proxy(*, repository: Repository, message_prefix: str) -> Node:
-    if repository.bind_node_type != Repository.BindNodeType.PROXY or not repository.bind_node_id:
+def _bound_proxy(
+    *,
+    repository: Repository,
+    message_prefix: str,
+    node_id: int | None = None,
+) -> Node:
+    resolved_node_id = node_id or repository.bind_node_id
+    if repository.bind_node_type != Repository.BindNodeType.PROXY or not resolved_node_id:
         raise ValidationError({"repository_id": f"{message_prefix} is not bound to a proxy node."})
     node = Node.objects.filter(
-        id=repository.bind_node_id,
+        id=resolved_node_id,
         organization_id=repository.organization_id,
         role=NodeRole.PROXY,
         is_deleted=False,

--- a/src/backend/apps/storage/services/internal/repository_secrets.py
+++ b/src/backend/apps/storage/services/internal/repository_secrets.py
@@ -150,6 +150,7 @@ def build_repository_runtime_payload(
     execution_target: Any | None = None,
     repository_endpoint_type: object = "external",
     repository_endpoint: object = None,
+    authorized_bind_node_id: int | None = None,
 ) -> dict[str, Any]:
     from apps.storage.services.internal.nas_repository import (
         nas_agent_repository_subdir,
@@ -189,7 +190,8 @@ def build_repository_runtime_payload(
             raise ValidationError(
                 {"repository_id": "Proxy filesystem repository must be accessed through its bound proxy node."}
             )
-        if int(repository.bind_node_id or 0) != execution_target.node.id:
+        expected_node_id = authorized_bind_node_id or repository.bind_node_id
+        if int(expected_node_id or 0) != execution_target.node.id:
             raise ValidationError({"repository_id": "Proxy filesystem repository is bound to a different proxy node."})
         proxy_dir = str(config.get("proxy_node_dir") or "").strip()
         if not proxy_dir:
@@ -208,7 +210,8 @@ def build_repository_runtime_payload(
                 raise ValidationError(
                     {"repository_id": "NAS repository must be accessed through its bound proxy node."}
                 )
-            if int(repository.bind_node_id or 0) != execution_target.node.id:
+            expected_node_id = authorized_bind_node_id or repository.bind_node_id
+            if int(expected_node_id or 0) != execution_target.node.id:
                 raise ValidationError({"repository_id": "NAS repository is bound to a different proxy node."})
             subdir = nas_proxy_repository_subdir(repository)
             node_id = execution_target.node.id

--- a/src/backend/apps/storage/tests/test_repository_api.py
+++ b/src/backend/apps/storage/tests/test_repository_api.py
@@ -548,6 +548,33 @@ class StorageRepositoryApiTests(TestCase):
             response.data["data"]["errors"],
         )
 
+    def test_s3_repository_cannot_change_region(self):
+        repository = Repository.objects.create(
+            organization_id=self.org.id,
+            name="immutable-s3-location",
+            repo_type=Repository.Type.S3,
+            status=Repository.Status.CREATED,
+            health=Repository.Health.ONLINE,
+            s3_platform=Repository.S3Platform.AWS,
+            s3_bucket="immutable-bucket",
+            config={
+                "region": "us-east-1",
+                "endpoint": "s3.amazonaws.com",
+                "prefix": "hfl/repository",
+            },
+        )
+
+        response = self.client.patch(
+            f"/api/v1/storage/repositories/{repository.id}/",
+            {"config": {"region": "us-east-1"}},
+            format="json",
+            **self._headers(),
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        repository.refresh_from_db()
+        self.assertEqual(repository.config["region"], "us-east-1")
+
     def test_associated_sources_lists_direct_nas_agent_health(self):
         agent = Node.objects.create(
             organization=self.org,

--- a/src/backend/apps/storage/tests/test_repository_proxy_bindings.py
+++ b/src/backend/apps/storage/tests/test_repository_proxy_bindings.py
@@ -74,6 +74,29 @@ class StorageRepositoryProxyBindingTests(TestCase):
         repo.refresh_from_db()
         self.assertEqual(repo.bind_node_id, self.proxy_a.id)
 
+    def test_proxy_fs_cannot_change_physical_directory(self):
+        repo = Repository.objects.create(
+            organization_id=self.org.id,
+            name="disk-immutable-path",
+            repo_type=Repository.Type.PROXY_FS,
+            status=Repository.Status.CREATED,
+            health=Repository.Health.ONLINE,
+            bind_node_type=Repository.BindNodeType.PROXY,
+            bind_node_id=self.proxy_a.id,
+            config={"proxy_node_dir": "/data/repo"},
+        )
+
+        response = self.client.patch(
+            f"/api/v1/storage/repositories/{repo.id}/",
+            {"config": {"proxy_node_dir": "/data/other-repo"}},
+            format="json",
+            **self._headers(),
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        repo.refresh_from_db()
+        self.assertEqual(repo.config["proxy_node_dir"], "/data/repo")
+
     @mock.patch("apps.storage.services.interface.enqueue_repository_usage_refresh")
     def test_proxy_fs_can_replace_proxy(self, enqueue_usage):
         repo = Repository.objects.create(
@@ -171,6 +194,36 @@ class StorageRepositoryProxyBindingTests(TestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         repo.refresh_from_db()
         self.assertEqual(repo.bind_node_id, self.proxy_a.id)
+
+    def test_nas_cannot_change_physical_location_or_protocol(self):
+        repo = Repository.objects.create(
+            organization_id=self.org.id,
+            name="target-nas-immutable-location",
+            repo_type=Repository.Type.NAS,
+            nas_protocol=Repository.NasProtocol.NFS,
+            status=Repository.Status.CREATED,
+            health=Repository.Health.ONLINE,
+            config={"server_address": "10.0.0.10", "share_path": "/backup"},
+        )
+
+        response = self.client.patch(
+            f"/api/v1/storage/repositories/{repo.id}/",
+            {
+                "nas_protocol": Repository.NasProtocol.SMB,
+                "config": {
+                    "server_address": "10.0.0.11",
+                    "share_path": "/other-backup",
+                },
+            },
+            format="json",
+            **self._headers(),
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        repo.refresh_from_db()
+        self.assertEqual(repo.nas_protocol, Repository.NasProtocol.NFS)
+        self.assertEqual(repo.config["server_address"], "10.0.0.10")
+        self.assertEqual(repo.config["share_path"], "/backup")
 
     @mock.patch("apps.storage.services.internal.nas_repository.run_agent_task_sync")
     def test_target_nas_initializer_persists_agent_mount_point(self, run_agent_task_sync):


### PR DESCRIPTION
## Summary
- persist each physical snapshot's credential-free repository location
- route Insight Chat, browsing, download, recovery, deletion, and configuration reset through the original repository context
- isolate NAS Kopia configurations and preserve compatibility with historical ProxyFS/NAS snapshots

## Validation
- 285 Django tests passed
- go test ./... passed
- Ruff, gofmt, compileall, migration checks, and git diff --check passed

Fixes #451