### PR TITLE
fix(ui): prevent desktop header overflow

### DIFF
--- a/src/frontend/src/app/layout/PrimaryNavigationIcons.test.ts
+++ b/src/frontend/src/app/layout/PrimaryNavigationIcons.test.ts
@@ -39,7 +39,7 @@ describe('primary navigation icons', () => {
 
   it('compacts icons and timezone text at constrained desktop widths', () => {
     expect(topNavSource).toMatch(
-      /@media \(min-width: 1024px\) and \(max-width: 1279\.98px\)[\s\S]*?\.nav-item__icon\s*{[\s\S]*?display:\s*none/,
+      /@media \(min-width: 1024px\) and \(max-width: 1439\.98px\)[\s\S]*?\.nav-item__icon\s*{[\s\S]*?display:\s*none/,
     )
     expect(topNavSource).toMatch(
       /@media \(min-width: 1024px\) and \(max-width: 1439\.98px\)[\s\S]*?\.timezone-display__label\s*{[\s\S]*?display:\s*none/,
@@ -50,12 +50,24 @@ describe('primary navigation icons', () => {
     )
   })
 
-  it('uses a compact desktop layout before switching to the mobile drawer', () => {
+  it('keeps the desktop header flex chain shrinkable at laptop widths', () => {
     expect(topNavSource).toMatch(
-      /@media \(min-width: 1024px\) and \(max-width: 1151\.98px\)[\s\S]*?\.nav-item\s*{[\s\S]*?min-width:\s*0[\s\S]*?padding-right:\s*8px/,
+      /\.top-nav\s*{[\s\S]*?width:\s*100%[\s\S]*?min-width:\s*0/,
     )
     expect(topNavSource).toMatch(
-      /@media \(min-width: 1024px\) and \(max-width: 1151\.98px\)[\s\S]*?\.top-nav \.platform-ops-entry\s*{[\s\S]*?border:\s*0[\s\S]*?background:\s*transparent/,
+      /\.nav-menu\s*{[\s\S]*?min-width:\s*0[\s\S]*?flex:\s*0 1 auto/,
+    )
+    expect(topNavSource).toMatch(
+      /\.right-menu\s*{[\s\S]*?min-width:\s*0[\s\S]*?flex:\s*0 1 auto/,
+    )
+  })
+
+  it('uses a compact desktop layout before switching to the mobile drawer', () => {
+    expect(topNavSource).toMatch(
+      /@media \(min-width: 1024px\) and \(max-width: 1439\.98px\)[\s\S]*?\.nav-item\s*{[\s\S]*?min-width:\s*0[\s\S]*?padding-right:\s*8px/,
+    )
+    expect(topNavSource).toMatch(
+      /@media \(min-width: 1024px\) and \(max-width: 1439\.98px\)[\s\S]*?\.top-nav \.platform-ops-entry\s*{[\s\S]*?border:\s*0[\s\S]*?background:\s*transparent/,
     )
     expect(topNavSource).toMatch(
       /\.top-nav \.platform-ops-entry svg\s*{[\s\S]*?width:\s*18px[\s\S]*?height:\s*18px/,

--- a/src/frontend/src/app/layout/TopNav.vue
+++ b/src/frontend/src/app/layout/TopNav.vue
@@ -151,6 +151,8 @@ function handleNavClick(event: MouseEvent, to: string) {
   z-index: 40;
   display: flex;
   align-items: center;
+  width: 100%;
+  min-width: 0;
   box-sizing: border-box;
   padding: var(--app-safe-top) max(16px, var(--app-safe-right)) 0 max(12px, var(--app-safe-left));
   box-shadow: var(--tnav-shadow, 0 12px 26px rgba(9, 8, 15, 0.22));
@@ -214,6 +216,8 @@ function handleNavClick(event: MouseEvent, to: string) {
 
 .nav-menu {
   display: flex;
+  min-width: 0;
+  flex: 0 1 auto;
   align-items: center;
   height: 52px;
 }
@@ -278,6 +282,7 @@ function handleNavClick(event: MouseEvent, to: string) {
 
 .right-menu {
   min-width: 0;
+  flex: 0 1 auto;
   margin-left: auto;
   display: flex;
   align-items: center;
@@ -327,13 +332,7 @@ function handleNavClick(event: MouseEvent, to: string) {
   position: relative;
 }
 
-@media (min-width: 1024px) and (max-width: 1279.98px) {
-  .nav-item__icon {
-    display: none;
-  }
-}
-
-@media (min-width: 1024px) and (max-width: 1151.98px) {
+@media (min-width: 1024px) and (max-width: 1439.98px) {
   .top-nav {
     padding-right: max(8px, var(--app-safe-right));
     padding-left: max(8px, var(--app-safe-left));
@@ -346,6 +345,10 @@ function handleNavClick(event: MouseEvent, to: string) {
 
   .nav-menu {
     min-width: 0;
+  }
+
+  .nav-item__icon {
+    display: none;
   }
 
   .nav-item {
@@ -393,9 +396,7 @@ function handleNavClick(event: MouseEvent, to: string) {
     outline: 2px solid var(--color-primary, #6D5EF6);
     outline-offset: 2px;
   }
-}
 
-@media (min-width: 1024px) and (max-width: 1439.98px) {
   .timezone-display__label {
     display: none;
   }

--- a/src/frontend/src/components/NavUserMenu.test.ts
+++ b/src/frontend/src/components/NavUserMenu.test.ts
@@ -7,6 +7,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { en } from '../locales/en'
 import NavUserMenu from './NavUserMenu.vue'
+import navUserMenuSource from './NavUserMenu.vue?raw'
 
 const mocks = vi.hoisted(() => ({
   fetchDeployProfile: vi.fn(),
@@ -114,5 +115,16 @@ describe('NavUserMenu product identity', () => {
     await flushPromises()
 
     expect(wrapper.find('.nav-user-product').exists()).toBe(false)
+  })
+})
+
+describe('NavUserMenu responsive trigger', () => {
+  it('allows the trigger and label to shrink without clipping the page', () => {
+    expect(navUserMenuSource).toMatch(
+      /\.nav-user-trigger\s*{[\s\S]*?min-width:\s*0[\s\S]*?max-width:\s*100%[\s\S]*?flex:\s*0 1 auto/,
+    )
+    expect(navUserMenuSource).toMatch(
+      /\.nav-user-trigger__label\s*{[\s\S]*?min-width:\s*0[\s\S]*?max-width:\s*140px[\s\S]*?flex:\s*1 1 auto/,
+    )
   })
 })

--- a/src/frontend/src/components/NavUserMenu.vue
+++ b/src/frontend/src/components/NavUserMenu.vue
@@ -190,7 +190,11 @@ async function confirmLogout() {
 <style scoped>
 .nav-user-trigger {
   display: inline-flex;
+  min-width: 0;
+  max-width: 100%;
+  flex: 0 1 auto;
   align-items: center;
+  box-sizing: border-box;
   gap: 6px;
   min-height: 32px;
   padding: 0 10px;
@@ -210,7 +214,9 @@ async function confirmLogout() {
 }
 
 .nav-user-trigger__label {
+  min-width: 0;
   max-width: 140px;
+  flex: 1 1 auto;
   overflow: hidden;
   font-size: 14px;
   font-weight: 500;


### PR DESCRIPTION
## Summary
- keep the desktop header flex chain shrinkable
- use the compact navigation layout through laptop-width viewports
- allow long user labels to ellipsize without expanding the document
- add regression coverage for the responsive layout contract

## Validation
- Host frontend: 205 files, 1002 tests passed
- Enterprise extension frontend: 22 files, 61 tests passed
- Community production build passed
- Enterprise composition production build passed
- ESLint: 0 errors (1 unrelated existing warning)