### PR TITLE
Support Python 3.8 agent packaging

### DIFF
--- a/src/agent/scripts/package.sh
+++ b/src/agent/scripts/package.sh
@@ -461,7 +461,10 @@ def safe_extract_tar(archive_path: Path, destination: Path) -> Path:
             roots.add(parts[0])
         if len(roots) != 1:
             raise PrerequisiteError(f"base archive must contain one root directory: {archive_path}")
-        archive.extractall(destination, filter="data")
+        # Python 3.12 adds tarfile's data filter. The checks above enforce the
+        # same restrictions before extraction so supported older hosts (such as
+        # Ubuntu 20.04's Python 3.8) can package offline Agent bundles too.
+        archive.extractall(destination, members=members)
     return destination / next(iter(roots))
 
 

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -204,7 +204,7 @@ grep -F 'source_version=0.20.0' <<<"${component_identity}" >/dev/null
 grep -F 'build_compose_file=docker-compose.standalone.yml' \
 	<<<"${component_identity}" >/dev/null
 
-grep -F 'archive.extractall(destination, filter="data")' \
+grep -F 'archive.extractall(destination, members=members)' \
 	"${ROOT}/src/agent/scripts/package.sh" >/dev/null
 grep -F 'chown postgres:postgres /var/lib/postgresql/data' \
 	"${ROOT}/deploy/installer/sourcelens/docker-compose.template.yml" >/dev/null


### PR DESCRIPTION
## Summary

- Keep offline Agent archive extraction compatible with Python 3.8 hosts.
- Preserve the existing path, link, device, and root-directory safety checks before extraction.
- Update the release contract assertion for the compatible extraction path.

## Testing

- `bash tools/quality/check-release-contracts.sh`