### PR TITLE
Standardize Agent lifecycle installer output

### DIFF
--- a/.github/workflows/artifact_pipeline.yml
+++ b/.github/workflows/artifact_pipeline.yml
@@ -435,6 +435,7 @@ jobs:
           ./tools/quality/test-gateway-lifecycle-upgrade.sh
           ./tools/quality/test-platform-gateway-auto-deploy.sh
           ./tools/quality/test-agent-gateway-uninstall.sh
+          ./tools/quality/test-agent-installer-output.sh
           ./tools/quality/test-installer-image-refresh.sh
           ./tools/quality/test-language-pack-runtime-index.sh
           ./tools/quality/test-bundled-language-pack-lifecycle.sh

--- a/deploy/bootstrap/agent-bootstrap-linux.sh
+++ b/deploy/bootstrap/agent-bootstrap-linux.sh
@@ -13,21 +13,17 @@ export HFL_API_BASE="__HFL_API_BASE__"
 export HFL_WSS_URL="__HFL_WSS_URL__"
 export HFL_INSECURE_TLS="__HFL_INSECURE_TLS__"
 
-hfl_now() {
-	date -u +%Y-%m-%dT%H:%M:%S.000Z 2>/dev/null || date -u +%Y-%m-%dT%H:%M:%SZ
-}
-
 hfl_fail() {
-	printf '[%s] [FAIL ] %s\n' "$(hfl_now)" "$1" >&2
+	printf '  [FAIL] %s\n' "$1" >&2
 	exit "${2:-1}"
 }
 
 hfl_step() {
-	printf '[%s] [....] %s\n' "$(hfl_now)" "$1"
+	printf '  [....] %s\n' "$1"
 }
 
 hfl_ok() {
-	printf '[%s] [ OK  ] %s\n' "$(hfl_now)" "$1"
+	printf '  [ OK ] %s\n' "$1"
 }
 
 hfl_format_bytes() {
@@ -59,7 +55,7 @@ hfl_download() {
 	fi
 	# ${arr[@]+...} keeps empty CURL_TLS safe under `set -u` on Bash < 4.4 (CentOS 7).
 	if ! curl ${CURL_TLS[@]+"${CURL_TLS[@]}"} \
-		--fail --show-error --location --progress-bar \
+		--fail --silent --show-error --location \
 		--retry 3 ${retry_connrefused[@]+"${retry_connrefused[@]}"} --retry-delay 2 \
 		"${url}" -o "${partial}"; then
 		rm -f "${partial}"

--- a/deploy/bootstrap/agent-bootstrap-macos.sh
+++ b/deploy/bootstrap/agent-bootstrap-macos.sh
@@ -13,21 +13,17 @@ export HFL_API_BASE="__HFL_API_BASE__"
 export HFL_WSS_URL="__HFL_WSS_URL__"
 export HFL_INSECURE_TLS="__HFL_INSECURE_TLS__"
 
-hfl_now() {
-	date -u +%Y-%m-%dT%H:%M:%S.000Z 2>/dev/null || date -u +%Y-%m-%dT%H:%M:%SZ
-}
-
 hfl_fail() {
-	printf '[%s] [FAIL ] %s\n' "$(hfl_now)" "$1" >&2
+	printf '  [FAIL] %s\n' "$1" >&2
 	exit "${2:-1}"
 }
 
 hfl_step() {
-	printf '[%s] [....] %s\n' "$(hfl_now)" "$1"
+	printf '  [....] %s\n' "$1"
 }
 
 hfl_ok() {
-	printf '[%s] [ OK  ] %s\n' "$(hfl_now)" "$1"
+	printf '  [ OK ] %s\n' "$1"
 }
 
 hfl_format_bytes() {
@@ -59,7 +55,7 @@ hfl_download() {
 	fi
 	# ${arr[@]+...} keeps empty CURL_TLS safe under `set -u` on Bash < 4.4.
 	if ! curl ${CURL_TLS[@]+"${CURL_TLS[@]}"} \
-		--fail --show-error --location --progress-bar \
+		--fail --silent --show-error --location \
 		--retry 3 ${retry_connrefused[@]+"${retry_connrefused[@]}"} --retry-delay 2 \
 		"${url}" -o "${partial}"; then
 		rm -f "${partial}"

--- a/deploy/bootstrap/agent-bootstrap-windows.ps1
+++ b/deploy/bootstrap/agent-bootstrap-windows.ps1
@@ -14,9 +14,15 @@ function Write-HflBootstrapLog {
     [Parameter(Mandatory = $true)][string]$Level,
     [Parameter(Mandatory = $true)][string]$Message
   )
-  $ts = [DateTime]::UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffZ")
   if ($Message -notmatch '[.!?]$') { $Message = "$Message." }
-  Write-Host "[$ts] [$Level] $Message"
+  $status = switch ($Level.Trim()) {
+    'OK' { ' OK '; break }
+    'WARN' { 'WARN'; break }
+    'FAIL' { 'FAIL'; break }
+    'INFO' { 'INFO'; break }
+    default { '....' }
+  }
+  Write-Host "  [$status] $Message"
 }
 
 function Format-HflBytes {
@@ -37,15 +43,14 @@ function Write-HflDownloadProgress {
     [Parameter(Mandatory = $true)][long]$Downloaded,
     [Parameter(Mandatory = $true)][long]$Total
   )
-  $ts = [DateTime]::UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffZ")
   if ($Total -gt 0) {
     $percent = [Math]::Min(100, [Math]::Round(($Downloaded * 100.0) / $Total))
-    Write-Host -NoNewline ("`r[{0}] [PROG ] Enrollment helper {1}% - {2} / {3}" -f `
-        $ts, $percent, (Format-HflBytes $Downloaded), (Format-HflBytes $Total))
+    Write-Host -NoNewline ("`r  [....] Enrollment helper {0}% - {1} / {2}" -f `
+        $percent, (Format-HflBytes $Downloaded), (Format-HflBytes $Total))
     return
   }
-  Write-Host -NoNewline ("`r[{0}] [PROG ] Enrollment helper - {1} downloaded" -f `
-      $ts, (Format-HflBytes $Downloaded))
+  Write-Host -NoNewline ("`r  [....] Enrollment helper - {0} downloaded" -f `
+      (Format-HflBytes $Downloaded))
 }
 
 if (-not (Test-HflAdmin)) {
@@ -78,7 +83,7 @@ function Get-HflEnrollmentBinary {
 
   if (Get-Command curl.exe -ErrorAction SilentlyContinue) {
     $curlArgs = @(
-      '-fL', '--show-error', '--progress-bar',
+      '-fL', '--silent', '--show-error',
       '--retry', '3', '--retry-connrefused', '--retry-delay', '2',
       '-o', $partial, $Url
     )

--- a/deploy/bootstrap/gateway-bootstrap-linux.sh
+++ b/deploy/bootstrap/gateway-bootstrap-linux.sh
@@ -23,20 +23,16 @@ export HFL_API_BASE="__HFL_API_BASE__"
 export HFL_WSS_URL="__HFL_WSS_URL__"
 export HFL_INSECURE_TLS="__HFL_INSECURE_TLS__"
 
-hfl_now() {
-	date -u +%Y-%m-%dT%H:%M:%S.000Z 2>/dev/null || date -u +%Y-%m-%dT%H:%M:%SZ
-}
-
 hfl_step() {
-	printf '[%s] [....] %s\n' "$(hfl_now)" "$1"
+	printf '  [....] %s\n' "$1"
 }
 
 hfl_ok() {
-	printf '[%s] [ OK  ] %s\n' "$(hfl_now)" "$1"
+	printf '  [ OK ] %s\n' "$1"
 }
 
 hfl_fail() {
-	printf '[%s] [FAIL ] %s\n' "$(hfl_now)" "$1" >&2
+	printf '  [FAIL] %s\n' "$1" >&2
 	exit "${2:-1}"
 }
 
@@ -69,7 +65,7 @@ hfl_download() {
 	fi
 	# ${arr[@]+...} keeps empty CURL_TLS safe under `set -u` on Bash < 4.4 (CentOS 7).
 	if ! curl ${CURL_TLS[@]+"${CURL_TLS[@]}"} \
-		--fail --show-error --location --progress-bar \
+		--fail --silent --show-error --location \
 		--retry 3 ${retry_connrefused[@]+"${retry_connrefused[@]}"} --retry-delay 2 \
 		"${url}" -o "${partial}"; then
 		rm -f "${partial}"
@@ -117,7 +113,7 @@ aarch64 | arm64) HFL_ARCH=arm64 ;;
 esac
 
 if [[ "${HFL_ARCH}" != "amd64" ]]; then
-	hfl_fail "Data Gateway full install (Docker + LensNode) requires amd64 (current: ${RAW_ARCH})." 4
+	hfl_fail "Data Gateway full install (Docker + AI engine) requires amd64 (current: ${RAW_ARCH})." 4
 fi
 
 if [[ "$(id -u)" -ne 0 ]]; then

--- a/deploy/bootstrap/gateway-install-docker-ubuntu-amd64.sh
+++ b/deploy/bootstrap/gateway-install-docker-ubuntu-amd64.sh
@@ -13,24 +13,20 @@ DOCKER_DEBS_ARCHIVE=""
 MIN_ENGINE_VERSION="${HFL_DOCKER_MIN_ENGINE:-24.0.0}"
 MIN_COMPOSE_VERSION="${HFL_COMPOSE_MIN_VERSION:-2.20.0}"
 
-hfl_now() {
-	date -u +%Y-%m-%dT%H:%M:%S.000Z 2>/dev/null || date -u +%Y-%m-%dT%H:%M:%SZ
-}
-
 hfl_step() {
-	printf '[%s] [....] %s\n' "$(hfl_now)" "$1"
+	printf '  [....] %s\n' "$1"
 }
 
 hfl_ok() {
-	printf '[%s] [ OK  ] %s\n' "$(hfl_now)" "$1"
+	printf '  [ OK ] %s\n' "$1"
 }
 
 hfl_warn() {
-	printf '[%s] [WARN ] %s\n' "$(hfl_now)" "$1" >&2
+	printf '  [WARN] %s\n' "$1" >&2
 }
 
 hfl_fail() {
-	printf '[%s] [FAIL ] %s\n' "$(hfl_now)" "$1" >&2
+	printf '  [FAIL] %s\n' "$1" >&2
 	exit "${2:-1}"
 }
 
@@ -63,7 +59,7 @@ hfl_download() {
 	fi
 	# ${arr[@]+...} keeps empty CURL_TLS safe under `set -u` on Bash < 4.4.
 	if ! curl ${CURL_TLS[@]+"${CURL_TLS[@]}"} \
-		--fail --show-error --location --progress-bar \
+		--fail --silent --show-error --location \
 		--retry 3 ${retry_connrefused[@]+"${retry_connrefused[@]}"} --retry-delay 2 \
 		"${url}" -o "${partial}"; then
 		rm -f "${partial}"

--- a/deploy/bootstrap/gateway-install-lensnode-sidecar.sh
+++ b/deploy/bootstrap/gateway-install-lensnode-sidecar.sh
@@ -10,24 +10,20 @@ DEFAULT_LENSNODE_IMAGE="${LENSNODE_IMAGE:-hyperfilelens-sourcelens-lensnode:late
 SENTRY_PRIVACY_FILE="${COMPOSE_DIR}/hfl-sentry-sitecustomize.py"
 SIDECAR_LOCK_FILE="${HFL_GATEWAY_SIDECAR_LOCK_FILE:-/run/lock/hyperfilelens-gateway-sidecar.lock}"
 
-hfl_now() {
-	date -u +%Y-%m-%dT%H:%M:%S.000Z 2>/dev/null || date -u +%Y-%m-%dT%H:%M:%SZ
-}
-
 hfl_step() {
-	printf '[%s] [....] %s\n' "$(hfl_now)" "$1"
+	printf '  [....] %s\n' "$1"
 }
 
 hfl_ok() {
-	printf '[%s] [ OK  ] %s\n' "$(hfl_now)" "$1"
+	printf '  [ OK ] %s\n' "$1"
 }
 
 hfl_warn() {
-	printf '[%s] [WARN ] %s\n' "$(hfl_now)" "$1" >&2
+	printf '  [WARN] %s\n' "$1" >&2
 }
 
 hfl_fail() {
-	printf '[%s] [FAIL ] %s\n' "$(hfl_now)" "$1" >&2
+	printf '  [FAIL] %s\n' "$1" >&2
 	exit "${2:-1}"
 }
 
@@ -102,7 +98,7 @@ hfl_step "Verifying SourceLens connectivity at ${LENS_HOST_URL}."
 curl ${CURL_TLS[@]+"${CURL_TLS[@]}"} -fsSL "${LENS_HOST_URL%/}/health" >/dev/null
 hfl_ok "SourceLens health check passed."
 
-hfl_step "Preparing Gateway workspace mounts for LensNode."
+hfl_step "Preparing Gateway workspace mounts for the AI engine."
 mkdir -p "${HFL_WORKSPACE_ROOT}"
 HFL_GATEWAY_STATE_ROOT="$(dirname "${HFL_WORKSPACE_ROOT}")/.hyperfilelens"
 HFL_SOURCELENS_STATE_ROOT="${HFL_GATEWAY_STATE_ROOT}/sourcelens"
@@ -129,7 +125,7 @@ prepare_sentry_privacy_adapter() {
 	esac
 	local base="${HFL_API_BASE:-}" temporary="${SENTRY_PRIVACY_FILE}.tmp.$$"
 	if [[ -z "${base}" ]]; then
-		hfl_warn "Sentry privacy adapter URL is unavailable; LensNode reporting is disabled."
+		hfl_warn "Sentry privacy adapter URL is unavailable; AI engine reporting is disabled."
 		SENTRY_ENABLED=false
 		SENTRY_BACKEND_DSN=
 		return 0
@@ -139,7 +135,7 @@ prepare_sentry_privacy_adapter() {
 		-o "${temporary}" \
 		|| ! grep -Fx '# HFL_SENTRY_PRIVACY_ADAPTER=1' "${temporary}" >/dev/null; then
 		rm -f "${temporary}"
-		hfl_warn "Sentry privacy adapter download failed; LensNode reporting is disabled."
+		hfl_warn "Sentry privacy adapter download failed; AI engine reporting is disabled."
 		SENTRY_ENABLED=false
 		SENTRY_BACKEND_DSN=
 		return 0
@@ -208,9 +204,9 @@ install_docker_sidecar() {
 		fi
 	fi
 	if ! docker image inspect "${image}" >/dev/null 2>&1; then
-		hfl_fail "LensNode image ${image} is not available locally. Load the bundled lensnode-image archive before running gateway-install." 3
+		hfl_fail "AI engine image ${image} is not available locally. Load the bundled image archive before running gateway-install." 3
 	fi
-	hfl_step "Installing LensNode sidecar via Docker (${image})."
+	hfl_step "Installing AI engine via Docker (${image})."
 	EXTRA_HOSTS_BLOCK=""
 	if lens_url_needs_extra_hosts "${LENS_CONTAINER_URL}"; then
 		EXTRA_HOSTS_BLOCK=$'    extra_hosts:\n      - "host.docker.internal:host-gateway"\n'
@@ -282,23 +278,23 @@ EOF
 			fi
 			compose_args=(up -d --pull never)
 			if [[ -n "${current_container}" && "${current_image_id}" != "${desired_image_id}" ]]; then
-				hfl_step "Recreating LensNode because its loaded image ID changed."
+				hfl_step "Recreating the AI engine because its loaded image ID changed."
 				compose_args+=(--force-recreate)
 			fi
 			docker compose -p "${COMPOSE_PROJECT}" "${compose_args[@]}"
 		)
 	else
-		hfl_fail "Docker Compose v2 is required when using a LensNode container image." 3
+		hfl_fail "Docker Compose v2 is required when using the AI engine container image." 3
 	fi
-	hfl_ok "LensNode sidecar container started."
+	hfl_ok "AI engine container started."
 }
 
 SIDECAR_MODE=""
 if ! command -v docker >/dev/null 2>&1; then
-	hfl_fail "Docker is required to install the LensNode sidecar." 3
+	hfl_fail "Docker is required to install the AI engine." 3
 fi
 RESOLVED_IMAGE="$(resolve_lensnode_image)"
 install_docker_sidecar "${RESOLVED_IMAGE}"
 SIDECAR_MODE="docker"
 
-hfl_ok "LensNode sidecar install completed (${SIDECAR_MODE})."
+hfl_ok "AI engine installation completed (${SIDECAR_MODE})."

--- a/deploy/bootstrap/gateway-lifecycle.sh
+++ b/deploy/bootstrap/gateway-lifecycle.sh
@@ -25,17 +25,13 @@ COMPOSE_PROJECT="hyperfilelens-gateway"
 DEFAULT_LENSNODE_IMAGE="hyperfilelens-sourcelens-lensnode:latest"
 OWNED_LENSNODE_IMAGES=("${DEFAULT_LENSNODE_IMAGE}")
 
-hfl_now() {
-	date -u +%Y-%m-%dT%H:%M:%S.000Z 2>/dev/null || date -u +%Y-%m-%dT%H:%M:%SZ
-}
-
 hfl_log() {
-	printf '[%s] [INFO ] %s\n' "$(hfl_now)" "$*" >&2
+	printf '  [INFO] %s\n' "$*" >&2
 }
 
 hfl_fail() {
 	HFL_LAST_ERROR=$1
-	printf '[%s] [FAIL ] %s\n' "$(hfl_now)" "$1" >&2
+	printf '  [FAIL] %s\n' "$1" >&2
 	exit "${2:-1}"
 }
 
@@ -62,8 +58,8 @@ usage() {
 Usage: gateway-lifecycle.sh <command> [options]
 
 Commands:
-  upgrade-sidecar       Reload LensNode image and restart hyperfilelens-gateway-lensnode-1
-  uninstall-sidecar     Stop sidecar; use --purge-all to remove config, workspace, images
+  upgrade-sidecar       Reload the AI engine image and restart its container
+  uninstall-sidecar     Stop the AI engine; use --purge-all to remove its local data
 
 Options:
   --purge-all           Remove lensnode.env, compose dir, workspace, and local images
@@ -148,7 +144,7 @@ compose_down_sidecar() {
 	remove_owned_legacy_gateway_containers
 	if [[ -f "${COMPOSE_DIR}/docker-compose.yml" ]]; then
 		docker compose version >/dev/null 2>&1 \
-			|| hfl_fail "Docker Compose v2 is required to remove the LensNode sidecar" 3
+			|| hfl_fail "Docker Compose v2 is required to remove the AI engine" 3
 		while IFS= read -r image; do
 			remember_owned_lensnode_image "${image}"
 		done < <(
@@ -163,7 +159,7 @@ compose_down_sidecar() {
 	while IFS= read -r id; do
 		[[ -n "${id}" ]] || continue
 		remember_owned_lensnode_image "$(docker inspect --format '{{.Config.Image}}' "${id}" 2>/dev/null || true)"
-		hfl_log "Removing owned Gateway LensNode container ${id:0:12}."
+		hfl_log "Removing managed AI engine container ${id:0:12}."
 		docker rm -f "${id}" >/dev/null
 	done < <(
 		docker ps -aq \
@@ -174,7 +170,7 @@ compose_down_sidecar() {
 		--filter 'label=com.hyperfilelens.managed=true' \
 		--filter 'label=com.hyperfilelens.component=gateway-lensnode' \
 		| grep -q .; then
-		hfl_fail "Gateway LensNode containers remain after uninstall" 4
+		hfl_fail "AI engine containers remain after uninstall" 4
 	fi
 }
 
@@ -190,7 +186,7 @@ download_bootstrap_file() {
 	for ((attempt = 1; attempt <= DOWNLOAD_MAX_ATTEMPTS; attempt++)); do
 		curl_rc=0
 		if curl "${curl_tls[@]}" \
-			--fail --show-error --location --progress-bar \
+			--fail --silent --show-error --location \
 			--continue-at - \
 			"${GATEWAY_BOOTSTRAP_BASE}/${name}" -o "${partial}"; then
 			if [[ ! -s "${partial}" ]]; then
@@ -232,7 +228,7 @@ load_lensnode_image() {
 	local work_dir=$1 ref
 	local archive="${work_dir}/${LENSNODE_IMAGE_ARCHIVE}"
 	download_bootstrap_file "${LENSNODE_IMAGE_ARCHIVE}" "${archive}"
-	hfl_log "Loading LensNode container image."
+	hfl_log "Loading AI engine container image."
 	docker load -i "${archive}"
 	for ref in \
 		"${DEFAULT_LENSNODE_IMAGE}" \
@@ -240,12 +236,12 @@ load_lensnode_image() {
 		oneprocloud/sourcelens-lensnode:latest; do
 		if docker image inspect "${ref}" >/dev/null 2>&1; then
 			if ! lensnode_image_supports_insecure_tls "${ref}"; then
-				hfl_fail "LensNode image ${ref} is missing configurable TLS verification support" 5
+				hfl_fail "AI engine image ${ref} is missing configurable TLS verification support" 5
 			fi
 			return 0
 		fi
 	done
-	hfl_fail "LensNode image not present after docker load (expected ${DEFAULT_LENSNODE_IMAGE})" 5
+	hfl_fail "AI engine image not present after docker load (expected ${DEFAULT_LENSNODE_IMAGE})" 5
 }
 
 run_sidecar_install_script() {
@@ -274,7 +270,7 @@ cmd_upgrade_sidecar() {
 	rm -rf "${tmp}"
 	report_lifecycle_status "sidecar_upgrade" "success"
 	trap - EXIT
-	hfl_log "LensNode sidecar upgrade completed."
+	hfl_log "AI engine upgrade completed."
 }
 
 gateway_upgrade_exit() {
@@ -284,7 +280,7 @@ gateway_upgrade_exit() {
 		report_lifecycle_status \
 			"sidecar_upgrade" \
 			"failed" \
-			"${HFL_LAST_ERROR:-LensNode sidecar upgrade failed (exit ${rc})}"
+			"${HFL_LAST_ERROR:-AI engine upgrade failed (exit ${rc})}"
 	fi
 	[[ -z "${tmp}" ]] || rm -rf "${tmp}"
 	return "${rc}"
@@ -297,11 +293,11 @@ remove_lensnode_images() {
 		[[ -n "${image}" && -z "${seen[${image}]:-}" ]] || continue
 		seen["${image}"]=1
 		if docker ps -aq --filter "ancestor=${image}" | grep -q .; then
-			hfl_log "Keeping shared LensNode image ${image}; another container still references it."
+			hfl_log "Keeping shared AI engine image ${image}; another container still references it."
 			continue
 		fi
 		docker image rm "${image}" >/dev/null 2>&1 \
-			|| hfl_log "LensNode image ${image} was absent or retained by Docker."
+			|| hfl_log "AI engine image ${image} was absent or retained by Docker."
 	done
 }
 
@@ -340,7 +336,7 @@ purge_sidecar_artifacts() {
 cmd_uninstall_sidecar() {
 	acquire_sidecar_lock
 	if ! load_agent_credentials_optional; then
-		hfl_log "Agent credentials are unavailable; continuing local LensNode cleanup without status reporting."
+		hfl_log "Agent credentials are unavailable; continuing local AI engine cleanup without status reporting."
 	fi
 	ensure_docker_ready
 	report_lifecycle_status "sidecar_uninstall" "running"
@@ -350,7 +346,7 @@ cmd_uninstall_sidecar() {
 		compose_down_sidecar
 	fi
 	report_lifecycle_status "sidecar_uninstall" "success"
-	hfl_log "LensNode sidecar uninstall completed."
+	hfl_log "AI engine uninstall completed."
 }
 
 main() {

--- a/src/agent/cmd/enroll/main.go
+++ b/src/agent/cmd/enroll/main.go
@@ -36,7 +36,7 @@ func run() int {
 		if err := enroll.WithInstallLock(ctx, func() error {
 			return enroll.RunInstall(ctx, opts)
 		}); err != nil {
-			enroll.PrintCommandFailure(err)
+			enroll.PrintCommandFailureFor(installFailureOperation(opts.Mode), err)
 			return 1
 		}
 	case "gateway-install":
@@ -45,7 +45,7 @@ func run() int {
 		if err := enroll.WithInstallLock(ctx, func() error {
 			return enroll.RunGatewayInstall(ctx, opts)
 		}); err != nil {
-			enroll.PrintCommandFailure(err)
+			enroll.PrintCommandFailureFor(installFailureOperation(opts.Mode), err)
 			return 1
 		}
 	case "gateway-upgrade":
@@ -54,7 +54,7 @@ func run() int {
 		if err := enroll.WithInstallLock(ctx, func() error {
 			return enroll.RunGatewayUpgrade(ctx, fromArchive)
 		}); err != nil {
-			enroll.PrintCommandFailure(err)
+			enroll.PrintCommandFailureFor("upgrade", err)
 			return 1
 		}
 	case "gateway-uninstall":
@@ -63,7 +63,7 @@ func run() int {
 		if err := enroll.WithInstallLock(ctx, func() error {
 			return enroll.RunGatewayUninstall(ctx, purgeAll)
 		}); err != nil {
-			enroll.PrintCommandFailure(err)
+			enroll.PrintCommandFailureFor("uninstall", err)
 			return 1
 		}
 	case "register":
@@ -72,14 +72,14 @@ func run() int {
 		if err := enroll.WithInstallLock(ctx, func() error {
 			return enroll.RunRegister(ctx, opts)
 		}); err != nil {
-			enroll.PrintCommandFailure(err)
+			enroll.PrintCommandFailureFor("registration", err)
 			return 1
 		}
 	case "status":
 		if err := enroll.RunCommand(func() error {
 			return enroll.RunStatus(ctx)
 		}); err != nil {
-			enroll.PrintCommandFailure(err)
+			enroll.PrintCommandFailureFor("status", err)
 			return 1
 		}
 	case "help", "-h", "--help":
@@ -101,8 +101,8 @@ Usage:
   hfl-enroll install --reinstall          Reinstall the console release over an existing Agent
   hfl-enroll install --uninstall          Uninstall the Agent and preserve its data
   hfl-enroll gateway-install [--yes|-y]   Public or Private Data Gateway (Linux)
-  hfl-enroll gateway-upgrade [--from PATH] Upgrade agent bundle and LensNode sidecar (Linux)
-  hfl-enroll gateway-uninstall [--keep-data] Remove sidecar and agent (default: purge-all)
+  hfl-enroll gateway-upgrade [--from PATH] Upgrade Agent and AI engine (Linux)
+  hfl-enroll gateway-uninstall [--keep-data] Remove AI engine and Agent (default: purge-all)
   hfl-enroll register [--yes|-y]          HTTP heartbeat registration only (agent installed)
   hfl-enroll status                       Show node_id and service state
   hfl-enroll help                         Show this help
@@ -149,4 +149,15 @@ func hasFlag(args []string, name string) bool {
 		}
 	}
 	return false
+}
+
+func installFailureOperation(mode enroll.InstallMode) string {
+	switch mode {
+	case enroll.InstallModeUpgrade:
+		return "upgrade"
+	case enroll.InstallModeUninstall:
+		return "uninstall"
+	default:
+		return "install"
+	}
 }

--- a/src/agent/internal/enroll/command_logging.go
+++ b/src/agent/internal/enroll/command_logging.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"time"
 )
 
 type commandLogSink struct {
@@ -55,11 +56,10 @@ func (stream *commandLogStream) Write(content []byte) (int, error) {
 }
 
 func (stream *commandLogStream) flush() {
-	if len(stream.line) == 0 {
-		_, _ = stream.sink.Write([]byte("\n"))
-		return
-	}
-	line := append(append([]byte{}, stream.line...), '\n')
+	timestamp := time.Now().UTC().Format("2006-01-02T15:04:05.000Z")
+	line := []byte("[" + timestamp + "] ")
+	line = append(line, stream.line...)
+	line = append(line, '\n')
 	_, _ = stream.sink.Write(line)
 	stream.line = stream.line[:0]
 }

--- a/src/agent/internal/enroll/command_logging_test.go
+++ b/src/agent/internal/enroll/command_logging_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 )
@@ -52,6 +53,10 @@ func TestCommandLoggingFlushesBufferedAndLiveOutput(t *testing.T) {
 		if !strings.Contains(string(content), expected) {
 			t.Errorf("install log does not contain %q: %s", expected, content)
 		}
+	}
+	timestampedLine := regexp.MustCompile(`(?m)^\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z\] `)
+	if !timestampedLine.Match(content) {
+		t.Fatalf("install log does not contain UTC RFC3339 timestamps: %s", content)
 	}
 }
 

--- a/src/agent/internal/enroll/download_progress.go
+++ b/src/agent/internal/enroll/download_progress.go
@@ -50,19 +50,19 @@ func (display *downloadProgressDisplay) report(progress platforminstall.Download
 		}
 		display.lastLogged = progress.Elapsed
 	}
-	line := fmt.Sprintf("[....] %s %s", display.label, formatDownloadProgress(progress))
+	line := fmt.Sprintf("  [....] %s %s", display.label, formatDownloadProgress(progress))
 	if columns, _ := strconv.Atoi(strings.TrimSpace(os.Getenv("COLUMNS"))); columns > 20 && len(line) > columns {
-		line = fmt.Sprintf("[....] %s %s", display.label, compactDownloadProgress(progress))
+		line = fmt.Sprintf("  [....] %s %s", display.label, compactDownloadProgress(progress))
 		if len(line) > columns {
 			line = line[:columns]
 		}
 	}
 	if display.terminal {
-		fmt.Fprintf(os.Stdout, "\r%s\033[K", line)
-		display.terminalActive = !progress.Completed
 		if progress.Completed {
-			fmt.Fprintln(os.Stdout)
+			return
 		}
+		fmt.Fprintf(os.Stdout, "\r%s\033[K", line)
+		display.terminalActive = true
 		return
 	}
 	if jsonOutput() {
@@ -77,7 +77,10 @@ func (display *downloadProgressDisplay) report(progress platforminstall.Download
 		})
 		return
 	}
-	fmt.Fprintf(os.Stdout, "[INFO] Download progress: %s %s\n", display.label, compactDownloadProgress(progress))
+	if progress.Completed {
+		return
+	}
+	fmt.Fprintf(os.Stdout, "  [INFO] Download progress: %s %s\n", display.label, compactDownloadProgress(progress))
 }
 
 func compactDownloadProgress(progress platforminstall.DownloadProgress) string {
@@ -95,6 +98,21 @@ func (display *downloadProgressDisplay) abort() {
 	if display.terminal && display.terminalActive {
 		fmt.Fprintln(os.Stdout)
 		display.terminalActive = false
+	}
+}
+
+func (display *downloadProgressDisplay) success() {
+	message := display.successMessage()
+	display.mu.Lock()
+	terminal := display.terminal
+	if terminal {
+		styled := colorize(ansiGreen, " OK ")
+		fmt.Fprintf(os.Stdout, "\r  [%s] %s\033[K\n", styled, ensureSentence(message))
+		display.terminalActive = false
+	}
+	display.mu.Unlock()
+	if !terminal {
+		logOK(message)
 	}
 }
 
@@ -132,7 +150,7 @@ func downloadWithProgress(
 		display.abort()
 		return err
 	}
-	logOK(display.successMessage())
+	display.success()
 	return nil
 }
 

--- a/src/agent/internal/enroll/gateway_install.go
+++ b/src/agent/internal/enroll/gateway_install.go
@@ -44,8 +44,6 @@ func RunGatewayInstall(ctx context.Context, opts InstallOptions) error {
 	if opts.Mode == InstallModeUninstall {
 		return RunInstall(ctx, opts)
 	}
-	gatewayName := roleDisplayName(cfg.NodeRole, cfg.GatewayScope)
-
 	if err := RunInstall(ctx, opts); err != nil {
 		return err
 	}
@@ -53,18 +51,18 @@ func RunGatewayInstall(ctx context.Context, opts InstallOptions) error {
 	if credential := readEnvKey(EnvFilePath(), "HFL_NODE_CREDENTIAL"); credential != "" {
 		cfg.NodeToken = credential
 	}
-	logStep("Continuing " + gatewayName + " setup (AI engine).")
+	printPhase("Installing AI engine")
 
 	nodeID := strings.TrimSpace(ReadNodeID(EnvFilePath()))
 	if nodeID == "" {
 		logFail("Agent registered but node_id is missing from agent.env", 5)
 	}
 
-	logStep("Fetching LensNode configuration from the console.")
+	logStep("Fetching AI engine configuration from the console.")
 	lensCfg, err := FetchGatewayLensConfig(ctx, cfg, nodeID)
 	if err != nil {
 		_ = ReportGatewayInstallStatus(ctx, cfg, nodeID, "failed", err.Error())
-		logFail("LensNode configuration is unavailable: "+err.Error(), 6)
+		logFail("AI engine configuration is unavailable: "+err.Error(), 6)
 	}
 	// The authenticated console response is authoritative. Public Data Gateways
 	// receive the deployment Sentry policy; Private Data Gateways receive disabled.
@@ -77,7 +75,6 @@ func RunGatewayInstall(ctx context.Context, opts InstallOptions) error {
 		}
 	}
 
-	logStep("Installing AI engine.")
 	if err := ensureGatewayDocker(ctx, cfg); err != nil {
 		_ = ReportGatewayInstallStatus(ctx, cfg, nodeID, "failed", err.Error())
 		logFail("Docker setup failed: "+err.Error(), 7)
@@ -89,7 +86,11 @@ func RunGatewayInstall(ctx context.Context, opts InstallOptions) error {
 	_ = ReportGatewayInstallStatus(ctx, cfg, nodeID, "success", "")
 	logOK("AI engine was installed successfully.")
 
-	info := summaryFromState(cfg.APIBase, nodeID, "", serviceState(ctx))
+	agentVersion := ""
+	if version, versionErr := InstalledAgentVersion(ctx); versionErr == nil {
+		agentVersion = version
+	}
+	info := summaryFromState(cfg.APIBase, nodeID, agentVersion, serviceState(ctx))
 	printGatewayInstallSuccess(info, lensCfg)
 	return nil
 }
@@ -255,7 +256,7 @@ func floatField(m map[string]any, key string) float64 {
 
 func printGatewayInstallSuccess(info SummaryInfo, lens LensSidecarConfig) {
 	info.Role = gatewayDisplayName(lens.GatewayScope)
-	info.LensNode = "running"
+	info.LensNode = "active"
 	printEnrollmentSuccess(info)
 }
 

--- a/src/agent/internal/enroll/gateway_lifecycle.go
+++ b/src/agent/internal/enroll/gateway_lifecycle.go
@@ -21,52 +21,120 @@ const gatewayLifecycleScript = "gateway-lifecycle.sh"
 func RunGatewayUpgrade(ctx context.Context, fromArchive string) error {
 	cfg, err := LoadConfigFromEnv()
 	if err != nil {
-		logFail(err.Error(), 2)
+		abortInstall("Initialization", err.Error(), 2, "HFL-UPGRADE-CONFIG")
 	}
 	if cfg.NodeRole != model.RoleGateway {
-		logFail("gateway-upgrade requires HFL_NODE_ROLE=gateway", 2)
+		abortInstall("Preflight checks", "gateway-upgrade requires HFL_NODE_ROLE=gateway", 2, "HFL-UPGRADE-ROLE")
 	}
 	if runtime.GOOS != "linux" {
-		logFail("gateway-upgrade is Linux-only", 2)
+		abortInstall("Preflight checks", "gateway-upgrade is Linux-only", 2, "HFL-UPGRADE-PLATFORM")
 	}
 	gatewayName := roleDisplayName(cfg.NodeRole, cfg.GatewayScope)
+	currentVersion := "unknown"
+	if version, versionErr := InstalledAgentVersion(ctx); versionErr == nil && version != "" {
+		currentVersion = version
+	}
+
+	if !jsonOutput() {
+		printLifecycleBanner(gatewayName, "Upgrade")
+		fmt.Fprintln(os.Stdout)
+		fmt.Fprintln(os.Stdout, "Target")
+		printSummaryValue("Console", cfg.APIBase)
+		printSummaryValue("Organization", cfg.OrgKey)
+		printSummaryValue("Role", gatewayName)
+		printSummaryValue("Current version", currentVersion)
+		if strings.TrimSpace(fromArchive) != "" {
+			printSummaryValue("Package source", fromArchive)
+		}
+	}
+	printPhase("Preflight checks")
+	logOK("Gateway role and platform support were verified.")
+	commitInstallLog()
 
 	fromArchive = strings.TrimSpace(fromArchive)
 	if fromArchive != "" {
 		installDir := vfs.DefaultInstallDir()
 		installScript := filepath.Join(installDir, "install.sh")
-		logStep("Upgrading HyperFileLens agent.")
+		printPhase("Upgrading Agent")
 		cmd := exec.CommandContext(ctx, "/bin/bash", installScript, "upgrade", "--from", fromArchive, "--yes", "--quiet-footer")
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 		if err := cmd.Run(); err != nil {
 			return fmt.Errorf("agent upgrade: %w", err)
 		}
+	} else {
+		logSkip("Agent package upgrade was not requested.")
 	}
 
-	logStep("Upgrading AI engine (LensNode sidecar).")
+	printPhase("Upgrading AI engine")
 	if err := runGatewayLifecycleScript(ctx, cfg, "upgrade-sidecar", false); err != nil {
 		return err
 	}
-	logOK(gatewayName + " upgrade completed.")
+	logOK("AI engine upgrade completed.")
+
+	printPhase("Verifying")
+	service := serviceState(ctx)
+	if service == "" {
+		service = "active"
+	}
+	logOK("Agent service is " + service + ".")
+	version := currentVersion
+	if installedVersion, versionErr := InstalledAgentVersion(ctx); versionErr == nil && installedVersion != "" {
+		version = installedVersion
+	}
+	printGatewayUpgradeSuccess(gatewayName, version, service)
 	return nil
+}
+
+func printGatewayUpgradeSuccess(role, version, service string) {
+	if jsonOutput() {
+		emitJSON(os.Stdout, map[string]any{
+			"type":            "upgrade_result",
+			"result":          "success",
+			"role":            role,
+			"agent_version":   version,
+			"agent_service":   service,
+			"ai_engine_state": "active",
+		})
+		return
+	}
+	printResultRule(os.Stdout, "Upgrade completed successfully", ansiGreen)
+	fmt.Fprintln(os.Stdout)
+	fmt.Fprintln(os.Stdout, "Upgrade summary")
+	printSummaryValue("Role", role)
+	printSummaryValue("Agent version", version)
+	printSummaryValue("Service state", service)
+	printSummaryValue("AI engine", "active")
+	printSummaryValue("Log file", activeInstallLogPath())
 }
 
 // RunGatewayUninstall removes LensNode sidecar then the HFL agent (default purge-all).
 func RunGatewayUninstall(ctx context.Context, purgeAll bool) error {
+	return runGatewayUninstall(ctx, purgeAll, true)
+}
+
+func runGatewayUninstall(ctx context.Context, purgeAll, renderLifecycle bool) error {
 	cfg, err := LoadConfigFromEnv()
 	if err != nil {
-		logFail(err.Error(), 2)
+		abortInstall("Initialization", err.Error(), 2, "HFL-UNINSTALL-CONFIG")
 	}
 	if cfg.NodeRole != model.RoleGateway {
-		logFail("gateway-uninstall requires HFL_NODE_ROLE=gateway", 2)
+		abortInstall("Preflight checks", "gateway-uninstall requires HFL_NODE_ROLE=gateway", 2, "HFL-UNINSTALL-ROLE")
 	}
 	if runtime.GOOS != "linux" {
-		logFail("gateway-uninstall is Linux-only", 2)
+		abortInstall("Preflight checks", "gateway-uninstall is Linux-only", 2, "HFL-UNINSTALL-PLATFORM")
 	}
 	gatewayName := roleDisplayName(cfg.NodeRole, cfg.GatewayScope)
+	state := DetectInstallState()
+	if renderLifecycle {
+		printUninstallContext(cfg.APIBase, cfg.OrgKey, cfg.NodeRole, state, purgeAll)
+		printPhase("Preflight checks")
+		logOK("Gateway role and platform support were verified.")
+		commitInstallLog()
+		printPhase("Uninstalling")
+	}
 
-	logStep("Removing AI engine (LensNode sidecar).")
+	logStep("Removing AI engine.")
 	if err := runGatewayLifecycleScript(ctx, cfg, "uninstall-sidecar", purgeAll); err != nil {
 		return err
 	}
@@ -74,12 +142,17 @@ func RunGatewayUninstall(ctx context.Context, purgeAll bool) error {
 	installDir := vfs.DefaultInstallDir()
 	installScript := filepath.Join(installDir, "install.sh")
 	if _, err := os.Stat(installScript); err != nil {
-		logOK("Agent install bundle not found; sidecar removal completed.")
+		logOK("Agent install bundle not found; AI engine removal completed.")
+		if renderLifecycle {
+			printPhase("Verifying")
+			logOK("Managed AI engine resources were removed.")
+			printUninstallSuccess(state, purgeAll)
+		}
 		return nil
 	}
 
 	logStep("Removing HyperFileLens agent.")
-	args := []string{installScript, "uninstall"}
+	args := []string{installScript, "uninstall", "--quiet-footer"}
 	if purgeAll {
 		args = append(args, "--purge-all")
 	}
@@ -91,6 +164,11 @@ func RunGatewayUninstall(ctx context.Context, purgeAll bool) error {
 		return fmt.Errorf("agent uninstall: %w", err)
 	}
 	logOK(gatewayName + " uninstall completed.")
+	if renderLifecycle {
+		printPhase("Verifying")
+		logOK("Agent service, installed files, and AI engine resources were removed.")
+		printUninstallSuccess(state, purgeAll)
+	}
 	return nil
 }
 

--- a/src/agent/internal/enroll/gateway_lifecycle_stub.go
+++ b/src/agent/internal/enroll/gateway_lifecycle_stub.go
@@ -14,3 +14,7 @@ func RunGatewayUpgrade(_ context.Context, _ string) error {
 func RunGatewayUninstall(_ context.Context, _ bool) error {
 	return fmt.Errorf("gateway-uninstall is Linux-only")
 }
+
+func runGatewayUninstall(_ context.Context, _ bool, _ bool) error {
+	return fmt.Errorf("gateway-uninstall is Linux-only")
+}

--- a/src/agent/internal/enroll/install.go
+++ b/src/agent/internal/enroll/install.go
@@ -70,6 +70,7 @@ func RunInstall(ctx context.Context, opts InstallOptions) error {
 			logFail(err.Error(), 1)
 		}
 	}
+	printPhase(installActionPhase(plan.Action))
 	commitInstallLog()
 	if err := persistInstallationID(cfg.InstallationID); err != nil {
 		logFail("Failed to persist the installation identity: "+err.Error(), 3)
@@ -268,27 +269,43 @@ func runExplicitUninstall(ctx context.Context, cfg Config, opts InstallOptions) 
 		return nil
 	}
 	if state.OrgKey != "" && !strings.EqualFold(state.OrgKey, cfg.OrgKey) {
-		logFail("This Agent belongs to a different organization. Use its original installation environment to uninstall it.", 1)
+		abortInstall(
+			"Preflight checks",
+			"This Agent belongs to a different organization. Use its original installation environment to uninstall it.",
+			1,
+			"HFL-UNINSTALL-ORG",
+		)
 	}
+	printUninstallContext(cfg.APIBase, cfg.OrgKey, cfg.NodeRole, state, opts.PurgeAll)
+	printPhase("Preflight checks")
+	logOK("Installed Agent ownership was verified.")
 	message := "Uninstall the HyperFileLens Agent and preserve its data directory?"
 	if opts.PurgeAll {
 		message = "Uninstall the HyperFileLens Agent and permanently remove its managed data?"
 	}
 	if err := confirmAction(message, opts.AutoYes); err != nil {
-		logFail(err.Error(), 1)
+		abortInstall("Preflight checks", err.Error(), 1, "HFL-UNINSTALL-CONFIRM")
 	}
+	logOK("Uninstall request was confirmed.")
+	printPhase("Uninstalling")
+	var uninstallErr error
 	if cfg.NodeRole == model.RoleGateway {
-		return RunGatewayUninstall(ctx, opts.PurgeAll)
+		uninstallErr = runGatewayUninstall(ctx, opts.PurgeAll, false)
+	} else {
+		logStep("Removing the HyperFileLens Agent.")
+		uninstallErr = install.RunUninstallWithDataPolicy(
+			ctx,
+			install.DefaultInstallDir(),
+			!opts.PurgeAll,
+		)
 	}
-	logStep("Removing the HyperFileLens Agent.")
-	if err := install.RunUninstallWithDataPolicy(
-		ctx,
-		install.DefaultInstallDir(),
-		!opts.PurgeAll,
-	); err != nil {
-		return err
+	if uninstallErr != nil {
+		return uninstallErr
 	}
 	logOK("HyperFileLens Agent uninstall completed.")
+	printPhase("Verifying")
+	logOK("Agent service and installed files were removed.")
+	printUninstallSuccess(state, opts.PurgeAll)
 	return nil
 }
 
@@ -351,7 +368,7 @@ func finishEnrollment(
 			logFail("Node registration failed: "+err.Error(), 5)
 		}
 	} else {
-		logOK(fmt.Sprintf("Node registered successfully (id=%s).", nodeID))
+		logOK(fmt.Sprintf("Node registered successfully (ID %s).", nodeID))
 	}
 
 	envPath := EnvFilePath()
@@ -386,12 +403,13 @@ func finishEnrollment(
 		logFail("Agent service start failed: "+err.Error(), 6)
 	}
 
+	printPhase("Verifying")
 	service := serviceState(ctx)
 	if service == "" {
 		service = "active"
 	}
 	logOK(fmt.Sprintf("Agent service is %s.", service))
-	logStep("Waiting for the Agent to come online")
+	logStep("Waiting for the Agent to come online.")
 	if err := enrollmentclient.WaitNodeOnline(ctx, agentCfg, nodeID, 30*time.Second); err != nil {
 		abortInstall(
 			"Post-install verification",
@@ -409,6 +427,21 @@ func finishEnrollment(
 	}
 	printEnrollmentSuccess(info)
 	return nil
+}
+
+func installActionPhase(action ReinstallAction) string {
+	switch action {
+	case ActionUpgrade:
+		return "Upgrading Agent"
+	case ActionRepair:
+		return "Repairing Agent"
+	case ActionReinstall:
+		return "Reinstalling Agent"
+	case ActionRebind:
+		return "Registering Agent"
+	default:
+		return "Installing Agent"
+	}
 }
 
 func installerScriptName() string {
@@ -460,7 +493,7 @@ func installAgentPackage(ctx context.Context, cfg Config, agentVer *string) erro
 	if err := RunBundleInstall(ctx, bundleRoot, cfg); err != nil {
 		return err
 	}
-	logOK("Agent binaries and service were installed successfully.")
+	logOK("Agent files and service configuration were installed successfully.")
 
 	if ver, verErr := InstalledAgentVersion(ctx); verErr == nil && ver != "" {
 		*agentVer = ver

--- a/src/agent/internal/enroll/output.go
+++ b/src/agent/internal/enroll/output.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 
@@ -85,7 +86,18 @@ func emitLine(level, message string, writer io.Writer) {
 	case "INFO":
 		styled = colorize(ansiCyan, level)
 	}
-	_, _ = fmt.Fprintf(writer, "[%s] %s\n", styled, message)
+	_, _ = fmt.Fprintf(writer, "  [%s] %s\n", styled, message)
+}
+
+func emitDetailLine(level, title, detail string, writer io.Writer) {
+	title = strings.TrimSpace(title)
+	detail = strings.TrimSpace(detail)
+	if detail == "" || jsonOutput() {
+		emitLine(level, joinDetail(title, detail), writer)
+		return
+	}
+	emitLine(level, title, writer)
+	_, _ = fmt.Fprintf(writer, "         %s\n", detail)
 }
 
 func logInfo(message string) { emitLine("INFO", message, os.Stdout) }
@@ -122,25 +134,34 @@ func RecoverInstallFailure(target *error) {
 
 // PrintCommandFailure renders a stable final failure block for returned errors.
 func PrintCommandFailure(err error) {
+	PrintCommandFailureFor("install", err)
+}
+
+// PrintCommandFailureFor renders a stable failure block for one lifecycle operation.
+func PrintCommandFailureFor(operation string, err error) {
 	if err == nil {
 		return
 	}
+	operation = normalizeFailureOperation(operation)
+	noun, codePrefix, activeStage := failureOperationLabels(operation)
 	failure := InstallFailure{
-		Stage:   "Initialization",
+		Stage:   activeStage,
 		Reason:  err.Error(),
 		Code:    1,
-		CodeKey: "HFL-INSTALL-001",
+		CodeKey: codePrefix + "-001",
 	}
 	var typed InstallFailure
 	if errors.As(err, &typed) {
 		failure = typed
 	} else if errors.Is(err, ErrInstallLocked) {
+		failure.Stage = "Initialization"
 		failure.Reason = "Another HyperFileLens installation is already running."
-		failure.CodeKey = "HFL-INSTALL-LOCKED"
+		failure.CodeKey = codePrefix + "-LOCKED"
 	}
 	if jsonOutput() {
 		emitJSON(os.Stderr, map[string]any{
 			"type":          "install_result",
+			"operation":     operation,
 			"result":        "failed",
 			"stage":         failure.Stage,
 			"reason":        ensureSentence(failure.Reason),
@@ -149,13 +170,13 @@ func PrintCommandFailure(err error) {
 		})
 		return
 	}
-	title := "Installation failed"
+	title := noun + " failed"
 	systemChange := "See the cleanup status above"
 	if failure.Stage == "Preflight checks" || failure.Stage == "Initialization" {
-		title = "Installation was not started"
+		title = noun + " was not started"
 		systemChange = "None"
 	}
-	if failure.Stage == "Post-install verification" {
+	if operation == "install" && failure.Stage == "Post-install verification" {
 		title = "Installation completed, but verification failed"
 		systemChange = "Agent installed; verification requires attention"
 	}
@@ -168,12 +189,36 @@ func PrintCommandFailure(err error) {
 	fmt.Fprintln(os.Stderr)
 	fmt.Fprintln(os.Stderr, "Error code:")
 	fmt.Fprintf(os.Stderr, "  %s\n", failure.CodeKey)
-	if failure.Stage == "Post-install verification" {
+	if operation == "install" && failure.Stage == "Post-install verification" {
 		fmt.Fprintln(os.Stderr)
 		fmt.Fprintln(os.Stderr, "Suggested actions:")
 		fmt.Fprintln(os.Stderr, "  1. Check outbound network access to the control plane.")
 		fmt.Fprintln(os.Stderr, "  2. Confirm that any proxy supports WebSocket connections.")
 		fmt.Fprintln(os.Stderr, "  3. Review the Agent service log and run hfl-enroll status.")
+	}
+}
+
+func normalizeFailureOperation(operation string) string {
+	switch strings.ToLower(strings.TrimSpace(operation)) {
+	case "upgrade", "uninstall", "registration", "status":
+		return strings.ToLower(strings.TrimSpace(operation))
+	default:
+		return "install"
+	}
+}
+
+func failureOperationLabels(operation string) (noun, codePrefix, activeStage string) {
+	switch operation {
+	case "upgrade":
+		return "Upgrade", "HFL-UPGRADE", "Upgrading Agent"
+	case "uninstall":
+		return "Uninstallation", "HFL-UNINSTALL", "Uninstalling"
+	case "registration":
+		return "Registration", "HFL-REGISTER", "Registering Agent"
+	case "status":
+		return "Status check", "HFL-STATUS", "Checking status"
+	default:
+		return "Installation", "HFL-INSTALL", "Initialization"
 	}
 }
 
@@ -191,6 +236,10 @@ func ensureSentence(message string) string {
 }
 
 func printBanner(role string) {
+	printLifecycleBanner(role, "Installer")
+}
+
+func printLifecycleBanner(role, operation string) {
 	if bannerPrinted || os.Getenv("HFL_NO_BANNER") != "" {
 		return
 	}
@@ -206,8 +255,20 @@ func printBanner(role string) {
 |_| |_|\__, | .__/ \___|_|  |_|   |_|_|\___|_____\___|_| |_|___/
        |___/|_|                     INSTALLER`))
 	}
-	fmt.Fprintf(os.Stdout, "\nHyperFileLens %s Installer\n", role)
+	fmt.Fprintf(os.Stdout, "\nHyperFileLens %s %s\n", role, operation)
 	fmt.Fprintln(os.Stdout, strings.Repeat("-", 64))
+}
+
+func printPhase(title string) {
+	title = strings.TrimSpace(title)
+	if title == "" {
+		return
+	}
+	if jsonOutput() {
+		return
+	}
+	fmt.Fprintln(os.Stdout)
+	fmt.Fprintln(os.Stdout, title)
 }
 
 // SummaryInfo is the final enrollment summary block.
@@ -254,6 +315,74 @@ func printEnrollmentContext(
 	fmt.Fprintln(os.Stdout, "Preflight checks")
 }
 
+func printUninstallContext(
+	consoleURL string,
+	orgKey string,
+	role model.Role,
+	state InstallState,
+	purgeAll bool,
+) {
+	displayRole := roleDisplayName(role, os.Getenv("HFL_GATEWAY_SCOPE"))
+	dataPolicy := "Preserve Agent data"
+	if purgeAll {
+		dataPolicy = "Remove Agent data"
+	}
+	if jsonOutput() {
+		emitJSON(os.Stdout, map[string]any{
+			"type":         "uninstall_target",
+			"console":      consoleURL,
+			"organization": orgKey,
+			"role":         displayRole,
+			"node_id":      state.NodeID,
+			"version":      state.Version,
+			"service":      state.Service,
+			"data_policy":  dataPolicy,
+		})
+		return
+	}
+	printLifecycleBanner(displayRole, "Uninstaller")
+	fmt.Fprintln(os.Stdout)
+	fmt.Fprintln(os.Stdout, "Target")
+	printSummaryValue("Console", consoleURL)
+	printSummaryValue("Organization", orgKey)
+	printSummaryValue("Role", displayRole)
+	printSummaryValue("Node ID", state.NodeID)
+	printSummaryValue("Agent version", state.Version)
+	printSummaryValue("Service state", state.Service)
+	printSummaryValue("Install path", defaultInstallPath())
+	printSummaryValue("Data path", dataDirForAgent())
+	printSummaryValue("Data removal", dataPolicy)
+}
+
+func printUninstallSuccess(state InstallState, purgeAll bool) {
+	dataState := "preserved"
+	logState := filepath.Join(dataDirForAgent(), "logs", "uninstall.log")
+	if purgeAll {
+		dataState = "removed"
+		logState = "removed with Agent data"
+	}
+	if jsonOutput() {
+		emitJSON(os.Stdout, map[string]any{
+			"type":            "uninstall_result",
+			"result":          "success",
+			"node_id":         state.NodeID,
+			"install_path":    "removed",
+			"data_path_state": dataState,
+			"log_file":        logState,
+		})
+		return
+	}
+	printResultRule(os.Stdout, "Uninstallation completed successfully", ansiGreen)
+	fmt.Fprintln(os.Stdout)
+	fmt.Fprintln(os.Stdout, "Uninstallation summary")
+	printSummaryValue("Node ID", state.NodeID)
+	printSummaryValue("Service", "removed")
+	printSummaryValue("Install path", "removed")
+	printSummaryValue("Data path", dataState)
+	printSummaryValue("Console record", "not changed by local uninstall")
+	printSummaryValue("Log file", logState)
+}
+
 func summaryFromState(consoleURL, nodeID, version, service string) SummaryInfo {
 	return SummaryInfo{
 		NodeID:      nodeID,
@@ -292,15 +421,35 @@ func printEnrollmentSuccess(info SummaryInfo) {
 	printSummaryValue("Role", info.Role)
 	printSummaryValue("Node ID", info.NodeID)
 	printSummaryValue("Agent version", info.Version)
-	printSummaryValue("Agent service", info.Service)
-	printSummaryValue("LensNode", info.LensNode)
+	printSummaryValue("Service state", info.Service)
+	printSummaryValue("AI engine", info.LensNode)
 	printSummaryValue("Console state", "online")
 	printSummaryValue("Install path", info.InstallPath)
 	printSummaryValue("Data path", info.DataPath)
 	printSummaryValue("Log file", info.LogPath)
 	fmt.Fprintln(os.Stdout)
-	fmt.Fprintln(os.Stdout, "Next step:")
-	fmt.Fprintln(os.Stdout, "  Open HyperFileLens and continue configuring this host.")
+	fmt.Fprintln(os.Stdout, "Next step")
+	if strings.Contains(info.Role, "Data Gateway") {
+		fmt.Fprintln(os.Stdout, "  Open HyperFileLens and configure the data sources available")
+		fmt.Fprintln(os.Stdout, "  through this Gateway.")
+	} else {
+		fmt.Fprintln(os.Stdout, "  Open HyperFileLens and configure backup sources and")
+		fmt.Fprintln(os.Stdout, "  protection policies.")
+	}
+	fmt.Fprintln(os.Stdout)
+	fmt.Fprintln(os.Stdout, "Useful commands")
+	if runtime.GOOS == "windows" {
+		fmt.Fprintln(os.Stdout, "  sc.exe query HyperFileLensAgent")
+		fmt.Fprintln(os.Stdout, "  Get-Service HyperFileLensAgent")
+		fmt.Fprintln(os.Stdout, `  & "$env:ProgramFiles\HyperFileLens\Agent\install.cmd" status`)
+	} else if runtime.GOOS == "darwin" {
+		fmt.Fprintln(os.Stdout, "  launchctl print system/com.hyperfilelens.agent")
+		fmt.Fprintln(os.Stdout, "  sudo /opt/hyperfilelens-agent/install.sh status")
+	} else {
+		fmt.Fprintln(os.Stdout, "  systemctl status hyperfilelens-agent")
+		fmt.Fprintln(os.Stdout, "  journalctl -u hyperfilelens-agent -f")
+		fmt.Fprintln(os.Stdout, "  sudo /opt/hyperfilelens-agent/install.sh status")
+	}
 }
 
 func printAlreadyEnrolled(info SummaryInfo) {

--- a/src/agent/internal/enroll/output_test.go
+++ b/src/agent/internal/enroll/output_test.go
@@ -1,6 +1,12 @@
 package enroll
 
-import "testing"
+import (
+	"errors"
+	"io"
+	"os"
+	"strings"
+	"testing"
+)
 
 func TestJoinDetail(t *testing.T) {
 	got := joinDetail("Console API reachable", "GET /health → 200")
@@ -42,5 +48,90 @@ func TestResolveWSSURL(t *testing.T) {
 func TestRequiredCommandsDetail(t *testing.T) {
 	if requiredCommandsDetail() == "" {
 		t.Fatal("expected commands detail")
+	}
+}
+
+func TestFailureOperationLabels(t *testing.T) {
+	tests := []struct {
+		operation string
+		noun      string
+		stage     string
+	}{
+		{"install", "Installation", "Initialization"},
+		{"upgrade", "Upgrade", "Upgrading Agent"},
+		{"uninstall", "Uninstallation", "Uninstalling"},
+		{"registration", "Registration", "Registering Agent"},
+		{"status", "Status check", "Checking status"},
+	}
+	for _, test := range tests {
+		t.Run(test.operation, func(t *testing.T) {
+			noun, _, stage := failureOperationLabels(test.operation)
+			if noun != test.noun || stage != test.stage {
+				t.Fatalf("labels = (%q, %q), want (%q, %q)", noun, stage, test.noun, test.stage)
+			}
+		})
+	}
+}
+
+func TestPrintCommandFailureForUninstall(t *testing.T) {
+	t.Setenv("HFL_OUTPUT", "plain")
+	previousStderr := os.Stderr
+	readPipe, writePipe, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stderr = writePipe
+	t.Cleanup(func() {
+		os.Stderr = previousStderr
+		_ = readPipe.Close()
+		_ = writePipe.Close()
+	})
+
+	PrintCommandFailureFor("uninstall", errors.New("cleanup failed"))
+	if err := writePipe.Close(); err != nil {
+		t.Fatal(err)
+	}
+	content, err := io.ReadAll(readPipe)
+	if err != nil {
+		t.Fatal(err)
+	}
+	output := string(content)
+	for _, expected := range []string{"Uninstallation failed", "Stage         Uninstalling", "cleanup failed"} {
+		if !strings.Contains(output, expected) {
+			t.Fatalf("failure output does not contain %q: %s", expected, output)
+		}
+	}
+	if strings.Contains(output, "Installation was not started") || strings.Contains(output, "System change None") {
+		t.Fatalf("uninstall failure was rendered as an untouched installation: %s", output)
+	}
+}
+
+func TestPrintCommandFailureForKeepsJSONResultTypeCompatible(t *testing.T) {
+	t.Setenv("HFL_OUTPUT", "json")
+	previousStderr := os.Stderr
+	readPipe, writePipe, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stderr = writePipe
+	t.Cleanup(func() {
+		os.Stderr = previousStderr
+		_ = readPipe.Close()
+		_ = writePipe.Close()
+	})
+
+	PrintCommandFailureFor("uninstall", errors.New("cleanup failed"))
+	if err := writePipe.Close(); err != nil {
+		t.Fatal(err)
+	}
+	content, err := io.ReadAll(readPipe)
+	if err != nil {
+		t.Fatal(err)
+	}
+	output := string(content)
+	for _, expected := range []string{`"type":"install_result"`, `"operation":"uninstall"`} {
+		if !strings.Contains(output, expected) {
+			t.Fatalf("JSON failure output does not contain %q: %s", expected, output)
+		}
 	}
 }

--- a/src/agent/internal/enroll/preflight_evidence.go
+++ b/src/agent/internal/enroll/preflight_evidence.go
@@ -12,16 +12,16 @@ type preflightFailures struct {
 }
 
 func logOKDetail(title, detail string) {
-	logOK(joinDetail(title, detail))
+	emitDetailLine(" OK ", title, detail, os.Stdout)
 }
 
 func logWarnDetail(title, detail string) {
-	logWarn(joinDetail(title, detail))
+	emitDetailLine("WARN", title, detail, os.Stderr)
 }
 
 func (failures *preflightFailures) add(title, detail string, code int) {
 	message := joinDetail(title, detail)
-	emitLine("FAIL", message, os.Stderr)
+	emitDetailLine("FAIL", title, detail, os.Stderr)
 	failures.count++
 	if failures.first == nil {
 		failure := InstallFailure{

--- a/src/agent/internal/enroll/sidecar_install_unix.go
+++ b/src/agent/internal/enroll/sidecar_install_unix.go
@@ -130,12 +130,12 @@ func checkGatewayRuntimePreflight(ctx context.Context, cfg Config) gatewayRuntim
 	if dockerReady {
 		warnings := []string{}
 		if state := existingLensSidecarState(); state != "" && state != "running (healthy)" && state != "running" {
-			warnings = append(warnings, "existing LensNode container is "+state+"; repair or reinstall will be attempted")
+			warnings = append(warnings, "existing AI engine container is "+state+"; repair or reinstall will be attempted")
 		}
 		return gatewayRuntimePreflightResult{
 			ExistingDocker: true,
 			Detail: fmt.Sprintf(
-				"Docker engine %s and Compose %s will be reused; LensNode artifacts are available",
+				"Docker engine %s and Compose %s will be reused; AI engine artifacts are available",
 				dockerEngineVersion(),
 				dockerComposeVersion(),
 			),
@@ -144,7 +144,7 @@ func checkGatewayRuntimePreflight(ctx context.Context, cfg Config) gatewayRuntim
 		}
 	}
 	return gatewayRuntimePreflightResult{
-		Detail:        "Docker is not installed; verified offline Docker and LensNode bundles will be used",
+		Detail:        "Docker is not installed; verified offline Docker and AI engine bundles will be used",
 		RequiredSpace: downloadBytes * 3,
 	}
 }
@@ -225,7 +225,7 @@ func (runtime lensSidecarRuntime) install(
 		if runtime.healthy() &&
 			os.Getenv("HFL_FORCE_SIDECAR_INSTALL") != "1" &&
 			lensConfigurationApplied(runtime.appliedPath, fingerprint) {
-			logStep("LensNode sidecar is already running.")
+			logStep("AI engine is already running.")
 			return nil
 		}
 
@@ -404,7 +404,7 @@ func (runtime lensSidecarRuntime) convergeObservability(
 			return nil
 		}
 		if err := runtime.installSidecar(ctx, cfg); err != nil {
-			return fmt.Errorf("refresh LensNode observability: %w", err)
+			return fmt.Errorf("refresh AI engine observability: %w", err)
 		}
 		if err := markLensConfigurationApplied(runtime.appliedPath, fingerprint); err != nil {
 			return err
@@ -422,10 +422,10 @@ func lensConfigurationApplied(path, fingerprint string) bool {
 
 func markLensConfigurationApplied(path, fingerprint string) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
-		return fmt.Errorf("create LensNode state directory: %w", err)
+		return fmt.Errorf("create AI engine state directory: %w", err)
 	}
 	if err := writePrivateEnvAtomically(path, []byte(fingerprint+"\n")); err != nil {
-		return fmt.Errorf("record applied LensNode configuration: %w", err)
+		return fmt.Errorf("record applied AI engine configuration: %w", err)
 	}
 	return nil
 }
@@ -497,7 +497,7 @@ func ensureLensnodeImage(ctx context.Context, cfg Config) error {
 		return nil
 	}
 	if dockerImageExists(defaultLensnodeImage) {
-		logWarn("Local LensNode image lacks configurable TLS verification support; loading console bundle.")
+		logWarn("Local AI engine image lacks configurable TLS verification support; loading console bundle.")
 	}
 
 	workDir, err := os.MkdirTemp("", "hfl-lens-image-")
@@ -508,17 +508,17 @@ func ensureLensnodeImage(ctx context.Context, cfg Config) error {
 
 	url := strings.TrimRight(cfg.APIBase, "/") + "/media/gateway-bootstrap/" + lensnodeImageArchive
 	archivePath := filepath.Join(workDir, lensnodeImageArchive)
-	logStep("Downloading LensNode container image bundle.")
-	if err := downloadWithProgress(ctx, url, archivePath, "LensNode image bundle"); err != nil {
-		return fmt.Errorf("download lensnode image bundle: %w", err)
+	logStep("Downloading AI engine container image bundle.")
+	if err := downloadWithProgress(ctx, url, archivePath, "AI engine image bundle"); err != nil {
+		return fmt.Errorf("download AI engine image bundle: %w", err)
 	}
 
-	logStep("Loading LensNode container image.")
+	logStep("Loading AI engine container image.")
 	cmd := exec.CommandContext(ctx, "docker", "load", "-i", archivePath)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("docker load lensnode image: %w", err)
+		return fmt.Errorf("Docker load AI engine image: %w", err)
 	}
 	for _, ref := range []string{
 		defaultLensnodeImage,
@@ -527,12 +527,12 @@ func ensureLensnodeImage(ctx context.Context, cfg Config) error {
 	} {
 		if dockerImageExists(ref) {
 			if !lensnodeImageSupportsInsecureTLS(ref) {
-				return fmt.Errorf("lensnode image %s is missing configurable TLS verification support", ref)
+				return fmt.Errorf("AI engine image %s is missing configurable TLS verification support", ref)
 			}
 			return nil
 		}
 	}
-	return fmt.Errorf("lensnode image not present after docker load (expected %s)", defaultLensnodeImage)
+	return fmt.Errorf("AI engine image not present after Docker load (expected %s)", defaultLensnodeImage)
 }
 
 func lensnodeImageSupportsInsecureTLS(ref string) bool {

--- a/src/agent/internal/platform/install/lifecycle.go
+++ b/src/agent/internal/platform/install/lifecycle.go
@@ -63,7 +63,7 @@ func upgradeCommand(archivePath string) (string, []string) {
 
 func uninstallCommand(bundleDir string, keepData, keepInstallationIdentity bool) (string, []string) {
 	if runtime.GOOS == "windows" {
-		args := []string{"uninstall"}
+		args := []string{"uninstall", "-QuietFooter"}
 		if !keepData {
 			args = append(args, "-PurgeAll")
 		} else if keepInstallationIdentity {
@@ -71,7 +71,7 @@ func uninstallCommand(bundleDir string, keepData, keepInstallationIdentity bool)
 		}
 		return filepath.Join(bundleDir, "install.ps1"), args
 	}
-	args := []string{"uninstall"}
+	args := []string{"uninstall", "--quiet-footer"}
 	if !keepData {
 		args = append(args, "--purge-all")
 	} else if keepInstallationIdentity {

--- a/src/agent/packaging/install/install.ps1
+++ b/src/agent/packaging/install/install.ps1
@@ -115,10 +115,31 @@ $script:HflUninstallLogPath = $null
 
 function Write-HflInstallLogLine {
   param([Parameter(Mandatory = $true)][AllowEmptyString()][string]$Line)
+  $entry = $Line
+  if ($entry -notmatch '^\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z\] ') {
+    $entry = "[$([DateTime]::UtcNow.ToString('yyyy-MM-ddTHH:mm:ss.fffZ'))] [INFO ] $entry"
+  }
   foreach ($path in @($script:HflInstallLogPath, $script:HflUninstallLogPath)) {
     if (-not $path) { continue }
-    Add-Content -LiteralPath $path -Value $Line -Encoding UTF8
+    try {
+      Add-Content -LiteralPath $path -Value $entry -Encoding UTF8 -ErrorAction Stop
+    }
+    catch {
+      # Installer logging is diagnostic and must never replace the real failure.
+    }
   }
+}
+
+function Write-HflDisplayLine {
+  param([Parameter(Mandatory = $true)][AllowEmptyString()][string]$Line)
+  Write-Host $Line
+  Write-HflInstallLogLine $Line
+}
+
+function Write-HflDetailLine {
+  param([Parameter(Mandatory = $true)][AllowEmptyString()][string]$Line)
+  $ts = [DateTime]::UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffZ")
+  Write-HflInstallLogLine "[$ts] [DETAIL] $Line"
 }
 
 function Start-HflInstallLog {
@@ -163,14 +184,53 @@ function Stop-HflUninstallLog {
   $script:HflUninstallLogPath = $null
 }
 
+function Get-HflRoleDisplayName {
+  param([string]$Value)
+  switch ($Value.Trim().ToLowerInvariant()) {
+    'proxy' { return 'Proxy Host' }
+    'gateway' { return 'Data Gateway' }
+    default { return 'Source Host' }
+  }
+}
+
 function Write-HflBanner {
-  param([Parameter(Mandatory = $true)][string]$Title)
-  Write-HflLog -Level 'INFO ' -Message "HyperFileLens Agent - $Title"
+  param(
+    [Parameter(Mandatory = $true)][string]$Title,
+    [string]$RoleName = ""
+  )
+  if ($QuietFooter) { return }
+  if ($Title -notmatch '^(install|upgrade|uninstall)') {
+    Write-Host "HyperFileLens Agent - $Title"
+    return
+  }
+  if (-not $RoleName) { $RoleName = Get-HflRoleDisplayName -Value $Role }
+  $operation = switch -Regex ($Title) {
+    '^install' { 'Installer'; break }
+    '^upgrade' { 'Upgrade'; break }
+    '^uninstall' { 'Uninstaller'; break }
+    default { $Title }
+  }
+  $banner = @'
+ _   _                       _____ _ _      _
+| | | |_   _ _ __   ___ _ _|  ___(_) | ___| |    ___ _ __  ___
+| |_| | | | | '_ \ / _ \ '__| |_  | | |/ _ \ |   / _ \ '_ \/ __|
+|  _  | |_| | |_) |  __/ |  |  _| | | |  __/ |__|  __/ | | \__ \
+|_| |_|\__, | .__/ \___|_|  |_|   |_|_|\___|_____\___|_| |_|___/
+       |___/|_|                     INSTALLER
+'@
+  foreach ($line in ($banner -split "`r?`n")) {
+    Write-HflDisplayLine $line
+  }
+  Write-Host ""
+  Write-HflDisplayLine "HyperFileLens $RoleName $operation"
+  Write-HflDisplayLine ("-" * 64)
 }
 
 function Write-HflSection {
   param([Parameter(Mandatory = $true)][string]$Title)
-  Write-HflLog -Level 'INFO ' -Message $Title
+  if ($QuietFooter) { return }
+  Write-Host ""
+  Write-HflDisplayLine $Title
 }
 
 function Get-HflLogTimestamp {
@@ -189,15 +249,29 @@ function Write-HflLog {
     [Parameter(Mandatory = $true)][ValidateSet('INFO ', ' OK  ', 'WARN ', 'FAIL ', 'STEP ', 'SKIP ')][string]$Level,
     [Parameter(Mandatory = $true)][string]$Message
   )
-  $line = "[$(Get-HflLogTimestamp)] [$Level] $(Format-HflSentence $Message)"
-  if ($Level -eq 'WARN ') {
-    Write-Host $line -ForegroundColor Yellow
+  $messageText = Format-HflSentence $Message
+  $line = "[$(Get-HflLogTimestamp)] [$Level] $messageText"
+  $status = switch ($Level.Trim()) {
+    'OK' { ' OK '; break }
+    'WARN' { 'WARN'; break }
+    'FAIL' { 'FAIL'; break }
+    'STEP' { '....'; break }
+    'SKIP' { 'SKIP'; break }
+    default { 'INFO' }
   }
-  elseif ($Level -eq 'FAIL ') {
-    Write-Host $line -ForegroundColor Red
-  }
-  else {
-    Write-Host $line
+  $displayLine = "  [$status] $messageText"
+  # QuietFooter suppresses duplicate inner lifecycle output, but the outer
+  # enrollment command still needs the concrete failure reason.
+  if ((-not $QuietFooter) -or ($Level -eq 'FAIL ')) {
+    if ($Level -eq 'WARN ') {
+      Write-Host $displayLine -ForegroundColor Yellow
+    }
+    elseif ($Level -eq 'FAIL ') {
+      Write-Host $displayLine -ForegroundColor Red
+    }
+    else {
+      Write-Host $displayLine
+    }
   }
   Write-HflInstallLogLine $line
 }
@@ -220,71 +294,68 @@ function Write-HflSummaryLine {
     [Parameter(Mandatory = $true)][string]$Key,
     [Parameter(Mandatory = $true)][string]$Value
   )
-  Write-HflLog -Level 'INFO ' -Message "${Key}: ${Value}"
+  $message = "${Key}: ${Value}"
+  if (-not $QuietFooter) {
+    Write-Host ("  {0,-13} {1}" -f $Key, $Value)
+  }
+  Write-HflInstallLogLine "[$(Get-HflLogTimestamp)] [INFO ] $message"
 }
 
 function Write-HflFooter {
   param(
     [Parameter(Mandatory = $true)][ValidateSet('install', 'upgrade', 'uninstall', 'status')][string]$Outcome
   )
+  if ($QuietFooter) { return }
   Write-Host ""
+  if ($Outcome -ne 'status') {
+    Write-HflDisplayLine ("=" * 64)
+  }
   switch ($Outcome) {
     'install' {
-      Write-Host "Success"
-      Write-HflInstallLogLine "Success"
+      Write-HflDisplayLine "Installation completed successfully"
+      Write-HflDisplayLine ("=" * 64)
       if ($NoStart) {
-        Write-Host "  Installation files deployed on this host."
-        Write-Host "  Complete enrollment (register node and start service) to finish setup."
-        Write-HflInstallLogLine "  Installation files deployed on this host."
-        Write-HflInstallLogLine "  Complete enrollment (register node and start service) to finish setup."
+        Write-HflDisplayLine "  Installation files deployed on this host."
+        Write-HflDisplayLine "  Complete enrollment (register node and start service) to finish setup."
       }
       elseif ($NoService) {
-        Write-Host "  HyperFileLens Agent installed successfully."
+        Write-HflDisplayLine "  HyperFileLens Agent installed successfully."
         Write-Host ""
-        Write-Host "  Return to the HyperFileLens console to add backup sources,"
-        Write-Host "  configure policies, and run backup jobs."
-        Write-HflInstallLogLine "  HyperFileLens Agent installed successfully."
-        Write-HflInstallLogLine "  Return to the HyperFileLens console to add backup sources,"
-        Write-HflInstallLogLine "  configure policies, and run backup jobs."
+        Write-HflDisplayLine "  Return to the HyperFileLens console to add backup sources,"
+        Write-HflDisplayLine "  configure policies, and run backup jobs."
         if ($ApiBase) {
           Write-Host ""
-          Write-Host "  Console: $($ApiBase.TrimEnd('/'))"
-          Write-HflInstallLogLine "  Console: $($ApiBase.TrimEnd('/'))"
+          Write-HflDisplayLine "  Console: $($ApiBase.TrimEnd('/'))"
         }
       }
       else {
-        Write-Host "  HyperFileLens Agent installed successfully."
+        Write-HflDisplayLine "  HyperFileLens Agent installed successfully."
         Write-Host ""
-        Write-Host "  Return to the HyperFileLens console to add backup sources,"
-        Write-Host "  configure policies, and run backup jobs."
-        Write-HflInstallLogLine "  HyperFileLens Agent installed successfully."
-        Write-HflInstallLogLine "  Return to the HyperFileLens console to add backup sources,"
-        Write-HflInstallLogLine "  configure policies, and run backup jobs."
+        Write-HflDisplayLine "  Return to the HyperFileLens console to add backup sources,"
+        Write-HflDisplayLine "  configure policies, and run backup jobs."
         if ($ApiBase) {
           Write-Host ""
-          Write-Host "  Console: $($ApiBase.TrimEnd('/'))"
-          Write-HflInstallLogLine "  Console: $($ApiBase.TrimEnd('/'))"
+          Write-HflDisplayLine "  Console: $($ApiBase.TrimEnd('/'))"
         }
       }
     }
     'upgrade' {
-      Write-Host "Success"
-      Write-Host "  HyperFileLens Agent upgraded successfully."
+      Write-HflDisplayLine "Upgrade completed successfully"
+      Write-HflDisplayLine ("=" * 64)
+      Write-HflDisplayLine "  HyperFileLens Agent upgraded successfully."
       if ($ApiBase) {
         Write-Host ""
-        Write-Host "  Console: $($ApiBase.TrimEnd('/'))"
+        Write-HflDisplayLine "  Console: $($ApiBase.TrimEnd('/'))"
       }
     }
     'uninstall' {
-      Write-Host "Success"
-      Write-Host "  HyperFileLens Agent removed from this host."
-      Write-Host "  If this node still appears in the console, delete it there."
-      Write-HflInstallLogLine "Success"
-      Write-HflInstallLogLine "  HyperFileLens Agent removed from this host."
-      Write-HflInstallLogLine "  If this node still appears in the console, delete it there."
+      Write-HflDisplayLine "Uninstallation completed successfully"
+      Write-HflDisplayLine ("=" * 64)
+      Write-HflDisplayLine "  HyperFileLens Agent removed from this host."
+      Write-HflDisplayLine "  The local uninstall does not change the console record."
     }
     'status' {
-      Write-Host "Done."
+      Write-HflDisplayLine "Done."
     }
   }
   Write-Host ""
@@ -697,7 +768,7 @@ function Write-Trace([string]`$msg) {
   `$dir = Split-Path -Parent `$logFile
   if (-not `$dir -or -not (Test-Path -LiteralPath `$dir)) { return }
   `$ts = [DateTime]::UtcNow.ToString('yyyy-MM-ddTHH:mm:ss.fffZ')
-  Add-Content -LiteralPath `$logFile -Value "`$ts `$msg" -Encoding UTF8 -ErrorAction SilentlyContinue
+  Add-Content -LiteralPath `$logFile -Value "[`$ts] [DETAIL] `$msg" -Encoding UTF8 -ErrorAction SilentlyContinue
 }
 Write-Trace "deferred install dir removal started target=`$target"
 Start-Sleep -Seconds 8
@@ -974,14 +1045,16 @@ function Invoke-Install {
   Start-HflInstallLog -DataRoot $dataRoot
   try {
     if (-not $QuietFooter) {
-      Write-HflBanner "install v$(Get-BundleVersion)"
-      Write-HflSection "Preflight"
-      Write-HflSummaryLine "platform" "windows/$archRel"
-      Write-HflSummaryLine "role" $Role
-      Write-HflSummaryLine "install dir" $InstallRoot
-      Write-HflSummaryLine "data dir" $dataRoot
+      $displayRole = Get-HflRoleDisplayName -Value $Role
+      Write-HflBanner "install v$(Get-BundleVersion)" -RoleName $displayRole
+      Write-HflSection "Target"
+      Write-HflSummaryLine "Platform" "windows/$archRel"
+      Write-HflSummaryLine "Role" $displayRole
+      Write-HflSummaryLine "Install path" $InstallRoot
+      Write-HflSummaryLine "Data path" $dataRoot
+      Write-HflSection "Preflight checks"
       Write-HflBundlePreflight
-      Write-HflSection "Actions"
+      Write-HflSection "Installing Agent"
     }
 
     Deploy-Binaries
@@ -991,7 +1064,9 @@ function Invoke-Install {
     if ($NoService) {
       if (-not $QuietFooter) {
         Write-HflSkip "install Windows service (-NoService)"
-        Write-HflSection "Summary"
+        Write-HflSection "Verifying"
+        Write-HflSkip "Windows service was not installed by request"
+        Write-HflSection "Installation summary"
         Write-HflSummaryLine "Status" "installed (no service)"
         Write-HflSummaryLine "Binary" (Join-Path $InstallRoot "hfl-agent.exe")
         Write-HflSummaryLine "Config" $envFile
@@ -1009,7 +1084,14 @@ function Invoke-Install {
       return
     }
 
-    Write-HflSection "Summary"
+    Write-HflSection "Verifying"
+    if ($NoStart) {
+      Write-HflSkip "Agent service was not started by request"
+    }
+    else {
+      Write-HflOk "Agent service is $(Get-HflServiceStatusLine)"
+    }
+    Write-HflSection "Installation summary"
     Write-HflSummaryLine "Status" "installed"
     Write-HflSummaryLine "Binary" (Join-Path $InstallRoot "hfl-agent.exe")
     Write-HflSummaryLine "Config" $envFile
@@ -1025,6 +1107,7 @@ function Invoke-Install {
     Stop-HflInstallLog -ExitCode 0
   }
   catch {
+    Write-HflLog -Level 'FAIL ' -Message "Installation failed: $($_.Exception.Message)"
     Stop-HflInstallLog -ExitCode 1
     throw
   }
@@ -1047,19 +1130,24 @@ function Invoke-Upgrade {
     $prevVer = (Get-Content -LiteralPath $InstalledVersionFile -Raw).Trim()
   }
 
+  $upgradeSucceeded = $false
+  Start-HflInstallLog -DataRoot $dataRoot
   try {
     $srcRoot = Resolve-UpgradeSource -Path $From -DataRoot $dataRoot
     $newVer = Get-BundleVersionFrom -Root $srcRoot
 
     if (-not $QuietFooter) {
-      Write-HflBanner "upgrade $prevVer -> $newVer"
-      Write-HflSection "Preflight"
-      Write-HflSummaryLine "previous" $prevVer
-      Write-HflSummaryLine "target" $newVer
-      Write-HflSummaryLine "install dir" $InstallRoot
-      Write-HflSummaryLine "data dir" $dataRoot
-      Write-HflSummaryLine "source" $From
-      Write-HflSection "Actions"
+      $installedRole = Read-HflEnvValue -EnvFile $envFile -Key "HFL_NODE_ROLE"
+      Write-HflBanner "upgrade $prevVer -> $newVer" -RoleName (Get-HflRoleDisplayName -Value $installedRole)
+      Write-HflSection "Target"
+      Write-HflSummaryLine "Current version" $prevVer
+      Write-HflSummaryLine "Target version" $newVer
+      Write-HflSummaryLine "Install path" $InstallRoot
+      Write-HflSummaryLine "Data path" $dataRoot
+      Write-HflSummaryLine "Package source" $From
+      Write-HflSection "Preflight checks"
+      Write-HflOk "Upgrade source and rollback paths are ready"
+      Write-HflSection "Upgrading Agent"
     }
 
     Backup-RollbackBinaries -DataRoot $dataRoot
@@ -1087,49 +1175,85 @@ function Invoke-Upgrade {
     }
 
     Remove-UpgradeRollback -DataRoot $dataRoot
+    $upgradeSucceeded = $true
+  }
+  catch {
+    Write-HflLog -Level 'FAIL ' -Message "Upgrade failed: $($_.Exception.Message)"
+    throw
   }
   finally {
     Remove-UpgradeWorkspace -Workspace $workspace
+    if (-not $upgradeSucceeded) {
+      Stop-HflInstallLog -ExitCode 1
+    }
   }
 
-  if ($QuietFooter) { return }
+  if ($QuietFooter) {
+    Stop-HflInstallLog -ExitCode 0
+    return
+  }
 
-  Write-HflSection "Summary"
+  Write-HflSection "Verifying"
+  if (-not $NoService) {
+    Write-HflOk "Agent service is $(Get-HflServiceStatusLine)"
+  }
+  Write-HflSection "Upgrade summary"
   Write-HflSummaryLine "Status" "upgraded"
   Write-HflSummaryLine "Version" (Get-BundleVersionFrom -Root $InstallRoot)
   if (-not $NoService) {
     Write-HflSummaryLine "Service" "$ServiceName ($(Get-HflServiceStatusLine))"
   }
   Write-HflFooter -Outcome upgrade
+  Stop-HflInstallLog -ExitCode 0
 }
 
 function Invoke-Uninstall {
   $dataRoot = Get-ResolvedDataRoot -Override $DataDir
   $envFile = Join-Path $DefaultDataRoot "agent.env"
+  $nodeId = Read-HflEnvValue -EnvFile $envFile -Key "HFL_NODE_ID"
+  $installedRole = Read-HflEnvValue -EnvFile $envFile -Key "HFL_NODE_ROLE"
+  $displayRole = Get-HflRoleDisplayName -Value $installedRole
+  $installedVersion = "unknown"
+  if (Test-Path -LiteralPath $InstalledVersionFile) {
+    $installedVersion = (Get-Content -LiteralPath $InstalledVersionFile -Raw).Trim()
+  }
   Start-HflUninstallLog -DataRoot $dataRoot
   try {
 
-  Write-HflBanner "uninstall"
-  Write-HflSection "Preflight"
-  Write-HflSummaryLine "install dir" $InstallRoot
-  Write-HflSummaryLine "data dir" $dataRoot
-  Write-HflSummaryLine "purge data" ($(if ($PurgeAll) { "yes (-PurgeAll)" } else { "no (data dir preserved)" }))
+  Write-HflBanner "uninstall" -RoleName $displayRole
+  Write-HflSection "Target"
+  Write-HflSummaryLine "Role" $displayRole
+  if ($nodeId) { Write-HflSummaryLine "Node ID" $nodeId }
+  Write-HflSummaryLine "Agent version" $installedVersion
+  Write-HflSummaryLine "Service state" (Get-HflServiceStatusLine)
+  Write-HflSummaryLine "Install path" $InstallRoot
+  Write-HflSummaryLine "Data path" $dataRoot
+  Write-HflSummaryLine "Data removal" ($(if ($PurgeAll) { "Remove Agent data" } else { "Preserve Agent data" }))
 
-  Write-HflSection "Actions"
-  Remove-HflService
-  Stop-HflAgentProcesses -Reason "uninstall"
-
+  Write-HflSection "Preflight checks"
   if ($PurgeAll -and $KeepInstallationIdentity) {
     throw "-PurgeAll and -KeepInstallationIdentity are mutually exclusive."
   }
 
+  $agentBinary = Join-Path $InstallRoot "hfl-agent.exe"
+  if ((-not $PurgeAll) -and (-not $KeepInstallationIdentity) -and
+      (-not (Test-Path -LiteralPath $agentBinary))) {
+    throw "Cannot retire the installation identity because $agentBinary is unavailable."
+  }
+  Write-HflOk "Installed Agent paths and data policy were verified"
+
+  Write-HflSection "Uninstalling"
+  Remove-HflService
+  Stop-HflAgentProcesses -Reason "uninstall"
+
   if ((-not $PurgeAll) -and (-not $KeepInstallationIdentity)) {
-    $agentBinary = Join-Path $InstallRoot "hfl-agent.exe"
-    if (-not (Test-Path -LiteralPath $agentBinary)) {
-      throw "Cannot retire the installation identity because $agentBinary is unavailable."
-    }
     Write-HflLog -Level 'STEP ' -Message "Retiring the local installation identity."
-    & $agentBinary config retire-installation --data-dir $dataRoot
+    $retireOutput = @(& $agentBinary config retire-installation --data-dir $dataRoot 2>&1)
+    foreach ($line in $retireOutput) {
+      $text = [string]$line
+      Write-HflDetailLine $text
+      if (-not $QuietFooter) { Write-Host $text }
+    }
     if ($LASTEXITCODE -ne 0) {
       throw "Failed to retire the local installation identity; Agent files and data were preserved for retry."
     }
@@ -1157,13 +1281,7 @@ function Invoke-Uninstall {
     Write-HflSkip "remove $envFile (preserved without installation identity; use -PurgeAll)"
   }
 
-  Write-HflSection "Summary"
-  Write-HflSummaryLine "Status" "uninstalled"
-  Write-HflSummaryLine "Console" "remove this node in SaaS if still listed (when offline)"
-  Write-HflFooter -Outcome uninstall
   $uninstallLogPath = $script:HflUninstallLogPath
-  Stop-HflUninstallLog -ExitCode 0
-
   if (-not $PurgeAll) {
     Write-HflSkip "remove data directory $dataRoot (preserved; use -PurgeAll)"
   }
@@ -1182,8 +1300,17 @@ function Invoke-Uninstall {
   # install-root remover must never recreate that directory after cleanup.
   $uninstallLog = if (-not $PurgeAll -and $uninstallLogPath) { $uninstallLogPath } else { "" }
   Schedule-InstallRootRemoval -InstallRoot $InstallRoot -LogFile $uninstallLog
+
+  Write-HflSection "Verifying"
+  Write-HflOk "Agent service and installed files were removed"
+  Write-HflSection "Uninstallation summary"
+  Write-HflSummaryLine "Status" "uninstalled"
+  Write-HflSummaryLine "Console record" "not changed by local uninstall"
+  Write-HflFooter -Outcome uninstall
+  Stop-HflUninstallLog -ExitCode 0
   }
   catch {
+    Write-HflLog -Level 'FAIL ' -Message "Uninstallation failed: $($_.Exception.Message)"
     Stop-HflUninstallLog -ExitCode 1
     throw
   }

--- a/src/agent/packaging/install/install.sh
+++ b/src/agent/packaging/install/install.sh
@@ -44,8 +44,18 @@ AGENT_ONLY=0
 KOPIA_ONLY=0
 NO_RESTART=0
 QUIET_FOOTER=0
+HFL_ACTIVE_LOG_FILE=""
+HFL_ACTIVE_LOG_KIND=""
+HFL_DETAIL_LOG_PID=""
+HFL_FAILURE_REPORTED=0
+HFL_FAILURE_MARKER=""
+HFL_LOG_FINALIZING=0
 UPGRADE_FROM=""
 UPGRADE_YES=0
+
+# Preserve the caller's terminal while command stdout/stderr is mirrored to a
+# timestamped detail log during install, upgrade, and uninstall operations.
+exec 3>&1 4>&2
 
 usage() {
 	cat <<'USAGE'
@@ -86,7 +96,7 @@ Options:
 Install paths:
   /opt/hyperfilelens-agent                         Binaries and installer scripts
   /opt/hyperfilelens-agent/libexec/gateway-lifecycle.sh
-                                                   Data Gateway LensNode lifecycle helper
+                                                   Data Gateway AI engine lifecycle helper
   /var/lib/hyperfilelens-agent                     Runtime data, backup, and configuration
   /var/lib/hyperfilelens-agent/backup/state/       Pre-upgrade agent.env/agent.db snapshot (retained until uninstall --purge-all)
   /opt/hyperfilelens-agent/backup/                 Legacy upgrade archives (removed on uninstall)
@@ -167,6 +177,7 @@ parse_uninstall_flags() {
 		case "$1" in
 			--purge-all) PURGE_ALL=1; shift ;;
 			--keep-installation-identity) KEEP_INSTALLATION_IDENTITY=1; shift ;;
+			--quiet-footer) QUIET_FOOTER=1; shift ;;
 			-h|--help) usage; exit 0 ;;
 			*)
 				echo "Unknown option: $1" >&2
@@ -363,58 +374,252 @@ hfl_finish_sentence() {
 _hfl_emit_raw() {
 	local level="$1"
 	shift
-	printf '[%s] [%s] %s\n' "$(hfl_now)" "${level}" "$(hfl_finish_sentence "$*")"
+	local message display_level log_dir
+	message="$(hfl_finish_sentence "$*")"
+	display_level="$(printf '%s' "${level}" | sed 's/^ *//; s/ *$//')"
+	case "${display_level}" in
+	OK) display_level=" OK " ;;
+	STEP) display_level="...." ;;
+	INFO) display_level="INFO" ;;
+	WARN) display_level="WARN" ;;
+	FAIL) display_level="FAIL" ;;
+	SKIP) display_level="SKIP" ;;
+	esac
+	if [[ -n "${HFL_ACTIVE_LOG_FILE}" ]]; then
+		log_dir="$(dirname "${HFL_ACTIVE_LOG_FILE}")"
+		if [[ -d "${log_dir}" ]]; then
+			printf '[%s] [%s] %s\n' "$(hfl_now)" "${level}" "${message}" \
+				>>"${HFL_ACTIVE_LOG_FILE}" 2>/dev/null || true
+		fi
+	fi
+	if [[ "${QUIET_FOOTER}" -eq 0 || "${display_level}" == "FAIL" ]]; then
+		if [[ "${display_level}" == "WARN" || "${display_level}" == "FAIL" ]]; then
+			printf '  [%s] %s\n' "${display_level}" "${message}" >&4
+		else
+			printf '  [%s] %s\n' "${display_level}" "${message}" >&3
+		fi
+	fi
 }
 
-log_info() { _hfl_emit_raw "INFO " "$@" >&2; }
-log_ok() { _hfl_emit_raw " OK  " "$@" >&2; }
-log_step() { _hfl_emit_raw "STEP " "$@" >&2; }
-log_skip() { _hfl_emit_raw "SKIP " "$@" >&2; }
-log_warn() { _hfl_emit_raw "WARN " "$@" >&2; }
+log_info() { _hfl_emit_raw "INFO " "$@"; }
+log_ok() { _hfl_emit_raw " OK  " "$@"; }
+log_step() { _hfl_emit_raw "STEP " "$@"; }
+log_skip() { _hfl_emit_raw "SKIP " "$@"; }
+log_warn() { _hfl_emit_raw "WARN " "$@"; }
 log_fail() {
-	_hfl_emit_raw "FAIL " "$@" >&2
-	exit "${2:-1}"
+	local message="$1" code="${2:-1}"
+	HFL_FAILURE_REPORTED=1
+	if [[ -n "${HFL_FAILURE_MARKER}" ]]; then
+		: >"${HFL_FAILURE_MARKER}" 2>/dev/null || true
+	fi
+	_hfl_emit_raw "FAIL " "${message}"
+	exit "${code}"
+}
+
+hfl_detail_log_stream() {
+	local log_file="$1" line
+	while IFS= read -r line || [[ -n "${line}" ]]; do
+		printf '[%s] [DETAIL] %s\n' "$(hfl_now)" "${line}" >>"${log_file}" 2>/dev/null || true
+	done
+}
+
+hfl_role_display_name() {
+	local role="${1:-agent}" scope="${2:-}"
+	case "${role}" in
+	proxy) printf '%s' "Proxy Host" ;;
+	gateway)
+		case "${scope}" in
+		public | platform) printf '%s' "Public Data Gateway" ;;
+		*) printf '%s' "Private Data Gateway" ;;
+		esac
+		;;
+	*) printf '%s' "Source Host" ;;
+	esac
+}
+
+hfl_write_display_log() {
+	local line="$1" log_dir
+	[[ -n "${HFL_ACTIVE_LOG_FILE}" ]] || return 0
+	log_dir="$(dirname "${HFL_ACTIVE_LOG_FILE}")"
+	[[ -d "${log_dir}" ]] || return 0
+	printf '[%s] [INFO ] %s\n' "$(hfl_now)" "${line}" \
+		>>"${HFL_ACTIVE_LOG_FILE}" 2>/dev/null || true
+}
+
+hfl_emit_display_line() {
+	printf '%s\n' "$1" >&3
+	hfl_write_display_log "$1"
+}
+
+hfl_print_banner() {
+	local role="$1" operation="$2"
+	[[ "${QUIET_FOOTER}" -eq 0 ]] || return 0
+	while IFS= read -r line; do
+		hfl_emit_display_line "${line}"
+	done <<'BANNER'
+ _   _                       _____ _ _      _
+| | | |_   _ _ __   ___ _ _|  ___(_) | ___| |    ___ _ __  ___
+| |_| | | | | '_ \ / _ \ '__| |_  | | |/ _ \ |   / _ \ '_ \/ __|
+|  _  | |_| | |_) |  __/ |  |  _| | | |  __/ |__|  __/ | | \__ \
+|_| |_|\__, | .__/ \___|_|  |_|   |_|_|\___|_____\___|_| |_|___/
+       |___/|_|                     INSTALLER
+BANNER
+	printf '\n' >&3
+	hfl_emit_display_line "HyperFileLens ${role} ${operation}"
+	hfl_emit_display_line '----------------------------------------------------------------'
+}
+
+hfl_print_section() {
+	[[ "${QUIET_FOOTER}" -eq 0 ]] || return 0
+	printf '\n%s\n' "$1" >&3
+	hfl_write_display_log "$1"
+}
+
+hfl_print_value() {
+	local label="$1" value="$2"
+	[[ "${QUIET_FOOTER}" -eq 0 && -n "${value}" ]] || return 0
+	printf '  %-13s %s\n' "${label}" "${value}" >&3
+	hfl_write_display_log "${label}: ${value}"
+}
+
+hfl_print_result() {
+	local title="$1"
+	[[ "${QUIET_FOOTER}" -eq 0 ]] || return 0
+	printf '\n' >&3
+	hfl_emit_display_line '================================================================'
+	hfl_emit_display_line "${title}"
+	hfl_emit_display_line '================================================================'
+}
+
+begin_detail_log_capture() {
+	local log_file="$1"
+	exec > >(hfl_detail_log_stream "${log_file}") 2>&1
+	HFL_DETAIL_LOG_PID=$!
+}
+
+finish_detail_log_capture() {
+	exec 1>&3 2>&4
+	if [[ -n "${HFL_DETAIL_LOG_PID}" ]]; then
+		wait "${HFL_DETAIL_LOG_PID}" 2>/dev/null || true
+		HFL_DETAIL_LOG_PID=""
+	fi
 }
 
 begin_install_log() {
-	local data_dir="$1"
+	local data_dir="$1" operation="${2:-install}"
 	local log_file="${data_dir}/logs/install.log"
 	mkdir -p "$(dirname "${log_file}")"
-	if [[ $QUIET_FOOTER -eq 1 ]]; then
-		{
-			log_info "Install session started."
-		} >>"${log_file}" 2>&1
-		exec >>"${log_file}" 2>&1
-	else
-		log_info "Install session started."
-		exec > >(tee -a "${log_file}") 2>&1
-	fi
+	HFL_ACTIVE_LOG_FILE="${log_file}"
+	HFL_ACTIVE_LOG_KIND="${operation}"
+	HFL_FAILURE_REPORTED=0
+	HFL_FAILURE_MARKER="${log_file}.failure.$$"
+	rm -f "${HFL_FAILURE_MARKER}"
+	log_info "Install session started."
+	begin_detail_log_capture "${log_file}"
+	trap 'hfl_finalize_active_log $?' EXIT
 }
 
 finish_install_log() {
 	local rc="$1"
+	finish_detail_log_capture
 	if [[ "${rc}" -eq 0 ]]; then
 		log_info "Install session finished successfully."
 	else
 		log_warn "Install session finished with errors (exit=${rc})."
 	fi
+	HFL_ACTIVE_LOG_FILE=""
+	HFL_ACTIVE_LOG_KIND=""
+	HFL_FAILURE_REPORTED=0
+	[[ -z "${HFL_FAILURE_MARKER}" ]] || rm -f "${HFL_FAILURE_MARKER}"
+	HFL_FAILURE_MARKER=""
 }
 
 begin_uninstall_log() {
 	local data_dir="$1"
 	local log_file="${data_dir}/logs/uninstall.log"
 	mkdir -p "$(dirname "${log_file}")"
+	HFL_ACTIVE_LOG_FILE="${log_file}"
+	HFL_ACTIVE_LOG_KIND="uninstall"
+	HFL_FAILURE_REPORTED=0
+	HFL_FAILURE_MARKER="${log_file}.failure.$$"
+	rm -f "${HFL_FAILURE_MARKER}"
 	log_info "Uninstall session started."
-	exec > >(tee -a "${log_file}") 2>&1
+	begin_detail_log_capture "${log_file}"
+	trap 'hfl_finalize_active_log $?' EXIT
 }
 
 finish_uninstall_log() {
 	local rc="$1"
+	finish_detail_log_capture
 	if [[ "${rc}" -eq 0 ]]; then
 		log_info "Uninstall session finished successfully."
 	else
 		log_warn "Uninstall session finished with errors (exit=${rc})."
 	fi
+	HFL_ACTIVE_LOG_FILE=""
+	HFL_ACTIVE_LOG_KIND=""
+	HFL_FAILURE_REPORTED=0
+	[[ -z "${HFL_FAILURE_MARKER}" ]] || rm -f "${HFL_FAILURE_MARKER}"
+	HFL_FAILURE_MARKER=""
+}
+
+hfl_finalize_active_log() {
+	local rc="${1:-1}" operation failure_logged=0
+	[[ -n "${HFL_ACTIVE_LOG_FILE}" && "${HFL_LOG_FINALIZING}" -eq 0 ]] || return 0
+	HFL_LOG_FINALIZING=1
+	case "${HFL_ACTIVE_LOG_KIND}" in
+	install) operation="Installation" ;;
+	upgrade) operation="Upgrade" ;;
+	uninstall) operation="Uninstallation" ;;
+	*) operation="Operation" ;;
+	esac
+	if [[ "${HFL_FAILURE_REPORTED}" -eq 1 ]] \
+		|| [[ -n "${HFL_FAILURE_MARKER}" && -f "${HFL_FAILURE_MARKER}" ]]; then
+		failure_logged=1
+	fi
+	if [[ "${rc}" -ne 0 && "${failure_logged}" -eq 0 ]]; then
+		HFL_FAILURE_REPORTED=1
+		_hfl_emit_raw "FAIL " "${operation} failed (exit code ${rc}); review ${HFL_ACTIVE_LOG_FILE} for details."
+	fi
+	case "${HFL_ACTIVE_LOG_KIND}" in
+	uninstall) finish_uninstall_log "${rc}" ;;
+	*) finish_install_log "${rc}" ;;
+	esac
+	HFL_LOG_FINALIZING=0
+}
+
+hfl_print_install_success() {
+	local role="$1" version="$2" service="$3" data_dir="$4"
+	hfl_print_section "Verifying"
+	case "${service}" in
+	"not started" | "not managed") log_skip "Agent service is ${service}." ;;
+	*) log_ok "Agent service is ${service}." ;;
+	esac
+	hfl_print_result "Installation completed successfully"
+	hfl_print_section "Installation summary"
+	hfl_print_value "Role" "${role}"
+	hfl_print_value "Agent version" "${version}"
+	hfl_print_value "Service state" "${service}"
+	hfl_print_value "Install path" "${INSTALL_DIR}"
+	hfl_print_value "Data path" "${data_dir}"
+	hfl_print_value "Log file" "${data_dir}/logs/install.log"
+}
+
+hfl_print_upgrade_success() {
+	local version="$1" service="$2" data_dir="$3"
+	hfl_print_section "Verifying"
+	if [[ "${service}" == "not restarted" ]]; then
+		log_skip "Agent service was not restarted by request."
+	else
+		log_ok "Agent service is ${service}."
+	fi
+	hfl_print_result "Upgrade completed successfully"
+	hfl_print_section "Upgrade summary"
+	hfl_print_value "Agent version" "${version}"
+	hfl_print_value "Service state" "${service}"
+	hfl_print_value "Install path" "${INSTALL_DIR}"
+	hfl_print_value "Data path" "${data_dir}"
+	hfl_print_value "Log file" "${data_dir}/logs/install.log"
 }
 
 bundle_agent() { echo "${BUNDLE_ROOT}/bin/hfl-agent"; }
@@ -1175,8 +1380,19 @@ cmd_install() {
 	trap 'finish_install_log $?' RETURN
 
 	if [[ $QUIET_FOOTER -eq 0 ]]; then
-		log_info "Starting HyperFileLens agent installation (version $(bundle_version))."
-		log_info "Platform: $(uname -s | tr '[:upper:]' '[:lower:]')/$(bundle_arch) · Role: ${NODE_ROLE} · Install dir: ${INSTALL_DIR} · Data dir: ${DATA_DIR}."
+		hfl_print_banner "$(hfl_role_display_name "${NODE_ROLE}" "${HFL_GATEWAY_SCOPE:-}")" "Installer"
+		hfl_print_section "Target"
+		hfl_print_value "Console" "${API_BASE}"
+		hfl_print_value "Organization" "${ORG_KEY}"
+		hfl_print_value "Role" "$(hfl_role_display_name "${NODE_ROLE}" "${HFL_GATEWAY_SCOPE:-}")"
+		hfl_print_value "Agent version" "$(bundle_version)"
+		hfl_print_value "Platform" "$(uname -s | tr '[:upper:]' '[:lower:]')/$(bundle_arch)"
+		hfl_print_value "Install path" "${INSTALL_DIR}"
+		hfl_print_value "Data path" "${DATA_DIR}"
+		hfl_print_section "Preflight checks"
+		log_ok "Administrator privileges and service manager are available."
+		log_ok "Agent package layout is valid."
+		hfl_print_section "Installing Agent"
 	fi
 
 	gateway_resource_preflight "${NODE_ROLE}" "${DATA_DIR}"
@@ -1190,22 +1406,21 @@ cmd_install() {
 			install_launchd_plist "${DATA_DIR}/agent.env"
 			if [[ $QUIET_FOOTER -eq 0 ]]; then
 				log_skip "Launchd service ${LAUNCHD_LABEL} was not started (--no-start)."
-				log_info "Installation completed. Start the service with sudo ${INSTALL_DIR}/install.sh start."
+				hfl_print_install_success "$(hfl_role_display_name "${NODE_ROLE}" "${HFL_GATEWAY_SCOPE:-}")" "$(bundle_version)" "not started" "${DATA_DIR}"
 			fi
 			return 0
 		fi
 		start_launchd_service "${DATA_DIR}/agent.env"
 		if [[ $QUIET_FOOTER -eq 0 ]]; then
-			log_info "Installation completed successfully (service: ${LAUNCHD_LABEL}, $(launchd_service_status_line))."
-			log_info "Return to the HyperFileLens console to add backup sources and policies."
+			hfl_print_install_success "$(hfl_role_display_name "${NODE_ROLE}" "${HFL_GATEWAY_SCOPE:-}")" "$(bundle_version)" "$(launchd_service_status_line)" "${DATA_DIR}"
 		fi
 		return 0
 	fi
 
 	if ! agent_uses_systemd; then
 		if [[ $QUIET_FOOTER -eq 0 ]]; then
-			log_info "Installation completed, but systemd was not found on this host."
-			log_info "Start the agent manually from ${INSTALL_DIR}/hfl-agent."
+			log_warn "No supported service manager was found; start the Agent manually."
+			hfl_print_install_success "$(hfl_role_display_name "${NODE_ROLE}" "${HFL_GATEWAY_SCOPE:-}")" "$(bundle_version)" "not managed" "${DATA_DIR}"
 		fi
 		return 0
 	fi
@@ -1216,15 +1431,14 @@ cmd_install() {
 		log_ok "Systemd was reloaded successfully."
 		if [[ $QUIET_FOOTER -eq 0 ]]; then
 			log_skip "Service hyperfilelens-agent.service was not started (--no-start)."
-			log_info "Installation completed. Start the service with systemctl start hyperfilelens-agent."
+			hfl_print_install_success "$(hfl_role_display_name "${NODE_ROLE}" "${HFL_GATEWAY_SCOPE:-}")" "$(bundle_version)" "not started" "${DATA_DIR}"
 		fi
 		return 0
 	fi
 
 	start_service
 	if [[ $QUIET_FOOTER -eq 0 ]]; then
-		log_info "Installation completed successfully (service: hyperfilelens-agent.service, $(service_status_line))."
-		log_info "Return to the HyperFileLens console to add backup sources and policies."
+		hfl_print_install_success "$(hfl_role_display_name "${NODE_ROLE}" "${HFL_GATEWAY_SCOPE:-}")" "$(bundle_version)" "$(service_status_line)" "${DATA_DIR}"
 	fi
 }
 
@@ -1245,8 +1459,10 @@ cmd_upgrade() {
 	upgrade_ws="$(upgrade_workspace_dir "${data_dir}")"
 	prev_ver="unknown"
 	[[ -f "$INSTALLED_VERSION_FILE" ]] && prev_ver="$(tr -d ' \t\r\n' <"$INSTALLED_VERSION_FILE")"
+	begin_install_log "${data_dir}" "upgrade"
+	trap 'finish_install_log $?' RETURN
 
-	trap 'cleanup_upgrade_workspace "$upgrade_ws"' EXIT
+	trap 'rc=$?; cleanup_upgrade_workspace "$upgrade_ws"; hfl_finalize_active_log "$rc"' EXIT
 	src_root="$(prepare_upgrade_source "${UPGRADE_FROM}" "${data_dir}")"
 	new_ver="$(bundle_version_from "${src_root}")"
 
@@ -1260,11 +1476,21 @@ cmd_upgrade() {
 	fi
 
 	if [[ $QUIET_FOOTER -eq 0 ]]; then
-		log_info "Starting in-place upgrade (${prev_ver} → ${new_ver})."
-		log_info "Install dir: ${INSTALL_DIR} · Data dir: ${data_dir} · Source: ${UPGRADE_FROM}."
+		local installed_role gateway_scope
+		installed_role="$(read_env_value "${env_file}" "HFL_NODE_ROLE" || true)"
+		gateway_scope="$(read_env_value "${env_file}" "HFL_GATEWAY_SCOPE" || true)"
+		hfl_print_banner "$(hfl_role_display_name "${installed_role}" "${gateway_scope}")" "Upgrade"
+		hfl_print_section "Target"
+		hfl_print_value "Role" "$(hfl_role_display_name "${installed_role}" "${gateway_scope}")"
+		hfl_print_value "Current version" "${prev_ver}"
+		hfl_print_value "Target version" "${new_ver}"
+		hfl_print_value "Install path" "${INSTALL_DIR}"
+		hfl_print_value "Data path" "${data_dir}"
+		hfl_print_section "Preflight checks"
 	fi
 
 	upgrade_preflight "${data_dir}"
+	hfl_print_section "Upgrading Agent"
 	backup_upgrade_binaries "${data_dir}"
 	trap upgrade_rollback_on_error ERR
 
@@ -1292,7 +1518,7 @@ cmd_upgrade() {
 	if [[ $NO_RESTART -eq 1 ]]; then
 		if [[ $QUIET_FOOTER -eq 0 ]]; then
 			log_skip "Service $(service_display_name) was not restarted (--no-restart)."
-			log_info "Upgrade completed successfully (version ${new_ver})."
+			hfl_print_upgrade_success "${new_ver}" "not restarted" "${data_dir}"
 		fi
 		return 0
 	fi
@@ -1302,7 +1528,7 @@ cmd_upgrade() {
 	fi
 
 	if [[ $QUIET_FOOTER -eq 0 ]]; then
-		log_info "Upgrade completed successfully (version ${new_ver}, service: $(service_display_name), $(service_status_line))."
+		hfl_print_upgrade_success "${new_ver}" "$(service_status_line)" "${data_dir}"
 	fi
 }
 
@@ -1458,14 +1684,14 @@ uninstall_gateway_sidecar_if_needed() {
 	role="$(read_env_value "${env_file}" "HFL_NODE_ROLE" || true)"
 	[[ "${role}" == "gateway" ]] || return 0
 	[[ "$(uname -s)" == "Linux" ]] \
-		|| log_fail "Data Gateway LensNode uninstall is supported on Linux only." 2
+		|| log_fail "Data Gateway AI engine uninstall is supported on Linux only." 2
 	[[ -x "${GATEWAY_LIFECYCLE_SCRIPT}" ]] \
 		|| log_fail "Missing ${GATEWAY_LIFECYCLE_SCRIPT}; upgrade the Agent before uninstalling this Data Gateway." 2
 	[[ "${PURGE_ALL}" -eq 0 ]] || purge_args+=(--purge-all)
-	log_step "Removing the Data Gateway LensNode sidecar before the Agent."
+	log_step "Removing the Data Gateway AI engine before the Agent."
 	HFL_AGENT_ENV_FILE="${env_file}" \
 		bash "${GATEWAY_LIFECYCLE_SCRIPT}" uninstall-sidecar "${purge_args[@]}"
-	log_ok "Data Gateway LensNode sidecar removal completed."
+	log_ok "Data Gateway AI engine removal completed."
 }
 
 cmd_uninstall() {
@@ -1476,10 +1702,32 @@ cmd_uninstall() {
 	resolved_data="$(resolve_data_dir)"
 	env_file="${resolved_data}/agent.env"
 	begin_uninstall_log "${resolved_data}"
-	trap 'finish_uninstall_log $?' EXIT
+	trap 'hfl_finalize_active_log $?' EXIT
 
-	log_info "Starting HyperFileLens agent uninstallation."
-	log_info "Install dir: ${INSTALL_DIR} · Data dir: ${resolved_data} · Purge data: $([[ $PURGE_ALL -eq 1 ]] && echo yes || echo no)."
+	local installed_role gateway_scope node_id installed_version data_policy
+	installed_role="$(read_env_value "${env_file}" "HFL_NODE_ROLE" || true)"
+	gateway_scope="$(read_env_value "${env_file}" "HFL_GATEWAY_SCOPE" || true)"
+	node_id="$(read_env_value "${env_file}" "HFL_NODE_ID" || true)"
+	installed_version="unknown"
+	[[ -f "${INSTALLED_VERSION_FILE}" ]] && installed_version="$(tr -d ' \t\r\n' <"${INSTALLED_VERSION_FILE}")"
+	data_policy="preserve"
+	[[ "${PURGE_ALL}" -eq 0 ]] || data_policy="remove"
+	hfl_print_banner "$(hfl_role_display_name "${installed_role}" "${gateway_scope}")" "Uninstaller"
+	hfl_print_section "Target"
+	hfl_print_value "Role" "$(hfl_role_display_name "${installed_role}" "${gateway_scope}")"
+	hfl_print_value "Node ID" "${node_id}"
+	hfl_print_value "Agent version" "${installed_version}"
+	hfl_print_value "Service state" "$(service_status_line)"
+	hfl_print_value "Install path" "${INSTALL_DIR}"
+	hfl_print_value "Data path" "${resolved_data}"
+	hfl_print_value "Data removal" "${data_policy}"
+	hfl_print_section "Preflight checks"
+	if [[ "${PURGE_ALL}" -eq 0 && "${KEEP_INSTALLATION_IDENTITY}" -eq 0 \
+		&& ! -x "${INSTALL_DIR}/hfl-agent" ]]; then
+		log_fail "Cannot retire the installation identity because ${INSTALL_DIR}/hfl-agent is unavailable." 1
+	fi
+	log_ok "Installed Agent paths and data policy were verified."
+	hfl_print_section "Uninstalling"
 	uninstall_gateway_sidecar_if_needed "${env_file}"
 
 	stop_service
@@ -1538,7 +1786,18 @@ cmd_uninstall() {
 		log_skip "No data directory was resolved for removal."
 	fi
 
-	log_info "Uninstallation completed. If this node still appears in the console, remove it there."
+	hfl_print_section "Verifying"
+	log_ok "Agent service and installed files were removed."
+	hfl_print_result "Uninstallation completed successfully"
+	hfl_print_section "Uninstallation summary"
+	hfl_print_value "Node ID" "${node_id}"
+	hfl_print_value "Service" "removed"
+	hfl_print_value "Install path" "removed"
+	hfl_print_value "Data path" "$([[ "${PURGE_ALL}" -eq 1 ]] && echo removed || echo preserved)"
+	hfl_print_value "Console record" "not changed by local uninstall"
+	if [[ "${PURGE_ALL}" -eq 0 ]]; then
+		hfl_print_value "Log file" "${resolved_data}/logs/uninstall.log"
+	fi
 	finish_uninstall_log 0
 	trap - EXIT
 }

--- a/src/frontend/src/lib/nodeApi.test.ts
+++ b/src/frontend/src/lib/nodeApi.test.ts
@@ -141,7 +141,9 @@ describe('Data Gateway enrollment', () => {
 
     expect(result.command).toContain("curl --proto '=https' --tlsv1.2")
     expect(result.command).toContain('/api/v1/node/enrollment/bootstrap-gateway?')
-    expect(result.command).toContain("| sudo bash -c 'cd / || cd /tmp; exec bash -s'")
+    expect(result.command).toContain('cd / && curl')
+    expect(result.command).toContain('--silent --show-error')
+    expect(result.command).toContain('| sudo bash -s')
     expect(result.command).not.toContain('curl -k')
     expect(result.command).not.toContain('--progress-bar')
     expect(result.command).not.toContain('installer.tar.gz')
@@ -195,8 +197,8 @@ describe('Data Gateway enrollment', () => {
 
     const result = await issuePlatformGatewayEnrollmentInstall()
 
-    expect(result.command).toMatch(/^curl -k --fail --show-error --location '/)
-    expect(result.command).toContain("| sudo bash -c 'cd / || cd /tmp; exec bash -s'")
+    expect(result.command).toMatch(/^cd \/ && curl -k --fail --silent --show-error --location '/)
+    expect(result.command).toContain('| sudo bash -s')
     expect(result.command).not.toContain('--progress-bar')
     expect(result.command).not.toContain('WARNING:')
     expect(result.command.split('\n')).toHaveLength(1)
@@ -258,9 +260,9 @@ describe('Data Gateway enrollment', () => {
       tlsVerify: true,
     })
 
-    expect(command).toMatch(/^curl --proto '=https' --tlsv1\.2 --fail --show-error --location '/)
+    expect(command).toMatch(/^cd \/ && curl --proto '=https' --tlsv1\.2 --fail --silent --show-error --location '/)
     expect(command).toContain('/api/v1/node/enrollment/bootstrap?')
-    expect(command).toContain("| sudo bash -c 'cd / || cd /tmp; exec bash -s'")
+    expect(command).toContain('| sudo bash -s')
     expect(command).not.toContain('--progress-bar')
     expect(command).not.toContain('installer.tar.gz')
     expect(command).not.toContain('mktemp')

--- a/src/frontend/src/lib/nodeApi.ts
+++ b/src/frontend/src/lib/nodeApi.ts
@@ -451,14 +451,14 @@ function buildWindowsEnrollmentInstallCommand(url: string, tlsVerify: boolean): 
  * POSIX one-liner: curl the rendered bootstrap stub into sudo bash.
  * The bootstrap script downloads one slim enroll helper and runs install.
  *
- * --chdir avoids getcwd noise when the caller is sitting in a deleted install dir.
- * No --progress-bar here: the bootstrap stub is tiny; real download progress comes later.
+ * Moving to / avoids getcwd noise when the caller is sitting in a deleted install dir.
+ * The outer curl stays silent; the installer owns all user-facing progress output.
  */
 function buildPosixEnrollmentInstallCommand(url: string, tlsVerify: boolean): string {
   const tlsOptions = tlsVerify
     ? "--proto '=https' --tlsv1.2"
     : '-k'
-  return `curl ${tlsOptions} --fail --show-error --location '${url}' | sudo bash -c 'cd / || cd /tmp; exec bash -s'`
+  return `cd / && curl ${tlsOptions} --fail --silent --show-error --location '${url}' | sudo bash -s`
 }
 
 /** Short copy-paste command for the target host. Shown on deploy pages only. */

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -995,19 +995,52 @@ gateway_bootstrap_linux="${ROOT}/deploy/bootstrap/gateway-bootstrap-linux.sh"
 gateway_docker_installer="${ROOT}/deploy/bootstrap/gateway-install-docker-ubuntu-amd64.sh"
 gateway_lifecycle="${ROOT}/deploy/bootstrap/gateway-lifecycle.sh"
 gateway_sidecar_installer="${ROOT}/deploy/bootstrap/gateway-install-lensnode-sidecar.sh"
+agent_bundle_installer="${ROOT}/src/agent/packaging/install/install.sh"
+agent_windows_installer="${ROOT}/src/agent/packaging/install/install.ps1"
+agent_output="${ROOT}/src/agent/internal/enroll/output.go"
+agent_gateway_lifecycle="${ROOT}/src/agent/internal/enroll/gateway_lifecycle.go"
 grep -F 'requires a systemd-based Linux distribution' "${agent_bootstrap_linux}" >/dev/null
 grep -F 'systemctl show-environment' "${agent_bootstrap_linux}" >/dev/null
 grep -F 'launchd is required to install the agent service on macOS' "${agent_bootstrap_macos}" >/dev/null
 grep -F 'Windows ARM64 is not supported by this release' "${agent_bootstrap_windows}" >/dev/null
+for output_source in "${agent_bundle_installer}" "${agent_windows_installer}" "${agent_output}"; do
+	grep -F '|_| |_|\__, | .__/ \___|_|  |_|   |_|_|\___|_____\___|_| |_|___/' \
+		"${output_source}" >/dev/null
+done
+for phase in 'Preflight checks' 'Installing Agent' 'Verifying' 'Installation summary'; do
+	grep -F "${phase}" "${agent_bundle_installer}" >/dev/null
+done
+for phase in 'Target' 'Upgrading Agent' 'Uninstalling' 'Upgrade summary' 'Uninstallation summary'; do
+	grep -F "${phase}" "${agent_bundle_installer}" >/dev/null
+	grep -F "${phase}" "${agent_windows_installer}" >/dev/null
+done
+grep -F 'hfl_detail_log_stream' "${agent_bundle_installer}" >/dev/null
+grep -F "printf '[%s] [DETAIL] %s\\n'" "${agent_bundle_installer}" >/dev/null
+grep -F 'Write-HflDisplayLine' "${agent_windows_installer}" >/dev/null
+grep -F 'Installation failed: $($_.Exception.Message)' "${agent_windows_installer}" >/dev/null
+grep -F 'Upgrade failed: $($_.Exception.Message)' "${agent_windows_installer}" >/dev/null
+grep -F 'Uninstallation failed: $($_.Exception.Message)' "${agent_windows_installer}" >/dev/null
+grep -F "if ((-not \$QuietFooter) -or (\$Level -eq 'FAIL '))" \
+	"${agent_windows_installer}" >/dev/null
+grep -F 'printLifecycleBanner(gatewayName, "Upgrade")' \
+	"${agent_gateway_lifecycle}" >/dev/null
+grep -F 'printGatewayUpgradeSuccess(gatewayName, version, service)' \
+	"${agent_gateway_lifecycle}" >/dev/null
+grep -F 'printUninstallSuccess(state, purgeAll)' \
+	"${agent_gateway_lifecycle}" >/dev/null
+if grep -E 'Write-HflInstallLogLine "(Success|  )' "${agent_windows_installer}" >/dev/null; then
+	printf 'ERROR: Windows Agent lifecycle output must use the timestamping display logger\n' >&2
+	exit 1
+fi
 for bootstrap in "${agent_bootstrap_linux}" "${agent_bootstrap_macos}"; do
-	grep -F -- '--fail --show-error --location --progress-bar' "${bootstrap}" >/dev/null
+	grep -F -- '--fail --silent --show-error --location' "${bootstrap}" >/dev/null
 	grep -F 'curl --retry-connrefused --version' "${bootstrap}" >/dev/null
 	grep -F -- '--retry 3 ${retry_connrefused[@]+"${retry_connrefused[@]}"} --retry-delay 2' "${bootstrap}" >/dev/null
 	grep -F 'HyperFileLens enrollment helper' "${bootstrap}" >/dev/null
 	grep -F 'partial="${destination}.part"' "${bootstrap}" >/dev/null
 done
 for bootstrap in "${gateway_bootstrap_linux}" "${gateway_docker_installer}"; do
-	grep -F -- '--fail --show-error --location --progress-bar' "${bootstrap}" >/dev/null
+	grep -F -- '--fail --silent --show-error --location' "${bootstrap}" >/dev/null
 	grep -F 'curl --retry-connrefused --version' "${bootstrap}" >/dev/null
 	grep -F -- '--retry 3 ${retry_connrefused[@]+"${retry_connrefused[@]}"} --retry-delay 2' "${bootstrap}" >/dev/null
 	grep -F 'partial="${destination}.part"' "${bootstrap}" >/dev/null
@@ -1051,7 +1084,7 @@ grep -F 'checkSourceLensHealthViaConsole' \
 	"${ROOT}/src/agent/internal/enroll/sidecar_install_unix.go" >/dev/null
 grep -F 'isPublicGatewayScope' \
 	"${ROOT}/src/agent/internal/enroll/download_progress.go" >/dev/null
-grep -F -- '--fail --show-error --location --progress-bar' "${gateway_lifecycle}" >/dev/null
+grep -F -- '--fail --silent --show-error --location' "${gateway_lifecycle}" >/dev/null
 grep -F -- '--continue-at -' "${gateway_lifecycle}" >/dev/null
 grep -F 'HFL_GATEWAY_DOWNLOAD_MAX_ATTEMPTS:-5' "${gateway_lifecycle}" >/dev/null
 grep -F 'partial="${2}.part"' "${gateway_lifecycle}" >/dev/null
@@ -1074,7 +1107,11 @@ fi
 grep -F 'script="${INSTALL_SH%/install.sh}/libexec/gateway-lifecycle.sh"' \
 	"${ROOT}/src/agent/internal/platform/install/gateway_hooks_unix.go" >/dev/null
 grep -F 'Docker CE offline bundle' "${gateway_docker_installer}" >/dev/null
-grep -F -- "'--progress-bar'" "${agent_bootstrap_windows}" >/dev/null
+grep -F -- "'--silent'" "${agent_bootstrap_windows}" >/dev/null
+if grep -F -- '--progress-bar' "${agent_bootstrap_windows}" >/dev/null; then
+	printf 'ERROR: Windows bootstrap must not expose curl native progress output\n' >&2
+	exit 1
+fi
 grep -F 'Write-HflDownloadProgress' "${agent_bootstrap_windows}" >/dev/null
 grep -F 'Download size mismatch' "${agent_bootstrap_windows}" >/dev/null
 if grep -F 'hfl-enroll-windows-$archRel.exe' "${agent_bootstrap_windows}" >/dev/null \
@@ -1153,6 +1190,7 @@ grep -F './tools/quality/test-gateway-lifecycle-upgrade.sh' "${workflow}" >/dev/
 grep -F './tools/quality/test-platform-gateway-auto-deploy.sh' "${workflow}" >/dev/null
 grep -F './tools/quality/test-agent-release-retention.sh' "${workflow}" >/dev/null
 grep -F './tools/quality/test-agent-gateway-uninstall.sh' "${workflow}" >/dev/null
+grep -F './tools/quality/test-agent-installer-output.sh' "${workflow}" >/dev/null
 grep -F 'HFL_PLATFORM_GATEWAY_AUTO_DEPLOY=true' "${ROOT}/.env.example" >/dev/null
 grep -F 'com.hyperfilelens.component: "gateway-lensnode"' \
 	"${gateway_sidecar_installer}" >/dev/null

--- a/tools/quality/test-agent-gateway-uninstall.sh
+++ b/tools/quality/test-agent-gateway-uninstall.sh
@@ -56,6 +56,21 @@ unmount_agent_mounts() { :; }
 
 export TEST_AGENT_ENV="${DEFAULT_DATA}/agent.env"
 export TEST_SIDECAR_MARKER="${marker}"
+
+# Preserving data retires the installation identity. A missing Agent binary
+# must fail during preflight, before the service or Gateway sidecar is touched.
+set +e
+(
+	exec 3>&1 4>&2
+	cmd_uninstall
+) >"${tmp}/uninstall-preflight.log" 2>&1
+preflight_status=$?
+set -e
+[[ "${preflight_status}" -eq 1 ]]
+grep -F 'Cannot retire the installation identity' "${tmp}/uninstall-preflight.log" >/dev/null
+[[ ! -e "${marker}" ]]
+[[ ! -e "${stop_marker}" ]]
+
 cmd_uninstall --purge-all
 
 [[ -f "${marker}" ]]

--- a/tools/quality/test-agent-installer-output.sh
+++ b/tools/quality/test-agent-installer-output.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Validate standalone Agent lifecycle output and timestamped file logging.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+installer="${ROOT}/src/agent/packaging/install/install.sh"
+tmp="$(mktemp -d)"
+trap 'rm -rf "${tmp}"' EXIT
+
+run_success_case() (
+	# Load helpers without dispatching the real installer.
+	# shellcheck disable=SC1090
+	source <(sed '/^bundle_agent()/,$d' "${installer}")
+	begin_install_log "${tmp}/success"
+	hfl_print_banner "Source Host" "Installer"
+	hfl_print_section "Target"
+	hfl_print_value "Role" "Source Host"
+	hfl_print_section "Installing Agent"
+	log_ok "Agent files were installed."
+	hfl_print_result "Installation completed successfully"
+	finish_install_log 0
+)
+
+run_success_case >"${tmp}/success.out" 2>&1
+success_log="${tmp}/success/logs/install.log"
+grep -F 'HyperFileLens Source Host Installer' "${tmp}/success.out" >/dev/null
+grep -F 'Installation completed successfully' "${tmp}/success.out" >/dev/null
+grep -F 'HyperFileLens Source Host Installer' "${success_log}" >/dev/null
+grep -F 'Installation completed successfully' "${success_log}" >/dev/null
+if awk 'NF && $0 !~ /^\[[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]{3}Z\] / { exit 1 }' \
+	"${success_log}"; then
+	:
+else
+	printf 'Agent install log contains a non-timestamped line\n' >&2
+	exit 1
+fi
+
+set +e
+(
+	# shellcheck disable=SC1090
+	source <(sed '/^bundle_agent()/,$d' "${installer}")
+	begin_install_log "${tmp}/failure" "upgrade"
+	log_fail "Simulated upgrade failure" 7
+) >"${tmp}/failure.out" 2>&1
+status=$?
+set -e
+[[ "${status}" -eq 7 ]]
+failure_log="${tmp}/failure/logs/install.log"
+grep -F '[FAIL] Simulated upgrade failure.' "${tmp}/failure.out" >/dev/null
+if grep -F 'Simulated upgrade failure 7.' "${tmp}/failure.out" >/dev/null; then
+	printf 'Agent failure output leaked the numeric exit code into the message\n' >&2
+	exit 1
+fi
+grep -F 'Install session finished with errors (exit=7).' "${failure_log}" >/dev/null
+
+set +e
+(
+	# An unexpected shell failure must still produce one useful final failure and
+	# close the timestamped session log.
+	# shellcheck disable=SC1090
+	source <(sed '/^bundle_agent()/,$d' "${installer}")
+	begin_install_log "${tmp}/unexpected" "upgrade"
+	false
+) >"${tmp}/unexpected.out" 2>&1
+status=$?
+set -e
+[[ "${status}" -eq 1 ]]
+[[ "$(grep -cF '[FAIL]' "${tmp}/unexpected.out")" -eq 1 ]]
+grep -F 'Upgrade failed (exit code 1)' "${tmp}/unexpected.out" >/dev/null
+grep -F 'Install session finished with errors (exit=1).' \
+	"${tmp}/unexpected/logs/install.log" >/dev/null
+
+set +e
+(
+	# A helper may fail inside command substitution; the outer EXIT trap must not
+	# add a second generic failure after the specific message was already logged.
+	# shellcheck disable=SC1090
+	source <(sed '/^bundle_agent()/,$d' "${installer}")
+	begin_install_log "${tmp}/subshell" "upgrade"
+	value="$(log_fail "Specific package source failure" 2)"
+	printf '%s\n' "${value}"
+) >"${tmp}/subshell.out" 2>&1
+status=$?
+set -e
+[[ "${status}" -eq 2 ]]
+[[ "$(grep -cF '[FAIL]' "${tmp}/subshell.out")" -eq 1 ]]
+grep -F '[FAIL] Specific package source failure.' "${tmp}/subshell.out" >/dev/null
+
+printf 'Agent installer output checks passed.\n'

--- a/tools/quality/test-bootstrap-curl-tls-nounset.sh
+++ b/tools/quality/test-bootstrap-curl-tls-nounset.sh
@@ -39,7 +39,7 @@ SH
 chmod +x "${tmp}/bin/curl"
 
 # Host Bash smoke: empty CURL_TLS must still drive hfl_download successfully.
-source <(sed -n '/^hfl_now()/,/^hfl_build_enroll_args()/p' "${bootstrap}" | sed '$d')
+source <(sed -n '/^hfl_fail()/,/^hfl_build_enroll_args()/p' "${bootstrap}" | sed '$d')
 CURL_TLS=()
 PATH="${tmp}/bin:${PATH}"
 export PATH

--- a/tools/quality/test-bootstrap-download-progress.sh
+++ b/tools/quality/test-bootstrap-download-progress.sh
@@ -39,7 +39,7 @@ SH
 chmod +x "${tmp}/bin/curl"
 
 # Load only the standalone bootstrap logging and download helpers.
-source <(sed -n '/^hfl_now()/,/^hfl_build_enroll_args()/p' "${bootstrap}" | sed '$d')
+source <(sed -n '/^hfl_fail()/,/^hfl_build_enroll_args()/p' "${bootstrap}" | sed '$d')
 CURL_TLS=()
 PATH="${tmp}/bin:${PATH}"
 export PATH HFL_TEST_CURL_LOG="${tmp}/curl.log"
@@ -48,8 +48,8 @@ export HFL_TEST_CURL_SUPPORT_RETRY_CONNREFUSED=1
 destination="${tmp}/hfl-enroll"
 output="$(hfl_download "HyperFileLens enrollment helper" https://example.invalid/helper "${destination}" 2>&1)"
 grep -F '[....] Downloading HyperFileLens enrollment helper.' <<<"${output}" >/dev/null
-grep -F '[ OK  ] HyperFileLens enrollment helper downloaded (' <<<"${output}" >/dev/null
-grep -Fx -- '--progress-bar' "${HFL_TEST_CURL_LOG}" >/dev/null
+grep -F '[ OK ] HyperFileLens enrollment helper downloaded (' <<<"${output}" >/dev/null
+grep -Fx -- '--silent' "${HFL_TEST_CURL_LOG}" >/dev/null
 grep -Fx -- '--retry' "${HFL_TEST_CURL_LOG}" >/dev/null
 grep -Fx -- '--retry-connrefused' "${HFL_TEST_CURL_LOG}" >/dev/null
 grep -Fx 'bootstrap-download-fixture' "${destination}" >/dev/null
@@ -60,7 +60,7 @@ rm -f "${destination}"
 : >"${HFL_TEST_CURL_LOG}"
 export HFL_TEST_CURL_SUPPORT_RETRY_CONNREFUSED=0
 output="$(hfl_download "HyperFileLens enrollment helper" https://example.invalid/helper "${destination}" 2>&1)"
-grep -F '[ OK  ] HyperFileLens enrollment helper downloaded (' <<<"${output}" >/dev/null
+grep -F '[ OK ] HyperFileLens enrollment helper downloaded (' <<<"${output}" >/dev/null
 grep -Fx -- '--retry' "${HFL_TEST_CURL_LOG}" >/dev/null
 grep -Fx -- '--retry-delay' "${HFL_TEST_CURL_LOG}" >/dev/null
 if grep -Fx -- '--retry-connrefused' "${HFL_TEST_CURL_LOG}" >/dev/null; then
@@ -79,7 +79,7 @@ set +e
 status=$?
 set -e
 [[ "${status}" -eq 3 ]]
-grep -F '[FAIL ] Failed to download HyperFileLens enrollment helper.' "${tmp}/failed.log" >/dev/null
+grep -F '[FAIL] Failed to download HyperFileLens enrollment helper.' "${tmp}/failed.log" >/dev/null
 [[ ! -e "${destination}" ]]
 [[ ! -e "${destination}.part" ]]
 


### PR DESCRIPTION
## Summary
- standardize install, upgrade, and uninstall output across Source Host, Proxy Host, and Data Gateway lifecycles
- keep terminal output concise while writing timestamped diagnostic logs
- preserve preflight checks, rollback behavior, exit codes, and machine-readable compatibility
- add regression coverage for lifecycle output and uninstall safety ordering

## Validation
- Agent full Go test suite
- affected frontend tests (14 passed)
- Linux lifecycle and release-contract checks
- Bash syntax checks
- Windows PowerShell parser checks
- Windows Agent cross-compilation
- git diff --check