### PR TITLE
fix(release): delete draft without temporary tag

### DIFF
--- a/.github/workflows/artifact_pipeline.yml
+++ b/.github/workflows/artifact_pipeline.yml
@@ -1206,7 +1206,7 @@ jobs:
               -p "$TEST_SSH_PORT" "$TEST_SSH_USER@$TEST_SSH_HOST" \
               "bash -s -- '$RELEASE_TAG' '$incoming' /root/hfl-release 10" \
               < .github/scripts/store-enterprise-release.sh
-            gh release delete "$ARTIFACT_ID" --repo "$GITHUB_REPOSITORY" --cleanup-tag --yes
+            gh release delete "$ARTIFACT_ID" --repo "$GITHUB_REPOSITORY" --yes
             {
               echo 'deployable=true'
               echo 'disposition=stored-on-test-host'
@@ -1418,5 +1418,5 @@ jobs:
             -p "$TEST_SSH_PORT" "$TEST_SSH_USER@$TEST_SSH_HOST" \
             "rm -rf -- '/root/hfl-release/.incoming/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}'" \
             || true
-          gh release delete "$ARTIFACT_ID" --repo "$GITHUB_REPOSITORY" --cleanup-tag --yes \
+          gh release delete "$ARTIFACT_ID" --repo "$GITHUB_REPOSITORY" --yes \
             || true

--- a/tools/quality/test-enterprise-release-flow.sh
+++ b/tools/quality/test-enterprise-release-flow.sh
@@ -183,6 +183,11 @@ grep -F 'Enterprise release package has an invalid extension_commit' \
 grep -F '"ls-remote"' "${workflow}" >/dev/null
 grep -F 'f"refs/tags/{tag}"' "${workflow}" >/dev/null
 grep -F 'gh release delete "$ARTIFACT_ID"' "${workflow}" >/dev/null
+if grep -F 'gh release delete "$ARTIFACT_ID"' "${workflow}" \
+	| grep -F -- '--cleanup-tag' >/dev/null; then
+	printf 'ERROR: temporary Enterprise releases have no Git tag to clean up\n' >&2
+	exit 1
+fi
 
 # Exercise the target-side downloader without network access. The fake curl
 # records its arguments and materializes the two expected assets, proving that


### PR DESCRIPTION
## Summary
- delete the temporary Enterprise Draft Release without requesting Git tag deletion
- apply the same semantics to failure cleanup
- add a contract preventing `--cleanup-tag` from returning

## Root cause
v0.1.34 downloaded, verified, and stored the Enterprise package successfully. The job failed only because `gh release delete --cleanup-tag` tried to delete a temporary Git ref that is intentionally never created, returning HTTP 422.

## Validation
- `./tools/quality/test-enterprise-release-flow.sh`
- `./tools/quality/check-release-contracts.sh`
- Shell syntax check and `git diff --check`