### PR TITLE
Fix SourceLens attachment validation errors

### DIFF
--- a/src/backend/apps/lens_bridge/services/sl_client.py
+++ b/src/backend/apps/lens_bridge/services/sl_client.py
@@ -283,8 +283,24 @@ def _invalidate_access_token(
 def _format_sl_error(body: Any) -> str:
     """Extract a readable message from SourceLens / DRF error payloads."""
 
+    if isinstance(body, (list, tuple)):
+        parts = [_format_sl_error(item) for item in body]
+        return "; ".join(part for part in parts if part)
+
+    if body is None:
+        return ""
+
     if not isinstance(body, dict):
         return str(body)
+
+    # SourceLens wraps validation errors as {code, message, data}.  The
+    # generic message is often just "failed" while data contains the stable
+    # product-facing reason (for example ATTACHMENT_DIMENSIONS_TOO_LARGE).
+    # Prefer that reason without taking ownership of SourceLens validation.
+    if body.get("code") not in (0, "0", None) and "data" in body:
+        nested = _format_sl_error(body.get("data"))
+        if nested:
+            return nested
 
     non_field = body.get("non_field_errors")
     if isinstance(non_field, list) and non_field:
@@ -325,14 +341,7 @@ def _raise_for_response(response: requests.Response) -> Any:
     detail = response.text[:2000]
     try:
         body = response.json()
-        try:
-            unwrapped = _unwrap_sl_body(body)
-        except LensBridgeError:
-            unwrapped = body.get("data") if isinstance(body, dict) else body
-        if isinstance(unwrapped, dict):
-            detail = _format_sl_error(unwrapped)
-        elif isinstance(body, dict):
-            detail = _format_sl_error(body)
+        detail = _format_sl_error(body) or detail
     except ValueError:
         body = detail
     exc = LensBridgeError(detail=str(detail))

--- a/src/backend/apps/lens_bridge/tests/test_sl_client_readiness.py
+++ b/src/backend/apps/lens_bridge/tests/test_sl_client_readiness.py
@@ -8,6 +8,7 @@ from django.test import SimpleTestCase
 
 from apps.lens_bridge.api.views import _lens_error_response
 from apps.lens_bridge.services import sl_client
+from common.http.exceptions import api_exception_handler
 
 
 class SourceLensClientReadinessTests(SimpleTestCase):
@@ -23,6 +24,20 @@ class SourceLensClientReadinessTests(SimpleTestCase):
         response = _lens_error_response(error)
 
         self.assertEqual(response.status_code, 502)
+
+    def test_source_validation_reason_survives_hfl_problem_details(self) -> None:
+        error = sl_client.LensBridgeError(
+            "ATTACHMENT_DIMENSIONS_TOO_LARGE"
+        )
+        error.status_code = 400
+
+        response = api_exception_handler(error, {})
+
+        self.assertIsNotNone(response)
+        self.assertEqual(
+            response.data["data"]["meta"]["diagnostic"],
+            "ATTACHMENT_DIMENSIONS_TOO_LARGE",
+        )
 
     def test_remote_server_error_is_retryable_and_sanitized(self) -> None:
         response = Mock(status_code=503, content=b"provider api_key=must-not-leak")
@@ -98,6 +113,48 @@ class SourceLensClientReadinessTests(SimpleTestCase):
         self.assertEqual(forwarded[0], "report.pdf")
         self.assertIs(forwarded[1], uploaded)
         self.assertEqual(forwarded[2], "application/pdf")
+
+    @patch.object(sl_client, "_auth_headers", return_value={})
+    @patch.object(sl_client, "_base_url", return_value="http://sourcelens")
+    @patch.object(sl_client.requests, "post")
+    def test_multipart_upload_preserves_source_validation_reason(
+        self,
+        post,
+        _base_url,
+        _headers,
+    ) -> None:
+        response = Mock(
+            status_code=400,
+            content=b'{"code":400}',
+            text=(
+                '{"code":400,"message":"failed",'
+                '"data":["ATTACHMENT_DIMENSIONS_TOO_LARGE"]}'
+            ),
+        )
+        response.json.return_value = {
+            "code": 400,
+            "message": "failed",
+            "data": ["ATTACHMENT_DIMENSIONS_TOO_LARGE"],
+        }
+        post.return_value = response
+        uploaded = SimpleUploadedFile(
+            "screenshot.png",
+            b"image-bytes",
+            content_type="image/png",
+        )
+
+        with self.assertRaises(sl_client.LensBridgeError) as raised:
+            sl_client.request_multipart(
+                "/api/lens/sessions/session-uuid/attachments/",
+                uploaded_file=uploaded,
+                hfl_user=Mock(pk=7),
+            )
+
+        self.assertEqual(raised.exception.status_code, 400)
+        self.assertEqual(
+            str(raised.exception),
+            "ATTACHMENT_DIMENSIONS_TOO_LARGE",
+        )
 
     @patch.object(sl_client, "_invalidate_access_token")
     @patch.object(sl_client, "_auth_headers", return_value={})

--- a/src/frontend/src/pages/insight/InsightCopilot.vue
+++ b/src/frontend/src/pages/insight/InsightCopilot.vue
@@ -6,6 +6,7 @@ import { ElMessage } from 'element-plus'
 
 defineOptions({ name: 'InsightCopilot' })
 import { apiErrorMessage, type ApiError } from '../../lib/api'
+import { normalizeThrownError } from '../../lib/errors'
 import {
   beginSessionRunSubmission,
   clearSessionRunSubmission,
@@ -624,7 +625,18 @@ function retryQuestion(text: string) {
 }
 
 function attachmentErrorMessage(error: unknown) {
-  const message = apiErrorMessage(error, '')
+  const fallbackMessage = apiErrorMessage(error, '')
+  const diagnostic = String(normalizeThrownError(error).meta?.diagnostic || '')
+  // HFL's problem-details handler keeps upstream validation reasons in
+  // meta.diagnostic while exposing a generic VALIDATION.FAILED title. Prefer
+  // the stable SourceLens reason here so the existing localized copy can be
+  // selected without duplicating SourceLens validation rules in HFL.
+  const message = [fallbackMessage, diagnostic].find((candidate) =>
+    candidate.includes('ATTACHMENT_')
+      || candidate.includes('DOCUMENT_ATTACHMENTS_UNSUPPORTED')
+      || candidate.includes('does not accept images')
+      || candidate.includes('does not accept document'),
+  ) || fallbackMessage
   if (message.includes('ATTACHMENT_TOO_LARGE')) {
     return t('insight.copilot.attachmentTooLarge')
   }

--- a/src/frontend/src/pages/insight/InsightCopilotStarterSubmission.test.ts
+++ b/src/frontend/src/pages/insight/InsightCopilotStarterSubmission.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 
 import { flushPromises, mount } from '@vue/test-utils'
+import { ElMessage } from 'element-plus'
 import { createI18n } from 'vue-i18n'
 import { defineComponent, nextTick, ref } from 'vue'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -341,6 +342,45 @@ describe('InsightCopilot starter question submission', () => {
       '00000000-0000-4000-8000-000000000001',
       '/api/v1/lens/copilot/sessions/444/attachments/document/?token=signed',
     )
+  })
+
+  it('localizes a SourceLens document attachment diagnostic', async () => {
+    const errorMessage = vi.spyOn(ElMessage, 'error')
+    mocks.uploadCopilotAttachment.mockRejectedValue({
+      status: 400,
+      message: 'Validation failed.',
+      code: 'VALIDATION.FAILED',
+      errorCode: 'VALIDATION.FAILED',
+      meta: {
+        diagnostic: 'DOCUMENT_ATTACHMENTS_UNSUPPORTED_BY_LENSNODE',
+      },
+    })
+    const i18n = createI18n({
+      legacy: false,
+      locale: 'en',
+      messages: { en },
+      missingWarn: false,
+      fallbackWarn: false,
+    })
+    const wrapper = mountCopilot(i18n)
+    try {
+      await flushPromises()
+      const fileInput = wrapper.get('input[type="file"]')
+      Object.defineProperty(fileInput.element, 'files', {
+        configurable: true,
+        value: [new File(['pdf'], 'report.pdf', { type: 'application/pdf' })],
+      })
+
+      await fileInput.trigger('change')
+      await flushPromises()
+
+      expect(errorMessage).toHaveBeenCalledWith(expect.objectContaining({
+        message: en.insight.copilot.attachmentUnsupported,
+      }))
+    } finally {
+      errorMessage.mockRestore()
+      wrapper.unmount()
+    }
   })
 
   it('removes the optimistic message when rejection reconciliation also fails', async () => {


### PR DESCRIPTION
## Summary
- preserve structured SourceLens attachment validation reasons through the HFL bridge
- localize image and document attachment failures in Insight Chat
- add backend and frontend regression coverage

## Validation
- Django SourceLens client tests: 17 passed
- Insight Copilot frontend tests: 10 passed
- Ruff, ESLint, Vue TypeScript checks, and diff checks passed