### PR TITLE
fix(frontend): restore release quality checks

### DIFF
--- a/src/frontend/src/composables/useInlineFormValidation.ts
+++ b/src/frontend/src/composables/useInlineFormValidation.ts
@@ -33,7 +33,7 @@ export function useInlineFormValidation(root: Ref<HTMLElement | null>) {
         return true
       })
       if (!fieldEl) return
-      fieldEl.scrollIntoView({ behavior: 'smooth', block: 'center' })
+      fieldEl.scrollIntoView?.({ behavior: 'smooth', block: 'center' })
       window.setTimeout(() => {
         fieldEl.querySelector<HTMLElement>(
           'input:not([type="hidden"]), textarea, button, [tabindex]:not([tabindex="-1"])',

--- a/src/frontend/src/pages/insight/AssistantFormPage.vue
+++ b/src/frontend/src/pages/insight/AssistantFormPage.vue
@@ -126,21 +126,6 @@ const pageTitle = computed(() => {
 
 const pageDesc = computed(() => t('insight.assistants.addPageDesc'))
 
-const AGENT_ROUNDS_VALUES = ['flash', 'fast', 'balanced', 'deep', 'max'] as const
-
-const canSubmit = computed(
-  () =>
-    name.value.trim().length > 0 &&
-    Boolean(agentModelRef.value) &&
-    Boolean(knowledgeSourceId.value) &&
-    Boolean(selectedTask.value) &&
-    ((selectedKnowledgeSource.value?.indexed_paths.length ?? 0) > 0 ||
-      (selectedKnowledgeSource.value?.scope_paths.length ?? 0) > 0) &&
-    AGENT_ROUNDS_VALUES.includes(agentRounds.value as (typeof AGENT_ROUNDS_VALUES)[number]) &&
-    Number(maxConcurrency.value) >= 1 &&
-    Number(maxConcurrency.value) <= 50,
-)
-
 function knowledgeSourceStatusLabel(status: string) {
   if (status === 'ready') return t('insight.kb.statusReady')
   if (status === 'degraded') return t('insight.kb.statusDegraded')

--- a/src/frontend/src/pages/insight/McpServerFormPage.vue
+++ b/src/frontend/src/pages/insight/McpServerFormPage.vue
@@ -46,10 +46,6 @@ const pageTitle = computed(() => {
 
 const pageDesc = computed(() => t('insight.mcpServers.addPageDesc'))
 
-const canSubmit = computed(
-  () => Boolean(name.value.trim() && endpoint.value.trim() && transport.value),
-)
-
 const endpointPlaceholder = computed(() =>
   transport.value === 'stdio'
     ? t('insight.mcpServers.fieldEndpointPhStdio')

--- a/src/frontend/src/pages/insight/SkillFormPage.vue
+++ b/src/frontend/src/pages/insight/SkillFormPage.vue
@@ -46,8 +46,6 @@ const pageTitle = computed(() => {
 
 const pageDesc = computed(() => t('insight.skills.addPageDesc'))
 
-const canSubmit = computed(() => Boolean(name.value.trim() && content.value.trim()))
-
 function applyRow(row: LensSkill) {
   name.value = row.name || ''
   description.value = skillDescription(row)

--- a/src/frontend/src/pages/node/AddNasRepository.vue
+++ b/src/frontend/src/pages/node/AddNasRepository.vue
@@ -115,7 +115,7 @@ const validQuotaAlertThreshold = computed(() => {
 
 /* ---------- validation ---------- */
 function validateForm(): boolean {
-  return validateInline([
+  const rules = [
     { field: 'smbHost', message: t('addNasRepo.errSmbHost'), valid: protocol.value !== 'smb' || !!smbHost.value.trim() },
     { field: 'smbShare', message: t('addNasRepo.errSmbShare'), valid: protocol.value !== 'smb' || !!smbShare.value.trim() },
     { field: 'smbUsername', message: t('repositoriesPage.errSmbUsername'), valid: protocol.value !== 'smb' || !!smbUsername.value.trim() },
@@ -125,7 +125,12 @@ function validateForm(): boolean {
     { field: 'proxyNode', message: t('addNasRepo.errProxyDecisionRequired'), valid: hasProxyDecision.value },
     { field: 'repoName', message: t('repositoriesPage.errName'), valid: !!repoName.value.trim() },
     { field: 'quotaThreshold', message: t('repositoriesPage.hintQuotaAlertThreshold'), valid: !enableQuotaAlert.value || validQuotaAlertThreshold.value },
-  ])
+  ]
+  const valid = validateInline(rules)
+  if (!valid && rules.find(rule => !rule.valid)?.field === 'proxyNode') {
+    ElMessage.warning({ message: t('addNasRepo.errProxyDecisionRequired'), grouping: true })
+  }
+  return valid
 }
 
 /* ---------- submit ---------- */

--- a/src/frontend/src/pages/protection/BackupCreateWizard.vue
+++ b/src/frontend/src/pages/protection/BackupCreateWizard.vue
@@ -808,7 +808,6 @@ type NasProtocol = 'smb' | 'nfs'
 const nasProtocol = ref<NasProtocol>('smb')
 const nasBindNodeId = ref<number | undefined>(undefined)
 const nasBindNodeError = ref('')
-const nasBindSectionRef = ref<HTMLElement | null>(null)
 const { clear: clearNasFieldError, errors: nasFieldErrors, validate: validateNasInline } = useInlineFormValidation(addSourceShellRef)
 const nasName = ref('')
 const nasNameTouched = ref(false)
@@ -847,53 +846,6 @@ const generatedNasName = computed(() =>
 
 function clearNasBindNodeError() {
   nasBindNodeError.value = ''
-}
-
-function validateNasBindNode(): boolean {
-  clearNasBindNodeError()
-  if (proxyNodes.value.length === 0) {
-    nasBindNodeError.value = t('protection.sourceResources.nasNoProxy')
-    ElMessage.warning({ message: t('protection.sourceResources.nasNoProxy'), grouping: true })
-    nasBindSectionRef.value?.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
-    return false
-  }
-  if (nasBindNodeId.value == null) {
-    nasBindNodeError.value = t('protection.sourceResources.errNasProxyRequired')
-    ElMessage.warning({ message: t('protection.sourceResources.errNasProxyRequired'), grouping: true })
-    nasBindSectionRef.value?.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
-    return false
-  }
-  return true
-}
-
-type NasWizardStep = 0 | 1 | 2
-
-function validateNasStep(step: NasWizardStep): boolean {
-  if (step === 0) {
-    if (!nasProtocol.value) {
-      ElMessage.warning({ message: t('repositoriesPage.errProtocol'), grouping: true })
-      return false
-    }
-    if (nasProtocol.value === 'smb') {
-      if (!nasSmbServer.value.trim()) { ElMessage.warning({ message: t('addNasRepo.errSmbHost'), grouping: true }); return false }
-      if (!nasSmbShare.value.trim()) { ElMessage.warning({ message: t('addNasRepo.errSmbShare'), grouping: true }); return false }
-      if (!nasSmbUsername.value.trim()) { ElMessage.warning({ message: t('repositoriesPage.errSmbUsername'), grouping: true }); return false }
-      if (!nasSmbPassword.value.trim()) { ElMessage.warning({ message: t('repositoriesPage.errSmbPassword'), grouping: true }); return false }
-    } else if (nasProtocol.value === 'nfs') {
-      if (!nasNfsHost.value.trim()) { ElMessage.warning({ message: t('repositoriesPage.errNfsHost'), grouping: true }); return false }
-      if (!nasNfsExport.value.trim()) { ElMessage.warning({ message: t('repositoriesPage.errNfsExport'), grouping: true }); return false }
-    }
-    return true
-  }
-  if (step === 1) {
-    return validateNasBindNode()
-  }
-  if (step === 2) {
-    if (!nasName.value.trim()) { ElMessage.warning({ message: t('repositoriesPage.errName'), grouping: true }); return false }
-    if (!nasDir.value.trim()) { ElMessage.warning({ message: t('repositoriesPage.errRepoDir'), grouping: true }); return false }
-    return true
-  }
-  return false
 }
 
 function validateNasForm(): boolean {


### PR DESCRIPTION
## Summary

- remove unused form validation state that blocked the v0.1.36 frontend quality gate
- preserve the explicit NAS Proxy decision warning in the active inline validation path
- safely degrade validation scrolling when `scrollIntoView` is unavailable

## Validation

- frontend lint: 0 errors
- Host frontend tests: 900 passed
- frontend production build
- `git diff --check`