### PR TITLE
fix(agent): skip special file types during snapshot scope resolve

### DIFF
--- a/src/agent/internal/engine/managed_backup.go
+++ b/src/agent/internal/engine/managed_backup.go
@@ -1801,7 +1801,14 @@ func (e *Engine) runManagedSnapshotScopeResolve(
 				directoryCount++
 				return
 			}
-			if !strings.HasPrefix(strings.ToLower(mode), "-") || size < 0 {
+			if !strings.HasPrefix(strings.ToLower(mode), "-") {
+				// Symlinks, sockets, pipes, devices and other special file
+				// types are present in the snapshot but cannot be used as
+				// chat source entries. Skip them instead of failing the whole
+				// scope resolve.
+				return
+			}
+			if size < 0 {
 				invalidTotals = true
 				return
 			}
@@ -2846,7 +2853,10 @@ func looksLikeMode(value string) bool {
 		return false
 	}
 	first := value[0]
-	return first == 'd' || first == '-' || first == 'l'
+	return first == 'd' || first == '-' || first == 'l' || first == 'L' ||
+		first == 's' || first == 'S' || first == 'p' || first == 'P' ||
+		first == 'b' || first == 'c' || first == 'C' || first == 'D' ||
+		first == 'w'
 }
 
 func mapSnapshotBrowseType(isDir bool) string {

--- a/src/agent/internal/engine/managed_backup_test.go
+++ b/src/agent/internal/engine/managed_backup_test.go
@@ -939,6 +939,63 @@ func TestSnapshotScopeRecursiveLinesProduceTrustedTotals(t *testing.T) {
 	}
 }
 
+func TestSnapshotScopeRecursiveTotalsSkipSpecialFiles(t *testing.T) {
+	// Some snapshots contain symlinks, sockets, pipes or devices. These should
+	// not cause the whole scope resolve to fail; they should simply be skipped.
+	stdout := `drwx------            1 2026-08-12 11:15:59 CST object-dir sub/
+Lrwxrwxrwx           12 2026-08-12 11:15:59 CST object-link sub/link
+srwxrwxrwx            0 2026-08-12 11:15:59 CST object-sock sub/sock
+-rw-------            7 2026-08-12 11:15:59 CST object-file sub/file.txt`
+
+	var files int64
+	var directories int64
+	var sizeBytes int64
+	var invalid bool
+	for _, line := range strings.Split(stdout, "\n") {
+		mode, size, _, _, ok := parseInsightSnapshotLongLine(line)
+		if !ok {
+			if strings.TrimSpace(line) != "" {
+				invalid = true
+			}
+			continue
+		}
+		if strings.HasPrefix(strings.ToLower(mode), "d") {
+			if size < 0 {
+				invalid = true
+				continue
+			}
+			directories++
+			continue
+		}
+		if !strings.HasPrefix(strings.ToLower(mode), "-") {
+			// Skip special file types without failing.
+			continue
+		}
+		if size < 0 {
+			invalid = true
+			continue
+		}
+		files++
+		if size > 0 && sizeBytes <= math.MaxInt64-size {
+			sizeBytes += size
+		} else if size > 0 {
+			invalid = true
+		}
+	}
+
+	if invalid {
+		t.Fatal("expected special file types to be skipped, not marked invalid")
+	}
+	if files != 1 || directories != 1 || sizeBytes != 7 {
+		t.Fatalf(
+			"unexpected totals after skipping special files: files=%d directories=%d size=%d",
+			files,
+			directories,
+			sizeBytes,
+		)
+	}
+}
+
 func TestInsightSnapshotResultContainsOnlyBusinessIdentity(t *testing.T) {
 	result := newInsightSnapshotResult(" snapshot-1 ", " /reports/quarterly/ ")
 


### PR DESCRIPTION
## Summary

The agent's `lens.snapshot.scope.resolve` task failed the entire scope when `kopia ls -lr` encountered special file types such as symlinks, sockets, pipes or devices inside the selected directory. Users saw `We Couldn't Prepare This Chat` when starting a chat against a snapshot path that contained entries like `.codex`.

## Root cause

- `parseInsightSnapshotLongLine` already accepted symlinks (`l`/`L`), but the scope-resolve callback treated any non-regular, non-directory mode as invalid.
- Sockets, pipes and devices were rejected by `looksLikeMode` before parsing, so `parseInsightSnapshotLongLine` returned `ok=false`, which the callback also treated as invalid.

## Changes

- `src/agent/internal/engine/managed_backup.go`
  - Expand `looksLikeMode` to accept POSIX special-file modes (socket, pipe, device, door, whiteout).
  - Skip those entries when computing scope totals instead of failing the whole resolve.
- `src/agent/internal/engine/managed_backup_test.go`
  - Add `TestSnapshotScopeRecursiveTotalsSkipSpecialFiles` covering symlinks, sockets and regular files in the same snapshot.

## Verification

`go test ./internal/engine/...` passes.