### PR TITLE
fix(source): align deregistration task steps

### DIFF
--- a/src/backend/apps/source/services/internal/backup_source_delete.py
+++ b/src/backend/apps/source/services/internal/backup_source_delete.py
@@ -81,8 +81,8 @@ _ACTIVE_TASK_STATUSES = {
 _SOURCE_UNREGISTER_STEPS = [
     "prepare_source_unregister",
     "cleanup_direct_nas_repositories",
-    "reset_backup_config",
     "cleanup_source_endpoint",
+    "reset_backup_config",
     "finalize_source_unregister",
 ]
 
@@ -2118,14 +2118,6 @@ def _complete_source_unregister_transaction(
     }
     _set_unregister_step(
         task=locked_task,
-        step_name="reset_backup_config",
-        status=TaskStep.Status.SUCCESS,
-        progress=60,
-        message="Backup configuration data reset",
-        metadata={"cleanup": cleanup},
-    )
-    _set_unregister_step(
-        task=locked_task,
         step_name="cleanup_source_endpoint",
         status=(
             TaskStep.Status.WARNING
@@ -2145,6 +2137,14 @@ def _complete_source_unregister_transaction(
             "cleanup_complete": bool(response.get("cleanup_complete", True)),
             "retained_resources": response.get("retained_resources") or [],
         },
+    )
+    _set_unregister_step(
+        task=locked_task,
+        step_name="reset_backup_config",
+        status=TaskStep.Status.SUCCESS,
+        progress=95,
+        message="Backup configuration data reset",
+        metadata={"cleanup": cleanup},
     )
     _set_unregister_step(
         task=locked_task,
@@ -2396,9 +2396,9 @@ def _execute_source_unregister_work(
         _set_unregister_step(
             task=unregister_task,
             step_name="reset_backup_config",
-            status=TaskStep.Status.RUNNING,
+            status=TaskStep.Status.PENDING,
             progress=35,
-            message="Resetting backup configuration data",
+            message="Backup configuration reset deferred until endpoint cleanup completes",
         )
         # Remote NAS work must run after the preparation transaction commits
         # and outside the database cleanup transaction below.  Agent task
@@ -2516,7 +2516,7 @@ def _execute_source_unregister_work(
         step_name="reset_backup_config",
         status=TaskStep.Status.PENDING,
         progress=35,
-        message="Backup configuration data retained until endpoint cleanup completes",
+        message="Backup configuration reset deferred until endpoint cleanup completes",
         metadata={"cleanup": aggregate_cleanup},
     )
     _set_unregister_step(

--- a/src/backend/apps/source/tests/test_api.py
+++ b/src/backend/apps/source/tests/test_api.py
@@ -31,6 +31,8 @@ from apps.storage.repositories.models import Repository
 from apps.task.models import Task, TaskResource, TaskStep
 from apps.task.services.interface import complete_task
 from apps.source.services.internal.backup_source_delete import (
+    _create_source_unregister_task,
+    _set_unregister_step,
     reconcile_stuck_source_unregister_tasks,
     run_source_unregister_task,
 )
@@ -3198,6 +3200,47 @@ class BackupSourceBulkDeleteTests(TestCase):
                 ref_id=resource.id,
             ).exists()
         )
+
+    def test_source_unregister_endpoint_cleanup_precedes_reset_in_new_tasks(self):
+        task = _create_source_unregister_task(
+            org=self.org,
+            selectable_id=f"agent:{self.agent.id}",
+            force=True,
+        )
+
+        self.assertEqual(
+            list(task.steps.order_by("step_index").values_list("step_name", flat=True)),
+            [
+                "prepare_source_unregister",
+                "cleanup_direct_nas_repositories",
+                "cleanup_source_endpoint",
+                "reset_backup_config",
+                "finalize_source_unregister",
+            ],
+        )
+
+        _set_unregister_step(
+            task=task,
+            step_name="reset_backup_config",
+            status=TaskStep.Status.PENDING,
+            progress=35,
+            message="Backup configuration reset deferred until endpoint cleanup completes",
+        )
+        _set_unregister_step(
+            task=task,
+            step_name="cleanup_source_endpoint",
+            status=TaskStep.Status.RUNNING,
+            progress=70,
+            message="Cleaning up source endpoints",
+        )
+
+        task.refresh_from_db()
+        endpoint_step = task.steps.get(step_name="cleanup_source_endpoint")
+        reset_step = task.steps.get(step_name="reset_backup_config")
+        self.assertLess(endpoint_step.step_index, reset_step.step_index)
+        self.assertEqual(endpoint_step.status, TaskStep.Status.RUNNING)
+        self.assertEqual(reset_step.status, TaskStep.Status.PENDING)
+        self.assertEqual(task.current_step, "cleanup_source_endpoint")
 
 
 class SourceUnregisterCeleryTests(TestCase):


### PR DESCRIPTION
## Problem and root cause

Source deregistration displayed backup configuration reset before source endpoint cleanup. During the asynchronous Agent uninstall wait, the earlier reset step was pending while endpoint cleanup was running, which made task progress appear out of order.

## Solution

Order endpoint cleanup before backup configuration reset for newly created deregistration tasks. Keep reset pending while endpoint cleanup is active and mark it complete only after the endpoint cleanup reaches its terminal state. Existing persisted task step indexes are unchanged.

## Validation

- Targeted deregistration step-order regression test
- `apps.source.tests.test_api.BackupSourceBulkDeleteTests`
- `apps.source.tests.test_api.SourceUnregisterCeleryTests`
- `apps.source.tests` (191 tests)
- Ruff, Python compile check, English-source check, and `git diff --check`
- Manual testing: passed

## Risks and compatibility

Only newly created tasks receive the corrected display order. Existing task records retain their persisted step indexes, avoiding a history rewrite while preserving the existing endpoint-cleanup safety boundary.

Fixes #590
