### PR TITLE
fix(dev): require modern Bash on macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ src/backend/staticfiles/
 
 # --- Other ---
 *.mo
+.installer.lock
 .worktrees/
 .tmp/
 .tools/

--- a/dev/stack.sh
+++ b/dev/stack.sh
@@ -15,13 +15,18 @@ set -euo pipefail
 
 configure_macos_dev_shell() {
 	[[ "$(uname -s)" == "Darwin" ]] || return 0
-	command -v brew >/dev/null 2>&1 || return 0
 	if ((BASH_VERSINFO[0] < 5)); then
+		command -v brew >/dev/null 2>&1 || {
+			printf 'ERROR: macOS development requires Homebrew Bash 5 or newer; install Homebrew and run: brew install bash\n' >&2
+			exit 2
+		}
 		local brew_bash
 		brew_bash="$(brew --prefix bash 2>/dev/null)/bin/bash"
-		if [[ -x "${brew_bash}" ]]; then
-			exec "${brew_bash}" "$0" "$@"
-		fi
+		[[ -x "${brew_bash}" ]] || {
+			printf 'ERROR: macOS development requires Homebrew Bash 5 or newer; run: brew install bash\n' >&2
+			exit 2
+		}
+		exec "${brew_bash}" "$0" "$@"
 	fi
 	# Make `#!/usr/bin/env bash` child scripts resolve to Homebrew Bash as well.
 	# Without this, macOS falls back to its Bash 3.2 after this script re-execs.

--- a/tools/lib/docker-images.sh
+++ b/tools/lib/docker-images.sh
@@ -67,7 +67,20 @@ hfl_docker_pull_error_is_terminal() {
 
 hfl_docker_image_matches_platform() {
 	local image=$1 platform="${2:-}" actual expected
-	actual="$(docker image inspect "${image}" --format '{{.Os}}/{{.Architecture}}' 2>/dev/null || true)"
+	if [[ -n "${platform}" ]]; then
+		# Docker 29 may keep a locally pulled multi-platform tag as an OCI image
+		# index. A generic inspect then exposes empty Os/Architecture fields even
+		# though the requested platform is present in the local image store.
+		actual="$(docker image inspect --platform "${platform}" "${image}" \
+			--format '{{.Os}}/{{.Architecture}}' 2>/dev/null || true)"
+		# Docker clients predating platform-selective inspect still expose
+		# platform fields for their single-platform local image representation.
+		[[ -n "${actual}" ]] || actual="$(docker image inspect "${image}" \
+			--format '{{.Os}}/{{.Architecture}}' 2>/dev/null || true)"
+	else
+		actual="$(docker image inspect "${image}" \
+			--format '{{.Os}}/{{.Architecture}}' 2>/dev/null || true)"
+	fi
 	[[ -n "${actual}" ]] || return 1
 	[[ -z "${platform}" ]] && return 0
 	case "${platform}" in

--- a/tools/quality/test-docker-image-digest-alias.sh
+++ b/tools/quality/test-docker-image-digest-alias.sh
@@ -16,6 +16,16 @@ set -euo pipefail
 case "${1:-}" in
 image)
 	[[ "${2:-}" == "inspect" ]]
+	if [[ -f "${HFL_DOCKER_TEST_STATE}/legacy-local" ]]; then
+		[[ " $* " != *" --platform "* ]] || exit 1
+		printf 'linux/amd64\n'
+		exit 0
+	fi
+	if [[ -f "${HFL_DOCKER_TEST_STATE}/local-index" ]]; then
+		[[ " $* " == *" --platform linux/amd64 "* ]] || exit 1
+		printf 'linux/amd64\n'
+		exit 0
+	fi
 	[[ -f "${HFL_DOCKER_TEST_STATE}/pulled" ]] || exit 1
 	printf 'linux/amd64\n'
 	;;
@@ -36,6 +46,14 @@ chmod +x "${tmp}/bin/docker"
 export HFL_DOCKER_TEST_STATE="${tmp}/state"
 PATH="${tmp}/bin:${PATH}"
 export PATH
+
+touch "${HFL_DOCKER_TEST_STATE}/local-index"
+hfl_docker_image_matches_platform redis:alpine linux/amd64
+rm -f "${HFL_DOCKER_TEST_STATE}/local-index"
+
+touch "${HFL_DOCKER_TEST_STATE}/legacy-local"
+hfl_docker_image_matches_platform redis:alpine linux/amd64
+rm -f "${HFL_DOCKER_TEST_STATE}/legacy-local"
 
 digest="sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 source_ref="nginx:stable-alpine@${digest}"


### PR DESCRIPTION
## Summary

- fail early with an actionable Homebrew Bash requirement on macOS
- inspect Docker OCI indexes for the requested platform with a legacy fallback
- ignore the development installer lock file

## Testing

- `/bin/bash -n dev/stack.sh tools/lib/docker-images.sh tools/quality/test-docker-image-digest-alias.sh`
- `/bin/bash tools/quality/test-docker-image-digest-alias.sh`
- `/bin/bash ./dev/stack.sh --print-config`
- manual local stack update and health verification