### PR TITLE
test(backend): align recovery and stream fixtures

### DIFF
--- a/src/backend/apps/lens_bridge/tests/test_copilot_sessions.py
+++ b/src/backend/apps/lens_bridge/tests/test_copilot_sessions.py
@@ -136,7 +136,7 @@ class CopilotSessionApiTests(TestCase):
             f"/api/lens/runs/{run_uuid}/stream/",
             hfl_user=self.user,
         )
-        response.close()
+        self.assertEqual(b"".join(response.streaming_content), b"data: {}\n\n")
 
     @patch("apps.lens_bridge.api.views.sl_client.stream_sse")
     def test_run_stream_rejects_a_run_not_bound_to_the_session(self, stream_sse):

--- a/src/backend/apps/storage/tests/test_repository_operation_recovery.py
+++ b/src/backend/apps/storage/tests/test_repository_operation_recovery.py
@@ -54,6 +54,7 @@ class RepositoryOperationRecoveryTests(TestCase):
                     "capabilities": [
                         "repository_operation_v1",
                         "repository_cleanup_v1",
+                        "repository_cleanup_v2",
                     ]
                 }
             },
@@ -66,7 +67,11 @@ class RepositoryOperationRecoveryTests(TestCase):
             health=Repository.Health.ONLINE,
             bind_node_type=Repository.BindNodeType.PROXY,
             bind_node_id=self.node.id,
-            config={"proxy_node_dir": "/data/recovery-repository"},
+            config={
+                "proxy_node_base_dir": "/data",
+                "proxy_node_dir": "/data/hfl-repo-recovery",
+                "proxy_fs_layout": "managed_subdir_v1",
+            },
         )
         discover_repository_execution_targets()
 


### PR DESCRIPTION
## Summary
- exercise storage cleanup recovery with the managed local-disk layout and `repository_cleanup_v2` capability required by the current product contract
- consume the Copilot SSE response in its stream test instead of closing the entire test response and its shared database request lifecycle
- prevent the resulting closed database connection from cascading into later Copilot tests

## Validation
- targeted storage recovery and Copilot session tests: 28 passed
- full Community backend suite: 1335 passed
- `git diff --check`

Follow-up to the Backend checks failure in Actions run 31552417769.