### PR TITLE
fix(insight): stabilize chat provisioning and cleanup

### DIFF
--- a/src/backend/apps/lens_bridge/api/serializers.py
+++ b/src/backend/apps/lens_bridge/api/serializers.py
@@ -304,6 +304,38 @@ class LensKnowledgeSourceCreateSerializer(serializers.ModelSerializer):
                     {"backup_snapshot_directory_id": "Select a snapshot directory root."}
                 )
 
+        mode = attrs.get(
+            "linked_version_mode",
+            LensKnowledgeSource.LinkedVersionMode.LATEST,
+        )
+        if mode == LensKnowledgeSource.LinkedVersionMode.PINNED:
+            pinned_snapshot_id = (
+                attrs.get("pinned_snapshot_id")
+                or attrs.get("backup_source_snapshot_id")
+            )
+            if not pinned_snapshot_id:
+                raise serializers.ValidationError(
+                    {
+                        "pinned_snapshot_id": (
+                            "Pinned snapshot id is required when mode is pinned."
+                        )
+                    }
+                )
+            if (
+                attrs.get("backup_source_snapshot_id")
+                and pinned_snapshot_id != attrs["backup_source_snapshot_id"]
+            ):
+                raise serializers.ValidationError(
+                    {
+                        "pinned_snapshot_id": (
+                            "Pinned snapshot must match the selected snapshot."
+                        )
+                    }
+                )
+            attrs["pinned_snapshot_id"] = pinned_snapshot_id
+        else:
+            attrs["pinned_snapshot_id"] = None
+
         raw_ingest_policy = attrs.pop("ingest_policy", None)
         if (
             raw_ingest_policy
@@ -481,6 +513,8 @@ class LensSessionLinkSerializer(serializers.ModelSerializer):
             "lifecycle_status",
             "provision_phase",
             "provision_detail",
+            "cleanup_intent",
+            "cleanup_status",
             "document_conversion",
             "data_context",
             "lifecycle_error",

--- a/src/backend/apps/lens_bridge/management/commands/resume_blocked_chat_cleanup.py
+++ b/src/backend/apps/lens_bridge/management/commands/resume_blocked_chat_cleanup.py
@@ -1,0 +1,135 @@
+"""Resume one blocked Chat cleanup through an audited operator confirmation."""
+
+from __future__ import annotations
+
+import getpass
+
+from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
+from django.utils import timezone
+
+from apps.lens_bridge.models import LensKnowledgeSource, LensSessionLink
+from apps.lens_bridge.services import sl_client
+
+
+class Command(BaseCommand):
+    help = (
+        "Resume one blocked Chat cleanup after an operator has independently "
+        "confirmed that its LensNode conversion executor stopped."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument("--session-id", type=int, required=True)
+        parser.add_argument("--source-lens-task-id", required=True)
+        parser.add_argument("--reason", required=True)
+        parser.add_argument(
+            "--confirm-executor-stopped",
+            action="store_true",
+            help="Required acknowledgement that the old executor no longer runs.",
+        )
+
+    def handle(self, *args, **options):
+        if not options["confirm_executor_stopped"]:
+            raise CommandError(
+                "Refusing to resume cleanup without --confirm-executor-stopped."
+            )
+        task_id = str(options["source_lens_task_id"] or "").strip()
+        reason = str(options["reason"] or "").strip()
+        if not task_id or not reason:
+            raise CommandError("SourceLens task id and reason are required.")
+
+        remote_task = sl_client.get_task_by_id(task_id)
+        if remote_task is None:
+            raise CommandError("SourceLens task was not found; cleanup remains blocked.")
+        remote_status = str(remote_task.get("status") or "").upper()
+        returned_task_id = str(remote_task.get("task_id") or "").strip()
+        if returned_task_id != task_id:
+            raise CommandError(
+                "SourceLens did not return the exact requested task identity."
+            )
+        if remote_status not in {"FAILURE", "REVOKED"}:
+            raise CommandError(
+                f"SourceLens task is {remote_status or 'UNKNOWN'}, not terminal."
+            )
+
+        with transaction.atomic():
+            session = (
+                LensSessionLink.objects.select_for_update()
+                .select_related("knowledge_source")
+                .filter(pk=options["session_id"])
+                .first()
+            )
+            if session is None:
+                raise CommandError("Chat session was not found.")
+            if session.cleanup_status != LensSessionLink.CleanupStatus.BLOCKED:
+                raise CommandError("Chat cleanup is not blocked.")
+            knowledge_source = session.knowledge_source
+            if knowledge_source is None:
+                raise CommandError("Blocked Chat has no Knowledge Source.")
+
+            knowledge_source = LensKnowledgeSource.all_objects.select_for_update().get(
+                pk=knowledge_source.pk
+            )
+            sync_state = dict(knowledge_source.sync_state_json or {})
+            conversion = dict(sync_state.get("conversion") or {})
+            recorded_task_id = str(conversion.get("task_id") or "").strip()
+            if recorded_task_id != task_id:
+                raise CommandError(
+                    "SourceLens task id does not match the blocked Knowledge Source."
+                )
+
+            confirmation = {
+                "confirmed": True,
+                "task_id": task_id,
+                "remote_status": remote_status,
+                "operator": getpass.getuser(),
+                "reason": reason[:1000],
+                "confirmed_at": timezone.now().isoformat(),
+            }
+            conversion["manual_stop_confirmation"] = confirmation
+            sync_state["conversion"] = conversion
+            knowledge_source.sync_state_json = sync_state
+            knowledge_source.teardown_next_retry_at = None
+            knowledge_source.status_detail = (
+                "Conversion stop was confirmed; cleanup is queued."
+            )
+            knowledge_source.save(
+                update_fields=[
+                    "sync_state_json",
+                    "teardown_next_retry_at",
+                    "status_detail",
+                    "updated_at",
+                ]
+            )
+
+            teardown_state = dict(session.teardown_state_json or {})
+            teardown_state["manual_stop_confirmation"] = confirmation
+            session.teardown_state_json = teardown_state
+            session.cleanup_status = LensSessionLink.CleanupStatus.PENDING
+            session.teardown_claim_token = None
+            session.teardown_claimed_at = None
+            session.teardown_next_retry_at = None
+            session.save(
+                update_fields=[
+                    "teardown_state_json",
+                    "cleanup_status",
+                    "teardown_claim_token",
+                    "teardown_claimed_at",
+                    "teardown_next_retry_at",
+                    "updated_at",
+                ]
+            )
+
+            from apps.lens_bridge.services.chat_lifecycle import (
+                _queue_teardown_or_record_error,
+            )
+
+            transaction.on_commit(
+                lambda: _queue_teardown_or_record_error(session.id)
+            )
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Queued audited cleanup recovery for Chat {session.id}."
+            )
+        )

--- a/src/backend/apps/lens_bridge/migrations/0034_session_cleanup_and_poll_fencing.py
+++ b/src/backend/apps/lens_bridge/migrations/0034_session_cleanup_and_poll_fencing.py
@@ -1,0 +1,96 @@
+"""Add explicit Chat cleanup state and provision poll fencing."""
+
+from django.db import migrations, models
+from django.db.models.functions import Coalesce
+
+
+def migrate_chat_lifecycle_state(apps, schema_editor):
+    KnowledgeSource = apps.get_model("lens_bridge", "LensKnowledgeSource")
+    SessionLink = apps.get_model("lens_bridge", "LensSessionLink")
+
+    chat_knowledge_source_ids = SessionLink.objects.filter(
+        knowledge_source_id__isnull=False
+    ).values_list("knowledge_source_id", flat=True)
+    KnowledgeSource.objects.filter(
+        pk__in=chat_knowledge_source_ids,
+        backup_source_snapshot_id__isnull=False,
+    ).update(
+        linked_version_mode="pinned",
+        pinned_snapshot_id=Coalesce(
+            "pinned_snapshot_id",
+            "backup_source_snapshot_id",
+        ),
+    )
+
+    for session in SessionLink.objects.filter(lifecycle_status="deleting").iterator():
+        state = session.teardown_state_json or {}
+        intent = str(state.get("intent") or "delete_session")
+        if intent not in {"reset_for_retry", "delete_session"}:
+            intent = "delete_session"
+        values = {
+            "cleanup_intent": intent,
+            "cleanup_status": "pending",
+        }
+        if intent == "reset_for_retry":
+            values.update(
+                lifecycle_status="failed",
+                status="active",
+                provision_phase="cleaning_up",
+            )
+        SessionLink.objects.filter(pk=session.pk).update(
+            **values,
+        )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("lens_bridge", "0033_gateway_capacity_bytes"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="lenssessionlink",
+            name="cleanup_intent",
+            field=models.CharField(
+                choices=[
+                    ("none", "None"),
+                    ("reset_for_retry", "Reset for retry"),
+                    ("delete_session", "Delete session"),
+                ],
+                db_index=True,
+                default="none",
+                max_length=24,
+            ),
+        ),
+        migrations.AddField(
+            model_name="lenssessionlink",
+            name="cleanup_status",
+            field=models.CharField(
+                choices=[
+                    ("none", "None"),
+                    ("pending", "Pending"),
+                    ("running", "Running"),
+                    ("blocked", "Blocked"),
+                    ("complete", "Complete"),
+                ],
+                db_index=True,
+                default="none",
+                max_length=16,
+            ),
+        ),
+        migrations.AddField(
+            model_name="lenssessionlink",
+            name="provision_generation",
+            field=models.PositiveBigIntegerField(default=1),
+        ),
+        migrations.AddField(
+            model_name="lenssessionlink",
+            name="provision_poll_sequence",
+            field=models.PositiveBigIntegerField(default=0),
+        ),
+        migrations.RunPython(
+            migrate_chat_lifecycle_state,
+            reverse_code=migrations.RunPython.noop,
+        ),
+    ]

--- a/src/backend/apps/lens_bridge/models/links.py
+++ b/src/backend/apps/lens_bridge/models/links.py
@@ -629,6 +629,18 @@ class LensSessionLink(OrganizationScopedModel):
         DELETING = "deleting", "Deleting"
         DELETED = "deleted", "Deleted"
 
+    class CleanupIntent(models.TextChoices):
+        NONE = "none", "None"
+        RESET_FOR_RETRY = "reset_for_retry", "Reset for retry"
+        DELETE_SESSION = "delete_session", "Delete session"
+
+    class CleanupStatus(models.TextChoices):
+        NONE = "none", "None"
+        PENDING = "pending", "Pending"
+        RUNNING = "running", "Running"
+        BLOCKED = "blocked", "Blocked"
+        COMPLETE = "complete", "Complete"
+
     class GatewaySelectionMode(models.TextChoices):
         AUTO = "auto", "Auto"
         MANUAL = "manual", "Manual"
@@ -746,6 +758,20 @@ class LensSessionLink(OrganizationScopedModel):
     provision_claim_token = models.UUIDField(null=True, blank=True, unique=True)
     provision_claimed_at = models.DateTimeField(null=True, blank=True, db_index=True)
     provision_next_retry_at = models.DateTimeField(null=True, blank=True, db_index=True)
+    provision_generation = models.PositiveBigIntegerField(default=1)
+    provision_poll_sequence = models.PositiveBigIntegerField(default=0)
+    cleanup_intent = models.CharField(
+        max_length=24,
+        choices=CleanupIntent.choices,
+        default=CleanupIntent.NONE,
+        db_index=True,
+    )
+    cleanup_status = models.CharField(
+        max_length=16,
+        choices=CleanupStatus.choices,
+        default=CleanupStatus.NONE,
+        db_index=True,
+    )
     teardown_state_json = models.JSONField(default=dict, blank=True)
     teardown_attempts = models.PositiveIntegerField(default=0)
     teardown_claim_token = models.UUIDField(null=True, blank=True, unique=True)

--- a/src/backend/apps/lens_bridge/services/chat_lifecycle.py
+++ b/src/backend/apps/lens_bridge/services/chat_lifecycle.py
@@ -56,6 +56,8 @@ _ASSISTANT_CREATE_OPERATION = "assistant_create"
 _SESSION_CREATE_OPERATION = "session_create"
 _TEARDOWN_INTENT_DELETE = "delete_session"
 _TEARDOWN_INTENT_RESET_FOR_RETRY = "reset_for_retry"
+_PROVISION_TRANSIENT_RETRY_BASE_SECONDS = 15
+_PROVISION_TRANSIENT_RETRY_MAX_SECONDS = 300
 _SCOPE_TASK_STATE_KEY = "scope_resolution"
 _MAX_BIGINT = 2**63 - 1
 _MIN_BIGINT = -(2**63)
@@ -504,10 +506,24 @@ def request_copilot_chat_teardown(link: LensSessionLink) -> LensSessionLink:
     if locked.lifecycle_status == LensSessionLink.LifecycleStatus.DELETED:
         return locked
 
-    teardown_intent = str((locked.teardown_state_json or {}).get("intent") or "")
+    legacy_teardown_intent = str(
+        (locked.teardown_state_json or {}).get("intent") or ""
+    )
     delete_intent_already_active = (
         locked.lifecycle_status == LensSessionLink.LifecycleStatus.DELETING
-        and teardown_intent == _TEARDOWN_INTENT_DELETE
+        and (
+            (
+                locked.cleanup_intent
+                == LensSessionLink.CleanupIntent.DELETE_SESSION
+                and locked.cleanup_status
+                in {
+                    LensSessionLink.CleanupStatus.PENDING,
+                    LensSessionLink.CleanupStatus.RUNNING,
+                    LensSessionLink.CleanupStatus.BLOCKED,
+                }
+            )
+            or legacy_teardown_intent == _TEARDOWN_INTENT_DELETE
+        )
     )
     if not delete_intent_already_active:
         locked.lifecycle_status = LensSessionLink.LifecycleStatus.DELETING
@@ -518,6 +534,10 @@ def request_copilot_chat_teardown(link: LensSessionLink) -> LensSessionLink:
         locked.provision_claim_token = None
         locked.provision_claimed_at = None
         locked.provision_next_retry_at = None
+        locked.provision_generation += 1
+        locked.provision_poll_sequence = 0
+        locked.cleanup_intent = LensSessionLink.CleanupIntent.DELETE_SESSION
+        locked.cleanup_status = LensSessionLink.CleanupStatus.PENDING
         locked.teardown_attempts = 0
         locked.teardown_claim_token = None
         locked.teardown_claimed_at = None
@@ -533,6 +553,10 @@ def request_copilot_chat_teardown(link: LensSessionLink) -> LensSessionLink:
                 "provision_claim_token",
                 "provision_claimed_at",
                 "provision_next_retry_at",
+                "provision_generation",
+                "provision_poll_sequence",
+                "cleanup_intent",
+                "cleanup_status",
                 "teardown_attempts",
                 "teardown_claim_token",
                 "teardown_claimed_at",
@@ -547,6 +571,9 @@ def request_copilot_chat_teardown(link: LensSessionLink) -> LensSessionLink:
 
 def _claim_copilot_chat_provision(
     session_link_id: int,
+    *,
+    expected_generation: int | None = None,
+    expected_poll_sequence: int | None = None,
 ) -> tuple[str | None, str]:
     """Claim one queued or stale Chat provisioning execution."""
     now = timezone.now()
@@ -560,6 +587,20 @@ def _claim_copilot_chat_provision(
             return None, "missing"
         if link.lifecycle_status != LensSessionLink.LifecycleStatus.PROVISIONING:
             return None, str(link.lifecycle_status)
+        if expected_generation is None and expected_poll_sequence is None:
+            # Messages published before poll fencing was deployed carry no
+            # tokens. They may claim only the initial migrated generation;
+            # accepting them after Retry/Delete has advanced the generation
+            # would let an old message take ownership of a new lifecycle run.
+            if link.provision_generation != 1 or link.provision_poll_sequence != 0:
+                return None, "stale"
+        elif expected_generation is None or expected_poll_sequence is None:
+            return None, "stale"
+        elif (
+            link.provision_generation != int(expected_generation)
+            or link.provision_poll_sequence != int(expected_poll_sequence)
+        ):
+            return None, "stale"
         if link.provision_claimed_at and link.provision_claimed_at > now - timedelta(
             seconds=PROVISION_CLAIM_TTL_SECONDS
         ):
@@ -568,7 +609,8 @@ def _claim_copilot_chat_provision(
             return None, "scheduled"
 
         claim_token = uuid_lib.uuid4()
-        link.provision_attempts += 1
+        if link.provision_poll_sequence == 0:
+            link.provision_attempts += 1
         link.provision_claim_token = claim_token
         link.provision_claimed_at = now
         link.provision_next_retry_at = next_retry_at(link.provision_attempts)
@@ -586,9 +628,18 @@ def _claim_copilot_chat_provision(
     return str(claim_token), "claimed"
 
 
-def run_copilot_chat_provision(*, session_link_id: int) -> dict[str, Any]:
+def run_copilot_chat_provision(
+    *,
+    session_link_id: int,
+    expected_generation: int | None = None,
+    expected_poll_sequence: int | None = None,
+) -> dict[str, Any]:
     """Provision one chat and persist failures from every execution stage."""
-    claim_token, claim_status = _claim_copilot_chat_provision(session_link_id)
+    claim_token, claim_status = _claim_copilot_chat_provision(
+        session_link_id,
+        expected_generation=expected_generation,
+        expected_poll_sequence=expected_poll_sequence,
+    )
     if claim_token is None:
         return {"session_link_id": session_link_id, "status": claim_status}
     try:
@@ -597,7 +648,17 @@ def run_copilot_chat_provision(*, session_link_id: int) -> dict[str, Any]:
             claim_token=claim_token,
         )
         if result.get("status") == "waiting":
-            _release_provision_claim(session_link_id, claim_token)
+            sync_result = result.get("sync") if isinstance(result.get("sync"), dict) else {}
+            retry_after_seconds = int(
+                result.get("retry_after_seconds")
+                or sync_result.get("retry_after_seconds")
+                or 5
+            )
+            result["next_poll"] = _defer_provision_poll(
+                session_link_id,
+                claim_token,
+                retry_after_seconds=retry_after_seconds,
+            )
         return result
     except ChatProvisionLeaseLostError:
         current_status = (
@@ -613,6 +674,18 @@ def run_copilot_chat_provision(*, session_link_id: int) -> dict[str, Any]:
         return {
             "session_link_id": session_link_id,
             "status": current_status or "missing",
+        }
+    except sl_client.LensBridgeUnavailable as exc:
+        next_poll = _defer_provision_for_transient_error(
+            session_link_id,
+            claim_token,
+            detail=str(exc.detail),
+        )
+        return {
+            "session_link_id": session_link_id,
+            "status": "waiting",
+            "detail": str(exc.detail),
+            "next_poll": next_poll,
         }
     except Exception as exc:
         logger.exception(
@@ -741,6 +814,8 @@ def _run_copilot_chat_provision(
             backup_snapshot_directory_id=first_directory_id,
             source_path=first_path,
             source_scopes_json=scopes,
+            linked_version_mode=LensKnowledgeSource.LinkedVersionMode.PINNED,
+            pinned_snapshot_id=snapshot_id,
             sl_lensnode_uuid=gateway_link.sl_lensnode_uuid,
             ingest_policy_json=ingest_policy.normalize_ingest_policy(
                 {
@@ -782,11 +857,26 @@ def _run_copilot_chat_provision(
         progress_callback=sync_progress,
     )
     if sync_result.get("status") in {"waiting", "busy", "scheduled"}:
+        retry_after_seconds = int(sync_result.get("retry_after_seconds") or 0)
+        if retry_after_seconds <= 0:
+            next_poll_at = (
+                LensKnowledgeSource.objects.filter(pk=ks.id)
+                .values_list("sync_next_poll_at", flat=True)
+                .first()
+            )
+            if next_poll_at is not None:
+                retry_after_seconds = max(
+                    1,
+                    int((next_poll_at - timezone.now()).total_seconds()),
+                )
+        if retry_after_seconds <= 0:
+            retry_after_seconds = 10 if sync_result.get("status") == "busy" else 5
         return {
             "session_link_id": link.id,
             "status": "waiting",
             "knowledge_source_id": ks.id,
             "sync": sync_result,
+            "retry_after_seconds": retry_after_seconds,
         }
     ks.refresh_from_db()
     if ks.status not in (
@@ -1198,21 +1288,92 @@ def _require_provision_claim(link_id: int, claim_token: str) -> None:
         raise ChatProvisionLeaseLostError("Chat provisioning lease was lost.")
 
 
-def _release_provision_claim(link_id: int, claim_token: str) -> None:
-    """Release a healthy provision lease while external work is pending."""
+@transaction.atomic
+def _defer_provision_poll(
+    link_id: int,
+    claim_token: str,
+    *,
+    retry_after_seconds: int,
+    transient_detail: str = "",
+) -> dict[str, int]:
+    """Advance one durable poll generation and release the worker lease."""
 
-    updated = LensSessionLink.objects.filter(
-        pk=link_id,
-        lifecycle_status=LensSessionLink.LifecycleStatus.PROVISIONING,
-        provision_claim_token=claim_token,
-    ).update(
-        provision_claim_token=None,
-        provision_claimed_at=None,
-        provision_next_retry_at=None,
-        updated_at=timezone.now(),
+    link = (
+        LensSessionLink.objects.select_for_update()
+        .filter(
+            pk=link_id,
+            lifecycle_status=LensSessionLink.LifecycleStatus.PROVISIONING,
+            provision_claim_token=claim_token,
+        )
+        .first()
     )
-    if updated != 1:
+    if link is None:
         raise ChatProvisionLeaseLostError("Chat provisioning lease was lost.")
+    delay = max(1, min(int(retry_after_seconds), _PROVISION_TRANSIENT_RETRY_MAX_SECONDS))
+    link.provision_poll_sequence += 1
+    link.provision_claim_token = None
+    link.provision_claimed_at = None
+    link.provision_next_retry_at = timezone.now() + timedelta(seconds=delay)
+    state = dict(link.provision_state_json or {})
+    if transient_detail:
+        transient = dict(state.get("source_lens_transient") or {})
+        transient.update(
+            {
+                "count": int(transient.get("count") or 0) + 1,
+                "detail": transient_detail[:500],
+                "last_seen_at": timezone.now().isoformat(),
+            }
+        )
+        state["source_lens_transient"] = transient
+        link.provision_state_json = state
+        link.provision_detail = (
+            "SourceLens is temporarily unavailable. Retrying automatically."
+        )
+    else:
+        state.pop("source_lens_transient", None)
+        link.provision_state_json = state
+    link.save(
+        update_fields=[
+            "provision_poll_sequence",
+            "provision_claim_token",
+            "provision_claimed_at",
+            "provision_next_retry_at",
+            "provision_state_json",
+            "provision_detail",
+            "updated_at",
+        ]
+    )
+    return {
+        "generation": int(link.provision_generation),
+        "sequence": int(link.provision_poll_sequence),
+        "retry_after_seconds": delay,
+    }
+
+
+def _defer_provision_for_transient_error(
+    link_id: int,
+    claim_token: str,
+    *,
+    detail: str,
+) -> dict[str, int]:
+    state = (
+        LensSessionLink.objects.filter(pk=link_id)
+        .values_list("provision_state_json", flat=True)
+        .first()
+        or {}
+    )
+    transient = state.get("source_lens_transient") if isinstance(state, dict) else {}
+    count = int((transient or {}).get("count") or 0) + 1
+    delay = min(
+        _PROVISION_TRANSIENT_RETRY_MAX_SECONDS,
+        _PROVISION_TRANSIENT_RETRY_BASE_SECONDS * (2 ** min(count - 1, 4)),
+    )
+    return _defer_provision_poll(
+        link_id,
+        claim_token,
+        retry_after_seconds=delay,
+        transient_detail=detail,
+    )
 
 
 def _update_provision_claim(
@@ -1599,7 +1760,10 @@ def _complete_copilot_chat_provision(
             operation["status"] = "bound"
             operation["updated_at"] = timezone.now().isoformat()
             provision_state[kind] = operation
+    provision_state.pop("source_lens_transient", None)
     link.provision_state_json = provision_state
+    link.cleanup_intent = LensSessionLink.CleanupIntent.NONE
+    link.cleanup_status = LensSessionLink.CleanupStatus.NONE
     link.provision_claim_token = None
     link.provision_claimed_at = None
     link.provision_next_retry_at = None
@@ -1612,6 +1776,8 @@ def _complete_copilot_chat_provision(
             "provision_detail",
             "lifecycle_error",
             "provision_state_json",
+            "cleanup_intent",
+            "cleanup_status",
             "provision_claim_token",
             "provision_claimed_at",
             "provision_next_retry_at",
@@ -1732,32 +1898,71 @@ def _record_late_source_lens_resource(
     else:
         setattr(link, field, resource_uuid)
         update_fields = [field, "lifecycle_error", "updated_at"]
+    delete_session = (
+        link.lifecycle_status
+        in {
+            LensSessionLink.LifecycleStatus.DELETING,
+            LensSessionLink.LifecycleStatus.DELETED,
+        }
+        or link.cleanup_intent == LensSessionLink.CleanupIntent.DELETE_SESSION
+        or link.status == LensSessionLink.Status.ARCHIVED
+    )
+    cleanup_intent = (
+        LensSessionLink.CleanupIntent.DELETE_SESSION
+        if delete_session
+        else LensSessionLink.CleanupIntent.RESET_FOR_RETRY
+    )
     link.lifecycle_error = error[:2000]
-    if link.lifecycle_status != LensSessionLink.LifecycleStatus.DELETING:
+    link.cleanup_intent = cleanup_intent
+    link.cleanup_status = LensSessionLink.CleanupStatus.PENDING
+    teardown_state = dict(link.teardown_state_json or {})
+    teardown_state["intent"] = cleanup_intent
+    link.teardown_state_json = teardown_state
+    update_fields.extend(
+        ["cleanup_intent", "cleanup_status", "teardown_state_json"]
+    )
+    link.teardown_claim_token = None
+    link.teardown_claimed_at = None
+    link.teardown_next_retry_at = None
+    update_fields.extend(
+        [
+            "teardown_claim_token",
+            "teardown_claimed_at",
+            "teardown_next_retry_at",
+        ]
+    )
+    link.provision_claim_token = None
+    link.provision_claimed_at = None
+    link.provision_next_retry_at = None
+    link.provision_generation += 1
+    link.provision_poll_sequence = 0
+    update_fields.extend(
+        [
+            "provision_claim_token",
+            "provision_claimed_at",
+            "provision_next_retry_at",
+            "provision_generation",
+            "provision_poll_sequence",
+        ]
+    )
+    if delete_session:
         link.lifecycle_status = LensSessionLink.LifecycleStatus.DELETING
         link.status = LensSessionLink.Status.ARCHIVED
-        link.provision_phase = LensSessionLink.ProvisionPhase.CLEANING_UP
+        link.provision_phase = LensSessionLink.ProvisionPhase.DELETING
         link.provision_detail = "Deleting a resource returned after Chat deletion."
-        link.provision_claim_token = None
-        link.provision_claimed_at = None
-        link.provision_next_retry_at = None
-        link.teardown_claim_token = None
-        link.teardown_claimed_at = None
-        link.teardown_next_retry_at = None
-        update_fields.extend(
-            [
-                "lifecycle_status",
-                "status",
-                "provision_phase",
-                "provision_detail",
-                "provision_claim_token",
-                "provision_claimed_at",
-                "provision_next_retry_at",
-                "teardown_claim_token",
-                "teardown_claimed_at",
-                "teardown_next_retry_at",
-            ]
-        )
+    else:
+        link.lifecycle_status = LensSessionLink.LifecycleStatus.FAILED
+        link.status = LensSessionLink.Status.ACTIVE
+        link.provision_phase = LensSessionLink.ProvisionPhase.CLEANING_UP
+        link.provision_detail = "Cleaning up a late resource from failed preparation."
+    update_fields.extend(
+        [
+            "lifecycle_status",
+            "status",
+            "provision_phase",
+            "provision_detail",
+        ]
+    )
     link.save(update_fields=update_fields)
     transaction.on_commit(lambda: _queue_teardown_or_record_error(link.id))
 
@@ -1827,8 +2032,34 @@ def _claim_copilot_chat_teardown(session_link_id: int) -> tuple[str | None, str]
             return None, "missing"
         if link.lifecycle_status == LensSessionLink.LifecycleStatus.DELETED:
             return None, "deleted"
-        if link.lifecycle_status != LensSessionLink.LifecycleStatus.DELETING:
+        if link.cleanup_intent == LensSessionLink.CleanupIntent.NONE:
+            legacy_intent = str((link.teardown_state_json or {}).get("intent") or "")
+            if (
+                link.lifecycle_status == LensSessionLink.LifecycleStatus.DELETING
+                and not legacy_intent
+            ):
+                legacy_intent = _TEARDOWN_INTENT_DELETE
+            if (
+                link.lifecycle_status == LensSessionLink.LifecycleStatus.DELETING
+                and legacy_intent
+                in {_TEARDOWN_INTENT_DELETE, _TEARDOWN_INTENT_RESET_FOR_RETRY}
+            ):
+                link.cleanup_intent = legacy_intent
+                link.cleanup_status = LensSessionLink.CleanupStatus.PENDING
+                if legacy_intent == _TEARDOWN_INTENT_RESET_FOR_RETRY:
+                    link.lifecycle_status = LensSessionLink.LifecycleStatus.FAILED
+        delete_cleanup = (
+            link.cleanup_intent == LensSessionLink.CleanupIntent.DELETE_SESSION
+            and link.lifecycle_status == LensSessionLink.LifecycleStatus.DELETING
+        )
+        reset_cleanup = (
+            link.cleanup_intent == LensSessionLink.CleanupIntent.RESET_FOR_RETRY
+            and link.lifecycle_status == LensSessionLink.LifecycleStatus.FAILED
+        )
+        if not (delete_cleanup or reset_cleanup):
             return None, str(link.lifecycle_status)
+        if link.cleanup_status == LensSessionLink.CleanupStatus.COMPLETE:
+            return None, "complete"
         if link.teardown_claimed_at and link.teardown_claimed_at > now - timedelta(
             seconds=TEARDOWN_CLAIM_TTL_SECONDS
         ):
@@ -1836,8 +2067,8 @@ def _claim_copilot_chat_teardown(session_link_id: int) -> tuple[str | None, str]
         if link.teardown_next_retry_at and link.teardown_next_retry_at > now:
             return None, "scheduled"
         claim_token = uuid_lib.uuid4()
-        link.lifecycle_status = LensSessionLink.LifecycleStatus.DELETING
         link.teardown_attempts += 1
+        link.cleanup_status = LensSessionLink.CleanupStatus.RUNNING
         link.teardown_claim_token = claim_token
         link.teardown_claimed_at = now
         link.teardown_next_retry_at = next_retry_at(link.teardown_attempts)
@@ -1845,6 +2076,8 @@ def _claim_copilot_chat_teardown(session_link_id: int) -> tuple[str | None, str]
             update_fields=[
                 "teardown_attempts",
                 "lifecycle_status",
+                "cleanup_intent",
+                "cleanup_status",
                 "teardown_claim_token",
                 "teardown_claimed_at",
                 "teardown_next_retry_at",
@@ -1887,7 +2120,7 @@ def _update_chat_claim(
     updated = LensSessionLink.objects.filter(
         pk=link.id,
         teardown_claim_token=claim_token,
-        lifecycle_status=LensSessionLink.LifecycleStatus.DELETING,
+        cleanup_status=LensSessionLink.CleanupStatus.RUNNING,
     ).update(**values)
     if updated != 1:
         raise ChatTeardownIncompleteError("Chat teardown lease was lost.")
@@ -1916,7 +2149,13 @@ def run_copilot_chat_teardown(*, session_link_id: int) -> dict[str, Any]:
     critical_errors: list[str] = []
     warnings: list[str] = []
     teardown_state = dict(link.teardown_state_json or {})
-    teardown_intent = str(teardown_state.get("intent") or _TEARDOWN_INTENT_DELETE)
+    teardown_intent = str(link.cleanup_intent or teardown_state.get("intent") or "")
+    if teardown_intent not in {
+        _TEARDOWN_INTENT_DELETE,
+        _TEARDOWN_INTENT_RESET_FOR_RETRY,
+    }:
+        teardown_intent = _TEARDOWN_INTENT_DELETE
+    teardown_state["intent"] = teardown_intent
 
     if link.active_run_uuid:
         try:
@@ -2003,6 +2242,7 @@ def run_copilot_chat_teardown(*, session_link_id: int) -> dict[str, Any]:
     journal_assistant_uuid: uuid_lib.UUID | None = None
     failed_assistant_uuids: list[uuid_lib.UUID] = []
     ks = link.knowledge_source
+    cleanup_waiting_for_conversion_stop = False
     assistant_uuids: set[uuid_lib.UUID] = set()
     if session_cleanup_complete:
         try:
@@ -2121,6 +2361,19 @@ def run_copilot_chat_teardown(*, session_link_id: int) -> dict[str, Any]:
             _teardown_step(teardown_state, "cleanup_workspace", status="success")
         except Exception as exc:
             critical_errors.append(f"cleanup_workspace: {exc}")
+            latest_ks_teardown_state = (
+                LensKnowledgeSource.all_objects.filter(pk=ks.id)
+                .values_list("teardown_state_json", flat=True)
+                .first()
+                or {}
+            )
+            cleanup_waiting_for_conversion_stop = bool(
+                isinstance(latest_ks_teardown_state, dict)
+                and (
+                    latest_ks_teardown_state.get("cancel_conversion") or {}
+                ).get("status")
+                == "waiting"
+            )
             _teardown_step(
                 teardown_state, "cleanup_workspace", status="retry", error=str(exc)
             )
@@ -2140,21 +2393,36 @@ def run_copilot_chat_teardown(*, session_link_id: int) -> dict[str, Any]:
         )
 
     reset_for_retry = teardown_intent == _TEARDOWN_INTENT_RESET_FOR_RETRY
+    cleanup_blocked = cleanup_waiting_for_conversion_stop
     if critical_errors:
-        link.lifecycle_status = LensSessionLink.LifecycleStatus.DELETING
+        link.lifecycle_status = (
+            LensSessionLink.LifecycleStatus.FAILED
+            if reset_for_retry
+            else LensSessionLink.LifecycleStatus.DELETING
+        )
         link.status = (
             LensSessionLink.Status.ACTIVE
             if reset_for_retry
             else LensSessionLink.Status.ARCHIVED
         )
         link.provision_phase = LensSessionLink.ProvisionPhase.CLEANING_UP
-        link.provision_detail = "Chat cleanup is incomplete and will be retried."
+        link.cleanup_status = (
+            LensSessionLink.CleanupStatus.BLOCKED
+            if cleanup_blocked
+            else LensSessionLink.CleanupStatus.PENDING
+        )
+        link.provision_detail = (
+            "Cleanup is waiting for SourceLens to confirm conversion has stopped."
+            if cleanup_blocked
+            else "Chat cleanup is incomplete and will be retried."
+        )
         link.lifecycle_error = "; ".join([*critical_errors, *warnings])[:2000]
     elif reset_for_retry:
         link.lifecycle_status = LensSessionLink.LifecycleStatus.FAILED
         link.status = LensSessionLink.Status.ACTIVE
         link.provision_phase = LensSessionLink.ProvisionPhase.QUEUED
         link.provision_detail = "Chat preparation failed. Retry to try again."
+        link.cleanup_status = LensSessionLink.CleanupStatus.COMPLETE
         provision_error = str(teardown_state.get("provision_error") or "")
         link.lifecycle_error = "; ".join(
             item for item in [provision_error, *warnings] if item
@@ -2164,18 +2432,21 @@ def run_copilot_chat_teardown(*, session_link_id: int) -> dict[str, Any]:
         link.status = LensSessionLink.Status.ARCHIVED
         link.provision_phase = LensSessionLink.ProvisionPhase.DELETED
         link.provision_detail = "Chat resources deleted."
+        link.cleanup_status = LensSessionLink.CleanupStatus.COMPLETE
         link.lifecycle_error = "; ".join(warnings)[:2000]
     link.active_run_uuid = None
     link.active_run_status = ""
     link.teardown_state_json = teardown_state
     link.teardown_claim_token = None
     link.teardown_claimed_at = None
-    if not critical_errors:
+    if cleanup_blocked:
+        link.teardown_next_retry_at = timezone.now() + timedelta(minutes=5)
+    elif not critical_errors:
         link.teardown_next_retry_at = None
     final_query = LensSessionLink.objects.filter(
         pk=link.id,
         teardown_claim_token=claim_token,
-        lifecycle_status=LensSessionLink.LifecycleStatus.DELETING,
+        cleanup_status=LensSessionLink.CleanupStatus.RUNNING,
     )
     if not critical_errors:
         final_query = final_query.filter(
@@ -2192,6 +2463,7 @@ def run_copilot_chat_teardown(*, session_link_id: int) -> dict[str, Any]:
         active_run_uuid=None,
         active_run_status="",
         teardown_state_json=teardown_state,
+        cleanup_status=link.cleanup_status,
         teardown_claim_token=None,
         teardown_claimed_at=None,
         teardown_next_retry_at=link.teardown_next_retry_at,
@@ -2231,6 +2503,8 @@ def _mark_provision_failed_by_id(
         provision_claim_token=None,
         provision_claimed_at=None,
         provision_next_retry_at=None,
+        cleanup_intent=LensSessionLink.CleanupIntent.RESET_FOR_RETRY,
+        cleanup_status=LensSessionLink.CleanupStatus.COMPLETE,
         capacity_reservation_status=LensSessionLink.CapacityReservationStatus.RELEASED,
         updated_at=timezone.now(),
     )
@@ -2255,7 +2529,7 @@ def _transition_failed_provision_to_teardown(
     )
     if link is None:
         return False
-    link.lifecycle_status = LensSessionLink.LifecycleStatus.DELETING
+    link.lifecycle_status = LensSessionLink.LifecycleStatus.FAILED
     link.status = LensSessionLink.Status.ACTIVE
     link.provision_phase = LensSessionLink.ProvisionPhase.CLEANING_UP
     link.provision_detail = "Provisioning cleanup is incomplete and will be retried."
@@ -2263,6 +2537,10 @@ def _transition_failed_provision_to_teardown(
     link.provision_claim_token = None
     link.provision_claimed_at = None
     link.provision_next_retry_at = None
+    link.provision_generation += 1
+    link.provision_poll_sequence = 0
+    link.cleanup_intent = LensSessionLink.CleanupIntent.RESET_FOR_RETRY
+    link.cleanup_status = LensSessionLink.CleanupStatus.PENDING
     link.teardown_attempts = 0
     link.teardown_claim_token = None
     link.teardown_claimed_at = None
@@ -2281,6 +2559,10 @@ def _transition_failed_provision_to_teardown(
             "provision_claim_token",
             "provision_claimed_at",
             "provision_next_retry_at",
+            "provision_generation",
+            "provision_poll_sequence",
+            "cleanup_intent",
+            "cleanup_status",
             "teardown_attempts",
             "teardown_claim_token",
             "teardown_claimed_at",
@@ -2377,6 +2659,18 @@ def retry_copilot_chat_provision(link: LensSessionLink) -> LensSessionLink:
             return locked
     elif locked.lifecycle_status != LensSessionLink.LifecycleStatus.FAILED:
         raise ValidationError({"lifecycle_status": "Session is not retryable."})
+    if locked.cleanup_status in {
+        LensSessionLink.CleanupStatus.PENDING,
+        LensSessionLink.CleanupStatus.RUNNING,
+        LensSessionLink.CleanupStatus.BLOCKED,
+    }:
+        raise ValidationError(
+            {
+                "lifecycle_status": (
+                    "Chat recovery must finish before preparation can be retried."
+                )
+            }
+        )
 
     _assert_retry_public_gateway_capacity(session=locked)
 
@@ -2387,6 +2681,10 @@ def retry_copilot_chat_provision(link: LensSessionLink) -> LensSessionLink:
     locked.provision_claim_token = None
     locked.provision_claimed_at = None
     locked.provision_next_retry_at = None
+    locked.provision_generation += 1
+    locked.provision_poll_sequence = 0
+    locked.cleanup_intent = LensSessionLink.CleanupIntent.NONE
+    locked.cleanup_status = LensSessionLink.CleanupStatus.NONE
     locked.teardown_attempts = 0
     locked.teardown_claim_token = None
     locked.teardown_claimed_at = None
@@ -2394,6 +2692,7 @@ def retry_copilot_chat_provision(link: LensSessionLink) -> LensSessionLink:
     locked.teardown_state_json = {}
     provision_state = dict(locked.provision_state_json or {})
     provision_state.pop(_SCOPE_TASK_STATE_KEY, None)
+    provision_state.pop("source_lens_transient", None)
     locked.provision_state_json = provision_state
     if locked.knowledge_source_id is None:
         locked.capacity_reservation_status = (
@@ -2408,6 +2707,10 @@ def retry_copilot_chat_provision(link: LensSessionLink) -> LensSessionLink:
             "provision_claim_token",
             "provision_claimed_at",
             "provision_next_retry_at",
+            "provision_generation",
+            "provision_poll_sequence",
+            "cleanup_intent",
+            "cleanup_status",
             "teardown_attempts",
             "teardown_claim_token",
             "teardown_claimed_at",
@@ -2422,11 +2725,28 @@ def retry_copilot_chat_provision(link: LensSessionLink) -> LensSessionLink:
     return locked
 
 
-def _queue_provision_or_mark_failed(session_link_id: int) -> None:
+def _queue_provision_or_mark_failed(
+    session_link_id: int,
+) -> None:
     from apps.lens_bridge.services.sync_queue import queue_copilot_chat_provision
 
     try:
-        queue_copilot_chat_provision(session_link_id=session_link_id)
+        tokens = (
+            LensSessionLink.objects.filter(
+                pk=session_link_id,
+                lifecycle_status=LensSessionLink.LifecycleStatus.PROVISIONING,
+            )
+            .values_list("provision_generation", "provision_poll_sequence")
+            .first()
+        )
+        if tokens is None:
+            return
+        generation, poll_sequence = tokens
+        queue_copilot_chat_provision(
+            session_link_id=session_link_id,
+            expected_generation=generation,
+            expected_poll_sequence=poll_sequence,
+        )
     except Exception as exc:
         logger.exception(
             "copilot chat provision dispatch failed session_link_id=%s", session_link_id
@@ -2453,12 +2773,25 @@ def _queue_teardown_or_record_error(session_link_id: int) -> None:
         logger.exception(
             "copilot chat teardown dispatch failed session_link_id=%s", session_link_id
         )
-        LensSessionLink.objects.filter(
+        cleanup_query = LensSessionLink.objects.filter(
             pk=session_link_id,
-            lifecycle_status=LensSessionLink.LifecycleStatus.DELETING,
-        ).update(
+            cleanup_status__in=(
+                LensSessionLink.CleanupStatus.PENDING,
+                LensSessionLink.CleanupStatus.RUNNING,
+                LensSessionLink.CleanupStatus.BLOCKED,
+            ),
+        )
+        cleanup_intent = cleanup_query.values_list(
+            "cleanup_intent", flat=True
+        ).first()
+        cleanup_query.update(
             lifecycle_error=("Teardown queue unavailable: " + str(exc))[:2000],
-            provision_detail="Deletion is waiting for the worker queue.",
+            provision_detail=(
+                "Recovery cleanup is waiting for the worker queue."
+                if cleanup_intent
+                == LensSessionLink.CleanupIntent.RESET_FOR_RETRY
+                else "Deletion is waiting for the worker queue."
+            ),
             updated_at=timezone.now(),
         )
 

--- a/src/backend/apps/lens_bridge/services/knowledge_source_sync.py
+++ b/src/backend/apps/lens_bridge/services/knowledge_source_sync.py
@@ -24,6 +24,7 @@ from apps.lens_bridge.services import (
     ingest_policy,
     managed_datasource,
     provisioning,
+    sl_client,
 )
 from apps.lens_bridge.services.gateway_execution import context_for_knowledge_source
 from apps.node.models.node import Node
@@ -477,26 +478,58 @@ def run_knowledge_source_sync(
             ks=ks,
             progress_callback=progress_callback,
         )
+        _clear_source_lens_transient_state(ks)
         _release_sync_claim(
             knowledge_source_id=knowledge_source_id,
             claim_token=claim_token,
         )
         return result
     except managed_datasource.ManagedDatasourcePending as exc:
+        retry_after_seconds = exc.retry_after_seconds
+        _clear_source_lens_transient_state(ks)
         _release_sync_claim(
             knowledge_source_id=knowledge_source_id,
             claim_token=claim_token,
             next_poll_at=(
                 timezone.now()
-                + timedelta(
-                    seconds=managed_datasource.CONVERSION_RETRY_SECONDS
-                )
+                + timedelta(seconds=retry_after_seconds)
             ),
         )
         return {
             "knowledge_source_id": ks.id,
             "status": "waiting",
             "detail": str(exc),
+            "retry_after_seconds": retry_after_seconds,
+        }
+    except sl_client.LensBridgeUnavailable as exc:
+        retry_after_seconds = managed_datasource.CONVERSION_TRANSIENT_RETRY_MAX_SECONDS // 10
+        sync_state = dict(ks.sync_state_json or {})
+        transient = dict(sync_state.get("source_lens_transient") or {})
+        transient_count = int(transient.get("count") or 0) + 1
+        retry_after_seconds = min(
+            managed_datasource.CONVERSION_TRANSIENT_RETRY_MAX_SECONDS,
+            retry_after_seconds * (2 ** max(0, min(transient_count - 1, 3))),
+        )
+        sync_state["source_lens_transient"] = {
+            "count": transient_count,
+            "last_seen_at": timezone.now().isoformat(),
+        }
+        ks.sync_state_json = sync_state
+        ks.status = LensKnowledgeSource.Status.SYNCING
+        ks.status_detail = "SourceLens is temporarily unavailable. Retrying automatically."
+        ks.save(
+            update_fields=["sync_state_json", "status", "status_detail", "updated_at"]
+        )
+        _release_sync_claim(
+            knowledge_source_id=knowledge_source_id,
+            claim_token=claim_token,
+            next_poll_at=timezone.now() + timedelta(seconds=retry_after_seconds),
+        )
+        return {
+            "knowledge_source_id": ks.id,
+            "status": "waiting",
+            "detail": str(exc.detail),
+            "retry_after_seconds": retry_after_seconds,
         }
     except Exception as exc:
         logger.exception(
@@ -510,6 +543,27 @@ def run_knowledge_source_sync(
             claim_token=claim_token,
         )
         raise
+
+
+def _clear_source_lens_transient_state(ks: LensKnowledgeSource) -> None:
+    """Clear a recovered bridge outage without overwriting pipeline progress."""
+
+    current_state = (
+        LensKnowledgeSource.all_objects.filter(pk=ks.id)
+        .values_list("sync_state_json", flat=True)
+        .first()
+    )
+    if (
+        not isinstance(current_state, dict)
+        or "source_lens_transient" not in current_state
+    ):
+        return
+    current_state = dict(current_state)
+    current_state.pop("source_lens_transient", None)
+    LensKnowledgeSource.all_objects.filter(pk=ks.id).update(
+        sync_state_json=current_state,
+        updated_at=timezone.now(),
+    )
 
 
 def _run_sync_pipeline(

--- a/src/backend/apps/lens_bridge/services/managed_datasource.py
+++ b/src/backend/apps/lens_bridge/services/managed_datasource.py
@@ -16,6 +16,8 @@ from apps.lens_bridge.services import sl_client
 CONVERSION_WAIT_SECONDS = 6 * 3600
 CONVERSION_RETRY_SECONDS = 5
 CONVERSION_RECOVERY_CLOCK_SKEW_SECONDS = 60
+CONVERSION_TRANSIENT_RETRY_MAX_SECONDS = 300
+CONVERSION_IDLE_RETRY_MAX_SECONDS = 60
 
 
 class ManagedDatasourceError(RuntimeError):
@@ -24,6 +26,47 @@ class ManagedDatasourceError(RuntimeError):
 
 class ManagedDatasourcePending(RuntimeError):
     """Raised when durable conversion work must be polled by a later task."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        retry_after_seconds: int = CONVERSION_RETRY_SECONDS,
+    ):
+        super().__init__(message)
+        self.retry_after_seconds = max(1, int(retry_after_seconds))
+
+
+def _transient_retry_seconds(attempt: int) -> int:
+    return min(
+        CONVERSION_TRANSIENT_RETRY_MAX_SECONDS,
+        15 * (2 ** max(0, min(int(attempt) - 1, 5))),
+    )
+
+
+def _record_transient_state(
+    *,
+    ks: LensKnowledgeSource,
+    sync_state: dict[str, Any],
+    state: dict[str, Any],
+    operation: str,
+) -> int:
+    count = int(state.get("transient_error_count") or 0) + 1
+    state.update(
+        {
+            "transient_error_count": count,
+            "last_transient_operation": operation,
+            "last_transient_error_at": timezone.now().isoformat(),
+        }
+    )
+    _persist_conversion_state(ks=ks, sync_state=sync_state, state=state)
+    return _transient_retry_seconds(count)
+
+
+def _clear_transient_state(state: dict[str, Any]) -> None:
+    state.pop("transient_error_count", None)
+    state.pop("last_transient_operation", None)
+    state.pop("last_transient_error_at", None)
 
 
 def _save_sync_state(
@@ -408,6 +451,13 @@ def conversion_stop_confirmed(ks: LensKnowledgeSource) -> bool:
         return True
     if status not in {"FAILURE", "REVOKED"}:
         return False
+    manual_confirmation = conversion_state.get("manual_stop_confirmation")
+    if (
+        isinstance(manual_confirmation, dict)
+        and manual_confirmation.get("confirmed") is True
+        and str(manual_confirmation.get("task_id") or "") == task_id
+    ):
+        return True
     metadata = (
         task.get("metadata") if isinstance(task.get("metadata"), dict) else {}
     )
@@ -448,10 +498,22 @@ def convert_documents(
         and state.get("policy_fingerprint") == fingerprint
         and str(state.get("status") or "").upper() == "STARTING"
     ):
-        task = _recover_started_conversion(
-            datasource_uuid=str(ks.sl_datasource_uuid),
-            state=state,
-        )
+        try:
+            task = _recover_started_conversion(
+                datasource_uuid=str(ks.sl_datasource_uuid),
+                state=state,
+            )
+        except sl_client.LensBridgeUnavailable as exc:
+            retry_after = _record_transient_state(
+                ks=ks,
+                sync_state=sync_state,
+                state=state,
+                operation="recover_conversion_start",
+            )
+            raise ManagedDatasourcePending(
+                "SourceLens is temporarily unavailable while reconciling the conversion.",
+                retry_after_seconds=retry_after,
+            ) from exc
         if task is None:
             state["lookup_missing_at"] = timezone.now().isoformat()
             _persist_conversion_state(
@@ -481,7 +543,19 @@ def convert_documents(
             state=state,
         )
     if task_id and state.get("policy_fingerprint") == fingerprint:
-        task = task or sl_client.get_task_by_id(task_id)
+        try:
+            task = task or sl_client.get_task_by_id(task_id)
+        except sl_client.LensBridgeUnavailable as exc:
+            retry_after = _record_transient_state(
+                ks=ks,
+                sync_state=sync_state,
+                state=state,
+                operation="poll_conversion",
+            )
+            raise ManagedDatasourcePending(
+                "SourceLens is temporarily unavailable while checking conversion progress.",
+                retry_after_seconds=retry_after,
+            ) from exc
         if task is None:
             state["lookup_missing_at"] = timezone.now().isoformat()
             _persist_conversion_state(
@@ -497,6 +571,7 @@ def convert_documents(
                 "Document conversion state is being reconciled."
             )
         elif str(task.get("status") or "") == "SUCCESS":
+            _clear_transient_state(state)
             summary = _conversion_summary(task)
             state.update(
                 {
@@ -571,13 +646,15 @@ def convert_documents(
                 raise ManagedDatasourceError(
                     "SourceLens rejected the document conversion request."
                 ) from exc
-            _persist_conversion_state(
+            retry_after = _record_transient_state(
                 ks=ks,
                 sync_state=sync_state,
                 state=state,
+                operation="start_conversion",
             )
             raise ManagedDatasourcePending(
-                "Document conversion start is being reconciled."
+                "Document conversion start is being reconciled.",
+                retry_after_seconds=retry_after,
             ) from exc
         task_id = str(started["task_id"])
         state.update(
@@ -588,6 +665,7 @@ def convert_documents(
                 "start_confirmed_at": timezone.now().isoformat(),
             }
         )
+        _clear_transient_state(state)
         _persist_conversion_state(
             ks=ks,
             sync_state=sync_state,
@@ -600,6 +678,26 @@ def convert_documents(
         task.get("metadata") if isinstance(task.get("metadata"), dict) else {}
     )
     summary = _conversion_summary(task)
+    previous_progress = str(state.get("progress_fingerprint") or "")
+    progress_fingerprint = hashlib.sha256(
+        json.dumps(
+            {
+                "status": status,
+                "step": metadata.get("progress_step") or "",
+                "message": metadata.get("progress_message") or "",
+                "percent": metadata.get("progress_percent"),
+                "summary": summary,
+            },
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()
+    idle_polls = (
+        int(state.get("idle_poll_count") or 0) + 1
+        if previous_progress == progress_fingerprint
+        else 0
+    )
     state.update(
         {
             "status": status,
@@ -611,8 +709,11 @@ def convert_documents(
                 summary,
                 visual_model_configured=bool(conversion.get("vision_model_ref")),
             ),
+            "progress_fingerprint": progress_fingerprint,
+            "idle_poll_count": idle_polls,
         }
     )
+    _clear_transient_state(state)
     _persist_conversion_state(
         ks=ks,
         sync_state=sync_state,
@@ -645,6 +746,11 @@ def convert_documents(
         raise ManagedDatasourceError(
             "SourceLens conversion did not complete before the wait timeout."
         )
+    retry_after = min(
+        CONVERSION_IDLE_RETRY_MAX_SECONDS,
+        CONVERSION_RETRY_SECONDS * (2 ** min(idle_polls, 4)),
+    )
     raise ManagedDatasourcePending(
-        str(state.get("progress_message") or "Document conversion is running.")
+        str(state.get("progress_message") or "Document conversion is running."),
+        retry_after_seconds=retry_after,
     )

--- a/src/backend/apps/lens_bridge/services/sl_client.py
+++ b/src/backend/apps/lens_bridge/services/sl_client.py
@@ -335,7 +335,7 @@ def _raise_for_response(response: requests.Response) -> Any:
         except ValueError:
             return response.text
         return _unwrap_sl_body(body)
-    if response.status_code >= 500:
+    if response.status_code == 429 or response.status_code >= 500:
         logger.warning("SourceLens upstream returned status=%s", response.status_code)
         raise LensBridgeUnavailable()
     detail = response.text[:2000]

--- a/src/backend/apps/lens_bridge/services/sync_queue.py
+++ b/src/backend/apps/lens_bridge/services/sync_queue.py
@@ -97,7 +97,12 @@ def queue_sl_chat_user_provision(*, user_id: int, gateway_operator: bool = False
         thread.start()
 
 
-def queue_copilot_chat_provision(*, session_link_id: int) -> None:
+def queue_copilot_chat_provision(
+    *,
+    session_link_id: int,
+    expected_generation: int | None = None,
+    expected_poll_sequence: int | None = None,
+) -> None:
     """Queue a durable Copilot job.
 
     Copilot provisioning owns external resources and must never run in an API
@@ -106,8 +111,17 @@ def queue_copilot_chat_provision(*, session_link_id: int) -> None:
     """
     from apps.lens_bridge.tasks.chat_lifecycle import execute_copilot_chat_provision_task
 
+    expected_generation = 1 if expected_generation is None else expected_generation
+    expected_poll_sequence = (
+        0 if expected_poll_sequence is None else expected_poll_sequence
+    )
+
     try:
-        execute_copilot_chat_provision_task.delay(session_link_id=session_link_id)
+        execute_copilot_chat_provision_task.delay(
+            session_link_id=session_link_id,
+            expected_generation=int(expected_generation),
+            expected_poll_sequence=int(expected_poll_sequence),
+        )
     except Exception as exc:
         logger.exception("Failed to queue copilot chat provision via Celery session=%s", session_link_id)
         raise RuntimeError("Unable to queue chat provisioning.") from exc

--- a/src/backend/apps/lens_bridge/tasks/chat_lifecycle.py
+++ b/src/backend/apps/lens_bridge/tasks/chat_lifecycle.py
@@ -33,7 +33,13 @@ _CHAT_PROVISION_WAIT_SECONDS = 5
     soft_time_limit=_PROVISION_SOFT_LIMIT,
     time_limit=_PROVISION_TIME_LIMIT,
 )
-def execute_copilot_chat_provision_task(self, *, session_link_id: int) -> dict:
+def execute_copilot_chat_provision_task(
+    self,
+    *,
+    session_link_id: int,
+    expected_generation: int | None = None,
+    expected_poll_sequence: int | None = None,
+) -> dict:
     with celery_trace(
         f"copilot-provision-{session_link_id}",
         task_name="apps.lens_bridge.tasks.chat_lifecycle.execute_copilot_chat_provision_task",
@@ -41,12 +47,34 @@ def execute_copilot_chat_provision_task(self, *, session_link_id: int) -> dict:
         from apps.lens_bridge.services.chat_lifecycle import run_copilot_chat_provision
 
         logger.info("copilot chat provision celery started session_link_id=%s", session_link_id)
-        result = run_copilot_chat_provision(session_link_id=int(session_link_id))
-        if result.get("status") == "waiting":
-            self.apply_async(
-                kwargs={"session_link_id": int(session_link_id)},
-                countdown=_CHAT_PROVISION_WAIT_SECONDS,
+        result = run_copilot_chat_provision(
+            session_link_id=int(session_link_id),
+            expected_generation=expected_generation,
+            expected_poll_sequence=expected_poll_sequence,
+        )
+        next_poll = result.get("next_poll")
+        if result.get("status") == "waiting" and isinstance(next_poll, dict):
+            retry_after_seconds = max(
+                _CHAT_PROVISION_WAIT_SECONDS,
+                int(next_poll.get("retry_after_seconds") or 0),
             )
+            try:
+                self.apply_async(
+                    kwargs={
+                        "session_link_id": int(session_link_id),
+                        "expected_generation": int(next_poll["generation"]),
+                        "expected_poll_sequence": int(next_poll["sequence"]),
+                    },
+                    countdown=retry_after_seconds,
+                )
+            except Exception:
+                logger.exception(
+                    "copilot provision follow-up dispatch failed; durable reconciler will retry "
+                    "session_link_id=%s generation=%s sequence=%s",
+                    session_link_id,
+                    next_poll.get("generation"),
+                    next_poll.get("sequence"),
+                )
         logger.info(
             "copilot chat provision celery finished session_link_id=%s status=%s",
             session_link_id,
@@ -93,7 +121,7 @@ def reconcile_copilot_chat_provisions_task(*, limit: int = 100) -> dict:
 
     now = timezone.now()
     stale_claim = now - timedelta(seconds=PROVISION_CLAIM_TTL_SECONDS)
-    session_ids = list(
+    sessions = list(
         LensSessionLink.objects.filter(
             lifecycle_status=LensSessionLink.LifecycleStatus.PROVISIONING,
         )
@@ -106,13 +134,19 @@ def reconcile_copilot_chat_provisions_task(*, limit: int = 100) -> dict:
             | Q(provision_claimed_at__lte=stale_claim)
         )
         .order_by("provision_next_retry_at", "id")
-        .values_list("id", flat=True)[: max(1, min(int(limit), 500))]
+        .values_list("id", "provision_generation", "provision_poll_sequence")[
+            : max(1, min(int(limit), 500))
+        ]
     )
     queued_session_ids: list[int] = []
     failures: list[dict[str, str | int]] = []
-    for session_id in session_ids:
+    for session_id, generation, poll_sequence in sessions:
         try:
-            execute_copilot_chat_provision_task.delay(session_link_id=session_id)
+            execute_copilot_chat_provision_task.delay(
+                session_link_id=session_id,
+                expected_generation=generation,
+                expected_poll_sequence=poll_sequence,
+            )
             queued_session_ids.append(session_id)
         except Exception as exc:
             logger.exception(
@@ -145,7 +179,29 @@ def reconcile_lens_resource_teardowns_task(*, limit: int = 100) -> dict:
     stale_claim = now - timedelta(seconds=TEARDOWN_CLAIM_TTL_SECONDS)
     session_ids = list(
         LensSessionLink.objects.filter(
-            lifecycle_status=LensSessionLink.LifecycleStatus.DELETING,
+            (
+                (
+                    Q(
+                        lifecycle_status=LensSessionLink.LifecycleStatus.DELETING,
+                        cleanup_intent=LensSessionLink.CleanupIntent.DELETE_SESSION,
+                    )
+                    | Q(
+                        lifecycle_status=LensSessionLink.LifecycleStatus.FAILED,
+                        cleanup_intent=LensSessionLink.CleanupIntent.RESET_FOR_RETRY,
+                    )
+                )
+                & Q(
+                    cleanup_status__in=(
+                        LensSessionLink.CleanupStatus.PENDING,
+                        LensSessionLink.CleanupStatus.RUNNING,
+                        LensSessionLink.CleanupStatus.BLOCKED,
+                    )
+                )
+            )
+            | Q(
+                lifecycle_status=LensSessionLink.LifecycleStatus.DELETING,
+                cleanup_intent=LensSessionLink.CleanupIntent.NONE,
+            )
         )
         .filter(
             Q(teardown_next_retry_at__isnull=True)

--- a/src/backend/apps/lens_bridge/tasks/knowledge_source_sync.py
+++ b/src/backend/apps/lens_bridge/tasks/knowledge_source_sync.py
@@ -57,7 +57,10 @@ def execute_knowledge_source_sync_task(
                     "knowledge_source_id": int(knowledge_source_id),
                     "mode": "resume",
                 },
-                countdown=CONVERSION_RETRY_SECONDS,
+                countdown=max(
+                    CONVERSION_RETRY_SECONDS,
+                    int(result.get("retry_after_seconds") or 0),
+                ),
             )
         logger.info(
             "knowledge source sync celery finished ks_id=%s status=%s",

--- a/src/backend/apps/lens_bridge/tests/test_chat_lifecycle_queue.py
+++ b/src/backend/apps/lens_bridge/tests/test_chat_lifecycle_queue.py
@@ -42,7 +42,15 @@ from common.errors import AppError
 class CopilotLifecycleQueueTests(SimpleTestCase):
     @patch(
         "apps.lens_bridge.services.chat_lifecycle.run_copilot_chat_provision",
-        return_value={"session_link_id": 42, "status": "waiting"},
+        return_value={
+            "session_link_id": 42,
+            "status": "waiting",
+            "next_poll": {
+                "generation": 3,
+                "sequence": 8,
+                "retry_after_seconds": 30,
+            },
+        },
     )
     def test_pending_task_schedules_a_short_follow_up(self, _run):
         task = chat_lifecycle_tasks.execute_copilot_chat_provision_task
@@ -51,11 +59,15 @@ class CopilotLifecycleQueueTests(SimpleTestCase):
 
         self.assertEqual(result["status"], "waiting")
         apply_async.assert_called_once_with(
-            kwargs={"session_link_id": 42},
-            countdown=5,
+            kwargs={
+                "session_link_id": 42,
+                "expected_generation": 3,
+                "expected_poll_sequence": 8,
+            },
+            countdown=30,
         )
 
-    @patch("apps.lens_bridge.services.chat_lifecycle._release_provision_claim")
+    @patch("apps.lens_bridge.services.chat_lifecycle._defer_provision_poll")
     @patch(
         "apps.lens_bridge.services.chat_lifecycle._claim_copilot_chat_provision",
         return_value=("claim-token", "claimed"),
@@ -68,12 +80,47 @@ class CopilotLifecycleQueueTests(SimpleTestCase):
         self,
         _run,
         _claim,
-        release_claim,
+        defer_poll,
     ):
         result = chat_lifecycle.run_copilot_chat_provision(session_link_id=42)
 
         self.assertEqual(result["status"], "waiting")
-        release_claim.assert_called_once_with(42, "claim-token")
+        defer_poll.assert_called_once_with(
+            42,
+            "claim-token",
+            retry_after_seconds=5,
+        )
+
+    @patch("apps.lens_bridge.services.chat_lifecycle._cleanup_failed_provision")
+    @patch(
+        "apps.lens_bridge.services.chat_lifecycle._defer_provision_for_transient_error",
+        return_value={
+            "generation": 2,
+            "sequence": 4,
+            "retry_after_seconds": 30,
+        },
+    )
+    @patch(
+        "apps.lens_bridge.services.chat_lifecycle._claim_copilot_chat_provision",
+        return_value=("claim-token", "claimed"),
+    )
+    @patch(
+        "apps.lens_bridge.services.chat_lifecycle._run_copilot_chat_provision",
+        side_effect=chat_lifecycle.sl_client.LensBridgeUnavailable(),
+    )
+    def test_transient_source_lens_failure_waits_without_cleanup(
+        self,
+        _run,
+        _claim,
+        defer_transient,
+        cleanup_failed,
+    ):
+        result = chat_lifecycle.run_copilot_chat_provision(session_link_id=42)
+
+        self.assertEqual(result["status"], "waiting")
+        self.assertEqual(result["next_poll"]["sequence"], 4)
+        defer_transient.assert_called_once()
+        cleanup_failed.assert_not_called()
 
     @patch("apps.lens_bridge.services.chat_lifecycle.LensSessionLink.objects.filter")
     @patch("apps.lens_bridge.services.chat_lifecycle._mark_provision_failed_by_id")
@@ -108,7 +155,11 @@ class CopilotLifecycleQueueTests(SimpleTestCase):
     def test_provision_dispatches_to_celery(self, delay):
         queue_copilot_chat_provision(session_link_id=42)
 
-        delay.assert_called_once_with(session_link_id=42)
+        delay.assert_called_once_with(
+            session_link_id=42,
+            expected_generation=1,
+            expected_poll_sequence=0,
+        )
 
     @patch(
         "apps.lens_bridge.tasks.chat_lifecycle.execute_copilot_chat_teardown_task.delay",
@@ -357,6 +408,99 @@ class CopilotRetryTests(TestCase):
 
         with self.assertRaisesRegex(ValidationError, "Session is not retryable"):
             chat_lifecycle.retry_copilot_chat_provision(session)
+
+    def test_cleanup_blocked_session_is_not_retryable(self):
+        session = self.create_session(LensSessionLink.LifecycleStatus.FAILED)
+        session.cleanup_intent = LensSessionLink.CleanupIntent.RESET_FOR_RETRY
+        session.cleanup_status = LensSessionLink.CleanupStatus.BLOCKED
+        session.save(
+            update_fields=["cleanup_intent", "cleanup_status", "updated_at"]
+        )
+
+        with self.assertRaisesRegex(ValidationError, "recovery must finish"):
+            chat_lifecycle.retry_copilot_chat_provision(session)
+
+    def test_stale_poll_message_cannot_claim_or_spawn_a_successor(self):
+        session = self.create_session(LensSessionLink.LifecycleStatus.PROVISIONING)
+        session.provision_generation = 3
+        session.provision_poll_sequence = 2
+        session.save(
+            update_fields=[
+                "provision_generation",
+                "provision_poll_sequence",
+                "updated_at",
+            ]
+        )
+
+        token, status = chat_lifecycle._claim_copilot_chat_provision(
+            session.id,
+            expected_generation=3,
+            expected_poll_sequence=1,
+        )
+
+        self.assertIsNone(token)
+        self.assertEqual(status, "stale")
+        session.refresh_from_db()
+        self.assertIsNone(session.provision_claim_token)
+
+    def test_legacy_message_cannot_claim_a_new_generation(self):
+        session = self.create_session(LensSessionLink.LifecycleStatus.PROVISIONING)
+        session.provision_generation = 2
+        session.provision_poll_sequence = 0
+        session.save(
+            update_fields=[
+                "provision_generation",
+                "provision_poll_sequence",
+                "updated_at",
+            ]
+        )
+
+        token, status = chat_lifecycle._claim_copilot_chat_provision(session.id)
+
+        self.assertIsNone(token)
+        self.assertEqual(status, "stale")
+        session.refresh_from_db()
+        self.assertIsNone(session.provision_claim_token)
+
+    def test_partially_fenced_message_is_stale(self):
+        session = self.create_session(LensSessionLink.LifecycleStatus.PROVISIONING)
+
+        token, status = chat_lifecycle._claim_copilot_chat_provision(
+            session.id,
+            expected_generation=1,
+        )
+
+        self.assertIsNone(token)
+        self.assertEqual(status, "stale")
+        session.refresh_from_db()
+        self.assertIsNone(session.provision_claim_token)
+
+    def test_valid_poll_advances_exactly_one_sequence(self):
+        session = self.create_session(LensSessionLink.LifecycleStatus.PROVISIONING)
+        session.provision_generation = 3
+        session.provision_poll_sequence = 2
+        session.save(
+            update_fields=[
+                "provision_generation",
+                "provision_poll_sequence",
+                "updated_at",
+            ]
+        )
+        token, status = chat_lifecycle._claim_copilot_chat_provision(
+            session.id,
+            expected_generation=3,
+            expected_poll_sequence=2,
+        )
+
+        self.assertEqual(status, "claimed")
+        next_poll = chat_lifecycle._defer_provision_poll(
+            session.id,
+            token,
+            retry_after_seconds=30,
+        )
+
+        self.assertEqual(next_poll["generation"], 3)
+        self.assertEqual(next_poll["sequence"], 3)
 
     @patch("apps.lens_bridge.services.chat_lifecycle._queue_provision_or_mark_failed")
     @patch(

--- a/src/backend/apps/lens_bridge/tests/test_chat_teardown.py
+++ b/src/backend/apps/lens_bridge/tests/test_chat_teardown.py
@@ -269,6 +269,71 @@ class CopilotChatTeardownTests(TestCase):
         self.assertIsNone(self.session.knowledge_source_id)
         self.assertIn("LensNode was unavailable", self.session.lifecycle_error)
 
+    @mock.patch("apps.lens_bridge.services.assistant_access.soft_delete_assistant_link")
+    @mock.patch("apps.lens_bridge.services.assistants._delete_sl_assistant")
+    @mock.patch("apps.lens_bridge.services.chat_lifecycle.sl_client.request_json")
+    def test_unconfirmed_conversion_stop_blocks_cleanup_without_deleting_workspace(
+        self,
+        request_json,
+        _delete_assistant,
+        _soft_delete_assistant,
+    ):
+        request_json.side_effect = self._not_found()
+        self.session.lifecycle_status = LensSessionLink.LifecycleStatus.FAILED
+        self.session.cleanup_intent = LensSessionLink.CleanupIntent.RESET_FOR_RETRY
+        self.session.cleanup_status = LensSessionLink.CleanupStatus.PENDING
+        self.session.status = LensSessionLink.Status.ACTIVE
+        self.session.teardown_state_json = {
+            "intent": "reset_for_retry",
+            "provision_error": "conversion failed",
+        }
+        self.session.save(
+            update_fields=[
+                "lifecycle_status",
+                "cleanup_intent",
+                "cleanup_status",
+                "status",
+                "teardown_state_json",
+                "updated_at",
+            ]
+        )
+
+        def block_knowledge_source_cleanup(**_kwargs):
+            LensKnowledgeSource.all_objects.filter(
+                pk=self.knowledge_source.id
+            ).update(
+                teardown_state_json={
+                    "cancel_conversion": {"status": "waiting"}
+                }
+            )
+            raise knowledge_source_teardown.KnowledgeSourceTeardownIncompleteError(
+                "Waiting for LensNode to stop document conversion."
+            )
+
+        with mock.patch(
+            "apps.lens_bridge.services.knowledge_source_teardown."
+            "run_knowledge_source_teardown",
+            side_effect=block_knowledge_source_cleanup,
+        ), self.assertRaises(chat_lifecycle.ChatTeardownIncompleteError):
+            chat_lifecycle.run_copilot_chat_teardown(
+                session_link_id=self.session.id
+            )
+
+        self.session.refresh_from_db()
+        self.workspace_binding.refresh_from_db()
+        self.assertEqual(
+            self.session.lifecycle_status,
+            LensSessionLink.LifecycleStatus.FAILED,
+        )
+        self.assertEqual(
+            self.session.cleanup_status,
+            LensSessionLink.CleanupStatus.BLOCKED,
+        )
+        self.assertEqual(
+            self.workspace_binding.state,
+            LensWorkspaceBinding.State.READY,
+        )
+
     @mock.patch(
         "apps.lens_bridge.services.chat_lifecycle."
         "_queue_teardown_or_record_error"
@@ -298,8 +363,91 @@ class CopilotChatTeardownTests(TestCase):
             self.session.teardown_state_json["intent"],
             "reset_for_retry",
         )
+        self.assertEqual(
+            self.session.lifecycle_status,
+            LensSessionLink.LifecycleStatus.FAILED,
+        )
+        self.assertEqual(
+            self.session.cleanup_intent,
+            LensSessionLink.CleanupIntent.RESET_FOR_RETRY,
+        )
+        self.assertEqual(
+            self.session.cleanup_status,
+            LensSessionLink.CleanupStatus.PENDING,
+        )
         self.assertEqual(self.session.status, LensSessionLink.Status.ACTIVE)
         queue_teardown.assert_called_once_with(self.session.id)
+
+    @mock.patch(
+        "apps.lens_bridge.services.chat_lifecycle."
+        "knowledge_source_sync.run_knowledge_source_sync",
+        return_value={"status": "waiting", "retry_after_seconds": 15},
+    )
+    @mock.patch(
+        "apps.lens_bridge.services.chat_lifecycle."
+        "knowledge_source_sync.prepare_new_knowledge_source",
+        side_effect=lambda *, org, ks: ks,
+    )
+    @mock.patch(
+        "apps.lens_bridge.services.chat_lifecycle."
+        "chat_user_provisioning.ensure_sl_chat_user"
+    )
+    @mock.patch("apps.lens_bridge.services.chat_lifecycle._reserve_chat_capacity")
+    @mock.patch(
+        "apps.lens_bridge.services.chat_lifecycle._resolve_chat_scopes",
+        return_value=None,
+    )
+    @mock.patch(
+        "apps.lens_bridge.services.gateway_execution.context_for_gateway_link"
+    )
+    def test_chat_knowledge_source_always_pins_selected_snapshot(
+        self,
+        _context,
+        _resolve_scopes,
+        _reserve_capacity,
+        _ensure_user,
+        _prepare_knowledge_source,
+        _run_sync,
+    ):
+        claim_token = uuid.uuid4()
+        self.session.knowledge_source = None
+        self.session.lifecycle_status = LensSessionLink.LifecycleStatus.PROVISIONING
+        self.session.provision_claim_token = claim_token
+        self.session.provision_claimed_at = timezone.now()
+        self.session.backup_source_snapshot_id = 11
+        self.session.source_scopes_json = [
+            {
+                "source_path": "/data",
+                "backup_snapshot_directory_id": 12,
+                "path_type": "dir",
+            }
+        ]
+        self.session.save(
+            update_fields=[
+                "knowledge_source",
+                "lifecycle_status",
+                "provision_claim_token",
+                "provision_claimed_at",
+                "backup_source_snapshot_id",
+                "source_scopes_json",
+                "updated_at",
+            ]
+        )
+
+        result = chat_lifecycle._run_copilot_chat_provision(
+            session_link_id=self.session.id,
+            claim_token=str(claim_token),
+        )
+
+        self.assertEqual(result["status"], "waiting")
+        self.session.refresh_from_db()
+        knowledge_source = self.session.knowledge_source
+        self.assertIsNotNone(knowledge_source)
+        self.assertEqual(
+            knowledge_source.linked_version_mode,
+            LensKnowledgeSource.LinkedVersionMode.PINNED,
+        )
+        self.assertEqual(knowledge_source.pinned_snapshot_id, 11)
 
     @mock.patch(
         "apps.lens_bridge.services.sync_queue.queue_knowledge_source_teardown"
@@ -523,7 +671,7 @@ class CopilotChatTeardownTests(TestCase):
         "apps.lens_bridge.services.chat_lifecycle._run_copilot_chat_provision",
         side_effect=RuntimeError("provision failed"),
     )
-    def test_failed_provision_with_incomplete_compensation_becomes_teardown(
+    def test_failed_provision_with_incomplete_compensation_starts_recovery(
         self,
         _run_provision,
         _cleanup,
@@ -557,13 +705,17 @@ class CopilotChatTeardownTests(TestCase):
         self.session.refresh_from_db()
         self.assertEqual(
             self.session.lifecycle_status,
-            LensSessionLink.LifecycleStatus.DELETING,
+            LensSessionLink.LifecycleStatus.FAILED,
         )
         self.assertEqual(
             self.session.provision_phase,
             LensSessionLink.ProvisionPhase.CLEANING_UP,
         )
         self.assertIsNone(self.session.provision_claim_token)
+        self.assertEqual(
+            self.session.cleanup_status,
+            LensSessionLink.CleanupStatus.PENDING,
+        )
         queue_teardown.assert_called_once_with(self.session.id)
 
     @mock.patch(
@@ -1126,7 +1278,11 @@ class CopilotChatTeardownTests(TestCase):
         result = reconcile_copilot_chat_provisions_task(limit=10)
 
         self.assertEqual(result["session_ids"], [self.session.id])
-        delay.assert_called_once_with(session_link_id=self.session.id)
+        delay.assert_called_once_with(
+            session_link_id=self.session.id,
+            expected_generation=self.session.provision_generation,
+            expected_poll_sequence=self.session.provision_poll_sequence,
+        )
 
     @mock.patch(
         "apps.lens_bridge.tasks.chat_lifecycle."

--- a/src/backend/apps/lens_bridge/tests/test_managed_datasource.py
+++ b/src/backend/apps/lens_bridge/tests/test_managed_datasource.py
@@ -198,6 +198,31 @@ class ManagedDatasourceTests(SimpleTestCase):
         )
 
     @patch("apps.lens_bridge.services.managed_datasource.sl_client.get_task_by_id")
+    def test_audited_manual_confirmation_unblocks_terminal_conversion(self, get_task):
+        knowledge_source = self._knowledge_source()
+        knowledge_source.sync_state_json = {
+            "conversion": {
+                "task_id": "convert-1",
+                "manual_stop_confirmation": {
+                    "confirmed": True,
+                    "task_id": "convert-1",
+                },
+            }
+        }
+        get_task.return_value = {
+            "task_id": "convert-1",
+            "status": "REVOKED",
+            "metadata": {
+                "datasource_conversion_request_id": "request-1",
+                "manual_revoked_at": "2026-08-18T01:00:00Z",
+            },
+        }
+
+        self.assertTrue(
+            managed_datasource.conversion_stop_confirmed(knowledge_source)
+        )
+
+    @patch("apps.lens_bridge.services.managed_datasource.sl_client.get_task_by_id")
     def test_missing_dispatched_task_does_not_prove_conversion_stopped(
         self,
         get_task,
@@ -248,6 +273,49 @@ class ManagedDatasourceTests(SimpleTestCase):
 
         start_conversion.assert_not_called()
         self.assertIn("lookup_missing_at", sync_state["conversion"])
+
+    @patch(
+        "apps.lens_bridge.services.managed_datasource."
+        "sl_client.start_managed_datasource_conversion"
+    )
+    @patch(
+        "apps.lens_bridge.services.managed_datasource.sl_client.get_task_by_id",
+        side_effect=sl_client.LensBridgeUnavailable(),
+    )
+    def test_temporary_poll_failure_is_pending_with_backoff(
+        self,
+        _get_task,
+        start_conversion,
+    ):
+        knowledge_source = self._knowledge_source()
+        knowledge_source.sl_datasource_uuid = self.datasource_uuid
+        policy = {"document": True}
+        sync_state = {
+            "conversion": {
+                "task_id": "convert-1",
+                "status": "STARTED",
+                "policy_fingerprint": (
+                    managed_datasource.conversion_policy_fingerprint(policy)
+                ),
+                "started_at": timezone.now().isoformat(),
+            }
+        }
+
+        with self.assertRaises(
+            managed_datasource.ManagedDatasourcePending
+        ) as raised:
+            managed_datasource.convert_documents(
+                ks=knowledge_source,
+                sync_state=sync_state,
+                conversion=policy,
+            )
+
+        self.assertGreaterEqual(raised.exception.retry_after_seconds, 15)
+        self.assertEqual(
+            sync_state["conversion"]["last_transient_operation"],
+            "poll_conversion",
+        )
+        start_conversion.assert_not_called()
 
     @patch("apps.lens_bridge.services.managed_datasource.sl_client.get_task_by_id")
     def test_failed_dispatched_conversion_waits_for_lensnode_callback(

--- a/src/backend/apps/lens_bridge/tests/test_resume_blocked_chat_cleanup_command.py
+++ b/src/backend/apps/lens_bridge/tests/test_resume_blocked_chat_cleanup_command.py
@@ -1,0 +1,63 @@
+from unittest.mock import patch
+
+from django.core.management.base import CommandError
+from django.test import SimpleTestCase
+
+from apps.lens_bridge.management.commands.resume_blocked_chat_cleanup import Command
+
+
+class ResumeBlockedChatCleanupCommandTests(SimpleTestCase):
+    def _options(self, **overrides):
+        options = {
+            "session_id": 42,
+            "source_lens_task_id": "convert-1",
+            "reason": "LensNode executor stop confirmed by the operator.",
+            "confirm_executor_stopped": True,
+        }
+        options.update(overrides)
+        return options
+
+    @patch(
+        "apps.lens_bridge.management.commands.resume_blocked_chat_cleanup."
+        "sl_client.get_task_by_id"
+    )
+    def test_requires_explicit_executor_stop_confirmation(self, get_task):
+        with self.assertRaisesRegex(CommandError, "confirm-executor-stopped"):
+            Command().handle(
+                **self._options(confirm_executor_stopped=False),
+            )
+
+        get_task.assert_not_called()
+
+    @patch(
+        "apps.lens_bridge.management.commands.resume_blocked_chat_cleanup."
+        "sl_client.get_task_by_id",
+        return_value=None,
+    )
+    def test_rejects_a_missing_source_lens_task(self, get_task):
+        with self.assertRaisesRegex(CommandError, "was not found"):
+            Command().handle(**self._options())
+
+        get_task.assert_called_once_with("convert-1")
+
+    @patch(
+        "apps.lens_bridge.management.commands.resume_blocked_chat_cleanup."
+        "sl_client.get_task_by_id",
+        return_value={"status": "REVOKED"},
+    )
+    def test_requires_source_lens_to_return_the_exact_task_identity(self, get_task):
+        with self.assertRaisesRegex(CommandError, "exact requested task identity"):
+            Command().handle(**self._options())
+
+        get_task.assert_called_once_with("convert-1")
+
+    @patch(
+        "apps.lens_bridge.management.commands.resume_blocked_chat_cleanup."
+        "sl_client.get_task_by_id",
+        return_value={"task_id": "convert-1", "status": "STARTED"},
+    )
+    def test_rejects_a_nonterminal_source_lens_task(self, get_task):
+        with self.assertRaisesRegex(CommandError, "not terminal"):
+            Command().handle(**self._options())
+
+        get_task.assert_called_once_with("convert-1")

--- a/src/backend/apps/lens_bridge/tests/test_sl_client_readiness.py
+++ b/src/backend/apps/lens_bridge/tests/test_sl_client_readiness.py
@@ -47,6 +47,12 @@ class SourceLensClientReadinessTests(SimpleTestCase):
 
         self.assertNotIn("must-not-leak", str(raised.exception))
 
+    def test_remote_rate_limit_is_retryable(self) -> None:
+        response = Mock(status_code=429, content=b"rate limited")
+
+        with self.assertRaises(sl_client.LensBridgeUnavailable):
+            sl_client._raise_for_response(response)
+
     @patch.object(sl_client, "_auth_headers", return_value={})
     @patch.object(sl_client, "_base_url", return_value="http://sourcelens")
     @patch.object(sl_client.requests, "get")

--- a/src/frontend/src/composables/useKnowledgeSourceForm.test.ts
+++ b/src/frontend/src/composables/useKnowledgeSourceForm.test.ts
@@ -8,6 +8,7 @@ import { useKnowledgeSourceForm } from './useKnowledgeSourceForm'
 
 const mocks = vi.hoisted(() => ({
   browseCopilotSnapshotDirectory: vi.fn(),
+  createKnowledgeSource: vi.fn(),
   warning: vi.fn(),
   error: vi.fn(),
   success: vi.fn(),
@@ -32,7 +33,7 @@ vi.mock('../lib/api', () => ({
 vi.mock('../lib/lensApi', () => ({
   browseCopilotSnapshotDirectory: mocks.browseCopilotSnapshotDirectory,
   browseGatewayDirectory: vi.fn(),
-  createKnowledgeSource: vi.fn(),
+  createKnowledgeSource: mocks.createKnowledgeSource,
   fetchKnowledgeSource: vi.fn(),
   listLensGateways: vi.fn().mockResolvedValue([]),
   patchKnowledgeSource: vi.fn(),
@@ -86,11 +87,11 @@ function snapshotFixture(): BackupSourceSnapshot {
   }
 }
 
-function mountForm(): { form: KnowledgeSourceForm; wrapper: VueWrapper } {
+function mountForm(editingId: number | null = 1): { form: KnowledgeSourceForm; wrapper: VueWrapper } {
   let form!: KnowledgeSourceForm
   const wrapper = mount(defineComponent({
     setup() {
-      form = useKnowledgeSourceForm(ref(1), ref('backup_source'))
+      form = useKnowledgeSourceForm(ref(editingId), ref('backup_source'))
       return () => h('div')
     },
   }))
@@ -111,6 +112,62 @@ describe('knowledge source backup scope validation', () => {
 
   afterEach(() => {
     vi.useRealTimers()
+  })
+
+  it('submits a selected snapshot as pinned', async () => {
+    const { form, wrapper } = mountForm(null)
+    try {
+      await flushPromises()
+      form.name.value = 'Pinned source'
+      form.gatewayId.value = 6
+      form.snapshotPickerValue.value = 71
+      form.pickBackupScopeForEntry(form.backupScopeEntries.value[0].id, {
+        id: '31:dir:/root/datatest',
+        label: 'datatest',
+        path: '/root/datatest',
+        type: 'dir',
+        directoryId: 31,
+        isLeaf: false,
+      })
+
+      await expect(form.submit()).resolves.toBe(true)
+
+      expect(mocks.createKnowledgeSource).toHaveBeenCalledWith(expect.objectContaining({
+        backup_source_snapshot_id: 71,
+        linked_version_mode: 'pinned',
+        pinned_snapshot_id: 71,
+      }))
+    } finally {
+      wrapper.unmount()
+    }
+  })
+
+  it('submits latest mode without a pinned snapshot', async () => {
+    const { form, wrapper } = mountForm(null)
+    try {
+      await flushPromises()
+      form.name.value = 'Latest source'
+      form.gatewayId.value = 6
+      form.snapshotPickerValue.value = 'latest'
+      form.pickBackupScopeForEntry(form.backupScopeEntries.value[0].id, {
+        id: '31:dir:/root/datatest',
+        label: 'datatest',
+        path: '/root/datatest',
+        type: 'dir',
+        directoryId: 31,
+        isLeaf: false,
+      })
+
+      await expect(form.submit()).resolves.toBe(true)
+
+      expect(mocks.createKnowledgeSource).toHaveBeenCalledWith(expect.objectContaining({
+        backup_source_snapshot_id: 71,
+        linked_version_mode: 'latest',
+        pinned_snapshot_id: null,
+      }))
+    } finally {
+      wrapper.unmount()
+    }
   })
 
   it('does not warn when blur is caused by opening the scope picker', async () => {

--- a/src/frontend/src/composables/useKnowledgeSourceForm.ts
+++ b/src/frontend/src/composables/useKnowledgeSourceForm.ts
@@ -859,7 +859,12 @@ export function useKnowledgeSourceForm(
             backup_snapshot_directory_id: sourceScopes[0].backup_snapshot_directory_id,
             source_path: sourceScopes[0].source_path,
             source_scopes: sourceScopes,
-            linked_version_mode: 'latest',
+            linked_version_mode: snapshotPickerValue.value === SNAPSHOT_PICKER_LATEST
+              ? 'latest'
+              : 'pinned',
+            pinned_snapshot_id: snapshotPickerValue.value === SNAPSHOT_PICKER_LATEST
+              ? null
+              : effectiveSnapshotId.value,
             scan_enabled: scanEnabled.value,
             ingest_policy: normalizeLensIngestPolicy(ingestPolicy.value),
           })

--- a/src/frontend/src/lib/lensApi.ts
+++ b/src/frontend/src/lib/lensApi.ts
@@ -328,6 +328,8 @@ export type LensSessionLink = {
   lifecycle_error?: string
   provision_phase?: string
   provision_detail?: string
+  cleanup_intent?: 'none' | 'reset_for_retry' | 'delete_session' | string
+  cleanup_status?: 'none' | 'pending' | 'running' | 'blocked' | 'complete' | string
   document_conversion?: DocumentConversion | null
   data_context?: SessionDataContext | null
   last_message_at: string | null

--- a/src/frontend/src/pages/insight/InsightCopilot.vue
+++ b/src/frontend/src/pages/insight/InsightCopilot.vue
@@ -80,8 +80,10 @@ const selectedStarterBySession = ref<Record<number, string>>({})
 const input = ref('')
 const composerAttachments = ref<CopilotComposerAttachment[]>([])
 const messageListRef = ref<{ scrollToBottom: () => void } | null>(null)
-const lifecyclePollingIds = new Set<number>()
+const lifecyclePollingEpochs = new Map<number, number>()
 let componentUnmounted = false
+let componentActive = false
+let lifecyclePollingEpoch = 0
 let composerLifecycleGeneration = 0
 
 let idSeq = 0
@@ -353,6 +355,18 @@ const copilotReadiness = computed((): CopilotReadiness => {
 
 const showActiveChat = computed(() => activeSession.value != null)
 
+function sessionCleanupInProgress(session: LensSessionLink | SessionRow) {
+  return session.lifecycle_status === 'failed'
+    && session.cleanup_intent === 'reset_for_retry'
+    && ['pending', 'running', 'blocked'].includes(session.cleanup_status || '')
+}
+
+function sessionNeedsLifecyclePolling(session: LensSessionLink | SessionRow) {
+  return session.lifecycle_status === 'provisioning'
+    || session.lifecycle_status === 'deleting'
+    || sessionCleanupInProgress(session)
+}
+
 async function markSessionViewed(sessionId: number) {
   copilotStore.markSessionViewed(sessionId)
   try {
@@ -415,7 +429,7 @@ async function bootstrap() {
     sessions.value = toSessionRows(sessionRows)
     refreshPollerSessions()
     for (const session of sessions.value) {
-      if (session.lifecycle_status === 'provisioning' || session.lifecycle_status === 'deleting') {
+      if (sessionNeedsLifecyclePolling(session)) {
         void pollSessionLifecycle(session.id)
       }
     }
@@ -432,7 +446,7 @@ async function bootstrap() {
       }
       activeSessionId.value = nextId
       const next = sessions.value.find((row) => row.id === nextId)
-      if (next?.lifecycle_status === 'provisioning') {
+      if (next && sessionNeedsLifecyclePolling(next)) {
         void pollSessionLifecycle(nextId)
       } else if (next?.lifecycle_status !== 'failed') {
         await copilotStore.syncSession(nextId, syncHandlers, nextId, { attachStream: true })
@@ -466,13 +480,32 @@ function openNewChatFlow() {
 }
 
 async function pollSessionLifecycle(sessionId: number) {
-  if (lifecyclePollingIds.has(sessionId)) return
-  lifecyclePollingIds.add(sessionId)
+  if (componentUnmounted || !componentActive) return
+  const pollingEpoch = lifecyclePollingEpoch
+  if (lifecyclePollingEpochs.get(sessionId) === pollingEpoch) return
+  lifecyclePollingEpochs.set(sessionId, pollingEpoch)
   try {
-    for (let i = 0; i < 120 && !componentUnmounted; i += 1) {
-      await new Promise((resolve) => setTimeout(resolve, 3000))
+    let pollDelayMilliseconds = 3000
+    let unchangedPolls = 0
+    let previousFingerprint = ''
+    while (
+      !componentUnmounted
+      && componentActive
+      && lifecyclePollingEpoch === pollingEpoch
+    ) {
+      await new Promise((resolve) => setTimeout(resolve, pollDelayMilliseconds))
+      if (
+        componentUnmounted
+        || !componentActive
+        || lifecyclePollingEpoch !== pollingEpoch
+      ) return
       try {
         const rows = await listCopilotSessions()
+        if (
+          componentUnmounted
+          || !componentActive
+          || lifecyclePollingEpoch !== pollingEpoch
+        ) return
         sessions.value = toSessionRows(rows)
         refreshPollerSessions()
         const current = sessions.value.find((row) => row.id === sessionId)
@@ -485,13 +518,32 @@ async function pollSessionLifecycle(sessionId: number) {
           }
           return
         }
-        if (current.lifecycle_status === 'failed' || current.lifecycle_status === 'deleted') return
+        if (current.lifecycle_status === 'deleted') return
+        if (current.lifecycle_status === 'failed' && !sessionCleanupInProgress(current)) return
+        const fingerprint = [
+          current.lifecycle_status,
+          current.provision_phase,
+          current.provision_detail,
+          current.cleanup_status,
+        ].join(':')
+        unchangedPolls = fingerprint === previousFingerprint ? unchangedPolls + 1 : 0
+        previousFingerprint = fingerprint
+        if (current.cleanup_status === 'blocked' || unchangedPolls >= 20) {
+          pollDelayMilliseconds = 15000
+        } else if (unchangedPolls >= 5) {
+          pollDelayMilliseconds = 10000
+        } else {
+          pollDelayMilliseconds = 3000
+        }
       } catch {
         if (componentUnmounted) return
+        pollDelayMilliseconds = Math.min(30000, Math.max(5000, pollDelayMilliseconds * 2))
       }
     }
   } finally {
-    lifecyclePollingIds.delete(sessionId)
+    if (lifecyclePollingEpochs.get(sessionId) === pollingEpoch) {
+      lifecyclePollingEpochs.delete(sessionId)
+    }
   }
 }
 
@@ -951,6 +1003,7 @@ async function stopStreaming() {
 
 onMounted(() => {
   componentUnmounted = false
+  componentActive = true
   void bootstrap()
 })
 
@@ -963,6 +1016,7 @@ watch(
 
 onActivated(() => {
   componentUnmounted = false
+  componentActive = true
   if (bridgeReady.value) {
     copilotStore.startBackgroundPoller(syncHandlers, () => activeSessionId.value)
     const id = activeSessionId.value
@@ -970,7 +1024,7 @@ onActivated(() => {
       void copilotStore.syncSession(id, syncHandlers, id, { attachStream: true })
     }
     for (const session of sessions.value) {
-      if (session.lifecycle_status === 'provisioning' || session.lifecycle_status === 'deleting') {
+      if (sessionNeedsLifecyclePolling(session)) {
         void pollSessionLifecycle(session.id)
       }
     }
@@ -978,12 +1032,16 @@ onActivated(() => {
 })
 
 onDeactivated(() => {
+  componentActive = false
+  lifecyclePollingEpoch += 1
   clearComposerAttachments({ deleteDocuments: true })
   copilotStore.detachSessionStream(activeSessionId.value ?? -1)
 })
 
 onUnmounted(() => {
   componentUnmounted = true
+  componentActive = false
+  lifecyclePollingEpoch += 1
   clearComposerAttachments({ deleteDocuments: true })
   copilotStore.teardown()
 })

--- a/src/frontend/src/pages/insight/InsightCopilotStarterSubmission.test.ts
+++ b/src/frontend/src/pages/insight/InsightCopilotStarterSubmission.test.ts
@@ -75,11 +75,14 @@ function deferred<T>() {
 
 const SimpleStub = defineComponent({ template: '<div />' })
 
-function sessionRow(activeRun: { uuid: string; status: string } | null = null) {
+function sessionRow(
+  activeRun: { uuid: string; status: string } | null = null,
+  lifecycleStatus = 'ready',
+) {
   return {
     id: 444,
     title: 'Chat',
-    lifecycle_status: 'ready',
+    lifecycle_status: lifecycleStatus,
     status: 'active',
     sl_session_uuid: 'session-1',
     sl_assistant_uuid: 'assistant-1',
@@ -149,6 +152,34 @@ describe('InsightCopilot starter question submission', () => {
 
   afterEach(() => {
     vi.useRealTimers()
+  })
+
+  it('keeps long lifecycle polling active and stops it after unmount', async () => {
+    vi.useFakeTimers()
+    mocks.listCopilotSessions.mockResolvedValue([
+      sessionRow(null, 'provisioning'),
+    ])
+    const i18n = createI18n({
+      legacy: false,
+      locale: 'en',
+      messages: { en },
+      missingWarn: false,
+      fallbackWarn: false,
+    })
+    const wrapper = mountCopilot(i18n)
+    await flushPromises()
+
+    await vi.advanceTimersByTimeAsync(2_400_000)
+    await flushPromises()
+
+    expect(mocks.listCopilotSessions.mock.calls.length).toBeGreaterThan(121)
+    wrapper.unmount()
+    const callsAfterUnmount = mocks.listCopilotSessions.mock.calls.length
+
+    await vi.advanceTimersByTimeAsync(60_000)
+    await flushPromises()
+
+    expect(mocks.listCopilotSessions).toHaveBeenCalledTimes(callsAfterUnmount)
   })
 
   it('submits the starter question without copying it into the composer', async () => {

--- a/src/frontend/src/pages/insight/copilot/CopilotContextBar.vue
+++ b/src/frontend/src/pages/insight/copilot/CopilotContextBar.vue
@@ -24,8 +24,20 @@ const { t } = useI18n()
 const router = useRouter()
 const detailsOpen = ref(false)
 const activeRunStatuses = new Set(['queued', 'running', 'streaming'])
+const isRecoveryCleanup = computed(() => (
+  props.session.lifecycle_status === 'failed'
+  && props.session.cleanup_intent === 'reset_for_retry'
+  && ['pending', 'running'].includes(props.session.cleanup_status || '')
+))
+const isCleanupBlocked = computed(() => (
+  props.session.lifecycle_status === 'failed'
+  && props.session.cleanup_intent === 'reset_for_retry'
+  && props.session.cleanup_status === 'blocked'
+))
 
 const statusLabel = computed(() => {
+  if (isRecoveryCleanup.value) return 'Recovering…'
+  if (isCleanupBlocked.value) return 'Recovery Blocked'
   if (props.session.lifecycle_status === 'failed') return 'Failed'
   if (props.session.lifecycle_status === 'provisioning') return 'Preparing…'
   if (props.session.lifecycle_status === 'deleting') return 'Deleting…'
@@ -34,8 +46,8 @@ const statusLabel = computed(() => {
 })
 
 const statusClass = computed(() => ({
-  'is-failed': props.session.lifecycle_status === 'failed',
-  'is-preparing': props.session.lifecycle_status === 'provisioning',
+  'is-failed': props.session.lifecycle_status === 'failed' && !isRecoveryCleanup.value,
+  'is-preparing': props.session.lifecycle_status === 'provisioning' || isRecoveryCleanup.value,
   'is-deleting': props.session.lifecycle_status === 'deleting',
   'is-answering': activeRunStatuses.has(props.session.active_run_status || ''),
 }))

--- a/src/frontend/src/pages/insight/copilot/CopilotLifecycleState.test.ts
+++ b/src/frontend/src/pages/insight/copilot/CopilotLifecycleState.test.ts
@@ -102,4 +102,28 @@ describe('CopilotLifecycleState', () => {
     expect(steps[0].classes()).toContain('is-active')
     expect(steps[1].classes()).toContain('is-pending')
   })
+
+  it('shows automatic compensation as recovery instead of chat deletion', () => {
+    const wrapper = mountState(session({
+      lifecycle_status: 'failed',
+      cleanup_intent: 'reset_for_retry',
+      cleanup_status: 'running',
+    }))
+
+    expect(wrapper.text()).toContain('Recovering Chat Resources')
+    expect(wrapper.text()).not.toContain('Deleting Chat')
+    expect(wrapper.text()).not.toContain('Try Again')
+  })
+
+  it('explains blocked cleanup without an endless deleting spinner', () => {
+    const wrapper = mountState(session({
+      lifecycle_status: 'failed',
+      cleanup_intent: 'reset_for_retry',
+      cleanup_status: 'blocked',
+    }))
+
+    expect(wrapper.text()).toContain('Chat Recovery Needs Attention')
+    expect(wrapper.text()).toContain('Temporary data is being retained')
+    expect(wrapper.text()).not.toContain('Deleting Chat')
+  })
 })

--- a/src/frontend/src/pages/insight/copilot/CopilotLifecycleState.vue
+++ b/src/frontend/src/pages/insight/copilot/CopilotLifecycleState.vue
@@ -76,6 +76,16 @@ const showFailedConversionPanel = computed(() => Boolean(
   conversion.value
   && (countsLabel.value || problemItems.value.length || conversion.value.error || conversionWarnings.value.length),
 ))
+const isRecoveryCleanup = computed(() => (
+  props.session.lifecycle_status === 'failed'
+  && props.session.cleanup_intent === 'reset_for_retry'
+  && ['pending', 'running'].includes(props.session.cleanup_status || '')
+))
+const isCleanupBlocked = computed(() => (
+  props.session.lifecycle_status === 'failed'
+  && props.session.cleanup_intent === 'reset_for_retry'
+  && props.session.cleanup_status === 'blocked'
+))
 
 function stepState(index: number) {
   if (index < currentStep.value) return 'done'
@@ -87,7 +97,38 @@ function stepState(index: number) {
 <template>
   <main class="copilot-lifecycle-state">
     <div
-      v-if="session.lifecycle_status === 'failed'"
+      v-if="isRecoveryCleanup"
+      class="copilot-lifecycle-card"
+    >
+      <span class="copilot-lifecycle-icon"><LoaderCircle
+        :size="30"
+        class="copilot-lifecycle-spin"
+      /></span>
+      <h2>Recovering Chat Resources</h2>
+      <p>Preparation stopped, and temporary resources are being cleaned up safely. You can retry when recovery finishes.</p>
+      <div class="copilot-lifecycle-actions">
+        <ElButton @click="emit('delete')">
+          Delete Chat
+        </ElButton>
+      </div>
+    </div>
+
+    <div
+      v-else-if="isCleanupBlocked"
+      class="copilot-lifecycle-card is-failed"
+    >
+      <span class="copilot-lifecycle-icon is-failed"><TriangleAlert :size="30" /></span>
+      <h2>Chat Recovery Needs Attention</h2>
+      <p>Cleanup is waiting for SourceLens to confirm that document conversion has stopped. Temporary data is being retained to prevent unsafe deletion.</p>
+      <div class="copilot-lifecycle-actions">
+        <ElButton @click="emit('delete')">
+          Delete Chat
+        </ElButton>
+      </div>
+    </div>
+
+    <div
+      v-else-if="session.lifecycle_status === 'failed'"
       class="copilot-lifecycle-card is-failed"
     >
       <span class="copilot-lifecycle-icon is-failed"><AlertCircle :size="30" /></span>

--- a/src/frontend/src/pages/insight/copilot/CopilotSessionSidebar.test.ts
+++ b/src/frontend/src/pages/insight/copilot/CopilotSessionSidebar.test.ts
@@ -12,7 +12,7 @@ const SlotStub = defineComponent({
   template: '<div><slot /><slot name="dropdown" /></div>',
 })
 
-function session(lifecycleStatus: string): SessionRow {
+function session(lifecycleStatus: string, overrides: Partial<SessionRow> = {}): SessionRow {
   return {
     id: 7,
     title: 'Quarterly review',
@@ -28,6 +28,7 @@ function session(lifecycleStatus: string): SessionRow {
     created_at: '2026-08-14T08:00:00Z',
     updated_at: '2026-08-14T08:00:00Z',
     group: 'today',
+    ...overrides,
   }
 }
 
@@ -66,5 +67,15 @@ describe('CopilotSessionSidebar pin actions', () => {
     const failed = mountSidebar(session('failed'))
     expect(failed.find('.copilot-session-menu__pin').exists()).toBe(false)
     failed.unmount()
+  })
+
+  it('shows recovery state and hides retry until cleanup completes', () => {
+    const recovering = mountSidebar(session('failed', {
+      cleanup_intent: 'reset_for_retry',
+      cleanup_status: 'running',
+    }))
+
+    expect(recovering.text()).toContain('Recovering Chat…')
+    expect(recovering.find('.copilot-session-menu__retry').exists()).toBe(false)
   })
 })

--- a/src/frontend/src/pages/insight/copilot/CopilotSessionSidebar.vue
+++ b/src/frontend/src/pages/insight/copilot/CopilotSessionSidebar.vue
@@ -49,6 +49,8 @@ function sessionTitle(row: SessionRow) {
 }
 
 function sessionMeta(row: SessionRow) {
+  if (sessionIsRecovering(row)) return 'Recovering Chat…'
+  if (sessionCleanupBlocked(row)) return 'Recovery Needs Attention'
   if (row.lifecycle_status === 'provisioning') return 'Preparing Chat…'
   if (row.lifecycle_status === 'failed') return 'Preparation Failed'
   if (row.lifecycle_status === 'deleting') return 'Deleting…'
@@ -63,6 +65,23 @@ function sessionMeta(row: SessionRow) {
   if (allFiles) scopeLabel = `${scopes.length} File${scopes.length === 1 ? '' : 's'}`
   if (allFolders) scopeLabel = `${scopes.length} Folder${scopes.length === 1 ? '' : 's'}`
   return `${source} · ${scopeLabel}`
+}
+
+function sessionIsRecovering(row: SessionRow) {
+  return row.lifecycle_status === 'failed'
+    && row.cleanup_intent === 'reset_for_retry'
+    && ['pending', 'running'].includes(row.cleanup_status || '')
+}
+
+function sessionCleanupBlocked(row: SessionRow) {
+  return row.lifecycle_status === 'failed'
+    && row.cleanup_intent === 'reset_for_retry'
+    && row.cleanup_status === 'blocked'
+}
+
+function sessionIsRetryable(row: SessionRow) {
+  return row.lifecycle_status === 'failed'
+    && !['pending', 'running', 'blocked'].includes(row.cleanup_status || '')
 }
 
 function sessionIsRunning(row: SessionRow) {
@@ -189,15 +208,20 @@ function handleAction(command: string, row: SessionRow) {
               aria-hidden="true"
             >
               <span
-                v-if="row.lifecycle_status === 'failed'"
+                v-if="sessionCleanupBlocked(row)"
+                class="copilot-session-item__state is-failed"
+                title="Recovery needs attention"
+              ><AlertCircle :size="14" /></span>
+              <span
+                v-else-if="row.lifecycle_status === 'provisioning' || sessionIsRecovering(row)"
+                class="copilot-session-item__state is-preparing"
+                :title="sessionIsRecovering(row) ? 'Recovering' : 'Preparing'"
+              ><i /><i /><i /></span>
+              <span
+                v-else-if="row.lifecycle_status === 'failed'"
                 class="copilot-session-item__state is-failed"
                 title="Preparation failed"
               ><AlertCircle :size="14" /></span>
-              <span
-                v-else-if="row.lifecycle_status === 'provisioning'"
-                class="copilot-session-item__state is-preparing"
-                title="Preparing"
-              ><i /><i /><i /></span>
               <span
                 v-else-if="sessionIsRunning(row)"
                 class="copilot-session-item__state is-running"
@@ -240,7 +264,7 @@ function handleAction(command: string, row: SessionRow) {
                       Rename Chat
                     </ElDropdownItem>
                     <ElDropdownItem
-                      v-if="row.lifecycle_status === 'failed'"
+                      v-if="sessionIsRetryable(row)"
                       class="copilot-session-menu__retry"
                       command="retry"
                       :icon="RotateCcw"


### PR DESCRIPTION
## Summary
- pin the resolved snapshot used by newly created Chat knowledge sources
- fence durable provisioning polls and retry transient SourceLens failures safely
- separate retry recovery from user deletion and retain workspaces until conversion stop is confirmed
- keep lifecycle polling active with adaptive backoff and expose recovery states in the UI

## Validation
- backend focused tests: 49 passed
- frontend focused tests: 31 passed
- full frontend suite: 1013 passed
- Ruff and ESLint passed
- Django system check and migration consistency check passed
- git diff --check passed