### PR TITLE
feat(release): separate Community and Enterprise delivery workflows

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,7 +26,7 @@ HFL_GATEWAY_VERSION=0.1.0
 HFL_RELEASE_CHANNEL=release
 
 # Deployment ownership used only for observability tags. GitHub-managed targets
-# replace these with managed and test/preprod/prod before services start.
+# replace these with managed and test/community/prod before services start.
 HFL_DEPLOYMENT_MODE=standalone
 HFL_DEPLOY_TARGET=
 
@@ -358,7 +358,7 @@ SENTRY_BACKEND_DSN=
 SENTRY_FRONTEND_DSN=
 
 # Deployment label reported to Sentry (managed targets use hfl-test,
-# hfl-preprod, or hfl-production).
+# hfl-community, or hfl-production).
 SENTRY_ENVIRONMENT=
 
 # Fraction of transactions traced by Sentry, from 0.0 to 1.0.

--- a/.github/scripts/remote-deploy.sh
+++ b/.github/scripts/remote-deploy.sh
@@ -11,19 +11,21 @@ ADMIN_PUBLIC_URL=""
 DIRECT_HOST=""
 RUNTIME_ENV_FILE=""
 DOWNLOAD_PROXY_URL=""
+PACKAGE_FILE=""
 
 usage() {
 	cat <<'USAGE'
-Usage: remote-deploy.sh --tag vX.Y.Z|main-SHA7 --channel release|main --direct-host HOST [options]
+Usage: remote-deploy.sh --tag vX.Y.Z --channel release --direct-host HOST [options]
 
   --repository OWNER/REPO  Public GitHub repository (default: HyperBDR/hyperfilelens)
-	--channel CHANNEL       Artifact channel: release or main (default: release)
+	--channel CHANNEL       Artifact channel: release (default: release)
   --install-dir DIR        HFL install directory (default: /opt/hyperfilelens)
   --direct-host HOST       SSH-reachable host used for direct listener URLs
   --public-url URL         Optional canonical browser URL; external checks are non-blocking
   --admin-public-url URL   Optional Admin Console browser URL; invalid values only warn
   --runtime-env-file PATH  Root-only staged runtime configuration under /var/tmp
   --download-proxy-url URL Optional HTTP(S) proxy used only for GitHub Release downloads
+  --package-file PATH       Verified local package; bypass GitHub Release download
 USAGE
 }
 
@@ -38,6 +40,7 @@ while [[ $# -gt 0 ]]; do
 	--install-dir) INSTALL_DIR=${2:-}; shift 2 ;;
 	--runtime-env-file) RUNTIME_ENV_FILE=${2:-}; shift 2 ;;
 	--download-proxy-url) DOWNLOAD_PROXY_URL=${2:-}; shift 2 ;;
+	--package-file) PACKAGE_FILE=${2:-}; shift 2 ;;
 	-h | --help) usage; exit 0 ;;
 	*) printf 'ERROR: unknown argument: %s\n' "$1" >&2; exit 2 ;;
 	esac
@@ -47,11 +50,8 @@ if [[ "${DOWNLOAD_PROXY_URL}" == "UNCONFIGURED" ]]; then
 	DOWNLOAD_PROXY_URL=""
 fi
 
-case "${CHANNEL}" in
-release) [[ "${TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || { printf 'ERROR: invalid release tag\n' >&2; exit 2; } ;;
-main) [[ "${TAG}" =~ ^main-[0-9a-f]{7}$ ]] || { printf 'ERROR: invalid main build identifier\n' >&2; exit 2; } ;;
-*) printf 'ERROR: invalid artifact channel\n' >&2; exit 2 ;;
-esac
+[[ "${CHANNEL}" == "release" && "${TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] \
+	|| { printf 'ERROR: invalid release identity\n' >&2; exit 2; }
 [[ "${REPOSITORY}" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] || { printf 'ERROR: invalid repository\n' >&2; exit 2; }
 [[ "${INSTALL_DIR}" == /opt/hyperfilelens ]] || {
 	printf 'ERROR: current HFL installer supports /opt/hyperfilelens only\n' >&2
@@ -83,6 +83,18 @@ if [[ -n "${DOWNLOAD_PROXY_URL}" ]]; then
 		printf 'ERROR: download proxy port is out of range\n' >&2
 		exit 2
 	}
+fi
+if [[ -n "${PACKAGE_FILE}" ]]; then
+	[[ "${PACKAGE_FILE}" =~ ^/root/hfl-release/v[0-9]+\.[0-9]+\.[0-9]+/hyperfilelens-[0-9]+\.[0-9]+\.[0-9]+-ee\.tar\.gz$ ]] || {
+		printf 'ERROR: invalid Enterprise package path\n' >&2
+		exit 2
+	}
+	[[ -f "${PACKAGE_FILE}" && ! -L "${PACKAGE_FILE}" ]] || {
+		printf 'ERROR: Enterprise package is missing or unsafe\n' >&2
+		exit 1
+	}
+	exec 8</root/hfl-release/.lock
+	flock -s 8
 fi
 command -v curl >/dev/null || { printf 'ERROR: curl is required\n' >&2; exit 1; }
 command -v python3 >/dev/null || { printf 'ERROR: python3 is required\n' >&2; exit 1; }
@@ -380,13 +392,24 @@ download_release_file() {
 		"$(basename "${output}")" "${size_human}" "${elapsed}" "${rate_human}"
 }
 
-if [[ -n "${DOWNLOAD_PROXY_URL}" ]]; then
+if [[ -n "${DOWNLOAD_PROXY_URL}" && -z "${PACKAGE_FILE}" ]]; then
 	printf '[deploy] Target-side Release download proxy is enabled\n'
 fi
-api="https://api.github.com/repos/${REPOSITORY}/releases/tags/${TAG}"
-printf '[deploy] Resolving published release %s\n' "${TAG}"
-download_release_file "${api}" "${work}/release.json"
+if [[ -n "${PACKAGE_FILE}" ]]; then
+	check_disk_capacity "$(stat -c '%s' "${PACKAGE_FILE}")"
+	package="${work}/$(basename "${PACKAGE_FILE}")"
+	cp --reflink=auto "${PACKAGE_FILE}" "${package}"
+	checksum_file="$(dirname "${PACKAGE_FILE}")/SHA256SUMS"
+	[[ -s "${checksum_file}" ]]
+	expected="$(awk -v file="$(basename "${PACKAGE_FILE}")" '$2 == file || $2 == "*" file {print $1; exit}' "${checksum_file}")"
+	[[ -n "${expected}" ]]
+	printf '%s  %s\n' "${expected}" "${package}" | sha256sum -c -
+else
+	api="https://api.github.com/repos/${REPOSITORY}/releases/tags/${TAG}"
+	printf '[deploy] Resolving published release %s\n' "${TAG}"
+	download_release_file "${api}" "${work}/release.json"
 
+# BEGIN COMMUNITY RELEASE ASSET SELECTOR
 python3 - "${work}/release.json" "${work}/assets.tsv" "${TAG}" <<'PY'
 import json
 import pathlib
@@ -400,33 +423,42 @@ if release.get("draft"):
 if release.get("tag_name") != tag:
     raise SystemExit("release tag does not match the requested tag")
 assets = {item["name"]: item["browser_download_url"] for item in release.get("assets", [])}
-selected = {}
 if "SHA256SUMS" not in assets:
     raise SystemExit("release has no SHA256SUMS")
-selected["SHA256SUMS"] = assets["SHA256SUMS"]
-if tag.startswith("main-"):
-    package_pattern = re.escape(f"hyperfilelens-{tag}.tar.gz")
-else:
-    prefix = re.escape(f"hyperfilelens-{tag[1:]}-")
-    package_pattern = prefix + r"[0-9a-f]{7}\.tar\.gz"
-full = sorted(name for name in assets if re.fullmatch(package_pattern, name))
-if len(full) == 1:
-    selected[full[0]] = assets[full[0]]
-else:
-    parts = sorted(
-        name
-        for name in assets
-        if re.fullmatch(package_pattern + r"\.part-[0-9]{3}", name)
+
+
+def package_assets(base):
+    if base in assets:
+        return [base]
+    return sorted(
+        name for name in assets if re.fullmatch(re.escape(base) + r"\.part-[0-9]{3}", name)
     )
-    if not parts:
-        raise SystemExit("release has neither one full package nor package parts")
-    for name in parts:
-        selected[name] = assets[name]
+
+
+current_base = f"hyperfilelens-{tag[1:]}.tar.gz"
+package_names = package_assets(current_base)
+if not package_names:
+    legacy_pattern = re.compile(
+        rf"^(hyperfilelens-{re.escape(tag[1:])}-[0-9a-fA-F]{{7}}\.tar\.gz)"
+        rf"(?:\.part-[0-9]{{3}})?$"
+    )
+    legacy_bases = sorted(
+        {match.group(1) for name in assets if (match := legacy_pattern.fullmatch(name))}
+    )
+    if len(legacy_bases) > 1:
+        raise SystemExit("release has multiple legacy package candidates")
+    if legacy_bases:
+        package_names = package_assets(legacy_bases[0])
+if not package_names:
+    raise SystemExit("release has neither one full package nor package parts")
+
+selected = ["SHA256SUMS", *package_names]
 pathlib.Path(sys.argv[2]).write_text(
-    "".join(f"{name}\t{url}\n" for name, url in selected.items()),
+    "".join(f"{name}\t{assets[name]}\n" for name in selected),
     encoding="utf-8",
 )
 PY
+# END COMMUNITY RELEASE ASSET SELECTOR
 
 total_bytes="$(python3 - "${work}/release.json" "${work}/assets.tsv" <<'PY'
 import json, pathlib, sys
@@ -444,24 +476,35 @@ while IFS=$'\t' read -r name url; do
 done <"${work}/assets.tsv"
 
 package="$(find "${work}" -maxdepth 1 -type f -name 'hyperfilelens-*.tar.gz' -print -quit)"
-if [[ -z "${package}" ]]; then
-	first_part="$(find "${work}" -maxdepth 1 -type f -name 'hyperfilelens-*.tar.gz.part-000' -print -quit)"
-	[[ -n "${first_part}" ]] || { printf 'ERROR: package parts are missing\n' >&2; exit 1; }
-	package="${first_part%.part-000}"
-	cat "${package}.part-"* >"${package}"
+	if [[ -z "${package}" ]]; then
+		first_part="$(find "${work}" -maxdepth 1 -type f -name 'hyperfilelens-*.tar.gz.part-000' -print -quit)"
+		[[ -n "${first_part}" ]] || { printf 'ERROR: package parts are missing\n' >&2; exit 1; }
+		package="${first_part%.part-000}"
+		cat "${package}.part-"* >"${package}"
+	fi
+	# End of the GitHub Release download path. Local Enterprise packages bypass it.
 fi
 package_name="$(basename "${package}")"
-expected="$(awk -v file="${package_name}" '$2 == file || $2 == "*" file {print $1; exit}' "${work}/SHA256SUMS")"
-if [[ -n "${expected}" ]]; then
-	printf '%s  %s\n' "${expected}" "${package}" | sha256sum -c -
-else
-	# Split releases checksum every part; validate all downloaded parts before use.
-	while IFS= read -r part; do
-		name="$(basename "${part}")"
-		expected="$(awk -v file="${name}" '$2 == file || $2 == "*" file {print $1; exit}' "${work}/SHA256SUMS")"
-		[[ -n "${expected}" ]] || { printf 'ERROR: no checksum for %s\n' "${name}" >&2; exit 1; }
-		printf '%s  %s\n' "${expected}" "${part}" | sha256sum -c -
-	done < <(find "${work}" -maxdepth 1 -type f -name '*.part-*' | sort)
+if [[ -z "${PACKAGE_FILE}" ]]; then
+	expected="$(awk -v file="${package_name}" '$2 == file || $2 == "*" file {print $1; exit}' "${work}/SHA256SUMS")"
+	if [[ -n "${expected}" ]]; then
+		printf '%s  %s\n' "${expected}" "${package}" | sha256sum -c -
+	else
+		# Split releases checksum every part; validate all downloaded parts before use.
+		mapfile -t package_parts < <(
+			find "${work}" -maxdepth 1 -type f -name '*.part-*' | sort
+		)
+		((${#package_parts[@]} > 0)) || {
+			printf 'ERROR: no checksum for %s\n' "${package_name}" >&2
+			exit 1
+		}
+		for part in "${package_parts[@]}"; do
+			name="$(basename "${part}")"
+			expected="$(awk -v file="${name}" '$2 == file || $2 == "*" file {print $1; exit}' "${work}/SHA256SUMS")"
+			[[ -n "${expected}" ]] || { printf 'ERROR: no checksum for %s\n' "${name}" >&2; exit 1; }
+			printf '%s  %s\n' "${expected}" "${part}" | sha256sum -c -
+		done
+	fi
 fi
 
 mkdir -p "${work}/extract"
@@ -471,7 +514,9 @@ package_root="$(find "${work}/extract" -mindepth 1 -maxdepth 1 -type d -name 'hy
 	printf 'ERROR: invalid HFL package layout\n' >&2
 	exit 1
 }
-python3 - "${package_root}/MANIFEST.json" "${CHANNEL}" "${TAG}" <<'PY'
+expected_edition=community
+[[ -z "${PACKAGE_FILE}" ]] || expected_edition=enterprise
+python3 - "${package_root}/MANIFEST.json" "${CHANNEL}" "${TAG}" "${expected_edition}" <<'PY'
 import json
 import pathlib
 import sys
@@ -479,6 +524,7 @@ import sys
 manifest = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
 expected_channel = sys.argv[2]
 expected_id = sys.argv[3]
+expected_edition = sys.argv[4]
 channel = str(manifest.get("channel") or "release")
 if channel != expected_channel:
     raise SystemExit(f"package channel mismatch: {channel} != {expected_channel}")
@@ -487,6 +533,13 @@ if expected_channel == "release" and not artifact_id:
     artifact_id = "v" + str(manifest.get("version") or "")
 if artifact_id != expected_id:
     raise SystemExit(f"package identity mismatch: {artifact_id} != {expected_id}")
+version = expected_id[1:] if expected_id.startswith("v") else expected_id
+edition = str(manifest.get("edition") or "community")
+if edition != expected_edition:
+    raise SystemExit(f"package edition mismatch: {edition} != {expected_edition}")
+expected_image_version = version + ("-ee" if edition == "enterprise" else "")
+if manifest.get("image_version", version) != expected_image_version:
+    raise SystemExit("package image identity mismatch")
 PY
 
 if [[ -f "${INSTALL_DIR}/.env" && -f "${INSTALL_DIR}/VERSION" ]]; then
@@ -499,7 +552,6 @@ if [[ -f "${INSTALL_DIR}/.env" && -f "${INSTALL_DIR}/VERSION" ]]; then
 		--public-url "${PUBLIC_URL}"
 		--admin-public-url "${ADMIN_PUBLIC_URL}"
 	)
-	[[ "${CHANNEL}" == "main" ]] && install_args+=(--allow-main-build)
 	if [[ -n "${RUNTIME_ENV_FILE}" ]]; then
 		install_args+=(--runtime-env-file "${RUNTIME_ENV_FILE}")
 	fi
@@ -513,7 +565,6 @@ else
 		--public-url "${PUBLIC_URL}"
 		--admin-public-url "${ADMIN_PUBLIC_URL}"
 	)
-	[[ "${CHANNEL}" == "main" ]] && install_args+=(--allow-main-build)
 	if [[ -n "${RUNTIME_ENV_FILE}" ]]; then
 		install_args+=(--runtime-env-file "${RUNTIME_ENV_FILE}")
 	fi

--- a/.github/scripts/store-enterprise-release.sh
+++ b/.github/scripts/store-enterprise-release.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+# Validate and atomically retain one Enterprise release on the TEST host.
+set -euo pipefail
+
+tag=${1:-}
+incoming=${2:-}
+store_root=${3:-/root/hfl-release}
+keep=${4:-10}
+
+[[ "${tag}" =~ ^v([0-9]+\.[0-9]+\.[0-9]+)$ ]] || {
+	printf 'ERROR: invalid Enterprise release tag\n' >&2
+	exit 2
+}
+version=${BASH_REMATCH[1]}
+[[ "${incoming}" == "${store_root}/.incoming/"* ]] || {
+	printf 'ERROR: incoming directory must be below %s/.incoming\n' "${store_root}" >&2
+	exit 2
+}
+incoming_name=${incoming#"${store_root}/.incoming/"}
+[[ "${incoming_name}" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]] || {
+	printf 'ERROR: unsafe incoming directory name\n' >&2
+	exit 2
+}
+[[ "${keep}" =~ ^[0-9]+$ ]] || { printf 'ERROR: invalid retention count\n' >&2; exit 2; }
+[[ -d "${incoming}" && ! -L "${incoming}" ]] || { printf 'ERROR: upload is missing\n' >&2; exit 1; }
+
+exec 9>"${store_root}/.lock"
+flock 9
+
+(
+	cd "${incoming}"
+	[[ -s SHA256SUMS && -s MANIFEST.json ]] || {
+		printf 'ERROR: Enterprise release metadata is incomplete\n' >&2
+		exit 1
+	}
+	sha256sum -c SHA256SUMS
+	archive="hyperfilelens-${version}-ee.tar.gz"
+	if [[ ! -f "${archive}" ]]; then
+		first="${archive}.part-000"
+		[[ -s "${first}" ]] || { printf 'ERROR: Enterprise archive is missing\n' >&2; exit 1; }
+		cat "${archive}.part-"* >"${archive}.part"
+		mv "${archive}.part" "${archive}"
+	fi
+	python3 - MANIFEST.json "${tag}" "${archive}" <<'PY'
+import json
+import pathlib
+import sys
+import tarfile
+
+manifest_path = pathlib.Path(sys.argv[1])
+tag = sys.argv[2]
+archive_path = pathlib.Path(sys.argv[3])
+manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+version = tag[1:] if tag.startswith("v") else tag
+if manifest.get("edition") != "enterprise":
+    raise SystemExit("release is not Enterprise edition")
+if manifest.get("version") != version or manifest.get("artifact_id") != tag:
+    raise SystemExit("Enterprise release identity mismatch")
+if manifest.get("image_version") != f"{version}-ee":
+    raise SystemExit("Enterprise image identity mismatch")
+extension_commit = manifest.get("extension_commit", "")
+if not isinstance(extension_commit, str) or len(extension_commit) != 40 or any(
+    character not in "0123456789abcdef" for character in extension_commit
+):
+    raise SystemExit("Enterprise extension identity is missing or invalid")
+with tarfile.open(archive_path, "r:gz") as archive:
+    members = [item for item in archive.getmembers() if item.name.endswith("/MANIFEST.json")]
+    if len(members) != 1:
+        raise SystemExit("Enterprise archive manifest is missing or ambiguous")
+    stream = archive.extractfile(members[0])
+    if stream is None or json.load(stream) != manifest:
+        raise SystemExit("external and archived manifests differ")
+PY
+	# The canonical, reconstructed archive is the only package payload retained.
+	find . -maxdepth 1 -type f -name '*.part-*' -delete
+	find . -maxdepth 1 -type f \
+		! -name "${archive}" ! -name MANIFEST.json ! -name SHA256SUMS -delete
+	sha256sum "${archive}" MANIFEST.json >SHA256SUMS
+)
+
+destination="${store_root}/${tag}"
+if [[ -e "${destination}" ]]; then
+	[[ -d "${destination}" && ! -L "${destination}" ]] || {
+		printf 'ERROR: immutable Enterprise destination is not a safe directory\n' >&2
+		exit 1
+	}
+	(
+		cd "${destination}"
+		sha256sum -c SHA256SUMS
+		python3 - MANIFEST.json "${tag}" "hyperfilelens-${version}-ee.tar.gz" <<'PY'
+import json
+import pathlib
+import sys
+import tarfile
+
+manifest_path = pathlib.Path(sys.argv[1])
+tag = sys.argv[2]
+archive_path = pathlib.Path(sys.argv[3])
+manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+version = tag[1:]
+if manifest.get("edition") != "enterprise":
+    raise SystemExit("stored release is not Enterprise edition")
+if manifest.get("version") != version or manifest.get("artifact_id") != tag:
+    raise SystemExit("stored Enterprise release identity mismatch")
+if manifest.get("image_version") != f"{version}-ee":
+    raise SystemExit("stored Enterprise image identity mismatch")
+extension_commit = manifest.get("extension_commit", "")
+if not isinstance(extension_commit, str) or len(extension_commit) != 40 or any(
+    character not in "0123456789abcdef" for character in extension_commit
+):
+    raise SystemExit("stored Enterprise extension identity is missing or invalid")
+with tarfile.open(archive_path, "r:gz") as archive:
+    members = [item for item in archive.getmembers() if item.name.endswith("/MANIFEST.json")]
+    if len(members) != 1:
+        raise SystemExit("stored Enterprise archive manifest is missing or ambiguous")
+    stream = archive.extractfile(members[0])
+    if stream is None or json.load(stream) != manifest:
+        raise SystemExit("stored external and archived manifests differ")
+PY
+	)
+	python3 - "${incoming}/MANIFEST.json" "${destination}/MANIFEST.json" <<'PY'
+import json
+import pathlib
+import sys
+
+incoming = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+stored = json.loads(pathlib.Path(sys.argv[2]).read_text(encoding="utf-8"))
+identity_fields = (
+    "product",
+    "edition",
+    "version",
+    "artifact_id",
+    "image_version",
+    "git_commit",
+    "extension_commit",
+)
+differences = [
+    field for field in identity_fields if incoming.get(field) != stored.get(field)
+]
+if differences:
+    raise SystemExit(
+        "immutable Enterprise release identity differs for: " + ", ".join(differences)
+    )
+PY
+	incoming_digest="$(sha256sum "${incoming}/hyperfilelens-${version}-ee.tar.gz" | awk '{print $1}')"
+	stored_digest="$(sha256sum "${destination}/hyperfilelens-${version}-ee.tar.gz" | awk '{print $1}')"
+	[[ "${incoming_digest}" == "${stored_digest}" ]] || {
+		printf 'ERROR: immutable Enterprise package content differs for %s\n' "${tag}" >&2
+		exit 1
+	}
+	printf 'Enterprise version %s already exists; retaining the immutable stored package\n' \
+		"${tag}" >&2
+	rm -rf -- "${incoming}"
+else
+	mv "${incoming}" "${destination}"
+fi
+
+if ((keep > 0)); then
+	mapfile -t releases < <(
+		find "${store_root}" -mindepth 1 -maxdepth 1 -type d -name 'v*' \
+			-printf '%f\n' \
+			| sed -n '/^v[0-9]\+\.[0-9]\+\.[0-9]\+$/p' \
+			| sort -Vr \
+			| sed "s#^#${store_root}/#"
+	)
+	for ((index = keep; index < ${#releases[@]}; index++)); do
+		old=${releases[index]}
+		[[ "${old}" =~ /v[0-9]+\.[0-9]+\.[0-9]+$ ]] || continue
+		rm -rf -- "${old}"
+	done
+fi
+
+[[ -d "${destination}" && ! -L "${destination}" \
+	&& -f "${destination}/hyperfilelens-${version}-ee.tar.gz" ]] || {
+	printf 'ERROR: Enterprise version %s is outside the retained SemVer window\n' \
+		"${tag}" >&2
+	exit 1
+}
+printf '%s\n' "${destination}/hyperfilelens-${version}-ee.tar.gz"

--- a/.github/workflows/artifact_pipeline.yml
+++ b/.github/workflows/artifact_pipeline.yml
@@ -7,27 +7,18 @@ on:
         description: Artifact channel requested by a trusted wrapper
         required: true
         type: string
-      force_rebuild:
-        description: Rebuild an already-published Main commit
+      edition:
+        description: Product edition to package
         required: false
-        default: false
-        type: boolean
-
+        default: community
+        type: string
+      release_tag:
+        description: Existing OSS release tag used as the immutable source baseline
+        required: true
+        type: string
 concurrency:
-  group: >-
-    ${{
-      inputs.channel == 'main' &&
-      (
-        github.run_attempt == 1 &&
-        'hyperfilelens-main' ||
-        format('hyperfilelens-main-rerun-{0}-{1}', github.run_id, github.run_attempt)
-      ) ||
-      format('hyperfilelens-release-{0}', github.ref_name)
-    }}
-  # Main is a moving development target, while formal release builds must
-  # always run to completion once a version tag has been accepted. A stale
-  # Main retry must never cancel the active build for a newer commit.
-  cancel-in-progress: ${{ inputs.channel == 'main' && github.run_attempt == 1 }}
+  group: ${{ format('hyperfilelens-package-{0}', inputs.release_tag) }}
+  cancel-in-progress: false
 
 permissions:
   contents: read
@@ -46,54 +37,52 @@ jobs:
       contents: write
     outputs:
       version: ${{ steps.version.outputs.version }}
+      image_version: ${{ steps.version.outputs.image_version }}
       tag: ${{ steps.version.outputs.tag }}
+      release_tag: ${{ steps.version.outputs.release_tag }}
       commit: ${{ steps.version.outputs.commit }}
       channel: ${{ steps.version.outputs.channel }}
+      edition: ${{ steps.version.outputs.edition }}
+      enterprise_commit: ${{ steps.enterprise-ref.outputs.commit }}
+      enterprise_stored: ${{ steps.enterprise-store.outputs.stored }}
       build_required: ${{ steps.candidate.outputs.build_required }}
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           fetch-depth: 0
+          ref: ${{ inputs.release_tag }}
 
       - name: Validate release tag and commit
         id: version
         env:
           REQUESTED_CHANNEL: ${{ inputs.channel }}
+          REQUESTED_EDITION: ${{ inputs.edition }}
+          REQUESTED_TAG: ${{ inputs.release_tag }}
         shell: bash
         run: |
           set -euo pipefail
+          [[ "$REQUESTED_CHANNEL" == "release" ]]
+          [[ "$REQUESTED_EDITION" =~ ^(community|enterprise)$ ]]
+          TAG="$REQUESTED_TAG"
+          [[ "$TAG" =~ ^v([0-9]+\.[0-9]+\.[0-9]+)$ ]]
+          VERSION="${BASH_REMATCH[1]}"
+          IMAGE_VERSION="$VERSION"
+          [[ "$REQUESTED_EDITION" == "community" ]] || IMAGE_VERSION="${VERSION}-ee"
           git fetch origin main --no-tags
-          case "$REQUESTED_CHANNEL" in
-            release)
-              TAG="${GITHUB_REF_NAME}"
-              [[ "$TAG" =~ ^v([0-9]+\.[0-9]+\.[0-9]+)$ ]]
-              VERSION="${BASH_REMATCH[1]}"
-              ;;
-            main)
-              [[ "$GITHUB_REF" == "refs/heads/main" ]]
-              [[ "$GITHUB_SHA" =~ ^[0-9a-f]{40}$ ]]
-              TAG="main-${GITHUB_SHA:0:7}"
-              VERSION="$TAG"
-              ;;
-            *)
-              echo "unsupported artifact channel: $REQUESTED_CHANNEL" >&2
-              exit 2
-              ;;
-          esac
-          if [[ "$REQUESTED_CHANNEL" == "main" ]]; then
-            latest_main="$(git rev-parse --verify 'refs/remotes/origin/main^{commit}')"
-            [[ "$GITHUB_SHA" == "$latest_main" ]] || {
-              echo "Main build $GITHUB_SHA is superseded by $latest_main; stale retries stop before package construction" >&2
-              exit 1
-            }
-          else
-            git merge-base --is-ancestor "$GITHUB_SHA" origin/main
+          COMMIT="$(git rev-parse --verify "${TAG}^{commit}")"
+          git merge-base --is-ancestor "$COMMIT" origin/main
+          CANDIDATE_TAG="$TAG"
+          if [[ "$REQUESTED_EDITION" == "enterprise" ]]; then
+            CANDIDATE_TAG="enterprise-${TAG}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           fi
           {
             echo "version=$VERSION"
-            echo "tag=$TAG"
-            echo "commit=$GITHUB_SHA"
+            echo "image_version=$IMAGE_VERSION"
+            echo "tag=$CANDIDATE_TAG"
+            echo "release_tag=$TAG"
+            echo "commit=$COMMIT"
             echo "channel=$REQUESTED_CHANNEL"
+            echo "edition=$REQUESTED_EDITION"
           } >> "$GITHUB_OUTPUT"
           [[ "${REGISTRY_HOST}" =~ ^[a-z0-9][a-z0-9.-]*(:[0-9]+)?$ ]] || {
             echo "REGISTRY_HOST repository variable is missing or invalid" >&2
@@ -104,66 +93,202 @@ jobs:
             exit 1
           }
 
+      - name: Validate matching Enterprise tag
+        id: enterprise-ref
+        if: ${{ steps.version.outputs.edition == 'enterprise' }}
+        env:
+          ENTERPRISE_EXTENSION_REPOSITORY: ${{ vars.ENTERPRISE_EXTENSION_REPOSITORY }}
+          HFL_EXTENSION_GIT_TOKEN: ${{ secrets.ENTERPRISE_EXTENSION_GIT_TOKEN }}
+          RELEASE_TAG: ${{ steps.version.outputs.release_tag }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$ENTERPRISE_EXTENSION_REPOSITORY" =~ ^https://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+(\.git)?$ ]] || {
+            echo 'ENTERPRISE_EXTENSION_REPOSITORY must be a credential-free GitHub HTTPS repository URL' >&2
+            exit 1
+          }
+          enterprise_commit="$(python3 - "$ENTERPRISE_EXTENSION_REPOSITORY" "$RELEASE_TAG" <<'PY'
+          import re
+          import subprocess
+          import sys
+
+          from tools.extensions.materialize_extensions import _git_env
+
+          repository, tag = sys.argv[1:]
+          result = subprocess.run(
+              [
+                  "git",
+                  "ls-remote",
+                  "--exit-code",
+                  repository,
+                  f"refs/tags/{tag}",
+                  f"refs/tags/{tag}^{{}}",
+              ],
+              check=True,
+              env=_git_env(repository, require_https_auth=True),
+              stdout=subprocess.PIPE,
+              text=True,
+          )
+          refs = {}
+          for line in result.stdout.splitlines():
+              commit, ref = line.split("\t", 1)
+              refs[ref] = commit
+          commit = refs.get(f"refs/tags/{tag}^{{}}") or refs.get(f"refs/tags/{tag}")
+          if not commit or not re.fullmatch(r"[0-9a-f]{40}", commit):
+              raise SystemExit("Enterprise tag did not resolve to one commit")
+          print(commit)
+          PY
+          )"
+          echo "commit=$enterprise_commit" >> "$GITHUB_OUTPUT"
+
+      - name: Check immutable Enterprise store
+        id: enterprise-store
+        if: ${{ steps.version.outputs.edition == 'enterprise' }}
+        env:
+          RELEASE_TAG: ${{ steps.version.outputs.release_tag }}
+          RELEASE_COMMIT: ${{ steps.version.outputs.commit }}
+          ENTERPRISE_COMMIT: ${{ steps.enterprise-ref.outputs.commit }}
+          TEST_SSH_HOST: ${{ vars.TEST_SSH_HOST }}
+          TEST_SSH_PORT: ${{ vars.TEST_SSH_PORT }}
+          TEST_SSH_USER: ${{ vars.TEST_SSH_USER }}
+          TEST_SSH_KNOWN_HOSTS: ${{ vars.TEST_SSH_KNOWN_HOSTS }}
+          TEST_SSH_PRIVATE_KEY: ${{ secrets.TEST_SSH_PRIVATE_KEY }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$TEST_SSH_HOST" =~ ^[A-Za-z0-9][A-Za-z0-9.-]*$ && "$TEST_SSH_PORT" =~ ^[0-9]+$ ]]
+          [[ "$TEST_SSH_USER" =~ ^[a-z_][a-z0-9_-]*$ ]]
+          [[ -n "$TEST_SSH_KNOWN_HOSTS" && -n "$TEST_SSH_PRIVATE_KEY" ]]
+          install -d -m 0700 ~/.ssh
+          printf '%s\n' "$TEST_SSH_KNOWN_HOSTS" > ~/.ssh/known_hosts
+          printf '%s\n' "$TEST_SSH_PRIVATE_KEY" > ~/.ssh/hyperfilelens_test
+          chmod 0600 ~/.ssh/known_hosts ~/.ssh/hyperfilelens_test
+          stored="$({
+            ssh -i ~/.ssh/hyperfilelens_test \
+              -o BatchMode=yes -o StrictHostKeyChecking=yes \
+              -p "$TEST_SSH_PORT" "$TEST_SSH_USER@$TEST_SSH_HOST" \
+              "bash -s -- '$RELEASE_TAG' '$RELEASE_COMMIT' '$ENTERPRISE_COMMIT'" <<'REMOTE'
+          set -euo pipefail
+          tag=$1
+          oss_commit=$2
+          enterprise_commit=$3
+          [[ "$tag" =~ ^v([0-9]+\.[0-9]+\.[0-9]+)$ ]]
+          version=${BASH_REMATCH[1]}
+          directory="/root/hfl-release/${tag}"
+          exec 9>/root/hfl-release/.lock
+          flock -s 9
+          if [[ ! -e "$directory" ]]; then
+            printf 'false\n'
+            exit 0
+          fi
+          [[ -d "$directory" && ! -L "$directory" ]]
+          [[ -f "$directory/SHA256SUMS" && ! -L "$directory/SHA256SUMS" ]]
+          [[ -f "$directory/MANIFEST.json" && ! -L "$directory/MANIFEST.json" ]]
+          [[ -f "$directory/hyperfilelens-${version}-ee.tar.gz" \
+            && ! -L "$directory/hyperfilelens-${version}-ee.tar.gz" ]]
+          (
+            cd "$directory"
+            sha256sum -c SHA256SUMS >/dev/null
+            python3 - MANIFEST.json "$tag" "$version" "$oss_commit" "$enterprise_commit" <<'PY'
+          import json
+          import pathlib
+          import sys
+
+          path, tag, version, oss_commit, enterprise_commit = sys.argv[1:]
+          manifest = json.loads(pathlib.Path(path).read_text(encoding="utf-8"))
+          expected = {
+              "product": "hyperfilelens",
+              "edition": "enterprise",
+              "version": version,
+              "artifact_id": tag,
+              "image_version": f"{version}-ee",
+              "git_commit": oss_commit,
+              "extension_commit": enterprise_commit,
+          }
+          differences = [key for key, value in expected.items() if manifest.get(key) != value]
+          if differences:
+              raise SystemExit(
+                  "stored Enterprise release identity differs for: " + ", ".join(differences)
+              )
+          PY
+          )
+          printf 'true\n'
+          REMOTE
+          } 2>&1)" || {
+            printf '%s\n' "$stored" >&2
+            exit 1
+          }
+          [[ "$stored" =~ ^(true|false)$ ]]
+          echo "stored=$stored" >> "$GITHUB_OUTPUT"
+
       - name: Create or reuse build candidate
         id: candidate
         env:
           GH_TOKEN: ${{ github.token }}
           ARTIFACT_CHANNEL: ${{ steps.version.outputs.channel }}
           ARTIFACT_ID: ${{ steps.version.outputs.tag }}
-          FORCE_REBUILD: ${{ inputs.force_rebuild }}
+          RELEASE_TAG: ${{ steps.version.outputs.release_tag }}
+          RELEASE_EDITION: ${{ steps.version.outputs.edition }}
+          RELEASE_COMMIT: ${{ steps.version.outputs.commit }}
+          ENTERPRISE_STORED: ${{ steps.enterprise-store.outputs.stored }}
         shell: bash
         run: |
           set -euo pipefail
-          if [[ "$ARTIFACT_CHANNEL" == "main" ]] \
-            && existing_commit="$(git rev-parse --verify "${ARTIFACT_ID}^{commit}" 2>/dev/null)"; then
-            [[ "$existing_commit" == "$GITHUB_SHA" ]] || {
-              echo "Main artifact ID collision: $ARTIFACT_ID already identifies $existing_commit" >&2
-              exit 1
-            }
+          validate_build_contract() {
+            local file
+            local -a required_files=(
+              release/ci/assemble-release.sh
+              release/build.sh
+              tools/extensions/materialize_extensions.py
+              tools/lib/version.sh
+              tools/quality/test-enterprise-release-flow.sh
+            )
+            for file in "${required_files[@]}"; do
+              [[ -f "$file" ]] || {
+                echo "::error::Selected tag predates the edition-aware release contract: missing $file"
+                return 1
+              }
+            done
+            grep -F -- '--edition' release/ci/assemble-release.sh >/dev/null
+            grep -F 'HFL_RELEASE_EDITION' release/build.sh >/dev/null
+            grep -F 'HFL_EXTENSION_EXPECTED_COMMIT' \
+              tools/extensions/materialize_extensions.py >/dev/null
+            grep -F 'normalize_edition' tools/lib/version.sh >/dev/null
+          }
+          if [[ "$RELEASE_EDITION" == "enterprise" ]]; then
+            if [[ "$ENTERPRISE_STORED" == "true" ]]; then
+              echo "build_required=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            validate_build_contract
+            gh release create "$ARTIFACT_ID" \
+              --target "$RELEASE_COMMIT" \
+              --draft \
+              --title "Enterprise build candidate $RELEASE_TAG"
+            echo "build_required=true" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
           if gh release view "$ARTIFACT_ID" \
             --json isDraft,isPrerelease,targetCommitish \
             >/tmp/hfl-release.json 2>/dev/null; then
-            if [[ "$ARTIFACT_CHANNEL" == "main" ]]; then
-              release_target="$(jq -r .targetCommitish /tmp/hfl-release.json)"
-              [[ "$release_target" == "$GITHUB_SHA" ]] || {
-                echo "Main artifact target mismatch: $ARTIFACT_ID targets $release_target, expected $GITHUB_SHA" >&2
-                exit 1
-              }
-            fi
             if [[ "$ARTIFACT_CHANNEL" == "release" ]]; then
-              [[ "$(jq -r .isDraft /tmp/hfl-release.json)" == "true" ]] || {
-                echo "Refusing to overwrite an already-published release" >&2
-                exit 1
-              }
-              echo "build_required=true" >> "$GITHUB_OUTPUT"
-            elif [[ "$FORCE_REBUILD" == "true" ]]; then
-              gh release delete "$ARTIFACT_ID" --cleanup-tag --yes
-              gh release create "$ARTIFACT_ID" \
-                --target "$GITHUB_SHA" \
-                --draft \
-                --prerelease \
-                --title "Main ${GITHUB_SHA:0:7}"
-              echo "build_required=true" >> "$GITHUB_OUTPUT"
-            elif [[ "$(jq -r .isDraft /tmp/hfl-release.json)" == "true" ]]; then
-              echo "build_required=true" >> "$GITHUB_OUTPUT"
+              if [[ "$(jq -r .isDraft /tmp/hfl-release.json)" == "true" ]]; then
+                validate_build_contract
+                echo "build_required=true" >> "$GITHUB_OUTPUT"
+              else
+                echo "build_required=false" >> "$GITHUB_OUTPUT"
+              fi
             else
-              [[ "$(jq -r .isPrerelease /tmp/hfl-release.json)" == "true" ]]
               echo "build_required=false" >> "$GITHUB_OUTPUT"
             fi
           else
             if [[ "$ARTIFACT_CHANNEL" == "release" ]]; then
+              validate_build_contract
               gh release create "$ARTIFACT_ID" \
                 --verify-tag \
                 --draft \
                 --generate-notes \
                 --title "HyperFileLens $ARTIFACT_ID"
-            else
-              gh release create "$ARTIFACT_ID" \
-                --target "$GITHUB_SHA" \
-                --draft \
-                --prerelease \
-                --title "Main ${GITHUB_SHA:0:7}"
             fi
             echo "build_required=true" >> "$GITHUB_OUTPUT"
           fi
@@ -206,6 +331,8 @@ jobs:
       DJANGO_DEBUG: "true"
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          ref: ${{ needs.prepare.outputs.commit }}
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.12"
@@ -222,6 +349,50 @@ jobs:
         with:
           version: "0.10.2"
           enable-cache: true
+
+      - name: Materialize Enterprise extension for quality gates
+        env:
+          RELEASE_EDITION: ${{ needs.prepare.outputs.edition }}
+          RELEASE_TAG: ${{ needs.prepare.outputs.release_tag }}
+          ENTERPRISE_COMMIT: ${{ needs.prepare.outputs.enterprise_commit }}
+          ENTERPRISE_EXTENSION_REPOSITORY: ${{ vars.ENTERPRISE_EXTENSION_REPOSITORY }}
+          HFL_EXTENSION_GIT_TOKEN: ${{ secrets.ENTERPRISE_EXTENSION_GIT_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "$RELEASE_EDITION" == "community" ]]; then
+            echo "HFL_EXTENSIONS=" >>"$GITHUB_ENV"
+            echo "Community quality gates: extensions disabled by edition"
+            exit 0
+          fi
+          [[ "$ENTERPRISE_EXTENSION_REPOSITORY" =~ ^https://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+(\.git)?$ ]] || {
+            echo "::error::ENTERPRISE_EXTENSION_REPOSITORY must be a credential-free GitHub HTTPS repository URL"
+            exit 1
+          }
+          token="${HFL_EXTENSION_GIT_TOKEN:-}"
+          if [[ ${#token} -lt 20 || "$token" == "-" ]]; then
+            echo "::error::ENTERPRISE_EXTENSION_GIT_TOKEN is missing or a placeholder; set a token with contents:read on the private extension repository"
+            exit 1
+          fi
+          quality_dir="$GITHUB_WORKSPACE/build/quality/extensions"
+          HFL_EXTENSION_GIT_TOKEN="$token" \
+            python3 tools/extensions/materialize_extensions.py \
+              --repo-root . \
+              --sources "${ENTERPRISE_EXTENSION_REPOSITORY}@${RELEASE_TAG}" \
+              --expected-commit "$ENTERPRISE_COMMIT" \
+              --bake-dir "$quality_dir"
+          extensions="$(
+            find "$quality_dir" -mindepth 1 -maxdepth 1 -type d \
+              -exec test -d '{}/src/backend' \; -print \
+              | sort \
+              | paste -sd, -
+          )"
+          [[ -n "$extensions" ]] || {
+            echo "::error::Enterprise extension materialization produced no extension roots"
+            exit 1
+          }
+          echo "HFL_EXTENSIONS=$extensions" >>"$GITHUB_ENV"
+          echo "Enterprise quality gates: extension enabled"
 
       - name: Release and source checks
         shell: bash
@@ -252,10 +423,7 @@ jobs:
           ./tools/quality/test-redis-rdb-preflight.sh
           ./tools/quality/test-agent-release-retention.sh
           ./tools/quality/test-managed-image-retention.sh
-          ./tools/quality/test-main-channel-contracts.sh
-          ./tools/quality/test-main-release-freshness.sh
-          ./tools/quality/test-main-release-cleanup.sh
-          ./tools/quality/test-release-freshness.sh
+          ./tools/quality/test-enterprise-release-flow.sh
           ./tools/quality/test-shared-host-guard.sh
           ./tools/quality/test-release-download-proxy.sh
           ./tools/quality/test-public-endpoint-check.sh
@@ -265,7 +433,7 @@ jobs:
           ./tools/quality/test-sentry-runtime-config.sh
           ./tools/quality/test-payload-tree-hash.sh
           ./tools/quality/test-ci-release-assembly.sh
-          HFL_TEST_VERSION=main-0123456 ./tools/quality/test-ci-release-assembly.sh
+          HFL_TEST_EDITION=enterprise ./tools/quality/test-ci-release-assembly.sh
           ./tools/quality/test-kopia-build-config.sh
           ./tools/quality/test-dev-stack-upgrade.sh
           ./tools/quality/test-sourcelens-git-mirror.sh
@@ -281,6 +449,25 @@ jobs:
           uv run ruff check src/backend
           uv run python src/backend/manage.py makemigrations --check --dry-run
           uv run python src/backend/manage.py test
+          if [[ -n "${HFL_EXTENSIONS:-}" ]]; then
+            extension_test_labels=()
+            IFS=',' read -r -a extension_roots <<<"$HFL_EXTENSIONS"
+            for root in "${extension_roots[@]}"; do
+              backend="$root/src/backend"
+              while IFS= read -r test_dir; do
+                label="${test_dir#"$backend/"}"
+                extension_test_labels+=("${label//\//.}")
+              done < <(
+                find "$backend" -type d -name tests -exec test -f '{}/__init__.py' \; -print \
+                  | sort
+              )
+            done
+            ((${#extension_test_labels[@]} > 0)) || {
+              echo "::error::Enterprise extension contains no discoverable backend tests"
+              exit 1
+            }
+            uv run python src/backend/manage.py test "${extension_test_labels[@]}"
+          fi
 
       - name: Frontend checks
         working-directory: src/frontend
@@ -330,6 +517,8 @@ jobs:
             needs_kopia: false
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          ref: ${{ needs.prepare.outputs.commit }}
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         if: matrix.needs_kopia
         with:
@@ -356,18 +545,23 @@ jobs:
 
       - name: Materialize Open Core extensions for image bake
         env:
-          HFL_EXTENSION_SOURCES: ${{ vars.HFL_EXTENSION_SOURCES }}
-          HFL_EXTENSION_GIT_TOKEN: ${{ secrets.HFL_EXTENSION_GIT_TOKEN }}
+          RELEASE_EDITION: ${{ needs.prepare.outputs.edition }}
+          RELEASE_TAG: ${{ needs.prepare.outputs.release_tag }}
+          ENTERPRISE_COMMIT: ${{ needs.prepare.outputs.enterprise_commit }}
+          ENTERPRISE_EXTENSION_REPOSITORY: ${{ vars.ENTERPRISE_EXTENSION_REPOSITORY }}
+          HFL_EXTENSION_GIT_TOKEN: ${{ secrets.ENTERPRISE_EXTENSION_GIT_TOKEN }}
         shell: bash
         run: |
           set -euo pipefail
           mkdir -p build/release/extensions
           : >build/release/extensions/.gitkeep
-          if [[ -z "${HFL_EXTENSION_SOURCES// }" ]]; then
+          if [[ "$RELEASE_EDITION" == "community" ]]; then
             echo "HFL_EXTENSIONS=" >>"${GITHUB_ENV}"
-            echo "Community bake: HFL_EXTENSION_SOURCES empty"
+            echo "Community bake: extensions disabled by edition"
             exit 0
           fi
+          [[ "$ENTERPRISE_EXTENSION_REPOSITORY" == https://github.com/* ]]
+          HFL_EXTENSION_SOURCES="${ENTERPRISE_EXTENSION_REPOSITORY}@${RELEASE_TAG}"
           # Prefer packaging secret for private plugin repos; do not fall back to
           # github.token (that token cannot clone other private repositories).
           # Scope to HFL_EXTENSION_GIT_TOKEN only (materialize reads it first).
@@ -379,9 +573,10 @@ jobs:
           exts="$(
             HFL_EXTENSION_GIT_TOKEN="${token}" \
               python3 tools/extensions/materialize_extensions.py \
-              --repo-root . \
-              --sources "${HFL_EXTENSION_SOURCES}" \
-              --bake-dir build/release/extensions \
+                --repo-root . \
+                --sources "${HFL_EXTENSION_SOURCES}" \
+                --expected-commit "${ENTERPRISE_COMMIT}" \
+                --bake-dir build/release/extensions \
               --print-extensions
           )"
           echo "HFL_EXTENSIONS=${exts}" >>"${GITHUB_ENV}"
@@ -396,16 +591,16 @@ jobs:
           platforms: linux/amd64
           push: true
           provenance: false
-          tags: ${{ env.REGISTRY_PREFIX }}/${{ matrix.repository }}:${{ needs.prepare.outputs.version }}
+          tags: ${{ env.REGISTRY_PREFIX }}/${{ matrix.repository }}:${{ needs.prepare.outputs.image_version }}
           build-args: |
             KOPIA_BINARY=build/kopia/dist/linux/amd64/kopia
-            IMAGE_VERSION=${{ needs.prepare.outputs.version }}
+            IMAGE_VERSION=${{ needs.prepare.outputs.image_version }}
             IMAGE_REVISION=${{ needs.prepare.outputs.commit }}
             PIP_TIMEOUT=600
             SENTRY_URL=${{ vars.SENTRY_URL }}
             SENTRY_ORG=${{ vars.SENTRY_ORG }}
             SENTRY_FRONTEND_PROJECT=${{ vars.SENTRY_FRONTEND_PROJECT }}
-            SENTRY_RELEASE=hyperfilelens-frontend@${{ needs.prepare.outputs.version }}
+            SENTRY_RELEASE=hyperfilelens-frontend@${{ needs.prepare.outputs.image_version }}
             VITE_SHOW_EULA=false
             HFL_EXTENSIONS=${{ env.HFL_EXTENSIONS }}
           secrets: ${{ matrix.component == 'hfl-frontend' && secrets.SENTRY_AUTH_TOKEN != '' && format('sentry_auth_token={0}', secrets.SENTRY_AUTH_TOKEN) || '' }}
@@ -415,7 +610,7 @@ jobs:
       - name: Upload immutable image metadata
         env:
           GH_TOKEN: ${{ github.token }}
-          IMAGE_REF: ${{ env.REGISTRY_PREFIX }}/${{ matrix.repository }}:${{ needs.prepare.outputs.version }}
+          IMAGE_REF: ${{ env.REGISTRY_PREFIX }}/${{ matrix.repository }}:${{ needs.prepare.outputs.image_version }}
           IMAGE_DIGEST: ${{ steps.build.outputs.digest }}
         shell: bash
         run: |
@@ -446,6 +641,8 @@ jobs:
         component: [backend, frontend, lensnode]
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          ref: ${{ needs.prepare.outputs.commit }}
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
       - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
@@ -505,6 +702,8 @@ jobs:
             asset: windows-amd64
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          ref: ${{ needs.prepare.outputs.commit }}
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version-file: src/agent/go.mod
@@ -565,6 +764,8 @@ jobs:
             runner: windows-2022
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          ref: ${{ needs.prepare.outputs.commit }}
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.12"
@@ -618,6 +819,8 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          ref: ${{ needs.prepare.outputs.commit }}
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.12"
@@ -673,6 +876,8 @@ jobs:
             asset: ubuntu2404
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          ref: ${{ needs.prepare.outputs.commit }}
       - name: Build host dependency asset
         env:
           APT_MIRROR: ${{ vars.CI_UBUNTU_APT_MIRROR }}
@@ -702,6 +907,8 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          ref: ${{ needs.prepare.outputs.commit }}
       - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ env.REGISTRY_HOST }}
@@ -718,7 +925,7 @@ jobs:
         run: |
           ./release/ci/export-hfl-images.sh \
             build/ci-metadata \
-            "${{ needs.prepare.outputs.version }}" \
+            "${{ needs.prepare.outputs.image_version }}" \
             _internal-hfl-images.tar
       - name: Upload offline HFL archive
         env:
@@ -735,6 +942,8 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          ref: ${{ needs.prepare.outputs.commit }}
       - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ env.REGISTRY_HOST }}
@@ -770,6 +979,8 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          ref: ${{ needs.prepare.outputs.commit }}
       - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ env.REGISTRY_HOST }}
@@ -796,8 +1007,12 @@ jobs:
       - export-runtime-images
     permissions:
       contents: write
+    outputs:
+      stored: ${{ steps.store-enterprise.outputs.stored }}
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          ref: ${{ needs.prepare.outputs.commit }}
       - name: Download matrix bundles
         env:
           GH_TOKEN: ${{ github.token }}
@@ -807,14 +1022,24 @@ jobs:
       - name: Assemble canonical offline release
         env:
           # Same sources as image bake so packaged .env.example matches image ENV.
-          HFL_EXTENSION_SOURCES: ${{ vars.HFL_EXTENSION_SOURCES }}
-          HFL_EXTENSION_GIT_TOKEN: ${{ secrets.HFL_EXTENSION_GIT_TOKEN }}
+          RELEASE_EDITION: ${{ needs.prepare.outputs.edition }}
+          RELEASE_TAG: ${{ needs.prepare.outputs.release_tag }}
+          HFL_EXTENSION_EXPECTED_COMMIT: ${{ needs.prepare.outputs.enterprise_commit }}
+          ENTERPRISE_EXTENSION_REPOSITORY: ${{ vars.ENTERPRISE_EXTENSION_REPOSITORY }}
+          HFL_EXTENSION_GIT_TOKEN: ${{ secrets.ENTERPRISE_EXTENSION_GIT_TOKEN }}
         run: |
+          if [[ "$RELEASE_EDITION" == "enterprise" ]]; then
+            export HFL_EXTENSION_SOURCES="${ENTERPRISE_EXTENSION_REPOSITORY}@${RELEASE_TAG}"
+          else
+            export HFL_EXTENSION_SOURCES=""
+          fi
           ./release/ci/assemble-release.sh \
             --input-dir build/ci-input \
             --version "${{ needs.prepare.outputs.version }}" \
-            --commit "${{ needs.prepare.outputs.commit }}"
-      - name: Upload final assets to draft release
+            --commit "${{ needs.prepare.outputs.commit }}" \
+            --edition "${{ needs.prepare.outputs.edition }}"
+      - name: Upload Community assets to draft release
+        if: ${{ needs.prepare.outputs.edition == 'community' }}
         env:
           GH_TOKEN: ${{ github.token }}
         shell: bash
@@ -829,6 +1054,34 @@ jobs:
             ./release/ci/gh-release-upload.sh "${{ needs.prepare.outputs.tag }}" \
               "build/release/dist/${asset}" --clobber
           done < build/release/release-assets.txt
+      - name: Stage Enterprise release on TEST host
+        id: store-enterprise
+        if: ${{ needs.prepare.outputs.edition == 'enterprise' }}
+        env:
+          RELEASE_TAG: ${{ needs.prepare.outputs.release_tag }}
+          TEST_SSH_HOST: ${{ vars.TEST_SSH_HOST }}
+          TEST_SSH_PORT: ${{ vars.TEST_SSH_PORT }}
+          TEST_SSH_USER: ${{ vars.TEST_SSH_USER }}
+          TEST_SSH_KNOWN_HOSTS: ${{ vars.TEST_SSH_KNOWN_HOSTS }}
+          TEST_SSH_PRIVATE_KEY: ${{ secrets.TEST_SSH_PRIVATE_KEY }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$TEST_SSH_HOST" =~ ^[A-Za-z0-9][A-Za-z0-9.-]*$ && "$TEST_SSH_PORT" =~ ^[0-9]+$ ]]
+          [[ "$TEST_SSH_USER" =~ ^[a-z_][a-z0-9_-]*$ ]]
+          [[ -n "$TEST_SSH_KNOWN_HOSTS" && -n "$TEST_SSH_PRIVATE_KEY" ]]
+          install -d -m 0700 ~/.ssh
+          printf '%s\n' "$TEST_SSH_KNOWN_HOSTS" > ~/.ssh/known_hosts
+          printf '%s\n' "$TEST_SSH_PRIVATE_KEY" > ~/.ssh/hyperfilelens_test
+          chmod 0600 ~/.ssh/known_hosts ~/.ssh/hyperfilelens_test
+          incoming="/root/hfl-release/.incoming/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          ssh -i ~/.ssh/hyperfilelens_test -o BatchMode=yes -o StrictHostKeyChecking=yes \
+            -p "$TEST_SSH_PORT" "$TEST_SSH_USER@$TEST_SSH_HOST" \
+            "install -d -m 0700 '$incoming'"
+          scp -i ~/.ssh/hyperfilelens_test -o BatchMode=yes -o StrictHostKeyChecking=yes \
+            -P "$TEST_SSH_PORT" build/release/dist/* \
+            "$TEST_SSH_USER@$TEST_SSH_HOST:$incoming/"
+          echo 'stored=true' >> "$GITHUB_OUTPUT"
       - name: Disk report
         if: always()
         run: df -h
@@ -843,12 +1096,15 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          ref: ${{ needs.prepare.outputs.commit }}
       - name: Reclaim unused runner toolchains
         run: |
           sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc
           docker system prune -af || true
           df -h
-      - name: Download public release candidates from draft
+      - name: Download Community release candidate from draft
+        if: ${{ needs.prepare.outputs.edition == 'community' }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -861,6 +1117,29 @@ jobs:
             --pattern 'hyperfilelens-root-ca.crt' \
             --pattern 'assemble-release.*' \
             --dir build/release-candidate
+      - name: Download Enterprise release candidate from TEST host
+        if: ${{ needs.prepare.outputs.edition == 'enterprise' }}
+        env:
+          RELEASE_TAG: ${{ needs.prepare.outputs.release_tag }}
+          RELEASE_VERSION: ${{ needs.prepare.outputs.version }}
+          TEST_SSH_HOST: ${{ vars.TEST_SSH_HOST }}
+          TEST_SSH_PORT: ${{ vars.TEST_SSH_PORT }}
+          TEST_SSH_USER: ${{ vars.TEST_SSH_USER }}
+          TEST_SSH_KNOWN_HOSTS: ${{ vars.TEST_SSH_KNOWN_HOSTS }}
+          TEST_SSH_PRIVATE_KEY: ${{ secrets.TEST_SSH_PRIVATE_KEY }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          install -d -m 0700 ~/.ssh build/release-candidate
+          printf '%s\n' "$TEST_SSH_KNOWN_HOSTS" > ~/.ssh/known_hosts
+          printf '%s\n' "$TEST_SSH_PRIVATE_KEY" > ~/.ssh/hyperfilelens_test
+          chmod 0600 ~/.ssh/known_hosts ~/.ssh/hyperfilelens_test
+          remote="/root/hfl-release/.incoming/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          scp -r -i ~/.ssh/hyperfilelens_test \
+            -o BatchMode=yes -o StrictHostKeyChecking=yes \
+            -P "$TEST_SSH_PORT" \
+            "$TEST_SSH_USER@$TEST_SSH_HOST:$remote/." \
+            build/release-candidate/
       - name: Verify checksums and reconstruct package when split
         id: package
         working-directory: build/release-candidate
@@ -913,37 +1192,42 @@ jobs:
       disposition: ${{ steps.publish.outputs.disposition }}
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          ref: ${{ needs.prepare.outputs.commit }}
       - name: Remove internal assets and publish release
         id: publish
         env:
           GH_TOKEN: ${{ github.token }}
           ARTIFACT_CHANNEL: ${{ needs.prepare.outputs.channel }}
           ARTIFACT_ID: ${{ needs.prepare.outputs.tag }}
+          RELEASE_EDITION: ${{ needs.prepare.outputs.edition }}
+          RELEASE_TAG: ${{ needs.prepare.outputs.release_tag }}
+          TEST_SSH_HOST: ${{ vars.TEST_SSH_HOST }}
+          TEST_SSH_PORT: ${{ vars.TEST_SSH_PORT }}
+          TEST_SSH_USER: ${{ vars.TEST_SSH_USER }}
+          TEST_SSH_KNOWN_HOSTS: ${{ vars.TEST_SSH_KNOWN_HOSTS }}
+          TEST_SSH_PRIVATE_KEY: ${{ secrets.TEST_SSH_PRIVATE_KEY }}
         shell: bash
         run: |
           set -euo pipefail
-          release_freshness=not-applicable
-          if [[ "$ARTIFACT_CHANNEL" == "main" ]]; then
-            freshness="$(./.github/scripts/check-main-freshness.sh "$GITHUB_SHA")"
-            if [[ "$freshness" == "superseded" ]]; then
-              if gh release view "$ARTIFACT_ID" --repo "$GITHUB_REPOSITORY" \
-                >/dev/null 2>&1; then
-                gh release delete "$ARTIFACT_ID" --repo "$GITHUB_REPOSITORY" --yes
-              fi
-              if gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${ARTIFACT_ID}" \
-                --silent >/dev/null 2>&1; then
-                gh api --method DELETE \
-                  "repos/${GITHUB_REPOSITORY}/git/refs/tags/${ARTIFACT_ID}" --silent
-              fi
-              {
-                echo 'deployable=false'
-                echo 'disposition=superseded'
-              } >> "$GITHUB_OUTPUT"
-              printf '### Main publish\n\nSkipped `%s`: origin/main advanced beyond `%s`; a stale rerun cannot publish or deploy.\n' \
-                "$ARTIFACT_ID" "$GITHUB_SHA" >> "$GITHUB_STEP_SUMMARY"
-              exit 0
-            fi
-            [[ "$freshness" == "current" ]]
+          if [[ "$RELEASE_EDITION" == "enterprise" ]]; then
+            install -d -m 0700 ~/.ssh
+            printf '%s\n' "$TEST_SSH_KNOWN_HOSTS" > ~/.ssh/known_hosts
+            printf '%s\n' "$TEST_SSH_PRIVATE_KEY" > ~/.ssh/hyperfilelens_test
+            chmod 0600 ~/.ssh/known_hosts ~/.ssh/hyperfilelens_test
+            incoming="/root/hfl-release/.incoming/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+            ssh -i ~/.ssh/hyperfilelens_test -o BatchMode=yes -o StrictHostKeyChecking=yes \
+              -p "$TEST_SSH_PORT" "$TEST_SSH_USER@$TEST_SSH_HOST" \
+              "bash -s -- '$RELEASE_TAG' '$incoming' /root/hfl-release 10" \
+              < .github/scripts/store-enterprise-release.sh
+            gh release delete "$ARTIFACT_ID" --repo "$GITHUB_REPOSITORY" --cleanup-tag --yes
+            {
+              echo 'deployable=true'
+              echo 'disposition=stored-on-test-host'
+            } >> "$GITHUB_OUTPUT"
+            printf '### Enterprise release\n\nVerified and stored on the TEST host; the temporary GitHub build candidate was deleted.\n' \
+              >> "$GITHUB_STEP_SUMMARY"
+            exit 0
           fi
           while IFS= read -r asset; do
             [[ -n "$asset" ]] || continue
@@ -952,30 +1236,17 @@ jobs:
           done < <(gh release view "${{ needs.prepare.outputs.tag }}" \
             --repo "${GITHUB_REPOSITORY}" --json assets \
             --jq '.assets[] | select(.name | startswith("_internal-")) | .name')
-          if [[ "$ARTIFACT_CHANNEL" == "main" ]]; then
-            gh release edit "${{ needs.prepare.outputs.tag }}" \
-              --repo "${GITHUB_REPOSITORY}" --draft=false --prerelease
-          else
-            release_api_url="$(gh release view "$ARTIFACT_ID" \
-              --repo "$GITHUB_REPOSITORY" --json apiUrl --jq '.apiUrl')"
-            release_api_prefix="https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/"
-            [[ "$release_api_url" == "$release_api_prefix"* ]]
-            release_id="${release_api_url#"$release_api_prefix"}"
-            [[ "$release_id" =~ ^[0-9]+$ ]]
-            gh api --method PATCH \
-              "$release_api_url" \
-              -F draft=false -F prerelease=false -f make_latest=legacy --silent
-            release_freshness="$(./.github/scripts/check-release-freshness.sh "$ARTIFACT_ID")"
-            [[ "$release_freshness" == "current" || "$release_freshness" == "superseded" ]]
-          fi
+          release_api_url="$(gh release view "$ARTIFACT_ID" \
+            --repo "$GITHUB_REPOSITORY" --json apiUrl --jq '.apiUrl')"
+          release_api_prefix="https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/"
+          [[ "$release_api_url" == "$release_api_prefix"* ]]
+          release_id="${release_api_url#"$release_api_prefix"}"
+          [[ "$release_id" =~ ^[0-9]+$ ]]
+          gh api --method PATCH \
+            "$release_api_url" \
+            -F draft=false -F prerelease=false -f make_latest=legacy --silent
           deployable=true
           disposition=published
-          if [[ "$ARTIFACT_CHANNEL" == "release" && "$release_freshness" == "superseded" ]]; then
-            deployable=false
-            disposition=published-superseded
-            printf '### Release publish\n\nPublished historical release `%s`; a higher SemVer tag exists, so PREPROD deployment was skipped.\n' \
-              "$ARTIFACT_ID" >> "$GITHUB_STEP_SUMMARY"
-          fi
           {
             echo "deployable=$deployable"
             echo "disposition=$disposition"
@@ -987,8 +1258,8 @@ jobs:
     if: >-
       ${{
         always() &&
-        needs.prepare.outputs.channel == 'main' &&
-        vars.TEST_DEPLOY_ENABLED == 'true' &&
+        needs.prepare.outputs.edition == 'enterprise' &&
+        vars.TEST_AUTO_DEPLOY != 'false' &&
         needs.prepare.result == 'success' &&
         (
           (
@@ -1004,11 +1275,11 @@ jobs:
     uses: ./.github/workflows/deploy_target.yml
     with:
       target: test
-      channel: main
-      tag: ${{ needs.prepare.outputs.tag }}
+      channel: release
+      package_source: host-store
+      tag: ${{ needs.prepare.outputs.release_tag }}
       public_url: ${{ vars.TEST_PUBLIC_URL }}
       admin_public_url: ${{ vars.TEST_ADMIN_PUBLIC_URL }}
-      release_download_proxy_url: ${{ vars.TEST_RELEASE_DOWNLOAD_PROXY_URL }}
       ssh_host: ${{ vars.TEST_SSH_HOST }}
       ssh_port: ${{ vars.TEST_SSH_PORT }}
       ssh_user: ${{ vars.TEST_SSH_USER }}
@@ -1044,82 +1315,120 @@ jobs:
       sentry_frontend_dsn: ${{ secrets.SENTRY_FRONTEND_DSN }}
       sentry_auth_token: ${{ secrets.SENTRY_AUTH_TOKEN }}
 
-  deploy-preprod:
-    name: Deploy · PREPROD
+  promote-production:
+    name: Promote · PROD
+    needs: [prepare, deploy-test]
+    if: >-
+      ${{
+        always() &&
+        needs.prepare.outputs.edition == 'enterprise' &&
+        vars.TEST_AUTO_DEPLOY != 'false' &&
+        vars.PROD_AUTO_DEPLOY != 'false' &&
+        needs.deploy-test.result == 'success'
+      }}
+    uses: ./.github/workflows/enterprise_promotion.yml
+    with:
+      tag: ${{ needs.prepare.outputs.release_tag }}
+      automatic: true
+    secrets: inherit
+
+  deploy-community:
+    name: Deploy · Community
     needs: [prepare, publish-release]
     if: >-
       ${{
         always() &&
-        needs.prepare.outputs.channel == 'release' &&
-        vars.PREPROD_DEPLOY_ENABLED == 'true' &&
+        needs.prepare.outputs.edition == 'community' &&
+        vars.COMMUNITY_AUTO_DEPLOY != 'false' &&
         needs.prepare.result == 'success' &&
-        needs.publish-release.result == 'success' &&
-        needs.publish-release.outputs.deployable == 'true'
+        (
+          (
+            needs.publish-release.result == 'success' &&
+            needs.publish-release.outputs.deployable == 'true'
+          ) ||
+          (
+            needs.prepare.outputs.build_required == 'false' &&
+            needs.publish-release.result == 'skipped'
+          )
+        )
       }}
     uses: ./.github/workflows/deploy_target.yml
     with:
-      target: preprod
+      target: community
       channel: release
-      tag: ${{ needs.prepare.outputs.tag }}
-      public_url: ${{ vars.PREPROD_PUBLIC_URL }}
-      admin_public_url: ${{ vars.PREPROD_ADMIN_PUBLIC_URL }}
-      release_download_proxy_url: ${{ vars.PREPROD_RELEASE_DOWNLOAD_PROXY_URL }}
-      ssh_host: ${{ vars.PREPROD_SSH_HOST }}
-      ssh_port: ${{ vars.PREPROD_SSH_PORT }}
-      ssh_user: ${{ vars.PREPROD_SSH_USER }}
-      ssh_known_hosts: ${{ vars.PREPROD_SSH_KNOWN_HOSTS }}
-      turnstile_site_key: ${{ vars.PREPROD_TURNSTILE_SITE_KEY }}
-      turnstile_enabled: ${{ vars.PREPROD_TURNSTILE_ENABLED == 'true' }}
-      email_signup_enabled: ${{ vars.PREPROD_EMAIL_SIGNUP_ENABLED == 'true' }}
-      email_code_login_enabled: ${{ vars.PREPROD_EMAIL_CODE_LOGIN_ENABLED != 'false' }}
-      google_oauth_enabled: ${{ vars.PREPROD_GOOGLE_OAUTH_ENABLED == 'true' }}
-      google_client_id: ${{ vars.PREPROD_GOOGLE_CLIENT_ID }}
-      sentry_enabled: ${{ vars.PREPROD_SENTRY_ENABLED == 'true' }}
-      platform_gateway_auto_deploy: ${{ vars.PREPROD_PLATFORM_GATEWAY_AUTO_DEPLOY == 'true' }}
-      hfl_insecure_tls: ${{ vars.PREPROD_HFL_INSECURE_TLS }}
-      smtp_host: ${{ vars.PREPROD_SMTP_HOST }}
-      smtp_port: ${{ vars.PREPROD_SMTP_PORT }}
-      smtp_username: ${{ vars.PREPROD_SMTP_USERNAME }}
-      smtp_security: ${{ vars.PREPROD_SMTP_SECURITY }}
-      email_from: ${{ vars.PREPROD_EMAIL_FROM }}
-      ai_model_provider: ${{ vars.PREPROD_AI_MODEL_PROVIDER }}
-      ai_model_id: ${{ vars.PREPROD_AI_MODEL_ID }}
-      ai_model_display_name: ${{ vars.PREPROD_AI_MODEL_DISPLAY_NAME }}
-      ai_multimodal_model_provider: ${{ vars.PREPROD_AI_MULTIMODAL_MODEL_PROVIDER }}
-      ai_multimodal_model_id: ${{ vars.PREPROD_AI_MULTIMODAL_MODEL_ID }}
-      ai_multimodal_model_display_name: ${{ vars.PREPROD_AI_MULTIMODAL_MODEL_DISPLAY_NAME }}
+      tag: ${{ needs.prepare.outputs.release_tag }}
+      public_url: ${{ vars.COMMUNITY_PUBLIC_URL }}
+      admin_public_url: ${{ vars.COMMUNITY_ADMIN_PUBLIC_URL }}
+      release_download_proxy_url: ${{ vars.COMMUNITY_RELEASE_DOWNLOAD_PROXY_URL }}
+      ssh_host: ${{ vars.COMMUNITY_SSH_HOST }}
+      ssh_port: ${{ vars.COMMUNITY_SSH_PORT }}
+      ssh_user: ${{ vars.COMMUNITY_SSH_USER }}
+      ssh_known_hosts: ${{ vars.COMMUNITY_SSH_KNOWN_HOSTS }}
+      turnstile_site_key: ${{ vars.COMMUNITY_TURNSTILE_SITE_KEY }}
+      turnstile_enabled: ${{ vars.COMMUNITY_TURNSTILE_ENABLED == 'true' }}
+      email_signup_enabled: ${{ vars.COMMUNITY_EMAIL_SIGNUP_ENABLED == 'true' }}
+      email_code_login_enabled: ${{ vars.COMMUNITY_EMAIL_CODE_LOGIN_ENABLED != 'false' }}
+      google_oauth_enabled: ${{ vars.COMMUNITY_GOOGLE_OAUTH_ENABLED == 'true' }}
+      google_client_id: ${{ vars.COMMUNITY_GOOGLE_CLIENT_ID }}
+      sentry_enabled: ${{ vars.COMMUNITY_SENTRY_ENABLED == 'true' }}
+      platform_gateway_auto_deploy: ${{ vars.COMMUNITY_PLATFORM_GATEWAY_AUTO_DEPLOY == 'true' }}
+      hfl_insecure_tls: ${{ vars.COMMUNITY_HFL_INSECURE_TLS }}
+      smtp_host: ${{ vars.COMMUNITY_SMTP_HOST }}
+      smtp_port: ${{ vars.COMMUNITY_SMTP_PORT }}
+      smtp_username: ${{ vars.COMMUNITY_SMTP_USERNAME }}
+      smtp_security: ${{ vars.COMMUNITY_SMTP_SECURITY }}
+      email_from: ${{ vars.COMMUNITY_EMAIL_FROM }}
+      ai_model_provider: ${{ vars.COMMUNITY_AI_MODEL_PROVIDER }}
+      ai_model_id: ${{ vars.COMMUNITY_AI_MODEL_ID }}
+      ai_model_display_name: ${{ vars.COMMUNITY_AI_MODEL_DISPLAY_NAME }}
+      ai_multimodal_model_provider: ${{ vars.COMMUNITY_AI_MULTIMODAL_MODEL_PROVIDER }}
+      ai_multimodal_model_id: ${{ vars.COMMUNITY_AI_MULTIMODAL_MODEL_ID }}
+      ai_multimodal_model_display_name: ${{ vars.COMMUNITY_AI_MULTIMODAL_MODEL_DISPLAY_NAME }}
     secrets:
-      ssh_private_key: ${{ secrets.PREPROD_SSH_PRIVATE_KEY }}
-      turnstile_secret_key: ${{ secrets.PREPROD_TURNSTILE_SECRET_KEY }}
-      smtp_password: ${{ secrets.PREPROD_SMTP_PASSWORD }}
-      google_client_secret: ${{ secrets.PREPROD_GOOGLE_CLIENT_SECRET }}
-      ai_model_api_base: ${{ secrets.PREPROD_AI_MODEL_API_BASE }}
-      ai_model_api_key: ${{ secrets.PREPROD_AI_MODEL_API_KEY }}
+      ssh_private_key: ${{ secrets.COMMUNITY_SSH_PRIVATE_KEY }}
+      turnstile_secret_key: ${{ secrets.COMMUNITY_TURNSTILE_SECRET_KEY }}
+      smtp_password: ${{ secrets.COMMUNITY_SMTP_PASSWORD }}
+      google_client_secret: ${{ secrets.COMMUNITY_GOOGLE_CLIENT_SECRET }}
+      ai_model_api_base: ${{ secrets.COMMUNITY_AI_MODEL_API_BASE }}
+      ai_model_api_key: ${{ secrets.COMMUNITY_AI_MODEL_API_KEY }}
       sentry_backend_dsn: ${{ secrets.SENTRY_BACKEND_DSN }}
       sentry_frontend_dsn: ${{ secrets.SENTRY_FRONTEND_DSN }}
       sentry_auth_token: ${{ secrets.SENTRY_AUTH_TOKEN }}
 
-  cleanup-main-builds:
-    name: Cleanup · Main releases
+  cleanup-enterprise-candidate:
+    name: Cleanup · Enterprise candidate
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     needs: [prepare, publish-release]
     if: >-
       ${{
         always() &&
-        needs.prepare.outputs.channel == 'main' &&
-        needs.prepare.result == 'success'
+        needs.prepare.outputs.edition == 'enterprise' &&
+        needs.prepare.outputs.build_required == 'true' &&
+        needs.prepare.result == 'success' &&
+        needs.publish-release.result != 'success'
       }}
     permissions:
       contents: write
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
-      - name: Retain retryable draft or current successful Main build
+      - name: Delete temporary Enterprise candidate
         env:
           GH_TOKEN: ${{ github.token }}
           ARTIFACT_ID: ${{ needs.prepare.outputs.tag }}
-          MAIN_COMMIT: ${{ needs.prepare.outputs.commit }}
-          BUILD_REQUIRED: ${{ needs.prepare.outputs.build_required }}
-          PUBLISH_RESULT: ${{ needs.publish-release.result }}
-          PUBLISH_DISPOSITION: ${{ needs.publish-release.outputs.disposition }}
-        run: ./.github/scripts/cleanup-main-builds.sh
+          TEST_SSH_HOST: ${{ vars.TEST_SSH_HOST }}
+          TEST_SSH_PORT: ${{ vars.TEST_SSH_PORT }}
+          TEST_SSH_USER: ${{ vars.TEST_SSH_USER }}
+          TEST_SSH_KNOWN_HOSTS: ${{ vars.TEST_SSH_KNOWN_HOSTS }}
+          TEST_SSH_PRIVATE_KEY: ${{ secrets.TEST_SSH_PRIVATE_KEY }}
+        run: |
+          install -d -m 0700 ~/.ssh
+          printf '%s\n' "$TEST_SSH_KNOWN_HOSTS" > ~/.ssh/known_hosts
+          printf '%s\n' "$TEST_SSH_PRIVATE_KEY" > ~/.ssh/hyperfilelens_test
+          chmod 0600 ~/.ssh/known_hosts ~/.ssh/hyperfilelens_test
+          ssh -i ~/.ssh/hyperfilelens_test -o BatchMode=yes -o StrictHostKeyChecking=yes \
+            -p "$TEST_SSH_PORT" "$TEST_SSH_USER@$TEST_SSH_HOST" \
+            "rm -rf -- '/root/hfl-release/.incoming/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}'" \
+            || true
+          gh release delete "$ARTIFACT_ID" --repo "$GITHUB_REPOSITORY" --cleanup-tag --yes \
+            || true

--- a/.github/workflows/deploy_target.yml
+++ b/.github/workflows/deploy_target.yml
@@ -4,14 +4,24 @@ on:
   workflow_call:
     inputs:
       target:
-        description: Deployment target identity (test, preprod, or prod)
+        description: Deployment target identity (test, community, or prod)
         required: true
         type: string
       channel:
-        description: Artifact channel (release or main)
+        description: Artifact channel (release)
         required: false
         default: release
         type: string
+      package_source:
+        description: Package source (github or host-store)
+        required: false
+        default: github
+        type: string
+      allow_automatic_prod:
+        description: Allow a trusted caller to deploy PROD outside workflow_dispatch
+        required: false
+        default: false
+        type: boolean
       tag:
         description: Published HFL artifact identifier to deploy
         required: true
@@ -184,7 +194,7 @@ permissions:
 
 jobs:
   deploy:
-    name: ${{ inputs.target == 'test' && 'Deploy · TEST' || inputs.target == 'preprod' && 'Deploy · PREPROD' || 'Deploy · PROD' }}
+    name: ${{ inputs.target == 'test' && 'Deploy · TEST' || inputs.target == 'community' && 'Deploy · Community' || 'Deploy · PROD' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 120
     concurrency:
@@ -200,35 +210,6 @@ jobs:
       RELEASE_DOWNLOAD_PROXY_URL: ${{ inputs.release_download_proxy_url }}
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
-
-      - name: Guard Current Main Deployment
-        if: ${{ inputs.channel == 'main' }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          freshness="$(./.github/scripts/check-main-freshness.sh "$GITHUB_SHA")"
-          if [[ "$freshness" != "current" ]]; then
-            echo '::error title=Superseded Main deployment::A newer origin/main commit exists; this deployment will not contact the TEST host.'
-            printf '### Main deployment\n\nBlocked stale Main commit `%s` before any target-host operation.\n' \
-              "$GITHUB_SHA" >> "$GITHUB_STEP_SUMMARY"
-            exit 1
-          fi
-
-      - name: Guard Current PREPROD Release
-        if: ${{ inputs.target == 'preprod' && inputs.channel == 'release' }}
-        env:
-          ARTIFACT_ID: ${{ inputs.tag }}
-          GH_TOKEN: ${{ github.token }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          freshness="$(./.github/scripts/check-release-freshness.sh "$ARTIFACT_ID")"
-          if [[ "$freshness" != "current" ]]; then
-            echo '::error title=Superseded PREPROD release::A higher SemVer tag exists; this deployment will not contact the PREPROD host.'
-            printf '### PREPROD deployment\n\nBlocked historical release `%s` before any target-host operation.\n' \
-              "$ARTIFACT_ID" >> "$GITHUB_STEP_SUMMARY"
-            exit 1
-          fi
 
       - name: Validate Deployment Inputs
         env:
@@ -266,13 +247,21 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          [[ -n "$DEPLOY_SSH_HOST" && "$DEPLOY_SSH_HOST" != *[[:space:]]* ]]
+          [[ "$DEPLOY_SSH_HOST" =~ ^[A-Za-z0-9][A-Za-z0-9.-]*$ ]]
           [[ "$DEPLOY_SSH_PORT" =~ ^[0-9]+$ ]]
           [[ "$DEPLOY_SSH_USER" =~ ^[a-z_][a-z0-9_-]*$ ]]
           [[ -n "$DEPLOY_SSH_KNOWN_HOSTS" ]]
           [[ -n "$DEPLOY_SSH_PRIVATE_KEY" ]]
-          [[ "$DEPLOY_TARGET" =~ ^(test|preprod|prod)$ ]]
-          [[ "$ARTIFACT_CHANNEL" =~ ^(release|main)$ ]]
+          [[ "$DEPLOY_TARGET" =~ ^(test|community|prod)$ ]]
+          [[ "${{ inputs.package_source }}" =~ ^(github|host-store)$ ]]
+          [[ "$ARTIFACT_CHANNEL" == "release" ]]
+          case "$DEPLOY_TARGET:${{ inputs.package_source }}" in
+            community:github|test:host-store|prod:host-store) ;;
+            *)
+              echo "Deployment target $DEPLOY_TARGET refuses package source ${{ inputs.package_source }}" >&2
+              exit 1
+              ;;
+          esac
           if [[ -n "$RELEASE_DOWNLOAD_PROXY_URL" && "$RELEASE_DOWNLOAD_PROXY_URL" != "UNCONFIGURED" ]]; then
             [[ "$RELEASE_DOWNLOAD_PROXY_URL" =~ ^https?://[A-Za-z0-9.-]+:[0-9]{1,5}$ ]] || {
               echo 'Release download proxy must use http://host:port or https://host:port without credentials' >&2
@@ -282,18 +271,16 @@ jobs:
             proxy_port="${proxy_address##*:}"
             ((proxy_port >= 1 && proxy_port <= 65535))
           fi
-          case "$ARTIFACT_CHANNEL" in
-            release) [[ "$ARTIFACT_ID" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] ;;
-            main) [[ "$ARTIFACT_ID" =~ ^main-[0-9a-f]{7}$ ]] ;;
-          esac
+          [[ "$ARTIFACT_ID" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]
           case "$DEPLOY_TARGET:$ARTIFACT_CHANNEL" in
-            test:main|preprod:release|prod:release) ;;
+            test:release|community:release|prod:release) ;;
             *)
               echo "Deployment target $DEPLOY_TARGET refuses channel $ARTIFACT_CHANNEL" >&2
               exit 1
               ;;
           esac
-          if [[ "$DEPLOY_TARGET" == "prod" && "$GITHUB_EVENT_NAME" != "workflow_dispatch" ]]; then
+          if [[ "$DEPLOY_TARGET" == "prod" && "$GITHUB_EVENT_NAME" != "workflow_dispatch" \
+            && "${{ inputs.allow_automatic_prod }}" != "true" ]]; then
             echo 'Production deployment requires a manual workflow_dispatch event' >&2
             exit 1
           fi
@@ -302,7 +289,7 @@ jobs:
             exit 1
           }
           case "$DEPLOY_TARGET:$HFL_INSECURE_TLS" in
-            test:1|preprod:1|prod:0) ;;
+            test:1|community:1|prod:0) ;;
             *)
               echo "Deployment target $DEPLOY_TARGET refuses HFL_INSECURE_TLS=$HFL_INSECURE_TLS" >&2
               exit 1
@@ -486,7 +473,7 @@ jobs:
                   target = os.environ.get("DEPLOY_TARGET", "")
                   value = {
                       "test": "hfl-test",
-                      "preprod": "hfl-preprod",
+                      "community": "hfl-community",
                       "prod": "hfl-production",
                   }.get(target, "")
               elif name == "SENTRY_TRACES_SAMPLE_RATE":
@@ -532,35 +519,6 @@ jobs:
             "umask 077 && cat > /var/tmp/hyperfilelens-runtime-${GITHUB_RUN_ID}.env && chmod 0600 /var/tmp/hyperfilelens-runtime-${GITHUB_RUN_ID}.env" \
             < "$runtime_env"
 
-      - name: Revalidate Current Main Deployment
-        if: ${{ inputs.channel == 'main' }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          freshness="$(./.github/scripts/check-main-freshness.sh "$GITHUB_SHA")"
-          if [[ "$freshness" != "current" ]]; then
-            echo '::error title=Superseded Main deployment::origin/main advanced while this deployment was being prepared; installation is blocked.'
-            printf '### Main deployment\n\nBlocked stale Main commit `%s` immediately before installation.\n' \
-              "$GITHUB_SHA" >> "$GITHUB_STEP_SUMMARY"
-            exit 1
-          fi
-
-      - name: Revalidate Current PREPROD Release
-        if: ${{ inputs.target == 'preprod' && inputs.channel == 'release' }}
-        env:
-          ARTIFACT_ID: ${{ inputs.tag }}
-          GH_TOKEN: ${{ github.token }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          freshness="$(./.github/scripts/check-release-freshness.sh "$ARTIFACT_ID")"
-          if [[ "$freshness" != "current" ]]; then
-            echo '::error title=Superseded PREPROD release::A higher SemVer tag appeared while deployment was being prepared; installation is blocked.'
-            printf '### PREPROD deployment\n\nBlocked historical release `%s` immediately before installation.\n' \
-              "$ARTIFACT_ID" >> "$GITHUB_STEP_SUMMARY"
-            exit 1
-          fi
-
       - name: Download and Install Release
         shell: bash
         run: |
@@ -569,6 +527,23 @@ jobs:
           if [[ -n "$RELEASE_DOWNLOAD_PROXY_URL" && "$RELEASE_DOWNLOAD_PROXY_URL" != "UNCONFIGURED" ]]; then
             download_proxy_args=(--download-proxy-url "$RELEASE_DOWNLOAD_PROXY_URL")
           fi
+          package_args=()
+          if [[ "${{ inputs.package_source }}" == "host-store" ]]; then
+            version="${{ inputs.tag }}"
+            version="${version#v}"
+            package_args=(--package-file "/root/hfl-release/${{ inputs.tag }}/hyperfilelens-${version}-ee.tar.gz")
+          fi
+          printf -v remote_command '%q ' \
+            bash -s -- \
+              --tag "${{ inputs.tag }}" \
+              --channel "${{ inputs.channel }}" \
+              --public-url "$APP_PUBLIC_URL" \
+              --admin-public-url "$ADMIN_PUBLIC_URL" \
+              --direct-host "$DEPLOY_SSH_HOST" \
+              --install-dir /opt/hyperfilelens \
+              "${download_proxy_args[@]}" \
+              "${package_args[@]}" \
+              --runtime-env-file "/var/tmp/hyperfilelens-runtime-${GITHUB_RUN_ID}.env"
           ssh -i ~/.ssh/hyperfilelens_deploy \
             -o BatchMode=yes \
             -o StrictHostKeyChecking=yes \
@@ -578,15 +553,7 @@ jobs:
             -o TCPKeepAlive=yes \
             -p "$DEPLOY_SSH_PORT" \
             "$DEPLOY_SSH_USER@$DEPLOY_SSH_HOST" \
-            bash -s -- \
-              --tag "${{ inputs.tag }}" \
-              --channel "${{ inputs.channel }}" \
-              --public-url "$APP_PUBLIC_URL" \
-              --admin-public-url "$ADMIN_PUBLIC_URL" \
-              --direct-host "$DEPLOY_SSH_HOST" \
-              --install-dir /opt/hyperfilelens \
-              "${download_proxy_args[@]}" \
-              --runtime-env-file "/var/tmp/hyperfilelens-runtime-${GITHUB_RUN_ID}.env" \
+            "$remote_command" \
             < .github/scripts/remote-deploy.sh
 
       - name: Remove Staged Runtime Configuration
@@ -884,6 +851,7 @@ jobs:
           SENTRY_AUTH_TOKEN: ${{ secrets.sentry_auth_token }}
           DEPLOY_TARGET: ${{ inputs.target }}
           ARTIFACT_ID: ${{ inputs.tag }}
+          PACKAGE_SOURCE: ${{ inputs.package_source }}
         shell: bash
         run: |
           set +e
@@ -909,12 +877,15 @@ jobs:
               raise SystemExit(0)
 
           artifact = os.environ.get("ARTIFACT_ID", "").removeprefix("v")
+          hfl_artifact = artifact
+          if os.environ.get("PACKAGE_SOURCE") == "host-store":
+              hfl_artifact += "-ee"
           defaults = pathlib.Path("tools/sourcelens/defaults.env").read_text(encoding="utf-8")
           match = re.search(r"SOURCELENS_GIT_REF=.*?v(\d+\.\d+\.\d+)", defaults)
           sl_version = match.group(1) if match else "unknown"
           releases = (
-              (f"hyperfilelens-backend@{artifact}", backend_project),
-              (f"hyperfilelens-frontend@{artifact}", frontend_project),
+              (f"hyperfilelens-backend@{hfl_artifact}", backend_project),
+              (f"hyperfilelens-frontend@{hfl_artifact}", frontend_project),
               (f"hyperfilelens-sourcelens@{artifact}-sl{sl_version}", backend_project),
               (f"hyperfilelens-sourcelens-frontend@{artifact}-sl{sl_version}", frontend_project),
               (f"hyperfilelens-agent@{artifact}", backend_project),
@@ -922,7 +893,7 @@ jobs:
           )
           environment = {
               "test": "hfl-test",
-              "preprod": "hfl-preprod",
+              "community": "hfl-community",
               "prod": "hfl-production",
           }[os.environ["DEPLOY_TARGET"]]
           failed = []

--- a/.github/workflows/enterprise_promotion.yml
+++ b/.github/workflows/enterprise_promotion.yml
@@ -1,0 +1,186 @@
+name: HFL - Enterprise Promotion (Reusable)
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        description: Enterprise release stored on the TEST host (vX.Y.Z)
+        required: true
+        type: string
+      automatic:
+        description: Promotion follows a successful TEST deployment in the same run
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: hyperfilelens-enterprise-promotion-prod
+  cancel-in-progress: false
+
+jobs:
+  stage-production:
+    name: Stage · PROD
+    runs-on: ubuntu-24.04
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          # Automatic promotion stays on the immutable release tag. The manual
+          # wrapper only permits main, so emergency promotion uses reviewed main code.
+          ref: ${{ inputs.automatic && inputs.tag || 'main' }}
+      - name: Validate and copy Enterprise release from TEST to PROD
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+          TEST_SSH_HOST: ${{ vars.TEST_SSH_HOST }}
+          TEST_SSH_PORT: ${{ vars.TEST_SSH_PORT }}
+          TEST_SSH_USER: ${{ vars.TEST_SSH_USER }}
+          TEST_SSH_KNOWN_HOSTS: ${{ vars.TEST_SSH_KNOWN_HOSTS }}
+          TEST_SSH_PRIVATE_KEY: ${{ secrets.TEST_SSH_PRIVATE_KEY }}
+          PROD_SSH_HOST: ${{ vars.PROD_SSH_HOST }}
+          PROD_SSH_PORT: ${{ vars.PROD_SSH_PORT }}
+          PROD_SSH_USER: ${{ vars.PROD_SSH_USER }}
+          PROD_SSH_KNOWN_HOSTS: ${{ vars.PROD_SSH_KNOWN_HOSTS }}
+          PROD_SSH_PRIVATE_KEY: ${{ secrets.PROD_SSH_PRIVATE_KEY }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$RELEASE_TAG" =~ ^v([0-9]+\.[0-9]+\.[0-9]+)$ ]]
+          version="${BASH_REMATCH[1]}"
+          [[ "$TEST_SSH_HOST" =~ ^[A-Za-z0-9][A-Za-z0-9.-]*$ && "$TEST_SSH_PORT" =~ ^[0-9]+$ ]]
+          [[ "$PROD_SSH_HOST" =~ ^[A-Za-z0-9][A-Za-z0-9.-]*$ && "$PROD_SSH_PORT" =~ ^[0-9]+$ ]]
+          [[ "$TEST_SSH_USER" =~ ^[a-z_][a-z0-9_-]*$ ]]
+          [[ "$PROD_SSH_USER" =~ ^[a-z_][a-z0-9_-]*$ ]]
+          [[ -n "$TEST_SSH_KNOWN_HOSTS" && -n "$TEST_SSH_PRIVATE_KEY" ]]
+          [[ -n "$PROD_SSH_KNOWN_HOSTS" && -n "$PROD_SSH_PRIVATE_KEY" ]]
+
+          install -d -m 0700 ~/.ssh
+          printf '%s\n' "$TEST_SSH_KNOWN_HOSTS" > ~/.ssh/known_hosts
+          printf '%s\n' "$TEST_SSH_PRIVATE_KEY" > ~/.ssh/hyperfilelens_test
+          chmod 0600 ~/.ssh/known_hosts ~/.ssh/hyperfilelens_test
+
+          hop="/var/tmp/hfl-prod-promotion-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          printf '%s\n' "$PROD_SSH_PRIVATE_KEY" > "$RUNNER_TEMP/prod-key"
+          printf '%s\n' "$PROD_SSH_KNOWN_HOSTS" > "$RUNNER_TEMP/prod-known-hosts"
+          chmod 0600 "$RUNNER_TEMP/prod-key" "$RUNNER_TEMP/prod-known-hosts"
+          eval "$(ssh-agent -s)"
+          trap 'ssh-agent -k >/dev/null 2>&1 || true' EXIT
+          ssh-add "$RUNNER_TEMP/prod-key"
+          ssh -i ~/.ssh/hyperfilelens_test -o BatchMode=yes -o StrictHostKeyChecking=yes \
+            -p "$TEST_SSH_PORT" "$TEST_SSH_USER@$TEST_SSH_HOST" \
+            "rm -rf -- '$hop' && install -d -m 0700 '$hop'"
+          scp -i ~/.ssh/hyperfilelens_test -o BatchMode=yes -o StrictHostKeyChecking=yes \
+            -P "$TEST_SSH_PORT" \
+            "$RUNNER_TEMP/prod-known-hosts" \
+            .github/scripts/store-enterprise-release.sh \
+            "$TEST_SSH_USER@$TEST_SSH_HOST:$hop/"
+          printf -v remote_command '%q ' \
+            bash -s -- "$RELEASE_TAG" "$version" "$hop" \
+              "$PROD_SSH_HOST" "$PROD_SSH_PORT" "$PROD_SSH_USER"
+          ssh -A -i ~/.ssh/hyperfilelens_test -o IdentitiesOnly=yes \
+            -o BatchMode=yes -o StrictHostKeyChecking=yes \
+            -p "$TEST_SSH_PORT" "$TEST_SSH_USER@$TEST_SSH_HOST" \
+            "$remote_command" <<'REMOTE'
+          set -euo pipefail
+          tag=$1
+          version=$2
+          hop=$3
+          prod_host=$4
+          prod_port=$5
+          prod_user=$6
+          source="/root/hfl-release/${tag}"
+          incoming="/root/hfl-release/.incoming/promotion-${tag#v}"
+          cleanup() {
+            ssh -o BatchMode=yes -o StrictHostKeyChecking=yes \
+              -o UserKnownHostsFile="$hop/prod-known-hosts" -p "$prod_port" \
+              "$prod_user@$prod_host" "rm -rf -- '$incoming'" >/dev/null 2>&1 || true
+            rm -rf -- "$hop"
+          }
+          trap cleanup EXIT
+          chmod 0600 "$hop/prod-known-hosts"
+          exec 9</root/hfl-release/.lock
+          flock -s 9
+          cd "$source"
+          sha256sum -c SHA256SUMS
+          ssh -o BatchMode=yes -o StrictHostKeyChecking=yes \
+            -o UserKnownHostsFile="$hop/prod-known-hosts" -p "$prod_port" \
+            "$prod_user@$prod_host" "rm -rf -- '$incoming' && install -d -m 0700 '$incoming'"
+          scp -o BatchMode=yes -o StrictHostKeyChecking=yes \
+            -o UserKnownHostsFile="$hop/prod-known-hosts" -P "$prod_port" \
+            "hyperfilelens-${version}-ee.tar.gz" SHA256SUMS MANIFEST.json \
+            "$prod_user@$prod_host:$incoming/"
+          ssh -o BatchMode=yes -o StrictHostKeyChecking=yes \
+            -o UserKnownHostsFile="$hop/prod-known-hosts" -p "$prod_port" \
+            "$prod_user@$prod_host" \
+            "bash -s -- '$tag' '$incoming' /root/hfl-release 0" \
+            < "$hop/store-enterprise-release.sh"
+          REMOTE
+
+      - name: Remove promotion staging from TEST
+        if: ${{ always() }}
+        env:
+          TEST_SSH_HOST: ${{ vars.TEST_SSH_HOST }}
+          TEST_SSH_PORT: ${{ vars.TEST_SSH_PORT }}
+          TEST_SSH_USER: ${{ vars.TEST_SSH_USER }}
+          TEST_SSH_KNOWN_HOSTS: ${{ vars.TEST_SSH_KNOWN_HOSTS }}
+          TEST_SSH_PRIVATE_KEY: ${{ secrets.TEST_SSH_PRIVATE_KEY }}
+        shell: bash
+        run: |
+          set +e
+          install -d -m 0700 ~/.ssh
+          printf '%s\n' "$TEST_SSH_KNOWN_HOSTS" > ~/.ssh/known_hosts
+          printf '%s\n' "$TEST_SSH_PRIVATE_KEY" > ~/.ssh/hyperfilelens_test
+          chmod 0600 ~/.ssh/known_hosts ~/.ssh/hyperfilelens_test
+          ssh -i ~/.ssh/hyperfilelens_test -o BatchMode=yes -o StrictHostKeyChecking=yes \
+            -p "$TEST_SSH_PORT" "$TEST_SSH_USER@$TEST_SSH_HOST" \
+            "rm -rf -- '/var/tmp/hfl-prod-promotion-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}'"
+
+  deploy-production:
+    name: Deploy · PROD
+    needs: stage-production
+    uses: ./.github/workflows/deploy_target.yml
+    with:
+      target: prod
+      channel: release
+      package_source: host-store
+      allow_automatic_prod: ${{ inputs.automatic }}
+      tag: ${{ inputs.tag }}
+      public_url: ${{ vars.PROD_PUBLIC_URL }}
+      admin_public_url: ${{ vars.PROD_ADMIN_PUBLIC_URL }}
+      ssh_host: ${{ vars.PROD_SSH_HOST }}
+      ssh_port: ${{ vars.PROD_SSH_PORT }}
+      ssh_user: ${{ vars.PROD_SSH_USER }}
+      ssh_known_hosts: ${{ vars.PROD_SSH_KNOWN_HOSTS }}
+      turnstile_site_key: ${{ vars.PROD_TURNSTILE_SITE_KEY }}
+      turnstile_enabled: ${{ vars.PROD_TURNSTILE_ENABLED == 'true' }}
+      email_signup_enabled: ${{ vars.PROD_EMAIL_SIGNUP_ENABLED == 'true' }}
+      email_code_login_enabled: ${{ vars.PROD_EMAIL_CODE_LOGIN_ENABLED != 'false' }}
+      google_oauth_enabled: ${{ vars.PROD_GOOGLE_OAUTH_ENABLED == 'true' }}
+      google_client_id: ${{ vars.PROD_GOOGLE_CLIENT_ID }}
+      ga_measurement_id: ${{ vars.PROD_GA_MEASUREMENT_ID }}
+      sentry_enabled: ${{ vars.PROD_SENTRY_ENABLED == 'true' }}
+      platform_gateway_auto_deploy: ${{ vars.PROD_PLATFORM_GATEWAY_AUTO_DEPLOY == 'true' }}
+      hfl_insecure_tls: ${{ vars.PROD_HFL_INSECURE_TLS }}
+      smtp_host: ${{ vars.PROD_SMTP_HOST }}
+      smtp_port: ${{ vars.PROD_SMTP_PORT }}
+      smtp_username: ${{ vars.PROD_SMTP_USERNAME }}
+      smtp_security: ${{ vars.PROD_SMTP_SECURITY }}
+      email_from: ${{ vars.PROD_EMAIL_FROM }}
+      ai_model_provider: ${{ vars.PROD_AI_MODEL_PROVIDER }}
+      ai_model_id: ${{ vars.PROD_AI_MODEL_ID }}
+      ai_model_display_name: ${{ vars.PROD_AI_MODEL_DISPLAY_NAME }}
+      ai_multimodal_model_provider: ${{ vars.PROD_AI_MULTIMODAL_MODEL_PROVIDER }}
+      ai_multimodal_model_id: ${{ vars.PROD_AI_MULTIMODAL_MODEL_ID }}
+      ai_multimodal_model_display_name: ${{ vars.PROD_AI_MULTIMODAL_MODEL_DISPLAY_NAME }}
+    secrets:
+      ssh_private_key: ${{ secrets.PROD_SSH_PRIVATE_KEY }}
+      turnstile_secret_key: ${{ secrets.PROD_TURNSTILE_SECRET_KEY }}
+      smtp_password: ${{ secrets.PROD_SMTP_PASSWORD }}
+      google_client_secret: ${{ secrets.PROD_GOOGLE_CLIENT_SECRET }}
+      ai_model_api_base: ${{ secrets.PROD_AI_MODEL_API_BASE }}
+      ai_model_api_key: ${{ secrets.PROD_AI_MODEL_API_KEY }}
+      sentry_backend_dsn: ${{ secrets.SENTRY_BACKEND_DSN }}
+      sentry_frontend_dsn: ${{ secrets.SENTRY_FRONTEND_DSN }}
+      sentry_auth_token: ${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/.github/workflows/production_deploy.yml
+++ b/.github/workflows/production_deploy.yml
@@ -1,11 +1,11 @@
-name: HFL - PROD Release Promotion
+name: HFL - Enterprise PROD Promotion
 run-name: PROD · ${{ inputs.tag }} · Promote
 
 on:
   workflow_dispatch:
     inputs:
       tag:
-        description: Published HFL release tag (vX.Y.Z)
+        description: Enterprise release stored on the TEST host (vX.Y.Z)
         required: true
         type: string
 
@@ -13,95 +13,25 @@ permissions:
   contents: read
 
 jobs:
-  validate-production-release:
-    name: Validate · PROD release
+  validate-production-promotion:
+    name: Validate · Manual promotion
     runs-on: ubuntu-24.04
-    timeout-minutes: 10
+    timeout-minutes: 5
     steps:
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
-        with:
-          fetch-depth: 0
-
-      - name: Validate PROD Release
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PROD_DEPLOY_ENABLED: ${{ vars.PROD_DEPLOY_ENABLED }}
-          RELEASE_TAG: ${{ inputs.tag }}
+      - name: Require main branch
         shell: bash
         run: |
           set -euo pipefail
           [[ "$GITHUB_REF" == "refs/heads/main" ]] || {
-            echo 'Production deployment must be dispatched from refs/heads/main' >&2
-            exit 1
-          }
-          [[ "$PROD_DEPLOY_ENABLED" == "true" ]] || {
-            echo 'Production deployment is disabled' >&2
-            exit 1
-          }
-          [[ "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
-            echo 'Production requires a formal vX.Y.Z release tag' >&2
-            exit 2
-          }
-          gh release view "$RELEASE_TAG" \
-            --repo "$GITHUB_REPOSITORY" \
-            --json isDraft,isPrerelease,tagName \
-            > "$RUNNER_TEMP/production-release.json"
-          jq -e --arg tag "$RELEASE_TAG" \
-            '.tagName == $tag and .isDraft == false and .isPrerelease == false' \
-            "$RUNNER_TEMP/production-release.json" >/dev/null || {
-              echo 'Production requires a published, non-prerelease GitHub Release' >&2
-              exit 1
-            }
-          git fetch origin main --no-tags
-          release_commit="$(git rev-parse --verify "${RELEASE_TAG}^{commit}")"
-          git merge-base --is-ancestor "$release_commit" origin/main || {
-            echo 'Production release tag is not part of main' >&2
+            echo "::error::Manual production promotion must be started from the main branch"
             exit 1
           }
 
-  deploy-production:
-    name: Deploy · PROD
-    needs: validate-production-release
-    uses: ./.github/workflows/deploy_target.yml
+  promote-production:
+    name: Promote · PROD
+    needs: validate-production-promotion
+    uses: ./.github/workflows/enterprise_promotion.yml
     with:
-      target: prod
-      channel: release
       tag: ${{ inputs.tag }}
-      public_url: ${{ vars.PROD_PUBLIC_URL }}
-      admin_public_url: ${{ vars.PROD_ADMIN_PUBLIC_URL }}
-      release_download_proxy_url: ${{ vars.PROD_RELEASE_DOWNLOAD_PROXY_URL }}
-      ssh_host: ${{ vars.PROD_SSH_HOST }}
-      ssh_port: ${{ vars.PROD_SSH_PORT }}
-      ssh_user: ${{ vars.PROD_SSH_USER }}
-      ssh_known_hosts: ${{ vars.PROD_SSH_KNOWN_HOSTS }}
-      turnstile_site_key: ${{ vars.PROD_TURNSTILE_SITE_KEY }}
-      turnstile_enabled: ${{ vars.PROD_TURNSTILE_ENABLED == 'true' }}
-      email_signup_enabled: ${{ vars.PROD_EMAIL_SIGNUP_ENABLED == 'true' }}
-      email_code_login_enabled: ${{ vars.PROD_EMAIL_CODE_LOGIN_ENABLED != 'false' }}
-      google_oauth_enabled: ${{ vars.PROD_GOOGLE_OAUTH_ENABLED == 'true' }}
-      google_client_id: ${{ vars.PROD_GOOGLE_CLIENT_ID }}
-      ga_measurement_id: ${{ vars.PROD_GA_MEASUREMENT_ID }}
-      sentry_enabled: ${{ vars.PROD_SENTRY_ENABLED == 'true' }}
-      platform_gateway_auto_deploy: ${{ vars.PROD_PLATFORM_GATEWAY_AUTO_DEPLOY == 'true' }}
-      hfl_insecure_tls: ${{ vars.PROD_HFL_INSECURE_TLS }}
-      smtp_host: ${{ vars.PROD_SMTP_HOST }}
-      smtp_port: ${{ vars.PROD_SMTP_PORT }}
-      smtp_username: ${{ vars.PROD_SMTP_USERNAME }}
-      smtp_security: ${{ vars.PROD_SMTP_SECURITY }}
-      email_from: ${{ vars.PROD_EMAIL_FROM }}
-      ai_model_provider: ${{ vars.PROD_AI_MODEL_PROVIDER }}
-      ai_model_id: ${{ vars.PROD_AI_MODEL_ID }}
-      ai_model_display_name: ${{ vars.PROD_AI_MODEL_DISPLAY_NAME }}
-      ai_multimodal_model_provider: ${{ vars.PROD_AI_MULTIMODAL_MODEL_PROVIDER }}
-      ai_multimodal_model_id: ${{ vars.PROD_AI_MULTIMODAL_MODEL_ID }}
-      ai_multimodal_model_display_name: ${{ vars.PROD_AI_MULTIMODAL_MODEL_DISPLAY_NAME }}
-    secrets:
-      ssh_private_key: ${{ secrets.PROD_SSH_PRIVATE_KEY }}
-      turnstile_secret_key: ${{ secrets.PROD_TURNSTILE_SECRET_KEY }}
-      smtp_password: ${{ secrets.PROD_SMTP_PASSWORD }}
-      google_client_secret: ${{ secrets.PROD_GOOGLE_CLIENT_SECRET }}
-      ai_model_api_base: ${{ secrets.PROD_AI_MODEL_API_BASE }}
-      ai_model_api_key: ${{ secrets.PROD_AI_MODEL_API_KEY }}
-      sentry_backend_dsn: ${{ secrets.SENTRY_BACKEND_DSN }}
-      sentry_frontend_dsn: ${{ secrets.SENTRY_FRONTEND_DSN }}
-      sentry_auth_token: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      automatic: false
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,11 @@
-name: HFL - PREPROD Release & Deploy
-run-name: ${{ github.event_name == 'workflow_dispatch' && format('PREPROD · {0} · Redeploy', inputs.tag) || format('PREPROD · {0} · Build, release & deploy', github.ref_name) }}
+name: HFL - Community Release & Deploy
+run-name: Community · ${{ inputs.tag }} · Release & deploy
 
 on:
-  push:
-    tags:
-      - "v[0-9]+.[0-9]+.[0-9]+"
   workflow_dispatch:
     inputs:
       tag:
-        description: Published HFL release tag to redeploy to pre-production (vX.Y.Z)
+        description: Existing OSS tag to publish (vX.Y.Z)
         required: true
         type: string
 
@@ -16,104 +13,26 @@ permissions:
   contents: write
 
 jobs:
-  build-publish-and-deploy-preprod:
-    name: Build, Release & Deploy · PREPROD
-    if: ${{ github.event_name == 'push' }}
-    uses: ./.github/workflows/artifact_pipeline.yml
-    with:
-      channel: release
-      force_rebuild: false
-    secrets: inherit
-
-  validate-preprod-release:
-    name: Validate · PREPROD release
-    if: ${{ github.event_name == 'workflow_dispatch' }}
+  validate-community-release:
+    name: Validate · Community release
     runs-on: ubuntu-24.04
-    timeout-minutes: 10
+    timeout-minutes: 5
     steps:
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
-        with:
-          fetch-depth: 0
-      - name: Validate PREPROD Release
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PREPROD_DEPLOY_ENABLED: ${{ vars.PREPROD_DEPLOY_ENABLED }}
-          RELEASE_TAG: ${{ inputs.tag }}
+      - name: Require main branch
         shell: bash
         run: |
           set -euo pipefail
           [[ "$GITHUB_REF" == "refs/heads/main" ]] || {
-            echo 'Pre-production redeployment must be dispatched from refs/heads/main' >&2
-            exit 1
-          }
-          [[ "$PREPROD_DEPLOY_ENABLED" == "true" ]] || {
-            echo 'PREPROD deployment is disabled' >&2
-            exit 1
-          }
-          [[ "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
-            echo 'Pre-production requires a formal vX.Y.Z release tag' >&2
-            exit 2
-          }
-          gh release view "$RELEASE_TAG" \
-            --repo "$GITHUB_REPOSITORY" \
-            --json isDraft,isPrerelease,tagName \
-            > "$RUNNER_TEMP/preprod-release.json"
-          jq -e --arg tag "$RELEASE_TAG" \
-            '.tagName == $tag and .isDraft == false and .isPrerelease == false' \
-            "$RUNNER_TEMP/preprod-release.json" >/dev/null || {
-              echo 'Pre-production redeployment requires a published, non-prerelease GitHub Release' >&2
-              exit 1
-            }
-          git fetch origin main --no-tags
-          release_commit="$(git rev-parse --verify "${RELEASE_TAG}^{commit}")"
-          git merge-base --is-ancestor "$release_commit" origin/main || {
-            echo 'Pre-production release tag is not part of main' >&2
+            echo "::error::Community releases must be started from the main branch"
             exit 1
           }
 
-  redeploy-preprod:
-    name: Deploy · PREPROD
-    if: ${{ github.event_name == 'workflow_dispatch' }}
-    needs: validate-preprod-release
-    uses: ./.github/workflows/deploy_target.yml
+  release-community:
+    name: Build, Release & Deploy · Community
+    needs: validate-community-release
+    uses: ./.github/workflows/artifact_pipeline.yml
     with:
-      target: preprod
       channel: release
-      tag: ${{ inputs.tag }}
-      public_url: ${{ vars.PREPROD_PUBLIC_URL }}
-      admin_public_url: ${{ vars.PREPROD_ADMIN_PUBLIC_URL }}
-      release_download_proxy_url: ${{ vars.PREPROD_RELEASE_DOWNLOAD_PROXY_URL }}
-      ssh_host: ${{ vars.PREPROD_SSH_HOST }}
-      ssh_port: ${{ vars.PREPROD_SSH_PORT }}
-      ssh_user: ${{ vars.PREPROD_SSH_USER }}
-      ssh_known_hosts: ${{ vars.PREPROD_SSH_KNOWN_HOSTS }}
-      turnstile_site_key: ${{ vars.PREPROD_TURNSTILE_SITE_KEY }}
-      turnstile_enabled: ${{ vars.PREPROD_TURNSTILE_ENABLED == 'true' }}
-      email_signup_enabled: ${{ vars.PREPROD_EMAIL_SIGNUP_ENABLED == 'true' }}
-      email_code_login_enabled: ${{ vars.PREPROD_EMAIL_CODE_LOGIN_ENABLED != 'false' }}
-      google_oauth_enabled: ${{ vars.PREPROD_GOOGLE_OAUTH_ENABLED == 'true' }}
-      google_client_id: ${{ vars.PREPROD_GOOGLE_CLIENT_ID }}
-      sentry_enabled: ${{ vars.PREPROD_SENTRY_ENABLED == 'true' }}
-      platform_gateway_auto_deploy: ${{ vars.PREPROD_PLATFORM_GATEWAY_AUTO_DEPLOY == 'true' }}
-      hfl_insecure_tls: ${{ vars.PREPROD_HFL_INSECURE_TLS }}
-      smtp_host: ${{ vars.PREPROD_SMTP_HOST }}
-      smtp_port: ${{ vars.PREPROD_SMTP_PORT }}
-      smtp_username: ${{ vars.PREPROD_SMTP_USERNAME }}
-      smtp_security: ${{ vars.PREPROD_SMTP_SECURITY }}
-      email_from: ${{ vars.PREPROD_EMAIL_FROM }}
-      ai_model_provider: ${{ vars.PREPROD_AI_MODEL_PROVIDER }}
-      ai_model_id: ${{ vars.PREPROD_AI_MODEL_ID }}
-      ai_model_display_name: ${{ vars.PREPROD_AI_MODEL_DISPLAY_NAME }}
-      ai_multimodal_model_provider: ${{ vars.PREPROD_AI_MULTIMODAL_MODEL_PROVIDER }}
-      ai_multimodal_model_id: ${{ vars.PREPROD_AI_MULTIMODAL_MODEL_ID }}
-      ai_multimodal_model_display_name: ${{ vars.PREPROD_AI_MULTIMODAL_MODEL_DISPLAY_NAME }}
-    secrets:
-      ssh_private_key: ${{ secrets.PREPROD_SSH_PRIVATE_KEY }}
-      turnstile_secret_key: ${{ secrets.PREPROD_TURNSTILE_SECRET_KEY }}
-      smtp_password: ${{ secrets.PREPROD_SMTP_PASSWORD }}
-      google_client_secret: ${{ secrets.PREPROD_GOOGLE_CLIENT_SECRET }}
-      ai_model_api_base: ${{ secrets.PREPROD_AI_MODEL_API_BASE }}
-      ai_model_api_key: ${{ secrets.PREPROD_AI_MODEL_API_KEY }}
-      sentry_backend_dsn: ${{ secrets.SENTRY_BACKEND_DSN }}
-      sentry_frontend_dsn: ${{ secrets.SENTRY_FRONTEND_DSN }}
-      sentry_auth_token: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      edition: community
+      release_tag: ${{ inputs.tag }}
+    secrets: inherit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,95 +1,45 @@
-name: HFL - TEST Build & Deploy
-run-name: TEST · main · Build & deploy
+name: HFL - Enterprise Build & Deploy
+run-name: Enterprise · ${{ github.event_name == 'push' && github.ref_name || inputs.tag }} · Build & deploy
 
 on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
   workflow_dispatch:
     inputs:
-      force_rebuild:
-        description: Rebuild and redeploy an already-published Main commit
-        required: false
-        default: false
-        type: boolean
-  schedule:
-    # 02:30 Asia/Shanghai, Monday through Friday.
-    - cron: "30 18 * * 0-4"
+      tag:
+        description: Existing OSS and EE tag to rebuild (vX.Y.Z)
+        required: true
+        type: string
 
 permissions:
   contents: write
 
 jobs:
-  require-main:
-    name: Prepare · TEST
+  validate-enterprise-build:
+    name: Validate · Enterprise build
     runs-on: ubuntu-24.04
     timeout-minutes: 5
-    outputs:
-      should_run: ${{ steps.target.outputs.should_run }}
     steps:
-      - name: Validate Main Ref
+      - name: Validate trusted trigger
         shell: bash
         run: |
           set -euo pipefail
-          [[ "$GITHUB_REF" == "refs/heads/main" ]] || {
-            echo "This workflow only builds refs/heads/main" >&2
-            exit 1
-          }
-          [[ "$GITHUB_SHA" =~ ^[0-9a-f]{40}$ ]]
-
-      - name: Resolve TEST Build Target
-        id: target
-        env:
-          DEPLOY_ENABLED: ${{ vars.TEST_DEPLOY_ENABLED }}
-          DEPLOY_SSH_HOST: ${{ vars.TEST_SSH_HOST }}
-          DEPLOY_SSH_PORT: ${{ vars.TEST_SSH_PORT }}
-          DEPLOY_SSH_USER: ${{ vars.TEST_SSH_USER }}
-          DEPLOY_SSH_KNOWN_HOSTS: ${{ vars.TEST_SSH_KNOWN_HOSTS }}
-          DEPLOY_SSH_PRIVATE_KEY: ${{ secrets.TEST_SSH_PRIVATE_KEY }}
-          FORCE_REBUILD: ${{ inputs.force_rebuild || false }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [[ "$DEPLOY_ENABLED" != "true" ]]; then
-            echo 'TEST deployment is disabled; skipping Main build.'
-            echo 'should_run=false' >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          [[ -n "$DEPLOY_SSH_HOST" && "$DEPLOY_SSH_HOST" != *[[:space:]]* ]]
-          [[ "$DEPLOY_SSH_PORT" =~ ^[0-9]+$ ]]
-          [[ "$DEPLOY_SSH_USER" =~ ^[a-z_][a-z0-9_-]*$ ]]
-          [[ -n "$DEPLOY_SSH_KNOWN_HOSTS" && -n "$DEPLOY_SSH_PRIVATE_KEY" ]]
-          install -d -m 0700 ~/.ssh
-          printf '%s\n' "$DEPLOY_SSH_KNOWN_HOSTS" > ~/.ssh/known_hosts
-          printf '%s\n' "$DEPLOY_SSH_PRIVATE_KEY" > ~/.ssh/hyperfilelens_test
-          chmod 0600 ~/.ssh/known_hosts ~/.ssh/hyperfilelens_test
-          ssh -i ~/.ssh/hyperfilelens_test \
-            -o BatchMode=yes \
-            -o StrictHostKeyChecking=yes \
-            -o ConnectTimeout=20 \
-            -p "$DEPLOY_SSH_PORT" \
-            "$DEPLOY_SSH_USER@$DEPLOY_SSH_HOST" \
-            'if [[ -f /opt/hyperfilelens/MANIFEST.json ]]; then cat /opt/hyperfilelens/MANIFEST.json; else printf "{}\n"; fi' \
-            > "$RUNNER_TEMP/test-manifest.json"
-          deployed_commit="$(python3 - "$RUNNER_TEMP/test-manifest.json" <<'PY'
-          import json
-          import pathlib
-          import sys
-
-          manifest = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
-          print(str(manifest.get("git_commit") or "").strip().lower())
-          PY
-          )"
-          if [[ "$FORCE_REBUILD" != "true" && "$deployed_commit" == "$GITHUB_SHA" ]]; then
-            echo "TEST already runs main-${GITHUB_SHA:0:7}; skipping."
-            echo 'should_run=false' >> "$GITHUB_OUTPUT"
+          if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
+            [[ "$GITHUB_REF" == "refs/heads/main" ]] || {
+              echo "::error::Manual Enterprise builds must be started from the main branch"
+              exit 1
+            }
           else
-            echo 'should_run=true' >> "$GITHUB_OUTPUT"
+            [[ "$GITHUB_REF" == refs/tags/v* ]]
           fi
 
-  build-and-deploy-test:
-    name: Build & Deploy · TEST
-    needs: require-main
-    if: ${{ needs.require-main.outputs.should_run == 'true' }}
+  build-enterprise:
+    name: Build & Deploy · Enterprise
+    needs: validate-enterprise-build
     uses: ./.github/workflows/artifact_pipeline.yml
     with:
-      channel: main
-      force_rebuild: ${{ inputs.force_rebuild || false }}
+      channel: release
+      edition: enterprise
+      release_tag: ${{ github.event_name == 'push' && github.ref_name || inputs.tag }}
     secrets: inherit

--- a/README.md
+++ b/README.md
@@ -404,10 +404,14 @@ Application source code is not copied into the release package. Installed
 runtime files are placed under `/opt/hyperfilelens`, with persistent state
 under `/opt/hyperfilelens/data`.
 
+Community and Enterprise CI publishing, deployment, artifact retention, and
+repository configuration are documented in
+[`docs/release-workflows.md`](docs/release-workflows.md).
+
 Install a generated package:
 
 ```bash
-tar xzf hyperfilelens-<version>-<commit7>.tar.gz
+tar xzf hyperfilelens-<version>.tar.gz
 cd hyperfilelens-<version>
 sudo ./install.sh install
 ```
@@ -423,7 +427,7 @@ Upgrade an existing installation:
 
 ```bash
 sudo /opt/hyperfilelens/install.sh upgrade \
-  --from /path/to/hyperfilelens-<version>-<commit7>.tar.gz
+  --from /path/to/hyperfilelens-<version>.tar.gz
 ```
 
 Inspect all build options from the repository and installer options from an

--- a/deploy/installer/apply-runtime-config.py
+++ b/deploy/installer/apply-runtime-config.py
@@ -41,7 +41,9 @@ GOOGLE_CLIENT_ID_PATTERN = re.compile(
     r"^[0-9]+-[A-Za-z0-9_-]+\.apps\.googleusercontent\.com$"
 )
 GA4_MEASUREMENT_ID_PATTERN = re.compile(r"^G-[A-Z0-9]+$")
-SENTRY_ENVIRONMENT_PATTERN = re.compile(r"^hfl-(test|preprod|production)$")
+SENTRY_ENVIRONMENT_PATTERN = re.compile(
+    r"^hfl-(test|community|preprod|production)$"
+)
 
 
 def warn(message: str) -> None:
@@ -414,7 +416,7 @@ def apply_configuration(
 
         updates.update(turnstile_runtime_updates(runtime_values))
         deploy_target = runtime_values.get("HFL_DEPLOY_TARGET", "").strip()
-        if deploy_target in {"test", "preprod", "prod"}:
+        if deploy_target in {"test", "community", "preprod", "prod"}:
             updates["HFL_DEPLOY_TARGET"] = deploy_target
             updates["HFL_DEPLOYMENT_MODE"] = "managed"
         else:

--- a/deploy/installer/install.sh
+++ b/deploy/installer/install.sh
@@ -122,7 +122,7 @@ Examples:
   sudo ./install.sh
   sudo ./install.sh install
   sudo ./install.sh backup
-  sudo ./install.sh upgrade --from /path/to/hyperfilelens-0.1.0-<commit7>.tar.gz
+  sudo ./install.sh upgrade --from /path/to/hyperfilelens-0.1.0.tar.gz
   sudo ./install.sh uninstall
   sudo ./install.sh uninstall --purge-all
   sudo ./install.sh lang-pack install --file /path/to/hyperfilelens-lang-fr-0.1.0.tar.gz
@@ -332,7 +332,7 @@ safe_assert_env_file() {
 
 safe_assert_package_basename() {
 	local name=$1
-	[[ "${name}" =~ ^hyperfilelens-([0-9][0-9A-Za-z._-]*-[0-9a-fA-F]{7}|main-[0-9a-f]{7})\.tar\.gz$ ]] \
+	[[ "${name}" =~ ^hyperfilelens-([0-9]+\.[0-9]+\.[0-9]+(-ee|-[0-9a-fA-F]{7})?|main-[0-9a-f]{7})\.tar\.gz$ ]] \
 		|| die "invalid release package basename: ${name}"
 	[[ "${name}" != */* ]] || die "package basename must not contain slashes: ${name}"
 }
@@ -1093,6 +1093,25 @@ print(str(manifest.get("channel") or "release").strip())
 PY
 }
 
+read_image_version_from_dir() {
+	local dir=$1
+	python3 - "${dir}" <<'PY'
+import json
+import pathlib
+import sys
+
+root = pathlib.Path(sys.argv[1])
+manifest_path = root / "MANIFEST.json"
+if manifest_path.is_file():
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    value = str(manifest.get("image_version") or "").strip()
+    if value:
+        print(value)
+        raise SystemExit(0)
+print((root / "VERSION").read_text(encoding="utf-8").strip())
+PY
+}
+
 validate_package_identity() {
 	local dir=$1
 	python3 - "${dir}" <<'PY'
@@ -1107,6 +1126,9 @@ channel = str(manifest.get("channel") or "release").strip()
 commit = str(manifest.get("git_commit") or "").strip().lower()
 artifact_id = str(manifest.get("artifact_id") or "").strip().lower()
 version_file = (root / "VERSION").read_text(encoding="utf-8").strip()
+edition = str(manifest.get("edition") or "community").strip()
+image_version = str(manifest.get("image_version") or version_file).strip()
+extension_commit = str(manifest.get("extension_commit") or "").strip().lower()
 
 if not re.fullmatch(r"[0-9a-f]{40}", commit):
     raise SystemExit("release manifest has an invalid git_commit")
@@ -1129,6 +1151,16 @@ else:
     raise SystemExit(f"unsupported release channel: {channel}")
 if version_file != expected:
     raise SystemExit("VERSION does not match the release manifest identity")
+if edition not in {"community", "enterprise"}:
+    raise SystemExit("release package has an invalid edition")
+expected_image_version = version_file + ("-ee" if edition == "enterprise" else "")
+if image_version != expected_image_version:
+    raise SystemExit("release package image_version does not match its edition")
+if edition == "enterprise":
+    if not re.fullmatch(r"[0-9a-f]{40}", extension_commit):
+        raise SystemExit("Enterprise release package has an invalid extension_commit")
+elif extension_commit:
+    raise SystemExit("Community release package must not declare extension_commit")
 PY
 }
 
@@ -1398,8 +1430,9 @@ ensure_env_file() {
 		return 0
 	fi
 
-	local version channel secret db_pass host
+	local version image_version channel secret db_pass host
 	version="$(read_version)"
+	image_version="$(read_image_version_from_dir "${ROOT}")"
 	channel="$(read_channel_from_dir "${ROOT}")"
 	secret="$(random_hex)"
 	db_pass="$(random_hex | cut -c1-32)"
@@ -1412,13 +1445,13 @@ ensure_env_file() {
 	step "Creating .env from .env.example ..."
 	cp "${example}" "${env_file}"
 	chmod 600 "${env_file}"
-	python3 - "${env_file}" "${version}" "${channel}" "${secret}" "${db_pass}" "${host}" <<'PY'
+	python3 - "${env_file}" "${version}" "${image_version}" "${channel}" "${secret}" "${db_pass}" "${host}" <<'PY'
 import pathlib
 import re
 import sys
 
 path = pathlib.Path(sys.argv[1])
-version, channel, secret, db_pass, host = sys.argv[2:7]
+version, image_version, channel, secret, db_pass, host = sys.argv[2:8]
 text = path.read_text(encoding="utf-8")
 
 def sub_key(name, value):
@@ -1430,8 +1463,8 @@ def sub_key(name, value):
         text = text.rstrip() + f"\n{name}={value}\n"
 
 sub_key("AGENT_VERSION", version)
-sub_key("APP_VERSION", version)
-sub_key("HFL_GATEWAY_VERSION", version)
+sub_key("APP_VERSION", image_version)
+sub_key("HFL_GATEWAY_VERSION", image_version)
 sub_key("HFL_RELEASE_CHANNEL", channel)
 sub_key("SECRET_KEY", secret)
 sub_key("POSTGRES_PASSWORD", db_pass)
@@ -1693,8 +1726,8 @@ sync_env_from_example() {
 reconcile_hfl_extensions_env() {
 	# Empty HFL_EXTENSIONS= in .env overrides Dockerfile ENV and disables baked plugins.
 	# - Example has a non-empty value → fill missing/empty .env from example (Enterprise).
-	# - Example omits the key (Community) → drop empty HFL_EXTENSIONS= so image ENV wins.
-	# Non-empty operator overrides in .env are preserved.
+	# - Example omits the key (Community) → remove any previous extension setting.
+	# Non-empty Enterprise operator overrides are preserved.
 	local env_file=$1
 	local example=$2
 	[[ -f "${env_file}" ]] || return 0
@@ -1729,7 +1762,7 @@ if example_val:
         )
     else:
         raise SystemExit(0)
-elif env_val == "":
+elif env_val is not None:
     env_text = re.sub(r"(?m)^[ \t]*HFL_EXTENSIONS=.*\n?", "", env_text)
 else:
     raise SystemExit(0)
@@ -1769,21 +1802,23 @@ PY
 update_env_versions() {
 	local version=$1
 	local channel=$2
-	python3 - "${ROOT}" "${version}" "${channel}" <<'PY'
+	local image_version=${3:-$1}
+	python3 - "${ROOT}" "${version}" "${channel}" "${image_version}" <<'PY'
 import pathlib, re, sys
 root = pathlib.Path(sys.argv[1])
 version = sys.argv[2]
 channel = sys.argv[3]
+image_version = sys.argv[4]
 env = root / ".env"
 if not env.exists():
     raise SystemExit(0)
 text = env.read_text(encoding="utf-8")
-for key in ("AGENT_VERSION", "APP_VERSION"):
+for key, value in (("AGENT_VERSION", version), ("APP_VERSION", image_version)):
     pattern = rf"^({re.escape(key)}=).*$"
     if re.search(pattern, text, flags=re.M):
-        text = re.sub(pattern, lambda m, v=version: f"{m.group(1)}{v}", text, count=1, flags=re.M)
+        text = re.sub(pattern, lambda m, v=value: f"{m.group(1)}{v}", text, count=1, flags=re.M)
     else:
-        text = text.rstrip() + f"\n{key}={version}\n"
+        text = text.rstrip() + f"\n{key}={value}\n"
 pattern = r"^(HFL_RELEASE_CHANNEL=).*$"
 if re.search(pattern, text, flags=re.M):
     text = re.sub(pattern, rf"\g<1>{channel}", text, count=1, flags=re.M)
@@ -4250,7 +4285,7 @@ cmd_upgrade() {
 		# Do not claim a blue active pool while the legacy API still owns traffic.
 		safe_rm_file "$(active_color_file)"
 	fi
-	update_env_versions "${new_version}" "${new_channel}"
+	update_env_versions "${new_version}" "${new_channel}" "$(read_image_version_from_dir "${src_root}")"
 	if [[ "$(configured_sourcelens_mode)" == "bundled" ]] \
 		&& sourcelens_installed \
 		&& [[ "${remove_sourcelens}" -eq 0 ]]; then

--- a/docs/release-workflows.md
+++ b/docs/release-workflows.md
@@ -1,0 +1,87 @@
+# Release Workflows
+
+HyperFileLens publishes Community and Enterprise from the OSS repository while
+keeping their artifacts and deployment paths separate.
+
+## Enterprise
+
+Pushing an existing `vX.Y.Z` tag starts `HFL - Enterprise Build & Deploy`. The
+same immutable tag must exist in both the OSS and private Enterprise
+repositories. The quality gates load that exact Enterprise tag, so backend and
+frontend extension tests are explicitly discovered and run together with the
+OSS checks before any image is built. An Enterprise extension without backend
+tests fails the gate. The workflow builds the HFL application images with the
+`X.Y.Z-ee` tag, packages `hyperfilelens-X.Y.Z-ee.tar.gz`, verifies a complete
+offline installation, and stores the result on the TEST host under
+`/root/hfl-release/vX.Y.Z/`. It does not publish the final Enterprise package
+in a GitHub Release. The TEST store retains the ten highest Enterprise
+versions by semantic version.
+
+Manual rebuilding uses the source and release tooling committed in the
+selected tag. A tag created before the edition-aware release contract is
+rejected up front; the workflow never combines historical product source with
+newer packaging code under the old version number.
+
+Rerunning an existing tag never overwrites its stored Enterprise package or
+registry image tags. The workflow validates the retained package and confirms
+that its OSS and Enterprise source commits still match both tags, then skips
+the build and continues with TEST deployment and optional PROD promotion. If
+either tag resolves to a different commit, or the retained package is damaged,
+the workflow fails instead of silently reusing or replacing a different build.
+
+TEST and PROD deployment are enabled unless `TEST_AUTO_DEPLOY` or
+`PROD_AUTO_DEPLOY` is explicitly set to `false`. Automatic PROD promotion runs
+only after TEST deployment succeeds in the same workflow run.
+
+`HFL - Enterprise PROD Promotion` is the manual promotion path. It accepts a
+valid Enterprise version already present on the TEST host, validates its
+manifest and checksum, copies that package from TEST to PROD, and deploys it.
+It is not controlled by `PROD_AUTO_DEPLOY` and does not require an additional
+status marker. Package deployment still follows the installer's compatibility
+rules; database rollback uses a verified managed backup rather than installing
+an older package over newer data.
+
+## Community
+
+`HFL - Community Release & Deploy` is started manually with an existing
+`vX.Y.Z` OSS tag from the `main` branch. It always disables Enterprise
+extension sources, packages `hyperfilelens-X.Y.Z.tar.gz`, and publishes the
+verified assets as the formal GitHub Release. Community deployment is enabled unless
+`COMMUNITY_AUTO_DEPLOY` is explicitly set to `false`.
+
+New Community releases use the stable package name above. Deployment also
+accepts one unambiguous legacy `hyperfilelens-X.Y.Z-SHA7.tar.gz` asset (or its
+split parts), so an already-published historical tag remains deployable. The
+stable name always takes precedence, and multiple legacy candidates are
+rejected. A historical published release can be deployed without rebuilding;
+an unpublished historical tag that predates the edition-aware build contract
+cannot be repackaged by this workflow.
+
+## Repository configuration
+
+Configure these repository variables and secrets before enabling the new
+workflows:
+
+| Kind | Name | Purpose |
+| --- | --- | --- |
+| Variable | `ENTERPRISE_EXTENSION_REPOSITORY` | Credential-free HTTPS URL of the private Enterprise repository |
+| Secret | `ENTERPRISE_EXTENSION_GIT_TOKEN` | Token with read access to the private Enterprise repository |
+| Variable | `TEST_AUTO_DEPLOY` | Set to `false` to retain Enterprise packages without deploying TEST |
+| Variable | `PROD_AUTO_DEPLOY` | Set to `false` to disable automatic PROD promotion |
+| Variable | `COMMUNITY_AUTO_DEPLOY` | Set to `false` to publish Community without deploying it |
+| Variable/secret prefix | `COMMUNITY_*` | Community host and runtime configuration, replacing `PREPROD_*` |
+
+The existing `TEST_*` and `PROD_*` SSH and runtime configuration remains in
+use. Rename old settings as follows:
+
+| Previous name | New name |
+| --- | --- |
+| `HFL_EXTENSION_SOURCES` | `ENTERPRISE_EXTENSION_REPOSITORY` |
+| `HFL_EXTENSION_GIT_TOKEN` | `ENTERPRISE_EXTENSION_GIT_TOKEN` |
+| `TEST_DEPLOY_ENABLED` | `TEST_AUTO_DEPLOY` |
+| `PROD_DEPLOY_ENABLED` | `PROD_AUTO_DEPLOY` |
+| `PREPROD_*` | `COMMUNITY_*` |
+
+The three automatic-deploy variables deliberately use opt-out semantics:
+missing or empty means enabled, and only the exact value `false` disables the
+corresponding deployment.

--- a/release/build.sh
+++ b/release/build.sh
@@ -220,7 +220,8 @@ usage() {
 Usage: release/build.sh [options]
 
 Build one package into build/release/dist/:
-  release channel: hyperfilelens-<version>-<commit7>.tar.gz
+  Community:       hyperfilelens-<version>.tar.gz
+  Enterprise:      hyperfilelens-<version>-ee.tar.gz
   main channel:    hyperfilelens-main-<commit7>.tar.gz
 
 Version:
@@ -527,7 +528,8 @@ stage_release_env_example() {
 	local pkg_root=$1
 	local example="${pkg_root}/.env.example"
 	cp "${ROOT}/.env.example" "${example}"
-	HFL_EXTENSIONS_RUNTIME="${HFL_EXTENSIONS_RUNTIME:-}" python3 - "${example}" <<'PY'
+	HFL_EXTENSIONS_RUNTIME="${HFL_EXTENSIONS_RUNTIME:-}" \
+		HFL_IMAGE_VERSION="${HFL_IMAGE_VERSION:-}" python3 - "${example}" <<'PY'
 import os
 import pathlib
 import re
@@ -537,6 +539,9 @@ path = pathlib.Path(sys.argv[1])
 text = path.read_text(encoding="utf-8")
 text = re.sub(r"(?m)^[ \t]*HFL_EXTENSIONS=.*\n?", "", text)
 runtime = os.environ.get("HFL_EXTENSIONS_RUNTIME", "").strip()
+image_version = os.environ.get("HFL_IMAGE_VERSION", "").strip()
+if image_version:
+    text = re.sub(r"(?m)^APP_VERSION=.*$", f"APP_VERSION={image_version}", text, count=1)
 if runtime:
     block = (
         "\n# Baked into this release's control-plane images (Open Core).\n"
@@ -706,6 +711,7 @@ preflight() {
 
 build_control_plane_images() {
 	[[ -n "${HFL_VERSION:-}" ]] || die "HFL_VERSION is not resolved" 2
+	local image_version="${HFL_IMAGE_VERSION:-${HFL_VERSION}}"
 	local -a common_args=(
 		--platform linux/amd64
 		--network host
@@ -717,10 +723,10 @@ build_control_plane_images() {
 		common_args+=(--no-cache)
 	fi
 
-	log "Building hyperfilelens-backend:${HFL_VERSION} (alias: latest)"
+	log "Building hyperfilelens-backend:${image_version} (alias: latest)"
 	docker build "${common_args[@]}" \
 		-f "${ROOT}/deploy/docker/backend.Dockerfile" \
-		-t "hyperfilelens-backend:${HFL_VERSION}" \
+		-t "hyperfilelens-backend:${image_version}" \
 		-t hyperfilelens-backend:latest \
 		--build-arg "APT_MIRROR=${APT_MIRROR:-}" \
 		--build-arg "BACKEND_BASE_IMAGE=${HFL_BACKEND_BASE_IMAGE}" \
@@ -728,7 +734,7 @@ build_control_plane_images() {
 		--build-arg "PIP_TRUSTED_HOST=${PIP_TRUSTED_HOST:-}" \
 		--build-arg "PIP_TIMEOUT=${PIP_TIMEOUT:-600}" \
 		--build-arg "KOPIA_BINARY=${KOPIA_BINARY:-build/kopia/dist/linux/amd64/kopia}" \
-		--build-arg "IMAGE_VERSION=${HFL_VERSION}" \
+		--build-arg "IMAGE_VERSION=${image_version}" \
 		--build-arg "IMAGE_REVISION=${RELEASE_COMMIT}" \
 		--build-arg "HFL_EXTENSIONS=${HFL_EXTENSIONS_RUNTIME:-}" \
 		"${ROOT}"
@@ -745,16 +751,16 @@ build_control_plane_images() {
 	[[ "${FORCE_PULL}" -eq 0 ]] || website_args+=(--pull)
 	"${ROOT}/website/build.sh" "${website_args[@]}"
 
-	log "Building hyperfilelens-frontend:${HFL_VERSION} (alias: latest)"
+	log "Building hyperfilelens-frontend:${image_version} (alias: latest)"
 	docker build "${common_args[@]}" \
 		-f "${ROOT}/deploy/docker/frontend.Dockerfile" \
-		-t "hyperfilelens-frontend:${HFL_VERSION}" \
+		-t "hyperfilelens-frontend:${image_version}" \
 		-t hyperfilelens-frontend:latest \
 		--build-arg "NPM_REGISTRY=${NPM_REGISTRY:-}" \
 		--build-arg "FRONTEND_NODE_BASE_IMAGE=${HFL_FRONTEND_NODE_BASE_IMAGE}" \
 		--build-arg "FRONTEND_NGINX_BASE_IMAGE=${HFL_FRONTEND_NGINX_BASE_IMAGE}" \
 		--build-arg "VITE_SHOW_EULA=${VITE_SHOW_EULA:-false}" \
-		--build-arg "IMAGE_VERSION=${HFL_VERSION}" \
+		--build-arg "IMAGE_VERSION=${image_version}" \
 		--build-arg "IMAGE_REVISION=${RELEASE_COMMIT}" \
 		--build-arg "HFL_EXTENSIONS=${HFL_EXTENSIONS_RUNTIME:-}" \
 		"${ROOT}"
@@ -867,14 +873,14 @@ save_image_archive() {
 
 save_images() {
 	local images_dir=$1
-	local archive
+	local archive image_version="${HFL_IMAGE_VERSION:-${HFL_VERSION}}"
 	mkdir -p "${images_dir}"
 
 	log "Saving hyperfilelens backend + frontend images..."
 	archive="${images_dir}/00-hyperfilelens.tar.gz"
 	save_image_archive "${archive}" \
-		"hyperfilelens-backend:${HFL_VERSION}" hyperfilelens-backend:latest \
-		"hyperfilelens-frontend:${HFL_VERSION}" hyperfilelens-frontend:latest
+		"hyperfilelens-backend:${image_version}" hyperfilelens-backend:latest \
+		"hyperfilelens-frontend:${image_version}" hyperfilelens-frontend:latest
 	log "  wrote $(du -h "${archive}" | awk '{print $1}') ${archive##*/}"
 
 	log "Saving hyperfilelens-postgres:17..."
@@ -907,7 +913,9 @@ write_manifest() {
 	python3 - "${pkg_root}/MANIFEST.json" "${version}" "${built_at}" "${commit}" \
 		"${payload_sha}" \
 		"${backend_digest}" "${frontend_digest}" "${postgres_digest}" "${redis_digest}" \
-		"${version_file}" "${build_info}" <<'PY'
+		"${version_file}" "${build_info}" \
+		"${HFL_RELEASE_EDITION:-community}" "${HFL_IMAGE_VERSION:-${version}}" \
+		"${HFL_EXTENSION_EXPECTED_COMMIT:-}" <<'PY'
 import hashlib
 import json
 import pathlib
@@ -927,7 +935,10 @@ import tarfile
     redis_d,
     version_file,
     build_info_path,
-) = sys.argv[1:12]
+    edition,
+    image_version,
+    extension_commit,
+) = sys.argv[1:15]
 pkg_root = pathlib.Path(out_path).parent
 
 pins = {}
@@ -985,9 +996,9 @@ images = [
     {
         "file": "images/00-hyperfilelens.tar.gz",
         "refs": [
-            f"hyperfilelens-backend:{version}",
+            f"hyperfilelens-backend:{image_version}",
             "hyperfilelens-backend:latest",
-            f"hyperfilelens-frontend:{version}",
+            f"hyperfilelens-frontend:{image_version}",
             "hyperfilelens-frontend:latest",
         ],
         "digests": [backend_d, frontend_d],
@@ -1092,6 +1103,8 @@ for role, relative in (
 manifest = {
     "schema_version": 2,
     "product": "hyperfilelens",
+    "edition": edition,
+    "image_version": image_version,
     "channel": "main" if version.startswith("main-") else "release",
     "artifact_id": version if version.startswith("main-") else f"v{version}",
     "built_at": built_at,
@@ -1116,6 +1129,19 @@ manifest = {
         "default_tls": tls_artifacts,
     },
 }
+if edition not in {"community", "enterprise"}:
+    raise SystemExit(f"invalid release edition: {edition}")
+expected_image_version = version + ("-ee" if edition == "enterprise" else "")
+if image_version != expected_image_version:
+    raise SystemExit(
+        f"image version {image_version} does not match {edition} release {version}"
+    )
+if edition == "enterprise":
+    if not re.fullmatch(r"[0-9a-f]{40}", extension_commit):
+        raise SystemExit("Enterprise release requires an immutable extension commit")
+    manifest["extension_commit"] = extension_commit
+elif extension_commit:
+    raise SystemExit("Community release must not identify an Enterprise extension commit")
 if manifest["channel"] == "release":
     manifest["version"] = version
 pathlib.Path(out_path).write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
@@ -1179,6 +1205,8 @@ validate_release_publish_artifacts() {
 write_package_readme() {
 	local pkg_root=$1
 	local version=$2
+	local edition=${3:-community} edition_suffix=""
+	[[ "${edition}" == community ]] || edition_suffix="-ee"
 	cat > "${pkg_root}/README.md" <<EOF
 # HyperFileLens ${version}
 
@@ -1215,8 +1243,8 @@ enters through the configured HyperFileLens Tenant HTTPS endpoint.
 ## Install
 
 \`\`\`bash
-tar xzf hyperfilelens-${version}-<commit7>.tar.gz
-cd hyperfilelens-${version}
+tar xzf hyperfilelens-${version}${edition_suffix}.tar.gz
+cd hyperfilelens-${version}${edition_suffix}
 sudo ./install.sh install
 \`\`\`
 
@@ -1252,7 +1280,7 @@ Existing complete \`tls.crt\` / \`tls.key\` pairs are preserved during upgrade; 
 ## Upgrade
 
 \`\`\`bash
-sudo ./install.sh upgrade --from /path/to/hyperfilelens-<version>-<commit>.tar.gz
+sudo ./install.sh upgrade --from /path/to/hyperfilelens-<version>.tar.gz
 sudo ./install.sh upgrade --from /path/to/new.tar.gz --hfl-only
 sudo ./install.sh upgrade --from /path/to/new.tar.gz --remove-sourcelens
 \`\`\`
@@ -1293,24 +1321,31 @@ main() {
 	preflight
 	log "Checking English-only public source trees"
 	python3 "${ROOT}/tools/quality/check-english-source.py"
-	local version commit_full commit7 release_commit pkg_name pkg_root images_dir tar_path tar_basename
+	local version commit_full commit7 release_commit pkg_name pkg_root images_dir tar_path tar_basename edition edition_suffix
 	version="$(read_version)"
 	HFL_VERSION="${version}"
 	commit_full="$(resolve_commit_full "${ROOT}")"
 	commit7="$(resolve_commit7 "${ROOT}")"
 	release_commit="${commit_full}"
 	RELEASE_COMMIT="${release_commit}"
-	pkg_name="hyperfilelens-${version}"
+	edition=community
+	[[ ${#EXTENSION_SOURCES[@]} -eq 0 ]] || edition=enterprise
+	edition_suffix=""
+	[[ "${edition}" == community ]] || edition_suffix="-ee"
+	pkg_name="hyperfilelens-${version}${edition_suffix}"
 	if [[ -n "${PACKAGE_BASENAME:-}" ]]; then
 		tar_basename="${PACKAGE_BASENAME}"
 	else
-		tar_basename="$(release_package_basename_for_version "${version}" "${commit7}")"
+		tar_basename="$(release_package_basename_for_version "${version}" "${commit7}" "${edition}")"
 	fi
 	safe_assert_package_basename "${tar_basename}"
 	pkg_root="${STAGING_BASE}/${pkg_name}"
 	images_dir="${pkg_root}/images"
 
-	log "Version ${version} (git ${commit7}, ${commit_full})"
+	HFL_RELEASE_EDITION="${edition}"
+	HFL_IMAGE_VERSION="${version}${edition_suffix}"
+	export HFL_RELEASE_EDITION HFL_IMAGE_VERSION
+	log "Version ${version} (${edition}, git ${commit7}, ${commit_full})"
 	safe_assert_staging_pkg_root "${pkg_root}" "${STAGING_BASE}"
 	safe_rm_dir "${pkg_root}"
 	mkdir -p "${images_dir}"
@@ -1377,7 +1412,7 @@ main() {
 	write_manifest "${pkg_root}" "${version}" "${release_commit}" "${payload_sha}" \
 		"${backend_digest}" "${frontend_digest}" "${postgres_digest}" "${redis_digest}"
 	validate_release_publish_artifacts "${pkg_root}"
-	write_package_readme "${pkg_root}" "${version}"
+	write_package_readme "${pkg_root}" "${version}" "${edition}"
 	validate_release_security "${pkg_root}"
 
 	mkdir -p "${DIST_DIR}"

--- a/release/ci/assemble-release.sh
+++ b/release/ci/assemble-release.sh
@@ -16,18 +16,20 @@ fi
 
 usage() {
 	cat <<'USAGE'
-Usage: assemble-release.sh --input-dir DIR --version X.Y.Z|main-SHA7 --commit SHA
+Usage: assemble-release.sh --input-dir DIR --version X.Y.Z|main-SHA7 --commit SHA [--edition community|enterprise]
 USAGE
 }
 
 input_dir=""
 version=""
 commit=""
+edition="community"
 while [[ $# -gt 0 ]]; do
 	case "$1" in
 	--input-dir) input_dir=${2:-}; shift 2 ;;
 	--version) version=${2#v}; shift 2 ;;
 	--commit) commit=${2:-}; shift 2 ;;
+	--edition) edition=${2:-}; shift 2 ;;
 	-h | --help) usage; exit 0 ;;
 	*) printf 'ERROR: unknown argument: %s\n' "$1" >&2; exit 2 ;;
 	esac
@@ -35,6 +37,11 @@ done
 
 [[ -d "${input_dir}" ]] || { printf 'ERROR: input directory is missing\n' >&2; exit 2; }
 version="$(normalize_artifact_id "${version}")"
+edition="$(normalize_edition "${edition}")"
+if [[ "${version}" == main-* && "${edition}" != "community" ]]; then
+	printf 'ERROR: main packages do not support an edition override\n' >&2
+	exit 2
+fi
 [[ "${commit}" =~ ^[0-9a-f]{40}$ ]] || { printf 'ERROR: invalid commit\n' >&2; exit 2; }
 if [[ "${version}" == main-* && "${version#main-}" != "${commit:0:7}" ]]; then
 	printf 'ERROR: main build identifier does not match commit\n' >&2
@@ -46,10 +53,12 @@ hfl_logging_start
 trap 'hfl_logging_finish "$?"' EXIT
 
 commit7=${commit:0:7}
-pkg_name="hyperfilelens-${version}"
+edition_suffix=""
+[[ "${edition}" == community ]] || edition_suffix="-ee"
+pkg_name="hyperfilelens-${version}${edition_suffix}"
 pkg_root="${STAGING_BASE}/${pkg_name}"
 images_dir="${pkg_root}/images"
-tar_basename="$(release_package_basename_for_version "${version}" "${commit7}")"
+tar_basename="$(release_package_basename_for_version "${version}" "${commit7}" "${edition}")"
 safe_assert_package_basename "${tar_basename}"
 safe_assert_staging_pkg_root "${pkg_root}" "${STAGING_BASE}"
 safe_rm_dir "${pkg_root}"
@@ -191,6 +200,8 @@ if [[ -z "${HFL_EXTENSIONS_RUNTIME}" && -n "${HFL_EXTENSION_SOURCES:-}" ]]; then
 	)"
 fi
 export HFL_EXTENSIONS_RUNTIME
+HFL_IMAGE_VERSION="${version}${edition_suffix}"
+export HFL_IMAGE_VERSION
 stage_release_env_example "${pkg_root}"
 cp "${ROOT}/LICENSE" "${pkg_root}/LICENSE"
 mkdir -p \
@@ -223,11 +234,12 @@ frontend_digest="$(image_digest "${pkg_root}/metadata/hfl-frontend.json")"
 postgres_digest="$(jq -r '.digest' "${pkg_root}/metadata/postgres.json")"
 redis_digest="$(jq -r '.digest' "${pkg_root}/metadata/redis.json")"
 
-write_manifest "${pkg_root}" "${version}" "${commit}" "${payload_sha}" \
+HFL_RELEASE_EDITION="${edition}" HFL_IMAGE_VERSION="${HFL_IMAGE_VERSION}" \
+	write_manifest "${pkg_root}" "${version}" "${commit}" "${payload_sha}" \
 	"${backend_digest}" "${frontend_digest}" "${postgres_digest}" "${redis_digest}"
 rm -rf "${pkg_root}/metadata"
 validate_release_publish_artifacts "${pkg_root}"
-write_package_readme "${pkg_root}" "${version}"
+write_package_readme "${pkg_root}" "${version}" "${edition}"
 validate_release_security "${pkg_root}"
 
 python3 - "${pkg_root}" <<'PY'

--- a/src/agent/internal/enroll/observability_policy.go
+++ b/src/agent/internal/enroll/observability_policy.go
@@ -8,7 +8,7 @@ import (
 )
 
 var (
-	observabilityEnvironmentPattern = regexp.MustCompile(`^hfl-(test|preprod|production)$`)
+	observabilityEnvironmentPattern = regexp.MustCompile(`^hfl-(test|community|preprod|production)$`)
 	observabilityReleasePattern     = regexp.MustCompile(`^[A-Za-z0-9._@+-]+$`)
 )
 

--- a/src/agent/internal/enroll/observability_policy_test.go
+++ b/src/agent/internal/enroll/observability_policy_test.go
@@ -37,7 +37,7 @@ func TestParseGatewayLensConfigNormalizesObservabilityPolicy(t *testing.T) {
         "observability": {
             "enabled": true,
             "backend_dsn": "https://public@sentry.example.com/25",
-            "environment": "hfl-preprod",
+            "environment": "hfl-community",
             "agent_release": "hyperfilelens-agent@0.1.8",
             "lensnode_release": "hyperfilelens-lensnode@0.1.8-sl0.20.0",
             "traces_sample_rate": 0
@@ -51,7 +51,7 @@ func TestParseGatewayLensConfigNormalizesObservabilityPolicy(t *testing.T) {
 	if !lens.Observability.Enabled {
 		t.Fatalf("observability policy was disabled: %#v", lens.Observability)
 	}
-	if lens.Observability.Environment != "hfl-preprod" {
+	if lens.Observability.Environment != "hfl-community" {
 		t.Fatalf("environment = %q", lens.Observability.Environment)
 	}
 }

--- a/src/backend/apps/node/services/internal/gateway_observability.py
+++ b/src/backend/apps/node/services/internal/gateway_observability.py
@@ -14,7 +14,7 @@ from apps.lens_bridge.services.platform_lens import PLATFORM_ORG_KEY
 from apps.node.models import Node
 from apps.node.models.base import NodeRole
 
-_ENVIRONMENT_RE = re.compile(r"^hfl-(test|preprod|production)$")
+_ENVIRONMENT_RE = re.compile(r"^hfl-(test|community|preprod|production)$")
 _VERSION_RE = re.compile(r"^[A-Za-z0-9._+-]+$")
 
 

--- a/src/backend/apps/node/tests/test_gateway_observability.py
+++ b/src/backend/apps/node/tests/test_gateway_observability.py
@@ -59,6 +59,21 @@ class GatewayObservabilityPolicyTests(TestCase):
             "hyperfilelens-lensnode@main-123abcd-sl0.20.0",
         )
 
+    @override_settings(SENTRY_ENVIRONMENT="hfl-community")
+    @patch.dict(
+        "os.environ",
+        {
+            "SENTRY_BACKEND_DSN": "https://public@sentry.example.com/25",
+            "SOURCELENS_GIT_REF": "v0.20.0",
+        },
+        clear=False,
+    )
+    def test_community_gateway_receives_error_tracking_policy(self) -> None:
+        policy = gateway_observability_policy(self.node)
+
+        self.assertTrue(policy["enabled"])
+        self.assertEqual(policy["environment"], "hfl-community")
+
     @patch.dict(
         "os.environ",
         {"SENTRY_BACKEND_DSN": "https://public@sentry.example.com/25"},

--- a/tools/extensions/materialize_extensions.py
+++ b/tools/extensions/materialize_extensions.py
@@ -263,6 +263,11 @@ def main() -> int:
     parser.add_argument("--sources", default=os.getenv("HFL_EXTENSION_SOURCES", ""))
     parser.add_argument("--extensions", default=os.getenv("HFL_EXTENSIONS", ""))
     parser.add_argument(
+        "--expected-commit",
+        default=os.getenv("HFL_EXTENSION_EXPECTED_COMMIT", ""),
+        help="Require the single Git extension source to resolve to this commit.",
+    )
+    parser.add_argument(
         "--compose-out",
         type=Path,
         default=None,
@@ -308,6 +313,25 @@ def main() -> int:
         if args.print_extensions:
             print("")
         return 0
+
+    expected_commit = args.expected_commit.strip().lower()
+    if expected_commit:
+        if not re.fullmatch(r"[0-9a-f]{40}", expected_commit):
+            raise SystemExit("invalid expected extension commit")
+        if len(sources) != 1 or len(host_roots) != 1:
+            raise SystemExit("expected extension commit requires one Git source")
+        location, _ = _parse_source(sources[0])
+        if not (location.startswith("git@") or "://" in location):
+            raise SystemExit("expected extension commit requires a Git source")
+        actual_commit = subprocess.check_output(
+            ["git", "-C", str(host_roots[0]), "rev-parse", "HEAD"],
+            text=True,
+        ).strip().lower()
+        if actual_commit != expected_commit:
+            raise SystemExit(
+                "extension source commit mismatch: "
+                f"{actual_commit} != {expected_commit}"
+            )
 
     if bake_dir is not None:
         mounts = bake_extensions(host_roots, bake_dir)

--- a/tools/lib/safe-path.sh
+++ b/tools/lib/safe-path.sh
@@ -24,7 +24,7 @@ safe_assert_absolute() {
 
 safe_assert_package_basename() {
 	local name=$1
-	[[ "${name}" =~ ^hyperfilelens-([0-9][0-9A-Za-z._-]*-[0-9a-fA-F]{7}|main-[0-9a-f]{7})\.tar\.gz$ ]] \
+	[[ "${name}" =~ ^hyperfilelens-([0-9]+\.[0-9]+\.[0-9]+(-ee)?|main-[0-9a-f]{7})\.tar\.gz$ ]] \
 		|| safe_path_die "invalid release package basename: ${name}"
 	[[ "${name}" != */* ]] || safe_path_die "package basename must not contain slashes: ${name}"
 }

--- a/tools/lib/version.sh
+++ b/tools/lib/version.sh
@@ -19,6 +19,13 @@ normalize_release_version() {
 	printf '%s' "${version}"
 }
 
+normalize_edition() {
+	local edition="${1:-community}"
+	[[ "${edition}" == "community" || "${edition}" == "enterprise" ]] \
+		|| version_die "invalid edition: ${edition} (expected community or enterprise)" 2
+	printf '%s' "${edition}"
+}
+
 lowercase() {
 	printf '%s' "$1" | tr '[:upper:]' '[:lower:]'
 }
@@ -93,9 +100,10 @@ resolve_commit7() {
 }
 
 release_package_basename_for_version() {
-	local version commit7
+	local version commit7 edition
 	version="$(normalize_artifact_id "$1")" || return $?
 	commit7="$(lowercase "$2")"
+	edition="$(normalize_edition "${3:-community}")" || return $?
 	[[ "${commit7}" =~ ^[0-9a-f]{7}$ ]] \
 		|| version_die "invalid short git commit: ${2} (expected 7 hexadecimal characters)" 2
 	if [[ "${version}" == main-* ]]; then
@@ -104,5 +112,9 @@ release_package_basename_for_version() {
 		printf 'hyperfilelens-%s.tar.gz' "${version}"
 		return
 	fi
-	printf 'hyperfilelens-%s-%s.tar.gz' "${version}" "${commit7}"
+	if [[ "${edition}" == "enterprise" ]]; then
+		printf 'hyperfilelens-%s-ee.tar.gz' "${version}"
+	else
+		printf 'hyperfilelens-%s.tar.gz' "${version}"
+	fi
 }

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -21,8 +21,13 @@ grep -F './tools/quality/test-dev-stack-upgrade.sh' \
 # shellcheck source=../lib/version.sh
 source "${ROOT}/tools/lib/version.sh"
 actual="$(release_package_basename_for_version v0.1.0 69F809F)"
-[[ "${actual}" == "hyperfilelens-0.1.0-69f809f.tar.gz" ]] || {
+[[ "${actual}" == "hyperfilelens-0.1.0.tar.gz" ]] || {
 	printf 'ERROR: unexpected release package basename: %s\n' "${actual}" >&2
+	exit 1
+}
+enterprise_actual="$(release_package_basename_for_version v0.1.0 69F809F enterprise)"
+[[ "${enterprise_actual}" == "hyperfilelens-0.1.0-ee.tar.gz" ]] || {
+	printf 'ERROR: unexpected Enterprise package basename: %s\n' "${enterprise_actual}" >&2
 	exit 1
 }
 main_actual="$(release_package_basename_for_version main-69f809f 69F809F)"
@@ -437,12 +442,15 @@ workflow="${ROOT}/.github/workflows/artifact_pipeline.yml"
 release_workflow="${ROOT}/.github/workflows/release.yml"
 test_workflow="${ROOT}/.github/workflows/test.yml"
 production_workflow="${ROOT}/.github/workflows/production_deploy.yml"
+enterprise_promotion_workflow="${ROOT}/.github/workflows/enterprise_promotion.yml"
 agent_certification="${ROOT}/release/ci/certify-agent-candidate.py"
 [[ -f "${workflow}" ]] || {
 	printf 'ERROR: reusable artifact workflow is missing\n' >&2
 	exit 1
 }
-for entrypoint in "${release_workflow}" "${test_workflow}" "${production_workflow}"; do
+for entrypoint in \
+	"${release_workflow}" "${test_workflow}" "${production_workflow}" \
+	"${enterprise_promotion_workflow}"; do
 	[[ -f "${entrypoint}" ]] || {
 		printf 'ERROR: deployment entrypoint is missing: %s\n' "${entrypoint}" >&2
 		exit 1
@@ -462,22 +470,18 @@ grep -F 'Existing Docker not found; the verified offline release bundle will ins
 	"${ROOT}/.github/scripts/remote-deploy.sh" >/dev/null
 grep -F 'existing Docker daemon is not reachable' \
 	"${ROOT}/.github/scripts/remote-deploy.sh" >/dev/null
-grep -F 'turnstile_enabled: ${{ vars.PREPROD_TURNSTILE_ENABLED' "${workflow}" >/dev/null
-grep -F 'public_url: ${{ vars.PREPROD_PUBLIC_URL }}' "${workflow}" >/dev/null
-grep -F 'admin_public_url: ${{ vars.PREPROD_ADMIN_PUBLIC_URL }}' "${workflow}" >/dev/null
+grep -F 'turnstile_enabled: ${{ vars.COMMUNITY_TURNSTILE_ENABLED' "${workflow}" >/dev/null
+grep -F 'public_url: ${{ vars.COMMUNITY_PUBLIC_URL }}' "${workflow}" >/dev/null
+grep -F 'admin_public_url: ${{ vars.COMMUNITY_ADMIN_PUBLIC_URL }}' "${workflow}" >/dev/null
 grep -F 'turnstile_enabled: ${{ vars.TEST_TURNSTILE_ENABLED' "${workflow}" >/dev/null
 grep -F 'public_url: ${{ vars.TEST_PUBLIC_URL }}' "${workflow}" >/dev/null
 grep -F 'admin_public_url: ${{ vars.TEST_ADMIN_PUBLIC_URL }}' "${workflow}" >/dev/null
-grep -F 'turnstile_enabled: ${{ vars.PROD_TURNSTILE_ENABLED' "${production_workflow}" >/dev/null
-grep -F 'public_url: ${{ vars.PROD_PUBLIC_URL }}' "${production_workflow}" >/dev/null
-grep -F 'admin_public_url: ${{ vars.PROD_ADMIN_PUBLIC_URL }}' "${production_workflow}" >/dev/null
+grep -F 'turnstile_enabled: ${{ vars.PROD_TURNSTILE_ENABLED' "${ROOT}/.github/workflows/enterprise_promotion.yml" >/dev/null
+grep -F 'public_url: ${{ vars.PROD_PUBLIC_URL }}' "${ROOT}/.github/workflows/enterprise_promotion.yml" >/dev/null
+grep -F 'admin_public_url: ${{ vars.PROD_ADMIN_PUBLIC_URL }}' "${ROOT}/.github/workflows/enterprise_promotion.yml" >/dev/null
 grep -F 'hfl_insecure_tls: ${{ vars.TEST_HFL_INSECURE_TLS }}' "${workflow}" >/dev/null
-grep -F 'hfl_insecure_tls: ${{ vars.PREPROD_HFL_INSECURE_TLS }}' "${workflow}" >/dev/null
-grep -F 'hfl_insecure_tls: ${{ vars.PREPROD_HFL_INSECURE_TLS }}' "${release_workflow}" >/dev/null
-grep -F 'hfl_insecure_tls: ${{ vars.PROD_HFL_INSECURE_TLS }}' "${production_workflow}" >/dev/null
-grep -F 'release_download_proxy_url: ${{ vars.TEST_RELEASE_DOWNLOAD_PROXY_URL }}' "${workflow}" >/dev/null
-grep -F 'release_download_proxy_url: ${{ vars.PREPROD_RELEASE_DOWNLOAD_PROXY_URL }}' "${workflow}" >/dev/null
-grep -F 'release_download_proxy_url: ${{ vars.PROD_RELEASE_DOWNLOAD_PROXY_URL }}' "${production_workflow}" >/dev/null
+grep -F 'hfl_insecure_tls: ${{ vars.COMMUNITY_HFL_INSECURE_TLS }}' "${workflow}" >/dev/null
+grep -F 'hfl_insecure_tls: ${{ vars.PROD_HFL_INSECURE_TLS }}' "${ROOT}/.github/workflows/enterprise_promotion.yml" >/dev/null
 if grep -F 'PROD_PUBLIC_HOST' "${workflow}" "${production_workflow}" >/dev/null; then
 	printf 'ERROR: release workflow still uses the ambiguous PROD_PUBLIC_HOST variable\n' >&2
 	exit 1
@@ -486,34 +490,34 @@ grep -F '"TURNSTILE_ENABLED"' \
 	"${ROOT}/.github/workflows/deploy_target.yml" >/dev/null
 grep -F '"HFL_INSECURE_TLS"' \
 	"${ROOT}/.github/workflows/deploy_target.yml" >/dev/null
-grep -F 'test:1|preprod:1|prod:0' \
+grep -F 'test:1|community:1|prod:0' \
 	"${ROOT}/.github/workflows/deploy_target.yml" >/dev/null
 for variable in \
 	SMTP_HOST SMTP_PORT SMTP_USERNAME SMTP_SECURITY EMAIL_FROM; do
 	grep -F "TEST_${variable}" "${workflow}" >/dev/null
-	grep -F "PREPROD_${variable}" "${workflow}" >/dev/null
-	grep -F "PROD_${variable}" "${production_workflow}" >/dev/null
+	grep -F "COMMUNITY_${variable}" "${workflow}" >/dev/null
+	grep -F "PROD_${variable}" "${ROOT}/.github/workflows/enterprise_promotion.yml" >/dev/null
 done
 grep -F 'smtp_password: ${{ secrets.TEST_SMTP_PASSWORD }}' "${workflow}" >/dev/null
-grep -F 'smtp_password: ${{ secrets.PREPROD_SMTP_PASSWORD }}' "${workflow}" >/dev/null
-grep -F 'smtp_password: ${{ secrets.PROD_SMTP_PASSWORD }}' "${production_workflow}" >/dev/null
+grep -F 'smtp_password: ${{ secrets.COMMUNITY_SMTP_PASSWORD }}' "${workflow}" >/dev/null
+grep -F 'smtp_password: ${{ secrets.PROD_SMTP_PASSWORD }}' "${ROOT}/.github/workflows/enterprise_promotion.yml" >/dev/null
 for variable in AI_MODEL_PROVIDER AI_MODEL_ID AI_MODEL_DISPLAY_NAME; do
 	grep -F "TEST_${variable}" "${workflow}" >/dev/null
-	grep -F "PREPROD_${variable}" "${workflow}" >/dev/null
-	grep -F "PROD_${variable}" "${production_workflow}" >/dev/null
+	grep -F "COMMUNITY_${variable}" "${workflow}" >/dev/null
+	grep -F "PROD_${variable}" "${ROOT}/.github/workflows/enterprise_promotion.yml" >/dev/null
 done
 for variable in \
 	AI_MULTIMODAL_MODEL_PROVIDER \
 	AI_MULTIMODAL_MODEL_ID \
 	AI_MULTIMODAL_MODEL_DISPLAY_NAME; do
 	grep -F "TEST_${variable}" "${workflow}" >/dev/null
-	grep -F "PREPROD_${variable}" "${workflow}" >/dev/null
-	grep -F "PROD_${variable}" "${production_workflow}" >/dev/null
+	grep -F "COMMUNITY_${variable}" "${workflow}" >/dev/null
+	grep -F "PROD_${variable}" "${ROOT}/.github/workflows/enterprise_promotion.yml" >/dev/null
 done
 for secret in AI_MODEL_API_BASE AI_MODEL_API_KEY; do
 	grep -F "secrets.TEST_${secret}" "${workflow}" >/dev/null
-	grep -F "secrets.PREPROD_${secret}" "${workflow}" >/dev/null
-	grep -F "secrets.PROD_${secret}" "${production_workflow}" >/dev/null
+	grep -F "secrets.COMMUNITY_${secret}" "${workflow}" >/dev/null
+	grep -F "secrets.PROD_${secret}" "${ROOT}/.github/workflows/enterprise_promotion.yml" >/dev/null
 done
 grep -F '/opt/hyperfilelens/install.sh manage ensure_platform_ai_model' \
 	"${ROOT}/.github/workflows/deploy_target.yml" >/dev/null
@@ -530,12 +534,12 @@ if grep -F '"AI_MODEL_API_KEY=$AI_MODEL_API_KEY"' \
 fi
 for variable in EMAIL_SIGNUP_ENABLED EMAIL_CODE_LOGIN_ENABLED GOOGLE_OAUTH_ENABLED GOOGLE_CLIENT_ID; do
 	grep -F "vars.TEST_${variable}" "${workflow}" >/dev/null
-	grep -F "vars.PREPROD_${variable}" "${workflow}" >/dev/null
-	grep -F "vars.PROD_${variable}" "${production_workflow}" >/dev/null
+	grep -F "vars.COMMUNITY_${variable}" "${workflow}" >/dev/null
+	grep -F "vars.PROD_${variable}" "${ROOT}/.github/workflows/enterprise_promotion.yml" >/dev/null
 done
 grep -F 'secrets.TEST_GOOGLE_CLIENT_SECRET' "${workflow}" >/dev/null
-grep -F 'secrets.PREPROD_GOOGLE_CLIENT_SECRET' "${workflow}" "${release_workflow}" >/dev/null
-grep -F 'secrets.PROD_GOOGLE_CLIENT_SECRET' "${production_workflow}" >/dev/null
+grep -F 'secrets.COMMUNITY_GOOGLE_CLIENT_SECRET' "${workflow}" >/dev/null
+grep -F 'secrets.PROD_GOOGLE_CLIENT_SECRET' "${ROOT}/.github/workflows/enterprise_promotion.yml" >/dev/null
 for runtime_key in \
 	HFL_EMAIL_SIGNUP_ENABLED HFL_EMAIL_CODE_LOGIN_ENABLED HFL_GOOGLE_OAUTH_ENABLED \
 	GOOGLE_CLIENT_ID GOOGLE_CLIENT_SECRET SMTP_PASSWORD; do
@@ -583,42 +587,31 @@ if grep -E '^  (workflow_dispatch|push|schedule):' "${workflow}" >/dev/null; the
 	exit 1
 fi
 grep -F 'workflow_call:' "${workflow}" >/dev/null
-grep -F 'tags:' "${release_workflow}" >/dev/null
 grep -F 'workflow_dispatch:' "${release_workflow}" >/dev/null
-grep -F 'name: HFL - TEST Build & Deploy' "${test_workflow}" >/dev/null
-grep -F 'name: HFL - PREPROD Release & Deploy' "${release_workflow}" >/dev/null
-grep -F 'name: HFL - PROD Release Promotion' "${production_workflow}" >/dev/null
+grep -F 'name: HFL - Enterprise Build & Deploy' "${test_workflow}" >/dev/null
+grep -F 'name: HFL - Community Release & Deploy' "${release_workflow}" >/dev/null
+grep -F 'name: HFL - Enterprise PROD Promotion' "${production_workflow}" >/dev/null
 grep -F 'name: HFL - Build & Package (Reusable)' "${workflow}" >/dev/null
-grep -F 'Validate PREPROD Release' "${release_workflow}" >/dev/null
-grep -F 'uses: ./.github/workflows/deploy_target.yml' "${release_workflow}" >/dev/null
+grep -F 'uses: ./.github/workflows/artifact_pipeline.yml' "${release_workflow}" >/dev/null
 grep -F 'channel: release' "${release_workflow}" >/dev/null
 grep -F 'workflow_dispatch:' "${test_workflow}" >/dev/null
-grep -F 'schedule:' "${test_workflow}" >/dev/null
-grep -F 'channel: main' "${test_workflow}" >/dev/null
+grep -F 'tags:' "${test_workflow}" >/dev/null
+grep -F 'edition: enterprise' "${test_workflow}" >/dev/null
 grep -F 'workflow_dispatch:' "${production_workflow}" >/dev/null
-grep -F 'Production deployment must be dispatched from refs/heads/main' \
-	"${production_workflow}" >/dev/null
-grep -F 'Production requires a published, non-prerelease GitHub Release' \
-	"${production_workflow}" >/dev/null
 for job in \
 	prepare quality build-hfl-images build-sourcelens-images build-agent \
 	certify-source-host agent-release-gate \
 	build-host-debs export-hfl-images export-sourcelens-bundle \
 	export-runtime-images assemble-release verify-release publish-release \
-	deploy-test deploy-preprod; do
+	deploy-test deploy-community promote-production; do
 	grep -F "  ${job}:" "${workflow}" >/dev/null || {
 		printf 'ERROR: artifact workflow job is missing: %s\n' "${job}" >&2
 		exit 1
 	}
 done
-if grep -F 'deploy-prod:' "${workflow}" >/dev/null \
-	|| grep -E '(^|[^A-Z])PROD_' "${workflow}" >/dev/null; then
-	printf 'ERROR: automatic artifact workflow must not contain production deployment configuration\n' >&2
-	exit 1
-fi
-grep -F "vars.TEST_DEPLOY_ENABLED == 'true'" "${workflow}" >/dev/null
-grep -F "vars.PREPROD_DEPLOY_ENABLED == 'true'" "${workflow}" >/dev/null
-grep -F 'PROD_DEPLOY_ENABLED' "${production_workflow}" >/dev/null
+grep -F "vars.TEST_AUTO_DEPLOY != 'false'" "${workflow}" >/dev/null
+grep -F "vars.COMMUNITY_AUTO_DEPLOY != 'false'" "${workflow}" >/dev/null
+grep -F "vars.PROD_AUTO_DEPLOY != 'false'" "${workflow}" >/dev/null
 
 for job in build-hfl-images build-sourcelens-images build-host-debs export-runtime-images; do
 	body="$(sed -n "/^  ${job}:/,/^  [a-zA-Z0-9_-]*:/p" "${workflow}")"
@@ -627,41 +620,11 @@ for job in build-hfl-images build-sourcelens-images build-host-debs export-runti
 		exit 1
 	}
 done
-grep -F "'hyperfilelens-main'" "${workflow}" >/dev/null
-grep -F "format('hyperfilelens-main-rerun-{0}-{1}', github.run_id, github.run_attempt)" \
-	"${workflow}" >/dev/null
-grep -F "format('hyperfilelens-release-{0}', github.ref_name)" "${workflow}" >/dev/null
-grep -F 'cancel-in-progress: ${{ inputs.channel == '\''main'\'' && github.run_attempt == 1 }}' \
-	"${workflow}" >/dev/null
-grep -F '[[ "$GITHUB_SHA" == "$latest_main" ]]' "${workflow}" >/dev/null
-grep -F 'git merge-base --is-ancestor "$GITHUB_SHA" origin/main' "${workflow}" >/dev/null
-grep -F 'Retain retryable draft or current successful Main build' "${workflow}" >/dev/null
-grep -F 'needs: [prepare, publish-release]' "${workflow}" >/dev/null
-grep -F 'BUILD_REQUIRED: ${{ needs.prepare.outputs.build_required }}' "${workflow}" >/dev/null
-grep -F 'MAIN_COMMIT: ${{ needs.prepare.outputs.commit }}' "${workflow}" >/dev/null
-grep -F 'PUBLISH_DISPOSITION: ${{ needs.publish-release.outputs.disposition }}' \
-	"${workflow}" >/dev/null
-grep -F 'freshness="$(./.github/scripts/check-main-freshness.sh "$GITHUB_SHA")"' \
-	"${workflow}" >/dev/null
-grep -F "needs.publish-release.outputs.deployable == 'true'" "${workflow}" >/dev/null
-cleanup_body="$(sed -n '/^  cleanup-main-builds:/,$p' "${workflow}")"
-grep -F 'run: ./.github/scripts/cleanup-main-builds.sh' <<<"${cleanup_body}" >/dev/null
-if grep -F -- '--cleanup-tag' <<<"${cleanup_body}" >/dev/null; then
-  printf 'ERROR: idempotent Main cleanup must not fail when a Release has no Git tag\n' >&2
-  exit 1
-fi
-cleanup_script="${ROOT}/.github/scripts/cleanup-main-builds.sh"
-grep -F 'Retaining retryable Main draft' "${cleanup_script}" >/dev/null
-grep -F '"${PUBLISH_DISPOSITION}" == "superseded"' "${cleanup_script}" >/dev/null
-grep -F 'check-main-freshness.sh" "${MAIN_COMMIT}"' "${cleanup_script}" >/dev/null
-grep -F 'compare/${target_commit}...${MAIN_COMMIT}' "${cleanup_script}" >/dev/null
-grep -F '"${BUILD_REQUIRED}" == "false" && "${PUBLISH_RESULT}" == "skipped"' \
-	"${cleanup_script}" >/dev/null
-grep -F 'gh release delete "${artifact_id}" --repo "${GITHUB_REPOSITORY}" --yes' \
-	"${cleanup_script}" >/dev/null
-grep -F 'git/ref/tags/${artifact_id}' "${cleanup_script}" >/dev/null
-grep -F 'git/refs/tags/${artifact_id}' "${cleanup_script}" >/dev/null
-grep -F 'check-release-freshness.sh "$ARTIFACT_ID"' "${workflow}" >/dev/null
+grep -F "format('hyperfilelens-package-{0}', inputs.release_tag)" "${workflow}" >/dev/null
+grep -F 'cancel-in-progress: false' "${workflow}" >/dev/null
+grep -F 'git merge-base --is-ancestor "$COMMIT" origin/main' "${workflow}" >/dev/null
+grep -F 'cleanup-enterprise-candidate:' "${workflow}" >/dev/null
+grep -F 'gh release delete "$ARTIFACT_ID"' "${workflow}" >/dev/null
 grep -F 'make_latest=legacy' "${workflow}" >/dev/null
 grep -F -- '--json apiUrl --jq '\''.apiUrl'\''' "${workflow}" >/dev/null
 grep -F 'release_api_prefix="https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/"' \
@@ -671,12 +634,6 @@ if grep -F 'releases/tags/${ARTIFACT_ID}' "${workflow}" >/dev/null; then
 	exit 1
 fi
 grep -F "needs.publish-release.outputs.deployable == 'true'" "${workflow}" >/dev/null
-grep -F "inputs.target == 'preprod' && inputs.channel == 'release'" \
-	"${ROOT}/.github/workflows/deploy_target.yml" >/dev/null
-if grep -F -- '--cleanup-tag' "${cleanup_script}" >/dev/null; then
-	printf 'ERROR: idempotent Main cleanup must not fail when a Release has no Git tag\n' >&2
-	exit 1
-fi
 grep -F 'ubuntu_release: "22.04"' "${workflow}" >/dev/null
 grep -F 'asset: ubuntu2204' "${workflow}" >/dev/null
 
@@ -1278,6 +1235,7 @@ for executable in \
 	"${ROOT}/.github/scripts/check-public-endpoint.sh" \
 	"${ROOT}/.github/scripts/cleanup-main-builds.sh" \
 	"${ROOT}/.github/scripts/remote-deploy.sh" \
+	"${ROOT}/.github/scripts/store-enterprise-release.sh" \
 	"${ROOT}/tools/quality/check-python38-runtime.py" \
 	"${ROOT}/tools/quality/test-docker-pull-retry.sh" \
 	"${ROOT}/tools/quality/test-bootstrap-curl-tls-nounset.sh" \
@@ -1287,6 +1245,7 @@ for executable in \
 	"${ROOT}/tools/quality/test-main-release-freshness.sh" \
 	"${ROOT}/tools/quality/test-main-release-cleanup.sh" \
 	"${ROOT}/tools/quality/test-release-freshness.sh" \
+	"${ROOT}/tools/quality/test-enterprise-release-flow.sh" \
 	"${ROOT}/tools/quality/test-language-pack-runtime-index.sh" \
 	"${ROOT}/tools/quality/test-upgrade-backup-retention.sh" \
 	"${ROOT}/tools/quality/test-redis-rdb-preflight.sh" \
@@ -1439,8 +1398,8 @@ grep -F 'MemoryHigh=512M' "${ROOT}/src/agent/packaging/install/install.sh" >/dev
 grep -F 'CPUQuota=50%' "${ROOT}/src/agent/packaging/install/install.sh" >/dev/null
 grep -F 'name: hyperfilelens-sourcelens' \
 	"${ROOT}/deploy/installer/sourcelens/docker-compose.template.yml" >/dev/null
-grep -F 'target: prod' "${production_workflow}" >/dev/null
-grep -F 'channel: release' "${production_workflow}" >/dev/null
+grep -F 'target: prod' "${enterprise_promotion_workflow}" >/dev/null
+grep -F 'channel: release' "${enterprise_promotion_workflow}" >/dev/null
 grep -F 'Production deployment requires a manual workflow_dispatch event' \
 	"${ROOT}/.github/workflows/deploy_target.yml" >/dev/null
 grep -F 'if ! SOURCELENS_BUILD_SOURCE_MAPS=1' \

--- a/tools/quality/test-agent-gateway-uninstall.sh
+++ b/tools/quality/test-agent-gateway-uninstall.sh
@@ -112,6 +112,7 @@ PATH="${fake_bin}:${PATH}" \
 	HFL_AGENT_ENV_FILE="${tmp}/missing-agent.env" \
 	HFL_LENS_ENV_FILE="${tmp}/missing-lensnode.env" \
 	HFL_GATEWAY_COMPOSE_DIR="${compose_dir}" \
+	HFL_GATEWAY_SIDECAR_LOCK_FILE="${tmp}/gateway-sidecar.lock" \
 	bash "${ROOT}/deploy/bootstrap/gateway-lifecycle.sh" uninstall-sidecar --purge-all
 
 [[ -f "${docker_state}.down" ]]

--- a/tools/quality/test-ci-release-assembly.sh
+++ b/tools/quality/test-ci-release-assembly.sh
@@ -5,6 +5,9 @@ umask 022
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 version="${HFL_TEST_VERSION:-1.2.3}"
+edition="${HFL_TEST_EDITION:-community}"
+image_version="${version}"
+[[ "${edition}" == community ]] || image_version="${version}-ee"
 commit="0123456789abcdef0123456789abcdef01234567"
 tmp="$(mktemp -d "${ROOT}/build/ci-assembly-test.XXXXXX")"
 trap 'rm -rf "${tmp}"' EXIT
@@ -28,8 +31,8 @@ make_metadata() {
 
 hfl="${fixtures}/hfl"
 make_gzip "${hfl}/images/00-hyperfilelens.tar.gz" hfl-images
-make_metadata "${hfl}/metadata/hfl-backend.json" hfl-backend "example/hfl-backend:${version}" 1
-make_metadata "${hfl}/metadata/hfl-frontend.json" hfl-frontend "example/hfl-frontend:${version}" 2
+make_metadata "${hfl}/metadata/hfl-backend.json" hfl-backend "example/hfl-backend:${image_version}" 1
+make_metadata "${hfl}/metadata/hfl-frontend.json" hfl-frontend "example/hfl-frontend:${image_version}" 2
 tar -C "${hfl}" -cf "${input}/_internal-hfl-images.tar" images metadata
 
 runtime="${fixtures}/runtime"
@@ -146,10 +149,12 @@ done
 HFL_CI_RELEASE_BUILD_DIR="${output}" \
 	HFL_RELEASE_MAX_SINGLE_BYTES=1024 \
 	HFL_RELEASE_PART_BYTES=4096 \
+	HFL_EXTENSION_EXPECTED_COMMIT="$([[ "${edition}" == enterprise ]] && printf '%s' 89abcdef0123456789abcdef0123456789abcdef)" \
 	"${ROOT}/release/ci/assemble-release.sh" \
 		--input-dir "${input}" \
 		--version "${version}" \
-		--commit "${commit}"
+		--commit "${commit}" \
+		--edition "${edition}"
 
 (
 	cd "${output}/dist"
@@ -168,9 +173,15 @@ HFL_CI_RELEASE_BUILD_DIR="${output}" \
 			'.channel == "main" and .artifact_id == $id and (has("version") | not)' \
 			MANIFEST.json >/dev/null
 	else
-		jq -e --arg version "${version}" \
-			'.channel == "release" and .artifact_id == ("v" + $version) and .version == $version' \
-			MANIFEST.json >/dev/null
+		if [[ "${edition}" == enterprise ]]; then
+			jq -e --arg version "${version}" \
+				'.channel == "release" and .artifact_id == ("v" + $version) and .version == $version and .edition == "enterprise" and .image_version == ($version + "-ee") and .extension_commit == "89abcdef0123456789abcdef0123456789abcdef"' \
+				MANIFEST.json >/dev/null
+		else
+			jq -e --arg version "${version}" \
+				'.channel == "release" and .artifact_id == ("v" + $version) and .version == $version and .edition == "community" and .image_version == $version and (has("extension_commit") | not)' \
+				MANIFEST.json >/dev/null
+		fi
 	fi
 	sha256sum -c SHA256SUMS
 	[[ -s hyperfilelens-root-ca.crt ]]

--- a/tools/quality/test-enterprise-release-flow.sh
+++ b/tools/quality/test-enterprise-release-flow.sh
@@ -1,0 +1,262 @@
+#!/usr/bin/env bash
+# Fast contracts for Community/Enterprise CI identity and TEST-host retention.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+# shellcheck source=../lib/version.sh
+source "${ROOT}/tools/lib/version.sh"
+
+[[ "$(release_package_basename_for_version v1.2.3 abcdef0 community)" \
+	== "hyperfilelens-1.2.3.tar.gz" ]]
+[[ "$(release_package_basename_for_version v1.2.3 abcdef0 enterprise)" \
+	== "hyperfilelens-1.2.3-ee.tar.gz" ]]
+
+# The packaged installer carries its own deletion guards; both canonical
+# release names must remain valid when passed directly to `upgrade --from`.
+# shellcheck disable=SC1090
+source "${ROOT}/deploy/installer/install.sh"
+tmp_guard="$(mktemp -d)"
+trap 'rm -rf "${tmp_guard}"' EXIT
+touch "${tmp_guard}/hyperfilelens-1.2.3.tar.gz" \
+	"${tmp_guard}/hyperfilelens-1.2.3-ee.tar.gz" \
+	"${tmp_guard}/hyperfilelens-1.2.3-abcdef0.tar.gz"
+safe_assert_upgrade_package_file "${tmp_guard}/hyperfilelens-1.2.3.tar.gz"
+safe_assert_upgrade_package_file "${tmp_guard}/hyperfilelens-1.2.3-ee.tar.gz"
+safe_assert_upgrade_package_file "${tmp_guard}/hyperfilelens-1.2.3-abcdef0.tar.gz"
+rm -rf "${tmp_guard}"
+trap - EXIT
+
+tmp_extensions="$(mktemp -d)"
+trap 'rm -rf "${tmp_extensions}"' EXIT
+env_file="${tmp_extensions}/.env"
+example_file="${tmp_extensions}/.env.example"
+printf '%s\n' 'APP_VERSION=1.2.2-ee' \
+	'HFL_EXTENSIONS=/opt/hfl/extensions/platform' >"${env_file}"
+printf '%s\n' 'APP_VERSION=1.2.3' >"${example_file}"
+reconcile_hfl_extensions_env "${env_file}" "${example_file}"
+if grep -F 'HFL_EXTENSIONS=' "${env_file}" >/dev/null; then
+	printf 'ERROR: Community upgrade must remove a previous Enterprise extension path\n' >&2
+	exit 1
+fi
+printf '%s\n' 'APP_VERSION=1.2.3-ee' \
+	'HFL_EXTENSIONS=/opt/hfl/extensions/platform' >"${example_file}"
+reconcile_hfl_extensions_env "${env_file}" "${example_file}"
+grep -Fx 'HFL_EXTENSIONS=/opt/hfl/extensions/platform' "${env_file}" >/dev/null
+rm -rf "${tmp_extensions}"
+trap - EXIT
+
+workflow="${ROOT}/.github/workflows/artifact_pipeline.yml"
+entry_enterprise="${ROOT}/.github/workflows/test.yml"
+entry_community="${ROOT}/.github/workflows/release.yml"
+promotion="${ROOT}/.github/workflows/production_deploy.yml"
+grep -F 'name: HFL - Enterprise Build & Deploy' "${entry_enterprise}" >/dev/null
+grep -F 'tags:' "${entry_enterprise}" >/dev/null
+grep -F 'edition: enterprise' "${entry_enterprise}" >/dev/null
+grep -F 'needs: validate-enterprise-build' "${entry_enterprise}" >/dev/null
+grep -F 'Manual Enterprise builds must be started from the main branch' \
+	"${entry_enterprise}" >/dev/null
+grep -F 'name: HFL - Community Release & Deploy' "${entry_community}" >/dev/null
+if grep -F 'tags:' "${entry_community}" >/dev/null; then
+	printf 'ERROR: Community publishing must be manual\n' >&2
+	exit 1
+fi
+grep -F 'edition: community' "${entry_community}" >/dev/null
+grep -F 'needs: validate-community-release' "${entry_community}" >/dev/null
+grep -F 'Community releases must be started from the main branch' \
+	"${entry_community}" >/dev/null
+grep -F "vars.TEST_AUTO_DEPLOY != 'false'" "${workflow}" >/dev/null
+grep -F "vars.PROD_AUTO_DEPLOY != 'false'" "${workflow}" >/dev/null
+grep -F "vars.COMMUNITY_AUTO_DEPLOY != 'false'" "${workflow}" >/dev/null
+grep -F 'ENTERPRISE_EXTENSION_REPOSITORY' "${workflow}" >/dev/null
+grep -F 'secrets.ENTERPRISE_EXTENSION_GIT_TOKEN' "${workflow}" >/dev/null
+grep -F 'Materialize Enterprise extension for quality gates' "${workflow}" >/dev/null
+grep -F 'HFL_EXTENSIONS=$extensions' "${workflow}" >/dev/null
+grep -F 'Enterprise extension contains no discoverable backend tests' "${workflow}" >/dev/null
+grep -F 'manage.py test "${extension_test_labels[@]}"' "${workflow}" >/dev/null
+grep -F 'enterprise_commit: ${{ steps.enterprise-ref.outputs.commit }}' "${workflow}" >/dev/null
+grep -F 'Check immutable Enterprise store' "${workflow}" >/dev/null
+grep -F 'ENTERPRISE_STORED: ${{ steps.enterprise-store.outputs.stored }}' "${workflow}" >/dev/null
+grep -F 'stored Enterprise release identity differs' "${workflow}" >/dev/null
+grep -F 'flock -s 9' "${workflow}" >/dev/null
+grep -F -- '--expected-commit "$ENTERPRISE_COMMIT"' "${workflow}" >/dev/null
+grep -F 'validate_build_contract()' "${workflow}" >/dev/null
+grep -F 'Selected tag predates the edition-aware release contract' "${workflow}" >/dev/null
+grep -F '"$TEST_SSH_USER@$TEST_SSH_HOST:$remote/."' "${workflow}" >/dev/null
+grep -F 'local image_version="${HFL_IMAGE_VERSION:-${HFL_VERSION}}"' \
+	"${ROOT}/release/build.sh" >/dev/null
+grep -F 'tar xzf hyperfilelens-${version}${edition_suffix}.tar.gz' \
+	"${ROOT}/release/build.sh" >/dev/null
+grep -F '"hyperfilelens-backend:${image_version}"' "${ROOT}/release/build.sh" >/dev/null
+grep -F '"hyperfilelens-frontend:${image_version}"' "${ROOT}/release/build.sh" >/dev/null
+grep -F 'sub_key("HFL_GATEWAY_VERSION", image_version)' \
+	"${ROOT}/deploy/installer/install.sh" >/dev/null
+grep -F 'Enterprise release package has an invalid extension_commit' \
+	"${ROOT}/deploy/installer/install.sh" >/dev/null
+grep -F '"ls-remote"' "${workflow}" >/dev/null
+grep -F 'f"refs/tags/{tag}"' "${workflow}" >/dev/null
+grep -F 'gh release delete "$ARTIFACT_ID"' "${workflow}" >/dev/null
+grep -F 'uses: ./.github/workflows/enterprise_promotion.yml' "${promotion}" >/dev/null
+grep -F 'needs: validate-production-promotion' "${promotion}" >/dev/null
+grep -F '[[ "$GITHUB_REF" == "refs/heads/main" ]]' "${promotion}" >/dev/null
+grep -F "ref: \${{ inputs.automatic && inputs.tag || 'main' }}" \
+	"${ROOT}/.github/workflows/enterprise_promotion.yml" >/dev/null
+grep -F 'ssh-agent -s' "${ROOT}/.github/workflows/enterprise_promotion.yml" >/dev/null
+grep -F 'flock -s 9' "${ROOT}/.github/workflows/enterprise_promotion.yml" >/dev/null
+grep -F "printf -v remote_command '%q '" \
+	"${ROOT}/.github/workflows/enterprise_promotion.yml" >/dev/null
+grep -F 'expected_edition=enterprise' "${ROOT}/.github/scripts/remote-deploy.sh" >/dev/null
+grep -F 'flock -s 8' "${ROOT}/.github/scripts/remote-deploy.sh" >/dev/null
+grep -F "printf -v remote_command '%q '" \
+	"${ROOT}/.github/workflows/deploy_target.yml" >/dev/null
+grep -F 'release has multiple legacy package candidates' \
+	"${ROOT}/.github/scripts/remote-deploy.sh" >/dev/null
+grep -F 'ERROR: no checksum for %s' \
+	"${ROOT}/.github/scripts/remote-deploy.sh" >/dev/null
+grep -F 'community:github|test:host-store|prod:host-store' \
+	"${ROOT}/.github/workflows/deploy_target.yml" >/dev/null
+grep -F 'PACKAGE_SOURCE: ${{ inputs.package_source }}' \
+	"${ROOT}/.github/workflows/deploy_target.yml" >/dev/null
+grep -F 'hfl_artifact += "-ee"' "${ROOT}/.github/workflows/deploy_target.yml" >/dev/null
+grep -F 'hyperfilelens-agent@{artifact}' "${ROOT}/.github/workflows/deploy_target.yml" >/dev/null
+if grep -E '^[[:space:]]+"\$RUNNER_TEMP/prod-key"[[:space:]]' \
+	"${ROOT}/.github/workflows/enterprise_promotion.yml" >/dev/null; then
+	printf 'ERROR: the PROD private key must not be copied onto the TEST host\n' >&2
+	exit 1
+fi
+if grep -R -F 'TESTED' "${promotion}" "${ROOT}/.github/workflows/enterprise_promotion.yml" >/dev/null; then
+	printf 'ERROR: manual Enterprise production promotion must not require TESTED\n' >&2
+	exit 1
+fi
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "${tmp}"' EXIT
+
+selector="${tmp}/select-community-release-assets.py"
+sed -n \
+	'/^# BEGIN COMMUNITY RELEASE ASSET SELECTOR$/,/^# END COMMUNITY RELEASE ASSET SELECTOR$/p' \
+	"${ROOT}/.github/scripts/remote-deploy.sh" \
+	| sed '1d;$d' \
+	| sed '1d;$d' >"${selector}"
+
+write_release_json() {
+	python3 - "$1" "${@:2}" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+names = sys.argv[2:]
+path.write_text(
+    json.dumps(
+        {
+            "draft": False,
+            "tag_name": "v1.2.3",
+            "assets": [
+                {"name": name, "browser_download_url": f"https://example.invalid/{name}"}
+                for name in ["SHA256SUMS", *names]
+            ],
+        }
+    ),
+    encoding="utf-8",
+)
+PY
+}
+
+release_json="${tmp}/release.json"
+assets_tsv="${tmp}/assets.tsv"
+write_release_json "$release_json" \
+	"hyperfilelens-1.2.3.tar.gz" \
+	"hyperfilelens-1.2.3-abcdef0.tar.gz"
+python3 "$selector" "$release_json" "$assets_tsv" v1.2.3
+grep -F $'hyperfilelens-1.2.3.tar.gz\thttps://example.invalid/hyperfilelens-1.2.3.tar.gz' \
+	"$assets_tsv" >/dev/null
+if grep -F 'hyperfilelens-1.2.3-abcdef0.tar.gz' "$assets_tsv" >/dev/null; then
+	printf 'ERROR: current Community package must take precedence over a legacy package\n' >&2
+	exit 1
+fi
+
+write_release_json "$release_json" \
+	"hyperfilelens-1.2.3-abcdef0.tar.gz.part-000" \
+	"hyperfilelens-1.2.3-abcdef0.tar.gz.part-001"
+python3 "$selector" "$release_json" "$assets_tsv" v1.2.3
+grep -F 'hyperfilelens-1.2.3-abcdef0.tar.gz.part-000' "$assets_tsv" >/dev/null
+grep -F 'hyperfilelens-1.2.3-abcdef0.tar.gz.part-001' "$assets_tsv" >/dev/null
+
+write_release_json "$release_json" \
+	"hyperfilelens-1.2.3-abcdef0.tar.gz" \
+	"hyperfilelens-1.2.3-1234567.tar.gz"
+if python3 "$selector" "$release_json" "$assets_tsv" v1.2.3 2>"${tmp}/selector-error"; then
+	printf 'ERROR: ambiguous legacy Community packages must be rejected\n' >&2
+	exit 1
+fi
+grep -F 'multiple legacy package candidates' "${tmp}/selector-error" >/dev/null
+
+store="${tmp}/hfl-release"
+mkdir -p "${store}/.incoming"
+
+make_candidate() {
+	local number=$1 marker=${2:-} extension_commit=${3:-89abcdef0123456789abcdef0123456789abcdef}
+	local tag version incoming root archive
+	version="1.0.${number}"
+	tag="v${version}"
+	incoming="${store}/.incoming/${number}"
+	root="${tmp}/package-${number}/hyperfilelens-${version}-ee"
+	archive="${incoming}/hyperfilelens-${version}-ee.tar.gz"
+	mkdir -p "${incoming}" "${root}"
+	printf '%s\n' "${version}" >"${root}/VERSION"
+	printf '#!/usr/bin/env bash\n' >"${root}/install.sh"
+	chmod +x "${root}/install.sh"
+	[[ -z "${marker}" ]] || printf '%s\n' "${marker}" >"${root}/BUILD-MARKER"
+	cat >"${root}/MANIFEST.json" <<JSON
+{"schema_version":2,"product":"hyperfilelens","edition":"enterprise","image_version":"${version}-ee","channel":"release","artifact_id":"${tag}","version":"${version}","git_commit":"0123456789abcdef0123456789abcdef01234567","extension_commit":"${extension_commit}"}
+JSON
+	cp "${root}/MANIFEST.json" "${incoming}/MANIFEST.json"
+	tar -C "$(dirname "${root}")" -czf "${archive}" "$(basename "${root}")"
+	(cd "${incoming}" && sha256sum "$(basename "${archive}")" MANIFEST.json >SHA256SUMS)
+	"${ROOT}/.github/scripts/store-enterprise-release.sh" \
+		"${tag}" "${incoming}" "${store}" 10 >/dev/null
+}
+
+for number in $(seq 0 10); do
+	make_candidate "${number}"
+done
+[[ "$(find "${store}" -mindepth 1 -maxdepth 1 -type d -name 'v*' | wc -l)" -eq 10 ]]
+[[ ! -e "${store}/v1.0.0" ]]
+[[ -s "${store}/v1.0.10/hyperfilelens-1.0.10-ee.tar.gz" ]]
+[[ "$(find "${store}/v1.0.10" -maxdepth 1 -type f | wc -l)" -eq 3 ]]
+(cd "${store}/v1.0.10" && sha256sum -c SHA256SUMS >/dev/null)
+
+# Revalidating an old version must not make it displace a newer SemVer.
+if make_candidate 0 2>"${tmp}/retention-error"; then
+	printf 'ERROR: an Enterprise version outside the retention window must not be deployable\n' >&2
+	exit 1
+fi
+grep -F 'is outside the retained SemVer window' "${tmp}/retention-error" >/dev/null
+[[ ! -e "${store}/v1.0.0" ]]
+[[ -e "${store}/v1.0.1" && -e "${store}/v1.0.10" ]]
+
+# The store accepts an exact retry without replacing the retained package.
+stored_digest="$(sha256sum "${store}/v1.0.10/hyperfilelens-1.0.10-ee.tar.gz" | awk '{print $1}')"
+exact_retry="${store}/.incoming/exact-retry"
+cp -a "${store}/v1.0.10" "${exact_retry}"
+"${ROOT}/.github/scripts/store-enterprise-release.sh" \
+	v1.0.10 "${exact_retry}" "${store}" 10 >/dev/null
+[[ "$(sha256sum "${store}/v1.0.10/hyperfilelens-1.0.10-ee.tar.gz" | awk '{print $1}')" \
+	== "${stored_digest}" ]]
+
+# Different output for the same source identity is not an immutable retry.
+if make_candidate 10 changed-output 2>"${tmp}/content-error"; then
+	printf 'ERROR: an immutable Enterprise version accepted different package bytes\n' >&2
+	exit 1
+fi
+grep -F 'immutable Enterprise package content differs' "${tmp}/content-error" >/dev/null
+
+# Moving either source tag must not make an immutable version appear to rebuild.
+if make_candidate 10 changed-source fedcba9876543210fedcba9876543210fedcba98 \
+	2>"${tmp}/identity-error"; then
+	printf 'ERROR: an immutable Enterprise version accepted different source identity\n' >&2
+	exit 1
+fi
+grep -F 'immutable Enterprise release identity differs' "${tmp}/identity-error" >/dev/null
+
+printf 'Enterprise release flow contracts passed.\n'

--- a/tools/quality/test-ga-runtime-config.sh
+++ b/tools/quality/test-ga-runtime-config.sh
@@ -36,7 +36,7 @@ grep -F 'alias /usr/share/nginx/runtime/admin-app-runtime-config.js;' \
 grep -F '<script src="/app-runtime-config.js"></script>' \
 	"${ROOT}/src/frontend/index.html" >/dev/null
 grep -F 'PROD_GA_MEASUREMENT_ID' \
-	"${ROOT}/.github/workflows/production_deploy.yml" >/dev/null
+	"${ROOT}/.github/workflows/enterprise_promotion.yml" >/dev/null
 grep -F 'ga4_measurement_id_pattern.fullmatch(candidate)' \
 	"${ROOT}/.github/workflows/deploy_target.yml" >/dev/null
 grep -F "event_callback: completeNavigation" \
@@ -87,7 +87,7 @@ invalid_value, invalid_output = render(
 )
 assert invalid_value == ""
 assert "::warning title=Google Analytics configuration::" in invalid_output
-assert render("preprod", "G-0RX9GZJCWF", "preprod.env") == ("", "")
+assert render("community", "G-0RX9GZJCWF", "community.env") == ("", "")
 PY
 
 if grep -R -E '(TEST|PREPROD)_GA_MEASUREMENT_ID' "${ROOT}/.github/workflows" >/dev/null; then

--- a/tools/quality/test-sentry-runtime-config.sh
+++ b/tools/quality/test-sentry-runtime-config.sh
@@ -14,12 +14,12 @@ HFL_WEBSITE_CONFIG_OUTPUT="${website}" \
 	HFL_ADMIN_CONFIG_OUTPUT="${admin}" \
 	HFL_SENTRY_ENABLED=true \
 	HFL_SENTRY_DSN=https://public@sentry.example.com/42 \
-	HFL_SENTRY_ENVIRONMENT=hfl-preprod \
+	HFL_SENTRY_ENVIRONMENT=hfl-community \
 	HFL_SENTRY_RELEASE=hyperfilelens-frontend@0.1.8 \
 	HFL_SENTRY_TRACES_SAMPLE_RATE=0.1 \
 	sh "${ROOT}/deploy/docker/frontend-runtime-config.sh"
 grep -F "sentryEnabled: true" "${tenant}" >/dev/null
-grep -F "sentryEnvironment: 'hfl-preprod'" "${tenant}" >/dev/null
+grep -F "sentryEnvironment: 'hfl-community'" "${tenant}" >/dev/null
 grep -F "sentrySurface: 'tenant'" "${tenant}" >/dev/null
 grep -F "sentrySurface: 'admin'" "${admin}" >/dev/null
 if grep -F 'sentryDsn' "${website}" >/dev/null; then
@@ -68,9 +68,9 @@ cat >"${runtime_file}" <<'EOF'
 SENTRY_ENABLED=true
 SENTRY_BACKEND_DSN=https://backend@sentry.example.com/41
 SENTRY_FRONTEND_DSN=https://frontend@sentry.example.com/42
-SENTRY_ENVIRONMENT=hfl-preprod
+SENTRY_ENVIRONMENT=hfl-community
 SENTRY_TRACES_SAMPLE_RATE=0.1
-HFL_DEPLOY_TARGET=preprod
+HFL_DEPLOY_TARGET=community
 HFL_INSECURE_TLS=1
 HFL_PLATFORM_GATEWAY_AUTO_DEPLOY=false
 HFL_EMAIL_SIGNUP_ENABLED=false
@@ -97,8 +97,8 @@ python3 "${ROOT}/deploy/installer/apply-runtime-config.py" \
 grep -Fx 'SENTRY_ENABLED=true' "${env_file}" >/dev/null
 grep -Fx 'SENTRY_BACKEND_DSN="https://backend@sentry.example.com/41"' "${env_file}" >/dev/null
 grep -Fx 'SENTRY_FRONTEND_DSN="https://frontend@sentry.example.com/42"' "${env_file}" >/dev/null
-grep -Fx 'SENTRY_ENVIRONMENT=hfl-preprod' "${env_file}" >/dev/null
-grep -Fx 'HFL_DEPLOY_TARGET=preprod' "${env_file}" >/dev/null
+grep -Fx 'SENTRY_ENVIRONMENT=hfl-community' "${env_file}" >/dev/null
+grep -Fx 'HFL_DEPLOY_TARGET=community' "${env_file}" >/dev/null
 grep -Fx 'HFL_DEPLOYMENT_MODE=managed' "${env_file}" >/dev/null
 
 sl_env="${tmp}/sl.env"
@@ -304,8 +304,8 @@ if grep -R -n -E 'ARG SENTRY_DSN|ENV SENTRY_DSN|import\.meta\.env\.SENTRY' \
 	exit 1
 fi
 grep -F 'TEST_SENTRY_ENABLED' "${ROOT}/.github/workflows/artifact_pipeline.yml" >/dev/null
-grep -F 'PREPROD_SENTRY_ENABLED' "${ROOT}/.github/workflows/artifact_pipeline.yml" >/dev/null
-grep -F 'PROD_SENTRY_ENABLED' "${ROOT}/.github/workflows/production_deploy.yml" >/dev/null
+grep -F 'COMMUNITY_SENTRY_ENABLED' "${ROOT}/.github/workflows/artifact_pipeline.yml" >/dev/null
+grep -F 'PROD_SENTRY_ENABLED' "${ROOT}/.github/workflows/enterprise_promotion.yml" >/dev/null
 grep -F 'SENTRY_AUTH_TOKEN' "${ROOT}/.github/workflows/artifact_pipeline.yml" >/dev/null
 grep -F "secrets.SENTRY_AUTH_TOKEN != ''" \
 	"${ROOT}/.github/workflows/artifact_pipeline.yml" >/dev/null


### PR DESCRIPTION
## Summary

- publish Community releases manually from existing OSS tags
- build Enterprise releases from matching OSS and private EE tags, retain them on TEST, and promote them to PROD
- enforce immutable edition identity, package retention, and deployment contracts

## Validation

- release contract checks
- Community and Enterprise synthetic offline package assembly
- installer image refresh and blue/green recovery checks
- managed image retention, GA/Sentry runtime, and Agent Gateway checks
- Agent observability tests, YAML syntax/unique-key checks, and git diff checks