### PR TITLE
Unify detail drawer scrolling

### DIFF
--- a/src/frontend/src/components/ProxyBoundNasSourcesPanel.vue
+++ b/src/frontend/src/components/ProxyBoundNasSourcesPanel.vue
@@ -3,6 +3,7 @@ import { ref, watch } from 'vue'
 import { getSourceResource, listSourceResources, type SourceResource } from '../lib/sourceApi'
 import { listAllNodes } from '../lib/nodeApi'
 import { usePageRequestScope } from '../composables/usePageRequestScope'
+import { useDrawerTableMaxHeight } from '../composables/useDrawerTableMaxHeight'
 import type { ApiNode } from '../types/node'
 import NasSourceListTable from './NasSourceListTable.vue'
 import NasSourceDetailDrawer from '../pages/protection/components/NasSourceDetailDrawer.vue'
@@ -18,6 +19,7 @@ const proxyNodes = ref<ApiNode[]>([])
 const loading = ref(false)
 const detailOpen = ref(false)
 const detail = ref<SourceResource | null>(null)
+const { tableMaxHeight, containerRef: tableRef } = useDrawerTableMaxHeight()
 
 async function loadProxyNodes(signal?: AbortSignal) {
   try {
@@ -88,9 +90,11 @@ watch(
 <template>
   <div class="proxy-bound-nas-panel">
     <NasSourceListTable
+      ref="tableRef"
       :rows="rows"
       :proxy-nodes="proxyNodes"
       :loading="loading"
+      :max-height="tableMaxHeight"
       @row-click="openDetail"
     />
     <NasSourceDetailDrawer

--- a/src/frontend/src/components/ProxyStorageRepositoriesPanel.vue
+++ b/src/frontend/src/components/ProxyStorageRepositoriesPanel.vue
@@ -11,6 +11,7 @@ import {
   nodeSupportsStorageInventory,
 } from '../lib/nodeInventoryDisplay'
 import { usePageRequestScope } from '../composables/usePageRequestScope'
+import { useDrawerTableMaxHeight } from '../composables/useDrawerTableMaxHeight'
 import HflCapacityCell from './HflCapacityCell.vue'
 import RepositoryUsageCell from './RepositoryUsageCell.vue'
 import { remainingLimitExceedsAvailableStorage } from '../lib/repositoryCapacityDisplay'
@@ -35,6 +36,7 @@ const { t } = useI18n()
 const requests = usePageRequestScope()
 const bindings = ref<NodeBindings | null>(null)
 const loading = ref(false)
+const { tableMaxHeight, containerRef: tableRef } = useDrawerTableMaxHeight()
 
 const localStoragePools = computed(() => nodeStoragePoolRows(props.node, 'local_storage_pools'))
 const networkStoragePools = computed(() => nodeStoragePoolRows(props.node, 'network_storage_pools'))
@@ -195,9 +197,11 @@ watch(
 
       <ElTable
         v-if="localStoragePools.length"
+        ref="tableRef"
         :data="localStoragePools"
         size="small"
         class="proxy-storage-panel__table"
+        :max-height="tableMaxHeight"
       >
         <ElTableColumn
           :label="t('protection.sourceResources.storageDevice')"
@@ -265,9 +269,11 @@ watch(
 
       <ElTable
         v-if="networkStoragePools.length"
+        ref="tableRef"
         :data="networkStoragePools"
         size="small"
         class="proxy-storage-panel__table"
+        :max-height="tableMaxHeight"
       >
         <ElTableColumn
           :label="t('protection.sourceResources.storageShare')"
@@ -335,9 +341,11 @@ watch(
 
       <ElTable
         v-if="storagePools.length"
+        ref="tableRef"
         :data="storagePools"
         size="small"
         class="proxy-storage-panel__table"
+        :max-height="tableMaxHeight"
       >
         <ElTableColumn
           :label="t('protection.sourceResources.storageMountPoint')"
@@ -400,9 +408,11 @@ watch(
 
       <ElTable
         v-if="repositories.length"
+        ref="tableRef"
         :data="repositories"
         size="small"
         class="proxy-storage-panel__table"
+        :max-height="tableMaxHeight"
       >
         <ElTableColumn
           :label="t('repositoriesPage.colListName')"

--- a/src/frontend/src/composables/useDrawerTableMaxHeight.ts
+++ b/src/frontend/src/composables/useDrawerTableMaxHeight.ts
@@ -1,0 +1,96 @@
+import { nextTick, onMounted, onUnmounted, ref, watch, type ComponentPublicInstance } from 'vue'
+
+type MeasurableElement = HTMLElement | ComponentPublicInstance<{ $el: HTMLElement }>
+
+/**
+ * Computes a max-height value for a table inside a drawer tab so the
+ * table body scrolls internally without making the drawer pane scroll.
+ *
+ * Mirrors the HflTablePanel ResizeObserver pattern: measures the
+ * distance from the container's top to the bottom of the drawer body
+ * viewport (the `.el-drawer__body`), then subtracts the offset for
+ * section headings, padding, and scrollbar reserve.
+ *
+ * @param offset - Pixels to subtract for chrome above the table
+ *   (section heading, bottom padding, scrollbar reserve).
+ */
+export function useDrawerTableMaxHeight(offset = 16) {
+  const tableMaxHeight = ref(400)
+  const containerRef = ref<MeasurableElement | null>(null)
+
+  let resizeObserver: ResizeObserver | null = null
+  let observedElement: HTMLElement | null = null
+  let observedViewport: HTMLElement | null = null
+
+  function resolveElement(value: MeasurableElement | null) {
+    if (value instanceof HTMLElement) return value
+    return value?.$el instanceof HTMLElement ? value.$el : null
+  }
+
+  function update() {
+    const el = resolveElement(containerRef.value)
+    if (!el) return
+
+    const taskDrawer = el.closest<HTMLElement>('.hfl-task-drawer')
+    const viewport = taskDrawer?.querySelector<HTMLElement>(':scope > .el-drawer__body')
+      ?? el.closest<HTMLElement>('.el-tab-pane, .hfl-detail-drawer__body, .repo-detail-drawer__body, .hfl-task-drawer__body')
+    if (!viewport) return
+
+    const viewportRect = viewport.getBoundingClientRect()
+    const tableRect = el.getBoundingClientRect()
+    let trailingHeight = 0
+
+    for (let sibling = el.nextElementSibling; sibling; sibling = sibling.nextElementSibling) {
+      if (!(sibling instanceof HTMLElement)) continue
+      const style = window.getComputedStyle(sibling)
+      if (style.display === 'none' || style.position === 'absolute' || style.position === 'fixed') continue
+      const rect = sibling.getBoundingClientRect()
+      trailingHeight += rect.height + Number.parseFloat(style.marginTop || '0') + Number.parseFloat(style.marginBottom || '0')
+    }
+
+    const next = Math.max(160, Math.floor(viewportRect.bottom - tableRect.top - trailingHeight - offset))
+
+    if (tableMaxHeight.value !== next) {
+      tableMaxHeight.value = next
+    }
+  }
+
+  function observe(value: MeasurableElement | null) {
+    resizeObserver?.disconnect()
+    observedViewport?.removeEventListener('scroll', update)
+    observedElement = resolveElement(value)
+    const taskDrawer = observedElement?.closest<HTMLElement>('.hfl-task-drawer')
+    observedViewport = taskDrawer?.querySelector<HTMLElement>(':scope > .el-drawer__body')
+      ?? observedElement?.closest<HTMLElement>('.el-tab-pane, .hfl-detail-drawer__body, .repo-detail-drawer__body, .hfl-task-drawer__body')
+      ?? null
+    if (observedElement) resizeObserver?.observe(observedElement)
+    if (observedViewport) {
+      resizeObserver?.observe(observedViewport)
+      observedViewport.addEventListener('scroll', update, { passive: true })
+    }
+    for (const child of observedElement?.parentElement?.children ?? []) {
+      if (child instanceof HTMLElement) resizeObserver?.observe(child)
+    }
+    void nextTick(update)
+    requestAnimationFrame(update)
+  }
+
+  const stopWatching = watch(containerRef, observe, { flush: 'post' })
+
+  onMounted(() => {
+    resizeObserver = new ResizeObserver(() => update())
+    observe(containerRef.value)
+    window.addEventListener('resize', update)
+    window.visualViewport?.addEventListener('resize', update)
+  })
+
+  onUnmounted(() => {
+    stopWatching()
+    resizeObserver?.disconnect()
+    observedViewport?.removeEventListener('scroll', update)
+    window.removeEventListener('resize', update)
+    window.visualViewport?.removeEventListener('resize', update)
+  })
+
+  return { tableMaxHeight, containerRef }
+}

--- a/src/frontend/src/pages/node/Repositories.vue
+++ b/src/frontend/src/pages/node/Repositories.vue
@@ -30,6 +30,7 @@ import HflBooleanStatusTag from '../../components/HflBooleanStatusTag.vue'
 import { remainingLimitExceedsAvailableStorage, repositoryCapacityParts, repositoryStorageParts } from '../../lib/repositoryCapacityDisplay'
 import { lifecycleStatusTagAttrs } from '../../lib/statusTag'
 import { useResponsiveDrawerWidth } from '../../composables/useResponsiveDrawerWidth'
+import { useDrawerTableMaxHeight } from '../../composables/useDrawerTableMaxHeight'
 import { usePageRequestScope } from '../../composables/usePageRequestScope'
 import {
   createStorageRepository,
@@ -727,6 +728,8 @@ const form = ref({
 })
 
 const { t } = useI18n()
+const { tableMaxHeight: associatedSourcesTableMaxHeight, containerRef: associatedSourcesTableRef } = useDrawerTableMaxHeight()
+const { tableMaxHeight: repositoryTasksTableMaxHeight, containerRef: repositoryTasksTableRef } = useDrawerTableMaxHeight()
 const route = useRoute()
 const router = useRouter()
 const pageRequests = usePageRequestScope()
@@ -3702,10 +3705,12 @@ function s3ObjectPrefixCell(row: RepositoryRow) {
           >
             <div class="repo-associated-sources">
               <ElTable
+                ref="associatedSourcesTableRef"
                 v-loading="associatedSourcesLoading"
                 :data="associatedSources"
                 stripe
                 :empty-text="t('repositoriesPage.associatedSourcesEmpty')"
+                :max-height="associatedSourcesTableMaxHeight"
                 class="hfl-list-table repo-associated-sources__table"
               >
                 <ElTableColumn
@@ -4006,10 +4011,12 @@ function s3ObjectPrefixCell(row: RepositoryRow) {
                 class="repo-tasks__error"
               />
               <ElTable
+                ref="repositoryTasksTableRef"
                 v-loading="repositoryTasksLoading"
                 :data="repositoryTasks"
                 stripe
                 :empty-text="t('repositoriesPage.tasksEmpty')"
+                :max-height="repositoryTasksTableMaxHeight"
                 class="hfl-list-table repo-tasks__table"
                 @row-click="openRepositoryTaskDetail"
               >

--- a/src/frontend/src/pages/ops/NotificationChannels.vue
+++ b/src/frontend/src/pages/ops/NotificationChannels.vue
@@ -25,6 +25,7 @@ import HflTypeLabel from '../../components/HflTypeLabel.vue'
 import { useOpsMenus } from '../../composables/useOpsMenus'
 import { useDebouncedAction } from '../../composables/useDebouncedAction'
 import { useResponsiveDrawerWidth } from '../../composables/useResponsiveDrawerWidth'
+import { useDrawerTableMaxHeight } from '../../composables/useDrawerTableMaxHeight'
 import { usePageRequestScope } from '../../composables/usePageRequestScope'
 import { getNotificationTypeIcon } from '../../composables/useNotificationTypeIcon'
 import { formatLocalDateTime } from '../../lib/dateTime'
@@ -57,6 +58,8 @@ const { t, te } = useI18n()
 const opsMenus = useOpsMenus()
 const pageRequests = usePageRequestScope()
 const { drawerSize, bindDrawerResize } = useResponsiveDrawerWidth()
+const { tableMaxHeight: policyTableMaxHeight, containerRef: policyTableRef } = useDrawerTableMaxHeight()
+const { tableMaxHeight: deliveryTableMaxHeight, containerRef: deliveryTableRef } = useDrawerTableMaxHeight()
 const detailsLoading = ref(false)
 const detailsError = ref<string | null>(null)
 const channelInlineEditing = ref<ChannelInlineField | null>(null)
@@ -1684,8 +1687,10 @@ watch(
               name="policies"
             >
               <el-table
+                ref="policyTableRef"
                 v-table-column-resize="'ops.notificationChannels.associatedPolicies'"
                 :data="asList(details.associated_policies)"
+                :max-height="policyTableMaxHeight"
                 stripe
                 class="hfl-list-table"
               >
@@ -1733,8 +1738,10 @@ watch(
               name="deliveries"
             >
               <el-table
+                ref="deliveryTableRef"
                 v-table-column-resize="'ops.notificationChannels.notificationLogs'"
                 :data="asList(details.notification_logs)"
+                :max-height="deliveryTableMaxHeight"
                 stripe
                 class="hfl-list-table"
               >

--- a/src/frontend/src/pages/ops/Tasks.vue
+++ b/src/frontend/src/pages/ops/Tasks.vue
@@ -19,6 +19,7 @@ import { useOpsMenus } from '../../composables/useOpsMenus'
 import { useListSearch } from '../../composables/useListSearch'
 import { useResponsiveDrawerWidth } from '../../composables/useResponsiveDrawerWidth'
 import { useDrawerScrollReset } from '../../composables/useDrawerScrollReset'
+import { useDrawerTableMaxHeight } from '../../composables/useDrawerTableMaxHeight'
 import { usePageRequestScope } from '../../composables/usePageRequestScope'
 import { useRepositoryTaskCancellation } from '../../composables/useRepositoryTaskCancellation'
 import { apiErrorMessage, apiErrorMessageI18n } from '../../lib/api'
@@ -70,6 +71,7 @@ import type { TaskResourceRow } from '../../lib/taskApi'
 import { isRestoreTaskType } from '../../lib/taskType'
 
 const { t, te } = useI18n()
+const { tableMaxHeight: resourceTableMaxHeight, containerRef: resourceTableRef } = useDrawerTableMaxHeight()
 const stopConfirmDialog = useProtectionStopConfirmDialog()
 const stopConfirmOpen = stopConfirmDialog.open
 const stopConfirmKind = stopConfirmDialog.kind
@@ -2036,10 +2038,12 @@ watch(
                 </div>
 
                 <el-table
+                  ref="resourceTableRef"
                   v-table-column-resize="'ops.tasks.resources'"
                   v-table-overflow-title
                   v-loading="resourceLoading"
                   :data="selectedResourceRows"
+                  :max-height="resourceTableMaxHeight"
                   class="hfl-list-table hfl-list-table--compact hfl-task-drawer__resource-table"
                 >
                   <el-table-column
@@ -2331,8 +2335,7 @@ watch(
   display: flex;
   flex-direction: column;
   gap: 14px;
-  padding: 2px 24px 24px;
-  background: #fff;
+  background: var(--el-bg-color);
 }
 
 .hfl-task-drawer__loading {
@@ -3054,10 +3057,6 @@ watch(
 
   .hfl-task-drawer :deep(.el-drawer__body) {
     padding: 0;
-  }
-
-  .hfl-task-drawer__body {
-    padding: 2px 18px 18px;
   }
 
   .hfl-task-drawer__header-title {

--- a/src/frontend/src/pages/protection/BackupDetail.vue
+++ b/src/frontend/src/pages/protection/BackupDetail.vue
@@ -26,6 +26,7 @@ import { apiErrorMessage } from '../../lib/api'
 import { useProtectionSideNav } from '../../composables/useProtectionSideNav'
 import { useResponsiveDrawerWidth } from '../../composables/useResponsiveDrawerWidth'
 import { useDrawerScrollReset } from '../../composables/useDrawerScrollReset'
+import { useDrawerTableMaxHeight } from '../../composables/useDrawerTableMaxHeight'
 import { formatLocalDateTime } from '../../lib/dateTime'
 import {
   useProtectionDemoStore,
@@ -53,6 +54,7 @@ import { listBackupSelectableSources, type BackupSelectableSource } from '../../
 import { listTasks, type TaskRow } from '../../lib/taskApi'
 
 const { t, te, locale } = useI18n()
+const { tableMaxHeight: snapshotDrawerTableMaxHeight, containerRef: snapshotDrawerTableRef } = useDrawerTableMaxHeight()
 const route = useRoute()
 const store = useProtectionDemoStore()
 
@@ -1359,7 +1361,7 @@ function closeDeleteSnapshotDialog() {
     destroy-on-close
     :modal="true"
     :size="drawerSize"
-    class="snapshot-detail-drawer"
+    class="hfl-detail-drawer snapshot-detail-drawer"
     @opened="onSnapshotDrawerOpened"
     @closed="onSnapshotDrawerClosed"
   >
@@ -1368,7 +1370,7 @@ function closeDeleteSnapshotDialog() {
     </template>
     <div
       v-if="activeSnapshot"
-      class="snapshot-drawer-body"
+      class="hfl-detail-drawer__body snapshot-drawer-body"
     >
       <p class="text-sm text-slate-500 m-0 mb-3">
         {{
@@ -1384,9 +1386,11 @@ function closeDeleteSnapshotDialog() {
           {{ t('protection.backupDetail.panelDirList') }}
         </div>
         <el-table
+          ref="snapshotDrawerTableRef"
           v-table-column-resize="'protection.backupDetail.snapshotDrawer.dirs'"
           v-table-overflow-title
           :data="activeSnapshot.dirs"
+          :max-height="snapshotDrawerTableMaxHeight"
           stripe
           class="hfl-list-table"
         >
@@ -1461,7 +1465,7 @@ function closeDeleteSnapshotDialog() {
     destroy-on-close
     :modal="true"
     :size="drawerSize"
-    class="task-detail-drawer"
+    class="hfl-detail-drawer task-detail-drawer"
     @opened="onTaskDrawerOpened"
     @closed="onTaskDrawerClosed"
   >
@@ -1471,7 +1475,7 @@ function closeDeleteSnapshotDialog() {
     <div
       v-if="activeTask"
       ref="drawerScrollAnchorRef"
-      class="snapshot-drawer-body"
+      class="hfl-detail-drawer__body snapshot-drawer-body"
     >
       <el-descriptions
         :column="1"

--- a/src/frontend/src/pages/protection/DataProtection.vue
+++ b/src/frontend/src/pages/protection/DataProtection.vue
@@ -68,6 +68,7 @@ import { useNodeLifecycleOps } from '../../composables/useNodeLifecycleOps'
 import { flowSourceReadyStatus } from '../../lib/flowSourceDisplay'
 import { backupSourceLifecycleDisplay } from '../../lib/backupSourceLifecycleDisplay'
 import { useResponsiveDrawerWidth } from '../../composables/useResponsiveDrawerWidth'
+import { useDrawerTableMaxHeight } from '../../composables/useDrawerTableMaxHeight'
 import { usePageRequestScope } from '../../composables/usePageRequestScope'
 import { useRestoreTargetCatalog } from '../../composables/useRestoreTargetCatalog'
 import {
@@ -269,6 +270,8 @@ const fixedRestoreDirtyTracking = ref(false)
 let fixedRestoreLeaveApproved = false
 
 const { t, te, locale } = useI18n()
+const { tableMaxHeight: runningRestoreTableMaxHeight, containerRef: runningRestoreTableRef } = useDrawerTableMaxHeight()
+const { tableMaxHeight: restoreHistoryTableMaxHeight, containerRef: restoreHistoryTableRef } = useDrawerTableMaxHeight()
 const sourcePendingOps = useBackupWizardSourcePendingOps({ t })
 
 const lifecycleOps = useNodeLifecycleOps({
@@ -11343,7 +11346,7 @@ async function runRecovery(mode: 'plan' | 'manual' = 'manual') {
           direction="rtl"
           :size="drawerSize"
           destroy-on-close
-          class="dp-restore-task-drawer"
+          class="hfl-detail-drawer dp-restore-task-drawer"
           @closed="onRestoreTaskDrawerClosed"
         >
           <template #header>
@@ -11355,7 +11358,7 @@ async function runRecovery(mode: 'plan' | 'manual' = 'manual') {
             </div>
           </template>
 
-          <div class="space-y-4">
+          <div class="hfl-detail-drawer__body space-y-4">
             <section
               v-if="drawerRunningRestoreTasks.length > 0"
               class="restore-task-section"
@@ -11371,8 +11374,10 @@ async function runRecovery(mode: 'plan' | 'manual' = 'manual') {
                 </el-tag>
               </div>
               <el-table
+                ref="runningRestoreTableRef"
                 v-table-overflow-title
                 :data="drawerRunningRestoreTasks"
+                :max-height="runningRestoreTableMaxHeight"
                 stripe
                 class="hfl-list-table restore-task-drawer-table"
               >
@@ -11431,8 +11436,10 @@ async function runRecovery(mode: 'plan' | 'manual' = 'manual') {
                 </el-tag>
               </div>
               <el-table
+                ref="restoreHistoryTableRef"
                 v-table-overflow-title
                 :data="drawerPagedHistoryRestoreTasks"
+                :max-height="restoreHistoryTableMaxHeight"
                 stripe
                 class="hfl-list-table restore-task-drawer-table"
               >

--- a/src/frontend/src/pages/protection/Policies.vue
+++ b/src/frontend/src/pages/protection/Policies.vue
@@ -14,6 +14,7 @@ import HflBooleanStatusTag from '../../components/HflBooleanStatusTag.vue'
 import DangerConfirmDialog, { type DangerConfirmItem } from '../../components/DangerConfirmDialog.vue'
 import { useProtectionSideNav } from '../../composables/useProtectionSideNav'
 import { useResponsiveDrawerWidth } from '../../composables/useResponsiveDrawerWidth'
+import { useDrawerTableMaxHeight } from '../../composables/useDrawerTableMaxHeight'
 import { usePageRequestScope } from '../../composables/usePageRequestScope'
 import { useListSearch } from '../../composables/useListSearch'
 import { apiErrorMessage } from '../../lib/api'
@@ -81,6 +82,8 @@ type PolicyRetentionDetailLine = {
 }
 
 const { t, locale } = useI18n()
+const { tableMaxHeight: policyUsageTableMaxHeight, containerRef: policyUsageTableRef } = useDrawerTableMaxHeight()
+const { tableMaxHeight: filterUsageTableMaxHeight, containerRef: filterUsageTableRef } = useDrawerTableMaxHeight()
 const { drawerSize } = useResponsiveDrawerWidth()
 const pageRequests = usePageRequestScope()
 const route = useRoute()
@@ -1504,10 +1507,12 @@ function onMoreDisable() {
                 class="mb-3"
               />
               <el-table
+                ref="policyUsageTableRef"
                 v-table-column-resize="'protection.policies.backup.related'"
                 v-table-overflow-title
                 v-loading="relatedBackupConfigsLoading"
                 :data="pagedRelatedBackupConfigs"
+                :max-height="policyUsageTableMaxHeight"
                 stripe
                 row-key="id"
                 class="hfl-list-table policy-related-backup-table"
@@ -1669,10 +1674,12 @@ function onMoreDisable() {
                 class="mb-3"
               />
               <el-table
+                ref="filterUsageTableRef"
                 v-table-column-resize="'protection.policies.filters.related'"
                 v-table-overflow-title
                 v-loading="filterRelatedBackupConfigsLoading"
                 :data="pagedFilterRelatedBackupConfigs"
+                :max-height="filterUsageTableMaxHeight"
                 stripe
                 row-key="id"
                 class="hfl-list-table policy-related-backup-table"

--- a/src/frontend/src/pages/protection/components/BackupConfigDetailPanel.vue
+++ b/src/frontend/src/pages/protection/components/BackupConfigDetailPanel.vue
@@ -2,6 +2,7 @@
 import { computed, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useProtectionDemoStore } from '../../../composables/useProtectionDemoStore'
+import { useDrawerTableMaxHeight } from '../../../composables/useDrawerTableMaxHeight'
 import {
   getBackupConfig,
   type BackupConfigDetail,
@@ -16,6 +17,7 @@ const { t } = useI18n()
 const store = useProtectionDemoStore()
 const realConfig = ref<BackupConfigDetail | null>(null)
 const loading = ref(false)
+const { tableMaxHeight, containerRef: tableRef } = useDrawerTableMaxHeight()
 
 const backup = computed(() => store.getBackup(props.backupId))
 const policy = computed(() =>
@@ -102,8 +104,10 @@ watch(
         {{ t('protection.backupDetail.panelDirList') }}
       </div>
       <el-table
+        ref="tableRef"
         v-table-overflow-title
         :data="realConfig.directories"
+        :max-height="tableMaxHeight"
         stripe
         size="small"
         class="hfl-list-table"

--- a/src/frontend/src/pages/protection/components/BackupSourceHistorySection.vue
+++ b/src/frontend/src/pages/protection/components/BackupSourceHistorySection.vue
@@ -10,6 +10,7 @@ import type { DemoBackup, DemoFsNode, DemoSnapshotDir } from '../../../composabl
 import { useProtectionDemoStore } from '../../../composables/useProtectionDemoStore'
 import { useResponsiveDrawerWidth } from '../../../composables/useResponsiveDrawerWidth'
 import { useDrawerScrollReset } from '../../../composables/useDrawerScrollReset'
+import { useDrawerTableMaxHeight } from '../../../composables/useDrawerTableMaxHeight'
 import { formatLocalDateTime } from '../../../lib/dateTime'
 import {
   buildHistoryTasksForBackups,
@@ -26,6 +27,7 @@ const props = defineProps<{
 
 const { t } = useI18n()
 const store = useProtectionDemoStore()
+const { tableMaxHeight: drawerTableMaxHeight, containerRef: drawerTableRef } = useDrawerTableMaxHeight()
 
 const TABLE_HEADER_STYLE: Record<string, string> = {
   background: 'rgba(248, 250, 252, 0.96)',
@@ -411,7 +413,7 @@ onBeforeUnmount(() => {
       :modal="true"
       :z-index="3200"
       :size="drawerSize"
-      class="snapshot-detail-drawer"
+      class="hfl-detail-drawer snapshot-detail-drawer"
       @opened="onSnapshotDrawerOpened"
       @closed="onSnapshotDrawerClosed"
     >
@@ -428,7 +430,7 @@ onBeforeUnmount(() => {
       </template>
       <div
         v-if="activeSnapshot"
-        class="snapshot-drawer-body"
+        class="hfl-detail-drawer__body snapshot-drawer-body"
       >
         <p class="text-sm text-slate-500 m-0 mb-3">
           {{
@@ -444,12 +446,13 @@ onBeforeUnmount(() => {
             {{ t('protection.backupDetail.panelDirList') }}
           </div>
           <el-table
+            ref="drawerTableRef"
             v-table-column-resize="'protection.backupSourceHistory.dirs'"
             v-table-overflow-title
             :data="activeSnapshot.dirs"
             stripe
             :row-key="snapshotDirRowKey"
-            max-height="calc(var(--app-viewport-height) - 250px)"
+            :max-height="drawerTableMaxHeight"
             :header-cell-style="TABLE_HEADER_STYLE"
             class="hfl-list-table"
           >
@@ -529,7 +532,7 @@ onBeforeUnmount(() => {
       :modal="true"
       :z-index="3200"
       :size="drawerSize"
-      class="task-detail-drawer"
+      class="hfl-detail-drawer task-detail-drawer"
       @opened="onTaskDrawerOpened"
       @closed="onTaskDrawerClosed"
     >
@@ -547,7 +550,7 @@ onBeforeUnmount(() => {
       <div
         v-if="activeTask"
         ref="drawerScrollAnchorRef"
-        class="snapshot-drawer-body"
+        class="hfl-detail-drawer__body snapshot-drawer-body"
       >
         <el-descriptions
           :column="1"

--- a/src/frontend/src/pages/protection/components/FlowBackupConfigDetailDrawer.vue
+++ b/src/frontend/src/pages/protection/components/FlowBackupConfigDetailDrawer.vue
@@ -36,7 +36,7 @@ const backupTitle = computed(() => {
     destroy-on-close
     append-to-body
     :z-index="3100"
-    class="dp-flow-backup-config-detail-drawer"
+    class="hfl-detail-drawer dp-flow-backup-config-detail-drawer"
     :show-close="true"
   >
     <template
@@ -45,10 +45,12 @@ const backupTitle = computed(() => {
     >
       <span class="truncate text-base font-semibold text-slate-900">{{ backupTitle }}</span>
     </template>
-    <BackupConfigDetailPanel
-      v-if="backupId && drawerOpen"
-      :backup-id="backupId"
-    />
+    <div class="hfl-detail-drawer__body">
+      <BackupConfigDetailPanel
+        v-if="backupId && drawerOpen"
+        :backup-id="backupId"
+      />
+    </div>
   </el-drawer>
 </template>
 

--- a/src/frontend/src/pages/protection/components/FlowBackupSourceDetailDrawer.vue
+++ b/src/frontend/src/pages/protection/components/FlowBackupSourceDetailDrawer.vue
@@ -32,9 +32,10 @@ import {
 } from 'lucide-vue-next'
 import { ElMessage } from 'element-plus'
 import { pushToast } from '../../../lib/toast/store'
-import type { ElTable, ElTree } from 'element-plus'
+import type { ElTree } from 'element-plus'
 import HflPopover from '../../../components/HflPopover.vue'
 import HflPagination from '../../../components/HflPagination.vue'
+import { useDrawerTableMaxHeight } from '../../../composables/useDrawerTableMaxHeight'
 import { apiErrorMessage } from '../../../lib/api'
 import { copyTextToClipboard } from '../../../lib/clipboard'
 import { getNode } from '../../../lib/nodeApi'
@@ -253,7 +254,10 @@ const activeTab = ref<FlowSourceDetailTab>('overview')
 const activeTaskSubTab = ref<FlowSourceDetailTaskSubTab>('history')
 const dirsSectionRef = ref<HTMLElement | null>(null)
 const targetsSectionRef = ref<HTMLElement | null>(null)
-const snapshotTableRef = ref<InstanceType<typeof ElTable> | null>(null)
+const { tableMaxHeight: snapshotTableMaxHeight, containerRef: snapshotTableRef } = useDrawerTableMaxHeight()
+const { tableMaxHeight: restoreTableMaxHeight, containerRef: restoreTableRef } = useDrawerTableMaxHeight()
+const { tableMaxHeight: sourceTasksTableMaxHeight, containerRef: sourceTasksTableRef } = useDrawerTableMaxHeight()
+const { tableMaxHeight: taskResourceTableMaxHeight, containerRef: taskResourceTableRef } = useDrawerTableMaxHeight()
 const selectedSnapshotId = ref<number | null>(null)
 const expandedSnapshotRowKeys = ref<number[]>([])
 const snapshotDetailLoading = ref(false)
@@ -3130,7 +3134,7 @@ function onClosed() {
             :data="pagedSourceSnapshots"
             stripe
             row-key="id"
-            max-height="calc(var(--app-viewport-height) - 260px)"
+            :max-height="snapshotTableMaxHeight"
             :expand-row-keys="expandedSnapshotRowKeys"
             :header-cell-style="TABLE_HEADER_STYLE"
             class="hfl-list-table"
@@ -3164,6 +3168,7 @@ function onClosed() {
                     v-table-column-resize="'protection.flowBackupSource.snapshotDirectories'"
                     v-table-overflow-title
                     :data="selectedSnapshotDirectories"
+                    :max-height="snapshotTableMaxHeight"
                     :fit="false"
                     stripe
                     :header-cell-style="TABLE_HEADER_STYLE"
@@ -3679,13 +3684,14 @@ function onClosed() {
           />
           <el-table
             v-if="displayedRestoreRecords.length || restoreRecordsLoading"
+            ref="restoreTableRef"
             v-table-column-resize="'protection.flowBackupSource.restoreRecords'"
             v-table-overflow-title
             v-loading="restoreRecordsLoading"
             :data="displayedRestoreRecords"
             :fit="false"
             row-key="id"
-            max-height="calc(var(--app-viewport-height) - 260px)"
+            :max-height="restoreTableMaxHeight"
             :expand-row-keys="expandedRestoreRecordRowKeys"
             :header-cell-style="TABLE_HEADER_STYLE"
             stripe
@@ -4222,11 +4228,13 @@ function onClosed() {
             </div>
           </div>
           <el-table
+            ref="sourceTasksTableRef"
             v-table-column-resize="'protection.flowBackupSource.sourceTasks'"
             v-table-overflow-title
             v-loading="sourceTasksLoading"
             :data="sourceTaskRows"
             stripe
+            :max-height="sourceTasksTableMaxHeight"
             class="restore-task-drawer-table dp-source-task-table hfl-list-table"
             :row-class-name="sourceTaskRowClassName"
           >
@@ -4370,7 +4378,7 @@ function onClosed() {
 
   <ElDrawer
     v-model="taskDetailOpen"
-    class="dp-task-detail-drawer"
+    class="hfl-task-drawer dp-task-detail-drawer"
     :size="taskDetailDrawerSize"
     :z-index="3200"
     @opened="resetDrawerScroll"
@@ -4445,7 +4453,7 @@ function onClosed() {
       v-if="activeTask"
       ref="drawerScrollAnchorRef"
       v-loading="activeTaskLoading"
-      class="dp-task-detail__body"
+      class="hfl-task-drawer__body dp-task-detail__body"
     >
       <section class="dp-task-detail__hero">
         <div class="dp-task-detail__hero-section-title">
@@ -4933,10 +4941,12 @@ function onClosed() {
               </div>
 
               <el-table
+                ref="taskResourceTableRef"
                 v-table-column-resize="'protection.flowBackupSource.resources'"
                 v-table-overflow-title
                 v-loading="resourceLoading"
                 :data="selectedResourceRows"
+                :max-height="taskResourceTableMaxHeight"
                 class="hfl-list-table hfl-list-table--compact dp-task-detail__resource-table"
               >
                 <el-table-column
@@ -6103,7 +6113,7 @@ function onClosed() {
 }
 
 .dp-flow-source-detail-tabs :deep(.el-tabs__content) {
-  overflow: visible;
+  overflow: hidden;
 }
 
 .dp-flow-source-detail-drawer__body .hfl-list-footer {
@@ -6399,7 +6409,7 @@ function onClosed() {
   flex-direction: column;
   gap: 14px;
   padding: 0;
-  background: #fff;
+  background: var(--el-bg-color);
 }
 
 .dp-task-detail__hero {

--- a/src/frontend/src/pages/protection/components/TaskDetailDrawer.vue
+++ b/src/frontend/src/pages/protection/components/TaskDetailDrawer.vue
@@ -30,6 +30,7 @@ import {
 } from '../../../lib/protectionStopConfirm'
 import { useProtectionStopConfirmDialog } from '../../../composables/useProtectionStopConfirmDialog'
 import { useDrawerScrollReset } from '../../../composables/useDrawerScrollReset'
+import { useDrawerTableMaxHeight } from '../../../composables/useDrawerTableMaxHeight'
 import { useRepositoryTaskCancellation } from '../../../composables/useRepositoryTaskCancellation'
 import ProtectionStopConfirmDialog from '../../../components/ProtectionStopConfirmDialog.vue'
 import { getSourceResource } from '../../../lib/sourceApi'
@@ -71,6 +72,7 @@ const emit = defineEmits<{
 }>()
 
 const { t, te } = useI18n()
+const { tableMaxHeight: resourceTableMaxHeight, containerRef: resourceTableRef } = useDrawerTableMaxHeight()
 const stopConfirmDialog = useProtectionStopConfirmDialog()
 const stopConfirmOpen = stopConfirmDialog.open
 const stopConfirmKind = stopConfirmDialog.kind
@@ -1147,10 +1149,12 @@ watch(
               </div>
               <el-table
                 v-if="targetRepositoryResources.length"
+                ref="resourceTableRef"
                 v-table-column-resize="'repositories.taskDetail.resources'"
                 v-table-overflow-title
                 v-loading="repositoryResourceLoading"
                 :data="repositoryResourceRows"
+                :max-height="resourceTableMaxHeight"
                 class="hfl-list-table hfl-list-table--compact hfl-task-drawer__resource-table"
               >
                 <el-table-column
@@ -1239,10 +1243,12 @@ watch(
               </div>
               <el-table
                 v-if="resourceTypeTabs.length && selectedResourceType === 'backup_source'"
+                ref="resourceTableRef"
                 v-table-column-resize="'protection.taskDetail.resources'"
                 v-table-overflow-title
                 v-loading="backupSourceLoading"
                 :data="backupSourceRows"
+                :max-height="resourceTableMaxHeight"
                 class="hfl-list-table hfl-list-table--compact hfl-task-drawer__resource-table"
               >
                 <el-table-column
@@ -1304,9 +1310,11 @@ watch(
               </el-table>
               <el-table
                 v-else
+                ref="resourceTableRef"
                 v-table-column-resize="'protection.taskDetail.resources'"
                 v-table-overflow-title
                 :data="selectedResources"
+                :max-height="resourceTableMaxHeight"
                 class="hfl-list-table hfl-list-table--compact hfl-task-drawer__resource-table"
               >
                 <el-table-column
@@ -1529,7 +1537,7 @@ watch(
   padding: 14px;
   border: 1px solid rgb(226 232 240);
   border-radius: 10px;
-  background: #fff;
+  background: var(--el-bg-color);
 }
 
 .hfl-task-drawer__hero,

--- a/src/frontend/src/styles/detail-page-ui.css
+++ b/src/frontend/src/styles/detail-page-ui.css
@@ -864,8 +864,11 @@
   }
 }
 
-.hfl-detail-drawer.el-drawer.rtl .el-drawer__body,
-.repo-detail-drawer.el-drawer.rtl .el-drawer__body {
+.hfl-detail-drawer.el-drawer > .el-drawer__body,
+.repo-detail-drawer.el-drawer > .el-drawer__body,
+.hfl-task-drawer.el-drawer > .el-drawer__body {
+  overflow: hidden;
+  background: var(--el-bg-color);
   padding-top: 0;
 }
 
@@ -877,10 +880,19 @@
 }
 
 .hfl-detail-drawer__body,
-.repo-detail-drawer__body {
+.repo-detail-drawer__body,
+.hfl-task-drawer__body {
   display: flex;
+  height: 100%;
+  min-height: 0;
   flex-direction: column;
-  min-height: 100%;
+  overflow: hidden;
+}
+
+.hfl-detail-drawer__body:not(:has(.hfl-detail-tabs)),
+.repo-detail-drawer__body:not(:has(.repo-drawer-tabs)),
+.hfl-task-drawer__body:not(:has(.hfl-detail-tabs)) {
+  overflow-y: auto;
 }
 
 .hfl-detail-row__value--break {
@@ -888,9 +900,84 @@
   white-space: pre-wrap;
 }
 
+.hfl-detail-tabs.el-tabs,
+.repo-drawer-tabs.el-tabs {
+  display: flex;
+  min-height: 0;
+  flex: 1 1 auto;
+  flex-direction: column;
+}
+
 .hfl-detail-tabs.el-tabs > .el-tabs__header,
 .repo-drawer-tabs.el-tabs > .el-tabs__header {
+  flex: 0 0 auto;
   margin-bottom: 12px;
+}
+
+.hfl-detail-tabs.el-tabs > .el-tabs__content,
+.repo-drawer-tabs.el-tabs > .el-tabs__content {
+  min-height: 0;
+  flex: 1 1 auto;
+  overflow: hidden;
+}
+
+.hfl-detail-tabs.el-tabs > .el-tabs__content > .el-tab-pane,
+.repo-drawer-tabs.el-tabs > .el-tabs__content > .el-tab-pane {
+  height: 100%;
+  overflow: hidden auto;
+}
+
+/* Task drawers reveal the summary first, then pin tabs as the summary scrolls away. */
+.hfl-task-drawer.el-drawer > .el-drawer__body {
+  overflow: hidden auto;
+  padding-top: 0 !important;
+}
+
+.hfl-task-drawer .hfl-task-drawer__body {
+  height: auto;
+  min-height: 100%;
+  padding-top: var(--el-drawer-padding-primary) !important;
+  overflow: visible;
+}
+
+.hfl-task-drawer .hfl-task-drawer__body:not(:has(.hfl-detail-tabs)) {
+  overflow: visible;
+}
+
+.hfl-task-drawer .hfl-detail-tabs.el-tabs {
+  display: block;
+  min-height: auto;
+  flex: none;
+  overflow: visible;
+  isolation: isolate;
+}
+
+.hfl-task-drawer .hfl-detail-tabs.el-tabs > .el-tabs__header {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  margin-bottom: 0;
+  padding-bottom: 12px;
+  background: var(--el-bg-color) !important;
+  box-shadow: 0 1px 0 var(--el-border-color-lighter);
+  transform: translateZ(0);
+}
+
+.hfl-task-drawer .hfl-detail-tabs.el-tabs > .el-tabs__header .el-tabs__nav-wrap {
+  background: var(--el-bg-color);
+}
+
+.hfl-task-drawer .hfl-detail-tabs.el-tabs > .el-tabs__content {
+  position: relative;
+  z-index: 0;
+  min-height: auto;
+  overflow: visible;
+  isolation: isolate;
+}
+
+.hfl-task-drawer .hfl-detail-tabs.el-tabs > .el-tabs__content > .el-tab-pane {
+  height: auto;
+  overflow: visible;
 }
 
 .hfl-detail-tabs.el-tabs .el-tabs__item,

--- a/src/frontend/src/styles/detailDrawerScrolling.test.ts
+++ b/src/frontend/src/styles/detailDrawerScrolling.test.ts
@@ -1,0 +1,93 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+function source(path: string) {
+  return readFileSync(resolve(process.cwd(), path), 'utf8')
+}
+
+const styles = source('src/styles/detail-page-ui.css')
+const drawerHeight = source('src/composables/useDrawerTableMaxHeight.ts')
+
+describe('detail drawer scrolling', () => {
+  it('keeps drawer chrome fixed and scrolls only the active tab pane', () => {
+    expect(styles).toContain('.hfl-detail-drawer.el-drawer > .el-drawer__body')
+    expect(styles).toContain('.hfl-task-drawer.el-drawer > .el-drawer__body')
+    expect(styles).toContain('background: var(--el-bg-color)')
+    expect(styles).toContain('.hfl-detail-tabs.el-tabs > .el-tabs__content')
+    expect(styles).toContain('.hfl-detail-tabs.el-tabs > .el-tabs__content > .el-tab-pane')
+    expect(styles).toContain('overflow: hidden auto')
+
+    const tabHeaderRule = styles.match(
+      /\.hfl-detail-tabs\.el-tabs > \.el-tabs__header,[\s\S]*?\n}/,
+    )?.[0]
+    expect(tabHeaderRule).toContain('flex: 0 0 auto')
+    expect(tabHeaderRule).not.toContain('position: sticky')
+  })
+
+  it('lets task summaries scroll away before pinning the tab header', () => {
+    expect(styles).toContain('.hfl-task-drawer.el-drawer > .el-drawer__body')
+    expect(styles).toContain('.hfl-task-drawer .hfl-task-drawer__body')
+    expect(styles).toContain('padding-top: 0 !important')
+    expect(styles).toContain('padding-top: var(--el-drawer-padding-primary) !important')
+    expect(styles).toContain('.hfl-task-drawer .hfl-detail-tabs.el-tabs > .el-tabs__header')
+    expect(styles).toContain('position: sticky')
+    expect(styles).toContain('padding-bottom: 12px')
+    expect(styles).toContain('isolation: isolate')
+    expect(styles).toContain('z-index: 100')
+    expect(styles).toContain('.hfl-task-drawer .hfl-detail-tabs.el-tabs > .el-tabs__content')
+    expect(styles).toContain('.hfl-task-drawer .hfl-detail-tabs.el-tabs > .el-tabs__content > .el-tab-pane')
+  })
+
+  it('measures table height from the actual drawer content viewport', () => {
+    expect(drawerHeight).toContain("'.el-tab-pane, .hfl-detail-drawer__body, .repo-detail-drawer__body, .hfl-task-drawer__body'")
+    expect(drawerHeight).toContain("taskDrawer?.querySelector<HTMLElement>(':scope > .el-drawer__body')")
+    expect(drawerHeight).toContain('viewportRect.bottom - tableRect.top - trailingHeight - offset')
+    expect(drawerHeight).toContain('el.nextElementSibling')
+    expect(drawerHeight).toContain('watch(containerRef, observe')
+    expect(drawerHeight).toContain('ResizeObserver')
+    expect(drawerHeight).toContain("observedViewport.addEventListener('scroll', update")
+  })
+
+  it('does not use viewport offset constants for tables inside detail drawers', () => {
+    const drawerTableSources = [
+      'src/components/ProxyBoundNasSourcesPanel.vue',
+      'src/components/ProxyStorageRepositoriesPanel.vue',
+      'src/pages/node/Repositories.vue',
+      'src/pages/ops/NotificationChannels.vue',
+      'src/pages/ops/Tasks.vue',
+      'src/pages/protection/DataProtection.vue',
+      'src/pages/protection/Policies.vue',
+      'src/pages/protection/BackupDetail.vue',
+      'src/pages/protection/components/BackupConfigDetailPanel.vue',
+      'src/pages/protection/components/FlowBackupSourceDetailDrawer.vue',
+      'src/pages/protection/components/TaskDetailDrawer.vue',
+    ]
+
+    for (const path of drawerTableSources) {
+      const contents = source(path)
+      expect(contents).not.toMatch(/max-height=["{:`]+calc\(var\(--app-viewport-height\) - (?:170|220|250|260|265|320)px\)/)
+    }
+  })
+
+  it('covers every table discovered in detail drawer templates and child panels', () => {
+    const expectedBindings = new Map([
+      ['src/pages/ops/NotificationChannels.vue', ['policyTableMaxHeight', 'deliveryTableMaxHeight']],
+      ['src/pages/protection/DataProtection.vue', ['runningRestoreTableMaxHeight', 'restoreHistoryTableMaxHeight']],
+      ['src/pages/protection/components/BackupConfigDetailPanel.vue', ['tableMaxHeight']],
+      ['src/pages/protection/components/FlowBackupSourceDetailDrawer.vue', [
+        'snapshotTableMaxHeight',
+        'restoreTableMaxHeight',
+        'sourceTasksTableMaxHeight',
+        'taskResourceTableMaxHeight',
+      ]],
+    ])
+
+    for (const [path, bindings] of expectedBindings) {
+      const contents = source(path)
+      for (const binding of bindings) {
+        expect(contents).toContain(`:max-height="${binding}"`)
+      }
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- keep detail drawer headers, tabs, and footers visible while content scrolls internally
- size embedded tables from measured drawer space instead of fixed viewport offsets
- pin task tabs after summary content scrolls away and standardize drawer behavior across modules
- add regression coverage for drawer layout and adaptive table sizing

## Testing
- `cd src/frontend && npm run build`
- `cd src/frontend && npm run lint`
- `cd src/frontend && npm test -- --run`

Closes #592