### PR TITLE
fix(frontend): show task source connectivity

### DIFF
--- a/src/frontend/src/lib/taskBackupSourceResource.ts
+++ b/src/frontend/src/lib/taskBackupSourceResource.ts
@@ -10,6 +10,7 @@ export type TaskBackupSourceResourceDisplay = {
   registeredAt: string
   status: string
   statusValue: string
+  availability?: 'online' | 'offline'
   flowSource: FlowSourceRow
 }
 
@@ -55,7 +56,7 @@ export function resolveTaskBackupSourceResourceFromPayload(
       hostname: sourceName,
       nodeName: sourceName,
       nodeIp: '',
-      status: 'offline',
+      status: 'removed',
       registeredAt: String(cleanupSource.registered_at || ''),
       type: sourceKind === 'agent' ? 'host' : 'nas',
     }
@@ -66,6 +67,7 @@ export function resolveTaskBackupSourceResourceFromPayload(
       registeredAt: String(cleanupSource.registered_at || ''),
       status: 'unregistered',
       statusValue: 'unregistered',
+      availability: undefined,
       flowSource,
     }
   }
@@ -83,7 +85,7 @@ export function resolveTaskBackupSourceResourceFromPayload(
       hostname: orphanName,
       nodeName: orphanName,
       nodeIp: '',
-      status: 'offline',
+      status: 'removed',
       registeredAt: '',
       type: sourceKind === 'agent' ? 'host' : 'nas',
     }
@@ -94,6 +96,7 @@ export function resolveTaskBackupSourceResourceFromPayload(
       registeredAt: '',
       status: 'unregistered',
       statusValue: 'unregistered',
+      availability: undefined,
       flowSource,
     }
   }
@@ -113,7 +116,7 @@ export function resolveTaskBackupSourceResourceFromPayload(
       hostname: sourceName,
       nodeName: sourceName,
       nodeIp: '',
-      status: 'offline',
+      status: 'removed',
       registeredAt: '',
       type: sourceKind === 'agent' ? 'host' : 'nas',
     }
@@ -124,6 +127,7 @@ export function resolveTaskBackupSourceResourceFromPayload(
       registeredAt: '',
       status: 'unregistered',
       statusValue: 'unregistered',
+      availability: undefined,
       flowSource,
     }
   }
@@ -155,7 +159,8 @@ export async function resolveTaskBackupSourceResource(
       hostname,
       nodeName: node.name || EMPTY,
       nodeIp: node.ip_address || '',
-      status: node.status === 'online' ? 'online' : 'offline',
+      status: node.status,
+      availability: node.availability,
       registeredAt: node.created_at || '',
       type: 'host',
       platform,
@@ -167,6 +172,7 @@ export async function resolveTaskBackupSourceResource(
       registeredAt: node.created_at || '',
       status: node.status || '',
       statusValue: node.status || '',
+      availability: node.availability,
       flowSource,
     }
   }
@@ -182,7 +188,8 @@ export async function resolveTaskBackupSourceResource(
     hostname: source.name || EMPTY,
     nodeName: boundNode?.name || source.bound_node_name || '',
     nodeIp: boundNode?.ip_address || '',
-    status: source.status === 'online' || source.status === 'active' ? 'online' : 'offline',
+    status: (source.status || 'inactive') as FlowSourceRow['status'],
+    availability: source.availability,
     registeredAt: source.created_at || '',
     type: 'nas',
     protocol,
@@ -197,6 +204,7 @@ export async function resolveTaskBackupSourceResource(
     registeredAt: source.created_at || '',
     status: source.status_display || source.status || '',
     statusValue: source.status || '',
+    availability: source.availability,
     flowSource,
   }
 }

--- a/src/frontend/src/pages/ops/Tasks.vue
+++ b/src/frontend/src/pages/ops/Tasks.vue
@@ -166,6 +166,7 @@ type ResourceDetailRow = {
   endpointName?: string
   endpointIp?: string
   registeredAt?: string
+  availability?: 'online' | 'offline'
   flowSource?: Awaited<ReturnType<typeof resolveTaskBackupSourceResource>>['flowSource']
 }
 
@@ -600,6 +601,16 @@ function resourceSummary(raw: unknown) {
   ].filter(Boolean).join(' · ')
 }
 
+function backupSourceConnectivityLabel(value?: string) {
+  return value === 'online'
+    ? t('protection.sourceResources.nodeStatusOnline')
+    : t('protection.sourceResources.nodeStatusOffline')
+}
+
+function backupSourceConnectivityTagType(value?: string): 'success' | 'danger' {
+  return value === 'online' ? 'success' : 'danger'
+}
+
 function normalizeResourceDetail(type: string, id: number, raw: unknown, source?: Awaited<ReturnType<typeof resolveTaskBackupSourceResource>>): ResourceDetailRow {
   const record = raw && typeof raw === 'object' ? raw as Record<string, unknown> : {}
   const rawType = objectValue(record, ['resource_type', 'repo_type', 'role', 'snapshot_type'])
@@ -617,6 +628,7 @@ function normalizeResourceDetail(type: string, id: number, raw: unknown, source?
     endpointName: source?.endpointName || objectValue(record, ['hostname', 'name', 'display_name']),
     endpointIp: source?.endpointIp || objectValue(record, ['ip_address', 'endpoint']),
     registeredAt: source?.registeredAt || objectValue(record, ['created_at']),
+    availability: source?.availability,
     flowSource: source?.flowSource,
   }
 }
@@ -1719,9 +1731,25 @@ watch(
                   </ElTag>
                 </template>
               </el-table-column>
-              <el-table-column :label="t('ops.task.colStatus')" :width="isRepositoryResourceType ? 165 : 110">
+              <el-table-column
+                :label="selectedResourceType === 'backup_source'
+                  ? t('protection.sourceResources.colConnectivity')
+                  : t('ops.task.colStatus')"
+                :width="isRepositoryResourceType ? 165 : 110"
+              >
                 <template #default="{ row }">
-                  <ElTag v-if="row.status" v-bind="lifecycleStatusTagAttrs(row.statusValue)" size="small">
+                  <ElTag
+                    v-if="selectedResourceType === 'backup_source' && row.availability"
+                    :type="backupSourceConnectivityTagType(row.availability)"
+                    size="small"
+                  >
+                    {{ backupSourceConnectivityLabel(row.availability) }}
+                  </ElTag>
+                  <ElTag
+                    v-else-if="selectedResourceType !== 'backup_source' && row.status"
+                    v-bind="lifecycleStatusTagAttrs(row.statusValue)"
+                    size="small"
+                  >
                     {{ row.status }}
                   </ElTag>
                   <span v-else class="hfl-empty-mark">—</span>

--- a/src/frontend/src/pages/protection/components/FlowBackupSourceDetailDrawer.vue
+++ b/src/frontend/src/pages/protection/components/FlowBackupSourceDetailDrawer.vue
@@ -158,6 +158,7 @@ type ResourceDetailRow = {
   endpointName?: string
   endpointIp?: string
   registeredAt?: string
+  availability?: 'online' | 'offline'
   flowSource?: Awaited<ReturnType<typeof resolveTaskBackupSourceResource>>['flowSource']
 }
 
@@ -1118,6 +1119,7 @@ function normalizeResourceDetail(type: string, id: number, raw: unknown, source?
     endpointName: source?.endpointName,
     endpointIp: source?.endpointIp,
     registeredAt: source?.registeredAt,
+    availability: source?.availability,
     flowSource: source?.flowSource,
   }
 }
@@ -4267,9 +4269,26 @@ function onClosed() {
                 </ElTag>
               </template>
             </el-table-column>
-            <el-table-column :label="t('ops.task.colStatus')" width="120">
+            <el-table-column
+              :label="selectedResourceType === 'backup_source'
+                ? t('protection.sourceResources.colConnectivity')
+                : t('ops.task.colStatus')"
+              width="120"
+            >
               <template #default="{ row }">
-                <ElTag v-if="row.status" v-bind="lifecycleStatusTagAttrs(row.statusValue)" size="small">
+                <ElTag
+                  v-if="selectedResourceType === 'backup_source' && row.availability"
+                  :type="flowSourceStatusTagType(row.availability)"
+                  :class="{ 'hfl-tag--neutral': flowSourceStatusTag(row.availability) === 'neutral' }"
+                  size="small"
+                >
+                  {{ flowSourceStatusLabel(row.availability) }}
+                </ElTag>
+                <ElTag
+                  v-else-if="selectedResourceType !== 'backup_source' && row.status"
+                  v-bind="lifecycleStatusTagAttrs(row.statusValue)"
+                  size="small"
+                >
                   {{ row.status }}
                 </ElTag>
                 <span v-else class="hfl-empty-mark">—</span>

--- a/src/frontend/src/pages/protection/components/TaskDetailDrawer.vue
+++ b/src/frontend/src/pages/protection/components/TaskDetailDrawer.vue
@@ -41,7 +41,6 @@ import {
   canCancelRepositoryTask,
 } from '../../../lib/repositoryTaskCancellation'
 import { taskResourceSnapshot } from '../../../lib/taskOutcomeDisplay'
-import { lifecycleStatusTagAttrs } from '../../../lib/statusTag'
 import { resolveTaskBackupSourceResource, resolveTaskBackupSourceResourceFromPayload } from '../../../lib/taskBackupSourceResource'
 import { parseTaskStepStatusEvent, taskEventMessageKey, taskEventObjectText } from '../../../lib/taskEventDisplay'
 import { hasExpandableTaskStep, hasExpandedTaskStep } from '../../../lib/taskStepExpansion'
@@ -90,6 +89,7 @@ const backupSourceRows = ref<Array<{
   endpointIp: string
   status: string
   statusValue: string
+  availability?: 'online' | 'offline'
   registeredAt: string
   flowSource: Awaited<ReturnType<typeof resolveTaskBackupSourceResource>>['flowSource']
 }>>([])
@@ -222,6 +222,16 @@ function valueLabel(value?: string | null) {
   if (!value) return t('ops.task.emptyMark')
   const key = `ops.task.resourceValue.${value}`
   return te(key) ? t(key) : t('ops.task.unknownValue')
+}
+
+function backupSourceConnectivityLabel(value?: string) {
+  return value === 'online'
+    ? t('protection.sourceResources.nodeStatusOnline')
+    : t('protection.sourceResources.nodeStatusOffline')
+}
+
+function backupSourceConnectivityTagType(value?: string): 'success' | 'danger' {
+  return value === 'online' ? 'success' : 'danger'
 }
 
 function progressValue(row: TaskRow) {
@@ -1027,9 +1037,15 @@ watch(
               <FlowSourceConnectionCell :row="row.flowSource" />
             </template>
           </el-table-column>
-          <el-table-column :label="t('ops.task.colStatus')" width="110">
+          <el-table-column :label="t('protection.sourceResources.colConnectivity')" width="110">
             <template #default="{ row }">
-              <ElTag v-if="row.status" v-bind="lifecycleStatusTagAttrs(row.statusValue)" size="small">{{ row.status }}</ElTag>
+              <ElTag
+                v-if="row.availability"
+                :type="backupSourceConnectivityTagType(row.availability)"
+                size="small"
+              >
+                {{ backupSourceConnectivityLabel(row.availability) }}
+              </ElTag>
               <span v-else class="hfl-empty-mark">{{ t('ops.task.emptyMark') }}</span>
             </template>
           </el-table-column>

--- a/src/frontend/src/styles/taskDetailBackupSourceConnectivity.test.ts
+++ b/src/frontend/src/styles/taskDetailBackupSourceConnectivity.test.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const files = [
+  'src/pages/ops/Tasks.vue',
+  'src/pages/protection/components/TaskDetailDrawer.vue',
+  'src/pages/protection/components/FlowBackupSourceDetailDrawer.vue',
+]
+
+describe('task detail backup source resource columns', () => {
+  it.each(files)('%s uses Connectivity and source availability', (file) => {
+    const source = readFileSync(resolve(process.cwd(), file), 'utf8')
+    const resourcesTab = source.slice(source.indexOf('<ElTabPane name="resources">'))
+
+    expect(resourcesTab).toContain('protection.sourceResources.colConnectivity')
+    expect(resourcesTab).toContain('row.availability')
+    expect(resourcesTab).not.toContain('row.flowSource.availability')
+  })
+
+  it.each([
+    'src/pages/ops/Tasks.vue',
+    'src/pages/protection/components/FlowBackupSourceDetailDrawer.vue',
+  ])('%s never falls back to lifecycle status for Backup Source connectivity', (file) => {
+    const source = readFileSync(resolve(process.cwd(), file), 'utf8')
+    const resourcesTab = source.slice(source.indexOf('<ElTabPane name="resources">'))
+
+    expect(resourcesTab).toContain("v-else-if=\"selectedResourceType !== 'backup_source' && row.status\"")
+  })
+})


### PR DESCRIPTION
## Summary

- rename the Backup Source resource Status column to Connectivity across all task detail surfaces
- derive connectivity exclusively from the API `availability` field instead of lifecycle `status`
- show an empty value when historical or removed sources do not provide availability
- preserve lifecycle Status behavior for non-Backup Source resource types

## Validation

- Manual testing: passed
- `node node_modules/vitest/vitest.mjs run src/styles/taskDetailBackupSourceConnectivity.test.ts src/styles/relatedBackupSourceColumns.test.ts`
- `node node_modules/eslint/bin/eslint.js --quiet src/lib/taskBackupSourceResource.ts src/pages/ops/Tasks.vue src/pages/protection/components/FlowBackupSourceDetailDrawer.vue src/pages/protection/components/TaskDetailDrawer.vue src/styles/taskDetailBackupSourceConnectivity.test.ts`
- `node node_modules/vue-tsc/bin/vue-tsc.js --noEmit`
- `node node_modules/vite/bin/vite.js build`
- `python3 tools/quality/check-english-source.py`
- `git diff --check origin/main...HEAD`
