### PR TITLE
Align Proxy Host dropdown option height

### DIFF
--- a/src/frontend/src/pages/protection/components/NasAddForm.vue
+++ b/src/frontend/src/pages/protection/components/NasAddForm.vue
@@ -533,6 +533,7 @@ defineExpose({
   justify-content: space-between;
   gap: 10px;
   padding: 2px 0;
+  height: 34px;
   line-height: 1.35;
   max-width: 100%;
 }


### PR DESCRIPTION
## Summary

- Set Proxy Host dropdown options to a consistent 34px height.
- Preserve the single-line hostname and vertically centered status tag layout.

## Testing

- `npm run build` (from `src/frontend`)
- `npm run lint` (from `src/frontend`; passes with existing repository warnings)

Closes #490