### PR TITLE
fix(installer): avoid Nginx reload races during startup

### DIFF
--- a/.github/workflows/artifact_pipeline.yml
+++ b/.github/workflows/artifact_pipeline.yml
@@ -449,6 +449,7 @@ jobs:
           ./tools/quality/test-upgrade-backup-retention.sh
           ./tools/quality/test-upgrade-transaction.sh
           ./tools/quality/test-blue-green-recovery.sh
+          ./tools/quality/test-nginx-startup-readiness.sh
           ./tools/quality/test-sourcelens-runtime-sync.sh
           ./tools/quality/test-sourcelens-runtime-fingerprint.sh
           ./tools/quality/test-redis-rdb-preflight.sh

--- a/deploy/installer/install.sh
+++ b/deploy/installer/install.sh
@@ -1036,28 +1036,76 @@ wait_for_color_health() {
 	wait_for_services_health "${timeout_seconds}" "api-${color}" "web-${color}"
 }
 
+stable_nginx_running_generation() {
+	local cid
+	cid="$(compose_in_root ps -q nginx 2>/dev/null | sed -n '1p')" || return 1
+	[[ -n "${cid}" ]] || return 0
+	docker inspect --format \
+		'{{if .State.Running}}{{.Id}}|{{.State.StartedAt}}{{end}}' \
+		"${cid}" 2>/dev/null
+}
+
+stable_nginx_master_ready() {
+	compose_in_root exec -T nginx sh -c '
+		pid="$(cat /run/nginx.pid 2>/dev/null || true)"
+		case "${pid}" in
+		"" | *[!0-9]*) exit 1 ;;
+		esac
+		[ "${pid}" -gt 0 ] && kill -0 "${pid}"
+	' >/dev/null 2>&1
+}
+
+wait_for_stable_nginx_master() {
+	local timeout_seconds="${HFL_NGINX_RELOAD_TIMEOUT_SECONDS:-30}" deadline
+	if [[ ! "${timeout_seconds}" =~ ^[0-9]+$ ]] || ((timeout_seconds < 1)); then
+		timeout_seconds=30
+	fi
+	deadline=$((SECONDS + timeout_seconds))
+	while ((SECONDS < deadline)); do
+		stable_nginx_master_ready && return 0
+		sleep 1
+	done
+	warn "stable Nginx master did not become ready within ${timeout_seconds}s"
+	return 1
+}
+
 reload_stable_nginx() {
-	compose_in_root exec -T nginx nginx -t
-	compose_in_root exec -T nginx nginx -s reload
+	wait_for_stable_nginx_master || return 1
+	compose_in_root exec -T nginx nginx -t || return 1
+	compose_in_root exec -T nginx nginx -s reload || return 1
 }
 
 start_hfl_stack() {
-	local color
-	ensure_blue_green_state
-	color="$(read_active_color)"
-	compose_in_root up -d --no-build --pull never --no-recreate postgres redis
+	local color nginx_generation_before nginx_generation_after
+	ensure_blue_green_state || return 1
+	color="$(read_active_color)" || return 1
+	if ! nginx_generation_before="$(stable_nginx_running_generation)"; then
+		warn "could not inspect the stable Nginx instance before service convergence"
+		return 1
+	fi
+	compose_in_root up -d --no-build --pull never --no-recreate postgres redis || return 1
 	# Compose v2.27 supports `up --pull` but not `run --pull`. The migration
 	# service inherits `pull_policy: never` from the release Compose model, so
 	# this remains offline without relying on a version-sensitive CLI flag.
-	compose_in_root --profile tools run --rm --no-deps migration
-	compose_in_root up -d --no-build --pull never worker scheduler
-	compose_color "${color}" up -d --no-build --pull never "api-${color}" "web-${color}"
+	compose_in_root --profile tools run --rm --no-deps migration || return 1
+	compose_in_root up -d --no-build --pull never worker scheduler || return 1
+	compose_color "${color}" up -d --no-build --pull never "api-${color}" "web-${color}" || return 1
 	wait_for_color_health "${color}" || return 1
-	compose_in_root up -d --no-build --pull never nginx
-	# Compose may recreate an active-color container with a new address while the
-	# stable gateway itself stays running. Reload so Nginx resolves the current
-	# service addresses instead of retaining a stale upstream from its last start.
-	reload_stable_nginx || return 1
+	compose_in_root up -d --no-build --pull never nginx || return 1
+	if ! nginx_generation_after="$(stable_nginx_running_generation)"; then
+		warn "could not inspect the stable Nginx instance after service convergence"
+		return 1
+	fi
+	if [[ -n "${nginx_generation_before}" \
+		&& "${nginx_generation_before}" == "${nginx_generation_after}" ]]; then
+		# The stable gateway stayed continuously online while an active-color
+		# container may have acquired a new address. Reload only this case so
+		# Nginx resolves the current upstream without racing a new master process.
+		reload_stable_nginx || return 1
+	else
+		log "Stable Nginx started with the current configuration; reload is not required"
+	fi
+	wait_for_services_health "${HFL_HEALTH_TIMEOUT_SECONDS:-600}" nginx || return 1
 }
 
 drain_api_color() {

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -945,6 +945,7 @@ fi
 grep -F 'compose_color "${recovery_color}" start' <<<"${recovery_body}" >/dev/null
 grep -F 'compose_in_root start worker scheduler' <<<"${recovery_body}" >/dev/null
 grep -F './tools/quality/test-blue-green-recovery.sh' "${workflow}" >/dev/null
+grep -F './tools/quality/test-nginx-startup-readiness.sh' "${workflow}" >/dev/null
 grep -F './tools/quality/test-sourcelens-runtime-sync.sh' "${workflow}" >/dev/null
 grep -F './tools/quality/test-sourcelens-runtime-fingerprint.sh' "${workflow}" >/dev/null
 

--- a/tools/quality/test-blue-green-recovery.sh
+++ b/tools/quality/test-blue-green-recovery.sh
@@ -21,6 +21,7 @@ reload_stable_nginx() { calls+=("reload"); }
 write_active_color() { calls+=("active:$*"); }
 wait_for_public_endpoints() { calls+=("public-health"); }
 wait_for_color_health() { calls+=("color-health:$*"); }
+wait_for_services_health() { calls+=("service-health:$*"); }
 ensure_blue_green_state() { calls+=("ensure-state"); }
 read_active_color() { printf 'blue'; }
 sourcelens_installed() { [[ "${sourcelens_present}" == "1" ]]; }
@@ -55,7 +56,9 @@ start_hfl_stack
 [[ " ${calls[*]} " != *" run --rm --no-deps --pull never migration "* ]]
 [[ " ${calls[*]} " == *" color:blue up -d --no-build --pull never api-blue web-blue "* ]]
 [[ " ${calls[*]} " == *" color-health:blue "* ]]
-[[ " ${calls[*]} " == *" compose:up -d --no-build --pull never nginx reload "* ]]
+[[ " ${calls[*]} " == *" compose:up -d --no-build --pull never nginx "* ]]
+[[ " ${calls[*]} " == *" service-health:600 nginx "* ]]
+[[ " ${calls[*]} " != *" reload "* ]]
 
 calls=()
 UPGRADE_HFL_WAS_RUNNING=1

--- a/tools/quality/test-nginx-startup-readiness.sh
+++ b/tools/quality/test-nginx-startup-readiness.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+# shellcheck disable=SC1090
+source "${ROOT_REPO}/deploy/installer/install.sh"
+ORIGINAL_RELOAD_STABLE_NGINX="$(declare -f reload_stable_nginx)"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "${tmp}"' EXIT
+ROOT="${tmp}/install"
+mkdir -p "${ROOT}"
+printf 'APP_VERSION=1.0.0\n' >"${ROOT}/.env"
+
+calls=()
+nginx_generation=""
+nginx_generation_after_up=""
+nginx_generation_status=0
+nginx_generation_status_after_up=0
+compose_failure_pattern=""
+
+compose_in_root() {
+	calls+=("compose:$*")
+	if [[ -n "${compose_failure_pattern}" && " $* " == *" ${compose_failure_pattern} "* ]]; then
+		return 1
+	fi
+	if [[ " $* " == *" up -d --no-build --pull never nginx "* ]]; then
+		nginx_generation="${nginx_generation_after_up}"
+		nginx_generation_status="${nginx_generation_status_after_up}"
+	fi
+}
+compose_color() { calls+=("color:$*"); }
+ensure_blue_green_state() { calls+=("ensure-state"); }
+read_active_color() { printf 'blue'; }
+stable_nginx_running_generation() {
+	[[ "${nginx_generation_status}" -eq 0 ]] || return "${nginx_generation_status}"
+	printf '%s' "${nginx_generation}"
+}
+wait_for_color_health() { calls+=("color-health:$*"); }
+wait_for_services_health() { calls+=("service-health:$*"); }
+reload_stable_nginx() { calls+=("reload"); }
+log() { :; }
+
+# A new stable gateway reads the current configuration during process startup.
+# Reloading it immediately is both redundant and racy because nginx.pid may not
+# have been populated yet.
+nginx_generation=""
+nginx_generation_after_up="new-container|started-now"
+nginx_generation_status=0
+nginx_generation_status_after_up=0
+start_hfl_stack
+[[ " ${calls[*]} " != *" reload "* ]]
+[[ " ${calls[*]} " == *" service-health:600 nginx "* ]]
+
+# A failed Compose start must stop the function before instance inspection,
+# reload, or health checks. start_hfl_stack is called through `|| die`, so its
+# critical commands cannot rely on Bash's implicit errexit behavior.
+calls=()
+nginx_generation="stable-container|original-start"
+nginx_generation_after_up="stable-container|original-start"
+nginx_generation_status=0
+nginx_generation_status_after_up=0
+compose_failure_pattern="up -d --no-build --pull never nginx"
+if start_hfl_stack; then
+	printf 'ERROR: failed Nginx Compose start was ignored\n' >&2
+	exit 1
+fi
+[[ " ${calls[*]} " == *" compose:up -d --no-build --pull never nginx "* ]]
+[[ " ${calls[*]} " != *" reload "* ]]
+[[ " ${calls[*]} " != *" service-health:600 nginx "* ]]
+compose_failure_pattern=""
+
+# A continuously running gateway retains resolved upstream addresses and must
+# reload after the active API/Web pool is converged.
+calls=()
+nginx_generation="stable-container|original-start"
+nginx_generation_after_up="stable-container|original-start"
+nginx_generation_status=0
+nginx_generation_status_after_up=0
+start_hfl_stack
+[[ " ${calls[*]} " == *" reload "* ]]
+[[ " ${calls[*]} " == *" service-health:600 nginx "* ]]
+
+# A recreated gateway has already read the new configuration and follows the
+# same readiness path as a clean installation.
+calls=()
+nginx_generation="old-container|old-start"
+nginx_generation_after_up="new-container|new-start"
+nginx_generation_status=0
+nginx_generation_status_after_up=0
+start_hfl_stack
+[[ " ${calls[*]} " != *" reload "* ]]
+[[ " ${calls[*]} " == *" service-health:600 nginx "* ]]
+
+# Instance inspection failures are not equivalent to an absent or restarted
+# gateway. Fail closed so a transient Docker error cannot leave stale upstreams.
+calls=()
+nginx_generation_status=1
+nginx_generation_status_after_up=0
+if start_hfl_stack; then
+	printf 'ERROR: pre-start Nginx inspection failure was ignored\n' >&2
+	exit 1
+fi
+[[ " ${calls[*]} " != *" compose:up -d --no-build --pull never nginx "* ]]
+
+calls=()
+nginx_generation="stable-container|original-start"
+nginx_generation_after_up="stable-container|original-start"
+nginx_generation_status=0
+nginx_generation_status_after_up=1
+if start_hfl_stack; then
+	printf 'ERROR: post-start Nginx inspection failure was ignored\n' >&2
+	exit 1
+fi
+[[ " ${calls[*]} " == *" compose:up -d --no-build --pull never nginx "* ]]
+[[ " ${calls[*]} " != *" reload "* ]]
+
+# The reload helper waits for a numeric, live master PID before validating and
+# signaling Nginx. This protects cutover and rollback paths as well as start.
+calls=()
+master_attempts=0
+stable_nginx_master_ready() {
+	master_attempts=$((master_attempts + 1))
+	((master_attempts >= 3))
+}
+sleep() { SECONDS=$((SECONDS + 1)); }
+HFL_NGINX_RELOAD_TIMEOUT_SECONDS=5
+wait_for_stable_nginx_master
+[[ "${master_attempts}" -eq 3 ]]
+
+master_attempts=0
+stable_nginx_master_ready() {
+	master_attempts=$((master_attempts + 1))
+	return 1
+}
+HFL_NGINX_RELOAD_TIMEOUT_SECONDS=2
+if wait_for_stable_nginx_master; then
+	printf 'ERROR: unavailable Nginx master passed its readiness gate\n' >&2
+	exit 1
+fi
+[[ "${master_attempts}" -eq 2 ]]
+
+# Bash disables implicit errexit inside functions invoked by `if !` or `||`.
+# Explicit guards must prevent a failed config test from being hidden by a
+# later successful reload command.
+eval "${ORIGINAL_RELOAD_STABLE_NGINX}"
+calls=()
+nginx_config_valid=0
+nginx_reload_valid=1
+wait_for_stable_nginx_master() { calls+=("master-ready"); }
+compose_in_root() {
+	calls+=("compose:$*")
+	case "$*" in
+	"exec -T nginx nginx -t") [[ "${nginx_config_valid}" -eq 1 ]] ;;
+	"exec -T nginx nginx -s reload") [[ "${nginx_reload_valid}" -eq 1 ]] ;;
+	esac
+}
+if reload_stable_nginx; then
+	printf 'ERROR: failed Nginx config validation was masked\n' >&2
+	exit 1
+fi
+[[ " ${calls[*]} " == *" compose:exec -T nginx nginx -t "* ]]
+[[ " ${calls[*]} " != *" compose:exec -T nginx nginx -s reload "* ]]
+
+calls=()
+nginx_config_valid=1
+nginx_reload_valid=0
+if reload_stable_nginx; then
+	printf 'ERROR: failed Nginx reload was masked\n' >&2
+	exit 1
+fi
+[[ " ${calls[*]} " == *" compose:exec -T nginx nginx -s reload "* ]]
+
+calls=()
+nginx_reload_valid=1
+reload_stable_nginx
+[[ " ${calls[*]} " == *" master-ready compose:exec -T nginx nginx -t compose:exec -T nginx nginx -s reload "* ]]
+
+printf 'Nginx startup and reload readiness checks passed.\n'


### PR DESCRIPTION
## Summary
- distinguish newly started or recreated Nginx containers from continuously running instances
- wait for a live Nginx master before reload and fail closed on inspection, validation, or Compose errors
- add startup, recreation, readiness, and failure-propagation regression coverage to release quality gates

## Validation
- test-nginx-startup-readiness.sh
- test-blue-green-recovery.sh
- check-release-contracts.sh
- test-upgrade-transaction.sh
- test-lifecycle-output-contract.sh
- test-installer-image-refresh.sh
- check-english-source.py --check-all