### PR TITLE
fix(release): restore proxied enterprise staging

### DIFF
--- a/.github/scripts/download-enterprise-release.sh
+++ b/.github/scripts/download-enterprise-release.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Runs on the TEST host. Download a private Draft Release through a short-lived
+# GitHub asset URL without receiving repository credentials.
+set -euo pipefail
+
+incoming=${1:-}
+download_proxy=${2:-}
+plan_base64=${3:-}
+
+[[ "${incoming}" =~ ^/root/hfl-release/\.incoming/[A-Za-z0-9][A-Za-z0-9._-]*$ ]] || {
+	printf 'ERROR: Enterprise incoming directory is invalid\n' >&2
+	exit 2
+}
+[[ "${download_proxy}" =~ ^https?://[A-Za-z0-9.-]+:[0-9]{1,5}$ ]] || {
+	printf 'ERROR: Enterprise download proxy is invalid\n' >&2
+	exit 2
+}
+proxy_port=${download_proxy##*:}
+((proxy_port >= 1 && proxy_port <= 65535)) || {
+	printf 'ERROR: Enterprise download proxy port is out of range\n' >&2
+	exit 2
+}
+[[ -n "${plan_base64}" ]] || { printf 'ERROR: download plan is missing\n' >&2; exit 2; }
+
+install -d -m 0700 "${incoming}"
+plan="${incoming}/.download-plan"
+trap 'rm -f "${plan}"' EXIT
+printf '%s' "${plan_base64}" | base64 -d >"${plan}"
+chmod 0600 "${plan}"
+
+download() {
+	local name=$1 url=$2 partial
+	[[ "${name}" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]] || return 2
+	[[ "${url}" == https://release-assets.githubusercontent.com/* ]] || return 2
+	partial="${incoming}/.${name}.partial"
+	printf '[enterprise-stage] Downloading %s through TEST proxy\n' "${name}"
+	curl -fL --silent --show-error \
+		--proxy "${download_proxy}" --noproxy '' \
+		--connect-timeout 30 --max-time 3000 \
+		--speed-time 180 --speed-limit 1024 \
+		--retry 12 --retry-delay 5 --retry-all-errors \
+		--continue-at - --output "${partial}" "${url}"
+	mv "${partial}" "${incoming}/${name}"
+}
+
+while IFS=$'\t' read -r name url; do
+	[[ -n "${name}" && -n "${url}" ]] || {
+		printf 'ERROR: invalid Enterprise download plan\n' >&2
+		exit 1
+	}
+	download "${name}" "${url}"
+done <"${plan}"
+
+(
+	cd "${incoming}"
+	sha256sum -c SHA256SUMS
+)

--- a/.github/scripts/stage-enterprise-release.sh
+++ b/.github/scripts/stage-enterprise-release.sh
@@ -1,14 +1,11 @@
 #!/usr/bin/env bash
-# Upload an Enterprise release candidate to the TEST host with bounded,
-# retryable parallel transfers. The caller publishes the staged directory only
-# after the downstream release verification succeeds.
+# Upload an Enterprise candidate to its temporary Draft Release, then ask the
+# TEST host to download it through the configured target-side proxy.
 set -euo pipefail
 
 source_dir=${1:-}
 incoming=${2:-}
-parallel=${HFL_ENTERPRISE_TRANSFER_PARALLEL:-6}
-attempts=${HFL_ENTERPRISE_TRANSFER_ATTEMPTS:-3}
-transfer_timeout=${HFL_ENTERPRISE_TRANSFER_TIMEOUT:-20m}
+asset_list="$(dirname "${source_dir}")/release-assets.txt"
 
 [[ -d "${source_dir}" && ! -L "${source_dir}" ]] || {
 	printf 'ERROR: Enterprise release source directory is invalid\n' >&2
@@ -18,10 +15,22 @@ transfer_timeout=${HFL_ENTERPRISE_TRANSFER_TIMEOUT:-20m}
 	printf 'ERROR: Enterprise incoming directory is invalid\n' >&2
 	exit 2
 }
-[[ "${parallel}" =~ ^[1-8]$ ]] || { printf 'ERROR: invalid transfer parallelism\n' >&2; exit 2; }
-[[ "${attempts}" =~ ^[1-5]$ ]] || { printf 'ERROR: invalid transfer attempts\n' >&2; exit 2; }
-[[ "${transfer_timeout}" =~ ^[1-9][0-9]*[smh]$ ]] || {
-	printf 'ERROR: invalid transfer timeout\n' >&2
+[[ "${ARTIFACT_ID:-}" =~ ^enterprise-v[0-9]+\.[0-9]+\.[0-9]+-[0-9]+-[0-9]+$ ]] || {
+	printf 'ERROR: Enterprise candidate identity is invalid\n' >&2
+	exit 2
+}
+[[ "${GITHUB_REPOSITORY:-}" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] || {
+	printf 'ERROR: GitHub repository identity is invalid\n' >&2
+	exit 2
+}
+[[ -s "${asset_list}" ]] || { printf 'ERROR: release asset list is missing\n' >&2; exit 2; }
+[[ "${TEST_RELEASE_DOWNLOAD_PROXY_URL:-}" =~ ^https?://[A-Za-z0-9.-]+:[0-9]{1,5}$ ]] || {
+	printf 'ERROR: TEST release download proxy is invalid\n' >&2
+	exit 2
+}
+proxy_port=${TEST_RELEASE_DOWNLOAD_PROXY_URL##*:}
+((proxy_port >= 1 && proxy_port <= 65535)) || {
+	printf 'ERROR: TEST release download proxy port is out of range\n' >&2
 	exit 2
 }
 [[ "${TEST_SSH_HOST:-}" =~ ^[A-Za-z0-9][A-Za-z0-9.-]*$ \
@@ -33,8 +42,9 @@ transfer_timeout=${HFL_ENTERPRISE_TRANSFER_TIMEOUT:-20m}
 	printf 'ERROR: invalid TEST SSH user\n' >&2
 	exit 2
 }
-[[ -n "${TEST_SSH_KNOWN_HOSTS:-}" && -n "${TEST_SSH_PRIVATE_KEY:-}" ]] || {
-	printf 'ERROR: TEST SSH trust material is missing\n' >&2
+[[ -n "${TEST_SSH_KNOWN_HOSTS:-}" && -n "${TEST_SSH_PRIVATE_KEY:-}" \
+	&& -n "${GH_TOKEN:-}" ]] || {
+	printf 'ERROR: Enterprise staging credentials are missing\n' >&2
 	exit 2
 }
 
@@ -45,71 +55,79 @@ transfer_timeout=${HFL_ENTERPRISE_TRANSFER_TIMEOUT:-20m}
 		exit 1
 	}
 	sha256sum -c SHA256SUMS
-	archive_count="$({
-		find . -mindepth 1 -maxdepth 1 -type f \
-			\( -name 'hyperfilelens-*-ee.tar.gz' \
-			-o -name 'hyperfilelens-*-ee.tar.gz.part-000' \) -print
-	} | wc -l)"
-	if [[ "${archive_count}" -ne 1 ]]; then
-		printf 'ERROR: Enterprise release archive is missing\n' >&2
+	archive_count="$(find . -mindepth 1 -maxdepth 1 -type f \
+		-name 'hyperfilelens-*-ee.tar.gz' -print | wc -l)"
+	[[ "${archive_count}" -eq 1 ]] || {
+		printf 'ERROR: Enterprise release must contain one canonical archive\n' >&2
 		exit 1
-	fi
-	while IFS= read -r -d '' asset; do
-		name=${asset#./}
-		[[ "${name}" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]] || {
-			printf 'ERROR: unsafe Enterprise release asset name: %s\n' "${name}" >&2
-			exit 1
-		}
-	done < <(find . -mindepth 1 -maxdepth 1 -type f -print0)
+	}
 )
 
+while IFS= read -r asset; do
+	[[ "${asset}" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ \
+		&& -f "${source_dir}/${asset}" ]] || {
+		printf 'ERROR: unsafe or missing Enterprise release asset: %s\n' "${asset}" >&2
+		exit 1
+	}
+	./release/ci/gh-release-upload.sh "${ARTIFACT_ID}" \
+		"${source_dir}/${asset}" --clobber
+done <"${asset_list}"
+
+assets_json="$(mktemp)"
+plan="$(mktemp)"
+trap 'rm -f "${assets_json}" "${plan}"' EXIT
+gh release view "${ARTIFACT_ID}" --repo "${GITHUB_REPOSITORY}" \
+	--json assets >"${assets_json}"
+
+while IFS= read -r asset; do
+	api_url="$(python3 - "${assets_json}" "${asset}" <<'PY'
+import json
+import pathlib
+import sys
+
+payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+matches = [item["apiUrl"] for item in payload["assets"] if item["name"] == sys.argv[2]]
+if len(matches) != 1:
+    raise SystemExit(f"temporary Enterprise asset is missing or ambiguous: {sys.argv[2]}")
+print(matches[0])
+PY
+)"
+	signed_url="$(curl -fsSI \
+		-H 'Accept: application/octet-stream' \
+		-H "Authorization: Bearer ${GH_TOKEN}" \
+		"${api_url}" \
+		| awk 'BEGIN { IGNORECASE=1 } /^location:/ { sub(/\r$/, "", $2); print $2; exit }')"
+	python3 - "${asset}" "${signed_url}" >>"${plan}" <<'PY'
+import sys
+import urllib.parse
+from datetime import datetime, timedelta, timezone
+
+asset, url = sys.argv[1:]
+parts = urllib.parse.urlsplit(url)
+if parts.scheme != "https" or parts.hostname != "release-assets.githubusercontent.com":
+    raise SystemExit("GitHub returned an unexpected Enterprise asset download URL")
+if not parts.query or any(character in url for character in "\r\n\t"):
+    raise SystemExit("GitHub returned an invalid Enterprise asset download URL")
+expires = urllib.parse.parse_qs(parts.query).get("se", [""])[0]
+try:
+    expires_at = datetime.fromisoformat(expires.replace("Z", "+00:00"))
+except ValueError as error:
+    raise SystemExit("GitHub asset download URL has no valid expiry") from error
+if expires_at < datetime.now(timezone.utc) + timedelta(minutes=50):
+    raise SystemExit("GitHub asset download URL expires too soon")
+print(f"{asset}\t{url}")
+PY
+done <"${asset_list}"
+
+plan_base64="$(base64 -w 0 "${plan}")"
 install -d -m 0700 ~/.ssh
 printf '%s\n' "${TEST_SSH_KNOWN_HOSTS}" >~/.ssh/known_hosts
 printf '%s\n' "${TEST_SSH_PRIVATE_KEY}" >~/.ssh/hyperfilelens_test
 chmod 0600 ~/.ssh/known_hosts ~/.ssh/hyperfilelens_test
-
-ssh_options=(
-	-i ~/.ssh/hyperfilelens_test
-	-o BatchMode=yes
-	-o StrictHostKeyChecking=yes
-	-o ConnectTimeout=30
-	-o ServerAliveInterval=30
-	-o ServerAliveCountMax=6
-)
-remote="${TEST_SSH_USER}@${TEST_SSH_HOST}"
-ssh "${ssh_options[@]}" -p "${TEST_SSH_PORT}" "${remote}" \
-	"install -d -m 0700 '${incoming}'"
-
-export TEST_SSH_HOST TEST_SSH_PORT TEST_SSH_USER
-export incoming attempts transfer_timeout
-export HFL_ENTERPRISE_SSH_KEY=~/.ssh/hyperfilelens_test
-upload_asset() {
-	local asset=$1 attempt
-	for ((attempt = 1; attempt <= attempts; attempt++)); do
-		if timeout "${transfer_timeout}" scp \
-			-i "${HFL_ENTERPRISE_SSH_KEY}" \
-			-o BatchMode=yes \
-			-o StrictHostKeyChecking=yes \
-			-o ConnectTimeout=30 \
-			-o ServerAliveInterval=30 \
-			-o ServerAliveCountMax=6 \
-			-o Compression=no \
-			-P "${TEST_SSH_PORT}" "${asset}" \
-			"${TEST_SSH_USER}@${TEST_SSH_HOST}:${incoming}/"; then
-			return 0
-		fi
-		printf 'WARN: transfer attempt %d/%d failed for %s\n' \
-			"${attempt}" "${attempts}" "$(basename "${asset}")" >&2
-		((attempt == attempts)) || sleep $((attempt * 5))
-	done
-	return 1
-}
-export -f upload_asset
-
-find "${source_dir}" -mindepth 1 -maxdepth 1 -type f -print0 \
-	| xargs -0 -r -n 1 -P "${parallel}" bash -c 'upload_asset "$1"' _
-
-# The remote checksum closes the transfer gate before verification downloads
-# the staged candidate. Split parts are reconstructed only after verification.
-ssh "${ssh_options[@]}" -p "${TEST_SSH_PORT}" "${remote}" \
-	"cd '${incoming}' && sha256sum -c SHA256SUMS"
+printf -v remote_command '%q ' bash -s -- \
+	"${incoming}" "${TEST_RELEASE_DOWNLOAD_PROXY_URL}" "${plan_base64}"
+ssh -i ~/.ssh/hyperfilelens_test \
+	-o BatchMode=yes -o StrictHostKeyChecking=yes \
+	-o ConnectTimeout=30 -o ServerAliveInterval=30 -o ServerAliveCountMax=6 \
+	-p "${TEST_SSH_PORT}" "${TEST_SSH_USER}@${TEST_SSH_HOST}" \
+	"${remote_command}" <.github/scripts/download-enterprise-release.sh

--- a/.github/workflows/artifact_pipeline.yml
+++ b/.github/workflows/artifact_pipeline.yml
@@ -1051,10 +1051,6 @@ jobs:
           HFL_EXTENSION_EXPECTED_COMMIT: ${{ needs.prepare.outputs.enterprise_commit }}
           ENTERPRISE_EXTENSION_REPOSITORY: ${{ vars.ENTERPRISE_EXTENSION_REPOSITORY }}
           HFL_EXTENSION_GIT_TOKEN: ${{ secrets.ENTERPRISE_EXTENSION_GIT_TOKEN || secrets.HFL_EXTENSION_GIT_TOKEN }}
-          # Enterprise packages are staged outside GitHub. Fixed-size parts
-          # make the cross-region transfer parallel, retryable and bounded.
-          HFL_RELEASE_MAX_SINGLE_BYTES: ${{ needs.prepare.outputs.edition == 'enterprise' && '1' || '1900000000' }}
-          HFL_RELEASE_PART_BYTES: ${{ needs.prepare.outputs.edition == 'enterprise' && '100663296' || '1073741824' }}
         run: |
           if [[ "$RELEASE_EDITION" == "enterprise" ]]; then
             export HFL_EXTENSION_SOURCES="${ENTERPRISE_EXTENSION_REPOSITORY}@${RELEASE_TAG}"
@@ -1087,6 +1083,9 @@ jobs:
         if: ${{ needs.prepare.outputs.edition == 'enterprise' }}
         env:
           RELEASE_TAG: ${{ needs.prepare.outputs.release_tag }}
+          ARTIFACT_ID: ${{ needs.prepare.outputs.tag }}
+          GH_TOKEN: ${{ github.token }}
+          TEST_RELEASE_DOWNLOAD_PROXY_URL: ${{ vars.TEST_RELEASE_DOWNLOAD_PROXY_URL }}
           TEST_SSH_HOST: ${{ vars.TEST_SSH_HOST }}
           TEST_SSH_PORT: ${{ vars.TEST_SSH_PORT }}
           TEST_SSH_USER: ${{ vars.TEST_SSH_USER }}
@@ -1120,8 +1119,7 @@ jobs:
           sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc
           docker system prune -af || true
           df -h
-      - name: Download Community release candidate from draft
-        if: ${{ needs.prepare.outputs.edition == 'community' }}
+      - name: Download release candidate from temporary draft
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -1134,29 +1132,6 @@ jobs:
             --pattern 'hyperfilelens-root-ca.crt' \
             --pattern 'assemble-release.*' \
             --dir build/release-candidate
-      - name: Download Enterprise release candidate from TEST host
-        if: ${{ needs.prepare.outputs.edition == 'enterprise' }}
-        env:
-          RELEASE_TAG: ${{ needs.prepare.outputs.release_tag }}
-          RELEASE_VERSION: ${{ needs.prepare.outputs.version }}
-          TEST_SSH_HOST: ${{ vars.TEST_SSH_HOST }}
-          TEST_SSH_PORT: ${{ vars.TEST_SSH_PORT }}
-          TEST_SSH_USER: ${{ vars.TEST_SSH_USER }}
-          TEST_SSH_KNOWN_HOSTS: ${{ vars.TEST_SSH_KNOWN_HOSTS }}
-          TEST_SSH_PRIVATE_KEY: ${{ secrets.TEST_SSH_PRIVATE_KEY }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          install -d -m 0700 ~/.ssh build/release-candidate
-          printf '%s\n' "$TEST_SSH_KNOWN_HOSTS" > ~/.ssh/known_hosts
-          printf '%s\n' "$TEST_SSH_PRIVATE_KEY" > ~/.ssh/hyperfilelens_test
-          chmod 0600 ~/.ssh/known_hosts ~/.ssh/hyperfilelens_test
-          remote="/root/hfl-release/.incoming/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-          scp -r -i ~/.ssh/hyperfilelens_test \
-            -o BatchMode=yes -o StrictHostKeyChecking=yes \
-            -P "$TEST_SSH_PORT" \
-            "$TEST_SSH_USER@$TEST_SSH_HOST:$remote/." \
-            build/release-candidate/
       - name: Verify checksums and reconstruct package when split
         id: package
         working-directory: build/release-candidate

--- a/tools/quality/test-enterprise-release-flow.sh
+++ b/tools/quality/test-enterprise-release-flow.sh
@@ -89,10 +89,6 @@ if grep -Fx '          npm run test:ci' "${workflow}" >/dev/null; then
 	printf 'ERROR: Host and Extension frontend test contracts must run separately\n' >&2
 	exit 1
 fi
-grep -F "HFL_RELEASE_MAX_SINGLE_BYTES: \${{ needs.prepare.outputs.edition == 'enterprise' && '1' || '1900000000' }}" \
-	"${workflow}" >/dev/null
-grep -F "HFL_RELEASE_PART_BYTES: \${{ needs.prepare.outputs.edition == 'enterprise' && '100663296' || '1073741824' }}" \
-	"${workflow}" >/dev/null
 awk '
 	/^  assemble-release:$/ { inside = 1; next }
 	inside && /^  [a-z0-9-]+:$/ { inside = 0 }
@@ -101,18 +97,31 @@ awk '
 ' "${workflow}"
 grep -F '.github/scripts/stage-enterprise-release.sh build/release/dist "$incoming"' \
 	"${workflow}" >/dev/null
-if grep -F 'build/release/dist/*' "${workflow}" >/dev/null; then
-	printf 'ERROR: Enterprise release must not use one unbounded SCP transfer\n' >&2
+if grep -F 'HFL_RELEASE_MAX_SINGLE_BYTES:' "${workflow}" >/dev/null \
+	|| grep -F 'HFL_RELEASE_PART_BYTES:' "${workflow}" >/dev/null; then
+	printf 'ERROR: Enterprise staging must retain the canonical single archive\n' >&2
 	exit 1
 fi
 transfer="${ROOT}/.github/scripts/stage-enterprise-release.sh"
-grep -F 'HFL_ENTERPRISE_TRANSFER_PARALLEL:-6' "${transfer}" >/dev/null
-grep -F 'HFL_ENTERPRISE_TRANSFER_ATTEMPTS:-3' "${transfer}" >/dev/null
-grep -F 'HFL_ENTERPRISE_TRANSFER_TIMEOUT:-20m' "${transfer}" >/dev/null
-grep -F 'xargs -0 -r -n 1 -P "${parallel}"' "${transfer}" >/dev/null
+grep -F 'TEST_RELEASE_DOWNLOAD_PROXY_URL' "${workflow}" >/dev/null
+grep -F 'gh-release-upload.sh "${ARTIFACT_ID}"' "${transfer}" >/dev/null
+grep -F 'release-assets.githubusercontent.com' "${transfer}" >/dev/null
 grep -F 'ServerAliveInterval=30' "${transfer}" >/dev/null
-grep -F 'timeout "${transfer_timeout}" scp' "${transfer}" >/dev/null
-grep -F 'sha256sum -c SHA256SUMS' "${transfer}" >/dev/null
+grep -F '<.github/scripts/download-enterprise-release.sh' "${transfer}" >/dev/null
+if grep -F 'scp ' "${transfer}" >/dev/null; then
+	printf 'ERROR: Enterprise package staging must not copy release assets over SSH\n' >&2
+	exit 1
+fi
+downloader="${ROOT}/.github/scripts/download-enterprise-release.sh"
+grep -F -- '--proxy "${download_proxy}"' "${downloader}" >/dev/null
+grep -F -- '--continue-at -' "${downloader}" >/dev/null
+grep -F -- '--max-time 3000' "${downloader}" >/dev/null
+grep -F 'sha256sum -c SHA256SUMS' "${downloader}" >/dev/null
+grep -F 'Download release candidate from temporary draft' "${workflow}" >/dev/null
+if grep -F 'Download Enterprise release candidate from TEST host' "${workflow}" >/dev/null; then
+	printf 'ERROR: Enterprise verification must not copy the package back over SCP\n' >&2
+	exit 1
+fi
 grep -F 'enterprise_commit: ${{ steps.enterprise-ref.outputs.commit }}' "${workflow}" >/dev/null
 grep -F 'Check immutable Enterprise store' "${workflow}" >/dev/null
 grep -F 'ENTERPRISE_STORED: ${{ steps.enterprise-store.outputs.stored }}' "${workflow}" >/dev/null
@@ -121,7 +130,6 @@ grep -F 'flock -s 9' "${workflow}" >/dev/null
 grep -F -- '--expected-commit "$ENTERPRISE_COMMIT"' "${workflow}" >/dev/null
 grep -F 'validate_build_contract()' "${workflow}" >/dev/null
 grep -F 'Selected tag predates the edition-aware release contract' "${workflow}" >/dev/null
-grep -F '"$TEST_SSH_USER@$TEST_SSH_HOST:$remote/."' "${workflow}" >/dev/null
 grep -F 'local image_version="${HFL_IMAGE_VERSION:-${HFL_VERSION}}"' \
 	"${ROOT}/release/build.sh" >/dev/null
 grep -F 'tar xzf hyperfilelens-${version}${edition_suffix}.tar.gz' \
@@ -135,6 +143,60 @@ grep -F 'Enterprise release package has an invalid extension_commit' \
 grep -F '"ls-remote"' "${workflow}" >/dev/null
 grep -F 'f"refs/tags/{tag}"' "${workflow}" >/dev/null
 grep -F 'gh release delete "$ARTIFACT_ID"' "${workflow}" >/dev/null
+
+# Exercise the target-side downloader without network access. The fake curl
+# records its arguments and materializes the two expected assets, proving that
+# the canonical archive is downloaded through the configured proxy and then
+# covered by SHA256SUMS.
+download_test="$(mktemp -d)"
+trap 'rm -rf "${download_test}"' EXIT
+mkdir -p "${download_test}/bin" "${download_test}/.incoming/candidate"
+archive_name=hyperfilelens-1.2.3-ee.tar.gz
+printf 'enterprise archive\n' >"${download_test}/${archive_name}"
+archive_digest="$(sha256sum "${download_test}/${archive_name}" | awk '{print $1}')"
+printf '%s  %s\n' "${archive_digest}" "${archive_name}" >"${download_test}/SHA256SUMS"
+# Preserve the production downloader verbatim except for its fixed TEST-store
+# root, which an unprivileged CI contract test cannot create under /root.
+sed "s#/root/hfl-release#${download_test}#g" "${downloader}" \
+	>"${download_test}/downloader"
+chmod +x "${download_test}/downloader"
+cat >"${download_test}/bin/curl" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%q ' "$@" >>"${HFL_FAKE_CURL_LOG}"
+printf '\n' >>"${HFL_FAKE_CURL_LOG}"
+output=""
+url=""
+while (($#)); do
+	case "$1" in
+	--output) output=$2; shift 2 ;;
+	https://*) url=$1; shift ;;
+	*) shift ;;
+	esac
+done
+[[ -n "${output}" && -n "${url}" ]]
+cp "${HFL_FAKE_ASSET_ROOT}/${url##*/}" "${output}"
+SH
+chmod +x "${download_test}/bin/curl"
+plan="${archive_name}"$'\t'"https://release-assets.githubusercontent.com/${archive_name}"$'\n'
+plan+="SHA256SUMS"$'\t'"https://release-assets.githubusercontent.com/SHA256SUMS"$'\n'
+PATH="${download_test}/bin:${PATH}" \
+	HFL_FAKE_ASSET_ROOT="${download_test}" \
+	HFL_FAKE_CURL_LOG="${download_test}/curl.log" \
+	"${download_test}/downloader" \
+	"${download_test}/.incoming/candidate" \
+	http://192.0.2.10:7890 \
+	"$(printf '%s' "${plan}" | base64 -w 0)" >/dev/null
+cmp "${download_test}/${archive_name}" \
+	"${download_test}/.incoming/candidate/${archive_name}"
+grep -F -- '--proxy http://192.0.2.10:7890' "${download_test}/curl.log" >/dev/null
+grep -F -- '--continue-at -' "${download_test}/curl.log" >/dev/null
+if find "${download_test}/.incoming/candidate" -maxdepth 1 -name '*.part-*' | grep -q .; then
+	printf 'ERROR: Enterprise target-side staging unexpectedly created split assets\n' >&2
+	exit 1
+fi
+rm -rf "${download_test}"
+trap - EXIT
 
 checkout_count="$(grep -c 'uses: actions/checkout@' "${workflow}")"
 credentialless_checkout_count="$(grep -c 'persist-credentials: false' "${workflow}")"


### PR DESCRIPTION
## Summary
- restore the proven single-archive Enterprise release path
- stage the private Draft Release asset from the TEST host through the configured download proxy
- remove concurrent SCP part transfers and avoid copying the package back to the runner
- add contracts for proxy use, checksum verification, and the no-SCP/no-split workflow

## Validation
- `./tools/quality/test-enterprise-release-flow.sh`
- `./tools/quality/check-release-contracts.sh`
- `HFL_TEST_EDITION=enterprise ./tools/quality/test-ci-release-assembly.sh`
- Shell syntax checks and `git diff --check`