### PR TITLE
fix(release): verify enterprise package before staging

### DIFF
--- a/.github/scripts/stage-enterprise-release.sh
+++ b/.github/scripts/stage-enterprise-release.sh
@@ -1,16 +1,11 @@
 #!/usr/bin/env bash
-# Upload an Enterprise candidate to its temporary Draft Release, then ask the
-# TEST host to download it through the configured target-side proxy.
+# After Runner verification succeeds, ask the TEST host to download the
+# Enterprise candidate from its temporary Draft Release through the configured
+# target-side proxy. Repository credentials never leave the Runner.
 set -euo pipefail
 
-source_dir=${1:-}
-incoming=${2:-}
-asset_list="$(dirname "${source_dir}")/release-assets.txt"
+incoming=${1:-}
 
-[[ -d "${source_dir}" && ! -L "${source_dir}" ]] || {
-	printf 'ERROR: Enterprise release source directory is invalid\n' >&2
-	exit 2
-}
 [[ "${incoming}" =~ ^/root/hfl-release/\.incoming/[A-Za-z0-9][A-Za-z0-9._-]*$ ]] || {
 	printf 'ERROR: Enterprise incoming directory is invalid\n' >&2
 	exit 2
@@ -23,7 +18,6 @@ asset_list="$(dirname "${source_dir}")/release-assets.txt"
 	printf 'ERROR: GitHub repository identity is invalid\n' >&2
 	exit 2
 }
-[[ -s "${asset_list}" ]] || { printf 'ERROR: release asset list is missing\n' >&2; exit 2; }
 [[ "${TEST_RELEASE_DOWNLOAD_PROXY_URL:-}" =~ ^https?://[A-Za-z0-9.-]+:[0-9]{1,5}$ ]] || {
 	printf 'ERROR: TEST release download proxy is invalid\n' >&2
 	exit 2
@@ -47,39 +41,33 @@ proxy_port=${TEST_RELEASE_DOWNLOAD_PROXY_URL##*:}
 	printf 'ERROR: Enterprise staging credentials are missing\n' >&2
 	exit 2
 }
-
-(
-	cd "${source_dir}"
-	[[ -s SHA256SUMS && -s MANIFEST.json ]] || {
-		printf 'ERROR: Enterprise release metadata is incomplete\n' >&2
-		exit 1
-	}
-	sha256sum -c SHA256SUMS
-	archive_count="$(find . -mindepth 1 -maxdepth 1 -type f \
-		-name 'hyperfilelens-*-ee.tar.gz' -print | wc -l)"
-	[[ "${archive_count}" -eq 1 ]] || {
-		printf 'ERROR: Enterprise release must contain one canonical archive\n' >&2
-		exit 1
-	}
-)
-
-while IFS= read -r asset; do
-	[[ "${asset}" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ \
-		&& -f "${source_dir}/${asset}" ]] || {
-		printf 'ERROR: unsafe or missing Enterprise release asset: %s\n' "${asset}" >&2
-		exit 1
-	}
-	./release/ci/gh-release-upload.sh "${ARTIFACT_ID}" \
-		"${source_dir}/${asset}" --clobber
-done <"${asset_list}"
-
 assets_json="$(mktemp)"
 plan="$(mktemp)"
 trap 'rm -f "${assets_json}" "${plan}"' EXIT
 gh release view "${ARTIFACT_ID}" --repo "${GITHUB_REPOSITORY}" \
 	--json assets >"${assets_json}"
 
-while IFS= read -r asset; do
+mapfile -t assets < <(python3 - "${assets_json}" <<'PY'
+import json
+import pathlib
+import re
+import sys
+
+payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+names = sorted(item["name"] for item in payload["assets"] if not item["name"].startswith("_internal-"))
+archives = [name for name in names if re.fullmatch(r"hyperfilelens-[0-9]+\.[0-9]+\.[0-9]+-ee\.tar\.gz", name)]
+required = {"SHA256SUMS", "MANIFEST.json"}
+if len(archives) != 1 or not required.issubset(names):
+    raise SystemExit("temporary Enterprise candidate is incomplete or ambiguous")
+for name in names:
+    if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]*", name):
+        raise SystemExit(f"unsafe Enterprise release asset name: {name}")
+    print(name)
+PY
+)
+(( ${#assets[@]} >= 3 )) || { printf 'ERROR: Enterprise asset list is empty\n' >&2; exit 1; }
+
+for asset in "${assets[@]}"; do
 	api_url="$(python3 - "${assets_json}" "${asset}" <<'PY'
 import json
 import pathlib
@@ -117,7 +105,7 @@ if expires_at < datetime.now(timezone.utc) + timedelta(minutes=50):
     raise SystemExit("GitHub asset download URL expires too soon")
 print(f"{asset}\t{url}")
 PY
-done <"${asset_list}"
+done
 
 plan_base64="$(base64 -w 0 "${plan}")"
 install -d -m 0700 ~/.ssh

--- a/.github/workflows/artifact_pipeline.yml
+++ b/.github/workflows/artifact_pipeline.yml
@@ -1030,8 +1030,6 @@ jobs:
       - export-runtime-images
     permissions:
       contents: write
-    outputs:
-      stored: ${{ steps.store-enterprise.outputs.stored }}
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
@@ -1078,25 +1076,18 @@ jobs:
             ./release/ci/gh-release-upload.sh "${{ needs.prepare.outputs.tag }}" \
               "build/release/dist/${asset}" --clobber
           done < build/release/release-assets.txt
-      - name: Stage Enterprise release on TEST host
-        id: store-enterprise
+      - name: Upload Enterprise candidate to temporary draft
         if: ${{ needs.prepare.outputs.edition == 'enterprise' }}
         env:
-          RELEASE_TAG: ${{ needs.prepare.outputs.release_tag }}
           ARTIFACT_ID: ${{ needs.prepare.outputs.tag }}
           GH_TOKEN: ${{ github.token }}
-          TEST_RELEASE_DOWNLOAD_PROXY_URL: ${{ vars.TEST_RELEASE_DOWNLOAD_PROXY_URL }}
-          TEST_SSH_HOST: ${{ vars.TEST_SSH_HOST }}
-          TEST_SSH_PORT: ${{ vars.TEST_SSH_PORT }}
-          TEST_SSH_USER: ${{ vars.TEST_SSH_USER }}
-          TEST_SSH_KNOWN_HOSTS: ${{ vars.TEST_SSH_KNOWN_HOSTS }}
-          TEST_SSH_PRIVATE_KEY: ${{ secrets.TEST_SSH_PRIVATE_KEY }}
         shell: bash
         run: |
           set -euo pipefail
-          incoming="/root/hfl-release/.incoming/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-          .github/scripts/stage-enterprise-release.sh build/release/dist "$incoming"
-          echo 'stored=true' >> "$GITHUB_OUTPUT"
+          while IFS= read -r asset; do
+            ./release/ci/gh-release-upload.sh "$ARTIFACT_ID" \
+              "build/release/dist/${asset}" --clobber
+          done < build/release/release-assets.txt
       - name: Disk report
         if: always()
         run: df -h
@@ -1172,10 +1163,10 @@ jobs:
           df -h
 
   publish-release:
-    name: Publish · Release
+    name: Distribute · Verified release
     if: ${{ needs.prepare.outputs.build_required == 'true' }}
     runs-on: ubuntu-24.04
-    timeout-minutes: 10
+    timeout-minutes: 90
     needs: [prepare, verify-release]
     permissions:
       contents: write
@@ -1187,7 +1178,7 @@ jobs:
         with:
           persist-credentials: false
           ref: ${{ needs.prepare.outputs.commit }}
-      - name: Remove internal assets and publish release
+      - name: Store Enterprise candidate or publish Community release
         id: publish
         env:
           GH_TOKEN: ${{ github.token }}
@@ -1200,15 +1191,17 @@ jobs:
           TEST_SSH_USER: ${{ vars.TEST_SSH_USER }}
           TEST_SSH_KNOWN_HOSTS: ${{ vars.TEST_SSH_KNOWN_HOSTS }}
           TEST_SSH_PRIVATE_KEY: ${{ secrets.TEST_SSH_PRIVATE_KEY }}
+          TEST_RELEASE_DOWNLOAD_PROXY_URL: ${{ vars.TEST_RELEASE_DOWNLOAD_PROXY_URL }}
         shell: bash
         run: |
           set -euo pipefail
           if [[ "$RELEASE_EDITION" == "enterprise" ]]; then
+            incoming="/root/hfl-release/.incoming/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+            .github/scripts/stage-enterprise-release.sh "$incoming"
             install -d -m 0700 ~/.ssh
             printf '%s\n' "$TEST_SSH_KNOWN_HOSTS" > ~/.ssh/known_hosts
             printf '%s\n' "$TEST_SSH_PRIVATE_KEY" > ~/.ssh/hyperfilelens_test
             chmod 0600 ~/.ssh/known_hosts ~/.ssh/hyperfilelens_test
-            incoming="/root/hfl-release/.incoming/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
             ssh -i ~/.ssh/hyperfilelens_test -o BatchMode=yes -o StrictHostKeyChecking=yes \
               -p "$TEST_SSH_PORT" "$TEST_SSH_USER@$TEST_SSH_HOST" \
               "bash -s -- '$RELEASE_TAG' '$incoming' /root/hfl-release 10" \

--- a/tools/quality/test-enterprise-release-flow.sh
+++ b/tools/quality/test-enterprise-release-flow.sh
@@ -95,8 +95,8 @@ awk '
 	inside && /timeout-minutes: 120/ { found = 1 }
 	END { exit(found ? 0 : 1) }
 ' "${workflow}"
-grep -F '.github/scripts/stage-enterprise-release.sh build/release/dist "$incoming"' \
-	"${workflow}" >/dev/null
+grep -F 'Upload Enterprise candidate to temporary draft' "${workflow}" >/dev/null
+grep -F '.github/scripts/stage-enterprise-release.sh "$incoming"' "${workflow}" >/dev/null
 if grep -F 'HFL_RELEASE_MAX_SINGLE_BYTES:' "${workflow}" >/dev/null \
 	|| grep -F 'HFL_RELEASE_PART_BYTES:' "${workflow}" >/dev/null; then
 	printf 'ERROR: Enterprise staging must retain the canonical single archive\n' >&2
@@ -104,7 +104,10 @@ if grep -F 'HFL_RELEASE_MAX_SINGLE_BYTES:' "${workflow}" >/dev/null \
 fi
 transfer="${ROOT}/.github/scripts/stage-enterprise-release.sh"
 grep -F 'TEST_RELEASE_DOWNLOAD_PROXY_URL' "${workflow}" >/dev/null
-grep -F 'gh-release-upload.sh "${ARTIFACT_ID}"' "${transfer}" >/dev/null
+if grep -F 'gh-release-upload.sh' "${transfer}" >/dev/null; then
+	printf 'ERROR: TEST staging must not upload the candidate before verification\n' >&2
+	exit 1
+fi
 grep -F 'release-assets.githubusercontent.com' "${transfer}" >/dev/null
 grep -F 'ServerAliveInterval=30' "${transfer}" >/dev/null
 grep -F '<.github/scripts/download-enterprise-release.sh' "${transfer}" >/dev/null
@@ -118,6 +121,34 @@ grep -F -- '--continue-at -' "${downloader}" >/dev/null
 grep -F -- '--max-time 3000' "${downloader}" >/dev/null
 grep -F 'sha256sum -c SHA256SUMS' "${downloader}" >/dev/null
 grep -F 'Download release candidate from temporary draft' "${workflow}" >/dev/null
+python3 - "${workflow}" <<'PY'
+import pathlib
+import sys
+
+workflow = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
+verify = workflow.index("  verify-release:")
+publish = workflow.index("  publish-release:")
+stage = workflow.index('.github/scripts/stage-enterprise-release.sh "$incoming"')
+deploy = workflow.index("  deploy-test:")
+production = workflow.index("  promote-production:")
+if not verify < publish < stage < deploy < production:
+    raise SystemExit("Enterprise release order must be verify, TEST stage, TEST deploy, PROD promotion")
+publish_block = workflow[publish:deploy]
+if "needs: [prepare, verify-release]" not in publish_block:
+    raise SystemExit("Enterprise TEST staging must depend on successful Runner verification")
+deploy_block = workflow[deploy:production]
+if "needs: [prepare, publish-release]" not in deploy_block:
+    raise SystemExit("Enterprise TEST deployment must depend on successful TEST storage")
+production_block = workflow[production:]
+if "needs: [prepare, deploy-test]" not in production_block:
+    raise SystemExit("Enterprise PROD promotion must depend on successful TEST deployment")
+PY
+awk '
+	/^  publish-release:$/ { inside = 1; next }
+	inside && /^  [a-z0-9-]+:$/ { inside = 0 }
+	inside && /timeout-minutes: 90/ { found = 1 }
+	END { exit(found ? 0 : 1) }
+' "${workflow}"
 if grep -F 'Download Enterprise release candidate from TEST host' "${workflow}" >/dev/null; then
 	printf 'ERROR: Enterprise verification must not copy the package back over SCP\n' >&2
 	exit 1


### PR DESCRIPTION
## Summary
- keep the Enterprise package on the temporary Draft Release until Runner verification succeeds
- move TEST-host proxy download and immutable storage behind the verification gate
- preserve the deployment order: verify, TEST storage, TEST deployment, then PROD promotion
- add release-flow contracts that enforce the dependency and ordering guarantees

## Validation
- `./tools/quality/test-enterprise-release-flow.sh`
- `./tools/quality/check-release-contracts.sh`
- Enterprise synthetic release assembly
- Shell syntax checks and `git diff --check`