### PR TITLE
fix(release): make production promotion resumable

### DIFF
--- a/.github/scripts/promote-enterprise-release.sh
+++ b/.github/scripts/promote-enterprise-release.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# Copy one verified Enterprise release from TEST to PROD and retain it atomically.
+set -euo pipefail
+
+tag=${1:-}
+version=${2:-}
+hop=${3:-}
+prod_host=${4:-}
+prod_port=${5:-}
+prod_user=${6:-}
+store_root=${HFL_PROMOTION_STORE_ROOT:-/root/hfl-release}
+hop_root=${HFL_PROMOTION_HOP_ROOT:-/var/tmp}
+
+for root in "${store_root}" "${hop_root}"; do
+	[[ "${root}" =~ ^/[A-Za-z0-9._/-]+$ \
+		&& "${root}" != *..* && "${root}" != */ ]] || {
+		printf 'ERROR: invalid promotion root path\n' >&2
+		exit 2
+	}
+done
+[[ "${tag}" == "v${version}" && "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+	printf 'ERROR: invalid Enterprise release identity\n' >&2
+	exit 2
+}
+hop_name=${hop#"${hop_root}/"}
+[[ "${hop}" == "${hop_root}/"* \
+	&& "${hop_name}" =~ ^hfl-prod-promotion-[A-Za-z0-9._-]+$ ]] || {
+	printf 'ERROR: invalid promotion workspace\n' >&2
+	exit 2
+}
+[[ "${prod_host}" =~ ^[A-Za-z0-9][A-Za-z0-9.-]*$ && "${prod_port}" =~ ^[0-9]+$ ]] || {
+	printf 'ERROR: invalid PROD SSH endpoint\n' >&2
+	exit 2
+}
+[[ "${prod_user}" =~ ^[a-z_][a-z0-9_-]*$ ]] || {
+	printf 'ERROR: invalid PROD SSH user\n' >&2
+	exit 2
+}
+
+source_dir="${store_root}/${tag}"
+# This version-scoped path is intentionally stable across attempts and workflow
+# runs. Interrupted rsync partials remain useful until the release is retained.
+incoming="${store_root}/.incoming/promotion-${version}"
+archive="hyperfilelens-${version}-ee.tar.gz"
+known_hosts="${hop}/prod-known-hosts"
+store_script="${hop}/store-enterprise-release.sh"
+ssh_target="${prod_user}@${prod_host}"
+ssh_options=(
+	-o BatchMode=yes
+	-o StrictHostKeyChecking=yes
+	-o "UserKnownHostsFile=${known_hosts}"
+	-o ConnectTimeout=30
+	-o ServerAliveInterval=30
+	-o ServerAliveCountMax=20
+	-o TCPKeepAlive=yes
+	-p "${prod_port}"
+)
+
+[[ -d "${source_dir}" && ! -L "${source_dir}" ]] || {
+	printf 'ERROR: Enterprise release is missing on TEST: %s\n' "${tag}" >&2
+	exit 1
+}
+[[ -s "${known_hosts}" && -s "${store_script}" ]] || {
+	printf 'ERROR: promotion support files are incomplete\n' >&2
+	exit 1
+}
+command -v rsync >/dev/null || { printf 'ERROR: rsync is required on TEST\n' >&2; exit 1; }
+chmod 0600 "${known_hosts}"
+
+exec 9<"${store_root}/.lock"
+flock -s 9
+(
+	cd "${source_dir}"
+	sha256sum -c SHA256SUMS
+	[[ -f "${archive}" ]] || { printf 'ERROR: Enterprise archive is missing\n' >&2; exit 1; }
+)
+source_archive_digest="$(sha256sum "${source_dir}/${archive}" | awk '{print $1}')"
+source_manifest_digest="$(sha256sum "${source_dir}/MANIFEST.json" | awk '{print $1}')"
+[[ "${source_archive_digest}" =~ ^[0-9a-f]{64}$ \
+	&& "${source_manifest_digest}" =~ ^[0-9a-f]{64}$ ]]
+
+# Exact retries must not resend an already retained immutable release.
+if ssh -n "${ssh_options[@]}" "${ssh_target}" \
+	"test -d '${store_root}/${tag}' && cd '${store_root}/${tag}' && sha256sum -c SHA256SUMS && test \"\$(sha256sum '${archive}' | awk '{print \$1}')\" = '${source_archive_digest}' && test \"\$(sha256sum MANIFEST.json | awk '{print \$1}')\" = '${source_manifest_digest}'"; then
+	printf 'Enterprise version %s is already retained on PROD\n' "${tag}"
+	exit 0
+fi
+
+ssh -n "${ssh_options[@]}" "${ssh_target}" \
+	"command -v rsync >/dev/null && if [ -e '${incoming}' ]; then [ -d '${incoming}' ] && [ ! -L '${incoming}' ]; else install -d -m 0700 '${incoming}'; fi"
+
+printf -v rsync_shell 'ssh'
+for option in "${ssh_options[@]}"; do
+	printf -v rsync_shell '%s %q' "${rsync_shell}" "${option}"
+done
+
+transfer_complete=false
+for attempt in 1 2 3; do
+	printf 'Enterprise PROD transfer attempt %s/3\n' "${attempt}"
+	if (
+		cd "${source_dir}"
+		rsync --archive --checksum --partial --partial-dir=.rsync-partial \
+			--timeout=900 --info=progress2 --human-readable \
+			-e "${rsync_shell}" \
+			"${archive}" SHA256SUMS MANIFEST.json \
+			"${ssh_target}:${incoming}/"
+	) && ssh -n "${ssh_options[@]}" "${ssh_target}" \
+		"cd '${incoming}' && sha256sum -c SHA256SUMS && test -f '${archive}' && rm -rf -- .rsync-partial"; then
+		transfer_complete=true
+		break
+	fi
+	printf 'WARN: Enterprise PROD transfer attempt %s failed; retaining partial data\n' \
+		"${attempt}" >&2
+	sleep $((attempt * 10))
+done
+[[ "${transfer_complete}" == true ]] || {
+	printf 'ERROR: Enterprise PROD transfer failed after 3 attempts\n' >&2
+	exit 1
+}
+
+ssh "${ssh_options[@]}" "${ssh_target}" \
+	"bash -s -- '${tag}' '${incoming}' '${store_root}' 0" <"${store_script}"
+
+# The deploy job may start only after the immutable PROD copy independently
+# satisfies the retained checksum contract.
+ssh -n "${ssh_options[@]}" "${ssh_target}" \
+	"cd '${store_root}/${tag}' && sha256sum -c SHA256SUMS && test -f '${archive}'"

--- a/.github/workflows/artifact_pipeline.yml
+++ b/.github/workflows/artifact_pipeline.yml
@@ -450,6 +450,7 @@ jobs:
           ./tools/quality/test-agent-release-retention.sh
           ./tools/quality/test-managed-image-retention.sh
           ./tools/quality/test-enterprise-release-flow.sh
+          ./tools/quality/test-enterprise-promotion-transfer.sh
           ./tools/quality/test-shared-host-guard.sh
           ./tools/quality/test-release-download-proxy.sh
           ./tools/quality/test-public-endpoint-check.sh

--- a/.github/workflows/enterprise_promotion.yml
+++ b/.github/workflows/enterprise_promotion.yml
@@ -68,63 +68,31 @@ jobs:
           eval "$(ssh-agent -s)"
           trap 'ssh-agent -k >/dev/null 2>&1 || true' EXIT
           ssh-add "$RUNNER_TEMP/prod-key"
-          ssh -i ~/.ssh/hyperfilelens_test -o BatchMode=yes -o StrictHostKeyChecking=yes \
+          ssh -n -i ~/.ssh/hyperfilelens_test \
+            -o BatchMode=yes -o StrictHostKeyChecking=yes \
+            -o ConnectTimeout=30 -o ServerAliveInterval=30 -o ServerAliveCountMax=20 \
+            -o TCPKeepAlive=yes \
             -p "$TEST_SSH_PORT" "$TEST_SSH_USER@$TEST_SSH_HOST" \
             "rm -rf -- '$hop' && install -d -m 0700 '$hop'"
-          scp -i ~/.ssh/hyperfilelens_test -o BatchMode=yes -o StrictHostKeyChecking=yes \
+          scp -i ~/.ssh/hyperfilelens_test \
+            -o BatchMode=yes -o StrictHostKeyChecking=yes \
+            -o ConnectTimeout=30 -o ServerAliveInterval=30 -o ServerAliveCountMax=20 \
+            -o TCPKeepAlive=yes \
             -P "$TEST_SSH_PORT" \
             "$RUNNER_TEMP/prod-known-hosts" \
+            .github/scripts/promote-enterprise-release.sh \
             .github/scripts/store-enterprise-release.sh \
             "$TEST_SSH_USER@$TEST_SSH_HOST:$hop/"
           printf -v remote_command '%q ' \
-            bash -s -- "$RELEASE_TAG" "$version" "$hop" \
+            bash "$hop/promote-enterprise-release.sh" \
+              "$RELEASE_TAG" "$version" "$hop" \
               "$PROD_SSH_HOST" "$PROD_SSH_PORT" "$PROD_SSH_USER"
-          ssh -A -i ~/.ssh/hyperfilelens_test -o IdentitiesOnly=yes \
+          ssh -n -A -i ~/.ssh/hyperfilelens_test -o IdentitiesOnly=yes \
             -o BatchMode=yes -o StrictHostKeyChecking=yes \
+            -o ConnectTimeout=30 -o ServerAliveInterval=30 -o ServerAliveCountMax=20 \
+            -o TCPKeepAlive=yes \
             -p "$TEST_SSH_PORT" "$TEST_SSH_USER@$TEST_SSH_HOST" \
-            "$remote_command" <<'REMOTE'
-          set -euo pipefail
-          tag=$1
-          version=$2
-          hop=$3
-          prod_host=$4
-          prod_port=$5
-          prod_user=$6
-          source="/root/hfl-release/${tag}"
-          incoming="/root/hfl-release/.incoming/promotion-${tag#v}"
-          cleanup() {
-            ssh -n -o BatchMode=yes -o StrictHostKeyChecking=yes \
-              -o UserKnownHostsFile="$hop/prod-known-hosts" -p "$prod_port" \
-              "$prod_user@$prod_host" "rm -rf -- '$incoming'" >/dev/null 2>&1 || true
-            rm -rf -- "$hop"
-          }
-          trap cleanup EXIT
-          chmod 0600 "$hop/prod-known-hosts"
-          exec 9</root/hfl-release/.lock
-          flock -s 9
-          cd "$source"
-          sha256sum -c SHA256SUMS
-          # This shell itself arrives on stdin. Commands that do not explicitly
-          # receive a script must not consume the remaining promotion program.
-          ssh -n -o BatchMode=yes -o StrictHostKeyChecking=yes \
-            -o UserKnownHostsFile="$hop/prod-known-hosts" -p "$prod_port" \
-            "$prod_user@$prod_host" "rm -rf -- '$incoming' && install -d -m 0700 '$incoming'"
-          scp -o BatchMode=yes -o StrictHostKeyChecking=yes \
-            -o UserKnownHostsFile="$hop/prod-known-hosts" -P "$prod_port" \
-            "hyperfilelens-${version}-ee.tar.gz" SHA256SUMS MANIFEST.json \
-            "$prod_user@$prod_host:$incoming/"
-          ssh -o BatchMode=yes -o StrictHostKeyChecking=yes \
-            -o UserKnownHostsFile="$hop/prod-known-hosts" -p "$prod_port" \
-            "$prod_user@$prod_host" \
-            "bash -s -- '$tag' '$incoming' /root/hfl-release 0" \
-            < "$hop/store-enterprise-release.sh"
-          # Do not let cleanup or the deploy job run until the immutable PROD
-          # package has independently passed its retained checksum contract.
-          ssh -n -o BatchMode=yes -o StrictHostKeyChecking=yes \
-            -o UserKnownHostsFile="$hop/prod-known-hosts" -p "$prod_port" \
-            "$prod_user@$prod_host" \
-            "cd '/root/hfl-release/$tag' && sha256sum -c SHA256SUMS && test -f 'hyperfilelens-${version}-ee.tar.gz'"
-          REMOTE
+            "$remote_command"
 
       - name: Remove promotion staging from TEST
         if: ${{ always() }}
@@ -141,7 +109,10 @@ jobs:
           printf '%s\n' "$TEST_SSH_KNOWN_HOSTS" > ~/.ssh/known_hosts
           printf '%s\n' "$TEST_SSH_PRIVATE_KEY" > ~/.ssh/hyperfilelens_test
           chmod 0600 ~/.ssh/known_hosts ~/.ssh/hyperfilelens_test
-          ssh -i ~/.ssh/hyperfilelens_test -o BatchMode=yes -o StrictHostKeyChecking=yes \
+          ssh -n -i ~/.ssh/hyperfilelens_test \
+            -o BatchMode=yes -o StrictHostKeyChecking=yes \
+            -o ConnectTimeout=30 -o ServerAliveInterval=30 -o ServerAliveCountMax=20 \
+            -o TCPKeepAlive=yes \
             -p "$TEST_SSH_PORT" "$TEST_SSH_USER@$TEST_SSH_HOST" \
             "rm -rf -- '/var/tmp/hfl-prod-promotion-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}'"
 

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -1247,6 +1247,7 @@ for executable in \
 	"${ROOT}/.github/scripts/check-release-freshness.sh" \
 	"${ROOT}/.github/scripts/check-public-endpoint.sh" \
 	"${ROOT}/.github/scripts/cleanup-main-builds.sh" \
+	"${ROOT}/.github/scripts/promote-enterprise-release.sh" \
 	"${ROOT}/.github/scripts/remote-deploy.sh" \
 	"${ROOT}/.github/scripts/store-enterprise-release.sh" \
 	"${ROOT}/tools/quality/check-python38-runtime.py" \
@@ -1259,6 +1260,7 @@ for executable in \
 	"${ROOT}/tools/quality/test-main-release-cleanup.sh" \
 	"${ROOT}/tools/quality/test-release-freshness.sh" \
 	"${ROOT}/tools/quality/test-enterprise-release-flow.sh" \
+	"${ROOT}/tools/quality/test-enterprise-promotion-transfer.sh" \
 	"${ROOT}/tools/quality/test-language-pack-runtime-index.sh" \
 	"${ROOT}/tools/quality/test-upgrade-backup-retention.sh" \
 	"${ROOT}/tools/quality/test-redis-rdb-preflight.sh" \

--- a/tools/quality/test-enterprise-promotion-transfer.sh
+++ b/tools/quality/test-enterprise-promotion-transfer.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Exercise retry, partial retention, verification, and atomic retention without SSH.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+tmp="$(mktemp -d)"
+trap 'rm -rf "${tmp}"' EXIT
+store="${tmp}/store"
+remote_store="${tmp}/remote-store"
+hop_root="${tmp}/hop"
+hop="${hop_root}/hfl-prod-promotion-test"
+source_dir="${store}/v1.2.3"
+incoming="${store}/.incoming/promotion-1.2.3"
+bin="${tmp}/bin"
+mkdir -p "${source_dir}" "${remote_store}/.incoming" "${hop}" "${bin}"
+
+printf 'enterprise archive payload\n' >"${source_dir}/hyperfilelens-1.2.3-ee.tar.gz"
+printf '{"edition":"enterprise","version":"1.2.3"}\n' >"${source_dir}/MANIFEST.json"
+(
+	cd "${source_dir}"
+	sha256sum hyperfilelens-1.2.3-ee.tar.gz MANIFEST.json >SHA256SUMS
+)
+printf 'test known host\n' >"${hop}/prod-known-hosts"
+cat >"${hop}/store-enterprise-release.sh" <<'STORE'
+#!/usr/bin/env bash
+set -euo pipefail
+tag=$1
+incoming=$2
+store=$3
+(
+	cd "${incoming}"
+	sha256sum -c SHA256SUMS
+)
+mv "${incoming}" "${store}/${tag}"
+STORE
+chmod +x "${hop}/store-enterprise-release.sh"
+touch "${store}/.lock"
+
+cat >"${bin}/ssh" <<'SSH'
+#!/usr/bin/env bash
+set -euo pipefail
+while (($#)); do
+	case "$1" in
+		-n) shift ;;
+		-o|-p) shift 2 ;;
+		*) shift; break ;;
+	esac
+done
+command_text=${1:-}
+[[ -n "${command_text}" ]]
+command_text=${command_text//${HFL_PROMOTION_STORE_ROOT:?}/${HFL_FAKE_REMOTE_STORE:?}}
+bash -c "${command_text}"
+SSH
+
+cat >"${bin}/rsync" <<'RSYNC'
+#!/usr/bin/env bash
+set -euo pipefail
+count_file=${HFL_FAKE_RSYNC_COUNT:?}
+count=0
+[[ ! -f "${count_file}" ]] || read -r count <"${count_file}"
+count=$((count + 1))
+printf '%s\n' "${count}" >"${count_file}"
+files=()
+while (($#)); do
+	case "$1" in
+		-e) shift 2 ;;
+		--*) shift ;;
+		*) files+=("$1"); shift ;;
+	esac
+done
+destination=${files[${#files[@]}-1]#*:}
+destination=${destination//${HFL_PROMOTION_STORE_ROOT:?}/${HFL_FAKE_REMOTE_STORE:?}}
+mkdir -p "${destination}/.rsync-partial"
+if ((count == 1)); then
+	head -c 8 "${files[0]}" >"${destination}/.rsync-partial/$(basename "${files[0]}")"
+	exit 12
+fi
+[[ -s "${destination}/.rsync-partial/$(basename "${files[0]}")" ]] || {
+	printf 'ERROR: retry did not retain the partial archive\n' >&2
+	exit 1
+}
+for ((index = 0; index < ${#files[@]} - 1; index++)); do
+	cp "${files[index]}" "${destination}/"
+done
+RSYNC
+cat >"${bin}/sleep" <<'SLEEP'
+#!/usr/bin/env bash
+exit 0
+SLEEP
+chmod +x "${bin}/ssh" "${bin}/rsync" "${bin}/sleep"
+
+PATH="${bin}:${PATH}" \
+	HFL_FAKE_RSYNC_COUNT="${tmp}/rsync-count" \
+	HFL_FAKE_REMOTE_STORE="${remote_store}" \
+	HFL_PROMOTION_STORE_ROOT="${store}" \
+	HFL_PROMOTION_HOP_ROOT="${hop_root}" \
+	"${ROOT}/.github/scripts/promote-enterprise-release.sh" \
+	v1.2.3 1.2.3 "${hop}" prod.example.test 22 root
+
+[[ "$(<"${tmp}/rsync-count")" == 2 ]]
+[[ -f "${remote_store}/v1.2.3/hyperfilelens-1.2.3-ee.tar.gz" ]]
+[[ ! -e "${remote_store}/.incoming/promotion-1.2.3" ]]
+(
+	cd "${remote_store}/v1.2.3"
+	sha256sum -c SHA256SUMS
+)
+printf 'Enterprise promotion retry checks passed.\n'

--- a/tools/quality/test-enterprise-release-flow.sh
+++ b/tools/quality/test-enterprise-release-flow.sh
@@ -315,17 +315,34 @@ grep -F '[[ "$GITHUB_REF" == "refs/heads/main" ]]' "${promotion}" >/dev/null
 grep -F "ref: \${{ inputs.automatic && inputs.tag || 'main' }}" \
 	"${ROOT}/.github/workflows/enterprise_promotion.yml" >/dev/null
 grep -F 'ssh-agent -s' "${ROOT}/.github/workflows/enterprise_promotion.yml" >/dev/null
-grep -F 'flock -s 9' "${ROOT}/.github/workflows/enterprise_promotion.yml" >/dev/null
+promotion_transfer="${ROOT}/.github/scripts/promote-enterprise-release.sh"
+[[ -x "${promotion_transfer}" ]]
+grep -F 'flock -s 9' "${promotion_transfer}" >/dev/null
 promotion_no_stdin_ssh_count="$(grep -c \
-	'^[[:space:]]*ssh -n -o BatchMode=yes -o StrictHostKeyChecking=yes' \
+	'^[[:space:]]*ssh -n ' \
 	"${ROOT}/.github/workflows/enterprise_promotion.yml")"
 [[ "${promotion_no_stdin_ssh_count}" -eq 3 ]] || {
 	printf 'ERROR: every non-script PROD promotion SSH must disable stdin (found %s/3)\n' \
 		"${promotion_no_stdin_ssh_count}" >&2
 	exit 1
 }
-grep -F "cd '/root/hfl-release/\$tag' && sha256sum -c SHA256SUMS" \
-	"${ROOT}/.github/workflows/enterprise_promotion.yml" >/dev/null
+[[ "$(grep -c 'ServerAliveInterval=30' "${ROOT}/.github/workflows/enterprise_promotion.yml")" -eq 4 ]]
+grep -F 'ServerAliveCountMax=20' "${ROOT}/.github/workflows/enterprise_promotion.yml" >/dev/null
+grep -F 'ServerAliveInterval=30' "${promotion_transfer}" >/dev/null
+grep -F 'ServerAliveCountMax=20' "${promotion_transfer}" >/dev/null
+grep -F 'rsync --archive --checksum --partial --partial-dir=.rsync-partial' \
+	"${promotion_transfer}" >/dev/null
+grep -F -- '--info=progress2' "${promotion_transfer}" >/dev/null
+grep -F 'for attempt in 1 2 3' "${promotion_transfer}" >/dev/null
+grep -F 'retaining partial data' "${promotion_transfer}" >/dev/null
+grep -F 'already retained on PROD' "${promotion_transfer}" >/dev/null
+if grep -F 'rm -rf -- "${incoming}"' "${promotion_transfer}" >/dev/null \
+	|| grep -F 'scp ' "${promotion_transfer}" >/dev/null; then
+	printf 'ERROR: PROD promotion must retain resumable partial data and must not copy the archive with scp\n' >&2
+	exit 1
+fi
+grep -F "cd '\${store_root}/\${tag}' && sha256sum -c SHA256SUMS" \
+	"${promotion_transfer}" >/dev/null
 grep -F "printf -v remote_command '%q '" \
 	"${ROOT}/.github/workflows/enterprise_promotion.yml" >/dev/null
 grep -F 'expected_edition=enterprise' "${ROOT}/.github/scripts/remote-deploy.sh" >/dev/null


### PR DESCRIPTION
Harden TEST-to-PROD Enterprise promotion for large offline releases.\n\n- enable SSH keepalives on both hops\n- replace archive scp with checksummed, resumable rsync\n- retry interrupted transfers while retaining partial data\n- verify on PROD before immutable retention and deployment\n- short-circuit exact retries only after source and PROD digests match\n- add a fault-injection test covering interruption, resume, checksum, and atomic retention\n\nValidated with release contracts, Enterprise flow contracts, fault-injection transfer test, workflow YAML parsing, all shell syntax checks, English-only source checks, and git diff checks.