### PR TITLE
feat(i18n): add professional language selection

### DIFF
--- a/src/frontend/src/app/layout/AppShell.vue
+++ b/src/frontend/src/app/layout/AppShell.vue
@@ -7,7 +7,6 @@ import { LANG_STORAGE_KEY } from '../../i18n'
 import { useTheme } from '../../composables/useTheme'
 import { platformOpsEntryUrl, fetchDeployProfile } from '../../composables/useDeployProfile'
 import { currentUser } from '../../composables/useAuth'
-import { useLocaleSwitch } from '../../composables/useLocaleSwitch'
 import { useOrganizationSwitcher } from '../../composables/useOrganizationSwitcher'
 import Sidebar from '../../components/Sidebar.vue'
 import type { MenuItem } from '../../components/ModulePage.vue'
@@ -35,7 +34,6 @@ const opsFallbackMenus = useOpsMenus()
 const accountFallbackMenus = useAccountCenterMenus()
 const mobileNavigationOpen = ref(false)
 const { itemsWithActiveState: primaryNavItems } = useAppPrimaryNav()
-const { canSwitchLocale, currentLocaleLabel, nextLocaleLabel, toggleLocale } = useLocaleSwitch()
 const { showSwitcher: showOrganizationSwitcher } = useOrganizationSwitcher()
 
 const adminConsoleHref = computed(() =>
@@ -486,12 +484,9 @@ function applyThemeVars(t: string) {
     <TopNav
       :mobile-menu-open="mobileNavigationOpen"
       :admin-console-href="adminConsoleHref"
-      :can-switch-locale="canSwitchLocale"
-      :next-locale-label="nextLocaleLabel"
       :timezone-display="timezoneDisplay"
       :timezone-offset-display="timezoneOffsetDisplay"
       @toggle-mobile-menu="mobileNavigationOpen = !mobileNavigationOpen"
-      @toggle-locale="toggleLocale"
     />
     <MobileNavigationDrawer
       v-model="mobileNavigationOpen"
@@ -499,12 +494,8 @@ function applyThemeVars(t: string) {
       :primary-items="primaryNavItems"
       :module-items="fallbackMenuItems"
       :admin-console-href="adminConsoleHref"
-      :can-switch-locale="canSwitchLocale"
-      :current-locale-label="currentLocaleLabel"
-      :next-locale-label="nextLocaleLabel"
       :show-organization-switcher="showOrganizationSwitcher"
       :timezone-offset-display="timezoneOffsetDisplay"
-      @toggle-locale="toggleLocale"
     />
     <div
       v-if="supportOrgKey"

--- a/src/frontend/src/app/layout/TopNav.vue
+++ b/src/frontend/src/app/layout/TopNav.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { RouterLink, useRoute, useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
-import { Globe, Menu, Shield } from 'lucide-vue-next'
+import { Menu, Shield } from 'lucide-vue-next'
 import NavNotificationPopover from '../../components/NavNotificationPopover.vue'
 import NavUserMenu from '../../components/NavUserMenu.vue'
 import OrgSwitcher from '../../components/OrgSwitcher.vue'
@@ -9,19 +9,17 @@ import AppLogoMark from '../../components/AppLogoMark.vue'
 import { beginRouteRequestScope } from '../../lib/routeRequestAbort'
 import { beginRouteTransition } from '../../lib/routeTransition'
 import { useAppPrimaryNav } from '../../composables/useAppPrimaryNav'
+import LanguageSwitcher from '../../components/LanguageSwitcher.vue'
 
 withDefaults(
   defineProps<{
     mobileMenuOpen?: boolean
     adminConsoleHref?: string
-    canSwitchLocale?: boolean
-    nextLocaleLabel?: string
     timezoneDisplay?: string
     timezoneOffsetDisplay?: string
   }>(),
   {
     adminConsoleHref: '',
-    nextLocaleLabel: '',
     timezoneDisplay: '',
     timezoneOffsetDisplay: '',
   },
@@ -29,7 +27,6 @@ withDefaults(
 
 const emit = defineEmits<{
   'toggle-mobile-menu': []
-  'toggle-locale': []
 }>()
 
 const { t } = useI18n()
@@ -106,16 +103,9 @@ function handleNavClick(event: MouseEvent, to: string) {
         <span>{{ timezoneOffsetDisplay }}</span>
       </span>
 
-      <ElButton
-        v-if="canSwitchLocale"
-        class="icon-btn desktop-navigation-control"
-        :title="t('nav.switchLanguage', { language: nextLocaleLabel })"
-        :aria-label="t('nav.switchLanguage', { language: nextLocaleLabel })"
-        text
-        @click="emit('toggle-locale')"
-      >
-        <Globe :size="16" />
-      </ElButton>
+      <span class="desktop-navigation-control">
+        <LanguageSwitcher variant="navigation" />
+      </span>
 
       <span class="desktop-navigation-control"><OrgSwitcher /></span>
 

--- a/src/frontend/src/components/LanguageSwitcher.test.ts
+++ b/src/frontend/src/components/LanguageSwitcher.test.ts
@@ -1,0 +1,71 @@
+// @vitest-environment jsdom
+
+import { flushPromises, mount } from '@vue/test-utils'
+import ElementPlus from 'element-plus'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  DEFAULT_LOCALE,
+  i18n,
+  registerLocale,
+  selectLocale,
+  unregisterLocale,
+} from '../i18n'
+import { installedLangPacks } from '../lib/langPacks'
+import LanguageSwitcher from './LanguageSwitcher.vue'
+
+afterEach(() => {
+  selectLocale(DEFAULT_LOCALE)
+  unregisterLocale('zh-hans')
+  installedLangPacks.value = []
+  document.body.innerHTML = ''
+})
+
+describe('LanguageSwitcher', () => {
+  it('shows user-facing language names and selects a language directly', async () => {
+    registerLocale('zh-hans', { nav: { languageLabel: 'Language' } }, ['zh', 'zh-cn'])
+    installedLangPacks.value = [{
+      id: 'zh-hans',
+      display_name: 'Simplified Chinese',
+      frontend_code: 'zh-hans',
+      backend_code: 'zh-hans',
+      aliases: ['zh', 'zh-cn'],
+      version: '0.2.0',
+    }]
+
+    const wrapper = mount(LanguageSwitcher, {
+      attachTo: document.body,
+      props: { variant: 'auth' },
+      global: { plugins: [i18n, ElementPlus] },
+    })
+
+    const trigger = wrapper.get('button')
+    expect(trigger.text()).toContain('English')
+    expect(trigger.text()).not.toContain('ZH-HANS')
+
+    await trigger.trigger('click')
+    await flushPromises()
+    const items = [...document.body.querySelectorAll<HTMLElement>('.el-dropdown-menu__item')]
+    expect(items.map((item) => item.textContent?.trim())).toEqual(['English', 'Simplified Chinese'])
+    expect(items[0]?.getAttribute('aria-current')).toBe('true')
+    expect(items[1]?.hasAttribute('aria-current')).toBe(false)
+
+    items[1]?.click()
+    await flushPromises()
+    expect(i18n.global.locale.value).toBe('zh-hans')
+    expect(trigger.text()).toContain('Simplified Chinese')
+    expect(trigger.text()).not.toContain('ZH-HANS')
+    expect(wrapper.emitted('change')).toEqual([['zh-hans']])
+    expect(items[0]?.hasAttribute('aria-current')).toBe(false)
+    expect(items[1]?.getAttribute('aria-current')).toBe('true')
+
+    await trigger.trigger('click')
+    await flushPromises()
+    const selectedItem = [...document.body.querySelectorAll<HTMLElement>('.el-dropdown-menu__item')]
+      .find((item) => item.textContent?.includes('Simplified Chinese'))
+    selectedItem?.click()
+    await flushPromises()
+    expect(wrapper.emitted('change')).toEqual([['zh-hans']])
+
+    wrapper.unmount()
+  })
+})

--- a/src/frontend/src/components/LanguageSwitcher.vue
+++ b/src/frontend/src/components/LanguageSwitcher.vue
@@ -1,0 +1,315 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { Check, ChevronDown, Globe } from 'lucide-vue-next'
+import { useLocaleSwitch } from '../composables/useLocaleSwitch'
+
+const props = withDefaults(
+  defineProps<{
+    variant?: 'auth' | 'navigation' | 'mobile'
+  }>(),
+  { variant: 'navigation' },
+)
+
+const emit = defineEmits<{
+  change: [locale: string]
+}>()
+
+const { t, locale } = useI18n()
+const {
+  canSwitchLocale,
+  currentLocaleLabel,
+  localeOptions,
+  selectLocale,
+} = useLocaleSwitch()
+const dropdownOpen = ref(false)
+
+const popperClass = computed(
+  () => `hfl-language-switcher-popper hfl-language-switcher-popper--${props.variant}`,
+)
+const ariaLabel = computed(
+  () => `${t('nav.languageLabel')}: ${currentLocaleLabel.value}`,
+)
+
+function handleCommand(code: string | number | object) {
+  if (typeof code !== 'string') return
+  if (!selectLocale(code)) return
+  emit('change', code)
+}
+
+function handleVisibleChange(visible: boolean) {
+  dropdownOpen.value = visible
+}
+</script>
+
+<template>
+  <ElDropdown
+    v-if="canSwitchLocale"
+    :class="['language-switcher', `language-switcher--${variant}`]"
+    trigger="click"
+    placement="bottom-end"
+    :popper-class="popperClass"
+    :hide-on-click="true"
+    @visible-change="handleVisibleChange"
+    @command="handleCommand"
+  >
+    <button
+      type="button"
+      class="language-switcher__trigger"
+      :aria-label="ariaLabel"
+      aria-haspopup="menu"
+      :aria-expanded="dropdownOpen"
+    >
+      <Globe
+        class="language-switcher__globe"
+        :size="variant === 'mobile' ? 18 : 17"
+        aria-hidden="true"
+      />
+      <span
+        v-if="variant === 'mobile'"
+        class="language-switcher__mobile-copy"
+      >
+        <span class="language-switcher__mobile-title">{{ t('nav.languageLabel') }}</span>
+        <span class="language-switcher__mobile-current">{{ currentLocaleLabel }}</span>
+      </span>
+      <span
+        v-else
+        class="language-switcher__current"
+      >{{ currentLocaleLabel }}</span>
+      <ChevronDown
+        :class="['language-switcher__chevron', { 'is-open': dropdownOpen }]"
+        :size="15"
+        aria-hidden="true"
+      />
+    </button>
+
+    <template #dropdown>
+      <ElDropdownMenu
+        role="menu"
+        :aria-label="t('nav.languageLabel')"
+      >
+        <ElDropdownItem
+          v-for="option in localeOptions"
+          :key="option.code"
+          :command="option.code"
+          :class="{ 'is-selected': option.code === String(locale) }"
+          :aria-current="option.code === String(locale) ? 'true' : undefined"
+        >
+          <span class="language-switcher__option">
+            <span class="language-switcher__option-label">{{ option.label }}</span>
+            <Check
+              v-if="option.code === String(locale)"
+              class="language-switcher__check"
+              :size="16"
+              aria-hidden="true"
+            />
+          </span>
+        </ElDropdownItem>
+      </ElDropdownMenu>
+    </template>
+  </ElDropdown>
+  <span
+    v-else
+    :class="['language-switcher', 'language-switcher--static', `language-switcher--${variant}`]"
+    :aria-label="ariaLabel"
+  >
+    <Globe
+      class="language-switcher__globe"
+      :size="variant === 'mobile' ? 18 : 17"
+      aria-hidden="true"
+    />
+    <span
+      v-if="variant === 'mobile'"
+      class="language-switcher__mobile-copy"
+    >
+      <span class="language-switcher__mobile-title">{{ t('nav.languageLabel') }}</span>
+      <span class="language-switcher__mobile-current">{{ currentLocaleLabel }}</span>
+    </span>
+    <span
+      v-else
+      class="language-switcher__current"
+    >{{ currentLocaleLabel }}</span>
+  </span>
+</template>
+
+<style scoped>
+.language-switcher {
+  display: inline-flex;
+  min-width: 0;
+}
+
+.language-switcher__trigger,
+.language-switcher--static {
+  display: inline-flex;
+  align-items: center;
+  min-height: 34px;
+  gap: 7px;
+  padding: 5px 9px;
+  color: inherit;
+  font: inherit;
+  line-height: 1;
+  white-space: nowrap;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 8px;
+}
+
+.language-switcher__trigger {
+  cursor: pointer;
+  transition: background-color 0.15s ease, border-color 0.15s ease;
+}
+
+.language-switcher__trigger:hover,
+.language-switcher__trigger:focus-visible {
+  background: rgba(255, 255, 255, 0.08);
+  border-color: rgba(255, 255, 255, 0.16);
+}
+
+.language-switcher__trigger:focus-visible {
+  outline: 2px solid rgba(174, 164, 255, 0.9);
+  outline-offset: 2px;
+}
+
+.language-switcher__trigger:focus:not(:focus-visible) {
+  outline: none;
+}
+
+.language-switcher__globe {
+  flex: 0 0 auto;
+  opacity: 0.86;
+}
+
+.language-switcher__current {
+  overflow: hidden;
+  font-size: 13px;
+  font-weight: 500;
+  text-overflow: ellipsis;
+}
+
+.language-switcher__chevron {
+  flex: 0 0 auto;
+  opacity: 0.7;
+  transition: transform 0.15s ease;
+}
+
+.language-switcher__chevron.is-open {
+  transform: rotate(180deg);
+}
+
+.language-switcher--auth {
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.language-switcher--navigation {
+  color: var(--nav-text-secondary, rgba(255, 255, 255, 0.78));
+}
+
+.language-switcher--mobile {
+  width: 100%;
+}
+
+.language-switcher--mobile .language-switcher__trigger,
+.language-switcher--mobile.language-switcher--static {
+  width: 100%;
+  justify-content: flex-start;
+  min-height: 44px;
+  padding: 8px 12px;
+}
+
+.language-switcher__mobile-copy {
+  display: flex;
+  min-width: 0;
+  flex: 1;
+  flex-direction: column;
+  gap: 3px;
+  text-align: left;
+}
+
+.language-switcher__mobile-title {
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1.25;
+}
+
+.language-switcher__mobile-current {
+  overflow: hidden;
+  color: var(--color-text-tertiary, #909399);
+  font-size: 12px;
+  line-height: 1.25;
+  text-overflow: ellipsis;
+}
+
+.language-switcher--static {
+  cursor: default;
+}
+
+@media (max-width: 540px) {
+  .language-switcher--auth .language-switcher__trigger {
+    padding-inline: 7px;
+  }
+
+  .language-switcher--auth .language-switcher__current {
+    max-width: 92px;
+  }
+}
+</style>
+
+<style>
+.hfl-language-switcher-popper.el-popper {
+  min-width: 180px;
+  padding: 6px !important;
+  overflow: hidden;
+  background: #272633 !important;
+  border: 1px solid rgba(255, 255, 255, 0.14) !important;
+  border-radius: 10px !important;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.34) !important;
+}
+
+.hfl-language-switcher-popper .el-dropdown-menu {
+  padding: 0 !important;
+  background: transparent !important;
+}
+
+.hfl-language-switcher-popper.el-popper .el-popper__arrow::before {
+  background: #272633 !important;
+  border-color: rgba(255, 255, 255, 0.14) !important;
+}
+
+.hfl-language-switcher-popper .el-dropdown-menu__item {
+  min-height: 36px;
+  padding: 8px 10px !important;
+  color: rgba(255, 255, 255, 0.82) !important;
+  border-radius: 7px;
+}
+
+.hfl-language-switcher-popper .el-dropdown-menu__item:hover,
+.hfl-language-switcher-popper .el-dropdown-menu__item:focus,
+.hfl-language-switcher-popper .el-dropdown-menu__item.is-selected {
+  color: #fff !important;
+  background: rgba(109, 94, 246, 0.22) !important;
+}
+
+.hfl-language-switcher-popper .el-dropdown-menu__item:focus-visible {
+  outline: 2px solid rgba(174, 164, 255, 0.9);
+  outline-offset: -2px;
+}
+
+.language-switcher__option {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  gap: 22px;
+}
+
+.language-switcher__option-label {
+  font-size: 13px;
+  line-height: 1.35;
+}
+
+.language-switcher__check {
+  flex: 0 0 auto;
+  color: #b9b0ff;
+}
+
+</style>

--- a/src/frontend/src/components/MobileHeaderUtilities.test.ts
+++ b/src/frontend/src/components/MobileHeaderUtilities.test.ts
@@ -14,13 +14,12 @@ const dropdownStyles = source('src/styles/nav-dropdown-panel.css')
 const locale = source('src/locales/en.ts')
 
 describe('mobile header utilities', () => {
-  it('shares deploy profile and locale state from the app shell', () => {
+  it('shares deploy profile state from the app shell and one language selector', () => {
     expect(appShell).toContain('async function refreshHeaderProfile()')
     expect(appShell).toContain(':admin-console-href="adminConsoleHref"')
-    expect(appShell).toContain(':can-switch-locale="canSwitchLocale"')
-    expect(appShell).toContain(':current-locale-label="currentLocaleLabel"')
     expect(appShell).toContain(':timezone-offset-display="timezoneOffsetDisplay"')
-    expect(appShell).toContain('@toggle-locale="toggleLocale"')
+    expect(topNav).toContain('<LanguageSwitcher variant="navigation" />')
+    expect(drawer).toContain('variant="mobile"')
     expect(topNav).not.toContain('fetchDeployProfile')
   })
 
@@ -28,17 +27,12 @@ describe('mobile header utilities', () => {
     expect(drawer).toContain('<OrgSwitcher variant="mobile" />')
     expect(drawer).toContain('target="_blank"')
     expect(drawer).toContain("$t('nav.platformOps')")
-    expect(drawer).toContain("$t('nav.switchLanguage', { language: nextLocaleLabel })")
-    expect(drawer).toContain('v-if="currentLocaleLabel || timezoneOffsetDisplay"')
-    expect(drawer).toContain("$t('nav.languageLabel')")
-    expect(drawer).toContain("$t('nav.timezoneLabel')")
-    expect(drawer).toContain('v-if="canSwitchLocale"')
+    expect(drawer).toContain('<LanguageSwitcher')
     expect(drawer).toContain("$t('nav.timezoneLabel')")
     expect(drawer).toContain('{{ timezoneOffsetDisplay }}')
     expect(userMenu).not.toContain('nav-user-timezone')
     expect(locale).toContain("timezoneLabel: 'Time Zone'")
     expect(locale).toContain("languageLabel: 'Language'")
-    expect(locale).toContain("switchLanguage: 'Switch to {language}'")
   })
 
   it('keeps mobile triggers and popovers within narrow viewports', () => {

--- a/src/frontend/src/components/MobileNavigationDrawer.vue
+++ b/src/frontend/src/components/MobileNavigationDrawer.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
 import { ref, watch } from 'vue'
 import { RouterLink, useRoute } from 'vue-router'
-import { ChevronDown, Clock3, ExternalLink, Globe, Shield, X } from 'lucide-vue-next'
+import { ChevronDown, Clock3, ExternalLink, Shield, X } from 'lucide-vue-next'
 import type { AppPrimaryNavItem } from '../composables/useAppPrimaryNav'
 import type { MenuItem } from './ModulePage.vue'
 import OrgSwitcher from './OrgSwitcher.vue'
+import LanguageSwitcher from './LanguageSwitcher.vue'
 
 const props = withDefaults(
   defineProps<{
@@ -13,9 +14,6 @@ const props = withDefaults(
     primaryItems?: AppPrimaryNavItem[]
     moduleItems?: MenuItem[]
     adminConsoleHref?: string
-    canSwitchLocale?: boolean
-    currentLocaleLabel?: string
-    nextLocaleLabel?: string
     showOrganizationSwitcher?: boolean
     timezoneOffsetDisplay?: string
   }>(),
@@ -23,15 +21,12 @@ const props = withDefaults(
     primaryItems: () => [],
     moduleItems: () => [],
     adminConsoleHref: '',
-    currentLocaleLabel: '',
-    nextLocaleLabel: '',
     timezoneOffsetDisplay: '',
   },
 )
 
 const emit = defineEmits<{
   'update:modelValue': [value: boolean]
-  'toggle-locale': []
 }>()
 
 const route = useRoute()
@@ -61,11 +56,6 @@ function toggleGroup(index: number) {
   if (next.has(index)) next.delete(index)
   else next.add(index)
   expandedGroups.value = next
-}
-
-function toggleLocale() {
-  emit('toggle-locale')
-  close()
 }
 
 function routeQueryMatches(key: string, expected: string) {
@@ -243,41 +233,11 @@ function moduleItemActive(to?: string) {
           </a>
         </section>
 
-        <section
-          v-if="currentLocaleLabel || timezoneOffsetDisplay"
-          class="mobile-navigation__section mobile-navigation__section--utility"
-        >
-          <button
-            v-if="canSwitchLocale"
-            type="button"
-            class="mobile-navigation__utility-link"
-            :aria-label="$t('nav.switchLanguage', { language: nextLocaleLabel })"
-            @click="toggleLocale"
-          >
-            <Globe
-              :size="17"
-              aria-hidden="true"
-            />
-            <span class="mobile-navigation__utility-copy">
-              <span class="mobile-navigation__utility-title">{{ $t('nav.languageLabel') }}</span>
-              <span class="mobile-navigation__utility-subtitle">
-                {{ $t('nav.languageSwitchDetail', { current: currentLocaleLabel, language: nextLocaleLabel }) }}
-              </span>
-            </span>
-          </button>
-          <div
-            v-else-if="currentLocaleLabel"
-            class="mobile-navigation__utility-link mobile-navigation__utility-link--static"
-          >
-            <Globe
-              :size="17"
-              aria-hidden="true"
-            />
-            <span class="mobile-navigation__utility-copy">
-              <span class="mobile-navigation__utility-title">{{ $t('nav.languageLabel') }}</span>
-              <span class="mobile-navigation__utility-subtitle">{{ currentLocaleLabel }}</span>
-            </span>
-          </div>
+        <section class="mobile-navigation__section mobile-navigation__section--utility">
+          <LanguageSwitcher
+            variant="mobile"
+            @change="close"
+          />
           <div
             v-if="timezoneOffsetDisplay"
             class="mobile-navigation__utility-link mobile-navigation__utility-link--static"

--- a/src/frontend/src/composables/useLocaleSwitch.test.ts
+++ b/src/frontend/src/composables/useLocaleSwitch.test.ts
@@ -62,9 +62,9 @@ describe('useLocaleSwitch', () => {
       },
     }), { global: { plugins: [i18n] } })
 
-    localeSwitch?.toggleLocale()
+    localeSwitch?.selectLocale('zh-hans')
     await vi.waitFor(() => expect(mocks.api).toHaveBeenCalledTimes(1))
-    localeSwitch?.toggleLocale()
+    localeSwitch?.selectLocale('en')
     await Promise.resolve()
     expect(mocks.api).toHaveBeenCalledTimes(1)
 
@@ -108,9 +108,9 @@ describe('useLocaleSwitch', () => {
       },
     }), { global: { plugins: [i18n] } })
 
-    localeSwitch?.toggleLocale()
+    localeSwitch?.selectLocale('zh-hans')
     await vi.waitFor(() => expect(mocks.api).toHaveBeenCalledTimes(1))
-    localeSwitch?.toggleLocale()
+    localeSwitch?.selectLocale('en')
     currentUser.value = {
       id: 10,
       email: 'second-locale-user@example.com',
@@ -153,7 +153,7 @@ describe('useLocaleSwitch', () => {
       },
     }), { global: { plugins: [i18n] } })
 
-    localeSwitch?.toggleLocale()
+    localeSwitch?.selectLocale('pt-br')
 
     await vi.waitFor(() => expect(mocks.api).toHaveBeenCalledTimes(1))
     expect(i18n.global.locale.value).toBe('pt-br')

--- a/src/frontend/src/composables/useLocaleSwitch.ts
+++ b/src/frontend/src/composables/useLocaleSwitch.ts
@@ -3,7 +3,7 @@ import { useI18n } from 'vue-i18n'
 import {
   DEFAULT_LOCALE,
   getAvailableLocaleCodes,
-  selectLocale,
+  selectLocale as applyLocale,
   setAuthenticatedLocalePreference,
 } from '../i18n'
 import { hasMultipleLocales, installedLangPacks } from '../lib/langPacks'
@@ -23,22 +23,23 @@ export function useLocaleSwitch() {
     )
   }
   const currentLocaleLabel = computed(() => localeLabel(String(locale.value)))
-  const nextLocaleCode = computed(() => {
-    const available = getAvailableLocaleCodes()
-    const currentIndex = available.indexOf(String(locale.value))
-    return available[(currentIndex + 1) % available.length] ?? DEFAULT_LOCALE
-  })
-  const nextLocaleLabel = computed(() => localeLabel(nextLocaleCode.value))
+  const localeOptions = computed(() =>
+    getAvailableLocaleCodes().map((code) => ({
+      code,
+      label: localeLabel(code),
+    })),
+  )
 
-  function toggleLocale() {
-    if (!canSwitchLocale.value) return
-    const selected = selectLocale(nextLocaleCode.value)
+  function selectLocale(code: string) {
+    if (!canSwitchLocale.value || !getAvailableLocaleCodes().includes(code)) return false
+    if (String(locale.value) === code) return false
+    const selected = applyLocale(code)
     const user = currentUser.value
-    if (!user) return
+    if (!user) return true
     const profileLanguage = selected === DEFAULT_LOCALE
       ? DEFAULT_LOCALE
       : installedLangPacks.value.find((pack) => pack.frontend_code === selected)?.backend_code
-    if (!profileLanguage) return
+    if (!profileLanguage) return true
     currentUser.value = { ...user, language: profileLanguage }
     setAuthenticatedLocalePreference(profileLanguage)
     localePreferenceWriteQueue = localePreferenceWriteQueue.catch(() => undefined).then(async () => {
@@ -59,14 +60,14 @@ export function useLocaleSwitch() {
         })
       }
     })
+    return true
   }
 
   return {
     canSwitchLocale,
     currentLocaleLabel,
-    nextLocaleCode,
-    nextLocaleLabel,
-    toggleLocale,
+    localeOptions,
+    selectLocale,
     locale,
   }
 }

--- a/src/frontend/src/pages/auth/AuthTurnstileRetryFlows.test.ts
+++ b/src/frontend/src/pages/auth/AuthTurnstileRetryFlows.test.ts
@@ -31,9 +31,9 @@ vi.mock('../../composables/useDeployProfile', () => ({
 vi.mock('../../composables/useLocaleSwitch', () => ({
   useLocaleSwitch: () => ({
     canSwitchLocale: ref(false),
-    nextLocaleCode: ref('en'),
-    nextLocaleLabel: ref('English'),
-    toggleLocale: vi.fn(),
+    currentLocaleLabel: ref('English'),
+    localeOptions: ref([{ code: 'en', label: 'English' }]),
+    selectLocale: vi.fn(),
   }),
 }))
 

--- a/src/frontend/src/pages/auth/Login.vue
+++ b/src/frontend/src/pages/auth/Login.vue
@@ -3,15 +3,15 @@ import { ref, reactive, computed, nextTick, onMounted } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { ElMessage, ElMessageBox } from 'element-plus'
-import { Mail, Lock, Globe, Eye, EyeOff } from 'lucide-vue-next'
+import { Mail, Lock, Eye, EyeOff } from 'lucide-vue-next'
 import { api } from '../../lib/api'
 import { useAuth, setStoredOrgKey, fetchCurrentUser } from '../../composables/useAuth'
-import { useLocaleSwitch } from '../../composables/useLocaleSwitch'
 import { useTurnstileConfig } from '../../composables/useTurnstileConfig'
 import AuthBackdrop from '../../components/auth/AuthBackdrop.vue'
 import AuthBrandPanel from '../../components/auth/AuthBrandPanel.vue'
 import AuthTurnstileField from '../../components/auth/AuthTurnstileField.vue'
 import EmailCodeLoginForm from '../../components/auth/EmailCodeLoginForm.vue'
+import LanguageSwitcher from '../../components/LanguageSwitcher.vue'
 import type { EmailCodeLoginData } from '../../lib/emailCodeLoginApi'
 import ResetPasswordCard from '../../components/auth/ResetPasswordCard.vue'
 import { fetchDeployProfile, resolvePostLoginPath } from '../../composables/useDeployProfile'
@@ -28,12 +28,6 @@ const passwordResetAvailable = ref(false)
 const emailCodeLoginAvailable = ref(false)
 const showEula = appConfig.showEula
 const { t, locale } = useI18n()
-const {
-  canSwitchLocale,
-  nextLocaleCode,
-  nextLocaleLabel,
-  toggleLocale: switchLocale,
-} = useLocaleSwitch()
 const router = useRouter()
 const route = useRoute()
 const sessionNoticeDismissed = ref(false)
@@ -544,8 +538,7 @@ const canSubmitLogin = computed(() => {
   return true
 })
 
-function toggleLocale() {
-  switchLocale()
+function handleLocaleChange() {
   formItems.email.placeholder = t('login.emailPh')
   formItems.password.placeholder = t('login.passwordPh')
 }
@@ -608,15 +601,10 @@ onMounted(async () => {
         <span :class="{ '!text-base': locale === 'en' }">
           {{ cardTitle }}
         </span>
-        <button
-          v-if="canSwitchLocale"
-          class="lang-toggle"
-          :title="`Switch to ${nextLocaleLabel}`"
-          @click="toggleLocale"
-        >
-          <Globe :size="18" />
-          <span class="lang-label">{{ nextLocaleCode.toUpperCase() }}</span>
-        </button>
+        <LanguageSwitcher
+          variant="auth"
+          @change="handleLocaleChange"
+        />
       </div>
 
       <Transition
@@ -957,29 +945,6 @@ onMounted(async () => {
 }
 .login-box-title.title-en {
   font-size: 20px !important;
-}
-
-.lang-toggle {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  background: none;
-  border: none;
-  cursor: pointer;
-  color: #fff;
-  padding: 4px 8px;
-  border-radius: 4px;
-  transition: color 0.2s, background 0.2s;
-  font-size: 13px;
-  font-weight: normal;
-}
-
-.lang-toggle:hover {
-  background: rgba(255, 255, 255, 0.1);
-}
-
-.lang-label {
-  font-size: 12px;
 }
 
 .login-box-content {
@@ -1367,8 +1332,7 @@ onMounted(async () => {
     min-height: 44px;
   }
 
-  .eye-btn,
-  .lang-toggle {
+  .eye-btn {
     min-width: 36px;
     min-height: 36px;
   }

--- a/src/frontend/src/pages/auth/LoginTurnstileLifecycle.test.ts
+++ b/src/frontend/src/pages/auth/LoginTurnstileLifecycle.test.ts
@@ -37,9 +37,9 @@ vi.mock('../../composables/useAuth', () => ({
 vi.mock('../../composables/useLocaleSwitch', () => ({
   useLocaleSwitch: () => ({
     canSwitchLocale: ref(false),
-    nextLocaleCode: ref('en'),
-    nextLocaleLabel: ref('English'),
-    toggleLocale: vi.fn(),
+    currentLocaleLabel: ref('English'),
+    localeOptions: ref([{ code: 'en', label: 'English' }]),
+    selectLocale: vi.fn(),
   }),
 }))
 

--- a/src/frontend/src/pages/auth/Register.vue
+++ b/src/frontend/src/pages/auth/Register.vue
@@ -3,25 +3,19 @@ import { ref, reactive, computed, onMounted, onUnmounted } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { ElMessage } from 'element-plus'
-import { Mail, Lock, Key, Globe, Eye, EyeOff, CheckCircle2 } from 'lucide-vue-next'
+import { Mail, Lock, Key, Eye, EyeOff, CheckCircle2 } from 'lucide-vue-next'
 import { api } from '../../lib/api'
-import { useLocaleSwitch } from '../../composables/useLocaleSwitch'
 import { useTurnstileConfig } from '../../composables/useTurnstileConfig'
 import { fetchDeployProfile } from '../../composables/useDeployProfile'
 import AuthBackdrop from '../../components/auth/AuthBackdrop.vue'
 import AuthBrandPanel from '../../components/auth/AuthBrandPanel.vue'
 import AuthTurnstileField from '../../components/auth/AuthTurnstileField.vue'
+import LanguageSwitcher from '../../components/LanguageSwitcher.vue'
 import { appConfig } from '../../lib/appConfig'
 import { trackAppEvent } from '../../lib/analytics'
 import { LOGIN_ROUTE_NAME } from '../../lib/loginNavigation'
 
 const { t, locale } = useI18n()
-const {
-  canSwitchLocale,
-  nextLocaleCode,
-  nextLocaleLabel,
-  toggleLocale: switchLocale,
-} = useLocaleSwitch()
 const router = useRouter()
 const route = useRoute()
 const showEula = appConfig.showEula
@@ -415,10 +409,6 @@ function goLogin() {
   router.push(email ? { path: '/login', query: { email } } : '/login')
 }
 
-function toggleLocale() {
-  switchLocale()
-}
-
 onMounted(async () => {
   const profile = await fetchDeployProfile()
   if (!profile?.email_signup_enabled) {
@@ -455,15 +445,7 @@ onUnmounted(() => {
         :class="{ 'title-en': locale === 'en' }"
       >
         <span :class="{ '!text-base': locale === 'en' }">{{ t('register.welcomeTitle') }}</span>
-        <button
-          v-if="canSwitchLocale"
-          class="lang-toggle"
-          :title="`Switch to ${nextLocaleLabel}`"
-          @click="toggleLocale"
-        >
-          <Globe :size="18" />
-          <span class="lang-label">{{ nextLocaleCode.toUpperCase() }}</span>
-        </button>
+        <LanguageSwitcher variant="auth" />
       </div>
 
       <div class="register-box-content">
@@ -764,29 +746,6 @@ onUnmounted(() => {
 }
 .register-box-title.title-en {
   font-size: 20px !important;
-}
-
-.lang-toggle {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  background: none;
-  border: none;
-  cursor: pointer;
-  color: #fff;
-  padding: 4px 8px;
-  border-radius: 4px;
-  transition: color 0.2s, background 0.2s;
-  font-size: 13px;
-  font-weight: normal;
-}
-
-.lang-toggle:hover {
-  background: rgba(255, 255, 255, 0.1);
-}
-
-.lang-label {
-  font-size: 12px;
 }
 
 .register-box-content {
@@ -1212,8 +1171,7 @@ onUnmounted(() => {
     min-height: 44px;
   }
 
-  .eye-btn,
-  .lang-toggle {
+  .eye-btn {
     min-width: 36px;
     min-height: 36px;
   }


### PR DESCRIPTION
## Summary
- replace locale toggles with a shared language selector
- show user-facing language names across authentication, desktop navigation, and mobile navigation
- preserve authenticated locale preference persistence and improve accessibility

## Validation
- npm run lint
- npm exec vue-tsc -- --noEmit
- npm run build
- 28 focused frontend tests
- python3 tools/quality/check-english-source.py
- git diff --check