### PR TITLE
fix(deploy): scale Redis recovery capacity

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -86,6 +86,11 @@ DATABASE_URL=
 # Redis connection used by Django Channels.
 REDIS_URL=redis://redis:6379/0
 
+# Main Redis container memory ceiling. The 2 GiB default leaves enough headroom
+# to reload typical persisted datasets on the recommended 8 GiB host. Increase
+# this for larger datasets; upgrades validate the RDB against the configured limit.
+HFL_REDIS_MEMORY_LIMIT=2g
+
 # Redis connection used by Celery as its message broker.
 CELERY_BROKER_URL=redis://redis:6379/0
 

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -243,7 +243,7 @@ services:
       options:
         max-size: "10m"
         max-file: "10"
-    mem_limit: 1g
+    mem_limit: ${HFL_REDIS_MEMORY_LIMIT:-2g}
     cpus: 1.00
 
   nginx:

--- a/deploy/installer/install.sh
+++ b/deploy/installer/install.sh
@@ -2712,8 +2712,42 @@ create_managed_backup() {
 
 preflight_redis_recovery() {
 	local rdb="${ROOT}/data/redis/dump.rdb" cid output creation_bytes safe_bytes
-	local warn_bytes=$((768 * 1024 * 1024)) limit_bytes=$((1024 * 1024 * 1024))
+	local configured_limit limit_bytes limit_mib warn_bytes
 	[[ -s "${rdb}" ]] || { skip "Redis has no persisted RDB to validate"; return 0; }
+	configured_limit="$(grep -E '^HFL_REDIS_MEMORY_LIMIT=' "${ROOT}/.env" 2>/dev/null \
+		| head -1 | cut -d= -f2- | tr -d ' "' || true)"
+	configured_limit="${configured_limit:-2g}"
+	limit_bytes="$(python3 - "${configured_limit}" <<'PY'
+import re
+import sys
+
+raw = sys.argv[1].strip().lower()
+match = re.fullmatch(r"([0-9]+(?:\.[0-9]+)?)\s*([kmgt]i?b?|bytes?)", raw)
+if not match:
+    raise SystemExit(1)
+units = {
+    "k": 1024, "kb": 1024, "kib": 1024,
+    "m": 1024**2, "mb": 1024**2, "mib": 1024**2,
+    "g": 1024**3, "gb": 1024**3, "gib": 1024**3,
+    "t": 1024**4, "tb": 1024**4, "tib": 1024**4,
+    "byte": 1, "bytes": 1,
+}
+print(int(float(match.group(1)) * units[match.group(2)]))
+PY
+	)" || {
+		die "HFL_REDIS_MEMORY_LIMIT=${configured_limit} is invalid; use a size such as 2g or 3072m"
+		return 1
+	}
+	if [[ ! "${limit_bytes}" =~ ^[0-9]+$ ]]; then
+		die "HFL_REDIS_MEMORY_LIMIT=${configured_limit} did not resolve to a byte limit"
+		return 1
+	fi
+	limit_mib=$((limit_bytes / 1024 / 1024))
+	if ((limit_mib < 256)); then
+		die "HFL_REDIS_MEMORY_LIMIT=${configured_limit} is below the supported 256 MiB minimum"
+		return 1
+	fi
+	warn_bytes=$((limit_bytes * 3 / 4))
 	if ! cid="$(compose_in_root ps -q redis 2>/dev/null | head -1)" || [[ -z "${cid}" ]]; then
 		warn "Redis is not running; persisted RDB recovery memory could not be measured"
 		return 0
@@ -2748,11 +2782,11 @@ for line in sys.stdin:
 	fi
 	safe_bytes=$((creation_bytes * 2))
 	if ((safe_bytes > limit_bytes)); then
-		die "Redis RDB needs approximately $((safe_bytes / 1024 / 1024)) MiB to recover, exceeding the fixed 1 GiB container limit; current services were not stopped"
+		die "Redis RDB needs approximately $((safe_bytes / 1024 / 1024)) MiB to recover, exceeding the configured ${limit_mib} MiB container limit; increase HFL_REDIS_MEMORY_LIMIT after confirming host capacity; current services were not stopped"
 	elif ((safe_bytes >= warn_bytes)); then
-		warn "Redis RDB recovery may need approximately $((safe_bytes / 1024 / 1024)) MiB of the 1 GiB limit"
+		warn "Redis RDB recovery may need approximately $((safe_bytes / 1024 / 1024)) MiB of the configured ${limit_mib} MiB limit"
 	else
-		ok "Redis RDB recovery estimate is $((safe_bytes / 1024 / 1024)) MiB within the 1 GiB limit"
+		ok "Redis RDB recovery estimate is $((safe_bytes / 1024 / 1024)) MiB within the configured ${limit_mib} MiB limit"
 	fi
 }
 

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -1282,7 +1282,10 @@ grep -F 'create_managed_backup' "${installer}" >/dev/null
 grep -F 'backup-manifest.json' "${installer}" >/dev/null
 grep -F 'sorted(groups, reverse=True)[3:]' "${installer}" >/dev/null
 grep -F 'preflight_redis_recovery' "${installer}" >/dev/null
-grep -F 'fixed 1 GiB container limit' "${installer}" >/dev/null
+grep -F 'HFL_REDIS_MEMORY_LIMIT=${configured_limit} is invalid' "${installer}" >/dev/null
+grep -F 'exceeding the configured ${limit_mib} MiB container limit' "${installer}" >/dev/null
+grep -F 'HFL_REDIS_MEMORY_LIMIT=2g' "${ROOT}/.env.example" >/dev/null
+grep -F 'mem_limit: ${HFL_REDIS_MEMORY_LIMIT:-2g}' "${ROOT}/deploy/docker-compose.yml" >/dev/null
 grep -F 'recover_upgrade_services' "${installer}" >/dev/null
 grep -F 'prune_old_managed_image_refs' "${installer}" >/dev/null
 grep -F 'docker image rm "${ref}"' "${installer}" >/dev/null
@@ -1502,7 +1505,7 @@ grep -E '^[[:space:]]*11444[[:space:]]+ops;' \
 grep -F 'proxy_set_header X-HFL-Site-Role $hfl_site;' \
 	"${ROOT}/deploy/nginx/snippets/hfl-backend-proxy-headers.inc" >/dev/null
 for resource in \
-	'mem_limit: 128m' 'mem_limit: 256m' 'mem_limit: 512m' 'mem_limit: 1g' \
+	'mem_limit: 128m' 'mem_limit: 256m' 'mem_limit: 512m' \
 	'cpus: 0.125' 'cpus: 0.25' 'cpus: 0.50' 'cpus: 1.00'; do
 	grep -F "${resource}" "${ROOT}/deploy/docker-compose.yml" \
 		"${ROOT}/deploy/installer/sourcelens/docker-compose.template.yml" >/dev/null

--- a/tools/quality/test-redis-rdb-preflight.sh
+++ b/tools/quality/test-redis-rdb-preflight.sh
@@ -27,12 +27,24 @@ compose_in_root() {
 	esac
 }
 
-source <(sed -n '/^preflight_redis_recovery()/,/^}/p' "${installer}")
+source <(
+	sed -n '/^preflight_redis_recovery()/,/^managed_image_ref_is_in_use()/p' "${installer}" \
+		| sed '$d'
+)
 
 preflight_redis_recovery
-RDB_MEMORY=600
+RDB_MEMORY=1100
 if (preflight_redis_recovery); then
 	printf 'ERROR: oversized Redis RDB recovery estimate was accepted\n' >&2
+	exit 1
+fi
+
+printf 'HFL_REDIS_MEMORY_LIMIT=3g\n' >"${ROOT}/.env"
+preflight_redis_recovery
+
+printf 'HFL_REDIS_MEMORY_LIMIT=2048\n' >"${ROOT}/.env"
+if (preflight_redis_recovery); then
+	printf 'ERROR: unitless Redis memory limit was accepted\n' >&2
 	exit 1
 fi
 


### PR DESCRIPTION
## Summary
- replace the fixed 1 GiB main Redis ceiling with a configurable 2 GiB default
- validate configured Redis memory sizes before an upgrade maintenance window
- compare persisted RDB recovery demand with the effective configured ceiling
- preserve the integrity and capacity gate with clearer remediation guidance

## Incident
Enterprise v0.2.2 passed build, offline install, and browser verification, then TEST upgrade was safely blocked because its RDB needs about 1284 MiB to reload while the installed Redis container was fixed at 1 GiB. The TEST host has 7.8 GiB RAM and 4.7 GiB currently available.

## Validation
- Redis RDB preflight regression passed
- upgrade transaction and backup retention passed
- blue/green recovery passed
- development upgrade regression passed
- release contract checks passed
- Community and Enterprise synthetic release assembly passed
- Enterprise release-flow contracts passed