### PR TITLE
fix(storage): preserve repository ownership compatibility on Aliyun OSS

### DIFF
--- a/src/backend/apps/lens_bridge/services/chat_binding.py
+++ b/src/backend/apps/lens_bridge/services/chat_binding.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from typing import Any
 
 from django.contrib.auth.models import AbstractBaseUser
+from django.core.exceptions import ValidationError as DjangoValidationError
 from django.db import transaction
 from rest_framework.exceptions import ValidationError
 
@@ -45,11 +46,14 @@ def _validate_snapshot(
     ).first()
     if config is None:
         raise ValidationError({"backup_config_id": "Backup source not found."})
-    lock_repositories_for_workload(
-        organization_id=org.id,
-        repository_ids=[config.repository_id],
-        workload=RepositoryWorkload.RESTORE_READ,
-    )
+    try:
+        lock_repositories_for_workload(
+            organization_id=org.id,
+            repository_ids=[config.repository_id],
+            workload=RepositoryWorkload.RESTORE_READ,
+        )
+    except DjangoValidationError as exc:
+        raise ValidationError(exc.message_dict) from exc
 
     snapshot = BackupSourceSnapshot.objects.filter(
         organization_id=org.id,

--- a/src/backend/apps/lens_bridge/services/chat_lifecycle.py
+++ b/src/backend/apps/lens_bridge/services/chat_lifecycle.py
@@ -11,6 +11,7 @@ from datetime import timedelta
 from typing import Any
 
 from django.contrib.auth.models import AbstractBaseUser
+from django.core.exceptions import ValidationError as DjangoValidationError
 from django.db import IntegrityError, transaction
 from django.utils import timezone
 from rest_framework import status as http_status
@@ -332,11 +333,14 @@ def create_copilot_chat(
     ).first()
     if config is None:
         raise ValidationError({"backup_config_id": "Backup source not found."})
-    lock_repositories_for_workload(
-        organization_id=org.id,
-        repository_ids=[config.repository_id],
-        workload=RepositoryWorkload.RESTORE_READ,
-    )
+    try:
+        lock_repositories_for_workload(
+            organization_id=org.id,
+            repository_ids=[config.repository_id],
+            workload=RepositoryWorkload.RESTORE_READ,
+        )
+    except DjangoValidationError as exc:
+        raise ValidationError(exc.message_dict) from exc
     snapshot = BackupSourceSnapshot.objects.filter(
         id=backup_source_snapshot_id,
         organization_id=org.id,

--- a/src/backend/apps/lens_bridge/services/snapshot_scope_tasks.py
+++ b/src/backend/apps/lens_bridge/services/snapshot_scope_tasks.py
@@ -7,6 +7,7 @@ import posixpath
 import math
 from typing import Any
 
+from django.core.exceptions import ValidationError as DjangoValidationError
 from django.db import transaction
 from rest_framework.exceptions import ValidationError
 
@@ -102,7 +103,7 @@ def dispatch_snapshot_operation(
             repository_ids=[directory.repository_id],
             workload=RepositoryWorkload.RESTORE_READ,
         )[0]
-    except ValidationError as exc:
+    except (DjangoValidationError, ValidationError) as exc:
         raise ValidationError(
             {"directory_id": "Snapshot repository is not available."}
         ) from exc

--- a/src/backend/apps/lens_bridge/tests/test_chat_lifecycle_queue.py
+++ b/src/backend/apps/lens_bridge/tests/test_chat_lifecycle_queue.py
@@ -2,9 +2,11 @@ import threading
 import uuid
 from concurrent.futures import ThreadPoolExecutor
 from datetime import timedelta
+from types import SimpleNamespace
 from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
+from django.core.exceptions import ValidationError as DjangoValidationError
 from django.db import close_old_connections
 from django.test import SimpleTestCase, TestCase, TransactionTestCase
 from django.utils import timezone
@@ -20,7 +22,7 @@ from apps.lens_bridge.services.sync_queue import (
     queue_copilot_chat_provision,
     queue_copilot_chat_teardown,
 )
-from apps.lens_bridge.services import chat_lifecycle
+from apps.lens_bridge.services import chat_binding, chat_lifecycle
 from apps.lens_bridge.tasks import chat_lifecycle as chat_lifecycle_tasks
 from apps.node.models import Node
 from apps.protection.models import (
@@ -115,6 +117,34 @@ class CopilotLifecycleQueueTests(SimpleTestCase):
     def test_teardown_queue_failure_does_not_use_daemon_thread(self, _delay):
         with self.assertRaisesRegex(RuntimeError, "Unable to queue chat teardown"):
             queue_copilot_chat_teardown(session_link_id=42)
+
+
+class ChatBindingValidationTests(SimpleTestCase):
+    @patch(
+        "apps.lens_bridge.services.chat_binding.lock_repositories_for_workload",
+        side_effect=DjangoValidationError(
+            {"repository_id": "Repository is not available for read operations."}
+        ),
+    )
+    @patch("apps.lens_bridge.services.chat_binding.BackupConfig.objects.filter")
+    def test_repository_domain_error_is_exposed_as_api_validation(
+        self,
+        filter_configs,
+        _lock_repositories,
+    ):
+        filter_configs.return_value.first.return_value = SimpleNamespace(
+            repository_id=7
+        )
+
+        with self.assertRaises(ValidationError) as raised:
+            chat_binding._validate_snapshot(
+                SimpleNamespace(id=5),
+                backup_config_id=3,
+                backup_source_snapshot_id=11,
+                backup_snapshot_directory_id=None,
+            )
+
+        self.assertIn("repository_id", raised.exception.detail)
 
 
 class CopilotDefaultTitleTests(SimpleTestCase):
@@ -745,6 +775,18 @@ class CopilotChatModelBindingTests(TestCase):
         with self.assertRaises(ValidationError):
             self._create_chat()
 
+        self.assertFalse(
+            LensSessionLink.objects.filter(organization=self.organization).exists()
+        )
+
+    def test_offline_repository_is_reported_as_an_api_validation_error(self):
+        self.repository.health = Repository.Health.OFFLINE
+        self.repository.save(update_fields=["health", "updated_at"])
+
+        with self.assertRaises(ValidationError) as raised:
+            self._create_chat()
+
+        self.assertIn("repository_id", raised.exception.detail)
         self.assertFalse(
             LensSessionLink.objects.filter(organization=self.organization).exists()
         )

--- a/src/backend/apps/lens_bridge/tests/test_snapshot_scope_tasks.py
+++ b/src/backend/apps/lens_bridge/tests/test_snapshot_scope_tasks.py
@@ -1,6 +1,7 @@
 from types import SimpleNamespace
 from unittest.mock import patch
 
+from django.core.exceptions import ValidationError as DjangoValidationError
 from django.test import TestCase
 from rest_framework.exceptions import ValidationError
 
@@ -147,6 +148,31 @@ class SnapshotScopeTaskNormalizationTests(TestCase):
 
         self.assertIsNone(task)
         get_task.assert_called_once_with(org=organization, task_id="task-1")
+
+    @patch("apps.lens_bridge.services.snapshot_scope_tasks._directory_for_org")
+    @patch(
+        "apps.lens_bridge.services.snapshot_scope_tasks.lock_repositories_for_workload",
+        side_effect=DjangoValidationError(
+            {"repository_id": "Repository is not available for read operations."}
+        ),
+    )
+    def test_repository_domain_error_is_exposed_as_snapshot_validation(
+        self,
+        _lock_repositories,
+        directory_for_org,
+    ):
+        directory_for_org.return_value = SimpleNamespace(repository_id=7)
+
+        with self.assertRaises(ValidationError) as raised:
+            snapshot_scope_tasks.dispatch_snapshot_browse(
+                organization_id=5,
+                directory_id=31,
+                path="reports",
+                limit=100,
+                correlation_id="user:9:browse",
+            )
+
+        self.assertIn("directory_id", raised.exception.detail)
 
     @patch("apps.lens_bridge.services.snapshot_scope_tasks.run_agent_task_async")
     @patch(

--- a/src/backend/apps/storage/services/internal/repository_ownership.py
+++ b/src/backend/apps/storage/services/internal/repository_ownership.py
@@ -145,6 +145,7 @@ def claim_s3_repository_ownership(repository: Repository) -> None:
     marker_bytes = _encode_marker(expected)
     if not put_s3_object_if_absent(
         **s3_args,
+        platform=repository.s3_platform,
         key=marker_key,
         body=marker_bytes,
     ):
@@ -215,17 +216,21 @@ def verify_s3_repository_ownership(
             expected=expected,
             s3_args=s3_args,
         )
-        if not put_s3_object_if_absent(
+        marker_created = put_s3_object_if_absent(
             **s3_args,
+            platform=repository.s3_platform,
             key=marker_key,
             body=_encode_marker(expected),
-        ):
-            marker = read_s3_object(**s3_args, key=marker_key)
-            if marker is None:
-                raise RepositoryOwnershipError(
-                    "Repository ownership changed during legacy adoption."
-                )
-            _require_matching_marker(marker, expected=expected)
+        )
+        marker = read_s3_object(**s3_args, key=marker_key)
+        if marker is None:
+            message = (
+                "Repository ownership marker was not durable after legacy adoption."
+                if marker_created
+                else "Repository ownership changed during legacy adoption."
+            )
+            raise RepositoryOwnershipError(message)
+        _require_matching_marker(marker, expected=expected)
     else:
         _require_matching_marker(marker, expected=expected)
     if adopt_legacy:

--- a/src/backend/apps/storage/services/internal/s3_client.py
+++ b/src/backend/apps/storage/services/internal/s3_client.py
@@ -35,6 +35,11 @@ class BucketSummary:
 _PROVIDER_BUCKET_CAPABILITIES = {
     "aws": {"regional_list_buckets": True},
 }
+_ATOMIC_CREATE_IF_NONE_MATCH = "if_none_match"
+_ATOMIC_CREATE_ALIYUN_FORBID_OVERWRITE = "aliyun_forbid_overwrite"
+_PROVIDER_ATOMIC_CREATE_STRATEGIES = {
+    "aliyun": _ATOMIC_CREATE_ALIYUN_FORBID_OVERWRITE,
+}
 _BUCKET_REGION_FIELDS = (
     "BucketRegion",
     "LocationConstraint",
@@ -411,6 +416,7 @@ def read_s3_object(
 
 def put_s3_object_if_absent(
     *,
+    platform: str | None = None,
     endpoint: str | None,
     region: str | None,
     bucket: str,
@@ -432,22 +438,37 @@ def put_s3_object_if_absent(
         use_tls=use_tls,
         timeout_seconds=timeout_seconds,
     )
-    try:
-        client.put_object(
-            Bucket=bucket,
-            Key=key,
-            Body=body,
-            ContentLength=len(body),
-            ContentType="application/json",
-            IfNoneMatch="*",
+    put_args = {
+        "Bucket": bucket,
+        "Key": key,
+        "Body": body,
+        "ContentLength": len(body),
+        "ContentType": "application/json",
+    }
+    atomic_create_strategy = _s3_atomic_create_strategy(
+        platform=platform,
+        endpoint=endpoint,
+    )
+    if atomic_create_strategy == _ATOMIC_CREATE_ALIYUN_FORBID_OVERWRITE:
+        client.meta.events.register_first(
+            "before-sign.s3.PutObject",
+            _add_aliyun_forbid_overwrite_header,
+            unique_id="hfl-aliyun-forbid-overwrite",
         )
+    else:
+        put_args["IfNoneMatch"] = "*"
+    try:
+        client.put_object(**put_args)
         return True
     except ClientError as exc:
-        if _client_error_code(exc) in {
+        conflict_codes = {
             "ConditionalRequestConflict",
             "PreconditionFailed",
             "412",
-        }:
+        }
+        if atomic_create_strategy == _ATOMIC_CREATE_ALIYUN_FORBID_OVERWRITE:
+            conflict_codes.add("FileAlreadyExists")
+        if _client_error_code(exc) in conflict_codes:
             return False
         raise S3ClientError(
             _error_message("Unable to claim repository ownership", exc)
@@ -456,6 +477,32 @@ def put_s3_object_if_absent(
         raise S3ClientError(
             "The object store cannot atomically create the repository ownership marker."
         ) from exc
+
+
+def _s3_atomic_create_strategy(*, platform: str | None, endpoint: str | None) -> str:
+    """Select the Provider-specific atomic object creation contract.
+
+    Older installations stored Aliyun OSS as ``custom``. Endpoint inference is
+    deliberately limited to the official Aliyun domain so arbitrary custom S3
+    gateways continue using the standard conditional PutObject contract.
+    """
+    normalized_platform = str(platform or "").strip().lower()
+    if normalized_platform in {"", "custom"}:
+        hostname = urlparse(endpoint_for_requests(endpoint)).hostname or ""
+        normalized_hostname = hostname.rstrip(".").lower()
+        if normalized_hostname == "aliyuncs.com" or normalized_hostname.endswith(
+            ".aliyuncs.com"
+        ):
+            return _ATOMIC_CREATE_ALIYUN_FORBID_OVERWRITE
+    return _PROVIDER_ATOMIC_CREATE_STRATEGIES.get(
+        normalized_platform,
+        _ATOMIC_CREATE_IF_NONE_MATCH,
+    )
+
+
+def _add_aliyun_forbid_overwrite_header(*, request, **_kwargs) -> None:
+    """Apply Aliyun OSS's atomic create-only header before request signing."""
+    request.headers["x-oss-forbid-overwrite"] = "true"
 
 
 def list_s3_object_keys(

--- a/src/backend/apps/storage/tests/test_repository_location.py
+++ b/src/backend/apps/storage/tests/test_repository_location.py
@@ -492,6 +492,10 @@ class RepositoryLocationClaimTests(TestCase):
             put_marker.call_args.kwargs["key"],
             ".hyperfilelens/repository-owner-v1.json",
         )
+        self.assertEqual(
+            put_marker.call_args.kwargs["platform"],
+            Repository.S3Platform.HUAWEICLOUD,
+        )
 
     @mock.patch(
         "apps.storage.services.internal.repository_ownership._reject_foreign_ancestor_markers",
@@ -549,3 +553,67 @@ class RepositoryLocationClaimTests(TestCase):
                 verify_s3_repository_ownership(repository, adopt_legacy=True)
 
         put_marker.assert_not_called()
+
+    @mock.patch(
+        "apps.storage.services.internal.repository_ownership.mark_repository_location_ownership_verified"
+    )
+    @mock.patch(
+        "apps.storage.services.internal.repository_ownership._require_matching_marker"
+    )
+    @mock.patch(
+        "apps.storage.services.internal.repository_ownership._reject_foreign_descendant_markers"
+    )
+    @mock.patch(
+        "apps.storage.services.internal.repository_ownership._reject_foreign_ancestor_markers"
+    )
+    @mock.patch(
+        "apps.storage.services.internal.repository_ownership.put_s3_object_if_absent",
+        return_value=True,
+    )
+    @mock.patch(
+        "apps.storage.services.internal.repository_ownership.read_s3_object",
+        side_effect=[None, b"persisted-marker"],
+    )
+    @mock.patch(
+        "apps.storage.services.internal.repository_ownership.ownership_payload",
+        return_value={"repository_uuid": "expected"},
+    )
+    @mock.patch(
+        "apps.storage.services.internal.repository_ownership._ensure_s3_namespace_resolved"
+    )
+    @mock.patch(
+        "apps.storage.services.internal.repository_ownership._s3_args",
+        return_value={},
+    )
+    def test_legacy_aliyun_adoption_reads_back_marker_before_verification(
+        self,
+        _s3_args,
+        _resolve_namespace,
+        _ownership_payload,
+        read_marker,
+        put_marker,
+        _reject_ancestor,
+        _reject_descendant,
+        require_marker,
+        mark_verified,
+    ):
+        repository = self._s3_repository(name="Legacy Aliyun", prefix="hfl/")
+        repository.s3_platform = Repository.S3Platform.CUSTOM
+        repository.config = {
+            **repository.config,
+            "endpoint": "oss-cn-beijing.aliyuncs.com",
+        }
+        repository.save(update_fields=["s3_platform", "config", "updated_at"])
+
+        verify_s3_repository_ownership(repository, adopt_legacy=True)
+
+        self.assertEqual(read_marker.call_count, 2)
+        self.assertEqual(
+            put_marker.call_args.kwargs["platform"],
+            Repository.S3Platform.CUSTOM,
+        )
+        require_marker.assert_called_once_with(
+            b"persisted-marker",
+            expected={"repository_uuid": "expected"},
+        )
+        mark_verified.assert_called_once_with(repository)

--- a/src/backend/apps/storage/tests/test_s3_client.py
+++ b/src/backend/apps/storage/tests/test_s3_client.py
@@ -13,6 +13,7 @@ from apps.storage.services.internal.s3_client import (
     ensure_s3_bucket,
     list_s3_buckets,
     list_s3_buckets_by_region,
+    put_s3_object_if_absent,
 )
 from apps.storage.services.internal.repository_initializer import (
     RepositoryInitializationError,
@@ -794,3 +795,102 @@ class CheckS3BucketReadableTests(TestCase):
         client.create_bucket.assert_not_called()
         client.put_object.assert_not_called()
         client.delete_object.assert_not_called()
+
+
+class S3OwnershipMarkerAtomicCreateTests(TestCase):
+    def _put(self, **overrides):
+        args = {
+            "platform": Repository.S3Platform.AWS,
+            "endpoint": "https://s3.us-east-1.amazonaws.com",
+            "region": "us-east-1",
+            "bucket": "backup-bucket",
+            "key": "hfl/.hyperfilelens/repository-owner-v1.json",
+            "body": b"{}",
+            "access_key_id": "AK",
+            "secret_access_key": "SK",
+        }
+        args.update(overrides)
+        return put_s3_object_if_absent(**args)
+
+    @mock.patch("apps.storage.services.internal.s3_client._client")
+    def test_standard_s3_uses_if_none_match(self, client_factory):
+        client = mock.Mock()
+        client_factory.return_value = client
+
+        self.assertTrue(self._put())
+
+        client.put_object.assert_called_once_with(
+            Bucket="backup-bucket",
+            Key="hfl/.hyperfilelens/repository-owner-v1.json",
+            Body=b"{}",
+            ContentLength=2,
+            ContentType="application/json",
+            IfNoneMatch="*",
+        )
+        client.meta.events.register_first.assert_not_called()
+
+    @mock.patch("apps.storage.services.internal.s3_client._client")
+    def test_aliyun_uses_signed_forbid_overwrite_header(self, client_factory):
+        client = mock.Mock()
+        client_factory.return_value = client
+
+        self.assertTrue(
+            self._put(
+                platform=Repository.S3Platform.ALIYUN,
+                endpoint="https://oss-cn-beijing.aliyuncs.com",
+                region="oss-cn-beijing",
+            )
+        )
+
+        client.put_object.assert_called_once_with(
+            Bucket="backup-bucket",
+            Key="hfl/.hyperfilelens/repository-owner-v1.json",
+            Body=b"{}",
+            ContentLength=2,
+            ContentType="application/json",
+        )
+        registration = client.meta.events.register_first.call_args
+        self.assertEqual(registration.args[0], "before-sign.s3.PutObject")
+        request = SimpleNamespace(headers={})
+        registration.args[1](request=request)
+        self.assertEqual(request.headers["x-oss-forbid-overwrite"], "true")
+
+    @mock.patch("apps.storage.services.internal.s3_client._client")
+    def test_legacy_custom_aliyun_endpoint_uses_aliyun_semantics(
+        self, client_factory
+    ):
+        client = mock.Mock()
+        client_factory.return_value = client
+
+        self.assertTrue(
+            self._put(
+                platform=Repository.S3Platform.CUSTOM,
+                endpoint="oss-cn-beijing.aliyuncs.com",
+                region="oss-cn-beijing",
+            )
+        )
+
+        self.assertNotIn("IfNoneMatch", client.put_object.call_args.kwargs)
+        client.meta.events.register_first.assert_called_once()
+
+    @mock.patch("apps.storage.services.internal.s3_client._client")
+    def test_aliyun_existing_marker_returns_false(self, client_factory):
+        client = mock.Mock()
+        client.put_object.side_effect = ClientError(
+            {
+                "Error": {
+                    "Code": "FileAlreadyExists",
+                    "Message": "The object already exists.",
+                },
+                "ResponseMetadata": {"HTTPStatusCode": 409},
+            },
+            "PutObject",
+        )
+        client_factory.return_value = client
+
+        self.assertFalse(
+            self._put(
+                platform=Repository.S3Platform.ALIYUN,
+                endpoint="https://oss-cn-beijing.aliyuncs.com",
+            )
+        )


### PR DESCRIPTION
## Summary
- use Aliyun OSS atomic create semantics for repository ownership markers while preserving standard S3 behavior
- verify legacy ownership markers after persistence before marking repositories as trusted
- expose repository availability failures through Insight API validation boundaries instead of HTTP 500 responses

## Validation
- 109 storage and Insight regression tests
- 27 repository health and legacy adoption tests
- Ruff, Python compilation, and git diff checks

This is a compatibility follow-up to #572. Existing repositories are adopted automatically by startup and periodic health checks; no manual database migration is required.