### PR TITLE
Fix Copilot smart auto-scrolling for streamed replies

### DIFF
--- a/src/frontend/src/locales/en.ts
+++ b/src/frontend/src/locales/en.ts
@@ -885,6 +885,7 @@ export const en = {
       thinkingLiveProgress: 'Thinking… {seconds}s · step {count}',
       thinkingRetrievalHint: 'Retrieving and analyzing your workspace — the answer will stream in when ready.',
       messageTimeYesterday: 'Yesterday',
+      scrollToLatest: 'Back to latest',
       thinkingDone: 'Thought for {seconds}s · {count} steps',
       thinkingDoneSteps: '{count} reasoning steps',
       disclaimer: 'AI answers may be incomplete. Verify critical information.',

--- a/src/frontend/src/pages/insight/InsightCopilot.vue
+++ b/src/frontend/src/pages/insight/InsightCopilot.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, nextTick, onActivated, onDeactivated, onMounted, onUnmounted, ref, watch } from 'vue'
+import { computed, onActivated, onDeactivated, onMounted, onUnmounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
 import { ElMessage } from 'element-plus'
@@ -72,7 +72,7 @@ const deleteTarget = ref<SessionRow | null>(null)
 const messagesBySession = ref<Record<number, CopilotDisplayMessage[]>>({})
 const selectedStarterBySession = ref<Record<number, string>>({})
 const input = ref('')
-const chatScrollRef = ref<HTMLElement | null>(null)
+const messageListRef = ref<{ scrollToBottom: () => void } | null>(null)
 const lifecyclePollingIds = new Set<number>()
 let componentUnmounted = false
 
@@ -538,20 +538,8 @@ async function confirmDeleteSession() {
 }
 
 function scrollToBottom() {
-  nextTick(() => {
-    const el = chatScrollRef.value
-    if (el) el.scrollTop = el.scrollHeight
-  })
+  messageListRef.value?.scrollToBottom()
 }
-
-watch(
-  () => [
-    activeMessages.value.length,
-    activeStream.value?.partialAnswer,
-    activeStream.value?.isStreaming,
-  ],
-  () => scrollToBottom(),
-)
 
 async function applyStarterChip(key: string, text: string) {
   const sessionId = activeSessionId.value
@@ -565,7 +553,6 @@ async function applyStarterChip(key: string, text: string) {
 
 function retryQuestion(text: string) {
   input.value = text
-  scrollToBottom()
 }
 
 function onAttach() {
@@ -602,8 +589,6 @@ async function submitQuestion(question: string, { clearComposer = false } = {}) 
     const message = apiErrorMessage(err, t('errors.generic.requestFailed'))
     ElMessage.error({ message, grouping: true })
     await copilotStore.syncSession(sessionId, syncHandlers, activeSessionId.value).catch(() => undefined)
-  } finally {
-    scrollToBottom()
   }
 }
 
@@ -725,8 +710,10 @@ onUnmounted(() => {
           @delete="deleteActiveSession"
         />
 
-        <div v-if="activeSession?.lifecycle_status === 'ready'" ref="chatScrollRef" class="flex min-h-0 flex-1 flex-col overflow-hidden">
+        <div v-if="activeSession?.lifecycle_status === 'ready'" class="flex min-h-0 flex-1 flex-col overflow-hidden">
           <CopilotMessageList
+            :key="activeSessionId"
+            ref="messageListRef"
             :messages="activeMessages"
             :streaming="showLiveStream"
             :streaming-content="activeStream?.partialAnswer ?? ''"

--- a/src/frontend/src/pages/insight/copilot/CopilotMessageList.test.ts
+++ b/src/frontend/src/pages/insight/copilot/CopilotMessageList.test.ts
@@ -1,11 +1,28 @@
 // @vitest-environment jsdom
 
+import { nextTick } from 'vue'
 import { mount } from '@vue/test-utils'
 import { createI18n } from 'vue-i18n'
-import { describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { en } from '../../../locales/en'
 import CopilotMessageList from './CopilotMessageList.vue'
+
+let resizeCallback: ResizeObserverCallback | null = null
+
+class ResizeObserverMock {
+  constructor(callback: ResizeObserverCallback) {
+    resizeCallback = callback
+  }
+
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+function notifyContentResize() {
+  resizeCallback?.([], {} as ResizeObserver)
+}
 
 function mountList(props: Record<string, unknown>) {
   const i18n = createI18n({
@@ -25,6 +42,16 @@ function mountList(props: Record<string, unknown>) {
 }
 
 describe('CopilotMessageList starter questions and live feedback', () => {
+  beforeEach(() => {
+    resizeCallback = null
+    vi.stubGlobal('ResizeObserver', ResizeObserverMock)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+  })
+
   it('emits a starter question directly and exposes its selected state', async () => {
     const wrapper = mountList({
       messages: [{
@@ -81,6 +108,92 @@ describe('CopilotMessageList starter questions and live feedback', () => {
     expect(status.text()).toContain('Thinking… 2s')
     expect(livePanel.find('.thinking-panel-body').exists()).toBe(false)
     expect(wrapper.find('.message-card--typing').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('follows the rendered height after a streamed reply flushes', async () => {
+    vi.useFakeTimers()
+    const wrapper = mountList({
+      messages: [{ id: 'user-1', role: 'user', text: 'Question' }],
+      streaming: true,
+      streamingContent: '',
+    })
+    await nextTick()
+    const scroll = wrapper.get('.chat-scroll').element as HTMLElement
+    let scrollHeight = 800
+    Object.defineProperties(scroll, {
+      clientHeight: { configurable: true, get: () => 400 },
+      scrollHeight: { configurable: true, get: () => scrollHeight },
+      scrollTop: { configurable: true, writable: true, value: 400 },
+    })
+
+    await wrapper.setProps({ streamingContent: 'A new streamed reply' })
+    await nextTick()
+    expect(scroll.scrollTop).toBe(800)
+
+    await vi.advanceTimersByTimeAsync(64)
+    scrollHeight = 960
+    notifyContentResize()
+
+    expect(scroll.scrollTop).toBe(960)
+    wrapper.unmount()
+  })
+
+  it('pauses following while the user reads history and resumes on request', async () => {
+    const wrapper = mountList({
+      messages: [{ id: 'user-1', role: 'user', text: 'Question' }],
+      streaming: true,
+      streamingContent: '',
+    })
+    await nextTick()
+    const scroll = wrapper.get('.chat-scroll').element as HTMLElement
+    let scrollHeight = 1000
+    Object.defineProperties(scroll, {
+      clientHeight: { configurable: true, get: () => 400 },
+      scrollHeight: { configurable: true, get: () => scrollHeight },
+      scrollTop: { configurable: true, writable: true, value: 200 },
+    })
+
+    await wrapper.get('.chat-scroll').trigger('scroll')
+    expect(wrapper.get('.scroll-to-latest').text()).toContain('Back to latest')
+
+    scrollHeight = 1200
+    await wrapper.setProps({ streamingContent: 'Do not interrupt history reading' })
+    await nextTick()
+    notifyContentResize()
+    expect(scroll.scrollTop).toBe(200)
+
+    await wrapper.get('.scroll-to-latest').trigger('click')
+    await nextTick()
+    expect(scroll.scrollTop).toBe(1200)
+    expect(wrapper.find('.scroll-to-latest').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('resumes following when the user scrolls back near the bottom', async () => {
+    const wrapper = mountList({
+      messages: [{ id: 'user-1', role: 'user', text: 'Question' }],
+      streaming: true,
+      streamingContent: '',
+    })
+    await nextTick()
+    const scroll = wrapper.get('.chat-scroll').element as HTMLElement
+    let scrollHeight = 1000
+    Object.defineProperties(scroll, {
+      clientHeight: { configurable: true, get: () => 400 },
+      scrollHeight: { configurable: true, get: () => scrollHeight },
+      scrollTop: { configurable: true, writable: true, value: 200 },
+    })
+
+    await wrapper.get('.chat-scroll').trigger('scroll')
+    scroll.scrollTop = 560
+    await wrapper.get('.chat-scroll').trigger('scroll')
+    expect(wrapper.find('.scroll-to-latest').exists()).toBe(false)
+
+    scrollHeight = 1200
+    await wrapper.setProps({ streamingContent: 'Continue following the reply' })
+    await nextTick()
+    expect(scroll.scrollTop).toBe(1200)
     wrapper.unmount()
   })
 })

--- a/src/frontend/src/pages/insight/copilot/CopilotMessageList.vue
+++ b/src/frontend/src/pages/insight/copilot/CopilotMessageList.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { ArrowDown, ChevronDown, ChevronUp, Copy, RotateCcw, Share2, Sparkles } from 'lucide-vue-next'
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { ChevronDown, ChevronUp, Copy, RotateCcw, Share2, Sparkles } from 'lucide-vue-next'
 import { ElMessage } from 'element-plus'
 import { copyTextToClipboard } from '../../../lib/clipboard'
 import { currentUser } from '../../../composables/useAuth'
@@ -32,6 +32,59 @@ const emit = defineEmits<{
 const { t } = useI18n()
 const expandedThinking = ref<Set<string>>(new Set())
 const liveThinkingOpen = ref(true)
+const chatScrollRef = ref<HTMLElement | null>(null)
+const copilotThreadRef = ref<HTMLElement | null>(null)
+const followsLatest = ref(true)
+let contentResizeObserver: ResizeObserver | null = null
+
+const BOTTOM_FOLLOW_THRESHOLD = 48
+
+function isNearBottom(el: HTMLElement) {
+  return el.scrollHeight - el.scrollTop - el.clientHeight <= BOTTOM_FOLLOW_THRESHOLD
+}
+
+function syncFollowState() {
+  const el = chatScrollRef.value
+  if (el) followsLatest.value = isNearBottom(el)
+}
+
+function alignToLatestIfFollowing() {
+  if (!followsLatest.value) return
+  const el = chatScrollRef.value
+  if (el) el.scrollTop = el.scrollHeight
+}
+
+function scrollToBottom() {
+  followsLatest.value = true
+  nextTick(alignToLatestIfFollowing)
+}
+
+watch(
+  () => [
+    props.messages.length,
+    props.streamingContent,
+    props.streamingThinking?.length,
+    props.streaming,
+    props.streamError,
+  ],
+  () => {
+    nextTick(alignToLatestIfFollowing)
+  },
+  { flush: 'post' },
+)
+
+onMounted(() => {
+  scrollToBottom()
+  const thread = copilotThreadRef.value
+  if (thread && typeof ResizeObserver !== 'undefined') {
+    contentResizeObserver = new ResizeObserver(alignToLatestIfFollowing)
+    contentResizeObserver.observe(thread)
+  }
+})
+
+onBeforeUnmount(() => contentResizeObserver?.disconnect())
+
+defineExpose({ scrollToBottom })
 
 const starterChips = [
   { key: 'chipQuerySops', icon: '📖' },
@@ -67,6 +120,12 @@ function toggleThinking(id: string) {
   if (next.has(id)) next.delete(id)
   else next.add(id)
   expandedThinking.value = next
+  if (followsLatest.value) scrollToBottom()
+}
+
+function toggleLiveThinking() {
+  liveThinkingOpen.value = !liveThinkingOpen.value
+  if (followsLatest.value) scrollToBottom()
 }
 
 function thinkingStepsFor(message: CopilotDisplayMessage) {
@@ -171,187 +230,259 @@ const showLiveRow = computed(() => props.streaming)
 </script>
 
 <template>
-  <div class="chat-scroll min-h-0 flex-1 overflow-y-auto">
-    <div class="copilot-thread">
-      <div
-        v-for="msg in messages"
-        :key="msg.id"
-        class="message-row"
-        :class="msg.role === 'user' ? 'message-row-user' : 'message-row-assistant'"
-      >
+  <div class="chat-scroll-shell min-h-0 flex-1">
+    <div ref="chatScrollRef" class="chat-scroll h-full overflow-y-auto" @scroll="syncFollowState">
+      <div ref="copilotThreadRef" class="copilot-thread">
         <div
-          class="message-avatar message-avatar-icon"
-          :class="msg.role === 'user' ? 'message-avatar-icon--user' : 'message-avatar-icon--assistant'"
-          :aria-label="
-            msg.role === 'user' ? t('insight.copilot.roleUser') : t('insight.copilot.roleAi')
-          "
+          v-for="msg in messages"
+          :key="msg.id"
+          class="message-row"
+          :class="msg.role === 'user' ? 'message-row-user' : 'message-row-assistant'"
         >
-          <span v-if="msg.role === 'user'" class="message-avatar-initial">{{ userInitial }}</span>
-          <Sparkles v-else :size="16" :stroke-width="2" />
-        </div>
-
-        <div class="message-body">
           <div
-            v-if="msg.role === 'assistant' && thinkingStepsFor(msg).length"
-            class="thinking-panel thinking-panel-done"
+            class="message-avatar message-avatar-icon"
+            :class="
+              msg.role === 'user'
+                ? 'message-avatar-icon--user'
+                : 'message-avatar-icon--assistant'
+            "
+            :aria-label="
+              msg.role === 'user' ? t('insight.copilot.roleUser') : t('insight.copilot.roleAi')
+            "
           >
-            <button type="button" class="thinking-panel-header" @click="toggleThinking(msg.id)">
-              <span class="thinking-panel-status">
-                {{
-                  thinkingDuration(msg) != null
-                    ? t('insight.copilot.thinkingDone', {
-                        seconds: thinkingDuration(msg),
-                        count: thinkingStepsFor(msg).length,
-                      })
-                    : t('insight.copilot.thinkingDoneSteps', { count: thinkingStepsFor(msg).length })
-                }}
-              </span>
-              <ChevronUp v-if="expandedThinking.has(msg.id)" :size="13" class="thinking-panel-chevron" />
-              <ChevronDown v-else :size="13" class="thinking-panel-chevron" />
-            </button>
-            <div v-if="expandedThinking.has(msg.id)" class="thinking-panel-body">
-              <div v-for="(step, idx) in thinkingStepsFor(msg)" :key="idx" class="thinking-step-item">
-                <span class="thinking-step-bullet">▸</span>
-                <span class="thinking-step-text">{{ stepLabel(step) }}</span>
-              </div>
-            </div>
+            <span v-if="msg.role === 'user'" class="message-avatar-initial">{{ userInitial }}</span>
+            <Sparkles v-else :size="16" :stroke-width="2" />
           </div>
 
-          <div
-            class="message-card"
-            :class="[
-              msg.role,
-              msg.isError ? 'message-card--error' : '',
-              msg.starterChips ? 'message-card--welcome' : '',
-            ]"
-          >
-            <div v-if="msg.starterChips || msg.isError" class="message-text">{{ msg.text }}</div>
-            <div v-else-if="msg.role === 'assistant' && msg.text" class="message-markdown">
-              <CopilotMarkdown :content="msg.text" />
-            </div>
-            <div v-else-if="msg.text" class="message-text">{{ msg.text }}</div>
-
-            <div v-if="msg.starterChips" class="copilot-chip-grid">
-              <button
-                v-for="chip in starterChips"
-                :key="chip.key"
-                type="button"
-                class="copilot-chip-box"
-                :class="{ 'is-selected': selectedStarterKey === chip.key }"
-                :aria-pressed="selectedStarterKey === chip.key"
-                :disabled="starterDisabled"
-                @click="emit('starterChip', chip.key, starterChipPrompt(chip.key))"
-              >
-                <span class="copilot-chip-inner">
-                  <span class="copilot-chip-icon" aria-hidden="true">{{ chip.icon }}</span>
-                  <span class="copilot-chip-label">{{ starterChipTitle(chip.key) }}</span>
+          <div class="message-body">
+            <div
+              v-if="msg.role === 'assistant' && thinkingStepsFor(msg).length"
+              class="thinking-panel thinking-panel-done"
+            >
+              <button type="button" class="thinking-panel-header" @click="toggleThinking(msg.id)">
+                <span class="thinking-panel-status">
+                  {{
+                    thinkingDuration(msg) != null
+                      ? t('insight.copilot.thinkingDone', {
+                          seconds: thinkingDuration(msg),
+                          count: thinkingStepsFor(msg).length,
+                        })
+                      : t('insight.copilot.thinkingDoneSteps', {
+                          count: thinkingStepsFor(msg).length,
+                        })
+                  }}
                 </span>
+                <ChevronUp
+                  v-if="expandedThinking.has(msg.id)"
+                  :size="13"
+                  class="thinking-panel-chevron"
+                />
+                <ChevronDown v-else :size="13" class="thinking-panel-chevron" />
+              </button>
+              <div v-if="expandedThinking.has(msg.id)" class="thinking-panel-body">
+                <div
+                  v-for="(step, idx) in thinkingStepsFor(msg)"
+                  :key="idx"
+                  class="thinking-step-item"
+                >
+                  <span class="thinking-step-bullet">▸</span>
+                  <span class="thinking-step-text">{{ stepLabel(step) }}</span>
+                </div>
+              </div>
+            </div>
+
+            <div
+              class="message-card"
+              :class="[
+                msg.role,
+                msg.isError ? 'message-card--error' : '',
+                msg.starterChips ? 'message-card--welcome' : '',
+              ]"
+            >
+              <div v-if="msg.starterChips || msg.isError" class="message-text">{{ msg.text }}</div>
+              <div v-else-if="msg.role === 'assistant' && msg.text" class="message-markdown">
+                <CopilotMarkdown :content="msg.text" />
+              </div>
+              <div v-else-if="msg.text" class="message-text">{{ msg.text }}</div>
+
+              <div v-if="msg.starterChips" class="copilot-chip-grid">
+                <button
+                  v-for="chip in starterChips"
+                  :key="chip.key"
+                  type="button"
+                  class="copilot-chip-box"
+                  :class="{ 'is-selected': selectedStarterKey === chip.key }"
+                  :aria-pressed="selectedStarterKey === chip.key"
+                  :disabled="starterDisabled"
+                  @click="emit('starterChip', chip.key, starterChipPrompt(chip.key))"
+                >
+                  <span class="copilot-chip-inner">
+                    <span class="copilot-chip-icon" aria-hidden="true">{{ chip.icon }}</span>
+                    <span class="copilot-chip-label">{{ starterChipTitle(chip.key) }}</span>
+                  </span>
+                </button>
+              </div>
+            </div>
+
+            <div v-if="msg.createdAt" class="message-time" :class="msg.role">
+              {{ formatMessageTime(msg.createdAt) }}
+            </div>
+
+            <div
+              v-if="msg.role === 'assistant' && msg.text && !msg.starterChips && !msg.isError"
+              class="message-actions"
+            >
+              <button
+                type="button"
+                class="message-action-btn"
+                :title="t('common.copy')"
+                @click="copyText(msg.text || '')"
+              >
+                <Copy :size="16" />
+              </button>
+              <button
+                type="button"
+                class="message-action-btn"
+                :title="t('insight.copilot.retryQuestion')"
+                :disabled="!questionForMessage(msg)"
+                @click="retryForMessage(msg)"
+              >
+                <RotateCcw :size="16" />
+              </button>
+              <button
+                type="button"
+                class="message-action-btn"
+                :title="t('insight.copilot.shareAnswer')"
+                @click="shareMessage()"
+              >
+                <Share2 :size="16" />
               </button>
             </div>
           </div>
-
-          <div
-            v-if="msg.createdAt"
-            class="message-time"
-            :class="msg.role"
-          >
-            {{ formatMessageTime(msg.createdAt) }}
-          </div>
-
-          <div
-            v-if="msg.role === 'assistant' && msg.text && !msg.starterChips && !msg.isError"
-            class="message-actions"
-          >
-            <button
-              type="button"
-              class="message-action-btn"
-              :title="t('common.copy')"
-              @click="copyText(msg.text || '')"
-            >
-              <Copy :size="16" />
-            </button>
-            <button
-              type="button"
-              class="message-action-btn"
-              :title="t('insight.copilot.retryQuestion')"
-              :disabled="!questionForMessage(msg)"
-              @click="retryForMessage(msg)"
-            >
-              <RotateCcw :size="16" />
-            </button>
-            <button
-              type="button"
-              class="message-action-btn"
-              :title="t('insight.copilot.shareAnswer')"
-              @click="shareMessage()"
-            >
-              <Share2 :size="16" />
-            </button>
-          </div>
         </div>
-      </div>
 
-      <div v-if="showLiveRow" class="message-row message-row-assistant live-progress-row">
-        <div class="message-avatar message-avatar-icon message-avatar-icon--assistant" :aria-label="t('insight.copilot.roleAi')">
-          <Sparkles :size="16" :stroke-width="2" />
-        </div>
-        <div class="message-body">
-          <div v-if="!streamError" class="thinking-panel thinking-panel-live">
-            <button
-              v-if="streamingThinking?.length"
-              type="button"
-              class="thinking-panel-header"
-              :aria-expanded="liveThinkingOpen"
-              @click="liveThinkingOpen = !liveThinkingOpen"
-            >
-              <span class="live-progress-dot" />
-              <span class="thinking-panel-status">
-                <span class="thinking-panel-status-text">{{ liveThinkingStatus() }}</span>
-              </span>
-              <span v-if="streamingThinking.length" class="thinking-step-count">
-                {{ streamingThinking.length }}
-              </span>
-              <ChevronUp v-if="liveThinkingOpen" :size="13" class="thinking-panel-chevron" />
-              <ChevronDown v-else :size="13" class="thinking-panel-chevron" />
-            </button>
-            <div
-              v-else
-              class="thinking-panel-header thinking-panel-header--static"
-              role="status"
-              aria-live="polite"
-            >
-              <span class="live-progress-dot" />
-              <span class="thinking-panel-status">
-                <span class="thinking-panel-status-text">{{ liveThinkingStatus() }}</span>
-              </span>
-            </div>
-            <div v-if="liveThinkingOpen && streamingThinking?.length" class="thinking-panel-body">
-              <div v-for="(step, idx) in streamingThinking" :key="idx" class="thinking-step-item">
-                <span class="thinking-step-bullet">▸</span>
-                <span class="thinking-step-text">{{ step.displayMessage || stepLabel(step) }}</span>
+        <div v-if="showLiveRow" class="message-row message-row-assistant live-progress-row">
+          <div
+            class="message-avatar message-avatar-icon message-avatar-icon--assistant"
+            :aria-label="t('insight.copilot.roleAi')"
+          >
+            <Sparkles :size="16" :stroke-width="2" />
+          </div>
+          <div class="message-body">
+            <div v-if="!streamError" class="thinking-panel thinking-panel-live">
+              <button
+                v-if="streamingThinking?.length"
+                type="button"
+                class="thinking-panel-header"
+                :aria-expanded="liveThinkingOpen"
+                @click="toggleLiveThinking"
+              >
+                <span class="live-progress-dot" />
+                <span class="thinking-panel-status">
+                  <span class="thinking-panel-status-text">{{ liveThinkingStatus() }}</span>
+                </span>
+                <span v-if="streamingThinking.length" class="thinking-step-count">
+                  {{ streamingThinking.length }}
+                </span>
+                <ChevronUp v-if="liveThinkingOpen" :size="13" class="thinking-panel-chevron" />
+                <ChevronDown v-else :size="13" class="thinking-panel-chevron" />
+              </button>
+              <div
+                v-else
+                class="thinking-panel-header thinking-panel-header--static"
+                role="status"
+                aria-live="polite"
+              >
+                <span class="live-progress-dot" />
+                <span class="thinking-panel-status">
+                  <span class="thinking-panel-status-text">{{ liveThinkingStatus() }}</span>
+                </span>
+              </div>
+              <div v-if="liveThinkingOpen && streamingThinking?.length" class="thinking-panel-body">
+                <div v-for="(step, idx) in streamingThinking" :key="idx" class="thinking-step-item">
+                  <span class="thinking-step-bullet">▸</span>
+                  <span class="thinking-step-text">{{ step.displayMessage || stepLabel(step) }}</span>
+                </div>
               </div>
             </div>
-          </div>
 
-          <p v-if="showRetrievalHint" class="thinking-retrieval-hint">
-            {{ t('insight.copilot.thinkingRetrievalHint') }}
-          </p>
+            <p v-if="showRetrievalHint" class="thinking-retrieval-hint">
+              {{ t('insight.copilot.thinkingRetrievalHint') }}
+            </p>
 
-          <div v-if="streamingContent || streamError" class="message-card assistant">
-            <div v-if="streamError" class="message-text message-text--error">{{ streamError }}</div>
-            <div v-else class="message-markdown live-markdown" :class="{ 'is-streaming': streaming }">
-              <CopilotStreamingMarkdown :content="streamingContent || ''" :streaming="streaming" />
+            <div v-if="streamingContent || streamError" class="message-card assistant">
+              <div v-if="streamError" class="message-text message-text--error">{{ streamError }}</div>
+              <div
+                v-else
+                class="message-markdown live-markdown"
+                :class="{ 'is-streaming': streaming }"
+              >
+                <CopilotStreamingMarkdown
+                  :content="streamingContent || ''"
+                  :streaming="streaming"
+                />
+              </div>
             </div>
           </div>
         </div>
       </div>
     </div>
+
+    <button
+      v-if="!followsLatest"
+      type="button"
+      class="scroll-to-latest"
+      :aria-label="t('insight.copilot.scrollToLatest')"
+      :title="t('insight.copilot.scrollToLatest')"
+      @click="scrollToBottom"
+    >
+      <ArrowDown :size="16" aria-hidden="true" />
+      <span>{{ t('insight.copilot.scrollToLatest') }}</span>
+    </button>
   </div>
 </template>
 
 <style scoped>
+.chat-scroll-shell {
+  position: relative;
+}
+
 .chat-scroll {
   background: var(--color-card-bg);
+  overscroll-behavior: contain;
+}
+
+.scroll-to-latest {
+  position: absolute;
+  z-index: 2;
+  bottom: 16px;
+  left: 50%;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 34px;
+  padding: 7px 12px;
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  background: var(--color-card-bg);
+  box-shadow: var(--shadow-md);
+  color: var(--color-text-secondary);
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transform: translateX(-50%);
+  transition: border-color 0.16s ease, color 0.16s ease, box-shadow 0.16s ease;
+}
+
+.scroll-to-latest:hover {
+  border-color: color-mix(in srgb, var(--color-primary) 42%, var(--color-border));
+  color: var(--color-primary);
+  box-shadow: var(--shadow-lg);
+}
+
+.scroll-to-latest:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--color-primary) 55%, transparent);
+  outline-offset: 2px;
 }
 
 .copilot-thread {
@@ -803,6 +934,10 @@ const showLiveRow = computed(() => props.streaming)
 }
 
 @media (max-width: 768px) {
+  .scroll-to-latest {
+    min-height: 44px;
+  }
+
   .copilot-thread {
     padding: 16px 16px 28px;
   }


### PR DESCRIPTION
## Summary
- move Copilot scrolling to the actual message viewport
- follow streamed replies and rendered height changes while preserving manual history reading
- add a Back to latest control and mobile-friendly touch target
- keep retry selection from forcing users away from message history

## Validation
- `npm test -- --run src/pages/insight/copilot/CopilotMessageList.test.ts src/pages/insight/InsightCopilotStarterSubmission.test.ts src/pages/insight/copilot/CopilotLifecycleState.test.ts`
- `npx vue-tsc --noEmit`
- targeted ESLint
- `npm run build`
- `git diff --check`