### PR TITLE
test(storage): align fixtures with ownership lifecycle

### DIFF
--- a/src/backend/apps/alert/tests/test_repository_task_alerts.py
+++ b/src/backend/apps/alert/tests/test_repository_task_alerts.py
@@ -9,6 +9,11 @@ from apps.storage.services.internal.repository_operations import (
     create_repository_operation_task,
     discover_repository_execution_targets,
 )
+from apps.storage.services.internal.repository_location import (
+    mark_repository_location_owned,
+    mark_repository_location_ownership_verified,
+    reserve_repository_location,
+)
 from apps.task.models import Task
 
 
@@ -23,6 +28,9 @@ class RepositoryTaskAlertTests(TestCase):
             health=Repository.Health.ONLINE,
             s3_bucket="alert-bucket",
         )
+        reserve_repository_location(repository)
+        mark_repository_location_owned(repository)
+        mark_repository_location_ownership_verified(repository)
         discover_repository_execution_targets()
         repository_task = create_repository_operation_task(
             target_id=RepositoryExecutionTarget.objects.get(repository=repository).id,

--- a/src/backend/apps/source/tests/test_backup_source_delete_snapshots.py
+++ b/src/backend/apps/source/tests/test_backup_source_delete_snapshots.py
@@ -41,6 +41,11 @@ from apps.source.services.internal.backup_source_delete import (
     run_source_unregister_task,
 )
 from apps.storage.repositories.models import Repository
+from apps.storage.services.internal.repository_location import (
+    mark_repository_location_owned,
+    mark_repository_location_ownership_verified,
+    reserve_repository_location,
+)
 from apps.task.models import Task
 
 
@@ -105,6 +110,9 @@ class BackupSourceDeleteSnapshotTaskTests(TestCase):
                 "use_tls": False,
             },
         )
+        reserve_repository_location(self.repository)
+        mark_repository_location_owned(self.repository)
+        mark_repository_location_ownership_verified(self.repository)
         self.config = BackupConfig.objects.create(
             organization_id=self.org.id,
             name="NAS delete snap config",


### PR DESCRIPTION
## Summary
- initialize verified repository ownership in repository alert tests
- initialize verified repository ownership in snapshot deletion tests
- keep production ownership admission checks unchanged

## Validation
- targeted backend tests: 19 passed
- full OSS backend suite: 1626 passed, 4 skipped
- Ruff: passed
- migration check: no changes detected

Fixes the Quality failure in the v0.2.2 Enterprise release run: https://github.com/oneprolabs/hyperfilelens/actions/runs/31944982996