### PR TITLE
fix(ci): isolate host and enterprise test contexts

### DIFF
--- a/.github/workflows/artifact_pipeline.yml
+++ b/.github/workflows/artifact_pipeline.yml
@@ -449,8 +449,10 @@ jobs:
           set -euo pipefail
           uv sync --locked --group dev
           uv run ruff check src/backend
-          uv run python src/backend/manage.py makemigrations --check --dry-run
-          uv run python src/backend/manage.py test
+          # Host tests define the Community contract and must run with the
+          # extension socket empty, even while producing an Enterprise release.
+          HFL_EXTENSIONS= uv run python src/backend/manage.py makemigrations --check --dry-run
+          HFL_EXTENSIONS= uv run python src/backend/manage.py test
           if [[ -n "${HFL_EXTENSIONS:-}" ]]; then
             extension_test_labels=()
             IFS=',' read -r -a extension_roots <<<"$HFL_EXTENSIONS"
@@ -468,6 +470,7 @@ jobs:
               echo "::error::Enterprise extension contains no discoverable backend tests"
               exit 1
             }
+            uv run python src/backend/manage.py makemigrations --check --dry-run
             uv run python src/backend/manage.py test "${extension_test_labels[@]}"
           fi
 

--- a/tools/quality/test-enterprise-release-flow.sh
+++ b/tools/quality/test-enterprise-release-flow.sh
@@ -76,6 +76,11 @@ grep -F 'Materialize Enterprise extension for quality gates' "${workflow}" >/dev
 grep -F 'HFL_EXTENSIONS=$extensions' "${workflow}" >/dev/null
 grep -F 'Enterprise extension contains no discoverable backend tests' "${workflow}" >/dev/null
 grep -F 'manage.py test "${extension_test_labels[@]}"' "${workflow}" >/dev/null
+grep -F 'HFL_EXTENSIONS= uv run python src/backend/manage.py test' "${workflow}" >/dev/null
+if grep -Fx '          uv run python src/backend/manage.py test' "${workflow}" >/dev/null; then
+	printf 'ERROR: the full Host backend suite must run with the extension socket empty\n' >&2
+	exit 1
+fi
 grep -F 'enterprise_commit: ${{ steps.enterprise-ref.outputs.commit }}' "${workflow}" >/dev/null
 grep -F 'Check immutable Enterprise store' "${workflow}" >/dev/null
 grep -F 'ENTERPRISE_STORED: ${{ steps.enterprise-store.outputs.stored }}' "${workflow}" >/dev/null


### PR DESCRIPTION
## Summary

- run the full Host backend suite with an empty extension socket
- validate combined Host/EE migrations after loading the Enterprise extension
- run only Enterprise-owned test labels in the Enterprise context
- add a release-flow contract that prevents the Host suite from inheriting extensions

## Root cause

The Enterprise Quality job loaded EE globally before running the full Host suite. Community empty-socket tests and Host gateway fixtures therefore observed Enterprise providers and failed even though each product contract was valid in its own runtime shape.

## Validation

- `tools/quality/test-enterprise-release-flow.sh`
- Workflow YAML parse
- `bash -n tools/quality/test-enterprise-release-flow.sh`
- `git diff --check`
