### PR TITLE
test(insight): make chat recovery gateway readiness explicit

### DIFF
--- a/src/backend/apps/lens_bridge/tests/test_chat_teardown.py
+++ b/src/backend/apps/lens_bridge/tests/test_chat_teardown.py
@@ -694,6 +694,10 @@ class CopilotChatTeardownTests(TestCase):
 
     @mock.patch("apps.lens_bridge.services.chat_lifecycle._grant_assistant_to_chat_user")
     @mock.patch("apps.lens_bridge.services.chat_lifecycle.assistant_access.ensure_assistant_link")
+    @mock.patch(
+        "apps.lens_bridge.services.gateway_readiness.agent_ws_routable",
+        return_value=True,
+    )
     @mock.patch("apps.lens_bridge.services.chat_lifecycle.sl_client.request_json")
     @mock.patch("apps.lens_bridge.services.chat_lifecycle._find_remote_uuid")
     @mock.patch("apps.lens_bridge.services.chat_lifecycle.chat_user_provisioning.ensure_sl_chat_user")
@@ -706,6 +710,7 @@ class CopilotChatTeardownTests(TestCase):
         ensure_sl_user,
         find_remote_uuid,
         request_json,
+        _agent_ws_routable,
         _ensure_assistant_link,
         _grant_assistant,
     ):
@@ -721,6 +726,11 @@ class CopilotChatTeardownTests(TestCase):
         self.knowledge_source.sl_assistant_uuid = None
         self.knowledge_source.save(
             update_fields=["sl_assistant_uuid", "updated_at"]
+        )
+        self.gateway_link.sl_lensnode_uuid = uuid.uuid4()
+        self.gateway_link.sidecar_status = LensGatewayLink.SidecarStatus.ONLINE
+        self.gateway_link.save(
+            update_fields=["sl_lensnode_uuid", "sidecar_status", "updated_at"]
         )
         self.session.lifecycle_status = LensSessionLink.LifecycleStatus.PROVISIONING
         self.session.provision_claim_token = claim_token


### PR DESCRIPTION
## Summary

- make the chat journal recovery test explicitly provide a routable Gateway Agent
- mark the SourceLens sidecar online with a bound LensNode identity
- remove hidden dependence on Redis test ordering and residual routing state

## Root cause

The recovery path correctly enforces the current Data Gateway readiness contract, but this test still constructed the older partial gateway fixture. It therefore passed or failed depending on ambient routing state.

## Validation

- targeted Django test passed against a temporary PostgreSQL 17 instance
- `python3 -m py_compile src/backend/apps/lens_bridge/tests/test_chat_teardown.py`
- `git diff --check`
