### PR TITLE
fix(frontend): expose monitor node availability

### DIFF
--- a/src/frontend/src/lib/monitorApi.ts
+++ b/src/frontend/src/lib/monitorApi.ts
@@ -1,6 +1,6 @@
 import { api } from './api'
 import { unwrapApiPayload } from './parse'
-import type { NodeRole } from '../types/node'
+import type { Availability, NodeRole } from '../types/node'
 
 export type SystemMetricSample = {
   timestamp: string
@@ -50,6 +50,7 @@ export type MonitorNodeItem = {
   name: string
   role: NodeRole
   status: string
+  availability: Availability
   hostname: string
   platform: string
   resourceType?: string


### PR DESCRIPTION
## Problem and root cause

The shared monitor node contract exposed lifecycle `status` but not connectivity `availability`. After those fields were separated, the Enterprise Host Monitor continued treating lifecycle state as online/offline state and displayed connected nodes as Offline.

## Solution

Expose the typed `availability` field in `MonitorNodeItem` so extension consumers use the authoritative connectivity contract. The companion Enterprise PR updates the API producer, UI consumer, and regression coverage.

Companion PR: oneprolabs/hyperfilelens-ee#20

## Validation

- Enterprise tenant node monitor Django tests: passed (3 tests).
- Enterprise Host Monitor Vitest coverage: passed (5 tests across 2 files).
- Changed Python files Ruff checks: passed.
- Changed frontend files ESLint checks: passed with existing warnings only.
- Host + Enterprise production frontend build and type check: passed.
- Community frontend lane: passed (157 files, 804 tests).
- Community backend lane: passed (1,292 tests in an isolated temporary database).
- Manual testing: passed.
- Post-sync product retesting: skipped because synchronization was conflict-free.
- Mixed Community-empty-socket and Enterprise full-suite execution is not an applicable lane; both modes were validated separately under the project runbook.

## Risks and compatibility

The contract addition is backward-compatible. Coordinated delivery with the Enterprise PR is required so the API producer and monitor consumer remain aligned.

Fixes #453
