### PR TITLE
fix(protection): support second-precision policy starts

### DIFF
--- a/src/backend/apps/protection/migrations/0019_normalize_policy_start_seconds.py
+++ b/src/backend/apps/protection/migrations/0019_normalize_policy_start_seconds.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from django.db import migrations
+
+
+MINUTE_START_FORMAT = "%Y-%m-%dT%H:%M"
+
+
+def is_valid_minute_start(value):
+    try:
+        return datetime.strptime(value, MINUTE_START_FORMAT).strftime(MINUTE_START_FORMAT) == value
+    except (TypeError, ValueError):
+        return False
+
+
+def normalize_policy_start_seconds(apps, schema_editor):
+    BackupPolicy = apps.get_model("protection", "BackupPolicy")
+    for policy in BackupPolicy.objects.iterator():
+        schedule = policy.schedule
+        if not isinstance(schedule, dict) or not schedule.get("mode"):
+            continue
+        starts_at = schedule.get("starts_at")
+        if not isinstance(starts_at, str) or not is_valid_minute_start(starts_at):
+            continue
+        policy.schedule = {**schedule, "starts_at": f"{starts_at}:00"}
+        policy.save(update_fields=["schedule"])
+
+
+class Migration(migrations.Migration):
+    dependencies = [("protection", "0018_backup_directory_repository_locator")]
+
+    operations = [
+        migrations.RunPython(normalize_policy_start_seconds, migrations.RunPython.noop),
+    ]

--- a/src/backend/apps/protection/services/interface.py
+++ b/src/backend/apps/protection/services/interface.py
@@ -14,7 +14,8 @@ from apps.protection.models import BackupConfig, BackupPolicy, FileFilterRule
 CRON_FIELD_RE = re.compile(r"^(\*|\d+(-\d+)?)(/\d+)?(,(\*|\d+(-\d+)?)(/\d+)?)*$")
 SCHEDULE_MODES = {"interval", "daily", "weekly", "monthly", "advanced"}
 SCHEDULE_INTERVAL_LIMITS = {"minute": 59, "hour": 23, "day": 365}
-SCHEDULE_LOCAL_DATETIME_FORMAT = "%Y-%m-%dT%H:%M"
+SCHEDULE_LOCAL_DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S"
+LEGACY_SCHEDULE_LOCAL_DATETIME_FORMAT = "%Y-%m-%dT%H:%M"
 SCHEDULE_TIME_FORMAT = "%H:%M"
 
 
@@ -56,12 +57,25 @@ def _normalize_schedule_starts_at(raw: Any, timezone_name: str) -> str | None:
     if raw in (None, ""):
         return None
     text = str(raw).strip()
-    try:
-        parsed = datetime.strptime(text, SCHEDULE_LOCAL_DATETIME_FORMAT)
-    except (TypeError, ValueError) as exc:
+    parsed = None
+    for value_format in (
+        SCHEDULE_LOCAL_DATETIME_FORMAT,
+        LEGACY_SCHEDULE_LOCAL_DATETIME_FORMAT,
+    ):
+        try:
+            parsed = datetime.strptime(text, value_format)
+            break
+        except (TypeError, ValueError):
+            continue
+    if parsed is None:
         raise ValidationError(
-            {"schedule": "starts_at must use YYYY-MM-DDTHH:MM in the selected timezone."}
-        ) from exc
+            {
+                "schedule": (
+                    "starts_at must use YYYY-MM-DDTHH:MM:SS in the selected timezone "
+                    "(legacy YYYY-MM-DDTHH:MM is also accepted)."
+                )
+            }
+        )
     schedule_timezone = ZoneInfo(timezone_name)
     round_tripped = (
         parsed.replace(tzinfo=schedule_timezone)

--- a/src/backend/apps/protection/services/policy_execution.py
+++ b/src/backend/apps/protection/services/policy_execution.py
@@ -106,14 +106,25 @@ def _schedule_start(schedule: dict) -> datetime | None:
     raw = str(schedule.get("starts_at") or "").strip()
     if not raw:
         return None
-    try:
-        return datetime.strptime(raw, "%Y-%m-%dT%H:%M")
-    except ValueError:
+    for value_format in ("%Y-%m-%dT%H:%M:%S", "%Y-%m-%dT%H:%M"):
+        try:
+            return datetime.strptime(raw, value_format)
+        except ValueError:
+            continue
+    return None
+
+
+def _schedule_start_minute(schedule: dict) -> datetime | None:
+    starts_at = _schedule_start(schedule)
+    if starts_at is None:
         return None
+    if starts_at.second or starts_at.microsecond:
+        starts_at += timedelta(minutes=1)
+    return starts_at.replace(second=0, microsecond=0)
 
 
 def _schedule_start_instant(schedule: dict) -> datetime | None:
-    starts_at = _schedule_start(schedule)
+    starts_at = _schedule_start_minute(schedule)
     if starts_at is None:
         return None
     return starts_at.replace(
@@ -122,7 +133,7 @@ def _schedule_start_instant(schedule: dict) -> datetime | None:
 
 
 def _schedule_has_started(schedule: dict, current) -> bool:
-    starts_at = _schedule_start(schedule)
+    starts_at = _schedule_start_minute(schedule)
     if starts_at is None:
         return True
     return current.replace(tzinfo=None) >= starts_at
@@ -154,7 +165,7 @@ def schedule_matches_now(schedule: dict, *, now=None) -> bool:
             timezone_name=str(schedule.get("timezone") or "UTC"),
         )
     if mode == "interval":
-        starts_at = _schedule_start(schedule)
+        starts_at = _schedule_start_minute(schedule)
         if starts_at is None:
             return cron_matches_now(
                 str(schedule.get("cron_expr") or ""),

--- a/src/backend/apps/protection/tests/test_policy_api.py
+++ b/src/backend/apps/protection/tests/test_policy_api.py
@@ -98,7 +98,7 @@ class ProtectionPolicyApiTests(TestCase):
             "enabled": True,
             "mode": "weekly",
             "timezone": "Asia/Shanghai",
-            "starts_at": "2026-07-31T09:30",
+            "starts_at": "2026-07-31T09:30:45",
             "time": "09:30",
             "weekdays": [5, 1, 3, 3],
             "cron_expr": "ignored by normalization",
@@ -118,13 +118,40 @@ class ProtectionPolicyApiTests(TestCase):
                 "enabled": True,
                 "mode": "weekly",
                 "timezone": "Asia/Shanghai",
-                "starts_at": "2026-07-31T09:30",
+                "starts_at": "2026-07-31T09:30:45",
                 "time": "09:30",
                 "weekdays": [1, 3, 5],
                 "cron_expr": "30 9 * * 1,3,5",
             },
         )
         self.assertIn("Asia/Shanghai", response.data["schedule_summary"])
+
+        legacy_start = self._policy_payload("Legacy minute start")
+        legacy_start["schedule"] = {
+            **weekly["schedule"],
+            "starts_at": "2026-07-31T09:30",
+        }
+        legacy_response = self.client.post(
+            "/api/v1/protection/policies/",
+            legacy_start,
+            format="json",
+            **self._headers(),
+        )
+        self.assertEqual(legacy_response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(legacy_response.data["schedule"]["starts_at"], "2026-07-31T09:30:00")
+
+        invalid_second = self._policy_payload("Invalid start second")
+        invalid_second["schedule"] = {
+            **weekly["schedule"],
+            "starts_at": "2026-07-31T09:30:60",
+        }
+        invalid_second_response = self.client.post(
+            "/api/v1/protection/policies/",
+            invalid_second,
+            format="json",
+            **self._headers(),
+        )
+        self.assertEqual(invalid_second_response.status_code, status.HTTP_400_BAD_REQUEST)
 
         invalid_timezone = self._policy_payload("Invalid timezone")
         invalid_timezone["schedule"] = {
@@ -143,7 +170,7 @@ class ProtectionPolicyApiTests(TestCase):
         nonexistent_start["schedule"] = {
             **weekly["schedule"],
             "timezone": "America/New_York",
-            "starts_at": "2026-03-08T02:30",
+            "starts_at": "2026-03-08T02:30:15",
         }
         dst_response = self.client.post(
             "/api/v1/protection/policies/",

--- a/src/backend/apps/protection/tests/test_policy_execution.py
+++ b/src/backend/apps/protection/tests/test_policy_execution.py
@@ -188,6 +188,27 @@ class PolicyExecutionTests(TestCase):
             schedule_matches_now(legacy, now=datetime(2026, 7, 31, 18, 0, tzinfo=UTC))
         )
 
+    def test_interval_start_seconds_round_up_to_the_next_scheduler_minute(self):
+        interval = {
+            "enabled": True,
+            "mode": "interval",
+            "timezone": "UTC",
+            "starts_at": "2026-07-31T09:30:30",
+            "interval_unit": "hour",
+            "interval_value": 1,
+            "cron_expr": "0 */1 * * *",
+        }
+
+        self.assertFalse(
+            schedule_matches_now(interval, now=datetime(2026, 7, 31, 9, 30, 59, tzinfo=UTC))
+        )
+        self.assertTrue(
+            schedule_matches_now(interval, now=datetime(2026, 7, 31, 9, 31, tzinfo=UTC))
+        )
+        self.assertTrue(
+            schedule_matches_now(interval, now=datetime(2026, 7, 31, 10, 31, tzinfo=UTC))
+        )
+
     def test_repeated_dst_wall_minute_uses_one_fire_key(self):
         schedule = {
             "enabled": True,

--- a/src/backend/apps/protection/tests/test_policy_start_seconds_migration.py
+++ b/src/backend/apps/protection/tests/test_policy_start_seconds_migration.py
@@ -1,0 +1,77 @@
+from django.db import connection
+from django.db.migrations.executor import MigrationExecutor
+from django.test import TransactionTestCase
+
+
+class PolicyStartSecondsMigrationTests(TransactionTestCase):
+    migrate_from = [("protection", "0018_backup_directory_repository_locator")]
+    migrate_to = [("protection", "0019_normalize_policy_start_seconds")]
+
+    def setUp(self):
+        super().setUp()
+        executor = MigrationExecutor(connection)
+        executor.migrate(self.migrate_from)
+        old_apps = executor.loader.project_state(self.migrate_from).apps
+        BackupPolicy = old_apps.get_model("protection", "BackupPolicy")
+        Organization = old_apps.get_model("iam", "Organization")
+        organization = Organization.objects.create(
+            key="policy-start-seconds-migration",
+            name="Policy start seconds migration",
+        )
+
+        common = {
+            "organization_id": organization.id,
+            "is_active": True,
+            "retention": {},
+            "throttling": {},
+            "error_handling": {},
+        }
+        self.minute_id = BackupPolicy.objects.create(
+            name="Minute precision",
+            schedule={"enabled": True, "mode": "interval", "starts_at": "2026-08-18T09:30"},
+            **common,
+        ).id
+        self.second_id = BackupPolicy.objects.create(
+            name="Second precision",
+            schedule={"enabled": True, "mode": "interval", "starts_at": "2026-08-18T09:30:45"},
+            **common,
+        ).id
+        self.cron_id = BackupPolicy.objects.create(
+            name="Legacy cron",
+            schedule={"enabled": True, "cron_expr": "0 2 * * *", "starts_at": "2026-08-18T09:30"},
+            **common,
+        ).id
+        self.malformed_id = BackupPolicy.objects.create(
+            name="Malformed start",
+            schedule={"enabled": True, "mode": "interval", "starts_at": "2026-02-31T09:30"},
+            **common,
+        ).id
+
+        executor = MigrationExecutor(connection)
+        executor.migrate(self.migrate_to)
+        self.apps = executor.loader.project_state(self.migrate_to).apps
+
+    def tearDown(self):
+        executor = MigrationExecutor(connection)
+        executor.migrate(executor.loader.graph.leaf_nodes())
+        super().tearDown()
+
+    def test_only_structured_minute_precision_starts_are_normalized(self):
+        BackupPolicy = self.apps.get_model("protection", "BackupPolicy")
+
+        self.assertEqual(
+            BackupPolicy.objects.get(pk=self.minute_id).schedule["starts_at"],
+            "2026-08-18T09:30:00",
+        )
+        self.assertEqual(
+            BackupPolicy.objects.get(pk=self.second_id).schedule["starts_at"],
+            "2026-08-18T09:30:45",
+        )
+        self.assertEqual(
+            BackupPolicy.objects.get(pk=self.cron_id).schedule["starts_at"],
+            "2026-08-18T09:30",
+        )
+        self.assertEqual(
+            BackupPolicy.objects.get(pk=self.malformed_id).schedule["starts_at"],
+            "2026-02-31T09:30",
+        )

--- a/src/frontend/src/lib/protectionPolicyApi.ts
+++ b/src/frontend/src/lib/protectionPolicyApi.ts
@@ -11,7 +11,7 @@ export type BackupPolicySchedule = {
   mode?: BackupPolicyScheduleMode
   /** IANA timezone. Legacy policies without one execute in UTC. */
   timezone?: string
-  /** Local wall-clock activation minute in the selected timezone. */
+  /** Local wall-clock activation time in the selected timezone, canonically including seconds. */
   starts_at?: string | null
   interval_unit?: 'minute' | 'hour' | 'day'
   interval_value?: number

--- a/src/frontend/src/lib/protectionPolicyFormModel.test.ts
+++ b/src/frontend/src/lib/protectionPolicyFormModel.test.ts
@@ -99,17 +99,17 @@ describe('protection policy schedule mapping', () => {
 
   it('formats schedule wall-clock start times without changing their timezone meaning', () => {
     const form = createEmptyPolicyForm()
-    form.scheduleStartsAt = '2026-08-13T14:30'
+    form.scheduleStartsAt = '2026-08-13T14:30:45'
 
-    expect(formatScheduleStartForDisplay(form.scheduleStartsAt)).toBe('2026-08-13 14:30')
-    expect(summarizeSchedule(form)).toContain('starts 2026-08-13 14:30')
-    expect(summarizeSchedule(form)).not.toContain('2026-08-13T14:30')
+    expect(formatScheduleStartForDisplay(form.scheduleStartsAt)).toBe('2026-08-13 14:30:45')
+    expect(summarizeSchedule(form)).toContain('starts 2026-08-13 14:30:45')
+    expect(summarizeSchedule(form)).not.toContain('2026-08-13T14:30:45')
   })
 
   it('serializes hour and day intervals through the shared mapper', () => {
     const form = createEmptyPolicyForm()
     form.scheduleTimezone = 'UTC'
-    form.scheduleStartsAt = '2026-07-31T02:30'
+    form.scheduleStartsAt = '2026-07-31T02:30:15'
     form.simpleIntervalUnit = 'hour'
     form.simpleIntervalValue = 6
 
@@ -119,6 +119,7 @@ describe('protection policy schedule mapping', () => {
       interval_unit: 'hour',
       interval_value: 6,
       cron_expr: '0 */6 * * *',
+      starts_at: '2026-07-31T02:30:15',
     })
 
     form.simpleIntervalUnit = 'day'
@@ -145,14 +146,14 @@ describe('protection policy schedule mapping', () => {
       freqMode: 'simple',
       quickScheduleType: 'weekly',
       scheduleTimezone: 'Asia/Shanghai',
-      scheduleStartsAt: '2026-07-31T09:30',
+      scheduleStartsAt: '2026-07-31T09:30:00',
       scheduleTime: '09:30',
       scheduleWeekdays: [1, 3, 5],
     })
     expect(policyFormToWritePayload(form).schedule).toMatchObject({
       mode: 'weekly',
       timezone: 'Asia/Shanghai',
-      starts_at: '2026-07-31T09:30',
+      starts_at: '2026-07-31T09:30:00',
       time: '09:30',
       weekdays: [1, 3, 5],
       cron_expr: '30 9 * * 1,3,5',
@@ -214,7 +215,18 @@ describe('protection policy schedule mapping', () => {
     form.scheduleMonthEnd = false
     expect(validateScheduleForm(form)).toBe('Select at least one month day or end of month.')
 
-    form.scheduleStartsAt = '2026-02-31T09:00'
+    form.scheduleStartsAt = '2026-02-31T09:00:00'
     expect(validateScheduleForm(form)).toBe('Start time must be a valid date and time.')
+
+    form.scheduleStartsAt = '2026-08-13T14:30:60'
+    expect(validateScheduleForm(form)).toBe('Start time must be a valid date and time.')
+  })
+
+  it('normalizes legacy minute precision before writing', () => {
+    const form = createEmptyPolicyForm()
+    form.scheduleStartsAt = '2026-08-13T14:30'
+
+    expect(validateScheduleForm(form)).toBe('')
+    expect(policyFormToWritePayload(form).schedule.starts_at).toBe('2026-08-13T14:30:00')
   })
 })

--- a/src/frontend/src/lib/protectionPolicyFormModel.ts
+++ b/src/frontend/src/lib/protectionPolicyFormModel.ts
@@ -20,7 +20,7 @@ export type SimpleIntervalUnit = 'minute' | 'hour' | 'day'
 export type ScheduleWeekday = 1 | 2 | 3 | 4 | 5 | 6 | 7
 
 const SCHEDULE_TIME_RE = /^([01]\d|2[0-3]):([0-5]\d)$/
-const SCHEDULE_START_RE = /^\d{4}-\d{2}-\d{2}T([01]\d|2[0-3]):([0-5]\d)$/
+const SCHEDULE_START_RE = /^\d{4}-\d{2}-\d{2}T([01]\d|2[0-3]):([0-5]\d)(?::([0-5]\d))?$/
 
 export interface ScheduleTimezoneOption {
   value: string
@@ -86,7 +86,15 @@ function formatScheduleStart(date = new Date()): string {
   const day = String(date.getDate()).padStart(2, '0')
   const hour = String(date.getHours()).padStart(2, '0')
   const minute = String(date.getMinutes()).padStart(2, '0')
-  return `${year}-${month}-${day}T${hour}:${minute}`
+  const second = String(date.getSeconds()).padStart(2, '0')
+  return `${year}-${month}-${day}T${hour}:${minute}:${second}`
+}
+
+function normalizeScheduleStart(value: string): string {
+  const normalized = String(value || '').trim()
+  return /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/.test(normalized)
+    ? `${normalized}:00`
+    : normalized
 }
 
 export interface SimpleIntervalUnitMeta {
@@ -385,7 +393,10 @@ export function summarizeSchedule(f: BackupPolicyForm, locale: MessageLocale = '
 export function formatScheduleStartForDisplay(value: string, fallback = '—'): string {
   const normalized = String(value || '').trim()
   if (!normalized) return fallback
-  return normalized.replace(/^(\d{4}-\d{2}-\d{2})T(\d{2}:\d{2})$/, '$1 $2')
+  return normalizeScheduleStart(normalized).replace(
+    /^(\d{4}-\d{2}-\d{2})T(\d{2}:\d{2}:\d{2})$/,
+    '$1 $2',
+  )
 }
 
 function resolveHourlyHours(raw: Partial<BackupPolicyRetention>, fallback: number): number {
@@ -975,16 +986,18 @@ function scheduleTimeParts(value: string): { hour: number; minute: number } | nu
 
 function isValidScheduleStart(value: string): boolean {
   const text = value.trim()
-  if (!SCHEDULE_START_RE.test(text)) return false
+  const match = SCHEDULE_START_RE.exec(text)
+  if (!match) return false
   const [datePart, timePart] = text.split('T')
   const [year, month, day] = datePart!.split('-').map(Number)
-  const [hour, minute] = timePart!.split(':').map(Number)
-  const parsed = new Date(year!, month! - 1, day!, hour!, minute!)
+  const [hour, minute, second = 0] = timePart!.split(':').map(Number)
+  const parsed = new Date(year!, month! - 1, day!, hour!, minute!, second)
   return parsed.getFullYear() === year
     && parsed.getMonth() === month! - 1
     && parsed.getDate() === day
     && parsed.getHours() === hour
     && parsed.getMinutes() === minute
+    && parsed.getSeconds() === second
 }
 
 export function quickScheduleToCron(policyForm: BackupPolicyForm): string {
@@ -1095,7 +1108,7 @@ function applyScheduleFromApi(
       simpleIntervalValue: Number(schedule.interval_value) || base.simpleIntervalValue,
       cronExpr: expr || base.cronExpr,
       scheduleTimezone: schedule.timezone || 'UTC',
-      scheduleStartsAt: schedule.starts_at || '',
+      scheduleStartsAt: normalizeScheduleStart(schedule.starts_at || ''),
       scheduleTime: schedule.time || base.scheduleTime,
       scheduleWeekdays: weekdays.length ? weekdays : base.scheduleWeekdays,
       scheduleMonthDays: monthDays,
@@ -1185,7 +1198,7 @@ export function policyFormToWritePayload(policyForm: BackupPolicyForm): BackupPo
   const scheduleBase = {
     enabled: policyForm.sectionScheduleEnabled,
     timezone: policyForm.scheduleTimezone.trim() || 'UTC',
-    starts_at: (policyForm.scheduleStartsAt || '').trim() || null,
+    starts_at: normalizeScheduleStart(policyForm.scheduleStartsAt || '') || null,
   }
   let schedule: BackupPolicySchedule
   if (policyForm.freqMode === 'advanced') {

--- a/src/frontend/src/pages/protection/components/ProtectionPolicyEditorForm.vue
+++ b/src/frontend/src/pages/protection/components/ProtectionPolicyEditorForm.vue
@@ -457,6 +457,8 @@ function toggleScheduleMonthDay(day: number) {
               class="schedule-context-control"
               format="YYYY-MM-DD HH:mm:ss"
               value-format="YYYY-MM-DDTHH:mm:ss"
+              popper-class="policy-start-time-popper"
+              :teleported="true"
               :placeholder="t('protection.policiesPage.scheduleStartsAtPlaceholder')"
             />
           </ElFormItem>

--- a/src/frontend/src/pages/protection/components/ProtectionPolicyScheduleEditor.test.ts
+++ b/src/frontend/src/pages/protection/components/ProtectionPolicyScheduleEditor.test.ts
@@ -10,17 +10,33 @@ const wizardSource = readFileSync(
   resolve(process.cwd(), 'src/pages/protection/BackupCreateWizard.vue'),
   'utf8',
 )
+const datePickerStyles = readFileSync(
+  resolve(process.cwd(), 'src/styles/element-plus-date-picker.css'),
+  'utf8',
+)
 
 describe('protection policy quick schedule editor', () => {
   it('exposes timezone, activation, cycle, weekly, monthly, and exact-time controls', () => {
     expect(editorSource).toContain('v-model="policyForm.scheduleTimezone"')
     expect(editorSource).toContain('v-model="policyForm.scheduleStartsAt"')
+    expect(editorSource).toContain('format="YYYY-MM-DD HH:mm:ss"')
+    expect(editorSource).toContain('value-format="YYYY-MM-DDTHH:mm:ss"')
+    expect(editorSource).toContain('popper-class="policy-start-time-popper"')
+    expect(editorSource).toContain(':teleported="true"')
     expect(editorSource).toContain('v-model="policyForm.quickScheduleType"')
     expect(editorSource).toContain('v-model="policyForm.scheduleWeekdays"')
     expect(editorSource).toContain('policyForm.scheduleMonthDays.includes(day)')
     expect(editorSource).toContain('v-model="policyForm.scheduleTime"')
     expect(editorSource).toContain("policyForm.scheduleMonthEnd = !policyForm.scheduleMonthEnd")
     expect(editorSource).toContain('.schedule-interval-unit {\n  width: 240px !important;')
+  })
+
+  it('keeps the nested second-precision time panel visible', () => {
+    expect(datePickerStyles).toContain('.policy-start-time-popper.el-picker__popper')
+    expect(datePickerStyles).toContain('z-index: 3600 !important;')
+    expect(datePickerStyles).toContain('.policy-start-time-popper .el-date-picker__editor-wrap .el-time-panel')
+    expect(datePickerStyles).toContain('width: 33.3333%;')
+    expect(datePickerStyles).toContain('max-width: calc(100vw - 24px);')
   })
 
   it('uses the shared policy payload mapper in the backup wizard', () => {

--- a/src/frontend/src/styles/element-plus-date-picker.css
+++ b/src/frontend/src/styles/element-plus-date-picker.css
@@ -100,3 +100,41 @@
 .el-time-spinner__item:hover:not(.is-disabled):not(.is-active) {
   background: var(--el-fill-color-light, #f5f7fa) !important;
 }
+
+/* Backup Policy Start Time has a nested three-column time panel. Keep that
+   panel inside the date picker's editor cell instead of letting the global
+   popper overflow rule clip its right edge. */
+.policy-start-time-popper.el-picker__popper {
+  z-index: 3600 !important;
+}
+
+.policy-start-time-popper .el-date-picker__editor-wrap .el-time-panel {
+  box-sizing: border-box;
+  width: 100%;
+  min-width: 0;
+}
+
+.policy-start-time-popper .el-time-spinner.has-seconds .el-time-spinner__wrapper {
+  box-sizing: border-box;
+  width: 33.3333%;
+}
+
+@media (max-width: 360px) {
+  .policy-start-time-popper.el-picker__popper,
+  .policy-start-time-popper .el-date-picker {
+    max-width: calc(100vw - 24px);
+  }
+
+  .policy-start-time-popper .el-date-picker,
+  .policy-start-time-popper .el-date-picker .el-picker-panel__content {
+    box-sizing: border-box;
+  }
+
+  .policy-start-time-popper .el-date-picker {
+    width: 100%;
+  }
+
+  .policy-start-time-popper .el-date-picker .el-picker-panel__content {
+    width: calc(100% - 30px);
+  }
+}


### PR DESCRIPTION
## Problem and root cause

The Backup Policy Start Time picker emitted second-precision values after the
date component upgrade, while frontend validation and backend parsing still
expected minute precision. This made valid selections fail validation. The
nested three-column time panel was also wider than its editor cell and could
be clipped by the surrounding date-picker popper.

## Solution

- Canonicalize `schedule.starts_at` as `YYYY-MM-DDTHH:mm:ss` through the UI,
  API, stored schedule, summaries, and scheduler parsing.
- Continue accepting legacy minute-precision values and normalize valid
  structured schedules to `:00` with a data migration.
- Preserve minute scheduler cadence and round non-zero-second interval starts
  up to the next scheduler minute.
- Give the Backup Policy picker a dedicated teleported popper with bounded
  sizing, equal hour/minute/second columns, explicit stacking, and narrow
  viewport constraints.

## Validation

- Targeted backend tests: passed in Community and Enterprise-loaded modes.
- Targeted frontend tests: passed in Community and Enterprise-loaded modes.
- Changed-file Ruff and ESLint, full frontend lint, migration drift, English
  source validation, and `git diff --check`: passed.
- Community and Enterprise production frontend builds: passed.
- Manual testing: passed.
- Broad backend protection and frontend suites have only baseline-equivalent
  failures reproduced on clean canonical `origin/main` at
  `36f459a057fdb03ad945097728124ce316bc439a`; no Issue-related failure was
  introduced.
- Post-sync product checks were skipped because the rebase onto
  `be271926fcf191a6f9f837214241d1b5012ecba6` was conflict-free.

## Risks and compatibility

Legacy minute values remain accepted and are returned with `:00` seconds.
Malformed, empty, and cron-only schedules are left unchanged by migration.
`schedule.time` and five-field cron expressions remain minute precision. The
scheduler still polls once per minute, so a start such as `09:30:30` first
becomes eligible at `09:31`.

Fixes #640
