### PR TITLE
fix(ci): isolate frontend quality contexts

### DIFF
--- a/.github/workflows/artifact_pipeline.yml
+++ b/.github/workflows/artifact_pipeline.yml
@@ -485,7 +485,12 @@ jobs:
           set -euo pipefail
           npm ci
           npm run lint
-          npm run test:ci
+          # Community tests define the Host contract and always run with an
+          # empty Extension socket, including for Enterprise releases.
+          HFL_EXTENSIONS= HFL_FRONTEND_TEST_SCOPE=host npm run test:ci
+          if [[ -n "${HFL_EXTENSIONS:-}" ]]; then
+            HFL_FRONTEND_TEST_SCOPE=extension npm run test:ci
+          fi
           npm run build
 
       - name: Website checks

--- a/src/frontend/vite.config.ts
+++ b/src/frontend/vite.config.ts
@@ -47,6 +47,10 @@ function discoverExtensionRoots(): string[] {
 }
 
 const extensionRoots = discoverExtensionRoots()
+const frontendTestScope = (process.env.HFL_FRONTEND_TEST_SCOPE || 'host').trim()
+if (!['host', 'extension'].includes(frontendTestScope)) {
+  throw new Error(`Unsupported HFL_FRONTEND_TEST_SCOPE: ${frontendTestScope}`)
+}
 const extensionFrontendSrcs = extensionRoots.map((root) => ({
   id: readExtensionId(root),
   root,
@@ -106,6 +110,7 @@ const extensionDepAlias = extensionFrontendSrcs.length
   : []
 
 const extResolveAlias = [
+  { find: '@host', replacement: frontendSrc },
   ...(platformFrontendSrc
     ? [
         { find: '@ext/platform/platform-ops', replacement: resolve(platformFrontendSrc, 'platform-ops') },
@@ -136,15 +141,14 @@ export default defineConfig(() => ({
     alias: extResolveAlias,
   },
   test: {
-    // Host tests plus extension tests when HFL_EXTENSIONS is set (ops + platform-ops).
-    // Community CI has empty HFL_EXTENSIONS so only Host ``src/**`` runs.
-    include: [
-      'src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}',
-      ...extensionFrontendSrcs.flatMap((e) => [
-        `${e.src}/ops/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}`,
-        `${e.src}/platform-ops/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}`,
-      ]),
-    ],
+    // Host and Extension tests are separate contracts. Enterprise CI runs both
+    // scopes independently so Extension injection cannot change Community tests.
+    include: frontendTestScope === 'extension'
+      ? extensionFrontendSrcs.flatMap((e) => [
+          `${e.src}/ops/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}`,
+          `${e.src}/platform-ops/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}`,
+        ])
+      : ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
   },
   plugins: [
     ...(platformFrontendSrc ? [hflExtOssBridgePlugin()] : []),

--- a/tools/quality/test-enterprise-release-flow.sh
+++ b/tools/quality/test-enterprise-release-flow.sh
@@ -82,6 +82,13 @@ if grep -Fx '          uv run python src/backend/manage.py test' "${workflow}" >
 	printf 'ERROR: the full Host backend suite must run with the extension socket empty\n' >&2
 	exit 1
 fi
+grep -F 'HFL_EXTENSIONS= HFL_FRONTEND_TEST_SCOPE=host npm run test:ci' \
+	"${workflow}" >/dev/null
+grep -F 'HFL_FRONTEND_TEST_SCOPE=extension npm run test:ci' "${workflow}" >/dev/null
+if grep -Fx '          npm run test:ci' "${workflow}" >/dev/null; then
+	printf 'ERROR: Host and Extension frontend test contracts must run separately\n' >&2
+	exit 1
+fi
 grep -F 'enterprise_commit: ${{ steps.enterprise-ref.outputs.commit }}' "${workflow}" >/dev/null
 grep -F 'Check immutable Enterprise store' "${workflow}" >/dev/null
 grep -F 'ENTERPRISE_STORED: ${{ steps.enterprise-store.outputs.stored }}' "${workflow}" >/dev/null


### PR DESCRIPTION
## Summary
- run Host frontend tests with an empty Extension socket
- run Enterprise Extension tests as a separate test scope
- add an explicit Host source alias for Extension integration tests
- enforce the split in release-flow contract checks

## Validation
- Host frontend: 177 files, 890 tests passed
- Extension frontend: 21 files, 60 tests passed
- Enterprise frontend production build passed
- release-flow contracts passed
- lint completed without errors