### PR TITLE
test(storage): avoid legacy release ports

### DIFF
--- a/src/backend/apps/storage/tests/test_repository_api.py
+++ b/src/backend/apps/storage/tests/test_repository_api.py
@@ -1349,7 +1349,7 @@ class StorageRepositoryApiTests(TestCase):
             "/api/v1/storage/repositories/validate/s3/",
             {
                 "platform": "other",
-                "endpoint": "192.168.8.81:10443",
+                "endpoint": "192.0.2.81:9443",
                 "region": "",
                 "access_key_id": "002",
                 "secret_access_key": "not-a-real-secret",

--- a/src/backend/apps/storage/tests/test_s3_client.py
+++ b/src/backend/apps/storage/tests/test_s3_client.py
@@ -90,7 +90,7 @@ class S3ClientUrlStyleTests(TestCase):
 
         with self.assertRaises(S3ClientError) as ctx:
             list_s3_buckets(
-                endpoint="192.168.8.81:10443",
+                endpoint="192.0.2.81:9443",
                 region="",
                 access_key_id="002",
                 secret_access_key="not-a-real-secret",


### PR DESCRIPTION
Replace legacy 104xx ports in S3 error fixtures with an RFC 5737 documentation address and a neutral test port.\n\nValidated with the release contract checks, English-only source check, the two directly affected backend tests, and git diff checks.