### PR TITLE
fix(frontend): include flow backup drawer in danger-confirm contract

### DIFF
--- a/src/frontend/src/components/dangerConfirmCoverage.test.ts
+++ b/src/frontend/src/components/dangerConfirmCoverage.test.ts
@@ -20,10 +20,11 @@ describe('danger confirmation coverage', () => {
       .sort()
 
     expect(actual).toEqual([
+      'lib/logout.ts',
       'pages/node/RepairNasRepository.vue',
       'pages/ops/AlertIncidents.vue',
       'pages/protection/DataProtection.vue',
-      'lib/logout.ts',
+      'pages/protection/components/FlowBackupSourceDetailDrawer.vue',
     ].sort())
   })
 


### PR DESCRIPTION
## Problem

The v0.2.5 enterprise release fails in `Quality` → `Frontend checks`:

```
AssertionError: expected [ 'lib/logout.ts', …(4) ] to deeply equal [ 'lib/logout.ts', …(3) ]
+   pages/protection/components/FlowBackupSourceDetailDrawer.vue,
```

#613 (`e31c30e`) added `discardCurrentFailedConfig` to `FlowBackupSourceDetailDrawer.vue`, which uses `ElMessageBox.confirm` before discarding a provision-failed backup configuration. `dangerConfirmCoverage.test.ts` pins every `ElMessageBox.confirm` usage to a non-destructive lightweight allowlist, and the drawer was not added — so the exact-match contract failed.

## Fix

Add the drawer to the allowlist. The confirmed action is non-destructive:

- Only visible when the config is in `provision_failed` state
- Confirmation copy: "Any repository ownership record is retained for safety, but you can configure this source again"
- Semantically equivalent to the already-allowed `confirmDiscardFixedRestore` in `DataProtection.vue`

## Verification

- `npx vitest run src/components/dangerConfirmCoverage.test.ts` → 2 tests passed
- Lint clean (0 diagnostics)