### PR TITLE
fix(ci): align enterprise release contract with manual dispatch workflow

### DIFF
--- a/tools/quality/test-enterprise-release-flow.sh
+++ b/tools/quality/test-enterprise-release-flow.sh
@@ -70,10 +70,14 @@ entry_enterprise="${ROOT}/.github/workflows/enterprise_release.yml"
 entry_community="${ROOT}/.github/workflows/community_release.yml"
 promotion="${ROOT}/.github/workflows/enterprise_prod_promotion.yml"
 grep -F 'name: HFL - Enterprise Release & Deploy' "${entry_enterprise}" >/dev/null
-grep -F 'tags:' "${entry_enterprise}" >/dev/null
+grep -F 'workflow_dispatch:' "${entry_enterprise}" >/dev/null
+if grep -F 'push:' "${entry_enterprise}" >/dev/null; then
+	printf 'ERROR: Enterprise release must be started manually (workflow_dispatch only)\n' >&2
+	exit 1
+fi
 grep -F 'edition: enterprise' "${entry_enterprise}" >/dev/null
 grep -F 'needs: validate-enterprise-build' "${entry_enterprise}" >/dev/null
-grep -F 'Manual Enterprise builds must be started from the main branch' \
+grep -F 'Enterprise builds must be started from the main branch' \
 	"${entry_enterprise}" >/dev/null
 grep -F 'name: HFL - Community Release & Deploy' "${entry_community}" >/dev/null
 if grep -F 'tags:' "${entry_community}" >/dev/null; then


### PR DESCRIPTION
## Problem

Every `HFL - Enterprise Release & Deploy` run fails in the `Quality` job's `Release and source checks` step. `test-enterprise-release-flow.sh` exits silently (0.17s, no output) because #659 switched `enterprise_release.yml` from push-tag auto-triggering to `workflow_dispatch`-only, but the contract test still required a `tags:` trigger.

Under `set -euo pipefail`, the stale `grep -F 'tags:'` assertion failed and killed the script before any later contract could run.

## Fix

Update the contract to match the manual-dispatch design:
- Require `workflow_dispatch:` instead of `tags:`
- Reject any `push:` trigger (guards against regression to auto-triggering)
- Expect the updated main-branch guard message (`Enterprise builds must be started from the main branch`)

## Verification

- Local run: `Enterprise release flow contracts passed.` (exit 0)
- CI-mode run (`CI=true GITHUB_ACTIONS=true`) also passes — the same mode that previously reproduced the silent failure
- `bash -n` syntax check passes