### PR TITLE
fix(release): make enterprise staging resilient

### DIFF
--- a/.github/scripts/stage-enterprise-release.sh
+++ b/.github/scripts/stage-enterprise-release.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Upload an Enterprise release candidate to the TEST host with bounded,
+# retryable parallel transfers. The caller publishes the staged directory only
+# after the downstream release verification succeeds.
+set -euo pipefail
+
+source_dir=${1:-}
+incoming=${2:-}
+parallel=${HFL_ENTERPRISE_TRANSFER_PARALLEL:-6}
+attempts=${HFL_ENTERPRISE_TRANSFER_ATTEMPTS:-3}
+transfer_timeout=${HFL_ENTERPRISE_TRANSFER_TIMEOUT:-20m}
+
+[[ -d "${source_dir}" && ! -L "${source_dir}" ]] || {
+	printf 'ERROR: Enterprise release source directory is invalid\n' >&2
+	exit 2
+}
+[[ "${incoming}" =~ ^/root/hfl-release/\.incoming/[A-Za-z0-9][A-Za-z0-9._-]*$ ]] || {
+	printf 'ERROR: Enterprise incoming directory is invalid\n' >&2
+	exit 2
+}
+[[ "${parallel}" =~ ^[1-8]$ ]] || { printf 'ERROR: invalid transfer parallelism\n' >&2; exit 2; }
+[[ "${attempts}" =~ ^[1-5]$ ]] || { printf 'ERROR: invalid transfer attempts\n' >&2; exit 2; }
+[[ "${transfer_timeout}" =~ ^[1-9][0-9]*[smh]$ ]] || {
+	printf 'ERROR: invalid transfer timeout\n' >&2
+	exit 2
+}
+[[ "${TEST_SSH_HOST:-}" =~ ^[A-Za-z0-9][A-Za-z0-9.-]*$ \
+	&& "${TEST_SSH_PORT:-}" =~ ^[0-9]+$ ]] || {
+	printf 'ERROR: invalid TEST SSH endpoint\n' >&2
+	exit 2
+}
+[[ "${TEST_SSH_USER:-}" =~ ^[a-z_][a-z0-9_-]*$ ]] || {
+	printf 'ERROR: invalid TEST SSH user\n' >&2
+	exit 2
+}
+[[ -n "${TEST_SSH_KNOWN_HOSTS:-}" && -n "${TEST_SSH_PRIVATE_KEY:-}" ]] || {
+	printf 'ERROR: TEST SSH trust material is missing\n' >&2
+	exit 2
+}
+
+(
+	cd "${source_dir}"
+	[[ -s SHA256SUMS && -s MANIFEST.json ]] || {
+		printf 'ERROR: Enterprise release metadata is incomplete\n' >&2
+		exit 1
+	}
+	sha256sum -c SHA256SUMS
+	archive_count="$({
+		find . -mindepth 1 -maxdepth 1 -type f \
+			\( -name 'hyperfilelens-*-ee.tar.gz' \
+			-o -name 'hyperfilelens-*-ee.tar.gz.part-000' \) -print
+	} | wc -l)"
+	if [[ "${archive_count}" -ne 1 ]]; then
+		printf 'ERROR: Enterprise release archive is missing\n' >&2
+		exit 1
+	fi
+	while IFS= read -r -d '' asset; do
+		name=${asset#./}
+		[[ "${name}" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]] || {
+			printf 'ERROR: unsafe Enterprise release asset name: %s\n' "${name}" >&2
+			exit 1
+		}
+	done < <(find . -mindepth 1 -maxdepth 1 -type f -print0)
+)
+
+install -d -m 0700 ~/.ssh
+printf '%s\n' "${TEST_SSH_KNOWN_HOSTS}" >~/.ssh/known_hosts
+printf '%s\n' "${TEST_SSH_PRIVATE_KEY}" >~/.ssh/hyperfilelens_test
+chmod 0600 ~/.ssh/known_hosts ~/.ssh/hyperfilelens_test
+
+ssh_options=(
+	-i ~/.ssh/hyperfilelens_test
+	-o BatchMode=yes
+	-o StrictHostKeyChecking=yes
+	-o ConnectTimeout=30
+	-o ServerAliveInterval=30
+	-o ServerAliveCountMax=6
+)
+remote="${TEST_SSH_USER}@${TEST_SSH_HOST}"
+ssh "${ssh_options[@]}" -p "${TEST_SSH_PORT}" "${remote}" \
+	"install -d -m 0700 '${incoming}'"
+
+export TEST_SSH_HOST TEST_SSH_PORT TEST_SSH_USER
+export incoming attempts transfer_timeout
+export HFL_ENTERPRISE_SSH_KEY=~/.ssh/hyperfilelens_test
+upload_asset() {
+	local asset=$1 attempt
+	for ((attempt = 1; attempt <= attempts; attempt++)); do
+		if timeout "${transfer_timeout}" scp \
+			-i "${HFL_ENTERPRISE_SSH_KEY}" \
+			-o BatchMode=yes \
+			-o StrictHostKeyChecking=yes \
+			-o ConnectTimeout=30 \
+			-o ServerAliveInterval=30 \
+			-o ServerAliveCountMax=6 \
+			-o Compression=no \
+			-P "${TEST_SSH_PORT}" "${asset}" \
+			"${TEST_SSH_USER}@${TEST_SSH_HOST}:${incoming}/"; then
+			return 0
+		fi
+		printf 'WARN: transfer attempt %d/%d failed for %s\n' \
+			"${attempt}" "${attempts}" "$(basename "${asset}")" >&2
+		((attempt == attempts)) || sleep $((attempt * 5))
+	done
+	return 1
+}
+export -f upload_asset
+
+find "${source_dir}" -mindepth 1 -maxdepth 1 -type f -print0 \
+	| xargs -0 -r -n 1 -P "${parallel}" bash -c 'upload_asset "$1"' _
+
+# The remote checksum closes the transfer gate before verification downloads
+# the staged candidate. Split parts are reconstructed only after verification.
+ssh "${ssh_options[@]}" -p "${TEST_SSH_PORT}" "${remote}" \
+	"cd '${incoming}' && sha256sum -c SHA256SUMS"

--- a/.github/workflows/artifact_pipeline.yml
+++ b/.github/workflows/artifact_pipeline.yml
@@ -1019,7 +1019,7 @@ jobs:
     name: Assemble · Release
     if: ${{ needs.prepare.outputs.build_required == 'true' }}
     runs-on: ubuntu-24.04
-    timeout-minutes: 90
+    timeout-minutes: 120
     needs:
       - prepare
       - build-agent
@@ -1051,6 +1051,10 @@ jobs:
           HFL_EXTENSION_EXPECTED_COMMIT: ${{ needs.prepare.outputs.enterprise_commit }}
           ENTERPRISE_EXTENSION_REPOSITORY: ${{ vars.ENTERPRISE_EXTENSION_REPOSITORY }}
           HFL_EXTENSION_GIT_TOKEN: ${{ secrets.ENTERPRISE_EXTENSION_GIT_TOKEN || secrets.HFL_EXTENSION_GIT_TOKEN }}
+          # Enterprise packages are staged outside GitHub. Fixed-size parts
+          # make the cross-region transfer parallel, retryable and bounded.
+          HFL_RELEASE_MAX_SINGLE_BYTES: ${{ needs.prepare.outputs.edition == 'enterprise' && '1' || '1900000000' }}
+          HFL_RELEASE_PART_BYTES: ${{ needs.prepare.outputs.edition == 'enterprise' && '100663296' || '1073741824' }}
         run: |
           if [[ "$RELEASE_EDITION" == "enterprise" ]]; then
             export HFL_EXTENSION_SOURCES="${ENTERPRISE_EXTENSION_REPOSITORY}@${RELEASE_TAG}"
@@ -1091,20 +1095,8 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          [[ "$TEST_SSH_HOST" =~ ^[A-Za-z0-9][A-Za-z0-9.-]*$ && "$TEST_SSH_PORT" =~ ^[0-9]+$ ]]
-          [[ "$TEST_SSH_USER" =~ ^[a-z_][a-z0-9_-]*$ ]]
-          [[ -n "$TEST_SSH_KNOWN_HOSTS" && -n "$TEST_SSH_PRIVATE_KEY" ]]
-          install -d -m 0700 ~/.ssh
-          printf '%s\n' "$TEST_SSH_KNOWN_HOSTS" > ~/.ssh/known_hosts
-          printf '%s\n' "$TEST_SSH_PRIVATE_KEY" > ~/.ssh/hyperfilelens_test
-          chmod 0600 ~/.ssh/known_hosts ~/.ssh/hyperfilelens_test
           incoming="/root/hfl-release/.incoming/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-          ssh -i ~/.ssh/hyperfilelens_test -o BatchMode=yes -o StrictHostKeyChecking=yes \
-            -p "$TEST_SSH_PORT" "$TEST_SSH_USER@$TEST_SSH_HOST" \
-            "install -d -m 0700 '$incoming'"
-          scp -i ~/.ssh/hyperfilelens_test -o BatchMode=yes -o StrictHostKeyChecking=yes \
-            -P "$TEST_SSH_PORT" build/release/dist/* \
-            "$TEST_SSH_USER@$TEST_SSH_HOST:$incoming/"
+          .github/scripts/stage-enterprise-release.sh build/release/dist "$incoming"
           echo 'stored=true' >> "$GITHUB_OUTPUT"
       - name: Disk report
         if: always()

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -456,8 +456,8 @@ for entrypoint in \
 		exit 1
 	}
 done
-[[ "$(awk '/^  assemble-release:/{job=1} job && /timeout-minutes:/{print $2; exit}' "${workflow}")" == "90" ]] || {
-	printf 'ERROR: release assembly timeout must cover large GitHub asset uploads\n' >&2
+[[ "$(awk '/^  assemble-release:/{job=1} job && /timeout-minutes:/{print $2; exit}' "${workflow}")" == "120" ]] || {
+	printf 'ERROR: release assembly timeout must cover package transfer and retries\n' >&2
 	exit 1
 }
 [[ "$(awk '/^  verify-release:/{job=1} job && /timeout-minutes:/{print $2; exit}' "${workflow}")" == "120" ]] || {

--- a/tools/quality/test-enterprise-release-flow.sh
+++ b/tools/quality/test-enterprise-release-flow.sh
@@ -89,6 +89,30 @@ if grep -Fx '          npm run test:ci' "${workflow}" >/dev/null; then
 	printf 'ERROR: Host and Extension frontend test contracts must run separately\n' >&2
 	exit 1
 fi
+grep -F "HFL_RELEASE_MAX_SINGLE_BYTES: \${{ needs.prepare.outputs.edition == 'enterprise' && '1' || '1900000000' }}" \
+	"${workflow}" >/dev/null
+grep -F "HFL_RELEASE_PART_BYTES: \${{ needs.prepare.outputs.edition == 'enterprise' && '100663296' || '1073741824' }}" \
+	"${workflow}" >/dev/null
+awk '
+	/^  assemble-release:$/ { inside = 1; next }
+	inside && /^  [a-z0-9-]+:$/ { inside = 0 }
+	inside && /timeout-minutes: 120/ { found = 1 }
+	END { exit(found ? 0 : 1) }
+' "${workflow}"
+grep -F '.github/scripts/stage-enterprise-release.sh build/release/dist "$incoming"' \
+	"${workflow}" >/dev/null
+if grep -F 'build/release/dist/*' "${workflow}" >/dev/null; then
+	printf 'ERROR: Enterprise release must not use one unbounded SCP transfer\n' >&2
+	exit 1
+fi
+transfer="${ROOT}/.github/scripts/stage-enterprise-release.sh"
+grep -F 'HFL_ENTERPRISE_TRANSFER_PARALLEL:-6' "${transfer}" >/dev/null
+grep -F 'HFL_ENTERPRISE_TRANSFER_ATTEMPTS:-3' "${transfer}" >/dev/null
+grep -F 'HFL_ENTERPRISE_TRANSFER_TIMEOUT:-20m' "${transfer}" >/dev/null
+grep -F 'xargs -0 -r -n 1 -P "${parallel}"' "${transfer}" >/dev/null
+grep -F 'ServerAliveInterval=30' "${transfer}" >/dev/null
+grep -F 'timeout "${transfer_timeout}" scp' "${transfer}" >/dev/null
+grep -F 'sha256sum -c SHA256SUMS' "${transfer}" >/dev/null
 grep -F 'enterprise_commit: ${{ steps.enterprise-ref.outputs.commit }}' "${workflow}" >/dev/null
 grep -F 'Check immutable Enterprise store' "${workflow}" >/dev/null
 grep -F 'ENTERPRISE_STORED: ${{ steps.enterprise-store.outputs.stored }}' "${workflow}" >/dev/null


### PR DESCRIPTION
## Summary
- split Enterprise offline packages into fixed-size transfer parts
- upload parts to the TEST host in bounded parallel transfers
- retry failed parts with SSH keepalives and per-transfer timeouts
- verify all staged assets on the TEST host before release verification
- retain the existing atomic publish, immutable version, and retention contracts

## Validation
- Enterprise release-flow contracts passed
- release contracts passed
- synthetic Enterprise assembly and split reconstruction passed
- shell syntax checks passed