### PR TITLE
fix(release): isolate private extension authentication

### DIFF
--- a/.github/workflows/artifact_pipeline.yml
+++ b/.github/workflows/artifact_pipeline.yml
@@ -50,6 +50,7 @@ jobs:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           fetch-depth: 0
+          persist-credentials: false
           ref: ${{ inputs.release_tag }}
 
       - name: Validate release tag and commit
@@ -332,6 +333,7 @@ jobs:
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
+          persist-credentials: false
           ref: ${{ needs.prepare.outputs.commit }}
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
@@ -518,6 +520,7 @@ jobs:
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
+          persist-credentials: false
           ref: ${{ needs.prepare.outputs.commit }}
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         if: matrix.needs_kopia
@@ -642,6 +645,7 @@ jobs:
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
+          persist-credentials: false
           ref: ${{ needs.prepare.outputs.commit }}
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
       - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
@@ -703,6 +707,7 @@ jobs:
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
+          persist-credentials: false
           ref: ${{ needs.prepare.outputs.commit }}
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
@@ -765,6 +770,7 @@ jobs:
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
+          persist-credentials: false
           ref: ${{ needs.prepare.outputs.commit }}
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
@@ -820,6 +826,7 @@ jobs:
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
+          persist-credentials: false
           ref: ${{ needs.prepare.outputs.commit }}
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
@@ -877,6 +884,7 @@ jobs:
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
+          persist-credentials: false
           ref: ${{ needs.prepare.outputs.commit }}
       - name: Build host dependency asset
         env:
@@ -908,6 +916,7 @@ jobs:
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
+          persist-credentials: false
           ref: ${{ needs.prepare.outputs.commit }}
       - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
@@ -943,6 +952,7 @@ jobs:
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
+          persist-credentials: false
           ref: ${{ needs.prepare.outputs.commit }}
       - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
@@ -980,6 +990,7 @@ jobs:
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
+          persist-credentials: false
           ref: ${{ needs.prepare.outputs.commit }}
       - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
@@ -1012,6 +1023,7 @@ jobs:
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
+          persist-credentials: false
           ref: ${{ needs.prepare.outputs.commit }}
       - name: Download matrix bundles
         env:
@@ -1097,6 +1109,7 @@ jobs:
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
+          persist-credentials: false
           ref: ${{ needs.prepare.outputs.commit }}
       - name: Reclaim unused runner toolchains
         run: |
@@ -1193,6 +1206,7 @@ jobs:
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
+          persist-credentials: false
           ref: ${{ needs.prepare.outputs.commit }}
       - name: Remove internal assets and publish release
         id: publish
@@ -1412,6 +1426,8 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          persist-credentials: false
       - name: Delete temporary Enterprise candidate
         env:
           GH_TOKEN: ${{ github.token }}

--- a/tools/quality/test-enterprise-release-flow.sh
+++ b/tools/quality/test-enterprise-release-flow.sh
@@ -99,6 +99,14 @@ grep -F '"ls-remote"' "${workflow}" >/dev/null
 grep -F 'f"refs/tags/{tag}"' "${workflow}" >/dev/null
 grep -F 'gh release delete "$ARTIFACT_ID"' "${workflow}" >/dev/null
 
+checkout_count="$(grep -c 'uses: actions/checkout@' "${workflow}")"
+credentialless_checkout_count="$(grep -c 'persist-credentials: false' "${workflow}")"
+if [[ "${credentialless_checkout_count}" -ne "${checkout_count}" ]]; then
+	printf 'ERROR: every release checkout must disable persisted credentials (%s/%s)\n' \
+		"${credentialless_checkout_count}" "${checkout_count}" >&2
+	exit 1
+fi
+
 # actions/checkout leaves an Authorization extraheader in local Git config. The
 # extension auth environment must reset it before adding the private-repo token,
 # otherwise GitHub rejects the duplicate Authorization headers with HTTP 400.


### PR DESCRIPTION
## Summary

- disable persisted checkout credentials in every reusable release job
- keep private Enterprise repository authentication isolated to the extension PAT
- enforce this invariant in the Enterprise release-flow contract test

## Root cause

Manual builds load the workflow from `main` but check out the immutable release tag. The release-tag source may still contain the older extension helper, so the workflow must prevent `actions/checkout` from persisting a competing `Authorization` header before any tag source code runs.

## Validation

- `tools/quality/test-enterprise-release-flow.sh`
- all 15 release checkouts set `persist-credentials: false`
