### PR TITLE
[codex] retain unmounted Target NAS data on cleanup

### DIFF
--- a/src/agent/internal/engine/repository_cleanup.go
+++ b/src/agent/internal/engine/repository_cleanup.go
@@ -40,22 +40,38 @@ func (e *Engine) runManagedRepositoryCleanup(
 		"repository_type": spec.Type,
 	}
 	cleanupScope := strings.ToLower(strings.TrimSpace(payloadStringValue(p.Extra["cleanup_scope"])))
+	unmountedPolicy := strings.ToLower(strings.TrimSpace(payloadStringValue(p.Extra["unmounted_policy"])))
 	var repositoryPath string
 	var allowedRoot string
 	preservePhysicalRepository := false
+	skippedUnmountedNAS := false
 	if spec.Type == "nas" {
-		nassvc.LogSpec("repository_cleanup_mount_begin", *spec.TargetNAS, "task_id", taskID)
-		if err := nassvc.NewService().EnsureMounted(ctx, *spec.TargetNAS); err != nil {
-			return "failed", result, redactRepositoryCleanupPaths(
-				err.Error(),
-				spec.TargetNAS.MountPoint,
-				nassvc.ResolvedMountPoint(spec.TargetNAS.MountPoint),
-			)
-		}
-		allowedRoot = nassvc.ResolvedMountPoint(spec.TargetNAS.MountPoint)
-		repositoryPath, err = repositoryNASPath(spec)
-		if err != nil {
-			return "failed", result, err.Error()
+		nasService := nassvc.NewService()
+		if unmountedPolicy == "retain_and_continue" && !nasService.IsMounted(spec.TargetNAS.MountPoint) {
+			skippedUnmountedNAS = true
+			result["mount_status"] = "not_mounted"
+			result["physical_cleanup"] = "skipped_unmounted"
+			result["cleanup_complete"] = false
+			result["cleanup_failures"] = []map[string]any{{
+				"code":   "NAS_NOT_MOUNTED",
+				"detail": "Remote repository cleanup was skipped because the NAS was not mounted.",
+			}}
+			result["retained_resources"] = []string{fmt.Sprintf("nas_repository:%d", spec.ID)}
+			nassvc.LogSpec("repository_cleanup_skip_unmounted", *spec.TargetNAS, "task_id", taskID)
+		} else {
+			nassvc.LogSpec("repository_cleanup_mount_begin", *spec.TargetNAS, "task_id", taskID)
+			if err := nasService.EnsureMounted(ctx, *spec.TargetNAS); err != nil {
+				return "failed", result, redactRepositoryCleanupPaths(
+					err.Error(),
+					spec.TargetNAS.MountPoint,
+					nassvc.ResolvedMountPoint(spec.TargetNAS.MountPoint),
+				)
+			}
+			allowedRoot = nassvc.ResolvedMountPoint(spec.TargetNAS.MountPoint)
+			repositoryPath, err = repositoryNASPath(spec)
+			if err != nil {
+				return "failed", result, err.Error()
+			}
 		}
 	} else if spec.Type == "proxy_fs" {
 		if cleanupScope == "local_state_only" {
@@ -74,7 +90,9 @@ func (e *Engine) runManagedRepositoryCleanup(
 		"phase":          "repository_cleanup",
 		"operation_type": operationType,
 	})
-	if preservePhysicalRepository {
+	if skippedUnmountedNAS {
+		// Never inspect the mount-point tree when it is not an active NAS mount.
+	} else if preservePhysicalRepository {
 		result["repository_existed"] = true
 		result["physical_cleanup"] = "preserved_legacy_directory"
 		result["scope"] = "legacy_local_disk"
@@ -111,7 +129,14 @@ func (e *Engine) runManagedRepositoryCleanup(
 		cacheExisted = cacheExisted || existed
 	}
 	result["repository_cache_existed"] = cacheExisted
-	if spec.Type == "nas" {
+	result["local_state_cleanup"] = "completed"
+	if spec.Type == "nas" && skippedUnmountedNAS {
+		removed, cleanupErr := nassvc.NewService().CleanupUnmountedMountPoint(spec.TargetNAS.MountPoint)
+		if cleanupErr != nil {
+			return "failed", result, redactRepositoryCleanupPaths(cleanupErr.Error(), spec.TargetNAS.MountPoint)
+		}
+		result["mount_point_directory_removed"] = removed
+	} else if spec.Type == "nas" {
 		mountPoint := spec.TargetNAS.MountPoint
 		if err := nassvc.NewService().Unmount(ctx, mountPoint); err != nil {
 			return "failed", result, redactRepositoryCleanupPaths(

--- a/src/agent/internal/engine/repository_cleanup_test.go
+++ b/src/agent/internal/engine/repository_cleanup_test.go
@@ -164,6 +164,62 @@ func TestManagedRepositoryCleanupRemovesOnlyOwnedCache(t *testing.T) {
 	}
 }
 
+func TestManagedNASCleanupSkipsUnmountedRemoteAndRemovesLocalState(t *testing.T) {
+	dataDir := t.TempDir()
+	t.Setenv("HFL_DATA_DIR", dataDir)
+	engine := New(staticConfigProvider{cfg: &model.AgentConfig{DataDir: dataDir}})
+	mountPoint := filepath.Join(dataDir, "mounts", "repositories", "repo-17-node-13")
+	remoteLookingPath := filepath.Join(mountPoint, "hp-repos", "storage-17")
+	if err := os.MkdirAll(remoteLookingPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	marker := filepath.Join(remoteLookingPath, "must-not-delete")
+	if err := os.WriteFile(marker, []byte("keep"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	spec := repositorySpec{ID: 17, Type: "nas", Subdir: "hp-repos/storage-17"}
+	configFile := engine.repositoryConfigPath(spec)
+	if err := os.MkdirAll(filepath.Dir(configFile), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(configFile, []byte("config"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(managedRepositoryCacheDir(engine.current(), configFile), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	payload := ParsePayload(map[string]any{
+		"operation_type":   "cleanup.repository",
+		"unmounted_policy": "retain_and_continue",
+		"repository": map[string]any{
+			"id": 17, "type": "nas", "subdir": spec.Subdir,
+			"nas": map[string]any{
+				"protocol": "smb", "server": "192.0.2.1", "share": "backup",
+				"mount_point": mountPoint, "username": "backup", "password": "secret",
+			},
+		},
+	})
+	status, result, message := engine.runManagedRepositoryCleanup(
+		context.Background(), ReporterSink{}, "cleanup-unmounted", payload,
+	)
+	if status != "success" {
+		t.Fatalf("cleanup status=%q message=%q result=%#v", status, message, result)
+	}
+	if result["physical_cleanup"] != "skipped_unmounted" || result["cleanup_complete"] != false {
+		t.Fatalf("unexpected cleanup result: %#v", result)
+	}
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("unmounted mount-point contents were touched: %v", err)
+	}
+	if _, err := os.Stat(configFile); !os.IsNotExist(err) {
+		t.Fatalf("local config still exists: %v", err)
+	}
+	if _, err := os.Stat(managedRepositoryCacheDir(engine.current(), configFile)); !os.IsNotExist(err) {
+		t.Fatalf("local cache still exists: %v", err)
+	}
+}
+
 func TestManagedProxyFSCleanupPreservesBaseDirectorySiblings(t *testing.T) {
 	base := t.TempDir()
 	target := filepath.Join(base, "hfl-repo-81")

--- a/src/agent/internal/service/nas/mount_point_test.go
+++ b/src/agent/internal/service/nas/mount_point_test.go
@@ -1,6 +1,7 @@
 package nas
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -44,5 +45,37 @@ func TestResolveMountPointRejectsOutsideMounts(t *testing.T) {
 	}
 	if got := ResolvedMountPoint(`D:\backups\repo`); got != "" {
 		t.Fatalf("ResolvedMountPoint() = %q want empty", got)
+	}
+}
+
+func TestCleanupUnmountedMountPointRemovesOnlyEmptyManagedDirectory(t *testing.T) {
+	t.Setenv("HFL_DATA_DIR", t.TempDir())
+	service := NewService()
+	empty := filepath.Join(agentDataDirForMounts(), "mounts", "repositories", "empty")
+	if err := os.MkdirAll(empty, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	removed, err := service.CleanupUnmountedMountPoint(empty)
+	if err != nil || !removed {
+		t.Fatalf("empty mount point removed=%v err=%v", removed, err)
+	}
+	if _, err := os.Stat(empty); !os.IsNotExist(err) {
+		t.Fatalf("empty mount point still exists: %v", err)
+	}
+
+	nonEmpty := filepath.Join(agentDataDirForMounts(), "mounts", "repositories", "non-empty")
+	if err := os.MkdirAll(nonEmpty, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	marker := filepath.Join(nonEmpty, "keep")
+	if err := os.WriteFile(marker, []byte("keep"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	removed, err = service.CleanupUnmountedMountPoint(nonEmpty)
+	if err != nil || removed {
+		t.Fatalf("non-empty mount point removed=%v err=%v", removed, err)
+	}
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("non-empty mount point contents changed: %v", err)
 	}
 }

--- a/src/agent/internal/service/nas/service.go
+++ b/src/agent/internal/service/nas/service.go
@@ -2,6 +2,7 @@ package nas
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -23,6 +24,39 @@ type Service struct{}
 
 func NewService() *Service {
 	return &Service{}
+}
+
+// IsMounted reports whether mountPoint is an active filesystem mount.
+func (s *Service) IsMounted(mountPoint string) bool {
+	mountPoint = ResolvedMountPoint(mountPoint)
+	return mountPoint != "" && isMounted(mountPoint)
+}
+
+// CleanupUnmountedMountPoint removes an empty managed mount-point directory.
+// It checks the live mount table before inspecting and again before removing
+// the directory so cleanup never traverses a concurrently mounted NAS.
+func (s *Service) CleanupUnmountedMountPoint(mountPoint string) (bool, error) {
+	mountPoint = ResolvedMountPoint(mountPoint)
+	if mountPoint == "" {
+		return false, fmt.Errorf("invalid mount_point")
+	}
+	if isMounted(mountPoint) {
+		return false, nil
+	}
+	entries, err := os.ReadDir(mountPoint)
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	if len(entries) != 0 || isMounted(mountPoint) {
+		return false, nil
+	}
+	if err := removeManagedMountDirectory(mountPoint); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 // EnsureMounted mounts the NAS share when the mount point is not active yet.

--- a/src/backend/apps/storage/services/internal/repository_cleanup.py
+++ b/src/backend/apps/storage/services/internal/repository_cleanup.py
@@ -47,8 +47,8 @@ from apps.storage.services.internal.s3_client import (
     delete_s3_prefix,
 )
 from apps.storage.services.internal.s3_url_style import normalize_s3_url_style
-from apps.task.models import Task, TaskResource, TaskStep
-from apps.task.services.interface import complete_task, create_task, start_task
+from apps.task.models import Task, TaskEvent, TaskResource, TaskStep
+from apps.task.services.interface import append_task_event, complete_task, create_task, start_task
 from apps.task.services.recovery import (
     CONTROL_PLANE_RESTART_INTERRUPTED,
     MAX_AUTOMATIC_REPLACEMENTS,
@@ -551,7 +551,8 @@ def run_repository_cleanup_task(*, repository_task_id: int) -> dict[str, Any]:
                     repository_task,
                 ),
             }
-        if not physical_cleanup_complete and not repository_task.force:
+        retained_unmounted_nas = _is_unmounted_nas_cleanup(result)
+        if not physical_cleanup_complete and not repository_task.force and not retained_unmounted_nas:
             cleanup_failures = [
                 item
                 for item in result.get("cleanup_failures") or []
@@ -584,6 +585,27 @@ def run_repository_cleanup_task(*, repository_task_id: int) -> dict[str, Any]:
                     else []
                 ),
             }
+        elif retained_unmounted_nas:
+            result = {
+                **result,
+                "force": bool(repository_task.force),
+                "outcome": "cleanup_success_with_retained_resources",
+                "cleanup_complete": False,
+                "cleanup_failures": result.get("cleanup_failures") or [],
+                "retained_resources": result.get("retained_resources") or [],
+            }
+            append_task_event(
+                task=task,
+                step=task.steps.filter(step_name="delete_physical_repository").first(),
+                level=TaskEvent.Level.WARN,
+                message="Remote NAS repository cleanup skipped because the target was not mounted",
+                metadata={
+                    "owner_node_id": repository_task.owner_node_id,
+                    "mount_status": "not_mounted",
+                    "physical_cleanup": "skipped_unmounted",
+                    "retained_resources": result["retained_resources"],
+                },
+            )
         else:
             result = {
                 **result,
@@ -615,6 +637,8 @@ def run_repository_cleanup_task(*, repository_task_id: int) -> dict[str, Any]:
                 cleanup_result=(
                     Repository.CleanupResult.PRESERVED
                     if result.get("physical_cleanup") == "preserved_legacy_directory"
+                    else Repository.CleanupResult.FORCE_SKIPPED
+                    if retained_unmounted_nas
                     else None
                 ),
             )
@@ -1196,12 +1220,17 @@ def _execute_physical_cleanup(
     )
     if repository.repo_type == Repository.Type.NAS and target.repository_subdir:
         repository_payload["subdir"] = target.repository_subdir
+    if repository.repo_type == Repository.Type.NAS:
+        unmounted_policy = "retain_and_continue"
+    else:
+        unmounted_policy = ""
     return resolve_or_dispatch_repository_agent_operation(
         repository_task=repository_task,
         node=node,
         payload={
             "operation_type": repository_task.operation_type,
             "cleanup_scope": cleanup_scope,
+            "unmounted_policy": unmounted_policy,
             "repository": repository_payload,
         },
         correlation_type="repository_cleanup",
@@ -1342,8 +1371,13 @@ def _finalize_cleanup_task(*, repository_task_id: int) -> None:
             target.save(update_fields=["active_task", "is_active", "updated_at"])
 
         repository = repository_task.repository
+        task_result = task.result_payload if isinstance(task.result_payload, dict) else {}
         if task.status == Task.Status.SUCCESS:
-            audit_result = AuditResult.PARTIAL if repository_task.force else AuditResult.SUCCESS
+            audit_result = (
+                AuditResult.PARTIAL
+                if repository_task.force or task_result.get("cleanup_complete") is False
+                else AuditResult.SUCCESS
+            )
         else:
             if repository_task.operation_type == RepositoryTask.OperationType.CLEANUP_REPOSITORY:
                 repository.status = Repository.Status.REMOVE_FAILED
@@ -1354,7 +1388,8 @@ def _finalize_cleanup_task(*, repository_task_id: int) -> None:
             user=_repository_task_user(repository_task),
             result=audit_result,
             details=(
-                f"{repository_task.operation_type} finished with task status {task.status}"
+                f"{repository_task.operation_type} finished with task status {task.status}; "
+                f"physical_cleanup={task_result.get('physical_cleanup') or 'unknown'}"
             ),
         )
         triggered_task = (
@@ -1539,6 +1574,20 @@ def _cleanup_exception_message(exc: Exception) -> str:
         if messages:
             return "; ".join(str(item) for item in messages)
     return str(exc)
+
+
+def _is_unmounted_nas_cleanup(result: Any) -> bool:
+    if not isinstance(result, dict):
+        return False
+    if result.get("physical_cleanup") != "skipped_unmounted":
+        return False
+    failures = result.get("cleanup_failures")
+    if not isinstance(failures, list) or not failures:
+        return False
+    return all(
+        isinstance(item, dict) and item.get("code") == "NAS_NOT_MOUNTED"
+        for item in failures
+    )
 
 
 def _retained_repository_resources(

--- a/src/backend/apps/storage/tests/test_repository_cleanup.py
+++ b/src/backend/apps/storage/tests/test_repository_cleanup.py
@@ -104,6 +104,90 @@ class RepositoryCleanupTests(TestCase):
         self.assertEqual(repository.cleanup_result, Repository.CleanupResult.PRESERVED)
 
     @mock.patch(
+        "apps.storage.services.internal.repository_cleanup._execute_physical_cleanup",
+        return_value={
+            "mount_status": "not_mounted",
+            "physical_cleanup": "skipped_unmounted",
+            "cleanup_complete": False,
+            "local_state_cleanup": "completed",
+            "cleanup_failures": [
+                {
+                    "code": "NAS_NOT_MOUNTED",
+                    "detail": "Remote repository cleanup was skipped because the NAS was not mounted.",
+                }
+            ],
+            "retained_resources": ["nas_repository:17"],
+        },
+    )
+    def test_unmounted_nas_cleanup_succeeds_with_retained_resource_warning(self, _execute_cleanup):
+        proxy = Node.objects.create(
+            organization=self.org,
+            name="unmounted-nas-proxy",
+            role=Node.Role.PROXY,
+            status=Node.Status.ACTIVE,
+            availability=Node.Availability.ONLINE,
+            metadata={"inventory": {"capabilities": ["repository_cleanup_v1"]}},
+        )
+        repository = Repository.objects.create(
+            organization_id=self.org.id,
+            name="unmounted-nas",
+            repo_type=Repository.Type.NAS,
+            nas_protocol=Repository.NasProtocol.SMB,
+            status=Repository.Status.CREATED,
+            health=Repository.Health.OFFLINE,
+            config={"server_address": "192.0.2.1", "share_path": "/backup"},
+            bind_node_type=Repository.BindNodeType.PROXY,
+            bind_node_id=proxy.id,
+        )
+        repository_task = create_repository_cleanup_task(repository=repository, dispatch=False)
+
+        result = run_repository_cleanup_task(repository_task_id=repository_task.id)
+
+        repository.refresh_from_db()
+        repository_task.task.refresh_from_db()
+        warning_step = repository_task.task.steps.get(step_name="delete_physical_repository")
+        warning_event = repository_task.task.events.filter(level="WARN").get()
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["outcome"], "cleanup_success_with_retained_resources")
+        self.assertFalse(result["cleanup_complete"])
+        self.assertEqual(warning_step.status, warning_step.Status.WARNING)
+        self.assertEqual(warning_event.metadata["mount_status"], "not_mounted")
+        self.assertEqual(repository.status, Repository.Status.REMOVED)
+        self.assertEqual(repository.cleanup_result, Repository.CleanupResult.FORCE_SKIPPED)
+
+    @mock.patch(
+        "apps.storage.services.internal.repository_cleanup.resolve_or_dispatch_repository_agent_operation"
+    )
+    def test_nas_cleanup_dispatches_explicit_unmounted_policy(self, dispatch):
+        proxy = Node.objects.create(
+            organization=self.org,
+            name="nas-policy-proxy",
+            role=Node.Role.PROXY,
+            status=Node.Status.ACTIVE,
+            availability=Node.Availability.ONLINE,
+            metadata={"inventory": {"capabilities": ["repository_cleanup_v1"]}},
+        )
+        repository = Repository.objects.create(
+            organization_id=self.org.id,
+            name="nas-policy",
+            repo_type=Repository.Type.NAS,
+            nas_protocol=Repository.NasProtocol.NFS,
+            status=Repository.Status.CREATED,
+            health=Repository.Health.ONLINE,
+            config={"server_address": "192.0.2.1", "share_path": "/backup"},
+            bind_node_type=Repository.BindNodeType.PROXY,
+            bind_node_id=proxy.id,
+        )
+        repository_task = create_repository_cleanup_task(repository=repository, dispatch=False)
+
+        _execute_physical_cleanup(repository_task)
+
+        self.assertEqual(
+            dispatch.call_args.kwargs["payload"]["unmounted_policy"],
+            "retain_and_continue",
+        )
+
+    @mock.patch(
         "apps.storage.services.internal.repository_cleanup.resolve_or_dispatch_repository_agent_operation"
     )
     def test_legacy_local_disk_on_v1_agent_is_preserved_without_dispatch(self, dispatch):

--- a/src/frontend/src/locales/en.ts
+++ b/src/frontend/src/locales/en.ts
@@ -1712,7 +1712,8 @@ export const en = {
     batchDelete: 'Delete',
     batchDeleteNeedSelect: 'Select repositories to delete first',
     batchDeleteTitle: 'Batch Delete',
-    batchDeleteConfirm: 'Delete {n} selected repositories?',
+    batchDeleteConfirm:
+      'Delete {n} selected repositories? If a Target NAS is not currently mounted, its platform record will be removed but remote repository data may be retained.',
     batchDeleteS3Title: 'Delete Object Storage',
     batchDeleteS3Confirm:
       'Delete the selected {n} object storage repositories? This cannot be undone. Ensure data in these repositories has been handled or is no longer needed.',


### PR DESCRIPTION
## Summary

- skip remounting an unmounted Target NAS during repository cleanup
- remove only Agent-owned local configuration and cache state
- complete control-plane deletion with a warning and retained-resource audit trail
- surface the possible remote-data residue in the delete confirmation

## Root cause

Repository cleanup always called `EnsureMounted` before deleting a NAS repository. A Target NAS that had never mounted successfully, such as when the Proxy lacked `nls_utf8`, could therefore neither initialize nor be deleted.

## Behavior

When the backend explicitly requests `unmounted_policy=retain_and_continue` and the Agent confirms the NAS is not mounted, the Agent does not inspect the mount-point tree or retry the mount. It cleans repository-owned local state and returns `skipped_unmounted`. The platform tombstones the repository, marks physical cleanup incomplete, records retained resources, and completes the task with a warning. Other physical cleanup failures remain blocking.

## Validation

- `go test ./internal/engine` (targeted repository cleanup tests)
- `go test ./internal/service/nas`
- `python manage.py test apps.storage.tests.test_repository_cleanup --keepdb` (23 tests)
- `ruff check apps/storage/services/internal/repository_cleanup.py apps/storage/tests/test_repository_cleanup.py`
- `vitest run src/lib/taskOutcomeDisplay.test.ts`