### PR TITLE
fix(release): minimize enterprise target staging

### DIFF
--- a/.github/scripts/download-enterprise-release.sh
+++ b/.github/scripts/download-enterprise-release.sh
@@ -34,7 +34,31 @@ if [[ "${mode}" == "verify" ]]; then
 			printf 'ERROR: Enterprise release metadata is incomplete\n' >&2
 			exit 1
 		}
-		sha256sum -c SHA256SUMS
+		mapfile -t archives < <(find . -mindepth 1 -maxdepth 1 -type f \
+			-name 'hyperfilelens-*-ee.tar.gz' -printf '%f\n')
+		[[ "${#archives[@]}" -eq 1 ]] || {
+			printf 'ERROR: Enterprise archive is missing or ambiguous\n' >&2
+			exit 1
+		}
+		archive=${archives[0]}
+		python3 - SHA256SUMS "${archive}" MANIFEST.json <<'PY'
+import pathlib
+import re
+import sys
+
+lines = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8").splitlines()
+entries = {}
+for line in lines:
+    match = re.fullmatch(r"([0-9a-f]{64})  ([A-Za-z0-9][A-Za-z0-9._-]*)", line)
+    if match:
+        entries[match.group(2)] = match.group(1)
+missing = [name for name in sys.argv[2:] if name not in entries]
+if missing:
+    raise SystemExit("no checksum for required Enterprise assets: " + ", ".join(missing))
+PY
+		sha256sum --ignore-missing -c SHA256SUMS
+		sha256sum "${archive}" MANIFEST.json >SHA256SUMS.stored
+		mv SHA256SUMS.stored SHA256SUMS
 	)
 	exit 0
 fi

--- a/.github/scripts/stage-enterprise-release.sh
+++ b/.github/scripts/stage-enterprise-release.sh
@@ -54,22 +54,20 @@ import re
 import sys
 
 payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
-names = sorted(item["name"] for item in payload["assets"] if not item["name"].startswith("_internal-"))
+names = [item["name"] for item in payload["assets"]]
 archives = [name for name in names if re.fullmatch(r"hyperfilelens-[0-9]+\.[0-9]+\.[0-9]+-ee\.tar\.gz", name)]
 required = {"SHA256SUMS", "MANIFEST.json"}
 if len(archives) != 1 or not required.issubset(names):
     raise SystemExit("temporary Enterprise candidate is incomplete or ambiguous")
-for name in names:
+selected = ["MANIFEST.json", "SHA256SUMS", archives[0]]
+for name in selected:
     if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]*", name):
         raise SystemExit(f"unsafe Enterprise release asset name: {name}")
-for name in names:
-    if name not in archives:
-        print(name)
-for name in archives:
+for name in selected:
     print(name)
 PY
 )
-(( ${#assets[@]} >= 3 )) || { printf 'ERROR: Enterprise asset list is empty\n' >&2; exit 1; }
+[[ "${#assets[@]}" -eq 3 ]] || { printf 'ERROR: Enterprise asset list is invalid\n' >&2; exit 1; }
 
 install -d -m 0700 ~/.ssh
 printf '%s\n' "${TEST_SSH_KNOWN_HOSTS}" >~/.ssh/known_hosts
@@ -102,15 +100,17 @@ PY
 )"
 	asset_staged=false
 	for attempt in 1 2 3; do
+		request_nonce="$(date +%s%N)"
 		signed_url="$(curl -fsSI \
 			-H 'Accept: application/octet-stream' \
+			-H 'Cache-Control: no-cache' \
 			-H "Authorization: Bearer ${GH_TOKEN}" \
-			"${api_url}" \
+			"${api_url}?hfl_nonce=${request_nonce}" \
 			| awk 'BEGIN { IGNORECASE=1 } /^location:/ { sub(/\r$/, "", $2); print $2; exit }')"
 		python3 - "${asset}" "${signed_url}" >"${plan}" <<'PY'
 import sys
 import urllib.parse
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 
 asset, url = sys.argv[1:]
 parts = urllib.parse.urlsplit(url)
@@ -123,8 +123,8 @@ try:
     expires_at = datetime.fromisoformat(expires.replace("Z", "+00:00"))
 except ValueError as error:
     raise SystemExit("GitHub asset download URL has no valid expiry") from error
-if expires_at < datetime.now(timezone.utc) + timedelta(minutes=50):
-    raise SystemExit("GitHub asset download URL expires too soon")
+if expires_at <= datetime.now(timezone.utc):
+    raise SystemExit("GitHub asset download URL is already expired")
 print(f"{asset}\t{url}")
 PY
 		plan_base64="$(base64 -w 0 "${plan}")"

--- a/tools/quality/test-enterprise-release-flow.sh
+++ b/tools/quality/test-enterprise-release-flow.sh
@@ -114,7 +114,10 @@ grep -F '<.github/scripts/download-enterprise-release.sh' "${transfer}" >/dev/nu
 grep -F 'for attempt in 1 2 3' "${transfer}" >/dev/null
 grep -F 'refreshing URL' "${transfer}" >/dev/null
 grep -F 'run_remote verify' "${transfer}" >/dev/null
-grep -F 'if name not in archives:' "${transfer}" >/dev/null
+grep -F 'selected = ["MANIFEST.json", "SHA256SUMS", archives[0]]' "${transfer}" >/dev/null
+grep -F -- "-H 'Cache-Control: no-cache'" "${transfer}" >/dev/null
+grep -F '?hfl_nonce=${request_nonce}' "${transfer}" >/dev/null
+grep -F 'GitHub asset download URL is already expired' "${transfer}" >/dev/null
 if grep -F 'scp ' "${transfer}" >/dev/null; then
 	printf 'ERROR: Enterprise package staging must not copy release assets over SSH\n' >&2
 	exit 1
@@ -123,7 +126,9 @@ downloader="${ROOT}/.github/scripts/download-enterprise-release.sh"
 grep -F -- '--proxy "${download_proxy}"' "${downloader}" >/dev/null
 grep -F -- '--continue-at -' "${downloader}" >/dev/null
 grep -F -- '--max-time 3000' "${downloader}" >/dev/null
-grep -F 'sha256sum -c SHA256SUMS' "${downloader}" >/dev/null
+grep -F 'sha256sum --ignore-missing -c SHA256SUMS' "${downloader}" >/dev/null
+grep -F 'sha256sum "${archive}" MANIFEST.json >SHA256SUMS.stored' \
+	"${downloader}" >/dev/null
 grep -F 'Download release candidate from temporary draft' "${workflow}" >/dev/null
 python3 - "${workflow}" <<'PY'
 import pathlib


### PR DESCRIPTION
## Summary
- stage only the three Enterprise assets retained by TEST: package, manifest, and checksums
- request a non-cached private asset URL immediately before each target-side download
- reject only already-expired URLs and refresh on transfer failure
- verify the retained subset and rewrite its authoritative checksum file before immutable storage

## Root cause
v0.1.33 rejected a valid GitHub asset URL because the local 50-minute remaining-lifetime policy was stricter than GitHub's variable signed-URL lifetime. It also attempted to stage attachments that TEST immediately discards.

## Validation
- `./tools/quality/test-enterprise-release-flow.sh`
- `./tools/quality/check-release-contracts.sh`
- Enterprise synthetic release assembly
- Shell syntax checks and `git diff --check`