### PR TITLE
fix(analytics): deliver GA4 events correctly

### DIFF
--- a/src/frontend/src/lib/analytics.test.ts
+++ b/src/frontend/src/lib/analytics.test.ts
@@ -13,6 +13,12 @@ function route(path: string, ...recordPaths: string[]): RouteLocationNormalizedL
   } as RouteLocationNormalizedLoaded
 }
 
+function dataLayerCommands(): unknown[][] {
+  return (window.dataLayer || []).map((command) => (
+    Array.from(command as ArrayLike<unknown>)
+  ))
+}
+
 async function loadAnalytics(measurementId = '') {
   vi.resetModules()
   window.__HFL_APP_CONFIG__ = { gaMeasurementId: measurementId }
@@ -62,7 +68,10 @@ describe('runtime Google Analytics', () => {
       'protection/backups/:backupId',
     ))
 
-    expect(window.dataLayer).toEqual(expect.arrayContaining([
+    expect(window.dataLayer?.every((command) => (
+      Object.prototype.toString.call(command) === '[object Arguments]'
+    ))).toBe(true)
+    expect(dataLayerCommands()).toEqual(expect.arrayContaining([
       ['config', 'G-0RX9GZJCWF', { send_page_view: false }],
       ['event', 'page_view', expect.objectContaining({
         page_location: `${window.location.origin}/protection/backups/:backupId`,
@@ -75,7 +84,7 @@ describe('runtime Google Analytics', () => {
 
     window.history.replaceState({}, '', '/register?email=person@example.com')
     analytics.trackAppEvent('sign_up', { method: 'email' })
-    expect(window.dataLayer).toContainEqual([
+    expect(dataLayerCommands()).toContainEqual([
       'event',
       'sign_up',
       expect.objectContaining({
@@ -84,6 +93,6 @@ describe('runtime Google Analytics', () => {
         page_path: '/protection/backups/:backupId',
       }),
     ])
-    expect(JSON.stringify(window.dataLayer)).not.toContain('person@example.com')
+    expect(JSON.stringify(dataLayerCommands())).not.toContain('person@example.com')
   })
 })

--- a/src/frontend/src/lib/analytics.ts
+++ b/src/frontend/src/lib/analytics.ts
@@ -80,8 +80,10 @@ function installGoogleTag(measurementId: string): boolean {
 
   activeMeasurementId = measurementId
   window.dataLayer = window.dataLayer || []
-  window.gtag = function gtag(...args: unknown[]) {
-    window.dataLayer?.push(args)
+  // Google Tag distinguishes its Arguments command object from a normal Array.
+  window.gtag = function gtag() {
+    // eslint-disable-next-line prefer-rest-params
+    window.dataLayer?.push(arguments)
   }
   window.gtag('js', new Date())
   window.gtag('config', measurementId, { send_page_view: false })

--- a/website/.vitepress/theme/analytics.ts
+++ b/website/.vitepress/theme/analytics.ts
@@ -23,6 +23,7 @@ const GA4_MEASUREMENT_ID = /^G-[A-Z0-9]+$/
 const NAVIGATION_FALLBACK_MS = 400
 let activeMeasurementId = ''
 let activePagePath = '/'
+let lastTrackedPagePath = ''
 
 function sanitizedPath(value: string): string {
   try {
@@ -56,9 +57,12 @@ function configureGoogleTag(): boolean {
   if (activeMeasurementId === measurementId) return true
 
   activeMeasurementId = measurementId
+  lastTrackedPagePath = ''
   window.dataLayer = window.dataLayer || []
-  window.gtag = function gtag(...args: unknown[]) {
-    window.dataLayer?.push(args)
+  // Google Tag distinguishes its Arguments command object from a normal Array.
+  window.gtag = function gtag() {
+    // eslint-disable-next-line prefer-rest-params
+    window.dataLayer?.push(arguments)
   }
   window.gtag('js', new Date())
   window.gtag('config', measurementId, { send_page_view: false })
@@ -74,6 +78,8 @@ function configureGoogleTag(): boolean {
 export function trackWebsitePageView(value: string): void {
   if (!activeMeasurementId || !window.gtag) return
   const path = sanitizedPath(value)
+  if (path === lastTrackedPagePath) return
+  lastTrackedPagePath = path
   activePagePath = path
   window.gtag('event', 'page_view', {
     page_location: `${window.location.origin}${path}`,


### PR DESCRIPTION
## Summary
- send GA4 commands as Arguments objects so Google Tag processes config and events
- deduplicate the website initial page view
- verify the application analytics command shape in unit tests

## Validation
- frontend test suite: 203 files, 995 tests passed
- frontend production build passed
- website production build passed
- targeted ESLint and git diff checks passed