### PR TITLE
Unify inline form validation

### DIFF
--- a/src/frontend/src/composables/useInlineFormValidation.test.ts
+++ b/src/frontend/src/composables/useInlineFormValidation.test.ts
@@ -1,0 +1,48 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vitest'
+import { nextTick, ref } from 'vue'
+import { useInlineFormValidation } from './useInlineFormValidation'
+
+describe('useInlineFormValidation', () => {
+  it('renders errors, locates the first invalid field, and clears a corrected field', async () => {
+    const root = document.createElement('div')
+    root.innerHTML = '<div data-validation-field="name"><input /></div><div data-validation-field="bucket"><input /></div>'
+    const nameField = root.querySelector<HTMLElement>('[data-validation-field="name"]')!
+    const input = nameField.querySelector<HTMLInputElement>('input')!
+    nameField.scrollIntoView = vi.fn()
+    input.focus = vi.fn()
+    const validation = useInlineFormValidation(ref(root))
+
+    expect(validation.validate([
+      { field: 'name', message: 'Name is required', valid: false },
+      { field: 'bucket', message: 'Bucket is required', valid: false },
+    ])).toBe(false)
+    await nextTick()
+    await new Promise((resolve) => window.setTimeout(resolve, 250))
+
+    expect(validation.errors).toEqual({ name: 'Name is required', bucket: 'Bucket is required' })
+    expect(nameField.scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth', block: 'center' })
+    expect(input.focus).toHaveBeenCalledWith({ preventScroll: true })
+
+    validation.clear('name')
+    expect(validation.errors).toEqual({ bucket: 'Bucket is required' })
+  })
+
+  it('skips an identically named field hidden by a conditional form', async () => {
+    const root = document.createElement('div')
+    root.innerHTML = '<div style="display: none"><div data-validation-field="name"><input /></div></div><div data-validation-field="name"><input /></div>'
+    const hiddenField = root.querySelector<HTMLElement>('[style] [data-validation-field="name"]')!
+    const visibleField = root.querySelectorAll<HTMLElement>('[data-validation-field="name"]')[1]
+    hiddenField.scrollIntoView = vi.fn()
+    visibleField.scrollIntoView = vi.fn()
+    visibleField.querySelector<HTMLInputElement>('input')!.focus = vi.fn()
+    const validation = useInlineFormValidation(ref(root))
+
+    validation.validate([{ field: 'name', message: 'Name is required', valid: false }])
+    await nextTick()
+    await new Promise((resolve) => window.setTimeout(resolve, 250))
+
+    expect(hiddenField.scrollIntoView).not.toHaveBeenCalled()
+    expect(visibleField.scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth', block: 'center' })
+  })
+})

--- a/src/frontend/src/composables/useInlineFormValidation.ts
+++ b/src/frontend/src/composables/useInlineFormValidation.ts
@@ -1,0 +1,54 @@
+import { nextTick, reactive, type Ref } from 'vue'
+
+export type InlineValidationRule = {
+  field: string
+  message: string
+  valid: boolean
+}
+
+/**
+ * Shared client-side required-field validation for long forms.
+ *
+ * Keep server and workflow errors in their existing presentation; this is
+ * intentionally only for fields a user can correct in the current form.
+ */
+export function useInlineFormValidation(root: Ref<HTMLElement | null>) {
+  const errors = reactive<Record<string, string>>({})
+
+  function clear(field: string) {
+    delete errors[field]
+  }
+
+  function locate(field: string) {
+    void nextTick(() => {
+      const fields = root.value?.querySelectorAll<HTMLElement>(`[data-validation-field="${field}"]`)
+      const fieldEl = fields && [...fields].find((candidate) => {
+        let current: HTMLElement | null = candidate
+        while (current) {
+          const style = window.getComputedStyle(current)
+          if (style.display === 'none' || style.visibility === 'hidden') return false
+          if (current === root.value) break
+          current = current.parentElement
+        }
+        return true
+      })
+      if (!fieldEl) return
+      fieldEl.scrollIntoView({ behavior: 'smooth', block: 'center' })
+      window.setTimeout(() => {
+        fieldEl.querySelector<HTMLElement>(
+          'input:not([type="hidden"]), textarea, button, [tabindex]:not([tabindex="-1"])',
+        )?.focus({ preventScroll: true })
+      }, 240)
+    })
+  }
+
+  function validate(rules: InlineValidationRule[]) {
+    for (const key of Object.keys(errors)) delete errors[key]
+    const invalid = rules.filter((rule) => !rule.valid)
+    for (const rule of invalid) errors[rule.field] = rule.message
+    if (invalid[0]) locate(invalid[0].field)
+    return invalid.length === 0
+  }
+
+  return { clear, errors, validate }
+}

--- a/src/frontend/src/pages/insight/AssistantFormPage.vue
+++ b/src/frontend/src/pages/insight/AssistantFormPage.vue
@@ -12,6 +12,7 @@ import { useI18n } from 'vue-i18n'
 import { ArrowLeft, Plus, RefreshCw } from 'lucide-vue-next'
 import { ElMessage } from 'element-plus'
 import { apiErrorMessage } from '../../lib/api'
+import { useInlineFormValidation } from '../../composables/useInlineFormValidation'
 import { routeLocationWithListRefresh } from '../../lib/listRouteRefresh'
 import HflBooleanStatusTag from '../../components/HflBooleanStatusTag.vue'
 import {
@@ -41,6 +42,8 @@ const isEditing = computed(() => Boolean(editingUuid.value))
 
 const loading = ref(false)
 const saving = ref(false)
+const pageRef = ref<HTMLElement | null>(null)
+const { clear: clearFieldError, errors, validate: validateInline } = useInlineFormValidation(pageRef)
 const modelsRefreshing = ref(false)
 const formOptionsRefreshing = ref(false)
 const formOptions = ref<LensAssistantFormOptions | null>(null)
@@ -388,7 +391,14 @@ function buildPayload() {
 }
 
 async function handleSubmit() {
-  if (!canSubmit.value || saving.value) return
+  if (saving.value) return
+  if (!validateInline([
+    { field: 'name', message: t('insight.assistants.fieldName'), valid: !!name.value.trim() },
+    { field: 'agentModel', message: t('insight.assistants.fieldAgentModel'), valid: !!agentModelRef.value },
+    { field: 'maxConcurrency', message: t('insight.assistants.fieldMaxConcurrency'), valid: Number(maxConcurrency.value) >= 1 && Number(maxConcurrency.value) <= 50 },
+    { field: 'knowledgeSource', message: t('insight.assistants.fieldKnowledgeSource'), valid: !!knowledgeSourceId.value },
+    { field: 'scenario', message: t('insight.assistants.fieldScenario'), valid: !!selectedTask.value },
+  ])) return
   saving.value = true
   try {
     const payload = buildPayload()
@@ -421,7 +431,7 @@ watch(
 </script>
 
 <template>
-  <div class="fullscreen-form-fullscreen resource-add-fullscreen assistant-form-fullscreen">
+  <div ref="pageRef" class="fullscreen-form-fullscreen resource-add-fullscreen assistant-form-fullscreen">
     <div class="fullscreen-form-page">
       <header class="fullscreen-form-header">
         <button type="button" class="fullscreen-form-header__back" @click="handleBack">
@@ -443,17 +453,18 @@ watch(
                 {{ t('insight.assistants.sectionBasics') }}
               </h3>
               <ElForm label-position="top" class="fullscreen-form-el-form">
-                <ElFormItem :label="t('insight.assistants.fieldName')" required>
+                <ElFormItem data-validation-field="name" :error="errors.name" :label="t('insight.assistants.fieldName')" required>
                   <ElInput
                     v-model="name"
                     maxlength="120"
                     :placeholder="t('insight.assistants.fieldNamePlaceholder')"
+                    @input="clearFieldError('name')"
                   />
                   <p class="assistant-field-hint">{{ t('insight.assistants.fieldNameHint') }}</p>
                 </ElFormItem>
 
                 <div class="fullscreen-form-grid">
-                  <ElFormItem :label="t('insight.assistants.fieldAgentModel')" required>
+                  <ElFormItem data-validation-field="agentModel" :error="errors.agentModel" :label="t('insight.assistants.fieldAgentModel')" required>
                     <div class="assistant-select-row">
                       <div class="assistant-select-row__controls">
                         <ElSelect
@@ -462,6 +473,7 @@ watch(
                           class="assistant-select-row__select"
                           :loading="modelsRefreshing"
                           :placeholder="t('insight.assistants.fieldAgentModel')"
+                          @change="clearFieldError('agentModel')"
                         >
                           <ElOption
                             v-for="row in activeModels"
@@ -532,8 +544,8 @@ watch(
                   </ElFormItem>
                 </div>
 
-                <ElFormItem :label="t('insight.assistants.fieldMaxConcurrency')" required>
-                  <ElInputNumber v-model="maxConcurrency" :min="1" :max="50" class="assistant-concurrency-input" />
+                <ElFormItem data-validation-field="maxConcurrency" :error="errors.maxConcurrency" :label="t('insight.assistants.fieldMaxConcurrency')" required>
+                  <ElInputNumber v-model="maxConcurrency" :min="1" :max="50" class="assistant-concurrency-input" @change="clearFieldError('maxConcurrency')" />
                   <p class="assistant-field-hint">{{ t('insight.assistants.maxConcurrencyHint') }}</p>
                 </ElFormItem>
 
@@ -565,7 +577,7 @@ watch(
               </h3>
               <ElForm label-position="top" class="fullscreen-form-el-form">
                 <div class="fullscreen-form-grid">
-                  <ElFormItem :label="t('insight.assistants.fieldKnowledgeSource')" required>
+                  <ElFormItem data-validation-field="knowledgeSource" :error="errors.knowledgeSource" :label="t('insight.assistants.fieldKnowledgeSource')" required>
                     <div class="assistant-select-row">
                       <div class="assistant-select-row__controls">
                         <ElSelect
@@ -575,6 +587,7 @@ watch(
                           :loading="formOptionsRefreshing"
                           :placeholder="t('insight.assistants.phSelectKnowledgeSource')"
                           :disabled="selectableKnowledgeSources.length === 0 && !formOptionsRefreshing"
+                          @change="clearFieldError('knowledgeSource')"
                         >
                           <ElOption
                             v-for="row in selectableKnowledgeSources"
@@ -623,13 +636,14 @@ watch(
                     <p v-else class="assistant-field-hint">{{ t('insight.assistants.fieldKnowledgeSourceHint') }}</p>
                   </ElFormItem>
 
-                  <ElFormItem :label="t('insight.assistants.fieldScenario')" required>
+                  <ElFormItem data-validation-field="scenario" :error="errors.scenario" :label="t('insight.assistants.fieldScenario')" required>
                     <ElSelect
                       v-model="selectedTask"
                       filterable
                       class="w-full"
                       :placeholder="t('insight.assistants.phSelectScenario')"
                       :disabled="!selectedKnowledgeSource"
+                      @change="clearFieldError('scenario')"
                     >
                       <ElOption
                         v-for="task in taskOptions"
@@ -874,7 +888,7 @@ watch(
         <ElButton
           type="primary"
           :loading="saving"
-          :disabled="saving || loading || !canSubmit"
+          :disabled="saving || loading"
           @click="handleSubmit"
         >
           {{ isEditing ? t('common.save') : t('insight.assistants.btnCreate') }}

--- a/src/frontend/src/pages/insight/McpServerFormPage.vue
+++ b/src/frontend/src/pages/insight/McpServerFormPage.vue
@@ -6,6 +6,7 @@ import { useI18n } from 'vue-i18n'
 import { ArrowLeft, Plus, Trash2 } from 'lucide-vue-next'
 import { ElMessage } from 'element-plus'
 import { apiErrorMessage } from '../../lib/api'
+import { useInlineFormValidation } from '../../composables/useInlineFormValidation'
 import { routeLocationWithListRefresh } from '../../lib/listRouteRefresh'
 import {
   createLensMcpServer,
@@ -29,6 +30,8 @@ const isEditing = computed(() => Boolean(editingUuid.value))
 
 const loading = ref(false)
 const saving = ref(false)
+const pageRef = ref<HTMLElement | null>(null)
+const { clear: clearFieldError, errors, validate: validateInline } = useInlineFormValidation(pageRef)
 
 const name = ref('')
 const transport = ref<'url' | 'stdio'>('url')
@@ -131,7 +134,11 @@ function handleBack() {
 }
 
 async function handleSubmit() {
-  if (!canSubmit.value || saving.value) return
+  if (saving.value) return
+  if (!validateInline([
+    { field: 'name', message: t('insight.mcpServers.fieldName'), valid: !!name.value.trim() },
+    { field: 'endpoint', message: t('insight.mcpServers.fieldEndpoint'), valid: !!endpoint.value.trim() },
+  ])) return
   saving.value = true
   try {
     const payload = buildPayload()
@@ -160,7 +167,7 @@ watch(
 </script>
 
 <template>
-  <div class="fullscreen-form-fullscreen resource-add-fullscreen">
+  <div ref="pageRef" class="fullscreen-form-fullscreen resource-add-fullscreen">
     <div class="fullscreen-form-page">
       <header class="fullscreen-form-header">
         <button type="button" class="fullscreen-form-header__back" @click="handleBack">
@@ -177,8 +184,8 @@ watch(
           <div class="fullscreen-form-step-stack">
             <section class="fullscreen-form-card fullscreen-form-section">
               <ElForm label-position="top" class="fullscreen-form-el-form">
-                <ElFormItem :label="t('insight.mcpServers.fieldName')" required>
-                  <ElInput v-model="name" :placeholder="t('insight.mcpServers.fieldNamePh')" />
+                <ElFormItem data-validation-field="name" :error="errors.name" :label="t('insight.mcpServers.fieldName')" required>
+                  <ElInput v-model="name" :placeholder="t('insight.mcpServers.fieldNamePh')" @input="clearFieldError('name')" />
                   <p class="mcp-field-hint">{{ t('insight.mcpServers.fieldNameHint') }}</p>
                 </ElFormItem>
 
@@ -190,8 +197,8 @@ watch(
                     </ElSelect>
                     <p class="mcp-field-hint">{{ t('insight.mcpServers.fieldTransportHint') }}</p>
                   </ElFormItem>
-                  <ElFormItem :label="t('insight.mcpServers.fieldEndpoint')" required>
-                    <ElInput v-model="endpoint" :placeholder="endpointPlaceholder" />
+                  <ElFormItem data-validation-field="endpoint" :error="errors.endpoint" :label="t('insight.mcpServers.fieldEndpoint')" required>
+                    <ElInput v-model="endpoint" :placeholder="endpointPlaceholder" @input="clearFieldError('endpoint')" />
                     <p class="mcp-field-hint">{{ t('insight.mcpServers.fieldEndpointHint') }}</p>
                   </ElFormItem>
                 </div>
@@ -235,7 +242,7 @@ watch(
         <ElButton
           type="primary"
           :loading="saving"
-          :disabled="saving || loading || !canSubmit"
+          :disabled="saving || loading"
           @click="handleSubmit"
         >
           {{ isEditing ? t('common.save') : t('insight.mcpServers.btnCreate') }}

--- a/src/frontend/src/pages/insight/SkillFormPage.vue
+++ b/src/frontend/src/pages/insight/SkillFormPage.vue
@@ -6,6 +6,7 @@ import { useI18n } from 'vue-i18n'
 import { ArrowLeft, Sparkles } from 'lucide-vue-next'
 import { ElMessage } from 'element-plus'
 import { apiErrorMessage } from '../../lib/api'
+import { useInlineFormValidation } from '../../composables/useInlineFormValidation'
 import { routeLocationWithListRefresh } from '../../lib/listRouteRefresh'
 import {
   beautifyLensSkill,
@@ -30,6 +31,8 @@ const isEditing = computed(() => Boolean(editingUuid.value))
 const loading = ref(false)
 const saving = ref(false)
 const beautifying = ref(false)
+const pageRef = ref<HTMLElement | null>(null)
+const { clear: clearFieldError, errors, validate: validateInline } = useInlineFormValidation(pageRef)
 
 const name = ref('')
 const description = ref('')
@@ -114,7 +117,11 @@ async function handleBeautify() {
 }
 
 async function handleSubmit() {
-  if (!canSubmit.value || saving.value) return
+  if (saving.value) return
+  if (!validateInline([
+    { field: 'name', message: t('insight.skills.fieldName'), valid: !!name.value.trim() },
+    { field: 'content', message: t('insight.skills.fieldContent'), valid: !!content.value.trim() },
+  ])) return
   saving.value = true
   try {
     const payload = buildPayload()
@@ -143,7 +150,7 @@ watch(
 </script>
 
 <template>
-  <div class="fullscreen-form-fullscreen resource-add-fullscreen skill-form-fullscreen">
+  <div ref="pageRef" class="fullscreen-form-fullscreen resource-add-fullscreen skill-form-fullscreen">
     <div class="fullscreen-form-page">
       <header class="fullscreen-form-header">
         <button type="button" class="fullscreen-form-header__back" @click="handleBack">
@@ -160,8 +167,8 @@ watch(
           <div class="fullscreen-form-step-stack">
             <section class="fullscreen-form-card fullscreen-form-section">
               <ElForm label-position="top" class="fullscreen-form-el-form">
-                <ElFormItem :label="t('insight.skills.fieldName')" required>
-                  <ElInput v-model="name" :placeholder="t('insight.skills.fieldNamePh')" />
+                <ElFormItem data-validation-field="name" :error="errors.name" :label="t('insight.skills.fieldName')" required>
+                  <ElInput v-model="name" :placeholder="t('insight.skills.fieldNamePh')" @input="clearFieldError('name')" />
                   <p class="skill-field-hint">{{ t('insight.skills.fieldNameHint') }}</p>
                 </ElFormItem>
 
@@ -173,7 +180,7 @@ watch(
                   <p class="skill-field-hint">{{ t('insight.skills.fieldDescriptionHint') }}</p>
                 </ElFormItem>
 
-                <ElFormItem required>
+                <ElFormItem data-validation-field="content" :error="errors.content" required>
                   <template #label>
                     <span class="skill-content-label">
                       <span>{{ t('insight.skills.fieldContent') }}</span>
@@ -195,6 +202,7 @@ watch(
                     :rows="11"
                     :placeholder="t('insight.skills.fieldContentPh')"
                     class="skill-content-textarea"
+                    @input="clearFieldError('content')"
                   />
                   <p class="skill-field-hint">{{ t('insight.skills.fieldContentHint') }}</p>
                 </ElFormItem>
@@ -216,7 +224,7 @@ watch(
         <ElButton
           type="primary"
           :loading="saving"
-          :disabled="saving || loading || !canSubmit"
+          :disabled="saving || loading"
           @click="handleSubmit"
         >
           {{ isEditing ? t('common.save') : t('insight.skills.btnCreate') }}

--- a/src/frontend/src/pages/node/AddNasRepository.vue
+++ b/src/frontend/src/pages/node/AddNasRepository.vue
@@ -20,6 +20,7 @@ import { preflightNasRepositoryCreate, showNasDraftPreflightGuidance } from '../
 import { proxyAgentsRoute } from '../../lib/nodeDeployRoutes'
 import type { ApiNode } from '../../types/node'
 import NasProxyTopology from './NasProxyTopology.vue'
+import { useInlineFormValidation } from '../../composables/useInlineFormValidation'
 
 type NasProtocol = 'smb' | 'nfs'
 
@@ -48,6 +49,8 @@ const emit = defineEmits<{
 
 /* ---------- form state ---------- */
 const busy = ref(false)
+const pageRef = ref<HTMLElement | null>(null)
+const { clear: clearFieldError, errors, validate: validateInline } = useInlineFormValidation(pageRef)
 const proxyNodesRefreshing = ref(false)
 const proxyNodes = ref<ApiNode[]>([])
 
@@ -112,50 +115,17 @@ const validQuotaAlertThreshold = computed(() => {
 
 /* ---------- validation ---------- */
 function validateForm(): boolean {
-  if (!protocol.value) {
-    ElMessage.warning({ message: t('repositoriesPage.errProtocol'), grouping: true })
-    return false
-  }
-  if (protocol.value === 'smb') {
-    if (!smbHost.value.trim()) {
-      ElMessage.warning({ message: t('addNasRepo.errSmbHost'), grouping: true })
-      return false
-    }
-    if (!smbShare.value.trim()) {
-      ElMessage.warning({ message: t('addNasRepo.errSmbShare'), grouping: true })
-      return false
-    }
-    if (!smbUsername.value.trim()) {
-      ElMessage.warning({ message: t('repositoriesPage.errSmbUsername'), grouping: true })
-      return false
-    }
-    if (!smbPassword.value.trim()) {
-      ElMessage.warning({ message: t('repositoriesPage.errSmbPassword'), grouping: true })
-      return false
-    }
-  } else if (protocol.value === 'nfs') {
-    if (!nfsHost.value.trim()) {
-      ElMessage.warning({ message: t('repositoriesPage.errNfsHost'), grouping: true })
-      return false
-    }
-    if (!nfsExport.value.trim()) {
-      ElMessage.warning({ message: t('repositoriesPage.errNfsExport'), grouping: true })
-      return false
-    }
-  }
-  if (!hasProxyDecision.value) {
-    ElMessage.warning({ message: t('addNasRepo.errProxyDecisionRequired'), grouping: true })
-    return false
-  }
-  if (!repoName.value.trim()) {
-    ElMessage.warning({ message: t('repositoriesPage.errName'), grouping: true })
-    return false
-  }
-  if (enableQuotaAlert.value && !validQuotaAlertThreshold.value) {
-    ElMessage.warning({ message: t('repositoriesPage.hintQuotaAlertThreshold'), grouping: true })
-    return false
-  }
-  return true
+  return validateInline([
+    { field: 'smbHost', message: t('addNasRepo.errSmbHost'), valid: protocol.value !== 'smb' || !!smbHost.value.trim() },
+    { field: 'smbShare', message: t('addNasRepo.errSmbShare'), valid: protocol.value !== 'smb' || !!smbShare.value.trim() },
+    { field: 'smbUsername', message: t('repositoriesPage.errSmbUsername'), valid: protocol.value !== 'smb' || !!smbUsername.value.trim() },
+    { field: 'smbPassword', message: t('repositoriesPage.errSmbPassword'), valid: protocol.value !== 'smb' || !!smbPassword.value.trim() },
+    { field: 'nfsHost', message: t('repositoriesPage.errNfsHost'), valid: protocol.value !== 'nfs' || !!nfsHost.value.trim() },
+    { field: 'nfsExport', message: t('repositoriesPage.errNfsExport'), valid: protocol.value !== 'nfs' || !!nfsExport.value.trim() },
+    { field: 'proxyNode', message: t('addNasRepo.errProxyDecisionRequired'), valid: hasProxyDecision.value },
+    { field: 'repoName', message: t('repositoriesPage.errName'), valid: !!repoName.value.trim() },
+    { field: 'quotaThreshold', message: t('repositoriesPage.hintQuotaAlertThreshold'), valid: !enableQuotaAlert.value || validQuotaAlertThreshold.value },
+  ])
 }
 
 /* ---------- submit ---------- */
@@ -270,7 +240,7 @@ watch(enableQuotaAlert, (enabled) => {
 </script>
 
 <template>
-  <div class="fullscreen-form-fullscreen resource-add-fullscreen" :class="{ 'resource-add-fullscreen--embedded': embedded }">
+  <div ref="pageRef" class="fullscreen-form-fullscreen resource-add-fullscreen" :class="{ 'resource-add-fullscreen--embedded': embedded }">
     <div class="fullscreen-form-page add-nas-page">
       <header v-if="!embedded" class="fullscreen-form-header">
         <button class="fullscreen-form-header__back" @click="handleBack">
@@ -332,23 +302,23 @@ watch(enableQuotaAlert, (enabled) => {
 
                 <ElForm label-position="top" class="fullscreen-form-el-form add-nas-form">
                   <div v-if="protocol === 'smb'" class="fullscreen-form-grid">
-                    <ElFormItem :label="t('addNasRepo.fieldSmbHost')" required class="flex-1">
-                      <ElInput v-model="smbHost" :placeholder="t('addNasRepo.phSmbHost')" />
+                    <ElFormItem data-validation-field="smbHost" :error="errors.smbHost" :label="t('addNasRepo.fieldSmbHost')" required class="flex-1">
+                      <ElInput v-model="smbHost" :placeholder="t('addNasRepo.phSmbHost')" @input="clearFieldError('smbHost')" />
                       <div class="mt-1 text-xs text-[rgb(100_116_139)]">{{ t('addNasRepo.hintSmbHost') }}</div>
                     </ElFormItem>
-                    <ElFormItem :label="t('addNasRepo.fieldSmbShare')" required class="flex-1">
-                      <ElInput v-model="smbShare" :placeholder="t('addNasRepo.phSmbShare')" />
+                    <ElFormItem data-validation-field="smbShare" :error="errors.smbShare" :label="t('addNasRepo.fieldSmbShare')" required class="flex-1">
+                      <ElInput v-model="smbShare" :placeholder="t('addNasRepo.phSmbShare')" @input="clearFieldError('smbShare')" />
                       <div class="mt-1 text-xs text-[rgb(100_116_139)]">{{ t('addNasRepo.hintSmbShare') }}</div>
                     </ElFormItem>
                   </div>
 
                   <div v-if="protocol === 'nfs'" class="fullscreen-form-grid">
-                    <ElFormItem :label="t('addNasRepo.fieldNfsHost')" required class="flex-1">
-                      <ElInput v-model="nfsHost" :placeholder="t('addNasRepo.phNfsHost')" />
+                    <ElFormItem data-validation-field="nfsHost" :error="errors.nfsHost" :label="t('addNasRepo.fieldNfsHost')" required class="flex-1">
+                      <ElInput v-model="nfsHost" :placeholder="t('addNasRepo.phNfsHost')" @input="clearFieldError('nfsHost')" />
                       <div class="mt-1 text-xs text-[rgb(100_116_139)]">{{ t('addNasRepo.hintNfsHost') }}</div>
                     </ElFormItem>
-                    <ElFormItem :label="t('addNasRepo.fieldNfsExport')" required class="flex-1">
-                      <ElInput v-model="nfsExport" :placeholder="t('addNasRepo.phNfsExport')" />
+                    <ElFormItem data-validation-field="nfsExport" :error="errors.nfsExport" :label="t('addNasRepo.fieldNfsExport')" required class="flex-1">
+                      <ElInput v-model="nfsExport" :placeholder="t('addNasRepo.phNfsExport')" @input="clearFieldError('nfsExport')" />
                       <div class="mt-1 text-xs text-[rgb(100_116_139)]">{{ t('addNasRepo.hintNfsExport') }}</div>
                     </ElFormItem>
                   </div>
@@ -389,14 +359,14 @@ watch(enableQuotaAlert, (enabled) => {
                   </h4>
                   <ElForm label-position="top" class="fullscreen-form-el-form add-nas-form">
                     <div class="fullscreen-form-grid">
-                      <ElFormItem :label="t('repositoriesPage.fieldSmbUsername')" required class="flex-1">
-                        <ElInput v-model="smbUsername" :placeholder="t('repositoriesPage.phSmbUsername')" />
+                      <ElFormItem data-validation-field="smbUsername" :error="errors.smbUsername" :label="t('repositoriesPage.fieldSmbUsername')" required class="flex-1">
+                        <ElInput v-model="smbUsername" :placeholder="t('repositoriesPage.phSmbUsername')" @input="clearFieldError('smbUsername')" />
                         <div class="mt-1 text-xs text-[rgb(100_116_139)]">
                           SMB user used to access the shared directory, e.g. backup_user.
                         </div>
                       </ElFormItem>
-                      <ElFormItem :label="t('repositoriesPage.fieldSmbPassword')" required class="flex-1">
-                        <ElInput v-model="smbPassword" type="password" show-password :placeholder="t('repositoriesPage.phSmbPassword')" />
+                      <ElFormItem data-validation-field="smbPassword" :error="errors.smbPassword" :label="t('repositoriesPage.fieldSmbPassword')" required class="flex-1">
+                        <ElInput v-model="smbPassword" type="password" show-password :placeholder="t('repositoriesPage.phSmbPassword')" @input="clearFieldError('smbPassword')" />
                         <div class="mt-1 text-xs text-[rgb(100_116_139)]">
                           Password for the shared directory; logs and errors are masked.
                         </div>
@@ -444,7 +414,7 @@ watch(enableQuotaAlert, (enabled) => {
                 <div class="add-nas-proxy-layout">
                   <div class="add-nas-proxy-form">
                     <ElForm label-position="top" class="fullscreen-form-el-form add-nas-form">
-                      <ElFormItem required class="add-nas-bind-form-item">
+                      <ElFormItem data-validation-field="proxyNode" :error="errors.proxyNode" required class="add-nas-bind-form-item">
                         <template #label>{{ t('addNasRepo.fieldSourceProxyNode') }}</template>
                         <div class="add-nas-select-row">
                           <ElSelect
@@ -453,7 +423,8 @@ watch(enableQuotaAlert, (enabled) => {
                             clearable
                             filterable
                             :placeholder="t('addNasRepo.phSourceProxyNode')"
-                            @clear="clearProxySelection"
+                            @clear="clearProxySelection(); clearFieldError('proxyNode')"
+                            @change="clearFieldError('proxyNode')"
                           >
                             <ElOption
                               v-for="n in availableProxyNodes"
@@ -532,8 +503,8 @@ watch(enableQuotaAlert, (enabled) => {
                   {{ t('repositoriesPage.stepRepo') }}
                 </h3>
                 <ElForm label-position="top" class="fullscreen-form-el-form add-nas-form">
-                  <ElFormItem :label="t('repositoriesPage.fieldRepoName')" required>
-                    <ElInput v-model="repoName" :placeholder="t('repositoriesPage.phRepoName')" />
+                  <ElFormItem data-validation-field="repoName" :error="errors.repoName" :label="t('repositoriesPage.fieldRepoName')" required>
+                    <ElInput v-model="repoName" :placeholder="t('repositoriesPage.phRepoName')" @input="clearFieldError('repoName')" />
                     <div class="mt-1 text-xs text-[rgb(100_116_139)]">
                       Display name used in repository lists and backup configs, e.g. Production NAS backup.
                     </div>
@@ -556,7 +527,7 @@ watch(enableQuotaAlert, (enabled) => {
                       <p class="fullscreen-form-field__hint">{{ t('repositoriesPage.hintQuota') }}</p>
                     </div>
 
-                    <div class="fullscreen-form-field repository-quota-field repository-quota-field--monitoring">
+                    <div data-validation-field="quotaThreshold" class="fullscreen-form-field repository-quota-field repository-quota-field--monitoring">
                       <div class="fullscreen-form-field__label repository-quota-head repository-quota-title-row">
                         <ElCheckbox v-model="enableQuotaAlert">{{ t('repositoriesPage.fieldQuotaAlert') }}</ElCheckbox>
                       </div>
@@ -569,11 +540,13 @@ watch(enableQuotaAlert, (enabled) => {
                             :max="100"
                             :disabled="!enableQuotaAlert"
                             controls-position="right"
+                            @change="clearFieldError('quotaThreshold')"
                           />
                           <div class="repository-quota-number__suffix">%</div>
                         </div>
                       </div>
                       <p class="fullscreen-form-field__hint">{{ t('repositoriesPage.hintQuotaAlertThreshold') }}</p>
+                      <p v-if="errors.quotaThreshold" class="el-form-item__error">{{ errors.quotaThreshold }}</p>
                     </div>
                   </div>
                 </ElForm>

--- a/src/frontend/src/pages/node/AddProxyFsRepository.vue
+++ b/src/frontend/src/pages/node/AddProxyFsRepository.vue
@@ -16,6 +16,7 @@ import { shouldAutoExpandRefreshedDirectory } from '../../lib/backupSourceDirect
 import { listAllNodes } from '../../lib/nodeApi'
 import { proxyAgentsRoute } from '../../lib/nodeDeployRoutes'
 import type { ApiNode } from '../../types/node'
+import { useInlineFormValidation } from '../../composables/useInlineFormValidation'
 
 const { t } = useI18n()
 const router = useRouter()
@@ -31,6 +32,8 @@ const emit = defineEmits<{
 
 /* ---------- form state ---------- */
 const busy = ref(false)
+const pageRef = ref<HTMLElement | null>(null)
+const { clear: clearFieldError, errors, validate: validateInline } = useInlineFormValidation(pageRef)
 const proxyNodeId = ref<number | undefined>(undefined)
 const proxyNodeDir = ref('')
 const repoName = ref('')
@@ -412,23 +415,12 @@ onMounted(() => {
 
 /* ---------- validation ---------- */
 function validateForm(): boolean {
-  if (!repoName.value.trim()) {
-    ElMessage.warning({ message: t('repositoriesPage.errName'), grouping: true })
-    return false
-  }
-  if (!proxyNodeId.value) {
-    ElMessage.warning({ message: t('repositoriesPage.errProxyNode'), grouping: true })
-    return false
-  }
-  if (!proxyNodeDir.value.trim()) {
-    ElMessage.warning({ message: t('repositoriesPage.errProxyNodeDir'), grouping: true })
-    return false
-  }
-  if (enableQuotaAlert.value && !validQuotaAlertThreshold.value) {
-    ElMessage.warning({ message: t('repositoriesPage.hintQuotaAlertThreshold'), grouping: true })
-    return false
-  }
-  return true
+  return validateInline([
+    { field: 'repoName', message: t('repositoriesPage.errName'), valid: !!repoName.value.trim() },
+    { field: 'proxyNode', message: t('repositoriesPage.errProxyNode'), valid: !!proxyNodeId.value },
+    { field: 'proxyNodeDir', message: t('repositoriesPage.errProxyNodeDir'), valid: !!proxyNodeDir.value.trim() },
+    { field: 'quotaThreshold', message: t('repositoriesPage.hintQuotaAlertThreshold'), valid: !enableQuotaAlert.value || validQuotaAlertThreshold.value },
+  ])
 }
 
 /* ---------- submit ---------- */
@@ -598,7 +590,7 @@ watch(enableQuotaAlert, (enabled) => {
 </script>
 
 <template>
-  <div class="fullscreen-form-fullscreen resource-add-fullscreen" :class="{ 'resource-add-fullscreen--embedded': embedded }">
+  <div ref="pageRef" class="fullscreen-form-fullscreen resource-add-fullscreen" :class="{ 'resource-add-fullscreen--embedded': embedded }">
     <div class="fullscreen-form-page add-proxy-fs-page">
       <header v-if="!embedded" class="fullscreen-form-header">
         <button class="fullscreen-form-header__back" @click="handleBack">
@@ -623,14 +615,14 @@ watch(enableQuotaAlert, (enabled) => {
                 {{ t('repositoriesPage.stepRepo') }}
               </h3>
               <ElForm label-position="top" class="fullscreen-form-el-form add-proxy-fs-form">
-                <ElFormItem :label="t('repositoriesPage.fieldRepoName')" required class="fullscreen-form-item--in-card">
-                  <ElInput v-model="repoName" :placeholder="t('repositoriesPage.phRepoName')" />
+                <ElFormItem data-validation-field="repoName" :error="errors.repoName" :label="t('repositoriesPage.fieldRepoName')" required class="fullscreen-form-item--in-card">
+                  <ElInput v-model="repoName" :placeholder="t('repositoriesPage.phRepoName')" @input="clearFieldError('repoName')" />
                   <div class="mt-1 text-xs text-[var(--color-text-tertiary)]">
                     {{ t('repositoriesPage.hintRepoNameAuto') }}
                   </div>
                 </ElFormItem>
 
-                <ElFormItem required class="fullscreen-form-item--in-card add-proxy-fs-bind-form-item is-no-asterisk">
+                <ElFormItem data-validation-field="proxyNode" :error="errors.proxyNode" required class="fullscreen-form-item--in-card add-proxy-fs-bind-form-item is-no-asterisk">
                   <template #label>
                     <div class="add-proxy-fs-proxy-label">
                       <span class="add-proxy-fs-proxy-label__title">
@@ -647,6 +639,7 @@ watch(enableQuotaAlert, (enabled) => {
                       class="add-proxy-fs-select-row__select"
                       :placeholder="t('repositoriesPage.phProxyNode')"
                       filterable
+                      @change="clearFieldError('proxyNode')"
                     >
                       <ElOption
                         v-for="n in availableProxyNodes"
@@ -667,7 +660,7 @@ watch(enableQuotaAlert, (enabled) => {
                   </div>
                 </ElFormItem>
 
-                <ElFormItem :label="t('repositoriesPage.fieldProxyNodeBaseDir')" required class="fullscreen-form-item--in-card">
+                <ElFormItem data-validation-field="proxyNodeDir" :error="errors.proxyNodeDir" :label="t('repositoriesPage.fieldProxyNodeBaseDir')" required class="fullscreen-form-item--in-card">
                   <div class="dir-selector-container">
                     <div class="dir-selector-toggle">
                       <button
@@ -813,6 +806,7 @@ watch(enableQuotaAlert, (enabled) => {
                       v-model="proxyNodeDir"
                       :placeholder="t('repositoriesPage.phProxyNodeDir')"
                       class="dir-input"
+                      @input="clearFieldError('proxyNodeDir')"
                     />
                   </div>
                 </ElFormItem>
@@ -847,7 +841,7 @@ watch(enableQuotaAlert, (enabled) => {
                     <p class="fullscreen-form-field__hint">{{ t('repositoriesPage.hintQuota') }}</p>
                   </div>
 
-                  <div class="fullscreen-form-field repository-quota-field repository-quota-field--monitoring">
+                  <div data-validation-field="quotaThreshold" class="fullscreen-form-field repository-quota-field repository-quota-field--monitoring">
                     <div class="fullscreen-form-field__label repository-quota-head repository-quota-title-row">
                       <ElCheckbox v-model="enableQuotaAlert">{{ t('repositoriesPage.fieldQuotaAlert') }}</ElCheckbox>
                     </div>
@@ -860,11 +854,13 @@ watch(enableQuotaAlert, (enabled) => {
                           :max="100"
                           :disabled="!enableQuotaAlert"
                           controls-position="right"
+                          @change="clearFieldError('quotaThreshold')"
                         />
                         <div class="repository-quota-number__suffix">%</div>
                       </div>
                     </div>
-                    <p class="fullscreen-form-field__hint">{{ t('repositoriesPage.hintQuotaAlertThreshold') }}</p>
+                      <p class="fullscreen-form-field__hint">{{ t('repositoriesPage.hintQuotaAlertThreshold') }}</p>
+                      <p v-if="errors.quotaThreshold" class="el-form-item__error">{{ errors.quotaThreshold }}</p>
                   </div>
                 </div>
               </ElForm>

--- a/src/frontend/src/pages/node/AddS3Repo.vue
+++ b/src/frontend/src/pages/node/AddS3Repo.vue
@@ -30,6 +30,7 @@ import {
   type S3UrlStyle,
 } from '../../lib/s3ProviderProfiles'
 import S3PlatformBrandIcon from '../../components/S3PlatformBrandIcon.vue'
+import { useInlineFormValidation } from '../../composables/useInlineFormValidation'
 import {
   ArrowLeft,
   RefreshCw,
@@ -53,6 +54,8 @@ const emit = defineEmits<{
   created: [payload: StorageRepository]
 }>()
 const busy = ref(false)
+const pageRef = ref<HTMLElement | null>(null)
+const { clear: clearFieldError, errors, validate: validateInline } = useInlineFormValidation(pageRef)
 const platformSearch = ref('')
 const regionSearch = ref('')
 
@@ -435,24 +438,16 @@ watch(
 watch([storagePlatform, platformLabel, bucket], syncAutoRepoName, { immediate: true })
 
 function validateForm(): boolean {
-  if (!validateAuthFields()) return false
-  if (!repoName.value.trim()) {
-    ElMessage.warning({ message: t('repositoriesPage.errName'), grouping: true })
-    return false
-  }
-  if (!bucket.value.trim()) {
-    ElMessage.warning({ message: t('repositoriesPage.errBucket'), grouping: true })
-    return false
-  }
-  if (!normalizeS3ObjectPrefix(prefix.value)) {
-    ElMessage.warning({ message: t('addS3Repo.errPrefix'), grouping: true })
-    return false
-  }
-  if (enableQuotaAlert.value && !validQuotaAlertThreshold.value) {
-    ElMessage.warning({ message: t('repositoriesPage.hintQuotaAlertThreshold'), grouping: true })
-    return false
-  }
-  return true
+  return validateInline([
+    { field: 'platform', message: t('repositoriesPage.errPlatform'), valid: !!storagePlatform.value },
+    { field: 'endpoint', message: t('addS3Repo.errEndpoint'), valid: !!endpoint.value.trim() },
+    { field: 'accessKey', message: t('addS3Repo.errAccessKey'), valid: !!accessKeyId.value.trim() },
+    { field: 'secretKey', message: t('addS3Repo.errSecretKey'), valid: !!accessKeySecret.value.trim() },
+    { field: 'repoName', message: t('repositoriesPage.errName'), valid: !!repoName.value.trim() },
+    { field: 'bucket', message: t('repositoriesPage.errBucket'), valid: !!bucket.value.trim() },
+    { field: 'prefix', message: t('addS3Repo.errPrefix'), valid: !!normalizeS3ObjectPrefix(prefix.value) },
+    { field: 'quotaThreshold', message: t('repositoriesPage.hintQuotaAlertThreshold'), valid: !enableQuotaAlert.value || validQuotaAlertThreshold.value },
+  ])
 }
 
 async function onSubmit() {
@@ -536,7 +531,7 @@ function handleBack() {
 </script>
 
 <template>
-  <div class="fullscreen-form-fullscreen resource-add-fullscreen" :class="{ 'resource-add-fullscreen--embedded': embedded }">
+  <div ref="pageRef" class="fullscreen-form-fullscreen resource-add-fullscreen" :class="{ 'resource-add-fullscreen--embedded': embedded }">
     <div class="fullscreen-form-page add-s3-page">
 
       <!-- Header -->
@@ -609,6 +604,7 @@ function handleBack() {
                       {{ t('addS3Repo.emptyPlatforms') }}
                     </div>
                   </div>
+                  <p v-if="errors.platform" class="el-form-item__error">{{ errors.platform }}</p>
 
                   <!-- Region Selection -->
                   <template v-if="currentRegions.length > 0">
@@ -662,7 +658,7 @@ function handleBack() {
 
                   <div class="fullscreen-form-grid">
                     <!-- Endpoint -->
-                    <div class="fullscreen-form-field">
+                    <div data-validation-field="endpoint" class="fullscreen-form-field">
                       <label class="fullscreen-form-field__label">
                         {{ t('addS3Repo.fieldEndpoint') }} <span class="fullscreen-form-field__required">*</span>
                       </label>
@@ -672,8 +668,10 @@ function handleBack() {
                         :placeholder="endpointPlaceholder"
                         :disabled="!!platformRegionKey"
                         @blur="endpoint = normalizeS3EndpointInput(endpoint)"
+                        @input="clearFieldError('endpoint')"
                       />
                       <p class="fullscreen-form-field__hint">{{ t('addS3Repo.hintEndpoint') }}</p>
+                      <p v-if="errors.endpoint" class="el-form-item__error">{{ errors.endpoint }}</p>
                     </div>
 
                     <!-- Region -->
@@ -691,7 +689,7 @@ function handleBack() {
                     </div>
 
                     <!-- Access Key -->
-                    <div class="fullscreen-form-field">
+                    <div data-validation-field="accessKey" class="fullscreen-form-field">
                       <label class="fullscreen-form-field__label">
                         {{ t('addS3Repo.fieldAccessKey') }} <span class="fullscreen-form-field__required">*</span>
                       </label>
@@ -699,12 +697,14 @@ function handleBack() {
                         v-model="accessKeyId"
                         class="add-s3-element-field"
                         :placeholder="t('addS3Repo.phAccessKey')"
+                        @input="clearFieldError('accessKey')"
                       />
                       <p class="fullscreen-form-field__hint">{{ t('addS3Repo.hintAccessKey') }}</p>
+                      <p v-if="errors.accessKey" class="el-form-item__error">{{ errors.accessKey }}</p>
                     </div>
 
                     <!-- Secret Key -->
-                    <div class="fullscreen-form-field">
+                    <div data-validation-field="secretKey" class="fullscreen-form-field">
                       <label class="fullscreen-form-field__label">
                         {{ t('addS3Repo.fieldSecretKey') }} <span class="fullscreen-form-field__required">*</span>
                       </label>
@@ -714,8 +714,10 @@ function handleBack() {
                         show-password
                         class="add-s3-element-field"
                         :placeholder="t('addS3Repo.phSecretKey')"
+                        @input="clearFieldError('secretKey')"
                       />
                       <p class="fullscreen-form-field__hint">{{ t('addS3Repo.hintSecretKey') }}</p>
+                      <p v-if="errors.secretKey" class="el-form-item__error">{{ errors.secretKey }}</p>
                     </div>
 
                     <!-- Path Style -->
@@ -761,7 +763,7 @@ function handleBack() {
                 <div class="fullscreen-form-grid">
                   <div class="add-s3-repo-primary-fields">
                   <!-- Repo Name -->
-                  <div class="fullscreen-form-field">
+                  <div data-validation-field="repoName" class="fullscreen-form-field">
                     <label class="fullscreen-form-field__label">
                       {{ t('addS3Repo.fieldRepoName') }} <span class="fullscreen-form-field__required">*</span>
                     </label>
@@ -769,13 +771,14 @@ function handleBack() {
                       v-model="repoName"
                       class="add-s3-element-field add-s3-repo-primary-input"
                       :placeholder="t('addS3Repo.phRepoName')"
-                      @input="onRepoNameInput"
+                      @input="onRepoNameInput(); clearFieldError('repoName')"
                     />
                     <p class="fullscreen-form-field__hint">{{ t('addS3Repo.hintRepoName') }}</p>
+                    <p v-if="errors.repoName" class="el-form-item__error">{{ errors.repoName }}</p>
                   </div>
 
                   <!-- Bucket -->
-                  <div class="fullscreen-form-field">
+                  <div data-validation-field="bucket" class="fullscreen-form-field">
                     <label class="fullscreen-form-field__label">
                       {{ t('addS3Repo.fieldBucket') }} <span class="fullscreen-form-field__required">*</span>
                     </label>
@@ -801,6 +804,7 @@ function handleBack() {
                         :placeholder="refreshingBuckets ? t('addS3Repo.btnValidatingAuth') : t('addS3Repo.phBucketSelect')"
                         @focus="loadBucketsForSelect"
                         @visible-change="(open) => open && loadBucketsForSelect()"
+                        @change="clearFieldError('bucket')"
                       >
                         <ElOption v-for="item in bucketSelectOptions" :key="item" :label="item" :value="item" />
                       </ElSelect>
@@ -819,11 +823,13 @@ function handleBack() {
                       v-model="bucket"
                       class="add-s3-element-field add-s3-repo-primary-input"
                       :placeholder="t('addS3Repo.phBucketNew')"
+                      @input="clearFieldError('bucket')"
                     />
                     <p class="fullscreen-form-field__hint">{{ t('addS3Repo.hintBucket') }}</p>
+                    <p v-if="errors.bucket" class="el-form-item__error">{{ errors.bucket }}</p>
                   </div>
                   <!-- Prefix -->
-                  <div class="fullscreen-form-field">
+                  <div data-validation-field="prefix" class="fullscreen-form-field">
                     <label class="fullscreen-form-field__label">
                       {{ t('addS3Repo.fieldPrefix') }} <span class="fullscreen-form-field__required">*</span>
                     </label>
@@ -832,8 +838,10 @@ function handleBack() {
                       class="add-s3-element-field add-s3-repo-primary-input"
                       :placeholder="t('addS3Repo.phPrefix')"
                       @blur="prefix = normalizeS3ObjectPrefix(prefix)"
+                      @input="clearFieldError('prefix')"
                     />
                     <p class="fullscreen-form-field__hint">{{ t('addS3Repo.hintPrefix') }}</p>
+                    <p v-if="errors.prefix" class="el-form-item__error">{{ errors.prefix }}</p>
                   </div>
                   </div>
 
@@ -856,7 +864,7 @@ function handleBack() {
                       <p class="fullscreen-form-field__hint">{{ t('addS3Repo.hintQuota') }}</p>
                     </div>
 
-                    <div class="fullscreen-form-field repository-quota-field repository-quota-field--monitoring">
+                    <div data-validation-field="quotaThreshold" class="fullscreen-form-field repository-quota-field repository-quota-field--monitoring">
                       <div class="fullscreen-form-field__label repository-quota-head repository-quota-title-row">
                         <ElCheckbox v-model="enableQuotaAlert">{{ t('repositoriesPage.fieldQuotaAlert') }}</ElCheckbox>
                       </div>
@@ -868,11 +876,13 @@ function handleBack() {
                             :min="1"
                             :max="100"
                             controls-position="right"
+                            @change="clearFieldError('quotaThreshold')"
                           />
                           <div class="repository-quota-number__suffix">%</div>
                         </div>
                       </div>
                       <p class="fullscreen-form-field__hint">{{ t('addS3Repo.hintQuotaAlertThreshold') }}</p>
+                      <p v-if="errors.quotaThreshold" class="el-form-item__error">{{ errors.quotaThreshold }}</p>
                     </div>
                   </div>
                 </div>

--- a/src/frontend/src/pages/node/EditProxyFsRepo.vue
+++ b/src/frontend/src/pages/node/EditProxyFsRepo.vue
@@ -14,6 +14,7 @@ import {
   updateStorageRepository,
   type StorageRepository,
 } from '../../lib/storageRepositoryApi'
+import { useInlineFormValidation } from '../../composables/useInlineFormValidation'
 
 const { t } = useI18n()
 const route = useRoute()
@@ -24,6 +25,8 @@ const repositoryId = computed(() => Number(route.params.id))
 
 /* ---------- form state ---------- */
 const loading = ref(false)
+const pageRef = ref<HTMLElement | null>(null)
+const { clear: clearFieldError, errors, validate: validateInline } = useInlineFormValidation(pageRef)
 const busy = ref(false)
 const repo = ref<StorageRepository | null>(null)
 
@@ -175,14 +178,10 @@ function buildPayload() {
 
 async function onSave() {
   if (busy.value) return
-  if (!name.value.trim()) {
-    ElMessage.warning({ message: t('repositoriesPage.editProxyFsRepo.errName'), grouping: true })
-    return
-  }
-  if (!validQuotaAlertThreshold.value) {
-    ElMessage.warning({ message: t('repositoriesPage.editProxyFsRepo.errQuotaAlertThreshold'), grouping: true })
-    return
-  }
+  if (!validateInline([
+    { field: 'name', message: t('repositoriesPage.editProxyFsRepo.errName'), valid: !!name.value.trim() },
+    { field: 'quotaThreshold', message: t('repositoriesPage.editProxyFsRepo.errQuotaAlertThreshold'), valid: validQuotaAlertThreshold.value },
+  ])) return
   busy.value = true
   try {
     await updateStorageRepository(repositoryId.value, buildPayload())
@@ -206,7 +205,7 @@ watch(repositoryId, (id) => {
 </script>
 
 <template>
-  <div class="fullscreen-form-fullscreen resource-add-fullscreen">
+  <div ref="pageRef" class="fullscreen-form-fullscreen resource-add-fullscreen">
     <div class="fullscreen-form-page add-proxy-fs-page edit-proxy-fs-page">
       <header class="fullscreen-form-header">
         <button
@@ -258,12 +257,15 @@ watch(repositoryId, (id) => {
               class="add-proxy-fs-form"
             >
               <ElFormItem
+                data-validation-field="name"
+                :error="errors.name"
                 :label="t('repositoriesPage.editProxyFsRepo.fieldName')"
                 required
               >
                 <ElInput
                   v-model="name"
                   :placeholder="t('repositoriesPage.phRepoName')"
+                  @input="clearFieldError('name')"
                 />
               </ElFormItem>
 
@@ -335,7 +337,7 @@ watch(repositoryId, (id) => {
                   </p>
                 </div>
 
-                <div class="fullscreen-form-field add-proxy-fs-quota-col add-proxy-fs-quota-panel">
+                <div data-validation-field="quotaThreshold" class="fullscreen-form-field add-proxy-fs-quota-col add-proxy-fs-quota-panel">
                   <div class="fullscreen-form-field__label add-proxy-fs-quota-head add-proxy-fs-quota-title-row">
                     <ElCheckbox v-model="quotaAlertEnabled">
                       {{ t('repositoriesPage.fieldQuotaAlert') }}
@@ -350,6 +352,7 @@ watch(repositoryId, (id) => {
                         :max="100"
                         :disabled="!quotaAlertEnabled"
                         controls-position="right"
+                        @change="clearFieldError('quotaThreshold')"
                       />
                       <div class="hfl-detail-form-input__suffix">
                         %
@@ -359,6 +362,7 @@ watch(repositoryId, (id) => {
                   <p class="fullscreen-form-field__hint">
                     {{ t('repositoriesPage.hintQuotaAlertThreshold') }}
                   </p>
+                  <p v-if="errors.quotaThreshold" class="el-form-item__error">{{ errors.quotaThreshold }}</p>
                 </div>
               </div>
             </ElForm>

--- a/src/frontend/src/pages/node/EditS3Repo.vue
+++ b/src/frontend/src/pages/node/EditS3Repo.vue
@@ -22,6 +22,7 @@ import {
   type S3StoragePlatform as StoragePlatform,
   type S3UrlStyle,
 } from '../../lib/s3ProviderProfiles'
+import { useInlineFormValidation } from '../../composables/useInlineFormValidation'
 
 
 const { t } = useI18n()
@@ -30,6 +31,8 @@ const router = useRouter()
 
 const repositoryId = computed(() => Number(route.params.id))
 const loading = ref(false)
+const pageRef = ref<HTMLElement | null>(null)
+const { clear: clearFieldError, errors, validate: validateInline } = useInlineFormValidation(pageRef)
 type SavingPhase = 'verifying' | 'saving'
 const busy = ref(false)
 const savingPhase = ref<SavingPhase | null>(null)
@@ -343,14 +346,10 @@ async function runVerify(): Promise<boolean> {
 
 async function onSave() {
   if (busy.value) return
-  if (!name.value.trim()) {
-    ElMessage.warning({ message: t('repositoriesPage.editS3Repo.errName'), grouping: true })
-    return
-  }
-  if (!quotaThresholdValid.value) {
-    ElMessage.warning({ message: t('repositoriesPage.editS3Repo.errQuotaAlertThreshold'), grouping: true })
-    return
-  }
+  if (!validateInline([
+    { field: 'name', message: t('repositoriesPage.editS3Repo.errName'), valid: !!name.value.trim() },
+    { field: 'quotaThreshold', message: t('repositoriesPage.editS3Repo.errQuotaAlertThreshold'), valid: quotaThresholdValid.value },
+  ])) return
 
   // When the connection or credentials changed, run an explicit verify step
   // user sees what is happening. On failure we keep the page editable and
@@ -405,7 +404,7 @@ watch(repositoryId, (id) => {
 </script>
 
 <template>
-  <div class="fullscreen-form-fullscreen resource-add-fullscreen">
+  <div ref="pageRef" class="fullscreen-form-fullscreen resource-add-fullscreen">
     <div class="fullscreen-form-page add-s3-page edit-s3-page">
       <div class="fullscreen-form-header">
         <button
@@ -610,7 +609,7 @@ watch(repositoryId, (id) => {
                 <div class="fullscreen-form-grid">
                   <div class="add-s3-repo-primary-fields">
                     <!-- Repo Name -->
-                    <div class="fullscreen-form-field">
+                    <div data-validation-field="name" class="fullscreen-form-field">
                       <label class="fullscreen-form-field__label edit-s3-locked-label">
                         {{ t('addS3Repo.fieldRepoName') }}
                         <span class="fullscreen-form-field__required">*</span>
@@ -619,10 +618,12 @@ watch(repositoryId, (id) => {
                         v-model="name"
                         class="add-s3-element-field add-s3-repo-primary-input"
                         :placeholder="t('repositoriesPage.phRepoName')"
+                        @input="clearFieldError('name')"
                       />
                       <p class="fullscreen-form-field__hint">
                         {{ t('addS3Repo.hintRepoName') }}
                       </p>
+                      <p v-if="errors.name" class="el-form-item__error">{{ errors.name }}</p>
                     </div>
 
                     <!-- Bucket (locked) -->
@@ -693,7 +694,7 @@ watch(repositoryId, (id) => {
                       </p>
                     </div>
 
-                    <div class="fullscreen-form-field add-s3-quota-pair__col add-s3-quota-alert-field">
+                    <div data-validation-field="quotaThreshold" class="fullscreen-form-field add-s3-quota-pair__col add-s3-quota-alert-field">
                       <div class="fullscreen-form-field__label add-s3-quota-pair__head add-s3-quota-alert-head">
                         <ElCheckbox v-model="quotaAlertEnabled">
                           {{ t('addS3Repo.fieldQuotaAlert') }}
@@ -710,6 +711,7 @@ watch(repositoryId, (id) => {
                             :disabled="!quotaAlertEnabled"
                             :placeholder="t('repositoriesPage.phQuotaAlertThreshold')"
                             controls-position="right"
+                            @change="clearFieldError('quotaThreshold')"
                           />
                           <div class="hfl-detail-form-input__suffix">
                             %
@@ -719,6 +721,7 @@ watch(repositoryId, (id) => {
                       <p class="fullscreen-form-field__hint">
                         {{ t('addS3Repo.hintQuotaAlertThreshold') }}
                       </p>
+                      <p v-if="errors.quotaThreshold" class="el-form-item__error">{{ errors.quotaThreshold }}</p>
                     </div>
                   </div>
                 </div>

--- a/src/frontend/src/pages/node/RepairNasRepository.vue
+++ b/src/frontend/src/pages/node/RepairNasRepository.vue
@@ -20,6 +20,7 @@ import {
 import { proxyAgentsRoute } from '../../lib/nodeDeployRoutes'
 import type { ApiNode } from '../../types/node'
 import NasProxyTopology from './NasProxyTopology.vue'
+import { useInlineFormValidation } from '../../composables/useInlineFormValidation'
 
 type NasProtocol = 'smb' | 'nfs'
 
@@ -29,6 +30,8 @@ const route = useRoute()
 
 const repoId = computed(() => Number(route.params.id))
 const busy = ref(false)
+const pageRef = ref<HTMLElement | null>(null)
+const { clear: clearFieldError, errors, validate: validateInline } = useInlineFormValidation(pageRef)
 const loading = ref(true)
 const loadError = ref('')
 const original = ref<StorageRepository | null>(null)
@@ -266,6 +269,10 @@ async function focusMountOptions() {
 
 async function onSubmit() {
   if (!original.value) return
+  if (!validateInline([
+    { field: 'displayName', message: t('repositoriesPage.errName'), valid: !!displayName.value.trim() },
+    { field: 'quotaThreshold', message: t('repositoriesPage.hintQuotaAlertThreshold'), valid: !quotaAlertEnabled.value || (Number(quotaAlertThreshold.value || 0) >= 1 && Number(quotaAlertThreshold.value || 0) <= 100) },
+  ])) return
   const validationError = validateForm()
   if (validationError) {
     ElMessage.warning({ message: validationError, grouping: true })
@@ -381,7 +388,7 @@ onMounted(async () => {
 </script>
 
 <template>
-  <div class="fullscreen-form-fullscreen resource-add-fullscreen">
+  <div ref="pageRef" class="fullscreen-form-fullscreen resource-add-fullscreen">
     <div class="fullscreen-form-page add-nas-page">
       <header class="fullscreen-form-header">
         <button class="fullscreen-form-header__back" @click="handleBack">
@@ -529,8 +536,8 @@ onMounted(async () => {
                 {{ t('repairNasRepo.sectionRepo') }}
               </h3>
               <ElForm label-position="top" class="add-nas-form">
-                <ElFormItem :label="t('repairNasRepo.labelDisplayName')" required>
-                  <ElInput v-model="displayName" :placeholder="t('repairNasRepo.phDisplayName')" />
+                <ElFormItem data-validation-field="displayName" :error="errors.displayName" :label="t('repairNasRepo.labelDisplayName')" required>
+                  <ElInput v-model="displayName" :placeholder="t('repairNasRepo.phDisplayName')" @input="clearFieldError('displayName')" />
                 </ElFormItem>
                 <ElFormItem id="nas-mount-options" :label="t('repairNasRepo.labelMountOptions')">
                   <ElInput
@@ -589,7 +596,7 @@ onMounted(async () => {
                       </div>
                     </div>
                   </div>
-                  <div class="fullscreen-form-field add-nas-quota-col add-nas-quota-panel">
+                  <div data-validation-field="quotaThreshold" class="fullscreen-form-field add-nas-quota-col add-nas-quota-panel">
                     <div class="fullscreen-form-field__label add-nas-quota-head add-nas-quota-title-row">
                       <ElCheckbox v-model="quotaAlertEnabled">
                         {{ t('repairNasRepo.labelQuotaAlert') }}
@@ -604,6 +611,7 @@ onMounted(async () => {
                           :max="100"
                           :disabled="!quotaAlertEnabled"
                           controls-position="right"
+                          @change="clearFieldError('quotaThreshold')"
                         />
                         <div class="hfl-detail-form-input__suffix">%</div>
                       </div>
@@ -611,6 +619,7 @@ onMounted(async () => {
                     <p class="fullscreen-form-field__hint">
                       {{ t('repairNasRepo.labelQuotaAlertThreshold') }}
                     </p>
+                    <p v-if="errors.quotaThreshold" class="el-form-item__error">{{ errors.quotaThreshold }}</p>
                   </div>
                 </div>
               </ElForm>

--- a/src/frontend/src/pages/protection/BackupCreateWizard.vue
+++ b/src/frontend/src/pages/protection/BackupCreateWizard.vue
@@ -44,6 +44,7 @@ import NasSourceDetailDrawer from './components/NasSourceDetailDrawer.vue'
 import { useProtectionSideNav } from '../../composables/useProtectionSideNav'
 import { useListSearch } from '../../composables/useListSearch'
 import { useRestoreTargetCatalog } from '../../composables/useRestoreTargetCatalog'
+import { useInlineFormValidation } from '../../composables/useInlineFormValidation'
 import {
   backupFlowSourceStepIcon,
   backupSourceTypeIcon,
@@ -808,6 +809,7 @@ const nasProtocol = ref<NasProtocol>('smb')
 const nasBindNodeId = ref<number | undefined>(undefined)
 const nasBindNodeError = ref('')
 const nasBindSectionRef = ref<HTMLElement | null>(null)
+const { clear: clearNasFieldError, errors: nasFieldErrors, validate: validateNasInline } = useInlineFormValidation(addSourceShellRef)
 const nasName = ref('')
 const nasNameTouched = ref(false)
 const nasDir = ref('')
@@ -895,7 +897,17 @@ function validateNasStep(step: NasWizardStep): boolean {
 }
 
 function validateNasForm(): boolean {
-  return validateNasStep(0) && validateNasStep(1) && validateNasStep(2)
+  return validateNasInline([
+    { field: 'smbServer', message: t('addNasRepo.errSmbHost'), valid: nasProtocol.value !== 'smb' || !!nasSmbServer.value.trim() },
+    { field: 'smbShare', message: t('addNasRepo.errSmbShare'), valid: nasProtocol.value !== 'smb' || !!nasSmbShare.value.trim() },
+    { field: 'smbUsername', message: t('repositoriesPage.errSmbUsername'), valid: nasProtocol.value !== 'smb' || !!nasSmbUsername.value.trim() },
+    { field: 'smbPassword', message: t('repositoriesPage.errSmbPassword'), valid: nasProtocol.value !== 'smb' || !!nasSmbPassword.value.trim() },
+    { field: 'nfsHost', message: t('repositoriesPage.errNfsHost'), valid: nasProtocol.value !== 'nfs' || !!nasNfsHost.value.trim() },
+    { field: 'nfsExport', message: t('repositoriesPage.errNfsExport'), valid: nasProtocol.value !== 'nfs' || !!nasNfsExport.value.trim() },
+    { field: 'bindNode', message: proxyNodes.value.length === 0 ? t('protection.sourceResources.nasNoProxy') : t('protection.sourceResources.errNasProxyRequired'), valid: !!nasBindNodeId.value },
+    { field: 'dir', message: t('repositoriesPage.errRepoDir'), valid: !!nasDir.value.trim() },
+    { field: 'name', message: t('repositoriesPage.errName'), valid: !!nasName.value.trim() },
+  ])
 }
 
 async function nasSubmit() {
@@ -1223,10 +1235,16 @@ const selGlobalFilter = ref('')
 const sourceFilterMap = ref<Record<string, string[]>>({})
 const sourceCompressionMap = ref<Record<string, CompressionLevel>>({})
 const addFilterOpen = ref(false)
+const addPolicyDialogRef = ref<HTMLElement | null>(null)
+const { clear: clearAddPolicyError, errors: addPolicyErrors, validate: validateAddPolicyInline } = useInlineFormValidation(addPolicyDialogRef)
 const addPolicyCreateKind = ref<'backup' | 'filter'>('backup')
 const addPolicyForm = ref<BackupPolicyForm>(createEmptyPolicyForm())
 const addFileFilterForm = ref<FileFilterRuleForm>(createEmptyFileFilterForm())
 const addPolicySaving = ref(false)
+watch(addPolicyForm, () => {
+  clearAddPolicyError('schedule')
+  clearAddPolicyError('retention')
+}, { deep: true })
 const createPhase = ref<'form' | 'waiting' | 'done'>('form')
 const createBootstrapping = ref(true)
 const editorWaitingText = computed(() => {
@@ -5201,15 +5219,13 @@ function filterSummaryLines(ids: string[]) {
 
 function closeAddFilterDialog() {
   addFilterOpen.value = false
+  for (const key of Object.keys(addPolicyErrors)) delete addPolicyErrors[key]
 }
 
 async function submitAddFilterDialog() {
   if (addPolicyCreateKind.value === 'filter') {
     const name = addFileFilterForm.value.name.trim()
-    if (!name) {
-      ElMessage.warning({ message: t('protection.policiesPage.msgNameRequired'), grouping: true })
-      return
-    }
+    if (!validateAddPolicyInline([{ field: 'name', message: t('protection.policiesPage.msgNameRequired'), valid: !!name }])) return
     addPolicySaving.value = true
     try {
       const snapshot = JSON.parse(JSON.stringify({ ...addFileFilterForm.value, name })) as FileFilterRuleForm
@@ -5229,19 +5245,16 @@ async function submitAddFilterDialog() {
   }
 
   const name = addPolicyForm.value.name.trim()
-  if (!name) {
-    ElMessage.warning({ message: t('protection.policiesPage.msgPolicyNameRequired'), grouping: true })
-    return
-  }
   const scheduleError = validateScheduleForm(addPolicyForm.value)
-  if (scheduleError) {
-    ElMessage.warning({ message: scheduleError, grouping: true })
-    return
-  }
-  if (addPolicyForm.value.sectionRetentionEnabled && addPolicyRetentionError.value) {
-    ElMessage.warning({ message: addPolicyRetentionError.value, grouping: true })
-    return
-  }
+  const showScheduleError = addPolicyForm.value.freqMode !== 'advanced' ? scheduleError : ''
+  const showRetentionError = addPolicyRetentionError.value === 'Latest restore points must be at least 1.'
+    ? ''
+    : addPolicyRetentionError.value
+  if (!validateAddPolicyInline([
+    { field: 'name', message: t('protection.policiesPage.msgPolicyNameRequired'), valid: !!name },
+    { field: 'schedule', message: showScheduleError || '', valid: !scheduleError },
+    { field: 'retention', message: showRetentionError || '', valid: !addPolicyForm.value.sectionRetentionEnabled || !addPolicyRetentionError.value },
+  ])) return
   addPolicySaving.value = true
   try {
     const snapshot = JSON.parse(JSON.stringify({ ...addPolicyForm.value, name })) as BackupPolicyForm
@@ -7123,6 +7136,7 @@ function preserveShallowestPathOrder(paths: string[]) {
         >
           <p class="create-policy-dialog__desc">{{ addPolicyDialogDesc }}</p>
 
+          <div ref="addPolicyDialogRef">
           <ProtectionPolicyEditorForm
             v-model:policy-form="addPolicyForm"
             v-model:filter-form="addFileFilterForm"
@@ -7131,7 +7145,12 @@ function preserveShallowestPathOrder(paths: string[]) {
             variant="dialog"
             :show-cron-help="false"
             cron-input-id="create-backup-policy-cron"
+            :name-error="addPolicyErrors.name"
+            :schedule-error="addPolicyErrors.schedule"
+            :retention-error="addPolicyErrors.retention"
+            @clear-name-error="clearAddPolicyError('name')"
           />
+          </div>
           <template #footer>
             <div class="flex justify-end gap-2">
               <ElButton @click="closeAddFilterDialog">{{ t('protection.backupsPage.btnCancel') }}</ElButton>
@@ -9396,6 +9415,7 @@ function preserveShallowestPathOrder(paths: string[]) {
                   :nfs-options="nasNfsOptions"
                   :bind-node-id="nasBindNodeId"
                   :bind-node-error="nasBindNodeError"
+                  :validation-errors="nasFieldErrors"
                   :name="nasName"
                   :generated-name="generatedNasName"
                   :dir="nasDir"
@@ -9418,6 +9438,7 @@ function preserveShallowestPathOrder(paths: string[]) {
                   @update:dir="nasDir = $event"
                   @dir-touched="nasDirTouched = true"
                   @clear-bind-node-error="clearNasBindNodeError"
+                  @clear-validation-error="clearNasFieldError"
                   @refresh-proxy-nodes="refreshProxyNodesManually"
                   @open-proxy-deploy="openProxyDeploy"
                   @cancel="closeAddSource"

--- a/src/frontend/src/pages/protection/PolicyEditorPage.vue
+++ b/src/frontend/src/pages/protection/PolicyEditorPage.vue
@@ -4,6 +4,7 @@ import { useRoute, useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { ElMessage } from 'element-plus'
 import { ArrowLeft, Filter, ShieldCheck } from 'lucide-vue-next'
+import { useInlineFormValidation } from '../../composables/useInlineFormValidation'
 import ProtectionPolicyEditorForm from './components/ProtectionPolicyEditorForm.vue'
 import { apiErrorMessage } from '../../lib/api'
 import {
@@ -38,6 +39,8 @@ const form = ref<BackupPolicyForm>(createEmptyPolicyForm())
 const filterForm = ref<FileFilterRuleForm>(createEmptyFileFilterForm())
 const loading = ref(false)
 const saving = ref(false)
+const pageRef = ref<HTMLElement | null>(null)
+const { clear: clearFieldError, errors, validate: validateInline } = useInlineFormValidation(pageRef)
 
 const editingId = computed(() => {
   const raw = route.params.id
@@ -74,10 +77,7 @@ function handleBack() {
 
 async function saveFilterRule() {
   const name = filterForm.value.name.trim()
-  if (!name) {
-    ElMessage.warning({ message: t('protection.policiesPage.msgNameRequired'), grouping: true })
-    return
-  }
+  if (!validateInline([{ field: 'name', message: t('protection.policiesPage.msgNameRequired'), valid: !!name }])) return
   const snapshot = JSON.parse(JSON.stringify({ ...filterForm.value, name })) as FileFilterRuleForm
   saving.value = true
   try {
@@ -98,20 +98,15 @@ async function saveFilterRule() {
 
 async function savePolicy() {
   const name = form.value.name.trim()
-  if (!name) {
-    ElMessage.warning({ message: t('protection.policiesPage.msgPolicyNameRequired'), grouping: true })
-    return
-  }
   const scheduleError = validateScheduleForm(form.value)
-  if (scheduleError) {
-    ElMessage.warning({ message: scheduleError, grouping: true })
-    return
-  }
+  const showScheduleError = form.value.freqMode !== 'advanced' ? scheduleError : ''
   const retentionError = validateRetentionForm(form.value, messageLocale.value)
-  if (form.value.sectionRetentionEnabled && retentionError) {
-    ElMessage.warning({ message: retentionError, grouping: true })
-    return
-  }
+  const showRetentionError = retentionError === 'Latest restore points must be at least 1.' ? '' : retentionError
+  if (!validateInline([
+    { field: 'name', message: t('protection.policiesPage.msgPolicyNameRequired'), valid: !!name },
+    { field: 'schedule', message: showScheduleError || '', valid: !scheduleError },
+    { field: 'retention', message: showRetentionError || '', valid: !form.value.sectionRetentionEnabled || !retentionError },
+  ])) return
   const snapshot = JSON.parse(JSON.stringify({ ...form.value, name })) as BackupPolicyForm
   saving.value = true
   try {
@@ -171,6 +166,7 @@ const editorPreviewIcon = computed(() => isFilterEditor.value ? Filter : ShieldC
 const editorPreviewActive = computed(() =>
   isFilterEditor.value ? filterForm.value.policyActive : form.value.policyActive,
 )
+const previewNumber = (value: unknown) => typeof value === 'number' && Number.isFinite(value) ? value : '—'
 
 const backupRetentionPreviewRows = computed(() => {
   const f = form.value
@@ -186,26 +182,26 @@ const backupRetentionPreviewRows = computed(() => {
   return [
     {
       label: 'Latest',
-      value: `${f.retentionRecentPoints} restore point(s)`,
+      value: `${previewNumber(f.retentionRecentPoints)} restore point(s)`,
     },
     {
       label: t('protection.policiesPage.shortTitle'),
       value: f.retentionShortHourly
-          ? `First ${f.retentionShortDaysMax} days`
+          ? `First ${previewNumber(f.retentionShortDaysMax)} days`
         : t('protection.policiesPage.statusOff'),
       muted: !f.retentionShortHourly,
     },
     {
       label: t('protection.policiesPage.midTitle'),
       value: f.retentionMidDaily
-          ? `Day ${f.retentionShortDaysMax} to ${f.retentionMidDaysMax}`
+          ? `Day ${previewNumber(f.retentionShortDaysMax)} to ${previewNumber(f.retentionMidDaysMax)}`
         : t('protection.policiesPage.statusOff'),
       muted: !f.retentionMidDaily,
     },
     {
       label: t('protection.policiesPage.longTitle'),
       value: f.retentionLongMonthly
-          ? `After day ${f.retentionMidDaysMax}, ${f.retentionLongMonths} months`
+          ? `After day ${previewNumber(f.retentionMidDaysMax)}, ${previewNumber(f.retentionLongMonths)} months`
         : t('protection.policiesPage.statusOff'),
       muted: !f.retentionLongMonthly,
     },
@@ -294,7 +290,7 @@ onMounted(() => {
 </script>
 
 <template>
-  <div class="fullscreen-form-fullscreen resource-add-fullscreen policy-editor-fullscreen">
+  <div ref="pageRef" class="fullscreen-form-fullscreen resource-add-fullscreen policy-editor-fullscreen">
     <div class="fullscreen-form-page add-s3-page">
       <header class="fullscreen-form-header">
         <button
@@ -320,6 +316,10 @@ onMounted(() => {
             :show-filter="isFilterEditor"
             variant="fullscreen"
             cron-input-id="policy-cron-expr"
+            :name-error="errors.name"
+            :schedule-error="errors.schedule"
+            :retention-error="errors.retention"
+            @clear-name-error="clearFieldError('name')"
           />
 
           <footer class="fullscreen-form-footer fullscreen-form-action-footer">

--- a/src/frontend/src/pages/protection/components/NasAddForm.vue
+++ b/src/frontend/src/pages/protection/components/NasAddForm.vue
@@ -28,6 +28,7 @@ const props = defineProps<{
   proxyNodes: ApiNode[]
   proxyNodesRefreshing: boolean
   busy: boolean
+  validationErrors?: Record<string, string>
 }>()
 
 const emit = defineEmits<{
@@ -50,6 +51,7 @@ const emit = defineEmits<{
   openProxyDeploy: []
   cancel: []
   submit: []
+  clearValidationError: [string]
 }>()
 
 const { t } = useI18n()
@@ -147,19 +149,21 @@ defineExpose({
             class="add-nas-form fullscreen-form-el-form"
           >
             <div v-if="protocol === 'smb'" class="add-nas-form-row add-nas-form-row--triple">
-              <ElFormItem :label="t('addNasRepo.fieldSmbHost')" required class="flex-1">
+              <ElFormItem data-validation-field="smbServer" :error="validationErrors?.smbServer" :label="t('addNasRepo.fieldSmbHost')" required class="flex-1">
                 <ElInput
                   :model-value="smbServer"
                   :placeholder="t('protection.sourceResources.nasPhSmbHost')"
                   @update:model-value="emit('update:smbServer', $event as string)"
+                  @input="emit('clearValidationError', 'smbServer')"
                 />
                 <p class="add-nas-field-hint">{{ t('protection.sourceResources.nasHintSmbHost') }}</p>
               </ElFormItem>
-              <ElFormItem :label="t('addNasRepo.fieldSmbShare')" required class="flex-1">
+              <ElFormItem data-validation-field="smbShare" :error="validationErrors?.smbShare" :label="t('addNasRepo.fieldSmbShare')" required class="flex-1">
                 <ElInput
                   :model-value="smbShare"
                   :placeholder="t('protection.sourceResources.nasPhSmbShare')"
                   @update:model-value="emit('update:smbShare', $event as string)"
+                  @input="emit('clearValidationError', 'smbShare')"
                 />
                 <p class="add-nas-field-hint">{{ t('protection.sourceResources.nasHintSmbShare') }}</p>
               </ElFormItem>
@@ -174,19 +178,21 @@ defineExpose({
             </div>
 
             <div v-else class="add-nas-form-row add-nas-form-row--triple">
-              <ElFormItem :label="t('addNasRepo.fieldNfsHost')" required class="flex-1">
+              <ElFormItem data-validation-field="nfsHost" :error="validationErrors?.nfsHost" :label="t('addNasRepo.fieldNfsHost')" required class="flex-1">
                 <ElInput
                   :model-value="nfsHost"
                   :placeholder="t('protection.sourceResources.nasPhNfsHost')"
                   @update:model-value="emit('update:nfsHost', $event as string)"
+                  @input="emit('clearValidationError', 'nfsHost')"
                 />
                 <p class="add-nas-field-hint">{{ t('protection.sourceResources.nasHintNfsHost') }}</p>
               </ElFormItem>
-              <ElFormItem :label="t('addNasRepo.fieldNfsExport')" required class="flex-1">
+              <ElFormItem data-validation-field="nfsExport" :error="validationErrors?.nfsExport" :label="t('addNasRepo.fieldNfsExport')" required class="flex-1">
                 <ElInput
                   :model-value="nfsExport"
                   :placeholder="t('protection.sourceResources.nasPhNfsExport')"
                   @update:model-value="emit('update:nfsExport', $event as string)"
+                  @input="emit('clearValidationError', 'nfsExport')"
                 />
                 <p class="add-nas-field-hint">{{ t('protection.sourceResources.nasHintNfsExport') }}</p>
               </ElFormItem>
@@ -207,22 +213,24 @@ defineExpose({
               class="add-nas-form add-nas-form--auth fullscreen-form-el-form"
             >
               <div class="add-nas-form-row add-nas-form-row--triple">
-                <ElFormItem :label="t('protection.sourceResources.nasFieldSmbUsername')" required class="flex-1">
+                <ElFormItem data-validation-field="smbUsername" :error="validationErrors?.smbUsername" :label="t('protection.sourceResources.nasFieldSmbUsername')" required class="flex-1">
                   <ElInput
                     :model-value="smbUsername"
                     :placeholder="t('protection.sourceResources.nasPhSmbUsername')"
-                    @update:model-value="emit('update:smbUsername', $event as string)"
-                  />
+                  @update:model-value="emit('update:smbUsername', $event as string)"
+                  @input="emit('clearValidationError', 'smbUsername')"
+                />
                   <p class="add-nas-field-hint">{{ t('protection.sourceResources.nasHintSmbUsername') }}</p>
                 </ElFormItem>
-                <ElFormItem :label="t('protection.sourceResources.nasFieldSmbPassword')" required class="flex-1">
+                <ElFormItem data-validation-field="smbPassword" :error="validationErrors?.smbPassword" :label="t('protection.sourceResources.nasFieldSmbPassword')" required class="flex-1">
                   <ElInput
                     :model-value="smbPassword"
                     type="password"
                     show-password
                     :placeholder="t('protection.sourceResources.nasPhSmbPassword')"
-                    @update:model-value="emit('update:smbPassword', $event as string)"
-                  />
+                  @update:model-value="emit('update:smbPassword', $event as string)"
+                  @input="emit('clearValidationError', 'smbPassword')"
+                />
                   <p class="add-nas-field-hint">{{ t('protection.sourceResources.nasHintSmbPassword') }}</p>
                 </ElFormItem>
                 <ElFormItem :label="t('protection.sourceResources.nasFieldSmbDomain')" class="flex-1">
@@ -252,6 +260,8 @@ defineExpose({
           >
             <div class="add-nas-form-row add-nas-form-row--pair add-nas-bind-row">
               <ElFormItem
+                data-validation-field="bindNode"
+                :error="validationErrors?.bindNode"
                 required
                 class="add-nas-bind-form-item flex-1"
               >
@@ -271,7 +281,7 @@ defineExpose({
                       filterable
                       fit-input-width
                       popper-class="nas-add-proxy-select-popper"
-                      @update:model-value="emit('update:bindNodeId', $event as number)"
+                      @update:model-value="emit('update:bindNodeId', $event as number); emit('clearValidationError', 'bindNode')"
                       @change="emit('clearBindNodeError')"
                     >
                       <ElOption
@@ -318,12 +328,12 @@ defineExpose({
                   {{ bindNodeError || proxySelectEmptyHint() || t('protection.sourceResources.nasHintBindProxy') }}
                 </p>
               </ElFormItem>
-              <ElFormItem :label="t('protection.sourceResources.nasFieldDir')" required class="add-nas-dir-form-item flex-1">
+              <ElFormItem data-validation-field="dir" :error="validationErrors?.dir" :label="t('protection.sourceResources.nasFieldDir')" required class="add-nas-dir-form-item flex-1">
                 <div class="add-nas-control-field">
                   <ElInput
                     :model-value="dir"
                     :placeholder="generatedDir"
-                    @update:model-value="emit('update:dir', $event as string)"
+                    @update:model-value="emit('update:dir', $event as string); emit('clearValidationError', 'dir')"
                     @input="emit('dirTouched')"
                   />
                 </div>
@@ -344,11 +354,11 @@ defineExpose({
             label-position="top"
             class="add-nas-form fullscreen-form-el-form"
           >
-            <ElFormItem :label="t('protection.sourceResources.nasFieldName')" required class="flex-1">
+            <ElFormItem data-validation-field="name" :error="validationErrors?.name" :label="t('protection.sourceResources.nasFieldName')" required class="flex-1">
               <ElInput
                 :model-value="name"
                 :placeholder="generatedName"
-                @update:model-value="emit('update:name', $event as string)"
+                @update:model-value="emit('update:name', $event as string); emit('clearValidationError', 'name')"
                 @input="emit('nameTouched')"
               />
               <p v-if="nameConflictMessage" class="add-nas-field-hint add-nas-field-hint--warn">

--- a/src/frontend/src/pages/protection/components/ProtectionPolicyEditorForm.vue
+++ b/src/frontend/src/pages/protection/components/ProtectionPolicyEditorForm.vue
@@ -26,15 +26,22 @@ const props = withDefaults(defineProps<{
   variant?: 'fullscreen' | 'dialog'
   showCronHelp?: boolean
   cronInputId?: string
+  nameError?: string
+  scheduleError?: string
+  retentionError?: string
 }>(), {
   showBackup: true,
   showFilter: false,
   variant: 'fullscreen',
   showCronHelp: true,
   cronInputId: 'policy-cron-expr',
+  nameError: '',
+  scheduleError: '',
+  retentionError: '',
 })
 const policyForm = defineModel<BackupPolicyForm>('policyForm', { required: true })
 const filterForm = defineModel<FileFilterRuleForm>('filterForm', { required: true })
+defineEmits<{ 'clear-name-error': [] }>()
 
 const { t } = useI18n()
 const router = useRouter()
@@ -70,6 +77,12 @@ const cronErrorText = computed(() => {
 const scheduleErrorText = computed(() => validateScheduleForm(policyForm.value))
 const midRetentionError = computed(() => validateMidRetention(policyForm.value, messageLocale.value))
 const longVsShortRetentionError = computed(() => validateLongVsShortRetention(policyForm.value, messageLocale.value))
+const recentRetentionError = computed(() =>
+  policyForm.value.sectionRetentionEnabled &&
+  (typeof policyForm.value.retentionRecentPoints !== 'number' || policyForm.value.retentionRecentPoints < 1)
+    ? 'Latest restore points must be at least 1.'
+    : '',
+)
 
 const formClass = computed(() =>
   props.variant === 'fullscreen'
@@ -292,19 +305,21 @@ function toggleScheduleMonthDay(day: number) {
         {{ t('protection.policiesPage.tabBasic') }}
       </h3>
       <div class="policy-basic-grid">
-        <div class="policy-basic-row">
+        <div data-validation-field="name" class="policy-basic-row">
           <label class="policy-basic-row__label" for="policy-name-input">
             {{ t('protection.policiesPage.labelPolicyName') }}
             <span class="policy-basic-row__required">*</span>
           </label>
-          <div class="policy-basic-row__control">
+          <div class="policy-basic-row__control" :class="{ 'is-invalid': !!nameError }">
             <ElInput
               id="policy-name-input"
               v-model="policyForm.name"
               :placeholder="t('protection.policiesPage.phPolicyName')"
               maxlength="128"
               show-word-limit
+              @input="$emit('clear-name-error')"
             />
+            <p v-if="nameError" class="fullscreen-form-inline-error">{{ nameError }}</p>
           </div>
         </div>
         <div class="policy-basic-row">
@@ -316,13 +331,14 @@ function toggleScheduleMonthDay(day: number) {
       </div>
     </section>
 
-    <section :class="nestedSectionClass">
+    <section data-validation-field="schedule" :class="nestedSectionClass">
       <div class="policy-section-head">
         <el-checkbox v-model="policyForm.sectionScheduleEnabled" />
         <span class="policy-section-head__title">{{ t('protection.policiesPage.sectionCheckSchedule') }}</span>
       </div>
       <p v-if="!policyForm.sectionScheduleEnabled" class="policy-section-off-hint">{{ t('protection.policiesPage.sectionOffHint') }}</p>
-      <div v-else class="policy-section-nested">
+      <p v-if="scheduleError" class="fullscreen-form-inline-error">{{ scheduleError }}</p>
+      <div v-if="policyForm.sectionScheduleEnabled" class="policy-section-nested">
         <el-radio-group v-model="policyForm.freqMode" class="mb-3">
           <el-radio value="simple">{{ t('protection.policiesPage.freqSimple') }}</el-radio>
           <el-radio value="advanced">{{ t('protection.policiesPage.freqAdvanced') }}</el-radio>
@@ -447,7 +463,7 @@ function toggleScheduleMonthDay(day: number) {
         <div v-else class="space-y-3">
           <div class="cron-row">
             <label class="cron-row__label" :for="cronInputId">
-              <span class="cron-row__required">*</span>{{ t('protection.policiesPage.cronLabel') }}
+              {{ t('protection.policiesPage.cronLabel') }}<span class="cron-row__required">*</span>
             </label>
             <div class="cron-row__field">
               <ElInput
@@ -487,13 +503,14 @@ function toggleScheduleMonthDay(day: number) {
       </div>
     </section>
 
-    <section :class="nestedSectionClass">
+    <section data-validation-field="retention" :class="nestedSectionClass">
       <div class="policy-section-head">
         <el-checkbox v-model="policyForm.sectionRetentionEnabled" />
         <span class="policy-section-head__title">{{ t('protection.policiesPage.sectionCheckRetention') }}</span>
       </div>
       <p v-if="!policyForm.sectionRetentionEnabled" class="policy-section-off-hint">{{ t('protection.policiesPage.sectionOffHint') }}</p>
-      <div v-else class="policy-section-nested policy-retention-stack">
+      <p v-if="retentionError" class="fullscreen-form-inline-error">{{ retentionError }}</p>
+      <div v-if="policyForm.sectionRetentionEnabled" class="policy-section-nested policy-retention-stack">
         <div>
           <div class="policy-option-title policy-option-title--with-desc">
             {{ t('protection.policiesPage.recentTitle') }}
@@ -503,8 +520,11 @@ function toggleScheduleMonthDay(day: number) {
           </div>
           <div class="retention-recent-row">
             <span class="policy-inline-label">{{ t('protection.policiesPage.recentLine') }}</span>
-            <div :class="retentionInputWrapClass">
+            <div :class="[retentionInputWrapClass, { 'is-invalid': !!recentRetentionError }]">
               <ElInputNumber v-model="policyForm.retentionRecentPoints" :min="1" :max="9999" />
+              <p v-if="recentRetentionError" class="fullscreen-form-inline-error retention-recent-input-wrap__error">
+                {{ recentRetentionError }}
+              </p>
             </div>
             <span class="policy-inline-label">{{ t('protection.policiesPage.recentPoints') }}</span>
           </div>
@@ -614,19 +634,21 @@ function toggleScheduleMonthDay(day: number) {
         {{ t('protection.policiesPage.tabBasic') }}
       </h3>
       <div class="policy-basic-grid">
-        <div class="policy-basic-row">
+        <div data-validation-field="name" class="policy-basic-row">
           <label class="policy-basic-row__label" for="filter-rule-name-input">
             {{ t('protection.policiesPage.fieldFilterRuleName') }}
             <span class="policy-basic-row__required">*</span>
           </label>
-          <div class="policy-basic-row__control">
+          <div class="policy-basic-row__control" :class="{ 'is-invalid': !!nameError }">
             <ElInput
               id="filter-rule-name-input"
               v-model="filterForm.name"
               :placeholder="t('protection.policiesPage.phFilterName')"
               maxlength="128"
               show-word-limit
+              @input="$emit('clear-name-error')"
             />
+            <p v-if="nameError" class="fullscreen-form-inline-error">{{ nameError }}</p>
           </div>
         </div>
         <div class="policy-basic-row">
@@ -902,13 +924,63 @@ function toggleScheduleMonthDay(day: number) {
 }
 
 .policy-basic-row__control {
+  position: relative;
   min-width: 0;
+}
+
+.policy-basic-row__control.is-invalid :deep(.el-input__wrapper) {
+  box-shadow: 0 0 0 1px var(--el-color-danger) inset;
+}
+
+.policy-basic-row__control .fullscreen-form-inline-error {
+  position: absolute;
+  margin-top: 2px;
+  left: 0;
+  z-index: 1;
 }
 
 .policy-basic-row__control--switch {
   display: flex;
   align-items: center;
   min-height: 32px;
+}
+
+.cron-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  gap: 8px 12px;
+}
+
+.cron-row__label {
+  flex-shrink: 0;
+  color: rgb(51 65 85);
+  font-size: 13px;
+  font-weight: 650;
+  line-height: 32px;
+  white-space: nowrap;
+}
+
+.cron-row__required {
+  margin-left: 3px;
+  color: var(--el-color-danger);
+}
+
+.cron-row__field {
+  flex: 1 1 320px;
+  min-width: 0;
+  max-width: 460px;
+}
+
+.cron-input--error :deep(.el-input__wrapper) {
+  box-shadow: 0 0 0 1px var(--el-color-danger) inset;
+}
+
+.cron-row__error {
+  margin: 4px 0 0;
+  color: var(--el-color-danger);
+  font-size: 12px;
+  line-height: 1.35;
 }
 
 .policy-cron-help {
@@ -1064,6 +1136,7 @@ function toggleScheduleMonthDay(day: number) {
   line-height: 1.5;
 }
 
+
 .policy-retention-stack {
   display: flex;
   flex-direction: column;
@@ -1176,7 +1249,20 @@ function toggleScheduleMonthDay(day: number) {
 
 .retention-tier-input-wrap,
 .retention-recent-input-wrap {
+  position: relative;
   width: 140px;
+}
+
+.retention-recent-input-wrap.is-invalid :deep(.el-input__wrapper) {
+  box-shadow: 0 0 0 1px var(--el-color-danger) inset;
+}
+
+.retention-recent-input-wrap__error {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  width: max-content;
+  margin: 0;
 }
 
 .retention-tier-input-wrap :deep(.el-input-number),

--- a/src/frontend/src/styles/fullscreen-form-shell.css
+++ b/src/frontend/src/styles/fullscreen-form-shell.css
@@ -388,6 +388,16 @@
   line-height: 1.5;
 }
 
+/* Use when a custom field layout cannot host Element Plus's absolutely
+ * positioned .el-form-item__error. A layout may anchor it locally when the
+ * message must not affect row height. */
+.fullscreen-form-inline-error {
+  margin: 4px 0 0;
+  color: var(--el-color-danger);
+  font-size: 12px;
+  line-height: 1.35;
+}
+
 .fullscreen-form-el-form {
   margin: 0;
 }


### PR DESCRIPTION
## Summary
- add shared inline validation with first-error scroll and focus support
- apply consistent feedback across repository, protection, and Insight forms
- anchor policy schedule and retention errors to their relevant controls

## Testing
- npm run build
- npm run lint
- npx vitest run src/composables/useInlineFormValidation.test.ts

Closes #501