### PR TITLE
fix(i18n): refine language selector layout

### DIFF
--- a/src/frontend/src/app/layout/TopNav.vue
+++ b/src/frontend/src/app/layout/TopNav.vue
@@ -103,10 +103,6 @@ function handleNavClick(event: MouseEvent, to: string) {
         <span>{{ timezoneOffsetDisplay }}</span>
       </span>
 
-      <span class="desktop-navigation-control">
-        <LanguageSwitcher variant="navigation" />
-      </span>
-
       <span class="desktop-navigation-control"><OrgSwitcher /></span>
 
       <a
@@ -128,6 +124,10 @@ function handleNavClick(event: MouseEvent, to: string) {
       <div class="icon-btn alerts-btn">
         <NavNotificationPopover />
       </div>
+
+      <span class="desktop-navigation-control">
+        <LanguageSwitcher variant="navigation" />
+      </span>
 
       <NavUserMenu />
     </div>

--- a/src/frontend/src/components/LanguageSwitcher.vue
+++ b/src/frontend/src/components/LanguageSwitcher.vue
@@ -135,7 +135,7 @@ function handleVisibleChange(visible: boolean) {
 <style scoped>
 .language-switcher {
   display: inline-flex;
-  min-width: 0;
+  flex: 0 0 auto;
 }
 
 .language-switcher__trigger,
@@ -155,6 +155,7 @@ function handleVisibleChange(visible: boolean) {
 }
 
 .language-switcher__trigger {
+  flex: 0 0 auto;
   cursor: pointer;
   transition: background-color 0.15s ease, border-color 0.15s ease;
 }
@@ -180,10 +181,9 @@ function handleVisibleChange(visible: boolean) {
 }
 
 .language-switcher__current {
-  overflow: hidden;
   font-size: 13px;
   font-weight: 500;
-  text-overflow: ellipsis;
+  line-height: 1.4;
 }
 
 .language-switcher__chevron {
@@ -202,6 +202,20 @@ function handleVisibleChange(visible: boolean) {
 
 .language-switcher--navigation {
   color: var(--nav-text-secondary, rgba(255, 255, 255, 0.78));
+}
+
+.language-switcher--navigation .language-switcher__trigger,
+.language-switcher--navigation.language-switcher--static {
+  min-height: 32px;
+  padding: 5px 9px;
+  background: var(--tz-bg, rgba(255, 255, 255, 0.045));
+  border-color: var(--tz-border, rgba(255, 255, 255, 0.1));
+}
+
+.language-switcher--navigation .language-switcher__trigger:hover,
+.language-switcher--navigation .language-switcher__trigger:focus-visible {
+  background: var(--icon-btn-hover-bg, rgba(255, 255, 255, 0.08));
+  border-color: rgba(255, 255, 255, 0.18);
 }
 
 .language-switcher--mobile {
@@ -246,10 +260,6 @@ function handleVisibleChange(visible: boolean) {
 @media (max-width: 540px) {
   .language-switcher--auth .language-switcher__trigger {
     padding-inline: 7px;
-  }
-
-  .language-switcher--auth .language-switcher__current {
-    max-width: 92px;
   }
 }
 </style>

--- a/src/frontend/src/components/MobileHeaderUtilities.test.ts
+++ b/src/frontend/src/components/MobileHeaderUtilities.test.ts
@@ -9,7 +9,10 @@ function source(path: string) {
 const appShell = source('src/app/layout/AppShell.vue')
 const topNav = source('src/app/layout/TopNav.vue')
 const drawer = source('src/components/MobileNavigationDrawer.vue')
+const languageSwitcher = source('src/components/LanguageSwitcher.vue')
 const userMenu = source('src/components/NavUserMenu.vue')
+const login = source('src/pages/auth/Login.vue')
+const register = source('src/pages/auth/Register.vue')
 const dropdownStyles = source('src/styles/nav-dropdown-panel.css')
 const locale = source('src/locales/en.ts')
 
@@ -21,6 +24,28 @@ describe('mobile header utilities', () => {
     expect(topNav).toContain('<LanguageSwitcher variant="navigation" />')
     expect(drawer).toContain('variant="mobile"')
     expect(topNav).not.toContain('fetchDeployProfile')
+  })
+
+  it('keeps language labels readable and groups the desktop selector with user utilities', () => {
+    const notificationsIndex = topNav.indexOf('<NavNotificationPopover />')
+    const languageIndex = topNav.indexOf('<LanguageSwitcher variant="navigation" />')
+    const userIndex = topNav.indexOf('<NavUserMenu />')
+
+    expect(notificationsIndex).toBeGreaterThan(-1)
+    expect(languageIndex).toBeGreaterThan(notificationsIndex)
+    expect(userIndex).toBeGreaterThan(languageIndex)
+    expect(languageSwitcher).toMatch(
+      /\.language-switcher__current\s*{[\s\S]*?line-height:\s*1\.4/,
+    )
+    expect(languageSwitcher).toMatch(
+      /\.language-switcher--navigation \.language-switcher__trigger,[\s\S]*?border-color:\s*var\(--tz-border/,
+    )
+    expect(login).toMatch(
+      /\.login-box-title\s*{[\s\S]*?grid-template-columns:\s*minmax\(0, 1fr\) auto;[\s\S]*?align-items:\s*center/,
+    )
+    expect(register).toMatch(
+      /\.register-box-title\s*{[\s\S]*?grid-template-columns:\s*minmax\(0, 1fr\) auto;[\s\S]*?align-items:\s*center/,
+    )
   })
 
   it('keeps hidden desktop utilities reachable from mobile surfaces', () => {

--- a/src/frontend/src/pages/auth/Login.vue
+++ b/src/frontend/src/pages/auth/Login.vue
@@ -27,7 +27,7 @@ const emailSignupEnabled = ref(false)
 const passwordResetAvailable = ref(false)
 const emailCodeLoginAvailable = ref(false)
 const showEula = appConfig.showEula
-const { t, locale } = useI18n()
+const { t } = useI18n()
 const router = useRouter()
 const route = useRoute()
 const sessionNoticeDismissed = ref(false)
@@ -594,11 +594,8 @@ onMounted(async () => {
 
     <!-- Login Form Box -->
     <div class="login-form-box">
-      <div
-        class="login-box-title"
-        :class="{ 'title-en': locale === 'en' }"
-      >
-        <span :class="{ '!text-base': locale === 'en' }">
+      <div class="login-box-title">
+        <span class="login-box-title__copy">
           {{ cardTitle }}
         </span>
         <LanguageSwitcher
@@ -937,14 +934,19 @@ onMounted(async () => {
 }
 
 .login-box-title {
-  display: flex;
-  justify-content: space-between;
-  font-size: 22px !important;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 12px;
   font-weight: 600;
   color: #FFF;
 }
-.login-box-title.title-en {
-  font-size: 20px !important;
+
+.login-box-title__copy {
+  min-width: 0;
+  font-size: 18px;
+  line-height: 1.35;
+  overflow-wrap: normal;
 }
 
 .login-box-content {
@@ -1319,6 +1321,10 @@ onMounted(async () => {
 
   .login-form-box {
     padding: 24px 16px;
+  }
+
+  .login-box-title__copy {
+    font-size: 20px;
   }
 
   .login-box-content {

--- a/src/frontend/src/pages/auth/Register.vue
+++ b/src/frontend/src/pages/auth/Register.vue
@@ -15,7 +15,7 @@ import { appConfig } from '../../lib/appConfig'
 import { trackAppEvent } from '../../lib/analytics'
 import { LOGIN_ROUTE_NAME } from '../../lib/loginNavigation'
 
-const { t, locale } = useI18n()
+const { t } = useI18n()
 const router = useRouter()
 const route = useRoute()
 const showEula = appConfig.showEula
@@ -440,11 +440,8 @@ onUnmounted(() => {
     </div>
 
     <div class="register-form-box">
-      <div
-        class="register-box-title"
-        :class="{ 'title-en': locale === 'en' }"
-      >
-        <span :class="{ '!text-base': locale === 'en' }">{{ t('register.welcomeTitle') }}</span>
+      <div class="register-box-title">
+        <span class="register-box-title__copy">{{ t('register.welcomeTitle') }}</span>
         <LanguageSwitcher variant="auth" />
       </div>
 
@@ -737,15 +734,20 @@ onUnmounted(() => {
 }
 
 .register-box-title {
-  display: flex;
-  justify-content: space-between;
-  font-size: 22px !important;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 12px;
   font-weight: 600;
   color: #FFF;
   margin-top: 4px;
 }
-.register-box-title.title-en {
-  font-size: 20px !important;
+
+.register-box-title__copy {
+  min-width: 0;
+  font-size: 18px;
+  line-height: 1.35;
+  overflow-wrap: normal;
 }
 
 .register-box-content {
@@ -1148,6 +1150,10 @@ onUnmounted(() => {
 
   .register-form-box {
     padding: 24px 16px;
+  }
+
+  .register-box-title__copy {
+    font-size: 20px;
   }
 
   .register-box-content {


### PR DESCRIPTION
## Summary
- prevent language labels from clipping or shrinking
- align authentication headings and language controls across responsive layouts
- position the desktop language selector with notification and user utilities
- add regression coverage for layout invariants

## Validation
- 31 related tests passed
- npm run lint (no errors; one unrelated existing warning)
- npm exec vue-tsc -- --noEmit
- npm run build
- python3 tools/quality/check-english-source.py
- git diff --check