### PR TITLE
Clarify SMB repository write failures

### DIFF
--- a/src/agent/internal/engine/managed_backup.go
+++ b/src/agent/internal/engine/managed_backup.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"log/slog"
 	"math"
 	"os"
@@ -33,6 +34,8 @@ const (
 	kopiaEstimatedUsageFactor            = 1.05
 	repositoryAlreadyExistsCode          = "STORAGE.REPOSITORY_ALREADY_EXISTS"
 	repositoryAlreadyExistsMessage       = "A Kopia repository already exists at the selected location. Import is not supported in this version. Choose a different storage location."
+	nasRepositoryWriteDeniedCode         = "NAS_REPOSITORY_WRITE_DENIED"
+	nasRepositoryWriteDeniedMessage      = "The SMB share was mounted, but the Agent could not create the repository directory."
 )
 
 type repositoryPrepareMode uint8
@@ -528,6 +531,14 @@ func (e *Engine) prepareManagedRepositoryLocked(
 			return os.MkdirAll(repoPath, 0o755)
 		}); mkErr != nil {
 			nassvc.LogSpec("repository_mkdir_failed", *spec.TargetNAS, "task_id", taskID, "repo_path", repoPath, "err", mkErr.Error())
+			if isNASRepositoryWriteDenied(*spec.TargetNAS, mkErr) {
+				return "", nil, map[string]any{
+					"error_code":   nasRepositoryWriteDeniedCode,
+					"protocol":     spec.TargetNAS.Protocol,
+					"stage":        "repository_directory_create",
+					"mount_status": "mounted",
+				}, repositorySpec{}, nasRepositoryWriteDeniedMessage
+			}
 			return "", nil, nil, repositorySpec{}, mkErr.Error()
 		}
 		nassvc.LogSpec("repository_mkdir_ok", *spec.TargetNAS, "task_id", taskID, "repo_path", repoPath)
@@ -659,6 +670,10 @@ func (e *Engine) prepareManagedRepositoryLocked(
 		map[string]any{"config_file": configFile},
 	))
 	return configFile, env, result, spec, ""
+}
+
+func isNASRepositoryWriteDenied(spec nassvc.Spec, err error) bool {
+	return spec.Protocol == "smb" && errors.Is(err, fs.ErrPermission)
 }
 
 func managedProxyFSCreatePathExists(spec repositorySpec) (bool, error) {

--- a/src/agent/internal/engine/managed_backup_test.go
+++ b/src/agent/internal/engine/managed_backup_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io/fs"
 	"math"
 	"os"
 	"path/filepath"
@@ -78,6 +79,24 @@ func TestRepositoryNASPathRejectsEscapes(t *testing.T) {
 	want := filepath.Clean(testRepositoryMountPoint(t, 42) + "/hp-repos/storage-42")
 	if got != want {
 		t.Fatalf("expected %q, got %q", want, got)
+	}
+}
+
+func TestNASRepositoryWriteDeniedIsLimitedToSMBPermissionErrors(t *testing.T) {
+	smb := mustNASSpec(t, map[string]any{
+		"protocol": "smb", "server": "10.0.0.15", "share": "backup",
+		"username": "backup", "password": "secret", "mount_point": testRepositoryMountPoint(t, 42),
+	})
+	if !isNASRepositoryWriteDenied(*smb, fs.ErrPermission) {
+		t.Fatal("expected SMB permission error to be classified")
+	}
+	nfs := *smb
+	nfs.Protocol = "nfs"
+	if isNASRepositoryWriteDenied(nfs, fs.ErrPermission) {
+		t.Fatal("did not expect NFS permission error to be classified")
+	}
+	if isNASRepositoryWriteDenied(*smb, fs.ErrNotExist) {
+		t.Fatal("did not expect non-permission error to be classified")
 	}
 }
 

--- a/src/backend/apps/storage/services/internal/nas_repository.py
+++ b/src/backend/apps/storage/services/internal/nas_repository.py
@@ -28,7 +28,9 @@ NAS_AGENT_REPOSITORY_SUBDIR_TEMPLATE = f"{NAS_REPOSITORY_ROOT}/agent-{{node_id}}
 
 
 class NASRepositoryError(RuntimeError):
-    pass
+    def __init__(self, message: str, *, error_code: str = "REPOSITORY_CREATE_FAILED"):
+        super().__init__(message)
+        self.error_code = error_code
 
 
 def nas_agent_repository_subdir(node_id: int) -> str:
@@ -214,7 +216,12 @@ def _run_proxy_nas_repository_task(
             outcome.result,
             last_error=str(getattr(outcome.task, "last_error", "") or ""),
         )
-        raise NASRepositoryError(message or "NAS repository initialization failed.")
+        result = outcome.result if isinstance(outcome.result, dict) else {}
+        error_code = str(result.get("error_code") or "").strip()
+        raise NASRepositoryError(
+            message or "NAS repository initialization failed.",
+            error_code=error_code or "REPOSITORY_CREATE_FAILED",
+        )
     if not health_only:
         sync_proxy_mount_path_from_repo_status(repository, outcome.result)
     logger.info(

--- a/src/backend/apps/storage/services/internal/repository_create.py
+++ b/src/backend/apps/storage/services/internal/repository_create.py
@@ -811,7 +811,9 @@ def _create_error_code(exc: Exception) -> str:
         return REPOSITORY_ALREADY_EXISTS_CODE
     if isinstance(exc, RepositoryInitializationError):
         return "REPOSITORY_S3_CREATE_FAILED"
-    if isinstance(exc, (NASRepositoryError, ProxyFSRepositoryError)):
+    if isinstance(exc, NASRepositoryError):
+        return exc.error_code
+    if isinstance(exc, ProxyFSRepositoryError):
         return "REPOSITORY_CREATE_FAILED"
     if isinstance(exc, (ValidationError, DRFValidationError)):
         return "REPOSITORY_CREATE_INVALID"

--- a/src/backend/apps/storage/tests/test_repository_create.py
+++ b/src/backend/apps/storage/tests/test_repository_create.py
@@ -7,6 +7,7 @@ from apps.iam.models import Membership, Organization
 from apps.node.models import Node
 from apps.storage.repositories.models import Credential, Repository, RepositoryTask
 from apps.storage.services.internal.repository_create import (
+    _create_error_code,
     enqueue_repository_create_task,
     run_repository_create_task,
 )
@@ -15,6 +16,7 @@ from apps.storage.services.internal.repository_errors import (
     RepositoryAlreadyExistsError,
 )
 from apps.storage.services.internal.repository_initializer import RepositoryInitializationError
+from apps.storage.services.internal.nas_repository import NASRepositoryError
 from apps.task.models import Task
 
 
@@ -34,6 +36,50 @@ class RepositoryCreateTaskTests(TestCase):
             organization=self.org,
             role=Membership.Role.ADMIN,
         )
+
+    def test_nas_write_denied_error_code_is_preserved(self):
+        self.assertEqual(
+            _create_error_code(NASRepositoryError(
+                "The SMB share was mounted, but the Agent could not create the repository directory.",
+                error_code="NAS_REPOSITORY_WRITE_DENIED",
+            )),
+            "NAS_REPOSITORY_WRITE_DENIED",
+        )
+
+    @mock.patch(
+        "apps.storage.services.internal.repository_create.initialize_proxy_nas_repository"
+    )
+    def test_nas_write_denied_failure_is_saved_on_task(self, initialize):
+        proxy = Node.objects.create(
+            organization=self.org,
+            name="write-denied-proxy",
+            role=Node.Role.PROXY,
+            status=Node.Status.ACTIVE,
+            availability=Node.Availability.ONLINE,
+            ip_address="10.0.0.41",
+        )
+        repository = Repository.objects.create(
+            organization_id=self.org.id,
+            name="write-denied-nas",
+            repo_type=Repository.Type.NAS,
+            nas_protocol=Repository.NasProtocol.SMB,
+            status=Repository.Status.CREATING,
+            health=Repository.Health.OFFLINE,
+            bind_node_type=Repository.BindNodeType.PROXY,
+            bind_node_id=proxy.id,
+            config={"server_address": "10.0.0.10", "share_path": "/backup"},
+        )
+        initialize.side_effect = NASRepositoryError(
+            "The SMB share was mounted, but the Agent could not create the repository directory.",
+            error_code="NAS_REPOSITORY_WRITE_DENIED",
+        )
+        repository_task = self._enqueue_create(repository)
+
+        result = run_repository_create_task(repository_task_id=repository_task.id)
+
+        self.assertEqual(result["error_code"], "NAS_REPOSITORY_WRITE_DENIED")
+        repository_task.task.refresh_from_db()
+        self.assertEqual(repository_task.task.error_code, "NAS_REPOSITORY_WRITE_DENIED")
 
     def _s3_repository(self, *, name: str = "async-s3", status=Repository.Status.CREATING):
         credential = Credential.objects.create(

--- a/src/backend/apps/storage/tests/test_repository_proxy_bindings.py
+++ b/src/backend/apps/storage/tests/test_repository_proxy_bindings.py
@@ -14,6 +14,7 @@ from apps.node.models import Node
 from apps.node.models.base import NodeRole
 from apps.storage.repositories.models import Repository
 from apps.storage.services.internal.nas_repository import (
+    NASRepositoryError,
     check_proxy_nas_repository,
     initialize_proxy_nas_repository,
 )
@@ -259,6 +260,33 @@ class StorageRepositoryProxyBindingTests(TestCase):
         run_agent_task_sync.reset_mock()
         check_proxy_nas_repository(repo)
         self.assertEqual(run_agent_task_sync.call_args.kwargs["kind"], "repo.status")
+
+    @mock.patch("apps.storage.services.internal.nas_repository.run_agent_task_sync")
+    def test_target_nas_initializer_preserves_agent_write_denied_code(self, run_agent_task_sync):
+        run_agent_task_sync.return_value = mock.Mock(
+            task=mock.Mock(
+                status="failed",
+                last_error="The SMB share was mounted, but the Agent could not create the repository directory.",
+            ),
+            result={"error_code": "NAS_REPOSITORY_WRITE_DENIED"},
+            ok=False,
+        )
+        repo = Repository.objects.create(
+            organization_id=self.org.id,
+            name="target-nas-write-denied",
+            repo_type=Repository.Type.NAS,
+            nas_protocol=Repository.NasProtocol.SMB,
+            status=Repository.Status.CREATED,
+            health=Repository.Health.ONLINE,
+            bind_node_type=Repository.BindNodeType.PROXY,
+            bind_node_id=self.proxy_a.id,
+            config={"server_address": "192.168.8.82", "share_path": "/smb-share"},
+        )
+
+        with self.assertRaises(NASRepositoryError) as raised:
+            initialize_proxy_nas_repository(repo)
+
+        self.assertEqual(raised.exception.error_code, "NAS_REPOSITORY_WRITE_DENIED")
 
     def test_proxy_fs_rejects_non_proxy_bind_node(self):
         agent = Node.objects.create(

--- a/src/frontend/src/lib/nasMountTroubleshooting.test.ts
+++ b/src/frontend/src/lib/nasMountTroubleshooting.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import {
+  NAS_REPOSITORY_WRITE_DENIED,
+  nasRepositoryFailureMessage,
+} from './nasMountTroubleshooting'
+
+describe('NAS repository failure guidance', () => {
+  it('replaces the structured SMB write-denied error with localized guidance', () => {
+    expect(nasRepositoryFailureMessage(
+      NAS_REPOSITORY_WRITE_DENIED,
+      'mkdir /mounted/share/hp-repos: permission denied',
+      (key) => key,
+    )).toBe('repositoriesPage.nasRepositoryWriteDenied')
+  })
+
+  it('preserves unrelated failure messages', () => {
+    expect(nasRepositoryFailureMessage(
+      'REPOSITORY_CREATE_FAILED',
+      'mount SMB share: permission denied',
+      (key) => key,
+    )).toBe('mount SMB share: permission denied')
+  })
+
+  it('does not create an error message for a successful repository task', () => {
+    expect(nasRepositoryFailureMessage('', '', (key) => key)).toBe('')
+  })
+
+  it('maps the structured error without depending on the fallback message', () => {
+    expect(nasRepositoryFailureMessage(
+      NAS_REPOSITORY_WRITE_DENIED,
+      '',
+      (key) => key,
+    )).toBe('repositoriesPage.nasRepositoryWriteDenied')
+  })
+})

--- a/src/frontend/src/lib/nasMountTroubleshooting.ts
+++ b/src/frontend/src/lib/nasMountTroubleshooting.ts
@@ -1,4 +1,5 @@
 export const NAS_MOUNT_OPTIONS_FOCUS_QUERY = 'mount-options'
+export const NAS_REPOSITORY_WRITE_DENIED = 'NAS_REPOSITORY_WRITE_DENIED'
 
 export const SMB_MOUNT_OPTION_EXAMPLES = [
   'vers=3.0',
@@ -26,6 +27,17 @@ export function isSmbMountNegotiationError(message: string): boolean {
     SMB_MOUNT_NEGOTIATION_PATTERNS.some((pattern) => pattern.test(normalized)) &&
     SMB_MOUNT_CONTEXT_PATTERNS.some((pattern) => pattern.test(normalized))
   )
+}
+
+export function nasRepositoryFailureMessage(
+  errorCode: string | null | undefined,
+  fallback: string | null | undefined,
+  t: (key: string) => string,
+): string {
+  if (String(errorCode || '').trim() === NAS_REPOSITORY_WRITE_DENIED) {
+    return t('repositoriesPage.nasRepositoryWriteDenied')
+  }
+  return String(fallback || '').trim()
 }
 
 export function buildNasRepairMountOptionsPath(repositoryId: number): string {

--- a/src/frontend/src/locales/en.ts
+++ b/src/frontend/src/locales/en.ts
@@ -1809,6 +1809,7 @@ export const en = {
     taskOperationCheck: 'Repository Check',
     createAccepted: 'Repository creation started. Track progress in the list.',
     createFailed: 'Repository creation failed. Review the task details and retry or delete the failed entry.',
+    nasRepositoryWriteDenied: 'The SMB share was mounted, but the backup account cannot create the repository directory. Check the NAS share ACL for create, write, and delete permissions; also confirm that the share is not read-only and has available quota.',
     createSucceeded: 'Repository is ready',
     taskStatusPending: 'Pending',
     taskStatusRunning: 'Running',

--- a/src/frontend/src/pages/node/Repositories.vue
+++ b/src/frontend/src/pages/node/Repositories.vue
@@ -15,6 +15,7 @@ import { useProtectionSideNav } from '../../composables/useProtectionSideNav'
 import { useListTableLayout } from '../../composables/useListTableLayout'
 import { useListSearch } from '../../composables/useListSearch'
 import { nasMountProtocolIcon } from '../../lib/resourceIcons'
+import { nasRepositoryFailureMessage } from '../../lib/nasMountTroubleshooting'
 import {
   DEFAULT_S3_OBJECT_PREFIX,
   distinctS3EndpointPair,
@@ -958,7 +959,11 @@ async function reconcileRepositoryCreateTasks() {
       } else if (['failed', 'cancelled', 'timeout'].includes(status)) {
         repositoryCreatePending.value.delete(repositoryId)
         ElMessage.error({
-          message: result.value.error_message || `${pending.repositoryName}: ${t('repositoriesPage.createFailed')}`,
+          message: nasRepositoryFailureMessage(
+            result.value.error_code,
+            result.value.error_message,
+            t,
+          ) || `${pending.repositoryName}: ${t('repositoriesPage.createFailed')}`,
           grouping: true,
         })
         terminal = true

--- a/src/frontend/src/pages/protection/components/TaskDetailDrawer.vue
+++ b/src/frontend/src/pages/protection/components/TaskDetailDrawer.vue
@@ -45,6 +45,7 @@ import { lifecycleStatusTagAttrs } from '../../../lib/statusTag'
 import { resolveTaskBackupSourceResource, resolveTaskBackupSourceResourceFromPayload } from '../../../lib/taskBackupSourceResource'
 import { parseTaskStepStatusEvent, taskEventMessageKey, taskEventObjectText } from '../../../lib/taskEventDisplay'
 import { hasExpandableTaskStep, hasExpandedTaskStep } from '../../../lib/taskStepExpansion'
+import { nasRepositoryFailureMessage } from '../../../lib/nasMountTroubleshooting'
 import TaskStatusTag from '../../../components/TaskStatusTag.vue'
 import FlowSourceSummaryCell from './FlowSourceSummaryCell.vue'
 import FlowSourceConnectionCell from './FlowSourceConnectionCell.vue'
@@ -326,10 +327,17 @@ function taskEventMetadataText(event: TaskEventRow, keys: string[]) {
 
 function eventErrorText(event: TaskEventRow) {
   const message = taskEventMetadataText(event, ['error_message'])
-  if (!message) return ''
   const code = taskEventMetadataText(event, ['error_code'])
-  return code ? `[${code}] ${message}` : message
+  const display = nasRepositoryFailureMessage(code, message, t)
+  if (!display) return ''
+  return code && display === message ? `[${code}] ${display}` : display
 }
+
+const taskFailureMessage = computed(() => nasRepositoryFailureMessage(
+  activeTask.value?.error_code,
+  activeTask.value?.error_message,
+  t,
+))
 
 function eventObjectText(event: TaskEventRow) {
   const canonicalValue = taskEventObjectText(event)
@@ -798,6 +806,14 @@ watch(
           </div>
         </div>
       </section>
+
+      <ElAlert
+        v-if="taskFailureMessage"
+        :title="taskFailureMessage"
+        type="error"
+        :closable="false"
+        show-icon
+      />
 
       <ElAlert
         v-if="['waiting', 'blocked'].includes(activeTask.status) && activeDependencies.length"

--- a/src/frontend/src/pages/protection/components/TaskDetailDrawerNasWriteDenied.test.ts
+++ b/src/frontend/src/pages/protection/components/TaskDetailDrawerNasWriteDenied.test.ts
@@ -1,0 +1,13 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const source = readFileSync(resolve(process.cwd(), 'src/pages/protection/components/TaskDetailDrawer.vue'), 'utf8')
+
+describe('TaskDetailDrawer NAS repository write denial', () => {
+  it('uses the shared structured-error mapping for task and event failures', () => {
+    expect(source).toContain("import { nasRepositoryFailureMessage } from '../../../lib/nasMountTroubleshooting'")
+    expect(source).toContain('const taskFailureMessage = computed(() => nasRepositoryFailureMessage(')
+    expect(source).toContain('const display = nasRepositoryFailureMessage(code, message, t)')
+  })
+})


### PR DESCRIPTION
## Summary

- Classify SMB repository-directory creation failures after a successful mount with a stable Agent error code.
- Preserve the error code through the repository task lifecycle.
- Show localized NAS ACL, read-only, and quota guidance in repository and task views.

## Testing

- `go test ./internal/engine -run 'TestNASRepositoryWriteDeniedIsLimitedToSMBPermissionErrors|TestManagedRepositoryInitializeRejectsExistingWithoutConnect'`\n- `npm test -- --run src/lib/nasMountTroubleshooting.test.ts src/pages/protection/components/TaskDetailDrawerNasWriteDenied.test.ts`\n- `python manage.py test apps.storage.tests.test_repository_proxy_bindings.StorageRepositoryProxyBindingTests.test_target_nas_initializer_preserves_agent_write_denied_code apps.storage.tests.test_repository_create.RepositoryCreateTaskTests.test_nas_write_denied_failure_is_saved_on_task --keepdb`\n\nCloses #226