### PR TITLE
fix(storage): allow re-initialization when the leftover bucket is empty

### DIFF
--- a/src/backend/apps/storage/services/internal/s3_client.py
+++ b/src/backend/apps/storage/services/internal/s3_client.py
@@ -290,8 +290,23 @@ def create_s3_bucket(
             create_args["CreateBucketConfiguration"] = create_bucket_configuration
         client.create_bucket(**create_args)
     except ClientError as exc:
+        if _client_error_code(exc) == "BucketAlreadyOwnedByYou":
+            # The bucket belongs to the current credentials; it may have been
+            # left behind by a previously failed creation attempt. Allow
+            # re-initialization only when the bucket holds no data, otherwise
+            # reject so an existing location is never silently reused.
+            try:
+                holds_state = _prefix_holds_any_state(client, bucket=bucket)
+            except (BotoCoreError, ClientError) as probe_exc:
+                raise S3ClientError(
+                    _error_message(f"Unable to inspect existing S3 bucket {bucket}", probe_exc)
+                ) from probe_exc
+            if holds_state:
+                raise S3ClientError(
+                    f"Unable to create S3 bucket {bucket}: bucket already exists."
+                ) from exc
+            return None
         if _client_error_code(exc) in {
-            "BucketAlreadyOwnedByYou",
             "BucketAlreadyExists",
             "OperationAborted",
         }:
@@ -636,6 +651,38 @@ def list_s3_object_keys(
         ) from exc
 
 
+def _prefix_holds_any_state(client, *, bucket: str, prefix: str = "") -> bool:
+    """Return whether a Prefix holds objects, versions, or uploads.
+
+    Legacy S3-compatible gateways (e.g. early MinIO releases) do not
+    implement ListObjectVersions and report NotImplemented. The objects
+    listing already proved the Prefix holds no current objects, so their
+    response is treated as "no historical versions" rather than failing the
+    whole probe.
+    """
+    objects = client.list_objects_v2(Bucket=bucket, Prefix=prefix, MaxKeys=1)
+    if objects.get("Contents"):
+        return True
+    try:
+        versions = client.list_object_versions(
+            Bucket=bucket,
+            Prefix=prefix,
+            MaxKeys=1,
+        )
+    except ClientError as exc:
+        if not _is_unsupported_s3_header_error(exc):
+            raise
+        versions = {}
+    if versions.get("Versions") or versions.get("DeleteMarkers"):
+        return True
+    uploads = client.list_multipart_uploads(
+        Bucket=bucket,
+        Prefix=prefix,
+        MaxUploads=1,
+    )
+    return bool(uploads.get("Uploads"))
+
+
 def s3_prefix_has_any_state(
     *,
     endpoint: str | None,
@@ -659,32 +706,7 @@ def s3_prefix_has_any_state(
         timeout_seconds=timeout_seconds,
     )
     try:
-        objects = client.list_objects_v2(Bucket=bucket, Prefix=prefix, MaxKeys=1)
-        if objects.get("Contents"):
-            return True
-        try:
-            versions = client.list_object_versions(
-                Bucket=bucket,
-                Prefix=prefix,
-                MaxKeys=1,
-            )
-        except ClientError as exc:
-            # Older S3-compatible servers (e.g. early MinIO releases) do not
-            # implement ListObjectVersions and report NotImplemented. The
-            # objects listing above already proved that the Prefix holds no
-            # current objects, so treat historical versions as absent rather
-            # than failing the whole probe.
-            if not _is_unsupported_s3_header_error(exc):
-                raise
-            versions = {}
-        if versions.get("Versions") or versions.get("DeleteMarkers"):
-            return True
-        uploads = client.list_multipart_uploads(
-            Bucket=bucket,
-            Prefix=prefix,
-            MaxUploads=1,
-        )
-        return bool(uploads.get("Uploads"))
+        return _prefix_holds_any_state(client, bucket=bucket, prefix=prefix)
     except (BotoCoreError, ClientError) as exc:
         raise S3ClientError(
             _error_message("Unable to inspect repository object prefix", exc)

--- a/src/backend/apps/storage/tests/test_s3_client.py
+++ b/src/backend/apps/storage/tests/test_s3_client.py
@@ -622,7 +622,7 @@ class CreateS3BucketTests(TestCase):
         client.list_buckets.assert_not_called()
 
     @mock.patch("apps.storage.services.internal.s3_client._client")
-    def test_rejects_an_existing_bucket_name(self, client_factory):
+    def test_rejects_an_existing_bucket_name_that_holds_data(self, client_factory):
         client = mock.Mock()
         client.create_bucket.side_effect = ClientError(
             {
@@ -631,6 +631,7 @@ class CreateS3BucketTests(TestCase):
             },
             "CreateBucket",
         )
+        client.list_objects_v2.return_value = {"Contents": [{"Key": "existing"}]}
         client_factory.return_value = client
 
         with self.assertRaisesRegex(S3ClientError, "already exists"):
@@ -641,6 +642,33 @@ class CreateS3BucketTests(TestCase):
                 access_key_id="AK",
                 secret_access_key="SK",
             )
+
+    @mock.patch("apps.storage.services.internal.s3_client._client")
+    def test_allows_reinitialization_when_existing_bucket_is_empty(self, client_factory):
+        client = mock.Mock()
+        client.create_bucket.side_effect = ClientError(
+            {
+                "Error": {"Code": "BucketAlreadyOwnedByYou", "Message": "owned"},
+                "ResponseMetadata": {"HTTPStatusCode": 409},
+            },
+            "CreateBucket",
+        )
+        client.list_objects_v2.return_value = {}
+        client.list_object_versions.return_value = {}
+        client.list_multipart_uploads.return_value = {}
+        client_factory.return_value = client
+
+        create_s3_bucket(
+            endpoint="https://s3.example.com",
+            region="us-east-1",
+            bucket="leftover-bucket",
+            access_key_id="AK",
+            secret_access_key="SK",
+        )
+
+        client.list_objects_v2.assert_called_once_with(
+            Bucket="leftover-bucket", Prefix="", MaxKeys=1
+        )
 
     @mock.patch("apps.storage.services.internal.s3_client._client")
     def test_legacy_gateway_retries_without_location_constraint(self, client_factory):


### PR DESCRIPTION
## Problem

Creating a repository against legacy MinIO fails at the prefix probe (#614 fixed that), but the bucket created during the failed attempt is left behind on S3. Pressing **Retry Initialization** then hits `BucketAlreadyOwnedByYou` inside `create_s3_bucket`, which rejected every retry with:

> Unable to create S3 bucket ...: bucket already exists.

So a repository whose bucket was already provisioned could never be recovered through retry.

## Fix

`BucketAlreadyOwnedByYou` means the bucket belongs to the current credentials, so it is safe to treat it as a leftover from an earlier attempt. Instead of rejecting unconditionally:

1. Probe the bucket with the same prefix-state logic used for ownership claims (`_prefix_holds_any_state`).
2. If it is empty, return success and let initialization continue.
3. If it holds any objects/versions/uploads, keep rejecting (fail-closed) so an existing location is never silently reused.
4. If the probe itself fails, raise a dedicated `S3ClientError` instead of swallowing it.

`_prefix_holds_any_state` is the extracted probe body of `s3_prefix_has_any_state` (including the legacy MinIO `NotImplemented` downgrade from #614), so the logic is reused rather than duplicated.

`BucketAlreadyExists` and `OperationAborted` are still rejected unconditionally, since they do not indicate ownership.

## Tests

- Renamed `test_rejects_an_existing_bucket_name` to `test_rejects_an_existing_bucket_name_that_holds_data` (mocks a non-empty bucket).
- Added `test_allows_reinitialization_when_existing_bucket_is_empty` (empty leftover bucket is accepted and probes with `MaxKeys=1`).
- All 53 storage tests in `test_s3_client.py` + `test_s3_cleanup.py` pass.