### PR TITLE
fix(ci): accept runtime extension paths in SaaS candidate assembly

### DIFF
--- a/release/ci/assemble-saas-candidate.sh
+++ b/release/ci/assemble-saas-candidate.sh
@@ -22,7 +22,7 @@ extensions=$5
 output=$6
 [[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
 [[ "${oss_commit}" =~ ^[0-9a-f]{40}$ && "${ee_commit}" =~ ^[0-9a-f]{40}$ ]]
-[[ "${extensions}" =~ ^[a-z0-9_]+(,[a-z0-9_]+)*$ ]]
+[[ "${extensions}" =~ ^/opt/hfl/extensions/[a-zA-Z0-9._-]+(,/opt/hfl/extensions/[a-zA-Z0-9._-]+)*$ ]]
 
 for component in \
 	hfl-backend hfl-frontend \


### PR DESCRIPTION
## 问题

`HFL - Enterprise SaaS Upgrade`（v0.2.5，run 32197723206）在 `Assemble · Registry candidate` 失败（13s，`exit code 1` 无输出）。

根因：`assemble-saas-candidate.sh` 第 25 行用纯扩展名正则校验 `HFL_EXTENSIONS`，但该变量的实际语义是 **镜像内运行时路径列表**（`materialize_extensions.py --print-extensions` 输出，如 `/opt/hfl/extensions/platform`，逗号分隔）。路径含 `/` 与 `-`，正则 `^[a-z0-9_]+...$` 不匹配 → `set -euo pipefail` 下脚本静默退出。

同一工作流 `build-hfl-images` 中该值作为 docker `HFL_EXTENSIONS` build-arg 正常使用，证明路径格式才是正确契约。

## 修复

```bash
-[[ "${extensions}" =~ ^[a-z0-9_]+(,[a-z0-9_]+)*$ ]]
+[[ "${extensions}" =~ ^/opt/hfl/extensions/[a-zA-Z0-9._-]+(,/opt/hfl/extensions/[a-zA-Z0-9._-]+)*$ ]]
```

本地验证：
- `bash -n` 语法通过
- 旧正则拦截 `/opt/hfl/extensions/platform`（预期）
- 新正则通过单/多扩展路径（`/opt/hfl/extensions/platform,/opt/hfl/extensions/ai-assistant`）

## 影响

- 仅 `release/ci/assemble-saas-candidate.sh` 单行改动
- 修复后 `v0.2.5` SaaS 流 `assemble-candidate` 应通过，可继续 `Deploy · TEST`