### PR TITLE
fix(protection): refresh source size for each backup

### DIFF
--- a/src/backend/apps/protection/services/backup_task.py
+++ b/src/backend/apps/protection/services/backup_task.py
@@ -621,8 +621,9 @@ def start_backup_tasks(
                         source_ref_id=source.source_ref_id,
                         repository_id=repository.id,
                     )
-                # Directory size (du) is pre-cached asynchronously on config save.
-                # Progress degrades when estimates are still missing. Never block Backup Now.
+                # Directory size is refreshed asynchronously for every new
+                # backup because configured path contents can change without a
+                # config edit. Never block the Backup Now request on path.size.
             except ValidationError as exc:
                 skipped_count += 1
                 results.append(
@@ -716,6 +717,7 @@ def start_backup_tasks(
                                 "backup_config_id": locked_config.id,
                                 "repository_id": locked_config.repository_id,
                                 "directory_count": directory_count,
+                                "directory_size_refresh_required": True,
                             },
                             resources=[
                                 {
@@ -749,6 +751,17 @@ def start_backup_tasks(
                             metadata={"task_display_name": task.display_name},
                         )
 
+                        from apps.protection.tasks.directory_size_estimate import (
+                            refresh_backup_config_directory_estimates_task,
+                        )
+
+                        transaction.on_commit(
+                            lambda config_id=locked_config.id, task_uuid=str(task.task_uuid): refresh_backup_config_directory_estimates_task.delay(
+                                config_id=config_id,
+                                force_refresh=True,
+                                task_uuid=task_uuid,
+                            )
+                        )
                         transaction.on_commit(
                             lambda org_id=organization_id, task_uuid=str(task.task_uuid), snapshot_id=snapshot.id: _queue_backup_execution(
                                 organization_id=org_id,

--- a/src/backend/apps/protection/services/directory_size_estimate.py
+++ b/src/backend/apps/protection/services/directory_size_estimate.py
@@ -133,6 +133,13 @@ def _du_total(config: BackupConfig) -> int:
     return _du_total_from_directories(config.directories.all())
 
 
+def _all_directory_estimates_verified(config: BackupConfig) -> bool:
+    directories = list(config.directories.all())
+    return bool(directories) and all(
+        directory.size_estimated_at is not None for directory in directories
+    )
+
+
 def backup_config_needs_directory_estimate_refresh(config: BackupConfig) -> bool:
     """True when at least one directory still needs a path.size attempt."""
     return any(
@@ -270,6 +277,7 @@ def refresh_backup_config_directory_estimates_by_id(
     *,
     config_id: int,
     attempt: int = 1,
+    force_refresh: bool = False,
 ) -> dict[str, Any]:
     """Celery entry: pre-cache missing estimates for one backup config."""
     attempt_n = max(1, int(attempt or 1))
@@ -282,6 +290,12 @@ def refresh_backup_config_directory_estimates_by_id(
             "attempt": attempt_n,
             "should_requeue": False,
         }
+
+    # A newly created backup must not reuse a size cached when the configured
+    # path contained different files. Invalidate once, then let the existing
+    # bounded retry flow handle every directory as a normal pending estimate.
+    if force_refresh and attempt_n == 1:
+        invalidate_backup_config_directory_estimates(config=config)
 
     timed_out = False
     resolve_failed = False
@@ -331,6 +345,7 @@ def refresh_backup_config_directory_estimates_by_id(
         "config_id": int(config.id),
         "status": status,
         "du_total": int(du_total),
+        "du_total_known": _all_directory_estimates_verified(config),
         "attempt": attempt_n,
         "should_requeue": should_requeue,
     }

--- a/src/backend/apps/protection/services/progress/step3_progress.py
+++ b/src/backend/apps/protection/services/progress/step3_progress.py
@@ -52,10 +52,33 @@ def du_total_for_task(
     task,
     source_snapshot: BackupSourceSnapshot | None = None,
 ) -> int:
+    result_payload = task.result_payload if isinstance(task.result_payload, dict) else {}
+    if result_payload.get("du_total_known"):
+        return _int(result_payload.get("du_total"))
+    request_payload = task.request_payload if isinstance(task.request_payload, dict) else {}
+    if request_payload.get("du_total_known"):
+        return _int(request_payload.get("du_total"))
+    transfer = result_payload.get("transfer_progress")
+    if isinstance(transfer, dict):
+        stored = _int(transfer.get("du_total"))
+        if stored > 0:
+            return stored
+
     config = _backup_config_for_task(task=task, source_snapshot=source_snapshot)
     if config is None:
-        stored = _int((task.result_payload or {}).get("du_total") if isinstance(task.result_payload, dict) else 0)
-        return stored
+        return _int(result_payload.get("du_total"))
+
+    if request_payload.get("directory_size_refresh_required"):
+        directories = list(config.directories.all())
+        task_created_at = getattr(task, "created_at", None)
+        if not directories or task_created_at is None:
+            return 0
+        if any(
+            directory.size_estimated_at is None
+            or directory.size_estimated_at < task_created_at
+            for directory in directories
+        ):
+            return 0
     return du_total_for_backup_config(config)
 
 
@@ -280,18 +303,39 @@ def enrich_step3_backup_transfer(
     prev = previous if isinstance(previous, dict) else {}
     current_now = now or timezone.now()
 
-    uploaded_bytes = _int(aggregate.get("uploaded_bytes"))
-    if uploaded_bytes <= 0:
-        uploaded_bytes = _int(merged.get("uploaded_bytes"))
-    estimated_bytes = _int(aggregate.get("estimated_bytes"))
-    if estimated_bytes <= 0:
-        estimated_bytes = _int(merged.get("estimated_bytes"))
+    # Agent reconnect snapshots can temporarily contain zeroed counters. Keep
+    # task-scoped cumulative values monotonic instead of letting a transient
+    # snapshot reset the Step 3 row while its display percent stays latched.
+    uploaded_bytes = max(
+        _int(aggregate.get("uploaded_bytes")),
+        _int(merged.get("uploaded_bytes")),
+        _int(prev.get("uploaded_bytes")),
+        _int(prev.get("bytes_done")),
+    )
+    uploaded_count = max(
+        _int(aggregate.get("uploaded_count")),
+        _int(merged.get("uploaded_count")),
+        _int(prev.get("uploaded_count")),
+    )
+    hashed_count = max(
+        _int(aggregate.get("hashed_count")),
+        _int(merged.get("hashed_count")),
+        _int(prev.get("hashed_count")),
+    )
+    estimated_bytes = max(
+        _int(aggregate.get("estimated_bytes")),
+        _int(merged.get("estimated_bytes")),
+        _int(prev.get("estimated_bytes")),
+    )
 
     merged["uploaded_bytes"] = uploaded_bytes
-    merged["uploaded_count"] = _int(aggregate.get("uploaded_count"))
-    merged["hashed_count"] = _int(aggregate.get("hashed_count"))
+    merged["uploaded_count"] = uploaded_count
+    merged["hashed_count"] = hashed_count
     merged["estimated_bytes"] = estimated_bytes
-    merged["du_total"] = du_total
+    frozen_du_total = _int(prev.get("du_total"))
+    if frozen_du_total <= 0:
+        frozen_du_total = du_total
+    merged["du_total"] = frozen_du_total
 
     switch_latched = bool(prev.get("switch_latched"))
     kopia_total_locked = _int(prev.get("kopia_total_locked"))
@@ -318,8 +362,8 @@ def enrich_step3_backup_transfer(
             effective_total = kopia_total_locked
         merged["bytes_total_estimated"] = False
     else:
-        effective_total = du_total
-        merged["bytes_total_estimated"] = du_total > 0
+        effective_total = frozen_du_total
+        merged["bytes_total_estimated"] = frozen_du_total > 0
 
     merged["bytes_done"] = uploaded_bytes
     if effective_total > 0:

--- a/src/backend/apps/protection/tasks/directory_size_estimate.py
+++ b/src/backend/apps/protection/tasks/directory_size_estimate.py
@@ -1,10 +1,32 @@
+from django.db import transaction
+
 from celery import shared_task
 
 from apps.protection.services.directory_size_estimate import (
     refresh_backup_config_directory_estimates_by_id,
 )
+from apps.task.models import Task
 
 _REQUEUE_COUNTDOWN_SECONDS = 5
+
+
+def _freeze_task_directory_size(*, task_uuid: str, du_total: int) -> None:
+    with transaction.atomic():
+        task = Task.objects.select_for_update().filter(
+            task_uuid=task_uuid,
+            task_type=Task.Type.BACKUP,
+        ).first()
+        if task is None:
+            return
+        result_payload = dict(task.result_payload) if isinstance(task.result_payload, dict) else {}
+        result_payload["du_total"] = max(0, int(du_total))
+        result_payload["du_total_known"] = True
+        request_payload = dict(task.request_payload) if isinstance(task.request_payload, dict) else {}
+        request_payload["du_total"] = max(0, int(du_total))
+        request_payload["du_total_known"] = True
+        task.result_payload = result_payload
+        task.request_payload = request_payload
+        task.save(update_fields=["request_payload", "result_payload", "updated_at"])
 
 
 @shared_task(
@@ -16,15 +38,28 @@ def refresh_backup_config_directory_estimates_task(
     *,
     config_id: int,
     attempt: int = 1,
+    force_refresh: bool = False,
+    task_uuid: str | None = None,
 ) -> dict:
     result = refresh_backup_config_directory_estimates_by_id(
         config_id=int(config_id),
         attempt=int(attempt or 1),
+        force_refresh=bool(force_refresh),
     )
+    if task_uuid and result.get("status") == "ok" and result.get("du_total_known"):
+        _freeze_task_directory_size(
+            task_uuid=str(task_uuid),
+            du_total=int(result.get("du_total") or 0),
+        )
     if result.get("should_requeue"):
         next_attempt = int(result.get("attempt") or 1) + 1
         refresh_backup_config_directory_estimates_task.apply_async(
-            kwargs={"config_id": int(config_id), "attempt": next_attempt},
+            kwargs={
+                "config_id": int(config_id),
+                "attempt": next_attempt,
+                "force_refresh": False,
+                "task_uuid": task_uuid,
+            },
             countdown=_REQUEUE_COUNTDOWN_SECONDS,
         )
     return result

--- a/src/backend/apps/protection/tests/test_backup_task_api.py
+++ b/src/backend/apps/protection/tests/test_backup_task_api.py
@@ -262,7 +262,15 @@ class ProtectionBackupTaskApiTests(TestCase):
         mock_cache_add.assert_called_once()
 
     @patch("apps.protection.services.backup_task._queue_backup_execution")
-    def test_start_backup_task_api_creates_task_and_source_snapshot(self, mock_queue):
+    @patch(
+        "apps.protection.tasks.directory_size_estimate."
+        "refresh_backup_config_directory_estimates_task.delay"
+    )
+    def test_start_backup_task_api_creates_task_and_source_snapshot(
+        self,
+        mock_size_refresh,
+        mock_queue,
+    ):
         with self.captureOnCommitCallbacks(execute=True):
             response = self.client.post(
                 "/api/v1/protection/backup-tasks/",
@@ -292,11 +300,22 @@ class ProtectionBackupTaskApiTests(TestCase):
         self.assertEqual(source_resource.resource_subtype, "agent")
         self.assertEqual(source_resource.resource_id, self.agent.id)
         mock_queue.assert_called_once()
+        mock_size_refresh.assert_called_once_with(
+            config_id=self.config.id,
+            force_refresh=True,
+            task_uuid=str(task.task_uuid),
+        )
+        self.assertTrue(task.request_payload["directory_size_refresh_required"])
 
     @patch("apps.protection.services.directory_size_estimate.run_agent_task_sync")
     @patch("apps.protection.services.backup_task._queue_backup_execution")
+    @patch(
+        "apps.protection.tasks.directory_size_estimate."
+        "refresh_backup_config_directory_estimates_task.delay"
+    )
     def test_start_backup_task_does_not_sync_directory_size_estimate(
         self,
+        mock_size_refresh,
         mock_queue,
         mock_path_size,
     ):
@@ -314,6 +333,7 @@ class ProtectionBackupTaskApiTests(TestCase):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.content)
         self.assertEqual(response.data["created_count"], 1)
         mock_queue.assert_called_once()
+        mock_size_refresh.assert_called_once()
         mock_path_size.assert_not_called()
 
     @patch("apps.protection.services.backup_task._queue_backup_execution")
@@ -518,7 +538,15 @@ class ProtectionBackupTaskApiTests(TestCase):
         mock_queue.assert_called_once()
 
     @patch("apps.protection.services.backup_task._queue_backup_execution")
-    def test_start_backup_task_api_reuses_item_when_idempotency_key_repeated(self, mock_queue):
+    @patch(
+        "apps.protection.tasks.directory_size_estimate."
+        "refresh_backup_config_directory_estimates_task.delay"
+    )
+    def test_start_backup_task_api_reuses_item_when_idempotency_key_repeated(
+        self,
+        mock_size_refresh,
+        mock_queue,
+    ):
         payload = {
             "source_ids": [f"agent:{self.agent.id}"],
             "trigger_type": "manual",
@@ -548,6 +576,7 @@ class ProtectionBackupTaskApiTests(TestCase):
         self.assertEqual(Task.objects.count(), 1)
         self.assertEqual(BackupSourceSnapshot.objects.count(), 1)
         mock_queue.assert_called_once()
+        mock_size_refresh.assert_called_once()
 
     def test_start_backup_task_api_rejects_running_duplicate(self):
         Task.objects.create(

--- a/src/backend/apps/protection/tests/test_directory_size_estimate.py
+++ b/src/backend/apps/protection/tests/test_directory_size_estimate.py
@@ -24,6 +24,8 @@ from apps.protection.services.directory_size_estimate import (
     refresh_missing_backup_config_directory_estimates,
 )
 from apps.storage.repositories.models import Repository
+from apps.task.models import Task
+from apps.task.services.interface import create_task
 
 
 class DirectorySizeEstimateTests(TestCase):
@@ -231,6 +233,31 @@ class DirectorySizeEstimateTests(TestCase):
         )
         self.assertEqual(total, 2048)
         mock_estimate.assert_not_called()
+
+    @patch(
+        "apps.protection.services.directory_size_estimate.estimate_directory_size_bytes",
+        return_value=2_000_000_000,
+    )
+    @patch("apps.protection.services.directory_size_estimate._resolve_execution_target")
+    def test_forced_refresh_replaces_cached_estimate(self, mock_resolve, mock_estimate):
+        self.directory.estimated_size_bytes = 12_500_000
+        self.directory.size_estimated_at = timezone.now()
+        self.directory.save(
+            update_fields=["estimated_size_bytes", "size_estimated_at", "updated_at"]
+        )
+        mock_resolve.return_value = self._target()
+
+        result = refresh_backup_config_directory_estimates_by_id(
+            config_id=self.config.id,
+            force_refresh=True,
+        )
+
+        self.directory.refresh_from_db()
+        self.assertEqual(result["status"], "ok")
+        self.assertEqual(result["du_total"], 2_000_000_000)
+        self.assertTrue(result["du_total_known"])
+        self.assertEqual(self.directory.estimated_size_bytes, 2_000_000_000)
+        mock_estimate.assert_called_once()
 
     @patch(
         "apps.protection.services.directory_size_estimate.estimate_directory_size_bytes"
@@ -503,6 +530,81 @@ class DirectorySizeEstimateTests(TestCase):
             )
         self.assertTrue(result["should_requeue"])
         mock_async.assert_called_once_with(
-            kwargs={"config_id": self.config.id, "attempt": 3},
+            kwargs={
+                "config_id": self.config.id,
+                "attempt": 3,
+                "force_refresh": False,
+                "task_uuid": None,
+            },
             countdown=5,
         )
+
+    @patch(
+        "apps.protection.tasks.directory_size_estimate."
+        "refresh_backup_config_directory_estimates_by_id"
+    )
+    def test_task_freezes_refreshed_total_on_backup_task(self, mock_by_id):
+        from apps.protection.tasks.directory_size_estimate import (
+            refresh_backup_config_directory_estimates_task,
+        )
+
+        task = create_task(
+            organization_id=self.org.id,
+            task_type=Task.Type.BACKUP,
+            display_name="Backup directory size",
+            request_payload={"backup_config_id": self.config.id},
+        )
+        mock_by_id.return_value = {
+            "config_id": self.config.id,
+            "status": "ok",
+            "du_total": 2_000_000_000,
+            "du_total_known": True,
+            "attempt": 1,
+            "should_requeue": False,
+        }
+
+        refresh_backup_config_directory_estimates_task.run(
+            config_id=self.config.id,
+            force_refresh=True,
+            task_uuid=str(task.task_uuid),
+        )
+
+        task.refresh_from_db()
+        self.assertEqual(task.request_payload["du_total"], 2_000_000_000)
+        self.assertTrue(task.request_payload["du_total_known"])
+        self.assertEqual(task.result_payload["du_total"], 2_000_000_000)
+        self.assertTrue(task.result_payload["du_total_known"])
+
+    @patch(
+        "apps.protection.tasks.directory_size_estimate."
+        "refresh_backup_config_directory_estimates_by_id"
+    )
+    def test_task_does_not_freeze_unverified_total(self, mock_by_id):
+        from apps.protection.tasks.directory_size_estimate import (
+            refresh_backup_config_directory_estimates_task,
+        )
+
+        task = create_task(
+            organization_id=self.org.id,
+            task_type=Task.Type.BACKUP,
+            display_name="Backup directory size unavailable",
+            request_payload={"backup_config_id": self.config.id},
+        )
+        mock_by_id.return_value = {
+            "config_id": self.config.id,
+            "status": "ok",
+            "du_total": 0,
+            "du_total_known": False,
+            "attempt": 1,
+            "should_requeue": False,
+        }
+
+        refresh_backup_config_directory_estimates_task.run(
+            config_id=self.config.id,
+            force_refresh=True,
+            task_uuid=str(task.task_uuid),
+        )
+
+        task.refresh_from_db()
+        self.assertNotIn("du_total", task.request_payload)
+        self.assertNotIn("du_total", task.result_payload or {})

--- a/src/backend/apps/protection/tests/test_step3_progress.py
+++ b/src/backend/apps/protection/tests/test_step3_progress.py
@@ -80,6 +80,51 @@ class Step3ProgressTests(SimpleTestCase):
         self.assertIsNone(transfer.get("step3_display_percent"))
         self.assertIsNone(transfer.get("eta_seconds"))
 
+    def test_backup_reconnect_keeps_cumulative_transfer_counters(self):
+        transfer = enrich_step3_backup_transfer(
+            transfer={"phase": "transferring", "uploaded_bytes": 0},
+            previous={
+                "phase": "transferring",
+                "uploaded_bytes": 5_000_000,
+                "bytes_done": 5_000_000,
+                "uploaded_count": 40,
+                "hashed_count": 80,
+                "estimated_bytes": 12_500_000,
+                "step3_display_percent": 40.0,
+            },
+            aggregate={
+                "uploaded_bytes": 0,
+                "uploaded_count": 0,
+                "hashed_count": 0,
+                "estimated_bytes": 0,
+            },
+            du_total=12_500_000,
+        )
+
+        self.assertEqual(transfer["bytes_done"], 5_000_000)
+        self.assertEqual(transfer["uploaded_bytes"], 5_000_000)
+        self.assertEqual(transfer["uploaded_count"], 40)
+        self.assertEqual(transfer["hashed_count"], 80)
+        self.assertEqual(transfer["estimated_bytes"], 12_500_000)
+        self.assertEqual(transfer["step3_display_percent"], 40.0)
+
+    def test_backup_keeps_task_scoped_source_total(self):
+        first = enrich_step3_backup_transfer(
+            transfer={"phase": "transferring"},
+            previous={},
+            aggregate={"uploaded_bytes": 100_000_000},
+            du_total=2_000_000_000,
+        )
+        second = enrich_step3_backup_transfer(
+            transfer={"phase": "transferring"},
+            previous=first,
+            aggregate={"uploaded_bytes": 200_000_000},
+            du_total=3_000_000_000,
+        )
+
+        self.assertEqual(second["du_total"], 2_000_000_000)
+        self.assertEqual(second["bytes_total"], 2_000_000_000)
+
     def test_should_latch_requires_uploaded_and_stable_estimate(self):
         now = timezone.now()
         history = [{"at": (now - timedelta(seconds=index)).isoformat(), "estimated_bytes": 1_050_000} for index in range(12)]

--- a/src/frontend/src/lib/kopiaProgress.test.ts
+++ b/src/frontend/src/lib/kopiaProgress.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+
+import { transferCapacityText } from './kopiaProgress'
+
+const t = (key: string, args?: Record<string, unknown>) => {
+  if (key.endsWith('bytesCapacityRef')) return `Transferred: ${args?.done} / source data: ${args?.total}`
+  if (key.endsWith('bytesCapacityEst')) return `Incremental transfer: ${args?.done} / est. ${args?.total}`
+  if (key.endsWith('bytesCapacity')) return `${args?.done} / ${args?.total}`
+  return key
+}
+
+describe('transferCapacityText', () => {
+  it('labels the logical source-data reference total explicitly', () => {
+    expect(transferCapacityText(t, {
+      bytes_done: 5_000_000,
+      bytes_total: 2_000_000_000,
+      bytes_total_known: true,
+      bytes_total_reference: true,
+    })).toBe('Transferred: 5.00 MB / source data: 2.00 GB')
+  })
+
+  it('labels a Kopia estimate as incremental transfer volume', () => {
+    expect(transferCapacityText(t, {
+      bytes_done: 5_000_000,
+      bytes_total: 12_500_000,
+      bytes_total_known: true,
+      estimated_bytes: 12_500_000,
+    })).toBe('Incremental transfer: 5.00 MB / est. 12.5 MB')
+  })
+})

--- a/src/frontend/src/lib/kopiaProgress.ts
+++ b/src/frontend/src/lib/kopiaProgress.ts
@@ -4,6 +4,7 @@ export type KopiaProgressAggregate = {
   bytes_total: number | null
   bytes_total_known: boolean
   bytes_total_reference?: boolean
+  bytes_total_estimated?: boolean
   speed_bps: number | null
   hash_speed_bps?: number | null
   upload_speed_bps?: number | null
@@ -161,6 +162,12 @@ export function transferCapacityText(t: TranslateFn, transfer?: TransferProgress
   const done = formatBytes(transfer.bytes_done)
   if (transfer.bytes_total_known && transfer.bytes_total != null) {
     const total = formatBytes(transfer.bytes_total)
+    if (transfer.bytes_total_reference) {
+      return t('protection.taskProgress.bytesCapacityRef', { done, total })
+    }
+    if (transfer.bytes_total_estimated || (transfer.estimated_bytes || 0) > 0) {
+      return t('protection.taskProgress.bytesCapacityEst', { done, total })
+    }
     return t('protection.taskProgress.bytesCapacity', { done, total })
   }
   if ((transfer.bytes_done || 0) > 0) {

--- a/src/frontend/src/locales/enProtectionPages.ts
+++ b/src/frontend/src/locales/enProtectionPages.ts
@@ -3,8 +3,8 @@ export const enProtectionPages = {
   taskProgress: {
     bytesTransferred: '{size} transferred',
     bytesCapacity: '{done} / {total}',
-    bytesCapacityEst: '{done} / {total} (est.)',
-    bytesCapacityRef: '{done} / {total} (ref.)',
+    bytesCapacityEst: 'Incremental transfer: {done} / est. {total}',
+    bytesCapacityRef: 'Transferred: {done} / source data: {total}',
     etaSeconds: '{n}s left',
     etaMinutes: '{n} min left',
     etaHours: '{n}h left',


### PR DESCRIPTION
## Problem and root cause

Backup progress reused `BackupConfigDirectory.estimated_size_bytes`, which was only refreshed when the backup configuration changed. Adding or removing files under an unchanged configured path therefore left subsequent backups showing a stale source capacity. Reconnect snapshots could also replace cumulative transfer counters with transient zero values.

## Solution

- Refresh configured directory sizes asynchronously for every newly created backup without blocking the start request.
- Freeze a verified logical source total on the corresponding task and keep the backup running when size estimation is unavailable.
- Preserve cumulative transfer counters across reconnect snapshots.
- Label logical source capacity separately from Kopia's incremental transfer estimate.

## Validation

- Targeted Django regression suite: 38 tests passed
- Host protection backend suite: 252 tests passed
- Ruff on changed Python files: passed
- Targeted Vitest: 2 tests passed
- ESLint on changed frontend files: passed
- Frontend production build: passed
- English source and `git diff --check`: passed
- Full Vitest under the available Node 26 runtime: 7 unrelated `localStorage` failures, baseline-equivalent to clean `origin/main` at `3cc5a34d6b5ab06aff7cf035f083f1c456c71f73`; no additional failure identities
- Manual testing: passed

## Risks and compatibility

Each newly created backup schedules an additional bounded asynchronous `path.size` scan, which can add source I/O but does not delay task creation. No database migration or Agent wire-schema change is required, and older tasks retain the existing fallback behavior.

Fixes #494
