### PR TITLE
fix(insight): make Copilot chat creation durable and asynchronous

### DIFF
--- a/src/agent/internal/engine/engine.go
+++ b/src/agent/internal/engine/engine.go
@@ -98,6 +98,24 @@ func (e *Engine) Run(ctx context.Context, cmd Command, sink ExecutionSink) Resul
 			break
 		}
 		status, result, errMsg = "failed", nil, "repository payload is required"
+	case "lens.snapshot.browse":
+		if _, ok, parseErr := parseRepositorySpec(p.Extra["repository"]); parseErr != nil {
+			status, result, errMsg = "failed", nil, parseErr.Error()
+			break
+		} else if ok {
+			status, result, errMsg = e.runManagedInsightSnapshotBrowse(ctx, rep, cmd.ID, p)
+			break
+		}
+		status, result, errMsg = "failed", nil, "repository payload is required"
+	case "lens.snapshot.scope.resolve":
+		if _, ok, parseErr := parseRepositorySpec(p.Extra["repository"]); parseErr != nil {
+			status, result, errMsg = "failed", nil, parseErr.Error()
+			break
+		} else if ok {
+			status, result, errMsg = e.runManagedSnapshotScopeResolve(ctx, rep, cmd.ID, p)
+			break
+		}
+		status, result, errMsg = "failed", nil, "repository payload is required"
 	case "snapshot.download":
 		if _, ok, parseErr := parseRepositorySpec(p.Extra["repository"]); parseErr != nil {
 			status, result, errMsg = "failed", nil, parseErr.Error()

--- a/src/agent/internal/engine/managed_backup.go
+++ b/src/agent/internal/engine/managed_backup.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"math"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -364,6 +365,21 @@ func int64Value(raw any) (int64, bool) {
 		}
 	}
 	return 0, false
+}
+
+func exactInt64Value(raw any) (int64, bool) {
+	switch value := raw.(type) {
+	case float64:
+		if math.IsNaN(value) || math.IsInf(value, 0) || math.Trunc(value) != value {
+			return 0, false
+		}
+		if value < math.MinInt64 || value >= math.MaxInt64 {
+			return 0, false
+		}
+		return int64(value), true
+	default:
+		return int64Value(raw)
+	}
 }
 
 func stringValue(raw any) string {
@@ -1347,6 +1363,137 @@ func snapshotObjectPath(snapshotID string, relPath string) string {
 	return snapshot + "/" + rel
 }
 
+func newInsightSnapshotResult(snapshotID string, path string) map[string]any {
+	return map[string]any{
+		"path":        strings.Trim(strings.TrimSpace(path), "/\\"),
+		"snapshot_id": strings.TrimSpace(snapshotID),
+	}
+}
+
+type snapshotScopeSelection struct {
+	name        string
+	found       bool
+	pathType    string
+	sizeBytes   int64
+	modifiedAt  string
+	invalidType bool
+}
+
+type insightSnapshotBrowseCollector struct {
+	basePath string
+	limit    int
+	entries  []map[string]any
+	hasMore  bool
+	invalid  bool
+}
+
+func newInsightSnapshotBrowseCollector(basePath string, limit int) *insightSnapshotBrowseCollector {
+	if limit <= 0 || limit > 500 {
+		limit = 500
+	}
+	return &insightSnapshotBrowseCollector{
+		basePath: strings.Trim(strings.TrimSpace(basePath), "/\\"),
+		limit:    limit,
+		entries:  make([]map[string]any, 0, limit),
+	}
+}
+
+func (collector *insightSnapshotBrowseCollector) consume(line string) bool {
+	if len(collector.entries) >= collector.limit {
+		collector.hasMore = true
+		return false
+	}
+	mode, size, modTime, name, ok := parseInsightSnapshotLongLine(line)
+	if !ok || size < 0 {
+		collector.invalid = true
+		return false
+	}
+	normalizedMode := strings.ToLower(mode)
+	isDir := strings.HasPrefix(normalizedMode, "d")
+	if !isDir && !strings.HasPrefix(normalizedMode, "-") {
+		collector.invalid = true
+		return false
+	}
+	path := normalizeSnapshotBrowsePath(name, name, collector.basePath, "")
+	collector.entries = append(collector.entries, map[string]any{
+		"name":         snapshotBrowseName(name, path),
+		"path":         path,
+		"type":         mapSnapshotBrowseType(isDir),
+		"is_dir":       isDir,
+		"size_bytes":   size,
+		"modified_at":  modTime,
+		"downloadable": true,
+		"has_children": nil,
+	})
+	return true
+}
+
+func (selection *snapshotScopeSelection) inspectLine(line string) {
+	if selection.found {
+		return
+	}
+	mode, size, modifiedAt, name, ok := parseInsightSnapshotLongLine(line)
+	if !ok || filepath.Base(filepath.ToSlash(name)) != selection.name {
+		return
+	}
+	selection.found = true
+	selection.modifiedAt = modifiedAt
+	normalizedMode := strings.ToLower(mode)
+	switch {
+	case strings.HasPrefix(normalizedMode, "-") && size >= 0:
+		selection.pathType = "file"
+		selection.sizeBytes = size
+	case strings.HasPrefix(normalizedMode, "d") && size >= 0:
+		selection.pathType = "dir"
+	default:
+		selection.invalidType = true
+	}
+}
+
+func inspectManagedSnapshotSelection(
+	ctx context.Context,
+	bin string,
+	configFile string,
+	env map[string]string,
+	snapshotID string,
+	cleanPath string,
+) (snapshotScopeSelection, process.Result, error) {
+	parentPath := filepath.ToSlash(filepath.Dir(cleanPath))
+	if parentPath == "." {
+		parentPath = ""
+	}
+	selection := snapshotScopeSelection{
+		name: filepath.Base(filepath.ToSlash(cleanPath)),
+	}
+	inspectCtx, cancelInspect := context.WithCancel(ctx)
+	defer cancelInspect()
+	inspectResult, inspectErr := process.RunStreamingDiscardStdout(
+		inspectCtx,
+		bin,
+		[]string{
+			"--config-file=" + configFile,
+			"ls",
+			"-l",
+			snapshotObjectPath(snapshotID, parentPath),
+		},
+		env,
+		"",
+		func(line string, stderr bool) {
+			if stderr {
+				return
+			}
+			selection.inspectLine(line)
+			if selection.found {
+				cancelInspect()
+			}
+		},
+	)
+	if selection.found && ctx.Err() == nil {
+		inspectErr = nil
+	}
+	return selection, inspectResult, inspectErr
+}
+
 func (e *Engine) runManagedSnapshotBrowse(
 	ctx context.Context,
 	rep ReporterSink,
@@ -1381,6 +1528,209 @@ func (e *Engine) runManagedSnapshotBrowse(
 	if runErr != nil {
 		return "failed", result, snapshotBrowseFailureMessage(res, runErr)
 	}
+	return "success", result, ""
+}
+
+func (e *Engine) runManagedInsightSnapshotBrowse(
+	ctx context.Context,
+	rep ReporterSink,
+	taskID string,
+	p Payload,
+) (string, map[string]any, string) {
+	if p.SnapshotID == "" {
+		return "failed", nil, "snapshot_id is required"
+	}
+	bin, err := e.kopiaBin(ctx)
+	if err != nil {
+		return "failed", nil, err.Error()
+	}
+	configFile, env, _, _, prepErr := e.prepareManagedRepository(
+		ctx,
+		rep,
+		taskID,
+		p,
+		repositoryPrepareConnect,
+	)
+	if prepErr != "" {
+		return "failed", nil, prepErr
+	}
+	basePath := strings.Trim(strings.TrimSpace(p.Path), "/\\")
+	result := newInsightSnapshotResult(p.SnapshotID, basePath)
+	target := snapshotObjectPath(p.SnapshotID, basePath)
+	args := []string{"--config-file=" + configFile, "ls", "-l", target}
+	collector := newInsightSnapshotBrowseCollector(basePath, p.Limit)
+	runCtx, cancelRun := context.WithCancel(ctx)
+	defer cancelRun()
+	res, runErr := process.RunStreamingDiscardStdout(
+		runCtx,
+		bin,
+		args,
+		env,
+		"",
+		func(line string, stderr bool) {
+			if !stderr && !collector.consume(line) {
+				cancelRun()
+			}
+		},
+	)
+	limitReached := collector.hasMore && ctx.Err() == nil
+	if collector.invalid {
+		return "failed", result, "snapshot browse returned invalid directory entries"
+	}
+	if runErr != nil && !limitReached {
+		if basePath != "" {
+			selection, _, inspectErr := inspectManagedSnapshotSelection(
+				ctx,
+				bin,
+				configFile,
+				env,
+				p.SnapshotID,
+				basePath,
+			)
+			if inspectErr == nil && selection.found && !selection.invalidType && selection.pathType == "file" {
+				result["entries"] = []map[string]any{
+					{
+						"name":         selection.name,
+						"path":         basePath,
+						"type":         "file",
+						"is_dir":       false,
+						"size_bytes":   selection.sizeBytes,
+						"modified_at":  selection.modifiedAt,
+						"downloadable": true,
+						"has_children": nil,
+					},
+				}
+				result["count"] = 1
+				result["has_more"] = false
+				return "success", result, ""
+			}
+		}
+		return "failed", result, snapshotBrowseFailureMessage(res, runErr)
+	}
+	result["entries"] = collector.entries
+	result["count"] = len(collector.entries)
+	result["has_more"] = collector.hasMore
+	return "success", result, ""
+}
+
+func (e *Engine) runManagedSnapshotScopeResolve(
+	ctx context.Context,
+	rep ReporterSink,
+	taskID string,
+	p Payload,
+) (string, map[string]any, string) {
+	if p.SnapshotID == "" {
+		return "failed", nil, "snapshot_id is required"
+	}
+	bin, err := e.kopiaBin(ctx)
+	if err != nil {
+		return "failed", nil, err.Error()
+	}
+	configFile, env, _, _, prepErr := e.prepareManagedRepository(
+		ctx,
+		rep,
+		taskID,
+		p,
+		repositoryPrepareConnect,
+	)
+	if prepErr != "" {
+		return "failed", nil, prepErr
+	}
+	cleanPath := strings.Trim(strings.TrimSpace(p.Path), "/\\")
+	result := newInsightSnapshotResult(p.SnapshotID, cleanPath)
+	pathType := "dir"
+	var selectedFileSize int64
+	if cleanPath == "" && strings.EqualFold(
+		strings.TrimSpace(stringValue(p.Extra["root_path_type"])),
+		"file",
+	) {
+		pathType = "file"
+		var sizeOK bool
+		selectedFileSize, sizeOK = exactInt64Value(p.Extra["root_size_bytes"])
+		if !sizeOK || selectedFileSize < 0 {
+			return "failed", result, "snapshot root file size is invalid"
+		}
+	} else if cleanPath != "" {
+		selection, inspectResult, inspectErr := inspectManagedSnapshotSelection(
+			ctx,
+			bin,
+			configFile,
+			env,
+			p.SnapshotID,
+			cleanPath,
+		)
+		if inspectErr != nil {
+			return "failed", result, snapshotBrowseFailureMessage(inspectResult, inspectErr)
+		}
+		if selection.invalidType {
+			return "failed", result, "selected snapshot path type is not supported"
+		}
+		if !selection.found {
+			return "failed", result, "selected snapshot path was not found"
+		}
+		pathType = selection.pathType
+		selectedFileSize = selection.sizeBytes
+	}
+	result["path_type"] = pathType
+	if pathType == "file" {
+		result["file_count"] = int64(1)
+		result["directory_count"] = int64(0)
+		result["size_bytes"] = selectedFileSize
+		return "success", result, ""
+	}
+
+	target := snapshotObjectPath(p.SnapshotID, cleanPath)
+	args := []string{"--config-file=" + configFile, "ls", "-lr", target}
+	var fileCount int64
+	var sizeBytes int64
+	var directoryCount int64
+	var invalidTotals bool
+	res, runErr := process.RunStreamingDiscardStdout(
+		ctx,
+		bin,
+		args,
+		env,
+		"",
+		func(line string, stderr bool) {
+			if stderr {
+				return
+			}
+			mode, size, _, _, ok := parseInsightSnapshotLongLine(line)
+			if !ok {
+				if strings.TrimSpace(line) != "" {
+					invalidTotals = true
+				}
+				return
+			}
+			if strings.HasPrefix(strings.ToLower(mode), "d") {
+				if size < 0 {
+					invalidTotals = true
+					return
+				}
+				directoryCount++
+				return
+			}
+			if !strings.HasPrefix(strings.ToLower(mode), "-") || size < 0 {
+				invalidTotals = true
+				return
+			}
+			fileCount++
+			if size > 0 && sizeBytes <= math.MaxInt64-size {
+				sizeBytes += size
+			} else if size > 0 {
+				invalidTotals = true
+			}
+		},
+	)
+	if runErr != nil {
+		return "failed", result, snapshotBrowseFailureMessage(res, runErr)
+	}
+	if invalidTotals {
+		return "failed", result, "snapshot scope contains unsupported or invalid entries"
+	}
+	result["file_count"] = fileCount
+	result["directory_count"] = directoryCount
+	result["size_bytes"] = sizeBytes
 	return "success", result, ""
 }
 
@@ -2076,6 +2426,22 @@ func parseSnapshotBrowseLongLine(line string) (mode string, size int64, modTime 
 		return "", 0, "", "", false
 	}
 	return mode, size, modTime, name, true
+}
+
+func parseInsightSnapshotLongLine(line string) (mode string, size int64, modTime string, name string, ok bool) {
+	fields := strings.Fields(line)
+	if len(fields) < 7 || !looksLikeMode(fields[0]) {
+		return "", 0, "", "", false
+	}
+	parsedSize, err := strconv.ParseInt(fields[1], 10, 64)
+	if err != nil {
+		return "", 0, "", "", false
+	}
+	mode, _, modTime, name, ok = parseSnapshotBrowseLongLine(line)
+	if !ok {
+		return "", 0, "", "", false
+	}
+	return mode, parsedSize, modTime, name, true
 }
 
 func parseSnapshotBrowseTextOutput(stdout string, basePath string) []map[string]any {

--- a/src/agent/internal/engine/managed_backup_test.go
+++ b/src/agent/internal/engine/managed_backup_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -717,6 +718,155 @@ func TestParseSnapshotBrowseOutputHandlesKopiaModeAndNestedPath(t *testing.T) {
 	}
 	if rows[1]["path"] != "docs/logo.png" {
 		t.Fatalf("expected nested file path docs/logo.png, got %#v", rows[1]["path"])
+	}
+}
+
+func TestSnapshotScopeRecursiveLinesProduceTrustedTotals(t *testing.T) {
+	stdout := `drwx------            5 2026-08-12 11:15:59 CST object-dir sub/
+-rw-------            5 2026-08-12 11:15:59 CST object-file sub/b.txt
+-rw-------            3 2026-08-12 11:15:59 CST object-root a.txt`
+
+	var files int64
+	var directories int64
+	var sizeBytes int64
+	for _, line := range strings.Split(stdout, "\n") {
+		mode, size, _, _, ok := parseInsightSnapshotLongLine(line)
+		if !ok {
+			continue
+		}
+		if strings.HasPrefix(strings.ToLower(mode), "d") {
+			directories++
+			continue
+		}
+		files++
+		sizeBytes += size
+	}
+
+	if files != 2 || directories != 1 || sizeBytes != 8 {
+		t.Fatalf(
+			"unexpected totals files=%d directories=%d size=%d",
+			files,
+			directories,
+			sizeBytes,
+		)
+	}
+}
+
+func TestInsightSnapshotResultContainsOnlyBusinessIdentity(t *testing.T) {
+	result := newInsightSnapshotResult(" snapshot-1 ", " /reports/quarterly/ ")
+
+	if result["snapshot_id"] != "snapshot-1" || result["path"] != "reports/quarterly" {
+		t.Fatalf("unexpected Insight result identity: %#v", result)
+	}
+	for _, key := range []string{
+		"config_file",
+		"repository_status",
+		"repository_connect",
+		"repository_create",
+	} {
+		if _, exists := result[key]; exists {
+			t.Fatalf("Insight result must not contain %q: %#v", key, result)
+		}
+	}
+}
+
+func TestSnapshotScopeLongLineRejectsInvalidSize(t *testing.T) {
+	line := "-rw------- not-a-size 2026-08-12 11:15:59 CST object-file report.txt"
+	if _, _, _, _, ok := parseInsightSnapshotLongLine(line); ok {
+		t.Fatal("expected invalid size to be rejected")
+	}
+	if _, size, _, _, ok := parseSnapshotBrowseLongLine(line); !ok || size != 0 {
+		t.Fatal("shared snapshot browsing parser behavior must remain unchanged")
+	}
+}
+
+func TestExactInt64ValueRejectsInvalidJSONNumbers(t *testing.T) {
+	for _, value := range []any{1.5, math.NaN(), math.Inf(1), float64(math.MaxInt64)} {
+		if _, ok := exactInt64Value(value); ok {
+			t.Fatalf("expected invalid exact integer %v to be rejected", value)
+		}
+	}
+	if value, ok := exactInt64Value(float64(42)); !ok || value != 42 {
+		t.Fatalf("expected exact JSON integer, got value=%d ok=%v", value, ok)
+	}
+}
+
+func TestSnapshotScopeSelectionIgnoresOtherEntries(t *testing.T) {
+	selection := snapshotScopeSelection{name: "report.pdf"}
+	selection.inspectLine(
+		"-rw------- 12 2026-08-12 11:15:59 CST object-other other.pdf",
+	)
+	selection.inspectLine(
+		"-rw------- 42 2026-08-12 11:15:59 CST object-report report.pdf",
+	)
+
+	if !selection.found || selection.invalidType {
+		t.Fatalf("expected a valid selected file, got %#v", selection)
+	}
+	if selection.pathType != "file" || selection.sizeBytes != 42 {
+		t.Fatalf("unexpected selected file summary: %#v", selection)
+	}
+	if selection.modifiedAt != "2026-08-12 11:15:59 CST" {
+		t.Fatalf("unexpected selected file timestamp: %#v", selection)
+	}
+}
+
+func TestSnapshotScopeSelectionRejectsInvalidFileSize(t *testing.T) {
+	selection := snapshotScopeSelection{name: "report.pdf"}
+	selection.inspectLine(
+		"-rw------- -1 2026-08-12 11:15:59 CST object-report report.pdf",
+	)
+
+	if !selection.found || !selection.invalidType {
+		t.Fatalf("expected invalid selected file size, got %#v", selection)
+	}
+}
+
+func TestSnapshotScopeSelectionRejectsUnsupportedEntryType(t *testing.T) {
+	selection := snapshotScopeSelection{name: "latest"}
+	selection.inspectLine(
+		"lrwx------ 12 2026-08-12 11:15:59 CST object-link latest",
+	)
+
+	if !selection.found || !selection.invalidType {
+		t.Fatalf("expected unsupported selected path type, got %#v", selection)
+	}
+}
+
+func TestInsightSnapshotLongLinePreservesNegativeSizeForValidation(t *testing.T) {
+	line := "drwx------ -1 2026-08-12 11:15:59 CST object-dir reports/"
+	_, size, _, _, ok := parseInsightSnapshotLongLine(line)
+	if !ok || size != -1 {
+		t.Fatalf("expected a parsed negative size for fail-closed validation, got %d", size)
+	}
+}
+
+func TestInsightSnapshotBrowseCollectorBoundsAndNormalizesEntries(t *testing.T) {
+	collector := newInsightSnapshotBrowseCollector("reports", 2)
+	collector.consume("drwx------ 0 2026-08-12 11:15:59 CST object-dir quarterly/")
+	collector.consume("-rw------- 12 2026-08-12 11:15:59 CST object-one one.pdf")
+	continueReading := collector.consume(
+		"-rw------- 18 2026-08-12 11:15:59 CST object-two two.pdf",
+	)
+
+	if continueReading || len(collector.entries) != 2 || !collector.hasMore {
+		t.Fatalf("expected two bounded entries and has_more, got %#v", collector)
+	}
+	if collector.entries[0]["path"] != "reports/quarterly" || collector.entries[0]["type"] != "dir" {
+		t.Fatalf("unexpected directory entry: %#v", collector.entries[0])
+	}
+	if collector.entries[1]["path"] != "reports/one.pdf" || collector.entries[1]["size_bytes"] != int64(12) {
+		t.Fatalf("unexpected file entry: %#v", collector.entries[1])
+	}
+}
+
+func TestInsightSnapshotBrowseCollectorRejectsMalformedOutput(t *testing.T) {
+	collector := newInsightSnapshotBrowseCollector("reports", 2)
+	collector.consume("unexpected kopia output")
+	collector.consume("lrwx------ 4 2026-08-12 11:15:59 CST object-link latest")
+
+	if !collector.invalid || len(collector.entries) != 0 {
+		t.Fatalf("expected malformed output to invalidate the result, got %#v", collector)
 	}
 }
 

--- a/src/agent/internal/engine/payload.go
+++ b/src/agent/internal/engine/payload.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"fmt"
+	"math"
 	"strings"
 )
 
@@ -114,6 +115,14 @@ func payloadIntValue(v any) (int, bool) {
 	case int64:
 		return int(x), true
 	case float64:
+		if math.IsNaN(x) || math.IsInf(x, 0) || math.Trunc(x) != x {
+			return 0, false
+		}
+		maxInt := int64(^uint(0) >> 1)
+		minInt := -maxInt - 1
+		if x < float64(minInt) || x > float64(maxInt) {
+			return 0, false
+		}
 		return int(x), true
 	case string:
 		s := strings.TrimSpace(x)
@@ -121,7 +130,8 @@ func payloadIntValue(v any) (int, bool) {
 			return 0, false
 		}
 		var out int
-		if _, err := fmt.Sscanf(s, "%d", &out); err == nil {
+		var trailing string
+		if count, err := fmt.Sscanf(s, "%d%s", &out, &trailing); err == nil && count == 1 {
 			return out, true
 		}
 	}
@@ -152,6 +162,10 @@ func NormalizeKind(kind string) string {
 		return "snapshot.list"
 	case "snapshot.browse", "kopia.snapshot.browse":
 		return "snapshot.browse"
+	case "lens.snapshot.browse":
+		return "lens.snapshot.browse"
+	case "lens.snapshot.scope.resolve":
+		return "lens.snapshot.scope.resolve"
 	case "snapshot.download", "kopia.snapshot.download":
 		return "snapshot.download"
 	case "snapshot.delete", "snapshot.remove", "kopia.snapshot.delete", "kopia.snapshot.remove":

--- a/src/agent/internal/engine/payload_test.go
+++ b/src/agent/internal/engine/payload_test.go
@@ -26,6 +26,12 @@ func TestNormalizeKind(t *testing.T) {
 	if got := NormalizeKind("snapshot.list"); got != "snapshot.list" {
 		t.Fatalf("got %q", got)
 	}
+	if got := NormalizeKind("lens.snapshot.scope.resolve"); got != "lens.snapshot.scope.resolve" {
+		t.Fatalf("got %q", got)
+	}
+	if got := NormalizeKind("lens.snapshot.browse"); got != "lens.snapshot.browse" {
+		t.Fatalf("got %q", got)
+	}
 	if got := NormalizeKind("repo.policy.apply"); got != "repository.policy.apply" {
 		t.Fatalf("got %q", got)
 	}
@@ -80,6 +86,14 @@ func TestParsePayloadBrowseOptions(t *testing.T) {
 	}
 	if p.Cursor != "200" {
 		t.Fatalf("cursor = %q", p.Cursor)
+	}
+}
+
+func TestPayloadIntValueRejectsFractionalAndTrailingInput(t *testing.T) {
+	for _, value := range []any{1.5, "10items", "1.5"} {
+		if _, ok := payloadIntValue(value); ok {
+			t.Fatalf("expected invalid integer payload %v to be rejected", value)
+		}
 	}
 }
 

--- a/src/agent/internal/platform/process/stream.go
+++ b/src/agent/internal/platform/process/stream.go
@@ -24,6 +24,31 @@ func RunStreaming(
 	workDir string,
 	onLine OutputLineHandler,
 ) (Result, error) {
+	return runStreaming(ctx, bin, args, extraEnv, workDir, onLine, true)
+}
+
+// RunStreamingDiscardStdout streams stdout without retaining it in memory.
+// Stderr remains captured so callers can return a useful command failure.
+func RunStreamingDiscardStdout(
+	ctx context.Context,
+	bin string,
+	args []string,
+	extraEnv map[string]string,
+	workDir string,
+	onLine OutputLineHandler,
+) (Result, error) {
+	return runStreaming(ctx, bin, args, extraEnv, workDir, onLine, false)
+}
+
+func runStreaming(
+	ctx context.Context,
+	bin string,
+	args []string,
+	extraEnv map[string]string,
+	workDir string,
+	onLine OutputLineHandler,
+	captureStdout bool,
+) (Result, error) {
 	if bin == "" {
 		return Result{}, fmt.Errorf("empty binary path")
 	}
@@ -57,7 +82,11 @@ func RunStreaming(
 	}
 
 	wg.Add(2)
-	go capture(stdoutPipe, false, &stdoutBuf)
+	if captureStdout {
+		go capture(stdoutPipe, false, &stdoutBuf)
+	} else {
+		go capture(stdoutPipe, false, nil)
+	}
 	go capture(stderrPipe, true, &stderrBuf)
 
 	stopKill := startContextProcessGroupKill(ctx, cmd)
@@ -92,8 +121,10 @@ func captureProgressLines(
 	for {
 		line, err := readProgressLine(br)
 		if line != "" {
-			buf.WriteString(line)
-			buf.WriteByte('\n')
+			if buf != nil {
+				buf.WriteString(line)
+				buf.WriteByte('\n')
+			}
 			if onLine != nil {
 				onLine(line, stderr)
 			}

--- a/src/agent/internal/platform/process/stream_test.go
+++ b/src/agent/internal/platform/process/stream_test.go
@@ -46,3 +46,32 @@ func TestRunStreamingEmitsCarriageReturnProgress(t *testing.T) {
 		t.Fatalf("expected captured stderr, got %q", res.Stderr)
 	}
 }
+
+func TestRunStreamingDiscardStdoutStillEmitsLinesAndCapturesStderr(t *testing.T) {
+	ctx := context.Background()
+	var stdoutLines []string
+	res, err := RunStreamingDiscardStdout(
+		ctx,
+		"bash",
+		[]string{"-c", `printf 'one\ntwo\n'; printf 'warning\n' 1>&2`},
+		nil,
+		"",
+		func(line string, stderr bool) {
+			if !stderr {
+				stdoutLines = append(stdoutLines, line)
+			}
+		},
+	)
+	if err != nil {
+		t.Fatalf("RunStreamingDiscardStdout failed: %v", err)
+	}
+	if res.Stdout != "" {
+		t.Fatalf("expected discarded stdout, got %q", res.Stdout)
+	}
+	if strings.Join(stdoutLines, ",") != "one,two" {
+		t.Fatalf("unexpected streamed stdout lines: %#v", stdoutLines)
+	}
+	if res.Stderr != "warning" {
+		t.Fatalf("expected captured stderr, got %q", res.Stderr)
+	}
+}

--- a/src/backend/apps/lens_bridge/api/serializers.py
+++ b/src/backend/apps/lens_bridge/api/serializers.py
@@ -587,6 +587,7 @@ class LensSessionLinkSerializer(serializers.ModelSerializer):
 class LensSessionCreateSerializer(serializers.Serializer):
     """New Copilot chat configuration. Resources are provisioned asynchronously."""
 
+    idempotency_key = serializers.CharField(max_length=128)
     title = serializers.CharField(required=False, allow_blank=True, max_length=160)
     backup_config_id = serializers.IntegerField(min_value=1)
     backup_source_snapshot_id = serializers.IntegerField(min_value=1)
@@ -614,6 +615,14 @@ class LensSessionCreateSerializer(serializers.Serializer):
                 }
             )
         return attrs
+
+
+class LensSnapshotBrowseCreateSerializer(serializers.Serializer):
+    """Insight-owned asynchronous snapshot browse request."""
+
+    directory_id = serializers.IntegerField(min_value=1)
+    path = serializers.CharField(required=False, allow_blank=True, max_length=2000)
+    limit = serializers.IntegerField(required=False, min_value=1, max_value=500, default=500)
 
 
 class LensSessionUpdateSerializer(serializers.Serializer):

--- a/src/backend/apps/lens_bridge/api/urls.py
+++ b/src/backend/apps/lens_bridge/api/urls.py
@@ -10,6 +10,8 @@ from apps.lens_bridge.api.views import (
     LensCopilotReadinessView,
     LensCopilotRunStreamView,
     LensCopilotSessionViewSet,
+    LensCopilotSnapshotBrowseTaskView,
+    LensCopilotSnapshotBrowseView,
     LensCopilotUsageView,
     LensGatewayViewSet,
     LensKnowledgeSourceViewSet,
@@ -46,6 +48,16 @@ urlpatterns = [
     path("copilot/gateway-options/", LensCopilotGatewayOptionsView.as_view(), name="lens-copilot-gateway-options"),
     path("copilot/knowledge-sources/", LensCopilotKnowledgeSourceView.as_view(), name="lens-copilot-ks"),
     path("copilot/readiness/", LensCopilotReadinessView.as_view(), name="lens-copilot-readiness"),
+    path(
+        "copilot/snapshot-browse/",
+        LensCopilotSnapshotBrowseView.as_view(),
+        name="lens-copilot-snapshot-browse",
+    ),
+    path(
+        "copilot/snapshot-browse/<uuid:task_id>/",
+        LensCopilotSnapshotBrowseTaskView.as_view(),
+        name="lens-copilot-snapshot-browse-task",
+    ),
     path("copilot/usage/", LensCopilotUsageView.as_view(), name="lens-copilot-usage"),
     path(
         "copilot/usage/<uuid:run_uuid>/",

--- a/src/backend/apps/lens_bridge/api/views.py
+++ b/src/backend/apps/lens_bridge/api/views.py
@@ -1,7 +1,7 @@
-from django.http import JsonResponse, StreamingHttpResponse
 import uuid
 
 from django.db import transaction
+from django.http import JsonResponse, StreamingHttpResponse
 from rest_framework import status, viewsets
 from rest_framework.decorators import action
 from rest_framework.exceptions import APIException, NotFound, ValidationError
@@ -9,7 +9,12 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from apps.iam.permissions_org import IsOrgOperator, IsOrgStaffReader, IsOrgWriter
+from apps.iam.permissions_org import (
+    IsOrgOperator,
+    IsOrgStaffReader,
+    IsOrgWriter,
+    get_membership,
+)
 from apps.lens_bridge.api.serializers import (
     LensChatBindingEnsureSerializer,
     LensCopilotGatewayOptionSerializer,
@@ -20,6 +25,7 @@ from apps.lens_bridge.api.serializers import (
     LensOrgSettingsSerializer,
     LensRunCreateSerializer,
     LensSessionCreateSerializer,
+    LensSnapshotBrowseCreateSerializer,
     LensSessionLinkSerializer,
     LensSessionTitleSerializer,
     LensSessionUpdateSerializer,
@@ -36,7 +42,6 @@ from apps.lens_bridge.services import (
     sl_client,
     usage,
 )
-from apps.iam.permissions_org import get_membership
 from apps.lens_bridge.services import (
     assistant_access,
     chat_binding as chat_binding_service,
@@ -79,6 +84,72 @@ class CopilotRunConflict(APIException):
     status_code = status.HTTP_409_CONFLICT
     default_detail = "This chat already has an active response."
     default_code = "copilot_run_active"
+
+
+class LensCopilotSnapshotBrowseView(OrgScopedMixin, APIView):
+    """Dispatch and inspect snapshot browsing for Insight without blocking API."""
+
+    permission_classes = [IsAuthenticated, IsOrgOperator]
+
+    def post(self, request):
+        body = LensSnapshotBrowseCreateSerializer(data=request.data)
+        body.is_valid(raise_exception=True)
+        from apps.lens_bridge.services import snapshot_scope_tasks
+
+        task = snapshot_scope_tasks.dispatch_snapshot_browse(
+            organization_id=self.org.id,
+            directory_id=body.validated_data["directory_id"],
+            path=body.validated_data.get("path", ""),
+            limit=body.validated_data["limit"],
+            correlation_id=f"user:{request.user.id}:{uuid.uuid4()}",
+        )
+        return Response(
+            {"task_id": str(task.id), "status": str(task.status)},
+            status=status.HTTP_202_ACCEPTED,
+        )
+
+
+class LensCopilotSnapshotBrowseTaskView(OrgScopedMixin, APIView):
+    """Return only Insight browse tasks owned by the active organization."""
+
+    permission_classes = [IsAuthenticated, IsOrgStaffReader]
+
+    def get(self, request, task_id):
+        from apps.lens_bridge.services import snapshot_scope_tasks
+        from apps.node.models import NodeTask
+
+        try:
+            task = snapshot_scope_tasks.task_for_org(
+                organization=self.org,
+                task_id=str(task_id),
+            )
+        except ValidationError as exc:
+            raise NotFound("Insight snapshot operation was not found.") from exc
+        if (
+            task.correlation_type != snapshot_scope_tasks.BROWSE_CORRELATION_TYPE
+            or task.kind != "lens.snapshot.browse"
+            or not str(task.correlation_id or "").startswith(f"user:{request.user.id}:")
+        ):
+            raise NotFound("Insight snapshot operation was not found.")
+        payload = {
+            "task_id": str(task.id),
+            "status": str(task.status),
+            "error": (
+                "Unable to browse the selected snapshot. Try again."
+                if task.status
+                in {
+                    NodeTask.Status.FAILED,
+                    NodeTask.Status.TIMEOUT,
+                    NodeTask.Status.CANCELED,
+                }
+                else ""
+            ),
+        }
+        if task.status == NodeTask.Status.SUCCESS:
+            payload["entries"] = snapshot_scope_tasks.normalized_browse_entries(task)
+            result = task.result if isinstance(task.result, dict) else {}
+            payload["has_more"] = bool(result.get("has_more"))
+        return Response(payload)
 
 
 def _lens_error_response(exc: sl_client.LensBridgeError) -> Response:
@@ -852,6 +923,7 @@ class LensCopilotSessionViewSet(OrgScopedMixin, viewsets.ViewSet):
                 source_scopes=body.validated_data["source_scopes"],
                 gateway_mode=body.validated_data["gateway_mode"],
                 gateway_link_id=body.validated_data.get("gateway_link_id"),
+                idempotency_key=body.validated_data["idempotency_key"],
                 title=body.validated_data.get("title"),
             )
         except ValidationError:

--- a/src/backend/apps/lens_bridge/migrations/0031_session_create_and_capacity_state.py
+++ b/src/backend/apps/lens_bridge/migrations/0031_session_create_and_capacity_state.py
@@ -1,0 +1,163 @@
+import math
+
+from django.db import migrations, models
+
+_MAX_BIGINT = 2**63 - 1
+_MIN_BIGINT = -(2**63)
+
+
+def prepare_incomplete_session_reservations(apps, schema_editor):
+    """Make every in-flight legacy Chat rebuild its trusted reservation."""
+
+    del schema_editor
+    session_model = apps.get_model("lens_bridge", "LensSessionLink")
+    # Every row present while this migration runs predates durable reservations.
+    # Existing workspaces remain the usage authority until a new/retried Chat
+    # explicitly builds and reserves a trusted summary.
+    session_model.objects.update(
+        capacity_reservation_status="released",
+        capacity_reserved_bytes=0,
+        capacity_reserved_at=None,
+    )
+    rows = session_model.objects.filter(
+        lifecycle_status__in=("provisioning", "failed"),
+    ).only("id", "source_scopes_json")
+    for row in rows.iterator(chunk_size=500):
+        scopes = list(row.source_scopes_json or [])
+        summaries_complete = bool(scopes) and all(
+            _has_nonnegative_summary(scope) for scope in scopes
+        )
+        session_model.objects.filter(pk=row.pk).update(
+            scope_resolution_status=(
+                "resolved" if summaries_complete else "pending"
+            ),
+            capacity_reservation_status="pending",
+            capacity_reserved_bytes=0,
+            capacity_reserved_at=None,
+        )
+
+
+def _has_nonnegative_summary(scope):
+    if not isinstance(scope, dict):
+        return False
+    path_type = str(scope.get("path_type") or "").lower()
+    if path_type not in {"file", "dir"}:
+        return False
+    try:
+        file_count = _exact_int(scope["file_count"])
+        size_bytes = _exact_int(scope["size_bytes"])
+    except (KeyError, TypeError, ValueError, OverflowError):
+        return False
+    if file_count < 0 or size_bytes < 0:
+        return False
+    return path_type != "file" or file_count == 1
+
+
+def _exact_int(value):
+    if isinstance(value, bool):
+        raise ValueError("boolean is not an integer value")
+    if isinstance(value, int):
+        parsed = value
+    elif isinstance(value, float):
+        if not math.isfinite(value) or not value.is_integer():
+            raise ValueError("value must be an exact integer")
+        parsed = int(value)
+    elif isinstance(value, str):
+        parsed = int(value.strip())
+    else:
+        raise TypeError("value must be an integer")
+    if parsed < _MIN_BIGINT or parsed > _MAX_BIGINT:
+        raise OverflowError("value is outside the database integer range")
+    return parsed
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("lens_bridge", "0030_lens_run_submission"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="lenssessionlink",
+            name="provision_phase",
+            field=models.CharField(
+                choices=[
+                    ("queued", "Queued"),
+                    ("resolving_scope", "Validating selected data"),
+                    ("reserving_capacity", "Reserving gateway capacity"),
+                    ("restoring", "Restoring backup data"),
+                    ("converting", "Extracting document content"),
+                    ("creating_knowledge_source", "Creating knowledge source"),
+                    ("creating_assistant", "Creating assistant"),
+                    ("granting_assistant", "Granting assistant"),
+                    ("creating_session", "Creating chat session"),
+                    ("ready", "Ready"),
+                    ("cleaning_up", "Cleaning up"),
+                    ("deleting", "Deleting"),
+                    ("deleted", "Deleted"),
+                ],
+                db_index=True,
+                default="ready",
+                max_length=32,
+            ),
+        ),
+        migrations.AddField(
+            model_name="lenssessionlink",
+            name="create_idempotency_key",
+            field=models.CharField(blank=True, max_length=128, null=True),
+        ),
+        migrations.AddField(
+            model_name="lenssessionlink",
+            name="create_request_hash",
+            field=models.CharField(blank=True, default="", max_length=64),
+        ),
+        migrations.AddField(
+            model_name="lenssessionlink",
+            name="scope_resolution_status",
+            field=models.CharField(
+                choices=[("pending", "Pending"), ("resolved", "Resolved")],
+                db_index=True,
+                default="resolved",
+                max_length=16,
+            ),
+        ),
+        migrations.AddField(
+            model_name="lenssessionlink",
+            name="capacity_reservation_status",
+            field=models.CharField(
+                choices=[
+                    ("pending", "Pending"),
+                    ("reserved", "Reserved"),
+                    ("released", "Released"),
+                ],
+                db_index=True,
+                default="reserved",
+                max_length=16,
+            ),
+        ),
+        migrations.AddField(
+            model_name="lenssessionlink",
+            name="capacity_reserved_bytes",
+            field=models.BigIntegerField(default=0),
+        ),
+        migrations.AddField(
+            model_name="lenssessionlink",
+            name="capacity_reserved_at",
+            field=models.DateTimeField(blank=True, null=True),
+        ),
+        migrations.RunPython(
+            prepare_incomplete_session_reservations,
+            migrations.RunPython.noop,
+        ),
+        migrations.AddConstraint(
+            model_name="lenssessionlink",
+            constraint=models.UniqueConstraint(
+                condition=models.Q(
+                    create_idempotency_key__isnull=False,
+                    is_deleted=False,
+                ),
+                fields=("organization", "hfl_user", "create_idempotency_key"),
+                name="uniq_lens_session_create_key",
+            ),
+        ),
+    ]

--- a/src/backend/apps/lens_bridge/models/links.py
+++ b/src/backend/apps/lens_bridge/models/links.py
@@ -635,6 +635,8 @@ class LensSessionLink(OrganizationScopedModel):
 
     class ProvisionPhase(models.TextChoices):
         QUEUED = "queued", "Queued"
+        RESOLVING_SCOPE = "resolving_scope", "Validating selected data"
+        RESERVING_CAPACITY = "reserving_capacity", "Reserving gateway capacity"
         RESTORING = "restoring", "Restoring backup data"
         CONVERTING = "converting", "Extracting document content"
         CREATING_KNOWLEDGE_SOURCE = "creating_knowledge_source", "Creating knowledge source"
@@ -646,14 +648,43 @@ class LensSessionLink(OrganizationScopedModel):
         DELETING = "deleting", "Deleting"
         DELETED = "deleted", "Deleted"
 
+    class ScopeResolutionStatus(models.TextChoices):
+        PENDING = "pending", "Pending"
+        RESOLVED = "resolved", "Resolved"
+
+    class CapacityReservationStatus(models.TextChoices):
+        PENDING = "pending", "Pending"
+        RESERVED = "reserved", "Reserved"
+        RELEASED = "released", "Released"
+
     hfl_user = models.ForeignKey(
         settings.AUTH_USER_MODEL,
         on_delete=models.CASCADE,
         related_name="lens_session_links",
     )
+    create_idempotency_key = models.CharField(
+        max_length=128,
+        null=True,
+        blank=True,
+    )
+    create_request_hash = models.CharField(max_length=64, blank=True, default="")
     backup_config_id = models.BigIntegerField(null=True, blank=True, db_index=True)
     backup_source_snapshot_id = models.BigIntegerField(null=True, blank=True, db_index=True)
     source_scopes_json = models.JSONField(default=list, blank=True)
+    scope_resolution_status = models.CharField(
+        max_length=16,
+        choices=ScopeResolutionStatus.choices,
+        default=ScopeResolutionStatus.RESOLVED,
+        db_index=True,
+    )
+    capacity_reservation_status = models.CharField(
+        max_length=16,
+        choices=CapacityReservationStatus.choices,
+        default=CapacityReservationStatus.RESERVED,
+        db_index=True,
+    )
+    capacity_reserved_bytes = models.BigIntegerField(default=0)
+    capacity_reserved_at = models.DateTimeField(null=True, blank=True)
     gateway_link = models.ForeignKey(
         LensGatewayLink,
         on_delete=models.PROTECT,
@@ -724,6 +755,16 @@ class LensSessionLink(OrganizationScopedModel):
     class Meta:
         db_table = "lens_bridge_session_link"
         ordering = ["-last_message_at", "-created_at", "-id"]
+        constraints = [
+            models.UniqueConstraint(
+                fields=["organization", "hfl_user", "create_idempotency_key"],
+                condition=models.Q(
+                    create_idempotency_key__isnull=False,
+                    is_deleted=False,
+                ),
+                name="uniq_lens_session_create_key",
+            ),
+        ]
         indexes = [
             models.Index(
                 fields=["organization", "hfl_user", "status"],

--- a/src/backend/apps/lens_bridge/services/chat_lifecycle.py
+++ b/src/backend/apps/lens_bridge/services/chat_lifecycle.py
@@ -2,15 +2,19 @@
 
 from __future__ import annotations
 
+import hashlib
+import json
 import logging
+import math
 import uuid as uuid_lib
 from datetime import timedelta
 from typing import Any
 
 from django.contrib.auth.models import AbstractBaseUser
-from django.db import transaction
+from django.db import IntegrityError, transaction
 from django.utils import timezone
-from rest_framework.exceptions import ValidationError
+from rest_framework import status as http_status
+from rest_framework.exceptions import APIException, ValidationError
 
 from apps.iam.models import Organization
 from apps.lens_bridge.models import (
@@ -34,7 +38,11 @@ from apps.lens_bridge.services.teardown_claims import (
     TEARDOWN_CLAIM_TTL_SECONDS,
     next_retry_at,
 )
-from apps.protection.models import BackupConfig, BackupSourceSnapshot, BackupSourceSnapshotDirectory
+from apps.protection.models import (
+    BackupConfig,
+    BackupSourceSnapshot,
+    BackupSourceSnapshotDirectory,
+)
 from apps.protection.services.source_identity import resolve_source_display_name
 
 logger = logging.getLogger(__name__)
@@ -43,6 +51,9 @@ _ASSISTANT_CREATE_OPERATION = "assistant_create"
 _SESSION_CREATE_OPERATION = "session_create"
 _TEARDOWN_INTENT_DELETE = "delete_session"
 _TEARDOWN_INTENT_RESET_FOR_RETRY = "reset_for_retry"
+_SCOPE_TASK_STATE_KEY = "scope_resolution"
+_MAX_BIGINT = 2**63 - 1
+_MIN_BIGINT = -(2**63)
 
 
 class ChatProvisionLeaseLostError(RuntimeError):
@@ -51,6 +62,109 @@ class ChatProvisionLeaseLostError(RuntimeError):
 
 class ChatTeardownIncompleteError(RuntimeError):
     """Raised after durable teardown state is saved so Celery retries it."""
+
+
+class ChatCreateIdempotencyConflict(APIException):
+    """Raised when an idempotency key is reused for another Chat request."""
+
+    status_code = http_status.HTTP_409_CONFLICT
+    default_detail = "The chat request key was already used with different data."
+    default_code = "chat_create_idempotency_conflict"
+
+
+def _chat_create_request_identity(
+    *,
+    backup_config_id: int,
+    backup_source_snapshot_id: int,
+    source_scopes: list[dict[str, Any]],
+    gateway_mode: str,
+    gateway_link_id: int | None,
+    title: str | None,
+) -> tuple[str, list[dict[str, Any]]]:
+    """Return a stable request hash and normalized user-selected scopes."""
+
+    from apps.subscription.services.quota import normalize_scope_path
+
+    request_scopes: list[dict[str, Any]] = []
+    for index, scope in enumerate(source_scopes):
+        raw_path = str(scope.get("source_path") or "").strip()
+        try:
+            directory_id = int(scope.get("backup_snapshot_directory_id"))
+        except (TypeError, ValueError) as exc:
+            raise ValidationError(
+                {"source_scopes": {index: "Select a valid file or directory."}}
+            ) from exc
+        if not raw_path or directory_id <= 0:
+            raise ValidationError(
+                {"source_scopes": {index: "Select a valid file or directory."}}
+            )
+        selected_path = normalize_scope_path(raw_path)
+        request_scopes.append(
+            {
+                "source_path": selected_path,
+                "backup_snapshot_directory_id": directory_id,
+            }
+        )
+    if not request_scopes:
+        raise ValidationError({"source_scopes": "Select at least one file or folder."})
+
+    canonical_request = {
+        "backup_config_id": int(backup_config_id),
+        "backup_source_snapshot_id": int(backup_source_snapshot_id),
+        "source_scopes": request_scopes,
+        "gateway_mode": str(gateway_mode),
+        "gateway_link_id": (
+            int(gateway_link_id) if gateway_link_id is not None else None
+        ),
+        "title": str(title or "").strip(),
+    }
+    request_hash = hashlib.sha256(
+        json.dumps(
+            canonical_request,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()
+    return request_hash, request_scopes
+
+
+def _scope_has_trusted_summary(scope: Any) -> bool:
+    """Return whether a scope has a complete nonnegative Agent/root summary."""
+
+    if not isinstance(scope, dict):
+        return False
+    path_type = str(scope.get("path_type") or "").lower()
+    if path_type not in {"file", "dir"}:
+        return False
+    try:
+        file_count = _exact_summary_int(scope["file_count"])
+        size_bytes = _exact_summary_int(scope["size_bytes"])
+    except (KeyError, TypeError, ValueError, OverflowError):
+        return False
+    if file_count < 0 or size_bytes < 0:
+        return False
+    return path_type != "file" or file_count == 1
+
+
+def _exact_summary_int(value: Any) -> int:
+    """Parse one JSON integer without truncating fractional numeric values."""
+
+    if isinstance(value, bool):
+        raise ValueError("boolean is not an integer summary")
+    if isinstance(value, int):
+        parsed = value
+    elif isinstance(value, float):
+        if not math.isfinite(value) or not value.is_integer():
+            raise ValueError("summary must be an exact integer")
+        parsed = int(value)
+    elif isinstance(value, str):
+        parsed = int(value.strip())
+    else:
+        raise TypeError("summary must be an integer")
+    if parsed < _MIN_BIGINT or parsed > _MAX_BIGINT:
+        raise OverflowError("summary is outside the database integer range")
+    return parsed
 
 
 def _source_path_basename(path: str) -> str:
@@ -102,6 +216,44 @@ def _default_session_title(
     return _unique_session_title(org, user=user, base_title=base_title)
 
 
+def _configured_gateway_link_for_chat(
+    org: Organization,
+    *,
+    user: AbstractBaseUser,
+    gateway_mode: str,
+    gateway_link_id: int | None,
+):
+    """Select an authorized configured gateway using database state only."""
+
+    from apps.lens_bridge.models import LensGatewayLink
+
+    if gateway_mode == LensSessionLink.GatewaySelectionMode.AUTO:
+        platform_org = platform_lens.get_or_create_platform_org()
+        return (
+            LensGatewayLink.objects.filter(
+                organization=platform_org,
+                scope=LensGatewayLink.GatewayScope.PLATFORM,
+                sl_lensnode_uuid__isnull=False,
+                is_deleted=False,
+            )
+            .select_related("organization", "gateway")
+            .order_by("-is_platform_default", "created_at", "id")
+            .first()
+        )
+    return (
+        LensGatewayLink.objects.filter(
+            pk=gateway_link_id,
+            organization=org,
+            owner_user=user,
+            scope=LensGatewayLink.GatewayScope.USER,
+            sl_lensnode_uuid__isnull=False,
+            is_deleted=False,
+        )
+        .select_related("organization", "gateway")
+        .first()
+    )
+
+
 def start_copilot_chat(
     org: Organization,
     *,
@@ -112,11 +264,13 @@ def start_copilot_chat(
     """Legacy adapter for old clients that still submit a prepared binding."""
     if not binding.gateway_link_id:
         raise ValidationError({"gateway_link_id": "Data gateway is required."})
-    scopes = [{
-        "source_path": binding.source_path,
-        "backup_snapshot_directory_id": binding.backup_snapshot_directory_id,
-        "path_type": "unknown",
-    }]
+    scopes = [
+        {
+            "source_path": binding.source_path,
+            "backup_snapshot_directory_id": binding.backup_snapshot_directory_id,
+            "path_type": "unknown",
+        }
+    ]
     link = create_copilot_chat(
         org,
         user=user,
@@ -126,6 +280,7 @@ def start_copilot_chat(
         gateway_mode=LensSessionLink.GatewaySelectionMode.MANUAL,
         gateway_link_id=binding.gateway_link_id,
         title=title,
+        idempotency_key=str(uuid_lib.uuid4()),
     )
     link.chat_binding = binding
     link.save(update_fields=["chat_binding", "updated_at"])
@@ -142,10 +297,35 @@ def create_copilot_chat(
     source_scopes: list[dict[str, Any]],
     gateway_mode: str,
     gateway_link_id: int | None,
+    idempotency_key: str,
     title: str | None = None,
 ) -> LensSessionLink:
-    """Create the local Chat shell; all SourceLens resources are asynchronous."""
-    config = BackupConfig.objects.filter(id=backup_config_id, organization_id=org.id).first()
+    """Persist an idempotent local Chat shell without remote service calls."""
+    request_key = str(idempotency_key or "").strip()
+    if not request_key:
+        raise ValidationError({"idempotency_key": "A chat request key is required."})
+    request_hash, request_scopes = _chat_create_request_identity(
+        backup_config_id=backup_config_id,
+        backup_source_snapshot_id=backup_source_snapshot_id,
+        source_scopes=source_scopes,
+        gateway_mode=gateway_mode,
+        gateway_link_id=gateway_link_id,
+        title=title,
+    )
+    existing = LensSessionLink.objects.filter(
+        organization=org,
+        hfl_user=user,
+        create_idempotency_key=request_key,
+        is_deleted=False,
+    ).first()
+    if existing is not None:
+        if existing.create_request_hash != request_hash:
+            raise ChatCreateIdempotencyConflict()
+        return existing
+
+    config = BackupConfig.objects.filter(
+        id=backup_config_id, organization_id=org.id
+    ).first()
     if config is None:
         raise ValidationError({"backup_config_id": "Backup source not found."})
     snapshot = BackupSourceSnapshot.objects.filter(
@@ -154,94 +334,94 @@ def create_copilot_chat(
         backup_config_id=config.id,
     ).first()
     if snapshot is None:
-        raise ValidationError({"backup_source_snapshot_id": "Snapshot not found for this backup source."})
+        raise ValidationError(
+            {"backup_source_snapshot_id": "Snapshot not found for this backup source."}
+        )
 
     normalized_scopes: list[dict[str, Any]] = []
-    scope_directories: list[BackupSourceSnapshotDirectory] = []
     from apps.subscription.services.quota import (
-        assert_gateway_select_within_limits,
-        resolve_scope_entry,
-        summarize_gateway_select_scopes,
+        normalize_scope_path,
+        relative_scope_path,
     )
 
-    for index, scope in enumerate(source_scopes):
-        path = str(scope.get("source_path") or "").strip()
-        directory_id = scope.get("backup_snapshot_directory_id")
+    for index, scope in enumerate(request_scopes):
+        path = str(scope["source_path"])
+        directory_id = int(scope["backup_snapshot_directory_id"])
         directory = BackupSourceSnapshotDirectory.objects.filter(
             id=directory_id,
             source_snapshot_id=snapshot.id,
             status=BackupSourceSnapshotDirectory.Status.AVAILABLE,
         ).first()
         if not path or directory is None:
-            raise ValidationError({"source_scopes": {index: "Select a valid file or directory from this snapshot."}})
-        trusted_type, size_bytes = resolve_scope_entry(
-            organization_id=org.id,
-            directory=directory,
-            source_path=path,
-            claimed_type=str(scope.get("path_type") or "unknown"),
+            raise ValidationError(
+                {
+                    "source_scopes": {
+                        index: "Select a valid file or directory from this snapshot."
+                    }
+                }
+            )
+        root_path = str(directory.source_path)
+        relative_path = relative_scope_path(root=root_path, selected=path)
+        if path != normalize_scope_path(root_path) and not relative_path:
+            raise ValidationError(
+                {
+                    "source_scopes": {
+                        index: "Selected path is outside the snapshot directory."
+                    }
+                }
+            )
+        is_root = path == normalize_scope_path(root_path)
+        trusted_type = (
+            "file"
+            if is_root and str(directory.path_type or "").lower() == "file"
+            else "dir"
+            if is_root
+            else "unknown"
         )
         normalized = {
             "source_path": path,
             "backup_snapshot_directory_id": directory.id,
             "path_type": trusted_type,
         }
-        if size_bytes is not None:
-            normalized["size_bytes"] = int(size_bytes)
+        if is_root:
+            normalized["file_count"] = (
+                1
+                if trusted_type == "file"
+                else max(0, int(directory.file_count or 0))
+            )
+            normalized["size_bytes"] = max(0, int(directory.size_bytes or 0))
         normalized_scopes.append(normalized)
-        scope_directories.append(directory)
-    if not normalized_scopes:
-        raise ValidationError({"source_scopes": "Select at least one file or folder."})
-
-    total_files, total_bytes, unknown_directory = summarize_gateway_select_scopes(
-        normalized_scopes,
-        scope_directories,
+    all_scopes_resolved = all(
+        _scope_has_trusted_summary(scope) for scope in normalized_scopes
     )
-    assert_gateway_select_within_limits(
-        organization=org,
-        file_count=total_files,
-        size_bytes=total_bytes,
-        unknown_directory=unknown_directory,
+    gateway_link = _configured_gateway_link_for_chat(
+        org,
+        user=user,
+        gateway_mode=gateway_mode,
+        gateway_link_id=gateway_link_id,
     )
-
-    if gateway_mode == LensSessionLink.GatewaySelectionMode.AUTO:
-        gateway_link = platform_lens.resolve_auto_gateway_link_for_copilot(user=user)
-    else:
-        gateway_link = platform_lens.resolve_gateway_link_for_copilot(
-            org,
-            user=user,
-            gateway_link_id=gateway_link_id,
-        )
     if gateway_link is None:
         raise ValidationError(
-            {
-                "gateway_link_id": (
-                    platform_lens.NO_PUBLIC_DATA_GATEWAY_AVAILABLE
-                )
-            }
+            {"gateway_link_id": (platform_lens.NO_PUBLIC_DATA_GATEWAY_AVAILABLE)}
         )
 
-    from apps.lens_bridge.models import LensGatewayLink
     from apps.lens_bridge.services.gateway_execution import context_for_gateway_link
-    from apps.lens_bridge.services.public_gateway_capacity import (
-        assert_public_gateway_capacity,
-        lock_public_gateway_capacity,
-    )
-    from apps.subscription.services.interface import enforce_license_quota
 
     context_for_gateway_link(
         tenant_organization=org,
         gateway_link=gateway_link,
         expected_owner_user_id=(
-            user.id
-            if gateway_link.scope == gateway_link.GatewayScope.USER
-            else None
+            user.id if gateway_link.scope == gateway_link.GatewayScope.USER else None
         ),
+        require_ready=False,
     )
     model_ref, multimodal_model_ref = (
-        provisioning.default_model_refs_for_org(org)
+        provisioning.configured_default_model_refs_for_org(org)
     )
     if not model_ref:
-        raise ValidationError({"model": "Configure an active AI model before creating a chat."})
+        raise ValidationError(
+            {"model": "Configure an active AI model before creating a chat."}
+        )
 
     source_display_name = resolve_source_display_name(
         organization_id=org.id,
@@ -260,6 +440,8 @@ def create_copilot_chat(
         return LensSessionLink.objects.create(
             organization=org,
             hfl_user=user,
+            create_idempotency_key=request_key,
+            create_request_hash=request_hash,
             title=(title or "").strip() or default_title,
             backup_config_id=config.id,
             backup_source_snapshot_id=snapshot.id,
@@ -268,6 +450,15 @@ def create_copilot_chat(
             gateway_selection_mode=gateway_mode,
             agent_model_ref=model_ref,
             multimodal_model_ref=multimodal_model_ref,
+            scope_resolution_status=(
+                LensSessionLink.ScopeResolutionStatus.RESOLVED
+                if all_scopes_resolved
+                else LensSessionLink.ScopeResolutionStatus.PENDING
+            ),
+            capacity_reservation_status=(
+                LensSessionLink.CapacityReservationStatus.PENDING
+            ),
+            capacity_reserved_bytes=0,
             status=LensSessionLink.Status.ACTIVE,
             lifecycle_status=LensSessionLink.LifecycleStatus.PROVISIONING,
             provision_phase=LensSessionLink.ProvisionPhase.QUEUED,
@@ -275,69 +466,21 @@ def create_copilot_chat(
             lifecycle_error="",
         )
 
-    def _assert_org_public_capacity() -> None:
-        """Org pool share (GiB) across all Public Gateways."""
-        from common.errors import AppError
-        from common.extension_spi import get_quota_provider
-
-        provider = get_quota_provider()
-        if provider is None:
-            return
-        limits = provider.get_limits(org) or {}
-        # Missing key must not mean unlimited (fail closed).
-        if "max_public_gateway_capacity_gb" not in limits:
-            raise AppError(
-                code="SUBSCRIPTION.QUOTA_EXCEEDED",
-                status=403,
-                title=(
-                    "Organization public gateway capacity is unavailable. "
-                    "Contact your platform administrator."
-                ),
-                diagnostic="max_public_gateway_capacity_gb missing from quota limits",
-                meta={
-                    "quota_type": "max_public_gateway_capacity_gb",
-                    "scope": "organization",
-                },
-            )
-        limit = int(limits["max_public_gateway_capacity_gb"])
-        if limit < 0:
-            return
-        if unknown_directory:
-            raise AppError(
-                code="SUBSCRIPTION.QUOTA_EXCEEDED",
-                status=403,
-                title=(
-                    "Organization public gateway capacity cannot be proven for this "
-                    "selection. Contact your platform administrator."
-                ),
-                diagnostic="unknown public gateway selection size",
-                meta={
-                    "quota_type": "max_public_gateway_capacity_gb",
-                    "unknown_size": True,
-                    "limit": limit,
-                    "scope": "organization",
-                },
-            )
-        additional_gb = float(total_bytes) / float(1024**3)
-        enforce_license_quota(org, "max_public_gateway_capacity_gb", additional=additional_gb)
-
-    # Public Gateway: lock + infra/org capacity + PROVISIONING insert together so
-    # concurrent creates observe each other's reserved occupancy.
-    if gateway_link.scope == LensGatewayLink.GatewayScope.PLATFORM:
-        from apps.iam.models import Organization
-
-        # Serialize org capacity (layer 3) across different Public Gateways.
-        Organization.objects.select_for_update().get(pk=org.pk)
-        locked_gateway = lock_public_gateway_capacity(gateway_link=gateway_link)
-        assert_public_gateway_capacity(
-            gateway_link=locked_gateway,
-            additional_bytes=total_bytes,
-            unknown_size=unknown_directory,
-        )
-        _assert_org_public_capacity()
-        link = _create_session_link()
-    else:
-        link = _create_session_link()
+    try:
+        with transaction.atomic():
+            link = _create_session_link()
+    except IntegrityError:
+        link = LensSessionLink.objects.filter(
+            organization=org,
+            hfl_user=user,
+            create_idempotency_key=request_key,
+            is_deleted=False,
+        ).first()
+        if link is None:
+            raise
+        if link.create_request_hash != request_hash:
+            raise ChatCreateIdempotencyConflict()
+        return link
 
     transaction.on_commit(lambda: _queue_provision_or_mark_failed(link.id))
     return link
@@ -350,9 +493,7 @@ def request_copilot_chat_teardown(link: LensSessionLink) -> LensSessionLink:
     if locked.lifecycle_status == LensSessionLink.LifecycleStatus.DELETED:
         return locked
 
-    teardown_intent = str(
-        (locked.teardown_state_json or {}).get("intent") or ""
-    )
+    teardown_intent = str((locked.teardown_state_json or {}).get("intent") or "")
     delete_intent_already_active = (
         locked.lifecycle_status == LensSessionLink.LifecycleStatus.DELETING
         and teardown_intent == _TEARDOWN_INTENT_DELETE
@@ -408,16 +549,11 @@ def _claim_copilot_chat_provision(
             return None, "missing"
         if link.lifecycle_status != LensSessionLink.LifecycleStatus.PROVISIONING:
             return None, str(link.lifecycle_status)
-        if (
-            link.provision_claimed_at
-            and link.provision_claimed_at
-            > now - timedelta(seconds=PROVISION_CLAIM_TTL_SECONDS)
+        if link.provision_claimed_at and link.provision_claimed_at > now - timedelta(
+            seconds=PROVISION_CLAIM_TTL_SECONDS
         ):
             return None, "busy"
-        if (
-            link.provision_next_retry_at
-            and link.provision_next_retry_at > now
-        ):
+        if link.provision_next_retry_at and link.provision_next_retry_at > now:
             return None, "scheduled"
 
         claim_token = uuid_lib.uuid4()
@@ -527,18 +663,47 @@ def _run_copilot_chat_provision(
         raise ValidationError({"gateway_link": "Data gateway is missing."})
     scopes = list(link.source_scopes_json or [])
     if not scopes and binding is not None:
-        scopes = [{
-            "source_path": binding.source_path,
-            "backup_snapshot_directory_id": binding.backup_snapshot_directory_id,
-            "path_type": "unknown",
-        }]
+        scopes = [
+            {
+                "source_path": binding.source_path,
+                "backup_snapshot_directory_id": binding.backup_snapshot_directory_id,
+                "path_type": "unknown",
+            }
+        ]
     if not scopes:
         raise ValidationError({"source_scopes": "Backup content selection is missing."})
-    snapshot_id = link.backup_source_snapshot_id or (binding.backup_source_snapshot_id if binding else None)
+    snapshot_id = link.backup_source_snapshot_id or (
+        binding.backup_source_snapshot_id if binding else None
+    )
     if not snapshot_id:
-        raise ValidationError({"backup_source_snapshot_id": "Backup snapshot is missing."})
+        raise ValidationError(
+            {"backup_source_snapshot_id": "Backup snapshot is missing."}
+        )
     org = link.organization
     user = link.hfl_user
+
+    from apps.lens_bridge.services.gateway_execution import context_for_gateway_link
+
+    context_for_gateway_link(
+        tenant_organization=org,
+        gateway_link=gateway_link,
+        expected_owner_user_id=(
+            user.id if gateway_link.scope == gateway_link.GatewayScope.USER else None
+        ),
+        require_ready=True,
+    )
+
+    scope_result = _resolve_chat_scopes(
+        link=link,
+        claim_token=claim_token,
+        scopes=scopes,
+    )
+    if scope_result is not None:
+        return scope_result
+    link.refresh_from_db()
+    scopes = list(link.source_scopes_json or [])
+    _reserve_chat_capacity(link=link, claim_token=claim_token, scopes=scopes)
+    link.refresh_from_db()
 
     _set_phase(
         link,
@@ -552,7 +717,9 @@ def _run_copilot_chat_provision(
     ks = link.knowledge_source
     if ks is None:
         first_path = str(scopes[0].get("source_path") or "Copilot")
-        ks_name = f"{first_path.rstrip('/').split('/')[-1] or 'Copilot'} · Chat {link.id}"
+        ks_name = (
+            f"{first_path.rstrip('/').split('/')[-1] or 'Copilot'} · Chat {link.id}"
+        )
         first_directory_id = scopes[0].get("backup_snapshot_directory_id")
         ks = LensKnowledgeSource.objects.create(
             organization=org,
@@ -569,9 +736,7 @@ def _run_copilot_chat_provision(
                     "document": True,
                     "image": bool(link.multimodal_model_ref),
                     "embedded_image": bool(link.multimodal_model_ref),
-                    "pdf_render_scanned_pages": bool(
-                        link.multimodal_model_ref
-                    ),
+                    "pdf_render_scanned_pages": bool(link.multimodal_model_ref),
                     "vision_model_ref": (
                         str(link.multimodal_model_ref)
                         if link.multimodal_model_ref
@@ -597,9 +762,7 @@ def _run_copilot_chat_provision(
             else LensSessionLink.ProvisionPhase.RESTORING
         )
         if phase in {"push_assistant", "finalize"}:
-            provision_phase = (
-                LensSessionLink.ProvisionPhase.CREATING_KNOWLEDGE_SOURCE
-            )
+            provision_phase = LensSessionLink.ProvisionPhase.CREATING_KNOWLEDGE_SOURCE
         _set_phase(link, claim_token, provision_phase, detail)
 
     sync_result = knowledge_source_sync.run_knowledge_source_sync(
@@ -620,7 +783,9 @@ def _run_copilot_chat_provision(
         LensKnowledgeSource.Status.DEGRADED,
     ):
         raise ValidationError(
-            {"knowledge_source": f"Knowledge source sync did not complete ({ks.status})."}
+            {
+                "knowledge_source": f"Knowledge source sync did not complete ({ks.status})."
+            }
         )
 
     # 3) Create Assistant (SL Admin) and grant to Chat User.
@@ -755,6 +920,260 @@ def _run_copilot_chat_provision(
         "knowledge_source_id": ks.id,
         "sync": sync_result,
     }
+
+
+def _resolve_chat_scopes(
+    *,
+    link: LensSessionLink,
+    claim_token: str,
+    scopes: list[dict[str, Any]],
+) -> dict[str, Any] | None:
+    """Resolve one selected scope per pass and release the worker while pending."""
+
+    if link.scope_resolution_status == LensSessionLink.ScopeResolutionStatus.RESOLVED:
+        return None
+    from apps.lens_bridge.services import snapshot_scope_tasks
+    from apps.node.models import NodeTask
+    from apps.subscription.services.quota import normalize_scope_path
+
+    state = dict(link.provision_state_json or {})
+    scope_state = dict(state.get(_SCOPE_TASK_STATE_KEY) or {})
+    for index, scope in enumerate(scopes):
+        if _scope_has_trusted_summary(scope):
+            continue
+        _set_phase(
+            link,
+            claim_token,
+            LensSessionLink.ProvisionPhase.RESOLVING_SCOPE,
+            "Validating selected backup data.",
+        )
+        task_id = str(scope_state.get("task_id") or "")
+        task_index = scope_state.get("scope_index")
+        correlation_id = str(scope_state.get("correlation_id") or "")
+        task = None
+        if task_id and task_index == index:
+            task = snapshot_scope_tasks.scope_task_for_reference(
+                organization=link.organization,
+                task_id=task_id,
+                correlation_id=correlation_id,
+            )
+        if task is None and correlation_id and task_index == index:
+            task = snapshot_scope_tasks.scope_task_for_correlation(
+                organization=link.organization,
+                correlation_id=correlation_id,
+            )
+            if task is not None:
+                scope_state["task_id"] = str(task.id)
+                state[_SCOPE_TASK_STATE_KEY] = scope_state
+                link.provision_state_json = state
+                _update_provision_claim(
+                    link,
+                    claim_token,
+                    "provision_state_json",
+                )
+        if task is not None:
+            if task.status in {NodeTask.Status.PENDING, NodeTask.Status.RUNNING}:
+                return {
+                    "session_link_id": link.id,
+                    "status": "waiting",
+                    "scope_task_id": str(task.id),
+                }
+            if task.status != NodeTask.Status.SUCCESS:
+                logger.warning(
+                    "copilot scope validation failed session_link_id=%s "
+                    "node_task_id=%s task_status=%s error=%s",
+                    link.id,
+                    task.id,
+                    task.status,
+                    str(task.last_error or "")[:500],
+                )
+                raise ValidationError(
+                    {
+                        "source_scopes": (
+                            "Selected backup data could not be validated. "
+                            "Try again or choose another file or folder."
+                        )
+                    }
+                )
+            summary = snapshot_scope_tasks.resolved_scope_summary(task)
+            updated_scopes = list(scopes)
+            updated_scopes[index] = {
+                **scope,
+                **summary,
+            }
+            state.pop(_SCOPE_TASK_STATE_KEY, None)
+            link.source_scopes_json = updated_scopes
+            link.provision_state_json = state
+            link.scope_resolution_status = (
+                LensSessionLink.ScopeResolutionStatus.RESOLVED
+                if all(_scope_has_trusted_summary(row) for row in updated_scopes)
+                else LensSessionLink.ScopeResolutionStatus.PENDING
+            )
+            _update_provision_claim(
+                link,
+                claim_token,
+                "source_scopes_json",
+                "provision_state_json",
+                "scope_resolution_status",
+            )
+            return _resolve_chat_scopes(
+                link=link,
+                claim_token=claim_token,
+                scopes=updated_scopes,
+            )
+
+        directory = BackupSourceSnapshotDirectory.objects.filter(
+            id=scope.get("backup_snapshot_directory_id"),
+            source_snapshot_id=link.backup_source_snapshot_id,
+            organization_id=link.organization_id,
+            status=BackupSourceSnapshotDirectory.Status.AVAILABLE,
+        ).first()
+        if directory is None:
+            raise ValidationError(
+                {"source_scopes": "Snapshot directory is no longer available."}
+            )
+        selected = normalize_scope_path(str(scope.get("source_path") or ""))
+        root = normalize_scope_path(directory.source_path)
+        relative_path = (
+            "" if selected == root else selected[len(root.rstrip("/") + "/") :]
+        )
+        if not correlation_id or task_index != index:
+            correlation_id = f"chat:{link.id}:scope:{index}:{uuid_lib.uuid4().hex}"
+            state[_SCOPE_TASK_STATE_KEY] = {
+                "scope_index": index,
+                "correlation_id": correlation_id,
+            }
+            link.provision_state_json = state
+            _update_provision_claim(link, claim_token, "provision_state_json")
+        task = snapshot_scope_tasks.dispatch_scope_resolution(
+            organization_id=link.organization_id,
+            directory_id=directory.id,
+            path=relative_path,
+            correlation_id=correlation_id,
+        )
+        state[_SCOPE_TASK_STATE_KEY] = {
+            "scope_index": index,
+            "correlation_id": correlation_id,
+            "task_id": str(task.id),
+        }
+        link.provision_state_json = state
+        _update_provision_claim(link, claim_token, "provision_state_json")
+        return {
+            "session_link_id": link.id,
+            "status": "waiting",
+            "scope_task_id": str(task.id),
+        }
+
+    link.scope_resolution_status = LensSessionLink.ScopeResolutionStatus.RESOLVED
+    _update_provision_claim(link, claim_token, "scope_resolution_status")
+    return None
+
+
+@transaction.atomic
+def _reserve_chat_capacity(
+    *,
+    link: LensSessionLink,
+    claim_token: str,
+    scopes: list[dict[str, Any]],
+) -> None:
+    """Atomically validate trusted summaries and reserve Chat capacity once."""
+
+    locked = (
+        LensSessionLink.objects.select_for_update()
+        .select_related("gateway_link", "organization")
+        .filter(
+            pk=link.id,
+            lifecycle_status=LensSessionLink.LifecycleStatus.PROVISIONING,
+            provision_claim_token=claim_token,
+        )
+        .first()
+    )
+    if locked is None:
+        raise ChatProvisionLeaseLostError("Chat provisioning lease was lost.")
+    if (
+        locked.capacity_reservation_status
+        == LensSessionLink.CapacityReservationStatus.RESERVED
+    ):
+        return
+    if locked.scope_resolution_status != LensSessionLink.ScopeResolutionStatus.RESOLVED:
+        raise RuntimeError("Chat capacity cannot be reserved before scope resolution.")
+    if not scopes or not all(_scope_has_trusted_summary(scope) for scope in scopes):
+        raise RuntimeError("Chat capacity requires trusted scope summaries.")
+
+    total_files = sum(max(0, int(scope.get("file_count") or 0)) for scope in scopes)
+    total_bytes = sum(max(0, int(scope.get("size_bytes") or 0)) for scope in scopes)
+    if total_files > _MAX_BIGINT or total_bytes > _MAX_BIGINT:
+        raise RuntimeError("Chat scope totals exceed the supported integer range.")
+    from apps.lens_bridge.models import LensGatewayLink
+    from apps.subscription.services.quota import assert_gateway_select_within_limits
+
+    assert_gateway_select_within_limits(
+        organization=locked.organization,
+        file_count=total_files,
+        size_bytes=total_bytes,
+        unknown_directory=False,
+    )
+    if locked.gateway_link.scope == LensGatewayLink.GatewayScope.PLATFORM:
+        from common.errors import AppError
+        from common.extension_spi import get_quota_provider
+        from apps.lens_bridge.services.public_gateway_capacity import (
+            assert_public_gateway_capacity,
+            lock_public_gateway_capacity,
+        )
+        from apps.subscription.services.interface import enforce_license_quota
+
+        Organization.objects.select_for_update().get(pk=locked.organization_id)
+        gateway = lock_public_gateway_capacity(gateway_link=locked.gateway_link)
+        assert_public_gateway_capacity(
+            gateway_link=gateway,
+            additional_bytes=total_bytes,
+            unknown_size=False,
+        )
+        provider = get_quota_provider()
+        if provider is not None:
+            limits = provider.get_limits(locked.organization) or {}
+            if "max_public_gateway_capacity_gb" not in limits:
+                raise AppError(
+                    code="SUBSCRIPTION.QUOTA_EXCEEDED",
+                    status=403,
+                    title="Organization public gateway capacity is unavailable.",
+                    diagnostic="max_public_gateway_capacity_gb missing from quota limits",
+                    meta={
+                        "quota_type": "max_public_gateway_capacity_gb",
+                        "scope": "organization",
+                    },
+                )
+            enforce_license_quota(
+                locked.organization,
+                "max_public_gateway_capacity_gb",
+                additional=float(total_bytes) / float(1024**3),
+            )
+
+    now = timezone.now()
+    locked.provision_phase = LensSessionLink.ProvisionPhase.RESERVING_CAPACITY
+    locked.provision_detail = "Reserving Data Gateway capacity."
+    locked.capacity_reservation_status = (
+        LensSessionLink.CapacityReservationStatus.RESERVED
+    )
+    locked.capacity_reserved_bytes = total_bytes
+    locked.capacity_reserved_at = now
+    locked.provision_claimed_at = now
+    locked.save(
+        update_fields=[
+            "provision_phase",
+            "provision_detail",
+            "capacity_reservation_status",
+            "capacity_reserved_bytes",
+            "capacity_reserved_at",
+            "provision_claimed_at",
+            "updated_at",
+        ]
+    )
+    link.capacity_reservation_status = (
+        LensSessionLink.CapacityReservationStatus.RESERVED
+    )
+    link.capacity_reserved_bytes = total_bytes
+    link.capacity_reserved_at = now
 
 
 def _require_provision_claim(link_id: int, claim_token: str) -> None:
@@ -928,9 +1347,7 @@ def _bind_assistant_to_provision_claim(
     locked.provision_state_json = state
     locked.sl_assistant_uuid = assistant_uuid
     locked_knowledge_source.sl_assistant_uuid = assistant_uuid
-    locked_knowledge_source.save(
-        update_fields=["sl_assistant_uuid", "updated_at"]
-    )
+    locked_knowledge_source.save(update_fields=["sl_assistant_uuid", "updated_at"])
     assistant_access.ensure_assistant_link(
         org=locked.organization,
         sl_assistant_uuid=assistant_uuid,
@@ -1037,11 +1454,7 @@ def _find_remote_uuid(
             hfl_user=hfl_user,
         )
         items = _remote_items(raw)
-        matches = [
-            item
-            for item in items
-            if str(item.get(field) or "") == value
-        ]
+        matches = [item for item in items if str(item.get(field) or "") == value]
         if len(matches) > 1:
             raise sl_client.LensBridgeError(
                 f"SourceLens returned multiple {field}={value!r} resources."
@@ -1056,8 +1469,7 @@ def _find_remote_uuid(
         if isinstance(raw, list) or not items or len(items) < page_size:
             return None
         signature = tuple(
-            str(item.get("uuid") or item.get(field) or "")
-            for item in items
+            str(item.get("uuid") or item.get(field) or "") for item in items
         )
         if signature in seen_pages:
             raise sl_client.LensBridgeError(
@@ -1210,10 +1622,7 @@ def _orphan_knowledge_source_needs_enqueue(knowledge_source_id: int) -> bool:
     )
     if knowledge_source is None:
         return False
-    if (
-        knowledge_source.lifecycle_status
-        == LensKnowledgeSource.LifecycleStatus.DELETED
-    ):
+    if knowledge_source.lifecycle_status == LensKnowledgeSource.LifecycleStatus.DELETED:
         return False
     if (
         knowledge_source.teardown_claimed_at
@@ -1294,9 +1703,7 @@ def _record_late_source_lens_resource(
     link = LensSessionLink.objects.select_for_update().get(pk=link_id)
     existing = getattr(link, field)
     if existing not in {None, resource_uuid}:
-        resource_kind = (
-            "session" if field == "sl_session_uuid" else "assistant"
-        )
+        resource_kind = "session" if field == "sl_session_uuid" else "assistant"
         late_resources = _late_remote_uuids(link, resource_kind)
         late_resources.add(resource_uuid)
         _retain_failed_late_resources(
@@ -1398,17 +1805,19 @@ def _compensate_late_assistant(
 def _claim_copilot_chat_teardown(session_link_id: int) -> tuple[str | None, str]:
     now = timezone.now()
     with transaction.atomic():
-        link = LensSessionLink.objects.select_for_update().filter(pk=session_link_id).first()
+        link = (
+            LensSessionLink.objects.select_for_update()
+            .filter(pk=session_link_id)
+            .first()
+        )
         if link is None:
             return None, "missing"
         if link.lifecycle_status == LensSessionLink.LifecycleStatus.DELETED:
             return None, "deleted"
         if link.lifecycle_status != LensSessionLink.LifecycleStatus.DELETING:
             return None, str(link.lifecycle_status)
-        if (
-            link.teardown_claimed_at
-            and link.teardown_claimed_at
-            > now - timedelta(seconds=TEARDOWN_CLAIM_TTL_SECONDS)
+        if link.teardown_claimed_at and link.teardown_claimed_at > now - timedelta(
+            seconds=TEARDOWN_CLAIM_TTL_SECONDS
         ):
             return None, "busy"
         if link.teardown_next_retry_at and link.teardown_next_retry_at > now:
@@ -1433,7 +1842,10 @@ def _claim_copilot_chat_teardown(session_link_id: int) -> tuple[str | None, str]
 
 
 def _source_lens_not_found(exc: Exception) -> bool:
-    return isinstance(exc, sl_client.LensBridgeError) and getattr(exc, "status_code", None) == 404
+    return (
+        isinstance(exc, sl_client.LensBridgeError)
+        and getattr(exc, "status_code", None) == 404
+    )
 
 
 def _teardown_step(
@@ -1491,9 +1903,7 @@ def run_copilot_chat_teardown(*, session_link_id: int) -> dict[str, Any]:
     critical_errors: list[str] = []
     warnings: list[str] = []
     teardown_state = dict(link.teardown_state_json or {})
-    teardown_intent = str(
-        teardown_state.get("intent") or _TEARDOWN_INTENT_DELETE
-    )
+    teardown_intent = str(teardown_state.get("intent") or _TEARDOWN_INTENT_DELETE)
 
     if link.active_run_uuid:
         try:
@@ -1505,7 +1915,9 @@ def run_copilot_chat_teardown(*, session_link_id: int) -> dict[str, Any]:
         except Exception as exc:
             if not _source_lens_not_found(exc):
                 warnings.append(f"cancel_run: {exc}")
-                _teardown_step(teardown_state, "cancel_run", status="warning", error=str(exc))
+                _teardown_step(
+                    teardown_state, "cancel_run", status="warning", error=str(exc)
+                )
             else:
                 _teardown_step(teardown_state, "cancel_run", status="success")
         else:
@@ -1540,9 +1952,7 @@ def run_copilot_chat_teardown(*, session_link_id: int) -> dict[str, Any]:
             if not _source_lens_not_found(exc):
                 failed_session_uuids.append(session_uuid)
                 critical_errors.append(f"delete_session {session_uuid}: {exc}")
-    link.sl_session_uuid = (
-        failed_session_uuids[0] if failed_session_uuids else None
-    )
+    link.sl_session_uuid = failed_session_uuids[0] if failed_session_uuids else None
     if journal_session_uuid and journal_session_uuid not in failed_session_uuids:
         _set_operation_status(
             link,
@@ -1606,9 +2016,7 @@ def run_copilot_chat_teardown(*, session_link_id: int) -> dict[str, Any]:
                 assistant_access.soft_delete_assistant_link(org, assistant_uuid)
             except Exception as exc:
                 failed_assistant_uuids.append(assistant_uuid)
-                critical_errors.append(
-                    f"delete_assistant {assistant_uuid}: {exc}"
-                )
+                critical_errors.append(f"delete_assistant {assistant_uuid}: {exc}")
         link.sl_assistant_uuid = (
             failed_assistant_uuids[0] if failed_assistant_uuids else None
         )
@@ -1627,9 +2035,7 @@ def run_copilot_chat_teardown(*, session_link_id: int) -> dict[str, Any]:
             failed_assistant_uuids,
         )
         if ks is not None:
-            deleted_assistant_uuids = assistant_uuids.difference(
-                failed_assistant_uuids
-            )
+            deleted_assistant_uuids = assistant_uuids.difference(failed_assistant_uuids)
             if ks.sl_assistant_uuid in deleted_assistant_uuids:
                 LensKnowledgeSource.objects.filter(
                     pk=ks.id,
@@ -1702,7 +2108,9 @@ def run_copilot_chat_teardown(*, session_link_id: int) -> dict[str, Any]:
             _teardown_step(teardown_state, "cleanup_workspace", status="success")
         except Exception as exc:
             critical_errors.append(f"cleanup_workspace: {exc}")
-            _teardown_step(teardown_state, "cleanup_workspace", status="retry", error=str(exc))
+            _teardown_step(
+                teardown_state, "cleanup_workspace", status="retry", error=str(exc)
+            )
     elif ks is None:
         _teardown_step(teardown_state, "cleanup_workspace", status="success")
     else:
@@ -1774,6 +2182,11 @@ def run_copilot_chat_teardown(*, session_link_id: int) -> dict[str, Any]:
         teardown_claim_token=None,
         teardown_claimed_at=None,
         teardown_next_retry_at=link.teardown_next_retry_at,
+        capacity_reservation_status=(
+            LensSessionLink.CapacityReservationStatus.RELEASED
+            if not critical_errors
+            else link.capacity_reservation_status
+        ),
         updated_at=timezone.now(),
     )
     if updated != 1:
@@ -1805,6 +2218,7 @@ def _mark_provision_failed_by_id(
         provision_claim_token=None,
         provision_claimed_at=None,
         provision_next_retry_at=None,
+        capacity_reservation_status=LensSessionLink.CapacityReservationStatus.RELEASED,
         updated_at=timezone.now(),
     )
 
@@ -1882,77 +2296,6 @@ def retry_copilot_chat_provision(link: LensSessionLink) -> LensSessionLink:
     elif locked.lifecycle_status != LensSessionLink.LifecycleStatus.FAILED:
         raise ValidationError({"lifecycle_status": "Session is not retryable."})
 
-    # FAILED → PROVISIONING re-reserves capacity only when this session is not
-    # already represented via a linked knowledge_source / binding.
-    was_failed = locked.lifecycle_status == LensSessionLink.LifecycleStatus.FAILED
-    if (
-        was_failed
-        and locked.knowledge_source_id is None
-        and locked.gateway_link is not None
-    ):
-        from apps.lens_bridge.models import LensGatewayLink
-        from apps.lens_bridge.services.public_gateway_capacity import (
-            assert_public_gateway_capacity,
-            lock_public_gateway_capacity,
-            session_scope_occupancy,
-        )
-        from apps.subscription.services.interface import enforce_license_quota
-
-        if locked.gateway_link.scope == LensGatewayLink.GatewayScope.PLATFORM:
-            from apps.iam.models import Organization
-            from common.errors import AppError
-            from common.extension_spi import get_quota_provider
-
-            Organization.objects.select_for_update().get(pk=locked.organization_id)
-            locked_gateway = lock_public_gateway_capacity(gateway_link=locked.gateway_link)
-            nbytes, unknown = session_scope_occupancy(session=locked)
-            assert_public_gateway_capacity(
-                gateway_link=locked_gateway,
-                additional_bytes=nbytes,
-                unknown_size=unknown,
-            )
-            # Align with create: fail closed on unknown size when org capacity is finite.
-            provider = get_quota_provider()
-            if provider is not None:
-                limits = provider.get_limits(locked.organization) or {}
-                if "max_public_gateway_capacity_gb" not in limits:
-                    raise AppError(
-                        code="SUBSCRIPTION.QUOTA_EXCEEDED",
-                        status=403,
-                        title=(
-                            "Organization public gateway capacity is unavailable. "
-                            "Contact your platform administrator."
-                        ),
-                        diagnostic="max_public_gateway_capacity_gb missing from quota limits",
-                        meta={
-                            "quota_type": "max_public_gateway_capacity_gb",
-                            "scope": "organization",
-                        },
-                    )
-                org_cap = int(limits["max_public_gateway_capacity_gb"])
-                if org_cap >= 0 and unknown:
-                    raise AppError(
-                        code="SUBSCRIPTION.QUOTA_EXCEEDED",
-                        status=403,
-                        title=(
-                            "Organization public gateway capacity cannot be proven for this "
-                            "selection. Contact your platform administrator."
-                        ),
-                        diagnostic="unknown public gateway selection size on retry",
-                        meta={
-                            "quota_type": "max_public_gateway_capacity_gb",
-                            "unknown_size": True,
-                            "limit": org_cap,
-                            "scope": "organization",
-                        },
-                    )
-                if org_cap >= 0 and not unknown:
-                    enforce_license_quota(
-                        locked.organization,
-                        "max_public_gateway_capacity_gb",
-                        additional=float(nbytes) / float(1024**3),
-                    )
-
     locked.lifecycle_status = LensSessionLink.LifecycleStatus.PROVISIONING
     locked.provision_phase = LensSessionLink.ProvisionPhase.QUEUED
     locked.provision_detail = "Chat creation is queued."
@@ -1965,6 +2308,13 @@ def retry_copilot_chat_provision(link: LensSessionLink) -> LensSessionLink:
     locked.teardown_claimed_at = None
     locked.teardown_next_retry_at = None
     locked.teardown_state_json = {}
+    provision_state = dict(locked.provision_state_json or {})
+    provision_state.pop(_SCOPE_TASK_STATE_KEY, None)
+    locked.provision_state_json = provision_state
+    if locked.knowledge_source_id is None:
+        locked.capacity_reservation_status = (
+            LensSessionLink.CapacityReservationStatus.PENDING
+        )
     locked.save(
         update_fields=[
             "lifecycle_status",
@@ -1979,6 +2329,8 @@ def retry_copilot_chat_provision(link: LensSessionLink) -> LensSessionLink:
             "teardown_claimed_at",
             "teardown_next_retry_at",
             "teardown_state_json",
+            "provision_state_json",
+            "capacity_reservation_status",
             "updated_at",
         ]
     )
@@ -1992,16 +2344,16 @@ def _queue_provision_or_mark_failed(session_link_id: int) -> None:
     try:
         queue_copilot_chat_provision(session_link_id=session_link_id)
     except Exception as exc:
-        logger.exception("copilot chat provision dispatch failed session_link_id=%s", session_link_id)
+        logger.exception(
+            "copilot chat provision dispatch failed session_link_id=%s", session_link_id
+        )
         LensSessionLink.objects.filter(
             pk=session_link_id,
             lifecycle_status=LensSessionLink.LifecycleStatus.PROVISIONING,
             provision_claim_token__isnull=True,
         ).update(
             provision_phase=LensSessionLink.ProvisionPhase.QUEUED,
-            provision_detail=(
-                "Chat preparation is waiting for the worker queue."
-            ),
+            provision_detail=("Chat preparation is waiting for the worker queue."),
             lifecycle_error=str(exc)[:2000],
             provision_next_retry_at=timezone.now() + timedelta(seconds=60),
             updated_at=timezone.now(),
@@ -2014,7 +2366,9 @@ def _queue_teardown_or_record_error(session_link_id: int) -> None:
     try:
         queue_copilot_chat_teardown(session_link_id=session_link_id)
     except Exception as exc:
-        logger.exception("copilot chat teardown dispatch failed session_link_id=%s", session_link_id)
+        logger.exception(
+            "copilot chat teardown dispatch failed session_link_id=%s", session_link_id
+        )
         LensSessionLink.objects.filter(
             pk=session_link_id,
             lifecycle_status=LensSessionLink.LifecycleStatus.DELETING,
@@ -2084,7 +2438,10 @@ def _cleanup_failed_provision(
         except Exception as exc:
             if _source_lens_not_found(exc):
                 link.sl_session_uuid = None
-                if _operation_remote_uuid(link, _SESSION_CREATE_OPERATION) == session_uuid:
+                if (
+                    _operation_remote_uuid(link, _SESSION_CREATE_OPERATION)
+                    == session_uuid
+                ):
                     _set_operation_status(
                         link,
                         _SESSION_CREATE_OPERATION,
@@ -2107,9 +2464,14 @@ def _cleanup_failed_provision(
             from apps.lens_bridge.services.assistants import _delete_sl_assistant
 
             _delete_sl_assistant(assistant_uuid)
-            assistant_access.soft_delete_assistant_link(link.organization, assistant_uuid)
+            assistant_access.soft_delete_assistant_link(
+                link.organization, assistant_uuid
+            )
             link.sl_assistant_uuid = None
-            if _operation_remote_uuid(link, _ASSISTANT_CREATE_OPERATION) == assistant_uuid:
+            if (
+                _operation_remote_uuid(link, _ASSISTANT_CREATE_OPERATION)
+                == assistant_uuid
+            ):
                 _set_operation_status(
                     link,
                     _ASSISTANT_CREATE_OPERATION,
@@ -2157,5 +2519,7 @@ def _cleanup_failed_provision(
         "provision_state_json",
     )
     if errors:
-        logger.warning("partial Copilot cleanup session_link_id=%s errors=%s", link.id, errors)
+        logger.warning(
+            "partial Copilot cleanup session_link_id=%s errors=%s", link.id, errors
+        )
     return errors

--- a/src/backend/apps/lens_bridge/services/provisioning.py
+++ b/src/backend/apps/lens_bridge/services/provisioning.py
@@ -160,6 +160,69 @@ def default_model_refs_for_org(
     return agent_ref, multimodal_ref
 
 
+def configured_default_model_refs_for_org(
+    org: Organization,
+) -> tuple[str | None, str | None]:
+    """Resolve HFL-owned model defaults without calling SourceLens."""
+
+    from apps.lens_bridge.services import platform_lens
+
+    platform_org = platform_lens.get_or_create_platform_org()
+    org_defaults = get_or_create_org_link(org)
+    platform_defaults = (
+        org_defaults
+        if org.pk == platform_org.pk
+        else get_or_create_org_link(platform_org)
+    )
+
+    def _owned_default(owner: Organization, model_ref) -> str | None:
+        if not model_ref:
+            return None
+        exists = org_models.org_model_links(owner).filter(
+            sl_config_uuid=model_ref,
+            is_deployment_history=False,
+        ).exists()
+        return str(model_ref) if exists else None
+
+    agent_ref = None
+    if org.pk != platform_org.pk:
+        agent_ref = _owned_default(org, org_defaults.default_agent_model_ref)
+    if agent_ref is None:
+        agent_ref = _owned_default(
+            platform_org,
+            platform_defaults.default_agent_model_ref,
+        )
+    if agent_ref is None:
+        managed_agent = org_models.deployment_managed_model_uuid(
+            platform_org,
+            role="agent",
+        )
+        agent_ref = str(managed_agent) if managed_agent is not None else None
+
+    multimodal_ref = None
+    if org.pk != platform_org.pk:
+        multimodal_ref = _owned_default(
+            org,
+            org_defaults.default_multimodal_model_ref,
+        )
+    if multimodal_ref is None:
+        multimodal_ref = _owned_default(
+            platform_org,
+            platform_defaults.default_multimodal_model_ref,
+        )
+    if multimodal_ref is None:
+        managed_multimodal = org_models.deployment_managed_model_uuid(
+            platform_org,
+            role="multimodal",
+        )
+        multimodal_ref = (
+            str(managed_multimodal)
+            if managed_multimodal is not None
+            else None
+        )
+    return agent_ref, multimodal_ref
+
+
 def default_model_ref_for_org(org: Organization) -> str | None:
     """Resolve the effective Agent model for an organization."""
 

--- a/src/backend/apps/lens_bridge/services/public_gateway_capacity.py
+++ b/src/backend/apps/lens_bridge/services/public_gateway_capacity.py
@@ -8,9 +8,14 @@ Layers:
 
 from __future__ import annotations
 
+import math
+from typing import Any
+
 from common.errors import AppError
 
 _GIB = 1024**3
+_MAX_BIGINT = 2**63 - 1
+_MIN_BIGINT = -(2**63)
 
 # Legacy instance-wide runtime setting (migrated onto LensGatewayLink.capacity_gb).
 KEY_PUBLIC_GATEWAY_CAPACITY_GB = "gateway.public_total_capacity_gb"
@@ -19,6 +24,24 @@ _CAPACITY_FULL_MESSAGE = (
     "Public Data Gateway capacity is full. Contact your platform administrator "
     "to raise the workspace limit on this gateway."
 )
+
+
+def _exact_stored_int(value: Any) -> int:
+    if isinstance(value, bool):
+        raise ValueError("boolean is not an integer value")
+    if isinstance(value, int):
+        parsed = value
+    elif isinstance(value, float):
+        if not math.isfinite(value) or not value.is_integer():
+            raise ValueError("stored value must be an exact integer")
+        parsed = int(value)
+    elif isinstance(value, str):
+        parsed = int(value.strip())
+    else:
+        raise TypeError("stored value must be an integer")
+    if parsed < _MIN_BIGINT or parsed > _MAX_BIGINT:
+        raise OverflowError("stored value is outside the database integer range")
+    return parsed
 
 
 def _normalize_capacity_gb(capacity_gb: int) -> int:
@@ -62,10 +85,58 @@ def lock_public_gateway_capacity(*, gateway_link):
 
 def session_scope_occupancy(*, session) -> tuple[int, bool]:
     """Bytes + unknown flag for a session's stored source_scopes_json."""
+    if getattr(session, "capacity_reservation_status", "") == "reserved":
+        try:
+            reserved_bytes = _exact_stored_int(
+                getattr(session, "capacity_reserved_bytes", 0) or 0
+            )
+        except (TypeError, ValueError, OverflowError):
+            return 0, True
+        if reserved_bytes < 0:
+            return 0, True
+        return reserved_bytes, False
     return _occupancy_from_scope_dicts(
         organization_id=int(getattr(session, "organization_id", 0) or 0),
         scopes=list(getattr(session, "source_scopes_json", None) or []),
         re_resolve=False,
+    )
+
+
+def _metered_managed_restore_bindings(
+    *,
+    gateway_link_ids: list[int],
+    organization_id: int | None = None,
+):
+    """Return workspaces not currently represented by a Chat reservation."""
+
+    from django.db.models import Exists, OuterRef
+
+    from apps.lens_bridge.models import LensSessionLink, LensWorkspaceBinding
+
+    active_reservation = LensSessionLink.objects.filter(
+        organization_id=OuterRef("organization_id"),
+        knowledge_source_id=OuterRef("knowledge_source_id"),
+        gateway_link_id=OuterRef("gateway_link_id"),
+        lifecycle_status__in=(
+            LensSessionLink.LifecycleStatus.PROVISIONING,
+            LensSessionLink.LifecycleStatus.DELETING,
+        ),
+        capacity_reservation_status=(
+            LensSessionLink.CapacityReservationStatus.RESERVED
+        ),
+    )
+    filters = {
+        "gateway_link_id__in": gateway_link_ids,
+        "workspace_kind": LensWorkspaceBinding.WorkspaceKind.MANAGED_RESTORE,
+    }
+    if organization_id is not None:
+        filters["organization_id"] = int(organization_id)
+    return (
+        LensWorkspaceBinding.objects.filter(**filters)
+        .exclude(state=LensWorkspaceBinding.State.DELETED)
+        .annotate(has_chat_reservation=Exists(active_reservation))
+        .filter(has_chat_reservation=False)
+        .select_related("knowledge_source")
     )
 
 
@@ -75,12 +146,10 @@ def _occupancy_from_scope_dicts(
     scopes: list[dict],
     re_resolve: bool,
 ) -> tuple[int, bool]:
-    """Return (bytes, has_unknown) for a list of scope dicts."""
+    """Return stored (bytes, has_unknown) without Agent or browser I/O."""
+    del re_resolve  # retained for compatibility with current callers
     from apps.protection.models import BackupSourceSnapshotDirectory
-    from apps.subscription.services.quota import (
-        resolve_scope_entry,
-        summarize_gateway_select_scopes,
-    )
+    from apps.subscription.services.quota import summarize_gateway_select_scopes
 
     scope_entries = [scope for scope in scopes if isinstance(scope, dict)]
     if not scope_entries:
@@ -95,33 +164,75 @@ def _occupancy_from_scope_dicts(
         except (TypeError, ValueError):
             any_unknown = True
             continue
-        directory = BackupSourceSnapshotDirectory.objects.filter(id=directory_id).first()
+        directory_filters = {"id": directory_id}
+        if organization_id > 0:
+            directory_filters["organization_id"] = organization_id
+        directory = BackupSourceSnapshotDirectory.objects.filter(
+            **directory_filters
+        ).first()
         if directory is None:
             any_unknown = True
             continue
         path = str(scope.get("source_path") or directory.source_path or "")
-        if re_resolve:
-            path_type, size_bytes = resolve_scope_entry(
-                organization_id=organization_id or int(directory.organization_id),
-                directory=directory,
-                source_path=path,
-                claimed_type=str(scope.get("path_type") or "unknown"),
+        resolved = {
+            "source_path": path,
+            "path_type": str(scope.get("path_type") or "unknown"),
+        }
+        has_summary = (
+            scope.get("size_bytes") is not None
+            and scope.get("file_count") is not None
+        )
+        if has_summary:
+            try:
+                size_bytes = _exact_stored_int(scope["size_bytes"])
+                file_count = _exact_stored_int(scope["file_count"])
+            except (TypeError, ValueError, OverflowError):
+                any_unknown = True
+                continue
+            summary_valid = (
+                resolved["path_type"] in {"file", "dir"}
+                and size_bytes >= 0
+                and file_count >= 0
+                and (
+                    resolved["path_type"] != "file"
+                    or file_count == 1
+                )
             )
-            resolved: dict = {"source_path": path, "path_type": path_type}
-            if size_bytes is not None:
-                resolved["size_bytes"] = int(size_bytes)
-        else:
-            resolved = {
-                "source_path": path,
-                "path_type": str(scope.get("path_type") or "unknown"),
-            }
-            if "size_bytes" in scope and scope.get("size_bytes") is not None:
-                resolved["size_bytes"] = int(scope["size_bytes"])
+            if not summary_valid:
+                any_unknown = True
+                continue
+            resolved["size_bytes"] = size_bytes
+            resolved["file_count"] = file_count
+        elif "size_bytes" in scope and scope.get("size_bytes") is not None:
+            try:
+                legacy_size_bytes = _exact_stored_int(scope["size_bytes"])
+            except (TypeError, ValueError, OverflowError):
+                any_unknown = True
+            else:
+                if legacy_size_bytes < 0:
+                    any_unknown = True
+                else:
+                    resolved["size_bytes"] = legacy_size_bytes
         paired_scopes.append(resolved)
         paired_dirs.append(directory)
     if not paired_scopes:
         return 0, True
-    _files, nbytes, unknown = summarize_gateway_select_scopes(paired_scopes, paired_dirs)
+    trusted_bytes = sum(
+        max(0, int(scope.get("size_bytes") or 0))
+        for scope in paired_scopes
+        if "file_count" in scope
+    )
+    legacy_scopes = [scope for scope in paired_scopes if "file_count" not in scope]
+    legacy_dirs = [
+        directory
+        for scope, directory in zip(paired_scopes, paired_dirs, strict=True)
+        if "file_count" not in scope
+    ]
+    _files, legacy_bytes, unknown = summarize_gateway_select_scopes(
+        legacy_scopes,
+        legacy_dirs,
+    )
+    nbytes = trusted_bytes + legacy_bytes
     return int(nbytes or 0), bool(any_unknown or unknown)
 
 
@@ -131,10 +242,10 @@ def bulk_public_gateway_used_bytes(
     """
     Logical occupancy keyed by gateway_link_id.
 
-    Counts managed-restore workspace bindings + PROVISIONING sessions that have
-    not yet linked a knowledge_source (reservation without double-count).
+    Counts managed-restore workspaces, except while a PROVISIONING Chat's
+    durable reservation is authoritative for that workspace.
     """
-    from apps.lens_bridge.models import LensSessionLink, LensWorkspaceBinding
+    from apps.lens_bridge.models import LensSessionLink
     from apps.lens_bridge.services import platform_lens
 
     if link_ids is None:
@@ -147,13 +258,8 @@ def bulk_public_gateway_used_bytes(
     totals: dict[int, int] = {link_id: 0 for link_id in ids}
     unknowns: dict[int, bool] = {link_id: False for link_id in ids}
 
-    bindings = (
-        LensWorkspaceBinding.objects.filter(
-            gateway_link_id__in=ids,
-            workspace_kind=LensWorkspaceBinding.WorkspaceKind.MANAGED_RESTORE,
-        )
-        .exclude(state=LensWorkspaceBinding.State.DELETED)
-        .select_related("knowledge_source")
+    bindings = _metered_managed_restore_bindings(
+        gateway_link_ids=ids,
     )
     for binding in bindings:
         link_id = int(binding.gateway_link_id)
@@ -171,17 +277,17 @@ def bulk_public_gateway_used_bytes(
 
     provisioning = LensSessionLink.objects.filter(
         gateway_link_id__in=ids,
-        lifecycle_status=LensSessionLink.LifecycleStatus.PROVISIONING,
-        status=LensSessionLink.Status.ACTIVE,
-        knowledge_source_id__isnull=True,
-    ).only("id", "organization_id", "source_scopes_json", "gateway_link_id")
+        lifecycle_status__in=(
+            LensSessionLink.LifecycleStatus.PROVISIONING,
+            LensSessionLink.LifecycleStatus.DELETING,
+        ),
+        capacity_reservation_status=(
+            LensSessionLink.CapacityReservationStatus.RESERVED
+        ),
+    ).only("id", "capacity_reserved_bytes", "gateway_link_id")
     for session in provisioning:
         link_id = int(session.gateway_link_id)
-        nbytes, unknown = _occupancy_from_scope_dicts(
-            organization_id=int(session.organization_id),
-            scopes=list(session.source_scopes_json or []),
-            re_resolve=False,
-        )
+        nbytes, unknown = session_scope_occupancy(session=session)
         totals[link_id] = totals.get(link_id, 0) + nbytes
         unknowns[link_id] = bool(unknowns.get(link_id) or unknown)
 
@@ -205,28 +311,25 @@ def org_public_gateway_used_bytes(*, organization_id: int) -> tuple[int, bool]:
 
     Sums managed-restore bindings + provisioning reservations for this org.
     """
-    from apps.lens_bridge.models import LensSessionLink, LensWorkspaceBinding
+    from apps.lens_bridge.models import LensSessionLink
     from apps.lens_bridge.services import platform_lens
 
     org_id = int(organization_id)
     if org_id <= 0:
         return 0, False
 
-    platform_ids = list(platform_lens.platform_gateway_links().values_list("id", flat=True))
+    platform_ids = list(
+        platform_lens.platform_gateway_links().values_list("id", flat=True)
+    )
     if not platform_ids:
         return 0, False
 
     total = 0
     any_unknown = False
 
-    bindings = (
-        LensWorkspaceBinding.objects.filter(
-            organization_id=org_id,
-            gateway_link_id__in=platform_ids,
-            workspace_kind=LensWorkspaceBinding.WorkspaceKind.MANAGED_RESTORE,
-        )
-        .exclude(state=LensWorkspaceBinding.State.DELETED)
-        .select_related("knowledge_source")
+    bindings = _metered_managed_restore_bindings(
+        gateway_link_ids=platform_ids,
+        organization_id=org_id,
     )
     for binding in bindings:
         ks = binding.knowledge_source
@@ -243,16 +346,16 @@ def org_public_gateway_used_bytes(*, organization_id: int) -> tuple[int, bool]:
     provisioning = LensSessionLink.objects.filter(
         organization_id=org_id,
         gateway_link_id__in=platform_ids,
-        lifecycle_status=LensSessionLink.LifecycleStatus.PROVISIONING,
-        status=LensSessionLink.Status.ACTIVE,
-        knowledge_source_id__isnull=True,
-    ).only("id", "organization_id", "source_scopes_json", "gateway_link_id")
+        lifecycle_status__in=(
+            LensSessionLink.LifecycleStatus.PROVISIONING,
+            LensSessionLink.LifecycleStatus.DELETING,
+        ),
+        capacity_reservation_status=(
+            LensSessionLink.CapacityReservationStatus.RESERVED
+        ),
+    ).only("id", "capacity_reserved_bytes", "gateway_link_id")
     for session in provisioning:
-        nbytes, unknown = _occupancy_from_scope_dicts(
-            organization_id=org_id,
-            scopes=list(session.source_scopes_json or []),
-            re_resolve=False,
-        )
+        nbytes, unknown = session_scope_occupancy(session=session)
         total += nbytes
         any_unknown = bool(any_unknown or unknown)
 
@@ -261,7 +364,9 @@ def org_public_gateway_used_bytes(*, organization_id: int) -> tuple[int, bool]:
 
 def org_public_gateway_capacity_used_gb(*, organization_id: int) -> float:
     """GiB used by one org across Public Gateways (for EffectiveQuota meters)."""
-    used_bytes, _unknown = org_public_gateway_used_bytes(organization_id=organization_id)
+    used_bytes, _unknown = org_public_gateway_used_bytes(
+        organization_id=organization_id
+    )
     return round(float(used_bytes) / float(_GIB), 6)
 
 
@@ -319,7 +424,9 @@ def assert_public_gateway_capacity(
 
 def public_gateway_capacity_payload(*, gateway_link) -> dict:
     limit_gb = get_public_gateway_capacity_gb(gateway_link=gateway_link)
-    used_bytes, used_unknown = public_gateway_used_bytes(gateway_link_id=int(gateway_link.pk))
+    used_bytes, used_unknown = public_gateway_used_bytes(
+        gateway_link_id=int(gateway_link.pk)
+    )
     gateway = getattr(gateway_link, "gateway", None)
     return {
         "gateway_link_id": int(gateway_link.pk),
@@ -338,7 +445,9 @@ def list_public_gateway_capacity_payloads() -> list[dict]:
     """Capacity payload for every platform Public Gateway link."""
     from apps.lens_bridge.services import platform_lens
 
-    links = list(platform_lens.platform_gateway_links().select_related("gateway").order_by("id"))
+    links = list(
+        platform_lens.platform_gateway_links().select_related("gateway").order_by("id")
+    )
     used_map = bulk_public_gateway_used_bytes([int(link.id) for link in links])
     payloads = []
     for link in links:

--- a/src/backend/apps/lens_bridge/services/snapshot_scope_tasks.py
+++ b/src/backend/apps/lens_bridge/services/snapshot_scope_tasks.py
@@ -1,0 +1,335 @@
+"""Asynchronous snapshot operations owned by the Insight product surface."""
+
+from __future__ import annotations
+
+import ntpath
+import posixpath
+import math
+from typing import Any
+
+from rest_framework.exceptions import ValidationError
+
+from apps.iam.models import Organization
+from apps.node.models import NodeTask
+from apps.node.selectors.interface import (
+    get_node_task_by_correlation,
+    get_node_task_for_org,
+)
+from apps.node.services.interface import run_agent_task_async
+from apps.protection.models import BackupSourceSnapshot, BackupSourceSnapshotDirectory
+from apps.protection.services.backup_task import _resolve_execution_target
+from apps.protection.services.snapshot_repository_locator import (
+    resolve_snapshot_repository_reader,
+)
+from apps.storage.repositories.models import Repository
+from apps.storage.services.internal.repository_access import (
+    repository_uses_bound_proxy,
+)
+
+BROWSE_CORRELATION_TYPE = "lens_bridge.snapshot_browse"
+SCOPE_CORRELATION_TYPE = "lens_bridge.scope_resolve"
+_MAX_BIGINT = 2**63 - 1
+_MIN_BIGINT = -(2**63)
+
+
+def _clean_relative_path(path: str) -> str:
+    value = str(path or "").strip().replace("\\", "/")
+    if not value:
+        return ""
+    if "\x00" in value or value.startswith("/") or ntpath.splitdrive(value)[0]:
+        raise ValidationError({"path": "Snapshot path must be relative."})
+    parts = [part for part in value.split("/") if part not in ("", ".")]
+    if any(part == ".." for part in parts):
+        raise ValidationError(
+            {"path": "Snapshot path cannot contain a parent traversal."}
+        )
+    return posixpath.normpath("/".join(parts)) if parts else ""
+
+
+def _directory_for_org(
+    *,
+    organization_id: int,
+    directory_id: int,
+) -> BackupSourceSnapshotDirectory:
+    directory = (
+        BackupSourceSnapshotDirectory.objects.select_related("source_snapshot")
+        .filter(
+            organization_id=organization_id,
+            id=directory_id,
+            status=BackupSourceSnapshotDirectory.Status.AVAILABLE,
+        )
+        .first()
+    )
+    if directory is None:
+        raise ValidationError({"directory_id": "Snapshot directory is not available."})
+    if directory.source_snapshot.status not in {
+        BackupSourceSnapshot.Status.AVAILABLE,
+        BackupSourceSnapshot.Status.PARTIAL,
+    }:
+        raise ValidationError({"directory_id": "Snapshot is not available."})
+    if not str(directory.kopia_snapshot_id or "").strip():
+        raise ValidationError(
+            {"directory_id": "Snapshot directory has no snapshot identifier."}
+        )
+    return directory
+
+
+def dispatch_snapshot_operation(
+    *,
+    organization_id: int,
+    directory_id: int,
+    path: str,
+    kind: str,
+    correlation_type: str,
+    correlation_id: str,
+    extra_payload: dict[str, Any] | None = None,
+    directory: BackupSourceSnapshotDirectory | None = None,
+) -> NodeTask:
+    """Dispatch one Insight snapshot operation without waiting for the Agent."""
+
+    directory = directory or _directory_for_org(
+        organization_id=organization_id,
+        directory_id=directory_id,
+    )
+    repository = (
+        Repository.objects.filter(
+            organization_id=organization_id,
+            id=directory.repository_id,
+        )
+        .exclude(status=Repository.Status.REMOVED)
+        .first()
+    )
+    if repository is None:
+        raise ValidationError({"directory_id": "Snapshot repository is not available."})
+    fallback_target = None
+    if not repository_uses_bound_proxy(repository):
+        fallback_target = _resolve_execution_target(
+            source_snapshot=directory.source_snapshot,
+        )
+    access = resolve_snapshot_repository_reader(
+        directory=directory,
+        repository=repository,
+        fallback_node=(fallback_target.node if fallback_target is not None else None),
+        source_type=directory.source_snapshot.source_type,
+        source_ref_id=directory.source_snapshot.source_ref_id,
+    )
+    clean_path = _clean_relative_path(path)
+    delivery_payload = {
+        "repository": access.repository_payload,
+        "snapshot_id": directory.kopia_snapshot_id,
+        "path": clean_path,
+        **(extra_payload or {}),
+    }
+    persisted_payload = {
+        "snapshot_directory_id": directory.id,
+        "snapshot_id": directory.kopia_snapshot_id,
+        "path": clean_path,
+        **(extra_payload or {}),
+    }
+    handle = run_agent_task_async(
+        organization_id=organization_id,
+        node_id=access.node.id,
+        kind=kind,
+        payload=delivery_payload,
+        persisted_payload=persisted_payload,
+        correlation_type=correlation_type,
+        correlation_id=correlation_id,
+        requesting_organization_id=organization_id,
+    )
+    return handle.task
+
+
+def dispatch_snapshot_browse(
+    *,
+    organization_id: int,
+    directory_id: int,
+    path: str,
+    limit: int,
+    correlation_id: str,
+) -> NodeTask:
+    return dispatch_snapshot_operation(
+        organization_id=organization_id,
+        directory_id=directory_id,
+        path=path,
+        kind="lens.snapshot.browse",
+        correlation_type=BROWSE_CORRELATION_TYPE,
+        correlation_id=correlation_id,
+        extra_payload={"limit": max(1, min(int(limit), 500))},
+    )
+
+
+def dispatch_scope_resolution(
+    *,
+    organization_id: int,
+    directory_id: int,
+    path: str,
+    correlation_id: str,
+) -> NodeTask:
+    directory = _directory_for_org(
+        organization_id=organization_id,
+        directory_id=directory_id,
+    )
+    extra_payload = None
+    if (
+        not _clean_relative_path(path)
+        and directory.path_type == BackupSourceSnapshotDirectory.PathType.FILE
+    ):
+        extra_payload = {
+            "root_path_type": "file",
+            "root_size_bytes": max(0, int(directory.size_bytes or 0)),
+        }
+    return dispatch_snapshot_operation(
+        organization_id=organization_id,
+        directory_id=directory_id,
+        path=path,
+        kind="lens.snapshot.scope.resolve",
+        correlation_type=SCOPE_CORRELATION_TYPE,
+        correlation_id=correlation_id,
+        extra_payload=extra_payload,
+        directory=directory,
+    )
+
+
+def task_for_org(*, organization: Organization, task_id: str) -> NodeTask:
+    task = get_node_task_for_org(org=organization, task_id=task_id)
+    if task is None:
+        raise ValidationError({"task_id": "Insight snapshot operation was not found."})
+    return task
+
+
+def scope_task_for_correlation(
+    *,
+    organization: Organization,
+    correlation_id: str,
+) -> NodeTask | None:
+    """Recover a previously dispatched Chat scope task after worker interruption."""
+
+    task = get_node_task_by_correlation(
+        org=organization,
+        correlation_type=SCOPE_CORRELATION_TYPE,
+        correlation_id=correlation_id,
+    )
+    if task is None or task.kind != "lens.snapshot.scope.resolve":
+        return None
+    return task
+
+
+def scope_task_for_reference(
+    *,
+    organization: Organization,
+    task_id: str,
+    correlation_id: str,
+) -> NodeTask | None:
+    """Resolve only the scope task represented by one durable correlation."""
+
+    task = get_node_task_for_org(org=organization, task_id=task_id)
+    if task is None:
+        return None
+    if (
+        task.kind != "lens.snapshot.scope.resolve"
+        or task.correlation_type != SCOPE_CORRELATION_TYPE
+        or str(task.correlation_id or "") != str(correlation_id or "")
+    ):
+        return None
+    return task
+
+
+def normalized_browse_entries(
+    task: NodeTask, *, limit: int = 500
+) -> list[dict[str, Any]]:
+    result = task.result if isinstance(task.result, dict) else {}
+    rows: list[dict[str, Any]] = []
+    for item in list(result.get("entries") or [])[: max(1, min(int(limit), 2000))]:
+        if not isinstance(item, dict):
+            continue
+        try:
+            path = _clean_relative_path(str(item.get("path") or ""))
+        except ValidationError:
+            continue
+        name = posixpath.basename(
+            str(item.get("name") or path).strip().replace("\\", "/").rstrip("/")
+        )
+        if not path or not name or name in {".", ".."}:
+            continue
+        entry_type = str(item.get("type") or "").strip().lower()
+        is_directory = bool(item.get("is_dir")) or entry_type in {
+            "dir",
+            "directory",
+            "folder",
+            "d",
+        }
+        rows.append(
+            {
+                "name": name,
+                "path": path,
+                "type": "dir" if is_directory else "file",
+                "size_bytes": _nonnegative_int(
+                    item.get("size_bytes", item.get("size", 0))
+                ),
+                "modified_at": item.get("modified_at") or item.get("mod_time") or None,
+                "downloadable": item.get("downloadable", True) is not False,
+                "has_children": item.get("has_children"),
+            }
+        )
+    return rows
+
+
+def _nonnegative_int(value: Any) -> int:
+    try:
+        return max(0, int(value or 0))
+    except (TypeError, ValueError, OverflowError):
+        return 0
+
+
+def resolved_scope_summary(task: NodeTask) -> dict[str, int | str]:
+    result = task.result if isinstance(task.result, dict) else {}
+    path_type = str(result.get("path_type") or "").strip().lower()
+    if path_type not in {"file", "dir"}:
+        raise RuntimeError("Agent returned an invalid Insight scope type.")
+    try:
+        file_count = _exact_result_int(result["file_count"])
+        size_bytes = _exact_result_int(result["size_bytes"])
+    except (KeyError, TypeError, ValueError, OverflowError) as exc:
+        raise RuntimeError("Agent returned an invalid Insight scope summary.") from exc
+    if (
+        file_count < 0
+        or size_bytes < 0
+        or (path_type == "file" and file_count != 1)
+    ):
+        raise RuntimeError("Agent returned an invalid Insight scope summary.")
+    return {
+        "path_type": path_type,
+        "file_count": file_count,
+        "size_bytes": size_bytes,
+    }
+
+
+def _exact_result_int(value: Any) -> int:
+    if isinstance(value, bool):
+        raise ValueError("boolean is not an integer result")
+    if isinstance(value, int):
+        parsed = value
+    elif isinstance(value, float):
+        if not math.isfinite(value) or not value.is_integer():
+            raise ValueError("result must be an exact integer")
+        parsed = int(value)
+    elif isinstance(value, str):
+        parsed = int(value.strip())
+    else:
+        raise TypeError("result must be an integer")
+    if parsed < _MIN_BIGINT or parsed > _MAX_BIGINT:
+        raise OverflowError("result is outside the database integer range")
+    return parsed
+
+
+__all__ = [
+    "BROWSE_CORRELATION_TYPE",
+    "SCOPE_CORRELATION_TYPE",
+    "dispatch_scope_resolution",
+    "dispatch_snapshot_browse",
+    "normalized_browse_entries",
+    "resolved_scope_summary",
+    "scope_task_for_correlation",
+    "scope_task_for_reference",
+    "task_for_org",
+]

--- a/src/backend/apps/lens_bridge/tasks/chat_lifecycle.py
+++ b/src/backend/apps/lens_bridge/tasks/chat_lifecycle.py
@@ -21,6 +21,7 @@ _PROVISION_TIME_LIMIT = PROVISION_TASK_HARD_LIMIT_SECONDS
 _PROVISION_SOFT_LIMIT = max(60, _PROVISION_TIME_LIMIT - 300)
 _TEARDOWN_TIME_LIMIT = TEARDOWN_TASK_HARD_LIMIT_SECONDS
 _TEARDOWN_SOFT_LIMIT = max(60, _TEARDOWN_TIME_LIMIT - 300)
+_CHAT_PROVISION_WAIT_SECONDS = 5
 
 
 @shared_task(
@@ -42,13 +43,9 @@ def execute_copilot_chat_provision_task(self, *, session_link_id: int) -> dict:
         logger.info("copilot chat provision celery started session_link_id=%s", session_link_id)
         result = run_copilot_chat_provision(session_link_id=int(session_link_id))
         if result.get("status") == "waiting":
-            from apps.lens_bridge.services.managed_datasource import (
-                CONVERSION_RETRY_SECONDS,
-            )
-
             self.apply_async(
                 kwargs={"session_link_id": int(session_link_id)},
-                countdown=CONVERSION_RETRY_SECONDS,
+                countdown=_CHAT_PROVISION_WAIT_SECONDS,
             )
         logger.info(
             "copilot chat provision celery finished session_link_id=%s status=%s",

--- a/src/backend/apps/lens_bridge/tests/test_chat_lifecycle_queue.py
+++ b/src/backend/apps/lens_bridge/tests/test_chat_lifecycle_queue.py
@@ -54,9 +54,7 @@ class CopilotLifecycleQueueTests(SimpleTestCase):
         _claim,
         release_claim,
     ):
-        result = chat_lifecycle.run_copilot_chat_provision(
-            session_link_id=42
-        )
+        result = chat_lifecycle.run_copilot_chat_provision(session_link_id=42)
 
         self.assertEqual(result["status"], "waiting")
         release_claim.assert_called_once_with(42, "claim-token")
@@ -88,7 +86,9 @@ class CopilotLifecycleQueueTests(SimpleTestCase):
             "database schema mismatch",
         )
 
-    @patch("apps.lens_bridge.tasks.chat_lifecycle.execute_copilot_chat_provision_task.delay")
+    @patch(
+        "apps.lens_bridge.tasks.chat_lifecycle.execute_copilot_chat_provision_task.delay"
+    )
     def test_provision_dispatches_to_celery(self, delay):
         queue_copilot_chat_provision(session_link_id=42)
 
@@ -139,7 +139,10 @@ class CopilotDefaultTitleTests(SimpleTestCase):
 
     @patch("apps.lens_bridge.services.chat_lifecycle.LensSessionLink.objects.filter")
     def test_duplicate_titles_use_parenthesized_number(self, filter_sessions):
-        filter_sessions.return_value.values_list.return_value = ["Reports", "Reports (2)"]
+        filter_sessions.return_value.values_list.return_value = [
+            "Reports",
+            "Reports (2)",
+        ]
 
         title = chat_lifecycle._unique_session_title(
             object(),
@@ -150,9 +153,54 @@ class CopilotDefaultTitleTests(SimpleTestCase):
         self.assertEqual(title, "Reports (3)")
 
 
+class CopilotTrustedScopeSummaryTests(SimpleTestCase):
+    def test_accepts_complete_nonnegative_summary(self):
+        self.assertTrue(
+            chat_lifecycle._scope_has_trusted_summary(
+                {"path_type": "dir", "file_count": 2, "size_bytes": 42}
+            )
+        )
+
+    def test_rejects_negative_or_non_numeric_summary(self):
+        self.assertFalse(
+            chat_lifecycle._scope_has_trusted_summary(
+                {"path_type": "file", "file_count": 1, "size_bytes": -1}
+            )
+        )
+        self.assertFalse(
+            chat_lifecycle._scope_has_trusted_summary(
+                {"path_type": "dir", "file_count": "invalid", "size_bytes": 42}
+            )
+        )
+        self.assertFalse(
+            chat_lifecycle._scope_has_trusted_summary(
+                {"path_type": "dir", "file_count": 1.5, "size_bytes": 42}
+            )
+        )
+        self.assertFalse(
+            chat_lifecycle._scope_has_trusted_summary(
+                {"path_type": "dir", "file_count": 1, "size_bytes": 2**63}
+            )
+        )
+
+    def test_rejects_file_summary_without_exactly_one_file(self):
+        self.assertFalse(
+            chat_lifecycle._scope_has_trusted_summary(
+                {"path_type": "file", "file_count": 0, "size_bytes": 0}
+            )
+        )
+        self.assertFalse(
+            chat_lifecycle._scope_has_trusted_summary(
+                {"path_type": "file", "file_count": 2, "size_bytes": 42}
+            )
+        )
+
+
 class CopilotRetryTests(TestCase):
     def setUp(self):
-        self.organization = Organization.objects.create(key="copilot-retry", name="Copilot Retry")
+        self.organization = Organization.objects.create(
+            key="copilot-retry", name="Copilot Retry"
+        )
         self.user = get_user_model().objects.create_user(
             username="copilot-retry",
             email="copilot-retry@example.com",
@@ -174,7 +222,9 @@ class CopilotRetryTests(TestCase):
         with self.captureOnCommitCallbacks(execute=True):
             updated = chat_lifecycle.retry_copilot_chat_provision(session)
 
-        self.assertEqual(updated.lifecycle_status, LensSessionLink.LifecycleStatus.PROVISIONING)
+        self.assertEqual(
+            updated.lifecycle_status, LensSessionLink.LifecycleStatus.PROVISIONING
+        )
         self.assertEqual(updated.provision_phase, LensSessionLink.ProvisionPhase.QUEUED)
         queue_provision.assert_called_once_with(session.id)
 
@@ -185,7 +235,9 @@ class CopilotRetryTests(TestCase):
         with self.captureOnCommitCallbacks(execute=True):
             updated = chat_lifecycle.retry_copilot_chat_provision(session)
 
-        self.assertEqual(updated.lifecycle_status, LensSessionLink.LifecycleStatus.PROVISIONING)
+        self.assertEqual(
+            updated.lifecycle_status, LensSessionLink.LifecycleStatus.PROVISIONING
+        )
         queue_provision.assert_called_once_with(session.id)
 
     @patch("apps.lens_bridge.services.chat_lifecycle._queue_provision_or_mark_failed")
@@ -217,7 +269,9 @@ class CopilotRetryTests(TestCase):
 
         updated = chat_lifecycle.retry_copilot_chat_provision(session)
 
-        self.assertEqual(updated.lifecycle_status, LensSessionLink.LifecycleStatus.READY)
+        self.assertEqual(
+            updated.lifecycle_status, LensSessionLink.LifecycleStatus.READY
+        )
         queue_provision.assert_not_called()
 
     def test_deleting_session_is_not_retryable(self):
@@ -292,21 +346,16 @@ class CopilotChatModelBindingTests(TestCase):
             ],
             gateway_mode=LensSessionLink.GatewaySelectionMode.MANUAL,
             gateway_link_id=self.gateway_link.id,
+            idempotency_key="copilot-model-binding-create",
         )
 
     @patch(
         "apps.lens_bridge.services.chat_lifecycle."
-        "provisioning.default_model_refs_for_org",
+        "provisioning.configured_default_model_refs_for_org",
         return_value=(None, None),
     )
-    @patch(
-        "apps.lens_bridge.services.chat_lifecycle."
-        "platform_lens.resolve_gateway_link_for_copilot"
-    )
-    @patch(
-        "apps.lens_bridge.services.gateway_execution."
-        "context_for_gateway_link"
-    )
+    @patch("apps.lens_bridge.services.chat_lifecycle._configured_gateway_link_for_chat")
+    @patch("apps.lens_bridge.services.gateway_execution.context_for_gateway_link")
     def test_missing_agent_model_blocks_chat_creation(
         self,
         _context,
@@ -319,27 +368,16 @@ class CopilotChatModelBindingTests(TestCase):
             self._create_chat()
 
         self.assertFalse(
-            LensSessionLink.objects.filter(
-                organization=self.organization
-            ).exists()
+            LensSessionLink.objects.filter(organization=self.organization).exists()
         )
 
+    @patch("apps.lens_bridge.services.chat_lifecycle._queue_provision_or_mark_failed")
     @patch(
         "apps.lens_bridge.services.chat_lifecycle."
-        "_queue_provision_or_mark_failed"
+        "provisioning.configured_default_model_refs_for_org"
     )
-    @patch(
-        "apps.lens_bridge.services.chat_lifecycle."
-        "provisioning.default_model_refs_for_org"
-    )
-    @patch(
-        "apps.lens_bridge.services.chat_lifecycle."
-        "platform_lens.resolve_gateway_link_for_copilot"
-    )
-    @patch(
-        "apps.lens_bridge.services.gateway_execution."
-        "context_for_gateway_link"
-    )
+    @patch("apps.lens_bridge.services.chat_lifecycle._configured_gateway_link_for_chat")
+    @patch("apps.lens_bridge.services.gateway_execution.context_for_gateway_link")
     def test_missing_multimodal_model_keeps_text_chat_available(
         self,
         _context,
@@ -357,3 +395,297 @@ class CopilotChatModelBindingTests(TestCase):
         self.assertEqual(str(session.agent_model_ref), str(agent_uuid))
         self.assertIsNone(session.multimodal_model_ref)
         queue_provision.assert_called_once_with(session.id)
+
+    @patch("apps.lens_bridge.services.chat_lifecycle._queue_provision_or_mark_failed")
+    @patch(
+        "apps.lens_bridge.services.chat_lifecycle."
+        "provisioning.configured_default_model_refs_for_org",
+    )
+    @patch("apps.lens_bridge.services.chat_lifecycle._configured_gateway_link_for_chat")
+    @patch("apps.lens_bridge.services.gateway_execution.context_for_gateway_link")
+    def test_same_create_key_returns_the_original_chat(
+        self,
+        _context,
+        resolve_gateway,
+        default_models,
+        queue_provision,
+    ):
+        resolve_gateway.return_value = self.gateway_link
+        default_models.return_value = (str(uuid.uuid4()), None)
+
+        with self.captureOnCommitCallbacks(execute=True):
+            first = self._create_chat()
+        second = self._create_chat()
+
+        self.assertEqual(second.id, first.id)
+        self.assertEqual(
+            LensSessionLink.objects.filter(organization=self.organization).count(),
+            1,
+        )
+        queue_provision.assert_called_once_with(first.id)
+
+    @patch("apps.lens_bridge.services.chat_lifecycle._queue_provision_or_mark_failed")
+    @patch(
+        "apps.lens_bridge.services.chat_lifecycle."
+        "provisioning.configured_default_model_refs_for_org",
+    )
+    @patch("apps.lens_bridge.services.chat_lifecycle._configured_gateway_link_for_chat")
+    @patch("apps.lens_bridge.services.gateway_execution.context_for_gateway_link")
+    def test_same_create_key_replays_after_snapshot_directory_becomes_unavailable(
+        self,
+        _context,
+        resolve_gateway,
+        default_models,
+        queue_provision,
+    ):
+        resolve_gateway.return_value = self.gateway_link
+        default_models.return_value = (str(uuid.uuid4()), None)
+
+        with self.captureOnCommitCallbacks(execute=True):
+            first = self._create_chat()
+        self.directory.status = BackupSourceSnapshotDirectory.Status.FAILED
+        self.directory.save(update_fields=["status", "updated_at"])
+
+        replay = self._create_chat()
+
+        self.assertEqual(replay.id, first.id)
+        queue_provision.assert_called_once_with(first.id)
+
+    @patch("apps.lens_bridge.services.chat_lifecycle._queue_provision_or_mark_failed")
+    @patch(
+        "apps.lens_bridge.services.chat_lifecycle."
+        "provisioning.configured_default_model_refs_for_org",
+        return_value=("fd1bd1fc-8856-4d3f-aae0-d0d289ddca98", None),
+    )
+    @patch("apps.lens_bridge.services.chat_lifecycle._configured_gateway_link_for_chat")
+    @patch("apps.lens_bridge.services.gateway_execution.context_for_gateway_link")
+    def test_same_create_key_rejects_a_different_request(
+        self,
+        _context,
+        resolve_gateway,
+        _default_models,
+        _queue_provision,
+    ):
+        resolve_gateway.return_value = self.gateway_link
+        self._create_chat()
+
+        with self.assertRaises(chat_lifecycle.ChatCreateIdempotencyConflict):
+            chat_lifecycle.create_copilot_chat(
+                self.organization,
+                user=self.user,
+                backup_config_id=self.config.id,
+                backup_source_snapshot_id=self.snapshot.id,
+                source_scopes=[
+                    {
+                        "source_path": "/documents/reports",
+                        "backup_snapshot_directory_id": self.directory.id,
+                        "path_type": "dir",
+                    }
+                ],
+                gateway_mode=LensSessionLink.GatewaySelectionMode.MANUAL,
+                gateway_link_id=self.gateway_link.id,
+                idempotency_key="copilot-model-binding-create",
+            )
+
+    @patch("apps.lens_bridge.services.chat_lifecycle._queue_provision_or_mark_failed")
+    @patch(
+        "apps.lens_bridge.services.chat_lifecycle."
+        "provisioning.configured_default_model_refs_for_org",
+        return_value=("fd1bd1fc-8856-4d3f-aae0-d0d289ddca98", None),
+    )
+    @patch("apps.lens_bridge.services.chat_lifecycle._configured_gateway_link_for_chat")
+    @patch("apps.lens_bridge.services.gateway_execution.context_for_gateway_link")
+    @patch("apps.protection.services.snapshot_browser.browse_snapshot_directory")
+    @patch("apps.node.services.interface.run_agent_task_sync")
+    @patch("apps.lens_bridge.services.sl_client.request_json")
+    def test_nested_scope_create_is_local_and_returns_pending(
+        self,
+        sl_request,
+        run_agent_sync,
+        browse_snapshot,
+        _context,
+        resolve_gateway,
+        _default_models,
+        _queue_provision,
+    ):
+        resolve_gateway.return_value = self.gateway_link
+
+        session = chat_lifecycle.create_copilot_chat(
+            self.organization,
+            user=self.user,
+            backup_config_id=self.config.id,
+            backup_source_snapshot_id=self.snapshot.id,
+            source_scopes=[
+                {
+                    "source_path": "/documents/reports",
+                    "backup_snapshot_directory_id": self.directory.id,
+                    "path_type": "dir",
+                }
+            ],
+            gateway_mode=LensSessionLink.GatewaySelectionMode.MANUAL,
+            gateway_link_id=self.gateway_link.id,
+            idempotency_key="nested-local-create",
+        )
+
+        self.assertEqual(
+            session.scope_resolution_status,
+            LensSessionLink.ScopeResolutionStatus.PENDING,
+        )
+        self.assertEqual(
+            session.capacity_reservation_status,
+            LensSessionLink.CapacityReservationStatus.PENDING,
+        )
+        browse_snapshot.assert_not_called()
+        run_agent_sync.assert_not_called()
+        sl_request.assert_not_called()
+
+    @patch("apps.lens_bridge.services.chat_lifecycle._queue_provision_or_mark_failed")
+    @patch(
+        "apps.lens_bridge.services.chat_lifecycle."
+        "provisioning.configured_default_model_refs_for_org",
+        return_value=("fd1bd1fc-8856-4d3f-aae0-d0d289ddca98", None),
+    )
+    @patch("apps.lens_bridge.services.chat_lifecycle._configured_gateway_link_for_chat")
+    @patch("apps.lens_bridge.services.gateway_execution.context_for_gateway_link")
+    def test_root_file_scope_is_always_counted_as_one_file(
+        self,
+        _context,
+        resolve_gateway,
+        _default_models,
+        _queue_provision,
+    ):
+        resolve_gateway.return_value = self.gateway_link
+        self.directory.path_type = BackupSourceSnapshotDirectory.PathType.FILE
+        self.directory.file_count = 0
+        self.directory.size_bytes = 42
+        self.directory.save(
+            update_fields=["path_type", "file_count", "size_bytes", "updated_at"]
+        )
+
+        session = self._create_chat()
+
+        self.assertEqual(session.source_scopes_json[0]["path_type"], "file")
+        self.assertEqual(session.source_scopes_json[0]["file_count"], 1)
+        self.assertEqual(session.source_scopes_json[0]["size_bytes"], 42)
+        self.assertEqual(
+            session.scope_resolution_status,
+            LensSessionLink.ScopeResolutionStatus.RESOLVED,
+        )
+
+
+class CopilotScopeRecoveryTests(SimpleTestCase):
+    @patch("apps.lens_bridge.services.chat_lifecycle._set_phase")
+    @patch("apps.lens_bridge.services.chat_lifecycle._update_provision_claim")
+    def test_scope_resolution_recovers_dispatched_task_by_correlation(
+        self,
+        update_claim,
+        _set_phase,
+    ):
+        task_id = uuid.uuid4()
+        recovered_task = type(
+            "RecoveredTask",
+            (),
+            {"id": task_id, "status": "pending"},
+        )()
+        link = type(
+            "ScopeLink",
+            (),
+            {
+                "id": 9,
+                "organization": object(),
+                "scope_resolution_status": "pending",
+                "provision_state_json": {
+                    "scope_resolution": {
+                        "scope_index": 0,
+                        "correlation_id": "chat:9:scope:0:dispatch-token",
+                    }
+                },
+            },
+        )()
+
+        with patch(
+            "apps.lens_bridge.services.snapshot_scope_tasks.scope_task_for_correlation",
+            return_value=recovered_task,
+        ) as recover_task:
+            result = chat_lifecycle._resolve_chat_scopes(
+                link=link,
+                claim_token="claim-token",
+                scopes=[{"path_type": "unknown"}],
+            )
+
+        self.assertEqual(result["status"], "waiting")
+        self.assertEqual(result["scope_task_id"], str(task_id))
+        recover_task.assert_called_once_with(
+            organization=link.organization,
+            correlation_id="chat:9:scope:0:dispatch-token",
+        )
+        update_claim.assert_called_once_with(
+            link,
+            "claim-token",
+            "provision_state_json",
+        )
+        self.assertEqual(
+            link.provision_state_json["scope_resolution"]["task_id"],
+            str(task_id),
+        )
+
+    @patch("apps.lens_bridge.services.chat_lifecycle._set_phase")
+    @patch("apps.lens_bridge.services.chat_lifecycle._update_provision_claim")
+    def test_scope_resolution_ignores_a_mismatched_stored_task_id(
+        self,
+        update_claim,
+        _set_phase,
+    ):
+        task_id = uuid.uuid4()
+        recovered_task = type(
+            "RecoveredTask",
+            (),
+            {"id": task_id, "status": "pending"},
+        )()
+        link = type(
+            "ScopeLink",
+            (),
+            {
+                "id": 9,
+                "organization": object(),
+                "scope_resolution_status": "pending",
+                "provision_state_json": {
+                    "scope_resolution": {
+                        "scope_index": 0,
+                        "task_id": "wrong-task",
+                        "correlation_id": "chat:9:scope:0:dispatch-token",
+                    }
+                },
+            },
+        )()
+
+        with (
+            patch(
+                "apps.lens_bridge.services.snapshot_scope_tasks."
+                "scope_task_for_reference",
+                return_value=None,
+            ) as task_for_reference,
+            patch(
+                "apps.lens_bridge.services.snapshot_scope_tasks."
+                "scope_task_for_correlation",
+                return_value=recovered_task,
+            ) as task_for_correlation,
+        ):
+            result = chat_lifecycle._resolve_chat_scopes(
+                link=link,
+                claim_token="claim-token",
+                scopes=[{"source_path": "/documents/reports"}],
+            )
+
+        self.assertEqual(result["status"], "waiting")
+        task_for_reference.assert_called_once()
+        task_for_correlation.assert_called_once()
+        update_claim.assert_called_once_with(
+            link,
+            "claim-token",
+            "provision_state_json",
+        )
+        self.assertEqual(
+            link.provision_state_json["scope_resolution"]["task_id"],
+            str(task_id),
+        )

--- a/src/backend/apps/lens_bridge/tests/test_copilot_sessions.py
+++ b/src/backend/apps/lens_bridge/tests/test_copilot_sessions.py
@@ -21,6 +21,7 @@ from apps.lens_bridge.services import sl_client
 class LensSessionCreateSerializerTests(SimpleTestCase):
     def _payload(self, **overrides):
         payload = {
+            "idempotency_key": "session-create-test",
             "backup_config_id": 1,
             "backup_source_snapshot_id": 1,
             "source_scopes": [
@@ -43,6 +44,14 @@ class LensSessionCreateSerializerTests(SimpleTestCase):
             str(serializer.errors["gateway_link_id"][0]),
             "Select a Private Data Gateway.",
         )
+
+    def test_create_requires_an_idempotency_key(self):
+        serializer = LensSessionCreateSerializer(
+            data=self._payload(idempotency_key=None)
+        )
+
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("idempotency_key", serializer.errors)
 
     def test_public_gateway_option_rejects_a_specific_gateway(self):
         serializer = LensSessionCreateSerializer(

--- a/src/backend/apps/lens_bridge/tests/test_public_gateway_capacity.py
+++ b/src/backend/apps/lens_bridge/tests/test_public_gateway_capacity.py
@@ -6,7 +6,12 @@ from unittest.mock import MagicMock, patch
 from django.contrib.auth.models import User
 from django.test import TestCase
 
-from apps.lens_bridge.models import LensGatewayLink, LensSessionLink
+from apps.lens_bridge.models import (
+    LensGatewayLink,
+    LensKnowledgeSource,
+    LensSessionLink,
+    LensWorkspaceBinding,
+)
 from apps.lens_bridge.services import platform_lens
 from apps.lens_bridge.services.public_gateway_capacity import (
     assert_public_gateway_capacity,
@@ -90,7 +95,9 @@ class PublicGatewayCapacityServiceTests(TestCase):
                 additional_bytes=3 * 1024**3,
             )
         self.assertEqual(ctx.exception.code, "SUBSCRIPTION.QUOTA_EXCEEDED")
-        self.assertEqual(ctx.exception.meta.get("quota_type"), "gateway.public_capacity_gb")
+        self.assertEqual(
+            ctx.exception.meta.get("quota_type"), "gateway.public_capacity_gb"
+        )
 
     @patch(
         "apps.lens_bridge.services.public_gateway_capacity.public_gateway_used_bytes",
@@ -128,6 +135,121 @@ class PublicGatewayCapacityServiceTests(TestCase):
         self.assertEqual(nbytes, 0)
         self.assertTrue(unknown)
 
+    def test_corrupt_scope_summary_fails_closed_without_crashing(self):
+        from apps.lens_bridge.services import public_gateway_capacity as cap
+        from apps.protection.models import BackupSourceSnapshotDirectory
+
+        directory = SimpleNamespace(
+            source_path="/root",
+            file_count=1,
+            size_bytes=42,
+        )
+        with patch.object(
+            BackupSourceSnapshotDirectory.objects,
+            "filter",
+        ) as directory_filter:
+            directory_filter.return_value.first.return_value = directory
+            nbytes, unknown = cap._occupancy_from_scope_dicts(
+                organization_id=1,
+                scopes=[
+                    {
+                        "source_path": "/root/file.txt",
+                        "backup_snapshot_directory_id": 31,
+                        "path_type": "file",
+                        "file_count": 0,
+                        "size_bytes": "not-a-number",
+                    }
+                ],
+                re_resolve=False,
+            )
+
+        self.assertEqual(nbytes, 0)
+        self.assertTrue(unknown)
+
+    def test_negative_legacy_scope_size_fails_closed(self):
+        from apps.lens_bridge.services import public_gateway_capacity as cap
+        from apps.protection.models import BackupSourceSnapshotDirectory
+
+        directory = SimpleNamespace(
+            source_path="/root",
+            file_count=1,
+            size_bytes=42,
+        )
+        with patch.object(
+            BackupSourceSnapshotDirectory.objects,
+            "filter",
+        ) as directory_filter:
+            directory_filter.return_value.first.return_value = directory
+            nbytes, unknown = cap._occupancy_from_scope_dicts(
+                organization_id=1,
+                scopes=[
+                    {
+                        "source_path": "/root/file.txt",
+                        "backup_snapshot_directory_id": 31,
+                        "path_type": "file",
+                        "size_bytes": -1,
+                    }
+                ],
+                re_resolve=False,
+            )
+
+        self.assertEqual(nbytes, 0)
+        self.assertTrue(unknown)
+
+    def test_fractional_scope_summary_fails_closed(self):
+        from apps.lens_bridge.services import public_gateway_capacity as cap
+        from apps.protection.models import BackupSourceSnapshotDirectory
+
+        directory = SimpleNamespace(source_path="/root", file_count=1, size_bytes=42)
+        with patch.object(
+            BackupSourceSnapshotDirectory.objects,
+            "filter",
+        ) as directory_filter:
+            directory_filter.return_value.first.return_value = directory
+            nbytes, unknown = cap._occupancy_from_scope_dicts(
+                organization_id=1,
+                scopes=[
+                    {
+                        "source_path": "/root/file.txt",
+                        "backup_snapshot_directory_id": 31,
+                        "path_type": "file",
+                        "file_count": 1.5,
+                        "size_bytes": 42,
+                    }
+                ],
+                re_resolve=False,
+            )
+
+        self.assertEqual(nbytes, 0)
+        self.assertTrue(unknown)
+
+    def test_scope_directory_is_resolved_within_the_session_organization(self):
+        from apps.lens_bridge.services import public_gateway_capacity as cap
+        from apps.protection.models import BackupSourceSnapshotDirectory
+
+        with patch.object(
+            BackupSourceSnapshotDirectory.objects,
+            "filter",
+        ) as directory_filter:
+            directory_filter.return_value.first.return_value = None
+            nbytes, unknown = cap._occupancy_from_scope_dicts(
+                organization_id=17,
+                scopes=[
+                    {
+                        "source_path": "/root/file.txt",
+                        "backup_snapshot_directory_id": 31,
+                        "path_type": "file",
+                        "file_count": 1,
+                        "size_bytes": 42,
+                    }
+                ],
+                re_resolve=False,
+            )
+
+        directory_filter.assert_called_once_with(id=31, organization_id=17)
+        self.assertEqual(nbytes, 0)
+        self.assertTrue(unknown)
+
     def test_org_usage_includes_provisioning_reservation(self):
         from apps.iam.models import Organization
 
@@ -154,12 +276,12 @@ class PublicGatewayCapacityServiceTests(TestCase):
             status=LensSessionLink.Status.ACTIVE,
             lifecycle_status=LensSessionLink.LifecycleStatus.PROVISIONING,
             knowledge_source=None,
+            capacity_reservation_status=(
+                LensSessionLink.CapacityReservationStatus.RESERVED
+            ),
+            capacity_reserved_bytes=2 * gib,
         )
-        with patch(
-            "apps.lens_bridge.services.public_gateway_capacity._occupancy_from_scope_dicts",
-            return_value=(2 * gib, False),
-        ):
-            used_gb = org_public_gateway_capacity_used_gb(organization_id=tenant.id)
+        used_gb = org_public_gateway_capacity_used_gb(organization_id=tenant.id)
         self.assertAlmostEqual(used_gb, 2.0, places=3)
 
     @patch(
@@ -172,14 +294,14 @@ class PublicGatewayCapacityServiceTests(TestCase):
         gateway_qs = MagicMock()
         gateway_qs.values_list.return_value = [self.link_a.id, self.link_b.id]
         session_a = SimpleNamespace(
-            organization_id=5,
             gateway_link_id=self.link_a.id,
-            source_scopes_json=[{"source_path": "/a", "backup_snapshot_directory_id": 1}],
+            capacity_reservation_status="reserved",
+            capacity_reserved_bytes=2 * 1024**3,
         )
         session_b = SimpleNamespace(
-            organization_id=5,
             gateway_link_id=self.link_b.id,
-            source_scopes_json=[{"source_path": "/b", "backup_snapshot_directory_id": 2}],
+            capacity_reservation_status="reserved",
+            capacity_reserved_bytes=2 * 1024**3,
         )
         session_qs = MagicMock()
         session_qs.only.return_value = [session_a, session_b]
@@ -206,4 +328,196 @@ class PublicGatewayCapacityServiceTests(TestCase):
 
         self.assertEqual(used_map[self.link_a.id][0], 2 * 1024**3)
         self.assertEqual(used_map[self.link_b.id][0], 2 * 1024**3)
-        self.assertEqual(mock_occ.call_count, 2)
+        mock_occ.assert_not_called()
+
+    def test_unresolved_session_does_not_reserve_capacity(self):
+        from apps.iam.models import Organization
+
+        tenant = Organization.objects.create(
+            key="cap-unresolved",
+            name="Cap Unresolved",
+        )
+        user = User.objects.create_user(username="cap-unresolved@test.local")
+        LensSessionLink.objects.create(
+            organization=tenant,
+            hfl_user=user,
+            title="pending",
+            gateway_link=self.link_a,
+            source_scopes_json=[
+                {
+                    "source_path": "/root/nested",
+                    "backup_snapshot_directory_id": 1,
+                    "path_type": "unknown",
+                }
+            ],
+            status=LensSessionLink.Status.ACTIVE,
+            lifecycle_status=LensSessionLink.LifecycleStatus.PROVISIONING,
+            scope_resolution_status=LensSessionLink.ScopeResolutionStatus.PENDING,
+            capacity_reservation_status=(
+                LensSessionLink.CapacityReservationStatus.PENDING
+            ),
+        )
+
+        self.assertEqual(
+            org_public_gateway_capacity_used_gb(organization_id=tenant.id),
+            0,
+        )
+
+    def test_corrupt_negative_reservation_fails_closed(self):
+        from apps.lens_bridge.services import public_gateway_capacity as cap
+
+        used, unknown = cap.session_scope_occupancy(
+            session=SimpleNamespace(
+                capacity_reservation_status="reserved",
+                capacity_reserved_bytes=-1,
+            )
+        )
+
+        self.assertEqual(used, 0)
+        self.assertTrue(unknown)
+
+    def test_deleting_chat_keeps_its_reservation_until_cleanup_finishes(self):
+        from apps.iam.models import Organization
+
+        tenant = Organization.objects.create(
+            key="cap-deleting",
+            name="Cap Deleting",
+        )
+        user = User.objects.create_user(username="cap-deleting@test.local")
+        gib = 1024**3
+        LensSessionLink.objects.create(
+            organization=tenant,
+            hfl_user=user,
+            title="deleting",
+            gateway_link=self.link_a,
+            status=LensSessionLink.Status.ARCHIVED,
+            lifecycle_status=LensSessionLink.LifecycleStatus.DELETING,
+            capacity_reservation_status=(
+                LensSessionLink.CapacityReservationStatus.RESERVED
+            ),
+            capacity_reserved_bytes=2 * gib,
+        )
+
+        self.assertEqual(
+            org_public_gateway_capacity_used_gb(organization_id=tenant.id),
+            2,
+        )
+
+    def test_provisioning_chat_reservation_is_not_double_counted_with_workspace(
+        self,
+    ):
+        from apps.iam.models import Organization
+        from apps.lens_bridge.services import public_gateway_capacity as cap
+
+        tenant = Organization.objects.create(
+            key="cap-transition",
+            name="Cap Transition",
+        )
+        user = User.objects.create_user(username="cap-transition@test.local")
+        gib = 1024**3
+        knowledge_source = LensKnowledgeSource.objects.create(
+            organization=tenant,
+            name="Transitioning workspace",
+            gateway=self.link_a.gateway,
+            gateway_link=self.link_a,
+            source_scopes_json=[
+                {
+                    "source_path": "/root",
+                    "backup_snapshot_directory_id": 1,
+                    "path_type": "file",
+                    "file_count": 1,
+                    "size_bytes": 2 * gib,
+                }
+            ],
+            created_by=user,
+        )
+        LensWorkspaceBinding.objects.create(
+            organization=tenant,
+            knowledge_source=knowledge_source,
+            gateway_link=self.link_a,
+            execution_organization_id=self.link_a.organization_id,
+            execution_node_id=self.link_a.gateway_id,
+            workspace_kind=LensWorkspaceBinding.WorkspaceKind.MANAGED_RESTORE,
+            workspace_root="/workspace",
+            relative_path="hfl-ks-transition",
+        )
+        LensSessionLink.objects.create(
+            organization=tenant,
+            hfl_user=user,
+            title="transitioning",
+            gateway_link=self.link_a,
+            knowledge_source=knowledge_source,
+            status=LensSessionLink.Status.ACTIVE,
+            lifecycle_status=LensSessionLink.LifecycleStatus.PROVISIONING,
+            capacity_reservation_status=(
+                LensSessionLink.CapacityReservationStatus.RESERVED
+            ),
+            capacity_reserved_bytes=2 * gib,
+        )
+
+        with patch.object(
+            cap,
+            "_occupancy_from_scope_dicts",
+            wraps=cap._occupancy_from_scope_dicts,
+        ) as occupancy:
+            used, unknown = cap.public_gateway_used_bytes(
+                gateway_link_id=self.link_a.id,
+            )
+
+        self.assertEqual(used, 2 * gib)
+        self.assertFalse(unknown)
+        occupancy.assert_not_called()
+
+    def test_reservation_on_another_gateway_does_not_hide_workspace_usage(self):
+        from apps.iam.models import Organization
+        from apps.lens_bridge.services import public_gateway_capacity as cap
+
+        tenant = Organization.objects.create(
+            key="cap-cross-gateway",
+            name="Cap Cross Gateway",
+        )
+        user = User.objects.create_user(username="cap-cross-gateway@test.local")
+        gib = 1024**3
+        knowledge_source = LensKnowledgeSource.objects.create(
+            organization=tenant,
+            name="Gateway A workspace",
+            gateway=self.link_a.gateway,
+            gateway_link=self.link_a,
+            source_scopes_json=[],
+            created_by=user,
+        )
+        LensWorkspaceBinding.objects.create(
+            organization=tenant,
+            knowledge_source=knowledge_source,
+            gateway_link=self.link_a,
+            execution_organization_id=self.link_a.organization_id,
+            execution_node_id=self.link_a.gateway_id,
+            workspace_kind=LensWorkspaceBinding.WorkspaceKind.MANAGED_RESTORE,
+            workspace_root="/workspace",
+            relative_path="hfl-ks-cross-gateway",
+        )
+        LensSessionLink.objects.create(
+            organization=tenant,
+            hfl_user=user,
+            title="mismatched reservation",
+            gateway_link=self.link_b,
+            knowledge_source=knowledge_source,
+            lifecycle_status=LensSessionLink.LifecycleStatus.PROVISIONING,
+            capacity_reservation_status=(
+                LensSessionLink.CapacityReservationStatus.RESERVED
+            ),
+            capacity_reserved_bytes=2 * gib,
+        )
+
+        with patch.object(
+            cap,
+            "_occupancy_from_scope_dicts",
+            return_value=(3 * gib, False),
+        ) as occupancy:
+            used_map = cap.bulk_public_gateway_used_bytes(
+                [self.link_a.id, self.link_b.id]
+            )
+
+        self.assertEqual(used_map[self.link_a.id][0], 3 * gib)
+        self.assertEqual(used_map[self.link_b.id][0], 2 * gib)
+        occupancy.assert_called_once()

--- a/src/backend/apps/lens_bridge/tests/test_snapshot_browse_api.py
+++ b/src/backend/apps/lens_bridge/tests/test_snapshot_browse_api.py
@@ -1,0 +1,207 @@
+import uuid
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+from django.utils import timezone
+from rest_framework.test import APIClient
+
+from apps.iam.models import Membership
+from apps.iam.services.registration_service import provision_registered_user_tenant
+from apps.lens_bridge.services import snapshot_scope_tasks
+from apps.node.models import Node, NodeTask
+
+
+class SnapshotBrowseApiTests(TestCase):
+    def setUp(self):
+        self.owner = get_user_model().objects.create_user(
+            username="snapshot-browse-owner@example.test",
+            email="snapshot-browse-owner@example.test",
+        )
+        self.organization, _ = provision_registered_user_tenant(self.owner)
+        self.peer = get_user_model().objects.create_user(
+            username="snapshot-browse-peer@example.test",
+            email="snapshot-browse-peer@example.test",
+        )
+        Membership.objects.create(
+            organization=self.organization,
+            user=self.peer,
+            role=Membership.Role.OPERATOR,
+            is_active=True,
+        )
+        self.other_user = get_user_model().objects.create_user(
+            username="snapshot-browse-other@example.test",
+            email="snapshot-browse-other@example.test",
+        )
+        self.other_organization, _ = provision_registered_user_tenant(self.other_user)
+        self.node = Node.objects.create(
+            organization=self.organization,
+            name="Insight browse Agent",
+            role=Node.Role.AGENT,
+        )
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.owner)
+
+    @staticmethod
+    def _payload(response):
+        body = response.json()
+        return body.get("data", body)
+
+    def _create_task(
+        self,
+        *,
+        kind="lens.snapshot.browse",
+        correlation_type=snapshot_scope_tasks.BROWSE_CORRELATION_TYPE,
+        correlation_user=None,
+    ):
+        user = correlation_user or self.owner
+        return NodeTask.objects.create(
+            organization=self.organization,
+            requesting_organization_id=self.organization.id,
+            node=self.node,
+            kind=kind,
+            correlation_type=correlation_type,
+            correlation_id=f"user:{user.id}:{uuid.uuid4()}",
+            status=NodeTask.Status.SUCCESS,
+            result={
+                "has_more": True,
+                "entries": [
+                    {
+                        "name": "reports",
+                        "path": "reports",
+                        "type": "dir",
+                    }
+                ]
+            },
+            watchdog_deadline_at=timezone.now() + timezone.timedelta(minutes=5),
+        )
+
+    @patch("apps.lens_bridge.services.snapshot_scope_tasks.dispatch_snapshot_browse")
+    @patch("apps.iam.permissions_org.get_authz_provider")
+    def test_operator_can_dispatch_browse_asynchronously(
+        self,
+        get_authz_provider,
+        dispatch,
+    ):
+        task_id = uuid.uuid4()
+        get_authz_provider.return_value = SimpleNamespace(
+            get_org_role=lambda _user, _org_key: Membership.Role.OPERATOR,
+        )
+        dispatch.return_value = SimpleNamespace(
+            id=task_id,
+            status=NodeTask.Status.PENDING,
+        )
+
+        response = self.client.post(
+            reverse("lens-copilot-snapshot-browse"),
+            {"directory_id": 31, "path": "reports"},
+            format="json",
+            HTTP_X_ORG_KEY=self.organization.key,
+        )
+
+        self.assertEqual(response.status_code, 202)
+        self.assertEqual(self._payload(response)["task_id"], str(task_id))
+        dispatch.assert_called_once()
+        kwargs = dispatch.call_args.kwargs
+        self.assertEqual(kwargs["organization_id"], self.organization.id)
+        self.assertEqual(kwargs["directory_id"], 31)
+        self.assertEqual(kwargs["path"], "reports")
+        self.assertEqual(kwargs["limit"], 500)
+        self.assertTrue(kwargs["correlation_id"].startswith(f"user:{self.owner.id}:"))
+
+    def test_owner_can_read_their_completed_browse_task(self):
+        task = self._create_task()
+
+        response = self.client.get(
+            reverse(
+                "lens-copilot-snapshot-browse-task",
+                kwargs={"task_id": task.id},
+            ),
+            HTTP_X_ORG_KEY=self.organization.key,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        payload = self._payload(response)
+        self.assertEqual(payload["status"], NodeTask.Status.SUCCESS)
+        self.assertEqual(payload["entries"][0]["path"], "reports")
+        self.assertIs(payload["has_more"], True)
+
+    def test_failed_task_does_not_expose_agent_diagnostics(self):
+        task = self._create_task()
+        task.status = NodeTask.Status.FAILED
+        task.last_error = "repository /var/lib/hfl/private.config failed"
+        task.result = {"config_file": "/var/lib/hfl/private.config"}
+        task.save(update_fields=["status", "last_error", "result", "updated_at"])
+
+        response = self.client.get(
+            reverse(
+                "lens-copilot-snapshot-browse-task",
+                kwargs={"task_id": task.id},
+            ),
+            HTTP_X_ORG_KEY=self.organization.key,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        payload = self._payload(response)
+        self.assertEqual(
+            payload["error"],
+            "Unable to browse the selected snapshot. Try again.",
+        )
+        self.assertNotIn("entries", payload)
+        self.assertNotIn("private.config", str(payload))
+
+    def test_same_organization_peer_cannot_read_another_users_task(self):
+        task = self._create_task()
+        self.client.force_authenticate(user=self.peer)
+
+        response = self.client.get(
+            reverse(
+                "lens-copilot-snapshot-browse-task",
+                kwargs={"task_id": task.id},
+            ),
+            HTTP_X_ORG_KEY=self.organization.key,
+        )
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_other_organization_cannot_read_the_task(self):
+        task = self._create_task()
+        self.client.force_authenticate(user=self.other_user)
+
+        response = self.client.get(
+            reverse(
+                "lens-copilot-snapshot-browse-task",
+                kwargs={"task_id": task.id},
+            ),
+            HTTP_X_ORG_KEY=self.other_organization.key,
+        )
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_non_insight_browse_task_is_not_exposed(self):
+        task = self._create_task(correlation_type="protection.snapshot_browse")
+
+        response = self.client.get(
+            reverse(
+                "lens-copilot-snapshot-browse-task",
+                kwargs={"task_id": task.id},
+            ),
+            HTTP_X_ORG_KEY=self.organization.key,
+        )
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_non_browse_insight_task_is_not_exposed(self):
+        task = self._create_task(kind="snapshot.browse")
+
+        response = self.client.get(
+            reverse(
+                "lens-copilot-snapshot-browse-task",
+                kwargs={"task_id": task.id},
+            ),
+            HTTP_X_ORG_KEY=self.organization.key,
+        )
+
+        self.assertEqual(response.status_code, 404)

--- a/src/backend/apps/lens_bridge/tests/test_snapshot_scope_tasks.py
+++ b/src/backend/apps/lens_bridge/tests/test_snapshot_scope_tasks.py
@@ -1,0 +1,246 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from django.test import SimpleTestCase
+from rest_framework.exceptions import ValidationError
+
+from apps.lens_bridge.services import snapshot_scope_tasks
+
+
+class SnapshotScopeTaskNormalizationTests(SimpleTestCase):
+    def test_rejects_parent_path_traversal(self):
+        with self.assertRaises(ValidationError):
+            snapshot_scope_tasks._clean_relative_path("reports/../secrets")
+
+    def test_normalizes_browse_entries_for_the_insight_client(self):
+        task = SimpleNamespace(
+            result={
+                "entries": [
+                    {
+                        "name": "reports",
+                        "path": r"finance\reports",
+                        "type": "directory",
+                        "size": 0,
+                    },
+                    {
+                        "name": "summary.pdf",
+                        "path": "finance/summary.pdf",
+                        "type": "file",
+                        "size_bytes": 42,
+                        "downloadable": False,
+                    },
+                ]
+            }
+        )
+
+        rows = snapshot_scope_tasks.normalized_browse_entries(task)
+
+        self.assertEqual(rows[0]["type"], "dir")
+        self.assertEqual(rows[0]["path"], "finance/reports")
+        self.assertTrue(rows[0]["downloadable"])
+        self.assertEqual(rows[1]["size_bytes"], 42)
+        self.assertFalse(rows[1]["downloadable"])
+
+    def test_scope_summary_rejects_negative_agent_values(self):
+        task = SimpleNamespace(
+            result={"path_type": "file", "file_count": 1, "size_bytes": -1}
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "invalid Insight scope summary"):
+            snapshot_scope_tasks.resolved_scope_summary(task)
+
+    def test_scope_summary_rejects_invalid_file_count(self):
+        task = SimpleNamespace(
+            result={"path_type": "file", "file_count": 0, "size_bytes": 0}
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "invalid Insight scope summary"):
+            snapshot_scope_tasks.resolved_scope_summary(task)
+
+    def test_scope_summary_rejects_fractional_values(self):
+        task = SimpleNamespace(
+            result={"path_type": "file", "file_count": 1.5, "size_bytes": 0}
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "invalid Insight scope summary"):
+            snapshot_scope_tasks.resolved_scope_summary(task)
+
+    def test_scope_summary_rejects_values_outside_database_range(self):
+        task = SimpleNamespace(
+            result={"path_type": "file", "file_count": 1, "size_bytes": 2**63}
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "invalid Insight scope summary"):
+            snapshot_scope_tasks.resolved_scope_summary(task)
+
+    def test_browse_normalization_discards_unsafe_paths_and_tolerates_bad_size(self):
+        task = SimpleNamespace(
+            result={
+                "entries": [
+                    {"name": "secret", "path": "../secret", "type": "file"},
+                    {
+                        "name": "report.pdf",
+                        "path": "reports/report.pdf",
+                        "type": "file",
+                        "size_bytes": "not-a-number",
+                    },
+                ]
+            }
+        )
+
+        rows = snapshot_scope_tasks.normalized_browse_entries(task)
+
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["path"], "reports/report.pdf")
+        self.assertEqual(rows[0]["size_bytes"], 0)
+
+    @patch(
+        "apps.lens_bridge.services.snapshot_scope_tasks.get_node_task_by_correlation"
+    )
+    def test_recovers_scope_task_by_correlation(self, get_task):
+        expected_task = SimpleNamespace(kind="lens.snapshot.scope.resolve")
+        organization = SimpleNamespace(id=5)
+        get_task.return_value = expected_task
+
+        task = snapshot_scope_tasks.scope_task_for_correlation(
+            organization=organization,
+            correlation_id="chat:9:scope:0:dispatch-token",
+        )
+
+        self.assertIs(task, expected_task)
+        get_task.assert_called_once_with(
+            org=organization,
+            correlation_type=snapshot_scope_tasks.SCOPE_CORRELATION_TYPE,
+            correlation_id="chat:9:scope:0:dispatch-token",
+        )
+
+    @patch(
+        "apps.lens_bridge.services.snapshot_scope_tasks.get_node_task_by_correlation"
+    )
+    def test_does_not_recover_another_task_kind(self, get_task):
+        get_task.return_value = SimpleNamespace(kind="snapshot.browse")
+
+        task = snapshot_scope_tasks.scope_task_for_correlation(
+            organization=SimpleNamespace(id=5),
+            correlation_id="chat:9:scope:0:dispatch-token",
+        )
+
+        self.assertIsNone(task)
+
+    @patch("apps.lens_bridge.services.snapshot_scope_tasks.get_node_task_for_org")
+    def test_scope_reference_requires_matching_kind_type_and_correlation(
+        self,
+        get_task,
+    ):
+        organization = SimpleNamespace(id=5)
+        get_task.return_value = SimpleNamespace(
+            kind="lens.snapshot.scope.resolve",
+            correlation_type=snapshot_scope_tasks.SCOPE_CORRELATION_TYPE,
+            correlation_id="chat:9:scope:0:other-token",
+        )
+
+        task = snapshot_scope_tasks.scope_task_for_reference(
+            organization=organization,
+            task_id="task-1",
+            correlation_id="chat:9:scope:0:dispatch-token",
+        )
+
+        self.assertIsNone(task)
+        get_task.assert_called_once_with(org=organization, task_id="task-1")
+
+    @patch("apps.lens_bridge.services.snapshot_scope_tasks.run_agent_task_async")
+    @patch(
+        "apps.lens_bridge.services.snapshot_scope_tasks."
+        "resolve_snapshot_repository_reader"
+    )
+    @patch("apps.lens_bridge.services.snapshot_scope_tasks._directory_for_org")
+    @patch("apps.lens_bridge.services.snapshot_scope_tasks.Repository.objects.filter")
+    @patch(
+        "apps.lens_bridge.services.snapshot_scope_tasks.repository_uses_bound_proxy",
+        return_value=True,
+    )
+    def test_scope_resolution_uses_async_agent_dispatch(
+        self,
+        _uses_proxy,
+        repository_filter,
+        directory_for_org,
+        resolve_reader,
+        run_async,
+    ):
+        directory_for_org.return_value = SimpleNamespace(
+            id=31,
+            repository_id=7,
+            kopia_snapshot_id="kopia-1",
+            source_snapshot=SimpleNamespace(source_type="host", source_ref_id=9),
+        )
+        repository_filter.return_value.exclude.return_value.first.return_value = (
+            SimpleNamespace(id=7)
+        )
+        resolve_reader.return_value = SimpleNamespace(
+            node=SimpleNamespace(id=12),
+            repository_payload={"type": "s3"},
+        )
+        expected_task = SimpleNamespace(id="task-1")
+        run_async.return_value = SimpleNamespace(task=expected_task)
+
+        task = snapshot_scope_tasks.dispatch_scope_resolution(
+            organization_id=5,
+            directory_id=31,
+            path="reports",
+            correlation_id="chat:9:scope:0",
+        )
+
+        self.assertIs(task, expected_task)
+        run_async.assert_called_once()
+        kwargs = run_async.call_args.kwargs
+        self.assertEqual(kwargs["kind"], "lens.snapshot.scope.resolve")
+        self.assertEqual(kwargs["payload"]["path"], "reports")
+        self.assertNotIn("repository", kwargs["persisted_payload"])
+
+    @patch("apps.lens_bridge.services.snapshot_scope_tasks.run_agent_task_async")
+    @patch(
+        "apps.lens_bridge.services.snapshot_scope_tasks."
+        "resolve_snapshot_repository_reader"
+    )
+    @patch("apps.lens_bridge.services.snapshot_scope_tasks._directory_for_org")
+    @patch("apps.lens_bridge.services.snapshot_scope_tasks.Repository.objects.filter")
+    @patch(
+        "apps.lens_bridge.services.snapshot_scope_tasks.repository_uses_bound_proxy",
+        return_value=True,
+    )
+    def test_root_file_scope_dispatches_trusted_snapshot_metadata(
+        self,
+        _uses_proxy,
+        repository_filter,
+        directory_for_org,
+        resolve_reader,
+        run_async,
+    ):
+        directory = SimpleNamespace(
+            id=31,
+            repository_id=7,
+            kopia_snapshot_id="kopia-file-1",
+            path_type="file",
+            size_bytes=42,
+            source_snapshot=SimpleNamespace(source_type="host", source_ref_id=9),
+        )
+        directory_for_org.return_value = directory
+        repository_filter.return_value.exclude.return_value.first.return_value = (
+            SimpleNamespace(id=7)
+        )
+        resolve_reader.return_value = SimpleNamespace(
+            node=SimpleNamespace(id=12),
+            repository_payload={"type": "s3"},
+        )
+        run_async.return_value = SimpleNamespace(task=SimpleNamespace(id="task-file"))
+
+        snapshot_scope_tasks.dispatch_scope_resolution(
+            organization_id=5,
+            directory_id=31,
+            path="",
+            correlation_id="chat:9:scope:0",
+        )
+
+        kwargs = run_async.call_args.kwargs
+        self.assertEqual(kwargs["payload"]["root_path_type"], "file")
+        self.assertEqual(kwargs["persisted_payload"]["root_size_bytes"], 42)

--- a/src/frontend/src/composables/useKnowledgeSourceForm.test.ts
+++ b/src/frontend/src/composables/useKnowledgeSourceForm.test.ts
@@ -7,7 +7,7 @@ import type { BackupSourceSnapshot } from '../lib/protectionBackupConfigApi'
 import { useKnowledgeSourceForm } from './useKnowledgeSourceForm'
 
 const mocks = vi.hoisted(() => ({
-  browseBackupSnapshotDirectory: vi.fn(),
+  browseCopilotSnapshotDirectory: vi.fn(),
   warning: vi.fn(),
   error: vi.fn(),
   success: vi.fn(),
@@ -30,6 +30,7 @@ vi.mock('../lib/api', () => ({
 }))
 
 vi.mock('../lib/lensApi', () => ({
+  browseCopilotSnapshotDirectory: mocks.browseCopilotSnapshotDirectory,
   browseGatewayDirectory: vi.fn(),
   createKnowledgeSource: vi.fn(),
   fetchKnowledgeSource: vi.fn(),
@@ -38,7 +39,6 @@ vi.mock('../lib/lensApi', () => ({
 }))
 
 vi.mock('../lib/protectionBackupConfigApi', () => ({
-  browseBackupSnapshotDirectory: mocks.browseBackupSnapshotDirectory,
   getBackupSourceSnapshot: vi.fn(),
   listBackupSourceSnapshots: vi.fn().mockResolvedValue({ results: [] }),
 }))
@@ -106,7 +106,7 @@ describe('knowledge source backup scope validation', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     vi.useFakeTimers()
-    mocks.browseBackupSnapshotDirectory.mockResolvedValue({ entries: [] })
+    mocks.browseCopilotSnapshotDirectory.mockResolvedValue({ entries: [] })
   })
 
   afterEach(() => {
@@ -124,7 +124,7 @@ describe('knowledge source backup scope validation', () => {
 
       await expect(validation).resolves.toBe(false)
       expect(mocks.warning).not.toHaveBeenCalled()
-      expect(mocks.browseBackupSnapshotDirectory).not.toHaveBeenCalled()
+      expect(mocks.browseCopilotSnapshotDirectory).not.toHaveBeenCalled()
     } finally {
       wrapper.unmount()
     }
@@ -153,7 +153,7 @@ describe('knowledge source backup scope validation', () => {
         pathType: 'dir',
       })
       expect(mocks.warning).not.toHaveBeenCalled()
-      expect(mocks.browseBackupSnapshotDirectory).not.toHaveBeenCalled()
+      expect(mocks.browseCopilotSnapshotDirectory).not.toHaveBeenCalled()
     } finally {
       wrapper.unmount()
     }
@@ -169,10 +169,10 @@ describe('knowledge source backup scope validation', () => {
       await vi.runAllTimersAsync()
 
       await expect(validation).resolves.toBe(true)
-      expect(mocks.browseBackupSnapshotDirectory).toHaveBeenCalledWith(31, {
+      expect(mocks.browseCopilotSnapshotDirectory).toHaveBeenCalledWith(31, {
         path: 'docs',
         limit: 1,
-      })
+      }, expect.any(AbortSignal))
       expect(form.backupScopeEntries.value[0]).toMatchObject({
         path: '/root/datatest/docs',
         directoryId: 31,
@@ -192,16 +192,16 @@ describe('knowledge source backup scope validation', () => {
 
       await vi.runAllTimersAsync()
       await expect(blurValidation).resolves.toBe(false)
-      expect(mocks.browseBackupSnapshotDirectory).not.toHaveBeenCalled()
+      expect(mocks.browseCopilotSnapshotDirectory).not.toHaveBeenCalled()
 
       form.setBackupScopePickerOpen(entryId, false)
       await vi.runAllTimersAsync()
       await flushPromises()
 
-      expect(mocks.browseBackupSnapshotDirectory).toHaveBeenCalledWith(31, {
+      expect(mocks.browseCopilotSnapshotDirectory).toHaveBeenCalledWith(31, {
         path: 'docs',
         limit: 1,
-      })
+      }, expect.any(AbortSignal))
       expect(form.backupScopeEntries.value[0]).toMatchObject({
         path: '/root/datatest/docs',
         directoryId: 31,
@@ -213,7 +213,7 @@ describe('knowledge source backup scope validation', () => {
 
   it('deduplicates picker-close and blur validation from the same outside click', async () => {
     let resolveBrowse!: (value: { entries: never[] }) => void
-    mocks.browseBackupSnapshotDirectory.mockReturnValueOnce(
+    mocks.browseCopilotSnapshotDirectory.mockReturnValueOnce(
       new Promise((resolve) => { resolveBrowse = resolve }),
     )
     const { form, wrapper } = mountForm()
@@ -224,15 +224,15 @@ describe('knowledge source backup scope validation', () => {
 
       const blurValidation = form.validateBackupScopeEntryOnBlur(entryId)
       form.setBackupScopePickerOpen(entryId, false)
-      expect(mocks.browseBackupSnapshotDirectory).not.toHaveBeenCalled()
+      expect(mocks.browseCopilotSnapshotDirectory).not.toHaveBeenCalled()
 
       await vi.runAllTimersAsync()
-      expect(mocks.browseBackupSnapshotDirectory).toHaveBeenCalledTimes(1)
+      expect(mocks.browseCopilotSnapshotDirectory).toHaveBeenCalledTimes(1)
       resolveBrowse({ entries: [] })
 
       await expect(blurValidation).resolves.toBe(false)
       await flushPromises()
-      expect(mocks.browseBackupSnapshotDirectory).toHaveBeenCalledTimes(1)
+      expect(mocks.browseCopilotSnapshotDirectory).toHaveBeenCalledTimes(1)
       expect(form.backupScopeEntries.value[0]).toMatchObject({
         path: '/root/datatest/docs',
         directoryId: 31,
@@ -244,7 +244,7 @@ describe('knowledge source backup scope validation', () => {
 
   it('deduplicates the same validation when picker-close arrives before blur', async () => {
     let resolveBrowse!: (value: { entries: never[] }) => void
-    mocks.browseBackupSnapshotDirectory.mockReturnValueOnce(
+    mocks.browseCopilotSnapshotDirectory.mockReturnValueOnce(
       new Promise((resolve) => { resolveBrowse = resolve }),
     )
     const { form, wrapper } = mountForm()
@@ -255,14 +255,14 @@ describe('knowledge source backup scope validation', () => {
 
       form.setBackupScopePickerOpen(entryId, false)
       const blurValidation = form.validateBackupScopeEntryOnBlur(entryId)
-      expect(mocks.browseBackupSnapshotDirectory).not.toHaveBeenCalled()
+      expect(mocks.browseCopilotSnapshotDirectory).not.toHaveBeenCalled()
 
       await vi.runAllTimersAsync()
-      expect(mocks.browseBackupSnapshotDirectory).toHaveBeenCalledTimes(1)
+      expect(mocks.browseCopilotSnapshotDirectory).toHaveBeenCalledTimes(1)
       resolveBrowse({ entries: [] })
 
       await expect(blurValidation).resolves.toBe(true)
-      expect(mocks.browseBackupSnapshotDirectory).toHaveBeenCalledTimes(1)
+      expect(mocks.browseCopilotSnapshotDirectory).toHaveBeenCalledTimes(1)
       expect(form.backupScopeEntries.value[0]).toMatchObject({
         path: '/root/datatest/docs',
         directoryId: 31,
@@ -274,7 +274,7 @@ describe('knowledge source backup scope validation', () => {
 
   it('does not let an older async validation overwrite a newer tree selection', async () => {
     let resolveBrowse!: (value: { entries: never[] }) => void
-    mocks.browseBackupSnapshotDirectory.mockReturnValueOnce(
+    mocks.browseCopilotSnapshotDirectory.mockReturnValueOnce(
       new Promise((resolve) => { resolveBrowse = resolve }),
     )
     const { form, wrapper } = mountForm()
@@ -307,7 +307,7 @@ describe('knowledge source backup scope validation', () => {
   it('lets only the latest request report the result for an unchanged path', async () => {
     let rejectFirst!: (reason: Error) => void
     let resolveSecond!: (value: { entries: never[] }) => void
-    mocks.browseBackupSnapshotDirectory
+    mocks.browseCopilotSnapshotDirectory
       .mockReturnValueOnce(new Promise((_resolve, reject) => { rejectFirst = reject }))
       .mockReturnValueOnce(new Promise((resolve) => { resolveSecond = resolve }))
     const { form, wrapper } = mountForm()
@@ -342,14 +342,14 @@ describe('knowledge source backup scope validation', () => {
     await vi.runAllTimersAsync()
 
     await expect(validation).resolves.toBe(false)
-    expect(mocks.browseBackupSnapshotDirectory).not.toHaveBeenCalled()
+    expect(mocks.browseCopilotSnapshotDirectory).not.toHaveBeenCalled()
     expect(mocks.warning).not.toHaveBeenCalled()
     expect(mocks.error).not.toHaveBeenCalled()
   })
 
   it('ignores a successful validation result after the form unmounts', async () => {
     let resolveBrowse!: (value: { entries: never[] }) => void
-    mocks.browseBackupSnapshotDirectory.mockReturnValueOnce(
+    mocks.browseCopilotSnapshotDirectory.mockReturnValueOnce(
       new Promise((resolve) => { resolveBrowse = resolve }),
     )
     const { form, wrapper } = mountForm()
@@ -370,7 +370,7 @@ describe('knowledge source backup scope validation', () => {
 
   it('suppresses a failed validation result after the form unmounts', async () => {
     let rejectBrowse!: (reason: Error) => void
-    mocks.browseBackupSnapshotDirectory.mockReturnValueOnce(
+    mocks.browseCopilotSnapshotDirectory.mockReturnValueOnce(
       new Promise((_resolve, reject) => { rejectBrowse = reject }),
     )
     const { form, wrapper } = mountForm()
@@ -382,6 +382,42 @@ describe('knowledge source backup scope validation', () => {
     rejectBrowse(new Error('request completed after navigation'))
 
     await expect(validation).resolves.toBe(false)
+    expect(mocks.error).not.toHaveBeenCalled()
+  })
+
+  it('treats an aborted directory browse as normal form disposal', async () => {
+    mocks.browseCopilotSnapshotDirectory.mockImplementationOnce(
+      (_directoryId, _params, signal: AbortSignal) => new Promise((_resolve, reject) => {
+        signal.addEventListener(
+          'abort',
+          () => reject(new DOMException('Aborted', 'AbortError')),
+          { once: true },
+        )
+      }),
+    )
+    const { form, wrapper } = mountForm()
+    const resolvedNodes: unknown[][] = []
+    const browse = form.loadBackupScopePickerNode(
+      {
+        level: 1,
+        data: {
+          id: '31:dir:/root/datatest',
+          label: 'datatest',
+          path: '/root/datatest',
+          type: 'dir',
+          directoryId: 31,
+          browsePath: '',
+          sourceRootPath: '/root/datatest',
+          isLeaf: false,
+        },
+      },
+      (nodes) => resolvedNodes.push(nodes),
+    )
+
+    wrapper.unmount()
+    await browse
+
+    expect(resolvedNodes).toEqual([[]])
     expect(mocks.error).not.toHaveBeenCalled()
   })
 })

--- a/src/frontend/src/composables/useKnowledgeSourceForm.ts
+++ b/src/frontend/src/composables/useKnowledgeSourceForm.ts
@@ -4,6 +4,7 @@ import { ElMessage } from 'element-plus'
 import { apiErrorMessage } from '../lib/api'
 import {
   browseGatewayDirectory,
+  browseCopilotSnapshotDirectory,
   createKnowledgeSource,
   fetchKnowledgeSource,
   listLensGateways,
@@ -12,7 +13,6 @@ import {
   type LensIngestPolicy,
 } from '../lib/lensApi'
 import {
-  browseBackupSnapshotDirectory,
   getBackupSourceSnapshot,
   listBackupSourceSnapshots,
   type BackupSourceSnapshot,
@@ -105,6 +105,7 @@ export function useKnowledgeSourceForm(
   let backupScopeValidationSequence = 0
   let backupScopeBlurSequence = 0
   let scopeDisposed = false
+  const snapshotBrowseControllers = new Set<AbortController>()
   const openBackupScopePickerId = ref<string | null>(null)
   const backupScopeTreeRevision = ref(0)
   const backupScopeBrowseLoading = ref(false)
@@ -119,6 +120,32 @@ export function useKnowledgeSourceForm(
 
   const readOnlyGatewayName = ref('')
   const readOnlySourcePath = ref('')
+
+  async function browseInsightSnapshotDirectory(
+    directoryId: number,
+    params: { path?: string; limit?: number },
+  ) {
+    const controller = new AbortController()
+    snapshotBrowseControllers.add(controller)
+    try {
+      return await browseCopilotSnapshotDirectory(
+        directoryId,
+        params,
+        controller.signal,
+      )
+    } finally {
+      snapshotBrowseControllers.delete(controller)
+    }
+  }
+
+  function cancelSnapshotBrowseRequests() {
+    for (const controller of snapshotBrowseControllers) controller.abort()
+    snapshotBrowseControllers.clear()
+  }
+
+  function isAbortError(error: unknown): boolean {
+    return (error as { name?: string } | null)?.name === 'AbortError'
+  }
 
   const isEditing = computed(() => editingId.value != null)
   const isBackupSource = computed(() => sourceType.value === 'backup_source')
@@ -248,6 +275,7 @@ export function useKnowledgeSourceForm(
   const canSubmitCreate = computed(() => canSubmit.value)
 
   function resetBackupScopeState() {
+    cancelSnapshotBrowseRequests()
     latestBackupScopeValidation.clear()
     pendingBackupScopeBlurValidation.clear()
     backupScopeEntries.value = [createBackupScopeEntry()]
@@ -394,7 +422,7 @@ export function useKnowledgeSourceForm(
     }
     backupScopeBrowseLoading.value = true
     try {
-      const result = await browseBackupSnapshotDirectory(data.directoryId, {
+      const result = await browseInsightSnapshotDirectory(data.directoryId, {
         path: data.browsePath || '',
         limit: 500,
       })
@@ -417,7 +445,9 @@ export function useKnowledgeSourceForm(
         }
       }))
     } catch (err) {
-      ElMessage.error({ message: apiErrorMessage(err, t('insight.kb.backupScopeBrowseFailed')), grouping: true })
+      if (!isAbortError(err)) {
+        ElMessage.error({ message: apiErrorMessage(err, t('insight.kb.backupScopeBrowseFailed')), grouping: true })
+      }
       resolve([])
     } finally {
       backupScopeBrowseLoading.value = false
@@ -521,7 +551,7 @@ export function useKnowledgeSourceForm(
     const relativePath = relativeSnapshotPath(directory.source_path, rawPath)
     try {
       if (relativePath) {
-        await browseBackupSnapshotDirectory(directory.id, { path: relativePath, limit: 1 })
+        await browseInsightSnapshotDirectory(directory.id, { path: relativePath, limit: 1 })
       }
       if (!isCurrentBackupScopeValidation(
         entryId,
@@ -878,6 +908,7 @@ export function useKnowledgeSourceForm(
 
   onScopeDispose(() => {
     scopeDisposed = true
+    cancelSnapshotBrowseRequests()
     latestBackupScopeValidation.clear()
     pendingBackupScopeBlurValidation.clear()
   })

--- a/src/frontend/src/lib/lensApi.test.ts
+++ b/src/frontend/src/lib/lensApi.test.ts
@@ -1,9 +1,10 @@
 // @vitest-environment jsdom
 
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { api } from './api'
 import type { LensIngestPolicy } from './lensApi'
 import {
+  browseCopilotSnapshotDirectory,
   createKnowledgeSource,
   patchKnowledgeSource,
   setLensApiScope,
@@ -46,6 +47,65 @@ vi.mock('../composables/useAuth', () => ({
 afterEach(() => {
   setLensApiScope('tenant')
   vi.clearAllMocks()
+})
+
+describe('Insight snapshot browsing', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('polls the bounded Insight task and returns its result', async () => {
+    vi.mocked(api)
+      .mockResolvedValueOnce({ task_id: 'browse-1', status: 'pending' })
+      .mockResolvedValueOnce({
+        task_id: 'browse-1',
+        status: 'success',
+        has_more: true,
+        entries: [{ name: 'reports', path: 'reports', type: 'dir' }],
+      })
+
+    const request = browseCopilotSnapshotDirectory(31, { path: 'docs', limit: 10 })
+    await vi.runAllTimersAsync()
+
+    await expect(request).resolves.toMatchObject({
+      has_more: true,
+      entries: [{ path: 'reports' }],
+    })
+    expect(api).toHaveBeenNthCalledWith(
+      1,
+      '/api/v1/lens/copilot/snapshot-browse/',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ directory_id: 31, path: 'docs', limit: 10 }),
+      }),
+    )
+  })
+
+  it('stops polling a task that never reaches a terminal state', async () => {
+    vi.mocked(api).mockResolvedValue({ task_id: 'browse-stuck', status: 'pending' })
+
+    const request = browseCopilotSnapshotDirectory(31)
+    const rejection = expect(request).rejects.toThrow('Snapshot browsing timed out')
+    await vi.runAllTimersAsync()
+
+    await rejection
+    expect(api).toHaveBeenCalledTimes(241)
+  })
+
+  it('honors a signal that is already aborted before polling', async () => {
+    vi.mocked(api).mockResolvedValue({ task_id: 'browse-1', status: 'pending' })
+    const controller = new AbortController()
+    controller.abort()
+
+    await expect(
+      browseCopilotSnapshotDirectory(31, undefined, controller.signal),
+    ).rejects.toMatchObject({ name: 'AbortError' })
+    expect(api).toHaveBeenCalledTimes(1)
+  })
 })
 
 describe('saved AI model connectivity', () => {

--- a/src/frontend/src/lib/lensApi.ts
+++ b/src/frontend/src/lib/lensApi.ts
@@ -1,9 +1,12 @@
 import { getEffectiveOrgKey } from '../composables/useAuth'
 import { api, isAbortError } from './api'
 import type { DocumentConversion, SessionDataContext } from './conversionSummary'
+import type { BackupSnapshotBrowserEntry } from './protectionBackupConfigApi'
 import { asList, unwrapApiPayload } from './parse'
 
 const API_BASE = import.meta.env.VITE_API_BASE?.toString() || ''
+const COPILOT_SNAPSHOT_BROWSE_POLL_MS = 500
+const COPILOT_SNAPSHOT_BROWSE_MAX_POLLS = 240
 
 export type LensApiScope = 'tenant' | 'platform'
 
@@ -865,6 +868,7 @@ export async function fetchCopilotUsageDetail(runUuid: string): Promise<LensCopi
 }
 
 export type CreateCopilotSessionPayload = {
+  idempotency_key: string
   title?: string
   backup_config_id: number
   backup_source_snapshot_id: number
@@ -884,6 +888,83 @@ export async function createCopilotSession(body: CreateCopilotSessionPayload): P
     body: JSON.stringify(body),
   })
   return lensPayload<LensSessionLink>(raw)
+}
+
+export type LensSnapshotBrowseTask = {
+  task_id: string
+  status: 'pending' | 'running' | 'success' | 'failed' | 'timeout' | 'canceled' | string
+  error?: string
+  entries?: BackupSnapshotBrowserEntry[]
+  has_more?: boolean
+}
+
+export async function startCopilotSnapshotBrowse(
+  directoryId: number,
+  params?: { path?: string; limit?: number },
+  signal?: AbortSignal,
+): Promise<LensSnapshotBrowseTask> {
+  const raw = await api(lensUrl('copilot/snapshot-browse/'), {
+    method: 'POST',
+    headers: lensHeaders(),
+    signal,
+    body: JSON.stringify({
+      directory_id: directoryId,
+      path: params?.path || '',
+      limit: Math.max(1, Math.min(params?.limit || 500, 500)),
+    }),
+  })
+  return lensPayload<LensSnapshotBrowseTask>(raw)
+}
+
+export async function fetchCopilotSnapshotBrowse(
+  taskId: string,
+  signal?: AbortSignal,
+): Promise<LensSnapshotBrowseTask> {
+  const raw = await api(lensUrl(`copilot/snapshot-browse/${taskId}/`), {
+    headers: lensHeaders(),
+    signal,
+  })
+  return lensPayload<LensSnapshotBrowseTask>(raw)
+}
+
+export async function browseCopilotSnapshotDirectory(
+  directoryId: number,
+  params?: { path?: string; limit?: number },
+  signal?: AbortSignal,
+): Promise<{ entries: BackupSnapshotBrowserEntry[]; has_more: boolean }> {
+  const started = await startCopilotSnapshotBrowse(directoryId, params, signal)
+  let task = started
+  let polls = 0
+  while (task.status === 'pending' || task.status === 'running') {
+    if (polls >= COPILOT_SNAPSHOT_BROWSE_MAX_POLLS) {
+      throw new Error('Snapshot browsing timed out. Try again.')
+    }
+    polls += 1
+    await new Promise<void>((resolve, reject) => {
+      if (signal?.aborted) {
+        reject(new DOMException('Aborted', 'AbortError'))
+        return
+      }
+      let timer: number
+      const onAbort = () => {
+        window.clearTimeout(timer)
+        reject(new DOMException('Aborted', 'AbortError'))
+      }
+      timer = window.setTimeout(() => {
+        signal?.removeEventListener('abort', onAbort)
+        resolve()
+      }, COPILOT_SNAPSHOT_BROWSE_POLL_MS)
+      signal?.addEventListener('abort', onAbort, { once: true })
+    })
+    task = await fetchCopilotSnapshotBrowse(task.task_id, signal)
+  }
+  if (task.status !== 'success') {
+    throw new Error(task.error || 'Unable to browse the selected snapshot.')
+  }
+  return {
+    entries: (task.entries || []).slice(0, params?.limit || 500),
+    has_more: Boolean(task.has_more),
+  }
 }
 
 export async function retryCopilotSession(sessionId: number): Promise<LensSessionLink> {

--- a/src/frontend/src/pages/insight/NewCopilotChat.vue
+++ b/src/frontend/src/pages/insight/NewCopilotChat.vue
@@ -57,6 +57,13 @@ const backupScopePickerWidth = ref(460)
 const backupScopeStackRef = ref<HTMLElement | null>(null)
 const privateGatewayCardRef = ref<HTMLElement | null>(null)
 let backupScopeResizeObserver: ResizeObserver | null = null
+let createIdempotencyKey: string | null = null
+let createRequestFingerprint = ''
+
+function newCreateIdempotencyKey(): string {
+  if (globalThis.crypto?.randomUUID) return globalThis.crypto.randomUUID()
+  return `chat-${Date.now()}-${Math.random().toString(36).slice(2)}`
+}
 
 const {
   loading,
@@ -241,16 +248,30 @@ async function createChat() {
   if (!scopesValid || sourceScopes.value.length === 0) return
 
   submitting.value = true
+  const requestPayload = {
+    backup_config_id: selectedBackupConfigId.value,
+    backup_source_snapshot_id: effectiveSnapshotId.value,
+    source_scopes: sourceScopes.value,
+    gateway_mode: gatewayMode.value,
+    gateway_link_id: gatewayMode.value === 'manual' ? gatewayLinkId.value : null,
+  }
+  const requestFingerprint = JSON.stringify(requestPayload)
+  if (!createIdempotencyKey || createRequestFingerprint !== requestFingerprint) {
+    createIdempotencyKey = newCreateIdempotencyKey()
+    createRequestFingerprint = requestFingerprint
+  }
   try {
     const session = await createCopilotSession({
-      backup_config_id: selectedBackupConfigId.value,
-      backup_source_snapshot_id: effectiveSnapshotId.value,
-      source_scopes: sourceScopes.value,
-      gateway_mode: gatewayMode.value,
-      gateway_link_id: gatewayMode.value === 'manual' ? gatewayLinkId.value : null,
+      idempotency_key: createIdempotencyKey,
+      ...requestPayload,
     })
     await router.replace({ path: '/insight/copilot', query: { session: String(session.id) } })
   } catch (error) {
+    const status = Number((error as { status?: number })?.status || 0)
+    if (status >= 400 && status < 500 && status !== 408 && status !== 429) {
+      createIdempotencyKey = null
+      createRequestFingerprint = ''
+    }
     ElMessage.error({ message: apiErrorMessage(error, 'Unable to start chat.'), grouping: true })
   } finally {
     submitting.value = false

--- a/src/frontend/src/pages/insight/NewCopilotChatGatewayWarning.test.ts
+++ b/src/frontend/src/pages/insight/NewCopilotChatGatewayWarning.test.ts
@@ -310,6 +310,29 @@ describe('New Chat Public Data Gateway warning', () => {
     wrapper.unmount()
   })
 
+  it('reuses the create request key after an uncertain transport failure', async () => {
+    mocks.createCopilotSession
+      .mockRejectedValueOnce(new Error('network unavailable'))
+      .mockResolvedValueOnce({ id: 91 })
+    const wrapper = await mountNewChat({ gatewayResponse: [publicGateway] })
+
+    await startChatButton(wrapper).trigger('click')
+    await flushPromises()
+    await startChatButton(wrapper).trigger('click')
+    await flushPromises()
+
+    expect(mocks.createCopilotSession).toHaveBeenCalledTimes(2)
+    const firstKey = mocks.createCopilotSession.mock.calls[0][0].idempotency_key
+    const secondKey = mocks.createCopilotSession.mock.calls[1][0].idempotency_key
+    expect(firstKey).toBeTruthy()
+    expect(secondKey).toBe(firstKey)
+    expect(mocks.routerReplace).toHaveBeenCalledWith({
+      path: '/insight/copilot',
+      query: { session: '91' },
+    })
+    wrapper.unmount()
+  })
+
   it('keeps the warning theme-aware and safe to wrap on narrow screens', () => {
     expect(componentSource).toContain(
       'background: color-mix(in srgb, var(--color-warning) 10%, var(--color-card-bg))',

--- a/src/frontend/src/pages/insight/copilot/CopilotLifecycleState.test.ts
+++ b/src/frontend/src/pages/insight/copilot/CopilotLifecycleState.test.ts
@@ -1,0 +1,105 @@
+// @vitest-environment jsdom
+
+import { mount } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import { describe, expect, it } from 'vitest'
+
+import type { LensSessionLink } from '../../../lib/lensApi'
+import { en } from '../../../locales/en'
+import CopilotLifecycleState from './CopilotLifecycleState.vue'
+
+function session(overrides: Partial<LensSessionLink> = {}): LensSessionLink {
+  return {
+    title: 'Quarterly reports',
+    knowledge_source: null,
+    knowledge_source_name: null,
+    sl_session_uuid: null,
+    sl_assistant_uuid: null,
+    agent_model_ref: 'model-ref',
+    backup_config_id: 7,
+    backup_source_name: 'Documents',
+    backup_source_snapshot_id: 17,
+    snapshot_created_at: '2026-08-12T03:00:00Z',
+    snapshot_size_bytes: 4096,
+    source_scopes_json: [{ backup_snapshot_directory_id: 31, source_path: '/reports' }],
+    gateway_link: 11,
+    gateway_selection_mode: 'auto',
+    gateway_name: 'public-dg-01',
+    gateway_scope: 'platform',
+    status: 'active',
+    lifecycle_status: 'provisioning',
+    provision_phase: 'converting',
+    provision_detail: 'Prepared 11 files for conversion.',
+    document_conversion: {
+      status: 'STARTED',
+      phase: 'running',
+      progress_message: 'Prepared 11 files for conversion.',
+      counts: {
+        total: 11,
+        candidates: 6,
+        success: 0,
+        failed: 0,
+        skipped: 0,
+        unsupported: 5,
+        unchanged: 0,
+      },
+      items: Array.from({ length: 5 }, (_, index) => ({
+        name: `unsupported-${index + 1}.txt`,
+        reason: 'UNSUPPORTED_TYPE',
+        reason_label: 'Unsupported file type',
+      })),
+      warnings: [],
+      usable: false,
+    },
+    last_message_at: null,
+    last_assistant_message_at: null,
+    last_viewed_at: null,
+    has_unread: false,
+    created_at: '2026-08-12T03:00:00Z',
+    updated_at: '2026-08-12T03:00:00Z',
+    ...overrides,
+  }
+}
+
+function mountState(value: LensSessionLink) {
+  const i18n = createI18n({
+    legacy: false,
+    locale: 'en',
+    messages: { en },
+    missingWarn: false,
+    fallbackWarn: false,
+  })
+  return mount(CopilotLifecycleState, {
+    props: { session: value },
+    global: {
+      plugins: [i18n],
+      stubs: {
+        ElButton: { template: '<button><slot /></button>' },
+      },
+    },
+  })
+}
+
+describe('CopilotLifecycleState', () => {
+  it('shows one conversion message and keeps file-level problems collapsed', () => {
+    const wrapper = mountState(session())
+
+    expect(wrapper.findAll('.copilot-conversion__detail')).toHaveLength(1)
+    expect(wrapper.text().match(/Prepared 11 files for conversion\./g)).toHaveLength(1)
+    expect(wrapper.get('summary').text()).toContain('5 items need attention')
+    expect(wrapper.get('details').attributes('open')).toBeUndefined()
+    expect(wrapper.get('.copilot-lifecycle-card').classes()).toContain('has-conversion')
+  })
+
+  it('maps asynchronous scope resolution to the first preparation step', () => {
+    const wrapper = mountState(session({
+      provision_phase: 'resolving_scope',
+      provision_detail: 'Checking selected files and folders.',
+      document_conversion: null,
+    }))
+
+    const steps = wrapper.findAll('.copilot-lifecycle-steps li')
+    expect(steps[0].classes()).toContain('is-active')
+    expect(steps[1].classes()).toContain('is-pending')
+  })
+})

--- a/src/frontend/src/pages/insight/copilot/CopilotLifecycleState.vue
+++ b/src/frontend/src/pages/insight/copilot/CopilotLifecycleState.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { AlertCircle, Check, Circle, LoaderCircle, Sparkles } from 'lucide-vue-next'
+import { AlertCircle, Check, ChevronDown, Circle, LoaderCircle, Sparkles, TriangleAlert } from 'lucide-vue-next'
 import {
   conversionCountsLabel,
   conversionPhase,
@@ -22,7 +22,7 @@ const emit = defineEmits<{
 const { t } = useI18n()
 
 const steps = [
-  { label: 'Validating Selected Data', phases: ['queued'] },
+  { label: 'Validating Selected Data', phases: ['queued', 'resolving_scope', 'reserving_capacity'] },
   { label: 'Preparing Files and Folders', phases: ['restoring'] },
   { label: 'Extracting Document Content', phases: ['converting'] },
   { label: 'Indexing Selected Content', phases: ['creating_knowledge_source'] },
@@ -36,7 +36,8 @@ const currentStep = computed(() => {
 
 const conversion = computed(() => props.session.document_conversion ?? null)
 const countsLabel = computed(() => conversionCountsLabel(conversion.value))
-const problemItems = computed(() => conversionProblemItems(conversion.value).slice(0, 8))
+const allProblemItems = computed(() => conversionProblemItems(conversion.value))
+const problemItems = computed(() => allProblemItems.value.slice(0, 12))
 const phase = computed(() => conversionPhase(conversion.value))
 const isConvertingStep = computed(() => props.session.provision_phase === 'converting')
 const showRunningMessage = computed(() => (
@@ -61,6 +62,16 @@ const showFormatHint = computed(() => (
   isConvertingStep.value || phase.value === 'running'
 ))
 const conversionWarnings = computed(() => conversionWarningsForDisplay(conversion.value, 5))
+const conversionDetail = computed(() => (
+  conversion.value?.progress_message?.trim()
+  || props.session.provision_detail?.trim()
+  || ''
+))
+const attentionCount = computed(() => allProblemItems.value.length + conversionWarnings.value.length)
+const attentionLabel = computed(() => {
+  if (!attentionCount.value) return 'Supported document formats'
+  return `${attentionCount.value} ${attentionCount.value === 1 ? 'item needs' : 'items need'} attention`
+})
 const showFailedConversionPanel = computed(() => Boolean(
   conversion.value
   && (countsLabel.value || problemItems.value.length || conversion.value.error || conversionWarnings.value.length),
@@ -79,7 +90,7 @@ function stepState(index: number) {
       <span class="copilot-lifecycle-icon is-failed"><AlertCircle :size="30" /></span>
       <h2>We Couldn't Prepare This Chat</h2>
       <p>Something went wrong while preparing the selected data. Try again, or delete this chat and create a new one.</p>
-      <div v-if="showFailedConversionPanel" class="copilot-conversion">
+      <div v-if="showFailedConversionPanel" class="copilot-conversion copilot-conversion--failed">
         <p v-if="countsLabel" class="copilot-conversion__counts">{{ countsLabel }}</p>
         <p v-if="conversion?.error" class="copilot-conversion__detail">{{ conversion.error }}</p>
         <ul v-if="problemItems.length" class="copilot-conversion__list">
@@ -106,39 +117,61 @@ function stepState(index: number) {
       <p>The chat and its temporary data are being removed.</p>
     </div>
 
-    <div v-else class="copilot-lifecycle-card">
-      <span class="copilot-lifecycle-icon"><Sparkles :size="30" /></span>
-      <h2>Preparing Your Chat</h2>
-      <p>Your selected data is being prepared for AI Copilot.</p>
+    <div v-else class="copilot-lifecycle-card" :class="{ 'has-conversion': showConversionPanel }">
+      <div class="copilot-lifecycle-heading" role="status" aria-live="polite">
+        <span class="copilot-lifecycle-icon"><Sparkles :size="25" /></span>
+        <div>
+          <h2>Preparing Your Chat</h2>
+          <p>Your selected data is being prepared for AI Copilot.</p>
+        </div>
+      </div>
 
-      <ol class="copilot-lifecycle-steps">
-        <li v-for="(step, index) in steps" :key="step.label" :class="`is-${stepState(index)}`">
-          <span>
-            <Check v-if="stepState(index) === 'done'" :size="14" />
-            <LoaderCircle v-else-if="stepState(index) === 'active'" :size="14" class="copilot-lifecycle-spin" />
-            <Circle v-else :size="12" />
-          </span>
-          {{ step.label }}
-        </li>
-      </ol>
+      <div class="copilot-lifecycle-body">
+        <ol class="copilot-lifecycle-steps" aria-label="Chat preparation progress">
+          <li v-for="(step, index) in steps" :key="step.label" :class="`is-${stepState(index)}`">
+            <span>
+              <Check v-if="stepState(index) === 'done'" :size="14" />
+              <LoaderCircle v-else-if="stepState(index) === 'active'" :size="14" class="copilot-lifecycle-spin" />
+              <Circle v-else :size="12" />
+            </span>
+            {{ step.label }}
+          </li>
+        </ol>
 
-      <div v-if="showConversionPanel" class="copilot-conversion">
-        <p v-if="session.provision_detail" class="copilot-conversion__detail">{{ session.provision_detail }}</p>
-        <p v-if="conversion?.progress_message" class="copilot-conversion__detail">{{ conversion.progress_message }}</p>
-        <p v-if="showRunningMessage" class="copilot-conversion__detail">{{ t('insight.copilot.documentConversionRunning') }}</p>
-        <p v-if="countsLabel" class="copilot-conversion__counts">{{ countsLabel }}</p>
-        <ul v-if="problemItems.length" class="copilot-conversion__list">
-          <li v-for="(item, index) in problemItems" :key="`${item.name}-${index}`">
-            <strong>{{ item.name }}</strong>
-            <span>{{ item.reason_label }}</span>
-          </li>
-        </ul>
-        <ul v-if="conversionWarnings.length" class="copilot-conversion__list">
-          <li v-for="(warning, index) in conversionWarnings" :key="`${warning.code}-${index}`">
-            <span>{{ warning.label || warning.code }}</span>
-          </li>
-        </ul>
-        <p v-if="showFormatHint" class="copilot-conversion__hint">{{ t('insight.copilot.documentFormatHint') }}</p>
+        <section v-if="showConversionPanel" class="copilot-conversion" aria-label="Document preparation details">
+          <span class="copilot-conversion__eyebrow">Document preparation</span>
+          <p v-if="conversionDetail" class="copilot-conversion__detail">{{ conversionDetail }}</p>
+          <p v-else-if="showRunningMessage" class="copilot-conversion__detail">{{ t('insight.copilot.documentConversionRunning') }}</p>
+          <p v-if="countsLabel" class="copilot-conversion__counts">{{ countsLabel }}</p>
+
+          <details v-if="attentionCount || showFormatHint" class="copilot-conversion__details">
+            <summary>
+              <span class="copilot-conversion__summary-icon" :class="{ 'has-attention': attentionCount }">
+                <TriangleAlert v-if="attentionCount" :size="14" />
+                <Circle v-else :size="12" />
+              </span>
+              <span>{{ attentionLabel }}</span>
+              <ChevronDown :size="15" class="copilot-conversion__chevron" />
+            </summary>
+            <div class="copilot-conversion__details-body">
+              <ul v-if="problemItems.length" class="copilot-conversion__list">
+                <li v-for="(item, index) in problemItems" :key="`${item.name}-${index}`">
+                  <strong>{{ item.name }}</strong>
+                  <span>{{ item.reason_label }}</span>
+                </li>
+              </ul>
+              <p v-if="allProblemItems.length > problemItems.length" class="copilot-conversion__more">
+                {{ allProblemItems.length - problemItems.length }} more files are available in Chat Details.
+              </p>
+              <ul v-if="conversionWarnings.length" class="copilot-conversion__list is-warnings">
+                <li v-for="(warning, index) in conversionWarnings" :key="`${warning.code}-${index}`">
+                  <span>{{ warning.label || warning.code }}</span>
+                </li>
+              </ul>
+              <p v-if="showFormatHint" class="copilot-conversion__hint">{{ t('insight.copilot.documentFormatHint') }}</p>
+            </div>
+          </details>
+        </section>
       </div>
 
       <small>You can leave this page. Preparation will continue in the background.</small>
@@ -147,13 +180,18 @@ function stepState(index: number) {
 </template>
 
 <style scoped>
-.copilot-lifecycle-state { display: flex; min-height: 0; flex: 1; align-items: center; justify-content: center; padding: 40px 24px; overflow-y: auto; background: var(--color-card-bg); }
-.copilot-lifecycle-card { display: flex; width: min(520px, 100%); flex-direction: column; align-items: center; padding: 34px 36px; border: 1px solid var(--color-border-light); border-radius: 14px; background: var(--color-card-bg); box-shadow: 0 14px 34px rgba(29, 33, 41, .07); text-align: center; }
-.copilot-lifecycle-icon { display: inline-flex; width: 58px; height: 58px; align-items: center; justify-content: center; margin-bottom: 18px; border-radius: 16px; background: color-mix(in srgb, var(--color-primary) 10%, var(--color-card-bg)); color: var(--color-primary); animation: copilot-lifecycle-breathe 2.2s ease-in-out infinite; }
+.copilot-lifecycle-state { display: flex; min-height: 0; flex: 1; align-items: center; justify-content: center; padding: 32px 24px; overflow-y: auto; background: var(--color-card-bg); }
+.copilot-lifecycle-card { display: flex; width: min(520px, 100%); flex-direction: column; align-items: center; padding: 30px 34px; border: 1px solid var(--color-border-light); border-radius: 14px; background: var(--color-card-bg); box-shadow: 0 14px 34px rgba(29, 33, 41, .07); text-align: center; }
+.copilot-lifecycle-card.has-conversion { width: min(720px, 100%); }
+.copilot-lifecycle-heading { display: flex; align-items: center; justify-content: center; gap: 14px; text-align: left; }
+.copilot-lifecycle-icon { display: inline-flex; width: 48px; height: 48px; flex: 0 0 48px; align-items: center; justify-content: center; border-radius: 14px; background: color-mix(in srgb, var(--color-primary) 10%, var(--color-card-bg)); color: var(--color-primary); animation: copilot-lifecycle-breathe 2.2s ease-in-out infinite; }
+.copilot-lifecycle-card > .copilot-lifecycle-icon { margin-bottom: 18px; }
 .copilot-lifecycle-icon.is-failed { background: #fef3f2; color: #d92d20; animation: none; }
 .copilot-lifecycle-card h2 { margin: 0; color: var(--color-text-title); font-size: 20px; font-weight: 650; }
-.copilot-lifecycle-card > p { max-width: 430px; margin: 9px 0 0; color: var(--color-text-tertiary); font-size: 13px; line-height: 1.6; }
-.copilot-lifecycle-steps { display: grid; width: min(360px, 100%); gap: 13px; margin: 26px 0 22px; padding: 20px 22px; border-radius: 10px; background: var(--color-grey-2); list-style: none; text-align: left; }
+.copilot-lifecycle-card > p,.copilot-lifecycle-heading p { max-width: 430px; margin: 7px 0 0; color: var(--color-text-tertiary); font-size: 13px; line-height: 1.55; }
+.copilot-lifecycle-body { display: grid; width: 100%; grid-template-columns: minmax(0, 360px); justify-content: center; margin: 24px 0 20px; }
+.has-conversion .copilot-lifecycle-body { grid-template-columns: minmax(0, .92fr) minmax(0, 1.08fr); align-items: start; gap: 24px; }
+.copilot-lifecycle-steps { display: grid; width: 100%; gap: 13px; margin: 0; padding: 7px 0; list-style: none; text-align: left; }
 .copilot-lifecycle-steps li { display: flex; align-items: center; gap: 10px; color: var(--color-text-disabled); font-size: 13px; }
 .copilot-lifecycle-steps li > span { display: inline-flex; width: 20px; height: 20px; flex-shrink: 0; align-items: center; justify-content: center; }
 .copilot-lifecycle-steps li.is-done { color: var(--color-text-secondary); }.copilot-lifecycle-steps li.is-done > span { border-radius: 999px; background: #ecfdf3; color: #039855; }
@@ -161,14 +199,38 @@ function stepState(index: number) {
 .copilot-lifecycle-card small { color: var(--color-text-tertiary); font-size: 12px; }
 .copilot-lifecycle-actions { display: flex; justify-content: center; gap: 10px; margin-top: 24px; }
 .copilot-lifecycle-spin { animation: copilot-lifecycle-spin .9s linear infinite; }
-.copilot-conversion { width: min(400px, 100%); margin: 0 0 18px; padding: 14px 16px; border-radius: 10px; background: var(--color-grey-2); text-align: left; }
-.copilot-conversion__detail { margin: 0 0 8px; color: var(--color-text-secondary); font-size: 12px; line-height: 1.5; }
-.copilot-conversion__counts { margin: 0 0 8px; color: var(--color-text-title); font-size: 12px; font-weight: 600; }
-.copilot-conversion__list { display: grid; gap: 8px; margin: 0; padding: 0; list-style: none; }
+.copilot-conversion { width: 100%; min-width: 0; padding: 7px 0 7px 24px; border-left: 1px solid var(--color-border-light); text-align: left; }
+.copilot-conversion--failed { width: min(400px, 100%); margin-top: 18px; padding: 14px 16px; border: 0; border-radius: 10px; background: var(--color-grey-2); }
+.copilot-conversion__eyebrow { display: block; margin-bottom: 8px; color: var(--color-text-title); font-size: 12px; font-weight: 650; }
+.copilot-conversion__detail { margin: 0; color: var(--color-text-secondary); font-size: 12px; line-height: 1.5; }
+.copilot-conversion__counts { margin: 9px 0 0; color: var(--color-text-title); font-size: 13px; font-weight: 650; }
+.copilot-conversion__details { margin-top: 10px; }
+.copilot-conversion__details summary { display: flex; min-height: 40px; align-items: center; gap: 8px; padding: 9px 0 0; color: var(--color-text-secondary); font-size: 12px; font-weight: 600; list-style: none; cursor: pointer; }
+.copilot-conversion__details summary::-webkit-details-marker { display: none; }
+.copilot-conversion__details summary:focus-visible { border-radius: 4px; outline: 2px solid color-mix(in srgb, var(--color-primary) 45%, transparent); outline-offset: 2px; }
+.copilot-conversion__summary-icon { display: inline-flex; align-items: center; color: var(--color-text-tertiary); }
+.copilot-conversion__summary-icon.has-attention { color: #b54708; }
+.copilot-conversion__chevron { margin-left: auto; transition: transform .2s ease; }
+.copilot-conversion__details[open] .copilot-conversion__chevron { transform: rotate(180deg); }
+.copilot-conversion__details-body { max-height: 230px; padding: 5px 4px 2px 22px; overflow-y: auto; }
+.copilot-conversion__list { display: grid; gap: 9px; margin: 0; padding: 0; list-style: none; }
+.copilot-conversion__list.is-warnings { margin-top: 10px; }
 .copilot-conversion__list li { display: grid; gap: 2px; }
 .copilot-conversion__list strong { overflow-wrap: anywhere; color: var(--color-text-title); font-size: 12px; font-weight: 600; }
 .copilot-conversion__list span { color: var(--color-text-tertiary); font-size: 11px; line-height: 1.4; }
+.copilot-conversion__more { margin: 10px 0 0; color: var(--color-text-tertiary); font-size: 11px; line-height: 1.45; }
 .copilot-conversion__hint { margin: 10px 0 0; color: var(--color-text-tertiary); font-size: 11px; line-height: 1.45; }
 @keyframes copilot-lifecycle-spin { to { transform: rotate(360deg); } }
 @keyframes copilot-lifecycle-breathe { 50% { transform: translateY(-3px) scale(1.04); box-shadow: 0 10px 26px color-mix(in srgb, var(--color-primary) 20%, transparent); } }
+@media (max-width: 760px) {
+  .copilot-lifecycle-state { align-items: flex-start; padding: 20px 14px; }
+  .copilot-lifecycle-card,.copilot-lifecycle-card.has-conversion { width: 100%; padding: 24px 18px; }
+  .has-conversion .copilot-lifecycle-body { grid-template-columns: minmax(0, 1fr); }
+  .copilot-lifecycle-heading { align-items: flex-start; }
+  .copilot-conversion { padding: 18px 0 0; border-top: 1px solid var(--color-border-light); border-left: 0; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .copilot-lifecycle-icon,.copilot-lifecycle-spin { animation: none; }
+  .copilot-conversion__chevron { transition: none; }
+}
 </style>


### PR DESCRIPTION
## Summary

- create Copilot chats locally and idempotently, then run provisioning and snapshot-scope preparation asynchronously
- persist lifecycle correlation and Public Data Gateway capacity reservations so interrupted workers can safely resume
- add bounded Insight snapshot browsing and store only the selected scope plus aggregate statistics
- improve lifecycle feedback and remove the duplicated-card appearance from the chat preparation page
- keep Protection and Restore paths unchanged

## Validation

- Go engine and process tests
- Ruff, Django system check, and migration drift check
- 80 related Django tests (completed before the final rebase; the rebase had no overlapping files)
- 33 focused frontend tests
- frontend production build
- git diff --check

Related to #444 and #445.