### PR TITLE
Fix Enterprise production promotion staging

### DIFF
--- a/.github/workflows/enterprise_promotion.yml
+++ b/.github/workflows/enterprise_promotion.yml
@@ -93,7 +93,7 @@ jobs:
           source="/root/hfl-release/${tag}"
           incoming="/root/hfl-release/.incoming/promotion-${tag#v}"
           cleanup() {
-            ssh -o BatchMode=yes -o StrictHostKeyChecking=yes \
+            ssh -n -o BatchMode=yes -o StrictHostKeyChecking=yes \
               -o UserKnownHostsFile="$hop/prod-known-hosts" -p "$prod_port" \
               "$prod_user@$prod_host" "rm -rf -- '$incoming'" >/dev/null 2>&1 || true
             rm -rf -- "$hop"
@@ -104,7 +104,9 @@ jobs:
           flock -s 9
           cd "$source"
           sha256sum -c SHA256SUMS
-          ssh -o BatchMode=yes -o StrictHostKeyChecking=yes \
+          # This shell itself arrives on stdin. Commands that do not explicitly
+          # receive a script must not consume the remaining promotion program.
+          ssh -n -o BatchMode=yes -o StrictHostKeyChecking=yes \
             -o UserKnownHostsFile="$hop/prod-known-hosts" -p "$prod_port" \
             "$prod_user@$prod_host" "rm -rf -- '$incoming' && install -d -m 0700 '$incoming'"
           scp -o BatchMode=yes -o StrictHostKeyChecking=yes \
@@ -116,6 +118,12 @@ jobs:
             "$prod_user@$prod_host" \
             "bash -s -- '$tag' '$incoming' /root/hfl-release 0" \
             < "$hop/store-enterprise-release.sh"
+          # Do not let cleanup or the deploy job run until the immutable PROD
+          # package has independently passed its retained checksum contract.
+          ssh -n -o BatchMode=yes -o StrictHostKeyChecking=yes \
+            -o UserKnownHostsFile="$hop/prod-known-hosts" -p "$prod_port" \
+            "$prod_user@$prod_host" \
+            "cd '/root/hfl-release/$tag' && sha256sum -c SHA256SUMS && test -f 'hyperfilelens-${version}-ee.tar.gz'"
           REMOTE
 
       - name: Remove promotion staging from TEST

--- a/tools/quality/test-enterprise-release-flow.sh
+++ b/tools/quality/test-enterprise-release-flow.sh
@@ -316,6 +316,16 @@ grep -F "ref: \${{ inputs.automatic && inputs.tag || 'main' }}" \
 	"${ROOT}/.github/workflows/enterprise_promotion.yml" >/dev/null
 grep -F 'ssh-agent -s' "${ROOT}/.github/workflows/enterprise_promotion.yml" >/dev/null
 grep -F 'flock -s 9' "${ROOT}/.github/workflows/enterprise_promotion.yml" >/dev/null
+promotion_no_stdin_ssh_count="$(grep -c \
+	'^[[:space:]]*ssh -n -o BatchMode=yes -o StrictHostKeyChecking=yes' \
+	"${ROOT}/.github/workflows/enterprise_promotion.yml")"
+[[ "${promotion_no_stdin_ssh_count}" -eq 3 ]] || {
+	printf 'ERROR: every non-script PROD promotion SSH must disable stdin (found %s/3)\n' \
+		"${promotion_no_stdin_ssh_count}" >&2
+	exit 1
+}
+grep -F "cd '/root/hfl-release/\$tag' && sha256sum -c SHA256SUMS" \
+	"${ROOT}/.github/workflows/enterprise_promotion.yml" >/dev/null
 grep -F "printf -v remote_command '%q '" \
 	"${ROOT}/.github/workflows/enterprise_promotion.yml" >/dev/null
 grep -F 'expected_edition=enterprise' "${ROOT}/.github/scripts/remote-deploy.sh" >/dev/null


### PR DESCRIPTION
## Summary
- prevent nested PROD SSH commands from consuming the remaining promotion script
- verify the retained PROD package before staging cleanup and deployment
- add regression contracts for stdin isolation and retained-package verification

## Validation
- Enterprise release flow contracts passed.
- Release contract checks passed.
- 