### PR TITLE
fix(runtime): restore periodic task delivery and Redis baseline

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -86,10 +86,9 @@ DATABASE_URL=
 # Redis connection used by Django Channels.
 REDIS_URL=redis://redis:6379/0
 
-# Main Redis container memory ceiling. The 2 GiB default leaves enough headroom
-# to reload typical persisted datasets on the recommended 8 GiB host. Increase
-# this for larger datasets; upgrades validate the RDB against the configured limit.
-HFL_REDIS_MEMORY_LIMIT=2g
+# Main Redis container memory ceiling. Increase this for a legitimately larger
+# dataset; upgrades validate the persisted RDB against the configured limit.
+HFL_REDIS_MEMORY_LIMIT=1g
 
 # Redis connection used by Celery as its message broker.
 CELERY_BROKER_URL=redis://redis:6379/0

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -243,7 +243,7 @@ services:
       options:
         max-size: "10m"
         max-file: "10"
-    mem_limit: ${HFL_REDIS_MEMORY_LIMIT:-2g}
+    mem_limit: ${HFL_REDIS_MEMORY_LIMIT:-1g}
     cpus: 1.00
 
   nginx:

--- a/deploy/installer/install.sh
+++ b/deploy/installer/install.sh
@@ -2716,7 +2716,7 @@ preflight_redis_recovery() {
 	[[ -s "${rdb}" ]] || { skip "Redis has no persisted RDB to validate"; return 0; }
 	configured_limit="$(grep -E '^HFL_REDIS_MEMORY_LIMIT=' "${ROOT}/.env" 2>/dev/null \
 		| head -1 | cut -d= -f2- | tr -d ' "' || true)"
-	configured_limit="${configured_limit:-2g}"
+	configured_limit="${configured_limit:-1g}"
 	limit_bytes="$(python3 - "${configured_limit}" <<'PY'
 import re
 import sys
@@ -2735,7 +2735,7 @@ units = {
 print(int(float(match.group(1)) * units[match.group(2)]))
 PY
 	)" || {
-		die "HFL_REDIS_MEMORY_LIMIT=${configured_limit} is invalid; use a size such as 2g or 3072m"
+		die "HFL_REDIS_MEMORY_LIMIT=${configured_limit} is invalid; use a size such as 1g or 3072m"
 		return 1
 	}
 	if [[ ! "${limit_bytes}" =~ ^[0-9]+$ ]]; then

--- a/src/backend/common/scheduling/scheduler.py
+++ b/src/backend/common/scheduling/scheduler.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-from copy import copy
-
+from celery.beat import ScheduleEntry
 from django_celery_beat.schedulers import DatabaseScheduler
 
 from common.scheduling.periodic_wakeup import (
@@ -33,6 +32,21 @@ class CoalescingDatabaseScheduler(DatabaseScheduler):
         if self.should_sync():
             self._do_sync()
 
+    @staticmethod
+    def _publishing_entry(entry, *, options: dict) -> ScheduleEntry:
+        """Build a detached Celery entry without copying a Django ModelEntry."""
+        return ScheduleEntry(
+            name=entry.name,
+            task=entry.task,
+            last_run_at=entry.last_run_at,
+            total_run_count=entry.total_run_count,
+            schedule=entry.schedule,
+            args=entry.args,
+            kwargs=entry.kwargs,
+            options=options,
+            app=entry.app,
+        )
+
     def apply_async(self, entry, producer=None, advance=True, **kwargs):
         if not self._coalescing_enabled(entry):
             return super().apply_async(
@@ -53,21 +67,21 @@ class CoalescingDatabaseScheduler(DatabaseScheduler):
                 **kwargs,
             )
 
-        claimed_entry = copy(entry)
-        claimed_entry.options = dict(entry.options)
-        stamped_headers = list(claimed_entry.options.get("stamped_headers") or [])
-        for header in (
-            PERIODIC_WAKEUP_NAME_HEADER,
-            PERIODIC_WAKEUP_TOKEN_HEADER,
-        ):
-            if header not in stamped_headers:
-                stamped_headers.append(header)
-        claimed_entry.options["stamped_headers"] = stamped_headers
-        claimed_entry.options[PERIODIC_WAKEUP_NAME_HEADER] = entry.name
-        claimed_entry.options[PERIODIC_WAKEUP_TOKEN_HEADER] = claim
-        if advance:
-            self.reserve(entry)
         try:
+            options = dict(entry.options)
+            stamped_headers = list(options.get("stamped_headers") or [])
+            for header in (
+                PERIODIC_WAKEUP_NAME_HEADER,
+                PERIODIC_WAKEUP_TOKEN_HEADER,
+            ):
+                if header not in stamped_headers:
+                    stamped_headers.append(header)
+            options["stamped_headers"] = stamped_headers
+            options[PERIODIC_WAKEUP_NAME_HEADER] = entry.name
+            options[PERIODIC_WAKEUP_TOKEN_HEADER] = claim
+            claimed_entry = self._publishing_entry(entry, options=options)
+            if advance:
+                self.reserve(entry)
             result = super().apply_async(
                 claimed_entry,
                 producer=producer,

--- a/src/backend/common/tests/test_periodic_wakeup.py
+++ b/src/backend/common/tests/test_periodic_wakeup.py
@@ -4,8 +4,10 @@ from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
 from celery import Celery, states
+from celery.beat import ScheduleEntry
 from django.test import SimpleTestCase
-from django_celery_beat.schedulers import DatabaseScheduler
+from django_celery_beat.models import IntervalSchedule, PeriodicTask
+from django_celery_beat.schedulers import DatabaseScheduler, ModelEntry
 
 from common.scheduling.periodic_wakeup import (
     PERIODIC_WAKEUP_COALESCE_HEADER,
@@ -201,11 +203,22 @@ class CoalescingSchedulerTests(SimpleTestCase):
         scheduler._do_sync = Mock()
         return scheduler
 
+    @staticmethod
+    def _entry(*, options: dict) -> ScheduleEntry:
+        return ScheduleEntry(
+            name="reconcile",
+            task="tests.periodic",
+            schedule=1,
+            args=(),
+            kwargs={},
+            options=options,
+            app=Celery("periodic-scheduler-test"),
+        )
+
     @patch("common.scheduling.scheduler.claim_periodic_wakeup", return_value=False)
     def test_duplicate_is_advanced_without_publish(self, _claim) -> None:
         scheduler = self._scheduler()
-        entry = SimpleNamespace(
-            name="reconcile",
+        entry = self._entry(
             options={"headers": {PERIODIC_WAKEUP_COALESCE_HEADER: True}},
         )
 
@@ -223,8 +236,7 @@ class CoalescingSchedulerTests(SimpleTestCase):
     @patch("common.scheduling.scheduler.promote_periodic_wakeup")
     def test_claim_token_is_carried_in_message_headers(self, promote, _claim) -> None:
         scheduler = self._scheduler()
-        entry = SimpleNamespace(
-            name="reconcile",
+        entry = self._entry(
             options={
                 "headers": {
                     "x": "y",
@@ -259,6 +271,50 @@ class CoalescingSchedulerTests(SimpleTestCase):
         )
         promote.assert_called_once_with("reconcile", _TEST_TOKEN)
 
+    @patch(
+        "common.scheduling.scheduler.claim_periodic_wakeup",
+        return_value=_TEST_TOKEN,
+    )
+    @patch("common.scheduling.scheduler.promote_periodic_wakeup")
+    def test_real_model_entry_is_published_without_copying(
+        self,
+        promote,
+        _claim,
+    ) -> None:
+        scheduler = self._scheduler()
+        model = PeriodicTask(
+            name="reconcile",
+            task="tests.periodic",
+            interval=IntervalSchedule(
+                every=1,
+                period=IntervalSchedule.SECONDS,
+            ),
+            args="[]",
+            kwargs="{}",
+            headers=(
+                '{"hfl_periodic_wakeup_coalesce": true, "source": "database"}'
+            ),
+        )
+        entry = ModelEntry(model, app=Celery("periodic-model-entry-test"))
+
+        with patch.object(
+            DatabaseScheduler,
+            "apply_async",
+            return_value="sent",
+        ) as publish:
+            result = scheduler.apply_async(entry, advance=False)
+
+        self.assertEqual(result, "sent")
+        claimed_entry = publish.call_args.args[0]
+        self.assertIsInstance(claimed_entry, ScheduleEntry)
+        self.assertNotIsInstance(claimed_entry, ModelEntry)
+        self.assertEqual(
+            claimed_entry.options["headers"]["source"],
+            "database",
+        )
+        self.assertNotIn(PERIODIC_WAKEUP_TOKEN_HEADER, entry.options)
+        promote.assert_called_once_with("reconcile", _TEST_TOKEN)
+
     @patch("common.scheduling.scheduler.release_periodic_wakeup")
     @patch("common.scheduling.scheduler.promote_periodic_wakeup")
     @patch(
@@ -267,8 +323,7 @@ class CoalescingSchedulerTests(SimpleTestCase):
     )
     def test_publish_failure_releases_claim(self, _claim, promote, release) -> None:
         scheduler = self._scheduler()
-        entry = SimpleNamespace(
-            name="reconcile",
+        entry = self._entry(
             options={"headers": {PERIODIC_WAKEUP_COALESCE_HEADER: True}},
         )
 
@@ -285,10 +340,33 @@ class CoalescingSchedulerTests(SimpleTestCase):
         release.assert_called_once_with("reconcile", _TEST_TOKEN)
         promote.assert_not_called()
 
+    @patch("common.scheduling.scheduler.release_periodic_wakeup")
+    @patch(
+        "common.scheduling.scheduler.claim_periodic_wakeup",
+        return_value=_TEST_TOKEN,
+    )
+    def test_entry_preparation_failure_releases_claim(self, _claim, release) -> None:
+        scheduler = self._scheduler()
+        entry = self._entry(
+            options={"headers": {PERIODIC_WAKEUP_COALESCE_HEADER: True}},
+        )
+
+        with (
+            patch.object(
+                scheduler,
+                "_publishing_entry",
+                side_effect=RuntimeError("entry preparation failed"),
+            ),
+            self.assertRaisesRegex(RuntimeError, "entry preparation failed"),
+        ):
+            scheduler.apply_async(entry)
+
+        release.assert_called_once_with("reconcile", _TEST_TOKEN)
+
     @patch("common.scheduling.scheduler.claim_periodic_wakeup")
     def test_unmanaged_schedule_uses_standard_delivery(self, claim) -> None:
         scheduler = self._scheduler()
-        entry = SimpleNamespace(name="operator-task", options={"headers": {}})
+        entry = self._entry(options={"headers": {}})
 
         with patch.object(
             DatabaseScheduler,

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -1284,8 +1284,8 @@ grep -F 'sorted(groups, reverse=True)[3:]' "${installer}" >/dev/null
 grep -F 'preflight_redis_recovery' "${installer}" >/dev/null
 grep -F 'HFL_REDIS_MEMORY_LIMIT=${configured_limit} is invalid' "${installer}" >/dev/null
 grep -F 'exceeding the configured ${limit_mib} MiB container limit' "${installer}" >/dev/null
-grep -F 'HFL_REDIS_MEMORY_LIMIT=2g' "${ROOT}/.env.example" >/dev/null
-grep -F 'mem_limit: ${HFL_REDIS_MEMORY_LIMIT:-2g}' "${ROOT}/deploy/docker-compose.yml" >/dev/null
+grep -F 'HFL_REDIS_MEMORY_LIMIT=1g' "${ROOT}/.env.example" >/dev/null
+grep -F 'mem_limit: ${HFL_REDIS_MEMORY_LIMIT:-1g}' "${ROOT}/deploy/docker-compose.yml" >/dev/null
 grep -F 'recover_upgrade_services' "${installer}" >/dev/null
 grep -F 'prune_old_managed_image_refs' "${installer}" >/dev/null
 grep -F 'docker image rm "${ref}"' "${installer}" >/dev/null


### PR DESCRIPTION
## Summary
- publish coalesced Celery Beat tasks through a detached ScheduleEntry instead of copying django-celery-beat ModelEntry
- release the single-flight claim for entry preparation and broker failures
- restore the default Redis container limit to 1 GiB while retaining configurable recovery preflight checks
- add a real ModelEntry regression test

## Validation
- 16 periodic wake-up tests passed
- Ruff checks passed
- Redis RDB preflight checks passed
- release contract checks passed