### PR TITLE
fix(ci): select SaaS registries by deployment region

### DIFF
--- a/.github/actions/deploy-saas/action.yml
+++ b/.github/actions/deploy-saas/action.yml
@@ -41,6 +41,7 @@ runs:
           [[ "$CN_REGISTRY_HOST" =~ ^[a-z0-9][a-z0-9.-]*(:[0-9]+)?$ ]]
           [[ -n "$REGISTRY_USERNAME" && -n "$REGISTRY_PASSWORD" ]]
           [[ -n "$CN_REGISTRY_USERNAME" && -n "$CN_REGISTRY_PASSWORD" ]]
+          [[ "$HFL_REGISTRY_REGION" =~ ^(cn|global)$ ]]
           [[ "$HFL_INSECURE_TLS" =~ ^[01]$ ]]
           case "$DEPLOY_TARGET:$HFL_INSECURE_TLS" in
             test:1|prod:0) ;;
@@ -141,6 +142,7 @@ runs:
               --candidate "$remote_dir/candidate.tar.gz" \
               --candidate-sha256 "$candidate_sha" \
               --registry-credentials "$remote_dir/registry.json" \
+              --registry-region "$HFL_REGISTRY_REGION" \
               --runtime-env-file "$remote_dir/runtime.env" \
               --direct-host "$DEPLOY_SSH_HOST" \
               --public-url "$APP_PUBLIC_URL" \

--- a/.github/scripts/remote-saas-deploy.sh
+++ b/.github/scripts/remote-saas-deploy.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 candidate_archive=""
 candidate_sha256=""
 registry_credentials=""
+registry_region=""
 runtime_env_file=""
 direct_host=""
 public_url=""
@@ -15,6 +16,7 @@ while [[ $# -gt 0 ]]; do
 	--candidate) candidate_archive=${2:-}; shift 2 ;;
 	--candidate-sha256) candidate_sha256=${2:-}; shift 2 ;;
 	--registry-credentials) registry_credentials=${2:-}; shift 2 ;;
+	--registry-region) registry_region=${2:-}; shift 2 ;;
 	--runtime-env-file) runtime_env_file=${2:-}; shift 2 ;;
 	--direct-host) direct_host=${2:-}; shift 2 ;;
 	--public-url) public_url=${2:-}; shift 2 ;;
@@ -27,6 +29,7 @@ done
 [[ "${registry_credentials}" =~ ^/var/tmp/hyperfilelens-saas-[0-9]+-[0-9]+/registry\.json$ ]]
 [[ "${runtime_env_file}" =~ ^/var/tmp/hyperfilelens-saas-[0-9]+-[0-9]+/runtime\.env$ ]]
 [[ "${candidate_sha256}" =~ ^[0-9a-f]{64}$ ]]
+[[ "${registry_region}" =~ ^(cn|global)$ ]]
 [[ -n "${direct_host}" && "${direct_host}" != *[[:space:]]* ]]
 for file in "${candidate_archive}" "${registry_credentials}" "${runtime_env_file}"; do
 	[[ -f "${file}" && ! -L "${file}" ]] || {
@@ -115,7 +118,9 @@ PY
 }
 
 registry_login_count=0
-for prefix in global cn; do
+fallback_region="global"
+[[ "${registry_region}" == "cn" ]] || fallback_region="cn"
+for prefix in "${registry_region}" "${fallback_region}"; do
 	host="$(read_credential "${prefix}_host")"
 	username="$(read_credential "${prefix}_username")"
 	password="$(read_credential "${prefix}_password")"
@@ -135,9 +140,11 @@ done
 }
 
 export DOCKER_CONFIG="${docker_config}"
-python3 - "${candidate_root}/MANIFEST.json" >"${stage_dir}/assets.tsv" <<'PY'
+python3 - "${candidate_root}/MANIFEST.json" "${registry_region}" >"${stage_dir}/assets.tsv" <<'PY'
 import json, pathlib, re, sys
 manifest = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+preferred_region = sys.argv[2]
+fallback_region = "global" if preferred_region == "cn" else "cn"
 delivery = manifest.get("delivery") or {}
 if delivery.get("mode") != "registry":
     raise SystemExit("candidate is not registry-backed")
@@ -160,8 +167,14 @@ for image in asset_images:
         local_ref,
     ):
         raise SystemExit("candidate contains invalid asset local reference")
-    refs = [str(item.get("ref") or "") for item in sources]
-    if len(refs) != 2 or any(
+    sources_by_region = {str(item.get("region") or ""): item for item in sources}
+    if len(sources) != 2 or set(sources_by_region) != {"cn", "global"}:
+        raise SystemExit("candidate asset sources must contain cn and global regions")
+    refs = [
+        str(sources_by_region[region].get("ref") or "")
+        for region in (preferred_region, fallback_region)
+    ]
+    if any(
         not re.fullmatch(
             r"[a-z0-9][a-z0-9.-]*(?::[0-9]+)?/[a-z0-9._/-]+:[A-Za-z0-9][A-Za-z0-9._-]{0,127}",
             ref,
@@ -278,7 +291,8 @@ upgrade_args=(
 )
 [[ -z "${public_url}" ]] || upgrade_args+=(--public-url "${public_url}")
 [[ -z "${admin_public_url}" ]] || upgrade_args+=(--admin-public-url "${admin_public_url}")
-HFL_UPGRADE_ARTIFACT_SHA256="${candidate_sha256}" \
+HFL_REGISTRY_REGION="${registry_region}" \
+	HFL_UPGRADE_ARTIFACT_SHA256="${candidate_sha256}" \
 	bash "${candidate_root}/install.sh" "${upgrade_args[@]}"
 
 candidate_id="$(sha256sum "${candidate_root}/MANIFEST.json" | cut -c1-12)"

--- a/.github/workflows/enterprise_saas_upgrade.yml
+++ b/.github/workflows/enterprise_saas_upgrade.yml
@@ -71,6 +71,8 @@ jobs:
           git fetch origin main --no-tags
           git merge-base --is-ancestor "$commit" origin/main
           for contract in \
+            .github/actions/deploy-saas/action.yml \
+            .github/scripts/remote-saas-deploy.sh \
             deploy/installer/install.sh \
             release/ci/assemble-saas-candidate.sh \
             release/ci/prepare-saas-asset-context.sh; do
@@ -79,6 +81,12 @@ jobs:
               exit 1
             }
           done
+          grep -Fq -- '--registry-region "$HFL_REGISTRY_REGION"' \
+            .github/actions/deploy-saas/action.yml
+          grep -Fq 'HFL_REGISTRY_REGION="${registry_region}"' \
+            .github/scripts/remote-saas-deploy.sh
+          grep -Fq 'registry delivery requires HFL_REGISTRY_REGION=cn or global' \
+            deploy/installer/install.sh
           [[ "$REGISTRY_HOST" =~ ^[a-z0-9][a-z0-9.-]*(:[0-9]+)?$ ]]
           [[ "$CN_REGISTRY_HOST" =~ ^[a-z0-9][a-z0-9.-]*(:[0-9]+)?$ ]]
           for namespace in "$REGISTRY_NAMESPACE" "$CN_REGISTRY_NAMESPACE"; do
@@ -673,6 +681,7 @@ jobs:
       CN_REGISTRY_HOST: ${{ vars.CN_REGISTRY_HOST }}
       CN_REGISTRY_USERNAME: ${{ secrets.CN_REGISTRY_USERNAME }}
       CN_REGISTRY_PASSWORD: ${{ secrets.CN_REGISTRY_PASSWORD }}
+      HFL_REGISTRY_REGION: ${{ vars.TEST_REGISTRY_REGION }}
       HFL_INSECURE_TLS: ${{ vars.TEST_HFL_INSECURE_TLS }}
       HFL_PLATFORM_GATEWAY_AUTO_DEPLOY: ${{ vars.TEST_PLATFORM_GATEWAY_AUTO_DEPLOY }}
       HFL_EMAIL_SIGNUP_ENABLED: ${{ vars.TEST_EMAIL_SIGNUP_ENABLED }}
@@ -736,6 +745,7 @@ jobs:
       CN_REGISTRY_HOST: ${{ vars.CN_REGISTRY_HOST }}
       CN_REGISTRY_USERNAME: ${{ secrets.CN_REGISTRY_USERNAME }}
       CN_REGISTRY_PASSWORD: ${{ secrets.CN_REGISTRY_PASSWORD }}
+      HFL_REGISTRY_REGION: ${{ vars.PROD_REGISTRY_REGION }}
       HFL_INSECURE_TLS: ${{ vars.PROD_HFL_INSECURE_TLS }}
       HFL_PLATFORM_GATEWAY_AUTO_DEPLOY: ${{ vars.PROD_PLATFORM_GATEWAY_AUTO_DEPLOY }}
       HFL_EMAIL_SIGNUP_ENABLED: ${{ vars.PROD_EMAIL_SIGNUP_ENABLED }}

--- a/deploy/installer/install.sh
+++ b/deploy/installer/install.sh
@@ -2338,6 +2338,7 @@ load_images_from_manifest() {
 	python3 - "${package_root}" "${skip_sourcelens}" <<'PY'
 import hashlib
 import json
+import os
 import pathlib
 import subprocess
 import sys
@@ -2403,6 +2404,10 @@ def has_expected_digest(ref: str, digest: str) -> bool:
 
 
 if delivery_mode == "registry":
+    preferred_region = os.environ.get("HFL_REGISTRY_REGION", "").strip()
+    if preferred_region not in {"cn", "global"}:
+        raise SystemExit("registry delivery requires HFL_REGISTRY_REGION=cn or global")
+    fallback_region = "global" if preferred_region == "cn" else "cn"
     registry_images = [
         image
         for image in (delivery.get("registry_images") or [])
@@ -2414,7 +2419,18 @@ if delivery_mode == "registry":
     for index, image in enumerate(registry_images, start=1):
         local_ref = str(image.get("local_ref") or "")
         digest = str(image.get("digest") or "")
-        sources = image.get("sources") or []
+        declared_sources = image.get("sources") or []
+        sources_by_region = {
+            str(source.get("region") or ""): source for source in declared_sources
+        }
+        if len(declared_sources) != 2 or set(sources_by_region) != {"cn", "global"}:
+            raise SystemExit(
+                f"registry image sources must contain cn and global regions: {local_ref}"
+            )
+        sources = [
+            sources_by_region[preferred_region],
+            sources_by_region[fallback_region],
+        ]
         pulled = ""
         errors = []
         print(

--- a/tools/quality/test-saas-registry-delivery.sh
+++ b/tools/quality/test-saas-registry-delivery.sh
@@ -29,7 +29,15 @@ grep -Fq 'group: hyperfilelens-deploy-test' \
 grep -Fq 'group: hyperfilelens-deploy-prod' \
 	"${ROOT}/.github/workflows/enterprise_saas_upgrade.yml"
 grep -Fq 'using: composite' "${ROOT}/.github/actions/deploy-saas/action.yml"
+grep -Fq 'HFL_REGISTRY_REGION: ${{ vars.TEST_REGISTRY_REGION }}' \
+	"${ROOT}/.github/workflows/enterprise_saas_upgrade.yml"
+grep -Fq 'HFL_REGISTRY_REGION: ${{ vars.PROD_REGISTRY_REGION }}' \
+	"${ROOT}/.github/workflows/enterprise_saas_upgrade.yml"
+grep -Fq -- '--registry-region "$HFL_REGISTRY_REGION"' \
+	"${ROOT}/.github/actions/deploy-saas/action.yml"
 grep -Fq 'registry_login_count > 0' \
+	"${ROOT}/.github/scripts/remote-saas-deploy.sh"
+grep -Fq 'for prefix in "${registry_region}" "${fallback_region}"' \
 	"${ROOT}/.github/scripts/remote-saas-deploy.sh"
 grep -Fq 'platform-gateway verify --required --timeout 0' \
 	"${ROOT}/.github/actions/deploy-saas/action.yml"
@@ -42,6 +50,8 @@ grep -Fq 'TEST_AI_MULTIMODAL_MODEL_PROVIDER' \
 grep -Fq 'PROD_AI_MODEL_API_KEY' \
 	"${ROOT}/.github/workflows/enterprise_saas_upgrade.yml"
 grep -Fq 'Required repository secret is empty' \
+	"${ROOT}/.github/workflows/enterprise_saas_upgrade.yml"
+grep -Fq "registry delivery requires HFL_REGISTRY_REGION=cn or global" \
 	"${ROOT}/.github/workflows/enterprise_saas_upgrade.yml"
 for deploy_job in deploy-test deploy-prod; do
 	job_definition="$(awk -v job="${deploy_job}" '
@@ -99,11 +109,18 @@ case "${1:-} ${2:-}" in
 "pull --platform")
 	ref="${4:-}"
 	printf '%s\n' "${ref}" >>"${HFL_TEST_PULL_MARKER}"
-	[[ "${ref}" == registry.example.cn/* ]] && exit 1
-	[[ "${ref}" == docker.io/example/hyperfilelens-backend@sha256:* ]]
+	case "${HFL_TEST_FAIL_REGION:-}" in
+	cn) [[ "${ref}" == registry.example.cn/* ]] && exit 1 ;;
+	global) [[ "${ref}" == docker.io/* ]] && exit 1 ;;
+	both) exit 1 ;;
+	"") ;;
+	*) exit 2 ;;
+	esac
+	[[ "${ref}" == registry.example.cn/* || "${ref}" == docker.io/* ]]
 	printf 'pulled %s\n' "${ref}"
 	;;
-"tag docker.io/example/hyperfilelens-backend@sha256"*)
+"tag "*)
+	[[ "${2:-}" == *@sha256:* ]]
 	: >"${HFL_TEST_TAG_MARKER}"
 	;;
 "image inspect")
@@ -146,10 +163,39 @@ export PATH="${fake_bin}:${PATH}"
 	"${digest}" \
 	registry.example.cn/example/hyperfilelens-backend:1.0.0-ee
 source "${ROOT}/deploy/installer/install.sh"
-load_images_from_manifest 0 "${package_root}"
+HFL_TEST_FAIL_REGION=cn HFL_REGISTRY_REGION=cn \
+	load_images_from_manifest 0 "${package_root}"
 [[ -f "${tag_marker}" ]]
 [[ "$(wc -l <"${pull_marker}")" -eq 2 ]]
-load_images_from_manifest 0 "${package_root}"
+[[ "$(sed -n '1p' "${pull_marker}")" == registry.example.cn/* ]]
+[[ "$(sed -n '2p' "${pull_marker}")" == docker.io/* ]]
+HFL_REGISTRY_REGION=cn load_images_from_manifest 0 "${package_root}"
+[[ "$(wc -l <"${pull_marker}")" -eq 2 ]]
+
+rm -f "${tag_marker}"
+: >"${pull_marker}"
+HFL_REGISTRY_REGION=global load_images_from_manifest 0 "${package_root}"
+[[ -f "${tag_marker}" ]]
+[[ "$(wc -l <"${pull_marker}")" -eq 1 ]]
+[[ "$(sed -n '1p' "${pull_marker}")" == docker.io/* ]]
+
+rm -f "${tag_marker}"
+: >"${pull_marker}"
+HFL_TEST_FAIL_REGION=global HFL_REGISTRY_REGION=global \
+	load_images_from_manifest 0 "${package_root}"
+[[ -f "${tag_marker}" ]]
+[[ "$(wc -l <"${pull_marker}")" -eq 2 ]]
+[[ "$(sed -n '1p' "${pull_marker}")" == docker.io/* ]]
+[[ "$(sed -n '2p' "${pull_marker}")" == registry.example.cn/* ]]
+
+rm -f "${tag_marker}"
+: >"${pull_marker}"
+if HFL_TEST_FAIL_REGION=both HFL_REGISTRY_REGION=cn \
+	load_images_from_manifest 0 "${package_root}" >/dev/null 2>&1; then
+	printf 'ERROR: registry delivery accepted two unavailable sources\n' >&2
+	exit 1
+fi
+[[ ! -e "${tag_marker}" ]]
 [[ "$(wc -l <"${pull_marker}")" -eq 2 ]]
 
 export DEPLOY_SSH_HOST=test.example.com


### PR DESCRIPTION
## Summary
- prefer the CN registry for TEST and the global registry for PROD
- apply the same preferred/fallback order to runtime and asset images
- reject tags that predate the regional registry contract
- preserve all offline release workflows

## Validation
- Actionlint
- SaaS registry delivery contract tests
- release contract checks
- installer, upgrade transaction, blue-green, release assembly, and language-pack regression tests

Closes #621