### PR TITLE
Restore frontend release quality gates

### DIFF
--- a/src/frontend/src/lib/lensApi.ts
+++ b/src/frontend/src/lib/lensApi.ts
@@ -945,12 +945,11 @@ export async function browseCopilotSnapshotDirectory(
         reject(new DOMException('Aborted', 'AbortError'))
         return
       }
-      let timer: number
       const onAbort = () => {
         window.clearTimeout(timer)
         reject(new DOMException('Aborted', 'AbortError'))
       }
-      timer = window.setTimeout(() => {
+      const timer = window.setTimeout(() => {
         signal?.removeEventListener('abort', onAbort)
         resolve()
       }, COPILOT_SNAPSHOT_BROWSE_POLL_MS)

--- a/src/frontend/src/pages/node/AddProxyFsRepository.vue
+++ b/src/frontend/src/pages/node/AddProxyFsRepository.vue
@@ -33,7 +33,6 @@ const emit = defineEmits<{
 const busy = ref(false)
 const proxyNodeId = ref<number | undefined>(undefined)
 const proxyNodeDir = ref('')
-const repositoryServerHost = ref('')
 const repoName = ref('')
 const quota = ref(0)
 const enableQuotaAlert = ref(false)
@@ -474,7 +473,6 @@ function buildCreatePayload() {
     bind_node_id: proxyNodeId.value,
     config: {
       proxy_node_base_dir: proxyNodeDir.value.trim(),
-      proxy_repository_server_host: repositoryServerHost.value.trim() || undefined,
       quota_gb: quota.value || 0,
       quota_alert_enabled: enableQuotaAlert.value,
       quota_alert_threshold: enableQuotaAlert.value ? Number(quotaAlertThreshold.value || 0) : 0,
@@ -666,16 +664,6 @@ watch(enableQuotaAlert, (enabled) => {
                     >
                       <RefreshCw :size="16" :class="{ 'is-spinning': proxyNodesRefreshing }" />
                     </ElButton>
-                  </div>
-                </ElFormItem>
-
-                <ElFormItem :label="t('repositoriesPage.fieldRepositoryServerHost')" class="fullscreen-form-item--in-card">
-                  <ElInput
-                    v-model="repositoryServerHost"
-                    :placeholder="t('repositoriesPage.phRepositoryServerHost')"
-                  />
-                  <div class="mt-1 text-xs text-[var(--color-text-tertiary)]">
-                    {{ t('repositoriesPage.hintRepositoryServerHost') }}
                   </div>
                 </ElFormItem>
 
@@ -945,12 +933,6 @@ watch(enableQuotaAlert, (enabled) => {
 
               <div class="add-form-preview-section">
                 <h5 class="add-form-preview-section__title">{{ t('addS3Repo.previewConnection') }}</h5>
-                <div class="add-form-preview-row">
-                  <span class="add-form-preview-row__label">{{ t('repositoriesPage.fieldRepositoryServerHost') }}</span>
-                  <span class="add-form-preview-row__value" :class="{ 'add-form-preview-row__value--empty': !repositoryServerHost }">
-                    {{ repositoryServerHost || t('repositoriesPage.repositoryServerHostNotConfigured') }}
-                  </span>
-                </div>
                 <div class="add-form-preview-row">
                   <span class="add-form-preview-row__label">{{ t('repositoriesPage.fieldProxyNodeBaseDir') }}</span>
                   <span class="add-form-preview-row__value" :class="{ 'add-form-preview-row__value--empty': !proxyNodeDir }">

--- a/src/frontend/src/pages/node/AddProxyFsRepositoryAvailability.test.ts
+++ b/src/frontend/src/pages/node/AddProxyFsRepositoryAvailability.test.ts
@@ -14,14 +14,6 @@ describe('Add Local Disk Repository proxy availability', () => {
     expect(page).toContain("node.role === 'proxy' && node.availability === 'online'")
   })
 
-  it('includes the optional repository server address in the confirmation summary', () => {
-    expect(page).toContain("const repositoryServerHost = ref('')")
-    expect(page).toContain('v-model="repositoryServerHost"')
-    expect(page).toContain('proxy_repository_server_host: repositoryServerHost.value.trim() || undefined')
-    expect(page).toContain("t('repositoriesPage.fieldRepositoryServerHost')")
-    expect(page).toContain("repositoryServerHost || t('repositoriesPage.repositoryServerHostNotConfigured')")
-  })
-
   it('submits a base directory and previews the managed child path', () => {
     expect(page).toContain('proxy_node_base_dir: proxyNodeDir.value.trim()')
     expect(page).toContain('hfl-repo-<repository-id>')


### PR DESCRIPTION
## Summary
- satisfy the snapshot browse timer lint contract
- keep Proxy repository server addressing at the Proxy node level
- remove the obsolete repository-level address from Local Disk Repository creation

## Validation
- frontend lint: 0 errors
- frontend tests: 177 files, 890 tests passed
- frontend production build: passed
- website production build: passed
- agent Go tests: passed