### PR TITLE
Fix date-time range boundaries

### DIFF
--- a/src/frontend/src/components/HflDateTimeRangePicker.vue
+++ b/src/frontend/src/components/HflDateTimeRangePicker.vue
@@ -79,12 +79,12 @@ function pad2(n: number) {
 }
 
 function formatLocalDateTime(date: Date) {
-  return `${date.getFullYear()}-${pad2(date.getMonth() + 1)}-${pad2(date.getDate())}T${pad2(date.getHours())}:${pad2(date.getMinutes())}`
+  return `${date.getFullYear()}-${pad2(date.getMonth() + 1)}-${pad2(date.getDate())}T${pad2(date.getHours())}:${pad2(date.getMinutes())}:${pad2(date.getSeconds())}`
 }
 
 function rangeFromProps(): RangeValue {
   if (!props.start || !props.end) return ''
-  return [props.start.slice(0, 16), props.end.slice(0, 16)]
+  return [props.start.slice(0, 19), props.end.slice(0, 19)]
 }
 
 function displayRangeFromProps(): RangeValue {
@@ -114,7 +114,7 @@ function normalizeRange(value: unknown): RangeValue {
   if (start instanceof Date && end instanceof Date) {
     return [formatLocalDateTime(start), formatLocalDateTime(end)]
   }
-  return [String(start).slice(0, 16), String(end).slice(0, 16)]
+  return [String(start).slice(0, 19), String(end).slice(0, 19)]
 }
 
 function onUpdate(value: unknown) {
@@ -122,7 +122,10 @@ function onUpdate(value: unknown) {
 }
 
 function onChange(value: unknown) {
-  const range = normalizeRange(value)
+  let range = normalizeRange(value)
+  if (range && isTodayEndOfDay(range[1])) {
+    range = [range[0], formatLocalDateTime(new Date())]
+  }
   pickerValue.value = range
   if (suppressNextChange.value) {
     suppressNextChange.value = false
@@ -140,6 +143,18 @@ function onChange(value: unknown) {
     return
   }
   emit('apply', range[0], range[1])
+}
+
+function isTodayEndOfDay(value: string) {
+  const date = new Date(value)
+  const now = new Date()
+  return Number.isFinite(date.getTime())
+    && date.getFullYear() === now.getFullYear()
+    && date.getMonth() === now.getMonth()
+    && date.getDate() === now.getDate()
+    && date.getHours() === 23
+    && date.getMinutes() === 59
+    && date.getSeconds() === 59
 }
 
 function onClear() {
@@ -168,8 +183,9 @@ watch(
       class="hfl-date-time-range-picker__trigger"
       type="datetimerange"
       unlink-panels
-      format="YYYY-MM-DD HH:mm"
-      value-format="YYYY-MM-DDTHH:mm"
+      format="YYYY-MM-DD HH:mm:ss"
+      value-format="YYYY-MM-DDTHH:mm:ss"
+      :default-time="[new Date(2000, 0, 1, 0, 0, 0), new Date(2000, 0, 1, 23, 59, 59)]"
       :name="rangeInputNames"
       :aria-label="label"
       :shortcuts="shortcuts"

--- a/src/frontend/src/pages/node/Repositories.vue
+++ b/src/frontend/src/pages/node/Repositories.vue
@@ -1378,7 +1378,11 @@ function repositoryTaskCreatedRangeParams() {
   if (repositoryTaskTimeMode.value === 'range' && repositoryTaskDateRange.value) {
     return {
       created_after: repositoryTaskDateRange.value[0].toISOString(),
-      created_before: repositoryTaskDateRange.value[1].toISOString(),
+      created_before: (() => {
+        const end = new Date(repositoryTaskDateRange.value[1])
+        end.setMilliseconds(999)
+        return end.toISOString()
+      })(),
     }
   }
   return { created_after: undefined, created_before: undefined }
@@ -1404,11 +1408,25 @@ function resetRepositoryTaskAdvancedFilterDraft() {
 }
 
 function applyRepositoryTaskAdvancedFilters() {
-  repositoryTaskDateRange.value = repositoryTaskAdvancedFilterDraft.dateRange
+  repositoryTaskDateRange.value = normalizeRepositoryTaskDateRange(repositoryTaskAdvancedFilterDraft.dateRange)
   if (repositoryTaskDateRange.value) repositoryTaskTimeMode.value = 'range'
   else if (repositoryTaskTimeMode.value === 'range') repositoryTaskTimeMode.value = lastRepositoryTaskQuickTimeMode.value
   repositoryTaskAdvancedFilterOpen.value = false
   applyRepositoryTaskFilters()
+}
+
+function normalizeRepositoryTaskDateRange(range: [Date, Date] | null) {
+  if (!range) return null
+  const [start, selectedEnd] = range
+  const end = new Date(selectedEnd)
+  const now = new Date()
+  if (end.getFullYear() === now.getFullYear()
+    && end.getMonth() === now.getMonth()
+    && end.getDate() === now.getDate()
+    && end.getHours() === 23 && end.getMinutes() === 59 && end.getSeconds() === 59) {
+    return [start, now] as [Date, Date]
+  }
+  return [start, end] as [Date, Date]
 }
 
 function onRepositoryTaskAdvancedFilterClosed() {
@@ -4091,6 +4109,9 @@ function s3ObjectPrefixCell(row: RepositoryRow) {
           <ElDatePicker
             v-model="repositoryTaskAdvancedFilterDraft.dateRange"
             type="datetimerange"
+            format="YYYY-MM-DD HH:mm:ss"
+            value-format="YYYY-MM-DDTHH:mm:ss"
+            :default-time="[new Date(2000, 0, 1, 0, 0, 0), new Date(2000, 0, 1, 23, 59, 59)]"
             :shortcuts="repositoryTaskDateRangeShortcuts"
             :start-placeholder="t('ops.task.startTime')"
             :end-placeholder="t('ops.task.endTime')"

--- a/src/frontend/src/pages/ops/Audit.vue
+++ b/src/frontend/src/pages/ops/Audit.vue
@@ -192,7 +192,7 @@ function pad2(n: number) {
 
 function formatLocalInputDateTime(date?: Date | null) {
   if (!(date instanceof Date) || !Number.isFinite(date.getTime())) return ''
-  return `${date.getFullYear()}-${pad2(date.getMonth() + 1)}-${pad2(date.getDate())}T${pad2(date.getHours())}:${pad2(date.getMinutes())}`
+  return `${date.getFullYear()}-${pad2(date.getMonth() + 1)}-${pad2(date.getDate())}T${pad2(date.getHours())}:${pad2(date.getMinutes())}:${pad2(date.getSeconds())}`
 }
 
 function parseLocalInputDateTime(value: string) {
@@ -202,9 +202,11 @@ function parseLocalInputDateTime(value: string) {
   return Number.isFinite(date.getTime()) ? date : null
 }
 
-function isoDateTimeParam(value: string) {
+function isoDateTimeParam(value: string, inclusiveEnd = false) {
   const date = parseLocalInputDateTime(value)
-  return date ? date.toISOString() : value
+  if (!date) return value
+  if (inclusiveEnd) date.setMilliseconds(999)
+  return date.toISOString()
 }
 
 const auditAdvancedRangeLabel = computed(() => {
@@ -254,7 +256,7 @@ function buildParams(): Record<string, string | number> {
   if (filters.time_range && filters.time_range !== 'custom') p.time_range = filters.time_range
   if (filters.time_range === 'custom') {
     if (filters.start_date) p.start_date = isoDateTimeParam(filters.start_date)
-    if (filters.end_date) p.end_date = isoDateTimeParam(filters.end_date)
+    if (filters.end_date) p.end_date = isoDateTimeParam(filters.end_date, true)
   }
   if (activeCorrelation.value) {
     p.correlation_id = activeCorrelation.value

--- a/src/frontend/src/pages/ops/Tasks.vue
+++ b/src/frontend/src/pages/ops/Tasks.vue
@@ -210,7 +210,7 @@ function pad2(n: number) {
 
 function formatLocalInputDateTime(date?: Date | null) {
   if (!(date instanceof Date) || !Number.isFinite(date.getTime())) return ''
-  return `${date.getFullYear()}-${pad2(date.getMonth() + 1)}-${pad2(date.getDate())}T${pad2(date.getHours())}:${pad2(date.getMinutes())}`
+  return `${date.getFullYear()}-${pad2(date.getMonth() + 1)}-${pad2(date.getDate())}T${pad2(date.getHours())}:${pad2(date.getMinutes())}:${pad2(date.getSeconds())}`
 }
 
 function parseLocalInputDateTime(value: string) {
@@ -345,8 +345,11 @@ function formatTime(iso?: string | null) {
   return formatLocalDateTime(iso, t('ops.task.emptyMark'))
 }
 
-function isoDateParam(date?: Date | null) {
-  return date instanceof Date && Number.isFinite(date.getTime()) ? date.toISOString() : undefined
+function isoDateParam(date?: Date | null, inclusiveEnd = false) {
+  if (!(date instanceof Date) || !Number.isFinite(date.getTime())) return undefined
+  const normalized = new Date(date)
+  if (inclusiveEnd) normalized.setMilliseconds(999)
+  return normalized.toISOString()
 }
 
 function taskTimeRangeParams() {
@@ -358,7 +361,7 @@ function taskTimeRangeParams() {
   if (filters.time_mode === '30d') after = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000).toISOString()
   if (filters.time_mode === 'range' && filters.created_range) {
     after = isoDateParam(filters.created_range[0])
-    before = isoDateParam(filters.created_range[1])
+    before = isoDateParam(filters.created_range[1], true)
   }
   if (filters.time_field === 'finished') {
     return { created_after: undefined, created_before: undefined, finished_after: after, finished_before: before }

--- a/src/frontend/src/pages/protection/components/FlowBackupSourceDetailDrawer.vue
+++ b/src/frontend/src/pages/protection/components/FlowBackupSourceDetailDrawer.vue
@@ -1527,10 +1527,24 @@ function openSourceTaskAdvancedFilterDrawer() {
 }
 
 function applySourceTaskAdvancedFilters() {
-  taskFilterDateRange.value = taskAdvancedFilterDraft.dateRange
+  taskFilterDateRange.value = normalizeSourceTaskDateRange(taskAdvancedFilterDraft.dateRange)
   if (taskFilterDateRange.value) taskFilterTimeMode.value = 'range'
   else if (taskFilterTimeMode.value === 'range') taskFilterTimeMode.value = lastSourceTaskQuickTimeMode.value
   taskAdvancedFilterOpen.value = false
+}
+
+function normalizeSourceTaskDateRange(range: [Date, Date] | null) {
+  if (!range) return null
+  const [start, selectedEnd] = range
+  const end = new Date(selectedEnd)
+  const now = new Date()
+  if (end.getFullYear() === now.getFullYear()
+    && end.getMonth() === now.getMonth()
+    && end.getDate() === now.getDate()
+    && end.getHours() === 23 && end.getMinutes() === 59 && end.getSeconds() === 59) {
+    return [start, now] as [Date, Date]
+  }
+  return [start, end] as [Date, Date]
 }
 
 function onSourceTaskAdvancedFilterClosed() {
@@ -1550,7 +1564,7 @@ function sourceTaskCreatedRangeParams() {
   if (taskFilterTimeMode.value === 'range' && taskFilterDateRange.value) {
     return {
       created_after: isoDateParam(taskFilterDateRange.value[0]),
-      created_before: isoDateParam(taskFilterDateRange.value[1]),
+      created_before: (() => { const end = new Date(taskFilterDateRange.value[1]); end.setMilliseconds(999); return isoDateParam(end) })(),
     }
   }
   return { created_after: undefined, created_before: undefined }
@@ -4328,6 +4342,9 @@ function onClosed() {
         <ElDatePicker
           v-model="taskAdvancedFilterDraft.dateRange"
           type="datetimerange"
+          format="YYYY-MM-DD HH:mm:ss"
+          value-format="YYYY-MM-DDTHH:mm:ss"
+          :default-time="[new Date(2000, 0, 1, 0, 0, 0), new Date(2000, 0, 1, 23, 59, 59)]"
           :shortcuts="sourceTaskDateRangeShortcuts"
           :start-placeholder="t('ops.task.startTime')"
           :end-placeholder="t('ops.task.endTime')"

--- a/src/frontend/src/pages/protection/components/ProtectionPolicyEditorForm.vue
+++ b/src/frontend/src/pages/protection/components/ProtectionPolicyEditorForm.vue
@@ -455,8 +455,8 @@ function toggleScheduleMonthDay(day: number) {
               v-model="policyForm.scheduleStartsAt"
               type="datetime"
               class="schedule-context-control"
-              format="YYYY-MM-DD HH:mm"
-              value-format="YYYY-MM-DDTHH:mm"
+              format="YYYY-MM-DD HH:mm:ss"
+              value-format="YYYY-MM-DDTHH:mm:ss"
               :placeholder="t('protection.policiesPage.scheduleStartsAtPlaceholder')"
             />
           </ElFormItem>


### PR DESCRIPTION
## Summary

- render date-time controls with second precision across task, audit, repository, source, and policy flows
- make calendar-selected custom ranges cover the selected final second and use the current time when ending today
- preserve date-only Usage filtering while keeping its inclusive end-date behavior

Closes #584

## Testing

- `npm run build`
- `npm run test -- --run src/components/HflDateTimeRangePicker.test.ts`
- `git diff --check`