### PR TITLE
fix(ci): discover tests from extension roots

### DIFF
--- a/.github/workflows/artifact_pipeline.yml
+++ b/.github/workflows/artifact_pipeline.yml
@@ -454,24 +454,28 @@ jobs:
           HFL_EXTENSIONS= uv run python src/backend/manage.py makemigrations --check --dry-run
           HFL_EXTENSIONS= uv run python src/backend/manage.py test
           if [[ -n "${HFL_EXTENSIONS:-}" ]]; then
-            extension_test_labels=()
+            uv run python src/backend/manage.py makemigrations --check --dry-run
+            extension_test_count=0
             IFS=',' read -r -a extension_roots <<<"$HFL_EXTENSIONS"
             for root in "${extension_roots[@]}"; do
               backend="$root/src/backend"
+              extension_test_dirs=()
               while IFS= read -r test_dir; do
-                label="${test_dir#"$backend/"}"
-                extension_test_labels+=("${label//\//.}")
+                extension_test_dirs+=("$test_dir")
               done < <(
                 find "$backend" -type d -name tests -exec test -f '{}/__init__.py' \; -print \
                   | sort
               )
+              ((${#extension_test_dirs[@]} > 0)) || continue
+              extension_test_count=$((extension_test_count + ${#extension_test_dirs[@]}))
+              uv run python src/backend/manage.py test \
+                "${extension_test_dirs[@]}" \
+                --top-level-directory "$backend"
             done
-            ((${#extension_test_labels[@]} > 0)) || {
+            ((extension_test_count > 0)) || {
               echo "::error::Enterprise extension contains no discoverable backend tests"
               exit 1
             }
-            uv run python src/backend/manage.py makemigrations --check --dry-run
-            uv run python src/backend/manage.py test "${extension_test_labels[@]}"
           fi
 
       - name: Frontend checks

--- a/tools/quality/test-enterprise-release-flow.sh
+++ b/tools/quality/test-enterprise-release-flow.sh
@@ -75,7 +75,8 @@ grep -F 'secrets.COMMUNITY_SSH_PRIVATE_KEY || secrets.PREPROD_SSH_PRIVATE_KEY' \
 grep -F 'Materialize Enterprise extension for quality gates' "${workflow}" >/dev/null
 grep -F 'HFL_EXTENSIONS=$extensions' "${workflow}" >/dev/null
 grep -F 'Enterprise extension contains no discoverable backend tests' "${workflow}" >/dev/null
-grep -F 'manage.py test "${extension_test_labels[@]}"' "${workflow}" >/dev/null
+grep -F '"${extension_test_dirs[@]}"' "${workflow}" >/dev/null
+grep -F -- '--top-level-directory "$backend"' "${workflow}" >/dev/null
 grep -F 'HFL_EXTENSIONS= uv run python src/backend/manage.py test' "${workflow}" >/dev/null
 if grep -Fx '          uv run python src/backend/manage.py test' "${workflow}" >/dev/null; then
 	printf 'ERROR: the full Host backend suite must run with the extension socket empty\n' >&2


### PR DESCRIPTION
## Summary

- discover Enterprise tests from absolute Extension test directories
- set each Extension backend as the unittest top-level directory
- keep Host `manage.py` as the combined runtime bootstrap
- enforce the external test-root contract in release-flow checks

## Root cause

Django resolved Extension module labels to directories outside the Host project root. Python unittest discovery then rejected them with `AssertionError: Path must be within the project`.

## Validation

- Host release-flow contract passed
- Workflow YAML parse passed
- discovered and ran all 133 EE tests against temporary PostgreSQL 17 and Redis services
- `git diff --check`
