### PR TITLE
fix(storage): support legacy MinIO during S3 repository validation

### DIFF
--- a/src/backend/apps/storage/services/internal/s3_client.py
+++ b/src/backend/apps/storage/services/internal/s3_client.py
@@ -298,6 +298,20 @@ def create_s3_bucket(
             raise S3ClientError(
                 f"Unable to create S3 bucket {bucket}: bucket already exists."
             ) from exc
+        if (
+            "CreateBucketConfiguration" in create_args
+            and _client_error_code(exc) in {"InvalidLocationConstraint", "XMinioInvalidRequest"}
+        ):
+            # Legacy single-Region gateways (e.g. older MinIO) reject the
+            # LocationConstraint block; retry with the default placement.
+            create_args.pop("CreateBucketConfiguration")
+            try:
+                client.create_bucket(**create_args)
+            except (ClientError, BotoCoreError) as retry_exc:
+                raise S3ClientError(
+                    _error_message(f"Unable to create S3 bucket {bucket}", retry_exc)
+                ) from retry_exc
+            return None
         raise S3ClientError(
             _error_message(f"Unable to create S3 bucket {bucket}", exc)
         ) from exc
@@ -537,6 +551,21 @@ def put_s3_object_if_absent(
             conflict_codes.add("FileAlreadyExists")
         if _client_error_code(exc) in conflict_codes:
             return False
+        if (
+            atomic_create_strategy == _ATOMIC_CREATE_IF_NONE_MATCH
+            and _client_error_code(exc) in {"NotImplemented", "XMinioInvalidRequest"}
+        ):
+            # Legacy S3-compatible gateways (e.g. older MinIO) do not support
+            # the If-None-Match conditional create. Fall back to a plain
+            # overwrite; the ownership marker is signature-verified downstream.
+            put_args.pop("IfNoneMatch", None)
+            try:
+                client.put_object(**put_args)
+                return True
+            except (ClientError, BotoCoreError, ParamValidationError) as retry_exc:
+                raise S3ClientError(
+                    _error_message("Unable to claim repository ownership", retry_exc)
+                ) from retry_exc
         raise S3ClientError(
             _error_message("Unable to claim repository ownership", exc)
         ) from exc

--- a/src/backend/apps/storage/services/internal/s3_validation_errors.py
+++ b/src/backend/apps/storage/services/internal/s3_validation_errors.py
@@ -21,6 +21,7 @@ class S3ValidationFailure:
     code: str
     message: str
     retryable: bool = False
+    diagnostic: str = ""
 
 
 _CREDENTIAL_CODES = {
@@ -43,12 +44,19 @@ _PERMISSION_CODES = {
 _BUCKET_MISSING_CODES = {"NoSuchBucket", "NotFound", "XNoSuchBucket"}
 _CONFIGURATION_CODES = {
     "AuthorizationHeaderMalformed",
+    "IncompleteBody",
     "InvalidArgument",
+    "InvalidBucketName",
     "InvalidEndpoint",
+    "InvalidLocationConstraint",
     "InvalidRegion",
     "InvalidRequest",
+    "MalformedXML",
+    "NotImplemented",
     "PermanentRedirect",
+    "XMinioInvalidRequest",
 }
+_CLOCK_SKEW_CODES = {"RequestTimeTooSkewed", "RequestExpired"}
 
 
 def classify_s3_validation_error(
@@ -101,6 +109,12 @@ def classify_s3_validation_error(
             "The object storage endpoint could not be reached. Check the endpoint and network connectivity, then try again.",
             retryable=True,
         )
+    if error_code in _CLOCK_SKEW_CODES:
+        return S3ValidationFailure(
+            "STORAGE.S3_CLOCK_SKEW",
+            "The object storage request was rejected because the server clock is out of sync. Check the server time and NTP synchronization, then try again.",
+            retryable=True,
+        )
     if error_code in _CONFIGURATION_CODES or any(
         isinstance(item, (ParamValidationError, TypeError, ValueError)) for item in chain
     ):
@@ -111,6 +125,7 @@ def classify_s3_validation_error(
     return S3ValidationFailure(
         "STORAGE.S3_VALIDATION_FAILED",
         "Object storage validation failed. Check the connection settings and IAM permissions, then try again.",
+        diagnostic=f"provider_error_code={error_code}" if error_code else "",
     )
 
 
@@ -121,6 +136,7 @@ def s3_validation_app_error(exc: Exception, *, operation: str) -> AppError:
         status=400,
         retryable=failure.retryable,
         title=failure.message,
+        diagnostic=failure.diagnostic,
     )
 
 

--- a/src/backend/apps/storage/tests/test_s3_client.py
+++ b/src/backend/apps/storage/tests/test_s3_client.py
@@ -642,6 +642,45 @@ class CreateS3BucketTests(TestCase):
                 secret_access_key="SK",
             )
 
+    @mock.patch("apps.storage.services.internal.s3_client._client")
+    def test_legacy_gateway_retries_without_location_constraint(self, client_factory):
+        client = mock.Mock()
+        client.create_bucket.side_effect = [
+            ClientError(
+                {
+                    "Error": {
+                        "Code": "InvalidLocationConstraint",
+                        "Message": "region not supported",
+                    },
+                    "ResponseMetadata": {"HTTPStatusCode": 400},
+                },
+                "CreateBucket",
+            ),
+            None,
+        ]
+        client_factory.return_value = client
+
+        create_s3_bucket(
+            endpoint="https://minio.example.com",
+            region="cn-north-1",
+            bucket="new-bucket",
+            access_key_id="AK",
+            secret_access_key="SK",
+        )
+
+        self.assertEqual(client.create_bucket.call_count, 2)
+        self.assertEqual(
+            client.create_bucket.call_args_list[0],
+            mock.call(
+                Bucket="new-bucket",
+                CreateBucketConfiguration={"LocationConstraint": "cn-north-1"},
+            ),
+        )
+        self.assertEqual(
+            client.create_bucket.call_args_list[1],
+            mock.call(Bucket="new-bucket"),
+        )
+
 
 class InitializeS3RepositoryBucketModeTests(TestCase):
     def _repository(self, mode):
@@ -894,3 +933,29 @@ class S3OwnershipMarkerAtomicCreateTests(TestCase):
                 endpoint="https://oss-cn-beijing.aliyuncs.com",
             )
         )
+
+    @mock.patch("apps.storage.services.internal.s3_client._client")
+    def test_legacy_gateway_falls_back_to_plain_overwrite(self, client_factory):
+        client = mock.Mock()
+        client.put_object.side_effect = [
+            ClientError(
+                {
+                    "Error": {
+                        "Code": "NotImplemented",
+                        "Message": "conditional write unsupported",
+                    },
+                    "ResponseMetadata": {"HTTPStatusCode": 501},
+                },
+                "PutObject",
+            ),
+            None,
+        ]
+        client_factory.return_value = client
+
+        self.assertTrue(self._put())
+
+        self.assertEqual(client.put_object.call_count, 2)
+        first_call = client.put_object.call_args_list[0]
+        second_call = client.put_object.call_args_list[1]
+        self.assertIn("IfNoneMatch", first_call.kwargs)
+        self.assertNotIn("IfNoneMatch", second_call.kwargs)

--- a/src/backend/apps/storage/tests/test_s3_validation_errors.py
+++ b/src/backend/apps/storage/tests/test_s3_validation_errors.py
@@ -60,6 +60,40 @@ class S3ValidationErrorTests(SimpleTestCase):
         self.assertNotIn("s3.example.test", network.message)
         self.assertNotIn("certificate failed", tls.message)
 
+    def test_legacy_gateway_codes_are_configuration_errors(self):
+        for code in ("InvalidLocationConstraint", "NotImplemented", "XMinioInvalidRequest", "InvalidBucketName"):
+            failure = classify_s3_validation_error(
+                _wrapped_client_error(code),
+                operation="bucket_access",
+            )
+            self.assertEqual(failure.code, "STORAGE.S3_CONFIGURATION_INVALID", code)
+            self.assertNotIn("provider detail", failure.message, code)
+
+    def test_clock_skew_is_distinct_and_retryable(self):
+        failure = classify_s3_validation_error(
+            _wrapped_client_error("RequestTimeTooSkewed"),
+            operation="bucket_access",
+        )
+
+        self.assertEqual(failure.code, "STORAGE.S3_CLOCK_SKEW")
+        self.assertTrue(failure.retryable)
+        self.assertIn("clock", failure.message.lower())
+
+    def test_unknown_failure_exposes_only_the_safe_provider_error_code(self):
+        failure = classify_s3_validation_error(
+            _wrapped_client_error("SomeWeirdProviderCode", "secret-token-value"),
+            operation="bucket_access",
+        )
+        app_error = s3_validation_app_error(
+            _wrapped_client_error("SomeWeirdProviderCode", "secret-token-value"),
+            operation="bucket_access",
+        )
+
+        self.assertEqual(failure.code, "STORAGE.S3_VALIDATION_FAILED")
+        self.assertEqual(failure.diagnostic, "provider_error_code=SomeWeirdProviderCode")
+        self.assertEqual(app_error.diagnostic, failure.diagnostic)
+        self.assertNotIn("secret-token-value", app_error.diagnostic)
+
     def test_unknown_failure_uses_safe_generic_message(self):
         failure = classify_s3_validation_error(
             S3ClientError("access-key=AKIA_SECRET secret=super-secret upstream payload"),
@@ -69,3 +103,4 @@ class S3ValidationErrorTests(SimpleTestCase):
         self.assertEqual(failure.code, "STORAGE.S3_VALIDATION_FAILED")
         self.assertNotIn("AKIA_SECRET", failure.message)
         self.assertNotIn("super-secret", failure.message)
+        self.assertEqual(failure.diagnostic, "")


### PR DESCRIPTION
## Summary

Adding a repository backed by an older MinIO gateway (e.g. `192.168.8.69`) failed with the generic `Object storage validation failed. Check the connection settings and IAM permissions, then try again.` error because the gateway error codes were not classified and two modern S3 features are unsupported by legacy MinIO.

## Changes

- **`s3_client.py`**: fall back to a plain overwrite put when the `If-None-Match` conditional create is unsupported (`NotImplemented`/`XMinioInvalidRequest`); retry bucket creation without the `CreateBucketConfiguration` `LocationConstraint` block on legacy single-Region gateways.
- **`s3_validation_errors.py`**: classify legacy gateway codes (`NotImplemented`, `InvalidLocationConstraint`, `XMinioInvalidRequest`, `InvalidBucketName`, `MalformedXML`, `IncompleteBody`, `RequestTimeTooSkewed`, `RequestExpired`) and surface the sanitized provider error code in the validation `diagnostic` when classification falls back to the generic failure.
- **Tests**: added coverage for both fallback paths and the new error classification in `test_s3_client.py` and `test_s3_validation_errors.py`.

## Verification

`python manage.py test apps.storage.tests.test_s3_validation_errors apps.storage.tests.test_s3_client` -> 46 tests passed.