### PR TITLE
Clean up frontend lint and bundle loading

### DIFF
--- a/src/frontend/eslint.config.js
+++ b/src/frontend/eslint.config.js
@@ -23,6 +23,16 @@ export default tseslint.config(
     },
   },
   {
+    // Tests intentionally colocate small inline Vue stubs. Production prop
+    // contracts are enforced in maintained components, not throwaway stubs.
+    files: ['**/*.{test,spec}.ts'],
+    rules: {
+      'vue/one-component-per-file': 'off',
+      'vue/require-default-prop': 'off',
+      'vue/require-prop-types': 'off',
+    },
+  },
+  {
     languageOptions: {
       globals: {
         ...globals.browser,

--- a/src/frontend/src/app/layout/AppShell.vue
+++ b/src/frontend/src/app/layout/AppShell.vue
@@ -506,7 +506,10 @@ function applyThemeVars(t: string) {
       :timezone-offset-display="timezoneOffsetDisplay"
       @toggle-locale="toggleLocale"
     />
-    <div v-if="supportOrgKey" class="support-banner">
+    <div
+      v-if="supportOrgKey"
+      class="support-banner"
+    >
       {{ t('common.supportModeBanner', { org: supportOrgKey }) }}
     </div>
     <main class="content-wrapper">
@@ -546,32 +549,32 @@ function applyThemeVars(t: string) {
                   aria-hidden="true"
                 >
                   <div class="app-route-generic-skeleton__header">
-                    <span class="app-route-generic-skeleton__back"></span>
+                    <span class="app-route-generic-skeleton__back" />
                     <div class="app-route-generic-skeleton__title-group">
-                      <span></span>
-                      <i></i>
+                      <span />
+                      <i />
                     </div>
                   </div>
                   <div class="app-route-generic-skeleton__body">
                     <section class="app-route-generic-skeleton__section app-route-generic-skeleton__section--hero">
-                      <span></span>
-                      <i></i>
-                      <b></b>
+                      <span />
+                      <i />
+                      <b />
                     </section>
                     <section
                       v-for="idx in 3"
                       :key="`generic-section-${idx}`"
                       class="app-route-generic-skeleton__section"
                     >
-                      <span></span>
-                      <i></i>
-                      <i></i>
-                      <b></b>
+                      <span />
+                      <i />
+                      <i />
+                      <b />
                     </section>
                   </div>
                   <div class="app-route-generic-skeleton__footer">
-                    <span></span>
-                    <i></i>
+                    <span />
+                    <i />
                   </div>
                 </div>
                 <div
@@ -580,226 +583,326 @@ function applyThemeVars(t: string) {
                   aria-hidden="true"
                 >
                   <div class="app-route-skeleton__header">
-                    <span class="app-route-skeleton__title"></span>
+                    <span class="app-route-skeleton__title" />
                     <div class="app-route-skeleton__actions">
-                      <span></span>
-                      <span></span>
+                      <span />
+                      <span />
                     </div>
                   </div>
                   <div class="app-route-flow-skeleton__steps">
-                    <template v-for="idx in 3" :key="`flow-step-${idx}`">
+                    <template
+                      v-for="idx in 3"
+                      :key="`flow-step-${idx}`"
+                    >
                       <span class="app-route-flow-skeleton__step">
-                        <i></i>
-                        <b></b>
-                        <em></em>
-                        <small></small>
+                        <i />
+                        <b />
+                        <em />
+                        <small />
                       </span>
-                      <span v-if="idx < 3" class="app-route-flow-skeleton__connector"></span>
+                      <span
+                        v-if="idx < 3"
+                        class="app-route-flow-skeleton__connector"
+                      />
                     </template>
                   </div>
                   <div class="app-route-skeleton__panel app-route-flow-skeleton__panel">
                     <div class="app-route-skeleton__toolbar">
-                      <span></span>
-                      <i></i>
+                      <span />
+                      <i />
                     </div>
                     <div class="app-route-skeleton__table">
-                      <span v-for="idx in 8" :key="`flow-row-${idx}`">
-                        <i></i>
-                        <i></i>
-                        <i></i>
-                        <i></i>
+                      <span
+                        v-for="idx in 8"
+                        :key="`flow-row-${idx}`"
+                      >
+                        <i />
+                        <i />
+                        <i />
+                        <i />
                       </span>
                     </div>
                   </div>
                 </div>
-                <div v-else-if="fallbackIsDashboard" class="app-route-skeleton app-route-dashboard-skeleton" aria-hidden="true">
+                <div
+                  v-else-if="fallbackIsDashboard"
+                  class="app-route-skeleton app-route-dashboard-skeleton"
+                  aria-hidden="true"
+                >
                   <div class="app-route-dashboard-skeleton__pipeline">
                     <div class="app-route-dashboard-skeleton__pipeline-head">
-                      <span></span>
-                      <i></i>
+                      <span />
+                      <i />
                     </div>
                     <div class="app-route-dashboard-skeleton__pipeline-flow">
-                      <template v-for="idx in 3" :key="`dashboard-pipeline-${idx}`">
+                      <template
+                        v-for="idx in 3"
+                        :key="`dashboard-pipeline-${idx}`"
+                      >
                         <span class="app-route-dashboard-skeleton__pipeline-step">
-                          <i></i>
-                          <b></b>
-                          <em></em>
-                          <small></small>
+                          <i />
+                          <b />
+                          <em />
+                          <small />
                         </span>
-                        <span v-if="idx < 3" class="app-route-dashboard-skeleton__pipeline-connector"></span>
+                        <span
+                          v-if="idx < 3"
+                          class="app-route-dashboard-skeleton__pipeline-connector"
+                        />
                       </template>
                     </div>
                   </div>
                   <div class="app-route-dashboard-skeleton__grid">
-                    <span v-for="idx in 3" :key="`dashboard-card-${idx}`" class="app-route-dashboard-skeleton__card">
-                      <i></i>
-                      <b></b>
-                      <em></em>
+                    <span
+                      v-for="idx in 3"
+                      :key="`dashboard-card-${idx}`"
+                      class="app-route-dashboard-skeleton__card"
+                    >
+                      <i />
+                      <b />
+                      <em />
                     </span>
                   </div>
                   <div class="app-route-dashboard-skeleton__cockpit">
                     <span class="app-route-dashboard-skeleton__panel app-route-dashboard-skeleton__panel--attention">
-                      <i></i>
-                      <b v-for="idx in 5" :key="`dashboard-attention-${idx}`"></b>
+                      <i />
+                      <b
+                        v-for="idx in 5"
+                        :key="`dashboard-attention-${idx}`"
+                      />
                     </span>
                     <span class="app-route-dashboard-skeleton__panel app-route-dashboard-skeleton__panel--storage">
-                      <i></i>
-                      <b v-for="idx in 4" :key="`dashboard-storage-${idx}`"></b>
+                      <i />
+                      <b
+                        v-for="idx in 4"
+                        :key="`dashboard-storage-${idx}`"
+                      />
                     </span>
                     <span class="app-route-dashboard-skeleton__panel app-route-dashboard-skeleton__panel--quota">
-                      <i></i>
-                      <b v-for="idx in 4" :key="`dashboard-quota-${idx}`"></b>
+                      <i />
+                      <b
+                        v-for="idx in 4"
+                        :key="`dashboard-quota-${idx}`"
+                      />
                     </span>
                     <span class="app-route-dashboard-skeleton__panel app-route-dashboard-skeleton__panel--running">
-                      <i></i>
-                      <b v-for="idx in 4" :key="`dashboard-running-${idx}`"></b>
+                      <i />
+                      <b
+                        v-for="idx in 4"
+                        :key="`dashboard-running-${idx}`"
+                      />
                     </span>
                     <span class="app-route-dashboard-skeleton__panel app-route-dashboard-skeleton__panel--chart">
-                      <i></i>
-                      <em v-for="idx in 7" :key="`dashboard-chart-${idx}`"></em>
+                      <i />
+                      <em
+                        v-for="idx in 7"
+                        :key="`dashboard-chart-${idx}`"
+                      />
                     </span>
                   </div>
                 </div>
-                <div v-else-if="fallbackIsHostMonitor" class="app-route-skeleton app-route-monitor-skeleton" aria-hidden="true">
+                <div
+                  v-else-if="fallbackIsHostMonitor"
+                  class="app-route-skeleton app-route-monitor-skeleton"
+                  aria-hidden="true"
+                >
                   <div class="app-route-skeleton__header">
-                    <span class="app-route-skeleton__title"></span>
+                    <span class="app-route-skeleton__title" />
                     <div class="app-route-skeleton__actions">
-                      <span></span>
-                      <span></span>
+                      <span />
+                      <span />
                     </div>
                   </div>
                   <div class="app-route-skeleton__stats">
-                    <span v-for="idx in 4" :key="`monitor-kpi-${idx}`" class="app-route-skeleton__stat">
-                      <i></i>
-                      <b></b>
-                      <em></em>
+                    <span
+                      v-for="idx in 4"
+                      :key="`monitor-kpi-${idx}`"
+                      class="app-route-skeleton__stat"
+                    >
+                      <i />
+                      <b />
+                      <em />
                     </span>
                   </div>
                   <div class="app-route-monitor-skeleton__charts">
-                    <span v-for="idx in 4" :key="`monitor-chart-${idx}`" class="app-route-monitor-skeleton__chart">
-                      <i></i>
-                      <b></b>
+                    <span
+                      v-for="idx in 4"
+                      :key="`monitor-chart-${idx}`"
+                      class="app-route-monitor-skeleton__chart"
+                    >
+                      <i />
+                      <b />
                     </span>
                   </div>
                   <div class="app-route-monitor-skeleton__charts app-route-monitor-skeleton__charts--pair">
-                    <span v-for="idx in 2" :key="`monitor-wide-chart-${idx}`" class="app-route-monitor-skeleton__chart">
-                      <i></i>
-                      <b></b>
+                    <span
+                      v-for="idx in 2"
+                      :key="`monitor-wide-chart-${idx}`"
+                      class="app-route-monitor-skeleton__chart"
+                    >
+                      <i />
+                      <b />
                     </span>
                   </div>
                 </div>
-                <div v-else-if="fallbackIsCopilot" class="app-route-skeleton app-route-copilot-skeleton" aria-hidden="true">
+                <div
+                  v-else-if="fallbackIsCopilot"
+                  class="app-route-skeleton app-route-copilot-skeleton"
+                  aria-hidden="true"
+                >
                   <aside class="app-route-copilot-skeleton__aside">
-                    <span></span>
-                    <i v-for="idx in 7" :key="`copilot-session-${idx}`"></i>
+                    <span />
+                    <i
+                      v-for="idx in 7"
+                      :key="`copilot-session-${idx}`"
+                    />
                   </aside>
                   <section class="app-route-copilot-skeleton__main">
                     <div class="app-route-copilot-skeleton__topbar">
-                      <span></span>
-                      <i></i>
+                      <span />
+                      <i />
                     </div>
                     <div class="app-route-copilot-skeleton__messages">
-                      <span class="app-route-copilot-skeleton__bubble app-route-copilot-skeleton__bubble--ai"></span>
-                      <span class="app-route-copilot-skeleton__bubble app-route-copilot-skeleton__bubble--user"></span>
-                      <span class="app-route-copilot-skeleton__bubble app-route-copilot-skeleton__bubble--ai app-route-copilot-skeleton__bubble--long"></span>
+                      <span class="app-route-copilot-skeleton__bubble app-route-copilot-skeleton__bubble--ai" />
+                      <span class="app-route-copilot-skeleton__bubble app-route-copilot-skeleton__bubble--user" />
+                      <span class="app-route-copilot-skeleton__bubble app-route-copilot-skeleton__bubble--ai app-route-copilot-skeleton__bubble--long" />
                     </div>
-                    <div class="app-route-copilot-skeleton__composer"></div>
+                    <div class="app-route-copilot-skeleton__composer" />
                   </section>
                 </div>
-                <div v-else-if="fallbackIsAccountProfile" class="app-route-skeleton app-route-profile-skeleton" aria-hidden="true">
+                <div
+                  v-else-if="fallbackIsAccountProfile"
+                  class="app-route-skeleton app-route-profile-skeleton"
+                  aria-hidden="true"
+                >
                   <div class="app-route-skeleton__header">
-                    <span class="app-route-skeleton__title"></span>
+                    <span class="app-route-skeleton__title" />
                   </div>
-                  <section v-for="idx in 3" :key="`profile-section-${idx}`" class="app-route-profile-skeleton__section">
-                    <span></span>
-                    <i v-for="row in idx === 2 ? 4 : 3" :key="`profile-row-${idx}-${row}`"></i>
+                  <section
+                    v-for="idx in 3"
+                    :key="`profile-section-${idx}`"
+                    class="app-route-profile-skeleton__section"
+                  >
+                    <span />
+                    <i
+                      v-for="row in idx === 2 ? 4 : 3"
+                      :key="`profile-row-${idx}-${row}`"
+                    />
                   </section>
                 </div>
-                <div v-else-if="fallbackIsNodeSubscription" class="app-route-skeleton app-route-subscription-skeleton" aria-hidden="true">
+                <div
+                  v-else-if="fallbackIsNodeSubscription"
+                  class="app-route-skeleton app-route-subscription-skeleton"
+                  aria-hidden="true"
+                >
                   <section class="app-route-subscription-skeleton__section app-route-subscription-skeleton__section--overview">
                     <div class="app-route-subscription-skeleton__section-head">
-                      <span></span>
-                      <i></i>
+                      <span />
+                      <i />
                     </div>
                     <div class="app-route-subscription-skeleton__overview-grid">
-                      <b v-for="idx in 4" :key="`subscription-overview-${idx}`"></b>
+                      <b
+                        v-for="idx in 4"
+                        :key="`subscription-overview-${idx}`"
+                      />
                     </div>
                   </section>
                   <section class="app-route-subscription-skeleton__section">
                     <div class="app-route-subscription-skeleton__section-head">
-                      <span></span>
+                      <span />
                     </div>
                     <div class="app-route-subscription-skeleton__quota-grid">
-                      <b v-for="idx in 4" :key="`subscription-quota-${idx}`"></b>
+                      <b
+                        v-for="idx in 4"
+                        :key="`subscription-quota-${idx}`"
+                      />
                     </div>
                   </section>
                   <section class="app-route-subscription-skeleton__section app-route-subscription-skeleton__section--activation">
                     <div class="app-route-subscription-skeleton__section-head">
-                      <span></span>
+                      <span />
                     </div>
                     <div class="app-route-subscription-skeleton__activation">
                       <div class="app-route-subscription-skeleton__activation-step">
-                        <span></span>
+                        <span />
                         <div class="app-route-subscription-skeleton__code-row">
-                          <i></i>
-                          <b></b>
+                          <i />
+                          <b />
                         </div>
-                        <em></em>
+                        <em />
                       </div>
                       <div class="app-route-subscription-skeleton__activation-step">
-                        <span></span>
-                        <i></i>
-                        <b></b>
+                        <span />
+                        <i />
+                        <b />
                       </div>
                     </div>
                   </section>
                   <section class="app-route-subscription-skeleton__section app-route-subscription-skeleton__section--history">
                     <div class="app-route-subscription-skeleton__section-head">
-                      <span></span>
+                      <span />
                     </div>
                     <div class="app-route-skeleton__panel">
                       <div class="app-route-skeleton__table">
-                        <span v-for="idx in 5" :key="`subscription-history-${idx}`">
-                          <i></i>
-                          <i></i>
-                          <i></i>
-                          <i></i>
+                        <span
+                          v-for="idx in 5"
+                          :key="`subscription-history-${idx}`"
+                        >
+                          <i />
+                          <i />
+                          <i />
+                          <i />
                         </span>
                       </div>
                     </div>
                   </section>
                 </div>
-                <div v-else-if="fallbackIsNodeSystem" class="app-route-skeleton app-route-system-skeleton" aria-hidden="true">
+                <div
+                  v-else-if="fallbackIsNodeSystem"
+                  class="app-route-skeleton app-route-system-skeleton"
+                  aria-hidden="true"
+                >
                   <div class="app-route-system-skeleton__panel">
-                    <section v-for="idx in 2" :key="`system-row-${idx}`" class="app-route-system-skeleton__row">
-                      <span></span>
-                      <b></b>
-                      <i></i>
+                    <section
+                      v-for="idx in 2"
+                      :key="`system-row-${idx}`"
+                      class="app-route-system-skeleton__row"
+                    >
+                      <span />
+                      <b />
+                      <i />
                     </section>
                   </div>
                   <div class="app-route-system-skeleton__footer">
-                    <span></span>
+                    <span />
                   </div>
                 </div>
-                <div v-else class="app-route-skeleton" aria-hidden="true">
+                <div
+                  v-else
+                  class="app-route-skeleton"
+                  aria-hidden="true"
+                >
                   <div class="app-route-skeleton__header">
-                    <span class="app-route-skeleton__title"></span>
+                    <span class="app-route-skeleton__title" />
                     <div class="app-route-skeleton__actions">
-                      <span></span>
-                      <span></span>
+                      <span />
+                      <span />
                     </div>
                   </div>
                   <div class="app-route-skeleton__panel">
                     <div class="app-route-skeleton__toolbar">
-                      <span></span>
-                      <i></i>
+                      <span />
+                      <i />
                     </div>
                     <div class="app-route-skeleton__table">
-                      <span v-for="idx in 8" :key="`row-${idx}`">
-                        <i></i>
-                        <i></i>
-                        <i></i>
-                        <i></i>
+                      <span
+                        v-for="idx in 8"
+                        :key="`row-${idx}`"
+                      >
+                        <i />
+                        <i />
+                        <i />
+                        <i />
                       </span>
                     </div>
                   </div>

--- a/src/frontend/src/app/layout/TopNav.vue
+++ b/src/frontend/src/app/layout/TopNav.vue
@@ -61,10 +61,18 @@ function handleNavClick(event: MouseEvent, to: string) {
       :aria-expanded="mobileMenuOpen || false"
       @click="emit('toggle-mobile-menu')"
     >
-      <Menu :size="21" aria-hidden="true" />
+      <Menu
+        :size="21"
+        aria-hidden="true"
+      />
     </button>
 
-    <button type="button" class="logo" :aria-label="t('nav.overview')" @click="navigateImmediately('/')">
+    <button
+      type="button"
+      class="logo"
+      :aria-label="t('nav.overview')"
+      @click="navigateImmediately('/')"
+    >
       <AppLogoMark :size="18" />
       <span class="logo-text"><span>Hyper</span><strong>FileLens</strong></span>
     </button>
@@ -103,8 +111,8 @@ function handleNavClick(event: MouseEvent, to: string) {
         class="icon-btn desktop-navigation-control"
         :title="t('nav.switchLanguage', { language: nextLocaleLabel })"
         :aria-label="t('nav.switchLanguage', { language: nextLocaleLabel })"
-        @click="emit('toggle-locale')"
         text
+        @click="emit('toggle-locale')"
       >
         <Globe :size="16" />
       </ElButton>
@@ -120,7 +128,10 @@ function handleNavClick(event: MouseEvent, to: string) {
         target="_blank"
         rel="noopener noreferrer"
       >
-        <Shield :size="15" aria-hidden="true" />
+        <Shield
+          :size="15"
+          aria-hidden="true"
+        />
         <span>{{ t('nav.platformOps') }}</span>
       </a>
 

--- a/src/frontend/src/components/AlertPolicyTypeLabel.vue
+++ b/src/frontend/src/components/AlertPolicyTypeLabel.vue
@@ -14,5 +14,8 @@ const label = computed(() => policyTypeLabel(props.type))
 </script>
 
 <template>
-  <HflTypeLabel :icon="icon" :label="label" />
+  <HflTypeLabel
+    :icon="icon"
+    :label="label"
+  />
 </template>

--- a/src/frontend/src/components/BackupSourceResetDialogBody.vue
+++ b/src/frontend/src/components/BackupSourceResetDialogBody.vue
@@ -134,7 +134,10 @@ function sourceTypeText(row: BackupSourceUnregisterDisplayRow) {
               >
                 {{ row.statusLabel }}
               </ElTag>
-              <span v-else class="hfl-empty-mark">—</span>
+              <span
+                v-else
+                class="hfl-empty-mark"
+              >—</span>
             </template>
           </ElTableColumn>
           <ElTableColumn
@@ -143,7 +146,10 @@ function sourceTypeText(row: BackupSourceUnregisterDisplayRow) {
             align="right"
           >
             <template #default="{ row }">
-              <span class="hfl-flow-action-dialog__count tabular-nums" :class="{ 'hfl-empty-mark': row.snapshotCount == null }">
+              <span
+                class="hfl-flow-action-dialog__count tabular-nums"
+                :class="{ 'hfl-empty-mark': row.snapshotCount == null }"
+              >
                 {{ row.snapshotCount ?? '—' }}
               </span>
             </template>
@@ -153,7 +159,10 @@ function sourceTypeText(row: BackupSourceUnregisterDisplayRow) {
             width="150"
           >
             <template #default="{ row }">
-              <span class="hfl-table-cell-time" :class="{ 'hfl-empty-mark': !row.registeredAt || row.registeredAt === '—' }">
+              <span
+                class="hfl-table-cell-time"
+                :class="{ 'hfl-empty-mark': !row.registeredAt || row.registeredAt === '—' }"
+              >
                 {{ row.registeredAt || '—' }}
               </span>
             </template>

--- a/src/frontend/src/components/BackupSourceUnregisterDialogBody.vue
+++ b/src/frontend/src/components/BackupSourceUnregisterDialogBody.vue
@@ -29,8 +29,10 @@ const props = withDefaults(defineProps<{
   previousFailureSummary?: string
   previousFailureClickable?: boolean
 }>(), {
+  sources: () => [],
   showSnapshots: true,
   isStep3: false,
+  displayRisks: () => [],
   preflightLoading: false,
   preflightError: false,
   loading: false,
@@ -215,7 +217,10 @@ function reasonLabel(reason: Parameters<typeof unregisterReasonLabel>[0]) {
               >
                 {{ row.statusLabel }}
               </ElTag>
-              <span v-else class="hfl-empty-mark">—</span>
+              <span
+                v-else
+                class="hfl-empty-mark"
+              >—</span>
             </template>
           </ElTableColumn>
           <ElTableColumn
@@ -225,7 +230,10 @@ function reasonLabel(reason: Parameters<typeof unregisterReasonLabel>[0]) {
             align="right"
           >
             <template #default="{ row }">
-              <span class="hfl-flow-action-dialog__count tabular-nums" :class="{ 'hfl-empty-mark': row.snapshotCount == null }">
+              <span
+                class="hfl-flow-action-dialog__count tabular-nums"
+                :class="{ 'hfl-empty-mark': row.snapshotCount == null }"
+              >
                 {{ row.snapshotCount ?? '—' }}
               </span>
             </template>
@@ -235,7 +243,10 @@ function reasonLabel(reason: Parameters<typeof unregisterReasonLabel>[0]) {
             width="150"
           >
             <template #default="{ row }">
-              <span class="hfl-table-cell-time" :class="{ 'hfl-empty-mark': !row.registeredAt || row.registeredAt === '—' }">
+              <span
+                class="hfl-table-cell-time"
+                :class="{ 'hfl-empty-mark': !row.registeredAt || row.registeredAt === '—' }"
+              >
                 {{ row.registeredAt || '—' }}
               </span>
             </template>

--- a/src/frontend/src/components/DangerConfirmDialog.vue
+++ b/src/frontend/src/components/DangerConfirmDialog.vue
@@ -55,13 +55,30 @@ const props = withDefaults(
     beforeClose?: () => boolean | Promise<boolean>
   }>(),
   {
+    subtitle: '',
     level: 'high',
+    message: '',
+    warning: '',
+    items: undefined,
     maxItemRows: 5,
+    overflowLabel: '',
+    itemsHeading: '',
+    itemNameLabel: undefined,
+    itemStatusLabel: undefined,
+    itemDetailsLabel: undefined,
     confirmMode: 'single',
     confirmKeyword: 'DELETE',
+    confirmKeywordHint: '',
+    confirmKeywordPlaceholder: '',
+    irreversibleHint: '',
     irreversibleTone: 'danger',
+    cancelText: undefined,
+    confirmText: undefined,
     loading: false,
+    pendingText: undefined,
+    errorText: '',
     width: undefined,
+    beforeClose: undefined,
   },
 )
 
@@ -167,12 +184,26 @@ async function onDialogBeforeClose(done: () => void) {
   >
     <template #header>
       <div class="hfl-danger-confirm__header">
-        <div class="hfl-danger-confirm__icon" :class="accentClass" aria-hidden="true">
-          <component :is="Icon" :size="20" />
+        <div
+          class="hfl-danger-confirm__icon"
+          :class="accentClass"
+          aria-hidden="true"
+        >
+          <component
+            :is="Icon"
+            :size="20"
+          />
         </div>
         <div class="hfl-danger-confirm__titles">
-          <h2 class="hfl-danger-confirm__title">{{ title }}</h2>
-          <p v-if="subtitle" class="hfl-danger-confirm__subtitle">{{ subtitle }}</p>
+          <h2 class="hfl-danger-confirm__title">
+            {{ title }}
+          </h2>
+          <p
+            v-if="subtitle"
+            class="hfl-danger-confirm__subtitle"
+          >
+            {{ subtitle }}
+          </p>
         </div>
         <button
           type="button"
@@ -187,7 +218,10 @@ async function onDialogBeforeClose(done: () => void) {
     </template>
 
     <div class="hfl-danger-confirm__body">
-      <div v-if="pending" class="hfl-danger-confirm__pending">
+      <div
+        v-if="pending"
+        class="hfl-danger-confirm__pending"
+      >
         <LoaderCircle
           :size="18"
           class="hfl-danger-confirm__pending-icon"
@@ -195,21 +229,38 @@ async function onDialogBeforeClose(done: () => void) {
         <span>{{ pendingText ?? 'Checking dependencies...' }}</span>
       </div>
 
-      <div v-else-if="errorText" class="hfl-danger-confirm__error">
+      <div
+        v-else-if="errorText"
+        class="hfl-danger-confirm__error"
+      >
         <AlertTriangle :size="16" />
         <span>{{ errorText }}</span>
       </div>
 
       <template v-else>
-        <p v-if="message" class="hfl-danger-confirm__message">{{ message }}</p>
+        <p
+          v-if="message"
+          class="hfl-danger-confirm__message"
+        >
+          {{ message }}
+        </p>
 
-        <div v-if="warning" class="hfl-danger-confirm__warning">
+        <div
+          v-if="warning"
+          class="hfl-danger-confirm__warning"
+        >
           <AlertTriangle :size="16" />
           <span>{{ warning }}</span>
         </div>
 
-        <section v-if="hasItems" class="hfl-danger-confirm__items">
-          <header v-if="itemsHeading" class="hfl-danger-confirm__items-heading">
+        <section
+          v-if="hasItems"
+          class="hfl-danger-confirm__items"
+        >
+          <header
+            v-if="itemsHeading"
+            class="hfl-danger-confirm__items-heading"
+          >
             {{ itemsHeading }}
           </header>
           <div class="hfl-danger-confirm__item-table-scroll">
@@ -221,9 +272,15 @@ async function onDialogBeforeClose(done: () => void) {
               </colgroup>
               <thead>
                 <tr>
-                  <th scope="col">{{ itemNameLabel ?? 'Name' }}</th>
-                  <th scope="col">{{ itemStatusLabel ?? 'Status' }}</th>
-                  <th scope="col">{{ itemDetailsLabel ?? 'Details' }}</th>
+                  <th scope="col">
+                    {{ itemNameLabel ?? 'Name' }}
+                  </th>
+                  <th scope="col">
+                    {{ itemStatusLabel ?? 'Status' }}
+                  </th>
+                  <th scope="col">
+                    {{ itemDetailsLabel ?? 'Details' }}
+                  </th>
                 </tr>
               </thead>
               <tbody>
@@ -235,7 +292,10 @@ async function onDialogBeforeClose(done: () => void) {
                     class="hfl-danger-confirm__item-name-cell"
                     :class="{ 'hfl-danger-confirm__item-name-cell--full': !item.status }"
                   >
-                    <span class="hfl-danger-confirm__item-name" :title="item.name">{{ item.name }}</span>
+                    <span
+                      class="hfl-danger-confirm__item-name"
+                      :title="item.name"
+                    >{{ item.name }}</span>
                   </td>
                   <td class="hfl-danger-confirm__item-status-cell">
                     <span
@@ -290,7 +350,10 @@ async function onDialogBeforeClose(done: () => void) {
           {{ irreversibleHint }}
         </p>
 
-        <section v-if="needsKeyword" class="hfl-danger-confirm__keyword">
+        <section
+          v-if="needsKeyword"
+          class="hfl-danger-confirm__keyword"
+        >
           <ExactKeywordConfirmInput
             v-model="confirmInput"
             :keyword="confirmKeyword"
@@ -315,7 +378,10 @@ async function onDialogBeforeClose(done: () => void) {
           :confirm="onPrimary"
           :cancel="close"
         >
-          <ElButton :disabled="loading" @click="close">
+          <ElButton
+            :disabled="loading"
+            @click="close"
+          >
             {{ cancelText ?? 'Cancel' }}
           </ElButton>
           <ElButton

--- a/src/frontend/src/components/DangerConfirmDialogLayout.test.ts
+++ b/src/frontend/src/components/DangerConfirmDialogLayout.test.ts
@@ -1,5 +1,4 @@
 // @vitest-environment jsdom
-/* eslint-disable vue/one-component-per-file, vue/require-default-prop */
 
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
@@ -65,6 +64,23 @@ function functionSource(source: string, start: string, end: string) {
 }
 
 describe('Danger confirmation item layout', () => {
+  it('preserves built-in labels when optional copy is omitted', async () => {
+    const wrapper = mountDialog([{ name: 'proxy-01' }])
+
+    expect(wrapper.findAll('th').map(cell => cell.text())).toEqual([
+      'Name',
+      'Status',
+      'Details',
+    ])
+    expect(wrapper.get('.hfl-danger-confirm__close').attributes('aria-label')).toBe('Close')
+    expect(wrapper.get('.hfl-danger-confirm__footer').text()).toContain('Cancel')
+    expect(wrapper.get('.hfl-danger-confirm__footer').text()).toContain('Confirm')
+
+    await wrapper.setProps({ pending: true })
+    expect(wrapper.get('.hfl-danger-confirm__pending').text()).toContain('Checking dependencies...')
+    wrapper.unmount()
+  })
+
   it('keeps item-dialog width stable while asynchronous items load', async () => {
     const wrapper = mountDialog([])
     const itemWidth = 'min(600px, calc(100vw - 32px))'

--- a/src/frontend/src/components/HflCapacityCell.vue
+++ b/src/frontend/src/components/HflCapacityCell.vue
@@ -24,6 +24,7 @@ const props = withDefaults(
     showBar: true,
     showPercent: true,
     usedOnly: false,
+    unlimitedTotalLabel: '',
     knownTotal: null,
   },
 )
@@ -53,29 +54,59 @@ const percent = computed(() => {
 </script>
 
 <template>
-  <div v-if="showFullCapacity" class="repo-usage-cell" :class="variantClass">
+  <div
+    v-if="showFullCapacity"
+    class="repo-usage-cell"
+    :class="variantClass"
+  >
     <div class="repo-usage-cell__numbers">
       <span class="repo-usage-cell__used">{{ formatBytes(usedBytes) }}</span>
       <span class="repo-usage-cell__capacity">/ {{ formatBytes(totalBytes) }}</span>
-      <span v-if="showPercent" class="repo-usage-cell__percent">{{ percent }}%</span>
+      <span
+        v-if="showPercent"
+        class="repo-usage-cell__percent"
+      >{{ percent }}%</span>
     </div>
-    <div v-if="showBar" class="repo-usage-bar">
-      <span class="repo-usage-bar__fill" :style="{ width: `${percent}%` }" />
+    <div
+      v-if="showBar"
+      class="repo-usage-bar"
+    >
+      <span
+        class="repo-usage-bar__fill"
+        :style="{ width: `${percent}%` }"
+      />
     </div>
   </div>
-  <div v-else-if="showUsedOnly" class="repo-usage-cell" :class="variantClass">
+  <div
+    v-else-if="showUsedOnly"
+    class="repo-usage-cell"
+    :class="variantClass"
+  >
     <div class="repo-usage-cell__numbers">
       <span class="repo-usage-cell__used">{{ formatBytes(usedBytes) }}</span>
     </div>
-    <div v-if="showBar" class="repo-usage-bar">
-      <span class="repo-usage-bar__fill" style="width: 0%" />
+    <div
+      v-if="showBar"
+      class="repo-usage-bar"
+    >
+      <span
+        class="repo-usage-bar__fill"
+        style="width: 0%"
+      />
     </div>
   </div>
-  <div v-else-if="showUnlimited" class="repo-usage-cell repo-usage-cell--unlimited" :class="variantClass">
+  <div
+    v-else-if="showUnlimited"
+    class="repo-usage-cell repo-usage-cell--unlimited"
+    :class="variantClass"
+  >
     <div class="repo-usage-cell__numbers">
       <span class="repo-usage-cell__used">{{ formatBytes(usedBytes) }}</span>
       <span class="repo-usage-cell__capacity">/ {{ unlimitedTotalLabel }}</span>
     </div>
   </div>
-  <span v-else class="hfl-empty-mark">{{ emptyLabel }}</span>
+  <span
+    v-else
+    class="hfl-empty-mark"
+  >{{ emptyLabel }}</span>
 </template>

--- a/src/frontend/src/components/HflDateTimeRangePicker.test.ts
+++ b/src/frontend/src/components/HflDateTimeRangePicker.test.ts
@@ -1,12 +1,50 @@
 // @vitest-environment jsdom
 
-import { mount } from '@vue/test-utils'
+import { flushPromises, mount } from '@vue/test-utils'
 import ElementPlus from 'element-plus'
-import { nextTick } from 'vue'
+import { defineComponent, nextTick } from 'vue'
 import { describe, expect, it } from 'vitest'
 import HflDateTimeRangePicker from './HflDateTimeRangePicker.vue'
 
+const ElDatePickerStub = defineComponent({
+  props: {
+    shortcuts: {
+      type: Array,
+      default: () => [],
+    },
+  },
+  template: '<div />',
+})
+
 describe('HflDateTimeRangePicker accessibility', () => {
+  it('uses the Element Plus value contract for range shortcuts', () => {
+    const wrapper = mount(HflDateTimeRangePicker, {
+      props: {
+        label: 'Monitor time range',
+        clearText: 'Clear',
+        applyText: 'Apply',
+        presets: [{ value: '24h', label: 'Last 24 hours', hours: 24 }],
+      },
+      global: {
+        stubs: { ElDatePicker: ElDatePickerStub },
+      },
+    })
+
+    const [shortcut] = wrapper.getComponent(ElDatePickerStub).props('shortcuts') as Array<{
+      text: string
+      value: () => [Date, Date]
+      onClick?: unknown
+    }>
+    const range = shortcut.value()
+
+    expect(shortcut.text).toBe('Last 24 hours')
+    expect(shortcut.onClick).toBeUndefined()
+    expect(range[0]).toBeInstanceOf(Date)
+    expect(range[1]).toBeInstanceOf(Date)
+    expect(range[1].getTime() - range[0].getTime()).toBe(24 * 60 * 60 * 1000)
+    expect(wrapper.emitted('preset')).toEqual([['24h', 24]])
+  })
+
   it('gives both range inputs unique ids, names, and an accessible label', async () => {
     const wrapper = mount(HflDateTimeRangePicker, {
       props: {
@@ -31,5 +69,31 @@ describe('HflDateTimeRangePicker accessibility', () => {
       'Monitor time range',
       'Monitor time range',
     ])
+  })
+
+  it('handles a preset click through the real Element Plus range panel', async () => {
+    const wrapper = mount(HflDateTimeRangePicker, {
+      attachTo: document.body,
+      props: {
+        label: 'Monitor time range',
+        clearText: 'Clear',
+        applyText: 'Apply',
+        presets: [{ value: '24h', label: 'Last 24 hours', hours: 24 }],
+      },
+      global: { plugins: [ElementPlus] },
+    })
+
+    await wrapper.get('input.el-range-input').trigger('click')
+    await nextTick()
+    await flushPromises()
+    const shortcut = document.body.querySelector<HTMLButtonElement>('.el-picker-panel__shortcut')
+    expect(shortcut).not.toBeNull()
+
+    shortcut?.click()
+    await nextTick()
+    await flushPromises()
+    expect(wrapper.emitted('preset')).toEqual([['24h', 24]])
+    expect(wrapper.emitted('apply')).toBeUndefined()
+    wrapper.unmount()
   })
 })

--- a/src/frontend/src/components/HflDateTimeRangePicker.vue
+++ b/src/frontend/src/components/HflDateTimeRangePicker.vue
@@ -9,9 +9,6 @@ export type HflDateTimeRangePreset = {
 }
 
 type RangeValue = [string, string] | ''
-type PickerShortcutContext = {
-  emit: (event: string, value: [Date, Date]) => void
-}
 
 const props = withDefaults(
   defineProps<{
@@ -60,19 +57,22 @@ const popperClass = computed(() => [
   props.constrainToTrigger ? 'hfl-date-time-range-picker__popper--constrained' : '',
 ].filter(Boolean).join(' '))
 
-const shortcuts = computed(() => props.presets.map((preset) => ({
-  text: preset.label,
-  onClick: ({ emit: pickerEmit }: PickerShortcutContext) => {
-    const range = rangeForPreset(preset)
-    if (!range) return
-    suppressNextChange.value = true
-    emit('preset', preset.value, preset.hours)
-    pickerEmit('pick', range)
-    void nextTick(() => {
-      pickerValue.value = displayRangeFromProps()
-    })
-  },
-})))
+const shortcuts = computed(() => props.presets.flatMap((preset) => {
+  const hours = preset.hours
+  if (!hours) return []
+  return [{
+    text: preset.label,
+    value: () => {
+      const range = rangeForHours(hours)
+      suppressNextChange.value = true
+      emit('preset', preset.value, hours)
+      void nextTick(() => {
+        pickerValue.value = displayRangeFromProps()
+      })
+      return range
+    },
+  }]
+}))
 
 function pad2(n: number) {
   return String(n).padStart(2, '0')
@@ -98,8 +98,12 @@ function displayRangeFromProps(): RangeValue {
 
 function rangeForPreset(preset: HflDateTimeRangePreset): [Date, Date] | null {
   if (!preset.hours) return null
+  return rangeForHours(preset.hours)
+}
+
+function rangeForHours(hours: number): [Date, Date] {
   const end = new Date()
-  const start = new Date(end.getTime() - preset.hours * 60 * 60 * 1000)
+  const start = new Date(end.getTime() - hours * 60 * 60 * 1000)
   return [start, end]
 }
 
@@ -159,8 +163,8 @@ watch(
     :class="{ 'hfl-date-time-range-picker--constrained': constrainToTrigger }"
   >
     <ElDatePicker
-      :model-value="pickerValue"
       :id="rangeInputIds"
+      :model-value="pickerValue"
       class="hfl-date-time-range-picker__trigger"
       type="datetimerange"
       unlink-panels

--- a/src/frontend/src/components/HflDetailDrawerFooter.vue
+++ b/src/frontend/src/components/HflDetailDrawerFooter.vue
@@ -18,7 +18,10 @@ const { t } = useI18n()
 
 <template>
   <div class="el-drawer__footer-actions">
-    <ElButton :disabled="cancelDisabled || saving" @click="$emit('cancel')">
+    <ElButton
+      :disabled="cancelDisabled || saving"
+      @click="$emit('cancel')"
+    >
       {{ t('repositoriesPage.btnCancel') }}
     </ElButton>
     <ElButton

--- a/src/frontend/src/components/HflHelpTip.vue
+++ b/src/frontend/src/components/HflHelpTip.vue
@@ -11,6 +11,7 @@ const props = withDefaults(defineProps<{
   popperClass?: string
   triggerClass?: string
 }>(), {
+  content: '',
   placement: 'top',
   ariaLabel: 'More information',
   size: 14,

--- a/src/frontend/src/components/HflPagination.vue
+++ b/src/frontend/src/components/HflPagination.vue
@@ -21,9 +21,14 @@ const props = withDefaults(
     responsive?: boolean
   }>(),
   {
+    currentPage: 1,
+    pageSize: 10,
+    total: 0,
     pageSizes: () => [10, 20, 30, 50, 100],
+    layout: 'total, sizes, prev, pager, next, jumper',
     size: 'small',
     popperClass: '',
+    pagerCount: undefined,
     responsive: true,
   },
 )

--- a/src/frontend/src/components/HflTablePanel.vue
+++ b/src/frontend/src/components/HflTablePanel.vue
@@ -67,7 +67,10 @@ onUnmounted(() => {
         'hfl-list-toolbar--mobile-primary-utility': $slots.toolbar && $slots['toolbar-actions'] && $slots['toolbar-utility'],
       }"
     >
-      <div v-if="$slots.toolbar" class="hfl-list-toolbar__primary">
+      <div
+        v-if="$slots.toolbar"
+        class="hfl-list-toolbar__primary"
+      >
         <slot name="toolbar" />
       </div>
       <div
@@ -81,16 +84,29 @@ onUnmounted(() => {
         }"
       >
         <slot name="toolbar-actions" />
-        <div v-if="$slots['toolbar-utility']" class="hfl-list-toolbar__utility">
+        <div
+          v-if="$slots['toolbar-utility']"
+          class="hfl-list-toolbar__utility"
+        >
           <slot name="toolbar-utility" />
         </div>
       </div>
     </div>
     <slot />
-    <div v-if="$slots.table" ref="tableViewportRef" class="hfl-list-table-viewport">
-      <slot name="table" :table-max-height="tableMaxHeight" />
+    <div
+      v-if="$slots.table"
+      ref="tableViewportRef"
+      class="hfl-list-table-viewport"
+    >
+      <slot
+        name="table"
+        :table-max-height="tableMaxHeight"
+      />
     </div>
-    <div v-if="$slots.footer" class="hfl-list-footer">
+    <div
+      v-if="$slots.footer"
+      class="hfl-list-footer"
+    >
       <slot name="footer" />
     </div>
   </div>

--- a/src/frontend/src/components/HostSourceDetailDrawer.vue
+++ b/src/frontend/src/components/HostSourceDetailDrawer.vue
@@ -191,10 +191,19 @@ onUnmounted(() => {
       <span class="hfl-detail-drawer__title">{{ node?.name || '—' }}</span>
     </template>
 
-    <div v-loading="busy" class="hfl-detail-drawer__body">
+    <div
+      v-loading="busy"
+      class="hfl-detail-drawer__body"
+    >
       <template v-if="node">
-        <ElTabs v-model="drawerTab" class="hfl-detail-tabs">
-          <ElTabPane :label="t('protection.sourceResources.detailTabBasic')" name="basic">
+        <ElTabs
+          v-model="drawerTab"
+          class="hfl-detail-tabs"
+        >
+          <ElTabPane
+            :label="t('protection.sourceResources.detailTabBasic')"
+            name="basic"
+          >
             <NodeBasicInfoPanel
               ref="basicPanelRef"
               :node="node"
@@ -207,7 +216,10 @@ onUnmounted(() => {
             />
           </ElTabPane>
 
-          <ElTabPane :label="t('protection.sourceResources.detailTabAdvanced')" name="performance">
+          <ElTabPane
+            :label="t('protection.sourceResources.detailTabAdvanced')"
+            name="performance"
+          >
             <NodePerfSettingsPanel
               ref="perfPanelRef"
               hide-actions
@@ -216,7 +228,11 @@ onUnmounted(() => {
             />
           </ElTabPane>
 
-          <ElTabPane :label="t('nodeLifecycle.maintenance')" name="maintenance" lazy>
+          <ElTabPane
+            :label="t('nodeLifecycle.maintenance')"
+            name="maintenance"
+            lazy
+          >
             <NodeMaintenancePanel
               :node="node"
               :refreshing="busy"
@@ -226,10 +242,17 @@ onUnmounted(() => {
         </ElTabs>
       </template>
 
-      <ElEmpty v-else-if="!busy" :description="t('protection.sourceResources.hostDetailEmpty')" :image-size="72" />
+      <ElEmpty
+        v-else-if="!busy"
+        :description="t('protection.sourceResources.hostDetailEmpty')"
+        :image-size="72"
+      />
     </div>
 
-    <template v-if="node && drawerTab === 'performance'" #footer>
+    <template
+      v-if="node && drawerTab === 'performance'"
+      #footer
+    >
       <HflDetailDrawerFooter
         :saving="saving"
         :save-disabled="!hasDrawerChanges"

--- a/src/frontend/src/components/JsonCodeEditor.vue
+++ b/src/frontend/src/components/JsonCodeEditor.vue
@@ -55,7 +55,10 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-  <div ref="host" class="hfl-json-editor" />
+  <div
+    ref="host"
+    class="hfl-json-editor"
+  />
 </template>
 
 <style>

--- a/src/frontend/src/components/MobileNavigationDrawer.vue
+++ b/src/frontend/src/components/MobileNavigationDrawer.vue
@@ -108,17 +108,34 @@ function moduleItemActive(to?: string) {
     <div class="mobile-navigation__shell">
       <header class="mobile-navigation__header">
         <h2>{{ title }}</h2>
-        <button type="button" class="mobile-navigation__close" :aria-label="$t('common.close')" @click="close">
-          <X :size="20" aria-hidden="true" />
+        <button
+          type="button"
+          class="mobile-navigation__close"
+          :aria-label="$t('common.close')"
+          @click="close"
+        >
+          <X
+            :size="20"
+            aria-hidden="true"
+          />
         </button>
       </header>
 
-      <nav class="mobile-navigation__body" :aria-label="title">
-        <section v-if="showOrganizationSwitcher" class="mobile-navigation__section">
+      <nav
+        class="mobile-navigation__body"
+        :aria-label="title"
+      >
+        <section
+          v-if="showOrganizationSwitcher"
+          class="mobile-navigation__section"
+        >
           <OrgSwitcher variant="mobile" />
         </section>
 
-        <section v-if="primaryItems.length" class="mobile-navigation__section">
+        <section
+          v-if="primaryItems.length"
+          class="mobile-navigation__section"
+        >
           <RouterLink
             v-for="item in primaryItems"
             :key="item.to"
@@ -138,8 +155,14 @@ function moduleItemActive(to?: string) {
           </RouterLink>
         </section>
 
-        <section v-if="moduleItems.length" class="mobile-navigation__section mobile-navigation__section--module">
-          <template v-for="(item, index) in moduleItems" :key="item.to || `${item.label}-${index}`">
+        <section
+          v-if="moduleItems.length"
+          class="mobile-navigation__section mobile-navigation__section--module"
+        >
+          <template
+            v-for="(item, index) in moduleItems"
+            :key="item.to || `${item.label}-${index}`"
+          >
             <button
               v-if="item.children?.length"
               type="button"
@@ -148,9 +171,16 @@ function moduleItemActive(to?: string) {
               @click="toggleGroup(index)"
             >
               <span>{{ item.label }}</span>
-              <ChevronDown :size="17" :class="{ 'is-expanded': expandedGroups.has(index) }" aria-hidden="true" />
+              <ChevronDown
+                :size="17"
+                :class="{ 'is-expanded': expandedGroups.has(index) }"
+                aria-hidden="true"
+              />
             </button>
-            <div v-if="item.children?.length && expandedGroups.has(index)" class="mobile-navigation__children">
+            <div
+              v-if="item.children?.length && expandedGroups.has(index)"
+              class="mobile-navigation__children"
+            >
               <RouterLink
                 v-for="child in item.children"
                 :key="child.to || child.label"
@@ -161,7 +191,12 @@ function moduleItemActive(to?: string) {
                 :aria-disabled="!child.to || undefined"
                 @click="child.to && close()"
               >
-                <component :is="child.icon" v-if="child.icon" :size="17" aria-hidden="true" />
+                <component
+                  :is="child.icon"
+                  v-if="child.icon"
+                  :size="17"
+                  aria-hidden="true"
+                />
                 <span>{{ child.label }}</span>
               </RouterLink>
             </div>
@@ -173,13 +208,21 @@ function moduleItemActive(to?: string) {
               :aria-current="moduleItemActive(item.to) ? 'page' : undefined"
               @click="close"
             >
-              <component :is="item.icon" v-if="item.icon" :size="17" aria-hidden="true" />
+              <component
+                :is="item.icon"
+                v-if="item.icon"
+                :size="17"
+                aria-hidden="true"
+              />
               <span>{{ item.label }}</span>
             </RouterLink>
           </template>
         </section>
 
-        <section v-if="adminConsoleHref" class="mobile-navigation__section mobile-navigation__section--utility">
+        <section
+          v-if="adminConsoleHref"
+          class="mobile-navigation__section mobile-navigation__section--utility"
+        >
           <a
             :href="adminConsoleHref"
             class="mobile-navigation__utility-link"
@@ -187,9 +230,16 @@ function moduleItemActive(to?: string) {
             rel="noopener noreferrer"
             @click="close"
           >
-            <Shield :size="17" aria-hidden="true" />
+            <Shield
+              :size="17"
+              aria-hidden="true"
+            />
             <span>{{ $t('nav.platformOps') }}</span>
-            <ExternalLink class="mobile-navigation__utility-external" :size="15" aria-hidden="true" />
+            <ExternalLink
+              class="mobile-navigation__utility-external"
+              :size="15"
+              aria-hidden="true"
+            />
           </a>
         </section>
 
@@ -204,7 +254,10 @@ function moduleItemActive(to?: string) {
             :aria-label="$t('nav.switchLanguage', { language: nextLocaleLabel })"
             @click="toggleLocale"
           >
-            <Globe :size="17" aria-hidden="true" />
+            <Globe
+              :size="17"
+              aria-hidden="true"
+            />
             <span class="mobile-navigation__utility-copy">
               <span class="mobile-navigation__utility-title">{{ $t('nav.languageLabel') }}</span>
               <span class="mobile-navigation__utility-subtitle">
@@ -212,15 +265,27 @@ function moduleItemActive(to?: string) {
               </span>
             </span>
           </button>
-          <div v-else-if="currentLocaleLabel" class="mobile-navigation__utility-link mobile-navigation__utility-link--static">
-            <Globe :size="17" aria-hidden="true" />
+          <div
+            v-else-if="currentLocaleLabel"
+            class="mobile-navigation__utility-link mobile-navigation__utility-link--static"
+          >
+            <Globe
+              :size="17"
+              aria-hidden="true"
+            />
             <span class="mobile-navigation__utility-copy">
               <span class="mobile-navigation__utility-title">{{ $t('nav.languageLabel') }}</span>
               <span class="mobile-navigation__utility-subtitle">{{ currentLocaleLabel }}</span>
             </span>
           </div>
-          <div v-if="timezoneOffsetDisplay" class="mobile-navigation__utility-link mobile-navigation__utility-link--static">
-            <Clock3 :size="17" aria-hidden="true" />
+          <div
+            v-if="timezoneOffsetDisplay"
+            class="mobile-navigation__utility-link mobile-navigation__utility-link--static"
+          >
+            <Clock3
+              :size="17"
+              aria-hidden="true"
+            />
             <span class="mobile-navigation__utility-copy">
               <span class="mobile-navigation__utility-title">{{ $t('nav.timezoneLabel') }}</span>
               <span class="mobile-navigation__utility-subtitle">{{ timezoneOffsetDisplay }}</span>

--- a/src/frontend/src/components/Modal.vue
+++ b/src/frontend/src/components/Modal.vue
@@ -16,6 +16,11 @@ const props = withDefaults(defineProps<{
   inline?: boolean
   showBack?: boolean
 }>(), {
+  width: undefined,
+  description: '',
+  size: 'default',
+  minHeight: undefined,
+  variant: 'modal',
   showBack: true,
   theme: 'default',
   inline: false,
@@ -106,8 +111,15 @@ onUnmounted(() => {
     v-if="visible"
     :class="isPageVariant ? (props.inline ? 'relative z-auto flex min-h-0 w-full flex-1' : 'absolute inset-0 z-50') : 'fixed inset-0 z-50'"
   >
-    <div v-if="!isPageVariant" class="absolute inset-0 bg-black/30" @click="requestClose" />
-    <div :class="[shellClass, { 'modal-page-shell modal-page-shell--policy': isPolicyTheme }]" :style="shellStyle">
+    <div
+      v-if="!isPageVariant"
+      class="absolute inset-0 bg-black/30"
+      @click="requestClose"
+    />
+    <div
+      :class="[shellClass, { 'modal-page-shell modal-page-shell--policy': isPolicyTheme }]"
+      :style="shellStyle"
+    >
       <template v-if="isPageVariant">
         <div
           :class="[
@@ -120,16 +132,30 @@ onUnmounted(() => {
               v-if="props.showBack"
               :class="isPolicyTheme ? 'modal-page-shell__back !p-1.5' : '!p-1.5'"
               aria-label="Back"
-              @click="requestClose"
               text
+              @click="requestClose"
             >
-              <ArrowLeft :size="20" class="text-slate-600" />
+              <ArrowLeft
+                :size="20"
+                class="text-slate-600"
+              />
             </ElButton>
-            <div v-if="isPolicyTheme" class="modal-page-shell__headline">
+            <div
+              v-if="isPolicyTheme"
+              class="modal-page-shell__headline"
+            >
               <span class="modal-page-shell__title">{{ title }}</span>
-              <p v-if="description" class="modal-page-shell__desc">{{ description }}</p>
+              <p
+                v-if="description"
+                class="modal-page-shell__desc"
+              >
+                {{ description }}
+              </p>
             </div>
-            <span v-else class="text-base font-semibold text-slate-900">{{ title }}</span>
+            <span
+              v-else
+              class="text-base font-semibold text-slate-900"
+            >{{ title }}</span>
           </div>
         </div>
         <div
@@ -153,17 +179,32 @@ onUnmounted(() => {
       <template v-else>
         <div class="flex shrink-0 items-center justify-between border-b border-[var(--color-border-light,#f1f5f9)] px-5 py-3">
           <div class="min-w-0">
-            <div class="text-sm font-semibold text-slate-900">{{ title }}</div>
-            <p v-if="description" class="mt-1 text-xs text-slate-500">{{ description }}</p>
+            <div class="text-sm font-semibold text-slate-900">
+              {{ title }}
+            </div>
+            <p
+              v-if="description"
+              class="mt-1 text-xs text-slate-500"
+            >
+              {{ description }}
+            </p>
           </div>
-          <ElButton class="!p-1.5" aria-label="Close" @click="requestClose" text>
+          <ElButton
+            class="!p-1.5"
+            aria-label="Close"
+            text
+            @click="requestClose"
+          >
             <X :size="16" />
           </ElButton>
         </div>
         <div class="scrollbar min-h-0 flex-1 overflow-x-hidden overflow-y-auto overscroll-contain px-5 py-4">
           <slot />
         </div>
-        <div v-if="$slots.footer" class="modal-footer-actions shrink-0 border-t border-[var(--color-border-light,#f1f5f9)] bg-[var(--modal-bg,#fff)] px-5 py-3">
+        <div
+          v-if="$slots.footer"
+          class="modal-footer-actions shrink-0 border-t border-[var(--color-border-light,#f1f5f9)] bg-[var(--modal-bg,#fff)] px-5 py-3"
+        >
           <slot name="footer" />
         </div>
       </template>

--- a/src/frontend/src/components/ModulePage.vue
+++ b/src/frontend/src/components/ModulePage.vue
@@ -130,10 +130,21 @@ watch(
 </script>
 
 <template>
-  <div class="module-page" :class="{ 'module-page--admin': isAdminSettingsShell }">
+  <div
+    class="module-page"
+    :class="{ 'module-page--admin': isAdminSettingsShell }"
+  >
     <div class="sidebar-wrapper">
-      <Sidebar v-if="menuItems.length > 0" :collapsed="effectiveCollapsed" :menus="menuItems" @toggle="toggleSidebar">
-        <template v-if="slots.sidebarPrepend" #prepend>
+      <Sidebar
+        v-if="menuItems.length > 0"
+        :collapsed="effectiveCollapsed"
+        :menus="menuItems"
+        @toggle="toggleSidebar"
+      >
+        <template
+          v-if="slots.sidebarPrepend"
+          #prepend
+        >
           <slot name="sidebar-prepend" />
         </template>
       </Sidebar>
@@ -144,9 +155,14 @@ watch(
       class="main-content"
     >
       <div class="main-content-route-surface">
-        <div v-if="!hidePageTitle" class="page-header">
+        <div
+          v-if="!hidePageTitle"
+          class="page-header"
+        >
           <div class="page-title-row">
-            <h1 class="page-title">{{ displayTitle }}</h1>
+            <h1 class="page-title">
+              {{ displayTitle }}
+            </h1>
           </div>
         </div>
         <div
@@ -154,7 +170,10 @@ watch(
           class="page-body"
           :class="{ 'page-body--fill': bodyFill }"
         >
-          <div v-if="slots.actions" class="page-actions">
+          <div
+            v-if="slots.actions"
+            class="page-actions"
+          >
             <slot name="actions" />
           </div>
           <slot />

--- a/src/frontend/src/components/NasSourceListTable.vue
+++ b/src/frontend/src/components/NasSourceListTable.vue
@@ -24,7 +24,9 @@ const props = withDefaults(
   {
     loading: false,
     selectable: false,
+    maxHeight: undefined,
     capacitySyncing: false,
+    emptyDescription: '',
   },
 )
 
@@ -50,7 +52,12 @@ const display = useNasSourceListDisplay(toRef(props, 'proxyNodes'))
     :header-cell-style="NAS_SOURCE_TABLE_HEADER_STYLE"
     @selection-change="emit('selection-change', $event)"
   >
-    <el-table-column v-if="selectable" type="selection" width="35" fixed="left" />
+    <el-table-column
+      v-if="selectable"
+      type="selection"
+      width="35"
+      fixed="left"
+    />
     <el-table-column
       :label="t('protection.sourceResources.colName')"
       min-width="200"
@@ -67,21 +74,40 @@ const display = useNasSourceListDisplay(toRef(props, 'proxyNodes'))
         </button>
       </template>
     </el-table-column>
-    <el-table-column :label="t('protection.sourceResources.colProtocol')" width="100">
+    <el-table-column
+      :label="t('protection.sourceResources.colProtocol')"
+      width="100"
+    >
       <template #default="{ row }">
-        <span v-if="display.nasProtocolType(row) !== 'nas'" :class="display.nasProtocolPillClass(row)">
-          <component :is="nasMountProtocolIcon(display.nasProtocolType(row))" :size="12" stroke-width="2.25" />
+        <span
+          v-if="display.nasProtocolType(row) !== 'nas'"
+          :class="display.nasProtocolPillClass(row)"
+        >
+          <component
+            :is="nasMountProtocolIcon(display.nasProtocolType(row))"
+            :size="12"
+            stroke-width="2.25"
+          />
           {{ display.nasProtocolLabel(row) }}
         </span>
-        <span v-else class="hfl-empty-mark">—</span>
+        <span
+          v-else
+          class="hfl-empty-mark"
+        >—</span>
       </template>
     </el-table-column>
-    <el-table-column :label="t('protection.sourceResources.colNasServer')" min-width="140">
+    <el-table-column
+      :label="t('protection.sourceResources.colNasServer')"
+      min-width="140"
+    >
       <template #default="{ row }">
         {{ display.nasServerAddress(row) }}
       </template>
     </el-table-column>
-    <el-table-column :label="t('protection.sourceResources.colNasShareExport')" min-width="160">
+    <el-table-column
+      :label="t('protection.sourceResources.colNasShareExport')"
+      min-width="160"
+    >
       <template #default="{ row }">
         <div class="table-stack-cell">
           <span class="table-stack-cell__secondary">{{ display.nasPathKindLabel(row) }}</span>
@@ -89,7 +115,10 @@ const display = useNasSourceListDisplay(toRef(props, 'proxyNodes'))
         </div>
       </template>
     </el-table-column>
-    <el-table-column :label="t('protection.sourceResources.colSourceProxy')" min-width="150">
+    <el-table-column
+      :label="t('protection.sourceResources.colSourceProxy')"
+      min-width="150"
+    >
       <template #header>
         <span class="hfl-table-header-with-tip">
           <span>{{ t('protection.sourceResources.colSourceProxy') }}</span>
@@ -101,19 +130,31 @@ const display = useNasSourceListDisplay(toRef(props, 'proxyNodes'))
       </template>
       <template #default="{ row }">
         <div class="table-stack-cell">
-          <span class="table-stack-cell__primary" :class="{ 'hfl-empty-mark': !display.nasSourceProxyName(row) }">{{ display.nasSourceProxyName(row) || '—' }}</span>
-          <span v-if="display.nasSourceProxyIp(row)" class="table-stack-cell__secondary">
+          <span
+            class="table-stack-cell__primary"
+            :class="{ 'hfl-empty-mark': !display.nasSourceProxyName(row) }"
+          >{{ display.nasSourceProxyName(row) || '—' }}</span>
+          <span
+            v-if="display.nasSourceProxyIp(row)"
+            class="table-stack-cell__secondary"
+          >
             {{ display.nasSourceProxyIp(row) }}
           </span>
         </div>
       </template>
     </el-table-column>
-    <el-table-column :label="t('protection.sourceResources.colProxyMountPoint')" min-width="220">
+    <el-table-column
+      :label="t('protection.sourceResources.colProxyMountPoint')"
+      min-width="220"
+    >
       <template #default="{ row }">
         <span class="hfl-table-cell-full hfl-table-no-tooltip">{{ display.nasProxyMountPoint(row) }}</span>
       </template>
     </el-table-column>
-    <el-table-column :label="t('protection.sourceResources.colCapacity')" min-width="200">
+    <el-table-column
+      :label="t('protection.sourceResources.colCapacity')"
+      min-width="200"
+    >
       <template #default="{ row }">
         <HflCapacityCell
           v-if="row.total_size"
@@ -128,25 +169,43 @@ const display = useNasSourceListDisplay(toRef(props, 'proxyNodes'))
         >
           {{ t('protection.sourceResources.capacitySyncing') }}
         </span>
-        <span v-else class="hfl-empty-mark">—</span>
+        <span
+          v-else
+          class="hfl-empty-mark"
+        >—</span>
       </template>
     </el-table-column>
-    <el-table-column :label="t('protection.sourceResources.colStatus')" width="88">
+    <el-table-column
+      :label="t('protection.sourceResources.colStatus')"
+      width="88"
+    >
       <template #default="{ row }">
         <div class="hfl-table-no-tooltip">
-          <el-tag :type="display.sourceNodeOnlineTagType(row)" size="small">
+          <el-tag
+            :type="display.sourceNodeOnlineTagType(row)"
+            size="small"
+          >
             {{ display.sourceNodeOnlineLabel(row) }}
           </el-tag>
         </div>
       </template>
     </el-table-column>
-    <el-table-column :label="t('protection.sourceResources.colRegistered')" min-width="170">
+    <el-table-column
+      :label="t('protection.sourceResources.colRegistered')"
+      min-width="170"
+    >
       <template #default="{ row }">
-        <span class="hfl-table-cell-time" :class="{ 'hfl-empty-mark': !display.sourceRegisteredAt(row) }">{{ display.formatDate(display.sourceRegisteredAt(row)) }}</span>
+        <span
+          class="hfl-table-cell-time"
+          :class="{ 'hfl-empty-mark': !display.sourceRegisteredAt(row) }"
+        >{{ display.formatDate(display.sourceRegisteredAt(row)) }}</span>
       </template>
     </el-table-column>
     <template #empty>
-      <el-empty :description="emptyDescription || t('protection.sourceResources.emptyNasSources')" :image-size="80" />
+      <el-empty
+        :description="emptyDescription || t('protection.sourceResources.emptyNasSources')"
+        :image-size="80"
+      />
     </template>
   </el-table>
 </template>

--- a/src/frontend/src/components/NavNotificationPopover.vue
+++ b/src/frontend/src/components/NavNotificationPopover.vue
@@ -173,7 +173,10 @@ onUnmounted(() => {
           :aria-label="t('nav.notificationPopover.bellAria')"
         >
           <Bell :size="18" />
-          <span v-if="badgeCount > 0" class="nav-notification-badge">{{ badgeText }}</span>
+          <span
+            v-if="badgeCount > 0"
+            class="nav-notification-badge"
+          >{{ badgeText }}</span>
         </button>
       </template>
 
@@ -196,16 +199,30 @@ onUnmounted(() => {
         </header>
 
         <div class="nav-dropdown-panel__body nav-dropdown-panel__body--flush">
-          <div v-if="loadError" class="nn-load-error" role="status">
+          <div
+            v-if="loadError"
+            class="nn-load-error"
+            role="status"
+          >
             {{ loadError }}
           </div>
-          <div v-if="loading && !notifications.length" class="nav-dropdown-panel__empty">
+          <div
+            v-if="loading && !notifications.length"
+            class="nav-dropdown-panel__empty"
+          >
             {{ t('nav.notificationPopover.loading') }}
           </div>
-          <div v-else-if="!notifications.length && !loadError" class="nav-dropdown-panel__empty">
+          <div
+            v-else-if="!notifications.length && !loadError"
+            class="nav-dropdown-panel__empty"
+          >
             {{ t('nav.notificationPopover.empty') }}
           </div>
-          <ul v-else class="nav-dropdown-panel__list nn-list" role="list">
+          <ul
+            v-else
+            class="nav-dropdown-panel__list nn-list"
+            role="list"
+          >
             <li
               v-for="notification in notifications"
               :key="notification.id"
@@ -222,22 +239,35 @@ onUnmounted(() => {
                 aria-hidden="true"
               />
               <div class="nn-item-body">
-                <div class="nn-item-title">{{ notification.title }}</div>
+                <div class="nn-item-title">
+                  {{ notification.title }}
+                </div>
                 <div class="nn-item-meta">
                   <span class="nn-item-summary">{{ notification.summary || '—' }}</span>
                   <span class="nn-item-sep">|</span>
                   <span class="nn-item-time">{{ formatRelativeTime(notification.occurred_at || notification.updated_at) }}</span>
                 </div>
               </div>
-              <span v-if="!notification.is_read" class="nn-unread-dot" aria-hidden="true" />
+              <span
+                v-if="!notification.is_read"
+                class="nn-unread-dot"
+                aria-hidden="true"
+              />
             </li>
           </ul>
         </div>
 
         <footer class="nav-dropdown-panel__foot">
-          <button type="button" class="nav-dropdown-panel__foot-link" @click="viewAll">
+          <button
+            type="button"
+            class="nav-dropdown-panel__foot-link"
+            @click="viewAll"
+          >
             <span>{{ t('nav.notificationPopover.viewAll') }}</span>
-            <ArrowUpRight :size="14" aria-hidden="true" />
+            <ArrowUpRight
+              :size="14"
+              aria-hidden="true"
+            />
           </button>
         </footer>
       </div>

--- a/src/frontend/src/components/NavUserMenu.vue
+++ b/src/frontend/src/components/NavUserMenu.vue
@@ -73,24 +73,44 @@ async function confirmLogout() {
         :aria-label="`${displayLabel} · ${t('account.userMenuAria')}`"
       >
         <span class="nav-user-trigger__label">{{ displayLabel }}</span>
-        <ChevronDown :size="14" class="nav-user-trigger__caret" stroke-width="2" aria-hidden="true" />
+        <ChevronDown
+          :size="14"
+          class="nav-user-trigger__caret"
+          stroke-width="2"
+          aria-hidden="true"
+        />
       </button>
     </template>
 
     <div class="nav-dropdown-panel">
       <header class="nav-dropdown-panel__head nav-dropdown-panel__head--stacked">
-        <h3 class="nav-dropdown-panel__title">{{ email }}</h3>
+        <h3 class="nav-dropdown-panel__title">
+          {{ email }}
+        </h3>
         <span class="nav-dropdown-panel__role-badge">{{ role }}</span>
       </header>
 
       <div class="nav-dropdown-panel__body">
-        <button type="button" class="nav-dropdown-panel__item" @click="go('/account/profile')">
-          <span class="nav-dropdown-panel__icon-box" aria-hidden="true">
-            <User :size="16" stroke-width="1.75" />
+        <button
+          type="button"
+          class="nav-dropdown-panel__item"
+          @click="go('/account/profile')"
+        >
+          <span
+            class="nav-dropdown-panel__icon-box"
+            aria-hidden="true"
+          >
+            <User
+              :size="16"
+              stroke-width="1.75"
+            />
           </span>
           <span class="nav-dropdown-panel__item-text">
             <span class="nav-dropdown-panel__item-title">{{ t('account.menuProfile') }}</span>
-            <span v-if="profileSub" class="nav-dropdown-panel__item-sub">{{ profileSub }}</span>
+            <span
+              v-if="profileSub"
+              class="nav-dropdown-panel__item-sub"
+            >{{ profileSub }}</span>
           </span>
         </button>
       </div>
@@ -103,12 +123,21 @@ async function confirmLogout() {
           class="nav-dropdown-panel__item nav-dropdown-panel__item--danger"
           @click.stop.prevent="confirmLogout"
         >
-          <span class="nav-dropdown-panel__icon-box nav-dropdown-panel__icon-box--danger" aria-hidden="true">
-            <LogOut :size="16" stroke-width="1.75" />
+          <span
+            class="nav-dropdown-panel__icon-box nav-dropdown-panel__icon-box--danger"
+            aria-hidden="true"
+          >
+            <LogOut
+              :size="16"
+              stroke-width="1.75"
+            />
           </span>
           <span class="nav-dropdown-panel__item-text">
             <span class="nav-dropdown-panel__item-title">{{ t('account.menuSignOut') }}</span>
-            <span v-if="signOutSub" class="nav-dropdown-panel__item-sub">{{ signOutSub }}</span>
+            <span
+              v-if="signOutSub"
+              class="nav-dropdown-panel__item-sub"
+            >{{ signOutSub }}</span>
           </span>
         </button>
       </div>

--- a/src/frontend/src/components/NodeBasicInfoPanel.vue
+++ b/src/frontend/src/components/NodeBasicInfoPanel.vue
@@ -216,7 +216,9 @@ function detailValueClass(text: string, monoWhenPresent = false) {
 <template>
   <div class="hfl-detail-sections">
     <section class="hfl-detail-section">
-      <h4 class="hfl-detail-section__title">{{ t('protection.sourceResources.detailSectionIdentity') }}</h4>
+      <h4 class="hfl-detail-section__title">
+        {{ t('protection.sourceResources.detailSectionIdentity') }}
+      </h4>
       <div class="hfl-detail-grid">
         <div class="hfl-detail-row">
           <span class="hfl-detail-row__label">{{ t('protection.sourceResources.fieldSourceName') }}</span>
@@ -231,13 +233,34 @@ function detailValueClass(text: string, monoWhenPresent = false) {
                 @keyup.enter="saveName"
               />
               <span class="hfl-detail-inline-edit__actions">
-                <ElButton text circle size="small" :title="t('common.save')" :disabled="savingName" @click="saveName"><Check :size="14" /></ElButton>
-                <ElButton text circle size="small" :title="t('common.cancel')" :disabled="savingName" @click="discardNameEdit"><X :size="14" /></ElButton>
+                <ElButton
+                  text
+                  circle
+                  size="small"
+                  :title="t('common.save')"
+                  :disabled="savingName"
+                  @click="saveName"
+                ><Check :size="14" /></ElButton>
+                <ElButton
+                  text
+                  circle
+                  size="small"
+                  :title="t('common.cancel')"
+                  :disabled="savingName"
+                  @click="discardNameEdit"
+                ><X :size="14" /></ElButton>
               </span>
             </template>
             <template v-else>
               <span class="hfl-detail-row__text">{{ node.name }}</span>
-              <ElButton text circle size="small" class="hfl-detail-row__edit" :title="t('protection.sourceResources.editBtn')" @click="beginNameEdit">
+              <ElButton
+                text
+                circle
+                size="small"
+                class="hfl-detail-row__edit"
+                :title="t('protection.sourceResources.editBtn')"
+                @click="beginNameEdit"
+              >
                 <Pencil :size="13" />
               </ElButton>
             </template>
@@ -255,7 +278,14 @@ function detailValueClass(text: string, monoWhenPresent = false) {
           <span class="hfl-detail-row__label">{{ t('protection.sourceResources.fieldSourceId') }}</span>
           <span class="hfl-detail-row__value hfl-detail-row__value--editable hfl-detail-row__value--mono">
             <span class="hfl-detail-row__text">{{ externalId }}</span>
-            <ElButton text circle size="small" class="hfl-detail-row__edit" :title="t('common.copy')" @click="copyText(externalId)">
+            <ElButton
+              text
+              circle
+              size="small"
+              class="hfl-detail-row__edit"
+              :title="t('common.copy')"
+              @click="copyText(externalId)"
+            >
               <Copy :size="13" />
             </ElButton>
           </span>
@@ -277,7 +307,10 @@ function detailValueClass(text: string, monoWhenPresent = false) {
             </ElButton>
           </span>
         </div>
-        <div v-if="showRepositoryServerAddress" class="hfl-detail-row">
+        <div
+          v-if="showRepositoryServerAddress"
+          class="hfl-detail-row"
+        >
           <span class="hfl-detail-row__label">{{ t('nodesPage.repositoryServerAddress') }}</span>
           <span class="hfl-detail-row__value hfl-detail-row__value--editable hfl-detail-row__value--mono">
             <span class="hfl-detail-row__text">{{ repositoryServerAddress }}</span>
@@ -301,7 +334,9 @@ function detailValueClass(text: string, monoWhenPresent = false) {
     </section>
 
     <section class="hfl-detail-section">
-      <h4 class="hfl-detail-section__title">{{ t('protection.sourceResources.detailSectionSpecs') }}</h4>
+      <h4 class="hfl-detail-section__title">
+        {{ t('protection.sourceResources.detailSectionSpecs') }}
+      </h4>
       <div class="hfl-detail-grid">
         <div class="hfl-detail-row">
           <span class="hfl-detail-row__label">{{ t('protection.sourceResources.colOperatingSystem') }}</span>
@@ -309,27 +344,45 @@ function detailValueClass(text: string, monoWhenPresent = false) {
         </div>
         <div class="hfl-detail-row">
           <span class="hfl-detail-row__label">{{ t('protection.sourceResources.fieldArch') }}</span>
-          <span class="hfl-detail-row__value" :class="detailValueClass(arch, true)">{{ arch }}</span>
+          <span
+            class="hfl-detail-row__value"
+            :class="detailValueClass(arch, true)"
+          >{{ arch }}</span>
         </div>
         <div class="hfl-detail-row">
           <span class="hfl-detail-row__label">{{ t('protection.sourceResources.colCpu') }}</span>
-          <span class="hfl-detail-row__value" :class="detailValueClass(cpuText)">{{ cpuText }}</span>
+          <span
+            class="hfl-detail-row__value"
+            :class="detailValueClass(cpuText)"
+          >{{ cpuText }}</span>
         </div>
         <div class="hfl-detail-row">
           <span class="hfl-detail-row__label">{{ t('protection.sourceResources.colMemory') }}</span>
-          <span class="hfl-detail-row__value" :class="detailValueClass(memoryText)">{{ memoryText }}</span>
+          <span
+            class="hfl-detail-row__value"
+            :class="detailValueClass(memoryText)"
+          >{{ memoryText }}</span>
         </div>
         <div class="hfl-detail-row">
           <span class="hfl-detail-row__label">{{ t('protection.sourceResources.colDiskCount') }}</span>
-          <span class="hfl-detail-row__value" :class="detailValueClass(diskCountText)">{{ diskCountText }}</span>
+          <span
+            class="hfl-detail-row__value"
+            :class="detailValueClass(diskCountText)"
+          >{{ diskCountText }}</span>
         </div>
         <div class="hfl-detail-row">
           <span class="hfl-detail-row__label">{{ t('protection.sourceResources.fieldMacAddress') }}</span>
-          <span class="hfl-detail-row__value" :class="detailValueClass(macText, true)">{{ macText }}</span>
+          <span
+            class="hfl-detail-row__value"
+            :class="detailValueClass(macText, true)"
+          >{{ macText }}</span>
         </div>
         <div class="hfl-detail-row hfl-detail-row--full">
           <span class="hfl-detail-row__label">{{ t('protection.sourceResources.colCapacity') }}</span>
-          <span class="hfl-detail-row__value" :class="{ 'hfl-detail-row__value--stacked': capacityParts.total > 0 }">
+          <span
+            class="hfl-detail-row__value"
+            :class="{ 'hfl-detail-row__value--stacked': capacityParts.total > 0 }"
+          >
             <HflCapacityCell
               v-if="useUnifiedCapacity"
               :used-bytes="capacityParts.used"
@@ -339,14 +392,26 @@ function detailValueClass(text: string, monoWhenPresent = false) {
               :empty-label="DETAIL_EMPTY"
             />
             <template v-else>
-              <span v-if="capacityParts.total > 0" class="hfl-detail-row__text repo-usage-cell__numbers">
+              <span
+                v-if="capacityParts.total > 0"
+                class="hfl-detail-row__text repo-usage-cell__numbers"
+              >
                 <span class="repo-usage-cell__used">{{ formatNodeBytes(capacityParts.used) }}</span>
                 <span class="repo-usage-cell__capacity">/ {{ formatNodeBytes(capacityParts.total) }}</span>
                 <span class="repo-usage-cell__percent">{{ capacityParts.pct }}%</span>
               </span>
-              <span v-else class="hfl-detail-row__text hfl-detail-row__empty">{{ DETAIL_EMPTY }}</span>
-              <div v-if="capacityParts.total > 0" class="hfl-detail-capacity-bar">
-                <div class="hfl-detail-capacity-bar__fill" :style="{ width: `${capacityParts.pct}%` }" />
+              <span
+                v-else
+                class="hfl-detail-row__text hfl-detail-row__empty"
+              >{{ DETAIL_EMPTY }}</span>
+              <div
+                v-if="capacityParts.total > 0"
+                class="hfl-detail-capacity-bar"
+              >
+                <div
+                  class="hfl-detail-capacity-bar__fill"
+                  :style="{ width: `${capacityParts.pct}%` }"
+                />
               </div>
             </template>
           </span>
@@ -357,7 +422,9 @@ function detailValueClass(text: string, monoWhenPresent = false) {
     <slot name="before-runtime" />
 
     <section class="hfl-detail-section">
-      <h4 class="hfl-detail-section__title">{{ t('protection.sourceResources.detailSectionRuntime') }}</h4>
+      <h4 class="hfl-detail-section__title">
+        {{ t('protection.sourceResources.detailSectionRuntime') }}
+      </h4>
       <div class="hfl-detail-grid">
         <div class="hfl-detail-row">
           <span class="hfl-detail-row__label">{{ t(useBackupSourceTerminology ? 'protection.sourceResources.colLifecycleStatus' : 'protection.sourceResources.colStatus') }}</span>
@@ -366,7 +433,10 @@ function detailValueClass(text: string, monoWhenPresent = false) {
               :node="node"
               :resolve-display-status="resolveNodeDisplayStatus"
             />
-            <span v-if="uptimeLabel" class="node-basic-info-status__meta">({{ uptimeLabel }})</span>
+            <span
+              v-if="uptimeLabel"
+              class="node-basic-info-status__meta"
+            >({{ uptimeLabel }})</span>
           </div>
         </div>
         <div class="hfl-detail-row">
@@ -376,20 +446,32 @@ function detailValueClass(text: string, monoWhenPresent = false) {
         <div class="hfl-detail-row">
           <span class="hfl-detail-row__label">{{ t(useBackupSourceTerminology ? 'protection.sourceResources.colConnectivity' : 'protection.sourceResources.colAvailability') }}</span>
           <span class="hfl-detail-row__value">
-            <ElTag :type="availabilityTagType" size="small">{{ availabilityLabel }}</ElTag>
+            <ElTag
+              :type="availabilityTagType"
+              size="small"
+            >{{ availabilityLabel }}</ElTag>
           </span>
         </div>
         <div class="hfl-detail-row">
           <span class="hfl-detail-row__label">{{ t(useBackupSourceTerminology ? 'protection.sourceResources.fieldConnectivityUpdatedAt' : 'protection.sourceResources.fieldAvailabilityUpdatedAt') }}</span>
-          <span class="hfl-detail-row__value" :class="{ 'hfl-detail-row__empty': !node.availability_updated_at }">{{ formatNodeDate(node.availability_updated_at) }}</span>
+          <span
+            class="hfl-detail-row__value"
+            :class="{ 'hfl-detail-row__empty': !node.availability_updated_at }"
+          >{{ formatNodeDate(node.availability_updated_at) }}</span>
         </div>
         <div class="hfl-detail-row">
           <span class="hfl-detail-row__label">{{ t(useBackupSourceTerminology ? 'protection.sourceResources.colRegisteredAt' : 'protection.sourceResources.colRegistered') }}</span>
-          <span class="hfl-detail-row__value" :class="{ 'hfl-detail-row__empty': !node.created_at }">{{ formatNodeDate(node.created_at) }}</span>
+          <span
+            class="hfl-detail-row__value"
+            :class="{ 'hfl-detail-row__empty': !node.created_at }"
+          >{{ formatNodeDate(node.created_at) }}</span>
         </div>
         <div class="hfl-detail-row">
           <span class="hfl-detail-row__label">{{ t('nodesPage.proxyDetailLastSeen') }}</span>
-          <span class="hfl-detail-row__value" :class="{ 'hfl-detail-row__empty': !node.last_seen_at }">{{ formatNodeDate(node.last_seen_at) }}</span>
+          <span
+            class="hfl-detail-row__value"
+            :class="{ 'hfl-detail-row__empty': !node.last_seen_at }"
+          >{{ formatNodeDate(node.last_seen_at) }}</span>
         </div>
       </div>
     </section>

--- a/src/frontend/src/components/NodeLifecycleWizard.vue
+++ b/src/frontend/src/components/NodeLifecycleWizard.vue
@@ -509,13 +509,20 @@ defineExpose({ clearInstallCommand })
     </ElAlert>
 
     <div class="fullscreen-form-step-stack">
-      <div v-if="showRolePicker && !roleLocked" class="fullscreen-form-card">
+      <div
+        v-if="showRolePicker && !roleLocked"
+        class="fullscreen-form-card"
+      >
         <section class="fullscreen-form-section">
           <h3 class="fullscreen-form-section__title">
             <span class="fullscreen-form-section__indicator" />
             {{ t('nodesDeploy.step2') }}
           </h3>
-          <ElRadioGroup :model-value="role" class="deploy-role-grid" @update:model-value="selectRole">
+          <ElRadioGroup
+            :model-value="role"
+            class="deploy-role-grid"
+            @update:model-value="selectRole"
+          >
             <ElRadio
               v-for="opt in roleOptions"
               :key="opt.value"
@@ -525,8 +532,12 @@ defineExpose({ clearInstallCommand })
               class="deploy-role-option !mr-0"
             >
               <div>
-                <div class="deploy-role-option__title">{{ opt.title }}</div>
-                <div class="deploy-role-option__desc">{{ opt.desc }}</div>
+                <div class="deploy-role-option__title">
+                  {{ opt.title }}
+                </div>
+                <div class="deploy-role-option__desc">
+                  {{ opt.desc }}
+                </div>
               </div>
             </ElRadio>
           </ElRadioGroup>
@@ -542,33 +553,46 @@ defineExpose({ clearInstallCommand })
           class="fullscreen-form-section"
           :class="{ 'agent-install-wizard__platform-section': installOnly }"
         >
-          <div v-if="installOnly" class="agent-install-wizard__platform-head">
+          <div
+            v-if="installOnly"
+            class="agent-install-wizard__platform-head"
+          >
             <h3 class="fullscreen-form-section__title">
               <span class="fullscreen-form-section__indicator" />
               {{ isUbuntuHostDeploy ? t('nodesDeploy.proxyReqTitle') : t('nodeLifecycle.osStep') }}
             </h3>
           </div>
-          <h3 v-else class="fullscreen-form-section__title">
+          <h3
+            v-else
+            class="fullscreen-form-section__title"
+          >
             <span class="fullscreen-form-section__indicator" />
             {{ isUbuntuHostDeploy ? t('nodesDeploy.proxyReqTitle') : t('nodeLifecycle.osStep') }}
           </h3>
 
           <template v-if="isUbuntuHostDeploy">
-            <div class="proxy-req-grid" role="list" :aria-label="t('nodesDeploy.proxyReqTitle')">
+            <div
+              class="proxy-req-grid"
+              role="list"
+              :aria-label="t('nodesDeploy.proxyReqTitle')"
+            >
               <div
                 v-for="card in proxyReqCards"
                 :key="card.key"
                 class="proxy-req-card"
                 role="listitem"
               >
-                <div class="proxy-req-card__icon-wrap" aria-hidden="true">
+                <div
+                  class="proxy-req-card__icon-wrap"
+                  aria-hidden="true"
+                >
                   <UbuntuBrandIcon
                     v-if="card.kind === 'ubuntu'"
                     class="proxy-req-card__brand proxy-req-card__brand--ubuntu"
                   />
                   <component
-                    v-else
                     :is="card.icon"
+                    v-else
                     class="proxy-req-card__brand proxy-req-card__brand--hardware"
                     :size="32"
                   />
@@ -602,9 +626,15 @@ defineExpose({ clearInstallCommand })
                   class="os-icon-card__icon-wrap"
                   :class="`os-icon-card__icon-wrap--${opt.value}`"
                 >
-                  <AgentPlatformBrandIcon :os="opt.value" class="os-icon-card__brand" />
+                  <AgentPlatformBrandIcon
+                    :os="opt.value"
+                    class="os-icon-card__brand"
+                  />
                 </span>
-                <span class="os-icon-card__check" aria-hidden="true">
+                <span
+                  class="os-icon-card__check"
+                  aria-hidden="true"
+                >
                   <span />
                 </span>
               </span>
@@ -613,13 +643,42 @@ defineExpose({ clearInstallCommand })
             </button>
           </div>
 
-          <ElRadioGroup v-else :model-value="os" class="source-radio-row" @update:model-value="selectOs">
-            <ElRadio value="linux" border class="source-radio-card !mr-0">{{ t('nodesDeploy.osLinux') }}</ElRadio>
-            <ElRadio value="windows" border class="source-radio-card !mr-0" :disabled="osDisabled.windows">{{ t('nodesDeploy.osWindows') }}</ElRadio>
-            <ElRadio value="macos" border class="source-radio-card !mr-0" :disabled="osDisabled.macos">{{ t('nodesDeploy.osMacos') }}</ElRadio>
+          <ElRadioGroup
+            v-else
+            :model-value="os"
+            class="source-radio-row"
+            @update:model-value="selectOs"
+          >
+            <ElRadio
+              value="linux"
+              border
+              class="source-radio-card !mr-0"
+            >
+              {{ t('nodesDeploy.osLinux') }}
+            </ElRadio>
+            <ElRadio
+              value="windows"
+              border
+              class="source-radio-card !mr-0"
+              :disabled="osDisabled.windows"
+            >
+              {{ t('nodesDeploy.osWindows') }}
+            </ElRadio>
+            <ElRadio
+              value="macos"
+              border
+              class="source-radio-card !mr-0"
+              :disabled="osDisabled.macos"
+            >
+              {{ t('nodesDeploy.osMacos') }}
+            </ElRadio>
           </ElRadioGroup>
 
-          <div v-if="installOnly && !isUbuntuHostDeploy" class="agent-os-support" :class="{ 'is-open': supportOpen }">
+          <div
+            v-if="installOnly && !isUbuntuHostDeploy"
+            class="agent-os-support"
+            :class="{ 'is-open': supportOpen }"
+          >
             <button
               type="button"
               class="agent-os-support__toggle"
@@ -628,25 +687,59 @@ defineExpose({ clearInstallCommand })
             >
               <span class="agent-os-support__toggle-main">
                 <span class="agent-os-support__toggle-icon">
-                  <Info :size="14" aria-hidden="true" />
+                  <Info
+                    :size="14"
+                    aria-hidden="true"
+                  />
                 </span>
                 <span>{{ viewSupportedLabel }}</span>
               </span>
-              <ChevronDown class="agent-os-support__chevron" :size="16" aria-hidden="true" />
+              <ChevronDown
+                class="agent-os-support__chevron"
+                :size="16"
+                aria-hidden="true"
+              />
             </button>
-            <div v-show="supportOpen" class="agent-os-support__body">
+            <div
+              v-show="supportOpen"
+              class="agent-os-support__body"
+            >
               <template v-if="os === 'linux'">
-                <p class="agent-os-support__group">{{ t('nodeLifecycle.supportedGroupDeb') }}</p>
+                <p class="agent-os-support__group">
+                  {{ t('nodeLifecycle.supportedGroupDeb') }}
+                </p>
                 <div class="agent-os-support__grid">
-                  <div v-for="name in LINUX_DISTROS.deb" :key="name" class="agent-os-support__chip">{{ name }}</div>
+                  <div
+                    v-for="name in LINUX_DISTROS.deb"
+                    :key="name"
+                    class="agent-os-support__chip"
+                  >
+                    {{ name }}
+                  </div>
                 </div>
-                <p class="agent-os-support__group">{{ t('nodeLifecycle.supportedGroupRpm') }}</p>
+                <p class="agent-os-support__group">
+                  {{ t('nodeLifecycle.supportedGroupRpm') }}
+                </p>
                 <div class="agent-os-support__grid">
-                  <div v-for="name in LINUX_DISTROS.rpm" :key="name" class="agent-os-support__chip">{{ name }}</div>
+                  <div
+                    v-for="name in LINUX_DISTROS.rpm"
+                    :key="name"
+                    class="agent-os-support__chip"
+                  >
+                    {{ name }}
+                  </div>
                 </div>
-                <p class="agent-os-support__group">{{ t('nodeLifecycle.supportedGroupCloud') }}</p>
+                <p class="agent-os-support__group">
+                  {{ t('nodeLifecycle.supportedGroupCloud') }}
+                </p>
                 <div class="agent-os-support__grid">
-                  <div v-for="name in LINUX_DISTROS.cloud" :key="name" class="agent-os-support__chip">{{ name }}</div>
+                  <div
+                    v-for="name in LINUX_DISTROS.cloud"
+                    :key="name"
+                    class="agent-os-support__chip"
+                  >
+                    {{ name }}
+                  </div>
                 </div>
                 <div class="agent-os-support__notes">
                   <p class="agent-os-support__note">
@@ -660,7 +753,9 @@ defineExpose({ clearInstallCommand })
                 </div>
               </template>
               <template v-else-if="os === 'windows'">
-                <p class="agent-os-support__group">{{ t('nodeLifecycle.supportedGroupDesktopServer') }}</p>
+                <p class="agent-os-support__group">
+                  {{ t('nodeLifecycle.supportedGroupDesktopServer') }}
+                </p>
                 <div class="agent-os-support__grid">
                   <div class="agent-os-support__chip">
                     <span class="agent-os-support__chip-name">Windows 10 / 11</span>
@@ -673,7 +768,9 @@ defineExpose({ clearInstallCommand })
                 </div>
               </template>
               <template v-else>
-                <p class="agent-os-support__group">{{ t('nodeLifecycle.supportedGroupHardware') }}</p>
+                <p class="agent-os-support__group">
+                  {{ t('nodeLifecycle.supportedGroupHardware') }}
+                </p>
                 <div class="agent-os-support__grid">
                   <div class="agent-os-support__chip">
                     <span class="agent-os-support__chip-name">Apple Silicon</span>
@@ -688,7 +785,12 @@ defineExpose({ clearInstallCommand })
             </div>
           </div>
 
-          <p v-if="linuxOnlyRoleHint && !isUbuntuHostDeploy" class="fullscreen-form-field__hint">{{ linuxOnlyRoleHint }}</p>
+          <p
+            v-if="linuxOnlyRoleHint && !isUbuntuHostDeploy"
+            class="fullscreen-form-field__hint"
+          >
+            {{ linuxOnlyRoleHint }}
+          </p>
         </section>
       </div>
 
@@ -705,18 +807,33 @@ defineExpose({ clearInstallCommand })
               tag="p"
               class="fullscreen-form-field__hint agent-install-wizard__command-lead"
             >
-              <template #root><strong>root</strong></template>
-              <template #sudo><strong>sudo</strong></template>
-              <template #cmd><strong>CMD</strong></template>
-              <template #powershell><strong>PowerShell</strong></template>
-              <template #administrator><strong>{{ t('nodeLifecycle.installLeadAdministrator') }}</strong></template>
-              <template #terminal><strong>{{ t('nodeLifecycle.installLeadTerminal') }}</strong></template>
+              <template #root>
+                <strong>root</strong>
+              </template>
+              <template #sudo>
+                <strong>sudo</strong>
+              </template>
+              <template #cmd>
+                <strong>CMD</strong>
+              </template>
+              <template #powershell>
+                <strong>PowerShell</strong>
+              </template>
+              <template #administrator>
+                <strong>{{ t('nodeLifecycle.installLeadAdministrator') }}</strong>
+              </template>
+              <template #terminal>
+                <strong>{{ t('nodeLifecycle.installLeadTerminal') }}</strong>
+              </template>
             </I18nT>
 
             <div class="source-script-shell agent-install-wizard__console">
               <div class="agent-install-wizard__console-bar">
                 <span>{{ consoleBarTitle }}</span>
-                <span v-if="installGenerated" class="agent-install-wizard__token-status">
+                <span
+                  v-if="installGenerated"
+                  class="agent-install-wizard__token-status"
+                >
                   <span>{{ tokenValidityLabel }}</span>
                 </span>
               </div>
@@ -728,7 +845,10 @@ defineExpose({ clearInstallCommand })
                 <pre class="agent-install-wizard__console-pre">{{ displayCommand }}</pre>
               </div>
               <div class="agent-install-wizard__console-foot agent-install-wizard__console-foot--copy-only">
-                <span v-if="installGenerated" class="agent-install-wizard__console-hint">
+                <span
+                  v-if="installGenerated"
+                  class="agent-install-wizard__console-hint"
+                >
                   {{ t('nodeLifecycle.installCommandReusable') }}
                 </span>
                 <button
@@ -738,7 +858,11 @@ defineExpose({ clearInstallCommand })
                   :disabled="loading"
                   @click="generateInstallCommand"
                 >
-                  <RefreshCw :size="12" :class="{ 'is-spinning': loading }" aria-hidden="true" />
+                  <RefreshCw
+                    :size="12"
+                    :class="{ 'is-spinning': loading }"
+                    aria-hidden="true"
+                  />
                   <span>{{ t('nodeLifecycle.generateInstallCommand') }}</span>
                 </button>
                 <button
@@ -749,23 +873,47 @@ defineExpose({ clearInstallCommand })
                   :disabled="!displayCommand || loading || !tokenIsUsable"
                   @click="onCopy"
                 >
-                  <Check v-if="copied" :size="12" aria-hidden="true" />
-                  <Copy v-else :size="12" aria-hidden="true" />
+                  <Check
+                    v-if="copied"
+                    :size="12"
+                    aria-hidden="true"
+                  />
+                  <Copy
+                    v-else
+                    :size="12"
+                    aria-hidden="true"
+                  />
                   <span>{{ copied ? t('nodesDeploy.copied') : t('nodesDeploy.clickCopyCmd') }}</span>
                 </button>
               </div>
             </div>
 
-            <div v-if="localCommandWarning" class="add-s3-warning agent-install-wizard__warn" role="note">
-              <TriangleAlert :size="16" aria-hidden="true" />
+            <div
+              v-if="localCommandWarning"
+              class="add-s3-warning agent-install-wizard__warn"
+              role="note"
+            >
+              <TriangleAlert
+                :size="16"
+                aria-hidden="true"
+              />
               <div class="agent-install-wizard__warn-body">
-                <p class="agent-install-wizard__warn-title">{{ t('nodeLifecycle.localInstallCommandTitle') }}</p>
-                <p class="agent-install-wizard__warn-desc">{{ t('nodeLifecycle.localInstallCommandWarning') }}</p>
+                <p class="agent-install-wizard__warn-title">
+                  {{ t('nodeLifecycle.localInstallCommandTitle') }}
+                </p>
+                <p class="agent-install-wizard__warn-desc">
+                  {{ t('nodeLifecycle.localInstallCommandWarning') }}
+                </p>
               </div>
             </div>
 
-            <div class="install-flow-note" :aria-label="t('nodeLifecycle.installFlowLabel')">
-              <p class="install-flow-note__label">{{ t('nodeLifecycle.installFlowLabel') }}</p>
+            <div
+              class="install-flow-note"
+              :aria-label="t('nodeLifecycle.installFlowLabel')"
+            >
+              <p class="install-flow-note__label">
+                {{ t('nodeLifecycle.installFlowLabel') }}
+              </p>
               <div class="install-flow-note__steps">
                 <p class="install-flow-note__step">
                   <strong>{{ t('nodeLifecycle.installFlowStepDownload') }}</strong>
@@ -781,139 +929,215 @@ defineExpose({ clearInstallCommand })
                 </p>
               </div>
             </div>
-
           </template>
 
           <template v-else>
-          <div class="node-lifecycle-wizard__tabs">
-            <button
-              v-for="tab in visibleTabs"
-              :key="tab"
-              type="button"
-              class="node-lifecycle-wizard__tab"
-              :class="{ 'node-lifecycle-wizard__tab--active': activeTab === tab }"
-              @click="activeTab = tab"
-            >
-              {{ t(`nodeLifecycle.tab.${tab}`) }}
-            </button>
-          </div>
-
-          <div class="agent-install-wizard__body-grid">
-            <div class="agent-install-wizard__platform">
-              <AgentPlatformBrandIcon :os="os" class="agent-install-wizard__platform-icon" />
-              <p class="agent-install-wizard__platform-name">{{ roleLabel }}</p>
-              <div v-if="activeTab !== 'install'" class="agent-install-wizard__platform-hints">
-                <p class="agent-install-wizard__platform-hint-line">
-                  <span>{{ t('nodeLifecycle.installPathLabel') }}</span>
-                  <strong>{{ paths.installDir }}</strong>
-                </p>
-                <p class="agent-install-wizard__platform-hint-line">
-                  <span>{{ t('nodeLifecycle.dataPathLabel') }}</span>
-                  <strong>{{ paths.dataDir }}</strong>
-                </p>
-                <p class="agent-install-wizard__platform-hint-line">
-                  <span>{{ t('nodeLifecycle.serviceNameLabel') }}</span>
-                  <strong>{{ paths.service }}</strong>
-                </p>
-              </div>
+            <div class="node-lifecycle-wizard__tabs">
+              <button
+                v-for="tab in visibleTabs"
+                :key="tab"
+                type="button"
+                class="node-lifecycle-wizard__tab"
+                :class="{ 'node-lifecycle-wizard__tab--active': activeTab === tab }"
+                @click="activeTab = tab"
+              >
+                {{ t(`nodeLifecycle.tab.${tab}`) }}
+              </button>
             </div>
 
-            <div class="agent-install-wizard__command-col">
-              <p class="fullscreen-form-field__hint agent-install-wizard__command-lead">{{ tabHint }}</p>
-
-              <ElAlert
-                v-if="activeTab === 'upgrade' && upgradeError"
-                type="error"
-                :closable="false"
-                show-icon
-                :title="upgradeError"
-              />
-
-              <div v-if="activeTab === 'uninstall'" class="node-lifecycle-wizard__options">
-                <ElCheckbox v-model="purgeAll">{{ t('nodeLifecycle.purgeAll') }}</ElCheckbox>
+            <div class="agent-install-wizard__body-grid">
+              <div class="agent-install-wizard__platform">
+                <AgentPlatformBrandIcon
+                  :os="os"
+                  class="agent-install-wizard__platform-icon"
+                />
+                <p class="agent-install-wizard__platform-name">
+                  {{ roleLabel }}
+                </p>
+                <div
+                  v-if="activeTab !== 'install'"
+                  class="agent-install-wizard__platform-hints"
+                >
+                  <p class="agent-install-wizard__platform-hint-line">
+                    <span>{{ t('nodeLifecycle.installPathLabel') }}</span>
+                    <strong>{{ paths.installDir }}</strong>
+                  </p>
+                  <p class="agent-install-wizard__platform-hint-line">
+                    <span>{{ t('nodeLifecycle.dataPathLabel') }}</span>
+                    <strong>{{ paths.dataDir }}</strong>
+                  </p>
+                  <p class="agent-install-wizard__platform-hint-line">
+                    <span>{{ t('nodeLifecycle.serviceNameLabel') }}</span>
+                    <strong>{{ paths.service }}</strong>
+                  </p>
+                </div>
               </div>
-              <div v-if="activeTab === 'service'" class="node-lifecycle-wizard__options">
-                <ElRadioGroup v-model="serviceAction" size="small">
-                  <ElRadio value="status">{{ t('nodeLifecycle.serviceStatus') }}</ElRadio>
-                  <ElRadio value="start">{{ t('nodeLifecycle.serviceStart') }}</ElRadio>
-                  <ElRadio value="stop">{{ t('nodeLifecycle.serviceStop') }}</ElRadio>
-                  <ElRadio value="restart">{{ t('nodeLifecycle.serviceRestart') }}</ElRadio>
-                </ElRadioGroup>
-              </div>
 
-              <div class="source-script-shell agent-install-wizard__console">
-                <div class="agent-install-wizard__console-bar">
-                  <span>{{ consoleBarTitle }}</span>
-                  <span v-if="activeTab === 'upgrade' && releaseVersion">v{{ releaseVersion }}</span>
-                  <span
-                    v-else-if="activeTab === 'install' && installGenerated"
-                    class="agent-install-wizard__token-status"
-                  >
-                    <span>{{ tokenValidityLabel }}</span>
-                  </span>
+              <div class="agent-install-wizard__command-col">
+                <p class="fullscreen-form-field__hint agent-install-wizard__command-lead">
+                  {{ tabHint }}
+                </p>
+
+                <ElAlert
+                  v-if="activeTab === 'upgrade' && upgradeError"
+                  type="error"
+                  :closable="false"
+                  show-icon
+                  :title="upgradeError"
+                />
+
+                <div
+                  v-if="activeTab === 'uninstall'"
+                  class="node-lifecycle-wizard__options"
+                >
+                  <ElCheckbox v-model="purgeAll">
+                    {{ t('nodeLifecycle.purgeAll') }}
+                  </ElCheckbox>
                 </div>
                 <div
-                  v-loading="loading && (activeTab === 'install' || activeTab === 'upgrade')"
-                  class="agent-install-wizard__console-body"
-                  element-loading-background="rgba(43, 45, 54, 0.88)"
+                  v-if="activeTab === 'service'"
+                  class="node-lifecycle-wizard__options"
                 >
-                  <div v-if="loading && activeTab === 'upgrade'" class="proxy-install-wizard__generating">
-                    <RefreshCw class="proxy-install-wizard__generating-icon" :size="14" aria-hidden="true" />
-                    <span>{{ t('nodeLifecycle.upgradeLoading') }}</span>
-                  </div>
-                  <pre v-else class="agent-install-wizard__console-pre">{{ displayCommand }}</pre>
-                </div>
-                <div class="agent-install-wizard__console-foot">
-                  <span class="agent-install-wizard__console-hint">
-                    <template v-if="activeTab === 'install' && installGenerated">
-                      {{ t('nodeLifecycle.installCommandReusable') }}
-                    </template>
-                    <template v-else>
-                      {{ footnote }}
-                    </template>
-                  </span>
-                  <button
-                    type="button"
-                    class="btn btn-primary agent-install-wizard__copy-btn"
-                    :class="{ 'agent-install-wizard__copy-btn--done': copied }"
-                    :disabled="!displayCommand || loading || (activeTab === 'install' && !tokenIsUsable)"
-                    @click="onCopy"
+                  <ElRadioGroup
+                    v-model="serviceAction"
+                    size="small"
                   >
-                    <Check v-if="copied" :size="12" aria-hidden="true" />
-                    <Copy v-else :size="12" aria-hidden="true" />
-                    <span>{{ copied ? t('nodesDeploy.copied') : t('nodesDeploy.clickCopyCmd') }}</span>
-                  </button>
+                    <ElRadio value="status">
+                      {{ t('nodeLifecycle.serviceStatus') }}
+                    </ElRadio>
+                    <ElRadio value="start">
+                      {{ t('nodeLifecycle.serviceStart') }}
+                    </ElRadio>
+                    <ElRadio value="stop">
+                      {{ t('nodeLifecycle.serviceStop') }}
+                    </ElRadio>
+                    <ElRadio value="restart">
+                      {{ t('nodeLifecycle.serviceRestart') }}
+                    </ElRadio>
+                  </ElRadioGroup>
                 </div>
-              </div>
 
-              <div
-                v-if="localCommandWarning"
-                class="add-s3-warning agent-install-wizard__warn"
-                role="note"
-              >
-                <TriangleAlert class="add-s3-warning__icon" :size="16" stroke-width="2" />
-                <div class="agent-install-wizard__warn-body">
-                  <p class="agent-install-wizard__warn-desc">{{ localCommandWarningText }}</p>
+                <div class="source-script-shell agent-install-wizard__console">
+                  <div class="agent-install-wizard__console-bar">
+                    <span>{{ consoleBarTitle }}</span>
+                    <span v-if="activeTab === 'upgrade' && releaseVersion">v{{ releaseVersion }}</span>
+                    <span
+                      v-else-if="activeTab === 'install' && installGenerated"
+                      class="agent-install-wizard__token-status"
+                    >
+                      <span>{{ tokenValidityLabel }}</span>
+                    </span>
+                  </div>
+                  <div
+                    v-loading="loading && (activeTab === 'install' || activeTab === 'upgrade')"
+                    class="agent-install-wizard__console-body"
+                    element-loading-background="rgba(43, 45, 54, 0.88)"
+                  >
+                    <div
+                      v-if="loading && activeTab === 'upgrade'"
+                      class="proxy-install-wizard__generating"
+                    >
+                      <RefreshCw
+                        class="proxy-install-wizard__generating-icon"
+                        :size="14"
+                        aria-hidden="true"
+                      />
+                      <span>{{ t('nodeLifecycle.upgradeLoading') }}</span>
+                    </div>
+                    <pre
+                      v-else
+                      class="agent-install-wizard__console-pre"
+                    >{{ displayCommand }}</pre>
+                  </div>
+                  <div class="agent-install-wizard__console-foot">
+                    <span class="agent-install-wizard__console-hint">
+                      <template v-if="activeTab === 'install' && installGenerated">
+                        {{ t('nodeLifecycle.installCommandReusable') }}
+                      </template>
+                      <template v-else>
+                        {{ footnote }}
+                      </template>
+                    </span>
+                    <button
+                      type="button"
+                      class="btn btn-primary agent-install-wizard__copy-btn"
+                      :class="{ 'agent-install-wizard__copy-btn--done': copied }"
+                      :disabled="!displayCommand || loading || (activeTab === 'install' && !tokenIsUsable)"
+                      @click="onCopy"
+                    >
+                      <Check
+                        v-if="copied"
+                        :size="12"
+                        aria-hidden="true"
+                      />
+                      <Copy
+                        v-else
+                        :size="12"
+                        aria-hidden="true"
+                      />
+                      <span>{{ copied ? t('nodesDeploy.copied') : t('nodesDeploy.clickCopyCmd') }}</span>
+                    </button>
+                  </div>
                 </div>
-              </div>
 
-              <div v-if="roleNote" class="add-s3-warning agent-install-wizard__warn" role="note">
-                <TriangleAlert class="add-s3-warning__icon" :size="16" stroke-width="2" />
-                <div class="agent-install-wizard__warn-body">
-                  <p class="agent-install-wizard__warn-title">{{ t('nodesDeploy.notesTitle') }}</p>
-                  <p class="agent-install-wizard__warn-desc">{{ roleNote }}</p>
+                <div
+                  v-if="localCommandWarning"
+                  class="add-s3-warning agent-install-wizard__warn"
+                  role="note"
+                >
+                  <TriangleAlert
+                    class="add-s3-warning__icon"
+                    :size="16"
+                    stroke-width="2"
+                  />
+                  <div class="agent-install-wizard__warn-body">
+                    <p class="agent-install-wizard__warn-desc">
+                      {{ localCommandWarningText }}
+                    </p>
+                  </div>
                 </div>
-              </div>
 
-              <div v-if="activeTab === 'upgrade'" class="add-s3-warning agent-install-wizard__warn" role="note">
-                <TriangleAlert class="add-s3-warning__icon" :size="16" stroke-width="2" />
-                <div class="agent-install-wizard__warn-body">
-                  <p class="agent-install-wizard__warn-desc">{{ t('nodeLifecycle.upgradeOnlineHint') }}</p>
-                  <p class="agent-install-wizard__warn-desc">{{ t('nodeLifecycle.upgradeInterruptHint') }}</p>
+                <div
+                  v-if="roleNote"
+                  class="add-s3-warning agent-install-wizard__warn"
+                  role="note"
+                >
+                  <TriangleAlert
+                    class="add-s3-warning__icon"
+                    :size="16"
+                    stroke-width="2"
+                  />
+                  <div class="agent-install-wizard__warn-body">
+                    <p class="agent-install-wizard__warn-title">
+                      {{ t('nodesDeploy.notesTitle') }}
+                    </p>
+                    <p class="agent-install-wizard__warn-desc">
+                      {{ roleNote }}
+                    </p>
+                  </div>
+                </div>
+
+                <div
+                  v-if="activeTab === 'upgrade'"
+                  class="add-s3-warning agent-install-wizard__warn"
+                  role="note"
+                >
+                  <TriangleAlert
+                    class="add-s3-warning__icon"
+                    :size="16"
+                    stroke-width="2"
+                  />
+                  <div class="agent-install-wizard__warn-body">
+                    <p class="agent-install-wizard__warn-desc">
+                      {{ t('nodeLifecycle.upgradeOnlineHint') }}
+                    </p>
+                    <p class="agent-install-wizard__warn-desc">
+                      {{ t('nodeLifecycle.upgradeInterruptHint') }}
+                    </p>
+                  </div>
                 </div>
               </div>
             </div>
-          </div>
           </template>
         </section>
       </div>

--- a/src/frontend/src/components/NodeMaintenancePanel.vue
+++ b/src/frontend/src/components/NodeMaintenancePanel.vue
@@ -54,7 +54,9 @@ async function copyCommand(command: string) {
       show-icon
       class="node-maintenance-panel__offline"
     >
-      <template #title>{{ t('nodeLifecycle.offlineMaintenanceTitle') }}</template>
+      <template #title>
+        {{ t('nodeLifecycle.offlineMaintenanceTitle') }}
+      </template>
       <div class="node-maintenance-panel__offline-body">
         <span>
           {{ node.last_seen_at
@@ -68,7 +70,11 @@ async function copyCommand(command: string) {
           :aria-label="t('nodeLifecycle.refreshNodeStatus')"
           @click="emit('refresh')"
         >
-          <RefreshCw v-if="!refreshing" :size="14" aria-hidden="true" />
+          <RefreshCw
+            v-if="!refreshing"
+            :size="14"
+            aria-hidden="true"
+          />
           {{ t('nodeLifecycle.refreshNodeStatus') }}
         </ElButton>
       </div>

--- a/src/frontend/src/components/NodePerfSettingsPanel.vue
+++ b/src/frontend/src/components/NodePerfSettingsPanel.vue
@@ -187,10 +187,14 @@ defineExpose({ hasPerfChanges, savePerfSettings, cancelPerfEdits, resetPerfDefau
 <template>
   <div class="hfl-detail-sections node-perf-drawer-sections">
     <section class="hfl-detail-section">
-      <h4 class="hfl-detail-section__title">{{ t('nodesDetail.perfResSection') }}</h4>
+      <h4 class="hfl-detail-section__title">
+        {{ t('nodesDetail.perfResSection') }}
+      </h4>
       <div class="hfl-detail-config-grid">
         <div class="hfl-detail-config-cell">
-          <div class="hfl-detail-config-cell__label">{{ t('nodesDetail.perfCpuCap') }}</div>
+          <div class="hfl-detail-config-cell__label">
+            {{ t('nodesDetail.perfCpuCap') }}
+          </div>
           <div class="hfl-detail-config-cell__slider-row">
             <ElSlider
               v-model="perfCpuCapCores"
@@ -202,11 +206,15 @@ defineExpose({ hasPerfChanges, savePerfSettings, cancelPerfEdits, resetPerfDefau
             />
             <span class="hfl-detail-config-cell__metric">{{ perfCpuDisplay }}</span>
           </div>
-          <p class="hfl-detail-config-cell__hint">{{ t('nodesDetail.perfDescCpu') }}</p>
+          <p class="hfl-detail-config-cell__hint">
+            {{ t('nodesDetail.perfDescCpu') }}
+          </p>
         </div>
 
         <div class="hfl-detail-config-cell">
-          <div class="hfl-detail-config-cell__label">{{ t('nodesDetail.perfMemSoft') }}</div>
+          <div class="hfl-detail-config-cell__label">
+            {{ t('nodesDetail.perfMemSoft') }}
+          </div>
           <div class="hfl-detail-config-cell__slider-row">
             <ElSlider
               v-model="perfMemCapMb"
@@ -218,11 +226,15 @@ defineExpose({ hasPerfChanges, savePerfSettings, cancelPerfEdits, resetPerfDefau
             />
             <span class="hfl-detail-config-cell__metric">{{ perfMemDisplay }}</span>
           </div>
-          <p class="hfl-detail-config-cell__hint">{{ t('nodesDetail.perfDescMem') }}</p>
+          <p class="hfl-detail-config-cell__hint">
+            {{ t('nodesDetail.perfDescMem') }}
+          </p>
         </div>
 
         <div class="hfl-detail-config-cell">
-          <div class="hfl-detail-config-cell__label">{{ t('nodesDetail.perfBandwidth') }}</div>
+          <div class="hfl-detail-config-cell__label">
+            {{ t('nodesDetail.perfBandwidth') }}
+          </div>
           <div class="hfl-detail-config-cell__control">
             <div class="hfl-detail-form-input hfl-detail-form-input--bandwidth">
               <ElInputNumber
@@ -237,29 +249,55 @@ defineExpose({ hasPerfChanges, savePerfSettings, cancelPerfEdits, resetPerfDefau
               </div>
             </div>
           </div>
-          <p class="hfl-detail-config-cell__hint">{{ t('nodesDetail.perfDescBandwidth') }}</p>
+          <p class="hfl-detail-config-cell__hint">
+            {{ t('nodesDetail.perfDescBandwidth') }}
+          </p>
         </div>
       </div>
     </section>
 
     <section class="hfl-detail-section">
-      <h4 class="hfl-detail-section__title">{{ t('nodesDetail.perfLogSection') }}</h4>
+      <h4 class="hfl-detail-section__title">
+        {{ t('nodesDetail.perfLogSection') }}
+      </h4>
       <div class="hfl-detail-config-grid">
         <div class="hfl-detail-config-cell">
-          <div class="hfl-detail-config-cell__label">{{ t('nodesDetail.perfLogLevel') }}</div>
+          <div class="hfl-detail-config-cell__label">
+            {{ t('nodesDetail.perfLogLevel') }}
+          </div>
           <div class="hfl-detail-config-cell__control">
-            <ElSelect v-model="perfLogLevel" class="hfl-detail-config-cell__select" teleported>
-              <ElOption value="debug" :label="t('nodesDetail.perfLogLevelDebug')" />
-              <ElOption value="info" :label="t('nodesDetail.perfLogLevelInfo')" />
-              <ElOption value="warning" :label="t('nodesDetail.perfLogLevelWarning')" />
-              <ElOption value="error" :label="t('nodesDetail.perfLogLevelError')" />
+            <ElSelect
+              v-model="perfLogLevel"
+              class="hfl-detail-config-cell__select"
+              teleported
+            >
+              <ElOption
+                value="debug"
+                :label="t('nodesDetail.perfLogLevelDebug')"
+              />
+              <ElOption
+                value="info"
+                :label="t('nodesDetail.perfLogLevelInfo')"
+              />
+              <ElOption
+                value="warning"
+                :label="t('nodesDetail.perfLogLevelWarning')"
+              />
+              <ElOption
+                value="error"
+                :label="t('nodesDetail.perfLogLevelError')"
+              />
             </ElSelect>
           </div>
-          <p class="hfl-detail-config-cell__hint">{{ t('nodesDetail.perfDescLogLevel') }}</p>
+          <p class="hfl-detail-config-cell__hint">
+            {{ t('nodesDetail.perfDescLogLevel') }}
+          </p>
         </div>
 
         <div class="hfl-detail-config-cell">
-          <div class="hfl-detail-config-cell__label">{{ t('nodesDetail.perfLogRetention') }}</div>
+          <div class="hfl-detail-config-cell__label">
+            {{ t('nodesDetail.perfLogRetention') }}
+          </div>
           <div class="hfl-detail-config-cell__control">
             <div class="hfl-detail-form-input hfl-detail-form-input--narrow">
               <ElInputNumber
@@ -274,11 +312,15 @@ defineExpose({ hasPerfChanges, savePerfSettings, cancelPerfEdits, resetPerfDefau
               </div>
             </div>
           </div>
-          <p class="hfl-detail-config-cell__hint">{{ t('nodesDetail.perfDescLogRetention') }}</p>
+          <p class="hfl-detail-config-cell__hint">
+            {{ t('nodesDetail.perfDescLogRetention') }}
+          </p>
         </div>
 
         <div class="hfl-detail-config-cell">
-          <div class="hfl-detail-config-cell__label">{{ t('nodesDetail.perfLogSpace') }}</div>
+          <div class="hfl-detail-config-cell__label">
+            {{ t('nodesDetail.perfLogSpace') }}
+          </div>
           <div class="hfl-detail-config-cell__control">
             <div class="hfl-detail-form-input hfl-detail-form-input--narrow">
               <ElInputNumber
@@ -294,17 +336,34 @@ defineExpose({ hasPerfChanges, savePerfSettings, cancelPerfEdits, resetPerfDefau
               </div>
             </div>
           </div>
-          <p class="hfl-detail-config-cell__hint">{{ t('nodesDetail.perfDescLogSpace') }}</p>
+          <p class="hfl-detail-config-cell__hint">
+            {{ t('nodesDetail.perfDescLogSpace') }}
+          </p>
         </div>
       </div>
     </section>
   </div>
 
-  <div v-if="!hideActions" class="node-perf-drawer-inline-actions">
-    <p class="hfl-detail-row__hint">{{ t('nodesDetail.perfApplyFooter') }}</p>
+  <div
+    v-if="!hideActions"
+    class="node-perf-drawer-inline-actions"
+  >
+    <p class="hfl-detail-row__hint">
+      {{ t('nodesDetail.perfApplyFooter') }}
+    </p>
     <div class="node-perf-drawer-inline-actions__btns">
-      <ElButton text @click="cancelPerfEdits">{{ t('nodesDetail.perfCancelEdits') }}</ElButton>
-      <ElButton plain @click="resetPerfDefaults">{{ t('nodesDetail.perfResetDefaults') }}</ElButton>
+      <ElButton
+        text
+        @click="cancelPerfEdits"
+      >
+        {{ t('nodesDetail.perfCancelEdits') }}
+      </ElButton>
+      <ElButton
+        plain
+        @click="resetPerfDefaults"
+      >
+        {{ t('nodesDetail.perfResetDefaults') }}
+      </ElButton>
       <ElButton
         type="primary"
         :disabled="!node || !hasPerfChanges"

--- a/src/frontend/src/components/OrgSwitcher.vue
+++ b/src/frontend/src/components/OrgSwitcher.vue
@@ -23,7 +23,10 @@ const {
     class="org-switcher"
     :class="`org-switcher--${props.variant}`"
   >
-    <label class="org-switcher__label" :for="controlId">{{ t('nav.orgSwitcher') }}</label>
+    <label
+      class="org-switcher__label"
+      :for="controlId"
+    >{{ t('nav.orgSwitcher') }}</label>
     <select
       :id="controlId"
       class="org-switcher__select"
@@ -31,7 +34,11 @@ const {
       :value="currentKey"
       @change="switchOrganization(($event.target as HTMLSelectElement).value)"
     >
-      <option v-for="org in organizations" :key="org.key" :value="org.key">
+      <option
+        v-for="org in organizations"
+        :key="org.key"
+        :value="org.key"
+      >
         {{ org.name }}
       </option>
     </select>

--- a/src/frontend/src/components/ProtectionStopConfirmDialog.vue
+++ b/src/frontend/src/components/ProtectionStopConfirmDialog.vue
@@ -159,7 +159,10 @@ function confirm() {
               min-width="180"
             >
               <template #default="{ row }">
-                <span class="hfl-table-cell-time" :class="{ 'hfl-empty-mark': detailText(row) === '—' }">{{ detailText(row) }}</span>
+                <span
+                  class="hfl-table-cell-time"
+                  :class="{ 'hfl-empty-mark': detailText(row) === '—' }"
+                >{{ detailText(row) }}</span>
               </template>
             </ElTableColumn>
           </ElTable>

--- a/src/frontend/src/components/ProxyNodeDetailDrawer.vue
+++ b/src/frontend/src/components/ProxyNodeDetailDrawer.vue
@@ -184,10 +184,19 @@ onUnmounted(() => {
       <span class="hfl-detail-drawer__title">{{ node?.name || '—' }}</span>
     </template>
 
-    <div v-loading="busy" class="hfl-detail-drawer__body">
+    <div
+      v-loading="busy"
+      class="hfl-detail-drawer__body"
+    >
       <template v-if="node">
-        <ElTabs v-model="drawerTab" class="hfl-detail-tabs">
-          <ElTabPane :label="t('protection.sourceResources.detailTabBasic')" name="basic">
+        <ElTabs
+          v-model="drawerTab"
+          class="hfl-detail-tabs"
+        >
+          <ElTabPane
+            :label="t('protection.sourceResources.detailTabBasic')"
+            name="basic"
+          >
             <NodeBasicInfoPanel
               ref="basicPanelRef"
               :node="node"
@@ -199,7 +208,10 @@ onUnmounted(() => {
             />
           </ElTabPane>
 
-          <ElTabPane :label="t('protection.sourceResources.detailTabAdvanced')" name="performance">
+          <ElTabPane
+            :label="t('protection.sourceResources.detailTabAdvanced')"
+            name="performance"
+          >
             <NodePerfSettingsPanel
               ref="perfPanelRef"
               hide-actions
@@ -208,7 +220,10 @@ onUnmounted(() => {
             />
           </ElTabPane>
 
-          <ElTabPane :label="t('protection.sourceResources.detailTabStorage')" name="storage">
+          <ElTabPane
+            :label="t('protection.sourceResources.detailTabStorage')"
+            name="storage"
+          >
             <ProxyStorageRepositoriesPanel
               v-if="nodeId != null"
               :node-id="nodeId"
@@ -217,7 +232,10 @@ onUnmounted(() => {
             />
           </ElTabPane>
 
-          <ElTabPane :label="t('protection.sourceResources.tabNas')" name="nas">
+          <ElTabPane
+            :label="t('protection.sourceResources.tabNas')"
+            name="nas"
+          >
             <ProxyBoundNasSourcesPanel
               v-if="nodeId != null"
               :node-id="nodeId"
@@ -225,7 +243,11 @@ onUnmounted(() => {
             />
           </ElTabPane>
 
-          <ElTabPane :label="t('nodeLifecycle.maintenance')" name="maintenance" lazy>
+          <ElTabPane
+            :label="t('nodeLifecycle.maintenance')"
+            name="maintenance"
+            lazy
+          >
             <NodeMaintenancePanel
               :node="node"
               :refreshing="busy"
@@ -235,10 +257,17 @@ onUnmounted(() => {
         </ElTabs>
       </template>
 
-      <ElEmpty v-else-if="!busy" :description="t('nodesPage.proxyDetailEmpty')" :image-size="72" />
+      <ElEmpty
+        v-else-if="!busy"
+        :description="t('nodesPage.proxyDetailEmpty')"
+        :image-size="72"
+      />
     </div>
 
-    <template v-if="node && drawerTab === 'performance'" #footer>
+    <template
+      v-if="node && drawerTab === 'performance'"
+      #footer
+    >
       <HflDetailDrawerFooter
         :saving="saving"
         :save-disabled="!hasDrawerChanges"

--- a/src/frontend/src/components/ProxyStorageRepositoriesPanel.vue
+++ b/src/frontend/src/components/ProxyStorageRepositoriesPanel.vue
@@ -431,8 +431,14 @@ watch(
           <template #header>
             <span class="repo-table-header-with-help">
               {{ t('repositoriesPage.colRepositoryUsage') }}
-              <ElTooltip :content="t('repositoriesPage.repositoryUsageHelp')" placement="top">
-                <Info :size="13" aria-hidden="true" />
+              <ElTooltip
+                :content="t('repositoriesPage.repositoryUsageHelp')"
+                placement="top"
+              >
+                <Info
+                  :size="13"
+                  aria-hidden="true"
+                />
               </ElTooltip>
             </span>
           </template>

--- a/src/frontend/src/components/RepositoryUsageCell.vue
+++ b/src/frontend/src/components/RepositoryUsageCell.vue
@@ -51,12 +51,21 @@ const unavailableSupportingLabel = computed(() => (
 </script>
 
 <template>
-  <div class="repository-estimated-usage" :class="`repository-estimated-usage--${variant}`">
+  <div
+    class="repository-estimated-usage"
+    :class="`repository-estimated-usage--${variant}`"
+  >
     <template v-if="status === 'success'">
       <div class="repository-estimated-usage__numbers">
         <span class="repository-estimated-usage__used">≈ {{ formatBytes(used) }}</span>
-        <span v-if="hasLimit" class="repository-estimated-usage__limit">/ {{ formatBytes(limit) }}</span>
-        <span v-if="hasLimit" class="repo-usage-cell__percent hfl-table-no-tooltip">{{ percent }}%</span>
+        <span
+          v-if="hasLimit"
+          class="repository-estimated-usage__limit"
+        >/ {{ formatBytes(limit) }}</span>
+        <span
+          v-if="hasLimit"
+          class="repo-usage-cell__percent hfl-table-no-tooltip"
+        >{{ percent }}%</span>
         <HflPopover
           v-if="warning"
           trigger="hover"
@@ -66,11 +75,18 @@ const unavailableSupportingLabel = computed(() => (
           popper-class="repository-info-popper repository-warning-popper"
         >
           <template #reference>
-            <AlertTriangle class="repository-estimated-usage__warning" :size="15" aria-hidden="true" />
+            <AlertTriangle
+              class="repository-estimated-usage__warning"
+              :size="15"
+              aria-hidden="true"
+            />
           </template>
           <div class="repository-info-popover repository-capacity-popover">
             <div class="repository-info-popover__head repository-capacity-popover__head">
-              <span class="repository-capacity-popover__icon" aria-hidden="true">
+              <span
+                class="repository-capacity-popover__icon"
+                aria-hidden="true"
+              >
                 <AlertTriangle :size="17" />
               </span>
               <div class="repository-info-popover__title">
@@ -96,14 +112,26 @@ const unavailableSupportingLabel = computed(() => (
           </div>
         </HflPopover>
       </div>
-      <div v-if="hasLimit && showBar" class="repo-usage-bar">
-        <span class="repo-usage-bar__fill" :style="{ width: `${percent}%` }" />
+      <div
+        v-if="hasLimit && showBar"
+        class="repo-usage-bar"
+      >
+        <span
+          class="repo-usage-bar__fill"
+          :style="{ width: `${percent}%` }"
+        />
       </div>
-      <span v-if="showSupporting" class="repository-estimated-usage__supporting">{{ supportingLabel }}</span>
+      <span
+        v-if="showSupporting"
+        class="repository-estimated-usage__supporting"
+      >{{ supportingLabel }}</span>
     </template>
     <template v-else>
       <span class="repository-estimated-usage__state">{{ stateLabel }}</span>
-      <span v-if="unavailableSupportingLabel" class="repository-estimated-usage__supporting">
+      <span
+        v-if="unavailableSupportingLabel"
+        class="repository-estimated-usage__supporting"
+      >
         {{ unavailableSupportingLabel }}
       </span>
     </template>

--- a/src/frontend/src/components/ResourceNameSummaryCell.vue
+++ b/src/frontend/src/components/ResourceNameSummaryCell.vue
@@ -67,7 +67,10 @@ function onClick() {
     class="backup-source-cell backup-source-cell--summary backup-source-cell--clickable"
     @click.stop="onClick"
   >
-    <div v-if="showIcon" class="backup-source-cell__icon-col">
+    <div
+      v-if="showIcon"
+      class="backup-source-cell__icon-col"
+    >
       <S3PlatformBrandIcon
         v-if="kind === 's3'"
         :platform="s3Platform"
@@ -76,8 +79,8 @@ function onClick() {
         lucide-class="resource-name-summary-cell__main-icon text-slate-500"
       />
       <component
-        v-else
         :is="mainIcon"
+        v-else
         :size="16"
         class="resource-name-summary-cell__main-icon"
         :class="{
@@ -103,7 +106,11 @@ function onClick() {
           class="repo-protocol-pill repo-protocol-pill--icon-only"
           :class="`repo-protocol-pill--${protocol || 'nfs'}`"
         >
-          <component :is="nasMountProtocolIcon(protocol)" :size="12" stroke-width="2.25" />
+          <component
+            :is="nasMountProtocolIcon(protocol)"
+            :size="12"
+            stroke-width="2.25"
+          />
         </span>
       </ElTooltip>
     </div>
@@ -111,13 +118,22 @@ function onClick() {
       <span class="hfl-table-name-link hfl-table-name-link--single">
         {{ name }}
       </span>
-      <span v-if="summary" class="backup-source-cell__type">
+      <span
+        v-if="summary"
+        class="backup-source-cell__type"
+      >
         {{ summary }}
       </span>
     </span>
   </button>
-  <span v-else class="backup-source-cell backup-source-cell--summary">
-    <span v-if="showIcon" class="backup-source-cell__icon-col">
+  <span
+    v-else
+    class="backup-source-cell backup-source-cell--summary"
+  >
+    <span
+      v-if="showIcon"
+      class="backup-source-cell__icon-col"
+    >
       <S3PlatformBrandIcon
         v-if="kind === 's3'"
         :platform="s3Platform"
@@ -125,13 +141,21 @@ function onClick() {
         icon-class="resource-name-summary-cell__s3-icon"
         lucide-class="resource-name-summary-cell__main-icon text-slate-500"
       />
-      <component v-else :is="mainIcon" :size="16" class="resource-name-summary-cell__main-icon text-slate-500" />
+      <component
+        :is="mainIcon"
+        v-else
+        :size="16"
+        class="resource-name-summary-cell__main-icon text-slate-500"
+      />
     </span>
     <span class="backup-source-cell__body">
       <span class="hfl-table-name-link hfl-table-name-link--single">
         {{ name }}
       </span>
-      <span v-if="summary" class="backup-source-cell__type">
+      <span
+        v-if="summary"
+        class="backup-source-cell__type"
+      >
         {{ summary }}
       </span>
     </span>

--- a/src/frontend/src/components/S3PlatformBrandIcon.vue
+++ b/src/frontend/src/components/S3PlatformBrandIcon.vue
@@ -10,7 +10,9 @@ const props = withDefaults(defineProps<{
   iconClass?: string
   lucideClass?: string
 }>(), {
+  platform: null,
   size: 18,
+  alt: '',
   iconClass: '',
   lucideClass: '',
 })
@@ -37,5 +39,5 @@ const usesDatabaseIcon = computed(() => {
     :height="size"
     loading="lazy"
     decoding="async"
-  />
+  >
 </template>

--- a/src/frontend/src/components/Sidebar.vue
+++ b/src/frontend/src/components/Sidebar.vue
@@ -135,19 +135,36 @@ const collapsedNavItems = computed<FlatNavItem[]>(() => {
 </script>
 
 <template>
-  <aside :class="{ collapsed }" class="sidebar">
+  <aside
+    :class="{ collapsed }"
+    class="sidebar"
+  >
     <div class="sidebar-content">
-      <div v-if="$slots.prepend && !collapsed" class="sidebar-prepend">
+      <div
+        v-if="$slots.prepend && !collapsed"
+        class="sidebar-prepend"
+      >
         <slot name="prepend" />
       </div>
 
-      <nav v-if="collapsed" class="sidebar-nav sidebar-nav--collapsed">
-        <template v-for="(nav, idx) in collapsedNavItems" :key="nav.to || nav.label">
+      <nav
+        v-if="collapsed"
+        class="sidebar-nav sidebar-nav--collapsed"
+      >
+        <template
+          v-for="(nav, idx) in collapsedNavItems"
+          :key="nav.to || nav.label"
+        >
           <div
             v-if="idx > 0 && collapsedNavItems[idx - 1].groupIndex !== nav.groupIndex"
             class="collapsed-divider"
           />
-          <ElTooltip v-if="nav.to" placement="right" :content="nav.label" :show-after="100">
+          <ElTooltip
+            v-if="nav.to"
+            placement="right"
+            :content="nav.label"
+            :show-after="100"
+          >
             <RouterLink
               :to="nav.to"
               :class="{ active: isActive(nav.to) }"
@@ -155,21 +172,47 @@ const collapsedNavItems = computed<FlatNavItem[]>(() => {
               class="collapsed-icon-btn"
               @click="handleNavClick($event, nav.to)"
             >
-              <component :is="nav.icon || HelpCircle" :size="18" class="collapsed-icon-btn__icon" />
+              <component
+                :is="nav.icon || HelpCircle"
+                :size="18"
+                class="collapsed-icon-btn__icon"
+              />
             </RouterLink>
           </ElTooltip>
-          <ElTooltip v-else placement="right" :content="nav.label" :show-after="100">
+          <ElTooltip
+            v-else
+            placement="right"
+            :content="nav.label"
+            :show-after="100"
+          >
             <div class="collapsed-icon-btn collapsed-icon-btn--disabled">
-              <component :is="nav.icon || HelpCircle" :size="18" class="collapsed-icon-btn__icon" />
+              <component
+                :is="nav.icon || HelpCircle"
+                :size="18"
+                class="collapsed-icon-btn__icon"
+              />
             </div>
           </ElTooltip>
         </template>
       </nav>
 
-      <nav v-else class="sidebar-nav">
-        <template v-for="(item, index) in menus" :key="index">
-          <div v-if="item.children && item.children.length > 0" class="menu-item">
-            <div class="menu-parent" :class="{ expanded: expandedParentIndices.has(index) }" @click.stop="toggleExpand(index)">
+      <nav
+        v-else
+        class="sidebar-nav"
+      >
+        <template
+          v-for="(item, index) in menus"
+          :key="index"
+        >
+          <div
+            v-if="item.children && item.children.length > 0"
+            class="menu-item"
+          >
+            <div
+              class="menu-parent"
+              :class="{ expanded: expandedParentIndices.has(index) }"
+              @click.stop="toggleExpand(index)"
+            >
               <span class="menu-label">{{ item.label }}</span>
               <ChevronRight
                 :size="14"
@@ -178,8 +221,14 @@ const collapsedNavItems = computed<FlatNavItem[]>(() => {
               />
             </div>
             <Transition name="slide">
-              <div v-if="expandedParentIndices.has(index)" class="submenu">
-                <template v-for="child in item.children" :key="child.to || child.label">
+              <div
+                v-if="expandedParentIndices.has(index)"
+                class="submenu"
+              >
+                <template
+                  v-for="child in item.children"
+                  :key="child.to || child.label"
+                >
                   <RouterLink
                     v-if="child.to"
                     :to="child.to"
@@ -188,17 +237,20 @@ const collapsedNavItems = computed<FlatNavItem[]>(() => {
                     @click="handleNavClick($event, child.to)"
                   >
                     <component
-                      v-if="child.icon"
                       :is="child.icon"
+                      v-if="child.icon"
                       :size="16"
                       class="submenu-item__icon"
                     />
                     <span class="submenu-item__label">{{ child.label }}</span>
                   </RouterLink>
-                  <div v-else class="submenu-item submenu-item--disabled">
+                  <div
+                    v-else
+                    class="submenu-item submenu-item--disabled"
+                  >
                     <component
-                      v-if="child.icon"
                       :is="child.icon"
+                      v-if="child.icon"
                       :size="16"
                       class="submenu-item__icon"
                     />
@@ -216,13 +268,21 @@ const collapsedNavItems = computed<FlatNavItem[]>(() => {
             class="menu-link"
             @click="handleNavClick($event, item.to)"
           >
-            <component v-if="item.icon" :is="item.icon" :size="16" class="menu-link__icon" />
+            <component
+              :is="item.icon"
+              v-if="item.icon"
+              :size="16"
+              class="menu-link__icon"
+            />
             <span class="menu-link__label">{{ item.label }}</span>
           </RouterLink>
         </template>
       </nav>
 
-      <div class="sidebar-footer" @click="emit('toggle')">
+      <div
+        class="sidebar-footer"
+        @click="emit('toggle')"
+      >
         <ChevronLeft
           :size="16"
           :class="{ 'rotated': collapsed }"

--- a/src/frontend/src/components/SnapshotStatusTag.vue
+++ b/src/frontend/src/components/SnapshotStatusTag.vue
@@ -25,7 +25,10 @@ const label = computed(() => {
 </script>
 
 <template>
-  <ElTag v-bind="lifecycleStatusTagAttrs(status)" size="small">
+  <ElTag
+    v-bind="lifecycleStatusTagAttrs(status)"
+    size="small"
+  >
     {{ label }}
   </ElTag>
 </template>

--- a/src/frontend/src/components/SourceProxyCell.vue
+++ b/src/frontend/src/components/SourceProxyCell.vue
@@ -44,10 +44,20 @@ const tooltipText = computed(() => {
 </script>
 
 <template>
-  <ElTooltip :content="tooltipText" :disabled="!tooltipText" placement="right">
+  <ElTooltip
+    :content="tooltipText"
+    :disabled="!tooltipText"
+    placement="right"
+  >
     <div class="source-proxy-cell">
-      <span class="source-proxy-cell__name" :class="{ 'hfl-empty-mark': !displayName }">{{ displayName || '—' }}</span>
-      <span v-if="displayIp" class="source-proxy-cell__ip">{{ displayIp }}</span>
+      <span
+        class="source-proxy-cell__name"
+        :class="{ 'hfl-empty-mark': !displayName }"
+      >{{ displayName || '—' }}</span>
+      <span
+        v-if="displayIp"
+        class="source-proxy-cell__ip"
+      >{{ displayIp }}</span>
     </div>
   </ElTooltip>
 </template>

--- a/src/frontend/src/components/WizardSteps.vue
+++ b/src/frontend/src/components/WizardSteps.vue
@@ -87,8 +87,8 @@ function onStepClick(item: WizardStepItem, index: number) {
         <span class="wizard-steps__num">
           <template v-if="isStepDone(item, index)">✓</template>
           <component
-            v-else-if="item.icon"
             :is="item.icon"
+            v-else-if="item.icon"
             class="wizard-steps__icon"
             :size="14"
             stroke-width="2"
@@ -111,8 +111,8 @@ function onStepClick(item: WizardStepItem, index: number) {
         <span class="wizard-steps__num">
           <template v-if="isStepDone(item, index)">✓</template>
           <component
-            v-else-if="item.icon"
             :is="item.icon"
+            v-else-if="item.icon"
             class="wizard-steps__icon"
             :size="14"
             stroke-width="2"

--- a/src/frontend/src/components/agent-deploy/AgentPlatformBrandIcon.vue
+++ b/src/frontend/src/components/agent-deploy/AgentPlatformBrandIcon.vue
@@ -28,13 +28,22 @@ defineProps<{
         d="M42 21s9-18-8-31c16 17 6 32 6 32h-3C36-13 27 6 14-56 29-73 0-88 0-60h-9c1-24-20-12-8 5-1 37-23 52-23 78-7-18 6-32 6-32s-18 15-7 37 31 17 17 27c22 15 56 5 55-27 1-8 22-5 24-3s-3-4-13-4m-56-78c-7-2-5-11-2-11s8 7 2 11m19 1c-5-7-1-14 4-13s5 13-4 13"
         fill="#ffffff"
       />
-      <g fill="#fabf24" stroke="#1e293b" stroke-width="1.2" stroke-linejoin="round" stroke-linecap="round">
+      <g
+        fill="#fabf24"
+        stroke="#1e293b"
+        stroke-width="1.2"
+        stroke-linejoin="round"
+        stroke-linecap="round"
+      >
         <path
           d="M-41 31l21 30c11 7 5 35-25 21-17-5-31-4-33-13s4-10 3-14c-4-22 14-11 19-22s5-16 15-2M71 45c-4-6 0-17-14-16-6 12-23 24-24 0-10 0-3 24-7 35-9 27 17 29 28 16l26-18c2-3 5-6-9-17m-92-92c-3-6 11-14 16-14s12 4 19 6 4 9 2 10S3-35-5-35s-10-8-16-12"
         />
         <path d="M-21-48c8 6 17 11 35-3" />
       </g>
-      <path d="M-10-54c-2 0 1-2 2-1m7 1c1-1-1-2-3-1" fill="#1e293b" />
+      <path
+        d="M-10-54c-2 0 1-2 2-1m7 1c1-1-1-2-3-1"
+        fill="#1e293b"
+      />
     </g>
   </svg>
 
@@ -48,10 +57,22 @@ defineProps<{
     xmlns="http://www.w3.org/2000/svg"
     aria-hidden="true"
   >
-    <path d="M16 26 L52 21 L52 56 L16 56 Z" fill="#00adef" />
-    <path d="M16 61 L52 61 L52 96 L16 91 Z" fill="#00adef" />
-    <path d="M57 20 L104 14 L104 56 L57 56 Z" fill="#0078d7" />
-    <path d="M57 61 L104 61 L104 103 L57 97 Z" fill="#0078d7" />
+    <path
+      d="M16 26 L52 21 L52 56 L16 56 Z"
+      fill="#00adef"
+    />
+    <path
+      d="M16 61 L52 61 L52 96 L16 91 Z"
+      fill="#00adef"
+    />
+    <path
+      d="M57 20 L104 14 L104 56 L57 56 Z"
+      fill="#0078d7"
+    />
+    <path
+      d="M57 61 L104 61 L104 103 L57 97 Z"
+      fill="#0078d7"
+    />
   </svg>
 
   <!-- Apple Logo -->

--- a/src/frontend/src/components/ai-model/AiProviderIcon.vue
+++ b/src/frontend/src/components/ai-model/AiProviderIcon.vue
@@ -25,7 +25,11 @@ const style = computed(() => ({
 </script>
 
 <template>
-  <span class="ai-provider-icon" :style="style" aria-hidden="true">
+  <span
+    class="ai-provider-icon"
+    :style="style"
+    aria-hidden="true"
+  >
     {{ aiProviderLetter(provider) }}
   </span>
 </template>

--- a/src/frontend/src/components/auth/EmailCodeLoginForm.vue
+++ b/src/frontend/src/components/auth/EmailCodeLoginForm.vue
@@ -316,10 +316,20 @@ onBeforeUnmount(() => {
 
 <template>
   <div class="email-code-login-form">
-    <div class="input-wrapper" :class="{ 'has-error': emailError }">
-      <label class="sr-only" for="email-code-login-email">{{ t('login.emailPh') }}</label>
+    <div
+      class="input-wrapper"
+      :class="{ 'has-error': emailError }"
+    >
+      <label
+        class="sr-only"
+        for="email-code-login-email"
+      >{{ t('login.emailPh') }}</label>
       <div class="input-row">
-        <Mail class="input-icon" :size="18" aria-hidden="true" />
+        <Mail
+          class="input-icon"
+          :size="18"
+          aria-hidden="true"
+        />
         <input
           id="email-code-login-email"
           v-model="email"
@@ -331,15 +341,31 @@ onBeforeUnmount(() => {
           @input="validateEmail"
           @blur="validateEmail"
           @keyup.enter="sendCode"
-        />
+        >
       </div>
-      <p v-if="emailError" class="error-msg" role="alert">{{ emailError }}</p>
+      <p
+        v-if="emailError"
+        class="error-msg"
+        role="alert"
+      >
+        {{ emailError }}
+      </p>
     </div>
 
-    <div class="input-wrapper" :class="{ 'has-error': codeError }">
-      <label class="sr-only" for="email-code-login-code">{{ t('login.emailCodePlaceholder') }}</label>
+    <div
+      class="input-wrapper"
+      :class="{ 'has-error': codeError }"
+    >
+      <label
+        class="sr-only"
+        for="email-code-login-code"
+      >{{ t('login.emailCodePlaceholder') }}</label>
       <div class="input-row email-code-login-form__code-row">
-        <KeyRound class="input-icon" :size="18" aria-hidden="true" />
+        <KeyRound
+          class="input-icon"
+          :size="18"
+          aria-hidden="true"
+        />
         <input
           id="email-code-login-code"
           ref="codeInputRef"
@@ -353,7 +379,7 @@ onBeforeUnmount(() => {
           :aria-invalid="Boolean(codeError)"
           @input="sanitizeCode"
           @keyup.enter="verifyCode"
-        />
+        >
         <button
           type="button"
           class="email-code-login-form__send"
@@ -363,7 +389,13 @@ onBeforeUnmount(() => {
           {{ sendLabel }}
         </button>
       </div>
-      <p v-if="codeError" class="error-msg" role="alert">{{ codeError }}</p>
+      <p
+        v-if="codeError"
+        class="error-msg"
+        role="alert"
+      >
+        {{ codeError }}
+      </p>
     </div>
 
     <ElButton

--- a/src/frontend/src/components/auth/ResetPasswordCard.vue
+++ b/src/frontend/src/components/auth/ResetPasswordCard.vue
@@ -437,14 +437,29 @@ onUnmounted(() => {
 
 <template>
   <div class="reset-password-card">
-    <Transition name="reset-view-fade" mode="out-in">
+    <Transition
+      name="reset-view-fade"
+      mode="out-in"
+    >
       <!-- Request View -->
-      <div v-if="view === 'request'" key="request" class="reset-view">
-        <p class="reset-subtitle">{{ t('findPwd.requestSubtitle') }}</p>
+      <div
+        v-if="view === 'request'"
+        key="request"
+        class="reset-view"
+      >
+        <p class="reset-subtitle">
+          {{ t('findPwd.requestSubtitle') }}
+        </p>
 
-        <div class="input-wrapper" :class="{ 'has-error': formItems.email.showError }">
+        <div
+          class="input-wrapper"
+          :class="{ 'has-error': formItems.email.showError }"
+        >
           <div class="input-row">
-            <Mail class="input-icon" :size="18" />
+            <Mail
+              class="input-icon"
+              :size="18"
+            />
             <input
               v-model="formItems.email.value"
               type="text"
@@ -454,12 +469,24 @@ onUnmounted(() => {
               @blur="validateEmailOnInput"
               @input="validateEmailOnInput(); emailNotRegistered = false"
               @keyup.enter="sendResetCode"
-            />
+            >
           </div>
-          <p v-if="formItems.email.showError" class="error-msg">{{ formItems.email.errorMsg }}</p>
-          <p v-if="emailNotRegistered" class="register-hint">
+          <p
+            v-if="formItems.email.showError"
+            class="error-msg"
+          >
+            {{ formItems.email.errorMsg }}
+          </p>
+          <p
+            v-if="emailNotRegistered"
+            class="register-hint"
+          >
             <span>{{ t('findPwd.emailNotRegisteredHint') }}</span>
-            <a href="#" class="register-hint-link" @click.prevent="goRegister">{{ t('findPwd.signUp') }}</a>
+            <a
+              href="#"
+              class="register-hint-link"
+              @click.prevent="goRegister"
+            >{{ t('findPwd.signUp') }}</a>
           </p>
         </div>
 
@@ -497,13 +524,22 @@ onUnmounted(() => {
       </div>
 
       <!-- Reset View -->
-      <div v-else key="reset" class="reset-view">
-        <p class="reset-email-hint">{{ t('findPwd.codeSentTo', { email: maskedEmail }) }}</p>
+      <div
+        v-else
+        key="reset"
+        class="reset-view"
+      >
+        <p class="reset-email-hint">
+          {{ t('findPwd.codeSentTo', { email: maskedEmail }) }}
+        </p>
 
         <div class="input-wrapper">
           <div class="captcha-row">
             <div class="input-row captcha-input">
-              <Key class="input-icon" :size="18" />
+              <Key
+                class="input-icon"
+                :size="18"
+              />
               <input
                 v-model="resetCode"
                 type="text"
@@ -514,7 +550,7 @@ onUnmounted(() => {
                 tabindex="1"
                 autocomplete="one-time-code"
                 @input="clearResetError"
-              />
+              >
             </div>
             <button
               type="button"
@@ -533,7 +569,10 @@ onUnmounted(() => {
 
         <div class="input-wrapper">
           <div class="input-row">
-            <Lock class="input-icon" :size="18" />
+            <Lock
+              class="input-icon"
+              :size="18"
+            />
             <input
               v-model="newPassword"
               :type="showNewPassword ? 'text' : 'password'"
@@ -541,7 +580,7 @@ onUnmounted(() => {
               tabindex="2"
               autocomplete="new-password"
               @input="clearResetError"
-            />
+            >
             <button
               type="button"
               class="eye-btn"
@@ -549,15 +588,24 @@ onUnmounted(() => {
               :aria-pressed="showNewPassword"
               @click="showNewPassword = !showNewPassword"
             >
-              <EyeOff v-if="showNewPassword" :size="16" />
-              <Eye v-else :size="16" />
+              <EyeOff
+                v-if="showNewPassword"
+                :size="16"
+              />
+              <Eye
+                v-else
+                :size="16"
+              />
             </button>
           </div>
         </div>
 
         <div class="input-wrapper">
           <div class="input-row">
-            <Lock class="input-icon" :size="18" />
+            <Lock
+              class="input-icon"
+              :size="18"
+            />
             <input
               v-model="confirmPassword"
               :type="showConfirmPassword ? 'text' : 'password'"
@@ -567,7 +615,7 @@ onUnmounted(() => {
               @input="onConfirmPasswordInput"
               @blur="confirmPasswordTouched = true"
               @keyup.enter="handleUpdatePassword"
-            />
+            >
             <button
               type="button"
               class="eye-btn"
@@ -575,24 +623,46 @@ onUnmounted(() => {
               :aria-pressed="showConfirmPassword"
               @click="showConfirmPassword = !showConfirmPassword"
             >
-              <EyeOff v-if="showConfirmPassword" :size="16" />
-              <Eye v-else :size="16" />
+              <EyeOff
+                v-if="showConfirmPassword"
+                :size="16"
+              />
+              <Eye
+                v-else
+                :size="16"
+              />
             </button>
           </div>
-          <p v-if="confirmPasswordError" class="error-msg">{{ confirmPasswordError }}</p>
+          <p
+            v-if="confirmPasswordError"
+            class="error-msg"
+          >
+            {{ confirmPasswordError }}
+          </p>
         </div>
 
-        <div v-if="newPassword" class="strength-bar-wrapper">
+        <div
+          v-if="newPassword"
+          class="strength-bar-wrapper"
+        >
           <div class="strength-bar">
             <div
               class="strength-fill"
               :style="{ width: (passwordStrength.level / 3 * 100) + '%', background: passwordStrength.color }"
-            ></div>
+            />
           </div>
-          <span class="strength-text" :style="{ color: passwordStrength.color }">{{ passwordStrength.text }}</span>
+          <span
+            class="strength-text"
+            :style="{ color: passwordStrength.color }"
+          >{{ passwordStrength.text }}</span>
         </div>
 
-        <p v-if="resetError" class="error-msg reset-error">{{ resetError }}</p>
+        <p
+          v-if="resetError"
+          class="error-msg reset-error"
+        >
+          {{ resetError }}
+        </p>
 
         <ElButton
           type="primary"
@@ -602,7 +672,10 @@ onUnmounted(() => {
           :loading="resetLoading"
           @click="handleUpdatePassword"
         >
-          <span v-if="resetSuccess" class="btn-success-content">
+          <span
+            v-if="resetSuccess"
+            class="btn-success-content"
+          >
             <CheckCircle2 :size="18" />
           </span>
           <span v-else>{{ t('findPwd.updatePassword') }}</span>
@@ -612,7 +685,11 @@ onUnmounted(() => {
 
     <div class="reset-footer">
       <span class="footer-text">{{ t('findPwd.alreadyHaveAccount') }}</span>
-      <a href="#" class="footer-link sign-in-link" @click.prevent="emit('back-to-login')">
+      <a
+        href="#"
+        class="footer-link sign-in-link"
+        @click.prevent="emit('back-to-login')"
+      >
         {{ t('findPwd.signIn') }}
       </a>
     </div>

--- a/src/frontend/src/components/copilot/CopilotMarkdown.test.ts
+++ b/src/frontend/src/components/copilot/CopilotMarkdown.test.ts
@@ -1,0 +1,30 @@
+// @vitest-environment jsdom
+
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import CopilotMarkdown from './CopilotMarkdown.vue'
+
+describe('CopilotMarkdown', () => {
+  it('renders safe links without allowing executable protocols', () => {
+    const wrapper = mount(CopilotMarkdown, {
+      props: {
+        content: [
+          '[Documentation](https://example.com/docs)',
+          '[Unsafe](javascript:alert(1))',
+          '<img src=x onerror=alert(1)>',
+        ].join('\n\n'),
+      },
+    })
+
+    const links = wrapper.findAll('a')
+    expect(links).toHaveLength(1)
+    expect(links[0].attributes()).toEqual(expect.objectContaining({
+      href: 'https://example.com/docs',
+      rel: 'noopener noreferrer',
+      target: '_blank',
+    }))
+    expect(wrapper.html()).toContain('Unsafe')
+    expect(wrapper.html()).not.toContain('javascript:')
+    expect(wrapper.html()).toContain('&lt;img src=x onerror=alert(1)&gt;')
+  })
+})

--- a/src/frontend/src/components/copilot/CopilotMarkdown.vue
+++ b/src/frontend/src/components/copilot/CopilotMarkdown.vue
@@ -13,6 +13,17 @@ function escapeHtml(value: string) {
     .replace(/"/g, '&quot;')
 }
 
+function safeLinkHref(value: string): boolean {
+  const normalized = value.trim().toLowerCase()
+  return normalized.startsWith('https://')
+    || normalized.startsWith('http://')
+    || normalized.startsWith('mailto:')
+    || normalized.startsWith('/')
+    || normalized.startsWith('./')
+    || normalized.startsWith('../')
+    || normalized.startsWith('#')
+}
+
 function renderMarkdown(text: string): string {
   if (!text.trim()) return ''
   let html = escapeHtml(text.replace(/\r\n/g, '\n').replace(/\r/g, '\n'))
@@ -24,7 +35,9 @@ function renderMarkdown(text: string): string {
   html = html.replace(/\*\*([^*\n]+)\*\*/g, '<strong>$1</strong>')
   html = html.replace(
     /\[([^\]]+)\]\(([^)\s]+)\)/g,
-    '<a href="$2" target="_blank" rel="noopener noreferrer">$1</a>',
+    (_match, label: string, href: string) => safeLinkHref(href)
+      ? `<a href="${href}" target="_blank" rel="noopener noreferrer">${label}</a>`
+      : label,
   )
 
   return html
@@ -40,8 +53,13 @@ const rendered = computed(() => renderMarkdown(props.content))
 </script>
 
 <template>
-  <!-- eslint-disable-next-line vue/no-v-html -->
-  <div class="copilot-markdown" v-html="rendered" />
+  <!-- Content is escaped and link protocols are allowlisted before rendering. -->
+  <!-- eslint-disable vue/no-v-html -->
+  <div
+    class="copilot-markdown"
+    v-html="rendered"
+  />
+  <!-- eslint-enable vue/no-v-html -->
 </template>
 
 <style scoped>

--- a/src/frontend/src/components/dashboard/DashboardIdleGearIllustration.vue
+++ b/src/frontend/src/components/dashboard/DashboardIdleGearIllustration.vue
@@ -26,38 +26,124 @@ const gearEdge = gearPath(36, 34.5, 8, 18.5, 14)
     aria-hidden="true"
   >
     <defs>
-      <radialGradient id="dashboardIdleGearShadow" cx="50%" cy="50%" r="50%">
-        <stop offset="0%" stop-color="#8b7cf8" stop-opacity="0.24" />
-        <stop offset="100%" stop-color="#8b7cf8" stop-opacity="0" />
+      <radialGradient
+        id="dashboardIdleGearShadow"
+        cx="50%"
+        cy="50%"
+        r="50%"
+      >
+        <stop
+          offset="0%"
+          stop-color="#8b7cf8"
+          stop-opacity="0.24"
+        />
+        <stop
+          offset="100%"
+          stop-color="#8b7cf8"
+          stop-opacity="0"
+        />
       </radialGradient>
-      <linearGradient id="dashboardIdleGearTop" x1="22" y1="16" x2="50" y2="48" gradientUnits="userSpaceOnUse">
+      <linearGradient
+        id="dashboardIdleGearTop"
+        x1="22"
+        y1="16"
+        x2="50"
+        y2="48"
+        gradientUnits="userSpaceOnUse"
+      >
         <stop stop-color="#ffffff" />
-        <stop offset="1" stop-color="#e7ebf3" />
+        <stop
+          offset="1"
+          stop-color="#e7ebf3"
+        />
       </linearGradient>
-      <linearGradient id="dashboardIdleGearSide" x1="22" y1="20" x2="50" y2="52" gradientUnits="userSpaceOnUse">
+      <linearGradient
+        id="dashboardIdleGearSide"
+        x1="22"
+        y1="20"
+        x2="50"
+        y2="52"
+        gradientUnits="userSpaceOnUse"
+      >
         <stop stop-color="#c8d0df" />
-        <stop offset="1" stop-color="#a7b2c6" />
+        <stop
+          offset="1"
+          stop-color="#a7b2c6"
+        />
       </linearGradient>
-      <linearGradient id="dashboardIdleGearHub" x1="32" y1="26" x2="40" y2="36" gradientUnits="userSpaceOnUse">
+      <linearGradient
+        id="dashboardIdleGearHub"
+        x1="32"
+        y1="26"
+        x2="40"
+        y2="36"
+        gradientUnits="userSpaceOnUse"
+      >
         <stop stop-color="#f8fafc" />
-        <stop offset="1" stop-color="#e2e8f0" />
+        <stop
+          offset="1"
+          stop-color="#e2e8f0"
+        />
       </linearGradient>
-      <filter id="dashboardIdleGearGlow" x="-30%" y="-20%" width="160%" height="170%">
-        <feDropShadow dx="0" dy="5" stdDeviation="4.5" flood-color="#7c6cf6" flood-opacity="0.16" />
+      <filter
+        id="dashboardIdleGearGlow"
+        x="-30%"
+        y="-20%"
+        width="160%"
+        height="170%"
+      >
+        <feDropShadow
+          dx="0"
+          dy="5"
+          stdDeviation="4.5"
+          flood-color="#7c6cf6"
+          flood-opacity="0.16"
+        />
       </filter>
     </defs>
 
-    <ellipse cx="36" cy="57" rx="19" ry="5" fill="url(#dashboardIdleGearShadow)" />
+    <ellipse
+      cx="36"
+      cy="57"
+      rx="19"
+      ry="5"
+      fill="url(#dashboardIdleGearShadow)"
+    />
 
     <g opacity="0.92">
-      <path :d="gearEdge" fill="url(#dashboardIdleGearSide)" />
-      <circle cx="36" cy="34.5" r="6.8" fill="#b8c2d3" />
+      <path
+        :d="gearEdge"
+        fill="url(#dashboardIdleGearSide)"
+      />
+      <circle
+        cx="36"
+        cy="34.5"
+        r="6.8"
+        fill="#b8c2d3"
+      />
     </g>
 
     <g filter="url(#dashboardIdleGearGlow)">
-      <path :d="gearBody" fill="url(#dashboardIdleGearTop)" stroke="#d5dce8" stroke-width="0.75" />
-      <circle cx="36" cy="31" r="6.8" fill="url(#dashboardIdleGearHub)" stroke="#d5dce8" stroke-width="0.75" />
-      <circle cx="36" cy="31" r="2.6" fill="#dbe2ec" />
+      <path
+        :d="gearBody"
+        fill="url(#dashboardIdleGearTop)"
+        stroke="#d5dce8"
+        stroke-width="0.75"
+      />
+      <circle
+        cx="36"
+        cy="31"
+        r="6.8"
+        fill="url(#dashboardIdleGearHub)"
+        stroke="#d5dce8"
+        stroke-width="0.75"
+      />
+      <circle
+        cx="36"
+        cy="31"
+        r="2.6"
+        fill="#dbe2ec"
+      />
     </g>
   </svg>
 </template>

--- a/src/frontend/src/components/dashboard/DashboardIdleShieldIllustration.vue
+++ b/src/frontend/src/components/dashboard/DashboardIdleShieldIllustration.vue
@@ -17,41 +17,134 @@ const shieldSide =
     aria-hidden="true"
   >
     <defs>
-      <radialGradient id="dashboardIdleShieldShadow" cx="50%" cy="50%" r="50%">
-        <stop offset="0%" stop-color="#818cf8" stop-opacity="0.26" />
-        <stop offset="100%" stop-color="#818cf8" stop-opacity="0" />
+      <radialGradient
+        id="dashboardIdleShieldShadow"
+        cx="50%"
+        cy="50%"
+        r="50%"
+      >
+        <stop
+          offset="0%"
+          stop-color="#818cf8"
+          stop-opacity="0.26"
+        />
+        <stop
+          offset="100%"
+          stop-color="#818cf8"
+          stop-opacity="0"
+        />
       </radialGradient>
-      <linearGradient id="dashboardIdleShieldTop" x1="24" y1="14" x2="48" y2="48" gradientUnits="userSpaceOnUse">
+      <linearGradient
+        id="dashboardIdleShieldTop"
+        x1="24"
+        y1="14"
+        x2="48"
+        y2="48"
+        gradientUnits="userSpaceOnUse"
+      >
         <stop stop-color="#ffffff" />
-        <stop offset="0.45" stop-color="#eef2ff" />
-        <stop offset="1" stop-color="#e7ebf3" />
+        <stop
+          offset="0.45"
+          stop-color="#eef2ff"
+        />
+        <stop
+          offset="1"
+          stop-color="#e7ebf3"
+        />
       </linearGradient>
-      <linearGradient id="dashboardIdleShieldSide" x1="24" y1="18" x2="48" y2="52" gradientUnits="userSpaceOnUse">
+      <linearGradient
+        id="dashboardIdleShieldSide"
+        x1="24"
+        y1="18"
+        x2="48"
+        y2="52"
+        gradientUnits="userSpaceOnUse"
+      >
         <stop stop-color="#c8d0df" />
-        <stop offset="1" stop-color="#9aa6bc" />
+        <stop
+          offset="1"
+          stop-color="#9aa6bc"
+        />
       </linearGradient>
-      <linearGradient id="dashboardIdleShieldTint" x1="28" y1="16" x2="44" y2="42" gradientUnits="userSpaceOnUse">
-        <stop stop-color="#818cf8" stop-opacity="0.18" />
-        <stop offset="1" stop-color="#a5b4fc" stop-opacity="0.08" />
+      <linearGradient
+        id="dashboardIdleShieldTint"
+        x1="28"
+        y1="16"
+        x2="44"
+        y2="42"
+        gradientUnits="userSpaceOnUse"
+      >
+        <stop
+          stop-color="#818cf8"
+          stop-opacity="0.18"
+        />
+        <stop
+          offset="1"
+          stop-color="#a5b4fc"
+          stop-opacity="0.08"
+        />
       </linearGradient>
-      <linearGradient id="dashboardIdleShieldHighlight" x1="30" y1="18" x2="38" y2="30" gradientUnits="userSpaceOnUse">
-        <stop stop-color="#ffffff" stop-opacity="0.85" />
-        <stop offset="1" stop-color="#ffffff" stop-opacity="0" />
+      <linearGradient
+        id="dashboardIdleShieldHighlight"
+        x1="30"
+        y1="18"
+        x2="38"
+        y2="30"
+        gradientUnits="userSpaceOnUse"
+      >
+        <stop
+          stop-color="#ffffff"
+          stop-opacity="0.85"
+        />
+        <stop
+          offset="1"
+          stop-color="#ffffff"
+          stop-opacity="0"
+        />
       </linearGradient>
-      <filter id="dashboardIdleShieldGlow" x="-30%" y="-20%" width="160%" height="170%">
-        <feDropShadow dx="0" dy="5" stdDeviation="4.5" flood-color="#7c6cf6" flood-opacity="0.18" />
+      <filter
+        id="dashboardIdleShieldGlow"
+        x="-30%"
+        y="-20%"
+        width="160%"
+        height="170%"
+      >
+        <feDropShadow
+          dx="0"
+          dy="5"
+          stdDeviation="4.5"
+          flood-color="#7c6cf6"
+          flood-opacity="0.18"
+        />
       </filter>
     </defs>
 
-    <ellipse cx="36" cy="57" rx="18" ry="5" fill="url(#dashboardIdleShieldShadow)" />
+    <ellipse
+      cx="36"
+      cy="57"
+      rx="18"
+      ry="5"
+      fill="url(#dashboardIdleShieldShadow)"
+    />
 
     <g opacity="0.92">
-      <path :d="shieldSide" fill="url(#dashboardIdleShieldSide)" />
+      <path
+        :d="shieldSide"
+        fill="url(#dashboardIdleShieldSide)"
+      />
     </g>
 
     <g filter="url(#dashboardIdleShieldGlow)">
-      <path :d="shieldFace" fill="url(#dashboardIdleShieldTop)" stroke="#cbd5e1" stroke-width="0.75" />
-      <path :d="shieldFace" fill="url(#dashboardIdleShieldTint)" />
+      <path
+        :d="shieldFace"
+        fill="url(#dashboardIdleShieldTop)"
+        stroke="#cbd5e1"
+        stroke-width="0.75"
+      />
+      <path
+        :d="shieldFace"
+        fill="url(#dashboardIdleShieldTint)"
+      />
       <path
         d="M36 18.5 C41.8 18.5 45.2 21.6 45.2 25.8 L45.2 29.2 C45.2 35.2 41.2 40.2 36 42.8 C30.8 40.2 26.8 35.2 26.8 29.2 L26.8 25.8 C26.8 21.6 30.2 18.5 36 18.5 Z"
         fill="url(#dashboardIdleShieldHighlight)"

--- a/src/frontend/src/components/errors/ErrorState.vue
+++ b/src/frontend/src/components/errors/ErrorState.vue
@@ -34,15 +34,43 @@ const heading = computed(() => props.title || t('errors.generic.loadFailed'))
 
 <template>
   <div class="hfl-error-state">
-    <div class="hfl-error-state__icon" aria-hidden="true">
-      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-        <circle cx="12" cy="12" r="10" />
-        <line x1="12" y1="8" x2="12" y2="12" />
-        <line x1="12" y1="16" x2="12.01" y2="16" />
+    <div
+      class="hfl-error-state__icon"
+      aria-hidden="true"
+    >
+      <svg
+        width="22"
+        height="22"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+      >
+        <circle
+          cx="12"
+          cy="12"
+          r="10"
+        />
+        <line
+          x1="12"
+          y1="8"
+          x2="12"
+          y2="12"
+        />
+        <line
+          x1="12"
+          y1="16"
+          x2="12.01"
+          y2="16"
+        />
       </svg>
     </div>
-    <h3 class="hfl-error-state__title">{{ heading }}</h3>
-    <p class="hfl-error-state__message">{{ message }}</p>
+    <h3 class="hfl-error-state__title">
+      {{ heading }}
+    </h3>
+    <p class="hfl-error-state__message">
+      {{ message }}
+    </p>
     <button
       v-if="showRetry"
       type="button"
@@ -51,7 +79,10 @@ const heading = computed(() => props.title || t('errors.generic.loadFailed'))
     >
       {{ t('common.retry') }}
     </button>
-    <p v-if="traceId" class="hfl-error-state__trace">
+    <p
+      v-if="traceId"
+      class="hfl-error-state__trace"
+    >
       {{ t('errors.generic.traceId') }}: {{ traceId }}
     </p>
   </div>

--- a/src/frontend/src/components/feedback/HflErrorDetailsDialog.vue
+++ b/src/frontend/src/components/feedback/HflErrorDetailsDialog.vue
@@ -34,39 +34,74 @@ async function copyDetails() {
     :show-close="false"
     @update:model-value="(open: boolean) => { if (!open) closeErrorDetails() }"
   >
-    <template v-if="details" #header>
+    <template
+      v-if="details"
+      #header
+    >
       <div class="hfl-error-details__header">
-        <span class="hfl-error-details__icon" aria-hidden="true"><AlertTriangle :size="24" /></span>
+        <span
+          class="hfl-error-details__icon"
+          aria-hidden="true"
+        ><AlertTriangle :size="24" /></span>
         <div class="hfl-error-details__heading">
           <div class="hfl-error-details__title-line">
             <h2>{{ details.title }}</h2>
-            <span v-if="details.errorCode" class="hfl-error-details__code">{{ details.errorCode }}</span>
+            <span
+              v-if="details.errorCode"
+              class="hfl-error-details__code"
+            >{{ details.errorCode }}</span>
           </div>
           <p>{{ details.summary }}</p>
         </div>
-        <button type="button" class="hfl-error-details__close" :aria-label="t('common.close')" @click="closeErrorDetails">
+        <button
+          type="button"
+          class="hfl-error-details__close"
+          :aria-label="t('common.close')"
+          @click="closeErrorDetails"
+        >
           <X :size="17" />
         </button>
       </div>
     </template>
 
     <template v-if="details">
-      <section v-if="details.issue" class="hfl-error-details__section">
+      <section
+        v-if="details.issue"
+        class="hfl-error-details__section"
+      >
         <h3>{{ t('feedback.errorDetails.issue') }}</h3>
-        <div class="hfl-error-details__issue">{{ details.issue }}</div>
+        <div class="hfl-error-details__issue">
+          {{ details.issue }}
+        </div>
       </section>
 
-      <section v-if="details.reasons?.length" class="hfl-error-details__section">
+      <section
+        v-if="details.reasons?.length"
+        class="hfl-error-details__section"
+      >
         <h3>{{ t('feedback.errorDetails.reasons') }}</h3>
         <ol class="hfl-error-details__list">
-          <li v-for="reason in details.reasons" :key="reason">{{ reason }}</li>
+          <li
+            v-for="reason in details.reasons"
+            :key="reason"
+          >
+            {{ reason }}
+          </li>
         </ol>
       </section>
 
-      <section v-if="details.resolutions?.length" class="hfl-error-details__section">
+      <section
+        v-if="details.resolutions?.length"
+        class="hfl-error-details__section"
+      >
         <h3>{{ t('feedback.errorDetails.resolutions') }}</h3>
         <ul class="hfl-error-details__list hfl-error-details__list--resolve">
-          <li v-for="resolution in details.resolutions" :key="resolution">{{ resolution }}</li>
+          <li
+            v-for="resolution in details.resolutions"
+            :key="resolution"
+          >
+            {{ resolution }}
+          </li>
         </ul>
       </section>
 
@@ -75,11 +110,17 @@ async function copyDetails() {
         class="hfl-error-details__section hfl-error-details__technical-desktop"
       >
         <h3>{{ t('feedback.errorDetails.technical') }}</h3>
-        <div v-if="details.traceId" class="hfl-error-details__trace">
+        <div
+          v-if="details.traceId"
+          class="hfl-error-details__trace"
+        >
           <span>{{ t('errors.generic.traceId') }}</span>
           <code>{{ details.traceId }}</code>
         </div>
-        <pre v-if="rawText" class="hfl-error-details__raw">{{ rawText }}</pre>
+        <pre
+          v-if="rawText"
+          class="hfl-error-details__raw"
+        >{{ rawText }}</pre>
       </section>
 
       <details
@@ -94,23 +135,47 @@ async function copyDetails() {
           />
         </summary>
         <div class="hfl-error-details__technical-content">
-          <div v-if="details.traceId" class="hfl-error-details__trace">
+          <div
+            v-if="details.traceId"
+            class="hfl-error-details__trace"
+          >
             <span>{{ t('errors.generic.traceId') }}</span>
             <code>{{ details.traceId }}</code>
           </div>
-          <pre v-if="rawText" class="hfl-error-details__raw">{{ rawText }}</pre>
+          <pre
+            v-if="rawText"
+            class="hfl-error-details__raw"
+          >{{ rawText }}</pre>
         </div>
       </details>
     </template>
 
-    <template v-if="details" #footer>
+    <template
+      v-if="details"
+      #footer
+    >
       <div class="hfl-error-details__footer">
-        <button type="button" class="hfl-error-details__copy" @click="copyDetails">
-          <Check v-if="copied" :size="15" />
-          <Copy v-else :size="15" />
+        <button
+          type="button"
+          class="hfl-error-details__copy"
+          @click="copyDetails"
+        >
+          <Check
+            v-if="copied"
+            :size="15"
+          />
+          <Copy
+            v-else
+            :size="15"
+          />
           {{ copied ? t('feedback.toast.copied') : t('feedback.errorDetails.copy') }}
         </button>
-        <ElButton type="primary" @click="closeErrorDetails">{{ t('common.confirm') }}</ElButton>
+        <ElButton
+          type="primary"
+          @click="closeErrorDetails"
+        >
+          {{ t('common.confirm') }}
+        </ElButton>
       </div>
     </template>
   </ElDialog>

--- a/src/frontend/src/components/feedback/HflToastItem.vue
+++ b/src/frontend/src/components/feedback/HflToastItem.vue
@@ -106,25 +106,57 @@ onUnmounted(() => {
     @focusin="onFocusIn"
     @focusout="onFocusOut"
   >
-    <span class="hfl-toast__icon" aria-hidden="true">
-      <component :is="icon" :size="18" />
+    <span
+      class="hfl-toast__icon"
+      aria-hidden="true"
+    >
+      <component
+        :is="icon"
+        :size="18"
+      />
     </span>
     <div class="hfl-toast__content">
-      <div v-if="toast.title" class="hfl-toast__title">
+      <div
+        v-if="toast.title"
+        class="hfl-toast__title"
+      >
         <span>{{ toast.title }}</span>
-        <span v-if="toast.repeatCount > 1" class="hfl-toast__repeat">×{{ toast.repeatCount }}</span>
+        <span
+          v-if="toast.repeatCount > 1"
+          class="hfl-toast__repeat"
+        >×{{ toast.repeatCount }}</span>
       </div>
       <p class="hfl-toast__message">
         {{ toast.message }}
-        <span v-if="!toast.title && toast.repeatCount > 1" class="hfl-toast__repeat">×{{ toast.repeatCount }}</span>
+        <span
+          v-if="!toast.title && toast.repeatCount > 1"
+          class="hfl-toast__repeat"
+        >×{{ toast.repeatCount }}</span>
       </p>
-      <div v-if="toast.copyText || toast.details" class="hfl-toast__actions">
-        <button v-if="toast.copyText" type="button" @click="copyDetails">
-          <Check v-if="copied" :size="13" />
-          <Copy v-else :size="13" />
+      <div
+        v-if="toast.copyText || toast.details"
+        class="hfl-toast__actions"
+      >
+        <button
+          v-if="toast.copyText"
+          type="button"
+          @click="copyDetails"
+        >
+          <Check
+            v-if="copied"
+            :size="13"
+          />
+          <Copy
+            v-else
+            :size="13"
+          />
           {{ copied ? t('feedback.toast.copied') : t('feedback.toast.copy') }}
         </button>
-        <button v-if="toast.details" type="button" @click="showDetails">
+        <button
+          v-if="toast.details"
+          type="button"
+          @click="showDetails"
+        >
           {{ detailsActionLabel }}
         </button>
       </div>

--- a/src/frontend/src/components/feedback/HflToastViewport.vue
+++ b/src/frontend/src/components/feedback/HflToastViewport.vue
@@ -4,9 +4,17 @@ import { toastState } from '../../lib/toast/store'
 </script>
 
 <template>
-  <div class="hfl-toast-viewport" aria-live="polite" aria-relevant="additions removals">
+  <div
+    class="hfl-toast-viewport"
+    aria-live="polite"
+    aria-relevant="additions removals"
+  >
     <TransitionGroup name="hfl-toast-list">
-      <HflToastItem v-for="toast in toastState.items" :key="toast.id" :toast="toast" />
+      <HflToastItem
+        v-for="toast in toastState.items"
+        :key="toast.id"
+        :toast="toast"
+      />
     </TransitionGroup>
   </div>
 </template>

--- a/src/frontend/src/components/insight/KnowledgeSourceRetrievalEnhancement.vue
+++ b/src/frontend/src/components/insight/KnowledgeSourceRetrievalEnhancement.vue
@@ -94,7 +94,10 @@ onMounted(() => {
 
     <!-- Document Content -->
     <template v-if="showDocumentBlock">
-      <h4 v-if="showGroupTitles" class="fullscreen-form-section__subtitle ks-retrieval-group-head">
+      <h4
+        v-if="showGroupTitles"
+        class="fullscreen-form-section__subtitle ks-retrieval-group-head"
+      >
         {{ t('insight.kb.retrieval.documentContentTitle') }}
       </h4>
       <p class="fullscreen-form-field__hint ks-retrieval-section-intro">
@@ -109,10 +112,15 @@ onMounted(() => {
           />
           <span class="ks-retrieval-checkline__text">{{ t('insight.kb.retrieval.convertDocuments') }}</span>
         </div>
-        <p class="fullscreen-form-field__hint">{{ t('insight.kb.retrieval.convertDocumentsHint') }}</p>
+        <p class="fullscreen-form-field__hint">
+          {{ t('insight.kb.retrieval.convertDocumentsHint') }}
+        </p>
       </div>
 
-      <div v-if="policy.document" class="ks-retrieval-nest">
+      <div
+        v-if="policy.document"
+        class="ks-retrieval-nest"
+      >
         <div class="fullscreen-form-field">
           <div
             class="fullscreen-form-checkline"
@@ -125,10 +133,15 @@ onMounted(() => {
             />
             <span class="ks-retrieval-checkline__text">{{ t('insight.kb.retrieval.convertEmbeddedImages') }}</span>
           </div>
-          <p class="fullscreen-form-field__hint">{{ t('insight.kb.retrieval.convertEmbeddedImagesHint') }}</p>
+          <p class="fullscreen-form-field__hint">
+            {{ t('insight.kb.retrieval.convertEmbeddedImagesHint') }}
+          </p>
         </div>
 
-        <div v-if="policy.embedded_image" class="ks-retrieval-nest ks-retrieval-nest--inner">
+        <div
+          v-if="policy.embedded_image"
+          class="ks-retrieval-nest ks-retrieval-nest--inner"
+        >
           <div class="fullscreen-form-field">
             <div class="fullscreen-form-checkline">
               <ElCheckbox
@@ -137,10 +150,15 @@ onMounted(() => {
               />
               <span class="ks-retrieval-checkline__text">{{ t('insight.kb.retrieval.pdfAdvancedTitle') }}</span>
             </div>
-            <p class="fullscreen-form-field__hint">{{ t('insight.kb.retrieval.pdfAdvancedHint') }}</p>
+            <p class="fullscreen-form-field__hint">
+              {{ t('insight.kb.retrieval.pdfAdvancedHint') }}
+            </p>
           </div>
 
-          <div v-if="pdfAdvancedOpen" class="ks-retrieval-nest ks-retrieval-nest--inner">
+          <div
+            v-if="pdfAdvancedOpen"
+            class="ks-retrieval-nest ks-retrieval-nest--inner"
+          >
             <div class="fullscreen-form-field">
               <div class="fullscreen-form-checkline">
                 <ElCheckbox
@@ -149,7 +167,9 @@ onMounted(() => {
                 />
                 <span class="ks-retrieval-checkline__text">{{ t('insight.kb.retrieval.pdfExtractImages') }}</span>
               </div>
-              <p class="fullscreen-form-field__hint">{{ t('insight.kb.retrieval.pdfExtractImagesHint') }}</p>
+              <p class="fullscreen-form-field__hint">
+                {{ t('insight.kb.retrieval.pdfExtractImagesHint') }}
+              </p>
             </div>
 
             <div class="fullscreen-form-field">
@@ -258,7 +278,10 @@ onMounted(() => {
 
     <!-- Standalone Images -->
     <template v-if="showImagesBlock">
-      <h4 v-if="showGroupTitles" class="fullscreen-form-section__subtitle ks-retrieval-group-head">
+      <h4
+        v-if="showGroupTitles"
+        class="fullscreen-form-section__subtitle ks-retrieval-group-head"
+      >
         {{ t('insight.kb.retrieval.standaloneImagesTitle') }}
       </h4>
       <p class="fullscreen-form-field__hint ks-retrieval-section-intro">
@@ -273,17 +296,25 @@ onMounted(() => {
           />
           <span class="ks-retrieval-checkline__text">{{ t('insight.kb.retrieval.convertImages') }}</span>
         </div>
-        <p class="fullscreen-form-field__hint">{{ t('insight.kb.retrieval.convertImagesHint') }}</p>
+        <p class="fullscreen-form-field__hint">
+          {{ t('insight.kb.retrieval.convertImagesHint') }}
+        </p>
       </div>
 
-      <p v-if="policy.image" class="fullscreen-form-field__hint">
+      <p
+        v-if="policy.image"
+        class="fullscreen-form-field__hint"
+      >
         {{ t('insight.kb.retrieval.adminMultimodalModelHint') }}
       </p>
     </template>
 
     <!-- Global Conversion Limits -->
     <template v-if="showLimitsBlock">
-      <h4 v-if="showGroupTitles" class="fullscreen-form-section__subtitle ks-retrieval-group-head">
+      <h4
+        v-if="showGroupTitles"
+        class="fullscreen-form-section__subtitle ks-retrieval-group-head"
+      >
         {{ t('insight.kb.retrieval.globalConversionLimitsTitle') }}
       </h4>
       <p class="fullscreen-form-field__hint ks-retrieval-section-intro">

--- a/src/frontend/src/components/monitor/SystemMonitorDashboard.vue
+++ b/src/frontend/src/components/monitor/SystemMonitorDashboard.vue
@@ -55,7 +55,10 @@ const { t } = useI18n()
         accent-side="left"
       >
         <template #icon>
-          <component :is="card.icon" :size="17" />
+          <component
+            :is="card.icon"
+            :size="17"
+          />
         </template>
       </OpsStatCard>
     </div>
@@ -70,8 +73,16 @@ const { t } = useI18n()
           <div class="chart-card__head">
             <h3>{{ t('ops.monitorPage.cpuUsage') }}</h3>
           </div>
-          <VChart v-if="hasChartData(cpuOption)" class="chart-card__chart" :option="cpuOption" autoresize />
-          <div v-else class="chart-card__empty">
+          <VChart
+            v-if="hasChartData(cpuOption)"
+            class="chart-card__chart"
+            :option="cpuOption"
+            autoresize
+          />
+          <div
+            v-else
+            class="chart-card__empty"
+          >
             <ChartSpline :size="28" />
             <span>{{ t('ops.monitorPage.noChartData') }}</span>
           </div>
@@ -80,8 +91,16 @@ const { t } = useI18n()
           <div class="chart-card__head">
             <h3>{{ t('ops.monitorPage.loadAverage') }}</h3>
           </div>
-          <VChart v-if="hasChartData(loadOption)" class="chart-card__chart" :option="loadOption" autoresize />
-          <div v-else class="chart-card__empty">
+          <VChart
+            v-if="hasChartData(loadOption)"
+            class="chart-card__chart"
+            :option="loadOption"
+            autoresize
+          />
+          <div
+            v-else
+            class="chart-card__empty"
+          >
             <ChartSpline :size="28" />
             <span>{{ t('ops.monitorPage.noChartData') }}</span>
           </div>
@@ -90,8 +109,16 @@ const { t } = useI18n()
           <div class="chart-card__head">
             <h3>{{ t('ops.monitorPage.memoryUsage') }}</h3>
           </div>
-          <VChart v-if="hasChartData(memoryOption)" class="chart-card__chart" :option="memoryOption" autoresize />
-          <div v-else class="chart-card__empty">
+          <VChart
+            v-if="hasChartData(memoryOption)"
+            class="chart-card__chart"
+            :option="memoryOption"
+            autoresize
+          />
+          <div
+            v-else
+            class="chart-card__empty"
+          >
             <ChartSpline :size="28" />
             <span>{{ t('ops.monitorPage.noChartData') }}</span>
           </div>
@@ -106,12 +133,28 @@ const { t } = useI18n()
               class="chart-card__filter"
               @update:model-value="emit('update:selectedDisk', $event)"
             >
-              <ElOption :label="t('ops.monitorPage.all')" value="all" />
-              <ElOption v-for="name in uniqueDiskNames" :key="name" :label="name" :value="name" />
+              <ElOption
+                :label="t('ops.monitorPage.all')"
+                value="all"
+              />
+              <ElOption
+                v-for="name in uniqueDiskNames"
+                :key="name"
+                :label="name"
+                :value="name"
+              />
             </ElSelect>
           </div>
-          <VChart v-if="hasChartData(diskUsageOption)" class="chart-card__chart" :option="diskUsageOption" autoresize />
-          <div v-else class="chart-card__empty">
+          <VChart
+            v-if="hasChartData(diskUsageOption)"
+            class="chart-card__chart"
+            :option="diskUsageOption"
+            autoresize
+          />
+          <div
+            v-else
+            class="chart-card__empty"
+          >
             <ChartSpline :size="28" />
             <span>{{ t('ops.monitorPage.noChartData') }}</span>
           </div>
@@ -129,8 +172,16 @@ const { t } = useI18n()
           <div class="chart-card__head">
             <h3>{{ t('ops.monitorPage.diskThroughput') }}</h3>
           </div>
-          <VChart v-if="hasChartData(diskThroughputOption)" class="chart-card__chart" :option="diskThroughputOption" autoresize />
-          <div v-else class="chart-card__empty">
+          <VChart
+            v-if="hasChartData(diskThroughputOption)"
+            class="chart-card__chart"
+            :option="diskThroughputOption"
+            autoresize
+          />
+          <div
+            v-else
+            class="chart-card__empty"
+          >
             <ChartSpline :size="28" />
             <span>{{ t('ops.monitorPage.noChartData') }}</span>
           </div>
@@ -139,8 +190,16 @@ const { t } = useI18n()
           <div class="chart-card__head">
             <h3>{{ t('ops.monitorPage.diskIops') }}</h3>
           </div>
-          <VChart v-if="hasChartData(diskIopsOption)" class="chart-card__chart" :option="diskIopsOption" autoresize />
-          <div v-else class="chart-card__empty">
+          <VChart
+            v-if="hasChartData(diskIopsOption)"
+            class="chart-card__chart"
+            :option="diskIopsOption"
+            autoresize
+          />
+          <div
+            v-else
+            class="chart-card__empty"
+          >
             <ChartSpline :size="28" />
             <span>{{ t('ops.monitorPage.noChartData') }}</span>
           </div>
@@ -164,12 +223,28 @@ const { t } = useI18n()
               class="chart-card__filter"
               @update:model-value="emit('update:selectedNetwork', $event)"
             >
-              <ElOption :label="t('ops.monitorPage.all')" value="all" />
-              <ElOption v-for="name in uniqueNetworkNames" :key="name" :label="name" :value="name" />
+              <ElOption
+                :label="t('ops.monitorPage.all')"
+                value="all"
+              />
+              <ElOption
+                v-for="name in uniqueNetworkNames"
+                :key="name"
+                :label="name"
+                :value="name"
+              />
             </ElSelect>
           </div>
-          <VChart v-if="hasChartData(networkBytesOption)" class="chart-card__chart" :option="networkBytesOption" autoresize />
-          <div v-else class="chart-card__empty">
+          <VChart
+            v-if="hasChartData(networkBytesOption)"
+            class="chart-card__chart"
+            :option="networkBytesOption"
+            autoresize
+          />
+          <div
+            v-else
+            class="chart-card__empty"
+          >
             <ChartSpline :size="28" />
             <span>{{ t('ops.monitorPage.noChartData') }}</span>
           </div>
@@ -178,8 +253,16 @@ const { t } = useI18n()
           <div class="chart-card__head">
             <h3>{{ t('ops.monitorPage.networkPackets') }}</h3>
           </div>
-          <VChart v-if="hasChartData(networkPacketsOption)" class="chart-card__chart" :option="networkPacketsOption" autoresize />
-          <div v-else class="chart-card__empty">
+          <VChart
+            v-if="hasChartData(networkPacketsOption)"
+            class="chart-card__chart"
+            :option="networkPacketsOption"
+            autoresize
+          />
+          <div
+            v-else
+            class="chart-card__empty"
+          >
             <ChartSpline :size="28" />
             <span>{{ t('ops.monitorPage.noChartData') }}</span>
           </div>

--- a/src/frontend/src/components/node-lifecycle/NodeLifecycleBanner.vue
+++ b/src/frontend/src/components/node-lifecycle/NodeLifecycleBanner.vue
@@ -62,8 +62,14 @@ const summary = computed(() => {
 </script>
 
 <template>
-  <div v-if="visible" class="node-lifecycle-banner">
-    <LoaderCircle :size="16" class="node-lifecycle-banner__icon is-spinning" />
+  <div
+    v-if="visible"
+    class="node-lifecycle-banner"
+  >
+    <LoaderCircle
+      :size="16"
+      class="node-lifecycle-banner__icon is-spinning"
+    />
     <span class="node-lifecycle-banner__text">{{ summary }}</span>
     <button
       v-if="queuedCount > 0"

--- a/src/frontend/src/components/node-lifecycle/NodeLifecycleStatusCell.vue
+++ b/src/frontend/src/components/node-lifecycle/NodeLifecycleStatusCell.vue
@@ -26,7 +26,11 @@ const label = computed(() => {
 
 <template>
   <div class="node-lifecycle-status">
-    <el-tag :type="display.tagType" size="small" :class="['node-lifecycle-status__tag', display.tagClass]">
+    <el-tag
+      :type="display.tagType"
+      size="small"
+      :class="['node-lifecycle-status__tag', display.tagClass]"
+    >
       <LoaderCircle
         v-if="display.spinning"
         :size="12"

--- a/src/frontend/src/components/node-lifecycle/NodeVersionCell.vue
+++ b/src/frontend/src/components/node-lifecycle/NodeVersionCell.vue
@@ -28,13 +28,19 @@ const display = computed(() => {
 </script>
 
 <template>
-  <div class="node-version-cell" :class="{ 'node-version-cell--upgrading': display.upgrading }">
+  <div
+    class="node-version-cell"
+    :class="{ 'node-version-cell--upgrading': display.upgrading }"
+  >
     <template v-if="display.upgrading && display.targetVersion">
       <span class="node-version-cell__from">{{ display.versionLabel }}</span>
       <span class="node-version-cell__arrow">→</span>
       <span class="node-version-cell__to">{{ display.targetVersion }}</span>
     </template>
-    <span v-else class="node-version-cell__value">{{ display.versionLabel }}</span>
+    <span
+      v-else
+      class="node-version-cell__value"
+    >{{ display.versionLabel }}</span>
   </div>
 </template>
 

--- a/src/frontend/src/components/ops/OpsStatCard.vue
+++ b/src/frontend/src/components/ops/OpsStatCard.vue
@@ -28,15 +28,35 @@ withDefaults(
     ]"
   >
     <div class="hfl-ops-stat-card__head">
-      <div class="hfl-ops-stat-card__label">{{ label }}</div>
-      <div v-if="$slots.icon" class="hfl-ops-stat-card__icon" aria-hidden="true">
+      <div class="hfl-ops-stat-card__label">
+        {{ label }}
+      </div>
+      <div
+        v-if="$slots.icon"
+        class="hfl-ops-stat-card__icon"
+        aria-hidden="true"
+      >
         <slot name="icon" />
       </div>
     </div>
     <div class="hfl-ops-stat-card__value-row">
-      <div class="hfl-ops-stat-card__value" :class="valueClass">{{ value }}</div>
-      <span v-if="pulse" class="hfl-ops-stat-card__pulse" aria-hidden="true" />
+      <div
+        class="hfl-ops-stat-card__value"
+        :class="valueClass"
+      >
+        {{ value }}
+      </div>
+      <span
+        v-if="pulse"
+        class="hfl-ops-stat-card__pulse"
+        aria-hidden="true"
+      />
     </div>
-    <div v-if="sub" class="hfl-ops-stat-card__sub">{{ sub }}</div>
+    <div
+      v-if="sub"
+      class="hfl-ops-stat-card__sub"
+    >
+      {{ sub }}
+    </div>
   </div>
 </template>

--- a/src/frontend/src/composables/useAuth.ts
+++ b/src/frontend/src/composables/useAuth.ts
@@ -2,6 +2,7 @@ import { computed, ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { router } from '../router'
 import {
+  clearDeployProfileCache,
   fetchDeployProfile,
   resolvePostLoginPath,
   shouldForceDeployProfileRefresh,
@@ -215,9 +216,7 @@ export function clearAuth() {
   isLoading.value = false
   setStoredOrgKey('')
   setAuthenticatedLocalePreference(null)
-  void import('./useDeployProfile').then(({ clearDeployProfileCache }) => {
-    clearDeployProfileCache()
-  })
+  clearDeployProfileCache()
 }
 
 const WATCHDOG_INTERVAL_MS = 15_000

--- a/src/frontend/src/lib/sentry.test.ts
+++ b/src/frontend/src/lib/sentry.test.ts
@@ -19,8 +19,31 @@ afterEach(() => {
 describe('runtime Sentry', () => {
   it('remains disabled when runtime configuration is absent', async () => {
     const { initSentry } = await import('./sentry')
-    initSentry({} as App, { afterEach: vi.fn() } as unknown as Router)
+    const load = vi.fn(() => import('./sentrySdk'))
+    await initSentry({} as App, { afterEach: vi.fn() } as unknown as Router, load)
     expect(sentryInit).not.toHaveBeenCalled()
+    expect(load).not.toHaveBeenCalled()
+  })
+
+  it('warns and continues when the optional SDK chunk cannot load', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    window.__HFL_APP_CONFIG__ = {
+      sentryEnabled: true,
+      sentryDsn: 'https://public@sentry.example.com/42',
+      sentryEnvironment: 'hfl-test',
+      sentryRelease: 'hyperfilelens-frontend@main-1234567',
+    }
+    const { initSentry } = await import('./sentry')
+
+    await expect(initSentry(
+      {} as App,
+      { afterEach: vi.fn() } as unknown as Router,
+      async () => { throw new Error('chunk unavailable') },
+    )).resolves.toBeUndefined()
+    expect(warn).toHaveBeenCalledWith(
+      '[sentry] Initialization failed; the application will continue.',
+      expect.any(Error),
+    )
   })
 
   it('warns and continues for malformed runtime configuration', async () => {
@@ -32,7 +55,7 @@ describe('runtime Sentry', () => {
       sentryRelease: 'hyperfilelens-frontend@main-1234567',
     }
     const { initSentry } = await import('./sentry')
-    initSentry({} as App, { afterEach: vi.fn() } as unknown as Router)
+    await initSentry({} as App, { afterEach: vi.fn() } as unknown as Router)
     expect(sentryInit).not.toHaveBeenCalled()
     expect(warn).toHaveBeenCalled()
   })
@@ -46,7 +69,7 @@ describe('runtime Sentry', () => {
       sentryRelease: 'hyperfilelens-frontend@main-1234567',
     }
     const { initSentry } = await import('./sentry')
-    initSentry({} as App, { afterEach: vi.fn() } as unknown as Router)
+    await initSentry({} as App, { afterEach: vi.fn() } as unknown as Router)
     expect(sentryInit).not.toHaveBeenCalled()
     expect(warn).toHaveBeenCalled()
   })
@@ -61,7 +84,7 @@ describe('runtime Sentry', () => {
       sentrySurface: 'admin',
     }
     const { initSentry } = await import('./sentry')
-    initSentry({} as App, { afterEach: vi.fn() } as unknown as Router)
+    await initSentry({} as App, { afterEach: vi.fn() } as unknown as Router)
 
     const options = sentryInit.mock.calls[0]?.[0]
     expect(options).toEqual(expect.objectContaining({

--- a/src/frontend/src/lib/sentry.ts
+++ b/src/frontend/src/lib/sentry.ts
@@ -1,6 +1,11 @@
-import * as Sentry from '@sentry/vue'
+import type * as SentryTypes from '@sentry/vue'
 import type { App } from 'vue'
 import type { Router } from 'vue-router'
+
+type SentryModule = typeof import('./sentrySdk')
+type SentryLoader = () => Promise<SentryModule>
+
+const loadSentryModule: SentryLoader = () => import('./sentrySdk')
 
 const FILTERED = '[Filtered]'
 const SAFE_SPAN_FIELDS = [
@@ -81,10 +86,10 @@ function sanitizeTraceContext(value: unknown): Record<string, unknown> | undefin
 }
 
 function sanitizeEvent(
-  event: Sentry.Event,
+  event: SentryTypes.Event,
   routePath: string,
   surface: 'admin' | 'tenant',
-): Sentry.Event {
+): SentryTypes.Event {
   delete event.user
   delete event.message
   delete event.logentry
@@ -117,7 +122,11 @@ function sanitizeEvent(
   return event
 }
 
-export function initSentry(app: App, router: Router): void {
+export async function initSentry(
+  app: App,
+  router: Router,
+  load: SentryLoader = loadSentryModule,
+): Promise<void> {
   const config = window.__HFL_APP_CONFIG__
   if (!config?.sentryEnabled) return
 
@@ -131,6 +140,7 @@ export function initSentry(app: App, router: Router): void {
   }
 
   try {
+    const Sentry = await load()
     let activeRoutePath = '/'
     router.afterEach?.((route) => {
       const routeTemplate = route.matched?.at(-1)?.path || '/'

--- a/src/frontend/src/lib/sentrySdk.ts
+++ b/src/frontend/src/lib/sentrySdk.ts
@@ -1,0 +1,15 @@
+import {
+  browserTracingIntegration as createBrowserTracingIntegration,
+  init as initializeSentry,
+} from '@sentry/vue'
+
+// Keep a real runtime module at the dynamic-import boundary. A pure re-export
+// facade is collapsed by Rollup and can turn the optional SDK back into a
+// static entry dependency.
+export const browserTracingIntegration = (
+  ...args: Parameters<typeof createBrowserTracingIntegration>
+) => createBrowserTracingIntegration(...args)
+
+export const init = (
+  ...args: Parameters<typeof initializeSentry>
+) => initializeSentry(...args)

--- a/src/frontend/src/lib/taskStepEmptyEventsCoverage.test.ts
+++ b/src/frontend/src/lib/taskStepEmptyEventsCoverage.test.ts
@@ -2,6 +2,7 @@ import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import { en } from '../locales/en'
+import { compactSourceText } from '../test/sourceText'
 
 const taskDetailSurfaces = [
   {
@@ -22,7 +23,7 @@ const taskDetailSurfaces = [
 ] as const
 
 describe.each(taskDetailSurfaces)('$name empty-event step expansion', ({ path, disabledClass }) => {
-  const source = readFileSync(resolve(process.cwd(), path), 'utf8')
+  const source = compactSourceText(readFileSync(resolve(process.cwd(), path), 'utf8'))
 
   it('keeps the step collapsed and exposes disabled semantics', () => {
     const toggleStart = source.indexOf('function toggleStep(stepId: number | string, eventCount: number)')
@@ -40,7 +41,7 @@ describe.each(taskDetailSurfaces)('$name empty-event step expansion', ({ path, d
   })
 
   it('shows a disabled right chevron with the shared tooltip', () => {
-    expect(source).toContain('<ElTooltip\n')
+    expect(source).toContain('<ElTooltip ')
     expect(source).toContain('v-if="step.events.length === 0"')
     expect(source).toContain(':content="t(\'ops.task.emptyEvents\')"')
     expect(source).toContain('teleported')

--- a/src/frontend/src/main.ts
+++ b/src/frontend/src/main.ts
@@ -25,9 +25,9 @@ import { setupAuthGuard, setupSessionWatchdog } from './composables/useAuth'
 import { initSentry } from './lib/sentry'
 import { initAppAnalytics } from './lib/analytics'
 
-function bootstrap() {
+async function bootstrap() {
   const app = createApp(App)
-  initSentry(app, router)
+  await initSentry(app, router)
   initAppAnalytics(router)
   app.use(i18n)
   app.use(router)
@@ -46,4 +46,4 @@ function bootstrap() {
   })
 }
 
-bootstrap()
+void bootstrap()

--- a/src/frontend/src/pages/Dashboard.vue
+++ b/src/frontend/src/pages/Dashboard.vue
@@ -449,7 +449,10 @@ onMounted(refresh)
 </script>
 
 <template>
-  <div v-loading="loading" class="dashboard-page">
+  <div
+    v-loading="loading"
+    class="dashboard-page"
+  >
     <ErrorState
       v-if="loadError && !overview"
       :error="loadError"
@@ -457,717 +460,882 @@ onMounted(refresh)
       @retry="refresh"
     />
     <template v-else>
-    <!-- DataFlowPipeline -->
-    <section class="pipeline">
-      <div class="pipeline__accent" aria-hidden="true" />
-      <div class="pipeline__head">
-        <div>
-          <h3 class="pipeline__title">{{ t('dashboard.pipeline.title') }}</h3>
-          <p class="pipeline__subtitle">{{ t('dashboard.pipeline.subtitle') }}</p>
-        </div>
-      </div>
-
-      <div class="pipeline__flow">
-        <!-- Step 1 -->
-        <div class="pipeline__step">
-          <div class="pipeline__orb pipeline__orb--indigo">
-            <div class="pipeline__orbit pipeline__orbit--indigo" />
-            <div class="pipeline__orb-glow pipeline__orb-glow--indigo" />
-            <div class="pipeline__orb-core">
-              <Server class="pipeline__orb-icon" />
-            </div>
-            <span class="pipeline__orb-pulse">
-              <span class="pipeline__orb-pulse-ring" />
-              <span class="pipeline__orb-pulse-dot" />
-            </span>
-          </div>
-          <div class="pipeline__step-text">
-            <h4>{{ t('dashboard.pipeline.step1Title') }}</h4>
-            <p>{{ t('dashboard.pipeline.step1Desc') }}</p>
-            <div class="pipeline__chip pipeline__chip--indigo">
-              <span>{{ pipelineStep1Chip }}</span>
-            </div>
+      <!-- DataFlowPipeline -->
+      <section class="pipeline">
+        <div
+          class="pipeline__accent"
+          aria-hidden="true"
+        />
+        <div class="pipeline__head">
+          <div>
+            <h3 class="pipeline__title">
+              {{ t('dashboard.pipeline.title') }}
+            </h3>
+            <p class="pipeline__subtitle">
+              {{ t('dashboard.pipeline.subtitle') }}
+            </p>
           </div>
         </div>
 
-        <div class="pipeline__connector">
-          <div class="pipeline__connector-line">
-            <div class="pipeline__connector-flow pipeline__connector-flow--indigo" />
-          </div>
-          <div class="pipeline__connector-badge">
-            <span class="pipeline__connector-dot" />
-            <span>{{ t('dashboard.pipeline.connectorBackup') }}</span>
-          </div>
-        </div>
-
-        <!-- Step 2 -->
-        <div class="pipeline__step">
-          <div class="pipeline__orb pipeline__orb--emerald">
-            <div class="pipeline__orbit pipeline__orbit--emerald" />
-            <div class="pipeline__orb-glow pipeline__orb-glow--emerald" />
-            <div class="pipeline__orb-core pipeline__orb-core--emerald">
-              <Database class="pipeline__orb-icon pipeline__orb-icon--emerald" />
-            </div>
-            <span class="pipeline__orb-pulse">
-              <span class="pipeline__orb-pulse-ring pipeline__orb-pulse-ring--emerald" />
-              <span class="pipeline__orb-pulse-dot pipeline__orb-pulse-dot--emerald" />
-            </span>
-          </div>
-          <div class="pipeline__step-text">
-            <h4>{{ t('dashboard.pipeline.step2Title') }}</h4>
-            <p>{{ t('dashboard.pipeline.step2Desc') }}</p>
-            <div class="pipeline__chip pipeline__chip--emerald">
-              <span>{{ pipelineStep2Chip }}</span>
-            </div>
-          </div>
-        </div>
-
-        <div class="pipeline__connector">
-          <div class="pipeline__connector-line">
-            <div class="pipeline__connector-flow pipeline__connector-flow--emerald" />
-          </div>
-          <div class="pipeline__connector-badge pipeline__connector-badge--emerald">
-            <span class="pipeline__connector-dot pipeline__connector-dot--emerald" />
-            <span>{{ t('dashboard.pipeline.connectorVerify') }}</span>
-          </div>
-        </div>
-
-        <!-- Step 3 -->
-        <div class="pipeline__step">
-          <div class="pipeline__orb pipeline__orb--indigo">
-            <div class="pipeline__orbit pipeline__orbit--indigo pipeline__orbit--fast" />
-            <div class="pipeline__orb-glow pipeline__orb-glow--violet" />
-            <div class="pipeline__orb-core">
-              <ShieldCheck class="pipeline__orb-icon" />
-            </div>
-            <span class="pipeline__orb-pulse">
-              <span class="pipeline__orb-pulse-ring" />
-              <span class="pipeline__orb-pulse-dot pipeline__orb-pulse-dot--indigo" />
-            </span>
-          </div>
-          <div class="pipeline__step-text">
-            <h4>{{ t('dashboard.pipeline.step3Title') }}</h4>
-            <p>{{ t('dashboard.pipeline.step3Desc') }}</p>
-            <div class="pipeline__chip pipeline__chip--indigo">
-              <span>{{ pipelineStep3Chip }}</span>
-            </div>
-          </div>
-        </div>
-      </div>
-    </section>
-
-    <!-- 3 Ribbon Metric Cards -->
-    <div class="ribbon-grid">
-      <!-- Production source -->
-      <RouterLink :to="routes.sources" class="ribbon-card ribbon-card--indigo">
-        <div class="ribbon-card__glow ribbon-card__glow--indigo" />
-        <div>
-          <div class="ribbon-card__head">
-            <div>
-              <h3>{{ t('dashboard.ribbon.infraTitle') }}</h3>
-            </div>
-            <div class="ribbon-card__icon ribbon-card__icon--indigo">
-              <Server class="w-5 h-5" />
-            </div>
-          </div>
-          <div class="ribbon-card__value-row">
-            <span class="ribbon-card__value">{{ sourceAvailabilityPct }}%</span>
-          </div>
-        </div>
-        <div class="ribbon-card__progress-block">
-          <div class="ribbon-card__progress-meta">
-            <span>{{ infraSourceMainValue }}</span>
-          </div>
-          <div class="ribbon-track">
-            <div class="ribbon-fill ribbon-fill--indigo" :style="{ width: `${sourceAvailabilityPct}%` }" />
-          </div>
-        </div>
-        <div class="ribbon-card__stats">
-          <div>
-            <span>{{ t('dashboard.ribbon.sourceTotal') }}</span>
-            <strong>{{ overview?.productionSources.total ?? 0 }}{{ t('dashboard.unitCount') ? ` ${t('dashboard.unitCount')}` : '' }}</strong>
-          </div>
-          <div>
-            <span>{{ t('dashboard.ribbon.sourceAvailableLabel') }}</span>
-            <strong class="text-emerald-600">{{ overview?.productionSources.available ?? 0 }}{{ t('dashboard.unitCount') ? ` ${t('dashboard.unitCount')}` : '' }}</strong>
-          </div>
-          <div>
-            <span>{{ t('dashboard.ribbon.sourceUnavailableLabel') }}</span>
-            <strong :class="(overview?.productionSources.unavailable ?? 0) > 0 ? 'ribbon-stat--danger' : 'ribbon-stat--muted'">
-              <span class="ribbon-stat-dot" :class="(overview?.productionSources.unavailable ?? 0) > 0 ? 'ribbon-stat-dot--danger' : 'ribbon-stat-dot--muted'" />
-              {{ overview?.productionSources.unavailable ?? 0 }}{{ t('dashboard.unitCount') ? ` ${t('dashboard.unitCount')}` : '' }}
-            </strong>
-          </div>
-        </div>
-      </RouterLink>
-
-      <!-- Target storage -->
-      <RouterLink :to="routes.repositories" class="ribbon-card ribbon-card--emerald">
-        <div class="ribbon-card__glow ribbon-card__glow--emerald" />
-        <div>
-          <div class="ribbon-card__head">
-            <div>
-              <h3>{{ t('dashboard.ribbon.storageTitle') }}</h3>
-            </div>
-            <div class="ribbon-card__icon ribbon-card__icon--emerald">
-              <Database class="w-5 h-5" />
-            </div>
-          </div>
-          <div class="ribbon-card__value-row">
-            <span class="ribbon-card__value">{{ storagePct != null ? `${storagePct}%` : '0%' }}</span>
-            <span
-              v-if="storageRibbonBadgeVisible"
-              class="ribbon-card__badge"
-              :class="storageRibbonBadgeClass"
-            >
-              {{ storageRibbonBadge }}
-            </span>
-          </div>
-        </div>
-        <div class="ribbon-card__progress-block">
-          <div class="ribbon-card__progress-meta">
-            <span>{{ storageUsedProgressLabel }}</span>
-          </div>
-          <div class="ribbon-track">
-            <div class="ribbon-fill ribbon-fill--indigo" :style="{ width: `${storagePct ?? 0}%` }" />
-          </div>
-        </div>
-        <div class="ribbon-card__stats">
-          <div>
-            <span>{{ t('dashboard.ribbon.repositories') }}</span>
-            <strong class="text-emerald-600">{{ overview?.storage.repoCount ?? 0 }}</strong>
-          </div>
-          <div>
-            <span>{{ t('dashboard.ribbon.used') }}</span>
-            <strong class="text-emerald-600">{{ formatGB(overview?.storage.usedBytes ?? 0) }}</strong>
-          </div>
-          <div>
-            <span>{{ t('dashboard.ribbon.capacityTotal') }}</span>
-            <strong :class="{ 'hfl-empty-mark': storageTotalCapacityLabel === '—' }">{{ storageTotalCapacityLabel }}</strong>
-          </div>
-        </div>
-      </RouterLink>
-
-      <!-- Recovery drill -->
-      <RouterLink :to="routes.recoveryDrillTasks" class="ribbon-card ribbon-card--indigo">
-        <div class="ribbon-card__glow ribbon-card__glow--indigo" />
-        <div>
-          <div class="ribbon-card__head">
-            <div>
-              <h3>{{ t('dashboard.ribbon.slaTitle') }}</h3>
-            </div>
-            <div class="ribbon-card__icon ribbon-card__icon--indigo">
-              <ShieldCheck class="w-5 h-5" />
-            </div>
-          </div>
-          <div class="ribbon-card__value-row">
-            <span class="ribbon-card__value">
-              {{ overview?.recoveryDrill24h?.successRate != null ? `${overview.recoveryDrill24h.successRate}%` : '—' }}
-            </span>
-            <span v-if="slaRibbonBadgeVisible" class="ribbon-card__badge" :class="slaRibbonBadgeClass">
-              {{ slaRibbonBadge }}
-            </span>
-          </div>
-        </div>
-        <div class="ribbon-card__progress-block">
-          <div class="ribbon-card__progress-meta">
-            <span>{{ t('dashboard.ribbon.tasks24hSuccessRate') }}</span>
-          </div>
-          <div class="ribbon-track">
-            <div
-              class="ribbon-fill ribbon-fill--indigo"
-              :style="{ width: `${overview?.recoveryDrill24h?.successRate ?? 0}%` }"
-            />
-          </div>
-        </div>
-        <div class="ribbon-card__stats">
-          <div>
-            <span>{{ t('dashboard.ribbon.succeeded') }}</span>
-            <strong class="text-emerald-600">
-              <span class="ribbon-stat-dot ribbon-stat-dot--success" />
-              {{ overview?.recoveryDrill24h?.success ?? 0 }}{{ t('dashboard.unitCount') ? ` ${t('dashboard.unitCount')}` : '' }}
-            </strong>
-          </div>
-          <div>
-            <span>{{ t('dashboard.ribbon.running') }}</span>
-            <strong class="ribbon-stat--primary">
-              <span class="ribbon-stat-pulse">
-                <span class="ribbon-stat-pulse__ring" />
-                <span class="ribbon-stat-pulse__dot" />
+        <div class="pipeline__flow">
+          <!-- Step 1 -->
+          <div class="pipeline__step">
+            <div class="pipeline__orb pipeline__orb--indigo">
+              <div class="pipeline__orbit pipeline__orbit--indigo" />
+              <div class="pipeline__orb-glow pipeline__orb-glow--indigo" />
+              <div class="pipeline__orb-core">
+                <Server class="pipeline__orb-icon" />
+              </div>
+              <span class="pipeline__orb-pulse">
+                <span class="pipeline__orb-pulse-ring" />
+                <span class="pipeline__orb-pulse-dot" />
               </span>
-              {{ overview?.recoveryDrill24h?.running ?? 0 }}{{ t('dashboard.unitCount') ? ` ${t('dashboard.unitCount')}` : '' }}
-            </strong>
-          </div>
-          <div>
-            <span>{{ t('dashboard.ribbon.failed') }}</span>
-            <strong :class="(overview?.recoveryDrill24h?.failed ?? 0) > 0 ? 'ribbon-stat--danger' : 'ribbon-stat--muted'">
-              <span class="ribbon-stat-dot" :class="(overview?.recoveryDrill24h?.failed ?? 0) > 0 ? 'ribbon-stat-dot--danger ribbon-stat-dot--pulse' : 'ribbon-stat-dot--muted'" />
-              {{ overview?.recoveryDrill24h?.failed ?? 0 }}{{ t('dashboard.unitCount') ? ` ${t('dashboard.unitCount')}` : '' }}
-            </strong>
-          </div>
-        </div>
-      </RouterLink>
-    </div>
-
-    <!-- 3-Column Cockpit -->
-    <div class="cockpit-grid">
-      <!-- Column 1: Attention -->
-      <div class="cockpit-stack">
-        <section class="panel panel--fixed panel--attention cockpit-attention">
-          <div class="panel-head panel-head--border">
-            <div class="panel-head__left">
-              <span class="panel-head-icon" aria-hidden="true">
-                <AlertTriangle :size="14" />
-              </span>
-              <h3 class="panel-title">{{ t('dashboard.attentionTitle') }}</h3>
-              <span v-if="overview?.attentionCount" class="attention-count">{{ overview.attentionCount }}</span>
             </div>
-            <RouterLink :to="routes.attention" class="panel-link">
-              {{ t('dashboard.viewAllAttention') }}
-              <ArrowUpRight class="panel-link__arrow" />
-            </RouterLink>
-          </div>
-          <div class="panel-body panel-body--attention">
-            <el-empty
-              v-if="!overview?.attention.length"
-              :description="t('dashboard.attentionEmptyDesc')"
-              :image-size="72"
-              class="dashboard-panel-empty dashboard-panel-empty--attention"
-            >
-              <template #image>
-                <DashboardIdleShieldIllustration />
-              </template>
-            </el-empty>
-            <div v-else class="attention-list scrollbar">
-              <div
-                v-for="item in overview.attention"
-                :key="item.id"
-                class="attention-item"
-                :class="attentionClass(item.kind)"
-              >
-                <div class="attention-item__content">
-                  <AlertCircle class="attention-item__icon" />
-                  <div>
-                    <p class="attention-item__title">{{ item.title }}</p>
-                    <span v-if="item.detail" class="attention-item__detail">{{ item.detail }}</span>
-                    <span v-if="item.at" class="attention-item__time">{{ formatTime(item.at) }}</span>
-                  </div>
-                </div>
-                <div class="attention-item__actions">
-                  <RouterLink :to="item.to" class="attention-item__solve">
-                    {{ t('dashboard.openAttentionItem') }}
-                  </RouterLink>
-                </div>
+            <div class="pipeline__step-text">
+              <h4>{{ t('dashboard.pipeline.step1Title') }}</h4>
+              <p>{{ t('dashboard.pipeline.step1Desc') }}</p>
+              <div class="pipeline__chip pipeline__chip--indigo">
+                <span>{{ pipelineStep1Chip }}</span>
               </div>
             </div>
-            <div
-              v-if="overview && overview.attention.length < overview.attentionCount"
-              class="attention-list__summary"
-            >
-              <span>{{ t('dashboard.attentionPreview', { shown: overview.attention.length, total: overview.attentionCount }) }}</span>
+          </div>
+
+          <div class="pipeline__connector">
+            <div class="pipeline__connector-line">
+              <div class="pipeline__connector-flow pipeline__connector-flow--indigo" />
+            </div>
+            <div class="pipeline__connector-badge">
+              <span class="pipeline__connector-dot" />
+              <span>{{ t('dashboard.pipeline.connectorBackup') }}</span>
             </div>
           </div>
-        </section>
+
+          <!-- Step 2 -->
+          <div class="pipeline__step">
+            <div class="pipeline__orb pipeline__orb--emerald">
+              <div class="pipeline__orbit pipeline__orbit--emerald" />
+              <div class="pipeline__orb-glow pipeline__orb-glow--emerald" />
+              <div class="pipeline__orb-core pipeline__orb-core--emerald">
+                <Database class="pipeline__orb-icon pipeline__orb-icon--emerald" />
+              </div>
+              <span class="pipeline__orb-pulse">
+                <span class="pipeline__orb-pulse-ring pipeline__orb-pulse-ring--emerald" />
+                <span class="pipeline__orb-pulse-dot pipeline__orb-pulse-dot--emerald" />
+              </span>
+            </div>
+            <div class="pipeline__step-text">
+              <h4>{{ t('dashboard.pipeline.step2Title') }}</h4>
+              <p>{{ t('dashboard.pipeline.step2Desc') }}</p>
+              <div class="pipeline__chip pipeline__chip--emerald">
+                <span>{{ pipelineStep2Chip }}</span>
+              </div>
+            </div>
+          </div>
+
+          <div class="pipeline__connector">
+            <div class="pipeline__connector-line">
+              <div class="pipeline__connector-flow pipeline__connector-flow--emerald" />
+            </div>
+            <div class="pipeline__connector-badge pipeline__connector-badge--emerald">
+              <span class="pipeline__connector-dot pipeline__connector-dot--emerald" />
+              <span>{{ t('dashboard.pipeline.connectorVerify') }}</span>
+            </div>
+          </div>
+
+          <!-- Step 3 -->
+          <div class="pipeline__step">
+            <div class="pipeline__orb pipeline__orb--indigo">
+              <div class="pipeline__orbit pipeline__orbit--indigo pipeline__orbit--fast" />
+              <div class="pipeline__orb-glow pipeline__orb-glow--violet" />
+              <div class="pipeline__orb-core">
+                <ShieldCheck class="pipeline__orb-icon" />
+              </div>
+              <span class="pipeline__orb-pulse">
+                <span class="pipeline__orb-pulse-ring" />
+                <span class="pipeline__orb-pulse-dot pipeline__orb-pulse-dot--indigo" />
+              </span>
+            </div>
+            <div class="pipeline__step-text">
+              <h4>{{ t('dashboard.pipeline.step3Title') }}</h4>
+              <p>{{ t('dashboard.pipeline.step3Desc') }}</p>
+              <div class="pipeline__chip pipeline__chip--indigo">
+                <span>{{ pipelineStep3Chip }}</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- 3 Ribbon Metric Cards -->
+      <div class="ribbon-grid">
+        <!-- Production source -->
+        <RouterLink
+          :to="routes.sources"
+          class="ribbon-card ribbon-card--indigo"
+        >
+          <div class="ribbon-card__glow ribbon-card__glow--indigo" />
+          <div>
+            <div class="ribbon-card__head">
+              <div>
+                <h3>{{ t('dashboard.ribbon.infraTitle') }}</h3>
+              </div>
+              <div class="ribbon-card__icon ribbon-card__icon--indigo">
+                <Server class="w-5 h-5" />
+              </div>
+            </div>
+            <div class="ribbon-card__value-row">
+              <span class="ribbon-card__value">{{ sourceAvailabilityPct }}%</span>
+            </div>
+          </div>
+          <div class="ribbon-card__progress-block">
+            <div class="ribbon-card__progress-meta">
+              <span>{{ infraSourceMainValue }}</span>
+            </div>
+            <div class="ribbon-track">
+              <div
+                class="ribbon-fill ribbon-fill--indigo"
+                :style="{ width: `${sourceAvailabilityPct}%` }"
+              />
+            </div>
+          </div>
+          <div class="ribbon-card__stats">
+            <div>
+              <span>{{ t('dashboard.ribbon.sourceTotal') }}</span>
+              <strong>{{ overview?.productionSources.total ?? 0 }}{{ t('dashboard.unitCount') ? ` ${t('dashboard.unitCount')}` : '' }}</strong>
+            </div>
+            <div>
+              <span>{{ t('dashboard.ribbon.sourceAvailableLabel') }}</span>
+              <strong class="text-emerald-600">{{ overview?.productionSources.available ?? 0 }}{{ t('dashboard.unitCount') ? ` ${t('dashboard.unitCount')}` : '' }}</strong>
+            </div>
+            <div>
+              <span>{{ t('dashboard.ribbon.sourceUnavailableLabel') }}</span>
+              <strong :class="(overview?.productionSources.unavailable ?? 0) > 0 ? 'ribbon-stat--danger' : 'ribbon-stat--muted'">
+                <span
+                  class="ribbon-stat-dot"
+                  :class="(overview?.productionSources.unavailable ?? 0) > 0 ? 'ribbon-stat-dot--danger' : 'ribbon-stat-dot--muted'"
+                />
+                {{ overview?.productionSources.unavailable ?? 0 }}{{ t('dashboard.unitCount') ? ` ${t('dashboard.unitCount')}` : '' }}
+              </strong>
+            </div>
+          </div>
+        </RouterLink>
+
+        <!-- Target storage -->
+        <RouterLink
+          :to="routes.repositories"
+          class="ribbon-card ribbon-card--emerald"
+        >
+          <div class="ribbon-card__glow ribbon-card__glow--emerald" />
+          <div>
+            <div class="ribbon-card__head">
+              <div>
+                <h3>{{ t('dashboard.ribbon.storageTitle') }}</h3>
+              </div>
+              <div class="ribbon-card__icon ribbon-card__icon--emerald">
+                <Database class="w-5 h-5" />
+              </div>
+            </div>
+            <div class="ribbon-card__value-row">
+              <span class="ribbon-card__value">{{ storagePct != null ? `${storagePct}%` : '0%' }}</span>
+              <span
+                v-if="storageRibbonBadgeVisible"
+                class="ribbon-card__badge"
+                :class="storageRibbonBadgeClass"
+              >
+                {{ storageRibbonBadge }}
+              </span>
+            </div>
+          </div>
+          <div class="ribbon-card__progress-block">
+            <div class="ribbon-card__progress-meta">
+              <span>{{ storageUsedProgressLabel }}</span>
+            </div>
+            <div class="ribbon-track">
+              <div
+                class="ribbon-fill ribbon-fill--indigo"
+                :style="{ width: `${storagePct ?? 0}%` }"
+              />
+            </div>
+          </div>
+          <div class="ribbon-card__stats">
+            <div>
+              <span>{{ t('dashboard.ribbon.repositories') }}</span>
+              <strong class="text-emerald-600">{{ overview?.storage.repoCount ?? 0 }}</strong>
+            </div>
+            <div>
+              <span>{{ t('dashboard.ribbon.used') }}</span>
+              <strong class="text-emerald-600">{{ formatGB(overview?.storage.usedBytes ?? 0) }}</strong>
+            </div>
+            <div>
+              <span>{{ t('dashboard.ribbon.capacityTotal') }}</span>
+              <strong :class="{ 'hfl-empty-mark': storageTotalCapacityLabel === '—' }">{{ storageTotalCapacityLabel }}</strong>
+            </div>
+          </div>
+        </RouterLink>
+
+        <!-- Recovery drill -->
+        <RouterLink
+          :to="routes.recoveryDrillTasks"
+          class="ribbon-card ribbon-card--indigo"
+        >
+          <div class="ribbon-card__glow ribbon-card__glow--indigo" />
+          <div>
+            <div class="ribbon-card__head">
+              <div>
+                <h3>{{ t('dashboard.ribbon.slaTitle') }}</h3>
+              </div>
+              <div class="ribbon-card__icon ribbon-card__icon--indigo">
+                <ShieldCheck class="w-5 h-5" />
+              </div>
+            </div>
+            <div class="ribbon-card__value-row">
+              <span class="ribbon-card__value">
+                {{ overview?.recoveryDrill24h?.successRate != null ? `${overview.recoveryDrill24h.successRate}%` : '—' }}
+              </span>
+              <span
+                v-if="slaRibbonBadgeVisible"
+                class="ribbon-card__badge"
+                :class="slaRibbonBadgeClass"
+              >
+                {{ slaRibbonBadge }}
+              </span>
+            </div>
+          </div>
+          <div class="ribbon-card__progress-block">
+            <div class="ribbon-card__progress-meta">
+              <span>{{ t('dashboard.ribbon.tasks24hSuccessRate') }}</span>
+            </div>
+            <div class="ribbon-track">
+              <div
+                class="ribbon-fill ribbon-fill--indigo"
+                :style="{ width: `${overview?.recoveryDrill24h?.successRate ?? 0}%` }"
+              />
+            </div>
+          </div>
+          <div class="ribbon-card__stats">
+            <div>
+              <span>{{ t('dashboard.ribbon.succeeded') }}</span>
+              <strong class="text-emerald-600">
+                <span class="ribbon-stat-dot ribbon-stat-dot--success" />
+                {{ overview?.recoveryDrill24h?.success ?? 0 }}{{ t('dashboard.unitCount') ? ` ${t('dashboard.unitCount')}` : '' }}
+              </strong>
+            </div>
+            <div>
+              <span>{{ t('dashboard.ribbon.running') }}</span>
+              <strong class="ribbon-stat--primary">
+                <span class="ribbon-stat-pulse">
+                  <span class="ribbon-stat-pulse__ring" />
+                  <span class="ribbon-stat-pulse__dot" />
+                </span>
+                {{ overview?.recoveryDrill24h?.running ?? 0 }}{{ t('dashboard.unitCount') ? ` ${t('dashboard.unitCount')}` : '' }}
+              </strong>
+            </div>
+            <div>
+              <span>{{ t('dashboard.ribbon.failed') }}</span>
+              <strong :class="(overview?.recoveryDrill24h?.failed ?? 0) > 0 ? 'ribbon-stat--danger' : 'ribbon-stat--muted'">
+                <span
+                  class="ribbon-stat-dot"
+                  :class="(overview?.recoveryDrill24h?.failed ?? 0) > 0 ? 'ribbon-stat-dot--danger ribbon-stat-dot--pulse' : 'ribbon-stat-dot--muted'"
+                />
+                {{ overview?.recoveryDrill24h?.failed ?? 0 }}{{ t('dashboard.unitCount') ? ` ${t('dashboard.unitCount')}` : '' }}
+              </strong>
+            </div>
+          </div>
+        </RouterLink>
       </div>
 
-      <!-- Column 2: Storage + Quota -->
-      <div class="cockpit-stack">
-        <section class="panel panel--fixed panel--storage-capacity cockpit-storage">
-          <div class="panel-head panel-head--border">
-            <div class="panel-head__left">
-              <span class="panel-head-icon" aria-hidden="true">
-                <Database :size="14" />
-              </span>
-              <h4 class="panel-title panel-title--sm">{{ t('dashboard.storageTitle') }}</h4>
-            </div>
-            <div class="storage-capacity-head__actions">
-              <RouterLink :to="routes.repositories" class="panel-link">
-                {{ t('dashboard.viewRepos') }} ({{ overview?.storage.repoCount ?? 0 }})
+      <!-- 3-Column Cockpit -->
+      <div class="cockpit-grid">
+        <!-- Column 1: Attention -->
+        <div class="cockpit-stack">
+          <section class="panel panel--fixed panel--attention cockpit-attention">
+            <div class="panel-head panel-head--border">
+              <div class="panel-head__left">
+                <span
+                  class="panel-head-icon"
+                  aria-hidden="true"
+                >
+                  <AlertTriangle :size="14" />
+                </span>
+                <h3 class="panel-title">
+                  {{ t('dashboard.attentionTitle') }}
+                </h3>
+                <span
+                  v-if="overview?.attentionCount"
+                  class="attention-count"
+                >{{ overview.attentionCount }}</span>
+              </div>
+              <RouterLink
+                :to="routes.attention"
+                class="panel-link"
+              >
+                {{ t('dashboard.viewAllAttention') }}
                 <ArrowUpRight class="panel-link__arrow" />
               </RouterLink>
             </div>
-          </div>
-
-          <div class="storage-capacity-body">
-            <section
-              class="storage-capacity-repos"
-              :class="{ 'storage-capacity-repos--selecting': capacityPlanRepositories.length > 0 && !selectedCapacityPlanRepo }"
-            >
-              <div v-if="!overview?.topRepos.length" class="storage-empty">
-                <p>{{ t('dashboard.noRepos') }}</p>
-              </div>
-	              <div v-else class="storage-list">
-	                <div
-	                  v-for="repo in visibleStorageRepos"
-	                  :key="repo.id"
-	                  class="storage-item"
-	                  :class="{ 'storage-item--selected': selectedCapacityPlanRepo?.id === repo.id }"
-	                >
-	                  <div class="storage-item__head">
-	                    <div class="storage-item__name">
-	                      <span class="storage-item__name-main">
-	                        <span class="storage-item__health" :class="`storage-item__health--${repoHealthKind(repo)}`" aria-hidden="true" />
-                        <span class="storage-item__name-text">{{ repo.name }}</span>
-                      </span>
-                      <span class="storage-item__health-label" :class="`storage-item__health-label--${repoHealthKind(repo)}`">
-	                        {{ repoHealthLabel(repo) }}
-	                      </span>
-	                    </div>
-	                    <span
-	                      class="storage-item__bytes"
-	                      :class="{ 'storage-item__bytes--unlimited': repo.capacityMode !== 'known' }"
-	                    >
-	                      <span class="storage-item__used">{{ formatBytes(repo.usedBytes) }}</span>
-                      <span class="storage-item__capacity" :class="{ 'hfl-empty-mark': repoCapacityLabel(repo) === '—' }">{{ repoCapacityLabel(repo) === '—' ? '—' : `/ ${repoCapacityLabel(repo)}` }}</span>
-	                      <span v-if="repo.capacityMode === 'known' && repo.pct !== null" class="storage-item__pct">
-	                        {{ repo.pct }}%
-	                      </span>
-	                    </span>
-	                    <button
-	                      type="button"
-	                      class="storage-item__plan"
-	                      :aria-pressed="selectedCapacityPlanRepo?.id === repo.id"
-	                      @click="selectCapacityPlanRepository(repo.id)"
-	                    >
-	                      {{ selectedCapacityPlanRepo?.id === repo.id
-	                        ? t('dashboard.capacityPlanner.planning')
-	                        : t('dashboard.capacityPlanner.plan') }}
-	                    </button>
-	                  </div>
-	                  <div v-if="repo.capacityMode === 'known'" class="storage-track">
-                    <div class="storage-fill" :style="{ width: `${repo.pct ?? 0}%` }" />
+            <div class="panel-body panel-body--attention">
+              <el-empty
+                v-if="!overview?.attention.length"
+                :description="t('dashboard.attentionEmptyDesc')"
+                :image-size="72"
+                class="dashboard-panel-empty dashboard-panel-empty--attention"
+              >
+                <template #image>
+                  <DashboardIdleShieldIllustration />
+                </template>
+              </el-empty>
+              <div
+                v-else
+                class="attention-list scrollbar"
+              >
+                <div
+                  v-for="item in overview.attention"
+                  :key="item.id"
+                  class="attention-item"
+                  :class="attentionClass(item.kind)"
+                >
+                  <div class="attention-item__content">
+                    <AlertCircle class="attention-item__icon" />
+                    <div>
+                      <p class="attention-item__title">
+                        {{ item.title }}
+                      </p>
+                      <span
+                        v-if="item.detail"
+                        class="attention-item__detail"
+                      >{{ item.detail }}</span>
+                      <span
+                        v-if="item.at"
+                        class="attention-item__time"
+                      >{{ formatTime(item.at) }}</span>
+                    </div>
+                  </div>
+                  <div class="attention-item__actions">
+                    <RouterLink
+                      :to="item.to"
+                      class="attention-item__solve"
+                    >
+                      {{ t('dashboard.openAttentionItem') }}
+                    </RouterLink>
                   </div>
                 </div>
               </div>
-            </section>
-
-            <section
-              class="storage-capacity-planner"
-              :class="{ 'storage-capacity-planner--selecting': capacityPlanRepositories.length > 0 && !selectedCapacityPlanRepo }"
-            >
-              <div class="storage-capacity-planner__title">
-                <span class="storage-capacity-planner__title-main">
-                  <Calculator :size="13" />
-                  <span>{{ t('dashboard.capacityPlanner.title') }}</span>
-                </span>
-                <span
-                  v-if="selectedCapacityPlanRepo"
-                  class="capacity-planner__status-chip"
-                  :class="`capacity-planner__status-chip--${capacityPlanStatus}`"
-                >
-                  {{ capacityPlanStatusLabel }}
-                </span>
-              </div>
-              <div v-if="!capacityPlanRepositories.length" class="capacity-planner__empty">
-                <span>{{ t('dashboard.capacityPlanner.empty') }}</span>
-                <RouterLink :to="routes.repositories">{{ t('dashboard.capacityPlanner.createRepository') }}</RouterLink>
-              </div>
               <div
-                v-else
-                class="capacity-planner__body"
-                :class="{ 'capacity-planner__body--selecting': !selectedCapacityPlanRepo }"
+                v-if="overview && overview.attention.length < overview.attentionCount"
+                class="attention-list__summary"
               >
-                <div class="capacity-planner__field">
-                  <label
-                    class="capacity-planner__label"
-                    for="dashboard-capacity-plan-repository"
-                  >
-                    {{ selectedCapacityPlanRepo
-                      ? t('dashboard.capacityPlanner.repository')
-                      : t('dashboard.capacityPlanner.selectRepositoryTitle') }}
-                  </label>
-                  <ElSelect
-                    id="dashboard-capacity-plan-repository"
-                    v-model="capacityPlanRepositoryId"
-                    class="capacity-planner__repository"
-                    :aria-label="selectedCapacityPlanRepo
-                      ? t('dashboard.capacityPlanner.repository')
-                      : t('dashboard.capacityPlanner.selectRepositoryTitle')"
-                    :placeholder="t('dashboard.capacityPlanner.selectRepository')"
-                    :teleported="false"
-                  >
-                    <ElOption
-                      v-for="repo in capacityPlanRepositories"
-                      :key="repo.id"
-                      :label="repo.name"
-                      :value="repo.id"
-                    />
-                  </ElSelect>
+                <span>{{ t('dashboard.attentionPreview', { shown: overview.attention.length, total: overview.attentionCount }) }}</span>
+              </div>
+            </div>
+          </section>
+        </div>
+
+        <!-- Column 2: Storage + Quota -->
+        <div class="cockpit-stack">
+          <section class="panel panel--fixed panel--storage-capacity cockpit-storage">
+            <div class="panel-head panel-head--border">
+              <div class="panel-head__left">
+                <span
+                  class="panel-head-icon"
+                  aria-hidden="true"
+                >
+                  <Database :size="14" />
+                </span>
+                <h4 class="panel-title panel-title--sm">
+                  {{ t('dashboard.storageTitle') }}
+                </h4>
+              </div>
+              <div class="storage-capacity-head__actions">
+                <RouterLink
+                  :to="routes.repositories"
+                  class="panel-link"
+                >
+                  {{ t('dashboard.viewRepos') }} ({{ overview?.storage.repoCount ?? 0 }})
+                  <ArrowUpRight class="panel-link__arrow" />
+                </RouterLink>
+              </div>
+            </div>
+
+            <div class="storage-capacity-body">
+              <section
+                class="storage-capacity-repos"
+                :class="{ 'storage-capacity-repos--selecting': capacityPlanRepositories.length > 0 && !selectedCapacityPlanRepo }"
+              >
+                <div
+                  v-if="!overview?.topRepos.length"
+                  class="storage-empty"
+                >
+                  <p>{{ t('dashboard.noRepos') }}</p>
                 </div>
-                <p v-if="!selectedCapacityPlanRepo" class="capacity-planner__select-hint">
-                  {{ t('dashboard.capacityPlanner.selectRepositoryHint') }}
-                </p>
-                <template v-if="selectedCapacityPlanRepo">
-                  <div class="capacity-planner__form">
-                    <div class="capacity-planner__field">
-                      <label
-                        class="capacity-planner__label"
-                        for="dashboard-capacity-plan-amount"
+                <div
+                  v-else
+                  class="storage-list"
+                >
+                  <div
+                    v-for="repo in visibleStorageRepos"
+                    :key="repo.id"
+                    class="storage-item"
+                    :class="{ 'storage-item--selected': selectedCapacityPlanRepo?.id === repo.id }"
+                  >
+                    <div class="storage-item__head">
+                      <div class="storage-item__name">
+                        <span class="storage-item__name-main">
+                          <span
+                            class="storage-item__health"
+                            :class="`storage-item__health--${repoHealthKind(repo)}`"
+                            aria-hidden="true"
+                          />
+                          <span class="storage-item__name-text">{{ repo.name }}</span>
+                        </span>
+                        <span
+                          class="storage-item__health-label"
+                          :class="`storage-item__health-label--${repoHealthKind(repo)}`"
+                        >
+                          {{ repoHealthLabel(repo) }}
+                        </span>
+                      </div>
+                      <span
+                        class="storage-item__bytes"
+                        :class="{ 'storage-item__bytes--unlimited': repo.capacityMode !== 'known' }"
                       >
-                        {{ t('dashboard.capacityPlanner.plannedAdd') }}
-                      </label>
-                      <div class="capacity-planner__controls">
+                        <span class="storage-item__used">{{ formatBytes(repo.usedBytes) }}</span>
+                        <span
+                          class="storage-item__capacity"
+                          :class="{ 'hfl-empty-mark': repoCapacityLabel(repo) === '—' }"
+                        >{{ repoCapacityLabel(repo) === '—' ? '—' : `/ ${repoCapacityLabel(repo)}` }}</span>
+                        <span
+                          v-if="repo.capacityMode === 'known' && repo.pct !== null"
+                          class="storage-item__pct"
+                        >
+                          {{ repo.pct }}%
+                        </span>
+                      </span>
+                      <button
+                        type="button"
+                        class="storage-item__plan"
+                        :aria-pressed="selectedCapacityPlanRepo?.id === repo.id"
+                        @click="selectCapacityPlanRepository(repo.id)"
+                      >
+                        {{ selectedCapacityPlanRepo?.id === repo.id
+                          ? t('dashboard.capacityPlanner.planning')
+                          : t('dashboard.capacityPlanner.plan') }}
+                      </button>
+                    </div>
+                    <div
+                      v-if="repo.capacityMode === 'known'"
+                      class="storage-track"
+                    >
+                      <div
+                        class="storage-fill"
+                        :style="{ width: `${repo.pct ?? 0}%` }"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </section>
+
+              <section
+                class="storage-capacity-planner"
+                :class="{ 'storage-capacity-planner--selecting': capacityPlanRepositories.length > 0 && !selectedCapacityPlanRepo }"
+              >
+                <div class="storage-capacity-planner__title">
+                  <span class="storage-capacity-planner__title-main">
+                    <Calculator :size="13" />
+                    <span>{{ t('dashboard.capacityPlanner.title') }}</span>
+                  </span>
+                  <span
+                    v-if="selectedCapacityPlanRepo"
+                    class="capacity-planner__status-chip"
+                    :class="`capacity-planner__status-chip--${capacityPlanStatus}`"
+                  >
+                    {{ capacityPlanStatusLabel }}
+                  </span>
+                </div>
+                <div
+                  v-if="!capacityPlanRepositories.length"
+                  class="capacity-planner__empty"
+                >
+                  <span>{{ t('dashboard.capacityPlanner.empty') }}</span>
+                  <RouterLink :to="routes.repositories">
+                    {{ t('dashboard.capacityPlanner.createRepository') }}
+                  </RouterLink>
+                </div>
+                <div
+                  v-else
+                  class="capacity-planner__body"
+                  :class="{ 'capacity-planner__body--selecting': !selectedCapacityPlanRepo }"
+                >
+                  <div class="capacity-planner__field">
+                    <label
+                      class="capacity-planner__label"
+                      for="dashboard-capacity-plan-repository"
+                    >
+                      {{ selectedCapacityPlanRepo
+                        ? t('dashboard.capacityPlanner.repository')
+                        : t('dashboard.capacityPlanner.selectRepositoryTitle') }}
+                    </label>
+                    <ElSelect
+                      id="dashboard-capacity-plan-repository"
+                      v-model="capacityPlanRepositoryId"
+                      class="capacity-planner__repository"
+                      :aria-label="selectedCapacityPlanRepo
+                        ? t('dashboard.capacityPlanner.repository')
+                        : t('dashboard.capacityPlanner.selectRepositoryTitle')"
+                      :placeholder="t('dashboard.capacityPlanner.selectRepository')"
+                      :teleported="false"
+                    >
+                      <ElOption
+                        v-for="repo in capacityPlanRepositories"
+                        :key="repo.id"
+                        :label="repo.name"
+                        :value="repo.id"
+                      />
+                    </ElSelect>
+                  </div>
+                  <p
+                    v-if="!selectedCapacityPlanRepo"
+                    class="capacity-planner__select-hint"
+                  >
+                    {{ t('dashboard.capacityPlanner.selectRepositoryHint') }}
+                  </p>
+                  <template v-if="selectedCapacityPlanRepo">
+                    <div class="capacity-planner__form">
+                      <div class="capacity-planner__field">
+                        <label
+                          class="capacity-planner__label"
+                          for="dashboard-capacity-plan-amount"
+                        >
+                          {{ t('dashboard.capacityPlanner.plannedAdd') }}
+                        </label>
+                        <div class="capacity-planner__controls">
+                          <ElInputNumber
+                            id="dashboard-capacity-plan-amount"
+                            v-model="capacityPlanAmount"
+                            class="capacity-planner__amount"
+                            name="dashboard_capacity_plan_amount"
+                            :aria-label="t('dashboard.capacityPlanner.plannedAdd')"
+                            :min="0"
+                            :step="0.1"
+                            :precision="1"
+                            controls-position="right"
+                          />
+                          <ElSelect
+                            v-model="capacityPlanUnit"
+                            class="capacity-planner__unit"
+                            :aria-label="t('dashboard.capacityPlanner.unit')"
+                            :teleported="false"
+                          >
+                            <ElOption
+                              label="GB"
+                              value="GB"
+                            />
+                            <ElOption
+                              label="TB"
+                              value="TB"
+                            />
+                          </ElSelect>
+                        </div>
+                      </div>
+                      <div class="capacity-planner__field">
+                        <label
+                          class="capacity-planner__label"
+                          for="dashboard-capacity-plan-factor"
+                        >
+                          {{ t('dashboard.capacityPlanner.factor') }}
+                        </label>
                         <ElInputNumber
-                          id="dashboard-capacity-plan-amount"
-                          v-model="capacityPlanAmount"
-                          class="capacity-planner__amount"
-                          name="dashboard_capacity_plan_amount"
-                          :aria-label="t('dashboard.capacityPlanner.plannedAdd')"
+                          id="dashboard-capacity-plan-factor"
+                          v-model="capacityPlanFactor"
+                          class="capacity-planner__factor"
+                          name="dashboard_capacity_plan_factor"
+                          :aria-label="t('dashboard.capacityPlanner.factor')"
                           :min="0"
                           :step="0.1"
                           :precision="1"
                           controls-position="right"
                         />
-                        <ElSelect
-                          v-model="capacityPlanUnit"
-                          class="capacity-planner__unit"
-                          :aria-label="t('dashboard.capacityPlanner.unit')"
-                          :teleported="false"
-                        >
-                          <ElOption label="GB" value="GB" />
-                          <ElOption label="TB" value="TB" />
-                        </ElSelect>
                       </div>
                     </div>
-                    <div class="capacity-planner__field">
-                      <label
-                        class="capacity-planner__label"
-                        for="dashboard-capacity-plan-factor"
-                      >
-                        {{ t('dashboard.capacityPlanner.factor') }}
-                      </label>
-                      <ElInputNumber
-                        id="dashboard-capacity-plan-factor"
-                        v-model="capacityPlanFactor"
-                        class="capacity-planner__factor"
-                        name="dashboard_capacity_plan_factor"
-                        :aria-label="t('dashboard.capacityPlanner.factor')"
-                        :min="0"
-                        :step="0.1"
-                        :precision="1"
-                        controls-position="right"
-                      />
-                    </div>
-                  </div>
-                  <div class="capacity-planner__metrics">
-                    <div class="capacity-planner__metric">
-                      <span>{{ capacityPlanPrimaryMetric.label }}</span>
-                      <strong>{{ capacityPlanPrimaryMetric.value }}</strong>
-                    </div>
-                    <div class="capacity-planner__metric">
-                      <span>{{ capacityPlanSecondaryMetric.label }}</span>
-                      <strong>{{ capacityPlanSecondaryMetric.value }}</strong>
-                    </div>
-                  </div>
-                </template>
-              </div>
-            </section>
-          </div>
-        </section>
-
-        <section v-if="quotaItems.length" class="panel panel--fixed panel--quota cockpit-quota">
-          <div class="panel-head panel-head--border">
-            <div class="panel-head__left">
-              <span class="panel-head-icon" aria-hidden="true">
-                <CreditCard :size="14" />
-              </span>
-              <h3 class="panel-title">{{ t('dashboard.quotaTitle') }}</h3>
-            </div>
-            <RouterLink :to="routes.subscription" class="panel-link">
-              {{ t('dashboard.viewLicense') }}
-              <ArrowUpRight class="panel-link__arrow" />
-            </RouterLink>
-          </div>
-          <div class="quota-grid scrollbar">
-            <div v-for="q in quotaItems" :key="q.key" class="quota-item">
-              <div class="quota-item__head">
-                <ElTooltip :content="q.label" placement="top" :enterable="true" :show-after="200">
-                  <span class="quota-item__label">{{ q.label }}</span>
-                </ElTooltip>
-                <span class="quota-item__nums">
-                  {{ q.used }} <span class="quota-item__limit">/ {{ formatQuotaLimit(q.limit) }}</span>
-                  <span v-if="q.suffix" class="quota-item__unit">{{ q.suffix }}</span>
-                  <span class="quota-pct" :class="quotaPctClass(quotaPct(q.used, q.limit))">
-                    {{ quotaPct(q.used, q.limit) }}%
-                  </span>
-                </span>
-              </div>
-              <div class="quota-track">
-                <div
-                  class="quota-bar"
-                  :class="quotaBarClass(quotaPct(q.used, q.limit))"
-                  :style="{ width: `${quotaPct(q.used, q.limit)}%` }"
-                />
-              </div>
-            </div>
-          </div>
-        </section>
-      </div>
-
-      <!-- Column 3: Running Tasks + Chart -->
-      <div class="cockpit-stack">
-        <section class="panel panel--fixed cockpit-running">
-          <div class="panel-head panel-head--border">
-            <div class="panel-head__left">
-              <span class="panel-head-icon" aria-hidden="true">
-                <History :size="14" />
-              </span>
-              <h4 class="panel-title panel-title--sm">{{ t('dashboard.runningTasksTitle') }}</h4>
-            </div>
-            <RouterLink :to="routes.taskList" class="panel-link">
-              {{ t('dashboard.linkTasks') }}
-              <ArrowUpRight class="panel-link__arrow" />
-            </RouterLink>
-          </div>
-          <el-empty
-            v-if="!overview?.runningTasks.length"
-            :description="t('dashboard.noRunningBackupTasks')"
-            :image-size="72"
-            class="dashboard-panel-empty dashboard-panel-empty--running"
-          >
-            <template #image>
-              <DashboardIdleGearIllustration />
-            </template>
-          </el-empty>
-          <div v-else class="running-list scrollbar">
-            <div v-for="task in overview.runningTasks" :key="task.id" class="running-item">
-              <div class="running-item__head">
-                <span class="running-item__name">{{ runningTaskLabel(task) }}</span>
-                <span class="running-item__pct">{{ taskProgressValue(task.progress) }}%</span>
-              </div>
-              <div class="running-track">
-                <div class="running-fill" :style="{ width: `${taskProgressValue(task.progress)}%` }" />
-              </div>
-              <div class="running-item__meta">
-                <span>{{ taskTypeLabel(task.task_type) }}</span>
-                <span :class="{ 'hfl-empty-mark': !(task.started_at || task.created_at) }">{{ formatTime(task.started_at || task.created_at) }}</span>
-              </div>
-            </div>
-          </div>
-        </section>
-
-        <section class="panel panel--fixed panel--chart cockpit-chart">
-          <div class="panel-head panel-head--border panel-head--chart">
-            <div class="panel-head__left">
-              <span class="panel-head-icon" aria-hidden="true">
-                <History :size="14" />
-              </span>
-              <h3 class="panel-title">{{ t('dashboard.chartTasks7d') }}</h3>
-            </div>
-            <RouterLink :to="routes.taskList" class="panel-link">
-              {{ t('dashboard.linkTasks') }}
-              <ArrowUpRight class="panel-link__arrow" />
-            </RouterLink>
-          </div>
-
-          <div class="chart-area">
-            <div class="chart-plot">
-              <div
-                v-for="(tick, idx) in chartYTicks"
-                :key="idx"
-                class="chart-y-row"
-                :style="{ top: `${(idx / 4) * 100}%` }"
-              >
-                <span class="chart-y-label">{{ tick }}</span>
-                <div class="chart-y-line" />
-              </div>
-              <div class="chart-bars">
-                <HflPopover
-                  v-for="(day, idx) in chartBuckets"
-                  :key="day.label"
-                  trigger="hover"
-                  placement="top"
-                  :show-after="0"
-                  :width="280"
-                  :fallback-placements="['bottom']"
-                  popper-class="dashboard-chart-outcome-popper"
-                >
-                  <template #reference>
-                    <div
-                      class="chart-col"
-                      role="link"
-                      tabindex="0"
-                      :aria-label="t('dashboard.goTo', { target: `${day.label} ${t('dashboard.linkTasks')}` })"
-                      @click="openTaskOutcomes(day)"
-                      @mouseenter="chartHoveredIdx = idx"
-                      @mouseleave="chartHoveredIdx = null"
-                      @keydown.enter.prevent="openTaskOutcomes(day)"
-                      @keydown.space.prevent="openTaskOutcomes(day)"
-                    >
-                      <div class="chart-col__pillar" :style="{ height: `${dayHeightPercent(day)}%` }">
-                        <div
-                          v-if="dayTotal(day) > 0"
-                          class="chart-pillar"
-                          :class="{ 'chart-pillar--hover': chartHoveredIdx === idx }"
-                        >
-                          <div
-                            v-if="day.cancel > 0"
-                            class="chart-seg chart-seg--cancel"
-                            :style="{ height: `${(day.cancel / dayTotal(day)) * 100}%` }"
-                          />
-                          <div
-                            v-if="day.fail > 0"
-                            class="chart-seg chart-seg--fail"
-                            :style="{ height: `${(day.fail / dayTotal(day)) * 100}%` }"
-                          />
-                          <div
-                            v-if="day.success > 0"
-                            class="chart-seg chart-seg--success"
-                            :style="{ height: `${(day.success / dayTotal(day)) * 100}%` }"
-                          />
-                        </div>
-                        <div v-else class="chart-zero" />
+                    <div class="capacity-planner__metrics">
+                      <div class="capacity-planner__metric">
+                        <span>{{ capacityPlanPrimaryMetric.label }}</span>
+                        <strong>{{ capacityPlanPrimaryMetric.value }}</strong>
                       </div>
-                      <span class="chart-x-label" :class="{ 'chart-x-label--active': chartHoveredIdx === idx }">
-                        {{ day.label }}
-                      </span>
+                      <div class="capacity-planner__metric">
+                        <span>{{ capacityPlanSecondaryMetric.label }}</span>
+                        <strong>{{ capacityPlanSecondaryMetric.value }}</strong>
+                      </div>
                     </div>
                   </template>
-                  <div class="chart-inline-tip">
-                    <div class="chart-inline-tip__head">
-                      <span class="chart-inline-tip__date">{{ day.label }}</span>
-                      <span class="chart-inline-tip__rate">
-                        <span class="chart-inline-tip__rate-label">{{ t('dashboard.chartSuccessRate') }}</span>
-                        {{ daySuccessRate(day) }}
-                      </span>
-                    </div>
-                    <div class="chart-inline-tip__metrics">
-                      <div class="chart-inline-tip__metric chart-inline-tip__metric--success">
-                        <span>{{ t('dashboard.chartSuccess') }}</span>
-                        <strong>{{ day.success }}</strong>
-                      </div>
-                      <div class="chart-inline-tip__metric chart-inline-tip__metric--fail">
-                        <span>{{ t('dashboard.chartFailed') }}</span>
-                        <strong>{{ day.fail }}</strong>
-                      </div>
-                      <div class="chart-inline-tip__metric chart-inline-tip__metric--cancel">
-                        <span>{{ t('dashboard.chartCancelled') }}</span>
-                        <strong>{{ day.cancel }}</strong>
-                      </div>
-                    </div>
-                  </div>
-                </HflPopover>
+                </div>
+              </section>
+            </div>
+          </section>
+
+          <section
+            v-if="quotaItems.length"
+            class="panel panel--fixed panel--quota cockpit-quota"
+          >
+            <div class="panel-head panel-head--border">
+              <div class="panel-head__left">
+                <span
+                  class="panel-head-icon"
+                  aria-hidden="true"
+                >
+                  <CreditCard :size="14" />
+                </span>
+                <h3 class="panel-title">
+                  {{ t('dashboard.quotaTitle') }}
+                </h3>
+              </div>
+              <RouterLink
+                :to="routes.subscription"
+                class="panel-link"
+              >
+                {{ t('dashboard.viewLicense') }}
+                <ArrowUpRight class="panel-link__arrow" />
+              </RouterLink>
+            </div>
+            <div class="quota-grid scrollbar">
+              <div
+                v-for="q in quotaItems"
+                :key="q.key"
+                class="quota-item"
+              >
+                <div class="quota-item__head">
+                  <ElTooltip
+                    :content="q.label"
+                    placement="top"
+                    :enterable="true"
+                    :show-after="200"
+                  >
+                    <span class="quota-item__label">{{ q.label }}</span>
+                  </ElTooltip>
+                  <span class="quota-item__nums">
+                    {{ q.used }} <span class="quota-item__limit">/ {{ formatQuotaLimit(q.limit) }}</span>
+                    <span
+                      v-if="q.suffix"
+                      class="quota-item__unit"
+                    >{{ q.suffix }}</span>
+                    <span
+                      class="quota-pct"
+                      :class="quotaPctClass(quotaPct(q.used, q.limit))"
+                    >
+                      {{ quotaPct(q.used, q.limit) }}%
+                    </span>
+                  </span>
+                </div>
+                <div class="quota-track">
+                  <div
+                    class="quota-bar"
+                    :class="quotaBarClass(quotaPct(q.used, q.limit))"
+                    :style="{ width: `${quotaPct(q.used, q.limit)}%` }"
+                  />
+                </div>
               </div>
             </div>
-          </div>
+          </section>
+        </div>
 
-          <div class="chart-legend">
-            <div class="chart-legend__item">
-              <span class="chart-legend__swatch chart-legend__swatch--success" />
-              <span>{{ t('dashboard.chartSuccess') }}</span>
+        <!-- Column 3: Running Tasks + Chart -->
+        <div class="cockpit-stack">
+          <section class="panel panel--fixed cockpit-running">
+            <div class="panel-head panel-head--border">
+              <div class="panel-head__left">
+                <span
+                  class="panel-head-icon"
+                  aria-hidden="true"
+                >
+                  <History :size="14" />
+                </span>
+                <h4 class="panel-title panel-title--sm">
+                  {{ t('dashboard.runningTasksTitle') }}
+                </h4>
+              </div>
+              <RouterLink
+                :to="routes.taskList"
+                class="panel-link"
+              >
+                {{ t('dashboard.linkTasks') }}
+                <ArrowUpRight class="panel-link__arrow" />
+              </RouterLink>
             </div>
-            <div class="chart-legend__item">
-              <span class="chart-legend__swatch chart-legend__swatch--fail" />
-              <span>{{ t('dashboard.chartFailed') }}</span>
+            <el-empty
+              v-if="!overview?.runningTasks.length"
+              :description="t('dashboard.noRunningBackupTasks')"
+              :image-size="72"
+              class="dashboard-panel-empty dashboard-panel-empty--running"
+            >
+              <template #image>
+                <DashboardIdleGearIllustration />
+              </template>
+            </el-empty>
+            <div
+              v-else
+              class="running-list scrollbar"
+            >
+              <div
+                v-for="task in overview.runningTasks"
+                :key="task.id"
+                class="running-item"
+              >
+                <div class="running-item__head">
+                  <span class="running-item__name">{{ runningTaskLabel(task) }}</span>
+                  <span class="running-item__pct">{{ taskProgressValue(task.progress) }}%</span>
+                </div>
+                <div class="running-track">
+                  <div
+                    class="running-fill"
+                    :style="{ width: `${taskProgressValue(task.progress)}%` }"
+                  />
+                </div>
+                <div class="running-item__meta">
+                  <span>{{ taskTypeLabel(task.task_type) }}</span>
+                  <span :class="{ 'hfl-empty-mark': !(task.started_at || task.created_at) }">{{ formatTime(task.started_at || task.created_at) }}</span>
+                </div>
+              </div>
             </div>
-            <div class="chart-legend__item">
-              <span class="chart-legend__swatch chart-legend__swatch--cancel" />
-              <span>{{ t('dashboard.chartCancelled') }}</span>
+          </section>
+
+          <section class="panel panel--fixed panel--chart cockpit-chart">
+            <div class="panel-head panel-head--border panel-head--chart">
+              <div class="panel-head__left">
+                <span
+                  class="panel-head-icon"
+                  aria-hidden="true"
+                >
+                  <History :size="14" />
+                </span>
+                <h3 class="panel-title">
+                  {{ t('dashboard.chartTasks7d') }}
+                </h3>
+              </div>
+              <RouterLink
+                :to="routes.taskList"
+                class="panel-link"
+              >
+                {{ t('dashboard.linkTasks') }}
+                <ArrowUpRight class="panel-link__arrow" />
+              </RouterLink>
             </div>
-          </div>
-        </section>
+
+            <div class="chart-area">
+              <div class="chart-plot">
+                <div
+                  v-for="(tick, idx) in chartYTicks"
+                  :key="idx"
+                  class="chart-y-row"
+                  :style="{ top: `${(idx / 4) * 100}%` }"
+                >
+                  <span class="chart-y-label">{{ tick }}</span>
+                  <div class="chart-y-line" />
+                </div>
+                <div class="chart-bars">
+                  <HflPopover
+                    v-for="(day, idx) in chartBuckets"
+                    :key="day.label"
+                    trigger="hover"
+                    placement="top"
+                    :show-after="0"
+                    :width="280"
+                    :fallback-placements="['bottom']"
+                    popper-class="dashboard-chart-outcome-popper"
+                  >
+                    <template #reference>
+                      <div
+                        class="chart-col"
+                        role="link"
+                        tabindex="0"
+                        :aria-label="t('dashboard.goTo', { target: `${day.label} ${t('dashboard.linkTasks')}` })"
+                        @click="openTaskOutcomes(day)"
+                        @mouseenter="chartHoveredIdx = idx"
+                        @mouseleave="chartHoveredIdx = null"
+                        @keydown.enter.prevent="openTaskOutcomes(day)"
+                        @keydown.space.prevent="openTaskOutcomes(day)"
+                      >
+                        <div
+                          class="chart-col__pillar"
+                          :style="{ height: `${dayHeightPercent(day)}%` }"
+                        >
+                          <div
+                            v-if="dayTotal(day) > 0"
+                            class="chart-pillar"
+                            :class="{ 'chart-pillar--hover': chartHoveredIdx === idx }"
+                          >
+                            <div
+                              v-if="day.cancel > 0"
+                              class="chart-seg chart-seg--cancel"
+                              :style="{ height: `${(day.cancel / dayTotal(day)) * 100}%` }"
+                            />
+                            <div
+                              v-if="day.fail > 0"
+                              class="chart-seg chart-seg--fail"
+                              :style="{ height: `${(day.fail / dayTotal(day)) * 100}%` }"
+                            />
+                            <div
+                              v-if="day.success > 0"
+                              class="chart-seg chart-seg--success"
+                              :style="{ height: `${(day.success / dayTotal(day)) * 100}%` }"
+                            />
+                          </div>
+                          <div
+                            v-else
+                            class="chart-zero"
+                          />
+                        </div>
+                        <span
+                          class="chart-x-label"
+                          :class="{ 'chart-x-label--active': chartHoveredIdx === idx }"
+                        >
+                          {{ day.label }}
+                        </span>
+                      </div>
+                    </template>
+                    <div class="chart-inline-tip">
+                      <div class="chart-inline-tip__head">
+                        <span class="chart-inline-tip__date">{{ day.label }}</span>
+                        <span class="chart-inline-tip__rate">
+                          <span class="chart-inline-tip__rate-label">{{ t('dashboard.chartSuccessRate') }}</span>
+                          {{ daySuccessRate(day) }}
+                        </span>
+                      </div>
+                      <div class="chart-inline-tip__metrics">
+                        <div class="chart-inline-tip__metric chart-inline-tip__metric--success">
+                          <span>{{ t('dashboard.chartSuccess') }}</span>
+                          <strong>{{ day.success }}</strong>
+                        </div>
+                        <div class="chart-inline-tip__metric chart-inline-tip__metric--fail">
+                          <span>{{ t('dashboard.chartFailed') }}</span>
+                          <strong>{{ day.fail }}</strong>
+                        </div>
+                        <div class="chart-inline-tip__metric chart-inline-tip__metric--cancel">
+                          <span>{{ t('dashboard.chartCancelled') }}</span>
+                          <strong>{{ day.cancel }}</strong>
+                        </div>
+                      </div>
+                    </div>
+                  </HflPopover>
+                </div>
+              </div>
+            </div>
+
+            <div class="chart-legend">
+              <div class="chart-legend__item">
+                <span class="chart-legend__swatch chart-legend__swatch--success" />
+                <span>{{ t('dashboard.chartSuccess') }}</span>
+              </div>
+              <div class="chart-legend__item">
+                <span class="chart-legend__swatch chart-legend__swatch--fail" />
+                <span>{{ t('dashboard.chartFailed') }}</span>
+              </div>
+              <div class="chart-legend__item">
+                <span class="chart-legend__swatch chart-legend__swatch--cancel" />
+                <span>{{ t('dashboard.chartCancelled') }}</span>
+              </div>
+            </div>
+          </section>
+        </div>
       </div>
-    </div>
     </template>
   </div>
 </template>

--- a/src/frontend/src/pages/Notifications.vue
+++ b/src/frontend/src/pages/Notifications.vue
@@ -101,7 +101,11 @@ watch(
       </el-button>
     </header>
 
-    <div v-if="loadError" class="notifications-page__error" role="status">
+    <div
+      v-if="loadError"
+      class="notifications-page__error"
+      role="status"
+    >
       {{ loadError }}
     </div>
 
@@ -114,7 +118,10 @@ watch(
           :aria-label="t('ops.task.btnRefresh')"
           @click="loadNotifications"
         >
-          <RefreshCw :size="16" :class="{ 'is-spinning': loading }" />
+          <RefreshCw
+            :size="16"
+            :class="{ 'is-spinning': loading }"
+          />
         </el-button>
       </template>
       <template #table="{ tableMaxHeight }">
@@ -126,34 +133,64 @@ watch(
           class="hfl-list-table"
           :max-height="tableMaxHeight"
         >
-          <el-table-column width="52" fixed="left">
+          <el-table-column
+            width="52"
+            fixed="left"
+          >
             <template #default="{ row }">
-              <span class="notifications-page__state" :class="{ 'is-unread': !row.is_read }">
+              <span
+                class="notifications-page__state"
+                :class="{ 'is-unread': !row.is_read }"
+              >
                 <Bell :size="16" />
               </span>
             </template>
           </el-table-column>
-          <el-table-column :label="t('notificationsPage.notification')" min-width="300">
+          <el-table-column
+            :label="t('notificationsPage.notification')"
+            min-width="300"
+          >
             <template #default="{ row }">
-              <button class="notifications-page__link" type="button" @click="openNotification(row)">
+              <button
+                class="notifications-page__link"
+                type="button"
+                @click="openNotification(row)"
+              >
                 <strong>{{ row.title }}</strong>
                 <span>{{ row.summary || '—' }}</span>
               </button>
             </template>
           </el-table-column>
-          <el-table-column :label="t('notificationsPage.severity')" width="140">
-            <template #default="{ row }">{{ row.severity }}</template>
+          <el-table-column
+            :label="t('notificationsPage.severity')"
+            width="140"
+          >
+            <template #default="{ row }">
+              {{ row.severity }}
+            </template>
           </el-table-column>
-          <el-table-column :label="t('notificationsPage.received')" width="190">
-            <template #default="{ row }">{{ formatLocalDateTime(row.occurred_at || row.updated_at, '—') }}</template>
+          <el-table-column
+            :label="t('notificationsPage.received')"
+            width="190"
+          >
+            <template #default="{ row }">
+              {{ formatLocalDateTime(row.occurred_at || row.updated_at, '—') }}
+            </template>
           </el-table-column>
-          <el-table-column :label="t('notificationsPage.status')" width="120">
+          <el-table-column
+            :label="t('notificationsPage.status')"
+            width="120"
+          >
             <template #default="{ row }">
               {{ row.is_read ? t('notificationsPage.read') : t('notificationsPage.unread') }}
             </template>
           </el-table-column>
           <template #empty>
-            <el-empty v-if="!loading" :description="emptyText" :image-size="72" />
+            <el-empty
+              v-if="!loading"
+              :description="emptyText"
+              :image-size="72"
+            />
           </template>
         </el-table>
       </template>

--- a/src/frontend/src/pages/Search.vue
+++ b/src/frontend/src/pages/Search.vue
@@ -162,7 +162,10 @@ async function onRefresh() {
 <template>
   <ModulePage :side="side">
     <template #actions>
-      <ElButton :disabled="busy" @click="onRefresh">
+      <ElButton
+        :disabled="busy"
+        @click="onRefresh"
+      >
         <RefreshCw :size="16" /> {{ t('searchPage.refresh') }}
       </ElButton>
     </template>
@@ -174,7 +177,10 @@ async function onRefresh() {
         clearable
       >
         <template #prefix>
-          <SearchIcon :size="18" class="text-slate-400" />
+          <SearchIcon
+            :size="18"
+            class="text-slate-400"
+          />
         </template>
       </ElInput>
       <div class="mt-2 text-xs text-slate-500">
@@ -184,104 +190,262 @@ async function onRefresh() {
 
     <div class="mt-4 grid grid-cols-1 lg:grid-cols-2 gap-[var(--card-gap)]">
       <div class="hfl-list-panel">
-        <div class="px-4 py-3 border-b border-slate-100 font-semibold text-slate-900">{{ t('searchPage.sectionTasks') }}</div>
-        <el-table :data="taskRows" stripe :loading="busy">
-          <el-table-column prop="id" :label="t('searchPage.colId')" width="80">
-            <template #default="{ row }">#{{ row.id }}</template>
-          </el-table-column>
-          <el-table-column prop="display_name" :label="t('searchPage.colName')" min-width="160" />
-          <el-table-column :label="t('searchPage.colType')" min-width="150">
-            <template #default="{ row }"><TaskTypeLabel :type="row.task_type" /></template>
-          </el-table-column>
-          <el-table-column :label="t('searchPage.colStatus')" width="120">
-            <template #default="{ row }"><TaskStatusTag :status="row.status" /></template>
-          </el-table-column>
-          <template #empty>
-            <el-empty :description="t('searchPage.empty')" :image-size="80" />
-          </template>
-        </el-table>
-      </div>
-
-      <div class="hfl-list-panel">
-        <div class="px-4 py-3 border-b border-slate-100 font-semibold text-slate-900">{{ t('searchPage.sectionNodes') }}</div>
-        <el-table :data="nodeRows" stripe :loading="busy">
-          <el-table-column prop="id" :label="t('searchPage.colId')" width="80">
-            <template #default="{ row }">#{{ row.id }}</template>
-          </el-table-column>
-          <el-table-column prop="name" :label="t('searchPage.colName')" min-width="160" />
-          <el-table-column :label="t('searchPage.colStatus')" width="120">
+        <div class="px-4 py-3 border-b border-slate-100 font-semibold text-slate-900">
+          {{ t('searchPage.sectionTasks') }}
+        </div>
+        <el-table
+          :data="taskRows"
+          stripe
+          :loading="busy"
+        >
+          <el-table-column
+            prop="id"
+            :label="t('searchPage.colId')"
+            width="80"
+          >
             <template #default="{ row }">
-              <ElTag v-bind="lifecycleStatusTagAttrs(row.status)" size="small">{{ nodeStatusLabel(row.status) }}</ElTag>
+              #{{ row.id }}
+            </template>
+          </el-table-column>
+          <el-table-column
+            prop="display_name"
+            :label="t('searchPage.colName')"
+            min-width="160"
+          />
+          <el-table-column
+            :label="t('searchPage.colType')"
+            min-width="150"
+          >
+            <template #default="{ row }">
+              <TaskTypeLabel :type="row.task_type" />
+            </template>
+          </el-table-column>
+          <el-table-column
+            :label="t('searchPage.colStatus')"
+            width="120"
+          >
+            <template #default="{ row }">
+              <TaskStatusTag :status="row.status" />
             </template>
           </el-table-column>
           <template #empty>
-            <el-empty :description="t('searchPage.empty')" :image-size="80" />
+            <el-empty
+              :description="t('searchPage.empty')"
+              :image-size="80"
+            />
           </template>
         </el-table>
       </div>
 
       <div class="hfl-list-panel">
-        <div class="px-4 py-3 border-b border-slate-100 font-semibold text-slate-900">{{ t('searchPage.sectionRepos') }}</div>
-        <el-table :data="repoRows" stripe :loading="busy">
-          <el-table-column prop="id" :label="t('searchPage.colId')" width="80">
-            <template #default="{ row }">#{{ row.id }}</template>
-          </el-table-column>
-          <el-table-column prop="name" :label="t('searchPage.colName')" min-width="160" />
-          <el-table-column :label="t('searchPage.colType')" width="140">
-            <template #default="{ row }"><HflTypeLabel :label="repositoryTypeLabel(row.repo_type)" /></template>
-          </el-table-column>
-          <el-table-column :label="t('searchPage.colStatus')" width="120">
+        <div class="px-4 py-3 border-b border-slate-100 font-semibold text-slate-900">
+          {{ t('searchPage.sectionNodes') }}
+        </div>
+        <el-table
+          :data="nodeRows"
+          stripe
+          :loading="busy"
+        >
+          <el-table-column
+            prop="id"
+            :label="t('searchPage.colId')"
+            width="80"
+          >
             <template #default="{ row }">
-              <ElTag v-bind="lifecycleStatusTagAttrs(row.status)" size="small">{{ repositoryStatusLabel(row.status) }}</ElTag>
+              #{{ row.id }}
+            </template>
+          </el-table-column>
+          <el-table-column
+            prop="name"
+            :label="t('searchPage.colName')"
+            min-width="160"
+          />
+          <el-table-column
+            :label="t('searchPage.colStatus')"
+            width="120"
+          >
+            <template #default="{ row }">
+              <ElTag
+                v-bind="lifecycleStatusTagAttrs(row.status)"
+                size="small"
+              >
+                {{ nodeStatusLabel(row.status) }}
+              </ElTag>
             </template>
           </el-table-column>
           <template #empty>
-            <el-empty :description="t('searchPage.empty')" :image-size="80" />
+            <el-empty
+              :description="t('searchPage.empty')"
+              :image-size="80"
+            />
           </template>
         </el-table>
       </div>
 
       <div class="hfl-list-panel">
-        <div class="px-4 py-3 border-b border-slate-100 font-semibold text-slate-900">{{ t('searchPage.sectionSnapshots') }}</div>
-        <el-table :data="snapRows" stripe :loading="busy">
-          <el-table-column prop="id" :label="t('searchPage.colId')" width="80">
-            <template #default="{ row }">#{{ row.id }}</template>
+        <div class="px-4 py-3 border-b border-slate-100 font-semibold text-slate-900">
+          {{ t('searchPage.sectionRepos') }}
+        </div>
+        <el-table
+          :data="repoRows"
+          stripe
+          :loading="busy"
+        >
+          <el-table-column
+            prop="id"
+            :label="t('searchPage.colId')"
+            width="80"
+          >
+            <template #default="{ row }">
+              #{{ row.id }}
+            </template>
           </el-table-column>
-          <el-table-column prop="snapshot_uid" :label="t('searchPage.colName')" min-width="180" show-overflow-tooltip>
+          <el-table-column
+            prop="name"
+            :label="t('searchPage.colName')"
+            min-width="160"
+          />
+          <el-table-column
+            :label="t('searchPage.colType')"
+            width="140"
+          >
+            <template #default="{ row }">
+              <HflTypeLabel :label="repositoryTypeLabel(row.repo_type)" />
+            </template>
+          </el-table-column>
+          <el-table-column
+            :label="t('searchPage.colStatus')"
+            width="120"
+          >
+            <template #default="{ row }">
+              <ElTag
+                v-bind="lifecycleStatusTagAttrs(row.status)"
+                size="small"
+              >
+                {{ repositoryStatusLabel(row.status) }}
+              </ElTag>
+            </template>
+          </el-table-column>
+          <template #empty>
+            <el-empty
+              :description="t('searchPage.empty')"
+              :image-size="80"
+            />
+          </template>
+        </el-table>
+      </div>
+
+      <div class="hfl-list-panel">
+        <div class="px-4 py-3 border-b border-slate-100 font-semibold text-slate-900">
+          {{ t('searchPage.sectionSnapshots') }}
+        </div>
+        <el-table
+          :data="snapRows"
+          stripe
+          :loading="busy"
+        >
+          <el-table-column
+            prop="id"
+            :label="t('searchPage.colId')"
+            width="80"
+          >
+            <template #default="{ row }">
+              #{{ row.id }}
+            </template>
+          </el-table-column>
+          <el-table-column
+            prop="snapshot_uid"
+            :label="t('searchPage.colName')"
+            min-width="180"
+            show-overflow-tooltip
+          >
             <template #default="{ row }">
               <span class="hfl-table-cell-mono">{{ row.snapshot_uid }}</span>
             </template>
           </el-table-column>
-          <el-table-column prop="repository_display_name" :label="t('searchPage.colRepo')" min-width="140" show-overflow-tooltip />
-          <el-table-column prop="source_display_name" :label="t('searchPage.colSource')" min-width="140" show-overflow-tooltip />
-          <el-table-column :label="t('searchPage.colStatus')" width="120">
-            <template #default="{ row }"><SnapshotStatusTag :status="row.status" /></template>
+          <el-table-column
+            prop="repository_display_name"
+            :label="t('searchPage.colRepo')"
+            min-width="140"
+            show-overflow-tooltip
+          />
+          <el-table-column
+            prop="source_display_name"
+            :label="t('searchPage.colSource')"
+            min-width="140"
+            show-overflow-tooltip
+          />
+          <el-table-column
+            :label="t('searchPage.colStatus')"
+            width="120"
+          >
+            <template #default="{ row }">
+              <SnapshotStatusTag :status="row.status" />
+            </template>
           </el-table-column>
           <template #empty>
-            <el-empty :description="t('searchPage.empty')" :image-size="80" />
+            <el-empty
+              :description="t('searchPage.empty')"
+              :image-size="80"
+            />
           </template>
         </el-table>
       </div>
 
       <div class="hfl-list-panel lg:col-span-2">
-        <div class="px-4 py-3 border-b border-slate-100 font-semibold text-slate-900">{{ t('searchPage.sectionAlerts') }}</div>
-        <el-table :data="alertRows" stripe :loading="busy">
-          <el-table-column prop="id" :label="t('searchPage.colId')" width="80">
-            <template #default="{ row }">#{{ row.id }}</template>
-          </el-table-column>
-          <el-table-column prop="title" :label="t('searchPage.colTitle')" min-width="200" />
-          <el-table-column :label="t('searchPage.colSeverity')" width="120">
+        <div class="px-4 py-3 border-b border-slate-100 font-semibold text-slate-900">
+          {{ t('searchPage.sectionAlerts') }}
+        </div>
+        <el-table
+          :data="alertRows"
+          stripe
+          :loading="busy"
+        >
+          <el-table-column
+            prop="id"
+            :label="t('searchPage.colId')"
+            width="80"
+          >
             <template #default="{ row }">
-              <ElTag v-bind="alertSeverityTagAttrs(row.severity)" size="small">{{ alertSeverityLabel(row.severity) }}</ElTag>
+              #{{ row.id }}
             </template>
           </el-table-column>
-          <el-table-column :label="t('searchPage.colStatus')" width="120">
+          <el-table-column
+            prop="title"
+            :label="t('searchPage.colTitle')"
+            min-width="200"
+          />
+          <el-table-column
+            :label="t('searchPage.colSeverity')"
+            width="120"
+          >
             <template #default="{ row }">
-              <ElTag v-bind="alertStatusTagAttrs(row.status)" size="small">{{ alertStatusLabel(row.status) }}</ElTag>
+              <ElTag
+                v-bind="alertSeverityTagAttrs(row.severity)"
+                size="small"
+              >
+                {{ alertSeverityLabel(row.severity) }}
+              </ElTag>
+            </template>
+          </el-table-column>
+          <el-table-column
+            :label="t('searchPage.colStatus')"
+            width="120"
+          >
+            <template #default="{ row }">
+              <ElTag
+                v-bind="alertStatusTagAttrs(row.status)"
+                size="small"
+              >
+                {{ alertStatusLabel(row.status) }}
+              </ElTag>
             </template>
           </el-table-column>
           <template #empty>
-            <el-empty :description="t('searchPage.empty')" :image-size="80" />
+            <el-empty
+              :description="t('searchPage.empty')"
+              :image-size="80"
+            />
           </template>
         </el-table>
       </div>

--- a/src/frontend/src/pages/account/AccountProfile.vue
+++ b/src/frontend/src/pages/account/AccountProfile.vue
@@ -320,16 +320,25 @@ watch(
           <span class="account-settings-section__icon account-settings-section__icon--account">
             <UserRound :size="16" />
           </span>
-          <h2 class="account-settings-section__title">{{ t('account.profileSectionAccount') }}</h2>
+          <h2 class="account-settings-section__title">
+            {{ t('account.profileSectionAccount') }}
+          </h2>
         </header>
         <div class="account-overview">
-          <div class="account-overview__avatar" aria-hidden="true">{{ accountInitial }}</div>
+          <div
+            class="account-overview__avatar"
+            aria-hidden="true"
+          >
+            {{ accountInitial }}
+          </div>
           <div class="account-overview__content">
             <div class="account-overview__name">
               <span class="account-settings-row__text">{{ username }}</span>
               <span class="account-role-badge">{{ role }}</span>
             </div>
-            <div class="account-overview__email">{{ email }}</div>
+            <div class="account-overview__email">
+              {{ email }}
+            </div>
           </div>
         </div>
         <div class="account-settings-row">
@@ -352,7 +361,6 @@ watch(
           >{{ registeredAt }}</span>
         </div>
       </section>
-
     </div>
 
     <section class="account-settings-section account-settings-section--password">
@@ -360,9 +368,15 @@ watch(
         <span class="account-settings-section__icon account-settings-section__icon--password">
           <KeyRound :size="16" />
         </span>
-        <h2 class="account-settings-section__title">{{ t('account.securitySectionPwd') }}</h2>
+        <h2 class="account-settings-section__title">
+          {{ t('account.securitySectionPwd') }}
+        </h2>
       </header>
-      <ElForm label-position="top" class="account-password-form" @submit.prevent>
+      <ElForm
+        label-position="top"
+        class="account-password-form"
+        @submit.prevent
+      >
         <div class="account-settings-row account-settings-row--form">
           <span class="account-settings-row__label">{{ t('account.fieldCurrentPassword') }}</span>
           <div class="account-settings-row__control">
@@ -375,7 +389,12 @@ watch(
               @input="onCurrentPasswordInput"
               @blur="currentPasswordTouched = true; validateCurrentPassword(true)"
             />
-            <p v-if="currentPasswordError" class="account-settings-row__error">{{ currentPasswordError }}</p>
+            <p
+              v-if="currentPasswordError"
+              class="account-settings-row__error"
+            >
+              {{ currentPasswordError }}
+            </p>
           </div>
         </div>
         <div class="account-settings-row account-settings-row--form">
@@ -390,19 +409,32 @@ watch(
               @input="onNewPasswordInput"
               @blur="newPasswordTouched = true; validateNewPassword(true)"
             />
-            <div v-if="newPassword" class="account-password-strength">
+            <div
+              v-if="newPassword"
+              class="account-password-strength"
+            >
               <div class="account-password-strength__bar">
                 <div
                   class="account-password-strength__fill"
                   :style="{ width: `${(passwordStrength.level / 3) * 100}%`, background: passwordStrength.color }"
                 />
               </div>
-              <span class="account-password-strength__text" :style="{ color: passwordStrength.color }">
+              <span
+                class="account-password-strength__text"
+                :style="{ color: passwordStrength.color }"
+              >
                 {{ passwordStrength.text }}
               </span>
             </div>
-            <p class="account-settings-row__hint">{{ t('account.securityPwdHint') }}</p>
-            <p v-if="newPasswordError" class="account-settings-row__error">{{ newPasswordError }}</p>
+            <p class="account-settings-row__hint">
+              {{ t('account.securityPwdHint') }}
+            </p>
+            <p
+              v-if="newPasswordError"
+              class="account-settings-row__error"
+            >
+              {{ newPasswordError }}
+            </p>
           </div>
         </div>
         <div class="account-settings-row account-settings-row--form">
@@ -417,11 +449,19 @@ watch(
               @input="onConfirmPasswordInput"
               @blur="confirmPasswordTouched = true; validateConfirmPassword(true)"
             />
-            <p v-if="confirmPasswordError" class="account-settings-row__error">{{ confirmPasswordError }}</p>
+            <p
+              v-if="confirmPasswordError"
+              class="account-settings-row__error"
+            >
+              {{ confirmPasswordError }}
+            </p>
           </div>
         </div>
         <div class="account-settings-row account-settings-row--form account-settings-row--actions">
-          <span class="account-settings-row__label" aria-hidden="true" />
+          <span
+            class="account-settings-row__label"
+            aria-hidden="true"
+          />
           <div class="account-settings-row__control">
             <ElButton
               type="primary"
@@ -441,7 +481,9 @@ watch(
         <span class="account-settings-section__icon account-settings-section__icon--audit">
           <ShieldCheck :size="16" />
         </span>
-        <h2 class="account-settings-section__title">{{ t('account.securityAuditCardTitle') }}</h2>
+        <h2 class="account-settings-section__title">
+          {{ t('account.securityAuditCardTitle') }}
+        </h2>
       </header>
       <div class="account-settings-row">
         <span class="account-settings-row__label">{{ t('account.lastLoginAtLabel') }}</span>

--- a/src/frontend/src/pages/account/AccountSettingsLayout.vue
+++ b/src/frontend/src/pages/account/AccountSettingsLayout.vue
@@ -10,9 +10,15 @@ const bodyFill = computed(() => route.path === '/account/notifications')
 </script>
 
 <template>
-  <ModulePage :menus="accountMenus" :body-fill="bodyFill">
+  <ModulePage
+    :menus="accountMenus"
+    :body-fill="bodyFill"
+  >
     <RouterView v-slot="{ Component }">
-      <Transition name="account-route" mode="out-in">
+      <Transition
+        name="account-route"
+        mode="out-in"
+      >
         <component :is="Component" />
       </Transition>
     </RouterView>

--- a/src/frontend/src/pages/auth/Login.vue
+++ b/src/frontend/src/pages/auth/Login.vue
@@ -601,22 +601,28 @@ onMounted(async () => {
 
     <!-- Login Form Box -->
     <div class="login-form-box">
-      <div class="login-box-title" :class="{ 'title-en': locale === 'en' }">
+      <div
+        class="login-box-title"
+        :class="{ 'title-en': locale === 'en' }"
+      >
         <span :class="{ '!text-base': locale === 'en' }">
           {{ cardTitle }}
         </span>
         <button
           v-if="canSwitchLocale"
           class="lang-toggle"
-          @click="toggleLocale"
           :title="`Switch to ${nextLocaleLabel}`"
+          @click="toggleLocale"
         >
           <Globe :size="18" />
           <span class="lang-label">{{ nextLocaleCode.toUpperCase() }}</span>
         </button>
       </div>
 
-      <Transition name="card-view-fade" mode="out-in">
+      <Transition
+        name="card-view-fade"
+        mode="out-in"
+      >
         <ResetPasswordCard
           v-if="cardView === 'reset'"
           key="reset"
@@ -626,207 +632,282 @@ onMounted(async () => {
           @update:step="onResetStepChange"
         />
 
-        <div v-else key="login" class="login-box-content">
-        <ElAlert
-          v-if="sessionNoticeMessage"
-          class="session-alert"
-          type="warning"
-          :title="sessionNoticeMessage"
-          show-icon
-          :closable="true"
-          @close="dismissSessionNotice"
-        />
-
         <div
-          v-if="emailCodeLoginAvailable"
-          class="login-method-tabs"
-          role="tablist"
-          :aria-label="t('login.methodLabel')"
-          aria-orientation="horizontal"
+          v-else
+          key="login"
+          class="login-box-content"
         >
-          <button
-            id="login-method-tab-password"
-            type="button"
-            class="login-method-tabs__tab"
-            :class="{ 'is-active': authMode === 'password' }"
-            role="tab"
-            :aria-selected="authMode === 'password'"
-            aria-controls="login-method-panel"
-            :tabindex="authMode === 'password' ? 0 : -1"
-            :ref="element => setAuthModeTabRef('password', element)"
-            @click="selectAuthMode('password')"
-            @keydown="onAuthModeKeydown"
-          >
-            {{ t('login.passwordMethod') }}
-          </button>
-          <button
-            id="login-method-tab-email-code"
-            type="button"
-            class="login-method-tabs__tab"
-            :class="{ 'is-active': authMode === 'email-code' }"
-            role="tab"
-            :aria-selected="authMode === 'email-code'"
-            aria-controls="login-method-panel"
-            :tabindex="authMode === 'email-code' ? 0 : -1"
-            :ref="element => setAuthModeTabRef('email-code', element)"
-            @click="selectAuthMode('email-code')"
-            @keydown="onAuthModeKeydown"
-          >
-            {{ t('login.emailCodeMethod') }}
-          </button>
-        </div>
-
-        <div
-          id="login-method-panel"
-          class="login-method-panel"
-          role="tabpanel"
-          :aria-labelledby="`login-method-tab-${authMode}`"
-        >
-        <!-- Email -->
-        <div v-if="authMode === 'password'" class="input-wrapper" :class="{ 'has-error': formItems.email.showError }">
-          <div class="input-row">
-            <Mail class="input-icon" :size="18" />
-            <input
-              v-model="formItems.email.value"
-              type="text"
-              :placeholder="formItems.email.placeholder"
-              tabindex="1"
-              autocomplete="email"
-              @blur="validateEmailOnInput"
-              @input="validateEmailOnInput"
-            />
-          </div>
-          <p v-if="formItems.email.showError" class="error-msg">{{ formItems.email.errorMsg }}</p>
-        </div>
-
-        <!-- Password -->
-        <div v-if="authMode === 'password'" class="input-wrapper" :class="{ 'has-error': formItems.password.showError }">
-          <div class="input-row">
-            <Lock class="input-icon" :size="18" />
-            <input
-              v-model="formItems.password.value"
-              :type="showPassword ? 'text' : 'password'"
-              :placeholder="formItems.password.placeholder"
-              tabindex="2"
-              autocomplete="current-password"
-              @blur="validatePasswordPresenceOnInput"
-              @input="validatePasswordPresenceOnInput"
-              @keyup.enter="handleSubmit"
-            />
-            <button
-              type="button"
-              class="eye-btn"
-              :aria-label="showPassword ? t('common.hidePassword') : t('common.showPassword')"
-              :aria-pressed="showPassword"
-              @click="showPassword = !showPassword"
-            >
-              <EyeOff v-if="showPassword" class="eye-icon" :size="16" />
-              <Eye v-else class="eye-icon" :size="16" />
-            </button>
-          </div>
-          <p v-if="formItems.password.showError" class="error-msg">{{ formItems.password.errorMsg }}</p>
-        </div>
-
-        <AuthTurnstileField
-          v-if="authMode === 'password'"
-          :key="authTurnstileMountGeneration"
-          ref="turnstileFieldRef"
-          :pending="isTurnstilePending"
-          :ready="isTurnstileReady"
-          :blocked="isTurnstileBlocked"
-          :verified="Boolean(turnstileToken)"
-          :site-key="turnstileSiteKey"
-          action="login"
-          :loading-message="t('login.captchaLoading')"
-          :blocked-message="t('login.captchaUnavailable')"
-          :retry-label="t('login.captchaRetry')"
-          :manual-retry-label="t('login.captchaManualRetry')"
-          :error-code-label="turnstileErrorCode ? t('login.captchaReferenceCode', { code: turnstileErrorCode }) : ''"
-          :error-message="turnstileError"
-          @retry="retryTurnstile"
-          @success="onTurnstileSuccess"
-          @expire="onTurnstileExpire"
-          @invalidate="onTurnstileInvalidate"
-          @error="onTurnstileError"
-          @load-failed="onTurnstileLoadFailed"
-        />
-
-        <div class="login-actions">
-          <div v-if="authMode === 'password'">
-            <!-- Submit Button -->
-            <ElButton
-              type="primary"
-              class="submit-btn"
-              :disabled="submitLoading || !canSubmitLogin"
-              :loading="submitLoading"
-              @click="handleSubmit"
-            >
-              {{ submitLoading ? t('login.btnSubmitLoading') : t('login.btnSubmit') }}
-            </ElButton>
-          </div>
-
-          <EmailCodeLoginForm
-            v-if="authMode === 'email-code'"
-            v-model:email="formItems.email.value"
-            @verified="handleEmailCodeVerified"
+          <ElAlert
+            v-if="sessionNoticeMessage"
+            class="session-alert"
+            type="warning"
+            :title="sessionNoticeMessage"
+            show-icon
+            :closable="true"
+            @close="dismissSessionNotice"
           />
 
-          <!-- Forgot Password -->
-          <div v-if="passwordResetAvailable" class="forgot-row">
-            <a href="#" class="forgot-link" @click.prevent="goForgetPwd">{{ t('login.forgotPwd') }}</a>
+          <div
+            v-if="emailCodeLoginAvailable"
+            class="login-method-tabs"
+            role="tablist"
+            :aria-label="t('login.methodLabel')"
+            aria-orientation="horizontal"
+          >
+            <button
+              id="login-method-tab-password"
+              :ref="element => setAuthModeTabRef('password', element)"
+              type="button"
+              class="login-method-tabs__tab"
+              :class="{ 'is-active': authMode === 'password' }"
+              role="tab"
+              :aria-selected="authMode === 'password'"
+              aria-controls="login-method-panel"
+              :tabindex="authMode === 'password' ? 0 : -1"
+              @click="selectAuthMode('password')"
+              @keydown="onAuthModeKeydown"
+            >
+              {{ t('login.passwordMethod') }}
+            </button>
+            <button
+              id="login-method-tab-email-code"
+              :ref="element => setAuthModeTabRef('email-code', element)"
+              type="button"
+              class="login-method-tabs__tab"
+              :class="{ 'is-active': authMode === 'email-code' }"
+              role="tab"
+              :aria-selected="authMode === 'email-code'"
+              aria-controls="login-method-panel"
+              :tabindex="authMode === 'email-code' ? 0 : -1"
+              @click="selectAuthMode('email-code')"
+              @keydown="onAuthModeKeydown"
+            >
+              {{ t('login.emailCodeMethod') }}
+            </button>
+          </div>
+
+          <div
+            id="login-method-panel"
+            class="login-method-panel"
+            role="tabpanel"
+            :aria-labelledby="`login-method-tab-${authMode}`"
+          >
+            <!-- Email -->
+            <div
+              v-if="authMode === 'password'"
+              class="input-wrapper"
+              :class="{ 'has-error': formItems.email.showError }"
+            >
+              <div class="input-row">
+                <Mail
+                  class="input-icon"
+                  :size="18"
+                />
+                <input
+                  v-model="formItems.email.value"
+                  type="text"
+                  :placeholder="formItems.email.placeholder"
+                  tabindex="1"
+                  autocomplete="email"
+                  @blur="validateEmailOnInput"
+                  @input="validateEmailOnInput"
+                >
+              </div>
+              <p
+                v-if="formItems.email.showError"
+                class="error-msg"
+              >
+                {{ formItems.email.errorMsg }}
+              </p>
+            </div>
+
+            <!-- Password -->
+            <div
+              v-if="authMode === 'password'"
+              class="input-wrapper"
+              :class="{ 'has-error': formItems.password.showError }"
+            >
+              <div class="input-row">
+                <Lock
+                  class="input-icon"
+                  :size="18"
+                />
+                <input
+                  v-model="formItems.password.value"
+                  :type="showPassword ? 'text' : 'password'"
+                  :placeholder="formItems.password.placeholder"
+                  tabindex="2"
+                  autocomplete="current-password"
+                  @blur="validatePasswordPresenceOnInput"
+                  @input="validatePasswordPresenceOnInput"
+                  @keyup.enter="handleSubmit"
+                >
+                <button
+                  type="button"
+                  class="eye-btn"
+                  :aria-label="showPassword ? t('common.hidePassword') : t('common.showPassword')"
+                  :aria-pressed="showPassword"
+                  @click="showPassword = !showPassword"
+                >
+                  <EyeOff
+                    v-if="showPassword"
+                    class="eye-icon"
+                    :size="16"
+                  />
+                  <Eye
+                    v-else
+                    class="eye-icon"
+                    :size="16"
+                  />
+                </button>
+              </div>
+              <p
+                v-if="formItems.password.showError"
+                class="error-msg"
+              >
+                {{ formItems.password.errorMsg }}
+              </p>
+            </div>
+
+            <AuthTurnstileField
+              v-if="authMode === 'password'"
+              :key="authTurnstileMountGeneration"
+              ref="turnstileFieldRef"
+              :pending="isTurnstilePending"
+              :ready="isTurnstileReady"
+              :blocked="isTurnstileBlocked"
+              :verified="Boolean(turnstileToken)"
+              :site-key="turnstileSiteKey"
+              action="login"
+              :loading-message="t('login.captchaLoading')"
+              :blocked-message="t('login.captchaUnavailable')"
+              :retry-label="t('login.captchaRetry')"
+              :manual-retry-label="t('login.captchaManualRetry')"
+              :error-code-label="turnstileErrorCode ? t('login.captchaReferenceCode', { code: turnstileErrorCode }) : ''"
+              :error-message="turnstileError"
+              @retry="retryTurnstile"
+              @success="onTurnstileSuccess"
+              @expire="onTurnstileExpire"
+              @invalidate="onTurnstileInvalidate"
+              @error="onTurnstileError"
+              @load-failed="onTurnstileLoadFailed"
+            />
+
+            <div class="login-actions">
+              <div v-if="authMode === 'password'">
+                <!-- Submit Button -->
+                <ElButton
+                  type="primary"
+                  class="submit-btn"
+                  :disabled="submitLoading || !canSubmitLogin"
+                  :loading="submitLoading"
+                  @click="handleSubmit"
+                >
+                  {{ submitLoading ? t('login.btnSubmitLoading') : t('login.btnSubmit') }}
+                </ElButton>
+              </div>
+
+              <EmailCodeLoginForm
+                v-if="authMode === 'email-code'"
+                v-model:email="formItems.email.value"
+                @verified="handleEmailCodeVerified"
+              />
+
+              <!-- Forgot Password -->
+              <div
+                v-if="passwordResetAvailable"
+                class="forgot-row"
+              >
+                <a
+                  href="#"
+                  class="forgot-link"
+                  @click.prevent="goForgetPwd"
+                >{{ t('login.forgotPwd') }}</a>
+              </div>
+            </div>
+          </div>
+
+          <!-- Divider -->
+          <div
+            v-if="googleEnabled"
+            class="divider-row"
+          >
+            <div class="divider-line" />
+            <span class="divider-text">{{ t('login.dividerOr') }}</span>
+            <div class="divider-line" />
+          </div>
+
+          <!-- Third Party -->
+          <div
+            v-if="googleEnabled"
+            class="google-signin-block"
+          >
+            <button
+              type="button"
+              class="google-btn"
+              :disabled="googleLoading"
+              @click="startGoogleLogin"
+            >
+              <svg
+                width="18"
+                height="18"
+                viewBox="0 0 24 24"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M22.56 12.25C22.56 11.47 22.49 10.73 22.36 10H12V14.26H17.92C17.66 15.63 16.89 16.8 15.72 17.58V20.34H19.28C21.36 18.42 22.56 15.6 22.56 12.25Z"
+                  fill="#4285F4"
+                />
+                <path
+                  d="M12 23C14.97 23 17.46 22.02 19.28 20.34L15.72 17.58C14.74 18.24 13.48 18.66 12 18.66C9.13999 18.66 6.70999 16.73 5.83999 14.12H2.17999V16.96C3.98999 20.55 7.7 23 12 23Z"
+                  fill="#34A853"
+                />
+                <path
+                  d="M5.84 14.12C5.62 13.46 5.49 12.75 5.49 12C5.49 11.25 5.61 10.54 5.84 9.88001V7.04001H2.18C1.43 8.53001 1 10.22 1 12C1 13.78 1.43 15.47 2.18 16.96L5.84 14.12Z"
+                  fill="#FBBC05"
+                />
+                <path
+                  d="M12 5.34001C13.62 5.34001 15.06 5.89001 16.21 6.99001L19.36 3.84001C17.46 2.07001 14.97 1 12 1C7.7 1 3.99 3.45001 2.18 7.04001L5.84 9.88001C6.71 7.27001 9.14 5.34001 12 5.34001Z"
+                  fill="#EA4335"
+                />
+              </svg>
+              <span>{{ t('login.googleBtn') }}</span>
+            </button>
+          </div>
+
+          <!-- Footer: Register + EULA -->
+          <div
+            v-if="emailSignupEnabled || showEula"
+            class="login-footer"
+          >
+            <div
+              v-if="emailSignupEnabled"
+              class="footer-row"
+            >
+              <span class="footer-text">{{ t('login.noAccount') }}</span>
+              <a
+                href="#"
+                class="footer-link sign-up-link"
+                @click.prevent="goRegister"
+              >{{ t('login.freeRegister') }}</a>
+            </div>
+            <p
+              v-if="showEula"
+              class="footer-legal"
+            >
+              {{ t('login.eulaText') }}
+              <a
+                class="footer-link"
+                href="https://oneprocloud.com/eula"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {{ $t('login.eulaNoticeLinkText') }}
+              </a>{{ t('login.eulaSuffix') }}
+            </p>
           </div>
         </div>
-        </div>
-
-        <!-- Divider -->
-        <div v-if="googleEnabled" class="divider-row">
-          <div class="divider-line"></div>
-          <span class="divider-text">{{ t('login.dividerOr') }}</span>
-          <div class="divider-line"></div>
-        </div>
-
-        <!-- Third Party -->
-        <div v-if="googleEnabled" class="google-signin-block">
-          <button
-            type="button"
-            class="google-btn"
-            :disabled="googleLoading"
-            @click="startGoogleLogin"
-          >
-            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-              <path d="M22.56 12.25C22.56 11.47 22.49 10.73 22.36 10H12V14.26H17.92C17.66 15.63 16.89 16.8 15.72 17.58V20.34H19.28C21.36 18.42 22.56 15.6 22.56 12.25Z" fill="#4285F4"/>
-              <path d="M12 23C14.97 23 17.46 22.02 19.28 20.34L15.72 17.58C14.74 18.24 13.48 18.66 12 18.66C9.13999 18.66 6.70999 16.73 5.83999 14.12H2.17999V16.96C3.98999 20.55 7.7 23 12 23Z" fill="#34A853"/>
-              <path d="M5.84 14.12C5.62 13.46 5.49 12.75 5.49 12C5.49 11.25 5.61 10.54 5.84 9.88001V7.04001H2.18C1.43 8.53001 1 10.22 1 12C1 13.78 1.43 15.47 2.18 16.96L5.84 14.12Z" fill="#FBBC05"/>
-              <path d="M12 5.34001C13.62 5.34001 15.06 5.89001 16.21 6.99001L19.36 3.84001C17.46 2.07001 14.97 1 12 1C7.7 1 3.99 3.45001 2.18 7.04001L5.84 9.88001C6.71 7.27001 9.14 5.34001 12 5.34001Z" fill="#EA4335"/>
-            </svg>
-            <span>{{ t('login.googleBtn') }}</span>
-          </button>
-        </div>
-
-        <!-- Footer: Register + EULA -->
-        <div
-          v-if="emailSignupEnabled || showEula"
-          class="login-footer"
-        >
-          <div v-if="emailSignupEnabled" class="footer-row">
-            <span class="footer-text">{{ t('login.noAccount') }}</span>
-            <a href="#" class="footer-link sign-up-link" @click.prevent="goRegister">{{ t('login.freeRegister') }}</a>
-          </div>
-          <p
-            v-if="showEula"
-            class="footer-legal"
-          >
-            {{ t('login.eulaText') }}
-            <a
-              class="footer-link"
-              href="https://oneprocloud.com/eula"
-              target="_blank"
-              rel="noopener noreferrer">
-              {{ $t('login.eulaNoticeLinkText') }}
-            </a>{{ t('login.eulaSuffix') }}
-          </p>
-        </div>
-      </div>
       </Transition>
     </div>
   </div>

--- a/src/frontend/src/pages/auth/OAuthError.vue
+++ b/src/frontend/src/pages/auth/OAuthError.vue
@@ -88,8 +88,14 @@ onMounted(async () => {
   <div class="oauth-error">
     <div class="oauth-error-card">
       <h1>{{ t('login.googleErrorTitle') }}</h1>
-      <p aria-live="polite">{{ message }}</p>
-      <button type="button" class="back-btn" @click="backToLogin">
+      <p aria-live="polite">
+        {{ message }}
+      </p>
+      <button
+        type="button"
+        class="back-btn"
+        @click="backToLogin"
+      >
         {{ t('login.backToLogin') }}
       </button>
     </div>

--- a/src/frontend/src/pages/auth/Register.vue
+++ b/src/frontend/src/pages/auth/Register.vue
@@ -450,13 +450,16 @@ onUnmounted(() => {
     </div>
 
     <div class="register-form-box">
-      <div class="register-box-title" :class="{ 'title-en': locale === 'en' }">
+      <div
+        class="register-box-title"
+        :class="{ 'title-en': locale === 'en' }"
+      >
         <span :class="{ '!text-base': locale === 'en' }">{{ t('register.welcomeTitle') }}</span>
         <button
           v-if="canSwitchLocale"
           class="lang-toggle"
-          @click="toggleLocale"
           :title="`Switch to ${nextLocaleLabel}`"
+          @click="toggleLocale"
         >
           <Globe :size="18" />
           <span class="lang-label">{{ nextLocaleCode.toUpperCase() }}</span>
@@ -465,9 +468,15 @@ onUnmounted(() => {
 
       <div class="register-box-content">
         <!-- Email -->
-        <div class="input-wrapper" :class="{ 'has-error': formItems.email.showError }">
+        <div
+          class="input-wrapper"
+          :class="{ 'has-error': formItems.email.showError }"
+        >
           <div class="input-row">
-            <Mail class="input-icon" :size="18" />
+            <Mail
+              class="input-icon"
+              :size="18"
+            />
             <input
               v-model="formItems.email.value"
               type="text"
@@ -475,9 +484,14 @@ onUnmounted(() => {
               tabindex="1"
               @blur="validateEmailOnInput"
               @input="validateEmailOnInput"
-            />
+            >
           </div>
-          <p v-if="formItems.email.showError" class="error-msg">{{ formItems.email.errorMsg }}</p>
+          <p
+            v-if="formItems.email.showError"
+            class="error-msg"
+          >
+            {{ formItems.email.errorMsg }}
+          </p>
         </div>
 
         <AuthTurnstileField
@@ -504,10 +518,16 @@ onUnmounted(() => {
         />
 
         <!-- Email Verification Code -->
-        <div class="input-wrapper" :class="{ 'has-error': formItems.code.showError }">
+        <div
+          class="input-wrapper"
+          :class="{ 'has-error': formItems.code.showError }"
+        >
           <div class="captcha-row">
             <div class="input-row captcha-input">
-              <Key class="input-icon" :size="18" />
+              <Key
+                class="input-icon"
+                :size="18"
+              />
               <input
                 v-model="formItems.code.value"
                 type="text"
@@ -515,7 +535,7 @@ onUnmounted(() => {
                 maxlength="6"
                 tabindex="3"
                 @input="clearCodeError"
-              />
+              >
             </div>
             <button
               type="button"
@@ -534,13 +554,24 @@ onUnmounted(() => {
               }}
             </button>
           </div>
-          <p v-if="formItems.code.showError" class="error-msg">{{ formItems.code.errorMsg }}</p>
+          <p
+            v-if="formItems.code.showError"
+            class="error-msg"
+          >
+            {{ formItems.code.errorMsg }}
+          </p>
         </div>
 
         <!-- Password -->
-        <div class="input-wrapper" :class="{ 'has-error': formItems.password.showError }">
+        <div
+          class="input-wrapper"
+          :class="{ 'has-error': formItems.password.showError }"
+        >
           <div class="input-row">
-            <Lock class="input-icon" :size="18" />
+            <Lock
+              class="input-icon"
+              :size="18"
+            />
             <input
               v-model="formItems.password.value"
               :type="showPassword ? 'text' : 'password'"
@@ -550,7 +581,7 @@ onUnmounted(() => {
               @blur="validatePasswordOnInput"
               @input="validatePasswordOnInput"
               @keyup.enter="handleSubmit"
-            />
+            >
             <button
               type="button"
               class="eye-btn"
@@ -558,20 +589,39 @@ onUnmounted(() => {
               :aria-pressed="showPassword"
               @click="showPassword = !showPassword"
             >
-              <EyeOff v-if="showPassword" class="eye-icon" :size="16" />
-              <Eye v-else class="eye-icon" :size="16" />
+              <EyeOff
+                v-if="showPassword"
+                class="eye-icon"
+                :size="16"
+              />
+              <Eye
+                v-else
+                class="eye-icon"
+                :size="16"
+              />
             </button>
           </div>
-          <div v-if="formItems.password.value" class="strength-bar-wrapper">
+          <div
+            v-if="formItems.password.value"
+            class="strength-bar-wrapper"
+          >
             <div class="strength-bar">
               <div
                 class="strength-fill"
                 :style="{ width: (passwordStrength.level / 3 * 100) + '%', background: passwordStrength.color }"
-              ></div>
+              />
             </div>
-            <span class="strength-text" :style="{ color: passwordStrength.color }">{{ passwordStrength.text }}</span>
+            <span
+              class="strength-text"
+              :style="{ color: passwordStrength.color }"
+            >{{ passwordStrength.text }}</span>
           </div>
-          <p v-if="formItems.password.showError" class="error-msg">{{ formItems.password.errorMsg }}</p>
+          <p
+            v-if="formItems.password.showError"
+            class="error-msg"
+          >
+            {{ formItems.password.errorMsg }}
+          </p>
         </div>
 
         <!-- Agreement -->
@@ -581,13 +631,17 @@ onUnmounted(() => {
           class="agree-terms"
           @animationend="shakeTerms = false"
         >
-          <ElCheckbox v-model="agree" class="agree-checkbox">
+          <ElCheckbox
+            v-model="agree"
+            class="agree-checkbox"
+          >
             <span class="footer-text">{{ t('register.agree') }}</span>
             <a
               class="footer-link"
               href="https://oneprocloud.com/eula"
               target="_blank"
-              rel="noopener noreferrer">
+              rel="noopener noreferrer"
+            >
               {{ $t('login.eulaNoticeLinkText') }}
             </a>{{ t('login.eulaSuffix') }}
           </ElCheckbox>
@@ -608,7 +662,11 @@ onUnmounted(() => {
         <div class="register-footer">
           <div class="footer-row">
             <span class="footer-text">{{ t('register.hasAccount') }}</span>
-            <a href="#" class="footer-link sign-in-link" @click.prevent="goLogin">{{ t('register.backToLogin') }}</a>
+            <a
+              href="#"
+              class="footer-link sign-in-link"
+              @click.prevent="goLogin"
+            >{{ t('register.backToLogin') }}</a>
           </div>
         </div>
       </div>
@@ -616,21 +674,43 @@ onUnmounted(() => {
 
     <!-- Success Overlay -->
     <Transition name="auth-success-fade">
-      <div v-if="registerSuccess" class="register-success-overlay" @click.self="goLogin()">
-        <div class="register-success-card" role="dialog" aria-labelledby="register-success-title">
+      <div
+        v-if="registerSuccess"
+        class="register-success-overlay"
+        @click.self="goLogin()"
+      >
+        <div
+          class="register-success-card"
+          role="dialog"
+          aria-labelledby="register-success-title"
+        >
           <div class="register-success-icon">
-            <CheckCircle2 :size="40" stroke-width="1.75" />
+            <CheckCircle2
+              :size="40"
+              stroke-width="1.75"
+            />
           </div>
-          <h2 id="register-success-title" class="register-success-title">
+          <h2
+            id="register-success-title"
+            class="register-success-title"
+          >
             {{ t('register.registerSuccessTitle') }}
           </h2>
-          <p class="register-success-desc">{{ t('register.registerSuccessDesc') }}</p>
+          <p class="register-success-desc">
+            {{ t('register.registerSuccessDesc') }}
+          </p>
           <div class="register-success-email">
             <Mail :size="16" />
             <span>{{ formItems.email.value }}</span>
           </div>
-          <p class="register-success-next">{{ t('register.registerSuccessNext') }}</p>
-          <button type="button" class="register-success-btn btn-primary" @click="goLogin()">
+          <p class="register-success-next">
+            {{ t('register.registerSuccessNext') }}
+          </p>
+          <button
+            type="button"
+            class="register-success-btn btn-primary"
+            @click="goLogin()"
+          >
             {{ t('register.registerSuccessLogin') }}
           </button>
         </div>

--- a/src/frontend/src/pages/insight/AiModelFormPage.vue
+++ b/src/frontend/src/pages/insight/AiModelFormPage.vue
@@ -67,16 +67,30 @@ onMounted(() => {
   <div class="fullscreen-form-fullscreen resource-add-fullscreen ai-model-form-fullscreen">
     <div class="fullscreen-form-page">
       <header class="fullscreen-form-header">
-        <button type="button" class="fullscreen-form-header__back" @click="handleBack">
-          <ArrowLeft class="fullscreen-form-header__back-icon" :size="18" />
+        <button
+          type="button"
+          class="fullscreen-form-header__back"
+          @click="handleBack"
+        >
+          <ArrowLeft
+            class="fullscreen-form-header__back-icon"
+            :size="18"
+          />
         </button>
         <div class="fullscreen-form-header__content">
-          <h1 class="fullscreen-form-header__title">{{ pageTitle }}</h1>
-          <p class="fullscreen-form-header__desc">{{ pageDesc }}</p>
+          <h1 class="fullscreen-form-header__title">
+            {{ pageTitle }}
+          </h1>
+          <p class="fullscreen-form-header__desc">
+            {{ pageDesc }}
+          </p>
         </div>
       </header>
 
-      <div v-loading="loading" class="fullscreen-form-layout">
+      <div
+        v-loading="loading"
+        class="fullscreen-form-layout"
+      >
         <div class="fullscreen-form-main">
           <div class="fullscreen-form-step-stack">
             <!-- Provider -->
@@ -85,7 +99,9 @@ onMounted(() => {
                 <span class="fullscreen-form-section__indicator" />
                 {{ t('insight.aiSettings.sectionProvider') }}
               </h3>
-              <p class="ai-model-section-desc">{{ t('insight.aiSettings.sectionProviderDesc') }}</p>
+              <p class="ai-model-section-desc">
+                {{ t('insight.aiSettings.sectionProviderDesc') }}
+              </p>
 
               <ElRadioGroup
                 v-model="form.provider"
@@ -100,9 +116,14 @@ onMounted(() => {
                   class="ai-provider-card !mr-0"
                 >
                   <div class="ai-provider-card__inner">
-                    <AiProviderIcon :provider="provider.id" size="lg" />
+                    <AiProviderIcon
+                      :provider="provider.id"
+                      size="lg"
+                    />
                     <div class="ai-provider-card__text">
-                      <div class="ai-provider-card__name">{{ provider.label || provider.name || provider.id }}</div>
+                      <div class="ai-provider-card__name">
+                        {{ provider.label || provider.name || provider.id }}
+                      </div>
                       <div class="ai-provider-card__meta">
                         {{ t('insight.aiSettings.providerModelCount', { n: provider.models?.length ?? 0 }) }}
                       </div>
@@ -113,14 +134,23 @@ onMounted(() => {
             </section>
 
             <!-- Connection -->
-            <section v-if="form.provider" class="fullscreen-form-card fullscreen-form-section ai-model-section--connection">
+            <section
+              v-if="form.provider"
+              class="fullscreen-form-card fullscreen-form-section ai-model-section--connection"
+            >
               <h3 class="fullscreen-form-section__title">
                 <span class="fullscreen-form-section__indicator" />
                 {{ t('insight.aiSettings.sectionCredentials') }}
               </h3>
 
-              <ElForm label-position="top" class="fullscreen-form-el-form">
-                <ElFormItem :label="t('insight.aiSettings.labelModel')" required>
+              <ElForm
+                label-position="top"
+                class="fullscreen-form-el-form"
+              >
+                <ElFormItem
+                  :label="t('insight.aiSettings.labelModel')"
+                  required
+                >
                   <div class="ai-model-dropdown">
                     <button
                       type="button"
@@ -128,9 +158,15 @@ onMounted(() => {
                       @click="modelDropdownOpen = !modelDropdownOpen"
                     >
                       <span class="truncate">{{ modelSelectLabel }}</span>
-                      <ChevronDown :size="16" class="shrink-0 text-[var(--color-text-tertiary)]" />
+                      <ChevronDown
+                        :size="16"
+                        class="shrink-0 text-[var(--color-text-tertiary)]"
+                      />
                     </button>
-                    <div v-show="modelDropdownOpen" class="ai-model-dropdown__panel">
+                    <div
+                      v-show="modelDropdownOpen"
+                      class="ai-model-dropdown__panel"
+                    >
                       <button
                         v-for="model in currentProviderModels"
                         :key="model.id"
@@ -139,7 +175,9 @@ onMounted(() => {
                         :class="{ 'is-active': !useCustomModel && form.model === model.id }"
                         @click="selectModel(model.id)"
                       >
-                        <div class="ai-model-dropdown__item-title">{{ model.label || model.name || model.id }}</div>
+                        <div class="ai-model-dropdown__item-title">
+                          {{ model.label || model.name || model.id }}
+                        </div>
                         <div
                           v-if="modelCapabilities(model).length"
                           class="ai-model-dropdown__caps"
@@ -173,8 +211,13 @@ onMounted(() => {
                   />
                 </ElFormItem>
 
-                <div v-if="selectedModelInfo" class="ai-model-info-card">
-                  <div class="ai-model-info-card__label">{{ t('insight.aiSettings.labelCapabilities') }}</div>
+                <div
+                  v-if="selectedModelInfo"
+                  class="ai-model-info-card"
+                >
+                  <div class="ai-model-info-card__label">
+                    {{ t('insight.aiSettings.labelCapabilities') }}
+                  </div>
                   <div class="ai-model-dropdown__caps">
                     <span
                       v-for="cap in selectedModelInfo.capabilities"
@@ -187,14 +230,19 @@ onMounted(() => {
                   </div>
                 </div>
 
-                <ElFormItem :label="t('insight.aiSettings.labelApiKey')" :required="!isEditing">
+                <ElFormItem
+                  :label="t('insight.aiSettings.labelApiKey')"
+                  :required="!isEditing"
+                >
                   <ElInput
                     v-model="form.api_key"
                     type="password"
                     show-password
                     :placeholder="isEditing ? t('insight.aiSettings.apiKeyKeepPlaceholder') : t('insight.aiSettings.apiKeyPlaceholder')"
                   />
-                  <p class="ai-model-field-hint">{{ t('insight.aiSettings.apiKeyEncryptHint') }}</p>
+                  <p class="ai-model-field-hint">
+                    {{ t('insight.aiSettings.apiKeyEncryptHint') }}
+                  </p>
                 </ElFormItem>
 
                 <ElFormItem :label="t('insight.aiSettings.labelApiBase')">
@@ -202,7 +250,9 @@ onMounted(() => {
                     v-model="form.api_base"
                     :placeholder="t('insight.aiSettings.apiBasePlaceholder')"
                   />
-                  <p class="ai-model-field-hint">{{ t('insight.aiSettings.apiBaseHint') }}</p>
+                  <p class="ai-model-field-hint">
+                    {{ t('insight.aiSettings.apiBaseHint') }}
+                  </p>
                 </ElFormItem>
 
                 <ElFormItem :label="t('insight.aiSettings.colName')">
@@ -211,12 +261,16 @@ onMounted(() => {
                     :placeholder="t('insight.aiSettings.namePlaceholder')"
                     @input="onNameInput"
                   />
-                  <p class="ai-model-field-hint">{{ t('insight.aiSettings.nameHint') }}</p>
+                  <p class="ai-model-field-hint">
+                    {{ t('insight.aiSettings.nameHint') }}
+                  </p>
                 </ElFormItem>
 
                 <ElFormItem :label="t('insight.aiSettings.labelActive')">
                   <ElSwitch v-model="form.is_active" />
-                  <p class="ai-model-field-hint">{{ t('insight.aiSettings.activeHint') }}</p>
+                  <p class="ai-model-field-hint">
+                    {{ t('insight.aiSettings.activeHint') }}
+                  </p>
                 </ElFormItem>
               </ElForm>
             </section>

--- a/src/frontend/src/pages/insight/AssistantFormPage.vue
+++ b/src/frontend/src/pages/insight/AssistantFormPage.vue
@@ -416,19 +416,36 @@ watch(
 </script>
 
 <template>
-  <div ref="pageRef" class="fullscreen-form-fullscreen resource-add-fullscreen assistant-form-fullscreen">
+  <div
+    ref="pageRef"
+    class="fullscreen-form-fullscreen resource-add-fullscreen assistant-form-fullscreen"
+  >
     <div class="fullscreen-form-page">
       <header class="fullscreen-form-header">
-        <button type="button" class="fullscreen-form-header__back" @click="handleBack">
-          <ArrowLeft class="fullscreen-form-header__back-icon" :size="18" />
+        <button
+          type="button"
+          class="fullscreen-form-header__back"
+          @click="handleBack"
+        >
+          <ArrowLeft
+            class="fullscreen-form-header__back-icon"
+            :size="18"
+          />
         </button>
         <div class="fullscreen-form-header__content">
-          <h1 class="fullscreen-form-header__title">{{ pageTitle }}</h1>
-          <p class="fullscreen-form-header__desc">{{ pageDesc }}</p>
+          <h1 class="fullscreen-form-header__title">
+            {{ pageTitle }}
+          </h1>
+          <p class="fullscreen-form-header__desc">
+            {{ pageDesc }}
+          </p>
         </div>
       </header>
 
-      <div v-loading="loading" class="fullscreen-form-layout">
+      <div
+        v-loading="loading"
+        class="fullscreen-form-layout"
+      >
         <div class="fullscreen-form-main">
           <div class="fullscreen-form-step-stack">
             <!-- 1. Basics & Models -->
@@ -437,19 +454,34 @@ watch(
                 <span class="fullscreen-form-section__indicator" />
                 {{ t('insight.assistants.sectionBasics') }}
               </h3>
-              <ElForm label-position="top" class="fullscreen-form-el-form">
-                <ElFormItem data-validation-field="name" :error="errors.name" :label="t('insight.assistants.fieldName')" required>
+              <ElForm
+                label-position="top"
+                class="fullscreen-form-el-form"
+              >
+                <ElFormItem
+                  data-validation-field="name"
+                  :error="errors.name"
+                  :label="t('insight.assistants.fieldName')"
+                  required
+                >
                   <ElInput
                     v-model="name"
                     maxlength="120"
                     :placeholder="t('insight.assistants.fieldNamePlaceholder')"
                     @input="clearFieldError('name')"
                   />
-                  <p class="assistant-field-hint">{{ t('insight.assistants.fieldNameHint') }}</p>
+                  <p class="assistant-field-hint">
+                    {{ t('insight.assistants.fieldNameHint') }}
+                  </p>
                 </ElFormItem>
 
                 <div class="fullscreen-form-grid">
-                  <ElFormItem data-validation-field="agentModel" :error="errors.agentModel" :label="t('insight.assistants.fieldAgentModel')" required>
+                  <ElFormItem
+                    data-validation-field="agentModel"
+                    :error="errors.agentModel"
+                    :label="t('insight.assistants.fieldAgentModel')"
+                    required
+                  >
                     <div class="assistant-select-row">
                       <div class="assistant-select-row__controls">
                         <ElSelect
@@ -474,7 +506,10 @@ watch(
                           :disabled="modelsRefreshing"
                           @click="refreshModels"
                         >
-                          <RefreshCw :size="16" :class="{ 'is-spinning': modelsRefreshing }" />
+                          <RefreshCw
+                            :size="16"
+                            :class="{ 'is-spinning': modelsRefreshing }"
+                          />
                         </ElButton>
                         <ElButton
                           class="fullscreen-form-icon-btn assistant-select-row__add"
@@ -486,7 +521,9 @@ watch(
                         </ElButton>
                       </div>
                     </div>
-                    <p class="assistant-field-hint">{{ t('insight.assistants.modelHint') }}</p>
+                    <p class="assistant-field-hint">
+                      {{ t('insight.assistants.modelHint') }}
+                    </p>
                   </ElFormItem>
                   <ElFormItem :label="t('insight.assistants.fieldMultimodalModel')">
                     <div class="assistant-select-row">
@@ -513,7 +550,10 @@ watch(
                           :disabled="modelsRefreshing"
                           @click="refreshModels"
                         >
-                          <RefreshCw :size="16" :class="{ 'is-spinning': modelsRefreshing }" />
+                          <RefreshCw
+                            :size="16"
+                            :class="{ 'is-spinning': modelsRefreshing }"
+                          />
                         </ElButton>
                         <ElButton
                           class="fullscreen-form-icon-btn assistant-select-row__add"
@@ -525,17 +565,38 @@ watch(
                         </ElButton>
                       </div>
                     </div>
-                    <p class="assistant-field-hint">{{ t('insight.assistants.multimodalModelHint') }}</p>
+                    <p class="assistant-field-hint">
+                      {{ t('insight.assistants.multimodalModelHint') }}
+                    </p>
                   </ElFormItem>
                 </div>
 
-                <ElFormItem data-validation-field="maxConcurrency" :error="errors.maxConcurrency" :label="t('insight.assistants.fieldMaxConcurrency')" required>
-                  <ElInputNumber v-model="maxConcurrency" :min="1" :max="50" class="assistant-concurrency-input" @change="clearFieldError('maxConcurrency')" />
-                  <p class="assistant-field-hint">{{ t('insight.assistants.maxConcurrencyHint') }}</p>
+                <ElFormItem
+                  data-validation-field="maxConcurrency"
+                  :error="errors.maxConcurrency"
+                  :label="t('insight.assistants.fieldMaxConcurrency')"
+                  required
+                >
+                  <ElInputNumber
+                    v-model="maxConcurrency"
+                    :min="1"
+                    :max="50"
+                    class="assistant-concurrency-input"
+                    @change="clearFieldError('maxConcurrency')"
+                  />
+                  <p class="assistant-field-hint">
+                    {{ t('insight.assistants.maxConcurrencyHint') }}
+                  </p>
                 </ElFormItem>
 
-                <ElFormItem :label="t('insight.assistants.fieldAgentRounds')" required>
-                  <ElRadioGroup v-model="agentRounds" class="assistant-rounds-grid">
+                <ElFormItem
+                  :label="t('insight.assistants.fieldAgentRounds')"
+                  required
+                >
+                  <ElRadioGroup
+                    v-model="agentRounds"
+                    class="assistant-rounds-grid"
+                  >
                     <ElRadio
                       v-for="tier in agentRoundsTiers"
                       :key="tier.value"
@@ -549,7 +610,9 @@ watch(
                       </div>
                     </ElRadio>
                   </ElRadioGroup>
-                  <p class="assistant-field-hint">{{ t('insight.assistants.fieldAgentRoundsHint') }}</p>
+                  <p class="assistant-field-hint">
+                    {{ t('insight.assistants.fieldAgentRoundsHint') }}
+                  </p>
                 </ElFormItem>
               </ElForm>
             </section>
@@ -560,9 +623,17 @@ watch(
                 <span class="fullscreen-form-section__indicator" />
                 {{ t('insight.assistants.sectionKnowledgeSource') }}
               </h3>
-              <ElForm label-position="top" class="fullscreen-form-el-form">
+              <ElForm
+                label-position="top"
+                class="fullscreen-form-el-form"
+              >
                 <div class="fullscreen-form-grid">
-                  <ElFormItem data-validation-field="knowledgeSource" :error="errors.knowledgeSource" :label="t('insight.assistants.fieldKnowledgeSource')" required>
+                  <ElFormItem
+                    data-validation-field="knowledgeSource"
+                    :error="errors.knowledgeSource"
+                    :label="t('insight.assistants.fieldKnowledgeSource')"
+                    required
+                  >
                     <div class="assistant-select-row">
                       <div class="assistant-select-row__controls">
                         <ElSelect
@@ -600,7 +671,10 @@ watch(
                           :disabled="formOptionsRefreshing"
                           @click="refreshFormOptions"
                         >
-                          <RefreshCw :size="16" :class="{ 'is-spinning': formOptionsRefreshing }" />
+                          <RefreshCw
+                            :size="16"
+                            :class="{ 'is-spinning': formOptionsRefreshing }"
+                          />
                         </ElButton>
                         <ElButton
                           class="fullscreen-form-icon-btn assistant-select-row__add"
@@ -618,10 +692,20 @@ watch(
                     >
                       {{ t('insight.assistants.knowledgeSourceEmpty') }}
                     </p>
-                    <p v-else class="assistant-field-hint">{{ t('insight.assistants.fieldKnowledgeSourceHint') }}</p>
+                    <p
+                      v-else
+                      class="assistant-field-hint"
+                    >
+                      {{ t('insight.assistants.fieldKnowledgeSourceHint') }}
+                    </p>
                   </ElFormItem>
 
-                  <ElFormItem data-validation-field="scenario" :error="errors.scenario" :label="t('insight.assistants.fieldScenario')" required>
+                  <ElFormItem
+                    data-validation-field="scenario"
+                    :error="errors.scenario"
+                    :label="t('insight.assistants.fieldScenario')"
+                    required
+                  >
                     <ElSelect
                       v-model="selectedTask"
                       filterable
@@ -637,7 +721,9 @@ watch(
                         :value="task.name"
                       />
                     </ElSelect>
-                    <p class="assistant-field-hint">{{ t('insight.assistants.fieldScenarioHint') }}</p>
+                    <p class="assistant-field-hint">
+                      {{ t('insight.assistants.fieldScenarioHint') }}
+                    </p>
                   </ElFormItem>
                 </div>
 
@@ -651,7 +737,9 @@ watch(
                       :placeholder="t('insight.assistants.fieldRetrievalScopePlaceholder')"
                       :disabled="!selectedKnowledgeSource"
                     />
-                    <p class="assistant-field-hint">{{ t('insight.assistants.fieldRetrievalScopeHint') }}</p>
+                    <p class="assistant-field-hint">
+                      {{ t('insight.assistants.fieldRetrievalScopeHint') }}
+                    </p>
                   </ElFormItem>
                   <ElFormItem :label="t('insight.assistants.fieldExcludeExtensions')">
                     <ElInput
@@ -661,7 +749,9 @@ watch(
                       class="font-mono assistant-retrieval-input"
                       :placeholder="DEFAULT_EXCLUDE_EXTENSIONS"
                     />
-                    <p class="assistant-field-hint">{{ t('insight.assistants.fieldExcludeExtensionsHint') }}</p>
+                    <p class="assistant-field-hint">
+                      {{ t('insight.assistants.fieldExcludeExtensionsHint') }}
+                    </p>
                   </ElFormItem>
                   <ElFormItem :label="t('insight.assistants.fieldExcludeDirs')">
                     <ElInput
@@ -671,7 +761,9 @@ watch(
                       class="font-mono assistant-retrieval-input"
                       :placeholder="DEFAULT_EXCLUDE_DIRS"
                     />
-                    <p class="assistant-field-hint">{{ t('insight.assistants.fieldExcludeDirsHint') }}</p>
+                    <p class="assistant-field-hint">
+                      {{ t('insight.assistants.fieldExcludeDirsHint') }}
+                    </p>
                   </ElFormItem>
                 </div>
               </ElForm>
@@ -684,7 +776,10 @@ watch(
                 {{ t('insight.assistants.sectionTools') }}
               </h3>
 
-              <ElForm label-position="top" class="fullscreen-form-el-form assistant-tools-form">
+              <ElForm
+                label-position="top"
+                class="fullscreen-form-el-form assistant-tools-form"
+              >
                 <ElFormItem :label="t('insight.assistants.fieldWorkspaceContext')">
                   <ElInput
                     v-model="workspaceGuideOverview"
@@ -693,7 +788,9 @@ watch(
                     class="assistant-workspace-input font-mono"
                     :placeholder="t('insight.assistants.workspaceContextPh')"
                   />
-                  <p class="assistant-field-hint">{{ t('insight.assistants.workspaceContextHint') }}</p>
+                  <p class="assistant-field-hint">
+                    {{ t('insight.assistants.workspaceContextHint') }}
+                  </p>
                 </ElFormItem>
 
                 <div class="assistant-tools-bindings">
@@ -709,7 +806,10 @@ watch(
                             :disabled="formOptionsRefreshing"
                             @click="refreshFormOptions"
                           >
-                            <RefreshCw :size="16" :class="{ 'is-spinning': formOptionsRefreshing }" />
+                            <RefreshCw
+                              :size="16"
+                              :class="{ 'is-spinning': formOptionsRefreshing }"
+                            />
                           </ElButton>
                           <ElButton
                             class="fullscreen-form-icon-btn assistant-field-label-row__add"
@@ -723,7 +823,10 @@ watch(
                       </span>
                     </template>
                     <div class="assistant-binding-panel">
-                      <div v-if="selectableSkills.length" class="assistant-binding-panel__toolbar">
+                      <div
+                        v-if="selectableSkills.length"
+                        class="assistant-binding-panel__toolbar"
+                      >
                         <span class="assistant-binding-panel__count">
                           {{
                             t('insight.assistants.bindingsSelectedCount', {
@@ -757,9 +860,16 @@ watch(
                           />
                         </label>
                       </ElCheckboxGroup>
-                      <p v-else class="assistant-binding-panel__empty">{{ t('insight.assistants.noSkills') }}</p>
+                      <p
+                        v-else
+                        class="assistant-binding-panel__empty"
+                      >
+                        {{ t('insight.assistants.noSkills') }}
+                      </p>
                     </div>
-                    <p class="assistant-field-hint">{{ t('insight.assistants.fieldSkillsHint') }}</p>
+                    <p class="assistant-field-hint">
+                      {{ t('insight.assistants.fieldSkillsHint') }}
+                    </p>
                   </ElFormItem>
 
                   <ElFormItem>
@@ -774,7 +884,10 @@ watch(
                             :disabled="formOptionsRefreshing"
                             @click="refreshFormOptions"
                           >
-                            <RefreshCw :size="16" :class="{ 'is-spinning': formOptionsRefreshing }" />
+                            <RefreshCw
+                              :size="16"
+                              :class="{ 'is-spinning': formOptionsRefreshing }"
+                            />
                           </ElButton>
                           <ElButton
                             class="fullscreen-form-icon-btn assistant-field-label-row__add"
@@ -788,7 +901,10 @@ watch(
                       </span>
                     </template>
                     <div class="assistant-binding-panel">
-                      <div v-if="mcps.length" class="assistant-binding-panel__toolbar">
+                      <div
+                        v-if="mcps.length"
+                        class="assistant-binding-panel__toolbar"
+                      >
                         <span class="assistant-binding-panel__count">
                           {{
                             t('insight.assistants.bindingsSelectedCount', {
@@ -825,9 +941,16 @@ watch(
                           />
                         </label>
                       </ElCheckboxGroup>
-                      <p v-else class="assistant-binding-panel__empty">{{ t('insight.assistants.noMcp') }}</p>
+                      <p
+                        v-else
+                        class="assistant-binding-panel__empty"
+                      >
+                        {{ t('insight.assistants.noMcp') }}
+                      </p>
                     </div>
-                    <p class="assistant-field-hint">{{ t('insight.assistants.fieldMcpHint') }}</p>
+                    <p class="assistant-field-hint">
+                      {{ t('insight.assistants.fieldMcpHint') }}
+                    </p>
                   </ElFormItem>
                 </div>
               </ElForm>
@@ -839,8 +962,15 @@ watch(
                 <span class="fullscreen-form-section__indicator" />
                 {{ t('insight.assistants.sectionVisibility') }}
               </h3>
-              <ElRadioGroup v-model="visibilityScope" class="assistant-visibility-grid">
-                <ElRadio value="user" border class="assistant-visibility-card !mr-0">
+              <ElRadioGroup
+                v-model="visibilityScope"
+                class="assistant-visibility-grid"
+              >
+                <ElRadio
+                  value="user"
+                  border
+                  class="assistant-visibility-card !mr-0"
+                >
                   <div class="assistant-visibility-card__inner">
                     <div class="assistant-visibility-card__title">
                       {{ t('insight.assistants.visibilityOnlyMe') }}
@@ -850,7 +980,11 @@ watch(
                     </div>
                   </div>
                 </ElRadio>
-                <ElRadio value="organization" border class="assistant-visibility-card !mr-0">
+                <ElRadio
+                  value="organization"
+                  border
+                  class="assistant-visibility-card !mr-0"
+                >
                   <div class="assistant-visibility-card__inner">
                     <div class="assistant-visibility-card__title">
                       {{ t('insight.assistants.visibilityOrganization') }}

--- a/src/frontend/src/pages/insight/CopilotGatewayTerminology.test.ts
+++ b/src/frontend/src/pages/insight/CopilotGatewayTerminology.test.ts
@@ -3,8 +3,9 @@ import { resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import { en } from '../../locales/en'
 import { copilotGatewayKind } from '../../lib/copilotGatewayTerminology'
+import { compactSourceText } from '../../test/sourceText'
 
-const source = (path: string) => readFileSync(resolve(process.cwd(), path), 'utf8')
+const source = (path: string) => compactSourceText(readFileSync(resolve(process.cwd(), path), 'utf8'))
 
 const newChat = source('src/pages/insight/NewCopilotChat.vue')
 const contextBar = source('src/pages/insight/copilot/CopilotContextBar.vue')

--- a/src/frontend/src/pages/insight/GatewayCompositeStatusCell.vue
+++ b/src/frontend/src/pages/insight/GatewayCompositeStatusCell.vue
@@ -32,7 +32,11 @@ const label = computed(() => {
 
 <template>
   <div class="dg-composite-status">
-    <el-tag :type="display.tagType" size="small" :class="['dg-composite-status__tag', display.tagClass]">
+    <el-tag
+      :type="display.tagType"
+      size="small"
+      :class="['dg-composite-status__tag', display.tagClass]"
+    >
       <LoaderCircle
         v-if="display.spinning"
         :size="12"

--- a/src/frontend/src/pages/insight/GatewayLensBasicSection.vue
+++ b/src/frontend/src/pages/insight/GatewayLensBasicSection.vue
@@ -76,12 +76,17 @@ function detailValueClass(text: string, monoWhenPresent = false) {
 
 <template>
   <section class="hfl-detail-section">
-    <h4 class="hfl-detail-section__title">{{ t('insight.dataGateway.detailSectionAiEngine') }}</h4>
+    <h4 class="hfl-detail-section__title">
+      {{ t('insight.dataGateway.detailSectionAiEngine') }}
+    </h4>
     <div class="hfl-detail-grid">
       <div class="hfl-detail-row">
         <span class="hfl-detail-row__label">{{ t('protection.sourceResources.colStatus') }}</span>
         <span class="hfl-detail-row__value">
-          <el-tag :type="slStatusTagType" size="small">
+          <el-tag
+            :type="slStatusTagType"
+            size="small"
+          >
             {{ slStatusLabel }}
           </el-tag>
         </span>
@@ -164,12 +169,18 @@ function detailValueClass(text: string, monoWhenPresent = false) {
       </div>
       <div class="hfl-detail-row">
         <span class="hfl-detail-row__label">{{ t('insight.dataGateway.fieldSlTasks') }}</span>
-        <span class="hfl-detail-row__value" :class="{ 'hfl-detail-row__empty': tasksLabel === DETAIL_EMPTY }">
+        <span
+          class="hfl-detail-row__value"
+          :class="{ 'hfl-detail-row__empty': tasksLabel === DETAIL_EMPTY }"
+        >
           {{ tasksLabel }}
         </span>
       </div>
     </div>
-    <p v-if="aiPhase === 'not_provisioned'" class="dg-lens-basic__hint">
+    <p
+      v-if="aiPhase === 'not_provisioned'"
+      class="dg-lens-basic__hint"
+    >
       {{ t('insight.dataGateway.aiNotProvisionedHint') }}
     </p>
   </section>

--- a/src/frontend/src/pages/insight/Insight.vue
+++ b/src/frontend/src/pages/insight/Insight.vue
@@ -7,7 +7,12 @@ const insightMenus = useInsightSideNav()
 </script>
 
 <template>
-  <ModulePage :menus="insightMenus" body-flush body-fill hide-page-title>
+  <ModulePage
+    :menus="insightMenus"
+    body-flush
+    body-fill
+    hide-page-title
+  >
     <KeepAlive include="InsightCopilot">
       <InsightCopilot />
     </KeepAlive>

--- a/src/frontend/src/pages/insight/InsightAiModelDetailDrawer.vue
+++ b/src/frontend/src/pages/insight/InsightAiModelDetailDrawer.vue
@@ -204,15 +204,23 @@ onUnmounted(() => {
       <span class="hfl-detail-drawer__title">{{ title }}</span>
     </template>
 
-    <div v-loading="busy" class="hfl-detail-drawer__body">
+    <div
+      v-loading="busy"
+      class="hfl-detail-drawer__body"
+    >
       <template v-if="detail">
         <div class="hfl-detail-sections">
           <section class="hfl-detail-section">
-            <h4 class="hfl-detail-section__title">{{ t('insight.aiSettings.sectionCredentials') }}</h4>
+            <h4 class="hfl-detail-section__title">
+              {{ t('insight.aiSettings.sectionCredentials') }}
+            </h4>
             <div class="hfl-detail-grid">
               <div class="hfl-detail-row">
                 <span class="hfl-detail-row__label">{{ t('insight.aiSettings.colName') }}</span>
-                <span class="hfl-detail-row__value" :class="detailValueClass(displayName)">
+                <span
+                  class="hfl-detail-row__value"
+                  :class="detailValueClass(displayName)"
+                >
                   {{ displayName }}
                 </span>
               </div>
@@ -285,18 +293,27 @@ onUnmounted(() => {
                 </span>
               </div>
 
-              <div class="hfl-detail-row ai-model-drawer__divider" aria-hidden="true" />
+              <div
+                class="hfl-detail-row ai-model-drawer__divider"
+                aria-hidden="true"
+              />
 
               <div class="hfl-detail-row">
                 <span class="hfl-detail-row__label">{{ t('insight.aiSettings.labelModel') }}</span>
-                <span class="hfl-detail-row__value" :class="detailValueClass(modelVersion, true)">
+                <span
+                  class="hfl-detail-row__value"
+                  :class="detailValueClass(modelVersion, true)"
+                >
                   {{ modelVersion }}
                 </span>
               </div>
               <div class="hfl-detail-row">
                 <span class="hfl-detail-row__label">{{ t('insight.aiSettings.labelCapabilities') }}</span>
                 <span class="hfl-detail-row__value">
-                  <span v-if="modelCapabilities.length" class="ai-model-drawer__caps">
+                  <span
+                    v-if="modelCapabilities.length"
+                    class="ai-model-drawer__caps"
+                  >
                     <span
                       v-for="cap in modelCapabilities"
                       :key="cap"
@@ -306,12 +323,18 @@ onUnmounted(() => {
                       {{ capabilityLabel(cap) }}
                     </span>
                   </span>
-                  <span v-else class="hfl-detail-row__empty">{{ DETAIL_EMPTY }}</span>
+                  <span
+                    v-else
+                    class="hfl-detail-row__empty"
+                  >{{ DETAIL_EMPTY }}</span>
                 </span>
               </div>
               <div class="hfl-detail-row">
                 <span class="hfl-detail-row__label">{{ t('insight.aiSettings.labelApiBase') }}</span>
-                <span class="hfl-detail-row__value" :class="detailValueClass(apiBase, true)">
+                <span
+                  class="hfl-detail-row__value"
+                  :class="detailValueClass(apiBase, true)"
+                >
                   {{ apiBase }}
                 </span>
               </div>
@@ -329,16 +352,36 @@ onUnmounted(() => {
         </div>
       </template>
 
-      <ElEmpty v-else-if="!busy" :description="t('errors.generic.loadFailed')" :image-size="72" />
+      <ElEmpty
+        v-else-if="!busy"
+        :description="t('errors.generic.loadFailed')"
+        :image-size="72"
+      />
     </div>
 
-    <template v-if="detail" #footer>
+    <template
+      v-if="detail"
+      #footer
+    >
       <div class="el-drawer__footer-actions">
-        <ElButton :disabled="testing" @click="open = false">{{ t('common.cancel') }}</ElButton>
-        <ElButton :loading="testing" @click="testConnection">
+        <ElButton
+          :disabled="testing"
+          @click="open = false"
+        >
+          {{ t('common.cancel') }}
+        </ElButton>
+        <ElButton
+          :loading="testing"
+          @click="testConnection"
+        >
           {{ t('insight.aiSettings.testConnection') }}
         </ElButton>
-        <ElButton v-if="!detail.deployment_managed" type="primary" :disabled="testing" @click="onEdit">
+        <ElButton
+          v-if="!detail.deployment_managed"
+          type="primary"
+          :disabled="testing"
+          @click="onEdit"
+        >
           {{ t('common.edit') }}
         </ElButton>
       </div>

--- a/src/frontend/src/pages/insight/InsightAiSettings.vue
+++ b/src/frontend/src/pages/insight/InsightAiSettings.vue
@@ -242,7 +242,11 @@ onMounted(() => {
   <div class="hfl-list-shell hfl-list-shell--fill">
     <div class="hfl-list-panel hfl-list-panel--fill">
       <div class="hfl-list-toolbar">
-        <ElButton type="primary" :disabled="!bridgeReady" @click="openCreate">
+        <ElButton
+          type="primary"
+          :disabled="!bridgeReady"
+          @click="openCreate"
+        >
           <Plus :size="16" />
           {{ isPlatformEngine ? t('platformOps.engineActions.addModel') : t('insight.aiSettings.btnAdd') }}
         </ElButton>
@@ -262,33 +266,64 @@ onMounted(() => {
           </ElButton>
           <template #dropdown>
             <ElDropdownMenu>
-              <ElDropdownItem :disabled="batchDisabled || !singleSelected || selectedIsManaged" @click="editSelected">
+              <ElDropdownItem
+                :disabled="batchDisabled || !singleSelected || selectedIsManaged"
+                @click="editSelected"
+              >
                 <span class="el-dropdown-menu__item-content">
-                  <Pencil :size="14" class="shrink-0" />
+                  <Pencil
+                    :size="14"
+                    class="shrink-0"
+                  />
                   <span>{{ t('common.edit') }}</span>
                 </span>
               </ElDropdownItem>
-              <ElDropdownItem :disabled="!selectedCanSetAgentDefault" @click="setSelectedAgentDefault">
+              <ElDropdownItem
+                :disabled="!selectedCanSetAgentDefault"
+                @click="setSelectedAgentDefault"
+              >
                 <span class="el-dropdown-menu__item-content">
-                  <Star :size="14" class="shrink-0" />
+                  <Star
+                    :size="14"
+                    class="shrink-0"
+                  />
                   <span>{{ t('insight.aiSettings.setDefaultAgent') }}</span>
                 </span>
               </ElDropdownItem>
-              <ElDropdownItem :disabled="!selectedCanSetMultimodalDefault" @click="setSelectedMultimodalDefault">
+              <ElDropdownItem
+                :disabled="!selectedCanSetMultimodalDefault"
+                @click="setSelectedMultimodalDefault"
+              >
                 <span class="el-dropdown-menu__item-content">
-                  <Images :size="14" class="shrink-0" />
+                  <Images
+                    :size="14"
+                    class="shrink-0"
+                  />
                   <span>{{ t('insight.aiSettings.setDefaultMultimodal') }}</span>
                 </span>
               </ElDropdownItem>
-              <ElDropdownItem divided :disabled="batchDisabled || !singleSelected || selectedIsManaged" @click="enableSelected">
+              <ElDropdownItem
+                divided
+                :disabled="batchDisabled || !singleSelected || selectedIsManaged"
+                @click="enableSelected"
+              >
                 <span class="el-dropdown-menu__item-content">
-                  <CirclePlay :size="14" class="shrink-0" />
+                  <CirclePlay
+                    :size="14"
+                    class="shrink-0"
+                  />
                   <span>{{ t('insight.aiSettings.enable') }}</span>
                 </span>
               </ElDropdownItem>
-              <ElDropdownItem :disabled="batchDisabled || !singleSelected || selectedIsManaged" @click="disableSelected">
+              <ElDropdownItem
+                :disabled="batchDisabled || !singleSelected || selectedIsManaged"
+                @click="disableSelected"
+              >
                 <span class="el-dropdown-menu__item-content">
-                  <CircleStop :size="14" class="shrink-0" />
+                  <CircleStop
+                    :size="14"
+                    class="shrink-0"
+                  />
                   <span>{{ t('insight.aiSettings.disable') }}</span>
                 </span>
               </ElDropdownItem>
@@ -299,7 +334,10 @@ onMounted(() => {
                 @click="deleteSelected"
               >
                 <span class="el-dropdown-menu__item-content">
-                  <Trash2 :size="14" class="shrink-0" />
+                  <Trash2
+                    :size="14"
+                    class="shrink-0"
+                  />
                   <span>{{ t('common.delete') }}</span>
                 </span>
               </ElDropdownItem>
@@ -317,7 +355,10 @@ onMounted(() => {
             @clear="clearSearch"
           >
             <template #prefix>
-              <Search :size="16" class="hfl-list-search__icon" />
+              <Search
+                :size="16"
+                class="hfl-list-search__icon"
+              />
             </template>
           </ElInput>
           <div class="hfl-list-toolbar__utility">
@@ -327,13 +368,19 @@ onMounted(() => {
               :disabled="loading"
               @click="load"
             >
-              <RefreshCw :size="16" :class="{ 'is-spinning': loading }" />
+              <RefreshCw
+                :size="16"
+                :class="{ 'is-spinning': loading }"
+              />
             </ElButton>
           </div>
         </div>
       </div>
 
-      <div ref="tableBlockRef" class="hfl-list-table-block">
+      <div
+        ref="tableBlockRef"
+        class="hfl-list-table-block"
+      >
         <el-table
           ref="tableRef"
           v-table-overflow-title
@@ -347,7 +394,11 @@ onMounted(() => {
           @scroll="handleTableScroll"
           @selection-change="onSelectionChange"
         >
-          <el-table-column type="selection" width="35" fixed="left" />
+          <el-table-column
+            type="selection"
+            width="35"
+            fixed="left"
+          />
           <el-table-column
             :label="t('insight.aiSettings.colName')"
             min-width="220"
@@ -356,38 +407,84 @@ onMounted(() => {
           >
             <template #default="{ row }">
               <div class="insight-ai-models-name">
-                <button type="button" class="hfl-table-name-link hfl-table-name-link--full" @click="openDetail(row)">
+                <button
+                  type="button"
+                  class="hfl-table-name-link hfl-table-name-link--full"
+                  @click="openDetail(row)"
+                >
                   {{ modelName(row) }}
                 </button>
-                <div v-if="row.is_default_agent || row.is_default_multimodal || row.deployment_managed || row.is_deployment_history" class="insight-ai-models-badges">
-                  <ElTag v-if="row.is_default_agent" size="small" type="success" effect="plain">
+                <div
+                  v-if="row.is_default_agent || row.is_default_multimodal || row.deployment_managed || row.is_deployment_history"
+                  class="insight-ai-models-badges"
+                >
+                  <ElTag
+                    v-if="row.is_default_agent"
+                    size="small"
+                    type="success"
+                    effect="plain"
+                  >
                     {{ t('insight.aiSettings.defaultAgentBadge') }}
                   </ElTag>
-                  <ElTag v-if="row.is_default_multimodal" size="small" type="warning" effect="plain">
+                  <ElTag
+                    v-if="row.is_default_multimodal"
+                    size="small"
+                    type="warning"
+                    effect="plain"
+                  >
                     {{ t('insight.aiSettings.defaultMultimodalBadge') }}
                   </ElTag>
-                  <ElTag v-if="row.deployment_managed" size="small" type="info" effect="plain">
+                  <ElTag
+                    v-if="row.deployment_managed"
+                    size="small"
+                    type="info"
+                    effect="plain"
+                  >
                     {{ t('insight.aiSettings.deploymentManagedBadge') }}
                   </ElTag>
-                  <ElTag v-if="row.is_deployment_history" size="small" type="info" effect="plain">
+                  <ElTag
+                    v-if="row.is_deployment_history"
+                    size="small"
+                    type="info"
+                    effect="plain"
+                  >
                     {{ t('insight.aiSettings.deploymentHistoryBadge') }}
                   </ElTag>
                 </div>
               </div>
             </template>
           </el-table-column>
-          <el-table-column :label="t('insight.aiSettings.labelProvider')" min-width="120">
-            <template #default="{ row }"><span :class="{ 'hfl-empty-mark': !row.provider && !row.name }">{{ row.provider || row.name || '—' }}</span></template>
-          </el-table-column>
-          <el-table-column :label="t('insight.aiSettings.labelModel')" min-width="160">
-            <template #default="{ row }"><span :class="{ 'hfl-empty-mark': !row.config?.model }">{{ row.config?.model || '—' }}</span></template>
-          </el-table-column>
-          <el-table-column :label="t('insight.aiSettings.labelApiBase')" min-width="200">
+          <el-table-column
+            :label="t('insight.aiSettings.labelProvider')"
+            min-width="120"
+          >
             <template #default="{ row }">
-              <span class="insight-ai-models-mono" :class="{ 'hfl-empty-mark': !row.config?.api_base }">{{ row.config?.api_base || '—' }}</span>
+              <span :class="{ 'hfl-empty-mark': !row.provider && !row.name }">{{ row.provider || row.name || '—' }}</span>
             </template>
           </el-table-column>
-          <el-table-column :label="t('insight.aiSettings.labelActive')" width="110">
+          <el-table-column
+            :label="t('insight.aiSettings.labelModel')"
+            min-width="160"
+          >
+            <template #default="{ row }">
+              <span :class="{ 'hfl-empty-mark': !row.config?.model }">{{ row.config?.model || '—' }}</span>
+            </template>
+          </el-table-column>
+          <el-table-column
+            :label="t('insight.aiSettings.labelApiBase')"
+            min-width="200"
+          >
+            <template #default="{ row }">
+              <span
+                class="insight-ai-models-mono"
+                :class="{ 'hfl-empty-mark': !row.config?.api_base }"
+              >{{ row.config?.api_base || '—' }}</span>
+            </template>
+          </el-table-column>
+          <el-table-column
+            :label="t('insight.aiSettings.labelActive')"
+            width="110"
+          >
             <template #default="{ row }">
               <HflBooleanStatusTag
                 :value="row.is_active !== false"

--- a/src/frontend/src/pages/insight/InsightAssistantDetailDrawer.vue
+++ b/src/frontend/src/pages/insight/InsightAssistantDetailDrawer.vue
@@ -306,65 +306,96 @@ onUnmounted(() => {
       <span class="hfl-detail-drawer__title">{{ drawerTitle }}</span>
     </template>
 
-    <div v-loading="loading" class="hfl-detail-drawer__body">
+    <div
+      v-loading="loading"
+      class="hfl-detail-drawer__body"
+    >
       <template v-if="activeRow">
         <div class="hfl-detail-sections">
           <section class="hfl-detail-section">
-            <h4 class="hfl-detail-section__title">{{ t('insight.assistants.sectionBasics') }}</h4>
+            <h4 class="hfl-detail-section__title">
+              {{ t('insight.assistants.sectionBasics') }}
+            </h4>
             <div class="hfl-detail-grid">
               <div class="hfl-detail-row">
                 <span class="hfl-detail-row__label">{{ t('insight.assistants.fieldName') }}</span>
-                <span class="hfl-detail-row__value" :class="detailValueClass(displayValue(activeRow.name))">
+                <span
+                  class="hfl-detail-row__value"
+                  :class="detailValueClass(displayValue(activeRow.name))"
+                >
                   {{ displayValue(activeRow.name) }}
                 </span>
               </div>
               <div class="hfl-detail-row">
                 <span class="hfl-detail-row__label">{{ t('insight.assistants.colStatus') }}</span>
                 <span class="hfl-detail-row__value">
-                  <ElTag v-bind="lifecycleStatusTagAttrs(String(activeRow.status || ''))" size="small">
+                  <ElTag
+                    v-bind="lifecycleStatusTagAttrs(String(activeRow.status || ''))"
+                    size="small"
+                  >
                     {{ statusLabel }}
                   </ElTag>
                 </span>
               </div>
               <div class="hfl-detail-row">
                 <span class="hfl-detail-row__label">{{ t('insight.assistants.fieldAgentModel') }}</span>
-                <span class="hfl-detail-row__value" :class="detailValueClass(agentModelLabel)">
+                <span
+                  class="hfl-detail-row__value"
+                  :class="detailValueClass(agentModelLabel)"
+                >
                   {{ agentModelLabel }}
                 </span>
               </div>
               <div class="hfl-detail-row">
                 <span class="hfl-detail-row__label">{{ t('insight.assistants.fieldMultimodalModel') }}</span>
-                <span class="hfl-detail-row__value" :class="detailValueClass(multimodalModelLabel)">
+                <span
+                  class="hfl-detail-row__value"
+                  :class="detailValueClass(multimodalModelLabel)"
+                >
                   {{ multimodalModelLabel }}
                 </span>
               </div>
               <div class="hfl-detail-row">
                 <span class="hfl-detail-row__label">{{ t('insight.assistants.fieldMaxConcurrency') }}</span>
-                <span class="hfl-detail-row__value" :class="detailValueClass(displayValue(activeRow.max_concurrency))">
+                <span
+                  class="hfl-detail-row__value"
+                  :class="detailValueClass(displayValue(activeRow.max_concurrency))"
+                >
                   {{ displayValue(activeRow.max_concurrency) }}
                 </span>
               </div>
               <div class="hfl-detail-row">
                 <span class="hfl-detail-row__label">{{ t('insight.assistants.fieldAgentRounds') }}</span>
                 <span class="hfl-detail-row__value">
-                  <ElTag size="small" effect="plain">{{ analysisDepthLabel }}</ElTag>
+                  <ElTag
+                    size="small"
+                    effect="plain"
+                  >{{ analysisDepthLabel }}</ElTag>
                 </span>
               </div>
             </div>
           </section>
 
           <section class="hfl-detail-section">
-            <h4 class="hfl-detail-section__title">{{ t('insight.assistants.sectionKnowledgeSource') }}</h4>
+            <h4 class="hfl-detail-section__title">
+              {{ t('insight.assistants.sectionKnowledgeSource') }}
+            </h4>
             <div class="hfl-detail-grid">
               <div class="hfl-detail-row">
                 <span class="hfl-detail-row__label">{{ t('insight.assistants.fieldKnowledgeSource') }}</span>
-                <span class="hfl-detail-row__value" :class="detailValueClass(knowledgeSourceLabel)">
+                <span
+                  class="hfl-detail-row__value"
+                  :class="detailValueClass(knowledgeSourceLabel)"
+                >
                   {{ knowledgeSourceLabel }}
                 </span>
               </div>
               <div class="hfl-detail-row">
                 <span class="hfl-detail-row__label">{{ t('insight.assistants.fieldGateway') }}</span>
-                <span class="hfl-detail-row__value" :class="detailValueClass(gatewayLabel)">
+                <span
+                  class="hfl-detail-row__value"
+                  :class="detailValueClass(gatewayLabel)"
+                >
                   {{ gatewayLabel }}
                 </span>
               </div>
@@ -378,26 +409,38 @@ onUnmounted(() => {
                   >
                     {{ knowledgeSourceStatusDisplay }}
                   </ElTag>
-                  <span v-else class="hfl-detail-row__empty">{{ DETAIL_EMPTY }}</span>
+                  <span
+                    v-else
+                    class="hfl-detail-row__empty"
+                  >{{ DETAIL_EMPTY }}</span>
                 </span>
               </div>
               <div class="hfl-detail-row">
                 <span class="hfl-detail-row__label">{{ t('insight.assistants.fieldScenario') }}</span>
-                <span class="hfl-detail-row__value" :class="detailValueClass(scenarioLabel)">
+                <span
+                  class="hfl-detail-row__value"
+                  :class="detailValueClass(scenarioLabel)"
+                >
                   {{ scenarioLabel }}
                 </span>
               </div>
               <div class="hfl-detail-row hfl-detail-row--full">
                 <span class="hfl-detail-row__label">{{ t('insight.assistants.fieldRetrievalScope') }}</span>
                 <span class="hfl-detail-row__value hfl-detail-row__value--stacked">
-                  <div v-if="retrievalScopeLines.length" class="create-filter-rules-preview">
+                  <div
+                    v-if="retrievalScopeLines.length"
+                    class="create-filter-rules-preview"
+                  >
                     <code
                       v-for="line in retrievalScopeLines"
                       :key="line"
                       class="create-filter-rules-preview__line"
                     >{{ line }}</code>
                   </div>
-                  <span v-else class="hfl-detail-row__empty">{{ DETAIL_EMPTY }}</span>
+                  <span
+                    v-else
+                    class="hfl-detail-row__empty"
+                  >{{ DETAIL_EMPTY }}</span>
                 </span>
               </div>
               <div class="hfl-detail-row">
@@ -422,49 +465,84 @@ onUnmounted(() => {
           </section>
 
           <section class="hfl-detail-section">
-            <h4 class="hfl-detail-section__title">{{ t('insight.assistants.sectionTools') }}</h4>
+            <h4 class="hfl-detail-section__title">
+              {{ t('insight.assistants.sectionTools') }}
+            </h4>
             <div class="hfl-detail-grid">
               <div class="hfl-detail-row hfl-detail-row--full">
                 <span class="hfl-detail-row__label">{{ t('insight.assistants.fieldWorkspaceContext') }}</span>
                 <span class="hfl-detail-row__value hfl-detail-row__value--stacked">
-                  <div v-if="workspaceContextText !== DETAIL_EMPTY" class="create-filter-rules-preview">
+                  <div
+                    v-if="workspaceContextText !== DETAIL_EMPTY"
+                    class="create-filter-rules-preview"
+                  >
                     <pre class="create-filter-rules-preview__line">{{ workspaceContextText }}</pre>
                   </div>
-                  <span v-else class="hfl-detail-row__empty">{{ DETAIL_EMPTY }}</span>
+                  <span
+                    v-else
+                    class="hfl-detail-row__empty"
+                  >{{ DETAIL_EMPTY }}</span>
                 </span>
               </div>
               <div class="hfl-detail-row hfl-detail-row--full">
                 <span class="hfl-detail-row__label">{{ t('insight.assistants.skillsSection') }}</span>
                 <span class="hfl-detail-row__value hfl-detail-row__value--stacked">
-                  <span v-if="boundSkillNames.length" class="insight-detail-tag-row">
-                    <ElTag v-for="name in boundSkillNames" :key="name" size="small" effect="plain">
+                  <span
+                    v-if="boundSkillNames.length"
+                    class="insight-detail-tag-row"
+                  >
+                    <ElTag
+                      v-for="name in boundSkillNames"
+                      :key="name"
+                      size="small"
+                      effect="plain"
+                    >
                       {{ name }}
                     </ElTag>
                   </span>
-                  <span v-else class="hfl-detail-row__empty">{{ DETAIL_EMPTY }}</span>
+                  <span
+                    v-else
+                    class="hfl-detail-row__empty"
+                  >{{ DETAIL_EMPTY }}</span>
                 </span>
               </div>
               <div class="hfl-detail-row hfl-detail-row--full">
                 <span class="hfl-detail-row__label">{{ t('insight.assistants.mcpSection') }}</span>
                 <span class="hfl-detail-row__value hfl-detail-row__value--stacked">
-                  <span v-if="boundMcpNames.length" class="insight-detail-tag-row">
-                    <ElTag v-for="name in boundMcpNames" :key="name" size="small" effect="plain">
+                  <span
+                    v-if="boundMcpNames.length"
+                    class="insight-detail-tag-row"
+                  >
+                    <ElTag
+                      v-for="name in boundMcpNames"
+                      :key="name"
+                      size="small"
+                      effect="plain"
+                    >
                       {{ name }}
                     </ElTag>
                   </span>
-                  <span v-else class="hfl-detail-row__empty">{{ DETAIL_EMPTY }}</span>
+                  <span
+                    v-else
+                    class="hfl-detail-row__empty"
+                  >{{ DETAIL_EMPTY }}</span>
                 </span>
               </div>
             </div>
           </section>
 
           <section class="hfl-detail-section">
-            <h4 class="hfl-detail-section__title">{{ t('insight.assistants.sectionVisibility') }}</h4>
+            <h4 class="hfl-detail-section__title">
+              {{ t('insight.assistants.sectionVisibility') }}
+            </h4>
             <div class="hfl-detail-grid">
               <div class="hfl-detail-row hfl-detail-row--full">
                 <span class="hfl-detail-row__label">{{ t('insight.assistants.fieldVisibility') }}</span>
                 <span class="hfl-detail-row__value hfl-detail-row__value--stacked">
-                  <ElTag :type="visibilityScope === 'user' ? 'warning' : 'success'" size="small">
+                  <ElTag
+                    :type="visibilityScope === 'user' ? 'warning' : 'success'"
+                    size="small"
+                  >
                     {{
                       visibilityScope === 'user'
                         ? t('insight.assistants.visibilityOnlyMe')
@@ -486,7 +564,10 @@ onUnmounted(() => {
       </template>
     </div>
 
-    <template v-if="activeRow" #footer>
+    <template
+      v-if="activeRow"
+      #footer
+    >
       <HflDetailDrawerFooter
         :save-label="t('common.edit')"
         @cancel="drawerOpen = false"

--- a/src/frontend/src/pages/insight/InsightAssistants.vue
+++ b/src/frontend/src/pages/insight/InsightAssistants.vue
@@ -314,7 +314,11 @@ watch(
   <div class="hfl-list-shell hfl-list-shell--fill">
     <div class="hfl-list-panel hfl-list-panel--fill">
       <div class="hfl-list-toolbar">
-        <ElButton type="primary" :disabled="!bridgeReady" @click="openCreate">
+        <ElButton
+          type="primary"
+          :disabled="!bridgeReady"
+          @click="openCreate"
+        >
           <Plus :size="16" />
           {{ isPlatformEngine ? t('platformOps.engineActions.addAssistant') : t('insight.assistants.btnAdd') }}
         </ElButton>
@@ -334,21 +338,40 @@ watch(
           </ElButton>
           <template #dropdown>
             <ElDropdownMenu>
-              <ElDropdownItem :disabled="batchDisabled || !singleSelected" @click="editSelected">
+              <ElDropdownItem
+                :disabled="batchDisabled || !singleSelected"
+                @click="editSelected"
+              >
                 <span class="el-dropdown-menu__item-content">
-                  <Pencil :size="14" class="shrink-0" />
+                  <Pencil
+                    :size="14"
+                    class="shrink-0"
+                  />
                   <span>{{ t('common.edit') }}</span>
                 </span>
               </ElDropdownItem>
-              <ElDropdownItem divided :disabled="batchDisabled || !singleSelected" @click="enableSelected">
+              <ElDropdownItem
+                divided
+                :disabled="batchDisabled || !singleSelected"
+                @click="enableSelected"
+              >
                 <span class="el-dropdown-menu__item-content">
-                  <CirclePlay :size="14" class="shrink-0" />
+                  <CirclePlay
+                    :size="14"
+                    class="shrink-0"
+                  />
                   <span>{{ t('insight.assistants.enable') }}</span>
                 </span>
               </ElDropdownItem>
-              <ElDropdownItem :disabled="batchDisabled || !singleSelected" @click="disableSelected">
+              <ElDropdownItem
+                :disabled="batchDisabled || !singleSelected"
+                @click="disableSelected"
+              >
                 <span class="el-dropdown-menu__item-content">
-                  <CircleStop :size="14" class="shrink-0" />
+                  <CircleStop
+                    :size="14"
+                    class="shrink-0"
+                  />
                   <span>{{ t('insight.assistants.disable') }}</span>
                 </span>
               </ElDropdownItem>
@@ -359,7 +382,10 @@ watch(
                 @click="deleteSelected"
               >
                 <span class="el-dropdown-menu__item-content">
-                  <Trash2 :size="14" class="shrink-0" />
+                  <Trash2
+                    :size="14"
+                    class="shrink-0"
+                  />
                   <span>{{ t('common.delete') }}</span>
                 </span>
               </ElDropdownItem>
@@ -377,7 +403,10 @@ watch(
             @clear="clearSearch"
           >
             <template #prefix>
-              <Search :size="16" class="hfl-list-search__icon" />
+              <Search
+                :size="16"
+                class="hfl-list-search__icon"
+              />
             </template>
           </ElInput>
           <div class="hfl-list-toolbar__utility">
@@ -387,13 +416,19 @@ watch(
               :disabled="loading"
               @click="load"
             >
-              <RefreshCw :size="16" :class="{ 'is-spinning': loading }" />
+              <RefreshCw
+                :size="16"
+                :class="{ 'is-spinning': loading }"
+              />
             </ElButton>
           </div>
         </div>
       </div>
 
-      <div ref="tableBlockRef" class="hfl-list-table-block">
+      <div
+        ref="tableBlockRef"
+        class="hfl-list-table-block"
+      >
         <el-table
           ref="tableRef"
           v-table-overflow-title
@@ -407,7 +442,11 @@ watch(
           @scroll="handleTableScroll"
           @selection-change="onSelectionChange"
         >
-          <el-table-column type="selection" width="35" fixed="left" />
+          <el-table-column
+            type="selection"
+            width="35"
+            fixed="left"
+          />
           <el-table-column
             :label="t('insight.assistants.colName')"
             min-width="200"
@@ -415,23 +454,44 @@ watch(
             class-name="hfl-table-name-col"
           >
             <template #default="{ row }">
-              <button type="button" class="hfl-table-name-link hfl-table-name-link--full" @click="openDetail(row)">
+              <button
+                type="button"
+                class="hfl-table-name-link hfl-table-name-link--full"
+                @click="openDetail(row)"
+              >
                 {{ row.name }}
               </button>
-              <div class="insight-assistants-slug">{{ row.slug }}</div>
+              <div class="insight-assistants-slug">
+                {{ row.slug }}
+              </div>
             </template>
           </el-table-column>
-          <el-table-column :label="t('insight.assistants.colAgentModel')" min-width="180">
+          <el-table-column
+            :label="t('insight.assistants.colAgentModel')"
+            min-width="180"
+          >
             <template #default="{ row }">
-              <span class="insight-assistants-model" :class="{ 'hfl-empty-mark': agentModelLabel(row) === '—' }">{{ agentModelLabel(row) }}</span>
+              <span
+                class="insight-assistants-model"
+                :class="{ 'hfl-empty-mark': agentModelLabel(row) === '—' }"
+              >{{ agentModelLabel(row) }}</span>
             </template>
           </el-table-column>
-          <el-table-column :label="t('insight.assistants.colMultimodalModel')" min-width="180">
+          <el-table-column
+            :label="t('insight.assistants.colMultimodalModel')"
+            min-width="180"
+          >
             <template #default="{ row }">
-              <span class="insight-assistants-model" :class="{ 'hfl-empty-mark': multimodalModelLabel(row) === '—' }">{{ multimodalModelLabel(row) }}</span>
+              <span
+                class="insight-assistants-model"
+                :class="{ 'hfl-empty-mark': multimodalModelLabel(row) === '—' }"
+              >{{ multimodalModelLabel(row) }}</span>
             </template>
           </el-table-column>
-          <el-table-column :label="t('insight.assistants.colKnowledgeSource')" min-width="220">
+          <el-table-column
+            :label="t('insight.assistants.colKnowledgeSource')"
+            min-width="220"
+          >
             <template #default="{ row }">
               <div class="insight-assistants-identity">
                 <strong :class="{ 'hfl-empty-mark': knowledgeSourceName(row) === '—' }">{{ knowledgeSourceName(row) }}</strong>
@@ -439,12 +499,18 @@ watch(
               </div>
             </template>
           </el-table-column>
-          <el-table-column :label="t('insight.assistants.colScenario')" min-width="140">
+          <el-table-column
+            :label="t('insight.assistants.colScenario')"
+            min-width="140"
+          >
             <template #default="{ row }">
               {{ scenarioLabel(row) }}
             </template>
           </el-table-column>
-          <el-table-column :label="t('insight.assistants.colAnalysisDepth')" width="120">
+          <el-table-column
+            :label="t('insight.assistants.colAnalysisDepth')"
+            width="120"
+          >
             <template #default="{ row }">
               <HflTypeLabel :label="analysisDepthLabel(row)" />
             </template>
@@ -459,9 +525,15 @@ watch(
               </div>
             </template>
           </el-table-column>
-          <el-table-column :label="t('insight.assistants.colStatus')" width="110">
+          <el-table-column
+            :label="t('insight.assistants.colStatus')"
+            width="110"
+          >
             <template #default="{ row }">
-              <el-tag v-bind="lifecycleStatusTagAttrs(row.status)" size="small">
+              <el-tag
+                v-bind="lifecycleStatusTagAttrs(row.status)"
+                size="small"
+              >
                 {{ statusLabel(row.status) }}
               </el-tag>
             </template>

--- a/src/frontend/src/pages/insight/InsightCopilot.vue
+++ b/src/frontend/src/pages/insight/InsightCopilot.vue
@@ -692,8 +692,15 @@ onUnmounted(() => {
 
     <div class="copilot-main flex min-h-0 min-w-0 flex-1 flex-col bg-[var(--color-card-bg)]">
       <div class="copilot-mobile-navigation">
-        <button type="button" :aria-label="t('insight.copilot.sessions')" @click="mobileSessionsOpen = true">
-          <Menu :size="20" aria-hidden="true" />
+        <button
+          type="button"
+          :aria-label="t('insight.copilot.sessions')"
+          @click="mobileSessionsOpen = true"
+        >
+          <Menu
+            :size="20"
+            aria-hidden="true"
+          />
           <span>{{ t('insight.copilot.sessions') }}</span>
         </button>
       </div>
@@ -710,7 +717,10 @@ onUnmounted(() => {
           @delete="deleteActiveSession"
         />
 
-        <div v-if="activeSession?.lifecycle_status === 'ready'" class="flex min-h-0 flex-1 flex-col overflow-hidden">
+        <div
+          v-if="activeSession?.lifecycle_status === 'ready'"
+          class="flex min-h-0 flex-1 flex-col overflow-hidden"
+        >
           <CopilotMessageList
             :key="activeSessionId"
             ref="messageListRef"

--- a/src/frontend/src/pages/insight/InsightDataGateways.vue
+++ b/src/frontend/src/pages/insight/InsightDataGateways.vue
@@ -673,27 +673,53 @@ onUnmounted(() => {
             </ElButton>
             <template #dropdown>
               <ElDropdownMenu>
-                <ElDropdownItem command="rename" :disabled="batchRenameDisabled">
+                <ElDropdownItem
+                  command="rename"
+                  :disabled="batchRenameDisabled"
+                >
                   <span class="el-dropdown-menu__item-content">
-                    <Pencil :size="14" class="shrink-0" />
+                    <Pencil
+                      :size="14"
+                      class="shrink-0"
+                    />
                     <span>{{ t('nodesPage.btnBatchRename') }}</span>
                   </span>
                 </ElDropdownItem>
-                <ElDropdownItem command="upgrade" :disabled="batchUpgradeDisabled">
+                <ElDropdownItem
+                  command="upgrade"
+                  :disabled="batchUpgradeDisabled"
+                >
                   <span class="el-dropdown-menu__item-content">
-                    <ArrowUpCircle :size="14" class="shrink-0" />
+                    <ArrowUpCircle
+                      :size="14"
+                      class="shrink-0"
+                    />
                     <span>{{ t('nodesPage.actionUpgrade') }}</span>
                   </span>
                 </ElDropdownItem>
-                <ElDropdownItem command="maintenance" :disabled="batchRenameDisabled">
+                <ElDropdownItem
+                  command="maintenance"
+                  :disabled="batchRenameDisabled"
+                >
                   <span class="el-dropdown-menu__item-content">
-                    <Wrench :size="14" class="shrink-0" />
+                    <Wrench
+                      :size="14"
+                      class="shrink-0"
+                    />
                     <span>{{ t('nodeLifecycle.maintenanceCommands') }}</span>
                   </span>
                 </ElDropdownItem>
-                <ElDropdownItem command="remove" divided class="el-dropdown-menu__item--danger" :disabled="batchDisabled">
+                <ElDropdownItem
+                  command="remove"
+                  divided
+                  class="el-dropdown-menu__item--danger"
+                  :disabled="batchDisabled"
+                >
                   <span class="el-dropdown-menu__item-content">
-                    <Trash2 :size="14" class="shrink-0" />
+                    <Trash2
+                      :size="14"
+                      class="shrink-0"
+                    />
                     <span>{{ t('nodesPage.actionDelete') }}</span>
                   </span>
                 </ElDropdownItem>
@@ -712,7 +738,10 @@ onUnmounted(() => {
             @clear="clearSearch"
           >
             <template #prefix>
-              <Search :size="16" class="hfl-list-search__icon" />
+              <Search
+                :size="16"
+                class="hfl-list-search__icon"
+              />
             </template>
           </ElInput>
           <div class="hfl-list-toolbar__utility">
@@ -722,15 +751,24 @@ onUnmounted(() => {
               :disabled="busy"
               @click="load()"
             >
-              <RefreshCw :size="16" :class="{ 'is-spinning': busy }" />
+              <RefreshCw
+                :size="16"
+                :class="{ 'is-spinning': busy }"
+              />
             </ElButton>
           </div>
         </div>
       </div>
 
-      <NodeLifecycleBanner :snapshot="lifecycleOps.snapshot" @cancel-queued="lifecycleOps.cancelQueued" />
+      <NodeLifecycleBanner
+        :snapshot="lifecycleOps.snapshot"
+        @cancel-queued="lifecycleOps.cancelQueued"
+      />
 
-      <div ref="tableBlockRef" class="hfl-list-table-block">
+      <div
+        ref="tableBlockRef"
+        class="hfl-list-table-block"
+      >
         <el-table
           ref="tableRef"
           v-table-overflow-title
@@ -771,18 +809,31 @@ onUnmounted(() => {
               <span v-else>{{ row.name }}</span>
             </template>
           </el-table-column>
-          <el-table-column v-if="isPlatformEngine" :label="t('insight.dataGateway.colOrigin')" min-width="110">
+          <el-table-column
+            v-if="isPlatformEngine"
+            :label="t('insight.dataGateway.colOrigin')"
+            min-width="110"
+          >
             <template #default="{ row }">
               <span>{{ originLabel(row) }}</span>
             </template>
           </el-table-column>
-          <el-table-column v-if="isPlatformEngine" label="HFL Readiness" min-width="190">
+          <el-table-column
+            v-if="isPlatformEngine"
+            label="HFL Readiness"
+            min-width="190"
+          >
             <template #default="{ row }">
               <span>{{ readinessLabel(row) }}</span>
             </template>
           </el-table-column>
-          <el-table-column :label="t('protection.sourceResources.colHostIp')" min-width="140">
-            <template #default="{ row }">{{ ipLine(row) }}</template>
+          <el-table-column
+            :label="t('protection.sourceResources.colHostIp')"
+            min-width="140"
+          >
+            <template #default="{ row }">
+              {{ ipLine(row) }}
+            </template>
           </el-table-column>
           <el-table-column
             v-if="isPlatformEngine"
@@ -804,7 +855,10 @@ onUnmounted(() => {
                       : undefined
                   "
                 />
-                <span v-else class="hfl-empty-mark">—</span>
+                <span
+                  v-else
+                  class="hfl-empty-mark"
+                >—</span>
                 <span
                   v-if="capacityFor(row)?.used_incomplete"
                   class="dg-capacity-cell__incomplete"
@@ -823,7 +877,11 @@ onUnmounted(() => {
               </div>
             </template>
           </el-table-column>
-          <el-table-column v-if="!isPlatformEngine" label="OS" min-width="120">
+          <el-table-column
+            v-if="!isPlatformEngine"
+            label="OS"
+            min-width="120"
+          >
             <template #default="{ row }">
               <div class="source-os-cell source-os-cell--compact hfl-table-no-tooltip">
                 <span class="source-os-cell__icon-wrap">
@@ -833,20 +891,38 @@ onUnmounted(() => {
               </div>
             </template>
           </el-table-column>
-          <el-table-column v-if="!isPlatformEngine" :label="t('protection.sourceResources.colCpu')" min-width="88">
+          <el-table-column
+            v-if="!isPlatformEngine"
+            :label="t('protection.sourceResources.colCpu')"
+            min-width="88"
+          >
             <template #default="{ row }">
               <span :class="{ 'hfl-empty-mark': nodeCpuCores(row) == null }">{{ nodeCpuCores(row) != null ? t('protection.sourceResources.cpuCoresValue', { n: nodeCpuCores(row) }) : '—' }}</span>
             </template>
           </el-table-column>
-          <el-table-column v-if="!isPlatformEngine" :label="t('protection.sourceResources.colMemory')" min-width="100">
+          <el-table-column
+            v-if="!isPlatformEngine"
+            :label="t('protection.sourceResources.colMemory')"
+            min-width="100"
+          >
             <template #default="{ row }">
               <span :class="{ 'hfl-empty-mark': nodeMemoryTotalBytes(row) == null }">{{ nodeMemoryTotalBytes(row) != null ? formatNodeBytes(nodeMemoryTotalBytes(row)!) : '—' }}</span>
             </template>
           </el-table-column>
-          <el-table-column v-if="!isPlatformEngine" :label="t('protection.sourceResources.colDiskCount')" min-width="96">
-            <template #default="{ row }"><span :class="{ 'hfl-empty-mark': nodeDiskCount(row) == null }">{{ nodeDiskCount(row) ?? '—' }}</span></template>
+          <el-table-column
+            v-if="!isPlatformEngine"
+            :label="t('protection.sourceResources.colDiskCount')"
+            min-width="96"
+          >
+            <template #default="{ row }">
+              <span :class="{ 'hfl-empty-mark': nodeDiskCount(row) == null }">{{ nodeDiskCount(row) ?? '—' }}</span>
+            </template>
           </el-table-column>
-          <el-table-column v-if="!isPlatformEngine" :label="t('protection.sourceResources.colCapacity')" min-width="200">
+          <el-table-column
+            v-if="!isPlatformEngine"
+            :label="t('protection.sourceResources.colCapacity')"
+            min-width="200"
+          >
             <template #default="{ row }">
               <HflCapacityCell
                 :used-bytes="nodeDiskUsageParts(row).used"
@@ -871,10 +947,16 @@ onUnmounted(() => {
               >
                 {{ row.knowledge_source_count }}
               </button>
-              <span v-else class="dg-muted">0</span>
+              <span
+                v-else
+                class="dg-muted"
+              >0</span>
             </template>
           </el-table-column>
-          <el-table-column :label="t('protection.sourceResources.colStatus')" min-width="120">
+          <el-table-column
+            :label="t('protection.sourceResources.colStatus')"
+            min-width="120"
+          >
             <template #default="{ row }">
               <GatewayCompositeStatusCell
                 :node="row"
@@ -883,7 +965,10 @@ onUnmounted(() => {
               />
             </template>
           </el-table-column>
-          <el-table-column :label="t('protection.sourceResources.colVersion')" min-width="130">
+          <el-table-column
+            :label="t('protection.sourceResources.colVersion')"
+            min-width="130"
+          >
             <template #default="{ row }">
               <NodeVersionCell
                 :node="row"
@@ -892,9 +977,15 @@ onUnmounted(() => {
               />
             </template>
           </el-table-column>
-          <el-table-column :label="t('protection.sourceResources.colRegistered')" min-width="170">
+          <el-table-column
+            :label="t('protection.sourceResources.colRegistered')"
+            min-width="170"
+          >
             <template #default="{ row }">
-              <span class="hfl-table-cell-time" :class="{ 'hfl-empty-mark': !row.created_at }">{{ formatNodeDate(row.created_at) }}</span>
+              <span
+                class="hfl-table-cell-time"
+                :class="{ 'hfl-empty-mark': !row.created_at }"
+              >{{ formatNodeDate(row.created_at) }}</span>
             </template>
           </el-table-column>
           <el-table-column
@@ -905,7 +996,12 @@ onUnmounted(() => {
             align="right"
           >
             <template #default="{ row }">
-              <ElButton v-if="canManageGateway(row)" link type="primary" @click="openDetail(row)">
+              <ElButton
+                v-if="canManageGateway(row)"
+                link
+                type="primary"
+                @click="openDetail(row)"
+              >
                 {{ t('platformOps.engineGateway.viewDetails') }}
               </ElButton>
               <ElButton
@@ -916,17 +1012,26 @@ onUnmounted(() => {
               >
                 {{ t('insight.dataGateway.defaultSet') }}
               </ElButton>
-              <span v-else-if="!canManageGateway(row)" class="hfl-empty-mark">—</span>
+              <span
+                v-else-if="!canManageGateway(row)"
+                class="hfl-empty-mark"
+              >—</span>
             </template>
           </el-table-column>
           <template #empty>
-            <el-empty :description="t('nodesPage.emptyGateway')" :image-size="80" />
+            <el-empty
+              :description="t('nodesPage.emptyGateway')"
+              :image-size="80"
+            />
           </template>
         </el-table>
       </div>
 
       <div class="hfl-list-footer">
-        <span v-if="selectedRows.length > 0" class="hfl-list-footer__selected">
+        <span
+          v-if="selectedRows.length > 0"
+          class="hfl-list-footer__selected"
+        >
           {{ t('nodesPage.selectedCount', { n: selectedRows.length }) }}
         </span>
         <PlatformOpsPagination
@@ -957,14 +1062,33 @@ onUnmounted(() => {
       align-center
       destroy-on-close
     >
-      <ElForm label-position="top" class="source-action-dialog__form" @submit.prevent="submitRename">
-        <ElFormItem :label="t('nodesPage.renameLabel')" required>
-          <ElInput v-model="renameInput" :placeholder="t('nodesPage.renamePlaceholder')" maxlength="128" show-word-limit />
+      <ElForm
+        label-position="top"
+        class="source-action-dialog__form"
+        @submit.prevent="submitRename"
+      >
+        <ElFormItem
+          :label="t('nodesPage.renameLabel')"
+          required
+        >
+          <ElInput
+            v-model="renameInput"
+            :placeholder="t('nodesPage.renamePlaceholder')"
+            maxlength="128"
+            show-word-limit
+          />
         </ElFormItem>
       </ElForm>
       <template #footer>
-        <el-button @click="renameDialogOpen = false">{{ t('common.cancel') }}</el-button>
-        <el-button type="primary" @click="submitRename">{{ t('common.save') }}</el-button>
+        <el-button @click="renameDialogOpen = false">
+          {{ t('common.cancel') }}
+        </el-button>
+        <el-button
+          type="primary"
+          @click="submitRename"
+        >
+          {{ t('common.save') }}
+        </el-button>
       </template>
     </el-dialog>
 
@@ -976,14 +1100,20 @@ onUnmounted(() => {
       align-center
       destroy-on-close
     >
-      <p class="dg-capacity-dialog__hint">{{ t('platformOps.engineGateway.capacityDialogHint') }}</p>
+      <p class="dg-capacity-dialog__hint">
+        {{ t('platformOps.engineGateway.capacityDialogHint') }}
+      </p>
       <p
         v-if="capacityTarget && capacityFor(capacityTarget)?.used_incomplete"
         class="dg-capacity-dialog__warn"
       >
         {{ t('platformOps.engineGateway.capacityUsedIncomplete') }}
       </p>
-      <ElForm label-position="top" class="source-action-dialog__form" @submit.prevent="submitCapacity">
+      <ElForm
+        label-position="top"
+        class="source-action-dialog__form"
+        @submit.prevent="submitCapacity"
+      >
         <ElFormItem>
           <ElCheckbox v-model="capacityUnlimited">
             {{ t('platformOps.engineGateway.capacityUnlimited') }}
@@ -994,14 +1124,27 @@ onUnmounted(() => {
           :label="t('platformOps.engineGateway.capacityLabel')"
           required
         >
-          <ElInputNumber v-model="capacityGbDraft" class="w-full" :min="0" :step="1" :precision="0" />
+          <ElInputNumber
+            v-model="capacityGbDraft"
+            class="w-full"
+            :min="0"
+            :step="1"
+            :precision="0"
+          />
         </ElFormItem>
       </ElForm>
       <template #footer>
-        <el-button :disabled="capacitySaving" @click="capacityDialogOpen = false">
+        <el-button
+          :disabled="capacitySaving"
+          @click="capacityDialogOpen = false"
+        >
           {{ t('common.cancel') }}
         </el-button>
-        <el-button type="primary" :loading="capacitySaving" @click="submitCapacity">
+        <el-button
+          type="primary"
+          :loading="capacitySaving"
+          @click="submitCapacity"
+        >
           {{ t('common.save') }}
         </el-button>
       </template>

--- a/src/frontend/src/pages/insight/InsightGatewayDetailDrawer.vue
+++ b/src/frontend/src/pages/insight/InsightGatewayDetailDrawer.vue
@@ -193,10 +193,19 @@ onUnmounted(() => {
       <span class="hfl-detail-drawer__title">{{ node?.name || '—' }}</span>
     </template>
 
-    <div v-loading="busy" class="hfl-detail-drawer__body">
+    <div
+      v-loading="busy"
+      class="hfl-detail-drawer__body"
+    >
       <template v-if="node">
-        <ElTabs v-model="drawerTab" class="hfl-detail-tabs">
-          <ElTabPane :label="t('protection.sourceResources.detailTabBasic')" name="basic">
+        <ElTabs
+          v-model="drawerTab"
+          class="hfl-detail-tabs"
+        >
+          <ElTabPane
+            :label="t('protection.sourceResources.detailTabBasic')"
+            name="basic"
+          >
             <NodeBasicInfoPanel
               ref="basicPanelRef"
               :node="node"
@@ -211,7 +220,10 @@ onUnmounted(() => {
             </NodeBasicInfoPanel>
           </ElTabPane>
 
-          <ElTabPane :label="t('protection.sourceResources.detailTabAdvanced')" name="performance">
+          <ElTabPane
+            :label="t('protection.sourceResources.detailTabAdvanced')"
+            name="performance"
+          >
             <NodePerfSettingsPanel
               ref="perfPanelRef"
               hide-actions
@@ -221,7 +233,11 @@ onUnmounted(() => {
             />
           </ElTabPane>
 
-          <ElTabPane :label="t('nodeLifecycle.maintenance')" name="maintenance" lazy>
+          <ElTabPane
+            :label="t('nodeLifecycle.maintenance')"
+            name="maintenance"
+            lazy
+          >
             <NodeMaintenancePanel
               :node="node"
               :gateway-scope="gatewayScope ?? 'user'"
@@ -232,10 +248,17 @@ onUnmounted(() => {
         </ElTabs>
       </template>
 
-      <ElEmpty v-else-if="!busy" :description="t('nodesPage.gatewayDetailEmpty')" :image-size="72" />
+      <ElEmpty
+        v-else-if="!busy"
+        :description="t('nodesPage.gatewayDetailEmpty')"
+        :image-size="72"
+      />
     </div>
 
-    <template v-if="node && drawerTab === 'performance'" #footer>
+    <template
+      v-if="node && drawerTab === 'performance'"
+      #footer
+    >
       <HflDetailDrawerFooter
         :saving="saving"
         :save-disabled="!hasDrawerChanges"

--- a/src/frontend/src/pages/insight/InsightGateways.vue
+++ b/src/frontend/src/pages/insight/InsightGateways.vue
@@ -7,7 +7,11 @@ const insightMenus = useInsightSideNav()
 </script>
 
 <template>
-  <ModulePage :menus="insightMenus" body-flush body-fill>
+  <ModulePage
+    :menus="insightMenus"
+    body-flush
+    body-fill
+  >
     <InsightDataGateways />
   </ModulePage>
 </template>

--- a/src/frontend/src/pages/insight/InsightKnowledgeBase.vue
+++ b/src/frontend/src/pages/insight/InsightKnowledgeBase.vue
@@ -262,13 +262,17 @@ watch(hasSyncingRows, (syncing) => {
   <div class="hfl-list-shell hfl-list-shell--fill">
     <div class="hfl-list-panel hfl-list-panel--fill">
       <div class="hfl-list-toolbar">
-        <ElButton type="primary" :disabled="!bridgeReady" @click="openCreate">
+        <ElButton
+          type="primary"
+          :disabled="!bridgeReady"
+          @click="openCreate"
+        >
           <Plus :size="16" />
           {{ isPlatformEngine ? t('platformOps.engineActions.addKnowledgeSource') : t('insight.kb.btnAdd') }}
         </ElButton>
 
         <ElDropdown
-            trigger="click"
+          trigger="click"
           popper-class="hfl-actions-dropdown"
           @visible-change="moreActionsOpen = $event"
         >
@@ -279,12 +283,18 @@ watch(hasSyncingRows, (syncing) => {
               class="hfl-list-more__chev"
               :class="{ 'hfl-list-more__chev--open': moreActionsOpen }"
             />
-              </ElButton>
+          </ElButton>
           <template #dropdown>
             <ElDropdownMenu>
-              <ElDropdownItem :disabled="batchDisabled || !singleSelected" @click="editSelected">
+              <ElDropdownItem
+                :disabled="batchDisabled || !singleSelected"
+                @click="editSelected"
+              >
                 <span class="el-dropdown-menu__item-content">
-                  <Pencil :size="14" class="shrink-0" />
+                  <Pencil
+                    :size="14"
+                    class="shrink-0"
+                  />
                   <span>{{ t('common.edit') }}</span>
                 </span>
               </ElDropdownItem>
@@ -293,7 +303,10 @@ watch(hasSyncingRows, (syncing) => {
                 @click="syncSelected"
               >
                 <span class="el-dropdown-menu__item-content">
-                  <RefreshCw :size="14" class="shrink-0" />
+                  <RefreshCw
+                    :size="14"
+                    class="shrink-0"
+                  />
                   <span>{{ t('insight.kb.sync') }}</span>
                 </span>
               </ElDropdownItem>
@@ -304,32 +317,50 @@ watch(hasSyncingRows, (syncing) => {
                 @click="deleteSelected"
               >
                 <span class="el-dropdown-menu__item-content">
-                  <Trash2 :size="14" class="shrink-0" />
+                  <Trash2
+                    :size="14"
+                    class="shrink-0"
+                  />
                   <span>{{ t('common.delete') }}</span>
                 </span>
               </ElDropdownItem>
             </ElDropdownMenu>
-            </template>
+          </template>
         </ElDropdown>
 
         <div class="hfl-list-toolbar__right hfl-list-toolbar__right--mobile-split">
           <ElSelect
             v-model="statusFilter"
             clearable
-          size="small"
+            size="small"
             :placeholder="t('insight.kb.filterRunState')"
             style="width: 160px"
           >
-            <ElOption value="ready" :label="t('insight.kb.statusReady')" />
-            <ElOption value="syncing" :label="t('insight.kb.statusSyncing')" />
-            <ElOption value="degraded" :label="t('insight.kb.statusDegraded')" />
-            <ElOption value="paused" :label="t('insight.kb.statusPaused')" />
-            <ElOption value="error" :label="t('insight.kb.statusError')" />
+            <ElOption
+              value="ready"
+              :label="t('insight.kb.statusReady')"
+            />
+            <ElOption
+              value="syncing"
+              :label="t('insight.kb.statusSyncing')"
+            />
+            <ElOption
+              value="degraded"
+              :label="t('insight.kb.statusDegraded')"
+            />
+            <ElOption
+              value="paused"
+              :label="t('insight.kb.statusPaused')"
+            />
+            <ElOption
+              value="error"
+              :label="t('insight.kb.statusError')"
+            />
           </ElSelect>
           <ElInput
             v-model="search"
             clearable
-          size="small"
+            size="small"
             :placeholder="t('insight.kb.searchPlaceholder')"
             class="hfl-list-search"
             @clear="clearSearch"
@@ -351,7 +382,10 @@ watch(hasSyncingRows, (syncing) => {
         </div>
       </div>
 
-      <div ref="tableBlockRef" class="hfl-list-table-block">
+      <div
+        ref="tableBlockRef"
+        class="hfl-list-table-block"
+      >
         <ElTable
           ref="tableRef"
           v-table-overflow-title
@@ -365,38 +399,69 @@ watch(hasSyncingRows, (syncing) => {
           @scroll="handleTableScroll"
           @selection-change="onSelectionChange"
         >
-          <ElTableColumn type="selection" width="35" fixed="left" />
+          <ElTableColumn
+            type="selection"
+            width="35"
+            fixed="left"
+          />
           <ElTableColumn
             :label="t('insight.kb.colName')"
             min-width="220"
             fixed="left"
             class-name="hfl-table-name-col"
           >
-          <template #default="{ row }">
-              <button type="button" class="hfl-table-name-link hfl-table-name-link--full" @click="openDetail(row)">
+            <template #default="{ row }">
+              <button
+                type="button"
+                class="hfl-table-name-link hfl-table-name-link--full"
+                @click="openDetail(row)"
+              >
                 <div class="ks-identity">
                   <strong>{{ row.name }}</strong>
                   <span>{{ row.source_path }}</span>
-            </div>
+                </div>
               </button>
-          </template>
+            </template>
           </ElTableColumn>
-          <ElTableColumn :label="t('insight.kb.colSourceType')" min-width="140">
-          <template #default="{ row }">
-              <HflTypeLabel :label="sourceTypeLabel(row)" />
-          </template>
-          </ElTableColumn>
-          <ElTableColumn :label="t('insight.kb.colGateway')" prop="gateway_name" min-width="140" />
-          <ElTableColumn :label="t('insight.kb.colLinkedVersion')" min-width="120">
-          <template #default="{ row }">
-              <span v-if="row.backup_source_snapshot_id">{{ versionLabel(row) }}</span>
-              <span v-else class="hfl-empty-mark">—</span>
-          </template>
-          </ElTableColumn>
-          <ElTableColumn :label="t('insight.kb.colRetrieval')" prop="ingest_summary" min-width="140" />
-          <ElTableColumn :label="t('insight.kb.colLearnStatus')" min-width="110">
+          <ElTableColumn
+            :label="t('insight.kb.colSourceType')"
+            min-width="140"
+          >
             <template #default="{ row }">
-              <ElTag v-bind="lifecycleStatusTagAttrs(row.status)" size="small">
+              <HflTypeLabel :label="sourceTypeLabel(row)" />
+            </template>
+          </ElTableColumn>
+          <ElTableColumn
+            :label="t('insight.kb.colGateway')"
+            prop="gateway_name"
+            min-width="140"
+          />
+          <ElTableColumn
+            :label="t('insight.kb.colLinkedVersion')"
+            min-width="120"
+          >
+            <template #default="{ row }">
+              <span v-if="row.backup_source_snapshot_id">{{ versionLabel(row) }}</span>
+              <span
+                v-else
+                class="hfl-empty-mark"
+              >—</span>
+            </template>
+          </ElTableColumn>
+          <ElTableColumn
+            :label="t('insight.kb.colRetrieval')"
+            prop="ingest_summary"
+            min-width="140"
+          />
+          <ElTableColumn
+            :label="t('insight.kb.colLearnStatus')"
+            min-width="110"
+          >
+            <template #default="{ row }">
+              <ElTag
+                v-bind="lifecycleStatusTagAttrs(row.status)"
+                size="small"
+              >
                 {{ statusLabel(row.status) }}
               </ElTag>
             </template>
@@ -408,8 +473,8 @@ watch(hasSyncingRows, (syncing) => {
             />
           </template>
         </ElTable>
-            </div>
-          </div>
+      </div>
+    </div>
 
     <InsightKnowledgeSourceDetailDrawer
       v-model:open="detailOpen"

--- a/src/frontend/src/pages/insight/InsightKnowledgeSourceDetailDrawer.vue
+++ b/src/frontend/src/pages/insight/InsightKnowledgeSourceDetailDrawer.vue
@@ -251,10 +251,19 @@ onUnmounted(() => {
       <span class="hfl-detail-drawer__title">{{ activeRow?.name || DETAIL_EMPTY }}</span>
     </template>
 
-    <div v-loading="loading || busy" class="hfl-detail-drawer__body">
+    <div
+      v-loading="loading || busy"
+      class="hfl-detail-drawer__body"
+    >
       <template v-if="activeRow">
-        <ElTabs v-model="tab" class="hfl-detail-tabs">
-          <ElTabPane :label="t('insight.kb.tabSource')" name="source">
+        <ElTabs
+          v-model="tab"
+          class="hfl-detail-tabs"
+        >
+          <ElTabPane
+            :label="t('insight.kb.tabSource')"
+            name="source"
+          >
             <div class="hfl-detail-sections ks-kb-detail-sections">
               <section class="hfl-detail-section ks-kb-detail-card">
                 <h4 class="ks-kb-detail-card__title">
@@ -264,7 +273,10 @@ onUnmounted(() => {
                 <div class="hfl-detail-grid">
                   <div class="hfl-detail-row">
                     <span class="hfl-detail-row__label">{{ t('insight.kb.fieldName') }}</span>
-                    <span class="hfl-detail-row__value" :class="detailValueClass(activeRow.name)">
+                    <span
+                      class="hfl-detail-row__value"
+                      :class="detailValueClass(activeRow.name)"
+                    >
                       {{ displayValue(activeRow.name) }}
                     </span>
                   </div>
@@ -286,18 +298,30 @@ onUnmounted(() => {
                   <div class="hfl-detail-row">
                     <span class="hfl-detail-row__label">{{ t('insight.kb.colLearnStatus') }}</span>
                     <span class="hfl-detail-row__value">
-                      <ElTag v-bind="lifecycleStatusTagAttrs(activeRow.status)" size="small">{{ statusLabel }}</ElTag>
+                      <ElTag
+                        v-bind="lifecycleStatusTagAttrs(activeRow.status)"
+                        size="small"
+                      >{{ statusLabel }}</ElTag>
                     </span>
                   </div>
                   <div class="hfl-detail-row">
                     <span class="hfl-detail-row__label">{{ t('insight.kb.fieldIngestSummary') }}</span>
-                    <span class="hfl-detail-row__value" :class="detailValueClass(activeRow.ingest_summary)">
+                    <span
+                      class="hfl-detail-row__value"
+                      :class="detailValueClass(activeRow.ingest_summary)"
+                    >
                       {{ displayValue(activeRow.ingest_summary) }}
                     </span>
                   </div>
-                  <div v-if="activeRow.status === 'syncing'" class="hfl-detail-row">
+                  <div
+                    v-if="activeRow.status === 'syncing'"
+                    class="hfl-detail-row"
+                  >
                     <span class="hfl-detail-row__label">{{ t('insight.kb.fieldSyncPhase') }}</span>
-                    <span class="hfl-detail-row__value" :class="detailValueClass(syncPhaseLabel)">
+                    <span
+                      class="hfl-detail-row__value"
+                      :class="detailValueClass(syncPhaseLabel)"
+                    >
                       {{ syncPhaseLabel }}
                     </span>
                   </div>
@@ -312,39 +336,66 @@ onUnmounted(() => {
                 <div class="hfl-detail-grid">
                   <div class="hfl-detail-row">
                     <span class="hfl-detail-row__label">{{ t('insight.copilot.documentConversionSummary') }}</span>
-                    <span class="hfl-detail-row__value" :class="detailValueClass(conversionSummaryDisplay)">
+                    <span
+                      class="hfl-detail-row__value"
+                      :class="detailValueClass(conversionSummaryDisplay)"
+                    >
                       {{ conversionSummaryDisplay }}
                     </span>
                   </div>
-                  <div v-if="conversionOk" class="hfl-detail-row">
+                  <div
+                    v-if="conversionOk"
+                    class="hfl-detail-row"
+                  >
                     <span class="hfl-detail-row__label">{{ t('insight.copilot.documentConversionTitle') }}</span>
                     <span class="hfl-detail-row__value">{{ t('insight.kb.retrieval.conversionResultsOk') }}</span>
                   </div>
-                  <div v-else-if="conversionEmpty" class="hfl-detail-row">
+                  <div
+                    v-else-if="conversionEmpty"
+                    class="hfl-detail-row"
+                  >
                     <span class="hfl-detail-row__label">{{ t('insight.copilot.documentConversionTitle') }}</span>
                     <span class="hfl-detail-row__value">{{ t('insight.copilot.documentConversionEmpty') }}</span>
                   </div>
-                  <div v-else-if="documentConversion && conversionFailed" class="hfl-detail-row">
+                  <div
+                    v-else-if="documentConversion && conversionFailed"
+                    class="hfl-detail-row"
+                  >
                     <span class="hfl-detail-row__label">{{ t('insight.copilot.documentConversionTitle') }}</span>
                     <span class="hfl-detail-row__value">{{ documentConversion.error || t('insight.copilot.documentConversionPartial') }}</span>
                   </div>
-                  <div v-else-if="documentConversion && !conversionRunning && conversionSummaryLabel && !conversionOk && conversionProblems.length === 0" class="hfl-detail-row">
+                  <div
+                    v-else-if="documentConversion && !conversionRunning && conversionSummaryLabel && !conversionOk && conversionProblems.length === 0"
+                    class="hfl-detail-row"
+                  >
                     <span class="hfl-detail-row__label">{{ t('insight.copilot.documentConversionTitle') }}</span>
                     <span class="hfl-detail-row__value">{{ t('insight.copilot.documentConversionPartial') }}</span>
                   </div>
-                  <div v-if="conversionProblems.length" class="hfl-detail-row ks-kb-detail-row--stack">
+                  <div
+                    v-if="conversionProblems.length"
+                    class="hfl-detail-row ks-kb-detail-row--stack"
+                  >
                     <span class="hfl-detail-row__label">{{ t('insight.copilot.documentConversionTitle') }}</span>
                     <ul class="ks-kb-conversion-list">
-                      <li v-for="(item, index) in conversionProblems" :key="`${item.name}-${index}`">
+                      <li
+                        v-for="(item, index) in conversionProblems"
+                        :key="`${item.name}-${index}`"
+                      >
                         <strong>{{ item.name }}</strong>
                         <span>{{ item.reason_label }}</span>
                       </li>
                     </ul>
                   </div>
-                  <div v-if="conversionWarnings.length" class="hfl-detail-row ks-kb-detail-row--stack">
+                  <div
+                    v-if="conversionWarnings.length"
+                    class="hfl-detail-row ks-kb-detail-row--stack"
+                  >
                     <span class="hfl-detail-row__label">{{ t('insight.copilot.documentConversionWarnings') }}</span>
                     <ul class="ks-kb-conversion-list">
-                      <li v-for="(warning, index) in conversionWarnings" :key="`${warning.code}-${index}`">
+                      <li
+                        v-for="(warning, index) in conversionWarnings"
+                        :key="`${warning.code}-${index}`"
+                      >
                         <span>{{ warning.label || warning.code }}</span>
                       </li>
                     </ul>
@@ -352,7 +403,10 @@ onUnmounted(() => {
                 </div>
               </section>
 
-              <section v-if="isBackupSource" class="hfl-detail-section ks-kb-detail-card">
+              <section
+                v-if="isBackupSource"
+                class="hfl-detail-section ks-kb-detail-card"
+              >
                 <h4 class="ks-kb-detail-card__title">
                   <span class="ks-kb-detail-card__indicator" />
                   {{ t('insight.kb.sourceTypeBackup') }}
@@ -360,13 +414,19 @@ onUnmounted(() => {
                 <div class="hfl-detail-grid">
                   <div class="hfl-detail-row">
                     <span class="hfl-detail-row__label">{{ t('insight.kb.fieldBackupSource') }}</span>
-                    <span class="hfl-detail-row__value" :class="detailValueClass(backupSourceLabel)">
+                    <span
+                      class="hfl-detail-row__value"
+                      :class="detailValueClass(backupSourceLabel)"
+                    >
                       {{ backupSourceLabel }}
                     </span>
                   </div>
                   <div class="hfl-detail-row">
                     <span class="hfl-detail-row__label">{{ t('insight.kb.fieldSnapshot') }}</span>
-                    <span class="hfl-detail-row__value" :class="detailValueClass(snapshotLabel)">
+                    <span
+                      class="hfl-detail-row__value"
+                      :class="detailValueClass(snapshotLabel)"
+                    >
                       {{ snapshotLabel }}
                     </span>
                   </div>
@@ -387,12 +447,18 @@ onUnmounted(() => {
                         </span>
                         <span class="ks-kb-detail-scope-list__path">{{ path }}</span>
                       </div>
-                      <span v-if="scopePaths.length === 0" class="hfl-detail-row__empty">{{ DETAIL_EMPTY }}</span>
+                      <span
+                        v-if="scopePaths.length === 0"
+                        class="hfl-detail-row__empty"
+                      >{{ DETAIL_EMPTY }}</span>
                     </div>
                   </div>
                   <div class="hfl-detail-row">
                     <span class="hfl-detail-row__label">{{ t('insight.kb.colGateway') }}</span>
-                    <span class="hfl-detail-row__value" :class="detailValueClass(activeRow.gateway_name)">
+                    <span
+                      class="hfl-detail-row__value"
+                      :class="detailValueClass(activeRow.gateway_name)"
+                    >
                       {{ displayValue(activeRow.gateway_name) }}
                     </span>
                   </div>
@@ -408,7 +474,10 @@ onUnmounted(() => {
                 </div>
               </section>
 
-              <section v-if="isGatewayLocal" class="hfl-detail-section ks-kb-detail-card">
+              <section
+                v-if="isGatewayLocal"
+                class="hfl-detail-section ks-kb-detail-card"
+              >
                 <h4 class="ks-kb-detail-card__title">
                   <span class="ks-kb-detail-card__indicator" />
                   {{ t('insight.kb.sourceTypeGatewayLocal') }}
@@ -416,19 +485,28 @@ onUnmounted(() => {
                 <div class="hfl-detail-grid">
                   <div class="hfl-detail-row">
                     <span class="hfl-detail-row__label">{{ t('insight.kb.colGateway') }}</span>
-                    <span class="hfl-detail-row__value" :class="detailValueClass(activeRow.gateway_name)">
+                    <span
+                      class="hfl-detail-row__value"
+                      :class="detailValueClass(activeRow.gateway_name)"
+                    >
                       {{ displayValue(activeRow.gateway_name) }}
                     </span>
                   </div>
                   <div class="hfl-detail-row">
                     <span class="hfl-detail-row__label">{{ t('insight.kb.wizardStepPath') }}</span>
-                    <span class="hfl-detail-row__value" :class="detailValueClass(activeRow.source_path, true)">
+                    <span
+                      class="hfl-detail-row__value"
+                      :class="detailValueClass(activeRow.source_path, true)"
+                    >
                       {{ displayValue(activeRow.source_path) }}
                     </span>
                   </div>
                   <div class="hfl-detail-row">
                     <span class="hfl-detail-row__label">{{ t('insight.kb.fieldWorkspace') }}</span>
-                    <span class="hfl-detail-row__value" :class="detailValueClass(activeRow.workspace_path_on_lensnode, true)">
+                    <span
+                      class="hfl-detail-row__value"
+                      :class="detailValueClass(activeRow.workspace_path_on_lensnode, true)"
+                    >
                       {{ displayValue(activeRow.workspace_path_on_lensnode) }}
                     </span>
                   </div>
@@ -443,31 +521,46 @@ onUnmounted(() => {
                 <div class="hfl-detail-grid">
                   <div class="hfl-detail-row">
                     <span class="hfl-detail-row__label">{{ t('insight.kb.fieldSnapshotId') }}</span>
-                    <span class="hfl-detail-row__value" :class="detailValueClass(activeRow.backup_source_snapshot_id)">
+                    <span
+                      class="hfl-detail-row__value"
+                      :class="detailValueClass(activeRow.backup_source_snapshot_id)"
+                    >
                       {{ displayValue(activeRow.backup_source_snapshot_id) }}
                     </span>
                   </div>
                   <div class="hfl-detail-row">
                     <span class="hfl-detail-row__label">{{ t('insight.kb.fieldDirectoryId') }}</span>
-                    <span class="hfl-detail-row__value" :class="detailValueClass(activeRow.backup_snapshot_directory_id)">
+                    <span
+                      class="hfl-detail-row__value"
+                      :class="detailValueClass(activeRow.backup_snapshot_directory_id)"
+                    >
                       {{ displayValue(activeRow.backup_snapshot_directory_id) }}
                     </span>
                   </div>
                   <div class="hfl-detail-row">
                     <span class="hfl-detail-row__label">{{ t('insight.kb.fieldAssistantUuid') }}</span>
-                    <span class="hfl-detail-row__value" :class="detailValueClass(activeRow.sl_assistant_uuid, true)">
+                    <span
+                      class="hfl-detail-row__value"
+                      :class="detailValueClass(activeRow.sl_assistant_uuid, true)"
+                    >
                       {{ displayValue(activeRow.sl_assistant_uuid) }}
                     </span>
                   </div>
                   <div class="hfl-detail-row">
                     <span class="hfl-detail-row__label">{{ t('insight.kb.fieldLensnodeUuid') }}</span>
-                    <span class="hfl-detail-row__value" :class="detailValueClass(activeRow.sl_lensnode_uuid, true)">
+                    <span
+                      class="hfl-detail-row__value"
+                      :class="detailValueClass(activeRow.sl_lensnode_uuid, true)"
+                    >
                       {{ displayValue(activeRow.sl_lensnode_uuid) }}
                     </span>
                   </div>
                   <div class="hfl-detail-row">
                     <span class="hfl-detail-row__label">{{ t('insight.kb.fieldStatusDetail') }}</span>
-                    <span class="hfl-detail-row__value hfl-detail-row__value--break" :class="detailValueClass(activeRow.status_detail)">
+                    <span
+                      class="hfl-detail-row__value hfl-detail-row__value--break"
+                      :class="detailValueClass(activeRow.status_detail)"
+                    >
                       {{ displayValue(activeRow.status_detail) }}
                     </span>
                   </div>
@@ -476,7 +569,10 @@ onUnmounted(() => {
             </div>
           </ElTabPane>
 
-          <ElTabPane :label="t('insight.kb.tabIngest')" name="retrieval">
+          <ElTabPane
+            :label="t('insight.kb.tabIngest')"
+            name="retrieval"
+          >
             <div class="hfl-detail-sections ks-kb-detail-sections">
               <section class="hfl-detail-section ks-kb-detail-card">
                 <h4 class="ks-kb-detail-card__title">
@@ -495,7 +591,10 @@ onUnmounted(() => {
                   <span class="ks-kb-detail-card__indicator" />
                   {{ t('insight.kb.retrieval.standaloneImagesTitle') }}
                 </h4>
-                <KnowledgeSourceRetrievalEnhancement v-model="ingestPolicy" section="images" />
+                <KnowledgeSourceRetrievalEnhancement
+                  v-model="ingestPolicy"
+                  section="images"
+                />
               </section>
 
               <section class="hfl-detail-section ks-kb-detail-card">
@@ -503,7 +602,10 @@ onUnmounted(() => {
                   <span class="ks-kb-detail-card__indicator" />
                   {{ t('insight.kb.retrieval.globalConversionLimitsTitle') }}
                 </h4>
-                <KnowledgeSourceRetrievalEnhancement v-model="ingestPolicy" section="limits" />
+                <KnowledgeSourceRetrievalEnhancement
+                  v-model="ingestPolicy"
+                  section="limits"
+                />
               </section>
             </div>
           </ElTabPane>
@@ -511,7 +613,10 @@ onUnmounted(() => {
       </template>
     </div>
 
-    <template v-if="activeRow && tab === 'retrieval'" #footer>
+    <template
+      v-if="activeRow && tab === 'retrieval'"
+      #footer
+    >
       <HflDetailDrawerFooter
         :saving="busy"
         :save-disabled="!hasIngestChanges"

--- a/src/frontend/src/pages/insight/InsightMcpServerDetailDrawer.vue
+++ b/src/frontend/src/pages/insight/InsightMcpServerDetailDrawer.vue
@@ -128,15 +128,23 @@ onUnmounted(() => {
       <span class="hfl-detail-drawer__title">{{ activeRow?.name || DETAIL_EMPTY }}</span>
     </template>
 
-    <div v-loading="loading" class="hfl-detail-drawer__body">
+    <div
+      v-loading="loading"
+      class="hfl-detail-drawer__body"
+    >
       <template v-if="activeRow">
         <div class="hfl-detail-sections">
           <section class="hfl-detail-section">
-            <h4 class="hfl-detail-section__title">{{ t('insight.mcpServers.detailSectionConnection') }}</h4>
+            <h4 class="hfl-detail-section__title">
+              {{ t('insight.mcpServers.detailSectionConnection') }}
+            </h4>
             <div class="hfl-detail-grid">
               <div class="hfl-detail-row">
                 <span class="hfl-detail-row__label">{{ t('insight.mcpServers.fieldName') }}</span>
-                <span class="hfl-detail-row__value" :class="detailValueClass(activeRow.name)">
+                <span
+                  class="hfl-detail-row__value"
+                  :class="detailValueClass(activeRow.name)"
+                >
                   {{ displayValue(activeRow.name) }}
                 </span>
               </div>
@@ -154,14 +162,21 @@ onUnmounted(() => {
               <div class="hfl-detail-row">
                 <span class="hfl-detail-row__label">{{ t('insight.mcpServers.fieldTransport') }}</span>
                 <span class="hfl-detail-row__value">
-                  <ElTag size="small" :type="transportTagType(activeRow.transport)" effect="plain">
+                  <ElTag
+                    size="small"
+                    :type="transportTagType(activeRow.transport)"
+                    effect="plain"
+                  >
                     {{ transportLabel(activeRow.transport) }}
                   </ElTag>
                 </span>
               </div>
               <div class="hfl-detail-row hfl-detail-row--full">
                 <span class="hfl-detail-row__label">{{ t('insight.mcpServers.fieldEndpoint') }}</span>
-                <span class="hfl-detail-row__value" :class="detailValueClass(activeRow.endpoint, true)">
+                <span
+                  class="hfl-detail-row__value"
+                  :class="detailValueClass(activeRow.endpoint, true)"
+                >
                   {{ displayValue(activeRow.endpoint) }}
                 </span>
               </div>
@@ -169,19 +184,27 @@ onUnmounted(() => {
           </section>
 
           <section class="hfl-detail-section">
-            <h4 class="hfl-detail-section__title">{{ t('insight.mcpServers.fieldConfig') }}</h4>
+            <h4 class="hfl-detail-section__title">
+              {{ t('insight.mcpServers.fieldConfig') }}
+            </h4>
             <div class="hfl-detail-grid">
               <div class="hfl-detail-row hfl-detail-row--full">
                 <span class="hfl-detail-row__label">{{ t('insight.mcpServers.colRuntimeSettings') }}</span>
                 <span class="hfl-detail-row__value hfl-detail-row__value--stacked">
-                  <div v-if="configEntries.length" class="create-filter-rules-preview">
+                  <div
+                    v-if="configEntries.length"
+                    class="create-filter-rules-preview"
+                  >
                     <code
                       v-for="entry in configEntries"
                       :key="entry.key"
                       class="create-filter-rules-preview__line"
                     >{{ entry.key }}={{ entry.value || DETAIL_EMPTY }}</code>
                   </div>
-                  <span v-else class="hfl-detail-row__empty">
+                  <span
+                    v-else
+                    class="hfl-detail-row__empty"
+                  >
                     {{ t('insight.mcpServers.runtimeSettingsNone') }}
                   </span>
                 </span>
@@ -192,7 +215,10 @@ onUnmounted(() => {
       </template>
     </div>
 
-    <template v-if="activeRow" #footer>
+    <template
+      v-if="activeRow"
+      #footer
+    >
       <HflDetailDrawerFooter
         :save-label="t('common.edit')"
         @cancel="drawerOpen = false"

--- a/src/frontend/src/pages/insight/InsightMcpServers.vue
+++ b/src/frontend/src/pages/insight/InsightMcpServers.vue
@@ -222,7 +222,11 @@ watch(
   <div class="hfl-list-shell hfl-list-shell--fill">
     <div class="hfl-list-panel hfl-list-panel--fill">
       <div class="hfl-list-toolbar">
-        <ElButton type="primary" :disabled="!bridgeReady" @click="openCreate">
+        <ElButton
+          type="primary"
+          :disabled="!bridgeReady"
+          @click="openCreate"
+        >
           <Plus :size="16" />
           {{ isPlatformEngine ? t('platformOps.engineActions.addMcpServer') : t('insight.mcpServers.btnAdd') }}
         </ElButton>
@@ -242,21 +246,40 @@ watch(
           </ElButton>
           <template #dropdown>
             <ElDropdownMenu>
-              <ElDropdownItem :disabled="batchDisabled || !singleSelected" @click="editSelected">
+              <ElDropdownItem
+                :disabled="batchDisabled || !singleSelected"
+                @click="editSelected"
+              >
                 <span class="el-dropdown-menu__item-content">
-                  <Pencil :size="14" class="shrink-0" />
+                  <Pencil
+                    :size="14"
+                    class="shrink-0"
+                  />
                   <span>{{ t('common.edit') }}</span>
                 </span>
               </ElDropdownItem>
-              <ElDropdownItem divided :disabled="batchDisabled || !singleSelected" @click="enableSelected">
+              <ElDropdownItem
+                divided
+                :disabled="batchDisabled || !singleSelected"
+                @click="enableSelected"
+              >
                 <span class="el-dropdown-menu__item-content">
-                  <CirclePlay :size="14" class="shrink-0" />
+                  <CirclePlay
+                    :size="14"
+                    class="shrink-0"
+                  />
                   <span>{{ t('insight.mcpServers.enable') }}</span>
                 </span>
               </ElDropdownItem>
-              <ElDropdownItem :disabled="batchDisabled || !singleSelected" @click="disableSelected">
+              <ElDropdownItem
+                :disabled="batchDisabled || !singleSelected"
+                @click="disableSelected"
+              >
                 <span class="el-dropdown-menu__item-content">
-                  <CircleStop :size="14" class="shrink-0" />
+                  <CircleStop
+                    :size="14"
+                    class="shrink-0"
+                  />
                   <span>{{ t('insight.mcpServers.disable') }}</span>
                 </span>
               </ElDropdownItem>
@@ -267,7 +290,10 @@ watch(
                 @click="deleteSelected"
               >
                 <span class="el-dropdown-menu__item-content">
-                  <Trash2 :size="14" class="shrink-0" />
+                  <Trash2
+                    :size="14"
+                    class="shrink-0"
+                  />
                   <span>{{ t('common.delete') }}</span>
                 </span>
               </ElDropdownItem>
@@ -285,7 +311,10 @@ watch(
             @clear="clearSearch"
           >
             <template #prefix>
-              <Search :size="16" class="hfl-list-search__icon" />
+              <Search
+                :size="16"
+                class="hfl-list-search__icon"
+              />
             </template>
           </ElInput>
           <div class="hfl-list-toolbar__utility">
@@ -295,13 +324,19 @@ watch(
               :disabled="loading"
               @click="load"
             >
-              <RefreshCw :size="16" :class="{ 'is-spinning': loading }" />
+              <RefreshCw
+                :size="16"
+                :class="{ 'is-spinning': loading }"
+              />
             </ElButton>
           </div>
         </div>
       </div>
 
-      <div ref="tableBlockRef" class="hfl-list-table-block">
+      <div
+        ref="tableBlockRef"
+        class="hfl-list-table-block"
+      >
         <el-table
           ref="tableRef"
           v-table-overflow-title
@@ -315,7 +350,11 @@ watch(
           @scroll="handleTableScroll"
           @selection-change="onSelectionChange"
         >
-          <el-table-column type="selection" width="35" fixed="left" />
+          <el-table-column
+            type="selection"
+            width="35"
+            fixed="left"
+          />
           <el-table-column
             :label="t('insight.mcpServers.colName')"
             min-width="200"
@@ -323,31 +362,53 @@ watch(
             class-name="hfl-table-name-col"
           >
             <template #default="{ row }">
-              <button type="button" class="hfl-table-name-link hfl-table-name-link--full" @click="openDetail(row)">
+              <button
+                type="button"
+                class="hfl-table-name-link hfl-table-name-link--full"
+                @click="openDetail(row)"
+              >
                 {{ row.name }}
               </button>
             </template>
           </el-table-column>
-          <el-table-column :label="t('insight.mcpServers.colTransport')" width="110">
+          <el-table-column
+            :label="t('insight.mcpServers.colTransport')"
+            width="110"
+          >
             <template #default="{ row }">
               <HflTypeLabel :label="transportLabel(row.transport)" />
             </template>
           </el-table-column>
-          <el-table-column :label="t('insight.mcpServers.colEndpoint')" min-width="240">
+          <el-table-column
+            :label="t('insight.mcpServers.colEndpoint')"
+            min-width="240"
+          >
             <template #default="{ row }">
-              <span class="insight-mcp-mono" :class="{ 'hfl-empty-mark': !row.endpoint }">{{ row.endpoint || '—' }}</span>
+              <span
+                class="insight-mcp-mono"
+                :class="{ 'hfl-empty-mark': !row.endpoint }"
+              >{{ row.endpoint || '—' }}</span>
             </template>
           </el-table-column>
-          <el-table-column :label="t('insight.mcpServers.colRuntimeSettings')" width="150">
+          <el-table-column
+            :label="t('insight.mcpServers.colRuntimeSettings')"
+            width="150"
+          >
             <template #default="{ row }">
               <span :class="runtimeSettingsCount(row) ? 'insight-mcp-runtime' : 'insight-mcp-muted'">
                 {{ runtimeSettingsLabel(row) }}
               </span>
             </template>
           </el-table-column>
-          <el-table-column :label="t('insight.mcpServers.colEnabled')" width="110">
+          <el-table-column
+            :label="t('insight.mcpServers.colEnabled')"
+            width="110"
+          >
             <template #default="{ row }">
-              <HflBooleanStatusTag :value="row.enabled" :label="statusLabel(row.enabled)" />
+              <HflBooleanStatusTag
+                :value="row.enabled"
+                :label="statusLabel(row.enabled)"
+              />
             </template>
           </el-table-column>
           <template #empty>

--- a/src/frontend/src/pages/insight/InsightSkillDetailDrawer.vue
+++ b/src/frontend/src/pages/insight/InsightSkillDetailDrawer.vue
@@ -121,15 +121,23 @@ onUnmounted(() => {
       <span class="hfl-detail-drawer__title">{{ activeRow?.name || DETAIL_EMPTY }}</span>
     </template>
 
-    <div v-loading="loading" class="hfl-detail-drawer__body">
+    <div
+      v-loading="loading"
+      class="hfl-detail-drawer__body"
+    >
       <template v-if="activeRow">
         <div class="hfl-detail-sections">
           <section class="hfl-detail-section">
-            <h4 class="hfl-detail-section__title">{{ t('insight.skills.detailSectionBasics') }}</h4>
+            <h4 class="hfl-detail-section__title">
+              {{ t('insight.skills.detailSectionBasics') }}
+            </h4>
             <div class="hfl-detail-grid">
               <div class="hfl-detail-row">
                 <span class="hfl-detail-row__label">{{ t('insight.skills.fieldName') }}</span>
-                <span class="hfl-detail-row__value" :class="detailValueClass(activeRow.name)">
+                <span
+                  class="hfl-detail-row__value"
+                  :class="detailValueClass(activeRow.name)"
+                >
                   {{ displayValue(activeRow.name) }}
                 </span>
               </div>
@@ -144,10 +152,17 @@ onUnmounted(() => {
                   />
                 </span>
               </div>
-              <div v-if="isWorkspaceGuideSkill(activeRow)" class="hfl-detail-row">
+              <div
+                v-if="isWorkspaceGuideSkill(activeRow)"
+                class="hfl-detail-row"
+              >
                 <span class="hfl-detail-row__label">{{ t('insight.skills.colType') }}</span>
                 <span class="hfl-detail-row__value">
-                  <ElTag size="small" type="primary" effect="plain">
+                  <ElTag
+                    size="small"
+                    type="primary"
+                    effect="plain"
+                  >
                     {{ t('insight.skills.typeWorkspaceGuide') }}
                   </ElTag>
                 </span>
@@ -165,15 +180,23 @@ onUnmounted(() => {
           </section>
 
           <section class="hfl-detail-section">
-            <h4 class="hfl-detail-section__title">{{ t('insight.skills.fieldContent') }}</h4>
+            <h4 class="hfl-detail-section__title">
+              {{ t('insight.skills.fieldContent') }}
+            </h4>
             <div class="hfl-detail-grid">
               <div class="hfl-detail-row hfl-detail-row--full">
                 <span class="hfl-detail-row__label">{{ t('insight.skills.colContent') }}</span>
                 <span class="hfl-detail-row__value hfl-detail-row__value--stacked">
-                  <div v-if="contentText !== DETAIL_EMPTY" class="create-filter-rules-preview">
+                  <div
+                    v-if="contentText !== DETAIL_EMPTY"
+                    class="create-filter-rules-preview"
+                  >
                     <pre class="create-filter-rules-preview__line">{{ contentText }}</pre>
                   </div>
-                  <span v-else class="hfl-detail-row__empty">{{ DETAIL_EMPTY }}</span>
+                  <span
+                    v-else
+                    class="hfl-detail-row__empty"
+                  >{{ DETAIL_EMPTY }}</span>
                 </span>
               </div>
             </div>
@@ -182,7 +205,10 @@ onUnmounted(() => {
       </template>
     </div>
 
-    <template v-if="activeRow" #footer>
+    <template
+      v-if="activeRow"
+      #footer
+    >
       <HflDetailDrawerFooter
         :save-label="t('common.edit')"
         @cancel="drawerOpen = false"

--- a/src/frontend/src/pages/insight/InsightSkills.vue
+++ b/src/frontend/src/pages/insight/InsightSkills.vue
@@ -209,7 +209,11 @@ watch(
   <div class="hfl-list-shell hfl-list-shell--fill">
     <div class="hfl-list-panel hfl-list-panel--fill">
       <div class="hfl-list-toolbar">
-        <ElButton type="primary" :disabled="!bridgeReady" @click="openCreate">
+        <ElButton
+          type="primary"
+          :disabled="!bridgeReady"
+          @click="openCreate"
+        >
           <Plus :size="16" />
           {{ isPlatformEngine ? t('platformOps.engineActions.addSkill') : t('insight.skills.btnAdd') }}
         </ElButton>
@@ -229,21 +233,40 @@ watch(
           </ElButton>
           <template #dropdown>
             <ElDropdownMenu>
-              <ElDropdownItem :disabled="batchDisabled || !singleSelected" @click="editSelected">
+              <ElDropdownItem
+                :disabled="batchDisabled || !singleSelected"
+                @click="editSelected"
+              >
                 <span class="el-dropdown-menu__item-content">
-                  <Pencil :size="14" class="shrink-0" />
+                  <Pencil
+                    :size="14"
+                    class="shrink-0"
+                  />
                   <span>{{ t('common.edit') }}</span>
                 </span>
               </ElDropdownItem>
-              <ElDropdownItem divided :disabled="batchDisabled || !singleSelected" @click="enableSelected">
+              <ElDropdownItem
+                divided
+                :disabled="batchDisabled || !singleSelected"
+                @click="enableSelected"
+              >
                 <span class="el-dropdown-menu__item-content">
-                  <CirclePlay :size="14" class="shrink-0" />
+                  <CirclePlay
+                    :size="14"
+                    class="shrink-0"
+                  />
                   <span>{{ t('insight.skills.enable') }}</span>
                 </span>
               </ElDropdownItem>
-              <ElDropdownItem :disabled="batchDisabled || !singleSelected" @click="disableSelected">
+              <ElDropdownItem
+                :disabled="batchDisabled || !singleSelected"
+                @click="disableSelected"
+              >
                 <span class="el-dropdown-menu__item-content">
-                  <CircleStop :size="14" class="shrink-0" />
+                  <CircleStop
+                    :size="14"
+                    class="shrink-0"
+                  />
                   <span>{{ t('insight.skills.disable') }}</span>
                 </span>
               </ElDropdownItem>
@@ -254,7 +277,10 @@ watch(
                 @click="deleteSelected"
               >
                 <span class="el-dropdown-menu__item-content">
-                  <Trash2 :size="14" class="shrink-0" />
+                  <Trash2
+                    :size="14"
+                    class="shrink-0"
+                  />
                   <span>{{ t('common.delete') }}</span>
                 </span>
               </ElDropdownItem>
@@ -272,7 +298,10 @@ watch(
             @clear="clearSearch"
           >
             <template #prefix>
-              <Search :size="16" class="hfl-list-search__icon" />
+              <Search
+                :size="16"
+                class="hfl-list-search__icon"
+              />
             </template>
           </ElInput>
           <div class="hfl-list-toolbar__utility">
@@ -282,13 +311,19 @@ watch(
               :disabled="loading"
               @click="load"
             >
-              <RefreshCw :size="16" :class="{ 'is-spinning': loading }" />
+              <RefreshCw
+                :size="16"
+                :class="{ 'is-spinning': loading }"
+              />
             </ElButton>
           </div>
         </div>
       </div>
 
-      <div ref="tableBlockRef" class="hfl-list-table-block">
+      <div
+        ref="tableBlockRef"
+        class="hfl-list-table-block"
+      >
         <el-table
           ref="tableRef"
           v-table-overflow-title
@@ -302,7 +337,11 @@ watch(
           @scroll="handleTableScroll"
           @selection-change="onSelectionChange"
         >
-          <el-table-column type="selection" width="35" fixed="left" />
+          <el-table-column
+            type="selection"
+            width="35"
+            fixed="left"
+          />
           <el-table-column
             :label="t('insight.skills.colName')"
             min-width="220"
@@ -310,15 +349,27 @@ watch(
             class-name="hfl-table-name-col"
           >
             <template #default="{ row }">
-              <button type="button" class="hfl-table-name-link hfl-table-name-link--full" @click="openDetail(row)">
+              <button
+                type="button"
+                class="hfl-table-name-link hfl-table-name-link--full"
+                @click="openDetail(row)"
+              >
                 <div class="insight-skills-identity">
                   <span class="insight-skills-identity__head">
                     <strong>{{ row.name }}</strong>
-                    <ElTag v-if="isWorkspaceGuideSkill(row)" size="small" type="primary" effect="plain">
+                    <ElTag
+                      v-if="isWorkspaceGuideSkill(row)"
+                      size="small"
+                      type="primary"
+                      effect="plain"
+                    >
                       {{ t('insight.skills.typeWorkspaceGuide') }}
                     </ElTag>
                   </span>
-                  <span v-if="skillDescription(row)" class="insight-skills-identity__meta">
+                  <span
+                    v-if="skillDescription(row)"
+                    class="insight-skills-identity__meta"
+                  >
                     {{ skillDescription(row) }}
                   </span>
                 </div>
@@ -330,15 +381,27 @@ watch(
             min-width="280"
           >
             <template #default="{ row }">
-              <span v-if="skillContentPreview(row)" class="insight-skills-content-preview">
+              <span
+                v-if="skillContentPreview(row)"
+                class="insight-skills-content-preview"
+              >
                 {{ skillContentPreview(row) }}
               </span>
-              <span v-else class="hfl-empty-mark">—</span>
+              <span
+                v-else
+                class="hfl-empty-mark"
+              >—</span>
             </template>
           </el-table-column>
-          <el-table-column :label="t('insight.skills.colEnabled')" width="110">
+          <el-table-column
+            :label="t('insight.skills.colEnabled')"
+            width="110"
+          >
             <template #default="{ row }">
-              <HflBooleanStatusTag :value="row.enabled" :label="statusLabel(row.enabled)" />
+              <HflBooleanStatusTag
+                :value="row.enabled"
+                :label="statusLabel(row.enabled)"
+              />
             </template>
           </el-table-column>
           <template #empty>

--- a/src/frontend/src/pages/insight/InsightUsage.vue
+++ b/src/frontend/src/pages/insight/InsightUsage.vue
@@ -314,20 +314,50 @@ onBeforeUnmount(() => {
 
 <template>
   <ModulePage :menus="insightMenus">
-    <div v-loading="loading && !usage" class="usage-page">
-      <section class="usage-period" aria-label="Usage period">
+    <div
+      v-loading="loading && !usage"
+      class="usage-page"
+    >
+      <section
+        class="usage-period"
+        aria-label="Usage period"
+      >
         <span class="usage-period__label">Date Range</span>
         <div class="usage-segments">
-          <button :class="{ active: periodPreset === 'today' }" type="button" @click="selectPreset('today')">Today</button>
-          <button :class="{ active: periodPreset === '7d' }" type="button" @click="selectPreset('7d')">Last 7 Days</button>
-          <button :class="{ active: periodPreset === '30d' }" type="button" @click="selectPreset('30d')">Last 30 Days</button>
-          <button :class="{ active: periodPreset === 'month' }" type="button" @click="selectPreset('month')">This Month</button>
+          <button
+            :class="{ active: periodPreset === 'today' }"
+            type="button"
+            @click="selectPreset('today')"
+          >
+            Today
+          </button>
+          <button
+            :class="{ active: periodPreset === '7d' }"
+            type="button"
+            @click="selectPreset('7d')"
+          >
+            Last 7 Days
+          </button>
+          <button
+            :class="{ active: periodPreset === '30d' }"
+            type="button"
+            @click="selectPreset('30d')"
+          >
+            Last 30 Days
+          </button>
+          <button
+            :class="{ active: periodPreset === 'month' }"
+            type="button"
+            @click="selectPreset('month')"
+          >
+            This Month
+          </button>
         </div>
         <div class="usage-period__tail">
           <ElDatePicker
+            :id="['usage-start-date', 'usage-end-date']"
             v-model="customRange"
             type="daterange"
-            :id="['usage-start-date', 'usage-end-date']"
             unlink-panels
             format="YYYY-MM-DD"
             value-format="YYYY-MM-DD"
@@ -339,9 +369,21 @@ onBeforeUnmount(() => {
             class="usage-date-picker"
             @change="applyCustomRange"
           />
-          <span v-if="usageFreshness" class="usage-freshness">{{ usageFreshness }}</span>
-          <button class="usage-icon-button" type="button" aria-label="Refresh usage" :disabled="loading" @click="loadUsage">
-            <RefreshCw :size="17" :class="{ 'is-spinning': loading }" />
+          <span
+            v-if="usageFreshness"
+            class="usage-freshness"
+          >{{ usageFreshness }}</span>
+          <button
+            class="usage-icon-button"
+            type="button"
+            aria-label="Refresh usage"
+            :disabled="loading"
+            @click="loadUsage"
+          >
+            <RefreshCw
+              :size="17"
+              :class="{ 'is-spinning': loading }"
+            />
           </button>
         </div>
       </section>
@@ -369,22 +411,53 @@ onBeforeUnmount(() => {
         <div class="usage-panel__head">
           <div><h2>Usage Trend</h2></div>
           <div class="usage-segments usage-segments--small">
-            <button :class="{ active: chartMetric === 'cost' }" type="button" @click="chartMetric = 'cost'">Cost</button>
-            <button :class="{ active: chartMetric === 'tokens' }" type="button" @click="chartMetric = 'tokens'">Tokens</button>
+            <button
+              :class="{ active: chartMetric === 'cost' }"
+              type="button"
+              @click="chartMetric = 'cost'"
+            >
+              Cost
+            </button>
+            <button
+              :class="{ active: chartMetric === 'tokens' }"
+              type="button"
+              @click="chartMetric = 'tokens'"
+            >
+              Tokens
+            </button>
           </div>
         </div>
-        <VChart v-if="usage?.trend.length" class="usage-chart" :option="chartOption" autoresize />
-        <div v-else class="usage-chart-empty"><ChartNoAxesCombined :size="25" /><span>No Usage for This Period</span></div>
+        <VChart
+          v-if="usage?.trend.length"
+          class="usage-chart"
+          :option="chartOption"
+          autoresize
+        />
+        <div
+          v-else
+          class="usage-chart-empty"
+        >
+          <ChartNoAxesCombined :size="25" /><span>No Usage for This Period</span>
+        </div>
       </section>
 
       <div class="usage-breakdown-grid">
         <section class="usage-panel">
-          <div class="usage-panel__head"><div><h2>Token Usage</h2></div></div>
+          <div class="usage-panel__head">
+            <div><h2>Token Usage</h2></div>
+          </div>
           <div class="token-breakdown">
-            <div v-for="row in tokenBreakdown" :key="row.label" class="token-breakdown__row" :class="{ 'is-detail': row.percent == null }">
+            <div
+              v-for="row in tokenBreakdown"
+              :key="row.label"
+              class="token-breakdown__row"
+              :class="{ 'is-detail': row.percent == null }"
+            >
               <div><span>{{ row.label }}</span><strong>{{ formatCompact(row.value) }}</strong></div>
               <template v-if="row.percent != null">
-                <div class="token-breakdown__track"><i :style="{ width: `${row.percent}%`, background: row.color }" /></div>
+                <div class="token-breakdown__track">
+                  <i :style="{ width: `${row.percent}%`, background: row.color }" />
+                </div>
                 <small>{{ row.percent.toFixed(1) }}%</small>
               </template>
             </div>
@@ -392,13 +465,18 @@ onBeforeUnmount(() => {
         </section>
 
         <section class="usage-panel">
-          <div class="usage-panel__head"><div><h2>Usage by Backup Source</h2></div></div>
+          <div class="usage-panel__head">
+            <div><h2>Usage by Backup Source</h2></div>
+          </div>
           <ElTable
             :data="usage?.by_backup_source || []"
             class="hfl-list-table usage-source-table"
             @row-click="filterByBackupSource"
           >
-            <ElTableColumn label="Backup Source" min-width="240">
+            <ElTableColumn
+              label="Backup Source"
+              min-width="240"
+            >
               <template #default="{ row }">
                 <div class="source-usage-list__identity">
                   <span class="source-usage-list__icon"><DatabaseBackup :size="16" /></span>
@@ -406,17 +484,41 @@ onBeforeUnmount(() => {
                 </div>
               </template>
             </ElTableColumn>
-            <ElTableColumn label="Questions" width="110" align="right">
-              <template #default="{ row }">{{ formatNumber(row.q_and_a_requests) }}</template>
+            <ElTableColumn
+              label="Questions"
+              width="110"
+              align="right"
+            >
+              <template #default="{ row }">
+                {{ formatNumber(row.q_and_a_requests) }}
+              </template>
             </ElTableColumn>
-            <ElTableColumn label="AI Calls" width="110" align="right">
-              <template #default="{ row }">{{ formatNumber(row.model_calls) }}</template>
+            <ElTableColumn
+              label="AI Calls"
+              width="110"
+              align="right"
+            >
+              <template #default="{ row }">
+                {{ formatNumber(row.model_calls) }}
+              </template>
             </ElTableColumn>
-            <ElTableColumn label="Total Tokens" width="120" align="right">
-              <template #default="{ row }">{{ formatCompact(row.total_tokens) }}</template>
+            <ElTableColumn
+              label="Total Tokens"
+              width="120"
+              align="right"
+            >
+              <template #default="{ row }">
+                {{ formatCompact(row.total_tokens) }}
+              </template>
             </ElTableColumn>
-            <ElTableColumn label="Cost" width="130" align="right">
-              <template #default="{ row }"><strong>{{ formatCost(row.estimated_cost) }}</strong></template>
+            <ElTableColumn
+              label="Cost"
+              width="130"
+              align="right"
+            >
+              <template #default="{ row }">
+                <strong>{{ formatCost(row.estimated_cost) }}</strong>
+              </template>
             </ElTableColumn>
             <template #empty>
               <ElEmpty description="No Backup Source Usage for This Period" />
@@ -443,13 +545,37 @@ onBeforeUnmount(() => {
                 placeholder="Search Chats or Questions..."
               >
             </div>
-            <ElSelect v-model="backupSourceFilter" clearable placeholder="All Backup Sources" class="usage-filter-select">
-              <ElOption v-for="name in usage?.backup_sources || []" :key="name" :label="name" :value="name" />
+            <ElSelect
+              v-model="backupSourceFilter"
+              clearable
+              placeholder="All Backup Sources"
+              class="usage-filter-select"
+            >
+              <ElOption
+                v-for="name in usage?.backup_sources || []"
+                :key="name"
+                :label="name"
+                :value="name"
+              />
             </ElSelect>
-            <ElSelect v-model="statusFilter" clearable placeholder="All Statuses" class="usage-filter-select usage-filter-select--status">
-              <ElOption label="Completed" value="done" />
-              <ElOption label="Failed" value="failed" />
-              <ElOption label="Cancelled" value="cancelled" />
+            <ElSelect
+              v-model="statusFilter"
+              clearable
+              placeholder="All Statuses"
+              class="usage-filter-select usage-filter-select--status"
+            >
+              <ElOption
+                label="Completed"
+                value="done"
+              />
+              <ElOption
+                label="Failed"
+                value="failed"
+              />
+              <ElOption
+                label="Cancelled"
+                value="cancelled"
+              />
             </ElSelect>
           </div>
         </div>
@@ -462,16 +588,35 @@ onBeforeUnmount(() => {
           class="hfl-list-table usage-history-table"
           row-key="run_uuid"
         >
-          <ElTableColumn label="Question" min-width="280" fixed="left">
+          <ElTableColumn
+            label="Question"
+            min-width="280"
+            fixed="left"
+          >
             <template #default="{ row }">
               <span class="usage-history-question">{{ row.question || 'Question Unavailable' }}</span>
             </template>
           </ElTableColumn>
-          <ElTableColumn label="Time" width="150">
-            <template #default="{ row }"><span class="usage-table__time" :class="{ 'hfl-empty-mark': !row.time }">{{ formatShortDateTime(row.time) }}</span></template>
+          <ElTableColumn
+            label="Time"
+            width="150"
+          >
+            <template #default="{ row }">
+              <span
+                class="usage-table__time"
+                :class="{ 'hfl-empty-mark': !row.time }"
+              >{{ formatShortDateTime(row.time) }}</span>
+            </template>
           </ElTableColumn>
-          <ElTableColumn label="Chat" min-width="180" prop="chat_title" />
-          <ElTableColumn label="Backup Source" min-width="220">
+          <ElTableColumn
+            label="Chat"
+            min-width="180"
+            prop="chat_title"
+          />
+          <ElTableColumn
+            label="Backup Source"
+            min-width="220"
+          >
             <template #default="{ row }">
               <div class="usage-history-source">
                 <strong>{{ row.backup_source_name }}</strong>
@@ -479,24 +624,53 @@ onBeforeUnmount(() => {
               </div>
             </template>
           </ElTableColumn>
-          <ElTableColumn label="AI Calls" width="100" align="right">
-            <template #default="{ row }">{{ formatNumber(row.model_calls) }}</template>
+          <ElTableColumn
+            label="AI Calls"
+            width="100"
+            align="right"
+          >
+            <template #default="{ row }">
+              {{ formatNumber(row.model_calls) }}
+            </template>
           </ElTableColumn>
-          <ElTableColumn label="Total Tokens" width="120" align="right">
-            <template #default="{ row }">{{ formatCompact(row.total_tokens) }}</template>
+          <ElTableColumn
+            label="Total Tokens"
+            width="120"
+            align="right"
+          >
+            <template #default="{ row }">
+              {{ formatCompact(row.total_tokens) }}
+            </template>
           </ElTableColumn>
-          <ElTableColumn label="Cost" width="120" align="right">
-            <template #default="{ row }">{{ formatCost(row.estimated_cost, row.cost_currency) }}</template>
+          <ElTableColumn
+            label="Cost"
+            width="120"
+            align="right"
+          >
+            <template #default="{ row }">
+              {{ formatCost(row.estimated_cost, row.cost_currency) }}
+            </template>
           </ElTableColumn>
-          <ElTableColumn label="Status" width="110">
-            <template #default="{ row }"><span class="usage-status" :class="`is-${row.status}`"><i />{{ statusLabel(row.status) }}</span></template>
+          <ElTableColumn
+            label="Status"
+            width="110"
+          >
+            <template #default="{ row }">
+              <span
+                class="usage-status"
+                :class="`is-${row.status}`"
+              ><i />{{ statusLabel(row.status) }}</span>
+            </template>
           </ElTableColumn>
           <template #empty>
             <ElEmpty :description="questionHistoryEmptyDescription" />
           </template>
         </ElTable>
 
-        <div v-if="usage && usage.total > 0" class="hfl-list-footer usage-history-footer">
+        <div
+          v-if="usage && usage.total > 0"
+          class="hfl-list-footer usage-history-footer"
+        >
           <HflPagination
             v-model:current-page="page"
             v-model:page-size="pageSize"

--- a/src/frontend/src/pages/insight/KnowledgeSourceFormPage.vue
+++ b/src/frontend/src/pages/insight/KnowledgeSourceFormPage.vue
@@ -160,16 +160,30 @@ onMounted(() => {
   <div class="fullscreen-form-fullscreen resource-add-fullscreen ks-form-fullscreen">
     <div class="fullscreen-form-page">
       <header class="fullscreen-form-header">
-        <button type="button" class="fullscreen-form-header__back" @click="handleBack">
-          <ArrowLeft class="fullscreen-form-header__back-icon" :size="18" />
+        <button
+          type="button"
+          class="fullscreen-form-header__back"
+          @click="handleBack"
+        >
+          <ArrowLeft
+            class="fullscreen-form-header__back-icon"
+            :size="18"
+          />
         </button>
         <div class="fullscreen-form-header__content">
-          <h1 class="fullscreen-form-header__title">{{ pageTitle }}</h1>
-          <p class="fullscreen-form-header__desc">{{ pageDesc }}</p>
+          <h1 class="fullscreen-form-header__title">
+            {{ pageTitle }}
+          </h1>
+          <p class="fullscreen-form-header__desc">
+            {{ pageDesc }}
+          </p>
         </div>
       </header>
 
-      <div v-loading="loading" class="fullscreen-form-layout">
+      <div
+        v-loading="loading"
+        class="fullscreen-form-layout"
+      >
         <div class="fullscreen-form-main">
           <div class="fullscreen-form-step-stack">
             <section class="fullscreen-form-card fullscreen-form-section">
@@ -177,16 +191,27 @@ onMounted(() => {
                 <span class="fullscreen-form-section__indicator" />
                 {{ t('insight.kb.sectionBasicInfo') }}
               </h3>
-              <ElForm label-position="top" class="fullscreen-form-el-form">
-                <ElFormItem :label="t('insight.kb.fieldName')" required>
+              <ElForm
+                label-position="top"
+                class="fullscreen-form-el-form"
+              >
+                <ElFormItem
+                  :label="t('insight.kb.fieldName')"
+                  required
+                >
                   <ElInput
                     v-model="name"
                     maxlength="160"
                     :placeholder="t('insight.kb.fieldNamePlaceholder')"
                   />
-                  <p class="ks-field-hint">{{ t('insight.kb.fieldNameHint') }}</p>
+                  <p class="ks-field-hint">
+                    {{ t('insight.kb.fieldNameHint') }}
+                  </p>
                 </ElFormItem>
-                <ElFormItem :label="t('insight.kb.fieldSourceType')" required>
+                <ElFormItem
+                  :label="t('insight.kb.fieldSourceType')"
+                  required
+                >
                   <ElSelect
                     v-model="sourceType"
                     fit-input-width
@@ -207,176 +232,225 @@ onMounted(() => {
                       {{ t('insight.kb.sourceTypeGatewayLocalOption') }}
                     </ElOption>
                   </ElSelect>
-                  <p class="ks-field-hint">{{ t('insight.kb.fieldSourceTypeHint') }}</p>
+                  <p class="ks-field-hint">
+                    {{ t('insight.kb.fieldSourceTypeHint') }}
+                  </p>
                 </ElFormItem>
               </ElForm>
             </section>
 
-            <section v-if="isGatewayLocal" class="fullscreen-form-card fullscreen-form-section">
+            <section
+              v-if="isGatewayLocal"
+              class="fullscreen-form-card fullscreen-form-section"
+            >
               <h3 class="fullscreen-form-section__title">
                 <span class="fullscreen-form-section__indicator" />
                 {{ t('insight.kb.sourceTypeGatewayLocal') }}
               </h3>
-              <p v-if="isEditing" class="ks-field-hint ks-section-desc">
+              <p
+                v-if="isEditing"
+                class="ks-field-hint ks-section-desc"
+              >
                 {{ t('insight.kb.fieldSourceBindingReadonlyHint') }}
               </p>
-              <ElForm label-position="top" class="fullscreen-form-el-form">
-                <ElFormItem :label="t('insight.kb.colGateway')" required>
-                    <p
-                      v-if="!isEditing && offlineGatewayCount > 0"
-                      class="ks-field-hint ks-field-hint--spaced"
-                    >
-                      {{ t('insight.kb.gatewayOnlineOnlyNote', { n: offlineGatewayCount }) }}
-                    </p>
-                    <div class="ks-gateway-select-row">
-                      <div class="ks-gateway-select-row__controls">
-                        <ElSelect
-                          v-model="gatewayId"
-                          class="ks-gateway-select-row__select"
-                          filterable
-                          fit-input-width
-                          :loading="gatewaysRefreshing"
-                          :disabled="isEditing || onlineGateways.length === 0"
-                          popper-class="ks-gateway-select-popper"
-                          :placeholder="t('insight.kb.colGateway')"
+              <ElForm
+                label-position="top"
+                class="fullscreen-form-el-form"
+              >
+                <ElFormItem
+                  :label="t('insight.kb.colGateway')"
+                  required
+                >
+                  <p
+                    v-if="!isEditing && offlineGatewayCount > 0"
+                    class="ks-field-hint ks-field-hint--spaced"
+                  >
+                    {{ t('insight.kb.gatewayOnlineOnlyNote', { n: offlineGatewayCount }) }}
+                  </p>
+                  <div class="ks-gateway-select-row">
+                    <div class="ks-gateway-select-row__controls">
+                      <ElSelect
+                        v-model="gatewayId"
+                        class="ks-gateway-select-row__select"
+                        filterable
+                        fit-input-width
+                        :loading="gatewaysRefreshing"
+                        :disabled="isEditing || onlineGateways.length === 0"
+                        popper-class="ks-gateway-select-popper"
+                        :placeholder="t('insight.kb.colGateway')"
+                      >
+                        <ElOption
+                          v-for="row in gatewaysForPicker"
+                          :key="row.id"
+                          :label="gatewaySelectLine(row)"
+                          :value="row.id"
                         >
-                          <ElOption
-                            v-for="row in gatewaysForPicker"
-                            :key="row.id"
-                            :label="gatewaySelectLine(row)"
-                            :value="row.id"
-                          >
-                            <div class="ks-gateway-option">
-                              <span class="ks-gateway-option__name">{{ gatewaySelectLine(row) }}</span>
-                              <span class="ks-gateway-option__tags">
-                                <ElTag size="small" type="success" effect="plain">
-                                  {{ t('protection.sourceResources.nodeStatusOnline') }}
-                                </ElTag>
-                                <ElTag size="small" :type="gatewayAiTagType(row)" effect="plain">
-                                  {{ gatewayAiLabel(row) }}
-                                </ElTag>
-                              </span>
-                            </div>
-                          </ElOption>
-                        </ElSelect>
-                        <ElButton
-                          v-if="!isEditing"
-                          class="hfl-refresh-button ks-gateway-select-row__refresh"
-                          :title="t('insight.kb.gatewayRefresh')"
-                          :aria-label="t('insight.kb.gatewayRefresh')"
-                          :disabled="gatewaysRefreshing"
-                          @click="refreshGateways"
-                        >
-                          <RefreshCw :size="16" :class="{ 'is-spinning': gatewaysRefreshing }" />
-                        </ElButton>
-                        <ElButton
-                          v-if="!isEditing"
-                          class="fullscreen-form-icon-btn ks-gateway-select-row__deploy"
-                          :title="t('nodesPage.deployGateway')"
-                          :aria-label="t('nodesPage.deployGateway')"
-                          @click="openGatewayDeploy"
-                        >
-                          <Plus :size="14" />
-                        </ElButton>
-                      </div>
+                          <div class="ks-gateway-option">
+                            <span class="ks-gateway-option__name">{{ gatewaySelectLine(row) }}</span>
+                            <span class="ks-gateway-option__tags">
+                              <ElTag
+                                size="small"
+                                type="success"
+                                effect="plain"
+                              >
+                                {{ t('protection.sourceResources.nodeStatusOnline') }}
+                              </ElTag>
+                              <ElTag
+                                size="small"
+                                :type="gatewayAiTagType(row)"
+                                effect="plain"
+                              >
+                                {{ gatewayAiLabel(row) }}
+                              </ElTag>
+                            </span>
+                          </div>
+                        </ElOption>
+                      </ElSelect>
+                      <ElButton
+                        v-if="!isEditing"
+                        class="hfl-refresh-button ks-gateway-select-row__refresh"
+                        :title="t('insight.kb.gatewayRefresh')"
+                        :aria-label="t('insight.kb.gatewayRefresh')"
+                        :disabled="gatewaysRefreshing"
+                        @click="refreshGateways"
+                      >
+                        <RefreshCw
+                          :size="16"
+                          :class="{ 'is-spinning': gatewaysRefreshing }"
+                        />
+                      </ElButton>
+                      <ElButton
+                        v-if="!isEditing"
+                        class="fullscreen-form-icon-btn ks-gateway-select-row__deploy"
+                        :title="t('nodesPage.deployGateway')"
+                        :aria-label="t('nodesPage.deployGateway')"
+                        @click="openGatewayDeploy"
+                      >
+                        <Plus :size="14" />
+                      </ElButton>
                     </div>
-                    <p
-                      v-if="!isEditing && !gatewaysRefreshing && onlineGateways.length === 0"
-                      class="ks-field-hint ks-field-hint--warn"
-                    >
-                      {{ t('insight.kb.gatewayNoOnline') }}
-                    </p>
-                    <p
-                      v-else-if="!isEditing && onlineGateways.length > 0"
-                      class="ks-field-hint"
-                    >
-                      {{ t('insight.kb.fieldGatewayLocalGatewayHint') }}
-                    </p>
-                  </ElFormItem>
+                  </div>
+                  <p
+                    v-if="!isEditing && !gatewaysRefreshing && onlineGateways.length === 0"
+                    class="ks-field-hint ks-field-hint--warn"
+                  >
+                    {{ t('insight.kb.gatewayNoOnline') }}
+                  </p>
+                  <p
+                    v-else-if="!isEditing && onlineGateways.length > 0"
+                    class="ks-field-hint"
+                  >
+                    {{ t('insight.kb.fieldGatewayLocalGatewayHint') }}
+                  </p>
+                </ElFormItem>
 
-                  <ElFormItem :label="t('insight.kb.wizardStepPath')" required>
-                    <HflPopover
-                      :visible="!isEditing && gatewayDirPickerOpen"
-                      trigger="click"
-                      placement="bottom-start"
-                      :width="gatewayDirPickerWidth"
-                      popper-class="ks-gateway-dir-popover"
-                      @update:visible="(open) => !isEditing && setGatewayDirPickerOpen(open)"
-                    >
-                      <template #reference>
-                        <div ref="gatewayDirInputRef" class="ks-dir-path-input">
-                          <ElInput
-                            :model-value="gatewaySelectedPath"
-                            :placeholder="t('insight.kb.phSelectOrEnterGatewayDirectory')"
-                            :disabled="isEditing || !gatewayId"
-                            @update:model-value="updateGatewayDirectoryInput"
-                            @blur="validateGatewayDirectoryPath(false)"
-                          >
-                            <template #prefix>
-                              <TextCursorInput :size="14" class="ks-dir-path-input__type-icon" />
-                            </template>
-                            <template #append>
-                              <ElTooltip :content="t('insight.kb.btnBrowseDirectory')" placement="top">
-                                <ElButton
-                                  class="ks-dir-path-input__btn"
-                                  :disabled="isEditing || !gatewayId"
-                                  @click.stop="setGatewayDirPickerOpen(!gatewayDirPickerOpen)"
-                                >
-                                  <FolderOpen :size="16" />
-                                </ElButton>
-                              </ElTooltip>
-                            </template>
-                          </ElInput>
-                        </div>
-                      </template>
-                      <div class="ks-gateway-dir-tree hfl-dir-tree-shell">
-                        <el-tree
-                          :key="`ks-gateway-dir-${gatewayId}-${gatewayDirTreeRevision}`"
-                          v-loading="gatewayBrowseLoading"
-                          class="hfl-dir-tree hfl-dir-tree--tall"
-                          node-key="path"
-                          lazy
-                          :expand-on-click-node="false"
-                          :load="loadGatewayDirTreeNode"
-                          :props="{ label: 'label', children: 'children', isLeaf: 'isLeaf' }"
-                          :current-node-key="gatewaySelectedPath"
-                          highlight-current
-                          @node-click="handleGatewayDirNodeClick"
+                <ElFormItem
+                  :label="t('insight.kb.wizardStepPath')"
+                  required
+                >
+                  <HflPopover
+                    :visible="!isEditing && gatewayDirPickerOpen"
+                    trigger="click"
+                    placement="bottom-start"
+                    :width="gatewayDirPickerWidth"
+                    popper-class="ks-gateway-dir-popover"
+                    @update:visible="(open) => !isEditing && setGatewayDirPickerOpen(open)"
+                  >
+                    <template #reference>
+                      <div
+                        ref="gatewayDirInputRef"
+                        class="ks-dir-path-input"
+                      >
+                        <ElInput
+                          :model-value="gatewaySelectedPath"
+                          :placeholder="t('insight.kb.phSelectOrEnterGatewayDirectory')"
+                          :disabled="isEditing || !gatewayId"
+                          @update:model-value="updateGatewayDirectoryInput"
+                          @blur="validateGatewayDirectoryPath(false)"
                         >
-                          <template #default="{ data }">
-                            <div class="hfl-dir-tree-node">
-                              <FolderOpen :size="15" class="hfl-dir-tree-node__icon" />
-                              <div class="hfl-dir-tree-node__text">
-                                <span class="hfl-dir-tree-node__label">{{ data.label }}</span>
-                                <span class="hfl-dir-tree-node__path">{{ data.path }}</span>
-                              </div>
-                            </div>
+                          <template #prefix>
+                            <TextCursorInput
+                              :size="14"
+                              class="ks-dir-path-input__type-icon"
+                            />
                           </template>
-                        </el-tree>
+                          <template #append>
+                            <ElTooltip
+                              :content="t('insight.kb.btnBrowseDirectory')"
+                              placement="top"
+                            >
+                              <ElButton
+                                class="ks-dir-path-input__btn"
+                                :disabled="isEditing || !gatewayId"
+                                @click.stop="setGatewayDirPickerOpen(!gatewayDirPickerOpen)"
+                              >
+                                <FolderOpen :size="16" />
+                              </ElButton>
+                            </ElTooltip>
+                          </template>
+                        </ElInput>
                       </div>
-                    </HflPopover>
-                    <p
-                      v-if="gatewayBrowseRoot && gatewaySelectedPath.trim() && !gatewayDirectoryValid"
-                      class="ks-field-hint ks-field-hint--warn"
-                    >
-                      {{ t('insight.kb.gatewayDirectoryOutOfWorkspace', { root: gatewayBrowseRoot }) }}
-                    </p>
-                    <p class="ks-field-hint">
-                      {{ t('insight.kb.fieldGatewayLocalDirectoryHint') }}
-                    </p>
-                  </ElFormItem>
-                </ElForm>
-              </section>
+                    </template>
+                    <div class="ks-gateway-dir-tree hfl-dir-tree-shell">
+                      <el-tree
+                        :key="`ks-gateway-dir-${gatewayId}-${gatewayDirTreeRevision}`"
+                        v-loading="gatewayBrowseLoading"
+                        class="hfl-dir-tree hfl-dir-tree--tall"
+                        node-key="path"
+                        lazy
+                        :expand-on-click-node="false"
+                        :load="loadGatewayDirTreeNode"
+                        :props="{ label: 'label', children: 'children', isLeaf: 'isLeaf' }"
+                        :current-node-key="gatewaySelectedPath"
+                        highlight-current
+                        @node-click="handleGatewayDirNodeClick"
+                      >
+                        <template #default="{ data }">
+                          <div class="hfl-dir-tree-node">
+                            <FolderOpen
+                              :size="15"
+                              class="hfl-dir-tree-node__icon"
+                            />
+                            <div class="hfl-dir-tree-node__text">
+                              <span class="hfl-dir-tree-node__label">{{ data.label }}</span>
+                              <span class="hfl-dir-tree-node__path">{{ data.path }}</span>
+                            </div>
+                          </div>
+                        </template>
+                      </el-tree>
+                    </div>
+                  </HflPopover>
+                  <p
+                    v-if="gatewayBrowseRoot && gatewaySelectedPath.trim() && !gatewayDirectoryValid"
+                    class="ks-field-hint ks-field-hint--warn"
+                  >
+                    {{ t('insight.kb.gatewayDirectoryOutOfWorkspace', { root: gatewayBrowseRoot }) }}
+                  </p>
+                  <p class="ks-field-hint">
+                    {{ t('insight.kb.fieldGatewayLocalDirectoryHint') }}
+                  </p>
+                </ElFormItem>
+              </ElForm>
+            </section>
 
-            <section v-if="isBackupSource" class="fullscreen-form-card fullscreen-form-section">
+            <section
+              v-if="isBackupSource"
+              class="fullscreen-form-card fullscreen-form-section"
+            >
               <h3 class="fullscreen-form-section__title">
                 <span class="fullscreen-form-section__indicator" />
                 {{ t('insight.kb.sourceTypeBackup') }}
               </h3>
-              <p v-if="isEditing" class="ks-field-hint ks-section-desc">
+              <p
+                v-if="isEditing"
+                class="ks-field-hint ks-section-desc"
+              >
                 {{ t('insight.kb.fieldSourceBindingReadonlyHint') }}
               </p>
-              <ElForm label-position="top" class="fullscreen-form-el-form">
+              <ElForm
+                label-position="top"
+                class="fullscreen-form-el-form"
+              >
                 <div class="ks-backup-form-row">
                   <ElFormItem
                     class="ks-backup-form-row__item"
@@ -394,12 +468,12 @@ onMounted(() => {
                           :loading="snapshotLoading"
                           :disabled="isEditing || (!snapshotLoading && backupSourceOptions.length === 0)"
                         >
-                            <ElOption
-                              v-for="row in backupSourceOptions"
-                              :key="row.backupConfigId"
-                              :label="row.label"
-                              :value="row.backupConfigId"
-                            />
+                          <ElOption
+                            v-for="row in backupSourceOptions"
+                            :key="row.backupConfigId"
+                            :label="row.label"
+                            :value="row.backupConfigId"
+                          />
                         </ElSelect>
                         <ElButton
                           v-if="!isEditing"
@@ -409,7 +483,10 @@ onMounted(() => {
                           :disabled="snapshotLoading"
                           @click="loadSnapshots"
                         >
-                          <RefreshCw :size="16" :class="{ 'is-spinning': snapshotLoading }" />
+                          <RefreshCw
+                            :size="16"
+                            :class="{ 'is-spinning': snapshotLoading }"
+                          />
                         </ElButton>
                       </div>
                     </div>
@@ -419,7 +496,12 @@ onMounted(() => {
                     >
                       {{ t('insight.kb.backupSourceNoAvailable') }}
                     </p>
-                    <p v-else class="ks-field-hint">{{ t('insight.kb.fieldBackupSourceHint') }}</p>
+                    <p
+                      v-else
+                      class="ks-field-hint"
+                    >
+                      {{ t('insight.kb.fieldBackupSourceHint') }}
+                    </p>
                   </ElFormItem>
 
                   <ElFormItem
@@ -435,257 +517,313 @@ onMounted(() => {
                       :placeholder="t('insight.kb.phSelectSnapshot')"
                       :disabled="isEditing || !selectedBackupConfigId"
                     >
-                        <ElOption
-                          :label="t('insight.kb.snapshotLatestOption')"
-                          :value="SNAPSHOT_PICKER_LATEST"
-                        />
-                        <ElOption
-                          v-for="row in snapshotsForSelectedBackupSource"
-                          :key="row.id"
-                          :label="snapshotOptionLabel(row)"
-                          :value="row.id"
-                        />
-                      </ElSelect>
-                      <p
-                        v-if="!selectedBackupConfigId"
-                        class="ks-field-hint"
-                      >
-                        {{ t('insight.kb.snapshotPickBackupFirst') }}
-                      </p>
-                      <p v-else class="ks-field-hint">{{ t('insight.kb.fieldSnapshotHint') }}</p>
-                    </ElFormItem>
-                  </div>
-
-                  <ElFormItem required class="ks-index-scope-form-item">
-                    <div class="ks-index-scope-stack" :class="{ 'ks-index-scope-stack--readonly': isEditing }">
-                      <div class="ks-index-scope-stack__header" aria-hidden="true">
-                        <span />
-                        <span class="ks-index-scope-stack__label">
-                          {{ t('insight.kb.fieldRestoreScope') }}
-                          <span class="ks-index-scope-stack__required">*</span>
-                        </span>
-                        <span v-if="!isEditing">{{ t('protection.backupsPage.colActions') }}</span>
-                      </div>
-                      <div
-                        v-for="(scopeEntry, scopeIndex) in backupScopeEntries"
-                        :key="scopeEntry.id"
-                        class="ks-index-scope-row"
-                      >
-                        <span class="ks-index-scope-row__index">
-                          {{ String(scopeIndex + 1).padStart(2, '0') }}
-                        </span>
-                        <div class="ks-index-scope-row__field">
-                          <HflPopover
-                            :visible="!isEditing && isBackupScopePickerOpen(scopeEntry.id)"
-                            trigger="click"
-                            placement="bottom-start"
-                            :width="backupScopePickerWidth"
-                            popper-class="ks-backup-scope-popover"
-                            @update:visible="(open) => !isEditing && setBackupScopePickerOpen(scopeEntry.id, open)"
-                          >
-                            <template #reference>
-                              <div class="ks-backup-scope-input">
-                                <ElInput
-                                  :model-value="scopeEntry.path"
-                                  :clearable="!isEditing"
-                                  :placeholder="t('insight.kb.phSelectOrEnterRestoreScope')"
-                                  :disabled="isEditing || !effectiveSnapshotId || snapshotDirectories.length === 0"
-                                  @update:model-value="updateBackupScopeEntryInput(scopeEntry.id, $event)"
-                                  @blur="validateBackupScopeEntryOnBlur(scopeEntry.id)"
-                                  @keydown.enter.prevent="validateBackupScopeEntry(scopeEntry.id)"
-                                >
-                                  <template #prefix>
-                                    <TextCursorInput :size="14" class="ks-backup-scope-input__type-icon" />
-                                  </template>
-                                  <template #append>
-                                    <ElTooltip :content="t('insight.kb.btnBrowseRestoreScope')" placement="top">
-                                      <ElButton
-                                        class="ks-backup-scope-input__btn"
-                                        :disabled="isEditing || !effectiveSnapshotId || snapshotDirectories.length === 0"
-                                        @click.stop="setBackupScopePickerOpen(scopeEntry.id, !isBackupScopePickerOpen(scopeEntry.id))"
-                                      >
-                                        <FolderOpen :size="16" />
-                                      </ElButton>
-                                    </ElTooltip>
-                                  </template>
-                                </ElInput>
-                              </div>
-                            </template>
-                            <div class="ks-backup-scope-tree hfl-dir-tree-shell">
-                              <el-tree
-                                :key="`ks-backup-scope-${scopeEntry.id}-${effectiveSnapshotId}-${backupScopeTreeRevision}`"
-                                v-loading="backupScopeBrowseLoading"
-                                class="hfl-dir-tree hfl-dir-tree--tall"
-                                node-key="id"
-                                lazy
-                                highlight-current
-                                :expand-on-click-node="false"
-                                :load="loadBackupScopePickerNode"
-                                :props="{ label: 'label', children: 'children', isLeaf: 'isLeaf' }"
-                                :current-node-key="scopeEntry.path"
-                                @node-click="(data) => handleBackupScopeNodeClick(scopeEntry.id, data)"
-                              >
-                                <template #default="{ data }">
-                                  <div class="hfl-dir-tree-node">
-                                    <FolderOpen
-                                      v-if="data.type === 'dir'"
-                                      :size="15"
-                                      class="hfl-dir-tree-node__icon hfl-dir-tree-node__icon--dir"
-                                    />
-                                    <File
-                                      v-else
-                                      :size="15"
-                                      class="hfl-dir-tree-node__icon hfl-dir-tree-node__icon--file"
-                                    />
-                                    <div class="hfl-dir-tree-node__text">
-                                      <span class="hfl-dir-tree-node__label">{{ data.label }}</span>
-                                      <span v-if="data.path" class="hfl-dir-tree-node__path">{{ data.path }}</span>
-                                    </div>
-                                  </div>
-                                </template>
-                              </el-tree>
-                            </div>
-                          </HflPopover>
-                        </div>
-                        <div class="ks-index-scope-row__actions">
-                          <ElButton
-                            v-if="!isEditing"
-                            type="danger"
-                            size="small"
-                            class="ks-index-scope-row__remove"
-                            :disabled="backupScopeEntries.length <= 1"
-                            :title="t('protection.backupsPage.ariaRemove')"
-                            :aria-label="t('protection.backupsPage.ariaRemove')"
-                            @click="removeBackupScopeEntry(scopeEntry.id)"
-                          >
-                            <Trash2 :size="14" />
-                          </ElButton>
-                        </div>
-                      </div>
-                      <div v-if="!isEditing" class="ks-index-scope-stack__add-wrap">
-                        <button
-                          type="button"
-                          class="ks-index-scope-stack__add"
-                          :disabled="!effectiveSnapshotId || snapshotDirectories.length === 0"
-                          @click="addBackupScopeEntry"
-                        >
-                          <Plus :size="16" />
-                          <span>{{ t('insight.kb.btnAddRestoreScope') }}</span>
-                        </button>
-                      </div>
-                    </div>
+                      <ElOption
+                        :label="t('insight.kb.snapshotLatestOption')"
+                        :value="SNAPSHOT_PICKER_LATEST"
+                      />
+                      <ElOption
+                        v-for="row in snapshotsForSelectedBackupSource"
+                        :key="row.id"
+                        :label="snapshotOptionLabel(row)"
+                        :value="row.id"
+                      />
+                    </ElSelect>
                     <p
-                      v-if="!effectiveSnapshotId"
+                      v-if="!selectedBackupConfigId"
                       class="ks-field-hint"
                     >
-                      {{ t('insight.kb.backupScopePickSnapshotFirst') }}
+                      {{ t('insight.kb.snapshotPickBackupFirst') }}
                     </p>
                     <p
-                      v-else-if="snapshotDirectories.length === 0"
-                      class="ks-field-hint ks-field-hint--warn"
+                      v-else
+                      class="ks-field-hint"
                     >
-                      {{ t('insight.kb.restoreScopeNoDirectories') }}
+                      {{ t('insight.kb.fieldSnapshotHint') }}
                     </p>
-                    <p v-else class="ks-field-hint">{{ t('insight.kb.fieldRestoreScopeHint') }}</p>
                   </ElFormItem>
+                </div>
 
-                  <ElFormItem :label="t('insight.kb.colGateway')" required>
-                    <p
-                      v-if="!isEditing && offlineGatewayCount > 0"
-                      class="ks-field-hint ks-field-hint--spaced"
+                <ElFormItem
+                  required
+                  class="ks-index-scope-form-item"
+                >
+                  <div
+                    class="ks-index-scope-stack"
+                    :class="{ 'ks-index-scope-stack--readonly': isEditing }"
+                  >
+                    <div
+                      class="ks-index-scope-stack__header"
+                      aria-hidden="true"
                     >
-                      {{ t('insight.kb.gatewayOnlineOnlyNote', { n: offlineGatewayCount }) }}
-                    </p>
-                    <div class="ks-gateway-select-row">
-                      <div class="ks-gateway-select-row__controls">
-                        <ElSelect
-                          v-model="gatewayId"
-                          class="ks-gateway-select-row__select"
-                          filterable
-                          fit-input-width
-                          :loading="gatewaysRefreshing"
-                          :disabled="isEditing || onlineGateways.length === 0"
-                          popper-class="ks-gateway-select-popper"
-                          :placeholder="t('insight.kb.colGateway')"
+                      <span />
+                      <span class="ks-index-scope-stack__label">
+                        {{ t('insight.kb.fieldRestoreScope') }}
+                        <span class="ks-index-scope-stack__required">*</span>
+                      </span>
+                      <span v-if="!isEditing">{{ t('protection.backupsPage.colActions') }}</span>
+                    </div>
+                    <div
+                      v-for="(scopeEntry, scopeIndex) in backupScopeEntries"
+                      :key="scopeEntry.id"
+                      class="ks-index-scope-row"
+                    >
+                      <span class="ks-index-scope-row__index">
+                        {{ String(scopeIndex + 1).padStart(2, '0') }}
+                      </span>
+                      <div class="ks-index-scope-row__field">
+                        <HflPopover
+                          :visible="!isEditing && isBackupScopePickerOpen(scopeEntry.id)"
+                          trigger="click"
+                          placement="bottom-start"
+                          :width="backupScopePickerWidth"
+                          popper-class="ks-backup-scope-popover"
+                          @update:visible="(open) => !isEditing && setBackupScopePickerOpen(scopeEntry.id, open)"
                         >
-                          <ElOption
-                            v-for="row in gatewaysForPicker"
-                            :key="row.id"
-                            :label="gatewaySelectLine(row)"
-                            :value="row.id"
-                          >
-                            <div class="ks-gateway-option">
-                              <span class="ks-gateway-option__name">{{ gatewaySelectLine(row) }}</span>
-                              <span class="ks-gateway-option__tags">
-                                <ElTag size="small" type="success" effect="plain">
-                                  {{ t('protection.sourceResources.nodeStatusOnline') }}
-                                </ElTag>
-                                <ElTag size="small" :type="gatewayAiTagType(row)" effect="plain">
-                                  {{ gatewayAiLabel(row) }}
-                                </ElTag>
-                              </span>
+                          <template #reference>
+                            <div class="ks-backup-scope-input">
+                              <ElInput
+                                :model-value="scopeEntry.path"
+                                :clearable="!isEditing"
+                                :placeholder="t('insight.kb.phSelectOrEnterRestoreScope')"
+                                :disabled="isEditing || !effectiveSnapshotId || snapshotDirectories.length === 0"
+                                @update:model-value="updateBackupScopeEntryInput(scopeEntry.id, $event)"
+                                @blur="validateBackupScopeEntryOnBlur(scopeEntry.id)"
+                                @keydown.enter.prevent="validateBackupScopeEntry(scopeEntry.id)"
+                              >
+                                <template #prefix>
+                                  <TextCursorInput
+                                    :size="14"
+                                    class="ks-backup-scope-input__type-icon"
+                                  />
+                                </template>
+                                <template #append>
+                                  <ElTooltip
+                                    :content="t('insight.kb.btnBrowseRestoreScope')"
+                                    placement="top"
+                                  >
+                                    <ElButton
+                                      class="ks-backup-scope-input__btn"
+                                      :disabled="isEditing || !effectiveSnapshotId || snapshotDirectories.length === 0"
+                                      @click.stop="setBackupScopePickerOpen(scopeEntry.id, !isBackupScopePickerOpen(scopeEntry.id))"
+                                    >
+                                      <FolderOpen :size="16" />
+                                    </ElButton>
+                                  </ElTooltip>
+                                </template>
+                              </ElInput>
                             </div>
-                          </ElOption>
-                        </ElSelect>
+                          </template>
+                          <div class="ks-backup-scope-tree hfl-dir-tree-shell">
+                            <el-tree
+                              :key="`ks-backup-scope-${scopeEntry.id}-${effectiveSnapshotId}-${backupScopeTreeRevision}`"
+                              v-loading="backupScopeBrowseLoading"
+                              class="hfl-dir-tree hfl-dir-tree--tall"
+                              node-key="id"
+                              lazy
+                              highlight-current
+                              :expand-on-click-node="false"
+                              :load="loadBackupScopePickerNode"
+                              :props="{ label: 'label', children: 'children', isLeaf: 'isLeaf' }"
+                              :current-node-key="scopeEntry.path"
+                              @node-click="(data) => handleBackupScopeNodeClick(scopeEntry.id, data)"
+                            >
+                              <template #default="{ data }">
+                                <div class="hfl-dir-tree-node">
+                                  <FolderOpen
+                                    v-if="data.type === 'dir'"
+                                    :size="15"
+                                    class="hfl-dir-tree-node__icon hfl-dir-tree-node__icon--dir"
+                                  />
+                                  <File
+                                    v-else
+                                    :size="15"
+                                    class="hfl-dir-tree-node__icon hfl-dir-tree-node__icon--file"
+                                  />
+                                  <div class="hfl-dir-tree-node__text">
+                                    <span class="hfl-dir-tree-node__label">{{ data.label }}</span>
+                                    <span
+                                      v-if="data.path"
+                                      class="hfl-dir-tree-node__path"
+                                    >{{ data.path }}</span>
+                                  </div>
+                                </div>
+                              </template>
+                            </el-tree>
+                          </div>
+                        </HflPopover>
+                      </div>
+                      <div class="ks-index-scope-row__actions">
                         <ElButton
                           v-if="!isEditing"
-                          class="hfl-refresh-button ks-gateway-select-row__refresh"
-                          :title="t('insight.kb.gatewayRefresh')"
-                          :aria-label="t('insight.kb.gatewayRefresh')"
-                          :disabled="gatewaysRefreshing"
-                          @click="refreshGateways"
+                          type="danger"
+                          size="small"
+                          class="ks-index-scope-row__remove"
+                          :disabled="backupScopeEntries.length <= 1"
+                          :title="t('protection.backupsPage.ariaRemove')"
+                          :aria-label="t('protection.backupsPage.ariaRemove')"
+                          @click="removeBackupScopeEntry(scopeEntry.id)"
                         >
-                          <RefreshCw :size="16" :class="{ 'is-spinning': gatewaysRefreshing }" />
-                        </ElButton>
-                        <ElButton
-                          v-if="!isEditing"
-                          class="fullscreen-form-icon-btn ks-gateway-select-row__deploy"
-                          :title="t('nodesPage.deployGateway')"
-                          :aria-label="t('nodesPage.deployGateway')"
-                          @click="openGatewayDeploy"
-                        >
-                          <Plus :size="14" />
+                          <Trash2 :size="14" />
                         </ElButton>
                       </div>
                     </div>
-                    <p
-                      v-if="!isEditing && !gatewaysRefreshing && onlineGateways.length === 0"
-                      class="ks-field-hint ks-field-hint--warn"
+                    <div
+                      v-if="!isEditing"
+                      class="ks-index-scope-stack__add-wrap"
                     >
-                      {{ t('insight.kb.gatewayNoOnline') }}
-                    </p>
-                    <p v-else class="ks-field-hint">{{ t('insight.kb.fieldGatewayHint') }}</p>
-                  </ElFormItem>
-                </ElForm>
-              </section>
+                      <button
+                        type="button"
+                        class="ks-index-scope-stack__add"
+                        :disabled="!effectiveSnapshotId || snapshotDirectories.length === 0"
+                        @click="addBackupScopeEntry"
+                      >
+                        <Plus :size="16" />
+                        <span>{{ t('insight.kb.btnAddRestoreScope') }}</span>
+                      </button>
+                    </div>
+                  </div>
+                  <p
+                    v-if="!effectiveSnapshotId"
+                    class="ks-field-hint"
+                  >
+                    {{ t('insight.kb.backupScopePickSnapshotFirst') }}
+                  </p>
+                  <p
+                    v-else-if="snapshotDirectories.length === 0"
+                    class="ks-field-hint ks-field-hint--warn"
+                  >
+                    {{ t('insight.kb.restoreScopeNoDirectories') }}
+                  </p>
+                  <p
+                    v-else
+                    class="ks-field-hint"
+                  >
+                    {{ t('insight.kb.fieldRestoreScopeHint') }}
+                  </p>
+                </ElFormItem>
 
-              <section class="fullscreen-form-card fullscreen-form-section">
-                <h3 class="fullscreen-form-section__title">
-                  <span class="fullscreen-form-section__indicator" />
-                  {{ t('insight.kb.retrieval.documentContentTitle') }}
-                </h3>
-                <KnowledgeSourceRetrievalEnhancement
-                  v-model="ingestPolicy"
-                  section="document"
-                  :show-lead="true"
-                />
-              </section>
+                <ElFormItem
+                  :label="t('insight.kb.colGateway')"
+                  required
+                >
+                  <p
+                    v-if="!isEditing && offlineGatewayCount > 0"
+                    class="ks-field-hint ks-field-hint--spaced"
+                  >
+                    {{ t('insight.kb.gatewayOnlineOnlyNote', { n: offlineGatewayCount }) }}
+                  </p>
+                  <div class="ks-gateway-select-row">
+                    <div class="ks-gateway-select-row__controls">
+                      <ElSelect
+                        v-model="gatewayId"
+                        class="ks-gateway-select-row__select"
+                        filterable
+                        fit-input-width
+                        :loading="gatewaysRefreshing"
+                        :disabled="isEditing || onlineGateways.length === 0"
+                        popper-class="ks-gateway-select-popper"
+                        :placeholder="t('insight.kb.colGateway')"
+                      >
+                        <ElOption
+                          v-for="row in gatewaysForPicker"
+                          :key="row.id"
+                          :label="gatewaySelectLine(row)"
+                          :value="row.id"
+                        >
+                          <div class="ks-gateway-option">
+                            <span class="ks-gateway-option__name">{{ gatewaySelectLine(row) }}</span>
+                            <span class="ks-gateway-option__tags">
+                              <ElTag
+                                size="small"
+                                type="success"
+                                effect="plain"
+                              >
+                                {{ t('protection.sourceResources.nodeStatusOnline') }}
+                              </ElTag>
+                              <ElTag
+                                size="small"
+                                :type="gatewayAiTagType(row)"
+                                effect="plain"
+                              >
+                                {{ gatewayAiLabel(row) }}
+                              </ElTag>
+                            </span>
+                          </div>
+                        </ElOption>
+                      </ElSelect>
+                      <ElButton
+                        v-if="!isEditing"
+                        class="hfl-refresh-button ks-gateway-select-row__refresh"
+                        :title="t('insight.kb.gatewayRefresh')"
+                        :aria-label="t('insight.kb.gatewayRefresh')"
+                        :disabled="gatewaysRefreshing"
+                        @click="refreshGateways"
+                      >
+                        <RefreshCw
+                          :size="16"
+                          :class="{ 'is-spinning': gatewaysRefreshing }"
+                        />
+                      </ElButton>
+                      <ElButton
+                        v-if="!isEditing"
+                        class="fullscreen-form-icon-btn ks-gateway-select-row__deploy"
+                        :title="t('nodesPage.deployGateway')"
+                        :aria-label="t('nodesPage.deployGateway')"
+                        @click="openGatewayDeploy"
+                      >
+                        <Plus :size="14" />
+                      </ElButton>
+                    </div>
+                  </div>
+                  <p
+                    v-if="!isEditing && !gatewaysRefreshing && onlineGateways.length === 0"
+                    class="ks-field-hint ks-field-hint--warn"
+                  >
+                    {{ t('insight.kb.gatewayNoOnline') }}
+                  </p>
+                  <p
+                    v-else
+                    class="ks-field-hint"
+                  >
+                    {{ t('insight.kb.fieldGatewayHint') }}
+                  </p>
+                </ElFormItem>
+              </ElForm>
+            </section>
 
-              <section class="fullscreen-form-card fullscreen-form-section">
-                <h3 class="fullscreen-form-section__title">
-                  <span class="fullscreen-form-section__indicator" />
-                  {{ t('insight.kb.retrieval.standaloneImagesTitle') }}
-                </h3>
-                <KnowledgeSourceRetrievalEnhancement v-model="ingestPolicy" section="images" />
-              </section>
+            <section class="fullscreen-form-card fullscreen-form-section">
+              <h3 class="fullscreen-form-section__title">
+                <span class="fullscreen-form-section__indicator" />
+                {{ t('insight.kb.retrieval.documentContentTitle') }}
+              </h3>
+              <KnowledgeSourceRetrievalEnhancement
+                v-model="ingestPolicy"
+                section="document"
+                :show-lead="true"
+              />
+            </section>
 
-              <section class="fullscreen-form-card fullscreen-form-section">
-                <h3 class="fullscreen-form-section__title">
-                  <span class="fullscreen-form-section__indicator" />
-                  {{ t('insight.kb.retrieval.globalConversionLimitsTitle') }}
-                </h3>
-                <KnowledgeSourceRetrievalEnhancement v-model="ingestPolicy" section="limits" />
-              </section>
+            <section class="fullscreen-form-card fullscreen-form-section">
+              <h3 class="fullscreen-form-section__title">
+                <span class="fullscreen-form-section__indicator" />
+                {{ t('insight.kb.retrieval.standaloneImagesTitle') }}
+              </h3>
+              <KnowledgeSourceRetrievalEnhancement
+                v-model="ingestPolicy"
+                section="images"
+              />
+            </section>
+
+            <section class="fullscreen-form-card fullscreen-form-section">
+              <h3 class="fullscreen-form-section__title">
+                <span class="fullscreen-form-section__indicator" />
+                {{ t('insight.kb.retrieval.globalConversionLimitsTitle') }}
+              </h3>
+              <KnowledgeSourceRetrievalEnhancement
+                v-model="ingestPolicy"
+                section="limits"
+              />
+            </section>
           </div>
 
           <footer class="fullscreen-form-footer">

--- a/src/frontend/src/pages/insight/McpServerFormPage.vue
+++ b/src/frontend/src/pages/insight/McpServerFormPage.vue
@@ -163,47 +163,113 @@ watch(
 </script>
 
 <template>
-  <div ref="pageRef" class="fullscreen-form-fullscreen resource-add-fullscreen">
+  <div
+    ref="pageRef"
+    class="fullscreen-form-fullscreen resource-add-fullscreen"
+  >
     <div class="fullscreen-form-page">
       <header class="fullscreen-form-header">
-        <button type="button" class="fullscreen-form-header__back" @click="handleBack">
-          <ArrowLeft class="fullscreen-form-header__back-icon" :size="18" />
+        <button
+          type="button"
+          class="fullscreen-form-header__back"
+          @click="handleBack"
+        >
+          <ArrowLeft
+            class="fullscreen-form-header__back-icon"
+            :size="18"
+          />
         </button>
         <div class="fullscreen-form-header__content">
-          <h1 class="fullscreen-form-header__title">{{ pageTitle }}</h1>
-          <p class="fullscreen-form-header__desc">{{ pageDesc }}</p>
+          <h1 class="fullscreen-form-header__title">
+            {{ pageTitle }}
+          </h1>
+          <p class="fullscreen-form-header__desc">
+            {{ pageDesc }}
+          </p>
         </div>
       </header>
 
-      <div v-loading="loading" class="fullscreen-form-layout">
+      <div
+        v-loading="loading"
+        class="fullscreen-form-layout"
+      >
         <div class="fullscreen-form-main">
           <div class="fullscreen-form-step-stack">
             <section class="fullscreen-form-card fullscreen-form-section">
-              <ElForm label-position="top" class="fullscreen-form-el-form">
-                <ElFormItem data-validation-field="name" :error="errors.name" :label="t('insight.mcpServers.fieldName')" required>
-                  <ElInput v-model="name" :placeholder="t('insight.mcpServers.fieldNamePh')" @input="clearFieldError('name')" />
-                  <p class="mcp-field-hint">{{ t('insight.mcpServers.fieldNameHint') }}</p>
+              <ElForm
+                label-position="top"
+                class="fullscreen-form-el-form"
+              >
+                <ElFormItem
+                  data-validation-field="name"
+                  :error="errors.name"
+                  :label="t('insight.mcpServers.fieldName')"
+                  required
+                >
+                  <ElInput
+                    v-model="name"
+                    :placeholder="t('insight.mcpServers.fieldNamePh')"
+                    @input="clearFieldError('name')"
+                  />
+                  <p class="mcp-field-hint">
+                    {{ t('insight.mcpServers.fieldNameHint') }}
+                  </p>
                 </ElFormItem>
 
                 <div class="fullscreen-form-grid mcp-connection-grid">
-                  <ElFormItem :label="t('insight.mcpServers.fieldTransport')" required>
-                    <ElSelect v-model="transport" class="w-full">
-                      <ElOption label="URL" value="url" />
-                      <ElOption label="STDIO" value="stdio" />
+                  <ElFormItem
+                    :label="t('insight.mcpServers.fieldTransport')"
+                    required
+                  >
+                    <ElSelect
+                      v-model="transport"
+                      class="w-full"
+                    >
+                      <ElOption
+                        label="URL"
+                        value="url"
+                      />
+                      <ElOption
+                        label="STDIO"
+                        value="stdio"
+                      />
                     </ElSelect>
-                    <p class="mcp-field-hint">{{ t('insight.mcpServers.fieldTransportHint') }}</p>
+                    <p class="mcp-field-hint">
+                      {{ t('insight.mcpServers.fieldTransportHint') }}
+                    </p>
                   </ElFormItem>
-                  <ElFormItem data-validation-field="endpoint" :error="errors.endpoint" :label="t('insight.mcpServers.fieldEndpoint')" required>
-                    <ElInput v-model="endpoint" :placeholder="endpointPlaceholder" @input="clearFieldError('endpoint')" />
-                    <p class="mcp-field-hint">{{ t('insight.mcpServers.fieldEndpointHint') }}</p>
+                  <ElFormItem
+                    data-validation-field="endpoint"
+                    :error="errors.endpoint"
+                    :label="t('insight.mcpServers.fieldEndpoint')"
+                    required
+                  >
+                    <ElInput
+                      v-model="endpoint"
+                      :placeholder="endpointPlaceholder"
+                      @input="clearFieldError('endpoint')"
+                    />
+                    <p class="mcp-field-hint">
+                      {{ t('insight.mcpServers.fieldEndpointHint') }}
+                    </p>
                   </ElFormItem>
                 </div>
 
                 <ElFormItem :label="t('insight.mcpServers.fieldConfig')">
                   <div class="mcp-config-panel">
-                    <div v-for="(row, index) in configRows" :key="index" class="mcp-config-row">
-                      <ElInput v-model="row.key" :placeholder="t('insight.mcpServers.fieldConfigKey')" />
-                      <ElInput v-model="row.value" :placeholder="t('insight.mcpServers.fieldConfigValue')" />
+                    <div
+                      v-for="(row, index) in configRows"
+                      :key="index"
+                      class="mcp-config-row"
+                    >
+                      <ElInput
+                        v-model="row.key"
+                        :placeholder="t('insight.mcpServers.fieldConfigKey')"
+                      />
+                      <ElInput
+                        v-model="row.value"
+                        :placeholder="t('insight.mcpServers.fieldConfigValue')"
+                      />
                       <button
                         type="button"
                         class="mcp-config-row__remove"
@@ -213,17 +279,24 @@ watch(
                         <Trash2 :size="16" />
                       </button>
                     </div>
-                    <ElButton size="small" @click="addConfigRow">
+                    <ElButton
+                      size="small"
+                      @click="addConfigRow"
+                    >
                       <Plus :size="14" />
                       {{ t('insight.mcpServers.addConfigRow') }}
                     </ElButton>
                   </div>
-                  <p class="mcp-field-hint">{{ t('insight.mcpServers.fieldConfigHint') }}</p>
+                  <p class="mcp-field-hint">
+                    {{ t('insight.mcpServers.fieldConfigHint') }}
+                  </p>
                 </ElFormItem>
 
                 <ElFormItem :label="t('insight.mcpServers.fieldEnabled')">
                   <ElSwitch v-model="enabled" />
-                  <p class="mcp-field-hint">{{ t('insight.mcpServers.fieldEnabledHint') }}</p>
+                  <p class="mcp-field-hint">
+                    {{ t('insight.mcpServers.fieldEnabledHint') }}
+                  </p>
                 </ElFormItem>
               </ElForm>
             </section>

--- a/src/frontend/src/pages/insight/NewCopilotChat.vue
+++ b/src/frontend/src/pages/insight/NewCopilotChat.vue
@@ -298,198 +298,395 @@ onBeforeUnmount(() => backupScopeResizeObserver?.disconnect())
   <div class="fullscreen-form-fullscreen resource-add-fullscreen">
     <div class="fullscreen-form-page new-copilot-chat-page">
       <div class="fullscreen-form-header">
-        <button type="button" class="fullscreen-form-header__back" aria-label="Back to Copilot" @click="router.push('/insight/copilot')">
-          <ArrowLeft class="fullscreen-form-header__back-icon" :size="18" />
+        <button
+          type="button"
+          class="fullscreen-form-header__back"
+          aria-label="Back to Copilot"
+          @click="router.push('/insight/copilot')"
+        >
+          <ArrowLeft
+            class="fullscreen-form-header__back-icon"
+            :size="18"
+          />
         </button>
         <div class="fullscreen-form-header__content">
-          <h1 class="fullscreen-form-header__title">New Chat</h1>
-          <p class="fullscreen-form-header__desc">Choose the backup data you want AI Copilot to analyze.</p>
+          <h1 class="fullscreen-form-header__title">
+            New Chat
+          </h1>
+          <p class="fullscreen-form-header__desc">
+            Choose the backup data you want AI Copilot to analyze.
+          </p>
         </div>
       </div>
 
-      <div v-loading="loading" class="fullscreen-form-layout">
+      <div
+        v-loading="loading"
+        class="fullscreen-form-layout"
+      >
         <main class="fullscreen-form-main">
           <div class="fullscreen-form-step-stack">
-            <div class="fullscreen-form-card"><section class="fullscreen-form-section">
-              <div class="new-chat-section-head">
-                <div class="new-chat-section-head__copy">
-                  <h2 class="fullscreen-form-section__title"><span class="fullscreen-form-section__indicator" />Data Source</h2>
-                </div>
-              </div>
-              <div class="new-chat-grid">
-                <div class="fullscreen-form-field">
-                  <label for="copilot-backup-source" class="fullscreen-form-field__label">Backup Source <span class="fullscreen-form-field__required">*</span></label>
-                  <ElSelect id="copilot-backup-source" v-model="selectedBackupConfigId" filterable placeholder="Select a backup source">
-                    <ElOption v-for="row in backupSourceOptions" :key="row.backupConfigId" :label="row.label" :value="row.backupConfigId" />
-                  </ElSelect>
-                  <p class="fullscreen-form-field__hint">Choose the backup source that contains the data you want to analyze.</p>
-                </div>
-                <div class="fullscreen-form-field">
-                  <label for="copilot-snapshot" class="fullscreen-form-field__label">Snapshot <span class="fullscreen-form-field__required">*</span></label>
-                  <ElSelect id="copilot-snapshot" v-model="snapshotPickerValue" :loading="snapshotLoading" :disabled="!selectedBackupConfigId" placeholder="Select a snapshot">
-                    <ElOption label="Latest available snapshot" :value="SNAPSHOT_PICKER_LATEST" />
-                    <ElOption v-for="row in snapshotsForSelectedBackupSource" :key="row.id" :label="snapshotOptionLabel(row)" :value="row.id" />
-                  </ElSelect>
-                  <p class="fullscreen-form-field__hint">Choose the backup snapshot you want to analyze.</p>
-                </div>
-              </div>
-              <div class="new-chat-source-divider" />
-              <div class="new-chat-source-subsection">
-                <div class="new-chat-source-subsection__head">
-                  <h3 class="fullscreen-form-field__label">Files and Folders <span class="fullscreen-form-field__required">*</span></h3>
-                </div>
-                <div ref="backupScopeStackRef" class="new-chat-scope-stack">
-                  <div class="new-chat-scope-stack__header" aria-hidden="true"><span /><span>Path</span><span>Actions</span></div>
-                  <div v-for="(scopeEntry, scopeIndex) in backupScopeEntries" :key="scopeEntry.id" class="new-chat-scope-row">
-                    <span class="new-chat-scope-row__index">{{ String(scopeIndex + 1).padStart(2, '0') }}</span>
-                    <HflPopover
-                      :visible="isBackupScopePickerOpen(scopeEntry.id)"
-                      trigger="click"
-                      placement="bottom-start"
-                      :width="backupScopePickerWidth"
-                      popper-class="ks-backup-scope-popover"
-                      @update:visible="(open) => setBackupScopePickerOpen(scopeEntry.id, open)"
-                    >
-                      <template #reference>
-                        <ElInput
-                          class="new-chat-scope-input"
-                          :model-value="scopeEntry.path"
-                          clearable
-                          placeholder="Select a file or folder"
-                          :disabled="!effectiveSnapshotId || snapshotDirectories.length === 0"
-                          @update:model-value="updateBackupScopeEntryInput(scopeEntry.id, $event)"
-                          @blur="validateBackupScopeEntryOnBlur(scopeEntry.id)"
-                          @keydown.enter.prevent="validateBackupScopeEntry(scopeEntry.id)"
-                        >
-                          <template #prefix><TextCursorInput :size="14" /></template>
-                          <template #append>
-                            <ElButton aria-label="Browse backup content" :disabled="!effectiveSnapshotId || snapshotDirectories.length === 0" @click.stop="setBackupScopePickerOpen(scopeEntry.id, !isBackupScopePickerOpen(scopeEntry.id))"><FolderOpen :size="16" /></ElButton>
-                          </template>
-                        </ElInput>
-                      </template>
-                      <div class="new-chat-scope-tree hfl-dir-tree-shell">
-                        <el-tree
-                          :key="`copilot-scope-${scopeEntry.id}-${effectiveSnapshotId}-${backupScopeTreeRevision}`"
-                          v-loading="backupScopeBrowseLoading"
-                          class="hfl-dir-tree hfl-dir-tree--tall"
-                          node-key="id"
-                          lazy
-                          highlight-current
-                          :expand-on-click-node="false"
-                          :load="loadBackupScopePickerNode"
-                          :props="{ label: 'label', children: 'children', isLeaf: 'isLeaf' }"
-                          @node-click="(data) => handleBackupScopeNodeClick(scopeEntry.id, data)"
-                        >
-                          <template #default="{ data }">
-                            <div class="hfl-dir-tree-node">
-                              <FolderOpen v-if="data.type === 'dir'" :size="15" class="hfl-dir-tree-node__icon hfl-dir-tree-node__icon--dir" />
-                              <File v-else :size="15" class="hfl-dir-tree-node__icon hfl-dir-tree-node__icon--file" />
-                              <div class="hfl-dir-tree-node__text"><span class="hfl-dir-tree-node__label">{{ data.label }}</span><span v-if="data.path" class="hfl-dir-tree-node__path">{{ data.path }}</span></div>
-                            </div>
-                          </template>
-                        </el-tree>
-                      </div>
-                    </HflPopover>
-                    <ElButton type="danger" size="small" :disabled="backupScopeEntries.length <= 1" aria-label="Remove scope" @click="removeBackupScopeEntry(scopeEntry.id)"><Trash2 :size="14" /></ElButton>
+            <div class="fullscreen-form-card">
+              <section class="fullscreen-form-section">
+                <div class="new-chat-section-head">
+                  <div class="new-chat-section-head__copy">
+                    <h2 class="fullscreen-form-section__title">
+                      <span class="fullscreen-form-section__indicator" />Data Source
+                    </h2>
                   </div>
-                  <div class="new-chat-scope-stack__add"><button type="button" :disabled="!effectiveSnapshotId || snapshotDirectories.length === 0" @click="addBackupScopeEntry"><CirclePlus :size="16" /> Add File or Folder</button></div>
                 </div>
-                <p v-if="!effectiveSnapshotId" class="fullscreen-form-field__hint new-chat-scope-hint">Select a snapshot to browse its files and folders.</p>
-                <p v-else-if="snapshotDirectories.length === 0" class="fullscreen-form-field__hint new-chat-scope-hint new-chat-hint--warn">No files or folders are available in this snapshot.</p>
-                <p v-else class="fullscreen-form-field__hint new-chat-scope-hint">Select one or more files or folders for this chat.</p>
-                <p class="fullscreen-form-field__hint new-chat-scope-hint">{{ t('insight.copilot.documentFormatHint') }}</p>
-                <p class="fullscreen-form-field__hint new-chat-scope-hint">{{ t('insight.copilot.dataOriginHint') }}</p>
-              </div>
-            </section></div>
-
-            <div class="fullscreen-form-card"><section class="fullscreen-form-section">
-              <div class="new-chat-section-head">
-                <div class="new-chat-section-head__copy">
-                  <h2 class="fullscreen-form-section__title"><span class="fullscreen-form-section__indicator" />Data Privacy</h2>
+                <div class="new-chat-grid">
+                  <div class="fullscreen-form-field">
+                    <label
+                      for="copilot-backup-source"
+                      class="fullscreen-form-field__label"
+                    >Backup Source <span class="fullscreen-form-field__required">*</span></label>
+                    <ElSelect
+                      id="copilot-backup-source"
+                      v-model="selectedBackupConfigId"
+                      filterable
+                      placeholder="Select a backup source"
+                    >
+                      <ElOption
+                        v-for="row in backupSourceOptions"
+                        :key="row.backupConfigId"
+                        :label="row.label"
+                        :value="row.backupConfigId"
+                      />
+                    </ElSelect>
+                    <p class="fullscreen-form-field__hint">
+                      Choose the backup source that contains the data you want to analyze.
+                    </p>
+                  </div>
+                  <div class="fullscreen-form-field">
+                    <label
+                      for="copilot-snapshot"
+                      class="fullscreen-form-field__label"
+                    >Snapshot <span class="fullscreen-form-field__required">*</span></label>
+                    <ElSelect
+                      id="copilot-snapshot"
+                      v-model="snapshotPickerValue"
+                      :loading="snapshotLoading"
+                      :disabled="!selectedBackupConfigId"
+                      placeholder="Select a snapshot"
+                    >
+                      <ElOption
+                        label="Latest available snapshot"
+                        :value="SNAPSHOT_PICKER_LATEST"
+                      />
+                      <ElOption
+                        v-for="row in snapshotsForSelectedBackupSource"
+                        :key="row.id"
+                        :label="snapshotOptionLabel(row)"
+                        :value="row.id"
+                      />
+                    </ElSelect>
+                    <p class="fullscreen-form-field__hint">
+                      Choose the backup snapshot you want to analyze.
+                    </p>
+                  </div>
                 </div>
-              </div>
-              <div class="new-chat-privacy-options">
-                <label class="new-chat-choice" :class="{ 'new-chat-choice--selected': gatewayMode === 'auto' }"><input v-model="gatewayMode" type="radio" value="auto"><span><strong>{{ t('insight.copilot.gatewayPublicTitle') }}</strong><small>{{ t('insight.copilot.gatewayPublicDescription') }}</small></span></label>
-                <div ref="privateGatewayCardRef" class="new-chat-choice new-chat-choice--private" :class="{ 'new-chat-choice--selected': gatewayMode === 'manual' }">
-                  <label class="new-chat-choice__radio"><input v-model="gatewayMode" type="radio" value="manual"><span><strong>{{ t('insight.copilot.gatewayPrivateTitle') }}</strong><small>{{ t('insight.copilot.gatewayPrivateDescription') }}</small></span></label>
-                  <div class="new-chat-choice__control">
-                    <div class="new-chat-gateway-select-row">
-                      <ElSelect
-                        v-model="gatewayLinkId"
-                        class="new-chat-gateway-select"
-                        filterable
-                        :loading="gatewayRefreshing"
-                        :no-data-text="t('insight.copilot.gatewayPrivateNoOnline')"
-                        placement="top-start"
-                        :fallback-placements="['bottom-start', 'top-end', 'bottom-end']"
-                        :placeholder="t('insight.copilot.gatewayPrivateSelectPlaceholder')"
-                        popper-class="new-chat-gateway-select-popper"
-                        @change="gatewayMode = 'manual'"
-                        @visible-change="(visible) => visible && ensurePrivateGatewayVisible()"
+                <div class="new-chat-source-divider" />
+                <div class="new-chat-source-subsection">
+                  <div class="new-chat-source-subsection__head">
+                    <h3 class="fullscreen-form-field__label">
+                      Files and Folders <span class="fullscreen-form-field__required">*</span>
+                    </h3>
+                  </div>
+                  <div
+                    ref="backupScopeStackRef"
+                    class="new-chat-scope-stack"
+                  >
+                    <div
+                      class="new-chat-scope-stack__header"
+                      aria-hidden="true"
+                    >
+                      <span /><span>Path</span><span>Actions</span>
+                    </div>
+                    <div
+                      v-for="(scopeEntry, scopeIndex) in backupScopeEntries"
+                      :key="scopeEntry.id"
+                      class="new-chat-scope-row"
+                    >
+                      <span class="new-chat-scope-row__index">{{ String(scopeIndex + 1).padStart(2, '0') }}</span>
+                      <HflPopover
+                        :visible="isBackupScopePickerOpen(scopeEntry.id)"
+                        trigger="click"
+                        placement="bottom-start"
+                        :width="backupScopePickerWidth"
+                        popper-class="ks-backup-scope-popover"
+                        @update:visible="(open) => setBackupScopePickerOpen(scopeEntry.id, open)"
                       >
-                        <ElOption
-                          v-for="row in privateGateways"
-                          :key="row.gateway_link_id"
-                          :label="row.name"
-                          :value="row.gateway_link_id"
-                        >
-                          <div class="new-chat-gateway-option">
-                            <span class="new-chat-gateway-option__name">{{ row.name }}</span>
-                            <span class="new-chat-gateway-option__status"><span class="new-chat-gateway-option__dot" />Online</span>
-                          </div>
-                        </ElOption>
-                      </ElSelect>
+                        <template #reference>
+                          <ElInput
+                            class="new-chat-scope-input"
+                            :model-value="scopeEntry.path"
+                            clearable
+                            placeholder="Select a file or folder"
+                            :disabled="!effectiveSnapshotId || snapshotDirectories.length === 0"
+                            @update:model-value="updateBackupScopeEntryInput(scopeEntry.id, $event)"
+                            @blur="validateBackupScopeEntryOnBlur(scopeEntry.id)"
+                            @keydown.enter.prevent="validateBackupScopeEntry(scopeEntry.id)"
+                          >
+                            <template #prefix>
+                              <TextCursorInput :size="14" />
+                            </template>
+                            <template #append>
+                              <ElButton
+                                aria-label="Browse backup content"
+                                :disabled="!effectiveSnapshotId || snapshotDirectories.length === 0"
+                                @click.stop="setBackupScopePickerOpen(scopeEntry.id, !isBackupScopePickerOpen(scopeEntry.id))"
+                              >
+                                <FolderOpen :size="16" />
+                              </ElButton>
+                            </template>
+                          </ElInput>
+                        </template>
+                        <div class="new-chat-scope-tree hfl-dir-tree-shell">
+                          <el-tree
+                            :key="`copilot-scope-${scopeEntry.id}-${effectiveSnapshotId}-${backupScopeTreeRevision}`"
+                            v-loading="backupScopeBrowseLoading"
+                            class="hfl-dir-tree hfl-dir-tree--tall"
+                            node-key="id"
+                            lazy
+                            highlight-current
+                            :expand-on-click-node="false"
+                            :load="loadBackupScopePickerNode"
+                            :props="{ label: 'label', children: 'children', isLeaf: 'isLeaf' }"
+                            @node-click="(data) => handleBackupScopeNodeClick(scopeEntry.id, data)"
+                          >
+                            <template #default="{ data }">
+                              <div class="hfl-dir-tree-node">
+                                <FolderOpen
+                                  v-if="data.type === 'dir'"
+                                  :size="15"
+                                  class="hfl-dir-tree-node__icon hfl-dir-tree-node__icon--dir"
+                                />
+                                <File
+                                  v-else
+                                  :size="15"
+                                  class="hfl-dir-tree-node__icon hfl-dir-tree-node__icon--file"
+                                />
+                                <div class="hfl-dir-tree-node__text">
+                                  <span class="hfl-dir-tree-node__label">{{ data.label }}</span><span
+                                    v-if="data.path"
+                                    class="hfl-dir-tree-node__path"
+                                  >{{ data.path }}</span>
+                                </div>
+                              </div>
+                            </template>
+                          </el-tree>
+                        </div>
+                      </HflPopover>
                       <ElButton
-                        class="hfl-refresh-button new-chat-gateway-select-row__refresh"
-                        :title="t('insight.copilot.gatewayPrivateRefreshAction')"
-                        :aria-label="t('insight.copilot.gatewayPrivateRefreshAction')"
-                        :disabled="gatewayRefreshing"
-                        @click="refreshGatewayOptions()"
+                        type="danger"
+                        size="small"
+                        :disabled="backupScopeEntries.length <= 1"
+                        aria-label="Remove scope"
+                        @click="removeBackupScopeEntry(scopeEntry.id)"
                       >
-                        <RefreshCw :size="16" :class="{ 'is-spinning': gatewayRefreshing }" />
-                      </ElButton>
-                      <ElButton
-                        class="fullscreen-form-icon-btn new-chat-gateway-select-row__deploy"
-                        :title="t('insight.copilot.gatewayPrivateInstallAction')"
-                        :aria-label="t('insight.copilot.gatewayPrivateInstallAction')"
-                        @click="openGatewayDeploy"
-                      >
-                        <Plus :size="14" />
+                        <Trash2 :size="14" />
                       </ElButton>
                     </div>
-                    <p v-if="!gatewayRefreshing && privateGateways.length === 0" class="new-chat-hint new-chat-hint--warn">{{ t('insight.copilot.gatewayPrivateNoOnline') }}</p>
+                    <div class="new-chat-scope-stack__add">
+                      <button
+                        type="button"
+                        :disabled="!effectiveSnapshotId || snapshotDirectories.length === 0"
+                        @click="addBackupScopeEntry"
+                      >
+                        <CirclePlus :size="16" /> Add File or Folder
+                      </button>
+                    </div>
+                  </div>
+                  <p
+                    v-if="!effectiveSnapshotId"
+                    class="fullscreen-form-field__hint new-chat-scope-hint"
+                  >
+                    Select a snapshot to browse its files and folders.
+                  </p>
+                  <p
+                    v-else-if="snapshotDirectories.length === 0"
+                    class="fullscreen-form-field__hint new-chat-scope-hint new-chat-hint--warn"
+                  >
+                    No files or folders are available in this snapshot.
+                  </p>
+                  <p
+                    v-else
+                    class="fullscreen-form-field__hint new-chat-scope-hint"
+                  >
+                    Select one or more files or folders for this chat.
+                  </p>
+                  <p class="fullscreen-form-field__hint new-chat-scope-hint">
+                    {{ t('insight.copilot.documentFormatHint') }}
+                  </p>
+                  <p class="fullscreen-form-field__hint new-chat-scope-hint">
+                    {{ t('insight.copilot.dataOriginHint') }}
+                  </p>
+                </div>
+              </section>
+            </div>
+
+            <div class="fullscreen-form-card">
+              <section class="fullscreen-form-section">
+                <div class="new-chat-section-head">
+                  <div class="new-chat-section-head__copy">
+                    <h2 class="fullscreen-form-section__title">
+                      <span class="fullscreen-form-section__indicator" />Data Privacy
+                    </h2>
                   </div>
                 </div>
-                <div
-                  v-if="publicGatewayUnavailable"
-                  class="new-chat-gateway-warning"
-                  role="alert"
-                >
-                  <TriangleAlert :size="16" aria-hidden="true" />
-                  <span>{{ t('insight.copilot.gatewayPublicUnavailable') }}</span>
+                <div class="new-chat-privacy-options">
+                  <label
+                    class="new-chat-choice"
+                    :class="{ 'new-chat-choice--selected': gatewayMode === 'auto' }"
+                  ><input
+                    v-model="gatewayMode"
+                    type="radio"
+                    value="auto"
+                  ><span><strong>{{ t('insight.copilot.gatewayPublicTitle') }}</strong><small>{{ t('insight.copilot.gatewayPublicDescription') }}</small></span></label>
+                  <div
+                    ref="privateGatewayCardRef"
+                    class="new-chat-choice new-chat-choice--private"
+                    :class="{ 'new-chat-choice--selected': gatewayMode === 'manual' }"
+                  >
+                    <label class="new-chat-choice__radio"><input
+                      v-model="gatewayMode"
+                      type="radio"
+                      value="manual"
+                    ><span><strong>{{ t('insight.copilot.gatewayPrivateTitle') }}</strong><small>{{ t('insight.copilot.gatewayPrivateDescription') }}</small></span></label>
+                    <div class="new-chat-choice__control">
+                      <div class="new-chat-gateway-select-row">
+                        <ElSelect
+                          v-model="gatewayLinkId"
+                          class="new-chat-gateway-select"
+                          filterable
+                          :loading="gatewayRefreshing"
+                          :no-data-text="t('insight.copilot.gatewayPrivateNoOnline')"
+                          placement="top-start"
+                          :fallback-placements="['bottom-start', 'top-end', 'bottom-end']"
+                          :placeholder="t('insight.copilot.gatewayPrivateSelectPlaceholder')"
+                          popper-class="new-chat-gateway-select-popper"
+                          @change="gatewayMode = 'manual'"
+                          @visible-change="(visible) => visible && ensurePrivateGatewayVisible()"
+                        >
+                          <ElOption
+                            v-for="row in privateGateways"
+                            :key="row.gateway_link_id"
+                            :label="row.name"
+                            :value="row.gateway_link_id"
+                          >
+                            <div class="new-chat-gateway-option">
+                              <span class="new-chat-gateway-option__name">{{ row.name }}</span>
+                              <span class="new-chat-gateway-option__status"><span class="new-chat-gateway-option__dot" />Online</span>
+                            </div>
+                          </ElOption>
+                        </ElSelect>
+                        <ElButton
+                          class="hfl-refresh-button new-chat-gateway-select-row__refresh"
+                          :title="t('insight.copilot.gatewayPrivateRefreshAction')"
+                          :aria-label="t('insight.copilot.gatewayPrivateRefreshAction')"
+                          :disabled="gatewayRefreshing"
+                          @click="refreshGatewayOptions()"
+                        >
+                          <RefreshCw
+                            :size="16"
+                            :class="{ 'is-spinning': gatewayRefreshing }"
+                          />
+                        </ElButton>
+                        <ElButton
+                          class="fullscreen-form-icon-btn new-chat-gateway-select-row__deploy"
+                          :title="t('insight.copilot.gatewayPrivateInstallAction')"
+                          :aria-label="t('insight.copilot.gatewayPrivateInstallAction')"
+                          @click="openGatewayDeploy"
+                        >
+                          <Plus :size="14" />
+                        </ElButton>
+                      </div>
+                      <p
+                        v-if="!gatewayRefreshing && privateGateways.length === 0"
+                        class="new-chat-hint new-chat-hint--warn"
+                      >
+                        {{ t('insight.copilot.gatewayPrivateNoOnline') }}
+                      </p>
+                    </div>
+                  </div>
+                  <div
+                    v-if="publicGatewayUnavailable"
+                    class="new-chat-gateway-warning"
+                    role="alert"
+                  >
+                    <TriangleAlert
+                      :size="16"
+                      aria-hidden="true"
+                    />
+                    <span>{{ t('insight.copilot.gatewayPublicUnavailable') }}</span>
+                  </div>
                 </div>
-              </div>
-            </section></div>
+              </section>
+            </div>
           </div>
         </main>
 
         <aside class="fullscreen-form-sidebar add-form-preview-sidebar">
           <div class="add-form-preview-card">
-            <div class="add-form-preview-header"><div class="add-form-preview-header__icon"><MessageSquare class="add-form-preview-header__icon-lucide" :size="25" /></div><div class="add-form-preview-header__info"><h2 class="add-form-preview-header__name">New Chat</h2><p class="add-form-preview-header__type">AI Copilot</p></div></div>
+            <div class="add-form-preview-header">
+              <div class="add-form-preview-header__icon">
+                <MessageSquare
+                  class="add-form-preview-header__icon-lucide"
+                  :size="25"
+                />
+              </div><div class="add-form-preview-header__info">
+                <h2 class="add-form-preview-header__name">
+                  New Chat
+                </h2><p class="add-form-preview-header__type">
+                  AI Copilot
+                </p>
+              </div>
+            </div>
             <div class="add-form-preview-body">
               <section class="add-form-preview-section">
-                <h3 class="add-form-preview-section__title">Data Source</h3>
-                <div class="add-form-preview-row"><span class="add-form-preview-row__label">Backup Source</span><span class="add-form-preview-row__value" :class="{ 'add-form-preview-row__value--empty': !selectedBackupSource }">{{ selectedBackupSource?.label || '—' }}</span></div>
-                <div class="add-form-preview-row"><span class="add-form-preview-row__label">{{ t('insight.copilot.dataOriginLabel') }}</span><span class="add-form-preview-row__value">{{ t('insight.copilot.dataOriginProtected') }}</span></div>
-                <div class="add-form-preview-row"><span class="add-form-preview-row__label">Snapshot</span><span class="add-form-preview-row__value" :class="{ 'add-form-preview-row__value--empty': !selectedSnapshot }">{{ selectedSnapshot ? snapshotOptionLabel(selectedSnapshot) : '—' }}</span></div>
-                <div class="add-form-preview-row"><span class="add-form-preview-row__label">Files and Folders</span><span class="add-form-preview-row__value" :class="{ 'add-form-preview-row__value--empty': !sourceScopes.length }">{{ selectedScopeSummary }}</span></div>
+                <h3 class="add-form-preview-section__title">
+                  Data Source
+                </h3>
+                <div class="add-form-preview-row">
+                  <span class="add-form-preview-row__label">Backup Source</span><span
+                    class="add-form-preview-row__value"
+                    :class="{ 'add-form-preview-row__value--empty': !selectedBackupSource }"
+                  >{{ selectedBackupSource?.label || '—' }}</span>
+                </div>
+                <div class="add-form-preview-row">
+                  <span class="add-form-preview-row__label">{{ t('insight.copilot.dataOriginLabel') }}</span><span class="add-form-preview-row__value">{{ t('insight.copilot.dataOriginProtected') }}</span>
+                </div>
+                <div class="add-form-preview-row">
+                  <span class="add-form-preview-row__label">Snapshot</span><span
+                    class="add-form-preview-row__value"
+                    :class="{ 'add-form-preview-row__value--empty': !selectedSnapshot }"
+                  >{{ selectedSnapshot ? snapshotOptionLabel(selectedSnapshot) : '—' }}</span>
+                </div>
+                <div class="add-form-preview-row">
+                  <span class="add-form-preview-row__label">Files and Folders</span><span
+                    class="add-form-preview-row__value"
+                    :class="{ 'add-form-preview-row__value--empty': !sourceScopes.length }"
+                  >{{ selectedScopeSummary }}</span>
+                </div>
               </section>
               <section class="add-form-preview-section">
-                <h3 class="add-form-preview-section__title">Data Privacy</h3>
-                <div class="add-form-preview-row"><span class="add-form-preview-row__label">{{ t('insight.copilot.gatewayTypeLabel') }}</span><span class="add-form-preview-row__value">{{ gatewayMode === 'auto' ? t('insight.copilot.gatewayTypePublic') : t('insight.copilot.gatewayTypePrivate') }}</span></div>
-                <div class="add-form-preview-row"><span class="add-form-preview-row__label">{{ t('insight.copilot.gatewayNameLabel') }}</span><span class="add-form-preview-row__value" :class="{ 'add-form-preview-row__value--empty': !selectedGateway }">{{ selectedGateway?.name || t('insight.copilot.gatewayNotReady') }}</span></div>
+                <h3 class="add-form-preview-section__title">
+                  Data Privacy
+                </h3>
+                <div class="add-form-preview-row">
+                  <span class="add-form-preview-row__label">{{ t('insight.copilot.gatewayTypeLabel') }}</span><span class="add-form-preview-row__value">{{ gatewayMode === 'auto' ? t('insight.copilot.gatewayTypePublic') : t('insight.copilot.gatewayTypePrivate') }}</span>
+                </div>
+                <div class="add-form-preview-row">
+                  <span class="add-form-preview-row__label">{{ t('insight.copilot.gatewayNameLabel') }}</span><span
+                    class="add-form-preview-row__value"
+                    :class="{ 'add-form-preview-row__value--empty': !selectedGateway }"
+                  >{{ selectedGateway?.name || t('insight.copilot.gatewayNotReady') }}</span>
+                </div>
               </section>
-              <p v-if="!visualModelReady" class="new-chat-visual-warning">
+              <p
+                v-if="!visualModelReady"
+                class="new-chat-visual-warning"
+              >
                 Visual understanding is unavailable. Text documents remain searchable, but images and scanned PDFs may not be readable.
               </p>
             </div>
@@ -498,9 +695,21 @@ onBeforeUnmount(() => backupScopeResizeObserver?.disconnect())
       </div>
 
       <footer class="fullscreen-form-footer">
-        <p v-if="footerSubmitBlockReason" class="form-submit-hint">{{ footerSubmitBlockReason }}</p>
-        <ElButton @click="router.push('/insight/copilot')">Cancel</ElButton>
-        <ElButton type="primary" :loading="submitting" :disabled="!canCreate" @click="createChat">
+        <p
+          v-if="footerSubmitBlockReason"
+          class="form-submit-hint"
+        >
+          {{ footerSubmitBlockReason }}
+        </p>
+        <ElButton @click="router.push('/insight/copilot')">
+          Cancel
+        </ElButton>
+        <ElButton
+          type="primary"
+          :loading="submitting"
+          :disabled="!canCreate"
+          @click="createChat"
+        >
           {{ submitting ? 'Starting Chat…' : 'Start Chat' }}
         </ElButton>
       </footer>

--- a/src/frontend/src/pages/insight/SkillFormPage.vue
+++ b/src/frontend/src/pages/insight/SkillFormPage.vue
@@ -148,26 +148,57 @@ watch(
 </script>
 
 <template>
-  <div ref="pageRef" class="fullscreen-form-fullscreen resource-add-fullscreen skill-form-fullscreen">
+  <div
+    ref="pageRef"
+    class="fullscreen-form-fullscreen resource-add-fullscreen skill-form-fullscreen"
+  >
     <div class="fullscreen-form-page">
       <header class="fullscreen-form-header">
-        <button type="button" class="fullscreen-form-header__back" @click="handleBack">
-          <ArrowLeft class="fullscreen-form-header__back-icon" :size="18" />
+        <button
+          type="button"
+          class="fullscreen-form-header__back"
+          @click="handleBack"
+        >
+          <ArrowLeft
+            class="fullscreen-form-header__back-icon"
+            :size="18"
+          />
         </button>
         <div class="fullscreen-form-header__content">
-          <h1 class="fullscreen-form-header__title">{{ pageTitle }}</h1>
-          <p class="fullscreen-form-header__desc">{{ pageDesc }}</p>
+          <h1 class="fullscreen-form-header__title">
+            {{ pageTitle }}
+          </h1>
+          <p class="fullscreen-form-header__desc">
+            {{ pageDesc }}
+          </p>
         </div>
       </header>
 
-      <div v-loading="loading" class="fullscreen-form-layout">
+      <div
+        v-loading="loading"
+        class="fullscreen-form-layout"
+      >
         <div class="fullscreen-form-main">
           <div class="fullscreen-form-step-stack">
             <section class="fullscreen-form-card fullscreen-form-section">
-              <ElForm label-position="top" class="fullscreen-form-el-form">
-                <ElFormItem data-validation-field="name" :error="errors.name" :label="t('insight.skills.fieldName')" required>
-                  <ElInput v-model="name" :placeholder="t('insight.skills.fieldNamePh')" @input="clearFieldError('name')" />
-                  <p class="skill-field-hint">{{ t('insight.skills.fieldNameHint') }}</p>
+              <ElForm
+                label-position="top"
+                class="fullscreen-form-el-form"
+              >
+                <ElFormItem
+                  data-validation-field="name"
+                  :error="errors.name"
+                  :label="t('insight.skills.fieldName')"
+                  required
+                >
+                  <ElInput
+                    v-model="name"
+                    :placeholder="t('insight.skills.fieldNamePh')"
+                    @input="clearFieldError('name')"
+                  />
+                  <p class="skill-field-hint">
+                    {{ t('insight.skills.fieldNameHint') }}
+                  </p>
                 </ElFormItem>
 
                 <ElFormItem :label="t('insight.skills.fieldDescription')">
@@ -175,10 +206,16 @@ watch(
                     v-model="description"
                     :placeholder="t('insight.skills.fieldDescriptionPh')"
                   />
-                  <p class="skill-field-hint">{{ t('insight.skills.fieldDescriptionHint') }}</p>
+                  <p class="skill-field-hint">
+                    {{ t('insight.skills.fieldDescriptionHint') }}
+                  </p>
                 </ElFormItem>
 
-                <ElFormItem data-validation-field="content" :error="errors.content" required>
+                <ElFormItem
+                  data-validation-field="content"
+                  :error="errors.content"
+                  required
+                >
                   <template #label>
                     <span class="skill-content-label">
                       <span>{{ t('insight.skills.fieldContent') }}</span>
@@ -193,7 +230,9 @@ watch(
                       </ElButton>
                     </span>
                   </template>
-                  <p class="skill-beautify-hint">{{ t('insight.skills.beautifyHint') }}</p>
+                  <p class="skill-beautify-hint">
+                    {{ t('insight.skills.beautifyHint') }}
+                  </p>
                   <ElInput
                     v-model="content"
                     type="textarea"
@@ -202,12 +241,16 @@ watch(
                     class="skill-content-textarea"
                     @input="clearFieldError('content')"
                   />
-                  <p class="skill-field-hint">{{ t('insight.skills.fieldContentHint') }}</p>
+                  <p class="skill-field-hint">
+                    {{ t('insight.skills.fieldContentHint') }}
+                  </p>
                 </ElFormItem>
 
                 <ElFormItem :label="t('insight.skills.fieldEnabled')">
                   <ElSwitch v-model="enabled" />
-                  <p class="skill-field-hint">{{ t('insight.skills.fieldEnabledHint') }}</p>
+                  <p class="skill-field-hint">
+                    {{ t('insight.skills.fieldEnabledHint') }}
+                  </p>
                 </ElFormItem>
               </ElForm>
             </section>

--- a/src/frontend/src/pages/insight/copilot/CopilotAssistantPickerDialog.vue
+++ b/src/frontend/src/pages/insight/copilot/CopilotAssistantPickerDialog.vue
@@ -114,7 +114,9 @@ function confirm() {
     destroy-on-close
     @update:model-value="openChanged"
   >
-    <p class="source-action-dialog__hint">{{ t('insight.copilot.pickAssistantHint') }}</p>
+    <p class="source-action-dialog__hint">
+      {{ t('insight.copilot.pickAssistantHint') }}
+    </p>
 
     <div class="copilot-assistant-picker-dialog__toolbar">
       <ElInput
@@ -124,12 +126,19 @@ function confirm() {
         :placeholder="t('insight.copilot.assistantSearchPlaceholder')"
       >
         <template #prefix>
-          <Search :size="16" class="hfl-list-search__icon" />
+          <Search
+            :size="16"
+            class="hfl-list-search__icon"
+          />
         </template>
       </ElInput>
     </div>
 
-    <div class="copilot-assistant-picker-dialog__list" role="listbox" :aria-label="t('insight.copilot.pickAssistant')">
+    <div
+      class="copilot-assistant-picker-dialog__list"
+      role="listbox"
+      :aria-label="t('insight.copilot.pickAssistant')"
+    >
       <button
         v-for="row in filtered"
         :key="row.uuid"
@@ -140,18 +149,30 @@ function confirm() {
         :aria-selected="draftUuid === row.uuid"
         @click="draftUuid = row.uuid"
       >
-        <span class="copilot-assistant-picker-card__indicator" aria-hidden="true" />
+        <span
+          class="copilot-assistant-picker-card__indicator"
+          aria-hidden="true"
+        />
         <span class="copilot-assistant-picker-card__body">
           <span class="copilot-assistant-picker-card__head">
             <span class="copilot-assistant-picker-card__identity">
-              <span class="copilot-assistant-picker-card__type" aria-hidden="true">
+              <span
+                class="copilot-assistant-picker-card__type"
+                aria-hidden="true"
+              >
                 <Bot :size="15" />
               </span>
-              <span class="copilot-assistant-picker-card__title" :title="displayName(row)">
+              <span
+                class="copilot-assistant-picker-card__title"
+                :title="displayName(row)"
+              >
                 {{ displayName(row) }}
               </span>
             </span>
-            <span v-if="row.knowledge_source_status" class="copilot-assistant-picker-card__badges">
+            <span
+              v-if="row.knowledge_source_status"
+              class="copilot-assistant-picker-card__badges"
+            >
               <span :class="ksStatusPillClass(row.knowledge_source_status)">
                 {{ ksStatusLabel(row.knowledge_source_status) }}
               </span>
@@ -203,17 +224,29 @@ function confirm() {
         </span>
       </button>
 
-      <div v-if="!availableAssistants.length" class="copilot-assistant-picker-dialog__empty">
+      <div
+        v-if="!availableAssistants.length"
+        class="copilot-assistant-picker-dialog__empty"
+      >
         {{ t('insight.copilot.assistantPickerAvailableEmpty') }}
       </div>
-      <div v-else-if="!filtered.length" class="copilot-assistant-picker-dialog__empty">
+      <div
+        v-else-if="!filtered.length"
+        class="copilot-assistant-picker-dialog__empty"
+      >
         {{ t('insight.copilot.assistantSearchEmpty') }}
       </div>
     </div>
 
     <template #footer>
-      <ElButton @click="emit('update:open', false)">{{ t('common.cancel') }}</ElButton>
-      <ElButton type="primary" :disabled="!draftUuid" @click="confirm">
+      <ElButton @click="emit('update:open', false)">
+        {{ t('common.cancel') }}
+      </ElButton>
+      <ElButton
+        type="primary"
+        :disabled="!draftUuid"
+        @click="confirm"
+      >
         {{ t('insight.copilot.btnStartChat') }}
       </ElButton>
     </template>

--- a/src/frontend/src/pages/insight/copilot/CopilotBindingSetup.vue
+++ b/src/frontend/src/pages/insight/copilot/CopilotBindingSetup.vue
@@ -120,9 +120,17 @@ onMounted(() => {
       <p>{{ t('insight.copilot.bindingDesc') }}</p>
     </header>
 
-    <el-form v-loading="loading" label-position="top" class="copilot-binding-setup__form">
+    <el-form
+      v-loading="loading"
+      label-position="top"
+      class="copilot-binding-setup__form"
+    >
       <el-form-item :label="t('insight.copilot.bindingBackupSource')">
-        <el-select v-model="backupConfigId" filterable style="width: 100%">
+        <el-select
+          v-model="backupConfigId"
+          filterable
+          style="width: 100%"
+        >
           <el-option
             v-for="row in backupConfigs"
             :key="row.id"
@@ -165,8 +173,15 @@ onMounted(() => {
       </el-form-item>
 
       <el-form-item :label="t('insight.copilot.bindingGateway')">
-        <el-select v-model="gatewayLinkId" clearable style="width: 100%">
-          <el-option :label="t('insight.copilot.bindingGatewayAuto')" :value="null" />
+        <el-select
+          v-model="gatewayLinkId"
+          clearable
+          style="width: 100%"
+        >
+          <el-option
+            :label="t('insight.copilot.bindingGatewayAuto')"
+            :value="null"
+          />
           <el-option
             v-for="row in gatewayOptions"
             :key="row.gateway_link_id"
@@ -176,7 +191,11 @@ onMounted(() => {
         </el-select>
       </el-form-item>
 
-      <el-button type="primary" :loading="submitting" @click="submit">
+      <el-button
+        type="primary"
+        :loading="submitting"
+        @click="submit"
+      >
         {{ submitting ? t('insight.copilot.bindingSubmitting') : t('insight.copilot.bindingSubmit') }}
       </el-button>
     </el-form>

--- a/src/frontend/src/pages/insight/copilot/CopilotComposer.vue
+++ b/src/frontend/src/pages/insight/copilot/CopilotComposer.vue
@@ -42,7 +42,10 @@ watch(
 
 <template>
   <footer class="copilot-composer">
-    <div class="copilot-input-shell" :class="{ 'is-disabled': disabled }">
+    <div
+      class="copilot-input-shell"
+      :class="{ 'is-disabled': disabled }"
+    >
       <textarea
         ref="fieldRef"
         :value="modelValue"
@@ -71,11 +74,16 @@ watch(
         :title="t('insight.copilot.send')"
         @click="emit('send')"
       >
-        <ArrowUp :size="18" :stroke-width="2.25" />
+        <ArrowUp
+          :size="18"
+          :stroke-width="2.25"
+        />
       </button>
     </div>
 
-    <p class="copilot-disclaimer">{{ t('insight.copilot.disclaimer') }}</p>
+    <p class="copilot-disclaimer">
+      {{ t('insight.copilot.disclaimer') }}
+    </p>
   </footer>
 </template>
 

--- a/src/frontend/src/pages/insight/copilot/CopilotContextBar.vue
+++ b/src/frontend/src/pages/insight/copilot/CopilotContextBar.vue
@@ -102,16 +102,34 @@ function openBackupDetail() {
   <header class="copilot-context-bar">
     <div class="copilot-context-bar__top">
       <div class="copilot-context-bar__identity">
-        <MessageSquare :size="16" class="copilot-context-bar__icon" aria-hidden="true" />
-        <h1 :title="session.title">{{ session.title }}</h1>
-        <span class="copilot-context-bar__status" :class="statusClass"><i />{{ statusLabel }}</span>
+        <MessageSquare
+          :size="16"
+          class="copilot-context-bar__icon"
+          aria-hidden="true"
+        />
+        <h1 :title="session.title">
+          {{ session.title }}
+        </h1>
+        <span
+          class="copilot-context-bar__status"
+          :class="statusClass"
+        ><i />{{ statusLabel }}</span>
       </div>
     </div>
 
-    <div class="copilot-context-bar__summary" :title="`${originLabel} · ${sourceName} · ${firstPath} · ${processingLabel} · Created ${createdShort}`">
+    <div
+      class="copilot-context-bar__summary"
+      :title="`${originLabel} · ${sourceName} · ${firstPath} · ${processingLabel} · Created ${createdShort}`"
+    >
       <span class="copilot-context-bar__origin">{{ originLabel }}</span><em>·</em>
       <span class="copilot-context-bar__source">{{ sourceName }}</span><em>·</em>
-      <button type="button" class="copilot-context-bar__path" @click="detailsOpen = true">{{ firstPath }}<b v-if="additionalPathCount"> +{{ additionalPathCount }}</b></button><em>·</em>
+      <button
+        type="button"
+        class="copilot-context-bar__path"
+        @click="detailsOpen = true"
+      >
+        {{ firstPath }}<b v-if="additionalPathCount"> +{{ additionalPathCount }}</b>
+      </button><em>·</em>
       <span class="copilot-context-bar__gateway">{{ processingLabel }}</span><em>·</em>
       <span class="copilot-context-bar__created">Created {{ createdShort }}</span>
     </div>
@@ -121,53 +139,136 @@ function openBackupDetail() {
       role="status"
       aria-live="polite"
     >
-      <TriangleAlert :size="13" aria-hidden="true" />
+      <TriangleAlert
+        :size="13"
+        aria-hidden="true"
+      />
       <span>Visual understanding is unavailable. Images and scanned PDFs may not be searchable.</span>
     </div>
   </header>
 
-  <ElDialog v-model="detailsOpen" :title="t('insight.copilot.chatDetailsTitle')" width="560px" append-to-body>
+  <ElDialog
+    v-model="detailsOpen"
+    :title="t('insight.copilot.chatDetailsTitle')"
+    width="560px"
+    append-to-body
+  >
     <div class="copilot-details">
       <section>
         <h3>{{ t('insight.copilot.detailsDataSource') }}</h3>
         <dl><dt>{{ t('insight.copilot.dataOriginLabel') }}</dt><dd>{{ originLabel }}</dd></dl>
         <dl><dt>{{ t('insight.kb.fieldBackupSource') }}</dt><dd>{{ sourceName }}</dd></dl>
-        <dl><dt>{{ t('insight.kb.fieldSnapshot') }}</dt><dd :class="{ 'hfl-empty-mark': !session.snapshot_created_at }">{{ session.snapshot_created_at ? formatLocalDateTime(session.snapshot_created_at) : '—' }}</dd></dl>
-        <dl><dt>{{ t('insight.copilot.snapshotSizeLabel') }}</dt><dd :class="{ 'hfl-empty-mark': session.snapshot_size_bytes == null }">{{ session.snapshot_size_bytes != null ? formatBytes(session.snapshot_size_bytes) : '—' }}</dd></dl>
-        <div v-if="dataContext?.restore_path || dataContext?.backup_detail_path" class="copilot-details__actions">
-          <ElButton v-if="dataContext?.restore_path" size="small" @click="openRestore">{{ t('insight.copilot.openSnapshotRestore') }}</ElButton>
-          <ElButton v-if="dataContext?.backup_detail_path" size="small" @click="openBackupDetail">{{ t('insight.copilot.openBackupDetail') }}</ElButton>
+        <dl>
+          <dt>{{ t('insight.kb.fieldSnapshot') }}</dt><dd :class="{ 'hfl-empty-mark': !session.snapshot_created_at }">
+            {{ session.snapshot_created_at ? formatLocalDateTime(session.snapshot_created_at) : '—' }}
+          </dd>
+        </dl>
+        <dl>
+          <dt>{{ t('insight.copilot.snapshotSizeLabel') }}</dt><dd :class="{ 'hfl-empty-mark': session.snapshot_size_bytes == null }">
+            {{ session.snapshot_size_bytes != null ? formatBytes(session.snapshot_size_bytes) : '—' }}
+          </dd>
+        </dl>
+        <div
+          v-if="dataContext?.restore_path || dataContext?.backup_detail_path"
+          class="copilot-details__actions"
+        >
+          <ElButton
+            v-if="dataContext?.restore_path"
+            size="small"
+            @click="openRestore"
+          >
+            {{ t('insight.copilot.openSnapshotRestore') }}
+          </ElButton>
+          <ElButton
+            v-if="dataContext?.backup_detail_path"
+            size="small"
+            @click="openBackupDetail"
+          >
+            {{ t('insight.copilot.openBackupDetail') }}
+          </ElButton>
         </div>
       </section>
       <section>
         <h3>{{ t('insight.copilot.detailsFilesFolders') }}</h3>
-        <ol><li v-for="(scope, index) in scopes" :key="`${scope.backup_snapshot_directory_id}-${index}`">{{ scope.source_path }}</li></ol>
+        <ol>
+          <li
+            v-for="(scope, index) in scopes"
+            :key="`${scope.backup_snapshot_directory_id}-${index}`"
+          >
+            {{ scope.source_path }}
+          </li>
+        </ol>
       </section>
       <section>
         <h3>{{ t('insight.copilot.detailsProcessingLocation') }}</h3>
         <dl><dt>{{ t('insight.copilot.gatewayTypeLabel') }}</dt><dd>{{ compactGatewayType }}</dd></dl>
-        <dl><dt>{{ t('insight.copilot.gatewayNameLabel') }}</dt><dd :class="{ 'hfl-empty-mark': !session.gateway_name }">{{ session.gateway_name || '—' }}</dd></dl>
-        <p class="copilot-details__note">{{ t('insight.copilot.processingLocationNote') }}</p>
+        <dl>
+          <dt>{{ t('insight.copilot.gatewayNameLabel') }}</dt><dd :class="{ 'hfl-empty-mark': !session.gateway_name }">
+            {{ session.gateway_name || '—' }}
+          </dd>
+        </dl>
+        <p class="copilot-details__note">
+          {{ t('insight.copilot.processingLocationNote') }}
+        </p>
       </section>
       <section v-if="conversion">
         <h3>{{ t('insight.copilot.documentConversionTitle') }}</h3>
-        <dl v-if="conversionLabel"><dt>{{ t('insight.copilot.documentConversionSummary') }}</dt><dd>{{ conversionLabel }}</dd></dl>
-        <p v-if="conversion?.error" class="copilot-details__note">{{ conversion.error }}</p>
-        <ul v-if="problemItems.length" class="copilot-details__problems">
-          <li v-for="(item, index) in problemItems" :key="`${item.name}-${index}`">
+        <dl v-if="conversionLabel">
+          <dt>{{ t('insight.copilot.documentConversionSummary') }}</dt><dd>{{ conversionLabel }}</dd>
+        </dl>
+        <p
+          v-if="conversion?.error"
+          class="copilot-details__note"
+        >
+          {{ conversion.error }}
+        </p>
+        <ul
+          v-if="problemItems.length"
+          class="copilot-details__problems"
+        >
+          <li
+            v-for="(item, index) in problemItems"
+            :key="`${item.name}-${index}`"
+          >
             <strong>{{ item.name }}</strong>
             <span>{{ item.reason_label }}</span>
           </li>
         </ul>
-        <ul v-if="conversionWarnings.length" class="copilot-details__problems">
-          <li v-for="(warning, index) in conversionWarnings" :key="`${warning.code}-${index}`">
+        <ul
+          v-if="conversionWarnings.length"
+          class="copilot-details__problems"
+        >
+          <li
+            v-for="(warning, index) in conversionWarnings"
+            :key="`${warning.code}-${index}`"
+          >
             <span>{{ warning.label || warning.code }}</span>
           </li>
         </ul>
-        <p v-if="!problemItems.length && conversionOk" class="copilot-details__note">{{ t('insight.copilot.documentConversionOk') }}</p>
-        <p v-else-if="!problemItems.length && conversionEmpty" class="copilot-details__note">{{ t('insight.copilot.documentConversionEmpty') }}</p>
-        <p v-else-if="!problemItems.length && conversionRunning" class="copilot-details__note">{{ t('insight.copilot.documentConversionRunning') }}</p>
-        <p v-else-if="!problemItems.length && (conversionFailed || (conversionLabel && !conversionOk))" class="copilot-details__note">{{ t('insight.copilot.documentConversionPartial') }}</p>
+        <p
+          v-if="!problemItems.length && conversionOk"
+          class="copilot-details__note"
+        >
+          {{ t('insight.copilot.documentConversionOk') }}
+        </p>
+        <p
+          v-else-if="!problemItems.length && conversionEmpty"
+          class="copilot-details__note"
+        >
+          {{ t('insight.copilot.documentConversionEmpty') }}
+        </p>
+        <p
+          v-else-if="!problemItems.length && conversionRunning"
+          class="copilot-details__note"
+        >
+          {{ t('insight.copilot.documentConversionRunning') }}
+        </p>
+        <p
+          v-else-if="!problemItems.length && (conversionFailed || (conversionLabel && !conversionOk))"
+          class="copilot-details__note"
+        >
+          {{ t('insight.copilot.documentConversionPartial') }}
+        </p>
       </section>
     </div>
   </ElDialog>

--- a/src/frontend/src/pages/insight/copilot/CopilotEmptyState.vue
+++ b/src/frontend/src/pages/insight/copilot/CopilotEmptyState.vue
@@ -31,26 +31,50 @@ const { t } = useI18n()
 </script>
 
 <template>
-  <div v-loading="phase === 'loading'" class="copilot-empty-state flex min-h-0 flex-1 flex-col items-center justify-center px-6 py-10">
+  <div
+    v-loading="phase === 'loading'"
+    class="copilot-empty-state flex min-h-0 flex-1 flex-col items-center justify-center px-6 py-10"
+  >
     <template v-if="phase === 'network_error'">
       <div class="empty-card">
         <div class="empty-icon empty-icon--error">
           <Network :size="28" />
         </div>
-        <h2 class="empty-title">{{ t('insight.copilot.emptyNetworkTitle') }}</h2>
-        <p class="empty-desc">{{ t('insight.copilot.emptyNetworkDesc') }}</p>
-        <ElButton type="primary" @click="emit('retry')">{{ t('insight.copilot.btnRetry') }}</ElButton>
+        <h2 class="empty-title">
+          {{ t('insight.copilot.emptyNetworkTitle') }}
+        </h2>
+        <p class="empty-desc">
+          {{ t('insight.copilot.emptyNetworkDesc') }}
+        </p>
+        <ElButton
+          type="primary"
+          @click="emit('retry')"
+        >
+          {{ t('insight.copilot.btnRetry') }}
+        </ElButton>
       </div>
     </template>
 
     <template v-else-if="phase === 'bridge_not_ready'">
       <div class="empty-card">
         <div class="empty-icon empty-icon--offline">
-          <CloudOff :size="26" stroke-width="1.75" />
+          <CloudOff
+            :size="26"
+            stroke-width="1.75"
+          />
         </div>
-        <h2 class="empty-title">{{ t('insight.copilot.emptyBridgeTitle') }}</h2>
-        <p class="empty-desc">{{ t('insight.shared.bridgeNotReady') }}</p>
-        <ElButton type="primary" @click="emit('retry')">{{ t('insight.copilot.btnRetry') }}</ElButton>
+        <h2 class="empty-title">
+          {{ t('insight.copilot.emptyBridgeTitle') }}
+        </h2>
+        <p class="empty-desc">
+          {{ t('insight.shared.bridgeNotReady') }}
+        </p>
+        <ElButton
+          type="primary"
+          @click="emit('retry')"
+        >
+          {{ t('insight.copilot.btnRetry') }}
+        </ElButton>
       </div>
     </template>
 
@@ -59,8 +83,12 @@ const { t } = useI18n()
         <div class="empty-icon empty-icon--primary">
           <Sparkles :size="28" />
         </div>
-        <h2 class="empty-title">{{ t('insight.copilot.onboardingTitle') }}</h2>
-        <p class="empty-desc">{{ t('insight.copilot.onboardingSubtitle') }}</p>
+        <h2 class="empty-title">
+          {{ t('insight.copilot.onboardingTitle') }}
+        </h2>
+        <p class="empty-desc">
+          {{ t('insight.copilot.onboardingSubtitle') }}
+        </p>
 
         <ElButton
           type="primary"

--- a/src/frontend/src/pages/insight/copilot/CopilotKsPickerDialog.vue
+++ b/src/frontend/src/pages/insight/copilot/CopilotKsPickerDialog.vue
@@ -79,7 +79,9 @@ function confirm() {
     destroy-on-close
     @update:model-value="openChanged"
   >
-    <p class="source-action-dialog__hint">{{ t('insight.copilot.pickKnowledgeSourceHint') }}</p>
+    <p class="source-action-dialog__hint">
+      {{ t('insight.copilot.pickKnowledgeSourceHint') }}
+    </p>
 
     <ElInput
       v-model="query"
@@ -88,11 +90,18 @@ function confirm() {
       :placeholder="t('insight.copilot.contextSearchPlaceholder')"
     >
       <template #prefix>
-        <Search :size="16" class="hfl-list-search__icon" />
+        <Search
+          :size="16"
+          class="hfl-list-search__icon"
+        />
       </template>
     </ElInput>
 
-    <div class="copilot-ks-picker-dialog__list" role="listbox" :aria-label="t('insight.copilot.pickKnowledgeSource')">
+    <div
+      class="copilot-ks-picker-dialog__list"
+      role="listbox"
+      :aria-label="t('insight.copilot.pickKnowledgeSource')"
+    >
       <button
         v-for="row in filtered"
         :key="row.id"
@@ -103,19 +112,34 @@ function confirm() {
         :aria-selected="draftId === row.id"
         @click="draftId = row.id"
       >
-        <span class="copilot-ks-picker-card__indicator" aria-hidden="true" />
+        <span
+          class="copilot-ks-picker-card__indicator"
+          aria-hidden="true"
+        />
         <span class="copilot-ks-picker-card__body">
           <span class="copilot-ks-picker-card__head">
-            <span class="copilot-ks-picker-card__type" aria-hidden="true">
-              <BookOpen v-if="isBackupSource(row)" :size="14" />
-              <FolderOpen v-else :size="14" />
+            <span
+              class="copilot-ks-picker-card__type"
+              aria-hidden="true"
+            >
+              <BookOpen
+                v-if="isBackupSource(row)"
+                :size="14"
+              />
+              <FolderOpen
+                v-else
+                :size="14"
+              />
             </span>
             <span class="copilot-ks-picker-card__title">{{ row.name }}</span>
           </span>
           <span class="copilot-ks-picker-card__meta">
             <span class="copilot-ks-picker-card__gateway">{{ row.gateway_name }}</span>
             <span class="copilot-ks-picker-card__sep">·</span>
-            <span class="copilot-ks-picker-card__path" :title="row.source_path">{{ row.source_path }}</span>
+            <span
+              class="copilot-ks-picker-card__path"
+              :title="row.source_path"
+            >{{ row.source_path }}</span>
           </span>
           <span class="copilot-ks-picker-card__tags">
             <span :class="statusPillClass(row.status)">{{ statusLabel(row.status) }}</span>
@@ -129,14 +153,23 @@ function confirm() {
         </span>
       </button>
 
-      <div v-if="!filtered.length" class="copilot-ks-picker-dialog__empty">
+      <div
+        v-if="!filtered.length"
+        class="copilot-ks-picker-dialog__empty"
+      >
         {{ t('insight.copilot.contextSearchEmpty') }}
       </div>
     </div>
 
     <template #footer>
-      <ElButton @click="emit('update:open', false)">{{ t('common.cancel') }}</ElButton>
-      <ElButton type="primary" :disabled="draftId == null" @click="confirm">
+      <ElButton @click="emit('update:open', false)">
+        {{ t('common.cancel') }}
+      </ElButton>
+      <ElButton
+        type="primary"
+        :disabled="draftId == null"
+        @click="confirm"
+      >
         {{ t('insight.copilot.btnStartChat') }}
       </ElButton>
     </template>

--- a/src/frontend/src/pages/insight/copilot/CopilotLifecycleState.vue
+++ b/src/frontend/src/pages/insight/copilot/CopilotLifecycleState.vue
@@ -86,39 +86,88 @@ function stepState(index: number) {
 
 <template>
   <main class="copilot-lifecycle-state">
-    <div v-if="session.lifecycle_status === 'failed'" class="copilot-lifecycle-card is-failed">
+    <div
+      v-if="session.lifecycle_status === 'failed'"
+      class="copilot-lifecycle-card is-failed"
+    >
       <span class="copilot-lifecycle-icon is-failed"><AlertCircle :size="30" /></span>
       <h2>We Couldn't Prepare This Chat</h2>
       <p>Something went wrong while preparing the selected data. Try again, or delete this chat and create a new one.</p>
-      <div v-if="showFailedConversionPanel" class="copilot-conversion copilot-conversion--failed">
-        <p v-if="countsLabel" class="copilot-conversion__counts">{{ countsLabel }}</p>
-        <p v-if="conversion?.error" class="copilot-conversion__detail">{{ conversion.error }}</p>
-        <ul v-if="problemItems.length" class="copilot-conversion__list">
-          <li v-for="(item, index) in problemItems" :key="`${item.name}-${index}`">
+      <div
+        v-if="showFailedConversionPanel"
+        class="copilot-conversion copilot-conversion--failed"
+      >
+        <p
+          v-if="countsLabel"
+          class="copilot-conversion__counts"
+        >
+          {{ countsLabel }}
+        </p>
+        <p
+          v-if="conversion?.error"
+          class="copilot-conversion__detail"
+        >
+          {{ conversion.error }}
+        </p>
+        <ul
+          v-if="problemItems.length"
+          class="copilot-conversion__list"
+        >
+          <li
+            v-for="(item, index) in problemItems"
+            :key="`${item.name}-${index}`"
+          >
             <strong>{{ item.name }}</strong>
             <span>{{ item.reason_label }}</span>
           </li>
         </ul>
-        <ul v-if="conversionWarnings.length" class="copilot-conversion__list">
-          <li v-for="(warning, index) in conversionWarnings" :key="`${warning.code}-${index}`">
+        <ul
+          v-if="conversionWarnings.length"
+          class="copilot-conversion__list"
+        >
+          <li
+            v-for="(warning, index) in conversionWarnings"
+            :key="`${warning.code}-${index}`"
+          >
             <span>{{ warning.label || warning.code }}</span>
           </li>
         </ul>
       </div>
       <div class="copilot-lifecycle-actions">
-        <ElButton @click="emit('delete')">Delete Chat</ElButton>
-        <ElButton type="primary" @click="emit('retry')">Try Again</ElButton>
+        <ElButton @click="emit('delete')">
+          Delete Chat
+        </ElButton>
+        <ElButton
+          type="primary"
+          @click="emit('retry')"
+        >
+          Try Again
+        </ElButton>
       </div>
     </div>
 
-    <div v-else-if="session.lifecycle_status === 'deleting'" class="copilot-lifecycle-card">
-      <span class="copilot-lifecycle-icon"><LoaderCircle :size="30" class="copilot-lifecycle-spin" /></span>
+    <div
+      v-else-if="session.lifecycle_status === 'deleting'"
+      class="copilot-lifecycle-card"
+    >
+      <span class="copilot-lifecycle-icon"><LoaderCircle
+        :size="30"
+        class="copilot-lifecycle-spin"
+      /></span>
       <h2>Deleting Chat</h2>
       <p>The chat and its temporary data are being removed.</p>
     </div>
 
-    <div v-else class="copilot-lifecycle-card" :class="{ 'has-conversion': showConversionPanel }">
-      <div class="copilot-lifecycle-heading" role="status" aria-live="polite">
+    <div
+      v-else
+      class="copilot-lifecycle-card"
+      :class="{ 'has-conversion': showConversionPanel }"
+    >
+      <div
+        class="copilot-lifecycle-heading"
+        role="status"
+        aria-live="polite"
+      >
         <span class="copilot-lifecycle-icon"><Sparkles :size="25" /></span>
         <div>
           <h2>Preparing Your Chat</h2>
@@ -127,48 +176,119 @@ function stepState(index: number) {
       </div>
 
       <div class="copilot-lifecycle-body">
-        <ol class="copilot-lifecycle-steps" aria-label="Chat preparation progress">
-          <li v-for="(step, index) in steps" :key="step.label" :class="`is-${stepState(index)}`">
+        <ol
+          class="copilot-lifecycle-steps"
+          aria-label="Chat preparation progress"
+        >
+          <li
+            v-for="(step, index) in steps"
+            :key="step.label"
+            :class="`is-${stepState(index)}`"
+          >
             <span>
-              <Check v-if="stepState(index) === 'done'" :size="14" />
-              <LoaderCircle v-else-if="stepState(index) === 'active'" :size="14" class="copilot-lifecycle-spin" />
-              <Circle v-else :size="12" />
+              <Check
+                v-if="stepState(index) === 'done'"
+                :size="14"
+              />
+              <LoaderCircle
+                v-else-if="stepState(index) === 'active'"
+                :size="14"
+                class="copilot-lifecycle-spin"
+              />
+              <Circle
+                v-else
+                :size="12"
+              />
             </span>
             {{ step.label }}
           </li>
         </ol>
 
-        <section v-if="showConversionPanel" class="copilot-conversion" aria-label="Document preparation details">
+        <section
+          v-if="showConversionPanel"
+          class="copilot-conversion"
+          aria-label="Document preparation details"
+        >
           <span class="copilot-conversion__eyebrow">Document preparation</span>
-          <p v-if="conversionDetail" class="copilot-conversion__detail">{{ conversionDetail }}</p>
-          <p v-else-if="showRunningMessage" class="copilot-conversion__detail">{{ t('insight.copilot.documentConversionRunning') }}</p>
-          <p v-if="countsLabel" class="copilot-conversion__counts">{{ countsLabel }}</p>
+          <p
+            v-if="conversionDetail"
+            class="copilot-conversion__detail"
+          >
+            {{ conversionDetail }}
+          </p>
+          <p
+            v-else-if="showRunningMessage"
+            class="copilot-conversion__detail"
+          >
+            {{ t('insight.copilot.documentConversionRunning') }}
+          </p>
+          <p
+            v-if="countsLabel"
+            class="copilot-conversion__counts"
+          >
+            {{ countsLabel }}
+          </p>
 
-          <details v-if="attentionCount || showFormatHint" class="copilot-conversion__details">
+          <details
+            v-if="attentionCount || showFormatHint"
+            class="copilot-conversion__details"
+          >
             <summary>
-              <span class="copilot-conversion__summary-icon" :class="{ 'has-attention': attentionCount }">
-                <TriangleAlert v-if="attentionCount" :size="14" />
-                <Circle v-else :size="12" />
+              <span
+                class="copilot-conversion__summary-icon"
+                :class="{ 'has-attention': attentionCount }"
+              >
+                <TriangleAlert
+                  v-if="attentionCount"
+                  :size="14"
+                />
+                <Circle
+                  v-else
+                  :size="12"
+                />
               </span>
               <span>{{ attentionLabel }}</span>
-              <ChevronDown :size="15" class="copilot-conversion__chevron" />
+              <ChevronDown
+                :size="15"
+                class="copilot-conversion__chevron"
+              />
             </summary>
             <div class="copilot-conversion__details-body">
-              <ul v-if="problemItems.length" class="copilot-conversion__list">
-                <li v-for="(item, index) in problemItems" :key="`${item.name}-${index}`">
+              <ul
+                v-if="problemItems.length"
+                class="copilot-conversion__list"
+              >
+                <li
+                  v-for="(item, index) in problemItems"
+                  :key="`${item.name}-${index}`"
+                >
                   <strong>{{ item.name }}</strong>
                   <span>{{ item.reason_label }}</span>
                 </li>
               </ul>
-              <p v-if="allProblemItems.length > problemItems.length" class="copilot-conversion__more">
+              <p
+                v-if="allProblemItems.length > problemItems.length"
+                class="copilot-conversion__more"
+              >
                 {{ allProblemItems.length - problemItems.length }} more files are available in Chat Details.
               </p>
-              <ul v-if="conversionWarnings.length" class="copilot-conversion__list is-warnings">
-                <li v-for="(warning, index) in conversionWarnings" :key="`${warning.code}-${index}`">
+              <ul
+                v-if="conversionWarnings.length"
+                class="copilot-conversion__list is-warnings"
+              >
+                <li
+                  v-for="(warning, index) in conversionWarnings"
+                  :key="`${warning.code}-${index}`"
+                >
                   <span>{{ warning.label || warning.code }}</span>
                 </li>
               </ul>
-              <p v-if="showFormatHint" class="copilot-conversion__hint">{{ t('insight.copilot.documentFormatHint') }}</p>
+              <p
+                v-if="showFormatHint"
+                class="copilot-conversion__hint"
+              >
+                {{ t('insight.copilot.documentFormatHint') }}
+              </p>
             </div>
           </details>
         </section>

--- a/src/frontend/src/pages/insight/copilot/CopilotMessageList.vue
+++ b/src/frontend/src/pages/insight/copilot/CopilotMessageList.vue
@@ -231,8 +231,15 @@ const showLiveRow = computed(() => props.streaming)
 
 <template>
   <div class="chat-scroll-shell min-h-0 flex-1">
-    <div ref="chatScrollRef" class="chat-scroll h-full overflow-y-auto" @scroll="syncFollowState">
-      <div ref="copilotThreadRef" class="copilot-thread">
+    <div
+      ref="chatScrollRef"
+      class="chat-scroll h-full overflow-y-auto"
+      @scroll="syncFollowState"
+    >
+      <div
+        ref="copilotThreadRef"
+        class="copilot-thread"
+      >
         <div
           v-for="msg in messages"
           :key="msg.id"
@@ -250,8 +257,15 @@ const showLiveRow = computed(() => props.streaming)
               msg.role === 'user' ? t('insight.copilot.roleUser') : t('insight.copilot.roleAi')
             "
           >
-            <span v-if="msg.role === 'user'" class="message-avatar-initial">{{ userInitial }}</span>
-            <Sparkles v-else :size="16" :stroke-width="2" />
+            <span
+              v-if="msg.role === 'user'"
+              class="message-avatar-initial"
+            >{{ userInitial }}</span>
+            <Sparkles
+              v-else
+              :size="16"
+              :stroke-width="2"
+            />
           </div>
 
           <div class="message-body">
@@ -259,17 +273,21 @@ const showLiveRow = computed(() => props.streaming)
               v-if="msg.role === 'assistant' && thinkingStepsFor(msg).length"
               class="thinking-panel thinking-panel-done"
             >
-              <button type="button" class="thinking-panel-header" @click="toggleThinking(msg.id)">
+              <button
+                type="button"
+                class="thinking-panel-header"
+                @click="toggleThinking(msg.id)"
+              >
                 <span class="thinking-panel-status">
                   {{
                     thinkingDuration(msg) != null
                       ? t('insight.copilot.thinkingDone', {
-                          seconds: thinkingDuration(msg),
-                          count: thinkingStepsFor(msg).length,
-                        })
+                        seconds: thinkingDuration(msg),
+                        count: thinkingStepsFor(msg).length,
+                      })
                       : t('insight.copilot.thinkingDoneSteps', {
-                          count: thinkingStepsFor(msg).length,
-                        })
+                        count: thinkingStepsFor(msg).length,
+                      })
                   }}
                 </span>
                 <ChevronUp
@@ -277,9 +295,16 @@ const showLiveRow = computed(() => props.streaming)
                   :size="13"
                   class="thinking-panel-chevron"
                 />
-                <ChevronDown v-else :size="13" class="thinking-panel-chevron" />
+                <ChevronDown
+                  v-else
+                  :size="13"
+                  class="thinking-panel-chevron"
+                />
               </button>
-              <div v-if="expandedThinking.has(msg.id)" class="thinking-panel-body">
+              <div
+                v-if="expandedThinking.has(msg.id)"
+                class="thinking-panel-body"
+              >
                 <div
                   v-for="(step, idx) in thinkingStepsFor(msg)"
                   :key="idx"
@@ -299,13 +324,29 @@ const showLiveRow = computed(() => props.streaming)
                 msg.starterChips ? 'message-card--welcome' : '',
               ]"
             >
-              <div v-if="msg.starterChips || msg.isError" class="message-text">{{ msg.text }}</div>
-              <div v-else-if="msg.role === 'assistant' && msg.text" class="message-markdown">
+              <div
+                v-if="msg.starterChips || msg.isError"
+                class="message-text"
+              >
+                {{ msg.text }}
+              </div>
+              <div
+                v-else-if="msg.role === 'assistant' && msg.text"
+                class="message-markdown"
+              >
                 <CopilotMarkdown :content="msg.text" />
               </div>
-              <div v-else-if="msg.text" class="message-text">{{ msg.text }}</div>
+              <div
+                v-else-if="msg.text"
+                class="message-text"
+              >
+                {{ msg.text }}
+              </div>
 
-              <div v-if="msg.starterChips" class="copilot-chip-grid">
+              <div
+                v-if="msg.starterChips"
+                class="copilot-chip-grid"
+              >
                 <button
                   v-for="chip in starterChips"
                   :key="chip.key"
@@ -317,14 +358,21 @@ const showLiveRow = computed(() => props.streaming)
                   @click="emit('starterChip', chip.key, starterChipPrompt(chip.key))"
                 >
                   <span class="copilot-chip-inner">
-                    <span class="copilot-chip-icon" aria-hidden="true">{{ chip.icon }}</span>
+                    <span
+                      class="copilot-chip-icon"
+                      aria-hidden="true"
+                    >{{ chip.icon }}</span>
                     <span class="copilot-chip-label">{{ starterChipTitle(chip.key) }}</span>
                   </span>
                 </button>
               </div>
             </div>
 
-            <div v-if="msg.createdAt" class="message-time" :class="msg.role">
+            <div
+              v-if="msg.createdAt"
+              class="message-time"
+              :class="msg.role"
+            >
               {{ formatMessageTime(msg.createdAt) }}
             </div>
 
@@ -361,15 +409,24 @@ const showLiveRow = computed(() => props.streaming)
           </div>
         </div>
 
-        <div v-if="showLiveRow" class="message-row message-row-assistant live-progress-row">
+        <div
+          v-if="showLiveRow"
+          class="message-row message-row-assistant live-progress-row"
+        >
           <div
             class="message-avatar message-avatar-icon message-avatar-icon--assistant"
             :aria-label="t('insight.copilot.roleAi')"
           >
-            <Sparkles :size="16" :stroke-width="2" />
+            <Sparkles
+              :size="16"
+              :stroke-width="2"
+            />
           </div>
           <div class="message-body">
-            <div v-if="!streamError" class="thinking-panel thinking-panel-live">
+            <div
+              v-if="!streamError"
+              class="thinking-panel thinking-panel-live"
+            >
               <button
                 v-if="streamingThinking?.length"
                 type="button"
@@ -381,11 +438,22 @@ const showLiveRow = computed(() => props.streaming)
                 <span class="thinking-panel-status">
                   <span class="thinking-panel-status-text">{{ liveThinkingStatus() }}</span>
                 </span>
-                <span v-if="streamingThinking.length" class="thinking-step-count">
+                <span
+                  v-if="streamingThinking.length"
+                  class="thinking-step-count"
+                >
                   {{ streamingThinking.length }}
                 </span>
-                <ChevronUp v-if="liveThinkingOpen" :size="13" class="thinking-panel-chevron" />
-                <ChevronDown v-else :size="13" class="thinking-panel-chevron" />
+                <ChevronUp
+                  v-if="liveThinkingOpen"
+                  :size="13"
+                  class="thinking-panel-chevron"
+                />
+                <ChevronDown
+                  v-else
+                  :size="13"
+                  class="thinking-panel-chevron"
+                />
               </button>
               <div
                 v-else
@@ -398,20 +466,38 @@ const showLiveRow = computed(() => props.streaming)
                   <span class="thinking-panel-status-text">{{ liveThinkingStatus() }}</span>
                 </span>
               </div>
-              <div v-if="liveThinkingOpen && streamingThinking?.length" class="thinking-panel-body">
-                <div v-for="(step, idx) in streamingThinking" :key="idx" class="thinking-step-item">
+              <div
+                v-if="liveThinkingOpen && streamingThinking?.length"
+                class="thinking-panel-body"
+              >
+                <div
+                  v-for="(step, idx) in streamingThinking"
+                  :key="idx"
+                  class="thinking-step-item"
+                >
                   <span class="thinking-step-bullet">▸</span>
                   <span class="thinking-step-text">{{ step.displayMessage || stepLabel(step) }}</span>
                 </div>
               </div>
             </div>
 
-            <p v-if="showRetrievalHint" class="thinking-retrieval-hint">
+            <p
+              v-if="showRetrievalHint"
+              class="thinking-retrieval-hint"
+            >
               {{ t('insight.copilot.thinkingRetrievalHint') }}
             </p>
 
-            <div v-if="streamingContent || streamError" class="message-card assistant">
-              <div v-if="streamError" class="message-text message-text--error">{{ streamError }}</div>
+            <div
+              v-if="streamingContent || streamError"
+              class="message-card assistant"
+            >
+              <div
+                v-if="streamError"
+                class="message-text message-text--error"
+              >
+                {{ streamError }}
+              </div>
               <div
                 v-else
                 class="message-markdown live-markdown"
@@ -436,7 +522,10 @@ const showLiveRow = computed(() => props.streaming)
       :title="t('insight.copilot.scrollToLatest')"
       @click="scrollToBottom"
     >
-      <ArrowDown :size="16" aria-hidden="true" />
+      <ArrowDown
+        :size="16"
+        aria-hidden="true"
+      />
       <span>{{ t('insight.copilot.scrollToLatest') }}</span>
     </button>
   </div>

--- a/src/frontend/src/pages/insight/copilot/CopilotSessionSidebar.vue
+++ b/src/frontend/src/pages/insight/copilot/CopilotSessionSidebar.vue
@@ -118,14 +118,27 @@ function handleAction(command: string, row: SessionRow) {
 <template>
   <aside class="copilot-aside">
     <div class="copilot-aside__new">
-      <ElButton class="w-full !justify-center" type="primary" size="small" @click="emit('newChat')">
+      <ElButton
+        class="w-full !justify-center"
+        type="primary"
+        size="small"
+        @click="emit('newChat')"
+      >
         <Plus :size="16" />{{ t('insight.copilot.newChat') }}
       </ElButton>
     </div>
 
-    <div v-loading="loading" class="copilot-session-scroll">
-      <template v-for="group in sessionGroups" :key="group.key">
-        <div class="copilot-session-group">{{ group.label }}</div>
+    <div
+      v-loading="loading"
+      class="copilot-session-scroll"
+    >
+      <template
+        v-for="group in sessionGroups"
+        :key="group.key"
+      >
+        <div class="copilot-session-group">
+          {{ group.label }}
+        </div>
         <article
           v-for="row in group.rows"
           :key="row.id"
@@ -144,27 +157,86 @@ function handleAction(command: string, row: SessionRow) {
                 @click.stop
                 @keydown="onRenameKeydown($event, row)"
                 @blur="commitRename(row, true)"
-              />
-              <span v-else class="copilot-session-item__title" :title="sessionTitle(row)">{{ sessionTitle(row) }}</span>
+              >
+              <span
+                v-else
+                class="copilot-session-item__title"
+                :title="sessionTitle(row)"
+              >{{ sessionTitle(row) }}</span>
             </div>
-            <span class="copilot-session-item__meta" :title="sessionMeta(row)">{{ sessionMeta(row) }}</span>
+            <span
+              class="copilot-session-item__meta"
+              :title="sessionMeta(row)"
+            >{{ sessionMeta(row) }}</span>
           </div>
 
-          <div v-if="editingId !== row.id" class="copilot-session-item__trailing">
-            <span class="copilot-session-item__state-slot" aria-hidden="true">
-              <span v-if="row.lifecycle_status === 'failed'" class="copilot-session-item__state is-failed" title="Preparation failed"><AlertCircle :size="14" /></span>
-              <span v-else-if="row.lifecycle_status === 'provisioning'" class="copilot-session-item__state is-preparing" title="Preparing"><i /><i /><i /></span>
-              <span v-else-if="sessionIsRunning(row)" class="copilot-session-item__state is-running" title="Answering" />
-              <span v-else-if="sessionHasUnread(row)" class="copilot-session-item__state is-unread" title="New answer" />
+          <div
+            v-if="editingId !== row.id"
+            class="copilot-session-item__trailing"
+          >
+            <span
+              class="copilot-session-item__state-slot"
+              aria-hidden="true"
+            >
+              <span
+                v-if="row.lifecycle_status === 'failed'"
+                class="copilot-session-item__state is-failed"
+                title="Preparation failed"
+              ><AlertCircle :size="14" /></span>
+              <span
+                v-else-if="row.lifecycle_status === 'provisioning'"
+                class="copilot-session-item__state is-preparing"
+                title="Preparing"
+              ><i /><i /><i /></span>
+              <span
+                v-else-if="sessionIsRunning(row)"
+                class="copilot-session-item__state is-running"
+                title="Answering"
+              />
+              <span
+                v-else-if="sessionHasUnread(row)"
+                class="copilot-session-item__state is-unread"
+                title="New answer"
+              />
             </span>
             <div class="copilot-session-item__actions">
-              <ElDropdown trigger="click" @command="(command) => handleAction(String(command), row)">
-                <button class="copilot-session-item__more" type="button" aria-label="Chat actions" @click.stop><Ellipsis :size="17" /></button>
+              <ElDropdown
+                trigger="click"
+                @command="(command) => handleAction(String(command), row)"
+              >
+                <button
+                  class="copilot-session-item__more"
+                  type="button"
+                  aria-label="Chat actions"
+                  @click.stop
+                >
+                  <Ellipsis :size="17" />
+                </button>
                 <template #dropdown>
                   <ElDropdownMenu>
-                    <ElDropdownItem class="copilot-session-menu__rename" command="rename" :icon="Pencil">Rename Chat</ElDropdownItem>
-                    <ElDropdownItem v-if="row.lifecycle_status === 'failed'" class="copilot-session-menu__retry" command="retry" :icon="RotateCcw">Try Again</ElDropdownItem>
-                    <ElDropdownItem class="copilot-session-menu__delete" command="delete" :icon="Trash2" divided>Delete Chat</ElDropdownItem>
+                    <ElDropdownItem
+                      class="copilot-session-menu__rename"
+                      command="rename"
+                      :icon="Pencil"
+                    >
+                      Rename Chat
+                    </ElDropdownItem>
+                    <ElDropdownItem
+                      v-if="row.lifecycle_status === 'failed'"
+                      class="copilot-session-menu__retry"
+                      command="retry"
+                      :icon="RotateCcw"
+                    >
+                      Try Again
+                    </ElDropdownItem>
+                    <ElDropdownItem
+                      class="copilot-session-menu__delete"
+                      command="delete"
+                      :icon="Trash2"
+                      divided
+                    >
+                      Delete Chat
+                    </ElDropdownItem>
                   </ElDropdownMenu>
                 </template>
               </ElDropdown>
@@ -173,7 +245,12 @@ function handleAction(command: string, row: SessionRow) {
         </article>
       </template>
 
-      <div v-if="!loading && !sessions.length" class="copilot-session-empty">{{ t('insight.copilot.emptyNoSessions') }}</div>
+      <div
+        v-if="!loading && !sessions.length"
+        class="copilot-session-empty"
+      >
+        {{ t('insight.copilot.emptyNoSessions') }}
+      </div>
     </div>
   </aside>
 </template>

--- a/src/frontend/src/pages/node/AddNasRepository.vue
+++ b/src/frontend/src/pages/node/AddNasRepository.vue
@@ -245,15 +245,32 @@ watch(enableQuotaAlert, (enabled) => {
 </script>
 
 <template>
-  <div ref="pageRef" class="fullscreen-form-fullscreen resource-add-fullscreen" :class="{ 'resource-add-fullscreen--embedded': embedded }">
+  <div
+    ref="pageRef"
+    class="fullscreen-form-fullscreen resource-add-fullscreen"
+    :class="{ 'resource-add-fullscreen--embedded': embedded }"
+  >
     <div class="fullscreen-form-page add-nas-page">
-      <header v-if="!embedded" class="fullscreen-form-header">
-        <button class="fullscreen-form-header__back" @click="handleBack">
-          <ArrowLeft class="fullscreen-form-header__back-icon" :size="18" />
+      <header
+        v-if="!embedded"
+        class="fullscreen-form-header"
+      >
+        <button
+          class="fullscreen-form-header__back"
+          @click="handleBack"
+        >
+          <ArrowLeft
+            class="fullscreen-form-header__back-icon"
+            :size="18"
+          />
         </button>
         <div class="fullscreen-form-header__content">
-          <h1 class="fullscreen-form-header__title">{{ t('repositoriesPage.addNasPage') }}</h1>
-          <p class="fullscreen-form-header__desc">{{ t('repositoriesPage.addNasPageDesc') }}</p>
+          <h1 class="fullscreen-form-header__title">
+            {{ t('repositoriesPage.addNasPage') }}
+          </h1>
+          <p class="fullscreen-form-header__desc">
+            {{ t('repositoriesPage.addNasPageDesc') }}
+          </p>
         </div>
       </header>
 
@@ -269,24 +286,47 @@ watch(enableQuotaAlert, (enabled) => {
                   {{ t('repositoriesPage.fieldProtocol') }}
                 </h3>
 
-                <ElRadioGroup v-model="protocol" class="add-nas-protocol-grid">
-                  <ElRadio value="smb" border class="add-nas-protocol-card !mr-0">
+                <ElRadioGroup
+                  v-model="protocol"
+                  class="add-nas-protocol-grid"
+                >
+                  <ElRadio
+                    value="smb"
+                    border
+                    class="add-nas-protocol-card !mr-0"
+                  >
                     <div class="add-nas-protocol-card__inner">
                       <span class="add-nas-protocol-card__icon">
-                        <component :is="nasMountProtocolIcon('smb')" :size="20" stroke-width="2" />
+                        <component
+                          :is="nasMountProtocolIcon('smb')"
+                          :size="20"
+                          stroke-width="2"
+                        />
                       </span>
                       <div class="add-nas-protocol-card__text">
-                        <div class="font-semibold">{{ t('repositoriesPage.protocolSmb') }}</div>
+                        <div class="font-semibold">
+                          {{ t('repositoriesPage.protocolSmb') }}
+                        </div>
                       </div>
                     </div>
                   </ElRadio>
-                  <ElRadio value="nfs" border class="add-nas-protocol-card !mr-0">
+                  <ElRadio
+                    value="nfs"
+                    border
+                    class="add-nas-protocol-card !mr-0"
+                  >
                     <div class="add-nas-protocol-card__inner">
                       <span class="add-nas-protocol-card__icon">
-                        <component :is="nasMountProtocolIcon('nfs')" :size="20" stroke-width="2" />
+                        <component
+                          :is="nasMountProtocolIcon('nfs')"
+                          :size="20"
+                          stroke-width="2"
+                        />
                       </span>
                       <div class="add-nas-protocol-card__text">
-                        <div class="font-semibold">{{ t('repositoriesPage.protocolNfs') }}</div>
+                        <div class="font-semibold">
+                          {{ t('repositoriesPage.protocolNfs') }}
+                        </div>
                       </div>
                     </div>
                   </ElRadio>
@@ -305,26 +345,83 @@ watch(enableQuotaAlert, (enabled) => {
                   {{ t('addNasRepo.titleNasInfo') }}
                 </h3>
 
-                <ElForm label-position="top" class="fullscreen-form-el-form add-nas-form">
-                  <div v-if="protocol === 'smb'" class="fullscreen-form-grid">
-                    <ElFormItem data-validation-field="smbHost" :error="errors.smbHost" :label="t('addNasRepo.fieldSmbHost')" required class="flex-1">
-                      <ElInput v-model="smbHost" :placeholder="t('addNasRepo.phSmbHost')" @input="clearFieldError('smbHost')" />
-                      <div class="mt-1 text-xs text-[rgb(100_116_139)]">{{ t('addNasRepo.hintSmbHost') }}</div>
+                <ElForm
+                  label-position="top"
+                  class="fullscreen-form-el-form add-nas-form"
+                >
+                  <div
+                    v-if="protocol === 'smb'"
+                    class="fullscreen-form-grid"
+                  >
+                    <ElFormItem
+                      data-validation-field="smbHost"
+                      :error="errors.smbHost"
+                      :label="t('addNasRepo.fieldSmbHost')"
+                      required
+                      class="flex-1"
+                    >
+                      <ElInput
+                        v-model="smbHost"
+                        :placeholder="t('addNasRepo.phSmbHost')"
+                        @input="clearFieldError('smbHost')"
+                      />
+                      <div class="mt-1 text-xs text-[rgb(100_116_139)]">
+                        {{ t('addNasRepo.hintSmbHost') }}
+                      </div>
                     </ElFormItem>
-                    <ElFormItem data-validation-field="smbShare" :error="errors.smbShare" :label="t('addNasRepo.fieldSmbShare')" required class="flex-1">
-                      <ElInput v-model="smbShare" :placeholder="t('addNasRepo.phSmbShare')" @input="clearFieldError('smbShare')" />
-                      <div class="mt-1 text-xs text-[rgb(100_116_139)]">{{ t('addNasRepo.hintSmbShare') }}</div>
+                    <ElFormItem
+                      data-validation-field="smbShare"
+                      :error="errors.smbShare"
+                      :label="t('addNasRepo.fieldSmbShare')"
+                      required
+                      class="flex-1"
+                    >
+                      <ElInput
+                        v-model="smbShare"
+                        :placeholder="t('addNasRepo.phSmbShare')"
+                        @input="clearFieldError('smbShare')"
+                      />
+                      <div class="mt-1 text-xs text-[rgb(100_116_139)]">
+                        {{ t('addNasRepo.hintSmbShare') }}
+                      </div>
                     </ElFormItem>
                   </div>
 
-                  <div v-if="protocol === 'nfs'" class="fullscreen-form-grid">
-                    <ElFormItem data-validation-field="nfsHost" :error="errors.nfsHost" :label="t('addNasRepo.fieldNfsHost')" required class="flex-1">
-                      <ElInput v-model="nfsHost" :placeholder="t('addNasRepo.phNfsHost')" @input="clearFieldError('nfsHost')" />
-                      <div class="mt-1 text-xs text-[rgb(100_116_139)]">{{ t('addNasRepo.hintNfsHost') }}</div>
+                  <div
+                    v-if="protocol === 'nfs'"
+                    class="fullscreen-form-grid"
+                  >
+                    <ElFormItem
+                      data-validation-field="nfsHost"
+                      :error="errors.nfsHost"
+                      :label="t('addNasRepo.fieldNfsHost')"
+                      required
+                      class="flex-1"
+                    >
+                      <ElInput
+                        v-model="nfsHost"
+                        :placeholder="t('addNasRepo.phNfsHost')"
+                        @input="clearFieldError('nfsHost')"
+                      />
+                      <div class="mt-1 text-xs text-[rgb(100_116_139)]">
+                        {{ t('addNasRepo.hintNfsHost') }}
+                      </div>
                     </ElFormItem>
-                    <ElFormItem data-validation-field="nfsExport" :error="errors.nfsExport" :label="t('addNasRepo.fieldNfsExport')" required class="flex-1">
-                      <ElInput v-model="nfsExport" :placeholder="t('addNasRepo.phNfsExport')" @input="clearFieldError('nfsExport')" />
-                      <div class="mt-1 text-xs text-[rgb(100_116_139)]">{{ t('addNasRepo.hintNfsExport') }}</div>
+                    <ElFormItem
+                      data-validation-field="nfsExport"
+                      :error="errors.nfsExport"
+                      :label="t('addNasRepo.fieldNfsExport')"
+                      required
+                      class="flex-1"
+                    >
+                      <ElInput
+                        v-model="nfsExport"
+                        :placeholder="t('addNasRepo.phNfsExport')"
+                        @input="clearFieldError('nfsExport')"
+                      />
+                      <div class="mt-1 text-xs text-[rgb(100_116_139)]">
+                        {{ t('addNasRepo.hintNfsExport') }}
+                      </div>
                     </ElFormItem>
                   </div>
 
@@ -338,7 +435,13 @@ watch(enableQuotaAlert, (enabled) => {
                         ? 'If SMB auto-negotiation fails, explicitly set the protocol version or authentication option.'
                         : t('addNasRepo.hintMountOptionsNfs') }}
                     </div>
-                    <ElAlert v-if="protocol === 'smb'" type="info" :closable="false" show-icon class="mt-2">
+                    <ElAlert
+                      v-if="protocol === 'smb'"
+                      type="info"
+                      :closable="false"
+                      show-icon
+                      class="mt-2"
+                    >
                       <div class="text-xs leading-5 text-[rgb(51_65_85)]">
                         <div>
                           Different NAS devices, SMB servers, and client kernels may support different protocol versions. Copy one example into Mount Options and test:
@@ -362,22 +465,53 @@ watch(enableQuotaAlert, (enabled) => {
                     <ShieldCheck :size="16" />
                     {{ t('addNasRepo.titleAuth') }}
                   </h4>
-                  <ElForm label-position="top" class="fullscreen-form-el-form add-nas-form">
+                  <ElForm
+                    label-position="top"
+                    class="fullscreen-form-el-form add-nas-form"
+                  >
                     <div class="fullscreen-form-grid">
-                      <ElFormItem data-validation-field="smbUsername" :error="errors.smbUsername" :label="t('repositoriesPage.fieldSmbUsername')" required class="flex-1">
-                        <ElInput v-model="smbUsername" :placeholder="t('repositoriesPage.phSmbUsername')" @input="clearFieldError('smbUsername')" />
+                      <ElFormItem
+                        data-validation-field="smbUsername"
+                        :error="errors.smbUsername"
+                        :label="t('repositoriesPage.fieldSmbUsername')"
+                        required
+                        class="flex-1"
+                      >
+                        <ElInput
+                          v-model="smbUsername"
+                          :placeholder="t('repositoriesPage.phSmbUsername')"
+                          @input="clearFieldError('smbUsername')"
+                        />
                         <div class="mt-1 text-xs text-[rgb(100_116_139)]">
                           SMB user used to access the shared directory, e.g. backup_user.
                         </div>
                       </ElFormItem>
-                      <ElFormItem data-validation-field="smbPassword" :error="errors.smbPassword" :label="t('repositoriesPage.fieldSmbPassword')" required class="flex-1">
-                        <ElInput v-model="smbPassword" type="password" show-password :placeholder="t('repositoriesPage.phSmbPassword')" @input="clearFieldError('smbPassword')" />
+                      <ElFormItem
+                        data-validation-field="smbPassword"
+                        :error="errors.smbPassword"
+                        :label="t('repositoriesPage.fieldSmbPassword')"
+                        required
+                        class="flex-1"
+                      >
+                        <ElInput
+                          v-model="smbPassword"
+                          type="password"
+                          show-password
+                          :placeholder="t('repositoriesPage.phSmbPassword')"
+                          @input="clearFieldError('smbPassword')"
+                        />
                         <div class="mt-1 text-xs text-[rgb(100_116_139)]">
                           Password for the shared directory; logs and errors are masked.
                         </div>
                       </ElFormItem>
-                      <ElFormItem :label="t('repositoriesPage.fieldSmbDomain')" class="flex-1">
-                        <ElInput v-model="smbDomain" :placeholder="t('repositoriesPage.phSmbDomain')" />
+                      <ElFormItem
+                        :label="t('repositoriesPage.fieldSmbDomain')"
+                        class="flex-1"
+                      >
+                        <ElInput
+                          v-model="smbDomain"
+                          :placeholder="t('repositoriesPage.phSmbDomain')"
+                        />
                         <div class="mt-1 text-xs text-[rgb(100_116_139)]">
                           Use CORP or WORKGROUP for domain environments; leave empty for local users.
                         </div>
@@ -401,15 +535,26 @@ watch(enableQuotaAlert, (enabled) => {
                       {{ t('addNasRepo.titleBindProxy') }}
                     </h3>
                   </div>
-                  <ElButton class="add-nas-proxy-action" @click="openProxyDeploy">
+                  <ElButton
+                    class="add-nas-proxy-action"
+                    @click="openProxyDeploy"
+                  >
                     <Plus :size="14" />
                     {{ t('addNasRepo.deployProxy') }}
                   </ElButton>
                 </div>
 
-                <ElAlert type="warning" :closable="false" class="add-nas-proxy-alert">
+                <ElAlert
+                  type="warning"
+                  :closable="false"
+                  class="add-nas-proxy-alert"
+                >
                   <ol class="add-nas-proxy-alert__list">
-                    <li v-for="(item, index) in bindProxyLeadItems" :key="item" class="add-nas-proxy-alert__item">
+                    <li
+                      v-for="(item, index) in bindProxyLeadItems"
+                      :key="item"
+                      class="add-nas-proxy-alert__item"
+                    >
                       <span class="add-nas-proxy-alert__index">{{ index + 1 }}</span>
                       <span class="add-nas-proxy-alert__text">{{ item }}</span>
                     </li>
@@ -418,9 +563,19 @@ watch(enableQuotaAlert, (enabled) => {
 
                 <div class="add-nas-proxy-layout">
                   <div class="add-nas-proxy-form">
-                    <ElForm label-position="top" class="fullscreen-form-el-form add-nas-form">
-                      <ElFormItem data-validation-field="proxyNode" :error="errors.proxyNode" required class="add-nas-bind-form-item">
-                        <template #label>{{ t('addNasRepo.fieldSourceProxyNode') }}</template>
+                    <ElForm
+                      label-position="top"
+                      class="fullscreen-form-el-form add-nas-form"
+                    >
+                      <ElFormItem
+                        data-validation-field="proxyNode"
+                        :error="errors.proxyNode"
+                        required
+                        class="add-nas-bind-form-item"
+                      >
+                        <template #label>
+                          {{ t('addNasRepo.fieldSourceProxyNode') }}
+                        </template>
                         <div class="add-nas-select-row">
                           <ElSelect
                             v-model="proxyNodeId"
@@ -437,7 +592,10 @@ watch(enableQuotaAlert, (enabled) => {
                               :value="n.id"
                               :label="n.ip_address ? `${n.name} (${n.ip_address})` : n.name"
                             />
-                            <ElOption :value="0" :label="t('addNasRepo.optionNoProxy')" />
+                            <ElOption
+                              :value="0"
+                              :label="t('addNasRepo.optionNoProxy')"
+                            />
                           </ElSelect>
                           <ElButton
                             class="hfl-refresh-button add-nas-select-row__refresh"
@@ -446,13 +604,22 @@ watch(enableQuotaAlert, (enabled) => {
                             :disabled="proxyNodesRefreshing"
                             @click="refreshProxyNodesManually"
                           >
-                            <RefreshCw :size="16" :class="{ 'is-spinning': proxyNodesRefreshing }" />
+                            <RefreshCw
+                              :size="16"
+                              :class="{ 'is-spinning': proxyNodesRefreshing }"
+                            />
                           </ElButton>
                         </div>
-                        <div v-if="hasBoundProxy" class="mt-2 text-xs text-[rgb(100_116_139)]">
+                        <div
+                          v-if="hasBoundProxy"
+                          class="mt-2 text-xs text-[rgb(100_116_139)]"
+                        >
                           {{ t('addNasRepo.hintProxySelected') }}
                         </div>
-                        <div v-else-if="!hasProxyDecision" class="mt-2 text-xs text-[rgb(100_116_139)]">
+                        <div
+                          v-else-if="!hasProxyDecision"
+                          class="mt-2 text-xs text-[rgb(100_116_139)]"
+                        >
                           {{ t('addNasRepo.hintProxyUndecided') }}
                         </div>
                         <ElAlert
@@ -493,7 +660,6 @@ watch(enableQuotaAlert, (enabled) => {
                     :source-labels="topologySourceLabels"
                   />
                 </div>
-
               </div>
             </section>
 
@@ -507,9 +673,21 @@ watch(enableQuotaAlert, (enabled) => {
                   <span class="fullscreen-form-section__indicator" />
                   {{ t('repositoriesPage.stepRepo') }}
                 </h3>
-                <ElForm label-position="top" class="fullscreen-form-el-form add-nas-form">
-                  <ElFormItem data-validation-field="repoName" :error="errors.repoName" :label="t('repositoriesPage.fieldRepoName')" required>
-                    <ElInput v-model="repoName" :placeholder="t('repositoriesPage.phRepoName')" @input="clearFieldError('repoName')" />
+                <ElForm
+                  label-position="top"
+                  class="fullscreen-form-el-form add-nas-form"
+                >
+                  <ElFormItem
+                    data-validation-field="repoName"
+                    :error="errors.repoName"
+                    :label="t('repositoriesPage.fieldRepoName')"
+                    required
+                  >
+                    <ElInput
+                      v-model="repoName"
+                      :placeholder="t('repositoriesPage.phRepoName')"
+                      @input="clearFieldError('repoName')"
+                    />
                     <div class="mt-1 text-xs text-[rgb(100_116_139)]">
                       Display name used in repository lists and backup configs, e.g. Production NAS backup.
                     </div>
@@ -526,15 +704,24 @@ watch(enableQuotaAlert, (enabled) => {
                             :min="0"
                             controls-position="right"
                           />
-                          <div class="repository-quota-number__suffix">GB</div>
+                          <div class="repository-quota-number__suffix">
+                            GB
+                          </div>
                         </div>
                       </div>
-                      <p class="fullscreen-form-field__hint">{{ t('repositoriesPage.hintQuota') }}</p>
+                      <p class="fullscreen-form-field__hint">
+                        {{ t('repositoriesPage.hintQuota') }}
+                      </p>
                     </div>
 
-                    <div data-validation-field="quotaThreshold" class="fullscreen-form-field repository-quota-field repository-quota-field--monitoring">
+                    <div
+                      data-validation-field="quotaThreshold"
+                      class="fullscreen-form-field repository-quota-field repository-quota-field--monitoring"
+                    >
                       <div class="fullscreen-form-field__label repository-quota-head repository-quota-title-row">
-                        <ElCheckbox v-model="enableQuotaAlert">{{ t('repositoriesPage.fieldQuotaAlert') }}</ElCheckbox>
+                        <ElCheckbox v-model="enableQuotaAlert">
+                          {{ t('repositoriesPage.fieldQuotaAlert') }}
+                        </ElCheckbox>
                       </div>
                       <div class="repository-quota-control">
                         <div class="repository-quota-number repository-quota-input">
@@ -547,11 +734,20 @@ watch(enableQuotaAlert, (enabled) => {
                             controls-position="right"
                             @change="clearFieldError('quotaThreshold')"
                           />
-                          <div class="repository-quota-number__suffix">%</div>
+                          <div class="repository-quota-number__suffix">
+                            %
+                          </div>
                         </div>
                       </div>
-                      <p class="fullscreen-form-field__hint">{{ t('repositoriesPage.hintQuotaAlertThreshold') }}</p>
-                      <p v-if="errors.quotaThreshold" class="el-form-item__error">{{ errors.quotaThreshold }}</p>
+                      <p class="fullscreen-form-field__hint">
+                        {{ t('repositoriesPage.hintQuotaAlertThreshold') }}
+                      </p>
+                      <p
+                        v-if="errors.quotaThreshold"
+                        class="el-form-item__error"
+                      >
+                        {{ errors.quotaThreshold }}
+                      </p>
                     </div>
                   </div>
                 </ElForm>
@@ -564,32 +760,53 @@ watch(enableQuotaAlert, (enabled) => {
               <ElButton @click="handleBack">
                 {{ t('repositoriesPage.btnCancel') }}
               </ElButton>
-              <ElButton type="primary" :loading="busy" :disabled="busy" @click="onSubmit">
+              <ElButton
+                type="primary"
+                :loading="busy"
+                :disabled="busy"
+                @click="onSubmit"
+              >
                 {{ submitButtonLabel }}
               </ElButton>
             </div>
           </div>
         </div>
 
-        <aside v-if="!embedded" class="fullscreen-form-sidebar add-form-preview-sidebar">
+        <aside
+          v-if="!embedded"
+          class="fullscreen-form-sidebar add-form-preview-sidebar"
+        >
           <div class="add-form-preview-card">
             <div class="add-form-preview-header">
               <div class="add-form-preview-header__glow" />
               <div class="add-form-preview-header__icon">
-                <component :is="nasMountProtocolIcon(protocol)" class="add-form-preview-header__icon-lucide" :size="28" />
+                <component
+                  :is="nasMountProtocolIcon(protocol)"
+                  class="add-form-preview-header__icon-lucide"
+                  :size="28"
+                />
               </div>
               <div class="add-form-preview-header__info">
-                <h4 class="add-form-preview-header__name">{{ repoName || t('addS3Repo.previewUnnamed') }}</h4>
-                <p class="add-form-preview-header__type">{{ protocolLabel }}</p>
+                <h4 class="add-form-preview-header__name">
+                  {{ repoName || t('addS3Repo.previewUnnamed') }}
+                </h4>
+                <p class="add-form-preview-header__type">
+                  {{ protocolLabel }}
+                </p>
               </div>
             </div>
 
             <div class="add-form-preview-body">
               <div class="add-form-preview-section">
-                <h5 class="add-form-preview-section__title">{{ t('addS3Repo.previewBasicInfo') }}</h5>
+                <h5 class="add-form-preview-section__title">
+                  {{ t('addS3Repo.previewBasicInfo') }}
+                </h5>
                 <div class="add-form-preview-row">
                   <span class="add-form-preview-row__label">{{ t('repositoriesPage.fieldRepoName') }}</span>
-                  <span class="add-form-preview-row__value" :class="{ 'add-form-preview-row__value--empty': !repoName }">
+                  <span
+                    class="add-form-preview-row__value"
+                    :class="{ 'add-form-preview-row__value--empty': !repoName }"
+                  >
                     {{ repoName || '—' }}
                   </span>
                 </div>
@@ -599,7 +816,10 @@ watch(enableQuotaAlert, (enabled) => {
                 </div>
                 <div class="add-form-preview-row">
                   <span class="add-form-preview-row__label">{{ t('addNasRepo.fieldSourceProxyNode') }}</span>
-                  <span class="add-form-preview-row__value" :class="{ 'add-form-preview-row__value--empty': !selectedProxyNodeName }">
+                  <span
+                    class="add-form-preview-row__value"
+                    :class="{ 'add-form-preview-row__value--empty': !selectedProxyNodeName }"
+                  >
                     {{ proxyPreviewLabel }}
                   </span>
                 </div>
@@ -609,14 +829,23 @@ watch(enableQuotaAlert, (enabled) => {
                 </div>
                 <div class="add-form-preview-row">
                   <span class="add-form-preview-row__label">{{ t('repositoriesPage.fieldQuota') }}</span>
-                  <span class="add-form-preview-row__value" :class="{ 'add-form-preview-row__value--highlight': quota > 0 }">
+                  <span
+                    class="add-form-preview-row__value"
+                    :class="{ 'add-form-preview-row__value--highlight': quota > 0 }"
+                  >
                     {{ quota > 0 ? `${quota} GB` : t('addS3Repo.previewUnlimited') }}
                   </span>
                 </div>
                 <div class="add-form-preview-row">
                   <span class="add-form-preview-row__label">{{ t('repositoriesPage.fieldQuotaAlert') }}</span>
-                  <span class="add-form-preview-row__value" :class="enableQuotaAlert ? 'add-form-preview-row__value--success' : 'add-form-preview-row__value--muted'">
-                    <span v-if="enableQuotaAlert" class="add-form-preview-row__dot add-form-preview-row__dot--green" />
+                  <span
+                    class="add-form-preview-row__value"
+                    :class="enableQuotaAlert ? 'add-form-preview-row__value--success' : 'add-form-preview-row__value--muted'"
+                  >
+                    <span
+                      v-if="enableQuotaAlert"
+                      class="add-form-preview-row__dot add-form-preview-row__dot--green"
+                    />
                     <template v-if="enableQuotaAlert">
                       {{ t('repositoriesPage.enabled') }} ({{ quotaAlertThreshold }}%)
                     </template>
@@ -628,46 +857,87 @@ watch(enableQuotaAlert, (enabled) => {
               </div>
 
               <div class="add-form-preview-section">
-                <h5 class="add-form-preview-section__title">{{ t('addS3Repo.previewConnection') }}</h5>
-                <div v-if="protocol === 'smb'" class="add-form-preview-row">
+                <h5 class="add-form-preview-section__title">
+                  {{ t('addS3Repo.previewConnection') }}
+                </h5>
+                <div
+                  v-if="protocol === 'smb'"
+                  class="add-form-preview-row"
+                >
                   <span class="add-form-preview-row__label">{{ t('addNasRepo.fieldSmbHost') }}</span>
-                  <span class="add-form-preview-row__value" :class="{ 'add-form-preview-row__value--empty': !smbHost }">
+                  <span
+                    class="add-form-preview-row__value"
+                    :class="{ 'add-form-preview-row__value--empty': !smbHost }"
+                  >
                     {{ smbHost || '—' }}
                   </span>
                 </div>
-                <div v-if="protocol === 'smb'" class="add-form-preview-row">
+                <div
+                  v-if="protocol === 'smb'"
+                  class="add-form-preview-row"
+                >
                   <span class="add-form-preview-row__label">{{ t('addNasRepo.fieldSmbShare') }}</span>
-                  <span class="add-form-preview-row__value" :class="{ 'add-form-preview-row__value--empty': !smbShare }">
+                  <span
+                    class="add-form-preview-row__value"
+                    :class="{ 'add-form-preview-row__value--empty': !smbShare }"
+                  >
                     {{ smbShare || '—' }}
                   </span>
                 </div>
-                <div v-if="protocol === 'smb'" class="add-form-preview-row">
+                <div
+                  v-if="protocol === 'smb'"
+                  class="add-form-preview-row"
+                >
                   <span class="add-form-preview-row__label">{{ t('repositoriesPage.fieldSmbUsername') }}</span>
-                  <span class="add-form-preview-row__value" :class="{ 'add-form-preview-row__value--empty': !smbUsername }">
+                  <span
+                    class="add-form-preview-row__value"
+                    :class="{ 'add-form-preview-row__value--empty': !smbUsername }"
+                  >
                     {{ smbUsername || '—' }}
                   </span>
                 </div>
-                <div v-if="protocol === 'smb'" class="add-form-preview-row">
+                <div
+                  v-if="protocol === 'smb'"
+                  class="add-form-preview-row"
+                >
                   <span class="add-form-preview-row__label">{{ t('repositoriesPage.fieldSmbDomain') }}</span>
-                  <span class="add-form-preview-row__value" :class="{ 'add-form-preview-row__value--empty': !smbDomain }">
+                  <span
+                    class="add-form-preview-row__value"
+                    :class="{ 'add-form-preview-row__value--empty': !smbDomain }"
+                  >
                     {{ smbDomain || '—' }}
                   </span>
                 </div>
-                <div v-if="protocol === 'nfs'" class="add-form-preview-row">
+                <div
+                  v-if="protocol === 'nfs'"
+                  class="add-form-preview-row"
+                >
                   <span class="add-form-preview-row__label">{{ t('addNasRepo.fieldNfsHost') }}</span>
-                  <span class="add-form-preview-row__value" :class="{ 'add-form-preview-row__value--empty': !nfsHost }">
+                  <span
+                    class="add-form-preview-row__value"
+                    :class="{ 'add-form-preview-row__value--empty': !nfsHost }"
+                  >
                     {{ nfsHost || '—' }}
                   </span>
                 </div>
-                <div v-if="protocol === 'nfs'" class="add-form-preview-row">
+                <div
+                  v-if="protocol === 'nfs'"
+                  class="add-form-preview-row"
+                >
                   <span class="add-form-preview-row__label">{{ t('addNasRepo.fieldNfsExport') }}</span>
-                  <span class="add-form-preview-row__value" :class="{ 'add-form-preview-row__value--empty': !nfsExport }">
+                  <span
+                    class="add-form-preview-row__value"
+                    :class="{ 'add-form-preview-row__value--empty': !nfsExport }"
+                  >
                     {{ nfsExport || '—' }}
                   </span>
                 </div>
                 <div class="add-form-preview-row">
                   <span class="add-form-preview-row__label">{{ t('addNasRepo.fieldMountOptions') }}</span>
-                  <span class="add-form-preview-row__value" :class="{ 'add-form-preview-row__value--empty': !mountOptions }">
+                  <span
+                    class="add-form-preview-row__value"
+                    :class="{ 'add-form-preview-row__value--empty': !mountOptions }"
+                  >
                     {{ mountOptions || '—' }}
                   </span>
                 </div>
@@ -675,9 +945,7 @@ watch(enableQuotaAlert, (enabled) => {
             </div>
           </div>
         </aside>
-
       </div>
-
     </div>
   </div>
 </template>

--- a/src/frontend/src/pages/node/AddProxyFsRepository.vue
+++ b/src/frontend/src/pages/node/AddProxyFsRepository.vue
@@ -590,15 +590,32 @@ watch(enableQuotaAlert, (enabled) => {
 </script>
 
 <template>
-  <div ref="pageRef" class="fullscreen-form-fullscreen resource-add-fullscreen" :class="{ 'resource-add-fullscreen--embedded': embedded }">
+  <div
+    ref="pageRef"
+    class="fullscreen-form-fullscreen resource-add-fullscreen"
+    :class="{ 'resource-add-fullscreen--embedded': embedded }"
+  >
     <div class="fullscreen-form-page add-proxy-fs-page">
-      <header v-if="!embedded" class="fullscreen-form-header">
-        <button class="fullscreen-form-header__back" @click="handleBack">
-          <ArrowLeft class="fullscreen-form-header__back-icon" :size="18" />
+      <header
+        v-if="!embedded"
+        class="fullscreen-form-header"
+      >
+        <button
+          class="fullscreen-form-header__back"
+          @click="handleBack"
+        >
+          <ArrowLeft
+            class="fullscreen-form-header__back-icon"
+            :size="18"
+          />
         </button>
         <div class="fullscreen-form-header__content">
-          <h1 class="fullscreen-form-header__title">{{ t('repositoriesPage.addProxyFsPage') }}</h1>
-          <p class="fullscreen-form-header__desc">{{ t('repositoriesPage.addProxyFsPageDesc') }}</p>
+          <h1 class="fullscreen-form-header__title">
+            {{ t('repositoriesPage.addProxyFsPage') }}
+          </h1>
+          <p class="fullscreen-form-header__desc">
+            {{ t('repositoriesPage.addProxyFsPageDesc') }}
+          </p>
         </div>
       </header>
 
@@ -614,21 +631,43 @@ watch(enableQuotaAlert, (enabled) => {
                 <span class="fullscreen-form-section__indicator" />
                 {{ t('repositoriesPage.stepRepo') }}
               </h3>
-              <ElForm label-position="top" class="fullscreen-form-el-form add-proxy-fs-form">
-                <ElFormItem data-validation-field="repoName" :error="errors.repoName" :label="t('repositoriesPage.fieldRepoName')" required class="fullscreen-form-item--in-card">
-                  <ElInput v-model="repoName" :placeholder="t('repositoriesPage.phRepoName')" @input="clearFieldError('repoName')" />
+              <ElForm
+                label-position="top"
+                class="fullscreen-form-el-form add-proxy-fs-form"
+              >
+                <ElFormItem
+                  data-validation-field="repoName"
+                  :error="errors.repoName"
+                  :label="t('repositoriesPage.fieldRepoName')"
+                  required
+                  class="fullscreen-form-item--in-card"
+                >
+                  <ElInput
+                    v-model="repoName"
+                    :placeholder="t('repositoriesPage.phRepoName')"
+                    @input="clearFieldError('repoName')"
+                  />
                   <div class="mt-1 text-xs text-[var(--color-text-tertiary)]">
                     {{ t('repositoriesPage.hintRepoNameAuto') }}
                   </div>
                 </ElFormItem>
 
-                <ElFormItem data-validation-field="proxyNode" :error="errors.proxyNode" required class="fullscreen-form-item--in-card add-proxy-fs-bind-form-item is-no-asterisk">
+                <ElFormItem
+                  data-validation-field="proxyNode"
+                  :error="errors.proxyNode"
+                  required
+                  class="fullscreen-form-item--in-card add-proxy-fs-bind-form-item is-no-asterisk"
+                >
                   <template #label>
                     <div class="add-proxy-fs-proxy-label">
                       <span class="add-proxy-fs-proxy-label__title">
                         {{ t('repositoriesPage.fieldProxyNode') }}<span class="add-proxy-fs-proxy-label__required">*</span>
                       </span>
-                      <ElButton type="primary" :icon="Plus" @click="openProxyDeploy">
+                      <ElButton
+                        type="primary"
+                        :icon="Plus"
+                        @click="openProxyDeploy"
+                      >
                         {{ t('addNasRepo.deployProxy') }}
                       </ElButton>
                     </div>
@@ -655,12 +694,21 @@ watch(enableQuotaAlert, (enabled) => {
                       :disabled="proxyNodesRefreshing"
                       @click="refreshProxyNodesManually"
                     >
-                      <RefreshCw :size="16" :class="{ 'is-spinning': proxyNodesRefreshing }" />
+                      <RefreshCw
+                        :size="16"
+                        :class="{ 'is-spinning': proxyNodesRefreshing }"
+                      />
                     </ElButton>
                   </div>
                 </ElFormItem>
 
-                <ElFormItem data-validation-field="proxyNodeDir" :error="errors.proxyNodeDir" :label="t('repositoriesPage.fieldProxyNodeBaseDir')" required class="fullscreen-form-item--in-card">
+                <ElFormItem
+                  data-validation-field="proxyNodeDir"
+                  :error="errors.proxyNodeDir"
+                  :label="t('repositoriesPage.fieldProxyNodeBaseDir')"
+                  required
+                  class="fullscreen-form-item--in-card"
+                >
                   <div class="dir-selector-container">
                     <div class="dir-selector-toggle">
                       <button
@@ -669,7 +717,10 @@ watch(enableQuotaAlert, (enabled) => {
                         type="button"
                         @click="useTreeSelect = true"
                       >
-                        <FolderTree :size="14" class="mr-1" />
+                        <FolderTree
+                          :size="14"
+                          class="mr-1"
+                        />
                         {{ t('repositoriesPage.dirSelectTree') }}
                       </button>
                       <button
@@ -678,18 +729,34 @@ watch(enableQuotaAlert, (enabled) => {
                         type="button"
                         @click="useTreeSelect = false"
                       >
-                        <HardDrive :size="14" class="mr-1" />
+                        <HardDrive
+                          :size="14"
+                          class="mr-1"
+                        />
                         {{ t('repositoriesPage.dirSelectInput') }}
                       </button>
                     </div>
 
-                    <div v-if="useTreeSelect" class="dir-tree-select hfl-dir-tree-shell">
-                      <div v-if="!proxyNodeId" class="dir-tree-select__empty hfl-dir-tree-empty">
+                    <div
+                      v-if="useTreeSelect"
+                      class="dir-tree-select hfl-dir-tree-shell"
+                    >
+                      <div
+                        v-if="!proxyNodeId"
+                        class="dir-tree-select__empty hfl-dir-tree-empty"
+                      >
                         {{ t('repositoriesPage.errProxyNode') }}
                       </div>
-                      <div v-else-if="treeError" class="dir-tree-select__empty hfl-dir-tree-empty">
+                      <div
+                        v-else-if="treeError"
+                        class="dir-tree-select__empty hfl-dir-tree-empty"
+                      >
                         <div>{{ treeError }}</div>
-                        <ElButton size="small" class="mt-2" @click="loadProxyRootDirectories()">
+                        <ElButton
+                          size="small"
+                          class="mt-2"
+                          @click="loadProxyRootDirectories()"
+                        >
                           {{ t('repositoriesPage.dirTreeRetry') }}
                         </ElButton>
                       </div>
@@ -708,8 +775,15 @@ watch(enableQuotaAlert, (enabled) => {
                               :size="14"
                               class="dir-tree-root-row__caret"
                             />
-                            <span v-else class="dir-tree-root-row__caret" aria-hidden="true" />
-                            <Folder :size="15" class="dir-tree-root-row__icon hfl-dir-tree-node__icon" />
+                            <span
+                              v-else
+                              class="dir-tree-root-row__caret"
+                              aria-hidden="true"
+                            />
+                            <Folder
+                              :size="15"
+                              class="dir-tree-root-row__icon hfl-dir-tree-node__icon"
+                            />
                             <span class="dir-tree-root-row__text hfl-dir-tree-node__text">
                               <span class="dir-tree-root-row__label hfl-dir-tree-node__label">/</span>
                               <span class="dir-tree-root-row__path hfl-dir-tree-node__path">/</span>
@@ -730,7 +804,10 @@ watch(enableQuotaAlert, (enabled) => {
                             />
                           </button>
                         </div>
-                        <div v-if="treeData.length === 0" class="dir-tree-empty-nested hfl-dir-tree-empty">
+                        <div
+                          v-if="treeData.length === 0"
+                          class="dir-tree-empty-nested hfl-dir-tree-empty"
+                        >
                           {{ t('repositoriesPage.dirTreeEmptyProxy') }}
                         </div>
                       </template>
@@ -759,12 +836,18 @@ watch(enableQuotaAlert, (enabled) => {
                       >
                         <template #default="{ data }">
                           <div class="tree-node-content hfl-dir-tree-node">
-                            <Folder :size="15" class="tree-node-content__icon hfl-dir-tree-node__icon" />
+                            <Folder
+                              :size="15"
+                              class="tree-node-content__icon hfl-dir-tree-node__icon"
+                            />
                             <div class="tree-node-content__text hfl-dir-tree-node__text">
                               <span class="tree-node-content__label hfl-dir-tree-node__label">{{ data.label }}</span>
                               <span class="tree-node-content__path hfl-dir-tree-node__path">{{ data.pathLabel }}</span>
                             </div>
-                            <span v-if="data.loadingChildren" class="tree-node-content__status">
+                            <span
+                              v-if="data.loadingChildren"
+                              class="tree-node-content__status"
+                            >
                               {{ t('common.loading') }}
                             </span>
                             <ElButton
@@ -791,7 +874,10 @@ watch(enableQuotaAlert, (enabled) => {
                               />
                             </button>
                           </div>
-                          <div v-if="data.loadError" class="tree-node-content__error">
+                          <div
+                            v-if="data.loadError"
+                            class="tree-node-content__error"
+                          >
                             {{ t('repositoriesPage.dirTreeNodeLoadFailed') }}
                           </div>
                         </template>
@@ -822,7 +908,10 @@ watch(enableQuotaAlert, (enabled) => {
                 <span class="fullscreen-form-section__indicator" />
                 {{ t('repositoriesPage.fieldQuota') }}
               </h3>
-              <ElForm label-position="top" class="fullscreen-form-el-form add-proxy-fs-form">
+              <ElForm
+                label-position="top"
+                class="fullscreen-form-el-form add-proxy-fs-form"
+              >
                 <div class="fullscreen-form-grid">
                   <div class="fullscreen-form-field repository-quota-field">
                     <label class="fullscreen-form-field__label repository-quota-head">{{ t('repositoriesPage.fieldQuota') }}</label>
@@ -835,15 +924,24 @@ watch(enableQuotaAlert, (enabled) => {
                           :min="0"
                           controls-position="right"
                         />
-                        <div class="repository-quota-number__suffix">GB</div>
+                        <div class="repository-quota-number__suffix">
+                          GB
+                        </div>
                       </div>
                     </div>
-                    <p class="fullscreen-form-field__hint">{{ t('repositoriesPage.hintQuota') }}</p>
+                    <p class="fullscreen-form-field__hint">
+                      {{ t('repositoriesPage.hintQuota') }}
+                    </p>
                   </div>
 
-                  <div data-validation-field="quotaThreshold" class="fullscreen-form-field repository-quota-field repository-quota-field--monitoring">
+                  <div
+                    data-validation-field="quotaThreshold"
+                    class="fullscreen-form-field repository-quota-field repository-quota-field--monitoring"
+                  >
                     <div class="fullscreen-form-field__label repository-quota-head repository-quota-title-row">
-                      <ElCheckbox v-model="enableQuotaAlert">{{ t('repositoriesPage.fieldQuotaAlert') }}</ElCheckbox>
+                      <ElCheckbox v-model="enableQuotaAlert">
+                        {{ t('repositoriesPage.fieldQuotaAlert') }}
+                      </ElCheckbox>
                     </div>
                     <div class="repository-quota-control">
                       <div class="repository-quota-number repository-quota-input">
@@ -856,11 +954,20 @@ watch(enableQuotaAlert, (enabled) => {
                           controls-position="right"
                           @change="clearFieldError('quotaThreshold')"
                         />
-                        <div class="repository-quota-number__suffix">%</div>
+                        <div class="repository-quota-number__suffix">
+                          %
+                        </div>
                       </div>
                     </div>
-                      <p class="fullscreen-form-field__hint">{{ t('repositoriesPage.hintQuotaAlertThreshold') }}</p>
-                      <p v-if="errors.quotaThreshold" class="el-form-item__error">{{ errors.quotaThreshold }}</p>
+                    <p class="fullscreen-form-field__hint">
+                      {{ t('repositoriesPage.hintQuotaAlertThreshold') }}
+                    </p>
+                    <p
+                      v-if="errors.quotaThreshold"
+                      class="el-form-item__error"
+                    >
+                      {{ errors.quotaThreshold }}
+                    </p>
                   </div>
                 </div>
               </ElForm>
@@ -872,51 +979,83 @@ watch(enableQuotaAlert, (enabled) => {
               <ElButton @click="handleBack">
                 {{ t('repositoriesPage.btnCancel') }}
               </ElButton>
-              <ElButton type="primary" :loading="busy" :disabled="busy" @click="onSubmit">
+              <ElButton
+                type="primary"
+                :loading="busy"
+                :disabled="busy"
+                @click="onSubmit"
+              >
                 {{ t('repositoriesPage.btnCreateRepo') }}
               </ElButton>
             </div>
           </div>
         </div>
 
-        <aside v-if="!embedded" class="fullscreen-form-sidebar add-form-preview-sidebar">
+        <aside
+          v-if="!embedded"
+          class="fullscreen-form-sidebar add-form-preview-sidebar"
+        >
           <div class="add-form-preview-card">
             <div class="add-form-preview-header">
               <div class="add-form-preview-header__glow" />
               <div class="add-form-preview-header__icon">
-                <HardDrive class="add-form-preview-header__icon-lucide" :size="28" />
+                <HardDrive
+                  class="add-form-preview-header__icon-lucide"
+                  :size="28"
+                />
               </div>
               <div class="add-form-preview-header__info">
-                <h4 class="add-form-preview-header__name">{{ repoName || t('addS3Repo.previewUnnamed') }}</h4>
-                <p class="add-form-preview-header__type">{{ t('repositoriesPage.kindProxyFs') }}</p>
+                <h4 class="add-form-preview-header__name">
+                  {{ repoName || t('addS3Repo.previewUnnamed') }}
+                </h4>
+                <p class="add-form-preview-header__type">
+                  {{ t('repositoriesPage.kindProxyFs') }}
+                </p>
               </div>
             </div>
 
             <div class="add-form-preview-body">
               <div class="add-form-preview-section">
-                <h5 class="add-form-preview-section__title">{{ t('addS3Repo.previewBasicInfo') }}</h5>
+                <h5 class="add-form-preview-section__title">
+                  {{ t('addS3Repo.previewBasicInfo') }}
+                </h5>
                 <div class="add-form-preview-row">
                   <span class="add-form-preview-row__label">{{ t('repositoriesPage.fieldRepoName') }}</span>
-                  <span class="add-form-preview-row__value" :class="{ 'add-form-preview-row__value--empty': !repoName }">
+                  <span
+                    class="add-form-preview-row__value"
+                    :class="{ 'add-form-preview-row__value--empty': !repoName }"
+                  >
                     {{ repoName || '—' }}
                   </span>
                 </div>
                 <div class="add-form-preview-row">
                   <span class="add-form-preview-row__label">{{ t('repositoriesPage.fieldProxyNode') }}</span>
-                  <span class="add-form-preview-row__value" :class="{ 'add-form-preview-row__value--empty': !selectedProxyNodeName }">
+                  <span
+                    class="add-form-preview-row__value"
+                    :class="{ 'add-form-preview-row__value--empty': !selectedProxyNodeName }"
+                  >
                     {{ selectedProxyNodeName || '—' }}
                   </span>
                 </div>
                 <div class="add-form-preview-row">
                   <span class="add-form-preview-row__label">{{ t('repositoriesPage.fieldQuota') }}</span>
-                  <span class="add-form-preview-row__value" :class="{ 'add-form-preview-row__value--highlight': quota > 0 }">
+                  <span
+                    class="add-form-preview-row__value"
+                    :class="{ 'add-form-preview-row__value--highlight': quota > 0 }"
+                  >
                     {{ quota > 0 ? `${quota} GB` : t('addS3Repo.previewUnlimited') }}
                   </span>
                 </div>
                 <div class="add-form-preview-row">
                   <span class="add-form-preview-row__label">{{ t('repositoriesPage.fieldQuotaAlert') }}</span>
-                  <span class="add-form-preview-row__value" :class="enableQuotaAlert ? 'add-form-preview-row__value--success' : 'add-form-preview-row__value--muted'">
-                    <span v-if="enableQuotaAlert" class="add-form-preview-row__dot add-form-preview-row__dot--green" />
+                  <span
+                    class="add-form-preview-row__value"
+                    :class="enableQuotaAlert ? 'add-form-preview-row__value--success' : 'add-form-preview-row__value--muted'"
+                  >
+                    <span
+                      v-if="enableQuotaAlert"
+                      class="add-form-preview-row__dot add-form-preview-row__dot--green"
+                    />
                     <template v-if="enableQuotaAlert">
                       {{ t('repositoriesPage.enabled') }} ({{ quotaAlertThreshold }}%)
                     </template>
@@ -928,16 +1067,24 @@ watch(enableQuotaAlert, (enabled) => {
               </div>
 
               <div class="add-form-preview-section">
-                <h5 class="add-form-preview-section__title">{{ t('addS3Repo.previewConnection') }}</h5>
+                <h5 class="add-form-preview-section__title">
+                  {{ t('addS3Repo.previewConnection') }}
+                </h5>
                 <div class="add-form-preview-row">
                   <span class="add-form-preview-row__label">{{ t('repositoriesPage.fieldProxyNodeBaseDir') }}</span>
-                  <span class="add-form-preview-row__value" :class="{ 'add-form-preview-row__value--empty': !proxyNodeDir }">
+                  <span
+                    class="add-form-preview-row__value"
+                    :class="{ 'add-form-preview-row__value--empty': !proxyNodeDir }"
+                  >
                     {{ proxyNodeDir || '—' }}
                   </span>
                 </div>
                 <div class="add-form-preview-row">
                   <span class="add-form-preview-row__label">{{ t('repositoriesPage.fieldManagedRepoPath') }}</span>
-                  <span class="add-form-preview-row__value" :class="{ 'add-form-preview-row__value--empty': !managedRepositoryPathPreview }">
+                  <span
+                    class="add-form-preview-row__value"
+                    :class="{ 'add-form-preview-row__value--empty': !managedRepositoryPathPreview }"
+                  >
                     {{ managedRepositoryPathPreview || '—' }}
                   </span>
                 </div>

--- a/src/frontend/src/pages/node/AddS3Repo.vue
+++ b/src/frontend/src/pages/node/AddS3Repo.vue
@@ -530,19 +530,33 @@ function handleBack() {
 </script>
 
 <template>
-  <div ref="pageRef" class="fullscreen-form-fullscreen resource-add-fullscreen" :class="{ 'resource-add-fullscreen--embedded': embedded }">
+  <div
+    ref="pageRef"
+    class="fullscreen-form-fullscreen resource-add-fullscreen"
+    :class="{ 'resource-add-fullscreen--embedded': embedded }"
+  >
     <div class="fullscreen-form-page add-s3-page">
-
       <!-- Header -->
-      <div v-if="!embedded" class="fullscreen-form-header">
-        <button class="fullscreen-form-header__back" @click="handleBack">
-          <ArrowLeft class="fullscreen-form-header__back-icon" :size="18" />
+      <div
+        v-if="!embedded"
+        class="fullscreen-form-header"
+      >
+        <button
+          class="fullscreen-form-header__back"
+          @click="handleBack"
+        >
+          <ArrowLeft
+            class="fullscreen-form-header__back-icon"
+            :size="18"
+          />
         </button>
         <div class="fullscreen-form-header__content">
           <h1 class="fullscreen-form-header__title">
             {{ t('addS3Repo.pageTitle') }}
           </h1>
-          <p class="fullscreen-form-header__desc">{{ t('addS3Repo.pageDesc') }}</p>
+          <p class="fullscreen-form-header__desc">
+            {{ t('addS3Repo.pageDesc') }}
+          </p>
         </div>
       </div>
 
@@ -550,18 +564,95 @@ function handleBack() {
         <!-- Main Form Area -->
         <div class="fullscreen-form-main">
           <div class="fullscreen-form-step-stack">
-              <div class="fullscreen-form-card">
-                <section class="fullscreen-form-section">
-                  <div class="fullscreen-form-section__head">
-                    <h3 class="fullscreen-form-section__title">
-                      <span class="fullscreen-form-section__indicator" />
-                      {{ t('addS3Repo.fieldPlatform') }}
-                    </h3>
+            <div class="fullscreen-form-card">
+              <section class="fullscreen-form-section">
+                <div class="fullscreen-form-section__head">
+                  <h3 class="fullscreen-form-section__title">
+                    <span class="fullscreen-form-section__indicator" />
+                    {{ t('addS3Repo.fieldPlatform') }}
+                  </h3>
+                  <div class="add-s3-search">
+                    <ElInput
+                      v-model="platformSearch"
+                      class="add-s3-search__input"
+                      :placeholder="t('addS3Repo.phSearchPlatform')"
+                      clearable
+                    >
+                      <template #prefix>
+                        <Search :size="14" />
+                      </template>
+                    </ElInput>
+                  </div>
+                </div>
+                <div
+                  v-if="catalogError"
+                  class="add-s3-empty-state"
+                >
+                  {{ catalogError }}
+                  <ElButton
+                    link
+                    type="primary"
+                    @click="loadProviderCatalog"
+                  >
+                    {{ t('common.retry') }}
+                  </ElButton>
+                </div>
+                <div
+                  v-loading="catalogLoading"
+                  class="add-s3-platform-grid add-s3-platform-grid--331"
+                >
+                  <button
+                    v-for="p in filteredPlatforms"
+                    :key="p.value"
+                    class="add-s3-platform-btn"
+                    :class="{
+                      'add-s3-platform-btn--active': storagePlatform === p.value,
+                      'add-s3-platform-btn--disabled': !isPlatformEnabled(p.value),
+                    }"
+                    :aria-disabled="!isPlatformEnabled(p.value)"
+                    :title="!isPlatformEnabled(p.value) ? t('addS3Repo.platformComingSoon') : undefined"
+                    @click="onPlatformChange(p.value)"
+                  >
+                    <div
+                      v-if="storagePlatform === p.value"
+                      class="add-s3-platform-btn__glow"
+                    />
+                    <span class="add-s3-platform-btn__icon">
+                      <S3PlatformBrandIcon
+                        :platform="p.value"
+                        :size="18"
+                        :alt="optionLabel(p)"
+                        icon-class="add-s3-platform-btn__icon-img"
+                        lucide-class="add-s3-platform-btn__icon-lucide"
+                      />
+                    </span>
+                    <span class="add-s3-platform-btn__label">{{ optionLabel(p) }}</span>
+                  </button>
+                  <div
+                    v-if="filteredPlatforms.length === 0"
+                    class="add-s3-empty-state"
+                  >
+                    {{ t('addS3Repo.emptyPlatforms') }}
+                  </div>
+                </div>
+                <p
+                  v-if="errors.platform"
+                  class="el-form-item__error"
+                >
+                  {{ errors.platform }}
+                </p>
+
+                <!-- Region Selection -->
+                <template v-if="currentRegions.length > 0">
+                  <div class="add-s3-region-head">
+                    <h4 class="fullscreen-form-section__subtitle">
+                      {{ t('addS3Repo.fieldRegion') }} <span class="fullscreen-form-field__required">*</span>
+                    </h4>
                     <div class="add-s3-search">
                       <ElInput
-                        v-model="platformSearch"
+                        v-model="regionSearch"
                         class="add-s3-search__input"
-                        :placeholder="t('addS3Repo.phSearchPlatform')"
+                        :placeholder="t('addS3Repo.phSearchRegion')"
                         clearable
                       >
                         <template #prefix>
@@ -570,190 +661,197 @@ function handleBack() {
                       </ElInput>
                     </div>
                   </div>
-                  <div v-if="catalogError" class="add-s3-empty-state">
-                    {{ catalogError }}
-                    <ElButton link type="primary" @click="loadProviderCatalog">{{ t('common.retry') }}</ElButton>
-                  </div>
-                  <div v-loading="catalogLoading" class="add-s3-platform-grid add-s3-platform-grid--331">
-                    <button
-                      v-for="p in filteredPlatforms"
-                      :key="p.value"
-                      class="add-s3-platform-btn"
-                      :class="{
-                        'add-s3-platform-btn--active': storagePlatform === p.value,
-                        'add-s3-platform-btn--disabled': !isPlatformEnabled(p.value),
-                      }"
-                      :aria-disabled="!isPlatformEnabled(p.value)"
-                      :title="!isPlatformEnabled(p.value) ? t('addS3Repo.platformComingSoon') : undefined"
-                      @click="onPlatformChange(p.value)"
+                  <div class="add-s3-region-groups add-s3-region-grid--scroll">
+                    <section
+                      v-for="group in groupedRegions"
+                      :key="group.key"
+                      class="add-s3-region-group"
                     >
-                      <div class="add-s3-platform-btn__glow" v-if="storagePlatform === p.value" />
-                      <span class="add-s3-platform-btn__icon">
-                        <S3PlatformBrandIcon
-                          :platform="p.value"
-                          :size="18"
-                          :alt="optionLabel(p)"
-                          icon-class="add-s3-platform-btn__icon-img"
-                          lucide-class="add-s3-platform-btn__icon-lucide"
-                        />
-                      </span>
-                      <span class="add-s3-platform-btn__label">{{ optionLabel(p) }}</span>
-                    </button>
-                    <div v-if="filteredPlatforms.length === 0" class="add-s3-empty-state">
-                      {{ t('addS3Repo.emptyPlatforms') }}
-                    </div>
-                  </div>
-                  <p v-if="errors.platform" class="el-form-item__error">{{ errors.platform }}</p>
-
-                  <!-- Region Selection -->
-                  <template v-if="currentRegions.length > 0">
-                    <div class="add-s3-region-head">
-                      <h4 class="fullscreen-form-section__subtitle">
-                        {{ t('addS3Repo.fieldRegion') }} <span class="fullscreen-form-field__required">*</span>
-                      </h4>
-                      <div class="add-s3-search">
-                        <ElInput
-                          v-model="regionSearch"
-                          class="add-s3-search__input"
-                          :placeholder="t('addS3Repo.phSearchRegion')"
-                          clearable
+                      <h5 class="add-s3-region-group__title">
+                        {{ group.label }}
+                      </h5>
+                      <div class="add-s3-region-grid">
+                        <button
+                          v-for="r in group.regions"
+                          :key="r.key"
+                          class="add-s3-region-btn"
+                          :class="{ 'add-s3-region-btn--active': platformRegionKey === r.key }"
+                          @click="applyRegionPreset(r.key)"
                         >
-                          <template #prefix>
-                            <Search :size="14" />
-                          </template>
-                        </ElInput>
+                          <span class="add-s3-region-btn__label">{{ r.label }}</span>
+                          <span class="add-s3-region-btn__code">{{ r.region }}</span>
+                        </button>
                       </div>
-                    </div>
-                    <div class="add-s3-region-groups add-s3-region-grid--scroll">
-                      <section v-for="group in groupedRegions" :key="group.key" class="add-s3-region-group">
-                        <h5 class="add-s3-region-group__title">{{ group.label }}</h5>
-                        <div class="add-s3-region-grid">
-                          <button
-                            v-for="r in group.regions"
-                            :key="r.key"
-                            class="add-s3-region-btn"
-                            :class="{ 'add-s3-region-btn--active': platformRegionKey === r.key }"
-                            @click="applyRegionPreset(r.key)"
-                          >
-                            <span class="add-s3-region-btn__label">{{ r.label }}</span>
-                            <span class="add-s3-region-btn__code">{{ r.region }}</span>
-                          </button>
-                        </div>
-                      </section>
-                      <div v-if="filteredRegions.length === 0" class="add-s3-empty-state">
-                        {{ t('addS3Repo.emptyRegions') }}
-                      </div>
-                    </div>
-                  </template>
-                </section>
-              </div>
-
-              <div class="fullscreen-form-card">
-                <section class="fullscreen-form-section">
-                  <h3 class="fullscreen-form-section__title">
-                    <span class="fullscreen-form-section__indicator" />
-                    {{ t('addS3Repo.connectionTitle') }}
-                  </h3>
-
-                  <div class="fullscreen-form-grid">
-                    <!-- Endpoint -->
-                    <div data-validation-field="endpoint" class="fullscreen-form-field">
-                      <label class="fullscreen-form-field__label">
-                        {{ t('addS3Repo.fieldEndpoint') }} <span class="fullscreen-form-field__required">*</span>
-                      </label>
-                      <ElInput
-                        v-model="endpoint"
-                        class="add-s3-element-field"
-                        :placeholder="endpointPlaceholder"
-                        :disabled="!!platformRegionKey"
-                        @blur="endpoint = normalizeS3EndpointInput(endpoint)"
-                        @input="clearFieldError('endpoint')"
-                      />
-                      <p class="fullscreen-form-field__hint">{{ t('addS3Repo.hintEndpoint') }}</p>
-                      <p v-if="errors.endpoint" class="el-form-item__error">{{ errors.endpoint }}</p>
-                    </div>
-
-                    <!-- Region -->
-                    <div class="fullscreen-form-field">
-                      <label class="fullscreen-form-field__label">
-                        {{ t('addS3Repo.fieldRegion') }}
-                      </label>
-                      <ElInput
-                        v-model="region"
-                        class="add-s3-element-field"
-                        :placeholder="t('addS3Repo.phRegion')"
-                        :disabled="regionReadonly"
-                      />
-                      <p class="fullscreen-form-field__hint">{{ t('addS3Repo.hintRegion') }}</p>
-                    </div>
-
-                    <!-- Access Key -->
-                    <div data-validation-field="accessKey" class="fullscreen-form-field">
-                      <label class="fullscreen-form-field__label">
-                        {{ t('addS3Repo.fieldAccessKey') }} <span class="fullscreen-form-field__required">*</span>
-                      </label>
-                      <ElInput
-                        v-model="accessKeyId"
-                        class="add-s3-element-field"
-                        :placeholder="t('addS3Repo.phAccessKey')"
-                        @input="clearFieldError('accessKey')"
-                      />
-                      <p class="fullscreen-form-field__hint">{{ t('addS3Repo.hintAccessKey') }}</p>
-                      <p v-if="errors.accessKey" class="el-form-item__error">{{ errors.accessKey }}</p>
-                    </div>
-
-                    <!-- Secret Key -->
-                    <div data-validation-field="secretKey" class="fullscreen-form-field">
-                      <label class="fullscreen-form-field__label">
-                        {{ t('addS3Repo.fieldSecretKey') }} <span class="fullscreen-form-field__required">*</span>
-                      </label>
-                      <ElInput
-                        v-model="accessKeySecret"
-                        type="password"
-                        show-password
-                        class="add-s3-element-field"
-                        :placeholder="t('addS3Repo.phSecretKey')"
-                        @input="clearFieldError('secretKey')"
-                      />
-                      <p class="fullscreen-form-field__hint">{{ t('addS3Repo.hintSecretKey') }}</p>
-                      <p v-if="errors.secretKey" class="el-form-item__error">{{ errors.secretKey }}</p>
-                    </div>
-
-                    <!-- Path Style -->
-                    <div class="fullscreen-form-field">
-                      <label class="fullscreen-form-field__label">
-                        {{ t('addS3Repo.fieldS3UrlStyle') }} <span class="fullscreen-form-field__required">*</span>
-                      </label>
-                      <ElSelect v-model="s3UrlStyle" class="add-s3-element-field">
-                        <ElOption :label="t('addS3Repo.s3UrlStyleAuto')" value="auto" />
-                        <ElOption :label="t('addS3Repo.s3UrlStylePath')" value="path" />
-                        <ElOption :label="t('addS3Repo.s3UrlStyleVirtualHosted')" value="virtual_hosted" />
-                      </ElSelect>
-                      <p class="fullscreen-form-field__hint">{{ t('addS3Repo.hintS3UrlStyle') }}</p>
-                    </div>
-
-                    <!-- TLS Toggle -->
-                    <div class="fullscreen-form-field">
-                      <label class="fullscreen-form-field__label fullscreen-form-field__label--toggle">
-                        {{ t('addS3Repo.fieldUseTls') }} <span class="fullscreen-form-field__required">*</span>
-                      </label>
-                      <div class="add-s3-toggle">
-                        <ElSwitch v-model="useTls" />
-                        <span class="fullscreen-form-field__hint add-s3-toggle__label">{{ useTls ? t('addS3Repo.tlsOnHint') : t('addS3Repo.tlsOffHint') }}</span>
-                      </div>
+                    </section>
+                    <div
+                      v-if="filteredRegions.length === 0"
+                      class="add-s3-empty-state"
+                    >
+                      {{ t('addS3Repo.emptyRegions') }}
                     </div>
                   </div>
+                </template>
+              </section>
+            </div>
 
-                  <div v-if="authStatus !== 'idle'" class="add-s3-auth-check">
-                    <p class="add-s3-auth-status" :class="`add-s3-auth-status--${authStatus}`">
-                      <span class="add-s3-auth-status__dot" />
-                      {{ authStatusText }}
+            <div class="fullscreen-form-card">
+              <section class="fullscreen-form-section">
+                <h3 class="fullscreen-form-section__title">
+                  <span class="fullscreen-form-section__indicator" />
+                  {{ t('addS3Repo.connectionTitle') }}
+                </h3>
+
+                <div class="fullscreen-form-grid">
+                  <!-- Endpoint -->
+                  <div
+                    data-validation-field="endpoint"
+                    class="fullscreen-form-field"
+                  >
+                    <label class="fullscreen-form-field__label">
+                      {{ t('addS3Repo.fieldEndpoint') }} <span class="fullscreen-form-field__required">*</span>
+                    </label>
+                    <ElInput
+                      v-model="endpoint"
+                      class="add-s3-element-field"
+                      :placeholder="endpointPlaceholder"
+                      :disabled="!!platformRegionKey"
+                      @blur="endpoint = normalizeS3EndpointInput(endpoint)"
+                      @input="clearFieldError('endpoint')"
+                    />
+                    <p class="fullscreen-form-field__hint">
+                      {{ t('addS3Repo.hintEndpoint') }}
+                    </p>
+                    <p
+                      v-if="errors.endpoint"
+                      class="el-form-item__error"
+                    >
+                      {{ errors.endpoint }}
                     </p>
                   </div>
-                </section>
-              </div>
 
-              <div class="fullscreen-form-card">
+                  <!-- Region -->
+                  <div class="fullscreen-form-field">
+                    <label class="fullscreen-form-field__label">
+                      {{ t('addS3Repo.fieldRegion') }}
+                    </label>
+                    <ElInput
+                      v-model="region"
+                      class="add-s3-element-field"
+                      :placeholder="t('addS3Repo.phRegion')"
+                      :disabled="regionReadonly"
+                    />
+                    <p class="fullscreen-form-field__hint">
+                      {{ t('addS3Repo.hintRegion') }}
+                    </p>
+                  </div>
+
+                  <!-- Access Key -->
+                  <div
+                    data-validation-field="accessKey"
+                    class="fullscreen-form-field"
+                  >
+                    <label class="fullscreen-form-field__label">
+                      {{ t('addS3Repo.fieldAccessKey') }} <span class="fullscreen-form-field__required">*</span>
+                    </label>
+                    <ElInput
+                      v-model="accessKeyId"
+                      class="add-s3-element-field"
+                      :placeholder="t('addS3Repo.phAccessKey')"
+                      @input="clearFieldError('accessKey')"
+                    />
+                    <p class="fullscreen-form-field__hint">
+                      {{ t('addS3Repo.hintAccessKey') }}
+                    </p>
+                    <p
+                      v-if="errors.accessKey"
+                      class="el-form-item__error"
+                    >
+                      {{ errors.accessKey }}
+                    </p>
+                  </div>
+
+                  <!-- Secret Key -->
+                  <div
+                    data-validation-field="secretKey"
+                    class="fullscreen-form-field"
+                  >
+                    <label class="fullscreen-form-field__label">
+                      {{ t('addS3Repo.fieldSecretKey') }} <span class="fullscreen-form-field__required">*</span>
+                    </label>
+                    <ElInput
+                      v-model="accessKeySecret"
+                      type="password"
+                      show-password
+                      class="add-s3-element-field"
+                      :placeholder="t('addS3Repo.phSecretKey')"
+                      @input="clearFieldError('secretKey')"
+                    />
+                    <p class="fullscreen-form-field__hint">
+                      {{ t('addS3Repo.hintSecretKey') }}
+                    </p>
+                    <p
+                      v-if="errors.secretKey"
+                      class="el-form-item__error"
+                    >
+                      {{ errors.secretKey }}
+                    </p>
+                  </div>
+
+                  <!-- Path Style -->
+                  <div class="fullscreen-form-field">
+                    <label class="fullscreen-form-field__label">
+                      {{ t('addS3Repo.fieldS3UrlStyle') }} <span class="fullscreen-form-field__required">*</span>
+                    </label>
+                    <ElSelect
+                      v-model="s3UrlStyle"
+                      class="add-s3-element-field"
+                    >
+                      <ElOption
+                        :label="t('addS3Repo.s3UrlStyleAuto')"
+                        value="auto"
+                      />
+                      <ElOption
+                        :label="t('addS3Repo.s3UrlStylePath')"
+                        value="path"
+                      />
+                      <ElOption
+                        :label="t('addS3Repo.s3UrlStyleVirtualHosted')"
+                        value="virtual_hosted"
+                      />
+                    </ElSelect>
+                    <p class="fullscreen-form-field__hint">
+                      {{ t('addS3Repo.hintS3UrlStyle') }}
+                    </p>
+                  </div>
+
+                  <!-- TLS Toggle -->
+                  <div class="fullscreen-form-field">
+                    <label class="fullscreen-form-field__label fullscreen-form-field__label--toggle">
+                      {{ t('addS3Repo.fieldUseTls') }} <span class="fullscreen-form-field__required">*</span>
+                    </label>
+                    <div class="add-s3-toggle">
+                      <ElSwitch v-model="useTls" />
+                      <span class="fullscreen-form-field__hint add-s3-toggle__label">{{ useTls ? t('addS3Repo.tlsOnHint') : t('addS3Repo.tlsOffHint') }}</span>
+                    </div>
+                  </div>
+                </div>
+
+                <div
+                  v-if="authStatus !== 'idle'"
+                  class="add-s3-auth-check"
+                >
+                  <p
+                    class="add-s3-auth-status"
+                    :class="`add-s3-auth-status--${authStatus}`"
+                  >
+                    <span class="add-s3-auth-status__dot" />
+                    {{ authStatusText }}
+                  </p>
+                </div>
+              </section>
+            </div>
+
+            <div class="fullscreen-form-card">
               <section class="fullscreen-form-section">
                 <h3 class="fullscreen-form-section__title">
                   <span class="fullscreen-form-section__indicator" />
@@ -761,87 +859,137 @@ function handleBack() {
                 </h3>
                 <div class="fullscreen-form-grid">
                   <div class="add-s3-repo-primary-fields">
-                  <!-- Repo Name -->
-                  <div data-validation-field="repoName" class="fullscreen-form-field">
-                    <label class="fullscreen-form-field__label">
-                      {{ t('addS3Repo.fieldRepoName') }} <span class="fullscreen-form-field__required">*</span>
-                    </label>
-                    <ElInput
-                      v-model="repoName"
-                      class="add-s3-element-field add-s3-repo-primary-input"
-                      :placeholder="t('addS3Repo.phRepoName')"
-                      @input="onRepoNameInput(); clearFieldError('repoName')"
-                    />
-                    <p class="fullscreen-form-field__hint">{{ t('addS3Repo.hintRepoName') }}</p>
-                    <p v-if="errors.repoName" class="el-form-item__error">{{ errors.repoName }}</p>
-                  </div>
-
-                  <!-- Bucket -->
-                  <div data-validation-field="bucket" class="fullscreen-form-field">
-                    <label class="fullscreen-form-field__label">
-                      {{ t('addS3Repo.fieldBucket') }} <span class="fullscreen-form-field__required">*</span>
-                    </label>
-                    <ElRadioGroup
-                      :model-value="bucketMode"
-                      class="source-radio-row hfl-segment-radio-row add-s3-bucket-segment"
-                      @update:model-value="(mode) => setBucketMode(mode as 'existing' | 'new')"
+                    <!-- Repo Name -->
+                    <div
+                      data-validation-field="repoName"
+                      class="fullscreen-form-field"
                     >
-                      <ElRadio value="existing" border class="source-radio-card !mr-0">
-                        {{ t('addS3Repo.fieldBucketExisting') }}
-                      </ElRadio>
-                      <ElRadio value="new" border class="source-radio-card !mr-0">
-                        {{ t('addS3Repo.fieldBucketNew') }}
-                      </ElRadio>
-                    </ElRadioGroup>
-                    <div v-if="bucketMode === 'existing'" class="add-s3-bucket-select-row">
-                      <ElSelect
-                        v-model="bucket"
-                        class="add-s3-bucket-select"
-                        filterable
-                        clearable
-                        :loading="refreshingBuckets"
-                        :placeholder="refreshingBuckets ? t('addS3Repo.btnValidatingAuth') : t('addS3Repo.phBucketSelect')"
-                        @focus="loadBucketsForSelect"
-                        @visible-change="(open) => open && loadBucketsForSelect()"
-                        @change="clearFieldError('bucket')"
+                      <label class="fullscreen-form-field__label">
+                        {{ t('addS3Repo.fieldRepoName') }} <span class="fullscreen-form-field__required">*</span>
+                      </label>
+                      <ElInput
+                        v-model="repoName"
+                        class="add-s3-element-field add-s3-repo-primary-input"
+                        :placeholder="t('addS3Repo.phRepoName')"
+                        @input="onRepoNameInput(); clearFieldError('repoName')"
+                      />
+                      <p class="fullscreen-form-field__hint">
+                        {{ t('addS3Repo.hintRepoName') }}
+                      </p>
+                      <p
+                        v-if="errors.repoName"
+                        class="el-form-item__error"
                       >
-                        <ElOption v-for="item in bucketSelectOptions" :key="item" :label="item" :value="item" />
-                      </ElSelect>
-                      <button
-                        class="add-s3-icon-btn"
-                        type="button"
-                        :title="t('common.refresh')"
-                        :disabled="refreshingBuckets"
-                        @click="refreshBuckets"
-                      >
-                        <RefreshCw class="add-s3-icon-btn__icon" :class="{ 'add-s3-icon-btn__icon--spinning': refreshingBuckets }" :size="16" />
-                      </button>
+                        {{ errors.repoName }}
+                      </p>
                     </div>
-                    <ElInput
-                      v-else
-                      v-model="bucket"
-                      class="add-s3-element-field add-s3-repo-primary-input"
-                      :placeholder="t('addS3Repo.phBucketNew')"
-                      @input="clearFieldError('bucket')"
-                    />
-                    <p class="fullscreen-form-field__hint">{{ t('addS3Repo.hintBucket') }}</p>
-                    <p v-if="errors.bucket" class="el-form-item__error">{{ errors.bucket }}</p>
-                  </div>
-                  <!-- Prefix -->
-                  <div data-validation-field="prefix" class="fullscreen-form-field">
-                    <label class="fullscreen-form-field__label">
-                      {{ t('addS3Repo.fieldPrefix') }} <span class="fullscreen-form-field__required">*</span>
-                    </label>
-                    <ElInput
-                      v-model="prefix"
-                      class="add-s3-element-field add-s3-repo-primary-input"
-                      :placeholder="t('addS3Repo.phPrefix')"
-                      @blur="prefix = normalizeS3ObjectPrefix(prefix)"
-                      @input="clearFieldError('prefix')"
-                    />
-                    <p class="fullscreen-form-field__hint">{{ t('addS3Repo.hintPrefix') }}</p>
-                    <p v-if="errors.prefix" class="el-form-item__error">{{ errors.prefix }}</p>
-                  </div>
+
+                    <!-- Bucket -->
+                    <div
+                      data-validation-field="bucket"
+                      class="fullscreen-form-field"
+                    >
+                      <label class="fullscreen-form-field__label">
+                        {{ t('addS3Repo.fieldBucket') }} <span class="fullscreen-form-field__required">*</span>
+                      </label>
+                      <ElRadioGroup
+                        :model-value="bucketMode"
+                        class="source-radio-row hfl-segment-radio-row add-s3-bucket-segment"
+                        @update:model-value="(mode) => setBucketMode(mode as 'existing' | 'new')"
+                      >
+                        <ElRadio
+                          value="existing"
+                          border
+                          class="source-radio-card !mr-0"
+                        >
+                          {{ t('addS3Repo.fieldBucketExisting') }}
+                        </ElRadio>
+                        <ElRadio
+                          value="new"
+                          border
+                          class="source-radio-card !mr-0"
+                        >
+                          {{ t('addS3Repo.fieldBucketNew') }}
+                        </ElRadio>
+                      </ElRadioGroup>
+                      <div
+                        v-if="bucketMode === 'existing'"
+                        class="add-s3-bucket-select-row"
+                      >
+                        <ElSelect
+                          v-model="bucket"
+                          class="add-s3-bucket-select"
+                          filterable
+                          clearable
+                          :loading="refreshingBuckets"
+                          :placeholder="refreshingBuckets ? t('addS3Repo.btnValidatingAuth') : t('addS3Repo.phBucketSelect')"
+                          @focus="loadBucketsForSelect"
+                          @visible-change="(open) => open && loadBucketsForSelect()"
+                          @change="clearFieldError('bucket')"
+                        >
+                          <ElOption
+                            v-for="item in bucketSelectOptions"
+                            :key="item"
+                            :label="item"
+                            :value="item"
+                          />
+                        </ElSelect>
+                        <button
+                          class="add-s3-icon-btn"
+                          type="button"
+                          :title="t('common.refresh')"
+                          :disabled="refreshingBuckets"
+                          @click="refreshBuckets"
+                        >
+                          <RefreshCw
+                            class="add-s3-icon-btn__icon"
+                            :class="{ 'add-s3-icon-btn__icon--spinning': refreshingBuckets }"
+                            :size="16"
+                          />
+                        </button>
+                      </div>
+                      <ElInput
+                        v-else
+                        v-model="bucket"
+                        class="add-s3-element-field add-s3-repo-primary-input"
+                        :placeholder="t('addS3Repo.phBucketNew')"
+                        @input="clearFieldError('bucket')"
+                      />
+                      <p class="fullscreen-form-field__hint">
+                        {{ t('addS3Repo.hintBucket') }}
+                      </p>
+                      <p
+                        v-if="errors.bucket"
+                        class="el-form-item__error"
+                      >
+                        {{ errors.bucket }}
+                      </p>
+                    </div>
+                    <!-- Prefix -->
+                    <div
+                      data-validation-field="prefix"
+                      class="fullscreen-form-field"
+                    >
+                      <label class="fullscreen-form-field__label">
+                        {{ t('addS3Repo.fieldPrefix') }} <span class="fullscreen-form-field__required">*</span>
+                      </label>
+                      <ElInput
+                        v-model="prefix"
+                        class="add-s3-element-field add-s3-repo-primary-input"
+                        :placeholder="t('addS3Repo.phPrefix')"
+                        @blur="prefix = normalizeS3ObjectPrefix(prefix)"
+                        @input="clearFieldError('prefix')"
+                      />
+                      <p class="fullscreen-form-field__hint">
+                        {{ t('addS3Repo.hintPrefix') }}
+                      </p>
+                      <p
+                        v-if="errors.prefix"
+                        class="el-form-item__error"
+                      >
+                        {{ errors.prefix }}
+                      </p>
+                    </div>
                   </div>
 
                   <!-- Quota -->
@@ -857,15 +1005,24 @@ function handleBack() {
                             :min="0"
                             controls-position="right"
                           />
-                          <div class="repository-quota-number__suffix">GB</div>
+                          <div class="repository-quota-number__suffix">
+                            GB
+                          </div>
                         </div>
                       </div>
-                      <p class="fullscreen-form-field__hint">{{ t('addS3Repo.hintQuota') }}</p>
+                      <p class="fullscreen-form-field__hint">
+                        {{ t('addS3Repo.hintQuota') }}
+                      </p>
                     </div>
 
-                    <div data-validation-field="quotaThreshold" class="fullscreen-form-field repository-quota-field repository-quota-field--monitoring">
+                    <div
+                      data-validation-field="quotaThreshold"
+                      class="fullscreen-form-field repository-quota-field repository-quota-field--monitoring"
+                    >
                       <div class="fullscreen-form-field__label repository-quota-head repository-quota-title-row">
-                        <ElCheckbox v-model="enableQuotaAlert">{{ t('repositoriesPage.fieldQuotaAlert') }}</ElCheckbox>
+                        <ElCheckbox v-model="enableQuotaAlert">
+                          {{ t('repositoriesPage.fieldQuotaAlert') }}
+                        </ElCheckbox>
                       </div>
                       <div class="repository-quota-control">
                         <div class="repository-quota-number repository-quota-input">
@@ -877,31 +1034,53 @@ function handleBack() {
                             controls-position="right"
                             @change="clearFieldError('quotaThreshold')"
                           />
-                          <div class="repository-quota-number__suffix">%</div>
+                          <div class="repository-quota-number__suffix">
+                            %
+                          </div>
                         </div>
                       </div>
-                      <p class="fullscreen-form-field__hint">{{ t('addS3Repo.hintQuotaAlertThreshold') }}</p>
-                      <p v-if="errors.quotaThreshold" class="el-form-item__error">{{ errors.quotaThreshold }}</p>
+                      <p class="fullscreen-form-field__hint">
+                        {{ t('addS3Repo.hintQuotaAlertThreshold') }}
+                      </p>
+                      <p
+                        v-if="errors.quotaThreshold"
+                        class="el-form-item__error"
+                      >
+                        {{ errors.quotaThreshold }}
+                      </p>
                     </div>
                   </div>
                 </div>
               </section>
-              </div>
             </div>
+          </div>
 
           <!-- Footer Actions -->
           <div class="fullscreen-form-footer add-s3-footer">
-            <p v-if="submitBlockReason" class="form-submit-hint">{{ submitBlockReason }}</p>
+            <p
+              v-if="submitBlockReason"
+              class="form-submit-hint"
+            >
+              {{ submitBlockReason }}
+            </p>
             <ElButton @click="handleBack">
               {{ t('repositoriesPage.btnCancel') }}
             </ElButton>
-            <ElButton type="primary" :loading="busy" :disabled="!canSubmit" @click="onSubmit">
+            <ElButton
+              type="primary"
+              :loading="busy"
+              :disabled="!canSubmit"
+              @click="onSubmit"
+            >
               {{ t('addS3Repo.btnCreateInit') }}
             </ElButton>
           </div>
         </div>
 
-        <aside v-if="!embedded" class="fullscreen-form-sidebar add-form-preview-sidebar">
+        <aside
+          v-if="!embedded"
+          class="fullscreen-form-sidebar add-form-preview-sidebar"
+        >
           <div class="add-form-preview-card">
             <!-- Preview Header -->
             <div class="add-form-preview-header">
@@ -916,24 +1095,36 @@ function handleBack() {
                 />
               </div>
               <div class="add-form-preview-header__info">
-                <h4 class="add-form-preview-header__name">{{ repoName || t('addS3Repo.previewUnnamed') }}</h4>
-                <p class="add-form-preview-header__type">{{ platformLabel || t('addS3Repo.previewSelectPlatform') }}</p>
+                <h4 class="add-form-preview-header__name">
+                  {{ repoName || t('addS3Repo.previewUnnamed') }}
+                </h4>
+                <p class="add-form-preview-header__type">
+                  {{ platformLabel || t('addS3Repo.previewSelectPlatform') }}
+                </p>
               </div>
             </div>
 
             <!-- Preview Body -->
             <div class="add-form-preview-body">
               <div class="add-form-preview-section">
-                <h5 class="add-form-preview-section__title">{{ t('addS3Repo.previewConnectionAuth') }}</h5>
+                <h5 class="add-form-preview-section__title">
+                  {{ t('addS3Repo.previewConnectionAuth') }}
+                </h5>
                 <div class="add-form-preview-row">
                   <span class="add-form-preview-row__label">{{ t('addS3Repo.fieldEndpoint') }}</span>
-                  <span class="add-form-preview-row__value" :class="{ 'add-form-preview-row__value--empty': !endpoint }">
+                  <span
+                    class="add-form-preview-row__value"
+                    :class="{ 'add-form-preview-row__value--empty': !endpoint }"
+                  >
                     {{ s3EndpointDisplay(endpoint) }}
                   </span>
                 </div>
                 <div class="add-form-preview-row">
                   <span class="add-form-preview-row__label">{{ t('addS3Repo.fieldRegion') }}</span>
-                  <span class="add-form-preview-row__value" :class="{ 'add-form-preview-row__value--empty': !region }">
+                  <span
+                    class="add-form-preview-row__value"
+                    :class="{ 'add-form-preview-row__value--empty': !region }"
+                  >
                     {{ region || '—' }}
                   </span>
                 </div>
@@ -967,30 +1158,48 @@ function handleBack() {
                 </div>
                 <div class="add-form-preview-row">
                   <span class="add-form-preview-row__label">{{ t('addS3Repo.fieldUseTls') }}</span>
-                  <span class="add-form-preview-row__value" :class="useTls ? 'add-form-preview-row__value--success' : 'add-form-preview-row__value--muted'">
-                    <ShieldCheck v-if="useTls" class="add-form-preview-row__shield" :size="14" />
+                  <span
+                    class="add-form-preview-row__value"
+                    :class="useTls ? 'add-form-preview-row__value--success' : 'add-form-preview-row__value--muted'"
+                  >
+                    <ShieldCheck
+                      v-if="useTls"
+                      class="add-form-preview-row__shield"
+                      :size="14"
+                    />
                     {{ useTls ? 'HTTPS' : 'HTTP' }}
                   </span>
                 </div>
               </div>
 
               <div class="add-form-preview-section">
-                <h5 class="add-form-preview-section__title">{{ t('addS3Repo.previewRepoConfig') }}</h5>
+                <h5 class="add-form-preview-section__title">
+                  {{ t('addS3Repo.previewRepoConfig') }}
+                </h5>
                 <div class="add-form-preview-row">
                   <span class="add-form-preview-row__label">{{ t('addS3Repo.fieldBucket') }}</span>
-                  <span class="add-form-preview-row__value" :class="{ 'add-form-preview-row__value--empty': !bucket }">
+                  <span
+                    class="add-form-preview-row__value"
+                    :class="{ 'add-form-preview-row__value--empty': !bucket }"
+                  >
                     {{ bucket || '—' }}
                   </span>
                 </div>
                 <div class="add-form-preview-row">
                   <span class="add-form-preview-row__label">{{ t('addS3Repo.fieldPrefix') }}</span>
-                  <span class="add-form-preview-row__value" :class="{ 'add-form-preview-row__value--empty': !prefix }">
+                  <span
+                    class="add-form-preview-row__value"
+                    :class="{ 'add-form-preview-row__value--empty': !prefix }"
+                  >
                     {{ prefix || '—' }}
                   </span>
                 </div>
                 <div class="add-form-preview-row">
                   <span class="add-form-preview-row__label">{{ t('addS3Repo.fieldQuota') }}</span>
-                  <span class="add-form-preview-row__value" :class="{ 'add-form-preview-row__value--highlight': quota > 0 }">
+                  <span
+                    class="add-form-preview-row__value"
+                    :class="{ 'add-form-preview-row__value--highlight': quota > 0 }"
+                  >
                     {{ quota > 0 ? `${quota} GB` : t('addS3Repo.previewUnlimited') }}
                   </span>
                 </div>
@@ -1000,7 +1209,10 @@ function handleBack() {
                     class="add-form-preview-row__value"
                     :class="enableQuotaAlert ? 'add-form-preview-row__value--success' : 'add-form-preview-row__value--muted'"
                   >
-                    <span v-if="enableQuotaAlert" class="add-form-preview-row__dot add-form-preview-row__dot--green" />
+                    <span
+                      v-if="enableQuotaAlert"
+                      class="add-form-preview-row__dot add-form-preview-row__dot--green"
+                    />
                     <template v-if="enableQuotaAlert">
                       {{ t('repositoriesPage.enabled') }} ({{ quotaAlertThreshold }}%)
                     </template>

--- a/src/frontend/src/pages/node/EditProxyFsRepo.vue
+++ b/src/frontend/src/pages/node/EditProxyFsRepo.vue
@@ -205,7 +205,10 @@ watch(repositoryId, (id) => {
 </script>
 
 <template>
-  <div ref="pageRef" class="fullscreen-form-fullscreen resource-add-fullscreen">
+  <div
+    ref="pageRef"
+    class="fullscreen-form-fullscreen resource-add-fullscreen"
+  >
     <div class="fullscreen-form-page add-proxy-fs-page edit-proxy-fs-page">
       <header class="fullscreen-form-header">
         <button
@@ -220,7 +223,10 @@ watch(repositoryId, (id) => {
         </button>
         <div class="fullscreen-form-header__content">
           <h1 class="fullscreen-form-header__title">
-            <Wrench :size="18" class="inline-block align-[-3px] mr-1 text-[rgb(37_99_235)]" />
+            <Wrench
+              :size="18"
+              class="inline-block align-[-3px] mr-1 text-[rgb(37_99_235)]"
+            />
             {{ t('repositoriesPage.editProxyFsRepo.pageTitle') }}
           </h1>
           <p class="fullscreen-form-header__desc">
@@ -337,7 +343,10 @@ watch(repositoryId, (id) => {
                   </p>
                 </div>
 
-                <div data-validation-field="quotaThreshold" class="fullscreen-form-field add-proxy-fs-quota-col add-proxy-fs-quota-panel">
+                <div
+                  data-validation-field="quotaThreshold"
+                  class="fullscreen-form-field add-proxy-fs-quota-col add-proxy-fs-quota-panel"
+                >
                   <div class="fullscreen-form-field__label add-proxy-fs-quota-head add-proxy-fs-quota-title-row">
                     <ElCheckbox v-model="quotaAlertEnabled">
                       {{ t('repositoriesPage.fieldQuotaAlert') }}
@@ -362,7 +371,12 @@ watch(repositoryId, (id) => {
                   <p class="fullscreen-form-field__hint">
                     {{ t('repositoriesPage.hintQuotaAlertThreshold') }}
                   </p>
-                  <p v-if="errors.quotaThreshold" class="el-form-item__error">{{ errors.quotaThreshold }}</p>
+                  <p
+                    v-if="errors.quotaThreshold"
+                    class="el-form-item__error"
+                  >
+                    {{ errors.quotaThreshold }}
+                  </p>
                 </div>
               </div>
             </ElForm>

--- a/src/frontend/src/pages/node/EditS3Repo.vue
+++ b/src/frontend/src/pages/node/EditS3Repo.vue
@@ -293,7 +293,10 @@ watch(repositoryId, (id) => {
 </script>
 
 <template>
-  <div ref="pageRef" class="fullscreen-form-fullscreen resource-add-fullscreen">
+  <div
+    ref="pageRef"
+    class="fullscreen-form-fullscreen resource-add-fullscreen"
+  >
     <div class="fullscreen-form-page add-s3-page edit-s3-page">
       <div class="fullscreen-form-header">
         <button
@@ -307,7 +310,10 @@ watch(repositoryId, (id) => {
         </button>
         <div class="fullscreen-form-header__content">
           <h1 class="fullscreen-form-header__title">
-            <Wrench :size="18" class="inline-block align-[-3px] mr-1 text-[rgb(37_99_235)]" />
+            <Wrench
+              :size="18"
+              class="inline-block align-[-3px] mr-1 text-[rgb(37_99_235)]"
+            />
             {{ t('repositoriesPage.editS3Repo.pageTitle') }}
           </h1>
           <p class="fullscreen-form-header__desc">
@@ -512,7 +518,10 @@ watch(repositoryId, (id) => {
                 <div class="fullscreen-form-grid">
                   <div class="add-s3-repo-primary-fields">
                     <!-- Repo Name -->
-                    <div data-validation-field="name" class="fullscreen-form-field">
+                    <div
+                      data-validation-field="name"
+                      class="fullscreen-form-field"
+                    >
                       <label class="fullscreen-form-field__label edit-s3-locked-label">
                         {{ t('addS3Repo.fieldRepoName') }}
                         <span class="fullscreen-form-field__required">*</span>
@@ -526,7 +535,12 @@ watch(repositoryId, (id) => {
                       <p class="fullscreen-form-field__hint">
                         {{ t('addS3Repo.hintRepoName') }}
                       </p>
-                      <p v-if="errors.name" class="el-form-item__error">{{ errors.name }}</p>
+                      <p
+                        v-if="errors.name"
+                        class="el-form-item__error"
+                      >
+                        {{ errors.name }}
+                      </p>
                     </div>
 
                     <!-- Bucket (locked) -->
@@ -597,7 +611,10 @@ watch(repositoryId, (id) => {
                       </p>
                     </div>
 
-                    <div data-validation-field="quotaThreshold" class="fullscreen-form-field add-s3-quota-pair__col add-s3-quota-alert-field">
+                    <div
+                      data-validation-field="quotaThreshold"
+                      class="fullscreen-form-field add-s3-quota-pair__col add-s3-quota-alert-field"
+                    >
                       <div class="fullscreen-form-field__label add-s3-quota-pair__head add-s3-quota-alert-head">
                         <ElCheckbox v-model="quotaAlertEnabled">
                           {{ t('addS3Repo.fieldQuotaAlert') }}
@@ -624,7 +641,12 @@ watch(repositoryId, (id) => {
                       <p class="fullscreen-form-field__hint">
                         {{ t('addS3Repo.hintQuotaAlertThreshold') }}
                       </p>
-                      <p v-if="errors.quotaThreshold" class="el-form-item__error">{{ errors.quotaThreshold }}</p>
+                      <p
+                        v-if="errors.quotaThreshold"
+                        class="el-form-item__error"
+                      >
+                        {{ errors.quotaThreshold }}
+                      </p>
                     </div>
                   </div>
                 </div>
@@ -817,7 +839,6 @@ watch(repositoryId, (id) => {
       </div>
     </div>
   </div>
-
 </template>
 
 <style src="../../styles/fullscreen-form-shell.css"></style>

--- a/src/frontend/src/pages/node/NasProxyTopology.vue
+++ b/src/frontend/src/pages/node/NasProxyTopology.vue
@@ -26,9 +26,13 @@ defineProps<{
         <span class="nas-proxy-topology__merge-line nas-proxy-topology__merge-line--middle" />
         <span class="nas-proxy-topology__merge-line nas-proxy-topology__merge-line--bottom" />
       </div>
-      <div class="nas-proxy-topology__node nas-proxy-topology__node--proxy">Proxy</div>
+      <div class="nas-proxy-topology__node nas-proxy-topology__node--proxy">
+        Proxy
+      </div>
       <div class="nas-proxy-topology__arrow" />
-      <div class="nas-proxy-topology__node nas-proxy-topology__node--nas">NAS</div>
+      <div class="nas-proxy-topology__node nas-proxy-topology__node--nas">
+        NAS
+      </div>
     </template>
 
     <template v-else>

--- a/src/frontend/src/pages/node/NodeAiSettings.vue
+++ b/src/frontend/src/pages/node/NodeAiSettings.vue
@@ -7,7 +7,10 @@ const insightMenus = useInsightSideNav()
 </script>
 
 <template>
-  <ModulePage :menus="insightMenus" body-fill>
+  <ModulePage
+    :menus="insightMenus"
+    body-fill
+  >
     <InsightAiSettings />
   </ModulePage>
 </template>

--- a/src/frontend/src/pages/node/NodeAssistants.vue
+++ b/src/frontend/src/pages/node/NodeAssistants.vue
@@ -7,7 +7,10 @@ const insightMenus = useInsightSideNav()
 </script>
 
 <template>
-  <ModulePage :menus="insightMenus" body-fill>
+  <ModulePage
+    :menus="insightMenus"
+    body-fill
+  >
     <InsightAssistants />
   </ModulePage>
 </template>

--- a/src/frontend/src/pages/node/NodeDataGateways.vue
+++ b/src/frontend/src/pages/node/NodeDataGateways.vue
@@ -7,7 +7,10 @@ const insightMenus = useInsightSideNav()
 </script>
 
 <template>
-  <ModulePage :menus="insightMenus" body-fill>
+  <ModulePage
+    :menus="insightMenus"
+    body-fill
+  >
     <InsightDataGateways />
   </ModulePage>
 </template>

--- a/src/frontend/src/pages/node/NodeKnowledgeBase.vue
+++ b/src/frontend/src/pages/node/NodeKnowledgeBase.vue
@@ -7,7 +7,10 @@ const insightMenus = useInsightSideNav()
 </script>
 
 <template>
-  <ModulePage :menus="insightMenus" body-fill>
+  <ModulePage
+    :menus="insightMenus"
+    body-fill
+  >
     <InsightKnowledgeBase />
   </ModulePage>
 </template>

--- a/src/frontend/src/pages/node/NodeMcpServers.vue
+++ b/src/frontend/src/pages/node/NodeMcpServers.vue
@@ -7,7 +7,10 @@ const insightMenus = useInsightSideNav()
 </script>
 
 <template>
-  <ModulePage :menus="insightMenus" body-fill>
+  <ModulePage
+    :menus="insightMenus"
+    body-fill
+  >
     <InsightMcpServers />
   </ModulePage>
 </template>

--- a/src/frontend/src/pages/node/NodeSkills.vue
+++ b/src/frontend/src/pages/node/NodeSkills.vue
@@ -7,7 +7,10 @@ const insightMenus = useInsightSideNav()
 </script>
 
 <template>
-  <ModulePage :menus="insightMenus" body-fill>
+  <ModulePage
+    :menus="insightMenus"
+    body-fill
+  >
     <InsightSkills />
   </ModulePage>
 </template>

--- a/src/frontend/src/pages/node/Nodes.vue
+++ b/src/frontend/src/pages/node/Nodes.vue
@@ -617,17 +617,28 @@ async function submitRename() {
 </script>
 
 <template>
-  <ModulePage :menus="nodeMenus" body-fill>
+  <ModulePage
+    :menus="nodeMenus"
+    body-fill
+  >
     <div class="hfl-list-shell hfl-list-shell--fill">
       <div class="hfl-list-panel hfl-list-panel--fill">
         <div class="hfl-list-toolbar">
-          <RouterLink :to="deployTarget" class="inline-flex">
+          <RouterLink
+            :to="deployTarget"
+            class="inline-flex"
+          >
             <ElButton type="primary">
               <Plus :size="16" />
               {{ deployButtonLabel }}
             </ElButton>
           </RouterLink>
-          <ElDropdown trigger="click" popper-class="hfl-actions-dropdown" @visible-change="moreActionsOpen = $event" @command="handleNodeMoreAction">
+          <ElDropdown
+            trigger="click"
+            popper-class="hfl-actions-dropdown"
+            @visible-change="moreActionsOpen = $event"
+            @command="handleNodeMoreAction"
+          >
             <ElButton>
               {{ t('nodesPage.btnMoreActions') }}
               <ChevronDown
@@ -636,39 +647,60 @@ async function submitRename() {
                 :class="{ 'hfl-list-more__chev--open': moreActionsOpen }"
               />
             </ElButton>
-              <template #dropdown>
-                <ElDropdownMenu>
-                  <ElDropdownItem command="rename" :disabled="batchRenameDisabled">
-                    <span class="el-dropdown-menu__item-content">
-                      <Pencil :size="14" class="shrink-0" />
-                      <span>{{ t('nodesPage.btnBatchRename') }}</span>
-                    </span>
-                  </ElDropdownItem>
-                  <ElDropdownItem command="upgrade" :disabled="batchUpgradeDisabled">
-                    <span class="el-dropdown-menu__item-content">
-                      <ArrowUpCircle :size="14" class="shrink-0" />
-                      <span>{{ t('nodesPage.actionUpgrade') }}</span>
-                    </span>
-                  </ElDropdownItem>
-                  <ElDropdownItem command="maintenance" :disabled="batchRenameDisabled">
-                    <span class="el-dropdown-menu__item-content">
-                      <Wrench :size="14" class="shrink-0" />
-                      <span>{{ t('nodeLifecycle.maintenanceCommands') }}</span>
-                    </span>
-                  </ElDropdownItem>
-                  <ElDropdownItem
-                    command="remove"
-                    divided
-                    class="el-dropdown-menu__item--danger"
-                    :disabled="batchDisabled"
-                  >
-                    <span class="el-dropdown-menu__item-content">
-                      <Trash2 :size="14" class="shrink-0" />
-                      <span>{{ t('nodesPage.actionDelete') }}</span>
-                    </span>
-                  </ElDropdownItem>
-                </ElDropdownMenu>
-                </template>
+            <template #dropdown>
+              <ElDropdownMenu>
+                <ElDropdownItem
+                  command="rename"
+                  :disabled="batchRenameDisabled"
+                >
+                  <span class="el-dropdown-menu__item-content">
+                    <Pencil
+                      :size="14"
+                      class="shrink-0"
+                    />
+                    <span>{{ t('nodesPage.btnBatchRename') }}</span>
+                  </span>
+                </ElDropdownItem>
+                <ElDropdownItem
+                  command="upgrade"
+                  :disabled="batchUpgradeDisabled"
+                >
+                  <span class="el-dropdown-menu__item-content">
+                    <ArrowUpCircle
+                      :size="14"
+                      class="shrink-0"
+                    />
+                    <span>{{ t('nodesPage.actionUpgrade') }}</span>
+                  </span>
+                </ElDropdownItem>
+                <ElDropdownItem
+                  command="maintenance"
+                  :disabled="batchRenameDisabled"
+                >
+                  <span class="el-dropdown-menu__item-content">
+                    <Wrench
+                      :size="14"
+                      class="shrink-0"
+                    />
+                    <span>{{ t('nodeLifecycle.maintenanceCommands') }}</span>
+                  </span>
+                </ElDropdownItem>
+                <ElDropdownItem
+                  command="remove"
+                  divided
+                  class="el-dropdown-menu__item--danger"
+                  :disabled="batchDisabled"
+                >
+                  <span class="el-dropdown-menu__item-content">
+                    <Trash2
+                      :size="14"
+                      class="shrink-0"
+                    />
+                    <span>{{ t('nodesPage.actionDelete') }}</span>
+                  </span>
+                </ElDropdownItem>
+              </ElDropdownMenu>
+            </template>
           </ElDropdown>
 
           <div class="hfl-list-toolbar__right hfl-list-toolbar__right--mobile-split">
@@ -682,13 +714,25 @@ async function submitRename() {
               @clear="clearSearch"
             >
               <template #prepend>
-                <ElSelect v-model="searchField" @change="handleSearchFieldChange">
-                  <ElOption value="name" :label="t('protection.listSearchFields.name')" />
-                  <ElOption value="ip" :label="t('protection.listSearchFields.ip')" />
+                <ElSelect
+                  v-model="searchField"
+                  @change="handleSearchFieldChange"
+                >
+                  <ElOption
+                    value="name"
+                    :label="t('protection.listSearchFields.name')"
+                  />
+                  <ElOption
+                    value="ip"
+                    :label="t('protection.listSearchFields.ip')"
+                  />
                 </ElSelect>
               </template>
               <template #prefix>
-                <Search :size="16" class="hfl-list-search__icon" />
+                <Search
+                  :size="16"
+                  class="hfl-list-search__icon"
+                />
               </template>
             </ElInput>
             <div class="hfl-list-toolbar__utility">
@@ -699,7 +743,10 @@ async function submitRename() {
                 :disabled="busy"
                 @click="load()"
               >
-                <RefreshCw :size="16" :class="{ 'is-spinning': busy }" />
+                <RefreshCw
+                  :size="16"
+                  :class="{ 'is-spinning': busy }"
+                />
               </ElButton>
             </div>
           </div>
@@ -711,205 +758,287 @@ async function submitRename() {
           @cancel-queued="lifecycleOps.cancelQueued"
         />
 
-        <div ref="tableBlockRef" class="hfl-list-table-block">
-        <el-table
-          v-table-overflow-title
-          v-table-header-scroll-sync
-          v-table-column-resize="isProxyNodesPage ? 'nodes.proxy.list' : 'nodes.agent.list'"
-          ref="tableRef"
-          v-loading="tableLoading"
-          :data="tableRows"
-          stripe
-          row-key="id"
-          class="hfl-list-table"
-          :max-height="tableMaxHeight"
-          :header-cell-style="TABLE_HEADER_STYLE"
-          @scroll="onTableScroll"
-          @selection-change="onSelectionChange"
+        <div
+          ref="tableBlockRef"
+          class="hfl-list-table-block"
         >
-          <el-table-column
-            type="selection"
-            width="35"
-            :fixed="isProxyNodesPage ? 'left' : undefined"
-            :reserve-selection="true"
-          />
-          <el-table-column
-            :label="isProxyNodesPage ? t('protection.sourceResources.colName') : t('nodesPage.colName')"
-            :min-width="isProxyNodesPage ? 170 : 116"
-            :fixed="isProxyNodesPage ? 'left' : undefined"
-            class-name="hfl-table-name-col"
+          <el-table
+            ref="tableRef"
+            v-table-overflow-title
+            v-table-header-scroll-sync
+            v-table-column-resize="isProxyNodesPage ? 'nodes.proxy.list' : 'nodes.agent.list'"
+            v-loading="tableLoading"
+            :data="tableRows"
+            stripe
+            row-key="id"
+            class="hfl-list-table"
+            :max-height="tableMaxHeight"
+            :header-cell-style="TABLE_HEADER_STYLE"
+            @scroll="onTableScroll"
+            @selection-change="onSelectionChange"
           >
-            <template #default="{ row }">
-              <button
-                v-if="isProxyNodesPage"
-                type="button"
-                class="hfl-table-name-link hfl-table-name-link--full"
-                @click="openNodeDetailDrawer(row)"
-              >
-                {{ row.name }}
-              </button>
-              <ResourceNameSummaryCell
-                v-else
-                :name="row.name"
-                kind="host"
-                :platform="nodeEnrollmentOs(row)"
-                :show-icon="false"
-                @open="openNodeDetailDrawer(row)"
-              />
-            </template>
-          </el-table-column>
-          <template v-if="isProxyNodesPage">
-            <el-table-column :label="t('protection.sourceResources.colLifecycleStatus')" width="126" align="center" header-align="center">
-              <template #default="{ row }">
-                <div class="hfl-table-no-tooltip">
-                  <NodeLifecycleStatusCell
-                    :node="row"
-                    :resolve-display-status="resolveBackupSourceLifecycleStatus"
-                  />
-                </div>
-              </template>
-            </el-table-column>
-            <el-table-column :label="t('protection.sourceResources.colHostIp')" min-width="120">
-              <template #default="{ row }">
-                <span>{{ ipLine(row) }}</span>
-              </template>
-            </el-table-column>
-            <el-table-column label="OS" min-width="105">
-              <template #default="{ row }">
-                <div class="source-os-cell source-os-cell--compact hfl-table-no-tooltip">
-                  <span class="source-os-cell__icon-wrap">
-                    <AgentPlatformBrandIcon :os="nodeEnrollmentOs(row)" />
-                  </span>
-                  <span class="source-os-cell__platform">{{ proxyPlatformLabel(row) }}</span>
-                </div>
-              </template>
-            </el-table-column>
-            <el-table-column :label="t('protection.sourceResources.colCpu')" min-width="76">
-              <template #default="{ row }">
-                <span :class="{ 'hfl-empty-mark': nodeCpuCores(row) == null }">{{ nodeCpuCores(row) != null ? t('protection.sourceResources.cpuCoresValue', { n: nodeCpuCores(row) }) : '—' }}</span>
-              </template>
-            </el-table-column>
-            <el-table-column :label="t('protection.sourceResources.colMemory')" min-width="90">
-              <template #default="{ row }">
-                <span :class="{ 'hfl-empty-mark': nodeMemoryTotalBytes(row) == null }">{{ nodeMemoryTotalBytes(row) != null ? formatNodeBytes(nodeMemoryTotalBytes(row)!) : '—' }}</span>
-              </template>
-            </el-table-column>
-            <el-table-column :label="t('protection.sourceResources.colDiskCount')" min-width="78">
-              <template #default="{ row }">
-                <span :class="{ 'hfl-empty-mark': nodeDiskCount(row) == null }">{{ nodeDiskCount(row) ?? '—' }}</span>
-              </template>
-            </el-table-column>
-            <el-table-column :label="t('protection.sourceResources.colCapacity')" min-width="170">
-              <template #default="{ row }">
-                <HflCapacityCell
-                  :used-bytes="nodeDiskUsageParts(row).used"
-                  :total-bytes="nodeDiskUsageParts(row).total"
-                  variant="compact"
-                  :format-bytes="formatNodeBytes"
-                />
-              </template>
-            </el-table-column>
-            <el-table-column :label="t('protection.sourceResources.colRepositories')" min-width="105" align="center" header-align="center">
-              <template #default="{ row }">
-                <span>{{ row.associated_repository_count ?? 0 }}</span>
-              </template>
-            </el-table-column>
-            <el-table-column :label="t('protection.sourceResources.colConnectivity')" min-width="110" align="center" header-align="center">
-              <template #default="{ row }">
-                <div class="hfl-table-no-tooltip">
-                  <ElTag :type="availabilityTagType(row.availability)" size="small">
-                    {{ availabilityLabel(row.availability) }}
-                  </ElTag>
-                </div>
-              </template>
-            </el-table-column>
-            <el-table-column :label="t('protection.sourceResources.colVersion')" min-width="115">
-              <template #default="{ row }">
-                <NodeVersionCell
-                  :node="row"
-                  :version-label="row.version || '—'"
-                  :resolve-version-display="lifecycleOps.resolveVersionDisplay"
-                />
-              </template>
-            </el-table-column>
-            <el-table-column :label="t('protection.sourceResources.colRegisteredAt')" min-width="145">
-              <template #default="{ row }">
-                <span class="hfl-table-cell-time" :class="{ 'hfl-empty-mark': !row.created_at }">{{ formatNodeDate(row.created_at) }}</span>
-              </template>
-            </el-table-column>
-          </template>
-          <template v-else>
-          <el-table-column :label="t('nodesPage.colIp')" min-width="148">
-            <template #default="{ row }">
-              <span class="nodes-ip-cell hfl-table-cell-mono">{{ ipLine(row) }}</span>
-            </template>
-          </el-table-column>
-          <el-table-column :label="t('nodesPage.colOs')" min-width="168">
-            <template #default="{ row }"><span :class="{ 'hfl-empty-mark': !row.os_name }">{{ row.os_name || '—' }}</span></template>
-          </el-table-column>
-          <el-table-column :label="t('nodesPage.colRole')" min-width="108">
-            <template #default="{ row }">
-              <ElTag
-                :type="roleTagType(row.role)"
-                size="small"
-                effect="light"
-                class="nodes-role-tag"
-              >
-                {{ roleLabel(row.role) }}
-              </ElTag>
-            </template>
-          </el-table-column>
-          <el-table-column :label="t('nodesPage.colStatus')" min-width="120">
-            <template #default="{ row }">
-              <NodeLifecycleStatusCell
-                v-if="usesRealNodeList"
-                :node="row"
-                :resolve-display-status="lifecycleOps.resolveDisplayStatus"
-              />
-              <ElTag v-else :type="statusTagType(debouncedNodeStatus(row))" size="small">
-                {{ statusLabel(row.status, row) }}
-              </ElTag>
-            </template>
-          </el-table-column>
-          <el-table-column :label="t('nodesPage.colVersion')" min-width="176">
-            <template #default="{ row }">
-              <NodeVersionCell
-                v-if="usesRealNodeList"
-                :node="row"
-                :version-label="row.version || '—'"
-                :resolve-version-display="lifecycleOps.resolveVersionDisplay"
-              />
-              <div v-else class="nodes-version-cell" :class="{ 'nodes-version-cell--stacked': needsUpgrade(row) && latestVersion }">
-                <span class="nodes-version-cell__value" :class="{ 'hfl-empty-mark': !row.version }">{{ row.version || '—' }}</span>
-                <ElTooltip
-                  v-if="needsUpgrade(row) && latestVersion"
-                  :content="t('nodesPage.latestVersionTip', { version: upgradeTargetVersion(row) })"
-                  placement="top"
-                >
-                  <span class="nodes-version-cell__hint">
-                    <TriangleAlert :size="14" stroke-width="2.1" />
-                    <span>{{ t('nodesPage.versionUpgradeAvailable') }}</span>
-                  </span>
-                </ElTooltip>
-              </div>
-            </template>
-          </el-table-column>
-          </template>
-          <template #empty>
-            <el-empty
-              :description="
-                isProxyNodesPage
-                  ? t('protection.sourceResources.emptyProxySources')
-                  : t('nodesPage.emptyNodes')
-              "
-              :image-size="80"
+            <el-table-column
+              type="selection"
+              width="35"
+              :fixed="isProxyNodesPage ? 'left' : undefined"
+              :reserve-selection="true"
             />
-          </template>
-        </el-table>
+            <el-table-column
+              :label="isProxyNodesPage ? t('protection.sourceResources.colName') : t('nodesPage.colName')"
+              :min-width="isProxyNodesPage ? 170 : 116"
+              :fixed="isProxyNodesPage ? 'left' : undefined"
+              class-name="hfl-table-name-col"
+            >
+              <template #default="{ row }">
+                <button
+                  v-if="isProxyNodesPage"
+                  type="button"
+                  class="hfl-table-name-link hfl-table-name-link--full"
+                  @click="openNodeDetailDrawer(row)"
+                >
+                  {{ row.name }}
+                </button>
+                <ResourceNameSummaryCell
+                  v-else
+                  :name="row.name"
+                  kind="host"
+                  :platform="nodeEnrollmentOs(row)"
+                  :show-icon="false"
+                  @open="openNodeDetailDrawer(row)"
+                />
+              </template>
+            </el-table-column>
+            <template v-if="isProxyNodesPage">
+              <el-table-column
+                :label="t('protection.sourceResources.colLifecycleStatus')"
+                width="126"
+                align="center"
+                header-align="center"
+              >
+                <template #default="{ row }">
+                  <div class="hfl-table-no-tooltip">
+                    <NodeLifecycleStatusCell
+                      :node="row"
+                      :resolve-display-status="resolveBackupSourceLifecycleStatus"
+                    />
+                  </div>
+                </template>
+              </el-table-column>
+              <el-table-column
+                :label="t('protection.sourceResources.colHostIp')"
+                min-width="120"
+              >
+                <template #default="{ row }">
+                  <span>{{ ipLine(row) }}</span>
+                </template>
+              </el-table-column>
+              <el-table-column
+                label="OS"
+                min-width="105"
+              >
+                <template #default="{ row }">
+                  <div class="source-os-cell source-os-cell--compact hfl-table-no-tooltip">
+                    <span class="source-os-cell__icon-wrap">
+                      <AgentPlatformBrandIcon :os="nodeEnrollmentOs(row)" />
+                    </span>
+                    <span class="source-os-cell__platform">{{ proxyPlatformLabel(row) }}</span>
+                  </div>
+                </template>
+              </el-table-column>
+              <el-table-column
+                :label="t('protection.sourceResources.colCpu')"
+                min-width="76"
+              >
+                <template #default="{ row }">
+                  <span :class="{ 'hfl-empty-mark': nodeCpuCores(row) == null }">{{ nodeCpuCores(row) != null ? t('protection.sourceResources.cpuCoresValue', { n: nodeCpuCores(row) }) : '—' }}</span>
+                </template>
+              </el-table-column>
+              <el-table-column
+                :label="t('protection.sourceResources.colMemory')"
+                min-width="90"
+              >
+                <template #default="{ row }">
+                  <span :class="{ 'hfl-empty-mark': nodeMemoryTotalBytes(row) == null }">{{ nodeMemoryTotalBytes(row) != null ? formatNodeBytes(nodeMemoryTotalBytes(row)!) : '—' }}</span>
+                </template>
+              </el-table-column>
+              <el-table-column
+                :label="t('protection.sourceResources.colDiskCount')"
+                min-width="78"
+              >
+                <template #default="{ row }">
+                  <span :class="{ 'hfl-empty-mark': nodeDiskCount(row) == null }">{{ nodeDiskCount(row) ?? '—' }}</span>
+                </template>
+              </el-table-column>
+              <el-table-column
+                :label="t('protection.sourceResources.colCapacity')"
+                min-width="170"
+              >
+                <template #default="{ row }">
+                  <HflCapacityCell
+                    :used-bytes="nodeDiskUsageParts(row).used"
+                    :total-bytes="nodeDiskUsageParts(row).total"
+                    variant="compact"
+                    :format-bytes="formatNodeBytes"
+                  />
+                </template>
+              </el-table-column>
+              <el-table-column
+                :label="t('protection.sourceResources.colRepositories')"
+                min-width="105"
+                align="center"
+                header-align="center"
+              >
+                <template #default="{ row }">
+                  <span>{{ row.associated_repository_count ?? 0 }}</span>
+                </template>
+              </el-table-column>
+              <el-table-column
+                :label="t('protection.sourceResources.colConnectivity')"
+                min-width="110"
+                align="center"
+                header-align="center"
+              >
+                <template #default="{ row }">
+                  <div class="hfl-table-no-tooltip">
+                    <ElTag
+                      :type="availabilityTagType(row.availability)"
+                      size="small"
+                    >
+                      {{ availabilityLabel(row.availability) }}
+                    </ElTag>
+                  </div>
+                </template>
+              </el-table-column>
+              <el-table-column
+                :label="t('protection.sourceResources.colVersion')"
+                min-width="115"
+              >
+                <template #default="{ row }">
+                  <NodeVersionCell
+                    :node="row"
+                    :version-label="row.version || '—'"
+                    :resolve-version-display="lifecycleOps.resolveVersionDisplay"
+                  />
+                </template>
+              </el-table-column>
+              <el-table-column
+                :label="t('protection.sourceResources.colRegisteredAt')"
+                min-width="145"
+              >
+                <template #default="{ row }">
+                  <span
+                    class="hfl-table-cell-time"
+                    :class="{ 'hfl-empty-mark': !row.created_at }"
+                  >{{ formatNodeDate(row.created_at) }}</span>
+                </template>
+              </el-table-column>
+            </template>
+            <template v-else>
+              <el-table-column
+                :label="t('nodesPage.colIp')"
+                min-width="148"
+              >
+                <template #default="{ row }">
+                  <span class="nodes-ip-cell hfl-table-cell-mono">{{ ipLine(row) }}</span>
+                </template>
+              </el-table-column>
+              <el-table-column
+                :label="t('nodesPage.colOs')"
+                min-width="168"
+              >
+                <template #default="{ row }">
+                  <span :class="{ 'hfl-empty-mark': !row.os_name }">{{ row.os_name || '—' }}</span>
+                </template>
+              </el-table-column>
+              <el-table-column
+                :label="t('nodesPage.colRole')"
+                min-width="108"
+              >
+                <template #default="{ row }">
+                  <ElTag
+                    :type="roleTagType(row.role)"
+                    size="small"
+                    effect="light"
+                    class="nodes-role-tag"
+                  >
+                    {{ roleLabel(row.role) }}
+                  </ElTag>
+                </template>
+              </el-table-column>
+              <el-table-column
+                :label="t('nodesPage.colStatus')"
+                min-width="120"
+              >
+                <template #default="{ row }">
+                  <NodeLifecycleStatusCell
+                    v-if="usesRealNodeList"
+                    :node="row"
+                    :resolve-display-status="lifecycleOps.resolveDisplayStatus"
+                  />
+                  <ElTag
+                    v-else
+                    :type="statusTagType(debouncedNodeStatus(row))"
+                    size="small"
+                  >
+                    {{ statusLabel(row.status, row) }}
+                  </ElTag>
+                </template>
+              </el-table-column>
+              <el-table-column
+                :label="t('nodesPage.colVersion')"
+                min-width="176"
+              >
+                <template #default="{ row }">
+                  <NodeVersionCell
+                    v-if="usesRealNodeList"
+                    :node="row"
+                    :version-label="row.version || '—'"
+                    :resolve-version-display="lifecycleOps.resolveVersionDisplay"
+                  />
+                  <div
+                    v-else
+                    class="nodes-version-cell"
+                    :class="{ 'nodes-version-cell--stacked': needsUpgrade(row) && latestVersion }"
+                  >
+                    <span
+                      class="nodes-version-cell__value"
+                      :class="{ 'hfl-empty-mark': !row.version }"
+                    >{{ row.version || '—' }}</span>
+                    <ElTooltip
+                      v-if="needsUpgrade(row) && latestVersion"
+                      :content="t('nodesPage.latestVersionTip', { version: upgradeTargetVersion(row) })"
+                      placement="top"
+                    >
+                      <span class="nodes-version-cell__hint">
+                        <TriangleAlert
+                          :size="14"
+                          stroke-width="2.1"
+                        />
+                        <span>{{ t('nodesPage.versionUpgradeAvailable') }}</span>
+                      </span>
+                    </ElTooltip>
+                  </div>
+                </template>
+              </el-table-column>
+            </template>
+            <template #empty>
+              <el-empty
+                :description="
+                  isProxyNodesPage
+                    ? t('protection.sourceResources.emptyProxySources')
+                    : t('nodesPage.emptyNodes')
+                "
+                :image-size="80"
+              />
+            </template>
+          </el-table>
         </div>
 
         <div class="hfl-list-footer">
-          <span v-if="selectedNodes.length > 0" class="hfl-list-footer__selected">
+          <span
+            v-if="selectedNodes.length > 0"
+            class="hfl-list-footer__selected"
+          >
             {{ t('nodesPage.selectedCount', { n: selectedNodes.length }) }}
           </span>
           <HflPagination
@@ -938,7 +1067,10 @@ async function submitRename() {
         class="source-action-dialog__form proxy-host-edit-form"
         @submit.prevent="submitRename"
       >
-        <ElFormItem :label="t('nodesPage.renameLabel')" required>
+        <ElFormItem
+          :label="t('nodesPage.renameLabel')"
+          required
+        >
           <ElInput
             v-model="renameInput"
             :placeholder="t('nodesPage.renamePlaceholder')"
@@ -960,8 +1092,15 @@ async function submitRename() {
         </ElFormItem>
       </ElForm>
       <template #footer>
-        <el-button @click="closeRenameDialog">{{ t('common.cancel') }}</el-button>
-        <el-button type="primary" @click="submitRename">{{ t('common.save') }}</el-button>
+        <el-button @click="closeRenameDialog">
+          {{ t('common.cancel') }}
+        </el-button>
+        <el-button
+          type="primary"
+          @click="submitRename"
+        >
+          {{ t('common.save') }}
+        </el-button>
       </template>
     </el-dialog>
 
@@ -1002,7 +1141,10 @@ async function submitRename() {
       @confirm="executeNodeDelete"
       @cancel="cancelNodeDelete"
     >
-      <div v-if="isProxyNodesPage" class="node-delete-force-option">
+      <div
+        v-if="isProxyNodesPage"
+        class="node-delete-force-option"
+      >
         <ElCheckbox v-model="pendingDeleteForce">
           {{ t('nodesPage.proxyDeleteForceAction') }}
         </ElCheckbox>

--- a/src/frontend/src/pages/node/NodesDeploy.vue
+++ b/src/frontend/src/pages/node/NodesDeploy.vue
@@ -116,12 +116,23 @@ function handleBack() {
     >
       <div class="fullscreen-form-page source-deploy-page">
         <div class="fullscreen-form-header">
-          <button type="button" class="fullscreen-form-header__back" @click="handleBack">
-            <ArrowLeft class="fullscreen-form-header__back-icon" :size="18" />
+          <button
+            type="button"
+            class="fullscreen-form-header__back"
+            @click="handleBack"
+          >
+            <ArrowLeft
+              class="fullscreen-form-header__back-icon"
+              :size="18"
+            />
           </button>
           <div class="fullscreen-form-header__content">
-            <h1 class="fullscreen-form-header__title">{{ deployPageTitle }}</h1>
-            <p class="fullscreen-form-header__desc">{{ deployPageDesc }}</p>
+            <h1 class="fullscreen-form-header__title">
+              {{ deployPageTitle }}
+            </h1>
+            <p class="fullscreen-form-header__desc">
+              {{ deployPageDesc }}
+            </p>
           </div>
         </div>
 

--- a/src/frontend/src/pages/node/RepairNasRepository.vue
+++ b/src/frontend/src/pages/node/RepairNasRepository.vue
@@ -388,29 +388,52 @@ onMounted(async () => {
 </script>
 
 <template>
-  <div ref="pageRef" class="fullscreen-form-fullscreen resource-add-fullscreen">
+  <div
+    ref="pageRef"
+    class="fullscreen-form-fullscreen resource-add-fullscreen"
+  >
     <div class="fullscreen-form-page add-nas-page">
       <header class="fullscreen-form-header">
-        <button class="fullscreen-form-header__back" @click="handleBack">
-          <ArrowLeft class="fullscreen-form-header__back-icon" :size="18" />
+        <button
+          class="fullscreen-form-header__back"
+          @click="handleBack"
+        >
+          <ArrowLeft
+            class="fullscreen-form-header__back-icon"
+            :size="18"
+          />
         </button>
         <div class="fullscreen-form-header__content">
           <h1 class="fullscreen-form-header__title">
-            <Wrench :size="18" class="inline-block align-[-3px] mr-1 text-[rgb(37_99_235)]" />
+            <Wrench
+              :size="18"
+              class="inline-block align-[-3px] mr-1 text-[rgb(37_99_235)]"
+            />
             {{ t('repairNasRepo.pageTitle') }}
           </h1>
-          <p class="fullscreen-form-header__desc">{{ t('repairNasRepo.pageDesc') }}</p>
+          <p class="fullscreen-form-header__desc">
+            {{ t('repairNasRepo.pageDesc') }}
+          </p>
         </div>
       </header>
 
-      <div v-if="loading" class="p-10 text-center text-sm text-[rgb(100_116_139)]">
+      <div
+        v-if="loading"
+        class="p-10 text-center text-sm text-[rgb(100_116_139)]"
+      >
         {{ t('common.loading') }}
       </div>
-      <div v-else-if="loadError" class="p-10 text-center text-sm text-red-500">
+      <div
+        v-else-if="loadError"
+        class="p-10 text-center text-sm text-red-500"
+      >
         {{ loadError }}
       </div>
 
-      <div v-else class="fullscreen-form-layout add-nas-layout">
+      <div
+        v-else
+        class="fullscreen-form-layout add-nas-layout"
+      >
         <div class="fullscreen-form-main add-nas-main">
           <section class="add-nas-card add-nas-step-section">
             <div class="add-nas-section">
@@ -418,22 +441,45 @@ onMounted(async () => {
                 <span class="add-nas-section__indicator" />
                 {{ t('repairNasRepo.sectionNasReadonly') }}
               </h3>
-              <ElForm label-position="top" class="add-nas-form">
+              <ElForm
+                label-position="top"
+                class="add-nas-form"
+              >
                 <div class="add-nas-form-row add-nas-form-row--responsive">
-                  <ElFormItem :label="t('repairNasRepo.labelProtocol')" class="flex-1">
-                    <ElTag size="large" effect="plain" class="!text-sm">
-                      <component :is="nasMountProtocolIcon(protocol)" :size="14" class="inline-block align-[-2px] mr-1" />
+                  <ElFormItem
+                    :label="t('repairNasRepo.labelProtocol')"
+                    class="flex-1"
+                  >
+                    <ElTag
+                      size="large"
+                      effect="plain"
+                      class="!text-sm"
+                    >
+                      <component
+                        :is="nasMountProtocolIcon(protocol)"
+                        :size="14"
+                        class="inline-block align-[-2px] mr-1"
+                      />
                       {{ protocol === 'smb' ? t('repositoriesPage.protocolSmb') : t('repositoriesPage.protocolNfs') }}
                     </ElTag>
                   </ElFormItem>
-                  <ElFormItem :label="t('repairNasRepo.labelServer')" class="flex-1">
-                    <ElInput :model-value="nasServer" disabled />
+                  <ElFormItem
+                    :label="t('repairNasRepo.labelServer')"
+                    class="flex-1"
+                  >
+                    <ElInput
+                      :model-value="nasServer"
+                      disabled
+                    />
                   </ElFormItem>
                   <ElFormItem
                     :label="protocol === 'smb' ? t('repairNasRepo.labelShareName') : t('repairNasRepo.labelExportPath')"
                     class="flex-1"
                   >
-                    <ElInput :model-value="nasShare" disabled />
+                    <ElInput
+                      :model-value="nasShare"
+                      disabled
+                    />
                   </ElFormItem>
                 </div>
                 <p class="text-xs text-[rgb(100_116_139)]">
@@ -443,16 +489,28 @@ onMounted(async () => {
             </div>
           </section>
 
-          <section v-if="protocol === 'smb'" class="add-nas-card add-nas-step-section">
+          <section
+            v-if="protocol === 'smb'"
+            class="add-nas-card add-nas-step-section"
+          >
             <div class="add-nas-section">
               <h3 class="add-nas-section__title">
                 <span class="add-nas-section__indicator" />
-                <ShieldCheck :size="16" class="inline-block align-[-3px] mr-1" />
+                <ShieldCheck
+                  :size="16"
+                  class="inline-block align-[-3px] mr-1"
+                />
                 {{ t('repairNasRepo.smbSection') }}
               </h3>
-              <ElForm label-position="top" class="add-nas-form">
+              <ElForm
+                label-position="top"
+                class="add-nas-form"
+              >
                 <div class="add-nas-form-row add-nas-form-row--responsive">
-                  <ElFormItem :label="t('repositoriesPage.fieldSmbUsername')" class="flex-1">
+                  <ElFormItem
+                    :label="t('repositoriesPage.fieldSmbUsername')"
+                    class="flex-1"
+                  >
                     <div
                       v-if="!smbUsernameRewriting"
                       class="repair-nas-credential"
@@ -485,7 +543,10 @@ onMounted(async () => {
                       </ElButton>
                     </div>
                   </ElFormItem>
-                  <ElFormItem :label="t('repositoriesPage.fieldSmbPassword')" class="flex-1">
+                  <ElFormItem
+                    :label="t('repositoriesPage.fieldSmbPassword')"
+                    class="flex-1"
+                  >
                     <div
                       v-if="!smbPasswordRewriting"
                       class="repair-nas-credential"
@@ -521,8 +582,14 @@ onMounted(async () => {
                       </ElButton>
                     </div>
                   </ElFormItem>
-                  <ElFormItem :label="t('repositoriesPage.fieldSmbDomain')" class="flex-1">
-                    <ElInput v-model="smbDomain" :placeholder="t('repositoriesPage.phSmbDomain')" />
+                  <ElFormItem
+                    :label="t('repositoriesPage.fieldSmbDomain')"
+                    class="flex-1"
+                  >
+                    <ElInput
+                      v-model="smbDomain"
+                      :placeholder="t('repositoriesPage.phSmbDomain')"
+                    />
                   </ElFormItem>
                 </div>
               </ElForm>
@@ -535,11 +602,26 @@ onMounted(async () => {
                 <span class="add-nas-section__indicator" />
                 {{ t('repairNasRepo.sectionRepo') }}
               </h3>
-              <ElForm label-position="top" class="add-nas-form">
-                <ElFormItem data-validation-field="displayName" :error="errors.displayName" :label="t('repairNasRepo.labelDisplayName')" required>
-                  <ElInput v-model="displayName" :placeholder="t('repairNasRepo.phDisplayName')" @input="clearFieldError('displayName')" />
+              <ElForm
+                label-position="top"
+                class="add-nas-form"
+              >
+                <ElFormItem
+                  data-validation-field="displayName"
+                  :error="errors.displayName"
+                  :label="t('repairNasRepo.labelDisplayName')"
+                  required
+                >
+                  <ElInput
+                    v-model="displayName"
+                    :placeholder="t('repairNasRepo.phDisplayName')"
+                    @input="clearFieldError('displayName')"
+                  />
                 </ElFormItem>
-                <ElFormItem id="nas-mount-options" :label="t('repairNasRepo.labelMountOptions')">
+                <ElFormItem
+                  id="nas-mount-options"
+                  :label="t('repairNasRepo.labelMountOptions')"
+                >
                   <ElInput
                     ref="mountOptionsInputRef"
                     v-model="mountOptionsDraft"
@@ -550,7 +632,13 @@ onMounted(async () => {
                       ? 'Saved value replaces the current mount options. If SMB auto-negotiation fails, copy one example below and test.'
                       : t('repairNasRepo.hintMountOptions') }}
                   </div>
-                  <ElAlert v-if="protocol === 'smb'" type="warning" :closable="false" show-icon class="mt-2">
+                  <ElAlert
+                    v-if="protocol === 'smb'"
+                    type="warning"
+                    :closable="false"
+                    show-icon
+                    class="mt-2"
+                  >
                     <div class="text-xs leading-5 text-[rgb(51_65_85)]">
                       <div>
                         Different NAS devices, SMB servers, and client kernels may support different protocol versions. For Operation not supported, Invalid argument, or mount.cifs errors, specify a protocol version here.
@@ -577,7 +665,10 @@ onMounted(async () => {
                 <span class="add-nas-section__indicator" />
                 {{ t('repairNasRepo.sectionQuota') }}
               </h3>
-              <ElForm label-position="top" class="add-nas-form">
+              <ElForm
+                label-position="top"
+                class="add-nas-form"
+              >
                 <div class="add-nas-form-row add-nas-form-row--responsive">
                   <div class="fullscreen-form-field add-nas-quota-col">
                     <label class="fullscreen-form-field__label add-nas-quota-head">
@@ -592,11 +683,16 @@ onMounted(async () => {
                           :min="0"
                           controls-position="right"
                         />
-                        <div class="hfl-detail-form-input__suffix">GB</div>
+                        <div class="hfl-detail-form-input__suffix">
+                          GB
+                        </div>
                       </div>
                     </div>
                   </div>
-                  <div data-validation-field="quotaThreshold" class="fullscreen-form-field add-nas-quota-col add-nas-quota-panel">
+                  <div
+                    data-validation-field="quotaThreshold"
+                    class="fullscreen-form-field add-nas-quota-col add-nas-quota-panel"
+                  >
                     <div class="fullscreen-form-field__label add-nas-quota-head add-nas-quota-title-row">
                       <ElCheckbox v-model="quotaAlertEnabled">
                         {{ t('repairNasRepo.labelQuotaAlert') }}
@@ -613,13 +709,20 @@ onMounted(async () => {
                           controls-position="right"
                           @change="clearFieldError('quotaThreshold')"
                         />
-                        <div class="hfl-detail-form-input__suffix">%</div>
+                        <div class="hfl-detail-form-input__suffix">
+                          %
+                        </div>
                       </div>
                     </div>
                     <p class="fullscreen-form-field__hint">
                       {{ t('repairNasRepo.labelQuotaAlertThreshold') }}
                     </p>
-                    <p v-if="errors.quotaThreshold" class="el-form-item__error">{{ errors.quotaThreshold }}</p>
+                    <p
+                      v-if="errors.quotaThreshold"
+                      class="el-form-item__error"
+                    >
+                      {{ errors.quotaThreshold }}
+                    </p>
                   </div>
                 </div>
               </ElForm>
@@ -634,9 +737,15 @@ onMounted(async () => {
                     <span class="add-nas-section__indicator" />
                     {{ bindLabel }}
                   </h3>
-                  <span v-if="!isCurrentlyBound" class="add-nas-optional-badge">{{ t('addNasRepo.optional') }}</span>
+                  <span
+                    v-if="!isCurrentlyBound"
+                    class="add-nas-optional-badge"
+                  >{{ t('addNasRepo.optional') }}</span>
                 </div>
-                <ElButton class="add-nas-proxy-action" @click="openProxyDeploy">
+                <ElButton
+                  class="add-nas-proxy-action"
+                  @click="openProxyDeploy"
+                >
                   <Plus :size="14" />
                   {{ t('addNasRepo.deployProxy') }}
                 </ElButton>
@@ -667,9 +776,14 @@ onMounted(async () => {
 
               <div class="add-nas-proxy-layout">
                 <div class="add-nas-proxy-form">
-                  <ElForm label-position="top" class="add-nas-form">
+                  <ElForm
+                    label-position="top"
+                    class="add-nas-form"
+                  >
                     <ElFormItem class="add-nas-bind-form-item">
-                      <template #label>{{ t('addNasRepo.fieldSourceProxyNode') }}</template>
+                      <template #label>
+                        {{ t('addNasRepo.fieldSourceProxyNode') }}
+                      </template>
                       <div class="add-nas-select-row">
                         <ElSelect
                           v-model="proxyNodeId"
@@ -680,7 +794,10 @@ onMounted(async () => {
                           :placeholder="t('repairNasRepo.phBindProxy')"
                         >
                           <template v-if="!isCurrentlyBound">
-                            <ElOption :value="undefined" :label="t('repairNasRepo.optionNoProxy')" />
+                            <ElOption
+                              :value="undefined"
+                              :label="t('repairNasRepo.optionNoProxy')"
+                            />
                           </template>
                           <ElOption
                             v-for="n in availableProxyNodes"
@@ -696,7 +813,10 @@ onMounted(async () => {
                           :disabled="proxyNodesRefreshing"
                           @click="refreshProxyNodesManually"
                         >
-                          <RefreshCw :size="16" :class="{ 'is-spinning': proxyNodesRefreshing }" />
+                          <RefreshCw
+                            :size="16"
+                            :class="{ 'is-spinning': proxyNodesRefreshing }"
+                          />
                         </ElButton>
                       </div>
                       <div class="mt-2 text-xs text-[rgb(100_116_139)]">
@@ -733,10 +853,18 @@ onMounted(async () => {
 
           <div class="fullscreen-form-footer add-nas-footer">
             <div class="add-nas-footer__actions">
-              <ElButton :disabled="busy" @click="handleBack">
+              <ElButton
+                :disabled="busy"
+                @click="handleBack"
+              >
                 {{ t('repositoriesPage.btnCancel') }}
               </ElButton>
-              <ElButton type="primary" :loading="busy" :disabled="busy" @click="onSubmit">
+              <ElButton
+                type="primary"
+                :loading="busy"
+                :disabled="busy"
+                @click="onSubmit"
+              >
                 {{ submitLabel }}
               </ElButton>
             </div>
@@ -748,7 +876,11 @@ onMounted(async () => {
             <div class="add-nas-preview-header">
               <div class="add-nas-preview-header__glow" />
               <div class="add-nas-preview-header__icon">
-                <component :is="nasMountProtocolIcon(protocol)" class="add-nas-preview-header__drive" :size="28" />
+                <component
+                  :is="nasMountProtocolIcon(protocol)"
+                  class="add-nas-preview-header__drive"
+                  :size="28"
+                />
               </div>
               <div class="add-nas-preview-header__info">
                 <h4 class="add-nas-preview-header__name">
@@ -761,16 +893,24 @@ onMounted(async () => {
             </div>
             <div class="add-nas-preview-body">
               <div class="add-nas-preview-section">
-                <h5 class="add-nas-preview-section__title">{{ t('addS3Repo.previewBasicInfo') }}</h5>
+                <h5 class="add-nas-preview-section__title">
+                  {{ t('addS3Repo.previewBasicInfo') }}
+                </h5>
                 <div class="add-nas-preview-row">
                   <span class="add-nas-preview-row__label">{{ t('repairNasRepo.labelDisplayName') }}</span>
-                  <span class="add-nas-preview-row__value" :class="{ 'add-nas-preview-row__value--empty': !displayName }">
+                  <span
+                    class="add-nas-preview-row__value"
+                    :class="{ 'add-nas-preview-row__value--empty': !displayName }"
+                  >
                     {{ displayName || '—' }}
                   </span>
                 </div>
                 <div class="add-nas-preview-row">
                   <span class="add-nas-preview-row__label">{{ t('addNasRepo.fieldSourceProxyNode') }}</span>
-                  <span class="add-nas-preview-row__value" :class="{ 'add-nas-preview-row__value--empty': !proxyNodeId }">
+                  <span
+                    class="add-nas-preview-row__value"
+                    :class="{ 'add-nas-preview-row__value--empty': !proxyNodeId }"
+                  >
                     {{ availableProxyNodes.find((n) => n.id === proxyNodeId)?.name || t('addNasRepo.notBoundProxy') }}
                   </span>
                 </div>
@@ -780,14 +920,23 @@ onMounted(async () => {
                 </div>
                 <div class="add-nas-preview-row">
                   <span class="add-nas-preview-row__label">{{ t('repairNasRepo.labelQuota') }}</span>
-                  <span class="add-nas-preview-row__value" :class="{ 'add-nas-preview-row__value--highlight': quotaGb > 0 }">
+                  <span
+                    class="add-nas-preview-row__value"
+                    :class="{ 'add-nas-preview-row__value--highlight': quotaGb > 0 }"
+                  >
                     {{ quotaGb > 0 ? `${quotaGb} GB` : t('addS3Repo.previewUnlimited') }}
                   </span>
                 </div>
                 <div class="add-nas-preview-row">
                   <span class="add-nas-preview-row__label">{{ t('repairNasRepo.labelQuotaAlert') }}</span>
-                  <span class="add-nas-preview-row__value add-nas-preview-row__value--badge" :class="quotaAlertEnabled ? 'add-nas-preview-row__value--success' : 'add-nas-preview-row__value--muted'">
-                    <span v-if="quotaAlertEnabled" class="add-nas-preview-row__dot add-nas-preview-row__dot--green" />
+                  <span
+                    class="add-nas-preview-row__value add-nas-preview-row__value--badge"
+                    :class="quotaAlertEnabled ? 'add-nas-preview-row__value--success' : 'add-nas-preview-row__value--muted'"
+                  >
+                    <span
+                      v-if="quotaAlertEnabled"
+                      class="add-nas-preview-row__dot add-nas-preview-row__dot--green"
+                    />
                     <template v-if="quotaAlertEnabled">
                       {{ t('repositoriesPage.enabled') }} ({{ quotaAlertThreshold || 0 }}%)
                     </template>

--- a/src/frontend/src/pages/node/Repositories.vue
+++ b/src/frontend/src/pages/node/Repositories.vue
@@ -2361,15 +2361,26 @@ function s3ObjectPrefixCell(row: RepositoryRow) {
 </script>
 
 <template>
-  <ModulePage :menus="nodeMenus" :page-title-override="pageTitle" body-fill>
+  <ModulePage
+    :menus="nodeMenus"
+    :page-title-override="pageTitle"
+    body-fill
+  >
     <div class="hfl-list-shell hfl-list-shell--fill">
       <div class="hfl-list-panel hfl-list-panel--fill">
         <div class="hfl-list-toolbar">
-          <ElButton type="primary" @click="activeTab === 'nas' ? router.push('/node/repositories/nas/add') : activeTab === 'proxy_fs' ? router.push('/node/repositories/proxy-fs/add') : router.push('/node/repositories/s3/add')">
+          <ElButton
+            type="primary"
+            @click="activeTab === 'nas' ? router.push('/node/repositories/nas/add') : activeTab === 'proxy_fs' ? router.push('/node/repositories/proxy-fs/add') : router.push('/node/repositories/s3/add')"
+          >
             <Plus :size="16" />
             {{ t('repositoriesPage.btnAdd') }}
           </ElButton>
-          <ElDropdown trigger="click" @command="onMoreCommand" @visible-change="moreActionsOpen = $event">
+          <ElDropdown
+            trigger="click"
+            @command="onMoreCommand"
+            @visible-change="moreActionsOpen = $event"
+          >
             <ElButton>
               {{ t('repositoriesPage.moreActions') }}
               <ChevronDown
@@ -2380,15 +2391,29 @@ function s3ObjectPrefixCell(row: RepositoryRow) {
             </ElButton>
             <template #dropdown>
               <ElDropdownMenu>
-                <ElDropdownItem command="edit-selected" :disabled="!canEditSelectedRow">
+                <ElDropdownItem
+                  command="edit-selected"
+                  :disabled="!canEditSelectedRow"
+                >
                   <span class="el-dropdown-menu__item-content">
-                    <Pencil :size="14" class="shrink-0" />
+                    <Pencil
+                      :size="14"
+                      class="shrink-0"
+                    />
                     <span>{{ t('repositoriesPage.btnEdit') }}</span>
                   </span>
                 </ElDropdownItem>
-                <ElDropdownItem command="batch-delete" divided class="el-dropdown-menu__item--danger" :disabled="!hasSelectedRows">
+                <ElDropdownItem
+                  command="batch-delete"
+                  divided
+                  class="el-dropdown-menu__item--danger"
+                  :disabled="!hasSelectedRows"
+                >
                   <span class="el-dropdown-menu__item-content">
-                    <Trash2 :size="14" class="shrink-0" />
+                    <Trash2
+                      :size="14"
+                      class="shrink-0"
+                    />
                     <span>{{ t('repositoriesPage.batchDelete') }}</span>
                   </span>
                 </ElDropdownItem>
@@ -2407,7 +2432,10 @@ function s3ObjectPrefixCell(row: RepositoryRow) {
               @clear="clearSearch"
             >
               <template #prepend>
-                <ElSelect v-model="searchField" @change="handleSearchFieldChange">
+                <ElSelect
+                  v-model="searchField"
+                  @change="handleSearchFieldChange"
+                >
                   <ElOption
                     v-for="option in searchFieldOptions"
                     :key="option.value"
@@ -2417,7 +2445,10 @@ function s3ObjectPrefixCell(row: RepositoryRow) {
                 </ElSelect>
               </template>
               <template #prefix>
-                <Search :size="16" class="hfl-list-search__icon" />
+                <Search
+                  :size="16"
+                  class="hfl-list-search__icon"
+                />
               </template>
             </ElInput>
             
@@ -2429,18 +2460,24 @@ function s3ObjectPrefixCell(row: RepositoryRow) {
                 :disabled="busy"
                 @click="refreshRepositories()"
               >
-                <RefreshCw :size="16" :class="{ 'is-spinning': busy }" />
+                <RefreshCw
+                  :size="16"
+                  :class="{ 'is-spinning': busy }"
+                />
               </ElButton>
             </div>
           </div>
         </div>
 
-        <div ref="tableBlockRef" class="hfl-list-table-block">
+        <div
+          ref="tableBlockRef"
+          class="hfl-list-table-block"
+        >
           <el-table
+            ref="tableRef"
             v-table-overflow-title
             v-table-header-scroll-sync
             v-table-column-resize="`repositories.${activeTab}.list`"
-            ref="tableRef"
             v-loading="repositoryTableLoading"
             class="hfl-list-table"
             :data="pagedRows"
@@ -2451,7 +2488,12 @@ function s3ObjectPrefixCell(row: RepositoryRow) {
             @scroll="onTableScroll"
             @selection-change="onSelectionChange"
           >
-            <el-table-column type="selection" width="35" fixed="left" reserve-selection />
+            <el-table-column
+              type="selection"
+              width="35"
+              fixed="left"
+              reserve-selection
+            />
             <el-table-column
               prop="name"
               :label="nameColumnLabel"
@@ -2476,7 +2518,12 @@ function s3ObjectPrefixCell(row: RepositoryRow) {
             >
               <template #default="{ row }">
                 <div class="hfl-table-no-tooltip">
-                  <ElTag :type="lifecycleTagType(row.status)" size="small">{{ repoLifecycleLabel(row.status) }}</ElTag>
+                  <ElTag
+                    :type="lifecycleTagType(row.status)"
+                    size="small"
+                  >
+                    {{ repoLifecycleLabel(row.status) }}
+                  </ElTag>
                 </div>
               </template>
             </el-table-column>
@@ -2549,11 +2596,23 @@ function s3ObjectPrefixCell(row: RepositoryRow) {
                   class="repo-protocol-pill"
                   :class="`repo-protocol-pill--${activeTab === 'proxy_fs' ? 'proxy-fs' : row.protocol}`"
                 >
-                  <HardDrive v-if="activeTab === 'proxy_fs'" :size="12" stroke-width="2.25" />
-                  <component v-else :is="nasMountProtocolIcon(row.protocol)" :size="12" stroke-width="2.25" />
+                  <HardDrive
+                    v-if="activeTab === 'proxy_fs'"
+                    :size="12"
+                    stroke-width="2.25"
+                  />
+                  <component
+                    :is="nasMountProtocolIcon(row.protocol)"
+                    v-else
+                    :size="12"
+                    stroke-width="2.25"
+                  />
                   {{ activeTab === 'proxy_fs' ? repoListProtocolLabel(row) : protocolLabel(row.protocol) }}
                 </span>
-                <span v-else class="hfl-empty-mark">—</span>
+                <span
+                  v-else
+                  class="hfl-empty-mark"
+                >—</span>
               </template>
             </el-table-column>
             <el-table-column
@@ -2562,7 +2621,10 @@ function s3ObjectPrefixCell(row: RepositoryRow) {
               min-width="260"
             >
               <template #default="{ row }">
-                <span class="hfl-table-mono" :class="{ 'hfl-empty-mark': nasRepositoryLocation(row) === DETAIL_EMPTY }">{{ nasRepositoryLocation(row) }}</span>
+                <span
+                  class="hfl-table-mono"
+                  :class="{ 'hfl-empty-mark': nasRepositoryLocation(row) === DETAIL_EMPTY }"
+                >{{ nasRepositoryLocation(row) }}</span>
               </template>
             </el-table-column>
             <el-table-column
@@ -2598,19 +2660,35 @@ function s3ObjectPrefixCell(row: RepositoryRow) {
                       </li>
                     </ol>
                   </template>
-                  <span class="repo-proxy-unbound-cell hfl-table-no-tooltip" tabindex="0">
+                  <span
+                    class="repo-proxy-unbound-cell hfl-table-no-tooltip"
+                    tabindex="0"
+                  >
                     <span class="repo-proxy-unbound-cell__text">
                       <span class="repo-proxy-unbound-cell__primary">
-                        <Unlink :size="14" stroke-width="2.2" aria-hidden="true" />
+                        <Unlink
+                          :size="14"
+                          stroke-width="2.2"
+                          aria-hidden="true"
+                        />
                         <span>{{ t('repositoriesPage.proxyNotBound') }}</span>
                       </span>
                       <span class="repo-proxy-unbound-cell__secondary">{{ t('addNasRepo.accessPathDirect') }}</span>
                     </span>
                   </span>
                 </ElTooltip>
-                <div v-else class="table-stack-cell">
-                  <span class="table-stack-cell__primary" :class="{ 'hfl-empty-mark': repoListSourceProxyName(row) === DETAIL_EMPTY }">{{ repoListSourceProxyName(row) }}</span>
-                  <span v-if="repoListSourceProxyIp(row)" class="table-stack-cell__secondary">{{ repoListSourceProxyIp(row) }}</span>
+                <div
+                  v-else
+                  class="table-stack-cell"
+                >
+                  <span
+                    class="table-stack-cell__primary"
+                    :class="{ 'hfl-empty-mark': repoListSourceProxyName(row) === DETAIL_EMPTY }"
+                  >{{ repoListSourceProxyName(row) }}</span>
+                  <span
+                    v-if="repoListSourceProxyIp(row)"
+                    class="table-stack-cell__secondary"
+                  >{{ repoListSourceProxyIp(row) }}</span>
                 </div>
               </template>
             </el-table-column>
@@ -2629,8 +2707,14 @@ function s3ObjectPrefixCell(row: RepositoryRow) {
               <template #header>
                 <span class="repo-table-header-with-help">
                   {{ usageColumnLabel }}
-                  <ElTooltip :content="t('repositoriesPage.repositoryUsageHelp')" placement="top">
-                    <Info :size="13" aria-hidden="true" />
+                  <ElTooltip
+                    :content="t('repositoriesPage.repositoryUsageHelp')"
+                    placement="top"
+                  >
+                    <Info
+                      :size="13"
+                      aria-hidden="true"
+                    />
                   </ElTooltip>
                 </span>
               </template>
@@ -2657,16 +2741,29 @@ function s3ObjectPrefixCell(row: RepositoryRow) {
                   :note="backingStoragePopoverNote(row)"
                 >
                   <div class="table-stack-cell hfl-table-no-tooltip">
-                    <span v-if="row.kind === 'nas' && !hasBoundProxy(row)" class="table-stack-cell__primary hfl-empty-mark">
+                    <span
+                      v-if="row.kind === 'nas' && !hasBoundProxy(row)"
+                      class="table-stack-cell__primary hfl-empty-mark"
+                    >
                       {{ t('repositoriesPage.capacityUnavailable') }}
                     </span>
-                    <span v-else-if="repoCapacityProbeFailed(row)" class="table-stack-cell__primary hfl-empty-mark">
+                    <span
+                      v-else-if="repoCapacityProbeFailed(row)"
+                      class="table-stack-cell__primary hfl-empty-mark"
+                    >
                       {{ t('repositoriesPage.capacityUnavailable') }}
                     </span>
-                    <span v-else-if="row.capacity_probe_status === 'pending'" class="table-stack-cell__primary hfl-empty-mark">
+                    <span
+                      v-else-if="row.capacity_probe_status === 'pending'"
+                      class="table-stack-cell__primary hfl-empty-mark"
+                    >
                       {{ t('repositoriesPage.metricsPending') }}
                     </span>
-                    <span v-else class="table-stack-cell__primary" :class="{ 'hfl-empty-mark': backingStorageAvailableLabel(row) === DETAIL_EMPTY }">
+                    <span
+                      v-else
+                      class="table-stack-cell__primary"
+                      :class="{ 'hfl-empty-mark': backingStorageAvailableLabel(row) === DETAIL_EMPTY }"
+                    >
                       {{ backingStorageAvailableLabel(row) }}
                     </span>
                     <span class="table-stack-cell__secondary">{{ backingStorageSourceLabel(row) }}</span>
@@ -2680,7 +2777,12 @@ function s3ObjectPrefixCell(row: RepositoryRow) {
             >
               <template #default="{ row }">
                 <div class="hfl-table-no-tooltip">
-                  <ElTag :type="healthTagType(row.health)" size="small">{{ repoHealthLabel(row.health) }}</ElTag>
+                  <ElTag
+                    :type="healthTagType(row.health)"
+                    size="small"
+                  >
+                    {{ repoHealthLabel(row.health) }}
+                  </ElTag>
                 </div>
               </template>
             </el-table-column>
@@ -2690,29 +2792,48 @@ function s3ObjectPrefixCell(row: RepositoryRow) {
               :min-width="activeTab === 'nas' ? 163 : activeTab === 's3' || activeTab === 'proxy_fs' ? 170 : createdAtColumnMinWidth"
             >
               <template #default="{ row }">
-                <span class="hfl-table-cell-time" :class="{ 'hfl-empty-mark': !row.created_at }">{{ formatLocalDateTime(row.created_at) }}</span>
+                <span
+                  class="hfl-table-cell-time"
+                  :class="{ 'hfl-empty-mark': !row.created_at }"
+                >{{ formatLocalDateTime(row.created_at) }}</span>
               </template>
             </el-table-column>
             <template #empty>
-              <el-empty v-if="repositoryListError" :description="repositoryListError" :image-size="80">
-                <ElButton type="primary" @click="load()">{{ t('repositoriesPage.retry') }}</ElButton>
+              <el-empty
+                v-if="repositoryListError"
+                :description="repositoryListError"
+                :image-size="80"
+              >
+                <ElButton
+                  type="primary"
+                  @click="load()"
+                >
+                  {{ t('repositoriesPage.retry') }}
+                </ElButton>
               </el-empty>
-              <el-empty v-else :description="emptyText" :image-size="80" />
+              <el-empty
+                v-else
+                :description="emptyText"
+                :image-size="80"
+              />
             </template>
           </el-table>
-          </div>
+        </div>
 
-          <div class="hfl-list-footer">
-            <span v-if="selectedRows.length > 0" class="hfl-list-footer__selected">
-              {{ t('repositoriesPage.selectedCount', { n: selectedRows.length }) }}
-            </span>
-            <HflPagination
-              class="hfl-list-footer__pagination"
-              v-model:current-page="currentPage"
-              v-model:page-size="pageSize"
-              :total="totalFiltered"
-            />
-          </div>
+        <div class="hfl-list-footer">
+          <span
+            v-if="selectedRows.length > 0"
+            class="hfl-list-footer__selected"
+          >
+            {{ t('repositoriesPage.selectedCount', { n: selectedRows.length }) }}
+          </span>
+          <HflPagination
+            v-model:current-page="currentPage"
+            v-model:page-size="pageSize"
+            class="hfl-list-footer__pagination"
+            :total="totalFiltered"
+          />
+        </div>
       </div>
     </div>
     <ElDrawer
@@ -2729,12 +2850,27 @@ function s3ObjectPrefixCell(row: RepositoryRow) {
         <span class="hfl-detail-drawer__title">{{ detailRow?.name || '—' }}</span>
       </template>
 
-      <div v-if="detailRow" class="hfl-detail-drawer__body">
-        <ElTabs v-model="detailActiveTab" class="hfl-detail-tabs" @tab-change="onDetailTabChange">
-          <ElTabPane :label="t('protection.sourceResources.detailTabBasic')" name="basic">
-        <div v-if="detailRow.kind === 's3'" class="hfl-detail-sections repo-storage-detail">
+      <div
+        v-if="detailRow"
+        class="hfl-detail-drawer__body"
+      >
+        <ElTabs
+          v-model="detailActiveTab"
+          class="hfl-detail-tabs"
+          @tab-change="onDetailTabChange"
+        >
+          <ElTabPane
+            :label="t('protection.sourceResources.detailTabBasic')"
+            name="basic"
+          >
+            <div
+              v-if="detailRow.kind === 's3'"
+              class="hfl-detail-sections repo-storage-detail"
+            >
               <section class="hfl-detail-section">
-                <h4 class="hfl-detail-section__title">{{ t('repositoriesPage.stepRepo') }}</h4>
+                <h4 class="hfl-detail-section__title">
+                  {{ t('repositoriesPage.stepRepo') }}
+                </h4>
                 <div class="hfl-detail-grid">
                   <div class="hfl-detail-row">
                     <span class="hfl-detail-row__label">{{ t('addS3Repo.fieldRepoName') }}</span>
@@ -2747,7 +2883,10 @@ function s3ObjectPrefixCell(row: RepositoryRow) {
                   <div class="hfl-detail-row">
                     <span class="hfl-detail-row__label">{{ t('repositoriesPage.colStatus') }}</span>
                     <span class="hfl-detail-row__value">
-                      <ElTag :type="lifecycleTagType(detailRow.status)" size="small">
+                      <ElTag
+                        :type="lifecycleTagType(detailRow.status)"
+                        size="small"
+                      >
                         {{ repoLifecycleLabel(detailRow.status) }}
                       </ElTag>
                     </span>
@@ -2755,14 +2894,20 @@ function s3ObjectPrefixCell(row: RepositoryRow) {
                   <div class="hfl-detail-row">
                     <span class="hfl-detail-row__label">{{ t('repositoriesPage.colAvailability') }}</span>
                     <span class="hfl-detail-row__value">
-                      <ElTag :type="healthTagType(detailRow.health)" size="small">
+                      <ElTag
+                        :type="healthTagType(detailRow.health)"
+                        size="small"
+                      >
                         {{ repoHealthLabel(detailRow.health) }}
                       </ElTag>
                     </span>
                   </div>
                   <div class="hfl-detail-row">
                     <span class="hfl-detail-row__label">{{ t('repositoriesPage.colRegistered') }}</span>
-                    <span class="hfl-detail-row__value" :class="{ 'hfl-detail-row__empty': !detailRow.created_at }">{{ formatLocalDateTime(detailRow.created_at) }}</span>
+                    <span
+                      class="hfl-detail-row__value"
+                      :class="{ 'hfl-detail-row__empty': !detailRow.created_at }"
+                    >{{ formatLocalDateTime(detailRow.created_at) }}</span>
                   </div>
                   <div class="hfl-detail-row">
                     <span class="hfl-detail-row__label">{{ t('repositoriesPage.detailFieldPlatform') }}</span>
@@ -2784,13 +2929,19 @@ function s3ObjectPrefixCell(row: RepositoryRow) {
                   <div class="hfl-detail-row">
                     <span class="hfl-detail-row__label">{{ t('addS3Repo.fieldPrefix') }}</span>
                     <span class="hfl-detail-row__value hfl-detail-row__value--mono">
-                      <span class="hfl-detail-row__text" :class="detailEmptyValueClass(detailRow.config.prefix || DETAIL_EMPTY)">{{ detailRow.config.prefix || DETAIL_EMPTY }}</span>
+                      <span
+                        class="hfl-detail-row__text"
+                        :class="detailEmptyValueClass(detailRow.config.prefix || DETAIL_EMPTY)"
+                      >{{ detailRow.config.prefix || DETAIL_EMPTY }}</span>
                     </span>
                   </div>
                   <div class="hfl-detail-row hfl-detail-row--full">
                     <span class="hfl-detail-row__label">{{ t('repositoriesPage.detailFieldLocation') }}</span>
                     <span class="hfl-detail-row__value hfl-detail-row__value--editable hfl-detail-row__value--mono">
-                      <span class="hfl-detail-row__text" :class="detailEmptyValueClass(s3RepositoryLocation(detailRow))">{{ s3RepositoryLocation(detailRow) }}</span>
+                      <span
+                        class="hfl-detail-row__text"
+                        :class="detailEmptyValueClass(s3RepositoryLocation(detailRow))"
+                      >{{ s3RepositoryLocation(detailRow) }}</span>
                       <ElButton
                         v-if="s3RepositoryLocation(detailRow) !== DETAIL_EMPTY"
                         text
@@ -2808,24 +2959,35 @@ function s3ObjectPrefixCell(row: RepositoryRow) {
               </section>
 
               <section class="hfl-detail-section">
-                <h4 class="hfl-detail-section__title">{{ t('repositoriesPage.detailSectionConnectionAuth') }}</h4>
+                <h4 class="hfl-detail-section__title">
+                  {{ t('repositoriesPage.detailSectionConnectionAuth') }}
+                </h4>
                 <div class="hfl-detail-grid">
                   <div class="hfl-detail-row">
                     <span class="hfl-detail-row__label">{{ t('addS3Repo.fieldEndpoint') }}</span>
                     <span class="hfl-detail-row__value hfl-detail-row__value--mono">
-                      <span class="hfl-detail-row__text" :class="detailEmptyValueClass(s3EndpointDisplay(detailRow.config.endpoint) || DETAIL_EMPTY)">{{ s3EndpointDisplay(detailRow.config.endpoint) || DETAIL_EMPTY }}</span>
+                      <span
+                        class="hfl-detail-row__text"
+                        :class="detailEmptyValueClass(s3EndpointDisplay(detailRow.config.endpoint) || DETAIL_EMPTY)"
+                      >{{ s3EndpointDisplay(detailRow.config.endpoint) || DETAIL_EMPTY }}</span>
                     </span>
                   </div>
                   <div class="hfl-detail-row">
                     <span class="hfl-detail-row__label">{{ t('addS3Repo.fieldRegion') }}</span>
                     <span class="hfl-detail-row__value">
-                      <span class="hfl-detail-row__text" :class="detailEmptyValueClass(detailRow.config.region || DETAIL_EMPTY)">{{ detailRow.config.region || DETAIL_EMPTY }}</span>
+                      <span
+                        class="hfl-detail-row__text"
+                        :class="detailEmptyValueClass(detailRow.config.region || DETAIL_EMPTY)"
+                      >{{ detailRow.config.region || DETAIL_EMPTY }}</span>
                     </span>
                   </div>
                   <div class="hfl-detail-row">
                     <span class="hfl-detail-row__label">{{ t('addS3Repo.fieldAccessKey') }}</span>
                     <span class="hfl-detail-row__value hfl-detail-row__value--editable hfl-detail-row__value--mono">
-                      <span class="hfl-detail-row__text" :class="detailEmptyValueClass(detailRow.config.access_key_id || DETAIL_EMPTY)">{{ detailRow.config.access_key_id || DETAIL_EMPTY }}</span>
+                      <span
+                        class="hfl-detail-row__text"
+                        :class="detailEmptyValueClass(detailRow.config.access_key_id || DETAIL_EMPTY)"
+                      >{{ detailRow.config.access_key_id || DETAIL_EMPTY }}</span>
                       <ElButton
                         v-if="detailRow.config.access_key_id"
                         text
@@ -2841,7 +3003,10 @@ function s3ObjectPrefixCell(row: RepositoryRow) {
                   </div>
                   <div class="hfl-detail-row">
                     <span class="hfl-detail-row__label">{{ t('addS3Repo.fieldSecretKey') }}</span>
-                    <span class="hfl-detail-row__value hfl-detail-row__value--mono" :class="detailEmptyValueClass(s3SecretKeyDisplay(detailRow))">{{ s3SecretKeyDisplay(detailRow) }}</span>
+                    <span
+                      class="hfl-detail-row__value hfl-detail-row__value--mono"
+                      :class="detailEmptyValueClass(s3SecretKeyDisplay(detailRow))"
+                    >{{ s3SecretKeyDisplay(detailRow) }}</span>
                   </div>
                   <div class="hfl-detail-row">
                     <span class="hfl-detail-row__label">{{ t('addS3Repo.fieldS3UrlStyle') }}</span>
@@ -2876,13 +3041,18 @@ function s3ObjectPrefixCell(row: RepositoryRow) {
                   </template>
                   <div class="hfl-detail-row hfl-detail-row--full">
                     <span class="hfl-detail-row__label">{{ t('addS3Repo.fieldBucket') }}</span>
-                    <span class="hfl-detail-row__value hfl-detail-row__value--mono" :class="detailEmptyValueClass(detailRow.config.bucket || DETAIL_EMPTY)">{{ detailRow.config.bucket || DETAIL_EMPTY }}</span>
+                    <span
+                      class="hfl-detail-row__value hfl-detail-row__value--mono"
+                      :class="detailEmptyValueClass(detailRow.config.bucket || DETAIL_EMPTY)"
+                    >{{ detailRow.config.bucket || DETAIL_EMPTY }}</span>
                   </div>
                 </div>
               </section>
 
               <section class="hfl-detail-section">
-                <h4 class="hfl-detail-section__title">{{ t('repositoriesPage.detailFieldRepositoryUsage') }}</h4>
+                <h4 class="hfl-detail-section__title">
+                  {{ t('repositoriesPage.detailFieldRepositoryUsage') }}
+                </h4>
                 <div class="hfl-detail-grid">
                   <div class="hfl-detail-row">
                     <span class="hfl-detail-row__label">{{ t('repositoriesPage.estimatedRepositoryData') }}</span>
@@ -2901,7 +3071,10 @@ function s3ObjectPrefixCell(row: RepositoryRow) {
                     <span class="hfl-detail-row__label">{{ t('repositoriesPage.configuredLimit') }}</span>
                     <span class="hfl-detail-row__value">{{ s3QuotaLimitLabel(detailRow) }}</span>
                   </div>
-                  <div v-if="repositoryUsagePercent(detailRow) != null" class="hfl-detail-row">
+                  <div
+                    v-if="repositoryUsagePercent(detailRow) != null"
+                    class="hfl-detail-row"
+                  >
                     <span class="hfl-detail-row__label">{{ t('repositoriesPage.usageOfLimit') }}</span>
                     <span class="hfl-detail-row__value">{{ repositoryUsagePercent(detailRow) }}%</span>
                   </div>
@@ -2912,22 +3085,35 @@ function s3ObjectPrefixCell(row: RepositoryRow) {
                         :value="quotaMonitoringEnabled(detailRow)"
                         :label="quotaMonitoringLabel(detailRow)"
                       />
-                      <ElTag v-if="quotaMonitoringThresholdLabel(detailRow)" type="info" size="small" effect="plain">
+                      <ElTag
+                        v-if="quotaMonitoringThresholdLabel(detailRow)"
+                        type="info"
+                        size="small"
+                        effect="plain"
+                      >
                         {{ quotaMonitoringThresholdLabel(detailRow) }}
                       </ElTag>
                     </span>
                   </div>
                   <div class="hfl-detail-row">
                     <span class="hfl-detail-row__label">{{ t('repositoriesPage.usageLastUpdated') }}</span>
-                    <span class="hfl-detail-row__value" :class="detailEmptyValueClass(formatLastCheckedAt(detailRow.usage_last_success_at || detailRow.last_checked_at))">{{ formatLastCheckedAt(detailRow.usage_last_success_at || detailRow.last_checked_at) }}</span>
+                    <span
+                      class="hfl-detail-row__value"
+                      :class="detailEmptyValueClass(formatLastCheckedAt(detailRow.usage_last_success_at || detailRow.last_checked_at))"
+                    >{{ formatLastCheckedAt(detailRow.usage_last_success_at || detailRow.last_checked_at) }}</span>
                   </div>
                 </div>
               </section>
             </div>
 
-            <div v-else-if="detailRow.kind === 'nas'" class="hfl-detail-sections repo-storage-detail">
+            <div
+              v-else-if="detailRow.kind === 'nas'"
+              class="hfl-detail-sections repo-storage-detail"
+            >
               <section class="hfl-detail-section">
-                <h4 class="hfl-detail-section__title">{{ t('repositoriesPage.stepRepo') }}</h4>
+                <h4 class="hfl-detail-section__title">
+                  {{ t('repositoriesPage.stepRepo') }}
+                </h4>
                 <div class="hfl-detail-grid">
                   <div class="hfl-detail-row">
                     <span class="hfl-detail-row__label">{{ t('repositoriesPage.detailFieldName') }}</span>
@@ -2940,7 +3126,10 @@ function s3ObjectPrefixCell(row: RepositoryRow) {
                   <div class="hfl-detail-row">
                     <span class="hfl-detail-row__label">{{ t('repositoriesPage.colStatus') }}</span>
                     <span class="hfl-detail-row__value">
-                      <ElTag :type="lifecycleTagType(detailRow.status)" size="small">
+                      <ElTag
+                        :type="lifecycleTagType(detailRow.status)"
+                        size="small"
+                      >
                         {{ repoLifecycleLabel(detailRow.status) }}
                       </ElTag>
                     </span>
@@ -2948,14 +3137,20 @@ function s3ObjectPrefixCell(row: RepositoryRow) {
                   <div class="hfl-detail-row">
                     <span class="hfl-detail-row__label">{{ t('repositoriesPage.colAvailability') }}</span>
                     <span class="hfl-detail-row__value">
-                      <ElTag :type="healthTagType(detailRow.health)" size="small">
+                      <ElTag
+                        :type="healthTagType(detailRow.health)"
+                        size="small"
+                      >
                         {{ repoHealthLabel(detailRow.health) }}
                       </ElTag>
                     </span>
                   </div>
                   <div class="hfl-detail-row">
                     <span class="hfl-detail-row__label">{{ t('repositoriesPage.colRegistered') }}</span>
-                    <span class="hfl-detail-row__value" :class="{ 'hfl-detail-row__empty': !detailRow.created_at }">{{ formatLocalDateTime(detailRow.created_at) }}</span>
+                    <span
+                      class="hfl-detail-row__value"
+                      :class="{ 'hfl-detail-row__empty': !detailRow.created_at }"
+                    >{{ formatLocalDateTime(detailRow.created_at) }}</span>
                   </div>
                   <div class="hfl-detail-row hfl-detail-row--full">
                     <span class="hfl-detail-row__label">{{ t('repositoriesPage.detailFieldLocation') }}</span>
@@ -2978,17 +3173,30 @@ function s3ObjectPrefixCell(row: RepositoryRow) {
               </section>
 
               <section class="hfl-detail-section">
-                <h4 class="hfl-detail-section__title">{{ t('repositoriesPage.detailSectionConnectionAuth') }}</h4>
+                <h4 class="hfl-detail-section__title">
+                  {{ t('repositoriesPage.detailSectionConnectionAuth') }}
+                </h4>
                 <div class="hfl-detail-grid">
                   <div class="hfl-detail-row">
                     <span class="hfl-detail-row__label">
                       {{ detailRow.protocol === 'smb' ? t('addNasRepo.fieldSmbHost') : t('addNasRepo.fieldNfsHost') }}
                     </span>
                     <span class="hfl-detail-row__value repo-detail__inline-value">
-                      <span class="hfl-detail-row__text hfl-detail-row__value--mono" :class="detailEmptyValueClass(nasServerValueWithProtocol(detailRow))">{{ nasServerValueWithProtocol(detailRow) }}</span>
-                      <ElTag :type="nasProtocolTagType(detailRow.protocol)" size="small" effect="plain">
+                      <span
+                        class="hfl-detail-row__text hfl-detail-row__value--mono"
+                        :class="detailEmptyValueClass(nasServerValueWithProtocol(detailRow))"
+                      >{{ nasServerValueWithProtocol(detailRow) }}</span>
+                      <ElTag
+                        :type="nasProtocolTagType(detailRow.protocol)"
+                        size="small"
+                        effect="plain"
+                      >
                         <span class="hfl-detail-protocol-tag">
-                          <component :is="nasMountProtocolIcon(detailRow.protocol)" :size="12" stroke-width="2.25" />
+                          <component
+                            :is="nasMountProtocolIcon(detailRow.protocol)"
+                            :size="12"
+                            stroke-width="2.25"
+                          />
                           {{ protocolLabel(detailRow.protocol) }}
                         </span>
                       </ElTag>
@@ -2998,27 +3206,44 @@ function s3ObjectPrefixCell(row: RepositoryRow) {
                     <span class="hfl-detail-row__label">
                       {{ detailRow.protocol === 'smb' ? t('addNasRepo.fieldSmbShare') : t('addNasRepo.fieldNfsExport') }}
                     </span>
-                    <span class="hfl-detail-row__value hfl-detail-row__value--mono" :class="detailEmptyValueClass(nasRepoShareOrExport(detailRow))">{{ nasRepoShareOrExport(detailRow) }}</span>
+                    <span
+                      class="hfl-detail-row__value hfl-detail-row__value--mono"
+                      :class="detailEmptyValueClass(nasRepoShareOrExport(detailRow))"
+                    >{{ nasRepoShareOrExport(detailRow) }}</span>
                   </div>
                   <template v-if="detailRow.protocol === 'smb'">
                     <div class="hfl-detail-row">
                       <span class="hfl-detail-row__label">{{ t('repositoriesPage.fieldSmbUsername') }}</span>
-                      <span class="hfl-detail-row__value" :class="detailEmptyValueClass(detailRow.config.smb_username || DETAIL_EMPTY)">{{ detailRow.config.smb_username || DETAIL_EMPTY }}</span>
+                      <span
+                        class="hfl-detail-row__value"
+                        :class="detailEmptyValueClass(detailRow.config.smb_username || DETAIL_EMPTY)"
+                      >{{ detailRow.config.smb_username || DETAIL_EMPTY }}</span>
                     </div>
                     <div class="hfl-detail-row">
                       <span class="hfl-detail-row__label">{{ t('repositoriesPage.fieldSmbDomain') }}</span>
-                      <span class="hfl-detail-row__value" :class="detailEmptyValueClass(detailRow.config.smb_domain || DETAIL_EMPTY)">{{ detailRow.config.smb_domain || DETAIL_EMPTY }}</span>
+                      <span
+                        class="hfl-detail-row__value"
+                        :class="detailEmptyValueClass(detailRow.config.smb_domain || DETAIL_EMPTY)"
+                      >{{ detailRow.config.smb_domain || DETAIL_EMPTY }}</span>
                     </div>
                   </template>
                   <div class="hfl-detail-row hfl-detail-row--full">
                     <span class="hfl-detail-row__label">{{ t('addNasRepo.fieldMountOptions') }}</span>
-                    <span class="hfl-detail-row__value hfl-detail-row__value--mono" :class="detailEmptyValueClass(detailRow.config.nfs_options || DETAIL_EMPTY)">{{ detailRow.config.nfs_options || DETAIL_EMPTY }}</span>
+                    <span
+                      class="hfl-detail-row__value hfl-detail-row__value--mono"
+                      :class="detailEmptyValueClass(detailRow.config.nfs_options || DETAIL_EMPTY)"
+                    >{{ detailRow.config.nfs_options || DETAIL_EMPTY }}</span>
                   </div>
                 </div>
               </section>
 
-              <section v-if="hasBoundProxy(detailRow)" class="hfl-detail-section">
-                <h4 class="hfl-detail-section__title">{{ t('repositoriesPage.detailSectionProxyAccessMount') }}</h4>
+              <section
+                v-if="hasBoundProxy(detailRow)"
+                class="hfl-detail-section"
+              >
+                <h4 class="hfl-detail-section__title">
+                  {{ t('repositoriesPage.detailSectionProxyAccessMount') }}
+                </h4>
                 <div class="hfl-detail-grid">
                   <div class="hfl-detail-row">
                     <span class="hfl-detail-row__label">{{ t('repositoriesPage.colBoundProxyNode') }}</span>
@@ -3044,32 +3269,55 @@ function s3ObjectPrefixCell(row: RepositoryRow) {
               </section>
 
               <section class="hfl-detail-section">
-                <h4 class="hfl-detail-section__title">{{ t('repositoriesPage.detailFieldRepositoryUsage') }}</h4>
+                <h4 class="hfl-detail-section__title">
+                  {{ t('repositoriesPage.detailFieldRepositoryUsage') }}
+                </h4>
                 <div class="hfl-detail-grid">
                   <div class="hfl-detail-row">
                     <span class="hfl-detail-row__label">{{ t('repositoriesPage.estimatedRepositoryData') }}</span>
                     <span class="hfl-detail-row__value hfl-detail-row__value--stacked">
-                      <RepositoryUsageCell :used-bytes="repoUsageParts(detailRow).used" :limit-bytes="0" :probe-status="detailRow.usage_probe_status" :format-bytes="fmtBytes" variant="detail" :show-supporting="false" />
+                      <RepositoryUsageCell
+                        :used-bytes="repoUsageParts(detailRow).used"
+                        :limit-bytes="0"
+                        :probe-status="detailRow.usage_probe_status"
+                        :format-bytes="fmtBytes"
+                        variant="detail"
+                        :show-supporting="false"
+                      />
                     </span>
                   </div>
                   <div class="hfl-detail-row">
                     <span class="hfl-detail-row__label">{{ t('repositoriesPage.configuredLimit') }}</span>
                     <span class="hfl-detail-row__value">{{ storageLimitLabel(detailRow) }}</span>
                   </div>
-                  <div v-if="repositoryUsagePercent(detailRow) != null" class="hfl-detail-row">
+                  <div
+                    v-if="repositoryUsagePercent(detailRow) != null"
+                    class="hfl-detail-row"
+                  >
                     <span class="hfl-detail-row__label">{{ t('repositoriesPage.usageOfLimit') }}</span>
                     <span class="hfl-detail-row__value">{{ repositoryUsagePercent(detailRow) }}%</span>
                   </div>
                   <div class="hfl-detail-row">
                     <span class="hfl-detail-row__label">{{ t('repositoriesPage.quotaMonitoring') }}</span>
                     <span class="hfl-detail-row__value repo-detail__tag-group">
-                      <HflBooleanStatusTag :value="quotaMonitoringEnabled(detailRow)" :label="quotaMonitoringLabel(detailRow)" />
-                      <ElTag v-if="quotaMonitoringThresholdLabel(detailRow)" type="info" size="small" effect="plain">{{ t('repositoriesPage.alertAtValue', { value: detailRow.config.quota_alert_threshold }) }}</ElTag>
+                      <HflBooleanStatusTag
+                        :value="quotaMonitoringEnabled(detailRow)"
+                        :label="quotaMonitoringLabel(detailRow)"
+                      />
+                      <ElTag
+                        v-if="quotaMonitoringThresholdLabel(detailRow)"
+                        type="info"
+                        size="small"
+                        effect="plain"
+                      >{{ t('repositoriesPage.alertAtValue', { value: detailRow.config.quota_alert_threshold }) }}</ElTag>
                     </span>
                   </div>
                   <div class="hfl-detail-row">
                     <span class="hfl-detail-row__label">{{ t('repositoriesPage.usageLastUpdated') }}</span>
-                    <span class="hfl-detail-row__value" :class="detailEmptyValueClass(formatLastCheckedAt(detailRow.usage_last_success_at || detailRow.last_checked_at))">{{ formatLastCheckedAt(detailRow.usage_last_success_at || detailRow.last_checked_at) }}</span>
+                    <span
+                      class="hfl-detail-row__value"
+                      :class="detailEmptyValueClass(formatLastCheckedAt(detailRow.usage_last_success_at || detailRow.last_checked_at))"
+                    >{{ formatLastCheckedAt(detailRow.usage_last_success_at || detailRow.last_checked_at) }}</span>
                   </div>
                 </div>
               </section>
@@ -3083,23 +3331,49 @@ function s3ObjectPrefixCell(row: RepositoryRow) {
               />
 
               <section class="hfl-detail-section">
-                <h4 class="hfl-detail-section__title">{{ t('repositoriesPage.detailFieldBackingStorage') }}</h4>
+                <h4 class="hfl-detail-section__title">
+                  {{ t('repositoriesPage.detailFieldBackingStorage') }}
+                </h4>
                 <div class="hfl-detail-grid">
-                  <div class="hfl-detail-row"><span class="hfl-detail-row__label">{{ t('repositoriesPage.storageType') }}</span><span class="hfl-detail-row__value">{{ t('repositoriesPage.storageTypeNas') }}</span></div>
-                  <div class="hfl-detail-row"><span class="hfl-detail-row__label">{{ t('repositoriesPage.nasLocation') }}</span><span class="hfl-detail-row__value hfl-detail-row__value--mono">{{ nasRepositoryLocation(detailRow) }}</span></div>
-                  <div class="hfl-detail-row"><span class="hfl-detail-row__label">{{ hasBoundProxy(detailRow) ? t('repositoriesPage.accessedThrough') : t('repositoriesPage.accessMode') }}</span><span class="hfl-detail-row__value">{{ hasBoundProxy(detailRow) ? boundProxyNodeLabel(detailRow) : t('repositoriesPage.accessModeDirect') }}</span></div>
+                  <div class="hfl-detail-row">
+                    <span class="hfl-detail-row__label">{{ t('repositoriesPage.storageType') }}</span><span class="hfl-detail-row__value">{{ t('repositoriesPage.storageTypeNas') }}</span>
+                  </div>
+                  <div class="hfl-detail-row">
+                    <span class="hfl-detail-row__label">{{ t('repositoriesPage.nasLocation') }}</span><span class="hfl-detail-row__value hfl-detail-row__value--mono">{{ nasRepositoryLocation(detailRow) }}</span>
+                  </div>
+                  <div class="hfl-detail-row">
+                    <span class="hfl-detail-row__label">{{ hasBoundProxy(detailRow) ? t('repositoriesPage.accessedThrough') : t('repositoriesPage.accessMode') }}</span><span class="hfl-detail-row__value">{{ hasBoundProxy(detailRow) ? boundProxyNodeLabel(detailRow) : t('repositoriesPage.accessModeDirect') }}</span>
+                  </div>
                   <div class="hfl-detail-row">
                     <span class="hfl-detail-row__label">{{ t('repositoriesPage.availableSpace') }}</span>
-                    <RepositoryBackingStorageTooltip :rows="backingStoragePopoverRows(detailRow)" :note="backingStoragePopoverNote(detailRow)"><span class="hfl-detail-row__value" :class="{ 'hfl-detail-row__empty': backingStorageDisplayUnavailable(detailRow) }">{{ backingStorageDisplayLabel(detailRow) }}</span></RepositoryBackingStorageTooltip>
+                    <RepositoryBackingStorageTooltip
+                      :rows="backingStoragePopoverRows(detailRow)"
+                      :note="backingStoragePopoverNote(detailRow)"
+                    >
+                      <span
+                        class="hfl-detail-row__value"
+                        :class="{ 'hfl-detail-row__empty': backingStorageDisplayUnavailable(detailRow) }"
+                      >{{ backingStorageDisplayLabel(detailRow) }}</span>
+                    </RepositoryBackingStorageTooltip>
                   </div>
-                  <div v-if="hasBoundProxy(detailRow)" class="hfl-detail-row"><span class="hfl-detail-row__label">{{ t('repositoriesPage.detailFieldLastChecked') }}</span><span class="hfl-detail-row__value">{{ backingStorageLastChecked(detailRow) }}</span></div>
+                  <div
+                    v-if="hasBoundProxy(detailRow)"
+                    class="hfl-detail-row"
+                  >
+                    <span class="hfl-detail-row__label">{{ t('repositoriesPage.detailFieldLastChecked') }}</span><span class="hfl-detail-row__value">{{ backingStorageLastChecked(detailRow) }}</span>
+                  </div>
                 </div>
               </section>
             </div>
 
-            <div v-else class="hfl-detail-sections repo-storage-detail">
+            <div
+              v-else
+              class="hfl-detail-sections repo-storage-detail"
+            >
               <section class="hfl-detail-section">
-                <h4 class="hfl-detail-section__title">{{ t('repositoriesPage.stepRepo') }}</h4>
+                <h4 class="hfl-detail-section__title">
+                  {{ t('repositoriesPage.stepRepo') }}
+                </h4>
                 <div class="hfl-detail-grid">
                   <div class="hfl-detail-row">
                     <span class="hfl-detail-row__label">{{ t('repositoriesPage.detailFieldName') }}</span>
@@ -3112,7 +3386,10 @@ function s3ObjectPrefixCell(row: RepositoryRow) {
                   <div class="hfl-detail-row">
                     <span class="hfl-detail-row__label">{{ t('repositoriesPage.colStatus') }}</span>
                     <span class="hfl-detail-row__value">
-                      <ElTag :type="lifecycleTagType(detailRow.status)" size="small">
+                      <ElTag
+                        :type="lifecycleTagType(detailRow.status)"
+                        size="small"
+                      >
                         {{ repoLifecycleLabel(detailRow.status) }}
                       </ElTag>
                     </span>
@@ -3120,14 +3397,20 @@ function s3ObjectPrefixCell(row: RepositoryRow) {
                   <div class="hfl-detail-row">
                     <span class="hfl-detail-row__label">{{ t('repositoriesPage.colAvailability') }}</span>
                     <span class="hfl-detail-row__value">
-                      <ElTag :type="healthTagType(detailRow.health)" size="small">
+                      <ElTag
+                        :type="healthTagType(detailRow.health)"
+                        size="small"
+                      >
                         {{ repoHealthLabel(detailRow.health) }}
                       </ElTag>
                     </span>
                   </div>
                   <div class="hfl-detail-row">
                     <span class="hfl-detail-row__label">{{ t('repositoriesPage.colRegistered') }}</span>
-                    <span class="hfl-detail-row__value" :class="{ 'hfl-detail-row__empty': !detailRow.created_at }">{{ formatLocalDateTime(detailRow.created_at) }}</span>
+                    <span
+                      class="hfl-detail-row__value"
+                      :class="{ 'hfl-detail-row__empty': !detailRow.created_at }"
+                    >{{ formatLocalDateTime(detailRow.created_at) }}</span>
                   </div>
                   <div class="hfl-detail-row hfl-detail-row--full">
                     <span class="hfl-detail-row__label">{{ t('repositoriesPage.detailFieldLocation') }}</span>
@@ -3150,19 +3433,30 @@ function s3ObjectPrefixCell(row: RepositoryRow) {
               </section>
 
               <section class="hfl-detail-section">
-                <h4 class="hfl-detail-section__title">{{ t('repositoriesPage.detailSectionRepoConfig') }}</h4>
+                <h4 class="hfl-detail-section__title">
+                  {{ t('repositoriesPage.detailSectionRepoConfig') }}
+                </h4>
                 <div class="hfl-detail-grid">
                   <div class="hfl-detail-row">
                     <span class="hfl-detail-row__label">{{ t('repositoriesPage.detailFieldHostingProxyNode') }}</span>
-                    <span class="hfl-detail-row__value" :class="detailEmptyValueClass(localDiskHostingProxyNode(detailRow))">{{ localDiskHostingProxyNode(detailRow) }}</span>
+                    <span
+                      class="hfl-detail-row__value"
+                      :class="detailEmptyValueClass(localDiskHostingProxyNode(detailRow))"
+                    >{{ localDiskHostingProxyNode(detailRow) }}</span>
                   </div>
                   <div class="hfl-detail-row">
                     <span class="hfl-detail-row__label">{{ t('repositoriesPage.fieldProxyNodeDir') }}</span>
-                    <span class="hfl-detail-row__value hfl-detail-row__value--mono" :class="detailEmptyValueClass(localDiskRepositoryPath(detailRow))">{{ localDiskRepositoryPath(detailRow) }}</span>
+                    <span
+                      class="hfl-detail-row__value hfl-detail-row__value--mono"
+                      :class="detailEmptyValueClass(localDiskRepositoryPath(detailRow))"
+                    >{{ localDiskRepositoryPath(detailRow) }}</span>
                   </div>
                   <div class="hfl-detail-row">
                     <span class="hfl-detail-row__label">{{ t('repositoriesPage.fieldProxyNodeBaseDir') }}</span>
-                    <span class="hfl-detail-row__value hfl-detail-row__value--mono" :class="detailEmptyValueClass(localDiskBaseDirectory(detailRow))">{{ localDiskBaseDirectory(detailRow) }}</span>
+                    <span
+                      class="hfl-detail-row__value hfl-detail-row__value--mono"
+                      :class="detailEmptyValueClass(localDiskBaseDirectory(detailRow))"
+                    >{{ localDiskBaseDirectory(detailRow) }}</span>
                   </div>
                   <div class="hfl-detail-row">
                     <span class="hfl-detail-row__label">{{ t('repositoriesPage.fieldRepositoryServerHost') }}</span>
@@ -3172,13 +3466,43 @@ function s3ObjectPrefixCell(row: RepositoryRow) {
               </section>
 
               <section class="hfl-detail-section">
-                <h4 class="hfl-detail-section__title">{{ t('repositoriesPage.detailFieldRepositoryUsage') }}</h4>
+                <h4 class="hfl-detail-section__title">
+                  {{ t('repositoriesPage.detailFieldRepositoryUsage') }}
+                </h4>
                 <div class="hfl-detail-grid">
-                  <div class="hfl-detail-row"><span class="hfl-detail-row__label">{{ t('repositoriesPage.estimatedRepositoryData') }}</span><span class="hfl-detail-row__value hfl-detail-row__value--stacked"><RepositoryUsageCell :used-bytes="repoUsageParts(detailRow).used" :limit-bytes="0" :probe-status="detailRow.usage_probe_status" :format-bytes="fmtBytes" variant="detail" :show-supporting="false" /></span></div>
-                  <div class="hfl-detail-row"><span class="hfl-detail-row__label">{{ t('repositoriesPage.configuredLimit') }}</span><span class="hfl-detail-row__value">{{ storageLimitLabel(detailRow) }}</span></div>
-                  <div v-if="repositoryUsagePercent(detailRow) != null" class="hfl-detail-row"><span class="hfl-detail-row__label">{{ t('repositoriesPage.usageOfLimit') }}</span><span class="hfl-detail-row__value">{{ repositoryUsagePercent(detailRow) }}%</span></div>
-                  <div class="hfl-detail-row"><span class="hfl-detail-row__label">{{ t('repositoriesPage.quotaMonitoring') }}</span><span class="hfl-detail-row__value repo-detail__tag-group"><HflBooleanStatusTag :value="quotaMonitoringEnabled(detailRow)" :label="quotaMonitoringLabel(detailRow)" /><ElTag v-if="quotaMonitoringThresholdLabel(detailRow)" type="info" size="small" effect="plain">{{ t('repositoriesPage.alertAtValue', { value: detailRow.config.quota_alert_threshold }) }}</ElTag></span></div>
-                  <div class="hfl-detail-row"><span class="hfl-detail-row__label">{{ t('repositoriesPage.usageLastUpdated') }}</span><span class="hfl-detail-row__value">{{ formatLastCheckedAt(detailRow.usage_last_success_at || detailRow.last_checked_at) }}</span></div>
+                  <div class="hfl-detail-row">
+                    <span class="hfl-detail-row__label">{{ t('repositoriesPage.estimatedRepositoryData') }}</span><span class="hfl-detail-row__value hfl-detail-row__value--stacked"><RepositoryUsageCell
+                      :used-bytes="repoUsageParts(detailRow).used"
+                      :limit-bytes="0"
+                      :probe-status="detailRow.usage_probe_status"
+                      :format-bytes="fmtBytes"
+                      variant="detail"
+                      :show-supporting="false"
+                    /></span>
+                  </div>
+                  <div class="hfl-detail-row">
+                    <span class="hfl-detail-row__label">{{ t('repositoriesPage.configuredLimit') }}</span><span class="hfl-detail-row__value">{{ storageLimitLabel(detailRow) }}</span>
+                  </div>
+                  <div
+                    v-if="repositoryUsagePercent(detailRow) != null"
+                    class="hfl-detail-row"
+                  >
+                    <span class="hfl-detail-row__label">{{ t('repositoriesPage.usageOfLimit') }}</span><span class="hfl-detail-row__value">{{ repositoryUsagePercent(detailRow) }}%</span>
+                  </div>
+                  <div class="hfl-detail-row">
+                    <span class="hfl-detail-row__label">{{ t('repositoriesPage.quotaMonitoring') }}</span><span class="hfl-detail-row__value repo-detail__tag-group"><HflBooleanStatusTag
+                      :value="quotaMonitoringEnabled(detailRow)"
+                      :label="quotaMonitoringLabel(detailRow)"
+                    /><ElTag
+                      v-if="quotaMonitoringThresholdLabel(detailRow)"
+                      type="info"
+                      size="small"
+                      effect="plain"
+                    >{{ t('repositoriesPage.alertAtValue', { value: detailRow.config.quota_alert_threshold }) }}</ElTag></span>
+                  </div>
+                  <div class="hfl-detail-row">
+                    <span class="hfl-detail-row__label">{{ t('repositoriesPage.usageLastUpdated') }}</span><span class="hfl-detail-row__value">{{ formatLastCheckedAt(detailRow.usage_last_success_at || detailRow.last_checked_at) }}</span>
+                  </div>
                 </div>
               </section>
 
@@ -3191,13 +3515,33 @@ function s3ObjectPrefixCell(row: RepositoryRow) {
               />
 
               <section class="hfl-detail-section">
-                <h4 class="hfl-detail-section__title">{{ t('repositoriesPage.detailFieldBackingStorage') }}</h4>
+                <h4 class="hfl-detail-section__title">
+                  {{ t('repositoriesPage.detailFieldBackingStorage') }}
+                </h4>
                 <div class="hfl-detail-grid">
-                  <div class="hfl-detail-row"><span class="hfl-detail-row__label">{{ t('repositoriesPage.storageType') }}</span><span class="hfl-detail-row__value">{{ t('repositoriesPage.storageTypeProxyDisk') }}</span></div>
-                  <div class="hfl-detail-row"><span class="hfl-detail-row__label">{{ t('repositoriesPage.detailFieldHostingProxyNode') }}</span><span class="hfl-detail-row__value">{{ localDiskHostingProxyNode(detailRow) }}</span></div>
-                  <div class="hfl-detail-row"><span class="hfl-detail-row__label">{{ t('repositoriesPage.filesystem') }}</span><span class="hfl-detail-row__value hfl-detail-row__value--mono">{{ detailRow.storage_mount_point || localDiskBaseDirectory(detailRow) }}</span></div>
-                  <div class="hfl-detail-row"><span class="hfl-detail-row__label">{{ t('repositoriesPage.availableSpace') }}</span><RepositoryBackingStorageTooltip :rows="backingStoragePopoverRows(detailRow)" :note="backingStoragePopoverNote(detailRow)"><span class="hfl-detail-row__value" :class="{ 'hfl-detail-row__empty': backingStorageDisplayUnavailable(detailRow) }">{{ backingStorageDisplayLabel(detailRow) }}</span></RepositoryBackingStorageTooltip></div>
-                  <div class="hfl-detail-row"><span class="hfl-detail-row__label">{{ t('repositoriesPage.detailFieldLastChecked') }}</span><span class="hfl-detail-row__value">{{ backingStorageLastChecked(detailRow) }}</span></div>
+                  <div class="hfl-detail-row">
+                    <span class="hfl-detail-row__label">{{ t('repositoriesPage.storageType') }}</span><span class="hfl-detail-row__value">{{ t('repositoriesPage.storageTypeProxyDisk') }}</span>
+                  </div>
+                  <div class="hfl-detail-row">
+                    <span class="hfl-detail-row__label">{{ t('repositoriesPage.detailFieldHostingProxyNode') }}</span><span class="hfl-detail-row__value">{{ localDiskHostingProxyNode(detailRow) }}</span>
+                  </div>
+                  <div class="hfl-detail-row">
+                    <span class="hfl-detail-row__label">{{ t('repositoriesPage.filesystem') }}</span><span class="hfl-detail-row__value hfl-detail-row__value--mono">{{ detailRow.storage_mount_point || localDiskBaseDirectory(detailRow) }}</span>
+                  </div>
+                  <div class="hfl-detail-row">
+                    <span class="hfl-detail-row__label">{{ t('repositoriesPage.availableSpace') }}</span><RepositoryBackingStorageTooltip
+                      :rows="backingStoragePopoverRows(detailRow)"
+                      :note="backingStoragePopoverNote(detailRow)"
+                    >
+                      <span
+                        class="hfl-detail-row__value"
+                        :class="{ 'hfl-detail-row__empty': backingStorageDisplayUnavailable(detailRow) }"
+                      >{{ backingStorageDisplayLabel(detailRow) }}</span>
+                    </RepositoryBackingStorageTooltip>
+                  </div>
+                  <div class="hfl-detail-row">
+                    <span class="hfl-detail-row__label">{{ t('repositoriesPage.detailFieldLastChecked') }}</span><span class="hfl-detail-row__value">{{ backingStorageLastChecked(detailRow) }}</span>
+                  </div>
                 </div>
               </section>
             </div>
@@ -3269,7 +3613,10 @@ function s3ObjectPrefixCell(row: RepositoryRow) {
                               />
                             </span>
                           </ElTooltip>
-                          <span v-else class="hfl-empty-mark">
+                          <span
+                            v-else
+                            class="hfl-empty-mark"
+                          >
                             {{ DETAIL_EMPTY }}
                           </span>
                         </div>
@@ -3316,10 +3663,16 @@ function s3ObjectPrefixCell(row: RepositoryRow) {
                 >
                   <template #default="{ row }">
                     <div class="repo-associated-health-cell">
-                      <ElTag size="small" v-bind="associatedSourceHealthTagAttrs(row)">
+                      <ElTag
+                        size="small"
+                        v-bind="associatedSourceHealthTagAttrs(row)"
+                      >
                         {{ associatedSourceHealthLabel(row) }}
                       </ElTag>
-                      <span class="repo-associated-health-cell__time" :class="{ 'hfl-empty-mark': associatedSourceCheckedAt(row) === DETAIL_EMPTY }">{{ associatedSourceCheckedAt(row) }}</span>
+                      <span
+                        class="repo-associated-health-cell__time"
+                        :class="{ 'hfl-empty-mark': associatedSourceCheckedAt(row) === DETAIL_EMPTY }"
+                      >{{ associatedSourceCheckedAt(row) }}</span>
                       <ElTooltip
                         v-if="row.last_error"
                         :content="row.last_error"
@@ -3336,7 +3689,10 @@ function s3ObjectPrefixCell(row: RepositoryRow) {
                   min-width="130"
                 >
                   <template #default="{ row }">
-                    <ElTag size="small" v-bind="associatedSourceStatusTagAttrs(row.availability)">
+                    <ElTag
+                      size="small"
+                      v-bind="associatedSourceStatusTagAttrs(row.availability)"
+                    >
                       {{ associatedSourceStatusLabel(row.availability) }}
                     </ElTag>
                   </template>
@@ -3347,7 +3703,10 @@ function s3ObjectPrefixCell(row: RepositoryRow) {
                   min-width="170"
                 >
                   <template #default="{ row }">
-                    <span class="hfl-table-cell-time" :class="{ 'hfl-empty-mark': !row.registered_at }">{{ formatLocalDateTime(row.registered_at) }}</span>
+                    <span
+                      class="hfl-table-cell-time"
+                      :class="{ 'hfl-empty-mark': !row.registered_at }"
+                    >{{ formatLocalDateTime(row.registered_at) }}</span>
                   </template>
                 </ElTableColumn>
               </ElTable>
@@ -3364,7 +3723,10 @@ function s3ObjectPrefixCell(row: RepositoryRow) {
               </div>
             </div>
           </ElTabPane>
-          <ElTabPane :label="t('repositoriesPage.detailTabTasks')" name="tasks">
+          <ElTabPane
+            :label="t('repositoriesPage.detailTabTasks')"
+            name="tasks"
+          >
             <div class="repo-tasks">
               <div class="hfl-list-toolbar repo-tasks__filters">
                 <ElInput
@@ -3376,7 +3738,10 @@ function s3ObjectPrefixCell(row: RepositoryRow) {
                   @clear="clearRepositoryTaskSearch"
                 >
                   <template #prepend>
-                    <ElSelect v-model="repositoryTaskSearchField" @change="handleRepositoryTaskSearchFieldChange">
+                    <ElSelect
+                      v-model="repositoryTaskSearchField"
+                      @change="handleRepositoryTaskSearchFieldChange"
+                    >
                       <ElOption
                         v-for="option in repositoryTaskSearchFieldOptions"
                         :key="option.value"
@@ -3385,21 +3750,61 @@ function s3ObjectPrefixCell(row: RepositoryRow) {
                       />
                     </ElSelect>
                   </template>
-                  <template #prefix><Search :size="15" /></template>
+                  <template #prefix>
+                    <Search :size="15" />
+                  </template>
                 </ElInput>
-                <ElSelect v-model="repositoryTaskOperation" clearable :placeholder="t('repositoriesPage.tasksOperation')">
-                  <ElOption :label="t('repositoriesPage.taskOperationQuick')" value="maintenance.quick" />
-                  <ElOption :label="t('repositoriesPage.taskOperationFull')" value="maintenance.full" />
-                  <ElOption :label="t('repositoriesPage.taskOperationCleanupTarget')" value="cleanup.target" />
-                  <ElOption :label="t('repositoriesPage.taskOperationCleanupRepository')" value="cleanup.repository" />
-                  <ElOption :label="t('repositoriesPage.taskOperationCheck')" value="check" />
+                <ElSelect
+                  v-model="repositoryTaskOperation"
+                  clearable
+                  :placeholder="t('repositoriesPage.tasksOperation')"
+                >
+                  <ElOption
+                    :label="t('repositoriesPage.taskOperationQuick')"
+                    value="maintenance.quick"
+                  />
+                  <ElOption
+                    :label="t('repositoriesPage.taskOperationFull')"
+                    value="maintenance.full"
+                  />
+                  <ElOption
+                    :label="t('repositoriesPage.taskOperationCleanupTarget')"
+                    value="cleanup.target"
+                  />
+                  <ElOption
+                    :label="t('repositoriesPage.taskOperationCleanupRepository')"
+                    value="cleanup.repository"
+                  />
+                  <ElOption
+                    :label="t('repositoriesPage.taskOperationCheck')"
+                    value="check"
+                  />
                 </ElSelect>
-                <ElSelect v-model="repositoryTaskStatus" clearable :placeholder="t('repositoriesPage.tasksStatus')">
-                  <ElOption :label="t('repositoriesPage.taskStatusPending')" value="pending" />
-                  <ElOption :label="t('repositoriesPage.taskStatusRunning')" value="running" />
-                  <ElOption :label="t('repositoriesPage.taskStatusSuccess')" value="success" />
-                  <ElOption :label="t('repositoriesPage.taskStatusFailed')" value="failed" />
-                  <ElOption :label="t('repositoriesPage.taskStatusTimeout')" value="timeout" />
+                <ElSelect
+                  v-model="repositoryTaskStatus"
+                  clearable
+                  :placeholder="t('repositoriesPage.tasksStatus')"
+                >
+                  <ElOption
+                    :label="t('repositoriesPage.taskStatusPending')"
+                    value="pending"
+                  />
+                  <ElOption
+                    :label="t('repositoriesPage.taskStatusRunning')"
+                    value="running"
+                  />
+                  <ElOption
+                    :label="t('repositoriesPage.taskStatusSuccess')"
+                    value="success"
+                  />
+                  <ElOption
+                    :label="t('repositoriesPage.taskStatusFailed')"
+                    value="failed"
+                  />
+                  <ElOption
+                    :label="t('repositoriesPage.taskStatusTimeout')"
+                    value="timeout"
+                  />
                 </ElSelect>
                 <ElSelect
                   v-model="repositoryTaskTimeMode"
@@ -3435,7 +3840,10 @@ function s3ObjectPrefixCell(row: RepositoryRow) {
                     :disabled="repositoryTasksLoading"
                     @click="loadRepositoryTasks"
                   >
-                    <RefreshCw :size="16" :class="{ 'is-spinning': repositoryTasksLoading }" />
+                    <RefreshCw
+                      :size="16"
+                      :class="{ 'is-spinning': repositoryTasksLoading }"
+                    />
                   </ElButton>
                 </div>
               </div>
@@ -3455,7 +3863,10 @@ function s3ObjectPrefixCell(row: RepositoryRow) {
                 class="hfl-list-table repo-tasks__table"
                 @row-click="openRepositoryTaskDetail"
               >
-                <ElTableColumn :label="t('repositoriesPage.tasksName')" min-width="250">
+                <ElTableColumn
+                  :label="t('repositoriesPage.tasksName')"
+                  min-width="250"
+                >
                   <template #default="{ row }">
                     <div class="repo-task-name">
                       <span>{{ row.display_name }}</span>
@@ -3463,33 +3874,65 @@ function s3ObjectPrefixCell(row: RepositoryRow) {
                     </div>
                   </template>
                 </ElTableColumn>
-                <ElTableColumn :label="t('repositoriesPage.tasksOperation')" min-width="150">
-                  <template #default="{ row }">{{ repositoryTaskLabel('operation', row.operation_type) }}</template>
-                </ElTableColumn>
-                <ElTableColumn :label="t('repositoriesPage.tasksStatus')" width="120">
+                <ElTableColumn
+                  :label="t('repositoriesPage.tasksOperation')"
+                  min-width="150"
+                >
                   <template #default="{ row }">
-                    <ElTag size="small" effect="plain" :type="repositoryTaskStatusType(row.status)">
+                    {{ repositoryTaskLabel('operation', row.operation_type) }}
+                  </template>
+                </ElTableColumn>
+                <ElTableColumn
+                  :label="t('repositoriesPage.tasksStatus')"
+                  width="120"
+                >
+                  <template #default="{ row }">
+                    <ElTag
+                      size="small"
+                      effect="plain"
+                      :type="repositoryTaskStatusType(row.status)"
+                    >
                       {{ repositoryTaskLabel('status', row.status) }}
                     </ElTag>
                   </template>
                 </ElTableColumn>
-                <ElTableColumn :label="t('repositoriesPage.tasksProgress')" min-width="150">
+                <ElTableColumn
+                  :label="t('repositoriesPage.tasksProgress')"
+                  min-width="150"
+                >
                   <template #default="{ row }">
-                    <ElProgress :percentage="repositoryTaskProgress(row)" :stroke-width="7" />
+                    <ElProgress
+                      :percentage="repositoryTaskProgress(row)"
+                      :stroke-width="7"
+                    />
                   </template>
                 </ElTableColumn>
-                <ElTableColumn :label="t('repositoriesPage.tasksTrigger')" min-width="130">
+                <ElTableColumn
+                  :label="t('repositoriesPage.tasksTrigger')"
+                  min-width="130"
+                >
                   <template #default="{ row }">
-                    <ElTag type="info" size="small">
+                    <ElTag
+                      type="info"
+                      size="small"
+                    >
                       {{ repositoryTaskLabel('trigger', row.trigger_type) }}
                     </ElTag>
                   </template>
                 </ElTableColumn>
-                <ElTableColumn :label="t('repositoriesPage.tasksCreated')" width="180">
-                  <template #default="{ row }"><span :class="{ 'hfl-empty-mark': !row.created_at }">{{ formatLocalDateTime(row.created_at) }}</span></template>
+                <ElTableColumn
+                  :label="t('repositoriesPage.tasksCreated')"
+                  width="180"
+                >
+                  <template #default="{ row }">
+                    <span :class="{ 'hfl-empty-mark': !row.created_at }">{{ formatLocalDateTime(row.created_at) }}</span>
+                  </template>
                 </ElTableColumn>
               </ElTable>
-              <div v-if="repositoryTasksCount > repositoryTasksPageSize || repositoryTasks.length" class="repo-tasks__footer">
+              <div
+                v-if="repositoryTasksCount > repositoryTasksPageSize || repositoryTasks.length"
+                class="repo-tasks__footer"
+              >
                 <HflPagination
                   v-model:current-page="repositoryTasksPage"
                   v-model:page-size="repositoryTasksPageSize"
@@ -3525,8 +3968,15 @@ function s3ObjectPrefixCell(row: RepositoryRow) {
       </ElForm>
       <template #footer>
         <div class="repo-tasks__filter-drawer-footer">
-          <ElButton @click="resetRepositoryTaskAdvancedFilterDraft">{{ t('ops.task.resetFilter') }}</ElButton>
-          <ElButton type="primary" @click="applyRepositoryTaskAdvancedFilters">{{ t('ops.task.applyFilter') }}</ElButton>
+          <ElButton @click="resetRepositoryTaskAdvancedFilterDraft">
+            {{ t('ops.task.resetFilter') }}
+          </ElButton>
+          <ElButton
+            type="primary"
+            @click="applyRepositoryTaskAdvancedFilters"
+          >
+            {{ t('ops.task.applyFilter') }}
+          </ElButton>
         </div>
       </template>
     </ElDrawer>
@@ -3540,29 +3990,70 @@ function s3ObjectPrefixCell(row: RepositoryRow) {
       @task-updated="loadRepositoryTasks(false)"
     />
 
-    <Modal :open="modalOpen" :title="modalTitle" @close="modalOpen = false; resetForm()">
-      <ElAlert type="info" :closable="false" class="mb-4" show-icon>
+    <Modal
+      :open="modalOpen"
+      :title="modalTitle"
+      @close="modalOpen = false; resetForm()"
+    >
+      <ElAlert
+        type="info"
+        :closable="false"
+        class="mb-4"
+        show-icon
+      >
         {{ modalMode === 'add' ? t('repositoriesPage.modalLead') : t('repositoriesPage.modalEditLead') }}
       </ElAlert>
       <ElForm label-position="top">
         <template v-if="formKind === 's3'">
-          <ElFormItem :label="t('repositoriesPage.fieldAccessKey')" required>
-            <ElInput v-model="form.access_key_id" :placeholder="t('repositoriesPage.phAccessKey')" />
+          <ElFormItem
+            :label="t('repositoriesPage.fieldAccessKey')"
+            required
+          >
+            <ElInput
+              v-model="form.access_key_id"
+              :placeholder="t('repositoriesPage.phAccessKey')"
+            />
           </ElFormItem>
-          <ElFormItem :label="t('repositoriesPage.fieldSecretKey')" required>
-            <ElInput v-model="form.secret_access_key" type="password" show-password :placeholder="t('repositoriesPage.phSecretKey')" />
+          <ElFormItem
+            :label="t('repositoriesPage.fieldSecretKey')"
+            required
+          >
+            <ElInput
+              v-model="form.secret_access_key"
+              type="password"
+              show-password
+              :placeholder="t('repositoriesPage.phSecretKey')"
+            />
           </ElFormItem>
           <ElFormItem :label="t('repositoriesPage.fieldRegion')">
-            <ElInput v-model="form.region" :placeholder="t('repositoriesPage.phRegion')" />
+            <ElInput
+              v-model="form.region"
+              :placeholder="t('repositoriesPage.phRegion')"
+            />
           </ElFormItem>
           <ElFormItem :label="t('repositoriesPage.fieldEndpoint')">
-            <ElInput v-model="form.endpoint" :placeholder="t('repositoriesPage.phEndpoint')" />
+            <ElInput
+              v-model="form.endpoint"
+              :placeholder="t('repositoriesPage.phEndpoint')"
+            />
           </ElFormItem>
           <ElFormItem :label="t('repositoriesPage.fieldS3UrlStyle')">
-            <ElSelect v-model="form.s3_url_style" style="width: 100%">
-              <ElOption value="auto" :label="t('repositoriesPage.s3UrlStyleAuto')" />
-              <ElOption value="virtual_hosted" :label="t('repositoriesPage.s3UrlStyleVirtualHosted')" />
-              <ElOption value="path" :label="t('repositoriesPage.s3UrlStylePath')" />
+            <ElSelect
+              v-model="form.s3_url_style"
+              style="width: 100%"
+            >
+              <ElOption
+                value="auto"
+                :label="t('repositoriesPage.s3UrlStyleAuto')"
+              />
+              <ElOption
+                value="virtual_hosted"
+                :label="t('repositoriesPage.s3UrlStyleVirtualHosted')"
+              />
+              <ElOption
+                value="path"
+                :label="t('repositoriesPage.s3UrlStylePath')"
+              />
             </ElSelect>
           </ElFormItem>
           <ElFormItem :label="t('repositoriesPage.fieldUseTls')">
@@ -3571,14 +4062,29 @@ function s3ObjectPrefixCell(row: RepositoryRow) {
               <span class="repo-form-inline__hint">{{ form.use_tls ? t('repositoriesPage.tlsOnHint') : t('repositoriesPage.tlsOffHint') }}</span>
             </div>
           </ElFormItem>
-          <ElFormItem :label="t('repositoriesPage.fieldRepoName')" required>
-            <ElInput v-model="form.name" :placeholder="t('repositoriesPage.phRepoName')" />
+          <ElFormItem
+            :label="t('repositoriesPage.fieldRepoName')"
+            required
+          >
+            <ElInput
+              v-model="form.name"
+              :placeholder="t('repositoriesPage.phRepoName')"
+            />
           </ElFormItem>
-          <ElFormItem :label="t('repositoriesPage.fieldBucket')" required>
-            <ElInput v-model="form.bucket" :placeholder="t('repositoriesPage.phBucket')" />
+          <ElFormItem
+            :label="t('repositoriesPage.fieldBucket')"
+            required
+          >
+            <ElInput
+              v-model="form.bucket"
+              :placeholder="t('repositoriesPage.phBucket')"
+            />
           </ElFormItem>
           <ElFormItem :label="t('repositoriesPage.fieldPrefix')">
-            <ElInput v-model="form.prefix" :placeholder="t('repositoriesPage.phPrefix')" />
+            <ElInput
+              v-model="form.prefix"
+              :placeholder="t('repositoriesPage.phPrefix')"
+            />
           </ElFormItem>
           <ElFormItem :label="t('repositoriesPage.fieldSourceNode')">
             <ElSelect
@@ -3597,19 +4103,39 @@ function s3ObjectPrefixCell(row: RepositoryRow) {
           </ElFormItem>
         </template>
         <template v-else>
-          <ElFormItem :label="t('repositoriesPage.fieldRepoName')" required>
-            <ElInput v-model="form.name" :placeholder="t('repositoriesPage.phRepoName')" />
+          <ElFormItem
+            :label="t('repositoriesPage.fieldRepoName')"
+            required
+          >
+            <ElInput
+              v-model="form.name"
+              :placeholder="t('repositoriesPage.phRepoName')"
+            />
           </ElFormItem>
-          <ElFormItem :label="t('repositoriesPage.fieldMountPath')" required>
-            <ElInput v-model="form.mount_path" :placeholder="t('repositoriesPage.phMountPath')" />
+          <ElFormItem
+            :label="t('repositoriesPage.fieldMountPath')"
+            required
+          >
+            <ElInput
+              v-model="form.mount_path"
+              :placeholder="t('repositoriesPage.phMountPath')"
+            />
           </ElFormItem>
-          <p class="-mt-1 mb-2 text-xs text-[var(--color-text-tertiary)]">{{ t('repositoriesPage.hintNasPath') }}</p>
+          <p class="-mt-1 mb-2 text-xs text-[var(--color-text-tertiary)]">
+            {{ t('repositoriesPage.hintNasPath') }}
+          </p>
         </template>
       </ElForm>
       <template #footer>
         <div class="flex justify-end gap-2">
-          <ElButton @click="modalOpen = false; resetForm()">{{ t('repositoriesPage.btnCancel') }}</ElButton>
-          <ElButton type="primary" :loading="busy" @click="submitModal">
+          <ElButton @click="modalOpen = false; resetForm()">
+            {{ t('repositoriesPage.btnCancel') }}
+          </ElButton>
+          <ElButton
+            type="primary"
+            :loading="busy"
+            @click="submitModal"
+          >
             {{ formKind === 'proxy_fs' ? t('repositoriesPage.btnCreateRepo') : t('repositoriesPage.btnVerifyInit') }}
           </ElButton>
         </div>
@@ -3635,12 +4161,23 @@ function s3ObjectPrefixCell(row: RepositoryRow) {
         >
           <strong>{{ entry.repository.name }}</strong>
           <ul>
-            <li v-for="reason in entry.blockers" :key="reason">{{ reason }}</li>
+            <li
+              v-for="reason in entry.blockers"
+              :key="reason"
+            >
+              {{ reason }}
+            </li>
           </ul>
-          <div v-if="entry.associationCount" class="repo-cleanup-blocked-associations">
+          <div
+            v-if="entry.associationCount"
+            class="repo-cleanup-blocked-associations"
+          >
             <span>{{ t('repositoriesPage.cleanupBlockedAssociations', { n: entry.associationCount }) }}</span>
             <ul>
-              <li v-for="association in entry.associations" :key="association.backup_config_id">
+              <li
+                v-for="association in entry.associations"
+                :key="association.backup_config_id"
+              >
                 {{ association.backup_config_name }} — {{ association.source_name }}
               </li>
             </ul>
@@ -3648,7 +4185,10 @@ function s3ObjectPrefixCell(row: RepositoryRow) {
         </section>
       </div>
       <template #footer>
-        <ElButton type="primary" @click="repositoryCleanupBlockedDialogOpen = false">
+        <ElButton
+          type="primary"
+          @click="repositoryCleanupBlockedDialogOpen = false"
+        >
           {{ t('common.close') }}
         </ElButton>
       </template>
@@ -3675,7 +4215,10 @@ function s3ObjectPrefixCell(row: RepositoryRow) {
       @confirm="confirmDeleteRepositories"
       @cancel="closeDeleteRepositoriesDialog"
     >
-      <div v-if="canForceDeleteRepository" class="repo-delete-force-option">
+      <div
+        v-if="canForceDeleteRepository"
+        class="repo-delete-force-option"
+      >
         <ElCheckbox v-model="forceDeleteRepository">
           {{ t('repositoriesPage.cleanupForceOption') }}
         </ElCheckbox>

--- a/src/frontend/src/pages/node/Snapshots.vue
+++ b/src/frontend/src/pages/node/Snapshots.vue
@@ -74,42 +74,99 @@ onMounted(() => {
 <template>
   <ModulePage :menus="protectionMenus">
     <template #actions>
-      <ElButton :disabled="busy" @click="load">
+      <ElButton
+        :disabled="busy"
+        @click="load"
+      >
         <RefreshCw :size="16" /> {{ t('protection.snapshotsPage.refresh') }}
       </ElButton>
     </template>
 
     <div class="hfl-list-panel">
-      <el-table v-table-column-resize="'node.snapshots'" :data="rows" stripe :loading="busy">
-        <el-table-column prop="id" label="ID" width="80">
-          <template #default="{ row }">#{{ row.id }}</template>
+      <el-table
+        v-table-column-resize="'node.snapshots'"
+        :data="rows"
+        stripe
+        :loading="busy"
+      >
+        <el-table-column
+          prop="id"
+          label="ID"
+          width="80"
+        >
+          <template #default="{ row }">
+            #{{ row.id }}
+          </template>
         </el-table-column>
-        <el-table-column prop="source_display_name" :label="t('protection.snapshotsPage.colSource')" min-width="180" show-overflow-tooltip />
-        <el-table-column prop="backup_config_name" :label="t('protection.snapshotsPage.colBackupConfig')" min-width="180" show-overflow-tooltip />
-        <el-table-column prop="repository_display_name" :label="t('protection.snapshotsPage.colRepo')" min-width="160" show-overflow-tooltip />
-        <el-table-column prop="snapshot_uid" :label="t('protection.snapshotsPage.colSnapshotUid')" min-width="220" show-overflow-tooltip>
+        <el-table-column
+          prop="source_display_name"
+          :label="t('protection.snapshotsPage.colSource')"
+          min-width="180"
+          show-overflow-tooltip
+        />
+        <el-table-column
+          prop="backup_config_name"
+          :label="t('protection.snapshotsPage.colBackupConfig')"
+          min-width="180"
+          show-overflow-tooltip
+        />
+        <el-table-column
+          prop="repository_display_name"
+          :label="t('protection.snapshotsPage.colRepo')"
+          min-width="160"
+          show-overflow-tooltip
+        />
+        <el-table-column
+          prop="snapshot_uid"
+          :label="t('protection.snapshotsPage.colSnapshotUid')"
+          min-width="220"
+          show-overflow-tooltip
+        >
           <template #default="{ row }">
             <span class="hfl-table-cell-mono">{{ row.snapshot_uid }}</span>
           </template>
         </el-table-column>
-        <el-table-column :label="t('protection.snapshotsPage.fieldStatus')" width="120">
+        <el-table-column
+          :label="t('protection.snapshotsPage.fieldStatus')"
+          width="120"
+        >
           <template #default="{ row }">
             <SnapshotStatusTag :status="row.status" />
           </template>
         </el-table-column>
-        <el-table-column :label="t('protection.snapshotsPage.colDirectoryProgress')" min-width="140">
-          <template #default="{ row }">{{ progressLabel(row) }}</template>
-        </el-table-column>
-        <el-table-column :label="t('protection.snapshotsPage.colSize')" width="120">
-          <template #default="{ row }">{{ fmtBytes(row.total_size_bytes) }}</template>
-        </el-table-column>
-        <el-table-column prop="finished_at" :label="t('protection.snapshotsPage.colFinished')" min-width="180">
+        <el-table-column
+          :label="t('protection.snapshotsPage.colDirectoryProgress')"
+          min-width="140"
+        >
           <template #default="{ row }">
-            <span class="hfl-table-cell-time" :class="{ 'hfl-empty-mark': !(row.finished_at || row.created_at) }">{{ formatDate(row.finished_at || row.created_at) }}</span>
+            {{ progressLabel(row) }}
+          </template>
+        </el-table-column>
+        <el-table-column
+          :label="t('protection.snapshotsPage.colSize')"
+          width="120"
+        >
+          <template #default="{ row }">
+            {{ fmtBytes(row.total_size_bytes) }}
+          </template>
+        </el-table-column>
+        <el-table-column
+          prop="finished_at"
+          :label="t('protection.snapshotsPage.colFinished')"
+          min-width="180"
+        >
+          <template #default="{ row }">
+            <span
+              class="hfl-table-cell-time"
+              :class="{ 'hfl-empty-mark': !(row.finished_at || row.created_at) }"
+            >{{ formatDate(row.finished_at || row.created_at) }}</span>
           </template>
         </el-table-column>
         <template #empty>
-          <el-empty :description="t('protection.snapshotsPage.emptySnapshots')" :image-size="80" />
+          <el-empty
+            :description="t('protection.snapshotsPage.emptySnapshots')"
+            :image-size="80"
+          />
         </template>
       </el-table>
     </div>

--- a/src/frontend/src/pages/ops/AlertIncidents.vue
+++ b/src/frontend/src/pages/ops/AlertIncidents.vue
@@ -302,7 +302,11 @@ watch(
 </script>
 
 <template>
-  <ModulePage :title="t('ops.alertsCenter.active.title')" :menus="opsMenus" body-fill>
+  <ModulePage
+    :title="t('ops.alertsCenter.active.title')"
+    :menus="opsMenus"
+    body-fill
+  >
     <div class="hfl-ops-page hfl-ops-page--fill alert-incidents-page">
       <div class="hfl-ops-stats-grid hfl-ops-stats-grid--4">
         <OpsStatCard
@@ -357,7 +361,10 @@ watch(
                   @click="runBatchAcknowledge"
                 >
                   <span class="el-dropdown-menu__item-content">
-                    <Check :size="14" class="shrink-0" />
+                    <Check
+                      :size="14"
+                      class="shrink-0"
+                    />
                     <span>{{ t('ops.alertsCenter.common.acknowledge') }}</span>
                   </span>
                 </el-dropdown-item>
@@ -366,7 +373,10 @@ watch(
                   @click="runBatchResolve"
                 >
                   <span class="el-dropdown-menu__item-content">
-                    <X :size="14" class="shrink-0" />
+                    <X
+                      :size="14"
+                      class="shrink-0"
+                    />
                     <span>{{ t('ops.alerts.resolve') }}</span>
                   </span>
                 </el-dropdown-item>
@@ -382,7 +392,9 @@ watch(
             :placeholder="t('ops.alertsCenter.active.searchPlaceholder')"
             @clear="clearSearch"
           >
-            <template #prefix><Search class="h-4 w-4 opacity-60" /></template>
+            <template #prefix>
+              <Search class="h-4 w-4 opacity-60" />
+            </template>
           </el-input>
           <el-select
             v-model="filters.type"
@@ -390,11 +402,26 @@ watch(
             style="width: 150px"
             :placeholder="t('ops.alertsCenter.common.allTypes')"
           >
-            <el-option value="metric" :label="t('ops.alertsCenter.policyTypes.metric')" />
-            <el-option value="availability" :label="t('ops.alertsCenter.policyTypes.availability')" />
-            <el-option value="task" :label="t('ops.alertsCenter.policyTypes.task')" />
-            <el-option value="event" :label="t('ops.alertsCenter.policyTypes.event')" />
-            <el-option value="system" :label="t('ops.alertsCenter.policyTypes.system')" />
+            <el-option
+              value="metric"
+              :label="t('ops.alertsCenter.policyTypes.metric')"
+            />
+            <el-option
+              value="availability"
+              :label="t('ops.alertsCenter.policyTypes.availability')"
+            />
+            <el-option
+              value="task"
+              :label="t('ops.alertsCenter.policyTypes.task')"
+            />
+            <el-option
+              value="event"
+              :label="t('ops.alertsCenter.policyTypes.event')"
+            />
+            <el-option
+              value="system"
+              :label="t('ops.alertsCenter.policyTypes.system')"
+            />
           </el-select>
           <el-select
             v-model="filters.status"
@@ -402,9 +429,18 @@ watch(
             style="width: 130px"
             :placeholder="t('ops.alertsCenter.common.allStatus')"
           >
-            <el-option value="firing" :label="t('ops.alertsCenter.active.firing')" />
-            <el-option value="acknowledged" :label="t('ops.alertsCenter.active.acknowledged')" />
-            <el-option value="resolved" :label="t('ops.alerts.status.resolved')" />
+            <el-option
+              value="firing"
+              :label="t('ops.alertsCenter.active.firing')"
+            />
+            <el-option
+              value="acknowledged"
+              :label="t('ops.alertsCenter.active.acknowledged')"
+            />
+            <el-option
+              value="resolved"
+              :label="t('ops.alerts.status.resolved')"
+            />
           </el-select>
           <el-select
             v-model="filters.severity"
@@ -412,92 +448,143 @@ watch(
             style="width: 130px"
             :placeholder="t('ops.alertsCenter.common.allSeverity')"
           >
-            <el-option value="critical" :label="t('ops.alertsCenter.common.critical')" />
-            <el-option value="warning" :label="t('ops.alertsCenter.common.warning')" />
-            <el-option value="info" :label="t('ops.alertsCenter.common.info')" />
+            <el-option
+              value="critical"
+              :label="t('ops.alertsCenter.common.critical')"
+            />
+            <el-option
+              value="warning"
+              :label="t('ops.alertsCenter.common.warning')"
+            />
+            <el-option
+              value="info"
+              :label="t('ops.alertsCenter.common.info')"
+            />
           </el-select>
         </template>
         <template #toolbar-utility>
-          <el-button class="hfl-refresh-button" :title="t('ops.task.btnRefresh')" :aria-label="t('ops.task.btnRefresh')" :disabled="loading" @click="fetchAlerts">
-            <RefreshCw :size="16" :class="{ 'is-spinning': loading }" />
+          <el-button
+            class="hfl-refresh-button"
+            :title="t('ops.task.btnRefresh')"
+            :aria-label="t('ops.task.btnRefresh')"
+            :disabled="loading"
+            @click="fetchAlerts"
+          >
+            <RefreshCw
+              :size="16"
+              :class="{ 'is-spinning': loading }"
+            />
           </el-button>
         </template>
 
         <template #table="{ tableMaxHeight }">
-        <el-table
-          ref="alertsTableRef"
-          v-table-column-resize="'ops.alertIncidents'"
-          v-loading="loading"
-          :data="alerts"
-          stripe
-          class="hfl-list-table"
-          row-key="id"
-          :max-height="tableMaxHeight"
-          @selection-change="onAlertSelectionChange"
-        >
-          <el-table-column
-            type="selection"
-            width="35"
-            fixed="left"
-          />
-          <el-table-column :label="t('ops.alertsCenter.common.title')" min-width="260" fixed="left">
-            <template #default="{ row }">
-              <div class="hfl-ops-primary-cell">
-                <div class="min-w-0">
-                  <div class="flex min-w-0 items-center gap-1">
-                    <button
-                      type="button"
-                      class="hfl-table-name-link hfl-table-name-link--single min-w-0"
-                      @click="openDetail(row)"
-                    >
-                      {{ row.title }}
-                    </button>
-                  </div>
-                  <div class="hfl-ops-cell-stack__meta line-clamp-1">
-                    {{ alertTitleMeta(row) }}
+          <el-table
+            ref="alertsTableRef"
+            v-table-column-resize="'ops.alertIncidents'"
+            v-loading="loading"
+            :data="alerts"
+            stripe
+            class="hfl-list-table"
+            row-key="id"
+            :max-height="tableMaxHeight"
+            @selection-change="onAlertSelectionChange"
+          >
+            <el-table-column
+              type="selection"
+              width="35"
+              fixed="left"
+            />
+            <el-table-column
+              :label="t('ops.alertsCenter.common.title')"
+              min-width="260"
+              fixed="left"
+            >
+              <template #default="{ row }">
+                <div class="hfl-ops-primary-cell">
+                  <div class="min-w-0">
+                    <div class="flex min-w-0 items-center gap-1">
+                      <button
+                        type="button"
+                        class="hfl-table-name-link hfl-table-name-link--single min-w-0"
+                        @click="openDetail(row)"
+                      >
+                        {{ row.title }}
+                      </button>
+                    </div>
+                    <div class="hfl-ops-cell-stack__meta line-clamp-1">
+                      {{ alertTitleMeta(row) }}
+                    </div>
                   </div>
                 </div>
-              </div>
+              </template>
+            </el-table-column>
+            <el-table-column
+              :label="t('ops.alertsCenter.common.severity')"
+              width="100"
+            >
+              <template #default="{ row }">
+                <el-tag
+                  v-bind="severityStatusTagAttrs(row.severity)"
+                  size="small"
+                >
+                  {{ severityLabel(row.severity) }}
+                </el-tag>
+              </template>
+            </el-table-column>
+            <el-table-column
+              :label="t('ops.alertsCenter.common.type')"
+              width="130"
+            >
+              <template #default="{ row }">
+                <AlertPolicyTypeLabel :type="row.type" />
+              </template>
+            </el-table-column>
+            <el-table-column
+              :label="t('ops.alertsCenter.common.resource')"
+              min-width="160"
+            >
+              <template #default="{ row }">
+                <span :class="hasResourceLabel(row) ? 'hfl-table-cell-mono' : 'hfl-empty-mark'">{{ resourceLabel(row) }}</span>
+              </template>
+            </el-table-column>
+            <el-table-column
+              :label="t('ops.alertsCenter.common.status')"
+              width="120"
+            >
+              <template #default="{ row }">
+                <el-tag
+                  :type="statusTagType(row.status)"
+                  size="small"
+                >
+                  {{ statusLabel(row.status) }}
+                </el-tag>
+              </template>
+            </el-table-column>
+            <el-table-column
+              :label="t('ops.alertsCenter.active.firstTriggered')"
+              width="170"
+            >
+              <template #default="{ row }">
+                <span
+                  class="hfl-table-cell-time"
+                  :class="{ 'hfl-empty-mark': !(row.firstTriggeredAt || row.first_triggered_at) }"
+                >
+                  {{ formatDate(row.firstTriggeredAt || row.first_triggered_at) }}
+                </span>
+              </template>
+            </el-table-column>
+            <el-table-column
+              :label="t('ops.alertsCenter.common.duration')"
+              width="100"
+            >
+              <template #default="{ row }">
+                <span :class="{ 'hfl-empty-mark': (row.durationSeconds ?? row.duration_seconds) == null }">{{ duration(row) }}</span>
+              </template>
+            </el-table-column>
+            <template #empty>
+              <el-empty :description="emptyDescription" />
             </template>
-          </el-table-column>
-          <el-table-column :label="t('ops.alertsCenter.common.severity')" width="100">
-            <template #default="{ row }">
-              <el-tag v-bind="severityStatusTagAttrs(row.severity)" size="small">
-                {{ severityLabel(row.severity) }}
-              </el-tag>
-            </template>
-          </el-table-column>
-          <el-table-column :label="t('ops.alertsCenter.common.type')" width="130">
-            <template #default="{ row }">
-              <AlertPolicyTypeLabel :type="row.type" />
-            </template>
-          </el-table-column>
-          <el-table-column :label="t('ops.alertsCenter.common.resource')" min-width="160">
-            <template #default="{ row }">
-              <span :class="hasResourceLabel(row) ? 'hfl-table-cell-mono' : 'hfl-empty-mark'">{{ resourceLabel(row) }}</span>
-            </template>
-          </el-table-column>
-          <el-table-column :label="t('ops.alertsCenter.common.status')" width="120">
-            <template #default="{ row }">
-              <el-tag :type="statusTagType(row.status)" size="small">
-                {{ statusLabel(row.status) }}
-              </el-tag>
-            </template>
-          </el-table-column>
-          <el-table-column :label="t('ops.alertsCenter.active.firstTriggered')" width="170">
-            <template #default="{ row }">
-              <span class="hfl-table-cell-time" :class="{ 'hfl-empty-mark': !(row.firstTriggeredAt || row.first_triggered_at) }">
-                {{ formatDate(row.firstTriggeredAt || row.first_triggered_at) }}
-              </span>
-            </template>
-          </el-table-column>
-          <el-table-column :label="t('ops.alertsCenter.common.duration')" width="100">
-            <template #default="{ row }"><span :class="{ 'hfl-empty-mark': (row.durationSeconds ?? row.duration_seconds) == null }">{{ duration(row) }}</span></template>
-          </el-table-column>
-          <template #empty>
-            <el-empty :description="emptyDescription" />
-          </template>
-        </el-table>
+          </el-table>
         </template>
 
         <template #footer>
@@ -532,15 +619,23 @@ watch(
         <span class="hfl-detail-drawer__title">{{ selected?.title || t('ops.nav.alerts') }}</span>
       </template>
 
-      <div v-if="selected" class="hfl-detail-drawer__body">
+      <div
+        v-if="selected"
+        class="hfl-detail-drawer__body"
+      >
         <div class="hfl-detail-sections">
           <section class="hfl-detail-section">
-            <h4 class="hfl-detail-section__title">{{ t('ops.alertsCenter.common.basicInfo') }}</h4>
+            <h4 class="hfl-detail-section__title">
+              {{ t('ops.alertsCenter.common.basicInfo') }}
+            </h4>
             <div class="hfl-detail-grid">
               <div class="hfl-detail-row">
                 <span class="hfl-detail-row__label">{{ t('ops.alertsCenter.common.status') }}</span>
                 <span class="hfl-detail-row__value">
-                  <el-tag :type="statusTagType(selected.status)" size="small">
+                  <el-tag
+                    :type="statusTagType(selected.status)"
+                    size="small"
+                  >
                     {{ statusLabel(selected.status) }}
                   </el-tag>
                 </span>
@@ -548,14 +643,20 @@ watch(
               <div class="hfl-detail-row">
                 <span class="hfl-detail-row__label">{{ t('ops.alertsCenter.common.severity') }}</span>
                 <span class="hfl-detail-row__value">
-                  <el-tag v-bind="severityStatusTagAttrs(selected.severity)" size="small">
+                  <el-tag
+                    v-bind="severityStatusTagAttrs(selected.severity)"
+                    size="small"
+                  >
                     {{ severityLabel(selected.severity) }}
                   </el-tag>
                 </span>
               </div>
               <div class="hfl-detail-row">
                 <span class="hfl-detail-row__label">{{ t('ops.alertsCenter.common.type') }}</span>
-                <span class="hfl-detail-row__value" :class="{ 'hfl-detail-row__empty': !selected.type }">{{ typeLabel(selected.type) }}</span>
+                <span
+                  class="hfl-detail-row__value"
+                  :class="{ 'hfl-detail-row__empty': !selected.type }"
+                >{{ typeLabel(selected.type) }}</span>
               </div>
               <div class="hfl-detail-row">
                 <span class="hfl-detail-row__label">{{ t('ops.alertsCenter.common.id') }}</span>
@@ -573,50 +674,76 @@ watch(
           </section>
 
           <section class="hfl-detail-section">
-            <h4 class="hfl-detail-section__title">{{ t('ops.alertsCenter.common.resource') }}</h4>
+            <h4 class="hfl-detail-section__title">
+              {{ t('ops.alertsCenter.common.resource') }}
+            </h4>
             <div class="hfl-detail-grid">
               <div class="hfl-detail-row">
                 <span class="hfl-detail-row__label">{{ t('ops.alertsCenter.policies.targetColumn') }}</span>
-                <span class="hfl-detail-row__value" :class="{ 'hfl-detail-row__empty': !(selected.resourceType || selected.resource_type) }">{{ resourceTypeLabel(selected.resourceType || selected.resource_type) }}</span>
+                <span
+                  class="hfl-detail-row__value"
+                  :class="{ 'hfl-detail-row__empty': !(selected.resourceType || selected.resource_type) }"
+                >{{ resourceTypeLabel(selected.resourceType || selected.resource_type) }}</span>
               </div>
               <div class="hfl-detail-row">
                 <span class="hfl-detail-row__label">{{ t('ops.alertsCenter.common.resource') }}</span>
-                <span class="hfl-detail-row__value" :class="hasResourceLabel(selected) ? 'hfl-table-cell-mono' : 'hfl-empty-mark'">
+                <span
+                  class="hfl-detail-row__value"
+                  :class="hasResourceLabel(selected) ? 'hfl-table-cell-mono' : 'hfl-empty-mark'"
+                >
                   {{ resourceLabel(selected) }}
                 </span>
               </div>
               <div class="hfl-detail-row">
                 <span class="hfl-detail-row__label">{{ t('ops.task.resourceId') }}</span>
-                <span class="hfl-detail-row__value" :class="selected.resourceId || selected.resource_id ? 'hfl-table-cell-mono' : 'hfl-empty-mark'">
+                <span
+                  class="hfl-detail-row__value"
+                  :class="selected.resourceId || selected.resource_id ? 'hfl-table-cell-mono' : 'hfl-empty-mark'"
+                >
                   {{ selected.resourceId || selected.resource_id || t('common.empty') }}
                 </span>
               </div>
               <div class="hfl-detail-row">
                 <span class="hfl-detail-row__label">{{ t('ops.alertsCenter.policies.duration') }}</span>
-                <span class="hfl-detail-row__value" :class="{ 'hfl-detail-row__empty': (selected.durationSeconds ?? selected.duration_seconds) == null }">{{ duration(selected) }}</span>
+                <span
+                  class="hfl-detail-row__value"
+                  :class="{ 'hfl-detail-row__empty': (selected.durationSeconds ?? selected.duration_seconds) == null }"
+                >{{ duration(selected) }}</span>
               </div>
               <div class="hfl-detail-row">
                 <span class="hfl-detail-row__label">{{ t('ops.alertsCenter.active.firstTriggered') }}</span>
-                <span class="hfl-detail-row__value hfl-table-cell-time" :class="{ 'hfl-detail-row__empty': !(selected.firstTriggeredAt || selected.first_triggered_at) }">
+                <span
+                  class="hfl-detail-row__value hfl-table-cell-time"
+                  :class="{ 'hfl-detail-row__empty': !(selected.firstTriggeredAt || selected.first_triggered_at) }"
+                >
                   {{ formatDate(selected.firstTriggeredAt || selected.first_triggered_at) }}
                 </span>
               </div>
               <div class="hfl-detail-row">
                 <span class="hfl-detail-row__label">{{ t('ops.alertsCenter.common.updatedAt') }}</span>
-                <span class="hfl-detail-row__value hfl-table-cell-time" :class="{ 'hfl-detail-row__empty': !(selected.lastTriggeredAt || selected.last_triggered_at || selected.createdAt || selected.created_at) }">
+                <span
+                  class="hfl-detail-row__value hfl-table-cell-time"
+                  :class="{ 'hfl-detail-row__empty': !(selected.lastTriggeredAt || selected.last_triggered_at || selected.createdAt || selected.created_at) }"
+                >
                   {{ formatDate(selected.lastTriggeredAt || selected.last_triggered_at || selected.createdAt || selected.created_at) }}
                 </span>
               </div>
               <div class="hfl-detail-row">
                 <span class="hfl-detail-row__label">Current</span>
-                <span class="hfl-detail-row__value" :class="{ 'hfl-detail-row__empty': (selected.currentValue ?? selected.current_value) == null }">
+                <span
+                  class="hfl-detail-row__value"
+                  :class="{ 'hfl-detail-row__empty': (selected.currentValue ?? selected.current_value) == null }"
+                >
                   {{ alertNumericValue(selected.currentValue ?? selected.current_value) }}
                   <template v-if="selected.unit"> {{ selected.unit }}</template>
                 </span>
               </div>
               <div class="hfl-detail-row">
                 <span class="hfl-detail-row__label">Threshold</span>
-                <span class="hfl-detail-row__value" :class="{ 'hfl-detail-row__empty': (selected.thresholdValue ?? selected.threshold_value) == null }">
+                <span
+                  class="hfl-detail-row__value"
+                  :class="{ 'hfl-detail-row__empty': (selected.thresholdValue ?? selected.threshold_value) == null }"
+                >
                   {{ alertNumericValue(selected.thresholdValue ?? selected.threshold_value) }}
                   <template v-if="selected.unit"> {{ selected.unit }}</template>
                 </span>

--- a/src/frontend/src/pages/ops/AlertPolicies.vue
+++ b/src/frontend/src/pages/ops/AlertPolicies.vue
@@ -556,7 +556,11 @@ watch(
 </script>
 
 <template>
-  <ModulePage :title="t('ops.alertsCenter.policies.title')" :menus="opsMenus" body-fill>
+  <ModulePage
+    :title="t('ops.alertsCenter.policies.title')"
+    :menus="opsMenus"
+    body-fill
+  >
     <div class="hfl-ops-page hfl-ops-page--fill">
       <div class="hfl-ops-stats-grid hfl-ops-stats-grid--3">
         <OpsStatCard
@@ -583,7 +587,11 @@ watch(
 
       <HflTablePanel fill>
         <template #toolbar>
-          <el-button type="primary" :icon="Plus" @click="openCreate">
+          <el-button
+            type="primary"
+            :icon="Plus"
+            @click="openCreate"
+          >
             {{ t('common.add') }}
           </el-button>
           <el-dropdown
@@ -605,7 +613,10 @@ watch(
                   @click="onMoreEdit"
                 >
                   <span class="el-dropdown-menu__item-content">
-                    <SquarePen :size="14" class="shrink-0" />
+                    <SquarePen
+                      :size="14"
+                      class="shrink-0"
+                    />
                     <span>{{ t('ops.alertsCenter.common.editPolicy') }}</span>
                   </span>
                 </el-dropdown-item>
@@ -614,7 +625,10 @@ watch(
                   @click="onMoreDuplicate"
                 >
                   <span class="el-dropdown-menu__item-content">
-                    <Copy :size="14" class="shrink-0" />
+                    <Copy
+                      :size="14"
+                      class="shrink-0"
+                    />
                     <span>{{ t('ops.alertsCenter.common.duplicatePolicy') }}</span>
                   </span>
                 </el-dropdown-item>
@@ -624,7 +638,10 @@ watch(
                   @click="runBatchState(true)"
                 >
                   <span class="el-dropdown-menu__item-content">
-                    <CirclePlay :size="14" class="shrink-0" />
+                    <CirclePlay
+                      :size="14"
+                      class="shrink-0"
+                    />
                     <span>{{ t('ops.alertsCenter.common.enablePolicy') }}</span>
                   </span>
                 </el-dropdown-item>
@@ -633,7 +650,10 @@ watch(
                   @click="runBatchState(false)"
                 >
                   <span class="el-dropdown-menu__item-content">
-                    <CircleStop :size="14" class="shrink-0" />
+                    <CircleStop
+                      :size="14"
+                      class="shrink-0"
+                    />
                     <span>{{ t('ops.alertsCenter.common.disablePolicy') }}</span>
                   </span>
                 </el-dropdown-item>
@@ -644,7 +664,10 @@ watch(
                   @click="runBatchDelete"
                 >
                   <span class="el-dropdown-menu__item-content">
-                    <Trash2 :size="14" class="shrink-0" />
+                    <Trash2
+                      :size="14"
+                      class="shrink-0"
+                    />
                     <span>{{ t('ops.alertsCenter.common.deletePolicy') }}</span>
                   </span>
                 </el-dropdown-item>
@@ -660,9 +683,16 @@ watch(
             :placeholder="t('ops.alertsCenter.policies.searchPlaceholder')"
             @clear="clearSearch"
           >
-            <template #prefix><Search class="h-4 w-4 opacity-60" /></template>
+            <template #prefix>
+              <Search class="h-4 w-4 opacity-60" />
+            </template>
           </el-input>
-          <el-select v-model="filters.type" clearable style="width: 130px" :placeholder="t('ops.alertsCenter.common.allTypes')">
+          <el-select
+            v-model="filters.type"
+            clearable
+            style="width: 130px"
+            :placeholder="t('ops.alertsCenter.common.allTypes')"
+          >
             <el-option
               v-for="opt in policyTypeOptions"
               :key="opt.value"
@@ -670,106 +700,182 @@ watch(
               :label="opt.label"
             />
           </el-select>
-          <el-select v-model="filters.severity" clearable style="width: 130px" :placeholder="t('ops.alertsCenter.common.allSeverity')">
-            <el-option value="critical" :label="t('ops.alertsCenter.common.critical')" />
-            <el-option value="warning" :label="t('ops.alertsCenter.common.warning')" />
-            <el-option value="info" :label="t('ops.alertsCenter.common.info')" />
+          <el-select
+            v-model="filters.severity"
+            clearable
+            style="width: 130px"
+            :placeholder="t('ops.alertsCenter.common.allSeverity')"
+          >
+            <el-option
+              value="critical"
+              :label="t('ops.alertsCenter.common.critical')"
+            />
+            <el-option
+              value="warning"
+              :label="t('ops.alertsCenter.common.warning')"
+            />
+            <el-option
+              value="info"
+              :label="t('ops.alertsCenter.common.info')"
+            />
           </el-select>
-          <el-select v-model="filters.enabled" clearable style="width: 110px" :placeholder="t('ops.alertsCenter.common.status')">
-            <el-option value="true" :label="t('ops.alertsCenter.common.enabled')" />
-            <el-option value="false" :label="t('ops.alertsCenter.common.disabled')" />
+          <el-select
+            v-model="filters.enabled"
+            clearable
+            style="width: 110px"
+            :placeholder="t('ops.alertsCenter.common.status')"
+          >
+            <el-option
+              value="true"
+              :label="t('ops.alertsCenter.common.enabled')"
+            />
+            <el-option
+              value="false"
+              :label="t('ops.alertsCenter.common.disabled')"
+            />
           </el-select>
         </template>
         <template #toolbar-utility>
-          <el-button class="hfl-refresh-button" :title="t('ops.task.btnRefresh')" :aria-label="t('ops.task.btnRefresh')" :disabled="loading" @click="loadPolicies">
-            <RefreshCw :size="16" :class="{ 'is-spinning': loading }" />
+          <el-button
+            class="hfl-refresh-button"
+            :title="t('ops.task.btnRefresh')"
+            :aria-label="t('ops.task.btnRefresh')"
+            :disabled="loading"
+            @click="loadPolicies"
+          >
+            <RefreshCw
+              :size="16"
+              :class="{ 'is-spinning': loading }"
+            />
           </el-button>
         </template>
 
         <template #table="{ tableMaxHeight }">
-        <el-table
-          ref="alertPoliciesTableRef"
-          v-table-column-resize="'ops.alertPolicies'"
-          v-loading="loading"
-          :data="policies"
-          stripe
-          class="hfl-list-table hfl-alert-policy-table w-full"
-          row-key="id"
-          :max-height="tableMaxHeight"
-          @selection-change="onPolicySelectionChange"
-        >
-          <el-table-column
-            type="selection"
-            width="35"
-            fixed="left"
-          />
-          <el-table-column :label="t('ops.alertsCenter.common.name')" min-width="220" fixed="left">
-            <template #default="{ row }">
-              <div class="hfl-ops-primary-cell">
-                <div class="min-w-0">
-                  <div class="flex min-w-0 items-center gap-1">
-                    <button
-                      type="button"
-                      class="hfl-table-name-link hfl-table-name-link--single min-w-0"
-                      @click="openDetails(row)"
+          <el-table
+            ref="alertPoliciesTableRef"
+            v-table-column-resize="'ops.alertPolicies'"
+            v-loading="loading"
+            :data="policies"
+            stripe
+            class="hfl-list-table hfl-alert-policy-table w-full"
+            row-key="id"
+            :max-height="tableMaxHeight"
+            @selection-change="onPolicySelectionChange"
+          >
+            <el-table-column
+              type="selection"
+              width="35"
+              fixed="left"
+            />
+            <el-table-column
+              :label="t('ops.alertsCenter.common.name')"
+              min-width="220"
+              fixed="left"
+            >
+              <template #default="{ row }">
+                <div class="hfl-ops-primary-cell">
+                  <div class="min-w-0">
+                    <div class="flex min-w-0 items-center gap-1">
+                      <button
+                        type="button"
+                        class="hfl-table-name-link hfl-table-name-link--single min-w-0"
+                        @click="openDetails(row)"
+                      >
+                        {{ row.name }}
+                      </button>
+                    </div>
+                    <div
+                      v-if="alertPolicyNameMeta(row)"
+                      class="hfl-ops-cell-stack__meta line-clamp-1"
                     >
-                      {{ row.name }}
-                    </button>
-                  </div>
-                  <div v-if="alertPolicyNameMeta(row)" class="hfl-ops-cell-stack__meta line-clamp-1">
-                    {{ alertPolicyNameMeta(row) }}
+                      {{ alertPolicyNameMeta(row) }}
+                    </div>
                   </div>
                 </div>
-              </div>
+              </template>
+            </el-table-column>
+            <el-table-column
+              :label="t('ops.alertsCenter.common.type')"
+              width="130"
+            >
+              <template #default="{ row }">
+                <AlertPolicyTypeLabel :type="row.type" />
+              </template>
+            </el-table-column>
+            <el-table-column
+              :label="t('ops.alertsCenter.policies.targetColumn')"
+              width="130"
+            >
+              <template #default="{ row }">
+                <span :class="{ 'hfl-empty-mark': !(row.resourceType || row.resource_type) }">{{ resourceTypeLabel(row.resourceType || row.resource_type) }}</span>
+              </template>
+            </el-table-column>
+            <el-table-column
+              :label="t('ops.alertsCenter.common.severity')"
+              width="100"
+            >
+              <template #default="{ row }">
+                <el-tag
+                  v-bind="severityStatusTagAttrs(row.severity)"
+                  size="small"
+                >
+                  {{ severityLabel(row.severity) }}
+                </el-tag>
+              </template>
+            </el-table-column>
+            <el-table-column
+              :label="t('ops.alertsCenter.policies.scope')"
+              width="140"
+            >
+              <template #default="{ row }">
+                <el-tag
+                  :type="scopeTagType(row.scope)"
+                  :class="scopeTagClass(row.scope)"
+                  size="small"
+                >
+                  {{ scopeLabel(row.scope) }}
+                </el-tag>
+              </template>
+            </el-table-column>
+            <el-table-column
+              :label="t('ops.alertsCenter.common.status')"
+              width="90"
+            >
+              <template #default="{ row }">
+                <el-tag
+                  :type="booleanStatusTag(row.enabled).type"
+                  :class="booleanStatusTag(row.enabled).class"
+                  size="small"
+                >
+                  {{ row.enabled ? t('ops.alertsCenter.common.enabled') : t('ops.alertsCenter.common.disabled') }}
+                </el-tag>
+              </template>
+            </el-table-column>
+            <el-table-column
+              :label="t('ops.alertsCenter.policies.notificationColumn')"
+              min-width="160"
+            >
+              <template #default="{ row }">
+                <span>{{ channelLabel(row) }}</span>
+              </template>
+            </el-table-column>
+            <el-table-column
+              :label="t('ops.alertsCenter.common.updatedAt')"
+              width="170"
+            >
+              <template #default="{ row }">
+                <span
+                  class="hfl-table-cell-time"
+                  :class="{ 'hfl-empty-mark': !(row.updatedAt || row.updated_at) }"
+                >
+                  {{ formatDate(row.updatedAt || row.updated_at) }}
+                </span>
+              </template>
+            </el-table-column>
+            <template #empty>
+              <el-empty :description="emptyDescription" />
             </template>
-          </el-table-column>
-          <el-table-column :label="t('ops.alertsCenter.common.type')" width="130">
-            <template #default="{ row }">
-              <AlertPolicyTypeLabel :type="row.type" />
-            </template>
-          </el-table-column>
-          <el-table-column :label="t('ops.alertsCenter.policies.targetColumn')" width="130">
-            <template #default="{ row }">
-              <span :class="{ 'hfl-empty-mark': !(row.resourceType || row.resource_type) }">{{ resourceTypeLabel(row.resourceType || row.resource_type) }}</span>
-            </template>
-          </el-table-column>
-          <el-table-column :label="t('ops.alertsCenter.common.severity')" width="100">
-            <template #default="{ row }">
-              <el-tag v-bind="severityStatusTagAttrs(row.severity)" size="small">
-                {{ severityLabel(row.severity) }}
-              </el-tag>
-            </template>
-          </el-table-column>
-          <el-table-column :label="t('ops.alertsCenter.policies.scope')" width="140">
-            <template #default="{ row }">
-              <el-tag :type="scopeTagType(row.scope)" :class="scopeTagClass(row.scope)" size="small">
-                {{ scopeLabel(row.scope) }}
-              </el-tag>
-            </template>
-          </el-table-column>
-          <el-table-column :label="t('ops.alertsCenter.common.status')" width="90">
-            <template #default="{ row }">
-              <el-tag :type="booleanStatusTag(row.enabled).type" :class="booleanStatusTag(row.enabled).class" size="small">
-                {{ row.enabled ? t('ops.alertsCenter.common.enabled') : t('ops.alertsCenter.common.disabled') }}
-              </el-tag>
-            </template>
-          </el-table-column>
-          <el-table-column :label="t('ops.alertsCenter.policies.notificationColumn')" min-width="160">
-            <template #default="{ row }">
-              <span>{{ channelLabel(row) }}</span>
-            </template>
-          </el-table-column>
-          <el-table-column :label="t('ops.alertsCenter.common.updatedAt')" width="170">
-            <template #default="{ row }">
-              <span class="hfl-table-cell-time" :class="{ 'hfl-empty-mark': !(row.updatedAt || row.updated_at) }">
-                {{ formatDate(row.updatedAt || row.updated_at) }}
-              </span>
-            </template>
-          </el-table-column>
-          <template #empty>
-            <el-empty :description="emptyDescription" />
-          </template>
-        </el-table>
+          </el-table>
         </template>
 
         <template #footer>
@@ -848,15 +954,41 @@ watch(
                 <span class="hfl-detail-row__label">{{ t('ops.alertsCenter.common.name') }}</span>
                 <span class="hfl-detail-row__value hfl-detail-row__value--editable">
                   <template v-if="isPolicyInlineEditing('name')">
-                    <ElInput v-model="policyInlineDraft" size="small" class="hfl-detail-inline-edit__input" @keyup.enter="savePolicyInlineEdit" />
+                    <ElInput
+                      v-model="policyInlineDraft"
+                      size="small"
+                      class="hfl-detail-inline-edit__input"
+                      @keyup.enter="savePolicyInlineEdit"
+                    />
                     <span class="hfl-detail-inline-edit__actions">
-                      <ElButton text circle size="small" :title="t('common.save')" :disabled="policyInlineSaving" @click="savePolicyInlineEdit"><Check :size="14" /></ElButton>
-                      <ElButton text circle size="small" :title="t('common.cancel')" :disabled="policyInlineSaving" @click="cancelPolicyInlineEdit"><X :size="14" /></ElButton>
+                      <ElButton
+                        text
+                        circle
+                        size="small"
+                        :title="t('common.save')"
+                        :disabled="policyInlineSaving"
+                        @click="savePolicyInlineEdit"
+                      ><Check :size="14" /></ElButton>
+                      <ElButton
+                        text
+                        circle
+                        size="small"
+                        :title="t('common.cancel')"
+                        :disabled="policyInlineSaving"
+                        @click="cancelPolicyInlineEdit"
+                      ><X :size="14" /></ElButton>
                     </span>
                   </template>
                   <template v-else>
                     <span class="hfl-detail-row__text">{{ detailPolicy.name }}</span>
-                    <ElButton text circle size="small" class="hfl-detail-row__edit" :title="t('common.edit')" @click="beginPolicyInlineEdit('name')">
+                    <ElButton
+                      text
+                      circle
+                      size="small"
+                      class="hfl-detail-row__edit"
+                      :title="t('common.edit')"
+                      @click="beginPolicyInlineEdit('name')"
+                    >
                       <Pencil :size="13" />
                     </ElButton>
                   </template>
@@ -864,27 +996,67 @@ watch(
               </div>
               <div class="hfl-detail-row">
                 <span class="hfl-detail-row__label">{{ t('ops.alertsCenter.common.type') }}</span>
-                <span class="hfl-detail-row__value" :class="{ 'hfl-detail-row__empty': !detailPolicy.type }">{{ policyTypeLabel(detailPolicy.type) }}</span>
+                <span
+                  class="hfl-detail-row__value"
+                  :class="{ 'hfl-detail-row__empty': !detailPolicy.type }"
+                >{{ policyTypeLabel(detailPolicy.type) }}</span>
               </div>
               <div class="hfl-detail-row">
                 <span class="hfl-detail-row__label">{{ t('ops.alertsCenter.common.severity') }}</span>
                 <span class="hfl-detail-row__value hfl-detail-row__value--editable">
                   <template v-if="isPolicyInlineEditing('severity')">
-                    <ElSelect v-model="policyInlineDraft" size="small" class="hfl-detail-inline-edit__input">
-                      <ElOption value="critical" :label="t('ops.alertsCenter.common.critical')" />
-                      <ElOption value="warning" :label="t('ops.alertsCenter.common.warning')" />
-                      <ElOption value="info" :label="t('ops.alertsCenter.common.info')" />
+                    <ElSelect
+                      v-model="policyInlineDraft"
+                      size="small"
+                      class="hfl-detail-inline-edit__input"
+                    >
+                      <ElOption
+                        value="critical"
+                        :label="t('ops.alertsCenter.common.critical')"
+                      />
+                      <ElOption
+                        value="warning"
+                        :label="t('ops.alertsCenter.common.warning')"
+                      />
+                      <ElOption
+                        value="info"
+                        :label="t('ops.alertsCenter.common.info')"
+                      />
                     </ElSelect>
                     <span class="hfl-detail-inline-edit__actions">
-                      <ElButton text circle size="small" :title="t('common.save')" :disabled="policyInlineSaving" @click="savePolicyInlineEdit"><Check :size="14" /></ElButton>
-                      <ElButton text circle size="small" :title="t('common.cancel')" :disabled="policyInlineSaving" @click="cancelPolicyInlineEdit"><X :size="14" /></ElButton>
+                      <ElButton
+                        text
+                        circle
+                        size="small"
+                        :title="t('common.save')"
+                        :disabled="policyInlineSaving"
+                        @click="savePolicyInlineEdit"
+                      ><Check :size="14" /></ElButton>
+                      <ElButton
+                        text
+                        circle
+                        size="small"
+                        :title="t('common.cancel')"
+                        :disabled="policyInlineSaving"
+                        @click="cancelPolicyInlineEdit"
+                      ><X :size="14" /></ElButton>
                     </span>
                   </template>
                   <template v-else>
-                    <el-tag v-bind="severityStatusTagAttrs(detailPolicy.severity)" size="small">
+                    <el-tag
+                      v-bind="severityStatusTagAttrs(detailPolicy.severity)"
+                      size="small"
+                    >
                       {{ severityLabel(detailPolicy.severity) }}
                     </el-tag>
-                    <ElButton text circle size="small" class="hfl-detail-row__edit" :title="t('common.edit')" @click="beginPolicyInlineEdit('severity')">
+                    <ElButton
+                      text
+                      circle
+                      size="small"
+                      class="hfl-detail-row__edit"
+                      :title="t('common.edit')"
+                      @click="beginPolicyInlineEdit('severity')"
+                    >
                       <Pencil :size="13" />
                     </ElButton>
                   </template>
@@ -896,15 +1068,40 @@ watch(
                   <template v-if="isPolicyInlineEditing('enabled')">
                     <ElSwitch v-model="policyInlineDraft" />
                     <span class="hfl-detail-inline-edit__actions">
-                      <ElButton text circle size="small" :title="t('common.save')" :disabled="policyInlineSaving" @click="savePolicyInlineEdit"><Check :size="14" /></ElButton>
-                      <ElButton text circle size="small" :title="t('common.cancel')" :disabled="policyInlineSaving" @click="cancelPolicyInlineEdit"><X :size="14" /></ElButton>
+                      <ElButton
+                        text
+                        circle
+                        size="small"
+                        :title="t('common.save')"
+                        :disabled="policyInlineSaving"
+                        @click="savePolicyInlineEdit"
+                      ><Check :size="14" /></ElButton>
+                      <ElButton
+                        text
+                        circle
+                        size="small"
+                        :title="t('common.cancel')"
+                        :disabled="policyInlineSaving"
+                        @click="cancelPolicyInlineEdit"
+                      ><X :size="14" /></ElButton>
                     </span>
                   </template>
                   <template v-else>
-                    <el-tag :type="booleanStatusTag(detailPolicy.enabled).type" :class="booleanStatusTag(detailPolicy.enabled).class" size="small">
+                    <el-tag
+                      :type="booleanStatusTag(detailPolicy.enabled).type"
+                      :class="booleanStatusTag(detailPolicy.enabled).class"
+                      size="small"
+                    >
                       {{ detailPolicy.enabled ? t('ops.alertsCenter.common.enabled') : t('ops.alertsCenter.common.disabled') }}
                     </el-tag>
-                    <ElButton text circle size="small" class="hfl-detail-row__edit" :title="t('common.edit')" @click="beginPolicyInlineEdit('enabled')">
+                    <ElButton
+                      text
+                      circle
+                      size="small"
+                      class="hfl-detail-row__edit"
+                      :title="t('common.edit')"
+                      @click="beginPolicyInlineEdit('enabled')"
+                    >
                       <Pencil :size="13" />
                     </ElButton>
                   </template>
@@ -913,18 +1110,28 @@ watch(
               <div class="hfl-detail-row">
                 <span class="hfl-detail-row__label">{{ t('ops.alertsCenter.policies.scope') }}</span>
                 <span class="hfl-detail-row__value">
-                  <el-tag :type="scopeTagType(detailPolicy.scope)" :class="scopeTagClass(detailPolicy.scope)" size="small">
+                  <el-tag
+                    :type="scopeTagType(detailPolicy.scope)"
+                    :class="scopeTagClass(detailPolicy.scope)"
+                    size="small"
+                  >
                     {{ scopeLabel(detailPolicy.scope) }}
                   </el-tag>
                 </span>
               </div>
               <div class="hfl-detail-row">
                 <span class="hfl-detail-row__label">{{ t('ops.alertsCenter.policies.targetColumn') }}</span>
-                <span class="hfl-detail-row__value" :class="{ 'hfl-detail-row__empty': !detailResourceType(detailPolicy) }">{{ resourceTypeLabel(detailResourceType(detailPolicy)) }}</span>
+                <span
+                  class="hfl-detail-row__value"
+                  :class="{ 'hfl-detail-row__empty': !detailResourceType(detailPolicy) }"
+                >{{ resourceTypeLabel(detailResourceType(detailPolicy)) }}</span>
               </div>
               <div class="hfl-detail-row">
                 <span class="hfl-detail-row__label">{{ t('ops.alertsCenter.common.updatedAt') }}</span>
-                <span class="hfl-detail-row__value hfl-table-cell-time" :class="{ 'hfl-detail-row__empty': !(detailPolicy.updatedAt || detailPolicy.updated_at) }">
+                <span
+                  class="hfl-detail-row__value hfl-table-cell-time"
+                  :class="{ 'hfl-detail-row__empty': !(detailPolicy.updatedAt || detailPolicy.updated_at) }"
+                >
                   {{ formatDate(detailPolicy.updatedAt || detailPolicy.updated_at) }}
                 </span>
               </div>
@@ -932,15 +1139,45 @@ watch(
                 <span class="hfl-detail-row__label">{{ t('ops.alertsCenter.policies.description') }}</span>
                 <span class="hfl-detail-row__value hfl-detail-row__value--editable hfl-detail-row__value--break">
                   <template v-if="isPolicyInlineEditing('description')">
-                    <ElInput v-model="policyInlineDraft" size="small" type="textarea" :rows="2" class="hfl-detail-inline-edit__input" />
+                    <ElInput
+                      v-model="policyInlineDraft"
+                      size="small"
+                      type="textarea"
+                      :rows="2"
+                      class="hfl-detail-inline-edit__input"
+                    />
                     <span class="hfl-detail-inline-edit__actions">
-                      <ElButton text circle size="small" :title="t('common.save')" :disabled="policyInlineSaving" @click="savePolicyInlineEdit"><Check :size="14" /></ElButton>
-                      <ElButton text circle size="small" :title="t('common.cancel')" :disabled="policyInlineSaving" @click="cancelPolicyInlineEdit"><X :size="14" /></ElButton>
+                      <ElButton
+                        text
+                        circle
+                        size="small"
+                        :title="t('common.save')"
+                        :disabled="policyInlineSaving"
+                        @click="savePolicyInlineEdit"
+                      ><Check :size="14" /></ElButton>
+                      <ElButton
+                        text
+                        circle
+                        size="small"
+                        :title="t('common.cancel')"
+                        :disabled="policyInlineSaving"
+                        @click="cancelPolicyInlineEdit"
+                      ><X :size="14" /></ElButton>
                     </span>
                   </template>
                   <template v-else>
-                    <span class="hfl-detail-row__text" :class="{ 'hfl-empty-mark': !detailPolicy.description }">{{ detailPolicy.description || t('common.empty') }}</span>
-                    <ElButton text circle size="small" class="hfl-detail-row__edit" :title="t('common.edit')" @click="beginPolicyInlineEdit('description')">
+                    <span
+                      class="hfl-detail-row__text"
+                      :class="{ 'hfl-empty-mark': !detailPolicy.description }"
+                    >{{ detailPolicy.description || t('common.empty') }}</span>
+                    <ElButton
+                      text
+                      circle
+                      size="small"
+                      class="hfl-detail-row__edit"
+                      :title="t('common.edit')"
+                      @click="beginPolicyInlineEdit('description')"
+                    >
                       <Pencil :size="13" />
                     </ElButton>
                   </template>
@@ -986,15 +1223,27 @@ watch(
               <div class="hfl-detail-row hfl-detail-row--full">
                 <span class="hfl-detail-row__label">{{ t('ops.alertsCenter.common.triggerRule') }}</span>
                 <span class="hfl-detail-row__value hfl-alert-policy-detail-drawer__json-value">
-                  <pre v-if="hasJsonValue(detailTriggerRule(detailPolicy))" class="hfl-alert-policy-detail-drawer__json">{{ formatJson(detailTriggerRule(detailPolicy)) }}</pre>
-                  <span v-else class="hfl-empty-mark">{{ t('common.empty') }}</span>
+                  <pre
+                    v-if="hasJsonValue(detailTriggerRule(detailPolicy))"
+                    class="hfl-alert-policy-detail-drawer__json"
+                  >{{ formatJson(detailTriggerRule(detailPolicy)) }}</pre>
+                  <span
+                    v-else
+                    class="hfl-empty-mark"
+                  >{{ t('common.empty') }}</span>
                 </span>
               </div>
               <div class="hfl-detail-row hfl-detail-row--full">
                 <span class="hfl-detail-row__label">{{ t('ops.alertsCenter.common.recoveryRule') }}</span>
                 <span class="hfl-detail-row__value hfl-alert-policy-detail-drawer__json-value">
-                  <pre v-if="hasJsonValue(detailRecoveryRule(detailPolicy))" class="hfl-alert-policy-detail-drawer__json">{{ formatJson(detailRecoveryRule(detailPolicy)) }}</pre>
-                  <span v-else class="hfl-empty-mark">{{ t('common.empty') }}</span>
+                  <pre
+                    v-if="hasJsonValue(detailRecoveryRule(detailPolicy))"
+                    class="hfl-alert-policy-detail-drawer__json"
+                  >{{ formatJson(detailRecoveryRule(detailPolicy)) }}</pre>
+                  <span
+                    v-else
+                    class="hfl-empty-mark"
+                  >{{ t('common.empty') }}</span>
                 </span>
               </div>
             </div>

--- a/src/frontend/src/pages/ops/AlertPolicyEditorPage.vue
+++ b/src/frontend/src/pages/ops/AlertPolicyEditorPage.vue
@@ -623,20 +623,37 @@ onMounted(async () => {
 </script>
 
 <template>
-  <div ref="pageRef" class="fullscreen-form-fullscreen resource-add-fullscreen alert-policy-editor-fullscreen">
+  <div
+    ref="pageRef"
+    class="fullscreen-form-fullscreen resource-add-fullscreen alert-policy-editor-fullscreen"
+  >
     <div class="fullscreen-form-page add-s3-page alert-policy-editor-page">
       <div class="fullscreen-form-header">
-        <button type="button" class="fullscreen-form-header__back" @click="handleBack">
-          <ArrowLeft class="fullscreen-form-header__back-icon" :size="18" />
+        <button
+          type="button"
+          class="fullscreen-form-header__back"
+          @click="handleBack"
+        >
+          <ArrowLeft
+            class="fullscreen-form-header__back-icon"
+            :size="18"
+          />
         </button>
         <div class="fullscreen-form-header__content">
-          <h1 class="fullscreen-form-header__title">{{ pageTitle }}</h1>
-          <p class="fullscreen-form-header__desc">{{ t('ops.alertsCenter.policies.createSubtitle') }}</p>
+          <h1 class="fullscreen-form-header__title">
+            {{ pageTitle }}
+          </h1>
+          <p class="fullscreen-form-header__desc">
+            {{ t('ops.alertsCenter.policies.createSubtitle') }}
+          </p>
         </div>
       </div>
 
       <div class="fullscreen-form-layout">
-        <div ref="mainRef" class="fullscreen-form-main">
+        <div
+          ref="mainRef"
+          class="fullscreen-form-main"
+        >
           <el-form
             ref="formRef"
             :model="form"
@@ -646,435 +663,711 @@ onMounted(async () => {
             require-asterisk-position="right"
           >
             <div class="fullscreen-form-step-stack">
-        <section class="fullscreen-form-card fullscreen-form-section">
-          <h3 class="fullscreen-form-section__title">
-            <span class="fullscreen-form-section__indicator" />
-            {{ t('ops.alertsCenter.editor.sectionBasic') }}
-          </h3>
-          <p class="fullscreen-form-section__subtitle">{{ t('ops.alertsCenter.editor.sectionBasicDesc') }}</p>
-          <div class="fullscreen-form-grid">
-            <el-form-item
-              :label="t('ops.alertsCenter.common.name')"
-              prop="name"
-              class="fullscreen-form-item--in-card"
-              data-alert-policy-field="name"
-            >
-              <el-input
-                v-model="form.name"
-                :placeholder="t('ops.alertsCenter.policies.alertNamePlaceholder')"
-              />
-              <p class="fullscreen-form-field__hint">{{ t('ops.alertsCenter.editor.fieldNameHint') }}</p>
-            </el-form-item>
-            <el-form-item :label="t('ops.alertsCenter.policies.alertType')" class="fullscreen-form-item--in-card">
-              <el-select v-model="form.type" class="w-full">
-                <el-option
-                  v-for="opt in policyTypeOptions"
-                  :key="opt.value"
-                  :value="opt.value"
-                  :label="opt.label"
-                />
-              </el-select>
-              <p class="fullscreen-form-field__hint">{{ t('ops.alertsCenter.editor.fieldTypeHint') }}</p>
-            </el-form-item>
-            <el-form-item :label="t('ops.alertsCenter.common.severity')" class="fullscreen-form-item--in-card">
-              <el-select v-model="form.severity" class="w-full">
-                <el-option value="critical" :label="t('ops.alertsCenter.common.critical')" />
-                <el-option value="warning" :label="t('ops.alertsCenter.common.warning')" />
-                <el-option value="info" :label="t('ops.alertsCenter.common.info')" />
-              </el-select>
-              <p class="fullscreen-form-field__hint">{{ t('ops.alertsCenter.editor.fieldSeverityHint') }}</p>
-            </el-form-item>
-            <el-form-item :label="t('ops.alertsCenter.common.status')" class="fullscreen-form-status-item">
-              <el-switch
-                v-model="form.enabled"
-                :active-text="t('ops.alertsCenter.common.enabled')"
-                :inactive-text="t('ops.alertsCenter.common.disabled')"
-              />
-            </el-form-item>
-          </div>
-          <el-form-item :label="t('ops.alertsCenter.policies.description')" class="fullscreen-form-item--in-card">
-            <el-input
-              v-model="form.description"
-              type="textarea"
-              :rows="3"
-              :placeholder="t('ops.alertsCenter.policies.description')"
-            />
-            <p class="fullscreen-form-field__hint">{{ t('ops.alertsCenter.editor.fieldDescriptionHint') }}</p>
-          </el-form-item>
-        </section>
+              <section class="fullscreen-form-card fullscreen-form-section">
+                <h3 class="fullscreen-form-section__title">
+                  <span class="fullscreen-form-section__indicator" />
+                  {{ t('ops.alertsCenter.editor.sectionBasic') }}
+                </h3>
+                <p class="fullscreen-form-section__subtitle">
+                  {{ t('ops.alertsCenter.editor.sectionBasicDesc') }}
+                </p>
+                <div class="fullscreen-form-grid">
+                  <el-form-item
+                    :label="t('ops.alertsCenter.common.name')"
+                    prop="name"
+                    class="fullscreen-form-item--in-card"
+                    data-alert-policy-field="name"
+                  >
+                    <el-input
+                      v-model="form.name"
+                      :placeholder="t('ops.alertsCenter.policies.alertNamePlaceholder')"
+                    />
+                    <p class="fullscreen-form-field__hint">
+                      {{ t('ops.alertsCenter.editor.fieldNameHint') }}
+                    </p>
+                  </el-form-item>
+                  <el-form-item
+                    :label="t('ops.alertsCenter.policies.alertType')"
+                    class="fullscreen-form-item--in-card"
+                  >
+                    <el-select
+                      v-model="form.type"
+                      class="w-full"
+                    >
+                      <el-option
+                        v-for="opt in policyTypeOptions"
+                        :key="opt.value"
+                        :value="opt.value"
+                        :label="opt.label"
+                      />
+                    </el-select>
+                    <p class="fullscreen-form-field__hint">
+                      {{ t('ops.alertsCenter.editor.fieldTypeHint') }}
+                    </p>
+                  </el-form-item>
+                  <el-form-item
+                    :label="t('ops.alertsCenter.common.severity')"
+                    class="fullscreen-form-item--in-card"
+                  >
+                    <el-select
+                      v-model="form.severity"
+                      class="w-full"
+                    >
+                      <el-option
+                        value="critical"
+                        :label="t('ops.alertsCenter.common.critical')"
+                      />
+                      <el-option
+                        value="warning"
+                        :label="t('ops.alertsCenter.common.warning')"
+                      />
+                      <el-option
+                        value="info"
+                        :label="t('ops.alertsCenter.common.info')"
+                      />
+                    </el-select>
+                    <p class="fullscreen-form-field__hint">
+                      {{ t('ops.alertsCenter.editor.fieldSeverityHint') }}
+                    </p>
+                  </el-form-item>
+                  <el-form-item
+                    :label="t('ops.alertsCenter.common.status')"
+                    class="fullscreen-form-status-item"
+                  >
+                    <el-switch
+                      v-model="form.enabled"
+                      :active-text="t('ops.alertsCenter.common.enabled')"
+                      :inactive-text="t('ops.alertsCenter.common.disabled')"
+                    />
+                  </el-form-item>
+                </div>
+                <el-form-item
+                  :label="t('ops.alertsCenter.policies.description')"
+                  class="fullscreen-form-item--in-card"
+                >
+                  <el-input
+                    v-model="form.description"
+                    type="textarea"
+                    :rows="3"
+                    :placeholder="t('ops.alertsCenter.policies.description')"
+                  />
+                  <p class="fullscreen-form-field__hint">
+                    {{ t('ops.alertsCenter.editor.fieldDescriptionHint') }}
+                  </p>
+                </el-form-item>
+              </section>
 
-        <section class="fullscreen-form-card fullscreen-form-section">
-          <h3 class="fullscreen-form-section__title">
-            <span class="fullscreen-form-section__indicator" />
-            {{ t('ops.alertsCenter.editor.sectionTarget') }}
-          </h3>
-          <p class="fullscreen-form-section__subtitle">{{ t('ops.alertsCenter.editor.sectionTargetDesc') }}</p>
-          <div class="fullscreen-form-grid">
-            <el-form-item :label="t('ops.alertsCenter.policies.targetColumn')" class="fullscreen-form-item--in-card">
-              <el-select v-model="form.resourceType" class="w-full">
-                <el-option
-                  v-for="opt in resourceTypeOptions"
-                  :key="opt.value"
-                  :value="opt.value"
-                  :label="opt.label"
-                />
-              </el-select>
-              <p class="fullscreen-form-field__hint">{{ t('ops.alertsCenter.editor.fieldResourceTypeHint') }}</p>
-            </el-form-item>
-            <el-form-item :label="t('ops.alertsCenter.policies.scope')" class="fullscreen-form-item--in-card">
-              <el-select v-model="form.scope" class="w-full">
-                <el-option
-                  v-for="opt in scopeOptions"
-                  :key="opt.value"
-                  :value="opt.value"
-                  :label="opt.label"
-                />
-              </el-select>
-              <p class="fullscreen-form-field__hint">{{ t('ops.alertsCenter.editor.fieldScopeHint') }}</p>
-            </el-form-item>
-          </div>
-          <el-form-item
-            v-if="form.scope === 'selected' && form.type !== 'event'"
-            :label="t('ops.alertsCenter.editor.fieldMonitoringResources')"
-            prop="resourceIds"
-            class="fullscreen-form-item--in-card mt-2"
-            data-alert-policy-field="resources"
-          >
-            <div class="fullscreen-form-control-row">
-              <el-select
-                v-model="form.resourceIds"
-                multiple
-                filterable
-                collapse-tags
-                collapse-tags-tooltip
-                fit-input-width
-                :max-collapse-tags="2"
-                popper-class="alert-policy-editor-resource-select-popper"
-                class="fullscreen-form-control-main alert-policy-editor-resource-select"
-                :loading="resourcesLoading"
-                :placeholder="t('ops.alertsCenter.editor.fieldMonitoringResources')"
-              >
-                <el-option
-                  v-for="resource in resourceOptions"
-                  :key="resource.id"
-                  :value="resource.id"
-                  :label="`${resource.name}${resource.status ? ` · ${resource.status}` : ''}`"
-                />
-              </el-select>
-              <el-button
-                class="fullscreen-form-icon-btn hfl-refresh-button"
-                native-type="button"
-                :title="t('ops.alertsCenter.editor.refreshResources')"
-                :aria-label="t('ops.alertsCenter.editor.refreshResources')"
-                :disabled="resourcesLoading"
-                @click="loadResources"
-              >
-                <RefreshCw :size="16" :class="{ 'is-spinning': resourcesLoading }" />
-              </el-button>
-            </div>
-            <p class="fullscreen-form-field__hint">{{ t('ops.alertsCenter.editor.resourceMultiSelectHint') }}</p>
-          </el-form-item>
-        </section>
+              <section class="fullscreen-form-card fullscreen-form-section">
+                <h3 class="fullscreen-form-section__title">
+                  <span class="fullscreen-form-section__indicator" />
+                  {{ t('ops.alertsCenter.editor.sectionTarget') }}
+                </h3>
+                <p class="fullscreen-form-section__subtitle">
+                  {{ t('ops.alertsCenter.editor.sectionTargetDesc') }}
+                </p>
+                <div class="fullscreen-form-grid">
+                  <el-form-item
+                    :label="t('ops.alertsCenter.policies.targetColumn')"
+                    class="fullscreen-form-item--in-card"
+                  >
+                    <el-select
+                      v-model="form.resourceType"
+                      class="w-full"
+                    >
+                      <el-option
+                        v-for="opt in resourceTypeOptions"
+                        :key="opt.value"
+                        :value="opt.value"
+                        :label="opt.label"
+                      />
+                    </el-select>
+                    <p class="fullscreen-form-field__hint">
+                      {{ t('ops.alertsCenter.editor.fieldResourceTypeHint') }}
+                    </p>
+                  </el-form-item>
+                  <el-form-item
+                    :label="t('ops.alertsCenter.policies.scope')"
+                    class="fullscreen-form-item--in-card"
+                  >
+                    <el-select
+                      v-model="form.scope"
+                      class="w-full"
+                    >
+                      <el-option
+                        v-for="opt in scopeOptions"
+                        :key="opt.value"
+                        :value="opt.value"
+                        :label="opt.label"
+                      />
+                    </el-select>
+                    <p class="fullscreen-form-field__hint">
+                      {{ t('ops.alertsCenter.editor.fieldScopeHint') }}
+                    </p>
+                  </el-form-item>
+                </div>
+                <el-form-item
+                  v-if="form.scope === 'selected' && form.type !== 'event'"
+                  :label="t('ops.alertsCenter.editor.fieldMonitoringResources')"
+                  prop="resourceIds"
+                  class="fullscreen-form-item--in-card mt-2"
+                  data-alert-policy-field="resources"
+                >
+                  <div class="fullscreen-form-control-row">
+                    <el-select
+                      v-model="form.resourceIds"
+                      multiple
+                      filterable
+                      collapse-tags
+                      collapse-tags-tooltip
+                      fit-input-width
+                      :max-collapse-tags="2"
+                      popper-class="alert-policy-editor-resource-select-popper"
+                      class="fullscreen-form-control-main alert-policy-editor-resource-select"
+                      :loading="resourcesLoading"
+                      :placeholder="t('ops.alertsCenter.editor.fieldMonitoringResources')"
+                    >
+                      <el-option
+                        v-for="resource in resourceOptions"
+                        :key="resource.id"
+                        :value="resource.id"
+                        :label="`${resource.name}${resource.status ? ` · ${resource.status}` : ''}`"
+                      />
+                    </el-select>
+                    <el-button
+                      class="fullscreen-form-icon-btn hfl-refresh-button"
+                      native-type="button"
+                      :title="t('ops.alertsCenter.editor.refreshResources')"
+                      :aria-label="t('ops.alertsCenter.editor.refreshResources')"
+                      :disabled="resourcesLoading"
+                      @click="loadResources"
+                    >
+                      <RefreshCw
+                        :size="16"
+                        :class="{ 'is-spinning': resourcesLoading }"
+                      />
+                    </el-button>
+                  </div>
+                  <p class="fullscreen-form-field__hint">
+                    {{ t('ops.alertsCenter.editor.resourceMultiSelectHint') }}
+                  </p>
+                </el-form-item>
+              </section>
 
-        <section class="fullscreen-form-card fullscreen-form-section">
-          <h3 class="fullscreen-form-section__title">
-            <span class="fullscreen-form-section__indicator" />
-            {{ t('ops.alertsCenter.editor.sectionTrigger') }}
-          </h3>
-          <p class="fullscreen-form-section__subtitle">{{ t('ops.alertsCenter.editor.sectionTriggerDesc') }}</p>
+              <section class="fullscreen-form-card fullscreen-form-section">
+                <h3 class="fullscreen-form-section__title">
+                  <span class="fullscreen-form-section__indicator" />
+                  {{ t('ops.alertsCenter.editor.sectionTrigger') }}
+                </h3>
+                <p class="fullscreen-form-section__subtitle">
+                  {{ t('ops.alertsCenter.editor.sectionTriggerDesc') }}
+                </p>
 
-          <div v-if="form.type === 'metric'" class="fullscreen-form-grid">
-            <el-form-item
-              :label="t('ops.alertsCenter.editor.fieldMetric')"
-              prop="triggerRule.metric_key"
-              data-alert-policy-field="metric_key"
-            >
-              <el-select v-model="metricKey" class="w-full" filterable allow-create default-first-option>
-                <el-option v-for="key in metricKeys" :key="key" :value="key" :label="key" />
-              </el-select>
-              <p class="fullscreen-form-field__hint">{{ t('ops.alertsCenter.editor.fieldMetricHint') }}</p>
-            </el-form-item>
-            <el-form-item
-              :label="t('ops.alertsCenter.editor.fieldOperator')"
-              prop="triggerRule.operator"
-              data-alert-policy-field="operator"
-            >
-              <el-select v-model="metricOperator" class="w-full">
-                <el-option v-for="op in operatorOptions" :key="op" :value="op" :label="op" />
-              </el-select>
-              <p class="fullscreen-form-field__hint">{{ t('ops.alertsCenter.editor.fieldOperatorHint') }}</p>
-            </el-form-item>
-            <el-form-item
-              :label="t('ops.alertsCenter.editor.fieldThreshold')"
-              prop="triggerRule.threshold"
-              data-alert-policy-field="threshold"
-            >
-              <el-input-number v-model="metricThreshold" class="w-full" :min="0" />
-              <p class="fullscreen-form-field__hint">{{ t('ops.alertsCenter.editor.fieldThresholdHint') }}</p>
-            </el-form-item>
-            <el-form-item :label="t('ops.alertsCenter.editor.fieldUnit')">
-              <el-input v-model="metricUnit" />
-              <p class="fullscreen-form-field__hint">{{ t('ops.alertsCenter.editor.fieldUnitHint') }}</p>
-            </el-form-item>
-            <el-form-item
-              :label="t('ops.alertsCenter.editor.fieldDuration')"
-              prop="triggerRule.duration_seconds"
-              data-alert-policy-field="duration_seconds"
-            >
-              <el-select v-model="metricDuration" class="w-full">
-                <el-option
-                  v-for="opt in durationOptions"
-                  :key="opt.value"
-                  :value="opt.value"
-                  :label="opt.label"
-                />
-              </el-select>
-              <p class="fullscreen-form-field__hint">{{ t('ops.alertsCenter.editor.fieldDurationHint') }}</p>
-            </el-form-item>
-            <el-form-item
-              :label="t('ops.alertsCenter.editor.fieldEvaluationInterval')"
-              prop="triggerRule.evaluation_interval_seconds"
-              data-alert-policy-field="evaluation_interval_seconds"
-            >
-              <el-select v-model="metricInterval" class="w-full">
-                <el-option
-                  v-for="opt in durationOptions"
-                  :key="`interval-${opt.value}`"
-                  :value="opt.value"
-                  :label="opt.label"
-                />
-              </el-select>
-              <p class="fullscreen-form-field__hint">{{ t('ops.alertsCenter.editor.fieldEvaluationIntervalHint') }}</p>
-            </el-form-item>
-          </div>
+                <div
+                  v-if="form.type === 'metric'"
+                  class="fullscreen-form-grid"
+                >
+                  <el-form-item
+                    :label="t('ops.alertsCenter.editor.fieldMetric')"
+                    prop="triggerRule.metric_key"
+                    data-alert-policy-field="metric_key"
+                  >
+                    <el-select
+                      v-model="metricKey"
+                      class="w-full"
+                      filterable
+                      allow-create
+                      default-first-option
+                    >
+                      <el-option
+                        v-for="key in metricKeys"
+                        :key="key"
+                        :value="key"
+                        :label="key"
+                      />
+                    </el-select>
+                    <p class="fullscreen-form-field__hint">
+                      {{ t('ops.alertsCenter.editor.fieldMetricHint') }}
+                    </p>
+                  </el-form-item>
+                  <el-form-item
+                    :label="t('ops.alertsCenter.editor.fieldOperator')"
+                    prop="triggerRule.operator"
+                    data-alert-policy-field="operator"
+                  >
+                    <el-select
+                      v-model="metricOperator"
+                      class="w-full"
+                    >
+                      <el-option
+                        v-for="op in operatorOptions"
+                        :key="op"
+                        :value="op"
+                        :label="op"
+                      />
+                    </el-select>
+                    <p class="fullscreen-form-field__hint">
+                      {{ t('ops.alertsCenter.editor.fieldOperatorHint') }}
+                    </p>
+                  </el-form-item>
+                  <el-form-item
+                    :label="t('ops.alertsCenter.editor.fieldThreshold')"
+                    prop="triggerRule.threshold"
+                    data-alert-policy-field="threshold"
+                  >
+                    <el-input-number
+                      v-model="metricThreshold"
+                      class="w-full"
+                      :min="0"
+                    />
+                    <p class="fullscreen-form-field__hint">
+                      {{ t('ops.alertsCenter.editor.fieldThresholdHint') }}
+                    </p>
+                  </el-form-item>
+                  <el-form-item :label="t('ops.alertsCenter.editor.fieldUnit')">
+                    <el-input v-model="metricUnit" />
+                    <p class="fullscreen-form-field__hint">
+                      {{ t('ops.alertsCenter.editor.fieldUnitHint') }}
+                    </p>
+                  </el-form-item>
+                  <el-form-item
+                    :label="t('ops.alertsCenter.editor.fieldDuration')"
+                    prop="triggerRule.duration_seconds"
+                    data-alert-policy-field="duration_seconds"
+                  >
+                    <el-select
+                      v-model="metricDuration"
+                      class="w-full"
+                    >
+                      <el-option
+                        v-for="opt in durationOptions"
+                        :key="opt.value"
+                        :value="opt.value"
+                        :label="opt.label"
+                      />
+                    </el-select>
+                    <p class="fullscreen-form-field__hint">
+                      {{ t('ops.alertsCenter.editor.fieldDurationHint') }}
+                    </p>
+                  </el-form-item>
+                  <el-form-item
+                    :label="t('ops.alertsCenter.editor.fieldEvaluationInterval')"
+                    prop="triggerRule.evaluation_interval_seconds"
+                    data-alert-policy-field="evaluation_interval_seconds"
+                  >
+                    <el-select
+                      v-model="metricInterval"
+                      class="w-full"
+                    >
+                      <el-option
+                        v-for="opt in durationOptions"
+                        :key="`interval-${opt.value}`"
+                        :value="opt.value"
+                        :label="opt.label"
+                      />
+                    </el-select>
+                    <p class="fullscreen-form-field__hint">
+                      {{ t('ops.alertsCenter.editor.fieldEvaluationIntervalHint') }}
+                    </p>
+                  </el-form-item>
+                </div>
 
-          <div v-else-if="form.type === 'task'" class="fullscreen-form-grid">
-            <el-form-item
-              :label="t('ops.alertsCenter.editor.taskType')"
-              prop="triggerRule.task_type"
-              data-alert-policy-field="task_type"
-            >
-              <el-select v-model="taskType" class="w-full">
-                <el-option v-for="item in taskTypes" :key="item" :value="item" :label="item" />
-              </el-select>
-              <p class="fullscreen-form-field__hint">{{ t('ops.alertsCenter.editor.taskTypeHint') }}</p>
-            </el-form-item>
-            <el-form-item
-              :label="t('ops.alertsCenter.editor.eventType')"
-              prop="triggerRule.event_type"
-              data-alert-policy-field="event_type"
-            >
-              <el-select v-model="taskEventType" class="w-full">
-                <el-option v-for="item in taskEventTypes" :key="item" :value="item" :label="item" />
-              </el-select>
-              <p class="fullscreen-form-field__hint">{{ t('ops.alertsCenter.editor.eventTypeHint') }}</p>
-            </el-form-item>
-          </div>
+                <div
+                  v-else-if="form.type === 'task'"
+                  class="fullscreen-form-grid"
+                >
+                  <el-form-item
+                    :label="t('ops.alertsCenter.editor.taskType')"
+                    prop="triggerRule.task_type"
+                    data-alert-policy-field="task_type"
+                  >
+                    <el-select
+                      v-model="taskType"
+                      class="w-full"
+                    >
+                      <el-option
+                        v-for="item in taskTypes"
+                        :key="item"
+                        :value="item"
+                        :label="item"
+                      />
+                    </el-select>
+                    <p class="fullscreen-form-field__hint">
+                      {{ t('ops.alertsCenter.editor.taskTypeHint') }}
+                    </p>
+                  </el-form-item>
+                  <el-form-item
+                    :label="t('ops.alertsCenter.editor.eventType')"
+                    prop="triggerRule.event_type"
+                    data-alert-policy-field="event_type"
+                  >
+                    <el-select
+                      v-model="taskEventType"
+                      class="w-full"
+                    >
+                      <el-option
+                        v-for="item in taskEventTypes"
+                        :key="item"
+                        :value="item"
+                        :label="item"
+                      />
+                    </el-select>
+                    <p class="fullscreen-form-field__hint">
+                      {{ t('ops.alertsCenter.editor.eventTypeHint') }}
+                    </p>
+                  </el-form-item>
+                </div>
 
-          <div v-else-if="form.type === 'availability'" class="fullscreen-form-grid">
-            <el-form-item
-              :label="t('ops.alertsCenter.editor.checkType')"
-              prop="triggerRule.check_type"
-              data-alert-policy-field="check_type"
-            >
-              <el-select v-model="checkType" class="w-full">
-                <el-option v-for="item in availabilityCheckTypes" :key="item" :value="item" :label="item" />
-              </el-select>
-              <p class="fullscreen-form-field__hint">{{ t('ops.alertsCenter.editor.checkTypeHint') }}</p>
-            </el-form-item>
-            <el-form-item
-              :label="t('ops.alertsCenter.editor.fieldDuration')"
-              prop="triggerRule.duration_seconds"
-              data-alert-policy-field="duration_seconds"
-            >
-              <el-select v-model="availabilityDuration" class="w-full">
-                <el-option
-                  v-for="opt in durationOptions"
-                  :key="`avail-${opt.value}`"
-                  :value="opt.value"
-                  :label="opt.label"
-                />
-              </el-select>
-              <p class="fullscreen-form-field__hint">{{ t('ops.alertsCenter.editor.fieldDurationHint') }}</p>
-            </el-form-item>
-            <el-form-item
-              :label="t('ops.alertsCenter.editor.fieldAvailabilityTimeout')"
-              prop="triggerRule.timeout_seconds"
-              data-alert-policy-field="timeout_seconds"
-            >
-              <el-input-number v-model="availabilityTimeout" class="w-full" :min="0" />
-              <p class="fullscreen-form-field__hint">{{ t('ops.alertsCenter.editor.fieldAvailabilityTimeoutHint') }}</p>
-            </el-form-item>
-          </div>
+                <div
+                  v-else-if="form.type === 'availability'"
+                  class="fullscreen-form-grid"
+                >
+                  <el-form-item
+                    :label="t('ops.alertsCenter.editor.checkType')"
+                    prop="triggerRule.check_type"
+                    data-alert-policy-field="check_type"
+                  >
+                    <el-select
+                      v-model="checkType"
+                      class="w-full"
+                    >
+                      <el-option
+                        v-for="item in availabilityCheckTypes"
+                        :key="item"
+                        :value="item"
+                        :label="item"
+                      />
+                    </el-select>
+                    <p class="fullscreen-form-field__hint">
+                      {{ t('ops.alertsCenter.editor.checkTypeHint') }}
+                    </p>
+                  </el-form-item>
+                  <el-form-item
+                    :label="t('ops.alertsCenter.editor.fieldDuration')"
+                    prop="triggerRule.duration_seconds"
+                    data-alert-policy-field="duration_seconds"
+                  >
+                    <el-select
+                      v-model="availabilityDuration"
+                      class="w-full"
+                    >
+                      <el-option
+                        v-for="opt in durationOptions"
+                        :key="`avail-${opt.value}`"
+                        :value="opt.value"
+                        :label="opt.label"
+                      />
+                    </el-select>
+                    <p class="fullscreen-form-field__hint">
+                      {{ t('ops.alertsCenter.editor.fieldDurationHint') }}
+                    </p>
+                  </el-form-item>
+                  <el-form-item
+                    :label="t('ops.alertsCenter.editor.fieldAvailabilityTimeout')"
+                    prop="triggerRule.timeout_seconds"
+                    data-alert-policy-field="timeout_seconds"
+                  >
+                    <el-input-number
+                      v-model="availabilityTimeout"
+                      class="w-full"
+                      :min="0"
+                    />
+                    <p class="fullscreen-form-field__hint">
+                      {{ t('ops.alertsCenter.editor.fieldAvailabilityTimeoutHint') }}
+                    </p>
+                  </el-form-item>
+                </div>
 
-          <div v-else-if="form.type === 'system'" class="fullscreen-form-grid">
-            <el-form-item
-              :label="t('ops.alertsCenter.editor.checkType')"
-              prop="triggerRule.check_type"
-              data-alert-policy-field="check_type"
-            >
-              <el-select v-model="systemCheckType" class="w-full">
-                <el-option v-for="item in systemCheckTypes" :key="item" :value="item" :label="item" />
-              </el-select>
-              <p class="fullscreen-form-field__hint">{{ t('ops.alertsCenter.editor.checkTypeHint') }}</p>
-            </el-form-item>
-            <el-form-item
-              :label="t('ops.alertsCenter.editor.fieldDuration')"
-              prop="triggerRule.duration_seconds"
-              data-alert-policy-field="duration_seconds"
-            >
-              <el-select v-model="systemDuration" class="w-full">
-                <el-option
-                  v-for="opt in durationOptions"
-                  :key="`sys-${opt.value}`"
-                  :value="opt.value"
-                  :label="opt.label"
-                />
-              </el-select>
-              <p class="fullscreen-form-field__hint">{{ t('ops.alertsCenter.editor.fieldDurationHint') }}</p>
-            </el-form-item>
-          </div>
+                <div
+                  v-else-if="form.type === 'system'"
+                  class="fullscreen-form-grid"
+                >
+                  <el-form-item
+                    :label="t('ops.alertsCenter.editor.checkType')"
+                    prop="triggerRule.check_type"
+                    data-alert-policy-field="check_type"
+                  >
+                    <el-select
+                      v-model="systemCheckType"
+                      class="w-full"
+                    >
+                      <el-option
+                        v-for="item in systemCheckTypes"
+                        :key="item"
+                        :value="item"
+                        :label="item"
+                      />
+                    </el-select>
+                    <p class="fullscreen-form-field__hint">
+                      {{ t('ops.alertsCenter.editor.checkTypeHint') }}
+                    </p>
+                  </el-form-item>
+                  <el-form-item
+                    :label="t('ops.alertsCenter.editor.fieldDuration')"
+                    prop="triggerRule.duration_seconds"
+                    data-alert-policy-field="duration_seconds"
+                  >
+                    <el-select
+                      v-model="systemDuration"
+                      class="w-full"
+                    >
+                      <el-option
+                        v-for="opt in durationOptions"
+                        :key="`sys-${opt.value}`"
+                        :value="opt.value"
+                        :label="opt.label"
+                      />
+                    </el-select>
+                    <p class="fullscreen-form-field__hint">
+                      {{ t('ops.alertsCenter.editor.fieldDurationHint') }}
+                    </p>
+                  </el-form-item>
+                </div>
 
-          <div v-else-if="form.type === 'event'" class="fullscreen-form-grid">
-            <el-form-item
-              :label="t('ops.alertsCenter.editor.eventCategory')"
-              prop="triggerRule.event_category"
-              data-alert-policy-field="event_category"
-            >
-              <el-select v-model="eventCategory" class="w-full">
-                <el-option v-for="item in eventCategories" :key="item" :value="item" :label="item" />
-              </el-select>
-              <p class="fullscreen-form-field__hint">{{ t('ops.alertsCenter.editor.eventCategoryHint') }}</p>
-            </el-form-item>
-            <el-form-item
-              :label="t('ops.alertsCenter.editor.eventTypes')"
-              prop="triggerRule.event_types"
-              data-alert-policy-field="event_types"
-            >
-              <el-select
-                v-model="eventTypes"
-                multiple
-                filterable
-                collapse-tags
-                collapse-tags-tooltip
-                :max-collapse-tags="1"
-                :tag-tooltip="{ popperClass: 'alert-policy-editor-event-types-tooltip', placement: 'bottom' }"
-                class="w-full alert-policy-editor-event-types"
-              >
-                <el-option
-                  v-for="item in eventTypesByCategory[eventCategory] || []"
-                  :key="item"
-                  :value="item"
-                  :label="item"
-                />
-              </el-select>
-              <p class="fullscreen-form-field__hint">{{ t('ops.alertsCenter.editor.eventTypesHint') }}</p>
-            </el-form-item>
-          </div>
-        </section>
+                <div
+                  v-else-if="form.type === 'event'"
+                  class="fullscreen-form-grid"
+                >
+                  <el-form-item
+                    :label="t('ops.alertsCenter.editor.eventCategory')"
+                    prop="triggerRule.event_category"
+                    data-alert-policy-field="event_category"
+                  >
+                    <el-select
+                      v-model="eventCategory"
+                      class="w-full"
+                    >
+                      <el-option
+                        v-for="item in eventCategories"
+                        :key="item"
+                        :value="item"
+                        :label="item"
+                      />
+                    </el-select>
+                    <p class="fullscreen-form-field__hint">
+                      {{ t('ops.alertsCenter.editor.eventCategoryHint') }}
+                    </p>
+                  </el-form-item>
+                  <el-form-item
+                    :label="t('ops.alertsCenter.editor.eventTypes')"
+                    prop="triggerRule.event_types"
+                    data-alert-policy-field="event_types"
+                  >
+                    <el-select
+                      v-model="eventTypes"
+                      multiple
+                      filterable
+                      collapse-tags
+                      collapse-tags-tooltip
+                      :max-collapse-tags="1"
+                      :tag-tooltip="{ popperClass: 'alert-policy-editor-event-types-tooltip', placement: 'bottom' }"
+                      class="w-full alert-policy-editor-event-types"
+                    >
+                      <el-option
+                        v-for="item in eventTypesByCategory[eventCategory] || []"
+                        :key="item"
+                        :value="item"
+                        :label="item"
+                      />
+                    </el-select>
+                    <p class="fullscreen-form-field__hint">
+                      {{ t('ops.alertsCenter.editor.eventTypesHint') }}
+                    </p>
+                  </el-form-item>
+                </div>
+              </section>
 
-        <section class="fullscreen-form-card fullscreen-form-section">
-          <h3 class="fullscreen-form-section__title">
-            <span class="fullscreen-form-section__indicator" />
-            {{ t('ops.alertsCenter.editor.sectionRecovery') }}
-          </h3>
-          <p class="fullscreen-form-section__subtitle">{{ t('ops.alertsCenter.editor.sectionRecoveryDesc') }}</p>
-          <el-form-item class="fullscreen-form-status-item">
-            <el-switch v-model="recoveryEnabled" :active-text="t('ops.alertsCenter.editor.fieldRecoveryEnabled')" />
-          </el-form-item>
-          <p class="fullscreen-form-field__hint">{{ t('ops.alertsCenter.editor.fieldRecoveryEnabledHint') }}</p>
-          <div v-if="recoveryEnabled" class="fullscreen-form-grid mt-3">
-            <el-form-item :label="t('ops.alertsCenter.editor.fieldRecoveryCondition')">
-              <el-select v-model="recoveryCondition" class="w-full">
-                <el-option
-                  value="below_threshold"
-                  :label="t('ops.alertsCenter.editor.conditionBelowThreshold')"
-                />
-              </el-select>
-              <p class="fullscreen-form-field__hint">{{ t('ops.alertsCenter.editor.fieldRecoveryConditionHint') }}</p>
-            </el-form-item>
-            <el-form-item :label="t('ops.alertsCenter.editor.fieldOperator')">
-              <el-select v-model="recoveryOperator" class="w-full">
-                <el-option v-for="op in operatorOptions" :key="`recovery-${op}`" :value="op" :label="op" />
-              </el-select>
-              <p class="fullscreen-form-field__hint">{{ t('ops.alertsCenter.editor.fieldOperatorHint') }}</p>
-            </el-form-item>
-            <el-form-item :label="t('ops.alertsCenter.editor.fieldThreshold')">
-              <el-input-number v-model="recoveryThreshold" class="w-full" :min="0" />
-              <p class="fullscreen-form-field__hint">{{ t('ops.alertsCenter.editor.fieldRecoveryThresholdHint') }}</p>
-            </el-form-item>
-            <el-form-item :label="t('ops.alertsCenter.editor.fieldRecoveryDuration')">
-              <el-select v-model="recoveryDuration" class="w-full">
-                <el-option
-                  v-for="opt in durationOptions"
-                  :key="`recovery-${opt.value}`"
-                  :value="opt.value"
-                  :label="opt.label"
-                />
-              </el-select>
-              <p class="fullscreen-form-field__hint">{{ t('ops.alertsCenter.editor.fieldRecoveryDurationHint') }}</p>
-            </el-form-item>
-          </div>
-        </section>
+              <section class="fullscreen-form-card fullscreen-form-section">
+                <h3 class="fullscreen-form-section__title">
+                  <span class="fullscreen-form-section__indicator" />
+                  {{ t('ops.alertsCenter.editor.sectionRecovery') }}
+                </h3>
+                <p class="fullscreen-form-section__subtitle">
+                  {{ t('ops.alertsCenter.editor.sectionRecoveryDesc') }}
+                </p>
+                <el-form-item class="fullscreen-form-status-item">
+                  <el-switch
+                    v-model="recoveryEnabled"
+                    :active-text="t('ops.alertsCenter.editor.fieldRecoveryEnabled')"
+                  />
+                </el-form-item>
+                <p class="fullscreen-form-field__hint">
+                  {{ t('ops.alertsCenter.editor.fieldRecoveryEnabledHint') }}
+                </p>
+                <div
+                  v-if="recoveryEnabled"
+                  class="fullscreen-form-grid mt-3"
+                >
+                  <el-form-item :label="t('ops.alertsCenter.editor.fieldRecoveryCondition')">
+                    <el-select
+                      v-model="recoveryCondition"
+                      class="w-full"
+                    >
+                      <el-option
+                        value="below_threshold"
+                        :label="t('ops.alertsCenter.editor.conditionBelowThreshold')"
+                      />
+                    </el-select>
+                    <p class="fullscreen-form-field__hint">
+                      {{ t('ops.alertsCenter.editor.fieldRecoveryConditionHint') }}
+                    </p>
+                  </el-form-item>
+                  <el-form-item :label="t('ops.alertsCenter.editor.fieldOperator')">
+                    <el-select
+                      v-model="recoveryOperator"
+                      class="w-full"
+                    >
+                      <el-option
+                        v-for="op in operatorOptions"
+                        :key="`recovery-${op}`"
+                        :value="op"
+                        :label="op"
+                      />
+                    </el-select>
+                    <p class="fullscreen-form-field__hint">
+                      {{ t('ops.alertsCenter.editor.fieldOperatorHint') }}
+                    </p>
+                  </el-form-item>
+                  <el-form-item :label="t('ops.alertsCenter.editor.fieldThreshold')">
+                    <el-input-number
+                      v-model="recoveryThreshold"
+                      class="w-full"
+                      :min="0"
+                    />
+                    <p class="fullscreen-form-field__hint">
+                      {{ t('ops.alertsCenter.editor.fieldRecoveryThresholdHint') }}
+                    </p>
+                  </el-form-item>
+                  <el-form-item :label="t('ops.alertsCenter.editor.fieldRecoveryDuration')">
+                    <el-select
+                      v-model="recoveryDuration"
+                      class="w-full"
+                    >
+                      <el-option
+                        v-for="opt in durationOptions"
+                        :key="`recovery-${opt.value}`"
+                        :value="opt.value"
+                        :label="opt.label"
+                      />
+                    </el-select>
+                    <p class="fullscreen-form-field__hint">
+                      {{ t('ops.alertsCenter.editor.fieldRecoveryDurationHint') }}
+                    </p>
+                  </el-form-item>
+                </div>
+              </section>
 
-        <section class="fullscreen-form-card fullscreen-form-section">
-          <h3 class="fullscreen-form-section__title">
-            <span class="fullscreen-form-section__indicator" />
-            {{ t('ops.alertsCenter.editor.sectionNotification') }}
-          </h3>
-          <p class="fullscreen-form-section__subtitle">{{ t('ops.alertsCenter.editor.sectionNotificationDesc') }}</p>
-          <div class="fullscreen-form-grid">
-            <el-form-item :label="t('ops.alertsCenter.policies.notificationChannels')">
-              <el-select v-model="form.notificationChannelIds" multiple class="w-full" filterable>
-                <el-option v-for="ch in channels" :key="ch.id" :value="ch.id" :label="ch.name" />
-              </el-select>
-              <p class="fullscreen-form-field__hint">{{ t('ops.alertsCenter.editor.fieldNotificationChannelsHint') }}</p>
-            </el-form-item>
-            <el-form-item :label="t('ops.alertsCenter.editor.fieldNotifyOnFiring')">
-              <el-select v-model="notifyOnFiring" class="w-full">
-                <el-option
-                  v-for="opt in yesNoOptions"
-                  :key="`firing-${opt.label}`"
-                  :value="opt.value"
-                  :label="opt.label"
-                />
-              </el-select>
-              <p class="fullscreen-form-field__hint">{{ t('ops.alertsCenter.editor.fieldNotifyOnFiringHint') }}</p>
-            </el-form-item>
-            <el-form-item :label="t('ops.alertsCenter.editor.fieldNotifyOnResolved')">
-              <el-select v-model="notifyOnResolved" class="w-full">
-                <el-option
-                  v-for="opt in yesNoOptions"
-                  :key="`resolved-${opt.label}`"
-                  :value="opt.value"
-                  :label="opt.label"
-                />
-              </el-select>
-              <p class="fullscreen-form-field__hint">{{ t('ops.alertsCenter.editor.fieldNotifyOnResolvedHint') }}</p>
-            </el-form-item>
-            <el-form-item :label="t('ops.alertsCenter.editor.fieldRepeatInterval')">
-              <el-input-number v-model="repeatIntervalSeconds" class="w-full" :min="0" :step="60" />
-              <p class="fullscreen-form-field__hint">{{ t('ops.alertsCenter.editor.fieldRepeatIntervalHint') }}</p>
-            </el-form-item>
-            <el-form-item :label="t('ops.alertsCenter.editor.fieldMergeNotification')" class="fullscreen-form-status-item">
-              <el-switch
-                v-model="mergeEnabled"
-                :active-text="t('ops.alertsCenter.common.enabled')"
-                :inactive-text="t('ops.alertsCenter.common.disabled')"
-                @change="handleMergeEnabledChange"
-              />
-              <p class="fullscreen-form-field__hint">{{ t('ops.alertsCenter.editor.fieldMergeNotificationHint') }}</p>
-            </el-form-item>
-            <el-form-item v-if="mergeEnabled" :label="t('ops.alertsCenter.editor.fieldMergeKey')">
-              <el-input v-model="mergeKey" :placeholder="t('ops.alertsCenter.editor.phMergeKey')" />
-              <p class="fullscreen-form-field__hint">{{ t('ops.alertsCenter.editor.fieldMergeKeyHint') }}</p>
-            </el-form-item>
-            <el-form-item v-if="mergeEnabled" :label="t('ops.alertsCenter.editor.fieldMergeWindow')">
-              <el-input-number v-model="mergeWindowSeconds" class="w-full" :min="60" :step="60" />
-              <p class="fullscreen-form-field__hint">{{ t('ops.alertsCenter.editor.fieldMergeWindowHint') }}</p>
-            </el-form-item>
-          </div>
-        </section>
+              <section class="fullscreen-form-card fullscreen-form-section">
+                <h3 class="fullscreen-form-section__title">
+                  <span class="fullscreen-form-section__indicator" />
+                  {{ t('ops.alertsCenter.editor.sectionNotification') }}
+                </h3>
+                <p class="fullscreen-form-section__subtitle">
+                  {{ t('ops.alertsCenter.editor.sectionNotificationDesc') }}
+                </p>
+                <div class="fullscreen-form-grid">
+                  <el-form-item :label="t('ops.alertsCenter.policies.notificationChannels')">
+                    <el-select
+                      v-model="form.notificationChannelIds"
+                      multiple
+                      class="w-full"
+                      filterable
+                    >
+                      <el-option
+                        v-for="ch in channels"
+                        :key="ch.id"
+                        :value="ch.id"
+                        :label="ch.name"
+                      />
+                    </el-select>
+                    <p class="fullscreen-form-field__hint">
+                      {{ t('ops.alertsCenter.editor.fieldNotificationChannelsHint') }}
+                    </p>
+                  </el-form-item>
+                  <el-form-item :label="t('ops.alertsCenter.editor.fieldNotifyOnFiring')">
+                    <el-select
+                      v-model="notifyOnFiring"
+                      class="w-full"
+                    >
+                      <el-option
+                        v-for="opt in yesNoOptions"
+                        :key="`firing-${opt.label}`"
+                        :value="opt.value"
+                        :label="opt.label"
+                      />
+                    </el-select>
+                    <p class="fullscreen-form-field__hint">
+                      {{ t('ops.alertsCenter.editor.fieldNotifyOnFiringHint') }}
+                    </p>
+                  </el-form-item>
+                  <el-form-item :label="t('ops.alertsCenter.editor.fieldNotifyOnResolved')">
+                    <el-select
+                      v-model="notifyOnResolved"
+                      class="w-full"
+                    >
+                      <el-option
+                        v-for="opt in yesNoOptions"
+                        :key="`resolved-${opt.label}`"
+                        :value="opt.value"
+                        :label="opt.label"
+                      />
+                    </el-select>
+                    <p class="fullscreen-form-field__hint">
+                      {{ t('ops.alertsCenter.editor.fieldNotifyOnResolvedHint') }}
+                    </p>
+                  </el-form-item>
+                  <el-form-item :label="t('ops.alertsCenter.editor.fieldRepeatInterval')">
+                    <el-input-number
+                      v-model="repeatIntervalSeconds"
+                      class="w-full"
+                      :min="0"
+                      :step="60"
+                    />
+                    <p class="fullscreen-form-field__hint">
+                      {{ t('ops.alertsCenter.editor.fieldRepeatIntervalHint') }}
+                    </p>
+                  </el-form-item>
+                  <el-form-item
+                    :label="t('ops.alertsCenter.editor.fieldMergeNotification')"
+                    class="fullscreen-form-status-item"
+                  >
+                    <el-switch
+                      v-model="mergeEnabled"
+                      :active-text="t('ops.alertsCenter.common.enabled')"
+                      :inactive-text="t('ops.alertsCenter.common.disabled')"
+                      @change="handleMergeEnabledChange"
+                    />
+                    <p class="fullscreen-form-field__hint">
+                      {{ t('ops.alertsCenter.editor.fieldMergeNotificationHint') }}
+                    </p>
+                  </el-form-item>
+                  <el-form-item
+                    v-if="mergeEnabled"
+                    :label="t('ops.alertsCenter.editor.fieldMergeKey')"
+                  >
+                    <el-input
+                      v-model="mergeKey"
+                      :placeholder="t('ops.alertsCenter.editor.phMergeKey')"
+                    />
+                    <p class="fullscreen-form-field__hint">
+                      {{ t('ops.alertsCenter.editor.fieldMergeKeyHint') }}
+                    </p>
+                  </el-form-item>
+                  <el-form-item
+                    v-if="mergeEnabled"
+                    :label="t('ops.alertsCenter.editor.fieldMergeWindow')"
+                  >
+                    <el-input-number
+                      v-model="mergeWindowSeconds"
+                      class="w-full"
+                      :min="60"
+                      :step="60"
+                    />
+                    <p class="fullscreen-form-field__hint">
+                      {{ t('ops.alertsCenter.editor.fieldMergeWindowHint') }}
+                    </p>
+                  </el-form-item>
+                </div>
+              </section>
             </div>
           </el-form>
 
@@ -1098,19 +1391,26 @@ onMounted(async () => {
             <div class="add-form-preview-header">
               <div class="add-form-preview-header__glow" />
               <div class="add-form-preview-header__icon alert-policy-editor-preview__icon">
-                <BellRing class="add-form-preview-header__cloud" :size="28" />
+                <BellRing
+                  class="add-form-preview-header__cloud"
+                  :size="28"
+                />
               </div>
               <div class="add-form-preview-header__info">
                 <h4 class="add-form-preview-header__name">
                   {{ form.name.trim() || t('ops.alertsCenter.policies.unnamedPolicy') }}
                 </h4>
-                <p class="add-form-preview-header__type">{{ policyTypeLabel(form.type) }}</p>
+                <p class="add-form-preview-header__type">
+                  {{ policyTypeLabel(form.type) }}
+                </p>
               </div>
             </div>
 
             <div class="add-form-preview-body">
               <div class="add-form-preview-section">
-                <h5 class="add-form-preview-section__title">{{ t('ops.alertsCenter.editor.previewTitle') }}</h5>
+                <h5 class="add-form-preview-section__title">
+                  {{ t('ops.alertsCenter.editor.previewTitle') }}
+                </h5>
                 <div
                   v-for="row in previewBasicRows"
                   :key="row.label"
@@ -1136,7 +1436,9 @@ onMounted(async () => {
               </div>
 
               <div class="add-form-preview-section">
-                <h5 class="add-form-preview-section__title">{{ t('ops.alertsCenter.editor.sectionTrigger') }}</h5>
+                <h5 class="add-form-preview-section__title">
+                  {{ t('ops.alertsCenter.editor.sectionTrigger') }}
+                </h5>
                 <div
                   v-for="row in previewRuleRows"
                   :key="row.label"
@@ -1157,7 +1459,9 @@ onMounted(async () => {
               </div>
 
               <div class="add-form-preview-section">
-                <h5 class="add-form-preview-section__title">{{ t('ops.alertsCenter.editor.sectionNotification') }}</h5>
+                <h5 class="add-form-preview-section__title">
+                  {{ t('ops.alertsCenter.editor.sectionNotification') }}
+                </h5>
                 <div class="add-form-preview-row">
                   <span class="add-form-preview-row__label">{{ t('ops.alertsCenter.editor.previewNotification') }}</span>
                   <span

--- a/src/frontend/src/pages/ops/Attention.vue
+++ b/src/frontend/src/pages/ops/Attention.vue
@@ -68,48 +68,124 @@ watch(() => [pagination.page, pagination.pageSize], () => void loadItems())
 </script>
 
 <template>
-  <ModulePage :title="t('ops.attention.title')" :menus="opsMenus" body-fill>
+  <ModulePage
+    :title="t('ops.attention.title')"
+    :menus="opsMenus"
+    body-fill
+  >
     <div class="attention-page">
-      <p class="attention-page__subtitle">{{ t('ops.attention.subtitle') }}</p>
-      <p v-if="loadError" class="attention-page__error">{{ t('ops.attention.loadFailed') }}: {{ loadError }}</p>
+      <p class="attention-page__subtitle">
+        {{ t('ops.attention.subtitle') }}
+      </p>
+      <p
+        v-if="loadError"
+        class="attention-page__error"
+      >
+        {{ t('ops.attention.loadFailed') }}: {{ loadError }}
+      </p>
       <HflTablePanel fill>
         <template #toolbar>
-          <el-select v-model="filters.kind" clearable :placeholder="t('ops.attention.allTypes')" style="width: 160px">
-            <el-option v-for="kind in ['task', 'alert', 'node', 'source']" :key="kind" :value="kind" :label="itemKindLabel(kind as AttentionKind)" />
+          <el-select
+            v-model="filters.kind"
+            clearable
+            :placeholder="t('ops.attention.allTypes')"
+            style="width: 160px"
+          >
+            <el-option
+              v-for="kind in ['task', 'alert', 'node', 'source']"
+              :key="kind"
+              :value="kind"
+              :label="itemKindLabel(kind as AttentionKind)"
+            />
           </el-select>
         </template>
         <template #toolbar-utility>
-          <el-button class="hfl-refresh-button" :disabled="loading" :title="t('ops.task.btnRefresh')" :aria-label="t('ops.task.btnRefresh')" @click="loadItems">
-            <RefreshCw :size="16" :class="{ 'is-spinning': loading }" />
+          <el-button
+            class="hfl-refresh-button"
+            :disabled="loading"
+            :title="t('ops.task.btnRefresh')"
+            :aria-label="t('ops.task.btnRefresh')"
+            @click="loadItems"
+          >
+            <RefreshCw
+              :size="16"
+              :class="{ 'is-spinning': loading }"
+            />
           </el-button>
         </template>
         <template #table="{ tableMaxHeight }">
-          <el-table v-table-column-resize="'ops.attention'" v-table-overflow-title v-loading="loading" :data="filteredItems" row-key="id" class="hfl-list-table" stripe :max-height="tableMaxHeight">
-            <el-table-column :label="t('ops.attention.type')" width="120" fixed="left">
+          <el-table
+            v-table-column-resize="'ops.attention'"
+            v-table-overflow-title
+            v-loading="loading"
+            :data="filteredItems"
+            row-key="id"
+            class="hfl-list-table"
+            stripe
+            :max-height="tableMaxHeight"
+          >
+            <el-table-column
+              :label="t('ops.attention.type')"
+              width="120"
+              fixed="left"
+            >
               <template #default="{ row }">
-                <el-tag :type="itemTagType(row.kind)" size="small">{{ itemKindLabel(row.kind) }}</el-tag>
+                <el-tag
+                  :type="itemTagType(row.kind)"
+                  size="small"
+                >
+                  {{ itemKindLabel(row.kind) }}
+                </el-tag>
               </template>
             </el-table-column>
-            <el-table-column :label="t('ops.alertsCenter.common.title')" min-width="260">
+            <el-table-column
+              :label="t('ops.alertsCenter.common.title')"
+              min-width="260"
+            >
               <template #default="{ row }">
-                <div class="attention-page__title">{{ row.title }}</div>
+                <div class="attention-page__title">
+                  {{ row.title }}
+                </div>
               </template>
             </el-table-column>
-            <el-table-column :label="t('ops.attention.details')" min-width="280">
+            <el-table-column
+              :label="t('ops.attention.details')"
+              min-width="280"
+            >
               <template #default="{ row }">
                 <span :class="row.detail ? '' : 'hfl-empty-mark'">{{ row.detail || '—' }}</span>
               </template>
             </el-table-column>
-            <el-table-column :label="t('ops.attention.occurredAt')" width="180">
-              <template #default="{ row }">{{ itemTime(row) }}</template>
-            </el-table-column>
-            <el-table-column :label="t('ops.attention.action')" width="100" fixed="right">
+            <el-table-column
+              :label="t('ops.attention.occurredAt')"
+              width="180"
+            >
               <template #default="{ row }">
-                <el-button class="hfl-table-no-tooltip" link type="primary" @click="router.push(row.to)">{{ t('ops.attention.open') }}</el-button>
+                {{ itemTime(row) }}
+              </template>
+            </el-table-column>
+            <el-table-column
+              :label="t('ops.attention.action')"
+              width="100"
+              fixed="right"
+            >
+              <template #default="{ row }">
+                <el-button
+                  class="hfl-table-no-tooltip"
+                  link
+                  type="primary"
+                  @click="router.push(row.to)"
+                >
+                  {{ t('ops.attention.open') }}
+                </el-button>
               </template>
             </el-table-column>
             <template #empty>
-              <el-empty v-if="!loading" :description="t('ops.attention.empty')" :image-size="72" />
+              <el-empty
+                v-if="!loading"
+                :description="t('ops.attention.empty')"
+                :image-size="72"
+              />
             </template>
           </el-table>
         </template>

--- a/src/frontend/src/pages/ops/Audit.vue
+++ b/src/frontend/src/pages/ops/Audit.vue
@@ -409,11 +409,25 @@ watch(
 </script>
 
 <template>
-  <ModulePage :title="t('ops.audit.pageTitle')" :menus="opsMenus" body-fill>
+  <ModulePage
+    :title="t('ops.audit.pageTitle')"
+    :menus="opsMenus"
+    body-fill
+  >
     <div class="hfl-ops-page hfl-ops-page--fill">
       <div class="hfl-ops-stats-grid hfl-ops-stats-grid--4">
-        <OpsStatCard :label="t('ops.audit.statTotal')" :value="stats.total_count" accent="indigo" accent-side="left" />
-        <OpsStatCard :label="t('ops.audit.statToday')" :value="stats.today_count" accent="green" accent-side="left" />
+        <OpsStatCard
+          :label="t('ops.audit.statTotal')"
+          :value="stats.total_count"
+          accent="indigo"
+          accent-side="left"
+        />
+        <OpsStatCard
+          :label="t('ops.audit.statToday')"
+          :value="stats.today_count"
+          accent="green"
+          accent-side="left"
+        />
         <OpsStatCard
           :label="t('ops.audit.statFailures')"
           :value="stats.failure_count"
@@ -432,13 +446,20 @@ watch(
       <HflTablePanel fill>
         <template #toolbar>
           <el-dropdown>
-            <el-button :title="t('ops.audit.export')" :aria-label="t('ops.audit.export')">
+            <el-button
+              :title="t('ops.audit.export')"
+              :aria-label="t('ops.audit.export')"
+            >
               <Download :size="16" />
             </el-button>
             <template #dropdown>
               <el-dropdown-menu>
-                <el-dropdown-item @click="exportLogs('json')">JSON</el-dropdown-item>
-                <el-dropdown-item @click="exportLogs('csv')">CSV</el-dropdown-item>
+                <el-dropdown-item @click="exportLogs('json')">
+                  JSON
+                </el-dropdown-item>
+                <el-dropdown-item @click="exportLogs('csv')">
+                  CSV
+                </el-dropdown-item>
               </el-dropdown-menu>
             </template>
           </el-dropdown>
@@ -452,13 +473,31 @@ watch(
             @clear="clearSearch"
           >
             <template #prepend>
-              <el-select v-model="filters.search_field" @change="handleSearchFieldChange">
-                <el-option v-for="st in searchTypes" :key="st.value" :value="st.value" :label="st.label" />
+              <el-select
+                v-model="filters.search_field"
+                @change="handleSearchFieldChange"
+              >
+                <el-option
+                  v-for="st in searchTypes"
+                  :key="st.value"
+                  :value="st.value"
+                  :label="st.label"
+                />
               </el-select>
             </template>
           </el-input>
-          <el-select v-model="filters.time_range" clearable style="width: 130px" @change="onAuditTimeRangeChange">
-            <el-option v-for="p in datePresets" :key="p.value" :value="p.value" :label="p.label" />
+          <el-select
+            v-model="filters.time_range"
+            clearable
+            style="width: 130px"
+            @change="onAuditTimeRangeChange"
+          >
+            <el-option
+              v-for="p in datePresets"
+              :key="p.value"
+              :value="p.value"
+              :label="p.label"
+            />
           </el-select>
         </template>
         <template #toolbar-utility>
@@ -469,20 +508,48 @@ watch(
             :aria-label="t('ops.audit.advancedFilter')"
             @click="openAdvancedFilterDrawer"
           >
-            <el-badge v-if="advancedFilterCount > 0" :value="advancedFilterCount" :max="9" class="hfl-filter-badge">
+            <el-badge
+              v-if="advancedFilterCount > 0"
+              :value="advancedFilterCount"
+              :max="9"
+              class="hfl-filter-badge"
+            >
               <Filter :size="16" />
             </el-badge>
-            <Filter v-else :size="16" />
+            <Filter
+              v-else
+              :size="16"
+            />
           </el-button>
-          <el-button class="hfl-refresh-button" :title="t('ops.task.btnRefresh')" :aria-label="t('ops.task.btnRefresh')" :disabled="loading" @click="applyFilters">
-            <RefreshCw :size="16" :class="{ 'is-spinning': loading }" />
+          <el-button
+            class="hfl-refresh-button"
+            :title="t('ops.task.btnRefresh')"
+            :aria-label="t('ops.task.btnRefresh')"
+            :disabled="loading"
+            @click="applyFilters"
+          >
+            <RefreshCw
+              :size="16"
+              :class="{ 'is-spinning': loading }"
+            />
           </el-button>
         </template>
 
-        <el-alert v-if="activeCorrelation" type="info" :closable="false" show-icon class="mx-4 mt-4">
+        <el-alert
+          v-if="activeCorrelation"
+          type="info"
+          :closable="false"
+          show-icon
+          class="mx-4 mt-4"
+        >
           <div class="flex flex-wrap items-center gap-2">
             <span>{{ t('ops.audit.bannerCorrelation', { id: activeCorrelation }) }}</span>
-            <el-button size="small" text type="primary" @click="clearCorrelationFilter">
+            <el-button
+              size="small"
+              text
+              type="primary"
+              @click="clearCorrelationFilter"
+            >
               <X class="mr-1 h-3.5 w-3.5" />
               {{ t('ops.audit.clearCorrelationFilter') }}
             </el-button>
@@ -501,7 +568,11 @@ watch(
             row-key="id"
             :max-height="tableMaxHeight"
           >
-            <el-table-column :label="t('ops.audit.colAction')" width="220" fixed="left">
+            <el-table-column
+              :label="t('ops.audit.colAction')"
+              width="220"
+              fixed="left"
+            >
               <template #default="{ row }">
                 <div class="hfl-ops-primary-cell">
                   <div class="min-w-0">
@@ -514,19 +585,32 @@ watch(
                         {{ actionLabel(row.action) }}
                       </button>
                     </div>
-                    <div v-if="row.resource_type" class="hfl-ops-cell-stack__meta uppercase">
+                    <div
+                      v-if="row.resource_type"
+                      class="hfl-ops-cell-stack__meta uppercase"
+                    >
                       {{ row.resource_type }}
                     </div>
                   </div>
                 </div>
               </template>
             </el-table-column>
-            <el-table-column :label="t('ops.audit.colTime')" width="170">
+            <el-table-column
+              :label="t('ops.audit.colTime')"
+              width="170"
+            >
               <template #default="{ row }">
-                <span class="hfl-table-cell-time" :class="{ 'hfl-empty-mark': !(row.timestamp || row.created_at) }">{{ formatTime(row.timestamp || row.created_at) }}</span>
+                <span
+                  class="hfl-table-cell-time"
+                  :class="{ 'hfl-empty-mark': !(row.timestamp || row.created_at) }"
+                >{{ formatTime(row.timestamp || row.created_at) }}</span>
               </template>
             </el-table-column>
-            <el-table-column :label="t('ops.audit.colUser')" min-width="150" class-name="hfl-audit-user-column">
+            <el-table-column
+              :label="t('ops.audit.colUser')"
+              min-width="150"
+              class-name="hfl-audit-user-column"
+            >
               <template #default="{ row }">
                 <span class="hfl-ops-user-chip hfl-audit-user-cell">
                   <span class="hfl-audit-user-cell__name font-medium text-slate-800">
@@ -535,7 +619,10 @@ watch(
                 </span>
               </template>
             </el-table-column>
-            <el-table-column :label="t('ops.audit.colResult')" width="100">
+            <el-table-column
+              :label="t('ops.audit.colResult')"
+              width="100"
+            >
               <template #default="{ row }">
                 <el-tag
                   class="hfl-ops-result-tag"
@@ -559,7 +646,10 @@ watch(
                 </el-tag>
               </template>
             </el-table-column>
-            <el-table-column :label="t('ops.audit.colResource')" min-width="160">
+            <el-table-column
+              :label="t('ops.audit.colResource')"
+              min-width="160"
+            >
               <template #default="{ row }">
                 <div class="hfl-ops-cell-stack">
                   <div :class="hasDisplayValue(row.resource_name || row.resource_type) ? 'hfl-table-cell-mono' : 'hfl-empty-mark'">
@@ -574,9 +664,16 @@ watch(
                 </div>
               </template>
             </el-table-column>
-            <el-table-column :label="t('ops.audit.colIp')" width="130" prop="ip_address">
+            <el-table-column
+              :label="t('ops.audit.colIp')"
+              width="130"
+              prop="ip_address"
+            >
               <template #default="{ row }">
-                <span class="hfl-table-cell-mono" :class="{ 'hfl-empty-mark': !row.ip_address }">{{ row.ip_address || '—' }}</span>
+                <span
+                  class="hfl-table-cell-mono"
+                  :class="{ 'hfl-empty-mark': !row.ip_address }"
+                >{{ row.ip_address || '—' }}</span>
               </template>
             </el-table-column>
             <el-table-column
@@ -618,7 +715,10 @@ watch(
       class="hfl-audit-filter-drawer"
       @closed="onAdvancedFilterClosed"
     >
-      <el-form label-position="top" class="hfl-audit-filter-form">
+      <el-form
+        label-position="top"
+        class="hfl-audit-filter-form"
+      >
         <el-form-item :label="t('ops.audit.phFilterAction')">
           <el-select
             v-model="advancedFilterDraft.action"
@@ -626,7 +726,12 @@ watch(
             class="w-full"
             :placeholder="t('ops.audit.phFilterAction')"
           >
-            <el-option v-for="a in actionOptions" :key="a" :value="a" :label="actionLabel(a)" />
+            <el-option
+              v-for="a in actionOptions"
+              :key="a"
+              :value="a"
+              :label="actionLabel(a)"
+            />
           </el-select>
         </el-form-item>
         <el-form-item :label="t('ops.audit.phFilterResourceType')">
@@ -651,9 +756,18 @@ watch(
             class="w-full"
             :placeholder="t('ops.audit.phFilterResult')"
           >
-            <el-option value="success" :label="t('ops.audit.resultSuccess')" />
-            <el-option value="failure" :label="t('ops.audit.resultFailure')" />
-            <el-option value="partial" :label="t('ops.audit.resultPartial')" />
+            <el-option
+              value="success"
+              :label="t('ops.audit.resultSuccess')"
+            />
+            <el-option
+              value="failure"
+              :label="t('ops.audit.resultFailure')"
+            />
+            <el-option
+              value="partial"
+              :label="t('ops.audit.resultPartial')"
+            />
           </el-select>
         </el-form-item>
         <el-form-item :label="t('ops.audit.dateCustom')">
@@ -674,10 +788,19 @@ watch(
       </el-form>
       <template #footer>
         <div class="el-drawer__footer-main">
-          <el-button @click="cancelAdvancedFilter">{{ t('ops.audit.cancelFilter') }}</el-button>
+          <el-button @click="cancelAdvancedFilter">
+            {{ t('ops.audit.cancelFilter') }}
+          </el-button>
           <div class="el-drawer__footer-actions">
-            <el-button @click="resetAdvancedFilterDraft">{{ t('ops.audit.resetFilter') }}</el-button>
-            <el-button type="primary" @click="applyAdvancedFilters">{{ t('ops.audit.applyFilter') }}</el-button>
+            <el-button @click="resetAdvancedFilterDraft">
+              {{ t('ops.audit.resetFilter') }}
+            </el-button>
+            <el-button
+              type="primary"
+              @click="applyAdvancedFilters"
+            >
+              {{ t('ops.audit.applyFilter') }}
+            </el-button>
           </div>
         </div>
       </template>
@@ -694,22 +817,36 @@ watch(
         <span class="hfl-detail-drawer__title">{{ t('ops.audit.detailTitle') }}</span>
       </template>
 
-      <div v-if="detailLog" class="hfl-detail-drawer__body">
+      <div
+        v-if="detailLog"
+        class="hfl-detail-drawer__body"
+      >
         <div class="hfl-detail-sections">
           <section class="hfl-detail-section">
-            <h4 class="hfl-detail-section__title">{{ t('ops.audit.detailSectionBasic') }}</h4>
+            <h4 class="hfl-detail-section__title">
+              {{ t('ops.audit.detailSectionBasic') }}
+            </h4>
             <div class="hfl-detail-grid">
               <div class="hfl-detail-row">
                 <span class="hfl-detail-row__label">{{ t('ops.audit.colTime') }}</span>
-                <span class="hfl-detail-row__value" :class="{ 'hfl-detail-row__empty': !(detailLog.timestamp || detailLog.created_at) }">{{ formatTime(detailLog.timestamp || detailLog.created_at) }}</span>
+                <span
+                  class="hfl-detail-row__value"
+                  :class="{ 'hfl-detail-row__empty': !(detailLog.timestamp || detailLog.created_at) }"
+                >{{ formatTime(detailLog.timestamp || detailLog.created_at) }}</span>
               </div>
               <div class="hfl-detail-row">
                 <span class="hfl-detail-row__label">{{ t('ops.audit.colUser') }}</span>
-                <span class="hfl-detail-row__value" :class="{ 'hfl-detail-row__empty': !hasDisplayValue(detailLog.user_display) }">{{ displayValue(detailLog.user_display) }}</span>
+                <span
+                  class="hfl-detail-row__value"
+                  :class="{ 'hfl-detail-row__empty': !hasDisplayValue(detailLog.user_display) }"
+                >{{ displayValue(detailLog.user_display) }}</span>
               </div>
               <div class="hfl-detail-row">
                 <span class="hfl-detail-row__label">{{ t('ops.audit.colAction') }}</span>
-                <span class="hfl-detail-row__value" :class="{ 'hfl-detail-row__empty': !hasDisplayValue(detailLog.action) }">{{ actionLabel(detailLog.action) }}</span>
+                <span
+                  class="hfl-detail-row__value"
+                  :class="{ 'hfl-detail-row__empty': !hasDisplayValue(detailLog.action) }"
+                >{{ actionLabel(detailLog.action) }}</span>
               </div>
               <div class="hfl-detail-row">
                 <span class="hfl-detail-row__label">{{ t('ops.audit.colResult') }}</span>
@@ -733,79 +870,131 @@ watch(
               </div>
               <div class="hfl-detail-row">
                 <span class="hfl-detail-row__label">{{ t('ops.audit.colIp') }}</span>
-                <span class="hfl-detail-row__value" :class="{ 'hfl-detail-row__empty': !hasDisplayValue(detailLog.ip_address) }">{{ displayValue(detailLog.ip_address) }}</span>
+                <span
+                  class="hfl-detail-row__value"
+                  :class="{ 'hfl-detail-row__empty': !hasDisplayValue(detailLog.ip_address) }"
+                >{{ displayValue(detailLog.ip_address) }}</span>
               </div>
               <div class="hfl-detail-row">
                 <span class="hfl-detail-row__label">{{ t('ops.audit.colOrg') }}</span>
-                <span class="hfl-detail-row__value" :class="{ 'hfl-detail-row__empty': !hasDisplayValue(detailLog.organization_name || detailLog.organization) }">{{ displayValue(detailLog.organization_name || detailLog.organization) }}</span>
+                <span
+                  class="hfl-detail-row__value"
+                  :class="{ 'hfl-detail-row__empty': !hasDisplayValue(detailLog.organization_name || detailLog.organization) }"
+                >{{ displayValue(detailLog.organization_name || detailLog.organization) }}</span>
               </div>
             </div>
           </section>
 
           <section class="hfl-detail-section">
-            <h4 class="hfl-detail-section__title">{{ t('ops.audit.detailSectionResource') }}</h4>
+            <h4 class="hfl-detail-section__title">
+              {{ t('ops.audit.detailSectionResource') }}
+            </h4>
             <div class="hfl-detail-grid">
               <div class="hfl-detail-row">
                 <span class="hfl-detail-row__label">{{ t('ops.audit.phFilterResourceType') }}</span>
-                <span class="hfl-detail-row__value" :class="{ 'hfl-detail-row__empty': !hasDisplayValue(detailLog.resource_type) }">{{ displayValue(detailLog.resource_type) }}</span>
+                <span
+                  class="hfl-detail-row__value"
+                  :class="{ 'hfl-detail-row__empty': !hasDisplayValue(detailLog.resource_type) }"
+                >{{ displayValue(detailLog.resource_type) }}</span>
               </div>
               <div class="hfl-detail-row">
                 <span class="hfl-detail-row__label">{{ t('ops.audit.colResourceName') }}</span>
-                <span class="hfl-detail-row__value" :class="{ 'hfl-detail-row__empty': !hasDisplayValue(detailLog.resource_name) }">{{ displayValue(detailLog.resource_name) }}</span>
+                <span
+                  class="hfl-detail-row__value"
+                  :class="{ 'hfl-detail-row__empty': !hasDisplayValue(detailLog.resource_name) }"
+                >{{ displayValue(detailLog.resource_name) }}</span>
               </div>
               <div class="hfl-detail-row">
                 <span class="hfl-detail-row__label">{{ t('ops.audit.detailResourceId') }}</span>
-                <span class="hfl-detail-row__value" :class="hasDisplayValue(detailLog.resource_id) ? 'hfl-table-cell-mono' : 'hfl-empty-mark'">{{ displayValue(detailLog.resource_id) }}</span>
+                <span
+                  class="hfl-detail-row__value"
+                  :class="hasDisplayValue(detailLog.resource_id) ? 'hfl-table-cell-mono' : 'hfl-empty-mark'"
+                >{{ displayValue(detailLog.resource_id) }}</span>
               </div>
               <div class="hfl-detail-row">
                 <span class="hfl-detail-row__label">{{ t('ops.audit.detailTargetType') }}</span>
-                <span class="hfl-detail-row__value" :class="{ 'hfl-detail-row__empty': !hasDisplayValue(detailLog.target_type) }">{{ displayValue(detailLog.target_type) }}</span>
+                <span
+                  class="hfl-detail-row__value"
+                  :class="{ 'hfl-detail-row__empty': !hasDisplayValue(detailLog.target_type) }"
+                >{{ displayValue(detailLog.target_type) }}</span>
               </div>
               <div class="hfl-detail-row">
                 <span class="hfl-detail-row__label">{{ t('ops.audit.detailTargetId') }}</span>
-                <span class="hfl-detail-row__value" :class="hasDisplayValue(detailLog.target_id) ? 'hfl-table-cell-mono' : 'hfl-empty-mark'">{{ displayValue(detailLog.target_id) }}</span>
+                <span
+                  class="hfl-detail-row__value"
+                  :class="hasDisplayValue(detailLog.target_id) ? 'hfl-table-cell-mono' : 'hfl-empty-mark'"
+                >{{ displayValue(detailLog.target_id) }}</span>
               </div>
               <div class="hfl-detail-row">
                 <span class="hfl-detail-row__label">{{ t('ops.audit.colId') }}</span>
-                <span class="hfl-detail-row__value hfl-table-cell-mono" :class="{ 'hfl-detail-row__empty': !hasDisplayValue(detailLog.id) }">{{ displayValue(detailLog.id) }}</span>
+                <span
+                  class="hfl-detail-row__value hfl-table-cell-mono"
+                  :class="{ 'hfl-detail-row__empty': !hasDisplayValue(detailLog.id) }"
+                >{{ displayValue(detailLog.id) }}</span>
               </div>
             </div>
           </section>
 
           <section class="hfl-detail-section">
-            <h4 class="hfl-detail-section__title">{{ t('ops.audit.detailSectionRequest') }}</h4>
+            <h4 class="hfl-detail-section__title">
+              {{ t('ops.audit.detailSectionRequest') }}
+            </h4>
             <div class="hfl-detail-grid">
               <div class="hfl-detail-row">
                 <span class="hfl-detail-row__label">{{ t('ops.audit.detailRequestMethod') }}</span>
-                <span class="hfl-detail-row__value" :class="hasDisplayValue(detailLog.request_method) ? 'hfl-table-cell-mono' : 'hfl-empty-mark'">{{ displayValue(detailLog.request_method) }}</span>
+                <span
+                  class="hfl-detail-row__value"
+                  :class="hasDisplayValue(detailLog.request_method) ? 'hfl-table-cell-mono' : 'hfl-empty-mark'"
+                >{{ displayValue(detailLog.request_method) }}</span>
               </div>
               <div class="hfl-detail-row">
                 <span class="hfl-detail-row__label">{{ t('ops.audit.requestPath') }}</span>
-                <span class="hfl-detail-row__value" :class="hasDisplayValue(detailLog.request_path) ? 'hfl-table-cell-mono' : 'hfl-empty-mark'">{{ displayValue(detailLog.request_path) }}</span>
+                <span
+                  class="hfl-detail-row__value"
+                  :class="hasDisplayValue(detailLog.request_path) ? 'hfl-table-cell-mono' : 'hfl-empty-mark'"
+                >{{ displayValue(detailLog.request_path) }}</span>
               </div>
               <div class="hfl-detail-row">
                 <span class="hfl-detail-row__label">{{ t('ops.audit.detailRequestId') }}</span>
-                <span class="hfl-detail-row__value" :class="hasDisplayValue(detailLog.request_id) ? 'hfl-table-cell-mono' : 'hfl-empty-mark'">{{ displayValue(detailLog.request_id) }}</span>
+                <span
+                  class="hfl-detail-row__value"
+                  :class="hasDisplayValue(detailLog.request_id) ? 'hfl-table-cell-mono' : 'hfl-empty-mark'"
+                >{{ displayValue(detailLog.request_id) }}</span>
               </div>
               <div class="hfl-detail-row">
                 <span class="hfl-detail-row__label">{{ t('ops.audit.colCorrelationId') }}</span>
-                <span class="hfl-detail-row__value" :class="hasDisplayValue(detailLog.correlation_id) ? 'hfl-table-cell-mono' : 'hfl-empty-mark'">{{ displayValue(detailLog.correlation_id) }}</span>
+                <span
+                  class="hfl-detail-row__value"
+                  :class="hasDisplayValue(detailLog.correlation_id) ? 'hfl-table-cell-mono' : 'hfl-empty-mark'"
+                >{{ displayValue(detailLog.correlation_id) }}</span>
               </div>
               <div class="hfl-detail-row">
                 <span class="hfl-detail-row__label">{{ t('ops.audit.detailSessionId') }}</span>
-                <span class="hfl-detail-row__value" :class="hasDisplayValue(detailLog.session_id) ? 'hfl-table-cell-mono' : 'hfl-empty-mark'">{{ displayValue(detailLog.session_id) }}</span>
+                <span
+                  class="hfl-detail-row__value"
+                  :class="hasDisplayValue(detailLog.session_id) ? 'hfl-table-cell-mono' : 'hfl-empty-mark'"
+                >{{ displayValue(detailLog.session_id) }}</span>
               </div>
               <div class="hfl-detail-row">
                 <span class="hfl-detail-row__label">{{ t('ops.audit.detailErrorCode') }}</span>
-                <span class="hfl-detail-row__value" :class="hasDisplayValue(detailLog.error_code) ? 'hfl-table-cell-mono' : 'hfl-empty-mark'">{{ displayValue(detailLog.error_code) }}</span>
+                <span
+                  class="hfl-detail-row__value"
+                  :class="hasDisplayValue(detailLog.error_code) ? 'hfl-table-cell-mono' : 'hfl-empty-mark'"
+                >{{ displayValue(detailLog.error_code) }}</span>
               </div>
               <div class="hfl-detail-row hfl-detail-row--full">
                 <span class="hfl-detail-row__label">{{ t('ops.audit.userAgent') }}</span>
-                <span class="hfl-detail-row__value" :class="{ 'hfl-detail-row__empty': !hasDisplayValue(detailLog.user_agent) }">{{ displayValue(detailLog.user_agent) }}</span>
+                <span
+                  class="hfl-detail-row__value"
+                  :class="{ 'hfl-detail-row__empty': !hasDisplayValue(detailLog.user_agent) }"
+                >{{ displayValue(detailLog.user_agent) }}</span>
               </div>
               <div class="hfl-detail-row hfl-detail-row--full">
                 <span class="hfl-detail-row__label">{{ t('ops.audit.errorMessage') }}</span>
-                <span class="hfl-detail-row__value" :class="{ 'text-red-600': detailLog.error_message, 'hfl-detail-row__empty': !hasDisplayValue(detailLog.error_message) }">
+                <span
+                  class="hfl-detail-row__value"
+                  :class="{ 'text-red-600': detailLog.error_message, 'hfl-detail-row__empty': !hasDisplayValue(detailLog.error_message) }"
+                >
                   {{ displayValue(detailLog.error_message) }}
                 </span>
               </div>
@@ -813,38 +1002,67 @@ watch(
           </section>
 
           <section class="hfl-detail-section">
-            <h4 class="hfl-detail-section__title">{{ t('ops.audit.detailSectionPayload') }}</h4>
+            <h4 class="hfl-detail-section__title">
+              {{ t('ops.audit.detailSectionPayload') }}
+            </h4>
             <div class="hfl-detail-grid">
               <div class="hfl-detail-row hfl-detail-row--full">
                 <span class="hfl-detail-row__label">{{ t('ops.audit.colDetails') }}</span>
-                <span class="hfl-detail-row__value" :class="{ 'hfl-detail-row__empty': !hasDisplayValue(detailLog.details) }">{{ displayValue(detailLog.details) }}</span>
+                <span
+                  class="hfl-detail-row__value"
+                  :class="{ 'hfl-detail-row__empty': !hasDisplayValue(detailLog.details) }"
+                >{{ displayValue(detailLog.details) }}</span>
               </div>
               <div class="hfl-detail-row hfl-detail-row--full">
                 <span class="hfl-detail-row__label">{{ t('ops.audit.changes') }}</span>
                 <span class="hfl-detail-row__value hfl-detail-row__value--stacked">
-                  <pre v-if="hasObjectValue(detailLog.changes)" class="hfl-audit-detail-json">{{ formatJson(detailLog.changes) }}</pre>
-                  <span v-else class="hfl-empty-mark">{{ t('ops.audit.emptyMark') }}</span>
+                  <pre
+                    v-if="hasObjectValue(detailLog.changes)"
+                    class="hfl-audit-detail-json"
+                  >{{ formatJson(detailLog.changes) }}</pre>
+                  <span
+                    v-else
+                    class="hfl-empty-mark"
+                  >{{ t('ops.audit.emptyMark') }}</span>
                 </span>
               </div>
               <div class="hfl-detail-row hfl-detail-row--full">
                 <span class="hfl-detail-row__label">{{ t('ops.audit.queryParams') }}</span>
                 <span class="hfl-detail-row__value hfl-detail-row__value--stacked">
-                  <pre v-if="hasObjectValue(detailLog.request_query)" class="hfl-audit-detail-json">{{ formatJson(detailLog.request_query) }}</pre>
-                  <span v-else class="hfl-empty-mark">{{ t('ops.audit.emptyMark') }}</span>
+                  <pre
+                    v-if="hasObjectValue(detailLog.request_query)"
+                    class="hfl-audit-detail-json"
+                  >{{ formatJson(detailLog.request_query) }}</pre>
+                  <span
+                    v-else
+                    class="hfl-empty-mark"
+                  >{{ t('ops.audit.emptyMark') }}</span>
                 </span>
               </div>
               <div class="hfl-detail-row hfl-detail-row--full">
                 <span class="hfl-detail-row__label">{{ t('ops.audit.requestBody') }}</span>
                 <span class="hfl-detail-row__value hfl-detail-row__value--stacked">
-                  <pre v-if="hasObjectValue(detailLog.request_body)" class="hfl-audit-detail-json">{{ formatJson(detailLog.request_body) }}</pre>
-                  <span v-else class="hfl-empty-mark">{{ t('ops.audit.emptyMark') }}</span>
+                  <pre
+                    v-if="hasObjectValue(detailLog.request_body)"
+                    class="hfl-audit-detail-json"
+                  >{{ formatJson(detailLog.request_body) }}</pre>
+                  <span
+                    v-else
+                    class="hfl-empty-mark"
+                  >{{ t('ops.audit.emptyMark') }}</span>
                 </span>
               </div>
               <div class="hfl-detail-row hfl-detail-row--full">
                 <span class="hfl-detail-row__label">{{ t('ops.audit.metadata') }}</span>
                 <span class="hfl-detail-row__value hfl-detail-row__value--stacked">
-                  <pre v-if="hasObjectValue(detailLog.metadata)" class="hfl-audit-detail-json">{{ formatJson(detailLog.metadata) }}</pre>
-                  <span v-else class="hfl-empty-mark">{{ t('ops.audit.emptyMark') }}</span>
+                  <pre
+                    v-if="hasObjectValue(detailLog.metadata)"
+                    class="hfl-audit-detail-json"
+                  >{{ formatJson(detailLog.metadata) }}</pre>
+                  <span
+                    v-else
+                    class="hfl-empty-mark"
+                  >{{ t('ops.audit.emptyMark') }}</span>
                 </span>
               </div>
             </div>

--- a/src/frontend/src/pages/ops/NotificationChannelEditorPage.vue
+++ b/src/frontend/src/pages/ops/NotificationChannelEditorPage.vue
@@ -275,15 +275,29 @@ watch(() => form.type, () => {
 </script>
 
 <template>
-  <div ref="pageRef" class="fullscreen-form-fullscreen resource-add-fullscreen">
+  <div
+    ref="pageRef"
+    class="fullscreen-form-fullscreen resource-add-fullscreen"
+  >
     <div class="fullscreen-form-page add-s3-page">
       <div class="fullscreen-form-header">
-        <button type="button" class="fullscreen-form-header__back" @click="handleBack">
-          <ArrowLeft class="fullscreen-form-header__back-icon" :size="18" />
+        <button
+          type="button"
+          class="fullscreen-form-header__back"
+          @click="handleBack"
+        >
+          <ArrowLeft
+            class="fullscreen-form-header__back-icon"
+            :size="18"
+          />
         </button>
         <div class="fullscreen-form-header__content">
-          <h1 class="fullscreen-form-header__title">{{ pageTitle }}</h1>
-          <p class="fullscreen-form-header__desc">{{ t('ops.notification.modalSubtitle') }}</p>
+          <h1 class="fullscreen-form-header__title">
+            {{ pageTitle }}
+          </h1>
+          <p class="fullscreen-form-header__desc">
+            {{ t('ops.notification.modalSubtitle') }}
+          </p>
         </div>
       </div>
 
@@ -314,10 +328,20 @@ watch(() => form.type, () => {
                       v-model="form.name"
                       :placeholder="t('ops.notification.phChannelNameEmail')"
                     />
-                    <p class="fullscreen-form-field__hint">{{ t('ops.notification.tipChannelName') }}</p>
+                    <p class="fullscreen-form-field__hint">
+                      {{ t('ops.notification.tipChannelName') }}
+                    </p>
                   </el-form-item>
-                  <el-form-item :label="t('ops.notification.formChannelType')" required class="fullscreen-form-item--in-card">
-                    <el-select v-model="form.type" class="w-full" :disabled="!!editingId">
+                  <el-form-item
+                    :label="t('ops.notification.formChannelType')"
+                    required
+                    class="fullscreen-form-item--in-card"
+                  >
+                    <el-select
+                      v-model="form.type"
+                      class="w-full"
+                      :disabled="!!editingId"
+                    >
                       <el-option
                         v-for="opt in typeOptions"
                         :key="opt.value"
@@ -325,15 +349,22 @@ watch(() => form.type, () => {
                         :label="opt.label"
                       />
                     </el-select>
-                    <p class="fullscreen-form-field__hint">{{ t('ops.notification.tipChannelType') }}</p>
+                    <p class="fullscreen-form-field__hint">
+                      {{ t('ops.notification.tipChannelType') }}
+                    </p>
                   </el-form-item>
-                  <el-form-item :label="t('ops.notification.formEnabled')" class="fullscreen-form-status-item">
+                  <el-form-item
+                    :label="t('ops.notification.formEnabled')"
+                    class="fullscreen-form-status-item"
+                  >
                     <el-switch
                       v-model="form.enabled"
                       :active-text="t('ops.notification.statusEnabled')"
                       :inactive-text="t('ops.notification.statusDisabled')"
                     />
-                    <p class="fullscreen-form-field__hint">{{ t('ops.notification.tipEnabled') }}</p>
+                    <p class="fullscreen-form-field__hint">
+                      {{ t('ops.notification.tipEnabled') }}
+                    </p>
                   </el-form-item>
                 </div>
               </section>
@@ -344,221 +375,374 @@ watch(() => form.type, () => {
                   {{ t('ops.notification.sectionTarget') }}
                 </h3>
 
-              <template v-if="form.type === 'email'">
-                <div class="fullscreen-form-grid">
+                <template v-if="form.type === 'email'">
+                  <div class="fullscreen-form-grid">
+                    <el-form-item
+                      :label="t('ops.notification.emailSmtpHost')"
+                      prop="email.smtp_host"
+                      class="fullscreen-form-item--in-card"
+                      data-notification-channel-field="email.smtp_host"
+                    >
+                      <el-input
+                        v-model="form.email.smtp_host"
+                        :placeholder="t('ops.notification.phSmtpHost')"
+                      />
+                      <p class="fullscreen-form-field__hint">
+                        {{ t('ops.notification.tipSmtpHost') }}
+                      </p>
+                    </el-form-item>
+                    <el-form-item
+                      :label="t('ops.notification.emailSmtpPort')"
+                      prop="email.smtp_port"
+                      class="fullscreen-form-item--in-card"
+                      data-notification-channel-field="email.smtp_port"
+                    >
+                      <el-input
+                        v-model="form.email.smtp_port"
+                        :placeholder="t('ops.notification.phSmtpPort')"
+                      />
+                      <p class="fullscreen-form-field__hint">
+                        {{ t('ops.notification.tipSmtpPort') }}
+                      </p>
+                    </el-form-item>
+                    <el-form-item
+                      :label="t('ops.notification.emailSmtpUsername')"
+                      class="fullscreen-form-item--in-card"
+                    >
+                      <el-input
+                        v-model="form.email.smtp_username"
+                        :placeholder="t('ops.notification.phSmtpUsername')"
+                      />
+                      <p class="fullscreen-form-field__hint">
+                        {{ t('ops.notification.tipSmtpUsername') }}
+                      </p>
+                    </el-form-item>
+                    <el-form-item
+                      :label="t('ops.notification.emailSmtpPassword')"
+                      class="fullscreen-form-item--in-card"
+                    >
+                      <el-input
+                        v-model="form.email.smtp_password"
+                        type="password"
+                        show-password
+                        :placeholder="t('ops.notification.phSmtpPassword')"
+                      />
+                      <p class="fullscreen-form-field__hint">
+                        {{ t('ops.notification.tipSmtpPassword') }}
+                      </p>
+                    </el-form-item>
+                  </div>
                   <el-form-item
-                    :label="t('ops.notification.emailSmtpHost')"
-                    prop="email.smtp_host"
+                    :label="t('ops.notification.emailFrom')"
+                    prop="email.from_email"
                     class="fullscreen-form-item--in-card"
-                    data-notification-channel-field="email.smtp_host"
+                    data-notification-channel-field="email.from_email"
                   >
-                    <el-input v-model="form.email.smtp_host" :placeholder="t('ops.notification.phSmtpHost')" />
-                    <p class="fullscreen-form-field__hint">{{ t('ops.notification.tipSmtpHost') }}</p>
-                  </el-form-item>
-                  <el-form-item
-                    :label="t('ops.notification.emailSmtpPort')"
-                    prop="email.smtp_port"
-                    class="fullscreen-form-item--in-card"
-                    data-notification-channel-field="email.smtp_port"
-                  >
-                    <el-input v-model="form.email.smtp_port" :placeholder="t('ops.notification.phSmtpPort')" />
-                    <p class="fullscreen-form-field__hint">{{ t('ops.notification.tipSmtpPort') }}</p>
-                  </el-form-item>
-                  <el-form-item :label="t('ops.notification.emailSmtpUsername')" class="fullscreen-form-item--in-card">
                     <el-input
-                      v-model="form.email.smtp_username"
-                      :placeholder="t('ops.notification.phSmtpUsername')"
+                      v-model="form.email.from_email"
+                      :placeholder="t('ops.notification.phFromEmail')"
                     />
-                    <p class="fullscreen-form-field__hint">{{ t('ops.notification.tipSmtpUsername') }}</p>
+                    <p class="fullscreen-form-field__hint">
+                      {{ t('ops.notification.tipEmailFrom') }}
+                    </p>
                   </el-form-item>
-                  <el-form-item :label="t('ops.notification.emailSmtpPassword')" class="fullscreen-form-item--in-card">
+                  <el-form-item
+                    :label="t('ops.notification.emailSubjectOptional')"
+                    class="fullscreen-form-item--in-card"
+                  >
                     <el-input
-                      v-model="form.email.smtp_password"
+                      v-model="form.email.email_subject"
+                      :placeholder="t('ops.notification.phEmailSubject')"
+                    />
+                    <p class="fullscreen-form-field__hint">
+                      {{ t('ops.notification.tipEmailSubject') }}
+                    </p>
+                  </el-form-item>
+                  <el-form-item
+                    :label="t('ops.notification.emailTo')"
+                    prop="email.to_emails"
+                    class="fullscreen-form-item--in-card"
+                    data-notification-channel-field="email.to_emails"
+                  >
+                    <el-input
+                      v-model="form.email.to_emails"
+                      :placeholder="t('ops.notification.phRecipientsComma')"
+                    />
+                    <p class="fullscreen-form-field__hint">
+                      {{ t('ops.notification.tipEmailRecipients') }}
+                    </p>
+                  </el-form-item>
+                  <el-form-item
+                    :label="t('ops.notification.emailEncryption')"
+                    class="fullscreen-form-item--in-card"
+                  >
+                    <el-select
+                      v-model="form.email.encryption"
+                      class="w-full"
+                    >
+                      <el-option
+                        v-for="opt in emailEncryptionOptions"
+                        :key="opt.value"
+                        :value="opt.value"
+                        :label="opt.label"
+                      />
+                    </el-select>
+                    <p class="fullscreen-form-field__hint">
+                      {{ t('ops.notification.tipEmailEncryption') }}
+                    </p>
+                  </el-form-item>
+                </template>
+
+                <template v-else-if="form.type === 'webhook'">
+                  <el-form-item
+                    :label="t('ops.notification.formWebhookUrl')"
+                    prop="webhook.url"
+                    class="fullscreen-form-item--in-card"
+                    data-notification-channel-field="webhook.url"
+                  >
+                    <el-input
+                      v-model="form.webhook.url"
+                      :placeholder="t('ops.notification.phWebhookUrl')"
+                    />
+                    <p class="fullscreen-form-field__hint">
+                      {{ t('ops.notification.tipWebhookUrl') }}
+                    </p>
+                  </el-form-item>
+                  <div class="fullscreen-form-grid">
+                    <el-form-item
+                      :label="t('ops.notification.webhookMethod')"
+                      class="fullscreen-form-item--in-card"
+                    >
+                      <el-select
+                        v-model="form.webhook.method"
+                        class="w-full"
+                      >
+                        <el-option
+                          value="POST"
+                          label="POST"
+                        />
+                        <el-option
+                          value="PUT"
+                          label="PUT"
+                        />
+                      </el-select>
+                      <p class="fullscreen-form-field__hint">
+                        {{ t('ops.notification.tipWebhookMethod') }}
+                      </p>
+                    </el-form-item>
+                    <el-form-item
+                      :label="t('ops.notification.webhookTimeout')"
+                      class="fullscreen-form-item--in-card"
+                    >
+                      <el-input-number
+                        v-model="form.webhook.timeout"
+                        class="w-full"
+                        :min="1"
+                        :max="120"
+                      />
+                      <p class="fullscreen-form-field__hint">
+                        {{ t('ops.notification.tipWebhookTimeout') }}
+                      </p>
+                    </el-form-item>
+                  </div>
+                  <el-form-item
+                    :label="t('ops.notification.webhookHeaders')"
+                    class="fullscreen-form-item--in-card"
+                  >
+                    <el-input
+                      v-model="form.webhook.headers"
+                      type="textarea"
+                      :rows="4"
+                      :placeholder="t('ops.notification.phWebhookHeaders')"
+                    />
+                    <p class="fullscreen-form-field__hint">
+                      {{ t('ops.notification.tipWebhookHeaders') }}
+                    </p>
+                  </el-form-item>
+                </template>
+
+                <template v-else-if="form.type === 'dingtalk'">
+                  <el-form-item
+                    :label="t('ops.notification.formWebhookUrl')"
+                    prop="dingtalk.webhook_url"
+                    class="fullscreen-form-item--in-card"
+                    data-notification-channel-field="dingtalk.webhook_url"
+                  >
+                    <el-input
+                      v-model="form.dingtalk.webhook_url"
+                      :placeholder="t('ops.notification.phWebhookUrl')"
+                    />
+                    <p class="fullscreen-form-field__hint">
+                      {{ t('ops.notification.tipWebhookUrl') }}
+                    </p>
+                  </el-form-item>
+                  <el-form-item
+                    :label="t('ops.notification.formSecret')"
+                    class="fullscreen-form-item--in-card"
+                  >
+                    <el-input
+                      v-model="form.dingtalk.secret"
                       type="password"
                       show-password
-                      :placeholder="t('ops.notification.phSmtpPassword')"
+                      :placeholder="t('ops.notification.phSecret')"
                     />
-                    <p class="fullscreen-form-field__hint">{{ t('ops.notification.tipSmtpPassword') }}</p>
+                    <p class="fullscreen-form-field__hint">
+                      {{ t('ops.notification.tipSecret') }}
+                    </p>
                   </el-form-item>
-                </div>
-                <el-form-item
-                  :label="t('ops.notification.emailFrom')"
-                  prop="email.from_email"
-                  class="fullscreen-form-item--in-card"
-                  data-notification-channel-field="email.from_email"
-                >
-                  <el-input v-model="form.email.from_email" :placeholder="t('ops.notification.phFromEmail')" />
-                  <p class="fullscreen-form-field__hint">{{ t('ops.notification.tipEmailFrom') }}</p>
-                </el-form-item>
-                <el-form-item :label="t('ops.notification.emailSubjectOptional')" class="fullscreen-form-item--in-card">
-                  <el-input
-                    v-model="form.email.email_subject"
-                    :placeholder="t('ops.notification.phEmailSubject')"
-                  />
-                  <p class="fullscreen-form-field__hint">{{ t('ops.notification.tipEmailSubject') }}</p>
-                </el-form-item>
-                <el-form-item
-                  :label="t('ops.notification.emailTo')"
-                  prop="email.to_emails"
-                  class="fullscreen-form-item--in-card"
-                  data-notification-channel-field="email.to_emails"
-                >
-                  <el-input
-                    v-model="form.email.to_emails"
-                    :placeholder="t('ops.notification.phRecipientsComma')"
-                  />
-                  <p class="fullscreen-form-field__hint">{{ t('ops.notification.tipEmailRecipients') }}</p>
-                </el-form-item>
-                <el-form-item :label="t('ops.notification.emailEncryption')" class="fullscreen-form-item--in-card">
-                  <el-select v-model="form.email.encryption" class="w-full">
-                    <el-option
-                      v-for="opt in emailEncryptionOptions"
-                      :key="opt.value"
-                      :value="opt.value"
-                      :label="opt.label"
+                  <div class="fullscreen-form-grid">
+                    <el-form-item
+                      :label="t('ops.notification.formAtMobiles')"
+                      class="fullscreen-form-item--in-card"
+                    >
+                      <el-input
+                        v-model="form.dingtalk.at_mobiles"
+                        :placeholder="t('ops.notification.phAtMobiles')"
+                      />
+                      <p class="fullscreen-form-field__hint">
+                        {{ t('ops.notification.tipDingtalkAtMobiles') }}
+                      </p>
+                    </el-form-item>
+                    <el-form-item
+                      :label="t('ops.notification.formAtUserIds')"
+                      class="fullscreen-form-item--in-card"
+                    >
+                      <el-input
+                        v-model="form.dingtalk.at_user_ids"
+                        :placeholder="t('ops.notification.phAtUserIds')"
+                      />
+                      <p class="fullscreen-form-field__hint">
+                        {{ t('ops.notification.tipDingtalkAtUserIds') }}
+                      </p>
+                    </el-form-item>
+                  </div>
+                  <el-form-item
+                    :label="t('ops.notification.formAtAll')"
+                    class="fullscreen-form-status-item"
+                  >
+                    <el-switch
+                      v-model="form.dingtalk.is_at_all"
+                      :active-text="t('ops.notification.statusEnabled')"
+                      :inactive-text="t('ops.notification.statusDisabled')"
                     />
-                  </el-select>
-                  <p class="fullscreen-form-field__hint">{{ t('ops.notification.tipEmailEncryption') }}</p>
-                </el-form-item>
-              </template>
+                    <p class="fullscreen-form-field__hint">
+                      {{ t('ops.notification.tipAtAll') }}
+                    </p>
+                  </el-form-item>
+                </template>
 
-              <template v-else-if="form.type === 'webhook'">
-                <el-form-item
-                  :label="t('ops.notification.formWebhookUrl')"
-                  prop="webhook.url"
-                  class="fullscreen-form-item--in-card"
-                  data-notification-channel-field="webhook.url"
-                >
-                  <el-input v-model="form.webhook.url" :placeholder="t('ops.notification.phWebhookUrl')" />
-                  <p class="fullscreen-form-field__hint">{{ t('ops.notification.tipWebhookUrl') }}</p>
-                </el-form-item>
-                <div class="fullscreen-form-grid">
-                  <el-form-item :label="t('ops.notification.webhookMethod')" class="fullscreen-form-item--in-card">
-                    <el-select v-model="form.webhook.method" class="w-full">
-                      <el-option value="POST" label="POST" />
-                      <el-option value="PUT" label="PUT" />
-                    </el-select>
-                    <p class="fullscreen-form-field__hint">{{ t('ops.notification.tipWebhookMethod') }}</p>
+                <template v-else-if="form.type === 'sms'">
+                  <el-form-item
+                    :label="t('ops.notification.smsApiUrl')"
+                    prop="sms.url"
+                    class="fullscreen-form-item--in-card"
+                    data-notification-channel-field="sms.url"
+                  >
+                    <el-input
+                      v-model="form.sms.url"
+                      :placeholder="t('ops.notification.phSmsApiUrl')"
+                    />
+                    <p class="fullscreen-form-field__hint">
+                      {{ t('ops.notification.tipSmsApiUrl') }}
+                    </p>
                   </el-form-item>
-                  <el-form-item :label="t('ops.notification.webhookTimeout')" class="fullscreen-form-item--in-card">
-                    <el-input-number v-model="form.webhook.timeout" class="w-full" :min="1" :max="120" />
-                    <p class="fullscreen-form-field__hint">{{ t('ops.notification.tipWebhookTimeout') }}</p>
+                  <el-form-item
+                    :label="t('ops.notification.smsPhoneNumbers')"
+                    prop="sms.phone_numbers"
+                    class="fullscreen-form-item--in-card"
+                    data-notification-channel-field="sms.phone_numbers"
+                  >
+                    <el-input
+                      v-model="form.sms.phone_numbers"
+                      :placeholder="t('ops.notification.phSmsPhoneNumbers')"
+                    />
+                    <p class="fullscreen-form-field__hint">
+                      {{ t('ops.notification.tipSmsPhoneNumbers') }}
+                    </p>
                   </el-form-item>
-                </div>
-                <el-form-item :label="t('ops.notification.webhookHeaders')" class="fullscreen-form-item--in-card">
-                  <el-input
-                    v-model="form.webhook.headers"
-                    type="textarea"
-                    :rows="4"
-                    :placeholder="t('ops.notification.phWebhookHeaders')"
-                  />
-                  <p class="fullscreen-form-field__hint">{{ t('ops.notification.tipWebhookHeaders') }}</p>
-                </el-form-item>
-              </template>
+                  <el-form-item
+                    :label="t('ops.notification.smsApiKey')"
+                    class="fullscreen-form-item--in-card"
+                  >
+                    <el-input
+                      v-model="form.sms.api_key"
+                      type="password"
+                      show-password
+                    />
+                    <p class="fullscreen-form-field__hint">
+                      {{ t('ops.notification.tipSmsApiKey') }}
+                    </p>
+                  </el-form-item>
+                  <el-form-item
+                    :label="t('ops.notification.smsMessageTemplate')"
+                    class="fullscreen-form-item--in-card"
+                  >
+                    <el-input
+                      v-model="form.sms.message_template"
+                      :placeholder="t('ops.notification.phSmsMessageTemplate')"
+                    />
+                    <p class="fullscreen-form-field__hint">
+                      {{ t('ops.notification.tipSmsMessageTemplate') }}
+                    </p>
+                  </el-form-item>
+                </template>
 
-              <template v-else-if="form.type === 'dingtalk'">
-                <el-form-item
-                  :label="t('ops.notification.formWebhookUrl')"
-                  prop="dingtalk.webhook_url"
-                  class="fullscreen-form-item--in-card"
-                  data-notification-channel-field="dingtalk.webhook_url"
-                >
-                  <el-input v-model="form.dingtalk.webhook_url" :placeholder="t('ops.notification.phWebhookUrl')" />
-                  <p class="fullscreen-form-field__hint">{{ t('ops.notification.tipWebhookUrl') }}</p>
-                </el-form-item>
-                <el-form-item :label="t('ops.notification.formSecret')" class="fullscreen-form-item--in-card">
-                  <el-input
-                    v-model="form.dingtalk.secret"
-                    type="password"
-                    show-password
-                    :placeholder="t('ops.notification.phSecret')"
-                  />
-                  <p class="fullscreen-form-field__hint">{{ t('ops.notification.tipSecret') }}</p>
-                </el-form-item>
-                <div class="fullscreen-form-grid">
-                  <el-form-item :label="t('ops.notification.formAtMobiles')" class="fullscreen-form-item--in-card">
-                    <el-input v-model="form.dingtalk.at_mobiles" :placeholder="t('ops.notification.phAtMobiles')" />
-                    <p class="fullscreen-form-field__hint">{{ t('ops.notification.tipDingtalkAtMobiles') }}</p>
+                <template v-else>
+                  <el-form-item
+                    :label="t('ops.notification.formWebhookUrl')"
+                    prop="wecom.webhook_url"
+                    class="fullscreen-form-item--in-card"
+                    data-notification-channel-field="wecom.webhook_url"
+                  >
+                    <el-input
+                      v-model="form.wecom.webhook_url"
+                      :placeholder="t('ops.notification.phWebhookUrl')"
+                    />
+                    <p class="fullscreen-form-field__hint">
+                      {{ t('ops.notification.tipWebhookUrl') }}
+                    </p>
                   </el-form-item>
-                  <el-form-item :label="t('ops.notification.formAtUserIds')" class="fullscreen-form-item--in-card">
-                    <el-input v-model="form.dingtalk.at_user_ids" :placeholder="t('ops.notification.phAtUserIds')" />
-                    <p class="fullscreen-form-field__hint">{{ t('ops.notification.tipDingtalkAtUserIds') }}</p>
+                  <div class="fullscreen-form-grid">
+                    <el-form-item
+                      :label="t('ops.notification.formMentionedList')"
+                      class="fullscreen-form-item--in-card"
+                    >
+                      <el-input
+                        v-model="form.wecom.mentioned_list"
+                        :placeholder="t('ops.notification.phMentionedList')"
+                        :disabled="form.wecom.is_at_all"
+                      />
+                      <p class="fullscreen-form-field__hint">
+                        {{ t('ops.notification.tipWecomMentionedList') }}
+                      </p>
+                    </el-form-item>
+                    <el-form-item
+                      :label="t('ops.notification.formMentionedMobileList')"
+                      class="fullscreen-form-item--in-card"
+                    >
+                      <el-input
+                        v-model="form.wecom.mentioned_mobile_list"
+                        :placeholder="t('ops.notification.phAtMobiles')"
+                      />
+                      <p class="fullscreen-form-field__hint">
+                        {{ t('ops.notification.tipWecomMentionedMobileList') }}
+                      </p>
+                    </el-form-item>
+                  </div>
+                  <el-form-item
+                    :label="t('ops.notification.formAtAll')"
+                    class="fullscreen-form-status-item"
+                  >
+                    <el-switch
+                      v-model="form.wecom.is_at_all"
+                      :active-text="t('ops.notification.statusEnabled')"
+                      :inactive-text="t('ops.notification.statusDisabled')"
+                    />
+                    <p class="fullscreen-form-field__hint">
+                      {{ t('ops.notification.tipAtAll') }}
+                    </p>
                   </el-form-item>
-                </div>
-                <el-form-item :label="t('ops.notification.formAtAll')" class="fullscreen-form-status-item">
-                  <el-switch
-                    v-model="form.dingtalk.is_at_all"
-                    :active-text="t('ops.notification.statusEnabled')"
-                    :inactive-text="t('ops.notification.statusDisabled')"
-                  />
-                  <p class="fullscreen-form-field__hint">{{ t('ops.notification.tipAtAll') }}</p>
-                </el-form-item>
-              </template>
-
-              <template v-else-if="form.type === 'sms'">
-                <el-form-item
-                  :label="t('ops.notification.smsApiUrl')"
-                  prop="sms.url"
-                  class="fullscreen-form-item--in-card"
-                  data-notification-channel-field="sms.url"
-                >
-                  <el-input v-model="form.sms.url" :placeholder="t('ops.notification.phSmsApiUrl')" />
-                  <p class="fullscreen-form-field__hint">{{ t('ops.notification.tipSmsApiUrl') }}</p>
-                </el-form-item>
-                <el-form-item
-                  :label="t('ops.notification.smsPhoneNumbers')"
-                  prop="sms.phone_numbers"
-                  class="fullscreen-form-item--in-card"
-                  data-notification-channel-field="sms.phone_numbers"
-                >
-                  <el-input
-                    v-model="form.sms.phone_numbers"
-                    :placeholder="t('ops.notification.phSmsPhoneNumbers')"
-                  />
-                  <p class="fullscreen-form-field__hint">{{ t('ops.notification.tipSmsPhoneNumbers') }}</p>
-                </el-form-item>
-                <el-form-item :label="t('ops.notification.smsApiKey')" class="fullscreen-form-item--in-card">
-                  <el-input v-model="form.sms.api_key" type="password" show-password />
-                  <p class="fullscreen-form-field__hint">{{ t('ops.notification.tipSmsApiKey') }}</p>
-                </el-form-item>
-                <el-form-item :label="t('ops.notification.smsMessageTemplate')" class="fullscreen-form-item--in-card">
-                  <el-input
-                    v-model="form.sms.message_template"
-                    :placeholder="t('ops.notification.phSmsMessageTemplate')"
-                  />
-                  <p class="fullscreen-form-field__hint">{{ t('ops.notification.tipSmsMessageTemplate') }}</p>
-                </el-form-item>
-              </template>
-
-              <template v-else>
-                <el-form-item
-                  :label="t('ops.notification.formWebhookUrl')"
-                  prop="wecom.webhook_url"
-                  class="fullscreen-form-item--in-card"
-                  data-notification-channel-field="wecom.webhook_url"
-                >
-                  <el-input v-model="form.wecom.webhook_url" :placeholder="t('ops.notification.phWebhookUrl')" />
-                  <p class="fullscreen-form-field__hint">{{ t('ops.notification.tipWebhookUrl') }}</p>
-                </el-form-item>
-                <div class="fullscreen-form-grid">
-                  <el-form-item :label="t('ops.notification.formMentionedList')" class="fullscreen-form-item--in-card">
-                    <el-input v-model="form.wecom.mentioned_list" :placeholder="t('ops.notification.phMentionedList')" :disabled="form.wecom.is_at_all" />
-                    <p class="fullscreen-form-field__hint">{{ t('ops.notification.tipWecomMentionedList') }}</p>
-                  </el-form-item>
-                  <el-form-item :label="t('ops.notification.formMentionedMobileList')" class="fullscreen-form-item--in-card">
-                    <el-input v-model="form.wecom.mentioned_mobile_list" :placeholder="t('ops.notification.phAtMobiles')" />
-                    <p class="fullscreen-form-field__hint">{{ t('ops.notification.tipWecomMentionedMobileList') }}</p>
-                  </el-form-item>
-                </div>
-                <el-form-item :label="t('ops.notification.formAtAll')" class="fullscreen-form-status-item">
-                  <el-switch
-                    v-model="form.wecom.is_at_all"
-                    :active-text="t('ops.notification.statusEnabled')"
-                    :inactive-text="t('ops.notification.statusDisabled')"
-                  />
-                  <p class="fullscreen-form-field__hint">{{ t('ops.notification.tipAtAll') }}</p>
-                </el-form-item>
-              </template>
+                </template>
               </section>
             </div>
           </el-form>
@@ -592,19 +776,27 @@ watch(() => form.type, () => {
             <div class="add-form-preview-header">
               <div class="add-form-preview-header__glow" />
               <div class="add-form-preview-header__icon">
-                <component :is="previewTypeIcon" class="add-form-preview-header__cloud" :size="28" />
+                <component
+                  :is="previewTypeIcon"
+                  class="add-form-preview-header__cloud"
+                  :size="28"
+                />
               </div>
               <div class="add-form-preview-header__info">
                 <h4 class="add-form-preview-header__name">
                   {{ form.name.trim() || t('ops.notification.previewUnnamed') }}
                 </h4>
-                <p class="add-form-preview-header__type">{{ channelTypeLabel(form.type) }}</p>
+                <p class="add-form-preview-header__type">
+                  {{ channelTypeLabel(form.type) }}
+                </p>
               </div>
             </div>
 
             <div class="add-form-preview-body">
               <div class="add-form-preview-section">
-                <h5 class="add-form-preview-section__title">{{ t('ops.notification.basicInfo') }}</h5>
+                <h5 class="add-form-preview-section__title">
+                  {{ t('ops.notification.basicInfo') }}
+                </h5>
                 <div
                   v-for="row in previewBasicRows"
                   :key="row.label"
@@ -623,7 +815,9 @@ watch(() => form.type, () => {
               </div>
 
               <div class="add-form-preview-section">
-                <h5 class="add-form-preview-section__title">{{ t('ops.notification.sectionTarget') }}</h5>
+                <h5 class="add-form-preview-section__title">
+                  {{ t('ops.notification.sectionTarget') }}
+                </h5>
                 <div
                   v-for="row in previewTargetRows"
                   :key="row.label"

--- a/src/frontend/src/pages/ops/NotificationChannels.vue
+++ b/src/frontend/src/pages/ops/NotificationChannels.vue
@@ -1207,7 +1207,10 @@ watch(
             :disabled="loading"
             @click="fetchChannels"
           >
-            <RefreshCw :size="16" :class="{ 'is-spinning': loading }" />
+            <RefreshCw
+              :size="16"
+              :class="{ 'is-spinning': loading }"
+            />
           </el-button>
         </template>
 
@@ -1220,122 +1223,137 @@ watch(
           :title="listError"
         >
           <template #default>
-            <ElButton size="small" @click="fetchChannels">
+            <ElButton
+              size="small"
+              @click="fetchChannels"
+            >
               {{ t('common.retry') }}
             </ElButton>
           </template>
         </ElAlert>
 
         <template #table="{ tableMaxHeight }">
-        <el-table
-          ref="channelsTableRef"
-          v-table-column-resize="'ops.notificationChannels'"
-          v-loading="loading"
-          :data="channels"
-          stripe
-          class="hfl-list-table"
-          row-key="id"
-          :max-height="tableMaxHeight"
-          @selection-change="onChannelSelectionChange"
-        >
-          <el-table-column
-            type="selection"
-            width="35"
-            fixed="left"
-          />
-          <el-table-column
-            :label="t('ops.notification.colChannelName')"
-            min-width="190"
-            fixed="left"
+          <el-table
+            ref="channelsTableRef"
+            v-table-column-resize="'ops.notificationChannels'"
+            v-loading="loading"
+            :data="channels"
+            stripe
+            class="hfl-list-table"
+            row-key="id"
+            :max-height="tableMaxHeight"
+            @selection-change="onChannelSelectionChange"
           >
-            <template #default="{ row }">
-              <div class="hfl-ops-primary-cell">
-                <div class="min-w-0">
-                  <div class="flex min-w-0 items-center gap-1">
-                    <button
-                      type="button"
-                      class="hfl-table-name-link hfl-table-name-link--single min-w-0"
-                      @click="openDetails(row)"
-                    >
-                      {{ row.name }}
-                    </button>
+            <el-table-column
+              type="selection"
+              width="35"
+              fixed="left"
+            />
+            <el-table-column
+              :label="t('ops.notification.colChannelName')"
+              min-width="190"
+              fixed="left"
+            >
+              <template #default="{ row }">
+                <div class="hfl-ops-primary-cell">
+                  <div class="min-w-0">
+                    <div class="flex min-w-0 items-center gap-1">
+                      <button
+                        type="button"
+                        class="hfl-table-name-link hfl-table-name-link--single min-w-0"
+                        @click="openDetails(row)"
+                      >
+                        {{ row.name }}
+                      </button>
+                    </div>
                   </div>
                 </div>
-              </div>
-            </template>
-          </el-table-column>
-          <el-table-column
-            :label="t('ops.notification.colType')"
-            width="130"
-          >
-            <template #default="{ row }">
-              <HflTypeLabel
-                :icon="getNotificationTypeIcon(row.type)"
-                :label="channelTypeLabel(row.type)"
-              />
-            </template>
-          </el-table-column>
-          <el-table-column
-            :label="t('ops.notification.colTarget')"
-            min-width="220"
-          >
-            <template #default="{ row }">
-              <span :class="hasChannelTarget(row) ? 'hfl-table-cell-mono' : 'hfl-empty-mark'">{{ channelTarget(row) }}</span>
-            </template>
-          </el-table-column>
-          <el-table-column
-            :label="t('ops.notification.colStatus')"
-            width="100"
-          >
-            <template #default="{ row }">
-              <el-tag
-                :type="booleanStatusTag(row.enabled).type"
-                :class="booleanStatusTag(row.enabled).class"
-                size="small"
-              >
-                {{ row.enabled ? t('ops.notification.statusEnabled') : t('ops.notification.statusDisabled') }}
-              </el-tag>
-            </template>
-          </el-table-column>
-          <el-table-column
-            :label="t('ops.notification.colLinkedPolicies')"
-            width="110"
-          >
-            <template #default="{ row }">
-              <span>{{ channelPoliciesCount(row) }}</span>
-            </template>
-          </el-table-column>
-          <el-table-column
-            :label="t('ops.notification.colLastDelivery')"
-            width="170"
-          >
-            <template #default="{ row }">
-              <div v-if="channelLastDeliveryStatus(row)" class="hfl-ops-cell-stack">
+              </template>
+            </el-table-column>
+            <el-table-column
+              :label="t('ops.notification.colType')"
+              width="130"
+            >
+              <template #default="{ row }">
+                <HflTypeLabel
+                  :icon="getNotificationTypeIcon(row.type)"
+                  :label="channelTypeLabel(row.type)"
+                />
+              </template>
+            </el-table-column>
+            <el-table-column
+              :label="t('ops.notification.colTarget')"
+              min-width="220"
+            >
+              <template #default="{ row }">
+                <span :class="hasChannelTarget(row) ? 'hfl-table-cell-mono' : 'hfl-empty-mark'">{{ channelTarget(row) }}</span>
+              </template>
+            </el-table-column>
+            <el-table-column
+              :label="t('ops.notification.colStatus')"
+              width="100"
+            >
+              <template #default="{ row }">
                 <el-tag
-                  v-bind="lifecycleStatusTagAttrs(channelLastDeliveryStatus(row))"
+                  :type="booleanStatusTag(row.enabled).type"
+                  :class="booleanStatusTag(row.enabled).class"
                   size="small"
                 >
-                  {{ logStatusLabel(channelLastDeliveryStatus(row)) }}
+                  {{ row.enabled ? t('ops.notification.statusEnabled') : t('ops.notification.statusDisabled') }}
                 </el-tag>
-                <div class="hfl-ops-cell-stack__meta hfl-table-cell-time" :class="{ 'hfl-empty-mark': !channelLastDeliveryAt(row) }">
-                  {{ formatDate(channelLastDeliveryAt(row)) }}
+              </template>
+            </el-table-column>
+            <el-table-column
+              :label="t('ops.notification.colLinkedPolicies')"
+              width="110"
+            >
+              <template #default="{ row }">
+                <span>{{ channelPoliciesCount(row) }}</span>
+              </template>
+            </el-table-column>
+            <el-table-column
+              :label="t('ops.notification.colLastDelivery')"
+              width="170"
+            >
+              <template #default="{ row }">
+                <div
+                  v-if="channelLastDeliveryStatus(row)"
+                  class="hfl-ops-cell-stack"
+                >
+                  <el-tag
+                    v-bind="lifecycleStatusTagAttrs(channelLastDeliveryStatus(row))"
+                    size="small"
+                  >
+                    {{ logStatusLabel(channelLastDeliveryStatus(row)) }}
+                  </el-tag>
+                  <div
+                    class="hfl-ops-cell-stack__meta hfl-table-cell-time"
+                    :class="{ 'hfl-empty-mark': !channelLastDeliveryAt(row) }"
+                  >
+                    {{ formatDate(channelLastDeliveryAt(row)) }}
+                  </div>
                 </div>
-              </div>
-              <span v-else class="hfl-empty-mark">{{ t('common.empty') }}</span>
+                <span
+                  v-else
+                  class="hfl-empty-mark"
+                >{{ t('common.empty') }}</span>
+              </template>
+            </el-table-column>
+            <el-table-column
+              :label="t('ops.notification.colUpdatedAt')"
+              width="170"
+            >
+              <template #default="{ row }">
+                <span
+                  class="hfl-table-cell-time"
+                  :class="{ 'hfl-empty-mark': !(row.updatedAt || row.updated_at) }"
+                >{{ formatDate(row.updatedAt || row.updated_at) }}</span>
+              </template>
+            </el-table-column>
+            <template #empty>
+              <el-empty :description="emptyDescription" />
             </template>
-          </el-table-column>
-          <el-table-column
-            :label="t('ops.notification.colUpdatedAt')"
-            width="170"
-          >
-            <template #default="{ row }">
-              <span class="hfl-table-cell-time" :class="{ 'hfl-empty-mark': !(row.updatedAt || row.updated_at) }">{{ formatDate(row.updatedAt || row.updated_at) }}</span>
-            </template>
-          </el-table-column>
-          <template #empty>
-            <el-empty :description="emptyDescription" />
-          </template>
-        </el-table>
+          </el-table>
         </template>
 
         <template #footer>
@@ -1452,15 +1470,41 @@ watch(
                       <span class="hfl-detail-row__label">{{ t('ops.notification.colChannelName') }}</span>
                       <span class="hfl-detail-row__value hfl-detail-row__value--editable">
                         <template v-if="detailChannel(details) && isChannelInlineEditing('name')">
-                          <ElInput v-model="channelInlineDraft" size="small" class="hfl-detail-inline-edit__input" @keyup.enter="saveChannelInlineEdit" />
+                          <ElInput
+                            v-model="channelInlineDraft"
+                            size="small"
+                            class="hfl-detail-inline-edit__input"
+                            @keyup.enter="saveChannelInlineEdit"
+                          />
                           <span class="hfl-detail-inline-edit__actions">
-                            <ElButton text circle size="small" :title="t('common.save')" :disabled="channelInlineSaving" @click="saveChannelInlineEdit"><Check :size="14" /></ElButton>
-                            <ElButton text circle size="small" :title="t('common.cancel')" :disabled="channelInlineSaving" @click="cancelChannelInlineEdit"><X :size="14" /></ElButton>
+                            <ElButton
+                              text
+                              circle
+                              size="small"
+                              :title="t('common.save')"
+                              :disabled="channelInlineSaving"
+                              @click="saveChannelInlineEdit"
+                            ><Check :size="14" /></ElButton>
+                            <ElButton
+                              text
+                              circle
+                              size="small"
+                              :title="t('common.cancel')"
+                              :disabled="channelInlineSaving"
+                              @click="cancelChannelInlineEdit"
+                            ><X :size="14" /></ElButton>
                           </span>
                         </template>
                         <template v-else>
                           <span class="hfl-detail-row__text">{{ detailChannel(details)?.name }}</span>
-                          <ElButton text circle size="small" class="hfl-detail-row__edit" :title="t('common.edit')" @click="beginChannelInlineEdit('name')">
+                          <ElButton
+                            text
+                            circle
+                            size="small"
+                            class="hfl-detail-row__edit"
+                            :title="t('common.edit')"
+                            @click="beginChannelInlineEdit('name')"
+                          >
                             <Pencil :size="13" />
                           </ElButton>
                         </template>
@@ -1476,8 +1520,22 @@ watch(
                         <template v-if="detailChannel(details) && isChannelInlineEditing('enabled')">
                           <ElSwitch v-model="channelInlineDraft" />
                           <span class="hfl-detail-inline-edit__actions">
-                            <ElButton text circle size="small" :title="t('common.save')" :disabled="channelInlineSaving" @click="saveChannelInlineEdit"><Check :size="14" /></ElButton>
-                            <ElButton text circle size="small" :title="t('common.cancel')" :disabled="channelInlineSaving" @click="cancelChannelInlineEdit"><X :size="14" /></ElButton>
+                            <ElButton
+                              text
+                              circle
+                              size="small"
+                              :title="t('common.save')"
+                              :disabled="channelInlineSaving"
+                              @click="saveChannelInlineEdit"
+                            ><Check :size="14" /></ElButton>
+                            <ElButton
+                              text
+                              circle
+                              size="small"
+                              :title="t('common.cancel')"
+                              :disabled="channelInlineSaving"
+                              @click="cancelChannelInlineEdit"
+                            ><X :size="14" /></ElButton>
                           </span>
                         </template>
                         <template v-else>
@@ -1488,7 +1546,14 @@ watch(
                           >
                             {{ detailChannel(details)?.enabled ? t('ops.notification.statusEnabled') : t('ops.notification.statusDisabled') }}
                           </el-tag>
-                          <ElButton text circle size="small" class="hfl-detail-row__edit" :title="t('common.edit')" @click="beginChannelInlineEdit('enabled')">
+                          <ElButton
+                            text
+                            circle
+                            size="small"
+                            class="hfl-detail-row__edit"
+                            :title="t('common.edit')"
+                            @click="beginChannelInlineEdit('enabled')"
+                          >
                             <Pencil :size="13" />
                           </ElButton>
                         </template>
@@ -1496,25 +1561,37 @@ watch(
                     </div>
                     <div class="hfl-detail-row">
                       <span class="hfl-detail-row__label">{{ t('ops.notification.colCreatedAt') }}</span>
-                      <span class="hfl-detail-row__value hfl-table-cell-time" :class="{ 'hfl-detail-row__empty': !(detailChannel(details)?.createdAt || detailChannel(details)?.created_at) }">
+                      <span
+                        class="hfl-detail-row__value hfl-table-cell-time"
+                        :class="{ 'hfl-detail-row__empty': !(detailChannel(details)?.createdAt || detailChannel(details)?.created_at) }"
+                      >
                         {{ formatDate(detailChannel(details)?.createdAt || detailChannel(details)?.created_at) }}
                       </span>
                     </div>
                     <div class="hfl-detail-row">
                       <span class="hfl-detail-row__label">{{ t('ops.notification.colUpdatedAt') }}</span>
-                      <span class="hfl-detail-row__value hfl-table-cell-time" :class="{ 'hfl-detail-row__empty': !(detailChannel(details)?.updatedAt || detailChannel(details)?.updated_at) }">
+                      <span
+                        class="hfl-detail-row__value hfl-table-cell-time"
+                        :class="{ 'hfl-detail-row__empty': !(detailChannel(details)?.updatedAt || detailChannel(details)?.updated_at) }"
+                      >
                         {{ formatDate(detailChannel(details)?.updatedAt || detailChannel(details)?.updated_at) }}
                       </span>
                     </div>
                     <div class="hfl-detail-row">
                       <span class="hfl-detail-row__label">{{ t('ops.notification.lastSuccess') }}</span>
-                      <span class="hfl-detail-row__value hfl-table-cell-time" :class="{ 'hfl-detail-row__empty': !details.stats?.last_success_at }">
+                      <span
+                        class="hfl-detail-row__value hfl-table-cell-time"
+                        :class="{ 'hfl-detail-row__empty': !details.stats?.last_success_at }"
+                      >
                         {{ formatDate(details.stats?.last_success_at) }}
                       </span>
                     </div>
                     <div class="hfl-detail-row">
                       <span class="hfl-detail-row__label">{{ t('ops.notification.lastFailed') }}</span>
-                      <span class="hfl-detail-row__value hfl-table-cell-time" :class="{ 'hfl-detail-row__empty': !details.stats?.last_failed_at }">
+                      <span
+                        class="hfl-detail-row__value hfl-table-cell-time"
+                        :class="{ 'hfl-detail-row__empty': !details.stats?.last_failed_at }"
+                      >
                         {{ formatDate(details.stats?.last_failed_at) }}
                       </span>
                     </div>
@@ -1540,11 +1617,36 @@ watch(
                           :class="{ 'hfl-detail-row__value--editable': true, 'hfl-table-cell-mono': item.mono, 'hfl-detail-row__value--break': item.full }"
                         >
                           <template v-if="detailChannel(details) && isChannelInlineEditing(`config:${item.key}`)">
-                            <ElSwitch v-if="typeof item.value === 'boolean'" v-model="channelInlineDraft" />
-                            <ElInput v-else v-model="channelInlineDraft" size="small" :type="item.full ? 'textarea' : 'text'" :rows="item.full ? 2 : undefined" class="hfl-detail-inline-edit__input" @keyup.enter="saveChannelInlineEdit" />
+                            <ElSwitch
+                              v-if="typeof item.value === 'boolean'"
+                              v-model="channelInlineDraft"
+                            />
+                            <ElInput
+                              v-else
+                              v-model="channelInlineDraft"
+                              size="small"
+                              :type="item.full ? 'textarea' : 'text'"
+                              :rows="item.full ? 2 : undefined"
+                              class="hfl-detail-inline-edit__input"
+                              @keyup.enter="saveChannelInlineEdit"
+                            />
                             <span class="hfl-detail-inline-edit__actions">
-                              <ElButton text circle size="small" :title="t('common.save')" :disabled="channelInlineSaving" @click="saveChannelInlineEdit"><Check :size="14" /></ElButton>
-                              <ElButton text circle size="small" :title="t('common.cancel')" :disabled="channelInlineSaving" @click="cancelChannelInlineEdit"><X :size="14" /></ElButton>
+                              <ElButton
+                                text
+                                circle
+                                size="small"
+                                :title="t('common.save')"
+                                :disabled="channelInlineSaving"
+                                @click="saveChannelInlineEdit"
+                              ><Check :size="14" /></ElButton>
+                              <ElButton
+                                text
+                                circle
+                                size="small"
+                                :title="t('common.cancel')"
+                                :disabled="channelInlineSaving"
+                                @click="cancelChannelInlineEdit"
+                              ><X :size="14" /></ElButton>
                             </span>
                           </template>
                           <template v-else>
@@ -1683,7 +1785,10 @@ watch(
                   width="170"
                 >
                   <template #default="{ row }">
-                    <span class="hfl-table-cell-time" :class="{ 'hfl-empty-mark': !(row.sent_at || row.sentAt) }">{{ formatDate(row.sent_at || row.sentAt) }}</span>
+                    <span
+                      class="hfl-table-cell-time"
+                      :class="{ 'hfl-empty-mark': !(row.sent_at || row.sentAt) }"
+                    >{{ formatDate(row.sent_at || row.sentAt) }}</span>
                   </template>
                 </el-table-column>
                 <template #empty>
@@ -1766,7 +1871,10 @@ watch(
       @cancel="closeBatchDialog"
     >
       <template #extra>
-        <section v-if="pendingBatch.impactItems.length" class="notification-batch-impact">
+        <section
+          v-if="pendingBatch.impactItems.length"
+          class="notification-batch-impact"
+        >
           <header class="notification-batch-impact__heading">
             {{ pendingBatch.impactItemsHeading }}
           </header>
@@ -1787,7 +1895,10 @@ watch(
               width="140"
             >
               <template #default="{ row }">
-                <span class="notification-batch-impact__hint" :class="{ 'hfl-empty-mark': !row.hint }">{{ row.hint || '—' }}</span>
+                <span
+                  class="notification-batch-impact__hint"
+                  :class="{ 'hfl-empty-mark': !row.hint }"
+                >{{ row.hint || '—' }}</span>
               </template>
             </ElTableColumn>
           </ElTable>

--- a/src/frontend/src/pages/ops/NotificationRecords.vue
+++ b/src/frontend/src/pages/ops/NotificationRecords.vue
@@ -190,10 +190,19 @@ watch(
 </script>
 
 <template>
-  <ModulePage :title="t('ops.nav.deliveryHistory')" :menus="opsMenus" body-fill>
+  <ModulePage
+    :title="t('ops.nav.deliveryHistory')"
+    :menus="opsMenus"
+    body-fill
+  >
     <div class="hfl-ops-page hfl-ops-page--fill">
       <div class="hfl-ops-stats-grid hfl-ops-stats-grid--4">
-        <OpsStatCard :label="t('ops.notification.logsTotal')" :value="stats.total" accent="indigo" accent-side="left" />
+        <OpsStatCard
+          :label="t('ops.notification.logsTotal')"
+          :value="stats.total"
+          accent="indigo"
+          accent-side="left"
+        />
         <OpsStatCard
           :label="t('ops.notification.statusSuccess')"
           :value="stats.success"
@@ -225,7 +234,9 @@ watch(
             :placeholder="t('ops.notification.logsSearch')"
             @clear="clearSearch"
           >
-            <template #prefix><Search class="h-4 w-4 opacity-60" /></template>
+            <template #prefix>
+              <Search class="h-4 w-4 opacity-60" />
+            </template>
           </el-input>
           <el-select
             v-model="filters.channel_id"
@@ -233,17 +244,49 @@ watch(
             style="width: 150px"
             :placeholder="t('ops.notification.filterChannel')"
           >
-            <el-option v-for="ch in channels" :key="ch.id" :value="String(ch.id)" :label="ch.name" />
+            <el-option
+              v-for="ch in channels"
+              :key="ch.id"
+              :value="String(ch.id)"
+              :label="ch.name"
+            />
           </el-select>
-          <el-select v-model="filters.status" clearable style="width: 120px" :placeholder="t('ops.notification.filterAllStatus')">
-            <el-option value="success" :label="t('ops.notification.statusSuccess')" />
-            <el-option value="failed" :label="t('ops.notification.statusFailed')" />
+          <el-select
+            v-model="filters.status"
+            clearable
+            style="width: 120px"
+            :placeholder="t('ops.notification.filterAllStatus')"
+          >
+            <el-option
+              value="success"
+              :label="t('ops.notification.statusSuccess')"
+            />
+            <el-option
+              value="failed"
+              :label="t('ops.notification.statusFailed')"
+            />
           </el-select>
-          <el-select v-model="filters.notification_type" clearable style="width: 130px" :placeholder="t('ops.notification.filterNotificationType')">
-            <el-option value="firing" :label="t('ops.notification.logTypeFiring')" />
-            <el-option value="resolved" :label="t('ops.notification.logTypeResolved')" />
+          <el-select
+            v-model="filters.notification_type"
+            clearable
+            style="width: 130px"
+            :placeholder="t('ops.notification.filterNotificationType')"
+          >
+            <el-option
+              value="firing"
+              :label="t('ops.notification.logTypeFiring')"
+            />
+            <el-option
+              value="resolved"
+              :label="t('ops.notification.logTypeResolved')"
+            />
           </el-select>
-          <el-select v-model="filters.type" clearable style="width: 130px" :placeholder="t('ops.alertsCenter.common.allTypes')">
+          <el-select
+            v-model="filters.type"
+            clearable
+            style="width: 130px"
+            :placeholder="t('ops.alertsCenter.common.allTypes')"
+          >
             <el-option
               v-for="opt in policyTypeOptions"
               :key="opt.value"
@@ -251,15 +294,38 @@ watch(
               :label="opt.label"
             />
           </el-select>
-          <el-select v-model="filters.severity" clearable style="width: 130px" :placeholder="t('ops.alertsCenter.common.allSeverity')">
-            <el-option value="critical" :label="t('ops.alertsCenter.common.critical')" />
-            <el-option value="warning" :label="t('ops.alertsCenter.common.warning')" />
-            <el-option value="info" :label="t('ops.alertsCenter.common.info')" />
+          <el-select
+            v-model="filters.severity"
+            clearable
+            style="width: 130px"
+            :placeholder="t('ops.alertsCenter.common.allSeverity')"
+          >
+            <el-option
+              value="critical"
+              :label="t('ops.alertsCenter.common.critical')"
+            />
+            <el-option
+              value="warning"
+              :label="t('ops.alertsCenter.common.warning')"
+            />
+            <el-option
+              value="info"
+              :label="t('ops.alertsCenter.common.info')"
+            />
           </el-select>
         </template>
         <template #toolbar-utility>
-          <el-button class="hfl-refresh-button" :title="t('ops.task.btnRefresh')" :aria-label="t('ops.task.btnRefresh')" :disabled="loading" @click="fetchData">
-            <RefreshCw :size="16" :class="{ 'is-spinning': loading }" />
+          <el-button
+            class="hfl-refresh-button"
+            :title="t('ops.task.btnRefresh')"
+            :aria-label="t('ops.task.btnRefresh')"
+            :disabled="loading"
+            @click="fetchData"
+          >
+            <RefreshCw
+              :size="16"
+              :class="{ 'is-spinning': loading }"
+            />
           </el-button>
         </template>
 
@@ -273,7 +339,11 @@ watch(
             class="hfl-list-table"
             :max-height="tableMaxHeight"
           >
-            <el-table-column :label="t('ops.notification.logsAlert')" min-width="260" fixed="left">
+            <el-table-column
+              :label="t('ops.notification.logsAlert')"
+              min-width="260"
+              fixed="left"
+            >
               <template #default="{ row }">
                 <div class="hfl-ops-primary-cell">
                   <div class="min-w-0">
@@ -293,35 +363,71 @@ watch(
                 </div>
               </template>
             </el-table-column>
-            <el-table-column :label="t('ops.notification.logsPolicy')" min-width="150">
+            <el-table-column
+              :label="t('ops.notification.logsPolicy')"
+              min-width="150"
+            >
               <template #default="{ row }">
-                <div class="hfl-ops-cell-stack__title" :class="{ 'hfl-empty-mark': logPolicyName(row) === t('common.empty') }">{{ logPolicyName(row) }}</div>
+                <div
+                  class="hfl-ops-cell-stack__title"
+                  :class="{ 'hfl-empty-mark': logPolicyName(row) === t('common.empty') }"
+                >
+                  {{ logPolicyName(row) }}
+                </div>
                 <div class="hfl-ops-cell-stack__meta">
                   <AlertPolicyTypeLabel :type="logPolicyTypeValue(row)" />
                 </div>
               </template>
             </el-table-column>
-            <el-table-column :label="t('ops.notification.logsChannel')" width="160">
+            <el-table-column
+              :label="t('ops.notification.logsChannel')"
+              width="160"
+            >
               <template #default="{ row }">
-                <div class="hfl-ops-cell-stack__title" :class="{ 'hfl-empty-mark': !row.channel?.name }">{{ row.channel?.name || '—' }}</div>
-                <div class="hfl-ops-cell-stack__meta uppercase" :class="{ 'hfl-empty-mark': !row.channel?.type }">{{ row.channel?.type || '—' }}</div>
+                <div
+                  class="hfl-ops-cell-stack__title"
+                  :class="{ 'hfl-empty-mark': !row.channel?.name }"
+                >
+                  {{ row.channel?.name || '—' }}
+                </div>
+                <div
+                  class="hfl-ops-cell-stack__meta uppercase"
+                  :class="{ 'hfl-empty-mark': !row.channel?.type }"
+                >
+                  {{ row.channel?.type || '—' }}
+                </div>
               </template>
             </el-table-column>
-            <el-table-column :label="t('ops.notification.logsNotificationType')" width="110">
+            <el-table-column
+              :label="t('ops.notification.logsNotificationType')"
+              width="110"
+            >
               <template #default="{ row }">
-                <el-tag v-bind="notificationTypeTagAttrs(row.notificationType || row.notification_type)" size="small">
+                <el-tag
+                  v-bind="notificationTypeTagAttrs(row.notificationType || row.notification_type)"
+                  size="small"
+                >
                   {{ notificationTypeLabel(row.notificationType || row.notification_type) }}
                 </el-tag>
               </template>
             </el-table-column>
-            <el-table-column :label="t('ops.alertsCenter.common.severity')" width="100">
+            <el-table-column
+              :label="t('ops.alertsCenter.common.severity')"
+              width="100"
+            >
               <template #default="{ row }">
-                <el-tag v-bind="severityStatusTagAttrs(logSeverity(row))" size="small">
+                <el-tag
+                  v-bind="severityStatusTagAttrs(logSeverity(row))"
+                  size="small"
+                >
                   {{ severityLabel(logSeverity(row)) }}
                 </el-tag>
               </template>
             </el-table-column>
-            <el-table-column :label="t('ops.notification.colStatus')" width="110">
+            <el-table-column
+              :label="t('ops.notification.colStatus')"
+              width="110"
+            >
               <template #default="{ row }">
                 <el-tag
                   class="hfl-ops-result-tag"
@@ -340,37 +446,43 @@ watch(
                 </el-tag>
               </template>
             </el-table-column>
-          <el-table-column :label="t('ops.notification.logsSentAt')" width="170">
-            <template #default="{ row }">
-              <span class="hfl-table-cell-time" :class="{ 'hfl-empty-mark': !(row.sentAt || row.sent_at) }">{{ formatDate(row.sentAt || row.sent_at) }}</span>
-            </template>
-          </el-table-column>
-          <el-table-column
-            :label="t('ops.notification.logsResult')"
-            min-width="220"
-            class-name="hfl-notification-result-column"
-          >
-            <template #default="{ row }">
-              <el-tooltip
-                :content="responsePreview(row)"
-                placement="top-start"
-                popper-class="hfl-notification-result-tooltip"
-                :show-after="250"
-              >
-                <button
-                  type="button"
-                  class="hfl-ops-response-chip"
-                  @click.stop="openDetail(row)"
+            <el-table-column
+              :label="t('ops.notification.logsSentAt')"
+              width="170"
+            >
+              <template #default="{ row }">
+                <span
+                  class="hfl-table-cell-time"
+                  :class="{ 'hfl-empty-mark': !(row.sentAt || row.sent_at) }"
+                >{{ formatDate(row.sentAt || row.sent_at) }}</span>
+              </template>
+            </el-table-column>
+            <el-table-column
+              :label="t('ops.notification.logsResult')"
+              min-width="220"
+              class-name="hfl-notification-result-column"
+            >
+              <template #default="{ row }">
+                <el-tooltip
+                  :content="responsePreview(row)"
+                  placement="top-start"
+                  popper-class="hfl-notification-result-tooltip"
+                  :show-after="250"
                 >
-                  {{ responsePreview(row) }}
-                </button>
-              </el-tooltip>
+                  <button
+                    type="button"
+                    class="hfl-ops-response-chip"
+                    @click.stop="openDetail(row)"
+                  >
+                    {{ responsePreview(row) }}
+                  </button>
+                </el-tooltip>
+              </template>
+            </el-table-column>
+            <template #empty>
+              <el-empty :description="emptyDescription" />
             </template>
-          </el-table-column>
-          <template #empty>
-            <el-empty :description="emptyDescription" />
-          </template>
-        </el-table>
+          </el-table>
         </template>
 
         <template #footer>
@@ -401,10 +513,15 @@ watch(
         </span>
       </template>
 
-      <div v-if="selected" class="hfl-detail-drawer__body">
+      <div
+        v-if="selected"
+        class="hfl-detail-drawer__body"
+      >
         <div class="hfl-detail-sections">
           <section class="hfl-detail-section">
-            <h4 class="hfl-detail-section__title">{{ t('ops.notification.logDetail') }}</h4>
+            <h4 class="hfl-detail-section__title">
+              {{ t('ops.notification.logDetail') }}
+            </h4>
             <div class="hfl-detail-grid">
               <div class="hfl-detail-row">
                 <span class="hfl-detail-row__label">{{ t('ops.notification.colId') }}</span>
@@ -412,7 +529,10 @@ watch(
               </div>
               <div class="hfl-detail-row">
                 <span class="hfl-detail-row__label">{{ t('ops.notification.logsNotificationType') }}</span>
-                <span class="hfl-detail-row__value" :class="{ 'hfl-detail-row__empty': !(selected.notificationType || selected.notification_type) }">{{ notificationTypeLabel(selected.notificationType || selected.notification_type) }}</span>
+                <span
+                  class="hfl-detail-row__value"
+                  :class="{ 'hfl-detail-row__empty': !(selected.notificationType || selected.notification_type) }"
+                >{{ notificationTypeLabel(selected.notificationType || selected.notification_type) }}</span>
               </div>
               <div class="hfl-detail-row">
                 <span class="hfl-detail-row__label">{{ t('ops.notification.colStatus') }}</span>
@@ -436,7 +556,10 @@ watch(
               </div>
               <div class="hfl-detail-row">
                 <span class="hfl-detail-row__label">{{ t('ops.notification.logsSentAt') }}</span>
-                <span class="hfl-detail-row__value hfl-table-cell-time" :class="{ 'hfl-detail-row__empty': !(selected.sentAt || selected.sent_at) }">
+                <span
+                  class="hfl-detail-row__value hfl-table-cell-time"
+                  :class="{ 'hfl-detail-row__empty': !(selected.sentAt || selected.sent_at) }"
+                >
                   {{ formatDate(selected.sentAt || selected.sent_at) }}
                 </span>
               </div>
@@ -452,35 +575,55 @@ watch(
           </section>
 
           <section class="hfl-detail-section">
-            <h4 class="hfl-detail-section__title">{{ t('ops.alertsCenter.common.resourcesAndChannels') }}</h4>
+            <h4 class="hfl-detail-section__title">
+              {{ t('ops.alertsCenter.common.resourcesAndChannels') }}
+            </h4>
             <div class="hfl-detail-grid">
               <div class="hfl-detail-row">
                 <span class="hfl-detail-row__label">{{ t('ops.notification.logsChannel') }}</span>
-                <span class="hfl-detail-row__value" :class="{ 'hfl-detail-row__empty': !selected.channel?.name }">{{ displayValue(selected.channel?.name) }}</span>
+                <span
+                  class="hfl-detail-row__value"
+                  :class="{ 'hfl-detail-row__empty': !selected.channel?.name }"
+                >{{ displayValue(selected.channel?.name) }}</span>
               </div>
               <div class="hfl-detail-row">
                 <span class="hfl-detail-row__label">{{ t('ops.notification.colType') }}</span>
-                <span class="hfl-detail-row__value" :class="{ 'hfl-detail-row__empty': !selected.channel?.type }">{{ displayValue(selected.channel?.type) }}</span>
+                <span
+                  class="hfl-detail-row__value"
+                  :class="{ 'hfl-detail-row__empty': !selected.channel?.type }"
+                >{{ displayValue(selected.channel?.type) }}</span>
               </div>
               <div class="hfl-detail-row">
                 <span class="hfl-detail-row__label">{{ t('ops.notification.logsPolicy') }}</span>
-                <span class="hfl-detail-row__value" :class="{ 'hfl-detail-row__empty': logPolicyName(selected) === t('common.empty') }">{{ logPolicyName(selected) }}</span>
+                <span
+                  class="hfl-detail-row__value"
+                  :class="{ 'hfl-detail-row__empty': logPolicyName(selected) === t('common.empty') }"
+                >{{ logPolicyName(selected) }}</span>
               </div>
               <div class="hfl-detail-row">
                 <span class="hfl-detail-row__label">{{ t('ops.alertsCenter.common.type') }}</span>
-                <span class="hfl-detail-row__value" :class="{ 'hfl-detail-row__empty': logPolicyType(selected) === t('common.empty') }">{{ logPolicyType(selected) }}</span>
+                <span
+                  class="hfl-detail-row__value"
+                  :class="{ 'hfl-detail-row__empty': logPolicyType(selected) === t('common.empty') }"
+                >{{ logPolicyType(selected) }}</span>
               </div>
               <div class="hfl-detail-row">
                 <span class="hfl-detail-row__label">{{ t('ops.alertsCenter.common.severity') }}</span>
                 <span class="hfl-detail-row__value">
-                  <el-tag v-bind="severityStatusTagAttrs(logSeverity(selected))" size="small">
+                  <el-tag
+                    v-bind="severityStatusTagAttrs(logSeverity(selected))"
+                    size="small"
+                  >
                     {{ severityLabel(logSeverity(selected)) }}
                   </el-tag>
                 </span>
               </div>
               <div class="hfl-detail-row">
                 <span class="hfl-detail-row__label">{{ t('ops.alertsCenter.policies.targetColumn') }}</span>
-                <span class="hfl-detail-row__value" :class="{ 'hfl-detail-row__empty': logResourceSummary(selected) === t('common.empty') }">{{ logResourceSummary(selected) }}</span>
+                <span
+                  class="hfl-detail-row__value"
+                  :class="{ 'hfl-detail-row__empty': logResourceSummary(selected) === t('common.empty') }"
+                >{{ logResourceSummary(selected) }}</span>
               </div>
               <div class="hfl-detail-row hfl-detail-row--full">
                 <span class="hfl-detail-row__label">{{ t('ops.notification.logsAlert') }}</span>

--- a/src/frontend/src/pages/ops/Tasks.vue
+++ b/src/frontend/src/pages/ops/Tasks.vue
@@ -1013,7 +1013,11 @@ watch(
 </script>
 
 <template>
-  <ModulePage :title="t('ops.task.title')" :menus="opsMenus" body-fill>
+  <ModulePage
+    :title="t('ops.task.title')"
+    :menus="opsMenus"
+    body-fill
+  >
     <div class="hfl-ops-page hfl-ops-page--fill">
       <div class="hfl-ops-stats-grid hfl-ops-stats-grid--5">
         <OpsStatCard
@@ -1082,25 +1086,83 @@ watch(
             @clear="clearSearch"
           >
             <template #prepend>
-              <ElSelect v-model="filters.search_field" @change="handleSearchFieldChange">
-                <ElOption v-for="opt in searchFieldOptions" :key="opt.value" :value="opt.value" :label="opt.label" />
+              <ElSelect
+                v-model="filters.search_field"
+                @change="handleSearchFieldChange"
+              >
+                <ElOption
+                  v-for="opt in searchFieldOptions"
+                  :key="opt.value"
+                  :value="opt.value"
+                  :label="opt.label"
+                />
               </ElSelect>
             </template>
           </ElInput>
-          <ElSelect v-model="filters.task_type" clearable :placeholder="t('ops.task.filterType')" style="width: 130px">
-            <ElOption v-for="item in taskTypeOptions" :key="item" :label="labelFor('taskType', item)" :value="item" />
+          <ElSelect
+            v-model="filters.task_type"
+            clearable
+            :placeholder="t('ops.task.filterType')"
+            style="width: 130px"
+          >
+            <ElOption
+              v-for="item in taskTypeOptions"
+              :key="item"
+              :label="labelFor('taskType', item)"
+              :value="item"
+            />
           </ElSelect>
-          <ElSelect v-model="filters.status" clearable :placeholder="t('ops.task.filterStatus')" style="width: 130px">
-            <ElOption v-for="item in statusOptions" :key="item" :label="labelFor('status', item)" :value="item" />
+          <ElSelect
+            v-model="filters.status"
+            clearable
+            :placeholder="t('ops.task.filterStatus')"
+            style="width: 130px"
+          >
+            <ElOption
+              v-for="item in statusOptions"
+              :key="item"
+              :label="labelFor('status', item)"
+              :value="item"
+            />
           </ElSelect>
-          <ElSelect v-model="filters.trigger_type" clearable :placeholder="t('ops.task.filterTrigger')" style="width: 130px">
-            <ElOption v-for="item in triggerTypeOptions" :key="item" :label="labelFor('triggerType', item)" :value="item" />
+          <ElSelect
+            v-model="filters.trigger_type"
+            clearable
+            :placeholder="t('ops.task.filterTrigger')"
+            style="width: 130px"
+          >
+            <ElOption
+              v-for="item in triggerTypeOptions"
+              :key="item"
+              :label="labelFor('triggerType', item)"
+              :value="item"
+            />
           </ElSelect>
-          <ElSelect v-model="filters.time_field" :placeholder="t('ops.task.timeField')" style="width: 140px" @change="runFilterSearch">
-            <ElOption v-for="item in timeFieldOptions" :key="item.value" :label="item.label" :value="item.value" />
+          <ElSelect
+            v-model="filters.time_field"
+            :placeholder="t('ops.task.timeField')"
+            style="width: 140px"
+            @change="runFilterSearch"
+          >
+            <ElOption
+              v-for="item in timeFieldOptions"
+              :key="item.value"
+              :label="item.label"
+              :value="item.value"
+            />
           </ElSelect>
-          <ElSelect v-model="filters.time_mode" :placeholder="t('ops.task.filterTime')" style="width: 130px" @change="onTaskTimeModeChange">
-            <ElOption v-for="item in timeModeOptions" :key="item.value" :label="item.label" :value="item.value" />
+          <ElSelect
+            v-model="filters.time_mode"
+            :placeholder="t('ops.task.filterTime')"
+            style="width: 130px"
+            @change="onTaskTimeModeChange"
+          >
+            <ElOption
+              v-for="item in timeModeOptions"
+              :key="item.value"
+              :label="item.label"
+              :value="item.value"
+            />
           </ElSelect>
         </template>
         <template #toolbar-utility>
@@ -1111,10 +1173,18 @@ watch(
             :aria-label="t('ops.task.advancedFilter')"
             @click="openAdvancedFilterDrawer"
           >
-            <ElBadge v-if="advancedFilterCount > 0" :value="advancedFilterCount" :max="9" class="hfl-filter-badge">
+            <ElBadge
+              v-if="advancedFilterCount > 0"
+              :value="advancedFilterCount"
+              :max="9"
+              class="hfl-filter-badge"
+            >
               <Filter :size="16" />
             </ElBadge>
-            <Filter v-else :size="16" />
+            <Filter
+              v-else
+              :size="16"
+            />
           </ElButton>
           <ElButton
             class="hfl-refresh-button"
@@ -1123,100 +1193,136 @@ watch(
             :disabled="loading"
             @click="load"
           >
-            <RefreshCw :size="16" :class="{ 'is-spinning': loading }" />
+            <RefreshCw
+              :size="16"
+              :class="{ 'is-spinning': loading }"
+            />
           </ElButton>
         </template>
 
         <template #table="{ tableMaxHeight }">
-        <el-table
-          v-table-column-resize="'ops.tasks'"
-          v-loading="loading"
-          :data="rows"
-          stripe
-          class="hfl-list-table"
-          :max-height="tableMaxHeight"
-        >
-        <el-table-column
-          :label="t('ops.task.colName')"
-          min-width="240"
-          fixed="left"
-        >
-          <template #default="{ row }">
-            <ResourceNameSummaryCell
-              :name="row.display_name"
-              :summary="row.task_uuid"
-              kind="task"
-              :show-icon="false"
-              @open="openTaskDetail(row)"
-            />
-          </template>
-        </el-table-column>
-        <el-table-column
-          :label="t('ops.task.colType')"
-          min-width="190"
-        >
-          <template #default="{ row }">
-            <TaskTypeLabel
-              :type="row.task_type"
-              :operation-type="row.operation_type"
-            />
-          </template>
-        </el-table-column>
-        <el-table-column :label="t('ops.task.colStatus')" min-width="120">
-          <template #default="{ row }">
-            <TaskStatusTag :status="displayTaskStatus(row)" />
-          </template>
-        </el-table-column>
-        <el-table-column :label="t('ops.task.colStep')" min-width="150">
-          <template #default="{ row }">{{ stepDisplayName(row.current_step, row.task_type) }}</template>
-        </el-table-column>
-        <el-table-column :label="t('ops.task.colProgress')" min-width="160">
-          <template #default="{ row }">
-            <div class="hfl-task-list-progress">
-              <div class="hfl-task-list-progress__track">
-                <div
-                  class="hfl-task-list-progress__fill"
-                  :class="`hfl-task-list-progress__fill--${displayTaskStatus(row)}`"
-                  :style="{ width: `${progressValue(row)}%` }"
+          <el-table
+            v-table-column-resize="'ops.tasks'"
+            v-loading="loading"
+            :data="rows"
+            stripe
+            class="hfl-list-table"
+            :max-height="tableMaxHeight"
+          >
+            <el-table-column
+              :label="t('ops.task.colName')"
+              min-width="240"
+              fixed="left"
+            >
+              <template #default="{ row }">
+                <ResourceNameSummaryCell
+                  :name="row.display_name"
+                  :summary="row.task_uuid"
+                  kind="task"
+                  :show-icon="false"
+                  @open="openTaskDetail(row)"
                 />
-              </div>
-              <span class="hfl-task-list-progress__text">{{ progressText(row) }}</span>
-            </div>
-          </template>
-        </el-table-column>
-        <el-table-column
-          :label="t('ops.task.colTrigger')"
-          width="110"
-        >
-          <template #default="{ row }">
-            <el-tag type="info" size="small">
-              {{ labelFor('triggerType', row.trigger_type) }}
-            </el-tag>
-          </template>
-        </el-table-column>
-        <el-table-column
-          :label="t('ops.task.startedAt')"
-          width="165"
-        >
-          <template #default="{ row }">
-            <span class="hfl-table-cell-time" :class="{ 'hfl-empty-mark': !(row.started_at || row.created_at) }">{{ formatTime(row.started_at || row.created_at) }}</span>
-          </template>
-        </el-table-column>
-        <el-table-column
-          :label="t('ops.task.finishedAt')"
-          width="165"
-        >
-          <template #default="{ row }">
-            <span class="hfl-table-cell-time" :class="{ 'hfl-empty-mark': !row.finished_at }">{{ formatTime(row.finished_at) }}</span>
-          </template>
-        </el-table-column>
-        <template #empty>
-          <el-empty v-if="listLoadError" :description="listLoadError" :image-size="80">
-            <ElButton type="primary" @click="load()">{{ t('ops.task.btnRetry') }}</ElButton>
-          </el-empty>
-          <el-empty v-else :description="t('ops.task.empty')" :image-size="80" />
-        </template>
-      </el-table>
+              </template>
+            </el-table-column>
+            <el-table-column
+              :label="t('ops.task.colType')"
+              min-width="190"
+            >
+              <template #default="{ row }">
+                <TaskTypeLabel
+                  :type="row.task_type"
+                  :operation-type="row.operation_type"
+                />
+              </template>
+            </el-table-column>
+            <el-table-column
+              :label="t('ops.task.colStatus')"
+              min-width="120"
+            >
+              <template #default="{ row }">
+                <TaskStatusTag :status="displayTaskStatus(row)" />
+              </template>
+            </el-table-column>
+            <el-table-column
+              :label="t('ops.task.colStep')"
+              min-width="150"
+            >
+              <template #default="{ row }">
+                {{ stepDisplayName(row.current_step, row.task_type) }}
+              </template>
+            </el-table-column>
+            <el-table-column
+              :label="t('ops.task.colProgress')"
+              min-width="160"
+            >
+              <template #default="{ row }">
+                <div class="hfl-task-list-progress">
+                  <div class="hfl-task-list-progress__track">
+                    <div
+                      class="hfl-task-list-progress__fill"
+                      :class="`hfl-task-list-progress__fill--${displayTaskStatus(row)}`"
+                      :style="{ width: `${progressValue(row)}%` }"
+                    />
+                  </div>
+                  <span class="hfl-task-list-progress__text">{{ progressText(row) }}</span>
+                </div>
+              </template>
+            </el-table-column>
+            <el-table-column
+              :label="t('ops.task.colTrigger')"
+              width="110"
+            >
+              <template #default="{ row }">
+                <el-tag
+                  type="info"
+                  size="small"
+                >
+                  {{ labelFor('triggerType', row.trigger_type) }}
+                </el-tag>
+              </template>
+            </el-table-column>
+            <el-table-column
+              :label="t('ops.task.startedAt')"
+              width="165"
+            >
+              <template #default="{ row }">
+                <span
+                  class="hfl-table-cell-time"
+                  :class="{ 'hfl-empty-mark': !(row.started_at || row.created_at) }"
+                >{{ formatTime(row.started_at || row.created_at) }}</span>
+              </template>
+            </el-table-column>
+            <el-table-column
+              :label="t('ops.task.finishedAt')"
+              width="165"
+            >
+              <template #default="{ row }">
+                <span
+                  class="hfl-table-cell-time"
+                  :class="{ 'hfl-empty-mark': !row.finished_at }"
+                >{{ formatTime(row.finished_at) }}</span>
+              </template>
+            </el-table-column>
+            <template #empty>
+              <el-empty
+                v-if="listLoadError"
+                :description="listLoadError"
+                :image-size="80"
+              >
+                <ElButton
+                  type="primary"
+                  @click="load()"
+                >
+                  {{ t('ops.task.btnRetry') }}
+                </ElButton>
+              </el-empty>
+              <el-empty
+                v-else
+                :description="t('ops.task.empty')"
+                :image-size="80"
+              />
+            </template>
+          </el-table>
         </template>
 
         <template #footer>
@@ -1241,10 +1347,21 @@ watch(
       class="hfl-task-filter-drawer"
       @closed="onAdvancedFilterClosed"
     >
-      <ElForm label-position="top" class="hfl-task-filter-form">
+      <ElForm
+        label-position="top"
+        class="hfl-task-filter-form"
+      >
         <ElFormItem :label="t('ops.task.timeField')">
-          <ElSelect v-model="advancedFilterDraft.time_field" class="w-full">
-            <ElOption v-for="item in timeFieldOptions" :key="item.value" :label="item.label" :value="item.value" />
+          <ElSelect
+            v-model="advancedFilterDraft.time_field"
+            class="w-full"
+          >
+            <ElOption
+              v-for="item in timeFieldOptions"
+              :key="item.value"
+              :label="item.label"
+              :value="item.value"
+            />
           </ElSelect>
         </ElFormItem>
         <ElFormItem :label="t('ops.task.filterTime')">
@@ -1266,8 +1383,18 @@ watch(
           <ElSwitch v-model="advancedFilterDraft.terminal_only" />
         </ElFormItem>
         <ElFormItem :label="t('ops.task.filterResource')">
-          <ElSelect v-model="advancedFilterDraft.resource_type" clearable class="w-full" :placeholder="t('ops.task.filterResource')">
-            <ElOption v-for="item in resourceTypeOptions" :key="item" :label="labelFor('resourceType', item)" :value="item" />
+          <ElSelect
+            v-model="advancedFilterDraft.resource_type"
+            clearable
+            class="w-full"
+            :placeholder="t('ops.task.filterResource')"
+          >
+            <ElOption
+              v-for="item in resourceTypeOptions"
+              :key="item"
+              :label="labelFor('resourceType', item)"
+              :value="item"
+            />
           </ElSelect>
         </ElFormItem>
         <ElFormItem :label="t('ops.task.resourceId')">
@@ -1282,21 +1409,42 @@ watch(
       </ElForm>
       <template #footer>
         <div class="el-drawer__footer-main">
-          <ElButton @click="cancelAdvancedFilter">{{ t('ops.task.cancelFilter') }}</ElButton>
+          <ElButton @click="cancelAdvancedFilter">
+            {{ t('ops.task.cancelFilter') }}
+          </ElButton>
           <div class="el-drawer__footer-actions">
-            <ElButton @click="resetAdvancedFilterDraft">{{ t('ops.task.resetFilter') }}</ElButton>
-            <ElButton type="primary" :disabled="loading" @click="applyAdvancedFilters">{{ t('ops.task.applyFilter') }}</ElButton>
+            <ElButton @click="resetAdvancedFilterDraft">
+              {{ t('ops.task.resetFilter') }}
+            </ElButton>
+            <ElButton
+              type="primary"
+              :disabled="loading"
+              @click="applyAdvancedFilters"
+            >
+              {{ t('ops.task.applyFilter') }}
+            </ElButton>
           </div>
         </div>
       </template>
     </ElDrawer>
 
-    <ElDrawer v-model="detailOpen" class="hfl-task-drawer" :size="drawerSize" @opened="onDetailOpened" @closed="closeDetail">
+    <ElDrawer
+      v-model="detailOpen"
+      class="hfl-task-drawer"
+      :size="drawerSize"
+      @opened="onDetailOpened"
+      @closed="closeDetail"
+    >
       <template #header>
         <div class="hfl-task-drawer__header-bar">
-          <div v-if="activeTask" class="hfl-task-drawer__header-summary">
+          <div
+            v-if="activeTask"
+            class="hfl-task-drawer__header-summary"
+          >
             <div class="hfl-task-drawer__header-title-row">
-              <h2 class="hfl-task-drawer__header-title">{{ taskDescription(activeTask) }}</h2>
+              <h2 class="hfl-task-drawer__header-title">
+                {{ taskDescription(activeTask) }}
+              </h2>
               <TaskStatusTag :status="displayTaskStatus(activeTask)" />
             </div>
             <div class="hfl-task-drawer__header-meta">
@@ -1315,7 +1463,12 @@ watch(
               </span>
             </div>
           </div>
-          <h2 v-else class="hfl-task-drawer__header-title">{{ t('ops.task.detailTitle') }}</h2>
+          <h2
+            v-else
+            class="hfl-task-drawer__header-title"
+          >
+            {{ t('ops.task.detailTitle') }}
+          </h2>
           <div class="hfl-task-drawer__header-actions">
             <ElButton
               v-if="canCancel"
@@ -1338,25 +1491,45 @@ watch(
               :disabled="detailRefreshing"
               @click="refreshActiveTask"
             >
-              <RefreshCw :size="20" :class="{ 'is-spinning': detailRefreshing }" />
+              <RefreshCw
+                :size="20"
+                :class="{ 'is-spinning': detailRefreshing }"
+              />
             </button>
           </div>
         </div>
       </template>
 
-      <div v-if="activeTask" ref="drawerScrollAnchorRef" class="hfl-task-drawer__body">
+      <div
+        v-if="activeTask"
+        ref="drawerScrollAnchorRef"
+        class="hfl-task-drawer__body"
+      >
         <section class="hfl-task-drawer__hero">
-          <div class="hfl-task-drawer__hero-section-title">{{ t('ops.task.basicData') }}</div>
+          <div class="hfl-task-drawer__hero-section-title">
+            {{ t('ops.task.basicData') }}
+          </div>
           <div class="hfl-task-drawer__hero-grid">
             <div class="hfl-task-drawer__metric">
-              <Globe :size="18" class="hfl-task-drawer__metric-icon hfl-task-drawer__metric-icon--blue" />
+              <Globe
+                :size="18"
+                class="hfl-task-drawer__metric-icon hfl-task-drawer__metric-icon--blue"
+              />
               <div class="hfl-task-drawer__metric-copy">
                 <span class="hfl-task-drawer__metric-label">{{ t('ops.task.typeAndTrigger') }}</span>
                 <div class="hfl-task-drawer__metric-tags">
-                  <el-tag class="hfl-task-meta-tag" size="small" type="info">
+                  <el-tag
+                    class="hfl-task-meta-tag"
+                    size="small"
+                    type="info"
+                  >
                     {{ labelFor('taskType', activeTask.task_type) }}
                   </el-tag>
-                  <el-tag class="hfl-task-meta-tag" size="small" type="info">
+                  <el-tag
+                    class="hfl-task-meta-tag"
+                    size="small"
+                    type="info"
+                  >
                     {{ labelFor('triggerType', activeTask.trigger_type) }}
                   </el-tag>
                 </div>
@@ -1364,7 +1537,10 @@ watch(
             </div>
 
             <div class="hfl-task-drawer__metric">
-              <RotateCcw :size="18" class="hfl-task-drawer__metric-icon hfl-task-drawer__metric-icon--indigo" />
+              <RotateCcw
+                :size="18"
+                class="hfl-task-drawer__metric-icon hfl-task-drawer__metric-icon--indigo"
+              />
               <div class="hfl-task-drawer__metric-copy">
                 <span class="hfl-task-drawer__metric-label">{{ t('ops.task.retryCount') }}</span>
                 <span class="hfl-task-drawer__metric-value">{{ t('ops.task.retryCountValue', { count: activeTask.retry_count }) }}</span>
@@ -1372,19 +1548,31 @@ watch(
             </div>
 
             <div class="hfl-task-drawer__metric hfl-task-drawer__metric--wide">
-              <Clock3 :size="18" class="hfl-task-drawer__metric-icon" />
+              <Clock3
+                :size="18"
+                class="hfl-task-drawer__metric-icon"
+              />
               <div class="hfl-task-drawer__time-grid">
                 <div>
                   <span class="hfl-task-drawer__metric-label">{{ t('ops.task.startedAt') }}</span>
-                  <span class="hfl-task-drawer__time-value" :class="{ 'hfl-empty-mark': !(activeTask.started_at || activeTask.created_at) }">{{ formatTime(activeTask.started_at || activeTask.created_at) }}</span>
+                  <span
+                    class="hfl-task-drawer__time-value"
+                    :class="{ 'hfl-empty-mark': !(activeTask.started_at || activeTask.created_at) }"
+                  >{{ formatTime(activeTask.started_at || activeTask.created_at) }}</span>
                 </div>
                 <div>
                   <span class="hfl-task-drawer__metric-label">{{ t('ops.task.finishedAt') }}</span>
-                  <span class="hfl-task-drawer__time-value" :class="{ 'hfl-empty-mark': !activeTask.finished_at }">{{ formatTime(activeTask.finished_at) }}</span>
+                  <span
+                    class="hfl-task-drawer__time-value"
+                    :class="{ 'hfl-empty-mark': !activeTask.finished_at }"
+                  >{{ formatTime(activeTask.finished_at) }}</span>
                 </div>
                 <div>
                   <span class="hfl-task-drawer__metric-label">{{ t('ops.task.totalDuration') }}</span>
-                  <span class="hfl-task-drawer__time-value hfl-task-drawer__time-value--strong" :class="{ 'hfl-empty-mark': taskDuration(activeTask) === t('ops.task.emptyMark') }">{{ taskDuration(activeTask) }}</span>
+                  <span
+                    class="hfl-task-drawer__time-value hfl-task-drawer__time-value--strong"
+                    :class="{ 'hfl-empty-mark': taskDuration(activeTask) === t('ops.task.emptyMark') }"
+                  >{{ taskDuration(activeTask) }}</span>
                 </div>
               </div>
             </div>
@@ -1414,7 +1602,10 @@ watch(
         >
           <p>{{ activeTask.status === 'blocked' ? t('ops.task.blockedDescription') : t('ops.task.waitingDescription') }}</p>
           <ul>
-            <li v-for="dependency in activeDependencies" :key="dependency.id">
+            <li
+              v-for="dependency in activeDependencies"
+              :key="dependency.id"
+            >
               <span>{{ dependency.detail }}</span>
               <ElButton
                 v-if="dependency.blocking_task_uuid"
@@ -1428,45 +1619,82 @@ watch(
           </ul>
         </ElAlert>
 
-        <section v-if="showCleanupOutcome" class="hfl-task-drawer__cleanup-outcome" aria-live="polite">
+        <section
+          v-if="showCleanupOutcome"
+          class="hfl-task-drawer__cleanup-outcome"
+          aria-live="polite"
+        >
           <div class="hfl-task-drawer__cleanup-outcome-head">
-            <AlertTriangle :size="17" aria-hidden="true" />
+            <AlertTriangle
+              :size="17"
+              aria-hidden="true"
+            />
             <div>
               <strong>{{ cleanupOutcomeSucceeded ? t('ops.task.cleanupWarningTitle') : t('ops.task.cleanupIncompleteTitle') }}</strong>
               <p>{{ cleanupOutcomeSucceeded ? t('ops.task.cleanupWarningDescription') : t('ops.task.cleanupIncompleteDescription') }}</p>
             </div>
           </div>
-          <div v-if="activeCleanupFailures.length" class="hfl-task-drawer__cleanup-group">
+          <div
+            v-if="activeCleanupFailures.length"
+            class="hfl-task-drawer__cleanup-group"
+          >
             <span class="hfl-task-drawer__cleanup-label">{{ t('ops.task.cleanupFailures') }}</span>
             <ul>
-              <li v-for="failure in activeCleanupFailures" :key="`${failure.sourceId || ''}:${failure.code}:${failure.detail}`">
+              <li
+                v-for="failure in activeCleanupFailures"
+                :key="`${failure.sourceId || ''}:${failure.code}:${failure.detail}`"
+              >
                 <strong>{{ failure.sourceName || failure.code }}</strong>
                 <span>{{ failure.detail }}</span>
               </li>
             </ul>
           </div>
-          <div v-if="activeCleanupWarnings.length" class="hfl-task-drawer__cleanup-group">
+          <div
+            v-if="activeCleanupWarnings.length"
+            class="hfl-task-drawer__cleanup-group"
+          >
             <span class="hfl-task-drawer__cleanup-label">{{ t('ops.task.cleanupWarnings') }}</span>
             <ul>
-              <li v-for="warning in activeCleanupWarnings" :key="`${warning.sourceId || ''}:${warning.code}:${warning.detail}`">
+              <li
+                v-for="warning in activeCleanupWarnings"
+                :key="`${warning.sourceId || ''}:${warning.code}:${warning.detail}`"
+              >
                 <strong>{{ warning.sourceName || warning.code }}</strong>
                 <span>{{ warning.detail }}</span>
               </li>
             </ul>
           </div>
-          <div v-if="activeRetainedResources.length" class="hfl-task-drawer__cleanup-group">
+          <div
+            v-if="activeRetainedResources.length"
+            class="hfl-task-drawer__cleanup-group"
+          >
             <span class="hfl-task-drawer__cleanup-label">{{ t('ops.task.retainedResources') }}</span>
             <ul>
-              <li v-for="resource in activeRetainedResources" :key="resource">
+              <li
+                v-for="resource in activeRetainedResources"
+                :key="resource"
+              >
                 <code>{{ resource }}</code>
               </li>
             </ul>
           </div>
-          <div v-if="activeFailedCleanupChildren.length" class="hfl-task-drawer__cleanup-group">
+          <div
+            v-if="activeFailedCleanupChildren.length"
+            class="hfl-task-drawer__cleanup-group"
+          >
             <span class="hfl-task-drawer__cleanup-label">{{ t('ops.task.failedCleanupTasks') }}</span>
             <ul>
-              <li v-for="child in activeFailedCleanupChildren" :key="child.taskUuid">
-                <button type="button" class="hfl-table-name-link" @click="openTaskDetail(child.taskUuid)">{{ child.taskUuid }}</button>
+              <li
+                v-for="child in activeFailedCleanupChildren"
+                :key="child.taskUuid"
+              >
+                <button
+                  type="button"
+                  class="hfl-table-name-link"
+                  @click="openTaskDetail(child.taskUuid)"
+                >
+                  {{ child.taskUuid }}
+                </button>
                 <span>{{ child.error }}</span>
               </li>
             </ul>
@@ -1494,157 +1722,279 @@ watch(
               </span>
             </template>
             <section class="hfl-task-drawer__tab-panel">
-          <div class="hfl-task-drawer__steps-head">
-            <span>{{ t('ops.task.stepsHealthy') }}</span>
-            <ElButton
-              v-if="hasExpandableSteps"
-              size="small"
-              class="hfl-btn-with-icon"
-              @click="toggleAllStepsExpanded"
-            >
-              {{ hasAnyExpandedStep ? t('ops.task.collapseAll') : t('ops.task.expandAll') }}
-              <ChevronDown v-if="hasAnyExpandedStep" :size="16" class="hfl-task-step-chevron" />
-              <ChevronRight v-else :size="16" class="hfl-task-step-chevron" />
-            </ElButton>
-          </div>
-
-          <div v-if="stepsWithEvents.length > 0" class="hfl-task-drawer__step-list">
-            <div
-              v-for="(step, si) in stepsWithEvents"
-              :key="step.id"
-              class="hfl-task-drawer__step-item"
-              :class="{ 'hfl-task-drawer__step-item--last': si === stepsWithEvents.length - 1 && unlinkedEvents.length === 0 }"
-            >
-              <div class="hfl-task-drawer__step-anchor" :class="timelineIconClass(step.status)">
-                <Check v-if="step.status === 'success'" :size="15" />
-                <AlertTriangle v-else-if="step.status === 'warning'" :size="13" />
-                <X v-else-if="step.status === 'failed' || step.status === 'timeout'" :size="15" />
-                <Clock3 v-else-if="step.status === 'running'" :size="15" />
-                <Circle v-else :size="9" />
-              </div>
-
-              <article class="hfl-task-drawer__step-card">
-                <button
-                  type="button"
-                  class="hfl-task-drawer__step-card-head"
-                  :class="{ 'hfl-task-drawer__step-card-head--disabled': step.events.length === 0 }"
-                  :aria-expanded="step.events.length > 0 && isStepExpanded(step.id)"
-                  :aria-disabled="step.events.length === 0"
-                  :aria-description="step.events.length === 0 ? t('ops.task.emptyEvents') : undefined"
-                  @click="toggleStep(step.id, step.events.length)"
+              <div class="hfl-task-drawer__steps-head">
+                <span>{{ t('ops.task.stepsHealthy') }}</span>
+                <ElButton
+                  v-if="hasExpandableSteps"
+                  size="small"
+                  class="hfl-btn-with-icon"
+                  @click="toggleAllStepsExpanded"
                 >
-                  <span class="hfl-task-drawer__step-title">
-                    {{ stepDisplayName(step.step_name, activeTask.task_type) }}
-                    <span class="hfl-task-drawer__step-executed-at">
-                      <span :class="{ 'hfl-empty-mark': !(step.created_at || activeTask.created_at) }">{{ formatTime(step.created_at || activeTask.created_at) }}</span>
-                    </span>
-                  </span>
-                  <TaskStatusTag :status="step.status" />
-                  <span class="hfl-task-drawer__step-duration">
-                    <Clock3 :size="12" />
-                    {{ stepDuration(si) }}
-                  </span>
-                  <ElTooltip
-                    v-if="step.events.length === 0"
-                    :content="t('ops.task.emptyEvents')"
-                    teleported
-                    append-to="body"
-                    :z-index="3600"
-                    placement="top"
-                    :show-after="200"
-                  >
-                    <span class="hfl-task-step-chevron hfl-task-step-chevron--disabled">
-                      <ChevronRight :size="16" aria-hidden="true" />
-                    </span>
-                  </ElTooltip>
-                  <ChevronDown v-else-if="isStepExpanded(step.id)" :size="16" class="hfl-task-step-chevron" />
-                  <ChevronRight v-else :size="16" class="hfl-task-step-chevron" />
-                </button>
-
-                <div v-if="isStepExpanded(step.id) && step.events.length > 0" class="hfl-task-drawer__event-list">
-                  <div
-                    v-for="event in step.events"
-                    :key="event.id"
-                    class="hfl-task-drawer__event-row"
-                  >
-                    <span class="hfl-task-drawer__event-dot" :class="`hfl-task-drawer__event-dot--${eventTone(event)}`">
-                      <X v-if="eventTone(event) === 'danger'" :size="9" />
-                      <Circle v-else-if="eventTone(event) === 'muted'" :size="7" />
-                      <Check v-else :size="9" />
-                    </span>
-                    <span class="hfl-task-drawer__event-content">
-                      <span class="hfl-task-drawer__event-msg" :class="eventMessageClass(event)">{{ eventDisplayMessage(event) }}</span>
-                      <span v-if="eventObjectText(event)" class="hfl-task-drawer__event-object">
-                        <Link2 :size="11" />
-                        <span>{{ eventObjectText(event) }}</span>
-                      </span>
-                      <span v-if="eventErrorText(event)" class="hfl-task-drawer__event-error">{{ eventErrorText(event) }}</span>
-                    </span>
-                    <span class="hfl-task-drawer__event-time" :class="{ 'hfl-empty-mark': !event.created_at }">{{ formatTime(event.created_at) }}</span>
-                  </div>
-                </div>
-              </article>
-            </div>
-
-            <div v-if="unlinkedEvents.length > 0" class="hfl-task-drawer__step-item hfl-task-drawer__step-item--last">
-              <div class="hfl-task-drawer__step-anchor hfl-task-drawer__timeline-icon--muted">
-                <Circle :size="9" />
+                  {{ hasAnyExpandedStep ? t('ops.task.collapseAll') : t('ops.task.expandAll') }}
+                  <ChevronDown
+                    v-if="hasAnyExpandedStep"
+                    :size="16"
+                    class="hfl-task-step-chevron"
+                  />
+                  <ChevronRight
+                    v-else
+                    :size="16"
+                    class="hfl-task-step-chevron"
+                  />
+                </ElButton>
               </div>
-              <article class="hfl-task-drawer__step-card">
-                <div class="hfl-task-drawer__step-card-head hfl-task-drawer__step-card-head--static">
-                  <span class="hfl-task-drawer__step-title">{{ t('ops.task.events') }}</span>
-                  <span class="hfl-task-drawer__step-duration">{{ taskDuration(activeTask) }}</span>
-                </div>
-                <div class="hfl-task-drawer__event-list">
+
+              <div
+                v-if="stepsWithEvents.length > 0"
+                class="hfl-task-drawer__step-list"
+              >
+                <div
+                  v-for="(step, si) in stepsWithEvents"
+                  :key="step.id"
+                  class="hfl-task-drawer__step-item"
+                  :class="{ 'hfl-task-drawer__step-item--last': si === stepsWithEvents.length - 1 && unlinkedEvents.length === 0 }"
+                >
                   <div
-                    v-for="event in unlinkedEvents"
-                    :key="event.id"
-                    class="hfl-task-drawer__event-row"
+                    class="hfl-task-drawer__step-anchor"
+                    :class="timelineIconClass(step.status)"
                   >
-                    <span class="hfl-task-drawer__event-dot" :class="`hfl-task-drawer__event-dot--${eventTone(event)}`">
-                      <X v-if="eventTone(event) === 'danger'" :size="9" />
-                      <Circle v-else-if="eventTone(event) === 'muted'" :size="7" />
-                      <Check v-else :size="9" />
-                    </span>
-                    <span class="hfl-task-drawer__event-content">
-                      <span class="hfl-task-drawer__event-msg" :class="eventMessageClass(event)">{{ eventDisplayMessage(event) }}</span>
-                      <span v-if="eventObjectText(event)" class="hfl-task-drawer__event-object">
-                        <Link2 :size="11" />
-                        <span>{{ eventObjectText(event) }}</span>
-                      </span>
-                      <span v-if="eventErrorText(event)" class="hfl-task-drawer__event-error">{{ eventErrorText(event) }}</span>
-                    </span>
-                    <span class="hfl-task-drawer__event-time" :class="{ 'hfl-empty-mark': !event.created_at }">{{ formatTime(event.created_at) }}</span>
+                    <Check
+                      v-if="step.status === 'success'"
+                      :size="15"
+                    />
+                    <AlertTriangle
+                      v-else-if="step.status === 'warning'"
+                      :size="13"
+                    />
+                    <X
+                      v-else-if="step.status === 'failed' || step.status === 'timeout'"
+                      :size="15"
+                    />
+                    <Clock3
+                      v-else-if="step.status === 'running'"
+                      :size="15"
+                    />
+                    <Circle
+                      v-else
+                      :size="9"
+                    />
                   </div>
+
+                  <article class="hfl-task-drawer__step-card">
+                    <button
+                      type="button"
+                      class="hfl-task-drawer__step-card-head"
+                      :class="{ 'hfl-task-drawer__step-card-head--disabled': step.events.length === 0 }"
+                      :aria-expanded="step.events.length > 0 && isStepExpanded(step.id)"
+                      :aria-disabled="step.events.length === 0"
+                      :aria-description="step.events.length === 0 ? t('ops.task.emptyEvents') : undefined"
+                      @click="toggleStep(step.id, step.events.length)"
+                    >
+                      <span class="hfl-task-drawer__step-title">
+                        {{ stepDisplayName(step.step_name, activeTask.task_type) }}
+                        <span class="hfl-task-drawer__step-executed-at">
+                          <span :class="{ 'hfl-empty-mark': !(step.created_at || activeTask.created_at) }">{{ formatTime(step.created_at || activeTask.created_at) }}</span>
+                        </span>
+                      </span>
+                      <TaskStatusTag :status="step.status" />
+                      <span class="hfl-task-drawer__step-duration">
+                        <Clock3 :size="12" />
+                        {{ stepDuration(si) }}
+                      </span>
+                      <ElTooltip
+                        v-if="step.events.length === 0"
+                        :content="t('ops.task.emptyEvents')"
+                        teleported
+                        append-to="body"
+                        :z-index="3600"
+                        placement="top"
+                        :show-after="200"
+                      >
+                        <span class="hfl-task-step-chevron hfl-task-step-chevron--disabled">
+                          <ChevronRight
+                            :size="16"
+                            aria-hidden="true"
+                          />
+                        </span>
+                      </ElTooltip>
+                      <ChevronDown
+                        v-else-if="isStepExpanded(step.id)"
+                        :size="16"
+                        class="hfl-task-step-chevron"
+                      />
+                      <ChevronRight
+                        v-else
+                        :size="16"
+                        class="hfl-task-step-chevron"
+                      />
+                    </button>
+
+                    <div
+                      v-if="isStepExpanded(step.id) && step.events.length > 0"
+                      class="hfl-task-drawer__event-list"
+                    >
+                      <div
+                        v-for="event in step.events"
+                        :key="event.id"
+                        class="hfl-task-drawer__event-row"
+                      >
+                        <span
+                          class="hfl-task-drawer__event-dot"
+                          :class="`hfl-task-drawer__event-dot--${eventTone(event)}`"
+                        >
+                          <X
+                            v-if="eventTone(event) === 'danger'"
+                            :size="9"
+                          />
+                          <Circle
+                            v-else-if="eventTone(event) === 'muted'"
+                            :size="7"
+                          />
+                          <Check
+                            v-else
+                            :size="9"
+                          />
+                        </span>
+                        <span class="hfl-task-drawer__event-content">
+                          <span
+                            class="hfl-task-drawer__event-msg"
+                            :class="eventMessageClass(event)"
+                          >{{ eventDisplayMessage(event) }}</span>
+                          <span
+                            v-if="eventObjectText(event)"
+                            class="hfl-task-drawer__event-object"
+                          >
+                            <Link2 :size="11" />
+                            <span>{{ eventObjectText(event) }}</span>
+                          </span>
+                          <span
+                            v-if="eventErrorText(event)"
+                            class="hfl-task-drawer__event-error"
+                          >{{ eventErrorText(event) }}</span>
+                        </span>
+                        <span
+                          class="hfl-task-drawer__event-time"
+                          :class="{ 'hfl-empty-mark': !event.created_at }"
+                        >{{ formatTime(event.created_at) }}</span>
+                      </div>
+                    </div>
+                  </article>
                 </div>
-              </article>
-            </div>
-          </div>
 
-          <div v-else-if="detailEvents.length > 0" class="hfl-task-drawer__event-only">
-            <div
-              v-for="event in detailEvents"
-              :key="event.id"
-              class="hfl-task-drawer__event-row"
-            >
-              <span class="hfl-task-drawer__event-dot" :class="`hfl-task-drawer__event-dot--${eventTone(event)}`">
-                <X v-if="eventTone(event) === 'danger'" :size="9" />
-                <Circle v-else-if="eventTone(event) === 'muted'" :size="7" />
-                <Check v-else :size="9" />
-              </span>
-              <span class="hfl-task-drawer__event-content">
-                <span class="hfl-task-drawer__event-msg" :class="eventMessageClass(event)">{{ eventDisplayMessage(event) }}</span>
-                <span v-if="eventObjectText(event)" class="hfl-task-drawer__event-object">
-                  <Link2 :size="11" />
-                  <span>{{ eventObjectText(event) }}</span>
-                </span>
-                <span v-if="eventErrorText(event)" class="hfl-task-drawer__event-error">{{ eventErrorText(event) }}</span>
-              </span>
-              <span class="hfl-task-drawer__event-time">#{{ event.seq }} · <span :class="{ 'hfl-empty-mark': !event.created_at }">{{ formatTime(event.created_at) }}</span></span>
-            </div>
-          </div>
+                <div
+                  v-if="unlinkedEvents.length > 0"
+                  class="hfl-task-drawer__step-item hfl-task-drawer__step-item--last"
+                >
+                  <div class="hfl-task-drawer__step-anchor hfl-task-drawer__timeline-icon--muted">
+                    <Circle :size="9" />
+                  </div>
+                  <article class="hfl-task-drawer__step-card">
+                    <div class="hfl-task-drawer__step-card-head hfl-task-drawer__step-card-head--static">
+                      <span class="hfl-task-drawer__step-title">{{ t('ops.task.events') }}</span>
+                      <span class="hfl-task-drawer__step-duration">{{ taskDuration(activeTask) }}</span>
+                    </div>
+                    <div class="hfl-task-drawer__event-list">
+                      <div
+                        v-for="event in unlinkedEvents"
+                        :key="event.id"
+                        class="hfl-task-drawer__event-row"
+                      >
+                        <span
+                          class="hfl-task-drawer__event-dot"
+                          :class="`hfl-task-drawer__event-dot--${eventTone(event)}`"
+                        >
+                          <X
+                            v-if="eventTone(event) === 'danger'"
+                            :size="9"
+                          />
+                          <Circle
+                            v-else-if="eventTone(event) === 'muted'"
+                            :size="7"
+                          />
+                          <Check
+                            v-else
+                            :size="9"
+                          />
+                        </span>
+                        <span class="hfl-task-drawer__event-content">
+                          <span
+                            class="hfl-task-drawer__event-msg"
+                            :class="eventMessageClass(event)"
+                          >{{ eventDisplayMessage(event) }}</span>
+                          <span
+                            v-if="eventObjectText(event)"
+                            class="hfl-task-drawer__event-object"
+                          >
+                            <Link2 :size="11" />
+                            <span>{{ eventObjectText(event) }}</span>
+                          </span>
+                          <span
+                            v-if="eventErrorText(event)"
+                            class="hfl-task-drawer__event-error"
+                          >{{ eventErrorText(event) }}</span>
+                        </span>
+                        <span
+                          class="hfl-task-drawer__event-time"
+                          :class="{ 'hfl-empty-mark': !event.created_at }"
+                        >{{ formatTime(event.created_at) }}</span>
+                      </div>
+                    </div>
+                  </article>
+                </div>
+              </div>
 
-          <el-empty v-else :description="t('ops.task.emptySteps')" :image-size="52" />
+              <div
+                v-else-if="detailEvents.length > 0"
+                class="hfl-task-drawer__event-only"
+              >
+                <div
+                  v-for="event in detailEvents"
+                  :key="event.id"
+                  class="hfl-task-drawer__event-row"
+                >
+                  <span
+                    class="hfl-task-drawer__event-dot"
+                    :class="`hfl-task-drawer__event-dot--${eventTone(event)}`"
+                  >
+                    <X
+                      v-if="eventTone(event) === 'danger'"
+                      :size="9"
+                    />
+                    <Circle
+                      v-else-if="eventTone(event) === 'muted'"
+                      :size="7"
+                    />
+                    <Check
+                      v-else
+                      :size="9"
+                    />
+                  </span>
+                  <span class="hfl-task-drawer__event-content">
+                    <span
+                      class="hfl-task-drawer__event-msg"
+                      :class="eventMessageClass(event)"
+                    >{{ eventDisplayMessage(event) }}</span>
+                    <span
+                      v-if="eventObjectText(event)"
+                      class="hfl-task-drawer__event-object"
+                    >
+                      <Link2 :size="11" />
+                      <span>{{ eventObjectText(event) }}</span>
+                    </span>
+                    <span
+                      v-if="eventErrorText(event)"
+                      class="hfl-task-drawer__event-error"
+                    >{{ eventErrorText(event) }}</span>
+                  </span>
+                  <span class="hfl-task-drawer__event-time">#{{ event.seq }} · <span :class="{ 'hfl-empty-mark': !event.created_at }">{{ formatTime(event.created_at) }}</span></span>
+                </div>
+              </div>
+
+              <el-empty
+                v-else
+                :description="t('ops.task.emptySteps')"
+                :image-size="52"
+              />
             </section>
           </ElTabPane>
 
@@ -1656,132 +2006,179 @@ watch(
               </span>
             </template>
             <section class="hfl-task-drawer__tab-panel">
-          <div v-if="resourceTypeTabs.length > 0" class="hfl-task-drawer__resource-view">
-            <div class="hfl-task-drawer__resource-switcher">
-              <button
-                v-for="item in resourceTypeTabs"
-                :key="item.type"
-                type="button"
-                class="hfl-task-drawer__resource-switch"
-                :class="{ 'hfl-task-drawer__resource-switch--active': selectedResourceType === item.type }"
-                @click="loadResourceType(item.type)"
+              <div
+                v-if="resourceTypeTabs.length > 0"
+                class="hfl-task-drawer__resource-view"
               >
-                <Link2 :size="14" />
-                {{ item.label }}
-                <span class="hfl-task-drawer__resource-switch-count">{{ item.count }}</span>
-              </button>
-            </div>
-
-            <div v-if="resourceErrors[selectedResourceType]" class="hfl-task-drawer__resource-error">
-              {{ resourceErrors[selectedResourceType] }}
-            </div>
-
-            <el-table
-              v-table-column-resize="'ops.tasks.resources'"
-              v-table-overflow-title
-              v-loading="resourceLoading"
-              :data="selectedResourceRows"
-              class="hfl-list-table hfl-list-table--compact hfl-task-drawer__resource-table"
-            >
-              <el-table-column :label="t('ops.task.resourceId')" width="120">
-                <template #default="{ row }">
-                  <span class="hfl-table-cell-mono">{{ row.id }}</span>
-                </template>
-              </el-table-column>
-              <el-table-column
-                v-if="selectedResourceType === 'backup_source'"
-                :label="t('protection.backupsPage.colBackupSource')"
-                min-width="180"
-              >
-                <template #default="{ row }">
-                  <FlowSourceSummaryCell
-                    v-if="row.flowSource"
-                    :row="row.flowSource"
-                    :interactive="false"
-                  />
-                  <div v-else>
-                    <div class="hfl-task-drawer__resource-name">{{ row.name }}</div>
-                    <div class="hfl-task-drawer__resource-summary">{{ row.type }}</div>
-                  </div>
-                </template>
-              </el-table-column>
-              <el-table-column v-if="selectedResourceType === 'backup_source'" :label="t('protection.backupsPage.colConnectionAddress')" min-width="200">
-                <template #default="{ row }">
-                  <FlowSourceConnectionCell v-if="row.flowSource" :row="row.flowSource" />
-                  <span v-else :class="{ 'hfl-empty-mark': !row.endpointIp && !row.endpointName }">{{ row.endpointIp || row.endpointName || t('ops.task.emptyMark') }}</span>
-                </template>
-              </el-table-column>
-              <el-table-column
-                v-if="selectedResourceType !== 'backup_source'"
-                :label="t('ops.task.nameLabel')"
-                :min-width="isRepositoryResourceType ? 330 : 180"
-              >
-                <template #default="{ row }">
-                  <div class="hfl-task-drawer__resource-name">{{ row.name }}</div>
-                  <div class="hfl-task-drawer__resource-summary">{{ row.summary }}</div>
-                </template>
-              </el-table-column>
-              <el-table-column
-                v-if="selectedResourceType !== 'backup_source'"
-                :label="t('ops.task.resourceTypeLabel')"
-                :width="isRepositoryResourceType ? 195 : 140"
-              >
-                <template #default="{ row }">
-                  <ElTag type="info" size="small" effect="plain">
-                    {{ row.type }}
-                  </ElTag>
-                </template>
-              </el-table-column>
-              <el-table-column
-                :label="selectedResourceType === 'backup_source'
-                  ? t('protection.sourceResources.colConnectivity')
-                  : t('ops.task.colStatus')"
-                :width="isRepositoryResourceType ? 165 : 110"
-              >
-                <template #default="{ row }">
-                  <ElTag
-                    v-if="selectedResourceType === 'backup_source' && row.availability"
-                    :type="backupSourceConnectivityTagType(row.availability)"
-                    size="small"
+                <div class="hfl-task-drawer__resource-switcher">
+                  <button
+                    v-for="item in resourceTypeTabs"
+                    :key="item.type"
+                    type="button"
+                    class="hfl-task-drawer__resource-switch"
+                    :class="{ 'hfl-task-drawer__resource-switch--active': selectedResourceType === item.type }"
+                    @click="loadResourceType(item.type)"
                   >
-                    {{ backupSourceConnectivityLabel(row.availability) }}
-                  </ElTag>
-                  <ElTag
-                    v-else-if="selectedResourceType !== 'backup_source' && row.status"
-                    v-bind="lifecycleStatusTagAttrs(row.statusValue)"
-                    size="small"
+                    <Link2 :size="14" />
+                    {{ item.label }}
+                    <span class="hfl-task-drawer__resource-switch-count">{{ item.count }}</span>
+                  </button>
+                </div>
+
+                <div
+                  v-if="resourceErrors[selectedResourceType]"
+                  class="hfl-task-drawer__resource-error"
+                >
+                  {{ resourceErrors[selectedResourceType] }}
+                </div>
+
+                <el-table
+                  v-table-column-resize="'ops.tasks.resources'"
+                  v-table-overflow-title
+                  v-loading="resourceLoading"
+                  :data="selectedResourceRows"
+                  class="hfl-list-table hfl-list-table--compact hfl-task-drawer__resource-table"
+                >
+                  <el-table-column
+                    :label="t('ops.task.resourceId')"
+                    width="120"
                   >
-                    {{ row.status }}
-                  </ElTag>
-                  <span v-else class="hfl-empty-mark">—</span>
-                </template>
-              </el-table-column>
-              <el-table-column
-                :label="selectedResourceType === 'backup_source'
-                  ? t('protection.backupsPage.colRegistered')
-                  : isRepositoryResourceType
-                    ? t('ops.task.registeredAt')
-                    : t('ops.task.updatedAt')"
-                width="180"
-              >
-                <template #default="{ row }">
-                  <span
-                    class="hfl-table-cell-time"
-                    :class="{ 'hfl-empty-mark': !(selectedResourceType === 'backup_source' || isRepositoryResourceType ? row.registeredAt : row.updatedAt) }"
-                  >{{ formatTime(selectedResourceType === 'backup_source' || isRepositoryResourceType ? row.registeredAt : row.updatedAt) }}</span>
-                </template>
-              </el-table-column>
-            </el-table>
-          </div>
-          <el-empty v-else :description="t('ops.task.emptyResources')" :image-size="52" />
+                    <template #default="{ row }">
+                      <span class="hfl-table-cell-mono">{{ row.id }}</span>
+                    </template>
+                  </el-table-column>
+                  <el-table-column
+                    v-if="selectedResourceType === 'backup_source'"
+                    :label="t('protection.backupsPage.colBackupSource')"
+                    min-width="180"
+                  >
+                    <template #default="{ row }">
+                      <FlowSourceSummaryCell
+                        v-if="row.flowSource"
+                        :row="row.flowSource"
+                        :interactive="false"
+                      />
+                      <div v-else>
+                        <div class="hfl-task-drawer__resource-name">
+                          {{ row.name }}
+                        </div>
+                        <div class="hfl-task-drawer__resource-summary">
+                          {{ row.type }}
+                        </div>
+                      </div>
+                    </template>
+                  </el-table-column>
+                  <el-table-column
+                    v-if="selectedResourceType === 'backup_source'"
+                    :label="t('protection.backupsPage.colConnectionAddress')"
+                    min-width="200"
+                  >
+                    <template #default="{ row }">
+                      <FlowSourceConnectionCell
+                        v-if="row.flowSource"
+                        :row="row.flowSource"
+                      />
+                      <span
+                        v-else
+                        :class="{ 'hfl-empty-mark': !row.endpointIp && !row.endpointName }"
+                      >{{ row.endpointIp || row.endpointName || t('ops.task.emptyMark') }}</span>
+                    </template>
+                  </el-table-column>
+                  <el-table-column
+                    v-if="selectedResourceType !== 'backup_source'"
+                    :label="t('ops.task.nameLabel')"
+                    :min-width="isRepositoryResourceType ? 330 : 180"
+                  >
+                    <template #default="{ row }">
+                      <div class="hfl-task-drawer__resource-name">
+                        {{ row.name }}
+                      </div>
+                      <div class="hfl-task-drawer__resource-summary">
+                        {{ row.summary }}
+                      </div>
+                    </template>
+                  </el-table-column>
+                  <el-table-column
+                    v-if="selectedResourceType !== 'backup_source'"
+                    :label="t('ops.task.resourceTypeLabel')"
+                    :width="isRepositoryResourceType ? 195 : 140"
+                  >
+                    <template #default="{ row }">
+                      <ElTag
+                        type="info"
+                        size="small"
+                        effect="plain"
+                      >
+                        {{ row.type }}
+                      </ElTag>
+                    </template>
+                  </el-table-column>
+                  <el-table-column
+                    :label="selectedResourceType === 'backup_source'
+                      ? t('protection.sourceResources.colConnectivity')
+                      : t('ops.task.colStatus')"
+                    :width="isRepositoryResourceType ? 165 : 110"
+                  >
+                    <template #default="{ row }">
+                      <ElTag
+                        v-if="selectedResourceType === 'backup_source' && row.availability"
+                        :type="backupSourceConnectivityTagType(row.availability)"
+                        size="small"
+                      >
+                        {{ backupSourceConnectivityLabel(row.availability) }}
+                      </ElTag>
+                      <ElTag
+                        v-else-if="selectedResourceType !== 'backup_source' && row.status"
+                        v-bind="lifecycleStatusTagAttrs(row.statusValue)"
+                        size="small"
+                      >
+                        {{ row.status }}
+                      </ElTag>
+                      <span
+                        v-else
+                        class="hfl-empty-mark"
+                      >—</span>
+                    </template>
+                  </el-table-column>
+                  <el-table-column
+                    :label="selectedResourceType === 'backup_source'
+                      ? t('protection.backupsPage.colRegistered')
+                      : isRepositoryResourceType
+                        ? t('ops.task.registeredAt')
+                        : t('ops.task.updatedAt')"
+                    width="180"
+                  >
+                    <template #default="{ row }">
+                      <span
+                        class="hfl-table-cell-time"
+                        :class="{ 'hfl-empty-mark': !(selectedResourceType === 'backup_source' || isRepositoryResourceType ? row.registeredAt : row.updatedAt) }"
+                      >{{ formatTime(selectedResourceType === 'backup_source' || isRepositoryResourceType ? row.registeredAt : row.updatedAt) }}</span>
+                    </template>
+                  </el-table-column>
+                </el-table>
+              </div>
+              <el-empty
+                v-else
+                :description="t('ops.task.emptyResources')"
+                :image-size="52"
+              />
             </section>
           </ElTabPane>
-
         </ElTabs>
       </div>
-      <div v-else ref="drawerScrollAnchorRef" class="hfl-task-drawer__body">
-        <div class="hfl-task-drawer__loading" aria-busy="true">
-          <el-skeleton :rows="6" animated />
+      <div
+        v-else
+        ref="drawerScrollAnchorRef"
+        class="hfl-task-drawer__body"
+      >
+        <div
+          class="hfl-task-drawer__loading"
+          aria-busy="true"
+        >
+          <el-skeleton
+            :rows="6"
+            animated
+          />
         </div>
       </div>
     </ElDrawer>

--- a/src/frontend/src/pages/protection/BackupConfigCreateWizard.vue
+++ b/src/frontend/src/pages/protection/BackupConfigCreateWizard.vue
@@ -93,12 +93,23 @@ watch(
     >
       <div class="fullscreen-form-page create-backup-page">
         <div class="fullscreen-form-header">
-          <button type="button" class="fullscreen-form-header__back" @click="emit('close')">
-            <ArrowLeft class="fullscreen-form-header__back-icon" :size="18" />
+          <button
+            type="button"
+            class="fullscreen-form-header__back"
+            @click="emit('close')"
+          >
+            <ArrowLeft
+              class="fullscreen-form-header__back-icon"
+              :size="18"
+            />
           </button>
           <div class="fullscreen-form-header__content">
-            <h1 class="fullscreen-form-header__title">{{ title }}</h1>
-            <p class="fullscreen-form-header__desc">{{ description }}</p>
+            <h1 class="fullscreen-form-header__title">
+              {{ title }}
+            </h1>
+            <p class="fullscreen-form-header__desc">
+              {{ description }}
+            </p>
           </div>
         </div>
 
@@ -122,10 +133,20 @@ watch(
           />
 
           <main class="fullscreen-form-main create-backup-main">
-            <div v-if="bootstrapping" class="create-backup-step-body dp-process-page create-backup-loading-pane">
+            <div
+              v-if="bootstrapping"
+              class="create-backup-step-body dp-process-page create-backup-loading-pane"
+            >
               <div class="fullscreen-form-card create-backup-loading-card">
-                <el-progress :percentage="66" :indeterminate="true" status="warning" class="mb-4" />
-                <p class="text-slate-600">{{ waitingText }}</p>
+                <el-progress
+                  :percentage="66"
+                  :indeterminate="true"
+                  status="warning"
+                  class="mb-4"
+                />
+                <p class="text-slate-600">
+                  {{ waitingText }}
+                </p>
               </div>
             </div>
 
@@ -136,17 +157,41 @@ watch(
               <slot name="form" />
             </div>
 
-            <div v-else-if="phase === 'waiting'" class="fullscreen-form-card py-10 text-center">
-              <el-progress :percentage="66" :indeterminate="true" status="warning" class="mb-4" />
-              <p class="text-slate-600">{{ waitingText }}</p>
+            <div
+              v-else-if="phase === 'waiting'"
+              class="fullscreen-form-card py-10 text-center"
+            >
+              <el-progress
+                :percentage="66"
+                :indeterminate="true"
+                status="warning"
+                class="mb-4"
+              />
+              <p class="text-slate-600">
+                {{ waitingText }}
+              </p>
             </div>
 
-            <div v-else class="fullscreen-form-card py-8 text-center space-y-4">
-              <el-result icon="success" :title="resultTitle" :sub-title="resultSubtitle">
+            <div
+              v-else
+              class="fullscreen-form-card py-8 text-center space-y-4"
+            >
+              <el-result
+                icon="success"
+                :title="resultTitle"
+                :sub-title="resultSubtitle"
+              >
                 <template #extra>
                   <div class="flex flex-wrap items-center justify-center gap-2">
-                    <ElButton type="primary" @click="emit('close')">{{ closeLabel }}</ElButton>
-                    <ElButton @click="emit('goToStartBackup')">{{ goToStartBackupLabel }}</ElButton>
+                    <ElButton
+                      type="primary"
+                      @click="emit('close')"
+                    >
+                      {{ closeLabel }}
+                    </ElButton>
+                    <ElButton @click="emit('goToStartBackup')">
+                      {{ goToStartBackupLabel }}
+                    </ElButton>
                   </div>
                 </template>
               </el-result>
@@ -154,22 +199,46 @@ watch(
           </main>
         </div>
 
-        <div v-if="phase === 'form' || bootstrapping" class="fullscreen-form-footer create-backup-footer">
+        <div
+          v-if="phase === 'form' || bootstrapping"
+          class="fullscreen-form-footer create-backup-footer"
+        >
           <div class="create-backup-footer__inner">
             <div class="create-backup-footer__actions">
-              <ElButton class="hfl-btn-with-icon" @click="emit('close')">
+              <ElButton
+                class="hfl-btn-with-icon"
+                @click="emit('close')"
+              >
                 <X :size="14" />
                 <span>{{ cancelLabel }}</span>
               </ElButton>
-              <ElButton v-if="canGoPrev" class="hfl-btn-with-icon" :disabled="bootstrapping || busy" @click="emit('prev')">
+              <ElButton
+                v-if="canGoPrev"
+                class="hfl-btn-with-icon"
+                :disabled="bootstrapping || busy"
+                @click="emit('prev')"
+              >
                 <ArrowLeft :size="14" />
                 <span>{{ prevLabel }}</span>
               </ElButton>
-              <ElButton v-if="!isLastStep" type="primary" class="hfl-btn-with-icon" :loading="busy" :disabled="bootstrapping || busy" @click="emit('next')">
+              <ElButton
+                v-if="!isLastStep"
+                type="primary"
+                class="hfl-btn-with-icon"
+                :loading="busy"
+                :disabled="bootstrapping || busy"
+                @click="emit('next')"
+              >
                 <span>{{ nextLabel }}</span>
                 <ArrowRight :size="14" />
               </ElButton>
-              <ElButton v-else type="primary" class="hfl-btn-with-icon" :disabled="bootstrapping || busy" @click="emit('confirm')">
+              <ElButton
+                v-else
+                type="primary"
+                class="hfl-btn-with-icon"
+                :disabled="bootstrapping || busy"
+                @click="emit('confirm')"
+              >
                 <Check :size="14" />
                 <span>{{ confirmLabel }}</span>
               </ElButton>

--- a/src/frontend/src/pages/protection/BackupCreateWizard.vue
+++ b/src/frontend/src/pages/protection/BackupCreateWizard.vue
@@ -188,6 +188,7 @@ const props = withDefaults(defineProps<{
   embedded: false,
   initialSources: () => [],
   initialEditConfigIds: () => [],
+  initialEditSection: undefined,
 })
 const emit = defineEmits<{
   closed: []
@@ -5903,13 +5904,23 @@ function preserveShallowestPathOrder(paths: string[]) {
           >
             <X :size="15" />
           </button>
-          <div class="create-validation-popover__title">{{ validationPopoverTitle }}</div>
+          <div class="create-validation-popover__title">
+            {{ validationPopoverTitle }}
+          </div>
           <ul class="create-validation-popover__list">
-            <li v-for="item in validationPopoverItems" :key="item">{{ item }}</li>
+            <li
+              v-for="item in validationPopoverItems"
+              :key="item"
+            >
+              {{ item }}
+            </li>
           </ul>
         </div>
 
-        <div v-if="createStep === 0" class="dp-wizard-pane">
+        <div
+          v-if="createStep === 0"
+          class="dp-wizard-pane"
+        >
           <p class="text-sm text-slate-500 mb-3">
             {{ t('protection.backupsPage.createStep0Lead') }}
           </p>
@@ -5919,21 +5930,24 @@ function preserveShallowestPathOrder(paths: string[]) {
               <ElInput
                 v-model="createSourceSearch"
                 clearable
-                @clear="clearCreateSourceSearch"
                 size="small"
                 :placeholder="t('protection.backupsPage.phSearchCreateSources')"
                 class="create-source-config-search hfl-list-search"
+                @clear="clearCreateSourceSearch"
               >
                 <template #prefix>
-                  <Search :size="16" class="hfl-list-search__icon" />
+                  <Search
+                    :size="16"
+                    class="hfl-list-search__icon"
+                  />
                 </template>
               </ElInput>
             </div>
           </div>
 
           <el-table
-          v-table-overflow-title
             ref="createSourceTableRef"
+            v-table-overflow-title
             :data="filteredCreateSourceRows"
             row-key="id"
             stripe
@@ -5943,13 +5957,20 @@ function preserveShallowestPathOrder(paths: string[]) {
             class="hfl-list-table create-source-config-table"
             @expand-change="onCreateSourceExpandChange"
           >
-            <el-table-column type="expand" width="44" fixed="left" class-name="create-source-config-expand-column">
+            <el-table-column
+              type="expand"
+              width="44"
+              fixed="left"
+              class-name="create-source-config-expand-column"
+            >
               <template #default="{ row }">
                 <div class="create-source-config-detail">
                   <section class="create-source-config-detail__tree">
                     <div class="create-source-config-detail__head create-source-config-detail__head--compact">
                       <div class="create-source-config-detail__title-row">
-                        <div class="text-sm font-semibold text-slate-900">{{ t('protection.backupsPage.labelEnterPath') }}</div>
+                        <div class="text-sm font-semibold text-slate-900">
+                          {{ t('protection.backupsPage.labelEnterPath') }}
+                        </div>
                       </div>
                     </div>
                     <div class="create-manual-path">
@@ -5973,13 +5994,18 @@ function preserveShallowestPathOrder(paths: string[]) {
                       >
                         {{ t('protection.backupsPage.btnAdd') }}
                       </ElButton>
-                      <p v-if="manualSourcePathErrorBySource[row.id]" class="create-manual-path__error">
+                      <p
+                        v-if="manualSourcePathErrorBySource[row.id]"
+                        class="create-manual-path__error"
+                      >
                         {{ manualSourcePathErrorBySource[row.id] }}
                       </p>
                     </div>
                     <div class="create-source-config-detail__head create-source-config-detail__head--browse">
                       <div class="create-source-config-detail__title-row">
-                        <div class="text-sm font-semibold text-slate-900">{{ t('protection.backupsPage.labelBrowsePaths') }}</div>
+                        <div class="text-sm font-semibold text-slate-900">
+                          {{ t('protection.backupsPage.labelBrowsePaths') }}
+                        </div>
                       </div>
                       <ElButton
                         size="small"
@@ -5991,10 +6017,16 @@ function preserveShallowestPathOrder(paths: string[]) {
                         {{ t('protection.backupsPage.btnAddSelectedPaths') }}
                       </ElButton>
                     </div>
-                    <p v-if="noSourceTreeRootsBySource[row.id]" class="dp-create-tree-shell__warn">
+                    <p
+                      v-if="noSourceTreeRootsBySource[row.id]"
+                      class="dp-create-tree-shell__warn"
+                    >
                       {{ t('protection.backupsPage.dirTreeEmptyHost') }}
                     </p>
-                    <div v-if="createSourceTreeErrorBySource[row.id]" class="dp-create-tree-shell__error">
+                    <div
+                      v-if="createSourceTreeErrorBySource[row.id]"
+                      class="dp-create-tree-shell__error"
+                    >
                       <span>{{ createSourceTreeErrorBySource[row.id] }}</span>
                       <ElButton
                         size="small"
@@ -6032,7 +6064,10 @@ function preserveShallowestPathOrder(paths: string[]) {
                       @node-expand="(data) => onSourceDirectoryExpansionChange(row.id, data)"
                     >
                       <template #default="{ data }">
-                        <div v-if="data.nodeKind === 'loadMore'" class="create-dir-row create-dir-row--load-more">
+                        <div
+                          v-if="data.nodeKind === 'loadMore'"
+                          class="create-dir-row create-dir-row--load-more"
+                        >
                           <ElButton
                             size="small"
                             text
@@ -6126,8 +6161,12 @@ function preserveShallowestPathOrder(paths: string[]) {
                   <section class="create-source-config-detail__selected">
                     <div class="create-source-config-detail__head create-source-config-detail__head--compact">
                       <div class="create-source-config-detail__title-row">
-                        <div class="text-sm font-semibold text-slate-900">{{ t('protection.backupsPage.labelAddedPaths') }}</div>
-                        <div class="text-xs text-slate-500">{{ t('protection.backupsPage.addedCount', { n: sourceSelectedCount(row.id) }) }}</div>
+                        <div class="text-sm font-semibold text-slate-900">
+                          {{ t('protection.backupsPage.labelAddedPaths') }}
+                        </div>
+                        <div class="text-xs text-slate-500">
+                          {{ t('protection.backupsPage.addedCount', { n: sourceSelectedCount(row.id) }) }}
+                        </div>
                       </div>
                     </div>
                     <div
@@ -6136,7 +6175,10 @@ function preserveShallowestPathOrder(paths: string[]) {
                       :class="{ 'dp-added-dir-empty--error': Boolean(createSourceDirIssue(row.id)) }"
                     >
                       <template v-if="createSourceDirIssue(row.id)">
-                        <ShieldAlert :size="18" class="dp-added-dir-empty__icon" />
+                        <ShieldAlert
+                          :size="18"
+                          class="dp-added-dir-empty__icon"
+                        />
                         <div class="dp-added-dir-empty__title">
                           {{ t('protection.backupsPage.validationMissingSourceDirsShort') }}
                         </div>
@@ -6148,7 +6190,10 @@ function preserveShallowestPathOrder(paths: string[]) {
                         {{ t('protection.backupsPage.addedEmpty') }}
                       </template>
                     </div>
-                    <ul v-else class="dp-added-dir-list list-none m-0 p-0">
+                    <ul
+                      v-else
+                      class="dp-added-dir-list list-none m-0 p-0"
+                    >
                       <li
                         v-for="entry in sourceSelectedEntries(row.id)"
                         :key="entry.key"
@@ -6163,7 +6208,13 @@ function preserveShallowestPathOrder(paths: string[]) {
                         <div class="create-dir-row__body">
                           <span class="create-dir-row__path">{{ entry.path }}</span>
                         </div>
-                        <ElButton text type="danger" class="create-dir-row__action" :aria-label="t('protection.backupsPage.ariaRemove')" @click="removeWizardDirEntry(entry.key)">
+                        <ElButton
+                          text
+                          type="danger"
+                          class="create-dir-row__action"
+                          :aria-label="t('protection.backupsPage.ariaRemove')"
+                          @click="removeWizardDirEntry(entry.key)"
+                        >
                           <X :size="16" />
                         </ElButton>
                       </li>
@@ -6173,7 +6224,11 @@ function preserveShallowestPathOrder(paths: string[]) {
               </template>
             </el-table-column>
 
-            <el-table-column :label="t('protection.backupsPage.colBackupSource')" min-width="200" fixed="left">
+            <el-table-column
+              :label="t('protection.backupsPage.colBackupSource')"
+              min-width="200"
+              fixed="left"
+            >
               <template #default="{ row }">
                 <button
                   type="button"
@@ -6182,7 +6237,10 @@ function preserveShallowestPathOrder(paths: string[]) {
                   @click.stop="openCreateSourceDetail(row)"
                 >
                   <div class="backup-source-cell__body">
-                    <span class="create-backup-source-name" :title="row.name">{{ row.name }}</span>
+                    <span
+                      class="create-backup-source-name"
+                      :title="row.name"
+                    >{{ row.name }}</span>
                     <span class="create-backup-source-meta-row">
                       <el-tag
                         size="small"
@@ -6191,7 +6249,10 @@ function preserveShallowestPathOrder(paths: string[]) {
                       >
                         {{ backupSourceTypeLabel(row.type) }}
                       </el-tag>
-                      <span v-if="row.platform" class="create-backup-source-platform">
+                      <span
+                        v-if="row.platform"
+                        class="create-backup-source-platform"
+                      >
                         <AgentPlatformBrandIcon :os="row.platform" />
                       </span>
                     </span>
@@ -6199,16 +6260,30 @@ function preserveShallowestPathOrder(paths: string[]) {
                 </button>
               </template>
             </el-table-column>
-            <el-table-column :label="t('protection.sourceResources.colConnectivity')" min-width="110">
+            <el-table-column
+              :label="t('protection.sourceResources.colConnectivity')"
+              min-width="110"
+            >
               <template #default="{ row }">
-                <el-tag size="small" :type="sourceAvailabilityTagType(row.id)" effect="plain">
+                <el-tag
+                  size="small"
+                  :type="sourceAvailabilityTagType(row.id)"
+                  effect="plain"
+                >
                   {{ sourceAvailabilityLabel(row.id) }}
                 </el-tag>
               </template>
             </el-table-column>
-            <el-table-column :label="t('protection.backupsPage.labelSourceHostProxy')" min-width="180">
+            <el-table-column
+              :label="t('protection.backupsPage.labelSourceHostProxy')"
+              min-width="180"
+            >
               <template #default="{ row }">
-                <HflPopover trigger="hover" placement="top-start" :width="320">
+                <HflPopover
+                  trigger="hover"
+                  placement="top-start"
+                  :width="320"
+                >
                   <template #reference>
                     <div class="source-endpoint-cell table-stack-cell">
                       <span class="table-stack-cell__primary">{{ sourceEndpointInfo(row.id).primary }}</span>
@@ -6222,7 +6297,10 @@ function preserveShallowestPathOrder(paths: string[]) {
                 </HflPopover>
               </template>
             </el-table-column>
-            <el-table-column :label="t('protection.backupsPage.labelAddedPaths')" min-width="300">
+            <el-table-column
+              :label="t('protection.backupsPage.labelAddedPaths')"
+              min-width="300"
+            >
               <template #default="{ row }">
                 <div
                   v-if="!row.selectedEntries.length"
@@ -6230,11 +6308,19 @@ function preserveShallowestPathOrder(paths: string[]) {
                   :class="{ 'create-source-dir-preview-empty--error': Boolean(createSourceDirIssue(row.id)) }"
                 >
                   <div>{{ t('protection.backupsPage.addedEmptyCompact') }}</div>
-                  <div v-if="createSourceDirIssue(row.id)" class="create-source-dir-preview-empty__reason">
+                  <div
+                    v-if="createSourceDirIssue(row.id)"
+                    class="create-source-dir-preview-empty__reason"
+                  >
                     {{ createSourceDirIssue(row.id) }}
                   </div>
                 </div>
-                <HflPopover v-else trigger="hover" placement="top-start" :width="520">
+                <HflPopover
+                  v-else
+                  trigger="hover"
+                  placement="top-start"
+                  :width="520"
+                >
                   <template #reference>
                     <div class="create-source-dir-preview">
                       <div class="create-source-dir-preview__count">
@@ -6253,7 +6339,10 @@ function preserveShallowestPathOrder(paths: string[]) {
                         />
                         <span class="create-source-dir-preview__path hfl-table-cell-mono">{{ entry.path }}</span>
                       </div>
-                      <div v-if="row.hiddenDirCount > 0" class="create-source-dir-preview__more">
+                      <div
+                        v-if="row.hiddenDirCount > 0"
+                        class="create-source-dir-preview__more"
+                      >
                         {{ t('protection.backupsPage.moreDirs', { n: row.hiddenDirCount }) }}
                       </div>
                     </div>
@@ -6281,7 +6370,11 @@ function preserveShallowestPathOrder(paths: string[]) {
                 </HflPopover>
               </template>
             </el-table-column>
-            <el-table-column :label="t('protection.backupsPage.colAction')" width="112" fixed="right">
+            <el-table-column
+              :label="t('protection.backupsPage.colAction')"
+              width="112"
+              fixed="right"
+            >
               <template #default="{ row }">
                 <ElButton
                   text
@@ -6304,36 +6397,71 @@ function preserveShallowestPathOrder(paths: string[]) {
           </el-table>
         </div>
 
-        <div v-if="createStep === 1" class="policy-step dp-wizard-pane space-y-6">
+        <div
+          v-if="createStep === 1"
+          class="policy-step dp-wizard-pane space-y-6"
+        >
           <div>
             <div>
               <div class="create-source-config-toolbar create-source-config-toolbar--actions hfl-list-toolbar">
                 <div class="create-source-config-selection">
                   {{ t('protection.backupsPage.selectedSourceCount', { selected: checkedFilterPolicyGroups.length, total: wizardSourceGroups.length }) }}
                 </div>
-                <div class="create-source-config-toolbar__divider"></div>
-                <ElButton type="primary" class="hfl-btn-with-icon dp-create-action-btn" @click="goToBackupPolicyPage">
-                  <Plus :size="16" stroke-width="2" class="shrink-0" />
+                <div class="create-source-config-toolbar__divider" />
+                <ElButton
+                  type="primary"
+                  class="hfl-btn-with-icon dp-create-action-btn"
+                  @click="goToBackupPolicyPage"
+                >
+                  <Plus
+                    :size="16"
+                    stroke-width="2"
+                    class="shrink-0"
+                  />
                   <span>{{ t('protection.backupsPage.btnAddBackupPolicy') }}</span>
                 </ElButton>
-                <ElButton type="primary" class="hfl-btn-with-icon dp-create-action-btn" @click="goToFilterRulePage">
-                  <Plus :size="16" stroke-width="2" class="shrink-0" />
+                <ElButton
+                  type="primary"
+                  class="hfl-btn-with-icon dp-create-action-btn"
+                  @click="goToFilterRulePage"
+                >
+                  <Plus
+                    :size="16"
+                    stroke-width="2"
+                    class="shrink-0"
+                  />
                   <span>{{ t('protection.backupsPage.btnAddFileFilterRule') }}</span>
                 </ElButton>
-                <ElDropdown trigger="click" @command="openFilterPolicyBatchDialog">
+                <ElDropdown
+                  trigger="click"
+                  @command="openFilterPolicyBatchDialog"
+                >
                   <ElButton class="hfl-btn-with-icon">
                     <span>{{ t('protection.backupsPage.btnBatchActions') }}</span>
-                    <ChevronDown :size="15" stroke-width="2" class="shrink-0" />
+                    <ChevronDown
+                      :size="15"
+                      stroke-width="2"
+                      class="shrink-0"
+                    />
                   </ElButton>
                   <template #dropdown>
                     <ElDropdownMenu>
-                      <ElDropdownItem command="policy" :disabled="checkedFilterPolicyGroups.length === 0">
+                      <ElDropdownItem
+                        command="policy"
+                        :disabled="checkedFilterPolicyGroups.length === 0"
+                      >
                         {{ t('protection.backupsPage.batchPolicyAction') }}
                       </ElDropdownItem>
-                      <ElDropdownItem command="filter" :disabled="checkedFilterPolicyGroups.length === 0">
+                      <ElDropdownItem
+                        command="filter"
+                        :disabled="checkedFilterPolicyGroups.length === 0"
+                      >
                         {{ t('protection.backupsPage.batchFileFilterAction') }}
                       </ElDropdownItem>
-                      <ElDropdownItem command="compression" :disabled="checkedFilterPolicyGroups.length === 0">
+                      <ElDropdownItem
+                        command="compression"
+                        :disabled="checkedFilterPolicyGroups.length === 0"
+                      >
                         {{ t('protection.backupsPage.batchCompressionAction') }}
                       </ElDropdownItem>
                     </ElDropdownMenu>
@@ -6343,13 +6471,16 @@ function preserveShallowestPathOrder(paths: string[]) {
                   <ElInput
                     v-model="filterPolicySourceSearch"
                     clearable
-                    @clear="clearFilterPolicySourceSearch"
                     size="small"
                     :placeholder="t('protection.backupsPage.phSearchCreateSources')"
                     class="create-source-config-search hfl-list-search"
+                    @clear="clearFilterPolicySourceSearch"
                   >
                     <template #prefix>
-                      <Search :size="16" class="hfl-list-search__icon" />
+                      <Search
+                        :size="16"
+                        class="hfl-list-search__icon"
+                      />
                     </template>
                   </ElInput>
                 </div>
@@ -6380,22 +6511,43 @@ function preserveShallowestPathOrder(paths: string[]) {
                       :label="pol.name"
                       :value="pol.id"
                     >
-                      <HflPopover ref="optionPopoverRefs" trigger="hover" placement="bottom-start" :fallback-placements="['top-start', 'right-start']" :width="420" :persistent="false" popper-class="create-policy-option-popper">
+                      <HflPopover
+                        ref="optionPopoverRefs"
+                        trigger="hover"
+                        placement="bottom-start"
+                        :fallback-placements="['top-start', 'right-start']"
+                        :width="420"
+                        :persistent="false"
+                        popper-class="create-policy-option-popper"
+                      >
                         <template #reference>
-                          <div class="create-policy-option" @pointerdown.capture="hideOptionPopovers">
+                          <div
+                            class="create-policy-option"
+                            @pointerdown.capture="hideOptionPopovers"
+                          >
                             <div class="create-policy-option__head">
                               <span class="create-policy-option__name">{{ pol.name }}</span>
-                              <el-tag v-bind="policyStateTagAttrs(pol.isActive)" size="small">
+                              <el-tag
+                                v-bind="policyStateTagAttrs(pol.isActive)"
+                                size="small"
+                              >
                                 {{ policyStateLabel(pol.isActive) }}
                               </el-tag>
                             </div>
-                            <div class="create-policy-option__summary">{{ policyOptionSummary(pol) }}</div>
+                            <div class="create-policy-option__summary">
+                              {{ policyOptionSummary(pol) }}
+                            </div>
                           </div>
                         </template>
                         <div class="create-policy-detail-popover">
                           <div class="create-policy-detail-popover__head">
-                            <div class="create-policy-detail-popover__title">{{ pol.name }}</div>
-                            <el-tag v-bind="policyStateTagAttrs(pol.isActive)" size="small">
+                            <div class="create-policy-detail-popover__title">
+                              {{ pol.name }}
+                            </div>
+                            <el-tag
+                              v-bind="policyStateTagAttrs(pol.isActive)"
+                              size="small"
+                            >
                               {{ policyStateLabel(pol.isActive) }}
                             </el-tag>
                           </div>
@@ -6431,7 +6583,10 @@ function preserveShallowestPathOrder(paths: string[]) {
                                     class="policy-retention-detail-list__line"
                                     :class="{ 'policy-retention-detail-list__line--summary': !line.label }"
                                   >
-                                    <span v-if="line.label" class="policy-retention-detail-list__label">{{ line.label }}</span>
+                                    <span
+                                      v-if="line.label"
+                                      class="policy-retention-detail-list__label"
+                                    >{{ line.label }}</span>
                                     <span class="policy-retention-detail-list__text">{{ line.text }}</span>
                                   </div>
                                 </div>
@@ -6465,18 +6620,35 @@ function preserveShallowestPathOrder(paths: string[]) {
                       :label="gf.name"
                       :value="gf.id"
                     >
-                      <HflPopover ref="optionPopoverRefs" trigger="hover" placement="bottom-start" :fallback-placements="['top-start', 'right-start']" :width="460" :persistent="false" popper-class="create-policy-option-popper">
+                      <HflPopover
+                        ref="optionPopoverRefs"
+                        trigger="hover"
+                        placement="bottom-start"
+                        :fallback-placements="['top-start', 'right-start']"
+                        :width="460"
+                        :persistent="false"
+                        popper-class="create-policy-option-popper"
+                      >
                         <template #reference>
-                          <div class="create-policy-option" @pointerdown.capture="hideOptionPopovers">
+                          <div
+                            class="create-policy-option"
+                            @pointerdown.capture="hideOptionPopovers"
+                          >
                             <div class="create-policy-option__head">
                               <span class="create-policy-option__name">{{ gf.name }}</span>
-                              <el-tag v-bind="policyStateTagAttrs(gf.isActive)" size="small">
+                              <el-tag
+                                v-bind="policyStateTagAttrs(gf.isActive)"
+                                size="small"
+                              >
                                 {{ policyStateLabel(gf.isActive) }}
                               </el-tag>
                             </div>
                             <div class="create-filter-rules-option">
                               <span class="create-filter-rules-option__prefix">{{ t('protection.policiesPage.filterCustomTypeExclude') }}:</span>
-                              <div v-if="filterDisplayedRuleLines(gf).length" class="create-filter-rules-option__list">
+                              <div
+                                v-if="filterDisplayedRuleLines(gf).length"
+                                class="create-filter-rules-option__list"
+                              >
                                 <code
                                   v-for="(line, index) in filterDisplayedRuleLines(gf)"
                                   :key="`${index}-${line}`"
@@ -6485,7 +6657,10 @@ function preserveShallowestPathOrder(paths: string[]) {
                                   {{ line }}
                                 </code>
                               </div>
-                              <span v-else class="create-filter-rules-option__empty">
+                              <span
+                                v-else
+                                class="create-filter-rules-option__empty"
+                              >
                                 {{ t('protection.policiesPage.filterNoActiveRules') }}
                               </span>
                             </div>
@@ -6493,8 +6668,13 @@ function preserveShallowestPathOrder(paths: string[]) {
                         </template>
                         <div class="create-policy-detail-popover">
                           <div class="create-policy-detail-popover__head">
-                            <div class="create-policy-detail-popover__title">{{ gf.name }}</div>
-                            <el-tag v-bind="policyStateTagAttrs(gf.isActive)" size="small">
+                            <div class="create-policy-detail-popover__title">
+                              {{ gf.name }}
+                            </div>
+                            <el-tag
+                              v-bind="policyStateTagAttrs(gf.isActive)"
+                              size="small"
+                            >
                               {{ policyStateLabel(gf.isActive) }}
                             </el-tag>
                           </div>
@@ -6512,7 +6692,10 @@ function preserveShallowestPathOrder(paths: string[]) {
                               >
                                 {{ row.value }}
                               </el-tag>
-                              <span v-else class="create-policy-detail-popover__value">{{ row.value }}</span>
+                              <span
+                                v-else
+                                class="create-policy-detail-popover__value"
+                              >{{ row.value }}</span>
                             </section>
                             <section class="create-policy-detail-popover__section">
                               <div class="create-policy-detail-popover__section-title">
@@ -6528,7 +6711,10 @@ function preserveShallowestPathOrder(paths: string[]) {
                                     {{ line }}
                                   </code>
                                 </template>
-                                <p v-else class="create-filter-rules-preview__empty">
+                                <p
+                                  v-else
+                                  class="create-filter-rules-preview__empty"
+                                >
                                   {{ t('protection.policiesPage.filterNoActiveRules') }}
                                 </p>
                               </div>
@@ -6551,14 +6737,17 @@ function preserveShallowestPathOrder(paths: string[]) {
                   <ElButton @click="filterPolicyBatchDialogOpen = false">
                     {{ t('protection.backupsPage.btnCancel') }}
                   </ElButton>
-                  <ElButton type="primary" @click="applyBatchFilterPolicy">
+                  <ElButton
+                    type="primary"
+                    @click="applyBatchFilterPolicy"
+                  >
                     {{ t('protection.backupsPage.btnConfirm') }}
                   </ElButton>
                 </template>
               </el-dialog>
 
               <el-table
-          v-table-overflow-title
+                v-table-overflow-title
                 :data="filteredFilterPolicyGroups"
                 row-key="key"
                 stripe
@@ -6566,17 +6755,36 @@ function preserveShallowestPathOrder(paths: string[]) {
                 class="hfl-list-table create-source-config-table filter-policy-config-table"
                 @selection-change="onFilterPolicyGroupSelectionChange"
               >
-                <el-table-column type="selection" width="35" fixed="left" reserve-selection />
-                <el-table-column :label="t('protection.backupsPage.colBackupSource')" min-width="162" fixed="left">
+                <el-table-column
+                  type="selection"
+                  width="35"
+                  fixed="left"
+                  reserve-selection
+                />
+                <el-table-column
+                  :label="t('protection.backupsPage.colBackupSource')"
+                  min-width="162"
+                  fixed="left"
+                >
                   <template #default="{ row: group }">
                     <div class="backup-source-cell">
                       <div class="backup-source-cell__body">
-                        <span class="create-backup-source-name" :title="group.sourceName">{{ group.sourceName }}</span>
+                        <span
+                          class="create-backup-source-name"
+                          :title="group.sourceName"
+                        >{{ group.sourceName }}</span>
                         <span class="create-backup-source-meta-row">
-                          <el-tag size="small" effect="plain" class="create-backup-source-type-tag">
+                          <el-tag
+                            size="small"
+                            effect="plain"
+                            class="create-backup-source-type-tag"
+                          >
                             {{ backupSourceTypeLabel(group.sourceType) }}
                           </el-tag>
-                          <span v-if="group.platform" class="create-backup-source-platform">
+                          <span
+                            v-if="group.platform"
+                            class="create-backup-source-platform"
+                          >
                             <AgentPlatformBrandIcon :os="group.platform" />
                           </span>
                         </span>
@@ -6614,13 +6822,18 @@ function preserveShallowestPathOrder(paths: string[]) {
                             />
                             <span class="create-source-dir-preview__path hfl-table-cell-mono">{{ entry.path }}</span>
                           </div>
-                          <div v-if="group.entries.length > 3" class="create-source-dir-preview__more">
+                          <div
+                            v-if="group.entries.length > 3"
+                            class="create-source-dir-preview__more"
+                          >
                             {{ t('protection.backupsPage.moreDirs', { n: group.entries.length - 3 }) }}
                           </div>
                         </div>
                       </template>
                       <div class="create-table-info-popover create-table-info-popover--dirs create-table-info-popover--selected-paths">
-                        <div class="create-table-info-popover__summary">{{ backupDirPopoverSummary(group.entries) }}</div>
+                        <div class="create-table-info-popover__summary">
+                          {{ backupDirPopoverSummary(group.entries) }}
+                        </div>
                         <div
                           v-for="entry in group.entries"
                           :key="entry.key"
@@ -6649,88 +6862,112 @@ function preserveShallowestPathOrder(paths: string[]) {
                     <div class="create-config-summary-cell">
                       <div class="create-config-select-row">
                         <div class="create-config-select-hover-target hfl-table-no-tooltip">
-                              <el-select
-                                :model-value="groupPolicyId(group)"
-                                filterable
-                                clearable
-                                :placeholder="t('protection.backupsPage.phPolicyForDir')"
-                                class="target-picker-grid__target"
+                          <el-select
+                            :model-value="groupPolicyId(group)"
+                            filterable
+                            clearable
+                            :placeholder="t('protection.backupsPage.phPolicyForDir')"
+                            class="target-picker-grid__target"
+                            placement="bottom-start"
+                            popper-class="create-policy-select-popper"
+                            @update:model-value="setGroupPolicyId(group, String($event ?? ''))"
+                            @visible-change="handleConfigSelectVisibleChange"
+                          >
+                            <el-option
+                              v-for="pol in realPolicies"
+                              :key="pol.id"
+                              :label="pol.name"
+                              :value="pol.id"
+                            >
+                              <HflPopover
+                                ref="optionPopoverRefs"
+                                trigger="hover"
                                 placement="bottom-start"
-                                popper-class="create-policy-select-popper"
-                                @update:model-value="setGroupPolicyId(group, String($event ?? ''))"
-                                @visible-change="handleConfigSelectVisibleChange"
+                                :fallback-placements="['top-start', 'right-start']"
+                                :width="420"
+                                :persistent="false"
+                                popper-class="create-policy-option-popper"
                               >
-                                <el-option
-                                  v-for="pol in realPolicies"
-                                  :key="pol.id"
-                                  :label="pol.name"
-                                  :value="pol.id"
-                                >
-                                  <HflPopover ref="optionPopoverRefs" trigger="hover" placement="bottom-start" :fallback-placements="['top-start', 'right-start']" :width="420" :persistent="false" popper-class="create-policy-option-popper">
-                                    <template #reference>
-                                      <div class="create-policy-option" @pointerdown.capture="hideOptionPopovers">
-                                        <div class="create-policy-option__head">
-                                          <span class="create-policy-option__name">{{ pol.name }}</span>
-                                          <el-tag v-bind="policyStateTagAttrs(pol.isActive)" size="small">
-                                            {{ policyStateLabel(pol.isActive) }}
-                                          </el-tag>
-                                        </div>
-                                        <div class="create-policy-option__summary">{{ policyOptionSummary(pol) }}</div>
-                                      </div>
-                                    </template>
-                                    <div class="create-policy-detail-popover">
-                                      <div class="create-policy-detail-popover__head">
-                                        <div class="create-policy-detail-popover__title">{{ pol.name }}</div>
-                                        <el-tag v-bind="policyStateTagAttrs(pol.isActive)" size="small">
-                                          {{ policyStateLabel(pol.isActive) }}
-                                        </el-tag>
-                                      </div>
-                                      <div class="create-policy-detail-popover__sections">
-                                        <section
-                                          v-for="row in policyDetailRows(pol)"
-                                          :key="row.label"
-                                          class="create-policy-detail-popover__section create-policy-detail-popover__section--line"
-                                        >
-                                          <span class="create-policy-detail-popover__section-title">{{ row.label }}:</span>
-                                          <el-tag
-                                            v-if="row.state !== undefined"
-                                            size="small"
-                                            v-bind="policyStateTagAttrs(Boolean(row.state))"
-                                          >
-                                            {{ row.value }}
-                                          </el-tag>
-                                          <span
-                                            v-else
-                                            class="create-policy-detail-popover__value"
-                                            :class="{ 'create-policy-detail-popover__value--mono': row.mono }"
-                                          >{{ row.value }}</span>
-                                        </section>
-                                        <section class="create-policy-detail-popover__section">
-                                          <div class="create-policy-detail-popover__section-title">
-                                            {{ t('protection.policiesPage.fieldRetention') }}:
-                                          </div>
-                                          <div class="create-policy-detail-popover__retention-box">
-                                            <div class="policy-retention-detail-list">
-                                              <div
-                                                v-for="line in policyRetentionDetailLines(pol)"
-                                                :key="`${line.label || ''}${line.text}`"
-                                                class="policy-retention-detail-list__line"
-                                                :class="{ 'policy-retention-detail-list__line--summary': !line.label }"
-                                              >
-                                                <span v-if="line.label" class="policy-retention-detail-list__label">{{ line.label }}</span>
-                                                <span class="policy-retention-detail-list__text">{{ line.text }}</span>
-                                              </div>
-                                            </div>
-                                          </div>
-                                        </section>
-                                      </div>
+                                <template #reference>
+                                  <div
+                                    class="create-policy-option"
+                                    @pointerdown.capture="hideOptionPopovers"
+                                  >
+                                    <div class="create-policy-option__head">
+                                      <span class="create-policy-option__name">{{ pol.name }}</span>
+                                      <el-tag
+                                        v-bind="policyStateTagAttrs(pol.isActive)"
+                                        size="small"
+                                      >
+                                        {{ policyStateLabel(pol.isActive) }}
+                                      </el-tag>
                                     </div>
-                                  </HflPopover>
-                                </el-option>
-                                <template #empty>
-                                  {{ realPolicies.length ? t('protection.backupsPage.policiesNoMatch') : t('protection.backupsPage.policyTemplatesEmpty') }}
+                                    <div class="create-policy-option__summary">
+                                      {{ policyOptionSummary(pol) }}
+                                    </div>
+                                  </div>
                                 </template>
-                              </el-select>
+                                <div class="create-policy-detail-popover">
+                                  <div class="create-policy-detail-popover__head">
+                                    <div class="create-policy-detail-popover__title">
+                                      {{ pol.name }}
+                                    </div>
+                                    <el-tag
+                                      v-bind="policyStateTagAttrs(pol.isActive)"
+                                      size="small"
+                                    >
+                                      {{ policyStateLabel(pol.isActive) }}
+                                    </el-tag>
+                                  </div>
+                                  <div class="create-policy-detail-popover__sections">
+                                    <section
+                                      v-for="row in policyDetailRows(pol)"
+                                      :key="row.label"
+                                      class="create-policy-detail-popover__section create-policy-detail-popover__section--line"
+                                    >
+                                      <span class="create-policy-detail-popover__section-title">{{ row.label }}:</span>
+                                      <el-tag
+                                        v-if="row.state !== undefined"
+                                        size="small"
+                                        v-bind="policyStateTagAttrs(Boolean(row.state))"
+                                      >
+                                        {{ row.value }}
+                                      </el-tag>
+                                      <span
+                                        v-else
+                                        class="create-policy-detail-popover__value"
+                                        :class="{ 'create-policy-detail-popover__value--mono': row.mono }"
+                                      >{{ row.value }}</span>
+                                    </section>
+                                    <section class="create-policy-detail-popover__section">
+                                      <div class="create-policy-detail-popover__section-title">
+                                        {{ t('protection.policiesPage.fieldRetention') }}:
+                                      </div>
+                                      <div class="create-policy-detail-popover__retention-box">
+                                        <div class="policy-retention-detail-list">
+                                          <div
+                                            v-for="line in policyRetentionDetailLines(pol)"
+                                            :key="`${line.label || ''}${line.text}`"
+                                            class="policy-retention-detail-list__line"
+                                            :class="{ 'policy-retention-detail-list__line--summary': !line.label }"
+                                          >
+                                            <span
+                                              v-if="line.label"
+                                              class="policy-retention-detail-list__label"
+                                            >{{ line.label }}</span>
+                                            <span class="policy-retention-detail-list__text">{{ line.text }}</span>
+                                          </div>
+                                        </div>
+                                      </div>
+                                    </section>
+                                  </div>
+                                </div>
+                              </HflPopover>
+                            </el-option>
+                            <template #empty>
+                              {{ realPolicies.length ? t('protection.backupsPage.policiesNoMatch') : t('protection.backupsPage.policyTemplatesEmpty') }}
+                            </template>
+                          </el-select>
                         </div>
                         <ElButton
                           text
@@ -6742,7 +6979,11 @@ function preserveShallowestPathOrder(paths: string[]) {
                           :disabled="policiesRefreshing"
                           @click.stop="refreshWizardPolicies"
                         >
-                          <RefreshCw :size="15" stroke-width="2" :class="{ 'is-spinning': policiesRefreshing }" />
+                          <RefreshCw
+                            :size="15"
+                            stroke-width="2"
+                            :class="{ 'is-spinning': policiesRefreshing }"
+                          />
                         </ElButton>
                       </div>
                       <HflPopover
@@ -6759,7 +7000,10 @@ function preserveShallowestPathOrder(paths: string[]) {
                               class="wizard-summary-cell wizard-summary-cell--inline"
                               :class="Boolean(getRealPolicy(groupPolicyId(group))?.isActive) ? 'wizard-summary-cell--online' : 'wizard-summary-cell--offline'"
                             >
-                              <el-tag v-bind="policyStateTagAttrs(Boolean(getRealPolicy(groupPolicyId(group))?.isActive))" size="small">
+                              <el-tag
+                                v-bind="policyStateTagAttrs(Boolean(getRealPolicy(groupPolicyId(group))?.isActive))"
+                                size="small"
+                              >
                                 {{ policyStateLabel(Boolean(getRealPolicy(groupPolicyId(group))?.isActive)) }}
                               </el-tag>
                               <span class="wizard-summary-cell__detail">
@@ -6770,7 +7014,9 @@ function preserveShallowestPathOrder(paths: string[]) {
                         </template>
                         <div class="create-policy-detail-popover">
                           <div class="create-policy-detail-popover__head">
-                            <div class="create-policy-detail-popover__title">{{ getRealPolicy(groupPolicyId(group))?.name }}</div>
+                            <div class="create-policy-detail-popover__title">
+                              {{ getRealPolicy(groupPolicyId(group))?.name }}
+                            </div>
                             <el-tag
                               v-if="getRealPolicy(groupPolicyId(group))"
                               size="small"
@@ -6811,7 +7057,10 @@ function preserveShallowestPathOrder(paths: string[]) {
                                     class="policy-retention-detail-list__line"
                                     :class="{ 'policy-retention-detail-list__line--summary': !line.label }"
                                   >
-                                    <span v-if="line.label" class="policy-retention-detail-list__label">{{ line.label }}</span>
+                                    <span
+                                      v-if="line.label"
+                                      class="policy-retention-detail-list__label"
+                                    >{{ line.label }}</span>
                                     <span class="policy-retention-detail-list__text">{{ line.text }}</span>
                                   </div>
                                 </div>
@@ -6820,7 +7069,10 @@ function preserveShallowestPathOrder(paths: string[]) {
                           </div>
                         </div>
                       </HflPopover>
-                      <span v-else class="create-config-summary-line create-config-summary-line--empty hfl-table-no-tooltip">
+                      <span
+                        v-else
+                        class="create-config-summary-line create-config-summary-line--empty hfl-table-no-tooltip"
+                      >
                         {{ policyCompactSummary(group) }}
                       </span>
                     </div>
@@ -6835,99 +7087,130 @@ function preserveShallowestPathOrder(paths: string[]) {
                     <div class="create-config-summary-cell">
                       <div class="create-config-select-row">
                         <div class="create-config-select-hover-target hfl-table-no-tooltip">
-                              <el-select
-                                :model-value="groupFilterId(group)"
-                                filterable
-                                clearable
-                                :placeholder="t('protection.backupsPage.phFilterForDir')"
-                                class="target-picker-grid__target"
+                          <el-select
+                            :model-value="groupFilterId(group)"
+                            filterable
+                            clearable
+                            :placeholder="t('protection.backupsPage.phFilterForDir')"
+                            class="target-picker-grid__target"
+                            placement="bottom-start"
+                            popper-class="create-policy-select-popper"
+                            @update:model-value="(value) => setGroupFilterId(group, String(value || ''))"
+                            @visible-change="handleConfigSelectVisibleChange"
+                          >
+                            <el-option
+                              v-for="gf in realFilters"
+                              :key="gf.id"
+                              :label="gf.name"
+                              :value="gf.id"
+                            >
+                              <HflPopover
+                                ref="optionPopoverRefs"
+                                trigger="hover"
                                 placement="bottom-start"
-                                popper-class="create-policy-select-popper"
-                                @update:model-value="(value) => setGroupFilterId(group, String(value || ''))"
-                                @visible-change="handleConfigSelectVisibleChange"
+                                :fallback-placements="['top-start', 'right-start']"
+                                :width="460"
+                                :persistent="false"
+                                popper-class="create-policy-option-popper"
                               >
-                                <el-option
-                                  v-for="gf in realFilters"
-                                  :key="gf.id"
-                                  :label="gf.name"
-                                  :value="gf.id"
-                                >
-                                  <HflPopover ref="optionPopoverRefs" trigger="hover" placement="bottom-start" :fallback-placements="['top-start', 'right-start']" :width="460" :persistent="false" popper-class="create-policy-option-popper">
-                                    <template #reference>
-                                      <div class="create-policy-option" @pointerdown.capture="hideOptionPopovers">
-                                        <div class="create-policy-option__head">
-                                          <span class="create-policy-option__name">{{ gf.name }}</span>
-                                          <el-tag v-bind="policyStateTagAttrs(gf.isActive)" size="small">
-                                            {{ policyStateLabel(gf.isActive) }}
-                                          </el-tag>
-                                        </div>
-                                        <div class="create-filter-rules-option">
-                                          <span class="create-filter-rules-option__prefix">{{ t('protection.policiesPage.filterCustomTypeExclude') }}:</span>
-                                          <div v-if="filterDisplayedRuleLines(gf).length" class="create-filter-rules-option__list">
-                                            <code
-                                              v-for="(line, index) in filterDisplayedRuleLines(gf)"
-                                              :key="`${index}-${line}`"
-                                              class="create-filter-rules-option__rule"
-                                            >
-                                              {{ line }}
-                                            </code>
-                                          </div>
-                                          <span v-else class="create-filter-rules-option__empty">
-                                            {{ t('protection.policiesPage.filterNoActiveRules') }}
-                                          </span>
-                                        </div>
-                                      </div>
-                                    </template>
-                                    <div class="create-policy-detail-popover">
-                                      <div class="create-policy-detail-popover__head">
-                                        <div class="create-policy-detail-popover__title">{{ gf.name }}</div>
-                                        <el-tag v-bind="policyStateTagAttrs(gf.isActive)" size="small">
-                                          {{ policyStateLabel(gf.isActive) }}
-                                        </el-tag>
-                                      </div>
-                                      <div class="create-policy-detail-popover__sections">
-                                        <section
-                                          v-for="row in filterHoverRows(gf)"
-                                          :key="row.label"
-                                          class="create-policy-detail-popover__section create-policy-detail-popover__section--filter-line"
-                                        >
-                                          <span class="create-policy-detail-popover__section-title">{{ row.label }}:</span>
-                                          <el-tag
-                                            v-if="row.enabled"
-                                            size="small"
-                                            v-bind="policyStateTagAttrs(true)"
-                                          >
-                                            {{ row.value }}
-                                          </el-tag>
-                                          <span v-else class="create-policy-detail-popover__value">{{ row.value }}</span>
-                                        </section>
-                                        <section class="create-policy-detail-popover__section">
-                                          <div class="create-policy-detail-popover__section-title">
-                                            {{ t('protection.policiesPage.filterRulesPreviewTitle') }}:
-                                          </div>
-                                          <div class="create-filter-rules-preview">
-                                            <template v-if="filterCompiledRuleLines(gf).length">
-                                              <code
-                                                v-for="(line, index) in filterCompiledRuleLines(gf)"
-                                                :key="`${index}-${line}`"
-                                                class="create-filter-rules-preview__line"
-                                              >
-                                                {{ line }}
-                                              </code>
-                                            </template>
-                                            <p v-else class="create-filter-rules-preview__empty">
-                                              {{ t('protection.policiesPage.filterNoActiveRules') }}
-                                            </p>
-                                          </div>
-                                        </section>
-                                      </div>
+                                <template #reference>
+                                  <div
+                                    class="create-policy-option"
+                                    @pointerdown.capture="hideOptionPopovers"
+                                  >
+                                    <div class="create-policy-option__head">
+                                      <span class="create-policy-option__name">{{ gf.name }}</span>
+                                      <el-tag
+                                        v-bind="policyStateTagAttrs(gf.isActive)"
+                                        size="small"
+                                      >
+                                        {{ policyStateLabel(gf.isActive) }}
+                                      </el-tag>
                                     </div>
-                                  </HflPopover>
-                                </el-option>
-                                <template #empty>
-                                  {{ realFilters.length ? t('protection.backupsPage.filtersNoMatch') : t('protection.backupsPage.filterRulesEmpty') }}
+                                    <div class="create-filter-rules-option">
+                                      <span class="create-filter-rules-option__prefix">{{ t('protection.policiesPage.filterCustomTypeExclude') }}:</span>
+                                      <div
+                                        v-if="filterDisplayedRuleLines(gf).length"
+                                        class="create-filter-rules-option__list"
+                                      >
+                                        <code
+                                          v-for="(line, index) in filterDisplayedRuleLines(gf)"
+                                          :key="`${index}-${line}`"
+                                          class="create-filter-rules-option__rule"
+                                        >
+                                          {{ line }}
+                                        </code>
+                                      </div>
+                                      <span
+                                        v-else
+                                        class="create-filter-rules-option__empty"
+                                      >
+                                        {{ t('protection.policiesPage.filterNoActiveRules') }}
+                                      </span>
+                                    </div>
+                                  </div>
                                 </template>
-                              </el-select>
+                                <div class="create-policy-detail-popover">
+                                  <div class="create-policy-detail-popover__head">
+                                    <div class="create-policy-detail-popover__title">
+                                      {{ gf.name }}
+                                    </div>
+                                    <el-tag
+                                      v-bind="policyStateTagAttrs(gf.isActive)"
+                                      size="small"
+                                    >
+                                      {{ policyStateLabel(gf.isActive) }}
+                                    </el-tag>
+                                  </div>
+                                  <div class="create-policy-detail-popover__sections">
+                                    <section
+                                      v-for="row in filterHoverRows(gf)"
+                                      :key="row.label"
+                                      class="create-policy-detail-popover__section create-policy-detail-popover__section--filter-line"
+                                    >
+                                      <span class="create-policy-detail-popover__section-title">{{ row.label }}:</span>
+                                      <el-tag
+                                        v-if="row.enabled"
+                                        size="small"
+                                        v-bind="policyStateTagAttrs(true)"
+                                      >
+                                        {{ row.value }}
+                                      </el-tag>
+                                      <span
+                                        v-else
+                                        class="create-policy-detail-popover__value"
+                                      >{{ row.value }}</span>
+                                    </section>
+                                    <section class="create-policy-detail-popover__section">
+                                      <div class="create-policy-detail-popover__section-title">
+                                        {{ t('protection.policiesPage.filterRulesPreviewTitle') }}:
+                                      </div>
+                                      <div class="create-filter-rules-preview">
+                                        <template v-if="filterCompiledRuleLines(gf).length">
+                                          <code
+                                            v-for="(line, index) in filterCompiledRuleLines(gf)"
+                                            :key="`${index}-${line}`"
+                                            class="create-filter-rules-preview__line"
+                                          >
+                                            {{ line }}
+                                          </code>
+                                        </template>
+                                        <p
+                                          v-else
+                                          class="create-filter-rules-preview__empty"
+                                        >
+                                          {{ t('protection.policiesPage.filterNoActiveRules') }}
+                                        </p>
+                                      </div>
+                                    </section>
+                                  </div>
+                                </div>
+                              </HflPopover>
+                            </el-option>
+                            <template #empty>
+                              {{ realFilters.length ? t('protection.backupsPage.filtersNoMatch') : t('protection.backupsPage.filterRulesEmpty') }}
+                            </template>
+                          </el-select>
                         </div>
                         <ElButton
                           text
@@ -6939,7 +7222,11 @@ function preserveShallowestPathOrder(paths: string[]) {
                           :disabled="filtersRefreshing"
                           @click.stop="refreshWizardFilters"
                         >
-                          <RefreshCw :size="15" stroke-width="2" :class="{ 'is-spinning': filtersRefreshing }" />
+                          <RefreshCw
+                            :size="15"
+                            stroke-width="2"
+                            :class="{ 'is-spinning': filtersRefreshing }"
+                          />
                         </ElButton>
                       </div>
                       <HflPopover
@@ -6956,7 +7243,10 @@ function preserveShallowestPathOrder(paths: string[]) {
                               class="wizard-summary-cell wizard-summary-cell--inline"
                               :class="Boolean(getRealFilter(groupFilterId(group))?.isActive) ? 'wizard-summary-cell--online' : 'wizard-summary-cell--offline'"
                             >
-                              <el-tag v-bind="policyStateTagAttrs(Boolean(getRealFilter(groupFilterId(group))?.isActive))" size="small">
+                              <el-tag
+                                v-bind="policyStateTagAttrs(Boolean(getRealFilter(groupFilterId(group))?.isActive))"
+                                size="small"
+                              >
                                 {{ policyStateLabel(Boolean(getRealFilter(groupFilterId(group))?.isActive)) }}
                               </el-tag>
                               <span class="wizard-summary-cell__detail">
@@ -6967,7 +7257,9 @@ function preserveShallowestPathOrder(paths: string[]) {
                         </template>
                         <div class="create-policy-detail-popover">
                           <div class="create-policy-detail-popover__head">
-                            <div class="create-policy-detail-popover__title">{{ getRealFilter(groupFilterId(group))?.name }}</div>
+                            <div class="create-policy-detail-popover__title">
+                              {{ getRealFilter(groupFilterId(group))?.name }}
+                            </div>
                             <el-tag
                               v-if="getRealFilter(groupFilterId(group))"
                               size="small"
@@ -6990,7 +7282,10 @@ function preserveShallowestPathOrder(paths: string[]) {
                               >
                                 {{ row.value }}
                               </el-tag>
-                              <span v-else class="create-policy-detail-popover__value">{{ row.value }}</span>
+                              <span
+                                v-else
+                                class="create-policy-detail-popover__value"
+                              >{{ row.value }}</span>
                             </section>
                             <section class="create-policy-detail-popover__section">
                               <div class="create-policy-detail-popover__section-title">
@@ -7006,7 +7301,10 @@ function preserveShallowestPathOrder(paths: string[]) {
                                     {{ line }}
                                   </code>
                                 </template>
-                                <p v-else class="create-filter-rules-preview__empty">
+                                <p
+                                  v-else
+                                  class="create-filter-rules-preview__empty"
+                                >
                                   {{ t('protection.policiesPage.filterNoActiveRules') }}
                                 </p>
                               </div>
@@ -7014,7 +7312,10 @@ function preserveShallowestPathOrder(paths: string[]) {
                           </div>
                         </div>
                       </HflPopover>
-                      <span v-else class="create-config-summary-line create-config-summary-line--empty hfl-table-no-tooltip">
+                      <span
+                        v-else
+                        class="create-config-summary-line create-config-summary-line--empty hfl-table-no-tooltip"
+                      >
                         {{ filterCompactSummary(group) }}
                       </span>
                     </div>
@@ -7086,27 +7387,35 @@ function preserveShallowestPathOrder(paths: string[]) {
           destroy-on-close
           class="dp-add-target-dialog create-policy-dialog dp-dialog-soft-bg"
         >
-          <p class="create-policy-dialog__desc">{{ addPolicyDialogDesc }}</p>
+          <p class="create-policy-dialog__desc">
+            {{ addPolicyDialogDesc }}
+          </p>
 
           <div ref="addPolicyDialogRef">
-          <ProtectionPolicyEditorForm
-            v-model:policy-form="addPolicyForm"
-            v-model:filter-form="addFileFilterForm"
-            :show-backup="addPolicyCreateKind === 'backup'"
-            :show-filter="addPolicyCreateKind === 'filter'"
-            variant="dialog"
-            :show-cron-help="false"
-            cron-input-id="create-backup-policy-cron"
-            :name-error="addPolicyErrors.name"
-            :schedule-error="addPolicyErrors.schedule"
-            :retention-error="addPolicyErrors.retention"
-            @clear-name-error="clearAddPolicyError('name')"
-          />
+            <ProtectionPolicyEditorForm
+              v-model:policy-form="addPolicyForm"
+              v-model:filter-form="addFileFilterForm"
+              :show-backup="addPolicyCreateKind === 'backup'"
+              :show-filter="addPolicyCreateKind === 'filter'"
+              variant="dialog"
+              :show-cron-help="false"
+              cron-input-id="create-backup-policy-cron"
+              :name-error="addPolicyErrors.name"
+              :schedule-error="addPolicyErrors.schedule"
+              :retention-error="addPolicyErrors.retention"
+              @clear-name-error="clearAddPolicyError('name')"
+            />
           </div>
           <template #footer>
             <div class="flex justify-end gap-2">
-              <ElButton @click="closeAddFilterDialog">{{ t('protection.backupsPage.btnCancel') }}</ElButton>
-              <ElButton type="primary" :loading="addPolicySaving" @click="submitAddFilterDialog">
+              <ElButton @click="closeAddFilterDialog">
+                {{ t('protection.backupsPage.btnCancel') }}
+              </ElButton>
+              <ElButton
+                type="primary"
+                :loading="addPolicySaving"
+                @click="submitAddFilterDialog"
+              >
                 {{ addPolicySaveLabel }}
               </ElButton>
             </div>
@@ -7118,7 +7427,10 @@ function preserveShallowestPathOrder(paths: string[]) {
           class="dp-wizard-pane"
           :aria-busy="targetValidationInProgress"
         >
-          <div v-if="!wizardDirEntries.length" class="text-sm text-slate-400 py-8 text-center border border-dashed border-slate-200 rounded-md">
+          <div
+            v-if="!wizardDirEntries.length"
+            class="text-sm text-slate-400 py-8 text-center border border-dashed border-slate-200 rounded-md"
+          >
             {{ t('protection.backupsPage.addedEmpty') }}
           </div>
           <div v-else>
@@ -7126,14 +7438,18 @@ function preserveShallowestPathOrder(paths: string[]) {
               <div class="create-source-config-selection">
                 {{ t('protection.backupsPage.selectedSourceCount', { selected: checkedTargetGroups.length, total: wizardSourceGroups.length }) }}
               </div>
-              <div class="create-source-config-toolbar__divider"></div>
+              <div class="create-source-config-toolbar__divider" />
               <ElButton
                 type="primary"
                 class="hfl-btn-with-icon dp-create-action-btn"
                 :disabled="targetValidationInProgress"
                 @click="goToStorageRepositoryPage"
               >
-                <Plus :size="16" stroke-width="2" class="shrink-0" />
+                <Plus
+                  :size="16"
+                  stroke-width="2"
+                  class="shrink-0"
+                />
                 <span>{{ t('protection.backupsPage.btnAddTarget') }}</span>
               </ElButton>
               <ElButton
@@ -7142,20 +7458,27 @@ function preserveShallowestPathOrder(paths: string[]) {
                 :disabled="targetValidationInProgress || checkedTargetGroups.length === 0"
                 @click="openBatchTargetDialog"
               >
-                <Database :size="16" stroke-width="2" class="shrink-0" />
+                <Database
+                  :size="16"
+                  stroke-width="2"
+                  class="shrink-0"
+                />
                 <span>{{ t('protection.backupsPage.batchAssignTitle') }}</span>
               </ElButton>
               <div class="hfl-list-toolbar__right">
                 <ElInput
                   v-model="targetSourceSearch"
                   clearable
-                  @clear="clearTargetSourceSearch"
                   size="small"
                   :placeholder="t('protection.backupsPage.phSearchCreateSources')"
                   class="create-source-config-search hfl-list-search"
+                  @clear="clearTargetSourceSearch"
                 >
                   <template #prefix>
-                    <Search :size="16" class="hfl-list-search__icon" />
+                    <Search
+                      :size="16"
+                      class="hfl-list-search__icon"
+                    />
                   </template>
                 </ElInput>
               </div>
@@ -7197,11 +7520,14 @@ function preserveShallowestPathOrder(paths: string[]) {
               destroy-on-close
               class="target-batch-dialog dp-dialog-soft-bg"
             >
-              <ElForm label-position="top" class="target-batch-form">
+              <ElForm
+                label-position="top"
+                class="target-batch-form"
+              >
                 <TargetRepositoryPicker
-                  :model-value="batchTargetPicker.targetId"
                   v-model:repo-type="batchTargetPicker.repoType"
                   v-model:nas-mode="batchNasTargetMode"
+                  :model-value="batchTargetPicker.targetId"
                   :targets="targetOptionsForBatch()"
                   :selected-target="batchSelectedTarget"
                   :repo-type-options="repoTypeOptions"
@@ -7227,20 +7553,28 @@ function preserveShallowestPathOrder(paths: string[]) {
                     v-model="batchRepositoryEndpointType"
                     class="target-endpoint-choice__options"
                   >
-                    <ElRadio value="external" border>
+                    <ElRadio
+                      value="external"
+                      border
+                    >
                       <span class="target-endpoint-choice__option">
                         <strong>{{ t('addS3Repo.endpointExternal') }}</strong>
                         <span>{{ targetExternalEndpoint(batchSelectedTarget) }}</span>
                       </span>
                     </ElRadio>
-                    <ElRadio value="internal" border>
+                    <ElRadio
+                      value="internal"
+                      border
+                    >
                       <span class="target-endpoint-choice__option">
                         <strong>{{ t('addS3Repo.endpointInternal') }}</strong>
                         <span>{{ targetInternalEndpoint(batchSelectedTarget) }}</span>
                       </span>
                     </ElRadio>
                   </ElRadioGroup>
-                  <p class="target-endpoint-choice__hint">{{ t('addS3Repo.hintEndpointType') }}</p>
+                  <p class="target-endpoint-choice__hint">
+                    {{ t('addS3Repo.hintEndpointType') }}
+                  </p>
                 </ElFormItem>
               </ElForm>
               <template #footer>
@@ -7258,7 +7592,7 @@ function preserveShallowestPathOrder(paths: string[]) {
             </el-dialog>
 
             <el-table
-          v-table-overflow-title
+              v-table-overflow-title
               :data="filteredTargetGroups"
               row-key="key"
               stripe
@@ -7267,17 +7601,36 @@ function preserveShallowestPathOrder(paths: string[]) {
               class="hfl-list-table create-source-config-table filter-policy-config-table create-target-config-table"
               @selection-change="onTargetGroupSelectionChange"
             >
-              <el-table-column type="selection" width="35" fixed="left" reserve-selection />
-              <el-table-column :label="t('protection.backupsPage.colBackupSource')" min-width="200" fixed="left">
+              <el-table-column
+                type="selection"
+                width="35"
+                fixed="left"
+                reserve-selection
+              />
+              <el-table-column
+                :label="t('protection.backupsPage.colBackupSource')"
+                min-width="200"
+                fixed="left"
+              >
                 <template #default="{ row: group }">
                   <div class="backup-source-cell">
                     <div class="backup-source-cell__body">
-                      <span class="create-backup-source-name" :title="group.sourceName">{{ group.sourceName }}</span>
+                      <span
+                        class="create-backup-source-name"
+                        :title="group.sourceName"
+                      >{{ group.sourceName }}</span>
                       <span class="create-backup-source-meta-row">
-                        <el-tag size="small" effect="plain" class="create-backup-source-type-tag">
+                        <el-tag
+                          size="small"
+                          effect="plain"
+                          class="create-backup-source-type-tag"
+                        >
                           {{ backupSourceTypeLabel(group.sourceType) }}
                         </el-tag>
-                        <span v-if="group.platform" class="create-backup-source-platform">
+                        <span
+                          v-if="group.platform"
+                          class="create-backup-source-platform"
+                        >
                           <AgentPlatformBrandIcon :os="group.platform" />
                         </span>
                       </span>
@@ -7285,9 +7638,16 @@ function preserveShallowestPathOrder(paths: string[]) {
                   </div>
                 </template>
               </el-table-column>
-              <el-table-column :label="t('protection.backupsPage.labelBackupDirs')" min-width="200">
+              <el-table-column
+                :label="t('protection.backupsPage.labelBackupDirs')"
+                min-width="200"
+              >
                 <template #default="{ row: group }">
-                  <HflPopover trigger="hover" placement="top-start" :width="520">
+                  <HflPopover
+                    trigger="hover"
+                    placement="top-start"
+                    :width="520"
+                  >
                     <template #reference>
                       <div class="create-source-dir-preview">
                         <div class="create-source-dir-preview__count">
@@ -7306,13 +7666,18 @@ function preserveShallowestPathOrder(paths: string[]) {
                           />
                           <span class="create-source-dir-preview__path hfl-table-cell-mono">{{ entry.path }}</span>
                         </div>
-                        <div v-if="group.entries.length > 3" class="create-source-dir-preview__more">
+                        <div
+                          v-if="group.entries.length > 3"
+                          class="create-source-dir-preview__more"
+                        >
                           {{ t('protection.backupsPage.moreDirs', { n: group.entries.length - 3 }) }}
                         </div>
                       </div>
                     </template>
                     <div class="create-table-info-popover create-table-info-popover--dirs create-table-info-popover--selected-paths">
-                      <div class="create-table-info-popover__summary">{{ backupDirPopoverSummary(group.entries) }}</div>
+                      <div class="create-table-info-popover__summary">
+                        {{ backupDirPopoverSummary(group.entries) }}
+                      </div>
                       <div
                         v-for="entry in group.entries"
                         :key="entry.key"
@@ -7332,7 +7697,10 @@ function preserveShallowestPathOrder(paths: string[]) {
                   </HflPopover>
                 </template>
               </el-table-column>
-              <el-table-column :label="t('protection.backupsPage.labelTargetRepository')" min-width="220">
+              <el-table-column
+                :label="t('protection.backupsPage.labelTargetRepository')"
+                min-width="220"
+              >
                 <template #default="{ row: group }">
                   <div class="target-select-with-meta">
                     <HflPopover
@@ -7348,7 +7716,10 @@ function preserveShallowestPathOrder(paths: string[]) {
                             class="wizard-summary-cell"
                             :class="`wizard-summary-cell--${targetTone(getRealTarget(sourceTargetMap[group.key]))}`"
                           >
-                            <span class="wizard-summary-cell__dot" aria-hidden="true"></span>
+                            <span
+                              class="wizard-summary-cell__dot"
+                              aria-hidden="true"
+                            />
                             <div class="wizard-summary-cell__body">
                               <div class="wizard-summary-cell__name">
                                 {{ getRealTarget(sourceTargetMap[group.key])?.name }}
@@ -7371,7 +7742,10 @@ function preserveShallowestPathOrder(paths: string[]) {
                       </template>
                       <TargetRepositoryDetailCard :target="getRealTarget(sourceTargetMap[group.key])!" />
                     </HflPopover>
-                    <span v-else class="target-assignment-empty">
+                    <span
+                      v-else
+                      class="target-assignment-empty"
+                    >
                       {{ t('protection.backupsPage.targetUnassigned') }}
                     </span>
                     <ElButton
@@ -7390,7 +7764,10 @@ function preserveShallowestPathOrder(paths: string[]) {
                       class="target-assignment-issue"
                       role="status"
                     >
-                      <ShieldAlert :size="14" class="target-assignment-issue__icon" />
+                      <ShieldAlert
+                        :size="14"
+                        class="target-assignment-issue__icon"
+                      />
                       <span>{{ targetGroupIssue(group) }}</span>
                     </div>
                     <div
@@ -7438,7 +7815,10 @@ function preserveShallowestPathOrder(paths: string[]) {
           </div>
         </div>
 
-        <div v-if="createStep === 3" class="dp-wizard-pane">
+        <div
+          v-if="createStep === 3"
+          class="dp-wizard-pane"
+        >
           <p class="text-sm text-slate-500 mb-3 m-0">
             {{ t('protection.backupsPage.createRecoveryPlanLead') }}
           </p>
@@ -7447,41 +7827,57 @@ function preserveShallowestPathOrder(paths: string[]) {
               <div class="create-source-config-selection">
                 {{ t('protection.backupsPage.selectedSourceCount', { selected: checkedRecoveryPlanGroups.length, total: createRecoveryPlanGroups.length }) }}
               </div>
-              <div class="create-source-config-toolbar__divider"></div>
-              <ElDropdown trigger="click" @command="(command) => applyBatchRecoveryPlanEnabled(command === 'enable')">
+              <div class="create-source-config-toolbar__divider" />
+              <ElDropdown
+                trigger="click"
+                @command="(command) => applyBatchRecoveryPlanEnabled(command === 'enable')"
+              >
                 <ElButton class="hfl-btn-with-icon">
                   <span>{{ t('protection.backupsPage.btnBatchActions') }}</span>
-                  <ChevronDown :size="15" stroke-width="2" class="shrink-0" />
+                  <ChevronDown
+                    :size="15"
+                    stroke-width="2"
+                    class="shrink-0"
+                  />
                 </ElButton>
                 <template #dropdown>
                   <ElDropdownMenu>
-                    <ElDropdownItem command="enable" :disabled="checkedRecoveryPlanDisabledGroups.length === 0">
+                    <ElDropdownItem
+                      command="enable"
+                      :disabled="checkedRecoveryPlanDisabledGroups.length === 0"
+                    >
                       {{ t('protection.backupsPage.batchEnableRecoveryPlanAction') }}
                     </ElDropdownItem>
-                    <ElDropdownItem command="disable" :disabled="checkedRecoveryPlanEnabledGroups.length === 0">
+                    <ElDropdownItem
+                      command="disable"
+                      :disabled="checkedRecoveryPlanEnabledGroups.length === 0"
+                    >
                       {{ t('protection.backupsPage.batchDisableRecoveryPlanAction') }}
                     </ElDropdownItem>
                   </ElDropdownMenu>
-                  </template>
-                </ElDropdown>
+                </template>
+              </ElDropdown>
               <div class="hfl-list-toolbar__right">
                 <ElInput
                   v-model="recoveryPlanSourceSearch"
                   clearable
-                  @clear="clearRecoveryPlanSourceSearch"
                   size="small"
                   :placeholder="t('protection.backupsPage.phSearchCreateSources')"
                   class="create-source-config-search hfl-list-search"
+                  @clear="clearRecoveryPlanSourceSearch"
                 >
                   <template #prefix>
-                    <Search :size="16" class="hfl-list-search__icon" />
+                    <Search
+                      :size="16"
+                      class="hfl-list-search__icon"
+                    />
                   </template>
                 </ElInput>
               </div>
             </div>
             <el-table
-          v-table-overflow-title
               ref="createRecoveryPlanTableRef"
+              v-table-overflow-title
               :data="filteredRecoveryPlanGroups"
               row-key="key"
               stripe
@@ -7491,11 +7887,24 @@ function preserveShallowestPathOrder(paths: string[]) {
               @expand-change="onCreateRecoveryPlanExpandChange"
               @selection-change="onRecoveryPlanGroupSelectionChange"
             >
-              <el-table-column type="selection" width="35" fixed="left" reserve-selection />
-              <el-table-column type="expand" width="35" fixed="left" class-name="create-source-config-expand-column">
+              <el-table-column
+                type="selection"
+                width="35"
+                fixed="left"
+                reserve-selection
+              />
+              <el-table-column
+                type="expand"
+                width="35"
+                fixed="left"
+                class-name="create-source-config-expand-column"
+              >
                 <template #default="{ row: group }">
                   <div class="create-recovery-plan-expand">
-                    <div v-if="group.plan.enabled" class="create-recovery-config-panel">
+                    <div
+                      v-if="group.plan.enabled"
+                      class="create-recovery-config-panel"
+                    >
                       <div class="create-recovery-config-panel__head">
                         <div class="create-recovery-config-panel__title-wrap">
                           <div class="create-recovery-config-panel__title">
@@ -7518,13 +7927,19 @@ function preserveShallowestPathOrder(paths: string[]) {
                             :placeholder="t('protection.backupsPage.fileConflictPolicyPlaceholder')"
                             @update:model-value="(value) => updateRecoveryPlanConflictMode(group, value)"
                           >
-                            <el-option :label="t('protection.backupsPage.createRecoveryConflictSkip')" value="skip">
+                            <el-option
+                              :label="t('protection.backupsPage.createRecoveryConflictSkip')"
+                              value="skip"
+                            >
                               <div class="recovery-conflict-policy-option recovery-conflict-policy-option--skip">
                                 <ShieldCheck :size="14" />
                                 <span>{{ t('protection.backupsPage.createRecoveryConflictSkipFull') }}</span>
                               </div>
                             </el-option>
-                            <el-option :label="t('protection.backupsPage.createRecoveryConflictOverwrite')" value="overwrite">
+                            <el-option
+                              :label="t('protection.backupsPage.createRecoveryConflictOverwrite')"
+                              value="overwrite"
+                            >
                               <div class="recovery-conflict-policy-option recovery-conflict-policy-option--overwrite">
                                 <ShieldAlert :size="14" />
                                 <span>{{ t('protection.backupsPage.createRecoveryConflictOverwriteFull') }}</span>
@@ -7534,7 +7949,10 @@ function preserveShallowestPathOrder(paths: string[]) {
                         </div>
                       </div>
                       <div class="create-recovery-dir-plan-stack">
-                        <div class="create-recovery-dir-plan-header" aria-hidden="true">
+                        <div
+                          class="create-recovery-dir-plan-header"
+                          aria-hidden="true"
+                        >
                           <span />
                           <span class="create-recovery-required-label">
                             {{ t('protection.backupsPage.createRecoveryPlanScopeCol') }}
@@ -7601,7 +8019,10 @@ function preserveShallowestPathOrder(paths: string[]) {
                                     @blur="dirPlan.sourcePathValidation === 'pending' && validateCreateRecoverySourcePathInput(group, dirPlan)"
                                     @keydown.enter.prevent="validateCreateRecoverySourcePathInput(group, dirPlan)"
                                   >
-                                    <template v-if="isDirectoryLoading(recoveryDirPlanPickerKey(group, dirPlan, 'source'))" #suffix>
+                                    <template
+                                      v-if="isDirectoryLoading(recoveryDirPlanPickerKey(group, dirPlan, 'source'))"
+                                      #suffix
+                                    >
                                       <span class="create-recovery-path-input__checking">{{ t('common.loading') }}</span>
                                     </template>
                                     <template #prefix>
@@ -7676,7 +8097,11 @@ function preserveShallowestPathOrder(paths: string[]) {
                                         :size="15"
                                         class="create-tree-node-content__icon hfl-dir-tree-node__icon create-dir-row__icon--file"
                                       />
-                                      <FolderOpen v-else :size="15" class="create-tree-node-content__icon hfl-dir-tree-node__icon create-dir-row__icon--folder" />
+                                      <FolderOpen
+                                        v-else
+                                        :size="15"
+                                        class="create-tree-node-content__icon hfl-dir-tree-node__icon create-dir-row__icon--folder"
+                                      />
                                       <div class="create-tree-node-content__text hfl-dir-tree-node__text">
                                         <span class="create-tree-node-content__label hfl-dir-tree-node__label">{{ data.label }}</span>
                                         <span
@@ -7728,7 +8153,10 @@ function preserveShallowestPathOrder(paths: string[]) {
                               @update:model-value="(value) => onCreateRecoveryTargetHostChange(group, dirPlan, value)"
                             >
                               <template #label="{ label }">
-                                <span class="create-recovery-target-selected-label" :title="label">{{ label }}</span>
+                                <span
+                                  class="create-recovery-target-selected-label"
+                                  :title="label"
+                                >{{ label }}</span>
                               </template>
                               <template #header>
                                 <div class="create-recovery-target-quick-option">
@@ -7829,14 +8257,23 @@ function preserveShallowestPathOrder(paths: string[]) {
                                 value="__load_more_error__"
                                 :label="t('protection.backupsPage.recoveryTargetLoadFailed')"
                               >
-                                <ElButton link type="primary" @click.stop="restoreTargetCatalog.retry">
+                                <ElButton
+                                  link
+                                  type="primary"
+                                  @click.stop="restoreTargetCatalog.retry"
+                                >
                                   {{ t('common.retry') }}
                                 </ElButton>
                               </el-option>
                               <template #empty>
                                 <div class="py-3 text-center text-xs text-slate-500">
                                   <span>{{ recoveryTargetError ? t('protection.backupsPage.recoveryTargetLoadFailed') : t('protection.backupsPage.recoveryTargetEmpty') }}</span>
-                                  <ElButton v-if="recoveryTargetError" link type="primary" @click.stop="restoreTargetCatalog.retry">
+                                  <ElButton
+                                    v-if="recoveryTargetError"
+                                    link
+                                    type="primary"
+                                    @click.stop="restoreTargetCatalog.retry"
+                                  >
                                     {{ t('common.retry') }}
                                   </ElButton>
                                 </div>
@@ -7873,7 +8310,10 @@ function preserveShallowestPathOrder(paths: string[]) {
                                     @blur="dirPlan.restoreDirValidation === 'pending' && validateCreateRecoveryDestPathInput(group, dirPlan)"
                                     @keydown.enter.prevent="validateCreateRecoveryDestPathInput(group, dirPlan)"
                                   >
-                                    <template v-if="isDirectoryLoading(recoveryDirPlanPickerKey(group, dirPlan, 'dest'))" #suffix>
+                                    <template
+                                      v-if="isDirectoryLoading(recoveryDirPlanPickerKey(group, dirPlan, 'dest'))"
+                                      #suffix
+                                    >
                                       <span class="create-recovery-path-input__checking">{{ t('common.loading') }}</span>
                                     </template>
                                     <template #prefix>
@@ -7931,7 +8371,10 @@ function preserveShallowestPathOrder(paths: string[]) {
                                 >
                                   <template #default="{ data }">
                                     <div class="create-tree-node-content hfl-dir-tree-node">
-                                      <FolderOpen :size="15" class="create-tree-node-content__icon hfl-dir-tree-node__icon" />
+                                      <FolderOpen
+                                        :size="15"
+                                        class="create-tree-node-content__icon hfl-dir-tree-node__icon"
+                                      />
                                       <div class="create-tree-node-content__text hfl-dir-tree-node__text">
                                         <span class="create-tree-node-content__label hfl-dir-tree-node__label">{{ data.label }}</span>
                                         <span class="create-tree-node-content__path hfl-dir-tree-node__path">{{ data.path }}</span>
@@ -7957,7 +8400,10 @@ function preserveShallowestPathOrder(paths: string[]) {
                               </div>
                             </HflPopover>
                           </div>
-                          <div class="create-recovery-dir-plan-cell create-recovery-dir-plan-cell--actions" :data-label="t('protection.backupsPage.colActions')">
+                          <div
+                            class="create-recovery-dir-plan-cell create-recovery-dir-plan-cell--actions"
+                            :data-label="t('protection.backupsPage.colActions')"
+                          >
                             <ElButton
                               text
                               circle
@@ -7984,13 +8430,20 @@ function preserveShallowestPathOrder(paths: string[]) {
                         </div>
                       </div>
                     </div>
-                    <span v-else class="create-recovery-disabled-cell">
+                    <span
+                      v-else
+                      class="create-recovery-disabled-cell"
+                    >
                       {{ t('protection.backupsPage.createRecoveryPlanDisabled') }}
                     </span>
                   </div>
                 </template>
               </el-table-column>
-              <el-table-column :label="t('protection.backupsPage.colBackupSource')" min-width="200" fixed="left">
+              <el-table-column
+                :label="t('protection.backupsPage.colBackupSource')"
+                min-width="200"
+                fixed="left"
+              >
                 <template #default="{ row: group }">
                   <button
                     type="button"
@@ -7999,12 +8452,22 @@ function preserveShallowestPathOrder(paths: string[]) {
                     @click.stop="requestToggleCreateRecoveryPlanRow(group)"
                   >
                     <div class="backup-source-cell__body">
-                      <span class="create-backup-source-name" :title="group.sourceName">{{ group.sourceName }}</span>
+                      <span
+                        class="create-backup-source-name"
+                        :title="group.sourceName"
+                      >{{ group.sourceName }}</span>
                       <span class="create-backup-source-meta-row">
-                        <el-tag size="small" effect="plain" class="create-backup-source-type-tag">
+                        <el-tag
+                          size="small"
+                          effect="plain"
+                          class="create-backup-source-type-tag"
+                        >
                           {{ backupSourceTypeLabel(group.sourceType) }}
                         </el-tag>
-                        <span v-if="group.platform" class="create-backup-source-platform">
+                        <span
+                          v-if="group.platform"
+                          class="create-backup-source-platform"
+                        >
                           <AgentPlatformBrandIcon :os="group.platform" />
                         </span>
                       </span>
@@ -8012,9 +8475,16 @@ function preserveShallowestPathOrder(paths: string[]) {
                   </button>
                 </template>
               </el-table-column>
-              <el-table-column :label="t('protection.backupsPage.labelBackupDirs')" min-width="200">
+              <el-table-column
+                :label="t('protection.backupsPage.labelBackupDirs')"
+                min-width="200"
+              >
                 <template #default="{ row: group }">
-                  <HflPopover trigger="hover" placement="top-start" :width="520">
+                  <HflPopover
+                    trigger="hover"
+                    placement="top-start"
+                    :width="520"
+                  >
                     <template #reference>
                       <div class="create-source-dir-preview">
                         <div class="create-source-dir-preview__count">
@@ -8033,13 +8503,18 @@ function preserveShallowestPathOrder(paths: string[]) {
                           />
                           <span class="create-source-dir-preview__path hfl-table-cell-mono">{{ entry.path }}</span>
                         </div>
-                        <div v-if="group.entries.length > 3" class="create-source-dir-preview__more">
+                        <div
+                          v-if="group.entries.length > 3"
+                          class="create-source-dir-preview__more"
+                        >
                           {{ t('protection.backupsPage.moreDirs', { n: group.entries.length - 3 }) }}
                         </div>
                       </div>
                     </template>
                     <div class="create-table-info-popover create-table-info-popover--dirs create-table-info-popover--selected-paths">
-                      <div class="create-table-info-popover__summary">{{ backupDirPopoverSummary(group.entries) }}</div>
+                      <div class="create-table-info-popover__summary">
+                        {{ backupDirPopoverSummary(group.entries) }}
+                      </div>
                       <div
                         v-for="entry in group.entries"
                         :key="entry.key"
@@ -8078,7 +8553,10 @@ function preserveShallowestPathOrder(paths: string[]) {
                         :class="`create-recovery-plan-cell--${recoveryPlanStatusTone(group)}`"
                       >
                         <div class="create-recovery-plan-cell__status">
-                          <span class="create-recovery-plan-cell__dot" aria-hidden="true" />
+                          <span
+                            class="create-recovery-plan-cell__dot"
+                            aria-hidden="true"
+                          />
                           <span class="create-recovery-plan-cell__status-label">
                             {{ recoveryPlanStatusLabel(group) }}
                           </span>
@@ -8100,12 +8578,19 @@ function preserveShallowestPathOrder(paths: string[]) {
                             :size="14"
                             class="create-recovery-plan-cell__policy-icon"
                           />
-                          <Info v-else :size="14" class="create-recovery-plan-cell__policy-icon" />
+                          <Info
+                            v-else
+                            :size="14"
+                            class="create-recovery-plan-cell__policy-icon"
+                          />
                           <span class="create-recovery-plan-cell__policy-text">
                             {{ recoveryPlanConflictSummary(group) }}
                           </span>
                         </div>
-                        <div v-if="recoveryPlanIncompleteReason(group)" class="create-recovery-plan-cell__issue">
+                        <div
+                          v-if="recoveryPlanIncompleteReason(group)"
+                          class="create-recovery-plan-cell__issue"
+                        >
                           {{ recoveryPlanIncompleteReason(group) }}
                         </div>
                         <div class="create-recovery-plan-cell__mappings">
@@ -8129,18 +8614,31 @@ function preserveShallowestPathOrder(paths: string[]) {
                                   :size="14"
                                   class="create-recovery-plan-mapping__icon"
                                 />
-                                <Folder v-else :size="14" class="create-recovery-plan-mapping__icon" />
+                                <Folder
+                                  v-else
+                                  :size="14"
+                                  class="create-recovery-plan-mapping__icon"
+                                />
                                 <span class="create-recovery-plan-mapping__text">{{ recoverySourcePathLabel(dirPlan.sourcePath) }}</span>
                               </span>
-                              <span class="create-recovery-plan-mapping__arrow" aria-hidden="true">-&gt;</span>
+                              <span
+                                class="create-recovery-plan-mapping__arrow"
+                                aria-hidden="true"
+                              >-&gt;</span>
                               <span
                                 class="create-recovery-plan-mapping__endpoint create-recovery-plan-mapping__endpoint--target"
                               >
-                                <FolderOpen :size="14" class="create-recovery-plan-mapping__icon create-dir-row__icon--folder" />
+                                <FolderOpen
+                                  :size="14"
+                                  class="create-recovery-plan-mapping__icon create-dir-row__icon--folder"
+                                />
                                 <span class="create-recovery-plan-mapping__text">{{ recoveryDirPlanTargetSummary(dirPlan) }}</span>
                               </span>
                             </template>
-                            <span v-else class="create-recovery-plan-mapping__pending">
+                            <span
+                              v-else
+                              class="create-recovery-plan-mapping__pending"
+                            >
                               {{ recoveryDirPlanPendingLabel() }}
                             </span>
                           </div>
@@ -8172,12 +8670,19 @@ function preserveShallowestPathOrder(paths: string[]) {
                             :size="14"
                             class="create-recovery-plan-cell__policy-icon"
                           />
-                          <Info v-else :size="14" class="create-recovery-plan-cell__policy-icon" />
+                          <Info
+                            v-else
+                            :size="14"
+                            class="create-recovery-plan-cell__policy-icon"
+                          />
                           <span class="create-recovery-plan-cell__policy-text">
                             {{ recoveryPlanConflictLabel(group.plan.conflictMode) }}
                           </span>
                         </div>
-                        <div v-if="recoveryPlanIncompleteReason(group)" class="create-recovery-plan-tooltip__issue">
+                        <div
+                          v-if="recoveryPlanIncompleteReason(group)"
+                          class="create-recovery-plan-tooltip__issue"
+                        >
                           {{ recoveryPlanIncompleteReason(group) }}
                         </div>
                         <div
@@ -8200,27 +8705,46 @@ function preserveShallowestPathOrder(paths: string[]) {
                                 :size="14"
                                 class="create-recovery-plan-mapping__icon"
                               />
-                              <Folder v-else :size="14" class="create-recovery-plan-mapping__icon" />
+                              <Folder
+                                v-else
+                                :size="14"
+                                class="create-recovery-plan-mapping__icon"
+                              />
                               <span class="create-recovery-plan-mapping__text">{{ recoverySourcePathLabel(dirPlan.sourcePath) }}</span>
                             </span>
-                            <span class="create-recovery-plan-mapping__arrow" aria-hidden="true">-&gt;</span>
+                            <span
+                              class="create-recovery-plan-mapping__arrow"
+                              aria-hidden="true"
+                            >-&gt;</span>
                             <span
                               class="create-recovery-plan-mapping__endpoint create-recovery-plan-mapping__endpoint--target"
                             >
-                              <FolderOpen :size="14" class="create-recovery-plan-mapping__icon create-dir-row__icon--folder" />
+                              <FolderOpen
+                                :size="14"
+                                class="create-recovery-plan-mapping__icon create-dir-row__icon--folder"
+                              />
                               <span class="create-recovery-plan-mapping__text">{{ recoveryDirPlanTargetSummary(dirPlan) }}</span>
                             </span>
                           </template>
-                          <span v-else class="create-recovery-plan-mapping__pending">
+                          <span
+                            v-else
+                            class="create-recovery-plan-mapping__pending"
+                          >
                             {{ recoveryDirPlanPendingLabel() }}
                           </span>
                         </div>
                       </div>
                     </template>
                   </HflPopover>
-                  <div v-else class="create-recovery-plan-cell create-recovery-plan-cell--disabled">
+                  <div
+                    v-else
+                    class="create-recovery-plan-cell create-recovery-plan-cell--disabled"
+                  >
                     <div class="create-recovery-plan-cell__status">
-                      <span class="create-recovery-plan-cell__dot" aria-hidden="true" />
+                      <span
+                        class="create-recovery-plan-cell__dot"
+                        aria-hidden="true"
+                      />
                       <span class="create-recovery-plan-cell__status-label">
                         {{ recoveryPlanStatusLabel(group) }}
                       </span>
@@ -8231,7 +8755,12 @@ function preserveShallowestPathOrder(paths: string[]) {
                   </div>
                 </template>
               </el-table-column>
-              <el-table-column :label="t('protection.backupsPage.createRecoveryPlanEnabled')" width="96" fixed="right" align="center">
+              <el-table-column
+                :label="t('protection.backupsPage.createRecoveryPlanEnabled')"
+                width="96"
+                fixed="right"
+                align="center"
+              >
                 <template #default="{ row: group }">
                   <div class="create-recovery-plan-action hfl-table-no-tooltip">
                     <el-switch
@@ -8250,8 +8779,13 @@ function preserveShallowestPathOrder(paths: string[]) {
           </div>
         </div>
 
-        <div v-if="createStep === 4" class="dp-wizard-pane">
-          <p class="create-confirm-lead">{{ t('protection.backupsPage.createStep3Lead') }}</p>
+        <div
+          v-if="createStep === 4"
+          class="dp-wizard-pane"
+        >
+          <p class="create-confirm-lead">
+            {{ t('protection.backupsPage.createStep3Lead') }}
+          </p>
           <section class="create-confirm-section create-confirm-section--first">
             <div class="create-confirm-list">
               <article
@@ -8261,11 +8795,19 @@ function preserveShallowestPathOrder(paths: string[]) {
               >
                 <div class="create-confirm-card__main">
                   <div class="create-confirm-card__name">
-                    <span class="create-confirm-card__index" :class="`is-${row.group.sourceType}`">
-                      <component :is="backupSourceTypeIcon(row.group.sourceType)" :size="14" />
+                    <span
+                      class="create-confirm-card__index"
+                      :class="`is-${row.group.sourceType}`"
+                    >
+                      <component
+                        :is="backupSourceTypeIcon(row.group.sourceType)"
+                        :size="14"
+                      />
                       {{ String(row.index + 1).padStart(2, '0') }}
                     </span>
-                    <div class="create-confirm-card__name-text">{{ row.name }}</div>
+                    <div class="create-confirm-card__name-text">
+                      {{ row.name }}
+                    </div>
                   </div>
                   <dl class="create-confirm-card__meta">
                     <div class="create-confirm-card__meta-item create-confirm-card__meta-item--wide">
@@ -8281,10 +8823,17 @@ function preserveShallowestPathOrder(paths: string[]) {
                             <div class="create-confirm-source__identity">
                               <span class="create-confirm-source__name">{{ row.group.sourceName }}</span>
                               <span class="create-backup-source-meta-row">
-                                <el-tag size="small" effect="plain" class="create-backup-source-type-tag">
+                                <el-tag
+                                  size="small"
+                                  effect="plain"
+                                  class="create-backup-source-type-tag"
+                                >
                                   {{ backupSourceTypeLabel(row.group.sourceType) }}
                                 </el-tag>
-                                <span v-if="row.group.platform" class="create-backup-source-platform">
+                                <span
+                                  v-if="row.group.platform"
+                                  class="create-backup-source-platform"
+                                >
                                   <AgentPlatformBrandIcon :os="row.group.platform" />
                                 </span>
                               </span>
@@ -8295,7 +8844,11 @@ function preserveShallowestPathOrder(paths: string[]) {
                           </div>
                           <div class="create-confirm-dir-box">
                             <ul class="create-confirm-dir-list">
-                              <li v-for="entry in row.entries" :key="entry.key" class="create-confirm-dir-list__item">
+                              <li
+                                v-for="entry in row.entries"
+                                :key="entry.key"
+                                class="create-confirm-dir-list__item"
+                              >
                                 <component
                                   :is="entry.pathType === 'file' ? FileIcon : Folder"
                                   :size="14"
@@ -8321,13 +8874,24 @@ function preserveShallowestPathOrder(paths: string[]) {
                           class="wizard-target-repository-cell wizard-target-repository-cell--confirm"
                           :class="`wizard-target-repository-cell--${row.targetTone}`"
                         >
-                          <span class="wizard-target-repository-cell__dot" aria-hidden="true"></span>
+                          <span
+                            class="wizard-target-repository-cell__dot"
+                            aria-hidden="true"
+                          />
                           <div class="wizard-target-repository-cell__body">
-                            <div class="wizard-target-repository-cell__name">{{ row.target }}</div>
-                            <div v-if="row.targetLocation" class="wizard-target-repository-cell__location hfl-table-cell-mono">
+                            <div class="wizard-target-repository-cell__name">
+                              {{ row.target }}
+                            </div>
+                            <div
+                              v-if="row.targetLocation"
+                              class="wizard-target-repository-cell__location hfl-table-cell-mono"
+                            >
                               {{ row.targetLocation }}
                             </div>
-                            <div v-if="row.targetEndpoint" class="wizard-target-repository-cell__location hfl-table-cell-mono">
+                            <div
+                              v-if="row.targetEndpoint"
+                              class="wizard-target-repository-cell__location hfl-table-cell-mono"
+                            >
                               {{ row.targetEndpoint }}
                             </div>
                           </div>
@@ -8359,17 +8923,28 @@ function preserveShallowestPathOrder(paths: string[]) {
                           popper-class="create-policy-option-popper"
                         >
                           <template #reference>
-                            <button type="button" class="create-confirm-hover-summary create-confirm-binding-summary">
+                            <button
+                              type="button"
+                              class="create-confirm-hover-summary create-confirm-binding-summary"
+                            >
                               <span class="create-confirm-binding-summary__name">{{ row.policyObject.name }}</span>
-                              <el-tag v-bind="policyStateTagAttrs(row.policyObject.isActive)" size="small">
+                              <el-tag
+                                v-bind="policyStateTagAttrs(row.policyObject.isActive)"
+                                size="small"
+                              >
                                 {{ policyStateLabel(row.policyObject.isActive) }}
                               </el-tag>
                             </button>
                           </template>
                           <div class="create-policy-detail-popover">
                             <div class="create-policy-detail-popover__head">
-                              <div class="create-policy-detail-popover__title">{{ row.policyObject.name }}</div>
-                              <el-tag v-bind="policyStateTagAttrs(row.policyObject.isActive)" size="small">
+                              <div class="create-policy-detail-popover__title">
+                                {{ row.policyObject.name }}
+                              </div>
+                              <el-tag
+                                v-bind="policyStateTagAttrs(row.policyObject.isActive)"
+                                size="small"
+                              >
                                 {{ policyStateLabel(row.policyObject.isActive) }}
                               </el-tag>
                             </div>
@@ -8394,7 +8969,10 @@ function preserveShallowestPathOrder(paths: string[]) {
                                       class="policy-retention-detail-list__line"
                                       :class="{ 'policy-retention-detail-list__line--summary': !line.label }"
                                     >
-                                      <span v-if="line.label" class="policy-retention-detail-list__label">{{ line.label }}</span>
+                                      <span
+                                        v-if="line.label"
+                                        class="policy-retention-detail-list__label"
+                                      >{{ line.label }}</span>
                                       <span class="policy-retention-detail-list__text">{{ line.text }}</span>
                                     </div>
                                   </div>
@@ -8403,7 +8981,10 @@ function preserveShallowestPathOrder(paths: string[]) {
                             </div>
                           </div>
                         </HflPopover>
-                        <span v-else class="create-confirm-binding-empty">
+                        <span
+                          v-else
+                          class="create-confirm-binding-empty"
+                        >
                           {{ t('protection.backupsPage.policyNoneOptional') }}
                         </span>
                       </dd>
@@ -8424,14 +9005,20 @@ function preserveShallowestPathOrder(paths: string[]) {
                           popper-class="create-policy-option-popper"
                         >
                           <template #reference>
-                            <button type="button" class="create-confirm-hover-summary create-confirm-binding-summary">
+                            <button
+                              type="button"
+                              class="create-confirm-hover-summary create-confirm-binding-summary"
+                            >
                               <span
                                 v-for="filter in row.filterObjects"
                                 :key="filter.id"
                                 class="create-confirm-binding-summary__item"
                               >
                                 <span class="create-confirm-binding-summary__name">{{ filter.name }}</span>
-                                <el-tag v-bind="policyStateTagAttrs(filter.isActive)" size="small">
+                                <el-tag
+                                  v-bind="policyStateTagAttrs(filter.isActive)"
+                                  size="small"
+                                >
                                   {{ policyStateLabel(filter.isActive) }}
                                 </el-tag>
                               </span>
@@ -8444,8 +9031,13 @@ function preserveShallowestPathOrder(paths: string[]) {
                               class="create-policy-detail-popover"
                             >
                               <div class="create-policy-detail-popover__head">
-                                <div class="create-policy-detail-popover__title">{{ filter.name }}</div>
-                                <el-tag v-bind="policyStateTagAttrs(filter.isActive)" size="small">
+                                <div class="create-policy-detail-popover__title">
+                                  {{ filter.name }}
+                                </div>
+                                <el-tag
+                                  v-bind="policyStateTagAttrs(filter.isActive)"
+                                  size="small"
+                                >
                                   {{ policyStateLabel(filter.isActive) }}
                                 </el-tag>
                               </div>
@@ -8463,7 +9055,10 @@ function preserveShallowestPathOrder(paths: string[]) {
                                   >
                                     {{ detailRow.value }}
                                   </el-tag>
-                                  <span v-else class="create-policy-detail-popover__value">{{ detailRow.value }}</span>
+                                  <span
+                                    v-else
+                                    class="create-policy-detail-popover__value"
+                                  >{{ detailRow.value }}</span>
                                 </section>
                                 <section class="create-policy-detail-popover__section">
                                   <div class="create-policy-detail-popover__section-title">
@@ -8479,7 +9074,10 @@ function preserveShallowestPathOrder(paths: string[]) {
                                         {{ line }}
                                       </code>
                                     </template>
-                                    <p v-else class="create-filter-rules-preview__empty">
+                                    <p
+                                      v-else
+                                      class="create-filter-rules-preview__empty"
+                                    >
                                       {{ t('protection.policiesPage.filterNoActiveRules') }}
                                     </p>
                                   </div>
@@ -8488,22 +9086,33 @@ function preserveShallowestPathOrder(paths: string[]) {
                             </div>
                           </div>
                         </HflPopover>
-                        <span v-else class="create-confirm-binding-empty">
+                        <span
+                          v-else
+                          class="create-confirm-binding-empty"
+                        >
                           {{ row.fileFilter }}
                         </span>
                       </dd>
                     </div>
-                    <div v-if="row.nasPlan" class="create-confirm-card__meta-item">
+                    <div
+                      v-if="row.nasPlan"
+                      class="create-confirm-card__meta-item"
+                    >
                       <dt>
                         <span class="create-confirm-meta-label">
-                          <component :is="targetNasSidebarIcon" :size="14" />
+                          <component
+                            :is="targetNasSidebarIcon"
+                            :size="14"
+                          />
                           {{ t('protection.backupsPage.descNasPlan') }}
                         </span>
                       </dt>
                       <dd>
                         <div class="create-confirm-detail-stack">
                           <div>{{ row.nasPlan }}</div>
-                          <div class="create-confirm-detail-line">{{ row.nasPlanDesc }}</div>
+                          <div class="create-confirm-detail-line">
+                            {{ row.nasPlanDesc }}
+                          </div>
                         </div>
                       </dd>
                     </div>
@@ -8521,7 +9130,10 @@ function preserveShallowestPathOrder(paths: string[]) {
                           :class="`create-recovery-plan-cell--${recoveryPlanStatusTone(row.recoveryGroup)}`"
                         >
                           <div class="create-recovery-plan-cell__status">
-                            <span class="create-recovery-plan-cell__dot" aria-hidden="true" />
+                            <span
+                              class="create-recovery-plan-cell__dot"
+                              aria-hidden="true"
+                            />
                             <span class="create-recovery-plan-cell__status-label">
                               {{ recoveryPlanStatusLabel(row.recoveryGroup) }}
                             </span>
@@ -8543,12 +9155,19 @@ function preserveShallowestPathOrder(paths: string[]) {
                               :size="14"
                               class="create-recovery-plan-cell__policy-icon"
                             />
-                            <Info v-else :size="14" class="create-recovery-plan-cell__policy-icon" />
+                            <Info
+                              v-else
+                              :size="14"
+                              class="create-recovery-plan-cell__policy-icon"
+                            />
                             <span class="create-recovery-plan-cell__policy-text">
                               {{ recoveryPlanConflictLabel(row.recoveryGroup.plan.conflictMode) }}
                             </span>
                           </div>
-                          <div v-if="recoveryPlanIncompleteReason(row.recoveryGroup)" class="create-recovery-plan-cell__issue">
+                          <div
+                            v-if="recoveryPlanIncompleteReason(row.recoveryGroup)"
+                            class="create-recovery-plan-cell__issue"
+                          >
                             {{ recoveryPlanIncompleteReason(row.recoveryGroup) }}
                           </div>
                           <div class="create-recovery-plan-cell__mappings">
@@ -8573,19 +9192,38 @@ function preserveShallowestPathOrder(paths: string[]) {
                                     :size="14"
                                     class="create-recovery-plan-mapping__icon"
                                   />
-                                  <Folder v-else :size="14" class="create-recovery-plan-mapping__icon" />
-                                  <span class="create-recovery-plan-mapping__text" :title="recoverySourcePathLabel(dirPlan.sourcePath)">{{ recoverySourcePathLabel(dirPlan.sourcePath) }}</span>
+                                  <Folder
+                                    v-else
+                                    :size="14"
+                                    class="create-recovery-plan-mapping__icon"
+                                  />
+                                  <span
+                                    class="create-recovery-plan-mapping__text"
+                                    :title="recoverySourcePathLabel(dirPlan.sourcePath)"
+                                  >{{ recoverySourcePathLabel(dirPlan.sourcePath) }}</span>
                                 </span>
-                                <span class="create-recovery-plan-mapping__arrow" aria-hidden="true">-&gt;</span>
+                                <span
+                                  class="create-recovery-plan-mapping__arrow"
+                                  aria-hidden="true"
+                                >-&gt;</span>
                                 <span
                                   class="create-recovery-plan-mapping__endpoint create-recovery-plan-mapping__endpoint--target"
                                   :title="recoveryDirPlanTargetSummary(dirPlan)"
                                 >
-                                  <FolderOpen :size="14" class="create-recovery-plan-mapping__icon create-dir-row__icon--folder" />
-                                  <span class="create-recovery-plan-mapping__text" :title="recoveryDirPlanTargetSummary(dirPlan)">{{ recoveryDirPlanTargetSummary(dirPlan) }}</span>
+                                  <FolderOpen
+                                    :size="14"
+                                    class="create-recovery-plan-mapping__icon create-dir-row__icon--folder"
+                                  />
+                                  <span
+                                    class="create-recovery-plan-mapping__text"
+                                    :title="recoveryDirPlanTargetSummary(dirPlan)"
+                                  >{{ recoveryDirPlanTargetSummary(dirPlan) }}</span>
                                 </span>
                               </template>
-                              <span v-else class="create-recovery-plan-mapping__pending">
+                              <span
+                                v-else
+                                class="create-recovery-plan-mapping__pending"
+                              >
                                 {{ recoveryDirPlanPendingLabel() }}
                               </span>
                             </div>
@@ -8597,9 +9235,15 @@ function preserveShallowestPathOrder(paths: string[]) {
                             </div>
                           </div>
                         </div>
-                        <div v-else class="create-recovery-plan-cell create-recovery-plan-cell--disabled">
+                        <div
+                          v-else
+                          class="create-recovery-plan-cell create-recovery-plan-cell--disabled"
+                        >
                           <div class="create-recovery-plan-cell__status">
-                            <span class="create-recovery-plan-cell__dot" aria-hidden="true" />
+                            <span
+                              class="create-recovery-plan-cell__dot"
+                              aria-hidden="true"
+                            />
                             <span class="create-recovery-plan-cell__status-label">
                               {{ recoveryPlanStatusLabel(row.recoveryGroup) }}
                             </span>
@@ -8615,9 +9259,7 @@ function preserveShallowestPathOrder(paths: string[]) {
               </article>
             </div>
           </section>
-
         </div>
-
       </template>
     </BackupConfigCreateWizard>
 
@@ -8641,7 +9283,10 @@ function preserveShallowestPathOrder(paths: string[]) {
               :aria-pressed="addTargetKind === item.value"
               @click="onAddTargetKindChange(item.value)"
             >
-              <span class="add-source-type-card__indicator" aria-hidden="true" />
+              <span
+                class="add-source-type-card__indicator"
+                aria-hidden="true"
+              />
               <span class="add-source-type-card__inner">
                 <span class="add-source-type-card__text">
                   <span class="add-source-type-card__name">{{ item.label }}</span>
@@ -8674,530 +9319,800 @@ function preserveShallowestPathOrder(paths: string[]) {
                 @created="onEmbeddedTargetCreated"
               />
 
-              <div v-show="false" aria-hidden="true">
-              <template v-if="addTargetKind === 's3'">
-                <div class="repository-add-steps">
-                  <div
-                    class="repository-add-step"
-                    :class="{
-                      'repository-add-step--active': addTargetS3Step === 0,
-                      'repository-add-step--done': addTargetS3Step > 0,
-                    }"
-                  >
-                    <span class="repository-add-step__num">{{ addTargetS3Step > 0 ? '✓' : '01' }}</span>
-                    <span class="repository-add-step__label">{{ t('addS3Repo.stepAuth') }}</span>
-                  </div>
-                  <div class="repository-add-step__connector" :class="{ 'is-on': addTargetS3Step > 0 }" />
-                  <div
-                    class="repository-add-step"
-                    :class="{ 'repository-add-step--active': addTargetS3Step === 1 }"
-                  >
-                    <span class="repository-add-step__num">02</span>
-                    <span class="repository-add-step__label">{{ t('addS3Repo.stepRepo') }}</span>
-                  </div>
-                </div>
-
-                <template v-if="addTargetS3Step === 0">
-                <section class="repository-add-card">
-                  <div class="repository-add-section">
-                    <h4 class="repository-add-section__title">
-                      <span class="repository-add-section__indicator" />
-                      {{ t('addS3Repo.fieldPlatform') }}
-                    </h4>
-                    <div class="repository-platform-grid">
-                      <button
-                        v-for="platform in addTargetS3PlatformOptions"
-                        :key="platform.value"
-                        type="button"
-                        class="repository-platform-btn"
-                        :class="{ 'is-active': addTargetS3Platform === platform.value }"
-                        @click="onAddTargetS3PlatformChange(platform.value)"
-                      >
-                        {{ platform.label }}
-                      </button>
+              <div
+                v-show="false"
+                aria-hidden="true"
+              >
+                <template v-if="addTargetKind === 's3'">
+                  <div class="repository-add-steps">
+                    <div
+                      class="repository-add-step"
+                      :class="{
+                        'repository-add-step--active': addTargetS3Step === 0,
+                        'repository-add-step--done': addTargetS3Step > 0,
+                      }"
+                    >
+                      <span class="repository-add-step__num">{{ addTargetS3Step > 0 ? '✓' : '01' }}</span>
+                      <span class="repository-add-step__label">{{ t('addS3Repo.stepAuth') }}</span>
                     </div>
-
-                    <template v-if="addTargetS3Platform && addTargetS3Platform !== 'other'">
-                      <h5 class="repository-add-section__subtitle">{{ t('repositoriesPage.fieldRegion') }}</h5>
-                      <div class="repository-region-grid">
-                        <button
-                          v-for="region in addTargetS3Regions"
-                          :key="region.key"
-                          type="button"
-                          class="repository-region-btn"
-                          :class="{ 'is-active': addTargetS3RegionPreset === region.key }"
-                          @click="applyAddTargetS3RegionPreset(region.key)"
-                        >
-                          <span class="repository-region-btn__label">{{ region.label }}</span>
-                          <span class="repository-region-btn__code">{{ region.region }}</span>
-                        </button>
-                      </div>
-                    </template>
-                  </div>
-                </section>
-
-                <section class="repository-add-card">
-                  <div class="repository-add-section">
-                    <h4 class="repository-add-section__title">
-                      <span class="repository-add-section__indicator" />
-                      {{ t('addS3Repo.connectionTitle') }}
-                    </h4>
-                    <div class="repository-add-warning">
-                      <Info :size="18" />
-                      <span>{{ t('addS3Repo.s3WarningHint') }}</span>
+                    <div
+                      class="repository-add-step__connector"
+                      :class="{ 'is-on': addTargetS3Step > 0 }"
+                    />
+                    <div
+                      class="repository-add-step"
+                      :class="{ 'repository-add-step--active': addTargetS3Step === 1 }"
+                    >
+                      <span class="repository-add-step__num">02</span>
+                      <span class="repository-add-step__label">{{ t('addS3Repo.stepRepo') }}</span>
                     </div>
-                    <ElForm label-position="top" class="repository-add-form repository-add-form--grid">
-                      <ElFormItem :label="t('addS3Repo.fieldEndpoint')" required>
-                        <ElInput v-model="addTargetS3Endpoint" :placeholder="t('addS3Repo.phEndpoint')" />
-                      </ElFormItem>
-                      <ElFormItem :label="t('repositoriesPage.fieldRegion')">
-                        <ElInput v-model="addTargetS3Region" :placeholder="t('repositoriesPage.phRegion')" />
-                      </ElFormItem>
-                      <ElFormItem :label="t('repositoriesPage.fieldAccessKey')" required>
-                        <ElInput v-model="addTargetS3AccessKey" :placeholder="t('repositoriesPage.phAccessKey')" />
-                      </ElFormItem>
-                      <ElFormItem :label="t('repositoriesPage.fieldSecretKey')" required>
-                        <ElInput v-model="addTargetS3SecretKey" type="password" show-password :placeholder="t('repositoriesPage.phSecretKey')" />
-                      </ElFormItem>
-                      <ElFormItem :label="t('repositoriesPage.fieldS3UrlStyle')">
-                        <ElSelect v-model="addTargetS3UrlStyle" class="w-full">
-                          <ElOption :label="t('repositoriesPage.s3UrlStyleAuto')" value="auto" />
-                          <ElOption :label="t('repositoriesPage.s3UrlStyleVirtualHosted')" value="virtual_hosted" />
-                          <ElOption :label="t('repositoriesPage.s3UrlStylePath')" value="path" />
-                        </ElSelect>
-                      </ElFormItem>
-                      <ElFormItem :label="t('repositoriesPage.fieldUseTls')">
-                        <ElSwitch
-                          v-model="addTargetS3UseTls"
-                          :active-text="t('repositoriesPage.tlsOnHint')"
-                          :inactive-text="t('repositoriesPage.tlsOffHint')"
-                        />
-                      </ElFormItem>
-                    </ElForm>
                   </div>
-                </section>
-                </template>
 
-                <section v-else class="repository-add-card">
-                  <div class="repository-add-section">
-                    <h4 class="repository-add-section__title">
-                      <span class="repository-add-section__indicator" />
-                      {{ t('repositoriesPage.stepRepo') }}
-                    </h4>
-                    <ElForm label-position="top" class="repository-add-form">
-                      <ElFormItem :label="t('repositoriesPage.fieldRepoName')" required>
-                        <ElInput v-model="addTargetRepoName" :placeholder="t('repositoriesPage.phRepoName')" />
-                      </ElFormItem>
-                      <ElFormItem :label="t('repositoriesPage.fieldBucket')" required>
-                        <div class="repository-segmented">
-                          <button
-                            type="button"
-                            class="repository-segmented__btn"
-                            :class="{ 'is-active': addTargetS3BucketMode === 'existing' }"
-                            @click="addTargetS3BucketMode = 'existing'"
-                          >
-                            {{ t('repositoriesPage.fieldBucketExisting') }}
-                          </button>
-                          <button
-                            type="button"
-                            class="repository-segmented__btn"
-                            :class="{ 'is-active': addTargetS3BucketMode === 'new' }"
-                            @click="addTargetS3BucketMode = 'new'"
-                          >
-                            {{ t('repositoriesPage.fieldBucketNew') }}
-                          </button>
-                        </div>
-                        <ElInput
-                          v-model="addTargetS3Bucket"
-                          :placeholder="addTargetS3BucketMode === 'existing' ? t('repositoriesPage.phBucketSelect') : t('repositoriesPage.phBucketNew')"
-                        />
-                      </ElFormItem>
-                      <ElFormItem :label="t('repositoriesPage.fieldPrefix')">
-                        <ElInput v-model="addTargetS3Prefix" :placeholder="t('repositoriesPage.phPrefix')" />
-                        <div class="mt-1 text-xs text-[var(--color-text-tertiary)]">{{ t('repositoriesPage.hintPrefix') }}</div>
-                      </ElFormItem>
-                    </ElForm>
-                  </div>
-                </section>
-              </template>
-
-              <template v-else-if="addTargetKind === 'nas'">
-                <div class="add-nas-steps add-nas-steps--panel">
-                  <div
-                    class="add-nas-steps__item"
-                    :class="{
-                      'add-nas-steps__item--active': addTargetNasStep === 0,
-                      'add-nas-steps__item--done': addTargetNasStep > 0,
-                    }"
-                  >
-                    <span class="add-nas-steps__num">{{ addTargetNasStep > 0 ? '✓' : '01' }}</span>
-                    <span class="add-nas-steps__label">{{ t('addNasRepo.stepAuthNas') }}</span>
-                  </div>
-                  <div class="add-nas-steps__connector" :class="{ 'add-nas-steps__connector--on': addTargetNasStep >= 1 }" />
-                  <div
-                    class="add-nas-steps__item"
-                    :class="{
-                      'add-nas-steps__item--active': addTargetNasStep === 1,
-                      'add-nas-steps__item--done': addTargetNasStep > 1,
-                    }"
-                  >
-                    <span class="add-nas-steps__num">{{ addTargetNasStep > 1 ? '✓' : '02' }}</span>
-                    <span class="add-nas-steps__label">{{ t('addNasRepo.stepBindProxy') }}</span>
-                  </div>
-                  <div class="add-nas-steps__connector" :class="{ 'add-nas-steps__connector--on': addTargetNasStep >= 2 }" />
-                  <div class="add-nas-steps__item" :class="{ 'add-nas-steps__item--active': addTargetNasStep === 2 }">
-                    <span class="add-nas-steps__num">03</span>
-                    <span class="add-nas-steps__label">{{ t('repositoriesPage.stepRepo') }}</span>
-                  </div>
-                </div>
-
-                <section v-show="addTargetNasStep === 0" class="add-nas-card">
-                  <div class="add-nas-section">
-                    <h4 class="add-nas-section__title">
-                      <span class="add-nas-section__indicator" />
-                      {{ t('repositoriesPage.fieldProtocol') }}
-                    </h4>
-                    <ElRadioGroup v-model="addTargetNasProtocol" class="add-nas-protocol-grid">
-                      <ElRadio value="smb" border class="add-nas-protocol-card !mr-0">
-                        <div class="add-nas-protocol-card__inner">
-                          <component :is="nasMountProtocolIcon('smb')" :size="24" />
-                          <div class="add-nas-protocol-card__text">
-                            <div class="font-semibold">{{ t('repositoriesPage.protocolSmb') }}</div>
-                          </div>
-                        </div>
-                      </ElRadio>
-                      <ElRadio value="nfs" border class="add-nas-protocol-card !mr-0">
-                        <div class="add-nas-protocol-card__inner">
-                          <component :is="nasMountProtocolIcon('nfs')" :size="24" />
-                          <div class="add-nas-protocol-card__text">
-                            <div class="font-semibold">{{ t('repositoriesPage.protocolNfs') }}</div>
-                          </div>
-                        </div>
-                      </ElRadio>
-                    </ElRadioGroup>
-
-                    <h5 class="add-nas-section__subtitle">
-                      <FolderOpen :size="16" />
-                      {{ t('addNasRepo.titleNasInfo') }}
-                    </h5>
-                    <ElForm label-position="top" class="add-nas-form">
-                      <div class="add-nas-form-row add-nas-form-row--responsive">
-                        <ElFormItem
-                          :label="addTargetNasProtocol === 'smb' ? t('addNasRepo.fieldSmbHost') : t('addNasRepo.fieldNfsHost')"
-                          required
-                          class="flex-1"
-                        >
-                          <ElInput v-model="addTargetNasHost" :placeholder="addTargetNasProtocol === 'smb' ? t('addNasRepo.phSmbHost') : t('addNasRepo.phNfsHost')" />
-                        </ElFormItem>
-                        <ElFormItem v-if="addTargetNasProtocol === 'smb'" :label="t('addNasRepo.fieldSmbShare')" required class="flex-1">
-                          <ElInput v-model="addTargetNasShare" :placeholder="t('addNasRepo.phSmbShare')" />
-                        </ElFormItem>
-                        <ElFormItem v-else :label="t('addNasRepo.fieldNfsExport')" required class="flex-1">
-                          <ElInput v-model="addTargetNasExport" :placeholder="t('addNasRepo.phNfsExport')" />
-                        </ElFormItem>
-                      </div>
-                      <div v-if="addTargetNasProtocol === 'smb'" class="add-nas-form-row add-nas-form-row--responsive">
-                        <ElFormItem :label="t('repositoriesPage.fieldSmbUsername')" required class="flex-1">
-                          <ElInput v-model="addTargetNasUsername" :placeholder="t('repositoriesPage.phSmbUsername')" />
-                        </ElFormItem>
-                        <ElFormItem :label="t('repositoriesPage.fieldSmbPassword')" required class="flex-1">
-                          <ElInput v-model="addTargetNasPassword" type="password" show-password :placeholder="t('repositoriesPage.phSmbPassword')" />
-                        </ElFormItem>
-                      </div>
-                      <ElFormItem :label="t('addNasRepo.fieldMountOptions')">
-                        <ElInput
-                          v-model="addTargetNasMountOptions"
-                          :placeholder="addTargetNasProtocol === 'smb' ? t('addNasRepo.phMountOptionsSmb') : t('addNasRepo.phMountOptionsNfs')"
-                        />
-                        <div class="mt-1 text-xs text-[rgb(100_116_139)]">
-                          {{ addTargetNasProtocol === 'smb' ? t('addNasRepo.hintMountOptionsSmb') : t('addNasRepo.hintMountOptionsNfs') }}
-                        </div>
-                      </ElFormItem>
-                    </ElForm>
-                  </div>
-                </section>
-
-                <section v-show="addTargetNasStep === 1" class="add-nas-card">
-                  <div class="add-nas-section">
-                    <div class="add-nas-section__head">
-                      <div class="add-nas-section__title-wrap">
-                        <h4 class="add-nas-section__title !mb-0">
-                          <span class="add-nas-section__indicator" />
-                          {{ t('addNasRepo.titleBindProxy') }}
+                  <template v-if="addTargetS3Step === 0">
+                    <section class="repository-add-card">
+                      <div class="repository-add-section">
+                        <h4 class="repository-add-section__title">
+                          <span class="repository-add-section__indicator" />
+                          {{ t('addS3Repo.fieldPlatform') }}
                         </h4>
-                        <span class="add-nas-optional-badge">{{ t('addNasRepo.optional') }}</span>
+                        <div class="repository-platform-grid">
+                          <button
+                            v-for="platform in addTargetS3PlatformOptions"
+                            :key="platform.value"
+                            type="button"
+                            class="repository-platform-btn"
+                            :class="{ 'is-active': addTargetS3Platform === platform.value }"
+                            @click="onAddTargetS3PlatformChange(platform.value)"
+                          >
+                            {{ platform.label }}
+                          </button>
+                        </div>
+
+                        <template v-if="addTargetS3Platform && addTargetS3Platform !== 'other'">
+                          <h5 class="repository-add-section__subtitle">
+                            {{ t('repositoriesPage.fieldRegion') }}
+                          </h5>
+                          <div class="repository-region-grid">
+                            <button
+                              v-for="region in addTargetS3Regions"
+                              :key="region.key"
+                              type="button"
+                              class="repository-region-btn"
+                              :class="{ 'is-active': addTargetS3RegionPreset === region.key }"
+                              @click="applyAddTargetS3RegionPreset(region.key)"
+                            >
+                              <span class="repository-region-btn__label">{{ region.label }}</span>
+                              <span class="repository-region-btn__code">{{ region.region }}</span>
+                            </button>
+                          </div>
+                        </template>
                       </div>
-                    </div>
+                    </section>
 
-                    <ElAlert type="warning" :closable="false" show-icon class="add-nas-proxy-alert">
-                      <ol class="add-nas-proxy-alert__list">
-                        <li v-for="item in bindProxyLeadItems" :key="item">{{ item }}</li>
-                      </ol>
-                    </ElAlert>
-
-                    <div class="add-nas-proxy-layout">
-                      <div class="add-nas-proxy-form">
-                        <ElForm label-position="top" class="add-nas-form">
-                          <ElFormItem class="add-nas-bind-form-item">
-                            <template #label>
-                              <span class="add-nas-field-label-with-action">
-                                <span>{{ t('addNasRepo.fieldSourceProxyNode') }}</span>
-                                <ElButton
-                                  text
-                                  circle
-                                  class="hfl-refresh-button add-nas-field-label-with-action__btn"
-                                  :title="t('addNasRepo.proxyRefresh')"
-                                  :aria-label="t('addNasRepo.proxyRefresh')"
-                                  :disabled="proxyNodesRefreshing"
-                                  @click.stop="refreshProxyNodesManually"
-                                >
-                                  <RefreshCw :size="15" stroke-width="2" :class="{ 'is-spinning': proxyNodesRefreshing }" />
-                                </ElButton>
-                              </span>
-                            </template>
-                            <div class="add-nas-select-row">
-                              <ElButton text circle class="add-nas-select-row__search" aria-hidden="true" tabindex="-1">
-                                <Search :size="15" stroke-width="2" />
-                              </ElButton>
-                              <ElSelect
-                                v-model="addTargetNasProxyNodeId"
-                                class="add-nas-select-row__select"
-                                :placeholder="t('addNasRepo.phSourceProxyNode')"
-                                filterable
-                                clearable
-                              >
-                                <ElOption :value="0" :label="t('addNasRepo.optionNoProxy')" />
-                                <ElOption
-                                  v-for="node in addTargetProxyNodeOptions"
-                                  :key="node.id"
-                                  :value="node.id"
-                                  :label="node.name"
-                                />
-                              </ElSelect>
-                            </div>
-                            <div class="mt-2 text-xs text-[var(--color-text-tertiary)]">
-                              {{ addTargetNasProxyNodeId ? t('addNasRepo.hintProxySelected') : t('addNasRepo.hintProxySkipped') }}
-                            </div>
+                    <section class="repository-add-card">
+                      <div class="repository-add-section">
+                        <h4 class="repository-add-section__title">
+                          <span class="repository-add-section__indicator" />
+                          {{ t('addS3Repo.connectionTitle') }}
+                        </h4>
+                        <div class="repository-add-warning">
+                          <Info :size="18" />
+                          <span>{{ t('addS3Repo.s3WarningHint') }}</span>
+                        </div>
+                        <ElForm
+                          label-position="top"
+                          class="repository-add-form repository-add-form--grid"
+                        >
+                          <ElFormItem
+                            :label="t('addS3Repo.fieldEndpoint')"
+                            required
+                          >
+                            <ElInput
+                              v-model="addTargetS3Endpoint"
+                              :placeholder="t('addS3Repo.phEndpoint')"
+                            />
+                          </ElFormItem>
+                          <ElFormItem :label="t('repositoriesPage.fieldRegion')">
+                            <ElInput
+                              v-model="addTargetS3Region"
+                              :placeholder="t('repositoriesPage.phRegion')"
+                            />
+                          </ElFormItem>
+                          <ElFormItem
+                            :label="t('repositoriesPage.fieldAccessKey')"
+                            required
+                          >
+                            <ElInput
+                              v-model="addTargetS3AccessKey"
+                              :placeholder="t('repositoriesPage.phAccessKey')"
+                            />
+                          </ElFormItem>
+                          <ElFormItem
+                            :label="t('repositoriesPage.fieldSecretKey')"
+                            required
+                          >
+                            <ElInput
+                              v-model="addTargetS3SecretKey"
+                              type="password"
+                              show-password
+                              :placeholder="t('repositoriesPage.phSecretKey')"
+                            />
+                          </ElFormItem>
+                          <ElFormItem :label="t('repositoriesPage.fieldS3UrlStyle')">
+                            <ElSelect
+                              v-model="addTargetS3UrlStyle"
+                              class="w-full"
+                            >
+                              <ElOption
+                                :label="t('repositoriesPage.s3UrlStyleAuto')"
+                                value="auto"
+                              />
+                              <ElOption
+                                :label="t('repositoriesPage.s3UrlStyleVirtualHosted')"
+                                value="virtual_hosted"
+                              />
+                              <ElOption
+                                :label="t('repositoriesPage.s3UrlStylePath')"
+                                value="path"
+                              />
+                            </ElSelect>
+                          </ElFormItem>
+                          <ElFormItem :label="t('repositoriesPage.fieldUseTls')">
+                            <ElSwitch
+                              v-model="addTargetS3UseTls"
+                              :active-text="t('repositoriesPage.tlsOnHint')"
+                              :inactive-text="t('repositoriesPage.tlsOffHint')"
+                            />
                           </ElFormItem>
                         </ElForm>
-
-                        <div class="add-nas-proxy-benefits">
-                          <div class="add-nas-proxy-benefit">
-                            <span class="add-nas-proxy-benefit__dot" />
-                            {{ t('addNasRepo.proxyBenefitAvoidMountFailure') }}
-                          </div>
-                          <div class="add-nas-proxy-benefit">
-                            <span class="add-nas-proxy-benefit__dot" />
-                            {{ t('addNasRepo.proxyBenefitSharedRepo') }}
-                          </div>
-                        </div>
                       </div>
+                    </section>
+                  </template>
 
-                      <div class="add-nas-path-card" :class="{ 'add-nas-path-card--direct': isAddTargetNasDirectAccess }" aria-hidden="true">
-                        <template v-if="!isAddTargetNasDirectAccess">
-                          <div class="add-nas-path-card__agents">
-                            <span>{{ t('addNasRepo.demoBackupSourceA') }}</span>
-                            <span>{{ t('addNasRepo.demoBackupSourceB') }}</span>
-                            <span>{{ t('addNasRepo.demoBackupSourceC') }}</span>
-                          </div>
-                          <div class="add-nas-path-card__join" />
-                          <div class="add-nas-path-card__node add-nas-path-card__node--proxy">Proxy</div>
-                          <div class="add-nas-path-card__line" />
-                          <div class="add-nas-path-card__node add-nas-path-card__node--nas">NAS</div>
-                        </template>
-                        <template v-else>
-                          <div class="add-nas-path-card__direct-rows">
-                            <div class="add-nas-path-card__direct-row">
-                              <span class="add-nas-path-card__source">{{ t('addNasRepo.demoBackupSourceA') }}</span>
-                              <span class="add-nas-path-card__direct-line" />
-                              <span class="add-nas-path-card__node add-nas-path-card__node--nas">NAS</span>
-                            </div>
-                            <div class="add-nas-path-card__direct-row">
-                              <span class="add-nas-path-card__source">{{ t('addNasRepo.demoBackupSourceB') }}</span>
-                              <span class="add-nas-path-card__direct-line" />
-                              <span class="add-nas-path-card__node add-nas-path-card__node--nas">NAS</span>
-                            </div>
-                            <div class="add-nas-path-card__direct-row">
-                              <span class="add-nas-path-card__source">{{ t('addNasRepo.demoBackupSourceC') }}</span>
-                              <span class="add-nas-path-card__direct-line" />
-                              <span class="add-nas-path-card__node add-nas-path-card__node--nas">NAS</span>
-                            </div>
-                          </div>
-                        </template>
-                      </div>
-                    </div>
-
-                    <ElButton class="add-nas-deploy-btn" type="primary" plain @click="openProxyDeploy">
-                      <Plus :size="14" class="inline" />
-                      {{ t('addNasRepo.deployProxy') }}
-                    </ElButton>
-                  </div>
-                </section>
-
-                <section v-show="addTargetNasStep === 2" class="add-nas-card">
-                  <div class="add-nas-section">
-                    <h4 class="add-nas-section__title">
-                      <span class="add-nas-section__indicator" />
-                      {{ t('repositoriesPage.stepRepo') }}
-                    </h4>
-                    <ElForm label-position="top" class="add-nas-form">
-                      <ElFormItem :label="t('repositoriesPage.fieldRepoName')" required>
-                        <ElInput v-model="addTargetRepoName" :placeholder="t('repositoriesPage.phRepoName')" />
-                      </ElFormItem>
-                    </ElForm>
-                  </div>
-                </section>
-              </template>
-
-              <template v-else>
-                <section class="repository-add-card">
-                  <div class="repository-add-section">
-                    <h4 class="repository-add-section__title">
-                      <span class="repository-add-section__indicator" />
-                      {{ t('repositoriesPage.addProxyFsPage') }}
-                    </h4>
-                    <ElForm label-position="top" class="repository-add-form">
-                      <ElFormItem :label="t('repositoriesPage.fieldRepoName')" required>
-                        <ElInput v-model="addTargetRepoName" :placeholder="t('repositoriesPage.phRepoName')" />
-                        <div class="mt-1 text-xs text-[var(--color-text-tertiary)]">{{ t('repositoriesPage.hintRepoNameAuto') }}</div>
-                      </ElFormItem>
-                      <ElFormItem :label="t('repositoriesPage.fieldProxyNode')" required>
-                        <ElSelect
-                          v-model="addTargetProxyNodeId"
-                          class="w-full"
-                          filterable
-                          :placeholder="t('repositoriesPage.phProxyNode')"
+                  <section
+                    v-else
+                    class="repository-add-card"
+                  >
+                    <div class="repository-add-section">
+                      <h4 class="repository-add-section__title">
+                        <span class="repository-add-section__indicator" />
+                        {{ t('repositoriesPage.stepRepo') }}
+                      </h4>
+                      <ElForm
+                        label-position="top"
+                        class="repository-add-form"
+                      >
+                        <ElFormItem
+                          :label="t('repositoriesPage.fieldRepoName')"
+                          required
                         >
-                          <ElOption
-                            v-for="node in addTargetProxyNodeOptions"
-                            :key="node.id"
-                            :label="node.name"
-                            :value="node.id"
+                          <ElInput
+                            v-model="addTargetRepoName"
+                            :placeholder="t('repositoriesPage.phRepoName')"
                           />
-                        </ElSelect>
-                      </ElFormItem>
-                      <ElFormItem :label="t('repositoriesPage.fieldProxyNodeDir')" required>
-                        <div class="repository-dir-selector">
+                        </ElFormItem>
+                        <ElFormItem
+                          :label="t('repositoriesPage.fieldBucket')"
+                          required
+                        >
                           <div class="repository-segmented">
                             <button
                               type="button"
                               class="repository-segmented__btn"
-                              :class="{ 'is-active': addTargetProxyUseTree }"
-                              @click="addTargetProxyUseTree = true"
+                              :class="{ 'is-active': addTargetS3BucketMode === 'existing' }"
+                              @click="addTargetS3BucketMode = 'existing'"
                             >
-                              <FolderTree :size="14" />
-                              {{ t('repositoriesPage.dirSelectTree') }}
+                              {{ t('repositoriesPage.fieldBucketExisting') }}
                             </button>
                             <button
                               type="button"
                               class="repository-segmented__btn"
-                              :class="{ 'is-active': !addTargetProxyUseTree }"
-                              @click="addTargetProxyUseTree = false"
+                              :class="{ 'is-active': addTargetS3BucketMode === 'new' }"
+                              @click="addTargetS3BucketMode = 'new'"
                             >
-                              <HardDrive :size="14" />
-                              {{ t('repositoriesPage.dirSelectInput') }}
+                              {{ t('repositoriesPage.fieldBucketNew') }}
                             </button>
                           </div>
-                          <div v-if="addTargetProxyUseTree" class="repository-dir-tree-shell hfl-dir-tree-shell">
-                            <div v-if="!addTargetProxyNodeId" class="repository-dir-tree-shell__empty hfl-dir-tree-empty">
-                              {{ t('repositoriesPage.errProxyNode') }}
-                            </div>
-                            <ElTree
-                              v-else
-                              ref="addTargetProxyDirTreeRef"
-                              class="repository-dir-tree hfl-dir-tree"
-                              :data="addTargetProxyTreeData"
-                              :props="{ children: 'children', label: 'label' }"
-                              node-key="id"
-                              show-checkbox
-                              check-strictly
-                              default-expand-all
-                              :check-on-click-node="true"
-                              :expand-on-click-node="false"
-                              :highlight-current="true"
-                              :current-node-key="addTargetProxyCurrentTreeNodeKey"
-                              :default-checked-keys="addTargetProxyCheckedTreeKeys"
-                              @current-change="onAddTargetProxyTreeSelect"
-                              @check-change="onAddTargetProxyTreeCheck"
-                            >
-                              <template #default="{ data }">
-                                <div class="repository-tree-node hfl-dir-tree-node">
-                                  <FolderOpen :size="15" class="repository-tree-node__icon hfl-dir-tree-node__icon" />
-                                  <div class="repository-tree-node__text hfl-dir-tree-node__text">
-                                    <span class="repository-tree-node__label hfl-dir-tree-node__label">{{ data.label }}</span>
-                                    <span class="repository-tree-node__path hfl-dir-tree-node__path">{{ data.pathLabel }}</span>
-                                  </div>
-                                </div>
-                              </template>
-                            </ElTree>
-                            <div class="mt-2 text-xs text-[var(--color-text-tertiary)]">{{ t('repositoriesPage.hintTreeSelect') }}</div>
+                          <ElInput
+                            v-model="addTargetS3Bucket"
+                            :placeholder="addTargetS3BucketMode === 'existing' ? t('repositoriesPage.phBucketSelect') : t('repositoriesPage.phBucketNew')"
+                          />
+                        </ElFormItem>
+                        <ElFormItem :label="t('repositoriesPage.fieldPrefix')">
+                          <ElInput
+                            v-model="addTargetS3Prefix"
+                            :placeholder="t('repositoriesPage.phPrefix')"
+                          />
+                          <div class="mt-1 text-xs text-[var(--color-text-tertiary)]">
+                            {{ t('repositoriesPage.hintPrefix') }}
                           </div>
-                          <ElInput v-else v-model="addTargetProxyDir" :placeholder="t('repositoriesPage.phProxyNodeDir')" />
+                        </ElFormItem>
+                      </ElForm>
+                    </div>
+                  </section>
+                </template>
+
+                <template v-else-if="addTargetKind === 'nas'">
+                  <div class="add-nas-steps add-nas-steps--panel">
+                    <div
+                      class="add-nas-steps__item"
+                      :class="{
+                        'add-nas-steps__item--active': addTargetNasStep === 0,
+                        'add-nas-steps__item--done': addTargetNasStep > 0,
+                      }"
+                    >
+                      <span class="add-nas-steps__num">{{ addTargetNasStep > 0 ? '✓' : '01' }}</span>
+                      <span class="add-nas-steps__label">{{ t('addNasRepo.stepAuthNas') }}</span>
+                    </div>
+                    <div
+                      class="add-nas-steps__connector"
+                      :class="{ 'add-nas-steps__connector--on': addTargetNasStep >= 1 }"
+                    />
+                    <div
+                      class="add-nas-steps__item"
+                      :class="{
+                        'add-nas-steps__item--active': addTargetNasStep === 1,
+                        'add-nas-steps__item--done': addTargetNasStep > 1,
+                      }"
+                    >
+                      <span class="add-nas-steps__num">{{ addTargetNasStep > 1 ? '✓' : '02' }}</span>
+                      <span class="add-nas-steps__label">{{ t('addNasRepo.stepBindProxy') }}</span>
+                    </div>
+                    <div
+                      class="add-nas-steps__connector"
+                      :class="{ 'add-nas-steps__connector--on': addTargetNasStep >= 2 }"
+                    />
+                    <div
+                      class="add-nas-steps__item"
+                      :class="{ 'add-nas-steps__item--active': addTargetNasStep === 2 }"
+                    >
+                      <span class="add-nas-steps__num">03</span>
+                      <span class="add-nas-steps__label">{{ t('repositoriesPage.stepRepo') }}</span>
+                    </div>
+                  </div>
+
+                  <section
+                    v-show="addTargetNasStep === 0"
+                    class="add-nas-card"
+                  >
+                    <div class="add-nas-section">
+                      <h4 class="add-nas-section__title">
+                        <span class="add-nas-section__indicator" />
+                        {{ t('repositoriesPage.fieldProtocol') }}
+                      </h4>
+                      <ElRadioGroup
+                        v-model="addTargetNasProtocol"
+                        class="add-nas-protocol-grid"
+                      >
+                        <ElRadio
+                          value="smb"
+                          border
+                          class="add-nas-protocol-card !mr-0"
+                        >
+                          <div class="add-nas-protocol-card__inner">
+                            <component
+                              :is="nasMountProtocolIcon('smb')"
+                              :size="24"
+                            />
+                            <div class="add-nas-protocol-card__text">
+                              <div class="font-semibold">
+                                {{ t('repositoriesPage.protocolSmb') }}
+                              </div>
+                            </div>
+                          </div>
+                        </ElRadio>
+                        <ElRadio
+                          value="nfs"
+                          border
+                          class="add-nas-protocol-card !mr-0"
+                        >
+                          <div class="add-nas-protocol-card__inner">
+                            <component
+                              :is="nasMountProtocolIcon('nfs')"
+                              :size="24"
+                            />
+                            <div class="add-nas-protocol-card__text">
+                              <div class="font-semibold">
+                                {{ t('repositoriesPage.protocolNfs') }}
+                              </div>
+                            </div>
+                          </div>
+                        </ElRadio>
+                      </ElRadioGroup>
+
+                      <h5 class="add-nas-section__subtitle">
+                        <FolderOpen :size="16" />
+                        {{ t('addNasRepo.titleNasInfo') }}
+                      </h5>
+                      <ElForm
+                        label-position="top"
+                        class="add-nas-form"
+                      >
+                        <div class="add-nas-form-row add-nas-form-row--responsive">
+                          <ElFormItem
+                            :label="addTargetNasProtocol === 'smb' ? t('addNasRepo.fieldSmbHost') : t('addNasRepo.fieldNfsHost')"
+                            required
+                            class="flex-1"
+                          >
+                            <ElInput
+                              v-model="addTargetNasHost"
+                              :placeholder="addTargetNasProtocol === 'smb' ? t('addNasRepo.phSmbHost') : t('addNasRepo.phNfsHost')"
+                            />
+                          </ElFormItem>
+                          <ElFormItem
+                            v-if="addTargetNasProtocol === 'smb'"
+                            :label="t('addNasRepo.fieldSmbShare')"
+                            required
+                            class="flex-1"
+                          >
+                            <ElInput
+                              v-model="addTargetNasShare"
+                              :placeholder="t('addNasRepo.phSmbShare')"
+                            />
+                          </ElFormItem>
+                          <ElFormItem
+                            v-else
+                            :label="t('addNasRepo.fieldNfsExport')"
+                            required
+                            class="flex-1"
+                          >
+                            <ElInput
+                              v-model="addTargetNasExport"
+                              :placeholder="t('addNasRepo.phNfsExport')"
+                            />
+                          </ElFormItem>
+                        </div>
+                        <div
+                          v-if="addTargetNasProtocol === 'smb'"
+                          class="add-nas-form-row add-nas-form-row--responsive"
+                        >
+                          <ElFormItem
+                            :label="t('repositoriesPage.fieldSmbUsername')"
+                            required
+                            class="flex-1"
+                          >
+                            <ElInput
+                              v-model="addTargetNasUsername"
+                              :placeholder="t('repositoriesPage.phSmbUsername')"
+                            />
+                          </ElFormItem>
+                          <ElFormItem
+                            :label="t('repositoriesPage.fieldSmbPassword')"
+                            required
+                            class="flex-1"
+                          >
+                            <ElInput
+                              v-model="addTargetNasPassword"
+                              type="password"
+                              show-password
+                              :placeholder="t('repositoriesPage.phSmbPassword')"
+                            />
+                          </ElFormItem>
+                        </div>
+                        <ElFormItem :label="t('addNasRepo.fieldMountOptions')">
+                          <ElInput
+                            v-model="addTargetNasMountOptions"
+                            :placeholder="addTargetNasProtocol === 'smb' ? t('addNasRepo.phMountOptionsSmb') : t('addNasRepo.phMountOptionsNfs')"
+                          />
+                          <div class="mt-1 text-xs text-[rgb(100_116_139)]">
+                            {{ addTargetNasProtocol === 'smb' ? t('addNasRepo.hintMountOptionsSmb') : t('addNasRepo.hintMountOptionsNfs') }}
+                          </div>
+                        </ElFormItem>
+                      </ElForm>
+                    </div>
+                  </section>
+
+                  <section
+                    v-show="addTargetNasStep === 1"
+                    class="add-nas-card"
+                  >
+                    <div class="add-nas-section">
+                      <div class="add-nas-section__head">
+                        <div class="add-nas-section__title-wrap">
+                          <h4 class="add-nas-section__title !mb-0">
+                            <span class="add-nas-section__indicator" />
+                            {{ t('addNasRepo.titleBindProxy') }}
+                          </h4>
+                          <span class="add-nas-optional-badge">{{ t('addNasRepo.optional') }}</span>
+                        </div>
+                      </div>
+
+                      <ElAlert
+                        type="warning"
+                        :closable="false"
+                        show-icon
+                        class="add-nas-proxy-alert"
+                      >
+                        <ol class="add-nas-proxy-alert__list">
+                          <li
+                            v-for="item in bindProxyLeadItems"
+                            :key="item"
+                          >
+                            {{ item }}
+                          </li>
+                        </ol>
+                      </ElAlert>
+
+                      <div class="add-nas-proxy-layout">
+                        <div class="add-nas-proxy-form">
+                          <ElForm
+                            label-position="top"
+                            class="add-nas-form"
+                          >
+                            <ElFormItem class="add-nas-bind-form-item">
+                              <template #label>
+                                <span class="add-nas-field-label-with-action">
+                                  <span>{{ t('addNasRepo.fieldSourceProxyNode') }}</span>
+                                  <ElButton
+                                    text
+                                    circle
+                                    class="hfl-refresh-button add-nas-field-label-with-action__btn"
+                                    :title="t('addNasRepo.proxyRefresh')"
+                                    :aria-label="t('addNasRepo.proxyRefresh')"
+                                    :disabled="proxyNodesRefreshing"
+                                    @click.stop="refreshProxyNodesManually"
+                                  >
+                                    <RefreshCw
+                                      :size="15"
+                                      stroke-width="2"
+                                      :class="{ 'is-spinning': proxyNodesRefreshing }"
+                                    />
+                                  </ElButton>
+                                </span>
+                              </template>
+                              <div class="add-nas-select-row">
+                                <ElButton
+                                  text
+                                  circle
+                                  class="add-nas-select-row__search"
+                                  aria-hidden="true"
+                                  tabindex="-1"
+                                >
+                                  <Search
+                                    :size="15"
+                                    stroke-width="2"
+                                  />
+                                </ElButton>
+                                <ElSelect
+                                  v-model="addTargetNasProxyNodeId"
+                                  class="add-nas-select-row__select"
+                                  :placeholder="t('addNasRepo.phSourceProxyNode')"
+                                  filterable
+                                  clearable
+                                >
+                                  <ElOption
+                                    :value="0"
+                                    :label="t('addNasRepo.optionNoProxy')"
+                                  />
+                                  <ElOption
+                                    v-for="node in addTargetProxyNodeOptions"
+                                    :key="node.id"
+                                    :value="node.id"
+                                    :label="node.name"
+                                  />
+                                </ElSelect>
+                              </div>
+                              <div class="mt-2 text-xs text-[var(--color-text-tertiary)]">
+                                {{ addTargetNasProxyNodeId ? t('addNasRepo.hintProxySelected') : t('addNasRepo.hintProxySkipped') }}
+                              </div>
+                            </ElFormItem>
+                          </ElForm>
+
+                          <div class="add-nas-proxy-benefits">
+                            <div class="add-nas-proxy-benefit">
+                              <span class="add-nas-proxy-benefit__dot" />
+                              {{ t('addNasRepo.proxyBenefitAvoidMountFailure') }}
+                            </div>
+                            <div class="add-nas-proxy-benefit">
+                              <span class="add-nas-proxy-benefit__dot" />
+                              {{ t('addNasRepo.proxyBenefitSharedRepo') }}
+                            </div>
+                          </div>
+                        </div>
+
+                        <div
+                          class="add-nas-path-card"
+                          :class="{ 'add-nas-path-card--direct': isAddTargetNasDirectAccess }"
+                          aria-hidden="true"
+                        >
+                          <template v-if="!isAddTargetNasDirectAccess">
+                            <div class="add-nas-path-card__agents">
+                              <span>{{ t('addNasRepo.demoBackupSourceA') }}</span>
+                              <span>{{ t('addNasRepo.demoBackupSourceB') }}</span>
+                              <span>{{ t('addNasRepo.demoBackupSourceC') }}</span>
+                            </div>
+                            <div class="add-nas-path-card__join" />
+                            <div class="add-nas-path-card__node add-nas-path-card__node--proxy">
+                              Proxy
+                            </div>
+                            <div class="add-nas-path-card__line" />
+                            <div class="add-nas-path-card__node add-nas-path-card__node--nas">
+                              NAS
+                            </div>
+                          </template>
+                          <template v-else>
+                            <div class="add-nas-path-card__direct-rows">
+                              <div class="add-nas-path-card__direct-row">
+                                <span class="add-nas-path-card__source">{{ t('addNasRepo.demoBackupSourceA') }}</span>
+                                <span class="add-nas-path-card__direct-line" />
+                                <span class="add-nas-path-card__node add-nas-path-card__node--nas">NAS</span>
+                              </div>
+                              <div class="add-nas-path-card__direct-row">
+                                <span class="add-nas-path-card__source">{{ t('addNasRepo.demoBackupSourceB') }}</span>
+                                <span class="add-nas-path-card__direct-line" />
+                                <span class="add-nas-path-card__node add-nas-path-card__node--nas">NAS</span>
+                              </div>
+                              <div class="add-nas-path-card__direct-row">
+                                <span class="add-nas-path-card__source">{{ t('addNasRepo.demoBackupSourceC') }}</span>
+                                <span class="add-nas-path-card__direct-line" />
+                                <span class="add-nas-path-card__node add-nas-path-card__node--nas">NAS</span>
+                              </div>
+                            </div>
+                          </template>
+                        </div>
+                      </div>
+
+                      <ElButton
+                        class="add-nas-deploy-btn"
+                        type="primary"
+                        plain
+                        @click="openProxyDeploy"
+                      >
+                        <Plus
+                          :size="14"
+                          class="inline"
+                        />
+                        {{ t('addNasRepo.deployProxy') }}
+                      </ElButton>
+                    </div>
+                  </section>
+
+                  <section
+                    v-show="addTargetNasStep === 2"
+                    class="add-nas-card"
+                  >
+                    <div class="add-nas-section">
+                      <h4 class="add-nas-section__title">
+                        <span class="add-nas-section__indicator" />
+                        {{ t('repositoriesPage.stepRepo') }}
+                      </h4>
+                      <ElForm
+                        label-position="top"
+                        class="add-nas-form"
+                      >
+                        <ElFormItem
+                          :label="t('repositoriesPage.fieldRepoName')"
+                          required
+                        >
+                          <ElInput
+                            v-model="addTargetRepoName"
+                            :placeholder="t('repositoriesPage.phRepoName')"
+                          />
+                        </ElFormItem>
+                      </ElForm>
+                    </div>
+                  </section>
+                </template>
+
+                <template v-else>
+                  <section class="repository-add-card">
+                    <div class="repository-add-section">
+                      <h4 class="repository-add-section__title">
+                        <span class="repository-add-section__indicator" />
+                        {{ t('repositoriesPage.addProxyFsPage') }}
+                      </h4>
+                      <ElForm
+                        label-position="top"
+                        class="repository-add-form"
+                      >
+                        <ElFormItem
+                          :label="t('repositoriesPage.fieldRepoName')"
+                          required
+                        >
+                          <ElInput
+                            v-model="addTargetRepoName"
+                            :placeholder="t('repositoriesPage.phRepoName')"
+                          />
+                          <div class="mt-1 text-xs text-[var(--color-text-tertiary)]">
+                            {{ t('repositoriesPage.hintRepoNameAuto') }}
+                          </div>
+                        </ElFormItem>
+                        <ElFormItem
+                          :label="t('repositoriesPage.fieldProxyNode')"
+                          required
+                        >
+                          <ElSelect
+                            v-model="addTargetProxyNodeId"
+                            class="w-full"
+                            filterable
+                            :placeholder="t('repositoriesPage.phProxyNode')"
+                          >
+                            <ElOption
+                              v-for="node in addTargetProxyNodeOptions"
+                              :key="node.id"
+                              :label="node.name"
+                              :value="node.id"
+                            />
+                          </ElSelect>
+                        </ElFormItem>
+                        <ElFormItem
+                          :label="t('repositoriesPage.fieldProxyNodeDir')"
+                          required
+                        >
+                          <div class="repository-dir-selector">
+                            <div class="repository-segmented">
+                              <button
+                                type="button"
+                                class="repository-segmented__btn"
+                                :class="{ 'is-active': addTargetProxyUseTree }"
+                                @click="addTargetProxyUseTree = true"
+                              >
+                                <FolderTree :size="14" />
+                                {{ t('repositoriesPage.dirSelectTree') }}
+                              </button>
+                              <button
+                                type="button"
+                                class="repository-segmented__btn"
+                                :class="{ 'is-active': !addTargetProxyUseTree }"
+                                @click="addTargetProxyUseTree = false"
+                              >
+                                <HardDrive :size="14" />
+                                {{ t('repositoriesPage.dirSelectInput') }}
+                              </button>
+                            </div>
+                            <div
+                              v-if="addTargetProxyUseTree"
+                              class="repository-dir-tree-shell hfl-dir-tree-shell"
+                            >
+                              <div
+                                v-if="!addTargetProxyNodeId"
+                                class="repository-dir-tree-shell__empty hfl-dir-tree-empty"
+                              >
+                                {{ t('repositoriesPage.errProxyNode') }}
+                              </div>
+                              <ElTree
+                                v-else
+                                ref="addTargetProxyDirTreeRef"
+                                class="repository-dir-tree hfl-dir-tree"
+                                :data="addTargetProxyTreeData"
+                                :props="{ children: 'children', label: 'label' }"
+                                node-key="id"
+                                show-checkbox
+                                check-strictly
+                                default-expand-all
+                                :check-on-click-node="true"
+                                :expand-on-click-node="false"
+                                :highlight-current="true"
+                                :current-node-key="addTargetProxyCurrentTreeNodeKey"
+                                :default-checked-keys="addTargetProxyCheckedTreeKeys"
+                                @current-change="onAddTargetProxyTreeSelect"
+                                @check-change="onAddTargetProxyTreeCheck"
+                              >
+                                <template #default="{ data }">
+                                  <div class="repository-tree-node hfl-dir-tree-node">
+                                    <FolderOpen
+                                      :size="15"
+                                      class="repository-tree-node__icon hfl-dir-tree-node__icon"
+                                    />
+                                    <div class="repository-tree-node__text hfl-dir-tree-node__text">
+                                      <span class="repository-tree-node__label hfl-dir-tree-node__label">{{ data.label }}</span>
+                                      <span class="repository-tree-node__path hfl-dir-tree-node__path">{{ data.pathLabel }}</span>
+                                    </div>
+                                  </div>
+                                </template>
+                              </ElTree>
+                              <div class="mt-2 text-xs text-[var(--color-text-tertiary)]">
+                                {{ t('repositoriesPage.hintTreeSelect') }}
+                              </div>
+                            </div>
+                            <ElInput
+                              v-else
+                              v-model="addTargetProxyDir"
+                              :placeholder="t('repositoriesPage.phProxyNodeDir')"
+                            />
+                          </div>
+                        </ElFormItem>
+                      </ElForm>
+                    </div>
+                  </section>
+                </template>
+
+                <section
+                  v-if="
+                    addTargetKind === 'proxy_fs' ||
+                      (addTargetKind === 's3' && addTargetS3Step === 1) ||
+                      (addTargetKind === 'nas' && addTargetNasStep === 2)
+                  "
+                  class="repository-add-card repository-add-card--quota"
+                >
+                  <div class="repository-add-section">
+                    <h4 class="repository-add-section__title">
+                      <span class="repository-add-section__indicator" />
+                      {{ t('repositoriesPage.fieldQuota') }}
+                    </h4>
+                    <ElForm
+                      label-position="top"
+                      class="repository-add-form repository-add-form--quota"
+                    >
+                      <ElFormItem
+                        :label="t('repositoriesPage.fieldQuota')"
+                        class="repository-add-form__grow"
+                      >
+                        <ElInput
+                          v-model.number="addTargetQuota"
+                          type="number"
+                          min="0"
+                          :placeholder="t('repositoriesPage.phQuota')"
+                        />
+                        <div class="mt-1 text-xs text-[var(--color-text-tertiary)]">
+                          {{ t('repositoriesPage.hintQuota') }}
                         </div>
                       </ElFormItem>
+                      <div class="repository-quota-panel">
+                        <ElCheckbox v-model="addTargetEnableQuotaAlert">
+                          {{ t('repositoriesPage.fieldQuotaAlert') }}
+                        </ElCheckbox>
+                        <div class="repository-quota-panel__threshold">
+                          <span>{{ t('repositoriesPage.fieldQuotaAlertThreshold') }}</span>
+                          <ElInput
+                            v-model.number="addTargetQuotaAlertThreshold"
+                            type="number"
+                            min="1"
+                            max="100"
+                            class="repository-quota-panel__input"
+                          />
+                          <span>%</span>
+                        </div>
+                      </div>
                     </ElForm>
                   </div>
                 </section>
-              </template>
-
-              <section
-                v-if="
-                  addTargetKind === 'proxy_fs' ||
-                  (addTargetKind === 's3' && addTargetS3Step === 1) ||
-                  (addTargetKind === 'nas' && addTargetNasStep === 2)
-                "
-                class="repository-add-card repository-add-card--quota"
-              >
-                <div class="repository-add-section">
-                  <h4 class="repository-add-section__title">
-                    <span class="repository-add-section__indicator" />
-                    {{ t('repositoriesPage.fieldQuota') }}
-                  </h4>
-                  <ElForm label-position="top" class="repository-add-form repository-add-form--quota">
-                    <ElFormItem :label="t('repositoriesPage.fieldQuota')" class="repository-add-form__grow">
-                      <ElInput v-model.number="addTargetQuota" type="number" min="0" :placeholder="t('repositoriesPage.phQuota')" />
-                      <div class="mt-1 text-xs text-[var(--color-text-tertiary)]">{{ t('repositoriesPage.hintQuota') }}</div>
-                    </ElFormItem>
-                    <div class="repository-quota-panel">
-                      <ElCheckbox v-model="addTargetEnableQuotaAlert">{{ t('repositoriesPage.fieldQuotaAlert') }}</ElCheckbox>
-                      <div class="repository-quota-panel__threshold">
-                        <span>{{ t('repositoriesPage.fieldQuotaAlertThreshold') }}</span>
-                        <ElInput
-                          v-model.number="addTargetQuotaAlertThreshold"
-                          type="number"
-                          min="1"
-                          max="100"
-                          class="repository-quota-panel__input"
-                        />
-                        <span>%</span>
-                      </div>
-                    </div>
-                  </ElForm>
-                </div>
-              </section>
               </div>
             </div>
 
-            <aside v-show="false" class="repository-add-preview">
+            <aside
+              v-show="false"
+              class="repository-add-preview"
+            >
               <div class="repository-add-preview__head">
                 <div class="repository-add-preview__icon">
-                  <Cloud v-if="addTargetKind === 's3'" :size="26" />
-                  <component :is="targetNasSidebarIcon" v-else-if="addTargetKind === 'nas'" :size="26" />
-                  <FolderTree v-else :size="26" />
+                  <Cloud
+                    v-if="addTargetKind === 's3'"
+                    :size="26"
+                  />
+                  <component
+                    :is="targetNasSidebarIcon"
+                    v-else-if="addTargetKind === 'nas'"
+                    :size="26"
+                  />
+                  <FolderTree
+                    v-else
+                    :size="26"
+                  />
                 </div>
                 <div class="repository-add-preview__title-wrap">
-                  <h4 class="repository-add-preview__title">{{ addTargetRepoName || t('addS3Repo.previewUnnamed') }}</h4>
+                  <h4 class="repository-add-preview__title">
+                    {{ addTargetRepoName || t('addS3Repo.previewUnnamed') }}
+                  </h4>
                   <p class="repository-add-preview__type">
-                    <template v-if="addTargetKind === 's3'">{{ addTargetS3PlatformLabel || t('addS3Repo.previewSelectPlatform') }}</template>
-                    <template v-else-if="addTargetKind === 'nas'">{{ addTargetNasProtocolLabel }}</template>
-                    <template v-else>{{ t('repositoriesPage.kindProxyFs') }}</template>
+                    <template v-if="addTargetKind === 's3'">
+                      {{ addTargetS3PlatformLabel || t('addS3Repo.previewSelectPlatform') }}
+                    </template>
+                    <template v-else-if="addTargetKind === 'nas'">
+                      {{ addTargetNasProtocolLabel }}
+                    </template>
+                    <template v-else>
+                      {{ t('repositoriesPage.kindProxyFs') }}
+                    </template>
                   </p>
                 </div>
               </div>
 
               <div class="repository-add-preview__body">
                 <section class="repository-add-preview__section">
-                  <h5 class="repository-add-preview__section-title">{{ t('addS3Repo.previewBasicInfo') }}</h5>
+                  <h5 class="repository-add-preview__section-title">
+                    {{ t('addS3Repo.previewBasicInfo') }}
+                  </h5>
                   <div class="repository-add-preview__row">
                     <span>{{ addTargetKind === 's3' ? t('repositoriesPage.fieldBucket') : t('repositoriesPage.fieldRepoName') }}</span>
                     <strong>{{ addTargetKind === 's3' ? (addTargetS3Bucket || '—') : (addTargetRepoName || '—') }}</strong>
@@ -9208,14 +10123,19 @@ function preserveShallowestPathOrder(paths: string[]) {
                   </div>
                   <div class="repository-add-preview__row">
                     <span>{{ t('repositoriesPage.fieldQuotaAlert') }}</span>
-                    <strong class="repository-add-preview__badge" :class="{ 'is-on': addTargetEnableQuotaAlert }">
+                    <strong
+                      class="repository-add-preview__badge"
+                      :class="{ 'is-on': addTargetEnableQuotaAlert }"
+                    >
                       {{ addTargetEnableQuotaAlert ? `${t('repositoriesPage.enabled')} (${addTargetQuotaAlertThreshold}%)` : t('repositoriesPage.disabled') }}
                     </strong>
                   </div>
                 </section>
 
                 <section class="repository-add-preview__section">
-                  <h5 class="repository-add-preview__section-title">{{ t('addS3Repo.previewConnection') }}</h5>
+                  <h5 class="repository-add-preview__section-title">
+                    {{ t('addS3Repo.previewConnection') }}
+                  </h5>
                   <template v-if="addTargetKind === 's3'">
                     <div class="repository-add-preview__row">
                       <span>{{ t('addS3Repo.fieldEndpoint') }}</span>
@@ -9235,8 +10155,14 @@ function preserveShallowestPathOrder(paths: string[]) {
                     </div>
                     <div class="repository-add-preview__row">
                       <span>{{ t('repositoriesPage.fieldUseTls') }}</span>
-                      <strong class="repository-add-preview__badge" :class="{ 'is-on': addTargetS3UseTls }">
-                        <ShieldCheck v-if="addTargetS3UseTls" :size="14" />
+                      <strong
+                        class="repository-add-preview__badge"
+                        :class="{ 'is-on': addTargetS3UseTls }"
+                      >
+                        <ShieldCheck
+                          v-if="addTargetS3UseTls"
+                          :size="14"
+                        />
                         {{ addTargetS3UseTls ? 'HTTPS' : 'HTTP' }}
                       </strong>
                     </div>
@@ -9277,18 +10203,35 @@ function preserveShallowestPathOrder(paths: string[]) {
       </div>
 
       <template #footer>
-        <div v-show="false" class="repository-add-footer">
-          <ElButton v-if="!addTargetIsFirstStep" @click="prevAddTargetStep">
+        <div
+          v-show="false"
+          class="repository-add-footer"
+        >
+          <ElButton
+            v-if="!addTargetIsFirstStep"
+            @click="prevAddTargetStep"
+          >
             {{ t('repositoriesPage.btnPrev') }}
           </ElButton>
           <span v-else />
           <div class="repository-add-footer__actions">
-            <ElButton @click="closeAddTargetDialog">{{ t('protection.backupsPage.btnCancel') }}</ElButton>
-            <ElButton v-if="!addTargetIsFinalStep" type="primary" @click="nextAddTargetStep">
+            <ElButton @click="closeAddTargetDialog">
+              {{ t('protection.backupsPage.btnCancel') }}
+            </ElButton>
+            <ElButton
+              v-if="!addTargetIsFinalStep"
+              type="primary"
+              @click="nextAddTargetStep"
+            >
               {{ addTargetNextButtonLabel }}
             </ElButton>
-            <ElButton v-else type="primary" :loading="addTargetSaving" @click="submitAddTargetDialog">
-            {{ t('protection.backupsPage.btnAddTargetConfirm') }}
+            <ElButton
+              v-else
+              type="primary"
+              :loading="addTargetSaving"
+              @click="submitAddTargetDialog"
+            >
+              {{ t('protection.backupsPage.btnAddTargetConfirm') }}
             </ElButton>
           </div>
         </div>
@@ -9308,12 +10251,23 @@ function preserveShallowestPathOrder(paths: string[]) {
       >
         <div class="fullscreen-form-page source-deploy-page">
           <header class="fullscreen-form-header">
-            <button type="button" class="fullscreen-form-header__back" @click="closeAddSource">
-              <ArrowLeft class="fullscreen-form-header__back-icon" :size="18" />
+            <button
+              type="button"
+              class="fullscreen-form-header__back"
+              @click="closeAddSource"
+            >
+              <ArrowLeft
+                class="fullscreen-form-header__back-icon"
+                :size="18"
+              />
             </button>
             <div class="fullscreen-form-header__content">
-              <h1 class="fullscreen-form-header__title">{{ t('protection.sourceResources.addSourcePageTitle') }}</h1>
-              <p class="fullscreen-form-header__desc">{{ t('protection.sourceResources.addSourcePageDesc') }}</p>
+              <h1 class="fullscreen-form-header__title">
+                {{ t('protection.sourceResources.addSourcePageTitle') }}
+              </h1>
+              <p class="fullscreen-form-header__desc">
+                {{ t('protection.sourceResources.addSourcePageDesc') }}
+              </p>
             </div>
           </header>
 
@@ -9329,10 +10283,17 @@ function preserveShallowestPathOrder(paths: string[]) {
                       :aria-pressed="addSourceType === 'hostFileSystem'"
                       @click="addSourceType = 'hostFileSystem'"
                     >
-                      <span class="add-source-type-card__indicator" aria-hidden="true" />
+                      <span
+                        class="add-source-type-card__indicator"
+                        aria-hidden="true"
+                      />
                       <span class="add-source-type-card__inner">
                         <span class="add-source-type-card__icon">
-                          <component :is="backupSourceTypeIcon('host')" :size="20" stroke-width="2" />
+                          <component
+                            :is="backupSourceTypeIcon('host')"
+                            :size="20"
+                            stroke-width="2"
+                          />
                         </span>
                         <span class="add-source-type-card__text">
                           <span class="add-source-type-card__name">{{ t('protection.sourceResources.addSourceTypeHostFile') }}</span>
@@ -9347,10 +10308,17 @@ function preserveShallowestPathOrder(paths: string[]) {
                       :aria-pressed="addSourceType === 'nas'"
                       @click="addSourceType = 'nas'"
                     >
-                      <span class="add-source-type-card__indicator" aria-hidden="true" />
+                      <span
+                        class="add-source-type-card__indicator"
+                        aria-hidden="true"
+                      />
                       <span class="add-source-type-card__inner">
                         <span class="add-source-type-card__icon">
-                          <component :is="backupSourceTypeIcon('nas')" :size="20" stroke-width="2" />
+                          <component
+                            :is="backupSourceTypeIcon('nas')"
+                            :size="20"
+                            stroke-width="2"
+                          />
                         </span>
                         <span class="add-source-type-card__text">
                           <span class="add-source-type-card__name">{{ t('protection.sourceResources.addSourceTypeNas') }}</span>

--- a/src/frontend/src/pages/protection/BackupCreateWizardRestorePlanLayout.test.ts
+++ b/src/frontend/src/pages/protection/BackupCreateWizardRestorePlanLayout.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest'
 import { readFileSync } from 'node:fs'
+import { compactSourceText } from '../../test/sourceText'
 
 const wizardSource = readFileSync(new URL('./BackupCreateWizard.vue', import.meta.url), 'utf8')
+const compactWizardSource = compactSourceText(wizardSource)
 const shellSource = readFileSync(new URL('./BackupConfigCreateWizard.vue', import.meta.url), 'utf8')
 
 describe('BackupCreateWizard restore plan layout', () => {
@@ -49,16 +51,16 @@ describe('BackupCreateWizard restore plan layout', () => {
   it('keeps long restore picker values available instead of silently clipping them', () => {
     const treeLabelRule = wizardSource.match(/\.create-tree-node-content__label \{([\s\S]*?)\n\}/)?.[1] || ''
 
-    expect(wizardSource).toContain(':title="recoverySourcePathInputValue(dirPlan.sourcePath) || undefined"')
-    expect(wizardSource).toContain('<template #label="{ label }">')
-    expect(wizardSource).toContain('class="create-recovery-target-selected-label" :title="label"')
-    expect(wizardSource).toContain(':title="dirPlan.restoreDir || undefined"')
+    expect(compactWizardSource).toContain(':title="recoverySourcePathInputValue(dirPlan.sourcePath) || undefined"')
+    expect(compactWizardSource).toContain('<template #label="{ label }">')
+    expect(compactWizardSource).toContain('class="create-recovery-target-selected-label" :title="label"')
+    expect(compactWizardSource).toContain(':title="dirPlan.restoreDir || undefined"')
     expect(treeLabelRule).toContain('overflow-wrap: anywhere;')
     expect(treeLabelRule).toContain('white-space: normal;')
     expect(treeLabelRule).not.toContain('text-overflow: ellipsis;')
     expect(wizardSource).toContain('.el-tree-node__expand-icon.is-leaf) {\n  width: 8px;')
     expect(wizardSource).toMatch(/\.source-dir-tree :deep\(\.el-tree-node\.is-current > \.el-tree-node__content\) \{[\s\S]*?var\(--el-bg-color-overlay\)/)
     expect(wizardSource).not.toContain('width: min(360px, calc(100vw - 48px)) !important;')
-    expect(wizardSource).toContain('class="create-recovery-plan-action hfl-table-no-tooltip"')
+    expect(compactWizardSource).toContain('class="create-recovery-plan-action hfl-table-no-tooltip"')
   })
 })

--- a/src/frontend/src/pages/protection/BackupDetail.vue
+++ b/src/frontend/src/pages/protection/BackupDetail.vue
@@ -1013,27 +1013,59 @@ function closeDeleteSnapshotDialog() {
 </script>
 
 <template>
-  <ModulePage :title="t('protection.moduleTitle')" :menus="protectionMenus">
-    <div v-if="detailLoading" class="py-16 text-center">
-      <el-empty :description="t('common.loading')" :image-size="64" />
+  <ModulePage
+    :title="t('protection.moduleTitle')"
+    :menus="protectionMenus"
+  >
+    <div
+      v-if="detailLoading"
+      class="py-16 text-center"
+    >
+      <el-empty
+        :description="t('common.loading')"
+        :image-size="64"
+      />
     </div>
 
-    <div v-else-if="backup" class="space-y-[var(--card-gap)]">
+    <div
+      v-else-if="backup"
+      class="space-y-[var(--card-gap)]"
+    >
       <div class="flex flex-wrap items-center gap-3">
         <RouterLink to="/protection/backups">
           <ElButton text>
-            <ArrowLeft :size="16" class="inline mr-1 align-text-bottom" />
+            <ArrowLeft
+              :size="16"
+              class="inline mr-1 align-text-bottom"
+            />
             {{ t('protection.backupDetail.backToList') }}
           </ElButton>
         </RouterLink>
       </div>
 
-      <el-tabs v-model="activeTab" class="detail-tabs repo-underline-tabs">
-        <el-tab-pane :label="t('protection.backupDetail.tabDetail')" name="detail">
-          <el-descriptions :column="1" border size="default" class="max-w-3xl">
-            <el-descriptions-item :label="t('protection.backupDetail.labelName')">{{ backup.name }}</el-descriptions-item>
-            <el-descriptions-item :label="t('protection.backupDetail.labelRemark')"><span :class="{ 'hfl-empty-mark': !backup.remark }">{{ backup.remark || t('protection.backupDetail.durationDash') }}</span></el-descriptions-item>
-            <el-descriptions-item :label="t('protection.backupDetail.labelSnapshotCount')">{{ backup.snapshots.length }}</el-descriptions-item>
+      <el-tabs
+        v-model="activeTab"
+        class="detail-tabs repo-underline-tabs"
+      >
+        <el-tab-pane
+          :label="t('protection.backupDetail.tabDetail')"
+          name="detail"
+        >
+          <el-descriptions
+            :column="1"
+            border
+            size="default"
+            class="max-w-3xl"
+          >
+            <el-descriptions-item :label="t('protection.backupDetail.labelName')">
+              {{ backup.name }}
+            </el-descriptions-item>
+            <el-descriptions-item :label="t('protection.backupDetail.labelRemark')">
+              <span :class="{ 'hfl-empty-mark': !backup.remark }">{{ backup.remark || t('protection.backupDetail.durationDash') }}</span>
+            </el-descriptions-item>
+            <el-descriptions-item :label="t('protection.backupDetail.labelSnapshotCount')">
+              {{ backup.snapshots.length }}
+            </el-descriptions-item>
             <el-descriptions-item :label="t('protection.backupDetail.labelLatestEnd')">
               <span :class="{ 'hfl-empty-mark': !backup.latestSnapshotAt }">{{ backup.latestSnapshotAt ?? t('protection.backupDetail.durationDash') }}</span>
             </el-descriptions-item>
@@ -1044,7 +1076,9 @@ function closeDeleteSnapshotDialog() {
                   :key="i"
                   class="border border-slate-100 rounded-md px-3 py-2 bg-[var(--color-grey-1,#f8fafc)]"
                 >
-                  <div class="text-sm font-medium text-slate-800">{{ s.path }}</div>
+                  <div class="text-sm font-medium text-slate-800">
+                    {{ s.path }}
+                  </div>
                   <div class="text-xs text-slate-500 mt-1">
                     {{
                       t('protection.backupDetail.hostLine', {
@@ -1061,39 +1095,62 @@ function closeDeleteSnapshotDialog() {
               <span class="text-slate-400 text-sm ml-2">{{ backup.targetLocation }}</span>
             </el-descriptions-item>
             <el-descriptions-item :label="t('protection.backupDetail.labelPolicyName')">
-              <template v-if="policy">{{ policy.name }}</template>
-              <span v-else class="text-slate-400">{{ t('protection.backupDetail.noPolicy') }}</span>
+              <template v-if="policy">
+                {{ policy.name }}
+              </template>
+              <span
+                v-else
+                class="text-slate-400"
+              >{{ t('protection.backupDetail.noPolicy') }}</span>
             </el-descriptions-item>
             <template v-if="policy">
-              <el-descriptions-item :label="t('protection.backupDetail.labelFreq')">{{ policy.backupFrequencyDesc }}</el-descriptions-item>
+              <el-descriptions-item :label="t('protection.backupDetail.labelFreq')">
+                {{ policy.backupFrequencyDesc }}
+              </el-descriptions-item>
               <el-descriptions-item :label="t('protection.backupDetail.labelCron')">
                 <code class="rounded bg-slate-100 px-2 py-0.5 text-sm text-slate-800">{{ policy.schedule }}</code>
               </el-descriptions-item>
-              <el-descriptions-item :label="t('protection.backupDetail.labelRetention')">{{ policy.retentionDesc }}</el-descriptions-item>
+              <el-descriptions-item :label="t('protection.backupDetail.labelRetention')">
+                {{ policy.retentionDesc }}
+              </el-descriptions-item>
             </template>
             <el-descriptions-item :label="t('protection.backupDetail.labelCompression')">
               {{ compressionLevelLabel(backup.compression) }}
             </el-descriptions-item>
             <el-descriptions-item :label="t('protection.backupDetail.labelGlobalFilterName')">
-              <template v-if="globalFilter">{{ globalFilter.name }}</template>
-              <span v-else class="text-slate-400">{{ t('protection.backupDetail.noGlobalFilter') }}</span>
+              <template v-if="globalFilter">
+                {{ globalFilter.name }}
+              </template>
+              <span
+                v-else
+                class="text-slate-400"
+              >{{ t('protection.backupDetail.noGlobalFilter') }}</span>
             </el-descriptions-item>
-            <el-descriptions-item v-if="globalFilter" :label="t('protection.backupDetail.labelGlobalFilterSummary')">
+            <el-descriptions-item
+              v-if="globalFilter"
+              :label="t('protection.backupDetail.labelGlobalFilterSummary')"
+            >
               {{ globalFilter.summary }}
             </el-descriptions-item>
           </el-descriptions>
         </el-tab-pane>
 
-        <el-tab-pane :label="t('protection.backupDetail.tabSnapshots')" name="snapshots">
+        <el-tab-pane
+          :label="t('protection.backupDetail.tabSnapshots')"
+          name="snapshots"
+        >
           <div class="hfl-list-panel">
             <el-table
-              v-table-overflow-title
               ref="snapshotTableRef"
+              v-table-overflow-title
               :data="backup.snapshots"
               stripe
               :row-class-name="snapshotRowClassName"
             >
-              <el-table-column :label="t('protection.backupDetail.colSnapStart')" width="260">
+              <el-table-column
+                :label="t('protection.backupDetail.colSnapStart')"
+                width="260"
+              >
                 <template #default="{ row }">
                   <button
                     type="button"
@@ -1104,50 +1161,114 @@ function closeDeleteSnapshotDialog() {
                   </button>
                 </template>
               </el-table-column>
-              <el-table-column :label="t('protection.backupDetail.colSnapEnd')" width="260" prop="endTime">
+              <el-table-column
+                :label="t('protection.backupDetail.colSnapEnd')"
+                width="260"
+                prop="endTime"
+              >
                 <template #default="{ row }">
-                  <span class="hfl-table-cell-time" :class="{ 'hfl-empty-mark': !row.endTime }">{{ row.endTime || '—' }}</span>
+                  <span
+                    class="hfl-table-cell-time"
+                    :class="{ 'hfl-empty-mark': !row.endTime }"
+                  >{{ row.endTime || '—' }}</span>
                 </template>
               </el-table-column>
-              <el-table-column :label="t('protection.backupDetail.colSnapSize')" width="120" header-cell-class-name="snapshot-th-split-start">
-                <template #default="{ row }">{{ fmtBytes(row.sizeBytes) }}</template>
+              <el-table-column
+                :label="t('protection.backupDetail.colSnapSize')"
+                width="120"
+                header-cell-class-name="snapshot-th-split-start"
+              >
+                <template #default="{ row }">
+                  {{ fmtBytes(row.sizeBytes) }}
+                </template>
               </el-table-column>
-              <el-table-column :label="t('protection.backupDetail.colSnapId')" width="300" prop="id">
+              <el-table-column
+                :label="t('protection.backupDetail.colSnapId')"
+                width="300"
+                prop="id"
+              >
                 <template #default="{ row }">
                   <span class="hfl-table-cell-mono">{{ row.id }}</span>
                 </template>
               </el-table-column>
-              <el-table-column :label="t('protection.backupDetail.colFileCount')" width="100" prop="fileCount" />
-              <el-table-column :label="t('protection.backupDetail.colDirCount')" width="100" prop="dirCount" />
-              <el-table-column :label="t('protection.backupDetail.labelStatus')" width="120">
+              <el-table-column
+                :label="t('protection.backupDetail.colFileCount')"
+                width="100"
+                prop="fileCount"
+              />
+              <el-table-column
+                :label="t('protection.backupDetail.colDirCount')"
+                width="100"
+                prop="dirCount"
+              />
+              <el-table-column
+                :label="t('protection.backupDetail.labelStatus')"
+                width="120"
+              >
                 <template #default="{ row }">
                   <SnapshotStatusTag :status="row.status" />
                 </template>
               </el-table-column>
-              <el-table-column :label="t('protection.backupDetail.colActions')" min-width="220" fixed="right" align="right">
+              <el-table-column
+                :label="t('protection.backupDetail.colActions')"
+                min-width="220"
+                fixed="right"
+                align="right"
+              >
                 <template #default="{ row }">
-                  <ElButton type="primary" link class="snapshot-action-btn" :disabled="!canRestoreSnapshot(row)" @click.stop="openRecoveryWizard(row)">
-                    <Undo2 :size="16" class="inline mr-1 align-text-bottom" />
+                  <ElButton
+                    type="primary"
+                    link
+                    class="snapshot-action-btn"
+                    :disabled="!canRestoreSnapshot(row)"
+                    @click.stop="openRecoveryWizard(row)"
+                  >
+                    <Undo2
+                      :size="16"
+                      class="inline mr-1 align-text-bottom"
+                    />
                     {{ t('protection.backupDetail.btnRecoverSnapshot') }}
                   </ElButton>
-                  <ElButton type="danger" link class="snapshot-action-btn" :disabled="!canDeleteSnapshot(row)" @click.stop="onDeleteSnapshot(row)">
-                    <Trash2 :size="16" class="inline mr-1 align-text-bottom" />
+                  <ElButton
+                    type="danger"
+                    link
+                    class="snapshot-action-btn"
+                    :disabled="!canDeleteSnapshot(row)"
+                    @click.stop="onDeleteSnapshot(row)"
+                  >
+                    <Trash2
+                      :size="16"
+                      class="inline mr-1 align-text-bottom"
+                    />
                     {{ t('protection.backupDetail.btnDeleteSnapshot') }}
                   </ElButton>
                 </template>
               </el-table-column>
               <template #empty>
-                <el-empty :description="t('protection.backupDetail.emptySnapshots')" :image-size="64" />
+                <el-empty
+                  :description="t('protection.backupDetail.emptySnapshots')"
+                  :image-size="64"
+                />
               </template>
             </el-table>
           </div>
         </el-tab-pane>
 
-        <el-tab-pane :label="t('protection.backupDetail.tabTasks')" name="tasks">
+        <el-tab-pane
+          :label="t('protection.backupDetail.tabTasks')"
+          name="tasks"
+        >
           <div class="hfl-list-panel">
             <el-table
-              v-table-overflow-title ref="taskTableRef" :data="taskList" stripe>
-              <el-table-column :label="t('protection.backupDetail.colTaskId')" min-width="260">
+              ref="taskTableRef"
+              v-table-overflow-title
+              :data="taskList"
+              stripe
+            >
+              <el-table-column
+                :label="t('protection.backupDetail.colTaskId')"
+                min-width="260"
+              >
                 <template #default="{ row }">
                   <button
                     type="button"
@@ -1158,18 +1279,32 @@ function closeDeleteSnapshotDialog() {
                   </button>
                 </template>
               </el-table-column>
-              <el-table-column :label="t('protection.backupDetail.colTaskType')" width="150">
+              <el-table-column
+                :label="t('protection.backupDetail.colTaskType')"
+                width="150"
+              >
                 <template #default="{ row }">
                   <TaskTypeLabel :type="row.type" />
                 </template>
               </el-table-column>
-              <el-table-column :label="t('protection.backupDetail.colTaskStatus')" width="100">
+              <el-table-column
+                :label="t('protection.backupDetail.colTaskStatus')"
+                width="100"
+              >
                 <template #default="{ row }">
                   <TaskStatusTag :status="row.status" />
                 </template>
               </el-table-column>
-              <el-table-column :label="t('protection.backupDetail.colDuration')" width="110" prop="duration" />
-              <el-table-column :label="t('protection.backupDetail.colTrigger')" width="110" prop="trigger" />
+              <el-table-column
+                :label="t('protection.backupDetail.colDuration')"
+                width="110"
+                prop="duration"
+              />
+              <el-table-column
+                :label="t('protection.backupDetail.colTrigger')"
+                width="110"
+                prop="trigger"
+              />
               <el-table-column
                 :label="t('protection.backupDetail.colLinkedSnap')"
                 min-width="140"
@@ -1180,13 +1315,23 @@ function closeDeleteSnapshotDialog() {
                   <span class="hfl-table-cell-mono">{{ row.snapshotId }}</span>
                 </template>
               </el-table-column>
-              <el-table-column :label="t('protection.backupDetail.colCreated')" min-width="180" prop="createdAt">
+              <el-table-column
+                :label="t('protection.backupDetail.colCreated')"
+                min-width="180"
+                prop="createdAt"
+              >
                 <template #default="{ row }">
-                  <span class="hfl-table-cell-time" :class="{ 'hfl-empty-mark': !row.createdAt }">{{ row.createdAt || '—' }}</span>
+                  <span
+                    class="hfl-table-cell-time"
+                    :class="{ 'hfl-empty-mark': !row.createdAt }"
+                  >{{ row.createdAt || '—' }}</span>
                 </template>
               </el-table-column>
               <template #empty>
-                <el-empty :description="t('protection.backupDetail.emptyTasks')" :image-size="64" />
+                <el-empty
+                  :description="t('protection.backupDetail.emptyTasks')"
+                  :image-size="64"
+                />
               </template>
             </el-table>
           </div>
@@ -1194,10 +1339,15 @@ function closeDeleteSnapshotDialog() {
       </el-tabs>
     </div>
 
-    <div v-else class="py-16 text-center">
+    <div
+      v-else
+      class="py-16 text-center"
+    >
       <el-empty :description="detailLoadError || t('protection.backupDetail.notFound')">
         <RouterLink to="/protection/backups">
-          <ElButton type="primary">{{ t('protection.backupDetail.backToDataProtection') }}</ElButton>
+          <ElButton type="primary">
+            {{ t('protection.backupDetail.backToDataProtection') }}
+          </ElButton>
         </RouterLink>
       </el-empty>
     </div>
@@ -1216,7 +1366,10 @@ function closeDeleteSnapshotDialog() {
     <template #header>
       <span class="snapshot-drawer-title">{{ t('protection.backupDetail.drawerSnapTitle', { id: activeSnapshot?.id || '' }) }}</span>
     </template>
-    <div v-if="activeSnapshot" class="snapshot-drawer-body">
+    <div
+      v-if="activeSnapshot"
+      class="snapshot-drawer-body"
+    >
       <p class="text-sm text-slate-500 m-0 mb-3">
         {{
           t('protection.backupDetail.snapMetaLine', {
@@ -1227,11 +1380,20 @@ function closeDeleteSnapshotDialog() {
         }}
       </p>
       <div class="hfl-list-panel">
-        <div class="px-4 py-3 border-b border-slate-100 text-sm font-medium text-slate-800">{{ t('protection.backupDetail.panelDirList') }}</div>
+        <div class="px-4 py-3 border-b border-slate-100 text-sm font-medium text-slate-800">
+          {{ t('protection.backupDetail.panelDirList') }}
+        </div>
         <el-table
           v-table-column-resize="'protection.backupDetail.snapshotDrawer.dirs'"
-          v-table-overflow-title :data="activeSnapshot.dirs" stripe class="hfl-list-table">
-          <el-table-column :label="t('protection.backupDetail.colBackupDir')" min-width="300">
+          v-table-overflow-title
+          :data="activeSnapshot.dirs"
+          stripe
+          class="hfl-list-table"
+        >
+          <el-table-column
+            :label="t('protection.backupDetail.colBackupDir')"
+            min-width="300"
+          >
             <template #default="{ row }">
               <button
                 type="button"
@@ -1248,7 +1410,10 @@ function closeDeleteSnapshotDialog() {
                   <span class="snapshot-source-path-cell__path hfl-table-cell-mono">{{ row.path }}</span>
                 </span>
                 <span class="snapshot-source-path-cell__child">
-                  <span class="snapshot-source-path-cell__branch" aria-hidden="true" />
+                  <span
+                    class="snapshot-source-path-cell__branch"
+                    aria-hidden="true"
+                  />
                   <span class="snapshot-source-path-cell__host">
                     {{
                       t('protection.backupDetail.hostSubline', {
@@ -1261,13 +1426,29 @@ function closeDeleteSnapshotDialog() {
               </button>
             </template>
           </el-table-column>
-          <el-table-column :label="t('protection.backupDetail.colDirSize')" width="120">
-            <template #default="{ row }">{{ fmtBytes(row.sizeBytes) }}</template>
+          <el-table-column
+            :label="t('protection.backupDetail.colDirSize')"
+            width="120"
+          >
+            <template #default="{ row }">
+              {{ fmtBytes(row.sizeBytes) }}
+            </template>
           </el-table-column>
-          <el-table-column :label="t('protection.backupDetail.colFileCountDirs')" width="110" prop="fileCount" />
-          <el-table-column :label="t('protection.backupDetail.colInnerDirs')" width="120" prop="innerDirCount" />
+          <el-table-column
+            :label="t('protection.backupDetail.colFileCountDirs')"
+            width="110"
+            prop="fileCount"
+          />
+          <el-table-column
+            :label="t('protection.backupDetail.colInnerDirs')"
+            width="120"
+            prop="innerDirCount"
+          />
           <template #empty>
-            <el-empty :description="t('protection.backupDetail.emptyDirs')" :image-size="64" />
+            <el-empty
+              :description="t('protection.backupDetail.emptyDirs')"
+              :image-size="64"
+            />
           </template>
         </el-table>
       </div>
@@ -1287,22 +1468,47 @@ function closeDeleteSnapshotDialog() {
     <template #header>
       <span class="snapshot-drawer-title">{{ t('protection.backupDetail.drawerTaskTitle', { id: activeTask?.id || '' }) }}</span>
     </template>
-    <div v-if="activeTask" ref="drawerScrollAnchorRef" class="snapshot-drawer-body">
-      <el-descriptions :column="1" border>
-        <el-descriptions-item :label="t('protection.backupDetail.labelTaskId')">{{ activeTask.id }}</el-descriptions-item>
-        <el-descriptions-item :label="t('protection.backupDetail.labelTaskType')">{{ activeTask.type }}</el-descriptions-item>
+    <div
+      v-if="activeTask"
+      ref="drawerScrollAnchorRef"
+      class="snapshot-drawer-body"
+    >
+      <el-descriptions
+        :column="1"
+        border
+      >
+        <el-descriptions-item :label="t('protection.backupDetail.labelTaskId')">
+          {{ activeTask.id }}
+        </el-descriptions-item>
+        <el-descriptions-item :label="t('protection.backupDetail.labelTaskType')">
+          {{ activeTask.type }}
+        </el-descriptions-item>
         <el-descriptions-item :label="t('protection.backupDetail.labelStatus')">
           <TaskStatusTag :status="activeTask.status" />
         </el-descriptions-item>
-        <el-descriptions-item :label="t('protection.backupDetail.labelStart')">{{ activeTask.startTime }}</el-descriptions-item>
-        <el-descriptions-item :label="t('protection.backupDetail.labelEnd')">{{ activeTask.endTime }}</el-descriptions-item>
-        <el-descriptions-item :label="t('protection.backupDetail.labelDuration')">{{ activeTask.duration }}</el-descriptions-item>
-        <el-descriptions-item :label="t('protection.backupDetail.labelTrigger')">{{ activeTask.trigger }}</el-descriptions-item>
-        <el-descriptions-item :label="t('protection.backupDetail.labelExecutor')">{{ activeTask.executor }}</el-descriptions-item>
-        <el-descriptions-item :label="t('protection.backupDetail.labelLinkedSnap')">{{
-          activeTask.snapshotId ?? t('protection.backupDetail.noLinkedSnap')
-        }}</el-descriptions-item>
-        <el-descriptions-item :label="t('protection.backupDetail.labelDetail')">{{ activeTask.detail }}</el-descriptions-item>
+        <el-descriptions-item :label="t('protection.backupDetail.labelStart')">
+          {{ activeTask.startTime }}
+        </el-descriptions-item>
+        <el-descriptions-item :label="t('protection.backupDetail.labelEnd')">
+          {{ activeTask.endTime }}
+        </el-descriptions-item>
+        <el-descriptions-item :label="t('protection.backupDetail.labelDuration')">
+          {{ activeTask.duration }}
+        </el-descriptions-item>
+        <el-descriptions-item :label="t('protection.backupDetail.labelTrigger')">
+          {{ activeTask.trigger }}
+        </el-descriptions-item>
+        <el-descriptions-item :label="t('protection.backupDetail.labelExecutor')">
+          {{ activeTask.executor }}
+        </el-descriptions-item>
+        <el-descriptions-item :label="t('protection.backupDetail.labelLinkedSnap')">
+          {{
+            activeTask.snapshotId ?? t('protection.backupDetail.noLinkedSnap')
+          }}
+        </el-descriptions-item>
+        <el-descriptions-item :label="t('protection.backupDetail.labelDetail')">
+          {{ activeTask.detail }}
+        </el-descriptions-item>
       </el-descriptions>
     </div>
   </ElDrawer>
@@ -1331,14 +1537,25 @@ function closeDeleteSnapshotDialog() {
             :class="data.type === 'dir' ? '' : 'text-slate-500'"
           />
           <span class="hfl-dir-tree-node__text">
-            <span class="hfl-dir-tree-node__label" :title="node.label">{{ node.label }}</span>
-            <span v-if="data.type === 'dir'" class="hfl-dir-tree-node__path">{{ t('protection.backupDetail.typeDir') }}</span>
-            <span v-else class="hfl-dir-tree-node__path">{{ t('protection.backupDetail.typeFile') }}</span>
+            <span
+              class="hfl-dir-tree-node__label"
+              :title="node.label"
+            >{{ node.label }}</span>
+            <span
+              v-if="data.type === 'dir'"
+              class="hfl-dir-tree-node__path"
+            >{{ t('protection.backupDetail.typeDir') }}</span>
+            <span
+              v-else
+              class="hfl-dir-tree-node__path"
+            >{{ t('protection.backupDetail.typeFile') }}</span>
           </span>
         </span>
       </template>
     </el-tree>
-    <p class="text-xs text-slate-400 mt-4">{{ t('protection.backupDetail.treeDemoHint') }}</p>
+    <p class="text-xs text-slate-400 mt-4">
+      {{ t('protection.backupDetail.treeDemoHint') }}
+    </p>
   </ElDrawer>
 
   <Modal
@@ -1349,7 +1566,10 @@ function closeDeleteSnapshotDialog() {
     min-height="min(820px, calc(var(--app-viewport-height) - 3rem))"
     @close="closeRecoveryWizard"
   >
-    <div v-if="recSnapshotForRecover && backup" class="dp-restore-wizard-body space-y-4">
+    <div
+      v-if="recSnapshotForRecover && backup"
+      class="dp-restore-wizard-body space-y-4"
+    >
       <p class="text-sm text-slate-500 m-0">
         {{ t('protection.backupDetail.recoverFromSnapshotLead', { backup: backup.name, snapshot: fmtLocalTime(recSnapshotForRecover.endTime) }) }}
       </p>
@@ -1360,7 +1580,10 @@ function closeDeleteSnapshotDialog() {
         :aria-label="t('protection.backupsPage.createRestoreWizardAria')"
       >
         <ol class="dp-create-wizard__list m-0 list-none p-0">
-          <template v-for="(step, idx) in recWizardSteps" :key="`bd-rec-step-${idx}`">
+          <template
+            v-for="(step, idx) in recWizardSteps"
+            :key="`bd-rec-step-${idx}`"
+          >
             <li
               class="dp-create-wizard__step"
               :class="{
@@ -1371,18 +1594,34 @@ function closeDeleteSnapshotDialog() {
               :aria-current="recStep === idx ? 'step' : undefined"
             >
               <div class="dp-create-wizard__card">
-                <div class="dp-create-wizard__icon-wrap" aria-hidden="true">
-                  <component :is="step.icon" :size="22" stroke-width="2" />
+                <div
+                  class="dp-create-wizard__icon-wrap"
+                  aria-hidden="true"
+                >
+                  <component
+                    :is="step.icon"
+                    :size="22"
+                    stroke-width="2"
+                  />
                 </div>
                 <div class="dp-create-wizard__content min-w-0 flex-1">
                   <div class="dp-create-wizard__head">
-                    <span class="dp-create-wizard__badge" aria-hidden="true">
-                      <Check v-if="recStep > idx" :size="13" stroke-width="3" />
+                    <span
+                      class="dp-create-wizard__badge"
+                      aria-hidden="true"
+                    >
+                      <Check
+                        v-if="recStep > idx"
+                        :size="13"
+                        stroke-width="3"
+                      />
                       <span v-else>{{ String(idx + 1).padStart(2, '0') }}</span>
                     </span>
                     <span class="dp-create-wizard__title">{{ step.title }}</span>
                   </div>
-                  <p class="dp-create-wizard__hint">{{ step.hint }}</p>
+                  <p class="dp-create-wizard__hint">
+                    {{ step.hint }}
+                  </p>
                 </div>
               </div>
             </li>
@@ -1395,7 +1634,10 @@ function closeDeleteSnapshotDialog() {
             >
               <span class="dp-create-wizard__rail dp-create-wizard__rail--left" />
               <span class="dp-create-wizard__chev">
-                <ChevronsRight :size="16" stroke-width="2.4" />
+                <ChevronsRight
+                  :size="16"
+                  stroke-width="2.4"
+                />
               </span>
               <span class="dp-create-wizard__rail dp-create-wizard__rail--right" />
             </li>
@@ -1403,8 +1645,13 @@ function closeDeleteSnapshotDialog() {
         </ol>
       </nav>
 
-      <div v-show="recStep === 0" class="dp-wizard-pane">
-        <p class="text-sm text-slate-500 mb-3">{{ t('protection.backupsPage.recStep3Lead') }}</p>
+      <div
+        v-show="recStep === 0"
+        class="dp-wizard-pane"
+      >
+        <p class="text-sm text-slate-500 mb-3">
+          {{ t('protection.backupsPage.recStep3Lead') }}
+        </p>
         <div class="flex flex-col gap-3 lg:flex-row lg:items-stretch min-h-[380px]">
           <div
             class="rounded-[var(--radius-card)] border border-[var(--color-border,#e2e8f0)] bg-[var(--color-grey-1,#f8fafc)]/70 p-3 lg:w-[min(100%,380px)] shrink-0"
@@ -1432,7 +1679,10 @@ function closeDeleteSnapshotDialog() {
             </div>
             <div class="mb-2 flex items-center gap-2">
               <span class="shrink-0 text-sm text-slate-600">{{ t('protection.backupsPage.labelCustomSubdir') }}</span>
-              <ElInput v-model="recCustomDestSubDir" :placeholder="t('protection.backupsPage.phCustomSubdir')" />
+              <ElInput
+                v-model="recCustomDestSubDir"
+                :placeholder="t('protection.backupsPage.phCustomSubdir')"
+              />
             </div>
             <el-tree
               ref="recDestTreeRef"
@@ -1448,8 +1698,14 @@ function closeDeleteSnapshotDialog() {
             >
               <template #default="{ data }">
                 <span class="rec-tree-node-label hfl-dir-tree-node">
-                  <span class="rec-custom-arrow" :class="{ 'rec-custom-arrow--hidden': !data.isCustom }">▸</span>
-                  <Folder :size="15" class="hfl-dir-tree-node__icon" />
+                  <span
+                    class="rec-custom-arrow"
+                    :class="{ 'rec-custom-arrow--hidden': !data.isCustom }"
+                  >▸</span>
+                  <Folder
+                    :size="15"
+                    class="hfl-dir-tree-node__icon"
+                  />
                   <span class="hfl-dir-tree-node__text">
                     <span class="hfl-dir-tree-node__label">{{ data.label }}</span>
                     <span class="hfl-dir-tree-node__path">{{ data.path }}</span>
@@ -1461,11 +1717,20 @@ function closeDeleteSnapshotDialog() {
         </div>
       </div>
 
-      <div v-show="recStep === 1" class="dp-wizard-pane">
-        <p class="text-sm text-slate-500 mb-3">{{ t('protection.backupsPage.recStep2Lead') }}</p>
+      <div
+        v-show="recStep === 1"
+        class="dp-wizard-pane"
+      >
+        <p class="text-sm text-slate-500 mb-3">
+          {{ t('protection.backupsPage.recStep2Lead') }}
+        </p>
         <div class="rounded-[var(--radius-card)] border border-[var(--color-border,#e2e8f0)] bg-[var(--color-card-bg,#fff)] p-3 dp-wizard-scroll-card">
-          <div class="text-sm font-semibold text-slate-800 mb-2">{{ t('protection.backupsPage.recDirsTitle') }}</div>
-          <p class="text-xs text-slate-500 m-0 mb-2">{{ t('protection.backupsPage.recDirsHint') }}</p>
+          <div class="text-sm font-semibold text-slate-800 mb-2">
+            {{ t('protection.backupsPage.recDirsTitle') }}
+          </div>
+          <p class="text-xs text-slate-500 m-0 mb-2">
+            {{ t('protection.backupsPage.recDirsHint') }}
+          </p>
           <el-tree
             ref="recSelectTreeRef"
             class="rec-select-tree hfl-dir-tree hfl-dir-tree--fill"
@@ -1480,7 +1745,10 @@ function closeDeleteSnapshotDialog() {
           >
             <template #default="{ data }">
               <span class="hfl-dir-tree-node">
-                <Folder :size="15" class="hfl-dir-tree-node__icon" />
+                <Folder
+                  :size="15"
+                  class="hfl-dir-tree-node__icon"
+                />
                 <span class="hfl-dir-tree-node__text">
                   <span class="hfl-dir-tree-node__label">{{ data.label }}</span>
                   <span class="hfl-dir-tree-node__path">{{ data.path }}</span>
@@ -1491,9 +1759,19 @@ function closeDeleteSnapshotDialog() {
         </div>
       </div>
 
-      <div v-show="recStep === 2" class="dp-wizard-pane">
-        <p class="text-sm text-slate-600 mb-3">{{ t('protection.backupsPage.recStep4Lead') }}</p>
-        <el-descriptions :column="1" border size="small" class="mt-2">
+      <div
+        v-show="recStep === 2"
+        class="dp-wizard-pane"
+      >
+        <p class="text-sm text-slate-600 mb-3">
+          {{ t('protection.backupsPage.recStep4Lead') }}
+        </p>
+        <el-descriptions
+          :column="1"
+          border
+          size="small"
+          class="mt-2"
+        >
           <el-descriptions-item :label="t('protection.backupsPage.descBackup')">
             {{ backup.name }}
           </el-descriptions-item>
@@ -1502,7 +1780,10 @@ function closeDeleteSnapshotDialog() {
           </el-descriptions-item>
           <el-descriptions-item :label="t('protection.backupsPage.descRecoveryDirs')">
             <ul class="list-disc pl-4 m-0">
-              <li v-for="d in recSelectedDirNodes" :key="d.id">
+              <li
+                v-for="d in recSelectedDirNodes"
+                :key="d.id"
+              >
                 {{ sourceNameByHostId(d.hostId) }} - {{ d.path }}
               </li>
             </ul>
@@ -1523,7 +1804,10 @@ function closeDeleteSnapshotDialog() {
                 class="flex items-center gap-2"
               >
                 <span class="w-32 text-slate-500">{{ sourceNameByHostId(h) }}</span>
-                <ElInput v-model="recHostDirNameMap[h]" :placeholder="t('protection.backupsPage.phHostDirName')" />
+                <ElInput
+                  v-model="recHostDirNameMap[h]"
+                  :placeholder="t('protection.backupsPage.phHostDirName')"
+                />
               </div>
             </div>
           </el-descriptions-item>
@@ -1539,19 +1823,33 @@ function closeDeleteSnapshotDialog() {
           </el-descriptions-item>
         </el-descriptions>
       </div>
-
     </div>
 
     <template #footer>
       <div class="flex items-center justify-between">
-        <ElButton v-if="recStep > 0" @click="prevRec">{{ t('protection.backupsPage.btnPrev') }}</ElButton>
+        <ElButton
+          v-if="recStep > 0"
+          @click="prevRec"
+        >
+          {{ t('protection.backupsPage.btnPrev') }}
+        </ElButton>
         <span v-else />
         <div class="flex gap-2">
-          <ElButton @click="closeRecoveryWizard">{{ t('protection.backupsPage.btnCancel') }}</ElButton>
-          <ElButton v-if="recStep < 2" type="primary" @click="nextRec">
+          <ElButton @click="closeRecoveryWizard">
+            {{ t('protection.backupsPage.btnCancel') }}
+          </ElButton>
+          <ElButton
+            v-if="recStep < 2"
+            type="primary"
+            @click="nextRec"
+          >
             {{ t('protection.backupsPage.btnNext') }}
           </ElButton>
-          <ElButton v-else type="primary" @click="runRecovery">
+          <ElButton
+            v-else
+            type="primary"
+            @click="runRecovery"
+          >
             {{ t('protection.backupsPage.btnConfirmRecovery') }}
           </ElButton>
         </div>

--- a/src/frontend/src/pages/protection/BackupSources.vue
+++ b/src/frontend/src/pages/protection/BackupSources.vue
@@ -2015,7 +2015,11 @@ onUnmounted(() => {
 </script>
 
 <template>
-  <ModulePage :menus="sideNav" :page-title-override="pageTitle" body-fill>
+  <ModulePage
+    :menus="sideNav"
+    :page-title-override="pageTitle"
+    body-fill
+  >
     <div class="hfl-list-shell hfl-list-shell--fill">
       <div class="hfl-list-panel hfl-list-panel--fill">
         <div class="hfl-list-toolbar">
@@ -2050,39 +2054,60 @@ onUnmounted(() => {
                 :class="{ 'hfl-list-more__chev--open': hostMoreActionsOpen }"
               />
             </ElButton>
-              <template #dropdown>
-                <ElDropdownMenu>
-                  <ElDropdownItem :disabled="hostRenameDisabled" @click="openHostRenameDialog">
-                    <span class="el-dropdown-menu__item-content">
-                      <Pencil :size="14" class="shrink-0" />
-                      <span>{{ t('protection.sourceResources.btnBatchRename') }}</span>
-                    </span>
-                  </ElDropdownItem>
-                  <ElDropdownItem :disabled="hostUpgradeDisabled" @click="onUpgradeSelectedHosts">
-                    <span class="el-dropdown-menu__item-content">
-                      <ArrowUpCircle :size="14" class="shrink-0" />
-                      <span>{{ t('nodesPage.actionUpgrade') }}</span>
-                    </span>
-                  </ElDropdownItem>
-                  <ElDropdownItem :disabled="hostRenameDisabled" @click="openSelectedHostMaintenance">
-                    <span class="el-dropdown-menu__item-content">
-                      <Wrench :size="14" class="shrink-0" />
-                      <span>{{ t('nodeLifecycle.maintenanceCommands') }}</span>
-                    </span>
-                  </ElDropdownItem>
-                  <ElDropdownItem
-                    divided
-                    class="el-dropdown-menu__item--danger"
-                    :disabled="hostDeleteDisabled"
-                    @click="onRemoveSelectedHosts()"
-                  >
-                    <span class="el-dropdown-menu__item-content">
-                      <Trash2 :size="14" class="shrink-0" />
-                      <span>{{ t('protection.sourceResources.deleteBtn') }}</span>
-                    </span>
-                  </ElDropdownItem>
-                </ElDropdownMenu>
-              </template>
+            <template #dropdown>
+              <ElDropdownMenu>
+                <ElDropdownItem
+                  :disabled="hostRenameDisabled"
+                  @click="openHostRenameDialog"
+                >
+                  <span class="el-dropdown-menu__item-content">
+                    <Pencil
+                      :size="14"
+                      class="shrink-0"
+                    />
+                    <span>{{ t('protection.sourceResources.btnBatchRename') }}</span>
+                  </span>
+                </ElDropdownItem>
+                <ElDropdownItem
+                  :disabled="hostUpgradeDisabled"
+                  @click="onUpgradeSelectedHosts"
+                >
+                  <span class="el-dropdown-menu__item-content">
+                    <ArrowUpCircle
+                      :size="14"
+                      class="shrink-0"
+                    />
+                    <span>{{ t('nodesPage.actionUpgrade') }}</span>
+                  </span>
+                </ElDropdownItem>
+                <ElDropdownItem
+                  :disabled="hostRenameDisabled"
+                  @click="openSelectedHostMaintenance"
+                >
+                  <span class="el-dropdown-menu__item-content">
+                    <Wrench
+                      :size="14"
+                      class="shrink-0"
+                    />
+                    <span>{{ t('nodeLifecycle.maintenanceCommands') }}</span>
+                  </span>
+                </ElDropdownItem>
+                <ElDropdownItem
+                  divided
+                  class="el-dropdown-menu__item--danger"
+                  :disabled="hostDeleteDisabled"
+                  @click="onRemoveSelectedHosts()"
+                >
+                  <span class="el-dropdown-menu__item-content">
+                    <Trash2
+                      :size="14"
+                      class="shrink-0"
+                    />
+                    <span>{{ t('protection.sourceResources.deleteBtn') }}</span>
+                  </span>
+                </ElDropdownItem>
+              </ElDropdownMenu>
+            </template>
           </ElDropdown>
 
           <ElDropdown
@@ -2099,39 +2124,61 @@ onUnmounted(() => {
                 :class="{ 'hfl-list-more__chev--open': nasMoreActionsOpen }"
               />
             </ElButton>
-              <template #dropdown>
-                <ElDropdownMenu>
-                  <ElDropdownItem :disabled="nasRenameDisabled" @click="openNasRenameDialog">
-                    <span class="el-dropdown-menu__item-content">
-                      <Pencil :size="14" class="shrink-0" />
-                      <span>{{ t('protection.sourceResources.btnBatchRename') }}</span>
-                    </span>
-                  </ElDropdownItem>
-                  <ElDropdownItem :disabled="nasBatchDisabled" @click="openNasRebindDialog">
-                    <span class="el-dropdown-menu__item-content">
-                      <component :is="sourceAgentSidebarIcon" :size="14" class="shrink-0" />
-                      <span>{{ t('protection.sourceResources.changeProxyNode') }}</span>
-                    </span>
-                  </ElDropdownItem>
-                  <ElDropdownItem :disabled="nasTestDisabled" @click="onTestSelectedNas">
-                    <span class="el-dropdown-menu__item-content">
-                      <Link2 :size="14" class="shrink-0" />
-                      <span>{{ t('protection.sourceResources.testConnection') }}</span>
-                    </span>
-                  </ElDropdownItem>
-                  <ElDropdownItem
-                    divided
-                    class="el-dropdown-menu__item--danger"
-                    :disabled="nasDeleteDisabled"
-                    @click="deleteSelectedNasRows(selectedNas)"
-                  >
-                    <span class="el-dropdown-menu__item-content">
-                      <Trash2 :size="14" class="shrink-0" />
-                      <span>{{ t('protection.sourceResources.deleteBtn') }}</span>
-                    </span>
-                  </ElDropdownItem>
-                </ElDropdownMenu>
-              </template>
+            <template #dropdown>
+              <ElDropdownMenu>
+                <ElDropdownItem
+                  :disabled="nasRenameDisabled"
+                  @click="openNasRenameDialog"
+                >
+                  <span class="el-dropdown-menu__item-content">
+                    <Pencil
+                      :size="14"
+                      class="shrink-0"
+                    />
+                    <span>{{ t('protection.sourceResources.btnBatchRename') }}</span>
+                  </span>
+                </ElDropdownItem>
+                <ElDropdownItem
+                  :disabled="nasBatchDisabled"
+                  @click="openNasRebindDialog"
+                >
+                  <span class="el-dropdown-menu__item-content">
+                    <component
+                      :is="sourceAgentSidebarIcon"
+                      :size="14"
+                      class="shrink-0"
+                    />
+                    <span>{{ t('protection.sourceResources.changeProxyNode') }}</span>
+                  </span>
+                </ElDropdownItem>
+                <ElDropdownItem
+                  :disabled="nasTestDisabled"
+                  @click="onTestSelectedNas"
+                >
+                  <span class="el-dropdown-menu__item-content">
+                    <Link2
+                      :size="14"
+                      class="shrink-0"
+                    />
+                    <span>{{ t('protection.sourceResources.testConnection') }}</span>
+                  </span>
+                </ElDropdownItem>
+                <ElDropdownItem
+                  divided
+                  class="el-dropdown-menu__item--danger"
+                  :disabled="nasDeleteDisabled"
+                  @click="deleteSelectedNasRows(selectedNas)"
+                >
+                  <span class="el-dropdown-menu__item-content">
+                    <Trash2
+                      :size="14"
+                      class="shrink-0"
+                    />
+                    <span>{{ t('protection.sourceResources.deleteBtn') }}</span>
+                  </span>
+                </ElDropdownItem>
+              </ElDropdownMenu>
+            </template>
           </ElDropdown>
 
           <div class="hfl-list-toolbar__right hfl-list-toolbar__right--mobile-split">
@@ -2145,7 +2192,10 @@ onUnmounted(() => {
               @clear="clearSearch"
             >
               <template #prepend>
-                <ElSelect v-model="filters.search_field" @change="handleSearchFieldChange">
+                <ElSelect
+                  v-model="filters.search_field"
+                  @change="handleSearchFieldChange"
+                >
                   <ElOption
                     v-for="option in searchFieldOptions"
                     :key="option.value"
@@ -2155,7 +2205,10 @@ onUnmounted(() => {
                 </ElSelect>
               </template>
               <template #prefix>
-                <Search :size="16" class="hfl-list-search__icon" />
+                <Search
+                  :size="16"
+                  class="hfl-list-search__icon"
+                />
               </template>
             </ElInput>
             <div class="hfl-list-toolbar__utility">
@@ -2166,7 +2219,10 @@ onUnmounted(() => {
                 :disabled="busy"
                 @click="load"
               >
-                <RefreshCw :size="16" :class="{ 'is-spinning': busy }" />
+                <RefreshCw
+                  :size="16"
+                  :class="{ 'is-spinning': busy }"
+                />
               </ElButton>
             </div>
           </div>
@@ -2178,250 +2234,385 @@ onUnmounted(() => {
           @cancel-queued="lifecycleOps.cancelQueued"
         />
 
-        <div v-show="activeTab === 'hostFileSystem'" ref="hostTableBlockRef" class="hfl-list-table-block">
-        <el-table
-          v-table-overflow-title
-          v-table-header-scroll-sync
-          v-table-column-resize="'protection.backupSources.host'"
-          ref="hostTableRef"
-          v-loading="hostTableLoading"
-          row-key="id"
-          :data="pagedHostAgents"
-          stripe
-          class="hfl-list-table"
-          :max-height="hostTableMaxHeight"
-          :header-cell-style="TABLE_HEADER_STYLE"
-          @scroll="onHostTableScroll"
-          @selection-change="onHostSelectionChange"
+        <div
+          v-show="activeTab === 'hostFileSystem'"
+          ref="hostTableBlockRef"
+          class="hfl-list-table-block"
         >
-              <el-table-column type="selection" width="35" fixed="left" />
-              <el-table-column
-                :label="t('protection.sourceResources.colName')"
-                min-width="170"
-                fixed="left"
-                class-name="hfl-table-name-col"
-              >
-                <template #default="{ row }">
-                  <button type="button" class="hfl-table-name-link hfl-table-name-link--full" @click="openHostRowDetail(row)">
-                    {{ row.name }}
-                  </button>
-                </template>
-              </el-table-column>
-              <el-table-column :label="t('protection.sourceResources.colLifecycleStatus')" min-width="155" align="center" header-align="center">
-                <template #default="{ row }">
-                  <div class="hfl-table-no-tooltip">
-                    <FlowSourceReadyStatusCell
-                      v-if="resolveSourcePendingStatus(hostSelectableId(row))"
-                      v-bind="resolveSourcePendingStatus(hostSelectableId(row))!"
-                      @click="openSourcePendingFailureDetails(hostSelectableId(row))"
-                    />
-                    <NodeLifecycleStatusCell
-                      v-else
-                      :node="row"
-                      :resolve-display-status="resolveBackupSourceLifecycleStatus"
-                    />
-                  </div>
-                </template>
-              </el-table-column>
-              <el-table-column :label="t('protection.sourceResources.colHostIp')" min-width="120">
-                <template #default="{ row }">
-                  <span :class="{ 'hfl-empty-mark': !row.ip_address?.trim() }">{{ row.ip_address?.trim() || '—' }}</span>
-                </template>
-              </el-table-column>
-              <el-table-column label="OS" min-width="105">
-                <template #default="{ row }">
-                  <div class="source-os-cell source-os-cell--compact hfl-table-no-tooltip">
-                    <span class="source-os-cell__icon-wrap">
-                      <AgentPlatformBrandIcon :os="agentEnrollmentOs(row)" />
-                    </span>
-                    <span class="source-os-cell__platform">{{ agentPlatformLabel(row) }}</span>
-                  </div>
-                </template>
-              </el-table-column>
-              <el-table-column :label="t('protection.sourceResources.colCpu')" min-width="76">
-                <template #default="{ row }">
-                  <span :class="{ 'hfl-empty-mark': nodeCpuCores(row) == null }">{{ nodeCpuCores(row) != null ? t('protection.sourceResources.cpuCoresValue', { n: nodeCpuCores(row) }) : '—' }}</span>
-                </template>
-              </el-table-column>
-              <el-table-column :label="t('protection.sourceResources.colMemory')" min-width="90">
-                <template #default="{ row }">
-                  <span :class="{ 'hfl-empty-mark': nodeMemoryTotalBytes(row) == null }">{{ nodeMemoryTotalBytes(row) != null ? formatNodeBytes(nodeMemoryTotalBytes(row)!) : '—' }}</span>
-                </template>
-              </el-table-column>
-              <el-table-column :label="t('protection.sourceResources.colDiskCount')" min-width="78">
-                <template #default="{ row }">
-                  <span :class="{ 'hfl-empty-mark': nodeDiskCount(row) == null }">{{ nodeDiskCount(row) ?? '—' }}</span>
-                </template>
-              </el-table-column>
-              <el-table-column :label="t('protection.sourceResources.colCapacity')" min-width="170">
-                <template #default="{ row }">
-                  <HflCapacityCell
-                    :used-bytes="agentUsageParts(row).used"
-                    :total-bytes="agentUsageParts(row).total"
-                    variant="compact"
-                    :format-bytes="formatBytes"
-                  />
-                </template>
-              </el-table-column>
-              <el-table-column :label="t('protection.sourceResources.colConnectivity')" min-width="110" align="center" header-align="center">
-                <template #default="{ row }">
-                  <div class="hfl-table-no-tooltip">
-                    <ElTag :type="availabilityTagType(row.availability)" size="small">
-                      {{ availabilityLabel(row.availability) }}
-                    </ElTag>
-                  </div>
-                </template>
-              </el-table-column>
-              <el-table-column :label="t('protection.sourceResources.colVersion')" min-width="115">
-                <template #default="{ row }">
-                  <NodeVersionCell
-                    :node="row"
-                    :version-label="agentVersion(row)"
-                    :resolve-version-display="lifecycleOps.resolveVersionDisplay"
-                  />
-                </template>
-              </el-table-column>
-              <el-table-column :label="t('protection.sourceResources.colRegisteredAt')" min-width="145">
-                <template #default="{ row }">
-                  <span class="hfl-table-cell-time" :class="{ 'hfl-empty-mark': !row.created_at }">{{ formatDate(row.created_at) }}</span>
-                </template>
-              </el-table-column>
-              <template #empty>
-                <el-empty :description="t('protection.sourceResources.emptyHostSources')" :image-size="80" />
+          <el-table
+            ref="hostTableRef"
+            v-table-overflow-title
+            v-table-header-scroll-sync
+            v-table-column-resize="'protection.backupSources.host'"
+            v-loading="hostTableLoading"
+            row-key="id"
+            :data="pagedHostAgents"
+            stripe
+            class="hfl-list-table"
+            :max-height="hostTableMaxHeight"
+            :header-cell-style="TABLE_HEADER_STYLE"
+            @scroll="onHostTableScroll"
+            @selection-change="onHostSelectionChange"
+          >
+            <el-table-column
+              type="selection"
+              width="35"
+              fixed="left"
+            />
+            <el-table-column
+              :label="t('protection.sourceResources.colName')"
+              min-width="170"
+              fixed="left"
+              class-name="hfl-table-name-col"
+            >
+              <template #default="{ row }">
+                <button
+                  type="button"
+                  class="hfl-table-name-link hfl-table-name-link--full"
+                  @click="openHostRowDetail(row)"
+                >
+                  {{ row.name }}
+                </button>
               </template>
-        </el-table>
+            </el-table-column>
+            <el-table-column
+              :label="t('protection.sourceResources.colLifecycleStatus')"
+              min-width="155"
+              align="center"
+              header-align="center"
+            >
+              <template #default="{ row }">
+                <div class="hfl-table-no-tooltip">
+                  <FlowSourceReadyStatusCell
+                    v-if="resolveSourcePendingStatus(hostSelectableId(row))"
+                    v-bind="resolveSourcePendingStatus(hostSelectableId(row))!"
+                    @click="openSourcePendingFailureDetails(hostSelectableId(row))"
+                  />
+                  <NodeLifecycleStatusCell
+                    v-else
+                    :node="row"
+                    :resolve-display-status="resolveBackupSourceLifecycleStatus"
+                  />
+                </div>
+              </template>
+            </el-table-column>
+            <el-table-column
+              :label="t('protection.sourceResources.colHostIp')"
+              min-width="120"
+            >
+              <template #default="{ row }">
+                <span :class="{ 'hfl-empty-mark': !row.ip_address?.trim() }">{{ row.ip_address?.trim() || '—' }}</span>
+              </template>
+            </el-table-column>
+            <el-table-column
+              label="OS"
+              min-width="105"
+            >
+              <template #default="{ row }">
+                <div class="source-os-cell source-os-cell--compact hfl-table-no-tooltip">
+                  <span class="source-os-cell__icon-wrap">
+                    <AgentPlatformBrandIcon :os="agentEnrollmentOs(row)" />
+                  </span>
+                  <span class="source-os-cell__platform">{{ agentPlatformLabel(row) }}</span>
+                </div>
+              </template>
+            </el-table-column>
+            <el-table-column
+              :label="t('protection.sourceResources.colCpu')"
+              min-width="76"
+            >
+              <template #default="{ row }">
+                <span :class="{ 'hfl-empty-mark': nodeCpuCores(row) == null }">{{ nodeCpuCores(row) != null ? t('protection.sourceResources.cpuCoresValue', { n: nodeCpuCores(row) }) : '—' }}</span>
+              </template>
+            </el-table-column>
+            <el-table-column
+              :label="t('protection.sourceResources.colMemory')"
+              min-width="90"
+            >
+              <template #default="{ row }">
+                <span :class="{ 'hfl-empty-mark': nodeMemoryTotalBytes(row) == null }">{{ nodeMemoryTotalBytes(row) != null ? formatNodeBytes(nodeMemoryTotalBytes(row)!) : '—' }}</span>
+              </template>
+            </el-table-column>
+            <el-table-column
+              :label="t('protection.sourceResources.colDiskCount')"
+              min-width="78"
+            >
+              <template #default="{ row }">
+                <span :class="{ 'hfl-empty-mark': nodeDiskCount(row) == null }">{{ nodeDiskCount(row) ?? '—' }}</span>
+              </template>
+            </el-table-column>
+            <el-table-column
+              :label="t('protection.sourceResources.colCapacity')"
+              min-width="170"
+            >
+              <template #default="{ row }">
+                <HflCapacityCell
+                  :used-bytes="agentUsageParts(row).used"
+                  :total-bytes="agentUsageParts(row).total"
+                  variant="compact"
+                  :format-bytes="formatBytes"
+                />
+              </template>
+            </el-table-column>
+            <el-table-column
+              :label="t('protection.sourceResources.colConnectivity')"
+              min-width="110"
+              align="center"
+              header-align="center"
+            >
+              <template #default="{ row }">
+                <div class="hfl-table-no-tooltip">
+                  <ElTag
+                    :type="availabilityTagType(row.availability)"
+                    size="small"
+                  >
+                    {{ availabilityLabel(row.availability) }}
+                  </ElTag>
+                </div>
+              </template>
+            </el-table-column>
+            <el-table-column
+              :label="t('protection.sourceResources.colVersion')"
+              min-width="115"
+            >
+              <template #default="{ row }">
+                <NodeVersionCell
+                  :node="row"
+                  :version-label="agentVersion(row)"
+                  :resolve-version-display="lifecycleOps.resolveVersionDisplay"
+                />
+              </template>
+            </el-table-column>
+            <el-table-column
+              :label="t('protection.sourceResources.colRegisteredAt')"
+              min-width="145"
+            >
+              <template #default="{ row }">
+                <span
+                  class="hfl-table-cell-time"
+                  :class="{ 'hfl-empty-mark': !row.created_at }"
+                >{{ formatDate(row.created_at) }}</span>
+              </template>
+            </el-table-column>
+            <template #empty>
+              <el-empty
+                :description="t('protection.sourceResources.emptyHostSources')"
+                :image-size="80"
+              />
+            </template>
+          </el-table>
         </div>
 
-        <div v-show="activeTab === 'nas'" ref="nasTableBlockRef" class="hfl-list-table-block">
-        <el-table
-          v-table-overflow-title
-          v-table-header-scroll-sync
-          v-table-column-resize="'protection.backupSources.nas'"
-          ref="nasTableRef"
-          v-loading="nasTableLoading"
-          row-key="id"
-          :data="nasRows"
-          stripe
-          class="hfl-list-table"
-          :max-height="nasTableMaxHeight"
-          :header-cell-style="TABLE_HEADER_STYLE"
-          @scroll="onNasTableScroll"
-          @selection-change="onNasSelectionChange"
+        <div
+          v-show="activeTab === 'nas'"
+          ref="nasTableBlockRef"
+          class="hfl-list-table-block"
         >
-              <el-table-column type="selection" width="35" fixed="left" />
-              <el-table-column
-                :label="t('protection.sourceResources.colName')"
-                min-width="170"
-                fixed="left"
-                class-name="hfl-table-name-col"
-              >
-                <template #default="{ row }">
-                  <button
-                    type="button"
-                    class="hfl-table-name-link hfl-table-name-link--full"
-                    @click="openRowDetail(row)"
-                  >
-                    {{ row.name }}
-                  </button>
-                </template>
-              </el-table-column>
-              <el-table-column :label="t('protection.sourceResources.colLifecycleStatus')" min-width="165" align="center" header-align="center">
-                <template #default="{ row }">
-                  <div class="hfl-table-no-tooltip">
-                    <FlowSourceReadyStatusCell
-                      v-if="resolveSourcePendingStatus(nasSelectableId(row))"
-                      v-bind="resolveSourcePendingStatus(nasSelectableId(row))!"
-                    />
-                    <el-tag v-else :type="sourceNodeOnlineTagType(row)" size="small">
-                      {{ sourceNodeOnlineLabel(row) }}
-                    </el-tag>
-                  </div>
-                </template>
-              </el-table-column>
-              <el-table-column :label="t('protection.sourceResources.colProtocol')" width="85">
-                <template #default="{ row }">
-                  <span v-if="nasProtocolType(row) !== 'nas'" :class="nasProtocolPillClass(row)">
-                    <component :is="nasMountProtocolIcon(nasProtocolType(row))" :size="12" stroke-width="2.25" />
-                    {{ nasProtocolLabel(row) }}
-                  </span>
-                  <span v-else class="hfl-empty-mark">—</span>
-                </template>
-              </el-table-column>
-              <el-table-column :label="t('protection.sourceResources.colNasServer')" min-width="115">
-                <template #default="{ row }">
-                  {{ nasServerAddress(row) }}
-                </template>
-              </el-table-column>
-              <el-table-column :label="t('protection.sourceResources.colNasShareExport')" min-width="120">
-                <template #default="{ row }">
-                  <div class="table-stack-cell">
-                    <span class="table-stack-cell__secondary">{{ t(nasPathKindLabelKey(row)) }}</span>
-                    <span class="table-stack-cell__primary">{{ nasShareOrExport(row) }}</span>
-                  </div>
-                </template>
-              </el-table-column>
-              <el-table-column :label="t('protection.sourceResources.colSourceProxy')" min-width="120">
-                <template #header>
-                  <span class="hfl-table-header-with-tip">
-                    <span>{{ t('protection.sourceResources.colSourceProxy') }}</span>
-                    <HflHelpTip
-                      :content="t('protection.sourceResources.sourceProxyColumnTip')"
-                      :aria-label="t('protection.sourceResources.sourceProxyColumnHelp')"
-                    />
-                  </span>
-                </template>
-                <template #default="{ row }">
-                  <div class="table-stack-cell">
-                    <span class="table-stack-cell__primary" :class="{ 'hfl-empty-mark': !nasSourceProxyName(row) }">{{ nasSourceProxyName(row) || '—' }}</span>
-                    <span v-if="sourceNeedsProxyRebind(row)" class="table-stack-cell__secondary source-needs-proxy">
-                      {{ t('protection.sourceResources.needsProxyRebind') }}
-                    </span>
-                    <span v-else-if="nasSourceProxyIp(row)" class="table-stack-cell__secondary">{{ nasSourceProxyIp(row) }}</span>
-                  </div>
-                </template>
-              </el-table-column>
-              <el-table-column :label="t('protection.sourceResources.colProxyMountPoint')" min-width="165">
-                <template #default="{ row }">
-                  <span class="hfl-table-cell-full hfl-table-no-tooltip">{{ nasProxyMountPoint(row) }}</span>
-                </template>
-              </el-table-column>
-              <el-table-column :label="t('protection.sourceResources.colCapacity')" min-width="170">
-                <template #default="{ row }">
-                  <HflCapacityCell
-                    v-if="row.total_size"
-                    :used-bytes="Number(row.used_size || 0)"
-                    :total-bytes="Number(row.total_size || 0)"
-                    variant="compact"
-                    :format-bytes="formatBytes"
-                  />
-                  <span v-else-if="nasShouldRefreshCapacity(row)" class="source-capacity-pending">
-                    {{ t('protection.sourceResources.capacitySyncing') }}
-                  </span>
-                  <span v-else class="hfl-empty-mark">—</span>
-                </template>
-              </el-table-column>
-              <el-table-column :label="t('protection.sourceResources.colConnectivity')" min-width="110" align="center" header-align="center">
-                <template #default="{ row }">
-                  <div class="hfl-table-no-tooltip">
-                    <ElTag :type="availabilityTagType(row.availability)" size="small">
-                      {{ availabilityLabel(row.availability) }}
-                    </ElTag>
-                  </div>
-                </template>
-              </el-table-column>
-              <el-table-column :label="t('protection.sourceResources.colRegisteredAt')" min-width="145">
-                <template #default="{ row }">
-                  <span class="hfl-table-cell-time" :class="{ 'hfl-empty-mark': !sourceRegisteredAt(row) }">{{ formatDate(sourceRegisteredAt(row)) }}</span>
-                </template>
-              </el-table-column>
-              <template #empty>
-                <el-empty :description="t('protection.sourceResources.emptyNasSources')" :image-size="80" />
+          <el-table
+            ref="nasTableRef"
+            v-table-overflow-title
+            v-table-header-scroll-sync
+            v-table-column-resize="'protection.backupSources.nas'"
+            v-loading="nasTableLoading"
+            row-key="id"
+            :data="nasRows"
+            stripe
+            class="hfl-list-table"
+            :max-height="nasTableMaxHeight"
+            :header-cell-style="TABLE_HEADER_STYLE"
+            @scroll="onNasTableScroll"
+            @selection-change="onNasSelectionChange"
+          >
+            <el-table-column
+              type="selection"
+              width="35"
+              fixed="left"
+            />
+            <el-table-column
+              :label="t('protection.sourceResources.colName')"
+              min-width="170"
+              fixed="left"
+              class-name="hfl-table-name-col"
+            >
+              <template #default="{ row }">
+                <button
+                  type="button"
+                  class="hfl-table-name-link hfl-table-name-link--full"
+                  @click="openRowDetail(row)"
+                >
+                  {{ row.name }}
+                </button>
               </template>
-        </el-table>
+            </el-table-column>
+            <el-table-column
+              :label="t('protection.sourceResources.colLifecycleStatus')"
+              min-width="165"
+              align="center"
+              header-align="center"
+            >
+              <template #default="{ row }">
+                <div class="hfl-table-no-tooltip">
+                  <FlowSourceReadyStatusCell
+                    v-if="resolveSourcePendingStatus(nasSelectableId(row))"
+                    v-bind="resolveSourcePendingStatus(nasSelectableId(row))!"
+                  />
+                  <el-tag
+                    v-else
+                    :type="sourceNodeOnlineTagType(row)"
+                    size="small"
+                  >
+                    {{ sourceNodeOnlineLabel(row) }}
+                  </el-tag>
+                </div>
+              </template>
+            </el-table-column>
+            <el-table-column
+              :label="t('protection.sourceResources.colProtocol')"
+              width="85"
+            >
+              <template #default="{ row }">
+                <span
+                  v-if="nasProtocolType(row) !== 'nas'"
+                  :class="nasProtocolPillClass(row)"
+                >
+                  <component
+                    :is="nasMountProtocolIcon(nasProtocolType(row))"
+                    :size="12"
+                    stroke-width="2.25"
+                  />
+                  {{ nasProtocolLabel(row) }}
+                </span>
+                <span
+                  v-else
+                  class="hfl-empty-mark"
+                >—</span>
+              </template>
+            </el-table-column>
+            <el-table-column
+              :label="t('protection.sourceResources.colNasServer')"
+              min-width="115"
+            >
+              <template #default="{ row }">
+                {{ nasServerAddress(row) }}
+              </template>
+            </el-table-column>
+            <el-table-column
+              :label="t('protection.sourceResources.colNasShareExport')"
+              min-width="120"
+            >
+              <template #default="{ row }">
+                <div class="table-stack-cell">
+                  <span class="table-stack-cell__secondary">{{ t(nasPathKindLabelKey(row)) }}</span>
+                  <span class="table-stack-cell__primary">{{ nasShareOrExport(row) }}</span>
+                </div>
+              </template>
+            </el-table-column>
+            <el-table-column
+              :label="t('protection.sourceResources.colSourceProxy')"
+              min-width="120"
+            >
+              <template #header>
+                <span class="hfl-table-header-with-tip">
+                  <span>{{ t('protection.sourceResources.colSourceProxy') }}</span>
+                  <HflHelpTip
+                    :content="t('protection.sourceResources.sourceProxyColumnTip')"
+                    :aria-label="t('protection.sourceResources.sourceProxyColumnHelp')"
+                  />
+                </span>
+              </template>
+              <template #default="{ row }">
+                <div class="table-stack-cell">
+                  <span
+                    class="table-stack-cell__primary"
+                    :class="{ 'hfl-empty-mark': !nasSourceProxyName(row) }"
+                  >{{ nasSourceProxyName(row) || '—' }}</span>
+                  <span
+                    v-if="sourceNeedsProxyRebind(row)"
+                    class="table-stack-cell__secondary source-needs-proxy"
+                  >
+                    {{ t('protection.sourceResources.needsProxyRebind') }}
+                  </span>
+                  <span
+                    v-else-if="nasSourceProxyIp(row)"
+                    class="table-stack-cell__secondary"
+                  >{{ nasSourceProxyIp(row) }}</span>
+                </div>
+              </template>
+            </el-table-column>
+            <el-table-column
+              :label="t('protection.sourceResources.colProxyMountPoint')"
+              min-width="165"
+            >
+              <template #default="{ row }">
+                <span class="hfl-table-cell-full hfl-table-no-tooltip">{{ nasProxyMountPoint(row) }}</span>
+              </template>
+            </el-table-column>
+            <el-table-column
+              :label="t('protection.sourceResources.colCapacity')"
+              min-width="170"
+            >
+              <template #default="{ row }">
+                <HflCapacityCell
+                  v-if="row.total_size"
+                  :used-bytes="Number(row.used_size || 0)"
+                  :total-bytes="Number(row.total_size || 0)"
+                  variant="compact"
+                  :format-bytes="formatBytes"
+                />
+                <span
+                  v-else-if="nasShouldRefreshCapacity(row)"
+                  class="source-capacity-pending"
+                >
+                  {{ t('protection.sourceResources.capacitySyncing') }}
+                </span>
+                <span
+                  v-else
+                  class="hfl-empty-mark"
+                >—</span>
+              </template>
+            </el-table-column>
+            <el-table-column
+              :label="t('protection.sourceResources.colConnectivity')"
+              min-width="110"
+              align="center"
+              header-align="center"
+            >
+              <template #default="{ row }">
+                <div class="hfl-table-no-tooltip">
+                  <ElTag
+                    :type="availabilityTagType(row.availability)"
+                    size="small"
+                  >
+                    {{ availabilityLabel(row.availability) }}
+                  </ElTag>
+                </div>
+              </template>
+            </el-table-column>
+            <el-table-column
+              :label="t('protection.sourceResources.colRegisteredAt')"
+              min-width="145"
+            >
+              <template #default="{ row }">
+                <span
+                  class="hfl-table-cell-time"
+                  :class="{ 'hfl-empty-mark': !sourceRegisteredAt(row) }"
+                >{{ formatDate(sourceRegisteredAt(row)) }}</span>
+              </template>
+            </el-table-column>
+            <template #empty>
+              <el-empty
+                :description="t('protection.sourceResources.emptyNasSources')"
+                :image-size="80"
+              />
+            </template>
+          </el-table>
         </div>
 
         <div class="hfl-list-footer">
-          <span v-if="tabSelectedCount > 0" class="hfl-list-footer__selected">
+          <span
+            v-if="tabSelectedCount > 0"
+            class="hfl-list-footer__selected"
+          >
             {{ t('protection.sourceResources.selectedCount', { n: tabSelectedCount }) }}
           </span>
           <HflPagination
@@ -2436,163 +2627,252 @@ onUnmounted(() => {
       </div>
     </div>
 
-      <!-- ===== Edit Dialog ===== -->
-      <el-dialog
-        v-model="dialogOpen"
-        :title="editing ? t('protection.sourceResources.edit') : t('protection.sourceResources.add')"
-        width="560px"
-        destroy-on-close
+    <!-- ===== Edit Dialog ===== -->
+    <el-dialog
+      v-model="dialogOpen"
+      :title="editing ? t('protection.sourceResources.edit') : t('protection.sourceResources.add')"
+      width="560px"
+      destroy-on-close
+    >
+      <el-form
+        label-width="120px"
+        @submit.prevent="saveForm"
       >
-        <el-form label-width="120px" @submit.prevent="saveForm">
-          <el-form-item :label="t('protection.sourceResources.formName')" required>
-            <el-input v-model="form.name" />
-          </el-form-item>
-          <el-form-item :label="t('protection.sourceResources.formType')">
-            <el-select v-model="form.resource_type" :disabled="!!editing">
-              <el-option v-for="rt in resourceTypes" :key="rt" :label="typeLabel(rt)" :value="rt" />
-            </el-select>
-          </el-form-item>
-          <el-form-item :label="t('protection.sourceResources.formDesc')">
-            <el-input v-model="form.description" type="textarea" :rows="2" />
-          </el-form-item>
-          <el-form-item :label="t('protection.sourceResources.formNode')">
-            <el-select
-              v-model="form.bound_node_id"
-              clearable
-              :placeholder="t('protection.sourceResources.selectNode')"
-            >
-              <el-option
-                v-for="n in proxyNodes"
-                :key="n.id"
-                :label="n.name"
-                :value="n.id"
-              />
-            </el-select>
-            <p v-if="!proxyNodes.length" class="hint-warn">
-              {{ t('protection.sourceResources.noProxy') }}
-              <RouterLink class="hint-link" to="/node/nodes/deploy?role=proxy">
-                {{ t('protection.sourceResources.deployProxy') }}
-              </RouterLink>
-            </p>
-          </el-form-item>
-
-          <template v-if="form.resource_type === 'local'">
-            <el-form-item :label="t('protection.sourceResources.rootPath')" required>
-              <el-input v-model="form.root_path" placeholder="/data/backup" />
-            </el-form-item>
-          </template>
-          <template v-else-if="form.resource_type === 'nfs'">
-            <el-form-item :label="t('protection.sourceResources.server')" required>
-              <el-input v-model="form.server" />
-            </el-form-item>
-            <el-form-item :label="t('protection.sourceResources.exportPath')" required>
-              <el-input v-model="form.export_path" />
-            </el-form-item>
-          </template>
-          <template v-else-if="form.resource_type === 'cifs'">
-            <el-form-item :label="t('protection.sourceResources.server')" required>
-              <el-input v-model="form.server" />
-            </el-form-item>
-            <el-form-item :label="t('protection.sourceResources.share')" required>
-              <el-input v-model="form.share" />
-            </el-form-item>
-            <el-form-item :label="t('protection.sourceResources.username')" required>
-              <el-input v-model="form.username" />
-            </el-form-item>
-            <el-form-item :label="t('protection.sourceResources.password')" required>
-              <el-input v-model="form.password" type="password" show-password />
-            </el-form-item>
-          </template>
-          <template v-else-if="form.resource_type === 'nas'">
-            <el-form-item :label="t('protection.sourceResources.server')" required>
-              <el-input v-model="form.server" />
-            </el-form-item>
-            <el-form-item :label="t('protection.sourceResources.share')">
-              <el-input v-model="form.share" />
-            </el-form-item>
-          </template>
-          <template v-else-if="form.resource_type === 's3'">
-            <el-form-item :label="t('protection.sourceResources.endpoint')" required>
-              <el-input v-model="form.endpoint" />
-            </el-form-item>
-            <el-form-item :label="t('protection.sourceResources.bucket')" required>
-              <el-input v-model="form.bucket" />
-            </el-form-item>
-            <el-form-item :label="t('protection.sourceResources.accessKey')" required>
-              <el-input v-model="form.access_key" />
-            </el-form-item>
-            <el-form-item :label="t('protection.sourceResources.secretKey')" required>
-              <el-input v-model="form.secret_key" type="password" show-password />
-            </el-form-item>
-          </template>
-        </el-form>
-        <template #footer>
-          <el-button @click="dialogOpen = false">{{ t('common.cancel') }}</el-button>
-          <el-button type="primary" :loading="formBusy" @click="saveForm">{{ t('common.save') }}</el-button>
-        </template>
-      </el-dialog>
-
-      <!-- ===== Rename Dialog ===== -->
-      <el-dialog
-        v-model="renameDialogOpen"
-        class="source-action-dialog"
-        :title="t('protection.sourceResources.renameTitle')"
-        width="480px"
-        align-center
-        destroy-on-close
-      >
-        <ElForm
-          label-position="top"
-          class="source-action-dialog__form"
-          @submit.prevent="submitRename"
+        <el-form-item
+          :label="t('protection.sourceResources.formName')"
+          required
         >
-          <ElFormItem :label="t('protection.sourceResources.renameLabel')" required>
-            <ElInput
-              v-model="renameInput"
-              :placeholder="t('protection.sourceResources.renamePlaceholder')"
-              maxlength="128"
-              show-word-limit
+          <el-input v-model="form.name" />
+        </el-form-item>
+        <el-form-item :label="t('protection.sourceResources.formType')">
+          <el-select
+            v-model="form.resource_type"
+            :disabled="!!editing"
+          >
+            <el-option
+              v-for="rt in resourceTypes"
+              :key="rt"
+              :label="typeLabel(rt)"
+              :value="rt"
             />
-          </ElFormItem>
-        </ElForm>
-        <template #footer>
-          <el-button @click="closeRenameDialog">{{ t('common.cancel') }}</el-button>
-          <el-button type="primary" @click="submitRename">{{ t('common.save') }}</el-button>
+          </el-select>
+        </el-form-item>
+        <el-form-item :label="t('protection.sourceResources.formDesc')">
+          <el-input
+            v-model="form.description"
+            type="textarea"
+            :rows="2"
+          />
+        </el-form-item>
+        <el-form-item :label="t('protection.sourceResources.formNode')">
+          <el-select
+            v-model="form.bound_node_id"
+            clearable
+            :placeholder="t('protection.sourceResources.selectNode')"
+          >
+            <el-option
+              v-for="n in proxyNodes"
+              :key="n.id"
+              :label="n.name"
+              :value="n.id"
+            />
+          </el-select>
+          <p
+            v-if="!proxyNodes.length"
+            class="hint-warn"
+          >
+            {{ t('protection.sourceResources.noProxy') }}
+            <RouterLink
+              class="hint-link"
+              to="/node/nodes/deploy?role=proxy"
+            >
+              {{ t('protection.sourceResources.deployProxy') }}
+            </RouterLink>
+          </p>
+        </el-form-item>
+
+        <template v-if="form.resource_type === 'local'">
+          <el-form-item
+            :label="t('protection.sourceResources.rootPath')"
+            required
+          >
+            <el-input
+              v-model="form.root_path"
+              placeholder="/data/backup"
+            />
+          </el-form-item>
         </template>
-      </el-dialog>
+        <template v-else-if="form.resource_type === 'nfs'">
+          <el-form-item
+            :label="t('protection.sourceResources.server')"
+            required
+          >
+            <el-input v-model="form.server" />
+          </el-form-item>
+          <el-form-item
+            :label="t('protection.sourceResources.exportPath')"
+            required
+          >
+            <el-input v-model="form.export_path" />
+          </el-form-item>
+        </template>
+        <template v-else-if="form.resource_type === 'cifs'">
+          <el-form-item
+            :label="t('protection.sourceResources.server')"
+            required
+          >
+            <el-input v-model="form.server" />
+          </el-form-item>
+          <el-form-item
+            :label="t('protection.sourceResources.share')"
+            required
+          >
+            <el-input v-model="form.share" />
+          </el-form-item>
+          <el-form-item
+            :label="t('protection.sourceResources.username')"
+            required
+          >
+            <el-input v-model="form.username" />
+          </el-form-item>
+          <el-form-item
+            :label="t('protection.sourceResources.password')"
+            required
+          >
+            <el-input
+              v-model="form.password"
+              type="password"
+              show-password
+            />
+          </el-form-item>
+        </template>
+        <template v-else-if="form.resource_type === 'nas'">
+          <el-form-item
+            :label="t('protection.sourceResources.server')"
+            required
+          >
+            <el-input v-model="form.server" />
+          </el-form-item>
+          <el-form-item :label="t('protection.sourceResources.share')">
+            <el-input v-model="form.share" />
+          </el-form-item>
+        </template>
+        <template v-else-if="form.resource_type === 's3'">
+          <el-form-item
+            :label="t('protection.sourceResources.endpoint')"
+            required
+          >
+            <el-input v-model="form.endpoint" />
+          </el-form-item>
+          <el-form-item
+            :label="t('protection.sourceResources.bucket')"
+            required
+          >
+            <el-input v-model="form.bucket" />
+          </el-form-item>
+          <el-form-item
+            :label="t('protection.sourceResources.accessKey')"
+            required
+          >
+            <el-input v-model="form.access_key" />
+          </el-form-item>
+          <el-form-item
+            :label="t('protection.sourceResources.secretKey')"
+            required
+          >
+            <el-input
+              v-model="form.secret_key"
+              type="password"
+              show-password
+            />
+          </el-form-item>
+        </template>
+      </el-form>
+      <template #footer>
+        <el-button @click="dialogOpen = false">
+          {{ t('common.cancel') }}
+        </el-button>
+        <el-button
+          type="primary"
+          :loading="formBusy"
+          @click="saveForm"
+        >
+          {{ t('common.save') }}
+        </el-button>
+      </template>
+    </el-dialog>
 
-      <ChangeProxyHostDialog
-        v-model="rebindDialogOpen"
-        v-model:node-id="rebindNodeId"
-        :selected-count="selectedNas.length"
-        :offline-proxy-count="offlineProxyNodeCount"
-        :proxy-nodes-refreshing="proxyNodesRefreshing"
-        :online-proxy-nodes="onlineProxyNodes"
-        :saving="nasRebindBusy"
-        @refresh="refreshProxyNodesManually"
-        @deploy="openProxyDeploy"
-        @save="submitNasRebind"
-      />
+    <!-- ===== Rename Dialog ===== -->
+    <el-dialog
+      v-model="renameDialogOpen"
+      class="source-action-dialog"
+      :title="t('protection.sourceResources.renameTitle')"
+      width="480px"
+      align-center
+      destroy-on-close
+    >
+      <ElForm
+        label-position="top"
+        class="source-action-dialog__form"
+        @submit.prevent="submitRename"
+      >
+        <ElFormItem
+          :label="t('protection.sourceResources.renameLabel')"
+          required
+        >
+          <ElInput
+            v-model="renameInput"
+            :placeholder="t('protection.sourceResources.renamePlaceholder')"
+            maxlength="128"
+            show-word-limit
+          />
+        </ElFormItem>
+      </ElForm>
+      <template #footer>
+        <el-button @click="closeRenameDialog">
+          {{ t('common.cancel') }}
+        </el-button>
+        <el-button
+          type="primary"
+          @click="submitRename"
+        >
+          {{ t('common.save') }}
+        </el-button>
+      </template>
+    </el-dialog>
 
-      <!-- ===== Host Detail Drawer ===== -->
-      <HostSourceDetailDrawer
-        :model-value="hostDetailOpen"
-        :node-id="hostDetailNodeId"
-        :source="hostDetailSource"
-        :initial-tab="hostDetailInitialTab"
-        :resolve-display-status="resolveBackupSourceLifecycleStatus"
-        @update:model-value="onHostDetailDrawerClose"
-        @saved="onHostDetailDrawerSaved"
-      />
+    <ChangeProxyHostDialog
+      v-model="rebindDialogOpen"
+      v-model:node-id="rebindNodeId"
+      :selected-count="selectedNas.length"
+      :offline-proxy-count="offlineProxyNodeCount"
+      :proxy-nodes-refreshing="proxyNodesRefreshing"
+      :online-proxy-nodes="onlineProxyNodes"
+      :saving="nasRebindBusy"
+      @refresh="refreshProxyNodesManually"
+      @deploy="openProxyDeploy"
+      @save="submitNasRebind"
+    />
 
-      <!-- ===== NAS Detail Drawer ===== -->
-      <NasSourceDetailDrawer
-        v-if="detailOpen && isNasDetail"
-        v-model="detailOpen"
-        :resource="detail"
-        :proxy-nodes="proxyNodes"
-        @updated="onNasDetailUpdated"
-      />
+    <!-- ===== Host Detail Drawer ===== -->
+    <HostSourceDetailDrawer
+      :model-value="hostDetailOpen"
+      :node-id="hostDetailNodeId"
+      :source="hostDetailSource"
+      :initial-tab="hostDetailInitialTab"
+      :resolve-display-status="resolveBackupSourceLifecycleStatus"
+      @update:model-value="onHostDetailDrawerClose"
+      @saved="onHostDetailDrawerSaved"
+    />
+
+    <!-- ===== NAS Detail Drawer ===== -->
+    <NasSourceDetailDrawer
+      v-if="detailOpen && isNasDetail"
+      v-model="detailOpen"
+      :resource="detail"
+      :proxy-nodes="proxyNodes"
+      @updated="onNasDetailUpdated"
+    />
 
     <!-- ===== Agent Deploy Fullscreen (Host File System) ===== -->
     <Teleport to="body">
@@ -2607,12 +2887,23 @@ onUnmounted(() => {
       >
         <div class="fullscreen-form-page source-deploy-page">
           <div class="fullscreen-form-header">
-            <button type="button" class="fullscreen-form-header__back" @click="closeAgentDeploy">
-              <ArrowLeft class="fullscreen-form-header__back-icon" :size="18" />
+            <button
+              type="button"
+              class="fullscreen-form-header__back"
+              @click="closeAgentDeploy"
+            >
+              <ArrowLeft
+                class="fullscreen-form-header__back-icon"
+                :size="18"
+              />
             </button>
             <div class="fullscreen-form-header__content">
-              <h1 class="fullscreen-form-header__title">{{ t('protection.sourceResources.deployAgent') }}</h1>
-              <p class="fullscreen-form-header__desc">{{ t('protection.sourceResources.deployAgentHint') }}</p>
+              <h1 class="fullscreen-form-header__title">
+                {{ t('protection.sourceResources.deployAgent') }}
+              </h1>
+              <p class="fullscreen-form-header__desc">
+                {{ t('protection.sourceResources.deployAgentHint') }}
+              </p>
             </div>
           </div>
 
@@ -2652,12 +2943,23 @@ onUnmounted(() => {
       >
         <div class="fullscreen-form-page source-deploy-page">
           <div class="fullscreen-form-header">
-            <button type="button" class="fullscreen-form-header__back" @click="closeNasAdd">
-              <ArrowLeft class="fullscreen-form-header__back-icon" :size="18" />
+            <button
+              type="button"
+              class="fullscreen-form-header__back"
+              @click="closeNasAdd"
+            >
+              <ArrowLeft
+                class="fullscreen-form-header__back-icon"
+                :size="18"
+              />
             </button>
             <div class="fullscreen-form-header__content">
-              <h1 class="fullscreen-form-header__title">{{ t('protection.sourceResources.addNas') }}</h1>
-              <p class="fullscreen-form-header__desc">{{ t('protection.sourceResources.addSourceTypeNasHint') }}</p>
+              <h1 class="fullscreen-form-header__title">
+                {{ t('protection.sourceResources.addNas') }}
+              </h1>
+              <p class="fullscreen-form-header__desc">
+                {{ t('protection.sourceResources.addSourceTypeNasHint') }}
+              </p>
             </div>
           </div>
 
@@ -2719,7 +3021,10 @@ onUnmounted(() => {
     >
       <div class="source-unregister-blocked-dialog__body">
         <div class="source-unregister-blocked-dialog__lead">
-          <span class="source-unregister-blocked-dialog__icon" aria-hidden="true">
+          <span
+            class="source-unregister-blocked-dialog__icon"
+            aria-hidden="true"
+          >
             <TriangleAlert :size="18" />
           </span>
           <div class="source-unregister-blocked-dialog__copy">
@@ -2732,7 +3037,10 @@ onUnmounted(() => {
           </div>
         </div>
 
-        <div class="source-unregister-blocked-dialog__impact" role="alert">
+        <div
+          class="source-unregister-blocked-dialog__impact"
+          role="alert"
+        >
           <ol class="source-unregister-blocked-dialog__impact-list">
             <li class="source-unregister-blocked-dialog__impact-item">
               <span class="source-unregister-blocked-dialog__impact-index">1</span>
@@ -2772,8 +3080,13 @@ onUnmounted(() => {
         </section>
       </div>
       <template #footer>
-        <el-button @click="closeUnregisterStep3BlockedDialog">{{ t('common.close') }}</el-button>
-        <el-button type="primary" @click="goToStartBackupForUnregister">
+        <el-button @click="closeUnregisterStep3BlockedDialog">
+          {{ t('common.close') }}
+        </el-button>
+        <el-button
+          type="primary"
+          @click="goToStartBackupForUnregister"
+        >
           {{ t('protection.backupsPage.btnGoToStartBackup') }}
         </el-button>
       </template>

--- a/src/frontend/src/pages/protection/DataProtection.vue
+++ b/src/frontend/src/pages/protection/DataProtection.vue
@@ -8993,1750 +8993,2527 @@ async function runRecovery(mode: 'plan' | 'manual' = 'manual') {
     :body-flush="inlineEditorMode === null"
   >
     <template v-if="inlineEditorMode === null">
-    <div class="protection-flow-workspace">
-    <div class="dp-flow-steps-row flex flex-col gap-2 xl:flex-row xl:items-stretch shrink-0">
-      <button
-        type="button"
-        class="dp-flow-card text-left flex-1"
-        :class="{ 'dp-flow-card--active': flowMainStep === 0 }"
-        :aria-pressed="flowMainStep === 0"
-        @click="enterSourceStep"
-      >
-        <div class="dp-flow-card__mark" aria-hidden="true">
-          <span class="dp-flow-card__index">01</span>
-          <span class="dp-flow-card__icon">
-            <component :is="backupFlowSourceStepIcon" :size="20" stroke-width="1.7" />
-          </span>
-        </div>
-        <div class="dp-flow-card__body min-w-0 flex-1">
-          <div class="dp-flow-card__header">
-            <div class="dp-flow-card__heading">
-              <span class="dp-flow-card__title">{{ t('protection.backupsPage.flowStepSourceTitle') }}</span>
-            </div>
-            <span class="dp-flow-card__pill" :class="{ 'dp-flow-card__pill--idle': flowMainStep !== 0 }">
-              <Check v-if="flowMainStep === 0" :size="12" stroke-width="3" />
-              {{ flowMainStep === 0
-                ? t('protection.backupsPage.flowStepBadgeCurrent')
-                : t('protection.backupsPage.flowStepBadgeSwitch') }}
-            </span>
-          </div>
-          <p class="dp-flow-card__desc">{{ t('protection.backupsPage.flowStepSourceDesc') }}</p>
-          <div class="dp-flow-card__meta">
-            <span class="dp-flow-card__meta-dot" aria-hidden="true" />
-            <span class="dp-flow-card__meta-text">
-              {{ t('protection.backupsPage.flowStepSourceMetric', { n: backupSelectableCount }) }}
-            </span>
-          </div>
-        </div>
-      </button>
-
-      <div class="dp-flow-steps-connector" aria-hidden="true">
-        <ChevronsRight :size="22" stroke-width="2" class="dp-flow-steps-connector__icon" />
-      </div>
-
-      <button
-        type="button"
-        class="dp-flow-card text-left flex-1"
-        :class="{ 'dp-flow-card--active': flowMainStep === 1 }"
-        :aria-pressed="flowMainStep === 1"
-        @click="enterBackupConfigStep()"
-      >
-        <div class="dp-flow-card__mark" aria-hidden="true">
-          <span class="dp-flow-card__index">02</span>
-          <span class="dp-flow-card__icon">
-            <Database :size="20" stroke-width="1.7" />
-          </span>
-        </div>
-        <div class="dp-flow-card__body min-w-0 flex-1">
-          <div class="dp-flow-card__header">
-            <div class="dp-flow-card__heading">
-              <span class="dp-flow-card__title">{{ t('protection.backupsPage.flowStepBackupTitle') }}</span>
-            </div>
-            <span class="dp-flow-card__pill" :class="{ 'dp-flow-card__pill--idle': flowMainStep !== 1 }">
-              <Check v-if="flowMainStep === 1" :size="12" stroke-width="3" />
-              {{ flowMainStep === 1
-                ? t('protection.backupsPage.flowStepBadgeCurrent')
-                : t('protection.backupsPage.flowStepBadgeSwitch') }}
-            </span>
-          </div>
-          <p class="dp-flow-card__desc">{{ t('protection.backupsPage.flowStepBackupDesc') }}</p>
-          <div class="dp-flow-card__meta">
-            <span class="dp-flow-card__meta-dot" aria-hidden="true" />
-            <span class="dp-flow-card__meta-text">
-              {{ t('protection.backupsPage.flowStepBackupMetricPending', { n: step2PendingCount }) }}
-            </span>
-          </div>
-        </div>
-      </button>
-
-      <div class="dp-flow-steps-connector" aria-hidden="true">
-        <ChevronsRight :size="22" stroke-width="2" class="dp-flow-steps-connector__icon" />
-      </div>
-
-      <button
-        type="button"
-        class="dp-flow-card text-left flex-1"
-        :class="{ 'dp-flow-card--active': flowMainStep === 2 }"
-        :aria-pressed="flowMainStep === 2"
-        @click="enterStartBackupStep({ requireReady: true })"
-      >
-        <div class="dp-flow-card__mark" aria-hidden="true">
-          <span class="dp-flow-card__index">03</span>
-          <span class="dp-flow-card__icon">
-            <CloudUpload :size="20" stroke-width="1.7" />
-          </span>
-        </div>
-        <div class="dp-flow-card__body min-w-0 flex-1">
-          <div class="dp-flow-card__header">
-            <div class="dp-flow-card__heading">
-              <span class="dp-flow-card__title">{{ t('protection.backupsPage.flowStepRestoreTitle') }}</span>
-            </div>
-            <span class="dp-flow-card__pill" :class="{ 'dp-flow-card__pill--idle': flowMainStep !== 2 }">
-              <Check v-if="flowMainStep === 2" :size="12" stroke-width="3" />
-              {{ flowMainStep === 2
-                ? t('protection.backupsPage.flowStepBadgeCurrent')
-                : t('protection.backupsPage.flowStepBadgeSwitch') }}
-            </span>
-          </div>
-          <p class="dp-flow-card__desc">{{ t('protection.backupsPage.flowStepRestoreDesc') }}</p>
-          <div class="dp-flow-card__meta">
-            <span class="dp-flow-card__meta-dot" aria-hidden="true" />
-            <span class="dp-flow-card__meta-text">
-              {{ t('protection.backupsPage.flowStepRestoreMetric', { n: step3SelectableCount }) }}
-            </span>
-          </div>
-        </div>
-      </button>
-    </div>
-
-    <div class="hfl-list-shell protection-flow-list-shell">
-      <div class="hfl-list-panel protection-flow-list-panel">
-    <div
-      ref="flowToolbarRef"
-      class="hfl-list-toolbar hfl-list-toolbar--mobile-primary-utility protection-flow-toolbar"
-    >
-      <div class="hfl-list-toolbar__primary">
-          <template v-if="flowMainStep === 0">
-            <ElButton
-              type="primary"
-              :title="t('protection.backupsPage.btnAddBackupSourceDesc')"
-              @click="onAddBackupSource"
+      <div class="protection-flow-workspace">
+        <div class="dp-flow-steps-row flex flex-col gap-2 xl:flex-row xl:items-stretch shrink-0">
+          <button
+            type="button"
+            class="dp-flow-card text-left flex-1"
+            :class="{ 'dp-flow-card--active': flowMainStep === 0 }"
+            :aria-pressed="flowMainStep === 0"
+            @click="enterSourceStep"
+          >
+            <div
+              class="dp-flow-card__mark"
+              aria-hidden="true"
             >
-              <Plus :size="16" />
-              {{ t('protection.backupsPage.btnAddBackupSource') }}
-            </ElButton>
-            <ElButton
-              type="primary"
-              :disabled="selectedSourceIds.length === 0 || flowAdvancingToBackupConfig"
-              :loading="flowAdvancingToBackupConfig"
-              @click="onGoToStep2"
-            >
-              <ArrowRight :size="16" class="shrink-0" />
-              {{ t('protection.backupsPage.btnNext') }}
-            </ElButton>
-            <ElDropdown
-              trigger="click"
-              popper-class="hfl-actions-dropdown"
-              @visible-change="moreActionsOpen = $event"
-            >
-              <ElButton>
-                {{ t('protection.backupsPage.flowMoreActions') }}
-                <ChevronDown
-                  :size="16"
-                  class="hfl-list-more__chev"
-                  :class="{ 'hfl-list-more__chev--open': moreActionsOpen }"
+              <span class="dp-flow-card__index">01</span>
+              <span class="dp-flow-card__icon">
+                <component
+                  :is="backupFlowSourceStepIcon"
+                  :size="20"
+                  stroke-width="1.7"
                 />
-              </ElButton>
-              <template #dropdown>
-                <ElDropdownMenu>
-                  <ElDropdownItem
-                    :disabled="!step1DisplayNameEditEnabled"
-                    @click="openStep1DisplayNameEditor"
-                  >
-                    <span class="el-dropdown-menu__item-content">
-                      <Pencil :size="14" class="shrink-0" />
-                      <span>{{ t('protection.backupsPage.flowActionEditDisplayName') }}</span>
-                    </span>
-                  </ElDropdownItem>
-                  <ElDropdownItem
-                    divided
-                    class="el-dropdown-menu__item--danger"
-                    :disabled="!step1UnregisterEnabled"
-                    @click="deleteSelectedSourcesFromStep1"
-                  >
-                    <span class="hfl-dropdown-item-row hfl-dropdown-item-row--danger">
-                      <Trash2 :size="14" class="shrink-0" />
-                      <span>{{ t('protection.backupsPage.flowActionDelete') }}</span>
-                    </span>
-                  </ElDropdownItem>
-                </ElDropdownMenu>
-              </template>
-            </ElDropdown>
-          </template>
-          <template v-else-if="flowMainStep === 1">
-            <ElButton
-              type="primary"
-              class="hfl-btn-with-icon"
-              :disabled="!step2ToolbarActionsEnabled || setupDrOpening"
-              :loading="setupDrOpening"
-              @click="onGoToCreateBackup"
-            >
-              <Database :size="16" class="shrink-0" />
-              {{ t('protection.backupsPage.btnCreateBackup') }}
-            </ElButton>
-            <ElDropdown
-              trigger="click"
-              popper-class="hfl-actions-dropdown"
-              @visible-change="moreActionsOpen = $event"
-            >
-              <ElButton>
-                {{ t('protection.backupsPage.flowMoreActions') }}
-                <ChevronDown
-                  :size="16"
-                  class="hfl-list-more__chev"
-                  :class="{ 'hfl-list-more__chev--open': moreActionsOpen }"
-                />
-              </ElButton>
-              <template #dropdown>
-                <ElDropdownMenu>
-                  <ElDropdownItem
-                    :disabled="!step2DisplayNameEditEnabled"
-                    @click="openStep2DisplayNameEditor"
-                  >
-                    <span class="el-dropdown-menu__item-content">
-                      <Pencil :size="14" class="shrink-0" />
-                      <span>{{ t('protection.backupsPage.flowActionEditDisplayName') }}</span>
-                    </span>
-                  </ElDropdownItem>
-                  <ElDropdownItem
-                    divided
-                    class="el-dropdown-menu__item--danger"
-                    :disabled="!step2UnregisterEnabled"
-                    @click="deleteSelectedSourcesFromStep2"
-                  >
-                    <span class="hfl-dropdown-item-row hfl-dropdown-item-row--danger">
-                      <Trash2 :size="14" class="shrink-0" />
-                      <span>{{ t('protection.backupsPage.flowActionDelete') }}</span>
-                    </span>
-                  </ElDropdownItem>
-                </ElDropdownMenu>
-              </template>
-            </ElDropdown>
-          </template>
-          <template v-else>
-            <ElTooltip
-              :content="t('protection.backupsPage.btnStartBackupCloudHint')"
-              placement="bottom"
-              :show-after="300"
-              :hide-after="0"
-            >
-              <span class="dp-flow-step3-action-tooltip">
-                <ElButton
-                  type="primary"
-                  plain
-                  class="hfl-btn-with-icon dp-flow-step3-action-btn shrink-0"
-                  :disabled="!step3SourceActionsEnabled || startBackupSubmitting || step3StopActionBusy"
-                  :loading="startBackupSubmitting"
-                  @click="startSelectedBackupTasks"
+              </span>
+            </div>
+            <div class="dp-flow-card__body min-w-0 flex-1">
+              <div class="dp-flow-card__header">
+                <div class="dp-flow-card__heading">
+                  <span class="dp-flow-card__title">{{ t('protection.backupsPage.flowStepSourceTitle') }}</span>
+                </div>
+                <span
+                  class="dp-flow-card__pill"
+                  :class="{ 'dp-flow-card__pill--idle': flowMainStep !== 0 }"
                 >
-                  <CloudUpload :size="16" class="shrink-0" />
-                  {{ t('protection.backupsPage.btnStartBackup') }}
-                </ElButton>
-              </span>
-            </ElTooltip>
-            <ElButton
-              type="primary"
-              class="hfl-btn-with-icon dp-flow-step3-action-btn shrink-0"
-              :disabled="!recoveryToolbarEnabled || recoveryOpening || step3StopActionBusy"
-              :loading="recoveryOpening"
-              @click="openRecovery"
-            >
-              <ArchiveRestore :size="16" class="shrink-0" />
-              {{ t('protection.backupsPage.btnRecover') }}
-            </ElButton>
-            <ElDropdown
-              trigger="click"
-              popper-class="hfl-actions-dropdown"
-              @visible-change="moreActionsOpen = $event"
-            >
-              <ElButton>
-                {{ t('protection.backupsPage.flowMoreActions') }}
-                <ChevronDown
-                  :size="16"
-                  class="hfl-list-more__chev"
-                  :class="{ 'hfl-list-more__chev--open': moreActionsOpen }"
+                  <Check
+                    v-if="flowMainStep === 0"
+                    :size="12"
+                    stroke-width="3"
+                  />
+                  {{ flowMainStep === 0
+                    ? t('protection.backupsPage.flowStepBadgeCurrent')
+                    : t('protection.backupsPage.flowStepBadgeSwitch') }}
+                </span>
+              </div>
+              <p class="dp-flow-card__desc">
+                {{ t('protection.backupsPage.flowStepSourceDesc') }}
+              </p>
+              <div class="dp-flow-card__meta">
+                <span
+                  class="dp-flow-card__meta-dot"
+                  aria-hidden="true"
                 />
-              </ElButton>
-              <template #dropdown>
-                <ElDropdownMenu>
-                  <ElDropdownItem
-                    :disabled="!step3DisplayNameEditEnabled"
-                    @click="openStep3DisplayNameEditor"
-                  >
-                    <span class="el-dropdown-menu__item-content">
-                      <Pencil :size="14" class="shrink-0" />
-                      <span>{{ t('protection.backupsPage.flowActionEditDisplayName') }}</span>
-                    </span>
-                  </ElDropdownItem>
-                  <ElDropdownItem
-                    divided
-                    :disabled="!step3SelectionEditable"
-                    @click="openBackupConfigEditFromStep3('paths')"
-                  >
-                    <span class="el-dropdown-menu__item-content">
-                      <FolderTree :size="14" class="shrink-0" />
-                      <span>{{ t('protection.backupsPage.flowActionEditBackupPaths') }}</span>
-                    </span>
-                  </ElDropdownItem>
-                  <ElDropdownItem
-                    :disabled="!step3SelectionEditable"
-                    @click="openBackupConfigEditFromStep3('policy')"
-                  >
-                    <span class="el-dropdown-menu__item-content">
-                      <ClipboardCheck :size="14" class="shrink-0" />
-                      <span>{{ t('protection.backupsPage.flowActionEditBackupPolicy') }}</span>
-                    </span>
-                  </ElDropdownItem>
-                  <ElDropdownItem
-                    :disabled="!step3SelectionEditable"
-                    @click="openBackupConfigEditFromStep3('recovery')"
-                  >
-                    <span class="el-dropdown-menu__item-content">
-                      <Route :size="14" class="shrink-0" />
-                      <span>{{ t('protection.backupsPage.flowActionEditRestorePlan') }}</span>
-                    </span>
-                  </ElDropdownItem>
-                  <ElDropdownItem
-                    divided
-                    :disabled="!step3CanStopBackup || step3StopActionBusy"
-                    @click="openStopBackupConfirmDialog"
-                  >
-                    <span class="el-dropdown-menu__item-content">
-                      <CircleStop :size="14" class="shrink-0" />
-                      <span>{{ t('protection.backupsPage.flowActionStopBackup') }}</span>
-                    </span>
-                  </ElDropdownItem>
-                  <ElDropdownItem
-                    :disabled="!step3CanStopRestore || step3StopActionBusy"
-                    @click="openStopRestoreConfirmDialog"
-                  >
-                    <span class="el-dropdown-menu__item-content">
-                      <CircleStop :size="14" class="shrink-0" />
-                      <span>{{ t('protection.backupsPage.flowActionStopRestore') }}</span>
-                    </span>
-                  </ElDropdownItem>
-                  <ElDropdownItem
-                    divided
-                    :disabled="!step3SelectionEditable"
-                    @click="revertSelectedSourcesFromStep3"
-                  >
-                    <span class="el-dropdown-menu__item-content">
-                      <Undo2 :size="14" class="shrink-0" />
-                      <span>{{ t('protection.backupsPage.actionResetBackupConfig') }}</span>
-                    </span>
-                  </ElDropdownItem>
-                  <ElDropdownItem
-                    class="el-dropdown-menu__item--danger"
-                    :disabled="!step3UnregisterEnabled"
-                    @click="deleteSelectedSourcesFromStep3"
-                  >
-                    <span class="hfl-dropdown-item-row hfl-dropdown-item-row--danger">
-                      <Trash2 :size="14" class="shrink-0" />
-                      <span>{{ t('protection.backupsPage.flowActionDelete') }}</span>
-                    </span>
-                  </ElDropdownItem>
-                </ElDropdownMenu>
-              </template>
-            </ElDropdown>
-          </template>
-      </div>
-        <div class="hfl-list-toolbar__right hfl-list-toolbar__right--mobile-split">
-          <ElInput
-            v-model="taskSearchQuery"
-            clearable
-            size="small"
-            :placeholder="t('protection.backupsPage.step3SearchPlaceholder')"
-            class="hfl-list-search hfl-list-search-group"
-            @keyup.enter="applyTaskSearchImmediately"
-            @clear="applyTaskSearchImmediately"
+                <span class="dp-flow-card__meta-text">
+                  {{ t('protection.backupsPage.flowStepSourceMetric', { n: backupSelectableCount }) }}
+                </span>
+              </div>
+            </div>
+          </button>
+
+          <div
+            class="dp-flow-steps-connector"
+            aria-hidden="true"
           >
-            <template #prepend>
-              <ElSelect v-model="step3SearchField" @change="onStep3SearchFieldChange">
-                <ElOption
-                  v-for="item in step3SearchFieldOptions"
-                  :key="item.value"
-                  :label="item.label"
-                  :value="item.value"
-                />
-              </ElSelect>
-            </template>
-          </ElInput>
-          <ElSelect
-            v-if="flowMainStep === 2"
-            v-model="step3BackupTaskStatus"
-            clearable
-            size="small"
-            :placeholder="t('protection.backupsPage.step3BackupTask')"
-            style="width: 130px"
-          >
-            <ElOption
-              v-for="item in step3BackupTaskStatusOptions"
-              :key="item.value"
-              :label="item.label"
-              :value="item.value"
+            <ChevronsRight
+              :size="22"
+              stroke-width="2"
+              class="dp-flow-steps-connector__icon"
             />
-          </ElSelect>
-          <ElSelect
-            v-if="flowMainStep === 2"
-            v-model="step3RestoreTaskStatus"
-            clearable
-            size="small"
-            :placeholder="t('protection.backupsPage.step3RestoreTask')"
-            style="width: 150px"
-          >
-            <ElOption
-              v-for="item in step3RestoreTaskStatusOptions"
-              :key="item.value"
-              :label="item.label"
-              :value="item.value"
-            />
-          </ElSelect>
-          <ElSelect
-            v-if="flowMainStep !== 2"
-            v-model="step3Availability"
-            clearable
-            size="small"
-            :placeholder="t('protection.backupsPage.step3Availability')"
-            style="width: 130px"
-          >
-            <ElOption
-              v-for="item in step3AvailabilityOptions"
-              :key="item.value"
-              :label="item.label"
-              :value="item.value"
-            />
-          </ElSelect>
-          <ElSelect
-            v-if="flowMainStep === 2"
-            v-model="step3Availability"
-            clearable
-            size="small"
-            :placeholder="t('protection.backupsPage.step3Availability')"
-            style="width: 130px"
-          >
-            <ElOption
-              v-for="item in step3AvailabilityOptions"
-              :key="item.value"
-              :label="item.label"
-              :value="item.value"
-            />
-          </ElSelect>
-          <div class="hfl-list-toolbar__utility">
-            <ElButton
-              :title="t('protection.backupsPage.flowFilterAdvanced')"
-              class="hfl-filter-button"
-              :class="{ 'hfl-filter-button--active': flowActiveFilterCount > 0 }"
-              :aria-label="t('protection.backupsPage.flowFilterAdvanced')"
-              @click="openAdvancedFilters"
-            >
-              <ElBadge v-if="flowActiveFilterCount > 0" :value="flowActiveFilterCount" :max="9" class="hfl-filter-badge">
-                <Filter :size="16" />
-              </ElBadge>
-              <Filter v-else :size="16" />
-            </ElButton>
-            <ElButton
-              class="hfl-refresh-button"
-              :title="t('protection.backupsPage.flowActionRefreshList')"
-              :aria-label="t('protection.backupsPage.flowActionRefreshList')"
-              :disabled="flowRefreshing"
-              @click="refreshTaskLists"
-            >
-              <RefreshCw :size="16" :class="{ 'is-spinning': flowRefreshing }" />
-            </ElButton>
           </div>
-        </div>
-    </div>
 
-    <div ref="flowTableZoneRef" class="protection-flow-table-zone">
-    <div v-if="flowMainStep === 0" class="protection-flow-panel protection-flow-panel--fill">
-      <div class="protection-flow-table-block">
-      <el-table
-          v-table-overflow-title
-        v-table-header-scroll-sync
-        v-table-column-resize="'protection.dataProtection.sources'"
-        v-loading="backupSelectableLoading"
-        class="hfl-list-table source-table--flow-pick"
-        :data="filteredBackupSelectableRows"
-        stripe
-        row-key="id"
-        :max-height="flowTableMaxHeight"
-        :header-cell-style="TABLE_HEADER_STYLE"
-        ref="sourceTableRef"
-        @selection-change="onSourceSelectionChange"
-        @cell-click="onFlowSourceCellClick"
-      >
-        <el-table-column type="selection" width="35" fixed="left" reserve-selection :selectable="flowSourceRowSelectable" />
-        <el-table-column
-          fixed="left"
-          column-key="backup-source"
-          :label="t('protection.backupsPage.colBackupSource')"
-          :min-width="FLOW_PICK_TABLE_COL_MIN.source"
-        >
-          <template #default="{ row }">
-            <FlowSourceSummaryCell
-              :row="row"
-              :interactive="false"
-              externally-interactive
-            />
-          </template>
-        </el-table-column>
-        <el-table-column
-          :label="t('protection.backupsPage.colConnectionAddress')"
-          :min-width="FLOW_PICK_TABLE_COL_MIN.connection"
-        >
-          <template #default="{ row }">
-            <FlowSourceConnectionCell :row="row" />
-          </template>
-        </el-table-column>
-        <el-table-column
-          :label="t('protection.sourceResources.colLifecycleStatus')"
-          width="168"
-          align="center"
-          header-align="center"
-        >
-          <template #header>
-            <span class="flow-filterable-header">
-              <span>{{ t('protection.sourceResources.colLifecycleStatus') }}</span>
-              <HflPopover v-if="flowMainStep !== 2" v-model:visible="flowHeaderFilterOpen.sourceStatus" trigger="click" placement="bottom" :width="210" popper-class="flow-header-filter-popper">
-                <template #reference>
-                  <button type="button" class="flow-header-filter-trigger" :class="{ 'flow-header-filter-trigger--active': hasFlowHeaderFilterValue('sourceStatus') }" @click.stop>
-                    <Filter :size="14" />
-                  </button>
-                </template>
-                <div class="flow-header-filter-panel">
-                  <ElInput v-model="flowHeaderFilterSearch.sourceStatus" size="small" clearable :placeholder="t('protection.backupsPage.flowFilterSearchPlaceholder')" />
-                  <ElCheckboxGroup v-model="flowFilterSourceStatuses" class="flow-header-filter-options">
-                    <ElCheckbox v-for="item in visibleFlowHeaderFilterOptions(flowSourceStatusFilterOptions, 'sourceStatus')" :key="item.value" :value="item.value">
-                      {{ item.text }}
-                    </ElCheckbox>
-                  </ElCheckboxGroup>
-                  <div v-if="visibleFlowHeaderFilterOptions(flowSourceStatusFilterOptions, 'sourceStatus').length === 0" class="flow-header-filter-empty">
-                    {{ t('protection.backupsPage.flowFilterNoOptions') }}
-                  </div>
-                  <div class="flow-header-filter-actions">
-                    <ElButton text size="small" @click="clearFlowHeaderFilter('sourceStatus')">{{ t('protection.backupsPage.flowFilterReset') }}</ElButton>
-                    <ElButton text size="small" type="primary" @click="closeFlowHeaderFilter('sourceStatus')">{{ t('protection.backupsPage.flowFilterApply') }}</ElButton>
-                  </div>
-                </div>
-              </HflPopover>
-            </span>
-          </template>
-          <template #default="{ row }">
-            <FlowSourceReadyStatusCell
-              v-bind="resolveFlowSourceDisplayStatus(row)"
-              neutral-as-danger
-              @click="openSourcePendingFailureDetails(row.id)"
-            />
-          </template>
-        </el-table-column>
-        <el-table-column
-          :label="t('protection.sourceResources.colCpu')"
-          :min-width="FLOW_PICK_TABLE_COL_MIN.cpu"
-        >
-          <template #default="{ row }">
-            <span>{{
-              flowSourceCpuCores(row) != null
-                ? t('protection.sourceResources.cpuCoresValue', { n: flowSourceCpuCores(row) })
-                : '—'
-            }}</span>
-          </template>
-        </el-table-column>
-        <el-table-column
-          :label="t('protection.sourceResources.colMemory')"
-          :min-width="FLOW_PICK_TABLE_COL_MIN.memory"
-        >
-          <template #default="{ row }">
-            <span>{{ flowSourceMemoryText(row) }}</span>
-          </template>
-        </el-table-column>
-        <el-table-column
-          :label="t('protection.sourceResources.colDiskCount')"
-          :min-width="FLOW_PICK_TABLE_COL_MIN.diskCount"
-        >
-          <template #default="{ row }">
-            <span>{{ flowSourceDiskCountText(row) }}</span>
-          </template>
-        </el-table-column>
-        <el-table-column
-          :label="t('protection.sourceResources.colConnectivity')"
-          width="110"
-          align="center"
-          header-align="center"
-        >
-          <template #default="{ row }">
-            <div class="hfl-table-no-tooltip">
-              <ElTag :type="flowSourceAvailabilityTagType(row.availability)" size="small">
-                {{ flowSourceAvailabilityLabel(row.availability) }}
-              </ElTag>
-            </div>
-          </template>
-        </el-table-column>
-        <el-table-column :label="t('protection.sourceResources.colRegisteredAt')" width="154">
-          <template #default="{ row }">
-            <span class="hfl-table-cell-time" :class="{ 'hfl-empty-mark': !row.registeredAt }">{{ flowSourceRegisteredAt(row.registeredAt) }}</span>
-          </template>
-        </el-table-column>
-        <template #empty>
-          <el-empty :image-size="72">
-            <template #description>
-              <p>
-                {{ t('protection.backupsPage.flowTaskEmptySourcePrefix') }}
-                <strong>{{ t('protection.backupsPage.flowTaskEmptySourceAction') }}</strong>
-                {{ t('protection.backupsPage.flowTaskEmptySourceSuffix') }}
-              </p>
-            </template>
-          </el-empty>
-        </template>
-      </el-table>
-      <div class="hfl-list-footer">
-        <span v-if="selectedSourceIds.length > 0" class="hfl-list-footer__selected">
-          {{ t('protection.sourceResources.selectedCount', { n: selectedSourceIds.length }) }}
-        </span>
-        <HflPagination
-          class="hfl-list-footer__pagination"
-          v-model:current-page="flowStep0Pager.page"
-          v-model:page-size="flowStep0Pager.pageSize"
-          :total="flowStep0DisplayTotal"
-        />
-      </div>
-      </div>
-    </div>
-
-    <div v-if="flowMainStep === 1" class="protection-flow-panel protection-flow-panel--fill">
-      <div class="protection-flow-table-block">
-      <el-table
-          v-table-overflow-title
-        v-table-header-scroll-sync
-        v-table-column-resize="'protection.dataProtection.configurations'"
-        v-loading="flowStepDataLoading[1]"
-        class="hfl-list-table source-table--flow-pick"
-        :data="paginatedStep2SourceList"
-        stripe
-        row-key="id"
-        :max-height="flowTableMaxHeight"
-        :header-cell-style="TABLE_HEADER_STYLE"
-        ref="step2TableRef"
-        @selection-change="onStep2SelectionChange"
-        @cell-click="onFlowSourceCellClick"
-      >
-        <el-table-column type="selection" width="35" fixed="left" reserve-selection :selectable="flowSourceRowSelectable" />
-        <el-table-column
-          fixed="left"
-          column-key="backup-source"
-          :label="t('protection.backupsPage.colBackupSource')"
-          :min-width="FLOW_PICK_TABLE_COL_MIN.source"
-        >
-          <template #default="{ row }">
-            <FlowSourceSummaryCell
-              :row="row"
-              :interactive="false"
-              externally-interactive
-            />
-          </template>
-        </el-table-column>
-        <el-table-column
-          :label="t('protection.backupsPage.colConnectionAddress')"
-          :min-width="FLOW_PICK_TABLE_COL_MIN.connection"
-        >
-          <template #default="{ row }">
-            <FlowSourceConnectionCell :row="row" />
-          </template>
-        </el-table-column>
-        <el-table-column
-          :label="t('protection.sourceResources.colLifecycleStatus')"
-          width="168"
-          align="center"
-          header-align="center"
-        >
-          <template #header>
-            <span class="flow-filterable-header">
-              <span>{{ t('protection.sourceResources.colLifecycleStatus') }}</span>
-              <HflPopover v-if="flowMainStep !== 2" v-model:visible="flowHeaderFilterOpen.sourceStatus" trigger="click" placement="bottom" :width="210" popper-class="flow-header-filter-popper">
-                <template #reference>
-                  <button type="button" class="flow-header-filter-trigger" :class="{ 'flow-header-filter-trigger--active': hasFlowHeaderFilterValue('sourceStatus') }" @click.stop>
-                    <Filter :size="14" />
-                  </button>
-                </template>
-                <div class="flow-header-filter-panel">
-                  <ElInput v-model="flowHeaderFilterSearch.sourceStatus" size="small" clearable :placeholder="t('protection.backupsPage.flowFilterSearchPlaceholder')" />
-                  <ElCheckboxGroup v-model="flowFilterSourceStatuses" class="flow-header-filter-options">
-                    <ElCheckbox v-for="item in visibleFlowHeaderFilterOptions(flowSourceStatusFilterOptions, 'sourceStatus')" :key="item.value" :value="item.value">
-                      {{ item.text }}
-                    </ElCheckbox>
-                  </ElCheckboxGroup>
-                  <div v-if="visibleFlowHeaderFilterOptions(flowSourceStatusFilterOptions, 'sourceStatus').length === 0" class="flow-header-filter-empty">
-                    {{ t('protection.backupsPage.flowFilterNoOptions') }}
-                  </div>
-                  <div class="flow-header-filter-actions">
-                    <ElButton text size="small" @click="clearFlowHeaderFilter('sourceStatus')">{{ t('protection.backupsPage.flowFilterReset') }}</ElButton>
-                    <ElButton text size="small" type="primary" @click="closeFlowHeaderFilter('sourceStatus')">{{ t('protection.backupsPage.flowFilterApply') }}</ElButton>
-                  </div>
-                </div>
-              </HflPopover>
-            </span>
-          </template>
-          <template #default="{ row }">
-            <FlowSourceReadyStatusCell
-              v-bind="resolveFlowSourceDisplayStatus(row)"
-              neutral-as-danger
-              @click="openSourcePendingFailureDetails(row.id)"
-            />
-          </template>
-        </el-table-column>
-        <el-table-column
-          :label="t('protection.sourceResources.colCpu')"
-          :min-width="FLOW_PICK_TABLE_COL_MIN.cpu"
-        >
-          <template #default="{ row }">
-            <span>{{
-              flowSourceCpuCores(row) != null
-                ? t('protection.sourceResources.cpuCoresValue', { n: flowSourceCpuCores(row) })
-                : '—'
-            }}</span>
-          </template>
-        </el-table-column>
-        <el-table-column
-          :label="t('protection.sourceResources.colMemory')"
-          :min-width="FLOW_PICK_TABLE_COL_MIN.memory"
-        >
-          <template #default="{ row }">
-            <span>{{ flowSourceMemoryText(row) }}</span>
-          </template>
-        </el-table-column>
-        <el-table-column
-          :label="t('protection.sourceResources.colDiskCount')"
-          :min-width="FLOW_PICK_TABLE_COL_MIN.diskCount"
-        >
-          <template #default="{ row }">
-            <span>{{ flowSourceDiskCountText(row) }}</span>
-          </template>
-        </el-table-column>
-        <el-table-column
-          :label="t('protection.sourceResources.colConnectivity')"
-          width="110"
-          align="center"
-          header-align="center"
-        >
-          <template #default="{ row }">
-            <div class="hfl-table-no-tooltip">
-              <ElTag :type="flowSourceAvailabilityTagType(row.availability)" size="small">
-                {{ flowSourceAvailabilityLabel(row.availability) }}
-              </ElTag>
-            </div>
-          </template>
-        </el-table-column>
-        <el-table-column :label="t('protection.sourceResources.colRegisteredAt')" width="154">
-          <template #default="{ row }">
-            <span class="hfl-table-cell-time" :class="{ 'hfl-empty-mark': !row.registeredAt }">{{ flowSourceRegisteredAt(row.registeredAt) }}</span>
-          </template>
-        </el-table-column>
-        <template #empty>
-          <el-empty :image-size="72">
-            <template #description>
-              <p v-if="step2AllSourcesConfigured">
-                {{ t('protection.backupsPage.flowStep2EmptyAllConfigured') }}
-              </p>
-              <p v-else>
-                {{ t('protection.backupsPage.flowTaskEmptyBackupConfigPrefix') }}
-                <strong>{{ t('protection.backupsPage.flowTaskEmptyBackupConfigStep') }}</strong>
-                {{ t('protection.backupsPage.flowTaskEmptyBackupConfigSuffix') }}
-              </p>
-            </template>
-          </el-empty>
-        </template>
-      </el-table>
-      <div class="hfl-list-footer">
-        <span v-if="step1Selection.length > 0" class="hfl-list-footer__selected">
-          {{ t('protection.sourceResources.selectedCount', { n: step1Selection.length }) }}
-        </span>
-        <HflPagination
-          class="hfl-list-footer__pagination"
-          v-model:current-page="flowStep1Pager.page"
-          v-model:page-size="flowStep1Pager.pageSize"
-          :total="flowMainStep === 1 ? step2SelectableCount : filteredStep2SourceList.length"
-        />
-      </div>
-      </div>
-    </div>
-
-    <div v-if="flowMainStep === 2" class="protection-flow-panel protection-flow-panel--fill">
-      <div class="protection-flow-table-block">
-      <el-table
-          v-table-overflow-title
-        v-table-header-scroll-sync
-        v-table-column-resize="'protection.dataProtection.startBackup'"
-        v-loading="flowStepDataLoading[2]"
-        class="hfl-list-table"
-        :data="paginatedStep3SourceList"
-        stripe
-        row-key="id"
-        :max-height="flowTableMaxHeight"
-        :header-cell-style="TABLE_HEADER_STYLE"
-        ref="step3TableRef"
-        @selection-change="onBackupTaskSelection"
-        @cell-click="onFlowSourceCellClick"
-      >
-        <el-table-column type="selection" width="35" fixed="left" reserve-selection :selectable="flowSourceRowSelectable" />
-        <el-table-column
-          fixed="left"
-          column-key="backup-source"
-          :label="t('protection.backupsPage.colBackupSource')"
-          :min-width="FLOW_PICK_TABLE_COL_MIN.source"
-        >
-          <template #header>
-            <span class="flow-filterable-header">
-              <span>{{ t('protection.backupsPage.colBackupSource') }}</span>
-              <HflPopover v-if="flowMainStep !== 2" v-model:visible="flowHeaderFilterOpen.sourceType" trigger="click" placement="bottom" :width="224" popper-class="flow-header-filter-popper">
-                <template #reference>
-                  <button type="button" class="flow-header-filter-trigger" :class="{ 'flow-header-filter-trigger--active': hasFlowHeaderFilterValue('sourceType') }" @click.stop>
-                    <Filter :size="14" />
-                  </button>
-                </template>
-                <div class="flow-header-filter-panel">
-                  <ElInput v-model="flowHeaderFilterSearch.sourceType" size="small" clearable :placeholder="t('protection.backupsPage.flowFilterSearchPlaceholder')" />
-                  <ElCheckboxGroup v-model="flowFilterSourceTypes" class="flow-header-filter-options">
-                    <ElCheckbox v-for="item in visibleFlowHeaderFilterOptions(flowSourceTypeFilterOptions, 'sourceType')" :key="item.value" :value="item.value">
-                      {{ item.text }}
-                    </ElCheckbox>
-                  </ElCheckboxGroup>
-                  <div v-if="visibleFlowHeaderFilterOptions(flowSourceTypeFilterOptions, 'sourceType').length === 0" class="flow-header-filter-empty">
-                    {{ t('protection.backupsPage.flowFilterNoOptions') }}
-                  </div>
-                  <div class="flow-header-filter-actions">
-                    <ElButton text size="small" @click="clearFlowHeaderFilter('sourceType')">{{ t('protection.backupsPage.flowFilterReset') }}</ElButton>
-                    <ElButton text size="small" type="primary" @click="closeFlowHeaderFilter('sourceType')">{{ t('protection.backupsPage.flowFilterApply') }}</ElButton>
-                  </div>
-                </div>
-              </HflPopover>
-            </span>
-          </template>
-          <template #default="{ row }">
-            <FlowSourceSummaryCell
-              :row="row"
-              :interactive="false"
-              externally-interactive
-            />
-          </template>
-        </el-table-column>
-        <el-table-column
-          :label="t('protection.backupsPage.colConnectionAddress')"
-          :min-width="FLOW_START_BACKUP_TABLE_COL_MIN.connection"
-        >
-          <template #default="{ row }">
-            <FlowSourceConnectionCell :row="row" />
-          </template>
-        </el-table-column>
-        <el-table-column
-          :label="t('protection.sourceResources.colLifecycleStatus')"
-          width="168"
-          align="center"
-          header-align="center"
-        >
-          <template #header>
-            <span class="flow-filterable-header">
-              <span>{{ t('protection.sourceResources.colLifecycleStatus') }}</span>
-              <HflPopover v-if="flowMainStep !== 2" v-model:visible="flowHeaderFilterOpen.sourceStatus" trigger="click" placement="bottom" :width="210" popper-class="flow-header-filter-popper">
-                <template #reference>
-                  <button type="button" class="flow-header-filter-trigger" :class="{ 'flow-header-filter-trigger--active': hasFlowHeaderFilterValue('sourceStatus') }" @click.stop>
-                    <Filter :size="14" />
-                  </button>
-                </template>
-                <div class="flow-header-filter-panel">
-                  <ElInput v-model="flowHeaderFilterSearch.sourceStatus" size="small" clearable :placeholder="t('protection.backupsPage.flowFilterSearchPlaceholder')" />
-                  <ElCheckboxGroup v-model="flowFilterSourceStatuses" class="flow-header-filter-options">
-                    <ElCheckbox v-for="item in visibleFlowHeaderFilterOptions(flowSourceStatusFilterOptions, 'sourceStatus')" :key="item.value" :value="item.value">
-                      {{ item.text }}
-                    </ElCheckbox>
-                  </ElCheckboxGroup>
-                  <div v-if="visibleFlowHeaderFilterOptions(flowSourceStatusFilterOptions, 'sourceStatus').length === 0" class="flow-header-filter-empty">
-                    {{ t('protection.backupsPage.flowFilterNoOptions') }}
-                  </div>
-                  <div class="flow-header-filter-actions">
-                    <ElButton text size="small" @click="clearFlowHeaderFilter('sourceStatus')">{{ t('protection.backupsPage.flowFilterReset') }}</ElButton>
-                    <ElButton text size="small" type="primary" @click="closeFlowHeaderFilter('sourceStatus')">{{ t('protection.backupsPage.flowFilterApply') }}</ElButton>
-                  </div>
-                </div>
-              </HflPopover>
-            </span>
-          </template>
-          <template #default="{ row }">
-            <button
-              v-if="sourceResetState(row.id)"
-              type="button"
-              class="reset-status-cell"
-              :class="`reset-status-cell--${sourceResetState(row.id)}`"
-              :title="t('protection.backupsPage.resetStatusClickHint')"
-              @click.stop="openResetTaskDetail(row)"
+          <button
+            type="button"
+            class="dp-flow-card text-left flex-1"
+            :class="{ 'dp-flow-card--active': flowMainStep === 1 }"
+            :aria-pressed="flowMainStep === 1"
+            @click="enterBackupConfigStep()"
+          >
+            <div
+              class="dp-flow-card__mark"
+              aria-hidden="true"
             >
-              <span class="reset-status-cell__label">{{ sourceResetStatusLabel(row.id) }}</span>
-              <span v-if="sourceResetState(row.id) === 'resetting'" class="reset-status-cell__progress">
-                <span class="reset-status-cell__track">
-                  <span class="reset-status-cell__fill" :style="{ width: `${sourceResetProgress(row.id)}%` }" />
-                </span>
-                <span class="reset-status-cell__percent">{{ sourceResetProgress(row.id) }}%</span>
+              <span class="dp-flow-card__index">02</span>
+              <span class="dp-flow-card__icon">
+                <Database
+                  :size="20"
+                  stroke-width="1.7"
+                />
               </span>
-            </button>
-            <FlowSourceReadyStatusCell
-              v-else
-              v-bind="resolveFlowSourceDisplayStatus(row)"
-              neutral-as-danger
-              @click="openSourcePendingFailureDetails(row.id)"
-            />
-          </template>
-        </el-table-column>
-        <el-table-column
-          :label="t('protection.backupsPage.flowBackupColBackupDirs')"
-          :min-width="FLOW_START_BACKUP_TABLE_COL_MIN.backupDirs"
-        >
-          <template #default="{ row }">
-            <div v-if="sourceConfigDirRows(row.id).length" class="table-stack-list">
-              <HflPopover
-                placement="right-start"
-                trigger="hover"
-                :hide-after="0"
-                :width="420"
-                append-to-body
-              >
-                <template #reference>
-                  <div class="table-stack-list flow-dir-preview-list">
-                    <div
-                      v-for="(dir, index) in sourceDirsPreview(row.id)"
-                      :key="`${row.id}-${dir.configId}-${dir.path}`"
-                      class="source-path-text flow-dir-preview-list__row"
-                      :class="{ 'flow-dir-preview-list__row--has-more': index === 0 && sourceDirsOverflowCount(row.id) > 0 }"
-                    >
-                      <span class="flow-dir-preview-list__path">{{ dir.path }}</span>
-                      <span v-if="index === 0 && sourceDirsOverflowCount(row.id) > 0" class="flow-dir-preview-list__more" aria-hidden="true">
-                        <MoreHorizontal :size="16" />
-                      </span>
-                    </div>
-                  </div>
-                </template>
-                <ul class="m-0 list-none p-0 text-sm text-slate-800 space-y-2">
-                  <li v-for="dir in sourceConfigDirRows(row.id)" :key="`all-${row.id}-${dir.configId}-${dir.path}`">
-                    <code class="flow-source-list-drawer-path">{{ dir.path }}</code>
-                  </li>
-                </ul>
-              </HflPopover>
             </div>
-            <span v-else class="hfl-empty-mark">{{ t('protection.backupDetail.durationDash') }}</span>
-          </template>
-        </el-table-column>
-        <el-table-column :label="t('protection.backupsPage.flowBackupColCurrentTaskStatus')" min-width="228">
-          <template #default="{ row }">
-            <button
-              type="button"
-              class="backup-task-trigger"
-              :disabled="!latestBackupTaskUuidForSource(row.id)"
-              :title="t('protection.backupsPage.backupTaskStatusClickHint')"
-              @click.stop="openLatestBackupTask(row)"
-            >
-              <TaskProgressCell
-                v-if="sourceBackupCellPhase(row.id) === 'running'"
-                :failed="sourceBackupRuntime(row.id).failed"
-                :progress="sourceBackupRuntime(row.id).progress"
-                :transfer-progress="sourceBackupRuntime(row.id).transferProgress"
-              />
-              <TaskProgressCell
-                v-else-if="sourceBackupCellPhase(row.id) === 'stopping'"
-                :progress="sourceBackupRuntime(row.id).progress"
-                :transfer-progress="sourceBackupRuntime(row.id).transferProgress"
-                stopping
-              />
-              <TaskTerminalOutcomeCell
-                v-else
-                :task="latestBackupTaskForSource(row.id)"
-                :fallback="latestSnapshotForSource(row.id)"
-              />
-            </button>
-          </template>
-        </el-table-column>
-        <el-table-column :label="t('protection.backupsPage.flowBackupColRestoreTaskStatus')" min-width="228">
-          <template #default="{ row }">
-            <button
-              type="button"
-              class="backup-task-trigger"
-              :disabled="!latestRestoreTaskForSource(row.id)?.task_uuid && !latestRestoreRecordForSource(row.id)?.task_uuid"
-              :title="t('protection.backupsPage.restoreTaskStatusClickHint')"
-              @click.stop="openLatestRestoreTask(row)"
-            >
-              <TaskProgressCell
-                v-if="sourceRestoreCellPhase(row.id) === 'running'"
-                :failed="sourceRestoreRuntime(row.id).failed"
-                :progress="sourceRestoreRuntime(row.id).progress"
-                :transfer-progress="sourceRestoreRuntime(row.id).transferProgress"
-              />
-              <TaskProgressCell
-                v-else-if="sourceRestoreCellPhase(row.id) === 'stopping'"
-                :progress="sourceRestoreRuntime(row.id).progress"
-                :transfer-progress="sourceRestoreRuntime(row.id).transferProgress"
-                stopping
-              />
-              <TaskTerminalOutcomeCell
-                v-else
-                :task="latestRestoreTaskForSource(row.id)"
-                :fallback="latestRestoreRecordForSource(row.id)?.task_summary"
-              />
-            </button>
-          </template>
-        </el-table-column>
-        <el-table-column
-          :label="t('protection.sourceResources.colConnectivity')"
-          width="110"
-          align="center"
-          header-align="center"
-        >
-          <template #default="{ row }">
-            <div class="hfl-table-no-tooltip">
-              <ElTag :type="flowSourceAvailabilityTagType(row.availability)" size="small">
-                {{ flowSourceAvailabilityLabel(row.availability) }}
-              </ElTag>
-            </div>
-          </template>
-        </el-table-column>
-        <el-table-column
-          :label="t('protection.backupsPage.flowBackupColTargetRepo')"
-          :min-width="FLOW_START_BACKUP_TABLE_COL_MIN.targetRepo"
-        >
-          <template #header>
-            <span class="flow-filterable-header">
-              <span>{{ t('protection.backupsPage.flowBackupColTargetRepo') }}</span>
-              <HflPopover v-if="flowMainStep !== 2" v-model:visible="flowHeaderFilterOpen.repoHealth" trigger="click" placement="bottom" :width="224" popper-class="flow-header-filter-popper">
-                <template #reference>
-                  <button type="button" class="flow-header-filter-trigger" :class="{ 'flow-header-filter-trigger--active': hasFlowHeaderFilterValue('repoHealth') }" @click.stop>
-                    <Filter :size="14" />
-                  </button>
-                </template>
-                <div class="flow-header-filter-panel">
-                  <ElInput v-model="flowHeaderFilterSearch.repoHealth" size="small" clearable :placeholder="t('protection.backupsPage.flowFilterSearchPlaceholder')" />
-                  <ElCheckboxGroup v-model="flowFilterRepoHealth" class="flow-header-filter-options">
-                    <ElCheckbox v-for="item in visibleFlowHeaderFilterOptions(flowRepoHealthFilterOptions, 'repoHealth')" :key="item.value" :value="item.value">
-                      {{ item.text }}
-                    </ElCheckbox>
-                  </ElCheckboxGroup>
-                  <div v-if="visibleFlowHeaderFilterOptions(flowRepoHealthFilterOptions, 'repoHealth').length === 0" class="flow-header-filter-empty">
-                    {{ t('protection.backupsPage.flowFilterNoOptions') }}
-                  </div>
-                  <div class="flow-header-filter-actions">
-                    <ElButton text size="small" @click="clearFlowHeaderFilter('repoHealth')">{{ t('protection.backupsPage.flowFilterReset') }}</ElButton>
-                    <ElButton text size="small" type="primary" @click="closeFlowHeaderFilter('repoHealth')">{{ t('protection.backupsPage.flowFilterApply') }}</ElButton>
-                  </div>
+            <div class="dp-flow-card__body min-w-0 flex-1">
+              <div class="dp-flow-card__header">
+                <div class="dp-flow-card__heading">
+                  <span class="dp-flow-card__title">{{ t('protection.backupsPage.flowStepBackupTitle') }}</span>
                 </div>
-              </HflPopover>
-            </span>
-          </template>
-          <template #default="{ row }">
-            <div v-if="sourceConfigTargetRows(row.id).length" class="table-stack-list">
-              <HflPopover
-                v-for="target in sourceTargetsPreview(row.id)"
-                :key="`${row.id}-target-${target.id}`"
-                class="table-stack-cell flow-target-repository-popover"
-                placement="top-start"
-                trigger="hover"
-                :hide-after="FLOW_DETAIL_POPOVER_HIDE_AFTER_MS"
-                :width="420"
-                :show-after="300"
-                append-to-body
-              >
-                <template #reference>
-                  <div
-                    class="wizard-target-repository-cell hfl-table-no-tooltip"
-                    :class="`wizard-target-repository-cell--${flowTargetTone(target)}`"
-                    :title="target.location ? `${target.name}\n${target.location}` : target.name"
-                  >
-                    <span class="wizard-target-repository-cell__dot" aria-hidden="true"></span>
-                    <div class="wizard-target-repository-cell__body">
-                      <div class="wizard-target-repository-cell__name">{{ target.name }}</div>
-                      <div
-                        v-if="target.location"
-                        class="wizard-target-repository-cell__location hfl-table-cell-mono"
-                      >
-                        {{ target.location }}
-                      </div>
-                    </div>
-                  </div>
-                </template>
-                <TargetRepositoryDetailCard :target="target" :hide-capacity="true" />
-              </HflPopover>
-              <button
-                v-if="sourceTargetsOverflowCount(row.id) > 0"
-                type="button"
-                class="source-more-link"
-                :title="t('protection.backupsPage.flowSourceTargetDrawerOpenHint')"
-                @click.stop="openFlowSourceListDrawer(row, 'targets')"
-              >
-                {{ t('protection.backupsPage.flowSourceTargetOverflow', { n: sourceTargetsOverflowCount(row.id) }) }}
-              </button>
-            </div>
-            <span v-else class="hfl-empty-mark">{{ t('protection.backupDetail.durationDash') }}</span>
-          </template>
-        </el-table-column>
-        <el-table-column
-          :label="t('protection.backupsPage.labelCompressionStrategy')"
-          :min-width="FLOW_START_BACKUP_TABLE_COL_MIN.compression"
-        >
-          <template #default="{ row }">
-            <HflPopover
-              v-if="sourceCompressionLabel(row.id)"
-              trigger="hover"
-              placement="bottom-start"
-              :width="288"
-              :fallback-placements="['bottom-start', 'bottom-end']"
-              popper-class="flow-compression-popper"
-            >
-              <template #reference>
-                <span class="flow-compression-cell hfl-table-no-tooltip">
-                  <component
-                    :is="compressionLevelIcon(sourceCompressionLevel(row.id) ?? 'balanced')"
-                    :size="15"
-                    aria-hidden="true"
-                    class="flow-compression-cell__icon"
-                    :class="`flow-compression-cell__icon--${sourceCompressionLevel(row.id) ?? 'balanced'}`"
+                <span
+                  class="dp-flow-card__pill"
+                  :class="{ 'dp-flow-card__pill--idle': flowMainStep !== 1 }"
+                >
+                  <Check
+                    v-if="flowMainStep === 1"
+                    :size="12"
+                    stroke-width="3"
                   />
-                  <span class="flow-compression-cell__label">{{ sourceCompressionLabel(row.id) }}</span>
+                  {{ flowMainStep === 1
+                    ? t('protection.backupsPage.flowStepBadgeCurrent')
+                    : t('protection.backupsPage.flowStepBadgeSwitch') }}
                 </span>
-              </template>
-              <div class="flow-compression-popover">
-                <div class="flow-compression-popover__title">
-                  <component
-                    :is="compressionLevelIcon(sourceCompressionLevel(row.id) ?? 'balanced')"
-                    :size="17"
-                    aria-hidden="true"
-                    class="flow-compression-popover__icon"
-                    :class="`flow-compression-popover__icon--${sourceCompressionLevel(row.id) ?? 'balanced'}`"
-                  />
-                  <span>{{ sourceCompressionLabel(row.id) }}</span>
+              </div>
+              <p class="dp-flow-card__desc">
+                {{ t('protection.backupsPage.flowStepBackupDesc') }}
+              </p>
+              <div class="dp-flow-card__meta">
+                <span
+                  class="dp-flow-card__meta-dot"
+                  aria-hidden="true"
+                />
+                <span class="dp-flow-card__meta-text">
+                  {{ t('protection.backupsPage.flowStepBackupMetricPending', { n: step2PendingCount }) }}
+                </span>
+              </div>
+            </div>
+          </button>
+
+          <div
+            class="dp-flow-steps-connector"
+            aria-hidden="true"
+          >
+            <ChevronsRight
+              :size="22"
+              stroke-width="2"
+              class="dp-flow-steps-connector__icon"
+            />
+          </div>
+
+          <button
+            type="button"
+            class="dp-flow-card text-left flex-1"
+            :class="{ 'dp-flow-card--active': flowMainStep === 2 }"
+            :aria-pressed="flowMainStep === 2"
+            @click="enterStartBackupStep({ requireReady: true })"
+          >
+            <div
+              class="dp-flow-card__mark"
+              aria-hidden="true"
+            >
+              <span class="dp-flow-card__index">03</span>
+              <span class="dp-flow-card__icon">
+                <CloudUpload
+                  :size="20"
+                  stroke-width="1.7"
+                />
+              </span>
+            </div>
+            <div class="dp-flow-card__body min-w-0 flex-1">
+              <div class="dp-flow-card__header">
+                <div class="dp-flow-card__heading">
+                  <span class="dp-flow-card__title">{{ t('protection.backupsPage.flowStepRestoreTitle') }}</span>
                 </div>
-                <div class="flow-compression-popover__body">
-                  {{ compressionLevelTooltip(sourceCompressionLevel(row.id) ?? 'balanced') }}
+                <span
+                  class="dp-flow-card__pill"
+                  :class="{ 'dp-flow-card__pill--idle': flowMainStep !== 2 }"
+                >
+                  <Check
+                    v-if="flowMainStep === 2"
+                    :size="12"
+                    stroke-width="3"
+                  />
+                  {{ flowMainStep === 2
+                    ? t('protection.backupsPage.flowStepBadgeCurrent')
+                    : t('protection.backupsPage.flowStepBadgeSwitch') }}
+                </span>
+              </div>
+              <p class="dp-flow-card__desc">
+                {{ t('protection.backupsPage.flowStepRestoreDesc') }}
+              </p>
+              <div class="dp-flow-card__meta">
+                <span
+                  class="dp-flow-card__meta-dot"
+                  aria-hidden="true"
+                />
+                <span class="dp-flow-card__meta-text">
+                  {{ t('protection.backupsPage.flowStepRestoreMetric', { n: step3SelectableCount }) }}
+                </span>
+              </div>
+            </div>
+          </button>
+        </div>
+
+        <div class="hfl-list-shell protection-flow-list-shell">
+          <div class="hfl-list-panel protection-flow-list-panel">
+            <div
+              ref="flowToolbarRef"
+              class="hfl-list-toolbar hfl-list-toolbar--mobile-primary-utility protection-flow-toolbar"
+            >
+              <div class="hfl-list-toolbar__primary">
+                <template v-if="flowMainStep === 0">
+                  <ElButton
+                    type="primary"
+                    :title="t('protection.backupsPage.btnAddBackupSourceDesc')"
+                    @click="onAddBackupSource"
+                  >
+                    <Plus :size="16" />
+                    {{ t('protection.backupsPage.btnAddBackupSource') }}
+                  </ElButton>
+                  <ElButton
+                    type="primary"
+                    :disabled="selectedSourceIds.length === 0 || flowAdvancingToBackupConfig"
+                    :loading="flowAdvancingToBackupConfig"
+                    @click="onGoToStep2"
+                  >
+                    <ArrowRight
+                      :size="16"
+                      class="shrink-0"
+                    />
+                    {{ t('protection.backupsPage.btnNext') }}
+                  </ElButton>
+                  <ElDropdown
+                    trigger="click"
+                    popper-class="hfl-actions-dropdown"
+                    @visible-change="moreActionsOpen = $event"
+                  >
+                    <ElButton>
+                      {{ t('protection.backupsPage.flowMoreActions') }}
+                      <ChevronDown
+                        :size="16"
+                        class="hfl-list-more__chev"
+                        :class="{ 'hfl-list-more__chev--open': moreActionsOpen }"
+                      />
+                    </ElButton>
+                    <template #dropdown>
+                      <ElDropdownMenu>
+                        <ElDropdownItem
+                          :disabled="!step1DisplayNameEditEnabled"
+                          @click="openStep1DisplayNameEditor"
+                        >
+                          <span class="el-dropdown-menu__item-content">
+                            <Pencil
+                              :size="14"
+                              class="shrink-0"
+                            />
+                            <span>{{ t('protection.backupsPage.flowActionEditDisplayName') }}</span>
+                          </span>
+                        </ElDropdownItem>
+                        <ElDropdownItem
+                          divided
+                          class="el-dropdown-menu__item--danger"
+                          :disabled="!step1UnregisterEnabled"
+                          @click="deleteSelectedSourcesFromStep1"
+                        >
+                          <span class="hfl-dropdown-item-row hfl-dropdown-item-row--danger">
+                            <Trash2
+                              :size="14"
+                              class="shrink-0"
+                            />
+                            <span>{{ t('protection.backupsPage.flowActionDelete') }}</span>
+                          </span>
+                        </ElDropdownItem>
+                      </ElDropdownMenu>
+                    </template>
+                  </ElDropdown>
+                </template>
+                <template v-else-if="flowMainStep === 1">
+                  <ElButton
+                    type="primary"
+                    class="hfl-btn-with-icon"
+                    :disabled="!step2ToolbarActionsEnabled || setupDrOpening"
+                    :loading="setupDrOpening"
+                    @click="onGoToCreateBackup"
+                  >
+                    <Database
+                      :size="16"
+                      class="shrink-0"
+                    />
+                    {{ t('protection.backupsPage.btnCreateBackup') }}
+                  </ElButton>
+                  <ElDropdown
+                    trigger="click"
+                    popper-class="hfl-actions-dropdown"
+                    @visible-change="moreActionsOpen = $event"
+                  >
+                    <ElButton>
+                      {{ t('protection.backupsPage.flowMoreActions') }}
+                      <ChevronDown
+                        :size="16"
+                        class="hfl-list-more__chev"
+                        :class="{ 'hfl-list-more__chev--open': moreActionsOpen }"
+                      />
+                    </ElButton>
+                    <template #dropdown>
+                      <ElDropdownMenu>
+                        <ElDropdownItem
+                          :disabled="!step2DisplayNameEditEnabled"
+                          @click="openStep2DisplayNameEditor"
+                        >
+                          <span class="el-dropdown-menu__item-content">
+                            <Pencil
+                              :size="14"
+                              class="shrink-0"
+                            />
+                            <span>{{ t('protection.backupsPage.flowActionEditDisplayName') }}</span>
+                          </span>
+                        </ElDropdownItem>
+                        <ElDropdownItem
+                          divided
+                          class="el-dropdown-menu__item--danger"
+                          :disabled="!step2UnregisterEnabled"
+                          @click="deleteSelectedSourcesFromStep2"
+                        >
+                          <span class="hfl-dropdown-item-row hfl-dropdown-item-row--danger">
+                            <Trash2
+                              :size="14"
+                              class="shrink-0"
+                            />
+                            <span>{{ t('protection.backupsPage.flowActionDelete') }}</span>
+                          </span>
+                        </ElDropdownItem>
+                      </ElDropdownMenu>
+                    </template>
+                  </ElDropdown>
+                </template>
+                <template v-else>
+                  <ElTooltip
+                    :content="t('protection.backupsPage.btnStartBackupCloudHint')"
+                    placement="bottom"
+                    :show-after="300"
+                    :hide-after="0"
+                  >
+                    <span class="dp-flow-step3-action-tooltip">
+                      <ElButton
+                        type="primary"
+                        plain
+                        class="hfl-btn-with-icon dp-flow-step3-action-btn shrink-0"
+                        :disabled="!step3SourceActionsEnabled || startBackupSubmitting || step3StopActionBusy"
+                        :loading="startBackupSubmitting"
+                        @click="startSelectedBackupTasks"
+                      >
+                        <CloudUpload
+                          :size="16"
+                          class="shrink-0"
+                        />
+                        {{ t('protection.backupsPage.btnStartBackup') }}
+                      </ElButton>
+                    </span>
+                  </ElTooltip>
+                  <ElButton
+                    type="primary"
+                    class="hfl-btn-with-icon dp-flow-step3-action-btn shrink-0"
+                    :disabled="!recoveryToolbarEnabled || recoveryOpening || step3StopActionBusy"
+                    :loading="recoveryOpening"
+                    @click="openRecovery"
+                  >
+                    <ArchiveRestore
+                      :size="16"
+                      class="shrink-0"
+                    />
+                    {{ t('protection.backupsPage.btnRecover') }}
+                  </ElButton>
+                  <ElDropdown
+                    trigger="click"
+                    popper-class="hfl-actions-dropdown"
+                    @visible-change="moreActionsOpen = $event"
+                  >
+                    <ElButton>
+                      {{ t('protection.backupsPage.flowMoreActions') }}
+                      <ChevronDown
+                        :size="16"
+                        class="hfl-list-more__chev"
+                        :class="{ 'hfl-list-more__chev--open': moreActionsOpen }"
+                      />
+                    </ElButton>
+                    <template #dropdown>
+                      <ElDropdownMenu>
+                        <ElDropdownItem
+                          :disabled="!step3DisplayNameEditEnabled"
+                          @click="openStep3DisplayNameEditor"
+                        >
+                          <span class="el-dropdown-menu__item-content">
+                            <Pencil
+                              :size="14"
+                              class="shrink-0"
+                            />
+                            <span>{{ t('protection.backupsPage.flowActionEditDisplayName') }}</span>
+                          </span>
+                        </ElDropdownItem>
+                        <ElDropdownItem
+                          divided
+                          :disabled="!step3SelectionEditable"
+                          @click="openBackupConfigEditFromStep3('paths')"
+                        >
+                          <span class="el-dropdown-menu__item-content">
+                            <FolderTree
+                              :size="14"
+                              class="shrink-0"
+                            />
+                            <span>{{ t('protection.backupsPage.flowActionEditBackupPaths') }}</span>
+                          </span>
+                        </ElDropdownItem>
+                        <ElDropdownItem
+                          :disabled="!step3SelectionEditable"
+                          @click="openBackupConfigEditFromStep3('policy')"
+                        >
+                          <span class="el-dropdown-menu__item-content">
+                            <ClipboardCheck
+                              :size="14"
+                              class="shrink-0"
+                            />
+                            <span>{{ t('protection.backupsPage.flowActionEditBackupPolicy') }}</span>
+                          </span>
+                        </ElDropdownItem>
+                        <ElDropdownItem
+                          :disabled="!step3SelectionEditable"
+                          @click="openBackupConfigEditFromStep3('recovery')"
+                        >
+                          <span class="el-dropdown-menu__item-content">
+                            <Route
+                              :size="14"
+                              class="shrink-0"
+                            />
+                            <span>{{ t('protection.backupsPage.flowActionEditRestorePlan') }}</span>
+                          </span>
+                        </ElDropdownItem>
+                        <ElDropdownItem
+                          divided
+                          :disabled="!step3CanStopBackup || step3StopActionBusy"
+                          @click="openStopBackupConfirmDialog"
+                        >
+                          <span class="el-dropdown-menu__item-content">
+                            <CircleStop
+                              :size="14"
+                              class="shrink-0"
+                            />
+                            <span>{{ t('protection.backupsPage.flowActionStopBackup') }}</span>
+                          </span>
+                        </ElDropdownItem>
+                        <ElDropdownItem
+                          :disabled="!step3CanStopRestore || step3StopActionBusy"
+                          @click="openStopRestoreConfirmDialog"
+                        >
+                          <span class="el-dropdown-menu__item-content">
+                            <CircleStop
+                              :size="14"
+                              class="shrink-0"
+                            />
+                            <span>{{ t('protection.backupsPage.flowActionStopRestore') }}</span>
+                          </span>
+                        </ElDropdownItem>
+                        <ElDropdownItem
+                          divided
+                          :disabled="!step3SelectionEditable"
+                          @click="revertSelectedSourcesFromStep3"
+                        >
+                          <span class="el-dropdown-menu__item-content">
+                            <Undo2
+                              :size="14"
+                              class="shrink-0"
+                            />
+                            <span>{{ t('protection.backupsPage.actionResetBackupConfig') }}</span>
+                          </span>
+                        </ElDropdownItem>
+                        <ElDropdownItem
+                          class="el-dropdown-menu__item--danger"
+                          :disabled="!step3UnregisterEnabled"
+                          @click="deleteSelectedSourcesFromStep3"
+                        >
+                          <span class="hfl-dropdown-item-row hfl-dropdown-item-row--danger">
+                            <Trash2
+                              :size="14"
+                              class="shrink-0"
+                            />
+                            <span>{{ t('protection.backupsPage.flowActionDelete') }}</span>
+                          </span>
+                        </ElDropdownItem>
+                      </ElDropdownMenu>
+                    </template>
+                  </ElDropdown>
+                </template>
+              </div>
+              <div class="hfl-list-toolbar__right hfl-list-toolbar__right--mobile-split">
+                <ElInput
+                  v-model="taskSearchQuery"
+                  clearable
+                  size="small"
+                  :placeholder="t('protection.backupsPage.step3SearchPlaceholder')"
+                  class="hfl-list-search hfl-list-search-group"
+                  @keyup.enter="applyTaskSearchImmediately"
+                  @clear="applyTaskSearchImmediately"
+                >
+                  <template #prepend>
+                    <ElSelect
+                      v-model="step3SearchField"
+                      @change="onStep3SearchFieldChange"
+                    >
+                      <ElOption
+                        v-for="item in step3SearchFieldOptions"
+                        :key="item.value"
+                        :label="item.label"
+                        :value="item.value"
+                      />
+                    </ElSelect>
+                  </template>
+                </ElInput>
+                <ElSelect
+                  v-if="flowMainStep === 2"
+                  v-model="step3BackupTaskStatus"
+                  clearable
+                  size="small"
+                  :placeholder="t('protection.backupsPage.step3BackupTask')"
+                  style="width: 130px"
+                >
+                  <ElOption
+                    v-for="item in step3BackupTaskStatusOptions"
+                    :key="item.value"
+                    :label="item.label"
+                    :value="item.value"
+                  />
+                </ElSelect>
+                <ElSelect
+                  v-if="flowMainStep === 2"
+                  v-model="step3RestoreTaskStatus"
+                  clearable
+                  size="small"
+                  :placeholder="t('protection.backupsPage.step3RestoreTask')"
+                  style="width: 150px"
+                >
+                  <ElOption
+                    v-for="item in step3RestoreTaskStatusOptions"
+                    :key="item.value"
+                    :label="item.label"
+                    :value="item.value"
+                  />
+                </ElSelect>
+                <ElSelect
+                  v-if="flowMainStep !== 2"
+                  v-model="step3Availability"
+                  clearable
+                  size="small"
+                  :placeholder="t('protection.backupsPage.step3Availability')"
+                  style="width: 130px"
+                >
+                  <ElOption
+                    v-for="item in step3AvailabilityOptions"
+                    :key="item.value"
+                    :label="item.label"
+                    :value="item.value"
+                  />
+                </ElSelect>
+                <ElSelect
+                  v-if="flowMainStep === 2"
+                  v-model="step3Availability"
+                  clearable
+                  size="small"
+                  :placeholder="t('protection.backupsPage.step3Availability')"
+                  style="width: 130px"
+                >
+                  <ElOption
+                    v-for="item in step3AvailabilityOptions"
+                    :key="item.value"
+                    :label="item.label"
+                    :value="item.value"
+                  />
+                </ElSelect>
+                <div class="hfl-list-toolbar__utility">
+                  <ElButton
+                    :title="t('protection.backupsPage.flowFilterAdvanced')"
+                    class="hfl-filter-button"
+                    :class="{ 'hfl-filter-button--active': flowActiveFilterCount > 0 }"
+                    :aria-label="t('protection.backupsPage.flowFilterAdvanced')"
+                    @click="openAdvancedFilters"
+                  >
+                    <ElBadge
+                      v-if="flowActiveFilterCount > 0"
+                      :value="flowActiveFilterCount"
+                      :max="9"
+                      class="hfl-filter-badge"
+                    >
+                      <Filter :size="16" />
+                    </ElBadge>
+                    <Filter
+                      v-else
+                      :size="16"
+                    />
+                  </ElButton>
+                  <ElButton
+                    class="hfl-refresh-button"
+                    :title="t('protection.backupsPage.flowActionRefreshList')"
+                    :aria-label="t('protection.backupsPage.flowActionRefreshList')"
+                    :disabled="flowRefreshing"
+                    @click="refreshTaskLists"
+                  >
+                    <RefreshCw
+                      :size="16"
+                      :class="{ 'is-spinning': flowRefreshing }"
+                    />
+                  </ElButton>
                 </div>
               </div>
-            </HflPopover>
-            <span v-else class="hfl-empty-mark">{{ t('protection.backupDetail.durationDash') }}</span>
-          </template>
-        </el-table-column>
-        <el-table-column
-          :label="t('protection.backupsPage.flowBackupColBoundBackupPolicy')"
-          :min-width="FLOW_START_BACKUP_TABLE_COL_MIN.binding"
-        >
-          <template #header>
-            <span class="flow-filterable-header">
-              <span>{{ t('protection.backupsPage.flowBackupColBoundBackupPolicy') }}</span>
-              <HflPopover v-if="flowMainStep !== 2" v-model:visible="flowHeaderFilterOpen.policyBinding" trigger="click" placement="bottom" :width="210" popper-class="flow-header-filter-popper">
-                <template #reference>
-                  <button type="button" class="flow-header-filter-trigger" :class="{ 'flow-header-filter-trigger--active': hasFlowHeaderFilterValue('policyBinding') }" @click.stop>
-                    <Filter :size="14" />
-                  </button>
-                </template>
-                <div class="flow-header-filter-panel">
-                  <ElInput v-model="flowHeaderFilterSearch.policyBinding" size="small" clearable :placeholder="t('protection.backupsPage.flowFilterSearchPlaceholder')" />
-                  <ElCheckboxGroup v-model="flowFilterPolicyBinding" class="flow-header-filter-options">
-                    <ElCheckbox v-for="item in visibleFlowHeaderFilterOptions(flowBindingFilterOptions, 'policyBinding')" :key="item.value" :value="item.value">
-                      {{ item.text }}
-                    </ElCheckbox>
-                  </ElCheckboxGroup>
-                  <div v-if="visibleFlowHeaderFilterOptions(flowBindingFilterOptions, 'policyBinding').length === 0" class="flow-header-filter-empty">
-                    {{ t('protection.backupsPage.flowFilterNoOptions') }}
-                  </div>
-                  <div class="flow-header-filter-actions">
-                    <ElButton text size="small" @click="clearFlowHeaderFilter('policyBinding')">{{ t('protection.backupsPage.flowFilterReset') }}</ElButton>
-                    <ElButton text size="small" type="primary" @click="closeFlowHeaderFilter('policyBinding')">{{ t('protection.backupsPage.flowFilterApply') }}</ElButton>
+            </div>
+
+            <div
+              ref="flowTableZoneRef"
+              class="protection-flow-table-zone"
+            >
+              <div
+                v-if="flowMainStep === 0"
+                class="protection-flow-panel protection-flow-panel--fill"
+              >
+                <div class="protection-flow-table-block">
+                  <el-table
+                    ref="sourceTableRef"
+                    v-table-overflow-title
+                    v-table-header-scroll-sync
+                    v-table-column-resize="'protection.dataProtection.sources'"
+                    v-loading="backupSelectableLoading"
+                    class="hfl-list-table source-table--flow-pick"
+                    :data="filteredBackupSelectableRows"
+                    stripe
+                    row-key="id"
+                    :max-height="flowTableMaxHeight"
+                    :header-cell-style="TABLE_HEADER_STYLE"
+                    @selection-change="onSourceSelectionChange"
+                    @cell-click="onFlowSourceCellClick"
+                  >
+                    <el-table-column
+                      type="selection"
+                      width="35"
+                      fixed="left"
+                      reserve-selection
+                      :selectable="flowSourceRowSelectable"
+                    />
+                    <el-table-column
+                      fixed="left"
+                      column-key="backup-source"
+                      :label="t('protection.backupsPage.colBackupSource')"
+                      :min-width="FLOW_PICK_TABLE_COL_MIN.source"
+                    >
+                      <template #default="{ row }">
+                        <FlowSourceSummaryCell
+                          :row="row"
+                          :interactive="false"
+                          externally-interactive
+                        />
+                      </template>
+                    </el-table-column>
+                    <el-table-column
+                      :label="t('protection.backupsPage.colConnectionAddress')"
+                      :min-width="FLOW_PICK_TABLE_COL_MIN.connection"
+                    >
+                      <template #default="{ row }">
+                        <FlowSourceConnectionCell :row="row" />
+                      </template>
+                    </el-table-column>
+                    <el-table-column
+                      :label="t('protection.sourceResources.colLifecycleStatus')"
+                      width="168"
+                      align="center"
+                      header-align="center"
+                    >
+                      <template #header>
+                        <span class="flow-filterable-header">
+                          <span>{{ t('protection.sourceResources.colLifecycleStatus') }}</span>
+                          <HflPopover
+                            v-if="flowMainStep !== 2"
+                            v-model:visible="flowHeaderFilterOpen.sourceStatus"
+                            trigger="click"
+                            placement="bottom"
+                            :width="210"
+                            popper-class="flow-header-filter-popper"
+                          >
+                            <template #reference>
+                              <button
+                                type="button"
+                                class="flow-header-filter-trigger"
+                                :class="{ 'flow-header-filter-trigger--active': hasFlowHeaderFilterValue('sourceStatus') }"
+                                @click.stop
+                              >
+                                <Filter :size="14" />
+                              </button>
+                            </template>
+                            <div class="flow-header-filter-panel">
+                              <ElInput
+                                v-model="flowHeaderFilterSearch.sourceStatus"
+                                size="small"
+                                clearable
+                                :placeholder="t('protection.backupsPage.flowFilterSearchPlaceholder')"
+                              />
+                              <ElCheckboxGroup
+                                v-model="flowFilterSourceStatuses"
+                                class="flow-header-filter-options"
+                              >
+                                <ElCheckbox
+                                  v-for="item in visibleFlowHeaderFilterOptions(flowSourceStatusFilterOptions, 'sourceStatus')"
+                                  :key="item.value"
+                                  :value="item.value"
+                                >
+                                  {{ item.text }}
+                                </ElCheckbox>
+                              </ElCheckboxGroup>
+                              <div
+                                v-if="visibleFlowHeaderFilterOptions(flowSourceStatusFilterOptions, 'sourceStatus').length === 0"
+                                class="flow-header-filter-empty"
+                              >
+                                {{ t('protection.backupsPage.flowFilterNoOptions') }}
+                              </div>
+                              <div class="flow-header-filter-actions">
+                                <ElButton
+                                  text
+                                  size="small"
+                                  @click="clearFlowHeaderFilter('sourceStatus')"
+                                >{{ t('protection.backupsPage.flowFilterReset') }}</ElButton>
+                                <ElButton
+                                  text
+                                  size="small"
+                                  type="primary"
+                                  @click="closeFlowHeaderFilter('sourceStatus')"
+                                >{{ t('protection.backupsPage.flowFilterApply') }}</ElButton>
+                              </div>
+                            </div>
+                          </HflPopover>
+                        </span>
+                      </template>
+                      <template #default="{ row }">
+                        <FlowSourceReadyStatusCell
+                          v-bind="resolveFlowSourceDisplayStatus(row)"
+                          neutral-as-danger
+                          @click="openSourcePendingFailureDetails(row.id)"
+                        />
+                      </template>
+                    </el-table-column>
+                    <el-table-column
+                      :label="t('protection.sourceResources.colCpu')"
+                      :min-width="FLOW_PICK_TABLE_COL_MIN.cpu"
+                    >
+                      <template #default="{ row }">
+                        <span>{{
+                          flowSourceCpuCores(row) != null
+                            ? t('protection.sourceResources.cpuCoresValue', { n: flowSourceCpuCores(row) })
+                            : '—'
+                        }}</span>
+                      </template>
+                    </el-table-column>
+                    <el-table-column
+                      :label="t('protection.sourceResources.colMemory')"
+                      :min-width="FLOW_PICK_TABLE_COL_MIN.memory"
+                    >
+                      <template #default="{ row }">
+                        <span>{{ flowSourceMemoryText(row) }}</span>
+                      </template>
+                    </el-table-column>
+                    <el-table-column
+                      :label="t('protection.sourceResources.colDiskCount')"
+                      :min-width="FLOW_PICK_TABLE_COL_MIN.diskCount"
+                    >
+                      <template #default="{ row }">
+                        <span>{{ flowSourceDiskCountText(row) }}</span>
+                      </template>
+                    </el-table-column>
+                    <el-table-column
+                      :label="t('protection.sourceResources.colConnectivity')"
+                      width="110"
+                      align="center"
+                      header-align="center"
+                    >
+                      <template #default="{ row }">
+                        <div class="hfl-table-no-tooltip">
+                          <ElTag
+                            :type="flowSourceAvailabilityTagType(row.availability)"
+                            size="small"
+                          >
+                            {{ flowSourceAvailabilityLabel(row.availability) }}
+                          </ElTag>
+                        </div>
+                      </template>
+                    </el-table-column>
+                    <el-table-column
+                      :label="t('protection.sourceResources.colRegisteredAt')"
+                      width="154"
+                    >
+                      <template #default="{ row }">
+                        <span
+                          class="hfl-table-cell-time"
+                          :class="{ 'hfl-empty-mark': !row.registeredAt }"
+                        >{{ flowSourceRegisteredAt(row.registeredAt) }}</span>
+                      </template>
+                    </el-table-column>
+                    <template #empty>
+                      <el-empty :image-size="72">
+                        <template #description>
+                          <p>
+                            {{ t('protection.backupsPage.flowTaskEmptySourcePrefix') }}
+                            <strong>{{ t('protection.backupsPage.flowTaskEmptySourceAction') }}</strong>
+                            {{ t('protection.backupsPage.flowTaskEmptySourceSuffix') }}
+                          </p>
+                        </template>
+                      </el-empty>
+                    </template>
+                  </el-table>
+                  <div class="hfl-list-footer">
+                    <span
+                      v-if="selectedSourceIds.length > 0"
+                      class="hfl-list-footer__selected"
+                    >
+                      {{ t('protection.sourceResources.selectedCount', { n: selectedSourceIds.length }) }}
+                    </span>
+                    <HflPagination
+                      v-model:current-page="flowStep0Pager.page"
+                      v-model:page-size="flowStep0Pager.pageSize"
+                      class="hfl-list-footer__pagination"
+                      :total="flowStep0DisplayTotal"
+                    />
                   </div>
                 </div>
-              </HflPopover>
-            </span>
-          </template>
-          <template #default="{ row }">
-            <template v-if="sourcePoliciesLabel(row.id)">
-              <HflPopover placement="right-start" trigger="hover" :hide-after="FLOW_DETAIL_POPOVER_HIDE_AFTER_MS" :width="420" append-to-body popper-class="create-policy-option-popper flow-binding-detail-popper">
-                <template #reference>
-                  <span class="flow-binding-list hfl-table-no-tooltip">
-                    <span
-                      v-for="policy in sourceBoundPolicyRows(row.id)"
-                      :key="policy.id"
-                      class="flow-binding-list-item"
-                    >
-                      <span :class="flowBindingStatusDotClass(policy.isActive)" aria-hidden="true" />
-                      <span class="flow-binding-list-item__name">{{ policy.name }}</span>
-                    </span>
-                  </span>
-                </template>
-                <div class="create-confirm-binding-popover-stack">
-                  <div
-                    v-for="policy in sourceBoundPolicyRows(row.id)"
-                    :key="policy.id"
-                    class="create-policy-detail-popover"
+              </div>
+
+              <div
+                v-if="flowMainStep === 1"
+                class="protection-flow-panel protection-flow-panel--fill"
+              >
+                <div class="protection-flow-table-block">
+                  <el-table
+                    ref="step2TableRef"
+                    v-table-overflow-title
+                    v-table-header-scroll-sync
+                    v-table-column-resize="'protection.dataProtection.configurations'"
+                    v-loading="flowStepDataLoading[1]"
+                    class="hfl-list-table source-table--flow-pick"
+                    :data="paginatedStep2SourceList"
+                    stripe
+                    row-key="id"
+                    :max-height="flowTableMaxHeight"
+                    :header-cell-style="TABLE_HEADER_STYLE"
+                    @selection-change="onStep2SelectionChange"
+                    @cell-click="onFlowSourceCellClick"
                   >
-                    <div class="create-policy-detail-popover__head">
-                      <div class="create-policy-detail-popover__title">{{ policy.name }}</div>
-                      <span :class="flowBindingStatePillClass(policy.isActive)">
-                        {{ flowBindingStateLabel(policy.isActive) }}
-                      </span>
-                    </div>
-                    <div class="create-policy-detail-popover__sections">
-                      <section
-                        v-for="detailRow in policy.detailRows"
-                        :key="detailRow.label"
-                        class="create-policy-detail-popover__section create-policy-detail-popover__section--line"
-                      >
-                        <span class="create-policy-detail-popover__section-title">{{ detailRow.label }}:</span>
-                        <span class="create-policy-detail-popover__value">{{ detailRow.value }}</span>
-                      </section>
-                      <section class="create-policy-detail-popover__section">
-                        <div class="create-policy-detail-popover__section-title">
-                          {{ t('protection.policiesPage.fieldRetention') }}:
+                    <el-table-column
+                      type="selection"
+                      width="35"
+                      fixed="left"
+                      reserve-selection
+                      :selectable="flowSourceRowSelectable"
+                    />
+                    <el-table-column
+                      fixed="left"
+                      column-key="backup-source"
+                      :label="t('protection.backupsPage.colBackupSource')"
+                      :min-width="FLOW_PICK_TABLE_COL_MIN.source"
+                    >
+                      <template #default="{ row }">
+                        <FlowSourceSummaryCell
+                          :row="row"
+                          :interactive="false"
+                          externally-interactive
+                        />
+                      </template>
+                    </el-table-column>
+                    <el-table-column
+                      :label="t('protection.backupsPage.colConnectionAddress')"
+                      :min-width="FLOW_PICK_TABLE_COL_MIN.connection"
+                    >
+                      <template #default="{ row }">
+                        <FlowSourceConnectionCell :row="row" />
+                      </template>
+                    </el-table-column>
+                    <el-table-column
+                      :label="t('protection.sourceResources.colLifecycleStatus')"
+                      width="168"
+                      align="center"
+                      header-align="center"
+                    >
+                      <template #header>
+                        <span class="flow-filterable-header">
+                          <span>{{ t('protection.sourceResources.colLifecycleStatus') }}</span>
+                          <HflPopover
+                            v-if="flowMainStep !== 2"
+                            v-model:visible="flowHeaderFilterOpen.sourceStatus"
+                            trigger="click"
+                            placement="bottom"
+                            :width="210"
+                            popper-class="flow-header-filter-popper"
+                          >
+                            <template #reference>
+                              <button
+                                type="button"
+                                class="flow-header-filter-trigger"
+                                :class="{ 'flow-header-filter-trigger--active': hasFlowHeaderFilterValue('sourceStatus') }"
+                                @click.stop
+                              >
+                                <Filter :size="14" />
+                              </button>
+                            </template>
+                            <div class="flow-header-filter-panel">
+                              <ElInput
+                                v-model="flowHeaderFilterSearch.sourceStatus"
+                                size="small"
+                                clearable
+                                :placeholder="t('protection.backupsPage.flowFilterSearchPlaceholder')"
+                              />
+                              <ElCheckboxGroup
+                                v-model="flowFilterSourceStatuses"
+                                class="flow-header-filter-options"
+                              >
+                                <ElCheckbox
+                                  v-for="item in visibleFlowHeaderFilterOptions(flowSourceStatusFilterOptions, 'sourceStatus')"
+                                  :key="item.value"
+                                  :value="item.value"
+                                >
+                                  {{ item.text }}
+                                </ElCheckbox>
+                              </ElCheckboxGroup>
+                              <div
+                                v-if="visibleFlowHeaderFilterOptions(flowSourceStatusFilterOptions, 'sourceStatus').length === 0"
+                                class="flow-header-filter-empty"
+                              >
+                                {{ t('protection.backupsPage.flowFilterNoOptions') }}
+                              </div>
+                              <div class="flow-header-filter-actions">
+                                <ElButton
+                                  text
+                                  size="small"
+                                  @click="clearFlowHeaderFilter('sourceStatus')"
+                                >{{ t('protection.backupsPage.flowFilterReset') }}</ElButton>
+                                <ElButton
+                                  text
+                                  size="small"
+                                  type="primary"
+                                  @click="closeFlowHeaderFilter('sourceStatus')"
+                                >{{ t('protection.backupsPage.flowFilterApply') }}</ElButton>
+                              </div>
+                            </div>
+                          </HflPopover>
+                        </span>
+                      </template>
+                      <template #default="{ row }">
+                        <FlowSourceReadyStatusCell
+                          v-bind="resolveFlowSourceDisplayStatus(row)"
+                          neutral-as-danger
+                          @click="openSourcePendingFailureDetails(row.id)"
+                        />
+                      </template>
+                    </el-table-column>
+                    <el-table-column
+                      :label="t('protection.sourceResources.colCpu')"
+                      :min-width="FLOW_PICK_TABLE_COL_MIN.cpu"
+                    >
+                      <template #default="{ row }">
+                        <span>{{
+                          flowSourceCpuCores(row) != null
+                            ? t('protection.sourceResources.cpuCoresValue', { n: flowSourceCpuCores(row) })
+                            : '—'
+                        }}</span>
+                      </template>
+                    </el-table-column>
+                    <el-table-column
+                      :label="t('protection.sourceResources.colMemory')"
+                      :min-width="FLOW_PICK_TABLE_COL_MIN.memory"
+                    >
+                      <template #default="{ row }">
+                        <span>{{ flowSourceMemoryText(row) }}</span>
+                      </template>
+                    </el-table-column>
+                    <el-table-column
+                      :label="t('protection.sourceResources.colDiskCount')"
+                      :min-width="FLOW_PICK_TABLE_COL_MIN.diskCount"
+                    >
+                      <template #default="{ row }">
+                        <span>{{ flowSourceDiskCountText(row) }}</span>
+                      </template>
+                    </el-table-column>
+                    <el-table-column
+                      :label="t('protection.sourceResources.colConnectivity')"
+                      width="110"
+                      align="center"
+                      header-align="center"
+                    >
+                      <template #default="{ row }">
+                        <div class="hfl-table-no-tooltip">
+                          <ElTag
+                            :type="flowSourceAvailabilityTagType(row.availability)"
+                            size="small"
+                          >
+                            {{ flowSourceAvailabilityLabel(row.availability) }}
+                          </ElTag>
                         </div>
-                        <div class="create-policy-detail-popover__retention-box">
-                          <div class="policy-retention-detail-list">
-                            <div
-                              v-for="line in policy.retentionLines"
-                              :key="`${line.label || ''}${line.text}`"
-                              class="policy-retention-detail-list__line"
-                              :class="{ 'policy-retention-detail-list__line--summary': !line.label }"
-                            >
-                              <span v-if="line.label" class="policy-retention-detail-list__label">{{ line.label }}</span>
-                              <span class="policy-retention-detail-list__text">{{ line.text }}</span>
+                      </template>
+                    </el-table-column>
+                    <el-table-column
+                      :label="t('protection.sourceResources.colRegisteredAt')"
+                      width="154"
+                    >
+                      <template #default="{ row }">
+                        <span
+                          class="hfl-table-cell-time"
+                          :class="{ 'hfl-empty-mark': !row.registeredAt }"
+                        >{{ flowSourceRegisteredAt(row.registeredAt) }}</span>
+                      </template>
+                    </el-table-column>
+                    <template #empty>
+                      <el-empty :image-size="72">
+                        <template #description>
+                          <p v-if="step2AllSourcesConfigured">
+                            {{ t('protection.backupsPage.flowStep2EmptyAllConfigured') }}
+                          </p>
+                          <p v-else>
+                            {{ t('protection.backupsPage.flowTaskEmptyBackupConfigPrefix') }}
+                            <strong>{{ t('protection.backupsPage.flowTaskEmptyBackupConfigStep') }}</strong>
+                            {{ t('protection.backupsPage.flowTaskEmptyBackupConfigSuffix') }}
+                          </p>
+                        </template>
+                      </el-empty>
+                    </template>
+                  </el-table>
+                  <div class="hfl-list-footer">
+                    <span
+                      v-if="step1Selection.length > 0"
+                      class="hfl-list-footer__selected"
+                    >
+                      {{ t('protection.sourceResources.selectedCount', { n: step1Selection.length }) }}
+                    </span>
+                    <HflPagination
+                      v-model:current-page="flowStep1Pager.page"
+                      v-model:page-size="flowStep1Pager.pageSize"
+                      class="hfl-list-footer__pagination"
+                      :total="flowMainStep === 1 ? step2SelectableCount : filteredStep2SourceList.length"
+                    />
+                  </div>
+                </div>
+              </div>
+
+              <div
+                v-if="flowMainStep === 2"
+                class="protection-flow-panel protection-flow-panel--fill"
+              >
+                <div class="protection-flow-table-block">
+                  <el-table
+                    ref="step3TableRef"
+                    v-table-overflow-title
+                    v-table-header-scroll-sync
+                    v-table-column-resize="'protection.dataProtection.startBackup'"
+                    v-loading="flowStepDataLoading[2]"
+                    class="hfl-list-table"
+                    :data="paginatedStep3SourceList"
+                    stripe
+                    row-key="id"
+                    :max-height="flowTableMaxHeight"
+                    :header-cell-style="TABLE_HEADER_STYLE"
+                    @selection-change="onBackupTaskSelection"
+                    @cell-click="onFlowSourceCellClick"
+                  >
+                    <el-table-column
+                      type="selection"
+                      width="35"
+                      fixed="left"
+                      reserve-selection
+                      :selectable="flowSourceRowSelectable"
+                    />
+                    <el-table-column
+                      fixed="left"
+                      column-key="backup-source"
+                      :label="t('protection.backupsPage.colBackupSource')"
+                      :min-width="FLOW_PICK_TABLE_COL_MIN.source"
+                    >
+                      <template #header>
+                        <span class="flow-filterable-header">
+                          <span>{{ t('protection.backupsPage.colBackupSource') }}</span>
+                          <HflPopover
+                            v-if="flowMainStep !== 2"
+                            v-model:visible="flowHeaderFilterOpen.sourceType"
+                            trigger="click"
+                            placement="bottom"
+                            :width="224"
+                            popper-class="flow-header-filter-popper"
+                          >
+                            <template #reference>
+                              <button
+                                type="button"
+                                class="flow-header-filter-trigger"
+                                :class="{ 'flow-header-filter-trigger--active': hasFlowHeaderFilterValue('sourceType') }"
+                                @click.stop
+                              >
+                                <Filter :size="14" />
+                              </button>
+                            </template>
+                            <div class="flow-header-filter-panel">
+                              <ElInput
+                                v-model="flowHeaderFilterSearch.sourceType"
+                                size="small"
+                                clearable
+                                :placeholder="t('protection.backupsPage.flowFilterSearchPlaceholder')"
+                              />
+                              <ElCheckboxGroup
+                                v-model="flowFilterSourceTypes"
+                                class="flow-header-filter-options"
+                              >
+                                <ElCheckbox
+                                  v-for="item in visibleFlowHeaderFilterOptions(flowSourceTypeFilterOptions, 'sourceType')"
+                                  :key="item.value"
+                                  :value="item.value"
+                                >
+                                  {{ item.text }}
+                                </ElCheckbox>
+                              </ElCheckboxGroup>
+                              <div
+                                v-if="visibleFlowHeaderFilterOptions(flowSourceTypeFilterOptions, 'sourceType').length === 0"
+                                class="flow-header-filter-empty"
+                              >
+                                {{ t('protection.backupsPage.flowFilterNoOptions') }}
+                              </div>
+                              <div class="flow-header-filter-actions">
+                                <ElButton
+                                  text
+                                  size="small"
+                                  @click="clearFlowHeaderFilter('sourceType')"
+                                >{{ t('protection.backupsPage.flowFilterReset') }}</ElButton>
+                                <ElButton
+                                  text
+                                  size="small"
+                                  type="primary"
+                                  @click="closeFlowHeaderFilter('sourceType')"
+                                >{{ t('protection.backupsPage.flowFilterApply') }}</ElButton>
+                              </div>
+                            </div>
+                          </HflPopover>
+                        </span>
+                      </template>
+                      <template #default="{ row }">
+                        <FlowSourceSummaryCell
+                          :row="row"
+                          :interactive="false"
+                          externally-interactive
+                        />
+                      </template>
+                    </el-table-column>
+                    <el-table-column
+                      :label="t('protection.backupsPage.colConnectionAddress')"
+                      :min-width="FLOW_START_BACKUP_TABLE_COL_MIN.connection"
+                    >
+                      <template #default="{ row }">
+                        <FlowSourceConnectionCell :row="row" />
+                      </template>
+                    </el-table-column>
+                    <el-table-column
+                      :label="t('protection.sourceResources.colLifecycleStatus')"
+                      width="168"
+                      align="center"
+                      header-align="center"
+                    >
+                      <template #header>
+                        <span class="flow-filterable-header">
+                          <span>{{ t('protection.sourceResources.colLifecycleStatus') }}</span>
+                          <HflPopover
+                            v-if="flowMainStep !== 2"
+                            v-model:visible="flowHeaderFilterOpen.sourceStatus"
+                            trigger="click"
+                            placement="bottom"
+                            :width="210"
+                            popper-class="flow-header-filter-popper"
+                          >
+                            <template #reference>
+                              <button
+                                type="button"
+                                class="flow-header-filter-trigger"
+                                :class="{ 'flow-header-filter-trigger--active': hasFlowHeaderFilterValue('sourceStatus') }"
+                                @click.stop
+                              >
+                                <Filter :size="14" />
+                              </button>
+                            </template>
+                            <div class="flow-header-filter-panel">
+                              <ElInput
+                                v-model="flowHeaderFilterSearch.sourceStatus"
+                                size="small"
+                                clearable
+                                :placeholder="t('protection.backupsPage.flowFilterSearchPlaceholder')"
+                              />
+                              <ElCheckboxGroup
+                                v-model="flowFilterSourceStatuses"
+                                class="flow-header-filter-options"
+                              >
+                                <ElCheckbox
+                                  v-for="item in visibleFlowHeaderFilterOptions(flowSourceStatusFilterOptions, 'sourceStatus')"
+                                  :key="item.value"
+                                  :value="item.value"
+                                >
+                                  {{ item.text }}
+                                </ElCheckbox>
+                              </ElCheckboxGroup>
+                              <div
+                                v-if="visibleFlowHeaderFilterOptions(flowSourceStatusFilterOptions, 'sourceStatus').length === 0"
+                                class="flow-header-filter-empty"
+                              >
+                                {{ t('protection.backupsPage.flowFilterNoOptions') }}
+                              </div>
+                              <div class="flow-header-filter-actions">
+                                <ElButton
+                                  text
+                                  size="small"
+                                  @click="clearFlowHeaderFilter('sourceStatus')"
+                                >{{ t('protection.backupsPage.flowFilterReset') }}</ElButton>
+                                <ElButton
+                                  text
+                                  size="small"
+                                  type="primary"
+                                  @click="closeFlowHeaderFilter('sourceStatus')"
+                                >{{ t('protection.backupsPage.flowFilterApply') }}</ElButton>
+                              </div>
+                            </div>
+                          </HflPopover>
+                        </span>
+                      </template>
+                      <template #default="{ row }">
+                        <button
+                          v-if="sourceResetState(row.id)"
+                          type="button"
+                          class="reset-status-cell"
+                          :class="`reset-status-cell--${sourceResetState(row.id)}`"
+                          :title="t('protection.backupsPage.resetStatusClickHint')"
+                          @click.stop="openResetTaskDetail(row)"
+                        >
+                          <span class="reset-status-cell__label">{{ sourceResetStatusLabel(row.id) }}</span>
+                          <span
+                            v-if="sourceResetState(row.id) === 'resetting'"
+                            class="reset-status-cell__progress"
+                          >
+                            <span class="reset-status-cell__track">
+                              <span
+                                class="reset-status-cell__fill"
+                                :style="{ width: `${sourceResetProgress(row.id)}%` }"
+                              />
+                            </span>
+                            <span class="reset-status-cell__percent">{{ sourceResetProgress(row.id) }}%</span>
+                          </span>
+                        </button>
+                        <FlowSourceReadyStatusCell
+                          v-else
+                          v-bind="resolveFlowSourceDisplayStatus(row)"
+                          neutral-as-danger
+                          @click="openSourcePendingFailureDetails(row.id)"
+                        />
+                      </template>
+                    </el-table-column>
+                    <el-table-column
+                      :label="t('protection.backupsPage.flowBackupColBackupDirs')"
+                      :min-width="FLOW_START_BACKUP_TABLE_COL_MIN.backupDirs"
+                    >
+                      <template #default="{ row }">
+                        <div
+                          v-if="sourceConfigDirRows(row.id).length"
+                          class="table-stack-list"
+                        >
+                          <HflPopover
+                            placement="right-start"
+                            trigger="hover"
+                            :hide-after="0"
+                            :width="420"
+                            append-to-body
+                          >
+                            <template #reference>
+                              <div class="table-stack-list flow-dir-preview-list">
+                                <div
+                                  v-for="(dir, index) in sourceDirsPreview(row.id)"
+                                  :key="`${row.id}-${dir.configId}-${dir.path}`"
+                                  class="source-path-text flow-dir-preview-list__row"
+                                  :class="{ 'flow-dir-preview-list__row--has-more': index === 0 && sourceDirsOverflowCount(row.id) > 0 }"
+                                >
+                                  <span class="flow-dir-preview-list__path">{{ dir.path }}</span>
+                                  <span
+                                    v-if="index === 0 && sourceDirsOverflowCount(row.id) > 0"
+                                    class="flow-dir-preview-list__more"
+                                    aria-hidden="true"
+                                  >
+                                    <MoreHorizontal :size="16" />
+                                  </span>
+                                </div>
+                              </div>
+                            </template>
+                            <ul class="m-0 list-none p-0 text-sm text-slate-800 space-y-2">
+                              <li
+                                v-for="dir in sourceConfigDirRows(row.id)"
+                                :key="`all-${row.id}-${dir.configId}-${dir.path}`"
+                              >
+                                <code class="flow-source-list-drawer-path">{{ dir.path }}</code>
+                              </li>
+                            </ul>
+                          </HflPopover>
+                        </div>
+                        <span
+                          v-else
+                          class="hfl-empty-mark"
+                        >{{ t('protection.backupDetail.durationDash') }}</span>
+                      </template>
+                    </el-table-column>
+                    <el-table-column
+                      :label="t('protection.backupsPage.flowBackupColCurrentTaskStatus')"
+                      min-width="228"
+                    >
+                      <template #default="{ row }">
+                        <button
+                          type="button"
+                          class="backup-task-trigger"
+                          :disabled="!latestBackupTaskUuidForSource(row.id)"
+                          :title="t('protection.backupsPage.backupTaskStatusClickHint')"
+                          @click.stop="openLatestBackupTask(row)"
+                        >
+                          <TaskProgressCell
+                            v-if="sourceBackupCellPhase(row.id) === 'running'"
+                            :failed="sourceBackupRuntime(row.id).failed"
+                            :progress="sourceBackupRuntime(row.id).progress"
+                            :transfer-progress="sourceBackupRuntime(row.id).transferProgress"
+                          />
+                          <TaskProgressCell
+                            v-else-if="sourceBackupCellPhase(row.id) === 'stopping'"
+                            :progress="sourceBackupRuntime(row.id).progress"
+                            :transfer-progress="sourceBackupRuntime(row.id).transferProgress"
+                            stopping
+                          />
+                          <TaskTerminalOutcomeCell
+                            v-else
+                            :task="latestBackupTaskForSource(row.id)"
+                            :fallback="latestSnapshotForSource(row.id)"
+                          />
+                        </button>
+                      </template>
+                    </el-table-column>
+                    <el-table-column
+                      :label="t('protection.backupsPage.flowBackupColRestoreTaskStatus')"
+                      min-width="228"
+                    >
+                      <template #default="{ row }">
+                        <button
+                          type="button"
+                          class="backup-task-trigger"
+                          :disabled="!latestRestoreTaskForSource(row.id)?.task_uuid && !latestRestoreRecordForSource(row.id)?.task_uuid"
+                          :title="t('protection.backupsPage.restoreTaskStatusClickHint')"
+                          @click.stop="openLatestRestoreTask(row)"
+                        >
+                          <TaskProgressCell
+                            v-if="sourceRestoreCellPhase(row.id) === 'running'"
+                            :failed="sourceRestoreRuntime(row.id).failed"
+                            :progress="sourceRestoreRuntime(row.id).progress"
+                            :transfer-progress="sourceRestoreRuntime(row.id).transferProgress"
+                          />
+                          <TaskProgressCell
+                            v-else-if="sourceRestoreCellPhase(row.id) === 'stopping'"
+                            :progress="sourceRestoreRuntime(row.id).progress"
+                            :transfer-progress="sourceRestoreRuntime(row.id).transferProgress"
+                            stopping
+                          />
+                          <TaskTerminalOutcomeCell
+                            v-else
+                            :task="latestRestoreTaskForSource(row.id)"
+                            :fallback="latestRestoreRecordForSource(row.id)?.task_summary"
+                          />
+                        </button>
+                      </template>
+                    </el-table-column>
+                    <el-table-column
+                      :label="t('protection.sourceResources.colConnectivity')"
+                      width="110"
+                      align="center"
+                      header-align="center"
+                    >
+                      <template #default="{ row }">
+                        <div class="hfl-table-no-tooltip">
+                          <ElTag
+                            :type="flowSourceAvailabilityTagType(row.availability)"
+                            size="small"
+                          >
+                            {{ flowSourceAvailabilityLabel(row.availability) }}
+                          </ElTag>
+                        </div>
+                      </template>
+                    </el-table-column>
+                    <el-table-column
+                      :label="t('protection.backupsPage.flowBackupColTargetRepo')"
+                      :min-width="FLOW_START_BACKUP_TABLE_COL_MIN.targetRepo"
+                    >
+                      <template #header>
+                        <span class="flow-filterable-header">
+                          <span>{{ t('protection.backupsPage.flowBackupColTargetRepo') }}</span>
+                          <HflPopover
+                            v-if="flowMainStep !== 2"
+                            v-model:visible="flowHeaderFilterOpen.repoHealth"
+                            trigger="click"
+                            placement="bottom"
+                            :width="224"
+                            popper-class="flow-header-filter-popper"
+                          >
+                            <template #reference>
+                              <button
+                                type="button"
+                                class="flow-header-filter-trigger"
+                                :class="{ 'flow-header-filter-trigger--active': hasFlowHeaderFilterValue('repoHealth') }"
+                                @click.stop
+                              >
+                                <Filter :size="14" />
+                              </button>
+                            </template>
+                            <div class="flow-header-filter-panel">
+                              <ElInput
+                                v-model="flowHeaderFilterSearch.repoHealth"
+                                size="small"
+                                clearable
+                                :placeholder="t('protection.backupsPage.flowFilterSearchPlaceholder')"
+                              />
+                              <ElCheckboxGroup
+                                v-model="flowFilterRepoHealth"
+                                class="flow-header-filter-options"
+                              >
+                                <ElCheckbox
+                                  v-for="item in visibleFlowHeaderFilterOptions(flowRepoHealthFilterOptions, 'repoHealth')"
+                                  :key="item.value"
+                                  :value="item.value"
+                                >
+                                  {{ item.text }}
+                                </ElCheckbox>
+                              </ElCheckboxGroup>
+                              <div
+                                v-if="visibleFlowHeaderFilterOptions(flowRepoHealthFilterOptions, 'repoHealth').length === 0"
+                                class="flow-header-filter-empty"
+                              >
+                                {{ t('protection.backupsPage.flowFilterNoOptions') }}
+                              </div>
+                              <div class="flow-header-filter-actions">
+                                <ElButton
+                                  text
+                                  size="small"
+                                  @click="clearFlowHeaderFilter('repoHealth')"
+                                >{{ t('protection.backupsPage.flowFilterReset') }}</ElButton>
+                                <ElButton
+                                  text
+                                  size="small"
+                                  type="primary"
+                                  @click="closeFlowHeaderFilter('repoHealth')"
+                                >{{ t('protection.backupsPage.flowFilterApply') }}</ElButton>
+                              </div>
+                            </div>
+                          </HflPopover>
+                        </span>
+                      </template>
+                      <template #default="{ row }">
+                        <div
+                          v-if="sourceConfigTargetRows(row.id).length"
+                          class="table-stack-list"
+                        >
+                          <HflPopover
+                            v-for="target in sourceTargetsPreview(row.id)"
+                            :key="`${row.id}-target-${target.id}`"
+                            class="table-stack-cell flow-target-repository-popover"
+                            placement="top-start"
+                            trigger="hover"
+                            :hide-after="FLOW_DETAIL_POPOVER_HIDE_AFTER_MS"
+                            :width="420"
+                            :show-after="300"
+                            append-to-body
+                          >
+                            <template #reference>
+                              <div
+                                class="wizard-target-repository-cell hfl-table-no-tooltip"
+                                :class="`wizard-target-repository-cell--${flowTargetTone(target)}`"
+                                :title="target.location ? `${target.name}\n${target.location}` : target.name"
+                              >
+                                <span
+                                  class="wizard-target-repository-cell__dot"
+                                  aria-hidden="true"
+                                />
+                                <div class="wizard-target-repository-cell__body">
+                                  <div class="wizard-target-repository-cell__name">
+                                    {{ target.name }}
+                                  </div>
+                                  <div
+                                    v-if="target.location"
+                                    class="wizard-target-repository-cell__location hfl-table-cell-mono"
+                                  >
+                                    {{ target.location }}
+                                  </div>
+                                </div>
+                              </div>
+                            </template>
+                            <TargetRepositoryDetailCard
+                              :target="target"
+                              :hide-capacity="true"
+                            />
+                          </HflPopover>
+                          <button
+                            v-if="sourceTargetsOverflowCount(row.id) > 0"
+                            type="button"
+                            class="source-more-link"
+                            :title="t('protection.backupsPage.flowSourceTargetDrawerOpenHint')"
+                            @click.stop="openFlowSourceListDrawer(row, 'targets')"
+                          >
+                            {{ t('protection.backupsPage.flowSourceTargetOverflow', { n: sourceTargetsOverflowCount(row.id) }) }}
+                          </button>
+                        </div>
+                        <span
+                          v-else
+                          class="hfl-empty-mark"
+                        >{{ t('protection.backupDetail.durationDash') }}</span>
+                      </template>
+                    </el-table-column>
+                    <el-table-column
+                      :label="t('protection.backupsPage.labelCompressionStrategy')"
+                      :min-width="FLOW_START_BACKUP_TABLE_COL_MIN.compression"
+                    >
+                      <template #default="{ row }">
+                        <HflPopover
+                          v-if="sourceCompressionLabel(row.id)"
+                          trigger="hover"
+                          placement="bottom-start"
+                          :width="288"
+                          :fallback-placements="['bottom-start', 'bottom-end']"
+                          popper-class="flow-compression-popper"
+                        >
+                          <template #reference>
+                            <span class="flow-compression-cell hfl-table-no-tooltip">
+                              <component
+                                :is="compressionLevelIcon(sourceCompressionLevel(row.id) ?? 'balanced')"
+                                :size="15"
+                                aria-hidden="true"
+                                class="flow-compression-cell__icon"
+                                :class="`flow-compression-cell__icon--${sourceCompressionLevel(row.id) ?? 'balanced'}`"
+                              />
+                              <span class="flow-compression-cell__label">{{ sourceCompressionLabel(row.id) }}</span>
+                            </span>
+                          </template>
+                          <div class="flow-compression-popover">
+                            <div class="flow-compression-popover__title">
+                              <component
+                                :is="compressionLevelIcon(sourceCompressionLevel(row.id) ?? 'balanced')"
+                                :size="17"
+                                aria-hidden="true"
+                                class="flow-compression-popover__icon"
+                                :class="`flow-compression-popover__icon--${sourceCompressionLevel(row.id) ?? 'balanced'}`"
+                              />
+                              <span>{{ sourceCompressionLabel(row.id) }}</span>
+                            </div>
+                            <div class="flow-compression-popover__body">
+                              {{ compressionLevelTooltip(sourceCompressionLevel(row.id) ?? 'balanced') }}
                             </div>
                           </div>
-                        </div>
-                      </section>
-                    </div>
+                        </HflPopover>
+                        <span
+                          v-else
+                          class="hfl-empty-mark"
+                        >{{ t('protection.backupDetail.durationDash') }}</span>
+                      </template>
+                    </el-table-column>
+                    <el-table-column
+                      :label="t('protection.backupsPage.flowBackupColBoundBackupPolicy')"
+                      :min-width="FLOW_START_BACKUP_TABLE_COL_MIN.binding"
+                    >
+                      <template #header>
+                        <span class="flow-filterable-header">
+                          <span>{{ t('protection.backupsPage.flowBackupColBoundBackupPolicy') }}</span>
+                          <HflPopover
+                            v-if="flowMainStep !== 2"
+                            v-model:visible="flowHeaderFilterOpen.policyBinding"
+                            trigger="click"
+                            placement="bottom"
+                            :width="210"
+                            popper-class="flow-header-filter-popper"
+                          >
+                            <template #reference>
+                              <button
+                                type="button"
+                                class="flow-header-filter-trigger"
+                                :class="{ 'flow-header-filter-trigger--active': hasFlowHeaderFilterValue('policyBinding') }"
+                                @click.stop
+                              >
+                                <Filter :size="14" />
+                              </button>
+                            </template>
+                            <div class="flow-header-filter-panel">
+                              <ElInput
+                                v-model="flowHeaderFilterSearch.policyBinding"
+                                size="small"
+                                clearable
+                                :placeholder="t('protection.backupsPage.flowFilterSearchPlaceholder')"
+                              />
+                              <ElCheckboxGroup
+                                v-model="flowFilterPolicyBinding"
+                                class="flow-header-filter-options"
+                              >
+                                <ElCheckbox
+                                  v-for="item in visibleFlowHeaderFilterOptions(flowBindingFilterOptions, 'policyBinding')"
+                                  :key="item.value"
+                                  :value="item.value"
+                                >
+                                  {{ item.text }}
+                                </ElCheckbox>
+                              </ElCheckboxGroup>
+                              <div
+                                v-if="visibleFlowHeaderFilterOptions(flowBindingFilterOptions, 'policyBinding').length === 0"
+                                class="flow-header-filter-empty"
+                              >
+                                {{ t('protection.backupsPage.flowFilterNoOptions') }}
+                              </div>
+                              <div class="flow-header-filter-actions">
+                                <ElButton
+                                  text
+                                  size="small"
+                                  @click="clearFlowHeaderFilter('policyBinding')"
+                                >{{ t('protection.backupsPage.flowFilterReset') }}</ElButton>
+                                <ElButton
+                                  text
+                                  size="small"
+                                  type="primary"
+                                  @click="closeFlowHeaderFilter('policyBinding')"
+                                >{{ t('protection.backupsPage.flowFilterApply') }}</ElButton>
+                              </div>
+                            </div>
+                          </HflPopover>
+                        </span>
+                      </template>
+                      <template #default="{ row }">
+                        <template v-if="sourcePoliciesLabel(row.id)">
+                          <HflPopover
+                            placement="right-start"
+                            trigger="hover"
+                            :hide-after="FLOW_DETAIL_POPOVER_HIDE_AFTER_MS"
+                            :width="420"
+                            append-to-body
+                            popper-class="create-policy-option-popper flow-binding-detail-popper"
+                          >
+                            <template #reference>
+                              <span class="flow-binding-list hfl-table-no-tooltip">
+                                <span
+                                  v-for="policy in sourceBoundPolicyRows(row.id)"
+                                  :key="policy.id"
+                                  class="flow-binding-list-item"
+                                >
+                                  <span
+                                    :class="flowBindingStatusDotClass(policy.isActive)"
+                                    aria-hidden="true"
+                                  />
+                                  <span class="flow-binding-list-item__name">{{ policy.name }}</span>
+                                </span>
+                              </span>
+                            </template>
+                            <div class="create-confirm-binding-popover-stack">
+                              <div
+                                v-for="policy in sourceBoundPolicyRows(row.id)"
+                                :key="policy.id"
+                                class="create-policy-detail-popover"
+                              >
+                                <div class="create-policy-detail-popover__head">
+                                  <div class="create-policy-detail-popover__title">
+                                    {{ policy.name }}
+                                  </div>
+                                  <span :class="flowBindingStatePillClass(policy.isActive)">
+                                    {{ flowBindingStateLabel(policy.isActive) }}
+                                  </span>
+                                </div>
+                                <div class="create-policy-detail-popover__sections">
+                                  <section
+                                    v-for="detailRow in policy.detailRows"
+                                    :key="detailRow.label"
+                                    class="create-policy-detail-popover__section create-policy-detail-popover__section--line"
+                                  >
+                                    <span class="create-policy-detail-popover__section-title">{{ detailRow.label }}:</span>
+                                    <span class="create-policy-detail-popover__value">{{ detailRow.value }}</span>
+                                  </section>
+                                  <section class="create-policy-detail-popover__section">
+                                    <div class="create-policy-detail-popover__section-title">
+                                      {{ t('protection.policiesPage.fieldRetention') }}:
+                                    </div>
+                                    <div class="create-policy-detail-popover__retention-box">
+                                      <div class="policy-retention-detail-list">
+                                        <div
+                                          v-for="line in policy.retentionLines"
+                                          :key="`${line.label || ''}${line.text}`"
+                                          class="policy-retention-detail-list__line"
+                                          :class="{ 'policy-retention-detail-list__line--summary': !line.label }"
+                                        >
+                                          <span
+                                            v-if="line.label"
+                                            class="policy-retention-detail-list__label"
+                                          >{{ line.label }}</span>
+                                          <span class="policy-retention-detail-list__text">{{ line.text }}</span>
+                                        </div>
+                                      </div>
+                                    </div>
+                                  </section>
+                                </div>
+                              </div>
+                            </div>
+                          </HflPopover>
+                        </template>
+                        <span
+                          v-else
+                          class="flow-binding-empty"
+                        >
+                          <Unlink
+                            :size="14"
+                            class="shrink-0"
+                            stroke-width="2.2"
+                            aria-hidden="true"
+                          />
+                          {{ t('protection.backupsPage.flowBackupColPolicyNone') }}
+                        </span>
+                      </template>
+                    </el-table-column>
+                    <el-table-column
+                      :label="t('protection.backupsPage.flowBackupColBoundFileFilter')"
+                      :min-width="FLOW_START_BACKUP_TABLE_COL_MIN.binding"
+                    >
+                      <template #header>
+                        <span class="flow-filterable-header">
+                          <span>{{ t('protection.backupsPage.flowBackupColBoundFileFilter') }}</span>
+                          <HflPopover
+                            v-if="flowMainStep !== 2"
+                            v-model:visible="flowHeaderFilterOpen.fileFilterBinding"
+                            trigger="click"
+                            placement="bottom"
+                            :width="210"
+                            popper-class="flow-header-filter-popper"
+                          >
+                            <template #reference>
+                              <button
+                                type="button"
+                                class="flow-header-filter-trigger"
+                                :class="{ 'flow-header-filter-trigger--active': hasFlowHeaderFilterValue('fileFilterBinding') }"
+                                @click.stop
+                              >
+                                <Filter :size="14" />
+                              </button>
+                            </template>
+                            <div class="flow-header-filter-panel">
+                              <ElInput
+                                v-model="flowHeaderFilterSearch.fileFilterBinding"
+                                size="small"
+                                clearable
+                                :placeholder="t('protection.backupsPage.flowFilterSearchPlaceholder')"
+                              />
+                              <ElCheckboxGroup
+                                v-model="flowFilterFileFilterBinding"
+                                class="flow-header-filter-options"
+                              >
+                                <ElCheckbox
+                                  v-for="item in visibleFlowHeaderFilterOptions(flowBindingFilterOptions, 'fileFilterBinding')"
+                                  :key="item.value"
+                                  :value="item.value"
+                                >
+                                  {{ item.text }}
+                                </ElCheckbox>
+                              </ElCheckboxGroup>
+                              <div
+                                v-if="visibleFlowHeaderFilterOptions(flowBindingFilterOptions, 'fileFilterBinding').length === 0"
+                                class="flow-header-filter-empty"
+                              >
+                                {{ t('protection.backupsPage.flowFilterNoOptions') }}
+                              </div>
+                              <div class="flow-header-filter-actions">
+                                <ElButton
+                                  text
+                                  size="small"
+                                  @click="clearFlowHeaderFilter('fileFilterBinding')"
+                                >{{ t('protection.backupsPage.flowFilterReset') }}</ElButton>
+                                <ElButton
+                                  text
+                                  size="small"
+                                  type="primary"
+                                  @click="closeFlowHeaderFilter('fileFilterBinding')"
+                                >{{ t('protection.backupsPage.flowFilterApply') }}</ElButton>
+                              </div>
+                            </div>
+                          </HflPopover>
+                        </span>
+                      </template>
+                      <template #default="{ row }">
+                        <template v-if="sourceFiltersLabel(row.id)">
+                          <HflPopover
+                            placement="right-start"
+                            trigger="hover"
+                            :hide-after="FLOW_DETAIL_POPOVER_HIDE_AFTER_MS"
+                            :width="460"
+                            append-to-body
+                            popper-class="create-policy-option-popper flow-binding-detail-popper"
+                          >
+                            <template #reference>
+                              <span class="flow-binding-list hfl-table-no-tooltip">
+                                <span
+                                  v-for="filter in sourceBoundFilterRows(row.id)"
+                                  :key="filter.id"
+                                  class="flow-binding-list-item"
+                                >
+                                  <span
+                                    :class="flowBindingStatusDotClass(filter.isActive)"
+                                    aria-hidden="true"
+                                  />
+                                  <span class="flow-binding-list-item__name">{{ filter.name }}</span>
+                                </span>
+                              </span>
+                            </template>
+                            <div class="create-confirm-binding-popover-stack">
+                              <div
+                                v-for="filter in sourceBoundFilterRows(row.id)"
+                                :key="filter.id"
+                                class="create-policy-detail-popover"
+                              >
+                                <div class="create-policy-detail-popover__head">
+                                  <div class="create-policy-detail-popover__title">
+                                    {{ filter.name }}
+                                  </div>
+                                  <span :class="flowBindingStatePillClass(filter.isActive)">
+                                    {{ flowBindingStateLabel(filter.isActive) }}
+                                  </span>
+                                </div>
+                                <div class="create-policy-detail-popover__sections">
+                                  <section
+                                    v-for="detailRow in filter.hoverRows"
+                                    :key="detailRow.label"
+                                    class="create-policy-detail-popover__section create-policy-detail-popover__section--filter-line"
+                                  >
+                                    <span class="create-policy-detail-popover__section-title">{{ detailRow.label }}:</span>
+                                    <span
+                                      v-if="detailRow.enabled"
+                                      :class="flowBindingStatePillClass(true)"
+                                    >
+                                      {{ detailRow.value }}
+                                    </span>
+                                    <span
+                                      v-else
+                                      class="create-policy-detail-popover__value"
+                                    >{{ detailRow.value }}</span>
+                                  </section>
+                                  <section class="create-policy-detail-popover__section">
+                                    <div class="create-policy-detail-popover__section-title">
+                                      {{ t('protection.policiesPage.filterRulesPreviewTitle') }}:
+                                    </div>
+                                    <div class="create-filter-rules-preview">
+                                      <template v-if="filter.compiledRules.length">
+                                        <code
+                                          v-for="(line, index) in filter.compiledRules"
+                                          :key="`${index}-${line}`"
+                                          class="create-filter-rules-preview__line"
+                                        >
+                                          {{ line }}
+                                        </code>
+                                      </template>
+                                      <p
+                                        v-else
+                                        class="create-filter-rules-preview__empty"
+                                      >
+                                        {{ t('protection.policiesPage.filterNoActiveRules') }}
+                                      </p>
+                                    </div>
+                                  </section>
+                                </div>
+                              </div>
+                            </div>
+                          </HflPopover>
+                        </template>
+                        <span
+                          v-else
+                          class="flow-binding-empty"
+                        >
+                          <Unlink
+                            :size="14"
+                            class="shrink-0"
+                            stroke-width="2.2"
+                            aria-hidden="true"
+                          />
+                          {{ t('protection.backupsPage.flowBackupColPolicyNone') }}
+                        </span>
+                      </template>
+                    </el-table-column>
+                    <el-table-column
+                      :label="t('protection.sourceResources.colRegisteredAt')"
+                      width="184"
+                    >
+                      <template #default="{ row }">
+                        <span
+                          class="hfl-table-cell-time"
+                          :class="{ 'hfl-empty-mark': !row.registeredAt }"
+                        >{{ flowSourceRegisteredAt(row.registeredAt) }}</span>
+                      </template>
+                    </el-table-column>
+                    <template #empty>
+                      <el-empty :image-size="72">
+                        <template #description>
+                          <p>
+                            {{ t('protection.backupsPage.flowTaskEmptyStep3SourcePrefix') }}
+                            <strong>{{ t('protection.backupsPage.flowTaskEmptyStep3SourceStep') }}</strong>
+                            {{ t('protection.backupsPage.flowTaskEmptyStep3SourceSuffix') }}
+                          </p>
+                        </template>
+                      </el-empty>
+                    </template>
+                  </el-table>
+                  <div class="hfl-list-footer">
+                    <span
+                      v-if="step3SourceSelection.length > 0"
+                      class="hfl-list-footer__selected"
+                    >
+                      {{ t('protection.sourceResources.selectedCount', { n: step3SourceSelection.length }) }}
+                    </span>
+                    <HflPagination
+                      v-model:current-page="flowStep2Pager.page"
+                      v-model:page-size="flowStep2Pager.pageSize"
+                      class="hfl-list-footer__pagination"
+                      :total="step3SelectableCount"
+                    />
                   </div>
                 </div>
-              </HflPopover>
-            </template>
-            <span v-else class="flow-binding-empty">
-              <Unlink :size="14" class="shrink-0" stroke-width="2.2" aria-hidden="true" />
-              {{ t('protection.backupsPage.flowBackupColPolicyNone') }}
-            </span>
-          </template>
-        </el-table-column>
-        <el-table-column
-          :label="t('protection.backupsPage.flowBackupColBoundFileFilter')"
-          :min-width="FLOW_START_BACKUP_TABLE_COL_MIN.binding"
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <el-drawer
+          v-model="flowAdvancedFilterOpen"
+          direction="rtl"
+          :size="nestedDrawerSize"
+          destroy-on-close
+          class="dp-flow-filter-drawer"
         >
           <template #header>
-            <span class="flow-filterable-header">
-              <span>{{ t('protection.backupsPage.flowBackupColBoundFileFilter') }}</span>
-              <HflPopover v-if="flowMainStep !== 2" v-model:visible="flowHeaderFilterOpen.fileFilterBinding" trigger="click" placement="bottom" :width="210" popper-class="flow-header-filter-popper">
-                <template #reference>
-                  <button type="button" class="flow-header-filter-trigger" :class="{ 'flow-header-filter-trigger--active': hasFlowHeaderFilterValue('fileFilterBinding') }" @click.stop>
-                    <Filter :size="14" />
-                  </button>
-                </template>
-                <div class="flow-header-filter-panel">
-                  <ElInput v-model="flowHeaderFilterSearch.fileFilterBinding" size="small" clearable :placeholder="t('protection.backupsPage.flowFilterSearchPlaceholder')" />
-                  <ElCheckboxGroup v-model="flowFilterFileFilterBinding" class="flow-header-filter-options">
-                    <ElCheckbox v-for="item in visibleFlowHeaderFilterOptions(flowBindingFilterOptions, 'fileFilterBinding')" :key="item.value" :value="item.value">
-                      {{ item.text }}
-                    </ElCheckbox>
-                  </ElCheckboxGroup>
-                  <div v-if="visibleFlowHeaderFilterOptions(flowBindingFilterOptions, 'fileFilterBinding').length === 0" class="flow-header-filter-empty">
-                    {{ t('protection.backupsPage.flowFilterNoOptions') }}
-                  </div>
-                  <div class="flow-header-filter-actions">
-                    <ElButton text size="small" @click="clearFlowHeaderFilter('fileFilterBinding')">{{ t('protection.backupsPage.flowFilterReset') }}</ElButton>
-                    <ElButton text size="small" type="primary" @click="closeFlowHeaderFilter('fileFilterBinding')">{{ t('protection.backupsPage.flowFilterApply') }}</ElButton>
-                  </div>
-                </div>
-              </HflPopover>
-            </span>
+            <div class="flex w-full min-w-0 items-center justify-between gap-3 pr-1">
+              <span class="truncate text-base font-semibold text-slate-900">{{ t('protection.backupsPage.flowFilterAdvanced') }}</span>
+            </div>
           </template>
-          <template #default="{ row }">
-            <template v-if="sourceFiltersLabel(row.id)">
-              <HflPopover placement="right-start" trigger="hover" :hide-after="FLOW_DETAIL_POPOVER_HIDE_AFTER_MS" :width="460" append-to-body popper-class="create-policy-option-popper flow-binding-detail-popper">
-                <template #reference>
-                  <span class="flow-binding-list hfl-table-no-tooltip">
-                    <span
-                      v-for="filter in sourceBoundFilterRows(row.id)"
-                      :key="filter.id"
-                      class="flow-binding-list-item"
-                    >
-                      <span :class="flowBindingStatusDotClass(filter.isActive)" aria-hidden="true" />
-                      <span class="flow-binding-list-item__name">{{ filter.name }}</span>
-                    </span>
-                  </span>
-                </template>
-                <div class="create-confirm-binding-popover-stack">
-                  <div
-                    v-for="filter in sourceBoundFilterRows(row.id)"
-                    :key="filter.id"
-                    class="create-policy-detail-popover"
-                  >
-                    <div class="create-policy-detail-popover__head">
-                      <div class="create-policy-detail-popover__title">{{ filter.name }}</div>
-                      <span :class="flowBindingStatePillClass(filter.isActive)">
-                        {{ flowBindingStateLabel(filter.isActive) }}
-                      </span>
-                    </div>
-                    <div class="create-policy-detail-popover__sections">
-                      <section
-                        v-for="detailRow in filter.hoverRows"
-                        :key="detailRow.label"
-                        class="create-policy-detail-popover__section create-policy-detail-popover__section--filter-line"
+          <div class="flow-filter-drawer">
+            <div class="flow-filter-drawer__body scrollbar">
+              <section class="flow-filter-section">
+                <h3>{{ t('protection.backupsPage.flowFilterSectionSource') }}</h3>
+                <ElAlert
+                  type="warning"
+                  :closable="false"
+                  show-icon
+                  class="flow-filter-nas-proxy-alert"
+                >
+                  {{ t('protection.backupsPage.step3NasProxyHelp') }}
+                </ElAlert>
+                <ElForm class="flow-filter-form">
+                  <ElFormItem :label="t('protection.backupsPage.flowFilterSourceType')">
+                    <div class="flow-filter-control">
+                      <ElSelect
+                        v-model="draftStep3SourceType"
+                        clearable
                       >
-                        <span class="create-policy-detail-popover__section-title">{{ detailRow.label }}:</span>
-                        <span
-                          v-if="detailRow.enabled"
-                          :class="flowBindingStatePillClass(true)"
-                        >
-                          {{ detailRow.value }}
-                        </span>
-                        <span v-else class="create-policy-detail-popover__value">{{ detailRow.value }}</span>
-                      </section>
-                      <section class="create-policy-detail-popover__section">
-                        <div class="create-policy-detail-popover__section-title">
-                          {{ t('protection.policiesPage.filterRulesPreviewTitle') }}:
-                        </div>
-                        <div class="create-filter-rules-preview">
-                          <template v-if="filter.compiledRules.length">
-                            <code
-                              v-for="(line, index) in filter.compiledRules"
-                              :key="`${index}-${line}`"
-                              class="create-filter-rules-preview__line"
-                            >
-                              {{ line }}
-                            </code>
-                          </template>
-                          <p v-else class="create-filter-rules-preview__empty">
-                            {{ t('protection.policiesPage.filterNoActiveRules') }}
-                          </p>
-                        </div>
-                      </section>
+                        <ElOption
+                          v-for="item in step3SourceTypeOptions"
+                          :key="item.value"
+                          :label="item.label"
+                          :value="item.value"
+                        />
+                      </ElSelect>
+                      <ElButton
+                        class="flow-filter-control__clear"
+                        :title="t('protection.backupsPage.flowFilterReset')"
+                        :aria-label="t('protection.backupsPage.flowFilterReset')"
+                        :disabled="!draftStep3SourceType"
+                        @click="clearStep3AdvancedFilterDraft('sourceType')"
+                      >
+                        <BrushCleaning :size="15" />
+                      </ElButton>
                     </div>
-                  </div>
-                </div>
-              </HflPopover>
-            </template>
-            <span v-else class="flow-binding-empty">
-              <Unlink :size="14" class="shrink-0" stroke-width="2.2" aria-hidden="true" />
-              {{ t('protection.backupsPage.flowBackupColPolicyNone') }}
-            </span>
+                  </ElFormItem>
+                  <ElFormItem :label="t('protection.backupsPage.step3SearchSourceName')">
+                    <div class="flow-filter-control">
+                      <ElInput
+                        v-model="draftStep3AdvancedSourceName"
+                        clearable
+                      /><ElButton
+                        class="flow-filter-control__clear"
+                        :title="t('protection.backupsPage.flowFilterReset')"
+                        :aria-label="t('protection.backupsPage.flowFilterReset')"
+                        :disabled="!draftStep3AdvancedSourceName"
+                        @click="clearStep3AdvancedFilterDraft('sourceName')"
+                      >
+                        <BrushCleaning :size="15" />
+                      </ElButton>
+                    </div>
+                  </ElFormItem>
+                  <ElFormItem :label="t('protection.backupsPage.step3SearchHostname')">
+                    <div class="flow-filter-control">
+                      <ElInput
+                        v-model="draftStep3AdvancedHostname"
+                        clearable
+                      /><ElButton
+                        class="flow-filter-control__clear"
+                        :title="t('protection.backupsPage.flowFilterReset')"
+                        :aria-label="t('protection.backupsPage.flowFilterReset')"
+                        :disabled="!draftStep3AdvancedHostname"
+                        @click="clearStep3AdvancedFilterDraft('hostname')"
+                      >
+                        <BrushCleaning :size="15" />
+                      </ElButton>
+                    </div>
+                  </ElFormItem>
+                  <ElFormItem :label="t('protection.backupsPage.step3SearchIp')">
+                    <div class="flow-filter-control">
+                      <ElInput
+                        v-model="draftStep3AdvancedIp"
+                        clearable
+                      /><ElButton
+                        class="flow-filter-control__clear"
+                        :title="t('protection.backupsPage.flowFilterReset')"
+                        :aria-label="t('protection.backupsPage.flowFilterReset')"
+                        :disabled="!draftStep3AdvancedIp"
+                        @click="clearStep3AdvancedFilterDraft('ip')"
+                      >
+                        <BrushCleaning :size="15" />
+                      </ElButton>
+                    </div>
+                  </ElFormItem>
+                  <ElFormItem :label="t('protection.backupsPage.step3SourceStatus')">
+                    <div class="flow-filter-control">
+                      <ElSelect
+                        v-model="draftStep3SourceStatus"
+                        clearable
+                      >
+                        <ElOption
+                          v-for="item in step3SourceStatusOptions"
+                          :key="item.value"
+                          :label="item.label"
+                          :value="item.value"
+                        />
+                      </ElSelect><ElButton
+                        class="flow-filter-control__clear"
+                        :title="t('protection.backupsPage.flowFilterReset')"
+                        :aria-label="t('protection.backupsPage.flowFilterReset')"
+                        :disabled="!draftStep3SourceStatus"
+                        @click="clearStep3AdvancedFilterDraft('sourceStatus')"
+                      >
+                        <BrushCleaning :size="15" />
+                      </ElButton>
+                    </div>
+                  </ElFormItem>
+                  <ElFormItem :label="t('protection.backupsPage.step3Availability')">
+                    <div class="flow-filter-control">
+                      <ElSelect
+                        v-model="draftStep3Availability"
+                        clearable
+                      >
+                        <ElOption
+                          v-for="item in step3AvailabilityOptions"
+                          :key="item.value"
+                          :label="item.label"
+                          :value="item.value"
+                        />
+                      </ElSelect><ElButton
+                        class="flow-filter-control__clear"
+                        :title="t('protection.backupsPage.flowFilterReset')"
+                        :aria-label="t('protection.backupsPage.flowFilterReset')"
+                        :disabled="!draftStep3Availability"
+                        @click="clearStep3AdvancedFilterDraft('availability')"
+                      >
+                        <BrushCleaning :size="15" />
+                      </ElButton>
+                    </div>
+                  </ElFormItem>
+                </ElForm>
+              </section>
+              <template v-if="flowMainStep === 2">
+                <section class="flow-filter-section flow-filter-section--divided">
+                  <h3>{{ t('protection.backupsPage.flowFilterSectionBackup') }}</h3>
+                  <ElForm class="flow-filter-form">
+                    <ElFormItem :label="t('protection.backupsPage.step3BackupTask')">
+                      <div class="flow-filter-control">
+                        <ElSelect
+                          v-model="draftStep3BackupTaskStatus"
+                          clearable
+                        >
+                          <ElOption
+                            v-for="item in step3BackupTaskStatusOptions"
+                            :key="item.value"
+                            :label="item.label"
+                            :value="item.value"
+                          />
+                        </ElSelect>
+                        <ElButton
+                          class="flow-filter-control__clear"
+                          :title="t('protection.backupsPage.flowFilterReset')"
+                          :aria-label="t('protection.backupsPage.flowFilterReset')"
+                          :disabled="!draftStep3BackupTaskStatus"
+                          @click="clearStep3AdvancedFilterDraft('backupTaskStatus')"
+                        >
+                          <BrushCleaning :size="15" />
+                        </ElButton>
+                      </div>
+                    </ElFormItem>
+                    <ElFormItem :label="t('protection.backupsPage.step3RestoreTask')">
+                      <div class="flow-filter-control">
+                        <ElSelect
+                          v-model="draftStep3RestoreTaskStatus"
+                          clearable
+                        >
+                          <ElOption
+                            v-for="item in step3RestoreTaskStatusOptions"
+                            :key="item.value"
+                            :label="item.label"
+                            :value="item.value"
+                          />
+                        </ElSelect>
+                        <ElButton
+                          class="flow-filter-control__clear"
+                          :title="t('protection.backupsPage.flowFilterReset')"
+                          :aria-label="t('protection.backupsPage.flowFilterReset')"
+                          :disabled="!draftStep3RestoreTaskStatus"
+                          @click="clearStep3AdvancedFilterDraft('restoreTaskStatus')"
+                        >
+                          <BrushCleaning :size="15" />
+                        </ElButton>
+                      </div>
+                    </ElFormItem>
+                  </ElForm>
+                </section>
+                <section class="flow-filter-section flow-filter-section--divided">
+                  <h3>{{ t('protection.backupsPage.flowFilterSectionTarget') }}</h3>
+                  <ElForm class="flow-filter-form">
+                    <ElFormItem :label="t('protection.backupsPage.flowFilterPolicyBinding')">
+                      <div class="flow-filter-control">
+                        <ElSelect
+                          v-model="draftStep3BackupPolicyId"
+                          clearable
+                          filterable
+                        >
+                          <ElOption
+                            v-for="item in step3BackupPolicyOptions"
+                            :key="item.id"
+                            :label="item.name"
+                            :value="item.id"
+                          />
+                        </ElSelect>
+                        <ElButton
+                          class="flow-filter-control__clear"
+                          :title="t('protection.backupsPage.flowFilterReset')"
+                          :aria-label="t('protection.backupsPage.flowFilterReset')"
+                          :disabled="!draftStep3BackupPolicyId"
+                          @click="clearStep3AdvancedFilterDraft('backupPolicy')"
+                        >
+                          <BrushCleaning :size="15" />
+                        </ElButton>
+                      </div>
+                    </ElFormItem>
+                    <ElFormItem :label="t('protection.backupsPage.flowFilterFileFilterBinding')">
+                      <div class="flow-filter-control">
+                        <ElSelect
+                          v-model="draftStep3FileFilterRuleId"
+                          clearable
+                          filterable
+                        >
+                          <ElOption
+                            v-for="item in step3FileFilterOptions"
+                            :key="item.id"
+                            :label="item.name"
+                            :value="item.id"
+                          />
+                        </ElSelect>
+                        <ElButton
+                          class="flow-filter-control__clear"
+                          :title="t('protection.backupsPage.flowFilterReset')"
+                          :aria-label="t('protection.backupsPage.flowFilterReset')"
+                          :disabled="!draftStep3FileFilterRuleId"
+                          @click="clearStep3AdvancedFilterDraft('fileFilter')"
+                        >
+                          <BrushCleaning :size="15" />
+                        </ElButton>
+                      </div>
+                    </ElFormItem>
+                    <ElFormItem :label="t('protection.backupsPage.flowFilterTargetRepo')">
+                      <div class="flow-filter-control">
+                        <ElSelect
+                          v-model="draftStep3RepositoryId"
+                          clearable
+                          filterable
+                        >
+                          <ElOption
+                            v-for="item in step3RepositoryOptions"
+                            :key="item.id"
+                            :label="item.name"
+                            :value="item.id"
+                          />
+                        </ElSelect>
+                        <ElButton
+                          class="flow-filter-control__clear"
+                          :title="t('protection.backupsPage.flowFilterReset')"
+                          :aria-label="t('protection.backupsPage.flowFilterReset')"
+                          :disabled="!draftStep3RepositoryId"
+                          @click="clearStep3AdvancedFilterDraft('repository')"
+                        >
+                          <BrushCleaning :size="15" />
+                        </ElButton>
+                      </div>
+                    </ElFormItem>
+                  </ElForm>
+                </section>
+              </template>
+            </div>
+          </div>
+          <template #footer>
+            <div class="flow-filter-drawer__footer">
+              <ElButton @click="resetStep3AdvancedFilterDrafts">
+                {{ t('protection.backupsPage.flowFilterReset') }}
+              </ElButton>
+              <ElButton @click="cancelAdvancedFilters">
+                {{ t('protection.backupsPage.flowFilterCancel') }}
+              </ElButton>
+              <ElButton
+                type="primary"
+                @click="applyAdvancedFilters"
+              >
+                {{ t('protection.backupsPage.flowFilterApply') }}
+              </ElButton>
+            </div>
           </template>
-        </el-table-column>
-        <el-table-column :label="t('protection.sourceResources.colRegisteredAt')" width="184">
-          <template #default="{ row }">
-            <span class="hfl-table-cell-time" :class="{ 'hfl-empty-mark': !row.registeredAt }">{{ flowSourceRegisteredAt(row.registeredAt) }}</span>
-          </template>
-        </el-table-column>
-        <template #empty>
-          <el-empty :image-size="72">
-            <template #description>
-              <p>
-                {{ t('protection.backupsPage.flowTaskEmptyStep3SourcePrefix') }}
-                <strong>{{ t('protection.backupsPage.flowTaskEmptyStep3SourceStep') }}</strong>
-                {{ t('protection.backupsPage.flowTaskEmptyStep3SourceSuffix') }}
-              </p>
-            </template>
-          </el-empty>
-        </template>
-      </el-table>
-      <div class="hfl-list-footer">
-        <span v-if="step3SourceSelection.length > 0" class="hfl-list-footer__selected">
-          {{ t('protection.sourceResources.selectedCount', { n: step3SourceSelection.length }) }}
-        </span>
-        <HflPagination
-          class="hfl-list-footer__pagination"
-          v-model:current-page="flowStep2Pager.page"
-          v-model:page-size="flowStep2Pager.pageSize"
-          :total="step3SelectableCount"
-        />
-      </div>
-      </div>
-    </div>
+        </el-drawer>
 
-    </div>
-      </div>
-    </div>
-
-    <el-drawer
-      v-model="flowAdvancedFilterOpen"
-      direction="rtl"
-      :size="nestedDrawerSize"
-      destroy-on-close
-      class="dp-flow-filter-drawer"
-    >
-      <template #header>
-        <div class="flex w-full min-w-0 items-center justify-between gap-3 pr-1">
-          <span class="truncate text-base font-semibold text-slate-900">{{ t('protection.backupsPage.flowFilterAdvanced') }}</span>
-        </div>
-      </template>
-      <div class="flow-filter-drawer">
-        <div class="flow-filter-drawer__body scrollbar">
-          <section class="flow-filter-section">
-              <h3>{{ t('protection.backupsPage.flowFilterSectionSource') }}</h3>
-              <ElAlert type="warning" :closable="false" show-icon class="flow-filter-nas-proxy-alert">
-                {{ t('protection.backupsPage.step3NasProxyHelp') }}
-              </ElAlert>
-              <ElForm class="flow-filter-form">
-                <ElFormItem :label="t('protection.backupsPage.flowFilterSourceType')">
-                  <div class="flow-filter-control">
-                    <ElSelect v-model="draftStep3SourceType" clearable>
-                      <ElOption v-for="item in step3SourceTypeOptions" :key="item.value" :label="item.label" :value="item.value" />
-                    </ElSelect>
-                    <ElButton class="flow-filter-control__clear" :title="t('protection.backupsPage.flowFilterReset')" :aria-label="t('protection.backupsPage.flowFilterReset')" :disabled="!draftStep3SourceType" @click="clearStep3AdvancedFilterDraft('sourceType')">
-                      <BrushCleaning :size="15" />
-                    </ElButton>
-                  </div>
-                </ElFormItem>
-                <ElFormItem :label="t('protection.backupsPage.step3SearchSourceName')">
-                  <div class="flow-filter-control"><ElInput v-model="draftStep3AdvancedSourceName" clearable /><ElButton class="flow-filter-control__clear" :title="t('protection.backupsPage.flowFilterReset')" :aria-label="t('protection.backupsPage.flowFilterReset')" :disabled="!draftStep3AdvancedSourceName" @click="clearStep3AdvancedFilterDraft('sourceName')"><BrushCleaning :size="15" /></ElButton></div>
-                </ElFormItem>
-                <ElFormItem :label="t('protection.backupsPage.step3SearchHostname')">
-                  <div class="flow-filter-control"><ElInput v-model="draftStep3AdvancedHostname" clearable /><ElButton class="flow-filter-control__clear" :title="t('protection.backupsPage.flowFilterReset')" :aria-label="t('protection.backupsPage.flowFilterReset')" :disabled="!draftStep3AdvancedHostname" @click="clearStep3AdvancedFilterDraft('hostname')"><BrushCleaning :size="15" /></ElButton></div>
-                </ElFormItem>
-                <ElFormItem :label="t('protection.backupsPage.step3SearchIp')">
-                  <div class="flow-filter-control"><ElInput v-model="draftStep3AdvancedIp" clearable /><ElButton class="flow-filter-control__clear" :title="t('protection.backupsPage.flowFilterReset')" :aria-label="t('protection.backupsPage.flowFilterReset')" :disabled="!draftStep3AdvancedIp" @click="clearStep3AdvancedFilterDraft('ip')"><BrushCleaning :size="15" /></ElButton></div>
-                </ElFormItem>
-                <ElFormItem :label="t('protection.backupsPage.step3SourceStatus')">
-                  <div class="flow-filter-control"><ElSelect v-model="draftStep3SourceStatus" clearable><ElOption v-for="item in step3SourceStatusOptions" :key="item.value" :label="item.label" :value="item.value" /></ElSelect><ElButton class="flow-filter-control__clear" :title="t('protection.backupsPage.flowFilterReset')" :aria-label="t('protection.backupsPage.flowFilterReset')" :disabled="!draftStep3SourceStatus" @click="clearStep3AdvancedFilterDraft('sourceStatus')"><BrushCleaning :size="15" /></ElButton></div>
-                </ElFormItem>
-                <ElFormItem :label="t('protection.backupsPage.step3Availability')">
-                  <div class="flow-filter-control"><ElSelect v-model="draftStep3Availability" clearable><ElOption v-for="item in step3AvailabilityOptions" :key="item.value" :label="item.label" :value="item.value" /></ElSelect><ElButton class="flow-filter-control__clear" :title="t('protection.backupsPage.flowFilterReset')" :aria-label="t('protection.backupsPage.flowFilterReset')" :disabled="!draftStep3Availability" @click="clearStep3AdvancedFilterDraft('availability')"><BrushCleaning :size="15" /></ElButton></div>
-                </ElFormItem>
-            </ElForm>
-          </section>
-          <template v-if="flowMainStep === 2">
-            <section class="flow-filter-section flow-filter-section--divided">
-              <h3>{{ t('protection.backupsPage.flowFilterSectionBackup') }}</h3>
-              <ElForm class="flow-filter-form">
-                <ElFormItem :label="t('protection.backupsPage.step3BackupTask')">
-                  <div class="flow-filter-control">
-                    <ElSelect v-model="draftStep3BackupTaskStatus" clearable>
-                      <ElOption v-for="item in step3BackupTaskStatusOptions" :key="item.value" :label="item.label" :value="item.value" />
-                    </ElSelect>
-                    <ElButton class="flow-filter-control__clear" :title="t('protection.backupsPage.flowFilterReset')" :aria-label="t('protection.backupsPage.flowFilterReset')" :disabled="!draftStep3BackupTaskStatus" @click="clearStep3AdvancedFilterDraft('backupTaskStatus')">
-                      <BrushCleaning :size="15" />
-                    </ElButton>
-                  </div>
-                </ElFormItem>
-                <ElFormItem :label="t('protection.backupsPage.step3RestoreTask')">
-                  <div class="flow-filter-control">
-                    <ElSelect v-model="draftStep3RestoreTaskStatus" clearable>
-                      <ElOption v-for="item in step3RestoreTaskStatusOptions" :key="item.value" :label="item.label" :value="item.value" />
-                    </ElSelect>
-                    <ElButton class="flow-filter-control__clear" :title="t('protection.backupsPage.flowFilterReset')" :aria-label="t('protection.backupsPage.flowFilterReset')" :disabled="!draftStep3RestoreTaskStatus" @click="clearStep3AdvancedFilterDraft('restoreTaskStatus')">
-                      <BrushCleaning :size="15" />
-                    </ElButton>
-                  </div>
-                </ElFormItem>
-              </ElForm>
-            </section>
-            <section class="flow-filter-section flow-filter-section--divided">
-              <h3>{{ t('protection.backupsPage.flowFilterSectionTarget') }}</h3>
-              <ElForm class="flow-filter-form">
-                <ElFormItem :label="t('protection.backupsPage.flowFilterPolicyBinding')">
-                  <div class="flow-filter-control">
-                    <ElSelect v-model="draftStep3BackupPolicyId" clearable filterable>
-                      <ElOption v-for="item in step3BackupPolicyOptions" :key="item.id" :label="item.name" :value="item.id" />
-                    </ElSelect>
-                    <ElButton class="flow-filter-control__clear" :title="t('protection.backupsPage.flowFilterReset')" :aria-label="t('protection.backupsPage.flowFilterReset')" :disabled="!draftStep3BackupPolicyId" @click="clearStep3AdvancedFilterDraft('backupPolicy')">
-                      <BrushCleaning :size="15" />
-                    </ElButton>
-                  </div>
-                </ElFormItem>
-                <ElFormItem :label="t('protection.backupsPage.flowFilterFileFilterBinding')">
-                  <div class="flow-filter-control">
-                    <ElSelect v-model="draftStep3FileFilterRuleId" clearable filterable>
-                      <ElOption v-for="item in step3FileFilterOptions" :key="item.id" :label="item.name" :value="item.id" />
-                    </ElSelect>
-                    <ElButton class="flow-filter-control__clear" :title="t('protection.backupsPage.flowFilterReset')" :aria-label="t('protection.backupsPage.flowFilterReset')" :disabled="!draftStep3FileFilterRuleId" @click="clearStep3AdvancedFilterDraft('fileFilter')">
-                      <BrushCleaning :size="15" />
-                    </ElButton>
-                  </div>
-                </ElFormItem>
-                <ElFormItem :label="t('protection.backupsPage.flowFilterTargetRepo')">
-                  <div class="flow-filter-control">
-                    <ElSelect v-model="draftStep3RepositoryId" clearable filterable>
-                      <ElOption v-for="item in step3RepositoryOptions" :key="item.id" :label="item.name" :value="item.id" />
-                    </ElSelect>
-                    <ElButton class="flow-filter-control__clear" :title="t('protection.backupsPage.flowFilterReset')" :aria-label="t('protection.backupsPage.flowFilterReset')" :disabled="!draftStep3RepositoryId" @click="clearStep3AdvancedFilterDraft('repository')">
-                      <BrushCleaning :size="15" />
-                    </ElButton>
-                  </div>
-                </ElFormItem>
-              </ElForm>
-            </section>
-          </template>
-        </div>
-      </div>
-      <template #footer>
-        <div class="flow-filter-drawer__footer">
-          <ElButton @click="resetStep3AdvancedFilterDrafts">
-            {{ t('protection.backupsPage.flowFilterReset') }}
-          </ElButton>
-          <ElButton @click="cancelAdvancedFilters">
-            {{ t('protection.backupsPage.flowFilterCancel') }}
-          </ElButton>
-          <ElButton type="primary" @click="applyAdvancedFilters">
-            {{ t('protection.backupsPage.flowFilterApply') }}
-          </ElButton>
-        </div>
-      </template>
-    </el-drawer>
-
-    <ElDialog
-      v-model="resetBackupConfigDialogOpen"
-      :title="t('protection.backupsPage.titleResetBackupConfig')"
-      class="hfl-flow-action-dialog hfl-flow-action-dialog--delete"
-      align-center
-      destroy-on-close
-      :close-on-click-modal="!resetBackupFromStep3Submitting"
-      :close-on-press-escape="!resetBackupFromStep3Submitting"
-      @closed="clearResetBackupConfigDialogState"
-    >
-      <BackupSourceResetDialogBody
-        v-model:confirm-text="resetBackupConfigConfirmText"
-        :sources="resetBackupConfigDisplayRows"
-        :loading="resetBackupFromStep3Submitting"
-        @confirm="confirmResetBackupConfiguration"
-      />
-      <template #footer>
-        <ElButton
-          :disabled="resetBackupFromStep3Submitting"
-          @click="resetBackupConfigDialogOpen = false"
+        <ElDialog
+          v-model="resetBackupConfigDialogOpen"
+          :title="t('protection.backupsPage.titleResetBackupConfig')"
+          class="hfl-flow-action-dialog hfl-flow-action-dialog--delete"
+          align-center
+          destroy-on-close
+          :close-on-click-modal="!resetBackupFromStep3Submitting"
+          :close-on-press-escape="!resetBackupFromStep3Submitting"
+          @closed="clearResetBackupConfigDialogState"
         >
-          {{ t('common.cancel') }}
-        </ElButton>
-        <ElButton
-          type="danger"
-          :disabled="resetBackupConfigConfirmText !== BACKUP_SOURCE_RESET_CONFIRMATION"
-          :loading="resetBackupFromStep3Submitting"
-          @click="confirmResetBackupConfiguration"
-        >
-          {{ t('protection.backupsPage.btnConfirmReset') }}
-        </ElButton>
-      </template>
-    </ElDialog>
-
-    <ElDialog
-      v-model="displayNameEditOpen"
-      :title="t('protection.backupsPage.displayNameDialogTitle')"
-      class="hfl-flow-action-dialog hfl-flow-action-dialog--form display-name-edit-dialog"
-      align-center
-      destroy-on-close
-      :show-close="!displayNameEditSubmitting"
-      :close-on-click-modal="!displayNameEditSubmitting"
-      :close-on-press-escape="!displayNameEditSubmitting"
-    >
-      <p class="display-name-edit-dialog__lead">
-        {{ t('protection.backupsPage.displayNameDialogLead') }}
-      </p>
-      <ElTable
-        v-table-overflow-title
-        :data="displayNameEditRows"
-        size="small"
-        class="hfl-flow-action-dialog__table hfl-table display-name-edit-dialog__table"
-        max-height="360"
-      >
-        <ElTableColumn
-          :label="t('protection.backupsPage.colBackupSource')"
-          min-width="240"
-        >
-          <template #default="{ row }">
-            <FlowSourceSummaryCell
-              :row="row.source"
-              :interactive="false"
-            />
-          </template>
-        </ElTableColumn>
-        <ElTableColumn
-          :label="t('protection.backupsPage.displayNameColumn')"
-          min-width="280"
-        >
-          <template #default="{ row }">
-            <ElFormItem
-              class="display-name-edit-dialog__field"
-              :error="displayNameEditError(row)"
+          <BackupSourceResetDialogBody
+            v-model:confirm-text="resetBackupConfigConfirmText"
+            :sources="resetBackupConfigDisplayRows"
+            :loading="resetBackupFromStep3Submitting"
+            @confirm="confirmResetBackupConfiguration"
+          />
+          <template #footer>
+            <ElButton
+              :disabled="resetBackupFromStep3Submitting"
+              @click="resetBackupConfigDialogOpen = false"
             >
-              <ElInput
-                v-model="row.name"
-                :maxlength="displayNameEditMaxLength(row)"
-                :placeholder="t('protection.backupsPage.displayNamePlaceholder')"
-                show-word-limit
-                :disabled="displayNameEditSubmitting"
-                @input="onDisplayNameInput(row)"
-                @keyup.enter="submitDisplayNameEdit"
-              />
-            </ElFormItem>
+              {{ t('common.cancel') }}
+            </ElButton>
+            <ElButton
+              type="danger"
+              :disabled="resetBackupConfigConfirmText !== BACKUP_SOURCE_RESET_CONFIRMATION"
+              :loading="resetBackupFromStep3Submitting"
+              @click="confirmResetBackupConfiguration"
+            >
+              {{ t('protection.backupsPage.btnConfirmReset') }}
+            </ElButton>
           </template>
-        </ElTableColumn>
-      </ElTable>
-      <template #footer>
-        <ElButton
-          :disabled="displayNameEditSubmitting"
-          @click="closeDisplayNameEditor"
+        </ElDialog>
+
+        <ElDialog
+          v-model="displayNameEditOpen"
+          :title="t('protection.backupsPage.displayNameDialogTitle')"
+          class="hfl-flow-action-dialog hfl-flow-action-dialog--form display-name-edit-dialog"
+          align-center
+          destroy-on-close
+          :show-close="!displayNameEditSubmitting"
+          :close-on-click-modal="!displayNameEditSubmitting"
+          :close-on-press-escape="!displayNameEditSubmitting"
         >
-          {{ t('common.cancel') }}
-        </ElButton>
-        <ElButton
-          type="primary"
-          :disabled="!displayNameEditCanSubmit"
-          :loading="displayNameEditSubmitting"
-          @click="submitDisplayNameEdit"
+          <p class="display-name-edit-dialog__lead">
+            {{ t('protection.backupsPage.displayNameDialogLead') }}
+          </p>
+          <ElTable
+            v-table-overflow-title
+            :data="displayNameEditRows"
+            size="small"
+            class="hfl-flow-action-dialog__table hfl-table display-name-edit-dialog__table"
+            max-height="360"
+          >
+            <ElTableColumn
+              :label="t('protection.backupsPage.colBackupSource')"
+              min-width="240"
+            >
+              <template #default="{ row }">
+                <FlowSourceSummaryCell
+                  :row="row.source"
+                  :interactive="false"
+                />
+              </template>
+            </ElTableColumn>
+            <ElTableColumn
+              :label="t('protection.backupsPage.displayNameColumn')"
+              min-width="280"
+            >
+              <template #default="{ row }">
+                <ElFormItem
+                  class="display-name-edit-dialog__field"
+                  :error="displayNameEditError(row)"
+                >
+                  <ElInput
+                    v-model="row.name"
+                    :maxlength="displayNameEditMaxLength(row)"
+                    :placeholder="t('protection.backupsPage.displayNamePlaceholder')"
+                    show-word-limit
+                    :disabled="displayNameEditSubmitting"
+                    @input="onDisplayNameInput(row)"
+                    @keyup.enter="submitDisplayNameEdit"
+                  />
+                </ElFormItem>
+              </template>
+            </ElTableColumn>
+          </ElTable>
+          <template #footer>
+            <ElButton
+              :disabled="displayNameEditSubmitting"
+              @click="closeDisplayNameEditor"
+            >
+              {{ t('common.cancel') }}
+            </ElButton>
+            <ElButton
+              type="primary"
+              :disabled="!displayNameEditCanSubmit"
+              :loading="displayNameEditSubmitting"
+              @click="submitDisplayNameEdit"
+            >
+              {{ t('common.save') }}
+            </ElButton>
+          </template>
+        </ElDialog>
+
+        <FlowBackupSourceDetailDrawer
+          v-if="flowSourceDetailMounted"
+          ref="flowSourceDetailDrawerRef"
+          v-model="flowSourceDetailOpen"
+          :drawer-size="drawerSize"
+          :source="activeFlowSource"
+          :source-rows="flowSourceDetailRows"
+          :initial-tab="flowSourceDetailTab"
+          :initial-task-sub-tab="flowSourceDetailTaskSubTab"
+          :initial-task-uuid="flowSourceDetailTaskUuid"
+          :initial-restore-record-id="flowSourceDetailRestoreRecordId"
+          :initial-restore-record-task-uuid="flowSourceDetailRestoreRecordTaskUuid"
+          :scroll-to="flowSourceDetailScrollTo"
+          :backup-flow-tasks="backupFlowTasks"
+          :restore-flow-tasks="restoreFlowTasks"
+          :backup-configs="backupConfigRows"
+          :backup-config-details="backupConfigDetailById"
+          :repositories="repositoryById"
+          :backup-policies="backupPolicyById"
+          :file-filters="fileFilterById"
+          :backup-snapshots="backupSnapshotRows"
+          :backup-tasks="flowSourceDetailOpen ? sourceRelatedTaskRows : EMPTY_TASK_ROWS"
+          @closed="onFlowSourceDetailClosed"
+          @start-backup="startBackupForSource"
+          @recover="openRecoveryForSource"
+          @restore-snapshot="openSnapshotRestore"
+          @view-all-restore="onFlowSourceDetailViewAllRestore"
+        />
+
+        <TaskDetailDrawer
+          v-model="backupTaskDetailOpen"
+          :task-uuid="backupTaskDetailUuid"
+          :drawer-size="drawerSize"
+        />
+
+        <el-drawer
+          v-model="restoreTaskDrawerOpen"
+          direction="rtl"
+          :size="drawerSize"
+          destroy-on-close
+          class="dp-restore-task-drawer"
+          @closed="onRestoreTaskDrawerClosed"
         >
-          {{ t('common.save') }}
-        </ElButton>
-      </template>
-    </ElDialog>
+          <template #header>
+            <div class="flex w-full min-w-0 flex-col gap-1 pr-1">
+              <span class="truncate text-base font-semibold text-slate-900">{{ t('protection.backupsPage.restoreTaskDrawerTitle') }}</span>
+              <span class="truncate text-xs text-slate-500">
+                {{ restoreDrawerSourceName }}
+              </span>
+            </div>
+          </template>
 
-    <FlowBackupSourceDetailDrawer
-      v-if="flowSourceDetailMounted"
-      ref="flowSourceDetailDrawerRef"
-      v-model="flowSourceDetailOpen"
-      :drawer-size="drawerSize"
-      :source="activeFlowSource"
-      :source-rows="flowSourceDetailRows"
-      :initial-tab="flowSourceDetailTab"
-      :initial-task-sub-tab="flowSourceDetailTaskSubTab"
-      :initial-task-uuid="flowSourceDetailTaskUuid"
-      :initial-restore-record-id="flowSourceDetailRestoreRecordId"
-      :initial-restore-record-task-uuid="flowSourceDetailRestoreRecordTaskUuid"
-      :scroll-to="flowSourceDetailScrollTo"
-      :backup-flow-tasks="backupFlowTasks"
-      :restore-flow-tasks="restoreFlowTasks"
-      :backup-configs="backupConfigRows"
-      :backup-config-details="backupConfigDetailById"
-      :repositories="repositoryById"
-      :backup-policies="backupPolicyById"
-      :file-filters="fileFilterById"
-      :backup-snapshots="backupSnapshotRows"
-      :backup-tasks="flowSourceDetailOpen ? sourceRelatedTaskRows : EMPTY_TASK_ROWS"
-      @closed="onFlowSourceDetailClosed"
-      @start-backup="startBackupForSource"
-      @recover="openRecoveryForSource"
-      @restore-snapshot="openSnapshotRestore"
-      @view-all-restore="onFlowSourceDetailViewAllRestore"
-    />
+          <div class="space-y-4">
+            <section
+              v-if="drawerRunningRestoreTasks.length > 0"
+              class="restore-task-section"
+            >
+              <div class="restore-task-section__head">
+                <span>{{ t('protection.backupsPage.restoreTaskRunningSection') }}</span>
+                <el-tag
+                  size="small"
+                  type="warning"
+                  effect="plain"
+                >
+                  {{ t('protection.backupsPage.restoreTaskRunningCount', { n: drawerRunningRestoreTasks.length }) }}
+                </el-tag>
+              </div>
+              <el-table
+                v-table-overflow-title
+                :data="drawerRunningRestoreTasks"
+                stripe
+                class="hfl-list-table restore-task-drawer-table"
+              >
+                <el-table-column
+                  :label="t('protection.backupsPage.flowRestoreRecordColName')"
+                  min-width="180"
+                >
+                  <template #default="{ row }">
+                    <button
+                      type="button"
+                      class="hfl-table-name-link restore-task-record-link"
+                      @click.stop="openRestoreTaskDetail(row)"
+                    >
+                      {{ row.title }}
+                    </button>
+                  </template>
+                </el-table-column>
+                <el-table-column
+                  :label="t('protection.backupsPage.flowTaskColPhase')"
+                  min-width="130"
+                >
+                  <template #default="{ row }">
+                    {{ restorePhaseLabel(row.phaseIndex) }}
+                  </template>
+                </el-table-column>
+                <el-table-column
+                  :label="t('protection.backupsPage.flowTaskColProgress')"
+                  min-width="130"
+                >
+                  <template #default="{ row }">
+                    <el-progress
+                      :percentage="row.progress"
+                      :stroke-width="7"
+                    />
+                  </template>
+                </el-table-column>
+                <el-table-column
+                  :label="t('protection.backupsPage.flowRestoreRecordColCreated')"
+                  min-width="150"
+                >
+                  <template #default="{ row }">
+                    {{ fmtLocalTime(row.startedAt) }}
+                  </template>
+                </el-table-column>
+              </el-table>
+            </section>
 
-    <TaskDetailDrawer
-      v-model="backupTaskDetailOpen"
-      :task-uuid="backupTaskDetailUuid"
-      :drawer-size="drawerSize"
-    />
-
-    <el-drawer
-      v-model="restoreTaskDrawerOpen"
-      direction="rtl"
-      :size="drawerSize"
-      destroy-on-close
-      class="dp-restore-task-drawer"
-      @closed="onRestoreTaskDrawerClosed"
-    >
-      <template #header>
-        <div class="flex w-full min-w-0 flex-col gap-1 pr-1">
-          <span class="truncate text-base font-semibold text-slate-900">{{ t('protection.backupsPage.restoreTaskDrawerTitle') }}</span>
-          <span class="truncate text-xs text-slate-500">
-            {{ restoreDrawerSourceName }}
-          </span>
-        </div>
-      </template>
-
-      <div class="space-y-4">
-        <section v-if="drawerRunningRestoreTasks.length > 0" class="restore-task-section">
-          <div class="restore-task-section__head">
-            <span>{{ t('protection.backupsPage.restoreTaskRunningSection') }}</span>
-            <el-tag size="small" type="warning" effect="plain">
-              {{ t('protection.backupsPage.restoreTaskRunningCount', { n: drawerRunningRestoreTasks.length }) }}
-            </el-tag>
+            <section class="restore-task-section">
+              <div class="restore-task-section__head">
+                <span>{{ t('protection.backupsPage.restoreTaskHistorySection') }}</span>
+                <el-tag
+                  size="small"
+                  effect="plain"
+                >
+                  {{ t('protection.backupsPage.restoreTaskTotalCount', { n: drawerHistoryRestoreTasks.length }) }}
+                </el-tag>
+              </div>
+              <el-table
+                v-table-overflow-title
+                :data="drawerPagedHistoryRestoreTasks"
+                stripe
+                class="hfl-list-table restore-task-drawer-table"
+              >
+                <el-table-column
+                  :label="t('protection.backupsPage.flowRestoreRecordColName')"
+                  min-width="180"
+                >
+                  <template #default="{ row }">
+                    <button
+                      type="button"
+                      class="hfl-table-name-link restore-task-record-link"
+                      @click.stop="openRestoreTaskDetail(row)"
+                    >
+                      {{ row.title }}
+                    </button>
+                  </template>
+                </el-table-column>
+                <el-table-column
+                  :label="t('protection.backupsPage.flowTaskColStatus')"
+                  width="92"
+                >
+                  <template #default="{ row }">
+                    <TaskStatusTag :status="row.status" />
+                  </template>
+                </el-table-column>
+                <el-table-column
+                  :label="t('protection.backupsPage.flowTaskColProgress')"
+                  width="120"
+                >
+                  <template #default="{ row }">
+                    <el-progress
+                      :percentage="row.progress"
+                      :status="row.status === 'failed' ? 'exception' : undefined"
+                      :stroke-width="7"
+                    />
+                  </template>
+                </el-table-column>
+                <el-table-column
+                  :label="t('protection.backupsPage.flowRestoreRecordColCreated')"
+                  min-width="150"
+                >
+                  <template #default="{ row }">
+                    <span
+                      class="hfl-table-cell-time"
+                      :class="{ 'hfl-empty-mark': !row.startedAt }"
+                    >{{ fmtLocalTime(row.startedAt) }}</span>
+                  </template>
+                </el-table-column>
+                <el-table-column
+                  :label="t('protection.backupsPage.flowRestoreRecordColFinished')"
+                  min-width="150"
+                >
+                  <template #default="{ row }">
+                    <span
+                      class="hfl-table-cell-time"
+                      :class="{ 'hfl-empty-mark': !row.endedAt }"
+                    >{{ row.endedAt ? fmtLocalTime(row.endedAt) : t('protection.backupDetail.durationDash') }}</span>
+                  </template>
+                </el-table-column>
+                <template #empty>
+                  <el-empty
+                    :description="t('protection.backupsPage.flowTaskEmptyRestore')"
+                    :image-size="64"
+                  />
+                </template>
+              </el-table>
+              <div class="hfl-list-footer">
+                <HflPagination
+                  v-model:current-page="restoreTaskPager.page"
+                  v-model:page-size="restoreTaskPager.pageSize"
+                  class="hfl-list-footer__pagination"
+                  :page-sizes="[5, 10, 20, 50]"
+                  :total="drawerHistoryRestoreTasks.length"
+                  layout="total, sizes, prev, pager, next"
+                  small
+                />
+              </div>
+            </section>
           </div>
-          <el-table
-          v-table-overflow-title
-            :data="drawerRunningRestoreTasks"
-            stripe
-            class="hfl-list-table restore-task-drawer-table"
-          >
-            <el-table-column :label="t('protection.backupsPage.flowRestoreRecordColName')" min-width="180">
-              <template #default="{ row }">
-                <button type="button" class="hfl-table-name-link restore-task-record-link" @click.stop="openRestoreTaskDetail(row)">
-                  {{ row.title }}
-                </button>
-              </template>
-            </el-table-column>
-            <el-table-column :label="t('protection.backupsPage.flowTaskColPhase')" min-width="130">
-              <template #default="{ row }">{{ restorePhaseLabel(row.phaseIndex) }}</template>
-            </el-table-column>
-            <el-table-column :label="t('protection.backupsPage.flowTaskColProgress')" min-width="130">
-              <template #default="{ row }">
-                <el-progress :percentage="row.progress" :stroke-width="7" />
-              </template>
-            </el-table-column>
-            <el-table-column :label="t('protection.backupsPage.flowRestoreRecordColCreated')" min-width="150">
-              <template #default="{ row }">{{ fmtLocalTime(row.startedAt) }}</template>
-            </el-table-column>
-          </el-table>
-        </section>
-
-        <section class="restore-task-section">
-          <div class="restore-task-section__head">
-            <span>{{ t('protection.backupsPage.restoreTaskHistorySection') }}</span>
-            <el-tag size="small" effect="plain">
-              {{ t('protection.backupsPage.restoreTaskTotalCount', { n: drawerHistoryRestoreTasks.length }) }}
-            </el-tag>
-          </div>
-          <el-table
-          v-table-overflow-title
-            :data="drawerPagedHistoryRestoreTasks"
-            stripe
-            class="hfl-list-table restore-task-drawer-table"
-          >
-            <el-table-column :label="t('protection.backupsPage.flowRestoreRecordColName')" min-width="180">
-              <template #default="{ row }">
-                <button type="button" class="hfl-table-name-link restore-task-record-link" @click.stop="openRestoreTaskDetail(row)">
-                  {{ row.title }}
-                </button>
-              </template>
-            </el-table-column>
-            <el-table-column :label="t('protection.backupsPage.flowTaskColStatus')" width="92">
-              <template #default="{ row }">
-                <TaskStatusTag :status="row.status" />
-              </template>
-            </el-table-column>
-            <el-table-column :label="t('protection.backupsPage.flowTaskColProgress')" width="120">
-              <template #default="{ row }">
-                <el-progress :percentage="row.progress" :status="row.status === 'failed' ? 'exception' : undefined" :stroke-width="7" />
-              </template>
-            </el-table-column>
-            <el-table-column :label="t('protection.backupsPage.flowRestoreRecordColCreated')" min-width="150">
-              <template #default="{ row }">
-                <span class="hfl-table-cell-time" :class="{ 'hfl-empty-mark': !row.startedAt }">{{ fmtLocalTime(row.startedAt) }}</span>
-              </template>
-            </el-table-column>
-            <el-table-column :label="t('protection.backupsPage.flowRestoreRecordColFinished')" min-width="150">
-              <template #default="{ row }">
-                <span class="hfl-table-cell-time" :class="{ 'hfl-empty-mark': !row.endedAt }">{{ row.endedAt ? fmtLocalTime(row.endedAt) : t('protection.backupDetail.durationDash') }}</span>
-              </template>
-            </el-table-column>
-            <template #empty>
-              <el-empty :description="t('protection.backupsPage.flowTaskEmptyRestore')" :image-size="64" />
-            </template>
-          </el-table>
-          <div class="hfl-list-footer">
-            <HflPagination
-              v-model:current-page="restoreTaskPager.page"
-              v-model:page-size="restoreTaskPager.pageSize"
-              class="hfl-list-footer__pagination"
-              :page-sizes="[5, 10, 20, 50]"
-              :total="drawerHistoryRestoreTasks.length"
-              layout="total, sizes, prev, pager, next"
-              small
-            />
-          </div>
-        </section>
+        </el-drawer>
       </div>
-    </el-drawer>
-
-    </div>
     </template>
 
     <el-dialog
@@ -10745,7 +11522,9 @@ async function runRecovery(mode: 'plan' | 'manual' = 'manual') {
       width="420px"
       destroy-on-close
     >
-      <p class="text-sm text-slate-600 mb-3">{{ t('protection.backupsPage.backupPickLead') }}</p>
+      <p class="text-sm text-slate-600 mb-3">
+        {{ t('protection.backupsPage.backupPickLead') }}
+      </p>
       <div class="space-y-2">
         <button
           v-for="config in backupConfigEditPickCandidates"
@@ -10768,7 +11547,9 @@ async function runRecovery(mode: 'plan' | 'manual' = 'manual') {
       width="420px"
       destroy-on-close
     >
-      <p class="text-sm text-slate-600 mb-3">{{ t('protection.backupsPage.backupPickLead') }}</p>
+      <p class="text-sm text-slate-600 mb-3">
+        {{ t('protection.backupsPage.backupPickLead') }}
+      </p>
       <div class="space-y-2">
         <button
           v-for="backup in backupPickCandidates"
@@ -10778,35 +11559,84 @@ async function runRecovery(mode: 'plan' | 'manual' = 'manual') {
           @click="onBackupPickSelected(backup)"
         >
           <span class="font-medium text-slate-800">{{ backup.name }}</span>
-          <span class="block text-xs text-slate-500 mt-0.5 truncate" :class="{ 'hfl-empty-mark': !backup.sources[0]?.path }">{{ backup.sources[0]?.path || '—' }}</span>
+          <span
+            class="block text-xs text-slate-500 mt-0.5 truncate"
+            :class="{ 'hfl-empty-mark': !backup.sources[0]?.path }"
+          >{{ backup.sources[0]?.path || '—' }}</span>
         </button>
       </div>
     </el-dialog>
 
-    <Modal v-if="editOpen" :open="editOpen" :title="t('protection.backupsPage.modalEditTitle')" variant="page" @close="editOpen = false">
-      <ElForm v-if="editRow" label-width="88px">
+    <Modal
+      v-if="editOpen"
+      :open="editOpen"
+      :title="t('protection.backupsPage.modalEditTitle')"
+      variant="page"
+      @close="editOpen = false"
+    >
+      <ElForm
+        v-if="editRow"
+        label-width="88px"
+      >
         <ElFormItem :label="t('protection.backupsPage.labelBackupName')">
           <ElInput v-model="editName" />
         </ElFormItem>
         <ElFormItem :label="t('protection.backupsPage.labelRemark')">
-          <ElInput v-model="editRemark" type="textarea" :rows="2" />
+          <ElInput
+            v-model="editRemark"
+            type="textarea"
+            :rows="2"
+          />
         </ElFormItem>
         <ElFormItem :label="t('protection.backupsPage.descPolicy')">
-          <el-select v-model="editPolicy" class="w-full" clearable :placeholder="t('protection.backupsPage.phNoPolicy')">
-            <el-option :label="t('protection.backupsPage.optNoPolicy')" value="" />
-            <el-option v-for="pol in store.policies" :key="pol.id" :label="pol.name" :value="pol.id" />
+          <el-select
+            v-model="editPolicy"
+            class="w-full"
+            clearable
+            :placeholder="t('protection.backupsPage.phNoPolicy')"
+          >
+            <el-option
+              :label="t('protection.backupsPage.optNoPolicy')"
+              value=""
+            />
+            <el-option
+              v-for="pol in store.policies"
+              :key="pol.id"
+              :label="pol.name"
+              :value="pol.id"
+            />
           </el-select>
         </ElFormItem>
         <ElFormItem :label="t('protection.backupsPage.descFileFilter')">
-          <el-select v-model="editGlobalFilter" class="w-full" clearable :placeholder="t('protection.backupsPage.phNoGlobalFilter')">
-            <el-option :label="t('protection.backupsPage.optNoGlobalFilter')" value="" />
-            <el-option v-for="gf in store.globalFilters" :key="gf.id" :label="gf.name" :value="gf.id" />
+          <el-select
+            v-model="editGlobalFilter"
+            class="w-full"
+            clearable
+            :placeholder="t('protection.backupsPage.phNoGlobalFilter')"
+          >
+            <el-option
+              :label="t('protection.backupsPage.optNoGlobalFilter')"
+              value=""
+            />
+            <el-option
+              v-for="gf in store.globalFilters"
+              :key="gf.id"
+              :label="gf.name"
+              :value="gf.id"
+            />
           </el-select>
         </ElFormItem>
       </ElForm>
       <div class="mt-4 flex justify-end gap-2">
-        <ElButton @click="editOpen = false">{{ t('protection.backupsPage.btnCancel') }}</ElButton>
-        <ElButton type="primary" @click="saveEdit">{{ t('protection.backupsPage.btnSave') }}</ElButton>
+        <ElButton @click="editOpen = false">
+          {{ t('protection.backupsPage.btnCancel') }}
+        </ElButton>
+        <ElButton
+          type="primary"
+          @click="saveEdit"
+        >
+          {{ t('protection.backupsPage.btnSave') }}
+        </ElButton>
       </div>
     </Modal>
 
@@ -10819,18 +11649,31 @@ async function runRecovery(mode: 'plan' | 'manual' = 'manual') {
       >
         <div class="fullscreen-form-page">
           <div class="fullscreen-form-header">
-            <button type="button" class="fullscreen-form-header__back" @click="closeRecoveryWizard">
-              <ArrowLeft class="fullscreen-form-header__back-icon" :size="18" />
+            <button
+              type="button"
+              class="fullscreen-form-header__back"
+              @click="closeRecoveryWizard"
+            >
+              <ArrowLeft
+                class="fullscreen-form-header__back-icon"
+                :size="18"
+              />
             </button>
             <div class="fullscreen-form-header__content">
-              <h1 class="fullscreen-form-header__title">{{ t('protection.backupsPage.snapshotRestoreTitle') }}</h1>
+              <h1 class="fullscreen-form-header__title">
+                {{ t('protection.backupsPage.snapshotRestoreTitle') }}
+              </h1>
             </div>
           </div>
           <div class="fullscreen-form-layout">
             <main class="fullscreen-form-main">
               <section class="fullscreen-form-card">
                 <div class="fullscreen-form-section">
-                  <el-skeleton v-if="fixedRestoreInitializing" :rows="6" animated />
+                  <el-skeleton
+                    v-if="fixedRestoreInitializing"
+                    :rows="6"
+                    animated
+                  />
                   <el-result
                     v-else
                     icon="error"
@@ -10838,7 +11681,10 @@ async function runRecovery(mode: 'plan' | 'manual' = 'manual') {
                     :sub-title="fixedRestoreInitError"
                   >
                     <template #extra>
-                      <ElButton type="primary" @click="closeRecoveryWizard">
+                      <ElButton
+                        type="primary"
+                        @click="closeRecoveryWizard"
+                      >
                         {{ t('protection.backupsPage.snapshotRestoreBack') }}
                       </ElButton>
                     </template>
@@ -10860,8 +11706,15 @@ async function runRecovery(mode: 'plan' | 'manual' = 'manual') {
       >
         <div class="fullscreen-form-page">
           <div class="fullscreen-form-header">
-            <button type="button" class="fullscreen-form-header__back" @click="closeRecoveryWizard">
-              <ArrowLeft class="fullscreen-form-header__back-icon" :size="18" />
+            <button
+              type="button"
+              class="fullscreen-form-header__back"
+              @click="closeRecoveryWizard"
+            >
+              <ArrowLeft
+                class="fullscreen-form-header__back-icon"
+                :size="18"
+              />
             </button>
             <div class="fullscreen-form-header__content">
               <h1 class="fullscreen-form-header__title">
@@ -10869,7 +11722,10 @@ async function runRecovery(mode: 'plan' | 'manual' = 'manual') {
                   ? `${t('protection.backupsPage.snapshotRestoreTitle')} · ${fixedRestoreSnapshot?.snapshot_uid || `#${fixedRestoreSnapshot?.id}`}`
                   : t('protection.backupsPage.modalCreateRestoreTitle') }}
               </h1>
-              <p v-if="recEntryStage === 'chooser' && !isFixedSnapshotRestore" class="fullscreen-form-header__desc">
+              <p
+                v-if="recEntryStage === 'chooser' && !isFixedSnapshotRestore"
+                class="fullscreen-form-header__desc"
+              >
                 {{ t('protection.backupsPage.recoveryEntryLead') }}
               </p>
             </div>
@@ -10890,1336 +11746,1575 @@ async function runRecovery(mode: 'plan' | 'manual' = 'manual') {
             <main class="fullscreen-form-main fullscreen-form-main--wizard">
               <section class="fullscreen-form-card fullscreen-form-step-section fullscreen-form-step-section--active dp-restore-wizard-card">
                 <div class="fullscreen-form-section dp-restore-wizard-body">
-        <template v-if="recEntryStage === 'chooser'">
-          <div class="recovery-entry-panel space-y-4">
-            <ElRadioGroup v-if="!isFixedSnapshotRestore" v-model="recEntryMode" class="recovery-entry-options" @change="onRecoveryEntryModeChange">
-              <ElRadio value="plan" border class="recovery-entry-card !mr-0">
-                <span class="recovery-entry-card__icon recovery-entry-card__icon--plan" aria-hidden="true">
-                  <ArchiveRestore :size="20" />
-                </span>
-                <div class="recovery-entry-card__body">
-                  <div class="recovery-entry-card__title">{{ t('protection.backupsPage.recoveryEntryPlanTitle') }}</div>
-                  <p class="recovery-entry-card__desc">{{ t('protection.backupsPage.recoveryEntryPlanDesc') }}</p>
-                </div>
-              </ElRadio>
-              <ElRadio value="manual" border class="recovery-entry-card !mr-0">
-                <span class="recovery-entry-card__icon recovery-entry-card__icon--manual" aria-hidden="true">
-                  <CirclePlus :size="20" />
-                </span>
-                <div class="recovery-entry-card__body">
-                  <div class="recovery-entry-card__title">{{ t('protection.backupsPage.recoveryEntryManualTitle') }}</div>
-                  <p class="recovery-entry-card__desc">{{ t('protection.backupsPage.recoveryEntryManualDesc') }}</p>
-                </div>
-              </ElRadio>
-            </ElRadioGroup>
-
-            <div
-              v-if="!isFixedSnapshotRestore && recEntryMode === 'plan' && recoveryPlanTableRows.length"
-              class="rounded-[var(--radius-card)] border border-[var(--color-border,#e2e8f0)] bg-[var(--color-card-bg,#fff)] p-4"
-            >
-              <p class="m-0 mb-3 text-xs text-slate-500">{{ t('protection.backupsPage.recoveryPlanPreviewHint') }}</p>
-              <el-table
-          v-table-overflow-title
-                :data="recoveryPlanTableRows"
-                :header-cell-style="TABLE_HEADER_STYLE"
-                stripe
-                class="recovery-plan-preview-table"
-                row-key="rowKey"
-              >
-                <el-table-column
-                  :label="t('protection.backupsPage.colBackupSourceAndSnapshot')"
-                  min-width="220"
-                >
-                  <template #default="{ row }">
-                    <div class="recovery-plan-preview-table__source-cell">
-                      <span
-                        class="recovery-plan-preview-table__source"
+                  <template v-if="recEntryStage === 'chooser'">
+                    <div class="recovery-entry-panel space-y-4">
+                      <ElRadioGroup
+                        v-if="!isFixedSnapshotRestore"
+                        v-model="recEntryMode"
+                        class="recovery-entry-options"
+                        @change="onRecoveryEntryModeChange"
                       >
-                        {{ row.sourceResourceName }}
-                      </span>
-                      <span
-                        class="recovery-plan-preview-table__endpoint-ip"
-                      >
-                        {{ row.sourceHostIp }}
-                      </span>
-                      <span class="recovery-plan-preview-table__source-snapshot text-xs text-slate-500">
-                        {{ t('protection.backupsPage.descSnapshot') }}: {{ fmtLocalTime(row.snapshotTime) }}
-                      </span>
-                    </div>
-                  </template>
-                </el-table-column>
-                <el-table-column
-                  :label="t('protection.backupsPage.descRecoveryPlan')"
-                  min-width="520"
-                >
-                  <template #default="{ row }">
-                    <HflPopover
-                      v-if="row.state === 'configured' && row.plan"
-                      trigger="hover"
-                      placement="top-start"
-                      :width="640"
-                      popper-class="create-recovery-plan-tooltip create-recovery-plan-tooltip--wide"
-                    >
-                      <template #reference>
-                        <div
-                          class="create-recovery-plan-cell create-recovery-plan-cell--review"
-                          :class="`create-recovery-plan-cell--${recoveryPlanRunStatusTone(row.plan)}`"
+                        <ElRadio
+                          value="plan"
+                          border
+                          class="recovery-entry-card !mr-0"
                         >
-                          <div class="create-recovery-plan-cell__status">
-                            <span class="create-recovery-plan-cell__dot" aria-hidden="true" />
-                            <span class="create-recovery-plan-cell__status-label">
-                              {{ recoveryPlanRunStatusLabel(row.plan) }}
-                            </span>
-                          </div>
-                          <div
-                            class="create-recovery-plan-cell__policy"
-                            :class="`create-recovery-plan-cell__policy--${row.plan.conflictPolicy}`"
+                          <span
+                            class="recovery-entry-card__icon recovery-entry-card__icon--plan"
+                            aria-hidden="true"
                           >
-                            <ShieldAlert
-                              v-if="row.plan.conflictPolicy === 'overwrite'"
-                              :size="14"
-                              class="create-recovery-plan-cell__policy-icon"
-                            />
-                            <ShieldCheck v-else :size="14" class="create-recovery-plan-cell__policy-icon" />
-                            <span class="create-recovery-plan-cell__policy-text">
-                              {{ recoveryPlanRunConflictSummary(row.plan) }}
-                            </span>
-                          </div>
-                          <div class="create-recovery-plan-cell__mappings">
-                            <div
-                              v-for="mapping in row.plan.mappings"
-                              :key="mapping.id"
-                              class="create-recovery-plan-mapping"
-                            >
-                              <span
-                                class="create-recovery-plan-mapping__endpoint"
-                                :class="`create-recovery-plan-mapping__endpoint--${recoveryPlanRunSourceKind(mapping.sourceDir)}`"
-                                :title="recoveryPlanRunSourcePathLabel(mapping.sourceDir)"
-                              >
-                                <component :is="recoveryPlanRunSourceIcon(mapping.sourceDir)" :size="14" class="create-recovery-plan-mapping__icon" />
-                                <span class="create-recovery-plan-mapping__text" :title="recoveryPlanRunSourcePathLabel(mapping.sourceDir)">{{ recoveryPlanRunSourcePathLabel(mapping.sourceDir) }}</span>
-                              </span>
-                              <span class="create-recovery-plan-mapping__arrow" aria-hidden="true">-&gt;</span>
-                              <span
-                                class="create-recovery-plan-mapping__endpoint create-recovery-plan-mapping__endpoint--target"
-                                :title="recoveryPlanMappingTargetSummary(mapping)"
-                              >
-                                <FolderOpen :size="14" class="create-recovery-plan-mapping__icon" />
-                                <span class="create-recovery-plan-mapping__text" :title="recoveryPlanMappingTargetSummary(mapping)">{{ recoveryPlanMappingTargetSummary(mapping) }}</span>
-                              </span>
+                            <ArchiveRestore :size="20" />
+                          </span>
+                          <div class="recovery-entry-card__body">
+                            <div class="recovery-entry-card__title">
+                              {{ t('protection.backupsPage.recoveryEntryPlanTitle') }}
                             </div>
+                            <p class="recovery-entry-card__desc">
+                              {{ t('protection.backupsPage.recoveryEntryPlanDesc') }}
+                            </p>
                           </div>
-                        </div>
-                      </template>
-                      <template #default>
-                        <div class="create-recovery-plan-tooltip__content">
-                          <div
-                            class="create-recovery-plan-tooltip__policy"
-                            :class="`create-recovery-plan-tooltip__policy--${row.plan.conflictPolicy}`"
+                        </ElRadio>
+                        <ElRadio
+                          value="manual"
+                          border
+                          class="recovery-entry-card !mr-0"
+                        >
+                          <span
+                            class="recovery-entry-card__icon recovery-entry-card__icon--manual"
+                            aria-hidden="true"
                           >
-                            <ShieldAlert
-                              v-if="row.plan.conflictPolicy === 'overwrite'"
-                              :size="14"
-                              class="create-recovery-plan-cell__policy-icon"
-                            />
-                            <ShieldCheck v-else :size="14" class="create-recovery-plan-cell__policy-icon" />
-                            <span class="create-recovery-plan-cell__policy-text">
-                              {{ recoveryPlanRunConflictSummary(row.plan) }}
-                            </span>
-                          </div>
-                          <div
-                            v-for="mapping in row.plan.mappings"
-                            :key="`${mapping.id}-tooltip`"
-                            class="create-recovery-plan-tooltip__mapping create-recovery-plan-mapping"
-                          >
-                            <span
-                              class="create-recovery-plan-mapping__endpoint"
-                              :class="`create-recovery-plan-mapping__endpoint--${recoveryPlanRunSourceKind(mapping.sourceDir)}`"
-                              :title="recoveryPlanRunSourcePathLabel(mapping.sourceDir)"
-                            >
-                              <component :is="recoveryPlanRunSourceIcon(mapping.sourceDir)" :size="14" class="create-recovery-plan-mapping__icon" />
-                              <span class="create-recovery-plan-mapping__text" :title="recoveryPlanRunSourcePathLabel(mapping.sourceDir)">{{ recoveryPlanRunSourcePathLabel(mapping.sourceDir) }}</span>
-                            </span>
-                            <span class="create-recovery-plan-mapping__arrow" aria-hidden="true">-&gt;</span>
-                            <span
-                              class="create-recovery-plan-mapping__endpoint create-recovery-plan-mapping__endpoint--target"
-                              :title="recoveryPlanMappingTargetSummary(mapping)"
-                            >
-                              <FolderOpen :size="14" class="create-recovery-plan-mapping__icon" />
-                              <span class="create-recovery-plan-mapping__text" :title="recoveryPlanMappingTargetSummary(mapping)">{{ recoveryPlanMappingTargetSummary(mapping) }}</span>
-                            </span>
-                          </div>
-                        </div>
-                      </template>
-                    </HflPopover>
-                    <div
-                      v-else
-                      class="create-recovery-plan-cell create-recovery-plan-cell--review create-recovery-plan-cell--pending recovery-plan-missing-cell"
-                    >
-                      <div class="create-recovery-plan-cell__status">
-                        <span class="create-recovery-plan-cell__dot" aria-hidden="true" />
-                        <span class="create-recovery-plan-cell__status-label">
-                          {{ t('protection.backupsPage.recoveryPlanMissingTitle') }}
-                        </span>
-                      </div>
-                      <div class="create-recovery-plan-cell__meta">
-                        {{ t('protection.backupsPage.recoveryPlanMissingDesc') }}
-                      </div>
-                      <ElButton
-                        text
-                        type="primary"
-                        size="small"
-                        class="hfl-btn-with-icon recovery-plan-missing-cell__action hfl-table-no-tooltip"
-                        @click="openConfigureRestorePlanFromMissingRow(row)"
-                      >
-                        <Route :size="14" class="shrink-0" />
-                        <span>{{ t('protection.backupsPage.flowActionConfigureRecoveryPlan') }}</span>
-                      </ElButton>
-                    </div>
-                  </template>
-                </el-table-column>
-                <el-table-column
-                  :label="t('protection.backupsPage.descSnapshot')"
-                  min-width="300"
-                >
-                  <template #default="{ row }">
-                    <el-select
-                      v-if="row.state === 'configured' && row.plan"
-                      :model-value="recoveryPlanSelectedSnapshotId(row.plan)"
-                      :placeholder="t('protection.backupsPage.phPickSnapshot')"
-                      class="w-full recovery-plan-preview-table__snapshot-select"
-                      :loading="recoverySnapshotListStateForHost(backupSourceHostId(row.plan.backupId)).loading"
-                      @visible-change="(visible) => onRecoveryPlanSnapshotVisible(row.plan, visible)"
-                      @update:model-value="(value) => updateRecoveryPlanSnapshot(row.plan, value)"
-                    >
-                      <el-option
-                        v-for="s in recoverySnapshotOptionsForSource(backupSourceHostId(row.plan.backupId))"
-                        :key="s.id"
-                        :label="`${fmtLocalTime(s.time)} · ${fmtBytes(s.sizeBytes)}`"
-                        :value="s.id"
-                        :disabled="!restorePlanSnapshotCompatibility(row.plan, s).compatible"
-                      >
-                        <ElTooltip
-                          :disabled="restorePlanSnapshotCompatibility(row.plan, s).compatible"
-                          :content="restorePlanSnapshotCompatibility(row.plan, s).reason"
-                          placement="bottom-start"
-                          :show-after="300"
-                        >
-                          <div class="recovery-snapshot-option" :class="{ 'is-disabled': !restorePlanSnapshotCompatibility(row.plan, s).compatible }">
-                            <span class="recovery-snapshot-option__label">
-                              {{ fmtLocalTime(s.time) }} · {{ fmtBytes(s.sizeBytes) }}
-                            </span>
-                            <el-tag
-                              size="small"
-                              :type="lifecycleStatusTagAttrs(s.status).type"
-                              :class="lifecycleStatusTagAttrs(s.status).class"
-                              effect="plain"
-                            >
-                              {{ snapshotStatusLabel(s.status) }}
-                            </el-tag>
-                            <Info
-                              v-if="!restorePlanSnapshotCompatibility(row.plan, s).compatible"
-                              :size="14"
-                              class="recovery-snapshot-option__info"
-                            />
-                          </div>
-                        </ElTooltip>
-                      </el-option>
-                      <el-option
-                        v-if="recoverySnapshotHasMore(backupSourceHostId(row.plan.backupId))"
-                        :key="`${row.rowKey}-snapshot-load-more`"
-                        :value="RECOVERY_SNAPSHOT_LOAD_MORE_VALUE"
-                        :label="recoverySnapshotLoadMoreLabel(backupSourceHostId(row.plan.backupId))"
-                      >
-                        <button
-                          type="button"
-                          class="recovery-snapshot-load-more"
-                          @mousedown.prevent
-                          @click.stop="updateRecoveryPlanSnapshot(row.plan, RECOVERY_SNAPSHOT_LOAD_MORE_VALUE)"
-                        >
-                          {{ recoverySnapshotLoadMoreLabel(backupSourceHostId(row.plan.backupId)) }}
-                        </button>
-                      </el-option>
-                    </el-select>
-                    <span v-else class="hfl-empty-mark">—</span>
-                  </template>
-                </el-table-column>
-              </el-table>
-            </div>
-            <div
-              v-else-if="recEntryMode === 'plan'"
-              class="recovery-plan-empty-state"
-            >
-              {{ t('protection.backupsPage.msgRecoveryPlanUnavailable') }}
-            </div>
-
-          </div>
-        </template>
-        <template v-else>
-        <div v-show="recStep === 0" class="dp-wizard-pane">
-          <p class="text-sm text-slate-500 mb-3">{{ t('protection.backupsPage.recStepBackupAndSnapshotLead') }}</p>
-          <div class="recovery-manual-table-shell">
-            <el-table
-          v-table-overflow-title
-              :data="recBackupSnapshotHostRows"
-              :header-cell-style="TABLE_HEADER_STYLE"
-              stripe
-              class="recovery-plan-preview-table recovery-manual-table"
-              row-key="rowKey"
-            >
-              <el-table-column
-                :label="t('protection.backupsPage.colBackupSource')"
-                min-width="240"
-              >
-                <template #default="{ row }">
-                  <div class="recovery-source-summary">
-                    <div class="recovery-source-summary__head">
-                      <span class="recovery-source-summary__name">
-                        {{ row.sourceSummary.displayName }}
-                      </span>
-                      <el-tag
-                        size="small"
-                        effect="plain"
-                        class="recovery-source-summary__type"
-                        :type="row.sourceSummary.typeTagType"
-                      >
-                        {{ row.sourceSummary.typeLabel }}
-                      </el-tag>
-                    </div>
-                    <div class="recovery-source-summary__meta">
-                      <span class="recovery-source-summary__ip">
-                        {{ row.sourceSummary.ipLine }}
-                      </span>
-                      <span class="recovery-source-summary__platform">
-                        <AgentPlatformBrandIcon
-                          v-if="row.sourceSummary.platform"
-                          :os="row.sourceSummary.platform"
-                        />
-                        <component
-                          :is="row.sourceSummary.sourceType === 'nas' ? sourceNasIcon : sourceHostIcon"
-                          v-else
-                          :size="16"
-                        />
-                      </span>
-                    </div>
-                  </div>
-                </template>
-              </el-table-column>
-              <el-table-column
-                :label="t('protection.backupsPage.descSnapshot')"
-                min-width="280"
-              >
-                <template #default="{ row }">
-                  <el-select
-                    :model-value="recGroupSnapshotId(row.hostId)"
-                    :placeholder="t('protection.backupsPage.phPickSnapshot')"
-                    class="w-full recovery-plan-preview-table__snapshot-select"
-                    :loading="recoverySnapshotListStateForHost(row.hostId).loading"
-                    @visible-change="(visible) => onRecoverySnapshotSelectVisible(row.hostId, visible)"
-                    @update:model-value="(value) => updateRecoverySnapshotSelectValue(row.hostId, value)"
-                  >
-                    <el-option
-                      v-for="s in recoverySnapshotOptionsForSource(row.hostId)"
-                      :key="s.id"
-                      :label="`${fmtLocalTime(s.time)} · ${fmtBytes(s.sizeBytes)}`"
-                      :value="s.id"
-                    >
-                      <div class="recovery-snapshot-option">
-                        <span class="recovery-snapshot-option__label">
-                          {{ fmtLocalTime(s.time) }} · {{ fmtBytes(s.sizeBytes) }}
-                        </span>
-                        <el-tag
-                          size="small"
-                          :type="lifecycleStatusTagAttrs(s.status).type"
-                          :class="lifecycleStatusTagAttrs(s.status).class"
-                          effect="plain"
-                        >
-                          {{ snapshotStatusLabel(s.status) }}
-                        </el-tag>
-                      </div>
-                    </el-option>
-                    <el-option
-                      v-if="recoverySnapshotHasMore(row.hostId)"
-                      :key="`${row.rowKey}-snapshot-load-more`"
-                      :value="RECOVERY_SNAPSHOT_LOAD_MORE_VALUE"
-                      :label="recoverySnapshotLoadMoreLabel(row.hostId)"
-                    >
-                      <button
-                        type="button"
-                        class="recovery-snapshot-load-more"
-                        @mousedown.prevent
-                        @click.stop="updateRecoverySnapshotSelectValue(row.hostId, RECOVERY_SNAPSHOT_LOAD_MORE_VALUE)"
-                      >
-                        {{ recoverySnapshotLoadMoreLabel(row.hostId) }}
-                      </button>
-                    </el-option>
-                  </el-select>
-                </template>
-              </el-table-column>
-            </el-table>
-          </div>
-        </div>
-
-        <div v-show="recStep === 1" class="dp-wizard-pane">
-          <p class="text-sm text-slate-500 mb-3">{{ t('protection.backupsPage.recStep3Lead') }}</p>
-          <div class="recovery-manual-table-shell">
-            <el-table
-          v-table-overflow-title
-              :data="recRecoveryDestSourceRows"
-              row-key="hostId"
-              stripe
-              :header-cell-style="TABLE_HEADER_STYLE"
-              class="hfl-list-table recovery-manual-table"
-            >
-              <el-table-column :label="t('protection.backupsPage.colBackupSourceSnapshot')" min-width="260">
-                <template #default="{ row }">
-                  <div class="recovery-source-summary recovery-source-summary--with-snapshot">
-                    <div class="recovery-source-summary__head">
-                      <span class="recovery-source-summary__name">
-                        {{ row.sourceSummary.displayName }}
-                      </span>
-                      <el-tag
-                        size="small"
-                        effect="plain"
-                        class="recovery-source-summary__type"
-                        :type="row.sourceSummary.typeTagType"
-                      >
-                        {{ row.sourceSummary.typeLabel }}
-                      </el-tag>
-                    </div>
-                    <div class="recovery-source-summary__meta">
-                      <span class="recovery-source-summary__ip">
-                        {{ row.sourceSummary.ipLine }}
-                      </span>
-                      <span class="recovery-source-summary__platform">
-                        <AgentPlatformBrandIcon
-                          v-if="row.sourceSummary.platform"
-                          :os="row.sourceSummary.platform"
-                        />
-                        <component
-                          :is="row.sourceSummary.sourceType === 'nas' ? sourceNasIcon : sourceHostIcon"
-                          v-else
-                          :size="16"
-                        />
-                      </span>
-                    </div>
-                    <div class="recovery-source-summary__snapshot">
-                      Snapshot: {{ row.snapshotLine }}
-                    </div>
-                  </div>
-                </template>
-              </el-table-column>
-              <el-table-column :label="t('protection.backupsPage.recStepDest')" min-width="360">
-                <template #default="{ row }">
-                  <div class="recovery-target-host-control hfl-table-no-tooltip">
-                    <ElTooltip
-                      :disabled="Boolean(recoverySourceHostButtonOption(row.hostId))"
-                      :content="t('protection.backupsPage.recoverySourceHostUnavailable')"
-                      placement="top"
-                    >
-                      <span class="recovery-target-host-control__source-wrap">
-                        <ElButton
-                          class="hfl-btn-with-icon recovery-target-host-control__source"
-                          :class="{ 'is-selected': isRecoverySourceHostSelected(row.hostId) }"
-                          :disabled="!recoverySourceHostButtonOption(row.hostId)"
-                          @click="toggleRecoverySourceTargetForSource(row.hostId)"
-                        >
-                          <Check v-if="isRecoverySourceHostSelected(row.hostId)" :size="14" />
-                          <component
-                            :is="row.sourceSummary.sourceType === 'nas' ? sourceNasIcon : sourceHostIcon"
-                            v-else
-                            :size="14"
-                          />
-                          <span>{{ t('protection.backupsPage.recoveryUseSourceHost') }}</span>
-                        </ElButton>
-                      </span>
-                    </ElTooltip>
-                    <div
-                      v-if="isRecoverySourceHostSelected(row.hostId)"
-                      class="recovery-target-host-control__readonly"
-                    >
-                      <div class="recovery-source-summary">
-                        <div class="recovery-source-summary__head">
-                          <span class="recovery-source-summary__name">
-                            {{ row.sourceSummary.displayName }}
+                            <CirclePlus :size="20" />
                           </span>
-                          <el-tag
-                            size="small"
-                            effect="plain"
-                            class="recovery-source-summary__type"
-                            :type="row.sourceSummary.typeTagType"
-                          >
-                            {{ row.sourceSummary.typeLabel }}
-                          </el-tag>
-                        </div>
-                        <div class="recovery-source-summary__meta">
-                          <span class="recovery-source-summary__ip">
-                            {{ row.sourceSummary.ipLine }}
-                          </span>
-                          <span class="recovery-source-summary__platform">
-                            <AgentPlatformBrandIcon
-                              v-if="row.sourceSummary.platform"
-                              :os="row.sourceSummary.platform"
-                            />
-                            <component
-                              :is="row.sourceSummary.sourceType === 'nas' ? sourceNasIcon : sourceHostIcon"
-                              v-else
-                              :size="16"
-                            />
-                          </span>
-                        </div>
-                      </div>
-                    </div>
-                    <el-select
-                      v-else
-                      :model-value="recoveryTargetNodeSelectModelForSource(row.hostId)"
-                      :placeholder="t('protection.backupsPage.phPickOtherRecoveryHost')"
-                      class="recovery-target-host-control__select"
-                      filterable
-                      remote
-                      reserve-keyword
-                      clearable
-                      :remote-method="searchRecoveryTargetHostOptions"
-                      :loading="recoveryTargetHostLoading || recoveryTargetHostLoadingMore"
-                      popper-class="recovery-target-node-select-popper"
-                      @visible-change="onRecoveryTargetNodeSelectVisible"
-                      @popup-scroll="onRecoveryTargetNodePopupScroll"
-                      @update:model-value="(value) => setRecoveryTargetNodeForSource(row.hostId, value)"
-                    >
-                      <el-option
-                        v-for="option in recoveryTargetNodeOptionsForSource(row.hostId)"
-                        :key="option.value"
-                        :label="option.label"
-                        :value="option.value"
-                        :disabled="!option.selectable"
-                      >
-                        <div class="recovery-target-node-option">
-                          <div class="recovery-target-node-option__main">
-                            <span class="recovery-target-node-option__label" :title="option.sourceSummary.displayName">
-                              {{ option.sourceSummary.displayName }}
-                            </span>
-                            <el-tag
-                              size="small"
-                              effect="plain"
-                              class="recovery-source-summary__type"
-                              :type="option.sourceSummary.typeTagType"
-                            >
-                              {{ option.sourceSummary.typeLabel }}
-                            </el-tag>
+                          <div class="recovery-entry-card__body">
+                            <div class="recovery-entry-card__title">
+                              {{ t('protection.backupsPage.recoveryEntryManualTitle') }}
+                            </div>
+                            <p class="recovery-entry-card__desc">
+                              {{ t('protection.backupsPage.recoveryEntryManualDesc') }}
+                            </p>
                           </div>
-                          <div class="recovery-source-summary__meta">
-                            <span class="recovery-target-node-option__meta" :title="option.sourceSummary.ipLine">
-                              {{ option.sourceSummary.ipLine }}
-                            </span>
-                            <span class="recovery-source-summary__platform">
-                              <AgentPlatformBrandIcon
-                                v-if="option.sourceSummary.platform"
-                                :os="option.sourceSummary.platform"
-                              />
-                              <component
-                                :is="option.sourceSummary.sourceType === 'nas' ? sourceNasIcon : sourceHostIcon"
-                                v-else
-                                :size="16"
-                              />
-                            </span>
-                          </div>
-                        </div>
-                      </el-option>
-                      <el-option
-                        v-if="recoveryTargetHostLoadingMore"
-                        key="recovery-target-loading-more"
-                        disabled
-                        value="__loading_more__"
-                        :label="t('common.loading')"
-                      >
-                        <span class="recovery-target-node-option__loading">{{ t('common.loading') }}</span>
-                      </el-option>
-                      <el-option
-                        v-else-if="recoveryTargetHostError"
-                        key="recovery-target-load-more-error"
-                        disabled
-                        value="__load_more_error__"
-                        :label="t('protection.backupsPage.recoveryTargetLoadFailed')"
-                      >
-                        <ElButton link type="primary" @click.stop="restoreTargetCatalog.retry">
-                          {{ t('common.retry') }}
-                        </ElButton>
-                      </el-option>
-                      <template #empty>
-                        <div class="py-3 text-center text-xs text-slate-500">
-                          <span>{{ recoveryTargetHostError ? t('protection.backupsPage.recoveryTargetLoadFailed') : t('protection.backupsPage.recoveryTargetEmpty') }}</span>
-                          <ElButton v-if="recoveryTargetHostError" link type="primary" @click.stop="restoreTargetCatalog.retry">
-                            {{ t('common.retry') }}
-                          </ElButton>
-                        </div>
-                      </template>
-                    </el-select>
-                  </div>
-                </template>
-              </el-table-column>
-            </el-table>
-          </div>
-        </div>
+                        </ElRadio>
+                      </ElRadioGroup>
 
-        <div v-show="recStep === 2" class="dp-wizard-pane">
-          <p class="text-sm text-slate-500 mb-3">{{ t('protection.backupsPage.recStep2Lead') }}</p>
-          <div class="recovery-manual-table-shell">
-            <el-table
-          v-table-overflow-title
-              ref="recRecoveryDirSourceTableRef"
-              :data="recRecoveryDirSourceRows"
-              row-key="hostId"
-              stripe
-              :expand-row-keys="recExpandedRecDirHostIds"
-              :header-cell-style="TABLE_HEADER_STYLE"
-              class="hfl-list-table recovery-dest-config-table recovery-dir-config-table recovery-manual-table"
-              @expand-change="onRecRecoveryDirExpandChange"
-            >
-              <el-table-column type="expand" width="35" class-name="recovery-dest-config-expand-column">
-                <template #default="{ row: sourceRow }">
-                  <div class="recovery-dest-config-detail">
-                    <div class="create-recovery-dir-plan-list recovery-dir-selection-list">
-                      <div class="create-recovery-dir-plan-labels recovery-dir-selection-labels" aria-hidden="true">
-                        <span class="create-recovery-required-label">
-                          {{ t('protection.backupsPage.colBackupSnapshotDirectory') }}
-                          <span class="create-recovery-required-mark">*</span>
-                          <HflHelpTip
-                            :content="t('protection.backupsPage.createRecoveryPathInputHint')"
-                            :size="13"
-                            :aria-label="t('protection.backupsPage.colBackupSnapshotDirectory')"
-                          />
-                        </span>
-                        <span class="create-recovery-required-label">
-                          {{ t('protection.backupsPage.colRecoveryTargetDirectory') }}
-                          <span class="create-recovery-required-mark">*</span>
-                          <HflHelpTip
-                            :content="t('protection.backupsPage.createRecoveryPathInputHint')"
-                            :size="13"
-                            :aria-label="t('protection.backupsPage.colRecoveryTargetDirectory')"
-                          />
-                        </span>
-                        <span>{{ t('protection.backupsPage.colActions') }}</span>
-                      </div>
                       <div
-                        v-for="entry in sourceRow.entries"
-                        :key="entry.id"
-                        class="create-recovery-dir-plan-row recovery-dir-selection-row"
+                        v-if="!isFixedSnapshotRestore && recEntryMode === 'plan' && recoveryPlanTableRows.length"
+                        class="rounded-[var(--radius-card)] border border-[var(--color-border,#e2e8f0)] bg-[var(--color-card-bg,#fff)] p-4"
                       >
-                        <div class="create-recovery-dir-plan-field" :data-label="t('protection.backupsPage.colBackupSnapshotDirectory')">
-                          <HflPopover
-                            :visible="isRecoverySnapshotRangePickerVisible(sourceRow.hostId, entry)"
-                            trigger="manual"
-                            placement="bottom-start"
-                            :width="460"
-                            popper-class="create-recovery-path-popover"
-                            @update:visible="(visible) => setRecoverySnapshotRangePickerVisible(sourceRow.hostId, entry, Boolean(visible))"
+                        <p class="m-0 mb-3 text-xs text-slate-500">
+                          {{ t('protection.backupsPage.recoveryPlanPreviewHint') }}
+                        </p>
+                        <el-table
+                          v-table-overflow-title
+                          :data="recoveryPlanTableRows"
+                          :header-cell-style="TABLE_HEADER_STYLE"
+                          stripe
+                          class="recovery-plan-preview-table"
+                          row-key="rowKey"
+                        >
+                          <el-table-column
+                            :label="t('protection.backupsPage.colBackupSourceAndSnapshot')"
+                            min-width="220"
                           >
-                            <template #reference>
-                              <div class="create-recovery-path-input">
-                                <el-input
-                                  :model-value="recoverySnapshotRangeDisplayForEntry(sourceRow.hostId, entry)"
-                                  clearable
-                                  :placeholder="t('protection.backupsPage.phSelectOrEnterRestoreScope')"
-                                  :class="{
-                                    'create-recovery-path-input--pending': entry.sourcePathValidation === 'pending',
-                                    'create-recovery-path-input--invalid': isRecoverySnapshotRangeInputInvalid(entry),
-                                  }"
-                                  :aria-describedby="isRecoverySnapshotRangeErrorVisible(sourceRow.hostId, entry) ? `recovery-snapshot-range-error-${sourceRow.hostId}-${entry.id}` : undefined"
-                                  @click.stop
-                                  @update:model-value="(value) => updateRecoverySnapshotRangeInput(sourceRow.hostId, entry, String(value))"
-                                  @blur="entry.sourcePathValidation === 'pending' && validateRecoverySnapshotRangeInput(sourceRow.hostId, entry)"
-                                  @keydown.enter.prevent="validateRecoverySnapshotRangeInput(sourceRow.hostId, entry)"
+                            <template #default="{ row }">
+                              <div class="recovery-plan-preview-table__source-cell">
+                                <span
+                                  class="recovery-plan-preview-table__source"
                                 >
-                                  <template v-if="isRecoverySnapshotRangeValidating(sourceRow.hostId, entry)" #suffix>
-                                    <span class="create-recovery-path-input__checking">{{ t('common.loading') }}</span>
-                                  </template>
-                                  <template #prefix>
-                                    <component
-                                      :is="recoverySnapshotRangeInputIcon(entry)"
-                                      :size="14"
-                                      class="create-recovery-path-input__type-icon"
-                                      :class="recoverySnapshotRangeInputIconClass(entry)"
-                                    />
-                                  </template>
-                                  <template #append>
-                                    <ElButton
-                                      class="create-recovery-path-input__btn"
-                                      :aria-label="t('protection.backupsPage.btnBrowsePaths')"
-                                      @click.stop="setRecoverySnapshotRangePickerVisible(sourceRow.hostId, entry, true)"
-                                    >
-                                      <FolderOpen :size="16" />
-                                    </ElButton>
-                                  </template>
-                                </el-input>
-                                <p
-                                  v-if="isRecoverySnapshotRangeErrorVisible(sourceRow.hostId, entry)"
-                                  :id="`recovery-snapshot-range-error-${sourceRow.hostId}-${entry.id}`"
-                                  class="create-recovery-path-input__error"
-                                  role="alert"
+                                  {{ row.sourceResourceName }}
+                                </span>
+                                <span
+                                  class="recovery-plan-preview-table__endpoint-ip"
                                 >
-                                  <span>{{ recoverySnapshotRangeInputError(entry) }}</span>
-                                  <button
-                                    type="button"
-                                    class="create-recovery-path-input__error-close"
-                                    :aria-label="t('protection.backupsPage.btnClose')"
-                                    @click.stop="dismissRecoveryPathError(sourceRow.hostId, entry, 'source')"
-                                  >
-                                    <X :size="13" />
-                                  </button>
-                                </p>
+                                  {{ row.sourceHostIp }}
+                                </span>
+                                <span class="recovery-plan-preview-table__source-snapshot text-xs text-slate-500">
+                                  {{ t('protection.backupsPage.descSnapshot') }}: {{ fmtLocalTime(row.snapshotTime) }}
+                                </span>
                               </div>
                             </template>
-                            <div class="create-recovery-tree-popover hfl-dir-tree-shell">
-                              <el-tree
-                                :ref="(el) => setRecoveryDirectoryTreeRef(recoveryDirectoryTreeKey(sourceRow.hostId, entry.id, 'snapshot'), el)"
-                                :key="`restore-snapshot-picker-${sourceRow.hostId}-${entry.id}-${selectedSnapshotNumericIdForSource(sourceRow.hostId)}-${recoverySnapshotBrowseRevision}`"
-                                class="source-dir-tree create-recovery-popover-tree hfl-dir-tree hfl-dir-tree--tall"
-                                node-key="id"
-                                lazy
-                                :load="(node, resolve) => loadRecoverySnapshotPickerNode(sourceRow.hostId, node, resolve)"
-                                :props="{ label: 'label', children: 'children', isLeaf: 'isLeaf' }"
-                                @node-click="(data) => pickRecoverySnapshotRange(sourceRow.hostId, entry, data)"
-                                @node-collapse="(data) => onRecoveryDirectoryExpansionChange(recoveryDirectoryTreeKey(sourceRow.hostId, entry.id, 'snapshot'), data.id)"
-                                @node-expand="(data) => onRecoveryDirectoryExpansionChange(recoveryDirectoryTreeKey(sourceRow.hostId, entry.id, 'snapshot'), data.id)"
+                          </el-table-column>
+                          <el-table-column
+                            :label="t('protection.backupsPage.descRecoveryPlan')"
+                            min-width="520"
+                          >
+                            <template #default="{ row }">
+                              <HflPopover
+                                v-if="row.state === 'configured' && row.plan"
+                                trigger="hover"
+                                placement="top-start"
+                                :width="640"
+                                popper-class="create-recovery-plan-tooltip create-recovery-plan-tooltip--wide"
                               >
-                                <template #default="{ data }">
+                                <template #reference>
                                   <div
-                                    class="create-tree-node-content hfl-dir-tree-node"
-                                    :class="{
-                                      'create-tree-node-content--snapshot': data.type === 'snapshot',
-                                      'recovery-snapshot-tree-node--selected': isRecoverySnapshotPickerNodeSelected(entry, data),
-                                    }"
+                                    class="create-recovery-plan-cell create-recovery-plan-cell--review"
+                                    :class="`create-recovery-plan-cell--${recoveryPlanRunStatusTone(row.plan)}`"
                                   >
-                                    <Camera
-                                      v-if="data.type === 'snapshot'"
-                                      :size="15"
-                                      class="create-tree-node-content__icon hfl-dir-tree-node__icon create-dir-row__icon--snapshot"
-                                    />
-                                    <FolderOpen
-                                      v-else-if="data.type === 'dir'"
-                                      :size="15"
-                                      class="create-tree-node-content__icon hfl-dir-tree-node__icon create-dir-row__icon--folder"
-                                    />
-                                    <File
-                                      v-else
-                                      :size="15"
-                                      class="create-tree-node-content__icon hfl-dir-tree-node__icon create-dir-row__icon--file"
-                                    />
-                                    <div class="create-tree-node-content__text hfl-dir-tree-node__text">
-                                      <span class="create-tree-node-content__label hfl-dir-tree-node__label">{{ data.label }}</span>
+                                    <div class="create-recovery-plan-cell__status">
                                       <span
-                                        v-if="data.type === 'snapshot'"
-                                        class="create-tree-node-content__snapshot-desc create-tree-node-content__path hfl-dir-tree-node__path"
-                                      >
-                                        {{ t('protection.backupsPage.createRecoveryScopeSnapshotDesc') }}
+                                        class="create-recovery-plan-cell__dot"
+                                        aria-hidden="true"
+                                      />
+                                      <span class="create-recovery-plan-cell__status-label">
+                                        {{ recoveryPlanRunStatusLabel(row.plan) }}
                                       </span>
                                     </div>
-                                    <button
-                                      v-if="data.type === 'dir'"
-                                      type="button"
-                                      class="hfl-dir-tree-node__refresh"
-                                      :class="{ 'is-refreshing': isRecoveryDirectoryRefreshing(recoveryDirectoryTreeKey(sourceRow.hostId, entry.id, 'snapshot'), data.id) }"
-                                      :disabled="isRecoveryDirectoryRefreshing(recoveryDirectoryTreeKey(sourceRow.hostId, entry.id, 'snapshot'), data.id)"
-                                      :aria-label="t('protection.backupsPage.ariaRefreshDirectory', { path: data.path })"
-                                      :title="t('protection.backupsPage.ariaRefreshDirectory', { path: data.path })"
-                                      @click.stop="refreshRecoverySnapshotDirectory(sourceRow.hostId, entry, data)"
+                                    <div
+                                      class="create-recovery-plan-cell__policy"
+                                      :class="`create-recovery-plan-cell__policy--${row.plan.conflictPolicy}`"
                                     >
-                                      <RefreshCw
+                                      <ShieldAlert
+                                        v-if="row.plan.conflictPolicy === 'overwrite'"
                                         :size="14"
-                                        :class="{ 'is-spinning': isRecoveryDirectoryRefreshing(recoveryDirectoryTreeKey(sourceRow.hostId, entry.id, 'snapshot'), data.id) }"
+                                        class="create-recovery-plan-cell__policy-icon"
                                       />
-                                    </button>
+                                      <ShieldCheck
+                                        v-else
+                                        :size="14"
+                                        class="create-recovery-plan-cell__policy-icon"
+                                      />
+                                      <span class="create-recovery-plan-cell__policy-text">
+                                        {{ recoveryPlanRunConflictSummary(row.plan) }}
+                                      </span>
+                                    </div>
+                                    <div class="create-recovery-plan-cell__mappings">
+                                      <div
+                                        v-for="mapping in row.plan.mappings"
+                                        :key="mapping.id"
+                                        class="create-recovery-plan-mapping"
+                                      >
+                                        <span
+                                          class="create-recovery-plan-mapping__endpoint"
+                                          :class="`create-recovery-plan-mapping__endpoint--${recoveryPlanRunSourceKind(mapping.sourceDir)}`"
+                                          :title="recoveryPlanRunSourcePathLabel(mapping.sourceDir)"
+                                        >
+                                          <component
+                                            :is="recoveryPlanRunSourceIcon(mapping.sourceDir)"
+                                            :size="14"
+                                            class="create-recovery-plan-mapping__icon"
+                                          />
+                                          <span
+                                            class="create-recovery-plan-mapping__text"
+                                            :title="recoveryPlanRunSourcePathLabel(mapping.sourceDir)"
+                                          >{{ recoveryPlanRunSourcePathLabel(mapping.sourceDir) }}</span>
+                                        </span>
+                                        <span
+                                          class="create-recovery-plan-mapping__arrow"
+                                          aria-hidden="true"
+                                        >-&gt;</span>
+                                        <span
+                                          class="create-recovery-plan-mapping__endpoint create-recovery-plan-mapping__endpoint--target"
+                                          :title="recoveryPlanMappingTargetSummary(mapping)"
+                                        >
+                                          <FolderOpen
+                                            :size="14"
+                                            class="create-recovery-plan-mapping__icon"
+                                          />
+                                          <span
+                                            class="create-recovery-plan-mapping__text"
+                                            :title="recoveryPlanMappingTargetSummary(mapping)"
+                                          >{{ recoveryPlanMappingTargetSummary(mapping) }}</span>
+                                        </span>
+                                      </div>
+                                    </div>
                                   </div>
                                 </template>
-                              </el-tree>
-                            </div>
-                          </HflPopover>
-                        </div>
-                        <div class="create-recovery-dir-plan-field" :data-label="t('protection.backupsPage.colRecoveryTargetDirectory')">
-                          <HflPopover
-                            :visible="isRecoveryTargetDirPickerVisible(sourceRow.hostId, entry)"
-                            trigger="manual"
-                            placement="bottom-start"
-                            :width="360"
-                            popper-class="create-recovery-path-popover"
-                            @update:visible="(visible) => setRecoveryTargetDirPickerVisible(sourceRow.hostId, entry, Boolean(visible))"
-                          >
-                            <template #reference>
-                              <div class="create-recovery-path-input">
-                                <el-input
-                                  :model-value="entry.targetPath || ''"
-                                  :placeholder="t('protection.backupsPage.phSelectOrEnterRestoreDirectory')"
-                                  :class="{
-                                    'create-recovery-path-input--pending': entry.targetPathValidation === 'pending',
-                                    'create-recovery-path-input--invalid': isRecoveryTargetDirInputInvalid(entry),
-                                  }"
-                                  :aria-describedby="isRecoveryTargetDirErrorVisible(sourceRow.hostId, entry) ? `recovery-target-dir-error-${sourceRow.hostId}-${entry.id}` : undefined"
-                                  @click.stop
-                                  @update:model-value="(value) => updateRecoveryTargetDirInput(sourceRow.hostId, entry, String(value))"
-                                  @blur="entry.targetPathValidation === 'pending' && validateRecoveryTargetDirInput(sourceRow.hostId, entry)"
-                                  @keydown.enter.prevent="validateRecoveryTargetDirInput(sourceRow.hostId, entry)"
-                                >
-                                  <template v-if="isRecoveryTargetDirValidating(sourceRow.hostId, entry)" #suffix>
-                                    <span class="create-recovery-path-input__checking">{{ t('common.loading') }}</span>
-                                  </template>
-                                  <template #prefix>
-                                    <component
-                                      :is="recoveryTargetDirInputIcon(entry)"
-                                      :size="14"
-                                      class="create-recovery-path-input__type-icon"
-                                      :class="recoveryTargetDirInputIconClass(entry)"
-                                    />
-                                  </template>
-                                  <template #append>
-                                    <ElButton
-                                      class="create-recovery-path-input__btn"
-                                      :aria-label="t('protection.backupsPage.btnBrowsePaths')"
-                                      @click.stop="setRecoveryTargetDirPickerVisible(sourceRow.hostId, entry, !isRecoveryTargetDirPickerVisible(sourceRow.hostId, entry))"
+                                <template #default>
+                                  <div class="create-recovery-plan-tooltip__content">
+                                    <div
+                                      class="create-recovery-plan-tooltip__policy"
+                                      :class="`create-recovery-plan-tooltip__policy--${row.plan.conflictPolicy}`"
                                     >
-                                      <FolderOpen :size="16" />
-                                    </ElButton>
-                                  </template>
-                                </el-input>
-                                <p
-                                  v-if="isRecoveryTargetDirErrorVisible(sourceRow.hostId, entry)"
-                                  :id="`recovery-target-dir-error-${sourceRow.hostId}-${entry.id}`"
-                                  class="create-recovery-path-input__error"
-                                  role="alert"
+                                      <ShieldAlert
+                                        v-if="row.plan.conflictPolicy === 'overwrite'"
+                                        :size="14"
+                                        class="create-recovery-plan-cell__policy-icon"
+                                      />
+                                      <ShieldCheck
+                                        v-else
+                                        :size="14"
+                                        class="create-recovery-plan-cell__policy-icon"
+                                      />
+                                      <span class="create-recovery-plan-cell__policy-text">
+                                        {{ recoveryPlanRunConflictSummary(row.plan) }}
+                                      </span>
+                                    </div>
+                                    <div
+                                      v-for="mapping in row.plan.mappings"
+                                      :key="`${mapping.id}-tooltip`"
+                                      class="create-recovery-plan-tooltip__mapping create-recovery-plan-mapping"
+                                    >
+                                      <span
+                                        class="create-recovery-plan-mapping__endpoint"
+                                        :class="`create-recovery-plan-mapping__endpoint--${recoveryPlanRunSourceKind(mapping.sourceDir)}`"
+                                        :title="recoveryPlanRunSourcePathLabel(mapping.sourceDir)"
+                                      >
+                                        <component
+                                          :is="recoveryPlanRunSourceIcon(mapping.sourceDir)"
+                                          :size="14"
+                                          class="create-recovery-plan-mapping__icon"
+                                        />
+                                        <span
+                                          class="create-recovery-plan-mapping__text"
+                                          :title="recoveryPlanRunSourcePathLabel(mapping.sourceDir)"
+                                        >{{ recoveryPlanRunSourcePathLabel(mapping.sourceDir) }}</span>
+                                      </span>
+                                      <span
+                                        class="create-recovery-plan-mapping__arrow"
+                                        aria-hidden="true"
+                                      >-&gt;</span>
+                                      <span
+                                        class="create-recovery-plan-mapping__endpoint create-recovery-plan-mapping__endpoint--target"
+                                        :title="recoveryPlanMappingTargetSummary(mapping)"
+                                      >
+                                        <FolderOpen
+                                          :size="14"
+                                          class="create-recovery-plan-mapping__icon"
+                                        />
+                                        <span
+                                          class="create-recovery-plan-mapping__text"
+                                          :title="recoveryPlanMappingTargetSummary(mapping)"
+                                        >{{ recoveryPlanMappingTargetSummary(mapping) }}</span>
+                                      </span>
+                                    </div>
+                                  </div>
+                                </template>
+                              </HflPopover>
+                              <div
+                                v-else
+                                class="create-recovery-plan-cell create-recovery-plan-cell--review create-recovery-plan-cell--pending recovery-plan-missing-cell"
+                              >
+                                <div class="create-recovery-plan-cell__status">
+                                  <span
+                                    class="create-recovery-plan-cell__dot"
+                                    aria-hidden="true"
+                                  />
+                                  <span class="create-recovery-plan-cell__status-label">
+                                    {{ t('protection.backupsPage.recoveryPlanMissingTitle') }}
+                                  </span>
+                                </div>
+                                <div class="create-recovery-plan-cell__meta">
+                                  {{ t('protection.backupsPage.recoveryPlanMissingDesc') }}
+                                </div>
+                                <ElButton
+                                  text
+                                  type="primary"
+                                  size="small"
+                                  class="hfl-btn-with-icon recovery-plan-missing-cell__action hfl-table-no-tooltip"
+                                  @click="openConfigureRestorePlanFromMissingRow(row)"
                                 >
-                                  <span>{{ recoveryTargetDirInputError(entry) }}</span>
-                                  <button
-                                    type="button"
-                                    class="create-recovery-path-input__error-close"
-                                    :aria-label="t('protection.backupsPage.btnClose')"
-                                    @click.stop="dismissRecoveryPathError(sourceRow.hostId, entry, 'target')"
-                                  >
-                                    <X :size="13" />
-                                  </button>
-                                </p>
+                                  <Route
+                                    :size="14"
+                                    class="shrink-0"
+                                  />
+                                  <span>{{ t('protection.backupsPage.flowActionConfigureRecoveryPlan') }}</span>
+                                </ElButton>
                               </div>
                             </template>
-                            <div class="create-recovery-tree-popover hfl-dir-tree-shell">
-                              <el-tree
-                                :ref="(el) => setRecoveryDirectoryTreeRef(recoveryDirectoryTreeKey(sourceRow.hostId, entry.id, 'target'), el)"
-                                :key="`restore-target-dir-picker-${sourceRow.hostId}-${entry.id}-${targetNodeSourceIdForSource(sourceRow.hostId)}`"
-                                v-loading="isRecoveryTargetDirTreeLoading(sourceRow.hostId, entry)"
-                                class="source-dir-tree create-recovery-popover-tree hfl-dir-tree hfl-dir-tree--tall"
-                                node-key="path"
-                                lazy
-                                :expand-on-click-node="false"
-                                :load="(node, resolve) => loadRecoveryTargetDirPickerNode(sourceRow.hostId, entry, node, resolve)"
-                                :props="{ label: 'label', children: 'children', isLeaf: 'isLeaf' }"
-                                :current-node-key="entry.targetPath"
-                                highlight-current
-                                @node-click="(data) => pickRecoveryTargetDir(sourceRow.hostId, entry, data.path)"
-                                @node-collapse="(data) => onRecoveryDirectoryExpansionChange(recoveryDirectoryTreeKey(sourceRow.hostId, entry.id, 'target'), data.path)"
-                                @node-expand="(data) => onRecoveryDirectoryExpansionChange(recoveryDirectoryTreeKey(sourceRow.hostId, entry.id, 'target'), data.path)"
+                          </el-table-column>
+                          <el-table-column
+                            :label="t('protection.backupsPage.descSnapshot')"
+                            min-width="300"
+                          >
+                            <template #default="{ row }">
+                              <el-select
+                                v-if="row.state === 'configured' && row.plan"
+                                :model-value="recoveryPlanSelectedSnapshotId(row.plan)"
+                                :placeholder="t('protection.backupsPage.phPickSnapshot')"
+                                class="w-full recovery-plan-preview-table__snapshot-select"
+                                :loading="recoverySnapshotListStateForHost(backupSourceHostId(row.plan.backupId)).loading"
+                                @visible-change="(visible) => onRecoveryPlanSnapshotVisible(row.plan, visible)"
+                                @update:model-value="(value) => updateRecoveryPlanSnapshot(row.plan, value)"
                               >
-                                <template #default="{ data }">
-                                  <div class="create-tree-node-content hfl-dir-tree-node">
-                                    <FolderOpen :size="15" class="create-tree-node-content__icon hfl-dir-tree-node__icon create-dir-row__icon--folder" />
-                                    <div class="create-tree-node-content__text hfl-dir-tree-node__text">
-                                      <span class="create-tree-node-content__label hfl-dir-tree-node__label">{{ data.label }}</span>
-                                      <span class="create-tree-node-content__path hfl-dir-tree-node__path">{{ data.path }}</span>
-                                    </div>
-                                    <button
-                                      type="button"
-                                      class="hfl-dir-tree-node__refresh"
-                                      :class="{ 'is-refreshing': isRecoveryDirectoryRefreshing(recoveryDirectoryTreeKey(sourceRow.hostId, entry.id, 'target'), data.path) }"
-                                      :disabled="isRecoveryDirectoryRefreshing(recoveryDirectoryTreeKey(sourceRow.hostId, entry.id, 'target'), data.path)"
-                                      :aria-label="t('protection.backupsPage.ariaRefreshDirectory', { path: data.path })"
-                                      :title="t('protection.backupsPage.ariaRefreshDirectory', { path: data.path })"
-                                      @click.stop="refreshRecoveryTargetDirectory(sourceRow.hostId, entry, data)"
+                                <el-option
+                                  v-for="s in recoverySnapshotOptionsForSource(backupSourceHostId(row.plan.backupId))"
+                                  :key="s.id"
+                                  :label="`${fmtLocalTime(s.time)} · ${fmtBytes(s.sizeBytes)}`"
+                                  :value="s.id"
+                                  :disabled="!restorePlanSnapshotCompatibility(row.plan, s).compatible"
+                                >
+                                  <ElTooltip
+                                    :disabled="restorePlanSnapshotCompatibility(row.plan, s).compatible"
+                                    :content="restorePlanSnapshotCompatibility(row.plan, s).reason"
+                                    placement="bottom-start"
+                                    :show-after="300"
+                                  >
+                                    <div
+                                      class="recovery-snapshot-option"
+                                      :class="{ 'is-disabled': !restorePlanSnapshotCompatibility(row.plan, s).compatible }"
                                     >
-                                      <RefreshCw
+                                      <span class="recovery-snapshot-option__label">
+                                        {{ fmtLocalTime(s.time) }} · {{ fmtBytes(s.sizeBytes) }}
+                                      </span>
+                                      <el-tag
+                                        size="small"
+                                        :type="lifecycleStatusTagAttrs(s.status).type"
+                                        :class="lifecycleStatusTagAttrs(s.status).class"
+                                        effect="plain"
+                                      >
+                                        {{ snapshotStatusLabel(s.status) }}
+                                      </el-tag>
+                                      <Info
+                                        v-if="!restorePlanSnapshotCompatibility(row.plan, s).compatible"
                                         :size="14"
-                                        :class="{ 'is-spinning': isRecoveryDirectoryRefreshing(recoveryDirectoryTreeKey(sourceRow.hostId, entry.id, 'target'), data.path) }"
+                                        class="recovery-snapshot-option__info"
                                       />
-                                    </button>
-                                  </div>
-                                </template>
-                              </el-tree>
-                            </div>
-                          </HflPopover>
-                        </div>
-                        <div class="create-recovery-dir-plan-field create-recovery-dir-plan-actions" :data-label="t('protection.backupsPage.colActions')">
-                          <ElButton
-                            text
-                            circle
-                            type="danger"
-                            size="small"
-                            :title="t('protection.backupsPage.ariaRemove')"
-                            @click="removeRecoveryDirEntry(sourceRow.hostId, entry.id)"
-                          >
-                            <Trash2 :size="14" />
-                          </ElButton>
-                        </div>
-                      </div>
-                      <div class="recovery-dir-selection-add-wrap">
-                        <button
-                          type="button"
-                          class="recovery-dir-selection-add-row"
-                          @click="addRecoveryDirEntryAndExpand(sourceRow)"
-                        >
-                          <CirclePlus :size="16" />
-                          <span>{{ t('protection.backupsPage.btnAddRecoveryDir') }}</span>
-                        </button>
-                      </div>
-                    </div>
-                  </div>
-                </template>
-              </el-table-column>
-              <el-table-column :label="t('protection.backupsPage.colBackupSnapshot')" min-width="220">
-                <template #default="{ row }">
-                  <button
-                    type="button"
-                    class="recovery-dir-source-toggle"
-                    @click="toggleRecRecoveryDirRow(row)"
-                  >
-                    <span class="recovery-source-summary recovery-source-summary--with-snapshot">
-                      <span class="recovery-source-summary__head">
-                        <span class="recovery-source-summary__name">
-                          {{ row.sourceSummary.displayName }}
-                        </span>
-                        <el-tag
-                          size="small"
-                          effect="plain"
-                          class="recovery-source-summary__type"
-                          :type="row.sourceSummary.typeTagType"
-                        >
-                          {{ row.sourceSummary.typeLabel }}
-                        </el-tag>
-                      </span>
-                      <span class="recovery-source-summary__meta">
-                        <span class="recovery-source-summary__ip">
-                          {{ row.sourceSummary.ipLine }}
-                        </span>
-                        <span class="recovery-source-summary__platform">
-                          <AgentPlatformBrandIcon
-                            v-if="row.sourceSummary.platform"
-                            :os="row.sourceSummary.platform"
-                          />
-                          <component
-                            :is="row.sourceSummary.sourceType === 'nas' ? sourceNasIcon : sourceHostIcon"
-                            v-else
-                            :size="16"
-                          />
-                        </span>
-                      </span>
-                      <span class="recovery-source-summary__snapshot">
-                        Snapshot: {{ row.snapshotLine }}
-                      </span>
-                    </span>
-                  </button>
-                </template>
-              </el-table-column>
-              <el-table-column :label="t('protection.backupsPage.recStepDest')" min-width="210">
-                <template #default="{ row }">
-                  <div v-if="row.destSummary" class="recovery-source-summary">
-                    <div class="recovery-source-summary__head">
-                      <span class="recovery-source-summary__name">
-                        {{ row.destSummary.displayName }}
-                      </span>
-                      <el-tag
-                        size="small"
-                        effect="plain"
-                        class="recovery-source-summary__type"
-                        :type="row.destSummary.typeTagType"
-                      >
-                        {{ row.destSummary.typeLabel }}
-                      </el-tag>
-                    </div>
-                    <div class="recovery-source-summary__meta">
-                      <span class="recovery-source-summary__ip">
-                        {{ row.destSummary.ipLine }}
-                      </span>
-                      <span class="recovery-source-summary__platform">
-                        <AgentPlatformBrandIcon
-                          v-if="row.destSummary.platform"
-                          :os="row.destSummary.platform"
-                        />
-                        <component
-                          :is="row.destSummary.sourceType === 'nas' ? sourceNasIcon : sourceHostIcon"
-                          v-else
-                          :size="16"
-                        />
-                      </span>
-                    </div>
-                  </div>
-                  <div v-else class="create-source-dir-preview-empty">
-                    {{ t('protection.backupsPage.recoveryDestEmptyCompact') }}
-                  </div>
-                </template>
-              </el-table-column>
-              <el-table-column min-width="220">
-                <template #header>
-                  <span class="create-recovery-required-label">
-                    {{ t('protection.backupsPage.recoveryConflictPolicyCol') }}
-                    <span class="create-recovery-required-mark">*</span>
-                  </span>
-                </template>
-                <template #default="{ row }">
-                  <div class="recovery-conflict-policy-cell hfl-table-no-tooltip">
-                    <el-select
-                      :model-value="recConflictPolicyForSource(row.hostId)"
-                      size="small"
-                      class="w-full recovery-conflict-policy-select"
-                      :class="{
-                        'recovery-conflict-policy-select--invalid': !recConflictPolicyForSource(row.hostId),
-                        'recovery-conflict-policy-select--skip': recConflictPolicyForSource(row.hostId) === 'skip',
-                        'recovery-conflict-policy-select--overwrite': recConflictPolicyForSource(row.hostId) === 'overwrite',
-                      }"
-                      :placeholder="t('protection.backupsPage.fileConflictPolicyPlaceholder')"
-                      @update:model-value="(value) => setRecConflictPolicyForSource(row.hostId, value as RecoveryConflictPolicy)"
-                    >
-                      <el-option :label="t('protection.backupsPage.recoveryConflictSkip')" value="skip">
-                        <div class="recovery-conflict-policy-option recovery-conflict-policy-option--skip">
-                          <ShieldCheck :size="14" />
-                          <span>{{ t('protection.backupsPage.createRecoveryConflictSkipFull') }}</span>
-                        </div>
-                      </el-option>
-                      <el-option :label="t('protection.backupsPage.recoveryConflictOverwrite')" value="overwrite">
-                        <div class="recovery-conflict-policy-option recovery-conflict-policy-option--overwrite">
-                          <ShieldAlert :size="14" />
-                          <span>{{ t('protection.backupsPage.createRecoveryConflictOverwriteFull') }}</span>
-                        </div>
-                      </el-option>
-                    </el-select>
-                  </div>
-                </template>
-              </el-table-column>
-              <el-table-column :label="t('protection.backupsPage.colRecoveryDirectoryMapping')" min-width="300">
-                <template #default="{ row }">
-                  <ElTooltip
-                    v-if="row.configuredEntries.length"
-                    placement="top-start"
-                    :show-after="300"
-                    popper-class="recovery-entry-preview-tooltip"
-                  >
-                    <template #content>
-                      <div class="recovery-entry-preview-tooltip__list">
-                        <div
-                          v-for="entry in row.configuredEntries"
-                          :key="entry.id"
-                          class="recovery-mapping-line recovery-entry-preview-tooltip__line"
-                        >
-                          <span
-                            class="recovery-mapping-line__endpoint"
-                            :class="`recovery-mapping-line__endpoint--${recoveryMappingSourceKind(entry)}`"
-                          >
-                            <Archive
-                              v-if="recoveryMappingSourceKind(entry) === 'snapshot'"
-                              :size="14"
-                              class="recovery-mapping-line__icon"
-                            />
-                            <File
-                              v-else-if="recoveryMappingSourceKind(entry) === 'file'"
-                              :size="14"
-                              class="recovery-mapping-line__icon"
-                            />
-                            <Folder v-else :size="14" class="recovery-mapping-line__icon" />
-                            <span class="recovery-mapping-line__text">{{ recoveryMappingSourceLabel(entry) }}</span>
-                          </span>
-                          <span class="recovery-mapping-line__arrow" aria-hidden="true">-&gt;</span>
-                          <span class="recovery-mapping-line__endpoint recovery-mapping-line__endpoint--target">
-                            <FolderOpen :size="14" class="recovery-mapping-line__icon" />
-                            <span class="recovery-mapping-line__text">{{ recoveryMappingTargetLabel(entry) }}</span>
-                          </span>
-                        </div>
-                      </div>
-                    </template>
-                    <div class="create-source-dir-preview recovery-entry-preview-trigger">
-                      <div class="create-source-dir-preview__count">
-                        {{ recoveryMappingTotalLabel(row.configuredEntries.length) }}
+                                    </div>
+                                  </ElTooltip>
+                                </el-option>
+                                <el-option
+                                  v-if="recoverySnapshotHasMore(backupSourceHostId(row.plan.backupId))"
+                                  :key="`${row.rowKey}-snapshot-load-more`"
+                                  :value="RECOVERY_SNAPSHOT_LOAD_MORE_VALUE"
+                                  :label="recoverySnapshotLoadMoreLabel(backupSourceHostId(row.plan.backupId))"
+                                >
+                                  <button
+                                    type="button"
+                                    class="recovery-snapshot-load-more"
+                                    @mousedown.prevent
+                                    @click.stop="updateRecoveryPlanSnapshot(row.plan, RECOVERY_SNAPSHOT_LOAD_MORE_VALUE)"
+                                  >
+                                    {{ recoverySnapshotLoadMoreLabel(backupSourceHostId(row.plan.backupId)) }}
+                                  </button>
+                                </el-option>
+                              </el-select>
+                              <span
+                                v-else
+                                class="hfl-empty-mark"
+                              >—</span>
+                            </template>
+                          </el-table-column>
+                        </el-table>
                       </div>
                       <div
-                        v-for="entry in row.previewEntries"
-                        :key="entry.id"
-                        class="create-source-dir-preview__item recovery-mapping-line recovery-mapping-line--preview"
+                        v-else-if="recEntryMode === 'plan'"
+                        class="recovery-plan-empty-state"
                       >
-                        <span
-                          class="recovery-mapping-line__endpoint"
-                          :class="`recovery-mapping-line__endpoint--${recoveryMappingSourceKind(entry)}`"
-                        >
-                          <Archive
-                            v-if="recoveryMappingSourceKind(entry) === 'snapshot'"
-                            :size="14"
-                            class="recovery-mapping-line__icon"
-                          />
-                          <File
-                            v-else-if="recoveryMappingSourceKind(entry) === 'file'"
-                            :size="14"
-                            class="recovery-mapping-line__icon"
-                          />
-                          <Folder v-else :size="14" class="recovery-mapping-line__icon" />
-                          <span class="recovery-mapping-line__text">{{ recoveryMappingSourceLabel(entry) }}</span>
-                        </span>
-                        <span class="recovery-mapping-line__arrow" aria-hidden="true">-&gt;</span>
-                        <span class="recovery-mapping-line__endpoint recovery-mapping-line__endpoint--target">
-                          <FolderOpen :size="14" class="recovery-mapping-line__icon" />
-                          <span class="recovery-mapping-line__text">{{ recoveryMappingTargetLabel(entry) }}</span>
-                        </span>
-                      </div>
-                      <div v-if="row.hiddenDirCount > 0" class="create-source-dir-preview__more">
-                        {{ t('protection.backupsPage.moreRecoveryDirs', { n: row.hiddenDirCount }) }}
-                      </div>
-                    </div>
-                  </ElTooltip>
-                  <div v-else class="create-source-dir-preview-empty">
-                    {{ t('protection.backupsPage.recoveryDirEmptyCompact') }}
-                  </div>
-                </template>
-              </el-table-column>
-            </el-table>
-          </div>
-
-          <el-drawer
-            v-model="recDirDrawerOpen"
-            direction="rtl"
-            destroy-on-close
-            append-to-body
-            :modal="true"
-            :z-index="REC_WIZARD_DRAWER_Z_INDEX"
-            :size="nestedDrawerSize"
-            class="dp-rec-dest-drawer dp-rec-dir-drawer"
-            @opened="onRecDirDrawerOpened"
-            @closed="onRecDirDrawerClosed"
-          >
-            <template #header>
-              <span class="dp-rec-dest-drawer__title">
-                {{ store.getNodeName(recDirDrawerHostId) || t('protection.backupsPage.recDirSelectionCol') }}
-              </span>
-            </template>
-
-            <div class="dp-rec-dest-drawer__body">
-              <div class="dp-rec-dest-drawer__content">
-                <p class="m-0 mb-1 text-xs text-slate-500">
-                  {{ t('protection.backupsPage.recDirsSnapshotHint', { time: recGroupSnapshotDisplayLine(recDirDrawerHostId) }) }}
-                </p>
-                <p class="m-0 mb-3 text-xs text-slate-500">{{ t('protection.backupsPage.recDirDrawerHint') }}</p>
-                <div
-                  v-if="!recDirTreeDataForSource(recDirDrawerHostId).length"
-                  class="dp-create-tree-shell__empty hfl-dir-tree-empty"
-                >
-                  {{ t('protection.backupsPage.recSourceTreeEmpty') }}
-                </div>
-                <el-tree
-                  v-else
-                  ref="recDirDrawerTreeRef"
-                  :key="`rec-dir-drawer-${recDirDrawerHostId}-${recDirDrawerEntryId}`"
-                  class="source-dir-tree rec-select-tree recovery-dir-picker__tree hfl-dir-tree hfl-dir-tree--tall dp-rec-dir-drawer__tree"
-                  :data="recDirTreeDataForSource(recDirDrawerHostId)"
-                  node-key="id"
-                  show-checkbox
-                  check-strictly
-                  default-expand-all
-                  :check-on-click-node="true"
-                  :expand-on-click-node="false"
-                  :props="{ label: 'label', children: 'children' }"
-                  :default-checked-keys="recDirDrawerDraftKeys"
-                  @check-change="(data, checked) => onRecDirDrawerTreeCheckChange(recDirDrawerHostId, data, checked)"
-                >
-                  <template #default="{ data }">
-                    <div class="tree-node-content hfl-dir-tree-node">
-                      <component
-                        :is="recoveryDirNodeIcon(data)"
-                        :size="15"
-                        class="tree-node-content__icon hfl-dir-tree-node__icon"
-                        :class="`create-dir-row__icon--${recoveryDirNodeSourceKind(data) === 'file' ? 'file' : 'folder'}`"
-                      />
-                      <div class="tree-node-content__text hfl-dir-tree-node__text">
-                        <span class="tree-node-content__label hfl-dir-tree-node__label">{{ data.label }}</span>
-                        <span class="tree-node-content__path hfl-dir-tree-node__path">{{ recoveryTreePathLabel(data) }}</span>
+                        {{ t('protection.backupsPage.msgRecoveryPlanUnavailable') }}
                       </div>
                     </div>
                   </template>
-                </el-tree>
-              </div>
-
-            </div>
-            <template #footer>
-              <div class="el-drawer__footer-actions">
-                <ElButton @click="cancelRecDirDrawer">
-                  {{ t('protection.backupsPage.btnCancel') }}
-                </ElButton>
-                <ElButton type="primary" @click="saveRecDirDrawer">
-                  {{ t('protection.backupsPage.btnEdit') }}
-                </ElButton>
-              </div>
-            </template>
-          </el-drawer>
-        </div>
-
-        <div v-show="recStep === 3" class="dp-wizard-pane">
-          <p class="text-sm text-slate-600 mb-3">{{ t('protection.backupsPage.recStep4Lead') }}</p>
-          <div class="recovery-manual-table-shell">
-            <el-table
-          v-table-overflow-title
-              ref="recRecoveryConfirmTableRef"
-              :data="recRecoveryConfirmSourceRows"
-              row-key="hostId"
-              stripe
-              :expand-row-keys="recExpandedRecConfirmHostIds"
-              :header-cell-style="TABLE_HEADER_STYLE"
-              class="hfl-list-table recovery-confirm-source-table recovery-manual-table"
-              @expand-change="onRecRecoveryConfirmExpandChange"
-            >
-              <el-table-column type="expand" width="35" class-name="recovery-dest-config-expand-column">
-                <template #default="{ row: sourceRow }">
-                  <div class="recovery-confirm-expand">
+                  <template v-else>
                     <div
-                      v-for="draft in sourceRow.taskDrafts"
-                      :key="`${draft.backupId}-${draft.destHostId}-${draft.destPath}`"
-                      class="recovery-confirm-mapping-group"
+                      v-show="recStep === 0"
+                      class="dp-wizard-pane"
                     >
-                      <div class="recovery-confirm-mapping-list">
-                        <div
-                          v-for="entry in draft.dirs"
-                          :key="`${draft.backupId}-${entry.id}`"
-                          class="recovery-mapping-line recovery-confirm-mapping-line"
-                          :title="`${recoveryMappingSourceLabel(entry)} -> ${recoveryMappingTargetLabel(entry)}`"
+                      <p class="text-sm text-slate-500 mb-3">
+                        {{ t('protection.backupsPage.recStepBackupAndSnapshotLead') }}
+                      </p>
+                      <div class="recovery-manual-table-shell">
+                        <el-table
+                          v-table-overflow-title
+                          :data="recBackupSnapshotHostRows"
+                          :header-cell-style="TABLE_HEADER_STYLE"
+                          stripe
+                          class="recovery-plan-preview-table recovery-manual-table"
+                          row-key="rowKey"
                         >
-                          <span
-                            class="recovery-mapping-line__endpoint"
-                            :class="`recovery-mapping-line__endpoint--${recoveryMappingSourceKind(entry)}`"
+                          <el-table-column
+                            :label="t('protection.backupsPage.colBackupSource')"
+                            min-width="240"
                           >
-                            <Archive
-                              v-if="recoveryMappingSourceKind(entry) === 'snapshot'"
-                              :size="14"
-                              class="recovery-mapping-line__icon"
-                            />
-                            <File
-                              v-else-if="recoveryMappingSourceKind(entry) === 'file'"
-                              :size="14"
-                              class="recovery-mapping-line__icon"
-                            />
-                            <Folder v-else :size="14" class="recovery-mapping-line__icon" />
-                            <span class="recovery-mapping-line__text">{{ recoveryMappingSourceLabel(entry) }}</span>
-                          </span>
-                          <span class="recovery-mapping-line__arrow" aria-hidden="true">-&gt;</span>
-                          <span class="recovery-mapping-line__endpoint recovery-mapping-line__endpoint--target">
-                            <FolderOpen :size="14" class="recovery-mapping-line__icon" />
-                            <span class="recovery-mapping-line__text">{{ recoveryMappingTargetLabel(entry) }}</span>
-                          </span>
-                        </div>
+                            <template #default="{ row }">
+                              <div class="recovery-source-summary">
+                                <div class="recovery-source-summary__head">
+                                  <span class="recovery-source-summary__name">
+                                    {{ row.sourceSummary.displayName }}
+                                  </span>
+                                  <el-tag
+                                    size="small"
+                                    effect="plain"
+                                    class="recovery-source-summary__type"
+                                    :type="row.sourceSummary.typeTagType"
+                                  >
+                                    {{ row.sourceSummary.typeLabel }}
+                                  </el-tag>
+                                </div>
+                                <div class="recovery-source-summary__meta">
+                                  <span class="recovery-source-summary__ip">
+                                    {{ row.sourceSummary.ipLine }}
+                                  </span>
+                                  <span class="recovery-source-summary__platform">
+                                    <AgentPlatformBrandIcon
+                                      v-if="row.sourceSummary.platform"
+                                      :os="row.sourceSummary.platform"
+                                    />
+                                    <component
+                                      :is="row.sourceSummary.sourceType === 'nas' ? sourceNasIcon : sourceHostIcon"
+                                      v-else
+                                      :size="16"
+                                    />
+                                  </span>
+                                </div>
+                              </div>
+                            </template>
+                          </el-table-column>
+                          <el-table-column
+                            :label="t('protection.backupsPage.descSnapshot')"
+                            min-width="280"
+                          >
+                            <template #default="{ row }">
+                              <el-select
+                                :model-value="recGroupSnapshotId(row.hostId)"
+                                :placeholder="t('protection.backupsPage.phPickSnapshot')"
+                                class="w-full recovery-plan-preview-table__snapshot-select"
+                                :loading="recoverySnapshotListStateForHost(row.hostId).loading"
+                                @visible-change="(visible) => onRecoverySnapshotSelectVisible(row.hostId, visible)"
+                                @update:model-value="(value) => updateRecoverySnapshotSelectValue(row.hostId, value)"
+                              >
+                                <el-option
+                                  v-for="s in recoverySnapshotOptionsForSource(row.hostId)"
+                                  :key="s.id"
+                                  :label="`${fmtLocalTime(s.time)} · ${fmtBytes(s.sizeBytes)}`"
+                                  :value="s.id"
+                                >
+                                  <div class="recovery-snapshot-option">
+                                    <span class="recovery-snapshot-option__label">
+                                      {{ fmtLocalTime(s.time) }} · {{ fmtBytes(s.sizeBytes) }}
+                                    </span>
+                                    <el-tag
+                                      size="small"
+                                      :type="lifecycleStatusTagAttrs(s.status).type"
+                                      :class="lifecycleStatusTagAttrs(s.status).class"
+                                      effect="plain"
+                                    >
+                                      {{ snapshotStatusLabel(s.status) }}
+                                    </el-tag>
+                                  </div>
+                                </el-option>
+                                <el-option
+                                  v-if="recoverySnapshotHasMore(row.hostId)"
+                                  :key="`${row.rowKey}-snapshot-load-more`"
+                                  :value="RECOVERY_SNAPSHOT_LOAD_MORE_VALUE"
+                                  :label="recoverySnapshotLoadMoreLabel(row.hostId)"
+                                >
+                                  <button
+                                    type="button"
+                                    class="recovery-snapshot-load-more"
+                                    @mousedown.prevent
+                                    @click.stop="updateRecoverySnapshotSelectValue(row.hostId, RECOVERY_SNAPSHOT_LOAD_MORE_VALUE)"
+                                  >
+                                    {{ recoverySnapshotLoadMoreLabel(row.hostId) }}
+                                  </button>
+                                </el-option>
+                              </el-select>
+                            </template>
+                          </el-table-column>
+                        </el-table>
                       </div>
                     </div>
-                    <div v-if="!sourceRow.taskDrafts.length" class="text-sm text-slate-400">
-                      {{ t('protection.backupsPage.recoveryDirEmptyCompact') }}
-                    </div>
-                  </div>
-                </template>
-              </el-table-column>
-              <el-table-column :label="t('protection.backupsPage.colBackupSnapshot')" min-width="220">
-                <template #default="{ row }">
-                  <button
-                    type="button"
-                    class="recovery-dir-source-toggle"
-                    @click="toggleRecRecoveryConfirmRow(row)"
-                  >
-                    <span class="recovery-source-summary recovery-source-summary--with-snapshot">
-                      <span class="recovery-source-summary__head">
-                        <span class="recovery-source-summary__name">
-                          {{ row.sourceSummary.displayName }}
-                        </span>
-                        <el-tag
-                          size="small"
-                          effect="plain"
-                          class="recovery-source-summary__type"
-                          :type="row.sourceSummary.typeTagType"
-                        >
-                          {{ row.sourceSummary.typeLabel }}
-                        </el-tag>
-                      </span>
-                      <span class="recovery-source-summary__meta">
-                        <span class="recovery-source-summary__ip">
-                          {{ row.sourceSummary.ipLine }}
-                        </span>
-                        <span class="recovery-source-summary__platform">
-                          <AgentPlatformBrandIcon
-                            v-if="row.sourceSummary.platform"
-                            :os="row.sourceSummary.platform"
-                          />
-                          <component
-                            :is="row.sourceSummary.sourceType === 'nas' ? sourceNasIcon : sourceHostIcon"
-                            v-else
-                            :size="16"
-                          />
-                        </span>
-                      </span>
-                      <span class="recovery-source-summary__snapshot">
-                        Snapshot: {{ row.snapshotLine }}
-                      </span>
-                    </span>
-                  </button>
-                </template>
-              </el-table-column>
-              <el-table-column :label="t('protection.backupsPage.recStepDest')" min-width="216">
-                <template #default="{ row }">
-                  <div v-if="row.destSummary" class="recovery-source-summary">
-                    <div class="recovery-source-summary__head">
-                      <span class="recovery-source-summary__name">
-                        {{ row.destSummary.displayName }}
-                      </span>
-                      <el-tag
-                        size="small"
-                        effect="plain"
-                        class="recovery-source-summary__type"
-                        :type="row.destSummary.typeTagType"
-                      >
-                        {{ row.destSummary.typeLabel }}
-                      </el-tag>
-                    </div>
-                    <div class="recovery-source-summary__meta">
-                      <span class="recovery-source-summary__ip">
-                        {{ row.destSummary.ipLine }}
-                      </span>
-                      <span class="recovery-source-summary__platform">
-                        <AgentPlatformBrandIcon
-                          v-if="row.destSummary.platform"
-                          :os="row.destSummary.platform"
-                        />
-                        <component
-                          :is="row.destSummary.sourceType === 'nas' ? sourceNasIcon : sourceHostIcon"
-                          v-else
-                          :size="16"
-                        />
-                      </span>
-                    </div>
-                  </div>
-                  <div v-else class="create-source-dir-preview-empty">
-                    {{ t('protection.backupsPage.recoveryDestEmptyCompact') }}
-                  </div>
-                </template>
-              </el-table-column>
-              <el-table-column :label="t('protection.backupsPage.recoveryConflictPolicyCol')" min-width="254">
-                <template #default="{ row }">
-                  <ElTooltip
-                    placement="top-start"
-                    :content="recoveryConflictPolicySummary(row.conflictPolicy)"
-                    :show-after="300"
-                  >
-                    <span
-                      class="create-recovery-plan-cell__policy recovery-confirm-policy-cell"
-                      :class="`create-recovery-plan-cell__policy--${row.conflictPolicy}`"
+
+                    <div
+                      v-show="recStep === 1"
+                      class="dp-wizard-pane"
                     >
-                      <ShieldAlert
-                        v-if="row.conflictPolicy === 'overwrite'"
-                        :size="14"
-                        class="create-recovery-plan-cell__policy-icon"
-                      />
-                      <ShieldCheck v-else :size="14" class="create-recovery-plan-cell__policy-icon" />
-                      <span class="create-recovery-plan-cell__policy-text">
-                        {{ recoveryConflictPolicySummary(row.conflictPolicy) }}
-                      </span>
-                    </span>
-                  </ElTooltip>
-                </template>
-              </el-table-column>
-            </el-table>
-          </div>
-        </div>
-        </template>
+                      <p class="text-sm text-slate-500 mb-3">
+                        {{ t('protection.backupsPage.recStep3Lead') }}
+                      </p>
+                      <div class="recovery-manual-table-shell">
+                        <el-table
+                          v-table-overflow-title
+                          :data="recRecoveryDestSourceRows"
+                          row-key="hostId"
+                          stripe
+                          :header-cell-style="TABLE_HEADER_STYLE"
+                          class="hfl-list-table recovery-manual-table"
+                        >
+                          <el-table-column
+                            :label="t('protection.backupsPage.colBackupSourceSnapshot')"
+                            min-width="260"
+                          >
+                            <template #default="{ row }">
+                              <div class="recovery-source-summary recovery-source-summary--with-snapshot">
+                                <div class="recovery-source-summary__head">
+                                  <span class="recovery-source-summary__name">
+                                    {{ row.sourceSummary.displayName }}
+                                  </span>
+                                  <el-tag
+                                    size="small"
+                                    effect="plain"
+                                    class="recovery-source-summary__type"
+                                    :type="row.sourceSummary.typeTagType"
+                                  >
+                                    {{ row.sourceSummary.typeLabel }}
+                                  </el-tag>
+                                </div>
+                                <div class="recovery-source-summary__meta">
+                                  <span class="recovery-source-summary__ip">
+                                    {{ row.sourceSummary.ipLine }}
+                                  </span>
+                                  <span class="recovery-source-summary__platform">
+                                    <AgentPlatformBrandIcon
+                                      v-if="row.sourceSummary.platform"
+                                      :os="row.sourceSummary.platform"
+                                    />
+                                    <component
+                                      :is="row.sourceSummary.sourceType === 'nas' ? sourceNasIcon : sourceHostIcon"
+                                      v-else
+                                      :size="16"
+                                    />
+                                  </span>
+                                </div>
+                                <div class="recovery-source-summary__snapshot">
+                                  Snapshot: {{ row.snapshotLine }}
+                                </div>
+                              </div>
+                            </template>
+                          </el-table-column>
+                          <el-table-column
+                            :label="t('protection.backupsPage.recStepDest')"
+                            min-width="360"
+                          >
+                            <template #default="{ row }">
+                              <div class="recovery-target-host-control hfl-table-no-tooltip">
+                                <ElTooltip
+                                  :disabled="Boolean(recoverySourceHostButtonOption(row.hostId))"
+                                  :content="t('protection.backupsPage.recoverySourceHostUnavailable')"
+                                  placement="top"
+                                >
+                                  <span class="recovery-target-host-control__source-wrap">
+                                    <ElButton
+                                      class="hfl-btn-with-icon recovery-target-host-control__source"
+                                      :class="{ 'is-selected': isRecoverySourceHostSelected(row.hostId) }"
+                                      :disabled="!recoverySourceHostButtonOption(row.hostId)"
+                                      @click="toggleRecoverySourceTargetForSource(row.hostId)"
+                                    >
+                                      <Check
+                                        v-if="isRecoverySourceHostSelected(row.hostId)"
+                                        :size="14"
+                                      />
+                                      <component
+                                        :is="row.sourceSummary.sourceType === 'nas' ? sourceNasIcon : sourceHostIcon"
+                                        v-else
+                                        :size="14"
+                                      />
+                                      <span>{{ t('protection.backupsPage.recoveryUseSourceHost') }}</span>
+                                    </ElButton>
+                                  </span>
+                                </ElTooltip>
+                                <div
+                                  v-if="isRecoverySourceHostSelected(row.hostId)"
+                                  class="recovery-target-host-control__readonly"
+                                >
+                                  <div class="recovery-source-summary">
+                                    <div class="recovery-source-summary__head">
+                                      <span class="recovery-source-summary__name">
+                                        {{ row.sourceSummary.displayName }}
+                                      </span>
+                                      <el-tag
+                                        size="small"
+                                        effect="plain"
+                                        class="recovery-source-summary__type"
+                                        :type="row.sourceSummary.typeTagType"
+                                      >
+                                        {{ row.sourceSummary.typeLabel }}
+                                      </el-tag>
+                                    </div>
+                                    <div class="recovery-source-summary__meta">
+                                      <span class="recovery-source-summary__ip">
+                                        {{ row.sourceSummary.ipLine }}
+                                      </span>
+                                      <span class="recovery-source-summary__platform">
+                                        <AgentPlatformBrandIcon
+                                          v-if="row.sourceSummary.platform"
+                                          :os="row.sourceSummary.platform"
+                                        />
+                                        <component
+                                          :is="row.sourceSummary.sourceType === 'nas' ? sourceNasIcon : sourceHostIcon"
+                                          v-else
+                                          :size="16"
+                                        />
+                                      </span>
+                                    </div>
+                                  </div>
+                                </div>
+                                <el-select
+                                  v-else
+                                  :model-value="recoveryTargetNodeSelectModelForSource(row.hostId)"
+                                  :placeholder="t('protection.backupsPage.phPickOtherRecoveryHost')"
+                                  class="recovery-target-host-control__select"
+                                  filterable
+                                  remote
+                                  reserve-keyword
+                                  clearable
+                                  :remote-method="searchRecoveryTargetHostOptions"
+                                  :loading="recoveryTargetHostLoading || recoveryTargetHostLoadingMore"
+                                  popper-class="recovery-target-node-select-popper"
+                                  @visible-change="onRecoveryTargetNodeSelectVisible"
+                                  @popup-scroll="onRecoveryTargetNodePopupScroll"
+                                  @update:model-value="(value) => setRecoveryTargetNodeForSource(row.hostId, value)"
+                                >
+                                  <el-option
+                                    v-for="option in recoveryTargetNodeOptionsForSource(row.hostId)"
+                                    :key="option.value"
+                                    :label="option.label"
+                                    :value="option.value"
+                                    :disabled="!option.selectable"
+                                  >
+                                    <div class="recovery-target-node-option">
+                                      <div class="recovery-target-node-option__main">
+                                        <span
+                                          class="recovery-target-node-option__label"
+                                          :title="option.sourceSummary.displayName"
+                                        >
+                                          {{ option.sourceSummary.displayName }}
+                                        </span>
+                                        <el-tag
+                                          size="small"
+                                          effect="plain"
+                                          class="recovery-source-summary__type"
+                                          :type="option.sourceSummary.typeTagType"
+                                        >
+                                          {{ option.sourceSummary.typeLabel }}
+                                        </el-tag>
+                                      </div>
+                                      <div class="recovery-source-summary__meta">
+                                        <span
+                                          class="recovery-target-node-option__meta"
+                                          :title="option.sourceSummary.ipLine"
+                                        >
+                                          {{ option.sourceSummary.ipLine }}
+                                        </span>
+                                        <span class="recovery-source-summary__platform">
+                                          <AgentPlatformBrandIcon
+                                            v-if="option.sourceSummary.platform"
+                                            :os="option.sourceSummary.platform"
+                                          />
+                                          <component
+                                            :is="option.sourceSummary.sourceType === 'nas' ? sourceNasIcon : sourceHostIcon"
+                                            v-else
+                                            :size="16"
+                                          />
+                                        </span>
+                                      </div>
+                                    </div>
+                                  </el-option>
+                                  <el-option
+                                    v-if="recoveryTargetHostLoadingMore"
+                                    key="recovery-target-loading-more"
+                                    disabled
+                                    value="__loading_more__"
+                                    :label="t('common.loading')"
+                                  >
+                                    <span class="recovery-target-node-option__loading">{{ t('common.loading') }}</span>
+                                  </el-option>
+                                  <el-option
+                                    v-else-if="recoveryTargetHostError"
+                                    key="recovery-target-load-more-error"
+                                    disabled
+                                    value="__load_more_error__"
+                                    :label="t('protection.backupsPage.recoveryTargetLoadFailed')"
+                                  >
+                                    <ElButton
+                                      link
+                                      type="primary"
+                                      @click.stop="restoreTargetCatalog.retry"
+                                    >
+                                      {{ t('common.retry') }}
+                                    </ElButton>
+                                  </el-option>
+                                  <template #empty>
+                                    <div class="py-3 text-center text-xs text-slate-500">
+                                      <span>{{ recoveryTargetHostError ? t('protection.backupsPage.recoveryTargetLoadFailed') : t('protection.backupsPage.recoveryTargetEmpty') }}</span>
+                                      <ElButton
+                                        v-if="recoveryTargetHostError"
+                                        link
+                                        type="primary"
+                                        @click.stop="restoreTargetCatalog.retry"
+                                      >
+                                        {{ t('common.retry') }}
+                                      </ElButton>
+                                    </div>
+                                  </template>
+                                </el-select>
+                              </div>
+                            </template>
+                          </el-table-column>
+                        </el-table>
+                      </div>
+                    </div>
+
+                    <div
+                      v-show="recStep === 2"
+                      class="dp-wizard-pane"
+                    >
+                      <p class="text-sm text-slate-500 mb-3">
+                        {{ t('protection.backupsPage.recStep2Lead') }}
+                      </p>
+                      <div class="recovery-manual-table-shell">
+                        <el-table
+                          ref="recRecoveryDirSourceTableRef"
+                          v-table-overflow-title
+                          :data="recRecoveryDirSourceRows"
+                          row-key="hostId"
+                          stripe
+                          :expand-row-keys="recExpandedRecDirHostIds"
+                          :header-cell-style="TABLE_HEADER_STYLE"
+                          class="hfl-list-table recovery-dest-config-table recovery-dir-config-table recovery-manual-table"
+                          @expand-change="onRecRecoveryDirExpandChange"
+                        >
+                          <el-table-column
+                            type="expand"
+                            width="35"
+                            class-name="recovery-dest-config-expand-column"
+                          >
+                            <template #default="{ row: sourceRow }">
+                              <div class="recovery-dest-config-detail">
+                                <div class="create-recovery-dir-plan-list recovery-dir-selection-list">
+                                  <div
+                                    class="create-recovery-dir-plan-labels recovery-dir-selection-labels"
+                                    aria-hidden="true"
+                                  >
+                                    <span class="create-recovery-required-label">
+                                      {{ t('protection.backupsPage.colBackupSnapshotDirectory') }}
+                                      <span class="create-recovery-required-mark">*</span>
+                                      <HflHelpTip
+                                        :content="t('protection.backupsPage.createRecoveryPathInputHint')"
+                                        :size="13"
+                                        :aria-label="t('protection.backupsPage.colBackupSnapshotDirectory')"
+                                      />
+                                    </span>
+                                    <span class="create-recovery-required-label">
+                                      {{ t('protection.backupsPage.colRecoveryTargetDirectory') }}
+                                      <span class="create-recovery-required-mark">*</span>
+                                      <HflHelpTip
+                                        :content="t('protection.backupsPage.createRecoveryPathInputHint')"
+                                        :size="13"
+                                        :aria-label="t('protection.backupsPage.colRecoveryTargetDirectory')"
+                                      />
+                                    </span>
+                                    <span>{{ t('protection.backupsPage.colActions') }}</span>
+                                  </div>
+                                  <div
+                                    v-for="entry in sourceRow.entries"
+                                    :key="entry.id"
+                                    class="create-recovery-dir-plan-row recovery-dir-selection-row"
+                                  >
+                                    <div
+                                      class="create-recovery-dir-plan-field"
+                                      :data-label="t('protection.backupsPage.colBackupSnapshotDirectory')"
+                                    >
+                                      <HflPopover
+                                        :visible="isRecoverySnapshotRangePickerVisible(sourceRow.hostId, entry)"
+                                        trigger="manual"
+                                        placement="bottom-start"
+                                        :width="460"
+                                        popper-class="create-recovery-path-popover"
+                                        @update:visible="(visible) => setRecoverySnapshotRangePickerVisible(sourceRow.hostId, entry, Boolean(visible))"
+                                      >
+                                        <template #reference>
+                                          <div class="create-recovery-path-input">
+                                            <el-input
+                                              :model-value="recoverySnapshotRangeDisplayForEntry(sourceRow.hostId, entry)"
+                                              clearable
+                                              :placeholder="t('protection.backupsPage.phSelectOrEnterRestoreScope')"
+                                              :class="{
+                                                'create-recovery-path-input--pending': entry.sourcePathValidation === 'pending',
+                                                'create-recovery-path-input--invalid': isRecoverySnapshotRangeInputInvalid(entry),
+                                              }"
+                                              :aria-describedby="isRecoverySnapshotRangeErrorVisible(sourceRow.hostId, entry) ? `recovery-snapshot-range-error-${sourceRow.hostId}-${entry.id}` : undefined"
+                                              @click.stop
+                                              @update:model-value="(value) => updateRecoverySnapshotRangeInput(sourceRow.hostId, entry, String(value))"
+                                              @blur="entry.sourcePathValidation === 'pending' && validateRecoverySnapshotRangeInput(sourceRow.hostId, entry)"
+                                              @keydown.enter.prevent="validateRecoverySnapshotRangeInput(sourceRow.hostId, entry)"
+                                            >
+                                              <template
+                                                v-if="isRecoverySnapshotRangeValidating(sourceRow.hostId, entry)"
+                                                #suffix
+                                              >
+                                                <span class="create-recovery-path-input__checking">{{ t('common.loading') }}</span>
+                                              </template>
+                                              <template #prefix>
+                                                <component
+                                                  :is="recoverySnapshotRangeInputIcon(entry)"
+                                                  :size="14"
+                                                  class="create-recovery-path-input__type-icon"
+                                                  :class="recoverySnapshotRangeInputIconClass(entry)"
+                                                />
+                                              </template>
+                                              <template #append>
+                                                <ElButton
+                                                  class="create-recovery-path-input__btn"
+                                                  :aria-label="t('protection.backupsPage.btnBrowsePaths')"
+                                                  @click.stop="setRecoverySnapshotRangePickerVisible(sourceRow.hostId, entry, true)"
+                                                >
+                                                  <FolderOpen :size="16" />
+                                                </ElButton>
+                                              </template>
+                                            </el-input>
+                                            <p
+                                              v-if="isRecoverySnapshotRangeErrorVisible(sourceRow.hostId, entry)"
+                                              :id="`recovery-snapshot-range-error-${sourceRow.hostId}-${entry.id}`"
+                                              class="create-recovery-path-input__error"
+                                              role="alert"
+                                            >
+                                              <span>{{ recoverySnapshotRangeInputError(entry) }}</span>
+                                              <button
+                                                type="button"
+                                                class="create-recovery-path-input__error-close"
+                                                :aria-label="t('protection.backupsPage.btnClose')"
+                                                @click.stop="dismissRecoveryPathError(sourceRow.hostId, entry, 'source')"
+                                              >
+                                                <X :size="13" />
+                                              </button>
+                                            </p>
+                                          </div>
+                                        </template>
+                                        <div class="create-recovery-tree-popover hfl-dir-tree-shell">
+                                          <el-tree
+                                            :ref="(el) => setRecoveryDirectoryTreeRef(recoveryDirectoryTreeKey(sourceRow.hostId, entry.id, 'snapshot'), el)"
+                                            :key="`restore-snapshot-picker-${sourceRow.hostId}-${entry.id}-${selectedSnapshotNumericIdForSource(sourceRow.hostId)}-${recoverySnapshotBrowseRevision}`"
+                                            class="source-dir-tree create-recovery-popover-tree hfl-dir-tree hfl-dir-tree--tall"
+                                            node-key="id"
+                                            lazy
+                                            :load="(node, resolve) => loadRecoverySnapshotPickerNode(sourceRow.hostId, node, resolve)"
+                                            :props="{ label: 'label', children: 'children', isLeaf: 'isLeaf' }"
+                                            @node-click="(data) => pickRecoverySnapshotRange(sourceRow.hostId, entry, data)"
+                                            @node-collapse="(data) => onRecoveryDirectoryExpansionChange(recoveryDirectoryTreeKey(sourceRow.hostId, entry.id, 'snapshot'), data.id)"
+                                            @node-expand="(data) => onRecoveryDirectoryExpansionChange(recoveryDirectoryTreeKey(sourceRow.hostId, entry.id, 'snapshot'), data.id)"
+                                          >
+                                            <template #default="{ data }">
+                                              <div
+                                                class="create-tree-node-content hfl-dir-tree-node"
+                                                :class="{
+                                                  'create-tree-node-content--snapshot': data.type === 'snapshot',
+                                                  'recovery-snapshot-tree-node--selected': isRecoverySnapshotPickerNodeSelected(entry, data),
+                                                }"
+                                              >
+                                                <Camera
+                                                  v-if="data.type === 'snapshot'"
+                                                  :size="15"
+                                                  class="create-tree-node-content__icon hfl-dir-tree-node__icon create-dir-row__icon--snapshot"
+                                                />
+                                                <FolderOpen
+                                                  v-else-if="data.type === 'dir'"
+                                                  :size="15"
+                                                  class="create-tree-node-content__icon hfl-dir-tree-node__icon create-dir-row__icon--folder"
+                                                />
+                                                <File
+                                                  v-else
+                                                  :size="15"
+                                                  class="create-tree-node-content__icon hfl-dir-tree-node__icon create-dir-row__icon--file"
+                                                />
+                                                <div class="create-tree-node-content__text hfl-dir-tree-node__text">
+                                                  <span class="create-tree-node-content__label hfl-dir-tree-node__label">{{ data.label }}</span>
+                                                  <span
+                                                    v-if="data.type === 'snapshot'"
+                                                    class="create-tree-node-content__snapshot-desc create-tree-node-content__path hfl-dir-tree-node__path"
+                                                  >
+                                                    {{ t('protection.backupsPage.createRecoveryScopeSnapshotDesc') }}
+                                                  </span>
+                                                </div>
+                                                <button
+                                                  v-if="data.type === 'dir'"
+                                                  type="button"
+                                                  class="hfl-dir-tree-node__refresh"
+                                                  :class="{ 'is-refreshing': isRecoveryDirectoryRefreshing(recoveryDirectoryTreeKey(sourceRow.hostId, entry.id, 'snapshot'), data.id) }"
+                                                  :disabled="isRecoveryDirectoryRefreshing(recoveryDirectoryTreeKey(sourceRow.hostId, entry.id, 'snapshot'), data.id)"
+                                                  :aria-label="t('protection.backupsPage.ariaRefreshDirectory', { path: data.path })"
+                                                  :title="t('protection.backupsPage.ariaRefreshDirectory', { path: data.path })"
+                                                  @click.stop="refreshRecoverySnapshotDirectory(sourceRow.hostId, entry, data)"
+                                                >
+                                                  <RefreshCw
+                                                    :size="14"
+                                                    :class="{ 'is-spinning': isRecoveryDirectoryRefreshing(recoveryDirectoryTreeKey(sourceRow.hostId, entry.id, 'snapshot'), data.id) }"
+                                                  />
+                                                </button>
+                                              </div>
+                                            </template>
+                                          </el-tree>
+                                        </div>
+                                      </HflPopover>
+                                    </div>
+                                    <div
+                                      class="create-recovery-dir-plan-field"
+                                      :data-label="t('protection.backupsPage.colRecoveryTargetDirectory')"
+                                    >
+                                      <HflPopover
+                                        :visible="isRecoveryTargetDirPickerVisible(sourceRow.hostId, entry)"
+                                        trigger="manual"
+                                        placement="bottom-start"
+                                        :width="360"
+                                        popper-class="create-recovery-path-popover"
+                                        @update:visible="(visible) => setRecoveryTargetDirPickerVisible(sourceRow.hostId, entry, Boolean(visible))"
+                                      >
+                                        <template #reference>
+                                          <div class="create-recovery-path-input">
+                                            <el-input
+                                              :model-value="entry.targetPath || ''"
+                                              :placeholder="t('protection.backupsPage.phSelectOrEnterRestoreDirectory')"
+                                              :class="{
+                                                'create-recovery-path-input--pending': entry.targetPathValidation === 'pending',
+                                                'create-recovery-path-input--invalid': isRecoveryTargetDirInputInvalid(entry),
+                                              }"
+                                              :aria-describedby="isRecoveryTargetDirErrorVisible(sourceRow.hostId, entry) ? `recovery-target-dir-error-${sourceRow.hostId}-${entry.id}` : undefined"
+                                              @click.stop
+                                              @update:model-value="(value) => updateRecoveryTargetDirInput(sourceRow.hostId, entry, String(value))"
+                                              @blur="entry.targetPathValidation === 'pending' && validateRecoveryTargetDirInput(sourceRow.hostId, entry)"
+                                              @keydown.enter.prevent="validateRecoveryTargetDirInput(sourceRow.hostId, entry)"
+                                            >
+                                              <template
+                                                v-if="isRecoveryTargetDirValidating(sourceRow.hostId, entry)"
+                                                #suffix
+                                              >
+                                                <span class="create-recovery-path-input__checking">{{ t('common.loading') }}</span>
+                                              </template>
+                                              <template #prefix>
+                                                <component
+                                                  :is="recoveryTargetDirInputIcon(entry)"
+                                                  :size="14"
+                                                  class="create-recovery-path-input__type-icon"
+                                                  :class="recoveryTargetDirInputIconClass(entry)"
+                                                />
+                                              </template>
+                                              <template #append>
+                                                <ElButton
+                                                  class="create-recovery-path-input__btn"
+                                                  :aria-label="t('protection.backupsPage.btnBrowsePaths')"
+                                                  @click.stop="setRecoveryTargetDirPickerVisible(sourceRow.hostId, entry, !isRecoveryTargetDirPickerVisible(sourceRow.hostId, entry))"
+                                                >
+                                                  <FolderOpen :size="16" />
+                                                </ElButton>
+                                              </template>
+                                            </el-input>
+                                            <p
+                                              v-if="isRecoveryTargetDirErrorVisible(sourceRow.hostId, entry)"
+                                              :id="`recovery-target-dir-error-${sourceRow.hostId}-${entry.id}`"
+                                              class="create-recovery-path-input__error"
+                                              role="alert"
+                                            >
+                                              <span>{{ recoveryTargetDirInputError(entry) }}</span>
+                                              <button
+                                                type="button"
+                                                class="create-recovery-path-input__error-close"
+                                                :aria-label="t('protection.backupsPage.btnClose')"
+                                                @click.stop="dismissRecoveryPathError(sourceRow.hostId, entry, 'target')"
+                                              >
+                                                <X :size="13" />
+                                              </button>
+                                            </p>
+                                          </div>
+                                        </template>
+                                        <div class="create-recovery-tree-popover hfl-dir-tree-shell">
+                                          <el-tree
+                                            :ref="(el) => setRecoveryDirectoryTreeRef(recoveryDirectoryTreeKey(sourceRow.hostId, entry.id, 'target'), el)"
+                                            :key="`restore-target-dir-picker-${sourceRow.hostId}-${entry.id}-${targetNodeSourceIdForSource(sourceRow.hostId)}`"
+                                            v-loading="isRecoveryTargetDirTreeLoading(sourceRow.hostId, entry)"
+                                            class="source-dir-tree create-recovery-popover-tree hfl-dir-tree hfl-dir-tree--tall"
+                                            node-key="path"
+                                            lazy
+                                            :expand-on-click-node="false"
+                                            :load="(node, resolve) => loadRecoveryTargetDirPickerNode(sourceRow.hostId, entry, node, resolve)"
+                                            :props="{ label: 'label', children: 'children', isLeaf: 'isLeaf' }"
+                                            :current-node-key="entry.targetPath"
+                                            highlight-current
+                                            @node-click="(data) => pickRecoveryTargetDir(sourceRow.hostId, entry, data.path)"
+                                            @node-collapse="(data) => onRecoveryDirectoryExpansionChange(recoveryDirectoryTreeKey(sourceRow.hostId, entry.id, 'target'), data.path)"
+                                            @node-expand="(data) => onRecoveryDirectoryExpansionChange(recoveryDirectoryTreeKey(sourceRow.hostId, entry.id, 'target'), data.path)"
+                                          >
+                                            <template #default="{ data }">
+                                              <div class="create-tree-node-content hfl-dir-tree-node">
+                                                <FolderOpen
+                                                  :size="15"
+                                                  class="create-tree-node-content__icon hfl-dir-tree-node__icon create-dir-row__icon--folder"
+                                                />
+                                                <div class="create-tree-node-content__text hfl-dir-tree-node__text">
+                                                  <span class="create-tree-node-content__label hfl-dir-tree-node__label">{{ data.label }}</span>
+                                                  <span class="create-tree-node-content__path hfl-dir-tree-node__path">{{ data.path }}</span>
+                                                </div>
+                                                <button
+                                                  type="button"
+                                                  class="hfl-dir-tree-node__refresh"
+                                                  :class="{ 'is-refreshing': isRecoveryDirectoryRefreshing(recoveryDirectoryTreeKey(sourceRow.hostId, entry.id, 'target'), data.path) }"
+                                                  :disabled="isRecoveryDirectoryRefreshing(recoveryDirectoryTreeKey(sourceRow.hostId, entry.id, 'target'), data.path)"
+                                                  :aria-label="t('protection.backupsPage.ariaRefreshDirectory', { path: data.path })"
+                                                  :title="t('protection.backupsPage.ariaRefreshDirectory', { path: data.path })"
+                                                  @click.stop="refreshRecoveryTargetDirectory(sourceRow.hostId, entry, data)"
+                                                >
+                                                  <RefreshCw
+                                                    :size="14"
+                                                    :class="{ 'is-spinning': isRecoveryDirectoryRefreshing(recoveryDirectoryTreeKey(sourceRow.hostId, entry.id, 'target'), data.path) }"
+                                                  />
+                                                </button>
+                                              </div>
+                                            </template>
+                                          </el-tree>
+                                        </div>
+                                      </HflPopover>
+                                    </div>
+                                    <div
+                                      class="create-recovery-dir-plan-field create-recovery-dir-plan-actions"
+                                      :data-label="t('protection.backupsPage.colActions')"
+                                    >
+                                      <ElButton
+                                        text
+                                        circle
+                                        type="danger"
+                                        size="small"
+                                        :title="t('protection.backupsPage.ariaRemove')"
+                                        @click="removeRecoveryDirEntry(sourceRow.hostId, entry.id)"
+                                      >
+                                        <Trash2 :size="14" />
+                                      </ElButton>
+                                    </div>
+                                  </div>
+                                  <div class="recovery-dir-selection-add-wrap">
+                                    <button
+                                      type="button"
+                                      class="recovery-dir-selection-add-row"
+                                      @click="addRecoveryDirEntryAndExpand(sourceRow)"
+                                    >
+                                      <CirclePlus :size="16" />
+                                      <span>{{ t('protection.backupsPage.btnAddRecoveryDir') }}</span>
+                                    </button>
+                                  </div>
+                                </div>
+                              </div>
+                            </template>
+                          </el-table-column>
+                          <el-table-column
+                            :label="t('protection.backupsPage.colBackupSnapshot')"
+                            min-width="220"
+                          >
+                            <template #default="{ row }">
+                              <button
+                                type="button"
+                                class="recovery-dir-source-toggle"
+                                @click="toggleRecRecoveryDirRow(row)"
+                              >
+                                <span class="recovery-source-summary recovery-source-summary--with-snapshot">
+                                  <span class="recovery-source-summary__head">
+                                    <span class="recovery-source-summary__name">
+                                      {{ row.sourceSummary.displayName }}
+                                    </span>
+                                    <el-tag
+                                      size="small"
+                                      effect="plain"
+                                      class="recovery-source-summary__type"
+                                      :type="row.sourceSummary.typeTagType"
+                                    >
+                                      {{ row.sourceSummary.typeLabel }}
+                                    </el-tag>
+                                  </span>
+                                  <span class="recovery-source-summary__meta">
+                                    <span class="recovery-source-summary__ip">
+                                      {{ row.sourceSummary.ipLine }}
+                                    </span>
+                                    <span class="recovery-source-summary__platform">
+                                      <AgentPlatformBrandIcon
+                                        v-if="row.sourceSummary.platform"
+                                        :os="row.sourceSummary.platform"
+                                      />
+                                      <component
+                                        :is="row.sourceSummary.sourceType === 'nas' ? sourceNasIcon : sourceHostIcon"
+                                        v-else
+                                        :size="16"
+                                      />
+                                    </span>
+                                  </span>
+                                  <span class="recovery-source-summary__snapshot">
+                                    Snapshot: {{ row.snapshotLine }}
+                                  </span>
+                                </span>
+                              </button>
+                            </template>
+                          </el-table-column>
+                          <el-table-column
+                            :label="t('protection.backupsPage.recStepDest')"
+                            min-width="210"
+                          >
+                            <template #default="{ row }">
+                              <div
+                                v-if="row.destSummary"
+                                class="recovery-source-summary"
+                              >
+                                <div class="recovery-source-summary__head">
+                                  <span class="recovery-source-summary__name">
+                                    {{ row.destSummary.displayName }}
+                                  </span>
+                                  <el-tag
+                                    size="small"
+                                    effect="plain"
+                                    class="recovery-source-summary__type"
+                                    :type="row.destSummary.typeTagType"
+                                  >
+                                    {{ row.destSummary.typeLabel }}
+                                  </el-tag>
+                                </div>
+                                <div class="recovery-source-summary__meta">
+                                  <span class="recovery-source-summary__ip">
+                                    {{ row.destSummary.ipLine }}
+                                  </span>
+                                  <span class="recovery-source-summary__platform">
+                                    <AgentPlatformBrandIcon
+                                      v-if="row.destSummary.platform"
+                                      :os="row.destSummary.platform"
+                                    />
+                                    <component
+                                      :is="row.destSummary.sourceType === 'nas' ? sourceNasIcon : sourceHostIcon"
+                                      v-else
+                                      :size="16"
+                                    />
+                                  </span>
+                                </div>
+                              </div>
+                              <div
+                                v-else
+                                class="create-source-dir-preview-empty"
+                              >
+                                {{ t('protection.backupsPage.recoveryDestEmptyCompact') }}
+                              </div>
+                            </template>
+                          </el-table-column>
+                          <el-table-column min-width="220">
+                            <template #header>
+                              <span class="create-recovery-required-label">
+                                {{ t('protection.backupsPage.recoveryConflictPolicyCol') }}
+                                <span class="create-recovery-required-mark">*</span>
+                              </span>
+                            </template>
+                            <template #default="{ row }">
+                              <div class="recovery-conflict-policy-cell hfl-table-no-tooltip">
+                                <el-select
+                                  :model-value="recConflictPolicyForSource(row.hostId)"
+                                  size="small"
+                                  class="w-full recovery-conflict-policy-select"
+                                  :class="{
+                                    'recovery-conflict-policy-select--invalid': !recConflictPolicyForSource(row.hostId),
+                                    'recovery-conflict-policy-select--skip': recConflictPolicyForSource(row.hostId) === 'skip',
+                                    'recovery-conflict-policy-select--overwrite': recConflictPolicyForSource(row.hostId) === 'overwrite',
+                                  }"
+                                  :placeholder="t('protection.backupsPage.fileConflictPolicyPlaceholder')"
+                                  @update:model-value="(value) => setRecConflictPolicyForSource(row.hostId, value as RecoveryConflictPolicy)"
+                                >
+                                  <el-option
+                                    :label="t('protection.backupsPage.recoveryConflictSkip')"
+                                    value="skip"
+                                  >
+                                    <div class="recovery-conflict-policy-option recovery-conflict-policy-option--skip">
+                                      <ShieldCheck :size="14" />
+                                      <span>{{ t('protection.backupsPage.createRecoveryConflictSkipFull') }}</span>
+                                    </div>
+                                  </el-option>
+                                  <el-option
+                                    :label="t('protection.backupsPage.recoveryConflictOverwrite')"
+                                    value="overwrite"
+                                  >
+                                    <div class="recovery-conflict-policy-option recovery-conflict-policy-option--overwrite">
+                                      <ShieldAlert :size="14" />
+                                      <span>{{ t('protection.backupsPage.createRecoveryConflictOverwriteFull') }}</span>
+                                    </div>
+                                  </el-option>
+                                </el-select>
+                              </div>
+                            </template>
+                          </el-table-column>
+                          <el-table-column
+                            :label="t('protection.backupsPage.colRecoveryDirectoryMapping')"
+                            min-width="300"
+                          >
+                            <template #default="{ row }">
+                              <ElTooltip
+                                v-if="row.configuredEntries.length"
+                                placement="top-start"
+                                :show-after="300"
+                                popper-class="recovery-entry-preview-tooltip"
+                              >
+                                <template #content>
+                                  <div class="recovery-entry-preview-tooltip__list">
+                                    <div
+                                      v-for="entry in row.configuredEntries"
+                                      :key="entry.id"
+                                      class="recovery-mapping-line recovery-entry-preview-tooltip__line"
+                                    >
+                                      <span
+                                        class="recovery-mapping-line__endpoint"
+                                        :class="`recovery-mapping-line__endpoint--${recoveryMappingSourceKind(entry)}`"
+                                      >
+                                        <Archive
+                                          v-if="recoveryMappingSourceKind(entry) === 'snapshot'"
+                                          :size="14"
+                                          class="recovery-mapping-line__icon"
+                                        />
+                                        <File
+                                          v-else-if="recoveryMappingSourceKind(entry) === 'file'"
+                                          :size="14"
+                                          class="recovery-mapping-line__icon"
+                                        />
+                                        <Folder
+                                          v-else
+                                          :size="14"
+                                          class="recovery-mapping-line__icon"
+                                        />
+                                        <span class="recovery-mapping-line__text">{{ recoveryMappingSourceLabel(entry) }}</span>
+                                      </span>
+                                      <span
+                                        class="recovery-mapping-line__arrow"
+                                        aria-hidden="true"
+                                      >-&gt;</span>
+                                      <span class="recovery-mapping-line__endpoint recovery-mapping-line__endpoint--target">
+                                        <FolderOpen
+                                          :size="14"
+                                          class="recovery-mapping-line__icon"
+                                        />
+                                        <span class="recovery-mapping-line__text">{{ recoveryMappingTargetLabel(entry) }}</span>
+                                      </span>
+                                    </div>
+                                  </div>
+                                </template>
+                                <div class="create-source-dir-preview recovery-entry-preview-trigger">
+                                  <div class="create-source-dir-preview__count">
+                                    {{ recoveryMappingTotalLabel(row.configuredEntries.length) }}
+                                  </div>
+                                  <div
+                                    v-for="entry in row.previewEntries"
+                                    :key="entry.id"
+                                    class="create-source-dir-preview__item recovery-mapping-line recovery-mapping-line--preview"
+                                  >
+                                    <span
+                                      class="recovery-mapping-line__endpoint"
+                                      :class="`recovery-mapping-line__endpoint--${recoveryMappingSourceKind(entry)}`"
+                                    >
+                                      <Archive
+                                        v-if="recoveryMappingSourceKind(entry) === 'snapshot'"
+                                        :size="14"
+                                        class="recovery-mapping-line__icon"
+                                      />
+                                      <File
+                                        v-else-if="recoveryMappingSourceKind(entry) === 'file'"
+                                        :size="14"
+                                        class="recovery-mapping-line__icon"
+                                      />
+                                      <Folder
+                                        v-else
+                                        :size="14"
+                                        class="recovery-mapping-line__icon"
+                                      />
+                                      <span class="recovery-mapping-line__text">{{ recoveryMappingSourceLabel(entry) }}</span>
+                                    </span>
+                                    <span
+                                      class="recovery-mapping-line__arrow"
+                                      aria-hidden="true"
+                                    >-&gt;</span>
+                                    <span class="recovery-mapping-line__endpoint recovery-mapping-line__endpoint--target">
+                                      <FolderOpen
+                                        :size="14"
+                                        class="recovery-mapping-line__icon"
+                                      />
+                                      <span class="recovery-mapping-line__text">{{ recoveryMappingTargetLabel(entry) }}</span>
+                                    </span>
+                                  </div>
+                                  <div
+                                    v-if="row.hiddenDirCount > 0"
+                                    class="create-source-dir-preview__more"
+                                  >
+                                    {{ t('protection.backupsPage.moreRecoveryDirs', { n: row.hiddenDirCount }) }}
+                                  </div>
+                                </div>
+                              </ElTooltip>
+                              <div
+                                v-else
+                                class="create-source-dir-preview-empty"
+                              >
+                                {{ t('protection.backupsPage.recoveryDirEmptyCompact') }}
+                              </div>
+                            </template>
+                          </el-table-column>
+                        </el-table>
+                      </div>
+
+                      <el-drawer
+                        v-model="recDirDrawerOpen"
+                        direction="rtl"
+                        destroy-on-close
+                        append-to-body
+                        :modal="true"
+                        :z-index="REC_WIZARD_DRAWER_Z_INDEX"
+                        :size="nestedDrawerSize"
+                        class="dp-rec-dest-drawer dp-rec-dir-drawer"
+                        @opened="onRecDirDrawerOpened"
+                        @closed="onRecDirDrawerClosed"
+                      >
+                        <template #header>
+                          <span class="dp-rec-dest-drawer__title">
+                            {{ store.getNodeName(recDirDrawerHostId) || t('protection.backupsPage.recDirSelectionCol') }}
+                          </span>
+                        </template>
+
+                        <div class="dp-rec-dest-drawer__body">
+                          <div class="dp-rec-dest-drawer__content">
+                            <p class="m-0 mb-1 text-xs text-slate-500">
+                              {{ t('protection.backupsPage.recDirsSnapshotHint', { time: recGroupSnapshotDisplayLine(recDirDrawerHostId) }) }}
+                            </p>
+                            <p class="m-0 mb-3 text-xs text-slate-500">
+                              {{ t('protection.backupsPage.recDirDrawerHint') }}
+                            </p>
+                            <div
+                              v-if="!recDirTreeDataForSource(recDirDrawerHostId).length"
+                              class="dp-create-tree-shell__empty hfl-dir-tree-empty"
+                            >
+                              {{ t('protection.backupsPage.recSourceTreeEmpty') }}
+                            </div>
+                            <el-tree
+                              v-else
+                              ref="recDirDrawerTreeRef"
+                              :key="`rec-dir-drawer-${recDirDrawerHostId}-${recDirDrawerEntryId}`"
+                              class="source-dir-tree rec-select-tree recovery-dir-picker__tree hfl-dir-tree hfl-dir-tree--tall dp-rec-dir-drawer__tree"
+                              :data="recDirTreeDataForSource(recDirDrawerHostId)"
+                              node-key="id"
+                              show-checkbox
+                              check-strictly
+                              default-expand-all
+                              :check-on-click-node="true"
+                              :expand-on-click-node="false"
+                              :props="{ label: 'label', children: 'children' }"
+                              :default-checked-keys="recDirDrawerDraftKeys"
+                              @check-change="(data, checked) => onRecDirDrawerTreeCheckChange(recDirDrawerHostId, data, checked)"
+                            >
+                              <template #default="{ data }">
+                                <div class="tree-node-content hfl-dir-tree-node">
+                                  <component
+                                    :is="recoveryDirNodeIcon(data)"
+                                    :size="15"
+                                    class="tree-node-content__icon hfl-dir-tree-node__icon"
+                                    :class="`create-dir-row__icon--${recoveryDirNodeSourceKind(data) === 'file' ? 'file' : 'folder'}`"
+                                  />
+                                  <div class="tree-node-content__text hfl-dir-tree-node__text">
+                                    <span class="tree-node-content__label hfl-dir-tree-node__label">{{ data.label }}</span>
+                                    <span class="tree-node-content__path hfl-dir-tree-node__path">{{ recoveryTreePathLabel(data) }}</span>
+                                  </div>
+                                </div>
+                              </template>
+                            </el-tree>
+                          </div>
+                        </div>
+                        <template #footer>
+                          <div class="el-drawer__footer-actions">
+                            <ElButton @click="cancelRecDirDrawer">
+                              {{ t('protection.backupsPage.btnCancel') }}
+                            </ElButton>
+                            <ElButton
+                              type="primary"
+                              @click="saveRecDirDrawer"
+                            >
+                              {{ t('protection.backupsPage.btnEdit') }}
+                            </ElButton>
+                          </div>
+                        </template>
+                      </el-drawer>
+                    </div>
+
+                    <div
+                      v-show="recStep === 3"
+                      class="dp-wizard-pane"
+                    >
+                      <p class="text-sm text-slate-600 mb-3">
+                        {{ t('protection.backupsPage.recStep4Lead') }}
+                      </p>
+                      <div class="recovery-manual-table-shell">
+                        <el-table
+                          ref="recRecoveryConfirmTableRef"
+                          v-table-overflow-title
+                          :data="recRecoveryConfirmSourceRows"
+                          row-key="hostId"
+                          stripe
+                          :expand-row-keys="recExpandedRecConfirmHostIds"
+                          :header-cell-style="TABLE_HEADER_STYLE"
+                          class="hfl-list-table recovery-confirm-source-table recovery-manual-table"
+                          @expand-change="onRecRecoveryConfirmExpandChange"
+                        >
+                          <el-table-column
+                            type="expand"
+                            width="35"
+                            class-name="recovery-dest-config-expand-column"
+                          >
+                            <template #default="{ row: sourceRow }">
+                              <div class="recovery-confirm-expand">
+                                <div
+                                  v-for="draft in sourceRow.taskDrafts"
+                                  :key="`${draft.backupId}-${draft.destHostId}-${draft.destPath}`"
+                                  class="recovery-confirm-mapping-group"
+                                >
+                                  <div class="recovery-confirm-mapping-list">
+                                    <div
+                                      v-for="entry in draft.dirs"
+                                      :key="`${draft.backupId}-${entry.id}`"
+                                      class="recovery-mapping-line recovery-confirm-mapping-line"
+                                      :title="`${recoveryMappingSourceLabel(entry)} -> ${recoveryMappingTargetLabel(entry)}`"
+                                    >
+                                      <span
+                                        class="recovery-mapping-line__endpoint"
+                                        :class="`recovery-mapping-line__endpoint--${recoveryMappingSourceKind(entry)}`"
+                                      >
+                                        <Archive
+                                          v-if="recoveryMappingSourceKind(entry) === 'snapshot'"
+                                          :size="14"
+                                          class="recovery-mapping-line__icon"
+                                        />
+                                        <File
+                                          v-else-if="recoveryMappingSourceKind(entry) === 'file'"
+                                          :size="14"
+                                          class="recovery-mapping-line__icon"
+                                        />
+                                        <Folder
+                                          v-else
+                                          :size="14"
+                                          class="recovery-mapping-line__icon"
+                                        />
+                                        <span class="recovery-mapping-line__text">{{ recoveryMappingSourceLabel(entry) }}</span>
+                                      </span>
+                                      <span
+                                        class="recovery-mapping-line__arrow"
+                                        aria-hidden="true"
+                                      >-&gt;</span>
+                                      <span class="recovery-mapping-line__endpoint recovery-mapping-line__endpoint--target">
+                                        <FolderOpen
+                                          :size="14"
+                                          class="recovery-mapping-line__icon"
+                                        />
+                                        <span class="recovery-mapping-line__text">{{ recoveryMappingTargetLabel(entry) }}</span>
+                                      </span>
+                                    </div>
+                                  </div>
+                                </div>
+                                <div
+                                  v-if="!sourceRow.taskDrafts.length"
+                                  class="text-sm text-slate-400"
+                                >
+                                  {{ t('protection.backupsPage.recoveryDirEmptyCompact') }}
+                                </div>
+                              </div>
+                            </template>
+                          </el-table-column>
+                          <el-table-column
+                            :label="t('protection.backupsPage.colBackupSnapshot')"
+                            min-width="220"
+                          >
+                            <template #default="{ row }">
+                              <button
+                                type="button"
+                                class="recovery-dir-source-toggle"
+                                @click="toggleRecRecoveryConfirmRow(row)"
+                              >
+                                <span class="recovery-source-summary recovery-source-summary--with-snapshot">
+                                  <span class="recovery-source-summary__head">
+                                    <span class="recovery-source-summary__name">
+                                      {{ row.sourceSummary.displayName }}
+                                    </span>
+                                    <el-tag
+                                      size="small"
+                                      effect="plain"
+                                      class="recovery-source-summary__type"
+                                      :type="row.sourceSummary.typeTagType"
+                                    >
+                                      {{ row.sourceSummary.typeLabel }}
+                                    </el-tag>
+                                  </span>
+                                  <span class="recovery-source-summary__meta">
+                                    <span class="recovery-source-summary__ip">
+                                      {{ row.sourceSummary.ipLine }}
+                                    </span>
+                                    <span class="recovery-source-summary__platform">
+                                      <AgentPlatformBrandIcon
+                                        v-if="row.sourceSummary.platform"
+                                        :os="row.sourceSummary.platform"
+                                      />
+                                      <component
+                                        :is="row.sourceSummary.sourceType === 'nas' ? sourceNasIcon : sourceHostIcon"
+                                        v-else
+                                        :size="16"
+                                      />
+                                    </span>
+                                  </span>
+                                  <span class="recovery-source-summary__snapshot">
+                                    Snapshot: {{ row.snapshotLine }}
+                                  </span>
+                                </span>
+                              </button>
+                            </template>
+                          </el-table-column>
+                          <el-table-column
+                            :label="t('protection.backupsPage.recStepDest')"
+                            min-width="216"
+                          >
+                            <template #default="{ row }">
+                              <div
+                                v-if="row.destSummary"
+                                class="recovery-source-summary"
+                              >
+                                <div class="recovery-source-summary__head">
+                                  <span class="recovery-source-summary__name">
+                                    {{ row.destSummary.displayName }}
+                                  </span>
+                                  <el-tag
+                                    size="small"
+                                    effect="plain"
+                                    class="recovery-source-summary__type"
+                                    :type="row.destSummary.typeTagType"
+                                  >
+                                    {{ row.destSummary.typeLabel }}
+                                  </el-tag>
+                                </div>
+                                <div class="recovery-source-summary__meta">
+                                  <span class="recovery-source-summary__ip">
+                                    {{ row.destSummary.ipLine }}
+                                  </span>
+                                  <span class="recovery-source-summary__platform">
+                                    <AgentPlatformBrandIcon
+                                      v-if="row.destSummary.platform"
+                                      :os="row.destSummary.platform"
+                                    />
+                                    <component
+                                      :is="row.destSummary.sourceType === 'nas' ? sourceNasIcon : sourceHostIcon"
+                                      v-else
+                                      :size="16"
+                                    />
+                                  </span>
+                                </div>
+                              </div>
+                              <div
+                                v-else
+                                class="create-source-dir-preview-empty"
+                              >
+                                {{ t('protection.backupsPage.recoveryDestEmptyCompact') }}
+                              </div>
+                            </template>
+                          </el-table-column>
+                          <el-table-column
+                            :label="t('protection.backupsPage.recoveryConflictPolicyCol')"
+                            min-width="254"
+                          >
+                            <template #default="{ row }">
+                              <ElTooltip
+                                placement="top-start"
+                                :content="recoveryConflictPolicySummary(row.conflictPolicy)"
+                                :show-after="300"
+                              >
+                                <span
+                                  class="create-recovery-plan-cell__policy recovery-confirm-policy-cell"
+                                  :class="`create-recovery-plan-cell__policy--${row.conflictPolicy}`"
+                                >
+                                  <ShieldAlert
+                                    v-if="row.conflictPolicy === 'overwrite'"
+                                    :size="14"
+                                    class="create-recovery-plan-cell__policy-icon"
+                                  />
+                                  <ShieldCheck
+                                    v-else
+                                    :size="14"
+                                    class="create-recovery-plan-cell__policy-icon"
+                                  />
+                                  <span class="create-recovery-plan-cell__policy-text">
+                                    {{ recoveryConflictPolicySummary(row.conflictPolicy) }}
+                                  </span>
+                                </span>
+                              </ElTooltip>
+                            </template>
+                          </el-table-column>
+                        </el-table>
+                      </div>
+                    </div>
+                  </template>
                 </div>
               </section>
             </main>
@@ -12227,60 +13322,74 @@ async function runRecovery(mode: 'plan' | 'manual' = 'manual') {
 
           <div class="fullscreen-form-footer">
             <div class="fullscreen-form-footer__actions">
-                <template v-if="recEntryStage === 'chooser' && recEntryMode === 'plan'">
-                  <ElButton class="hfl-btn-with-icon" :disabled="recSubmitting" @click="closeRecoveryWizard">
-                    <X :size="14" />
-                    <span>{{ t('protection.backupsPage.btnCancel') }}</span>
-                  </ElButton>
-                  <ElButton
-                    type="primary"
-                    class="hfl-btn-with-icon"
-                    :disabled="!selectedRecoveryPlans.length"
-                    :loading="recSubmitting"
-                    @click="confirmRecoveryEntry"
-                  >
-                    <Check :size="14" />
-                    <span>{{ t('protection.backupsPage.btnRunRecoveryPlan') }}</span>
-                  </ElButton>
-                </template>
-                <template v-else>
-                  <ElButton class="hfl-btn-with-icon" :disabled="recSubmitting" @click="closeRecoveryWizard">
-                    <X :size="14" />
-                    <span>{{ t('protection.backupsPage.btnCancel') }}</span>
-                  </ElButton>
-                  <ElButton
-                    v-if="recStep > (isFixedSnapshotRestore ? 1 : 0)"
-                    class="hfl-btn-with-icon"
-                    :disabled="recSubmitting"
-                    @click="prevRec"
-                  >
-                    <ArrowLeft :size="14" />
-                    <span>{{ t('protection.backupsPage.btnPrev') }}</span>
-                  </ElButton>
-                  <ElButton
-                    v-else-if="recEntryStage === 'wizard' && !isFixedSnapshotRestore"
-                    class="hfl-btn-with-icon"
-                    :disabled="recSubmitting"
-                    @click="returnToRecoveryEntryChooser"
-                  >
-                    <ArrowLeft :size="14" />
-                    <span>{{ t('protection.backupsPage.btnBackToRecoveryChoice') }}</span>
-                  </ElButton>
-                  <ElButton
-                    v-if="recStep < 3"
-                    type="primary"
-                    class="hfl-btn-with-icon"
-                    :disabled="(recStep === 1 && !recRecoveryDestStepReady) || (recStep === 2 && !recRecoveryDirStepReady)"
-                    @click="nextRec"
-                  >
-                    <span>{{ t('protection.backupsPage.btnNext') }}</span>
-                    <ArrowRight :size="14" />
-                  </ElButton>
-                  <ElButton v-else type="primary" class="hfl-btn-with-icon" :loading="recSubmitting" @click="runRecovery">
-                    <Check :size="14" />
-                    <span>{{ t('protection.backupsPage.btnConfirmRecovery') }}</span>
-                  </ElButton>
-                </template>
+              <template v-if="recEntryStage === 'chooser' && recEntryMode === 'plan'">
+                <ElButton
+                  class="hfl-btn-with-icon"
+                  :disabled="recSubmitting"
+                  @click="closeRecoveryWizard"
+                >
+                  <X :size="14" />
+                  <span>{{ t('protection.backupsPage.btnCancel') }}</span>
+                </ElButton>
+                <ElButton
+                  type="primary"
+                  class="hfl-btn-with-icon"
+                  :disabled="!selectedRecoveryPlans.length"
+                  :loading="recSubmitting"
+                  @click="confirmRecoveryEntry"
+                >
+                  <Check :size="14" />
+                  <span>{{ t('protection.backupsPage.btnRunRecoveryPlan') }}</span>
+                </ElButton>
+              </template>
+              <template v-else>
+                <ElButton
+                  class="hfl-btn-with-icon"
+                  :disabled="recSubmitting"
+                  @click="closeRecoveryWizard"
+                >
+                  <X :size="14" />
+                  <span>{{ t('protection.backupsPage.btnCancel') }}</span>
+                </ElButton>
+                <ElButton
+                  v-if="recStep > (isFixedSnapshotRestore ? 1 : 0)"
+                  class="hfl-btn-with-icon"
+                  :disabled="recSubmitting"
+                  @click="prevRec"
+                >
+                  <ArrowLeft :size="14" />
+                  <span>{{ t('protection.backupsPage.btnPrev') }}</span>
+                </ElButton>
+                <ElButton
+                  v-else-if="recEntryStage === 'wizard' && !isFixedSnapshotRestore"
+                  class="hfl-btn-with-icon"
+                  :disabled="recSubmitting"
+                  @click="returnToRecoveryEntryChooser"
+                >
+                  <ArrowLeft :size="14" />
+                  <span>{{ t('protection.backupsPage.btnBackToRecoveryChoice') }}</span>
+                </ElButton>
+                <ElButton
+                  v-if="recStep < 3"
+                  type="primary"
+                  class="hfl-btn-with-icon"
+                  :disabled="(recStep === 1 && !recRecoveryDestStepReady) || (recStep === 2 && !recRecoveryDirStepReady)"
+                  @click="nextRec"
+                >
+                  <span>{{ t('protection.backupsPage.btnNext') }}</span>
+                  <ArrowRight :size="14" />
+                </ElButton>
+                <ElButton
+                  v-else
+                  type="primary"
+                  class="hfl-btn-with-icon"
+                  :loading="recSubmitting"
+                  @click="runRecovery"
+                >
+                  <Check :size="14" />
+                  <span>{{ t('protection.backupsPage.btnConfirmRecovery') }}</span>
+                </ElButton>
+              </template>
             </div>
           </div>
         </div>
@@ -12300,12 +13409,23 @@ async function runRecovery(mode: 'plan' | 'manual' = 'manual') {
       >
         <div class="fullscreen-form-page source-deploy-page">
           <header class="fullscreen-form-header">
-            <button type="button" class="fullscreen-form-header__back" @click="closeAddSource">
-              <ArrowLeft class="fullscreen-form-header__back-icon" :size="18" />
+            <button
+              type="button"
+              class="fullscreen-form-header__back"
+              @click="closeAddSource"
+            >
+              <ArrowLeft
+                class="fullscreen-form-header__back-icon"
+                :size="18"
+              />
             </button>
             <div class="fullscreen-form-header__content">
-              <h1 class="fullscreen-form-header__title">{{ t('protection.sourceResources.addSourcePageTitle') }}</h1>
-              <p class="fullscreen-form-header__desc">{{ t('protection.sourceResources.addSourcePageDesc') }}</p>
+              <h1 class="fullscreen-form-header__title">
+                {{ t('protection.sourceResources.addSourcePageTitle') }}
+              </h1>
+              <p class="fullscreen-form-header__desc">
+                {{ t('protection.sourceResources.addSourcePageDesc') }}
+              </p>
             </div>
           </header>
 
@@ -12322,7 +13442,10 @@ async function runRecovery(mode: 'plan' | 'manual' = 'manual') {
                       @click="addSourceType = 'hostFileSystem'"
                     >
                       <span class="add-source-type-card__inner">
-                        <component :is="sourceHostIcon" :size="24" />
+                        <component
+                          :is="sourceHostIcon"
+                          :size="24"
+                        />
                         <span class="add-source-type-card__text">
                           <span class="font-semibold">{{ t('protection.sourceResources.addSourceTypeHostFile') }}</span>
                           <span class="text-xs text-[var(--color-text-tertiary)]">{{ t('protection.sourceResources.deployAgentHint') }}</span>
@@ -12337,7 +13460,10 @@ async function runRecovery(mode: 'plan' | 'manual' = 'manual') {
                       @click="addSourceType = 'nas'"
                     >
                       <span class="add-source-type-card__inner">
-                        <component :is="sourceNasIcon" :size="24" />
+                        <component
+                          :is="sourceNasIcon"
+                          :size="24"
+                        />
                         <span class="add-source-type-card__text">
                           <span class="font-semibold">{{ t('protection.sourceResources.addSourceTypeNas') }}</span>
                           <span class="text-xs text-[var(--color-text-tertiary)]">{{ t('protection.sourceResources.addSourceTypeNasHint') }}</span>
@@ -12487,63 +13613,69 @@ async function runRecovery(mode: 'plan' | 'manual' = 'manual') {
         role="status"
         :aria-label="t('protection.backupsPage.loadingCreateWizard')"
       >
-        <div class="fullscreen-form-page setup-dr-opening-skeleton__page" aria-hidden="true">
+        <div
+          class="fullscreen-form-page setup-dr-opening-skeleton__page"
+          aria-hidden="true"
+        >
           <header class="fullscreen-form-header setup-dr-opening-skeleton__header">
-            <span class="setup-dr-opening-skeleton__back"></span>
+            <span class="setup-dr-opening-skeleton__back" />
             <div class="fullscreen-form-header__content setup-dr-opening-skeleton__title">
-              <span></span>
-              <i></i>
+              <span />
+              <i />
             </div>
           </header>
           <div class="fullscreen-form-layout create-backup-layout create-backup-layout--steps setup-dr-opening-skeleton__layout">
             <aside class="create-backup-steps setup-dr-opening-skeleton__steps">
-              <span v-for="idx in 5" :key="`setup-dr-opening-step-${idx}`">
-                <i></i>
-                <b></b>
+              <span
+                v-for="idx in 5"
+                :key="`setup-dr-opening-step-${idx}`"
+              >
+                <i />
+                <b />
               </span>
             </aside>
             <main class="fullscreen-form-main create-backup-main setup-dr-opening-skeleton__main">
               <section class="setup-dr-opening-skeleton__wizard-panel">
                 <div class="setup-dr-opening-skeleton__lead">
-                  <span></span>
-                  <i></i>
+                  <span />
+                  <i />
                 </div>
                 <div class="setup-dr-opening-skeleton__panel-toolbar">
-                  <span></span>
-                  <i></i>
+                  <span />
+                  <i />
                 </div>
                 <div class="setup-dr-opening-skeleton__table">
                   <div class="setup-dr-opening-skeleton__table-head">
-                    <span></span>
-                    <span></span>
-                    <span></span>
-                    <span></span>
+                    <span />
+                    <span />
+                    <span />
+                    <span />
                   </div>
                   <div class="setup-dr-opening-skeleton__table-row">
-                    <span></span>
-                    <span></span>
-                    <span></span>
-                    <span></span>
+                    <span />
+                    <span />
+                    <span />
+                    <span />
                   </div>
                   <div class="setup-dr-opening-skeleton__expanded">
                     <section class="setup-dr-opening-skeleton__browse">
-                      <span></span>
+                      <span />
                       <div class="setup-dr-opening-skeleton__input-row">
-                        <i></i>
-                        <b></b>
+                        <i />
+                        <b />
                       </div>
-                      <em></em>
+                      <em />
                       <div class="setup-dr-opening-skeleton__tree-box">
-                        <small></small>
-                        <small></small>
-                        <small></small>
+                        <small />
+                        <small />
+                        <small />
                       </div>
                     </section>
                     <section class="setup-dr-opening-skeleton__selected">
-                      <span></span>
+                      <span />
                       <div class="setup-dr-opening-skeleton__selected-box">
-                        <i></i>
-                        <i></i>
+                        <i />
+                        <i />
                       </div>
                     </section>
                   </div>
@@ -12552,8 +13684,8 @@ async function runRecovery(mode: 'plan' | 'manual' = 'manual') {
             </main>
           </div>
           <footer class="setup-dr-opening-skeleton__footer">
-            <span></span>
-            <i></i>
+            <span />
+            <i />
           </footer>
         </div>
       </div>

--- a/src/frontend/src/pages/protection/DataProtectionAvailabilityColumns.test.ts
+++ b/src/frontend/src/pages/protection/DataProtectionAvailabilityColumns.test.ts
@@ -1,18 +1,20 @@
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
+import { compactSourceText } from '../../test/sourceText'
 
 const page = readFileSync(resolve(process.cwd(), 'src/pages/protection/DataProtection.vue'), 'utf8')
+const compactPage = compactSourceText(page)
 const createWizard = readFileSync(resolve(process.cwd(), 'src/pages/protection/BackupCreateWizard.vue'), 'utf8')
 const restoreTargetCatalog = readFileSync(resolve(process.cwd(), 'src/composables/useRestoreTargetCatalog.ts'), 'utf8')
 
 function tableForStep(step: number) {
   const startMarker = `<div v-if="flowMainStep === ${step}"`
-  const start = page.indexOf(startMarker)
-  const end = page.indexOf('</el-table>', start)
+  const start = compactPage.indexOf(startMarker)
+  const end = compactPage.indexOf('</el-table>', start)
   expect(start).toBeGreaterThan(-1)
   expect(end).toBeGreaterThan(start)
-  return page.slice(start, end)
+  return compactPage.slice(start, end)
 }
 
 function expectOrdered(text: string, markers: string[]) {

--- a/src/frontend/src/pages/protection/DataProtectionStep3ServerFilters.test.ts
+++ b/src/frontend/src/pages/protection/DataProtectionStep3ServerFilters.test.ts
@@ -1,9 +1,11 @@
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
+import { compactSourceText } from '../../test/sourceText'
 
 
 const page = readFileSync(resolve(process.cwd(), 'src/pages/protection/DataProtection.vue'), 'utf8')
+const compactPage = compactSourceText(page)
 const locale = readFileSync(resolve(process.cwd(), 'src/locales/enProtectionPages.ts'), 'utf8')
 
 function sourceBetween(startMarker: string, endMarker: string) {
@@ -69,8 +71,12 @@ describe('Backup Wizard Step 3 server filters', () => {
   })
 
   it('uses aligned Reset and Cancel buttons with compact label-control rows', () => {
-    const footer = sourceBetween('<div class="flow-filter-drawer__footer">', '</template>\n    </el-drawer>')
+    const start = compactPage.indexOf('<div class="flow-filter-drawer__footer">')
+    const end = compactPage.indexOf('</template></el-drawer>', start)
+    const footer = compactPage.slice(start, end)
 
+    expect(start).toBeGreaterThan(-1)
+    expect(end).toBeGreaterThan(start)
     expect(footer).toContain('<ElButton @click="resetStep3AdvancedFilterDrafts">')
     expect(footer).toContain('<ElButton @click="cancelAdvancedFilters">')
     expect(footer).not.toContain('text class="flow-filter-drawer__reset-btn"')

--- a/src/frontend/src/pages/protection/FileFilterRuleGuide.vue
+++ b/src/frontend/src/pages/protection/FileFilterRuleGuide.vue
@@ -55,7 +55,11 @@ const recipes = [
       <section class="rule-guide__section">
         <h2>Pattern Operators</h2>
         <div class="rule-guide__table">
-          <div v-for="row in operators" :key="row.token" class="rule-guide__table-row">
+          <div
+            v-for="row in operators"
+            :key="row.token"
+            class="rule-guide__table-row"
+          >
             <code>{{ row.token }}</code>
             <span>{{ row.meaning }}</span>
           </div>
@@ -65,7 +69,11 @@ const recipes = [
       <section class="rule-guide__section">
         <h2>Common Examples</h2>
         <div class="rule-guide__table">
-          <div v-for="row in examples" :key="row.rule" class="rule-guide__table-row">
+          <div
+            v-for="row in examples"
+            :key="row.rule"
+            class="rule-guide__table-row"
+          >
             <code>{{ row.rule }}</code>
             <span>{{ row.use }}</span>
           </div>
@@ -75,7 +83,11 @@ const recipes = [
       <section class="rule-guide__section">
         <h2>Reusable Recipes</h2>
         <div class="rule-guide__recipes">
-          <article v-for="recipe in recipes" :key="recipe.title" class="rule-guide__recipe">
+          <article
+            v-for="recipe in recipes"
+            :key="recipe.title"
+            class="rule-guide__recipe"
+          >
             <h3>{{ recipe.title }}</h3>
             <pre><code>{{ recipe.lines.join('\n') }}</code></pre>
           </article>

--- a/src/frontend/src/pages/protection/Policies.vue
+++ b/src/frontend/src/pages/protection/Policies.vue
@@ -1029,11 +1029,17 @@ function onMoreDisable() {
     <div class="hfl-list-shell hfl-list-shell--fill">
       <HflTablePanel fill>
         <template #toolbar>
-          <ElButton type="primary" @click="openAddDialog">
+          <ElButton
+            type="primary"
+            @click="openAddDialog"
+          >
             <Plus :size="16" />
             {{ t('protection.policiesPage.btnCreate') }}
           </ElButton>
-          <ElDropdown trigger="click" @visible-change="moreActionsOpen = $event">
+          <ElDropdown
+            trigger="click"
+            @visible-change="moreActionsOpen = $event"
+          >
             <ElButton :loading="listActionLoading">
               {{ t('protection.policiesPage.btnMoreActions') }}
               <ChevronDown
@@ -1044,27 +1050,54 @@ function onMoreDisable() {
             </ElButton>
             <template #dropdown>
               <ElDropdownMenu>
-                <ElDropdownItem :disabled="moreEditDisabled" @click="onMoreEdit">
+                <ElDropdownItem
+                  :disabled="moreEditDisabled"
+                  @click="onMoreEdit"
+                >
                   <span class="el-dropdown-menu__item-content">
-                    <SquarePen :size="14" class="shrink-0" />
+                    <SquarePen
+                      :size="14"
+                      class="shrink-0"
+                    />
                     <span>{{ t('protection.policiesPage.btnEdit') }}</span>
                   </span>
                 </ElDropdownItem>
-                <ElDropdownItem divided :disabled="batchEnableDisabled" @click="onMoreEnable">
+                <ElDropdownItem
+                  divided
+                  :disabled="batchEnableDisabled"
+                  @click="onMoreEnable"
+                >
                   <span class="el-dropdown-menu__item-content">
-                    <CirclePlay :size="14" class="shrink-0" />
+                    <CirclePlay
+                      :size="14"
+                      class="shrink-0"
+                    />
                     <span>{{ t('protection.policiesPage.btnEnable') }}</span>
                   </span>
                 </ElDropdownItem>
-                <ElDropdownItem :disabled="batchDisableDisabled" @click="onMoreDisable">
+                <ElDropdownItem
+                  :disabled="batchDisableDisabled"
+                  @click="onMoreDisable"
+                >
                   <span class="el-dropdown-menu__item-content">
-                    <CircleStop :size="14" class="shrink-0" />
+                    <CircleStop
+                      :size="14"
+                      class="shrink-0"
+                    />
                     <span>{{ t('protection.policiesPage.btnDisable') }}</span>
                   </span>
                 </ElDropdownItem>
-                <ElDropdownItem divided class="el-dropdown-menu__item--danger" :disabled="moreBatchDisabled" @click="onMoreDelete">
+                <ElDropdownItem
+                  divided
+                  class="el-dropdown-menu__item--danger"
+                  :disabled="moreBatchDisabled"
+                  @click="onMoreDelete"
+                >
                   <span class="el-dropdown-menu__item-content">
-                    <Trash2 :size="14" class="shrink-0" />
+                    <Trash2
+                      :size="14"
+                      class="shrink-0"
+                    />
                     <span>{{ t('protection.policiesPage.btnDelete') }}</span>
                   </span>
                 </ElDropdownItem>
@@ -1084,11 +1117,17 @@ function onMoreDisable() {
             >
               <template #prepend>
                 <ElSelect v-model="searchField">
-                  <ElOption value="name" :label="t('protection.listSearchFields.name')" />
+                  <ElOption
+                    value="name"
+                    :label="t('protection.listSearchFields.name')"
+                  />
                 </ElSelect>
               </template>
               <template #prefix>
-                <Search :size="16" class="hfl-list-search__icon" />
+                <Search
+                  :size="16"
+                  class="hfl-list-search__icon"
+                />
               </template>
             </ElInput>
             <div class="hfl-list-toolbar__utility">
@@ -1099,7 +1138,10 @@ function onMoreDisable() {
                 :disabled="listLoading"
                 @click="refreshPoliciesList"
               >
-                <RefreshCw :size="16" :class="{ 'is-spinning': listLoading }" />
+                <RefreshCw
+                  :size="16"
+                  :class="{ 'is-spinning': listLoading }"
+                />
               </ElButton>
             </div>
           </div>
@@ -1114,518 +1156,687 @@ function onMoreDisable() {
           :title="listError"
         >
           <template #default>
-            <ElButton size="small" @click="refreshPoliciesList">
+            <ElButton
+              size="small"
+              @click="refreshPoliciesList"
+            >
               {{ t('protection.policiesPage.btnRetry') }}
             </ElButton>
           </template>
         </ElAlert>
 
         <template #table="{ tableMaxHeight }">
-        <el-table
-          v-if="listTab === 'backup'"
-          v-table-overflow-title
-          v-table-header-scroll-sync
-          v-table-column-resize="'protection.policies.backup'"
-          ref="policyTableRef"
-          v-loading="listLoading"
-          class="hfl-list-table"
-          :data="pagedPolicyRows"
-          stripe
-          row-key="id"
-          :max-height="tableMaxHeight"
-          :header-cell-style="TABLE_HEADER_STYLE"
-          @selection-change="onPolicySelectionChange"
-        >
-          <el-table-column type="selection" width="35" fixed="left" />
-          <el-table-column
-            :label="t('protection.policiesPage.colName')"
-            min-width="200"
-            fixed="left"
-            class-name="hfl-table-name-col"
+          <el-table
+            v-if="listTab === 'backup'"
+            ref="policyTableRef"
+            v-table-overflow-title
+            v-table-header-scroll-sync
+            v-table-column-resize="'protection.policies.backup'"
+            v-loading="listLoading"
+            class="hfl-list-table"
+            :data="pagedPolicyRows"
+            stripe
+            row-key="id"
+            :max-height="tableMaxHeight"
+            :header-cell-style="TABLE_HEADER_STYLE"
+            @selection-change="onPolicySelectionChange"
           >
-            <template #default="{ row }">
-              <button
-                type="button"
-                class="hfl-table-name-link hfl-table-name-link--full"
-                @click="openPolicyDetail(row)"
-              >
-                {{ row.name }}
-              </button>
+            <el-table-column
+              type="selection"
+              width="35"
+              fixed="left"
+            />
+            <el-table-column
+              :label="t('protection.policiesPage.colName')"
+              min-width="200"
+              fixed="left"
+              class-name="hfl-table-name-col"
+            >
+              <template #default="{ row }">
+                <button
+                  type="button"
+                  class="hfl-table-name-link hfl-table-name-link--full"
+                  @click="openPolicyDetail(row)"
+                >
+                  {{ row.name }}
+                </button>
+              </template>
+            </el-table-column>
+            <el-table-column
+              :label="t('protection.policiesPage.colAssociatedSourceCount')"
+              width="100"
+              align="left"
+            >
+              <template #default="{ row }">
+                <span class="hfl-table-cell-full hfl-table-no-tooltip">{{ row.relatedBackupCount }}</span>
+              </template>
+            </el-table-column>
+            <el-table-column
+              :label="t('protection.policiesPage.colSchedule')"
+              min-width="180"
+            >
+              <template #default="{ row }">
+                <span class="hfl-table-cell-full hfl-table-no-tooltip">{{ row.scheduleSummary }}</span>
+              </template>
+            </el-table-column>
+            <el-table-column
+              :label="t('protection.policiesPage.colRetention')"
+              min-width="260"
+            >
+              <template #default="{ row }">
+                <HflPopover
+                  trigger="hover"
+                  placement="top-start"
+                  :width="420"
+                  popper-class="policy-retention-popover"
+                >
+                  <template #reference>
+                    <span class="hfl-table-cell-full hfl-table-no-tooltip policy-retention-cell">
+                      <span class="policy-retention-cell__summary">{{ policyRetentionListSummary(row) }}</span>
+                    </span>
+                  </template>
+                  <div class="policy-retention-popover__content">
+                    <section class="policy-retention-popover__section">
+                      <div class="policy-retention-detail-list">
+                        <div
+                          v-for="line in policyRetentionDetailLines(row)"
+                          :key="`${line.label || ''}${line.text}`"
+                          class="policy-retention-detail-list__line"
+                          :class="{ 'policy-retention-detail-list__line--summary': !line.label }"
+                        >
+                          <span
+                            v-if="line.label"
+                            class="policy-retention-detail-list__label"
+                          >{{ line.label }}</span>
+                          <span class="policy-retention-detail-list__text">{{ line.text }}</span>
+                        </div>
+                      </div>
+                    </section>
+                  </div>
+                </HflPopover>
+              </template>
+            </el-table-column>
+            <el-table-column
+              :label="t('protection.policiesPage.colStatus')"
+              width="98"
+            >
+              <template #default="{ row }">
+                <div class="hfl-table-no-tooltip">
+                  <HflBooleanStatusTag
+                    :value="row.is_active"
+                    :label="row.is_active ? t('protection.policiesPage.switchEnabledOn') : t('protection.policiesPage.switchEnabledOff')"
+                  />
+                </div>
+              </template>
+            </el-table-column>
+            <el-table-column
+              :label="t('protection.policiesPage.colUpdated')"
+              width="180"
+            >
+              <template #default="{ row }">
+                <span
+                  class="hfl-table-cell-time"
+                  :class="{ 'hfl-empty-mark': !row.updatedAt }"
+                >{{ fmtLocalTime(row.updatedAt) }}</span>
+              </template>
+            </el-table-column>
+            <el-table-column
+              :label="t('protection.policiesPage.colCreated')"
+              width="180"
+            >
+              <template #default="{ row }">
+                <span
+                  class="hfl-table-cell-time"
+                  :class="{ 'hfl-empty-mark': !row.createdAt }"
+                >{{ fmtLocalTime(row.createdAt) }}</span>
+              </template>
+            </el-table-column>
+            <template #empty>
+              <el-empty
+                :description="t('protection.policiesPage.emptyPolicies')"
+                :image-size="72"
+              />
             </template>
-          </el-table-column>
-          <el-table-column :label="t('protection.policiesPage.colAssociatedSourceCount')" width="100" align="left">
-            <template #default="{ row }">
-              <span class="hfl-table-cell-full hfl-table-no-tooltip">{{ row.relatedBackupCount }}</span>
-            </template>
-          </el-table-column>
-          <el-table-column :label="t('protection.policiesPage.colSchedule')" min-width="180">
-            <template #default="{ row }">
-              <span class="hfl-table-cell-full hfl-table-no-tooltip">{{ row.scheduleSummary }}</span>
-            </template>
-          </el-table-column>
-          <el-table-column :label="t('protection.policiesPage.colRetention')" min-width="260">
-            <template #default="{ row }">
-              <HflPopover
-                trigger="hover"
-                placement="top-start"
-                :width="420"
-                popper-class="policy-retention-popover"
-              >
-                <template #reference>
-                  <span class="hfl-table-cell-full hfl-table-no-tooltip policy-retention-cell">
-                    <span class="policy-retention-cell__summary">{{ policyRetentionListSummary(row) }}</span>
-                  </span>
-                </template>
-                <div class="policy-retention-popover__content">
-                  <section class="policy-retention-popover__section">
-                    <div class="policy-retention-detail-list">
-                      <div
-                        v-for="line in policyRetentionDetailLines(row)"
-                        :key="`${line.label || ''}${line.text}`"
-                        class="policy-retention-detail-list__line"
-                        :class="{ 'policy-retention-detail-list__line--summary': !line.label }"
-                      >
-                        <span v-if="line.label" class="policy-retention-detail-list__label">{{ line.label }}</span>
-                        <span class="policy-retention-detail-list__text">{{ line.text }}</span>
+          </el-table>
+          <el-table
+            v-else
+            ref="filterTableRef"
+            v-table-overflow-title
+            v-table-header-scroll-sync
+            v-table-column-resize="'protection.policies.filters'"
+            v-loading="listLoading"
+            class="hfl-list-table"
+            :data="pagedFilterRows"
+            stripe
+            row-key="id"
+            :max-height="tableMaxHeight"
+            :header-cell-style="TABLE_HEADER_STYLE"
+            :row-class-name="filterRowClassName"
+            @selection-change="onFilterSelectionChange"
+          >
+            <el-table-column
+              type="selection"
+              width="35"
+              fixed="left"
+            />
+            <el-table-column
+              :label="t('protection.policiesPage.colName')"
+              min-width="220"
+              fixed="left"
+              class-name="hfl-table-name-col"
+            >
+              <template #default="{ row }">
+                <button
+                  type="button"
+                  class="hfl-table-name-link hfl-table-name-link--full"
+                  @click="openFilterDetail(row)"
+                >
+                  {{ row.name }}
+                </button>
+              </template>
+            </el-table-column>
+            <el-table-column
+              :label="t('protection.policiesPage.colAssociatedSourceCount')"
+              width="100"
+              align="left"
+            >
+              <template #default="{ row }">
+                <span class="hfl-table-cell-full hfl-table-no-tooltip">{{ row.relatedBackupCount }}</span>
+              </template>
+            </el-table-column>
+            <el-table-column
+              :label="t('protection.policiesPage.colFilterSummary')"
+              min-width="430"
+            >
+              <template #default="{ row }">
+                <HflPopover
+                  v-if="row.excludeRuleLines.length"
+                  trigger="hover"
+                  placement="top-start"
+                  :width="460"
+                  popper-class="hfl-filter-rules-popover"
+                >
+                  <template #reference>
+                    <div class="hfl-table-cell-full hfl-table-no-tooltip hfl-filter-rules-cell">
+                      <span class="hfl-filter-rules-cell__prefix">{{ t('protection.policiesPage.filterExcludeRulesTitle') }}:</span>
+                      <div class="hfl-filter-rules-cell__list">
+                        <code
+                          v-for="(line, index) in row.excludeRuleLines"
+                          :key="`${index}-${line}`"
+                          class="hfl-filter-rules-cell__rule"
+                        >
+                          {{ line }}
+                        </code>
                       </div>
                     </div>
-                  </section>
-                </div>
-              </HflPopover>
-            </template>
-          </el-table-column>
-          <el-table-column :label="t('protection.policiesPage.colStatus')" width="98">
-            <template #default="{ row }">
-              <div class="hfl-table-no-tooltip">
-                <HflBooleanStatusTag
-                  :value="row.is_active"
-                  :label="row.is_active ? t('protection.policiesPage.switchEnabledOn') : t('protection.policiesPage.switchEnabledOff')"
-                />
-              </div>
-            </template>
-          </el-table-column>
-          <el-table-column :label="t('protection.policiesPage.colUpdated')" width="180">
-            <template #default="{ row }">
-              <span class="hfl-table-cell-time" :class="{ 'hfl-empty-mark': !row.updatedAt }">{{ fmtLocalTime(row.updatedAt) }}</span>
-            </template>
-          </el-table-column>
-          <el-table-column :label="t('protection.policiesPage.colCreated')" width="180">
-            <template #default="{ row }">
-              <span class="hfl-table-cell-time" :class="{ 'hfl-empty-mark': !row.createdAt }">{{ fmtLocalTime(row.createdAt) }}</span>
-            </template>
-          </el-table-column>
-          <template #empty>
-            <el-empty :description="t('protection.policiesPage.emptyPolicies')" :image-size="72" />
-          </template>
-        </el-table>
-        <el-table
-          v-else
-          v-table-overflow-title
-          v-table-header-scroll-sync
-          v-table-column-resize="'protection.policies.filters'"
-          ref="filterTableRef"
-          v-loading="listLoading"
-          class="hfl-list-table"
-          :data="pagedFilterRows"
-          stripe
-          row-key="id"
-          :max-height="tableMaxHeight"
-          :header-cell-style="TABLE_HEADER_STYLE"
-          :row-class-name="filterRowClassName"
-          @selection-change="onFilterSelectionChange"
-        >
-          <el-table-column type="selection" width="35" fixed="left" />
-          <el-table-column
-            :label="t('protection.policiesPage.colName')"
-            min-width="220"
-            fixed="left"
-            class-name="hfl-table-name-col"
-          >
-            <template #default="{ row }">
-              <button
-                type="button"
-                class="hfl-table-name-link hfl-table-name-link--full"
-                @click="openFilterDetail(row)"
-              >
-                {{ row.name }}
-              </button>
-            </template>
-          </el-table-column>
-          <el-table-column :label="t('protection.policiesPage.colAssociatedSourceCount')" width="100" align="left">
-            <template #default="{ row }">
-              <span class="hfl-table-cell-full hfl-table-no-tooltip">{{ row.relatedBackupCount }}</span>
-            </template>
-          </el-table-column>
-          <el-table-column :label="t('protection.policiesPage.colFilterSummary')" min-width="430">
-            <template #default="{ row }">
-              <HflPopover
-                v-if="row.excludeRuleLines.length"
-                trigger="hover"
-                placement="top-start"
-                :width="460"
-                popper-class="hfl-filter-rules-popover"
-              >
-                <template #reference>
-                  <div class="hfl-table-cell-full hfl-table-no-tooltip hfl-filter-rules-cell">
-                    <span class="hfl-filter-rules-cell__prefix">{{ t('protection.policiesPage.filterExcludeRulesTitle') }}:</span>
-                    <div class="hfl-filter-rules-cell__list">
+                  </template>
+                  <div class="hfl-filter-rules-popover__content">
+                    <div class="hfl-filter-rules-popover__divider">
+                      {{ t('protection.policiesPage.filterExcludeRulesTitle') }}
+                    </div>
+                    <div class="hfl-filter-rules-popover__lines">
                       <code
                         v-for="(line, index) in row.excludeRuleLines"
                         :key="`${index}-${line}`"
-                        class="hfl-filter-rules-cell__rule"
+                        class="hfl-filter-rules-popover__line"
                       >
                         {{ line }}
                       </code>
                     </div>
                   </div>
-                </template>
-                <div class="hfl-filter-rules-popover__content">
-                  <div class="hfl-filter-rules-popover__divider">{{ t('protection.policiesPage.filterExcludeRulesTitle') }}</div>
-                  <div class="hfl-filter-rules-popover__lines">
-                    <code
-                      v-for="(line, index) in row.excludeRuleLines"
-                      :key="`${index}-${line}`"
-                      class="hfl-filter-rules-popover__line"
-                    >
-                      {{ line }}
-                    </code>
-                  </div>
+                </HflPopover>
+                <div
+                  v-else
+                  class="hfl-table-cell-full hfl-table-no-tooltip hfl-filter-rules-cell"
+                >
+                  <span class="hfl-filter-rules-cell__prefix">{{ t('protection.policiesPage.filterExcludeRulesTitle') }}:</span>
+                  <span class="hfl-filter-rules-cell__empty">
+                    {{ t('protection.policiesPage.filterNoActiveRules') }}
+                  </span>
                 </div>
-              </HflPopover>
-              <div v-else class="hfl-table-cell-full hfl-table-no-tooltip hfl-filter-rules-cell">
-                <span class="hfl-filter-rules-cell__prefix">{{ t('protection.policiesPage.filterExcludeRulesTitle') }}:</span>
-                <span class="hfl-filter-rules-cell__empty">
-                  {{ t('protection.policiesPage.filterNoActiveRules') }}
-                </span>
-              </div>
+              </template>
+            </el-table-column>
+            <el-table-column
+              :label="t('protection.policiesPage.colStatus')"
+              width="98"
+            >
+              <template #default="{ row }">
+                <div class="hfl-table-no-tooltip">
+                  <HflBooleanStatusTag
+                    :value="row.is_active"
+                    :label="row.is_active ? t('protection.policiesPage.switchEnabledOn') : t('protection.policiesPage.switchEnabledOff')"
+                  />
+                </div>
+              </template>
+            </el-table-column>
+            <el-table-column
+              :label="t('protection.policiesPage.colUpdated')"
+              width="180"
+            >
+              <template #default="{ row }">
+                <span
+                  class="hfl-table-cell-time"
+                  :class="{ 'hfl-empty-mark': !row.updatedAt }"
+                >{{ fmtLocalTime(row.updatedAt) }}</span>
+              </template>
+            </el-table-column>
+            <el-table-column
+              :label="t('protection.policiesPage.colCreated')"
+              width="180"
+            >
+              <template #default="{ row }">
+                <span
+                  class="hfl-table-cell-time"
+                  :class="{ 'hfl-empty-mark': !row.createdAt }"
+                >{{ fmtLocalTime(row.createdAt) }}</span>
+              </template>
+            </el-table-column>
+            <template #empty>
+              <el-empty
+                :description="t('protection.policiesPage.emptyFilters')"
+                :image-size="72"
+              />
             </template>
-          </el-table-column>
-          <el-table-column :label="t('protection.policiesPage.colStatus')" width="98">
-            <template #default="{ row }">
-              <div class="hfl-table-no-tooltip">
-                <HflBooleanStatusTag
-                  :value="row.is_active"
-                  :label="row.is_active ? t('protection.policiesPage.switchEnabledOn') : t('protection.policiesPage.switchEnabledOff')"
-                />
-              </div>
-            </template>
-          </el-table-column>
-          <el-table-column :label="t('protection.policiesPage.colUpdated')" width="180">
-            <template #default="{ row }">
-              <span class="hfl-table-cell-time" :class="{ 'hfl-empty-mark': !row.updatedAt }">{{ fmtLocalTime(row.updatedAt) }}</span>
-            </template>
-          </el-table-column>
-          <el-table-column :label="t('protection.policiesPage.colCreated')" width="180">
-            <template #default="{ row }">
-              <span class="hfl-table-cell-time" :class="{ 'hfl-empty-mark': !row.createdAt }">{{ fmtLocalTime(row.createdAt) }}</span>
-            </template>
-          </el-table-column>
-          <template #empty>
-            <el-empty :description="t('protection.policiesPage.emptyFilters')" :image-size="72" />
-          </template>
-        </el-table>
+          </el-table>
         </template>
 
         <template #footer>
-          <span v-if="activeSelectedCount > 0" class="hfl-list-footer__selected">
+          <span
+            v-if="activeSelectedCount > 0"
+            class="hfl-list-footer__selected"
+          >
             {{ t('protection.policiesPage.selectedCount', { n: activeSelectedCount }) }}
           </span>
           <HflPagination
-            class="hfl-list-footer__pagination"
             v-model:current-page="currentPage"
             v-model:page-size="pageSize"
+            class="hfl-list-footer__pagination"
             :total="totalFiltered"
           />
         </template>
       </HflTablePanel>
 
-    <ElDrawer
-      v-model="detailDrawerOpen"
-      direction="rtl"
-      :size="drawerSize"
-      destroy-on-close
-      :modal="true"
-      class="hfl-detail-drawer policy-detail-drawer"
-      @closed="onPolicyDetailClosed"
-    >
-      <template #header>
-        <span class="hfl-detail-drawer__title">{{ activePolicy?.name || t('protection.policiesPage.detailDrawerTitle') }}</span>
-      </template>
+      <ElDrawer
+        v-model="detailDrawerOpen"
+        direction="rtl"
+        :size="drawerSize"
+        destroy-on-close
+        :modal="true"
+        class="hfl-detail-drawer policy-detail-drawer"
+        @closed="onPolicyDetailClosed"
+      >
+        <template #header>
+          <span class="hfl-detail-drawer__title">{{ activePolicy?.name || t('protection.policiesPage.detailDrawerTitle') }}</span>
+        </template>
 
-      <div v-if="activePolicy" class="hfl-detail-drawer__body policy-detail-body">
-        <ElTabs v-model="policyDetailTab" class="hfl-detail-tabs policy-detail-tabs">
-          <ElTabPane :label="t('protection.sourceResources.detailTabBasic')" name="basic">
-            <PolicyDetailBasicPanel
-              :key="activePolicy.apiId"
-              :policy-id="activePolicy.apiId"
-              :created-at="activePolicy.createdAt"
-              :associated-source-count="activePolicy.relatedBackupCount"
-              :updated-at="activePolicy.updatedAt"
-              @updated="loadActiveList"
-            />
-          </ElTabPane>
-
-          <ElTabPane :label="t('protection.policiesPage.tabRelatedBackupSources')" name="backups">
-            <el-alert
-              v-if="relatedBackupConfigsError"
-              :title="relatedBackupConfigsError"
-              type="error"
-              show-icon
-              :closable="false"
-              class="mb-3"
-            />
-            <el-table
-              v-table-column-resize="'protection.policies.backup.related'"
-              v-table-overflow-title
-              v-loading="relatedBackupConfigsLoading"
-              :data="pagedRelatedBackupConfigs"
-              stripe
-              row-key="id"
-              class="hfl-list-table policy-related-backup-table"
+        <div
+          v-if="activePolicy"
+          class="hfl-detail-drawer__body policy-detail-body"
+        >
+          <ElTabs
+            v-model="policyDetailTab"
+            class="hfl-detail-tabs policy-detail-tabs"
+          >
+            <ElTabPane
+              :label="t('protection.sourceResources.detailTabBasic')"
+              name="basic"
             >
-              <el-table-column :label="t('repositoriesPage.associatedSourceColId')" width="90" fixed="left">
-                <template #default="{ row }">
-                  <span class="hfl-table-mono">{{ row.source_ref_id }}</span>
-                </template>
-              </el-table-column>
-              <el-table-column :label="t('protection.backupsPage.colBackupSource')" min-width="260" fixed="left">
-                <template #default="{ row }">
-                  <div class="policy-related-source-cell">
-                    <span class="policy-related-source-cell__name">{{ backupConfigSourceLabel(row) }}</span>
-                    <span class="policy-related-source-cell__meta">
-                      <ElTag size="small" effect="plain">{{ sourceTypeLabel(row.source_type) }}</ElTag>
-                      <ElTooltip
-                        v-if="relatedSourceTraitLabel(row)"
-                        :content="relatedSourceTraitLabel(row)"
-                        placement="top"
-                      >
-                        <span
-                          v-if="relatedSourceKind(row) === 'host'"
-                          class="source-os-cell__icon-wrap policy-related-source-cell__trait-icon"
+              <PolicyDetailBasicPanel
+                :key="activePolicy.apiId"
+                :policy-id="activePolicy.apiId"
+                :created-at="activePolicy.createdAt"
+                :associated-source-count="activePolicy.relatedBackupCount"
+                :updated-at="activePolicy.updatedAt"
+                @updated="loadActiveList"
+              />
+            </ElTabPane>
+
+            <ElTabPane
+              :label="t('protection.policiesPage.tabRelatedBackupSources')"
+              name="backups"
+            >
+              <el-alert
+                v-if="relatedBackupConfigsError"
+                :title="relatedBackupConfigsError"
+                type="error"
+                show-icon
+                :closable="false"
+                class="mb-3"
+              />
+              <el-table
+                v-table-column-resize="'protection.policies.backup.related'"
+                v-table-overflow-title
+                v-loading="relatedBackupConfigsLoading"
+                :data="pagedRelatedBackupConfigs"
+                stripe
+                row-key="id"
+                class="hfl-list-table policy-related-backup-table"
+              >
+                <el-table-column
+                  :label="t('repositoriesPage.associatedSourceColId')"
+                  width="90"
+                  fixed="left"
+                >
+                  <template #default="{ row }">
+                    <span class="hfl-table-mono">{{ row.source_ref_id }}</span>
+                  </template>
+                </el-table-column>
+                <el-table-column
+                  :label="t('protection.backupsPage.colBackupSource')"
+                  min-width="260"
+                  fixed="left"
+                >
+                  <template #default="{ row }">
+                    <div class="policy-related-source-cell">
+                      <span class="policy-related-source-cell__name">{{ backupConfigSourceLabel(row) }}</span>
+                      <span class="policy-related-source-cell__meta">
+                        <ElTag
+                          size="small"
+                          effect="plain"
+                        >{{ sourceTypeLabel(row.source_type) }}</ElTag>
+                        <ElTooltip
+                          v-if="relatedSourceTraitLabel(row)"
+                          :content="relatedSourceTraitLabel(row)"
+                          placement="top"
                         >
-                          <AgentPlatformBrandIcon :os="relatedSource(row)?.platform || 'linux'" />
-                        </span>
+                          <span
+                            v-if="relatedSourceKind(row) === 'host'"
+                            class="source-os-cell__icon-wrap policy-related-source-cell__trait-icon"
+                          >
+                            <AgentPlatformBrandIcon :os="relatedSource(row)?.platform || 'linux'" />
+                          </span>
+                          <span
+                            v-else
+                            class="repo-protocol-pill repo-protocol-pill--icon-only policy-related-source-cell__trait-icon"
+                            :class="`repo-protocol-pill--${relatedSource(row)?.protocol || 'nfs'}`"
+                          >
+                            <component
+                              :is="nasMountProtocolIcon(relatedSource(row)?.protocol)"
+                              :size="12"
+                              stroke-width="2.25"
+                            />
+                          </span>
+                        </ElTooltip>
                         <span
                           v-else
-                          class="repo-protocol-pill repo-protocol-pill--icon-only policy-related-source-cell__trait-icon"
-                          :class="`repo-protocol-pill--${relatedSource(row)?.protocol || 'nfs'}`"
+                          class="hfl-empty-mark"
                         >
-                          <component
-                            :is="nasMountProtocolIcon(relatedSource(row)?.protocol)"
-                            :size="12"
-                            stroke-width="2.25"
-                          />
+                          {{ t('protection.policiesPage.timeDash') }}
                         </span>
-                      </ElTooltip>
-                      <span v-else class="hfl-empty-mark">
-                        {{ t('protection.policiesPage.timeDash') }}
                       </span>
-                    </span>
-                  </div>
+                    </div>
+                  </template>
+                </el-table-column>
+                <el-table-column
+                  :label="t('repositoriesPage.associatedSourceColEndpoint')"
+                  min-width="220"
+                >
+                  <template #default="{ row }">
+                    <FlowSourceConnectionCell :row="relatedSourceEndpointRow(row)" />
+                  </template>
+                </el-table-column>
+                <el-table-column
+                  :label="t('repositoriesPage.associatedSourceColAvailability')"
+                  min-width="130"
+                >
+                  <template #default="{ row }">
+                    <ElTag
+                      size="small"
+                      v-bind="lifecycleStatusTagAttrs(relatedSourceAvailability(row))"
+                    >
+                      {{ relatedSourceAvailabilityLabel(row) }}
+                    </ElTag>
+                  </template>
+                </el-table-column>
+                <el-table-column
+                  :label="t('protection.sourceResources.colRegisteredAt')"
+                  min-width="170"
+                >
+                  <template #default="{ row }">
+                    <span
+                      class="hfl-table-cell-time"
+                      :class="{ 'hfl-empty-mark': !relatedSourceRegisteredAt(row) }"
+                    >{{ relatedSourceRegisteredAt(row) || '—' }}</span>
+                  </template>
+                </el-table-column>
+                <template #empty>
+                  <el-empty
+                    :description="t('protection.policiesPage.emptyRelatedBackupSourcesPolicy')"
+                    :image-size="72"
+                  />
                 </template>
-              </el-table-column>
-              <el-table-column :label="t('repositoriesPage.associatedSourceColEndpoint')" min-width="220">
-                <template #default="{ row }">
-                  <FlowSourceConnectionCell :row="relatedSourceEndpointRow(row)" />
-                </template>
-              </el-table-column>
-              <el-table-column :label="t('repositoriesPage.associatedSourceColAvailability')" min-width="130">
-                <template #default="{ row }">
-                  <ElTag size="small" v-bind="lifecycleStatusTagAttrs(relatedSourceAvailability(row))">
-                    {{ relatedSourceAvailabilityLabel(row) }}
-                  </ElTag>
-                </template>
-              </el-table-column>
-              <el-table-column :label="t('protection.sourceResources.colRegisteredAt')" min-width="170">
-                <template #default="{ row }">
-                  <span class="hfl-table-cell-time" :class="{ 'hfl-empty-mark': !relatedSourceRegisteredAt(row) }">{{ relatedSourceRegisteredAt(row) || '—' }}</span>
-                </template>
-              </el-table-column>
-              <template #empty>
-                <el-empty :description="t('protection.policiesPage.emptyRelatedBackupSourcesPolicy')" :image-size="72" />
-              </template>
-            </el-table>
-            <div v-if="relatedBackupConfigs.length > 0" class="policy-related-backup-footer">
-              <HflPagination
-                v-model:current-page="relatedBackupPage"
-                v-model:page-size="relatedBackupPageSize"
-                :total="relatedBackupConfigs.length"
-                @update:page-size="relatedBackupPage = 1"
-              />
-            </div>
-          </ElTabPane>
-        </ElTabs>
-      </div>
-    </ElDrawer>
+              </el-table>
+              <div
+                v-if="relatedBackupConfigs.length > 0"
+                class="policy-related-backup-footer"
+              >
+                <HflPagination
+                  v-model:current-page="relatedBackupPage"
+                  v-model:page-size="relatedBackupPageSize"
+                  :total="relatedBackupConfigs.length"
+                  @update:page-size="relatedBackupPage = 1"
+                />
+              </div>
+            </ElTabPane>
+          </ElTabs>
+        </div>
+      </ElDrawer>
 
-    <ElDrawer
-      v-model="filterDetailDrawerOpen"
-      direction="rtl"
-      :size="drawerSize"
-      destroy-on-close
-      :modal="true"
-      class="hfl-detail-drawer policy-detail-drawer"
-      @closed="onFilterDetailClosed"
-    >
-      <template #header>
-        <span class="hfl-detail-drawer__title">{{ activeFilter?.name || t('protection.policiesPage.filterDetailDrawerTitle') }}</span>
-      </template>
-      <div v-if="activeFilter" class="hfl-detail-drawer__body policy-detail-body">
-        <ElTabs v-model="filterDetailTab" class="hfl-detail-tabs policy-detail-tabs">
-          <ElTabPane :label="t('protection.sourceResources.detailTabBasic')" name="basic">
-            <FileFilterDetailBasicPanel
-              :key="activeFilter.apiId"
-              :filter-id="activeFilter.apiId"
-              :created-at="activeFilter.createdAt"
-              :associated-source-count="activeFilter.relatedBackupCount"
-              :updated-at="activeFilter.updatedAt"
-              @updated="loadActiveList"
-            />
-          </ElTabPane>
-
-          <ElTabPane :label="t('protection.policiesPage.tabRelatedBackupSources')" name="backups">
-            <el-alert
-              v-if="filterRelatedBackupConfigsError"
-              :title="filterRelatedBackupConfigsError"
-              type="error"
-              show-icon
-              :closable="false"
-              class="mb-3"
-            />
-            <el-table
-              v-table-column-resize="'protection.policies.filters.related'"
-              v-table-overflow-title
-              v-loading="filterRelatedBackupConfigsLoading"
-              :data="pagedFilterRelatedBackupConfigs"
-              stripe
-              row-key="id"
-              class="hfl-list-table policy-related-backup-table"
+      <ElDrawer
+        v-model="filterDetailDrawerOpen"
+        direction="rtl"
+        :size="drawerSize"
+        destroy-on-close
+        :modal="true"
+        class="hfl-detail-drawer policy-detail-drawer"
+        @closed="onFilterDetailClosed"
+      >
+        <template #header>
+          <span class="hfl-detail-drawer__title">{{ activeFilter?.name || t('protection.policiesPage.filterDetailDrawerTitle') }}</span>
+        </template>
+        <div
+          v-if="activeFilter"
+          class="hfl-detail-drawer__body policy-detail-body"
+        >
+          <ElTabs
+            v-model="filterDetailTab"
+            class="hfl-detail-tabs policy-detail-tabs"
+          >
+            <ElTabPane
+              :label="t('protection.sourceResources.detailTabBasic')"
+              name="basic"
             >
-              <el-table-column :label="t('repositoriesPage.associatedSourceColId')" width="90" fixed="left">
-                <template #default="{ row }">
-                  <span class="hfl-table-mono">{{ row.source_ref_id }}</span>
-                </template>
-              </el-table-column>
-              <el-table-column :label="t('protection.backupsPage.colBackupSource')" min-width="260" fixed="left">
-                <template #default="{ row }">
-                  <div class="policy-related-source-cell">
-                    <span class="policy-related-source-cell__name">{{ backupConfigSourceLabel(row) }}</span>
-                    <span class="policy-related-source-cell__meta">
-                      <ElTag size="small" effect="plain">{{ sourceTypeLabel(row.source_type) }}</ElTag>
-                      <ElTooltip
-                        v-if="relatedSourceTraitLabel(row)"
-                        :content="relatedSourceTraitLabel(row)"
-                        placement="top"
-                      >
-                        <span
-                          v-if="relatedSourceKind(row) === 'host'"
-                          class="source-os-cell__icon-wrap policy-related-source-cell__trait-icon"
+              <FileFilterDetailBasicPanel
+                :key="activeFilter.apiId"
+                :filter-id="activeFilter.apiId"
+                :created-at="activeFilter.createdAt"
+                :associated-source-count="activeFilter.relatedBackupCount"
+                :updated-at="activeFilter.updatedAt"
+                @updated="loadActiveList"
+              />
+            </ElTabPane>
+
+            <ElTabPane
+              :label="t('protection.policiesPage.tabRelatedBackupSources')"
+              name="backups"
+            >
+              <el-alert
+                v-if="filterRelatedBackupConfigsError"
+                :title="filterRelatedBackupConfigsError"
+                type="error"
+                show-icon
+                :closable="false"
+                class="mb-3"
+              />
+              <el-table
+                v-table-column-resize="'protection.policies.filters.related'"
+                v-table-overflow-title
+                v-loading="filterRelatedBackupConfigsLoading"
+                :data="pagedFilterRelatedBackupConfigs"
+                stripe
+                row-key="id"
+                class="hfl-list-table policy-related-backup-table"
+              >
+                <el-table-column
+                  :label="t('repositoriesPage.associatedSourceColId')"
+                  width="90"
+                  fixed="left"
+                >
+                  <template #default="{ row }">
+                    <span class="hfl-table-mono">{{ row.source_ref_id }}</span>
+                  </template>
+                </el-table-column>
+                <el-table-column
+                  :label="t('protection.backupsPage.colBackupSource')"
+                  min-width="260"
+                  fixed="left"
+                >
+                  <template #default="{ row }">
+                    <div class="policy-related-source-cell">
+                      <span class="policy-related-source-cell__name">{{ backupConfigSourceLabel(row) }}</span>
+                      <span class="policy-related-source-cell__meta">
+                        <ElTag
+                          size="small"
+                          effect="plain"
+                        >{{ sourceTypeLabel(row.source_type) }}</ElTag>
+                        <ElTooltip
+                          v-if="relatedSourceTraitLabel(row)"
+                          :content="relatedSourceTraitLabel(row)"
+                          placement="top"
                         >
-                          <AgentPlatformBrandIcon :os="relatedSource(row)?.platform || 'linux'" />
-                        </span>
+                          <span
+                            v-if="relatedSourceKind(row) === 'host'"
+                            class="source-os-cell__icon-wrap policy-related-source-cell__trait-icon"
+                          >
+                            <AgentPlatformBrandIcon :os="relatedSource(row)?.platform || 'linux'" />
+                          </span>
+                          <span
+                            v-else
+                            class="repo-protocol-pill repo-protocol-pill--icon-only policy-related-source-cell__trait-icon"
+                            :class="`repo-protocol-pill--${relatedSource(row)?.protocol || 'nfs'}`"
+                          >
+                            <component
+                              :is="nasMountProtocolIcon(relatedSource(row)?.protocol)"
+                              :size="12"
+                              stroke-width="2.25"
+                            />
+                          </span>
+                        </ElTooltip>
                         <span
                           v-else
-                          class="repo-protocol-pill repo-protocol-pill--icon-only policy-related-source-cell__trait-icon"
-                          :class="`repo-protocol-pill--${relatedSource(row)?.protocol || 'nfs'}`"
+                          class="hfl-empty-mark"
                         >
-                          <component
-                            :is="nasMountProtocolIcon(relatedSource(row)?.protocol)"
-                            :size="12"
-                            stroke-width="2.25"
-                          />
+                          {{ t('protection.policiesPage.timeDash') }}
                         </span>
-                      </ElTooltip>
-                      <span v-else class="hfl-empty-mark">
-                        {{ t('protection.policiesPage.timeDash') }}
                       </span>
-                    </span>
-                  </div>
+                    </div>
+                  </template>
+                </el-table-column>
+                <el-table-column
+                  :label="t('repositoriesPage.associatedSourceColEndpoint')"
+                  min-width="220"
+                >
+                  <template #default="{ row }">
+                    <FlowSourceConnectionCell :row="relatedSourceEndpointRow(row)" />
+                  </template>
+                </el-table-column>
+                <el-table-column
+                  :label="t('repositoriesPage.associatedSourceColAvailability')"
+                  min-width="130"
+                >
+                  <template #default="{ row }">
+                    <ElTag
+                      size="small"
+                      v-bind="lifecycleStatusTagAttrs(relatedSourceAvailability(row))"
+                    >
+                      {{ relatedSourceAvailabilityLabel(row) }}
+                    </ElTag>
+                  </template>
+                </el-table-column>
+                <el-table-column
+                  :label="t('protection.sourceResources.colRegisteredAt')"
+                  min-width="170"
+                >
+                  <template #default="{ row }">
+                    <span
+                      class="hfl-table-cell-time"
+                      :class="{ 'hfl-empty-mark': !relatedSourceRegisteredAt(row) }"
+                    >{{ relatedSourceRegisteredAt(row) || '—' }}</span>
+                  </template>
+                </el-table-column>
+                <template #empty>
+                  <el-empty
+                    :description="t('protection.policiesPage.emptyRelatedBackupSourcesFilter')"
+                    :image-size="72"
+                  />
                 </template>
-              </el-table-column>
-              <el-table-column :label="t('repositoriesPage.associatedSourceColEndpoint')" min-width="220">
-                <template #default="{ row }">
-                  <FlowSourceConnectionCell :row="relatedSourceEndpointRow(row)" />
-                </template>
-              </el-table-column>
-              <el-table-column :label="t('repositoriesPage.associatedSourceColAvailability')" min-width="130">
-                <template #default="{ row }">
-                  <ElTag size="small" v-bind="lifecycleStatusTagAttrs(relatedSourceAvailability(row))">
-                    {{ relatedSourceAvailabilityLabel(row) }}
-                  </ElTag>
-                </template>
-              </el-table-column>
-              <el-table-column :label="t('protection.sourceResources.colRegisteredAt')" min-width="170">
-                <template #default="{ row }">
-                  <span class="hfl-table-cell-time" :class="{ 'hfl-empty-mark': !relatedSourceRegisteredAt(row) }">{{ relatedSourceRegisteredAt(row) || '—' }}</span>
-                </template>
-              </el-table-column>
-              <template #empty>
-                <el-empty :description="t('protection.policiesPage.emptyRelatedBackupSourcesFilter')" :image-size="72" />
-              </template>
-            </el-table>
-            <div v-if="filterRelatedBackupConfigs.length > 0" class="policy-related-backup-footer">
-              <HflPagination
-                v-model:current-page="filterRelatedBackupPage"
-                v-model:page-size="filterRelatedBackupPageSize"
-                :total="filterRelatedBackupConfigs.length"
-                @update:page-size="filterRelatedBackupPage = 1"
-              />
-            </div>
-          </ElTabPane>
-        </ElTabs>
-      </div>
-    </ElDrawer>
-    <DangerConfirmDialog
-      v-model="deleteConfirmOpen"
-      :title="deleteConfirmTitle"
-      :message="deleteConfirmMessage"
-      :items="deleteConfirmItems"
-      :items-heading="deleteConfirmItemsHeading"
-      :item-name-label="t('protection.policiesPage.colName')"
-      :item-status-label="t('protection.policiesPage.colStatus')"
-      :item-details-label="deleteConfirmKind === 'policy'
-        ? t('protection.policiesPage.colSchedule')
-        : t('protection.policiesPage.colFilterSummary')"
-      confirm-mode="keyword"
-      :confirm-keyword="t('protection.policiesPage.deleteKeyword')"
-      :confirm-keyword-hint="t('protection.policiesPage.deleteKeywordHint', { n: deleteConfirmRows.length })"
-      :confirm-keyword-placeholder="t('protection.policiesPage.deleteKeyword')"
-      :cancel-text="t('common.cancel')"
-      :confirm-text="t('protection.policiesPage.btnDeleteConfirm')"
-      :loading="listActionLoading"
-      level="high"
-      width="640px"
-      @confirm="executeDeleteConfirm"
-      @cancel="closeDeleteConfirm"
-    />
-    <DangerConfirmDialog
-      v-model="stateConfirmOpen"
-      :title="stateConfirmTitle"
-      :message="stateConfirmMessage"
-      :warning="stateConfirmWarning"
-      :items="stateConfirmItems"
-      :items-heading="stateConfirmEntityLabel"
-      :item-name-label="t('protection.policiesPage.colName')"
-      :item-status-label="t('protection.policiesPage.colStatus')"
-      :item-details-label="stateConfirmKind === 'policy'
-        ? t('protection.policiesPage.colSchedule')
-        : t('protection.policiesPage.colFilterSummary')"
-      confirm-mode="keyword"
-      :confirm-keyword="stateConfirmKeyword"
-      :confirm-keyword-hint="stateConfirmKeywordHint"
-      :confirm-keyword-placeholder="stateConfirmKeyword"
-      :irreversible-hint="t('protection.policiesPage.stateChangeIrreversible')"
-      irreversible-tone="neutral"
-      :cancel-text="t('common.cancel')"
-      :confirm-text="stateConfirmEnabled
-        ? t('protection.policiesPage.confirmEnableCount', { n: stateConfirmRows.length })
-        : t('protection.policiesPage.confirmDisableCount', { n: stateConfirmRows.length })"
-      :loading="listActionLoading"
-      level="medium"
-      width="640px"
-      @confirm="executeStateConfirm"
-      @cancel="closeStateConfirm"
-    />
+              </el-table>
+              <div
+                v-if="filterRelatedBackupConfigs.length > 0"
+                class="policy-related-backup-footer"
+              >
+                <HflPagination
+                  v-model:current-page="filterRelatedBackupPage"
+                  v-model:page-size="filterRelatedBackupPageSize"
+                  :total="filterRelatedBackupConfigs.length"
+                  @update:page-size="filterRelatedBackupPage = 1"
+                />
+              </div>
+            </ElTabPane>
+          </ElTabs>
+        </div>
+      </ElDrawer>
+      <DangerConfirmDialog
+        v-model="deleteConfirmOpen"
+        :title="deleteConfirmTitle"
+        :message="deleteConfirmMessage"
+        :items="deleteConfirmItems"
+        :items-heading="deleteConfirmItemsHeading"
+        :item-name-label="t('protection.policiesPage.colName')"
+        :item-status-label="t('protection.policiesPage.colStatus')"
+        :item-details-label="deleteConfirmKind === 'policy'
+          ? t('protection.policiesPage.colSchedule')
+          : t('protection.policiesPage.colFilterSummary')"
+        confirm-mode="keyword"
+        :confirm-keyword="t('protection.policiesPage.deleteKeyword')"
+        :confirm-keyword-hint="t('protection.policiesPage.deleteKeywordHint', { n: deleteConfirmRows.length })"
+        :confirm-keyword-placeholder="t('protection.policiesPage.deleteKeyword')"
+        :cancel-text="t('common.cancel')"
+        :confirm-text="t('protection.policiesPage.btnDeleteConfirm')"
+        :loading="listActionLoading"
+        level="high"
+        width="640px"
+        @confirm="executeDeleteConfirm"
+        @cancel="closeDeleteConfirm"
+      />
+      <DangerConfirmDialog
+        v-model="stateConfirmOpen"
+        :title="stateConfirmTitle"
+        :message="stateConfirmMessage"
+        :warning="stateConfirmWarning"
+        :items="stateConfirmItems"
+        :items-heading="stateConfirmEntityLabel"
+        :item-name-label="t('protection.policiesPage.colName')"
+        :item-status-label="t('protection.policiesPage.colStatus')"
+        :item-details-label="stateConfirmKind === 'policy'
+          ? t('protection.policiesPage.colSchedule')
+          : t('protection.policiesPage.colFilterSummary')"
+        confirm-mode="keyword"
+        :confirm-keyword="stateConfirmKeyword"
+        :confirm-keyword-hint="stateConfirmKeywordHint"
+        :confirm-keyword-placeholder="stateConfirmKeyword"
+        :irreversible-hint="t('protection.policiesPage.stateChangeIrreversible')"
+        irreversible-tone="neutral"
+        :cancel-text="t('common.cancel')"
+        :confirm-text="stateConfirmEnabled
+          ? t('protection.policiesPage.confirmEnableCount', { n: stateConfirmRows.length })
+          : t('protection.policiesPage.confirmDisableCount', { n: stateConfirmRows.length })"
+        :loading="listActionLoading"
+        level="medium"
+        width="640px"
+        @confirm="executeStateConfirm"
+        @cancel="closeStateConfirm"
+      />
     </div>
   </ModulePage>
 </template>

--- a/src/frontend/src/pages/protection/PolicyEditorPage.vue
+++ b/src/frontend/src/pages/protection/PolicyEditorPage.vue
@@ -290,7 +290,10 @@ onMounted(() => {
 </script>
 
 <template>
-  <div ref="pageRef" class="fullscreen-form-fullscreen resource-add-fullscreen policy-editor-fullscreen">
+  <div
+    ref="pageRef"
+    class="fullscreen-form-fullscreen resource-add-fullscreen policy-editor-fullscreen"
+  >
     <div class="fullscreen-form-page add-s3-page policy-editor-page">
       <header class="fullscreen-form-header">
         <button
@@ -299,15 +302,25 @@ onMounted(() => {
           :aria-label="t('protection.policiesPage.policyEditorBackAria')"
           @click="handleBack"
         >
-          <ArrowLeft class="fullscreen-form-header__back-icon" :size="18" />
+          <ArrowLeft
+            class="fullscreen-form-header__back-icon"
+            :size="18"
+          />
         </button>
         <div class="fullscreen-form-header__content">
-          <h1 class="fullscreen-form-header__title">{{ pageTitle }}</h1>
-          <p class="fullscreen-form-header__desc">{{ editorHeaderDesc }}</p>
+          <h1 class="fullscreen-form-header__title">
+            {{ pageTitle }}
+          </h1>
+          <p class="fullscreen-form-header__desc">
+            {{ editorHeaderDesc }}
+          </p>
         </div>
       </header>
 
-      <div v-loading="loading" class="fullscreen-form-layout">
+      <div
+        v-loading="loading"
+        class="fullscreen-form-layout"
+      >
         <main class="fullscreen-form-main">
           <ProtectionPolicyEditorForm
             v-model:policy-form="form"
@@ -323,10 +336,18 @@ onMounted(() => {
           />
 
           <footer class="fullscreen-form-footer fullscreen-form-action-footer">
-            <ElButton :disabled="saving" @click="handleBack">
+            <ElButton
+              :disabled="saving"
+              @click="handleBack"
+            >
               {{ t('protection.backupsPage.btnCancel') }}
             </ElButton>
-            <ElButton type="primary" :loading="saving" :disabled="saving || loading" @click="submitEditor">
+            <ElButton
+              type="primary"
+              :loading="saving"
+              :disabled="saving || loading"
+              @click="submitEditor"
+            >
               {{ editorSaveLabel }}
             </ElButton>
           </footer>
@@ -337,7 +358,11 @@ onMounted(() => {
             <div class="add-form-preview-header">
               <div class="add-form-preview-header__glow" />
               <div class="add-form-preview-header__icon">
-                <component :is="editorPreviewIcon" class="add-form-preview-header__cloud" :size="28" />
+                <component
+                  :is="editorPreviewIcon"
+                  class="add-form-preview-header__cloud"
+                  :size="28"
+                />
               </div>
               <div class="add-form-preview-header__info">
                 <h4
@@ -346,13 +371,17 @@ onMounted(() => {
                 >
                   {{ editorPreviewName || t('protection.policiesPage.previewUnnamed') }}
                 </h4>
-                <p class="add-form-preview-header__type">{{ editorPreviewType }}</p>
+                <p class="add-form-preview-header__type">
+                  {{ editorPreviewType }}
+                </p>
               </div>
             </div>
 
             <div class="add-form-preview-body">
               <div class="add-form-preview-section">
-                <h5 class="add-form-preview-section__title">{{ t('ops.alertsCenter.editor.previewTitle') }}</h5>
+                <h5 class="add-form-preview-section__title">
+                  {{ t('ops.alertsCenter.editor.previewTitle') }}
+                </h5>
                 <div class="add-form-preview-row">
                   <span class="add-form-preview-row__label">{{ t('protection.policiesPage.fieldPolicyStatus') }}</span>
                   <span
@@ -362,7 +391,11 @@ onMounted(() => {
                     {{ editorPreviewActive ? t('protection.policiesPage.statusOn') : t('protection.policiesPage.statusOff') }}
                   </span>
                 </div>
-                <div v-for="row in editorPreviewRows" :key="row.label" class="add-form-preview-row">
+                <div
+                  v-for="row in editorPreviewRows"
+                  :key="row.label"
+                  class="add-form-preview-row"
+                >
                   <span class="add-form-preview-row__label">{{ row.label }}</span>
                   <span
                     class="add-form-preview-row__value"
@@ -377,9 +410,18 @@ onMounted(() => {
                 </div>
               </div>
 
-              <div v-if="isFilterEditor" class="add-form-preview-section">
-                <h5 class="add-form-preview-section__title">{{ t('protection.policiesPage.filterRulesSectionTitle') }}</h5>
-                <div v-for="row in filterRulePreviewRows" :key="row.label" class="add-form-preview-row">
+              <div
+                v-if="isFilterEditor"
+                class="add-form-preview-section"
+              >
+                <h5 class="add-form-preview-section__title">
+                  {{ t('protection.policiesPage.filterRulesSectionTitle') }}
+                </h5>
+                <div
+                  v-for="row in filterRulePreviewRows"
+                  :key="row.label"
+                  class="add-form-preview-row"
+                >
                   <span class="add-form-preview-row__label">{{ row.label }}</span>
                   <span
                     class="add-form-preview-row__value"
@@ -390,9 +432,18 @@ onMounted(() => {
                 </div>
               </div>
 
-              <div v-if="isFilterEditor" class="add-form-preview-section">
-                <h5 class="add-form-preview-section__title">{{ t('protection.policiesPage.previewFilterAdvanced') }}</h5>
-                <div v-for="row in filterAdvancedPreviewRows" :key="row.label" class="add-form-preview-row">
+              <div
+                v-if="isFilterEditor"
+                class="add-form-preview-section"
+              >
+                <h5 class="add-form-preview-section__title">
+                  {{ t('protection.policiesPage.previewFilterAdvanced') }}
+                </h5>
+                <div
+                  v-for="row in filterAdvancedPreviewRows"
+                  :key="row.label"
+                  class="add-form-preview-row"
+                >
                   <span class="add-form-preview-row__label">{{ row.label }}</span>
                   <span
                     class="add-form-preview-row__value"
@@ -406,9 +457,18 @@ onMounted(() => {
                 </div>
               </div>
 
-              <div v-if="!isFilterEditor" class="add-form-preview-section">
-                <h5 class="add-form-preview-section__title">{{ t('protection.policiesPage.fieldRetention') }}</h5>
-                <div v-for="row in backupRetentionPreviewRows" :key="row.label" class="add-form-preview-row">
+              <div
+                v-if="!isFilterEditor"
+                class="add-form-preview-section"
+              >
+                <h5 class="add-form-preview-section__title">
+                  {{ t('protection.policiesPage.fieldRetention') }}
+                </h5>
+                <div
+                  v-for="row in backupRetentionPreviewRows"
+                  :key="row.label"
+                  class="add-form-preview-row"
+                >
                   <span class="add-form-preview-row__label">{{ row.label }}</span>
                   <span
                     class="add-form-preview-row__value"
@@ -419,9 +479,18 @@ onMounted(() => {
                 </div>
               </div>
 
-              <div v-if="!isFilterEditor" class="add-form-preview-section">
-                <h5 class="add-form-preview-section__title">{{ t('protection.policiesPage.sectionCheckError') }}</h5>
-                <div v-for="row in backupErrorHandlingPreviewRows" :key="row.label" class="add-form-preview-row">
+              <div
+                v-if="!isFilterEditor"
+                class="add-form-preview-section"
+              >
+                <h5 class="add-form-preview-section__title">
+                  {{ t('protection.policiesPage.sectionCheckError') }}
+                </h5>
+                <div
+                  v-for="row in backupErrorHandlingPreviewRows"
+                  :key="row.label"
+                  class="add-form-preview-row"
+                >
                   <span class="add-form-preview-row__label">{{ row.label }}</span>
                   <span
                     class="add-form-preview-row__value"

--- a/src/frontend/src/pages/protection/SnapshotDetail.vue
+++ b/src/frontend/src/pages/protection/SnapshotDetail.vue
@@ -65,12 +65,21 @@ function openDirTree(row: DemoSnapshotDir) {
 </script>
 
 <template>
-  <ModulePage :title="t('protection.moduleTitle')" :menus="protectionMenus">
-    <div v-if="backup && snapshot" class="space-y-4">
+  <ModulePage
+    :title="t('protection.moduleTitle')"
+    :menus="protectionMenus"
+  >
+    <div
+      v-if="backup && snapshot"
+      class="space-y-4"
+    >
       <div class="flex flex-wrap items-center gap-3">
         <RouterLink :to="`/protection/backups/${backupId}`">
           <ElButton text>
-            <ArrowLeft :size="16" class="inline mr-1 align-text-bottom" />
+            <ArrowLeft
+              :size="16"
+              class="inline mr-1 align-text-bottom"
+            />
             {{ t('protection.snapshotDetail.backToBackupDetail') }}
           </ElButton>
         </RouterLink>
@@ -91,10 +100,18 @@ function openDirTree(row: DemoSnapshotDir) {
       </p>
 
       <div class="hfl-list-panel">
-        <div class="px-4 py-3 border-b border-slate-100 text-sm font-medium text-slate-800">{{ t('protection.snapshotDetail.panelTitle') }}</div>
+        <div class="px-4 py-3 border-b border-slate-100 text-sm font-medium text-slate-800">
+          {{ t('protection.snapshotDetail.panelTitle') }}
+        </div>
         <el-table
-          v-table-overflow-title :data="snapshot.dirs" stripe>
-          <el-table-column :label="t('protection.snapshotDetail.colBackupDir')" min-width="280">
+          v-table-overflow-title
+          :data="snapshot.dirs"
+          stripe
+        >
+          <el-table-column
+            :label="t('protection.snapshotDetail.colBackupDir')"
+            min-width="280"
+          >
             <template #default="{ row }">
               <button
                 type="button"
@@ -113,13 +130,29 @@ function openDirTree(row: DemoSnapshotDir) {
               </button>
             </template>
           </el-table-column>
-          <el-table-column :label="t('protection.snapshotDetail.colDirSize')" width="120">
-            <template #default="{ row }">{{ fmtBytes(row.sizeBytes) }}</template>
+          <el-table-column
+            :label="t('protection.snapshotDetail.colDirSize')"
+            width="120"
+          >
+            <template #default="{ row }">
+              {{ fmtBytes(row.sizeBytes) }}
+            </template>
           </el-table-column>
-          <el-table-column :label="t('protection.snapshotDetail.colFiles')" width="110" prop="fileCount" />
-          <el-table-column :label="t('protection.snapshotDetail.colInnerDirs')" width="120" prop="innerDirCount" />
+          <el-table-column
+            :label="t('protection.snapshotDetail.colFiles')"
+            width="110"
+            prop="fileCount"
+          />
+          <el-table-column
+            :label="t('protection.snapshotDetail.colInnerDirs')"
+            width="120"
+            prop="innerDirCount"
+          />
           <template #empty>
-            <el-empty :description="t('protection.snapshotDetail.emptyDirs')" :image-size="64" />
+            <el-empty
+              :description="t('protection.snapshotDetail.emptyDirs')"
+              :image-size="64"
+            />
           </template>
         </el-table>
       </div>
@@ -147,24 +180,48 @@ function openDirTree(row: DemoSnapshotDir) {
                 :class="data.type === 'dir' ? '' : 'text-slate-500'"
               />
               <span class="hfl-dir-tree-node__text">
-                <span class="hfl-dir-tree-node__label" :title="node.label">{{ node.label }}</span>
-                <span v-if="data.type === 'dir'" class="hfl-dir-tree-node__path">{{ t('protection.snapshotDetail.typeDir') }}</span>
-                <span v-else class="hfl-dir-tree-node__path">{{ t('protection.snapshotDetail.typeFile') }}</span>
+                <span
+                  class="hfl-dir-tree-node__label"
+                  :title="node.label"
+                >{{ node.label }}</span>
+                <span
+                  v-if="data.type === 'dir'"
+                  class="hfl-dir-tree-node__path"
+                >{{ t('protection.snapshotDetail.typeDir') }}</span>
+                <span
+                  v-else
+                  class="hfl-dir-tree-node__path"
+                >{{ t('protection.snapshotDetail.typeFile') }}</span>
               </span>
             </span>
           </template>
         </el-tree>
-        <p class="text-xs text-slate-400 mt-4">{{ t('protection.snapshotDetail.treeDemoHint') }}</p>
+        <p class="text-xs text-slate-400 mt-4">
+          {{ t('protection.snapshotDetail.treeDemoHint') }}
+        </p>
       </ElDrawer>
     </div>
 
-    <div v-else class="py-16 text-center">
+    <div
+      v-else
+      class="py-16 text-center"
+    >
       <el-empty :description="t('protection.snapshotDetail.notFoundSnap')">
-        <RouterLink v-if="backup" :to="`/protection/backups/${backupId}`">
-          <ElButton type="primary">{{ t('protection.snapshotDetail.backToBackup') }}</ElButton>
+        <RouterLink
+          v-if="backup"
+          :to="`/protection/backups/${backupId}`"
+        >
+          <ElButton type="primary">
+            {{ t('protection.snapshotDetail.backToBackup') }}
+          </ElButton>
         </RouterLink>
-        <RouterLink v-else to="/protection/backups">
-          <ElButton type="primary">{{ t('protection.snapshotDetail.backToDataProtection') }}</ElButton>
+        <RouterLink
+          v-else
+          to="/protection/backups"
+        >
+          <ElButton type="primary">
+            {{ t('protection.snapshotDetail.backToDataProtection') }}
+          </ElButton>
         </RouterLink>
       </el-empty>
     </div>

--- a/src/frontend/src/pages/protection/SnapshotRestorePage.test.ts
+++ b/src/frontend/src/pages/protection/SnapshotRestorePage.test.ts
@@ -1,9 +1,11 @@
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
+import { compactSourceText } from '../../test/sourceText'
 
 const entryPage = readFileSync(resolve(process.cwd(), 'src/pages/protection/SnapshotRestorePage.vue'), 'utf8')
 const sharedWizard = readFileSync(resolve(process.cwd(), 'src/pages/protection/DataProtection.vue'), 'utf8')
+const compactSharedWizard = compactSourceText(sharedWizard)
 
 describe('SnapshotRestorePage shared wizard entry', () => {
   it('delegates rendering to the existing restore wizard', () => {
@@ -24,7 +26,7 @@ describe('SnapshotRestorePage shared wizard entry', () => {
   })
 
   it('hides the chooser and first step in fixed-snapshot mode', () => {
-    expect(sharedWizard).toContain('v-if="!isFixedSnapshotRestore" v-model="recEntryMode"')
+    expect(compactSharedWizard).toContain('v-if="!isFixedSnapshotRestore" v-model="recEntryMode"')
     expect(sharedWizard).toContain('.slice(isFixedSnapshotRestore.value ? 1 : 0)')
     expect(sharedWizard).toContain('recStep > (isFixedSnapshotRestore ? 1 : 0)')
   })

--- a/src/frontend/src/pages/protection/components/BackupConfigDetailPanel.vue
+++ b/src/frontend/src/pages/protection/components/BackupConfigDetailPanel.vue
@@ -53,20 +53,39 @@ watch(
 </script>
 
 <template>
-  <div v-if="loading" class="p-4" aria-busy="true">
-    <el-skeleton :rows="7" animated />
+  <div
+    v-if="loading"
+    class="p-4"
+    aria-busy="true"
+  >
+    <el-skeleton
+      :rows="7"
+      animated
+    />
   </div>
 
-  <div v-else-if="realConfig" class="backup-config-detail-panel">
-    <el-descriptions :column="1" border size="default" class="backup-config-detail-panel__desc">
-      <el-descriptions-item :label="t('protection.backupDetail.labelName')">{{ realConfig.name }}</el-descriptions-item>
+  <div
+    v-else-if="realConfig"
+    class="backup-config-detail-panel"
+  >
+    <el-descriptions
+      :column="1"
+      border
+      size="default"
+      class="backup-config-detail-panel__desc"
+    >
+      <el-descriptions-item :label="t('protection.backupDetail.labelName')">
+        {{ realConfig.name }}
+      </el-descriptions-item>
       <el-descriptions-item :label="t('protection.backupDetail.labelRemark')">
         <span :class="{ 'hfl-empty-mark': !realConfig.remark }">{{ realConfig.remark || t('protection.backupDetail.durationDash') }}</span>
       </el-descriptions-item>
       <el-descriptions-item :label="t('protection.backupDetail.labelSources')">
         {{ realConfig.source_type }}:{{ realConfig.source_ref_id }}
       </el-descriptions-item>
-      <el-descriptions-item :label="t('protection.backupDetail.labelTarget')">#{{ realConfig.repository_id }}</el-descriptions-item>
+      <el-descriptions-item :label="t('protection.backupDetail.labelTarget')">
+        #{{ realConfig.repository_id }}
+      </el-descriptions-item>
       <el-descriptions-item :label="t('protection.backupDetail.labelPolicyName')">
         {{ realConfig.backup_policy_id ? `#${realConfig.backup_policy_id}` : t('protection.backupDetail.noPolicy') }}
       </el-descriptions-item>
@@ -89,19 +108,37 @@ watch(
         size="small"
         class="hfl-list-table"
       >
-        <el-table-column :label="t('protection.backupDetail.colBackupDir')" min-width="260" prop="path">
+        <el-table-column
+          :label="t('protection.backupDetail.colBackupDir')"
+          min-width="260"
+          prop="path"
+        >
           <template #default="{ row }">
             <span class="hfl-table-cell-mono">{{ row.path }}</span>
           </template>
         </el-table-column>
-        <el-table-column :label="t('protection.backupDetail.colSnapSize')" width="130" prop="estimated_size_bytes" />
+        <el-table-column
+          :label="t('protection.backupDetail.colSnapSize')"
+          width="130"
+          prop="estimated_size_bytes"
+        />
       </el-table>
     </div>
   </div>
 
-  <div v-else-if="backup" class="backup-config-detail-panel">
-    <el-descriptions :column="1" border size="default" class="backup-config-detail-panel__desc">
-      <el-descriptions-item :label="t('protection.backupDetail.labelName')">{{ backup.name }}</el-descriptions-item>
+  <div
+    v-else-if="backup"
+    class="backup-config-detail-panel"
+  >
+    <el-descriptions
+      :column="1"
+      border
+      size="default"
+      class="backup-config-detail-panel__desc"
+    >
+      <el-descriptions-item :label="t('protection.backupDetail.labelName')">
+        {{ backup.name }}
+      </el-descriptions-item>
       <el-descriptions-item :label="t('protection.backupDetail.labelRemark')">
         <span :class="{ 'hfl-empty-mark': !backup.remark }">{{ backup.remark || t('protection.backupDetail.durationDash') }}</span>
       </el-descriptions-item>
@@ -118,7 +155,9 @@ watch(
             :key="i"
             class="border border-slate-100 rounded-md px-3 py-2 bg-[var(--color-grey-1,#f8fafc)]"
           >
-            <div class="text-sm font-medium text-slate-800">{{ s.path }}</div>
+            <div class="text-sm font-medium text-slate-800">
+              {{ s.path }}
+            </div>
             <div class="text-xs text-slate-500 mt-1">
               {{
                 t('protection.backupDetail.hostLine', {
@@ -135,8 +174,13 @@ watch(
         <span class="text-slate-400 text-sm ml-2">{{ store.getTarget(backup.targetId)?.location }}</span>
       </el-descriptions-item>
       <el-descriptions-item :label="t('protection.backupDetail.labelPolicyName')">
-        <template v-if="policy">{{ policy.name }}</template>
-        <span v-else class="text-slate-400">{{ t('protection.backupDetail.noPolicy') }}</span>
+        <template v-if="policy">
+          {{ policy.name }}
+        </template>
+        <span
+          v-else
+          class="text-slate-400"
+        >{{ t('protection.backupDetail.noPolicy') }}</span>
       </el-descriptions-item>
       <template v-if="policy">
         <el-descriptions-item :label="t('protection.backupDetail.labelFreq')">
@@ -153,10 +197,18 @@ watch(
         {{ compressionLevelLabel(backup.compressionLevel ?? 'balanced') }}
       </el-descriptions-item>
       <el-descriptions-item :label="t('protection.backupDetail.labelGlobalFilterName')">
-        <template v-if="globalFilter">{{ globalFilter.name }}</template>
-        <span v-else class="text-slate-400">{{ t('protection.backupDetail.noGlobalFilter') }}</span>
+        <template v-if="globalFilter">
+          {{ globalFilter.name }}
+        </template>
+        <span
+          v-else
+          class="text-slate-400"
+        >{{ t('protection.backupDetail.noGlobalFilter') }}</span>
       </el-descriptions-item>
-      <el-descriptions-item v-if="globalFilter" :label="t('protection.backupDetail.labelGlobalFilterSummary')">
+      <el-descriptions-item
+        v-if="globalFilter"
+        :label="t('protection.backupDetail.labelGlobalFilterSummary')"
+      >
         {{ globalFilter.summary }}
       </el-descriptions-item>
     </el-descriptions>
@@ -166,7 +218,11 @@ watch(
     </p>
   </div>
 
-  <el-empty v-else :description="t('protection.backupDetail.notFound')" :image-size="72" />
+  <el-empty
+    v-else
+    :description="t('protection.backupDetail.notFound')"
+    :image-size="72"
+  />
 </template>
 
 <style scoped>

--- a/src/frontend/src/pages/protection/components/BackupSourceHistorySection.vue
+++ b/src/frontend/src/pages/protection/components/BackupSourceHistorySection.vue
@@ -205,8 +205,8 @@ onBeforeUnmount(() => {
   <div class="backup-source-history-section">
     <div v-if="mode === 'snapshots'">
       <el-table
-        v-table-overflow-title
         ref="snapshotTableRef"
+        v-table-overflow-title
         :data="snapshotRows"
         stripe
         :row-key="snapshotRowKey"
@@ -221,7 +221,10 @@ onBeforeUnmount(() => {
           min-width="140"
           prop="backupName"
         />
-        <el-table-column :label="t('protection.backupDetail.colSnapStart')" min-width="200">
+        <el-table-column
+          :label="t('protection.backupDetail.colSnapStart')"
+          min-width="200"
+        >
           <template #default="{ row }">
             <button
               type="button"
@@ -232,9 +235,15 @@ onBeforeUnmount(() => {
             </button>
           </template>
         </el-table-column>
-        <el-table-column :label="t('protection.backupDetail.colSnapEnd')" min-width="200">
+        <el-table-column
+          :label="t('protection.backupDetail.colSnapEnd')"
+          min-width="200"
+        >
           <template #default="{ row }">
-            <span class="hfl-table-cell-time" :class="{ 'hfl-empty-mark': !row.snapshot.endTime }">{{ formatDate(row.snapshot.endTime) }}</span>
+            <span
+              class="hfl-table-cell-time"
+              :class="{ 'hfl-empty-mark': !row.snapshot.endTime }"
+            >{{ formatDate(row.snapshot.endTime) }}</span>
           </template>
         </el-table-column>
         <el-table-column
@@ -242,36 +251,66 @@ onBeforeUnmount(() => {
           width="110"
           align="right"
         >
-          <template #default="{ row }">{{ fmtBackupBytes(row.snapshot.sizeBytes) }}</template>
+          <template #default="{ row }">
+            {{ fmtBackupBytes(row.snapshot.sizeBytes) }}
+          </template>
         </el-table-column>
-        <el-table-column :label="t('protection.backupDetail.colSnapId')" min-width="200">
+        <el-table-column
+          :label="t('protection.backupDetail.colSnapId')"
+          min-width="200"
+        >
           <template #default="{ row }">
             <span class="hfl-table-cell-mono">{{ row.snapshot.id }}</span>
           </template>
         </el-table-column>
-        <el-table-column :label="t('protection.backupDetail.colFileCount')" width="90" align="right">
-          <template #default="{ row }">{{ row.snapshot.fileCount }}</template>
-        </el-table-column>
-        <el-table-column :label="t('protection.backupDetail.colDirCount')" width="90" align="right">
-          <template #default="{ row }">{{ row.snapshot.dirCount }}</template>
-        </el-table-column>
-        <el-table-column :label="t('protection.backupDetail.colActions')" width="100" fixed="right" align="right">
+        <el-table-column
+          :label="t('protection.backupDetail.colFileCount')"
+          width="90"
+          align="right"
+        >
           <template #default="{ row }">
-            <ElButton link type="danger" size="small" @click.stop="onDeleteSnapshot(row)">
+            {{ row.snapshot.fileCount }}
+          </template>
+        </el-table-column>
+        <el-table-column
+          :label="t('protection.backupDetail.colDirCount')"
+          width="90"
+          align="right"
+        >
+          <template #default="{ row }">
+            {{ row.snapshot.dirCount }}
+          </template>
+        </el-table-column>
+        <el-table-column
+          :label="t('protection.backupDetail.colActions')"
+          width="100"
+          fixed="right"
+          align="right"
+        >
+          <template #default="{ row }">
+            <ElButton
+              link
+              type="danger"
+              size="small"
+              @click.stop="onDeleteSnapshot(row)"
+            >
               {{ t('protection.backupDetail.btnDeleteSnapshot') }}
             </ElButton>
           </template>
         </el-table-column>
         <template #empty>
-          <el-empty :description="t('protection.backupDetail.emptySnapshots')" :image-size="64" />
+          <el-empty
+            :description="t('protection.backupDetail.emptySnapshots')"
+            :image-size="64"
+          />
         </template>
       </el-table>
     </div>
 
     <div v-else>
       <el-table
-        v-table-overflow-title
         ref="taskTableRef"
+        v-table-overflow-title
         :data="taskRows"
         stripe
         :row-key="taskRowKey"
@@ -285,7 +324,10 @@ onBeforeUnmount(() => {
           min-width="130"
           prop="backupName"
         />
-        <el-table-column :label="t('protection.backupDetail.colTaskId')" min-width="220">
+        <el-table-column
+          :label="t('protection.backupDetail.colTaskId')"
+          min-width="220"
+        >
           <template #default="{ row }">
             <button
               type="button"
@@ -296,24 +338,53 @@ onBeforeUnmount(() => {
             </button>
           </template>
         </el-table-column>
-        <el-table-column :label="t('protection.backupDetail.colTaskType')" width="120" prop="type" />
-        <el-table-column :label="t('protection.backupDetail.colTaskStatus')" width="96">
+        <el-table-column
+          :label="t('protection.backupDetail.colTaskType')"
+          width="120"
+          prop="type"
+        />
+        <el-table-column
+          :label="t('protection.backupDetail.colTaskStatus')"
+          width="96"
+        >
           <template #default="{ row }">
             <TaskStatusTag :status="row.status" />
           </template>
         </el-table-column>
-        <el-table-column :label="t('protection.backupDetail.colStart')" min-width="170" prop="startTime">
+        <el-table-column
+          :label="t('protection.backupDetail.colStart')"
+          min-width="170"
+          prop="startTime"
+        >
           <template #default="{ row }">
-            <span class="hfl-table-cell-time" :class="{ 'hfl-empty-mark': !row.startTime }">{{ formatDate(row.startTime) }}</span>
+            <span
+              class="hfl-table-cell-time"
+              :class="{ 'hfl-empty-mark': !row.startTime }"
+            >{{ formatDate(row.startTime) }}</span>
           </template>
         </el-table-column>
-        <el-table-column :label="t('protection.backupDetail.colEnd')" min-width="170" prop="endTime">
+        <el-table-column
+          :label="t('protection.backupDetail.colEnd')"
+          min-width="170"
+          prop="endTime"
+        >
           <template #default="{ row }">
-            <span class="hfl-table-cell-time" :class="{ 'hfl-empty-mark': !row.endTime }">{{ formatDate(row.endTime) }}</span>
+            <span
+              class="hfl-table-cell-time"
+              :class="{ 'hfl-empty-mark': !row.endTime }"
+            >{{ formatDate(row.endTime) }}</span>
           </template>
         </el-table-column>
-        <el-table-column :label="t('protection.backupDetail.colDuration')" width="100" prop="duration" />
-        <el-table-column :label="t('protection.backupDetail.colTrigger')" width="100" prop="trigger" />
+        <el-table-column
+          :label="t('protection.backupDetail.colDuration')"
+          width="100"
+          prop="duration"
+        />
+        <el-table-column
+          :label="t('protection.backupDetail.colTrigger')"
+          width="100"
+          prop="trigger"
+        />
         <el-table-column
           :label="t('protection.backupDetail.colLinkedSnap')"
           min-width="120"
@@ -324,7 +395,10 @@ onBeforeUnmount(() => {
           </template>
         </el-table-column>
         <template #empty>
-          <el-empty :description="t('protection.backupDetail.emptyTasks')" :image-size="64" />
+          <el-empty
+            :description="t('protection.backupDetail.emptyTasks')"
+            :image-size="64"
+          />
         </template>
       </el-table>
     </div>
@@ -345,11 +419,17 @@ onBeforeUnmount(() => {
         <span class="snapshot-drawer-title">
           {{ t('protection.backupDetail.drawerSnapTitle', { id: activeSnapshot?.id || '' }) }}
         </span>
-        <span v-if="activeSnapshotRow && showBackupName" class="ml-2 text-sm font-normal text-slate-500">
+        <span
+          v-if="activeSnapshotRow && showBackupName"
+          class="ml-2 text-sm font-normal text-slate-500"
+        >
           · {{ activeSnapshotRow.backupName }}
         </span>
       </template>
-      <div v-if="activeSnapshot" class="snapshot-drawer-body">
+      <div
+        v-if="activeSnapshot"
+        class="snapshot-drawer-body"
+      >
         <p class="text-sm text-slate-500 m-0 mb-3">
           {{
             t('protection.backupDetail.snapMetaLine', {
@@ -373,7 +453,10 @@ onBeforeUnmount(() => {
             :header-cell-style="TABLE_HEADER_STYLE"
             class="hfl-list-table"
           >
-            <el-table-column :label="t('protection.backupDetail.colBackupDir')" min-width="260">
+            <el-table-column
+              :label="t('protection.backupDetail.colBackupDir')"
+              min-width="260"
+            >
               <template #default="{ row }">
                 <button
                   type="button"
@@ -390,7 +473,10 @@ onBeforeUnmount(() => {
                     <span class="backup-source-history-dir-link__path hfl-table-cell-mono">{{ row.path }}</span>
                   </span>
                   <span class="backup-source-history-dir-link__child">
-                    <span class="backup-source-history-dir-link__branch" aria-hidden="true" />
+                    <span
+                      class="backup-source-history-dir-link__branch"
+                      aria-hidden="true"
+                    />
                     <span class="backup-source-history-dir-link__host">
                       {{
                         t('protection.backupDetail.hostSubline', {
@@ -403,13 +489,32 @@ onBeforeUnmount(() => {
                 </button>
               </template>
             </el-table-column>
-            <el-table-column :label="t('protection.backupDetail.colDirSize')" width="110" align="right">
-              <template #default="{ row }">{{ fmtBackupBytes(row.sizeBytes) }}</template>
+            <el-table-column
+              :label="t('protection.backupDetail.colDirSize')"
+              width="110"
+              align="right"
+            >
+              <template #default="{ row }">
+                {{ fmtBackupBytes(row.sizeBytes) }}
+              </template>
             </el-table-column>
-            <el-table-column :label="t('protection.backupDetail.colFileCountDirs')" width="100" prop="fileCount" align="right" />
-            <el-table-column :label="t('protection.backupDetail.colInnerDirs')" width="110" prop="innerDirCount" align="right" />
+            <el-table-column
+              :label="t('protection.backupDetail.colFileCountDirs')"
+              width="100"
+              prop="fileCount"
+              align="right"
+            />
+            <el-table-column
+              :label="t('protection.backupDetail.colInnerDirs')"
+              width="110"
+              prop="innerDirCount"
+              align="right"
+            />
             <template #empty>
-              <el-empty :description="t('protection.backupDetail.emptyDirs')" :image-size="64" />
+              <el-empty
+                :description="t('protection.backupDetail.emptyDirs')"
+                :image-size="64"
+              />
             </template>
           </el-table>
         </div>
@@ -432,29 +537,58 @@ onBeforeUnmount(() => {
         <span class="snapshot-drawer-title">
           {{ t('protection.backupDetail.drawerTaskTitle', { id: activeTask?.id || '' }) }}
         </span>
-        <span v-if="activeTask && showBackupName" class="ml-2 text-sm font-normal text-slate-500">
+        <span
+          v-if="activeTask && showBackupName"
+          class="ml-2 text-sm font-normal text-slate-500"
+        >
           · {{ activeTask.backupName }}
         </span>
       </template>
-      <div v-if="activeTask" ref="drawerScrollAnchorRef" class="snapshot-drawer-body">
-        <el-descriptions :column="1" border>
-          <el-descriptions-item :label="t('protection.backupDetail.labelTaskId')">{{ activeTask.id }}</el-descriptions-item>
-          <el-descriptions-item v-if="showBackupName" :label="t('protection.backupDetail.labelName')">
+      <div
+        v-if="activeTask"
+        ref="drawerScrollAnchorRef"
+        class="snapshot-drawer-body"
+      >
+        <el-descriptions
+          :column="1"
+          border
+        >
+          <el-descriptions-item :label="t('protection.backupDetail.labelTaskId')">
+            {{ activeTask.id }}
+          </el-descriptions-item>
+          <el-descriptions-item
+            v-if="showBackupName"
+            :label="t('protection.backupDetail.labelName')"
+          >
             {{ activeTask.backupName }}
           </el-descriptions-item>
-          <el-descriptions-item :label="t('protection.backupDetail.labelTaskType')">{{ activeTask.type }}</el-descriptions-item>
+          <el-descriptions-item :label="t('protection.backupDetail.labelTaskType')">
+            {{ activeTask.type }}
+          </el-descriptions-item>
           <el-descriptions-item :label="t('protection.backupDetail.labelStatus')">
             <TaskStatusTag :status="activeTask.status" />
           </el-descriptions-item>
-          <el-descriptions-item :label="t('protection.backupDetail.labelStart')">{{ activeTask.startTime }}</el-descriptions-item>
-          <el-descriptions-item :label="t('protection.backupDetail.labelEnd')">{{ activeTask.endTime }}</el-descriptions-item>
-          <el-descriptions-item :label="t('protection.backupDetail.labelDuration')">{{ activeTask.duration }}</el-descriptions-item>
-          <el-descriptions-item :label="t('protection.backupDetail.labelTrigger')">{{ activeTask.trigger }}</el-descriptions-item>
-          <el-descriptions-item :label="t('protection.backupDetail.labelExecutor')">{{ activeTask.executor }}</el-descriptions-item>
+          <el-descriptions-item :label="t('protection.backupDetail.labelStart')">
+            {{ activeTask.startTime }}
+          </el-descriptions-item>
+          <el-descriptions-item :label="t('protection.backupDetail.labelEnd')">
+            {{ activeTask.endTime }}
+          </el-descriptions-item>
+          <el-descriptions-item :label="t('protection.backupDetail.labelDuration')">
+            {{ activeTask.duration }}
+          </el-descriptions-item>
+          <el-descriptions-item :label="t('protection.backupDetail.labelTrigger')">
+            {{ activeTask.trigger }}
+          </el-descriptions-item>
+          <el-descriptions-item :label="t('protection.backupDetail.labelExecutor')">
+            {{ activeTask.executor }}
+          </el-descriptions-item>
           <el-descriptions-item :label="t('protection.backupDetail.labelLinkedSnap')">
             {{ activeTask.snapshotId ?? t('protection.backupDetail.noLinkedSnap') }}
           </el-descriptions-item>
-          <el-descriptions-item :label="t('protection.backupDetail.labelDetail')">{{ activeTask.detail }}</el-descriptions-item>
+          <el-descriptions-item :label="t('protection.backupDetail.labelDetail')">
+            {{ activeTask.detail }}
+          </el-descriptions-item>
         </el-descriptions>
       </div>
     </ElDrawer>
@@ -484,14 +618,25 @@ onBeforeUnmount(() => {
               :class="data.type === 'dir' ? '' : 'text-slate-500'"
             />
             <span class="hfl-dir-tree-node__text">
-              <span class="hfl-dir-tree-node__label" :title="node.label">{{ node.label }}</span>
-              <span v-if="data.type === 'dir'" class="hfl-dir-tree-node__path">{{ t('protection.backupDetail.typeDir') }}</span>
-              <span v-else class="hfl-dir-tree-node__path">{{ t('protection.backupDetail.typeFile') }}</span>
+              <span
+                class="hfl-dir-tree-node__label"
+                :title="node.label"
+              >{{ node.label }}</span>
+              <span
+                v-if="data.type === 'dir'"
+                class="hfl-dir-tree-node__path"
+              >{{ t('protection.backupDetail.typeDir') }}</span>
+              <span
+                v-else
+                class="hfl-dir-tree-node__path"
+              >{{ t('protection.backupDetail.typeFile') }}</span>
             </span>
           </span>
         </template>
       </el-tree>
-      <p class="text-xs text-slate-400 mt-4">{{ t('protection.backupDetail.treeDemoHint') }}</p>
+      <p class="text-xs text-slate-400 mt-4">
+        {{ t('protection.backupDetail.treeDemoHint') }}
+      </p>
     </ElDrawer>
     <DangerConfirmDialog
       v-model="deleteSnapshotDialogOpen"

--- a/src/frontend/src/pages/protection/components/FileFilterDetailBasicPanel.vue
+++ b/src/frontend/src/pages/protection/components/FileFilterDetailBasicPanel.vue
@@ -102,23 +102,55 @@ watch(
 </script>
 
 <template>
-  <div v-loading="loading" class="policy-detail-basic-panel policy-detail-overview">
+  <div
+    v-loading="loading"
+    class="policy-detail-basic-panel policy-detail-overview"
+  >
     <section class="hfl-detail-section">
-      <h4 class="hfl-detail-section__title">{{ t('protection.policiesPage.sectionFileFilterInfo') }}</h4>
+      <h4 class="hfl-detail-section__title">
+        {{ t('protection.policiesPage.sectionFileFilterInfo') }}
+      </h4>
       <div class="hfl-detail-grid">
         <div class="hfl-detail-row">
           <span class="hfl-detail-row__label">{{ t('protection.policiesPage.fieldName') }}</span>
           <span class="hfl-detail-row__value hfl-detail-row__value--editable">
             <template v-if="editingField === 'name'">
-              <ElInput v-model="inlineDraft" size="small" class="hfl-detail-inline-edit__input" :disabled="saving" @keyup.enter="saveInlineEdit" />
+              <ElInput
+                v-model="inlineDraft"
+                size="small"
+                class="hfl-detail-inline-edit__input"
+                :disabled="saving"
+                @keyup.enter="saveInlineEdit"
+              />
               <span class="hfl-detail-inline-edit__actions">
-                <ElButton text circle size="small" :title="t('common.save')" :disabled="saving" @click="saveInlineEdit"><Check :size="14" /></ElButton>
-                <ElButton text circle size="small" :title="t('common.cancel')" :disabled="saving" @click="cancelInlineEdit"><X :size="14" /></ElButton>
+                <ElButton
+                  text
+                  circle
+                  size="small"
+                  :title="t('common.save')"
+                  :disabled="saving"
+                  @click="saveInlineEdit"
+                ><Check :size="14" /></ElButton>
+                <ElButton
+                  text
+                  circle
+                  size="small"
+                  :title="t('common.cancel')"
+                  :disabled="saving"
+                  @click="cancelInlineEdit"
+                ><X :size="14" /></ElButton>
               </span>
             </template>
             <template v-else>
               <span class="hfl-detail-row__text">{{ filterForm.name || t('protection.policiesPage.timeDash') }}</span>
-              <ElButton text circle size="small" class="hfl-detail-row__edit" :title="t('common.edit')" @click="beginInlineEdit('name')">
+              <ElButton
+                text
+                circle
+                size="small"
+                class="hfl-detail-row__edit"
+                :title="t('common.edit')"
+                @click="beginInlineEdit('name')"
+              >
                 <Pencil :size="13" />
               </ElButton>
             </template>
@@ -128,10 +160,27 @@ watch(
           <span class="hfl-detail-row__label">{{ t('protection.policiesPage.fieldStatus') }}</span>
           <span class="hfl-detail-row__value hfl-detail-row__value--editable">
             <template v-if="editingField === 'active'">
-              <ElSwitch v-model="inlineDraft" :disabled="saving" />
+              <ElSwitch
+                v-model="inlineDraft"
+                :disabled="saving"
+              />
               <span class="hfl-detail-inline-edit__actions">
-                <ElButton text circle size="small" :title="t('common.save')" :disabled="saving" @click="saveInlineEdit"><Check :size="14" /></ElButton>
-                <ElButton text circle size="small" :title="t('common.cancel')" :disabled="saving" @click="cancelInlineEdit"><X :size="14" /></ElButton>
+                <ElButton
+                  text
+                  circle
+                  size="small"
+                  :title="t('common.save')"
+                  :disabled="saving"
+                  @click="saveInlineEdit"
+                ><Check :size="14" /></ElButton>
+                <ElButton
+                  text
+                  circle
+                  size="small"
+                  :title="t('common.cancel')"
+                  :disabled="saving"
+                  @click="cancelInlineEdit"
+                ><X :size="14" /></ElButton>
               </span>
             </template>
             <template v-else>
@@ -139,7 +188,14 @@ watch(
                 :value="filterForm.policyActive"
                 :label="filterForm.policyActive ? t('protection.policiesPage.switchEnabledOn') : t('protection.policiesPage.switchEnabledOff')"
               />
-              <ElButton text circle size="small" class="hfl-detail-row__edit" :title="t('common.edit')" @click="beginInlineEdit('active')">
+              <ElButton
+                text
+                circle
+                size="small"
+                class="hfl-detail-row__edit"
+                :title="t('common.edit')"
+                @click="beginInlineEdit('active')"
+              >
                 <Pencil :size="13" />
               </ElButton>
             </template>

--- a/src/frontend/src/pages/protection/components/FileFilterDetailEditorForm.vue
+++ b/src/frontend/src/pages/protection/components/FileFilterDetailEditorForm.vue
@@ -92,15 +92,24 @@ function enabledText(enabled: boolean) {
 
 <template>
   <div class="hfl-detail-sections policy-detail-overview policy-detail-overview--filter filter-rule-form">
-    <section v-if="!hideInfoSection" class="hfl-detail-section">
-      <h4 class="hfl-detail-section__title">{{ t('protection.policiesPage.sectionFileFilterInfo') }}</h4>
+    <section
+      v-if="!hideInfoSection"
+      class="hfl-detail-section"
+    >
+      <h4 class="hfl-detail-section__title">
+        {{ t('protection.policiesPage.sectionFileFilterInfo') }}
+      </h4>
       <div class="hfl-detail-grid">
         <div class="policy-detail-editor__pair-row">
           <div class="hfl-detail-row policy-detail-editor__pair-item">
             <span class="hfl-detail-row__label">{{ t('protection.policiesPage.fieldName') }}</span>
             <span class="hfl-detail-row__value policy-detail-overview__name-value">
               <span class="hfl-detail-row__text policy-detail-overview__primary">{{ filterForm.name || emptyText }}</span>
-              <ElTag :type="booleanStatusTag(filterForm.policyActive).type" :class="booleanStatusTag(filterForm.policyActive).class" size="small">{{ enabledText(filterForm.policyActive) }}</ElTag>
+              <ElTag
+                :type="booleanStatusTag(filterForm.policyActive).type"
+                :class="booleanStatusTag(filterForm.policyActive).class"
+                size="small"
+              >{{ enabledText(filterForm.policyActive) }}</ElTag>
             </span>
           </div>
           <div class="hfl-detail-row policy-detail-editor__pair-item">
@@ -124,7 +133,9 @@ function enabledText(enabled: boolean) {
     </section>
 
     <section class="hfl-detail-section">
-      <h4 class="hfl-detail-section__title">{{ t('protection.policiesPage.filterPresetSectionTitle') }}</h4>
+      <h4 class="hfl-detail-section__title">
+        {{ t('protection.policiesPage.filterPresetSectionTitle') }}
+      </h4>
       <div class="policy-detail-overview__list">
         <div
           v-for="preset in enabledFilterPresets"
@@ -136,14 +147,19 @@ function enabledText(enabled: boolean) {
             <span class="policy-detail-overview__list-desc">{{ preset.sub }}</span>
           </div>
         </div>
-        <div v-if="!enabledFilterPresets.length" class="policy-detail-overview__list-row">
+        <div
+          v-if="!enabledFilterPresets.length"
+          class="policy-detail-overview__list-row"
+        >
           <span class="policy-detail-overview__empty">{{ noneText }}</span>
         </div>
       </div>
     </section>
 
     <section class="hfl-detail-section">
-      <h4 class="hfl-detail-section__title">{{ t('protection.policiesPage.filterExcludeRulesTitle') }}</h4>
+      <h4 class="hfl-detail-section__title">
+        {{ t('protection.policiesPage.filterExcludeRulesTitle') }}
+      </h4>
       <div class="policy-detail-overview__code-list">
         <code
           v-for="(rule, index) in customExcludeRules"
@@ -152,16 +168,23 @@ function enabledText(enabled: boolean) {
         >
           {{ rule }}
         </code>
-        <span v-if="!customExcludeRules.length" class="policy-detail-overview__empty">{{ t('protection.policiesPage.filterNoExcludeRules') }}</span>
+        <span
+          v-if="!customExcludeRules.length"
+          class="policy-detail-overview__empty"
+        >{{ t('protection.policiesPage.filterNoExcludeRules') }}</span>
       </div>
     </section>
 
     <section class="hfl-detail-section">
-      <h4 class="hfl-detail-section__title">{{ t('protection.policiesPage.filterFinalPreviewTitle') }}</h4>
+      <h4 class="hfl-detail-section__title">
+        {{ t('protection.policiesPage.filterFinalPreviewTitle') }}
+      </h4>
       <div class="filter-rules-preview policy-detail-overview__rules-preview">
         <template v-if="compiledRuleLines.length">
           <div class="filter-rules-preview__group">
-            <div class="filter-rules-preview__divider">{{ t('protection.policiesPage.filterExcludeRulesTitle') }}</div>
+            <div class="filter-rules-preview__divider">
+              {{ t('protection.policiesPage.filterExcludeRulesTitle') }}
+            </div>
             <code
               v-for="(line, index) in compiledRuleLines"
               :key="`${index}-${line}`"
@@ -171,21 +194,36 @@ function enabledText(enabled: boolean) {
             </code>
           </div>
         </template>
-        <p v-else class="filter-rule-group__empty">
+        <p
+          v-else
+          class="filter-rule-group__empty"
+        >
           {{ t('protection.policiesPage.filterNoActiveRules') }}
         </p>
       </div>
     </section>
 
     <section class="hfl-detail-section">
-      <h4 class="hfl-detail-section__title">{{ t('protection.policiesPage.sectionAdvancedSettings') }}</h4>
+      <h4 class="hfl-detail-section__title">
+        {{ t('protection.policiesPage.sectionAdvancedSettings') }}
+      </h4>
       <div class="policy-detail-overview__list">
-        <div v-for="row in advancedRows" :key="row.key" class="policy-detail-overview__list-row">
+        <div
+          v-for="row in advancedRows"
+          :key="row.key"
+          class="policy-detail-overview__list-row"
+        >
           <div class="policy-detail-overview__list-copy">
             <span class="policy-detail-overview__list-title">{{ row.title }}</span>
             <span class="policy-detail-overview__list-desc">{{ row.desc }}</span>
           </div>
-          <ElTag :type="booleanStatusTag(row.enabled).type" :class="booleanStatusTag(row.enabled).class" size="small">{{ enabledText(row.enabled) }}</ElTag>
+          <ElTag
+            :type="booleanStatusTag(row.enabled).type"
+            :class="booleanStatusTag(row.enabled).class"
+            size="small"
+          >
+            {{ enabledText(row.enabled) }}
+          </ElTag>
         </div>
       </div>
     </section>

--- a/src/frontend/src/pages/protection/components/FlowBackupConfigDetailDrawer.vue
+++ b/src/frontend/src/pages/protection/components/FlowBackupConfigDetailDrawer.vue
@@ -39,10 +39,16 @@ const backupTitle = computed(() => {
     class="dp-flow-backup-config-detail-drawer"
     :show-close="true"
   >
-    <template v-if="backupId" #header>
+    <template
+      v-if="backupId"
+      #header
+    >
       <span class="truncate text-base font-semibold text-slate-900">{{ backupTitle }}</span>
     </template>
-    <BackupConfigDetailPanel v-if="backupId && drawerOpen" :backup-id="backupId" />
+    <BackupConfigDetailPanel
+      v-if="backupId && drawerOpen"
+      :backup-id="backupId"
+    />
   </el-drawer>
 </template>
 

--- a/src/frontend/src/pages/protection/components/FlowBackupSourceDetailDrawer.test.ts
+++ b/src/frontend/src/pages/protection/components/FlowBackupSourceDetailDrawer.test.ts
@@ -3,8 +3,11 @@ import { resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import { en } from '../../../locales/en'
 import { enProtectionPages } from '../../../locales/enProtectionPages'
+import { compactSourceText } from '../../../test/sourceText'
 
-const drawer = readFileSync(resolve(process.cwd(), 'src/pages/protection/components/FlowBackupSourceDetailDrawer.vue'), 'utf8')
+const drawer = compactSourceText(
+  readFileSync(resolve(process.cwd(), 'src/pages/protection/components/FlowBackupSourceDetailDrawer.vue'), 'utf8'),
+)
 
 function sourceBetween(start: string, end: string) {
   const startIndex = drawer.indexOf(start)
@@ -32,7 +35,7 @@ describe('FlowBackupSourceDetailDrawer task columns', () => {
   it('removes Current Step and keeps the remaining columns within the full-size drawer', () => {
     const tasksTab = sourceBetween(
       '<el-tab-pane :label="t(\'protection.backupDetail.tabTasks\')" name="tasks">',
-      '<ElDrawer\n    v-model="taskAdvancedFilterOpen"',
+      '<ElDrawer v-model="taskAdvancedFilterOpen"',
     )
 
     expect(tasksTab).not.toContain("t('protection.backupsPage.flowTaskColPhase')")

--- a/src/frontend/src/pages/protection/components/FlowBackupSourceDetailDrawer.vue
+++ b/src/frontend/src/pages/protection/components/FlowBackupSourceDetailDrawer.vue
@@ -2508,13 +2508,24 @@ function onClosed() {
     :z-index="3000"
     @closed="onClosed"
   >
-    <template v-if="source && aggregate" #header>
+    <template
+      v-if="source && aggregate"
+      #header
+    >
       <div class="dp-flow-source-detail-drawer__header min-w-0">
         <div class="flex flex-wrap items-center gap-2">
-          <h2 class="hfl-detail-drawer__title m-0 truncate">{{ source.name }}</h2>
-          <span class="dp-flow-type-pill shrink-0" :class="flowSourceTypeClass(source)">
+          <h2 class="hfl-detail-drawer__title m-0 truncate">
+            {{ source.name }}
+          </h2>
+          <span
+            class="dp-flow-type-pill shrink-0"
+            :class="flowSourceTypeClass(source)"
+          >
             <span class="dp-flow-type-pill__main">{{ flowSourceTypeParts(source).main }}</span>
-            <span v-if="flowSourceTypeParts(source).suffix" class="dp-flow-type-pill__suffix">
+            <span
+              v-if="flowSourceTypeParts(source).suffix"
+              class="dp-flow-type-pill__suffix"
+            >
               {{ flowSourceTypeParts(source).suffix }}
             </span>
           </span>
@@ -2534,28 +2545,45 @@ function onClosed() {
       </div>
     </template>
 
-    <div v-if="source && aggregate" class="hfl-detail-drawer__body dp-flow-source-detail-drawer__body">
-      <el-tabs v-model="activeTab" class="hfl-detail-tabs dp-flow-source-detail-tabs">
-        <el-tab-pane :label="t('protection.backupsPage.flowSourceDetailTabOverview')" name="overview">
-            <div class="hfl-detail-sections dp-flow-source-overview">
-              <el-alert
-                v-if="sourceDetailError"
-                :title="sourceDetailError"
-                type="error"
-                show-icon
-                :closable="false"
-              />
-              <template v-if="overviewSource">
+    <div
+      v-if="source && aggregate"
+      class="hfl-detail-drawer__body dp-flow-source-detail-drawer__body"
+    >
+      <el-tabs
+        v-model="activeTab"
+        class="hfl-detail-tabs dp-flow-source-detail-tabs"
+      >
+        <el-tab-pane
+          :label="t('protection.backupsPage.flowSourceDetailTabOverview')"
+          name="overview"
+        >
+          <div class="hfl-detail-sections dp-flow-source-overview">
+            <el-alert
+              v-if="sourceDetailError"
+              :title="sourceDetailError"
+              type="error"
+              show-icon
+              :closable="false"
+            />
+            <template v-if="overviewSource">
               <section class="hfl-detail-section">
-                <h4 class="hfl-detail-section__title">{{ t('protection.backupsPage.flowSourceDetailSectionMeta') }}</h4>
+                <h4 class="hfl-detail-section__title">
+                  {{ t('protection.backupsPage.flowSourceDetailSectionMeta') }}
+                </h4>
                 <div class="hfl-detail-grid">
                   <div class="hfl-detail-row">
                     <span class="hfl-detail-row__label">{{ t('protection.backupsPage.flowSourceDetailBackupSource') }}</span>
                     <span class="hfl-detail-row__value dp-flow-source-info-value">
                       <span class="dp-flow-source-info-name">{{ overviewSource.name }}</span>
-                      <span class="dp-flow-type-pill shrink-0" :class="flowSourceTypeClass(overviewSource)">
+                      <span
+                        class="dp-flow-type-pill shrink-0"
+                        :class="flowSourceTypeClass(overviewSource)"
+                      >
                         <span class="dp-flow-type-pill__main">{{ flowSourceTypeParts(overviewSource).main }}</span>
-                        <span v-if="flowSourceTypeParts(overviewSource).suffix" class="dp-flow-type-pill__suffix">
+                        <span
+                          v-if="flowSourceTypeParts(overviewSource).suffix"
+                          class="dp-flow-type-pill__suffix"
+                        >
                           {{ flowSourceTypeParts(overviewSource).suffix }}
                         </span>
                       </span>
@@ -2577,7 +2605,11 @@ function onClosed() {
                   <div class="hfl-detail-row">
                     <span class="hfl-detail-row__label">{{ t('protection.backupsPage.flowSourceDetailSourceStatus') }}</span>
                     <span class="hfl-detail-row__value">
-                      <el-tag size="small" :type="flowSourceLifecycleStatusTag(overviewSource.status)" effect="light">
+                      <el-tag
+                        size="small"
+                        :type="flowSourceLifecycleStatusTag(overviewSource.status)"
+                        effect="light"
+                      >
                         {{ flowSourceLifecycleStatusLabel(overviewSource.status) }}
                       </el-tag>
                     </span>
@@ -2603,10 +2635,15 @@ function onClosed() {
                 <h4 class="hfl-detail-section__title">
                   {{ t('protection.backupsPage.flowSourceDetailTabConfigs') }}
                 </h4>
-                <div v-if="currentSourceConfig" class="dp-flow-config-detail-list">
+                <div
+                  v-if="currentSourceConfig"
+                  class="dp-flow-config-detail-list"
+                >
                   <div class="dp-flow-config-subsections">
                     <section class="hfl-detail-section dp-flow-config-subsection">
-                      <h6 class="hfl-detail-section__title dp-flow-config-subsection__title">{{ t('protection.backupsPage.flowSourceDetailConfigSummary') }}</h6>
+                      <h6 class="hfl-detail-section__title dp-flow-config-subsection__title">
+                        {{ t('protection.backupsPage.flowSourceDetailConfigSummary') }}
+                      </h6>
                       <div class="hfl-detail-grid">
                         <div class="hfl-detail-row">
                           <span class="hfl-detail-row__label">{{ t('protection.backupsPage.flowSourceDetailColSnapshotCount') }}</span>
@@ -2633,264 +2670,278 @@ function onClosed() {
                       </div>
                     </section>
 
-                    <section class="hfl-detail-section dp-flow-config-subsection" ref="dirsSectionRef">
-                        <h6 class="hfl-detail-section__title dp-flow-config-subsection__title">{{ t('protection.backupsPage.flowBackupColBackupDirs') }}</h6>
-                        <div class="dp-flow-config-subsection__body">
-                          <div v-if="configDirectories(currentSourceConfig).length" class="dp-flow-config-paths dp-flow-config-paths--stack">
-                            <code
-                              v-for="dir in configDirectories(currentSourceConfig)"
-                              :key="`${currentSourceConfig.id}-${dir.id}`"
-                              class="flow-source-list-drawer-path dp-flow-config-path create-recovery-plan-mapping__endpoint"
-                              :class="`create-recovery-plan-mapping__endpoint--${backupConfigDirectoryKind(dir)}`"
-                            >
-                              <component
-                                :is="backupConfigDirectoryIcon(dir)"
-                                :size="14"
-                                class="dp-flow-config-path__icon create-recovery-plan-mapping__icon"
-                              />
-                              <span class="create-recovery-plan-mapping__text">{{ dir.path }}</span>
-                            </code>
-                          </div>
-                          <span v-else class="hfl-empty-mark">—</span>
-                        </div>
-                      </section>
-
-                      <section class="hfl-detail-section dp-flow-config-subsection" ref="targetsSectionRef">
-                        <h6 class="hfl-detail-section__title dp-flow-config-subsection__title">{{ t('protection.backupsPage.flowSourceDetailDisasterTarget') }}</h6>
-                        <div class="hfl-detail-grid dp-flow-config-detail-card__grid">
-                          <div class="hfl-detail-row">
-                            <span class="hfl-detail-row__label">{{ t('protection.backupsPage.flowSourceDetailTargetName') }}</span>
-                            <span class="hfl-detail-row__value">{{ configRepositoryName(currentSourceConfig) }}</span>
-                          </div>
-                          <div class="hfl-detail-row">
-                            <span class="hfl-detail-row__label">{{ t('protection.backupsPage.flowSourceDetailTargetType') }}</span>
-                            <span class="hfl-detail-row__value">
-                              <el-tag size="small" effect="plain">{{ configRepositoryType(currentSourceConfig) }}</el-tag>
-                            </span>
-                          </div>
-                          <div class="hfl-detail-row">
-                            <span class="hfl-detail-row__label">{{ t('protection.backupsPage.flowSourceDetailTargetLocation') }}</span>
-                            <span class="hfl-detail-row__value hfl-detail-row__value--mono">{{ configRepositoryLocation(currentSourceConfig) }}</span>
-                          </div>
-                        </div>
-                      </section>
-
-                      <section class="hfl-detail-section dp-flow-config-subsection">
-                        <h6 class="hfl-detail-section__title dp-flow-config-subsection__title">
-                          {{ t('protection.backupsPage.labelCompressionStrategy') }}
-                        </h6>
-                        <div class="dp-flow-config-compression">
-                          <div class="dp-flow-config-compression__summary">
+                    <section
+                      ref="dirsSectionRef"
+                      class="hfl-detail-section dp-flow-config-subsection"
+                    >
+                      <h6 class="hfl-detail-section__title dp-flow-config-subsection__title">
+                        {{ t('protection.backupsPage.flowBackupColBackupDirs') }}
+                      </h6>
+                      <div class="dp-flow-config-subsection__body">
+                        <div
+                          v-if="configDirectories(currentSourceConfig).length"
+                          class="dp-flow-config-paths dp-flow-config-paths--stack"
+                        >
+                          <code
+                            v-for="dir in configDirectories(currentSourceConfig)"
+                            :key="`${currentSourceConfig.id}-${dir.id}`"
+                            class="flow-source-list-drawer-path dp-flow-config-path create-recovery-plan-mapping__endpoint"
+                            :class="`create-recovery-plan-mapping__endpoint--${backupConfigDirectoryKind(dir)}`"
+                          >
                             <component
-                              :is="currentSourceCompression.icon"
-                              :size="15"
-                              aria-hidden="true"
-                              class="dp-flow-config-compression__icon"
-                              :class="`dp-flow-config-compression__icon--${currentSourceCompression.level}`"
+                              :is="backupConfigDirectoryIcon(dir)"
+                              :size="14"
+                              class="dp-flow-config-path__icon create-recovery-plan-mapping__icon"
                             />
-                            <strong class="dp-flow-config-compression__title">
-                              {{ currentSourceCompression.title }}
-                            </strong>
-                          </div>
-                          <p class="dp-flow-config-compression__description">
-                            {{ currentSourceCompression.description }}
-                          </p>
+                            <span class="create-recovery-plan-mapping__text">{{ dir.path }}</span>
+                          </code>
                         </div>
-                      </section>
+                        <span
+                          v-else
+                          class="hfl-empty-mark"
+                        >—</span>
+                      </div>
+                    </section>
 
-                      <section class="hfl-detail-section dp-flow-config-subsection">
-                        <h6 class="hfl-detail-section__title dp-flow-config-subsection__title">{{ t('protection.backupsPage.flowBackupColBoundBackupPolicy') }}</h6>
-                        <div v-if="currentSourcePolicy" class="hfl-detail-grid dp-flow-config-detail-card__grid">
-                          <div class="hfl-detail-row hfl-detail-row--full dp-flow-policy-overview__name-row">
-                            <span class="hfl-detail-row__label">{{ t('protection.policiesPage.fieldPolicyName') }}</span>
-                            <span class="hfl-detail-row__value dp-flow-policy-overview__name-value">
-                              <span class="dp-flow-detail-name-with-state dp-flow-policy-overview__name">
-                                <span>{{ currentSourcePolicy.name }}</span>
-                                <span :class="detailStatePillClass(currentSourcePolicy.is_active)">
-                                  {{ boolStatusLabel(currentSourcePolicy.is_active) }}
-                                </span>
+                    <section
+                      ref="targetsSectionRef"
+                      class="hfl-detail-section dp-flow-config-subsection"
+                    >
+                      <h6 class="hfl-detail-section__title dp-flow-config-subsection__title">
+                        {{ t('protection.backupsPage.flowSourceDetailDisasterTarget') }}
+                      </h6>
+                      <div class="hfl-detail-grid dp-flow-config-detail-card__grid">
+                        <div class="hfl-detail-row">
+                          <span class="hfl-detail-row__label">{{ t('protection.backupsPage.flowSourceDetailTargetName') }}</span>
+                          <span class="hfl-detail-row__value">{{ configRepositoryName(currentSourceConfig) }}</span>
+                        </div>
+                        <div class="hfl-detail-row">
+                          <span class="hfl-detail-row__label">{{ t('protection.backupsPage.flowSourceDetailTargetType') }}</span>
+                          <span class="hfl-detail-row__value">
+                            <el-tag
+                              size="small"
+                              effect="plain"
+                            >{{ configRepositoryType(currentSourceConfig) }}</el-tag>
+                          </span>
+                        </div>
+                        <div class="hfl-detail-row">
+                          <span class="hfl-detail-row__label">{{ t('protection.backupsPage.flowSourceDetailTargetLocation') }}</span>
+                          <span class="hfl-detail-row__value hfl-detail-row__value--mono">{{ configRepositoryLocation(currentSourceConfig) }}</span>
+                        </div>
+                      </div>
+                    </section>
+
+                    <section class="hfl-detail-section dp-flow-config-subsection">
+                      <h6 class="hfl-detail-section__title dp-flow-config-subsection__title">
+                        {{ t('protection.backupsPage.labelCompressionStrategy') }}
+                      </h6>
+                      <div class="dp-flow-config-compression">
+                        <div class="dp-flow-config-compression__summary">
+                          <component
+                            :is="currentSourceCompression.icon"
+                            :size="15"
+                            aria-hidden="true"
+                            class="dp-flow-config-compression__icon"
+                            :class="`dp-flow-config-compression__icon--${currentSourceCompression.level}`"
+                          />
+                          <strong class="dp-flow-config-compression__title">
+                            {{ currentSourceCompression.title }}
+                          </strong>
+                        </div>
+                        <p class="dp-flow-config-compression__description">
+                          {{ currentSourceCompression.description }}
+                        </p>
+                      </div>
+                    </section>
+
+                    <section class="hfl-detail-section dp-flow-config-subsection">
+                      <h6 class="hfl-detail-section__title dp-flow-config-subsection__title">
+                        {{ t('protection.backupsPage.flowBackupColBoundBackupPolicy') }}
+                      </h6>
+                      <div
+                        v-if="currentSourcePolicy"
+                        class="hfl-detail-grid dp-flow-config-detail-card__grid"
+                      >
+                        <div class="hfl-detail-row hfl-detail-row--full dp-flow-policy-overview__name-row">
+                          <span class="hfl-detail-row__label">{{ t('protection.policiesPage.fieldPolicyName') }}</span>
+                          <span class="hfl-detail-row__value dp-flow-policy-overview__name-value">
+                            <span class="dp-flow-detail-name-with-state dp-flow-policy-overview__name">
+                              <span>{{ currentSourcePolicy.name }}</span>
+                              <span :class="detailStatePillClass(currentSourcePolicy.is_active)">
+                                {{ boolStatusLabel(currentSourcePolicy.is_active) }}
                               </span>
                             </span>
-                          </div>
-                          <div class="hfl-detail-row hfl-detail-row--full">
-                            <span class="hfl-detail-row__label">{{ t('protection.policiesPage.appliedToBackupSourcesLabel') }}</span>
-                            <span class="hfl-detail-row__value">{{ policyUsageValue(currentSourcePolicy.related_backup_count) }}</span>
-                          </div>
-                          <div class="hfl-detail-row hfl-detail-row--full">
-                            <span class="hfl-detail-row__label">{{ t('protection.policiesPage.fieldSchedule') }}</span>
-                            <span class="hfl-detail-row__value" :class="{ 'hfl-detail-row__empty': currentSourcePolicy.schedule?.enabled && !currentSourcePolicy.schedule_summary }">{{ enabledConfigLabel(currentSourcePolicy.schedule?.enabled, currentSourcePolicy.schedule_summary) }}</span>
-                          </div>
-                          <div class="hfl-detail-row hfl-detail-row--full">
-                            <span class="hfl-detail-row__label">{{ t('protection.policiesPage.fieldRetention') }}</span>
-                            <span class="hfl-detail-row__value hfl-detail-row__value--stacked">
-                              <span class="create-policy-detail-popover__retention-box dp-flow-policy-overview__retention-box">
-                                <div class="policy-retention-detail-list">
-                                  <div
-                                    v-for="line in policyRetentionDetailLines(currentSourcePolicy)"
-                                    :key="`${line.label || ''}${line.text}`"
-                                    class="policy-retention-detail-list__line"
-                                    :class="{ 'policy-retention-detail-list__line--summary': !line.label }"
-                                  >
-                                    <span v-if="line.label" class="policy-retention-detail-list__label">{{ line.label }}</span>
-                                    <span class="policy-retention-detail-list__text">{{ line.text }}</span>
-                                  </div>
+                          </span>
+                        </div>
+                        <div class="hfl-detail-row hfl-detail-row--full">
+                          <span class="hfl-detail-row__label">{{ t('protection.policiesPage.appliedToBackupSourcesLabel') }}</span>
+                          <span class="hfl-detail-row__value">{{ policyUsageValue(currentSourcePolicy.related_backup_count) }}</span>
+                        </div>
+                        <div class="hfl-detail-row hfl-detail-row--full">
+                          <span class="hfl-detail-row__label">{{ t('protection.policiesPage.fieldSchedule') }}</span>
+                          <span
+                            class="hfl-detail-row__value"
+                            :class="{ 'hfl-detail-row__empty': currentSourcePolicy.schedule?.enabled && !currentSourcePolicy.schedule_summary }"
+                          >{{ enabledConfigLabel(currentSourcePolicy.schedule?.enabled, currentSourcePolicy.schedule_summary) }}</span>
+                        </div>
+                        <div class="hfl-detail-row hfl-detail-row--full">
+                          <span class="hfl-detail-row__label">{{ t('protection.policiesPage.fieldRetention') }}</span>
+                          <span class="hfl-detail-row__value hfl-detail-row__value--stacked">
+                            <span class="create-policy-detail-popover__retention-box dp-flow-policy-overview__retention-box">
+                              <div class="policy-retention-detail-list">
+                                <div
+                                  v-for="line in policyRetentionDetailLines(currentSourcePolicy)"
+                                  :key="`${line.label || ''}${line.text}`"
+                                  class="policy-retention-detail-list__line"
+                                  :class="{ 'policy-retention-detail-list__line--summary': !line.label }"
+                                >
+                                  <span
+                                    v-if="line.label"
+                                    class="policy-retention-detail-list__label"
+                                  >{{ line.label }}</span>
+                                  <span class="policy-retention-detail-list__text">{{ line.text }}</span>
                                 </div>
-                              </span>
-                            </span>
-                          </div>
-                        </div>
-                        <div v-else class="dp-flow-config-subsection__empty">
-                          <Unlink :size="14" />
-                          {{ t('protection.backupsPage.flowBackupColPolicyNone') }}
-                        </div>
-                      </section>
-
-                      <section class="hfl-detail-section dp-flow-config-subsection">
-                        <h6 class="hfl-detail-section__title dp-flow-config-subsection__title">{{ t('protection.backupsPage.flowBackupColBoundFileFilter') }}</h6>
-                        <div v-if="currentSourceFilter" class="hfl-detail-grid dp-flow-config-detail-card__grid">
-                          <div class="hfl-detail-row">
-                            <span class="hfl-detail-row__label">{{ t('protection.policiesPage.fieldFilterRuleName') }}</span>
-                            <span class="hfl-detail-row__value dp-flow-detail-name-with-state">
-                              <span>{{ currentSourceFilter.name }}</span>
-                              <span :class="detailStatePillClass(currentSourceFilter.is_active)">
-                                {{ boolStatusLabel(currentSourceFilter.is_active) }}
-                              </span>
-                            </span>
-                          </div>
-                          <div class="hfl-detail-row">
-                            <span class="hfl-detail-row__label">{{ t('protection.policiesPage.appliedToBackupSourcesLabel') }}</span>
-                            <span class="hfl-detail-row__value">{{ policyUsageValue(currentSourceFilter.related_backup_count) }}</span>
-                          </div>
-                          <div v-if="currentSourceFilter.large_file_limit_enabled" class="hfl-detail-row">
-                            <span class="hfl-detail-row__label">{{ t('protection.policiesPage.previewMaxSizeLimit') }}</span>
-                            <span class="hfl-detail-row__value">{{ fileFilterMaxSizeLimitValue(currentSourceFilter) }}</span>
-                          </div>
-                          <div v-if="currentSourceFilter.ignore_cache_directories" class="hfl-detail-row">
-                            <span class="hfl-detail-row__label">{{ t('protection.policiesPage.cacheTitle') }}</span>
-                            <span class="hfl-detail-row__value">
-                              <span :class="detailStatePillClass(true)">{{ boolStatusLabel(true) }}</span>
-                            </span>
-                          </div>
-                          <div v-if="currentSourceFilter.current_filesystem_only" class="hfl-detail-row">
-                            <span class="hfl-detail-row__label">{{ t('protection.policiesPage.fsOnlyTitle') }}</span>
-                            <span class="hfl-detail-row__value">
-                              <span :class="detailStatePillClass(true)">{{ boolStatusLabel(true) }}</span>
-                            </span>
-                          </div>
-                          <div class="hfl-detail-row hfl-detail-row--full">
-                            <span class="hfl-detail-row__label">{{ t('protection.policiesPage.filterRulesPreviewTitle') }}</span>
-                            <span class="hfl-detail-row__value">
-                              <div class="flow-binding-rules-preview dp-flow-detail-rules-preview">
-                                <template v-if="fileFilterCompiledRuleLines(currentSourceFilter).length">
-                                  <code
-                                    v-for="(line, index) in fileFilterCompiledRuleLines(currentSourceFilter)"
-                                    :key="`${index}-${line}`"
-                                    class="flow-binding-rules-preview__line"
-                                  >
-                                    {{ line }}
-                                  </code>
-                                </template>
-                                <p v-else class="flow-binding-rules-preview__empty">
-                                  {{ t('protection.policiesPage.filterNoActiveRules') }}
-                                </p>
                               </div>
                             </span>
-                          </div>
+                          </span>
                         </div>
-                        <div v-else class="dp-flow-config-subsection__empty">
-                          <Unlink :size="14" />
-                          {{ t('protection.backupsPage.flowBackupColPolicyNone') }}
-                        </div>
-                      </section>
+                      </div>
+                      <div
+                        v-else
+                        class="dp-flow-config-subsection__empty"
+                      >
+                        <Unlink :size="14" />
+                        {{ t('protection.backupsPage.flowBackupColPolicyNone') }}
+                      </div>
+                    </section>
 
-                      <section class="hfl-detail-section dp-flow-config-subsection">
-                        <h6 class="hfl-detail-section__title dp-flow-config-subsection__title">{{ t('protection.backupsPage.descRecoveryPlan') }}</h6>
-                        <div class="dp-flow-config-subsection__body">
-                          <div v-if="currentSourceRecoveryPlanMappings.length" class="dp-flow-restore-plan-card">
-                            <HflPopover
-                              trigger="hover"
-                              placement="top-start"
-                              :width="520"
-                              popper-class="create-recovery-plan-tooltip"
-                            >
-                              <template #reference>
-                                <div class="create-recovery-plan-cell create-recovery-plan-cell--review create-recovery-plan-cell--enabled">
-                                  <div class="create-recovery-plan-cell__status">
-                                    <span class="create-recovery-plan-cell__dot" aria-hidden="true" />
-                                    <span class="create-recovery-plan-cell__status-label">
-                                      {{ recoveryPlanStatusLabel(currentSourceRecoveryPlanMappings) }}
-                                    </span>
-                                  </div>
-                                  <div
-                                    class="create-recovery-plan-cell__policy"
-                                    :class="`create-recovery-plan-cell__policy--${recoveryPlanConflictTone(currentSourceRecoveryPlanMappings[0].plan)}`"
-                                  >
-                                    <ShieldAlert
-                                      v-if="recoveryPlanConflictTone(currentSourceRecoveryPlanMappings[0].plan) === 'overwrite'"
-                                      :size="14"
-                                      class="create-recovery-plan-cell__policy-icon"
-                                    />
-                                    <ShieldCheck v-else :size="14" class="create-recovery-plan-cell__policy-icon" />
-                                    <span class="create-recovery-plan-cell__policy-text">
-                                      {{ recoveryPlanConflictSummary(currentSourceRecoveryPlanMappings[0].plan) }}
-                                    </span>
-                                  </div>
-                                  <div class="create-recovery-plan-cell__mappings">
-                                    <div
-                                      v-for="mapping in currentSourceRecoveryPlanMappings"
-                                      :key="mapping.key"
-                                      class="create-recovery-plan-mapping"
-                                    >
-                                      <span
-                                        class="create-recovery-plan-mapping__endpoint"
-                                        :class="`create-recovery-plan-mapping__endpoint--${recoveryPlanMappingSourceKind(mapping)}`"
-                                        :title="recoveryPlanSourcePathLabel(mapping)"
-                                      >
-                                        <Camera
-                                          v-if="recoveryPlanMappingSourceKind(mapping) === 'snapshot'"
-                                          :size="14"
-                                          class="create-recovery-plan-mapping__icon"
-                                        />
-                                        <File
-                                          v-else-if="recoveryPlanMappingSourceKind(mapping) === 'file'"
-                                          :size="14"
-                                          class="create-recovery-plan-mapping__icon"
-                                        />
-                                        <Folder v-else :size="14" class="create-recovery-plan-mapping__icon" />
-                                        <span class="create-recovery-plan-mapping__text" :title="recoveryPlanSourcePathLabel(mapping)">{{ recoveryPlanSourcePathLabel(mapping) }}</span>
-                                      </span>
-                                      <span class="create-recovery-plan-mapping__arrow" aria-hidden="true">-&gt;</span>
-                                      <span
-                                        class="create-recovery-plan-mapping__endpoint create-recovery-plan-mapping__endpoint--target"
-                                        :title="recoveryPlanTargetSummary(mapping.plan)"
-                                      >
-                                        <FolderOpen :size="14" class="create-recovery-plan-mapping__icon" />
-                                        <span class="create-recovery-plan-mapping__text" :title="recoveryPlanTargetSummary(mapping.plan)">{{ recoveryPlanTargetSummary(mapping.plan) }}</span>
-                                      </span>
-                                    </div>
-                                  </div>
-                                </div>
+                    <section class="hfl-detail-section dp-flow-config-subsection">
+                      <h6 class="hfl-detail-section__title dp-flow-config-subsection__title">
+                        {{ t('protection.backupsPage.flowBackupColBoundFileFilter') }}
+                      </h6>
+                      <div
+                        v-if="currentSourceFilter"
+                        class="hfl-detail-grid dp-flow-config-detail-card__grid"
+                      >
+                        <div class="hfl-detail-row">
+                          <span class="hfl-detail-row__label">{{ t('protection.policiesPage.fieldFilterRuleName') }}</span>
+                          <span class="hfl-detail-row__value dp-flow-detail-name-with-state">
+                            <span>{{ currentSourceFilter.name }}</span>
+                            <span :class="detailStatePillClass(currentSourceFilter.is_active)">
+                              {{ boolStatusLabel(currentSourceFilter.is_active) }}
+                            </span>
+                          </span>
+                        </div>
+                        <div class="hfl-detail-row">
+                          <span class="hfl-detail-row__label">{{ t('protection.policiesPage.appliedToBackupSourcesLabel') }}</span>
+                          <span class="hfl-detail-row__value">{{ policyUsageValue(currentSourceFilter.related_backup_count) }}</span>
+                        </div>
+                        <div
+                          v-if="currentSourceFilter.large_file_limit_enabled"
+                          class="hfl-detail-row"
+                        >
+                          <span class="hfl-detail-row__label">{{ t('protection.policiesPage.previewMaxSizeLimit') }}</span>
+                          <span class="hfl-detail-row__value">{{ fileFilterMaxSizeLimitValue(currentSourceFilter) }}</span>
+                        </div>
+                        <div
+                          v-if="currentSourceFilter.ignore_cache_directories"
+                          class="hfl-detail-row"
+                        >
+                          <span class="hfl-detail-row__label">{{ t('protection.policiesPage.cacheTitle') }}</span>
+                          <span class="hfl-detail-row__value">
+                            <span :class="detailStatePillClass(true)">{{ boolStatusLabel(true) }}</span>
+                          </span>
+                        </div>
+                        <div
+                          v-if="currentSourceFilter.current_filesystem_only"
+                          class="hfl-detail-row"
+                        >
+                          <span class="hfl-detail-row__label">{{ t('protection.policiesPage.fsOnlyTitle') }}</span>
+                          <span class="hfl-detail-row__value">
+                            <span :class="detailStatePillClass(true)">{{ boolStatusLabel(true) }}</span>
+                          </span>
+                        </div>
+                        <div class="hfl-detail-row hfl-detail-row--full">
+                          <span class="hfl-detail-row__label">{{ t('protection.policiesPage.filterRulesPreviewTitle') }}</span>
+                          <span class="hfl-detail-row__value">
+                            <div class="flow-binding-rules-preview dp-flow-detail-rules-preview">
+                              <template v-if="fileFilterCompiledRuleLines(currentSourceFilter).length">
+                                <code
+                                  v-for="(line, index) in fileFilterCompiledRuleLines(currentSourceFilter)"
+                                  :key="`${index}-${line}`"
+                                  class="flow-binding-rules-preview__line"
+                                >
+                                  {{ line }}
+                                </code>
                               </template>
-                              <template #default>
-                                <div class="create-recovery-plan-tooltip__content">
-                                  <div
-                                    class="create-recovery-plan-tooltip__policy"
-                                    :class="`create-recovery-plan-tooltip__policy--${recoveryPlanConflictTone(currentSourceRecoveryPlanMappings[0].plan)}`"
-                                  >
-                                    <ShieldAlert
-                                      v-if="recoveryPlanConflictTone(currentSourceRecoveryPlanMappings[0].plan) === 'overwrite'"
-                                      :size="14"
-                                      class="create-recovery-plan-cell__policy-icon"
-                                    />
-                                    <ShieldCheck v-else :size="14" class="create-recovery-plan-cell__policy-icon" />
-                                    <span class="create-recovery-plan-cell__policy-text">
-                                      {{ recoveryPlanConflictFullLabel(currentSourceRecoveryPlanMappings[0].plan) }}
-                                    </span>
-                                  </div>
+                              <p
+                                v-else
+                                class="flow-binding-rules-preview__empty"
+                              >
+                                {{ t('protection.policiesPage.filterNoActiveRules') }}
+                              </p>
+                            </div>
+                          </span>
+                        </div>
+                      </div>
+                      <div
+                        v-else
+                        class="dp-flow-config-subsection__empty"
+                      >
+                        <Unlink :size="14" />
+                        {{ t('protection.backupsPage.flowBackupColPolicyNone') }}
+                      </div>
+                    </section>
+
+                    <section class="hfl-detail-section dp-flow-config-subsection">
+                      <h6 class="hfl-detail-section__title dp-flow-config-subsection__title">
+                        {{ t('protection.backupsPage.descRecoveryPlan') }}
+                      </h6>
+                      <div class="dp-flow-config-subsection__body">
+                        <div
+                          v-if="currentSourceRecoveryPlanMappings.length"
+                          class="dp-flow-restore-plan-card"
+                        >
+                          <HflPopover
+                            trigger="hover"
+                            placement="top-start"
+                            :width="520"
+                            popper-class="create-recovery-plan-tooltip"
+                          >
+                            <template #reference>
+                              <div class="create-recovery-plan-cell create-recovery-plan-cell--review create-recovery-plan-cell--enabled">
+                                <div class="create-recovery-plan-cell__status">
+                                  <span
+                                    class="create-recovery-plan-cell__dot"
+                                    aria-hidden="true"
+                                  />
+                                  <span class="create-recovery-plan-cell__status-label">
+                                    {{ recoveryPlanStatusLabel(currentSourceRecoveryPlanMappings) }}
+                                  </span>
+                                </div>
+                                <div
+                                  class="create-recovery-plan-cell__policy"
+                                  :class="`create-recovery-plan-cell__policy--${recoveryPlanConflictTone(currentSourceRecoveryPlanMappings[0].plan)}`"
+                                >
+                                  <ShieldAlert
+                                    v-if="recoveryPlanConflictTone(currentSourceRecoveryPlanMappings[0].plan) === 'overwrite'"
+                                    :size="14"
+                                    class="create-recovery-plan-cell__policy-icon"
+                                  />
+                                  <ShieldCheck
+                                    v-else
+                                    :size="14"
+                                    class="create-recovery-plan-cell__policy-icon"
+                                  />
+                                  <span class="create-recovery-plan-cell__policy-text">
+                                    {{ recoveryPlanConflictSummary(currentSourceRecoveryPlanMappings[0].plan) }}
+                                  </span>
+                                </div>
+                                <div class="create-recovery-plan-cell__mappings">
                                   <div
                                     v-for="mapping in currentSourceRecoveryPlanMappings"
-                                    :key="`${mapping.key}-tooltip`"
-                                    class="create-recovery-plan-tooltip__mapping create-recovery-plan-mapping"
+                                    :key="mapping.key"
+                                    class="create-recovery-plan-mapping"
                                   >
                                     <span
                                       class="create-recovery-plan-mapping__endpoint"
@@ -2907,926 +2958,1355 @@ function onClosed() {
                                         :size="14"
                                         class="create-recovery-plan-mapping__icon"
                                       />
-                                      <Folder v-else :size="14" class="create-recovery-plan-mapping__icon" />
-                                      <span class="create-recovery-plan-mapping__text" :title="recoveryPlanSourcePathLabel(mapping)">{{ recoveryPlanSourcePathLabel(mapping) }}</span>
+                                      <Folder
+                                        v-else
+                                        :size="14"
+                                        class="create-recovery-plan-mapping__icon"
+                                      />
+                                      <span
+                                        class="create-recovery-plan-mapping__text"
+                                        :title="recoveryPlanSourcePathLabel(mapping)"
+                                      >{{ recoveryPlanSourcePathLabel(mapping) }}</span>
                                     </span>
-                                    <span class="create-recovery-plan-mapping__arrow" aria-hidden="true">-&gt;</span>
+                                    <span
+                                      class="create-recovery-plan-mapping__arrow"
+                                      aria-hidden="true"
+                                    >-&gt;</span>
                                     <span
                                       class="create-recovery-plan-mapping__endpoint create-recovery-plan-mapping__endpoint--target"
                                       :title="recoveryPlanTargetSummary(mapping.plan)"
                                     >
-                                      <FolderOpen :size="14" class="create-recovery-plan-mapping__icon" />
-                                      <span class="create-recovery-plan-mapping__text" :title="recoveryPlanTargetSummary(mapping.plan)">{{ recoveryPlanTargetSummary(mapping.plan) }}</span>
+                                      <FolderOpen
+                                        :size="14"
+                                        class="create-recovery-plan-mapping__icon"
+                                      />
+                                      <span
+                                        class="create-recovery-plan-mapping__text"
+                                        :title="recoveryPlanTargetSummary(mapping.plan)"
+                                      >{{ recoveryPlanTargetSummary(mapping.plan) }}</span>
                                     </span>
                                   </div>
                                 </div>
-                              </template>
-                            </HflPopover>
-                          </div>
-                          <div v-else class="dp-flow-config-subsection__empty dp-flow-config-subsection__empty--block">
-                            <Unlink :size="14" />
-                            {{ t('protection.backupsPage.flowSourceDetailRestorePlanEmpty') }}
-                          </div>
+                              </div>
+                            </template>
+                            <template #default>
+                              <div class="create-recovery-plan-tooltip__content">
+                                <div
+                                  class="create-recovery-plan-tooltip__policy"
+                                  :class="`create-recovery-plan-tooltip__policy--${recoveryPlanConflictTone(currentSourceRecoveryPlanMappings[0].plan)}`"
+                                >
+                                  <ShieldAlert
+                                    v-if="recoveryPlanConflictTone(currentSourceRecoveryPlanMappings[0].plan) === 'overwrite'"
+                                    :size="14"
+                                    class="create-recovery-plan-cell__policy-icon"
+                                  />
+                                  <ShieldCheck
+                                    v-else
+                                    :size="14"
+                                    class="create-recovery-plan-cell__policy-icon"
+                                  />
+                                  <span class="create-recovery-plan-cell__policy-text">
+                                    {{ recoveryPlanConflictFullLabel(currentSourceRecoveryPlanMappings[0].plan) }}
+                                  </span>
+                                </div>
+                                <div
+                                  v-for="mapping in currentSourceRecoveryPlanMappings"
+                                  :key="`${mapping.key}-tooltip`"
+                                  class="create-recovery-plan-tooltip__mapping create-recovery-plan-mapping"
+                                >
+                                  <span
+                                    class="create-recovery-plan-mapping__endpoint"
+                                    :class="`create-recovery-plan-mapping__endpoint--${recoveryPlanMappingSourceKind(mapping)}`"
+                                    :title="recoveryPlanSourcePathLabel(mapping)"
+                                  >
+                                    <Camera
+                                      v-if="recoveryPlanMappingSourceKind(mapping) === 'snapshot'"
+                                      :size="14"
+                                      class="create-recovery-plan-mapping__icon"
+                                    />
+                                    <File
+                                      v-else-if="recoveryPlanMappingSourceKind(mapping) === 'file'"
+                                      :size="14"
+                                      class="create-recovery-plan-mapping__icon"
+                                    />
+                                    <Folder
+                                      v-else
+                                      :size="14"
+                                      class="create-recovery-plan-mapping__icon"
+                                    />
+                                    <span
+                                      class="create-recovery-plan-mapping__text"
+                                      :title="recoveryPlanSourcePathLabel(mapping)"
+                                    >{{ recoveryPlanSourcePathLabel(mapping) }}</span>
+                                  </span>
+                                  <span
+                                    class="create-recovery-plan-mapping__arrow"
+                                    aria-hidden="true"
+                                  >-&gt;</span>
+                                  <span
+                                    class="create-recovery-plan-mapping__endpoint create-recovery-plan-mapping__endpoint--target"
+                                    :title="recoveryPlanTargetSummary(mapping.plan)"
+                                  >
+                                    <FolderOpen
+                                      :size="14"
+                                      class="create-recovery-plan-mapping__icon"
+                                    />
+                                    <span
+                                      class="create-recovery-plan-mapping__text"
+                                      :title="recoveryPlanTargetSummary(mapping.plan)"
+                                    >{{ recoveryPlanTargetSummary(mapping.plan) }}</span>
+                                  </span>
+                                </div>
+                              </div>
+                            </template>
+                          </HflPopover>
                         </div>
-                      </section>
-                    </div>
+                        <div
+                          v-else
+                          class="dp-flow-config-subsection__empty dp-flow-config-subsection__empty--block"
+                        >
+                          <Unlink :size="14" />
+                          {{ t('protection.backupsPage.flowSourceDetailRestorePlanEmpty') }}
+                        </div>
+                      </div>
+                    </section>
+                  </div>
                 </div>
-                <el-empty v-else :description="t('protection.backupsPage.flowSourceDetailConfigsEmpty')" :image-size="72" />
+                <el-empty
+                  v-else
+                  :description="t('protection.backupsPage.flowSourceDetailConfigsEmpty')"
+                  :image-size="72"
+                />
               </section>
-              </template>
-              <div v-else-if="sourceDetailLoading" class="py-6">
-                <el-skeleton :rows="8" animated />
-              </div>
-              <el-empty
-                v-else-if="!sourceDetailError"
-                :description="t('protection.backupDetail.notFound')"
-                :image-size="72"
+            </template>
+            <div
+              v-else-if="sourceDetailLoading"
+              class="py-6"
+            >
+              <el-skeleton
+                :rows="8"
+                animated
               />
             </div>
+            <el-empty
+              v-else-if="!sourceDetailError"
+              :description="t('protection.backupDetail.notFound')"
+              :image-size="72"
+            />
+          </div>
         </el-tab-pane>
 
-        <el-tab-pane :label="t('protection.backupsPage.flowSourceDetailTabSnapshots')" name="snapshots">
-            <el-alert
-              v-if="sourceSnapshotsError"
-              :title="sourceSnapshotsError"
-              type="error"
-              show-icon
-              :closable="false"
-            />
-            <el-table
-              v-table-column-resize="'protection.flowBackupSource.snapshots'"
-              v-table-overflow-title
-              v-if="realSourceSnapshots.length || sourceSnapshotsLoading"
-              ref="snapshotTableRef"
-              v-loading="sourceSnapshotsLoading"
-              :data="pagedSourceSnapshots"
-              stripe
-              row-key="id"
-              max-height="calc(var(--app-viewport-height) - 260px)"
-              :expand-row-keys="expandedSnapshotRowKeys"
-              :header-cell-style="TABLE_HEADER_STYLE"
-              class="hfl-list-table"
-              @expand-change="onSnapshotExpandChange"
+        <el-tab-pane
+          :label="t('protection.backupsPage.flowSourceDetailTabSnapshots')"
+          name="snapshots"
+        >
+          <el-alert
+            v-if="sourceSnapshotsError"
+            :title="sourceSnapshotsError"
+            type="error"
+            show-icon
+            :closable="false"
+          />
+          <el-table
+            v-if="realSourceSnapshots.length || sourceSnapshotsLoading"
+            ref="snapshotTableRef"
+            v-table-column-resize="'protection.flowBackupSource.snapshots'"
+            v-table-overflow-title
+            v-loading="sourceSnapshotsLoading"
+            :data="pagedSourceSnapshots"
+            stripe
+            row-key="id"
+            max-height="calc(var(--app-viewport-height) - 260px)"
+            :expand-row-keys="expandedSnapshotRowKeys"
+            :header-cell-style="TABLE_HEADER_STYLE"
+            class="hfl-list-table"
+            @expand-change="onSnapshotExpandChange"
+          >
+            <el-table-column
+              type="expand"
+              width="35"
+              fixed
             >
-              <el-table-column type="expand" width="35" fixed>
-                <template #default="{ row }">
-                  <div class="snapshot-directory-expand-panel">
+              <template #default="{ row }">
+                <div class="snapshot-directory-expand-panel">
+                  <el-alert
+                    v-if="selectedSnapshotId === row.id && snapshotDetailError"
+                    :title="snapshotDetailError"
+                    type="error"
+                    show-icon
+                    :closable="false"
+                  />
+                  <div
+                    v-else-if="selectedSnapshotId === row.id && snapshotDetailLoading"
+                    class="py-6"
+                  >
+                    <el-skeleton
+                      :rows="3"
+                      animated
+                    />
+                  </div>
+                  <el-table
+                    v-else-if="selectedSnapshotId === row.id && selectedSnapshotDirectories.length"
+                    v-table-column-resize="'protection.flowBackupSource.snapshotDirectories'"
+                    v-table-overflow-title
+                    :data="selectedSnapshotDirectories"
+                    :fit="false"
+                    stripe
+                    :header-cell-style="TABLE_HEADER_STYLE"
+                    class="hfl-list-table hfl-list-table--compact snapshot-directory-table"
+                  >
+                    <el-table-column
+                      :label="t('protection.backupDetail.colBackupDir')"
+                      width="240"
+                    >
+                      <template #default="{ row: dir }">
+                        <button
+                          v-if="canBrowseSnapshotDirectory(dir)"
+                          type="button"
+                          class="hfl-table-name-link snapshot-directory-path-cell"
+                          @click.stop="openSnapshotDirectory(dir)"
+                        >
+                          <span class="snapshot-directory-path-cell__parent">
+                            <component
+                              :is="snapshotDirectoryIcon(dir)"
+                              :size="15"
+                              class="snapshot-directory-path-cell__icon"
+                              :class="`snapshot-directory-path-cell__icon--${snapshotDirectoryKind(dir)}`"
+                            />
+                            <span class="snapshot-directory-path-cell__path hfl-table-cell-mono">{{ dir.source_path }}</span>
+                          </span>
+                        </button>
+                        <span
+                          v-else
+                          class="snapshot-directory-path-cell snapshot-directory-path-cell--disabled"
+                        >
+                          <span class="snapshot-directory-path-cell__parent">
+                            <component
+                              :is="snapshotDirectoryIcon(dir)"
+                              :size="15"
+                              class="snapshot-directory-path-cell__icon"
+                              :class="`snapshot-directory-path-cell__icon--${snapshotDirectoryKind(dir)}`"
+                            />
+                            <code class="snapshot-directory-path-cell__path flow-source-list-drawer-path hfl-table-cell-mono">{{ dir.source_path }}</code>
+                          </span>
+                        </span>
+                      </template>
+                    </el-table-column>
+                    <el-table-column
+                      :label="t('protection.backupsPage.snapshotBrowserDirectorySnapshotId')"
+                      width="180"
+                    >
+                      <template #default="{ row: dir }">
+                        <span
+                          class="hfl-table-cell-mono"
+                          :class="{ 'hfl-empty-mark': !dir.kopia_snapshot_id }"
+                        >{{ dir.kopia_snapshot_id || '—' }}</span>
+                      </template>
+                    </el-table-column>
+                    <el-table-column
+                      :label="t('protection.backupDetail.colSnapSize')"
+                      width="110"
+                      align="right"
+                    >
+                      <template #default="{ row: dir }">
+                        {{ fmtBytes(dir.size_bytes) }}
+                      </template>
+                    </el-table-column>
+                    <el-table-column
+                      :label="t('protection.backupsPage.snapshotBrowserFileDirCount')"
+                      width="110"
+                      align="right"
+                    >
+                      <template #default="{ row: dir }">
+                        {{ dir.file_count }}/{{ dir.dir_count }}
+                      </template>
+                    </el-table-column>
+                    <el-table-column
+                      :label="t('protection.backupDetail.labelStatus')"
+                      width="92"
+                    >
+                      <template #default="{ row: dir }">
+                        <el-tag
+                          :type="lifecycleStatusTagAttrs(dir.status).type"
+                          :class="lifecycleStatusTagAttrs(dir.status).class"
+                          size="small"
+                        >
+                          {{ snapshotStatusLabel(dir.status) }}
+                        </el-tag>
+                      </template>
+                    </el-table-column>
+                    <el-table-column
+                      :label="t('protection.backupDetail.colError')"
+                      width="220"
+                    >
+                      <template #default="{ row: dir }">
+                        <span
+                          v-if="dir.error_message"
+                          class="snapshot-directory-error"
+                        >
+                          {{ dir.error_code ? `[${dir.error_code}] ` : '' }}{{ dir.error_message }}
+                        </span>
+                        <span
+                          v-else
+                          class="hfl-empty-mark"
+                        >{{ t('protection.backupDetail.durationDash') }}</span>
+                      </template>
+                    </el-table-column>
+                    <el-table-column
+                      :label="t('protection.sourceResources.colActions')"
+                      width="120"
+                      fixed="right"
+                      align="center"
+                      class-name="hfl-table-actions-col"
+                      header-class-name="hfl-table-actions-col"
+                    >
+                      <template #default="{ row: dir }">
+                        <div class="snapshot-point-actions">
+                          <button
+                            type="button"
+                            class="snapshot-point-actions__button snapshot-point-actions__button--browse"
+                            :title="t('protection.backupsPage.snapshotBrowserBrowse')"
+                            :disabled="!canBrowseSnapshotDirectory(dir)"
+                            @click.stop="openSnapshotDirectory(dir)"
+                          >
+                            <FolderOpen
+                              :size="14"
+                              class="snapshot-point-actions__icon"
+                              aria-hidden="true"
+                            />
+                            <span>{{ t('protection.backupsPage.snapshotBrowserBrowse') }}</span>
+                          </button>
+                        </div>
+                      </template>
+                    </el-table-column>
+                  </el-table>
+                  <el-empty
+                    v-else
+                    :description="t('protection.backupsPage.snapshotBrowserEmptyDirectories')"
+                    :image-size="56"
+                  />
+                </div>
+              </template>
+            </el-table-column>
+            <el-table-column
+              :label="t('protection.backupDetail.colSnapId')"
+              width="140"
+              fixed
+            >
+              <template #default="{ row }">
+                <button
+                  type="button"
+                  class="hfl-table-name-link hfl-table-cell-mono hfl-table-name-link--single"
+                  @click.stop="toggleSnapshot(row)"
+                >
+                  {{ row.snapshot_uid || `#${row.id}` }}
+                </button>
+              </template>
+            </el-table-column>
+            <el-table-column
+              :label="t('protection.backupDetail.colSnapStart')"
+              width="160"
+            >
+              <template #default="{ row }">
+                <span
+                  class="hfl-table-cell-time snapshot-point-time"
+                  :class="{ 'hfl-empty-mark': !(row.started_at || row.created_at) }"
+                  :title="formatNullableTime(row.started_at || row.created_at)"
+                >
+                  {{ formatNullableTime(row.started_at || row.created_at) }}
+                </span>
+              </template>
+            </el-table-column>
+            <el-table-column
+              :label="t('protection.backupDetail.colSnapEnd')"
+              width="160"
+            >
+              <template #default="{ row }">
+                <span
+                  class="hfl-table-cell-time snapshot-point-time"
+                  :class="{ 'hfl-empty-mark': !row.finished_at }"
+                  :title="formatNullableTime(row.finished_at)"
+                >
+                  {{ formatNullableTime(row.finished_at) }}
+                </span>
+              </template>
+            </el-table-column>
+            <el-table-column
+              :label="t('protection.backupDetail.colSnapSize')"
+              width="110"
+              align="right"
+            >
+              <template #default="{ row }">
+                {{ fmtBytes(snapshotDisplaySize(row)) }}
+              </template>
+            </el-table-column>
+            <el-table-column
+              :label="t('protection.backupsPage.snapshotBrowserFileDirCount')"
+              width="110"
+              align="right"
+            >
+              <template #default="{ row }">
+                {{ snapshotDisplayFileCount(row) }}/{{ snapshotDisplayDirCount(row) }}
+              </template>
+            </el-table-column>
+            <el-table-column
+              :label="t('protection.backupDetail.labelStatus')"
+              width="92"
+            >
+              <template #default="{ row }">
+                <el-tag
+                  :type="lifecycleStatusTagAttrs(row.status).type"
+                  :class="lifecycleStatusTagAttrs(row.status).class"
+                  size="small"
+                >
+                  {{ snapshotStatusLabel(row.status) }}
+                </el-tag>
+              </template>
+            </el-table-column>
+            <el-table-column
+              :label="t('protection.sourceResources.colActions')"
+              width="200"
+              fixed="right"
+              align="center"
+              class-name="hfl-table-actions-col"
+              header-class-name="hfl-table-actions-col"
+            >
+              <template #default="{ row }">
+                <div class="snapshot-point-actions">
+                  <ElTooltip
+                    :disabled="canRestoreSnapshot(row)"
+                    :content="snapshotRestoreDisabledReason(row)"
+                    placement="top"
+                  >
+                    <span class="snapshot-point-actions__tooltip-wrap">
+                      <button
+                        type="button"
+                        class="snapshot-point-actions__button snapshot-point-actions__button--restore"
+                        :title="t('protection.backupsPage.snapshotRecoverAction')"
+                        :disabled="!canRestoreSnapshot(row)"
+                        @click.stop="openSnapshotRestore(row)"
+                      >
+                        <RotateCcw
+                          :size="14"
+                          class="snapshot-point-actions__icon"
+                          aria-hidden="true"
+                        />
+                        <span>{{ t('protection.backupsPage.snapshotRecoverAction') }}</span>
+                      </button>
+                    </span>
+                  </ElTooltip>
+                  <button
+                    type="button"
+                    class="snapshot-point-actions__button snapshot-point-actions__button--browse"
+                    :title="t('protection.backupsPage.snapshotViewAction')"
+                    @click.stop="toggleSnapshot(row)"
+                  >
+                    <FolderOpen
+                      :size="14"
+                      class="snapshot-point-actions__icon"
+                      aria-hidden="true"
+                    />
+                    <span>{{ t('protection.backupsPage.snapshotViewAction') }}</span>
+                  </button>
+                </div>
+              </template>
+            </el-table-column>
+          </el-table>
+          <div
+            v-if="sourceSnapshotTotal > 0"
+            class="hfl-list-footer"
+          >
+            <HflPagination
+              v-model:current-page="snapshotPagination.page"
+              v-model:page-size="snapshotPagination.pageSize"
+              class="hfl-list-footer__pagination"
+              layout="total, sizes, prev, pager, next"
+              :total="sourceSnapshotTotal"
+              :page-sizes="DETAIL_PAGE_SIZE_OPTIONS"
+              @size-change="snapshotPagination.page = 1"
+            />
+          </div>
+          <Teleport to="body">
+            <div
+              v-if="fileBrowserDrawerOpen"
+              class="dp-snapshot-file-browser-shell"
+              @click.self="closeSnapshotFileBrowser"
+            >
+              <aside class="dp-snapshot-file-browser-panel">
+                <header class="dp-snapshot-file-browser-panel__header">
+                  <div class="min-w-0 pr-2">
+                    <div class="truncate text-base font-semibold text-slate-900">
+                      {{ t('protection.backupsPage.snapshotBrowserPreviewTitle') }}
+                    </div>
+                    <div
+                      v-if="selectedSnapshotDirectory"
+                      class="truncate text-xs text-slate-500"
+                    >
+                      {{ selectedSnapshotDirectory.source_path }}
+                    </div>
+                  </div>
+                  <button
+                    type="button"
+                    class="dp-snapshot-file-browser-panel__close"
+                    @click="closeSnapshotFileBrowser"
+                  >
+                    <X :size="18" />
+                  </button>
+                </header>
+                <div
+                  v-if="selectedSnapshotDirectory"
+                  class="dp-snapshot-file-browser dp-snapshot-file-browser-panel__body"
+                >
+                  <template v-if="selectedSnapshotDirectoryIsFile">
+                    <div class="dp-snapshot-file-browser__toolbar">
+                      <div class="dp-snapshot-file-browser__toolbar-main">
+                        <ElButton
+                          type="primary"
+                          size="small"
+                          :loading="downloadingSnapshotFile"
+                          :disabled="!selectedSnapshotFileChecked"
+                          @click="downloadSelectedSnapshotFile"
+                        >
+                          <Download
+                            :size="14"
+                            class="mr-1"
+                          />
+                          {{ t('protection.backupsPage.snapshotBrowserDownload') }}
+                        </ElButton>
+                        <div class="min-w-0">
+                          <div class="text-sm font-medium text-slate-800">
+                            {{ snapshotFileFallbackName(selectedSnapshotDirectory) }}
+                          </div>
+                          <div class="truncate text-xs text-slate-500">
+                            {{ selectedSnapshotDirectory.source_path }}
+                          </div>
+                        </div>
+                      </div>
+                      <div class="dp-snapshot-file-browser__toolbar-actions">
+                        <span class="dp-snapshot-file-browser__selected">
+                          {{ t('protection.backupsPage.snapshotBrowserSelectedCount', { n: selectedSnapshotFileCount }) }}
+                        </span>
+                        <ElButton
+                          v-if="selectedSnapshotFileChecked"
+                          size="small"
+                          @click="clearSnapshotFileSelection"
+                        >
+                          {{ t('protection.backupsPage.snapshotBrowserClearSelection') }}
+                        </ElButton>
+                      </div>
+                    </div>
+
+                    <div
+                      class="dp-snapshot-file-browser__file-row"
+                      :class="{ 'is-selected': selectedSnapshotFileChecked }"
+                      role="button"
+                      tabindex="0"
+                      @click="toggleSnapshotFileSelection"
+                      @keydown.enter.prevent="toggleSnapshotFileSelection"
+                      @keydown.space.prevent="toggleSnapshotFileSelection"
+                    >
+                      <ElCheckbox
+                        :model-value="selectedSnapshotFileChecked"
+                        @change="selectedSnapshotFileChecked = Boolean($event)"
+                        @click.stop
+                      />
+                      <span class="dp-snapshot-file-browser__entry">
+                        <File
+                          :size="15"
+                          class="snapshot-directory-path-cell__icon snapshot-directory-path-cell__icon--file"
+                        />
+                        <span class="truncate">{{ snapshotFileFallbackName(selectedSnapshotDirectory) }}</span>
+                      </span>
+                      <span class="dp-snapshot-file-browser__tree-path truncate">{{ selectedSnapshotDirectory.source_path }}</span>
+                      <span class="dp-snapshot-file-browser__tree-size">{{ fmtBytes(selectedSnapshotDirectory.size_bytes) }}</span>
+                      <span
+                        class="dp-snapshot-file-browser__tree-time"
+                        :class="{ 'hfl-empty-mark': !selectedSnapshotDirectory.created_at }"
+                      >{{ formatNullableTime(selectedSnapshotDirectory.created_at) }}</span>
+                    </div>
+                  </template>
+                  <template v-else>
+                    <div class="dp-snapshot-file-browser__toolbar">
+                      <div class="dp-snapshot-file-browser__toolbar-main">
+                        <ElButton
+                          type="primary"
+                          size="small"
+                          :loading="downloadingSelected"
+                          :disabled="!selectedBrowserPathCount"
+                          @click="downloadSelectedBrowserPaths"
+                        >
+                          <Download
+                            :size="14"
+                            class="mr-1"
+                          />
+                          {{ t('protection.backupsPage.snapshotBrowserDownload') }}
+                        </ElButton>
+                        <div class="min-w-0">
+                          <div class="text-sm font-medium text-slate-800">
+                            {{ selectedSnapshotDirectory.source_path }}
+                          </div>
+                          <div class="dp-snapshot-file-browser__crumbs">
+                            <template
+                              v-for="(crumb, index) in browserBreadcrumbs"
+                              :key="crumb.path || 'root'"
+                            >
+                              <button
+                                type="button"
+                                class="source-more-link"
+                                @click="openSnapshotDirectory(selectedSnapshotDirectory, crumb.path)"
+                              >
+                                {{ crumb.label }}
+                              </button>
+                              <span
+                                v-if="index < browserBreadcrumbs.length - 1"
+                                class="text-slate-400"
+                              >/</span>
+                            </template>
+                          </div>
+                        </div>
+                      </div>
+                      <div class="dp-snapshot-file-browser__toolbar-actions">
+                        <span class="dp-snapshot-file-browser__selected">
+                          {{ t('protection.backupsPage.snapshotBrowserSelectedCount', { n: selectedBrowserPathCount }) }}
+                        </span>
+                        <ElButton
+                          v-if="selectedBrowserPathCount"
+                          size="small"
+                          @click="clearBrowserSelection"
+                        >
+                          {{ t('protection.backupsPage.snapshotBrowserClearSelection') }}
+                        </ElButton>
+                        <ElButton
+                          v-if="browserParentPath || browserPath"
+                          size="small"
+                          @click="openSnapshotDirectory(selectedSnapshotDirectory, browserParentPath)"
+                        >
+                          <ArrowLeft
+                            :size="14"
+                            class="mr-1"
+                          />
+                          {{ t('protection.backupsPage.snapshotBrowserParent') }}
+                        </ElButton>
+                      </div>
+                    </div>
+
                     <el-alert
-                      v-if="selectedSnapshotId === row.id && snapshotDetailError"
-                      :title="snapshotDetailError"
+                      v-if="browserError"
+                      :title="browserError"
                       type="error"
                       show-icon
                       :closable="false"
                     />
-                    <div v-else-if="selectedSnapshotId === row.id && snapshotDetailLoading" class="py-6">
-                      <el-skeleton :rows="3" animated />
-                    </div>
-                    <el-table
-                      v-table-column-resize="'protection.flowBackupSource.snapshotDirectories'"
-                      v-table-overflow-title
-                      v-else-if="selectedSnapshotId === row.id && selectedSnapshotDirectories.length"
-                      :data="selectedSnapshotDirectories"
-                      :fit="false"
-                      stripe
-                      :header-cell-style="TABLE_HEADER_STYLE"
-                      class="hfl-list-table hfl-list-table--compact snapshot-directory-table"
+                    <el-tree
+                      ref="browserTreeRef"
+                      :key="`${selectedSnapshotDirectory.id}:${browserPath}:${browserTreeVersion}`"
+                      v-loading="browserLoading"
+                      node-key="id"
+                      show-checkbox
+                      check-strictly
+                      lazy
+                      :load="loadBrowserTreeNode"
+                      :props="{ children: 'children', label: 'label', disabled: 'disabled', isLeaf: 'isLeaf' }"
+                      class="dp-snapshot-file-browser__tree"
+                      empty-text=" "
+                      @check-change="onBrowserTreeCheckChange"
                     >
-                      <el-table-column :label="t('protection.backupDetail.colBackupDir')" width="240">
-                        <template #default="{ row: dir }">
-                          <button
-                            v-if="canBrowseSnapshotDirectory(dir)"
-                            type="button"
-                            class="hfl-table-name-link snapshot-directory-path-cell"
-                            @click.stop="openSnapshotDirectory(dir)"
-                          >
-                            <span class="snapshot-directory-path-cell__parent">
-                              <component
-                                :is="snapshotDirectoryIcon(dir)"
-                                :size="15"
-                                class="snapshot-directory-path-cell__icon"
-                                :class="`snapshot-directory-path-cell__icon--${snapshotDirectoryKind(dir)}`"
-                              />
-                              <span class="snapshot-directory-path-cell__path hfl-table-cell-mono">{{ dir.source_path }}</span>
-                            </span>
-                          </button>
-                          <span v-else class="snapshot-directory-path-cell snapshot-directory-path-cell--disabled">
-                            <span class="snapshot-directory-path-cell__parent">
-                              <component
-                                :is="snapshotDirectoryIcon(dir)"
-                                :size="15"
-                                class="snapshot-directory-path-cell__icon"
-                                :class="`snapshot-directory-path-cell__icon--${snapshotDirectoryKind(dir)}`"
-                              />
-                              <code class="snapshot-directory-path-cell__path flow-source-list-drawer-path hfl-table-cell-mono">{{ dir.source_path }}</code>
-                            </span>
+                      <template #default="{ data }">
+                        <div class="dp-snapshot-file-browser__tree-row">
+                          <span class="dp-snapshot-file-browser__entry">
+                            <Folder
+                              v-if="data.type === 'dir'"
+                              :size="15"
+                              class="snapshot-directory-path-cell__icon snapshot-directory-path-cell__icon--dir"
+                            />
+                            <File
+                              v-else
+                              :size="15"
+                              class="snapshot-directory-path-cell__icon snapshot-directory-path-cell__icon--file"
+                            />
+                            <span class="truncate">{{ data.name }}</span>
                           </span>
-                        </template>
-                      </el-table-column>
-                      <el-table-column :label="t('protection.backupsPage.snapshotBrowserDirectorySnapshotId')" width="180">
-                        <template #default="{ row: dir }">
-                          <span class="hfl-table-cell-mono" :class="{ 'hfl-empty-mark': !dir.kopia_snapshot_id }">{{ dir.kopia_snapshot_id || '—' }}</span>
-                        </template>
-                      </el-table-column>
-                      <el-table-column :label="t('protection.backupDetail.colSnapSize')" width="110" align="right">
-                        <template #default="{ row: dir }">{{ fmtBytes(dir.size_bytes) }}</template>
-                      </el-table-column>
-                      <el-table-column :label="t('protection.backupsPage.snapshotBrowserFileDirCount')" width="110" align="right">
-                        <template #default="{ row: dir }">{{ dir.file_count }}/{{ dir.dir_count }}</template>
-                      </el-table-column>
-                      <el-table-column :label="t('protection.backupDetail.labelStatus')" width="92">
-                        <template #default="{ row: dir }">
-                          <el-tag
-                            :type="lifecycleStatusTagAttrs(dir.status).type"
-                            :class="lifecycleStatusTagAttrs(dir.status).class"
-                            size="small"
-                          >
-                            {{ snapshotStatusLabel(dir.status) }}
-                          </el-tag>
-                        </template>
-                      </el-table-column>
-                      <el-table-column :label="t('protection.backupDetail.colError')" width="220">
-                        <template #default="{ row: dir }">
-                          <span v-if="dir.error_message" class="snapshot-directory-error">
-                            {{ dir.error_code ? `[${dir.error_code}] ` : '' }}{{ dir.error_message }}
-                          </span>
-                          <span v-else class="hfl-empty-mark">{{ t('protection.backupDetail.durationDash') }}</span>
-                        </template>
-                      </el-table-column>
-                      <el-table-column
-                        :label="t('protection.sourceResources.colActions')"
-                        width="120"
-                        fixed="right"
-                        align="center"
-                        class-name="hfl-table-actions-col"
-                        header-class-name="hfl-table-actions-col"
-                      >
-                        <template #default="{ row: dir }">
-                          <div class="snapshot-point-actions">
-                            <button
-                              type="button"
-                              class="snapshot-point-actions__button snapshot-point-actions__button--browse"
-                              :title="t('protection.backupsPage.snapshotBrowserBrowse')"
-                              :disabled="!canBrowseSnapshotDirectory(dir)"
-                              @click.stop="openSnapshotDirectory(dir)"
-                            >
-                              <FolderOpen :size="14" class="snapshot-point-actions__icon" aria-hidden="true" />
-                              <span>{{ t('protection.backupsPage.snapshotBrowserBrowse') }}</span>
-                            </button>
-                          </div>
-                        </template>
-                      </el-table-column>
-                    </el-table>
+                          <span class="dp-snapshot-file-browser__tree-path truncate">{{ data.path }}</span>
+                          <span class="dp-snapshot-file-browser__tree-size">{{ data.type === 'dir' ? '—' : fmtBytes(data.size_bytes) }}</span>
+                          <span
+                            class="dp-snapshot-file-browser__tree-time"
+                            :class="{ 'hfl-empty-mark': !data.modified_at }"
+                          >{{ formatNullableTime(data.modified_at) }}</span>
+                        </div>
+                      </template>
+                    </el-tree>
                     <el-empty
-                      v-else
-                      :description="t('protection.backupsPage.snapshotBrowserEmptyDirectories')"
-                      :image-size="56"
+                      v-if="!browserLoading && !browserError && !browserTreeEntries.length"
+                      :description="t('protection.backupsPage.snapshotBrowserEmpty')"
+                      :image-size="48"
                     />
-                  </div>
-                </template>
-              </el-table-column>
-              <el-table-column :label="t('protection.backupDetail.colSnapId')" width="140" fixed>
-                <template #default="{ row }">
-                  <button
-                    type="button"
-                    class="hfl-table-name-link hfl-table-cell-mono hfl-table-name-link--single"
-                    @click.stop="toggleSnapshot(row)"
-                  >
-                    {{ row.snapshot_uid || `#${row.id}` }}
-                  </button>
-                </template>
-              </el-table-column>
-              <el-table-column :label="t('protection.backupDetail.colSnapStart')" width="160">
-                <template #default="{ row }">
-                  <span
-                    class="hfl-table-cell-time snapshot-point-time"
-                    :class="{ 'hfl-empty-mark': !(row.started_at || row.created_at) }"
-                    :title="formatNullableTime(row.started_at || row.created_at)"
-                  >
-                    {{ formatNullableTime(row.started_at || row.created_at) }}
-                  </span>
-                </template>
-              </el-table-column>
-              <el-table-column :label="t('protection.backupDetail.colSnapEnd')" width="160">
-                <template #default="{ row }">
-                  <span
-                    class="hfl-table-cell-time snapshot-point-time"
-                    :class="{ 'hfl-empty-mark': !row.finished_at }"
-                    :title="formatNullableTime(row.finished_at)"
-                  >
-                    {{ formatNullableTime(row.finished_at) }}
-                  </span>
-                </template>
-              </el-table-column>
-              <el-table-column :label="t('protection.backupDetail.colSnapSize')" width="110" align="right">
-                <template #default="{ row }">{{ fmtBytes(snapshotDisplaySize(row)) }}</template>
-              </el-table-column>
-              <el-table-column :label="t('protection.backupsPage.snapshotBrowserFileDirCount')" width="110" align="right">
-                <template #default="{ row }">{{ snapshotDisplayFileCount(row) }}/{{ snapshotDisplayDirCount(row) }}</template>
-              </el-table-column>
-              <el-table-column :label="t('protection.backupDetail.labelStatus')" width="92">
-                <template #default="{ row }">
-                  <el-tag
-                    :type="lifecycleStatusTagAttrs(row.status).type"
-                    :class="lifecycleStatusTagAttrs(row.status).class"
-                    size="small"
-                  >
-                    {{ snapshotStatusLabel(row.status) }}
-                  </el-tag>
-                </template>
-              </el-table-column>
-              <el-table-column
-                :label="t('protection.sourceResources.colActions')"
-                width="200"
-                fixed="right"
-                align="center"
-                class-name="hfl-table-actions-col"
-                header-class-name="hfl-table-actions-col"
-              >
-                <template #default="{ row }">
-                  <div class="snapshot-point-actions">
-                    <ElTooltip
-                      :disabled="canRestoreSnapshot(row)"
-                      :content="snapshotRestoreDisabledReason(row)"
-                      placement="top"
-                    >
-                      <span class="snapshot-point-actions__tooltip-wrap">
-                        <button
-                          type="button"
-                          class="snapshot-point-actions__button snapshot-point-actions__button--restore"
-                          :title="t('protection.backupsPage.snapshotRecoverAction')"
-                          :disabled="!canRestoreSnapshot(row)"
-                          @click.stop="openSnapshotRestore(row)"
-                        >
-                          <RotateCcw :size="14" class="snapshot-point-actions__icon" aria-hidden="true" />
-                          <span>{{ t('protection.backupsPage.snapshotRecoverAction') }}</span>
-                        </button>
-                      </span>
-                    </ElTooltip>
-                    <button
-                      type="button"
-                      class="snapshot-point-actions__button snapshot-point-actions__button--browse"
-                      :title="t('protection.backupsPage.snapshotViewAction')"
-                      @click.stop="toggleSnapshot(row)"
-                    >
-                      <FolderOpen :size="14" class="snapshot-point-actions__icon" aria-hidden="true" />
-                      <span>{{ t('protection.backupsPage.snapshotViewAction') }}</span>
-                    </button>
-                  </div>
-                </template>
-              </el-table-column>
-            </el-table>
-            <div v-if="sourceSnapshotTotal > 0" class="hfl-list-footer">
-              <HflPagination
-                v-model:current-page="snapshotPagination.page"
-                v-model:page-size="snapshotPagination.pageSize"
-                class="hfl-list-footer__pagination"
-                layout="total, sizes, prev, pager, next"
-                :total="sourceSnapshotTotal"
-                :page-sizes="DETAIL_PAGE_SIZE_OPTIONS"
-                @size-change="snapshotPagination.page = 1"
-              />
-            </div>
-              <Teleport to="body">
-                <div
-                  v-if="fileBrowserDrawerOpen"
-                  class="dp-snapshot-file-browser-shell"
-                  @click.self="closeSnapshotFileBrowser"
-                >
-                  <aside class="dp-snapshot-file-browser-panel">
-                    <header class="dp-snapshot-file-browser-panel__header">
-                      <div class="min-w-0 pr-2">
-                    <div class="truncate text-base font-semibold text-slate-900">
-                      {{ t('protection.backupsPage.snapshotBrowserPreviewTitle') }}
-                    </div>
-                    <div v-if="selectedSnapshotDirectory" class="truncate text-xs text-slate-500">
-                      {{ selectedSnapshotDirectory.source_path }}
-                    </div>
-                  </div>
-                      <button type="button" class="dp-snapshot-file-browser-panel__close" @click="closeSnapshotFileBrowser">
-                        <X :size="18" />
-                      </button>
-                    </header>
-              <div v-if="selectedSnapshotDirectory" class="dp-snapshot-file-browser dp-snapshot-file-browser-panel__body">
-                <template v-if="selectedSnapshotDirectoryIsFile">
-                  <div class="dp-snapshot-file-browser__toolbar">
-                    <div class="dp-snapshot-file-browser__toolbar-main">
-                      <ElButton
-                        type="primary"
-                        size="small"
-                        :loading="downloadingSnapshotFile"
-                        :disabled="!selectedSnapshotFileChecked"
-                        @click="downloadSelectedSnapshotFile"
-                      >
-                        <Download :size="14" class="mr-1" />
-                        {{ t('protection.backupsPage.snapshotBrowserDownload') }}
-                      </ElButton>
-                      <div class="min-w-0">
-                        <div class="text-sm font-medium text-slate-800">
-                          {{ snapshotFileFallbackName(selectedSnapshotDirectory) }}
-                        </div>
-                        <div class="truncate text-xs text-slate-500">
-                          {{ selectedSnapshotDirectory.source_path }}
-                        </div>
-                      </div>
-                    </div>
-                    <div class="dp-snapshot-file-browser__toolbar-actions">
-                      <span class="dp-snapshot-file-browser__selected">
-                        {{ t('protection.backupsPage.snapshotBrowserSelectedCount', { n: selectedSnapshotFileCount }) }}
-                      </span>
-                      <ElButton
-                        v-if="selectedSnapshotFileChecked"
-                        size="small"
-                        @click="clearSnapshotFileSelection"
-                      >
-                        {{ t('protection.backupsPage.snapshotBrowserClearSelection') }}
-                      </ElButton>
-                    </div>
-                  </div>
-
-                  <div
-                    class="dp-snapshot-file-browser__file-row"
-                    :class="{ 'is-selected': selectedSnapshotFileChecked }"
-                    role="button"
-                    tabindex="0"
-                    @click="toggleSnapshotFileSelection"
-                    @keydown.enter.prevent="toggleSnapshotFileSelection"
-                    @keydown.space.prevent="toggleSnapshotFileSelection"
-                  >
-                    <ElCheckbox
-                      :model-value="selectedSnapshotFileChecked"
-                      @change="selectedSnapshotFileChecked = Boolean($event)"
-                      @click.stop
-                    />
-                    <span class="dp-snapshot-file-browser__entry">
-                      <File
-                        :size="15"
-                        class="snapshot-directory-path-cell__icon snapshot-directory-path-cell__icon--file"
-                      />
-                      <span class="truncate">{{ snapshotFileFallbackName(selectedSnapshotDirectory) }}</span>
-                    </span>
-                    <span class="dp-snapshot-file-browser__tree-path truncate">{{ selectedSnapshotDirectory.source_path }}</span>
-                    <span class="dp-snapshot-file-browser__tree-size">{{ fmtBytes(selectedSnapshotDirectory.size_bytes) }}</span>
-                    <span class="dp-snapshot-file-browser__tree-time" :class="{ 'hfl-empty-mark': !selectedSnapshotDirectory.created_at }">{{ formatNullableTime(selectedSnapshotDirectory.created_at) }}</span>
-                  </div>
-                </template>
-                <template v-else>
-                <div class="dp-snapshot-file-browser__toolbar">
-                  <div class="dp-snapshot-file-browser__toolbar-main">
-                    <ElButton
-                      type="primary"
-                      size="small"
-                      :loading="downloadingSelected"
-                      :disabled="!selectedBrowserPathCount"
-                      @click="downloadSelectedBrowserPaths"
-                    >
-                      <Download :size="14" class="mr-1" />
-                      {{ t('protection.backupsPage.snapshotBrowserDownload') }}
-                    </ElButton>
-                    <div class="min-w-0">
-                      <div class="text-sm font-medium text-slate-800">
-                        {{ selectedSnapshotDirectory.source_path }}
-                      </div>
-                      <div class="dp-snapshot-file-browser__crumbs">
-                        <template v-for="(crumb, index) in browserBreadcrumbs" :key="crumb.path || 'root'">
-                          <button type="button" class="source-more-link" @click="openSnapshotDirectory(selectedSnapshotDirectory, crumb.path)">
-                            {{ crumb.label }}
-                          </button>
-                          <span v-if="index < browserBreadcrumbs.length - 1" class="text-slate-400">/</span>
-                        </template>
-                      </div>
-                    </div>
-                  </div>
-                  <div class="dp-snapshot-file-browser__toolbar-actions">
-                    <span class="dp-snapshot-file-browser__selected">
-                      {{ t('protection.backupsPage.snapshotBrowserSelectedCount', { n: selectedBrowserPathCount }) }}
-                    </span>
-                    <ElButton
-                      v-if="selectedBrowserPathCount"
-                      size="small"
-                      @click="clearBrowserSelection"
-                    >
-                      {{ t('protection.backupsPage.snapshotBrowserClearSelection') }}
-                    </ElButton>
-                    <ElButton
-                      v-if="browserParentPath || browserPath"
-                      size="small"
-                      @click="openSnapshotDirectory(selectedSnapshotDirectory, browserParentPath)"
-                    >
-                      <ArrowLeft :size="14" class="mr-1" />
-                      {{ t('protection.backupsPage.snapshotBrowserParent') }}
-                    </ElButton>
-                  </div>
-                </div>
-
-                <el-alert
-                  v-if="browserError"
-                  :title="browserError"
-                  type="error"
-                  show-icon
-                  :closable="false"
-                />
-                <el-tree
-                  v-loading="browserLoading"
-                  ref="browserTreeRef"
-                  :key="`${selectedSnapshotDirectory.id}:${browserPath}:${browserTreeVersion}`"
-                  node-key="id"
-                  show-checkbox
-                  check-strictly
-                  lazy
-                  :load="loadBrowserTreeNode"
-                  :props="{ children: 'children', label: 'label', disabled: 'disabled', isLeaf: 'isLeaf' }"
-                  class="dp-snapshot-file-browser__tree"
-                  empty-text=" "
-                  @check-change="onBrowserTreeCheckChange"
-                >
-                  <template #default="{ data }">
-                    <div class="dp-snapshot-file-browser__tree-row">
-                      <span class="dp-snapshot-file-browser__entry">
-                        <Folder
-                          v-if="data.type === 'dir'"
-                          :size="15"
-                          class="snapshot-directory-path-cell__icon snapshot-directory-path-cell__icon--dir"
-                        />
-                        <File
-                          v-else
-                          :size="15"
-                          class="snapshot-directory-path-cell__icon snapshot-directory-path-cell__icon--file"
-                        />
-                        <span class="truncate">{{ data.name }}</span>
-                      </span>
-                      <span class="dp-snapshot-file-browser__tree-path truncate">{{ data.path }}</span>
-                      <span class="dp-snapshot-file-browser__tree-size">{{ data.type === 'dir' ? '—' : fmtBytes(data.size_bytes) }}</span>
-                      <span class="dp-snapshot-file-browser__tree-time" :class="{ 'hfl-empty-mark': !data.modified_at }">{{ formatNullableTime(data.modified_at) }}</span>
-                    </div>
                   </template>
-                </el-tree>
-                <el-empty
-                  v-if="!browserLoading && !browserError && !browserTreeEntries.length"
-                  :description="t('protection.backupsPage.snapshotBrowserEmpty')"
-                  :image-size="48"
-                />
-                </template>
-              </div>
-                  </aside>
                 </div>
-              </Teleport>
-            <el-empty
-              v-if="!sourceSnapshotsLoading && !sourceSnapshotsError && !realSourceSnapshots.length"
-              :description="t('protection.backupsPage.snapshotBrowserEmpty')"
-              :image-size="72"
-            />
+              </aside>
+            </div>
+          </Teleport>
+          <el-empty
+            v-if="!sourceSnapshotsLoading && !sourceSnapshotsError && !realSourceSnapshots.length"
+            :description="t('protection.backupsPage.snapshotBrowserEmpty')"
+            :image-size="72"
+          />
         </el-tab-pane>
 
-        <el-tab-pane :label="t('protection.backupsPage.flowSourceDetailTabRestoreRecords')" name="restoreRecords">
-            <el-alert
-              v-if="restoreRecordsError"
-              :title="t('protection.backupsPage.flowSourceDetailRestoreRecordsLoadFailed', { msg: restoreRecordsError })"
-              type="error"
-              show-icon
-              :closable="false"
-            />
-            <el-table
-              v-table-column-resize="'protection.flowBackupSource.restoreRecords'"
-              v-table-overflow-title
-              v-loading="restoreRecordsLoading"
-              v-if="displayedRestoreRecords.length || restoreRecordsLoading"
-              :data="displayedRestoreRecords"
-              :fit="false"
-              row-key="id"
-              max-height="calc(var(--app-viewport-height) - 260px)"
-              :expand-row-keys="expandedRestoreRecordRowKeys"
-              :header-cell-style="TABLE_HEADER_STYLE"
-              stripe
-              class="hfl-list-table restore-task-drawer-table"
-              @expand-change="onRestoreRecordExpandChange"
+        <el-tab-pane
+          :label="t('protection.backupsPage.flowSourceDetailTabRestoreRecords')"
+          name="restoreRecords"
+        >
+          <el-alert
+            v-if="restoreRecordsError"
+            :title="t('protection.backupsPage.flowSourceDetailRestoreRecordsLoadFailed', { msg: restoreRecordsError })"
+            type="error"
+            show-icon
+            :closable="false"
+          />
+          <el-table
+            v-if="displayedRestoreRecords.length || restoreRecordsLoading"
+            v-table-column-resize="'protection.flowBackupSource.restoreRecords'"
+            v-table-overflow-title
+            v-loading="restoreRecordsLoading"
+            :data="displayedRestoreRecords"
+            :fit="false"
+            row-key="id"
+            max-height="calc(var(--app-viewport-height) - 260px)"
+            :expand-row-keys="expandedRestoreRecordRowKeys"
+            :header-cell-style="TABLE_HEADER_STYLE"
+            stripe
+            class="hfl-list-table restore-task-drawer-table"
+            @expand-change="onRestoreRecordExpandChange"
+          >
+            <el-table-column
+              type="expand"
+              width="35"
+              fixed
             >
-              <el-table-column type="expand" width="35" fixed>
-                <template #default="{ row }">
-                  <div class="restore-record-expand-panel">
-                    <div class="restore-record-time-summary">
-                      <div class="restore-record-time-summary__point restore-record-time-summary__point--start">
-                        <span class="restore-record-time-summary__marker" aria-hidden="true">
-                          <Clock3 :size="14" />
-                        </span>
-                        <div class="restore-record-time-summary__copy">
-                          <span class="restore-record-time-summary__label">
-                            {{ t('protection.backupDetail.colStart') }}
-                          </span>
-                          <span class="restore-record-time-summary__value" :class="{ 'hfl-empty-mark': !(row.task_summary?.started_at || row.created_at) }">
-                            {{ formatNullableTime(row.task_summary?.started_at || row.created_at) }}
-                          </span>
-                        </div>
-                      </div>
-
-                      <div class="restore-record-time-summary__duration">
-                        <span class="restore-record-time-summary__duration-pill">
-                          <span class="restore-record-time-summary__duration-label">
-                            {{ t('protection.backupsPage.flowSourceDetailDuration') }}
-                          </span>
-                          <span class="restore-record-time-summary__duration-value" :class="{ 'hfl-empty-mark': restoreRecordDuration(row) === t('protection.backupDetail.durationDash') }">
-                            {{ restoreRecordDuration(row) }}
-                          </span>
-                        </span>
-                      </div>
-
-                      <div
-                        class="restore-record-time-summary__point restore-record-time-summary__point--end"
-                        :class="{ 'restore-record-time-summary__point--pending': !row.task_summary?.finished_at }"
+              <template #default="{ row }">
+                <div class="restore-record-expand-panel">
+                  <div class="restore-record-time-summary">
+                    <div class="restore-record-time-summary__point restore-record-time-summary__point--start">
+                      <span
+                        class="restore-record-time-summary__marker"
+                        aria-hidden="true"
                       >
-                        <span class="restore-record-time-summary__marker" aria-hidden="true">
-                          <Check v-if="row.task_summary?.finished_at" :size="14" />
-                          <Clock3 v-else :size="14" />
-                        </span>
-                        <div class="restore-record-time-summary__copy">
-                          <span class="restore-record-time-summary__label">
-                            {{ t('protection.backupDetail.colEnd') }}
-                          </span>
-                          <span class="restore-record-time-summary__value" :class="{ 'hfl-empty-mark': !row.task_summary?.finished_at }">
-                            {{ formatNullableTime(row.task_summary?.finished_at) }}
-                          </span>
-                        </div>
-                      </div>
-                    </div>
-                    <div class="restore-record-runtime-summary">
-                      <span class="restore-record-runtime-summary__label">
-                        {{ t('protection.backupsPage.flowRestoreRecordRuntimeSummary') }}
+                        <Clock3 :size="14" />
                       </span>
-                      <div v-if="restoreRecordMetrics(row).length" class="restore-record-runtime-summary__metrics">
+                      <div class="restore-record-time-summary__copy">
+                        <span class="restore-record-time-summary__label">
+                          {{ t('protection.backupDetail.colStart') }}
+                        </span>
                         <span
-                          v-for="metric in restoreRecordMetrics(row)"
-                          :key="metric"
-                          class="restore-record-runtime-summary__metric"
+                          class="restore-record-time-summary__value"
+                          :class="{ 'hfl-empty-mark': !(row.task_summary?.started_at || row.created_at) }"
                         >
-                          {{ metric }}
+                          {{ formatNullableTime(row.task_summary?.started_at || row.created_at) }}
                         </span>
                       </div>
-                      <span v-else class="restore-record-runtime-summary__unavailable">
-                        {{ restoreRecordRuntimeLoading(row)
-                          ? t('common.loading')
-                          : t('protection.backupsPage.flowRestoreRecordMetricsUnavailable') }}
+                    </div>
+
+                    <div class="restore-record-time-summary__duration">
+                      <span class="restore-record-time-summary__duration-pill">
+                        <span class="restore-record-time-summary__duration-label">
+                          {{ t('protection.backupsPage.flowSourceDetailDuration') }}
+                        </span>
+                        <span
+                          class="restore-record-time-summary__duration-value"
+                          :class="{ 'hfl-empty-mark': restoreRecordDuration(row) === t('protection.backupDetail.durationDash') }"
+                        >
+                          {{ restoreRecordDuration(row) }}
+                        </span>
                       </span>
                     </div>
-                    <div v-if="row.items?.length" class="dp-flow-restore-plan-card restore-record-structure-card">
-                      <div class="create-recovery-plan-cell create-recovery-plan-cell--review create-recovery-plan-cell--enabled">
-                        <div v-if="row.scope === 'snapshot'" class="restore-record-snapshot-tree">
-                          <div class="create-recovery-plan-mapping restore-record-mapping--with-result restore-record-snapshot-tree__parent">
-                            <span
-                              class="create-recovery-plan-mapping__endpoint create-recovery-plan-mapping__endpoint--snapshot"
-                              :title="t('protection.backupsPage.recoveryWholeSnapshot')"
-                            >
-                              <Camera :size="14" class="create-recovery-plan-mapping__icon" />
-                              <span class="create-recovery-plan-mapping__text">
-                                {{ t('protection.backupsPage.recoveryWholeSnapshot') }}
-                              </span>
-                            </span>
-                            <span class="create-recovery-plan-mapping__arrow" aria-hidden="true">-&gt;</span>
-                            <span
-                              class="create-recovery-plan-mapping__endpoint create-recovery-plan-mapping__endpoint--target"
-                              :title="restoreRecordTargetSummary(row)"
-                            >
-                              <FolderOpen :size="14" class="create-recovery-plan-mapping__icon" />
-                              <span class="create-recovery-plan-mapping__text hfl-table-cell-mono">
-                                {{ restoreRecordTargetSummary(row) }}
-                              </span>
-                            </span>
-                            <span class="restore-record-mapping__result">
-                              <TaskStatusTag v-if="restoreRecordStatus(row)" :status="restoreRecordStatus(row)" />
-                              <ElTag v-else type="info" size="small">
-                                {{ t('protection.backupsPage.flowRestoreRecordStatusUnknown') }}
-                              </ElTag>
-                            </span>
-                          </div>
 
-                          <div class="restore-record-snapshot-tree__children">
-                            <div v-for="item in row.items" :key="item.id" class="restore-record-structure-entry restore-record-snapshot-tree__child">
-                              <div class="create-recovery-plan-mapping restore-record-mapping--with-result">
-                                <span
-                                  class="create-recovery-plan-mapping__endpoint"
-                                  :class="`create-recovery-plan-mapping__endpoint--${restoreItemSourceKind(item)}`"
-                                  :title="item.source_path || '—'"
-                                >
-                                  <File
-                                    v-if="restoreItemSourceKind(item) === 'file'"
-                                    :size="14"
-                                    class="create-recovery-plan-mapping__icon"
-                                  />
-                                  <Folder v-else :size="14" class="create-recovery-plan-mapping__icon" />
-                                  <span class="create-recovery-plan-mapping__text hfl-table-cell-mono" :class="{ 'hfl-empty-mark': !item.source_path }">
-                                    {{ item.source_path || '—' }}
-                                  </span>
-                                </span>
-                                <span class="create-recovery-plan-mapping__arrow" aria-hidden="true">-&gt;</span>
-                                <span
-                                  class="create-recovery-plan-mapping__endpoint create-recovery-plan-mapping__endpoint--target"
-                                  :title="restoreItemTargetSummary(row, item)"
-                                >
-                                  <FolderOpen :size="14" class="create-recovery-plan-mapping__icon" />
-                                  <span class="create-recovery-plan-mapping__text hfl-table-cell-mono">
-                                    {{ restoreItemTargetSummary(row, item) }}
-                                  </span>
-                                </span>
-                                <span class="restore-record-mapping__result">
-                                  <TaskStatusTag :status="item.status" />
-                                </span>
-                              </div>
-                              <div v-if="item.error_code || item.error_message" class="restore-record-structure-entry__error">
-                                {{ item.error_code ? `[${item.error_code}] ` : '' }}{{ item.error_message }}
-                              </div>
-                            </div>
-                          </div>
+                    <div
+                      class="restore-record-time-summary__point restore-record-time-summary__point--end"
+                      :class="{ 'restore-record-time-summary__point--pending': !row.task_summary?.finished_at }"
+                    >
+                      <span
+                        class="restore-record-time-summary__marker"
+                        aria-hidden="true"
+                      >
+                        <Check
+                          v-if="row.task_summary?.finished_at"
+                          :size="14"
+                        />
+                        <Clock3
+                          v-else
+                          :size="14"
+                        />
+                      </span>
+                      <div class="restore-record-time-summary__copy">
+                        <span class="restore-record-time-summary__label">
+                          {{ t('protection.backupDetail.colEnd') }}
+                        </span>
+                        <span
+                          class="restore-record-time-summary__value"
+                          :class="{ 'hfl-empty-mark': !row.task_summary?.finished_at }"
+                        >
+                          {{ formatNullableTime(row.task_summary?.finished_at) }}
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="restore-record-runtime-summary">
+                    <span class="restore-record-runtime-summary__label">
+                      {{ t('protection.backupsPage.flowRestoreRecordRuntimeSummary') }}
+                    </span>
+                    <div
+                      v-if="restoreRecordMetrics(row).length"
+                      class="restore-record-runtime-summary__metrics"
+                    >
+                      <span
+                        v-for="metric in restoreRecordMetrics(row)"
+                        :key="metric"
+                        class="restore-record-runtime-summary__metric"
+                      >
+                        {{ metric }}
+                      </span>
+                    </div>
+                    <span
+                      v-else
+                      class="restore-record-runtime-summary__unavailable"
+                    >
+                      {{ restoreRecordRuntimeLoading(row)
+                        ? t('common.loading')
+                        : t('protection.backupsPage.flowRestoreRecordMetricsUnavailable') }}
+                    </span>
+                  </div>
+                  <div
+                    v-if="row.items?.length"
+                    class="dp-flow-restore-plan-card restore-record-structure-card"
+                  >
+                    <div class="create-recovery-plan-cell create-recovery-plan-cell--review create-recovery-plan-cell--enabled">
+                      <div
+                        v-if="row.scope === 'snapshot'"
+                        class="restore-record-snapshot-tree"
+                      >
+                        <div class="create-recovery-plan-mapping restore-record-mapping--with-result restore-record-snapshot-tree__parent">
+                          <span
+                            class="create-recovery-plan-mapping__endpoint create-recovery-plan-mapping__endpoint--snapshot"
+                            :title="t('protection.backupsPage.recoveryWholeSnapshot')"
+                          >
+                            <Camera
+                              :size="14"
+                              class="create-recovery-plan-mapping__icon"
+                            />
+                            <span class="create-recovery-plan-mapping__text">
+                              {{ t('protection.backupsPage.recoveryWholeSnapshot') }}
+                            </span>
+                          </span>
+                          <span
+                            class="create-recovery-plan-mapping__arrow"
+                            aria-hidden="true"
+                          >-&gt;</span>
+                          <span
+                            class="create-recovery-plan-mapping__endpoint create-recovery-plan-mapping__endpoint--target"
+                            :title="restoreRecordTargetSummary(row)"
+                          >
+                            <FolderOpen
+                              :size="14"
+                              class="create-recovery-plan-mapping__icon"
+                            />
+                            <span class="create-recovery-plan-mapping__text hfl-table-cell-mono">
+                              {{ restoreRecordTargetSummary(row) }}
+                            </span>
+                          </span>
+                          <span class="restore-record-mapping__result">
+                            <TaskStatusTag
+                              v-if="restoreRecordStatus(row)"
+                              :status="restoreRecordStatus(row)"
+                            />
+                            <ElTag
+                              v-else
+                              type="info"
+                              size="small"
+                            >
+                              {{ t('protection.backupsPage.flowRestoreRecordStatusUnknown') }}
+                            </ElTag>
+                          </span>
                         </div>
 
-                        <div v-else class="create-recovery-plan-cell__mappings restore-record-flat-mappings">
+                        <div class="restore-record-snapshot-tree__children">
                           <div
-                            v-for="mapping in restoreRecordPathMappings(row)"
-                            :key="mapping.key"
-                            class="restore-record-structure-entry"
+                            v-for="item in row.items"
+                            :key="item.id"
+                            class="restore-record-structure-entry restore-record-snapshot-tree__child"
                           >
                             <div class="create-recovery-plan-mapping restore-record-mapping--with-result">
                               <span
                                 class="create-recovery-plan-mapping__endpoint"
-                                :class="`create-recovery-plan-mapping__endpoint--${mapping.sourceKind}`"
-                                :title="mapping.sourcePath"
+                                :class="`create-recovery-plan-mapping__endpoint--${restoreItemSourceKind(item)}`"
+                                :title="item.source_path || '—'"
                               >
                                 <File
-                                  v-if="mapping.sourceKind === 'file'"
+                                  v-if="restoreItemSourceKind(item) === 'file'"
                                   :size="14"
                                   class="create-recovery-plan-mapping__icon"
                                 />
-                                <Folder v-else :size="14" class="create-recovery-plan-mapping__icon" />
-                                <span class="create-recovery-plan-mapping__text hfl-table-cell-mono">
-                                  {{ mapping.sourcePath }}
+                                <Folder
+                                  v-else
+                                  :size="14"
+                                  class="create-recovery-plan-mapping__icon"
+                                />
+                                <span
+                                  class="create-recovery-plan-mapping__text hfl-table-cell-mono"
+                                  :class="{ 'hfl-empty-mark': !item.source_path }"
+                                >
+                                  {{ item.source_path || '—' }}
                                 </span>
                               </span>
-                              <span class="create-recovery-plan-mapping__arrow" aria-hidden="true">-&gt;</span>
+                              <span
+                                class="create-recovery-plan-mapping__arrow"
+                                aria-hidden="true"
+                              >-&gt;</span>
                               <span
                                 class="create-recovery-plan-mapping__endpoint create-recovery-plan-mapping__endpoint--target"
-                                :title="restoreItemTargetSummary(row, mapping.item)"
+                                :title="restoreItemTargetSummary(row, item)"
                               >
-                                <FolderOpen :size="14" class="create-recovery-plan-mapping__icon" />
+                                <FolderOpen
+                                  :size="14"
+                                  class="create-recovery-plan-mapping__icon"
+                                />
                                 <span class="create-recovery-plan-mapping__text hfl-table-cell-mono">
-                                  {{ restoreItemTargetSummary(row, mapping.item) }}
+                                  {{ restoreItemTargetSummary(row, item) }}
                                 </span>
                               </span>
                               <span class="restore-record-mapping__result">
-                                <TaskStatusTag :status="mapping.item.status" />
+                                <TaskStatusTag :status="item.status" />
                               </span>
                             </div>
                             <div
-                              v-if="mapping.item.error_code || mapping.item.error_message"
+                              v-if="item.error_code || item.error_message"
                               class="restore-record-structure-entry__error"
                             >
-                              {{ mapping.item.error_code ? `[${mapping.item.error_code}] ` : '' }}{{ mapping.item.error_message }}
+                              {{ item.error_code ? `[${item.error_code}] ` : '' }}{{ item.error_message }}
                             </div>
                           </div>
                         </div>
                       </div>
+
+                      <div
+                        v-else
+                        class="create-recovery-plan-cell__mappings restore-record-flat-mappings"
+                      >
+                        <div
+                          v-for="mapping in restoreRecordPathMappings(row)"
+                          :key="mapping.key"
+                          class="restore-record-structure-entry"
+                        >
+                          <div class="create-recovery-plan-mapping restore-record-mapping--with-result">
+                            <span
+                              class="create-recovery-plan-mapping__endpoint"
+                              :class="`create-recovery-plan-mapping__endpoint--${mapping.sourceKind}`"
+                              :title="mapping.sourcePath"
+                            >
+                              <File
+                                v-if="mapping.sourceKind === 'file'"
+                                :size="14"
+                                class="create-recovery-plan-mapping__icon"
+                              />
+                              <Folder
+                                v-else
+                                :size="14"
+                                class="create-recovery-plan-mapping__icon"
+                              />
+                              <span class="create-recovery-plan-mapping__text hfl-table-cell-mono">
+                                {{ mapping.sourcePath }}
+                              </span>
+                            </span>
+                            <span
+                              class="create-recovery-plan-mapping__arrow"
+                              aria-hidden="true"
+                            >-&gt;</span>
+                            <span
+                              class="create-recovery-plan-mapping__endpoint create-recovery-plan-mapping__endpoint--target"
+                              :title="restoreItemTargetSummary(row, mapping.item)"
+                            >
+                              <FolderOpen
+                                :size="14"
+                                class="create-recovery-plan-mapping__icon"
+                              />
+                              <span class="create-recovery-plan-mapping__text hfl-table-cell-mono">
+                                {{ restoreItemTargetSummary(row, mapping.item) }}
+                              </span>
+                            </span>
+                            <span class="restore-record-mapping__result">
+                              <TaskStatusTag :status="mapping.item.status" />
+                            </span>
+                          </div>
+                          <div
+                            v-if="mapping.item.error_code || mapping.item.error_message"
+                            class="restore-record-structure-entry__error"
+                          >
+                            {{ mapping.item.error_code ? `[${mapping.item.error_code}] ` : '' }}{{ mapping.item.error_message }}
+                          </div>
+                        </div>
+                      </div>
                     </div>
-                    <el-empty
-                      v-else
-                      :description="t('protection.backupsPage.flowRestoreRecordMappingsEmpty')"
-                      :image-size="48"
+                  </div>
+                  <el-empty
+                    v-else
+                    :description="t('protection.backupsPage.flowRestoreRecordMappingsEmpty')"
+                    :image-size="48"
+                  />
+                </div>
+              </template>
+            </el-table-column>
+            <el-table-column
+              :label="t('protection.backupsPage.flowRestoreRecordColName')"
+              width="148"
+              fixed
+            >
+              <template #default="{ row }">
+                <button
+                  type="button"
+                  class="hfl-table-name-link hfl-table-cell-mono hfl-table-name-link--single"
+                  :aria-expanded="expandedRestoreRecordRowKeys.includes(row.id)"
+                  @click.stop="toggleRestoreRecord(row)"
+                >
+                  {{ row.restore_uid || `#${row.id}` }}
+                </button>
+              </template>
+            </el-table-column>
+            <el-table-column
+              :label="t('protection.backupDetail.colTaskId')"
+              width="160"
+            >
+              <template #default="{ row }">
+                <button
+                  v-if="row.task_uuid"
+                  type="button"
+                  class="hfl-table-name-link hfl-table-cell-mono hfl-table-name-link--single"
+                  :title="row.task_uuid"
+                  @click.stop="openTaskDetailByUuid(row.task_uuid)"
+                >
+                  {{ row.task_uuid }}
+                </button>
+                <span
+                  v-else
+                  class="hfl-empty-mark"
+                >{{ t('protection.backupDetail.durationDash') }}</span>
+              </template>
+            </el-table-column>
+            <el-table-column
+              :label="t('protection.backupsPage.flowRestoreRecordColStatusProgress')"
+              width="148"
+            >
+              <template #default="{ row }">
+                <div class="restore-record-status-progress">
+                  <div
+                    v-if="shouldShowRestoreRecordProgress(row)"
+                    class="restore-record-status-progress__bar"
+                  >
+                    <ElProgress
+                      :percentage="restoreRecordProgressValue(row)"
+                      :stroke-width="6"
+                      :show-text="false"
                     />
+                    <span>{{ restoreRecordProgressText(row) }}</span>
                   </div>
-                </template>
-              </el-table-column>
-              <el-table-column :label="t('protection.backupsPage.flowRestoreRecordColName')" width="148" fixed>
-                <template #default="{ row }">
-                  <button
-                    type="button"
-                    class="hfl-table-name-link hfl-table-cell-mono hfl-table-name-link--single"
-                    :aria-expanded="expandedRestoreRecordRowKeys.includes(row.id)"
-                    @click.stop="toggleRestoreRecord(row)"
+                  <TaskStatusTag
+                    v-else-if="restoreRecordStatus(row)"
+                    :status="restoreRecordStatus(row)"
+                  />
+                  <ElTag
+                    v-else
+                    type="info"
+                    size="small"
                   >
-                    {{ row.restore_uid || `#${row.id}` }}
-                  </button>
-                </template>
-              </el-table-column>
-              <el-table-column :label="t('protection.backupDetail.colTaskId')" width="160">
-                <template #default="{ row }">
-                  <button
-                    v-if="row.task_uuid"
-                    type="button"
-                    class="hfl-table-name-link hfl-table-cell-mono hfl-table-name-link--single"
-                    :title="row.task_uuid"
-                    @click.stop="openTaskDetailByUuid(row.task_uuid)"
-                  >
-                    {{ row.task_uuid }}
-                  </button>
-                  <span v-else class="hfl-empty-mark">{{ t('protection.backupDetail.durationDash') }}</span>
-                </template>
-              </el-table-column>
-              <el-table-column
-                :label="t('protection.backupsPage.flowRestoreRecordColStatusProgress')"
-                width="148"
-              >
-                <template #default="{ row }">
-                  <div class="restore-record-status-progress">
-                    <div v-if="shouldShowRestoreRecordProgress(row)" class="restore-record-status-progress__bar">
-                      <ElProgress
-                        :percentage="restoreRecordProgressValue(row)"
-                        :stroke-width="6"
-                        :show-text="false"
-                      />
-                      <span>{{ restoreRecordProgressText(row) }}</span>
-                    </div>
-                    <TaskStatusTag v-else-if="restoreRecordStatus(row)" :status="restoreRecordStatus(row)" />
-                    <ElTag v-else type="info" size="small">
-                      {{ t('protection.backupsPage.flowRestoreRecordStatusUnknown') }}
-                    </ElTag>
-                  </div>
-                </template>
-              </el-table-column>
-              <el-table-column :label="t('protection.backupDetail.colSnapId')" width="210">
-                <template #default="{ row }">
-                  <span class="hfl-table-cell-mono" :title="restoreRecordSnapshotLabel(row)">
-                    {{ restoreRecordSnapshotLabel(row) }}
-                  </span>
-                </template>
-              </el-table-column>
-              <el-table-column
-                :label="t('protection.backupsPage.flowRestoreRecordColConflict')"
-                width="96"
-              >
-                <template #default="{ row }">
-                  <ElTag :type="row.conflict_mode === 'overwrite' ? 'warning' : 'success'" size="small" effect="plain">
-                    {{ restoreRecordConflictLabel(row.conflict_mode) }}
+                    {{ t('protection.backupsPage.flowRestoreRecordStatusUnknown') }}
                   </ElTag>
-                </template>
-              </el-table-column>
-              <el-table-column
-                :label="t('protection.backupsPage.flowRestoreRecordColMode')"
-                width="132"
-              >
-                <template #default="{ row }">
-                  <ElTag size="small" effect="plain" :title="restoreRecordModeTitle(row)">
-                    {{ restoreRecordModeLabel(row) }}
-                  </ElTag>
-                </template>
-              </el-table-column>
-              <el-table-column
-                :label="t('protection.backupsPage.flowRestoreRecordColCreated')"
-                width="150"
-              >
-                <template #default="{ row }">
-                  <span class="hfl-table-cell-time" :class="{ 'hfl-empty-mark': !row.created_at }">{{ formatNullableTime(row.created_at) }}</span>
-                </template>
-              </el-table-column>
-            </el-table>
-            <el-empty
-              v-else-if="!restoreRecordsLoading && !restoreRecordsError"
-              :description="t('protection.backupsPage.flowSourceDetailRestoreRecordsEmpty')"
-              :image-size="72"
+                </div>
+              </template>
+            </el-table-column>
+            <el-table-column
+              :label="t('protection.backupDetail.colSnapId')"
+              width="210"
+            >
+              <template #default="{ row }">
+                <span
+                  class="hfl-table-cell-mono"
+                  :title="restoreRecordSnapshotLabel(row)"
+                >
+                  {{ restoreRecordSnapshotLabel(row) }}
+                </span>
+              </template>
+            </el-table-column>
+            <el-table-column
+              :label="t('protection.backupsPage.flowRestoreRecordColConflict')"
+              width="96"
+            >
+              <template #default="{ row }">
+                <ElTag
+                  :type="row.conflict_mode === 'overwrite' ? 'warning' : 'success'"
+                  size="small"
+                  effect="plain"
+                >
+                  {{ restoreRecordConflictLabel(row.conflict_mode) }}
+                </ElTag>
+              </template>
+            </el-table-column>
+            <el-table-column
+              :label="t('protection.backupsPage.flowRestoreRecordColMode')"
+              width="132"
+            >
+              <template #default="{ row }">
+                <ElTag
+                  size="small"
+                  effect="plain"
+                  :title="restoreRecordModeTitle(row)"
+                >
+                  {{ restoreRecordModeLabel(row) }}
+                </ElTag>
+              </template>
+            </el-table-column>
+            <el-table-column
+              :label="t('protection.backupsPage.flowRestoreRecordColCreated')"
+              width="150"
+            >
+              <template #default="{ row }">
+                <span
+                  class="hfl-table-cell-time"
+                  :class="{ 'hfl-empty-mark': !row.created_at }"
+                >{{ formatNullableTime(row.created_at) }}</span>
+              </template>
+            </el-table-column>
+          </el-table>
+          <el-empty
+            v-else-if="!restoreRecordsLoading && !restoreRecordsError"
+            :description="t('protection.backupsPage.flowSourceDetailRestoreRecordsEmpty')"
+            :image-size="72"
+          />
+          <div
+            v-if="displayedRestoreRecords.length || restoreRecordPagination.count > 0"
+            class="hfl-list-footer"
+          >
+            <HflPagination
+              v-model:current-page="restoreRecordPagination.page"
+              v-model:page-size="restoreRecordPagination.pageSize"
+              class="hfl-list-footer__pagination"
+              layout="total, sizes, prev, pager, next"
+              :total="restoreRecordPagination.count"
+              :page-sizes="DETAIL_PAGE_SIZE_OPTIONS"
+              @size-change="restoreRecordPagination.page = 1"
             />
-            <div v-if="displayedRestoreRecords.length || restoreRecordPagination.count > 0" class="hfl-list-footer">
-              <HflPagination
-                v-model:current-page="restoreRecordPagination.page"
-                v-model:page-size="restoreRecordPagination.pageSize"
-                class="hfl-list-footer__pagination"
-                layout="total, sizes, prev, pager, next"
-                :total="restoreRecordPagination.count"
-                :page-sizes="DETAIL_PAGE_SIZE_OPTIONS"
-                @size-change="restoreRecordPagination.page = 1"
-              />
-            </div>
+          </div>
         </el-tab-pane>
 
-        <el-tab-pane :label="t('protection.backupDetail.tabTasks')" name="tasks">
-            <el-alert
-              v-if="sourceTasksError"
-              :title="t('protection.backupsPage.flowSourceDetailTasksLoadFailed', { msg: sourceTasksError })"
-              type="error"
-              show-icon
-              :closable="false"
-            />
-            <div class="hfl-list-toolbar dp-source-task-toolbar">
-              <ElInput
-                v-model="taskFilterId"
-                clearable
-                class="hfl-list-search dp-source-task-toolbar__search"
-                :placeholder="t('ops.task.phSearch')"
-                @clear="clearSourceTaskSearch"
-              >
-                <template #prepend>
-                  <ElSelect v-model="taskFilterSearchField" style="width: 90px" popper-class="dp-source-task-select-popper" @change="handleSourceTaskSearchFieldChange">
-                    <ElOption
-                      v-for="opt in taskSearchFieldOptions"
-                      :key="opt.value"
-                      :value="opt.value"
-                      :label="opt.label"
-                    />
-                  </ElSelect>
-                </template>
-                <template #prefix>
-                  <Search :size="16" class="text-slate-400" />
-                </template>
-              </ElInput>
-              <ElSelect v-model="taskFilterType" clearable :placeholder="t('ops.task.filterType')" style="width: 130px" popper-class="dp-source-task-select-popper">
-                <ElOption v-for="option in taskTypeOptions" :key="option.value" :label="option.label" :value="option.value" />
-              </ElSelect>
-              <ElSelect v-model="taskFilterStatus" clearable :placeholder="t('ops.task.filterStatus')" style="width: 130px" popper-class="dp-source-task-select-popper">
-                <ElOption v-for="option in taskStatusOptions" :key="option.value" :label="option.label" :value="option.value" />
-              </ElSelect>
-              <ElSelect v-model="taskFilterTimeMode" :placeholder="t('ops.task.filterTime')" style="width: 130px" popper-class="dp-source-task-select-popper" @change="onSourceTaskTimeModeChange">
-                <ElOption v-for="option in sourceTaskTimeModeOptions" :key="option.value" :label="option.label" :value="option.value" />
-              </ElSelect>
-              <div class="hfl-list-toolbar__right">
-                <ElBadge :value="sourceTaskAdvancedFilterCount" :hidden="sourceTaskAdvancedFilterCount === 0" class="dp-source-task-filter-badge">
-                  <ElButton
-                    :class="{ 'dp-source-task-filter-button--active': sourceTaskAdvancedFilterCount > 0 }"
-                    :title="t('ops.task.advancedFilter')"
-                    :aria-label="t('ops.task.advancedFilter')"
-                    @click="openSourceTaskAdvancedFilterDrawer"
-                  >
-                    <Filter :size="16" />
-                  </ElButton>
-                </ElBadge>
-                <ElButton
-                  class="hfl-refresh-button"
-                  :title="t('ops.task.btnRefresh')"
-                  :aria-label="t('ops.task.btnRefresh')"
-                  :disabled="sourceTasksLoading"
-                  @click="loadTasksForSource"
-                >
-                  <RefreshCw :size="16" :class="{ 'is-spinning': sourceTasksLoading }" />
-                </ElButton>
-              </div>
-            </div>
-            <el-table
-              v-table-column-resize="'protection.flowBackupSource.sourceTasks'"
-              v-table-overflow-title
-              v-loading="sourceTasksLoading"
-              :data="sourceTaskRows"
-              stripe
-              class="restore-task-drawer-table dp-source-task-table hfl-list-table"
-              :row-class-name="sourceTaskRowClassName"
+        <el-tab-pane
+          :label="t('protection.backupDetail.tabTasks')"
+          name="tasks"
+        >
+          <el-alert
+            v-if="sourceTasksError"
+            :title="t('protection.backupsPage.flowSourceDetailTasksLoadFailed', { msg: sourceTasksError })"
+            type="error"
+            show-icon
+            :closable="false"
+          />
+          <div class="hfl-list-toolbar dp-source-task-toolbar">
+            <ElInput
+              v-model="taskFilterId"
+              clearable
+              class="hfl-list-search dp-source-task-toolbar__search"
+              :placeholder="t('ops.task.phSearch')"
+              @clear="clearSourceTaskSearch"
             >
-              <el-table-column :label="t('ops.task.colName')" width="275" fixed>
-                <template #default="{ row }">
-                  <ResourceNameSummaryCell
-                    :name="taskDetailTitle(row)"
-                    :summary="row.task_uuid"
-                    kind="task"
-                    :show-icon="false"
-                    @open="openTaskDetail(row)"
+              <template #prepend>
+                <ElSelect
+                  v-model="taskFilterSearchField"
+                  style="width: 90px"
+                  popper-class="dp-source-task-select-popper"
+                  @change="handleSourceTaskSearchFieldChange"
+                >
+                  <ElOption
+                    v-for="opt in taskSearchFieldOptions"
+                    :key="opt.value"
+                    :value="opt.value"
+                    :label="opt.label"
                   />
-                </template>
-              </el-table-column>
-              <el-table-column :label="t('protection.backupDetail.colTaskType')" width="205">
-                <template #default="{ row }">
-                  <TaskTypeLabel :type="row.task_type" />
-                </template>
-              </el-table-column>
-              <el-table-column :label="t('protection.backupDetail.colTaskStatus')" width="115">
-                <template #default="{ row }">
-                  <TaskStatusTag :status="row.status" />
-                </template>
-              </el-table-column>
-              <el-table-column :label="t('protection.backupsPage.flowTaskColProgress')" min-width="165">
-                <template #default="{ row }">
-                  <div class="hfl-task-list-progress">
-                    <div class="hfl-task-list-progress__track">
-                      <div
-                        class="hfl-task-list-progress__fill"
-                        :class="`hfl-task-list-progress__fill--${row.status}`"
-                        :style="{ width: `${progressValue(row)}%` }"
-                      />
-                    </div>
-                    <span class="hfl-task-list-progress__text">{{ progressText(row) }}</span>
-                  </div>
-                </template>
-              </el-table-column>
-              <el-table-column :label="t('ops.task.colTrigger')" width="105">
-                <template #default="{ row }">
-                  <el-tag type="info" size="small">
-                    {{ taskTriggerLabel(row.trigger_type) }}
-                  </el-tag>
-                </template>
-              </el-table-column>
-              <el-table-column :label="t('protection.backupDetail.colCreated')" min-width="160">
-                <template #default="{ row }">
-                  <span class="hfl-table-cell-time" :class="{ 'hfl-empty-mark': !row.created_at }">{{ formatNullableTime(row.created_at) }}</span>
-                </template>
-              </el-table-column>
-              <template #empty>
-                <el-empty
-                  v-if="!sourceTasksLoading && !sourceTasksError"
-                  :description="t('protection.backupsPage.flowSourceDetailTasksEmpty')"
-                  :image-size="72"
+                </ElSelect>
+              </template>
+              <template #prefix>
+                <Search
+                  :size="16"
+                  class="text-slate-400"
                 />
               </template>
-            </el-table>
-            <div class="hfl-list-footer">
-              <HflPagination
-                v-model:current-page="taskPagination.page"
-                v-model:page-size="taskPagination.pageSize"
-                class="hfl-list-footer__pagination"
-                layout="total, sizes, prev, pager, next"
-                :total="sourceTasksTotal"
-                :page-sizes="DETAIL_PAGE_SIZE_OPTIONS"
-                @size-change="taskPagination.page = 1"
+            </ElInput>
+            <ElSelect
+              v-model="taskFilterType"
+              clearable
+              :placeholder="t('ops.task.filterType')"
+              style="width: 130px"
+              popper-class="dp-source-task-select-popper"
+            >
+              <ElOption
+                v-for="option in taskTypeOptions"
+                :key="option.value"
+                :label="option.label"
+                :value="option.value"
               />
+            </ElSelect>
+            <ElSelect
+              v-model="taskFilterStatus"
+              clearable
+              :placeholder="t('ops.task.filterStatus')"
+              style="width: 130px"
+              popper-class="dp-source-task-select-popper"
+            >
+              <ElOption
+                v-for="option in taskStatusOptions"
+                :key="option.value"
+                :label="option.label"
+                :value="option.value"
+              />
+            </ElSelect>
+            <ElSelect
+              v-model="taskFilterTimeMode"
+              :placeholder="t('ops.task.filterTime')"
+              style="width: 130px"
+              popper-class="dp-source-task-select-popper"
+              @change="onSourceTaskTimeModeChange"
+            >
+              <ElOption
+                v-for="option in sourceTaskTimeModeOptions"
+                :key="option.value"
+                :label="option.label"
+                :value="option.value"
+              />
+            </ElSelect>
+            <div class="hfl-list-toolbar__right">
+              <ElBadge
+                :value="sourceTaskAdvancedFilterCount"
+                :hidden="sourceTaskAdvancedFilterCount === 0"
+                class="dp-source-task-filter-badge"
+              >
+                <ElButton
+                  :class="{ 'dp-source-task-filter-button--active': sourceTaskAdvancedFilterCount > 0 }"
+                  :title="t('ops.task.advancedFilter')"
+                  :aria-label="t('ops.task.advancedFilter')"
+                  @click="openSourceTaskAdvancedFilterDrawer"
+                >
+                  <Filter :size="16" />
+                </ElButton>
+              </ElBadge>
+              <ElButton
+                class="hfl-refresh-button"
+                :title="t('ops.task.btnRefresh')"
+                :aria-label="t('ops.task.btnRefresh')"
+                :disabled="sourceTasksLoading"
+                @click="loadTasksForSource"
+              >
+                <RefreshCw
+                  :size="16"
+                  :class="{ 'is-spinning': sourceTasksLoading }"
+                />
+              </ElButton>
             </div>
+          </div>
+          <el-table
+            v-table-column-resize="'protection.flowBackupSource.sourceTasks'"
+            v-table-overflow-title
+            v-loading="sourceTasksLoading"
+            :data="sourceTaskRows"
+            stripe
+            class="restore-task-drawer-table dp-source-task-table hfl-list-table"
+            :row-class-name="sourceTaskRowClassName"
+          >
+            <el-table-column
+              :label="t('ops.task.colName')"
+              width="275"
+              fixed
+            >
+              <template #default="{ row }">
+                <ResourceNameSummaryCell
+                  :name="taskDetailTitle(row)"
+                  :summary="row.task_uuid"
+                  kind="task"
+                  :show-icon="false"
+                  @open="openTaskDetail(row)"
+                />
+              </template>
+            </el-table-column>
+            <el-table-column
+              :label="t('protection.backupDetail.colTaskType')"
+              width="205"
+            >
+              <template #default="{ row }">
+                <TaskTypeLabel :type="row.task_type" />
+              </template>
+            </el-table-column>
+            <el-table-column
+              :label="t('protection.backupDetail.colTaskStatus')"
+              width="115"
+            >
+              <template #default="{ row }">
+                <TaskStatusTag :status="row.status" />
+              </template>
+            </el-table-column>
+            <el-table-column
+              :label="t('protection.backupsPage.flowTaskColProgress')"
+              min-width="165"
+            >
+              <template #default="{ row }">
+                <div class="hfl-task-list-progress">
+                  <div class="hfl-task-list-progress__track">
+                    <div
+                      class="hfl-task-list-progress__fill"
+                      :class="`hfl-task-list-progress__fill--${row.status}`"
+                      :style="{ width: `${progressValue(row)}%` }"
+                    />
+                  </div>
+                  <span class="hfl-task-list-progress__text">{{ progressText(row) }}</span>
+                </div>
+              </template>
+            </el-table-column>
+            <el-table-column
+              :label="t('ops.task.colTrigger')"
+              width="105"
+            >
+              <template #default="{ row }">
+                <el-tag
+                  type="info"
+                  size="small"
+                >
+                  {{ taskTriggerLabel(row.trigger_type) }}
+                </el-tag>
+              </template>
+            </el-table-column>
+            <el-table-column
+              :label="t('protection.backupDetail.colCreated')"
+              min-width="160"
+            >
+              <template #default="{ row }">
+                <span
+                  class="hfl-table-cell-time"
+                  :class="{ 'hfl-empty-mark': !row.created_at }"
+                >{{ formatNullableTime(row.created_at) }}</span>
+              </template>
+            </el-table-column>
+            <template #empty>
+              <el-empty
+                v-if="!sourceTasksLoading && !sourceTasksError"
+                :description="t('protection.backupsPage.flowSourceDetailTasksEmpty')"
+                :image-size="72"
+              />
+            </template>
+          </el-table>
+          <div class="hfl-list-footer">
+            <HflPagination
+              v-model:current-page="taskPagination.page"
+              v-model:page-size="taskPagination.pageSize"
+              class="hfl-list-footer__pagination"
+              layout="total, sizes, prev, pager, next"
+              :total="sourceTasksTotal"
+              :page-sizes="DETAIL_PAGE_SIZE_OPTIONS"
+              @size-change="taskPagination.page = 1"
+            />
+          </div>
         </el-tab-pane>
       </el-tabs>
     </div>
@@ -3840,7 +4320,10 @@ function onClosed() {
     :z-index="3150"
     @closed="onSourceTaskAdvancedFilterClosed"
   >
-    <ElForm label-position="top" class="dp-source-task-filter-form">
+    <ElForm
+      label-position="top"
+      class="dp-source-task-filter-form"
+    >
       <ElFormItem :label="t('ops.task.filterTime')">
         <ElDatePicker
           v-model="taskAdvancedFilterDraft.dateRange"
@@ -3855,8 +4338,15 @@ function onClosed() {
     </ElForm>
     <template #footer>
       <div class="dp-source-task-filter-drawer__footer">
-        <ElButton @click="resetSourceTaskAdvancedFilterDraft">{{ t('ops.task.resetFilter') }}</ElButton>
-        <ElButton type="primary" @click="applySourceTaskAdvancedFilters">{{ t('ops.task.applyFilter') }}</ElButton>
+        <ElButton @click="resetSourceTaskAdvancedFilterDraft">
+          {{ t('ops.task.resetFilter') }}
+        </ElButton>
+        <ElButton
+          type="primary"
+          @click="applySourceTaskAdvancedFilters"
+        >
+          {{ t('ops.task.applyFilter') }}
+        </ElButton>
       </div>
     </template>
   </ElDrawer>
@@ -3871,9 +4361,14 @@ function onClosed() {
   >
     <template #header>
       <div class="dp-task-detail__header-bar">
-        <div v-if="activeTask" class="dp-task-detail__header-summary">
+        <div
+          v-if="activeTask"
+          class="dp-task-detail__header-summary"
+        >
           <div class="dp-task-detail__header-title-row">
-            <h2 class="dp-task-detail__header-title">{{ taskDetailTitle(activeTask) }}</h2>
+            <h2 class="dp-task-detail__header-title">
+              {{ taskDetailTitle(activeTask) }}
+            </h2>
             <TaskStatusTag :status="activeTask.status" />
           </div>
           <div class="dp-task-detail__header-meta">
@@ -3892,7 +4387,12 @@ function onClosed() {
             </span>
           </div>
         </div>
-        <h2 v-else class="dp-task-detail__header-title">{{ t('protection.backupsPage.backupTaskDrawerTitle') }}</h2>
+        <h2
+          v-else
+          class="dp-task-detail__header-title"
+        >
+          {{ t('protection.backupsPage.backupTaskDrawerTitle') }}
+        </h2>
         <div class="dp-task-detail__header-actions">
           <ElButton
             v-if="canCancelBackupTask"
@@ -3915,25 +4415,44 @@ function onClosed() {
             :disabled="activeTaskLoading"
             @click="refreshActiveTask"
           >
-            <RefreshCw :size="20" :class="{ 'is-spinning': activeTaskLoading }" />
+            <RefreshCw
+              :size="20"
+              :class="{ 'is-spinning': activeTaskLoading }"
+            />
           </button>
         </div>
       </div>
     </template>
 
-    <div v-if="activeTask" ref="drawerScrollAnchorRef" v-loading="activeTaskLoading" class="dp-task-detail__body">
+    <div
+      v-if="activeTask"
+      ref="drawerScrollAnchorRef"
+      v-loading="activeTaskLoading"
+      class="dp-task-detail__body"
+    >
       <section class="dp-task-detail__hero">
-        <div class="dp-task-detail__hero-section-title">{{ t('protection.backupsPage.flowSourceDetailBasicData') }}</div>
+        <div class="dp-task-detail__hero-section-title">
+          {{ t('protection.backupsPage.flowSourceDetailBasicData') }}
+        </div>
         <div class="dp-task-detail__hero-grid">
           <div class="dp-task-detail__metric">
-            <Globe :size="18" class="dp-task-detail__metric-icon dp-task-detail__metric-icon--blue" />
+            <Globe
+              :size="18"
+              class="dp-task-detail__metric-icon dp-task-detail__metric-icon--blue"
+            />
             <div class="dp-task-detail__metric-copy">
               <span class="dp-task-detail__metric-label">{{ t('protection.backupsPage.flowSourceDetailTypeAndTrigger') }}</span>
               <div class="dp-task-detail__metric-tags">
-                <span class="dp-source-task-type-pill" :class="`dp-source-task-type-pill--${activeTask.task_type}`">
+                <span
+                  class="dp-source-task-type-pill"
+                  :class="`dp-source-task-type-pill--${activeTask.task_type}`"
+                >
                   <span class="dp-source-task-pill-text">{{ taskTypeLabel(activeTask.task_type) }}</span>
                 </span>
-                <span class="dp-source-task-trigger-pill" :class="`dp-source-task-trigger-pill--${activeTask.trigger_type}`">
+                <span
+                  class="dp-source-task-trigger-pill"
+                  :class="`dp-source-task-trigger-pill--${activeTask.trigger_type}`"
+                >
                   <span class="dp-source-task-pill-text">{{ taskTriggerLabel(activeTask.trigger_type) }}</span>
                 </span>
               </div>
@@ -3941,7 +4460,10 @@ function onClosed() {
           </div>
 
           <div class="dp-task-detail__metric">
-            <RotateCcw :size="18" class="dp-task-detail__metric-icon dp-task-detail__metric-icon--indigo" />
+            <RotateCcw
+              :size="18"
+              class="dp-task-detail__metric-icon dp-task-detail__metric-icon--indigo"
+            />
             <div class="dp-task-detail__metric-copy">
               <span class="dp-task-detail__metric-label">{{ t('protection.backupsPage.flowSourceDetailRetryCount') }}</span>
               <span class="dp-task-detail__metric-value">{{ activeTask.retry_count }}</span>
@@ -3949,19 +4471,31 @@ function onClosed() {
           </div>
 
           <div class="dp-task-detail__metric dp-task-detail__metric--wide">
-            <Clock3 :size="18" class="dp-task-detail__metric-icon" />
+            <Clock3
+              :size="18"
+              class="dp-task-detail__metric-icon"
+            />
             <div class="dp-task-detail__time-grid">
               <div>
                 <span class="dp-task-detail__metric-label">{{ t('protection.backupDetail.colStart') }}</span>
-                <span class="dp-task-detail__time-value" :class="{ 'hfl-empty-mark': !(activeTask.started_at || activeTask.created_at) }">{{ formatNullableTime(activeTask.started_at || activeTask.created_at) }}</span>
+                <span
+                  class="dp-task-detail__time-value"
+                  :class="{ 'hfl-empty-mark': !(activeTask.started_at || activeTask.created_at) }"
+                >{{ formatNullableTime(activeTask.started_at || activeTask.created_at) }}</span>
               </div>
               <div>
                 <span class="dp-task-detail__metric-label">{{ t('protection.backupDetail.colEnd') }}</span>
-                <span class="dp-task-detail__time-value" :class="{ 'hfl-empty-mark': !activeTask.finished_at }">{{ formatNullableTime(activeTask.finished_at) }}</span>
+                <span
+                  class="dp-task-detail__time-value"
+                  :class="{ 'hfl-empty-mark': !activeTask.finished_at }"
+                >{{ formatNullableTime(activeTask.finished_at) }}</span>
               </div>
               <div>
                 <span class="dp-task-detail__metric-label">{{ t('protection.backupsPage.flowSourceDetailDuration') }}</span>
-                <span class="dp-task-detail__time-value dp-task-detail__time-value--strong" :class="{ 'hfl-empty-mark': taskDuration(activeTask) === t('protection.backupDetail.durationDash') }">{{ taskDuration(activeTask) }}</span>
+                <span
+                  class="dp-task-detail__time-value dp-task-detail__time-value--strong"
+                  :class="{ 'hfl-empty-mark': taskDuration(activeTask) === t('protection.backupDetail.durationDash') }"
+                >{{ taskDuration(activeTask) }}</span>
               </div>
             </div>
           </div>
@@ -3973,7 +4507,10 @@ function onClosed() {
           :transfer-progress="activeTransferProgress"
           :failed="false"
         />
-        <div v-else class="dp-task-detail__progress-block">
+        <div
+          v-else
+          class="dp-task-detail__progress-block"
+        >
           <div class="dp-task-detail__progress-head">
             <span>{{ t('protection.backupsPage.flowTaskColProgress') }}</span>
             <span>{{ progressText(activeTask) }}</span>
@@ -3997,7 +4534,10 @@ function onClosed() {
       >
         <p>{{ activeTask.status === 'blocked' ? t('ops.task.blockedDescription') : t('ops.task.waitingDescription') }}</p>
         <ul>
-          <li v-for="dependency in activeTaskDependencies" :key="dependency.id">
+          <li
+            v-for="dependency in activeTaskDependencies"
+            :key="dependency.id"
+          >
             <span>{{ dependency.detail }}</span>
             <ElButton
               v-if="dependency.blocking_task_uuid"
@@ -4015,7 +4555,9 @@ function onClosed() {
         v-if="activeTask.task_type === 'backup' && (failedBackupDirectories.length || inProgressBackupDirectories.length)"
         class="dp-task-detail__directories"
       >
-        <div class="dp-task-detail__hero-section-title">{{ t('protection.backupsPage.backupTaskDirectoryStatus') }}</div>
+        <div class="dp-task-detail__hero-section-title">
+          {{ t('protection.backupsPage.backupTaskDirectoryStatus') }}
+        </div>
         <div class="dp-task-detail__directory-list">
           <div
             v-for="dir in [...inProgressBackupDirectories, ...failedBackupDirectories]"
@@ -4029,7 +4571,12 @@ function onClosed() {
                 <template v-if="directoryProgressPercent(dir) != null"> · {{ directoryProgressPercent(dir) }}%</template>
               </span>
             </div>
-            <div v-if="dir.error_message" class="dp-task-detail__directory-error">{{ dir.error_message }}</div>
+            <div
+              v-if="dir.error_message"
+              class="dp-task-detail__directory-error"
+            >
+              {{ dir.error_message }}
+            </div>
             <ElButton
               v-if="dir.status === 'failed'"
               size="small"
@@ -4056,144 +4603,281 @@ function onClosed() {
             </span>
           </template>
           <section class="dp-task-detail__tab-panel">
-        <div class="dp-task-detail__steps-head">
-          <span>{{ t('protection.backupsPage.flowSourceDetailStepsHint') }}</span>
-          <ElButton
-            v-if="hasExpandableTaskSteps"
-            size="small"
-            class="hfl-btn-with-icon"
-            @click="toggleAllTaskStepsExpanded"
-          >
-            {{ hasAnyExpandedTaskStep
-              ? t('protection.backupsPage.flowSourceDetailCollapseAll')
-              : t('protection.backupsPage.flowSourceDetailExpandAll') }}
-            <ChevronDown v-if="hasAnyExpandedTaskStep" :size="16" class="hfl-task-step-chevron" />
-            <ChevronRight v-else :size="16" class="hfl-task-step-chevron" />
-          </ElButton>
-        </div>
-
-        <div v-if="stepsWithEvents.length" class="dp-task-detail__step-list">
-          <div
-            v-for="(step, si) in stepsWithEvents"
-            :key="step.id"
-            class="dp-task-detail__step-item"
-            :class="{ 'dp-task-detail__step-item--last': si === stepsWithEvents.length - 1 && unlinkedTaskEvents.length === 0 }"
-          >
-            <div class="dp-task-detail__step-anchor" :class="timelineIconClass(step.status)">
-              <Check v-if="step.status === 'success'" :size="15" />
-              <X v-else-if="step.status === 'failed' || step.status === 'timeout'" :size="15" />
-              <LoaderCircle v-else-if="step.status === 'running'" :size="15" />
-              <Circle v-else :size="9" />
-            </div>
-
-            <article class="dp-task-detail__step-card">
-              <button
-                type="button"
-                class="dp-task-detail__step-card-head"
-                :class="{ 'dp-task-detail__step-card-head--disabled': step.events.length === 0 }"
-                :aria-expanded="step.events.length > 0 && isStepExpanded(step.id)"
-                :aria-disabled="step.events.length === 0"
-                :aria-description="step.events.length === 0 ? t('ops.task.emptyEvents') : undefined"
-                @click="toggleStep(step.id, step.events.length)"
+            <div class="dp-task-detail__steps-head">
+              <span>{{ t('protection.backupsPage.flowSourceDetailStepsHint') }}</span>
+              <ElButton
+                v-if="hasExpandableTaskSteps"
+                size="small"
+                class="hfl-btn-with-icon"
+                @click="toggleAllTaskStepsExpanded"
               >
-                <span class="dp-task-detail__step-title">
-                  {{ stepDisplayName(step.step_name, activeTask.task_type) }}
-                  <span class="dp-task-detail__step-executed-at" :class="{ 'hfl-empty-mark': !(step.created_at || activeTask.created_at) }">{{ formatNullableTime(step.created_at || activeTask.created_at) }}</span>
-                </span>
-                <TaskStatusTag :status="step.status" />
-                <span class="dp-task-detail__step-duration" :class="{ 'hfl-empty-mark': stepDuration(si) === t('protection.backupDetail.durationDash') }">
-                  <Clock3 :size="12" />
-                  {{ stepDuration(si) }}
-                </span>
-                <ElTooltip
-                  v-if="step.events.length === 0"
-                  :content="t('ops.task.emptyEvents')"
-                  teleported
-                  append-to="body"
-                  :z-index="3600"
-                  placement="top"
-                  :show-after="200"
-                >
-                  <span class="hfl-task-step-chevron hfl-task-step-chevron--disabled">
-                    <ChevronRight :size="16" aria-hidden="true" />
-                  </span>
-                </ElTooltip>
-                <ChevronDown v-else-if="isStepExpanded(step.id)" :size="16" class="hfl-task-step-chevron" />
-                <ChevronRight v-else :size="16" class="hfl-task-step-chevron" />
-              </button>
-
-              <div v-if="step.events.length > 0 && isStepExpanded(step.id)" class="dp-task-detail__event-list">
-                <div v-for="event in step.events" :key="event.id" class="dp-task-detail__event-row">
-                  <span class="dp-task-detail__event-dot" :class="`dp-task-detail__event-dot--${eventTone(event)}`">
-                    <X v-if="eventTone(event) === 'danger'" :size="9" />
-                    <Circle v-else-if="eventTone(event) === 'muted'" :size="7" />
-                    <Check v-else :size="9" />
-                  </span>
-                    <span class="dp-task-detail__event-content">
-                    <span class="dp-task-detail__event-msg" :class="eventMessageClass(event)">{{ eventDisplayMessage(event) }}</span>
-                    <span v-if="eventObjectText(event)" class="dp-task-detail__event-object">
-                      <Link2 :size="11" />
-                      <span>{{ eventObjectText(event) }}</span>
-                    </span>
-                    <span v-if="eventErrorText(event)" class="dp-task-detail__event-error">{{ eventErrorText(event) }}</span>
-                  </span>
-                  <span class="dp-task-detail__event-time" :class="{ 'hfl-empty-mark': !event.created_at }">{{ formatNullableTime(event.created_at) }}</span>
-                </div>
-              </div>
-            </article>
-          </div>
-
-          <div v-if="unlinkedTaskEvents.length > 0" class="dp-task-detail__step-item dp-task-detail__step-item--last">
-            <div class="dp-task-detail__step-anchor dp-task-detail__timeline-icon--muted">
-              <Circle :size="9" />
+                {{ hasAnyExpandedTaskStep
+                  ? t('protection.backupsPage.flowSourceDetailCollapseAll')
+                  : t('protection.backupsPage.flowSourceDetailExpandAll') }}
+                <ChevronDown
+                  v-if="hasAnyExpandedTaskStep"
+                  :size="16"
+                  class="hfl-task-step-chevron"
+                />
+                <ChevronRight
+                  v-else
+                  :size="16"
+                  class="hfl-task-step-chevron"
+                />
+              </ElButton>
             </div>
-            <article class="dp-task-detail__step-card">
-              <div class="dp-task-detail__step-card-head dp-task-detail__step-card-head--static">
-                <span class="dp-task-detail__step-title">{{ t('protection.backupsPage.flowSourceDetailEvents') }}</span>
-                <span class="dp-task-detail__step-duration" :class="{ 'hfl-empty-mark': taskDuration(activeTask) === t('protection.backupDetail.durationDash') }">{{ taskDuration(activeTask) }}</span>
-              </div>
-              <div class="dp-task-detail__event-list">
-                <div v-for="event in unlinkedTaskEvents" :key="event.id" class="dp-task-detail__event-row">
-                  <span class="dp-task-detail__event-dot" :class="`dp-task-detail__event-dot--${eventTone(event)}`">
-                    <X v-if="eventTone(event) === 'danger'" :size="9" />
-                    <Circle v-else-if="eventTone(event) === 'muted'" :size="7" />
-                    <Check v-else :size="9" />
-                  </span>
-                    <span class="dp-task-detail__event-content">
-                    <span class="dp-task-detail__event-msg" :class="eventMessageClass(event)">{{ eventDisplayMessage(event) }}</span>
-                    <span v-if="eventObjectText(event)" class="dp-task-detail__event-object">
-                      <Link2 :size="11" />
-                      <span>{{ eventObjectText(event) }}</span>
-                    </span>
-                    <span v-if="eventErrorText(event)" class="dp-task-detail__event-error">{{ eventErrorText(event) }}</span>
-                  </span>
-                  <span class="dp-task-detail__event-time">#{{ event.seq }} · <span :class="{ 'hfl-empty-mark': !event.created_at }">{{ formatNullableTime(event.created_at) }}</span></span>
+
+            <div
+              v-if="stepsWithEvents.length"
+              class="dp-task-detail__step-list"
+            >
+              <div
+                v-for="(step, si) in stepsWithEvents"
+                :key="step.id"
+                class="dp-task-detail__step-item"
+                :class="{ 'dp-task-detail__step-item--last': si === stepsWithEvents.length - 1 && unlinkedTaskEvents.length === 0 }"
+              >
+                <div
+                  class="dp-task-detail__step-anchor"
+                  :class="timelineIconClass(step.status)"
+                >
+                  <Check
+                    v-if="step.status === 'success'"
+                    :size="15"
+                  />
+                  <X
+                    v-else-if="step.status === 'failed' || step.status === 'timeout'"
+                    :size="15"
+                  />
+                  <LoaderCircle
+                    v-else-if="step.status === 'running'"
+                    :size="15"
+                  />
+                  <Circle
+                    v-else
+                    :size="9"
+                  />
                 </div>
-              </div>
-            </article>
-          </div>
-        </div>
 
-        <div v-else-if="taskDetailEvents.length" class="dp-task-detail__event-only">
-          <div v-for="event in taskDetailEvents" :key="event.id" class="dp-task-detail__event-row">
-            <span class="dp-task-detail__event-dot" :class="`dp-task-detail__event-dot--${eventTone(event)}`">
-              <X v-if="eventTone(event) === 'danger'" :size="9" />
-              <Circle v-else-if="eventTone(event) === 'muted'" :size="7" />
-              <Check v-else :size="9" />
-            </span>
-                    <span class="dp-task-detail__event-content">
-                    <span class="dp-task-detail__event-msg" :class="eventMessageClass(event)">{{ eventDisplayMessage(event) }}</span>
-                    <span v-if="eventObjectText(event)" class="dp-task-detail__event-object">
-                      <Link2 :size="11" />
-                      <span>{{ eventObjectText(event) }}</span>
+                <article class="dp-task-detail__step-card">
+                  <button
+                    type="button"
+                    class="dp-task-detail__step-card-head"
+                    :class="{ 'dp-task-detail__step-card-head--disabled': step.events.length === 0 }"
+                    :aria-expanded="step.events.length > 0 && isStepExpanded(step.id)"
+                    :aria-disabled="step.events.length === 0"
+                    :aria-description="step.events.length === 0 ? t('ops.task.emptyEvents') : undefined"
+                    @click="toggleStep(step.id, step.events.length)"
+                  >
+                    <span class="dp-task-detail__step-title">
+                      {{ stepDisplayName(step.step_name, activeTask.task_type) }}
+                      <span
+                        class="dp-task-detail__step-executed-at"
+                        :class="{ 'hfl-empty-mark': !(step.created_at || activeTask.created_at) }"
+                      >{{ formatNullableTime(step.created_at || activeTask.created_at) }}</span>
                     </span>
-                    <span v-if="eventErrorText(event)" class="dp-task-detail__event-error">{{ eventErrorText(event) }}</span>
-                  </span>
-            <span class="dp-task-detail__event-time">#{{ event.seq }} · <span :class="{ 'hfl-empty-mark': !event.created_at }">{{ formatNullableTime(event.created_at) }}</span></span>
-          </div>
-        </div>
+                    <TaskStatusTag :status="step.status" />
+                    <span
+                      class="dp-task-detail__step-duration"
+                      :class="{ 'hfl-empty-mark': stepDuration(si) === t('protection.backupDetail.durationDash') }"
+                    >
+                      <Clock3 :size="12" />
+                      {{ stepDuration(si) }}
+                    </span>
+                    <ElTooltip
+                      v-if="step.events.length === 0"
+                      :content="t('ops.task.emptyEvents')"
+                      teleported
+                      append-to="body"
+                      :z-index="3600"
+                      placement="top"
+                      :show-after="200"
+                    >
+                      <span class="hfl-task-step-chevron hfl-task-step-chevron--disabled">
+                        <ChevronRight
+                          :size="16"
+                          aria-hidden="true"
+                        />
+                      </span>
+                    </ElTooltip>
+                    <ChevronDown
+                      v-else-if="isStepExpanded(step.id)"
+                      :size="16"
+                      class="hfl-task-step-chevron"
+                    />
+                    <ChevronRight
+                      v-else
+                      :size="16"
+                      class="hfl-task-step-chevron"
+                    />
+                  </button>
 
-            <el-empty v-else :description="t('protection.backupsPage.flowSourceDetailEmptySteps')" :image-size="52" />
+                  <div
+                    v-if="step.events.length > 0 && isStepExpanded(step.id)"
+                    class="dp-task-detail__event-list"
+                  >
+                    <div
+                      v-for="event in step.events"
+                      :key="event.id"
+                      class="dp-task-detail__event-row"
+                    >
+                      <span
+                        class="dp-task-detail__event-dot"
+                        :class="`dp-task-detail__event-dot--${eventTone(event)}`"
+                      >
+                        <X
+                          v-if="eventTone(event) === 'danger'"
+                          :size="9"
+                        />
+                        <Circle
+                          v-else-if="eventTone(event) === 'muted'"
+                          :size="7"
+                        />
+                        <Check
+                          v-else
+                          :size="9"
+                        />
+                      </span>
+                      <span class="dp-task-detail__event-content">
+                        <span
+                          class="dp-task-detail__event-msg"
+                          :class="eventMessageClass(event)"
+                        >{{ eventDisplayMessage(event) }}</span>
+                        <span
+                          v-if="eventObjectText(event)"
+                          class="dp-task-detail__event-object"
+                        >
+                          <Link2 :size="11" />
+                          <span>{{ eventObjectText(event) }}</span>
+                        </span>
+                        <span
+                          v-if="eventErrorText(event)"
+                          class="dp-task-detail__event-error"
+                        >{{ eventErrorText(event) }}</span>
+                      </span>
+                      <span
+                        class="dp-task-detail__event-time"
+                        :class="{ 'hfl-empty-mark': !event.created_at }"
+                      >{{ formatNullableTime(event.created_at) }}</span>
+                    </div>
+                  </div>
+                </article>
+              </div>
+
+              <div
+                v-if="unlinkedTaskEvents.length > 0"
+                class="dp-task-detail__step-item dp-task-detail__step-item--last"
+              >
+                <div class="dp-task-detail__step-anchor dp-task-detail__timeline-icon--muted">
+                  <Circle :size="9" />
+                </div>
+                <article class="dp-task-detail__step-card">
+                  <div class="dp-task-detail__step-card-head dp-task-detail__step-card-head--static">
+                    <span class="dp-task-detail__step-title">{{ t('protection.backupsPage.flowSourceDetailEvents') }}</span>
+                    <span
+                      class="dp-task-detail__step-duration"
+                      :class="{ 'hfl-empty-mark': taskDuration(activeTask) === t('protection.backupDetail.durationDash') }"
+                    >{{ taskDuration(activeTask) }}</span>
+                  </div>
+                  <div class="dp-task-detail__event-list">
+                    <div
+                      v-for="event in unlinkedTaskEvents"
+                      :key="event.id"
+                      class="dp-task-detail__event-row"
+                    >
+                      <span
+                        class="dp-task-detail__event-dot"
+                        :class="`dp-task-detail__event-dot--${eventTone(event)}`"
+                      >
+                        <X
+                          v-if="eventTone(event) === 'danger'"
+                          :size="9"
+                        />
+                        <Circle
+                          v-else-if="eventTone(event) === 'muted'"
+                          :size="7"
+                        />
+                        <Check
+                          v-else
+                          :size="9"
+                        />
+                      </span>
+                      <span class="dp-task-detail__event-content">
+                        <span
+                          class="dp-task-detail__event-msg"
+                          :class="eventMessageClass(event)"
+                        >{{ eventDisplayMessage(event) }}</span>
+                        <span
+                          v-if="eventObjectText(event)"
+                          class="dp-task-detail__event-object"
+                        >
+                          <Link2 :size="11" />
+                          <span>{{ eventObjectText(event) }}</span>
+                        </span>
+                        <span
+                          v-if="eventErrorText(event)"
+                          class="dp-task-detail__event-error"
+                        >{{ eventErrorText(event) }}</span>
+                      </span>
+                      <span class="dp-task-detail__event-time">#{{ event.seq }} · <span :class="{ 'hfl-empty-mark': !event.created_at }">{{ formatNullableTime(event.created_at) }}</span></span>
+                    </div>
+                  </div>
+                </article>
+              </div>
+            </div>
+
+            <div
+              v-else-if="taskDetailEvents.length"
+              class="dp-task-detail__event-only"
+            >
+              <div
+                v-for="event in taskDetailEvents"
+                :key="event.id"
+                class="dp-task-detail__event-row"
+              >
+                <span
+                  class="dp-task-detail__event-dot"
+                  :class="`dp-task-detail__event-dot--${eventTone(event)}`"
+                >
+                  <X
+                    v-if="eventTone(event) === 'danger'"
+                    :size="9"
+                  />
+                  <Circle
+                    v-else-if="eventTone(event) === 'muted'"
+                    :size="7"
+                  />
+                  <Check
+                    v-else
+                    :size="9"
+                  />
+                </span>
+                <span class="dp-task-detail__event-content">
+                  <span
+                    class="dp-task-detail__event-msg"
+                    :class="eventMessageClass(event)"
+                  >{{ eventDisplayMessage(event) }}</span>
+                  <span
+                    v-if="eventObjectText(event)"
+                    class="dp-task-detail__event-object"
+                  >
+                    <Link2 :size="11" />
+                    <span>{{ eventObjectText(event) }}</span>
+                  </span>
+                  <span
+                    v-if="eventErrorText(event)"
+                    class="dp-task-detail__event-error"
+                  >{{ eventErrorText(event) }}</span>
+                </span>
+                <span class="dp-task-detail__event-time">#{{ event.seq }} · <span :class="{ 'hfl-empty-mark': !event.created_at }">{{ formatNullableTime(event.created_at) }}</span></span>
+              </div>
+            </div>
+
+            <el-empty
+              v-else
+              :description="t('protection.backupsPage.flowSourceDetailEmptySteps')"
+              :image-size="52"
+            />
           </section>
         </ElTabPane>
 
@@ -4205,110 +4889,157 @@ function onClosed() {
             </span>
           </template>
           <section class="dp-task-detail__tab-panel">
-        <div v-if="resourceTypeTabs.length" class="dp-task-detail__resource-view">
-          <div class="dp-task-detail__resource-switcher">
-            <button
-              v-for="item in resourceTypeTabs"
-              :key="item.type"
-              type="button"
-              class="dp-task-detail__resource-switch"
-              :class="{ 'dp-task-detail__resource-switch--active': selectedResourceType === item.type }"
-              @click="loadResourceType(item.type)"
+            <div
+              v-if="resourceTypeTabs.length"
+              class="dp-task-detail__resource-view"
             >
-              <Link2 :size="14" />
-              {{ item.label }}
-              <span class="hfl-task-drawer__resource-switch-count">{{ item.count }}</span>
-            </button>
-          </div>
-
-          <div v-if="resourceErrors[selectedResourceType]" class="dp-task-detail__resource-error">
-            {{ resourceErrors[selectedResourceType] }}
-          </div>
-
-          <el-table
-            v-table-column-resize="'protection.flowBackupSource.resources'"
-            v-table-overflow-title
-            v-loading="resourceLoading"
-            :data="selectedResourceRows"
-            class="hfl-list-table hfl-list-table--compact dp-task-detail__resource-table"
-          >
-            <el-table-column :label="t('protection.backupsPage.flowSourceDetailResourceId')" width="120">
-              <template #default="{ row }">
-                <span class="hfl-table-cell-mono">{{ row.id }}</span>
-              </template>
-            </el-table-column>
-            <el-table-column
-              v-if="selectedResourceType === 'backup_source'"
-              :label="t('protection.backupsPage.colBackupSource')"
-              min-width="180"
-            >
-              <template #default="{ row }">
-                <FlowSourceSummaryCell
-                  v-if="row.flowSource"
-                  :row="row.flowSource"
-                  :interactive="false"
-                />
-                <span v-else class="hfl-empty-mark">—</span>
-              </template>
-            </el-table-column>
-            <el-table-column v-if="selectedResourceType === 'backup_source'" :label="t('protection.backupsPage.colConnectionAddress')" min-width="200">
-              <template #default="{ row }">
-                <FlowSourceConnectionCell v-if="row.flowSource" :row="row.flowSource" />
-                <span v-else class="hfl-empty-mark">—</span>
-              </template>
-            </el-table-column>
-            <el-table-column v-if="selectedResourceType !== 'backup_source'" :label="t('protection.backupsPage.flowSourceDetailResourceName')" min-width="180">
-              <template #default="{ row }">
-                <div class="dp-task-detail__resource-name">{{ row.name }}</div>
-                <div class="dp-task-detail__resource-summary">{{ row.summary }}</div>
-              </template>
-            </el-table-column>
-            <el-table-column v-if="selectedResourceType !== 'backup_source'" :label="t('protection.backupsPage.flowSourceDetailResourceType')" width="130">
-              <template #default="{ row }">
-                <ElTag type="info" size="small" effect="plain">
-                  {{ row.type }}
-                </ElTag>
-              </template>
-            </el-table-column>
-            <el-table-column
-              :label="selectedResourceType === 'backup_source'
-                ? t('protection.sourceResources.colConnectivity')
-                : t('ops.task.colStatus')"
-              width="120"
-            >
-              <template #default="{ row }">
-                <ElTag
-                  v-if="selectedResourceType === 'backup_source' && row.availability"
-                  :type="flowSourceStatusTagType(row.availability)"
-                  :class="{ 'hfl-tag--neutral': flowSourceStatusTag(row.availability) === 'neutral' }"
-                  size="small"
+              <div class="dp-task-detail__resource-switcher">
+                <button
+                  v-for="item in resourceTypeTabs"
+                  :key="item.type"
+                  type="button"
+                  class="dp-task-detail__resource-switch"
+                  :class="{ 'dp-task-detail__resource-switch--active': selectedResourceType === item.type }"
+                  @click="loadResourceType(item.type)"
                 >
-                  {{ flowSourceStatusLabel(row.availability) }}
-                </ElTag>
-                <ElTag
-                  v-else-if="selectedResourceType !== 'backup_source' && row.status"
-                  v-bind="lifecycleStatusTagAttrs(row.statusValue)"
-                  size="small"
+                  <Link2 :size="14" />
+                  {{ item.label }}
+                  <span class="hfl-task-drawer__resource-switch-count">{{ item.count }}</span>
+                </button>
+              </div>
+
+              <div
+                v-if="resourceErrors[selectedResourceType]"
+                class="dp-task-detail__resource-error"
+              >
+                {{ resourceErrors[selectedResourceType] }}
+              </div>
+
+              <el-table
+                v-table-column-resize="'protection.flowBackupSource.resources'"
+                v-table-overflow-title
+                v-loading="resourceLoading"
+                :data="selectedResourceRows"
+                class="hfl-list-table hfl-list-table--compact dp-task-detail__resource-table"
+              >
+                <el-table-column
+                  :label="t('protection.backupsPage.flowSourceDetailResourceId')"
+                  width="120"
                 >
-                  {{ row.status }}
-                </ElTag>
-                <span v-else class="hfl-empty-mark">—</span>
-              </template>
-            </el-table-column>
-            <el-table-column :label="selectedResourceType === 'backup_source' ? t('protection.sourceResources.colRegisteredAt') : t('ops.task.updatedAt')" width="180">
-              <template #default="{ row }">
-                <span
-                  class="hfl-table-cell-time"
-                  :class="{ 'hfl-empty-mark': !(selectedResourceType === 'backup_source' ? row.registeredAt : row.updatedAt) }"
-                >{{ formatNullableTime(selectedResourceType === 'backup_source' ? row.registeredAt : row.updatedAt) }}</span>
-              </template>
-            </el-table-column>
-          </el-table>
-        </div>
-            <el-empty v-else :description="t('protection.backupsPage.flowSourceDetailEmptyResources')" :image-size="52" />
+                  <template #default="{ row }">
+                    <span class="hfl-table-cell-mono">{{ row.id }}</span>
+                  </template>
+                </el-table-column>
+                <el-table-column
+                  v-if="selectedResourceType === 'backup_source'"
+                  :label="t('protection.backupsPage.colBackupSource')"
+                  min-width="180"
+                >
+                  <template #default="{ row }">
+                    <FlowSourceSummaryCell
+                      v-if="row.flowSource"
+                      :row="row.flowSource"
+                      :interactive="false"
+                    />
+                    <span
+                      v-else
+                      class="hfl-empty-mark"
+                    >—</span>
+                  </template>
+                </el-table-column>
+                <el-table-column
+                  v-if="selectedResourceType === 'backup_source'"
+                  :label="t('protection.backupsPage.colConnectionAddress')"
+                  min-width="200"
+                >
+                  <template #default="{ row }">
+                    <FlowSourceConnectionCell
+                      v-if="row.flowSource"
+                      :row="row.flowSource"
+                    />
+                    <span
+                      v-else
+                      class="hfl-empty-mark"
+                    >—</span>
+                  </template>
+                </el-table-column>
+                <el-table-column
+                  v-if="selectedResourceType !== 'backup_source'"
+                  :label="t('protection.backupsPage.flowSourceDetailResourceName')"
+                  min-width="180"
+                >
+                  <template #default="{ row }">
+                    <div class="dp-task-detail__resource-name">
+                      {{ row.name }}
+                    </div>
+                    <div class="dp-task-detail__resource-summary">
+                      {{ row.summary }}
+                    </div>
+                  </template>
+                </el-table-column>
+                <el-table-column
+                  v-if="selectedResourceType !== 'backup_source'"
+                  :label="t('protection.backupsPage.flowSourceDetailResourceType')"
+                  width="130"
+                >
+                  <template #default="{ row }">
+                    <ElTag
+                      type="info"
+                      size="small"
+                      effect="plain"
+                    >
+                      {{ row.type }}
+                    </ElTag>
+                  </template>
+                </el-table-column>
+                <el-table-column
+                  :label="selectedResourceType === 'backup_source'
+                    ? t('protection.sourceResources.colConnectivity')
+                    : t('ops.task.colStatus')"
+                  width="120"
+                >
+                  <template #default="{ row }">
+                    <ElTag
+                      v-if="selectedResourceType === 'backup_source' && row.availability"
+                      :type="flowSourceStatusTagType(row.availability)"
+                      :class="{ 'hfl-tag--neutral': flowSourceStatusTag(row.availability) === 'neutral' }"
+                      size="small"
+                    >
+                      {{ flowSourceStatusLabel(row.availability) }}
+                    </ElTag>
+                    <ElTag
+                      v-else-if="selectedResourceType !== 'backup_source' && row.status"
+                      v-bind="lifecycleStatusTagAttrs(row.statusValue)"
+                      size="small"
+                    >
+                      {{ row.status }}
+                    </ElTag>
+                    <span
+                      v-else
+                      class="hfl-empty-mark"
+                    >—</span>
+                  </template>
+                </el-table-column>
+                <el-table-column
+                  :label="selectedResourceType === 'backup_source' ? t('protection.sourceResources.colRegisteredAt') : t('ops.task.updatedAt')"
+                  width="180"
+                >
+                  <template #default="{ row }">
+                    <span
+                      class="hfl-table-cell-time"
+                      :class="{ 'hfl-empty-mark': !(selectedResourceType === 'backup_source' ? row.registeredAt : row.updatedAt) }"
+                    >{{ formatNullableTime(selectedResourceType === 'backup_source' ? row.registeredAt : row.updatedAt) }}</span>
+                  </template>
+                </el-table-column>
+              </el-table>
+            </div>
+            <el-empty
+              v-else
+              :description="t('protection.backupsPage.flowSourceDetailEmptyResources')"
+              :image-size="52"
+            />
           </section>
         </ElTabPane>
-
       </ElTabs>
     </div>
   </ElDrawer>

--- a/src/frontend/src/pages/protection/components/FlowSourceExecutorCell.vue
+++ b/src/frontend/src/pages/protection/components/FlowSourceExecutorCell.vue
@@ -14,9 +14,18 @@ const nodeParts = computed(() => flowSourceNodeParts(props.row))
 </script>
 
 <template>
-  <span v-if="row.type === 'host'" class="protection-flow-cell-muted">{{ t('protection.backupsPage.flowExecutorLocalAgent') }}</span>
-  <div v-else class="protection-flow-node-cell">
+  <span
+    v-if="row.type === 'host'"
+    class="protection-flow-cell-muted"
+  >{{ t('protection.backupsPage.flowExecutorLocalAgent') }}</span>
+  <div
+    v-else
+    class="protection-flow-node-cell"
+  >
     <span class="source-node-name">{{ nodeParts.name }}</span>
-    <span v-if="nodeParts.ip" class="source-ip-text">{{ nodeParts.ip }}</span>
+    <span
+      v-if="nodeParts.ip"
+      class="source-ip-text"
+    >{{ nodeParts.ip }}</span>
   </div>
 </template>

--- a/src/frontend/src/pages/protection/components/FlowSourceProtocolCell.vue
+++ b/src/frontend/src/pages/protection/components/FlowSourceProtocolCell.vue
@@ -29,19 +29,29 @@ const hostPlatformLabel = computed(() => {
 </script>
 
 <template>
-  <span v-if="row.type === 'host' && row.platform" class="source-os-cell source-os-cell--compact">
+  <span
+    v-if="row.type === 'host' && row.platform"
+    class="source-os-cell source-os-cell--compact"
+  >
     <span class="source-os-cell__icon-wrap">
       <AgentPlatformBrandIcon :os="row.platform as EnrollmentOs" />
     </span>
     <span class="source-os-cell__platform">{{ hostPlatformLabel }}</span>
   </span>
-  <span v-else-if="row.type === 'host'" class="hfl-empty-mark">{{ t('protection.backupDetail.durationDash') }}</span>
+  <span
+    v-else-if="row.type === 'host'"
+    class="hfl-empty-mark"
+  >{{ t('protection.backupDetail.durationDash') }}</span>
   <span
     v-else
     class="repo-protocol-pill"
     :class="`repo-protocol-pill--${row.protocol || 'nfs'}`"
   >
-    <component :is="nasMountProtocolIcon(row.protocol)" :size="12" stroke-width="2.25" />
+    <component
+      :is="nasMountProtocolIcon(row.protocol)"
+      :size="12"
+      stroke-width="2.25"
+    />
     {{ protocolLabel }}
   </span>
 </template>

--- a/src/frontend/src/pages/protection/components/FlowSourceTypeCell.vue
+++ b/src/frontend/src/pages/protection/components/FlowSourceTypeCell.vue
@@ -19,7 +19,11 @@ const label = computed(() =>
 </script>
 
 <template>
-  <el-tag size="small" effect="plain" :type="row.type === 'host' ? 'info' : 'success'">
+  <el-tag
+    size="small"
+    effect="plain"
+    :type="row.type === 'host' ? 'info' : 'success'"
+  >
     {{ label }}
   </el-tag>
 </template>

--- a/src/frontend/src/pages/protection/components/KopiaTransferProgress.vue
+++ b/src/frontend/src/pages/protection/components/KopiaTransferProgress.vue
@@ -49,9 +49,19 @@ const showPercentMetric = computed(() => shouldShowPercentMetric(props.progress)
 </script>
 
 <template>
-  <div class="kopia-transfer-progress" :class="{ 'is-compact': compact, 'is-failed': failed }">
-    <p v-if="orchestrationLabel" class="kopia-transfer-progress__label">
-      <span v-if="!failed" class="kopia-transfer-progress__spinner" aria-hidden="true" />
+  <div
+    class="kopia-transfer-progress"
+    :class="{ 'is-compact': compact, 'is-failed': failed }"
+  >
+    <p
+      v-if="orchestrationLabel"
+      class="kopia-transfer-progress__label"
+    >
+      <span
+        v-if="!failed"
+        class="kopia-transfer-progress__spinner"
+        aria-hidden="true"
+      />
       {{ orchestrationLabel }}
     </p>
     <el-progress
@@ -61,9 +71,15 @@ const showPercentMetric = computed(() => shouldShowPercentMetric(props.progress)
       :stroke-width="compact ? 7 : 8"
       :show-text="compact"
     />
-    <p v-if="showMetrics" class="kopia-transfer-progress__metrics">
+    <p
+      v-if="showMetrics"
+      class="kopia-transfer-progress__metrics"
+    >
       <span v-if="capacity">{{ capacity }}</span>
-      <span v-else class="hfl-empty-mark">—</span>
+      <span
+        v-else
+        class="hfl-empty-mark"
+      >—</span>
       <span v-if="showPercentMetric">{{ percent }}%</span>
       <span :class="{ 'hfl-empty-mark': !speed }">{{ speed || '—' }}</span>
       <span :class="{ 'hfl-empty-mark': !eta }">{{ eta || '—' }}</span>

--- a/src/frontend/src/pages/protection/components/NasAddForm.vue
+++ b/src/frontend/src/pages/protection/components/NasAddForm.vue
@@ -108,7 +108,11 @@ defineExpose({
             >
               <div class="add-nas-protocol-card__inner">
                 <span class="add-nas-protocol-card__icon">
-                  <component :is="nasProtocolSmbIcon" :size="20" stroke-width="2" />
+                  <component
+                    :is="nasProtocolSmbIcon"
+                    :size="20"
+                    stroke-width="2"
+                  />
                 </span>
                 <div class="add-nas-protocol-card__text">
                   <div class="add-nas-protocol-card__title">
@@ -124,7 +128,11 @@ defineExpose({
             >
               <div class="add-nas-protocol-card__inner">
                 <span class="add-nas-protocol-card__icon">
-                  <component :is="nasProtocolNfsIcon" :size="20" stroke-width="2" />
+                  <component
+                    :is="nasProtocolNfsIcon"
+                    :size="20"
+                    stroke-width="2"
+                  />
                 </span>
                 <div class="add-nas-protocol-card__text">
                   <div class="add-nas-protocol-card__title">
@@ -148,61 +156,109 @@ defineExpose({
             label-position="top"
             class="add-nas-form fullscreen-form-el-form"
           >
-            <div v-if="protocol === 'smb'" class="add-nas-form-row add-nas-form-row--triple">
-              <ElFormItem data-validation-field="smbServer" :error="validationErrors?.smbServer" :label="t('addNasRepo.fieldSmbHost')" required class="flex-1">
+            <div
+              v-if="protocol === 'smb'"
+              class="add-nas-form-row add-nas-form-row--triple"
+            >
+              <ElFormItem
+                data-validation-field="smbServer"
+                :error="validationErrors?.smbServer"
+                :label="t('addNasRepo.fieldSmbHost')"
+                required
+                class="flex-1"
+              >
                 <ElInput
                   :model-value="smbServer"
                   :placeholder="t('protection.sourceResources.nasPhSmbHost')"
                   @update:model-value="emit('update:smbServer', $event as string)"
                   @input="emit('clearValidationError', 'smbServer')"
                 />
-                <p class="add-nas-field-hint">{{ t('protection.sourceResources.nasHintSmbHost') }}</p>
+                <p class="add-nas-field-hint">
+                  {{ t('protection.sourceResources.nasHintSmbHost') }}
+                </p>
               </ElFormItem>
-              <ElFormItem data-validation-field="smbShare" :error="validationErrors?.smbShare" :label="t('addNasRepo.fieldSmbShare')" required class="flex-1">
+              <ElFormItem
+                data-validation-field="smbShare"
+                :error="validationErrors?.smbShare"
+                :label="t('addNasRepo.fieldSmbShare')"
+                required
+                class="flex-1"
+              >
                 <ElInput
                   :model-value="smbShare"
                   :placeholder="t('protection.sourceResources.nasPhSmbShare')"
                   @update:model-value="emit('update:smbShare', $event as string)"
                   @input="emit('clearValidationError', 'smbShare')"
                 />
-                <p class="add-nas-field-hint">{{ t('protection.sourceResources.nasHintSmbShare') }}</p>
+                <p class="add-nas-field-hint">
+                  {{ t('protection.sourceResources.nasHintSmbShare') }}
+                </p>
               </ElFormItem>
-              <ElFormItem :label="t('addNasRepo.fieldMountOptions')" class="flex-1">
+              <ElFormItem
+                :label="t('addNasRepo.fieldMountOptions')"
+                class="flex-1"
+              >
                 <ElInput
                   :model-value="nfsOptions"
                   :placeholder="t('protection.sourceResources.nasPhMountOptionsSmb')"
                   @update:model-value="emit('update:nfsOptions', $event as string)"
                 />
-                <p class="add-nas-field-hint">{{ t('protection.sourceResources.nasHintMountOptionsSmb') }}</p>
+                <p class="add-nas-field-hint">
+                  {{ t('protection.sourceResources.nasHintMountOptionsSmb') }}
+                </p>
               </ElFormItem>
             </div>
 
-            <div v-else class="add-nas-form-row add-nas-form-row--triple">
-              <ElFormItem data-validation-field="nfsHost" :error="validationErrors?.nfsHost" :label="t('addNasRepo.fieldNfsHost')" required class="flex-1">
+            <div
+              v-else
+              class="add-nas-form-row add-nas-form-row--triple"
+            >
+              <ElFormItem
+                data-validation-field="nfsHost"
+                :error="validationErrors?.nfsHost"
+                :label="t('addNasRepo.fieldNfsHost')"
+                required
+                class="flex-1"
+              >
                 <ElInput
                   :model-value="nfsHost"
                   :placeholder="t('protection.sourceResources.nasPhNfsHost')"
                   @update:model-value="emit('update:nfsHost', $event as string)"
                   @input="emit('clearValidationError', 'nfsHost')"
                 />
-                <p class="add-nas-field-hint">{{ t('protection.sourceResources.nasHintNfsHost') }}</p>
+                <p class="add-nas-field-hint">
+                  {{ t('protection.sourceResources.nasHintNfsHost') }}
+                </p>
               </ElFormItem>
-              <ElFormItem data-validation-field="nfsExport" :error="validationErrors?.nfsExport" :label="t('addNasRepo.fieldNfsExport')" required class="flex-1">
+              <ElFormItem
+                data-validation-field="nfsExport"
+                :error="validationErrors?.nfsExport"
+                :label="t('addNasRepo.fieldNfsExport')"
+                required
+                class="flex-1"
+              >
                 <ElInput
                   :model-value="nfsExport"
                   :placeholder="t('protection.sourceResources.nasPhNfsExport')"
                   @update:model-value="emit('update:nfsExport', $event as string)"
                   @input="emit('clearValidationError', 'nfsExport')"
                 />
-                <p class="add-nas-field-hint">{{ t('protection.sourceResources.nasHintNfsExport') }}</p>
+                <p class="add-nas-field-hint">
+                  {{ t('protection.sourceResources.nasHintNfsExport') }}
+                </p>
               </ElFormItem>
-              <ElFormItem :label="t('addNasRepo.fieldMountOptions')" class="flex-1">
+              <ElFormItem
+                :label="t('addNasRepo.fieldMountOptions')"
+                class="flex-1"
+              >
                 <ElInput
                   :model-value="nfsOptions"
                   :placeholder="t('protection.sourceResources.nasPhMountOptionsNfs')"
                   @update:model-value="emit('update:nfsOptions', $event as string)"
                 />
-                <p class="add-nas-field-hint">{{ t('protection.sourceResources.nasHintMountOptionsNfs') }}</p>
+                <p class="add-nas-field-hint">
+                  {{ t('protection.sourceResources.nasHintMountOptionsNfs') }}
+                </p>
               </ElFormItem>
             </div>
           </ElForm>
@@ -213,33 +269,54 @@ defineExpose({
               class="add-nas-form add-nas-form--auth fullscreen-form-el-form"
             >
               <div class="add-nas-form-row add-nas-form-row--triple">
-                <ElFormItem data-validation-field="smbUsername" :error="validationErrors?.smbUsername" :label="t('protection.sourceResources.nasFieldSmbUsername')" required class="flex-1">
+                <ElFormItem
+                  data-validation-field="smbUsername"
+                  :error="validationErrors?.smbUsername"
+                  :label="t('protection.sourceResources.nasFieldSmbUsername')"
+                  required
+                  class="flex-1"
+                >
                   <ElInput
                     :model-value="smbUsername"
                     :placeholder="t('protection.sourceResources.nasPhSmbUsername')"
-                  @update:model-value="emit('update:smbUsername', $event as string)"
-                  @input="emit('clearValidationError', 'smbUsername')"
-                />
-                  <p class="add-nas-field-hint">{{ t('protection.sourceResources.nasHintSmbUsername') }}</p>
+                    @update:model-value="emit('update:smbUsername', $event as string)"
+                    @input="emit('clearValidationError', 'smbUsername')"
+                  />
+                  <p class="add-nas-field-hint">
+                    {{ t('protection.sourceResources.nasHintSmbUsername') }}
+                  </p>
                 </ElFormItem>
-                <ElFormItem data-validation-field="smbPassword" :error="validationErrors?.smbPassword" :label="t('protection.sourceResources.nasFieldSmbPassword')" required class="flex-1">
+                <ElFormItem
+                  data-validation-field="smbPassword"
+                  :error="validationErrors?.smbPassword"
+                  :label="t('protection.sourceResources.nasFieldSmbPassword')"
+                  required
+                  class="flex-1"
+                >
                   <ElInput
                     :model-value="smbPassword"
                     type="password"
                     show-password
                     :placeholder="t('protection.sourceResources.nasPhSmbPassword')"
-                  @update:model-value="emit('update:smbPassword', $event as string)"
-                  @input="emit('clearValidationError', 'smbPassword')"
-                />
-                  <p class="add-nas-field-hint">{{ t('protection.sourceResources.nasHintSmbPassword') }}</p>
+                    @update:model-value="emit('update:smbPassword', $event as string)"
+                    @input="emit('clearValidationError', 'smbPassword')"
+                  />
+                  <p class="add-nas-field-hint">
+                    {{ t('protection.sourceResources.nasHintSmbPassword') }}
+                  </p>
                 </ElFormItem>
-                <ElFormItem :label="t('protection.sourceResources.nasFieldSmbDomain')" class="flex-1">
+                <ElFormItem
+                  :label="t('protection.sourceResources.nasFieldSmbDomain')"
+                  class="flex-1"
+                >
                   <ElInput
                     :model-value="smbDomain"
                     :placeholder="t('protection.sourceResources.nasPhSmbDomain')"
                     @update:model-value="emit('update:smbDomain', $event as string)"
                   />
-                  <p class="add-nas-field-hint">{{ t('protection.sourceResources.nasHintSmbDomain') }}</p>
+                  <p class="add-nas-field-hint">
+                    {{ t('protection.sourceResources.nasHintSmbDomain') }}
+                  </p>
                 </ElFormItem>
               </div>
             </ElForm>
@@ -247,7 +324,10 @@ defineExpose({
         </section>
       </div>
 
-      <div ref="bindSectionRef" class="fullscreen-form-card">
+      <div
+        ref="bindSectionRef"
+        class="fullscreen-form-card"
+      >
         <section class="fullscreen-form-section">
           <h3 class="fullscreen-form-section__title">
             <span class="fullscreen-form-section__indicator" />
@@ -309,7 +389,10 @@ defineExpose({
                       :disabled="proxyNodesRefreshing"
                       @click="emit('refreshProxyNodes')"
                     >
-                      <RefreshCw :size="16" :class="{ 'is-spinning': proxyNodesRefreshing }" />
+                      <RefreshCw
+                        :size="16"
+                        :class="{ 'is-spinning': proxyNodesRefreshing }"
+                      />
                     </ElButton>
                     <ElButton
                       class="fullscreen-form-icon-btn add-nas-select-row__deploy"
@@ -328,7 +411,13 @@ defineExpose({
                   {{ bindNodeError || proxySelectEmptyHint() || t('protection.sourceResources.nasHintBindProxy') }}
                 </p>
               </ElFormItem>
-              <ElFormItem data-validation-field="dir" :error="validationErrors?.dir" :label="t('protection.sourceResources.nasFieldDir')" required class="add-nas-dir-form-item flex-1">
+              <ElFormItem
+                data-validation-field="dir"
+                :error="validationErrors?.dir"
+                :label="t('protection.sourceResources.nasFieldDir')"
+                required
+                class="add-nas-dir-form-item flex-1"
+              >
                 <div class="add-nas-control-field">
                   <ElInput
                     :model-value="dir"
@@ -337,7 +426,9 @@ defineExpose({
                     @input="emit('dirTouched')"
                   />
                 </div>
-                <p class="add-nas-field-hint add-nas-bind-row__dir-hint">{{ t('protection.sourceResources.nasFieldDirHint') }}</p>
+                <p class="add-nas-field-hint add-nas-bind-row__dir-hint">
+                  {{ t('protection.sourceResources.nasFieldDirHint') }}
+                </p>
               </ElFormItem>
             </div>
           </ElForm>
@@ -354,17 +445,31 @@ defineExpose({
             label-position="top"
             class="add-nas-form fullscreen-form-el-form"
           >
-            <ElFormItem data-validation-field="name" :error="validationErrors?.name" :label="t('protection.sourceResources.nasFieldName')" required class="flex-1">
+            <ElFormItem
+              data-validation-field="name"
+              :error="validationErrors?.name"
+              :label="t('protection.sourceResources.nasFieldName')"
+              required
+              class="flex-1"
+            >
               <ElInput
                 :model-value="name"
                 :placeholder="generatedName"
                 @update:model-value="emit('update:name', $event as string); emit('clearValidationError', 'name')"
                 @input="emit('nameTouched')"
               />
-              <p v-if="nameConflictMessage" class="add-nas-field-hint add-nas-field-hint--warn">
+              <p
+                v-if="nameConflictMessage"
+                class="add-nas-field-hint add-nas-field-hint--warn"
+              >
                 {{ nameConflictMessage }}
               </p>
-              <p v-else class="add-nas-field-hint">{{ t('protection.sourceResources.nasHintName') }}</p>
+              <p
+                v-else
+                class="add-nas-field-hint"
+              >
+                {{ t('protection.sourceResources.nasHintName') }}
+              </p>
             </ElFormItem>
           </ElForm>
         </section>

--- a/src/frontend/src/pages/protection/components/NasSourceDetailDrawer.vue
+++ b/src/frontend/src/pages/protection/components/NasSourceDetailDrawer.vue
@@ -477,26 +477,64 @@ onUnmounted(() => {
       <span class="hfl-detail-drawer__title">{{ row?.name || DETAIL_EMPTY }}</span>
     </template>
 
-    <div v-if="row" v-loading="saving" class="hfl-detail-drawer__body">
-      <ElTabs model-value="basic" class="hfl-detail-tabs">
-        <ElTabPane :label="t('protection.sourceResources.detailTabBasic')" name="basic">
+    <div
+      v-if="row"
+      v-loading="saving"
+      class="hfl-detail-drawer__body"
+    >
+      <ElTabs
+        model-value="basic"
+        class="hfl-detail-tabs"
+      >
+        <ElTabPane
+          :label="t('protection.sourceResources.detailTabBasic')"
+          name="basic"
+        >
           <div class="hfl-detail-sections">
             <section class="hfl-detail-section">
-              <h4 class="hfl-detail-section__title">{{ t('protection.sourceResources.detailSectionIdentity') }}</h4>
+              <h4 class="hfl-detail-section__title">
+                {{ t('protection.sourceResources.detailSectionIdentity') }}
+              </h4>
               <div class="hfl-detail-grid">
                 <div class="hfl-detail-row">
                   <span class="hfl-detail-row__label">{{ t('protection.sourceResources.fieldSourceName') }}</span>
                   <span class="hfl-detail-row__value hfl-detail-row__value--editable">
                     <template v-if="detailDraft && isFieldEditing('name')">
-                      <ElInput v-model="detailDraft.name" size="small" class="hfl-detail-inline-edit__input" :disabled="saving" @keyup.enter="saveDetailChanges" />
+                      <ElInput
+                        v-model="detailDraft.name"
+                        size="small"
+                        class="hfl-detail-inline-edit__input"
+                        :disabled="saving"
+                        @keyup.enter="saveDetailChanges"
+                      />
                       <span class="hfl-detail-inline-edit__actions">
-                        <ElButton text circle size="small" :title="t('common.save')" :disabled="saving" @click="saveDetailChanges"><Check :size="14" /></ElButton>
-                        <ElButton text circle size="small" :title="t('common.cancel')" :disabled="saving" @click="cancelFieldEdit"><X :size="14" /></ElButton>
+                        <ElButton
+                          text
+                          circle
+                          size="small"
+                          :title="t('common.save')"
+                          :disabled="saving"
+                          @click="saveDetailChanges"
+                        ><Check :size="14" /></ElButton>
+                        <ElButton
+                          text
+                          circle
+                          size="small"
+                          :title="t('common.cancel')"
+                          :disabled="saving"
+                          @click="cancelFieldEdit"
+                        ><X :size="14" /></ElButton>
                       </span>
                     </template>
                     <template v-else>
                       <span class="hfl-detail-row__text">{{ row.name }}</span>
-                      <ElButton text circle size="small" class="hfl-detail-row__edit" @click="beginFieldEdit('name')"><Pencil :size="13" /></ElButton>
+                      <ElButton
+                        text
+                        circle
+                        size="small"
+                        class="hfl-detail-row__edit"
+                        @click="beginFieldEdit('name')"
+                      ><Pencil :size="13" /></ElButton>
                     </template>
                   </span>
                 </div>
@@ -508,7 +546,14 @@ onUnmounted(() => {
                   <span class="hfl-detail-row__label">{{ t('protection.sourceResources.fieldSourceId') }}</span>
                   <span class="hfl-detail-row__value hfl-detail-row__value--editable hfl-detail-row__value--mono">
                     <span class="hfl-detail-row__text">{{ sourceIdText }}</span>
-                    <ElButton text circle size="small" class="hfl-detail-row__edit" :title="t('common.copy')" @click="copyText(sourceIdText)">
+                    <ElButton
+                      text
+                      circle
+                      size="small"
+                      class="hfl-detail-row__edit"
+                      :title="t('common.copy')"
+                      @click="copyText(sourceIdText)"
+                    >
                       <Copy :size="13" />
                     </ElButton>
                   </span>
@@ -517,7 +562,11 @@ onUnmounted(() => {
                   <span class="hfl-detail-row__label">{{ t('protection.sourceResources.colProtocol') }}</span>
                   <span class="hfl-detail-row__value">
                     <span :class="protocolPillClass(protocol)">
-                      <component :is="nasMountProtocolIcon(protocol)" :size="12" stroke-width="2.25" />
+                      <component
+                        :is="nasMountProtocolIcon(protocol)"
+                        :size="12"
+                        stroke-width="2.25"
+                      />
                       {{ protocolLabel(protocol) }}
                     </span>
                   </span>
@@ -526,21 +575,52 @@ onUnmounted(() => {
             </section>
 
             <section class="hfl-detail-section">
-              <h4 class="hfl-detail-section__title">{{ t('protection.sourceResources.detailSectionAccess') }}</h4>
+              <h4 class="hfl-detail-section__title">
+                {{ t('protection.sourceResources.detailSectionAccess') }}
+              </h4>
               <div class="hfl-detail-grid">
                 <div class="hfl-detail-row">
                   <span class="hfl-detail-row__label">{{ t('protection.sourceResources.colNasServer') }}</span>
-                  <span class="hfl-detail-row__value hfl-detail-row__value--editable" :class="detailValueClass(displayOrEmpty(cfg('server')), true)">
+                  <span
+                    class="hfl-detail-row__value hfl-detail-row__value--editable"
+                    :class="detailValueClass(displayOrEmpty(cfg('server')), true)"
+                  >
                     <template v-if="detailDraft && isFieldEditing('server')">
-                      <ElInput v-model="detailDraft.server" size="small" class="hfl-detail-inline-edit__input" :disabled="saving" @keyup.enter="saveDetailChanges" />
+                      <ElInput
+                        v-model="detailDraft.server"
+                        size="small"
+                        class="hfl-detail-inline-edit__input"
+                        :disabled="saving"
+                        @keyup.enter="saveDetailChanges"
+                      />
                       <span class="hfl-detail-inline-edit__actions">
-                        <ElButton text circle size="small" :title="t('common.save')" :disabled="saving" @click="saveDetailChanges"><Check :size="14" /></ElButton>
-                        <ElButton text circle size="small" :title="t('common.cancel')" :disabled="saving" @click="cancelFieldEdit"><X :size="14" /></ElButton>
+                        <ElButton
+                          text
+                          circle
+                          size="small"
+                          :title="t('common.save')"
+                          :disabled="saving"
+                          @click="saveDetailChanges"
+                        ><Check :size="14" /></ElButton>
+                        <ElButton
+                          text
+                          circle
+                          size="small"
+                          :title="t('common.cancel')"
+                          :disabled="saving"
+                          @click="cancelFieldEdit"
+                        ><X :size="14" /></ElButton>
                       </span>
                     </template>
                     <template v-else>
                       <span class="hfl-detail-row__text">{{ displayOrEmpty(cfg('server')) }}</span>
-                      <ElButton text circle size="small" class="hfl-detail-row__edit" @click="beginFieldEdit('server')"><Pencil :size="13" /></ElButton>
+                      <ElButton
+                        text
+                        circle
+                        size="small"
+                        class="hfl-detail-row__edit"
+                        @click="beginFieldEdit('server')"
+                      ><Pencil :size="13" /></ElButton>
                     </template>
                   </span>
                 </div>
@@ -570,8 +650,22 @@ onUnmounted(() => {
                         @keyup.enter="saveDetailChanges"
                       />
                       <span class="hfl-detail-inline-edit__actions">
-                        <ElButton text circle size="small" :title="t('common.save')" :disabled="saving" @click="saveDetailChanges"><Check :size="14" /></ElButton>
-                        <ElButton text circle size="small" :title="t('common.cancel')" :disabled="saving" @click="cancelFieldEdit"><X :size="14" /></ElButton>
+                        <ElButton
+                          text
+                          circle
+                          size="small"
+                          :title="t('common.save')"
+                          :disabled="saving"
+                          @click="saveDetailChanges"
+                        ><Check :size="14" /></ElButton>
+                        <ElButton
+                          text
+                          circle
+                          size="small"
+                          :title="t('common.cancel')"
+                          :disabled="saving"
+                          @click="cancelFieldEdit"
+                        ><X :size="14" /></ElButton>
                       </span>
                     </template>
                     <template v-else>
@@ -593,23 +687,55 @@ onUnmounted(() => {
                 <template v-if="protocol === 'smb'">
                   <div class="hfl-detail-row">
                     <span class="hfl-detail-row__label">{{ t('protection.sourceResources.nasFieldSmbUsername') }}</span>
-                    <span class="hfl-detail-row__value hfl-detail-row__value--editable" :class="detailValueClass(displayOrEmpty(cred('username')))">
+                    <span
+                      class="hfl-detail-row__value hfl-detail-row__value--editable"
+                      :class="detailValueClass(displayOrEmpty(cred('username')))"
+                    >
                       <template v-if="detailDraft && isFieldEditing('username')">
-                        <ElInput v-model="detailDraft.username" size="small" class="hfl-detail-inline-edit__input" :disabled="saving" @keyup.enter="saveDetailChanges" />
+                        <ElInput
+                          v-model="detailDraft.username"
+                          size="small"
+                          class="hfl-detail-inline-edit__input"
+                          :disabled="saving"
+                          @keyup.enter="saveDetailChanges"
+                        />
                         <span class="hfl-detail-inline-edit__actions">
-                          <ElButton text circle size="small" :title="t('common.save')" :disabled="saving" @click="saveDetailChanges"><Check :size="14" /></ElButton>
-                          <ElButton text circle size="small" :title="t('common.cancel')" :disabled="saving" @click="cancelFieldEdit"><X :size="14" /></ElButton>
+                          <ElButton
+                            text
+                            circle
+                            size="small"
+                            :title="t('common.save')"
+                            :disabled="saving"
+                            @click="saveDetailChanges"
+                          ><Check :size="14" /></ElButton>
+                          <ElButton
+                            text
+                            circle
+                            size="small"
+                            :title="t('common.cancel')"
+                            :disabled="saving"
+                            @click="cancelFieldEdit"
+                          ><X :size="14" /></ElButton>
                         </span>
                       </template>
                       <template v-else>
                         <span class="hfl-detail-row__text">{{ displayOrEmpty(cred('username')) }}</span>
-                        <ElButton text circle size="small" class="hfl-detail-row__edit" @click="beginFieldEdit('username')"><Pencil :size="13" /></ElButton>
+                        <ElButton
+                          text
+                          circle
+                          size="small"
+                          class="hfl-detail-row__edit"
+                          @click="beginFieldEdit('username')"
+                        ><Pencil :size="13" /></ElButton>
                       </template>
                     </span>
                   </div>
                   <div class="hfl-detail-row">
                     <span class="hfl-detail-row__label">{{ t('protection.sourceResources.nasFieldSmbPassword') }}</span>
-                    <span class="hfl-detail-row__value hfl-detail-row__value--editable" :class="detailValueClass(passwordDisplay())">
+                    <span
+                      class="hfl-detail-row__value hfl-detail-row__value--editable"
+                      :class="detailValueClass(passwordDisplay())"
+                    >
                       <template v-if="detailDraft && isFieldEditing('password')">
                         <ElInput
                           v-model="detailDraft.password"
@@ -622,34 +748,86 @@ onUnmounted(() => {
                           @keyup.enter="saveDetailChanges"
                         />
                         <span class="hfl-detail-inline-edit__actions">
-                          <ElButton text circle size="small" :title="t('common.save')" :disabled="saving" @click="saveDetailChanges"><Check :size="14" /></ElButton>
-                          <ElButton text circle size="small" :title="t('common.cancel')" :disabled="saving" @click="cancelFieldEdit"><X :size="14" /></ElButton>
+                          <ElButton
+                            text
+                            circle
+                            size="small"
+                            :title="t('common.save')"
+                            :disabled="saving"
+                            @click="saveDetailChanges"
+                          ><Check :size="14" /></ElButton>
+                          <ElButton
+                            text
+                            circle
+                            size="small"
+                            :title="t('common.cancel')"
+                            :disabled="saving"
+                            @click="cancelFieldEdit"
+                          ><X :size="14" /></ElButton>
                         </span>
                       </template>
                       <template v-else>
                         <span class="hfl-detail-row__text">{{ passwordDisplay() }}</span>
-                        <ElButton text circle size="small" class="hfl-detail-row__edit" @click="beginFieldEdit('password')"><Pencil :size="13" /></ElButton>
+                        <ElButton
+                          text
+                          circle
+                          size="small"
+                          class="hfl-detail-row__edit"
+                          @click="beginFieldEdit('password')"
+                        ><Pencil :size="13" /></ElButton>
                       </template>
                     </span>
                   </div>
                 </template>
                 <div class="hfl-detail-row">
                   <span class="hfl-detail-row__label">{{ t('addNasRepo.fieldMountOptions') }}</span>
-                  <span class="hfl-detail-row__value hfl-detail-row__value--editable" :class="detailValueClass(displayOrEmpty(cfg('options')), true)">
+                  <span
+                    class="hfl-detail-row__value hfl-detail-row__value--editable"
+                    :class="detailValueClass(displayOrEmpty(cfg('options')), true)"
+                  >
                     <template v-if="detailDraft && isFieldEditing('options')">
-                      <ElInput v-model="detailDraft.options" size="small" class="hfl-detail-inline-edit__input" :disabled="saving" @keyup.enter="saveDetailChanges" />
+                      <ElInput
+                        v-model="detailDraft.options"
+                        size="small"
+                        class="hfl-detail-inline-edit__input"
+                        :disabled="saving"
+                        @keyup.enter="saveDetailChanges"
+                      />
                       <span class="hfl-detail-inline-edit__actions">
-                        <ElButton text circle size="small" :title="t('common.save')" :disabled="saving" @click="saveDetailChanges"><Check :size="14" /></ElButton>
-                        <ElButton text circle size="small" :title="t('common.cancel')" :disabled="saving" @click="cancelFieldEdit"><X :size="14" /></ElButton>
+                        <ElButton
+                          text
+                          circle
+                          size="small"
+                          :title="t('common.save')"
+                          :disabled="saving"
+                          @click="saveDetailChanges"
+                        ><Check :size="14" /></ElButton>
+                        <ElButton
+                          text
+                          circle
+                          size="small"
+                          :title="t('common.cancel')"
+                          :disabled="saving"
+                          @click="cancelFieldEdit"
+                        ><X :size="14" /></ElButton>
                       </span>
                     </template>
                     <template v-else>
                       <span class="hfl-detail-row__text">{{ displayOrEmpty(cfg('options')) }}</span>
-                      <ElButton text circle size="small" class="hfl-detail-row__edit" @click="beginFieldEdit('options')"><Pencil :size="13" /></ElButton>
+                      <ElButton
+                        text
+                        circle
+                        size="small"
+                        class="hfl-detail-row__edit"
+                        @click="beginFieldEdit('options')"
+                      ><Pencil :size="13" /></ElButton>
                     </template>
                   </span>
                 </div>
-                <div v-if="protocol === 'nfs'" class="hfl-detail-row">
+                <div
+                  v-if="protocol === 'nfs'"
+                  class="hfl-detail-row"
+                >
                   <span class="hfl-detail-row__label">{{ t('protection.sourceResources.colConnection') }}</span>
                   <span class="hfl-detail-row__value hfl-detail-row__value--editable hfl-detail-row__value--mono">
                     <span class="hfl-detail-row__text">{{ connectionUri }}</span>
@@ -666,23 +844,58 @@ onUnmounted(() => {
                     </ElButton>
                   </span>
                 </div>
-                <div v-if="protocol === 'smb'" class="hfl-detail-row">
+                <div
+                  v-if="protocol === 'smb'"
+                  class="hfl-detail-row"
+                >
                   <span class="hfl-detail-row__label">{{ t('protection.sourceResources.nasFieldSmbDomain') }}</span>
-                  <span class="hfl-detail-row__value hfl-detail-row__value--editable" :class="detailValueClass(displayOrEmpty(cred('domain')))">
+                  <span
+                    class="hfl-detail-row__value hfl-detail-row__value--editable"
+                    :class="detailValueClass(displayOrEmpty(cred('domain')))"
+                  >
                     <template v-if="detailDraft && isFieldEditing('domain')">
-                      <ElInput v-model="detailDraft.domain" size="small" class="hfl-detail-inline-edit__input" :disabled="saving" @keyup.enter="saveDetailChanges" />
+                      <ElInput
+                        v-model="detailDraft.domain"
+                        size="small"
+                        class="hfl-detail-inline-edit__input"
+                        :disabled="saving"
+                        @keyup.enter="saveDetailChanges"
+                      />
                       <span class="hfl-detail-inline-edit__actions">
-                        <ElButton text circle size="small" :title="t('common.save')" :disabled="saving" @click="saveDetailChanges"><Check :size="14" /></ElButton>
-                        <ElButton text circle size="small" :title="t('common.cancel')" :disabled="saving" @click="cancelFieldEdit"><X :size="14" /></ElButton>
+                        <ElButton
+                          text
+                          circle
+                          size="small"
+                          :title="t('common.save')"
+                          :disabled="saving"
+                          @click="saveDetailChanges"
+                        ><Check :size="14" /></ElButton>
+                        <ElButton
+                          text
+                          circle
+                          size="small"
+                          :title="t('common.cancel')"
+                          :disabled="saving"
+                          @click="cancelFieldEdit"
+                        ><X :size="14" /></ElButton>
                       </span>
                     </template>
                     <template v-else>
                       <span class="hfl-detail-row__text">{{ displayOrEmpty(cred('domain')) }}</span>
-                      <ElButton text circle size="small" class="hfl-detail-row__edit" @click="beginFieldEdit('domain')"><Pencil :size="13" /></ElButton>
+                      <ElButton
+                        text
+                        circle
+                        size="small"
+                        class="hfl-detail-row__edit"
+                        @click="beginFieldEdit('domain')"
+                      ><Pencil :size="13" /></ElButton>
                     </template>
                   </span>
                 </div>
-                <div v-if="protocol === 'smb'" class="hfl-detail-row hfl-detail-row--full">
+                <div
+                  v-if="protocol === 'smb'"
+                  class="hfl-detail-row hfl-detail-row--full"
+                >
                   <span class="hfl-detail-row__label">{{ t('protection.sourceResources.colConnection') }}</span>
                   <span class="hfl-detail-row__value hfl-detail-row__value--editable hfl-detail-row__value--mono">
                     <span class="hfl-detail-row__text">{{ connectionUri }}</span>
@@ -703,11 +916,16 @@ onUnmounted(() => {
             </section>
 
             <section class="hfl-detail-section">
-              <h4 class="hfl-detail-section__title">{{ t('protection.sourceResources.detailSectionProxy') }}</h4>
+              <h4 class="hfl-detail-section__title">
+                {{ t('protection.sourceResources.detailSectionProxy') }}
+              </h4>
               <div class="hfl-detail-grid">
                 <div class="hfl-detail-row">
                   <span class="hfl-detail-row__label">{{ t('protection.sourceResources.colSourceProxy') }}</span>
-                  <span class="hfl-detail-row__value hfl-detail-row__value--editable" :class="detailValueClass(proxyPrimaryText, true)">
+                  <span
+                    class="hfl-detail-row__value hfl-detail-row__value--editable"
+                    :class="detailValueClass(proxyPrimaryText, true)"
+                  >
                     <template v-if="detailDraft && isFieldEditing('bound_node_id')">
                       <ElSelect
                         v-model="detailDraft.bound_node_id"
@@ -727,43 +945,102 @@ onUnmounted(() => {
                         >
                           <div class="nas-detail-proxy-option">
                             <span class="nas-detail-proxy-option__text">{{ proxyNodeSelectLine(node) }}</span>
-                            <ElTag size="small" :type="proxyNodeStatusTagType(node)" effect="plain">
+                            <ElTag
+                              size="small"
+                              :type="proxyNodeStatusTagType(node)"
+                              effect="plain"
+                            >
                               {{ proxyNodeStatusLabel(node) }}
                             </ElTag>
                           </div>
                         </ElOption>
                       </ElSelect>
                       <span class="hfl-detail-inline-edit__actions">
-                        <ElButton text circle size="small" :title="t('common.save')" :disabled="saving" @click="saveDetailChanges"><Check :size="14" /></ElButton>
-                        <ElButton text circle size="small" :title="t('common.cancel')" :disabled="saving" @click="cancelFieldEdit"><X :size="14" /></ElButton>
+                        <ElButton
+                          text
+                          circle
+                          size="small"
+                          :title="t('common.save')"
+                          :disabled="saving"
+                          @click="saveDetailChanges"
+                        ><Check :size="14" /></ElButton>
+                        <ElButton
+                          text
+                          circle
+                          size="small"
+                          :title="t('common.cancel')"
+                          :disabled="saving"
+                          @click="cancelFieldEdit"
+                        ><X :size="14" /></ElButton>
                       </span>
                     </template>
                     <template v-else>
                       <div class="table-stack-cell hfl-table-no-tooltip">
                         <span class="table-stack-cell__primary">{{ proxyPrimaryText }}</span>
-                        <span v-if="!isDetailEmpty(proxyIpText)" class="table-stack-cell__secondary">{{ proxyIpText }}</span>
+                        <span
+                          v-if="!isDetailEmpty(proxyIpText)"
+                          class="table-stack-cell__secondary"
+                        >{{ proxyIpText }}</span>
                       </div>
-                      <ElButton text circle size="small" class="hfl-detail-row__edit" @click="beginFieldEdit('bound_node_id')"><Pencil :size="13" /></ElButton>
+                      <ElButton
+                        text
+                        circle
+                        size="small"
+                        class="hfl-detail-row__edit"
+                        @click="beginFieldEdit('bound_node_id')"
+                      ><Pencil :size="13" /></ElButton>
                     </template>
                   </span>
                 </div>
                 <div class="hfl-detail-row">
                   <span class="hfl-detail-row__label">{{ t('protection.sourceResources.fieldProxyVersion') }}</span>
-                  <span class="hfl-detail-row__value" :class="detailValueClass(proxyVersionText)">{{ proxyVersionText }}</span>
+                  <span
+                    class="hfl-detail-row__value"
+                    :class="detailValueClass(proxyVersionText)"
+                  >{{ proxyVersionText }}</span>
                 </div>
                 <div class="hfl-detail-row">
                   <span class="hfl-detail-row__label">{{ t('protection.sourceResources.nasFieldDir') }}</span>
-                  <span class="hfl-detail-row__value hfl-detail-row__value--editable" :class="detailValueClass(mountDirText, true)">
+                  <span
+                    class="hfl-detail-row__value hfl-detail-row__value--editable"
+                    :class="detailValueClass(mountDirText, true)"
+                  >
                     <template v-if="detailDraft && isFieldEditing('path')">
-                      <ElInput v-model="detailDraft.path" size="small" class="hfl-detail-inline-edit__input" :disabled="saving" @keyup.enter="saveDetailChanges" />
+                      <ElInput
+                        v-model="detailDraft.path"
+                        size="small"
+                        class="hfl-detail-inline-edit__input"
+                        :disabled="saving"
+                        @keyup.enter="saveDetailChanges"
+                      />
                       <span class="hfl-detail-inline-edit__actions">
-                        <ElButton text circle size="small" :title="t('common.save')" :disabled="saving" @click="saveDetailChanges"><Check :size="14" /></ElButton>
-                        <ElButton text circle size="small" :title="t('common.cancel')" :disabled="saving" @click="cancelFieldEdit"><X :size="14" /></ElButton>
+                        <ElButton
+                          text
+                          circle
+                          size="small"
+                          :title="t('common.save')"
+                          :disabled="saving"
+                          @click="saveDetailChanges"
+                        ><Check :size="14" /></ElButton>
+                        <ElButton
+                          text
+                          circle
+                          size="small"
+                          :title="t('common.cancel')"
+                          :disabled="saving"
+                          @click="cancelFieldEdit"
+                        ><X :size="14" /></ElButton>
                       </span>
                     </template>
                     <template v-else>
                       <span class="hfl-detail-row__text">{{ mountDirText }}</span>
-                      <ElButton text circle size="small" class="hfl-detail-row__edit" @click="beginFieldEdit('path')"><Pencil :size="13" /></ElButton>
+                      <ElButton
+                        text
+                        circle
+                        size="small"
+                        class="hfl-detail-row__edit"
+                        @click="beginFieldEdit('path')"
+                      ><Pencil :size="13" /></ElButton>
                     </template>
                   </span>
                 </div>
@@ -771,7 +1048,9 @@ onUnmounted(() => {
             </section>
 
             <section class="hfl-detail-section">
-              <h4 class="hfl-detail-section__title">{{ t('protection.sourceResources.detailSectionRuntime') }}</h4>
+              <h4 class="hfl-detail-section__title">
+                {{ t('protection.sourceResources.detailSectionRuntime') }}
+              </h4>
               <div class="hfl-detail-grid">
                 <div class="hfl-detail-row">
                   <span class="hfl-detail-row__label">{{ t('protection.sourceResources.colLifecycleStatus') }}</span>
@@ -788,7 +1067,10 @@ onUnmounted(() => {
                 </div>
                 <div class="hfl-detail-row hfl-detail-row--full">
                   <span class="hfl-detail-row__label">{{ t('protection.sourceResources.colCapacity') }}</span>
-                  <span class="hfl-detail-row__value" :class="{ 'hfl-detail-row__value--stacked': capacityParts.total > 0 }">
+                  <span
+                    class="hfl-detail-row__value"
+                    :class="{ 'hfl-detail-row__value--stacked': capacityParts.total > 0 }"
+                  >
                     <HflCapacityCell
                       :used-bytes="capacityParts.used"
                       :total-bytes="capacityParts.total"
@@ -801,20 +1083,32 @@ onUnmounted(() => {
                 <div class="hfl-detail-row">
                   <span class="hfl-detail-row__label">{{ t('protection.sourceResources.colConnectivity') }}</span>
                   <span class="hfl-detail-row__value">
-                    <ElTag :type="availabilityTagType" size="small">{{ availabilityLabel }}</ElTag>
+                    <ElTag
+                      :type="availabilityTagType"
+                      size="small"
+                    >{{ availabilityLabel }}</ElTag>
                   </span>
                 </div>
                 <div class="hfl-detail-row">
                   <span class="hfl-detail-row__label">{{ t('protection.sourceResources.fieldConnectivityUpdatedAt') }}</span>
-                  <span class="hfl-detail-row__value" :class="{ 'hfl-detail-row__empty': !row.availability_updated_at }">{{ formatNodeDate(row.availability_updated_at) }}</span>
+                  <span
+                    class="hfl-detail-row__value"
+                    :class="{ 'hfl-detail-row__empty': !row.availability_updated_at }"
+                  >{{ formatNodeDate(row.availability_updated_at) }}</span>
                 </div>
                 <div class="hfl-detail-row">
                   <span class="hfl-detail-row__label">{{ t('protection.sourceResources.colRegisteredAt') }}</span>
-                  <span class="hfl-detail-row__value" :class="{ 'hfl-detail-row__empty': !row.created_at }">{{ formatNodeDate(row.created_at) }}</span>
+                  <span
+                    class="hfl-detail-row__value"
+                    :class="{ 'hfl-detail-row__empty': !row.created_at }"
+                  >{{ formatNodeDate(row.created_at) }}</span>
                 </div>
                 <div class="hfl-detail-row">
                   <span class="hfl-detail-row__label">{{ t('protection.sourceResources.colLastHeartbeat') }}</span>
-                  <span class="hfl-detail-row__value" :class="detailValueClass(lastHeartbeatText)">{{ lastHeartbeatText }}</span>
+                  <span
+                    class="hfl-detail-row__value"
+                    :class="detailValueClass(lastHeartbeatText)"
+                  >{{ lastHeartbeatText }}</span>
                 </div>
               </div>
             </section>

--- a/src/frontend/src/pages/protection/components/PolicyDetailBasicPanel.vue
+++ b/src/frontend/src/pages/protection/components/PolicyDetailBasicPanel.vue
@@ -102,23 +102,55 @@ watch(
 </script>
 
 <template>
-  <div v-loading="loading" class="policy-detail-basic-panel policy-detail-overview">
+  <div
+    v-loading="loading"
+    class="policy-detail-basic-panel policy-detail-overview"
+  >
     <section class="hfl-detail-section">
-      <h4 class="hfl-detail-section__title">{{ t('protection.policiesPage.sectionPolicyInfo') }}</h4>
+      <h4 class="hfl-detail-section__title">
+        {{ t('protection.policiesPage.sectionPolicyInfo') }}
+      </h4>
       <div class="hfl-detail-grid">
         <div class="hfl-detail-row">
           <span class="hfl-detail-row__label">{{ t('protection.policiesPage.fieldName') }}</span>
           <span class="hfl-detail-row__value hfl-detail-row__value--editable">
             <template v-if="editingField === 'name'">
-              <ElInput v-model="inlineDraft" size="small" class="hfl-detail-inline-edit__input" :disabled="saving" @keyup.enter="saveInlineEdit" />
+              <ElInput
+                v-model="inlineDraft"
+                size="small"
+                class="hfl-detail-inline-edit__input"
+                :disabled="saving"
+                @keyup.enter="saveInlineEdit"
+              />
               <span class="hfl-detail-inline-edit__actions">
-                <ElButton text circle size="small" :title="t('common.save')" :disabled="saving" @click="saveInlineEdit"><Check :size="14" /></ElButton>
-                <ElButton text circle size="small" :title="t('common.cancel')" :disabled="saving" @click="cancelInlineEdit"><X :size="14" /></ElButton>
+                <ElButton
+                  text
+                  circle
+                  size="small"
+                  :title="t('common.save')"
+                  :disabled="saving"
+                  @click="saveInlineEdit"
+                ><Check :size="14" /></ElButton>
+                <ElButton
+                  text
+                  circle
+                  size="small"
+                  :title="t('common.cancel')"
+                  :disabled="saving"
+                  @click="cancelInlineEdit"
+                ><X :size="14" /></ElButton>
               </span>
             </template>
             <template v-else>
               <span class="hfl-detail-row__text">{{ policyForm.name || t('protection.policiesPage.timeDash') }}</span>
-              <ElButton text circle size="small" class="hfl-detail-row__edit" :title="t('common.edit')" @click="beginInlineEdit('name')">
+              <ElButton
+                text
+                circle
+                size="small"
+                class="hfl-detail-row__edit"
+                :title="t('common.edit')"
+                @click="beginInlineEdit('name')"
+              >
                 <Pencil :size="13" />
               </ElButton>
             </template>
@@ -128,10 +160,27 @@ watch(
           <span class="hfl-detail-row__label">{{ t('protection.policiesPage.fieldStatus') }}</span>
           <span class="hfl-detail-row__value hfl-detail-row__value--editable">
             <template v-if="editingField === 'active'">
-              <ElSwitch v-model="inlineDraft" :disabled="saving" />
+              <ElSwitch
+                v-model="inlineDraft"
+                :disabled="saving"
+              />
               <span class="hfl-detail-inline-edit__actions">
-                <ElButton text circle size="small" :title="t('common.save')" :disabled="saving" @click="saveInlineEdit"><Check :size="14" /></ElButton>
-                <ElButton text circle size="small" :title="t('common.cancel')" :disabled="saving" @click="cancelInlineEdit"><X :size="14" /></ElButton>
+                <ElButton
+                  text
+                  circle
+                  size="small"
+                  :title="t('common.save')"
+                  :disabled="saving"
+                  @click="saveInlineEdit"
+                ><Check :size="14" /></ElButton>
+                <ElButton
+                  text
+                  circle
+                  size="small"
+                  :title="t('common.cancel')"
+                  :disabled="saving"
+                  @click="cancelInlineEdit"
+                ><X :size="14" /></ElButton>
               </span>
             </template>
             <template v-else>
@@ -139,7 +188,14 @@ watch(
                 :value="policyForm.policyActive"
                 :label="policyForm.policyActive ? t('protection.policiesPage.switchEnabledOn') : t('protection.policiesPage.switchEnabledOff')"
               />
-              <ElButton text circle size="small" class="hfl-detail-row__edit" :title="t('common.edit')" @click="beginInlineEdit('active')">
+              <ElButton
+                text
+                circle
+                size="small"
+                class="hfl-detail-row__edit"
+                :title="t('common.edit')"
+                @click="beginInlineEdit('active')"
+              >
                 <Pencil :size="13" />
               </ElButton>
             </template>

--- a/src/frontend/src/pages/protection/components/PolicyDetailEditorForm.vue
+++ b/src/frontend/src/pages/protection/components/PolicyDetailEditorForm.vue
@@ -115,15 +115,24 @@ function enabledText(enabled: boolean) {
 
 <template>
   <div class="hfl-detail-sections policy-detail-overview">
-    <section v-if="!hideInfoSection" class="hfl-detail-section">
-      <h4 class="hfl-detail-section__title">{{ t('protection.policiesPage.sectionPolicyInfo') }}</h4>
+    <section
+      v-if="!hideInfoSection"
+      class="hfl-detail-section"
+    >
+      <h4 class="hfl-detail-section__title">
+        {{ t('protection.policiesPage.sectionPolicyInfo') }}
+      </h4>
       <div class="hfl-detail-grid">
         <div class="policy-detail-editor__pair-row">
           <div class="hfl-detail-row policy-detail-editor__pair-item">
             <span class="hfl-detail-row__label">{{ t('protection.policiesPage.fieldName') }}</span>
             <span class="hfl-detail-row__value policy-detail-overview__name-value">
               <span class="hfl-detail-row__text policy-detail-overview__primary">{{ policyForm.name || emptyText }}</span>
-              <ElTag :type="booleanStatusTag(policyForm.policyActive).type" :class="booleanStatusTag(policyForm.policyActive).class" size="small">{{ enabledText(policyForm.policyActive) }}</ElTag>
+              <ElTag
+                :type="booleanStatusTag(policyForm.policyActive).type"
+                :class="booleanStatusTag(policyForm.policyActive).class"
+                size="small"
+              >{{ enabledText(policyForm.policyActive) }}</ElTag>
             </span>
           </div>
           <div class="hfl-detail-row policy-detail-editor__pair-item">
@@ -146,14 +155,25 @@ function enabledText(enabled: boolean) {
       </div>
     </section>
 
-    <section class="hfl-detail-section" :class="{ 'policy-detail-overview__section--off': !policyForm.sectionScheduleEnabled }">
-      <h4 class="hfl-detail-section__title">{{ t('protection.policiesPage.sectionSchedule') }}</h4>
+    <section
+      class="hfl-detail-section"
+      :class="{ 'policy-detail-overview__section--off': !policyForm.sectionScheduleEnabled }"
+    >
+      <h4 class="hfl-detail-section__title">
+        {{ t('protection.policiesPage.sectionSchedule') }}
+      </h4>
       <div class="hfl-detail-grid">
-        <div v-if="!policyForm.sectionScheduleEnabled" class="hfl-detail-row hfl-detail-row--full">
+        <div
+          v-if="!policyForm.sectionScheduleEnabled"
+          class="hfl-detail-row hfl-detail-row--full"
+        >
           <span class="hfl-detail-row__label">{{ t('protection.policiesPage.fieldSchedule') }}</span>
           <span class="hfl-detail-row__value">{{ notConfiguredText }}</span>
         </div>
-        <div v-else class="policy-detail-editor__pair-row">
+        <div
+          v-else
+          class="policy-detail-editor__pair-row"
+        >
           <div class="hfl-detail-row policy-detail-editor__pair-item">
             <span class="hfl-detail-row__label">{{ t('protection.policiesPage.labelFreqMode') }}</span>
             <span class="hfl-detail-row__value">
@@ -166,44 +186,76 @@ function enabledText(enabled: boolean) {
               class="hfl-detail-row__value"
               :class="{ 'hfl-detail-row__value--stacked': policyForm.freqMode === 'advanced' }"
             >
-              <code v-if="policyForm.freqMode === 'advanced'" class="policy-detail-overview__code">{{ policyForm.cronExpr }}</code>
-              <span v-else class="hfl-detail-row__text">{{ quickScheduleLabel }}</span>
-              <span v-if="policyForm.freqMode === 'advanced'" class="hfl-detail-row__hint">{{ cronDescription }}</span>
+              <code
+                v-if="policyForm.freqMode === 'advanced'"
+                class="policy-detail-overview__code"
+              >{{ policyForm.cronExpr }}</code>
+              <span
+                v-else
+                class="hfl-detail-row__text"
+              >{{ quickScheduleLabel }}</span>
+              <span
+                v-if="policyForm.freqMode === 'advanced'"
+                class="hfl-detail-row__hint"
+              >{{ cronDescription }}</span>
             </span>
           </div>
         </div>
-        <div v-if="policyForm.sectionScheduleEnabled" class="policy-detail-editor__pair-row">
+        <div
+          v-if="policyForm.sectionScheduleEnabled"
+          class="policy-detail-editor__pair-row"
+        >
           <div class="hfl-detail-row policy-detail-editor__pair-item">
             <span class="hfl-detail-row__label">{{ t('protection.policiesPage.scheduleTimezone') }}</span>
             <span class="hfl-detail-row__value">{{ policyForm.scheduleTimezone || 'UTC' }}</span>
           </div>
           <div class="hfl-detail-row policy-detail-editor__pair-item">
             <span class="hfl-detail-row__label">{{ t('protection.policiesPage.scheduleStartsAt') }}</span>
-            <span class="hfl-detail-row__value" :class="{ 'hfl-detail-row__empty': !policyForm.scheduleStartsAt }">{{ formatScheduleStartForDisplay(policyForm.scheduleStartsAt, emptyText) }}</span>
+            <span
+              class="hfl-detail-row__value"
+              :class="{ 'hfl-detail-row__empty': !policyForm.scheduleStartsAt }"
+            >{{ formatScheduleStartForDisplay(policyForm.scheduleStartsAt, emptyText) }}</span>
           </div>
         </div>
-        <div v-if="policyForm.sectionScheduleEnabled" class="hfl-detail-row hfl-detail-row--full">
+        <div
+          v-if="policyForm.sectionScheduleEnabled"
+          class="hfl-detail-row hfl-detail-row--full"
+        >
           <span class="hfl-detail-row__label">{{ t('protection.policiesPage.fieldSchedule') }}</span>
           <span class="hfl-detail-row__value">{{ scheduleSummary }}</span>
         </div>
       </div>
     </section>
 
-    <section class="hfl-detail-section" :class="{ 'policy-detail-overview__section--off': !policyForm.sectionRetentionEnabled }">
-      <h4 class="hfl-detail-section__title">{{ t('protection.policiesPage.sectionRetention') }}</h4>
+    <section
+      class="hfl-detail-section"
+      :class="{ 'policy-detail-overview__section--off': !policyForm.sectionRetentionEnabled }"
+    >
+      <h4 class="hfl-detail-section__title">
+        {{ t('protection.policiesPage.sectionRetention') }}
+      </h4>
       <div class="hfl-detail-grid">
-        <div v-if="retentionDetailLines.length" class="policy-detail-overview__retention-list">
+        <div
+          v-if="retentionDetailLines.length"
+          class="policy-detail-overview__retention-list"
+        >
           <div
             v-for="line in retentionDetailLines"
             :key="`${line.label}${line.text}`"
             class="policy-detail-overview__retention-line"
             :class="{ 'policy-detail-overview__retention-line--summary': !line.label }"
           >
-            <span v-if="line.label" class="policy-detail-overview__retention-label">{{ line.label }}</span>
+            <span
+              v-if="line.label"
+              class="policy-detail-overview__retention-label"
+            >{{ line.label }}</span>
             <span class="policy-detail-overview__retention-text">{{ line.text }}</span>
           </div>
         </div>
-        <div v-else class="hfl-detail-row hfl-detail-row--full">
+        <div
+          v-else
+          class="hfl-detail-row hfl-detail-row--full"
+        >
           <span class="hfl-detail-row__label">{{ t('protection.policiesPage.fieldRetention') }}</span>
           <span class="hfl-detail-row__value">{{ notConfiguredText }}</span>
         </div>
@@ -211,14 +263,26 @@ function enabledText(enabled: boolean) {
     </section>
 
     <section class="hfl-detail-section">
-      <h4 class="hfl-detail-section__title">{{ t('protection.policiesPage.sectionErrorHandling') }}</h4>
+      <h4 class="hfl-detail-section__title">
+        {{ t('protection.policiesPage.sectionErrorHandling') }}
+      </h4>
       <div class="policy-detail-overview__list">
-        <div v-for="row in errorHandlingRows" :key="row.key" class="policy-detail-overview__list-row">
+        <div
+          v-for="row in errorHandlingRows"
+          :key="row.key"
+          class="policy-detail-overview__list-row"
+        >
           <div class="policy-detail-overview__list-copy">
             <span class="policy-detail-overview__list-title">{{ row.title }}</span>
             <span class="policy-detail-overview__list-desc">{{ row.desc }}</span>
           </div>
-          <ElTag :type="booleanStatusTag(policyForm[row.key]).type" :class="booleanStatusTag(policyForm[row.key]).class" size="small">{{ enabledText(policyForm[row.key]) }}</ElTag>
+          <ElTag
+            :type="booleanStatusTag(policyForm[row.key]).type"
+            :class="booleanStatusTag(policyForm[row.key]).class"
+            size="small"
+          >
+            {{ enabledText(policyForm[row.key]) }}
+          </ElTag>
         </div>
       </div>
     </section>

--- a/src/frontend/src/pages/protection/components/ProtectionPolicyEditorForm.vue
+++ b/src/frontend/src/pages/protection/components/ProtectionPolicyEditorForm.vue
@@ -346,16 +346,28 @@ function toggleScheduleMonthDay(day: number) {
   >
     <section :class="sectionClass">
       <h3 :class="titleClass">
-        <span v-if="variant === 'fullscreen'" class="fullscreen-form-section__indicator" />
+        <span
+          v-if="variant === 'fullscreen'"
+          class="fullscreen-form-section__indicator"
+        />
         {{ t('protection.policiesPage.tabBasic') }}
       </h3>
       <div class="policy-basic-grid">
-        <div data-validation-field="name" class="policy-basic-row">
-          <label class="policy-basic-row__label" for="policy-name-input">
+        <div
+          data-validation-field="name"
+          class="policy-basic-row"
+        >
+          <label
+            class="policy-basic-row__label"
+            for="policy-name-input"
+          >
             {{ t('protection.policiesPage.labelPolicyName') }}
             <span class="policy-basic-row__required">*</span>
           </label>
-          <div class="policy-basic-row__control" :class="{ 'is-invalid': !!nameError }">
+          <div
+            class="policy-basic-row__control"
+            :class="{ 'is-invalid': !!nameError }"
+          >
             <ElInput
               id="policy-name-input"
               v-model="policyForm.name"
@@ -364,7 +376,12 @@ function toggleScheduleMonthDay(day: number) {
               show-word-limit
               @input="$emit('clear-name-error')"
             />
-            <p v-if="nameError" class="fullscreen-form-inline-error">{{ nameError }}</p>
+            <p
+              v-if="nameError"
+              class="fullscreen-form-inline-error"
+            >
+              {{ nameError }}
+            </p>
           </div>
         </div>
         <div class="policy-basic-row">
@@ -376,20 +393,46 @@ function toggleScheduleMonthDay(day: number) {
       </div>
     </section>
 
-    <section data-validation-field="schedule" :class="nestedSectionClass">
+    <section
+      data-validation-field="schedule"
+      :class="nestedSectionClass"
+    >
       <div class="policy-section-head">
         <el-checkbox v-model="policyForm.sectionScheduleEnabled" />
         <span class="policy-section-head__title">{{ t('protection.policiesPage.sectionCheckSchedule') }}</span>
       </div>
-      <p v-if="!policyForm.sectionScheduleEnabled" class="policy-section-off-hint">{{ t('protection.policiesPage.sectionOffHint') }}</p>
-      <p v-if="scheduleError" class="fullscreen-form-inline-error">{{ scheduleError }}</p>
-      <div v-if="policyForm.sectionScheduleEnabled" class="policy-section-nested">
-        <el-radio-group v-model="policyForm.freqMode" class="mb-3">
-          <el-radio value="simple">{{ t('protection.policiesPage.freqSimple') }}</el-radio>
-          <el-radio value="advanced">{{ t('protection.policiesPage.freqAdvanced') }}</el-radio>
+      <p
+        v-if="!policyForm.sectionScheduleEnabled"
+        class="policy-section-off-hint"
+      >
+        {{ t('protection.policiesPage.sectionOffHint') }}
+      </p>
+      <p
+        v-if="scheduleError"
+        class="fullscreen-form-inline-error"
+      >
+        {{ scheduleError }}
+      </p>
+      <div
+        v-if="policyForm.sectionScheduleEnabled"
+        class="policy-section-nested"
+      >
+        <el-radio-group
+          v-model="policyForm.freqMode"
+          class="mb-3"
+        >
+          <el-radio value="simple">
+            {{ t('protection.policiesPage.freqSimple') }}
+          </el-radio>
+          <el-radio value="advanced">
+            {{ t('protection.policiesPage.freqAdvanced') }}
+          </el-radio>
         </el-radio-group>
         <div class="schedule-context-grid">
-          <ElFormItem :label="t('protection.policiesPage.scheduleTimezone')" class="!mb-0">
+          <ElFormItem
+            :label="t('protection.policiesPage.scheduleTimezone')"
+            class="!mb-0"
+          >
             <el-select
               v-model="policyForm.scheduleTimezone"
               filterable
@@ -404,7 +447,10 @@ function toggleScheduleMonthDay(day: number) {
               />
             </el-select>
           </ElFormItem>
-          <ElFormItem :label="t('protection.policiesPage.scheduleStartsAt')" class="!mb-0">
+          <ElFormItem
+            :label="t('protection.policiesPage.scheduleStartsAt')"
+            class="!mb-0"
+          >
             <ElDatePicker
               v-model="policyForm.scheduleStartsAt"
               type="datetime"
@@ -415,11 +461,22 @@ function toggleScheduleMonthDay(day: number) {
             />
           </ElFormItem>
         </div>
-        <p class="schedule-context-hint">{{ t('protection.policiesPage.scheduleTimezoneHint') }}</p>
+        <p class="schedule-context-hint">
+          {{ t('protection.policiesPage.scheduleTimezoneHint') }}
+        </p>
 
-        <div v-if="policyForm.freqMode === 'simple'" class="quick-schedule-stack">
-          <ElFormItem :label="t('protection.policiesPage.scheduleCycle')" class="!mb-0">
-            <el-select v-model="policyForm.quickScheduleType" class="schedule-cycle-control">
+        <div
+          v-if="policyForm.freqMode === 'simple'"
+          class="quick-schedule-stack"
+        >
+          <ElFormItem
+            :label="t('protection.policiesPage.scheduleCycle')"
+            class="!mb-0"
+          >
+            <el-select
+              v-model="policyForm.quickScheduleType"
+              class="schedule-cycle-control"
+            >
               <el-option
                 v-for="option in quickScheduleTypeOptions"
                 :key="option.value"
@@ -429,8 +486,14 @@ function toggleScheduleMonthDay(day: number) {
             </el-select>
           </ElFormItem>
 
-          <div v-if="policyForm.quickScheduleType === 'interval'" class="schedule-inline-controls">
-            <ElFormItem :label="t('protection.policiesPage.labelInterval')" class="!mb-0">
+          <div
+            v-if="policyForm.quickScheduleType === 'interval'"
+            class="schedule-inline-controls"
+          >
+            <ElFormItem
+              :label="t('protection.policiesPage.labelInterval')"
+              class="!mb-0"
+            >
               <el-select
                 v-model="policyForm.simpleIntervalUnit"
                 class="schedule-interval-unit"
@@ -444,7 +507,10 @@ function toggleScheduleMonthDay(day: number) {
                 />
               </el-select>
             </ElFormItem>
-            <ElFormItem :label="currentIntervalUnitMeta.valueLabel + t('protection.policiesPage.labelColon')" class="!mb-0">
+            <ElFormItem
+              :label="currentIntervalUnitMeta.valueLabel + t('protection.policiesPage.labelColon')"
+              class="!mb-0"
+            >
               <ElInputNumber
                 v-model="policyForm.simpleIntervalValue"
                 :min="currentIntervalUnitMeta.min"
@@ -456,9 +522,15 @@ function toggleScheduleMonthDay(day: number) {
           </div>
 
           <template v-else>
-            <div v-if="policyForm.quickScheduleType === 'weekly'" class="schedule-picker-block">
+            <div
+              v-if="policyForm.quickScheduleType === 'weekly'"
+              class="schedule-picker-block"
+            >
               <span class="schedule-picker-label">{{ t('protection.policiesPage.scheduleWeekdays') }}</span>
-              <ElCheckboxGroup v-model="policyForm.scheduleWeekdays" class="schedule-weekday-grid">
+              <ElCheckboxGroup
+                v-model="policyForm.scheduleWeekdays"
+                class="schedule-weekday-grid"
+              >
                 <ElCheckbox
                   v-for="option in scheduleWeekdayOptions"
                   :key="option.value"
@@ -469,7 +541,10 @@ function toggleScheduleMonthDay(day: number) {
               </ElCheckboxGroup>
             </div>
 
-            <div v-if="policyForm.quickScheduleType === 'monthly'" class="schedule-picker-block">
+            <div
+              v-if="policyForm.quickScheduleType === 'monthly'"
+              class="schedule-picker-block"
+            >
               <span class="schedule-picker-label">{{ t('protection.policiesPage.scheduleMonthDays') }}</span>
               <div class="schedule-month-day-grid">
                 <button
@@ -495,7 +570,10 @@ function toggleScheduleMonthDay(day: number) {
               </div>
             </div>
 
-            <ElFormItem :label="t('protection.policiesPage.scheduleTime')" class="schedule-time-field !mb-0">
+            <ElFormItem
+              :label="t('protection.policiesPage.scheduleTime')"
+              class="schedule-time-field !mb-0"
+            >
               <ElInput
                 v-model="policyForm.scheduleTime"
                 type="time"
@@ -503,11 +581,22 @@ function toggleScheduleMonthDay(day: number) {
               />
             </ElFormItem>
           </template>
-          <p v-if="scheduleErrorText" class="schedule-field-error">{{ scheduleErrorText }}</p>
+          <p
+            v-if="scheduleErrorText"
+            class="schedule-field-error"
+          >
+            {{ scheduleErrorText }}
+          </p>
         </div>
-        <div v-else class="space-y-3">
+        <div
+          v-else
+          class="space-y-3"
+        >
           <div class="cron-row">
-            <label class="cron-row__label" :for="cronInputId">
+            <label
+              class="cron-row__label"
+              :for="cronInputId"
+            >
               {{ t('protection.policiesPage.cronLabel') }}<span class="cron-row__required">*</span>
             </label>
             <div class="cron-row__field">
@@ -517,14 +606,26 @@ function toggleScheduleMonthDay(day: number) {
                 :placeholder="t('protection.policiesPage.cronPh')"
                 :class="['cron-input', { 'cron-input--error': policyForm.sectionScheduleEnabled && !cronValidation.ok }]"
               />
-              <p v-if="cronErrorText && policyForm.sectionScheduleEnabled" class="cron-row__error">{{ cronErrorText }}</p>
+              <p
+                v-if="cronErrorText && policyForm.sectionScheduleEnabled"
+                class="cron-row__error"
+              >
+                {{ cronErrorText }}
+              </p>
             </div>
           </div>
 
-          <div v-if="showCronHelp" class="policy-cron-help text-slate-600 bg-[var(--color-grey-1,#f8fafc)] border border-[var(--color-border,#e2e8f0)] rounded-[var(--radius-card)] px-3 py-2 space-y-2">
-            <p class="m-0">{{ t('protection.policiesPage.cronHelpLead') }}</p>
+          <div
+            v-if="showCronHelp"
+            class="policy-cron-help text-slate-600 bg-[var(--color-grey-1,#f8fafc)] border border-[var(--color-border,#e2e8f0)] rounded-[var(--radius-card)] px-3 py-2 space-y-2"
+          >
+            <p class="m-0">
+              {{ t('protection.policiesPage.cronHelpLead') }}
+            </p>
             <div>
-              <p class="m-0 font-medium text-slate-700">{{ t('protection.policiesPage.cronHelpSymbolsTitle') }}</p>
+              <p class="m-0 font-medium text-slate-700">
+                {{ t('protection.policiesPage.cronHelpSymbolsTitle') }}
+              </p>
               <ul class="list-disc pl-5 m-0">
                 <li><code>*</code>{{ t('protection.policiesPage.cronSymStar') }}</li>
                 <li><code>,</code>{{ t('protection.policiesPage.cronSymComma') }}</li>
@@ -533,7 +634,9 @@ function toggleScheduleMonthDay(day: number) {
               </ul>
             </div>
             <div>
-              <p class="m-0 font-medium text-slate-700">{{ t('protection.policiesPage.cronExamplesTitle') }}</p>
+              <p class="m-0 font-medium text-slate-700">
+                {{ t('protection.policiesPage.cronExamplesTitle') }}
+              </p>
               <ul class="list-disc pl-5 m-0">
                 <li><code>15 * * * *</code>{{ t('protection.policiesPage.cronEx15') }}</li>
                 <li><code>0 2 * * *</code>{{ t('protection.policiesPage.cronEx0200') }}</li>
@@ -548,14 +651,30 @@ function toggleScheduleMonthDay(day: number) {
       </div>
     </section>
 
-    <section data-validation-field="retention" :class="nestedSectionClass">
+    <section
+      data-validation-field="retention"
+      :class="nestedSectionClass"
+    >
       <div class="policy-section-head">
         <el-checkbox v-model="policyForm.sectionRetentionEnabled" />
         <span class="policy-section-head__title">{{ t('protection.policiesPage.sectionCheckRetention') }}</span>
       </div>
-      <p v-if="!policyForm.sectionRetentionEnabled" class="policy-section-off-hint">{{ t('protection.policiesPage.sectionOffHint') }}</p>
-      <p v-if="retentionError" class="fullscreen-form-inline-error">{{ retentionError }}</p>
-      <div v-if="policyForm.sectionRetentionEnabled" class="policy-section-nested policy-retention-stack">
+      <p
+        v-if="!policyForm.sectionRetentionEnabled"
+        class="policy-section-off-hint"
+      >
+        {{ t('protection.policiesPage.sectionOffHint') }}
+      </p>
+      <p
+        v-if="retentionError"
+        class="fullscreen-form-inline-error"
+      >
+        {{ retentionError }}
+      </p>
+      <div
+        v-if="policyForm.sectionRetentionEnabled"
+        class="policy-section-nested policy-retention-stack"
+      >
         <div>
           <div class="policy-option-title policy-option-title--with-desc">
             {{ t('protection.policiesPage.recentTitle') }}
@@ -566,8 +685,15 @@ function toggleScheduleMonthDay(day: number) {
           <div class="retention-recent-row">
             <span class="policy-inline-label">{{ t('protection.policiesPage.recentLine') }}</span>
             <div :class="[retentionInputWrapClass, { 'is-invalid': !!recentRetentionError }]">
-              <ElInputNumber v-model="policyForm.retentionRecentPoints" :min="1" :max="9999" />
-              <p v-if="recentRetentionError" class="fullscreen-form-inline-error retention-recent-input-wrap__error">
+              <ElInputNumber
+                v-model="policyForm.retentionRecentPoints"
+                :min="1"
+                :max="9999"
+              />
+              <p
+                v-if="recentRetentionError"
+                class="fullscreen-form-inline-error retention-recent-input-wrap__error"
+              >
                 {{ recentRetentionError }}
               </p>
             </div>
@@ -576,9 +702,15 @@ function toggleScheduleMonthDay(day: number) {
         </div>
         <el-divider class="!my-2" />
         <div>
-          <div v-if="variant === 'fullscreen'" class="policy-option-title policy-option-title--with-desc">
+          <div
+            v-if="variant === 'fullscreen'"
+            class="policy-option-title policy-option-title--with-desc"
+          >
             {{ t('protection.policiesPage.shortTitle') }}
-            <span v-if="policyForm.retentionShortHourly" class="policy-inline-desc">
+            <span
+              v-if="policyForm.retentionShortHourly"
+              class="policy-inline-desc"
+            >
               {{ t('protection.policiesPage.shortDesc', { days: policyForm.retentionShortDaysMax }) }}
             </span>
           </div>
@@ -594,7 +726,10 @@ function toggleScheduleMonthDay(day: number) {
                 :max="30"
                 :disabled="!policyForm.retentionShortHourly"
               />
-              <p v-if="hourlyRetentionError" class="fullscreen-form-inline-error retention-input-wrap__error">
+              <p
+                v-if="hourlyRetentionError"
+                class="fullscreen-form-inline-error retention-input-wrap__error"
+              >
                 {{ hourlyRetentionError }}
               </p>
             </div>
@@ -602,9 +737,15 @@ function toggleScheduleMonthDay(day: number) {
           </div>
         </div>
         <div>
-          <div v-if="variant === 'fullscreen'" class="policy-option-title policy-option-title--with-desc">
+          <div
+            v-if="variant === 'fullscreen'"
+            class="policy-option-title policy-option-title--with-desc"
+          >
             {{ t('protection.policiesPage.midTitle') }}
-            <span v-if="policyForm.retentionMidDaily" class="policy-inline-desc">
+            <span
+              v-if="policyForm.retentionMidDaily"
+              class="policy-inline-desc"
+            >
               {{ t('protection.policiesPage.midDesc', { mid: policyForm.retentionMidDaysMax }) }}
             </span>
           </div>
@@ -620,18 +761,32 @@ function toggleScheduleMonthDay(day: number) {
                 :max="365"
                 :disabled="!policyForm.retentionMidDaily"
               />
-              <p v-if="dailyRetentionError" class="fullscreen-form-inline-error retention-input-wrap__error">
+              <p
+                v-if="dailyRetentionError"
+                class="fullscreen-form-inline-error retention-input-wrap__error"
+              >
                 {{ dailyRetentionError }}
               </p>
             </div>
             <span class="retention-tier-unit policy-inline-label">{{ t('protection.policiesPage.unitDays') }}</span>
           </div>
-          <p v-if="midRetentionError" class="text-[13px] text-red-500 m-0 mt-1">{{ midRetentionError }}</p>
+          <p
+            v-if="midRetentionError"
+            class="text-[13px] text-red-500 m-0 mt-1"
+          >
+            {{ midRetentionError }}
+          </p>
         </div>
         <div>
-          <div v-if="variant === 'fullscreen'" class="policy-option-title policy-option-title--with-desc">
+          <div
+            v-if="variant === 'fullscreen'"
+            class="policy-option-title policy-option-title--with-desc"
+          >
             {{ t('protection.policiesPage.longTitle') }}
-            <span v-if="policyForm.retentionLongMonthly" class="policy-inline-desc">
+            <span
+              v-if="policyForm.retentionLongMonthly"
+              class="policy-inline-desc"
+            >
               {{ t('protection.policiesPage.longDesc', { months: policyForm.retentionLongMonths }) }}
             </span>
           </div>
@@ -647,29 +802,51 @@ function toggleScheduleMonthDay(day: number) {
                 :max="120"
                 :disabled="!policyForm.retentionLongMonthly"
               />
-              <p v-if="monthlyRetentionError" class="fullscreen-form-inline-error retention-input-wrap__error">
+              <p
+                v-if="monthlyRetentionError"
+                class="fullscreen-form-inline-error retention-input-wrap__error"
+              >
                 {{ monthlyRetentionError }}
               </p>
             </div>
             <span class="retention-tier-unit policy-inline-label">{{ t('protection.policiesPage.unitMonths') }}</span>
           </div>
-          <p v-if="longVsShortRetentionError" class="text-[13px] text-red-500 m-0 mt-1">{{ longVsShortRetentionError }}</p>
+          <p
+            v-if="longVsShortRetentionError"
+            class="text-[13px] text-red-500 m-0 mt-1"
+          >
+            {{ longVsShortRetentionError }}
+          </p>
         </div>
       </div>
     </section>
 
     <section :class="nestedSectionClass">
       <h3 :class="titleClass">
-        <span v-if="variant === 'fullscreen'" class="fullscreen-form-section__indicator" />
+        <span
+          v-if="variant === 'fullscreen'"
+          class="fullscreen-form-section__indicator"
+        />
         {{ t('protection.policiesPage.sectionAdvancedSettings') }}
       </h3>
       <div class="policy-section-nested advanced-settings-panel">
         <div class="error-policy-list">
-          <div v-for="row in errorHandlingRows" :key="row.key" class="error-policy-list__item">
-            <el-switch v-model="policyForm[row.key]" class="error-policy-list__switch" />
+          <div
+            v-for="row in errorHandlingRows"
+            :key="row.key"
+            class="error-policy-list__item"
+          >
+            <el-switch
+              v-model="policyForm[row.key]"
+              class="error-policy-list__switch"
+            />
             <div class="error-policy-list__main">
-              <div class="error-policy-list__title">{{ row.title }}</div>
-              <p class="error-policy-list__desc">{{ row.desc }}</p>
+              <div class="error-policy-list__title">
+                {{ row.title }}
+              </div>
+              <p class="error-policy-list__desc">
+                {{ row.desc }}
+              </p>
             </div>
           </div>
         </div>
@@ -685,16 +862,28 @@ function toggleScheduleMonthDay(day: number) {
   >
     <section :class="sectionClass">
       <h3 :class="titleClass">
-        <span v-if="variant === 'fullscreen'" class="fullscreen-form-section__indicator" />
+        <span
+          v-if="variant === 'fullscreen'"
+          class="fullscreen-form-section__indicator"
+        />
         {{ t('protection.policiesPage.tabBasic') }}
       </h3>
       <div class="policy-basic-grid">
-        <div data-validation-field="name" class="policy-basic-row">
-          <label class="policy-basic-row__label" for="filter-rule-name-input">
+        <div
+          data-validation-field="name"
+          class="policy-basic-row"
+        >
+          <label
+            class="policy-basic-row__label"
+            for="filter-rule-name-input"
+          >
             {{ t('protection.policiesPage.fieldFilterRuleName') }}
             <span class="policy-basic-row__required">*</span>
           </label>
-          <div class="policy-basic-row__control" :class="{ 'is-invalid': !!nameError }">
+          <div
+            class="policy-basic-row__control"
+            :class="{ 'is-invalid': !!nameError }"
+          >
             <ElInput
               id="filter-rule-name-input"
               v-model="filterForm.name"
@@ -703,7 +892,12 @@ function toggleScheduleMonthDay(day: number) {
               show-word-limit
               @input="$emit('clear-name-error')"
             />
-            <p v-if="nameError" class="fullscreen-form-inline-error">{{ nameError }}</p>
+            <p
+              v-if="nameError"
+              class="fullscreen-form-inline-error"
+            >
+              {{ nameError }}
+            </p>
           </div>
         </div>
         <div class="policy-basic-row">
@@ -717,17 +911,26 @@ function toggleScheduleMonthDay(day: number) {
     <section :class="[sectionClass, { 'policy-dialog-card--rules': variant === 'dialog' }]">
       <div class="filter-section-heading">
         <h3 :class="titleClass">
-          <span v-if="variant === 'fullscreen'" class="fullscreen-form-section__indicator" />
+          <span
+            v-if="variant === 'fullscreen'"
+            class="fullscreen-form-section__indicator"
+          />
           {{ t('protection.policiesPage.filterRulesSectionTitle') }}
         </h3>
-        <button type="button" class="filter-rule-guide-button" @click="openFilterRuleGuide">
+        <button
+          type="button"
+          class="filter-rule-guide-button"
+          @click="openFilterRuleGuide"
+        >
           <BookOpen :size="14" />
           <span>{{ t('protection.policiesPage.filterRuleGuideBtn') }}</span>
         </button>
       </div>
       <div class="filter-rules-stack">
         <div class="filter-rules-subsection">
-          <div class="policy-option-title">{{ t('protection.policiesPage.filterPresetSectionTitle') }}</div>
+          <div class="policy-option-title">
+            {{ t('protection.policiesPage.filterPresetSectionTitle') }}
+          </div>
           <div
             class="filter-preset-grid"
             role="group"
@@ -739,7 +942,10 @@ function toggleScheduleMonthDay(day: number) {
               class="filter-preset-card"
               :class="{ 'filter-preset-card--active': filterForm[preset.key] }"
             >
-              <el-checkbox v-model="filterForm[preset.key]" @change="onFilterPresetChange" />
+              <el-checkbox
+                v-model="filterForm[preset.key]"
+                @change="onFilterPresetChange"
+              />
               <span class="filter-preset-card__body">
                 <span class="filter-preset-card__title">{{ preset.title }}</span>
                 <span class="filter-preset-card__desc">{{ preset.desc }}</span>
@@ -749,13 +955,19 @@ function toggleScheduleMonthDay(day: number) {
         </div>
 
         <div class="filter-rules-subsection">
-          <div class="policy-option-title">{{ t('protection.policiesPage.filterCustomSectionTitle') }}</div>
+          <div class="policy-option-title">
+            {{ t('protection.policiesPage.filterCustomSectionTitle') }}
+          </div>
           <div class="filter-custom-block">
             <div class="filter-rule-group">
               <div class="filter-custom-head">
                 <div>
-                  <div class="filter-rule-group__title">{{ t('protection.policiesPage.filterExcludeRulesTitle') }}</div>
-                  <p class="filter-rule-group__desc">{{ t('protection.policiesPage.filterExcludeRulesDesc') }}</p>
+                  <div class="filter-rule-group__title">
+                    {{ t('protection.policiesPage.filterExcludeRulesTitle') }}
+                  </div>
+                  <p class="filter-rule-group__desc">
+                    {{ t('protection.policiesPage.filterExcludeRulesDesc') }}
+                  </p>
                 </div>
                 <button
                   type="button"
@@ -769,7 +981,10 @@ function toggleScheduleMonthDay(day: number) {
                 <TriangleAlert :size="15" />
                 <span>{{ t('protection.policiesPage.filterRuleOrderHint') }}</span>
               </div>
-              <div v-if="!filterRulesTextMode" class="filter-custom-rules">
+              <div
+                v-if="!filterRulesTextMode"
+                class="filter-custom-rules"
+              >
                 <div
                   v-for="item in filterExcludeRules"
                   :key="`exclude-${item.index}`"
@@ -792,7 +1007,10 @@ function toggleScheduleMonthDay(day: number) {
                     <Trash2 :size="14" />
                   </button>
                 </div>
-                <p v-if="!filterExcludeRules.length" class="filter-rule-group__empty">
+                <p
+                  v-if="!filterExcludeRules.length"
+                  class="filter-rule-group__empty"
+                >
                   {{ t('protection.policiesPage.filterNoExcludeRules') }}
                 </p>
                 <div class="filter-custom-rule-add-wrap">
@@ -806,7 +1024,10 @@ function toggleScheduleMonthDay(day: number) {
                   </button>
                 </div>
               </div>
-              <div v-else class="filter-custom-text-mode">
+              <div
+                v-else
+                class="filter-custom-text-mode"
+              >
                 <ElInput
                   :model-value="filterRulesTextValue"
                   type="textarea"
@@ -822,18 +1043,25 @@ function toggleScheduleMonthDay(day: number) {
               </div>
             </div>
 
-            <p v-if="hasDuplicateFilterRules" class="filter-rule-group__warning">
+            <p
+              v-if="hasDuplicateFilterRules"
+              class="filter-rule-group__warning"
+            >
               {{ t('protection.policiesPage.filterDuplicateWarning') }}
             </p>
           </div>
         </div>
 
         <div class="filter-rules-subsection">
-          <div class="policy-option-title">{{ t('protection.policiesPage.filterFinalPreviewTitle') }}</div>
+          <div class="policy-option-title">
+            {{ t('protection.policiesPage.filterFinalPreviewTitle') }}
+          </div>
           <div class="filter-rules-preview">
             <template v-if="compiledFilterRuleLines.length">
               <div class="filter-rules-preview__group">
-                <div class="filter-rules-preview__divider">{{ t('protection.policiesPage.filterExcludeRulesTitle') }}</div>
+                <div class="filter-rules-preview__divider">
+                  {{ t('protection.policiesPage.filterExcludeRulesTitle') }}
+                </div>
                 <code
                   v-for="line in compiledFilterRuleLines"
                   :key="line"
@@ -843,7 +1071,10 @@ function toggleScheduleMonthDay(day: number) {
                 </code>
               </div>
             </template>
-            <p v-if="!compiledFilterRuleLines.length" class="filter-rule-group__empty">
+            <p
+              v-if="!compiledFilterRuleLines.length"
+              class="filter-rule-group__empty"
+            >
               {{ t('protection.policiesPage.filterNoActiveRules') }}
             </p>
           </div>
@@ -853,15 +1084,25 @@ function toggleScheduleMonthDay(day: number) {
 
     <section :class="sectionClass">
       <h3 :class="titleClass">
-        <span v-if="variant === 'fullscreen'" class="fullscreen-form-section__indicator" />
+        <span
+          v-if="variant === 'fullscreen'"
+          class="fullscreen-form-section__indicator"
+        />
         {{ t('protection.policiesPage.sectionAdvancedSettings') }}
       </h3>
       <div class="filter-advanced-list">
         <div class="filter-advanced-row filter-advanced-row--large-file">
-          <el-switch v-model="filterForm.largeFileLimitEnabled" class="filter-advanced-row__switch" />
+          <el-switch
+            v-model="filterForm.largeFileLimitEnabled"
+            class="filter-advanced-row__switch"
+          />
           <div class="filter-advanced-row__main">
-            <div class="filter-advanced-row__title">{{ t('protection.policiesPage.largeTitle') }}</div>
-            <p class="filter-advanced-row__desc">{{ t('protection.policiesPage.largeFileLimitEnableSub') }}</p>
+            <div class="filter-advanced-row__title">
+              {{ t('protection.policiesPage.largeTitle') }}
+            </div>
+            <p class="filter-advanced-row__desc">
+              {{ t('protection.policiesPage.largeFileLimitEnableSub') }}
+            </p>
           </div>
           <div class="filter-advanced-row__controls">
             <span class="policy-inline-label">{{ t('protection.policiesPage.largeLine') }}</span>
@@ -877,23 +1118,42 @@ function toggleScheduleMonthDay(day: number) {
               class="filter-large-file-unit"
               :disabled="!filterForm.largeFileLimitEnabled"
             >
-              <el-option label="KB" value="KB" />
-              <el-option label="MB" value="MB" />
-              <el-option label="GB" value="GB" />
+              <el-option
+                label="KB"
+                value="KB"
+              />
+              <el-option
+                label="MB"
+                value="MB"
+              />
+              <el-option
+                label="GB"
+                value="GB"
+              />
             </el-select>
           </div>
         </div>
 
         <div class="filter-advanced-row">
-          <el-switch v-model="filterForm.ignoreCacheDirectories" class="filter-advanced-row__switch" />
+          <el-switch
+            v-model="filterForm.ignoreCacheDirectories"
+            class="filter-advanced-row__switch"
+          />
           <div class="filter-advanced-row__main">
-            <div class="filter-advanced-row__title">{{ t('protection.policiesPage.cacheTitle') }}</div>
-            <p class="filter-advanced-row__desc">{{ t('protection.policiesPage.cacheSub') }}</p>
+            <div class="filter-advanced-row__title">
+              {{ t('protection.policiesPage.cacheTitle') }}
+            </div>
+            <p class="filter-advanced-row__desc">
+              {{ t('protection.policiesPage.cacheSub') }}
+            </p>
           </div>
         </div>
 
         <div class="filter-advanced-row filter-advanced-row--last">
-          <el-switch v-model="filterForm.currentFilesystemOnly" class="filter-advanced-row__switch" />
+          <el-switch
+            v-model="filterForm.currentFilesystemOnly"
+            class="filter-advanced-row__switch"
+          />
           <div class="filter-advanced-row__main">
             <div class="filter-advanced-row__title">
               {{ t('protection.policiesPage.fsOnlyTitle') }}
@@ -902,7 +1162,9 @@ function toggleScheduleMonthDay(day: number) {
                 :aria-label="t('protection.policiesPage.fsOnlyTitle')"
               />
             </div>
-            <p class="filter-advanced-row__desc">{{ t('protection.policiesPage.fsOnlySub') }}</p>
+            <p class="filter-advanced-row__desc">
+              {{ t('protection.policiesPage.fsOnlySub') }}
+            </p>
           </div>
         </div>
       </div>

--- a/src/frontend/src/pages/protection/components/TargetRepositoryDetailCard.vue
+++ b/src/frontend/src/pages/protection/components/TargetRepositoryDetailCard.vue
@@ -91,7 +91,9 @@ const unverifiedReason = computed(() =>
 <template>
   <div class="target-repository-detail">
     <div class="target-repository-detail__head">
-      <div class="target-repository-detail__title">{{ target.name }}</div>
+      <div class="target-repository-detail__title">
+        {{ target.name }}
+      </div>
       <span class="target-repository-detail__title-tags">
         <el-tag
           size="small"
@@ -136,7 +138,11 @@ const unverifiedReason = computed(() =>
       <section class="target-repository-detail__section target-repository-detail__section--line">
         <span class="target-repository-detail__section-title">Status:</span>
         <span class="target-repository-detail__tag-row">
-          <el-tag size="small" :type="healthTagType(health)" effect="light">
+          <el-tag
+            size="small"
+            :type="healthTagType(health)"
+            effect="light"
+          >
             {{ healthLabel(health) }}
           </el-tag>
           <el-tooltip
@@ -146,13 +152,22 @@ const unverifiedReason = computed(() =>
             :show-after="300"
             teleported
           >
-            <AlertTriangle :size="13" class="target-repository-detail__hint-icon" />
+            <AlertTriangle
+              :size="13"
+              class="target-repository-detail__hint-icon"
+            />
           </el-tooltip>
         </span>
       </section>
 
-      <div v-if="health === 'unverified'" class="target-repository-detail__reason">
-        <Info :size="13" class="target-repository-detail__reason-icon" />
+      <div
+        v-if="health === 'unverified'"
+        class="target-repository-detail__reason"
+      >
+        <Info
+          :size="13"
+          class="target-repository-detail__reason-icon"
+        />
         <span>{{ unverifiedReason }}</span>
       </div>
 
@@ -190,7 +205,10 @@ const unverifiedReason = computed(() =>
         <span class="target-repository-detail__value">
           {{ formatBytes(target.usedBytes) }} {{ t('protection.backupsPage.targetUsed') }} ·
           {{ target.capacityBytes ? t('protection.backupsPage.targetLimitValue', { limit: formatBytes(target.capacityBytes) }) : t('protection.backupsPage.targetNoConfiguredLimit') }}
-          <span v-if="usagePercent(target) !== null" class="target-repository-detail__usage">
+          <span
+            v-if="usagePercent(target) !== null"
+            class="target-repository-detail__usage"
+          >
             ({{ usagePercent(target) }}%)
           </span>
         </span>

--- a/src/frontend/src/pages/protection/components/TargetRepositoryPicker.vue
+++ b/src/frontend/src/pages/protection/components/TargetRepositoryPicker.vue
@@ -252,7 +252,10 @@ function nasProtocolLabel(protocol?: string | null): string {
 </script>
 
 <template>
-  <div class="target-repository-picker" :class="{ 'target-repository-picker--compact': compact }">
+  <div
+    class="target-repository-picker"
+    :class="{ 'target-repository-picker--compact': compact }"
+  >
     <ElFormItem>
       <template #label>
         <span class="target-repository-picker__label-row">
@@ -265,12 +268,20 @@ function nasProtocolLabel(protocol?: string | null): string {
             :disabled="refreshing"
             @click.stop="emit('refresh')"
           >
-            <RefreshCw :size="15" stroke-width="2" :class="{ 'is-spinning': refreshing }" />
+            <RefreshCw
+              :size="15"
+              stroke-width="2"
+              :class="{ 'is-spinning': refreshing }"
+            />
           </ElButton>
         </span>
       </template>
       <div class="target-repository-picker__selector">
-        <div class="target-repository-picker__type-panel" role="listbox" :aria-label="repoTypePlaceholder">
+        <div
+          class="target-repository-picker__type-panel"
+          role="listbox"
+          :aria-label="repoTypePlaceholder"
+        >
           <button
             v-for="option in repoTypeFilterOptions"
             :key="option.value"
@@ -369,7 +380,6 @@ function nasProtocolLabel(protocol?: string | null): string {
         </div>
       </div>
     </ElFormItem>
-
   </div>
 </template>
 

--- a/src/frontend/src/pages/protection/components/TaskDetailDrawer.vue
+++ b/src/frontend/src/pages/protection/components/TaskDetailDrawer.vue
@@ -689,9 +689,14 @@ watch(
   >
     <template #header>
       <div class="hfl-task-drawer__header-bar">
-        <div v-if="activeTask" class="hfl-task-drawer__header-summary">
+        <div
+          v-if="activeTask"
+          class="hfl-task-drawer__header-summary"
+        >
           <div class="hfl-task-drawer__header-title-row">
-            <h2 class="hfl-task-drawer__header-title">{{ taskDescription(activeTask) }}</h2>
+            <h2 class="hfl-task-drawer__header-title">
+              {{ taskDescription(activeTask) }}
+            </h2>
             <TaskStatusTag :status="activeTask.status" />
           </div>
           <div class="hfl-task-drawer__header-meta">
@@ -699,13 +704,23 @@ watch(
             <span class="hfl-task-drawer__header-divider" />
             <span class="hfl-task-drawer__uuid">
               {{ activeTask.task_uuid }}
-              <ElButton class="hfl-task-drawer__copy-button" text :title="t('ops.task.copyUuid')" @click.stop="copyTaskUuid">
+              <ElButton
+                class="hfl-task-drawer__copy-button"
+                text
+                :title="t('ops.task.copyUuid')"
+                @click.stop="copyTaskUuid"
+              >
                 <Copy :size="13" />
               </ElButton>
             </span>
           </div>
         </div>
-        <h2 v-else class="hfl-task-drawer__header-title">{{ t('ops.task.detailTitle') }}</h2>
+        <h2
+          v-else
+          class="hfl-task-drawer__header-title"
+        >
+          {{ t('ops.task.detailTitle') }}
+        </h2>
         <div class="hfl-task-drawer__header-actions">
           <ElButton
             v-if="canCancel"
@@ -728,49 +743,93 @@ watch(
             :disabled="detailRefreshing || actionBusy"
             @click="refreshActiveTask"
           >
-            <RefreshCw :size="20" :class="{ 'is-spinning': detailRefreshing }" />
+            <RefreshCw
+              :size="20"
+              :class="{ 'is-spinning': detailRefreshing }"
+            />
           </button>
         </div>
       </div>
     </template>
 
-    <div v-if="activeTask" ref="drawerScrollAnchorRef" v-loading="detailRefreshing" class="hfl-task-drawer__body">
+    <div
+      v-if="activeTask"
+      ref="drawerScrollAnchorRef"
+      v-loading="detailRefreshing"
+      class="hfl-task-drawer__body"
+    >
       <section class="hfl-task-drawer__hero">
-        <div class="hfl-task-drawer__hero-section-title">{{ t('ops.task.basicData') }}</div>
+        <div class="hfl-task-drawer__hero-section-title">
+          {{ t('ops.task.basicData') }}
+        </div>
         <div class="hfl-task-drawer__hero-grid">
           <div class="hfl-task-drawer__metric">
-            <Globe :size="18" class="hfl-task-drawer__metric-icon hfl-task-drawer__metric-icon--blue" />
+            <Globe
+              :size="18"
+              class="hfl-task-drawer__metric-icon hfl-task-drawer__metric-icon--blue"
+            />
             <div class="hfl-task-drawer__metric-copy">
               <span class="hfl-task-drawer__metric-label">{{ t('ops.task.typeAndTrigger') }}</span>
               <div class="hfl-task-drawer__metric-tags">
                 <template v-if="usesTargetRepositoryResources">
-                  <span class="hfl-task-drawer__type-pill" :class="`hfl-task-drawer__type-pill--${activeTask.task_type}`">
+                  <span
+                    class="hfl-task-drawer__type-pill"
+                    :class="`hfl-task-drawer__type-pill--${activeTask.task_type}`"
+                  >
                     <span class="hfl-task-drawer__pill-text">{{ labelFor('taskType', activeTask.task_type) }}</span>
                   </span>
-                  <span class="hfl-task-drawer__trigger-pill" :class="`hfl-task-drawer__trigger-pill--${activeTask.trigger_type}`">
+                  <span
+                    class="hfl-task-drawer__trigger-pill"
+                    :class="`hfl-task-drawer__trigger-pill--${activeTask.trigger_type}`"
+                  >
                     <span class="hfl-task-drawer__pill-text">{{ labelFor('triggerType', activeTask.trigger_type) }}</span>
                   </span>
                 </template>
                 <template v-else>
-                  <el-tag class="hfl-task-meta-tag" size="small" type="info">{{ labelFor('taskType', activeTask.task_type) }}</el-tag>
-                  <el-tag class="hfl-task-meta-tag" size="small" type="info">{{ labelFor('triggerType', activeTask.trigger_type) }}</el-tag>
+                  <el-tag
+                    class="hfl-task-meta-tag"
+                    size="small"
+                    type="info"
+                  >
+                    {{ labelFor('taskType', activeTask.task_type) }}
+                  </el-tag>
+                  <el-tag
+                    class="hfl-task-meta-tag"
+                    size="small"
+                    type="info"
+                  >
+                    {{ labelFor('triggerType', activeTask.trigger_type) }}
+                  </el-tag>
                 </template>
               </div>
             </div>
           </div>
           <div class="hfl-task-drawer__metric">
-            <RotateCcw :size="18" class="hfl-task-drawer__metric-icon hfl-task-drawer__metric-icon--indigo" />
+            <RotateCcw
+              :size="18"
+              class="hfl-task-drawer__metric-icon hfl-task-drawer__metric-icon--indigo"
+            />
             <div class="hfl-task-drawer__metric-copy">
               <span class="hfl-task-drawer__metric-label">{{ t('ops.task.retryCount') }}</span>
               <span class="hfl-task-drawer__metric-value">{{ t('ops.task.retryCountValue', { count: activeTask.retry_count }) }}</span>
             </div>
           </div>
-          <div v-if="cleanupMetadata" class="hfl-task-drawer__metric hfl-task-drawer__metric--wide">
-            <Link2 :size="18" class="hfl-task-drawer__metric-icon hfl-task-drawer__metric-icon--indigo" />
+          <div
+            v-if="cleanupMetadata"
+            class="hfl-task-drawer__metric hfl-task-drawer__metric--wide"
+          >
+            <Link2
+              :size="18"
+              class="hfl-task-drawer__metric-icon hfl-task-drawer__metric-icon--indigo"
+            />
             <div class="hfl-task-drawer__metric-copy">
               <span class="hfl-task-drawer__metric-label">{{ t('ops.task.cleanupMode') }}</span>
               <div class="hfl-task-drawer__metric-tags">
-                <ElTag :type="cleanupMetadata.force ? 'danger' : 'info'" size="small" effect="plain">
+                <ElTag
+                  :type="cleanupMetadata.force ? 'danger' : 'info'"
+                  size="small"
+                  effect="plain"
+                >
                   {{ cleanupMetadata.force ? t('ops.task.cleanupModeForce') : t('ops.task.cleanupModeNormal') }}
                 </ElTag>
                 <ElButton
@@ -786,19 +845,31 @@ watch(
             </div>
           </div>
           <div class="hfl-task-drawer__metric hfl-task-drawer__metric--wide">
-            <Clock3 :size="18" class="hfl-task-drawer__metric-icon" />
+            <Clock3
+              :size="18"
+              class="hfl-task-drawer__metric-icon"
+            />
             <div class="hfl-task-drawer__time-grid">
               <div>
                 <span class="hfl-task-drawer__metric-label">{{ t('ops.task.startedAt') }}</span>
-                <span class="hfl-task-drawer__time-value" :class="{ 'hfl-empty-mark': !(activeTask.started_at || activeTask.created_at) }">{{ formatTime(activeTask.started_at || activeTask.created_at) }}</span>
+                <span
+                  class="hfl-task-drawer__time-value"
+                  :class="{ 'hfl-empty-mark': !(activeTask.started_at || activeTask.created_at) }"
+                >{{ formatTime(activeTask.started_at || activeTask.created_at) }}</span>
               </div>
               <div>
                 <span class="hfl-task-drawer__metric-label">{{ t('ops.task.finishedAt') }}</span>
-                <span class="hfl-task-drawer__time-value" :class="{ 'hfl-empty-mark': !activeTask.finished_at }">{{ formatTime(activeTask.finished_at) }}</span>
+                <span
+                  class="hfl-task-drawer__time-value"
+                  :class="{ 'hfl-empty-mark': !activeTask.finished_at }"
+                >{{ formatTime(activeTask.finished_at) }}</span>
               </div>
               <div>
                 <span class="hfl-task-drawer__metric-label">{{ t('ops.task.totalDuration') }}</span>
-                <span class="hfl-task-drawer__time-value hfl-task-drawer__time-value--strong" :class="{ 'hfl-empty-mark': taskDuration(activeTask) === t('ops.task.emptyMark') }">{{ taskDuration(activeTask) }}</span>
+                <span
+                  class="hfl-task-drawer__time-value hfl-task-drawer__time-value--strong"
+                  :class="{ 'hfl-empty-mark': taskDuration(activeTask) === t('ops.task.emptyMark') }"
+                >{{ taskDuration(activeTask) }}</span>
               </div>
             </div>
           </div>
@@ -835,7 +906,10 @@ watch(
       >
         <p>{{ activeTask.status === 'blocked' ? t('ops.task.blockedDescription') : t('ops.task.waitingDescription') }}</p>
         <ul>
-          <li v-for="dependency in activeDependencies" :key="dependency.id">
+          <li
+            v-for="dependency in activeDependencies"
+            :key="dependency.id"
+          >
             <span>{{ dependency.detail }}</span>
             <ElButton
               v-if="dependency.blocking_task_uuid"
@@ -849,7 +923,11 @@ watch(
         </ul>
       </ElAlert>
 
-      <ElTabs v-model="activeDetailTab" class="hfl-detail-tabs hfl-task-drawer__tabs" @tab-change="onDetailTabChange">
+      <ElTabs
+        v-model="activeDetailTab"
+        class="hfl-detail-tabs hfl-task-drawer__tabs"
+        @tab-change="onDetailTabChange"
+      >
         <ElTabPane name="steps">
           <template #label>
             <span class="hfl-detail-tab-label">
@@ -858,97 +936,197 @@ watch(
             </span>
           </template>
           <section class="hfl-task-drawer__tab-panel hfl-task-drawer__tab-panel--borderless">
-        <div class="hfl-task-drawer__steps-head">
-          <span>{{ t('ops.task.stepsHealthy') }}</span>
-          <ElButton
-            v-if="hasExpandableSteps"
-            size="small"
-            class="hfl-btn-with-icon"
-            @click="toggleAllStepsExpanded"
-          >
-            {{ hasAnyExpandedStep ? t('ops.task.collapseAll') : t('ops.task.expandAll') }}
-            <ChevronDown v-if="hasAnyExpandedStep" :size="16" class="hfl-task-step-chevron" />
-            <ChevronRight v-else :size="16" class="hfl-task-step-chevron" />
-          </ElButton>
-        </div>
-        <div v-if="stepsWithEvents.length" class="hfl-task-drawer__step-list">
-          <div
-            v-for="(step, index) in stepsWithEvents"
-            :key="step.id"
-            class="hfl-task-drawer__step-item"
-            :class="{ 'hfl-task-drawer__step-item--last': index === stepsWithEvents.length - 1 && unlinkedEvents.length === 0 }"
-          >
-            <div class="hfl-task-drawer__step-anchor" :class="timelineIconClass(step.status)">
-              <Check v-if="step.status === 'success'" :size="15" />
-              <X v-else-if="step.status === 'failed' || step.status === 'timeout'" :size="15" />
-              <LoaderCircle v-else-if="step.status === 'running'" :size="15" />
-              <Circle v-else :size="9" />
-            </div>
-            <article class="hfl-task-drawer__step-card">
-              <button
-                type="button"
-                class="hfl-task-drawer__step-card-head"
-                :class="{ 'hfl-task-drawer__step-card-head--disabled': step.events.length === 0 }"
-                :aria-expanded="step.events.length > 0 && isStepExpanded(step.id)"
-                :aria-disabled="step.events.length === 0"
-                :aria-description="step.events.length === 0 ? t('ops.task.emptyEvents') : undefined"
-                @click="toggleStep(step.id, step.events.length)"
+            <div class="hfl-task-drawer__steps-head">
+              <span>{{ t('ops.task.stepsHealthy') }}</span>
+              <ElButton
+                v-if="hasExpandableSteps"
+                size="small"
+                class="hfl-btn-with-icon"
+                @click="toggleAllStepsExpanded"
               >
-                <span class="hfl-task-drawer__step-title">
-                  {{ stepDisplayName(step.step_name) }}
-                  <span class="hfl-task-drawer__step-executed-at" :class="{ 'hfl-empty-mark': !(step.created_at || activeTask.created_at) }">{{ formatTime(step.created_at || activeTask.created_at) }}</span>
-                </span>
-                <TaskStatusTag :status="step.status" />
-                <span class="hfl-task-drawer__step-duration"><Clock3 :size="12" /> {{ stepDuration(index) }}</span>
-                <ElTooltip
-                  v-if="step.events.length === 0"
-                  :content="t('ops.task.emptyEvents')"
-                  teleported
-                  append-to="body"
-                  :z-index="3600"
-                  placement="top"
-                  :show-after="200"
+                {{ hasAnyExpandedStep ? t('ops.task.collapseAll') : t('ops.task.expandAll') }}
+                <ChevronDown
+                  v-if="hasAnyExpandedStep"
+                  :size="16"
+                  class="hfl-task-step-chevron"
+                />
+                <ChevronRight
+                  v-else
+                  :size="16"
+                  class="hfl-task-step-chevron"
+                />
+              </ElButton>
+            </div>
+            <div
+              v-if="stepsWithEvents.length"
+              class="hfl-task-drawer__step-list"
+            >
+              <div
+                v-for="(step, index) in stepsWithEvents"
+                :key="step.id"
+                class="hfl-task-drawer__step-item"
+                :class="{ 'hfl-task-drawer__step-item--last': index === stepsWithEvents.length - 1 && unlinkedEvents.length === 0 }"
+              >
+                <div
+                  class="hfl-task-drawer__step-anchor"
+                  :class="timelineIconClass(step.status)"
                 >
-                  <span class="hfl-task-step-chevron hfl-task-step-chevron--disabled">
-                    <ChevronRight :size="16" aria-hidden="true" />
-                  </span>
-                </ElTooltip>
-                <ChevronDown v-else-if="isStepExpanded(step.id)" :size="16" class="hfl-task-step-chevron" />
-                <ChevronRight v-else :size="16" class="hfl-task-step-chevron" />
-              </button>
-              <div v-if="isStepExpanded(step.id) && step.events.length > 0" class="hfl-task-drawer__event-list">
-                <div v-for="event in step.events" :key="event.id" class="hfl-task-drawer__event-row">
-                  <span class="hfl-task-drawer__event-dot" :class="`hfl-task-drawer__event-dot--${eventTone(event)}`">
-                    <X v-if="eventTone(event) === 'danger'" :size="9" />
-                    <Circle v-else-if="eventTone(event) === 'muted'" :size="7" />
-                    <Check v-else :size="9" />
+                  <Check
+                    v-if="step.status === 'success'"
+                    :size="15"
+                  />
+                  <X
+                    v-else-if="step.status === 'failed' || step.status === 'timeout'"
+                    :size="15"
+                  />
+                  <LoaderCircle
+                    v-else-if="step.status === 'running'"
+                    :size="15"
+                  />
+                  <Circle
+                    v-else
+                    :size="9"
+                  />
+                </div>
+                <article class="hfl-task-drawer__step-card">
+                  <button
+                    type="button"
+                    class="hfl-task-drawer__step-card-head"
+                    :class="{ 'hfl-task-drawer__step-card-head--disabled': step.events.length === 0 }"
+                    :aria-expanded="step.events.length > 0 && isStepExpanded(step.id)"
+                    :aria-disabled="step.events.length === 0"
+                    :aria-description="step.events.length === 0 ? t('ops.task.emptyEvents') : undefined"
+                    @click="toggleStep(step.id, step.events.length)"
+                  >
+                    <span class="hfl-task-drawer__step-title">
+                      {{ stepDisplayName(step.step_name) }}
+                      <span
+                        class="hfl-task-drawer__step-executed-at"
+                        :class="{ 'hfl-empty-mark': !(step.created_at || activeTask.created_at) }"
+                      >{{ formatTime(step.created_at || activeTask.created_at) }}</span>
+                    </span>
+                    <TaskStatusTag :status="step.status" />
+                    <span class="hfl-task-drawer__step-duration"><Clock3 :size="12" /> {{ stepDuration(index) }}</span>
+                    <ElTooltip
+                      v-if="step.events.length === 0"
+                      :content="t('ops.task.emptyEvents')"
+                      teleported
+                      append-to="body"
+                      :z-index="3600"
+                      placement="top"
+                      :show-after="200"
+                    >
+                      <span class="hfl-task-step-chevron hfl-task-step-chevron--disabled">
+                        <ChevronRight
+                          :size="16"
+                          aria-hidden="true"
+                        />
+                      </span>
+                    </ElTooltip>
+                    <ChevronDown
+                      v-else-if="isStepExpanded(step.id)"
+                      :size="16"
+                      class="hfl-task-step-chevron"
+                    />
+                    <ChevronRight
+                      v-else
+                      :size="16"
+                      class="hfl-task-step-chevron"
+                    />
+                  </button>
+                  <div
+                    v-if="isStepExpanded(step.id) && step.events.length > 0"
+                    class="hfl-task-drawer__event-list"
+                  >
+                    <div
+                      v-for="event in step.events"
+                      :key="event.id"
+                      class="hfl-task-drawer__event-row"
+                    >
+                      <span
+                        class="hfl-task-drawer__event-dot"
+                        :class="`hfl-task-drawer__event-dot--${eventTone(event)}`"
+                      >
+                        <X
+                          v-if="eventTone(event) === 'danger'"
+                          :size="9"
+                        />
+                        <Circle
+                          v-else-if="eventTone(event) === 'muted'"
+                          :size="7"
+                        />
+                        <Check
+                          v-else
+                          :size="9"
+                        />
+                      </span>
+                      <span class="hfl-task-drawer__event-content">
+                        <span
+                          class="hfl-task-drawer__event-msg"
+                          :class="eventMessageClass(event)"
+                        >{{ eventDisplayMessage(event) }}</span>
+                        <span
+                          v-if="eventObjectText(event)"
+                          class="hfl-task-drawer__event-object"
+                        ><Link2 :size="11" /><span>{{ eventObjectText(event) }}</span></span>
+                        <span
+                          v-if="eventErrorText(event)"
+                          class="hfl-task-drawer__event-error"
+                        >{{ eventErrorText(event) }}</span>
+                      </span>
+                      <span
+                        class="hfl-task-drawer__event-time"
+                        :class="{ 'hfl-empty-mark': !event.created_at }"
+                      >{{ formatTime(event.created_at) }}</span>
+                    </div>
+                  </div>
+                </article>
+              </div>
+              <div
+                v-if="unlinkedEvents.length"
+                class="hfl-task-drawer__event-only"
+              >
+                <div
+                  v-for="event in unlinkedEvents"
+                  :key="event.id"
+                  class="hfl-task-drawer__event-row"
+                >
+                  <span
+                    class="hfl-task-drawer__event-dot"
+                    :class="`hfl-task-drawer__event-dot--${eventTone(event)}`"
+                  >
+                    <X
+                      v-if="eventTone(event) === 'danger'"
+                      :size="9"
+                    />
+                    <Circle
+                      v-else-if="eventTone(event) === 'muted'"
+                      :size="7"
+                    />
+                    <Check
+                      v-else
+                      :size="9"
+                    />
                   </span>
                   <span class="hfl-task-drawer__event-content">
-                    <span class="hfl-task-drawer__event-msg" :class="eventMessageClass(event)">{{ eventDisplayMessage(event) }}</span>
-                    <span v-if="eventObjectText(event)" class="hfl-task-drawer__event-object"><Link2 :size="11" /><span>{{ eventObjectText(event) }}</span></span>
-                    <span v-if="eventErrorText(event)" class="hfl-task-drawer__event-error">{{ eventErrorText(event) }}</span>
+                    <span
+                      class="hfl-task-drawer__event-msg"
+                      :class="eventMessageClass(event)"
+                    >{{ eventDisplayMessage(event) }}</span>
+                    <span
+                      v-if="eventErrorText(event)"
+                      class="hfl-task-drawer__event-error"
+                    >{{ eventErrorText(event) }}</span>
                   </span>
-                  <span class="hfl-task-drawer__event-time" :class="{ 'hfl-empty-mark': !event.created_at }">{{ formatTime(event.created_at) }}</span>
+                  <span class="hfl-task-drawer__event-time">#{{ event.seq }} · <span :class="{ 'hfl-empty-mark': !event.created_at }">{{ formatTime(event.created_at) }}</span></span>
                 </div>
               </div>
-            </article>
-          </div>
-          <div v-if="unlinkedEvents.length" class="hfl-task-drawer__event-only">
-            <div v-for="event in unlinkedEvents" :key="event.id" class="hfl-task-drawer__event-row">
-              <span class="hfl-task-drawer__event-dot" :class="`hfl-task-drawer__event-dot--${eventTone(event)}`">
-                <X v-if="eventTone(event) === 'danger'" :size="9" />
-                <Circle v-else-if="eventTone(event) === 'muted'" :size="7" />
-                <Check v-else :size="9" />
-              </span>
-              <span class="hfl-task-drawer__event-content">
-                <span class="hfl-task-drawer__event-msg" :class="eventMessageClass(event)">{{ eventDisplayMessage(event) }}</span>
-                <span v-if="eventErrorText(event)" class="hfl-task-drawer__event-error">{{ eventErrorText(event) }}</span>
-              </span>
-              <span class="hfl-task-drawer__event-time">#{{ event.seq }} · <span :class="{ 'hfl-empty-mark': !event.created_at }">{{ formatTime(event.created_at) }}</span></span>
             </div>
-          </div>
-        </div>
-        <el-empty v-else :description="t('ops.task.emptySteps')" :image-size="52" />
+            <el-empty
+              v-else
+              :description="t('ops.task.emptySteps')"
+              :image-size="52"
+            />
           </section>
         </ElTabPane>
 
@@ -960,131 +1138,228 @@ watch(
             </span>
           </template>
           <section class="hfl-task-drawer__tab-panel hfl-task-drawer__tab-panel--borderless">
-        <template v-if="usesTargetRepositoryResources">
-          <div v-if="repositoryResourceLoadError" class="hfl-task-drawer__resource-error">
-            {{ repositoryResourceLoadError }}
-          </div>
-          <el-table
-            v-if="targetRepositoryResources.length"
-            v-table-column-resize="'repositories.taskDetail.resources'"
-            v-table-overflow-title
-            v-loading="repositoryResourceLoading"
-            :data="repositoryResourceRows"
-            class="hfl-list-table hfl-list-table--compact hfl-task-drawer__resource-table"
-          >
-            <el-table-column :label="t('ops.task.resourceId')" width="120">
-              <template #default="{ row }"><span class="hfl-table-cell-mono">{{ row.id }}</span></template>
-            </el-table-column>
-            <el-table-column :label="t('repositoriesPage.colListName')" min-width="180">
-              <template #default="{ row }"><span>{{ row.name }}</span></template>
-            </el-table-column>
-            <el-table-column :label="t('ops.task.resourceTypeLabel')" width="150">
-              <template #default="{ row }">
-                <ElTag size="small" effect="plain" :class="[repositoryTypeTagClass(row.repoType), 'hfl-task-drawer__repository-type-tag']">
-                  {{ repositoryTypeLabel(row.repoType) }}
-                </ElTag>
-              </template>
-            </el-table-column>
-            <el-table-column :label="t('repositoriesPage.colStatus')" width="116">
-              <template #default="{ row }">
-                <ElTag v-if="row.health" :type="row.health === 'online' ? 'success' : row.health === 'unverified' ? 'warning' : 'danger'" size="small">
-                  {{ repositoryHealthLabel(row.health) }}
-                </ElTag>
-                <span v-else class="hfl-empty-mark">{{ t('ops.task.emptyMark') }}</span>
-              </template>
-            </el-table-column>
-            <el-table-column :label="t('repositoriesPage.colRegistered')" width="180">
-              <template #default="{ row }"><span class="hfl-table-cell-time" :class="{ 'hfl-empty-mark': !row.registeredAt }">{{ formatTime(row.registeredAt) }}</span></template>
-            </el-table-column>
-          </el-table>
-          <el-empty v-else :description="t('ops.task.emptyResources')" :image-size="52" />
-        </template>
-        <template v-else>
-        <div v-if="resourceTypeTabs.length" class="hfl-task-drawer__resource-switcher">
-          <button
-            v-for="item in resourceTypeTabs"
-            :key="item.type"
-            type="button"
-            class="hfl-task-drawer__resource-switch"
-            :class="{ 'hfl-task-drawer__resource-switch--active': selectedResourceType === item.type }"
-            @click="selectResourceType(item.type)"
-          >
-            <Link2 :size="14" />
-            {{ item.label }}
-            <span class="hfl-task-drawer__resource-switch-count">{{ item.count }}</span>
-          </button>
-        </div>
-        <el-table
-          v-if="resourceTypeTabs.length && selectedResourceType === 'backup_source'"
-          v-table-column-resize="'protection.taskDetail.resources'"
-          v-table-overflow-title
-          v-loading="backupSourceLoading"
-          :data="backupSourceRows"
-          class="hfl-list-table hfl-list-table--compact hfl-task-drawer__resource-table"
-        >
-          <el-table-column :label="t('ops.task.resourceId')" width="120">
-            <template #default="{ row }"><span class="hfl-table-cell-mono">{{ row.id }}</span></template>
-          </el-table-column>
-          <el-table-column :label="t('protection.backupsPage.colBackupSource')" min-width="180">
-            <template #default="{ row }">
-              <FlowSourceSummaryCell
-                :row="row.flowSource"
-                :interactive="false"
+            <template v-if="usesTargetRepositoryResources">
+              <div
+                v-if="repositoryResourceLoadError"
+                class="hfl-task-drawer__resource-error"
+              >
+                {{ repositoryResourceLoadError }}
+              </div>
+              <el-table
+                v-if="targetRepositoryResources.length"
+                v-table-column-resize="'repositories.taskDetail.resources'"
+                v-table-overflow-title
+                v-loading="repositoryResourceLoading"
+                :data="repositoryResourceRows"
+                class="hfl-list-table hfl-list-table--compact hfl-task-drawer__resource-table"
+              >
+                <el-table-column
+                  :label="t('ops.task.resourceId')"
+                  width="120"
+                >
+                  <template #default="{ row }">
+                    <span class="hfl-table-cell-mono">{{ row.id }}</span>
+                  </template>
+                </el-table-column>
+                <el-table-column
+                  :label="t('repositoriesPage.colListName')"
+                  min-width="180"
+                >
+                  <template #default="{ row }">
+                    <span>{{ row.name }}</span>
+                  </template>
+                </el-table-column>
+                <el-table-column
+                  :label="t('ops.task.resourceTypeLabel')"
+                  width="150"
+                >
+                  <template #default="{ row }">
+                    <ElTag
+                      size="small"
+                      effect="plain"
+                      :class="[repositoryTypeTagClass(row.repoType), 'hfl-task-drawer__repository-type-tag']"
+                    >
+                      {{ repositoryTypeLabel(row.repoType) }}
+                    </ElTag>
+                  </template>
+                </el-table-column>
+                <el-table-column
+                  :label="t('repositoriesPage.colStatus')"
+                  width="116"
+                >
+                  <template #default="{ row }">
+                    <ElTag
+                      v-if="row.health"
+                      :type="row.health === 'online' ? 'success' : row.health === 'unverified' ? 'warning' : 'danger'"
+                      size="small"
+                    >
+                      {{ repositoryHealthLabel(row.health) }}
+                    </ElTag>
+                    <span
+                      v-else
+                      class="hfl-empty-mark"
+                    >{{ t('ops.task.emptyMark') }}</span>
+                  </template>
+                </el-table-column>
+                <el-table-column
+                  :label="t('repositoriesPage.colRegistered')"
+                  width="180"
+                >
+                  <template #default="{ row }">
+                    <span
+                      class="hfl-table-cell-time"
+                      :class="{ 'hfl-empty-mark': !row.registeredAt }"
+                    >{{ formatTime(row.registeredAt) }}</span>
+                  </template>
+                </el-table-column>
+              </el-table>
+              <el-empty
+                v-else
+                :description="t('ops.task.emptyResources')"
+                :image-size="52"
               />
             </template>
-          </el-table-column>
-          <el-table-column :label="t('protection.backupsPage.colConnectionAddress')" min-width="200">
-            <template #default="{ row }">
-              <FlowSourceConnectionCell :row="row.flowSource" />
-            </template>
-          </el-table-column>
-          <el-table-column :label="t('protection.sourceResources.colConnectivity')" width="110">
-            <template #default="{ row }">
-              <ElTag
-                v-if="row.availability"
-                :type="backupSourceConnectivityTagType(row.availability)"
-                size="small"
+            <template v-else>
+              <div
+                v-if="resourceTypeTabs.length"
+                class="hfl-task-drawer__resource-switcher"
               >
-                {{ backupSourceConnectivityLabel(row.availability) }}
-              </ElTag>
-              <span v-else class="hfl-empty-mark">{{ t('ops.task.emptyMark') }}</span>
+                <button
+                  v-for="item in resourceTypeTabs"
+                  :key="item.type"
+                  type="button"
+                  class="hfl-task-drawer__resource-switch"
+                  :class="{ 'hfl-task-drawer__resource-switch--active': selectedResourceType === item.type }"
+                  @click="selectResourceType(item.type)"
+                >
+                  <Link2 :size="14" />
+                  {{ item.label }}
+                  <span class="hfl-task-drawer__resource-switch-count">{{ item.count }}</span>
+                </button>
+              </div>
+              <el-table
+                v-if="resourceTypeTabs.length && selectedResourceType === 'backup_source'"
+                v-table-column-resize="'protection.taskDetail.resources'"
+                v-table-overflow-title
+                v-loading="backupSourceLoading"
+                :data="backupSourceRows"
+                class="hfl-list-table hfl-list-table--compact hfl-task-drawer__resource-table"
+              >
+                <el-table-column
+                  :label="t('ops.task.resourceId')"
+                  width="120"
+                >
+                  <template #default="{ row }">
+                    <span class="hfl-table-cell-mono">{{ row.id }}</span>
+                  </template>
+                </el-table-column>
+                <el-table-column
+                  :label="t('protection.backupsPage.colBackupSource')"
+                  min-width="180"
+                >
+                  <template #default="{ row }">
+                    <FlowSourceSummaryCell
+                      :row="row.flowSource"
+                      :interactive="false"
+                    />
+                  </template>
+                </el-table-column>
+                <el-table-column
+                  :label="t('protection.backupsPage.colConnectionAddress')"
+                  min-width="200"
+                >
+                  <template #default="{ row }">
+                    <FlowSourceConnectionCell :row="row.flowSource" />
+                  </template>
+                </el-table-column>
+                <el-table-column
+                  :label="t('protection.sourceResources.colConnectivity')"
+                  width="110"
+                >
+                  <template #default="{ row }">
+                    <ElTag
+                      v-if="row.availability"
+                      :type="backupSourceConnectivityTagType(row.availability)"
+                      size="small"
+                    >
+                      {{ backupSourceConnectivityLabel(row.availability) }}
+                    </ElTag>
+                    <span
+                      v-else
+                      class="hfl-empty-mark"
+                    >{{ t('ops.task.emptyMark') }}</span>
+                  </template>
+                </el-table-column>
+                <el-table-column
+                  :label="t('protection.backupsPage.colRegistered')"
+                  width="180"
+                >
+                  <template #default="{ row }">
+                    <span
+                      class="hfl-table-cell-time"
+                      :class="{ 'hfl-empty-mark': !row.registeredAt }"
+                    >{{ formatTime(row.registeredAt) }}</span>
+                  </template>
+                </el-table-column>
+              </el-table>
+              <el-table
+                v-else
+                v-table-column-resize="'protection.taskDetail.resources'"
+                v-table-overflow-title
+                :data="selectedResources"
+                class="hfl-list-table hfl-list-table--compact hfl-task-drawer__resource-table"
+              >
+                <el-table-column
+                  :label="t('ops.task.resourceId')"
+                  width="120"
+                >
+                  <template #default="{ row }">
+                    <span class="hfl-table-cell-mono">{{ row.id }}</span>
+                  </template>
+                </el-table-column>
+                <el-table-column
+                  :label="t('ops.task.resourceTypeLabel')"
+                  min-width="160"
+                >
+                  <template #default="{ row }">
+                    <ElTag
+                      type="info"
+                      size="small"
+                      effect="plain"
+                    >
+                      {{ row.type }}
+                    </ElTag>
+                  </template>
+                </el-table-column>
+                <el-table-column
+                  :label="t('ops.task.resourceSubtype')"
+                  min-width="140"
+                  prop="subtype"
+                />
+              </el-table>
+              <el-empty
+                v-if="!resourceTypeTabs.length"
+                :description="t('ops.task.emptyResources')"
+                :image-size="52"
+              />
             </template>
-          </el-table-column>
-          <el-table-column :label="t('protection.backupsPage.colRegistered')" width="180">
-            <template #default="{ row }"><span class="hfl-table-cell-time" :class="{ 'hfl-empty-mark': !row.registeredAt }">{{ formatTime(row.registeredAt) }}</span></template>
-          </el-table-column>
-        </el-table>
-        <el-table
-          v-else
-          v-table-column-resize="'protection.taskDetail.resources'"
-          v-table-overflow-title
-          :data="selectedResources"
-          class="hfl-list-table hfl-list-table--compact hfl-task-drawer__resource-table"
-        >
-          <el-table-column :label="t('ops.task.resourceId')" width="120">
-            <template #default="{ row }">
-              <span class="hfl-table-cell-mono">{{ row.id }}</span>
-            </template>
-          </el-table-column>
-          <el-table-column :label="t('ops.task.resourceTypeLabel')" min-width="160">
-            <template #default="{ row }">
-              <ElTag type="info" size="small" effect="plain">
-                {{ row.type }}
-              </ElTag>
-            </template>
-          </el-table-column>
-          <el-table-column :label="t('ops.task.resourceSubtype')" min-width="140" prop="subtype" />
-        </el-table>
-        <el-empty v-if="!resourceTypeTabs.length" :description="t('ops.task.emptyResources')" :image-size="52" />
-        </template>
           </section>
         </ElTabPane>
-
       </ElTabs>
     </div>
-    <div v-else ref="drawerScrollAnchorRef" class="hfl-task-drawer__body">
-      <div class="hfl-task-drawer__loading" aria-busy="true">
-        <el-skeleton :rows="6" animated />
+    <div
+      v-else
+      ref="drawerScrollAnchorRef"
+      class="hfl-task-drawer__body"
+    >
+      <div
+        class="hfl-task-drawer__loading"
+        aria-busy="true"
+      >
+        <el-skeleton
+          :rows="6"
+          animated
+        />
       </div>
     </div>
   </ElDrawer>

--- a/src/frontend/src/pages/protection/components/TaskProgressCell.vue
+++ b/src/frontend/src/pages/protection/components/TaskProgressCell.vue
@@ -70,13 +70,30 @@ const labelTitle = computed(() => {
 </script>
 
 <template>
-  <div class="task-progress-cell" :class="{ 'is-compact': compact, 'is-failed': failed, 'is-stopping': stopping }">
-    <div v-if="orchestrationLabel || showRightPercent" class="task-progress-cell__row1">
-      <p v-if="orchestrationLabel" class="task-progress-cell__label" :title="labelTitle">
-        <span v-if="showSpinner" class="task-progress-cell__spinner" aria-hidden="true" />
+  <div
+    class="task-progress-cell"
+    :class="{ 'is-compact': compact, 'is-failed': failed, 'is-stopping': stopping }"
+  >
+    <div
+      v-if="orchestrationLabel || showRightPercent"
+      class="task-progress-cell__row1"
+    >
+      <p
+        v-if="orchestrationLabel"
+        class="task-progress-cell__label"
+        :title="labelTitle"
+      >
+        <span
+          v-if="showSpinner"
+          class="task-progress-cell__spinner"
+          aria-hidden="true"
+        />
         <span class="task-progress-cell__label-text">{{ orchestrationLabel }}</span>
       </p>
-      <span v-if="showRightPercent" class="task-progress-cell__percent">{{ progressText }}</span>
+      <span
+        v-if="showRightPercent"
+        class="task-progress-cell__percent"
+      >{{ progressText }}</span>
     </div>
     <el-progress
       class="protection-flow-progress task-progress-cell__bar"
@@ -85,9 +102,18 @@ const labelTitle = computed(() => {
       :stroke-width="compact ? 7 : 8"
       :show-text="false"
     />
-    <p class="task-progress-cell__metrics" :class="{ 'is-empty': !metricParts.length }">
-      <template v-for="(part, index) in metricParts" :key="index">
-        <span v-if="index > 0" class="task-progress-cell__sep">·</span>
+    <p
+      class="task-progress-cell__metrics"
+      :class="{ 'is-empty': !metricParts.length }"
+    >
+      <template
+        v-for="(part, index) in metricParts"
+        :key="index"
+      >
+        <span
+          v-if="index > 0"
+          class="task-progress-cell__sep"
+        >·</span>
         <span>{{ part }}</span>
       </template>
     </p>

--- a/src/frontend/src/pages/protection/components/TaskTerminalOutcomeCell.vue
+++ b/src/frontend/src/pages/protection/components/TaskTerminalOutcomeCell.vue
@@ -85,8 +85,15 @@ const outcome = computed(() => {
   >
     <span class="task-terminal-outcome__summary">
       <span class="task-terminal-outcome__status">{{ outcome.label }}</span>
-      <span v-if="outcome.timestamp" class="task-terminal-outcome__separator" aria-hidden="true">·</span>
-      <span v-if="outcome.timestamp" class="task-terminal-outcome__time">{{ outcome.timestamp }}</span>
+      <span
+        v-if="outcome.timestamp"
+        class="task-terminal-outcome__separator"
+        aria-hidden="true"
+      >·</span>
+      <span
+        v-if="outcome.timestamp"
+        class="task-terminal-outcome__time"
+      >{{ outcome.timestamp }}</span>
     </span>
     <span
       v-if="outcome.showDiagnostic"
@@ -98,10 +105,16 @@ const outcome = computed(() => {
         class="task-terminal-outcome__code"
         :class="{ 'task-terminal-outcome__code--only': !outcome.reason }"
       >[{{ outcome.code }}]</span>
-      <span v-if="outcome.reason" class="task-terminal-outcome__reason">{{ outcome.reason }}</span>
+      <span
+        v-if="outcome.reason"
+        class="task-terminal-outcome__reason"
+      >{{ outcome.reason }}</span>
     </span>
   </span>
-  <span v-else class="task-terminal-outcome task-terminal-outcome--empty hfl-empty-mark">—</span>
+  <span
+    v-else
+    class="task-terminal-outcome task-terminal-outcome--empty hfl-empty-mark"
+  >—</span>
 </template>
 
 <style scoped>

--- a/src/frontend/src/pages/settings/GlobalSettingsContent.vue
+++ b/src/frontend/src/pages/settings/GlobalSettingsContent.vue
@@ -123,7 +123,10 @@ onMounted(load)
 </script>
 
 <template>
-  <div v-loading="busy" class="hfl-list-shell global-settings">
+  <div
+    v-loading="busy"
+    class="hfl-list-shell global-settings"
+  >
     <div class="hfl-list-panel">
       <div class="global-settings__panel">
         <section
@@ -132,9 +135,16 @@ onMounted(load)
           class="global-settings__row"
         >
           <div class="global-settings__row-text">
-            <div class="global-settings__label">{{ t(f.labelKey) }}</div>
-            <p class="global-settings__desc">{{ t(f.hintKey) }}</p>
-            <p v-if="sources[f.key]" class="global-settings__source">
+            <div class="global-settings__label">
+              {{ t(f.labelKey) }}
+            </div>
+            <p class="global-settings__desc">
+              {{ t(f.hintKey) }}
+            </p>
+            <p
+              v-if="sources[f.key]"
+              class="global-settings__source"
+            >
               {{ t('settings.systemOrg.effectiveFrom', { source: sourceLabel[sources[f.key] as keyof typeof sourceLabel] || sources[f.key] }) }}
             </p>
           </div>
@@ -148,13 +158,20 @@ onMounted(load)
               controls-position="right"
               class="global-settings__input-num"
             />
-            <ElSwitch v-else v-model="form[f.key]" />
+            <ElSwitch
+              v-else
+              v-model="form[f.key]"
+            />
           </div>
         </section>
       </div>
 
       <div class="global-settings__footer">
-        <ElButton type="primary" :loading="saving" @click="save">
+        <ElButton
+          type="primary"
+          :loading="saving"
+          @click="save"
+        >
           {{ t('common.save') }}
         </ElButton>
       </div>

--- a/src/frontend/src/pages/settings/Members.vue
+++ b/src/frontend/src/pages/settings/Members.vue
@@ -111,49 +111,74 @@ watch(pageSize, () => {
 </script>
 
 <template>
-  <ModulePage :menus="nodeMenus" body-fill>
+  <ModulePage
+    :menus="nodeMenus"
+    body-fill
+  >
     <HflTablePanel fill>
       <template #table="{ tableMaxHeight }">
-      <el-table
-        v-table-column-resize="'settings.members'"
-        v-loading="busy"
-        :data="paginatedRows"
-        stripe
-        row-key="id"
-        class="hfl-list-table"
-        :max-height="tableMaxHeight"
-      >
-        <el-table-column :label="t('settings.member.colName')" min-width="180">
-          <template #default="{ row }">{{ memberDisplayName(row) }}</template>
-        </el-table-column>
-        <el-table-column
-          v-if="showMemberRoles"
-          :label="t('settings.member.colRole')"
-          width="120"
+        <el-table
+          v-table-column-resize="'settings.members'"
+          v-loading="busy"
+          :data="paginatedRows"
+          stripe
+          row-key="id"
+          class="hfl-list-table"
+          :max-height="tableMaxHeight"
         >
-          <template #default="{ row }">
-            <HflTypeLabel :label="roleLabel(row.role)" />
+          <el-table-column
+            :label="t('settings.member.colName')"
+            min-width="180"
+          >
+            <template #default="{ row }">
+              {{ memberDisplayName(row) }}
+            </template>
+          </el-table-column>
+          <el-table-column
+            v-if="showMemberRoles"
+            :label="t('settings.member.colRole')"
+            width="120"
+          >
+            <template #default="{ row }">
+              <HflTypeLabel :label="roleLabel(row.role)" />
+            </template>
+          </el-table-column>
+          <el-table-column
+            :label="t('settings.member.colOrg')"
+            min-width="140"
+          >
+            <template #default="{ row }">
+              {{ row.organization_name || primaryOrgName }}
+            </template>
+          </el-table-column>
+          <el-table-column
+            :label="t('settings.member.colStatus')"
+            width="100"
+          >
+            <template #default="{ row }">
+              <el-tag
+                v-bind="booleanStatusTag(row.is_active)"
+                size="small"
+              >
+                {{ row.is_active ? t('settings.member.statusActive') : t('settings.member.statusInactive') }}
+              </el-tag>
+            </template>
+          </el-table-column>
+          <el-table-column
+            :label="t('settings.member.colCreated')"
+            width="170"
+          >
+            <template #default="{ row }">
+              <span
+                class="hfl-table-cell-time"
+                :class="{ 'hfl-empty-mark': !row.created_at }"
+              >{{ formatCreatedAt(row.created_at) }}</span>
+            </template>
+          </el-table-column>
+          <template #empty>
+            <el-empty :description="t('settings.member.empty')" />
           </template>
-        </el-table-column>
-        <el-table-column :label="t('settings.member.colOrg')" min-width="140">
-          <template #default="{ row }">{{ row.organization_name || primaryOrgName }}</template>
-        </el-table-column>
-        <el-table-column :label="t('settings.member.colStatus')" width="100">
-          <template #default="{ row }">
-            <el-tag v-bind="booleanStatusTag(row.is_active)" size="small">
-              {{ row.is_active ? t('settings.member.statusActive') : t('settings.member.statusInactive') }}
-            </el-tag>
-          </template>
-        </el-table-column>
-        <el-table-column :label="t('settings.member.colCreated')" width="170">
-          <template #default="{ row }">
-            <span class="hfl-table-cell-time" :class="{ 'hfl-empty-mark': !row.created_at }">{{ formatCreatedAt(row.created_at) }}</span>
-          </template>
-        </el-table-column>
-        <template #empty>
-          <el-empty :description="t('settings.member.empty')" />
-        </template>
-      </el-table>
+        </el-table>
       </template>
 
       <template #footer>

--- a/src/frontend/src/pages/settings/OrganizationHub.vue
+++ b/src/frontend/src/pages/settings/OrganizationHub.vue
@@ -64,44 +64,78 @@ watch(pageSize, () => {
 </script>
 
 <template>
-  <ModulePage :menus="nodeMenus" body-fill>
+  <ModulePage
+    :menus="nodeMenus"
+    body-fill
+  >
     <HflTablePanel fill>
       <template #table="{ tableMaxHeight }">
-      <el-table
-        v-table-column-resize="'settings.organizations'"
-        v-loading="busy"
-        :data="paginatedRows"
-        stripe
-        row-key="id"
-        class="hfl-list-table"
-        :max-height="tableMaxHeight"
-      >
-        <el-table-column prop="name" :label="t('settings.org.colName')" min-width="140" />
-        <el-table-column :label="t('settings.org.colOwner')" min-width="160">
-          <template #default="{ row }"><span :class="{ 'hfl-empty-mark': !row.owner_email }">{{ row.owner_email || '—' }}</span></template>
-        </el-table-column>
-        <el-table-column :label="t('settings.org.colMembers')" width="100">
-          <template #default="{ row }">{{ row.member_count ?? 0 }}</template>
-        </el-table-column>
-        <el-table-column :label="t('settings.org.colPlan')" min-width="140">
-          <template #default>{{ t('settings.org.planDefault') }}</template>
-        </el-table-column>
-        <el-table-column :label="t('settings.org.colStatus')" width="100">
-          <template #default="{ row }">
-            <el-tag v-bind="booleanStatusTag(row.is_active)" size="small">
-              {{ row.is_active ? t('settings.org.statusNormal') : t('settings.org.statusInactive') }}
-            </el-tag>
+        <el-table
+          v-table-column-resize="'settings.organizations'"
+          v-loading="busy"
+          :data="paginatedRows"
+          stripe
+          row-key="id"
+          class="hfl-list-table"
+          :max-height="tableMaxHeight"
+        >
+          <el-table-column
+            prop="name"
+            :label="t('settings.org.colName')"
+            min-width="140"
+          />
+          <el-table-column
+            :label="t('settings.org.colOwner')"
+            min-width="160"
+          >
+            <template #default="{ row }">
+              <span :class="{ 'hfl-empty-mark': !row.owner_email }">{{ row.owner_email || '—' }}</span>
+            </template>
+          </el-table-column>
+          <el-table-column
+            :label="t('settings.org.colMembers')"
+            width="100"
+          >
+            <template #default="{ row }">
+              {{ row.member_count ?? 0 }}
+            </template>
+          </el-table-column>
+          <el-table-column
+            :label="t('settings.org.colPlan')"
+            min-width="140"
+          >
+            <template #default>
+              {{ t('settings.org.planDefault') }}
+            </template>
+          </el-table-column>
+          <el-table-column
+            :label="t('settings.org.colStatus')"
+            width="100"
+          >
+            <template #default="{ row }">
+              <el-tag
+                v-bind="booleanStatusTag(row.is_active)"
+                size="small"
+              >
+                {{ row.is_active ? t('settings.org.statusNormal') : t('settings.org.statusInactive') }}
+              </el-tag>
+            </template>
+          </el-table-column>
+          <el-table-column
+            :label="t('settings.org.colCreated')"
+            width="170"
+          >
+            <template #default="{ row }">
+              <span
+                class="hfl-table-cell-time"
+                :class="{ 'hfl-empty-mark': !row.created_at }"
+              >{{ formatCreatedAt(row.created_at) }}</span>
+            </template>
+          </el-table-column>
+          <template #empty>
+            <el-empty :description="t('settings.org.empty')" />
           </template>
-        </el-table-column>
-        <el-table-column :label="t('settings.org.colCreated')" width="170">
-          <template #default="{ row }">
-            <span class="hfl-table-cell-time" :class="{ 'hfl-empty-mark': !row.created_at }">{{ formatCreatedAt(row.created_at) }}</span>
-          </template>
-        </el-table-column>
-        <template #empty>
-          <el-empty :description="t('settings.org.empty')" />
-        </template>
-      </el-table>
+        </el-table>
       </template>
 
       <template #footer>

--- a/src/frontend/src/pages/settings/SubscriptionContent.vue
+++ b/src/frontend/src/pages/settings/SubscriptionContent.vue
@@ -222,8 +222,13 @@ onMounted(loadAll)
 </script>
 
 <template>
-  <div v-loading="loading" class="subscription-page">
-    <p class="subscription-page__lead">{{ pageSubtitle }}</p>
+  <div
+    v-loading="loading"
+    class="subscription-page"
+  >
+    <p class="subscription-page__lead">
+      {{ pageSubtitle }}
+    </p>
     <ElAlert
       class="subscription-page__enforcement"
       :type="enforcementEnabled ? 'success' : 'info'"
@@ -235,7 +240,9 @@ onMounted(loadAll)
     />
     <section class="subscription-section">
       <header class="subscription-section__header">
-        <h2 class="subscription-section__title">{{ t('settings.subscription.overviewTitle') }}</h2>
+        <h2 class="subscription-section__title">
+          {{ t('settings.subscription.overviewTitle') }}
+        </h2>
         <ElButton
           text
           class="subscription-section__refresh"
@@ -243,7 +250,10 @@ onMounted(loadAll)
           :disabled="loading"
           @click="loadAll"
         >
-          <RefreshCw :size="16" :class="{ 'is-spinning': loading }" />
+          <RefreshCw
+            :size="16"
+            :class="{ 'is-spinning': loading }"
+          />
         </ElButton>
       </header>
 
@@ -269,11 +279,19 @@ onMounted(loadAll)
 
     <section class="subscription-section">
       <header class="subscription-section__header">
-        <h2 class="subscription-section__title">{{ t('settings.subscription.limitsAndUsage') }}</h2>
+        <h2 class="subscription-section__title">
+          {{ t('settings.subscription.limitsAndUsage') }}
+        </h2>
       </header>
-      <p class="subscription-quota-lifetime-hint">{{ t('settings.subscription.aiTokensLifetimeHint') }}</p>
+      <p class="subscription-quota-lifetime-hint">
+        {{ t('settings.subscription.aiTokensLifetimeHint') }}
+      </p>
       <div class="subscription-quota-grid">
-        <div v-for="item in limitItems" :key="item.key" class="subscription-quota-item">
+        <div
+          v-for="item in limitItems"
+          :key="item.key"
+          class="subscription-quota-item"
+        >
           <span class="subscription-quota-item__label">{{ item.label }}</span>
           <span class="subscription-quota-item__numbers">
             {{ getUsage(item.usageKey) }}
@@ -293,24 +311,36 @@ onMounted(loadAll)
 
     <section class="subscription-section">
       <header class="subscription-section__header">
-        <h2 class="subscription-section__title">{{ t('settings.subscription.activationTitle') }}</h2>
+        <h2 class="subscription-section__title">
+          {{ t('settings.subscription.activationTitle') }}
+        </h2>
       </header>
 
       <div class="subscription-activation">
         <template v-if="canActivateHere">
           <div class="subscription-activation__step">
-            <h3 class="subscription-activation__step-title">{{ t('settings.subscription.activationStep1Title') }}</h3>
+            <h3 class="subscription-activation__step-title">
+              {{ t('settings.subscription.activationStep1Title') }}
+            </h3>
             <div class="subscription-activation__code-row">
               <code class="subscription-activation__code">{{ machineCode || '—' }}</code>
-              <ElButton type="primary" :disabled="!machineCode" @click="copyIdentification">
+              <ElButton
+                type="primary"
+                :disabled="!machineCode"
+                @click="copyIdentification"
+              >
                 {{ t('settings.subscription.copyIdentification') }}
               </ElButton>
             </div>
-            <p class="subscription-activation__hint">{{ t('settings.subscription.activationStep1Hint') }}</p>
+            <p class="subscription-activation__hint">
+              {{ t('settings.subscription.activationStep1Hint') }}
+            </p>
           </div>
 
           <div class="subscription-activation__step">
-            <h3 class="subscription-activation__step-title">{{ t('settings.subscription.activationStep2Title') }}</h3>
+            <h3 class="subscription-activation__step-title">
+              {{ t('settings.subscription.activationStep2Title') }}
+            </h3>
             <ElInput
               v-model="activationCode"
               type="textarea"
@@ -331,7 +361,10 @@ onMounted(loadAll)
             </div>
           </div>
         </template>
-        <p v-else class="subscription-activation__hint">
+        <p
+          v-else
+          class="subscription-activation__hint"
+        >
           {{ t('settings.subscription.instanceSharedHint') }}
         </p>
       </div>
@@ -339,7 +372,9 @@ onMounted(loadAll)
 
     <section class="subscription-section subscription-section--last">
       <header class="subscription-section__header">
-        <h2 class="subscription-section__title">{{ t('settings.subscription.historyTitle') }}</h2>
+        <h2 class="subscription-section__title">
+          {{ t('settings.subscription.historyTitle') }}
+        </h2>
       </header>
       <HflTablePanel>
         <el-table
@@ -353,25 +388,52 @@ onMounted(loadAll)
             <el-empty :description="t('settings.subscription.historyEmpty')" />
           </template>
 
-          <el-table-column :label="t('settings.subscription.historyLicenseKey')" min-width="220">
-            <template #default="{ row }"><span :class="{ 'hfl-empty-mark': !row.license_key }">{{ row.license_key || '—' }}</span></template>
-          </el-table-column>
-          <el-table-column :label="t('settings.subscription.historyChangeType')" min-width="180">
-            <template #default="{ row }">{{ historyChangeLabel(row) }}</template>
-          </el-table-column>
-          <el-table-column :label="t('settings.subscription.historyActivatedAt')" width="170">
+          <el-table-column
+            :label="t('settings.subscription.historyLicenseKey')"
+            min-width="220"
+          >
             <template #default="{ row }">
-              <span class="hfl-table-cell-time" :class="{ 'hfl-empty-mark': !(row.activated_at || row.archived_at) }">{{ formatDateTime(row.activated_at || row.archived_at) }}</span>
+              <span :class="{ 'hfl-empty-mark': !row.license_key }">{{ row.license_key || '—' }}</span>
             </template>
           </el-table-column>
-          <el-table-column :label="t('settings.subscription.historyValidUntil')" width="140">
+          <el-table-column
+            :label="t('settings.subscription.historyChangeType')"
+            min-width="180"
+          >
+            <template #default="{ row }">
+              {{ historyChangeLabel(row) }}
+            </template>
+          </el-table-column>
+          <el-table-column
+            :label="t('settings.subscription.historyActivatedAt')"
+            width="170"
+          >
+            <template #default="{ row }">
+              <span
+                class="hfl-table-cell-time"
+                :class="{ 'hfl-empty-mark': !(row.activated_at || row.archived_at) }"
+              >{{ formatDateTime(row.activated_at || row.archived_at) }}</span>
+            </template>
+          </el-table-column>
+          <el-table-column
+            :label="t('settings.subscription.historyValidUntil')"
+            width="140"
+          >
             <template #default="{ row }">
               <span :class="{ 'hfl-empty-mark': !row.is_perpetual && !row.expires_at }">{{ row.is_perpetual ? t('settings.subscription.unlimited') : formatDateOnly(row.expires_at) }}</span>
             </template>
           </el-table-column>
-          <el-table-column :label="t('settings.subscription.historyStatus')" width="100">
+          <el-table-column
+            :label="t('settings.subscription.historyStatus')"
+            width="100"
+          >
             <template #default="{ row }">
-              <el-tag v-bind="historyStatusTagAttrs(row)" size="small">{{ historyStatusLabel(row) }}</el-tag>
+              <el-tag
+                v-bind="historyStatusTagAttrs(row)"
+                size="small"
+              >
+                {{ historyStatusLabel(row) }}
+              </el-tag>
             </template>
           </el-table-column>
         </el-table>

--- a/src/frontend/src/platform-ops/components/PlatformOpsBackButton.vue
+++ b/src/frontend/src/platform-ops/components/PlatformOpsBackButton.vue
@@ -14,6 +14,9 @@ defineEmits<{
     :title="$t('common.back')"
     @click="$emit('click')"
   >
-    <ArrowLeft class="fullscreen-form-header__back-icon" :size="18" />
+    <ArrowLeft
+      class="fullscreen-form-header__back-icon"
+      :size="18"
+    />
   </button>
 </template>

--- a/src/frontend/src/platform-ops/components/PlatformOpsDetailSection.vue
+++ b/src/frontend/src/platform-ops/components/PlatformOpsDetailSection.vue
@@ -6,7 +6,9 @@ defineProps<{
 
 <template>
   <section class="hfl-detail-section">
-    <h4 class="hfl-detail-section__title">{{ title }}</h4>
+    <h4 class="hfl-detail-section__title">
+      {{ title }}
+    </h4>
     <slot />
   </section>
 </template>

--- a/src/frontend/src/platform-ops/components/PlatformOpsDetailShell.vue
+++ b/src/frontend/src/platform-ops/components/PlatformOpsDetailShell.vue
@@ -12,7 +12,10 @@ defineEmits<{
 </script>
 
 <template>
-  <div v-loading="loading" class="platform-ops-detail">
+  <div
+    v-loading="loading"
+    class="platform-ops-detail"
+  >
     <div class="platform-ops-detail__head">
       <PlatformOpsBackButton @click="$emit('back')" />
       <div class="platform-ops-detail__title-group">

--- a/src/frontend/src/platform-ops/components/PlatformOpsListToolbarActions.vue
+++ b/src/frontend/src/platform-ops/components/PlatformOpsListToolbarActions.vue
@@ -11,6 +11,7 @@ withDefaults(
     deleteDisabled?: boolean
   }>(),
   {
+    addLabel: '',
     addDisabled: false,
     editDisabled: true,
     deleteDisabled: true,
@@ -28,7 +29,11 @@ const moreActionsOpen = ref(false)
 </script>
 
 <template>
-  <el-button type="primary" :disabled="addDisabled" @click="emit('add')">
+  <el-button
+    type="primary"
+    :disabled="addDisabled"
+    @click="emit('add')"
+  >
     <Plus :size="16" />
     {{ addLabel || t('platformOps.list.btnAdd') }}
   </el-button>
@@ -48,9 +53,15 @@ const moreActionsOpen = ref(false)
     </el-button>
     <template #dropdown>
       <el-dropdown-menu>
-        <el-dropdown-item :disabled="editDisabled" @click="emit('edit')">
+        <el-dropdown-item
+          :disabled="editDisabled"
+          @click="emit('edit')"
+        >
           <span class="el-dropdown-menu__item-content">
-            <Pencil :size="14" class="shrink-0" />
+            <Pencil
+              :size="14"
+              class="shrink-0"
+            />
             <span>{{ t('common.edit') }}</span>
           </span>
         </el-dropdown-item>
@@ -61,7 +72,10 @@ const moreActionsOpen = ref(false)
           @click="emit('delete')"
         >
           <span class="el-dropdown-menu__item-content">
-            <Trash2 :size="14" class="shrink-0" />
+            <Trash2
+              :size="14"
+              class="shrink-0"
+            />
             <span>{{ t('common.delete') }}</span>
           </span>
         </el-dropdown-item>

--- a/src/frontend/src/platform-ops/components/PlatformOpsRefreshButton.vue
+++ b/src/frontend/src/platform-ops/components/PlatformOpsRefreshButton.vue
@@ -19,6 +19,9 @@ defineEmits<{
     :disabled="disabled || loading"
     @click="$emit('click')"
   >
-    <RefreshCw :size="16" :class="{ 'is-spinning': loading }" />
+    <RefreshCw
+      :size="16"
+      :class="{ 'is-spinning': loading }"
+    />
   </el-button>
 </template>

--- a/src/frontend/src/platform-ops/components/PlatformOpsStatusPill.vue
+++ b/src/frontend/src/platform-ops/components/PlatformOpsStatusPill.vue
@@ -11,6 +11,13 @@ const label = computed(() => {
 </script>
 
 <template>
-  <span v-if="label !== '—'" class="hfl-ops-status-pill" :class="opsStatusPillClass(label)">{{ label }}</span>
-  <span v-else class="hfl-empty-mark">—</span>
+  <span
+    v-if="label !== '—'"
+    class="hfl-ops-status-pill"
+    :class="opsStatusPillClass(label)"
+  >{{ label }}</span>
+  <span
+    v-else
+    class="hfl-empty-mark"
+  >—</span>
 </template>

--- a/src/frontend/src/platform-ops/components/PlatformOpsTimeCell.vue
+++ b/src/frontend/src/platform-ops/components/PlatformOpsTimeCell.vue
@@ -5,5 +5,8 @@ defineProps<{ value?: string | null }>()
 </script>
 
 <template>
-  <span class="hfl-table-cell-time" :class="{ 'hfl-empty-mark': !value }">{{ formatLocalDateTime(value, '—') }}</span>
+  <span
+    class="hfl-table-cell-time"
+    :class="{ 'hfl-empty-mark': !value }"
+  >{{ formatLocalDateTime(value, '—') }}</span>
 </template>

--- a/src/frontend/src/platform-ops/composables/usePlatformOpsSideNav.ts
+++ b/src/frontend/src/platform-ops/composables/usePlatformOpsSideNav.ts
@@ -5,6 +5,7 @@ import {
   Settings,
 } from 'lucide-vue-next'
 import type { MenuItem } from '../../components/ModulePage.vue'
+import { fetchDeployProfile } from '../../composables/useDeployProfile'
 
 /**
  * Community side nav: AI Models + optional Runtime only.
@@ -45,7 +46,6 @@ export function usePlatformOpsAccess() {
   const tenantPublicUrl = ref('')
 
   async function load() {
-    const { fetchDeployProfile } = await import('../../composables/useDeployProfile')
     const profile = await fetchDeployProfile()
     emailSignupEnabled.value = !!profile?.email_signup_enabled
     tenantPublicUrl.value = profile?.tenant_public_url || ''

--- a/src/frontend/src/platform-ops/layout/PlatformEngineLayout.vue
+++ b/src/frontend/src/platform-ops/layout/PlatformEngineLayout.vue
@@ -28,7 +28,11 @@ const hidePageTitle = computed(() => /\/(?:add|edit)$/.test(route.path))
 </script>
 
 <template>
-  <ModulePage :menus="sideNav" body-fill :hide-page-title="hidePageTitle">
+  <ModulePage
+    :menus="sideNav"
+    body-fill
+    :hide-page-title="hidePageTitle"
+  >
     <router-view />
   </ModulePage>
 </template>

--- a/src/frontend/src/platform-ops/layout/PlatformOpsShell.vue
+++ b/src/frontend/src/platform-ops/layout/PlatformOpsShell.vue
@@ -91,12 +91,15 @@ watch(
         :aria-expanded="mobileNavigationOpen"
         @click="mobileNavigationOpen = !mobileNavigationOpen"
       >
-        <Menu :size="21" aria-hidden="true" />
+        <Menu
+          :size="21"
+          aria-hidden="true"
+        />
       </button>
       <div class="platform-ops-header__brand">
         <AppLogoMark :size="18" />
         <span class="platform-ops-header__brand-name"><span>Hyper</span><strong>FileLens</strong></span>
-        <i aria-hidden="true"></i>
+        <i aria-hidden="true" />
         <span class="platform-ops-header__product">{{ t('platformOps.nav.title') }}</span>
       </div>
       <div class="platform-ops-header__actions">
@@ -107,7 +110,10 @@ watch(
           :disabled="!tenantUrl"
           @click="goTenantConsole"
         >
-          <ArrowLeft :size="16" aria-hidden="true" />
+          <ArrowLeft
+            :size="16"
+            aria-hidden="true"
+          />
           <span>{{ t('platformOps.nav.backToConsole') }}</span>
         </button>
         <NavUserMenu />
@@ -120,7 +126,10 @@ watch(
     />
     <main class="platform-ops-main">
       <RouterView v-slot="{ Component, route: viewRoute }">
-        <Suspense :key="platformOpsRouteViewKey(viewRoute)" timeout="0">
+        <Suspense
+          :key="platformOpsRouteViewKey(viewRoute)"
+          timeout="0"
+        >
           <component :is="Component" />
           <template #fallback>
             <div
@@ -143,30 +152,40 @@ watch(
                   aria-hidden="true"
                 >
                   <div class="platform-ops-route-skeleton__header">
-                    <span class="platform-ops-route-skeleton__title"></span>
+                    <span class="platform-ops-route-skeleton__title" />
                     <div class="platform-ops-route-skeleton__actions">
-                      <span></span>
-                      <span></span>
+                      <span />
+                      <span />
                     </div>
                   </div>
-                  <div v-if="routeSkeletonShowsCards" class="platform-ops-route-skeleton__cards">
-                    <span v-for="idx in 4" :key="`ops-card-${idx}`" class="platform-ops-route-skeleton__card">
-                      <i></i>
-                      <b></b>
-                      <em></em>
+                  <div
+                    v-if="routeSkeletonShowsCards"
+                    class="platform-ops-route-skeleton__cards"
+                  >
+                    <span
+                      v-for="idx in 4"
+                      :key="`ops-card-${idx}`"
+                      class="platform-ops-route-skeleton__card"
+                    >
+                      <i />
+                      <b />
+                      <em />
                     </span>
                   </div>
                   <div class="platform-ops-route-skeleton__panel">
                     <div class="platform-ops-route-skeleton__toolbar">
-                      <span></span>
-                      <i></i>
+                      <span />
+                      <i />
                     </div>
                     <div class="platform-ops-route-skeleton__rows">
-                      <span v-for="idx in 8" :key="`ops-row-${idx}`">
-                        <i></i>
-                        <i></i>
-                        <i></i>
-                        <i></i>
+                      <span
+                        v-for="idx in 8"
+                        :key="`ops-row-${idx}`"
+                      >
+                        <i />
+                        <i />
+                        <i />
+                        <i />
                       </span>
                     </div>
                   </div>

--- a/src/frontend/src/platform-ops/pages/engine/PlatformGatewayAdd.vue
+++ b/src/frontend/src/platform-ops/pages/engine/PlatformGatewayAdd.vue
@@ -88,8 +88,15 @@ onUnmounted(() => {
     >
       <div class="fullscreen-form-page source-deploy-page">
         <div class="fullscreen-form-header">
-          <button type="button" class="fullscreen-form-header__back" @click="handleBack">
-            <ArrowLeft class="fullscreen-form-header__back-icon" :size="18" />
+          <button
+            type="button"
+            class="fullscreen-form-header__back"
+            @click="handleBack"
+          >
+            <ArrowLeft
+              class="fullscreen-form-header__back-icon"
+              :size="18"
+            />
           </button>
           <div class="fullscreen-form-header__content">
             <h1 class="fullscreen-form-header__title">

--- a/src/frontend/src/platform-ops/pages/platform/settings/EmailSettings.vue
+++ b/src/frontend/src/platform-ops/pages/platform/settings/EmailSettings.vue
@@ -106,10 +106,18 @@ onMounted(load)
 </script>
 
 <template>
-  <ModulePage :menus="sideNav" body-fill>
-    <div v-loading="busy" class="platform-settings">
+  <ModulePage
+    :menus="sideNav"
+    body-fill
+  >
+    <div
+      v-loading="busy"
+      class="platform-settings"
+    >
       <div class="platform-settings__toolbar">
-        <p class="platform-settings__intro">{{ t('platformOps.settings.email.intro') }}</p>
+        <p class="platform-settings__intro">
+          {{ t('platformOps.settings.email.intro') }}
+        </p>
         <el-button
           v-if="emailEditable"
           type="primary"
@@ -144,18 +152,52 @@ onMounted(load)
             <p v-if="managedByDeployment">
               {{ t('platformOps.settings.email.managedByDeployment') }}
             </p>
-            <p v-if="meta.configuration_error">{{ meta.configuration_error }}</p>
+            <p v-if="meta.configuration_error">
+              {{ meta.configuration_error }}
+            </p>
           </template>
         </el-alert>
 
-        <div v-if="!emailEditable" class="platform-settings__readonly-summary hfl-detail-grid">
-          <div class="hfl-detail-row"><span class="hfl-detail-row__label">{{ t('platformOps.settings.email.backend') }}</span><strong class="hfl-detail-row__value" :class="{ 'hfl-detail-row__empty': !form.backend }">{{ form.backend || '—' }}</strong></div>
-          <div class="hfl-detail-row"><span class="hfl-detail-row__label">{{ t('platformOps.settings.email.host') }}</span><strong class="hfl-detail-row__value" :class="{ 'hfl-detail-row__empty': !form.host }">{{ form.host || '—' }}</strong></div>
-          <div class="hfl-detail-row"><span class="hfl-detail-row__label">{{ t('platformOps.settings.email.port') }}</span><strong class="hfl-detail-row__value" :class="{ 'hfl-detail-row__empty': !form.port }">{{ form.port || '—' }}</strong></div>
-          <div class="hfl-detail-row"><span class="hfl-detail-row__label">{{ t('platformOps.settings.email.hostUser') }}</span><strong class="hfl-detail-row__value" :class="{ 'hfl-detail-row__empty': !form.host_user }">{{ form.host_user || '—' }}</strong></div>
-          <div class="hfl-detail-row"><span class="hfl-detail-row__label">{{ t('platformOps.settings.email.password') }}</span><strong class="hfl-detail-row__value">{{ meta?.password_configured ? 'Configured' : 'Not configured' }}</strong></div>
-          <div class="hfl-detail-row"><span class="hfl-detail-row__label">{{ t('platformOps.settings.email.fromEmail') }}</span><strong class="hfl-detail-row__value" :class="{ 'hfl-detail-row__empty': !form.from_email }">{{ form.from_email || '—' }}</strong></div>
-          <div class="hfl-detail-row"><span class="hfl-detail-row__label">Transport security</span><strong class="hfl-detail-row__value">{{ form.use_ssl ? 'SSL' : form.use_tls ? 'TLS' : 'None' }}</strong></div>
+        <div
+          v-if="!emailEditable"
+          class="platform-settings__readonly-summary hfl-detail-grid"
+        >
+          <div class="hfl-detail-row">
+            <span class="hfl-detail-row__label">{{ t('platformOps.settings.email.backend') }}</span><strong
+              class="hfl-detail-row__value"
+              :class="{ 'hfl-detail-row__empty': !form.backend }"
+            >{{ form.backend || '—' }}</strong>
+          </div>
+          <div class="hfl-detail-row">
+            <span class="hfl-detail-row__label">{{ t('platformOps.settings.email.host') }}</span><strong
+              class="hfl-detail-row__value"
+              :class="{ 'hfl-detail-row__empty': !form.host }"
+            >{{ form.host || '—' }}</strong>
+          </div>
+          <div class="hfl-detail-row">
+            <span class="hfl-detail-row__label">{{ t('platformOps.settings.email.port') }}</span><strong
+              class="hfl-detail-row__value"
+              :class="{ 'hfl-detail-row__empty': !form.port }"
+            >{{ form.port || '—' }}</strong>
+          </div>
+          <div class="hfl-detail-row">
+            <span class="hfl-detail-row__label">{{ t('platformOps.settings.email.hostUser') }}</span><strong
+              class="hfl-detail-row__value"
+              :class="{ 'hfl-detail-row__empty': !form.host_user }"
+            >{{ form.host_user || '—' }}</strong>
+          </div>
+          <div class="hfl-detail-row">
+            <span class="hfl-detail-row__label">{{ t('platformOps.settings.email.password') }}</span><strong class="hfl-detail-row__value">{{ meta?.password_configured ? 'Configured' : 'Not configured' }}</strong>
+          </div>
+          <div class="hfl-detail-row">
+            <span class="hfl-detail-row__label">{{ t('platformOps.settings.email.fromEmail') }}</span><strong
+              class="hfl-detail-row__value"
+              :class="{ 'hfl-detail-row__empty': !form.from_email }"
+            >{{ form.from_email || '—' }}</strong>
+          </div>
+          <div class="hfl-detail-row">
+            <span class="hfl-detail-row__label">Transport security</span><strong class="hfl-detail-row__value">{{ form.use_ssl ? 'SSL' : form.use_tls ? 'TLS' : 'None' }}</strong>
+          </div>
           <div class="hfl-detail-row">
             <span class="hfl-detail-row__label">Configuration source</span>
             <strong class="hfl-detail-row__value">
@@ -170,16 +212,29 @@ onMounted(load)
           class="platform-settings__form"
         >
           <el-form-item :label="t('platformOps.settings.email.backend')">
-            <el-input v-model="form.backend" autocomplete="off" />
+            <el-input
+              v-model="form.backend"
+              autocomplete="off"
+            />
           </el-form-item>
           <el-form-item :label="t('platformOps.settings.email.host')">
-            <el-input v-model="form.host" autocomplete="off" />
+            <el-input
+              v-model="form.host"
+              autocomplete="off"
+            />
           </el-form-item>
           <el-form-item :label="t('platformOps.settings.email.port')">
-            <el-input-number v-model="form.port" :min="1" :max="65535" />
+            <el-input-number
+              v-model="form.port"
+              :min="1"
+              :max="65535"
+            />
           </el-form-item>
           <el-form-item :label="t('platformOps.settings.email.hostUser')">
-            <el-input v-model="form.host_user" autocomplete="off" />
+            <el-input
+              v-model="form.host_user"
+              autocomplete="off"
+            />
           </el-form-item>
           <el-form-item :label="t('platformOps.settings.email.password')">
             <el-input
@@ -189,10 +244,15 @@ onMounted(load)
               autocomplete="new-password"
               :placeholder="meta?.password_configured ? '••••••••' : ''"
             />
-            <p class="platform-settings__hint">{{ t('platformOps.settings.email.passwordHint') }}</p>
+            <p class="platform-settings__hint">
+              {{ t('platformOps.settings.email.passwordHint') }}
+            </p>
           </el-form-item>
           <el-form-item :label="t('platformOps.settings.email.fromEmail')">
-            <el-input v-model="form.from_email" autocomplete="off" />
+            <el-input
+              v-model="form.from_email"
+              autocomplete="off"
+            />
           </el-form-item>
           <el-form-item :label="t('platformOps.settings.email.tls')">
             <el-switch v-model="form.use_tls" />
@@ -203,14 +263,19 @@ onMounted(load)
         </el-form>
 
         <div class="platform-settings__test-block">
-          <h3 class="platform-settings__section">{{ t('platformOps.settings.email.testSectionTitle') }}</h3>
+          <h3 class="platform-settings__section">
+            {{ t('platformOps.settings.email.testSectionTitle') }}
+          </h3>
           <div class="platform-settings__test-row">
             <el-input
               v-model="testRecipient"
               :placeholder="t('platformOps.settings.email.testRecipient')"
               autocomplete="off"
             />
-            <el-button :loading="testing" @click="sendTest">
+            <el-button
+              :loading="testing"
+              @click="sendTest"
+            >
               {{ t('platformOps.settings.email.testSend') }}
             </el-button>
           </div>

--- a/src/frontend/src/platform-ops/pages/platform/settings/EnvironmentSettings.vue
+++ b/src/frontend/src/platform-ops/pages/platform/settings/EnvironmentSettings.vue
@@ -72,22 +72,40 @@ onMounted(load)
 </script>
 
 <template>
-  <ModulePage :menus="sideNav" body-fill>
-    <div v-loading="busy" class="platform-env">
+  <ModulePage
+    :menus="sideNav"
+    body-fill
+  >
+    <div
+      v-loading="busy"
+      class="platform-env"
+    >
       <div class="platform-env__toolbar">
-        <PlatformOpsRefreshButton :loading="busy" @click="load" />
+        <PlatformOpsRefreshButton
+          :loading="busy"
+          @click="load"
+        />
       </div>
 
-      <div v-if="payload" class="hfl-detail-sections">
+      <div
+        v-if="payload"
+        class="hfl-detail-sections"
+      >
         <PlatformOpsDetailSection :title="t('platformOps.settings.environmentTitle')">
           <div class="hfl-detail-grid">
             <div class="hfl-detail-row">
               <span class="hfl-detail-row__label">{{ t('platformOps.settings.environment.appVersion') }}</span>
-              <span class="hfl-detail-row__value hfl-detail-row__value--mono" :class="{ 'hfl-detail-row__empty': !payload.app_version }">{{ payload.app_version || '—' }}</span>
+              <span
+                class="hfl-detail-row__value hfl-detail-row__value--mono"
+                :class="{ 'hfl-detail-row__empty': !payload.app_version }"
+              >{{ payload.app_version || '—' }}</span>
             </div>
             <div class="hfl-detail-row">
               <span class="hfl-detail-row__label">{{ t('platformOps.settings.environment.agentVersion') }}</span>
-              <span class="hfl-detail-row__value hfl-detail-row__value--mono" :class="{ 'hfl-detail-row__empty': !payload.agent_version }">{{ payload.agent_version || '—' }}</span>
+              <span
+                class="hfl-detail-row__value hfl-detail-row__value--mono"
+                :class="{ 'hfl-detail-row__empty': !payload.agent_version }"
+              >{{ payload.agent_version || '—' }}</span>
             </div>
             <div class="hfl-detail-row">
               <span class="hfl-detail-row__label">{{ t('platformOps.settings.environment.djangoDebug') }}</span>
@@ -97,33 +115,69 @@ onMounted(load)
         </PlatformOpsDetailSection>
 
         <PlatformOpsDetailSection :title="t('platformOps.settings.environment.effectiveTitle')">
-          <div v-if="effectiveEntries.length" class="hfl-detail-grid">
-            <div v-for="entry in effectiveEntries" :key="entry.key" class="hfl-detail-row hfl-detail-row--full">
+          <div
+            v-if="effectiveEntries.length"
+            class="hfl-detail-grid"
+          >
+            <div
+              v-for="entry in effectiveEntries"
+              :key="entry.key"
+              class="hfl-detail-row hfl-detail-row--full"
+            >
               <span class="hfl-detail-row__label platform-env__label"><strong>{{ entry.label }}</strong><code>{{ entry.key }}</code></span>
               <span class="hfl-detail-row__value hfl-detail-row__value--mono hfl-detail-row__value--break">{{ entry.value }}</span>
             </div>
           </div>
-          <el-empty v-else :description="t('platformOps.settings.environment.emptyEffective')" :image-size="80" />
+          <el-empty
+            v-else
+            :description="t('platformOps.settings.environment.emptyEffective')"
+            :image-size="80"
+          />
         </PlatformOpsDetailSection>
 
         <PlatformOpsDetailSection :title="t('platformOps.settings.environment.sourcesTitle')">
-          <div v-if="sourceEntries.length" class="hfl-detail-grid">
-            <div v-for="entry in sourceEntries" :key="entry.key" class="hfl-detail-row hfl-detail-row--full">
+          <div
+            v-if="sourceEntries.length"
+            class="hfl-detail-grid"
+          >
+            <div
+              v-for="entry in sourceEntries"
+              :key="entry.key"
+              class="hfl-detail-row hfl-detail-row--full"
+            >
               <span class="hfl-detail-row__label platform-env__label"><strong>{{ entry.label }}</strong><code>{{ entry.key }}</code></span>
               <span class="hfl-detail-row__value">{{ entry.value }}</span>
             </div>
           </div>
-          <el-empty v-else :description="t('platformOps.settings.environment.emptySources')" :image-size="80" />
+          <el-empty
+            v-else
+            :description="t('platformOps.settings.environment.emptySources')"
+            :image-size="80"
+          />
         </PlatformOpsDetailSection>
 
         <PlatformOpsDetailSection :title="t('platformOps.settings.environment.healthTitle')">
-          <div v-if="Object.keys(health).length" class="hfl-detail-grid">
-            <div v-for="(value, key) in health" :key="key" class="hfl-detail-row hfl-detail-row--full">
+          <div
+            v-if="Object.keys(health).length"
+            class="hfl-detail-grid"
+          >
+            <div
+              v-for="(value, key) in health"
+              :key="key"
+              class="hfl-detail-row hfl-detail-row--full"
+            >
               <span class="hfl-detail-row__label platform-env__label"><strong>{{ humanizeKey(String(key)) }}</strong><code>{{ String(key) }}</code></span>
-              <span class="hfl-detail-row__value hfl-detail-row__value--mono" :class="{ 'hfl-detail-row__empty': formatValue(value) === '—' }">{{ formatValue(value) }}</span>
+              <span
+                class="hfl-detail-row__value hfl-detail-row__value--mono"
+                :class="{ 'hfl-detail-row__empty': formatValue(value) === '—' }"
+              >{{ formatValue(value) }}</span>
             </div>
           </div>
-          <el-empty v-else :description="t('platformOps.settings.environment.emptyHealth')" :image-size="80" />
+          <el-empty
+            v-else
+            :description="t('platformOps.settings.environment.emptyHealth')"
+            :image-size="80"
+          />
         </PlatformOpsDetailSection>
       </div>
     </div>

--- a/src/frontend/src/platform-ops/pages/platform/settings/IdentitySettings.vue
+++ b/src/frontend/src/platform-ops/pages/platform/settings/IdentitySettings.vue
@@ -118,8 +118,14 @@ onMounted(load)
 </script>
 
 <template>
-  <ModulePage :menus="sideNav" body-fill>
-    <div v-loading="busy" class="platform-settings">
+  <ModulePage
+    :menus="sideNav"
+    body-fill
+  >
+    <div
+      v-loading="busy"
+      class="platform-settings"
+    >
       <el-alert
         v-if="meta && !enterpriseIdentityEnabled"
         type="info"
@@ -130,10 +136,19 @@ onMounted(load)
         :description="t('platformOps.settings.identity.extensionRequiredBody')"
       />
 
-      <el-form label-position="top" class="platform-settings__form">
+      <el-form
+        label-position="top"
+        class="platform-settings__form"
+      >
         <el-form-item :label="t('platformOps.settings.identity.platformOps')">
-          <el-switch v-model="form.platform_ops_enabled" :disabled="platformOpsManaged" />
-          <p v-if="platformOpsManaged" class="platform-settings__hint">
+          <el-switch
+            v-model="form.platform_ops_enabled"
+            :disabled="platformOpsManaged"
+          />
+          <p
+            v-if="platformOpsManaged"
+            class="platform-settings__hint"
+          >
             Admin Console availability is managed by deployment configuration and is read-only here.
           </p>
         </el-form-item>
@@ -158,22 +173,33 @@ onMounted(load)
         </el-alert>
 
         <template v-if="enterpriseIdentityEnabled">
-          <h3 class="platform-settings__section">{{ t('platformOps.settings.identity.tenantAuthTitle') }}</h3>
+          <h3 class="platform-settings__section">
+            {{ t('platformOps.settings.identity.tenantAuthTitle') }}
+          </h3>
           <el-form-item :label="t('platformOps.settings.identity.emailSignup')">
             <el-switch v-model="form.email_signup_enabled" />
           </el-form-item>
           <el-form-item :label="t('platformOps.settings.identity.emailCodeLogin')">
             <el-switch v-model="form.email_code_login_enabled" />
-            <p class="platform-settings__hint">{{ t('platformOps.settings.identity.emailCodeLoginHint') }}</p>
+            <p class="platform-settings__hint">
+              {{ t('platformOps.settings.identity.emailCodeLoginHint') }}
+            </p>
           </el-form-item>
 
-          <h3 class="platform-settings__section">{{ t('platformOps.settings.googleOAuthTitle') }}</h3>
-          <p class="platform-settings__intro">{{ t('platformOps.settings.googleOAuth.intro') }}</p>
+          <h3 class="platform-settings__section">
+            {{ t('platformOps.settings.googleOAuthTitle') }}
+          </h3>
+          <p class="platform-settings__intro">
+            {{ t('platformOps.settings.googleOAuth.intro') }}
+          </p>
           <el-form-item :label="t('platformOps.settings.identity.googleOAuthEnabled')">
             <el-switch v-model="form.google_oauth_enabled" />
           </el-form-item>
           <el-form-item :label="t('platformOps.settings.identity.googleClientId')">
-            <el-input v-model="form.google_client_id" autocomplete="off" />
+            <el-input
+              v-model="form.google_client_id"
+              autocomplete="off"
+            />
           </el-form-item>
           <el-form-item :label="t('platformOps.settings.identity.googleClientSecret')">
             <el-input
@@ -185,12 +211,21 @@ onMounted(load)
             />
           </el-form-item>
           <el-form-item :label="t('platformOps.settings.identity.googleRedirect')">
-            <el-input :model-value="meta?.google_oauth_redirect_uri || '—'" disabled />
-            <p class="platform-settings__hint">{{ t('platformOps.settings.googleOAuth.redirectHint') }}</p>
+            <el-input
+              :model-value="meta?.google_oauth_redirect_uri || '—'"
+              disabled
+            />
+            <p class="platform-settings__hint">
+              {{ t('platformOps.settings.googleOAuth.redirectHint') }}
+            </p>
           </el-form-item>
 
-          <h3 class="platform-settings__section">{{ t('platformOps.settings.turnstileTitle') }}</h3>
-          <p class="platform-settings__intro">{{ t('platformOps.settings.turnstile.intro') }}</p>
+          <h3 class="platform-settings__section">
+            {{ t('platformOps.settings.turnstileTitle') }}
+          </h3>
+          <p class="platform-settings__intro">
+            {{ t('platformOps.settings.turnstile.intro') }}
+          </p>
           <el-form-item :label="t('platformOps.settings.turnstile.statusLabel')">
             <el-tag :type="meta?.turnstile_enabled ? 'success' : 'info'">
               {{
@@ -199,10 +234,15 @@ onMounted(load)
                   : t('platformOps.settings.turnstile.disabled')
               }}
             </el-tag>
-            <p class="platform-settings__hint">{{ t('platformOps.settings.turnstile.enableHint') }}</p>
+            <p class="platform-settings__hint">
+              {{ t('platformOps.settings.turnstile.enableHint') }}
+            </p>
           </el-form-item>
           <el-form-item :label="t('platformOps.settings.identity.turnstileSiteKey')">
-            <el-input v-model="form.turnstile_site_key" autocomplete="off" />
+            <el-input
+              v-model="form.turnstile_site_key"
+              autocomplete="off"
+            />
           </el-form-item>
           <el-form-item :label="t('platformOps.settings.identity.turnstileSecret')">
             <el-input
@@ -212,31 +252,64 @@ onMounted(load)
               autocomplete="new-password"
               :placeholder="meta?.turnstile_secret_configured ? '••••••••' : ''"
             />
-            <p class="platform-settings__hint">{{ t('platformOps.settings.turnstile.secretHint') }}</p>
+            <p class="platform-settings__hint">
+              {{ t('platformOps.settings.turnstile.secretHint') }}
+            </p>
           </el-form-item>
 
-          <h3 class="platform-settings__section">{{ t('platformOps.settings.identity.iamTitle') }}</h3>
+          <h3 class="platform-settings__section">
+            {{ t('platformOps.settings.identity.iamTitle') }}
+          </h3>
           <el-form-item :label="t('platformOps.settings.identity.regCodeMinutes')">
-            <el-input-number v-model="form.registration_verification_code_minutes" :min="1" :max="120" />
+            <el-input-number
+              v-model="form.registration_verification_code_minutes"
+              :min="1"
+              :max="120"
+            />
           </el-form-item>
           <el-form-item :label="t('platformOps.settings.identity.regTokenHours')">
-            <el-input-number v-model="form.registration_token_expiry_hours" :min="1" :max="168" />
+            <el-input-number
+              v-model="form.registration_token_expiry_hours"
+              :min="1"
+              :max="168"
+            />
           </el-form-item>
           <el-form-item :label="t('platformOps.settings.identity.resetCodeMinutes')">
-            <el-input-number v-model="form.password_reset_verification_code_minutes" :min="1" :max="120" />
+            <el-input-number
+              v-model="form.password_reset_verification_code_minutes"
+              :min="1"
+              :max="120"
+            />
           </el-form-item>
           <el-form-item :label="t('platformOps.settings.identity.resetTimeoutSeconds')">
-            <el-input-number v-model="form.password_reset_timeout_seconds" :min="60" :max="86400" />
+            <el-input-number
+              v-model="form.password_reset_timeout_seconds"
+              :min="60"
+              :max="86400"
+            />
           </el-form-item>
           <el-form-item :label="t('platformOps.settings.identity.loginCodeMinutes')">
-            <el-input-number v-model="form.login_verification_code_minutes" :min="1" :max="30" />
+            <el-input-number
+              v-model="form.login_verification_code_minutes"
+              :min="1"
+              :max="30"
+            />
           </el-form-item>
         </template>
       </el-form>
 
       <div class="platform-settings__footer">
-        <PlatformOpsRefreshButton :loading="busy" @click="load" />
-        <el-button type="primary" :loading="saving" @click="save">{{ t('common.save') }}</el-button>
+        <PlatformOpsRefreshButton
+          :loading="busy"
+          @click="load"
+        />
+        <el-button
+          type="primary"
+          :loading="saving"
+          @click="save"
+        >
+          {{ t('common.save') }}
+        </el-button>
       </div>
     </div>
     <DangerConfirmDialog

--- a/src/frontend/src/platform-ops/platformOpsFinalization.test.ts
+++ b/src/frontend/src/platform-ops/platformOpsFinalization.test.ts
@@ -1,9 +1,10 @@
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
+import { compactSourceText } from '../test/sourceText'
 
 function source(path: string) {
-  return readFileSync(resolve(process.cwd(), path), 'utf8')
+  return compactSourceText(readFileSync(resolve(process.cwd(), path), 'utf8'))
 }
 
 describe('Admin Console finalization contracts', () => {

--- a/src/frontend/src/router/index.ts
+++ b/src/frontend/src/router/index.ts
@@ -1,9 +1,7 @@
 import { nextTick } from 'vue'
 import { createRouter, createWebHistory } from 'vue-router'
-import AppShell from '../app/layout/AppShell.vue'
 import { resolvePlatformOpsRoutes } from '../platform-ops/resolveRoutes'
 import { resolveTenantOpsRoutes } from '../ops/resolveRoutes'
-import PlatformOpsShell from '../platform-ops/layout/PlatformOpsShell.vue'
 
 const platformOpsRoutes = resolvePlatformOpsRoutes()
 const tenantOpsRoutes = resolveTenantOpsRoutes()
@@ -22,6 +20,8 @@ const authTurnstilePrefetch = () => {
 
 const fullscreenRouteMeta = { layout: 'fullscreen' } as const
 
+const AppShell = () => import('../app/layout/AppShell.vue')
+const PlatformOpsShell = () => import('../platform-ops/layout/PlatformOpsShell.vue')
 const LoginPage = lazyRoute(() => import('../pages/auth/Login.vue'))
 const RegisterPage = lazyRoute(() => import('../pages/auth/Register.vue'))
 const OAuthCallbackPage = lazyRoute(() => import('../pages/auth/OAuthCallback.vue'))

--- a/src/frontend/src/router/routeShellLazyLoading.test.ts
+++ b/src/frontend/src/router/routeShellLazyLoading.test.ts
@@ -1,0 +1,14 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it } from 'vitest'
+import { router } from './index'
+
+describe('route shell loading', () => {
+  it('keeps tenant and platform shells as native async route components', () => {
+    const tenantRoute = router.options.routes.find(route => route.path === '/' && 'children' in route)
+    const platformRoute = router.options.routes.find(route => route.path === '/platform-ops')
+
+    expect(tenantRoute?.component).toEqual(expect.any(Function))
+    expect(platformRoute?.component).toEqual(expect.any(Function))
+  })
+})

--- a/src/frontend/src/styles/detailPageResponsive.test.ts
+++ b/src/frontend/src/styles/detailPageResponsive.test.ts
@@ -1,9 +1,11 @@
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
+import { compactSourceText } from '../test/sourceText'
 
 const styles = readFileSync(resolve(process.cwd(), 'src/styles/detail-page-ui.css'), 'utf8')
 const capacityCell = readFileSync(resolve(process.cwd(), 'src/components/HflCapacityCell.vue'), 'utf8')
+const compactCapacityCell = compactSourceText(capacityCell)
 const repositoryPage = readFileSync(resolve(process.cwd(), 'src/pages/node/Repositories.vue'), 'utf8')
 
 describe('responsive detail rows', () => {
@@ -12,7 +14,7 @@ describe('responsive detail rows', () => {
     expect(styles).toContain('text-align: left')
     expect(styles).toContain('.hfl-empty-mark {')
     expect(styles).toContain('align-self: flex-start')
-    expect(capacityCell).toContain('<span v-else class="hfl-empty-mark">{{ emptyLabel }}</span>')
+    expect(compactCapacityCell).toContain('<span v-else class="hfl-empty-mark">{{ emptyLabel }}</span>')
     const stackedRepositoryUsageRows = repositoryPage.match(
       /class="hfl-detail-row__value hfl-detail-row__value--stacked"/g,
     )

--- a/src/frontend/src/styles/fullscreenFormButtons.test.ts
+++ b/src/frontend/src/styles/fullscreenFormButtons.test.ts
@@ -1,6 +1,7 @@
 import { readdirSync, readFileSync } from 'node:fs'
 import { relative, resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
+import { compactSourceText } from '../test/sourceText'
 
 function frontendSourcesBelow(directory: string): string[] {
   return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
@@ -23,7 +24,9 @@ describe('fullscreen form buttons', () => {
   })
 
   it('binds the Add S3 primary action to the shared loading behavior', () => {
-    const addS3Repo = readFileSync(resolve(process.cwd(), 'src/pages/node/AddS3Repo.vue'), 'utf8')
+    const addS3Repo = compactSourceText(
+      readFileSync(resolve(process.cwd(), 'src/pages/node/AddS3Repo.vue'), 'utf8'),
+    )
 
     expect(addS3Repo).toContain('<ElButton type="primary" :loading="busy" :disabled="!canSubmit" @click="onSubmit">')
     expect(addS3Repo).not.toContain('form-action__loading')

--- a/src/frontend/src/test/sourceText.ts
+++ b/src/frontend/src/test/sourceText.ts
@@ -1,0 +1,9 @@
+export function compactSourceText(source: string): string {
+  return source
+    .replace(/\s+/g, ' ')
+    .replace(/\s+>(?=\s*(?:<|{{))/g, '>')
+    .replace(/>\s+</g, '><')
+    .replace(/>\s+(?={{)/g, '>')
+    .replace(/}}\s+</g, '}}<')
+    .trim()
+}

--- a/src/frontend/vite.config.ts
+++ b/src/frontend/vite.config.ts
@@ -1,16 +1,18 @@
-import { defineConfig } from 'vite'
+import { defineConfig, type Plugin } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import tailwindcss from '@tailwindcss/vite'
 import { sentryVitePlugin } from '@sentry/vite-plugin'
-import { existsSync, readFileSync } from 'node:fs'
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
-import { dirname, resolve } from 'node:path'
+import { dirname, relative, resolve } from 'node:path'
+import { gzipSync } from 'node:zlib'
 
 const frontendDir = dirname(fileURLToPath(import.meta.url))
 const frontendSrc = resolve(frontendDir, 'src')
 const repoRoot = resolve(frontendDir, '../..')
 const devApiTarget = process.env.VITE_DEV_API_TARGET || 'http://api:8000'
 const devWebSocketTarget = process.env.VITE_DEV_WEBSOCKET_TARGET || 'http://api:8001'
+const bundleReportEnabled = process.env.HFL_BUNDLE_REPORT === '1'
 const sentrySourceMapUpload = Boolean(
   process.env.SENTRY_AUTH_TOKEN
   && process.env.SENTRY_URL
@@ -131,6 +133,93 @@ for (const e of extensionFrontendSrcs) {
   console.info(`[vite] Extension frontend merged: ${e.id} ← ${e.root}`)
 }
 
+function bundleReportModuleId(moduleId: string): string {
+  const normalized = moduleId.replaceAll('\\', '/')
+  const nodeModulesMarker = '/node_modules/'
+  const nodeModulesIndex = normalized.lastIndexOf(nodeModulesMarker)
+  if (nodeModulesIndex >= 0) {
+    return `node_modules/${normalized.slice(nodeModulesIndex + nodeModulesMarker.length)}`
+  }
+  if (normalized.startsWith(`${frontendDir}/`)) {
+    return relative(frontendDir, normalized).replaceAll('\\', '/')
+  }
+  for (const extension of extensionFrontendSrcs) {
+    if (normalized.startsWith(`${extension.src}/`)) {
+      return `extensions/${extension.id}/${relative(extension.src, normalized).replaceAll('\\', '/')}`
+    }
+  }
+  return normalized.startsWith('\0') ? normalized : relative(repoRoot, normalized).replaceAll('\\', '/')
+}
+
+function hflBundleReportPlugin(): Plugin {
+  return {
+    name: 'hfl-bundle-report',
+    apply: 'build',
+    generateBundle(_options, bundle) {
+      const chunks = Object.values(bundle)
+        .filter(output => output.type === 'chunk')
+        .map((chunk) => ({
+          fileName: chunk.fileName,
+          isEntry: chunk.isEntry,
+          isDynamicEntry: chunk.isDynamicEntry,
+          facadeModuleId: chunk.facadeModuleId ? bundleReportModuleId(chunk.facadeModuleId) : null,
+          imports: [...chunk.imports].sort(),
+          dynamicImports: [...chunk.dynamicImports].sort(),
+          rawBytes: Buffer.byteLength(chunk.code),
+          gzipBytes: gzipSync(chunk.code).byteLength,
+          modules: Object.entries(chunk.modules)
+            .map(([moduleId, details]) => ({
+              id: bundleReportModuleId(moduleId),
+              renderedBytes: details.renderedLength,
+            }))
+            .sort((a, b) => b.renderedBytes - a.renderedBytes || a.id.localeCompare(b.id)),
+        }))
+        .sort((a, b) => b.rawBytes - a.rawBytes || a.fileName.localeCompare(b.fileName))
+      const assets = Object.values(bundle)
+        .filter(output => output.type === 'asset' && output.fileName.endsWith('.css'))
+        .map((asset) => {
+          const source = typeof asset.source === 'string' ? asset.source : Buffer.from(asset.source)
+          return {
+            fileName: asset.fileName,
+            rawBytes: typeof source === 'string' ? Buffer.byteLength(source) : source.byteLength,
+            gzipBytes: gzipSync(source).byteLength,
+          }
+        })
+        .sort((a, b) => b.rawBytes - a.rawBytes || a.fileName.localeCompare(b.fileName))
+      const reportDir = resolve(repoRoot, 'build/reports')
+      mkdirSync(reportDir, { recursive: true })
+      writeFileSync(
+        resolve(reportDir, 'frontend-bundle.json'),
+        `${JSON.stringify({ chunks, cssAssets: assets }, null, 2)}\n`,
+      )
+    },
+  }
+}
+
+function deterministicChunkName(moduleId: string): string | undefined {
+  const normalized = moduleId.replaceAll('\\', '/')
+  const marker = '/node_modules/'
+  const markerIndex = normalized.lastIndexOf(marker)
+  if (markerIndex < 0) return undefined
+  const dependencyPath = normalized.slice(markerIndex + marker.length)
+  const dependency = dependencyPath.startsWith('@')
+    ? dependencyPath.split('/').slice(0, 2).join('/')
+    : dependencyPath.split('/')[0]
+
+  if (dependency === 'echarts' || dependency === 'zrender') {
+    return 'charts-echarts'
+  }
+  if (dependency.startsWith('@sentry/') || dependency.startsWith('@sentry-internal/')) {
+    return 'observability-sentry'
+  }
+  if (
+    dependency === 'codemirror'
+    || dependency.startsWith('@codemirror/')
+    || dependency.startsWith('@lezer/')
+  ) return 'editor-codemirror'
+  return undefined
+}
+
 // https://vite.dev/config/
 export default defineConfig(() => ({
   envDir: repoRoot,
@@ -154,6 +243,7 @@ export default defineConfig(() => ({
     ...(platformFrontendSrc ? [hflExtOssBridgePlugin()] : []),
     vue(),
     tailwindcss(),
+    ...(bundleReportEnabled ? [hflBundleReportPlugin()] : []),
     ...(sentrySourceMapUpload
       ? [sentryVitePlugin({
           url: process.env.SENTRY_URL,
@@ -175,6 +265,11 @@ export default defineConfig(() => ({
   build: {
     target: 'es2022',
     sourcemap: sentrySourceMapUpload ? 'hidden' : false,
+    rollupOptions: {
+      output: {
+        manualChunks: deterministicChunkName,
+      },
+    },
   },
   optimizeDeps: {
     esbuildOptions: {


### PR DESCRIPTION
## Summary

- apply the supported ESLint fixes across maintained Vue sources, preserve component fallback contracts, and scope test-only rule exceptions
- lazy-load tenant and Admin Console shells plus the optional Sentry SDK, and split ECharts, Sentry, and CodeMirror families into deterministic chunks
- add an opt-in raw and gzip bundle composition report outside dist
- harden Copilot Markdown link protocols and fix Element Plus date-range shortcut handling found during browser verification

## Bundle results

- reduce the issue baseline entry from about 1,366.82 kB raw / 429.40 kB gzip to 1,163.76 kB raw / 372.32 kB gzip
- keep the entry static closure free of route shells, charts, and Sentry
- isolate ECharts at 495.14 kB raw / 169.40 kB gzip
- trim the optional Sentry chunk to 127.60 kB raw / 43.83 kB gzip by excluding Replay and Feedback code
- keep AppShell at 41.47 kB raw / 8.85 kB gzip and PlatformOpsShell at 21.17 kB raw / 3.62 kB gzip

A broader framework and Element Plus manual split was evaluated but rejected because it increased the login initial static closure by about 29%. The remaining entry-size warning is therefore explained by the default English catalog, Vue, vue-i18n, and globally registered Element Plus components rather than hidden route-only dependencies. The existing router static/dynamic import warning is also unchanged and does not prevent route chunking.

## Testing

- npm run lint -- --max-warnings=0
- npm run test:ci (198 files, 976 tests)
- HFL_BUNDLE_REPORT=1 npm run build
- manual cold-load checks for login, tenant shell, Admin Console shell, Insight Usage charts, conditional Sentry loading, and one-shot chunk recovery
- real Element Plus range-panel preset click coverage

Enterprise Extension and Website builds remain covered by the repository PR pipeline where those sources and dependencies are available.

Closes #280