### PR TITLE
fix(frontend): preserve input glyph visibility

### DIFF
--- a/src/frontend/src/styles/element-plus-table.css
+++ b/src/frontend/src/styles/element-plus-table.css
@@ -68,7 +68,6 @@
 
 .el-input__inner {
   height: 34px !important;
-  line-height: 34px !important;
   box-sizing: border-box;
 }
 

--- a/src/frontend/src/styles/listPageResponsiveControls.test.ts
+++ b/src/frontend/src/styles/listPageResponsiveControls.test.ts
@@ -11,6 +11,13 @@ const dataGatewaysPage = readFileSync(resolve(process.cwd(), 'src/pages/insight/
 const dataProtectionPage = readFileSync(resolve(process.cwd(), 'src/pages/protection/DataProtection.vue'), 'utf8')
 
 describe('responsive list toolbar controls', () => {
+  it('leaves text input line height to Element Plus while preserving control height', () => {
+    const inputInnerRule = tableStyles.match(/(?:^|\n)\.el-input__inner\s*{([^}]*)}/s)?.[1]
+
+    expect(inputInnerRule).toContain('height: 34px !important')
+    expect(inputInnerRule).not.toMatch(/line-height:/)
+  })
+
   it('keeps nested search field selects at their configured width', () => {
     expect(styles).toContain('.hfl-list-search-group .el-input-group__prepend .el-select')
     expect(styles).toMatch(/\.hfl-list-search-group \.el-input-group__prepend \.el-select\s*{[^}]*width:\s*140px;/s)


### PR DESCRIPTION
## Problem and root cause

HyperFileLens forced the native Element Plus input height and line height to the same 34px value. On an affected Windows Chromium environment at 100% browser zoom, device-pixel rounding clipped underscores and other glyph detail near the input boundary across multiple pages.

## Solution

Keep the established 34px control height while allowing Element Plus to manage the inner text line height. Add a focused style regression that preserves the control-size contract and prevents the unsafe full-height line-height override from returning.

## Validation

- Targeted style regression: passed (8 tests)
- Frontend ESLint: passed with no errors
- Frontend test suite: passed (190 files, 945 tests; two resource-contended coverage tests passed in isolated reruns)
- Type-checked production build with Node.js 22: passed
- Diff and English-source quality checks: passed
- Manual testing: passed

## Risks and compatibility

The outer input height remains unchanged, and number inputs retain their dedicated sizing rule. The change affects only inherited text line-height behavior for standard Element Plus inputs.

Fixes #538
