### PR TITLE
ci(release): align release trigger modes across enterprise and SaaS workflows

### DIFF
--- a/.github/workflows/enterprise_release.yml
+++ b/.github/workflows/enterprise_release.yml
@@ -1,10 +1,7 @@
 name: HFL - Enterprise Release & Deploy
-run-name: Enterprise · ${{ github.event_name == 'push' && github.ref_name || inputs.tag }} · Build & deploy
+run-name: Enterprise · ${{ inputs.tag }} · Build & deploy
 
 on:
-  push:
-    tags:
-      - "v[0-9]+.[0-9]+.[0-9]+"
   workflow_dispatch:
     inputs:
       tag:
@@ -25,14 +22,10 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
-            [[ "$GITHUB_REF" == "refs/heads/main" ]] || {
-              echo "::error::Manual Enterprise builds must be started from the main branch"
-              exit 1
-            }
-          else
-            [[ "$GITHUB_REF" == refs/tags/v* ]]
-          fi
+          [[ "$GITHUB_REF" == "refs/heads/main" ]] || {
+            echo "::error::Enterprise builds must be started from the main branch"
+            exit 1
+          }
 
   build-enterprise:
     name: Build & Deploy · Enterprise
@@ -41,5 +34,5 @@ jobs:
     with:
       channel: release
       edition: enterprise
-      release_tag: ${{ github.event_name == 'push' && github.ref_name || inputs.tag }}
+      release_tag: ${{ inputs.tag }}
     secrets: inherit

--- a/.github/workflows/enterprise_saas_upgrade.yml
+++ b/.github/workflows/enterprise_saas_upgrade.yml
@@ -1,7 +1,10 @@
 name: HFL - Enterprise SaaS Upgrade
-run-name: Enterprise SaaS · ${{ inputs.tag }} · Registry upgrade
+run-name: Enterprise SaaS · ${{ github.event_name == 'push' && github.ref_name || inputs.tag }} · Registry upgrade
 
 on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
   workflow_dispatch:
     inputs:
       tag:
@@ -22,7 +25,7 @@ on:
 concurrency:
   # The existing Release Pipeline already owns this group. Reusing its literal
   # name serializes same-version pushes without changing that workflow.
-  group: ${{ format('hyperfilelens-package-{0}', inputs.tag) }}
+  group: ${{ format('hyperfilelens-package-{0}', github.event_name == 'push' && github.ref_name || inputs.tag) }}
   cancel-in-progress: false
 
 permissions:
@@ -52,11 +55,11 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-          ref: ${{ inputs.tag }}
+          ref: ${{ github.event_name == 'push' && github.ref_name || inputs.tag }}
       - name: Validate source and registries
         id: source
         env:
-          RELEASE_TAG: ${{ inputs.tag }}
+          RELEASE_TAG: ${{ github.event_name == 'push' && github.ref_name || inputs.tag }}
           REGISTRY_USERNAME: ${{ secrets.REGISTRY_USERNAME }}
           REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
           CN_REGISTRY_USERNAME: ${{ secrets.CN_REGISTRY_USERNAME }}
@@ -64,7 +67,14 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          [[ "$GITHUB_REF" == "refs/heads/main" ]]
+          if [[ "$GITHUB_EVENT_NAME" == "push" ]]; then
+            [[ "$GITHUB_REF" == refs/tags/v* ]]
+          else
+            [[ "$GITHUB_REF" == "refs/heads/main" ]] || {
+              echo "::error::Manual SaaS upgrades must be started from the main branch"
+              exit 1
+            }
+          fi
           [[ "$RELEASE_TAG" =~ ^v([0-9]+\.[0-9]+\.[0-9]+)$ ]]
           version="${BASH_REMATCH[1]}"
           commit="$(git rev-parse --verify "${RELEASE_TAG}^{commit}")"
@@ -111,7 +121,7 @@ jobs:
         env:
           ENTERPRISE_EXTENSION_REPOSITORY: ${{ vars.ENTERPRISE_EXTENSION_REPOSITORY }}
           HFL_EXTENSION_GIT_TOKEN: ${{ secrets.ENTERPRISE_EXTENSION_GIT_TOKEN }}
-          RELEASE_TAG: ${{ inputs.tag }}
+          RELEASE_TAG: ${{ github.event_name == 'push' && github.ref_name || inputs.tag }}
         shell: bash
         run: |
           set -euo pipefail
@@ -661,7 +671,7 @@ jobs:
 
   deploy-test:
     name: Deploy · TEST
-    if: ${{ inputs.upgrade_test }}
+    if: ${{ github.event_name == 'push' || inputs.upgrade_test }}
     needs: [prepare, assemble-candidate]
     runs-on: ubuntu-24.04
     timeout-minutes: 120
@@ -725,7 +735,7 @@ jobs:
 
   deploy-prod:
     name: Deploy · PROD
-    if: ${{ inputs.upgrade_prod }}
+    if: ${{ github.event_name == 'push' || inputs.upgrade_prod }}
     needs: [prepare, assemble-candidate]
     runs-on: ubuntu-24.04
     timeout-minutes: 120


### PR DESCRIPTION
## Summary

Aligns release trigger modes across workflows so the Enterprise release no longer auto-triggers on tag push, matching the community release behavior, while the Enterprise SaaS upgrade becomes push-triggered with a manual fallback.

## Changes

### `enterprise_release.yml` (Enterprise)
- Removed `push: tags: v*` auto-trigger; now dispatched manually via `workflow_dispatch` with a target tag, matching `community_release.yml`
- Simplified `run-name` and validate step (main-branch check only)

### `enterprise_saas_upgrade.yml` (SaaS)
- Added `push: tags: v*` trigger: pushing a version tag automatically upgrades both TEST and PROD
- Kept the manual `workflow_dispatch` entry point to re-run an arbitrary existing tag or select individual environments
- Tag source resolves via `github.event_name == 'push' && github.ref_name || inputs.tag`
- Deploy jobs guard with `github.event_name == 'push' || inputs.upgrade_*` so push runs are not skipped when dispatch inputs are empty

## Behavior matrix

| Trigger | Enterprise release | SaaS upgrade |
|---|---|---|
| Tag push | no longer runs | auto-upgrade TEST + PROD |
| Manual dispatch (tag) | build & deploy | optional TEST/PROD |

## Validation
- No lint errors in either workflow file
- `release_pipeline.yml` untouched (depends only on `inputs.release_tag`)