### PR TITLE
fix(storage): allow S3 repository create after ownership claim

### DIFF
--- a/src/backend/apps/storage/services/internal/kopia_cli.py
+++ b/src/backend/apps/storage/services/internal/kopia_cli.py
@@ -581,5 +581,10 @@ def _repository_already_exists(result: subprocess.CompletedProcess[str]) -> bool
     output = f"{result.stdout}\n{result.stderr}".lower()
     return any(
         token in output
-        for token in ("already exists", "already initialized", "repository exists")
+        for token in (
+            "already exists",
+            "already initialized",
+            "repository exists",
+            "found existing data in storage location",
+        )
     )

--- a/src/backend/apps/storage/services/internal/repository_initializer.py
+++ b/src/backend/apps/storage/services/internal/repository_initializer.py
@@ -158,18 +158,21 @@ def initialize_s3_repository(repository: Repository) -> None:
         # weaken persisted-repository cleanup authorization.
         # Kopia refuses to create a repository inside a Prefix that already
         # contains any object - including the ownership marker written by the
-        # Claim above (it reports "found existing data in storage location").
-        # Hide the marker while Kopia initializes the empty Prefix, then
-        # restore it so the ownership proof survives. Unsaved models (older
-        # unit callers) have no Claim and therefore no marker to hide.
+        # Claim (it reports "found existing data in storage location").
+        # Claim first so the marker is validated (a residual marker left by a
+        # failed attempt is matched and kept; a fresh Prefix is atomically
+        # claimed). Only then hide the marker while Kopia initializes the empty
+        # Prefix, and restore it afterwards so the ownership proof survives.
+        # Unsaved models (older unit callers) have no Claim and therefore no
+        # marker to hide.
+        if repository.pk is not None:
+            claim_s3_repository_ownership(repository)
         marker_context = (
             s3_ownership_marker_hidden(repository)
             if repository.pk is not None
             else nullcontext()
         )
         with marker_context:
-            if repository.pk is not None:
-                claim_s3_repository_ownership(repository)
             create_s3_repository(repository)
     except S3UrlStyleProbeError as exc:
         raise RepositoryInitializationError(_sanitize(str(exc), repository)) from exc

--- a/src/backend/apps/storage/services/internal/repository_initializer.py
+++ b/src/backend/apps/storage/services/internal/repository_initializer.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from contextlib import nullcontext
 from ipaddress import ip_address
 from time import sleep
 from urllib.parse import urlparse
@@ -18,6 +19,7 @@ from apps.storage.services.internal.repository_errors import (
 from apps.storage.services.internal.repository_ownership import (
     RepositoryOwnershipError,
     claim_s3_repository_ownership,
+    s3_ownership_marker_hidden,
     verify_s3_repository_ownership,
 )
 from apps.storage.services.internal.s3_client import (
@@ -154,9 +156,21 @@ def initialize_s3_repository(repository: Repository) -> None:
         # is no database Claim to coordinate for such an object); those calls
         # cannot be used by the Controller lifecycle and therefore must not
         # weaken persisted-repository cleanup authorization.
-        if repository.pk is not None:
-            claim_s3_repository_ownership(repository)
-        create_s3_repository(repository)
+        # Kopia refuses to create a repository inside a Prefix that already
+        # contains any object - including the ownership marker written by the
+        # Claim above (it reports "found existing data in storage location").
+        # Hide the marker while Kopia initializes the empty Prefix, then
+        # restore it so the ownership proof survives. Unsaved models (older
+        # unit callers) have no Claim and therefore no marker to hide.
+        marker_context = (
+            s3_ownership_marker_hidden(repository)
+            if repository.pk is not None
+            else nullcontext()
+        )
+        with marker_context:
+            if repository.pk is not None:
+                claim_s3_repository_ownership(repository)
+            create_s3_repository(repository)
     except S3UrlStyleProbeError as exc:
         raise RepositoryInitializationError(_sanitize(str(exc), repository)) from exc
     except KopiaRepositoryAlreadyExistsError as exc:

--- a/src/backend/apps/storage/services/internal/repository_ownership.py
+++ b/src/backend/apps/storage/services/internal/repository_ownership.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import hmac
 import json
+from contextlib import contextmanager
 from dataclasses import dataclass
 
 from django.core.exceptions import ValidationError
@@ -24,8 +25,10 @@ from apps.storage.services.internal.repository_secrets import (
     resolve_repository_secrets,
 )
 from apps.storage.services.internal.s3_client import (
+    delete_s3_object,
     identify_s3_namespace,
     list_s3_object_keys,
+    put_s3_object,
     put_s3_object_if_absent,
     read_s3_object,
     s3_prefix_has_any_state,
@@ -466,6 +469,30 @@ def _require_matching_marker(
                 "Repository ownership belongs to another repository."
             )
     return marker
+
+
+@contextmanager
+def s3_ownership_marker_hidden(repository: Repository):
+    """Hide the ownership marker while Kopia initializes an empty Prefix.
+
+    ``claim_s3_repository_ownership`` atomically writes an ownership marker
+    before the physical repository is created. Kopia, however, refuses
+    ``repository create`` when the target Prefix already contains *any*
+    object - including our own marker - and reports "found existing data in
+    storage location". Temporarily remove the marker for the duration of the
+    physical create and restore it afterwards so the ownership proof survives.
+    """
+    s3_args = _s3_args(repository)
+    marker_key = _marker_key(repository)
+    marker = read_s3_object(**s3_args, key=marker_key)
+    if marker is None:
+        yield
+        return
+    delete_s3_object(**s3_args, key=marker_key)
+    try:
+        yield
+    finally:
+        put_s3_object(**s3_args, key=marker_key, body=marker)
 
 
 def _sign_marker(payload: dict[str, object]) -> str:

--- a/src/backend/apps/storage/services/internal/s3_client.py
+++ b/src/backend/apps/storage/services/internal/s3_client.py
@@ -414,6 +414,73 @@ def read_s3_object(
         ) from exc
 
 
+def delete_s3_object(
+    *,
+    endpoint: str | None,
+    region: str | None,
+    bucket: str,
+    key: str,
+    access_key_id: str,
+    secret_access_key: str,
+    s3_url_style: str | None = None,
+    use_tls: bool = True,
+    timeout_seconds: float = 15,
+) -> None:
+    """Remove a single owned object (used to hide the ownership marker)."""
+    client = _client(
+        endpoint=endpoint,
+        region=region,
+        access_key_id=access_key_id,
+        secret_access_key=secret_access_key,
+        s3_url_style=s3_url_style,
+        use_tls=use_tls,
+        timeout_seconds=timeout_seconds,
+    )
+    try:
+        client.delete_object(Bucket=bucket, Key=key)
+    except (BotoCoreError, ClientError) as exc:
+        raise S3ClientError(
+            _error_message("Unable to hide repository ownership marker", exc)
+        ) from exc
+
+
+def put_s3_object(
+    *,
+    endpoint: str | None,
+    region: str | None,
+    bucket: str,
+    key: str,
+    body: bytes,
+    access_key_id: str,
+    secret_access_key: str,
+    s3_url_style: str | None = None,
+    use_tls: bool = True,
+    timeout_seconds: float = 15,
+) -> None:
+    """Overwrite an existing object (used to restore the ownership marker)."""
+    client = _client(
+        endpoint=endpoint,
+        region=region,
+        access_key_id=access_key_id,
+        secret_access_key=secret_access_key,
+        s3_url_style=s3_url_style,
+        use_tls=use_tls,
+        timeout_seconds=timeout_seconds,
+    )
+    try:
+        client.put_object(
+            Bucket=bucket,
+            Key=key,
+            Body=body,
+            ContentLength=len(body),
+            ContentType="application/json",
+        )
+    except (BotoCoreError, ClientError, ParamValidationError) as exc:
+        raise S3ClientError(
+            _error_message("Unable to restore repository ownership marker", exc)
+        ) from exc
+
+
 def put_s3_object_if_absent(
     *,
     platform: str | None = None,

--- a/src/backend/apps/storage/tests/test_kopia_maintenance.py
+++ b/src/backend/apps/storage/tests/test_kopia_maintenance.py
@@ -116,6 +116,27 @@ class KopiaRepositoryCreateCommandTests(SimpleTestCase):
             ["repository", "create", "s3"],
         )
 
+    @patch("apps.storage.services.internal.kopia_cli._run_repository_command")
+    def test_prefix_with_ownership_marker_is_rejected_as_existing(self, run_command):
+        run_command.return_value = CompletedProcess(
+            [],
+            1,
+            stdout="",
+            stderr="unable to get repository storage: found existing data in storage location",
+        )
+        repository = Repository(
+            id=53,
+            name="S3 repository",
+            repo_type=Repository.Type.S3,
+            s3_bucket="bucket",
+            config={"endpoint": "s3.example.test", "prefix": "hfl/"},
+        )
+
+        with self.assertRaises(KopiaRepositoryAlreadyExistsError):
+            create_s3_repository(repository)
+
+        self.assertEqual(run_command.call_count, 1)
+
 
 class KopiaSnapshotDeleteCommandTests(SimpleTestCase):
     @patch(

--- a/src/backend/apps/storage/tests/test_repository_location.py
+++ b/src/backend/apps/storage/tests/test_repository_location.py
@@ -653,7 +653,7 @@ class RepositoryLocationClaimTests(TestCase):
         delete_marker.assert_not_called()
         put_marker.assert_not_called()
 
-    def test_initialize_s3_hides_ownership_marker_during_kopia_create(self):
+    def test_initialize_s3_claims_marker_before_hiding_it_for_kopia_create(self):
         repository = self._s3_repository(name="Initialized", prefix="hfl/")
         marker = (
             b'{"deployment_uuid":"d","repository_uuid":"r",'
@@ -666,9 +666,6 @@ class RepositoryLocationClaimTests(TestCase):
             call_sequence.append("create")
 
         with (
-            mock.patch(
-                "apps.storage.services.internal.repository_initializer.claim_s3_repository_ownership"
-            ),
             mock.patch(
                 "apps.storage.services.internal.repository_initializer.create_s3_repository",
                 side_effect=fake_create,
@@ -688,6 +685,13 @@ class RepositoryLocationClaimTests(TestCase):
             mock.patch(
                 "apps.storage.services.internal.repository_initializer.check_s3_bucket_readable"
             ),
+            # Run the real claim: a residual marker is validated and kept, then
+            # hidden for the physical create and restored afterwards. A claim
+            # that runs while the marker is already hidden would rewrite the
+            # marker and make Kopia reject the create again.
+            mock.patch(
+                "apps.storage.services.internal.repository_ownership._ensure_s3_namespace_resolved"
+            ),
             mock.patch(
                 "apps.storage.services.internal.repository_ownership._s3_args",
                 return_value={},
@@ -701,6 +705,19 @@ class RepositoryLocationClaimTests(TestCase):
                 return_value=marker,
             ),
             mock.patch(
+                "apps.storage.services.internal.repository_ownership._require_matching_marker",
+                side_effect=lambda *_args, **_kwargs: call_sequence.append("claimed"),
+            ),
+            mock.patch(
+                "apps.storage.services.internal.repository_ownership._reject_foreign_ancestor_markers"
+            ),
+            mock.patch(
+                "apps.storage.services.internal.repository_ownership._reject_foreign_descendant_markers"
+            ),
+            mock.patch(
+                "apps.storage.services.internal.repository_ownership.mark_repository_location_ownership_verified"
+            ),
+            mock.patch(
                 "apps.storage.services.internal.repository_ownership.delete_s3_object",
                 side_effect=lambda **_kwargs: call_sequence.append("deleted"),
             ),
@@ -711,7 +728,9 @@ class RepositoryLocationClaimTests(TestCase):
         ):
             initialize_s3_repository(repository)
 
-        self.assertEqual(call_sequence, ["deleted", "create", "restored"])
+        self.assertEqual(
+            call_sequence, ["claimed", "deleted", "create", "restored"]
+        )
 
     @mock.patch(
         "apps.storage.services.internal.repository_ownership.mark_repository_location_ownership_verified"

--- a/src/backend/apps/storage/tests/test_repository_location.py
+++ b/src/backend/apps/storage/tests/test_repository_location.py
@@ -19,11 +19,14 @@ from apps.storage.services.internal.repository_location import (
     reserve_direct_nas_location,
     reserve_repository_location,
 )
+from apps.storage.services.internal.repository_initializer import initialize_s3_repository
 from apps.storage.services.internal.repository_ownership import (
     RepositoryOwnershipError,
     claim_s3_repository_ownership,
+    s3_ownership_marker_hidden,
     verify_s3_repository_ownership,
 )
+from apps.storage.services.internal.s3_url_style import S3_URL_STYLE_PATH
 
 
 class RepositoryLocationClaimTests(TestCase):
@@ -553,6 +556,162 @@ class RepositoryLocationClaimTests(TestCase):
                 verify_s3_repository_ownership(repository, adopt_legacy=True)
 
         put_marker.assert_not_called()
+
+    def test_s3_ownership_marker_hidden_removes_marker_before_create_and_restores_after(self):
+        repository = self._s3_repository(name="Hidden marker", prefix="hfl/")
+        marker = (
+            b'{"deployment_uuid":"d","repository_uuid":"r",'
+            b'"location_digest":"l","format_version":1,"signature":"sig"}'
+        )
+        calls: list[str] = []
+
+        with (
+            mock.patch(
+                "apps.storage.services.internal.repository_ownership._s3_args",
+                return_value={},
+            ),
+            mock.patch(
+                "apps.storage.services.internal.repository_ownership._marker_key",
+                return_value="hfl/.hyperfilelens/repository-owner-v1.json",
+            ),
+            mock.patch(
+                "apps.storage.services.internal.repository_ownership.read_s3_object",
+                return_value=marker,
+            ),
+            mock.patch(
+                "apps.storage.services.internal.repository_ownership.delete_s3_object",
+                side_effect=lambda **_kwargs: calls.append("deleted"),
+            ),
+            mock.patch(
+                "apps.storage.services.internal.repository_ownership.put_s3_object",
+                side_effect=lambda **_kwargs: calls.append("restored"),
+            ),
+        ):
+            with s3_ownership_marker_hidden(repository):
+                calls.append("create")
+
+        self.assertEqual(calls, ["deleted", "create", "restored"])
+
+    def test_s3_ownership_marker_hidden_restores_marker_when_create_fails(self):
+        repository = self._s3_repository(name="Failed create", prefix="hfl/")
+        marker = (
+            b'{"deployment_uuid":"d","repository_uuid":"r",'
+            b'"location_digest":"l","format_version":1,"signature":"sig"}'
+        )
+
+        with (
+            mock.patch(
+                "apps.storage.services.internal.repository_ownership._s3_args",
+                return_value={},
+            ),
+            mock.patch(
+                "apps.storage.services.internal.repository_ownership._marker_key",
+                return_value="hfl/.hyperfilelens/repository-owner-v1.json",
+            ),
+            mock.patch(
+                "apps.storage.services.internal.repository_ownership.read_s3_object",
+                return_value=marker,
+            ),
+            mock.patch(
+                "apps.storage.services.internal.repository_ownership.delete_s3_object"
+            ),
+            mock.patch(
+                "apps.storage.services.internal.repository_ownership.put_s3_object"
+            ) as put_marker,
+        ):
+            with self.assertRaises(RuntimeError):
+                with s3_ownership_marker_hidden(repository):
+                    raise RuntimeError("kopia create failed")
+
+        put_marker.assert_called_once()
+
+    def test_s3_ownership_marker_hidden_noop_without_marker(self):
+        repository = self._s3_repository(name="No marker", prefix="hfl/")
+        with (
+            mock.patch(
+                "apps.storage.services.internal.repository_ownership._s3_args",
+                return_value={},
+            ),
+            mock.patch(
+                "apps.storage.services.internal.repository_ownership._marker_key",
+                return_value="hfl/.hyperfilelens/repository-owner-v1.json",
+            ),
+            mock.patch(
+                "apps.storage.services.internal.repository_ownership.read_s3_object",
+                return_value=None,
+            ),
+            mock.patch(
+                "apps.storage.services.internal.repository_ownership.delete_s3_object"
+            ) as delete_marker,
+            mock.patch(
+                "apps.storage.services.internal.repository_ownership.put_s3_object"
+            ) as put_marker,
+        ):
+            with s3_ownership_marker_hidden(repository):
+                pass
+
+        delete_marker.assert_not_called()
+        put_marker.assert_not_called()
+
+    def test_initialize_s3_hides_ownership_marker_during_kopia_create(self):
+        repository = self._s3_repository(name="Initialized", prefix="hfl/")
+        marker = (
+            b'{"deployment_uuid":"d","repository_uuid":"r",'
+            b'"location_digest":"l","format_version":1,"signature":"sig"}'
+        )
+        call_sequence: list[str] = []
+
+        def fake_create(repository):
+            # Kopia create must run while the marker is hidden.
+            call_sequence.append("create")
+
+        with (
+            mock.patch(
+                "apps.storage.services.internal.repository_initializer.claim_s3_repository_ownership"
+            ),
+            mock.patch(
+                "apps.storage.services.internal.repository_initializer.create_s3_repository",
+                side_effect=fake_create,
+            ),
+            mock.patch(
+                "apps.storage.services.internal.repository_initializer.resolve_repository_secrets",
+                return_value={},
+            ),
+            mock.patch(
+                "apps.storage.services.internal.repository_initializer.repository_control_endpoint",
+                return_value=None,
+            ),
+            mock.patch(
+                "apps.storage.services.internal.repository_initializer.resolve_s3_url_style",
+                return_value=S3_URL_STYLE_PATH,
+            ),
+            mock.patch(
+                "apps.storage.services.internal.repository_initializer.check_s3_bucket_readable"
+            ),
+            mock.patch(
+                "apps.storage.services.internal.repository_ownership._s3_args",
+                return_value={},
+            ),
+            mock.patch(
+                "apps.storage.services.internal.repository_ownership._marker_key",
+                return_value="hfl/.hyperfilelens/repository-owner-v1.json",
+            ),
+            mock.patch(
+                "apps.storage.services.internal.repository_ownership.read_s3_object",
+                return_value=marker,
+            ),
+            mock.patch(
+                "apps.storage.services.internal.repository_ownership.delete_s3_object",
+                side_effect=lambda **_kwargs: call_sequence.append("deleted"),
+            ),
+            mock.patch(
+                "apps.storage.services.internal.repository_ownership.put_s3_object",
+                side_effect=lambda **_kwargs: call_sequence.append("restored"),
+            ),
+        ):
+            initialize_s3_repository(repository)
+
+        self.assertEqual(call_sequence, ["deleted", "create", "restored"])
 
     @mock.patch(
         "apps.storage.services.internal.repository_ownership.mark_repository_location_ownership_verified"


### PR DESCRIPTION
## Summary
The weekend ownership-claim feature writes an ownership marker under the target S3 Prefix **before** the physical repository is initialized. Kopia refuses `repository create` when the Prefix already contains *any* object — including our own marker — and reports:

```
found existing data in storage location
```

That error token was missing from `_repository_already_exists`, so the failure was not classified as an already-exists conflict and surfaced as the misleading `STORAGE.S3_VALIDATION_FAILED` ("Object storage validation failed. Check the connection settings and IAM permissions, then try again."), while the repository row kept `ownership_verified_at` set.

## Root cause
1. `claim_s3_repository_ownership` atomically writes `hfl/.hyperfilelens/repository-owner-v1.json`
2. `create_s3_repository` → Kopia `repository create s3 --prefix=hfl/` sees a non-empty Prefix → refuses (`found existing data in storage location`)
3. `kopia_cli._repository_already_exists` only matched `already exists / already initialized / repository exists` → fell through to the S3 validation fallback error

## Changes
- **kopia_cli.py**: classify `found existing data in storage location` as an already-exists conflict (aligned with `repository_errors._REPOSITORY_CONFLICT_MARKERS`)
- **repository_ownership.py**: add `s3_ownership_marker_hidden` context manager that hides the ownership marker during Kopia create and restores it afterwards, so first-time creation succeeds
- **repository_initializer.py**: wrap `create_s3_repository` in the marker-hiding context (unsaved-model unit callers keep the old no-claim path)
- **s3_client.py**: add `delete_s3_object` / `put_s3_object` helpers used by the marker lifecycle
- **tests**: regression coverage for the error classification (`test_kopia_maintenance.py`) and the marker hide/restore lifecycle (`test_repository_location.py`); full `apps.storage` suite passes (398 tests)

## Production evidence
Failing repositories (23/24/25/26) share: `prefix=hfl/`, Huawei OBS, `ownership_verified_at` set; repository 8's stored error message is literally `found existing data in storage location`.