### PR TITLE
fix(deploy): auto-deploy local platform Gateway across all install paths

### DIFF
--- a/.github/actions/deploy-saas/action.yml
+++ b/.github/actions/deploy-saas/action.yml
@@ -173,11 +173,7 @@ runs:
             -o ConnectTimeout=20 -o ServerAliveInterval=30 -o ServerAliveCountMax=20 \
             -o TCPKeepAlive=yes -p "$DEPLOY_SSH_PORT" \
             "$DEPLOY_SSH_USER@$DEPLOY_SSH_HOST" \
-            'if /opt/hyperfilelens/install.sh platform-gateway verify --required --timeout 0; then
-               echo "Platform Gateway is already ready; preserving the running deployment";
-             else
-               /opt/hyperfilelens/install.sh platform-gateway ensure;
-             fi &&
+            '/opt/hyperfilelens/install.sh platform-gateway ensure &&
              /opt/hyperfilelens/install.sh platform-gateway verify --required --timeout 180'
     - name: Reconcile default AI model
       shell: bash

--- a/.github/workflows/deploy_target.yml
+++ b/.github/workflows/deploy_target.yml
@@ -99,7 +99,7 @@ on:
       platform_gateway_auto_deploy:
         description: Automatically deploy an HFL-managed local platform Gateway
         required: false
-        default: false
+        default: true
         type: boolean
       hfl_insecure_tls:
         description: Environment-wide TLS policy for remotely enrolled HFL Agents (0 verifies, 1 skips)
@@ -602,11 +602,7 @@ jobs:
             -o TCPKeepAlive=yes \
             -p "$DEPLOY_SSH_PORT" \
             "$DEPLOY_SSH_USER@$DEPLOY_SSH_HOST" \
-            'if /opt/hyperfilelens/install.sh platform-gateway verify --required --timeout 0; then
-               echo "Installer-managed Platform Gateway is already online; preserving its independent lifecycle."
-             else
-               /opt/hyperfilelens/install.sh platform-gateway ensure
-             fi'
+            '/opt/hyperfilelens/install.sh platform-gateway ensure'
 
       - name: Verify Platform Gateway Readiness
         if: ${{ inputs.platform_gateway_auto_deploy }}

--- a/deploy/installer/install.sh
+++ b/deploy/installer/install.sh
@@ -6250,6 +6250,7 @@ cmd_upgrade() {
 	record_upgrade_transaction_phase sourcelens_complete
 	sync_optional_identity_settings
 	check_local_platform_gateway_continuity
+	ensure_local_platform_gateway
 	record_upgrade_transaction_phase gateway_verified
 	prune_agent_release_media
 	prune_old_managed_image_refs

--- a/dev/stack.sh
+++ b/dev/stack.sh
@@ -1080,16 +1080,25 @@ ensure_local_platform_gateway_dev() {
 	log "Ensuring local public Data Gateway (platform Gateway auto-deploy)"
 	# Sidecar install expects :latest; versioned tags alone leave gateway-install
 	# downloading the bootstrap archive (or failing when that archive is stale).
-	if ! docker image inspect hyperfilelens-sourcelens-lensnode:latest >/dev/null 2>&1; then
-		local versioned=""
-		versioned="$(
-			docker images --format '{{.Repository}}:{{.Tag}}' \
-				| grep -E '^hyperfilelens-sourcelens-lensnode:[0-9]' \
-				| head -1 || true
-		)"
-		if [[ -n "${versioned}" ]]; then
-			docker tag "${versioned}" hyperfilelens-sourcelens-lensnode:latest
-			log "Tagged ${versioned} -> hyperfilelens-sourcelens-lensnode:latest for Gateway sidecar"
+	# Re-tag whenever the newest versioned image differs from :latest so the
+	# sidecar (which compares image IDs) is recreated after a SourceLens rebuild.
+	local latest_id versioned_ref versioned_id
+	latest_id="$(docker image inspect --format '{{.Id}}' hyperfilelens-sourcelens-lensnode:latest 2>/dev/null || true)"
+	versioned_ref="$(
+		docker images --format '{{.Repository}}:{{.Tag}}' \
+			| grep -E '^hyperfilelens-sourcelens-lensnode:[0-9]' \
+			| while read -r ref; do
+				printf '%s %s\n' "$(docker image inspect --format '{{.Created}}' "${ref}" 2>/dev/null || true)" "${ref}"
+			done \
+			| sort -r \
+			| head -1 \
+			| awk '{print $NF}'
+	)"
+	if [[ -n "${versioned_ref}" ]]; then
+		versioned_id="$(docker image inspect --format '{{.Id}}' "${versioned_ref}" 2>/dev/null || true)"
+		if [[ -z "${latest_id}" || "${latest_id}" != "${versioned_id}" ]]; then
+			docker tag "${versioned_ref}" hyperfilelens-sourcelens-lensnode:latest
+			log "Refreshed hyperfilelens-sourcelens-lensnode:latest from ${versioned_ref} for Gateway sidecar"
 		fi
 	fi
 

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -1219,8 +1219,6 @@ grep -F 'Ensure Platform Gateway' \
 	"${ROOT}/.github/workflows/deploy_target.yml" >/dev/null
 grep -F 'platform-gateway ensure' \
 	"${ROOT}/.github/workflows/deploy_target.yml" >/dev/null
-grep -F 'platform-gateway verify --required --timeout 0' \
-	"${ROOT}/.github/workflows/deploy_target.yml" >/dev/null
 grep -F 'Verify Platform Gateway Readiness' \
 	"${ROOT}/.github/workflows/deploy_target.yml" >/dev/null
 grep -F 'platform-gateway verify --required --timeout 180' \

--- a/tools/quality/test-saas-registry-delivery.sh
+++ b/tools/quality/test-saas-registry-delivery.sh
@@ -39,7 +39,7 @@ grep -Fq 'registry_login_count > 0' \
 	"${ROOT}/.github/scripts/remote-saas-deploy.sh"
 grep -Fq 'for prefix in "${registry_region}" "${fallback_region}"' \
 	"${ROOT}/.github/scripts/remote-saas-deploy.sh"
-grep -Fq 'platform-gateway verify --required --timeout 0' \
+grep -Fq 'platform-gateway ensure' \
 	"${ROOT}/.github/actions/deploy-saas/action.yml"
 grep -Fq 'reconcile-saas-ai-model.sh agent' \
 	"${ROOT}/.github/actions/deploy-saas/action.yml"


### PR DESCRIPTION
## Summary

Deploy and upgrade the installer-managed local platform Gateway (datagateway) on every install/upgrade path instead of only installing when nothing is running.

## Changes

- **`.github/workflows/deploy_target.yml`**: default `platform_gateway_auto_deploy` to `true`; always run `install.sh platform-gateway ensure` before the readiness check.
- **`.github/actions/deploy-saas/action.yml`**: always ensure the gateway, then verify with a 180s timeout (drop the stale "already ready" short-circuit).
- **`deploy/installer/install.sh`**: ensure the local platform Gateway during blue/green upgrades once the target API pool is healthy.
- **`dev/stack.sh`**: re-tag `hyperfilelens-sourcelens-lensnode:latest` from the newest versioned image on rebuild so the sidecar container is recreated.
- **`tools/quality/*`**: keep release-contract and SaaS delivery assertions in sync with the new flow.

`HFL_PLATFORM_GATEWAY_AUTO_DEPLOY` remains the master switch: when `false`, installation and upgrades are skipped on every path.

## Tests

- `bash -n` passes on `install.sh`, `stack.sh`, and both quality scripts.
- `test-upgrade-transaction.sh`, `test-platform-gateway-auto-deploy.sh`: PASS.
- `test-saas-registry-delivery.sh`, `check-release-contracts.sh`: two pre-existing baseline failures on `main` (from #659), unrelated to this change, verified via `git stash`.