### PR TITLE
Restore table selection on wizard close

### DIFF
--- a/src/frontend/src/pages/protection/DataProtection.vue
+++ b/src/frontend/src/pages/protection/DataProtection.vue
@@ -7904,6 +7904,9 @@ function setRecConflictPolicyForSource(hostId: string, policy: RecoveryConflictP
 }
 
 watch(recOpen, (open) => {
+  if (!open && !isFixedSnapshotRestore.value) {
+    nextTick(() => syncStep3TableSelection())
+  }
   if (typeof document === 'undefined') return
   if (addSourceOpen.value) return
   document.body.style.overflow = open ? 'hidden' : ''

--- a/src/frontend/src/pages/protection/DataProtectionRecoverySelection.test.ts
+++ b/src/frontend/src/pages/protection/DataProtectionRecoverySelection.test.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const page = readFileSync(resolve(process.cwd(), 'src/pages/protection/DataProtection.vue'), 'utf8')
+
+describe('restore wizard source selection', () => {
+  it('restores the table checkboxes when the wizard closes', () => {
+    const start = page.indexOf('watch(recOpen, (open) => {')
+    const end = page.indexOf('watch([recOpen, recBackupId]', start)
+    const watcher = page.slice(start, end)
+
+    expect(start).toBeGreaterThan(-1)
+    expect(end).toBeGreaterThan(start)
+    expect(watcher).toContain('if (!open && !isFixedSnapshotRestore.value)')
+    expect(watcher).toContain('nextTick(() => syncStep3TableSelection())')
+  })
+})


### PR DESCRIPTION
## Summary

- resynchronize the retained Step 3 source selection with the Element Plus table after the restore wizard closes
- keep the visible checkbox state aligned with the selected count and selection-dependent actions
- add regression coverage for the restore wizard close path

Closes #555

## Testing

- `npm test -- --run src/pages/protection/DataProtectionRecoverySelection.test.ts src/pages/protection/DataProtectionRecoverySnapshots.test.ts`
- `npm run build`
- `git diff --check`
