### PR TITLE
fix(release): harden offline upgrades and production promotion

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,8 +15,16 @@
 # Application version and mode
 # ==============================================================================
 
-# HyperFileLens image and API version. The release installer replaces this value.
+# Compatibility version exposed to the application. Release installs use the
+# immutable image version from MANIFEST.json.
 APP_VERSION=0.1.0
+
+# Product and runtime image identity. Release installers source these values
+# from MANIFEST.json instead of deriving image tags from the product version.
+HFL_PRODUCT_VERSION=0.1.0
+HFL_EDITION=community
+HFL_BACKEND_IMAGE=hyperfilelens-backend:0.1.0
+HFL_FRONTEND_IMAGE=hyperfilelens-frontend:0.1.0
 
 # Stable Nginx image version. The installer pins this independently so a later
 # `start` cannot unexpectedly recreate the public entry during an app upgrade.

--- a/.github/scripts/remote-deploy.sh
+++ b/.github/scripts/remote-deploy.sh
@@ -85,7 +85,10 @@ if [[ -n "${DOWNLOAD_PROXY_URL}" ]]; then
 	}
 fi
 if [[ -n "${PACKAGE_FILE}" ]]; then
-	[[ "${PACKAGE_FILE}" =~ ^/root/hfl-release/v[0-9]+\.[0-9]+\.[0-9]+/hyperfilelens-[0-9]+\.[0-9]+\.[0-9]+-ee\.tar\.gz$ ]] || {
+	package_dir="/root/hfl-release/${TAG}"
+	package_name="$(basename -- "${PACKAGE_FILE}")"
+	[[ "$(dirname -- "${PACKAGE_FILE}")" == "${package_dir}" \
+		&& "${package_name}" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*\.tar\.gz$ ]] || {
 		printf 'ERROR: invalid Enterprise package path\n' >&2
 		exit 2
 	}
@@ -485,6 +488,7 @@ package="$(find "${work}" -maxdepth 1 -type f -name 'hyperfilelens-*.tar.gz' -pr
 	# End of the GitHub Release download path. Local Enterprise packages bypass it.
 fi
 package_name="$(basename "${package}")"
+artifact_sha256="$(sha256sum "${package}" | awk '{print $1}')"
 if [[ -z "${PACKAGE_FILE}" ]]; then
 	expected="$(awk -v file="${package_name}" '$2 == file || $2 == "*" file {print $1; exit}' "${work}/SHA256SUMS")"
 	if [[ -n "${expected}" ]]; then
@@ -507,7 +511,53 @@ if [[ -z "${PACKAGE_FILE}" ]]; then
 	fi
 fi
 
+validate_release_archive_layout() {
+	local archive=$1
+	python3 - "${archive}" <<'PY'
+import pathlib
+import posixpath
+import sys
+import tarfile
+
+archive = pathlib.Path(sys.argv[1])
+archive_size = archive.stat().st_size
+with tarfile.open(archive, mode="r:gz") as package:
+    members = package.getmembers()
+    if not members or len(members) > 100_000:
+        raise SystemExit("release archive is empty or contains too many entries")
+    roots = set()
+    expanded_size = 0
+    for member in members:
+        raw = member.name
+        path = pathlib.PurePosixPath(raw)
+        if (
+            not raw
+            or path.is_absolute()
+            or any(part in {"", ".", ".."} for part in path.parts)
+        ):
+            raise SystemExit(f"release archive contains an unsafe path: {raw!r}")
+        roots.add(path.parts[0])
+        if not (member.isdir() or member.isreg() or member.issym() or member.islnk()):
+            raise SystemExit(f"release archive contains an unsupported entry: {raw!r}")
+        if member.isreg():
+            expanded_size += member.size
+        if member.issym() or member.islnk():
+            link = member.linkname
+            if not link or pathlib.PurePosixPath(link).is_absolute():
+                raise SystemExit(f"release archive contains an unsafe link: {raw!r}")
+            base = posixpath.dirname(raw) if member.issym() else ""
+            resolved = pathlib.PurePosixPath(posixpath.normpath(posixpath.join(base, link)))
+            if not resolved.parts or resolved.parts[0] != path.parts[0] or ".." in resolved.parts:
+                raise SystemExit(f"release archive link escapes its package root: {raw!r}")
+    if len(roots) != 1:
+        raise SystemExit("release archive must contain exactly one package root")
+    if expanded_size > archive_size * 4 + 4 * 1024**3:
+        raise SystemExit("release archive expands beyond the supported disk budget")
+PY
+}
+
 mkdir -p "${work}/extract"
+validate_release_archive_layout "${package}"
 tar -xzf "${package}" -C "${work}/extract"
 package_root="$(find "${work}/extract" -mindepth 1 -maxdepth 1 -type d -name 'hyperfilelens-*' -print -quit)"
 [[ -n "${package_root}" && -x "${package_root}/install.sh" ]] || {
@@ -537,9 +587,9 @@ version = expected_id[1:] if expected_id.startswith("v") else expected_id
 edition = str(manifest.get("edition") or "community")
 if edition != expected_edition:
     raise SystemExit(f"package edition mismatch: {edition} != {expected_edition}")
-expected_image_version = version + ("-ee" if edition == "enterprise" else "")
-if manifest.get("image_version", version) != expected_image_version:
-    raise SystemExit("package image identity mismatch")
+image_version = str(manifest.get("image_version") or "")
+if not image_version:
+    raise SystemExit("package image identity is missing")
 PY
 
 if [[ -f "${INSTALL_DIR}/.env" && -f "${INSTALL_DIR}/VERSION" ]]; then
@@ -556,6 +606,7 @@ if [[ -f "${INSTALL_DIR}/.env" && -f "${INSTALL_DIR}/VERSION" ]]; then
 		install_args+=(--runtime-env-file "${RUNTIME_ENV_FILE}")
 	fi
 	HFL_PUBLIC_HOST="${DIRECT_HOST}" HFL_SHOW_GENERATED_CREDENTIALS=0 \
+		HFL_UPGRADE_ARTIFACT_SHA256="${artifact_sha256}" \
 		bash "${package_root}/install.sh" "${install_args[@]}"
 else
 	printf '[deploy] Installing HFL %s\n' "${TAG}"

--- a/.github/scripts/store-enterprise-release.sh
+++ b/.github/scripts/store-enterprise-release.sh
@@ -44,6 +44,7 @@ flock 9
 	python3 - MANIFEST.json "${tag}" "${archive}" <<'PY'
 import json
 import pathlib
+import re
 import sys
 import tarfile
 
@@ -56,8 +57,27 @@ if manifest.get("edition") != "enterprise":
     raise SystemExit("release is not Enterprise edition")
 if manifest.get("version") != version or manifest.get("artifact_id") != tag:
     raise SystemExit("Enterprise release identity mismatch")
-if manifest.get("image_version") != f"{version}-ee":
-    raise SystemExit("Enterprise image identity mismatch")
+image_version = str(manifest.get("image_version") or "")
+if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}", image_version):
+    raise SystemExit("Enterprise image identity is missing or invalid")
+runtime_images = manifest.get("runtime_images") or {
+    "backend": f"hyperfilelens-backend:{image_version}",
+    "frontend": f"hyperfilelens-frontend:{image_version}",
+}
+if set(runtime_images) != {"backend", "frontend"}:
+    raise SystemExit("Enterprise runtime image identity is incomplete")
+hfl_refs = {
+    str(ref)
+    for item in manifest.get("images", [])
+    if item.get("role") == "hyperfilelens"
+    for ref in (item.get("refs") or [])
+}
+for role, ref in runtime_images.items():
+    if not re.fullmatch(
+        rf"hyperfilelens-{role}:[A-Za-z0-9][A-Za-z0-9._-]{{0,127}}",
+        str(ref),
+    ) or ref not in hfl_refs:
+        raise SystemExit(f"Enterprise {role} runtime image is not in the HFL archive")
 extension_commit = manifest.get("extension_commit", "")
 if not isinstance(extension_commit, str) or len(extension_commit) != 40 or any(
     character not in "0123456789abcdef" for character in extension_commit
@@ -90,6 +110,7 @@ if [[ -e "${destination}" ]]; then
 		python3 - MANIFEST.json "${tag}" "hyperfilelens-${version}-ee.tar.gz" <<'PY'
 import json
 import pathlib
+import re
 import sys
 import tarfile
 
@@ -102,8 +123,27 @@ if manifest.get("edition") != "enterprise":
     raise SystemExit("stored release is not Enterprise edition")
 if manifest.get("version") != version or manifest.get("artifact_id") != tag:
     raise SystemExit("stored Enterprise release identity mismatch")
-if manifest.get("image_version") != f"{version}-ee":
-    raise SystemExit("stored Enterprise image identity mismatch")
+image_version = str(manifest.get("image_version") or "")
+if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}", image_version):
+    raise SystemExit("stored Enterprise image identity is missing or invalid")
+runtime_images = manifest.get("runtime_images") or {
+    "backend": f"hyperfilelens-backend:{image_version}",
+    "frontend": f"hyperfilelens-frontend:{image_version}",
+}
+if set(runtime_images) != {"backend", "frontend"}:
+    raise SystemExit("stored Enterprise runtime image identity is incomplete")
+hfl_refs = {
+    str(ref)
+    for item in manifest.get("images", [])
+    if item.get("role") == "hyperfilelens"
+    for ref in (item.get("refs") or [])
+}
+for role, ref in runtime_images.items():
+    if not re.fullmatch(
+        rf"hyperfilelens-{role}:[A-Za-z0-9][A-Za-z0-9._-]{{0,127}}",
+        str(ref),
+    ) or ref not in hfl_refs:
+        raise SystemExit(f"stored Enterprise {role} runtime image is not in the HFL archive")
 extension_commit = manifest.get("extension_commit", "")
 if not isinstance(extension_commit, str) or len(extension_commit) != 40 or any(
     character not in "0123456789abcdef" for character in extension_commit
@@ -131,6 +171,7 @@ identity_fields = (
     "version",
     "artifact_id",
     "image_version",
+    "runtime_images",
     "git_commit",
     "extension_commit",
 )

--- a/.github/workflows/artifact_pipeline.yml
+++ b/.github/workflows/artifact_pipeline.yml
@@ -193,6 +193,7 @@ jobs:
             python3 - MANIFEST.json "$tag" "$version" "$oss_commit" "$enterprise_commit" <<'PY'
           import json
           import pathlib
+          import re
           import sys
 
           path, tag, version, oss_commit, enterprise_commit = sys.argv[1:]
@@ -202,7 +203,6 @@ jobs:
               "edition": "enterprise",
               "version": version,
               "artifact_id": tag,
-              "image_version": f"{version}-ee",
               "git_commit": oss_commit,
               "extension_commit": enterprise_commit,
           }
@@ -211,6 +211,29 @@ jobs:
               raise SystemExit(
                   "stored Enterprise release identity differs for: " + ", ".join(differences)
               )
+          image_version = str(manifest.get("image_version") or "")
+          if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}", image_version):
+              raise SystemExit("stored Enterprise image identity is missing or invalid")
+          runtime_images = manifest.get("runtime_images") or {
+              "backend": f"hyperfilelens-backend:{image_version}",
+              "frontend": f"hyperfilelens-frontend:{image_version}",
+          }
+          if set(runtime_images) != {"backend", "frontend"}:
+              raise SystemExit("stored Enterprise runtime image identity is incomplete")
+          hfl_refs = {
+              str(ref)
+              for item in manifest.get("images", [])
+              if item.get("role") == "hyperfilelens"
+              for ref in (item.get("refs") or [])
+          }
+          for role, ref in runtime_images.items():
+              if not re.fullmatch(
+                  rf"hyperfilelens-{role}:[A-Za-z0-9][A-Za-z0-9._-]{{0,127}}",
+                  str(ref),
+              ) or ref not in hfl_refs:
+                  raise SystemExit(
+                      f"stored Enterprise {role} runtime image is not in the HFL archive"
+                  )
           PY
           )
           printf 'true\n'
@@ -419,6 +442,7 @@ jobs:
           ./tools/quality/test-gh-release-upload-retry.sh
           ./tools/quality/test-offline-docker-package-plan.sh
           ./tools/quality/test-upgrade-backup-retention.sh
+          ./tools/quality/test-upgrade-transaction.sh
           ./tools/quality/test-blue-green-recovery.sh
           ./tools/quality/test-sourcelens-runtime-sync.sh
           ./tools/quality/test-sourcelens-runtime-fingerprint.sh

--- a/deploy/blue-green/README.md
+++ b/deploy/blue-green/README.md
@@ -79,9 +79,11 @@ drain every old Daphne instance, and provide shared or object-backed media,
 static, language-pack, and Agent-release storage. Those fleet responsibilities
 must not be inferred from the local execution-cache files.
 
-Stable Nginx is deliberately outside `APP_VERSION`. `HFL_GATEWAY_VERSION` pins
-the image present at first installation (or the first blue/green upgrade), so a
-later `install.sh start` cannot unexpectedly replace the public entry. Updating
-that gateway image requires a separately planned entry-layer maintenance action;
-zero-downtime gateway-image replacement requires an external load balancer or a
-host-level dual-entry driver.
+The product version, application-image identity, and stable entry image have
+separate lifecycles. The release manifest supplies the Backend and Frontend
+image references, while `HFL_GATEWAY_VERSION` pins the stable Nginx image
+present at first installation (or the first blue/green upgrade). A later
+`install.sh start` therefore cannot unexpectedly replace the public entry.
+Updating that gateway image requires a separately planned entry-layer
+maintenance action; zero-downtime gateway-image replacement requires an
+external load balancer or a host-level dual-entry driver.

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -5,7 +5,8 @@
 name: hyperfilelens
 
 x-backend-image: &backend-image
-  image: hyperfilelens-backend:${APP_VERSION:-latest}
+  image: ${HFL_BACKEND_IMAGE:-hyperfilelens-backend:${APP_VERSION:-latest}}
+  pull_policy: never
   platform: linux/amd64
   restart: unless-stopped
   env_file:
@@ -59,7 +60,8 @@ x-api: &api
       max-file: "10"
 
 x-web: &web
-  image: hyperfilelens-frontend:${APP_VERSION:-latest}
+  image: ${HFL_FRONTEND_IMAGE:-hyperfilelens-frontend:${APP_VERSION:-latest}}
+  pull_policy: never
   platform: linux/amd64
   restart: unless-stopped
   environment:
@@ -197,6 +199,7 @@ services:
 
   postgres:
     image: hyperfilelens-postgres:17
+    pull_policy: never
     restart: unless-stopped
     env_file:
       - ${HFL_ENV_FILE:-./.env}
@@ -225,6 +228,7 @@ services:
 
   redis:
     image: hyperfilelens-redis:alpine
+    pull_policy: never
     restart: unless-stopped
     volumes:
       - ./data/redis:/data
@@ -245,6 +249,7 @@ services:
     # The stable entry has an independently pinned lifecycle. Application
     # upgrades reload its configuration but cannot recreate it unexpectedly.
     image: hyperfilelens-frontend:${HFL_GATEWAY_VERSION:-latest}
+    pull_policy: never
     restart: unless-stopped
     extra_hosts:
       - "host.docker.internal:host-gateway"

--- a/deploy/installer/install.sh
+++ b/deploy/installer/install.sh
@@ -32,6 +32,10 @@ SOURCELENS_UPGRADE_STARTED=0
 SOURCELENS_GATE_ADOPTION_SOURCE=""
 UPGRADE_HFL_COMMITTED=0
 UPGRADE_HFL_CUTOVER_ATTEMPTED=0
+UPGRADE_ARTIFACT_SHA256="${HFL_UPGRADE_ARTIFACT_SHA256:-}"
+UPGRADE_TRANSACTION_DIR=""
+UPGRADE_TRANSACTION_PHASE=""
+UPGRADE_TRANSACTION_INITIALIZED=0
 INSTALLER_LOCK_ACQUIRED=0
 DRAINED_WS_INSTANCES=""
 LOCAL_PLATFORM_AGENT_INSTALL_DIR="/opt/hyperfilelens-agent"
@@ -73,7 +77,7 @@ Options:
     --runtime-env-file FILE Apply staged Turnstile settings from a root-only regular file
 
   upgrade:
-    --from PATH             Path to new package directory or hyperfilelens-*.tar.gz (required)
+    --from PATH             Path to a new package directory or .tar.gz release (required)
                             Creates a verified managed backup set under backup/ before upgrade
                             and retains the latest three valid sets
                             Extracts the new package to upgrade_tmp, merges keys from its .env.example into .env,
@@ -177,6 +181,9 @@ finish_session() {
 cleanup_upgrade_and_finish() {
 	local rc=$?
 	local recovery_rc=0
+	if [[ "${rc}" -ne 0 && "${UPGRADE_TRANSACTION_INITIALIZED}" == "1" ]]; then
+		mark_upgrade_transaction_status failed || true
+	fi
 	if [[ "${rc}" -ne 0 && "${UPGRADE_RECOVERY_ARMED}" == "1" ]]; then
 		record_deployment_phase failed "${UPGRADE_PREVIOUS_COLOR:-unknown}" \
 			"${UPGRADE_TARGET_COLOR:-unknown}" "${UPGRADE_TARGET_VERSION:-unknown}" || true
@@ -205,7 +212,7 @@ recover_upgrade_services() {
 	set +e
 	if [[ "${UPGRADE_SOURCELENS_WAS_RUNNING}" == "1" ]] && sourcelens_installed; then
 		if [[ "${SOURCELENS_UPGRADE_STARTED}" == "1" ]]; then
-			sourcelens_compose up -d --no-build
+			sourcelens_compose up -d --no-build --pull never
 		else
 			# Target SourceLens files may already be staged.  Starting existing
 			# containers avoids converging an unchanged live runtime before its
@@ -229,7 +236,7 @@ recover_upgrade_services() {
 			&& "${UPGRADE_PREVIOUS_COLOR}" == "legacy" \
 			&& -n "${UPGRADE_LEGACY_API_CID}" \
 			&& "$(docker inspect --format '{{.State.Running}}' "${UPGRADE_LEGACY_API_CID}" 2>/dev/null || true)" == "true" ]]; then
-			compose_in_root up -d --no-build --no-recreate postgres redis
+			compose_in_root up -d --no-build --pull never --no-recreate postgres redis
 			# The pre-upgrade singleton containers still carry the previous image.
 			# Starting them preserves one coherent rollback release; `up` would
 			# recreate them from the already-staged target image metadata.
@@ -250,7 +257,7 @@ recover_upgrade_services() {
 				"api-${recovery_color}" "web-${recovery_color}"
 			[[ $? -eq 0 ]] || recovered=0
 			if [[ "${UPGRADE_HFL_COMMITTED}" == "1" ]]; then
-				compose_in_root up -d --no-build worker scheduler
+				compose_in_root up -d --no-build --pull never worker scheduler
 			else
 				compose_in_root start worker scheduler
 			fi
@@ -340,16 +347,61 @@ safe_assert_env_file() {
 
 safe_assert_package_basename() {
 	local name=$1
-	[[ "${name}" =~ ^hyperfilelens-([0-9]+\.[0-9]+\.[0-9]+(-ee|-[0-9a-fA-F]{7})?|main-[0-9a-f]{7})\.tar\.gz$ ]] \
-		|| die "invalid release package basename: ${name}"
-	[[ "${name}" != */* ]] || die "package basename must not contain slashes: ${name}"
+	[[ "${name}" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*\.tar\.gz$ ]] \
+		|| die "unsafe release package basename: ${name}"
 }
 
 safe_assert_upgrade_package_file() {
 	local path=$1
 	safe_assert_absolute "${path}" "upgrade package file"
 	safe_assert_package_basename "$(basename "${path}")"
-	[[ -f "${path}" ]] || die "upgrade package not found: ${path}"
+	[[ -f "${path}" && ! -L "${path}" ]] \
+		|| die "upgrade package is missing or is not a regular file: ${path}"
+}
+
+validate_upgrade_archive_layout() {
+	local archive=$1
+	python3 - "${archive}" <<'PY'
+import pathlib
+import posixpath
+import sys
+import tarfile
+
+archive = pathlib.Path(sys.argv[1])
+archive_size = archive.stat().st_size
+with tarfile.open(archive, mode="r:gz") as package:
+    members = package.getmembers()
+    if not members or len(members) > 100_000:
+        raise SystemExit("upgrade archive is empty or contains too many entries")
+    roots = set()
+    expanded_size = 0
+    for member in members:
+        raw = member.name
+        path = pathlib.PurePosixPath(raw)
+        if (
+            not raw
+            or path.is_absolute()
+            or any(part in {"", ".", ".."} for part in path.parts)
+        ):
+            raise SystemExit(f"upgrade archive contains an unsafe path: {raw!r}")
+        roots.add(path.parts[0])
+        if not (member.isdir() or member.isreg() or member.issym() or member.islnk()):
+            raise SystemExit(f"upgrade archive contains an unsupported entry: {raw!r}")
+        if member.isreg():
+            expanded_size += member.size
+        if member.issym() or member.islnk():
+            link = member.linkname
+            if not link or pathlib.PurePosixPath(link).is_absolute():
+                raise SystemExit(f"upgrade archive contains an unsafe link: {raw!r}")
+            base = posixpath.dirname(raw) if member.issym() else ""
+            resolved = pathlib.PurePosixPath(posixpath.normpath(posixpath.join(base, link)))
+            if not resolved.parts or resolved.parts[0] != path.parts[0] or ".." in resolved.parts:
+                raise SystemExit(f"upgrade archive link escapes its package root: {raw!r}")
+    if len(roots) != 1:
+        raise SystemExit("upgrade archive must contain exactly one package root")
+    if expanded_size > archive_size * 4 + 4 * 1024**3:
+        raise SystemExit("upgrade archive expands beyond the supported disk budget")
+PY
 }
 
 safe_assert_package_root() {
@@ -597,6 +649,193 @@ record_deployment_phase() {
 	mv "${temporary}" "${output}"
 }
 
+upgrade_artifact_sha256() {
+	local source=$1
+	if [[ -f "${source}" ]]; then
+		sha256sum "${source}" | awk '{print $1}'
+		return
+	fi
+	[[ -d "${source}" ]] || die "upgrade source is missing: ${source}"
+	# Directory upgrades are used by release verification. The canonical
+	# manifest identifies the same immutable images, payload and source commits.
+	sha256sum "${source}/MANIFEST.json" | awk '{print $1}'
+}
+
+initialize_upgrade_transaction() {
+	local artifact_sha=$1 version=$2
+	[[ "${artifact_sha}" =~ ^[0-9a-fA-F]{64}$ ]] \
+		|| die "upgrade artifact has an invalid SHA-256"
+	UPGRADE_ARTIFACT_SHA256="$(printf '%s' "${artifact_sha}" | tr 'A-F' 'a-f')"
+	artifact_sha="${UPGRADE_ARTIFACT_SHA256}"
+	UPGRADE_TRANSACTION_DIR="${ROOT}/deploy/upgrades/${artifact_sha}"
+	mkdir -p "${UPGRADE_TRANSACTION_DIR}"
+	chmod 700 "${ROOT}/deploy/upgrades" "${UPGRADE_TRANSACTION_DIR}"
+	if [[ -f "${UPGRADE_TRANSACTION_DIR}/state" ]]; then
+		local recorded_sha recorded_version
+		validate_upgrade_transaction_state || return $?
+		chmod 600 "${UPGRADE_TRANSACTION_DIR}/state"
+		recorded_sha="$(read_upgrade_transaction_value artifact_sha256)"
+		recorded_version="$(read_upgrade_transaction_value target_version)"
+		[[ "${recorded_sha}" == "${artifact_sha}" && "${recorded_version}" == "${version}" ]] \
+			|| die "upgrade transaction identity does not match the target package"
+		UPGRADE_TRANSACTION_PHASE="$(read_upgrade_transaction_value phase)"
+		log "Resuming upgrade transaction ${artifact_sha:0:12} from ${UPGRADE_TRANSACTION_PHASE:-validated}"
+	else
+		UPGRADE_TRANSACTION_PHASE=validated
+		write_upgrade_transaction_state active validated ""
+	fi
+	UPGRADE_TRANSACTION_INITIALIZED=1
+}
+
+validate_upgrade_transaction_state() {
+	local state="${UPGRADE_TRANSACTION_DIR}/state"
+	[[ -f "${state}" && ! -L "${state}" ]] \
+		|| die "upgrade transaction state is missing or unsafe"
+	python3 - "${state}" "${ROOT}/backup" <<'PY'
+import pathlib
+import re
+import sys
+
+state = pathlib.Path(sys.argv[1])
+backup_root = pathlib.Path(sys.argv[2])
+expected = {
+    "artifact_sha256",
+    "target_version",
+    "status",
+    "phase",
+    "backup_dir",
+    "updated_at",
+}
+values = {}
+for line in state.read_text(encoding="utf-8").splitlines():
+    if "=" not in line:
+        raise SystemExit("upgrade transaction state contains a malformed entry")
+    key, value = line.split("=", 1)
+    if key not in expected or key in values:
+        raise SystemExit("upgrade transaction state has unexpected or duplicate fields")
+    values[key] = value
+if set(values) != expected:
+    raise SystemExit("upgrade transaction state is incomplete")
+if not re.fullmatch(r"[0-9a-f]{64}", values["artifact_sha256"]):
+    raise SystemExit("upgrade transaction state has an invalid artifact identity")
+if not re.fullmatch(
+    r"(?:[0-9]+\.[0-9]+\.[0-9]+|main-[0-9a-f]{7})",
+    values["target_version"],
+):
+    raise SystemExit("upgrade transaction state has an invalid target version")
+if values["status"] not in {"active", "failed", "complete"}:
+    raise SystemExit("upgrade transaction state has an invalid status")
+phases = {
+    "validated",
+    "preflight_complete",
+    "backup_complete",
+    "images_loaded",
+    "background_paused",
+    "migrated",
+    "candidate_ready",
+    "hfl_switched",
+    "sourcelens_complete",
+    "gateway_verified",
+    "complete",
+}
+if values["phase"] not in phases:
+    raise SystemExit("upgrade transaction state has an invalid phase")
+backup_dir = values["backup_dir"]
+if backup_dir:
+    path = pathlib.Path(backup_dir)
+    if path.parent != backup_root or not re.fullmatch(
+        r"upgrade-[0-9]{8}-[0-9]{6}", path.name
+    ):
+        raise SystemExit("upgrade transaction state has an invalid backup path")
+if not re.fullmatch(
+    r"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\.[0-9]+)?Z",
+    values["updated_at"],
+):
+    raise SystemExit("upgrade transaction state has an invalid update time")
+PY
+}
+
+read_upgrade_transaction_value() {
+	local key=$1 state="${UPGRADE_TRANSACTION_DIR}/state"
+	[[ -f "${state}" ]] || return 0
+	grep -E "^${key}=" "${state}" 2>/dev/null | head -1 | cut -d= -f2- || true
+}
+
+write_upgrade_transaction_state() {
+	local status=$1 phase=$2 backup_dir=${3:-}
+	local output="${UPGRADE_TRANSACTION_DIR}/state" temporary="${UPGRADE_TRANSACTION_DIR}/state.tmp.$$"
+	case "${status}" in active | failed | complete) ;; *) die "invalid upgrade transaction status: ${status}" ;; esac
+	case "${phase}" in
+	validated | preflight_complete | backup_complete | images_loaded | background_paused | migrated | candidate_ready | hfl_switched | sourcelens_complete | gateway_verified | complete) ;;
+	*) die "invalid upgrade transaction phase: ${phase}" ;;
+	esac
+	[[ -n "${backup_dir}" ]] || backup_dir="$(read_upgrade_transaction_value backup_dir)"
+	if [[ -n "${backup_dir}" ]]; then
+		[[ "$(dirname -- "${backup_dir}")" == "${ROOT}/backup" \
+			&& "$(basename -- "${backup_dir}")" =~ ^upgrade-[0-9]{8}-[0-9]{6}$ ]] \
+			|| die "invalid upgrade transaction backup path: ${backup_dir}"
+	fi
+	{
+		printf 'artifact_sha256=%s\n' "${UPGRADE_ARTIFACT_SHA256}"
+		printf 'target_version=%s\n' "${UPGRADE_TARGET_VERSION}"
+		printf 'status=%s\n' "${status}"
+		printf 'phase=%s\n' "${phase}"
+		printf 'backup_dir=%s\n' "${backup_dir}"
+		printf 'updated_at=%s\n' "$(hfl_now)"
+	} >"${temporary}"
+	chmod 600 "${temporary}"
+	mv "${temporary}" "${output}"
+	UPGRADE_TRANSACTION_PHASE="${phase}"
+}
+
+record_upgrade_transaction_phase() {
+	write_upgrade_transaction_state active "$1" "${2:-}"
+}
+
+mark_upgrade_transaction_status() {
+	write_upgrade_transaction_state "$1" "${UPGRADE_TRANSACTION_PHASE:-validated}" ""
+}
+
+reusable_upgrade_backup() {
+	local backup_dir backup_name
+	backup_dir="$(read_upgrade_transaction_value backup_dir)"
+	backup_name="$(basename -- "${backup_dir:-.}")"
+	[[ "$(dirname -- "${backup_dir:-.}")" == "${ROOT}/backup" \
+		&& "${backup_name}" =~ ^upgrade-[0-9]{8}-[0-9]{6}$ \
+		&& -d "${backup_dir}" && ! -L "${backup_dir}" \
+		&& -s "${backup_dir}/backup-manifest.json" ]] || return 1
+	python3 - "${backup_dir}" <<'PY' || return 1
+import hashlib
+import json
+import pathlib
+import sys
+
+root = pathlib.Path(sys.argv[1])
+manifest = json.loads(
+    (root / "backup-manifest.json").read_text(encoding="utf-8")
+)
+if manifest.get("complete") is not True:
+    raise SystemExit(1)
+files = manifest.get("files") or []
+if not files:
+    raise SystemExit(1)
+for item in files:
+    name = str(item.get("name") or "")
+    if not name or pathlib.PurePath(name).name != name:
+        raise SystemExit(1)
+    path = root / name
+    if not path.is_file() or path.stat().st_size != int(item.get("size", -1)):
+        raise SystemExit(1)
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    if digest.hexdigest() != item.get("sha256"):
+        raise SystemExit(1)
+PY
+	printf '%s' "${backup_dir}"
+}
+
 read_active_color() {
 	local color=""
 	[[ -f "$(active_color_file)" ]] && color="$(tr -d '[:space:]' < "$(active_color_file)")"
@@ -714,12 +953,12 @@ start_hfl_stack() {
 	local color
 	ensure_blue_green_state
 	color="$(read_active_color)"
-	compose_in_root up -d --no-build --no-recreate postgres redis
-	compose_in_root --profile tools run --rm --no-deps migration
-	compose_in_root up -d --no-build worker scheduler
-	compose_color "${color}" up -d --no-build "api-${color}" "web-${color}"
+	compose_in_root up -d --no-build --pull never --no-recreate postgres redis
+	compose_in_root --profile tools run --rm --no-deps --pull never migration
+	compose_in_root up -d --no-build --pull never worker scheduler
+	compose_color "${color}" up -d --no-build --pull never "api-${color}" "web-${color}"
 	wait_for_color_health "${color}" || return 1
-	compose_in_root up -d --no-build nginx
+	compose_in_root up -d --no-build --pull never nginx
 	# Compose may recreate an active-color container with a new address while the
 	# stable gateway itself stays running. Reload so Nginx resolves the current
 	# service addresses instead of retaining a stale upstream from its last start.
@@ -1120,6 +1359,48 @@ print((root / "VERSION").read_text(encoding="utf-8").strip())
 PY
 }
 
+read_runtime_image_from_dir() {
+	local dir=$1 role=$2
+	python3 - "${dir}/MANIFEST.json" "${role}" <<'PY'
+import json
+import pathlib
+import sys
+
+manifest = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+role = sys.argv[2]
+runtime_images = manifest.get("runtime_images") or {}
+value = str(runtime_images.get(role) or "").strip()
+if not value:
+    image_version = str(manifest.get("image_version") or "").strip()
+    value = f"hyperfilelens-{role}:{image_version}"
+print(value)
+PY
+}
+
+read_edition_from_dir() {
+	local dir=$1
+	python3 - "${dir}/MANIFEST.json" <<'PY'
+import json
+import pathlib
+import sys
+
+manifest = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+print(str(manifest.get("edition") or "community").strip())
+PY
+}
+
+read_minimum_upgrade_version_from_dir() {
+	local dir=$1
+	python3 - "${dir}/MANIFEST.json" <<'PY'
+import json
+import pathlib
+import sys
+
+manifest = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+print(str(manifest.get("minimum_upgrade_version") or "").strip())
+PY
+}
+
 validate_package_identity() {
 	local dir=$1
 	python3 - "${dir}" <<'PY'
@@ -1137,6 +1418,8 @@ version_file = (root / "VERSION").read_text(encoding="utf-8").strip()
 edition = str(manifest.get("edition") or "community").strip()
 image_version = str(manifest.get("image_version") or version_file).strip()
 extension_commit = str(manifest.get("extension_commit") or "").strip().lower()
+runtime_images = manifest.get("runtime_images") or {}
+minimum_upgrade_version = str(manifest.get("minimum_upgrade_version") or "").strip()
 
 if not re.fullmatch(r"[0-9a-f]{40}", commit):
     raise SystemExit("release manifest has an invalid git_commit")
@@ -1161,9 +1444,36 @@ if version_file != expected:
     raise SystemExit("VERSION does not match the release manifest identity")
 if edition not in {"community", "enterprise"}:
     raise SystemExit("release package has an invalid edition")
-expected_image_version = version_file + ("-ee" if edition == "enterprise" else "")
-if image_version != expected_image_version:
-    raise SystemExit("release package image_version does not match its edition")
+if minimum_upgrade_version and not re.fullmatch(
+    r"[0-9]+\.[0-9]+\.[0-9]+", minimum_upgrade_version
+):
+    raise SystemExit("release package has an invalid minimum_upgrade_version")
+if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}", image_version):
+    raise SystemExit("release package has an invalid image_version")
+if not runtime_images:
+    runtime_images = {
+        "backend": f"hyperfilelens-backend:{image_version}",
+        "frontend": f"hyperfilelens-frontend:{image_version}",
+    }
+if set(runtime_images) != {"backend", "frontend"}:
+    raise SystemExit("release package runtime_images must identify backend and frontend")
+for role, ref in runtime_images.items():
+    if not re.fullmatch(
+        rf"hyperfilelens-{role}:[A-Za-z0-9][A-Za-z0-9._-]{{0,127}}",
+        str(ref),
+    ):
+        raise SystemExit(f"release package has an invalid {role} runtime image")
+runtime_refs = {
+    str(ref)
+    for entry in manifest.get("images", [])
+    if entry.get("role") == "hyperfilelens"
+    for ref in (entry.get("refs") or [])
+}
+for role, ref in runtime_images.items():
+    if ref not in runtime_refs:
+        raise SystemExit(
+            f"release package runtime image is absent from the HFL archive: {role}"
+        )
 if edition == "enterprise":
     if not re.fullmatch(r"[0-9a-f]{40}", extension_commit):
         raise SystemExit("Enterprise release package has an invalid extension_commit")
@@ -1438,9 +1748,12 @@ ensure_env_file() {
 		return 0
 	fi
 
-	local version image_version channel secret db_pass host
+	local version image_version edition backend_image frontend_image channel secret db_pass host
 	version="$(read_version)"
 	image_version="$(read_image_version_from_dir "${ROOT}")"
+	edition="$(read_edition_from_dir "${ROOT}")"
+	backend_image="$(read_runtime_image_from_dir "${ROOT}" backend)"
+	frontend_image="$(read_runtime_image_from_dir "${ROOT}" frontend)"
 	channel="$(read_channel_from_dir "${ROOT}")"
 	secret="$(random_hex)"
 	db_pass="$(random_hex | cut -c1-32)"
@@ -1453,13 +1766,24 @@ ensure_env_file() {
 	step "Creating .env from .env.example ..."
 	cp "${example}" "${env_file}"
 	chmod 600 "${env_file}"
-	python3 - "${env_file}" "${version}" "${image_version}" "${channel}" "${secret}" "${db_pass}" "${host}" <<'PY'
+	python3 - "${env_file}" "${version}" "${image_version}" "${edition}" \
+		"${backend_image}" "${frontend_image}" "${channel}" "${secret}" "${db_pass}" "${host}" <<'PY'
 import pathlib
 import re
 import sys
 
 path = pathlib.Path(sys.argv[1])
-version, image_version, channel, secret, db_pass, host = sys.argv[2:8]
+(
+    version,
+    image_version,
+    edition,
+    backend_image,
+    frontend_image,
+    channel,
+    secret,
+    db_pass,
+    host,
+) = sys.argv[2:11]
 text = path.read_text(encoding="utf-8")
 
 def sub_key(name, value):
@@ -1472,6 +1796,10 @@ def sub_key(name, value):
 
 sub_key("AGENT_VERSION", version)
 sub_key("APP_VERSION", image_version)
+sub_key("HFL_PRODUCT_VERSION", version)
+sub_key("HFL_EDITION", edition)
+sub_key("HFL_BACKEND_IMAGE", backend_image)
+sub_key("HFL_FRONTEND_IMAGE", frontend_image)
 sub_key("HFL_GATEWAY_VERSION", image_version)
 sub_key("HFL_RELEASE_CHANNEL", channel)
 sub_key("SECRET_KEY", secret)
@@ -1811,17 +2139,29 @@ update_env_versions() {
 	local version=$1
 	local channel=$2
 	local image_version=${3:-$1}
-	python3 - "${ROOT}" "${version}" "${channel}" "${image_version}" <<'PY'
+	local edition=${4:-community}
+	local backend_image=${5:-hyperfilelens-backend:${image_version}}
+	local frontend_image=${6:-hyperfilelens-frontend:${image_version}}
+	python3 - "${ROOT}" "${version}" "${channel}" "${image_version}" \
+		"${edition}" "${backend_image}" "${frontend_image}" <<'PY'
 import pathlib, re, sys
 root = pathlib.Path(sys.argv[1])
 version = sys.argv[2]
 channel = sys.argv[3]
 image_version = sys.argv[4]
+edition, backend_image, frontend_image = sys.argv[5:8]
 env = root / ".env"
 if not env.exists():
     raise SystemExit(0)
 text = env.read_text(encoding="utf-8")
-for key, value in (("AGENT_VERSION", version), ("APP_VERSION", image_version)):
+for key, value in (
+    ("AGENT_VERSION", version),
+    ("APP_VERSION", image_version),
+    ("HFL_PRODUCT_VERSION", version),
+    ("HFL_EDITION", edition),
+    ("HFL_BACKEND_IMAGE", backend_image),
+    ("HFL_FRONTEND_IMAGE", frontend_image),
+):
     pattern = rf"^({re.escape(key)}=).*$"
     if re.search(pattern, text, flags=re.M):
         text = re.sub(pattern, lambda m, v=value: f"{m.group(1)}{v}", text, count=1, flags=re.M)
@@ -2011,7 +2351,8 @@ PY
 }
 
 prune_upgrade_backups() {
-	python3 - "${ROOT}/backup" <<'PY' || return 1
+	python3 - "${ROOT}/backup" "${ROOT}/deploy/upgrades" <<'PY' || return 1
+import json
 import pathlib
 import re
 import shutil
@@ -2019,8 +2360,28 @@ import sys
 import time
 
 root = pathlib.Path(sys.argv[1])
+transactions = pathlib.Path(sys.argv[2])
 if not root.is_dir():
     raise SystemExit(0)
+
+protected = set()
+if transactions.is_dir():
+    for state in transactions.glob("*/state"):
+        values = {}
+        for line in state.read_text(encoding="utf-8").splitlines():
+            if "=" in line:
+                key, value = line.split("=", 1)
+                values[key] = value
+        if values.get("status") == "complete":
+            continue
+        backup_dir = values.get("backup_dir", "")
+        backup_path = pathlib.Path(backup_dir)
+        try:
+            managed = backup_path.parent.resolve() == root.resolve()
+        except OSError:
+            managed = False
+        if managed and re.fullmatch(r"upgrade-\d{8}-\d{6}", backup_path.name):
+            protected.add(backup_path.name)
 
 now = time.time()
 for path in root.glob(".partial-*"):
@@ -2043,6 +2404,9 @@ for path in root.iterdir():
 
 for stamp in sorted(groups, reverse=True)[3:]:
     for path in groups[stamp]:
+        if path.name in protected:
+            print(f"[install.sh] retaining transaction backup {path.name}")
+            continue
         print(f"[install.sh] pruning expired managed backup {path.name}")
         shutil.rmtree(path) if path.is_dir() else path.unlink(missing_ok=True)
 PY
@@ -2180,14 +2544,18 @@ managed_image_ref_is_in_use() {
 }
 
 prune_old_managed_image_refs() {
-	local backup_manifest="" ref output
+	local backup_manifest="" gateway_version ref output
 	local -a removable=()
 	command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1 || return 0
+	gateway_version="$(grep -E '^HFL_GATEWAY_VERSION=' "${ROOT}/.env" 2>/dev/null \
+		| head -1 | cut -d= -f2- | tr -d ' "' || true)"
 	backup_manifest="$(find "${ROOT}/backup" -mindepth 2 -maxdepth 2 -type f \
 		-path '*/upgrade-*/MANIFEST.json' -print 2>/dev/null | sort -r | head -1)"
-	if ! output="$(python3 - "${ROOT}/MANIFEST.json" "${backup_manifest}" <<'PY'
+	if ! output="$(python3 - "${ROOT}/MANIFEST.json" "${backup_manifest}" \
+		"${gateway_version}" <<'PY'
 import json
 import pathlib
+import re
 import subprocess
 import sys
 
@@ -2199,7 +2567,7 @@ managed_repositories = {
     "hyperfilelens-sourcelens-lensnode",
 }
 protected = set()
-for raw in sys.argv[1:]:
+for raw in sys.argv[1:3]:
     path = pathlib.Path(raw) if raw else None
     if not path or not path.is_file():
         continue
@@ -2209,6 +2577,10 @@ for raw in sys.argv[1:]:
         continue
     for image in manifest.get("images", []):
         protected.update(str(ref) for ref in image.get("refs", []) if ref)
+
+gateway_version = sys.argv[3]
+if re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}", gateway_version):
+    protected.add(f"hyperfilelens-frontend:{gateway_version}")
 
 containers = subprocess.run(
     ["docker", "ps", "-aq", "--no-trunc"],
@@ -2368,6 +2740,7 @@ prepare_upgrade_source() {
 	fi
 	if [[ -f "${from}" && "${from}" == *.tar.gz ]]; then
 		safe_assert_upgrade_package_file "${from}"
+		validate_upgrade_archive_layout "${from}"
 		safe_rm_dir "${UPGRADE_TMP}"
 		mkdir -p "${UPGRADE_TMP}"
 		step "Extracting ${from} -> ${UPGRADE_TMP} ..."
@@ -2378,7 +2751,7 @@ prepare_upgrade_source() {
 		printf '%s' "${inner}"
 		return 0
 	fi
-	die "upgrade --from must be a directory or hyperfilelens-*.tar.gz: ${from}"
+	die "upgrade --from must be a release directory or .tar.gz package: ${from}"
 }
 
 cleanup_upgrade_tmp() {
@@ -4155,7 +4528,9 @@ cmd_backup() {
 cmd_upgrade() {
 	local from="" allow_main_build=0
 	local sourcelens_mode=-1 remove_sourcelens=0 purge_sourcelens_data=0
-	local src_root new_version cur_version new_channel cur_channel upgrade_sourcelens=0 backup_stamp
+	local src_root new_version cur_version new_channel cur_channel minimum_upgrade_version
+	local upgrade_sourcelens=0 backup_stamp
+	local artifact_sha transaction_status reusable_backup
 	local target_color running_worker_ids
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
@@ -4187,13 +4562,30 @@ cmd_upgrade() {
 	log "======== HyperFileLens upgrade ${cur_version} ========"
 
 	trap cleanup_upgrade_and_finish EXIT
+	artifact_sha="${UPGRADE_ARTIFACT_SHA256:-}"
+	[[ -n "${artifact_sha}" ]] || artifact_sha="$(upgrade_artifact_sha256 "${from}")"
 	src_root="$(prepare_upgrade_source "${from}")"
 	validate_package_identity "${src_root}"
 	new_version="$(read_version_from_dir "${src_root}")"
+	minimum_upgrade_version="$(read_minimum_upgrade_version_from_dir "${src_root}")"
+	UPGRADE_TARGET_VERSION="${new_version}"
 	cur_channel="$(read_channel_from_dir "${ROOT}")"
 	new_channel="$(read_channel_from_dir "${src_root}")"
 	if [[ "${new_channel}" == "main" && "${allow_main_build}" -ne 1 ]]; then
 		die "main channel packages require --allow-main-build"
+	fi
+	if [[ -n "${minimum_upgrade_version}" && "${cur_channel}" == "release" ]] \
+		&& version_lt "${cur_version}" "${minimum_upgrade_version}"; then
+		die "installed version ${cur_version} is below this package's supported upgrade baseline ${minimum_upgrade_version}"
+	fi
+	initialize_upgrade_transaction "${artifact_sha}" "${new_version}"
+	transaction_status="$(read_upgrade_transaction_value status)"
+	if [[ "${transaction_status}" == "complete" && "${new_version}" == "${cur_version}" ]] \
+		&& cmp -s "${src_root}/MANIFEST.json" "${ROOT}/MANIFEST.json"; then
+		ok "Upgrade transaction ${artifact_sha:0:12} is already complete"
+		cleanup_upgrade_tmp
+		trap finish_session EXIT
+		return 0
 	fi
 
 	if [[ "${new_version}" == "${cur_version}" ]]; then
@@ -4211,12 +4603,19 @@ cmd_upgrade() {
 	# host recoverable when an older failed upgrade already removed the links.
 	repair_sourcelens_runtime_bindings
 	preflight_redis_recovery
+	record_upgrade_transaction_phase preflight_complete
 
 	step "[2/8] Backing up current config and data ..."
-	backup_stamp="$(date +%Y%m%d-%H%M%S)"
-	create_managed_backup "${backup_stamp}" 0 \
-		|| die "managed upgrade backup failed; existing services were not stopped"
-	UPGRADE_BACKUP_DIR="${ROOT}/backup/upgrade-${backup_stamp}"
+	if reusable_backup="$(reusable_upgrade_backup)"; then
+		UPGRADE_BACKUP_DIR="${reusable_backup}"
+		log "Reusing verified managed backup ${UPGRADE_BACKUP_DIR}"
+	else
+		backup_stamp="$(date +%Y%m%d-%H%M%S)"
+		create_managed_backup "${backup_stamp}" 1 \
+			|| die "managed upgrade backup failed; existing services were not stopped"
+		UPGRADE_BACKUP_DIR="${ROOT}/backup/upgrade-${backup_stamp}"
+	fi
+	record_upgrade_transaction_phase backup_complete "${UPGRADE_BACKUP_DIR}"
 
 	step "[3/8] Validating upgrade package ..."
 	preflight_blue_green_source "${src_root}"
@@ -4249,6 +4648,7 @@ cmd_upgrade() {
 
 	step "Preloading verified target images before the maintenance window ..."
 	load_images_from_manifest "$([[ "${upgrade_sourcelens}" -eq 0 ]] && echo 1 || echo 0)" "${src_root}"
+	record_upgrade_transaction_phase images_loaded
 
 	step "[5/8] Selecting the inactive color and pausing background execution ..."
 	if compose_in_root ps -q 2>/dev/null | grep -q .; then
@@ -4282,6 +4682,7 @@ cmd_upgrade() {
 	fi
 	[[ -z "${running_worker_ids}" ]] \
 		|| die "old worker is still running; refusing to apply task-state migrations"
+	record_upgrade_transaction_phase background_paused
 
 	step "[6/8] Applying target files, configuration, and singleton migration ..."
 	# Existing releases used APP_VERSION for stable Nginx. Pin that currently
@@ -4293,7 +4694,13 @@ cmd_upgrade() {
 		# Do not claim a blue active pool while the legacy API still owns traffic.
 		safe_rm_file "$(active_color_file)"
 	fi
-	update_env_versions "${new_version}" "${new_channel}" "$(read_image_version_from_dir "${src_root}")"
+	update_env_versions \
+		"${new_version}" \
+		"${new_channel}" \
+		"$(read_image_version_from_dir "${src_root}")" \
+		"$(read_edition_from_dir "${src_root}")" \
+		"$(read_runtime_image_from_dir "${src_root}" backend)" \
+		"$(read_runtime_image_from_dir "${src_root}" frontend)"
 	if [[ "$(configured_sourcelens_mode)" == "bundled" ]] \
 		&& sourcelens_installed \
 		&& [[ "${remove_sourcelens}" -eq 0 ]]; then
@@ -4304,22 +4711,25 @@ cmd_upgrade() {
 
 	ensure_data_dirs
 	sync_runtime_media
-	compose_in_root up -d --no-recreate postgres redis
-	compose_in_root --profile tools run --rm --no-deps migration
+	compose_in_root up -d --no-build --pull never --no-recreate postgres redis
+	compose_in_root --profile tools run --rm --no-deps --pull never migration
 	record_deployment_phase migrated "${UPGRADE_PREVIOUS_COLOR}" "${target_color}" "${new_version}"
+	record_upgrade_transaction_phase migrated
 
 	step "[7/8] Starting ${target_color}, switching stable traffic, and handing off workers ..."
-	compose_color "${target_color}" up -d --no-build \
+	compose_color "${target_color}" up -d --no-build --pull never \
 		"api-${target_color}" "web-${target_color}"
 	wait_for_color_health "${target_color}" \
 		|| die "inactive ${target_color} API/Web pool failed its readiness gate"
 	record_deployment_phase candidate_ready "${UPGRADE_PREVIOUS_COLOR}" "${target_color}" "${new_version}"
+	record_upgrade_transaction_phase candidate_ready
 	cutover_hfl_color "${UPGRADE_PREVIOUS_COLOR}" "${target_color}" \
 		|| die "blue/green cutover failed; previous traffic route was restored"
 	record_deployment_phase switched "${UPGRADE_PREVIOUS_COLOR}" "${target_color}" "${new_version}"
+	record_upgrade_transaction_phase hfl_switched
 	# The active API/Web pool is now authoritative; start singleton consumers
 	# from the target release and recover any returned in-flight work.
-	compose_in_root up -d --no-build worker scheduler
+	compose_in_root up -d --no-build --pull never worker scheduler
 	wait_for_services_health "${HFL_HEALTH_TIMEOUT_SECONDS:-600}" \
 		postgres redis worker scheduler "api-${target_color}" "web-${target_color}" nginx \
 		&& wait_for_public_endpoints \
@@ -4360,11 +4770,14 @@ cmd_upgrade() {
 	if [[ "${SOURCELENS_PROXY_GATE_ARMED}" == "1" ]]; then
 		clear_sourcelens_proxy_gate
 	fi
+	record_upgrade_transaction_phase sourcelens_complete
 	sync_optional_identity_settings
 	check_local_platform_gateway_continuity
+	record_upgrade_transaction_phase gateway_verified
 	prune_agent_release_media
 	prune_old_managed_image_refs
 	record_deployment_phase complete "${UPGRADE_PREVIOUS_COLOR}" "${target_color}" "${new_version}"
+	write_upgrade_transaction_state complete complete "${UPGRADE_BACKUP_DIR}"
 	UPGRADE_RECOVERY_ARMED=0
 
 	step "[8/8] Cleaning up temporary directory ..."

--- a/docs/release-workflows.md
+++ b/docs/release-workflows.md
@@ -33,6 +33,12 @@ TEST and PROD deployment are enabled unless `TEST_AUTO_DEPLOY` or
 `PROD_AUTO_DEPLOY` is explicitly set to `false`. Automatic PROD promotion runs
 only after TEST deployment succeeds in the same workflow run.
 
+The package manifest and SHA-256 are the release identity; the archive filename
+is only a human-facing convention. Deployment never derives runtime image tags
+from the product version and never pulls a missing image from a registry. The
+manifest supplies complete Backend and Frontend image references, and every
+Compose start uses only verified offline image archives.
+
 `HFL - Enterprise PROD Promotion` is the manual promotion path. It accepts a
 valid Enterprise version already present on the TEST host, validates its
 manifest and checksum, copies that package from TEST to PROD, and deploys it.
@@ -40,6 +46,21 @@ It is not controlled by `PROD_AUTO_DEPLOY` and does not require an additional
 status marker. Package deployment still follows the installer's compatibility
 rules; database rollback uses a verified managed backup rather than installing
 an older package over newer data.
+
+## Upgrade transactions
+
+Each package SHA-256 owns one upgrade transaction under
+`deploy/upgrades/<sha256>/`. The transaction records validation, image loading,
+the managed backup, migration, HFL cutover, SourceLens convergence, Gateway
+verification, and completion. Retrying the same package reuses its verified
+backup and safely replays idempotent gates instead of creating another large
+backup. Backups referenced by unfinished transactions are excluded from
+retention cleanup. Reapplying an already-completed identical package returns
+success without touching running services.
+
+Release packages declare `minimum_upgrade_version` in `MANIFEST.json`, keeping
+compatibility policy with the target release rather than hard-coding it in the
+installed bootstrap. The current supported upgrade baseline is `0.1.34`.
 
 ## Community
 

--- a/release/build.sh
+++ b/release/build.sh
@@ -529,7 +529,9 @@ stage_release_env_example() {
 	local example="${pkg_root}/.env.example"
 	cp "${ROOT}/.env.example" "${example}"
 	HFL_EXTENSIONS_RUNTIME="${HFL_EXTENSIONS_RUNTIME:-}" \
-		HFL_IMAGE_VERSION="${HFL_IMAGE_VERSION:-}" python3 - "${example}" <<'PY'
+		HFL_IMAGE_VERSION="${HFL_IMAGE_VERSION:-}" \
+		HFL_RELEASE_EDITION="${HFL_RELEASE_EDITION:-community}" \
+		HFL_VERSION="${HFL_VERSION:-}" python3 - "${example}" <<'PY'
 import os
 import pathlib
 import re
@@ -540,8 +542,20 @@ text = path.read_text(encoding="utf-8")
 text = re.sub(r"(?m)^[ \t]*HFL_EXTENSIONS=.*\n?", "", text)
 runtime = os.environ.get("HFL_EXTENSIONS_RUNTIME", "").strip()
 image_version = os.environ.get("HFL_IMAGE_VERSION", "").strip()
+product_version = os.environ.get("HFL_VERSION", "").strip()
+edition = os.environ.get("HFL_RELEASE_EDITION", "community").strip()
 if image_version:
-    text = re.sub(r"(?m)^APP_VERSION=.*$", f"APP_VERSION={image_version}", text, count=1)
+    replacements = {
+        "APP_VERSION": image_version,
+        "HFL_PRODUCT_VERSION": product_version,
+        "HFL_EDITION": edition,
+        "HFL_BACKEND_IMAGE": f"hyperfilelens-backend:{image_version}",
+        "HFL_FRONTEND_IMAGE": f"hyperfilelens-frontend:{image_version}",
+    }
+    for key, value in replacements.items():
+        text = re.sub(
+            rf"(?m)^{re.escape(key)}=.*$", f"{key}={value}", text, count=1
+        )
 if runtime:
     block = (
         "\n# Baked into this release's control-plane images (Open Core).\n"
@@ -1105,9 +1119,14 @@ manifest = {
     "product": "hyperfilelens",
     "edition": edition,
     "image_version": image_version,
+    "runtime_images": {
+        "backend": f"hyperfilelens-backend:{image_version}",
+        "frontend": f"hyperfilelens-frontend:{image_version}",
+    },
     "channel": "main" if version.startswith("main-") else "release",
     "artifact_id": version if version.startswith("main-") else f"v{version}",
     "built_at": built_at,
+    "minimum_upgrade_version": "0.1.34",
     "git_commit": commit,
     "host_runtime": {
         "os_id": "ubuntu",
@@ -1131,11 +1150,8 @@ manifest = {
 }
 if edition not in {"community", "enterprise"}:
     raise SystemExit(f"invalid release edition: {edition}")
-expected_image_version = version + ("-ee" if edition == "enterprise" else "")
-if image_version != expected_image_version:
-    raise SystemExit(
-        f"image version {image_version} does not match {edition} release {version}"
-    )
+if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}", image_version):
+    raise SystemExit(f"invalid image version: {image_version}")
 if edition == "enterprise":
     if not re.fullmatch(r"[0-9a-f]{40}", extension_commit):
         raise SystemExit("Enterprise release requires an immutable extension commit")

--- a/release/ci/assemble-release.sh
+++ b/release/ci/assemble-release.sh
@@ -201,7 +201,9 @@ if [[ -z "${HFL_EXTENSIONS_RUNTIME}" && -n "${HFL_EXTENSION_SOURCES:-}" ]]; then
 fi
 export HFL_EXTENSIONS_RUNTIME
 HFL_IMAGE_VERSION="${version}${edition_suffix}"
-export HFL_IMAGE_VERSION
+HFL_VERSION="${version}"
+HFL_RELEASE_EDITION="${edition}"
+export HFL_IMAGE_VERSION HFL_VERSION HFL_RELEASE_EDITION
 stage_release_env_example "${pkg_root}"
 cp "${ROOT}/LICENSE" "${pkg_root}/LICENSE"
 mkdir -p \

--- a/src/backend/apps/instance_settings/services/environment_payload.py
+++ b/src/backend/apps/instance_settings/services/environment_payload.py
@@ -106,7 +106,11 @@ def deploy_profile_staff_payload() -> dict:
         "password_reset_available": password_reset_available(),
         "tenant_public_url": tenant_public_url(),
         "platform_ops_allowed_cidrs": platform_ops_allowed_cidrs(),
-        "app_version": os.getenv("APP_VERSION", "").strip() or None,
+        "app_version": (
+            os.getenv("HFL_PRODUCT_VERSION", "").strip()
+            or os.getenv("APP_VERSION", "").strip()
+            or None
+        ),
         "agent_version": os.getenv("AGENT_VERSION", "").strip() or None,
         "django_debug": bool(getattr(settings, "DEBUG", False)),
         "sentry_enabled": bool(getattr(settings, "SENTRY_ENABLED", False)),

--- a/src/backend/apps/lens_bridge/migrations/0031_session_create_and_capacity_state.py
+++ b/src/backend/apps/lens_bridge/migrations/0031_session_create_and_capacity_state.py
@@ -9,7 +9,6 @@ _MIN_BIGINT = -(2**63)
 def prepare_incomplete_session_reservations(apps, schema_editor):
     """Make every in-flight legacy Chat rebuild its trusted reservation."""
 
-    del schema_editor
     session_model = apps.get_model("lens_bridge", "LensSessionLink")
     # Every row present while this migration runs predates durable reservations.
     # Existing workspaces remain the usage authority until a new/retried Chat
@@ -35,6 +34,11 @@ def prepare_incomplete_session_reservations(apps, schema_editor):
             capacity_reserved_bytes=0,
             capacity_reserved_at=None,
         )
+    # Django creates indexes for the new db_index fields when the schema editor
+    # exits. Settle deferred foreign-key trigger events from the backfill first
+    # so PostgreSQL can create those indexes in this atomic migration.
+    if schema_editor.connection.vendor == "postgresql":
+        schema_editor.execute("SET CONSTRAINTS ALL IMMEDIATE")
 
 
 def _has_nonnegative_summary(scope):

--- a/src/backend/apps/monitor/services/internal/deployment_host.py
+++ b/src/backend/apps/monitor/services/internal/deployment_host.py
@@ -88,7 +88,10 @@ def current_host_identity() -> dict:
         "platform": platform.platform(),
         "python_version": platform.python_version(),
         "ip_address": _primary_ip(),
-        "app_version": os.getenv("APP_VERSION", "").strip() or "",
+        "app_version": (
+            os.getenv("HFL_PRODUCT_VERSION", "").strip()
+            or os.getenv("APP_VERSION", "").strip()
+        ),
         "boot_time": system_boot_time(),
     }
 

--- a/src/backend/common/ops/health.py
+++ b/src/backend/common/ops/health.py
@@ -45,7 +45,11 @@ def readiness(_request) -> JsonResponse:
     payload: dict[str, Any] = {
         "ok": ok,
         "time": timezone.now().isoformat(),
-        "version": str(os.getenv("APP_VERSION", "")).strip() or "0.0.0",
+        "version": (
+            str(os.getenv("HFL_PRODUCT_VERSION", "")).strip()
+            or str(os.getenv("APP_VERSION", "")).strip()
+            or "0.0.0"
+        ),
         "checks": [asdict(r) for r in results],
     }
     return JsonResponse(payload, status=200 if ok else 503)
@@ -59,4 +63,3 @@ def liveness(_request) -> JsonResponse:
         },
         status=200,
     )
-

--- a/src/backend/common/tests/test_health.py
+++ b/src/backend/common/tests/test_health.py
@@ -1,0 +1,43 @@
+"""Health endpoint product identity tests."""
+
+from __future__ import annotations
+
+import json
+import os
+from unittest.mock import patch
+
+from django.test import RequestFactory, SimpleTestCase
+
+from apps.monitor.services.internal.deployment_host import current_host_identity
+from common.ops.health import CheckResult, readiness
+
+
+class ReadinessVersionTests(SimpleTestCase):
+    def test_readiness_prefers_product_version_over_image_version(self):
+        with (
+            patch.dict(
+                os.environ,
+                {"HFL_PRODUCT_VERSION": "1.2.3", "APP_VERSION": "1.2.3-ee"},
+                clear=False,
+            ),
+            patch("common.ops.health._check_db", return_value=CheckResult("database", True)),
+            patch("common.ops.health._check_cache", return_value=CheckResult("cache", True)),
+        ):
+            response = readiness(RequestFactory().get("/health/ready"))
+
+        payload = json.loads(response.content)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(payload["version"], "1.2.3")
+
+    def test_host_identity_prefers_product_version_over_image_version(self):
+        with patch.dict(
+            os.environ,
+            {"HFL_PRODUCT_VERSION": "1.2.3", "APP_VERSION": "1.2.3-ee"},
+            clear=False,
+        ), patch(
+            "apps.monitor.services.internal.deployment_host._primary_ip",
+            return_value=None,
+        ):
+            identity = current_host_identity()
+
+        self.assertEqual(identity["app_version"], "1.2.3")

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -17,6 +17,8 @@ grep -F './tools/quality/test-sourcelens-submodule-recovery.sh' \
 	"${ROOT}/.github/workflows/artifact_pipeline.yml" >/dev/null
 grep -F './tools/quality/test-dev-stack-upgrade.sh' \
 	"${ROOT}/.github/workflows/artifact_pipeline.yml" >/dev/null
+grep -F './tools/quality/test-upgrade-transaction.sh' \
+	"${ROOT}/.github/workflows/artifact_pipeline.yml" >/dev/null
 
 # shellcheck source=../lib/version.sh
 source "${ROOT}/tools/lib/version.sh"
@@ -844,7 +846,7 @@ if grep -F 'compose_in_root down' <<<"${upgrade_body}" >/dev/null; then
 fi
 worker_stop_line="$(grep -n -F 'compose_in_root stop --timeout 600 worker' <<<"${upgrade_body}" | head -1 | cut -d: -f1)"
 worker_stopped_line="$(grep -n -F 'compose_in_root ps --status running -q worker' <<<"${upgrade_body}" | head -1 | cut -d: -f1)"
-migration_line="$(grep -n -F 'compose_in_root --profile tools run --rm --no-deps migration' <<<"${upgrade_body}" | head -1 | cut -d: -f1)"
+migration_line="$(grep -n -F 'compose_in_root --profile tools run --rm --no-deps --pull never migration' <<<"${upgrade_body}" | head -1 | cut -d: -f1)"
 if [[ -z "${worker_stop_line}" \
 	|| -z "${worker_stopped_line}" \
 	|| -z "${migration_line}" \

--- a/tools/quality/test-blue-green-recovery.sh
+++ b/tools/quality/test-blue-green-recovery.sh
@@ -51,10 +51,11 @@ grep -Fx 'LENS_GATEWAY_BASE_URL=https://app.example.invalid/sourcelens' \
 
 calls=()
 start_hfl_stack
-[[ " ${calls[*]} " == *" color:blue up -d --no-build api-blue web-blue "* ]]
+[[ " ${calls[*]} " == *" color:blue up -d --no-build --pull never api-blue web-blue "* ]]
 [[ " ${calls[*]} " == *" color-health:blue "* ]]
-[[ " ${calls[*]} " == *" compose:up -d --no-build nginx reload "* ]]
+[[ " ${calls[*]} " == *" compose:up -d --no-build --pull never nginx reload "* ]]
 
+calls=()
 UPGRADE_HFL_WAS_RUNNING=1
 UPGRADE_SOURCELENS_WAS_RUNNING=0
 UPGRADE_PREVIOUS_COLOR=blue
@@ -65,14 +66,14 @@ recover_upgrade_services
 [[ " ${calls[*]} " == *" active:blue "* ]]
 [[ " ${calls[*]} " != *" active:green "* ]]
 [[ " ${calls[*]} " == *" compose:start worker scheduler "* ]]
-[[ " ${calls[*]} " != *" compose:up -d --no-build worker scheduler "* ]]
+[[ " ${calls[*]} " != *" compose:up -d --no-build --pull never worker scheduler "* ]]
 
 calls=()
 UPGRADE_HFL_COMMITTED=1
 recover_upgrade_services
 [[ " ${calls[*]} " == *" render:green "* ]]
 [[ " ${calls[*]} " == *" active:green "* ]]
-[[ " ${calls[*]} " == *" compose:up -d --no-build worker scheduler "* ]]
+[[ " ${calls[*]} " == *" compose:up -d --no-build --pull never worker scheduler "* ]]
 
 calls=()
 UPGRADE_HFL_CUTOVER_ATTEMPTED=1

--- a/tools/quality/test-ci-release-assembly.sh
+++ b/tools/quality/test-ci-release-assembly.sh
@@ -175,11 +175,11 @@ HFL_CI_RELEASE_BUILD_DIR="${output}" \
 	else
 		if [[ "${edition}" == enterprise ]]; then
 			jq -e --arg version "${version}" \
-				'.channel == "release" and .artifact_id == ("v" + $version) and .version == $version and .edition == "enterprise" and .image_version == ($version + "-ee") and .extension_commit == "89abcdef0123456789abcdef0123456789abcdef"' \
+				'.channel == "release" and .artifact_id == ("v" + $version) and .version == $version and .edition == "enterprise" and .image_version == ($version + "-ee") and .runtime_images.backend == ("hyperfilelens-backend:" + $version + "-ee") and .runtime_images.frontend == ("hyperfilelens-frontend:" + $version + "-ee") and .minimum_upgrade_version == "0.1.34" and .extension_commit == "89abcdef0123456789abcdef0123456789abcdef"' \
 				MANIFEST.json >/dev/null
 		else
 			jq -e --arg version "${version}" \
-				'.channel == "release" and .artifact_id == ("v" + $version) and .version == $version and .edition == "community" and .image_version == $version and (has("extension_commit") | not)' \
+				'.channel == "release" and .artifact_id == ("v" + $version) and .version == $version and .edition == "community" and .image_version == $version and .runtime_images.backend == ("hyperfilelens-backend:" + $version) and .runtime_images.frontend == ("hyperfilelens-frontend:" + $version) and .minimum_upgrade_version == "0.1.34" and (has("extension_commit") | not)' \
 				MANIFEST.json >/dev/null
 		fi
 	fi
@@ -189,6 +189,16 @@ HFL_CI_RELEASE_BUILD_DIR="${output}" \
 	[[ -n "${first}" ]]
 	archive="${first%.part-000}"
 	cat "${archive}.part-"* >"${archive}"
+	env_example="$(tar -xOzf "${archive}" --wildcards '*/.env.example')"
+	grep -Fx "HFL_PRODUCT_VERSION=${version}" <<<"${env_example}" >/dev/null
+	grep -Fx "HFL_EDITION=${edition}" <<<"${env_example}" >/dev/null
+	image_suffix=""
+	[[ "${edition}" == enterprise ]] && image_suffix="-ee"
+	grep -Fx "APP_VERSION=${version}${image_suffix}" <<<"${env_example}" >/dev/null
+	grep -Fx "HFL_BACKEND_IMAGE=hyperfilelens-backend:${version}${image_suffix}" \
+		<<<"${env_example}" >/dev/null
+	grep -Fx "HFL_FRONTEND_IMAGE=hyperfilelens-frontend:${version}${image_suffix}" \
+		<<<"${env_example}" >/dev/null
 	tar -tzf "${archive}" | grep -E '/sync-env\.py$' >/dev/null
 	tar -tzf "${archive}" | grep -E '/apply-runtime-config\.py$' >/dev/null
 	tar -tzf "${archive}" | grep -E '/deploy/nginx/certs/tls\.crt$' >/dev/null

--- a/tools/quality/test-deployment-optional-config.sh
+++ b/tools/quality/test-deployment-optional-config.sh
@@ -249,7 +249,7 @@ assert start.index("wait_for_hfl_health") < start.index("sync_optional_identity_
 assert upgrade.index("apply_upgrade_files") < upgrade.index("apply_runtime_configuration")
 assert upgrade.index("apply_runtime_configuration") < upgrade.index("install_bundled_sourcelens")
 assert upgrade.index("apply_runtime_configuration") < upgrade.index(
-    "compose_in_root up -d --no-recreate postgres redis"
+    "compose_in_root up -d --no-build --pull never --no-recreate postgres redis"
 )
 assert upgrade.index("wait_for_services_health") < upgrade.index(
     "sync_optional_identity_settings"

--- a/tools/quality/test-enterprise-release-flow.sh
+++ b/tools/quality/test-enterprise-release-flow.sh
@@ -19,10 +19,30 @@ tmp_guard="$(mktemp -d)"
 trap 'rm -rf "${tmp_guard}"' EXIT
 touch "${tmp_guard}/hyperfilelens-1.2.3.tar.gz" \
 	"${tmp_guard}/hyperfilelens-1.2.3-ee.tar.gz" \
-	"${tmp_guard}/hyperfilelens-1.2.3-abcdef0.tar.gz"
+	"${tmp_guard}/hyperfilelens-1.2.3-abcdef0.tar.gz" \
+	"${tmp_guard}/customer-release.tar.gz"
 safe_assert_upgrade_package_file "${tmp_guard}/hyperfilelens-1.2.3.tar.gz"
 safe_assert_upgrade_package_file "${tmp_guard}/hyperfilelens-1.2.3-ee.tar.gz"
 safe_assert_upgrade_package_file "${tmp_guard}/hyperfilelens-1.2.3-abcdef0.tar.gz"
+safe_assert_upgrade_package_file "${tmp_guard}/customer-release.tar.gz"
+if (safe_assert_package_basename '../unsafe.tar.gz') >/dev/null 2>&1; then
+	printf 'ERROR: unsafe package basename passed validation\n' >&2
+	exit 1
+fi
+python3 - "${tmp_guard}/unsafe.tar.gz" <<'PY'
+import io
+import sys
+import tarfile
+
+with tarfile.open(sys.argv[1], "w:gz") as archive:
+    item = tarfile.TarInfo("../escape")
+    item.size = 1
+    archive.addfile(item, io.BytesIO(b"x"))
+PY
+if (validate_upgrade_archive_layout "${tmp_guard}/unsafe.tar.gz") >/dev/null 2>&1; then
+	printf 'ERROR: unsafe upgrade archive layout passed validation\n' >&2
+	exit 1
+fi
 rm -rf "${tmp_guard}"
 trap - EXIT
 
@@ -66,6 +86,7 @@ grep -F 'Community releases must be started from the main branch' \
 	"${entry_community}" >/dev/null
 grep -F "vars.TEST_AUTO_DEPLOY != 'false'" "${workflow}" >/dev/null
 grep -F "vars.PROD_AUTO_DEPLOY != 'false'" "${workflow}" >/dev/null
+grep -F 'needs.deploy-test.result == '\''success'\''' "${workflow}" >/dev/null
 grep -F "vars.COMMUNITY_AUTO_DEPLOY != 'false'" "${workflow}" >/dev/null
 grep -F 'ENTERPRISE_EXTENSION_REPOSITORY' "${workflow}" >/dev/null
 grep -F 'secrets.ENTERPRISE_EXTENSION_GIT_TOKEN || secrets.HFL_EXTENSION_GIT_TOKEN' \
@@ -166,6 +187,13 @@ grep -F 'enterprise_commit: ${{ steps.enterprise-ref.outputs.commit }}' "${workf
 grep -F 'Check immutable Enterprise store' "${workflow}" >/dev/null
 grep -F 'ENTERPRISE_STORED: ${{ steps.enterprise-store.outputs.stored }}' "${workflow}" >/dev/null
 grep -F 'stored Enterprise release identity differs' "${workflow}" >/dev/null
+if grep -F '"image_version": f"{version}-ee"' "${workflow}" >/dev/null; then
+	printf 'ERROR: stored Enterprise package validation derives image identity from version\n' >&2
+	exit 1
+fi
+grep -F 'stored Enterprise runtime image identity is incomplete' "${workflow}" >/dev/null
+grep -F 'stored Enterprise {role} runtime image is not in the HFL archive' \
+	"${workflow}" >/dev/null
 grep -F 'flock -s 9' "${workflow}" >/dev/null
 grep -F -- '--expected-commit "$ENTERPRISE_COMMIT"' "${workflow}" >/dev/null
 grep -F 'validate_build_contract()' "${workflow}" >/dev/null
@@ -281,6 +309,7 @@ assert env["GIT_CONFIG_VALUE_1"].startswith("AUTHORIZATION: basic ")
 PY
 
 grep -F 'uses: ./.github/workflows/enterprise_promotion.yml' "${promotion}" >/dev/null
+grep -F 'workflow_dispatch:' "${promotion}" >/dev/null
 grep -F 'needs: validate-production-promotion' "${promotion}" >/dev/null
 grep -F '[[ "$GITHUB_REF" == "refs/heads/main" ]]' "${promotion}" >/dev/null
 grep -F "ref: \${{ inputs.automatic && inputs.tag || 'main' }}" \
@@ -291,6 +320,10 @@ grep -F "printf -v remote_command '%q '" \
 	"${ROOT}/.github/workflows/enterprise_promotion.yml" >/dev/null
 grep -F 'expected_edition=enterprise' "${ROOT}/.github/scripts/remote-deploy.sh" >/dev/null
 grep -F 'flock -s 8' "${ROOT}/.github/scripts/remote-deploy.sh" >/dev/null
+grep -F 'validate_release_archive_layout "${package}"' \
+	"${ROOT}/.github/scripts/remote-deploy.sh" >/dev/null
+grep -F 'release archive link escapes its package root' \
+	"${ROOT}/.github/scripts/remote-deploy.sh" >/dev/null
 grep -F "printf -v remote_command '%q '" \
 	"${ROOT}/.github/workflows/deploy_target.yml" >/dev/null
 grep -F 'release has multiple legacy package candidates' \
@@ -393,7 +426,7 @@ make_candidate() {
 	chmod +x "${root}/install.sh"
 	[[ -z "${marker}" ]] || printf '%s\n' "${marker}" >"${root}/BUILD-MARKER"
 	cat >"${root}/MANIFEST.json" <<JSON
-{"schema_version":2,"product":"hyperfilelens","edition":"enterprise","image_version":"${version}-ee","channel":"release","artifact_id":"${tag}","version":"${version}","git_commit":"0123456789abcdef0123456789abcdef01234567","extension_commit":"${extension_commit}"}
+{"schema_version":2,"product":"hyperfilelens","edition":"enterprise","image_version":"build-${number}","runtime_images":{"backend":"hyperfilelens-backend:build-${number}","frontend":"hyperfilelens-frontend:build-${number}"},"channel":"release","artifact_id":"${tag}","version":"${version}","git_commit":"0123456789abcdef0123456789abcdef01234567","extension_commit":"${extension_commit}","images":[{"file":"images/hfl.tar.gz","refs":["hyperfilelens-backend:build-${number}","hyperfilelens-frontend:build-${number}"],"role":"hyperfilelens"}]}
 JSON
 	cp "${root}/MANIFEST.json" "${incoming}/MANIFEST.json"
 	tar -C "$(dirname "${root}")" -czf "${archive}" "$(basename "${root}")"

--- a/tools/quality/test-managed-image-retention.sh
+++ b/tools/quality/test-managed-image-retention.sh
@@ -8,6 +8,7 @@ trap 'rm -rf "${tmp}"' EXIT
 
 ROOT="${tmp}/install"
 mkdir -p "${ROOT}/backup/upgrade-20260727-010000" "${tmp}/bin"
+printf 'HFL_GATEWAY_VERSION=0.1.5\n' >"${ROOT}/.env"
 cat >"${ROOT}/MANIFEST.json" <<'JSON'
 {"images":[{"refs":["hyperfilelens-backend:0.1.8","hyperfilelens-backend:latest"]}]}
 JSON
@@ -31,6 +32,7 @@ case "$*" in
 		hyperfilelens-backend:0.1.6 \
 		hyperfilelens-backend:0.1.5 \
 		hyperfilelens-backend:0.1.4 \
+		hyperfilelens-frontend:0.1.5 \
 		customer-backend:0.1.5
 	;;
 "image inspect hyperfilelens-backend:0.1.5 --format {{.Id}}") printf 'sha256:unused\n' ;;

--- a/tools/quality/test-upgrade-backup-retention.sh
+++ b/tools/quality/test-upgrade-backup-retention.sh
@@ -58,13 +58,30 @@ for stamp in 20260720-010000 20260721-010000 20260722-010000 20260723-010000; do
 	mkdir -p "${ROOT}/backup/upgrade-${stamp}"
 	printf '{"complete": true}\n' >"${ROOT}/backup/upgrade-${stamp}/backup-manifest.json"
 done
+protected="${ROOT}/backup/upgrade-20260720-010000"
+transaction="${ROOT}/deploy/upgrades/$(printf a%.0s {1..64})"
+mkdir -p "${transaction}"
+cat >"${transaction}/state" <<EOF
+artifact_sha256=$(printf a%.0s {1..64})
+target_version=0.1.8
+status=failed
+phase=backup_complete
+backup_dir=${protected}
+updated_at=2026-07-23T01:00:00Z
+EOF
 mkdir -p "${ROOT}/backup/.partial-stale"
 touch -d '2 days ago' "${ROOT}/backup/.partial-stale"
 prune_upgrade_backups
 
-[[ ! -e "${ROOT}/backup/upgrade-20260720-010000" ]]
+[[ -e "${ROOT}/backup/upgrade-20260720-010000" ]]
 [[ -e "${ROOT}/backup/upgrade-20260721-010000" ]]
 [[ -e "${ROOT}/backup/upgrade-20260722-010000" ]]
 [[ -e "${ROOT}/backup/upgrade-20260723-010000" ]]
 [[ ! -e "${ROOT}/backup/.partial-stale" ]]
+
+# An untrusted transaction path must not protect a same-named managed backup.
+sed -i "s#^backup_dir=.*#backup_dir=/tmp/upgrade-20260720-010000#" \
+	"${transaction}/state"
+prune_upgrade_backups
+[[ ! -e "${ROOT}/backup/upgrade-20260720-010000" ]]
 printf 'Upgrade backup retention checks passed.\n'

--- a/tools/quality/test-upgrade-transaction.sh
+++ b/tools/quality/test-upgrade-transaction.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+# shellcheck disable=SC1090
+source "${ROOT_REPO}/deploy/installer/install.sh"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "${tmp}"' EXIT
+ROOT="${tmp}/install"
+mkdir -p "${ROOT}/deploy" "${ROOT}/backup/upgrade-20260813-010000"
+printf 'verified backup\n' >"${ROOT}/backup/upgrade-20260813-010000/data.dump"
+backup_sha="$(sha256sum "${ROOT}/backup/upgrade-20260813-010000/data.dump" | awk '{print $1}')"
+cat >"${ROOT}/backup/upgrade-20260813-010000/backup-manifest.json" <<EOF
+{"complete":true,"files":[{"name":"data.dump","size":16,"sha256":"${backup_sha}"}]}
+EOF
+
+artifact_sha="$(printf b%.0s {1..64})"
+UPGRADE_TARGET_VERSION=1.2.3
+initialize_upgrade_transaction "${artifact_sha}" "${UPGRADE_TARGET_VERSION}"
+[[ "${UPGRADE_TRANSACTION_INITIALIZED}" == 1 ]]
+[[ "$(stat -c '%a' "${UPGRADE_TRANSACTION_DIR}/state")" == 600 ]]
+[[ "$(read_upgrade_transaction_value status)" == active ]]
+[[ "$(read_upgrade_transaction_value phase)" == validated ]]
+
+record_upgrade_transaction_phase backup_complete \
+	"${ROOT}/backup/upgrade-20260813-010000"
+[[ "$(reusable_upgrade_backup)" == \
+	"${ROOT}/backup/upgrade-20260813-010000" ]]
+printf 'corrupt\n' >"${ROOT}/backup/upgrade-20260813-010000/data.dump"
+if reusable_upgrade_backup >/dev/null 2>&1; then
+	printf 'ERROR: corrupted transaction backup was reused\n' >&2
+	exit 1
+fi
+printf 'verified backup\n' >"${ROOT}/backup/upgrade-20260813-010000/data.dump"
+
+mkdir -p "${tmp}/outside-backup"
+cp "${ROOT}/backup/upgrade-20260813-010000/backup-manifest.json" \
+	"${tmp}/outside-backup/backup-manifest.json"
+cp "${ROOT}/backup/upgrade-20260813-010000/data.dump" \
+	"${tmp}/outside-backup/data.dump"
+if (write_upgrade_transaction_state failed backup_complete \
+	"${tmp}/outside-backup") >/dev/null 2>&1; then
+	printf 'ERROR: transaction state accepted a backup outside the managed root\n' >&2
+	exit 1
+fi
+record_upgrade_transaction_phase backup_complete \
+	"${ROOT}/backup/upgrade-20260813-010000"
+
+mark_upgrade_transaction_status failed
+chmod 644 "${UPGRADE_TRANSACTION_DIR}/state"
+initialize_upgrade_transaction "${artifact_sha}" "${UPGRADE_TARGET_VERSION}"
+[[ "${UPGRADE_TRANSACTION_PHASE}" == backup_complete ]]
+[[ "$(read_upgrade_transaction_value status)" == failed ]]
+[[ "$(stat -c '%a' "${UPGRADE_TRANSACTION_DIR}/state")" == 600 ]]
+
+write_upgrade_transaction_state complete complete \
+	"${ROOT}/backup/upgrade-20260813-010000"
+[[ "$(read_upgrade_transaction_value status)" == complete ]]
+[[ "$(read_upgrade_transaction_value phase)" == complete ]]
+
+printf 'status=unknown\n' >>"${UPGRADE_TRANSACTION_DIR}/state"
+UPGRADE_TRANSACTION_INITIALIZED=0
+if (initialize_upgrade_transaction "${artifact_sha}" \
+	"${UPGRADE_TARGET_VERSION}") >/dev/null 2>&1; then
+	printf 'ERROR: malformed upgrade transaction state passed validation\n' >&2
+	exit 1
+fi
+[[ "${UPGRADE_TRANSACTION_INITIALIZED}" == 0 ]]
+
+main_sha="$(printf c%.0s {1..64})"
+UPGRADE_TARGET_VERSION=main-abcdef0
+initialize_upgrade_transaction "${main_sha}" "${UPGRADE_TARGET_VERSION}"
+initialize_upgrade_transaction "${main_sha}" "${UPGRADE_TARGET_VERSION}"
+[[ "$(read_upgrade_transaction_value target_version)" == main-abcdef0 ]]
+
+identity_root="${tmp}/identity-package"
+mkdir -p "${identity_root}"
+printf '1.2.3\n' >"${identity_root}/VERSION"
+cat >"${identity_root}/MANIFEST.json" <<'JSON'
+{"schema_version":2,"product":"hyperfilelens","edition":"community","image_version":"build-1","runtime_images":{"backend":"hyperfilelens-backend:build-1","frontend":"hyperfilelens-frontend:build-1"},"channel":"release","artifact_id":"v1.2.3","version":"1.2.3","git_commit":"0123456789abcdef0123456789abcdef01234567","images":[{"role":"sourcelens-app","refs":["hyperfilelens-backend:build-1","hyperfilelens-frontend:build-1"]}]}
+JSON
+if (validate_package_identity "${identity_root}") >/dev/null 2>&1; then
+	printf 'ERROR: HFL runtime images were accepted from a non-HFL archive\n' >&2
+	exit 1
+fi
+sed -i 's/"role":"sourcelens-app"/"role":"hyperfilelens"/' \
+	"${identity_root}/MANIFEST.json"
+validate_package_identity "${identity_root}"
+
+package_root="${tmp}/package"
+mkdir -p "${package_root}"
+printf '%s\n' '{"minimum_upgrade_version":"0.1.34"}' \
+	>"${package_root}/MANIFEST.json"
+[[ "$(read_minimum_upgrade_version_from_dir "${package_root}")" == 0.1.34 ]]
+version_lt 0.1.33 0.1.34
+if version_lt 0.1.34 0.1.34; then
+	printf 'ERROR: supported upgrade baseline was rejected\n' >&2
+	exit 1
+fi
+upgrade_body="$(declare -f cmd_upgrade)"
+grep -F 'create_managed_backup "${backup_stamp}" 1' <<<"${upgrade_body}" >/dev/null
+channel_gate_line="$(grep -n -F 'main channel packages require --allow-main-build' \
+	<<<"${upgrade_body}" | head -1 | cut -d: -f1)"
+complete_shortcut_line="$(grep -n -F 'is already complete' \
+	<<<"${upgrade_body}" | head -1 | cut -d: -f1)"
+[[ -n "${channel_gate_line}" && -n "${complete_shortcut_line}" \
+	&& "${channel_gate_line}" -lt "${complete_shortcut_line}" ]]
+
+printf 'Upgrade transaction checks passed.\n'


### PR DESCRIPTION
## Summary

- separate immutable Community and Enterprise release identities and promotion paths
- make offline upgrades resumable with managed backup and blue-green recovery gates
- preserve runtime image and product-version identity across TEST and PROD

## Validation

- release contract and assembly checks
- Enterprise release and upgrade transaction checks
- backup retention and blue-green recovery checks
- workflow YAML, shell syntax, Ruff, Django version tests, and `git diff --check`