### PR TITLE
feat(ci): add registry-backed enterprise SaaS upgrades

### DIFF
--- a/.github/actions/deploy-saas/action.yml
+++ b/.github/actions/deploy-saas/action.yml
@@ -1,0 +1,197 @@
+name: HFL Enterprise SaaS deploy
+description: Deploy one registry-backed Candidate to an already-installed official environment
+inputs:
+  target:
+    description: Official target name, test or prod
+    required: true
+  tag:
+    description: Product release tag
+    required: true
+  artifact_name:
+    description: Actions artifact containing the thin Candidate package
+    required: true
+  public_url:
+    description: Canonical tenant URL
+    required: false
+  admin_public_url:
+    description: Canonical Admin Console URL
+    required: false
+runs:
+  using: composite
+  steps:
+    - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+      with:
+        name: ${{ inputs.artifact_name }}
+        path: ${{ runner.temp }}/saas-candidate
+    - name: Validate deployment inputs
+      shell: bash
+      env:
+        INPUT_TARGET: ${{ inputs.target }}
+        INPUT_TAG: ${{ inputs.tag }}
+      run: |
+          set -euo pipefail
+          [[ "$DEPLOY_TARGET" =~ ^(test|prod)$ ]]
+          [[ "$INPUT_TARGET" == "$DEPLOY_TARGET" ]]
+          [[ "$INPUT_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]
+          [[ "$DEPLOY_SSH_HOST" =~ ^[A-Za-z0-9][A-Za-z0-9.-]*$ ]]
+          [[ "$DEPLOY_SSH_PORT" =~ ^[0-9]+$ ]]
+          [[ "$DEPLOY_SSH_USER" =~ ^[a-z_][a-z0-9_-]*$ ]]
+          [[ -n "$DEPLOY_SSH_KNOWN_HOSTS" && -n "$DEPLOY_SSH_PRIVATE_KEY" ]]
+          [[ "$REGISTRY_HOST" =~ ^[a-z0-9][a-z0-9.-]*(:[0-9]+)?$ ]]
+          [[ "$CN_REGISTRY_HOST" =~ ^[a-z0-9][a-z0-9.-]*(:[0-9]+)?$ ]]
+          [[ -n "$REGISTRY_USERNAME" && -n "$REGISTRY_PASSWORD" ]]
+          [[ -n "$CN_REGISTRY_USERNAME" && -n "$CN_REGISTRY_PASSWORD" ]]
+          [[ "$HFL_INSECURE_TLS" =~ ^[01]$ ]]
+          case "$DEPLOY_TARGET:$HFL_INSECURE_TLS" in
+            test:1|prod:0) ;;
+            *) echo "Target refuses HFL_INSECURE_TLS=$HFL_INSECURE_TLS" >&2; exit 1 ;;
+          esac
+          [[ -s "$RUNNER_TEMP/saas-candidate/candidate.tar.gz" ]]
+          [[ -s "$RUNNER_TEMP/saas-candidate/candidate.tar.gz.sha256" ]]
+    - name: Prepare protected deployment files
+      shell: bash
+      run: |
+          set -euo pipefail
+          umask 077
+          install -d -m 0700 ~/.ssh "$RUNNER_TEMP/saas-stage"
+          printf '%s\n' "$DEPLOY_SSH_PRIVATE_KEY" >~/.ssh/hyperfilelens_saas
+          printf '%s\n' "$DEPLOY_SSH_KNOWN_HOSTS" >~/.ssh/known_hosts
+          chmod 0600 ~/.ssh/hyperfilelens_saas ~/.ssh/known_hosts
+          python3 - "$RUNNER_TEMP/saas-stage/registry.json" <<'PY'
+          import json, os, pathlib, sys
+          payload = {
+              "global_host": os.environ["REGISTRY_HOST"],
+              "global_username": os.environ["REGISTRY_USERNAME"],
+              "global_password": os.environ["REGISTRY_PASSWORD"],
+              "cn_host": os.environ["CN_REGISTRY_HOST"],
+              "cn_username": os.environ["CN_REGISTRY_USERNAME"],
+              "cn_password": os.environ["CN_REGISTRY_PASSWORD"],
+          }
+          pathlib.Path(sys.argv[1]).write_text(json.dumps(payload), encoding="utf-8")
+          PY
+          python3 - "$RUNNER_TEMP/saas-stage/runtime.env" <<'PY'
+          import os, pathlib, re, sys
+          names = (
+              "HFL_EMAIL_SIGNUP_ENABLED", "HFL_EMAIL_CODE_LOGIN_ENABLED",
+              "HFL_GOOGLE_OAUTH_ENABLED", "HFL_GA_MEASUREMENT_ID", "HFL_INSECURE_TLS",
+              "HFL_PLATFORM_GATEWAY_AUTO_DEPLOY", "SENTRY_ENABLED", "SENTRY_BACKEND_DSN",
+              "SENTRY_FRONTEND_DSN", "TURNSTILE_ENABLED", "TURNSTILE_SITE_KEY",
+              "TURNSTILE_SECRET_KEY", "SMTP_HOST", "SMTP_PORT", "SMTP_USERNAME",
+              "SMTP_PASSWORD", "SMTP_SECURITY", "EMAIL_FROM", "GOOGLE_CLIENT_ID",
+              "GOOGLE_CLIENT_SECRET",
+          )
+          lines = [f"HFL_DEPLOY_TARGET={os.environ['DEPLOY_TARGET']}"]
+          lines.append(f"SENTRY_ENVIRONMENT={'hfl-production' if os.environ['DEPLOY_TARGET'] == 'prod' else 'hfl-test'}")
+          lines.append("SENTRY_TRACES_SAMPLE_RATE=0")
+          for name in names:
+              value = os.environ.get(name, "")
+              if "\n" in value or "\r" in value or "\0" in value:
+                  if name == "HFL_GA_MEASUREMENT_ID":
+                      print(
+                          "::warning title=Google Analytics configuration::"
+                          "The GA4 measurement ID is malformed; analytics will be disabled."
+                      )
+                      lines.append(f"{name}=")
+                      continue
+                  print(
+                      f"::warning title=Optional runtime configuration::"
+                      f"Ignoring malformed {name}; the installed value will be preserved."
+                  )
+                  continue
+              if name == "HFL_GA_MEASUREMENT_ID" and value and not re.fullmatch(r"G-[A-Z0-9]+", value):
+                  print(
+                      "::warning title=Google Analytics configuration::"
+                      "The GA4 measurement ID is malformed; analytics will be disabled."
+                  )
+                  value = ""
+              lines.append(f"{name}={value}")
+          pathlib.Path(sys.argv[1]).write_text("\n".join(lines) + "\n", encoding="utf-8")
+          PY
+    - name: Stage Candidate on target
+      shell: bash
+      run: |
+          set -euo pipefail
+          remote_dir="/var/tmp/hyperfilelens-saas-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          ssh_args=(
+            -i ~/.ssh/hyperfilelens_saas -o BatchMode=yes -o StrictHostKeyChecking=yes
+            -o ConnectTimeout=20 -o ServerAliveInterval=30 -o ServerAliveCountMax=20
+            -o TCPKeepAlive=yes -p "$DEPLOY_SSH_PORT"
+          )
+          ssh "${ssh_args[@]}" "$DEPLOY_SSH_USER@$DEPLOY_SSH_HOST" \
+            "rm -rf -- '$remote_dir' && install -d -m 0700 '$remote_dir'"
+          scp -i ~/.ssh/hyperfilelens_saas -o BatchMode=yes -o StrictHostKeyChecking=yes \
+            -o ConnectTimeout=20 -o ServerAliveInterval=30 -o ServerAliveCountMax=20 \
+            -o TCPKeepAlive=yes -P "$DEPLOY_SSH_PORT" \
+            "$RUNNER_TEMP/saas-candidate/candidate.tar.gz" \
+            "$RUNNER_TEMP/saas-stage/registry.json" \
+            "$RUNNER_TEMP/saas-stage/runtime.env" \
+            "$DEPLOY_SSH_USER@$DEPLOY_SSH_HOST:$remote_dir/"
+    - name: Upgrade target from Candidate
+      shell: bash
+      env:
+        APP_PUBLIC_URL: ${{ inputs.public_url }}
+        ADMIN_PUBLIC_URL: ${{ inputs.admin_public_url }}
+      run: |
+          set -euo pipefail
+          remote_dir="/var/tmp/hyperfilelens-saas-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          candidate_sha="$(awk 'NR == 1 {print $1}' "$RUNNER_TEMP/saas-candidate/candidate.tar.gz.sha256")"
+          [[ "$candidate_sha" =~ ^[0-9a-f]{64}$ ]]
+          printf -v remote_command '%q ' \
+            bash -s -- \
+              --candidate "$remote_dir/candidate.tar.gz" \
+              --candidate-sha256 "$candidate_sha" \
+              --registry-credentials "$remote_dir/registry.json" \
+              --runtime-env-file "$remote_dir/runtime.env" \
+              --direct-host "$DEPLOY_SSH_HOST" \
+              --public-url "$APP_PUBLIC_URL" \
+              --admin-public-url "$ADMIN_PUBLIC_URL"
+          ssh -i ~/.ssh/hyperfilelens_saas -o BatchMode=yes -o StrictHostKeyChecking=yes \
+            -o ConnectTimeout=20 -o ServerAliveInterval=30 -o ServerAliveCountMax=20 \
+            -o TCPKeepAlive=yes -p "$DEPLOY_SSH_PORT" \
+            "$DEPLOY_SSH_USER@$DEPLOY_SSH_HOST" "$remote_command" \
+            <.github/scripts/remote-saas-deploy.sh
+    - name: Verify target health
+      shell: bash
+      run: |
+          set -euo pipefail
+          ssh -i ~/.ssh/hyperfilelens_saas -o BatchMode=yes -o StrictHostKeyChecking=yes \
+            -o ConnectTimeout=20 -o ServerAliveInterval=30 -o ServerAliveCountMax=20 \
+            -o TCPKeepAlive=yes -p "$DEPLOY_SSH_PORT" \
+            "$DEPLOY_SSH_USER@$DEPLOY_SSH_HOST" \
+            'curl -kfsS https://127.0.0.1:11442/en/ >/dev/null &&
+             curl -kfsS https://127.0.0.1:11443/health/ready >/dev/null &&
+             curl -kfsS https://127.0.0.1:11444/ >/dev/null &&
+             curl -kfsS https://127.0.0.1:11445/ >/dev/null'
+    - name: Reconcile Platform Gateway
+      if: ${{ env.HFL_PLATFORM_GATEWAY_AUTO_DEPLOY == 'true' }}
+      shell: bash
+      run: |
+          set -euo pipefail
+          ssh -i ~/.ssh/hyperfilelens_saas -o BatchMode=yes -o StrictHostKeyChecking=yes \
+            -o ConnectTimeout=20 -o ServerAliveInterval=30 -o ServerAliveCountMax=20 \
+            -o TCPKeepAlive=yes -p "$DEPLOY_SSH_PORT" \
+            "$DEPLOY_SSH_USER@$DEPLOY_SSH_HOST" \
+            'if /opt/hyperfilelens/install.sh platform-gateway verify --required --timeout 0; then
+               echo "Platform Gateway is already ready; preserving the running deployment";
+             else
+               /opt/hyperfilelens/install.sh platform-gateway ensure;
+             fi &&
+             /opt/hyperfilelens/install.sh platform-gateway verify --required --timeout 180'
+    - name: Reconcile default AI model
+      shell: bash
+      run: .github/scripts/reconcile-saas-ai-model.sh agent
+    - name: Reconcile optional multimodal model
+      shell: bash
+      run: .github/scripts/reconcile-saas-ai-model.sh multimodal
+    - name: Remove staged files
+      if: ${{ always() }}
+      shell: bash
+      run: |
+          rm -rf -- "$RUNNER_TEMP/saas-stage" "$RUNNER_TEMP/saas-candidate"
+          if [[ -f ~/.ssh/hyperfilelens_saas ]]; then
+            remote_dir="/var/tmp/hyperfilelens-saas-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+            ssh -i ~/.ssh/hyperfilelens_saas -o BatchMode=yes -o StrictHostKeyChecking=yes \
+              -o ConnectTimeout=20 -p "$DEPLOY_SSH_PORT" \
+              "$DEPLOY_SSH_USER@$DEPLOY_SSH_HOST" "rm -rf -- '$remote_dir'" || true
+          fi
+          rm -f -- ~/.ssh/hyperfilelens_saas

--- a/.github/scripts/reconcile-saas-ai-model.sh
+++ b/.github/scripts/reconcile-saas-ai-model.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# Reconcile one deployment-managed AI model without exposing its credentials.
+set -euo pipefail
+
+role=${1:-}
+case "${role}" in
+agent)
+	provider=${AI_MODEL_PROVIDER:-}
+	model_id=${AI_MODEL_ID:-}
+	display_name=${AI_MODEL_DISPLAY_NAME:-}
+	required=1
+	label="AI model"
+	;;
+multimodal)
+	provider=${AI_MULTIMODAL_MODEL_PROVIDER:-}
+	model_id=${AI_MULTIMODAL_MODEL_ID:-}
+	display_name=${AI_MULTIMODAL_MODEL_DISPLAY_NAME:-}
+	required=0
+	label="Multimodal model"
+	;;
+*)
+	printf 'Usage: %s agent|multimodal\n' "$0" >&2
+	exit 2
+	;;
+esac
+
+summary() {
+	[[ -z "${GITHUB_STEP_SUMMARY:-}" ]] || printf '### %s deployment\n\n%s\n' \
+		"${label}" "$1" >>"${GITHUB_STEP_SUMMARY}"
+}
+
+warn_and_preserve() {
+	printf '::warning title=%s configuration::%s; the installed value will be preserved.\n' \
+		"${label}" "$1"
+	summary "Warning: $1; the installed value was preserved."
+	exit 0
+}
+
+if [[ -z "${provider}" ]]; then
+	summary "Skipped: no deployment-managed ${label,,} is configured."
+	exit 0
+fi
+
+values=(
+	"${provider}" "${model_id}" "${display_name}"
+	"${AI_MODEL_API_BASE:-}" "${AI_MODEL_API_KEY:-}"
+)
+valid=1
+for value in "${values[@]}"; do
+	[[ -n "${value}" && "${value}" != *$'\n'* && "${value}" != *$'\r'* ]] || valid=0
+done
+[[ "${provider}" =~ ^[a-z0-9_]+$ ]] || valid=0
+[[ "${AI_MODEL_API_BASE:-}" == https://* ]] || valid=0
+
+if ((valid == 0)); then
+	if ((required == 1)); then
+		printf '::error title=%s configuration::Configuration is incomplete or malformed.\n' \
+			"${label}"
+		summary "Failed: required configuration is incomplete or malformed."
+		exit 1
+	fi
+	warn_and_preserve "Configuration is incomplete or malformed"
+fi
+
+payload="$(mktemp "${RUNNER_TEMP:-/tmp}/hyperfilelens-${role}-model.XXXXXX.json")"
+trap 'rm -f -- "${payload}"' EXIT
+chmod 0600 "${payload}"
+ROLE="${role}" PROVIDER="${provider}" MODEL_ID="${model_id}" \
+	DISPLAY_NAME="${display_name}" python3 - "${payload}" <<'PY'
+import json
+import os
+import pathlib
+import sys
+
+payload = {
+    "role": os.environ["ROLE"],
+    "provider": os.environ["PROVIDER"],
+    "model_id": os.environ["MODEL_ID"],
+    "display_name": os.environ["DISPLAY_NAME"],
+    "api_base": os.environ["AI_MODEL_API_BASE"],
+    "api_key": os.environ["AI_MODEL_API_KEY"],
+}
+pathlib.Path(sys.argv[1]).write_text(json.dumps(payload), encoding="utf-8")
+PY
+
+set +e
+output="$(ssh -i ~/.ssh/hyperfilelens_saas \
+	-o BatchMode=yes -o StrictHostKeyChecking=yes \
+	-o ConnectTimeout=20 -o ServerAliveInterval=30 -o ServerAliveCountMax=20 \
+	-o TCPKeepAlive=yes -p "${DEPLOY_SSH_PORT}" \
+	"${DEPLOY_SSH_USER}@${DEPLOY_SSH_HOST}" \
+	'/opt/hyperfilelens/install.sh manage ensure_platform_ai_model' \
+	<"${payload}" 2>&1)"
+command_status=$?
+set -e
+printf '%s\n' "${output}"
+
+failure=""
+if ((command_status != 0)); then
+	failure="The configured model could not be created or updated"
+elif grep -Fq 'HFL_AI_MODEL_APPLIED=false' <<<"${output}"; then
+	failure="The candidate failed validation"
+elif grep -Fq 'HFL_AI_MODEL_CONNECTIVITY=failed' <<<"${output}"; then
+	failure="The configured model failed connectivity validation"
+fi
+
+if [[ -n "${failure}" ]]; then
+	if ((required == 1)); then
+		printf '::error title=%s deployment::%s.\n' "${label}" "${failure}"
+		summary "Failed: ${failure}."
+		exit 1
+	fi
+	warn_and_preserve "${failure}"
+fi
+
+summary "Passed: the deployment-managed ${label,,} was applied and verified."

--- a/.github/scripts/remote-saas-deploy.sh
+++ b/.github/scripts/remote-saas-deploy.sh
@@ -1,0 +1,291 @@
+#!/usr/bin/env bash
+# Deploy one already-built Enterprise SaaS candidate from registry images.
+set -euo pipefail
+
+candidate_archive=""
+candidate_sha256=""
+registry_credentials=""
+runtime_env_file=""
+direct_host=""
+public_url=""
+admin_public_url=""
+
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+	--candidate) candidate_archive=${2:-}; shift 2 ;;
+	--candidate-sha256) candidate_sha256=${2:-}; shift 2 ;;
+	--registry-credentials) registry_credentials=${2:-}; shift 2 ;;
+	--runtime-env-file) runtime_env_file=${2:-}; shift 2 ;;
+	--direct-host) direct_host=${2:-}; shift 2 ;;
+	--public-url) public_url=${2:-}; shift 2 ;;
+	--admin-public-url) admin_public_url=${2:-}; shift 2 ;;
+	*) printf 'ERROR: unknown argument: %s\n' "$1" >&2; exit 2 ;;
+	esac
+done
+
+[[ "${candidate_archive}" =~ ^/var/tmp/hyperfilelens-saas-[0-9]+-[0-9]+/candidate\.tar\.gz$ ]]
+[[ "${registry_credentials}" =~ ^/var/tmp/hyperfilelens-saas-[0-9]+-[0-9]+/registry\.json$ ]]
+[[ "${runtime_env_file}" =~ ^/var/tmp/hyperfilelens-saas-[0-9]+-[0-9]+/runtime\.env$ ]]
+[[ "${candidate_sha256}" =~ ^[0-9a-f]{64}$ ]]
+[[ -n "${direct_host}" && "${direct_host}" != *[[:space:]]* ]]
+for file in "${candidate_archive}" "${registry_credentials}" "${runtime_env_file}"; do
+	[[ -f "${file}" && ! -L "${file}" ]] || {
+		printf 'ERROR: staged SaaS deployment file is missing or unsafe: %s\n' "${file}" >&2
+		exit 1
+	}
+	directory="$(dirname "${file}")"
+	[[ "$(stat -c '%a' "${directory}")" == "700" ]] || {
+		printf 'ERROR: SaaS staging directory must use mode 0700\n' >&2
+		exit 1
+	}
+done
+printf '%s  %s\n' "${candidate_sha256}" "${candidate_archive}" | sha256sum -c -
+
+command -v docker >/dev/null
+docker info >/dev/null
+command -v python3 >/dev/null
+command -v flock >/dev/null
+
+exec 9>/var/lock/hyperfilelens-deploy.lock
+flock 9
+
+stage_dir="$(dirname "${candidate_archive}")"
+extract_dir="${stage_dir}/extract"
+docker_config="${stage_dir}/docker-config"
+asset_container=""
+rm -rf -- "${extract_dir}" "${docker_config}"
+install -d -m 0700 "${extract_dir}" "${docker_config}"
+cleanup() {
+	rc=$?
+	if [[ -n "${asset_container}" ]]; then
+		docker rm -f "${asset_container}" >/dev/null 2>&1 || true
+	fi
+	rm -rf -- \
+		"${docker_config}" "${extract_dir}" \
+		"${stage_dir}/asset-agent" \
+		"${stage_dir}/asset-gateway" \
+		"${stage_dir}/asset-language"
+	rm -f -- \
+		"${stage_dir}/assets.tsv" \
+		"${registry_credentials}" \
+		"${runtime_env_file}" \
+		"${candidate_archive}"
+	exit "${rc}"
+}
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+python3 - "${candidate_archive}" <<'PY'
+import pathlib
+import sys
+import tarfile
+
+archive = pathlib.Path(sys.argv[1])
+with tarfile.open(archive, "r:gz") as package:
+    members = package.getmembers()
+    roots = set()
+    for member in members:
+        raw = member.name
+        path = pathlib.PurePosixPath(raw)
+        if not raw or path.is_absolute() or any(part in {"", ".", ".."} for part in path.parts):
+            raise SystemExit(f"candidate contains an unsafe path: {raw!r}")
+        roots.add(path.parts[0])
+        if not (member.isdir() or member.isreg()):
+            raise SystemExit(f"candidate contains an unsupported entry: {raw!r}")
+    if len(roots) != 1:
+        raise SystemExit("candidate must contain exactly one package root")
+PY
+tar -xzf "${candidate_archive}" -C "${extract_dir}"
+mapfile -t roots < <(find "${extract_dir}" -mindepth 1 -maxdepth 1 -type d -print)
+[[ ${#roots[@]} -eq 1 && -f "${roots[0]}/MANIFEST.json" ]] || {
+	printf 'ERROR: SaaS candidate has an invalid package layout\n' >&2
+	exit 1
+}
+candidate_root=${roots[0]}
+
+read_credential() {
+	python3 - "${registry_credentials}" "$1" <<'PY'
+import json, pathlib, sys
+value = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")).get(sys.argv[2], "")
+if not isinstance(value, str) or "\n" in value or "\r" in value or "\0" in value:
+    raise SystemExit("invalid registry credential")
+print(value, end="")
+PY
+}
+
+registry_login_count=0
+for prefix in global cn; do
+	host="$(read_credential "${prefix}_host")"
+	username="$(read_credential "${prefix}_username")"
+	password="$(read_credential "${prefix}_password")"
+	[[ "${host}" =~ ^[a-z0-9][a-z0-9.-]*(:[0-9]+)?$ && -n "${username}" && -n "${password}" ]]
+	if printf '%s' "${password}" | DOCKER_CONFIG="${docker_config}" docker login \
+		--username "${username}" --password-stdin "${host}" >/dev/null 2>&1; then
+		registry_login_count=$((registry_login_count + 1))
+		printf '[ OK ] Authenticated registry source: %s\n' "${host}"
+	else
+		printf '[WARN] Registry source is temporarily unavailable: %s\n' "${host}" >&2
+	fi
+	unset password
+done
+((registry_login_count > 0)) || {
+	printf 'ERROR: neither registry source is available\n' >&2
+	exit 1
+}
+
+export DOCKER_CONFIG="${docker_config}"
+python3 - "${candidate_root}/MANIFEST.json" >"${stage_dir}/assets.tsv" <<'PY'
+import json, pathlib, re, sys
+manifest = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+delivery = manifest.get("delivery") or {}
+if delivery.get("mode") != "registry":
+    raise SystemExit("candidate is not registry-backed")
+asset_images = delivery.get("asset_images") or []
+if len(asset_images) != 3:
+    raise SystemExit("candidate must contain exactly three asset images")
+seen = set()
+for image in asset_images:
+    kind = str(image.get("asset_kind") or "")
+    digest = str(image.get("digest") or "")
+    local_ref = str(image.get("local_ref") or "")
+    sources = image.get("sources") or []
+    if kind not in {"agent", "gateway", "language"} or kind in seen:
+        raise SystemExit("candidate contains invalid or duplicate asset metadata")
+    seen.add(kind)
+    if not re.fullmatch(r"sha256:[0-9a-f]{64}", digest):
+        raise SystemExit("candidate contains invalid asset metadata")
+    if not re.fullmatch(
+        rf"hyperfilelens-{kind}-assets:[A-Za-z0-9][A-Za-z0-9._-]{{0,127}}",
+        local_ref,
+    ):
+        raise SystemExit("candidate contains invalid asset local reference")
+    refs = [str(item.get("ref") or "") for item in sources]
+    if len(refs) != 2 or any(
+        not re.fullmatch(
+            r"[a-z0-9][a-z0-9.-]*(?::[0-9]+)?/[a-z0-9._/-]+:[A-Za-z0-9][A-Za-z0-9._-]{0,127}",
+            ref,
+        )
+        for ref in refs
+    ):
+        raise SystemExit("candidate contains invalid asset sources")
+    print("\t".join([kind, digest, local_ref, *refs]))
+PY
+
+while IFS=$'\t' read -r kind digest local_ref source_one source_two; do
+	[[ -n "${kind}" ]] || continue
+	pulled=""
+	for source_ref in "${source_one}" "${source_two}"; do
+		[[ -n "${source_ref}" ]] || continue
+		immutable_ref="${source_ref%:*}@${digest}"
+		if docker pull --platform linux/amd64 "${immutable_ref}"; then
+			pulled="${immutable_ref}"
+			break
+		fi
+	done
+	[[ -n "${pulled}" ]] || {
+		printf 'ERROR: could not pull %s asset image\n' "${kind}" >&2
+		exit 1
+	}
+	docker tag "${pulled}" "${local_ref}"
+	asset_extract="${stage_dir}/asset-${kind}"
+	rm -rf -- "${asset_extract}"
+	install -d -m 0700 "${asset_extract}"
+	asset_container="$(docker create "${local_ref}" /bin/true)"
+	if ! docker cp "${asset_container}:/opt/hyperfilelens-assets/." "${asset_extract}/"; then
+		docker rm -f "${asset_container}" >/dev/null 2>&1 || true
+		asset_container=""
+		exit 1
+	fi
+	docker rm -f "${asset_container}" >/dev/null
+	asset_container=""
+	[[ "$(cat "${asset_extract}/.asset-kind" 2>/dev/null || true)" == "${kind}" ]] || {
+		printf 'ERROR: %s asset image has an invalid payload marker\n' "${kind}" >&2
+		exit 1
+	}
+	python3 - "${asset_extract}" "${kind}" <<'PY'
+import os
+import pathlib
+import stat
+import sys
+
+root = pathlib.Path(sys.argv[1])
+kind = sys.argv[2]
+prefixes = {
+    "agent": (
+        pathlib.PurePosixPath("payload/media/agent-releases"),
+        pathlib.PurePosixPath("payload/media/enroll-bootstrap"),
+    ),
+    "gateway": (pathlib.PurePosixPath("payload/media/gateway-bootstrap"),),
+    "language": (pathlib.PurePosixPath("payload/language-packs"),),
+}[kind]
+ancestors = {pathlib.PurePosixPath(".asset-kind")}
+for prefix in prefixes:
+    ancestors.update(prefix.parents[:-1])
+    ancestors.add(prefix)
+
+seen_prefixes = set()
+
+
+def is_under(path: pathlib.PurePosixPath, prefix: pathlib.PurePosixPath) -> bool:
+    try:
+        path.relative_to(prefix)
+    except ValueError:
+        return False
+    return True
+
+
+for current, directories, files in os.walk(root, topdown=True, followlinks=False):
+    for name in [*directories, *files]:
+        path = pathlib.Path(current, name)
+        relative = pathlib.PurePosixPath(path.relative_to(root).as_posix())
+        mode = path.lstat().st_mode
+        if not (stat.S_ISDIR(mode) or stat.S_ISREG(mode)):
+            raise SystemExit(f"asset {kind} contains unsupported entry: {relative}")
+        allowed = relative in ancestors or any(is_under(relative, prefix) for prefix in prefixes)
+        if not allowed:
+            raise SystemExit(f"asset {kind} contains unexpected path: {relative}")
+        for prefix in prefixes:
+            if is_under(relative, prefix):
+                seen_prefixes.add(prefix)
+if seen_prefixes != set(prefixes):
+    missing = sorted(str(prefix) for prefix in set(prefixes) - seen_prefixes)
+    raise SystemExit(f"asset {kind} is missing payload roots: {missing}")
+PY
+	find "${asset_extract}" -type d -exec chmod 0755 {} +
+	find "${asset_extract}" -type f -exec chmod 0644 {} +
+	find "${asset_extract}/payload" -type f -name '*.sh' -exec chmod 0755 {} +
+	cp -a "${asset_extract}/payload/." "${candidate_root}/payload/"
+done <"${stage_dir}/assets.tsv"
+
+if find "${candidate_root}/payload" -type l -print -quit | grep -q .; then
+	printf 'ERROR: extracted SaaS assets contain symbolic links\n' >&2
+	exit 1
+fi
+
+install -d -m 0700 /opt/hyperfilelens/data/deployment-candidates
+previous_manifest="/opt/hyperfilelens/MANIFEST.json"
+if [[ -f "${previous_manifest}" ]]; then
+	previous_id="$(sha256sum "${previous_manifest}" | cut -c1-12)"
+	install -d -m 0700 "/opt/hyperfilelens/data/deployment-candidates/${previous_id}"
+	cp "${previous_manifest}" "/opt/hyperfilelens/data/deployment-candidates/${previous_id}/MANIFEST.json"
+fi
+
+upgrade_args=(
+	upgrade --from "${candidate_root}" --yes --with-sourcelens
+	--direct-host "${direct_host}"
+	--runtime-env-file "${runtime_env_file}"
+)
+[[ -z "${public_url}" ]] || upgrade_args+=(--public-url "${public_url}")
+[[ -z "${admin_public_url}" ]] || upgrade_args+=(--admin-public-url "${admin_public_url}")
+HFL_UPGRADE_ARTIFACT_SHA256="${candidate_sha256}" \
+	bash "${candidate_root}/install.sh" "${upgrade_args[@]}"
+
+candidate_id="$(sha256sum "${candidate_root}/MANIFEST.json" | cut -c1-12)"
+candidate_history="/opt/hyperfilelens/data/deployment-candidates/${candidate_id}"
+install -d -m 0700 "${candidate_history}"
+cp "${candidate_root}/MANIFEST.json" "${candidate_history}/MANIFEST.json"
+printf '%s\n' "${candidate_id}" >"/opt/hyperfilelens/data/deployment-candidates/current"
+if [[ -n "${previous_id:-}" && "${previous_id}" != "${candidate_id}" ]]; then
+	printf '%s\n' "${previous_id}" >"/opt/hyperfilelens/data/deployment-candidates/previous"
+fi

--- a/.github/workflows/enterprise_saas_upgrade.yml
+++ b/.github/workflows/enterprise_saas_upgrade.yml
@@ -1,0 +1,778 @@
+name: HFL - Enterprise SaaS Upgrade
+run-name: Enterprise SaaS · ${{ inputs.tag }} · Registry upgrade
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing matching OSS and EE tag (vX.Y.Z)
+        required: true
+        type: string
+      upgrade_test:
+        description: Upgrade the official TEST environment
+        required: true
+        default: true
+        type: boolean
+      upgrade_prod:
+        description: Upgrade the official PROD environment
+        required: true
+        default: true
+        type: boolean
+
+concurrency:
+  # The existing Release Pipeline already owns this group. Reusing its literal
+  # name serializes same-version pushes without changing that workflow.
+  group: ${{ format('hyperfilelens-package-{0}', inputs.tag) }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  REGISTRY_HOST: ${{ vars.REGISTRY_HOST }}
+  REGISTRY_NAMESPACE: ${{ vars.REGISTRY_NAMESPACE }}
+  REGISTRY_PREFIX: ${{ format('{0}/{1}', vars.REGISTRY_HOST, vars.REGISTRY_NAMESPACE) }}
+  CN_REGISTRY_HOST: ${{ vars.CN_REGISTRY_HOST }}
+  CN_REGISTRY_NAMESPACE: ${{ vars.CN_REGISTRY_NAMESPACE }}
+  CN_REGISTRY_PREFIX: ${{ format('{0}/{1}', vars.CN_REGISTRY_HOST, vars.CN_REGISTRY_NAMESPACE) }}
+
+jobs:
+  prepare:
+    name: Prepare · Enterprise candidate
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    outputs:
+      version: ${{ steps.source.outputs.version }}
+      image_version: ${{ steps.source.outputs.image_version }}
+      release_tag: ${{ steps.source.outputs.release_tag }}
+      commit: ${{ steps.source.outputs.commit }}
+      enterprise_commit: ${{ steps.enterprise.outputs.commit }}
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ inputs.tag }}
+      - name: Validate source and registries
+        id: source
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+          REGISTRY_USERNAME: ${{ secrets.REGISTRY_USERNAME }}
+          REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
+          CN_REGISTRY_USERNAME: ${{ secrets.CN_REGISTRY_USERNAME }}
+          CN_REGISTRY_PASSWORD: ${{ secrets.CN_REGISTRY_PASSWORD }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$GITHUB_REF" == "refs/heads/main" ]]
+          [[ "$RELEASE_TAG" =~ ^v([0-9]+\.[0-9]+\.[0-9]+)$ ]]
+          version="${BASH_REMATCH[1]}"
+          commit="$(git rev-parse --verify "${RELEASE_TAG}^{commit}")"
+          git fetch origin main --no-tags
+          git merge-base --is-ancestor "$commit" origin/main
+          for contract in \
+            deploy/installer/install.sh \
+            release/ci/assemble-saas-candidate.sh \
+            release/ci/prepare-saas-asset-context.sh; do
+            [[ -f "$contract" ]] || {
+              echo "Tag $RELEASE_TAG predates the Enterprise SaaS delivery contract: $contract" >&2
+              exit 1
+            }
+          done
+          [[ "$REGISTRY_HOST" =~ ^[a-z0-9][a-z0-9.-]*(:[0-9]+)?$ ]]
+          [[ "$CN_REGISTRY_HOST" =~ ^[a-z0-9][a-z0-9.-]*(:[0-9]+)?$ ]]
+          for namespace in "$REGISTRY_NAMESPACE" "$CN_REGISTRY_NAMESPACE"; do
+            [[ "$namespace" =~ ^[a-z0-9][a-z0-9._/-]*$ && "$namespace" != */ && "$namespace" != *//* ]]
+          done
+          for credential in \
+            REGISTRY_USERNAME REGISTRY_PASSWORD \
+            CN_REGISTRY_USERNAME CN_REGISTRY_PASSWORD; do
+            [[ -n "${!credential}" ]] || {
+              echo "Required repository secret is empty: $credential" >&2
+              exit 1
+            }
+          done
+          {
+            echo "version=$version"
+            echo "image_version=${version}-ee"
+            echo "release_tag=$RELEASE_TAG"
+            echo "commit=$commit"
+          } >>"$GITHUB_OUTPUT"
+      - name: Validate matching Enterprise tag
+        id: enterprise
+        env:
+          ENTERPRISE_EXTENSION_REPOSITORY: ${{ vars.ENTERPRISE_EXTENSION_REPOSITORY }}
+          HFL_EXTENSION_GIT_TOKEN: ${{ secrets.ENTERPRISE_EXTENSION_GIT_TOKEN }}
+          RELEASE_TAG: ${{ inputs.tag }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$ENTERPRISE_EXTENSION_REPOSITORY" =~ ^https://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+(\.git)?$ ]]
+          commit="$(python3 - "$ENTERPRISE_EXTENSION_REPOSITORY" "$RELEASE_TAG" <<'PY'
+          import re, subprocess, sys
+          from tools.extensions.materialize_extensions import _git_env
+          repository, tag = sys.argv[1:]
+          result = subprocess.run(
+              ["git", "ls-remote", "--exit-code", repository, f"refs/tags/{tag}", f"refs/tags/{tag}^{{}}"],
+              check=True, env=_git_env(repository, require_https_auth=True),
+              stdout=subprocess.PIPE, text=True,
+          )
+          refs = dict(line.split("\t", 1)[::-1] for line in result.stdout.splitlines())
+          commit = refs.get(f"refs/tags/{tag}^{{}}") or refs.get(f"refs/tags/{tag}")
+          if not commit or not re.fullmatch(r"[0-9a-f]{40}", commit):
+              raise SystemExit("Enterprise tag did not resolve to one commit")
+          print(commit)
+          PY
+          )"
+          echo "commit=$commit" >>"$GITHUB_OUTPUT"
+
+  quality:
+    name: Verify · SaaS delivery contracts
+    needs: prepare
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          persist-credentials: false
+          ref: ${{ needs.prepare.outputs.commit }}
+      - name: Validate shell and release contracts
+        run: |
+          bash -n \
+            deploy/installer/install.sh \
+            release/build-sourcelens.sh \
+            release/ci/assemble-saas-candidate.sh \
+            release/ci/mirror-saas-image.sh \
+            release/ci/prepare-saas-asset-context.sh \
+            release/ci/write-saas-image-metadata.sh \
+            .github/scripts/remote-saas-deploy.sh \
+            .github/scripts/reconcile-saas-ai-model.sh
+          ./tools/quality/check-release-contracts.sh
+          ./tools/quality/test-saas-registry-delivery.sh
+
+  build-hfl-images:
+    name: Build · HFL · ${{ matrix.name }}
+    needs: [prepare, quality]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: backend
+            component: hfl-backend
+            repository: hyperfilelens-backend
+            dockerfile: deploy/docker/backend.Dockerfile
+            needs_kopia: true
+          - name: frontend
+            component: hfl-frontend
+            repository: hyperfilelens-frontend
+            dockerfile: deploy/docker/frontend.Dockerfile
+            needs_kopia: false
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          persist-credentials: false
+          ref: ${{ needs.prepare.outputs.commit }}
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        if: matrix.needs_kopia
+        with:
+          go-version-file: src/agent/go.mod
+          cache: false
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ${{ env.REGISTRY_HOST }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ${{ env.CN_REGISTRY_HOST }}
+          username: ${{ secrets.CN_REGISTRY_USERNAME }}
+          password: ${{ secrets.CN_REGISTRY_PASSWORD }}
+      - name: Prepare pinned Kopia binary
+        if: matrix.needs_kopia
+        run: ./tools/kopia/prepare.sh --matrix linux:amd64
+      - name: Prepare Website artifact
+        if: matrix.component == 'hfl-frontend'
+        run: >-
+          ./website/build.sh --output build/website
+          --image-tag "hyperfilelens-website-builder:${GITHUB_RUN_ID}"
+          --platform linux/amd64
+      - name: Materialize Enterprise Extension
+        env:
+          RELEASE_TAG: ${{ needs.prepare.outputs.release_tag }}
+          ENTERPRISE_COMMIT: ${{ needs.prepare.outputs.enterprise_commit }}
+          ENTERPRISE_EXTENSION_REPOSITORY: ${{ vars.ENTERPRISE_EXTENSION_REPOSITORY }}
+          HFL_EXTENSION_GIT_TOKEN: ${{ secrets.ENTERPRISE_EXTENSION_GIT_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          extensions="$(HFL_EXTENSION_GIT_TOKEN="$HFL_EXTENSION_GIT_TOKEN" \
+            python3 tools/extensions/materialize_extensions.py \
+              --repo-root . \
+              --sources "${ENTERPRISE_EXTENSION_REPOSITORY}@${RELEASE_TAG}" \
+              --expected-commit "$ENTERPRISE_COMMIT" \
+              --bake-dir build/release/extensions \
+              --print-extensions)"
+          echo "HFL_EXTENSIONS=$extensions" >>"$GITHUB_ENV"
+      - name: Build and publish global image
+        id: build
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          platforms: linux/amd64
+          push: true
+          provenance: false
+          tags: ${{ env.REGISTRY_PREFIX }}/${{ matrix.repository }}:${{ needs.prepare.outputs.image_version }}
+          build-args: |
+            KOPIA_BINARY=build/kopia/dist/linux/amd64/kopia
+            IMAGE_VERSION=${{ needs.prepare.outputs.image_version }}
+            IMAGE_REVISION=${{ needs.prepare.outputs.commit }}
+            PIP_TIMEOUT=600
+            SENTRY_URL=${{ vars.SENTRY_URL }}
+            SENTRY_ORG=${{ vars.SENTRY_ORG }}
+            SENTRY_FRONTEND_PROJECT=${{ vars.SENTRY_FRONTEND_PROJECT }}
+            SENTRY_RELEASE=hyperfilelens-frontend@${{ needs.prepare.outputs.image_version }}
+            VITE_SHOW_EULA=false
+            HFL_EXTENSIONS=${{ env.HFL_EXTENSIONS }}
+          secrets: ${{ matrix.component == 'hfl-frontend' && secrets.SENTRY_AUTH_TOKEN != '' && format('sentry_auth_token={0}', secrets.SENTRY_AUTH_TOKEN) || '' }}
+          cache-from: type=gha,scope=saas-${{ matrix.component }}
+          cache-to: type=gha,scope=saas-${{ matrix.component }},mode=min
+      - name: Mirror immutable image to CN
+        run: |
+          ./release/ci/mirror-saas-image.sh \
+            "$REGISTRY_PREFIX/${{ matrix.repository }}:${{ needs.prepare.outputs.image_version }}" \
+            "${{ steps.build.outputs.digest }}" \
+            "$CN_REGISTRY_PREFIX/${{ matrix.repository }}:${{ needs.prepare.outputs.image_version }}"
+      - name: Record immutable metadata
+        run: |
+          ./release/ci/write-saas-image-metadata.sh \
+            "${{ matrix.component }}" \
+            "$REGISTRY_PREFIX/${{ matrix.repository }}:${{ needs.prepare.outputs.image_version }}" \
+            "$CN_REGISTRY_PREFIX/${{ matrix.repository }}:${{ needs.prepare.outputs.image_version }}" \
+            "${{ steps.build.outputs.digest }}" \
+            "${{ matrix.repository }}:${{ needs.prepare.outputs.image_version }}" \
+            hyperfilelens \
+            "${{ matrix.component }}.json"
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: saas-metadata-${{ matrix.component }}
+          path: ${{ matrix.component }}.json
+          retention-days: 3
+
+  build-sourcelens-images:
+    name: Build · SourceLens · ${{ matrix.component }}
+    needs: [prepare, quality]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        component: [backend, frontend, lensnode]
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          persist-credentials: false
+          ref: ${{ needs.prepare.outputs.commit }}
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ${{ env.REGISTRY_HOST }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ${{ env.CN_REGISTRY_HOST }}
+          username: ${{ secrets.CN_REGISTRY_USERNAME }}
+          password: ${{ secrets.CN_REGISTRY_PASSWORD }}
+      - name: Build global image
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          SENTRY_URL: ${{ vars.SENTRY_URL }}
+          SENTRY_ORG: ${{ vars.SENTRY_ORG }}
+          SENTRY_FRONTEND_PROJECT: ${{ vars.SENTRY_FRONTEND_PROJECT }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        run: >-
+          ./release/ci/build-sourcelens-image.sh
+          "${{ matrix.component }}" "$REGISTRY_PREFIX"
+          "${{ needs.prepare.outputs.version }}" source.json
+      - name: Mirror to CN and normalize metadata
+        shell: bash
+        run: |
+          set -euo pipefail
+          global_ref="$(jq -r '.ref' source.json)"
+          digest="$(jq -r '.digest' source.json)"
+          tag="${global_ref##*:}"
+          repository="hyperfilelens-sourcelens-${{ matrix.component }}"
+          cn_ref="$CN_REGISTRY_PREFIX/$repository:$tag"
+          ./release/ci/mirror-saas-image.sh "$global_ref" "$digest" "$cn_ref"
+          ./release/ci/write-saas-image-metadata.sh \
+            "sourcelens-${{ matrix.component }}" "$global_ref" "$cn_ref" "$digest" \
+            "$repository:$tag" "sourcelens-${{ matrix.component }}" \
+            "sourcelens-${{ matrix.component }}.json"
+          jq -s '.[0] * .[1]' source.json "sourcelens-${{ matrix.component }}.json" \
+            > merged.json
+          mv merged.json "sourcelens-${{ matrix.component }}.json"
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: saas-metadata-sourcelens-${{ matrix.component }}
+          path: sourcelens-${{ matrix.component }}.json
+          retention-days: 3
+
+  publish-runtime-images:
+    name: Publish · Runtime · ${{ matrix.component }}
+    needs: [prepare, quality]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - component: postgres
+            repository: hyperfilelens-postgres
+            tag: "17"
+            role: shared
+          - component: redis
+            repository: hyperfilelens-redis
+            tag: alpine
+            role: shared
+          - component: sourcelens-nginx
+            repository: hyperfilelens-sourcelens-nginx
+            tag: stable-alpine
+            role: sourcelens-nginx
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          persist-credentials: false
+          ref: ${{ needs.prepare.outputs.commit }}
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ${{ env.REGISTRY_HOST }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ${{ env.CN_REGISTRY_HOST }}
+          username: ${{ secrets.CN_REGISTRY_USERNAME }}
+          password: ${{ secrets.CN_REGISTRY_PASSWORD }}
+      - name: Publish pinned runtime image
+        shell: bash
+        run: |
+          set -euo pipefail
+          source tools/dependencies/versions/runtime-images.env
+          case "${{ matrix.component }}" in
+            postgres) source_image="$POSTGRES_IMAGE" ;;
+            redis) source_image="$REDIS_IMAGE" ;;
+            sourcelens-nginx) source_image="$NGINX_IMAGE" ;;
+          esac
+          digest="$source_image"
+          digest="${digest##*@}"
+          global_ref="$REGISTRY_PREFIX/${{ matrix.repository }}:${{ matrix.tag }}"
+          cn_ref="$CN_REGISTRY_PREFIX/${{ matrix.repository }}:${{ matrix.tag }}"
+          docker buildx imagetools create --prefer-index=false --tag "$global_ref" "$source_image"
+          ./release/ci/mirror-saas-image.sh "$global_ref" "$digest" "$cn_ref"
+          ./release/ci/write-saas-image-metadata.sh \
+            "${{ matrix.component }}" "$global_ref" "$cn_ref" "$digest" \
+            "${{ matrix.repository }}:${{ matrix.tag }}" "${{ matrix.role }}" \
+            "${{ matrix.component }}.json"
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: saas-metadata-${{ matrix.component }}
+          path: ${{ matrix.component }}.json
+          retention-days: 3
+
+  build-agent-assets:
+    name: Build · Agent asset · ${{ matrix.asset }}
+    needs: [prepare, quality]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: linux:amd64
+            asset: linux-amd64
+          - target: linux:arm64
+            asset: linux-arm64
+          - target: darwin:amd64
+            asset: darwin-amd64
+          - target: darwin:arm64
+            asset: darwin-arm64
+          - target: windows:amd64
+            asset: windows-amd64
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          persist-credentials: false
+          ref: ${{ needs.prepare.outputs.commit }}
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version-file: src/agent/go.mod
+          cache-dependency-path: src/agent/go.sum
+      - name: Build Agent bundle
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          APT_MIRROR: ${{ vars.CI_UBUNTU_APT_MIRROR }}
+        run: >-
+          ./release/ci/build-agent-asset.sh "${{ matrix.target }}"
+          "${{ needs.prepare.outputs.version }}" "${{ needs.prepare.outputs.commit }}"
+          "_internal-agent-${{ matrix.asset }}.tar"
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: saas-agent-${{ matrix.asset }}
+          path: _internal-agent-${{ matrix.asset }}.tar
+          compression-level: 0
+          retention-days: 3
+
+  build-host-assets:
+    name: Build · Gateway dependencies · Ubuntu ${{ matrix.release }}
+    needs: [prepare, quality]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - release: "20.04"
+            asset: ubuntu2004
+          - release: "22.04"
+            asset: ubuntu2204
+          - release: "24.04"
+            asset: ubuntu2404
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          persist-credentials: false
+          ref: ${{ needs.prepare.outputs.commit }}
+      - name: Build and verify Docker dependency bundle
+        env:
+          APT_MIRROR: ${{ vars.CI_UBUNTU_APT_MIRROR }}
+        run: |
+          ./release/ci/build-host-debs-asset.sh \
+            "${{ matrix.release }}" "_internal-host-debs-${{ matrix.asset }}.tar"
+          ./release/ci/verify-host-debs-asset.sh \
+            "${{ matrix.release }}" "_internal-host-debs-${{ matrix.asset }}.tar"
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: saas-host-${{ matrix.asset }}
+          path: _internal-host-debs-${{ matrix.asset }}.tar
+          compression-level: 0
+          retention-days: 3
+
+  build-language-assets:
+    name: Build · Language assets
+    needs: [prepare, quality]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          persist-credentials: false
+          ref: ${{ needs.prepare.outputs.commit }}
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: src/frontend/package-lock.json
+      - run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends gettext
+          npm ci --prefix src/frontend
+          ./language-packs/tooling/build-all.sh --version "${{ needs.prepare.outputs.version }}"
+          mkdir -p build/language-bundle/payload/language-packs
+          cp build/language-packs/dist/*.tar.gz build/language-bundle/payload/language-packs/
+          tar -cf _internal-language-packs.tar -C build/language-bundle payload
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: saas-language-packs
+          path: _internal-language-packs.tar
+          compression-level: 0
+          retention-days: 3
+
+  publish-asset-images:
+    name: Publish · ${{ matrix.kind }} assets
+    needs:
+      - prepare
+      - build-sourcelens-images
+      - build-agent-assets
+      - build-host-assets
+      - build-language-assets
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        kind: [agent, gateway, language]
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          persist-credentials: false
+          ref: ${{ needs.prepare.outputs.commit }}
+      - name: Download Agent assets
+        if: matrix.kind == 'agent'
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          pattern: saas-agent-*
+          path: build/saas-input
+          merge-multiple: true
+      - name: Download Gateway host assets
+        if: matrix.kind == 'gateway'
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          pattern: saas-host-*
+          path: build/saas-input
+          merge-multiple: true
+      - name: Download Gateway LensNode metadata
+        if: matrix.kind == 'gateway'
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: saas-metadata-sourcelens-lensnode
+          path: build/saas-input
+      - name: Download language assets
+        if: matrix.kind == 'language'
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: saas-language-packs
+          path: build/saas-input
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ${{ env.REGISTRY_HOST }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ${{ env.CN_REGISTRY_HOST }}
+          username: ${{ secrets.CN_REGISTRY_USERNAME }}
+          password: ${{ secrets.CN_REGISTRY_PASSWORD }}
+      - name: Prepare asset image context
+        run: >-
+          ./release/ci/prepare-saas-asset-context.sh "${{ matrix.kind }}"
+          build/saas-input "${{ needs.prepare.outputs.version }}"
+          "build/saas-${{ matrix.kind }}"
+      - name: Build and publish global asset image
+        id: build
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: build/saas-${{ matrix.kind }}
+          platforms: linux/amd64
+          push: true
+          provenance: false
+          tags: ${{ env.REGISTRY_PREFIX }}/hyperfilelens-${{ matrix.kind }}-assets:${{ needs.prepare.outputs.image_version }}
+      - name: Mirror immutable asset image to CN
+        run: |
+          ./release/ci/mirror-saas-image.sh \
+            "$REGISTRY_PREFIX/hyperfilelens-${{ matrix.kind }}-assets:${{ needs.prepare.outputs.image_version }}" \
+            "${{ steps.build.outputs.digest }}" \
+            "$CN_REGISTRY_PREFIX/hyperfilelens-${{ matrix.kind }}-assets:${{ needs.prepare.outputs.image_version }}"
+      - name: Record asset metadata
+        shell: bash
+        run: |
+          ./release/ci/write-saas-image-metadata.sh \
+            "${{ matrix.kind }}-assets" \
+            "$REGISTRY_PREFIX/hyperfilelens-${{ matrix.kind }}-assets:${{ needs.prepare.outputs.image_version }}" \
+            "$CN_REGISTRY_PREFIX/hyperfilelens-${{ matrix.kind }}-assets:${{ needs.prepare.outputs.image_version }}" \
+            "${{ steps.build.outputs.digest }}" \
+            "hyperfilelens-${{ matrix.kind }}-assets:${{ needs.prepare.outputs.image_version }}" \
+            "${{ matrix.kind }}-assets" \
+            "${{ matrix.kind }}-assets.json"
+          jq --arg kind "${{ matrix.kind }}" '. + {asset_kind: $kind}' \
+            "${{ matrix.kind }}-assets.json" > metadata.json
+          mv metadata.json "${{ matrix.kind }}-assets.json"
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: saas-metadata-${{ matrix.kind }}-assets
+          path: ${{ matrix.kind }}-assets.json
+          retention-days: 3
+
+  assemble-candidate:
+    name: Assemble · Registry candidate
+    needs:
+      - prepare
+      - build-hfl-images
+      - build-sourcelens-images
+      - publish-runtime-images
+      - publish-asset-images
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          persist-credentials: false
+          ref: ${{ needs.prepare.outputs.commit }}
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          pattern: saas-metadata-*
+          path: build/saas-metadata
+          merge-multiple: true
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ${{ env.REGISTRY_HOST }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+      - name: Resolve Enterprise Extension name
+        env:
+          RELEASE_TAG: ${{ needs.prepare.outputs.release_tag }}
+          ENTERPRISE_COMMIT: ${{ needs.prepare.outputs.enterprise_commit }}
+          ENTERPRISE_EXTENSION_REPOSITORY: ${{ vars.ENTERPRISE_EXTENSION_REPOSITORY }}
+          HFL_EXTENSION_GIT_TOKEN: ${{ secrets.ENTERPRISE_EXTENSION_GIT_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          extensions="$(HFL_EXTENSION_GIT_TOKEN="$HFL_EXTENSION_GIT_TOKEN" \
+            python3 tools/extensions/materialize_extensions.py \
+              --repo-root . \
+              --sources "${ENTERPRISE_EXTENSION_REPOSITORY}@${RELEASE_TAG}" \
+              --expected-commit "$ENTERPRISE_COMMIT" \
+              --bake-dir build/release/extensions-candidate \
+              --print-extensions)"
+          echo "HFL_EXTENSIONS=$extensions" >>"$GITHUB_ENV"
+      - name: Assemble thin Candidate
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p build/saas-candidate
+          ./release/ci/assemble-saas-candidate.sh \
+            build/saas-metadata \
+            "${{ needs.prepare.outputs.version }}" \
+            "${{ needs.prepare.outputs.commit }}" \
+            "${{ needs.prepare.outputs.enterprise_commit }}" \
+            "$HFL_EXTENSIONS" \
+            build/saas-candidate/candidate.tar.gz
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: enterprise-saas-${{ needs.prepare.outputs.version }}
+          path: |
+            build/saas-candidate/candidate.tar.gz
+            build/saas-candidate/candidate.tar.gz.sha256
+          compression-level: 0
+          retention-days: 3
+
+  deploy-test:
+    name: Deploy · TEST
+    if: ${{ inputs.upgrade_test }}
+    needs: [prepare, assemble-candidate]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 120
+    concurrency:
+      group: hyperfilelens-deploy-test
+      cancel-in-progress: false
+    env:
+      DEPLOY_TARGET: test
+      DEPLOY_SSH_HOST: ${{ vars.TEST_SSH_HOST }}
+      DEPLOY_SSH_PORT: ${{ vars.TEST_SSH_PORT }}
+      DEPLOY_SSH_USER: ${{ vars.TEST_SSH_USER }}
+      DEPLOY_SSH_KNOWN_HOSTS: ${{ vars.TEST_SSH_KNOWN_HOSTS }}
+      DEPLOY_SSH_PRIVATE_KEY: ${{ secrets.TEST_SSH_PRIVATE_KEY }}
+      REGISTRY_HOST: ${{ vars.REGISTRY_HOST }}
+      REGISTRY_USERNAME: ${{ secrets.REGISTRY_USERNAME }}
+      REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
+      CN_REGISTRY_HOST: ${{ vars.CN_REGISTRY_HOST }}
+      CN_REGISTRY_USERNAME: ${{ secrets.CN_REGISTRY_USERNAME }}
+      CN_REGISTRY_PASSWORD: ${{ secrets.CN_REGISTRY_PASSWORD }}
+      HFL_INSECURE_TLS: ${{ vars.TEST_HFL_INSECURE_TLS }}
+      HFL_PLATFORM_GATEWAY_AUTO_DEPLOY: ${{ vars.TEST_PLATFORM_GATEWAY_AUTO_DEPLOY }}
+      HFL_EMAIL_SIGNUP_ENABLED: ${{ vars.TEST_EMAIL_SIGNUP_ENABLED }}
+      HFL_EMAIL_CODE_LOGIN_ENABLED: ${{ vars.TEST_EMAIL_CODE_LOGIN_ENABLED }}
+      HFL_GOOGLE_OAUTH_ENABLED: ${{ vars.TEST_GOOGLE_OAUTH_ENABLED }}
+      HFL_GA_MEASUREMENT_ID: ""
+      SENTRY_ENABLED: ${{ vars.TEST_SENTRY_ENABLED }}
+      SENTRY_BACKEND_DSN: ${{ secrets.SENTRY_BACKEND_DSN }}
+      SENTRY_FRONTEND_DSN: ${{ secrets.SENTRY_FRONTEND_DSN }}
+      TURNSTILE_ENABLED: ${{ vars.TEST_TURNSTILE_ENABLED }}
+      TURNSTILE_SITE_KEY: ${{ vars.TEST_TURNSTILE_SITE_KEY }}
+      TURNSTILE_SECRET_KEY: ${{ secrets.TEST_TURNSTILE_SECRET_KEY }}
+      SMTP_HOST: ${{ vars.TEST_SMTP_HOST }}
+      SMTP_PORT: ${{ vars.TEST_SMTP_PORT }}
+      SMTP_USERNAME: ${{ vars.TEST_SMTP_USERNAME }}
+      SMTP_PASSWORD: ${{ secrets.TEST_SMTP_PASSWORD }}
+      SMTP_SECURITY: ${{ vars.TEST_SMTP_SECURITY }}
+      EMAIL_FROM: ${{ vars.TEST_EMAIL_FROM }}
+      GOOGLE_CLIENT_ID: ${{ vars.TEST_GOOGLE_CLIENT_ID }}
+      GOOGLE_CLIENT_SECRET: ${{ secrets.TEST_GOOGLE_CLIENT_SECRET }}
+      AI_MODEL_PROVIDER: ${{ vars.TEST_AI_MODEL_PROVIDER }}
+      AI_MODEL_ID: ${{ vars.TEST_AI_MODEL_ID }}
+      AI_MODEL_DISPLAY_NAME: ${{ vars.TEST_AI_MODEL_DISPLAY_NAME }}
+      AI_MULTIMODAL_MODEL_PROVIDER: ${{ vars.TEST_AI_MULTIMODAL_MODEL_PROVIDER }}
+      AI_MULTIMODAL_MODEL_ID: ${{ vars.TEST_AI_MULTIMODAL_MODEL_ID }}
+      AI_MULTIMODAL_MODEL_DISPLAY_NAME: ${{ vars.TEST_AI_MULTIMODAL_MODEL_DISPLAY_NAME }}
+      AI_MODEL_API_BASE: ${{ secrets.TEST_AI_MODEL_API_BASE }}
+      AI_MODEL_API_KEY: ${{ secrets.TEST_AI_MODEL_API_KEY }}
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          persist-credentials: false
+          ref: ${{ needs.prepare.outputs.commit }}
+      - uses: ./.github/actions/deploy-saas
+        with:
+          target: test
+          tag: ${{ needs.prepare.outputs.release_tag }}
+          artifact_name: enterprise-saas-${{ needs.prepare.outputs.version }}
+          public_url: ${{ vars.TEST_PUBLIC_URL }}
+          admin_public_url: ${{ vars.TEST_ADMIN_PUBLIC_URL }}
+
+  deploy-prod:
+    name: Deploy · PROD
+    if: ${{ inputs.upgrade_prod }}
+    needs: [prepare, assemble-candidate]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 120
+    concurrency:
+      group: hyperfilelens-deploy-prod
+      cancel-in-progress: false
+    env:
+      DEPLOY_TARGET: prod
+      DEPLOY_SSH_HOST: ${{ vars.PROD_SSH_HOST }}
+      DEPLOY_SSH_PORT: ${{ vars.PROD_SSH_PORT }}
+      DEPLOY_SSH_USER: ${{ vars.PROD_SSH_USER }}
+      DEPLOY_SSH_KNOWN_HOSTS: ${{ vars.PROD_SSH_KNOWN_HOSTS }}
+      DEPLOY_SSH_PRIVATE_KEY: ${{ secrets.PROD_SSH_PRIVATE_KEY }}
+      REGISTRY_HOST: ${{ vars.REGISTRY_HOST }}
+      REGISTRY_USERNAME: ${{ secrets.REGISTRY_USERNAME }}
+      REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
+      CN_REGISTRY_HOST: ${{ vars.CN_REGISTRY_HOST }}
+      CN_REGISTRY_USERNAME: ${{ secrets.CN_REGISTRY_USERNAME }}
+      CN_REGISTRY_PASSWORD: ${{ secrets.CN_REGISTRY_PASSWORD }}
+      HFL_INSECURE_TLS: ${{ vars.PROD_HFL_INSECURE_TLS }}
+      HFL_PLATFORM_GATEWAY_AUTO_DEPLOY: ${{ vars.PROD_PLATFORM_GATEWAY_AUTO_DEPLOY }}
+      HFL_EMAIL_SIGNUP_ENABLED: ${{ vars.PROD_EMAIL_SIGNUP_ENABLED }}
+      HFL_EMAIL_CODE_LOGIN_ENABLED: ${{ vars.PROD_EMAIL_CODE_LOGIN_ENABLED }}
+      HFL_GOOGLE_OAUTH_ENABLED: ${{ vars.PROD_GOOGLE_OAUTH_ENABLED }}
+      HFL_GA_MEASUREMENT_ID: ${{ vars.PROD_GA_MEASUREMENT_ID }}
+      SENTRY_ENABLED: ${{ vars.PROD_SENTRY_ENABLED }}
+      SENTRY_BACKEND_DSN: ${{ secrets.SENTRY_BACKEND_DSN }}
+      SENTRY_FRONTEND_DSN: ${{ secrets.SENTRY_FRONTEND_DSN }}
+      TURNSTILE_ENABLED: ${{ vars.PROD_TURNSTILE_ENABLED }}
+      TURNSTILE_SITE_KEY: ${{ vars.PROD_TURNSTILE_SITE_KEY }}
+      TURNSTILE_SECRET_KEY: ${{ secrets.PROD_TURNSTILE_SECRET_KEY }}
+      SMTP_HOST: ${{ vars.PROD_SMTP_HOST }}
+      SMTP_PORT: ${{ vars.PROD_SMTP_PORT }}
+      SMTP_USERNAME: ${{ vars.PROD_SMTP_USERNAME }}
+      SMTP_PASSWORD: ${{ secrets.PROD_SMTP_PASSWORD }}
+      SMTP_SECURITY: ${{ vars.PROD_SMTP_SECURITY }}
+      EMAIL_FROM: ${{ vars.PROD_EMAIL_FROM }}
+      GOOGLE_CLIENT_ID: ${{ vars.PROD_GOOGLE_CLIENT_ID }}
+      GOOGLE_CLIENT_SECRET: ${{ secrets.PROD_GOOGLE_CLIENT_SECRET }}
+      AI_MODEL_PROVIDER: ${{ vars.PROD_AI_MODEL_PROVIDER }}
+      AI_MODEL_ID: ${{ vars.PROD_AI_MODEL_ID }}
+      AI_MODEL_DISPLAY_NAME: ${{ vars.PROD_AI_MODEL_DISPLAY_NAME }}
+      AI_MULTIMODAL_MODEL_PROVIDER: ${{ vars.PROD_AI_MULTIMODAL_MODEL_PROVIDER }}
+      AI_MULTIMODAL_MODEL_ID: ${{ vars.PROD_AI_MULTIMODAL_MODEL_ID }}
+      AI_MULTIMODAL_MODEL_DISPLAY_NAME: ${{ vars.PROD_AI_MULTIMODAL_MODEL_DISPLAY_NAME }}
+      AI_MODEL_API_BASE: ${{ secrets.PROD_AI_MODEL_API_BASE }}
+      AI_MODEL_API_KEY: ${{ secrets.PROD_AI_MODEL_API_KEY }}
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          persist-credentials: false
+          ref: ${{ needs.prepare.outputs.commit }}
+      - uses: ./.github/actions/deploy-saas
+        with:
+          target: prod
+          tag: ${{ needs.prepare.outputs.release_tag }}
+          artifact_name: enterprise-saas-${{ needs.prepare.outputs.version }}
+          public_url: ${{ vars.PROD_PUBLIC_URL }}
+          admin_public_url: ${{ vars.PROD_ADMIN_PUBLIC_URL }}

--- a/deploy/installer/install.sh
+++ b/deploy/installer/install.sh
@@ -1629,6 +1629,18 @@ print(str(manifest.get("edition") or "community").strip())
 PY
 }
 
+read_delivery_mode_from_dir() {
+	local dir=$1
+	python3 - "${dir}/MANIFEST.json" <<'PY'
+import json
+import pathlib
+import sys
+
+manifest = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+print(str((manifest.get("delivery") or {}).get("mode") or "offline").strip())
+PY
+}
+
 display_edition_from_dir() {
 	local edition
 	edition="$(read_edition_from_dir "$1" | tr '[:upper:]' '[:lower:]')"
@@ -1670,6 +1682,8 @@ image_version = str(manifest.get("image_version") or version_file).strip()
 extension_commit = str(manifest.get("extension_commit") or "").strip().lower()
 runtime_images = manifest.get("runtime_images") or {}
 minimum_upgrade_version = str(manifest.get("minimum_upgrade_version") or "").strip()
+delivery = manifest.get("delivery") or {"mode": "offline"}
+delivery_mode = str(delivery.get("mode") or "offline").strip()
 
 if not re.fullmatch(r"[0-9a-f]{40}", commit):
     raise SystemExit("release manifest has an invalid git_commit")
@@ -1700,6 +1714,8 @@ if minimum_upgrade_version and not re.fullmatch(
     raise SystemExit("release package has an invalid minimum_upgrade_version")
 if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}", image_version):
     raise SystemExit("release package has an invalid image_version")
+if delivery_mode not in {"offline", "registry"}:
+    raise SystemExit("release package has an invalid delivery mode")
 if not runtime_images:
     runtime_images = {
         "backend": f"hyperfilelens-backend:{image_version}",
@@ -1724,6 +1740,84 @@ for role, ref in runtime_images.items():
         raise SystemExit(
             f"release package runtime image is absent from the HFL archive: {role}"
         )
+if delivery_mode == "registry":
+    registry_images = delivery.get("registry_images") or []
+    if not registry_images:
+        raise SystemExit("registry delivery has no runtime images")
+    declared_digests = {}
+    for entry in manifest.get("images", []):
+        refs = [str(ref) for ref in (entry.get("refs") or [])]
+        digests = [str(digest) for digest in (entry.get("digests") or [])]
+        if len(refs) != len(digests):
+            raise SystemExit("registry delivery image refs and digests are incomplete")
+        for ref, digest in zip(refs, digests):
+            if ref in declared_digests:
+                raise SystemExit(f"registry delivery has a duplicate declared image ref: {ref}")
+            if not re.fullmatch(r"sha256:[0-9a-f]{64}", digest):
+                raise SystemExit(f"registry delivery has an invalid declared digest for {ref}")
+            declared_digests[ref] = digest
+    declared_refs = set(declared_digests)
+    seen_refs = set()
+    for image in registry_images:
+        role = str(image.get("role") or "")
+        local_ref = str(image.get("local_ref") or "")
+        digest = str(image.get("digest") or "")
+        sources = image.get("sources") or []
+        if not re.fullmatch(r"[a-z0-9][a-z0-9-]*", role):
+            raise SystemExit("registry delivery has an invalid image role")
+        if not re.fullmatch(
+            r"hyperfilelens-[a-z0-9-]+:[A-Za-z0-9][A-Za-z0-9._-]{0,127}",
+            local_ref,
+        ):
+            raise SystemExit(f"registry delivery has an invalid local image ref: {local_ref}")
+        if local_ref not in declared_refs or local_ref in seen_refs:
+            raise SystemExit(f"registry delivery has an undeclared or duplicate image ref: {local_ref}")
+        seen_refs.add(local_ref)
+        if not re.fullmatch(r"sha256:[0-9a-f]{64}", digest):
+            raise SystemExit(f"registry delivery has an invalid digest for {local_ref}")
+        if declared_digests[local_ref] != digest:
+            raise SystemExit(f"registry delivery digest differs for {local_ref}")
+        if not sources:
+            raise SystemExit(f"registry delivery has no source for {local_ref}")
+        for source in sources:
+            ref = str(source.get("ref") or "")
+            if not re.fullmatch(
+                r"[a-z0-9][a-z0-9.-]*(?::[0-9]+)?/[a-z0-9._/-]+:[A-Za-z0-9][A-Za-z0-9._-]{0,127}",
+                ref,
+            ):
+                raise SystemExit(f"registry delivery has an invalid source ref: {ref}")
+    if seen_refs != declared_refs:
+        missing = sorted(declared_refs - seen_refs)
+        raise SystemExit(
+            "registry delivery has no source metadata for: " + ", ".join(missing)
+        )
+    asset_images = delivery.get("asset_images") or []
+    if len(asset_images) != 3:
+        raise SystemExit("registry delivery must declare three asset images")
+    asset_kinds = set()
+    for image in asset_images:
+        kind = str(image.get("asset_kind") or "")
+        local_ref = str(image.get("local_ref") or "")
+        digest = str(image.get("digest") or "")
+        sources = image.get("sources") or []
+        if kind not in {"agent", "gateway", "language"} or kind in asset_kinds:
+            raise SystemExit("registry delivery has an invalid asset kind")
+        asset_kinds.add(kind)
+        if not re.fullmatch(
+            rf"hyperfilelens-{kind}-assets:[A-Za-z0-9][A-Za-z0-9._-]{{0,127}}",
+            local_ref,
+        ):
+            raise SystemExit("registry delivery has an invalid asset image ref")
+        if not re.fullmatch(r"sha256:[0-9a-f]{64}", digest):
+            raise SystemExit("registry delivery has an invalid asset image digest")
+        if len(sources) != 2 or any(
+            not re.fullmatch(
+                r"[a-z0-9][a-z0-9.-]*(?::[0-9]+)?/[a-z0-9._/-]+:[A-Za-z0-9][A-Za-z0-9._-]{0,127}",
+                str(source.get("ref") or ""),
+            )
+            for source in sources
+        ):
+            raise SystemExit("registry delivery has invalid asset image sources")
 if edition == "enterprise":
     if not re.fullmatch(r"[0-9a-f]{40}", extension_commit):
         raise SystemExit("Enterprise release package has an invalid extension_commit")
@@ -2114,6 +2208,7 @@ apply_runtime_configuration() {
 
 preflight_package_layout() {
 	local require_blue_green=${1:-1}
+	local delivery_mode
 	step "Checking release package layout..."
 	[[ -f "${ROOT}/MANIFEST.json" ]] || die "missing MANIFEST.json"
 	[[ -f "${ROOT}/docker-compose.yml" ]] || die "missing docker-compose.yml"
@@ -2124,9 +2219,14 @@ preflight_package_layout() {
 		[[ -f "${ROOT}/deploy/blue-green/active-color" ]] \
 			|| die "missing blue/green initial state"
 	fi
-	[[ -f "${ROOT}/images/00-hyperfilelens.tar.gz" ]] || die "missing HFL image archive"
-	[[ -f "${ROOT}/images/01-postgres-17.tar.gz" ]] || die "missing PostgreSQL image archive"
-	[[ -f "${ROOT}/images/02-redis-alpine.tar.gz" ]] || die "missing Redis image archive"
+	delivery_mode="$(read_delivery_mode_from_dir "${ROOT}")"
+	if [[ "${delivery_mode}" == "offline" ]]; then
+		[[ -f "${ROOT}/images/00-hyperfilelens.tar.gz" ]] || die "missing HFL image archive"
+		[[ -f "${ROOT}/images/01-postgres-17.tar.gz" ]] || die "missing PostgreSQL image archive"
+		[[ -f "${ROOT}/images/02-redis-alpine.tar.gz" ]] || die "missing Redis image archive"
+	elif [[ "${delivery_mode}" != "registry" ]]; then
+		die "unsupported release delivery mode: ${delivery_mode}"
+	fi
 	validate_package_identity "${ROOT}"
 	log "Release package check passed"
 }
@@ -2246,6 +2346,8 @@ root = pathlib.Path(sys.argv[1])
 skip_sourcelens = sys.argv[2] == "1"
 with (root / "MANIFEST.json").open(encoding="utf-8") as fh:
     manifest = json.load(fh)
+delivery = manifest.get("delivery") or {"mode": "offline"}
+delivery_mode = str(delivery.get("mode") or "offline")
 
 
 def sha256_file(path: pathlib.Path) -> str:
@@ -2273,6 +2375,88 @@ def inspect_image(ref: str) -> dict:
     if not isinstance(inspected, list) or len(inspected) != 1:
         return {}
     return inspected[0] if isinstance(inspected[0], dict) else {}
+
+
+def verify_revision(ref: str, role: str) -> None:
+    if not role.startswith("hyperfilelens"):
+        return
+    expected_revision = str(manifest.get("git_commit", "")).strip()
+    if not expected_revision:
+        raise SystemExit("release manifest has no git_commit")
+    config = inspect_image(ref).get("Config") or {}
+    labels = config.get("Labels") or {}
+    actual_revision = str(labels.get("org.opencontainers.image.revision", ""))
+    if actual_revision != expected_revision:
+        raise SystemExit(
+            f"image {ref} revision {actual_revision or '<missing>'} "
+            f"does not match release {expected_revision}"
+        )
+
+
+def has_expected_digest(ref: str, digest: str) -> bool:
+    inspected = inspect_image(ref)
+    repo_digests = inspected.get("RepoDigests") or []
+    return any(
+        isinstance(value, str) and value.rsplit("@", 1)[-1] == digest
+        for value in repo_digests
+    )
+
+
+if delivery_mode == "registry":
+    registry_images = [
+        image
+        for image in (delivery.get("registry_images") or [])
+        if not (
+            skip_sourcelens
+            and str(image.get("role", "")).startswith("sourcelens")
+        )
+    ]
+    for index, image in enumerate(registry_images, start=1):
+        local_ref = str(image.get("local_ref") or "")
+        digest = str(image.get("digest") or "")
+        sources = image.get("sources") or []
+        pulled = ""
+        errors = []
+        print(
+            f"[....] Resolving registry image ({index}/{len(registry_images)}): "
+            f"{local_ref}@{digest}"
+        )
+        if has_expected_digest(local_ref, digest):
+            verify_revision(local_ref, str(image.get("role") or ""))
+            print(f"[ OK ] Reusing registry image: {local_ref}@{digest}")
+            continue
+        for source in sources:
+            source_ref = str(source.get("ref") or "")
+            repository = source_ref.rsplit(":", 1)[0]
+            immutable_ref = f"{repository}@{digest}"
+            completed = subprocess.run(
+                ["docker", "pull", "--platform", "linux/amd64", immutable_ref],
+                check=False,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+            )
+            if completed.returncode == 0:
+                pulled = immutable_ref
+                break
+            errors.append(f"{immutable_ref}: {completed.stdout.strip()[-500:]}")
+        if not pulled:
+            print(
+                f"[install.sh] ERROR: no registry source could provide {local_ref}",
+                file=sys.stderr,
+            )
+            for error in errors:
+                print(f"  - {error}", file=sys.stderr)
+            raise SystemExit(1)
+        subprocess.run(["docker", "tag", pulled, local_ref], check=True)
+        if not has_expected_digest(local_ref, digest):
+            raise SystemExit(f"registry image digest was not retained locally: {local_ref}")
+        verify_revision(local_ref, str(image.get("role") or ""))
+        print(f"[ OK ] Verified registry image: {local_ref}@{digest}")
+    print(f"[ OK ] Processed {len(registry_images)} registry image(s)")
+    raise SystemExit(0)
+if delivery_mode != "offline":
+    raise SystemExit(f"unsupported release delivery mode: {delivery_mode}")
 
 entries = [
     entry
@@ -2304,21 +2488,8 @@ for index, entry in enumerate(entries, start=1):
         )
         sys.exit(1)
     if entry.get("role") == "hyperfilelens":
-        expected_revision = str(manifest.get("git_commit", "")).strip()
-        if not expected_revision:
-            print("[install.sh] ERROR: release manifest has no git_commit", file=sys.stderr)
-            sys.exit(1)
         for ref in refs:
-            config = inspect_image(ref).get("Config") or {}
-            labels = config.get("Labels") or {}
-            actual_revision = str(labels.get("org.opencontainers.image.revision", ""))
-            if actual_revision != expected_revision:
-                print(
-                    f"[install.sh] ERROR: image {ref} revision {actual_revision or '<missing>'} "
-                    f"does not match release {expected_revision}",
-                    file=sys.stderr,
-                )
-                sys.exit(1)
+            verify_revision(ref, "hyperfilelens")
     print(f"[ OK ] Verified image references: {', '.join(refs)}")
 print(f"[ OK ] Processed {len(entries)} container image archive(s)")
 PY
@@ -2877,6 +3048,9 @@ managed_repositories = {
     "hyperfilelens-sourcelens-backend",
     "hyperfilelens-sourcelens-frontend",
     "hyperfilelens-sourcelens-lensnode",
+    "hyperfilelens-agent-assets",
+    "hyperfilelens-gateway-assets",
+    "hyperfilelens-language-assets",
 }
 protected = set()
 for raw in sys.argv[1:3]:
@@ -2889,6 +3063,11 @@ for raw in sys.argv[1:3]:
         continue
     for image in manifest.get("images", []):
         protected.update(str(ref) for ref in image.get("refs", []) if ref)
+    delivery = manifest.get("delivery") or {}
+    for image in delivery.get("asset_images") or []:
+        local_ref = str(image.get("local_ref") or "")
+        if local_ref:
+            protected.add(local_ref)
 
 gateway_version = sys.argv[3]
 if re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}", gateway_version):
@@ -3083,11 +3262,18 @@ import sys
 with open(f"{sys.argv[1]}/MANIFEST.json", encoding="utf-8") as fh:
     manifest = json.load(fh)
 seen = set()
-for entry in manifest.get("images", []):
+entries = list(manifest.get("images", []))
+entries.extend(
+    {"refs": [entry.get("local_ref", "")]}
+    for entry in (manifest.get("delivery") or {}).get("asset_images", [])
+)
+for entry in entries:
     if str(entry.get("role", "")).startswith("sourcelens"):
         continue
     for ref in entry.get("refs", []):
         tag = ref.split("@", 1)[0]
+        if not tag:
+            continue
         if tag in seen:
             continue
         seen.add(tag)
@@ -3523,6 +3709,7 @@ PY
 
 preflight_sourcelens_bundle() {
 	local src_root=$1
+	local delivery_mode
 	step "Checking SourceLens bundle in upgrade package ..."
 	local -a runtime_files=(
 		sourcelens/BUILD_INFO.json
@@ -3541,14 +3728,19 @@ preflight_sourcelens_bundle() {
 	for rel in "${runtime_files[@]}"; do
 		[[ -f "${src_root}/${rel}" ]] || die "missing ${rel}"
 	done
-	local -a images=(
-		images/10-sourcelens-app.tar.gz
-		images/11-sourcelens-lensnode.tar.gz
-		images/12-nginx-stable-alpine.tar.gz
-	)
-	for rel in "${images[@]}"; do
-		[[ -f "${src_root}/${rel}" ]] || die "missing SourceLens image archive ${rel}"
-	done
+	delivery_mode="$(read_delivery_mode_from_dir "${src_root}")"
+	if [[ "${delivery_mode}" == "offline" ]]; then
+		local -a images=(
+			images/10-sourcelens-app.tar.gz
+			images/11-sourcelens-lensnode.tar.gz
+			images/12-nginx-stable-alpine.tar.gz
+		)
+		for rel in "${images[@]}"; do
+			[[ -f "${src_root}/${rel}" ]] || die "missing SourceLens image archive ${rel}"
+		done
+	elif [[ "${delivery_mode}" != "registry" ]]; then
+		die "unsupported SourceLens delivery mode: ${delivery_mode}"
+	fi
 	log "SourceLens bundle check passed"
 }
 

--- a/release/build-sourcelens.sh
+++ b/release/build-sourcelens.sh
@@ -20,6 +20,7 @@ FORCE_PULL=0
 NO_CACHE=0
 FORCE_BUILD="${SOURCELENS_FORCE_BUILD:-0}"
 PREBUILT=0
+RUNTIME_ONLY=0
 LOG_FILE="${HFL_LOG_FILE:-}"
 VERBOSE="${HFL_LOG_VERBOSE:-0}"
 PRINT_CONFIG=0
@@ -40,6 +41,7 @@ Usage: ./release/build-sourcelens.sh --pkg-root DIR --images-dir DIR [options]
   --no-cache           Rebuild SourceLens Docker layers without BuildKit cache
   --force-build        Rebuild SourceLens images even when the build stamp matches
   --prebuilt           Package normalized images already loaded in Docker
+  --runtime-only       Stage runtime configuration without image archives or Gateway payload
   --sourcelens-git-url URL  Override SOURCELENS_GIT_URL
   --sourcelens-ref REF      SourceLens release tag in vX.Y.Z form
   --github-download-mirror URL  GitHub Git mirror with official fallback
@@ -75,6 +77,7 @@ force_build=${FORCE_BUILD}
 force_pull=${FORCE_PULL}
 no_cache=${NO_CACHE}
 prebuilt=${PREBUILT}
+runtime_only=${RUNTIME_ONLY}
 github_download_mirror=${GITHUB_DOWNLOAD_MIRROR:-<official>}
 github_fallback_timeout=${SOURCELENS_GIT_FALLBACK_TIMEOUT_SECONDS}
 github_token=$(hfl_redact "${GITHUB_TOKEN:-}")
@@ -118,6 +121,10 @@ parse_args() {
 			;;
 		--prebuilt)
 			PREBUILT=1
+			shift
+			;;
+		--runtime-only)
+			RUNTIME_ONLY=1
 			shift
 			;;
 		--sourcelens-git-url | --git-url)
@@ -398,10 +405,14 @@ main() {
 	else
 		sourcelens_build_app_images "${FORCE_BUILD}" "${NO_CACHE}"
 	fi
-	sourcelens_ensure_nginx_image "${FORCE_PULL}"
-	save_image_archives
+	if [[ "${RUNTIME_ONLY}" -eq 0 ]]; then
+		sourcelens_ensure_nginx_image "${FORCE_PULL}"
+		save_image_archives
+	fi
 	stage_runtime_tree
-	publish_gateway_lensnode_bundle
+	if [[ "${RUNTIME_ONLY}" -eq 0 ]]; then
+		publish_gateway_lensnode_bundle
+	fi
 	log "SourceLens bundle staged under ${PKG_ROOT}/sourcelens"
 }
 

--- a/release/ci/assemble-saas-candidate.sh
+++ b/release/ci/assemble-saas-candidate.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+# Assemble the small registry-backed package consumed by the installed HFL upgrader.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+# shellcheck source=../build.sh
+source "${ROOT}/release/build.sh"
+# shellcheck source=../../tools/dependencies/versions/runtime-images.env
+source "${ROOT}/tools/dependencies/versions/runtime-images.env"
+
+[[ $# -eq 6 ]] || {
+	printf 'Usage: %s METADATA_DIR VERSION OSS_COMMIT EE_COMMIT EXTENSIONS OUTPUT\n' "$0" >&2
+	exit 2
+}
+
+metadata_dir=$1
+version=${2#v}
+oss_commit=$3
+ee_commit=$4
+extensions=$5
+output=$6
+[[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
+[[ "${oss_commit}" =~ ^[0-9a-f]{40}$ && "${ee_commit}" =~ ^[0-9a-f]{40}$ ]]
+[[ "${extensions}" =~ ^[a-z0-9_]+(,[a-z0-9_]+)*$ ]]
+
+for component in \
+	hfl-backend hfl-frontend \
+	sourcelens-backend sourcelens-frontend sourcelens-lensnode sourcelens-nginx \
+	postgres redis; do
+	[[ -s "${metadata_dir}/${component}.json" ]] || {
+		printf 'ERROR: missing SaaS image metadata: %s\n' "${component}" >&2
+		exit 1
+	}
+done
+for asset in agent gateway language; do
+	[[ -s "${metadata_dir}/${asset}-assets.json" ]] || {
+		printf 'ERROR: missing SaaS asset metadata: %s\n' "${asset}" >&2
+		exit 1
+	}
+done
+
+pkg_name="hyperfilelens-${version}-ee-saas"
+pkg_root="${ROOT}/build/release/staging/${pkg_name}"
+images_dir="${pkg_root}/images"
+safe_assert_staging_pkg_root "${pkg_root}" "${ROOT}/build/release/staging"
+safe_rm_dir "${pkg_root}"
+mkdir -p \
+	"${images_dir}" \
+	"${pkg_root}/payload/media" \
+	"${pkg_root}/payload/language-packs" \
+	"${pkg_root}/deploy/nginx/certs" \
+	"${pkg_root}/deploy/nginx/snippets" \
+	"${pkg_root}/deploy/blue-green" \
+	"${pkg_root}/deploy/logrotate"
+
+pull_and_tag() {
+	local metadata=$1 source_ref digest local_ref immutable_ref
+	source_ref="$(jq -r '.sources[] | select(.region == "global") | .ref' "${metadata}")"
+	digest="$(jq -r '.digest' "${metadata}")"
+	local_ref="$(jq -r '.local_ref' "${metadata}")"
+	immutable_ref="${source_ref%:*}@${digest}"
+	docker pull --platform linux/amd64 "${immutable_ref}"
+	docker tag "${immutable_ref}" "${local_ref}"
+}
+
+for component in sourcelens-backend sourcelens-frontend sourcelens-lensnode; do
+	pull_and_tag "${metadata_dir}/${component}.json"
+done
+docker pull --platform linux/amd64 "${NGINX_IMAGE}"
+docker tag "${NGINX_IMAGE}" nginx:stable-alpine
+
+export SOURCELENS_HFL_VERSION="${version}"
+BUILD_SOURCELENS=1 "${ROOT}/release/build-sourcelens.sh" \
+	--pkg-root "${pkg_root}" \
+	--images-dir "${images_dir}" \
+	--prebuilt \
+	--runtime-only
+
+printf '%s\n' "${version}" >"${pkg_root}/VERSION"
+cp "${ROOT}/deploy/docker-compose.yml" "${pkg_root}/docker-compose.yml"
+HFL_RELEASE_EDITION=enterprise \
+	HFL_IMAGE_VERSION="${version}-ee" \
+	HFL_VERSION="${version}" \
+	HFL_EXTENSIONS_RUNTIME="${extensions}" \
+	stage_release_env_example "${pkg_root}"
+stage_default_tls_bundle "${pkg_root}"
+cp "${ROOT}/deploy/nginx/default.conf" "${pkg_root}/deploy/nginx/default.conf"
+cp "${ROOT}/deploy/nginx/web.conf" "${pkg_root}/deploy/nginx/web.conf"
+rsync -a "${ROOT}/deploy/nginx/snippets/" "${pkg_root}/deploy/nginx/snippets/"
+cp "${ROOT}/deploy/blue-green/active-color" "${pkg_root}/deploy/blue-green/active-color"
+cp "${ROOT}/deploy/logrotate/hyperfilelens.conf" "${pkg_root}/deploy/logrotate/hyperfilelens.conf"
+cp "${ROOT}/deploy/installer/install.sh" "${pkg_root}/install.sh"
+cp "${ROOT}/deploy/installer/apply-runtime-config.py" "${pkg_root}/apply-runtime-config.py"
+cp "${ROOT}/tools/config/sync_env.py" "${pkg_root}/sync-env.py"
+cp "${ROOT}/LICENSE" "${pkg_root}/LICENSE"
+chmod 755 "${pkg_root}/install.sh" "${pkg_root}/apply-runtime-config.py" "${pkg_root}/sync-env.py"
+
+python3 - "${pkg_root}" "${metadata_dir}" "${version}" "${oss_commit}" "${ee_commit}" <<'PY'
+import datetime
+import json
+import pathlib
+import sys
+
+root = pathlib.Path(sys.argv[1])
+metadata_dir = pathlib.Path(sys.argv[2])
+version, oss_commit, ee_commit = sys.argv[3:6]
+
+
+def read(name: str) -> dict:
+    return json.loads((metadata_dir / f"{name}.json").read_text(encoding="utf-8"))
+
+
+runtime = [
+    read("hfl-backend"),
+    read("hfl-frontend"),
+    read("sourcelens-backend"),
+    read("sourcelens-frontend"),
+    read("sourcelens-lensnode"),
+    read("sourcelens-nginx"),
+    read("postgres"),
+    read("redis"),
+]
+assets = [read("agent-assets"), read("gateway-assets"), read("language-assets")]
+by_component = {entry["component"]: entry for entry in runtime}
+images = [
+    {
+        "role": "hyperfilelens",
+        "refs": [
+            by_component["hfl-backend"]["local_ref"],
+            by_component["hfl-frontend"]["local_ref"],
+        ],
+        "digests": [
+            by_component["hfl-backend"]["digest"],
+            by_component["hfl-frontend"]["digest"],
+        ],
+    },
+    *[
+        {
+            "role": entry["role"],
+            "refs": [entry["local_ref"]],
+            "digests": [entry["digest"]],
+        }
+        for entry in runtime
+        if entry["component"].startswith("sourcelens-")
+    ],
+    *[
+        {
+            "role": entry["role"],
+            "refs": [entry["local_ref"]],
+            "digests": [entry["digest"]],
+        }
+        for entry in runtime
+        if entry["component"] in {"postgres", "redis"}
+    ],
+]
+sourcelens = json.loads((root / "sourcelens/BUILD_INFO.json").read_text(encoding="utf-8"))
+manifest = {
+    "schema_version": 3,
+    "product": "hyperfilelens",
+    "edition": "enterprise",
+    "channel": "release",
+    "artifact_id": f"v{version}",
+    "version": version,
+    "image_version": f"{version}-ee",
+    "built_at": datetime.datetime.now(datetime.UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+    "minimum_upgrade_version": "0.1.34",
+    "git_commit": oss_commit,
+    "extension_commit": ee_commit,
+    "runtime_images": {
+        "backend": by_component["hfl-backend"]["local_ref"],
+        "frontend": by_component["hfl-frontend"]["local_ref"],
+    },
+    "host_runtime": {
+        "os_id": "ubuntu",
+        "os_versions": ["20.04", "22.04", "24.04"],
+        "arch": "amd64",
+        "docker": {"min_engine_version": "24.0.0", "min_compose_version": "2.20.0"},
+    },
+    "sourcelens": sourcelens,
+    "images": images,
+    "delivery": {
+        "mode": "registry",
+        "registry_images": runtime,
+        "asset_images": assets,
+    },
+    "artifacts": {"agent_version": version},
+}
+(root / "MANIFEST.json").write_text(
+    json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+)
+PY
+
+normalize_release_permissions "${pkg_root}"
+mkdir -p "$(dirname "${output}")"
+tar_tmp="${output}.part"
+rm -f "${tar_tmp}"
+tar_create_gz "${tar_tmp}" "$(dirname "${pkg_root}")" "${pkg_name}"
+mv "${tar_tmp}" "${output}"
+sha256sum "${output}" >"${output}.sha256"

--- a/release/ci/mirror-saas-image.sh
+++ b/release/ci/mirror-saas-image.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Copy an immutable image manifest to the secondary registry and verify its digest.
+set -euo pipefail
+
+[[ $# -eq 3 ]] || {
+	printf 'Usage: %s SOURCE_REF DIGEST DESTINATION_REF\n' "$0" >&2
+	exit 2
+}
+
+source_ref=$1
+digest=$2
+destination_ref=$3
+[[ "${source_ref}" == */*:* && "${destination_ref}" == */*:* ]]
+[[ "${digest}" =~ ^sha256:[0-9a-f]{64}$ ]]
+
+source_repository=${source_ref%:*}
+docker buildx imagetools create \
+	--prefer-index=false \
+	--tag "${destination_ref}" \
+	"${source_repository}@${digest}"
+
+manifest_json="$(docker buildx imagetools inspect \
+	"${destination_ref}" --format '{{json .Manifest}}')"
+destination_digest="$(jq -r '.digest // empty' <<<"${manifest_json}")"
+[[ "${destination_digest}" == "${digest}" ]] || {
+	printf 'ERROR: mirrored digest mismatch: source=%s destination=%s\n' \
+		"${digest}" "${destination_digest:-missing}" >&2
+	exit 1
+}

--- a/release/ci/prepare-saas-asset-context.sh
+++ b/release/ci/prepare-saas-asset-context.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# Merge CI bundles into one minimal Docker build context used only as an asset carrier.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+[[ $# -eq 4 ]] || {
+	printf 'Usage: %s agent|gateway|language INPUT_DIR VERSION OUTPUT_DIR\n' "$0" >&2
+	exit 2
+}
+
+kind=$1
+input_dir=$2
+version=${3#v}
+output_dir=$4
+[[ "${kind}" =~ ^(agent|gateway|language)$ ]]
+[[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
+[[ -d "${input_dir}" ]]
+rm -rf -- "${output_dir}"
+asset_root="${output_dir}/rootfs/opt/hyperfilelens-assets"
+mkdir -p "${asset_root}"
+
+extract_matching() {
+	local pattern=$1 matched=0 archive
+	while IFS= read -r archive; do
+		[[ -n "${archive}" ]] || continue
+		matched=1
+		tar -xf "${archive}" -C "${asset_root}"
+	done < <(find "${input_dir}" -type f -name "${pattern}" -print | sort)
+	[[ "${matched}" -eq 1 ]] || {
+		printf 'ERROR: no input matched %s\n' "${pattern}" >&2
+		exit 1
+	}
+}
+
+case "${kind}" in
+agent)
+	extract_matching '_internal-agent-*.tar'
+	[[ -d "${asset_root}/payload/media/agent-releases/${version}" ]]
+	[[ -d "${asset_root}/payload/media/enroll-bootstrap/${version}" ]]
+	python3 - "${asset_root}/payload/media/enroll-bootstrap" "${version}" <<'PY'
+import hashlib
+import json
+import pathlib
+import re
+import sys
+
+root = pathlib.Path(sys.argv[1])
+version = sys.argv[2]
+artifacts = {}
+pattern = re.compile(r"^hfl-installer-(linux|darwin|windows)-(amd64|arm64)\.(tar\.gz|zip)$")
+for path in sorted((root / version).glob("hfl-installer-*")):
+    match = pattern.fullmatch(path.name)
+    if match is None:
+        continue
+    platform, arch, _ = match.groups()
+    artifacts[f"{platform}-{arch}"] = {
+        "filename": f"{version}/{path.name}",
+        "sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
+        "size": path.stat().st_size,
+    }
+expected = {"linux-amd64", "linux-arm64", "darwin-amd64", "darwin-arm64", "windows-amd64"}
+if set(artifacts) != expected:
+    raise SystemExit(f"minimal installer matrix mismatch: {sorted(artifacts)}")
+(root / "INSTALLER_MANIFEST.json").write_text(
+    json.dumps({"schema_version": 1, "artifacts": artifacts}, indent=2, sort_keys=True) + "\n",
+    encoding="utf-8",
+)
+PY
+	;;
+gateway)
+	extract_matching '_internal-host-debs-*.tar'
+	gateway_dir="${asset_root}/payload/media/gateway-bootstrap"
+	mkdir -p "${gateway_dir}"
+	for script in \
+		gateway-bootstrap-linux.sh \
+		gateway-install-lensnode-sidecar.sh \
+		gateway-lifecycle.sh \
+		gateway-install-docker-ubuntu-amd64.sh; do
+		cp "${ROOT}/deploy/bootstrap/${script}" "${gateway_dir}/${script}"
+		chmod 755 "${gateway_dir}/${script}"
+	done
+	cp "${ROOT}/deploy/installer/sourcelens/hfl-sentry-sitecustomize.py" \
+		"${gateway_dir}/hfl-sentry-sitecustomize.py"
+	metadata="$(find "${input_dir}" -type f -name 'sourcelens-lensnode.json' -print -quit)"
+	[[ -s "${metadata}" ]]
+	ref="$(jq -r '.sources[] | select(.region == "global") | .ref' "${metadata}")"
+	digest="$(jq -r '.digest' "${metadata}")"
+	immutable_ref="${ref%:*}@${digest}"
+	docker pull --platform linux/amd64 "${immutable_ref}"
+	docker tag "${immutable_ref}" hyperfilelens-sourcelens-lensnode:latest
+	docker tag "${immutable_ref}" sourcelens-lensnode:latest
+	partial="${gateway_dir}/lensnode-image-linux-amd64.tar.gz.part"
+	# The Gateway bundle uses stable local aliases. Omitting the HFL-versioned
+	# runtime tag keeps this large layer reusable while the SourceLens image is unchanged.
+	docker save hyperfilelens-sourcelens-lensnode:latest sourcelens-lensnode:latest \
+		| gzip -1 -n >"${partial}"
+	mv "${partial}" "${gateway_dir}/lensnode-image-linux-amd64.tar.gz"
+	;;
+language)
+	extract_matching '_internal-language-packs.tar'
+	compgen -G "${asset_root}/payload/language-packs/hyperfilelens-lang-*-${version}.tar.gz" >/dev/null
+	;;
+esac
+
+if find "${asset_root}" -type l -print -quit | grep -q .; then
+	printf 'ERROR: SaaS asset context contains symbolic links\n' >&2
+	exit 1
+fi
+printf '%s\n' "${kind}" >"${asset_root}/.asset-kind"
+case "${kind}" in
+agent)
+	cat >"${output_dir}/Dockerfile" <<'DOCKERFILE'
+FROM scratch
+COPY rootfs/opt/hyperfilelens-assets/payload/media/agent-releases /opt/hyperfilelens-assets/payload/media/agent-releases
+COPY rootfs/opt/hyperfilelens-assets/payload/media/enroll-bootstrap /opt/hyperfilelens-assets/payload/media/enroll-bootstrap
+COPY rootfs/opt/hyperfilelens-assets/.asset-kind /opt/hyperfilelens-assets/.asset-kind
+DOCKERFILE
+	;;
+gateway)
+	cat >"${output_dir}/Dockerfile" <<'DOCKERFILE'
+FROM scratch
+COPY rootfs/opt/hyperfilelens-assets/payload/media/gateway-bootstrap/docker-debs-ubuntu2004-amd64.tar.gz /opt/hyperfilelens-assets/payload/media/gateway-bootstrap/docker-debs-ubuntu2004-amd64.tar.gz
+COPY rootfs/opt/hyperfilelens-assets/payload/media/gateway-bootstrap/docker-debs-ubuntu2204-amd64.tar.gz /opt/hyperfilelens-assets/payload/media/gateway-bootstrap/docker-debs-ubuntu2204-amd64.tar.gz
+COPY rootfs/opt/hyperfilelens-assets/payload/media/gateway-bootstrap/docker-debs-ubuntu2404-amd64.tar.gz /opt/hyperfilelens-assets/payload/media/gateway-bootstrap/docker-debs-ubuntu2404-amd64.tar.gz
+COPY rootfs/opt/hyperfilelens-assets/payload/media/gateway-bootstrap/lensnode-image-linux-amd64.tar.gz /opt/hyperfilelens-assets/payload/media/gateway-bootstrap/lensnode-image-linux-amd64.tar.gz
+COPY rootfs/opt/hyperfilelens-assets/payload/media/gateway-bootstrap/gateway-bootstrap-linux.sh /opt/hyperfilelens-assets/payload/media/gateway-bootstrap/gateway-bootstrap-linux.sh
+COPY rootfs/opt/hyperfilelens-assets/payload/media/gateway-bootstrap/gateway-install-lensnode-sidecar.sh /opt/hyperfilelens-assets/payload/media/gateway-bootstrap/gateway-install-lensnode-sidecar.sh
+COPY rootfs/opt/hyperfilelens-assets/payload/media/gateway-bootstrap/gateway-lifecycle.sh /opt/hyperfilelens-assets/payload/media/gateway-bootstrap/gateway-lifecycle.sh
+COPY rootfs/opt/hyperfilelens-assets/payload/media/gateway-bootstrap/gateway-install-docker-ubuntu-amd64.sh /opt/hyperfilelens-assets/payload/media/gateway-bootstrap/gateway-install-docker-ubuntu-amd64.sh
+COPY rootfs/opt/hyperfilelens-assets/payload/media/gateway-bootstrap/hfl-sentry-sitecustomize.py /opt/hyperfilelens-assets/payload/media/gateway-bootstrap/hfl-sentry-sitecustomize.py
+COPY rootfs/opt/hyperfilelens-assets/.asset-kind /opt/hyperfilelens-assets/.asset-kind
+DOCKERFILE
+	;;
+language)
+	cat >"${output_dir}/Dockerfile" <<'DOCKERFILE'
+FROM scratch
+COPY rootfs/opt/hyperfilelens-assets/payload/language-packs /opt/hyperfilelens-assets/payload/language-packs
+COPY rootfs/opt/hyperfilelens-assets/.asset-kind /opt/hyperfilelens-assets/.asset-kind
+DOCKERFILE
+	;;
+esac

--- a/release/ci/write-saas-image-metadata.sh
+++ b/release/ci/write-saas-image-metadata.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Record one image published under the same version tag in global and CN registries.
+set -euo pipefail
+
+[[ $# -eq 7 ]] || {
+	printf 'Usage: %s COMPONENT GLOBAL_REF CN_REF DIGEST LOCAL_REF ROLE OUTPUT\n' "$0" >&2
+	exit 2
+}
+
+component=$1
+global_ref=$2
+cn_ref=$3
+digest=$4
+local_ref=$5
+role=$6
+output=$7
+
+[[ "${component}" =~ ^[a-z0-9][a-z0-9-]*$ ]]
+[[ "${role}" =~ ^[a-z0-9][a-z0-9-]*$ ]]
+[[ "${global_ref}" == */*:* && "${cn_ref}" == */*:* ]]
+[[ "${local_ref}" =~ ^hyperfilelens-[a-z0-9-]+:[A-Za-z0-9][A-Za-z0-9._-]{0,127}$ ]]
+[[ "${digest}" =~ ^sha256:[0-9a-f]{64}$ ]]
+
+mkdir -p "$(dirname "${output}")"
+jq -n \
+	--arg component "${component}" \
+	--arg role "${role}" \
+	--arg local_ref "${local_ref}" \
+	--arg digest "${digest}" \
+	--arg global_ref "${global_ref}" \
+	--arg cn_ref "${cn_ref}" \
+	'{
+	  component: $component,
+	  role: $role,
+	  local_ref: $local_ref,
+	  digest: $digest,
+	  platform: "linux/amd64",
+	  sources: [
+	    {region: "cn", ref: $cn_ref},
+	    {region: "global", ref: $global_ref}
+	  ]
+	}' >"${output}"

--- a/tools/quality/test-saas-registry-delivery.sh
+++ b/tools/quality/test-saas-registry-delivery.sh
@@ -1,0 +1,320 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+tmp="$(mktemp -d)"
+trap 'rm -rf "${tmp}"' EXIT
+
+digest="sha256:$(printf 'a%.0s' {1..64})"
+"${ROOT}/release/ci/write-saas-image-metadata.sh" \
+	hfl-backend \
+	docker.io/example/hyperfilelens-backend:1.0.0-ee \
+	registry.example.cn/example/hyperfilelens-backend:1.0.0-ee \
+	"${digest}" \
+	hyperfilelens-backend:1.0.0-ee \
+	hyperfilelens \
+	"${tmp}/metadata.json"
+
+jq -e \
+	--arg digest "${digest}" \
+	'.digest == $digest
+	 and .local_ref == "hyperfilelens-backend:1.0.0-ee"
+	 and [.sources[].region] == ["cn", "global"]' \
+	"${tmp}/metadata.json" >/dev/null
+
+grep -Fq 'delivery_mode == "registry"' "${ROOT}/deploy/installer/install.sh"
+grep -Fq -- '--runtime-only' "${ROOT}/release/build-sourcelens.sh"
+grep -Fq 'group: hyperfilelens-deploy-test' \
+	"${ROOT}/.github/workflows/enterprise_saas_upgrade.yml"
+grep -Fq 'group: hyperfilelens-deploy-prod' \
+	"${ROOT}/.github/workflows/enterprise_saas_upgrade.yml"
+grep -Fq 'using: composite' "${ROOT}/.github/actions/deploy-saas/action.yml"
+grep -Fq 'registry_login_count > 0' \
+	"${ROOT}/.github/scripts/remote-saas-deploy.sh"
+grep -Fq 'platform-gateway verify --required --timeout 0' \
+	"${ROOT}/.github/actions/deploy-saas/action.yml"
+grep -Fq 'reconcile-saas-ai-model.sh agent' \
+	"${ROOT}/.github/actions/deploy-saas/action.yml"
+grep -Fq "'HFL_AI_MODEL_APPLIED=false'" \
+	"${ROOT}/.github/scripts/reconcile-saas-ai-model.sh"
+grep -Fq 'TEST_AI_MULTIMODAL_MODEL_PROVIDER' \
+	"${ROOT}/.github/workflows/enterprise_saas_upgrade.yml"
+grep -Fq 'PROD_AI_MODEL_API_KEY' \
+	"${ROOT}/.github/workflows/enterprise_saas_upgrade.yml"
+grep -Fq 'Required repository secret is empty' \
+	"${ROOT}/.github/workflows/enterprise_saas_upgrade.yml"
+for deploy_job in deploy-test deploy-prod; do
+	job_definition="$(awk -v job="${deploy_job}" '
+		$0 == "  " job ":" {inside = 1; next}
+		inside && /^  [a-z0-9-]+:/ {exit}
+		inside {print}
+	' "${ROOT}/.github/workflows/enterprise_saas_upgrade.yml")"
+	# shellcheck disable=SC2016 # GitHub expression is an intentional literal.
+	grep -Fq 'ref: ${{ needs.prepare.outputs.commit }}' <<<"${job_definition}"
+done
+grep -Fq "format('hyperfilelens-package-{0}', inputs.tag)" \
+	"${ROOT}/.github/workflows/enterprise_saas_upgrade.yml"
+
+package_root="${tmp}/candidate"
+fake_bin="${tmp}/bin"
+tag_marker="${tmp}/tagged"
+pull_marker="${tmp}/pulls"
+mkdir -p "${package_root}" "${fake_bin}"
+revision="$(printf 'b%.0s' {1..40})"
+python3 - "${package_root}/MANIFEST.json" "${digest}" "${revision}" <<'PY'
+import json, pathlib, sys
+path, digest, revision = sys.argv[1:]
+pathlib.Path(path).write_text(json.dumps({
+    "git_commit": revision,
+    "delivery": {
+        "mode": "registry",
+        "registry_images": [{
+            "role": "hyperfilelens",
+            "local_ref": "hyperfilelens-backend:1.0.0-ee",
+            "digest": digest,
+            "sources": [
+                {"region": "cn", "ref": "registry.example.cn/example/hyperfilelens-backend:1.0.0-ee"},
+                {"region": "global", "ref": "docker.io/example/hyperfilelens-backend:1.0.0-ee"},
+            ],
+        }],
+    },
+}), encoding="utf-8")
+PY
+
+cat >"${fake_bin}/docker" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+case "${1:-} ${2:-}" in
+"buildx imagetools")
+	case "${3:-}" in
+	create)
+		[[ "$*" == *"${HFL_TEST_DIGEST}"* ]]
+		;;
+	inspect)
+		printf '{"digest":"%s"}\n' "${HFL_TEST_DIGEST}"
+		;;
+	*) exit 2 ;;
+	esac
+	;;
+"pull --platform")
+	ref="${4:-}"
+	printf '%s\n' "${ref}" >>"${HFL_TEST_PULL_MARKER}"
+	[[ "${ref}" == registry.example.cn/* ]] && exit 1
+	[[ "${ref}" == docker.io/example/hyperfilelens-backend@sha256:* ]]
+	printf 'pulled %s\n' "${ref}"
+	;;
+"tag docker.io/example/hyperfilelens-backend@sha256"*)
+	: >"${HFL_TEST_TAG_MARKER}"
+	;;
+"image inspect")
+	[[ -f "${HFL_TEST_TAG_MARKER}" ]] || exit 1
+	printf '[{"RepoDigests":["docker.io/example/hyperfilelens-backend@%s"],"Config":{"Labels":{"org.opencontainers.image.revision":"%s"}}}]\n' \
+		"${HFL_TEST_DIGEST}" "${HFL_TEST_REVISION}"
+	;;
+*)
+	printf 'unexpected fake docker invocation: %s\n' "$*" >&2
+	exit 2
+	;;
+esac
+SH
+chmod 755 "${fake_bin}/docker"
+cat >"${fake_bin}/ssh" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+cat >/dev/null
+case "${HFL_TEST_AI_RESULT:-passed}" in
+passed)
+	printf 'HFL_AI_MODEL_APPLIED=true\nHFL_AI_MODEL_CONNECTIVITY=passed\n'
+	;;
+rejected)
+	printf 'HFL_AI_MODEL_APPLIED=false\n'
+	;;
+command-failed)
+	exit 1
+	;;
+*) exit 2 ;;
+esac
+SH
+chmod 755 "${fake_bin}/ssh"
+export HFL_TEST_TAG_MARKER="${tag_marker}"
+export HFL_TEST_PULL_MARKER="${pull_marker}"
+export HFL_TEST_REVISION="${revision}"
+export HFL_TEST_DIGEST="${digest}"
+export PATH="${fake_bin}:${PATH}"
+"${ROOT}/release/ci/mirror-saas-image.sh" \
+	docker.io/example/hyperfilelens-backend:1.0.0-ee \
+	"${digest}" \
+	registry.example.cn/example/hyperfilelens-backend:1.0.0-ee
+source "${ROOT}/deploy/installer/install.sh"
+load_images_from_manifest 0 "${package_root}"
+[[ -f "${tag_marker}" ]]
+[[ "$(wc -l <"${pull_marker}")" -eq 2 ]]
+load_images_from_manifest 0 "${package_root}"
+[[ "$(wc -l <"${pull_marker}")" -eq 2 ]]
+
+export DEPLOY_SSH_HOST=test.example.com
+export DEPLOY_SSH_PORT=22
+export DEPLOY_SSH_USER=root
+export AI_MODEL_PROVIDER=openai
+export AI_MODEL_ID=test-agent
+export AI_MODEL_DISPLAY_NAME="Test Agent"
+export AI_MULTIMODAL_MODEL_PROVIDER=openai
+export AI_MULTIMODAL_MODEL_ID=test-vision
+export AI_MULTIMODAL_MODEL_DISPLAY_NAME="Test Vision"
+export AI_MODEL_API_BASE=https://example.com/v1
+export AI_MODEL_API_KEY=test-secret
+export GITHUB_STEP_SUMMARY="${tmp}/ai-summary.md"
+export RUNNER_TEMP="${tmp}"
+HFL_TEST_AI_RESULT=passed \
+	"${ROOT}/.github/scripts/reconcile-saas-ai-model.sh" agent
+grep -Fq 'Passed: the deployment-managed ai model was applied and verified.' \
+	"${GITHUB_STEP_SUMMARY}"
+if AI_MODEL_ID="" HFL_TEST_AI_RESULT=passed \
+	"${ROOT}/.github/scripts/reconcile-saas-ai-model.sh" agent >/dev/null 2>&1; then
+	printf 'ERROR: required Agent model accepted incomplete configuration\n' >&2
+	exit 1
+fi
+AI_MULTIMODAL_MODEL_ID="" HFL_TEST_AI_RESULT=passed \
+	"${ROOT}/.github/scripts/reconcile-saas-ai-model.sh" multimodal >/dev/null
+HFL_TEST_AI_RESULT=rejected \
+	"${ROOT}/.github/scripts/reconcile-saas-ai-model.sh" multimodal >/dev/null
+if HFL_TEST_AI_RESULT=command-failed \
+	"${ROOT}/.github/scripts/reconcile-saas-ai-model.sh" agent >/dev/null 2>&1; then
+	printf 'ERROR: required Agent model ignored a reconciliation failure\n' >&2
+	exit 1
+fi
+
+identity_root="${tmp}/registry-identity"
+mkdir -p "${identity_root}"
+printf '1.0.0\n' >"${identity_root}/VERSION"
+python3 - "${identity_root}/MANIFEST.json" "${digest}" "${revision}" <<'PY'
+import json, pathlib, sys
+path, digest, revision = sys.argv[1:]
+version = "1.0.0-ee"
+
+
+def metadata(component, local_ref, role):
+    repository = local_ref.rsplit(":", 1)[0]
+    return {
+        "component": component,
+        "role": role,
+        "local_ref": local_ref,
+        "digest": digest,
+        "sources": [
+            {"region": "cn", "ref": f"registry.example.cn/example/{repository}:{version}"},
+            {"region": "global", "ref": f"docker.io/example/{repository}:{version}"},
+        ],
+    }
+
+
+runtime = [
+    metadata("hfl-backend", "hyperfilelens-backend:1.0.0-ee", "hyperfilelens"),
+    metadata("hfl-frontend", "hyperfilelens-frontend:1.0.0-ee", "hyperfilelens"),
+]
+assets = []
+for kind in ("agent", "gateway", "language"):
+    entry = metadata(
+        f"{kind}-assets", f"hyperfilelens-{kind}-assets:1.0.0-ee", f"{kind}-assets"
+    )
+    entry["asset_kind"] = kind
+    assets.append(entry)
+manifest = {
+    "channel": "release",
+    "artifact_id": "v1.0.0",
+    "version": "1.0.0",
+    "image_version": "1.0.0-ee",
+    "edition": "enterprise",
+    "git_commit": revision,
+    "extension_commit": "c" * 40,
+    "runtime_images": {
+        "backend": runtime[0]["local_ref"],
+        "frontend": runtime[1]["local_ref"],
+    },
+    "images": [{
+        "role": "hyperfilelens",
+        "refs": [manifest_ref["local_ref"] for manifest_ref in runtime],
+        "digests": [manifest_ref["digest"] for manifest_ref in runtime],
+    }],
+    "delivery": {"mode": "registry", "registry_images": runtime, "asset_images": assets},
+}
+pathlib.Path(path).write_text(json.dumps(manifest), encoding="utf-8")
+PY
+validate_package_identity "${identity_root}"
+python3 - "${identity_root}/MANIFEST.json" <<'PY'
+import json, pathlib, sys
+path = pathlib.Path(sys.argv[1])
+manifest = json.loads(path.read_text(encoding="utf-8"))
+manifest["delivery"]["registry_images"].pop()
+path.write_text(json.dumps(manifest), encoding="utf-8")
+PY
+if (validate_package_identity "${identity_root}") >/dev/null 2>&1; then
+	printf 'ERROR: registry identity accepted incomplete runtime metadata\n' >&2
+	exit 1
+fi
+python3 - "${identity_root}/MANIFEST.json" "${digest}" <<'PY'
+import json, pathlib, sys
+path = pathlib.Path(sys.argv[1])
+manifest = json.loads(path.read_text(encoding="utf-8"))
+manifest["delivery"]["registry_images"] = [{
+    "component": "hfl-backend",
+    "role": "hyperfilelens",
+    "local_ref": "hyperfilelens-backend:1.0.0-ee",
+    "digest": sys.argv[2],
+    "sources": [
+        {"region": "cn", "ref": "registry.example.cn/example/hyperfilelens-backend:1.0.0-ee"},
+        {"region": "global", "ref": "docker.io/example/hyperfilelens-backend:1.0.0-ee"},
+    ],
+}, {
+    "component": "hfl-frontend",
+    "role": "hyperfilelens",
+    "local_ref": "hyperfilelens-frontend:1.0.0-ee",
+    "digest": sys.argv[2],
+    "sources": [
+        {"region": "cn", "ref": "registry.example.cn/example/hyperfilelens-frontend:1.0.0-ee"},
+        {"region": "global", "ref": "docker.io/example/hyperfilelens-frontend:1.0.0-ee"},
+    ],
+}]
+path.write_text(json.dumps(manifest), encoding="utf-8")
+PY
+validate_package_identity "${identity_root}"
+python3 - "${identity_root}/MANIFEST.json" <<'PY'
+import json, pathlib, sys
+path = pathlib.Path(sys.argv[1])
+manifest = json.loads(path.read_text(encoding="utf-8"))
+manifest["delivery"]["asset_images"].pop()
+path.write_text(json.dumps(manifest), encoding="utf-8")
+PY
+if (validate_package_identity "${identity_root}") >/dev/null 2>&1; then
+	printf 'ERROR: registry identity accepted an incomplete asset set\n' >&2
+	exit 1
+fi
+
+sourcelens_root="${tmp}/sourcelens-candidate"
+mkdir -p \
+	"${sourcelens_root}/sourcelens/deploy/nginx/hfl-maintenance" \
+	"${sourcelens_root}/sourcelens/deploy/sentry"
+for relative in \
+	sourcelens/BUILD_INFO.json \
+	sourcelens/.env.example \
+	sourcelens/compose-lifecycle.sh \
+	sourcelens/docker-compose.yml \
+	sourcelens/install.sh \
+	sourcelens/patch-env-runtime.py \
+	sourcelens/sync-sentry-runtime.py \
+	sourcelens/deploy/nginx/default.conf \
+	sourcelens/deploy/nginx/hfl-sentry-loader.js \
+	sourcelens/deploy/nginx/hfl-maintenance/run-creation-gate.conf \
+	sourcelens/deploy/sentry/hfl-sentry-sitecustomize.py; do
+	: >"${sourcelens_root}/${relative}"
+done
+printf '%s\n' '{"delivery":{"mode":"registry"}}' \
+	>"${sourcelens_root}/MANIFEST.json"
+preflight_sourcelens_bundle "${sourcelens_root}"
+printf '%s\n' '{"delivery":{"mode":"offline"}}' \
+	>"${sourcelens_root}/MANIFEST.json"
+if (preflight_sourcelens_bundle "${sourcelens_root}") >/dev/null 2>&1; then
+	printf 'ERROR: offline SourceLens preflight accepted missing image archives\n' >&2
+	exit 1
+fi
+
+printf 'SaaS registry delivery contract tests passed.\n'


### PR DESCRIPTION
Adds an independent registry-backed Enterprise SaaS upgrade workflow for existing TEST and PROD environments. Publishes runtime and asset images to global and CN registries by digest, reuses the existing installer transaction and blue/green lifecycle, and preserves all existing release workflows.\n\nValidation: Actionlint, ShellCheck, release contracts, SaaS delivery contracts, installer image refresh, release assembly, upgrade transactions, language-pack lifecycle, and Enterprise release flow.