### PR TITLE
fix(upgrade): make session migration and recovery atomic

### DIFF
--- a/deploy/installer/install.sh
+++ b/deploy/installer/install.sh
@@ -230,7 +230,10 @@ recover_upgrade_services() {
 			&& -n "${UPGRADE_LEGACY_API_CID}" \
 			&& "$(docker inspect --format '{{.State.Running}}' "${UPGRADE_LEGACY_API_CID}" 2>/dev/null || true)" == "true" ]]; then
 			compose_in_root up -d --no-build --no-recreate postgres redis
-			compose_in_root up -d --no-build worker scheduler
+			# The pre-upgrade singleton containers still carry the previous image.
+			# Starting them preserves one coherent rollback release; `up` would
+			# recreate them from the already-staged target image metadata.
+			compose_in_root start worker scheduler
 			[[ $? -eq 0 ]] || recovered=0
 			restore_previous_hfl_color legacy "${UPGRADE_TARGET_COLOR}"
 			[[ $? -eq 0 ]] || recovered=0
@@ -238,14 +241,19 @@ recover_upgrade_services() {
 			# Files and APP_VERSION already describe the target release.  `up`
 			# would therefore recreate the still-valid previous-color containers
 			# with the target image and destroy the rollback path.  Start only
-			# existing stable/color containers; worker and scheduler are singleton
-			# consumers and may safely converge to the target release.
+			# existing stable/color containers. Before commit, worker and scheduler
+			# must also remain on the previous release so API and background code do
+			# not run different schema/application contracts.
 			compose_in_root start postgres redis nginx
 			[[ $? -eq 0 ]] || recovered=0
 			compose_color "${recovery_color}" start \
 				"api-${recovery_color}" "web-${recovery_color}"
 			[[ $? -eq 0 ]] || recovered=0
-			compose_in_root up -d --no-build worker scheduler
+			if [[ "${UPGRADE_HFL_COMMITTED}" == "1" ]]; then
+				compose_in_root up -d --no-build worker scheduler
+			else
+				compose_in_root start worker scheduler
+			fi
 			[[ $? -eq 0 ]] || recovered=0
 			if [[ "${UPGRADE_HFL_COMMITTED}" == "1" ]]; then
 				render_active_upstreams "${recovery_color}"

--- a/src/backend/apps/lens_bridge/migrations/0031_session_create_and_capacity_state.py
+++ b/src/backend/apps/lens_bridge/migrations/0031_session_create_and_capacity_state.py
@@ -145,10 +145,6 @@ class Migration(migrations.Migration):
             name="capacity_reserved_at",
             field=models.DateTimeField(blank=True, null=True),
         ),
-        migrations.RunPython(
-            prepare_incomplete_session_reservations,
-            migrations.RunPython.noop,
-        ),
         migrations.AddConstraint(
             model_name="lenssessionlink",
             constraint=models.UniqueConstraint(
@@ -159,5 +155,12 @@ class Migration(migrations.Migration):
                 fields=("organization", "hfl_user", "create_idempotency_key"),
                 name="uniq_lens_session_create_key",
             ),
+        ),
+        # PostgreSQL cannot create the constraint's backing index while the
+        # preceding data updates have pending deferred trigger events. Keep all
+        # schema DDL before the backfill so this migration remains atomic.
+        migrations.RunPython(
+            prepare_incomplete_session_reservations,
+            migrations.RunPython.noop,
         ),
     ]

--- a/src/backend/apps/lens_bridge/tests/test_session_capacity_migration.py
+++ b/src/backend/apps/lens_bridge/tests/test_session_capacity_migration.py
@@ -1,0 +1,102 @@
+from django.conf import settings
+from django.db import IntegrityError, connection, transaction
+from django.db.migrations.executor import MigrationExecutor
+from django.test import TransactionTestCase
+
+
+class SessionCapacityMigrationTests(TransactionTestCase):
+    migrate_from = [
+        ("lens_bridge", "0030_lens_run_submission"),
+    ]
+    migrate_to = [
+        ("lens_bridge", "0031_session_create_and_capacity_state"),
+    ]
+
+    def setUp(self):
+        super().setUp()
+        executor = MigrationExecutor(connection)
+        executor.migrate(self.migrate_from)
+        old_apps = executor.loader.project_state(self.migrate_from).apps
+        self._seed_legacy_sessions(old_apps)
+
+        executor = MigrationExecutor(connection)
+        executor.migrate(self.migrate_to)
+        self.apps = executor.loader.project_state(self.migrate_to).apps
+
+    def tearDown(self):
+        executor = MigrationExecutor(connection)
+        executor.migrate(executor.loader.graph.leaf_nodes())
+        super().tearDown()
+
+    def _seed_legacy_sessions(self, apps):
+        app_label, model_name = settings.AUTH_USER_MODEL.split(".")
+        User = apps.get_model(app_label, model_name)
+        Organization = apps.get_model("iam", "Organization")
+        LensSessionLink = apps.get_model("lens_bridge", "LensSessionLink")
+
+        self.user_id = User.objects.create(
+            username="session-migration@example.test",
+            email="session-migration@example.test",
+        ).id
+        self.organization_id = Organization.objects.create(
+            key="session-capacity-migration",
+            name="Session capacity migration",
+        ).id
+
+        common = {
+            "organization_id": self.organization_id,
+            "hfl_user_id": self.user_id,
+        }
+        self.ready_id = LensSessionLink.objects.create(
+            **common,
+            lifecycle_status="ready",
+            source_scopes_json=[],
+        ).id
+        self.resolved_id = LensSessionLink.objects.create(
+            **common,
+            lifecycle_status="provisioning",
+            source_scopes_json=[
+                {"path_type": "file", "file_count": 1, "size_bytes": 42},
+            ],
+        ).id
+        self.pending_id = LensSessionLink.objects.create(
+            **common,
+            lifecycle_status="failed",
+            source_scopes_json=[
+                {"path_type": "file", "file_count": 2, "size_bytes": 42},
+            ],
+        ).id
+
+    def test_schema_and_legacy_capacity_state_are_migrated(self):
+        LensSessionLink = self.apps.get_model(
+            "lens_bridge",
+            "LensSessionLink",
+        )
+
+        ready = LensSessionLink.objects.get(pk=self.ready_id)
+        resolved = LensSessionLink.objects.get(pk=self.resolved_id)
+        pending = LensSessionLink.objects.get(pk=self.pending_id)
+
+        self.assertEqual(ready.scope_resolution_status, "resolved")
+        self.assertEqual(ready.capacity_reservation_status, "released")
+        self.assertEqual(resolved.scope_resolution_status, "resolved")
+        self.assertEqual(resolved.capacity_reservation_status, "pending")
+        self.assertEqual(pending.scope_resolution_status, "pending")
+        self.assertEqual(pending.capacity_reservation_status, "pending")
+        self.assertEqual(pending.capacity_reserved_bytes, 0)
+        self.assertIsNone(pending.capacity_reserved_at)
+
+    def test_active_create_idempotency_key_is_unique_per_user_and_org(self):
+        LensSessionLink = self.apps.get_model(
+            "lens_bridge",
+            "LensSessionLink",
+        )
+        common = {
+            "organization_id": self.organization_id,
+            "hfl_user_id": self.user_id,
+            "create_idempotency_key": "same-create-request",
+        }
+
+        LensSessionLink.objects.create(**common)
+        with self.assertRaises(IntegrityError), transaction.atomic():
+            LensSessionLink.objects.create(**common)

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -869,6 +869,7 @@ if grep -E 'compose_color .* up .*api-' <<<"${recovery_body}" >/dev/null; then
 	exit 1
 fi
 grep -F 'compose_color "${recovery_color}" start' <<<"${recovery_body}" >/dev/null
+grep -F 'compose_in_root start worker scheduler' <<<"${recovery_body}" >/dev/null
 grep -F './tools/quality/test-blue-green-recovery.sh' "${workflow}" >/dev/null
 grep -F './tools/quality/test-sourcelens-runtime-sync.sh' "${workflow}" >/dev/null
 grep -F './tools/quality/test-sourcelens-runtime-fingerprint.sh' "${workflow}" >/dev/null

--- a/tools/quality/test-blue-green-recovery.sh
+++ b/tools/quality/test-blue-green-recovery.sh
@@ -64,12 +64,15 @@ recover_upgrade_services
 [[ " ${calls[*]} " == *" render:blue "* ]]
 [[ " ${calls[*]} " == *" active:blue "* ]]
 [[ " ${calls[*]} " != *" active:green "* ]]
+[[ " ${calls[*]} " == *" compose:start worker scheduler "* ]]
+[[ " ${calls[*]} " != *" compose:up -d --no-build worker scheduler "* ]]
 
 calls=()
 UPGRADE_HFL_COMMITTED=1
 recover_upgrade_services
 [[ " ${calls[*]} " == *" render:green "* ]]
 [[ " ${calls[*]} " == *" active:green "* ]]
+[[ " ${calls[*]} " == *" compose:up -d --no-build worker scheduler "* ]]
 
 calls=()
 UPGRADE_HFL_CUTOVER_ATTEMPTED=1


### PR DESCRIPTION
## Summary
- order the session capacity migration so PostgreSQL completes constraint DDL before legacy-row updates
- add a real 0030-to-0031 migration regression test with existing session data
- preserve the previous worker and scheduler images when an upgrade fails before commit

## Validation
- PostgreSQL migration test: 0030 -> 0031 (2 tests)
- ./tools/quality/test-blue-green-recovery.sh
- ./tools/quality/check-release-contracts.sh
- ./tools/quality/test-enterprise-release-flow.sh
- ruff, compileall, bash -n, git diff --check