### PR TITLE
fix(release): refresh enterprise asset downloads

### DIFF
--- a/.github/scripts/download-enterprise-release.sh
+++ b/.github/scripts/download-enterprise-release.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 incoming=${1:-}
 download_proxy=${2:-}
 plan_base64=${3:-}
+mode=${4:-download}
 
 [[ "${incoming}" =~ ^/root/hfl-release/\.incoming/[A-Za-z0-9][A-Za-z0-9._-]*$ ]] || {
 	printf 'ERROR: Enterprise incoming directory is invalid\n' >&2
@@ -20,9 +21,25 @@ proxy_port=${download_proxy##*:}
 	printf 'ERROR: Enterprise download proxy port is out of range\n' >&2
 	exit 2
 }
-[[ -n "${plan_base64}" ]] || { printf 'ERROR: download plan is missing\n' >&2; exit 2; }
+[[ "${mode}" =~ ^(download|verify)$ ]] || {
+	printf 'ERROR: invalid Enterprise staging mode\n' >&2
+	exit 2
+}
 
 install -d -m 0700 "${incoming}"
+if [[ "${mode}" == "verify" ]]; then
+	(
+		cd "${incoming}"
+		[[ -s SHA256SUMS && -s MANIFEST.json ]] || {
+			printf 'ERROR: Enterprise release metadata is incomplete\n' >&2
+			exit 1
+		}
+		sha256sum -c SHA256SUMS
+	)
+	exit 0
+fi
+
+[[ -n "${plan_base64}" ]] || { printf 'ERROR: download plan is missing\n' >&2; exit 2; }
 plan="${incoming}/.download-plan"
 trap 'rm -f "${plan}"' EXIT
 printf '%s' "${plan_base64}" | base64 -d >"${plan}"
@@ -50,8 +67,3 @@ while IFS=$'\t' read -r name url; do
 	}
 	download "${name}" "${url}"
 done <"${plan}"
-
-(
-	cd "${incoming}"
-	sha256sum -c SHA256SUMS
-)

--- a/.github/scripts/stage-enterprise-release.sh
+++ b/.github/scripts/stage-enterprise-release.sh
@@ -62,10 +62,30 @@ if len(archives) != 1 or not required.issubset(names):
 for name in names:
     if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]*", name):
         raise SystemExit(f"unsafe Enterprise release asset name: {name}")
+for name in names:
+    if name not in archives:
+        print(name)
+for name in archives:
     print(name)
 PY
 )
 (( ${#assets[@]} >= 3 )) || { printf 'ERROR: Enterprise asset list is empty\n' >&2; exit 1; }
+
+install -d -m 0700 ~/.ssh
+printf '%s\n' "${TEST_SSH_KNOWN_HOSTS}" >~/.ssh/known_hosts
+printf '%s\n' "${TEST_SSH_PRIVATE_KEY}" >~/.ssh/hyperfilelens_test
+chmod 0600 ~/.ssh/known_hosts ~/.ssh/hyperfilelens_test
+
+run_remote() {
+	local mode=$1 encoded_plan=${2:-} remote_command
+	printf -v remote_command '%q ' bash -s -- \
+		"${incoming}" "${TEST_RELEASE_DOWNLOAD_PROXY_URL}" "${encoded_plan}" "${mode}"
+	ssh -i ~/.ssh/hyperfilelens_test \
+		-o BatchMode=yes -o StrictHostKeyChecking=yes \
+		-o ConnectTimeout=30 -o ServerAliveInterval=30 -o ServerAliveCountMax=6 \
+		-p "${TEST_SSH_PORT}" "${TEST_SSH_USER}@${TEST_SSH_HOST}" \
+		"${remote_command}" <.github/scripts/download-enterprise-release.sh
+}
 
 for asset in "${assets[@]}"; do
 	api_url="$(python3 - "${assets_json}" "${asset}" <<'PY'
@@ -80,12 +100,14 @@ if len(matches) != 1:
 print(matches[0])
 PY
 )"
-	signed_url="$(curl -fsSI \
-		-H 'Accept: application/octet-stream' \
-		-H "Authorization: Bearer ${GH_TOKEN}" \
-		"${api_url}" \
-		| awk 'BEGIN { IGNORECASE=1 } /^location:/ { sub(/\r$/, "", $2); print $2; exit }')"
-	python3 - "${asset}" "${signed_url}" >>"${plan}" <<'PY'
+	asset_staged=false
+	for attempt in 1 2 3; do
+		signed_url="$(curl -fsSI \
+			-H 'Accept: application/octet-stream' \
+			-H "Authorization: Bearer ${GH_TOKEN}" \
+			"${api_url}" \
+			| awk 'BEGIN { IGNORECASE=1 } /^location:/ { sub(/\r$/, "", $2); print $2; exit }')"
+		python3 - "${asset}" "${signed_url}" >"${plan}" <<'PY'
 import sys
 import urllib.parse
 from datetime import datetime, timedelta, timezone
@@ -105,17 +127,19 @@ if expires_at < datetime.now(timezone.utc) + timedelta(minutes=50):
     raise SystemExit("GitHub asset download URL expires too soon")
 print(f"{asset}\t{url}")
 PY
+		plan_base64="$(base64 -w 0 "${plan}")"
+		if run_remote download "${plan_base64}"; then
+			asset_staged=true
+			break
+		fi
+		printf 'WARN: Enterprise download attempt %d/3 failed for %s; refreshing URL\n' \
+			"${attempt}" "${asset}" >&2
+	done
+	[[ "${asset_staged}" == "true" ]] || {
+		printf 'ERROR: Enterprise asset download failed after URL refresh: %s\n' \
+			"${asset}" >&2
+		exit 1
+	}
 done
 
-plan_base64="$(base64 -w 0 "${plan}")"
-install -d -m 0700 ~/.ssh
-printf '%s\n' "${TEST_SSH_KNOWN_HOSTS}" >~/.ssh/known_hosts
-printf '%s\n' "${TEST_SSH_PRIVATE_KEY}" >~/.ssh/hyperfilelens_test
-chmod 0600 ~/.ssh/known_hosts ~/.ssh/hyperfilelens_test
-printf -v remote_command '%q ' bash -s -- \
-	"${incoming}" "${TEST_RELEASE_DOWNLOAD_PROXY_URL}" "${plan_base64}"
-ssh -i ~/.ssh/hyperfilelens_test \
-	-o BatchMode=yes -o StrictHostKeyChecking=yes \
-	-o ConnectTimeout=30 -o ServerAliveInterval=30 -o ServerAliveCountMax=6 \
-	-p "${TEST_SSH_PORT}" "${TEST_SSH_USER}@${TEST_SSH_HOST}" \
-	"${remote_command}" <.github/scripts/download-enterprise-release.sh
+run_remote verify

--- a/tools/quality/test-enterprise-release-flow.sh
+++ b/tools/quality/test-enterprise-release-flow.sh
@@ -111,6 +111,10 @@ fi
 grep -F 'release-assets.githubusercontent.com' "${transfer}" >/dev/null
 grep -F 'ServerAliveInterval=30' "${transfer}" >/dev/null
 grep -F '<.github/scripts/download-enterprise-release.sh' "${transfer}" >/dev/null
+grep -F 'for attempt in 1 2 3' "${transfer}" >/dev/null
+grep -F 'refreshing URL' "${transfer}" >/dev/null
+grep -F 'run_remote verify' "${transfer}" >/dev/null
+grep -F 'if name not in archives:' "${transfer}" >/dev/null
 if grep -F 'scp ' "${transfer}" >/dev/null; then
 	printf 'ERROR: Enterprise package staging must not copy release assets over SSH\n' >&2
 	exit 1
@@ -184,8 +188,12 @@ trap 'rm -rf "${download_test}"' EXIT
 mkdir -p "${download_test}/bin" "${download_test}/.incoming/candidate"
 archive_name=hyperfilelens-1.2.3-ee.tar.gz
 printf 'enterprise archive\n' >"${download_test}/${archive_name}"
+printf '{"edition":"enterprise"}\n' >"${download_test}/MANIFEST.json"
 archive_digest="$(sha256sum "${download_test}/${archive_name}" | awk '{print $1}')"
-printf '%s  %s\n' "${archive_digest}" "${archive_name}" >"${download_test}/SHA256SUMS"
+manifest_digest="$(sha256sum "${download_test}/MANIFEST.json" | awk '{print $1}')"
+printf '%s  %s\n%s  %s\n' \
+	"${archive_digest}" "${archive_name}" \
+	"${manifest_digest}" MANIFEST.json >"${download_test}/SHA256SUMS"
 # Preserve the production downloader verbatim except for its fixed TEST-store
 # root, which an unprivileged CI contract test cannot create under /root.
 sed "s#/root/hfl-release#${download_test}#g" "${downloader}" \
@@ -211,13 +219,18 @@ SH
 chmod +x "${download_test}/bin/curl"
 plan="${archive_name}"$'\t'"https://release-assets.githubusercontent.com/${archive_name}"$'\n'
 plan+="SHA256SUMS"$'\t'"https://release-assets.githubusercontent.com/SHA256SUMS"$'\n'
+plan+="MANIFEST.json"$'\t'"https://release-assets.githubusercontent.com/MANIFEST.json"$'\n'
 PATH="${download_test}/bin:${PATH}" \
 	HFL_FAKE_ASSET_ROOT="${download_test}" \
 	HFL_FAKE_CURL_LOG="${download_test}/curl.log" \
 	"${download_test}/downloader" \
 	"${download_test}/.incoming/candidate" \
 	http://192.0.2.10:7890 \
-	"$(printf '%s' "${plan}" | base64 -w 0)" >/dev/null
+	"$(printf '%s' "${plan}" | base64 -w 0)" \
+	download >/dev/null
+"${download_test}/downloader" \
+	"${download_test}/.incoming/candidate" \
+	http://192.0.2.10:7890 '' verify >/dev/null
 cmp "${download_test}/${archive_name}" \
 	"${download_test}/.incoming/candidate/${archive_name}"
 grep -F -- '--proxy http://192.0.2.10:7890' "${download_test}/curl.log" >/dev/null


### PR DESCRIPTION
## Summary
- download Enterprise metadata before the large archive
- acquire a fresh private Release asset URL immediately before each target-side download
- refresh expired URLs and resume partial downloads without splitting the canonical archive
- verify SHA256 only after every asset has completed

## Root cause
The 1.41 GB archive completed through the TEST proxy, but the pre-generated URL for the following small asset expired and GitHub returned HTTP 618.

## Validation
- `./tools/quality/test-enterprise-release-flow.sh`
- `./tools/quality/check-release-contracts.sh`
- Shell syntax checks and `git diff --check`