### PR TITLE
fix(quality): align contract assertions with push-triggered SaaS release

### DIFF
--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -646,7 +646,6 @@ grep -F 'name: HFL - Release Pipeline (Reusable)' "${workflow}" >/dev/null
 grep -F 'uses: ./.github/workflows/release_pipeline.yml' "${release_workflow}" >/dev/null
 grep -F 'channel: release' "${release_workflow}" >/dev/null
 grep -F 'workflow_dispatch:' "${test_workflow}" >/dev/null
-grep -F 'tags:' "${test_workflow}" >/dev/null
 grep -F 'edition: enterprise' "${test_workflow}" >/dev/null
 grep -F 'workflow_dispatch:' "${production_workflow}" >/dev/null
 for job in \

--- a/tools/quality/test-saas-registry-delivery.sh
+++ b/tools/quality/test-saas-registry-delivery.sh
@@ -62,7 +62,7 @@ for deploy_job in deploy-test deploy-prod; do
 	# shellcheck disable=SC2016 # GitHub expression is an intentional literal.
 	grep -Fq 'ref: ${{ needs.prepare.outputs.commit }}' <<<"${job_definition}"
 done
-grep -Fq "format('hyperfilelens-package-{0}', inputs.tag)" \
+grep -Fq "format('hyperfilelens-package-{0}', github.event_name == 'push' && github.ref_name || inputs.tag)" \
 	"${ROOT}/.github/workflows/enterprise_saas_upgrade.yml"
 
 package_root="${tmp}/candidate"


### PR DESCRIPTION
## Summary

Fixes two release-path quality tests that broke after #659 switched `enterprise_release.yml` to manual dispatch only and made the SaaS registry group expression resolve the tag from a push event with a manual fallback.

## Changes

- **`tools/quality/check-release-contracts.sh`**: drop the stale `tags:` trigger assertion for `enterprise_release.yml` (the `workflow_dispatch:` assertion already covers the trigger contract).
- **`tools/quality/test-saas-registry-delivery.sh`**: assert the actual group expression `github.event_name == 'push' && github.ref_name || inputs.tag`.

## Verification

- `./tools/quality/test-saas-registry-delivery.sh` — PASS
- `./tools/quality/check-release-contracts.sh` — PASS
- `bash -n` and lint — clean