### PR TITLE
fix(gateway): align bundled SourceLens endpoints with enrollment origins

### DIFF
--- a/dev/stack.sh
+++ b/dev/stack.sh
@@ -83,6 +83,8 @@ LANGUAGE_PACK_BUILD_OUTPUT="${ROOT}/build/language-packs"
 # Open Core extensions: CLI --extension-source only (not a .env setting).
 EXTENSION_SOURCES=()
 EXTENSION_SOURCES_CSV=""
+DEV_PUBLIC_URL=""
+DEV_ADMIN_PUBLIC_URL=""
 
 usage() {
 	cat <<'USAGE'
@@ -127,6 +129,10 @@ Extensions (optional overlay; community default = empty socket):
   stack.sh materializes sources → build/docker-compose.extensions.yml.
   Runtime containers see HFL_EXTENSIONS paths only (never git clone in api/web).
 
+Deployment identity (optional for source deployments reached from another host):
+  --public-url URL                 Canonical tenant origin used by remote Agents and links.
+  --admin-public-url URL           Canonical Admin Console origin.
+
 Mirror options (Kopia fetch + Agent publishing + SourceLens git clone; env fallback):
   --github-download-mirror URL     GitHub Git/release mirror (env: GITHUB_DOWNLOAD_MIRROR)
   --github-token TOKEN             GitHub token for API/release fetch, private SourceLens
@@ -157,6 +163,8 @@ Output options:
 Examples:
   ./dev/stack.sh up
   ./dev/stack.sh up --extension-source ../hyperfilelens-ee
+  ./dev/stack.sh up --public-url https://192.168.8.69:11443 \
+    --admin-public-url https://192.168.8.69:11444
   ./dev/stack.sh up --ubuntu2404-arch amd64
   ./dev/stack.sh down
   ./dev/stack.sh restart
@@ -268,6 +276,8 @@ pip_index_url=${OPT_PIP_INDEX_URL:-<official>}
 pip_trusted_host=${OPT_PIP_TRUSTED_HOST:-<unset>}
 npm_registry=${OPT_NPM_REGISTRY:-<official>}
 extension_sources=${EXTENSION_SOURCES_CSV:-<none>}
+public_url=${DEV_PUBLIC_URL:-<preserve>}
+admin_public_url=${DEV_ADMIN_PUBLIC_URL:-<preserve>}
 docker_pull_timeout=${DOCKER_PULL_TIMEOUT}
 docker_pull_retries=${DOCKER_PULL_RETRIES}
 offline=${DEV_OFFLINE}
@@ -384,6 +394,15 @@ ensure_env_file() {
 		chmod 600 "${env_file}"
 		log "Created .env from .env.example"
 	fi
+}
+
+apply_dev_public_urls() {
+	[[ -n "${DEV_PUBLIC_URL}" || -n "${DEV_ADMIN_PUBLIC_URL}" ]] || return 0
+	local -a args=(--env-file "${ROOT}/.env")
+	[[ -z "${DEV_PUBLIC_URL}" ]] || args+=(--public-url "${DEV_PUBLIC_URL}")
+	[[ -z "${DEV_ADMIN_PUBLIC_URL}" ]] || args+=(--admin-public-url "${DEV_ADMIN_PUBLIC_URL}")
+	python3 "${ROOT}/deploy/installer/apply-runtime-config.py" "${args[@]}"
+	log "Source deployment public origins synchronized"
 }
 
 ensure_tls_certs() {
@@ -1187,6 +1206,7 @@ cmd_up() {
 	apply_mirror_env_defaults
 	require_dev_build_tools
 	ensure_env_file
+	apply_dev_public_urls
 	require_docker
 	ensure_runtime_images
 	verify_amd64_runtime
@@ -1217,6 +1237,7 @@ cmd_restart() {
 	apply_mirror_env_defaults
 	require_dev_build_tools
 	ensure_env_file
+	apply_dev_public_urls
 	require_docker
 	ensure_runtime_images
 	verify_amd64_runtime
@@ -1523,6 +1544,16 @@ main() {
 			EXTENSION_SOURCES+=("$2")
 			shift 2
 			;;
+		--public-url)
+			require_value "$1" "${2:-}"
+			DEV_PUBLIC_URL="$2"
+			shift 2
+			;;
+		--admin-public-url)
+			require_value "$1" "${2:-}"
+			DEV_ADMIN_PUBLIC_URL="$2"
+			shift 2
+			;;
 		--github-download-mirror | --github-token | --docker-download-mirror | --apt-mirror | --ubuntu2404-arch | --kopia-mode | --kopia-git-url | --kopia-ref | --sourcelens-ref | --sourcelens-git-url | --go-proxy | --go-sumdb | --pip-index-url | --pip-trusted-host | --npm-registry | --pull-timeout | --pull-retries | --no-sourcelens | --hfl-only | --pull | --offline)
 			parse_common_option "$@" || die "failed to parse option: $1"
 			if [[ "$1" == "--no-sourcelens" || "$1" == "--hfl-only" \
@@ -1561,6 +1592,10 @@ main() {
 	fi
 	if [[ "${HFL_ONLY_DOWN}" -eq 1 && "${cmd}" != "down" ]]; then
 		die "--hfl-only is only valid with down" 2
+	fi
+	if [[ -n "${DEV_PUBLIC_URL}${DEV_ADMIN_PUBLIC_URL}" \
+		&& "${cmd}" != "up" && "${cmd}" != "restart" ]]; then
+		die "--public-url and --admin-public-url are only valid with up or restart" 2
 	fi
 	if [[ -n "${CLEAN_SCOPE}" && "${cmd}" != "clean" ]]; then
 		die "clean scope options are only valid with clean" 2

--- a/src/agent/internal/enroll/gateway_install.go
+++ b/src/agent/internal/enroll/gateway_install.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"runtime"
 	"strings"
 	"time"
@@ -19,6 +20,7 @@ import (
 type LensSidecarConfig struct {
 	GatewayScope  string
 	LensBaseURL   string
+	LensBasePath  string
 	LensnodeUUID  string
 	LensnodeToken string
 	LensnodeName  string
@@ -64,6 +66,12 @@ func RunGatewayInstall(ctx context.Context, opts InstallOptions) error {
 		_ = ReportGatewayInstallStatus(ctx, cfg, nodeID, "failed", err.Error())
 		logFail("AI engine configuration is unavailable: "+err.Error(), 6)
 	}
+	logStep("Verifying AI engine endpoint.")
+	if err := verifyLensEndpoint(ctx, lensCfg.LensBaseURL); err != nil {
+		_ = ReportGatewayInstallStatus(ctx, cfg, nodeID, "failed", err.Error())
+		logFail("AI engine endpoint is unreachable: "+err.Error(), 6)
+	}
+	logOK("AI engine endpoint is reachable.")
 	// The authenticated console response is authoritative. Public Data Gateways
 	// receive the deployment Sentry policy; Private Data Gateways receive disabled.
 	// Observability convergence must never block enrollment or data operations.
@@ -127,7 +135,11 @@ func FetchGatewayLensConfig(ctx context.Context, cfg Config, nodeID string) (Len
 		return LensSidecarConfig{}, fmt.Errorf("HTTP %s: %s", resp.Status, strings.TrimSpace(string(raw)))
 	}
 
-	return parseGatewayLensConfig(raw)
+	lens, err := parseGatewayLensConfig(raw)
+	if err != nil {
+		return LensSidecarConfig{}, err
+	}
+	return resolveGatewayLensConfig(cfg.APIBase, lens)
 }
 
 func parseGatewayLensConfig(raw []byte) (LensSidecarConfig, error) {
@@ -147,6 +159,7 @@ func parseGatewayLensConfig(raw []byte) (LensSidecarConfig, error) {
 	cfgOut := LensSidecarConfig{
 		GatewayScope:  stringField(data, "gateway_scope"),
 		LensBaseURL:   stringField(lensRaw, "lens_base_url"),
+		LensBasePath:  stringField(lensRaw, "lens_base_path"),
 		LensnodeUUID:  stringField(lensRaw, "lensnode_uuid"),
 		LensnodeToken: stringField(lensRaw, "lensnode_token"),
 		LensnodeName:  stringField(lensRaw, "lensnode_name"),
@@ -162,13 +175,87 @@ func parseGatewayLensConfig(raw []byte) (LensSidecarConfig, error) {
 			TracesSampleRate: floatField(observabilityRaw, "traces_sample_rate"),
 		}.Normalized()
 	}
-	if cfgOut.LensBaseURL == "" || cfgOut.LensnodeToken == "" || cfgOut.LensnodeUUID == "" {
+	if (cfgOut.LensBaseURL == "" && cfgOut.LensBasePath == "") ||
+		cfgOut.LensnodeToken == "" || cfgOut.LensnodeUUID == "" {
 		return LensSidecarConfig{}, fmt.Errorf("incomplete lens configuration from console")
 	}
 	if cfgOut.WorkspaceRoot == "" {
 		cfgOut.WorkspaceRoot = "/workspace"
 	}
 	return cfgOut, nil
+}
+
+func resolveGatewayLensConfig(apiBase string, lens LensSidecarConfig) (LensSidecarConfig, error) {
+	if lens.LensBasePath != "" {
+		origin, err := parseHTTPOrigin(apiBase)
+		if err != nil {
+			return LensSidecarConfig{}, fmt.Errorf("invalid HFL_API_BASE for LensNode: %w", err)
+		}
+		path, err := url.Parse(lens.LensBasePath)
+		if err != nil || path.IsAbs() || path.Host != "" || !strings.HasPrefix(path.Path, "/") ||
+			path.RawQuery != "" || path.Fragment != "" {
+			return LensSidecarConfig{}, fmt.Errorf("invalid LensNode base path from console")
+		}
+		origin.Path = path.Path
+		lens.LensBaseURL = strings.TrimRight(origin.String(), "/")
+	}
+	if _, err := parseHTTPURL(lens.LensBaseURL); err != nil {
+		return LensSidecarConfig{}, fmt.Errorf("invalid LensNode base URL from console: %w", err)
+	}
+	return lens, nil
+}
+
+func parseHTTPOrigin(raw string) (*url.URL, error) {
+	parsed, err := parseHTTPURL(raw)
+	if err != nil {
+		return nil, err
+	}
+	if parsed.Path != "" && parsed.Path != "/" {
+		return nil, fmt.Errorf("URL must be an origin without a path")
+	}
+	parsed.Path = ""
+	return parsed, nil
+}
+
+func parseHTTPURL(raw string) (*url.URL, error) {
+	parsed, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil {
+		return nil, err
+	}
+	if (parsed.Scheme != "http" && parsed.Scheme != "https") || parsed.Hostname() == "" ||
+		parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" {
+		return nil, fmt.Errorf("URL must be an absolute HTTP(S) URL without credentials, query, or fragment")
+	}
+	return parsed, nil
+}
+
+func verifyLensEndpoint(ctx context.Context, lensBaseURL string) error {
+	client := &http.Client{Timeout: 30 * time.Second}
+	if tlsclient.InsecureTLSEnabled() {
+		client.Transport = tlsclient.Transport()
+	}
+	return verifyLensEndpointWithClient(ctx, client, lensBaseURL)
+}
+
+func verifyLensEndpointWithClient(ctx context.Context, client *http.Client, lensBaseURL string) error {
+	base, err := parseHTTPURL(lensBaseURL)
+	if err != nil {
+		return err
+	}
+	base.Path = strings.TrimRight(base.Path, "/") + "/health"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, base.String(), nil)
+	if err != nil {
+		return err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("GET %s returned HTTP %s", base.Redacted(), resp.Status)
+	}
+	return nil
 }
 
 // ReportGatewayInstallStatus notifies the console when gateway-install succeeds or fails.

--- a/src/agent/internal/enroll/gateway_install_test.go
+++ b/src/agent/internal/enroll/gateway_install_test.go
@@ -1,0 +1,112 @@
+package enroll
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (function roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return function(request)
+}
+
+func TestResolveGatewayLensConfigUsesEnrolledControlPlaneOrigin(t *testing.T) {
+	lens, err := resolveGatewayLensConfig(
+		"https://console.example:11443",
+		LensSidecarConfig{
+			LensBaseURL:  "https://127.0.0.1:11443/sourcelens",
+			LensBasePath: "/sourcelens",
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lens.LensBaseURL != "https://console.example:11443/sourcelens" {
+		t.Fatalf("LensBaseURL = %q", lens.LensBaseURL)
+	}
+}
+
+func TestResolveGatewayLensConfigKeepsInstallerManagedLoopback(t *testing.T) {
+	lens, err := resolveGatewayLensConfig(
+		"https://127.0.0.1:11443",
+		LensSidecarConfig{
+			LensBaseURL:  "https://console.example:11443/sourcelens",
+			LensBasePath: "/sourcelens",
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lens.LensBaseURL != "https://127.0.0.1:11443/sourcelens" {
+		t.Fatalf("LensBaseURL = %q", lens.LensBaseURL)
+	}
+}
+
+func TestResolveGatewayLensConfigKeepsExternalSourceLensURL(t *testing.T) {
+	lens, err := resolveGatewayLensConfig(
+		"https://console.example:11443",
+		LensSidecarConfig{LensBaseURL: "https://lens.example/custom"},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lens.LensBaseURL != "https://lens.example/custom" {
+		t.Fatalf("LensBaseURL = %q", lens.LensBaseURL)
+	}
+}
+
+func TestResolveGatewayLensConfigRejectsNetworkPath(t *testing.T) {
+	_, err := resolveGatewayLensConfig(
+		"https://console.example:11443",
+		LensSidecarConfig{
+			LensBaseURL:  "https://lens.example",
+			LensBasePath: "//attacker.example/sourcelens",
+		},
+	)
+	if err == nil {
+		t.Fatal("resolveGatewayLensConfig accepted a network-path reference")
+	}
+}
+
+func TestVerifyLensEndpoint(t *testing.T) {
+	client := &http.Client{Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		if request.URL.String() != "https://console.example:11443/sourcelens/health" {
+			t.Fatalf("health URL = %q", request.URL.String())
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Status:     "200 OK",
+			Body:       io.NopCloser(strings.NewReader("ok")),
+		}, nil
+	})}
+
+	if err := verifyLensEndpointWithClient(
+		context.Background(),
+		client,
+		"https://console.example:11443/sourcelens",
+	); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestVerifyLensEndpointRejectsUnhealthyResponse(t *testing.T) {
+	client := &http.Client{Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusServiceUnavailable,
+			Status:     "503 Service Unavailable",
+			Body:       io.NopCloser(strings.NewReader("unavailable")),
+		}, nil
+	})}
+
+	if err := verifyLensEndpointWithClient(
+		context.Background(),
+		client,
+		"https://lens.example",
+	); err == nil {
+		t.Fatal("verifyLensEndpoint accepted HTTP 503")
+	}
+}

--- a/src/backend/apps/lens_bridge/deploy.py
+++ b/src/backend/apps/lens_bridge/deploy.py
@@ -74,6 +74,18 @@ def lens_gateway_base_url() -> str:
     return base
 
 
+def lens_gateway_base_path() -> str:
+    """Return the control-plane-relative SourceLens path for bundled gateways.
+
+    New Agents resolve this path against the ``HFL_API_BASE`` they already used
+    to enroll.  The absolute URL remains in the response for compatibility with
+    older Agents and for external SourceLens deployments.
+    """
+    if sourcelens_mode() == "bundled":
+        return LENS_GATEWAY_PUBLIC_PATH
+    return ""
+
+
 def local_platform_lens_gateway_base_url() -> str:
     """Return the bundled SourceLens URL for the installer-managed local Gateway."""
     if sourcelens_mode() != "bundled":

--- a/src/backend/apps/lens_bridge/services/provisioning.py
+++ b/src/backend/apps/lens_bridge/services/provisioning.py
@@ -1061,6 +1061,7 @@ def enable_ai_on_gateway(
 def build_lens_enroll_config(link: LensGatewayLink) -> dict[str, Any]:
     """LensNode credentials for gateway enrollment / sidecar install."""
     from apps.lens_bridge.deploy import (
+        lens_gateway_base_path,
         lens_gateway_base_url,
         local_platform_lens_gateway_base_url,
     )
@@ -1076,6 +1077,7 @@ def build_lens_enroll_config(link: LensGatewayLink) -> dict[str, Any]:
         gateway_base_url = local_platform_lens_gateway_base_url()
     return {
         "lens_base_url": gateway_base_url,
+        "lens_base_path": lens_gateway_base_path(),
         "lensnode_uuid": str(link.sl_lensnode_uuid) if link.sl_lensnode_uuid else None,
         "lensnode_token": config.get("lensnode_token"),
         "lensnode_name": lensnode_name,

--- a/src/backend/apps/lens_bridge/tests/test_deploy.py
+++ b/src/backend/apps/lens_bridge/tests/test_deploy.py
@@ -139,6 +139,22 @@ class LensDeployUrlTest(unittest.TestCase):
             "https://sourcelens.example.com",
         )
 
+    @patch("apps.lens_bridge.deploy.env_str")
+    def test_bundled_gateway_uses_control_plane_relative_path(self, env_str):
+        env_str.side_effect = lambda key, default="": (
+            "bundled" if key == "SOURCELENS_MODE" else default
+        )
+
+        self.assertEqual(deploy.lens_gateway_base_path(), "/sourcelens")
+
+    @patch("apps.lens_bridge.deploy.env_str")
+    def test_external_gateway_does_not_override_absolute_url(self, env_str):
+        env_str.side_effect = lambda key, default="": (
+            "external" if key == "SOURCELENS_MODE" else default
+        )
+
+        self.assertEqual(deploy.lens_gateway_base_path(), "")
+
     @patch("apps.lens_bridge.deploy.env_int", return_value=12443)
     @patch("apps.lens_bridge.deploy.env_str")
     def test_local_platform_gateway_uses_loopback_for_bundled_mode(

--- a/src/backend/apps/lens_bridge/tests/test_provisioning.py
+++ b/src/backend/apps/lens_bridge/tests/test_provisioning.py
@@ -173,6 +173,7 @@ class BuildLensEnrollConfigTests(SimpleTestCase):
             result["lens_base_url"],
             "https://127.0.0.1:11443/sourcelens",
         )
+        self.assertEqual(result["lens_base_path"], "/sourcelens")
 
     @patch(
         "apps.lens_bridge.deploy.local_platform_lens_gateway_base_url",
@@ -199,6 +200,7 @@ class BuildLensEnrollConfigTests(SimpleTestCase):
             result["lens_base_url"],
             "https://console.example/sourcelens",
         )
+        self.assertEqual(result["lens_base_path"], "/sourcelens")
 
 
 class LensnodeWorkspaceReadinessTests(SimpleTestCase):

--- a/src/backend/apps/node/services/internal/local_platform_gateway.py
+++ b/src/backend/apps/node/services/internal/local_platform_gateway.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ipaddress
 from urllib.parse import urlsplit
 
 from django.db import transaction
@@ -24,8 +25,12 @@ LOCAL_PLATFORM_GATEWAY_METADATA = {
 }
 
 
-def platform_gateway_api_base() -> str:
+def platform_gateway_api_base(*, require_remote: bool = False) -> str:
     """Return the configured tenant origin used by platform Data Gateways.
+
+    Args:
+        require_remote: Reject loopback hosts reserved for the installer-managed
+            local platform Gateway.
 
     Raises:
         ValueError: If ``FRONTEND_URL`` is not an absolute HTTP(S) origin.
@@ -52,6 +57,17 @@ def platform_gateway_api_base() -> str:
         raise ValueError(
             "FRONTEND_URL must be an absolute HTTP(S) origin for Data Gateway "
             "enrollment and must use HTTPS when TLS verification is enabled."
+        )
+    hostname = parsed.hostname.lower()
+    try:
+        address = ipaddress.ip_address(hostname)
+        non_routable = address.is_loopback or address.is_unspecified
+    except ValueError:
+        non_routable = hostname == "localhost" or hostname.endswith(".localhost")
+    if require_remote and non_routable:
+        raise ValueError(
+            "FRONTEND_URL must use a network-reachable host for remote Public "
+            "Data Gateway enrollment. Configure the deployment public URL first."
         )
     return api_base.rstrip("/")
 

--- a/src/backend/apps/node/tests/test_local_platform_gateway.py
+++ b/src/backend/apps/node/tests/test_local_platform_gateway.py
@@ -48,6 +48,16 @@ class LocalPlatformGatewayConfigTests(SimpleTestCase):
         with self.assertRaisesMessage(ValueError, "must use HTTPS"):
             platform_gateway_api_base()
 
+    @override_settings(FRONTEND_URL="https://127.0.0.1:11443")
+    def test_remote_platform_gateway_rejects_loopback_origin(self):
+        with self.assertRaisesMessage(ValueError, "network-reachable"):
+            platform_gateway_api_base(require_remote=True)
+
+    @override_settings(FRONTEND_URL="https://0.0.0.0:11443")
+    def test_remote_platform_gateway_rejects_unspecified_origin(self):
+        with self.assertRaisesMessage(ValueError, "network-reachable"):
+            platform_gateway_api_base(require_remote=True)
+
     def test_registration_metadata_requires_trusted_installer_state(self):
         untrusted = registration_metadata(LOCAL_PLATFORM_GATEWAY_METADATA)
         self.assertNotIn("install_key", untrusted)

--- a/tools/quality/test-dev-stack-upgrade.sh
+++ b/tools/quality/test-dev-stack-upgrade.sh
@@ -22,6 +22,24 @@ source "${ROOT_REPO}/tools/sourcelens/defaults.env"
 [[ "${SOURCELENS_GIT_REF}" == "v0.29.0" ]]
 ROOT="${original_root}"
 
+# Source deployments can persist the same canonical origins used by Release
+# and CI installs instead of editing .env by hand.
+source_deploy_root="${tmp}/source-deploy"
+mkdir -p "${source_deploy_root}/deploy/installer"
+cp "${ROOT_REPO}/.env.example" "${source_deploy_root}/.env"
+cp "${ROOT_REPO}/deploy/installer/apply-runtime-config.py" \
+	"${source_deploy_root}/deploy/installer/apply-runtime-config.py"
+ROOT="${source_deploy_root}"
+DEV_PUBLIC_URL="https://192.0.2.10:11443"
+DEV_ADMIN_PUBLIC_URL="https://192.0.2.10:11444"
+apply_dev_public_urls >/dev/null
+grep -Fx 'FRONTEND_URL=https://192.0.2.10:11443' "${ROOT}/.env" >/dev/null
+grep -Fx 'LENS_GATEWAY_BASE_URL=https://192.0.2.10:11443/sourcelens' "${ROOT}/.env" >/dev/null
+grep -Fx 'HFL_ADMIN_PUBLIC_URL=https://192.0.2.10:11444' "${ROOT}/.env" >/dev/null
+ROOT="${original_root}"
+DEV_PUBLIC_URL=""
+DEV_ADMIN_PUBLIC_URL=""
+
 dev_env_loader="$(sed -n '/^load_repo_env_defaults()/,/^}/p' "${ROOT_REPO}/dev/stack.sh")"
 release_env_loader="$(sed -n '/^load_repo_env_defaults()/,/^}/p' "${ROOT_REPO}/release/build.sh")"
 if grep -qw SOURCELENS_GIT_REF <<<"${dev_env_loader}${release_env_loader}"; then


### PR DESCRIPTION
Summary: Resolve bundled SourceLens through the enrolled control-plane origin, preserve legacy and external endpoint compatibility, validate reachability before LensNode image installation, and support canonical source-deployment URLs. Tests: full Agent Go test and vet suites, 43 targeted backend tests, release contract checks, development stack regression checks, Ruff, and diff checks passed.