### PR TITLE
fix(release): support legacy deployment secret names

### DIFF
--- a/.github/workflows/artifact_pipeline.yml
+++ b/.github/workflows/artifact_pipeline.yml
@@ -98,7 +98,7 @@ jobs:
         if: ${{ steps.version.outputs.edition == 'enterprise' }}
         env:
           ENTERPRISE_EXTENSION_REPOSITORY: ${{ vars.ENTERPRISE_EXTENSION_REPOSITORY }}
-          HFL_EXTENSION_GIT_TOKEN: ${{ secrets.ENTERPRISE_EXTENSION_GIT_TOKEN }}
+          HFL_EXTENSION_GIT_TOKEN: ${{ secrets.ENTERPRISE_EXTENSION_GIT_TOKEN || secrets.HFL_EXTENSION_GIT_TOKEN }}
           RELEASE_TAG: ${{ steps.version.outputs.release_tag }}
         shell: bash
         run: |
@@ -356,7 +356,7 @@ jobs:
           RELEASE_TAG: ${{ needs.prepare.outputs.release_tag }}
           ENTERPRISE_COMMIT: ${{ needs.prepare.outputs.enterprise_commit }}
           ENTERPRISE_EXTENSION_REPOSITORY: ${{ vars.ENTERPRISE_EXTENSION_REPOSITORY }}
-          HFL_EXTENSION_GIT_TOKEN: ${{ secrets.ENTERPRISE_EXTENSION_GIT_TOKEN }}
+          HFL_EXTENSION_GIT_TOKEN: ${{ secrets.ENTERPRISE_EXTENSION_GIT_TOKEN || secrets.HFL_EXTENSION_GIT_TOKEN }}
         shell: bash
         run: |
           set -euo pipefail
@@ -549,7 +549,7 @@ jobs:
           RELEASE_TAG: ${{ needs.prepare.outputs.release_tag }}
           ENTERPRISE_COMMIT: ${{ needs.prepare.outputs.enterprise_commit }}
           ENTERPRISE_EXTENSION_REPOSITORY: ${{ vars.ENTERPRISE_EXTENSION_REPOSITORY }}
-          HFL_EXTENSION_GIT_TOKEN: ${{ secrets.ENTERPRISE_EXTENSION_GIT_TOKEN }}
+          HFL_EXTENSION_GIT_TOKEN: ${{ secrets.ENTERPRISE_EXTENSION_GIT_TOKEN || secrets.HFL_EXTENSION_GIT_TOKEN }}
         shell: bash
         run: |
           set -euo pipefail
@@ -1026,7 +1026,7 @@ jobs:
           RELEASE_TAG: ${{ needs.prepare.outputs.release_tag }}
           HFL_EXTENSION_EXPECTED_COMMIT: ${{ needs.prepare.outputs.enterprise_commit }}
           ENTERPRISE_EXTENSION_REPOSITORY: ${{ vars.ENTERPRISE_EXTENSION_REPOSITORY }}
-          HFL_EXTENSION_GIT_TOKEN: ${{ secrets.ENTERPRISE_EXTENSION_GIT_TOKEN }}
+          HFL_EXTENSION_GIT_TOKEN: ${{ secrets.ENTERPRISE_EXTENSION_GIT_TOKEN || secrets.HFL_EXTENSION_GIT_TOKEN }}
         run: |
           if [[ "$RELEASE_EDITION" == "enterprise" ]]; then
             export HFL_EXTENSION_SOURCES="${ENTERPRISE_EXTENSION_REPOSITORY}@${RELEASE_TAG}"
@@ -1385,12 +1385,12 @@ jobs:
       ai_multimodal_model_id: ${{ vars.COMMUNITY_AI_MULTIMODAL_MODEL_ID }}
       ai_multimodal_model_display_name: ${{ vars.COMMUNITY_AI_MULTIMODAL_MODEL_DISPLAY_NAME }}
     secrets:
-      ssh_private_key: ${{ secrets.COMMUNITY_SSH_PRIVATE_KEY }}
-      turnstile_secret_key: ${{ secrets.COMMUNITY_TURNSTILE_SECRET_KEY }}
-      smtp_password: ${{ secrets.COMMUNITY_SMTP_PASSWORD }}
-      google_client_secret: ${{ secrets.COMMUNITY_GOOGLE_CLIENT_SECRET }}
-      ai_model_api_base: ${{ secrets.COMMUNITY_AI_MODEL_API_BASE }}
-      ai_model_api_key: ${{ secrets.COMMUNITY_AI_MODEL_API_KEY }}
+      ssh_private_key: ${{ secrets.COMMUNITY_SSH_PRIVATE_KEY || secrets.PREPROD_SSH_PRIVATE_KEY }}
+      turnstile_secret_key: ${{ secrets.COMMUNITY_TURNSTILE_SECRET_KEY || secrets.PREPROD_TURNSTILE_SECRET_KEY }}
+      smtp_password: ${{ secrets.COMMUNITY_SMTP_PASSWORD || secrets.PREPROD_SMTP_PASSWORD }}
+      google_client_secret: ${{ secrets.COMMUNITY_GOOGLE_CLIENT_SECRET || secrets.PREPROD_GOOGLE_CLIENT_SECRET }}
+      ai_model_api_base: ${{ secrets.COMMUNITY_AI_MODEL_API_BASE || secrets.PREPROD_AI_MODEL_API_BASE }}
+      ai_model_api_key: ${{ secrets.COMMUNITY_AI_MODEL_API_KEY || secrets.PREPROD_AI_MODEL_API_KEY }}
       sentry_backend_dsn: ${{ secrets.SENTRY_BACKEND_DSN }}
       sentry_frontend_dsn: ${{ secrets.SENTRY_FRONTEND_DSN }}
       sentry_auth_token: ${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/docs/release-workflows.md
+++ b/docs/release-workflows.md
@@ -82,6 +82,11 @@ use. Rename old settings as follows:
 | `PROD_DEPLOY_ENABLED` | `PROD_AUTO_DEPLOY` |
 | `PREPROD_*` | `COMMUNITY_*` |
 
+During migration, the workflows prefer the new Enterprise and Community
+secret names and fall back to the existing `HFL_EXTENSION_GIT_TOKEN` and
+`PREPROD_*` secrets. Variables use only the new names. This allows credentials
+to be rotated into the new names without exposing or copying existing values.
+
 The three automatic-deploy variables deliberately use opt-out semantics:
 missing or empty means enabled, and only the exact value `false` disables the
 corresponding deployment.

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -499,7 +499,7 @@ for variable in \
 	grep -F "PROD_${variable}" "${ROOT}/.github/workflows/enterprise_promotion.yml" >/dev/null
 done
 grep -F 'smtp_password: ${{ secrets.TEST_SMTP_PASSWORD }}' "${workflow}" >/dev/null
-grep -F 'smtp_password: ${{ secrets.COMMUNITY_SMTP_PASSWORD }}' "${workflow}" >/dev/null
+grep -F 'smtp_password: ${{ secrets.COMMUNITY_SMTP_PASSWORD || secrets.PREPROD_SMTP_PASSWORD }}' "${workflow}" >/dev/null
 grep -F 'smtp_password: ${{ secrets.PROD_SMTP_PASSWORD }}' "${ROOT}/.github/workflows/enterprise_promotion.yml" >/dev/null
 for variable in AI_MODEL_PROVIDER AI_MODEL_ID AI_MODEL_DISPLAY_NAME; do
 	grep -F "TEST_${variable}" "${workflow}" >/dev/null
@@ -516,7 +516,7 @@ for variable in \
 done
 for secret in AI_MODEL_API_BASE AI_MODEL_API_KEY; do
 	grep -F "secrets.TEST_${secret}" "${workflow}" >/dev/null
-	grep -F "secrets.COMMUNITY_${secret}" "${workflow}" >/dev/null
+	grep -F "secrets.COMMUNITY_${secret} || secrets.PREPROD_${secret}" "${workflow}" >/dev/null
 	grep -F "secrets.PROD_${secret}" "${ROOT}/.github/workflows/enterprise_promotion.yml" >/dev/null
 done
 grep -F '/opt/hyperfilelens/install.sh manage ensure_platform_ai_model' \
@@ -538,7 +538,7 @@ for variable in EMAIL_SIGNUP_ENABLED EMAIL_CODE_LOGIN_ENABLED GOOGLE_OAUTH_ENABL
 	grep -F "vars.PROD_${variable}" "${ROOT}/.github/workflows/enterprise_promotion.yml" >/dev/null
 done
 grep -F 'secrets.TEST_GOOGLE_CLIENT_SECRET' "${workflow}" >/dev/null
-grep -F 'secrets.COMMUNITY_GOOGLE_CLIENT_SECRET' "${workflow}" >/dev/null
+grep -F 'secrets.COMMUNITY_GOOGLE_CLIENT_SECRET || secrets.PREPROD_GOOGLE_CLIENT_SECRET' "${workflow}" >/dev/null
 grep -F 'secrets.PROD_GOOGLE_CLIENT_SECRET' "${ROOT}/.github/workflows/enterprise_promotion.yml" >/dev/null
 for runtime_key in \
 	HFL_EMAIL_SIGNUP_ENABLED HFL_EMAIL_CODE_LOGIN_ENABLED HFL_GOOGLE_OAUTH_ENABLED \

--- a/tools/quality/test-enterprise-release-flow.sh
+++ b/tools/quality/test-enterprise-release-flow.sh
@@ -68,7 +68,10 @@ grep -F "vars.TEST_AUTO_DEPLOY != 'false'" "${workflow}" >/dev/null
 grep -F "vars.PROD_AUTO_DEPLOY != 'false'" "${workflow}" >/dev/null
 grep -F "vars.COMMUNITY_AUTO_DEPLOY != 'false'" "${workflow}" >/dev/null
 grep -F 'ENTERPRISE_EXTENSION_REPOSITORY' "${workflow}" >/dev/null
-grep -F 'secrets.ENTERPRISE_EXTENSION_GIT_TOKEN' "${workflow}" >/dev/null
+grep -F 'secrets.ENTERPRISE_EXTENSION_GIT_TOKEN || secrets.HFL_EXTENSION_GIT_TOKEN' \
+	"${workflow}" >/dev/null
+grep -F 'secrets.COMMUNITY_SSH_PRIVATE_KEY || secrets.PREPROD_SSH_PRIVATE_KEY' \
+	"${workflow}" >/dev/null
 grep -F 'Materialize Enterprise extension for quality gates' "${workflow}" >/dev/null
 grep -F 'HFL_EXTENSIONS=$extensions' "${workflow}" >/dev/null
 grep -F 'Enterprise extension contains no discoverable backend tests' "${workflow}" >/dev/null


### PR DESCRIPTION
## Summary

- prefer the new Enterprise and Community secret names
- safely fall back to existing HFL_EXTENSION_GIT_TOKEN and PREPROD secrets during migration
- document credential rotation without reading or copying existing secret values

## Validation

- release contract checks
- Enterprise release flow contracts
- actionlint (only the existing custom macos-15-intel runner-label warning)