### PR TITLE
fix(storage): tolerate S3 backends that do not implement ListObjectVersions

### DIFF
--- a/src/backend/apps/storage/services/internal/s3_client.py
+++ b/src/backend/apps/storage/services/internal/s3_client.py
@@ -1100,8 +1100,9 @@ def _chunks(items: list[dict], size: int):
 def _next_s3_non_owner_version_batch(
     *, client, bucket: str, prefix: str, marker_key: str
 ) -> tuple[list[dict], list[dict]]:
-    paginator = client.get_paginator("list_object_versions")
-    for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
+    for page in _s3_list_object_version_pages(
+        client=client, bucket=bucket, prefix=prefix
+    ):
         versions = [
             {"Key": item["Key"], "VersionId": item["VersionId"]}
             for item in page.get("Versions", [])
@@ -1198,9 +1199,10 @@ def _require_s3_cleanup_marker(
 
 
 def _s3_marker_version_entries(*, client, bucket: str, key: str) -> list[dict] | None:
-    paginator = client.get_paginator("list_object_versions")
     entries: list[dict] = []
-    for page in paginator.paginate(Bucket=bucket, Prefix=key):
+    for page in _s3_list_object_version_pages(
+        client=client, bucket=bucket, prefix=key
+    ):
         entries.extend(
             {
                 "Key": item["Key"],
@@ -1225,8 +1227,9 @@ def _s3_marker_version_entries(*, client, bucket: str, key: str) -> list[dict] |
 def _verify_s3_prefix_contains_only_marker(
     *, client, bucket: str, prefix: str, marker_key: str
 ) -> None:
-    paginator = client.get_paginator("list_object_versions")
-    for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
+    for page in _s3_list_object_version_pages(
+        client=client, bucket=bucket, prefix=prefix
+    ):
         entries = [
             *page.get("Versions", []),
             *page.get("DeleteMarkers", []),
@@ -1262,6 +1265,43 @@ def _is_unsupported_s3_header_error(exc: ClientError) -> bool:
     return "header you provided implies functionality" in message
 
 
+def _s3_list_object_versions(*, client, bucket: str, prefix: str) -> dict:
+    """Call list_object_versions, treating unsupported versioning as empty.
+
+    Some S3-compatible backends (e.g. Huawei Cloud OBS without versioning,
+    or older MinIO configurations) return NotImplemented for
+    ListObjectVersions. We treat that as "no versions" so deletion can fall
+    back to the non-versioned object cleanup path.
+    """
+    try:
+        return client.list_object_versions(Bucket=bucket, Prefix=prefix, MaxKeys=1)
+    except ClientError as exc:
+        if _is_unsupported_s3_header_error(exc):
+            logger.debug(
+                "list_object_versions not supported for %s/%s, treating as empty",
+                bucket,
+                prefix,
+            )
+            return {}
+        raise
+
+
+def _s3_list_object_version_pages(*, client, bucket: str, prefix: str):
+    """Paginator for list_object_versions with NotImplemented fallback."""
+    paginator = client.get_paginator("list_object_versions")
+    try:
+        yield from paginator.paginate(Bucket=bucket, Prefix=prefix)
+    except ClientError as exc:
+        if _is_unsupported_s3_header_error(exc):
+            logger.debug(
+                "list_object_versions paginator not supported for %s/%s",
+                bucket,
+                prefix,
+            )
+            return
+        raise
+
+
 def _should_fallback_from_batch_delete(exc: ClientError) -> bool:
     return (
         _is_unsupported_s3_header_error(exc)
@@ -1270,7 +1310,9 @@ def _should_fallback_from_batch_delete(exc: ClientError) -> bool:
 
 
 def _verify_s3_prefix_empty(*, client, bucket: str, prefix: str) -> None:
-    versions = client.list_object_versions(Bucket=bucket, Prefix=prefix, MaxKeys=1)
+    versions = _s3_list_object_versions(
+        client=client, bucket=bucket, prefix=prefix
+    )
     if versions.get("Versions") or versions.get("DeleteMarkers"):
         raise S3ClientError(
             "Repository object prefix still contains object versions after cleanup."

--- a/src/backend/apps/storage/tests/test_s3_cleanup.py
+++ b/src/backend/apps/storage/tests/test_s3_cleanup.py
@@ -289,7 +289,7 @@ class S3PrefixCleanupTests(SimpleTestCase):
                 )
 
     @mock.patch("apps.storage.services.internal.s3_client._client")
-    def test_fails_closed_when_version_api_is_unsupported(self, build_client):
+    def test_deletes_objects_when_version_api_is_unsupported(self, build_client):
         client = self._client()
         unsupported_versions = ClientError(
             {
@@ -331,16 +331,32 @@ class S3PrefixCleanupTests(SimpleTestCase):
         client.delete_objects.return_value = {}
         build_client.return_value = client
 
-        with self.assertRaises(S3ClientError):
-            self._delete(
-                endpoint="https://s3.example.test",
-                region="us-east-1",
-                bucket="bucket",
-                prefix="repo/",
-                access_key_id="key",
-                secret_access_key="secret",
-            )
-        client.delete_objects.assert_not_called()
+        # Backends without versioning support are treated as version-free:
+        # current objects are deleted, no version/marker accounting, and the
+        # ownership marker itself is removed via a plain object delete.
+        result = self._delete(
+            endpoint="https://s3.example.test",
+            region="us-east-1",
+            bucket="bucket",
+            prefix="repo/",
+            access_key_id="key",
+            secret_access_key="secret",
+        )
+        self.assertEqual(result["deleted_versions"], 0)
+        self.assertEqual(result["deleted_markers"], 0)
+        self.assertEqual(result["deleted_objects"], 2)
+        deleted_keys = [
+            item["Key"]
+            for call in client.delete_objects.call_args_list
+            for item in call.kwargs["Delete"]["Objects"]
+        ]
+        self.assertEqual(
+            sorted(deleted_keys),
+            [
+                "repo/.hyperfilelens/repository-owner-v1.json",
+                "repo/object",
+            ],
+        )
 
 
 class S3BucketCleanupTests(SimpleTestCase):

--- a/src/backend/apps/storage/tests/test_s3_client.py
+++ b/src/backend/apps/storage/tests/test_s3_client.py
@@ -6,8 +6,11 @@ from apps.storage.services.internal.s3_client import (
     S3ClientError,
     _bucket_location_from_xml,
     _client,
+    _is_unsupported_s3_header_error,
     _merge_huawei_bucket_location,
     _register_huawei_bucket_location_compatibility,
+    _s3_list_object_versions,
+    _s3_list_object_version_pages,
     check_s3_bucket_readable,
     create_s3_bucket,
     ensure_s3_bucket,
@@ -759,6 +762,82 @@ class S3PrefixContainsOnlyKeyTests(TestCase):
 
         self.assertFalse(self._contains_only(client))
         client.list_multipart_uploads.assert_not_called()
+
+
+class S3ListObjectVersionsFallbackTests(TestCase):
+    def _not_implemented_error(self):
+        return ClientError(
+            error_response={
+                "Error": {
+                    "Code": "NotImplemented",
+                    "Message": "A header you provided implies functionality that is not implemented",
+                }
+            },
+            operation_name="ListObjectVersions",
+        )
+
+    def test_recognizes_unsupported_s3_header_error(self):
+        self.assertTrue(_is_unsupported_s3_header_error(self._not_implemented_error()))
+
+    def test_ignores_other_client_errors(self):
+        exc = ClientError(
+            error_response={"Error": {"Code": "NoSuchBucket", "Message": "No such bucket"}},
+            operation_name="ListObjectVersions",
+        )
+        self.assertFalse(_is_unsupported_s3_header_error(exc))
+
+    def test_list_object_versions_returns_empty_when_unsupported(self):
+        client = mock.Mock()
+        client.list_object_versions.side_effect = self._not_implemented_error()
+
+        result = _s3_list_object_versions(
+            client=client, bucket="bucket", prefix="hfl/"
+        )
+
+        self.assertEqual(result, {})
+        client.list_object_versions.assert_called_once_with(
+            Bucket="bucket", Prefix="hfl/", MaxKeys=1
+        )
+
+    def test_list_object_versions_reraises_other_errors(self):
+        client = mock.Mock()
+        client.list_object_versions.side_effect = ClientError(
+            error_response={"Error": {"Code": "NoSuchBucket", "Message": "missing"}},
+            operation_name="ListObjectVersions",
+        )
+
+        with self.assertRaises(ClientError):
+            _s3_list_object_versions(client=client, bucket="bucket", prefix="hfl/")
+
+    def test_list_object_version_pages_yields_no_pages_when_unsupported(self):
+        paginator = mock.Mock()
+        paginator.paginate.side_effect = self._not_implemented_error()
+        client = mock.Mock()
+        client.get_paginator.return_value = paginator
+
+        pages = list(
+            _s3_list_object_version_pages(
+                client=client, bucket="bucket", prefix="hfl/"
+            )
+        )
+
+        self.assertEqual(pages, [])
+        client.get_paginator.assert_called_once_with("list_object_versions")
+        paginator.paginate.assert_called_once_with(Bucket="bucket", Prefix="hfl/")
+
+    def test_list_object_version_pages_yields_pages_when_supported(self):
+        paginator = mock.Mock()
+        paginator.paginate.return_value = [{"Versions": [{"Key": "hfl/obj"}]}]
+        client = mock.Mock()
+        client.get_paginator.return_value = paginator
+
+        pages = list(
+            _s3_list_object_version_pages(
+                client=client, bucket="bucket", prefix="hfl/"
+            )
+        )
+
+        self.assertEqual(pages, [{"Versions": [{"Key": "hfl/obj"}]}])
 
 
 class InitializeS3RepositoryBucketModeTests(TestCase):


### PR DESCRIPTION
## Summary

Some S3-compatible storage (e.g. Huawei Cloud OBS without versioning, or legacy MinIO setups) return `NotImplemented` for `ListObjectVersions`, which made deleting an S3 repository fail with "A header you provided implies functionality that is not implemented".

## Root cause

`delete_s3_prefix` enumerated object versions unconditionally. On backends that do not implement versioning, the very first version listing raised and the deletion aborted. Other code paths in the module already treat this error as fail-open (`_prefix_holds_any_state`, `s3_prefix_contains_only_key`, `_bucket_nonempty_reason`); `delete_s3_prefix` was the only fail-closed path.

## Changes

- **`s3_client.py`**: add `_s3_list_object_versions` / `_s3_list_object_version_pages` helpers that return empty results on `NotImplemented`; use them for version enumeration, marker version lookup, only-marker verification and the final empty-prefix check. The ownership marker is then removed via a plain object delete. Other `ClientError`s still propagate.
- **`test_s3_client.py`**: 6 new unit tests covering the helpers (error recognition, empty fallback, re-raise, paginator fallback).
- **`test_s3_cleanup.py`**: align the previous fail-closed contract test to fail-open — unsupported version APIs now complete deletion of current objects and the ownership marker.

## Verification

- `test_s3_client.py` + `test_s3_cleanup.py`: 66 tests PASS
- `py_compile` and lint: clean