### PR TITLE
fix(frontend): render toolbar slot in Notifications test stub

### DIFF
--- a/src/frontend/src/pages/Notifications.test.ts
+++ b/src/frontend/src/pages/Notifications.test.ts
@@ -28,6 +28,7 @@ vi.mock('../lib/notificationApi', () => ({
 const HflTablePanelStub = defineComponent({
   template: `
     <div>
+      <slot name="toolbar" />
       <slot name="toolbar-utility" />
       <slot name="table" :table-max-height="500" />
       <slot name="footer" />

--- a/src/frontend/src/pages/settings/SubscriptionContent.vue
+++ b/src/frontend/src/pages/settings/SubscriptionContent.vue
@@ -337,7 +337,10 @@ onMounted(loadAll)
         >
           <span class="subscription-quota-item__label">
             {{ item.label }}
-            <small v-if="item.limitSource" class="subscription-quota-item__scope">
+            <small
+              v-if="item.limitSource"
+              class="subscription-quota-item__scope"
+            >
               {{ item.limitSource === 'override'
                 ? t('settings.subscription.manualOverride')
                 : t('settings.subscription.planLimit') }}


### PR DESCRIPTION
## Summary

v0.2.4 (commit 47eb5f6, PR #596/#600) moved the "Mark All Read" button into the `#toolbar` slot of `HflTablePanel`, but the `HflTablePanelStub` in `Notifications.test.ts` never rendered that slot. As a result the notification tests failed on the v0.2.4 tag.

## Fix

Render the `toolbar` slot in the test stub so the button is present in the shallow mount.

## Test

```bash
npm test -- Notifications
```

All notification tests pass.