### PR TITLE
fix(protection): make force cleanup resilient to offline sources

### DIFF
--- a/src/backend/apps/protection/services/backup_config_reset.py
+++ b/src/backend/apps/protection/services/backup_config_reset.py
@@ -14,16 +14,14 @@ from apps.protection.services.kopia_snapshot_delete import (
     normalize_kopia_snapshot_id,
 )
 from apps.protection.services.backup_task import (
-    _resolve_execution_target,
     _set_step_status,
 )
 from apps.protection.services.repository_compatibility import validate_backup_repository_compatible
 from apps.protection.services.snapshot_repository_locator import (
     group_snapshot_directories_by_repository_locator,
-    resolve_snapshot_repository_reader,
 )
+from apps.protection.services.snapshot_delete_execution import run_snapshot_delete
 from apps.storage.repositories.models import Repository
-from apps.storage.services.internal.repository_access import repository_uses_bound_proxy
 from apps.source.constants import PipelineStep
 from apps.source.services.internal.selectable_ids import parse_selectable_id
 from apps.source.services.internal.source_pipeline import force_set_pipeline_steps
@@ -725,28 +723,15 @@ def _run_kopia_snapshot_delete(
 ):
     from apps.node.services.interface import run_agent_task_sync
 
-    fallback_target = None
-    if not repository_uses_bound_proxy(repository):
-        fallback_target = _resolve_execution_target(source_snapshot=source_snapshot)
-    repository_access = resolve_snapshot_repository_reader(
+    return run_snapshot_delete(
+        organization_id=organization_id,
+        task=task,
+        source_snapshot=source_snapshot,
         directory=directory,
         repository=repository,
-        fallback_node=fallback_target.node if fallback_target is not None else None,
-        source_type=source_snapshot.source_type,
-        source_ref_id=source_snapshot.source_ref_id,
-    )
-    return run_agent_task_sync(
-        organization_id=organization_id,
-        node_id=repository_access.node.id,
-        kind="snapshot.delete",
-        payload={
-            "repository": repository_access.repository_payload,
-            "kopia_snapshot_ids": kopia_ids,
-        },
+        kopia_ids=kopia_ids,
         correlation_type="protection.backup_config_reset",
-        correlation_id=str(task.task_uuid),
-        parent_task=task,
-        wait_timeout_seconds=3600,
+        agent_runner=run_agent_task_sync,
     )
 
 

--- a/src/backend/apps/protection/services/snapshot_delete.py
+++ b/src/backend/apps/protection/services/snapshot_delete.py
@@ -12,7 +12,6 @@ from django.utils import timezone
 from apps.node.services.interface import run_agent_task_sync
 from apps.protection.models import BackupSourceSnapshot, BackupSourceSnapshotDirectory
 from apps.protection.services.backup_task import (
-    _resolve_execution_target,
     _set_step_status,
 )
 from apps.protection.services.kopia_snapshot_delete import (
@@ -22,9 +21,8 @@ from apps.protection.services.kopia_snapshot_delete import (
 from apps.protection.services.repository_compatibility import validate_backup_repository_compatible
 from apps.protection.services.snapshot_repository_locator import (
     group_snapshot_directories_by_repository_locator,
-    resolve_snapshot_repository_reader,
 )
-from apps.storage.services.internal.repository_access import repository_uses_bound_proxy
+from apps.protection.services.snapshot_delete_execution import run_snapshot_delete
 from apps.task.models import Task, TaskEvent, TaskResource, TaskStep
 from apps.task.services.interface import (
     append_task_step_event,
@@ -560,9 +558,6 @@ def _run_snapshot_delete_task_locked(
         source_ref_id=source_snapshot.source_ref_id,
         repository_id=source_snapshot.repository_id,
     )
-    fallback_target = None
-    if not repository_uses_bound_proxy(repository):
-        fallback_target = _resolve_execution_target(source_snapshot=source_snapshot)
     _set_step_status(
         task=task,
         step_name="delete_kopia_snapshots",
@@ -600,27 +595,15 @@ def _run_snapshot_delete_task_locked(
     now = timezone.now()
     for group in groups:
         group_kopia_ids = _kopia_snapshot_ids(group)
-        repository_access = resolve_snapshot_repository_reader(
+        outcome = run_snapshot_delete(
+            organization_id=organization_id,
+            task=task,
+            source_snapshot=source_snapshot,
             directory=group[0],
             repository=repository,
-            fallback_node=(
-                fallback_target.node if fallback_target is not None else None
-            ),
-            source_type=source_snapshot.source_type,
-            source_ref_id=source_snapshot.source_ref_id,
-        )
-        outcome = run_agent_task_sync(
-            organization_id=organization_id,
-            node_id=repository_access.node.id,
-            kind="snapshot.delete",
-            payload={
-                "repository": repository_access.repository_payload,
-                "kopia_snapshot_ids": group_kopia_ids,
-            },
+            kopia_ids=group_kopia_ids,
             correlation_type="protection.snapshot_delete",
-            correlation_id=str(task.task_uuid),
-            parent_task=task,
-            wait_timeout_seconds=3600,
+            agent_runner=run_agent_task_sync,
         )
         result = outcome.result if isinstance(outcome.result, dict) else {}
         group_results = (

--- a/src/backend/apps/protection/services/snapshot_delete_execution.py
+++ b/src/backend/apps/protection/services/snapshot_delete_execution.py
@@ -1,0 +1,209 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from django.core.exceptions import ValidationError
+
+from apps.node.models import Node, NodeTask
+from apps.node.services.interface import AgentTaskSyncResult
+from apps.node.services.internal.node_registry import node_is_available_for_work
+from apps.node.models.base import NodeRole
+from apps.protection.models import BackupSourceSnapshot, BackupSourceSnapshotDirectory
+from apps.protection.services.source_execution import resolve_source_execution_target
+from apps.protection.services.snapshot_repository_locator import (
+    resolve_snapshot_repository_locator,
+    resolve_snapshot_repository_reader,
+)
+from apps.storage.repositories.models import Repository
+from apps.storage.services.internal.kopia_cli import delete_s3_snapshots
+from apps.storage.services.internal.repository_access import repository_uses_bound_proxy
+from apps.task.models import Task
+
+
+@dataclass(frozen=True)
+class SnapshotDeleteOutcome:
+    task: _ControllerTask
+    result: dict[str, Any]
+    ok: bool
+    timed_out: bool = False
+
+
+@dataclass(frozen=True)
+class _ControllerTask:
+    id: str = "controller-snapshot-delete"
+    status: str = "success"
+    last_error: str = ""
+
+
+def run_snapshot_delete(
+    *,
+    organization_id: int,
+    task: Task,
+    source_snapshot: BackupSourceSnapshot,
+    directory: BackupSourceSnapshotDirectory,
+    repository: Repository,
+    kopia_ids: list[str],
+    correlation_type: str,
+    agent_runner: Callable[..., AgentTaskSyncResult],
+) -> SnapshotDeleteOutcome | AgentTaskSyncResult:
+    """Delete snapshots on their writer, falling back to the Controller for S3."""
+
+    if repository.repo_type != Repository.Type.S3:
+        return _run_non_s3_snapshot_delete(
+            organization_id=organization_id,
+            task=task,
+            source_snapshot=source_snapshot,
+            directory=directory,
+            repository=repository,
+            kopia_ids=kopia_ids,
+            correlation_type=correlation_type,
+            agent_runner=agent_runner,
+        )
+
+    locator = resolve_snapshot_repository_locator(
+        directory=directory,
+        repository=repository,
+    )
+    execution_node = _snapshot_execution_node(
+        organization_id=organization_id,
+        node_id=locator.writer_node_id,
+    )
+    failed_before_dispatch = False
+    if execution_node is not None and node_is_available_for_work(execution_node):
+        repository_access = resolve_snapshot_repository_reader(
+            directory=directory,
+            repository=repository,
+            fallback_node=execution_node,
+            source_type=source_snapshot.source_type,
+            source_ref_id=source_snapshot.source_ref_id,
+        )
+        outcome = agent_runner(
+            organization_id=organization_id,
+            node_id=repository_access.node.id,
+            kind="snapshot.delete",
+            payload={
+                "repository": repository_access.repository_payload,
+                "kopia_snapshot_ids": kopia_ids,
+            },
+            correlation_type=correlation_type,
+            correlation_id=str(task.task_uuid),
+            parent_task=task,
+            wait_timeout_seconds=3600,
+        )
+        # Once dispatched, keep the existing task result authoritative. Moving
+        # a possibly running delete to the Controller could execute it twice.
+        failed_before_dispatch = _agent_delete_failed_before_dispatch(outcome)
+        if not failed_before_dispatch:
+            return outcome
+
+    if (
+        execution_node is not None
+        and execution_node.availability == Node.Availability.ONLINE
+        and not failed_before_dispatch
+    ):
+        raise ValidationError(
+            {"repository_id": f'Snapshot execution node "{execution_node.name}" is busy.'}
+        )
+
+    result = delete_s3_snapshots(
+        repository,
+        snapshot_ids=kopia_ids,
+        timeout_seconds=3600,
+    )
+    failed_count = int(result.get("failed_count") or 0)
+    last_error = ""
+    if failed_count:
+        failed_items = [
+            item
+            for item in result.get("results", [])
+            if isinstance(item, dict) and item.get("status") == "failed"
+        ]
+        if failed_items:
+            last_error = str(failed_items[0].get("error_message") or "")
+    return SnapshotDeleteOutcome(
+        task=_ControllerTask(
+            status="failed" if failed_count else "success",
+            last_error=last_error,
+        ),
+        result=result,
+        ok=failed_count == 0,
+    )
+
+
+def _run_non_s3_snapshot_delete(
+    *,
+    organization_id: int,
+    task: Task,
+    source_snapshot: BackupSourceSnapshot,
+    directory: BackupSourceSnapshotDirectory,
+    repository: Repository,
+    kopia_ids: list[str],
+    correlation_type: str,
+    agent_runner: Callable[..., AgentTaskSyncResult],
+) -> AgentTaskSyncResult:
+    """Keep the established Agent/Proxy path for non-S3 repositories."""
+
+    fallback_node = None
+    if not repository_uses_bound_proxy(repository):
+        fallback_node = resolve_source_execution_target(
+            organization_id=source_snapshot.organization_id,
+            source_type=source_snapshot.source_type,
+            source_ref_id=source_snapshot.source_ref_id,
+        ).node
+    repository_access = resolve_snapshot_repository_reader(
+        directory=directory,
+        repository=repository,
+        fallback_node=fallback_node,
+        source_type=source_snapshot.source_type,
+        source_ref_id=source_snapshot.source_ref_id,
+    )
+    return agent_runner(
+        organization_id=organization_id,
+        node_id=repository_access.node.id,
+        kind="snapshot.delete",
+        payload={
+            "repository": repository_access.repository_payload,
+            "kopia_snapshot_ids": kopia_ids,
+        },
+        correlation_type=correlation_type,
+        correlation_id=str(task.task_uuid),
+        parent_task=task,
+        wait_timeout_seconds=3600,
+    )
+
+
+def _snapshot_execution_node(
+    *,
+    organization_id: int,
+    node_id: int | None,
+) -> Node | None:
+    if not node_id:
+        return None
+    node = Node.all_objects.filter(
+        organization_id=organization_id,
+        id=node_id,
+    ).first()
+    if (
+        node is None
+        or node.is_deleted
+        or node.role not in {NodeRole.AGENT, NodeRole.PROXY}
+    ):
+        return None
+    return node
+
+
+def _agent_delete_failed_before_dispatch(outcome: AgentTaskSyncResult) -> bool:
+    """Return whether delivery failed before the Agent could receive the task."""
+
+    marker = object()
+    dispatched_at = getattr(outcome.task, "dispatched_at", marker)
+    return (
+        not outcome.timed_out
+        and outcome.task.status == NodeTask.Status.FAILED
+        and dispatched_at is None
+    )
+
+
+__all__ = ["SnapshotDeleteOutcome", "run_snapshot_delete"]

--- a/src/backend/apps/protection/tests/test_snapshot_delete_task.py
+++ b/src/backend/apps/protection/tests/test_snapshot_delete_task.py
@@ -29,6 +29,7 @@ from apps.protection.services.snapshot_delete import (
     run_snapshot_delete_task,
     snapshot_delete_retry_delay,
 )
+from apps.source.models import SourceResource
 from apps.storage.repositories.models import Repository
 from apps.task.models import Task, TaskResource
 
@@ -409,8 +410,23 @@ class SnapshotDeleteTaskTests(TestCase):
             [TaskResource.Type.BACKUP_SOURCE],
         )
 
+    @patch(
+        "apps.protection.services.snapshot_delete_execution.delete_s3_snapshots",
+        return_value={
+            "deleted_count": 2,
+            "failed_count": 0,
+            "results": [
+                {"kopia_snapshot_id": "kopia-a", "status": "success"},
+                {"kopia_snapshot_id": "kopia-b", "status": "success"},
+            ],
+        },
+    )
     @patch("apps.protection.services.snapshot_delete.run_agent_task_sync")
-    def test_offline_source_is_closed_as_retryable_business_failure(self, mock_run_agent_task_sync):
+    def test_offline_s3_writer_falls_back_to_controller(
+        self,
+        mock_run_agent_task_sync,
+        mock_delete_s3_snapshots,
+    ):
         task = create_snapshot_delete_task(source_snapshot=self.snapshot)
         self.agent.availability = Node.Availability.OFFLINE
         self.agent.save(update_fields=["availability", "updated_at"])
@@ -424,11 +440,427 @@ class SnapshotDeleteTaskTests(TestCase):
         self.snapshot.refresh_from_db()
         task.refresh_from_db()
         mock_run_agent_task_sync.assert_not_called()
+        mock_delete_s3_snapshots.assert_called_once_with(
+            self.repository,
+            snapshot_ids=["kopia-a", "kopia-b"],
+            timeout_seconds=3600,
+        )
+        self.assertEqual(task.status, Task.Status.SUCCESS)
+        self.assertEqual(self.snapshot.status, BackupSourceSnapshot.Status.DELETED)
+        self.assertEqual(result["deleted_count"], 2)
+
+    @patch("apps.protection.services.snapshot_delete.run_agent_task_sync")
+    def test_busy_s3_writer_does_not_shift_cleanup_to_controller(
+        self,
+        mock_run_agent_task_sync,
+    ):
+        task = create_snapshot_delete_task(source_snapshot=self.snapshot)
+        self.agent.status = Node.Status.UPGRADING
+        self.agent.save(update_fields=["status", "updated_at"])
+
+        with patch(
+            "apps.protection.services.snapshot_delete_execution.delete_s3_snapshots"
+        ) as mock_delete_s3_snapshots:
+            run_snapshot_delete_task(
+                organization_id=self.org.id,
+                task_uuid=str(task.task_uuid),
+                source_snapshot_id=self.snapshot.id,
+            )
+
+        task.refresh_from_db()
+        mock_run_agent_task_sync.assert_not_called()
+        mock_delete_s3_snapshots.assert_not_called()
         self.assertEqual(task.status, Task.Status.FAILED)
-        self.assertEqual(task.error_code, "SNAPSHOT_DELETE_PRECONDITION_FAILED")
-        self.assertEqual(self.snapshot.status, BackupSourceSnapshot.Status.DELETE_FAILED)
-        self.assertIn("Agent source is offline", self.snapshot.error_message)
-        self.assertEqual(result["source_snapshot_id"], self.snapshot.id)
+        self.assertIn("busy", task.error_message)
+
+    @patch(
+        "apps.protection.services.snapshot_delete_execution.delete_s3_snapshots"
+    )
+    @patch("apps.protection.services.snapshot_delete.run_agent_task_sync")
+    def test_online_s3_writer_remains_preferred_over_controller(
+        self,
+        mock_run_agent_task_sync,
+        mock_delete_s3_snapshots,
+    ):
+        mock_run_agent_task_sync.return_value = SimpleNamespace(
+            task=SimpleNamespace(id="node-delete-online", status="success", last_error=""),
+            result={
+                "deleted_count": 2,
+                "failed_count": 0,
+                "results": [
+                    {"kopia_snapshot_id": "kopia-a", "status": "success"},
+                    {"kopia_snapshot_id": "kopia-b", "status": "success"},
+                ],
+            },
+            ok=True,
+            timed_out=False,
+        )
+        task = create_snapshot_delete_task(source_snapshot=self.snapshot)
+
+        run_snapshot_delete_task(
+            organization_id=self.org.id,
+            task_uuid=str(task.task_uuid),
+            source_snapshot_id=self.snapshot.id,
+        )
+
+        mock_run_agent_task_sync.assert_called_once()
+        self.assertEqual(
+            mock_run_agent_task_sync.call_args.kwargs["node_id"],
+            self.agent.id,
+        )
+        mock_delete_s3_snapshots.assert_not_called()
+
+    @patch(
+        "apps.protection.services.snapshot_delete_execution.delete_s3_snapshots",
+        return_value={
+            "deleted_count": 2,
+            "failed_count": 0,
+            "results": [
+                {"kopia_snapshot_id": "kopia-a", "status": "success"},
+                {"kopia_snapshot_id": "kopia-b", "status": "success"},
+            ],
+        },
+    )
+    @patch("apps.protection.services.snapshot_delete.run_agent_task_sync")
+    def test_s3_delivery_failure_before_dispatch_uses_controller(
+        self,
+        mock_run_agent_task_sync,
+        mock_delete_s3_snapshots,
+    ):
+        mock_run_agent_task_sync.return_value = SimpleNamespace(
+            task=SimpleNamespace(
+                id="node-delete-undelivered",
+                status="failed",
+                last_error="agent websocket is not routable",
+                dispatched_at=None,
+            ),
+            result={},
+            ok=False,
+            timed_out=False,
+        )
+        task = create_snapshot_delete_task(source_snapshot=self.snapshot)
+
+        run_snapshot_delete_task(
+            organization_id=self.org.id,
+            task_uuid=str(task.task_uuid),
+            source_snapshot_id=self.snapshot.id,
+        )
+
+        mock_run_agent_task_sync.assert_called_once()
+        mock_delete_s3_snapshots.assert_called_once()
+
+    @patch(
+        "apps.protection.services.snapshot_delete_execution.delete_s3_snapshots"
+    )
+    @patch("apps.protection.services.snapshot_delete.run_agent_task_sync")
+    def test_s3_failure_after_dispatch_does_not_run_twice_on_controller(
+        self,
+        mock_run_agent_task_sync,
+        mock_delete_s3_snapshots,
+    ):
+        mock_run_agent_task_sync.return_value = SimpleNamespace(
+            task=SimpleNamespace(
+                id="node-delete-dispatched",
+                status="failed",
+                last_error="Agent went offline during task execution.",
+                dispatched_at=timezone.now(),
+            ),
+            result={},
+            ok=False,
+            timed_out=False,
+        )
+        task = create_snapshot_delete_task(source_snapshot=self.snapshot)
+
+        run_snapshot_delete_task(
+            organization_id=self.org.id,
+            task_uuid=str(task.task_uuid),
+            source_snapshot_id=self.snapshot.id,
+        )
+
+        mock_run_agent_task_sync.assert_called_once()
+        mock_delete_s3_snapshots.assert_not_called()
+
+    @patch(
+        "apps.protection.services.snapshot_delete_execution.delete_s3_snapshots"
+    )
+    @patch("apps.protection.services.snapshot_delete.run_agent_task_sync")
+    def test_nas_source_s3_cleanup_prefers_backup_writer_proxy(
+        self,
+        mock_run_agent_task_sync,
+        mock_delete_s3_snapshots,
+    ):
+        proxy = Node.objects.create(
+            organization=self.org,
+            name="snapshot-delete-nas-proxy",
+            role=Node.Role.PROXY,
+            status=Node.Status.ACTIVE,
+            availability=Node.Availability.ONLINE,
+        )
+        nas_source = SourceResource.objects.create(
+            organization_id=self.org.id,
+            name="snapshot-delete-nas",
+            resource_type="nas",
+            bound_node=proxy,
+            availability="online",
+            mount_status="mounted",
+        )
+        self.config.source_type = "nas"
+        self.config.source_ref_id = nas_source.id
+        self.config.save(update_fields=["source_type", "source_ref_id"])
+        self.snapshot.source_type = "nas"
+        self.snapshot.source_ref_id = nas_source.id
+        self.snapshot.save(update_fields=["source_type", "source_ref_id", "updated_at"])
+        BackupSourceSnapshotDirectory.objects.filter(
+            source_snapshot=self.snapshot,
+        ).update(
+            repository_locator={
+                "version": 1,
+                "repository_id": self.repository.id,
+                "repository_type": Repository.Type.S3,
+                "repository_subdir": "",
+                "writer_node_id": proxy.id,
+                "access_node_id": None,
+            }
+        )
+        mock_run_agent_task_sync.return_value = SimpleNamespace(
+            task=SimpleNamespace(id="proxy-delete-s3", status="success", last_error=""),
+            result={
+                "deleted_count": 2,
+                "failed_count": 0,
+                "results": [
+                    {"kopia_snapshot_id": "kopia-a", "status": "success"},
+                    {"kopia_snapshot_id": "kopia-b", "status": "success"},
+                ],
+            },
+            ok=True,
+            timed_out=False,
+        )
+        task = create_snapshot_delete_task(source_snapshot=self.snapshot)
+
+        run_snapshot_delete_task(
+            organization_id=self.org.id,
+            task_uuid=str(task.task_uuid),
+            source_snapshot_id=self.snapshot.id,
+        )
+
+        self.assertEqual(
+            mock_run_agent_task_sync.call_args.kwargs["node_id"],
+            proxy.id,
+        )
+        mock_delete_s3_snapshots.assert_not_called()
+
+    @patch("apps.protection.services.snapshot_delete.run_agent_task_sync")
+    def test_offline_direct_nas_writer_never_uses_controller(
+        self,
+        mock_run_agent_task_sync,
+    ):
+        self.repository.repo_type = Repository.Type.NAS
+        self.repository.nas_protocol = Repository.NasProtocol.NFS
+        self.repository.s3_bucket = ""
+        self.repository.config = {
+            "server_address": "10.0.0.20",
+            "share_path": "/backup",
+            "kopia_password": "repo-pass",
+        }
+        self.repository.save()
+        self.agent.metadata = {"platform": "linux"}
+        self.agent.availability = Node.Availability.OFFLINE
+        self.agent.save(update_fields=["metadata", "availability", "updated_at"])
+        task = create_snapshot_delete_task(source_snapshot=self.snapshot)
+
+        with patch(
+            "apps.protection.services.snapshot_delete_execution.delete_s3_snapshots"
+        ) as mock_delete_s3_snapshots:
+            run_snapshot_delete_task(
+                organization_id=self.org.id,
+                task_uuid=str(task.task_uuid),
+                source_snapshot_id=self.snapshot.id,
+            )
+
+        task.refresh_from_db()
+        mock_run_agent_task_sync.assert_not_called()
+        mock_delete_s3_snapshots.assert_not_called()
+        self.assertEqual(task.status, Task.Status.FAILED)
+        self.assertIn("offline", task.error_message)
+
+    @patch("apps.protection.services.snapshot_delete.run_agent_task_sync")
+    def test_offline_proxy_filesystem_never_uses_controller(
+        self,
+        mock_run_agent_task_sync,
+    ):
+        proxy = Node.objects.create(
+            organization=self.org,
+            name="snapshot-delete-offline-proxy",
+            role=Node.Role.PROXY,
+            status=Node.Status.ACTIVE,
+            availability=Node.Availability.OFFLINE,
+        )
+        self.repository.repo_type = Repository.Type.PROXY_FS
+        self.repository.s3_bucket = ""
+        self.repository.bind_node_type = Repository.BindNodeType.PROXY
+        self.repository.bind_node_id = proxy.id
+        self.repository.config = {
+            "proxy_node_dir": "/srv/hfl-repository",
+            "kopia_password": "repo-pass",
+        }
+        self.repository.save()
+        BackupSourceSnapshotDirectory.objects.filter(
+            source_snapshot=self.snapshot,
+        ).update(
+            repository_locator={
+                "version": 1,
+                "repository_id": self.repository.id,
+                "repository_type": Repository.Type.PROXY_FS,
+                "repository_subdir": "",
+                "writer_node_id": self.agent.id,
+                "access_node_id": proxy.id,
+            }
+        )
+        task = create_snapshot_delete_task(source_snapshot=self.snapshot)
+
+        with patch(
+            "apps.protection.services.snapshot_delete_execution.delete_s3_snapshots"
+        ) as mock_delete_s3_snapshots:
+            run_snapshot_delete_task(
+                organization_id=self.org.id,
+                task_uuid=str(task.task_uuid),
+                source_snapshot_id=self.snapshot.id,
+            )
+
+        task.refresh_from_db()
+        mock_run_agent_task_sync.assert_not_called()
+        mock_delete_s3_snapshots.assert_not_called()
+        self.assertEqual(task.status, Task.Status.FAILED)
+        self.assertIn("offline", task.error_message)
+
+    @patch("apps.protection.services.snapshot_delete.run_agent_task_sync")
+    def test_offline_proxy_bound_nas_never_uses_controller(
+        self,
+        mock_run_agent_task_sync,
+    ):
+        proxy = Node.objects.create(
+            organization=self.org,
+            name="snapshot-delete-offline-nas-proxy",
+            role=Node.Role.PROXY,
+            status=Node.Status.ACTIVE,
+            availability=Node.Availability.OFFLINE,
+        )
+        self.repository.repo_type = Repository.Type.NAS
+        self.repository.nas_protocol = Repository.NasProtocol.NFS
+        self.repository.s3_bucket = ""
+        self.repository.bind_node_type = Repository.BindNodeType.PROXY
+        self.repository.bind_node_id = proxy.id
+        self.repository.config = {
+            "server_address": "10.0.0.20",
+            "share_path": "/backup",
+            "kopia_password": "repo-pass",
+        }
+        self.repository.save()
+        task = create_snapshot_delete_task(source_snapshot=self.snapshot)
+
+        with patch(
+            "apps.protection.services.snapshot_delete_execution.delete_s3_snapshots"
+        ) as mock_delete_s3_snapshots:
+            run_snapshot_delete_task(
+                organization_id=self.org.id,
+                task_uuid=str(task.task_uuid),
+                source_snapshot_id=self.snapshot.id,
+            )
+
+        task.refresh_from_db()
+        mock_run_agent_task_sync.assert_not_called()
+        mock_delete_s3_snapshots.assert_not_called()
+        self.assertEqual(task.status, Task.Status.FAILED)
+        self.assertIn("offline", task.error_message)
+
+    @patch(
+        "apps.protection.services.snapshot_delete_execution.delete_s3_snapshots",
+        return_value={
+            "deleted_count": 2,
+            "failed_count": 0,
+            "results": [
+                {"kopia_snapshot_id": "kopia-a", "status": "success"},
+                {"kopia_snapshot_id": "kopia-b", "status": "success"},
+            ],
+        },
+    )
+    @patch("apps.protection.services.snapshot_delete.run_agent_task_sync")
+    def test_data_gateway_is_never_selected_as_snapshot_delete_worker(
+        self,
+        mock_run_agent_task_sync,
+        mock_delete_s3_snapshots,
+    ):
+        gateway = Node.objects.create(
+            organization=self.org,
+            name="snapshot-delete-data-gateway",
+            role=Node.Role.GATEWAY,
+            status=Node.Status.ACTIVE,
+            availability=Node.Availability.ONLINE,
+        )
+        BackupSourceSnapshotDirectory.objects.filter(
+            source_snapshot=self.snapshot,
+        ).update(
+            repository_locator={
+                "version": 1,
+                "repository_id": self.repository.id,
+                "repository_type": Repository.Type.S3,
+                "repository_subdir": "",
+                "writer_node_id": gateway.id,
+                "access_node_id": None,
+            }
+        )
+        task = create_snapshot_delete_task(source_snapshot=self.snapshot)
+
+        run_snapshot_delete_task(
+            organization_id=self.org.id,
+            task_uuid=str(task.task_uuid),
+            source_snapshot_id=self.snapshot.id,
+        )
+
+        mock_run_agent_task_sync.assert_not_called()
+        mock_delete_s3_snapshots.assert_called_once()
+
+    @patch(
+        "apps.protection.services.snapshot_delete_execution.delete_s3_snapshots",
+        return_value={
+            "deleted_count": 0,
+            "failed_count": 1,
+            "results": [
+                {
+                    "kopia_snapshot_id": "kopia-a",
+                    "status": "failed",
+                    "delete": {"stderr_tail": "no snapshots matched kopia-a"},
+                },
+                {
+                    "kopia_snapshot_id": "kopia-b",
+                    "status": "failed",
+                    "delete": {"stderr_tail": "no snapshots matched kopia-b"},
+                },
+            ],
+        },
+    )
+    @patch("apps.protection.services.snapshot_delete.run_agent_task_sync")
+    def test_controller_treats_already_absent_snapshots_as_idempotent_success(
+        self,
+        mock_run_agent_task_sync,
+        _delete_s3_snapshots,
+    ):
+        self.agent.availability = Node.Availability.OFFLINE
+        self.agent.save(update_fields=["availability", "updated_at"])
+        task = create_snapshot_delete_task(source_snapshot=self.snapshot)
+
+        result = run_snapshot_delete_task(
+            organization_id=self.org.id,
+            task_uuid=str(task.task_uuid),
+            source_snapshot_id=self.snapshot.id,
+        )
+
+        task.refresh_from_db()
+        self.snapshot.refresh_from_db()
+        mock_run_agent_task_sync.assert_not_called()
+        self.assertEqual(task.status, Task.Status.SUCCESS)
+        self.assertEqual(self.snapshot.status, BackupSourceSnapshot.Status.DELETED)
+        self.assertEqual(result["already_absent_count"], 2)
 
     def test_reconcile_recovers_stale_running_task_by_request_payload(self):
         task = create_snapshot_delete_task(source_snapshot=self.snapshot)

--- a/src/backend/apps/storage/services/internal/kopia_cli.py
+++ b/src/backend/apps/storage/services/internal/kopia_cli.py
@@ -17,7 +17,11 @@ from typing import Callable
 
 from apps.storage.repositories.models import Repository
 from apps.storage.services.internal.s3_client import endpoint_for_kopia
-from apps.storage.services.internal.repository_secrets import resolve_repository_secrets
+from apps.storage.services.internal.repository_secrets import (
+    resolve_repository_secrets,
+    scrub_secrets,
+    secret_values_for_scrub,
+)
 from apps.storage.services.internal.repository_endpoints import repository_control_endpoint
 from apps.storage.services.internal.s3_url_style import (
     S3_URL_STYLE_AUTO,
@@ -161,6 +165,82 @@ def run_maintenance(
     if result.returncode != 0:
         raise KopiaCliError(_format_failure("Kopia repository maintenance failed", result))
     return KopiaResult(stdout=result.stdout, stderr=result.stderr)
+
+
+def delete_s3_snapshots(
+    repository: Repository,
+    *,
+    snapshot_ids: list[str],
+    timeout_seconds: int | None = None,
+) -> dict[str, object]:
+    """Delete selected S3 snapshots from the control-plane worker.
+
+    This is a fallback for an unavailable original writer. Normal snapshot
+    deletion continues to run on the Agent or Proxy that created the snapshot.
+    """
+
+    if repository.repo_type != Repository.Type.S3:
+        raise KopiaCliError("Control-plane snapshot delete only supports S3 repositories")
+
+    config_file = _snapshot_delete_config_file(repository)
+    secrets_payload = resolve_repository_secrets(repository)
+    secret_values = secret_values_for_scrub(
+        repository,
+        secrets_payload,
+    )
+    try:
+        _connect_maintenance_repository(
+            repository,
+            timeout_seconds=timeout_seconds,
+            config_file=config_file,
+        )
+    except KopiaCliError as exc:
+        safe_message = str(
+            scrub_secrets(str(exc), extra_values=secret_values) or ""
+        )
+        raise KopiaCliError(safe_message) from exc
+    results: list[dict[str, object]] = []
+    failed = 0
+    for raw_snapshot_id in snapshot_ids:
+        snapshot_id = str(raw_snapshot_id or "").strip()
+        if not snapshot_id:
+            continue
+        result = _run_repository_command(
+            repository,
+            ["snapshot", "delete", snapshot_id, "--delete"],
+            timeout_seconds=timeout_seconds,
+            config_file=config_file,
+        )
+        stdout_tail = str(
+            scrub_secrets(result.stdout[-2000:], extra_values=secret_values) or ""
+        )
+        stderr_tail = str(
+            scrub_secrets(result.stderr[-2000:], extra_values=secret_values) or ""
+        )
+        item: dict[str, object] = {
+            "kopia_snapshot_id": snapshot_id,
+            "status": "success" if result.returncode == 0 else "failed",
+            "delete": {
+                "exit_code": result.returncode,
+                "stdout_tail": stdout_tail,
+                "stderr_tail": stderr_tail,
+            },
+        }
+        if result.returncode != 0:
+            failed += 1
+            item["error_message"] = str(
+                scrub_secrets(
+                    _format_failure("Kopia snapshot delete failed", result),
+                    extra_values=secret_values,
+                )
+            )
+        results.append(item)
+    return {
+        "results": results,
+        "deleted_count": len(results) - failed,
+        "failed_count": failed,
+        "execution_mode": "controller_fallback",
+    }
 
 
 def _connect_maintenance_repository(
@@ -454,6 +534,10 @@ def _config_file(repository: Repository) -> Path:
 
 def _maintenance_config_file(repository: Repository) -> Path:
     return _config_file(repository).with_name("maintenance.repository.config")
+
+
+def _snapshot_delete_config_file(repository: Repository) -> Path:
+    return _config_file(repository).with_name("snapshot-delete.repository.config")
 
 
 def _environment(repository: Repository) -> dict[str, str]:

--- a/src/backend/apps/storage/tests/test_kopia_maintenance.py
+++ b/src/backend/apps/storage/tests/test_kopia_maintenance.py
@@ -19,6 +19,7 @@ from apps.storage.services.internal.kopia_cli import (
     _s3_flags,
     _terminate_process_group,
     create_s3_repository,
+    delete_s3_snapshots,
     run_maintenance,
 )
 
@@ -114,6 +115,74 @@ class KopiaRepositoryCreateCommandTests(SimpleTestCase):
             run_command.call_args.args[1][:3],
             ["repository", "create", "s3"],
         )
+
+
+class KopiaSnapshotDeleteCommandTests(SimpleTestCase):
+    @patch("apps.storage.services.internal.kopia_cli._connect_maintenance_repository")
+    @patch("apps.storage.services.internal.kopia_cli._run_repository_command")
+    def test_controller_fallback_deletes_only_requested_s3_snapshots(
+        self,
+        run_command,
+        connect_repository,
+    ):
+        repository = Repository(
+            id=7,
+            repo_type=Repository.Type.S3,
+            s3_bucket="bucket",
+            config={"secret_access_key": "secret-value"},
+        )
+        run_command.side_effect = [
+            CompletedProcess([], 0, stdout="deleted secret-value", stderr=""),
+            CompletedProcess(
+                [],
+                1,
+                stdout="",
+                stderr="no snapshots matched secret-value",
+            ),
+        ]
+
+        with TemporaryDirectory() as temporary, patch.dict(
+            "os.environ", {"HFL_KOPIA_CONFIG_DIR": temporary}
+        ):
+            result = delete_s3_snapshots(
+                repository,
+                snapshot_ids=["snapshot-a", "snapshot-b"],
+                timeout_seconds=45,
+            )
+
+        connect_repository.assert_called_once()
+        self.assertEqual(result["deleted_count"], 1)
+        self.assertEqual(result["failed_count"], 1)
+        self.assertEqual(result["execution_mode"], "controller_fallback")
+        delete_result = result["results"][0]["delete"]
+        self.assertNotIn("stdout", delete_result)
+        self.assertNotIn("stderr", delete_result)
+        self.assertEqual(delete_result["stdout_tail"], "deleted ******")
+        self.assertEqual(
+            result["results"][1]["delete"]["stderr_tail"],
+            "no snapshots matched ******",
+        )
+        self.assertNotIn("secret-value", str(result))
+        self.assertEqual(
+            [call.args[1] for call in run_command.call_args_list],
+            [
+                ["snapshot", "delete", "snapshot-a", "--delete"],
+                ["snapshot", "delete", "snapshot-b", "--delete"],
+            ],
+        )
+
+    def test_controller_fallback_rejects_non_s3_repository(self):
+        repository = Repository(
+            id=8,
+            repo_type=Repository.Type.NAS,
+            config={},
+        )
+
+        with self.assertRaisesMessage(
+            KopiaCliError,
+            "Control-plane snapshot delete only supports S3 repositories",
+        ):
+            delete_s3_snapshots(repository, snapshot_ids=["snapshot-a"])
 
 
 class KopiaMaintenanceCommandTests(SimpleTestCase):

--- a/src/frontend/src/lib/sourceUnregisterMonitor.test.ts
+++ b/src/frontend/src/lib/sourceUnregisterMonitor.test.ts
@@ -90,6 +90,22 @@ describe('sourceUnregisterTaskOutcome', () => {
     })
   })
 
+  it('does not report the final successful step as a failed step', () => {
+    expect(sourceUnregisterTaskOutcome({
+      status: 'success',
+      current_step: 'finalize_source_unregister',
+      result_payload: {
+        result: 'partial_success',
+        cleanup_complete: false,
+      },
+    } as never)).toMatchObject({
+      success: true,
+      partialSuccess: true,
+      failedStep: undefined,
+      currentStep: 'finalize_source_unregister',
+    })
+  })
+
   it('exposes structured failure fields for the details adapter', () => {
     expect(sourceUnregisterTaskOutcome({
       status: 'failed',

--- a/src/frontend/src/lib/sourceUnregisterMonitor.ts
+++ b/src/frontend/src/lib/sourceUnregisterMonitor.ts
@@ -114,7 +114,9 @@ export function sourceUnregisterTaskOutcome(task: TaskRow): SourceUnregisterTask
       typeof meta.hint === 'string' ? meta.hint.trim() : '',
     ].filter(Boolean)
   })
-  const failedStep = String(payload.failed_step || task.current_step || '').trim() || undefined
+  const failedStep = String(
+    payload.failed_step || (status === 'success' ? '' : task.current_step) || '',
+  ).trim() || undefined
   const hint = String(payload.hint || '').trim() || undefined
   return {
     terminal,

--- a/src/frontend/src/lib/unregisterFailureDetails.test.ts
+++ b/src/frontend/src/lib/unregisterFailureDetails.test.ts
@@ -80,6 +80,33 @@ describe('unregisterFailureToErrorDetails', () => {
     expect((details.rawDetail as { task_uuid?: string }).task_uuid).toBe('task-uuid-9')
   })
 
+  it('presents force residue as a completed removal instead of a failed cleanup', () => {
+    const details = unregisterFailureToErrorDetails({
+      t,
+      sourceId: 'agent:13',
+      sourceName: 'zjb',
+      task: {
+        status: 'success',
+        current_step: 'finalize_source_unregister',
+        result_payload: {
+          result: 'partial_success',
+          cleanup_complete: false,
+          retained_resources: ['repository_cleanup_record:6'],
+          snapshot_cleanup_tasks: [{
+            task_uuid: 'snapshot-task-1',
+            status: 'failed',
+            error_message: 'Agent source is offline.',
+          }],
+        },
+      } as never,
+    })
+
+    expect(details.title).toBe('Removed with cleanup warnings')
+    expect(details.reasons?.some(item => /Failed step/i.test(item))).toBe(false)
+    expect(details.reasons?.some(item => /Cleanup task .* failed/i.test(item))).toBe(false)
+    expect(details.resolutions?.some(item => /Open the deregistration dialog again/i.test(item))).toBe(false)
+  })
+
   it('falls back to a generic failure when no structured fields exist', () => {
     const details = unregisterFailureToErrorDetails({
       t,

--- a/src/frontend/src/lib/unregisterFailureDetails.ts
+++ b/src/frontend/src/lib/unregisterFailureDetails.ts
@@ -168,10 +168,11 @@ export function unregisterFailureToErrorDetails(input: {
     ...syncRetained,
   ])
   const failedChildren = outcome?.failedChildren ?? (task ? taskFailedCleanupChildren(task) : [])
+  const taskSucceeded = String(task?.status || '').trim().toLowerCase() === 'success'
   const failedStep = String(
     outcome?.failedStep
     || payload.failed_step
-    || task?.current_step
+    || (taskSucceeded ? '' : task?.current_step)
     || '',
   ).trim()
   const hint = String(outcome?.hint || payload.hint || '').trim()
@@ -190,7 +191,7 @@ export function unregisterFailureToErrorDetails(input: {
   )
 
   const reasons = uniqueStrings([
-    failedStep
+    !isResidue && failedStep
       ? t('protection.backupsPage.unregisterFailureFailedStep', { step: failedStep })
       : '',
     ...structuredReasons.map((reason) => unregisterReasonLabel(reason, t)),
@@ -200,12 +201,13 @@ export function unregisterFailureToErrorDetails(input: {
         ? `${item.detail} (${target})`
         : item.detail
     }),
-    ...failedChildren.map((item) =>
-      t('protection.backupsPage.unregisterFailureChildTask', {
-        uuid: item.taskUuid,
-        error: item.error,
-      }),
-    ),
+    ...(!isResidue
+      ? failedChildren.map((item) =>
+          t('protection.backupsPage.unregisterFailureChildTask', {
+            uuid: item.taskUuid,
+            error: item.error,
+          }))
+      : []),
     ...eventHints,
     isResidue ? '' : errorMessage,
   ])
@@ -226,7 +228,7 @@ export function unregisterFailureToErrorDetails(input: {
     isResidue
       ? t('protection.backupsPage.unregisterFailureForceCleanupHint')
       : t('protection.backupsPage.unregisterFailureStrictRetryHint'),
-    t('protection.backupsPage.unregisterFailureRetryHint'),
+    isResidue ? '' : t('protection.backupsPage.unregisterFailureRetryHint'),
   ])
 
   const summary = isResidue


### PR DESCRIPTION
## Summary
- prefer the original Agent or Proxy for snapshot cleanup and fall back to the Controller only for S3 repositories when dispatch cannot start
- preserve existing NAS and Proxy FS cleanup paths and prevent duplicate cleanup after dispatch
- present Force Cleanup residue as warnings after successful source removal

## Validation
- 123 backend cleanup and protection tests passed
- 22 targeted frontend tests passed
- frontend production build passed
- Ruff and git diff checks passed