### PR TITLE
fix(storage): merge concurrent migration branches

### DIFF
--- a/src/backend/apps/storage/migrations/0016_merge_0015_storage_branches.py
+++ b/src/backend/apps/storage/migrations/0016_merge_0015_storage_branches.py
@@ -1,0 +1,10 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("storage", "0015_repository_cleanup_preserved"),
+        ("storage", "0015_repository_storage_pool_metrics"),
+    ]
+
+    operations = []


### PR DESCRIPTION
## Summary
- merge the concurrent storage `0015` migration branches
- restore a single migration leaf for Django checks and test database setup

## Validation
- `ruff check src/backend/apps/storage/migrations/0016_merge_0015_storage_branches.py`
- `python manage.py makemigrations --check --dry-run`
- fresh test database applied both `0015` branches and the new `0016` merge successfully
- `git diff --check`

Fixes the migration conflict reported by failed Actions run 31528492066.