### PR TITLE
fix(installer): support migration on Compose v2.27

### DIFF
--- a/deploy/installer/install.sh
+++ b/deploy/installer/install.sh
@@ -954,7 +954,10 @@ start_hfl_stack() {
 	ensure_blue_green_state
 	color="$(read_active_color)"
 	compose_in_root up -d --no-build --pull never --no-recreate postgres redis
-	compose_in_root --profile tools run --rm --no-deps --pull never migration
+	# Compose v2.27 supports `up --pull` but not `run --pull`. The migration
+	# service inherits `pull_policy: never` from the release Compose model, so
+	# this remains offline without relying on a version-sensitive CLI flag.
+	compose_in_root --profile tools run --rm --no-deps migration
 	compose_in_root up -d --no-build --pull never worker scheduler
 	compose_color "${color}" up -d --no-build --pull never "api-${color}" "web-${color}"
 	wait_for_color_health "${color}" || return 1
@@ -4712,7 +4715,7 @@ cmd_upgrade() {
 	ensure_data_dirs
 	sync_runtime_media
 	compose_in_root up -d --no-build --pull never --no-recreate postgres redis
-	compose_in_root --profile tools run --rm --no-deps --pull never migration
+	compose_in_root --profile tools run --rm --no-deps migration
 	record_deployment_phase migrated "${UPGRADE_PREVIOUS_COLOR}" "${target_color}" "${new_version}"
 	record_upgrade_transaction_phase migrated
 

--- a/src/agent/internal/engine/managed_backup_test.go
+++ b/src/agent/internal/engine/managed_backup_test.go
@@ -411,8 +411,8 @@ func TestManagedRestoreFailureMessageKeepsBoundedTail(t *testing.T) {
 		t.Fatalf("expected valid UTF-8, got %q", got)
 	}
 
-	multibyteContext := string([]rune{0x4E0A, 0x4E0B, 0x6587})
-	multibyteFinalReason := string([]rune{0x6700, 0x7EC8, 0x539F, 0x56E0})
+	multibyteContext := string([]rune{utf8.RuneSelf, 1 << 11, 1 << 16})
+	multibyteFinalReason := string([]rune{utf8.RuneSelf + 1, 1<<11 + 1, 1<<16 + 1})
 	got = managedRestoreFailureMessage(
 		process.Result{Stderr: strings.Repeat(multibyteContext, 1000) + multibyteFinalReason},
 		fmt.Errorf("exit status 1"),

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -846,7 +846,7 @@ if grep -F 'compose_in_root down' <<<"${upgrade_body}" >/dev/null; then
 fi
 worker_stop_line="$(grep -n -F 'compose_in_root stop --timeout 600 worker' <<<"${upgrade_body}" | head -1 | cut -d: -f1)"
 worker_stopped_line="$(grep -n -F 'compose_in_root ps --status running -q worker' <<<"${upgrade_body}" | head -1 | cut -d: -f1)"
-migration_line="$(grep -n -F 'compose_in_root --profile tools run --rm --no-deps --pull never migration' <<<"${upgrade_body}" | head -1 | cut -d: -f1)"
+migration_line="$(grep -n -F 'compose_in_root --profile tools run --rm --no-deps migration' <<<"${upgrade_body}" | head -1 | cut -d: -f1)"
 if [[ -z "${worker_stop_line}" \
 	|| -z "${worker_stopped_line}" \
 	|| -z "${migration_line}" \
@@ -855,6 +855,16 @@ if [[ -z "${worker_stop_line}" \
 	printf 'ERROR: upgrade must stop and verify the old worker before applying task-state migrations\n' >&2
 	exit 1
 fi
+if grep -F 'run --rm --no-deps --pull never migration' \
+	"${ROOT}/deploy/installer/install.sh" >/dev/null; then
+	printf 'ERROR: migration must not use the Docker Compose v2.27-incompatible run --pull flag\n' >&2
+	exit 1
+fi
+release_backend_image_block="$(sed -n '/^x-backend-image:/,/^x-backend-volumes:/p' "${release_compose}")"
+grep -F 'pull_policy: never' <<<"${release_backend_image_block}" >/dev/null || {
+	printf 'ERROR: release backend services must remain offline through pull_policy: never\n' >&2
+	exit 1
+}
 if sed -n "${worker_stop_line}p" <<<"${upgrade_body}" | grep -F '|| true' >/dev/null; then
 	printf 'ERROR: upgrade must fail closed when the old worker cannot be stopped\n' >&2
 	exit 1

--- a/tools/quality/test-blue-green-recovery.sh
+++ b/tools/quality/test-blue-green-recovery.sh
@@ -51,6 +51,8 @@ grep -Fx 'LENS_GATEWAY_BASE_URL=https://app.example.invalid/sourcelens' \
 
 calls=()
 start_hfl_stack
+[[ " ${calls[*]} " == *" compose:--profile tools run --rm --no-deps migration "* ]]
+[[ " ${calls[*]} " != *" run --rm --no-deps --pull never migration "* ]]
 [[ " ${calls[*]} " == *" color:blue up -d --no-build --pull never api-blue web-blue "* ]]
 [[ " ${calls[*]} " == *" color-health:blue "* ]]
 [[ " ${calls[*]} " == *" compose:up -d --no-build --pull never nginx reload "* ]]


### PR DESCRIPTION
## Summary

- keep offline migrations compatible with Docker Compose v2.27
- enforce release-level pull policy through the Compose model
- make Agent UTF-8 coverage independent of CJK source and Unicode code points
- add regression checks for the migration command contract

## Validation

- `python3 tools/quality/check-english-source.py`
- `bash tools/quality/test-blue-green-recovery.sh`
- `bash tools/quality/check-release-contracts.sh`
- `bash tools/quality/test-upgrade-transaction.sh`
- Community and Enterprise synthetic release assembly
- `go test ./...` in `src/agent`
- `git diff --check`
