### PR TITLE
fix(installer): recover transient SourceLens compose exit races

### DIFF
--- a/.github/workflows/artifact_pipeline.yml
+++ b/.github/workflows/artifact_pipeline.yml
@@ -449,6 +449,7 @@ jobs:
           ./tools/quality/test-upgrade-backup-retention.sh
           ./tools/quality/test-upgrade-transaction.sh
           ./tools/quality/test-blue-green-recovery.sh
+          ./tools/quality/test-compose-lifecycle-reconcile.sh
           ./tools/quality/test-nginx-startup-readiness.sh
           ./tools/quality/test-sourcelens-runtime-sync.sh
           ./tools/quality/test-sourcelens-runtime-fingerprint.sh

--- a/deploy/installer/install.sh
+++ b/deploy/installer/install.sh
@@ -301,7 +301,7 @@ recover_upgrade_services() {
 	set +e
 	if [[ "${UPGRADE_SOURCELENS_WAS_RUNNING}" == "1" ]] && sourcelens_installed; then
 		if [[ "${SOURCELENS_UPGRADE_STARTED}" == "1" ]]; then
-			sourcelens_compose up -d --no-build --pull never
+			sourcelens_compose_with_lifecycle_recovery up -d --no-build --pull never
 		else
 			# Target SourceLens files may already be staged.  Starting existing
 			# containers avoids converging an unchanged live runtime before its
@@ -1314,11 +1314,12 @@ services:
       - ./deploy/nginx/hfl-maintenance/adoption-default.conf:/etc/nginx/conf.d/default.conf:ro
       - ./deploy/nginx/hfl-maintenance:/etc/nginx/hfl-maintenance:ro
 YAML
-		sourcelens_compose -f docker-compose.yml -f "${adoption_override}" \
+		sourcelens_compose_with_lifecycle_recovery \
+			-f docker-compose.yml -f "${adoption_override}" \
 			up -d --no-deps --no-build --pull never --force-recreate nginx || return 1
 	else
-		sourcelens_compose up -d --no-deps --no-build --pull never --force-recreate nginx \
-			|| return 1
+		sourcelens_compose_with_lifecycle_recovery \
+			up -d --no-deps --no-build --pull never --force-recreate nginx || return 1
 	fi
 	local deadline=$((SECONDS + timeout_seconds))
 	while ((SECONDS < deadline)); do
@@ -1360,7 +1361,7 @@ clear_sourcelens_proxy_gate() {
 			warn "SourceLens Nginx reload failed while clearing the direct Run gate; restarting Nginx"
 			# Preserve SOURCELENS_PROXY_GATE_ARMED on failure so the upgrade
 			# exit trap retries instead of leaving old workers blocking Runs.
-			sourcelens_compose restart nginx >/dev/null || return 1
+			sourcelens_compose_with_lifecycle_recovery restart nginx >/dev/null || return 1
 		fi
 	fi
 	SOURCELENS_PROXY_GATE_ARMED=0
@@ -3360,12 +3361,24 @@ sourcelens_compose() {
 	)
 }
 
+load_sourcelens_compose_lifecycle() {
+	local helper="${SOURCELENS_INSTALL_DIR}/compose-lifecycle.sh"
+	[[ -f "${helper}" ]] || die "missing bundled SourceLens lifecycle helper: ${helper}"
+	# shellcheck disable=SC1090
+	source "${helper}"
+}
+
+sourcelens_compose_with_lifecycle_recovery() {
+	load_sourcelens_compose_lifecycle
+	hfl_compose_command_with_exit_event_recovery sourcelens_compose "$@"
+}
+
 stop_bundled_sourcelens() {
 	if ! sourcelens_installed; then
 		return 0
 	fi
 	step "Stopping SourceLens stack ..."
-	sourcelens_compose down
+	sourcelens_compose_with_lifecycle_recovery down
 }
 
 remove_sourcelens_images() {
@@ -3435,7 +3448,7 @@ uninstall_bundled_sourcelens() {
 	fi
 	step "Uninstalling SourceLens ..."
 	if [[ "${configured}" -eq 1 ]]; then
-		if ! sourcelens_compose down --remove-orphans; then
+		if ! sourcelens_compose_with_lifecycle_recovery down --remove-orphans; then
 			warn "SourceLens Compose cleanup failed; removing only containers verified as installer-owned"
 		fi
 	else
@@ -3514,6 +3527,7 @@ preflight_sourcelens_bundle() {
 	local -a runtime_files=(
 		sourcelens/BUILD_INFO.json
 		sourcelens/.env.example
+		sourcelens/compose-lifecycle.sh
 		sourcelens/docker-compose.yml
 		sourcelens/install.sh
 		sourcelens/patch-env-runtime.py
@@ -3568,6 +3582,7 @@ root = pathlib.Path(sys.argv[1])
 paths = [
     "docker-compose.yml",
     ".env.example",
+    "compose-lifecycle.sh",
     "install.sh",
     "patch-env-runtime.py",
     "sync-sentry-runtime.py",
@@ -4408,7 +4423,8 @@ cmd_start() {
 	sync_runtime_media
 	if [[ "$(configured_sourcelens_mode)" == "bundled" ]] && sourcelens_installed; then
 		step "Starting bundled SourceLens ..."
-		sourcelens_compose up -d --no-build --pull never --remove-orphans
+		sourcelens_compose_with_lifecycle_recovery \
+			up -d --no-build --pull never --remove-orphans
 	fi
 	step "Starting services (docker compose up -d --no-build) ..."
 	start_hfl_stack || die "HyperFileLens active color failed to start"

--- a/deploy/installer/sourcelens/compose-lifecycle.sh
+++ b/deploy/installer/sourcelens/compose-lifecycle.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# Bounded recovery for a Docker Compose stop/recreate exit-event race.
+
+_hfl_compose_lifecycle_loaded="${_hfl_compose_lifecycle_loaded:-}"
+if [[ -n "${_hfl_compose_lifecycle_loaded}" ]]; then
+	return 0 2>/dev/null || exit 0
+fi
+_hfl_compose_lifecycle_loaded=1
+
+hfl_compose_lifecycle_warn() {
+	if declare -F hfl_log_warn >/dev/null 2>&1; then
+		hfl_log_warn "$@"
+	elif declare -F warn >/dev/null 2>&1; then
+		warn "$@"
+	else
+		printf '[WARN] %s\n' "$*" >&2
+	fi
+}
+
+hfl_compose_lifecycle_log() {
+	if declare -F hfl_log_info >/dev/null 2>&1; then
+		hfl_log_info "$@"
+	elif declare -F log >/dev/null 2>&1; then
+		log "$@"
+	else
+		printf '[INFO] %s\n' "$*" >&2
+	fi
+}
+
+hfl_compose_exit_event_container_ids() {
+	local error_file=$1
+	grep -E \
+		'cannot stop container: [0-9a-f]{12,64}: tried to kill container, but did not receive an exit event' \
+		"${error_file}" \
+		| sed -E 's/.*cannot stop container: ([0-9a-f]{12,64}):.*/\1/' \
+		| sort -u
+}
+
+hfl_compose_wait_for_container_exit_events() {
+	local container_ids=$1
+	local wait_seconds="${HFL_COMPOSE_EXIT_EVENT_WAIT_SECONDS:-60}"
+	local poll_seconds="${HFL_COMPOSE_EXIT_EVENT_POLL_SECONDS:-2}"
+	local deadline container_id inspect_output inspect_status inspect_timeout
+	local all_stopped remaining_seconds sleep_seconds
+	[[ "${wait_seconds}" =~ ^[1-9][0-9]*$ && "${wait_seconds}" -le 60 ]] || {
+		hfl_compose_lifecycle_warn \
+			"Invalid HFL_COMPOSE_EXIT_EVENT_WAIT_SECONDS=${wait_seconds}; use 1-60 seconds"
+		return 1
+	}
+	[[ "${poll_seconds}" =~ ^[1-9][0-9]*$ && "${poll_seconds}" -le "${wait_seconds}" ]] || {
+		hfl_compose_lifecycle_warn \
+			"Invalid HFL_COMPOSE_EXIT_EVENT_POLL_SECONDS=${poll_seconds}; use 1-${wait_seconds} seconds"
+		return 1
+	}
+
+	deadline=$((SECONDS + wait_seconds))
+	while true; do
+		remaining_seconds=$((deadline - SECONDS))
+		if ((remaining_seconds <= 0)); then
+			hfl_compose_lifecycle_warn \
+				"Docker did not settle the delayed container exit within ${wait_seconds}s; not retrying Compose"
+			return 1
+		fi
+		all_stopped=1
+		while IFS= read -r container_id; do
+			[[ -n "${container_id}" ]] || continue
+			remaining_seconds=$((deadline - SECONDS))
+			if ((remaining_seconds <= 0)); then
+				hfl_compose_lifecycle_warn \
+					"Docker did not settle the delayed container exit within ${wait_seconds}s; not retrying Compose"
+				return 1
+			fi
+			inspect_timeout=5
+			((inspect_timeout <= remaining_seconds)) || inspect_timeout=${remaining_seconds}
+			if inspect_output="$(timeout "${inspect_timeout}s" \
+				docker inspect --format '{{.State.Running}}' "${container_id}" 2>&1)"; then
+				case "${inspect_output}" in
+				false) ;;
+				true) all_stopped=0 ;;
+				*)
+					hfl_compose_lifecycle_warn \
+						"Docker returned an unknown running state for container ${container_id}: ${inspect_output}"
+					return 1
+					;;
+				esac
+			else
+				inspect_status=$?
+				if [[ "${inspect_status}" -eq 124 ]]; then
+					hfl_compose_lifecycle_warn \
+						"Docker inspect did not respond within ${inspect_timeout}s while waiting for container ${container_id}"
+					return 1
+				fi
+				if grep -Eq 'No such (object|container)' <<<"${inspect_output}"; then
+					# Compose may remove the old container while the daemon catches up.
+					continue
+				fi
+				hfl_compose_lifecycle_warn \
+					"Could not inspect container ${container_id} while waiting for its exit event: ${inspect_output}"
+				return 1
+			fi
+		done <<<"${container_ids}"
+
+		if [[ "${all_stopped}" -eq 1 ]]; then
+			return 0
+		fi
+		remaining_seconds=$((deadline - SECONDS))
+		((remaining_seconds > 0)) || continue
+		sleep_seconds=${poll_seconds}
+		((sleep_seconds <= remaining_seconds)) || sleep_seconds=${remaining_seconds}
+		sleep "${sleep_seconds}"
+	done
+}
+
+hfl_compose_command_with_exit_event_recovery() {
+	local compose_callback=${1:-}
+	shift || true
+	local error_file status container_ids capture_fd capture_pid
+	[[ -n "${compose_callback}" ]] || return 2
+	error_file="$(mktemp "${TMPDIR:-/tmp}/hfl-compose-lifecycle.XXXXXX")" || return 1
+
+	# Keep the callback in the current shell (some callers maintain transaction
+	# state) while teeing Docker/Compose stderr live for classification.
+	exec {capture_fd}> >(tee "${error_file}" >&2)
+	capture_pid=$!
+	if "${compose_callback}" "$@" 2>&${capture_fd}; then
+		status=0
+	else
+		status=$?
+	fi
+	exec {capture_fd}>&-
+	wait "${capture_pid}" || true
+	if [[ "${status}" -eq 0 ]]; then
+		rm -f -- "${error_file}"
+		return 0
+	fi
+
+	container_ids="$(hfl_compose_exit_event_container_ids "${error_file}" || true)"
+	rm -f -- "${error_file}"
+	if [[ -z "${container_ids}" ]]; then
+		return "${status}"
+	fi
+
+	hfl_compose_lifecycle_warn \
+		"Docker delayed a container exit event; waiting only for the affected container before one Compose retry"
+	if ! hfl_compose_wait_for_container_exit_events "${container_ids}"; then
+		return "${status}"
+	fi
+
+	hfl_compose_lifecycle_log \
+		"Docker container exit is settled; reconciling Compose once"
+	if "${compose_callback}" "$@"; then
+		return 0
+	else
+		status=$?
+		hfl_compose_lifecycle_warn \
+			"Compose reconciliation failed after the single lifecycle retry"
+		return "${status}"
+	fi
+}

--- a/deploy/installer/sourcelens/install.sh
+++ b/deploy/installer/sourcelens/install.sh
@@ -3,6 +3,10 @@
 # Installed under /opt/hyperfilelens/sourcelens by default.
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=compose-lifecycle.sh
+source "${SCRIPT_DIR}/compose-lifecycle.sh"
+
 SOURCELENS_INSTALL_DIR="${SOURCELENS_INSTALL_DIR:-/opt/hyperfilelens/sourcelens}"
 SOURCELENS_DATA_DIR="${SOURCELENS_DATA_DIR:-/opt/hyperfilelens/data/sourcelens}"
 SOURCELENS_CONFIG_DIR="${SOURCELENS_CONFIG_DIR:-${SOURCELENS_DATA_DIR}/config}"
@@ -424,7 +428,8 @@ cmd_install() {
 
 	ensure_bridge_network
 	log "Starting SourceLens stack in ${install_root}"
-	compose_cmd "${install_root}" up -d --no-build --pull never --remove-orphans
+	hfl_compose_command_with_exit_event_recovery \
+		compose_cmd "${install_root}" up -d --no-build --pull never --remove-orphans
 
 	wait_for_health "${install_root}"
 	log "SourceLens install complete on private network ${HFL_BRIDGE_NETWORK}"

--- a/dev/sourcelens.sh
+++ b/dev/sourcelens.sh
@@ -5,6 +5,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=../tools/sourcelens/common.sh
 source "${SCRIPT_DIR}/../tools/sourcelens/common.sh"
+# shellcheck source=../deploy/installer/sourcelens/compose-lifecycle.sh
+source "${SCRIPT_DIR}/../deploy/installer/sourcelens/compose-lifecycle.sh"
 
 FORCE_BUILD="${SOURCELENS_FORCE_BUILD:-0}"
 CMD=""
@@ -221,7 +223,8 @@ cmd_up() {
 	cmd_prepare
 	sourcelens_ensure_shared_network
 	sourcelens_log "Starting SourceLens stack (project=${SOURCELENS_COMPOSE_PROJECT})"
-	sourcelens_dev_compose up -d --pull never --remove-orphans
+	hfl_compose_command_with_exit_event_recovery \
+		sourcelens_dev_compose up -d --pull never --remove-orphans
 	sourcelens_ensure_database_initialized
 	if command -v curl >/dev/null 2>&1; then
 		sourcelens_wait_for_health || true
@@ -236,7 +239,7 @@ cmd_down() {
 		return 0
 	}
 	sourcelens_log "Stopping SourceLens stack (project=${SOURCELENS_COMPOSE_PROJECT})"
-	sourcelens_dev_compose down
+	hfl_compose_command_with_exit_event_recovery sourcelens_dev_compose down
 }
 
 main() {

--- a/release/build-sourcelens.sh
+++ b/release/build-sourcelens.sh
@@ -280,12 +280,15 @@ stage_runtime_tree() {
 	fi
 
 	cp "${SOURCELENS_INSTALLER_DIR}/sourcelens/install.sh" "${sl_root}/install.sh"
+	cp "${SOURCELENS_INSTALLER_DIR}/sourcelens/compose-lifecycle.sh" \
+		"${sl_root}/compose-lifecycle.sh"
 	cp "${SOURCELENS_INSTALLER_DIR}/sourcelens/patch-env-runtime.py" "${sl_root}/patch-env-runtime.py"
 	cp "${SOURCELENS_INSTALLER_DIR}/sourcelens/sync-sentry-runtime.py" "${sl_root}/sync-sentry-runtime.py"
 	cp "${SOURCELENS_INSTALLER_DIR}/sourcelens/hfl-sentry-sitecustomize.py" \
 		"${sl_root}/deploy/sentry/hfl-sentry-sitecustomize.py"
 	chmod 644 "${sl_root}/deploy/sentry/hfl-sentry-sitecustomize.py"
-	chmod +x "${sl_root}/install.sh" "${sl_root}/patch-env-runtime.py" "${sl_root}/sync-sentry-runtime.py"
+	chmod +x "${sl_root}/install.sh" "${sl_root}/compose-lifecycle.sh" \
+		"${sl_root}/patch-env-runtime.py" "${sl_root}/sync-sentry-runtime.py"
 
 	sourcelens_write_runtime_compose "${sl_root}/docker-compose.yml"
 

--- a/release/build.sh
+++ b/release/build.sh
@@ -73,6 +73,7 @@ normalize_release_permissions() {
 	fi
 	if [[ -d "${pkg_root}/sourcelens" ]]; then
 		chmod 755 "${pkg_root}/sourcelens/install.sh" \
+			"${pkg_root}/sourcelens/compose-lifecycle.sh" \
 			"${pkg_root}/sourcelens/patch-env-runtime.py" \
 			"${pkg_root}/sourcelens/sync-sentry-runtime.py"
 		find "${pkg_root}/sourcelens/deploy/postgresql/initdb.d" \

--- a/release/ci/assemble-release.sh
+++ b/release/ci/assemble-release.sh
@@ -164,6 +164,7 @@ for required in \
 	images/11-sourcelens-lensnode.tar.gz \
 	images/12-nginx-stable-alpine.tar.gz \
 	sourcelens/BUILD_INFO.json \
+	sourcelens/compose-lifecycle.sh \
 	sourcelens/sync-sentry-runtime.py \
 	sourcelens/deploy/sentry/hfl-sentry-sitecustomize.py \
 	sourcelens/deploy/nginx/hfl-sentry-loader.js; do

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -945,6 +945,7 @@ fi
 grep -F 'compose_color "${recovery_color}" start' <<<"${recovery_body}" >/dev/null
 grep -F 'compose_in_root start worker scheduler' <<<"${recovery_body}" >/dev/null
 grep -F './tools/quality/test-blue-green-recovery.sh' "${workflow}" >/dev/null
+grep -F './tools/quality/test-compose-lifecycle-reconcile.sh' "${workflow}" >/dev/null
 grep -F './tools/quality/test-nginx-startup-readiness.sh' "${workflow}" >/dev/null
 grep -F './tools/quality/test-sourcelens-runtime-sync.sh' "${workflow}" >/dev/null
 grep -F './tools/quality/test-sourcelens-runtime-fingerprint.sh' "${workflow}" >/dev/null
@@ -1359,8 +1360,10 @@ for executable in \
 	"${ROOT}/.github/scripts/stop-enterprise-promotion.sh" \
 	"${ROOT}/.github/scripts/remote-deploy.sh" \
 	"${ROOT}/.github/scripts/store-enterprise-release.sh" \
+	"${ROOT}/deploy/installer/sourcelens/compose-lifecycle.sh" \
 	"${ROOT}/tools/quality/check-python38-runtime.py" \
 	"${ROOT}/tools/quality/test-docker-pull-retry.sh" \
+	"${ROOT}/tools/quality/test-compose-lifecycle-reconcile.sh" \
 	"${ROOT}/tools/quality/test-bootstrap-curl-tls-nounset.sh" \
 	"${ROOT}/tools/quality/test-gh-release-upload-retry.sh" \
 	"${ROOT}/release/ci/gh-release-upload.sh" \
@@ -1387,6 +1390,12 @@ for executable in \
 		exit 1
 	}
 done
+
+grep -F 'compose-lifecycle.sh' "${ROOT}/release/build-sourcelens.sh" >/dev/null
+grep -F 'hfl_compose_command_with_exit_event_recovery' \
+	"${ROOT}/dev/sourcelens.sh" \
+	"${ROOT}/deploy/installer/sourcelens/install.sh" \
+	"${ROOT}/deploy/installer/install.sh" >/dev/null
 
 grep -F 'HFL_TENANT_PORT=11443' "${ROOT}/.env.example" >/dev/null
 grep -F 'HFL_WEBSITE_PORT=11442' "${ROOT}/.env.example" >/dev/null

--- a/tools/quality/test-blue-green-recovery.sh
+++ b/tools/quality/test-blue-green-recovery.sh
@@ -10,6 +10,10 @@ tmp="$(mktemp -d)"
 trap 'rm -rf "${tmp}"' EXIT
 ROOT="${tmp}/install"
 mkdir -p "${ROOT}"
+SOURCELENS_INSTALL_DIR="${ROOT}/sourcelens"
+mkdir -p "${SOURCELENS_INSTALL_DIR}"
+cp "${ROOT_REPO}/deploy/installer/sourcelens/compose-lifecycle.sh" \
+	"${SOURCELENS_INSTALL_DIR}/compose-lifecycle.sh"
 printf 'APP_VERSION=1.0.0\n' >"${ROOT}/.env"
 
 calls=()
@@ -125,6 +129,8 @@ fi
 
 SOURCELENS_INSTALL_DIR="${tmp}/sourcelens"
 mkdir -p "${SOURCELENS_INSTALL_DIR}/deploy/nginx/hfl-maintenance"
+cp "${ROOT_REPO}/deploy/installer/sourcelens/compose-lifecycle.sh" \
+	"${SOURCELENS_INSTALL_DIR}/compose-lifecycle.sh"
 sourcelens_nginx_running() { return 0; }
 sourcelens_nginx_has_proxy_gate() { return 0; }
 reload_sourcelens_proxy_gate() { calls+=("sourcelens-gate-reload"); }

--- a/tools/quality/test-ci-release-assembly.sh
+++ b/tools/quality/test-ci-release-assembly.sh
@@ -91,6 +91,8 @@ mkdir -p "${sl}/sourcelens/deploy/postgresql/initdb.d" \
 	"${sl}/sourcelens/deploy/sentry" \
 	"${sl}/payload/media/gateway-bootstrap"
 printf '#!/usr/bin/env bash\nexit 0\n' >"${sl}/sourcelens/install.sh"
+cp "${ROOT}/deploy/installer/sourcelens/compose-lifecycle.sh" \
+	"${sl}/sourcelens/compose-lifecycle.sh"
 printf '#!/usr/bin/env python3\n' >"${sl}/sourcelens/patch-env-runtime.py"
 printf '#!/usr/bin/env python3\n' >"${sl}/sourcelens/sync-sentry-runtime.py"
 mkdir -p "${sl}/sourcelens/deploy/nginx"

--- a/tools/quality/test-compose-lifecycle-reconcile.sh
+++ b/tools/quality/test-compose-lifecycle-reconcile.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "${TMP}"' EXIT
+
+warn() { printf '[WARN] %s\n' "$*"; }
+log() { printf '[INFO] %s\n' "$*"; }
+
+# shellcheck source=../../deploy/installer/sourcelens/compose-lifecycle.sh
+source "${ROOT}/deploy/installer/sourcelens/compose-lifecycle.sh"
+
+mkdir -p "${TMP}/bin"
+cat >"${TMP}/bin/docker" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+[[ "${1:-}" == "inspect" ]] || exit 90
+count_file="${HFL_TEST_DOCKER_COUNT_FILE}"
+count=0
+[[ ! -f "${count_file}" ]] || count="$(cat "${count_file}")"
+count=$((count + 1))
+printf '%s\n' "${count}" >"${count_file}"
+case "${HFL_TEST_DOCKER_MODE:-stopped}" in
+stopped) printf 'false\n' ;;
+settle)
+	if [[ "${count}" -lt 2 ]]; then printf 'true\n'; else printf 'false\n'; fi
+	;;
+stuck) printf 'true\n' ;;
+missing)
+	printf 'Error: No such object: %s\n' "${*: -1}" >&2
+	exit 1
+	;;
+error)
+	printf 'Cannot connect to the Docker daemon\n' >&2
+	exit 1
+	;;
+hang)
+	sleep 5
+	printf 'true\n'
+	;;
+*) exit 91 ;;
+esac
+SH
+chmod +x "${TMP}/bin/docker"
+export PATH="${TMP}/bin:${PATH}"
+export HFL_TEST_DOCKER_COUNT_FILE="${TMP}/docker-count"
+export HFL_COMPOSE_EXIT_EVENT_WAIT_SECONDS=3
+export HFL_COMPOSE_EXIT_EVENT_POLL_SECONDS=1
+
+increment_compose_count() {
+	local count=0
+	[[ ! -f "${TMP}/compose-count" ]] || count="$(cat "${TMP}/compose-count")"
+	printf '%s\n' "$((count + 1))" >"${TMP}/compose-count"
+}
+
+compose_success() {
+	increment_compose_count
+	printf 'compose ready\n'
+}
+
+compose_configuration_failure() {
+	increment_compose_count
+	printf 'Bind for 0.0.0.0:11445 failed: port is already allocated\n' >&2
+	return 17
+}
+
+compose_non_transient_stop_failure() {
+	increment_compose_count
+	printf 'Error response from daemon: cannot stop container: abcdef1234567890: permission denied\n' >&2
+	return 18
+}
+
+compose_transient_then_success() {
+	increment_compose_count
+	if [[ "$(cat "${TMP}/compose-count")" -eq 1 ]]; then
+		printf 'Error response from daemon: cannot stop container: abcdef1234567890: tried to kill container, but did not receive an exit event\n' >&2
+		return 1
+	fi
+	printf 'compose reconciled\n'
+}
+
+compose_transient_then_failure() {
+	increment_compose_count
+	if [[ "$(cat "${TMP}/compose-count")" -eq 1 ]]; then
+		printf 'Error response from daemon: cannot stop container: abcdef1234567890: tried to kill container, but did not receive an exit event\n' >&2
+		return 1
+	fi
+	printf 'second compose attempt failed\n' >&2
+	return 23
+}
+
+reset_case() {
+	rm -f "${TMP}/compose-count" "${HFL_TEST_DOCKER_COUNT_FILE}"
+}
+
+reset_case
+hfl_compose_command_with_exit_event_recovery compose_success up -d
+[[ "$(cat "${TMP}/compose-count")" == "1" ]]
+[[ ! -e "${HFL_TEST_DOCKER_COUNT_FILE}" ]]
+
+reset_case
+if hfl_compose_command_with_exit_event_recovery compose_configuration_failure up -d; then
+	printf 'non-retryable Compose failure unexpectedly succeeded\n' >&2
+	exit 1
+else
+	rc=$?
+fi
+[[ "${rc}" -eq 17 ]]
+[[ "$(cat "${TMP}/compose-count")" == "1" ]]
+[[ ! -e "${HFL_TEST_DOCKER_COUNT_FILE}" ]]
+
+reset_case
+if hfl_compose_command_with_exit_event_recovery compose_non_transient_stop_failure down; then
+	printf 'non-transient stop failure unexpectedly succeeded\n' >&2
+	exit 1
+else
+	rc=$?
+fi
+[[ "${rc}" -eq 18 ]]
+[[ "$(cat "${TMP}/compose-count")" == "1" ]]
+[[ ! -e "${HFL_TEST_DOCKER_COUNT_FILE}" ]]
+
+reset_case
+export HFL_TEST_DOCKER_MODE=stopped
+hfl_compose_command_with_exit_event_recovery compose_transient_then_success up -d
+[[ "$(cat "${TMP}/compose-count")" == "2" ]]
+[[ "$(cat "${HFL_TEST_DOCKER_COUNT_FILE}")" == "1" ]]
+
+reset_case
+export HFL_TEST_DOCKER_MODE=settle
+hfl_compose_command_with_exit_event_recovery compose_transient_then_success up -d
+[[ "$(cat "${TMP}/compose-count")" == "2" ]]
+[[ "$(cat "${HFL_TEST_DOCKER_COUNT_FILE}")" == "2" ]]
+
+reset_case
+export HFL_TEST_DOCKER_MODE=missing
+hfl_compose_command_with_exit_event_recovery compose_transient_then_success up -d
+[[ "$(cat "${TMP}/compose-count")" == "2" ]]
+
+reset_case
+export HFL_TEST_DOCKER_MODE=error
+if hfl_compose_command_with_exit_event_recovery compose_transient_then_success up -d; then
+	printf 'Docker inspect failure unexpectedly retried Compose\n' >&2
+	exit 1
+fi
+[[ "$(cat "${TMP}/compose-count")" == "1" ]]
+
+reset_case
+export HFL_TEST_DOCKER_MODE=stopped
+if hfl_compose_command_with_exit_event_recovery compose_transient_then_failure up -d; then
+	printf 'second Compose failure unexpectedly succeeded\n' >&2
+	exit 1
+else
+	rc=$?
+fi
+[[ "${rc}" -eq 23 ]]
+[[ "$(cat "${TMP}/compose-count")" == "2" ]]
+
+reset_case
+export HFL_TEST_DOCKER_MODE=stuck
+export HFL_COMPOSE_EXIT_EVENT_WAIT_SECONDS=1
+if hfl_compose_command_with_exit_event_recovery compose_transient_then_success up -d; then
+	printf 'stuck container unexpectedly retried Compose\n' >&2
+	exit 1
+fi
+[[ "$(cat "${TMP}/compose-count")" == "1" ]]
+
+reset_case
+export HFL_TEST_DOCKER_MODE=hang
+export HFL_COMPOSE_EXIT_EVENT_WAIT_SECONDS=1
+started_at=${SECONDS}
+if hfl_compose_command_with_exit_event_recovery compose_transient_then_success up -d; then
+	printf 'unresponsive Docker inspect unexpectedly retried Compose\n' >&2
+	exit 1
+fi
+[[ "$((SECONDS - started_at))" -le 2 ]]
+[[ "$(cat "${TMP}/compose-count")" == "1" ]]
+
+reset_case
+export HFL_TEST_DOCKER_MODE=stopped
+export HFL_COMPOSE_EXIT_EVENT_WAIT_SECONDS=61
+if hfl_compose_command_with_exit_event_recovery compose_transient_then_success up -d; then
+	printf 'overlong lifecycle window unexpectedly retried Compose\n' >&2
+	exit 1
+fi
+[[ "$(cat "${TMP}/compose-count")" == "1" ]]
+
+printf 'Compose lifecycle reconciliation checks passed.\n'

--- a/tools/quality/test-sourcelens-runtime-fingerprint.sh
+++ b/tools/quality/test-sourcelens-runtime-fingerprint.sh
@@ -28,6 +28,7 @@ write_bundle() {
 }
 JSON
 	printf 'services: {}\n' >"${root}/docker-compose.yml"
+	printf 'lifecycle-helper-v1\n' >"${root}/compose-lifecycle.sh"
 }
 
 write_bundle "${SOURCELENS_INSTALL_DIR}" old-patchset
@@ -80,6 +81,16 @@ sourcelens_bundle_changed "${tmp}/target"
 record_sourcelens_installed_bundle "${target}"
 if sourcelens_bundle_changed "${tmp}/target"; then
 	printf 'ERROR: recorded SourceLens runtime was reported as changed\n' >&2
+	exit 1
+fi
+
+# Lifecycle recovery is part of the installed runtime contract even when the
+# upstream SourceLens version and image identities stay unchanged.
+printf 'lifecycle-helper-v2\n' >"${target}/compose-lifecycle.sh"
+sourcelens_bundle_changed "${tmp}/target"
+record_sourcelens_installed_bundle "${target}"
+if sourcelens_bundle_changed "${tmp}/target"; then
+	printf 'ERROR: recorded SourceLens lifecycle helper was reported as changed\n' >&2
 	exit 1
 fi
 


### PR DESCRIPTION
## Summary
- recover the specific Docker exit-event delay during SourceLens Compose lifecycle operations
- bound reconciliation to one retry within a shared 60-second window
- ship and fingerprint the lifecycle helper in Community and Enterprise release assembly
- cover development, install, upgrade, recovery, and CI paths

## Validation
- Compose lifecycle reconciliation checks
- Nginx startup readiness checks
- blue/green recovery checks
- synthetic CI release assembly
- release contract checks
- English source boundary and workflow YAML validation