### PR TITLE
Polish restore plan layout

### DIFF
--- a/src/frontend/src/components/WizardSteps.vue
+++ b/src/frontend/src/components/WizardSteps.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { computed } from 'vue'
 import type { Component } from 'vue'
 
 type WizardStepValue = string | number
@@ -14,12 +15,14 @@ const props = withDefaults(defineProps<{
   currentStep: WizardStepValue
   ariaLabel?: string
   clickable?: boolean
+  responsiveHorizontal?: boolean
   as?: string
   isDone?: (step: WizardStepValue, index: number) => boolean
   isLocked?: (step: WizardStepValue, index: number) => boolean
 }>(), {
   ariaLabel: undefined,
   clickable: true,
+  responsiveHorizontal: false,
   as: 'nav',
   isDone: undefined,
   isLocked: undefined,
@@ -28,6 +31,13 @@ const props = withDefaults(defineProps<{
 const emit = defineEmits<{
   'step-click': [step: WizardStepValue, index: number]
 }>()
+
+const activeStepIndex = computed(() => {
+  const index = props.steps.findIndex((item) => item.step === props.currentStep)
+  return index >= 0 ? index : 0
+})
+
+const activeStepLabel = computed(() => props.steps[activeStepIndex.value]?.label || '')
 
 function stepKey(item: WizardStepItem, index: number) {
   return `${String(item.step)}-${index}`
@@ -55,6 +65,7 @@ function onStepClick(item: WizardStepItem, index: number) {
   <component
     :is="as"
     class="wizard-steps"
+    :class="{ 'wizard-steps--responsive-horizontal': responsiveHorizontal }"
     :aria-label="ariaLabel"
   >
     <template
@@ -118,6 +129,13 @@ function onStepClick(item: WizardStepItem, index: number) {
         aria-hidden="true"
       />
     </template>
+    <div
+      v-if="responsiveHorizontal"
+      class="wizard-steps__compact-status"
+      aria-hidden="true"
+    >
+      {{ activeStepIndex + 1 }}/{{ steps.length }} · {{ activeStepLabel }}
+    </div>
   </component>
 </template>
 
@@ -237,6 +255,75 @@ button.wizard-steps__item {
     height: 20px;
     min-height: 20px;
     flex-basis: 20px;
+  }
+}
+
+@media (max-width: 767.98px) {
+  .wizard-steps--responsive-horizontal {
+    width: 100%;
+    flex-direction: row;
+    align-items: flex-start;
+    padding: 0 4px;
+    overflow: hidden;
+  }
+
+  .wizard-steps--responsive-horizontal .wizard-steps__item {
+    flex: 0 1 112px;
+    flex-direction: column;
+    gap: 6px;
+    text-align: center;
+  }
+
+  .wizard-steps--responsive-horizontal .wizard-steps__label {
+    max-width: 112px;
+    font-size: 12px;
+    line-height: 1.25;
+    overflow-wrap: anywhere;
+    white-space: normal;
+  }
+
+  .wizard-steps--responsive-horizontal .wizard-steps__connector {
+    width: auto;
+    height: 1px;
+    min-height: 1px;
+    flex: 1 1 20px;
+    margin: 14px 6px 0;
+  }
+}
+
+.wizard-steps__compact-status {
+  display: none;
+}
+
+@media (max-width: 479.98px) {
+  .wizard-steps--responsive-horizontal {
+    flex-wrap: wrap;
+    row-gap: 8px;
+  }
+
+  .wizard-steps--responsive-horizontal .wizard-steps__item {
+    min-width: 28px;
+    flex: 0 0 28px;
+  }
+
+  .wizard-steps--responsive-horizontal .wizard-steps__label {
+    display: none;
+  }
+
+  .wizard-steps--responsive-horizontal .wizard-steps__connector {
+    margin-right: 4px;
+    margin-left: 4px;
+  }
+
+  .wizard-steps--responsive-horizontal .wizard-steps__compact-status {
+    display: block;
+    width: 100%;
+    flex: 0 0 100%;
+    color: rgb(71 85 105);
+    font-size: 12px;
+    font-weight: 600;
+    line-height: 18px;
+    text-align: center;
   }
 }
 </style>

--- a/src/frontend/src/components/WizardStepsResponsive.test.ts
+++ b/src/frontend/src/components/WizardStepsResponsive.test.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const source = readFileSync(resolve(process.cwd(), 'src/components/WizardSteps.vue'), 'utf8')
+
+describe('WizardSteps responsive horizontal variant', () => {
+  it('keeps the horizontal layout opt-in', () => {
+    expect(source).toContain('responsiveHorizontal?: boolean')
+    expect(source).toContain('responsiveHorizontal: false')
+    expect(source).toContain("'wizard-steps--responsive-horizontal': responsiveHorizontal")
+  })
+
+  it('uses a full horizontal stepper on narrow screens', () => {
+    expect(source).toMatch(/@media \(max-width: 767\.98px\) \{[\s\S]*?\.wizard-steps--responsive-horizontal \{[\s\S]*?flex-direction: row;/)
+    expect(source).toMatch(/\.wizard-steps--responsive-horizontal \.wizard-steps__connector \{[\s\S]*?height: 1px;/)
+  })
+
+  it('uses a compact status below phone width without horizontal scrolling', () => {
+    expect(source).toContain('{{ activeStepIndex + 1 }}/{{ steps.length }} · {{ activeStepLabel }}')
+    expect(source).toMatch(/@media \(max-width: 479\.98px\) \{[\s\S]*?\.wizard-steps--responsive-horizontal \.wizard-steps__label \{[\s\S]*?display: none;/)
+    expect(source).toMatch(/\.wizard-steps--responsive-horizontal \.wizard-steps__compact-status \{[\s\S]*?display: block;/)
+  })
+})

--- a/src/frontend/src/pages/protection/BackupConfigCreateWizard.vue
+++ b/src/frontend/src/pages/protection/BackupConfigCreateWizard.vue
@@ -188,6 +188,10 @@ watch(
   min-height: 0;
 }
 
+.create-backup-layout {
+  width: min(100%, 1560px);
+}
+
 .create-backup-fullscreen .create-backup-layout--steps {
   display: flex;
   flex-direction: column;

--- a/src/frontend/src/pages/protection/BackupCreateWizard.vue
+++ b/src/frontend/src/pages/protection/BackupCreateWizard.vue
@@ -7580,7 +7580,7 @@ function preserveShallowestPathOrder(paths: string[]) {
                               :visible="isCreateRecoverySourcePathPickerVisible(group, dirPlan)"
                               trigger="manual"
                               placement="bottom-start"
-                              :width="360"
+                              :width="460"
                               popper-class="create-recovery-path-popover"
                               @update:visible="(visible) => setCreateRecoverySourcePathPickerVisible(group, dirPlan, Boolean(visible))"
                             >
@@ -7588,6 +7588,7 @@ function preserveShallowestPathOrder(paths: string[]) {
                                 <div class="create-recovery-path-input">
                                   <el-input
                                     :model-value="recoverySourcePathInputValue(dirPlan.sourcePath)"
+                                    :title="recoverySourcePathInputValue(dirPlan.sourcePath) || undefined"
                                     clearable
                                     :placeholder="t('protection.backupsPage.phSelectOrEnterRestoreScope')"
                                     :class="{
@@ -7659,7 +7660,10 @@ function preserveShallowestPathOrder(paths: string[]) {
                                   <template #default="{ data }">
                                     <div
                                       class="create-tree-node-content hfl-dir-tree-node"
-                                      :class="{ 'create-tree-node-content--snapshot': isWholeSnapshotRecoveryPath(data.path) }"
+                                      :class="{
+                                        'create-tree-node-content--snapshot': isWholeSnapshotRecoveryPath(data.path),
+                                        'create-tree-node-content--selected': dirPlan.sourcePath === data.path,
+                                      }"
                                       :title="createRecoverySourceTreePathLabel(data)"
                                     >
                                       <Camera
@@ -7673,7 +7677,15 @@ function preserveShallowestPathOrder(paths: string[]) {
                                         class="create-tree-node-content__icon hfl-dir-tree-node__icon create-dir-row__icon--file"
                                       />
                                       <FolderOpen v-else :size="15" class="create-tree-node-content__icon hfl-dir-tree-node__icon create-dir-row__icon--folder" />
-                                      <span class="create-tree-node-content__label hfl-dir-tree-node__label">{{ data.label }}</span>
+                                      <div class="create-tree-node-content__text hfl-dir-tree-node__text">
+                                        <span class="create-tree-node-content__label hfl-dir-tree-node__label">{{ data.label }}</span>
+                                        <span
+                                          v-if="isWholeSnapshotRecoveryPath(data.path)"
+                                          class="create-tree-node-content__snapshot-desc hfl-dir-tree-node__path"
+                                        >
+                                          {{ t('protection.backupsPage.createRecoveryScopeSnapshotDesc') }}
+                                        </span>
+                                      </div>
                                       <button
                                         v-if="data.path_type === 'directory' && !isWholeSnapshotRecoveryPath(data.path)"
                                         type="button"
@@ -7715,6 +7727,9 @@ function preserveShallowestPathOrder(paths: string[]) {
                               @popup-scroll="onCreateRecoveryTargetPopupScroll"
                               @update:model-value="(value) => onCreateRecoveryTargetHostChange(group, dirPlan, value)"
                             >
+                              <template #label="{ label }">
+                                <span class="create-recovery-target-selected-label" :title="label">{{ label }}</span>
+                              </template>
                               <template #header>
                                 <div class="create-recovery-target-quick-option">
                                   <ElTooltip
@@ -7845,6 +7860,7 @@ function preserveShallowestPathOrder(paths: string[]) {
                                 <div class="create-recovery-path-input">
                                   <el-input
                                     :model-value="dirPlan.restoreDir"
+                                    :title="dirPlan.restoreDir || undefined"
                                     clearable
                                     :placeholder="t('protection.backupsPage.phSelectOrEnterRestoreDirectory')"
                                     :class="{
@@ -8217,7 +8233,7 @@ function preserveShallowestPathOrder(paths: string[]) {
               </el-table-column>
               <el-table-column :label="t('protection.backupsPage.createRecoveryPlanEnabled')" width="96" fixed="right" align="center">
                 <template #default="{ row: group }">
-                  <div class="create-recovery-plan-action">
+                  <div class="create-recovery-plan-action hfl-table-no-tooltip">
                     <el-switch
                       :model-value="group.plan.enabled"
                       inline-prompt
@@ -10448,6 +10464,14 @@ function preserveShallowestPathOrder(paths: string[]) {
   line-height: 1.3;
 }
 
+.create-recovery-target-selected-label {
+  display: block;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .create-recovery-target-node-option__main {
   display: flex;
   min-width: 0;
@@ -10931,16 +10955,36 @@ function preserveShallowestPathOrder(paths: string[]) {
   min-width: 100%;
 }
 
-.create-tree-node-content__label {
+.create-recovery-popover-tree :deep(.el-tree-node__expand-icon.is-leaf) {
+  width: 8px;
+  flex: 0 0 8px;
+  padding: 0;
+}
+
+.create-recovery-popover-tree :deep(.el-tree-node__content:has(> .create-tree-node-content--selected)) {
+  background: linear-gradient(180deg, color-mix(in srgb, var(--color-primary) 14%, var(--el-bg-color-overlay)) 0%, color-mix(in srgb, var(--color-primary) 20%, var(--el-bg-color-overlay)) 100%);
+}
+
+.create-tree-node-content__text {
+  flex: 1 1 auto;
   min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+}
+
+.create-tree-node-content__label {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow-wrap: anywhere;
+  white-space: normal;
 }
 
 .create-tree-node-content--snapshot .create-tree-node-content__label {
   color: var(--color-primary);
   font-weight: 700;
+}
+
+.create-tree-node-content__snapshot-desc {
+  overflow-wrap: anywhere;
+  white-space: normal;
 }
 
 @container (max-width: 900px) {
@@ -11022,7 +11066,6 @@ function preserveShallowestPathOrder(paths: string[]) {
 }
 
 :global(.create-recovery-path-popover.el-popper) {
-  width: min(360px, calc(100vw - 48px)) !important;
   max-width: calc(100vw - 48px);
   padding: 10px 10px 10px 12px;
   border-radius: 10px;
@@ -11668,7 +11711,7 @@ function preserveShallowestPathOrder(paths: string[]) {
 }
 
 .source-dir-tree :deep(.el-tree-node.is-current > .el-tree-node__content) {
-  background: linear-gradient(180deg, color-mix(in srgb, var(--color-primary) 14%, #fff) 0%, color-mix(in srgb, var(--color-primary) 20%, #fff) 100%);
+  background: linear-gradient(180deg, color-mix(in srgb, var(--color-primary) 14%, var(--el-bg-color-overlay)) 0%, color-mix(in srgb, var(--color-primary) 20%, var(--el-bg-color-overlay)) 100%);
 }
 
 .source-dir-tree :deep(.el-checkbox) {

--- a/src/frontend/src/pages/protection/BackupCreateWizard.vue
+++ b/src/frontend/src/pages/protection/BackupCreateWizard.vue
@@ -7564,12 +7564,15 @@ function preserveShallowestPathOrder(paths: string[]) {
                           v-for="(dirPlan, dirPlanIndex) in group.plan.dirPlans"
                           :key="dirPlan.id"
                           class="create-recovery-dir-plan-row"
-                          :class="{ 'create-recovery-dir-plan-row--invalid': highlightedRecoveryDirPlanIds.includes(dirPlan.id) }"
+                          :class="{
+                            'create-recovery-dir-plan-row--invalid': highlightedRecoveryDirPlanIds.includes(dirPlan.id)
+                              && !isRecoveryDirPlanComplete(group, dirPlan),
+                          }"
                           :data-recovery-dir-plan-id="dirPlan.id"
                         >
                           <span class="create-recovery-dir-plan-row__index">{{ String(dirPlanIndex + 1).padStart(2, '0') }}</span>
                           <div
-                            class="create-recovery-dir-plan-cell"
+                            class="create-recovery-dir-plan-cell create-recovery-dir-plan-cell--scope"
                             :class="{ 'create-recovery-dir-plan-cell--invalid': isCreateRecoveryDirPlanFieldInvalid(group, dirPlan, 'sourcePath') }"
                             :data-label="t('protection.backupsPage.createRecoveryPlanScopeCol')"
                           >
@@ -7654,7 +7657,11 @@ function preserveShallowestPathOrder(paths: string[]) {
                                   @node-expand="(data) => onCreateRecoveryDirectoryExpansionChange(recoveryDirPlanPickerKey(group, dirPlan, 'source'), data)"
                                 >
                                   <template #default="{ data }">
-                                    <div class="create-tree-node-content hfl-dir-tree-node">
+                                    <div
+                                      class="create-tree-node-content hfl-dir-tree-node"
+                                      :class="{ 'create-tree-node-content--snapshot': isWholeSnapshotRecoveryPath(data.path) }"
+                                      :title="createRecoverySourceTreePathLabel(data)"
+                                    >
                                       <Camera
                                         v-if="isWholeSnapshotRecoveryPath(data.path)"
                                         :size="15"
@@ -7666,10 +7673,7 @@ function preserveShallowestPathOrder(paths: string[]) {
                                         class="create-tree-node-content__icon hfl-dir-tree-node__icon create-dir-row__icon--file"
                                       />
                                       <FolderOpen v-else :size="15" class="create-tree-node-content__icon hfl-dir-tree-node__icon create-dir-row__icon--folder" />
-                                      <div class="create-tree-node-content__text hfl-dir-tree-node__text">
-                                        <span class="create-tree-node-content__label hfl-dir-tree-node__label">{{ data.label }}</span>
-                                        <span class="create-tree-node-content__path hfl-dir-tree-node__path">{{ createRecoverySourceTreePathLabel(data) }}</span>
-                                      </div>
+                                      <span class="create-tree-node-content__label hfl-dir-tree-node__label">{{ data.label }}</span>
                                       <button
                                         v-if="data.path_type === 'directory' && !isWholeSnapshotRecoveryPath(data.path)"
                                         type="button"
@@ -7692,7 +7696,7 @@ function preserveShallowestPathOrder(paths: string[]) {
                             </HflPopover>
                           </div>
                           <div
-                            class="create-recovery-dir-plan-cell"
+                            class="create-recovery-dir-plan-cell create-recovery-dir-plan-cell--target"
                             :class="{ 'create-recovery-dir-plan-cell--invalid': isCreateRecoveryDirPlanFieldInvalid(group, dirPlan, 'targetHostId') }"
                             :data-label="t('protection.backupsPage.createRecoveryPlanTargetHostCol')"
                           >
@@ -7825,7 +7829,7 @@ function preserveShallowestPathOrder(paths: string[]) {
                             </el-select>
                           </div>
                           <div
-                            class="create-recovery-dir-plan-cell"
+                            class="create-recovery-dir-plan-cell create-recovery-dir-plan-cell--directory"
                             :class="{ 'create-recovery-dir-plan-cell--invalid': isCreateRecoveryDirPlanFieldInvalid(group, dirPlan, 'restoreDir') }"
                             :data-label="t('protection.backupsPage.createRecoveryPlanTargetDirCol')"
                           >
@@ -10334,7 +10338,7 @@ function preserveShallowestPathOrder(paths: string[]) {
   border: 1px solid rgba(226, 232, 240, 0.95);
   border-radius: 8px;
   background: linear-gradient(180deg, rgb(255 255 255) 0%, rgb(248 250 252) 100%);
-  overflow-x: auto;
+  overflow-x: hidden;
   overflow-y: visible;
 }
 
@@ -10603,8 +10607,9 @@ function preserveShallowestPathOrder(paths: string[]) {
 
 .create-recovery-dir-plan-stack {
   display: flex;
-  min-width: 850px;
+  min-width: 0;
   flex-direction: column;
+  container-type: inline-size;
   border: 1px solid rgba(226, 232, 240, 0.95);
   border-radius: 8px;
   background: #fff;
@@ -10615,9 +10620,9 @@ function preserveShallowestPathOrder(paths: string[]) {
 .create-recovery-dir-plan-row,
 .create-recovery-dir-plan-add-wrap {
   display: grid;
-  min-width: 850px;
-  grid-template-columns: 34px minmax(230px, 1fr) minmax(260px, 1fr) minmax(230px, 1fr) 44px;
-  gap: 8px;
+  min-width: 0;
+  grid-template-columns: 34px minmax(190px, 1.1fr) minmax(190px, 1fr) minmax(190px, 1.1fr) 64px;
+  gap: 10px;
   align-items: center;
 }
 
@@ -10628,6 +10633,10 @@ function preserveShallowestPathOrder(paths: string[]) {
   font-weight: 700;
   line-height: 18px;
   background: rgb(248 250 252);
+}
+
+.create-recovery-dir-plan-header > span:last-child {
+  text-align: center;
 }
 
 .create-recovery-required-label {
@@ -10651,7 +10660,6 @@ function preserveShallowestPathOrder(paths: string[]) {
 }
 
 .create-recovery-dir-plan-row--invalid {
-  background: rgb(255 247 237);
   box-shadow: inset 3px 0 0 rgb(249 115 22);
 }
 
@@ -10867,17 +10875,13 @@ function preserveShallowestPathOrder(paths: string[]) {
 }
 
 .create-recovery-path-input__error {
-  position: absolute;
-  z-index: 3;
-  top: calc(100% + 4px);
-  left: 0;
   display: flex;
   min-width: 100%;
-  max-width: min(360px, calc(100vw - 48px));
+  max-width: 100%;
   align-items: flex-start;
   justify-content: space-between;
   gap: 6px;
-  margin: 0;
+  margin: 4px 0 0;
   padding: 4px 8px;
   border: 1px solid color-mix(in srgb, var(--el-color-danger) 38%, white);
   border-radius: 4px;
@@ -10925,6 +10929,82 @@ function preserveShallowestPathOrder(paths: string[]) {
 
 .create-recovery-popover-tree {
   min-width: 100%;
+}
+
+.create-tree-node-content__label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.create-tree-node-content--snapshot .create-tree-node-content__label {
+  color: var(--color-primary);
+  font-weight: 700;
+}
+
+@container (max-width: 900px) {
+  .create-recovery-dir-plan-header {
+    display: none;
+  }
+
+  .create-recovery-dir-plan-row {
+    grid-template-columns: 34px repeat(2, minmax(0, 1fr)) 36px;
+    align-items: start;
+    padding-block: 12px;
+  }
+
+  .create-recovery-dir-plan-cell:not(.create-recovery-dir-plan-cell--actions)::before {
+    display: block;
+    margin-bottom: 5px;
+    color: rgb(100 116 139);
+    content: attr(data-label);
+    font-size: 12px;
+    font-weight: 700;
+    line-height: 18px;
+  }
+
+  .create-recovery-dir-plan-cell--scope {
+    grid-column: 2 / 4;
+  }
+
+  .create-recovery-dir-plan-cell--target {
+    grid-column: 2;
+  }
+
+  .create-recovery-dir-plan-cell--directory {
+    grid-column: 3;
+  }
+
+  .create-recovery-dir-plan-cell--actions {
+    grid-column: 4;
+    grid-row: 1;
+  }
+
+  .create-recovery-dir-plan-add-wrap {
+    grid-template-columns: 34px minmax(0, 1fr) 36px;
+  }
+
+  .create-recovery-dir-plan-add-row {
+    grid-column: 2;
+    width: 100%;
+  }
+}
+
+@container (max-width: 620px) {
+  .create-recovery-dir-plan-row {
+    grid-template-columns: 34px minmax(0, 1fr) 36px;
+  }
+
+  .create-recovery-dir-plan-cell--actions {
+    grid-column: 3;
+  }
+
+  .create-recovery-dir-plan-cell--scope,
+  .create-recovery-dir-plan-cell--target,
+  .create-recovery-dir-plan-cell--directory {
+    grid-column: 2;
+  }
 }
 
 .create-recovery-conflict-options {

--- a/src/frontend/src/pages/protection/BackupCreateWizardRestorePlanLayout.test.ts
+++ b/src/frontend/src/pages/protection/BackupCreateWizardRestorePlanLayout.test.ts
@@ -37,7 +37,28 @@ describe('BackupCreateWizard restore plan layout', () => {
     )
 
     expect(sourceTreeTemplate).toContain(':title="createRecoverySourceTreePathLabel(data)"')
+    expect(wizardSource).toMatch(/isCreateRecoverySourcePathPickerVisible\(group, dirPlan\)[\s\S]*?:width="460"/)
     expect(sourceTreeTemplate).toContain('create-tree-node-content--snapshot')
+    expect(sourceTreeTemplate).toContain("'create-tree-node-content--selected': dirPlan.sourcePath === data.path")
+    expect(sourceTreeTemplate).toContain('v-if="isWholeSnapshotRecoveryPath(data.path)"')
+    expect(sourceTreeTemplate).toContain("t('protection.backupsPage.createRecoveryScopeSnapshotDesc')")
+    expect(wizardSource).toContain('.el-tree-node__content:has(> .create-tree-node-content--selected)')
     expect(sourceTreeTemplate).not.toContain('create-tree-node-content__path')
+  })
+
+  it('keeps long restore picker values available instead of silently clipping them', () => {
+    const treeLabelRule = wizardSource.match(/\.create-tree-node-content__label \{([\s\S]*?)\n\}/)?.[1] || ''
+
+    expect(wizardSource).toContain(':title="recoverySourcePathInputValue(dirPlan.sourcePath) || undefined"')
+    expect(wizardSource).toContain('<template #label="{ label }">')
+    expect(wizardSource).toContain('class="create-recovery-target-selected-label" :title="label"')
+    expect(wizardSource).toContain(':title="dirPlan.restoreDir || undefined"')
+    expect(treeLabelRule).toContain('overflow-wrap: anywhere;')
+    expect(treeLabelRule).toContain('white-space: normal;')
+    expect(treeLabelRule).not.toContain('text-overflow: ellipsis;')
+    expect(wizardSource).toContain('.el-tree-node__expand-icon.is-leaf) {\n  width: 8px;')
+    expect(wizardSource).toMatch(/\.source-dir-tree :deep\(\.el-tree-node\.is-current > \.el-tree-node__content\) \{[\s\S]*?var\(--el-bg-color-overlay\)/)
+    expect(wizardSource).not.toContain('width: min(360px, calc(100vw - 48px)) !important;')
+    expect(wizardSource).toContain('class="create-recovery-plan-action hfl-table-no-tooltip"')
   })
 })

--- a/src/frontend/src/pages/protection/BackupCreateWizardRestorePlanLayout.test.ts
+++ b/src/frontend/src/pages/protection/BackupCreateWizardRestorePlanLayout.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+
+const wizardSource = readFileSync(new URL('./BackupCreateWizard.vue', import.meta.url), 'utf8')
+const shellSource = readFileSync(new URL('./BackupConfigCreateWizard.vue', import.meta.url), 'utf8')
+
+describe('BackupCreateWizard restore plan layout', () => {
+  it('uses the available desktop width without forcing the mapping editor to scroll', () => {
+    expect(shellSource).toContain('.create-backup-layout {\n  width: min(100%, 1560px);')
+    expect(wizardSource).toContain('.create-recovery-dir-plan-stack {\n  display: flex;\n  min-width: 0;')
+    expect(wizardSource).toContain('container-type: inline-size;')
+    expect(wizardSource).toContain('minmax(190px, 1.1fr) 64px;')
+    expect(wizardSource).toContain('.create-recovery-dir-plan-header > span:last-child {\n  text-align: center;')
+    expect(wizardSource).toContain('@container (max-width: 900px)')
+    expect(wizardSource).toContain('@container (max-width: 620px)')
+    expect(wizardSource).toContain('.create-recovery-dir-plan-cell--actions {\n    grid-column: 3;')
+  })
+
+  it('keeps inline validation in document flow', () => {
+    const errorRule = wizardSource.match(/\.create-recovery-path-input__error \{([\s\S]*?)\n\}/)?.[1] || ''
+    const invalidRowRule = wizardSource.match(/\.create-recovery-dir-plan-row--invalid \{([\s\S]*?)\n\}/)?.[1] || ''
+
+    expect(errorRule).toContain('margin: 4px 0 0;')
+    expect(errorRule).not.toContain('position: absolute;')
+    expect(invalidRowRule).not.toContain('background:')
+  })
+
+  it('clears the failed-save row marker as soon as the mapping is complete', () => {
+    expect(wizardSource).toContain("'create-recovery-dir-plan-row--invalid': highlightedRecoveryDirPlanIds.includes(dirPlan.id)")
+    expect(wizardSource).toContain('&& !isRecoveryDirPlanComplete(group, dirPlan)')
+  })
+
+  it('renders one primary Restore Scope label and exposes its path as a title', () => {
+    const sourceTreeTemplate = wizardSource.slice(
+      wizardSource.indexOf(':key="`create-recovery-source-'),
+      wizardSource.indexOf(':key="`create-recovery-dest-'),
+    )
+
+    expect(sourceTreeTemplate).toContain(':title="createRecoverySourceTreePathLabel(data)"')
+    expect(sourceTreeTemplate).toContain('create-tree-node-content--snapshot')
+    expect(sourceTreeTemplate).not.toContain('create-tree-node-content__path')
+  })
+})

--- a/src/frontend/src/pages/protection/DataProtection.vue
+++ b/src/frontend/src/pages/protection/DataProtection.vue
@@ -10864,7 +10864,7 @@ async function runRecovery(mode: 'plan' | 'manual' = 'manual') {
             </div>
           </div>
 
-          <div class="fullscreen-form-layout">
+          <div class="fullscreen-form-layout dp-restore-wizard-layout">
             <WizardSteps
               v-if="recEntryStage === 'wizard'"
               as="aside"
@@ -10872,6 +10872,7 @@ async function runRecovery(mode: 'plan' | 'manual' = 'manual') {
               :current-step="recStep"
               :is-done="isRecStepDone"
               :clickable="false"
+              responsive-horizontal
               :aria-label="t('protection.backupsPage.createRestoreWizardAria')"
             />
 
@@ -14791,21 +14792,17 @@ html[data-theme='dark'] .setup-dr-opening-skeleton__footer {
 }
 
 .create-recovery-path-input__error {
-  position: absolute;
-  z-index: 3;
-  top: calc(100% + 4px);
-  left: 0;
   display: flex;
   min-width: 100%;
-  max-width: min(360px, calc(100vw - 48px));
+  max-width: 100%;
   align-items: flex-start;
   justify-content: space-between;
   gap: 6px;
-  margin: 0;
+  margin: 4px 0 0;
   padding: 4px 8px;
   border: 1px solid color-mix(in srgb, var(--el-color-danger) 38%, white);
   border-radius: 4px;
-  background: #fff7f7;
+  background: var(--color-error-light);
   box-shadow: 0 3px 8px rgba(127, 29, 29, 0.12);
   color: var(--el-color-danger);
   font-size: 12px;
@@ -16366,6 +16363,13 @@ html[data-theme='dark'] .setup-dr-opening-skeleton__footer {
   display: flex;
   flex: 1 0 auto;
   flex-direction: column;
+}
+
+@media (min-width: 768px) {
+  .dp-restore-wizard-layout {
+    flex-direction: row;
+    align-items: stretch;
+  }
 }
 
 .dp-wizard-pane {

--- a/src/frontend/src/pages/protection/DataProtection.vue
+++ b/src/frontend/src/pages/protection/DataProtection.vue
@@ -7357,6 +7357,11 @@ function recoverySnapshotRangeDisplayForEntry(hostId: string, entry: RecoveryDir
   return entry.path || ''
 }
 
+function isRecoverySnapshotPickerNodeSelected(entry: RecoveryDirSelectionEntry, node: RecoverySnapshotPickerNode) {
+  if (node.type === 'snapshot') return entry.scope === 'snapshot'
+  return entry.scope !== 'snapshot' && entry.path === node.path
+}
+
 async function ensureRecoverySnapshotBrowseOptions(hostId: string) {
   const snapshotId = selectedSnapshotNumericIdForSource(hostId)
   if (snapshotId > 0) {
@@ -7385,6 +7390,9 @@ function pickRecoverySnapshotRange(hostId: string, entry: RecoveryDirSelectionEn
     node.type === 'snapshot' ? '__snapshot__' : node.path,
     node.type === 'snapshot' ? 'snapshot' : node.type === 'file' ? 'file' : 'dir',
   )
+  recoveryDirectoryTreeRefs
+    .get(recoveryDirectoryTreeKey(hostId, entry.id, 'snapshot'))
+    ?.setCurrentKey(null)
   recSnapshotRangePickerVisible[recoveryDirEntryPickerKey(hostId, entry.id)] = false
 }
 
@@ -11058,7 +11066,7 @@ async function runRecovery(mode: 'plan' | 'manual' = 'manual') {
                         text
                         type="primary"
                         size="small"
-                        class="hfl-btn-with-icon recovery-plan-missing-cell__action"
+                        class="hfl-btn-with-icon recovery-plan-missing-cell__action hfl-table-no-tooltip"
                         @click="openConfigureRestorePlanFromMissingRow(row)"
                       >
                         <Route :size="14" class="shrink-0" />
@@ -11565,7 +11573,6 @@ async function runRecovery(mode: 'plan' | 'manual' = 'manual') {
                                 class="source-dir-tree create-recovery-popover-tree hfl-dir-tree hfl-dir-tree--tall"
                                 node-key="id"
                                 lazy
-                                highlight-current
                                 :load="(node, resolve) => loadRecoverySnapshotPickerNode(sourceRow.hostId, node, resolve)"
                                 :props="{ label: 'label', children: 'children', isLeaf: 'isLeaf' }"
                                 @node-click="(data) => pickRecoverySnapshotRange(sourceRow.hostId, entry, data)"
@@ -11573,7 +11580,13 @@ async function runRecovery(mode: 'plan' | 'manual' = 'manual') {
                                 @node-expand="(data) => onRecoveryDirectoryExpansionChange(recoveryDirectoryTreeKey(sourceRow.hostId, entry.id, 'snapshot'), data.id)"
                               >
                                 <template #default="{ data }">
-                                  <div class="create-tree-node-content hfl-dir-tree-node">
+                                  <div
+                                    class="create-tree-node-content hfl-dir-tree-node"
+                                    :class="{
+                                      'create-tree-node-content--snapshot': data.type === 'snapshot',
+                                      'recovery-snapshot-tree-node--selected': isRecoverySnapshotPickerNodeSelected(entry, data),
+                                    }"
+                                  >
                                     <Camera
                                       v-if="data.type === 'snapshot'"
                                       :size="15"
@@ -11591,7 +11604,12 @@ async function runRecovery(mode: 'plan' | 'manual' = 'manual') {
                                     />
                                     <div class="create-tree-node-content__text hfl-dir-tree-node__text">
                                       <span class="create-tree-node-content__label hfl-dir-tree-node__label">{{ data.label }}</span>
-                                      <span v-if="data.path" class="create-tree-node-content__path hfl-dir-tree-node__path">{{ data.path }}</span>
+                                      <span
+                                        v-if="data.type === 'snapshot'"
+                                        class="create-tree-node-content__snapshot-desc create-tree-node-content__path hfl-dir-tree-node__path"
+                                      >
+                                        {{ t('protection.backupsPage.createRecoveryScopeSnapshotDesc') }}
+                                      </span>
                                     </div>
                                     <button
                                       v-if="data.type === 'dir'"
@@ -14038,7 +14056,7 @@ html[data-theme='dark'] .setup-dr-opening-skeleton__footer {
   display: flex;
   flex-direction: column;
   gap: 8px;
-  padding: 4px 8px 22px 0;
+  padding: 4px 8px 0 0;
 }
 
 .recovery-dir-selection-labels {
@@ -14739,10 +14757,6 @@ html[data-theme='dark'] .setup-dr-opening-skeleton__footer {
   box-shadow: 0 0 0 1px var(--el-color-danger) inset;
 }
 
-.create-recovery-path-input--invalid :deep(.el-input-group__append) {
-  box-shadow: 0 0 0 1px var(--el-color-danger) inset;
-}
-
 .create-recovery-path-input__checking {
   font-size: 11px;
   color: rgb(100 116 139);
@@ -14846,6 +14860,12 @@ html[data-theme='dark'] .setup-dr-opening-skeleton__footer {
 
 .create-recovery-popover-tree {
   min-width: 100%;
+}
+
+.create-recovery-popover-tree :deep(.el-tree-node__expand-icon.is-leaf) {
+  width: 8px;
+  flex: 0 0 8px;
+  padding: 0;
 }
 
 .create-recovery-conflict-options {
@@ -15092,12 +15112,27 @@ html[data-theme='dark'] .setup-dr-opening-skeleton__footer {
   border-radius: 4px;
 }
 
+.source-dir-tree :deep(.el-tree-node__expand-icon) {
+  display: inline-flex;
+  width: 20px;
+  height: 30px;
+  flex: 0 0 20px;
+  align-items: center;
+  justify-content: center;
+  margin: 0;
+  padding: 0;
+}
+
 .source-dir-tree :deep(.el-tree-node__content:hover) {
   background: rgba(226, 232, 240, 0.5);
 }
 
 .source-dir-tree :deep(.el-tree-node.is-current > .el-tree-node__content) {
-  background: linear-gradient(180deg, rgba(219, 234, 254, 0.88) 0%, rgba(191, 219, 254, 0.72) 100%);
+  background: linear-gradient(180deg, color-mix(in srgb, var(--color-primary) 14%, var(--el-bg-color-overlay)) 0%, color-mix(in srgb, var(--color-primary) 20%, var(--el-bg-color-overlay)) 100%);
+}
+
+.create-recovery-popover-tree :deep(.el-tree-node__content:has(> .recovery-snapshot-tree-node--selected)) {
+  background: linear-gradient(180deg, color-mix(in srgb, var(--color-primary) 14%, var(--el-bg-color-overlay)) 0%, color-mix(in srgb, var(--color-primary) 20%, var(--el-bg-color-overlay)) 100%);
 }
 
 .source-dir-tree :deep(.el-checkbox) {
@@ -15143,12 +15178,21 @@ html[data-theme='dark'] .setup-dr-opening-skeleton__footer {
   font-size: 13px;
   line-height: 17px;
   color: rgb(30 41 59);
+  overflow-wrap: anywhere;
+  white-space: normal;
+}
+
+.create-tree-node-content--snapshot .create-tree-node-content__label {
+  color: var(--color-primary);
+  font-weight: 700;
 }
 
 .create-tree-node-content__path {
   font-size: 12px;
   line-height: 15px;
   color: rgb(100 116 139);
+  overflow-wrap: anywhere;
+  white-space: normal;
   word-break: break-word;
 }
 

--- a/src/frontend/src/pages/protection/DataProtectionManualRestoreLayout.test.ts
+++ b/src/frontend/src/pages/protection/DataProtectionManualRestoreLayout.test.ts
@@ -33,6 +33,8 @@ describe('manual restore wizard layout', () => {
     )
 
     expect(restoreDialog.match(/<WizardSteps/g)).toHaveLength(1)
+    expect(restoreDialog).toContain('responsive-horizontal')
+    expect(restoreDialog).toContain('class="fullscreen-form-layout dp-restore-wizard-layout"')
     expect(restoreDialog.match(/<main class="fullscreen-form-main fullscreen-form-main--wizard">/g)).toHaveLength(1)
     expect(restoreDialog).toContain('fullscreen-form-card fullscreen-form-step-section fullscreen-form-step-section--active dp-restore-wizard-card')
     expect(restoreDialog).toContain('fullscreen-form-section dp-restore-wizard-body')
@@ -82,8 +84,21 @@ describe('manual restore wizard layout', () => {
     expect(page).not.toContain('72px !important;')
   })
 
+  it('keeps mapping errors in flow so they do not cover the next row', () => {
+    const errorRule = page.match(/\.create-recovery-path-input__error \{([\s\S]*?)\n\}/)?.[1] || ''
+
+    expect(errorRule).toContain('margin: 4px 0 0;')
+    expect(errorRule).toContain('background: var(--color-error-light);')
+    expect(errorRule).not.toContain('position: absolute;')
+  })
+
+  it('relies on field errors without a redundant invalid-row state', () => {
+    expect(page).not.toContain('recovery-dir-selection-row--invalid')
+  })
+
   it('fills the visible main area with the shared restore wizard section', () => {
     expect(page).toMatch(/\.dp-restore-wizard-body \{[\s\S]*?flex: 1 0 auto;[\s\S]*?min-height: 0;/)
     expect(page).toMatch(/\.dp-restore-wizard-card \{[\s\S]*?display: flex;[\s\S]*?flex: 1 0 auto;[\s\S]*?flex-direction: column;/)
+    expect(page).toMatch(/@media \(min-width: 768px\) \{[\s\S]*?\.dp-restore-wizard-layout \{[\s\S]*?flex-direction: row;[\s\S]*?align-items: stretch;/)
   })
 })

--- a/src/frontend/src/pages/protection/DataProtectionManualRestoreLayout.test.ts
+++ b/src/frontend/src/pages/protection/DataProtectionManualRestoreLayout.test.ts
@@ -96,6 +96,37 @@ describe('manual restore wizard layout', () => {
     expect(page).not.toContain('recovery-dir-selection-row--invalid')
   })
 
+  it('keeps the selected Restore Scope visible and explains Entire Snapshot', () => {
+    const scopeTree = sourceBetween(
+      ':key="`restore-snapshot-picker-',
+      ':key="`restore-target-dir-picker-',
+    )
+
+    expect(page).toContain('function isRecoverySnapshotPickerNodeSelected')
+    expect(page).toContain(".get(recoveryDirectoryTreeKey(hostId, entry.id, 'snapshot'))")
+    expect(page).toContain('?.setCurrentKey(null)')
+    expect(scopeTree).toContain("'recovery-snapshot-tree-node--selected': isRecoverySnapshotPickerNodeSelected(entry, data)")
+    expect(scopeTree).toContain("'create-tree-node-content--snapshot': data.type === 'snapshot'")
+    expect(scopeTree).toContain("t('protection.backupsPage.createRecoveryScopeSnapshotDesc')")
+    expect(scopeTree).not.toContain('<span v-if="data.path"')
+    expect(scopeTree).not.toContain('highlight-current')
+    expect(page).toContain('.el-tree-node__content:has(> .recovery-snapshot-tree-node--selected)')
+    expect(page).toContain('.el-tree-node__expand-icon.is-leaf) {\n  width: 8px;')
+    expect(page).toMatch(/\.source-dir-tree :deep\(\.el-tree-node__expand-icon\) \{[\s\S]*?width: 20px;[\s\S]*?flex: 0 0 20px;/)
+    expect(page).toMatch(/\.source-dir-tree :deep\(\.el-tree-node\.is-current > \.el-tree-node__content\) \{[\s\S]*?var\(--el-bg-color-overlay\)/)
+
+    const treeLabelRule = page.match(/\.create-tree-node-content__label \{([\s\S]*?)\n\}/)?.[1] || ''
+    const treePathRule = page.match(/\.create-tree-node-content__path \{([\s\S]*?)\n\}/)?.[1] || ''
+    expect(treeLabelRule).toContain('overflow-wrap: anywhere;')
+    expect(treeLabelRule).toContain('white-space: normal;')
+    expect(treePathRule).toContain('overflow-wrap: anywhere;')
+    expect(treePathRule).toContain('white-space: normal;')
+  })
+
+  it('suppresses the redundant restore-plan action hint', () => {
+    expect(page).toContain('class="hfl-btn-with-icon recovery-plan-missing-cell__action hfl-table-no-tooltip"')
+  })
+
   it('fills the visible main area with the shared restore wizard section', () => {
     expect(page).toMatch(/\.dp-restore-wizard-body \{[\s\S]*?flex: 1 0 auto;[\s\S]*?min-height: 0;/)
     expect(page).toMatch(/\.dp-restore-wizard-card \{[\s\S]*?display: flex;[\s\S]*?flex: 1 0 auto;[\s\S]*?flex-direction: column;/)


### PR DESCRIPTION
## Summary

- expand the restore plan editor and reflow mappings across desktop, tablet, and narrow container widths
- keep Restore Scope labels complete, wrap long tree values, and restore the contextual Entire Snapshot description
- unify Restore Scope popover width, tree spacing, icons, and theme-aware selected states across create and edit flows
- keep restore validation feedback in flow, align invalid input styling, and clear resolved failed-save row markers
- suppress redundant hover hints for restore-plan switches and configuration actions
- add an opt-in responsive horizontal stepper for the Create Restore Task wizard
- add regression coverage for restore plan layout, picker values, selection states, mapping errors, and responsive wizard steps

Closes #526

## Testing

- `npx vitest run src/pages/protection/BackupCreateWizardRestorePlanLayout.test.ts src/pages/protection/DataProtectionManualRestoreLayout.test.ts src/components/WizardStepsResponsive.test.ts` — 18/18 passed after rebase
- `npx eslint src/pages/protection/BackupCreateWizard.vue src/pages/protection/BackupCreateWizardRestorePlanLayout.test.ts src/pages/protection/DataProtection.vue src/pages/protection/DataProtectionManualRestoreLayout.test.ts src/components/WizardSteps.vue src/components/WizardStepsResponsive.test.ts --quiet` — 0 errors
- `npm run build` — passed with existing Rollup import and chunk-size warnings
- `npm test` — 951/953 passed in the earlier parallel full run; two repository-wide coverage scans exceeded the default 5-second timeout
- `npm test -- --run src/composables/listSearchCoverage.test.ts` — 8/8 passed
- `npm test -- --run src/directives/tableOverflowCoverage.test.ts` — 5/5 passed
- `git diff --check`
