### PR TITLE
fix(operations): align alerts, monitoring, and development migrations

### DIFF
--- a/deploy/docker/backend-entrypoint.sh
+++ b/deploy/docker/backend-entrypoint.sh
@@ -125,7 +125,6 @@ run_api_dev() {
 run_worker_dev() {
   ensure_log_dir
   wait_for_postgres
-  run_migrations_and_register
   require_watchfiles
   echo "[entrypoint] watch backend source and restart celery worker"
   exec watchfiles --filter python --ignore-paths "${DEV_WATCH_IGNORE_PATHS}" \

--- a/dev/stack.sh
+++ b/dev/stack.sh
@@ -1085,6 +1085,15 @@ sync_optional_identity_settings() {
 	fi
 }
 
+run_dev_migration_gate() {
+	log "Stopping backend services before database migration"
+	compose stop api worker scheduler
+	log "Starting development data services"
+	compose up -d --wait --no-build --pull never postgres redis
+	log "Applying backend database migrations"
+	compose --profile tools run --rm --no-deps migration
+}
+
 cmd_up() {
 	apply_mirror_env_defaults
 	require_dev_build_tools
@@ -1095,6 +1104,7 @@ cmd_up() {
 	ensure_bridge_network
 	prepare_sourcelens_dev 0
 	prepare_dev 0
+	run_dev_migration_gate
 	log "Starting hot-reload HFL stack from explicitly prepared images"
 	compose up -d --no-build --pull never --remove-orphans
 	refresh_website_web_mount
@@ -1124,6 +1134,7 @@ cmd_restart() {
 	ensure_bridge_network
 	prepare_sourcelens_dev "${force}"
 	prepare_dev "${force}"
+	run_dev_migration_gate
 
 	if [[ "${force}" -eq 1 ]]; then
 		log "Force restart: recreating services from freshly rebuilt images"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 # Default local development stack. HFL source is bind-mounted with automatic process reload.
 # SourceLens remains a separate image-only stack managed by dev/sourcelens.sh.
-# Startup order: PostgreSQL/Redis, worker migrations, scheduler/API, Web, then Nginx.
+# Startup order: PostgreSQL/Redis, singleton migration, Worker/Scheduler/API, Web, then Nginx.
 # Website sources are built into build/website before Compose starts and are
 # served by the Web container; no separate Website runtime container is used.
 
@@ -34,6 +34,20 @@ x-backend-image: &backend-image
     - bridge
 
 services:
+  migration:
+    <<: *backend-image
+    profiles: ["tools"]
+    restart: "no"
+    environment:
+      <<: *backend-environment
+      LOG_FILE: /var/log/hyperfilelens/migration.log
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    command: migrate
+
   worker:
     <<: *backend-image
     build:

--- a/src/frontend/src/composables/useOpsMenus.test.ts
+++ b/src/frontend/src/composables/useOpsMenus.test.ts
@@ -76,8 +76,8 @@ describe('useOpsMenus', () => {
     expect(paths).toContain('/ops/audit-logs')
   })
 
-  it('shows Infrastructure Monitoring when the Enterprise extension contributes it', () => {
-    observeMenus.items = [{ label: 'Infrastructure Monitoring', to: '/ops/host-monitor' }]
+  it('shows System Monitoring when the Enterprise extension contributes it', () => {
+    observeMenus.items = [{ label: 'System Monitoring', to: '/ops/host-monitor' }]
     const menus = mountMenus()
     const paths = menus.value.flatMap((group) =>
       (group.children || []).map((child) => child.to).filter(Boolean),
@@ -86,7 +86,7 @@ describe('useOpsMenus', () => {
     const healthGroup = menus.value.find((group) => group.label === 'HEALTH & MONITORING')
     expect(healthGroup?.children?.map((item) => item.label)).toEqual([
       'Operational Health',
-      'Infrastructure Monitoring',
+      'System Monitoring',
     ])
     expect(paths).toContain('/ops/host-monitor')
   })

--- a/src/frontend/src/lib/alertApi.test.ts
+++ b/src/frontend/src/lib/alertApi.test.ts
@@ -1,0 +1,29 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { api } from './api'
+import { listPolicies, listRecords, policyStatistics, recordStatistics } from './alertApi'
+
+vi.mock('./api', () => ({ api: vi.fn() }))
+
+describe('alertApi', () => {
+  beforeEach(() => {
+    vi.mocked(api).mockReset()
+    vi.mocked(api).mockResolvedValue({ data: { count: 0, results: [] } })
+  })
+
+  it('uses the canonical plural alert API for records and statistics', async () => {
+    await listRecords()
+    await recordStatistics()
+
+    expect(api).toHaveBeenNthCalledWith(1, '/api/v1/alerts/records/')
+    expect(api).toHaveBeenNthCalledWith(2, '/api/v1/alerts/records/stats/')
+  })
+
+  it('uses the canonical plural alert API for rules and statistics', async () => {
+    await listPolicies()
+    await policyStatistics()
+
+    expect(api).toHaveBeenNthCalledWith(1, '/api/v1/alerts/policies/')
+    expect(api).toHaveBeenNthCalledWith(2, '/api/v1/alerts/policies/stats/')
+  })
+})

--- a/src/frontend/src/lib/alertApi.ts
+++ b/src/frontend/src/lib/alertApi.ts
@@ -68,7 +68,7 @@ function paged<T>(raw: unknown): Paged<T> {
   return { count, results }
 }
 
-const base = '/api/v1/alert'
+const base = '/api/v1/alerts'
 
 export async function listPolicies(params?: Record<string, string | number | boolean>) {
   const qs = new URLSearchParams()

--- a/src/frontend/src/locales/en.ts
+++ b/src/frontend/src/locales/en.ts
@@ -2547,7 +2547,7 @@ export const en = {
     nav: {
       groupHealthMonitoring: 'HEALTH & MONITORING',
       operationalHealth: 'Operational Health',
-      monitor: 'Infrastructure Monitoring',
+      monitor: 'System Monitoring',
       groupAlerting: 'ALERTING',
       groupActivity: 'ACTIVITY',
       alerts: 'Alerts',

--- a/tools/extensions/materialize_extensions.py
+++ b/tools/extensions/materialize_extensions.py
@@ -247,7 +247,7 @@ def write_compose(out: Path, mounts: list[tuple[str, Path]]) -> None:
         "    volumes:",
         *uniq_vols,
     ]
-    for svc in ("api", "worker", "scheduler"):
+    for svc in ("migration", "api", "worker", "scheduler"):
         lines.append(f"  {svc}:")
         lines.extend(block)
     lines.append("  web:")

--- a/tools/quality/test-dev-stack-upgrade.sh
+++ b/tools/quality/test-dev-stack-upgrade.sh
@@ -137,8 +137,28 @@ refresh_website_web_mount
 
 cmd_up_body="$(sed -n '/^cmd_up()/,/^}/p' "${ROOT_REPO}/dev/stack.sh")"
 cmd_restart_body="$(sed -n '/^cmd_restart()/,/^}/p' "${ROOT_REPO}/dev/stack.sh")"
+run_dev_migration_gate_body="$(sed -n '/^run_dev_migration_gate()/,/^}/p' "${ROOT_REPO}/dev/stack.sh")"
 grep -F 'refresh_website_web_mount' <<<"${cmd_up_body}" >/dev/null
 grep -F 'refresh_website_web_mount' <<<"${cmd_restart_body}" >/dev/null
+for command_body in "${cmd_up_body}" "${cmd_restart_body}"; do
+	gate_line="$(grep -nF 'run_dev_migration_gate' <<<"${command_body}" | cut -d: -f1)"
+	application_line="$(grep -nF 'compose up -d --no-build --pull never' <<<"${command_body}" | cut -d: -f1 | tail -n 1)"
+	[[ -n "${gate_line}" ]]
+	[[ -n "${application_line}" ]]
+	((gate_line < application_line))
+done
+backend_stop_line="$(grep -nF 'compose stop api worker scheduler' <<<"${run_dev_migration_gate_body}" | cut -d: -f1)"
+data_services_line="$(grep -nF 'compose up -d --wait --no-build --pull never postgres redis' <<<"${run_dev_migration_gate_body}" | cut -d: -f1)"
+migration_line="$(grep -nF 'compose --profile tools run --rm --no-deps migration' <<<"${run_dev_migration_gate_body}" | cut -d: -f1)"
+[[ -n "${backend_stop_line}" ]]
+[[ -n "${data_services_line}" ]]
+[[ -n "${migration_line}" ]]
+((backend_stop_line < data_services_line))
+((data_services_line < migration_line))
+
+# The singleton migration must load the same backend extensions as runtime services.
+grep -F 'for svc in ("migration", "api", "worker", "scheduler"):' \
+	"${ROOT_REPO}/tools/extensions/materialize_extensions.py" >/dev/null
 
 # Runtime artifacts are mounted below the backend source root in development.
 # Publishing Python helpers into media must not restart API or Celery processes.
@@ -149,6 +169,11 @@ grep -F 'python /dev-process-supervisor.py' "${backend_entrypoint}" >/dev/null
 grep -F 'deploy/docker/dev-process-supervisor.py deploy/bootstrap' \
 	"${ROOT_REPO}/dev/stack.sh" >/dev/null
 [[ "$(grep -Fc -- '--ignore-paths "${DEV_WATCH_IGNORE_PATHS}"' "${backend_entrypoint}")" -eq 2 ]]
+worker_dev_entrypoint="$(sed -n '/^run_worker_dev()/,/^}/p' "${backend_entrypoint}")"
+if grep -F 'run_migrations_and_register' <<<"${worker_dev_entrypoint}" >/dev/null; then
+	echo 'Development worker must not run singleton migrations' >&2
+	exit 1
+fi
 
 # Development Nginx must re-resolve API/Web after Compose recreates containers.
 dev_upstreams="${ROOT_REPO}/deploy/nginx/development-upstreams.conf"


### PR DESCRIPTION
## Summary
- use the canonical plural Alerts API and align the monitoring label to System Monitoring
- add a singleton development migration service and gate stack up/restart before backend startup
- load Enterprise extensions into the migration job and keep development workers migration-free

## Validation
- development stack upgrade regression checks
- focused Vitest coverage (5 tests)
- Vue TypeScript validation
- combined OSS + Enterprise production build
- Docker Compose configuration and extension overlay checks