### PR TITLE
fix(storage): harden S3 repository initialization and recovery

### DIFF
--- a/language-packs/packs/zh-hans/frontend/messages.json
+++ b/language-packs/packs/zh-hans/frontend/messages.json
@@ -4382,7 +4382,7 @@
     "phBucketSelect": "请选择已有存储桶",
     "phBucketNew": "请输入新存储桶名称，示例：my-backup-bucket",
     "fieldPrefix": "对象前缀",
-    "hintPrefix": "仓库存储数据的对象存储目录路径。",
+    "hintPrefix": "留空表示使用整个 Bucket；也可填写独立目录，系统会自动补全末尾的 /。",
     "fieldQuota": "存储限额",
     "phQuota": "0 表示不限制",
     "hintQuota": "设置为 0 表示不限制存储容量。",

--- a/src/backend/apps/storage/services/internal/repository_create.py
+++ b/src/backend/apps/storage/services/internal/repository_create.py
@@ -454,7 +454,15 @@ def _run_repository_create_task_locked(*, repository_task_id: int) -> dict[str, 
             ):
                 _run_repair_remount(repository_task)
             else:
-                initialization_outcome = _run_initialize(repository)
+                initialization_outcome = _run_initialize(
+                    repository,
+                    recovery=(
+                        not started_now
+                        or repository.location_claims.filter(
+                            state=RepositoryLocationClaim.State.RESIDUAL
+                        ).exists()
+                    ),
+                )
             physical_initialize_done = True
             if (
                 repository_task.operation_type
@@ -688,13 +696,13 @@ def _resolve_create_owner(
     )
 
 
-def _run_initialize(repository: Repository):
+def _run_initialize(repository: Repository, *, recovery: bool = False):
     if repository.repo_type == Repository.Type.NAS:
         return initialize_proxy_nas_repository(repository)
     if repository.repo_type == Repository.Type.PROXY_FS:
         return initialize_proxy_fs_repository(repository)
     if repository.repo_type == Repository.Type.S3:
-        initialize_s3_repository(repository)
+        initialize_s3_repository(repository, recovery=recovery)
         return
     raise ValidationError(
         f"Unsupported repository type for create: {repository.repo_type}"

--- a/src/backend/apps/storage/services/internal/repository_initializer.py
+++ b/src/backend/apps/storage/services/internal/repository_initializer.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from contextlib import nullcontext
 from ipaddress import ip_address
 from time import sleep
 from urllib.parse import urlparse
@@ -18,8 +17,10 @@ from apps.storage.services.internal.repository_errors import (
 )
 from apps.storage.services.internal.repository_ownership import (
     RepositoryOwnershipError,
-    claim_s3_repository_ownership,
-    s3_ownership_marker_hidden,
+    S3RepositoryInitializationState,
+    establish_s3_repository_ownership,
+    inspect_s3_repository_initialization,
+    reset_s3_legacy_marker_for_initialization_recovery,
     verify_s3_repository_ownership,
 )
 from apps.storage.services.internal.s3_client import (
@@ -36,7 +37,9 @@ from apps.storage.services.internal.repository_secrets import (
     scrub_secrets,
     secret_values_for_scrub,
 )
-from apps.storage.services.internal.repository_endpoints import repository_control_endpoint
+from apps.storage.services.internal.repository_endpoints import (
+    repository_control_endpoint,
+)
 from apps.storage.services.internal.s3_url_style import (
     S3_URL_STYLE_AUTO,
     S3_URL_STYLE_PATH,
@@ -62,7 +65,9 @@ def resolve_s3_url_style(*, s3_url_style: str | None, **bucket_args) -> str:
     normalized = normalize_s3_url_style(s3_url_style)
     if normalized != S3_URL_STYLE_AUTO:
         return normalized
-    probe_args = {key: value for key, value in bucket_args.items() if key != "s3_url_style"}
+    probe_args = {
+        key: value for key, value in bucket_args.items() if key != "s3_url_style"
+    }
     failures: dict[str, str] = {}
     successful_styles: set[str] = set()
     for style in (S3_URL_STYLE_PATH, S3_URL_STYLE_VIRTUAL_HOSTED):
@@ -72,7 +77,9 @@ def resolve_s3_url_style(*, s3_url_style: str | None, **bucket_args) -> str:
             # botocore silently falls back to path-style for IP endpoints even
             # when asked for virtual addressing. Kopia does not, so consider
             # this candidate incompatible rather than accepting a false probe.
-            failures[style] = "Virtual Hosted Style requires a DNS endpoint, not an IP address."
+            failures[style] = (
+                "Virtual Hosted Style requires a DNS endpoint, not an IP address."
+            )
             continue
         for attempt in range(S3_URL_STYLE_PROBE_ATTEMPTS):
             try:
@@ -108,7 +115,12 @@ def _s3_endpoint_is_ip_literal(endpoint: object) -> bool:
     return True
 
 
-def initialize_s3_repository(repository: Repository) -> None:
+def initialize_s3_repository(
+    repository: Repository,
+    *,
+    recovery: bool = False,
+) -> None:
+    """Initialize or recover an S3-backed Kopia repository."""
     config = dict(repository.config or {})
     secrets_payload = resolve_repository_secrets(repository)
     try:
@@ -123,13 +135,20 @@ def initialize_s3_repository(repository: Repository) -> None:
             ),
             use_tls=config.get("use_tls") is not False,
         )
+        bucket_created = False
         if repository.s3_bucket_mode == Repository.S3BucketMode.NEW:
-            create_s3_bucket(**bucket_args)
+            bucket_created = create_s3_bucket(
+                **bucket_args,
+                allow_existing_owned=recovery,
+            )
         if bucket_args["s3_url_style"] == S3_URL_STYLE_AUTO:
             try:
                 resolved_url_style = resolve_s3_url_style(**bucket_args)
             except S3UrlStyleProbeError as exc:
-                if repository.s3_bucket_mode != Repository.S3BucketMode.NEW:
+                if (
+                    repository.s3_bucket_mode != Repository.S3BucketMode.NEW
+                    or not bucket_created
+                ):
                     raise
                 rollback = delete_s3_bucket_if_empty(**bucket_args)
                 rollback_detail = ""
@@ -150,30 +169,48 @@ def initialize_s3_repository(repository: Repository) -> None:
             config["s3_url_style"] = resolved_url_style
             repository.config = config
             repository.save(update_fields=["config", "updated_at"])
-        # The lifecycle path persists the Repository before initialization, so
-        # the ownership Claim is mandatory there. Keep this low-level helper
-        # compatible with older/unit callers that pass an unsaved model (there
-        # is no database Claim to coordinate for such an object); those calls
-        # cannot be used by the Controller lifecycle and therefore must not
-        # weaken persisted-repository cleanup authorization.
-        # Kopia refuses to create a repository inside a Prefix that already
-        # contains any object - including the ownership marker written by the
-        # Claim (it reports "found existing data in storage location").
-        # Claim first so the marker is validated (a residual marker left by a
-        # failed attempt is matched and kept; a fresh Prefix is atomically
-        # claimed). Only then hide the marker while Kopia initializes the empty
-        # Prefix, and restore it afterwards so the ownership proof survives.
-        # Unsaved models (older unit callers) have no Claim and therefore no
-        # marker to hide.
-        if repository.pk is not None:
-            claim_s3_repository_ownership(repository)
-        marker_context = (
-            s3_ownership_marker_hidden(repository)
-            if repository.pk is not None
-            else nullcontext()
-        )
-        with marker_context:
+        # Kopia requires an empty Bucket+Prefix during first initialization.
+        # Persisted repositories therefore inspect without writing the HFL
+        # owner marker, initialize Kopia first, and establish ownership only
+        # after the physical repository exists. Unsaved unit/legacy callers
+        # retain the low-level create-only behavior and cannot authorize any
+        # later destructive lifecycle operation.
+        if repository.pk is None:
             create_s3_repository(repository)
+            return
+
+        initialization_state = inspect_s3_repository_initialization(repository)
+        if initialization_state == S3RepositoryInitializationState.OWNED:
+            try:
+                connect_s3_repository(repository)
+                kopia_status(repository)
+            except KopiaCliError:
+                if not recovery:
+                    raise
+                reset_s3_legacy_marker_for_initialization_recovery(repository)
+                create_s3_repository(repository)
+                establish_s3_repository_ownership(repository)
+            return
+        if initialization_state == S3RepositoryInitializationState.OCCUPIED:
+            if not recovery:
+                raise RepositoryAlreadyExistsError(
+                    "The selected object Prefix already contains data."
+                )
+            try:
+                connect_s3_repository(repository)
+                kopia_status(repository)
+            except KopiaCliError as exc:
+                raise RepositoryAlreadyExistsError(
+                    _sanitize(
+                        "The residual object Prefix is not a recoverable Kopia repository.",
+                        repository,
+                    )
+                ) from exc
+            establish_s3_repository_ownership(repository)
+            return
+
+        create_s3_repository(repository)
+        establish_s3_repository_ownership(repository)
     except S3UrlStyleProbeError as exc:
         raise RepositoryInitializationError(_sanitize(str(exc), repository)) from exc
     except KopiaRepositoryAlreadyExistsError as exc:
@@ -218,10 +255,15 @@ def validate_s3_connection(
             use_tls=use_tls,
         )
     except S3ClientError as exc:
-        raise RepositoryInitializationError(_sanitize(str(exc), {
-            "access_key_id": access_key_id,
-            "secret_access_key": secret_access_key,
-        })) from exc
+        raise RepositoryInitializationError(
+            _sanitize(
+                str(exc),
+                {
+                    "access_key_id": access_key_id,
+                    "secret_access_key": secret_access_key,
+                },
+            )
+        ) from exc
 
 
 def verify_s3_bucket_access(
@@ -245,10 +287,15 @@ def verify_s3_bucket_access(
             use_tls=use_tls,
         )
     except S3ClientError as exc:
-        raise RepositoryInitializationError(_sanitize(str(exc), {
-            "access_key_id": access_key_id,
-            "secret_access_key": secret_access_key,
-        })) from exc
+        raise RepositoryInitializationError(
+            _sanitize(
+                str(exc),
+                {
+                    "access_key_id": access_key_id,
+                    "secret_access_key": secret_access_key,
+                },
+            )
+        ) from exc
 
 
 def check_s3_repository(
@@ -292,6 +339,10 @@ def _sanitize(message: str, source) -> str:
     else:
         config = source or {}
         secrets_payload = config
-    return str(scrub_secrets(message, extra_values=secret_values_for_scrub(None, secrets_payload) + [
-        str(config.get("access_key_id") or "")
-    ]))
+    return str(
+        scrub_secrets(
+            message,
+            extra_values=secret_values_for_scrub(None, secrets_payload)
+            + [str(config.get("access_key_id") or "")],
+        )
+    )

--- a/src/backend/apps/storage/services/internal/repository_ownership.py
+++ b/src/backend/apps/storage/services/internal/repository_ownership.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 import hashlib
 import hmac
 import json
-from contextlib import contextmanager
 from dataclasses import dataclass
+from enum import StrEnum
 
 from django.core.exceptions import ValidationError
 
@@ -28,9 +28,9 @@ from apps.storage.services.internal.s3_client import (
     delete_s3_object,
     identify_s3_namespace,
     list_s3_object_keys,
-    put_s3_object,
     put_s3_object_if_absent,
     read_s3_object,
+    s3_prefix_contains_only_key,
     s3_prefix_has_any_state,
 )
 from apps.storage.services.internal.s3_url_style import normalize_s3_url_style
@@ -46,6 +46,14 @@ class RepositoryOwnershipError(ValidationError):
 
 class RepositoryOwnershipMarkerMissingError(RepositoryOwnershipError):
     """Raised when destructive ownership proof has no physical marker."""
+
+
+class S3RepositoryInitializationState(StrEnum):
+    """Physical states relevant to an S3 repository initialization attempt."""
+
+    EMPTY = "empty"
+    OWNED = "owned"
+    OCCUPIED = "occupied"
 
 
 @dataclass(frozen=True)
@@ -117,8 +125,10 @@ def ownership_payload(
     return {**unsigned, "signature": _sign_marker(unsigned)}
 
 
-def claim_s3_repository_ownership(repository: Repository) -> None:
-    """Resolve the S3 namespace and atomically claim an empty Prefix."""
+def inspect_s3_repository_initialization(
+    repository: Repository,
+) -> S3RepositoryInitializationState:
+    """Inspect the target Prefix without changing its physical contents."""
     s3_args = _s3_args(repository)
     _ensure_s3_namespace_resolved(repository, s3_args=s3_args)
     expected = ownership_payload(repository)
@@ -137,14 +147,42 @@ def claim_s3_repository_ownership(repository: Repository) -> None:
             s3_args=s3_args,
         )
         mark_repository_location_ownership_verified(repository)
-        return
+        return S3RepositoryInitializationState.OWNED
+
+    _reject_foreign_descendant_markers(
+        repository=repository,
+        expected=expected,
+        s3_args=s3_args,
+    )
 
     prefix = _prefix_with_slash(repository)
     if s3_prefix_has_any_state(**s3_args, prefix=prefix):
-        raise RepositoryOwnershipError(
-            "The selected object Prefix contains objects, historical versions, "
-            "or incomplete uploads and cannot be claimed as a new repository."
-        )
+        return S3RepositoryInitializationState.OCCUPIED
+    return S3RepositoryInitializationState.EMPTY
+
+
+def establish_s3_repository_ownership(repository: Repository) -> None:
+    """Persist and verify ownership after Kopia has initialized the Prefix."""
+    s3_args = _s3_args(repository)
+    _ensure_s3_namespace_resolved(repository, s3_args=s3_args)
+    expected = ownership_payload(repository)
+    marker_key = _marker_key(repository)
+    _reject_foreign_ancestor_markers(
+        repository=repository,
+        expected=expected,
+        s3_args=s3_args,
+    )
+    _reject_foreign_descendant_markers(
+        repository=repository,
+        expected=expected,
+        s3_args=s3_args,
+    )
+    existing = read_s3_object(**s3_args, key=marker_key)
+    if existing is not None:
+        _require_matching_marker(existing, expected=expected)
+        mark_repository_location_ownership_verified(repository)
+        return
+
     marker_bytes = _encode_marker(expected)
     if not put_s3_object_if_absent(
         **s3_args,
@@ -164,10 +202,8 @@ def claim_s3_repository_ownership(repository: Repository) -> None:
             "Repository ownership marker was not durable after creation."
         )
     _require_matching_marker(persisted, expected=expected)
-    # A database Claim serializes locations that the control plane can identify,
-    # but different private-network aliases may reach the same storage. Repeat
-    # the physical hierarchy proof after the atomic marker write so neither an
-    # ancestor nor a descendant can slip in between the initial probe and init.
+    # Repeat the hierarchy proof after persisting the marker so a concurrent
+    # ancestor or descendant cannot be accepted as a completed initialization.
     _reject_foreign_ancestor_markers(
         repository=repository,
         expected=expected,
@@ -179,6 +215,39 @@ def claim_s3_repository_ownership(repository: Repository) -> None:
         s3_args=s3_args,
     )
     mark_repository_location_ownership_verified(repository)
+
+
+def reset_s3_legacy_marker_for_initialization_recovery(
+    repository: Repository,
+) -> None:
+    """Remove a matching marker left by the pre-Kopia ownership protocol."""
+    s3_args = _s3_args(repository)
+    _ensure_s3_namespace_resolved(repository, s3_args=s3_args)
+    expected = ownership_payload(repository)
+    marker_key = _marker_key(repository)
+    marker = read_s3_object(**s3_args, key=marker_key)
+    if marker is None:
+        return
+    _require_matching_marker(marker, expected=expected)
+    _reject_foreign_ancestor_markers(
+        repository=repository,
+        expected=expected,
+        s3_args=s3_args,
+    )
+    prefix = _prefix_with_slash(repository)
+    if not s3_prefix_contains_only_key(
+        **s3_args,
+        prefix=prefix,
+        allowed_key=marker_key,
+    ):
+        raise RepositoryOwnershipError(
+            "The owned Prefix contains repository data and cannot be reset for initialization."
+        )
+    delete_s3_object(**s3_args, key=marker_key)
+    if read_s3_object(**s3_args, key=marker_key) is not None:
+        raise RepositoryOwnershipError(
+            "The legacy repository ownership marker could not be removed."
+        )
 
 
 def verify_s3_repository_ownership(
@@ -471,30 +540,6 @@ def _require_matching_marker(
     return marker
 
 
-@contextmanager
-def s3_ownership_marker_hidden(repository: Repository):
-    """Hide the ownership marker while Kopia initializes an empty Prefix.
-
-    ``claim_s3_repository_ownership`` atomically writes an ownership marker
-    before the physical repository is created. Kopia, however, refuses
-    ``repository create`` when the target Prefix already contains *any*
-    object - including our own marker - and reports "found existing data in
-    storage location". Temporarily remove the marker for the duration of the
-    physical create and restore it afterwards so the ownership proof survives.
-    """
-    s3_args = _s3_args(repository)
-    marker_key = _marker_key(repository)
-    marker = read_s3_object(**s3_args, key=marker_key)
-    if marker is None:
-        yield
-        return
-    delete_s3_object(**s3_args, key=marker_key)
-    try:
-        yield
-    finally:
-        put_s3_object(**s3_args, key=marker_key, body=marker)
-
-
 def _sign_marker(payload: dict[str, object]) -> str:
     encoded = json.dumps(
         payload,
@@ -515,10 +560,13 @@ __all__ = [
     "OWNERSHIP_MARKER_PATH",
     "RepositoryOwnershipError",
     "RepositoryOwnershipMarkerMissingError",
-    "claim_s3_repository_ownership",
+    "S3RepositoryInitializationState",
+    "establish_s3_repository_ownership",
+    "inspect_s3_repository_initialization",
     "ownership_payload_for_node",
     "repository_deployment_uuid",
     "repository_location_digest",
+    "reset_s3_legacy_marker_for_initialization_recovery",
     "s3_repository_ownership_marker",
     "verify_s3_repository_deletion_ownership",
     "verify_s3_repository_ownership",

--- a/src/backend/apps/storage/services/internal/s3_client.py
+++ b/src/backend/apps/storage/services/internal/s3_client.py
@@ -37,8 +37,10 @@ _PROVIDER_BUCKET_CAPABILITIES = {
 }
 _ATOMIC_CREATE_IF_NONE_MATCH = "if_none_match"
 _ATOMIC_CREATE_ALIYUN_FORBID_OVERWRITE = "aliyun_forbid_overwrite"
+_ATOMIC_CREATE_HUAWEI_FORBID_OVERWRITE = "huawei_forbid_overwrite"
 _PROVIDER_ATOMIC_CREATE_STRATEGIES = {
     "aliyun": _ATOMIC_CREATE_ALIYUN_FORBID_OVERWRITE,
+    "huaweicloud": _ATOMIC_CREATE_HUAWEI_FORBID_OVERWRITE,
 }
 _BUCKET_REGION_FIELDS = (
     "BucketRegion",
@@ -270,8 +272,9 @@ def create_s3_bucket(
     s3_url_style: str | None = None,
     use_tls: bool = True,
     timeout_seconds: float = 15,
-) -> None:
-    """Create a bucket and reject any existing-name collision."""
+    allow_existing_owned: bool = False,
+) -> bool:
+    """Create a bucket and report whether this call created it."""
     if not str(bucket or "").strip():
         raise S3ClientError("Bucket name is required.")
     client = _client(
@@ -291,21 +294,11 @@ def create_s3_bucket(
         client.create_bucket(**create_args)
     except ClientError as exc:
         if _client_error_code(exc) == "BucketAlreadyOwnedByYou":
-            # The bucket belongs to the current credentials; it may have been
-            # left behind by a previously failed creation attempt. Allow
-            # re-initialization only when the bucket holds no data, otherwise
-            # reject so an existing location is never silently reused.
-            try:
-                holds_state = _prefix_holds_any_state(client, bucket=bucket)
-            except (BotoCoreError, ClientError) as probe_exc:
-                raise S3ClientError(
-                    _error_message(f"Unable to inspect existing S3 bucket {bucket}", probe_exc)
-                ) from probe_exc
-            if holds_state:
-                raise S3ClientError(
-                    f"Unable to create S3 bucket {bucket}: bucket already exists."
-                ) from exc
-            return None
+            if allow_existing_owned:
+                return False
+            raise S3ClientError(
+                f"Unable to create S3 bucket {bucket}: bucket already exists."
+            ) from exc
         if _client_error_code(exc) in {
             "BucketAlreadyExists",
             "OperationAborted",
@@ -313,20 +306,29 @@ def create_s3_bucket(
             raise S3ClientError(
                 f"Unable to create S3 bucket {bucket}: bucket already exists."
             ) from exc
-        if (
-            "CreateBucketConfiguration" in create_args
-            and _client_error_code(exc) in {"InvalidLocationConstraint", "XMinioInvalidRequest"}
-        ):
+        if "CreateBucketConfiguration" in create_args and _client_error_code(exc) in {
+            "InvalidLocationConstraint",
+            "XMinioInvalidRequest",
+        }:
             # Legacy single-Region gateways (e.g. older MinIO) reject the
             # LocationConstraint block; retry with the default placement.
             create_args.pop("CreateBucketConfiguration")
             try:
                 client.create_bucket(**create_args)
-            except (ClientError, BotoCoreError) as retry_exc:
+            except ClientError as retry_exc:
+                if (
+                    allow_existing_owned
+                    and _client_error_code(retry_exc) == "BucketAlreadyOwnedByYou"
+                ):
+                    return False
                 raise S3ClientError(
                     _error_message(f"Unable to create S3 bucket {bucket}", retry_exc)
                 ) from retry_exc
-            return None
+            except BotoCoreError as retry_exc:
+                raise S3ClientError(
+                    _error_message(f"Unable to create S3 bucket {bucket}", retry_exc)
+                ) from retry_exc
+            return True
         raise S3ClientError(
             _error_message(f"Unable to create S3 bucket {bucket}", exc)
         ) from exc
@@ -334,6 +336,7 @@ def create_s3_bucket(
         raise S3ClientError(
             _error_message(f"Unable to create S3 bucket {bucket}", exc)
         ) from exc
+    return True
 
 
 def check_s3_bucket_readable(
@@ -455,7 +458,7 @@ def delete_s3_object(
     use_tls: bool = True,
     timeout_seconds: float = 15,
 ) -> None:
-    """Remove a single owned object (used to hide the ownership marker)."""
+    """Delete one exact object after the ownership service authorizes it."""
     client = _client(
         endpoint=endpoint,
         region=region,
@@ -469,44 +472,7 @@ def delete_s3_object(
         client.delete_object(Bucket=bucket, Key=key)
     except (BotoCoreError, ClientError) as exc:
         raise S3ClientError(
-            _error_message("Unable to hide repository ownership marker", exc)
-        ) from exc
-
-
-def put_s3_object(
-    *,
-    endpoint: str | None,
-    region: str | None,
-    bucket: str,
-    key: str,
-    body: bytes,
-    access_key_id: str,
-    secret_access_key: str,
-    s3_url_style: str | None = None,
-    use_tls: bool = True,
-    timeout_seconds: float = 15,
-) -> None:
-    """Overwrite an existing object (used to restore the ownership marker)."""
-    client = _client(
-        endpoint=endpoint,
-        region=region,
-        access_key_id=access_key_id,
-        secret_access_key=secret_access_key,
-        s3_url_style=s3_url_style,
-        use_tls=use_tls,
-        timeout_seconds=timeout_seconds,
-    )
-    try:
-        client.put_object(
-            Bucket=bucket,
-            Key=key,
-            Body=body,
-            ContentLength=len(body),
-            ContentType="application/json",
-        )
-    except (BotoCoreError, ClientError, ParamValidationError) as exc:
-        raise S3ClientError(
-            _error_message("Unable to restore repository ownership marker", exc)
+            _error_message("Unable to remove legacy repository ownership marker", exc)
         ) from exc
 
 
@@ -524,7 +490,7 @@ def put_s3_object_if_absent(
     use_tls: bool = True,
     timeout_seconds: float = 15,
 ) -> bool:
-    """Atomically create an ownership marker; return False if it exists."""
+    """Create an ownership marker without replacing a known existing object."""
     client = _client(
         endpoint=endpoint,
         region=region,
@@ -551,6 +517,12 @@ def put_s3_object_if_absent(
             _add_aliyun_forbid_overwrite_header,
             unique_id="hfl-aliyun-forbid-overwrite",
         )
+    elif atomic_create_strategy == _ATOMIC_CREATE_HUAWEI_FORBID_OVERWRITE:
+        client.meta.events.register_first(
+            "before-sign.s3.PutObject",
+            _add_huawei_forbid_overwrite_header,
+            unique_id="hfl-huawei-forbid-overwrite",
+        )
     else:
         put_args["IfNoneMatch"] = "*"
     try:
@@ -564,16 +536,44 @@ def put_s3_object_if_absent(
         }
         if atomic_create_strategy == _ATOMIC_CREATE_ALIYUN_FORBID_OVERWRITE:
             conflict_codes.add("FileAlreadyExists")
+        elif atomic_create_strategy == _ATOMIC_CREATE_HUAWEI_FORBID_OVERWRITE:
+            conflict_codes.update({"Conflict", "ObjectAlreadyExists", "409"})
         if _client_error_code(exc) in conflict_codes:
             return False
         if (
             atomic_create_strategy == _ATOMIC_CREATE_IF_NONE_MATCH
             and _client_error_code(exc) in {"NotImplemented", "XMinioInvalidRequest"}
         ):
-            # Legacy S3-compatible gateways (e.g. older MinIO) do not support
-            # the If-None-Match conditional create. Fall back to a plain
-            # overwrite; the ownership marker is signature-verified downstream.
+            # Legacy MinIO does not support conditional PutObject. Callers use
+            # this fallback only after the database Claim has serialized the
+            # location and Kopia has initialized it. The persisted marker is
+            # immediately read back and signature-verified by the ownership
+            # service; this write is not used as a pre-initialization lock.
             put_args.pop("IfNoneMatch", None)
+            try:
+                client.head_object(Bucket=bucket, Key=key)
+            except ClientError as probe_exc:
+                if _client_error_code(probe_exc) not in {
+                    "404",
+                    "NoSuchKey",
+                    "NotFound",
+                    "XNoSuchKey",
+                }:
+                    raise S3ClientError(
+                        _error_message(
+                            "Unable to inspect repository ownership marker",
+                            probe_exc,
+                        )
+                    ) from probe_exc
+            except BotoCoreError as probe_exc:
+                raise S3ClientError(
+                    _error_message(
+                        "Unable to inspect repository ownership marker",
+                        probe_exc,
+                    )
+                ) from probe_exc
+            else:
+                return False
             try:
                 client.put_object(**put_args)
                 return True
@@ -593,9 +593,9 @@ def put_s3_object_if_absent(
 def _s3_atomic_create_strategy(*, platform: str | None, endpoint: str | None) -> str:
     """Select the Provider-specific atomic object creation contract.
 
-    Older installations stored Aliyun OSS as ``custom``. Endpoint inference is
-    deliberately limited to the official Aliyun domain so arbitrary custom S3
-    gateways continue using the standard conditional PutObject contract.
+    Older installations stored Aliyun OSS and Huawei OBS as ``custom``.
+    Endpoint inference is deliberately limited to official Provider domains so
+    arbitrary custom S3 gateways keep the standard conditional PutObject path.
     """
     normalized_platform = str(platform or "").strip().lower()
     if normalized_platform in {"", "custom"}:
@@ -605,6 +605,10 @@ def _s3_atomic_create_strategy(*, platform: str | None, endpoint: str | None) ->
             ".aliyuncs.com"
         ):
             return _ATOMIC_CREATE_ALIYUN_FORBID_OVERWRITE
+        if normalized_hostname == "myhuaweicloud.com" or normalized_hostname.endswith(
+            ".myhuaweicloud.com"
+        ):
+            return _ATOMIC_CREATE_HUAWEI_FORBID_OVERWRITE
     return _PROVIDER_ATOMIC_CREATE_STRATEGIES.get(
         normalized_platform,
         _ATOMIC_CREATE_IF_NONE_MATCH,
@@ -614,6 +618,11 @@ def _s3_atomic_create_strategy(*, platform: str | None, endpoint: str | None) ->
 def _add_aliyun_forbid_overwrite_header(*, request, **_kwargs) -> None:
     """Apply Aliyun OSS's atomic create-only header before request signing."""
     request.headers["x-oss-forbid-overwrite"] = "true"
+
+
+def _add_huawei_forbid_overwrite_header(*, request, **_kwargs) -> None:
+    """Apply Huawei OBS's atomic create-only header before request signing."""
+    request.headers["x-obs-forbid-overwrite"] = "true"
 
 
 def list_s3_object_keys(
@@ -710,6 +719,63 @@ def s3_prefix_has_any_state(
     except (BotoCoreError, ClientError) as exc:
         raise S3ClientError(
             _error_message("Unable to inspect repository object prefix", exc)
+        ) from exc
+
+
+def s3_prefix_contains_only_key(
+    *,
+    endpoint: str | None,
+    region: str | None,
+    bucket: str,
+    prefix: str,
+    allowed_key: str,
+    access_key_id: str,
+    secret_access_key: str,
+    s3_url_style: str | None = None,
+    use_tls: bool = True,
+    timeout_seconds: float = 30,
+) -> bool:
+    """Return whether all current and historical Prefix state belongs to one key."""
+    client = _client(
+        endpoint=endpoint,
+        region=region,
+        access_key_id=access_key_id,
+        secret_access_key=secret_access_key,
+        s3_url_style=s3_url_style,
+        use_tls=use_tls,
+        timeout_seconds=timeout_seconds,
+    )
+    try:
+        object_pages = client.get_paginator("list_objects_v2")
+        for page in object_pages.paginate(Bucket=bucket, Prefix=prefix):
+            if any(
+                item.get("Key") and item.get("Key") != allowed_key
+                for item in page.get("Contents", [])
+            ):
+                return False
+        try:
+            version_pages = client.get_paginator("list_object_versions")
+            for page in version_pages.paginate(Bucket=bucket, Prefix=prefix):
+                if any(
+                    item.get("Key") and item.get("Key") != allowed_key
+                    for item in [
+                        *page.get("Versions", []),
+                        *page.get("DeleteMarkers", []),
+                    ]
+                ):
+                    return False
+        except ClientError as exc:
+            if not _is_unsupported_s3_header_error(exc):
+                raise
+        uploads = client.list_multipart_uploads(
+            Bucket=bucket,
+            Prefix=prefix,
+            MaxUploads=1,
+        )
+        return not bool(uploads.get("Uploads"))
+    except (BotoCoreError, ClientError) as exc:
+        raise S3ClientError(
+            _error_message("Unable to inspect legacy ownership residue", exc)
         ) from exc
 
 

--- a/src/backend/apps/storage/tests/test_repository_create.py
+++ b/src/backend/apps/storage/tests/test_repository_create.py
@@ -153,7 +153,7 @@ class RepositoryCreateTaskTests(TestCase):
         repository.refresh_from_db()
         self.assertEqual(repository.status, Repository.Status.CREATED)
         self.assertEqual(repository.health, Repository.Health.ONLINE)
-        initialize.assert_called_once_with(repository)
+        initialize.assert_called_once_with(repository, recovery=False)
         _enqueue.assert_called_once()
 
     @mock.patch(
@@ -530,6 +530,7 @@ class RepositoryCreateTaskTests(TestCase):
         self.assertEqual(repository.status, Repository.Status.CREATE_FAILED)
         claim.refresh_from_db()
         self.assertEqual(claim.state, RepositoryLocationClaim.State.RESIDUAL)
+        initialize.assert_called_once_with(repository, recovery=True)
         check_repository.assert_called_once_with(repository)
 
     @mock.patch(
@@ -558,6 +559,7 @@ class RepositoryCreateTaskTests(TestCase):
         self.assertEqual(repository.status, Repository.Status.CREATE_FAILED)
         claim.refresh_from_db()
         self.assertEqual(claim.state, RepositoryLocationClaim.State.RESIDUAL)
+        _initialize.assert_called_once_with(repository, recovery=True)
         check_repository.assert_called_once_with(repository)
 
     @mock.patch("apps.storage.services.internal.repository_create.check_s3_repository")
@@ -587,6 +589,7 @@ class RepositoryCreateTaskTests(TestCase):
         claim.refresh_from_db()
         self.assertEqual(repository.status, Repository.Status.CREATED)
         self.assertEqual(claim.state, RepositoryLocationClaim.State.OWNED)
+        _initialize.assert_called_once_with(repository, recovery=True)
         check_repository.assert_called_once_with(repository)
 
     @mock.patch(

--- a/src/backend/apps/storage/tests/test_repository_location.py
+++ b/src/backend/apps/storage/tests/test_repository_location.py
@@ -19,11 +19,16 @@ from apps.storage.services.internal.repository_location import (
     reserve_direct_nas_location,
     reserve_repository_location,
 )
-from apps.storage.services.internal.repository_initializer import initialize_s3_repository
+from apps.storage.services.internal.repository_initializer import (
+    initialize_s3_repository,
+)
+from apps.storage.services.internal.kopia_cli import KopiaCliError
 from apps.storage.services.internal.repository_ownership import (
     RepositoryOwnershipError,
-    claim_s3_repository_ownership,
-    s3_ownership_marker_hidden,
+    S3RepositoryInitializationState,
+    establish_s3_repository_ownership,
+    inspect_s3_repository_initialization,
+    reset_s3_legacy_marker_for_initialization_recovery,
     verify_s3_repository_ownership,
 )
 from apps.storage.services.internal.s3_url_style import S3_URL_STYLE_PATH
@@ -427,26 +432,29 @@ class RepositoryLocationClaimTests(TestCase):
         return_value=None,
     )
     @mock.patch(
+        "apps.storage.services.internal.repository_ownership.list_s3_object_keys",
+        return_value=[],
+    )
+    @mock.patch(
         "apps.storage.services.internal.repository_ownership._ensure_s3_namespace_resolved"
     )
     @mock.patch(
         "apps.storage.services.internal.repository_ownership._s3_args",
         return_value={},
     )
-    def test_s3_claim_rejects_hidden_physical_state(
+    def test_s3_inspection_reports_occupied_physical_state(
         self,
         _s3_args,
         _resolve_namespace,
+        _list_keys,
         _read_marker,
         _prefix_has_state,
     ):
         repository = self._s3_repository(name="Versioned residue", prefix="hfl/")
 
-        with self.assertRaisesRegex(
-            RepositoryOwnershipError,
-            "historical versions",
-        ):
-            claim_s3_repository_ownership(repository)
+        state = inspect_s3_repository_initialization(repository)
+
+        self.assertEqual(state, S3RepositoryInitializationState.OCCUPIED)
 
     @mock.patch(
         "apps.storage.services.internal.repository_ownership.mark_repository_location_ownership_verified"
@@ -483,12 +491,14 @@ class RepositoryLocationClaimTests(TestCase):
     ):
         repository = self._s3_repository(name="Bucket Root", prefix="")
         marker = b'{"marker":"persisted"}'
-        read_marker.side_effect = [None, marker]
+        read_marker.side_effect = [None, None, marker]
         with mock.patch(
             "apps.storage.services.internal.repository_ownership._require_matching_marker"
         ):
-            claim_s3_repository_ownership(repository)
+            state = inspect_s3_repository_initialization(repository)
+            establish_s3_repository_ownership(repository)
 
+        self.assertEqual(state, S3RepositoryInitializationState.EMPTY)
         prefix_has_state.assert_called_once_with(prefix="")
         put_marker.assert_called_once()
         self.assertEqual(
@@ -557,112 +567,11 @@ class RepositoryLocationClaimTests(TestCase):
 
         put_marker.assert_not_called()
 
-    def test_s3_ownership_marker_hidden_removes_marker_before_create_and_restores_after(self):
-        repository = self._s3_repository(name="Hidden marker", prefix="hfl/")
-        marker = (
-            b'{"deployment_uuid":"d","repository_uuid":"r",'
-            b'"location_digest":"l","format_version":1,"signature":"sig"}'
-        )
-        calls: list[str] = []
-
-        with (
-            mock.patch(
-                "apps.storage.services.internal.repository_ownership._s3_args",
-                return_value={},
-            ),
-            mock.patch(
-                "apps.storage.services.internal.repository_ownership._marker_key",
-                return_value="hfl/.hyperfilelens/repository-owner-v1.json",
-            ),
-            mock.patch(
-                "apps.storage.services.internal.repository_ownership.read_s3_object",
-                return_value=marker,
-            ),
-            mock.patch(
-                "apps.storage.services.internal.repository_ownership.delete_s3_object",
-                side_effect=lambda **_kwargs: calls.append("deleted"),
-            ),
-            mock.patch(
-                "apps.storage.services.internal.repository_ownership.put_s3_object",
-                side_effect=lambda **_kwargs: calls.append("restored"),
-            ),
-        ):
-            with s3_ownership_marker_hidden(repository):
-                calls.append("create")
-
-        self.assertEqual(calls, ["deleted", "create", "restored"])
-
-    def test_s3_ownership_marker_hidden_restores_marker_when_create_fails(self):
-        repository = self._s3_repository(name="Failed create", prefix="hfl/")
-        marker = (
-            b'{"deployment_uuid":"d","repository_uuid":"r",'
-            b'"location_digest":"l","format_version":1,"signature":"sig"}'
-        )
-
-        with (
-            mock.patch(
-                "apps.storage.services.internal.repository_ownership._s3_args",
-                return_value={},
-            ),
-            mock.patch(
-                "apps.storage.services.internal.repository_ownership._marker_key",
-                return_value="hfl/.hyperfilelens/repository-owner-v1.json",
-            ),
-            mock.patch(
-                "apps.storage.services.internal.repository_ownership.read_s3_object",
-                return_value=marker,
-            ),
-            mock.patch(
-                "apps.storage.services.internal.repository_ownership.delete_s3_object"
-            ),
-            mock.patch(
-                "apps.storage.services.internal.repository_ownership.put_s3_object"
-            ) as put_marker,
-        ):
-            with self.assertRaises(RuntimeError):
-                with s3_ownership_marker_hidden(repository):
-                    raise RuntimeError("kopia create failed")
-
-        put_marker.assert_called_once()
-
-    def test_s3_ownership_marker_hidden_noop_without_marker(self):
-        repository = self._s3_repository(name="No marker", prefix="hfl/")
-        with (
-            mock.patch(
-                "apps.storage.services.internal.repository_ownership._s3_args",
-                return_value={},
-            ),
-            mock.patch(
-                "apps.storage.services.internal.repository_ownership._marker_key",
-                return_value="hfl/.hyperfilelens/repository-owner-v1.json",
-            ),
-            mock.patch(
-                "apps.storage.services.internal.repository_ownership.read_s3_object",
-                return_value=None,
-            ),
-            mock.patch(
-                "apps.storage.services.internal.repository_ownership.delete_s3_object"
-            ) as delete_marker,
-            mock.patch(
-                "apps.storage.services.internal.repository_ownership.put_s3_object"
-            ) as put_marker,
-        ):
-            with s3_ownership_marker_hidden(repository):
-                pass
-
-        delete_marker.assert_not_called()
-        put_marker.assert_not_called()
-
-    def test_initialize_s3_claims_marker_before_hiding_it_for_kopia_create(self):
+    def test_initialize_s3_creates_kopia_before_establishing_ownership(self):
         repository = self._s3_repository(name="Initialized", prefix="hfl/")
-        marker = (
-            b'{"deployment_uuid":"d","repository_uuid":"r",'
-            b'"location_digest":"l","format_version":1,"signature":"sig"}'
-        )
         call_sequence: list[str] = []
 
-        def fake_create(repository):
-            # Kopia create must run while the marker is hidden.
+        def fake_create(_repository):
             call_sequence.append("create")
 
         with (
@@ -685,52 +594,226 @@ class RepositoryLocationClaimTests(TestCase):
             mock.patch(
                 "apps.storage.services.internal.repository_initializer.check_s3_bucket_readable"
             ),
-            # Run the real claim: a residual marker is validated and kept, then
-            # hidden for the physical create and restored afterwards. A claim
-            # that runs while the marker is already hidden would rewrite the
-            # marker and make Kopia reject the create again.
             mock.patch(
-                "apps.storage.services.internal.repository_ownership._ensure_s3_namespace_resolved"
+                "apps.storage.services.internal.repository_initializer.inspect_s3_repository_initialization",
+                return_value=S3RepositoryInitializationState.EMPTY,
             ),
+            mock.patch(
+                "apps.storage.services.internal.repository_initializer.establish_s3_repository_ownership",
+                side_effect=lambda _repository: call_sequence.append("ownership"),
+            ),
+        ):
+            initialize_s3_repository(repository)
+
+        self.assertEqual(call_sequence, ["create", "ownership"])
+
+    def test_initialize_s3_recovery_connects_residual_kopia_then_establishes_owner(
+        self,
+    ):
+        repository = self._s3_repository(name="Residual Kopia", prefix="hfl/")
+        calls: list[str] = []
+
+        with (
+            mock.patch(
+                "apps.storage.services.internal.repository_initializer.resolve_repository_secrets",
+                return_value={},
+            ),
+            mock.patch(
+                "apps.storage.services.internal.repository_initializer.repository_control_endpoint",
+                return_value=None,
+            ),
+            mock.patch(
+                "apps.storage.services.internal.repository_initializer.resolve_s3_url_style",
+                return_value=S3_URL_STYLE_PATH,
+            ),
+            mock.patch(
+                "apps.storage.services.internal.repository_initializer.check_s3_bucket_readable"
+            ),
+            mock.patch(
+                "apps.storage.services.internal.repository_initializer.inspect_s3_repository_initialization",
+                return_value=S3RepositoryInitializationState.OCCUPIED,
+            ),
+            mock.patch(
+                "apps.storage.services.internal.repository_initializer.connect_s3_repository",
+                side_effect=lambda _repository: calls.append("connect"),
+            ),
+            mock.patch(
+                "apps.storage.services.internal.repository_initializer.kopia_status",
+                side_effect=lambda _repository: calls.append("status"),
+            ),
+            mock.patch(
+                "apps.storage.services.internal.repository_initializer.establish_s3_repository_ownership",
+                side_effect=lambda _repository: calls.append("ownership"),
+            ),
+            mock.patch(
+                "apps.storage.services.internal.repository_initializer.create_s3_repository"
+            ) as create_repository,
+        ):
+            initialize_s3_repository(repository, recovery=True)
+
+        self.assertEqual(calls, ["connect", "status", "ownership"])
+        create_repository.assert_not_called()
+
+    def test_initialize_s3_owned_location_connects_without_recreating(self):
+        repository = self._s3_repository(name="Owned Kopia", prefix="hfl/")
+
+        with (
+            mock.patch(
+                "apps.storage.services.internal.repository_initializer.resolve_repository_secrets",
+                return_value={},
+            ),
+            mock.patch(
+                "apps.storage.services.internal.repository_initializer.repository_control_endpoint",
+                return_value=None,
+            ),
+            mock.patch(
+                "apps.storage.services.internal.repository_initializer.resolve_s3_url_style",
+                return_value=S3_URL_STYLE_PATH,
+            ),
+            mock.patch(
+                "apps.storage.services.internal.repository_initializer.check_s3_bucket_readable"
+            ),
+            mock.patch(
+                "apps.storage.services.internal.repository_initializer.inspect_s3_repository_initialization",
+                return_value=S3RepositoryInitializationState.OWNED,
+            ),
+            mock.patch(
+                "apps.storage.services.internal.repository_initializer.connect_s3_repository"
+            ) as connect_repository,
+            mock.patch(
+                "apps.storage.services.internal.repository_initializer.kopia_status"
+            ) as status_repository,
+            mock.patch(
+                "apps.storage.services.internal.repository_initializer.create_s3_repository"
+            ) as create_repository,
+            mock.patch(
+                "apps.storage.services.internal.repository_initializer.establish_s3_repository_ownership"
+            ) as establish_ownership,
+        ):
+            initialize_s3_repository(repository, recovery=True)
+
+        connect_repository.assert_called_once_with(repository)
+        status_repository.assert_called_once_with(repository)
+        create_repository.assert_not_called()
+        establish_ownership.assert_not_called()
+
+    def test_initialize_s3_recovery_upgrades_pre_kopia_marker_residue(self):
+        repository = self._s3_repository(name="Legacy marker", prefix="hfl/")
+        calls: list[str] = []
+
+        with (
+            mock.patch(
+                "apps.storage.services.internal.repository_initializer.resolve_repository_secrets",
+                return_value={},
+            ),
+            mock.patch(
+                "apps.storage.services.internal.repository_initializer.repository_control_endpoint",
+                return_value=None,
+            ),
+            mock.patch(
+                "apps.storage.services.internal.repository_initializer.resolve_s3_url_style",
+                return_value=S3_URL_STYLE_PATH,
+            ),
+            mock.patch(
+                "apps.storage.services.internal.repository_initializer.check_s3_bucket_readable"
+            ),
+            mock.patch(
+                "apps.storage.services.internal.repository_initializer.inspect_s3_repository_initialization",
+                return_value=S3RepositoryInitializationState.OWNED,
+            ),
+            mock.patch(
+                "apps.storage.services.internal.repository_initializer.connect_s3_repository",
+                side_effect=KopiaCliError("repository is not initialized"),
+            ),
+            mock.patch(
+                "apps.storage.services.internal.repository_initializer.reset_s3_legacy_marker_for_initialization_recovery",
+                side_effect=lambda _repository: calls.append("reset"),
+            ),
+            mock.patch(
+                "apps.storage.services.internal.repository_initializer.create_s3_repository",
+                side_effect=lambda _repository: calls.append("create"),
+            ),
+            mock.patch(
+                "apps.storage.services.internal.repository_initializer.establish_s3_repository_ownership",
+                side_effect=lambda _repository: calls.append("ownership"),
+            ),
+        ):
+            initialize_s3_repository(repository, recovery=True)
+
+        self.assertEqual(calls, ["reset", "create", "ownership"])
+
+    @mock.patch("apps.storage.services.internal.repository_ownership.delete_s3_object")
+    @mock.patch(
+        "apps.storage.services.internal.repository_ownership.s3_prefix_contains_only_key",
+        return_value=True,
+    )
+    @mock.patch(
+        "apps.storage.services.internal.repository_ownership._require_matching_marker"
+    )
+    @mock.patch(
+        "apps.storage.services.internal.repository_ownership.read_s3_object",
+        side_effect=[b"matching-marker", None, None],
+    )
+    @mock.patch(
+        "apps.storage.services.internal.repository_ownership._ensure_s3_namespace_resolved"
+    )
+    @mock.patch(
+        "apps.storage.services.internal.repository_ownership._s3_args",
+        return_value={},
+    )
+    def test_legacy_marker_reset_requires_marker_only_prefix(
+        self,
+        _s3_args,
+        _resolve_namespace,
+        _read_marker,
+        _require_marker,
+        contains_only_marker,
+        delete_marker,
+    ):
+        repository = self._s3_repository(name="Marker only", prefix="hfl/")
+
+        reset_s3_legacy_marker_for_initialization_recovery(repository)
+
+        contains_only_marker.assert_called_once_with(
+            prefix="hfl/",
+            allowed_key="hfl/.hyperfilelens/repository-owner-v1.json",
+        )
+        delete_marker.assert_called_once_with(
+            key="hfl/.hyperfilelens/repository-owner-v1.json"
+        )
+
+    def test_legacy_marker_reset_preserves_prefix_with_other_state(self):
+        repository = self._s3_repository(name="Marker plus data", prefix="hfl/")
+        with (
             mock.patch(
                 "apps.storage.services.internal.repository_ownership._s3_args",
                 return_value={},
             ),
             mock.patch(
-                "apps.storage.services.internal.repository_ownership._marker_key",
-                return_value="hfl/.hyperfilelens/repository-owner-v1.json",
+                "apps.storage.services.internal.repository_ownership._ensure_s3_namespace_resolved"
             ),
             mock.patch(
                 "apps.storage.services.internal.repository_ownership.read_s3_object",
-                return_value=marker,
+                return_value=b"matching-marker",
             ),
             mock.patch(
-                "apps.storage.services.internal.repository_ownership._require_matching_marker",
-                side_effect=lambda *_args, **_kwargs: call_sequence.append("claimed"),
+                "apps.storage.services.internal.repository_ownership._require_matching_marker"
             ),
             mock.patch(
-                "apps.storage.services.internal.repository_ownership._reject_foreign_ancestor_markers"
+                "apps.storage.services.internal.repository_ownership.s3_prefix_contains_only_key",
+                return_value=False,
             ),
             mock.patch(
-                "apps.storage.services.internal.repository_ownership._reject_foreign_descendant_markers"
-            ),
-            mock.patch(
-                "apps.storage.services.internal.repository_ownership.mark_repository_location_ownership_verified"
-            ),
-            mock.patch(
-                "apps.storage.services.internal.repository_ownership.delete_s3_object",
-                side_effect=lambda **_kwargs: call_sequence.append("deleted"),
-            ),
-            mock.patch(
-                "apps.storage.services.internal.repository_ownership.put_s3_object",
-                side_effect=lambda **_kwargs: call_sequence.append("restored"),
-            ),
+                "apps.storage.services.internal.repository_ownership.delete_s3_object"
+            ) as delete_marker,
         ):
-            initialize_s3_repository(repository)
+            with self.assertRaisesRegex(
+                RepositoryOwnershipError,
+                "contains repository data",
+            ):
+                reset_s3_legacy_marker_for_initialization_recovery(repository)
 
-        self.assertEqual(
-            call_sequence, ["claimed", "deleted", "create", "restored"]
-        )
+        delete_marker.assert_not_called()
 
     @mock.patch(
         "apps.storage.services.internal.repository_ownership.mark_repository_location_ownership_verified"

--- a/src/backend/apps/storage/tests/test_s3_client.py
+++ b/src/backend/apps/storage/tests/test_s3_client.py
@@ -14,6 +14,7 @@ from apps.storage.services.internal.s3_client import (
     list_s3_buckets,
     list_s3_buckets_by_region,
     put_s3_object_if_absent,
+    s3_prefix_contains_only_key,
 )
 from apps.storage.services.internal.repository_initializer import (
     RepositoryInitializationError,
@@ -263,9 +264,7 @@ class S3BucketRegionListingTests(TestCase):
                 {"Name": "lookup-match"},
             ]
         }
-        client.get_bucket_location.return_value = {
-            "LocationConstraint": "cn-hangzhou"
-        }
+        client.get_bucket_location.return_value = {"LocationConstraint": "cn-hangzhou"}
         client_factory.return_value = client
 
         buckets = list_s3_buckets_by_region(
@@ -460,9 +459,13 @@ class S3BucketRegionListingTests(TestCase):
 
         self.assertEqual(buckets, [])
         self.assertTrue(any("bucket excluded" in line for line in captured.output))
-        self.assertTrue(any("error_code=AccessDenied" in line for line in captured.output))
+        self.assertTrue(
+            any("error_code=AccessDenied" in line for line in captured.output)
+        )
         self.assertTrue(any("http_status=403" in line for line in captured.output))
-        self.assertTrue(any("request_id=request-123" in line for line in captured.output))
+        self.assertTrue(
+            any("request_id=request-123" in line for line in captured.output)
+        )
 
     @mock.patch("apps.storage.services.internal.s3_client._client")
     def test_aws_empty_location_maps_to_us_east_1_after_fallback(self, client_factory):
@@ -610,7 +613,7 @@ class CreateS3BucketTests(TestCase):
         client = mock.Mock()
         client_factory.return_value = client
 
-        create_s3_bucket(
+        created = create_s3_bucket(
             endpoint="https://s3.example.com",
             region="us-east-1",
             bucket="new-bucket",
@@ -620,9 +623,10 @@ class CreateS3BucketTests(TestCase):
 
         client.create_bucket.assert_called_once_with(Bucket="new-bucket")
         client.list_buckets.assert_not_called()
+        self.assertTrue(created)
 
     @mock.patch("apps.storage.services.internal.s3_client._client")
-    def test_rejects_an_existing_bucket_name_that_holds_data(self, client_factory):
+    def test_rejects_an_existing_bucket_name_on_first_attempt(self, client_factory):
         client = mock.Mock()
         client.create_bucket.side_effect = ClientError(
             {
@@ -631,7 +635,6 @@ class CreateS3BucketTests(TestCase):
             },
             "CreateBucket",
         )
-        client.list_objects_v2.return_value = {"Contents": [{"Key": "existing"}]}
         client_factory.return_value = client
 
         with self.assertRaisesRegex(S3ClientError, "already exists"):
@@ -644,7 +647,7 @@ class CreateS3BucketTests(TestCase):
             )
 
     @mock.patch("apps.storage.services.internal.s3_client._client")
-    def test_allows_reinitialization_when_existing_bucket_is_empty(self, client_factory):
+    def test_recovery_allows_an_existing_owned_bucket(self, client_factory):
         client = mock.Mock()
         client.create_bucket.side_effect = ClientError(
             {
@@ -653,22 +656,19 @@ class CreateS3BucketTests(TestCase):
             },
             "CreateBucket",
         )
-        client.list_objects_v2.return_value = {}
-        client.list_object_versions.return_value = {}
-        client.list_multipart_uploads.return_value = {}
         client_factory.return_value = client
 
-        create_s3_bucket(
+        created = create_s3_bucket(
             endpoint="https://s3.example.com",
             region="us-east-1",
             bucket="leftover-bucket",
             access_key_id="AK",
             secret_access_key="SK",
+            allow_existing_owned=True,
         )
 
-        client.list_objects_v2.assert_called_once_with(
-            Bucket="leftover-bucket", Prefix="", MaxKeys=1
-        )
+        client.list_objects_v2.assert_not_called()
+        self.assertFalse(created)
 
     @mock.patch("apps.storage.services.internal.s3_client._client")
     def test_legacy_gateway_retries_without_location_constraint(self, client_factory):
@@ -710,6 +710,57 @@ class CreateS3BucketTests(TestCase):
         )
 
 
+class S3PrefixContainsOnlyKeyTests(TestCase):
+    def _contains_only(self, client) -> bool:
+        with mock.patch(
+            "apps.storage.services.internal.s3_client._client",
+            return_value=client,
+        ):
+            return s3_prefix_contains_only_key(
+                endpoint="https://s3.example.com",
+                region="us-east-1",
+                bucket="backup-bucket",
+                prefix="hfl/",
+                allowed_key="hfl/.hyperfilelens/repository-owner-v1.json",
+                access_key_id="AK",
+                secret_access_key="SK",
+            )
+
+    def test_accepts_current_and_historical_state_for_the_allowed_marker(self):
+        client = mock.Mock()
+        object_pages = mock.Mock()
+        object_pages.paginate.return_value = [
+            {"Contents": [{"Key": "hfl/.hyperfilelens/repository-owner-v1.json"}]}
+        ]
+        version_pages = mock.Mock()
+        version_pages.paginate.return_value = [
+            {
+                "Versions": [{"Key": "hfl/.hyperfilelens/repository-owner-v1.json"}],
+                "DeleteMarkers": [],
+            }
+        ]
+        client.get_paginator.side_effect = [object_pages, version_pages]
+        client.list_multipart_uploads.return_value = {}
+
+        self.assertTrue(self._contains_only(client))
+
+    def test_rejects_any_other_object_in_the_prefix(self):
+        client = mock.Mock()
+        object_pages = mock.Mock()
+        object_pages.paginate.return_value = [
+            {
+                "Contents": [
+                    {"Key": "hfl/.hyperfilelens/repository-owner-v1.json"},
+                    {"Key": "hfl/kopia.repository"},
+                ]
+            }
+        ]
+        client.get_paginator.return_value = object_pages
+
+        self.assertFalse(self._contains_only(client))
+        client.list_multipart_uploads.assert_not_called()
+
+
 class InitializeS3RepositoryBucketModeTests(TestCase):
     def _repository(self, mode):
         return Repository(
@@ -717,22 +768,42 @@ class InitializeS3RepositoryBucketModeTests(TestCase):
             s3_platform=Repository.S3Platform.AWS,
             s3_bucket="bucket",
             s3_bucket_mode=mode,
-            config={"region": "us-east-1", "prefix": "repo/", "s3_url_style": "virtual_hosted"},
+            config={
+                "region": "us-east-1",
+                "prefix": "repo/",
+                "s3_url_style": "virtual_hosted",
+            },
         )
 
-    @mock.patch("apps.storage.services.internal.repository_initializer.create_s3_repository")
-    @mock.patch("apps.storage.services.internal.repository_initializer.check_s3_bucket_readable")
-    @mock.patch("apps.storage.services.internal.repository_initializer.create_s3_bucket")
-    def test_new_mode_strictly_creates_bucket(self, create_bucket, check_bucket, _create_repo):
+    @mock.patch(
+        "apps.storage.services.internal.repository_initializer.create_s3_repository"
+    )
+    @mock.patch(
+        "apps.storage.services.internal.repository_initializer.check_s3_bucket_readable"
+    )
+    @mock.patch(
+        "apps.storage.services.internal.repository_initializer.create_s3_bucket"
+    )
+    def test_new_mode_strictly_creates_bucket(
+        self, create_bucket, check_bucket, _create_repo
+    ):
         initialize_s3_repository(self._repository(Repository.S3BucketMode.NEW))
 
         create_bucket.assert_called_once()
         check_bucket.assert_not_called()
 
-    @mock.patch("apps.storage.services.internal.repository_initializer.create_s3_repository")
-    @mock.patch("apps.storage.services.internal.repository_initializer.check_s3_bucket_readable")
-    @mock.patch("apps.storage.services.internal.repository_initializer.create_s3_bucket")
-    def test_existing_mode_never_creates_bucket(self, create_bucket, check_bucket, _create_repo):
+    @mock.patch(
+        "apps.storage.services.internal.repository_initializer.create_s3_repository"
+    )
+    @mock.patch(
+        "apps.storage.services.internal.repository_initializer.check_s3_bucket_readable"
+    )
+    @mock.patch(
+        "apps.storage.services.internal.repository_initializer.create_s3_bucket"
+    )
+    def test_existing_mode_never_creates_bucket(
+        self, create_bucket, check_bucket, _create_repo
+    ):
         initialize_s3_repository(self._repository(Repository.S3BucketMode.EXISTING))
 
         check_bucket.assert_called_once()
@@ -750,7 +821,9 @@ class ResolveS3UrlStyleTests(TestCase):
     }
 
     @mock.patch("apps.storage.services.internal.repository_initializer.sleep")
-    @mock.patch("apps.storage.services.internal.repository_initializer.check_s3_bucket_readable")
+    @mock.patch(
+        "apps.storage.services.internal.repository_initializer.check_s3_bucket_readable"
+    )
     def test_auto_prefers_virtual_hosted(self, check_bucket, sleep):
         resolved = resolve_s3_url_style(s3_url_style="auto", **self._bucket_args)
 
@@ -761,7 +834,9 @@ class ResolveS3UrlStyleTests(TestCase):
         )
         sleep.assert_not_called()
 
-    @mock.patch("apps.storage.services.internal.repository_initializer.check_s3_bucket_readable")
+    @mock.patch(
+        "apps.storage.services.internal.repository_initializer.check_s3_bucket_readable"
+    )
     def test_auto_uses_path_for_ip_literal_endpoint(self, check_bucket):
         resolved = resolve_s3_url_style(
             s3_url_style="auto",
@@ -775,7 +850,9 @@ class ResolveS3UrlStyleTests(TestCase):
         )
 
     @mock.patch("apps.storage.services.internal.repository_initializer.sleep")
-    @mock.patch("apps.storage.services.internal.repository_initializer.check_s3_bucket_readable")
+    @mock.patch(
+        "apps.storage.services.internal.repository_initializer.check_s3_bucket_readable"
+    )
     def test_auto_falls_back_to_path(self, check_bucket, _sleep):
         check_bucket.side_effect = [None] + [S3ClientError("virtual failed")] * 3
 
@@ -788,7 +865,9 @@ class ResolveS3UrlStyleTests(TestCase):
         )
 
     @mock.patch("apps.storage.services.internal.repository_initializer.sleep")
-    @mock.patch("apps.storage.services.internal.repository_initializer.check_s3_bucket_readable")
+    @mock.patch(
+        "apps.storage.services.internal.repository_initializer.check_s3_bucket_readable"
+    )
     def test_auto_reports_both_probe_failures(self, check_bucket, _sleep):
         check_bucket.side_effect = S3ClientError("unavailable")
 
@@ -808,9 +887,15 @@ class InitializeAutoS3UrlStyleTests(TestCase):
         repository.save = mock.Mock()
         return repository
 
-    @mock.patch("apps.storage.services.internal.repository_initializer.create_s3_repository")
-    @mock.patch("apps.storage.services.internal.repository_initializer.check_s3_bucket_readable")
-    def test_auto_resolution_is_persisted_before_kopia_initialization(self, check_bucket, create_repo):
+    @mock.patch(
+        "apps.storage.services.internal.repository_initializer.create_s3_repository"
+    )
+    @mock.patch(
+        "apps.storage.services.internal.repository_initializer.check_s3_bucket_readable"
+    )
+    def test_auto_resolution_is_persisted_before_kopia_initialization(
+        self, check_bucket, create_repo
+    ):
         repository = self._repository(Repository.S3BucketMode.EXISTING)
 
         initialize_s3_repository(repository)
@@ -824,22 +909,65 @@ class InitializeAutoS3UrlStyleTests(TestCase):
         create_repo.assert_called_once_with(repository)
 
     @mock.patch("apps.storage.services.internal.repository_initializer.sleep")
-    @mock.patch("apps.storage.services.internal.repository_initializer.create_s3_repository")
-    @mock.patch("apps.storage.services.internal.repository_initializer.delete_s3_bucket_if_empty")
-    @mock.patch("apps.storage.services.internal.repository_initializer.check_s3_bucket_readable")
-    @mock.patch("apps.storage.services.internal.repository_initializer.create_s3_bucket")
+    @mock.patch(
+        "apps.storage.services.internal.repository_initializer.create_s3_repository"
+    )
+    @mock.patch(
+        "apps.storage.services.internal.repository_initializer.delete_s3_bucket_if_empty"
+    )
+    @mock.patch(
+        "apps.storage.services.internal.repository_initializer.check_s3_bucket_readable"
+    )
+    @mock.patch(
+        "apps.storage.services.internal.repository_initializer.create_s3_bucket"
+    )
     def test_new_bucket_auto_probe_failure_rolls_back_created_bucket(
         self, create_bucket, check_bucket, delete_bucket, create_repo, _sleep
     ):
         repository = self._repository(Repository.S3BucketMode.NEW)
         check_bucket.side_effect = S3ClientError("unavailable")
-        delete_bucket.return_value = {"bucket": "bucket", "status": "deleted", "reason": "bucket_empty"}
+        delete_bucket.return_value = {
+            "bucket": "bucket",
+            "status": "deleted",
+            "reason": "bucket_empty",
+        }
 
         with self.assertRaises(RepositoryInitializationError):
             initialize_s3_repository(repository)
 
         create_bucket.assert_called_once()
         delete_bucket.assert_called_once()
+        create_repo.assert_not_called()
+
+    @mock.patch("apps.storage.services.internal.repository_initializer.sleep")
+    @mock.patch(
+        "apps.storage.services.internal.repository_initializer.create_s3_repository"
+    )
+    @mock.patch(
+        "apps.storage.services.internal.repository_initializer.delete_s3_bucket_if_empty"
+    )
+    @mock.patch(
+        "apps.storage.services.internal.repository_initializer.check_s3_bucket_readable"
+    )
+    @mock.patch(
+        "apps.storage.services.internal.repository_initializer.create_s3_bucket"
+    )
+    def test_recovery_auto_probe_failure_does_not_delete_reused_bucket(
+        self,
+        create_bucket,
+        check_bucket,
+        delete_bucket,
+        create_repo,
+        _sleep,
+    ):
+        repository = self._repository(Repository.S3BucketMode.NEW)
+        create_bucket.return_value = False
+        check_bucket.side_effect = S3ClientError("unavailable")
+
+        with self.assertRaises(RepositoryInitializationError):
+            initialize_s3_repository(repository, recovery=True)
+
+        delete_bucket.assert_not_called()
         create_repo.assert_not_called()
 
 
@@ -923,9 +1051,7 @@ class S3OwnershipMarkerAtomicCreateTests(TestCase):
         self.assertEqual(request.headers["x-oss-forbid-overwrite"], "true")
 
     @mock.patch("apps.storage.services.internal.s3_client._client")
-    def test_legacy_custom_aliyun_endpoint_uses_aliyun_semantics(
-        self, client_factory
-    ):
+    def test_legacy_custom_aliyun_endpoint_uses_aliyun_semantics(self, client_factory):
         client = mock.Mock()
         client_factory.return_value = client
 
@@ -939,6 +1065,25 @@ class S3OwnershipMarkerAtomicCreateTests(TestCase):
 
         self.assertNotIn("IfNoneMatch", client.put_object.call_args.kwargs)
         client.meta.events.register_first.assert_called_once()
+
+    @mock.patch("apps.storage.services.internal.s3_client._client")
+    def test_legacy_custom_huawei_endpoint_uses_huawei_semantics(self, client_factory):
+        client = mock.Mock()
+        client_factory.return_value = client
+
+        self.assertTrue(
+            self._put(
+                platform=Repository.S3Platform.CUSTOM,
+                endpoint="obs.cn-north-4.myhuaweicloud.com",
+                region="cn-north-4",
+            )
+        )
+
+        self.assertNotIn("IfNoneMatch", client.put_object.call_args.kwargs)
+        registration = client.meta.events.register_first.call_args
+        request = SimpleNamespace(headers={})
+        registration.args[1](request=request)
+        self.assertEqual(request.headers["x-obs-forbid-overwrite"], "true")
 
     @mock.patch("apps.storage.services.internal.s3_client._client")
     def test_aliyun_existing_marker_returns_false(self, client_factory):
@@ -963,8 +1108,57 @@ class S3OwnershipMarkerAtomicCreateTests(TestCase):
         )
 
     @mock.patch("apps.storage.services.internal.s3_client._client")
+    def test_huawei_uses_signed_forbid_overwrite_header(self, client_factory):
+        client = mock.Mock()
+        client_factory.return_value = client
+
+        self.assertTrue(
+            self._put(
+                platform=Repository.S3Platform.HUAWEICLOUD,
+                endpoint="https://obs.cn-north-4.myhuaweicloud.com",
+                region="cn-north-4",
+            )
+        )
+
+        self.assertNotIn("IfNoneMatch", client.put_object.call_args.kwargs)
+        registration = client.meta.events.register_first.call_args
+        self.assertEqual(registration.args[0], "before-sign.s3.PutObject")
+        request = SimpleNamespace(headers={})
+        registration.args[1](request=request)
+        self.assertEqual(request.headers["x-obs-forbid-overwrite"], "true")
+
+    @mock.patch("apps.storage.services.internal.s3_client._client")
+    def test_huawei_existing_marker_returns_false(self, client_factory):
+        client = mock.Mock()
+        client.put_object.side_effect = ClientError(
+            {
+                "Error": {
+                    "Code": "ObjectAlreadyExists",
+                    "Message": "The object already exists.",
+                },
+                "ResponseMetadata": {"HTTPStatusCode": 409},
+            },
+            "PutObject",
+        )
+        client_factory.return_value = client
+
+        self.assertFalse(
+            self._put(
+                platform=Repository.S3Platform.HUAWEICLOUD,
+                endpoint="https://obs.cn-north-4.myhuaweicloud.com",
+            )
+        )
+
+    @mock.patch("apps.storage.services.internal.s3_client._client")
     def test_legacy_gateway_falls_back_to_plain_overwrite(self, client_factory):
         client = mock.Mock()
+        client.head_object.side_effect = ClientError(
+            {
+                "Error": {"Code": "NoSuchKey", "Message": "missing"},
+                "ResponseMetadata": {"HTTPStatusCode": 404},
+            },
+            "HeadObject",
+        )
         client.put_object.side_effect = [
             ClientError(
                 {
@@ -987,3 +1181,22 @@ class S3OwnershipMarkerAtomicCreateTests(TestCase):
         second_call = client.put_object.call_args_list[1]
         self.assertIn("IfNoneMatch", first_call.kwargs)
         self.assertNotIn("IfNoneMatch", second_call.kwargs)
+
+    @mock.patch("apps.storage.services.internal.s3_client._client")
+    def test_legacy_gateway_does_not_overwrite_an_existing_marker(self, client_factory):
+        client = mock.Mock()
+        client.put_object.side_effect = ClientError(
+            {
+                "Error": {
+                    "Code": "NotImplemented",
+                    "Message": "conditional write unsupported",
+                },
+                "ResponseMetadata": {"HTTPStatusCode": 501},
+            },
+            "PutObject",
+        )
+        client.head_object.return_value = {"ContentLength": 10}
+        client_factory.return_value = client
+
+        self.assertFalse(self._put())
+        client.put_object.assert_called_once()

--- a/src/frontend/src/locales/en.ts
+++ b/src/frontend/src/locales/en.ts
@@ -2322,7 +2322,7 @@ export const en = {
     phBucketNew: 'Enter a new bucket name, e.g. my-backup-bucket',
     fieldPrefix: 'Object Prefix',
     phPrefix: 'my-backup-prefix',
-    hintPrefix: 'Use a dedicated directory per application for data isolation and management. A trailing "/" will be added automatically if missing.',
+    hintPrefix: 'Leave empty to use the entire Bucket, or enter a dedicated directory. A trailing "/" is added automatically.',
     fieldQuota: 'Storage Limit',
     phQuota: '0 means unlimited',
     hintQuota: 'Set to 0 for unlimited storage capacity.',

--- a/src/frontend/src/pages/node/AddS3Repo.vue
+++ b/src/frontend/src/pages/node/AddS3Repo.vue
@@ -444,7 +444,6 @@ function validateForm(): boolean {
     { field: 'secretKey', message: t('addS3Repo.errSecretKey'), valid: !!accessKeySecret.value.trim() },
     { field: 'repoName', message: t('repositoriesPage.errName'), valid: !!repoName.value.trim() },
     { field: 'bucket', message: t('repositoriesPage.errBucket'), valid: !!bucket.value.trim() },
-    { field: 'prefix', message: t('addS3Repo.errPrefix'), valid: !!normalizeS3ObjectPrefix(prefix.value) },
     { field: 'quotaThreshold', message: t('repositoriesPage.hintQuotaAlertThreshold'), valid: !enableQuotaAlert.value || validQuotaAlertThreshold.value },
   ])
 }
@@ -971,7 +970,7 @@ function handleBack() {
                       class="fullscreen-form-field"
                     >
                       <label class="fullscreen-form-field__label">
-                        {{ t('addS3Repo.fieldPrefix') }} <span class="fullscreen-form-field__required">*</span>
+                        {{ t('addS3Repo.fieldPrefix') }}
                       </label>
                       <ElInput
                         v-model="prefix"
@@ -982,12 +981,6 @@ function handleBack() {
                       />
                       <p class="fullscreen-form-field__hint">
                         {{ t('addS3Repo.hintPrefix') }}
-                      </p>
-                      <p
-                        v-if="errors.prefix"
-                        class="el-form-item__error"
-                      >
-                        {{ errors.prefix }}
                       </p>
                     </div>
                   </div>

--- a/src/frontend/src/pages/node/AddS3RepoRegionBucket.test.ts
+++ b/src/frontend/src/pages/node/AddS3RepoRegionBucket.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import { flushPromises, mount, type VueWrapper } from '@vue/test-utils'
-import ElementPlus, { ElInput, ElOption, ElRadioGroup, ElSelect } from 'element-plus'
+import ElementPlus, { ElButton, ElInput, ElOption, ElRadioGroup, ElSelect } from 'element-plus'
 import { createI18n } from 'vue-i18n'
 import { nextTick } from 'vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -195,5 +195,42 @@ describe('AddS3Repo Region and Bucket state', () => {
     await nextTick()
 
     expect(bucketInput.props('modelValue')).toBe('new-bucket')
+  })
+
+  it('allows an Existing Bucket to use the Bucket root with an empty Prefix', async () => {
+    mocks.api.mockImplementation((path: string) => {
+      if (path.endsWith('/validate/s3/')) return Promise.resolve({ buckets: ['empty-bucket'] })
+      if (path === '/api/v1/storage/repositories/') {
+        return Promise.resolve({ id: 41, status: 'creating' })
+      }
+      return Promise.resolve({})
+    })
+    const wrapper = await mountForm()
+    const connectionInputs = wrapper
+      .findAllComponents(ElInput)
+      .filter((component) => component.classes().includes('add-s3-element-field'))
+    connectionInputs[2].vm.$emit('update:modelValue', 'access-key')
+    connectionInputs[3].vm.$emit('update:modelValue', 'secret-key')
+    existingBucketSelect(wrapper).vm.$emit('update:modelValue', 'empty-bucket')
+    const prefixInput = wrapper
+      .find('[data-validation-field="prefix"]')
+      .findComponent(ElInput)
+    prefixInput.vm.$emit('update:modelValue', '')
+    await nextTick()
+
+    const createButton = wrapper
+      .findAllComponents(ElButton)
+      .find((button) => button.text().includes('Create and Initialize'))
+    if (!createButton) throw new Error('Create button was not rendered')
+    await createButton.trigger('click')
+    await flushPromises()
+
+    const createCall = mocks.api.mock.calls.find(
+      ([path]) => path === '/api/v1/storage/repositories/',
+    )
+    expect(createCall).toBeDefined()
+    const payload = JSON.parse(String(createCall?.[1]?.body || '{}'))
+    expect(payload.config.prefix).toBeUndefined()
+    expect(wrapper.find('[data-validation-field="prefix"] .el-form-item__error').exists()).toBe(false)
   })
 })


### PR DESCRIPTION
## Summary
- initialize Kopia before persisting the HyperFileLens ownership marker
- recover interrupted S3 repository creation without adopting unrelated storage
- support bucket-root repositories and provider-specific atomic marker creation
- preserve strict ownership checks for cleanup and deletion

## Validation
- 152 backend storage tests passed
- 6 frontend tests passed
- Vue TypeScript, ESLint, Ruff, and diff checks passed