### PR TITLE
fix(agent): preserve shared parent directories on uninstall

### DIFF
--- a/src/agent/internal/platform/install/install_ps1_test.go
+++ b/src/agent/internal/platform/install/install_ps1_test.go
@@ -23,6 +23,18 @@ func TestInstallPs1PurgeDoesNotRecreateDataLogDirectory(t *testing.T) {
 	}
 }
 
+func TestInstallPs1DoesNotRemoveInstallParent(t *testing.T) {
+	source := readPackagingInstallScript(t)
+	for _, forbidden := range []string{
+		"`$parent = Split-Path -Parent `$target",
+		"removed empty parent directory `$parent",
+	} {
+		if strings.Contains(source, forbidden) {
+			t.Fatalf("install.ps1 must not remove the shared install parent: found %q", forbidden)
+		}
+	}
+}
+
 func TestInstallPs1SafeDataPathRequiresHyperFileLensDescendant(t *testing.T) {
 	source := readPackagingInstallScript(t)
 	for _, want := range []string{

--- a/src/agent/internal/platform/install/install_sh_test.go
+++ b/src/agent/internal/platform/install/install_sh_test.go
@@ -47,6 +47,29 @@ func TestInstallShellRetiresIdentityBeforeRemovingAgent(t *testing.T) {
 	}
 }
 
+func TestInstallShellDoesNotRemoveInstallParent(t *testing.T) {
+	t.Parallel()
+	_, currentFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("resolve current test file")
+	}
+	path := filepath.Clean(filepath.Join(
+		filepath.Dir(currentFile),
+		"..", "..", "..", "packaging", "install", "install.sh",
+	))
+	raw, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		t.Skipf("packaging source is not available beside the compiled test: %s", path)
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := string(raw)
+	if strings.Contains(body, `rmdir "$(dirname "$INSTALL_DIR")"`) {
+		t.Fatal("install.sh must not remove the parent of the Agent install directory")
+	}
+}
+
 func TestGatewayHooksPreferLongLivedNodeCredential(t *testing.T) {
 	t.Parallel()
 	for name, hook := range map[string]string{

--- a/src/agent/packaging/install/install.ps1
+++ b/src/agent/packaging/install/install.ps1
@@ -733,11 +733,6 @@ if (Test-Path -LiteralPath `$target) {
   Write-Trace "failed to remove install directory `$target after retries"
   exit 1
 }
-`$parent = Split-Path -Parent `$target
-if (`$parent -and (Test-Path -LiteralPath `$parent) -and -not (Get-ChildItem -LiteralPath `$parent -Force -ErrorAction SilentlyContinue)) {
-  Remove-Item -LiteralPath `$parent -Force -ErrorAction SilentlyContinue
-  Write-Trace "removed empty parent directory `$parent"
-}
 exit 0
 "@
   Set-Content -LiteralPath $runner -Value $body -Encoding UTF8

--- a/src/agent/packaging/install/install.sh
+++ b/src/agent/packaging/install/install.sh
@@ -1509,8 +1509,6 @@ cmd_uninstall() {
 			log_skip "Install directory ${INSTALL_DIR} was not removed (not empty or not present)."
 		fi
 	fi
-	rmdir "$(dirname "$INSTALL_DIR")" 2>/dev/null || true
-
 	if [[ $PURGE_ALL -eq 1 && -f "$env_file" ]]; then
 		rm -f "$env_file"
 		log_ok "Removed ${env_file}."

--- a/tools/quality/test-agent-gateway-uninstall.sh
+++ b/tools/quality/test-agent-gateway-uninstall.sh
@@ -13,6 +13,8 @@ source <(sed '/^case "$CMD" in/,$d' "${installer}")
 
 INSTALL_DIR="${tmp}/opt/hyperfilelens-agent"
 DEFAULT_DATA="${tmp}/var/lib/hyperfilelens-agent"
+install_parent="$(dirname "${INSTALL_DIR}")"
+data_parent="$(dirname "${DEFAULT_DATA}")"
 INSTALLED_VERSION_FILE="${INSTALL_DIR}/INSTALLED_VERSION"
 GATEWAY_LIFECYCLE_SCRIPT="${INSTALL_DIR}/libexec/gateway-lifecycle.sh"
 UNIT_DST="${tmp}/hyperfilelens-agent.service"
@@ -60,6 +62,8 @@ cmd_uninstall --purge-all
 [[ -f "${stop_marker}" ]]
 [[ ! -e "${INSTALL_DIR}" ]]
 [[ ! -e "${DEFAULT_DATA}" ]]
+[[ -d "${install_parent}" ]]
+[[ -d "${data_parent}" ]]
 
 fake_bin="${tmp}/fake-bin"
 docker_state="${tmp}/docker-state"


### PR DESCRIPTION
## Summary

- preserve shared parent directories during Agent uninstall on Linux, macOS, and Windows
- add regression guards for the shell and PowerShell installers
- verify purge removes Agent-owned directories without removing their parents

## Validation

- go test -count=1 ./internal/platform/install
- bash tools/quality/test-agent-gateway-uninstall.sh
- bash -n src/agent/packaging/install/install.sh
- git diff --check origin/main...HEAD

Closes #465