### PR TITLE
fix(frontend): prevent sibling menu items with shared path prefix from highlighting together

### DIFF
--- a/src/frontend/src/components/Sidebar.vue
+++ b/src/frontend/src/components/Sidebar.vue
@@ -92,8 +92,34 @@ function isActive(to?: string) {
   if (targetPath === '/platform-ops') {
     return route.path === '/platform-ops' || route.path === '/platform-ops/'
   }
-  return route.path === targetPath || route.path.startsWith(`${targetPath}/`)
+  if (route.path === targetPath) return true
+  if (route.path.startsWith(`${targetPath}/`)) {
+    // Don't highlight if a more specific menu item is a better match
+    for (const otherPath of allMenuPaths.value) {
+      if (
+        otherPath !== targetPath &&
+        otherPath.startsWith(`${targetPath}/`) &&
+        (route.path === otherPath || route.path.startsWith(`${otherPath}/`))
+      ) {
+        return false
+      }
+    }
+    return true
+  }
+  return false
 }
+
+const allMenuPaths = computed(() => {
+  const paths = new Set<string>()
+  function collect(items: MenuItem[]) {
+    for (const item of items) {
+      if (item.to) paths.add(item.to.split('?')[0])
+      if (item.children) collect(item.children)
+    }
+  }
+  collect(props.menus)
+  return paths
+})
 
 function navigateImmediately(to?: string) {
   if (!to || to === route.fullPath) return


### PR DESCRIPTION
## Summary

Fixes #591 — the `isActive` function in the Sidebar component used a `startsWith` prefix check that was too permissive. When navigating to `/ops/alerts/rules`, both the "Alerts" (`/ops/alerts`) and "Alert Rules" (`/ops/alerts/rules`) menu items were highlighted because `/ops/alerts` is a path prefix of `/ops/alerts/rules`.

The fix collects all known menu item paths into a computed set and, when the prefix heuristic matches, checks whether a more specific menu item is a better match for the current route. If a more specific sibling menu item matches, the shorter path is not marked active.

## Changes

- `src/frontend/src/components/Sidebar.vue` — added `allMenuPaths` computed property and refined `isActive` to skip the prefix match when a more specific menu item matches the current route

## Testing

- Type-checked with `vue-tsc --noEmit` — no errors
- Verified the following scenarios:
  - `/ops/alerts` → only "Alerts" highlighted
  - `/ops/alerts/rules` → only "Alert Rules" highlighted
  - `/ops/alerts/rules/create` (hypothetical child) → only "Alert Rules" highlighted
  - Genuine parent-child routes (e.g., `/protection/backups` → `/protection/backups/create`) continue to highlight the parent as before

Closes #591