### PR TITLE
fix(release): avoid duplicate extension auth headers

### DIFF
--- a/tools/extensions/materialize_extensions.py
+++ b/tools/extensions/materialize_extensions.py
@@ -81,8 +81,8 @@ def _git_env(url: str, *, require_https_auth: bool = False) -> dict[str, str]:
     """Env for git subprocesses: HTTPS auth via GIT_CONFIG_* (not argv / .git/config)."""
     env = os.environ.copy()
     env.setdefault("GIT_TERMINAL_PROMPT", "0")
-    # Drop inherited Actions checkout auth slots so a packaging token is the only
-    # http.*.extraheader applied (GITHUB_TOKEN cannot read private sibling repos).
+    # Drop inherited process-level config slots before constructing an isolated
+    # auth configuration for the extension request.
     for key in list(env):
         if key == "GIT_CONFIG_COUNT" or key.startswith("GIT_CONFIG_KEY_") or key.startswith(
             "GIT_CONFIG_VALUE_"
@@ -103,11 +103,16 @@ def _git_env(url: str, *, require_https_auth: bool = False) -> dict[str, str]:
             )
         return env
     basic = base64.b64encode(f"x-access-token:{token}".encode("utf-8")).decode("ascii")
-    # Ephemeral config through the environment — avoids token-in-URL remotes and
-    # keeps the secret out of `ps` argv (unlike `git -c ...extraheader=...`).
-    env["GIT_CONFIG_COUNT"] = "1"
-    env["GIT_CONFIG_KEY_0"] = f"http.https://{parts.hostname}/.extraheader"
-    env["GIT_CONFIG_VALUE_0"] = f"AUTHORIZATION: basic {basic}"
+    # actions/checkout persists its GITHUB_TOKEN extraheader in the repository's
+    # local config by default. An empty value resets lower-priority extraheaders;
+    # the following value then supplies the private-repository credential exactly
+    # once. Keep both entries ephemeral so credentials never enter argv or .git.
+    extraheader_key = f"http.https://{parts.hostname}/.extraheader"
+    env["GIT_CONFIG_COUNT"] = "2"
+    env["GIT_CONFIG_KEY_0"] = extraheader_key
+    env["GIT_CONFIG_VALUE_0"] = ""
+    env["GIT_CONFIG_KEY_1"] = extraheader_key
+    env["GIT_CONFIG_VALUE_1"] = f"AUTHORIZATION: basic {basic}"
     return env
 
 

--- a/tools/quality/test-enterprise-release-flow.sh
+++ b/tools/quality/test-enterprise-release-flow.sh
@@ -98,6 +98,27 @@ grep -F 'Enterprise release package has an invalid extension_commit' \
 grep -F '"ls-remote"' "${workflow}" >/dev/null
 grep -F 'f"refs/tags/{tag}"' "${workflow}" >/dev/null
 grep -F 'gh release delete "$ARTIFACT_ID"' "${workflow}" >/dev/null
+
+# actions/checkout leaves an Authorization extraheader in local Git config. The
+# extension auth environment must reset it before adding the private-repo token,
+# otherwise GitHub rejects the duplicate Authorization headers with HTTP 400.
+HFL_EXTENSION_GIT_TOKEN=01234567890123456789 python3 - "${ROOT}" <<'PY'
+import sys
+
+sys.path.insert(0, sys.argv[1])
+from tools.extensions.materialize_extensions import _git_env
+
+env = _git_env(
+    "https://github.com/oneprolabs/hyperfilelens-ee.git",
+    require_https_auth=True,
+)
+assert env["GIT_CONFIG_COUNT"] == "2"
+assert env["GIT_CONFIG_KEY_0"] == "http.https://github.com/.extraheader"
+assert env["GIT_CONFIG_VALUE_0"] == ""
+assert env["GIT_CONFIG_KEY_1"] == env["GIT_CONFIG_KEY_0"]
+assert env["GIT_CONFIG_VALUE_1"].startswith("AUTHORIZATION: basic ")
+PY
+
 grep -F 'uses: ./.github/workflows/enterprise_promotion.yml' "${promotion}" >/dev/null
 grep -F 'needs: validate-production-promotion' "${promotion}" >/dev/null
 grep -F '[[ "$GITHUB_REF" == "refs/heads/main" ]]' "${promotion}" >/dev/null


### PR DESCRIPTION
## Summary

- reset the Actions checkout authentication header before adding the private Enterprise repository credential
- add a regression contract for the isolated Git authentication environment

## Root cause

The new Enterprise tag validation added its PAT header while `actions/checkout` still had its `GITHUB_TOKEN` header in local Git config. GitHub rejected the duplicate `Authorization` headers with HTTP 400.

## Validation

- `tools/quality/test-enterprise-release-flow.sh`
- simulated a checkout-persisted header and successfully resolved the private EE `v0.1.25` tag