### PR TITLE
fix(i18n): normalize language pack runtime permissions

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -290,7 +290,7 @@ services:
       test:
         [
           "CMD-SHELL",
-          "nginx -t >/dev/null 2>&1 && wget --no-check-certificate -qO- https://127.0.0.1:11443/health/ready >/dev/null && wget --no-check-certificate -qO- https://127.0.0.1:11443/locales/installed.json >/dev/null && wget --no-check-certificate -qO- https://127.0.0.1:11442/health >/dev/null",
+          "nginx -t >/dev/null 2>&1 && wget --no-check-certificate -qO- https://127.0.0.1:11443/health/ready >/dev/null && sh /etc/nginx/snippets/check-language-packs.sh && wget --no-check-certificate -qO- https://127.0.0.1:11442/health >/dev/null",
         ]
       interval: 5s
       timeout: 3s

--- a/deploy/installer/install.sh
+++ b/deploy/installer/install.sh
@@ -4631,6 +4631,16 @@ recover_interrupted_language_pack_activations() {
 	done
 }
 
+normalize_language_pack_runtime_permissions() {
+	local pack_root=$1
+	[[ -d "${pack_root}" && ! -L "${pack_root}" ]] || return 1
+	# Language packs are immutable runtime catalogs mounted read-only into the
+	# API and Nginx containers. Do not inherit the invoking user's umask: Nginx
+	# workers must be able to traverse directories and read every catalog.
+	find "${pack_root}" -type d -exec chmod 0755 {} + || return 1
+	find "${pack_root}" -type f -exec chmod 0644 {} + || return 1
+}
+
 activate_language_pack_archive() {
 	local archive=$1 app_version=$2 language_root=${3:-$(language_pack_version_root "$2")}
 	local temp_dir validation_output pack_id pack_source incoming target backup
@@ -4661,8 +4671,16 @@ activate_language_pack_archive() {
 	backup="${language_root}/.backup-${pack_id}-$$"
 
 	safe_rm_dir "${incoming}"
-	mkdir -p "${incoming}"
-	cp -a "${pack_source}/." "${incoming}/"
+	if ! mkdir -p "${incoming}" || ! cp -a "${pack_source}/." "${incoming}/"; then
+		safe_rm_dir "${incoming}"
+		safe_rm_dir "${temp_dir}"
+		die "failed to stage language pack ${pack_id}"
+	fi
+	if ! normalize_language_pack_runtime_permissions "${incoming}"; then
+		safe_rm_dir "${incoming}"
+		safe_rm_dir "${temp_dir}"
+		die "failed to normalize runtime permissions for language pack ${pack_id}"
+	fi
 	if [[ -e "${target}" ]]; then
 		mv "${target}" "${backup}"
 	fi

--- a/deploy/nginx/snippets/check-language-packs.sh
+++ b/deploy/nginx/snippets/check-language-packs.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+set -eu
+
+language_root="${HFL_LANGUAGE_PACK_HEALTH_ROOT:-/opt/hyperfilelens/lang-packs}"
+base_url="${HFL_LANGUAGE_PACK_HEALTH_BASE_URL:-https://127.0.0.1:11443}"
+
+wget --no-check-certificate --spider -q "${base_url}/locales/installed.json"
+for pack_dir in "${language_root}"/*; do
+	[ -d "${pack_dir}" ] || continue
+	pack_id="${pack_dir##*/}"
+	messages="${pack_dir}/frontend/messages.json"
+	components="${pack_dir}/frontend/element-plus.json"
+	[ -f "${messages}" ] || exit 1
+	wget --no-check-certificate --spider -q \
+		"${base_url}/locales/${pack_id}/frontend/messages.json"
+	if [ -f "${components}" ]; then
+		wget --no-check-certificate --spider -q \
+			"${base_url}/locales/${pack_id}/frontend/element-plus.json"
+	fi
+done

--- a/dev/stack.sh
+++ b/dev/stack.sh
@@ -1288,7 +1288,7 @@ cmd_status() {
 }
 
 cmd_doctor() {
-	local failures=0 command image mode
+	local failures=0 command image mode invalid_language_path
 	ensure_env_file
 	apply_mirror_env_defaults
 	for command in docker go python3 openssl timeout flock gzip sha256sum realpath; do
@@ -1318,10 +1318,27 @@ cmd_doctor() {
 	if [[ -d "${ROOT}/data/lang-packs" ]]; then
 		local language_root="${ROOT}/data/lang-packs/versions/$(read_project_version)"
 		mode="$(stat -c '%a' "${ROOT}/data/lang-packs")"
-		if [[ "${mode}" =~ ^(755|775|777)$ && -r "${language_root}/installed.json" ]]; then
+		invalid_language_path="$(
+			find "${ROOT}/data/lang-packs" "${ROOT}/data/lang-packs/versions" \
+				"${language_root}" -maxdepth 0 -type d ! -perm 0755 \
+				-print -quit 2>/dev/null || true
+		)"
+		if [[ -z "${invalid_language_path}" ]]; then
+			invalid_language_path="$(
+				find "${language_root}" -mindepth 1 \
+				\( \( -type d ! -perm 0755 \) -o \( -type f ! -perm 0644 \) \) \
+					-print -quit 2>/dev/null || true
+			)"
+		fi
+		if [[ "${mode}" == "755" \
+			&& -r "${language_root}/installed.json" \
+			&& -z "${invalid_language_path}" ]]; then
 			printf 'ok      language packs mode=%s manifest=readable\n' "${mode}"
 		else
-			printf 'invalid language packs mode=%s or manifest unreadable (run up)\n' "${mode}"
+			printf 'invalid language packs mode=%s, manifest, or catalog permissions (run up)\n' \
+				"${mode}"
+			[[ -z "${invalid_language_path}" ]] \
+				|| printf 'invalid language pack path %s\n' "${invalid_language_path}"
 			failures=$((failures + 1))
 		fi
 	else

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -263,7 +263,7 @@ services:
       test:
         [
           "CMD-SHELL",
-          "nginx -t >/dev/null 2>&1 && wget --no-check-certificate -qO- https://127.0.0.1:11443/health >/dev/null && wget --no-check-certificate -qO- https://127.0.0.1:11443/locales/installed.json >/dev/null && wget --no-check-certificate -qO- https://127.0.0.1:11443/ >/dev/null && wget --no-check-certificate -qO- https://127.0.0.1:11442/en/ >/dev/null",
+          "nginx -t >/dev/null 2>&1 && wget --no-check-certificate -qO- https://127.0.0.1:11443/health >/dev/null && sh /etc/nginx/snippets/check-language-packs.sh && wget --no-check-certificate -qO- https://127.0.0.1:11443/ >/dev/null && wget --no-check-certificate -qO- https://127.0.0.1:11442/en/ >/dev/null",
         ]
       interval: 5s
       timeout: 3s

--- a/release/build.sh
+++ b/release/build.sh
@@ -1252,6 +1252,8 @@ validate_release_publish_artifacts() {
 		|| die "release package missing internal Web pool configuration"
 	[[ -f "${pkg_root}/deploy/nginx/snippets/hfl-active-upstreams.conf" ]] \
 		|| die "release package missing blue/green upstream configuration"
+	[[ -f "${pkg_root}/deploy/nginx/snippets/check-language-packs.sh" ]] \
+		|| die "release package missing language-pack health check"
 	[[ -f "${pkg_root}/deploy/blue-green/active-color" ]] \
 		|| die "release package missing blue/green initial state"
 	[[ -d "${releases}" && -n "$(ls -A "${releases}" 2>/dev/null)" ]] \

--- a/release/ci/verify-release.sh
+++ b/release/ci/verify-release.sh
@@ -198,6 +198,10 @@ PY
 )
 openssl verify -CAfile "${pkg_root}/deploy/nginx/certs/root-ca.crt" \
 	"${pkg_root}/deploy/nginx/certs/tls.crt" >/dev/null
+[[ -f "${pkg_root}/deploy/nginx/snippets/check-language-packs.sh" ]] || {
+	printf 'ERROR: release package is missing the language-pack health check\n' >&2
+	exit 1
+}
 
 artifact_channel="$(python3 - "${pkg_root}/MANIFEST.json" <<'PY'
 import json

--- a/tools/quality/test-bundled-language-pack-lifecycle.sh
+++ b/tools/quality/test-bundled-language-pack-lifecycle.sh
@@ -55,17 +55,35 @@ with tarfile.open(archive, "w:gz") as package:
     for name, content in files.items():
         member = tarfile.TarInfo(name)
         member.size = len(content)
-        member.mode = 0o644
+        # Runtime permissions must not trust archive metadata or caller umask.
+        member.mode = 0o600
         package.addfile(member, io.BytesIO(content))
 PY
 
+original_umask="$(umask)"
+umask 0077
 ensure_data_dirs
 sync_bundled_language_packs
+umask "${original_umask}"
 language_base="${ROOT}/data/lang-packs"
 language_root="${language_base}/versions/1.2.3"
 [[ -f "${language_root}/zh-hans/manifest.json" ]]
 [[ -f "${language_root}/fr/manifest.json" ]]
 [[ -f "${language_root}/.legacy-flat-layout-reviewed" ]]
+
+python3 - "${language_root}/zh-hans" <<'PY'
+import pathlib
+import stat
+import sys
+
+pack_root = pathlib.Path(sys.argv[1])
+for path in [pack_root, *pack_root.rglob("*")]:
+    mode = stat.S_IMODE(path.stat().st_mode)
+    if path.is_dir():
+        assert mode == 0o755, (path, oct(mode))
+    elif path.is_file():
+        assert mode == 0o644, (path, oct(mode))
+PY
 
 mv "${language_root}/zh-hans" "${language_root}/.backup-zh-hans-100"
 mkdir -p "${language_root}/.incoming-zh-hans-100"
@@ -169,6 +187,38 @@ jq -e 'length == 0' "${language_root}/zh-hans/frontend/messages.json" >/dev/null
 rm -f "${ROOT}/payload/language-packs/hyperfilelens-lang-zz-1.2.3.tar.gz"
 sync_bundled_language_packs
 jq -e '.revision == 2' "${language_root}/zh-hans/frontend/messages.json" >/dev/null
+
+# A permission-normalization failure must stop before the current package is
+# replaced. This also guards explicit error propagation when the activation
+# function is invoked from an if-condition, where Bash errexit is suppressed.
+permission_mock_bin="${test_root}/permission-mock-bin"
+mkdir -p "${permission_mock_bin}"
+cat >"${permission_mock_bin}/chmod" <<'SH'
+#!/bin/sh
+if [ "${1:-}" = "0755" ]; then
+	exit 1
+fi
+exec /bin/chmod "$@"
+SH
+chmod +x "${permission_mock_bin}/chmod"
+before_permission_failure_hash="$(
+	sha256sum "${language_root}/zh-hans/frontend/messages.json"
+)"
+if (
+	PATH="${permission_mock_bin}:${PATH}" activate_language_pack_archive \
+		"${ROOT}/payload/language-packs/hyperfilelens-lang-zh-hans-1.2.3.tar.gz" \
+		1.2.3 "${language_root}"
+) >/dev/null 2>&1; then
+	printf 'ERROR: language pack activation ignored a permission failure\n' >&2
+	exit 1
+fi
+[[ "$(sha256sum "${language_root}/zh-hans/frontend/messages.json")" \
+	== "${before_permission_failure_hash}" ]]
+if find "${language_root}" -mindepth 1 -maxdepth 1 \
+	\( -name '.extract-*' -o -name '.incoming-*' \) -print -quit | grep -q .; then
+	printf 'ERROR: permission failure left language-pack activation residue\n' >&2
+	exit 1
+fi
 
 # Simulate termination after the installed package was moved to the collection
 # backup but before its replacement was promoted. The next sync must restore a

--- a/tools/quality/test-language-pack-runtime-index.sh
+++ b/tools/quality/test-language-pack-runtime-index.sh
@@ -72,12 +72,74 @@ assert stat.S_IMODE(index_path.stat().st_mode) == 0o644
 PY
 
 for compose_file in docker-compose.yml deploy/docker-compose.yml; do
-	grep -F 'https://127.0.0.1:11443/locales/installed.json' \
+	grep -F 'sh /etc/nginx/snippets/check-language-packs.sh' \
 		"${ROOT_REPO}/${compose_file}" >/dev/null
 	grep -F './data/lang-packs/versions/${HFL_PRODUCT_VERSION:-latest}' \
 		"${ROOT_REPO}/${compose_file}" >/dev/null
 done
+health_root="${tmp}/health-root"
+mock_bin="${tmp}/mock-bin"
+wget_log="${tmp}/wget.log"
+mkdir -p \
+	"${health_root}/fr/frontend" \
+	"${health_root}/zh-hans/frontend" \
+	"${mock_bin}"
+printf '%s\n' '{}' >"${health_root}/installed.json"
+printf '%s\n' '{}' >"${health_root}/fr/frontend/messages.json"
+printf '%s\n' '{}' >"${health_root}/zh-hans/frontend/messages.json"
+printf '%s\n' '{}' >"${health_root}/zh-hans/frontend/element-plus.json"
+cat >"${mock_bin}/wget" <<'SH'
+#!/bin/sh
+for argument do
+	url="${argument}"
+done
+printf '%s\n' "${url}" >>"${HFL_TEST_WGET_LOG}"
+if [ "${HFL_TEST_WGET_FAIL_URL:-}" = "${url}" ]; then
+	exit 1
+fi
+SH
+chmod +x "${mock_bin}/wget"
+empty_health_root="${tmp}/empty-health-root"
+empty_wget_log="${tmp}/empty-wget.log"
+mkdir -p "${empty_health_root}"
+printf '%s\n' '{}' >"${empty_health_root}/installed.json"
+HFL_LANGUAGE_PACK_HEALTH_ROOT="${empty_health_root}" \
+	HFL_LANGUAGE_PACK_HEALTH_BASE_URL=https://language-pack.test \
+	HFL_TEST_WGET_LOG="${empty_wget_log}" \
+	PATH="${mock_bin}:${PATH}" \
+	sh "${ROOT_REPO}/deploy/nginx/snippets/check-language-packs.sh"
+[[ "$(wc -l <"${empty_wget_log}")" -eq 1 ]]
+grep -Fx 'https://language-pack.test/locales/installed.json' \
+	"${empty_wget_log}" >/dev/null
+HFL_LANGUAGE_PACK_HEALTH_ROOT="${health_root}" \
+	HFL_LANGUAGE_PACK_HEALTH_BASE_URL=https://language-pack.test \
+	HFL_TEST_WGET_LOG="${wget_log}" \
+	PATH="${mock_bin}:${PATH}" \
+	sh "${ROOT_REPO}/deploy/nginx/snippets/check-language-packs.sh"
+grep -Fx 'https://language-pack.test/locales/installed.json' "${wget_log}" >/dev/null
+grep -Fx 'https://language-pack.test/locales/fr/frontend/messages.json' \
+	"${wget_log}" >/dev/null
+if grep -Fx 'https://language-pack.test/locales/fr/frontend/element-plus.json' \
+	"${wget_log}" >/dev/null; then
+	printf 'ERROR: language-pack health check required an absent optional component catalog\n' >&2
+	exit 1
+fi
+grep -Fx 'https://language-pack.test/locales/zh-hans/frontend/messages.json' \
+	"${wget_log}" >/dev/null
+grep -Fx 'https://language-pack.test/locales/zh-hans/frontend/element-plus.json' \
+	"${wget_log}" >/dev/null
+if HFL_LANGUAGE_PACK_HEALTH_ROOT="${health_root}" \
+	HFL_LANGUAGE_PACK_HEALTH_BASE_URL=https://language-pack.test \
+	HFL_TEST_WGET_LOG="${wget_log}" \
+	HFL_TEST_WGET_FAIL_URL=https://language-pack.test/locales/zh-hans/frontend/messages.json \
+	PATH="${mock_bin}:${PATH}" \
+	sh "${ROOT_REPO}/deploy/nginx/snippets/check-language-packs.sh" >/dev/null 2>&1; then
+	printf 'ERROR: language-pack health check ignored an unreadable message catalog\n' >&2
+	exit 1
+fi
 grep -F '"app_version"' \
 	"${ROOT_REPO}/dev/stack.sh" >/dev/null
+grep -F '! -perm 0755' "${ROOT_REPO}/dev/stack.sh" >/dev/null
+grep -F '! -perm 0644' "${ROOT_REPO}/dev/stack.sh" >/dev/null
 
 printf 'Language-pack runtime index checks passed.\n'


### PR DESCRIPTION
## Summary
- normalize installed language-pack directories and catalogs to deterministic runtime permissions
- verify every installed frontend catalog from the shared Nginx health check
- include the health-check contract in Community and Enterprise release validation

## Tests
- language-pack runtime index and lifecycle regressions
- development upgrade, release upgrade transaction, and blue-green recovery regressions
- Community and Enterprise synthetic release assembly
- release contracts, English source boundary, Shell syntax, and diff checks