### PR TITLE
fix(frontend): prevent cleanup dialog text overlap

### DIFF
--- a/src/frontend/src/components/DangerConfirmDialog.vue
+++ b/src/frontend/src/components/DangerConfirmDialog.vue
@@ -20,6 +20,7 @@ export interface DangerConfirmItem {
   description?: string
   status?: { label: string; tone?: DangerConfirmStatusTone }
   hint?: string
+  warning?: string
 }
 
 const props = withDefaults(
@@ -60,7 +61,7 @@ const props = withDefaults(
     confirmKeyword: 'DELETE',
     irreversibleTone: 'danger',
     loading: false,
-    width: '480px',
+    width: undefined,
   },
 )
 
@@ -89,6 +90,13 @@ const shownItems = computed(() => {
   return props.items
 })
 const hasItems = computed(() => shownItems.value.length > 0)
+const usesItemLayout = computed(() => props.items !== undefined)
+const dialogWidth = computed(() => (
+  props.width
+  ?? (usesItemLayout.value
+    ? 'min(600px, calc(100vw - 32px))'
+    : 'min(480px, calc(100vw - 32px))')
+))
 const needsKeyword = computed(() => props.confirmMode === 'keyword')
 const keywordMatched = computed(() => (
   !needsKeyword.value
@@ -149,7 +157,7 @@ async function onDialogBeforeClose(done: () => void) {
 <template>
   <ElDialog
     v-model="visible"
-    :width="width"
+    :width="dialogWidth"
     :close-on-click-modal="false"
     :close-on-press-escape="!loading"
     :show-close="false"
@@ -223,22 +231,48 @@ async function onDialogBeforeClose(done: () => void) {
                   v-for="(item, idx) in shownItems"
                   :key="item.key ?? idx"
                 >
-                  <td>
+                  <td
+                    class="hfl-danger-confirm__item-name-cell"
+                    :class="{ 'hfl-danger-confirm__item-name-cell--full': !item.status }"
+                  >
                     <span class="hfl-danger-confirm__item-name" :title="item.name">{{ item.name }}</span>
                   </td>
-                  <td>
+                  <td class="hfl-danger-confirm__item-status-cell">
                     <span
                       v-if="item.status"
                       class="hfl-danger-confirm__status"
                       :class="statusClass(item.status.tone)"
+                      :title="item.status.label"
                     >{{ item.status.label }}</span>
                   </td>
-                  <td>
-                    <span
-                      class="hfl-danger-confirm__item-desc"
-                      :class="{ 'hfl-empty-mark': !item.description && !item.hint }"
-                      :title="item.description || item.hint || '—'"
-                    >{{ item.description || item.hint || '—' }}</span>
+                  <td
+                    class="hfl-danger-confirm__item-details-cell"
+                    :class="{
+                      'hfl-danger-confirm__item-details-cell--empty':
+                        !item.description && !item.hint && !item.warning,
+                    }"
+                  >
+                    <div class="hfl-danger-confirm__item-details">
+                      <span
+                        v-if="item.description || item.hint"
+                        class="hfl-danger-confirm__item-desc"
+                        :title="item.description || item.hint"
+                      >{{ item.description || item.hint }}</span>
+                      <span
+                        v-if="item.warning"
+                        class="hfl-danger-confirm__item-warning"
+                      >
+                        <AlertTriangle
+                          :size="12"
+                          aria-hidden="true"
+                        />
+                        <span>{{ item.warning }}</span>
+                      </span>
+                      <span
+                        v-if="!item.description && !item.hint && !item.warning"
+                        class="hfl-danger-confirm__item-desc hfl-empty-mark"
+                      >—</span>
+                    </div>
                   </td>
                 </tr>
               </tbody>
@@ -487,6 +521,7 @@ async function onDialogBeforeClose(done: () => void) {
 }
 .hfl-danger-confirm__item-table {
   table-layout: fixed;
+  min-width: 440px;
 }
 .hfl-danger-confirm__item-table th {
   position: sticky;
@@ -498,8 +533,13 @@ async function onDialogBeforeClose(done: () => void) {
   padding-right: 12px;
   padding-left: 12px;
 }
+.hfl-danger-confirm__item-table td {
+  min-width: 0;
+  overflow: hidden;
+  vertical-align: top;
+}
 .hfl-danger-confirm__item-col-name {
-  width: 44%;
+  width: 36%;
 }
 .hfl-danger-confirm__item-col-status {
   width: 110px;
@@ -525,12 +565,42 @@ async function onDialogBeforeClose(done: () => void) {
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+.hfl-danger-confirm__item-details {
+  display: grid;
+  gap: 5px;
+  min-width: 0;
+}
+.hfl-danger-confirm__item-warning {
+  display: grid;
+  grid-template-columns: 12px minmax(0, 1fr);
+  min-width: 0;
+  align-items: flex-start;
+  gap: 4px;
+  color: var(--color-warning-text, var(--color-warning));
+  font-size: 11px;
+  line-height: 1.4;
+  overflow-wrap: anywhere;
+}
+.hfl-danger-confirm__item-warning :deep(svg) {
+  flex: 0 0 12px;
+  margin-top: 2px;
+}
+.hfl-danger-confirm__item-warning > span {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
 .hfl-danger-confirm__status {
+  display: inline-block;
+  box-sizing: border-box;
+  max-width: 100%;
+  overflow: hidden;
   font-size: 11px;
   line-height: 1;
   padding: 3px 8px;
   border-radius: 999px;
   background: rgba(0, 0, 0, 0.05);
+  text-overflow: ellipsis;
+  vertical-align: middle;
   white-space: nowrap;
 }
 .hfl-danger-confirm__status--success { background: var(--color-success-light); color: var(--color-success); }
@@ -538,6 +608,93 @@ async function onDialogBeforeClose(done: () => void) {
 .hfl-danger-confirm__status--danger  { background: var(--color-error-light); color: var(--color-error); }
 .hfl-danger-confirm__status--info    { background: var(--color-info-light); color: var(--color-info); }
 .hfl-danger-confirm__status--neutral { background: #f3f4f6; color: #4b5563; }
+
+@media (max-width: 560px) {
+  .hfl-danger-confirm__item-table-scroll {
+    overflow-x: hidden;
+  }
+
+  .hfl-danger-confirm__item-table {
+    min-width: 0;
+    table-layout: auto;
+  }
+
+  .hfl-danger-confirm__item-table colgroup {
+    display: none;
+  }
+
+  .hfl-danger-confirm__item-table thead {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+
+  .hfl-danger-confirm__item-table tbody {
+    display: block;
+  }
+
+  .hfl-danger-confirm__item-table tr {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(88px, 42%);
+    gap: 8px 12px;
+    padding: 12px;
+    border-bottom: 1px solid var(--color-border);
+    background: var(--el-fill-color-blank, #fff);
+  }
+
+  .hfl-danger-confirm__item-table tr:last-child {
+    border-bottom: 0;
+  }
+
+  .hfl-danger-confirm__item-table td,
+  .hfl-danger-confirm__item-table tr:hover td {
+    display: block;
+    padding: 0;
+    border: 0;
+    background: transparent;
+  }
+
+  .hfl-danger-confirm__item-status-cell {
+    max-width: 100%;
+    justify-self: end;
+  }
+
+  .hfl-danger-confirm__item-name-cell--full {
+    grid-column: 1 / -1;
+  }
+
+  .hfl-danger-confirm__item-name,
+  .hfl-danger-confirm__status {
+    overflow: visible;
+    text-overflow: clip;
+    white-space: normal;
+    overflow-wrap: anywhere;
+  }
+
+  .hfl-danger-confirm__status {
+    line-height: 1.3;
+    text-align: right;
+  }
+
+  .hfl-danger-confirm__item-details-cell {
+    grid-column: 1 / -1;
+  }
+
+  .hfl-danger-confirm__item-warning {
+    font-size: 12px;
+    line-height: 1.5;
+  }
+
+  .hfl-danger-confirm__item-details-cell--empty {
+    display: none !important;
+  }
+}
 
 .hfl-danger-confirm__irreversible {
   margin: 4px 0 0;

--- a/src/frontend/src/components/DangerConfirmDialogLayout.test.ts
+++ b/src/frontend/src/components/DangerConfirmDialogLayout.test.ts
@@ -1,0 +1,143 @@
+// @vitest-environment jsdom
+/* eslint-disable vue/one-component-per-file, vue/require-default-prop */
+
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+import { mount } from '@vue/test-utils'
+import { defineComponent } from 'vue'
+import { describe, expect, it } from 'vitest'
+import DangerConfirmDialog, { type DangerConfirmItem } from './DangerConfirmDialog.vue'
+
+const dialogSource = readFileSync(
+  resolve(process.cwd(), 'src/components/DangerConfirmDialog.vue'),
+  'utf8',
+)
+const nodesPage = readFileSync(
+  resolve(process.cwd(), 'src/pages/node/Nodes.vue'),
+  'utf8',
+)
+const locale = readFileSync(
+  resolve(process.cwd(), 'src/locales/en.ts'),
+  'utf8',
+)
+
+const ElDialogStub = defineComponent({
+  props: {
+    modelValue: Boolean,
+    width: String,
+  },
+  template: `
+    <section data-test="dialog" :data-width="width">
+      <slot name="header" />
+      <slot />
+      <slot name="footer" />
+    </section>
+  `,
+})
+
+const ElButtonStub = defineComponent({
+  props: { disabled: Boolean },
+  emits: ['click'],
+  template: '<button :disabled="disabled" @click="$emit(\'click\')"><slot /></button>',
+})
+
+function mountDialog(items?: DangerConfirmItem[], width?: string) {
+  return mount(DangerConfirmDialog, {
+    props: {
+      modelValue: true,
+      title: 'Confirm cleanup',
+      ...(items === undefined ? {} : { items }),
+      ...(width === undefined ? {} : { width }),
+    },
+    global: {
+      stubs: {
+        ElButton: ElButtonStub,
+        ElDialog: ElDialogStub,
+        ExactKeywordConfirmInput: defineComponent({ template: '<input>' }),
+      },
+    },
+  })
+}
+
+function functionSource(source: string, start: string, end: string) {
+  return source.slice(source.indexOf(start), source.indexOf(end))
+}
+
+describe('Danger confirmation item layout', () => {
+  it('keeps item-dialog width stable while asynchronous items load', async () => {
+    const wrapper = mountDialog([])
+    const itemWidth = 'min(600px, calc(100vw - 32px))'
+
+    expect(wrapper.get('[data-test="dialog"]').attributes('data-width')).toBe(itemWidth)
+
+    await wrapper.setProps({
+      items: [{
+        name: 'proxy-01',
+        description: 'Last seen 2026-08-11 11:05:58',
+        status: { label: 'Offline', tone: 'danger' },
+        warning: 'Upgrade the Agent before Strict Cleanup.',
+      }],
+    })
+
+    expect(wrapper.get('[data-test="dialog"]').attributes('data-width')).toBe(itemWidth)
+    expect(wrapper.get('.hfl-danger-confirm__status').text()).toBe('Offline')
+    expect(wrapper.get('.hfl-danger-confirm__item-desc').text()).toContain('Last seen')
+    expect(wrapper.get('.hfl-danger-confirm__item-warning').text()).toContain('Upgrade the Agent')
+    wrapper.unmount()
+  })
+
+  it('retains compact and explicitly requested dialog widths', () => {
+    const compact = mountDialog()
+    const explicit = mountDialog([], '640px')
+
+    expect(compact.get('[data-test="dialog"]').attributes('data-width'))
+      .toBe('min(480px, calc(100vw - 32px))')
+    expect(explicit.get('[data-test="dialog"]').attributes('data-width')).toBe('640px')
+    compact.unmount()
+    explicit.unmount()
+  })
+
+  it('lets status-free items use the full mobile row', () => {
+    const wrapper = mountDialog([{
+      name: 'A long item name that should not reserve an empty status column',
+    }])
+
+    expect(wrapper.get('.hfl-danger-confirm__item-name-cell').classes())
+      .toContain('hfl-danger-confirm__item-name-cell--full')
+    expect(dialogSource).toMatch(/\.hfl-danger-confirm__item-name-cell--full\s*{[^}]*grid-column:\s*1 \/ -1;/s)
+    wrapper.unmount()
+  })
+
+  it('keeps status badges inside their table column', () => {
+    expect(dialogSource).toContain(':title="item.status.label"')
+    expect(dialogSource).toMatch(/\.hfl-danger-confirm__status\s*{[^}]*display:\s*inline-block;/s)
+    expect(dialogSource).toMatch(/\.hfl-danger-confirm__status\s*{[^}]*max-width:\s*100%;/s)
+    expect(dialogSource).toMatch(/\.hfl-danger-confirm__status\s*{[^}]*overflow:\s*hidden;/s)
+    expect(dialogSource).toMatch(/\.hfl-danger-confirm__status\s*{[^}]*text-overflow:\s*ellipsis;/s)
+    expect(dialogSource).toMatch(/\.hfl-danger-confirm__item-warning\s*{[^}]*grid-template-columns:\s*12px minmax\(0, 1fr\);/s)
+    expect(dialogSource).toMatch(/\.hfl-danger-confirm__item-warning > span\s*{[^}]*min-width:\s*0;/s)
+  })
+
+  it('stacks item details without horizontal scrolling on narrow screens', () => {
+    expect(dialogSource).toMatch(/@media \(max-width: 560px\)[\s\S]*?overflow-x:\s*hidden;/)
+    expect(dialogSource).toMatch(/@media \(max-width: 560px\)[\s\S]*?grid-template-columns:\s*minmax\(0, 1fr\) minmax\(88px, 42%\);/)
+    expect(dialogSource).toMatch(/\.hfl-danger-confirm__item-details-cell\s*{[^}]*grid-column:\s*1 \/ -1;/s)
+    expect(dialogSource).toMatch(/\.hfl-danger-confirm__item-name,[\s\S]*?white-space:\s*normal;/)
+  })
+
+  it('separates node state, last-seen metadata, and cleanup warnings', () => {
+    const itemMapping = functionSource(
+      nodesPage,
+      'function nodeDeleteDialogItem',
+      'async function deleteSelectedNodes',
+    )
+
+    expect(itemMapping).toContain("t('nodesPage.statusOffline')")
+    expect(itemMapping).toContain("t('nodesPage.lastSeenDetail'")
+    expect(itemMapping).toContain('warning: pendingDeleteUpgradeRequired.value.has(row.id)')
+    expect(itemMapping).not.toContain('statusOfflineWithLastSeen')
+    expect(dialogSource).toContain('warning?: string')
+    expect(locale).toContain("lastSeenDetail: 'Last seen {time}'")
+  })
+})

--- a/src/frontend/src/locales/en.ts
+++ b/src/frontend/src/locales/en.ts
@@ -1207,6 +1207,7 @@ export const en = {
     statusReconnecting: 'Reconnecting',
     statusOffline: 'Offline',
     statusOfflineWithLastSeen: 'Offline · last seen {time}',
+    lastSeenDetail: 'Last seen {time}',
     actionUpgradeNow: 'Upgrade Now',
     actionUpgrade: 'Upgrade',
     actionManage: 'Manage',

--- a/src/frontend/src/pages/node/Nodes.vue
+++ b/src/frontend/src/pages/node/Nodes.vue
@@ -484,9 +484,7 @@ function nodeDeleteDialogItem(row: ApiNode) {
     ? t('nodesPage.statusOnline')
     : status === 'reconnecting'
       ? t('nodesPage.statusReconnecting')
-      : row.last_seen_at
-        ? t('nodesPage.statusOfflineWithLastSeen', { time: formatNodeDate(row.last_seen_at) })
-        : t('nodesPage.statusOffline')
+      : t('nodesPage.statusOffline')
   return {
     key: row.id,
     name: row.name,
@@ -494,7 +492,10 @@ function nodeDeleteDialogItem(row: ApiNode) {
       label,
       tone: statusTagType(status),
     },
-    description: pendingDeleteUpgradeRequired.value.has(row.id)
+    description: status === 'offline' && row.last_seen_at
+      ? t('nodesPage.lastSeenDetail', { time: formatNodeDate(row.last_seen_at) })
+      : undefined,
+    warning: pendingDeleteUpgradeRequired.value.has(row.id)
       ? t('nodesPage.deleteUpgradeRequired')
       : undefined,
   }


### PR DESCRIPTION
## Summary

- separate host status, last-seen metadata, and cleanup warnings
- make danger-confirm item tables responsive without overlapping or horizontal scrolling
- preserve full-width mobile rows for items without a status
- add regression coverage for dialog sizing and responsive item layout

## Validation

- 821 frontend tests passed
- production build and TypeScript checks passed
- ESLint completed with 0 errors
- git diff --check passed

Fixes #461