### PR TITLE
fix(restore): join Windows source paths into restore targets

### DIFF
--- a/src/backend/apps/restore/services/interface.py
+++ b/src/backend/apps/restore/services/interface.py
@@ -1339,7 +1339,7 @@ def _finalize_restore_item_targets(
             target_path = item["dispatch_target_path"]
             if len(group) > 1:
                 target_path = _join_target_path(
-                    posixpath.dirname(natural_target),
+                    _path_parent(natural_target),
                     _safe_restore_name(
                         item["effective_source_path"],
                         source_path_type=item.get("source_path_type"),
@@ -2433,11 +2433,22 @@ def _is_windows_path(path: str) -> bool:
     return "\\" in path or (len(path) >= 2 and path[1] == ":")
 
 
+def _path_parent(path: str) -> str:
+    if _is_windows_path(str(path)):
+        return ntpath.dirname(path)
+    return posixpath.dirname(path)
+
+
 def _path_basename(path: str) -> str:
-    return posixpath.basename(_normalize_path(path).rstrip("/")) or "snapshot"
+    raw = str(path or "").strip().rstrip("/\\")
+    if _is_windows_path(raw):
+        return ntpath.basename(ntpath.normpath(raw)) or "snapshot"
+    return posixpath.basename(_normalize_path(raw)) or "snapshot"
 
 
 def _join_target_path(parent: str, leaf: str) -> str:
+    if _is_windows_path(str(parent)) or _is_windows_path(str(leaf)):
+        return ntpath.normpath(ntpath.join(str(parent or ""), str(leaf or "")))
     return _normalize_path(posixpath.join(_normalize_path(parent), leaf))
 
 
@@ -2477,8 +2488,12 @@ def _numbered_restore_target_path(
     source_path_type: str | None = None,
     selected_paths: tuple[str, ...] = (),
 ) -> str:
-    parent = posixpath.dirname(target_path)
-    leaf = posixpath.basename(target_path)
+    parent = _path_parent(target_path)
+    leaf = (
+        ntpath.basename(target_path)
+        if _is_windows_path(target_path)
+        else posixpath.basename(target_path)
+    )
     ext = _restore_file_extension(
         source_path=source_path,
         source_path_type=source_path_type,

--- a/src/backend/apps/restore/tests/test_restore_api.py
+++ b/src/backend/apps/restore/tests/test_restore_api.py
@@ -1693,6 +1693,32 @@ class RestoreApiTests(TestCase):
 
         self.assertEqual(name, "t--from-root_d_logs.log")
 
+    def test_finalize_restore_item_targets_joins_windows_restore_target(self):
+        items = restore_service._finalize_restore_item_targets(
+            [
+                {
+                    "source_snapshot_directory_id": 1,
+                    "selected_paths": [],
+                    "target_source_path": r"C:\备份测试",
+                    "source_path_type": BackupSourceSnapshotDirectory.PathType.DIRECTORY,
+                    "restore_dir": r"C:\恢复目录",
+                    "conflict_mode": "overwrite",
+                }
+            ]
+        )
+
+        self.assertEqual(items[0]["target_path"], r"C:\恢复目录\备份测试")
+
+    def test_numbered_restore_target_path_keeps_windows_semantics(self):
+        numbered = restore_service._numbered_restore_target_path(
+            r"C:\恢复目录\test.txt",
+            counter=2,
+            source_path=r"C:\data\test.txt",
+            source_path_type=BackupSourceSnapshotDirectory.PathType.FILE,
+        )
+
+        self.assertEqual(numbered, r"C:\恢复目录\test-2.txt")
+
     def test_run_restore_plans_for_source_keeps_distinct_selected_file_names_unsuffixed(
         self,
     ):


### PR DESCRIPTION
## Problem

Restoring a Windows source directory into a Windows restore directory fails on the target agent with `RESTORE_AGENT_FAILED` and `mkdir C:\\恢复目录\\C:\\备份测试` (`The filename, directory name, or volume label syntax is incorrect.`). Restoring to Linux works.

## Root cause

Path helpers in `src/backend/apps/restore/services/interface.py` treated every path as POSIX:

- `_path_basename(r"C:\\备份测试")` returned the whole string instead of `备份测试`
- `_join_target_path(r"C:\\恢复目录", "备份测试")` produced `C:\\恢复目录/备份测试` (mixed separators) instead of `C:\\恢复目录\\备份测试`

The broken target was persisted into `restore_record_item.target_path` and dispatched to the Windows agent, whose `os.MkdirAll` then failed. Confirmed in production DB (item target `C:\\恢复目录C/C:\\备份测试C`).

## Fix

Route Windows paths (backslash or drive letter) through `ntpath` in `_path_basename`, `_join_target_path`, `_numbered_restore_target_path`, and the parent lookup used by `_finalize_restore_item_targets`. POSIX behavior is unchanged.

## Tests

- `test_finalize_restore_item_targets_joins_windows_restore_target` (production scenario)
- `test_numbered_restore_target_path_keeps_windows_semantics`
- Existing Windows-related restore tests still pass.

## Verification

- 66/68 restore API tests pass; the 2 failures (`test_cancel_pending_*`) also fail on clean main (pre-existing environment issue, unrelated).