### PR TITLE
fix(protection): replace snapshot download result-passing with artifact upload streaming

### DIFF
--- a/deploy/nginx/snippets/hfl-tenant-locations.conf
+++ b/deploy/nginx/snippets/hfl-tenant-locations.conf
@@ -5,8 +5,8 @@
         proxy_pass http://hfl_api_http;
         include /etc/nginx/snippets/hfl-backend-proxy-headers.inc;
         proxy_http_version 1.1;
-        proxy_read_timeout 600s;
-        proxy_send_timeout 600s;
+        proxy_read_timeout 900s;
+        proxy_send_timeout 900s;
         proxy_buffering off;
         gzip off;
         chunked_transfer_encoding on;
@@ -21,6 +21,17 @@
         include /etc/nginx/snippets/hfl-backend-proxy-headers.inc;
         proxy_read_timeout 300s;
         proxy_send_timeout 300s;
+    }
+
+    # Snapshot artifacts are streamed from enrolled Agents into shared media.
+    # Disable request buffering so Nginx does not create a second 200 MiB copy.
+    location ~ ^/api/v1/protection/snapshot-download-artifacts/[0-9]+/content/?$ {
+        client_max_body_size 201m;
+        proxy_request_buffering off;
+        proxy_pass http://hfl_api_http;
+        include /etc/nginx/snippets/hfl-backend-proxy-headers.inc;
+        proxy_read_timeout 600s;
+        proxy_send_timeout 600s;
     }
 
     location /api/ {

--- a/src/agent/internal/engine/managed_backup.go
+++ b/src/agent/internal/engine/managed_backup.go
@@ -14,7 +14,10 @@ import (
 	"io/fs"
 	"log/slog"
 	"math"
+	"net/http"
+	"net/url"
 	"os"
+	"path"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -27,6 +30,7 @@ import (
 	agentdisk "hyperfilelens/agent/internal/platform/disk"
 	"hyperfilelens/agent/internal/platform/kopia"
 	"hyperfilelens/agent/internal/platform/process"
+	"hyperfilelens/agent/internal/platform/tlsclient"
 	nassvc "hyperfilelens/agent/internal/service/nas"
 )
 
@@ -1960,33 +1964,353 @@ func (e *Engine) runManagedSnapshotDownload(
 		return "failed", result, mkErr.Error()
 	}
 	defer os.RemoveAll(tempDir)
-	target := snapshotObjectPath(p.SnapshotID, p.Path)
-	isDir, inspectRes, inspectErr := snapshotDownloadTargetIsDir(ctx, bin, configFile, env, target)
-	result["snapshot_download_inspect"] = commandResult(inspectRes)
-	if inspectErr != nil && !snapshotDownloadInspectNotDirectory(inspectRes) {
-		return "failed", result, snapshotDownloadFailureMessage(inspectRes, inspectErr)
+	restoreRoot := filepath.Join(tempDir, "restore")
+	if err := os.MkdirAll(restoreRoot, 0o700); err != nil {
+		return "failed", result, err.Error()
 	}
-	restoreTarget := tempDir
-	if !isDir {
-		restoreTarget = filepath.Join(tempDir, snapshotDownloadFilename(p.Path))
+	requestedPaths, pathsErr := snapshotDownloadPaths(p)
+	if pathsErr != nil {
+		return "failed", result, pathsErr.Error()
 	}
-	restoreArgs := []string{"--config-file=" + configFile, "restore", target, restoreTarget}
-	res, runErr := process.Run(ctx, bin, restoreArgs, env, "")
-	result["snapshot_download"] = commandResult(res)
-	if runErr != nil {
-		return "failed", result, snapshotDownloadFailureMessage(res, runErr)
+	batchDownload := len(requestedPaths) > 0
+	forceZip := batchDownload
+	if len(requestedPaths) == 0 {
+		requestedPaths = []string{strings.Trim(strings.TrimSpace(p.Path), "/\\")}
 	}
-	downloadContent, filename, contentType, collectErr := collectRestoredDownload(tempDir, p.Path, isDir)
-	if collectErr != nil {
-		return "failed", result, collectErr.Error()
+	var singleIsDir bool
+	for _, requestedPath := range requestedPaths {
+		target := snapshotObjectPath(p.SnapshotID, requestedPath)
+		isDir, inspectRes, inspectErr := snapshotDownloadTargetIsDir(ctx, bin, configFile, env, target)
+		result["snapshot_download_inspect"] = commandResult(inspectRes)
+		if inspectErr != nil && !snapshotDownloadInspectNotDirectory(inspectRes) {
+			return "failed", result, snapshotDownloadFailureMessage(inspectRes, inspectErr)
+		}
+		singleIsDir = isDir
+		forceZip = forceZip || isDir
+		restoreTarget := restoreRoot
+		if batchDownload {
+			restoreTarget = filepath.Join(restoreRoot, filepath.FromSlash(requestedPath))
+			if err := os.MkdirAll(filepath.Dir(restoreTarget), 0o700); err != nil {
+				return "failed", result, err.Error()
+			}
+		} else if !isDir {
+			restoreTarget = filepath.Join(restoreRoot, snapshotDownloadFilename(requestedPath))
+		}
+		restoreArgs := []string{"--config-file=" + configFile, "restore", target, restoreTarget}
+		res, runErr := process.Run(ctx, bin, restoreArgs, env, "")
+		result["snapshot_download"] = commandResult(res)
+		if runErr != nil {
+			return "failed", result, snapshotDownloadFailureMessage(res, runErr)
+		}
+	}
+
+	uploadSpec, hasUpload, uploadErr := parseSnapshotArtifactUpload(p.Extra["artifact_upload"])
+	if uploadErr != nil {
+		return "failed", result, uploadErr.Error()
+	}
+	artifactPath := ""
+	filename := ""
+	contentType := "application/octet-stream"
+	if forceZip {
+		filename = snapshotDownloadArchiveName(p.Path, batchDownload)
+		artifactPath = filepath.Join(tempDir, filename)
+		maxBytes := int64(0)
+		if hasUpload {
+			maxBytes = uploadSpec.MaxBytes
+		}
+		if err := zipDirectoryContentsToFile(restoreRoot, artifactPath, maxBytes); err != nil {
+			return "failed", result, err.Error()
+		}
+		contentType = "application/zip"
+	} else {
+		entries, readErr := os.ReadDir(restoreRoot)
+		if readErr != nil || len(entries) != 1 || entries[0].IsDir() || singleIsDir {
+			return "failed", result, "restored file was not found"
+		}
+		artifactPath = filepath.Join(restoreRoot, entries[0].Name())
+		filename = entries[0].Name()
+	}
+	info, statErr := os.Stat(artifactPath)
+	if statErr != nil {
+		return "failed", result, statErr.Error()
+	}
+	if hasUpload {
+		uploadResult, uploadErr := e.uploadSnapshotArtifact(
+			ctx, uploadSpec, artifactPath, filename, contentType,
+		)
+		if uploadErr != nil {
+			return "failed", result, uploadErr.Error()
+		}
+		for key, value := range uploadResult {
+			result[key] = value
+		}
+		result["snapshot_id"] = p.SnapshotID
+		result["path"] = strings.Trim(strings.TrimSpace(p.Path), "/\\")
+		return "success", result, ""
+	}
+	downloadContent, readErr := os.ReadFile(artifactPath)
+	if readErr != nil {
+		return "failed", result, readErr.Error()
 	}
 	result["snapshot_id"] = p.SnapshotID
 	result["path"] = strings.Trim(strings.TrimSpace(p.Path), "/\\")
 	result["filename"] = filename
-	result["size_bytes"] = len(downloadContent)
+	result["size_bytes"] = info.Size()
 	result["content_type"] = contentType
 	result["content_base64"] = base64.StdEncoding.EncodeToString(downloadContent)
 	return "success", result, ""
+}
+
+type snapshotArtifactUploadSpec struct {
+	ArtifactID int64
+	Path       string
+	Token      string
+	MaxBytes   int64
+}
+
+func parseSnapshotArtifactUpload(raw any) (snapshotArtifactUploadSpec, bool, error) {
+	data, ok := raw.(map[string]any)
+	if !ok || len(data) == 0 {
+		return snapshotArtifactUploadSpec{}, false, nil
+	}
+	artifactID, idOK := exactInt64Value(data["artifact_id"])
+	maxBytes, maxOK := exactInt64Value(data["max_bytes"])
+	spec := snapshotArtifactUploadSpec{
+		ArtifactID: artifactID,
+		Path:       strings.TrimSpace(stringValue(data["path"])),
+		Token:      strings.TrimSpace(stringValue(data["token"])),
+		MaxBytes:   maxBytes,
+	}
+	if !idOK || spec.ArtifactID <= 0 || !maxOK || spec.MaxBytes <= 0 || spec.Path == "" || spec.Token == "" {
+		return snapshotArtifactUploadSpec{}, false, fmt.Errorf("snapshot artifact upload contract is invalid")
+	}
+	if !strings.HasPrefix(spec.Path, "/api/") || strings.Contains(spec.Path, "..") {
+		return snapshotArtifactUploadSpec{}, false, fmt.Errorf("snapshot artifact upload path is invalid")
+	}
+	return spec, true, nil
+}
+
+func snapshotDownloadPaths(p Payload) ([]string, error) {
+	raw, ok := p.Extra["paths"]
+	if !ok || raw == nil {
+		return nil, nil
+	}
+	items, ok := raw.([]any)
+	if !ok {
+		return nil, fmt.Errorf("snapshot download paths must be a list")
+	}
+	paths := make([]string, 0, len(items))
+	seen := map[string]struct{}{}
+	for _, item := range items {
+		value := strings.TrimSpace(stringValue(item))
+		value = strings.ReplaceAll(value, "\\", "/")
+		if path.IsAbs(value) || filepath.VolumeName(value) != "" {
+			return nil, fmt.Errorf("snapshot download path is invalid")
+		}
+		value = strings.Trim(value, "/")
+		clean := path.Clean(value)
+		if value == "" || clean == "." || clean == ".." || strings.HasPrefix(clean, "../") {
+			return nil, fmt.Errorf("snapshot download path is invalid")
+		}
+		if _, exists := seen[clean]; exists {
+			continue
+		}
+		seen[clean] = struct{}{}
+		paths = append(paths, clean)
+	}
+	if len(paths) == 0 {
+		return nil, fmt.Errorf("snapshot download paths are empty")
+	}
+	return paths, nil
+}
+
+func snapshotDownloadArchiveName(requestedPath string, batch bool) string {
+	if batch {
+		return "snapshot-download.zip"
+	}
+	name := snapshotDownloadFilename(requestedPath)
+	if name == "download" {
+		name = "snapshot"
+	}
+	return name + ".zip"
+}
+
+func fileSHA256(filePath string) (string, error) {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+	digest := sha256.New()
+	if _, err := io.Copy(digest, file); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(digest.Sum(nil)), nil
+}
+
+func (e *Engine) uploadSnapshotArtifact(
+	ctx context.Context,
+	spec snapshotArtifactUploadSpec,
+	filePath string,
+	filename string,
+	contentType string,
+) (map[string]any, error) {
+	info, err := os.Stat(filePath)
+	if err != nil {
+		return nil, err
+	}
+	if info.Size() > spec.MaxBytes {
+		return nil, fmt.Errorf("snapshot download exceeds the configured size limit")
+	}
+	checksum, err := fileSHA256(filePath)
+	if err != nil {
+		return nil, err
+	}
+	base := strings.TrimRight(strings.TrimSpace(e.current().APIBaseURL), "/")
+	if base == "" {
+		return nil, fmt.Errorf("control plane API URL is not configured")
+	}
+	baseURL, err := url.Parse(base)
+	if err != nil || (baseURL.Scheme != "https" && baseURL.Scheme != "http") || baseURL.Host == "" {
+		return nil, fmt.Errorf("control plane API URL is invalid")
+	}
+	uploadURL := base + spec.Path
+	client := &http.Client{}
+	if tlsclient.InsecureTLSEnabled() {
+		client.Transport = tlsclient.Transport()
+	}
+	var lastErr error
+	for attempt := 1; attempt <= 2; attempt++ {
+		file, openErr := os.Open(filePath)
+		if openErr != nil {
+			return nil, openErr
+		}
+		req, requestErr := http.NewRequestWithContext(ctx, http.MethodPut, uploadURL, file)
+		if requestErr != nil {
+			file.Close()
+			return nil, requestErr
+		}
+		req.ContentLength = info.Size()
+		req.Header.Set("Authorization", "Bearer "+spec.Token)
+		req.Header.Set("Content-Type", contentType)
+		req.Header.Set("X-Content-SHA256", checksum)
+		req.Header.Set("X-Artifact-Filename", url.QueryEscape(filename))
+		resp, sendErr := client.Do(req)
+		file.Close()
+		if sendErr != nil {
+			lastErr = sendErr
+			continue
+		}
+		body, readErr := io.ReadAll(io.LimitReader(resp.Body, 8*1024))
+		resp.Body.Close()
+		if readErr != nil {
+			lastErr = readErr
+			continue
+		}
+		if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+			return map[string]any{
+				"artifact_id":  spec.ArtifactID,
+				"filename":     filename,
+				"content_type": contentType,
+				"size_bytes":   info.Size(),
+				"sha256":       checksum,
+			}, nil
+		}
+		lastErr = fmt.Errorf("snapshot artifact upload returned HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+		if resp.StatusCode == http.StatusUnauthorized ||
+			resp.StatusCode == http.StatusForbidden ||
+			resp.StatusCode == http.StatusNotFound ||
+			resp.StatusCode == http.StatusRequestEntityTooLarge {
+			break
+		}
+	}
+	return nil, fmt.Errorf("snapshot artifact upload failed: %w", lastErr)
+}
+
+type boundedArtifactWriter struct {
+	w        io.Writer
+	written  int64
+	maxBytes int64
+}
+
+func (w *boundedArtifactWriter) Write(p []byte) (int, error) {
+	if w.maxBytes > 0 && w.written+int64(len(p)) > w.maxBytes {
+		return 0, fmt.Errorf("snapshot download exceeds the configured size limit")
+	}
+	n, err := w.w.Write(p)
+	w.written += int64(n)
+	return n, err
+}
+
+func zipDirectoryContentsToFile(root string, destination string, maxBytes int64) error {
+	file, err := os.OpenFile(destination, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	if err != nil {
+		return err
+	}
+	bounded := &boundedArtifactWriter{w: file, maxBytes: maxBytes}
+	zw := zip.NewWriter(bounded)
+	walkErr := filepath.WalkDir(root, func(filePath string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if filePath == root {
+			return nil
+		}
+		relative, err := filepath.Rel(root, filePath)
+		if err != nil {
+			return err
+		}
+		relative = filepath.ToSlash(relative)
+		if entry.IsDir() {
+			_, err = zw.Create(relative + "/")
+			return err
+		}
+		if entry.Type()&os.ModeSymlink != 0 {
+			return nil
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		if !info.Mode().IsRegular() {
+			return nil
+		}
+		header, err := zip.FileInfoHeader(info)
+		if err != nil {
+			return err
+		}
+		header.Name = relative
+		header.Method = zip.Deflate
+		writer, err := zw.CreateHeader(header)
+		if err != nil {
+			return err
+		}
+		input, err := os.Open(filePath)
+		if err != nil {
+			return err
+		}
+		_, copyErr := io.Copy(writer, input)
+		closeErr := input.Close()
+		if copyErr != nil {
+			return copyErr
+		}
+		return closeErr
+	})
+	closeZipErr := zw.Close()
+	closeFileErr := file.Close()
+	if walkErr != nil {
+		os.Remove(destination)
+		return walkErr
+	}
+	if closeZipErr != nil {
+		os.Remove(destination)
+		return closeZipErr
+	}
+	if closeFileErr != nil {
+		os.Remove(destination)
+		return closeFileErr
+	}
+	return nil
 }
 
 func snapshotDownloadTargetIsDir(ctx context.Context, bin string, configFile string, env map[string]string, target string) (bool, process.Result, error) {
@@ -2702,9 +3026,15 @@ func zipDirectoryContents(root string) ([]byte, error) {
 			_, createErr := zw.Create(rel + "/")
 			return createErr
 		}
+		if d.Type()&os.ModeSymlink != 0 {
+			return nil
+		}
 		info, infoErr := d.Info()
 		if infoErr != nil {
 			return infoErr
+		}
+		if !info.Mode().IsRegular() {
+			return nil
 		}
 		header, headerErr := zip.FileInfoHeader(info)
 		if headerErr != nil {
@@ -2897,6 +3227,41 @@ func truncateSnapshotBrowseError(value string, limit int) string {
 	return value[:limit]
 }
 
+// formatModTimeUTC parses a time string from Kopia output and returns it as
+// RFC 3339 (ISO 8601) in UTC. Kopia snapshot timestamps are always UTC but
+// the ls -l output omits the timezone indicator, causing frontends to
+// misinterpret them as local time.
+func formatModTimeUTC(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	// Strip trailing " UTC" / " UTC" that some Kopia JSON outputs append.
+	utcStripped := strings.TrimSuffix(raw, " UTC")
+	utcStripped = strings.TrimSuffix(utcStripped, " UTC")
+	utcStripped = strings.TrimSpace(utcStripped)
+	formats := []string{
+		"Jan 2 2006",
+		"Jan 2 15:04",
+		"Jan 2 15:04:05",
+		"2006-01-02 15:04:05",
+		"2006-01-02T15:04:05",
+		time.RFC3339,
+	}
+	for _, layout := range formats {
+		t, err := time.Parse(layout, utcStripped)
+		if err != nil {
+			continue
+		}
+		year := t.Year()
+		if year == 0 {
+			year = time.Now().Year()
+		}
+		return time.Date(year, t.Month(), t.Day(), t.Hour(), t.Minute(), t.Second(), t.Nanosecond(), time.UTC).Format(time.RFC3339)
+	}
+	return raw
+}
+
 func parseSnapshotBrowseLongLine(line string) (mode string, size int64, modTime string, name string, ok bool) {
 	fields := strings.Fields(line)
 	if len(fields) < 7 || !looksLikeMode(fields[0]) {
@@ -2904,7 +3269,7 @@ func parseSnapshotBrowseLongLine(line string) (mode string, size int64, modTime 
 	}
 	mode = fields[0]
 	size, _ = strconv.ParseInt(fields[1], 10, 64)
-	modTime = strings.Join(fields[2:5], " ")
+	modTime = formatModTimeUTC(strings.Join(fields[2:5], " "))
 	objectID := fields[5]
 	idx := strings.Index(line, objectID)
 	if idx < 0 {
@@ -3032,7 +3397,7 @@ func collectSnapshotEntries(raw any, rows *[]map[string]any, basePath string, sn
 			typ = "file"
 		}
 		size, _ := int64Value(firstPresent(value, "size", "size_bytes", "length"))
-		modTime := strings.TrimSpace(stringValue(firstPresent(value, "mod_time", "modified_at", "mtime", "modTime")))
+		modTime := formatModTimeUTC(strings.TrimSpace(stringValue(firstPresent(value, "mod_time", "modified_at", "mtime", "modTime"))))
 		path := normalizeSnapshotBrowsePath(
 			strings.TrimSpace(stringValue(firstPresent(value, "path", "name"))),
 			name,

--- a/src/agent/internal/engine/managed_backup_test.go
+++ b/src/agent/internal/engine/managed_backup_test.go
@@ -5,8 +5,11 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"io/fs"
 	"math"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -1586,6 +1589,122 @@ func TestCollectRestoredDownloadReturnsZipForDirectoryContainingOnlyDotfile(t *t
 	}
 	if len(zr.File) != 1 || zr.File[0].Name != ".hidden-note" {
 		t.Fatalf("expected zip to contain .hidden-note, got %#v", zr.File)
+	}
+}
+
+func TestUploadSnapshotArtifactStreamsFileWithIntegrityHeaders(t *testing.T) {
+	t.Setenv("HFL_INSECURE_TLS", "0")
+	content := []byte("streamed snapshot artifact")
+	var received []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut || r.URL.Path != "/upload" {
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		if r.Header.Get("Authorization") != "Bearer task-token" {
+			t.Fatalf("unexpected authorization header")
+		}
+		if r.Header.Get("X-Content-SHA256") == "" || r.Header.Get("X-Artifact-Filename") != "report.txt" {
+			t.Fatalf("missing artifact integrity headers: %#v", r.Header)
+		}
+		var err error
+		received, err = io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	filePath := filepath.Join(t.TempDir(), "report.txt")
+	if err := os.WriteFile(filePath, content, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	engine := New(staticConfigProvider{cfg: &model.AgentConfig{APIBaseURL: server.URL}})
+	result, err := engine.uploadSnapshotArtifact(
+		context.Background(),
+		snapshotArtifactUploadSpec{ArtifactID: 7, Path: "/upload", Token: "task-token", MaxBytes: 1024},
+		filePath,
+		"report.txt",
+		"application/octet-stream",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(received, content) || result["artifact_id"] != int64(7) {
+		t.Fatalf("unexpected upload result %#v content=%q", result, received)
+	}
+}
+
+func TestUploadSnapshotArtifactHonorsInsecureTLS(t *testing.T) {
+	content := []byte("self-signed snapshot artifact")
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut || r.URL.Path != "/upload" {
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	filePath := filepath.Join(t.TempDir(), "report.txt")
+	if err := os.WriteFile(filePath, content, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	engine := New(staticConfigProvider{cfg: &model.AgentConfig{APIBaseURL: server.URL}})
+	spec := snapshotArtifactUploadSpec{ArtifactID: 7, Path: "/upload", Token: "task-token", MaxBytes: 1024}
+
+	t.Setenv("HFL_INSECURE_TLS", "0")
+	if _, err := engine.uploadSnapshotArtifact(
+		context.Background(), spec, filePath, "report.txt", "application/octet-stream",
+	); err == nil {
+		t.Fatal("expected strict TLS verification to reject the self-signed server")
+	}
+
+	t.Setenv("HFL_INSECURE_TLS", "1")
+	if _, err := engine.uploadSnapshotArtifact(
+		context.Background(), spec, filePath, "report.txt", "application/octet-stream",
+	); err != nil {
+		t.Fatalf("expected configured insecure TLS upload to succeed: %v", err)
+	}
+}
+
+func TestZipDirectoryContentsToFileEnforcesArtifactLimit(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "large.bin"), bytes.Repeat([]byte("x"), 4096), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	destination := filepath.Join(t.TempDir(), "download.zip")
+	if err := zipDirectoryContentsToFile(root, destination, 16); err == nil {
+		t.Fatal("expected configured artifact limit to reject ZIP output")
+	}
+	if _, err := os.Stat(destination); !os.IsNotExist(err) {
+		t.Fatalf("partial ZIP was not removed: %v", err)
+	}
+}
+
+func TestZipDirectoryContentsToFileDoesNotFollowSymlinks(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires additional privileges on Windows")
+	}
+	root := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "secret.txt")
+	if err := os.WriteFile(outside, []byte("must not be archived"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(root, "linked-secret")); err != nil {
+		t.Fatal(err)
+	}
+	destination := filepath.Join(t.TempDir(), "download.zip")
+	if err := zipDirectoryContentsToFile(root, destination, 1024); err != nil {
+		t.Fatal(err)
+	}
+	archive, err := zip.OpenReader(destination)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer archive.Close()
+	if len(archive.File) != 0 {
+		t.Fatalf("symlink target escaped into artifact: %#v", archive.File)
 	}
 }
 

--- a/src/agent/internal/remote/inventory.go
+++ b/src/agent/internal/remote/inventory.go
@@ -56,6 +56,7 @@ func SendInventory(
 			"repository_ownership_v1",
 			"backup_prepared_snapshot_v1",
 			"snapshot_browse_v1",
+			"snapshot_artifact_upload_v1",
 			"snapshot_scope_resolve_v1",
 			"insight_safe_restore_v1",
 			"network_inventory_v1",

--- a/src/backend/apps/protection/api/urls.py
+++ b/src/backend/apps/protection/api/urls.py
@@ -16,6 +16,8 @@ from apps.protection.api.views import (
     SnapshotDirectoryDownloadView,
     SnapshotDirectoryDownloadTaskView,
     SnapshotDownloadArtifactFileView,
+    SnapshotDownloadArtifactContentView,
+    SnapshotDownloadArtifactDownloadUrlView,
     health,
 )
 
@@ -67,6 +69,16 @@ urlpatterns = [
         "backup-source-snapshot-directories/<int:directory_id>/batch-download-tasks/",
         SnapshotDirectoryBatchDownloadTaskView.as_view(),
         name="protection-backup-source-snapshot-directory-batch-download-task",
+    ),
+    path(
+        "snapshot-download-artifacts/<int:artifact_id>/content/",
+        SnapshotDownloadArtifactContentView.as_view(),
+        name="protection-snapshot-download-artifact-content",
+    ),
+    path(
+        "snapshot-download-artifacts/<int:artifact_id>/download-url/",
+        SnapshotDownloadArtifactDownloadUrlView.as_view(),
+        name="protection-snapshot-download-artifact-download-url",
     ),
     path(
         "snapshot-download-artifacts/<int:artifact_id>/file/",

--- a/src/backend/apps/protection/api/views/__init__.py
+++ b/src/backend/apps/protection/api/views/__init__.py
@@ -15,6 +15,8 @@ from apps.protection.api.views.snapshot_browser import (
     SnapshotDirectoryDownloadView,
     SnapshotDirectoryDownloadTaskView,
     SnapshotDownloadArtifactFileView,
+    SnapshotDownloadArtifactContentView,
+    SnapshotDownloadArtifactDownloadUrlView,
 )
 
 __all__ = [
@@ -32,5 +34,7 @@ __all__ = [
     "SnapshotDirectoryDownloadView",
     "SnapshotDirectoryDownloadTaskView",
     "SnapshotDownloadArtifactFileView",
+    "SnapshotDownloadArtifactContentView",
+    "SnapshotDownloadArtifactDownloadUrlView",
     "health",
 ]

--- a/src/backend/apps/protection/api/views/snapshot_browser.py
+++ b/src/backend/apps/protection/api/views/snapshot_browser.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from urllib.parse import quote
+from urllib.parse import quote, unquote, urlencode
 from pathlib import Path
 
 from django.core.exceptions import ValidationError as DjangoValidationError
@@ -8,6 +8,7 @@ from django.http import FileResponse, HttpResponse
 from django.utils import timezone
 from rest_framework.exceptions import NotFound, PermissionDenied, ValidationError
 from rest_framework.permissions import IsAuthenticated
+from rest_framework.permissions import AllowAny
 from rest_framework.views import APIView
 from rest_framework.response import Response
 
@@ -22,8 +23,12 @@ from apps.protection.services.snapshot_browser import (
 from apps.protection.services.snapshot_download import (
     create_snapshot_batch_download_task,
     create_snapshot_download_task,
+    create_snapshot_artifact_file_token,
+    accept_snapshot_artifact_upload,
     get_snapshot_download_artifact,
     mark_artifact_downloaded,
+    SnapshotArtifactUploadError,
+    validate_snapshot_artifact_file_token,
 )
 from apps.protection.models import SnapshotDownloadArtifact
 from apps.task.api.serializers import TaskSerializer
@@ -146,6 +151,18 @@ class SnapshotDownloadArtifactFileView(APIView):
 
     def get(self, request, artifact_id: int):
         org = require_org(request)
+        token = str(request.query_params.get("token") or "").strip()
+        if token:
+            try:
+                token_organization_id = validate_snapshot_artifact_file_token(
+                    token=token,
+                    artifact_id=int(artifact_id),
+                    user_id=int(request.user.id),
+                )
+            except SnapshotArtifactUploadError as exc:
+                raise PermissionDenied(str(exc)) from exc
+            if token_organization_id != org.id:
+                raise PermissionDenied("snapshot download link does not match the organization")
         artifact = get_snapshot_download_artifact(
             organization_id=org.id,
             artifact_id=int(artifact_id),
@@ -165,3 +182,56 @@ class SnapshotDownloadArtifactFileView(APIView):
         response["Content-Disposition"] = f"attachment; filename*=UTF-8''{filename}"
         response["Content-Length"] = str(artifact.size_bytes)
         return response
+
+
+class SnapshotDownloadArtifactDownloadUrlView(APIView):
+    permission_classes = [IsAuthenticated, IsOrgReader]
+
+    def get(self, request, artifact_id: int):
+        org = require_org(request)
+        artifact = get_snapshot_download_artifact(
+            organization_id=org.id,
+            artifact_id=int(artifact_id),
+        )
+        if artifact is None:
+            raise NotFound("snapshot download artifact not found")
+        if artifact.status != SnapshotDownloadArtifact.Status.READY or artifact.expires_at <= timezone.now():
+            raise ValidationError({"detail": "snapshot download artifact is not available"})
+        token = create_snapshot_artifact_file_token(
+            artifact=artifact,
+            user_id=int(request.user.id),
+        )
+        path = f"/api/v1/protection/snapshot-download-artifacts/{artifact.id}/file/"
+        return Response({"url": f"{path}?{urlencode({'token': token, 'org': org.key})}"})
+
+
+class SnapshotDownloadArtifactContentView(APIView):
+    authentication_classes = []
+    permission_classes = [AllowAny]
+    parser_classes = []
+
+    def put(self, request, artifact_id: int):
+        authorization = str(request.META.get("HTTP_AUTHORIZATION") or "")
+        scheme, _, token = authorization.partition(" ")
+        if scheme.lower() != "bearer" or not token.strip():
+            raise PermissionDenied("snapshot download upload token is required")
+        try:
+            artifact = accept_snapshot_artifact_upload(
+                artifact_id=int(artifact_id),
+                token=token.strip(),
+                stream=request.stream,
+                content_length=request.META.get("CONTENT_LENGTH"),
+                content_type=request.content_type or "application/octet-stream",
+                expected_sha256=request.META.get("HTTP_X_CONTENT_SHA256") or "",
+                filename=unquote(request.META.get("HTTP_X_ARTIFACT_FILENAME") or ""),
+            )
+        except SnapshotArtifactUploadError as exc:
+            raise ValidationError({"detail": str(exc)}) from exc
+        return Response(
+            {
+                "artifact_id": artifact.id,
+                "size_bytes": artifact.size_bytes,
+                "sha256": artifact.sha256,
+                "status": artifact.status,
+            }
+        )

--- a/src/backend/apps/protection/migrations/0019_snapshot_download_upload.py
+++ b/src/backend/apps/protection/migrations/0019_snapshot_download_upload.py
@@ -1,0 +1,34 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [("protection", "0018_backup_directory_repository_locator")]
+
+    operations = [
+        migrations.AddField(
+            model_name="snapshotdownloadartifact",
+            name="sha256",
+            field=models.CharField(blank=True, default="", max_length=64),
+        ),
+        migrations.AddField(
+            model_name="snapshotdownloadartifact",
+            name="upload_token_digest",
+            field=models.CharField(blank=True, default="", max_length=64),
+        ),
+        migrations.AlterField(
+            model_name="snapshotdownloadartifact",
+            name="status",
+            field=models.CharField(
+                choices=[
+                    ("uploading", "Uploading"),
+                    ("ready", "Ready"),
+                    ("failed", "Failed"),
+                    ("expired", "Expired"),
+                    ("deleted", "Deleted"),
+                ],
+                db_index=True,
+                default="ready",
+                max_length=20,
+            ),
+        ),
+    ]

--- a/src/backend/apps/protection/migrations/0021_snapshot_download_upload.py
+++ b/src/backend/apps/protection/migrations/0021_snapshot_download_upload.py
@@ -2,7 +2,7 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-    dependencies = [("protection", "0018_backup_directory_repository_locator")]
+    dependencies = [("protection", "0020_backup_config_provisioning")]
 
     operations = [
         migrations.AddField(

--- a/src/backend/apps/protection/models/snapshot_download.py
+++ b/src/backend/apps/protection/models/snapshot_download.py
@@ -7,7 +7,9 @@ from apps.task.models import Task
 
 class SnapshotDownloadArtifact(models.Model):
     class Status(models.TextChoices):
+        UPLOADING = "uploading", "Uploading"
         READY = "ready", "Ready"
+        FAILED = "failed", "Failed"
         EXPIRED = "expired", "Expired"
         DELETED = "deleted", "Deleted"
 
@@ -22,7 +24,9 @@ class SnapshotDownloadArtifact(models.Model):
     filename = models.CharField(max_length=300)
     content_type = models.CharField(max_length=120, default="application/octet-stream")
     size_bytes = models.BigIntegerField(default=0)
+    sha256 = models.CharField(max_length=64, blank=True, default="")
     storage_path = models.CharField(max_length=1200)
+    upload_token_digest = models.CharField(max_length=64, blank=True, default="")
     status = models.CharField(
         max_length=20,
         choices=Status.choices,

--- a/src/backend/apps/protection/periodic_tasks.py
+++ b/src/backend/apps/protection/periodic_tasks.py
@@ -63,3 +63,12 @@ def register_periodic_tasks() -> None:
         queue=None,
         enabled=True,
     )
+    TASK_REGISTRY.add(
+        name="protection_cleanup_snapshot_download_artifacts",
+        task="apps.protection.tasks.snapshot_download.cleanup_snapshot_download_artifacts",
+        schedule=60 * 60,
+        args=(),
+        kwargs={"limit": 1000},
+        queue=None,
+        enabled=True,
+    )

--- a/src/backend/apps/protection/services/snapshot_browser.py
+++ b/src/backend/apps/protection/services/snapshot_browser.py
@@ -33,11 +33,16 @@ class SnapshotBrowserForbidden(PermissionError):
     """Snapshot directory exists but cannot be browsed."""
 
 
+class SnapshotArtifactUploadUnsupported(SnapshotBrowserError):
+    """The selected repository reader predates artifact upload support."""
+
+
 @dataclass(frozen=True)
 class SnapshotFileDownload:
     filename: str
     content: bytes
     content_type: str = "application/octet-stream"
+    artifact_id: int | None = None
 
 
 def _clean_relative_path(path: str) -> str:
@@ -151,6 +156,7 @@ def _run_snapshot_agent_task(
     kind: str,
     path: str,
     wait_timeout_seconds: int,
+    extra_payload: dict[str, Any] | None = None,
 ) -> Any:
     snapshot = row.source_snapshot
     repository = _repository_for_directory(row)
@@ -177,15 +183,32 @@ def _run_snapshot_agent_task(
         path,
         wait_timeout_seconds,
     )
+    payload = {
+        "repository": repository_access.repository_payload,
+        "snapshot_id": row.kopia_snapshot_id,
+        "path": path,
+    }
+    if extra_payload:
+        payload.update(extra_payload)
+    persisted_payload = {
+        "snapshot_id": row.kopia_snapshot_id,
+        "path": path,
+    }
+    if isinstance(payload.get("paths"), list):
+        persisted_payload["paths"] = payload["paths"]
+    if isinstance(payload.get("artifact_upload"), dict):
+        upload = payload["artifact_upload"]
+        persisted_payload["artifact_upload"] = {
+            "artifact_id": upload.get("artifact_id"),
+            "path": upload.get("path"),
+            "max_bytes": upload.get("max_bytes"),
+        }
     outcome = run_agent_task_sync(
         organization_id=row.organization_id,
         node_id=repository_access.node.id,
         kind=kind,
-        payload={
-            "repository": repository_access.repository_payload,
-            "snapshot_id": row.kopia_snapshot_id,
-            "path": path,
-        },
+        payload=payload,
+        persisted_payload=persisted_payload,
         correlation_type="protection.snapshot_browser",
         correlation_id=str(row.id),
         wait_timeout_seconds=wait_timeout_seconds,
@@ -259,22 +282,78 @@ def download_snapshot_file(
     directory_id: int,
     path: str,
     wait_timeout_seconds: int | None = None,
+    upload_artifact=None,
+    paths: list[str] | None = None,
 ) -> SnapshotFileDownload:
     clean_path = _clean_relative_path(path)
     row = _get_directory(organization_id=organization_id, directory_id=directory_id)
-    if not clean_path and row.path_type != BackupSourceSnapshotDirectory.PathType.FILE:
+    clean_paths = [_clean_relative_path(item) for item in paths or []]
+    if not clean_path and not clean_paths and row.path_type != BackupSourceSnapshotDirectory.PathType.FILE:
         raise SnapshotBrowserForbidden("File path is required.")
+    extra_payload: dict[str, Any] = {}
+    if clean_paths:
+        extra_payload["paths"] = clean_paths
+    if upload_artifact is not None:
+        from apps.protection.services.snapshot_download import prepare_snapshot_artifact_upload
+
+        repository = _repository_for_directory(row)
+        fallback_target = None
+        if not repository_uses_bound_proxy(repository):
+            fallback_target = _resolve_execution_target(source_snapshot=row.source_snapshot)
+        repository_access = resolve_snapshot_repository_reader(
+            directory=row,
+            repository=repository,
+            fallback_node=fallback_target.node if fallback_target is not None else None,
+            source_type=row.source_snapshot.source_type,
+            source_ref_id=row.source_snapshot.source_ref_id,
+        )
+        metadata = repository_access.node.metadata if isinstance(repository_access.node.metadata, dict) else {}
+        inventory = metadata.get("inventory") if isinstance(metadata.get("inventory"), dict) else {}
+        capabilities = inventory.get("capabilities", metadata.get("capabilities", []))
+        capabilities = capabilities if isinstance(capabilities, (list, tuple, set)) else []
+        if clean_paths and "snapshot_artifact_upload_v1" not in capabilities:
+            raise SnapshotArtifactUploadUnsupported(
+                "The repository access Agent must be upgraded before downloading multiple snapshot paths."
+            )
+        extra_payload["artifact_upload"] = prepare_snapshot_artifact_upload(
+            artifact=upload_artifact,
+            node_id=repository_access.node.id,
+        )
     outcome = _run_snapshot_agent_task(
         row=row,
         kind="snapshot.download",
         path=clean_path,
         wait_timeout_seconds=_snapshot_browser_timeout_seconds() if wait_timeout_seconds is None else wait_timeout_seconds,
+        extra_payload=extra_payload,
     )
+    if upload_artifact is not None:
+        upload_artifact.refresh_from_db()
+        if upload_artifact.status == upload_artifact.Status.READY:
+            return SnapshotFileDownload(
+                filename=upload_artifact.filename,
+                content=b"",
+                content_type=upload_artifact.content_type,
+                artifact_id=upload_artifact.id,
+            )
     if getattr(outcome, "timed_out", False):
         raise SnapshotBrowserError("Snapshot download timed out.")
     if not getattr(outcome, "ok", False):
         raise SnapshotBrowserError(_agent_result_error(outcome, "Snapshot download failed."))
     result = outcome.result if isinstance(outcome.result, dict) else {}
+    if result.get("result_truncated"):
+        raise SnapshotBrowserError(
+            "Snapshot download content exceeded the legacy Agent result limit. Upgrade the Agent and retry."
+        )
+    if upload_artifact is not None and int(result.get("artifact_id") or 0) == int(upload_artifact.id):
+        upload_artifact.refresh_from_db()
+        if upload_artifact.status != upload_artifact.Status.READY:
+            raise SnapshotBrowserError("Snapshot download upload did not finalize the artifact.")
+        return SnapshotFileDownload(
+            filename=upload_artifact.filename,
+            content=b"",
+            content_type=upload_artifact.content_type,
+            artifact_id=upload_artifact.id,
+        )
     raw = str(result.get("content_base64") or "").strip()
     size_bytes: int | None
     try:

--- a/src/backend/apps/protection/services/snapshot_download.py
+++ b/src/backend/apps/protection/services/snapshot_download.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import logging
 import os
 import threading
@@ -8,15 +9,19 @@ from datetime import timedelta
 from io import BytesIO
 from pathlib import Path
 from typing import Any
+from uuid import uuid4
 
 from django.conf import settings
+from django.core import signing
 from django.core.exceptions import ValidationError
 from django.db import close_old_connections, transaction
 from django.utils import timezone
+from django.utils.crypto import constant_time_compare
 from django.utils.text import get_valid_filename
 
 from apps.protection.models import BackupSourceSnapshotDirectory, SnapshotDownloadArtifact
 from apps.protection.services.snapshot_browser import (
+    SnapshotArtifactUploadUnsupported,
     SnapshotFileDownload,
     SnapshotBrowserError,
     SnapshotBrowserForbidden,
@@ -31,7 +36,17 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_SNAPSHOT_DOWNLOAD_EXPIRES_HOURS = 24
 DEFAULT_SNAPSHOT_DOWNLOAD_MAX_BYTES = 200 * 1024 * 1024
+DEFAULT_SNAPSHOT_DOWNLOAD_TIMEOUT_SECONDS = 15 * 60
 DEFAULT_SNAPSHOT_BATCH_DOWNLOAD_MAX_PATHS = 100
+SNAPSHOT_DOWNLOAD_UPLOAD_PATH = "/api/v1/protection/snapshot-download-artifacts/{artifact_id}/content/"
+SNAPSHOT_DOWNLOAD_UPLOAD_MAX_AGE_SECONDS = 60 * 60
+_SNAPSHOT_DOWNLOAD_UPLOAD_SIGNING_SALT = "protection-snapshot-download-upload"
+SNAPSHOT_DOWNLOAD_FILE_TOKEN_MAX_AGE_SECONDS = 5 * 60
+_SNAPSHOT_DOWNLOAD_FILE_SIGNING_SALT = "protection-snapshot-download-file"
+
+
+class SnapshotArtifactUploadError(ValueError):
+    """Raised when an Agent artifact upload cannot be accepted safely."""
 
 
 def _artifact_root() -> Path:
@@ -54,6 +69,229 @@ def _max_download_bytes() -> int:
         return max(1, int(raw))
     except (TypeError, ValueError):
         return DEFAULT_SNAPSHOT_DOWNLOAD_MAX_BYTES
+
+
+def _download_timeout_seconds() -> int:
+    raw = getattr(
+        settings,
+        "PROTECTION_SNAPSHOT_DOWNLOAD_TIMEOUT_SECONDS",
+        DEFAULT_SNAPSHOT_DOWNLOAD_TIMEOUT_SECONDS,
+    )
+    try:
+        return max(1, int(raw))
+    except (TypeError, ValueError):
+        return DEFAULT_SNAPSHOT_DOWNLOAD_TIMEOUT_SECONDS
+
+
+def _token_digest(token: str) -> str:
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+def _artifact_storage_path(*, task: Task, filename: str) -> Path:
+    return _artifact_root() / str(task.organization_id) / str(task.task_uuid) / filename
+
+
+def _create_pending_artifact(
+    *,
+    task: Task,
+    directory_id: int,
+    relative_path: str,
+    filename: str,
+) -> SnapshotDownloadArtifact:
+    safe_filename = _safe_filename(filename, "snapshot-download")
+    return SnapshotDownloadArtifact.objects.create(
+        task=task,
+        organization_id=task.organization_id,
+        source_snapshot_directory_id=directory_id,
+        relative_path=relative_path,
+        filename=safe_filename,
+        content_type="application/octet-stream",
+        size_bytes=0,
+        storage_path=str(_artifact_storage_path(task=task, filename=safe_filename)),
+        status=SnapshotDownloadArtifact.Status.UPLOADING,
+        expires_at=_expires_at(),
+    )
+
+
+def prepare_snapshot_artifact_upload(
+    *, artifact: SnapshotDownloadArtifact, node_id: int
+) -> dict[str, Any]:
+    if artifact.status != SnapshotDownloadArtifact.Status.UPLOADING:
+        raise SnapshotArtifactUploadError("snapshot download artifact is not accepting uploads")
+    token = signing.dumps(
+        {
+            "artifact_id": int(artifact.id),
+            "task_id": int(artifact.task_id),
+            "organization_id": int(artifact.organization_id),
+            "node_id": int(node_id),
+            "nonce": str(uuid4()),
+        },
+        salt=_SNAPSHOT_DOWNLOAD_UPLOAD_SIGNING_SALT,
+        compress=True,
+    )
+    artifact.upload_token_digest = _token_digest(token)
+    artifact.save(update_fields=["upload_token_digest", "updated_at"])
+    return {
+        "artifact_id": int(artifact.id),
+        "path": SNAPSHOT_DOWNLOAD_UPLOAD_PATH.format(artifact_id=artifact.id),
+        "token": token,
+        "max_bytes": _max_download_bytes(),
+    }
+
+
+def _validated_upload_token(token: str) -> dict[str, Any]:
+    try:
+        payload = signing.loads(
+            token,
+            salt=_SNAPSHOT_DOWNLOAD_UPLOAD_SIGNING_SALT,
+            max_age=SNAPSHOT_DOWNLOAD_UPLOAD_MAX_AGE_SECONDS,
+        )
+    except signing.SignatureExpired as exc:
+        raise SnapshotArtifactUploadError("snapshot download upload token expired") from exc
+    except signing.BadSignature as exc:
+        raise SnapshotArtifactUploadError("invalid snapshot download upload token") from exc
+    if not isinstance(payload, dict):
+        raise SnapshotArtifactUploadError("invalid snapshot download upload token payload")
+    return payload
+
+
+def create_snapshot_artifact_file_token(
+    *, artifact: SnapshotDownloadArtifact, user_id: int
+) -> str:
+    return signing.dumps(
+        {
+            "artifact_id": int(artifact.id),
+            "organization_id": int(artifact.organization_id),
+            "user_id": int(user_id),
+        },
+        salt=_SNAPSHOT_DOWNLOAD_FILE_SIGNING_SALT,
+        compress=True,
+    )
+
+
+def validate_snapshot_artifact_file_token(
+    *, token: str, artifact_id: int, user_id: int
+) -> int:
+    try:
+        payload = signing.loads(
+            token,
+            salt=_SNAPSHOT_DOWNLOAD_FILE_SIGNING_SALT,
+            max_age=SNAPSHOT_DOWNLOAD_FILE_TOKEN_MAX_AGE_SECONDS,
+        )
+    except (signing.BadSignature, signing.SignatureExpired) as exc:
+        raise SnapshotArtifactUploadError("snapshot download link is invalid or expired") from exc
+    if not isinstance(payload, dict) or (
+        int(payload.get("artifact_id") or 0) != int(artifact_id)
+        or int(payload.get("user_id") or 0) != int(user_id)
+    ):
+        raise SnapshotArtifactUploadError("snapshot download link does not match this request")
+    return int(payload.get("organization_id") or 0)
+
+
+def accept_snapshot_artifact_upload(
+    *,
+    artifact_id: int,
+    token: str,
+    stream,
+    content_length: int,
+    content_type: str,
+    expected_sha256: str,
+    filename: str,
+) -> SnapshotDownloadArtifact:
+    clean_token = str(token or "").strip()
+    signed = _validated_upload_token(clean_token)
+    if int(signed.get("artifact_id") or 0) != int(artifact_id):
+        raise SnapshotArtifactUploadError("upload token does not match the artifact")
+    try:
+        content_length = int(content_length)
+    except (TypeError, ValueError) as exc:
+        raise SnapshotArtifactUploadError("Content-Length is required") from exc
+    if content_length < 0 or content_length > _max_download_bytes():
+        raise SnapshotArtifactUploadError("snapshot download exceeds the configured size limit")
+    expected_sha256 = str(expected_sha256 or "").strip().lower()
+    if len(expected_sha256) != 64 or any(ch not in "0123456789abcdef" for ch in expected_sha256):
+        raise SnapshotArtifactUploadError("X-Content-SHA256 is required")
+
+    artifact = SnapshotDownloadArtifact.objects.select_related("task").filter(id=artifact_id).first()
+    if artifact is None:
+        raise SnapshotArtifactUploadError("snapshot download artifact was not found")
+    if (
+        int(signed.get("task_id") or 0) != int(artifact.task_id)
+        or int(signed.get("organization_id") or 0) != int(artifact.organization_id)
+    ):
+        raise SnapshotArtifactUploadError("upload token does not match the download task")
+    if artifact.status == SnapshotDownloadArtifact.Status.READY:
+        if artifact.sha256 == expected_sha256 and artifact.size_bytes == content_length:
+            return artifact
+        raise SnapshotArtifactUploadError("snapshot download artifact was already finalized")
+    if not constant_time_compare(artifact.upload_token_digest, _token_digest(clean_token)):
+        raise SnapshotArtifactUploadError("upload token does not match the download task")
+    if artifact.status != SnapshotDownloadArtifact.Status.UPLOADING:
+        raise SnapshotArtifactUploadError("snapshot download artifact is not accepting uploads")
+    if artifact.expires_at <= timezone.now():
+        raise SnapshotArtifactUploadError("snapshot download artifact expired")
+    if artifact.task.status != Task.Status.RUNNING:
+        raise SnapshotArtifactUploadError("snapshot download task is no longer accepting uploads")
+
+    initial_path = Path(artifact.storage_path)
+    initial_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    safe_filename = _safe_filename(filename, artifact.filename)
+    final_path = _artifact_storage_path(task=artifact.task, filename=safe_filename)
+    temporary_path = initial_path.with_name(f".{initial_path.name}.{uuid4().hex}.part")
+    digest = hashlib.sha256()
+    written = 0
+    try:
+        with open(temporary_path, "xb") as output:
+            os.chmod(temporary_path, 0o600)
+            while True:
+                chunk = stream.read(1024 * 1024)
+                if not chunk:
+                    break
+                written += len(chunk)
+                if written > content_length or written > _max_download_bytes():
+                    raise SnapshotArtifactUploadError("snapshot download exceeds the declared size")
+                output.write(chunk)
+                digest.update(chunk)
+        if written != content_length:
+            raise SnapshotArtifactUploadError("snapshot download upload was incomplete")
+        if not constant_time_compare(digest.hexdigest(), expected_sha256):
+            raise SnapshotArtifactUploadError("snapshot download checksum mismatch")
+
+        with transaction.atomic():
+            locked_task = Task.objects.select_for_update().get(id=artifact.task_id)
+            if locked_task.status != Task.Status.RUNNING:
+                raise SnapshotArtifactUploadError("snapshot download task is no longer accepting uploads")
+            locked = SnapshotDownloadArtifact.objects.select_for_update().get(id=artifact.id)
+            if locked.status != SnapshotDownloadArtifact.Status.UPLOADING:
+                raise SnapshotArtifactUploadError("snapshot download artifact is not accepting uploads")
+            if not constant_time_compare(locked.upload_token_digest, _token_digest(clean_token)):
+                raise SnapshotArtifactUploadError("snapshot download upload token was already replaced")
+            os.replace(temporary_path, final_path)
+            locked.status = SnapshotDownloadArtifact.Status.READY
+            locked.filename = safe_filename
+            locked.content_type = str(content_type or "application/octet-stream")[:120]
+            locked.size_bytes = written
+            locked.sha256 = expected_sha256
+            locked.storage_path = str(final_path)
+            locked.upload_token_digest = ""
+            locked.save(
+                update_fields=[
+                    "status",
+                    "filename",
+                    "content_type",
+                    "size_bytes",
+                    "sha256",
+                    "storage_path",
+                    "upload_token_digest",
+                    "updated_at",
+                ]
+            )
+            return locked
+    finally:
+        try:
+            temporary_path.unlink()
+        except FileNotFoundError:
+            pass
 
 
 def create_snapshot_download_task(
@@ -92,6 +330,16 @@ def create_snapshot_download_task(
             },
         ],
         steps=["snapshot_download_restore", "snapshot_download_transfer", "snapshot_download_finalize"],
+    )
+    filename = _safe_filename(
+        str(display_path).replace("\\", "/").rstrip("/").rsplit("/", 1)[-1],
+        "snapshot-download",
+    )
+    _create_pending_artifact(
+        task=task,
+        directory_id=directory.id,
+        relative_path=clean_path,
+        filename=filename,
     )
     _queue_snapshot_download_execution(task_id=task.id)
     return task
@@ -160,6 +408,12 @@ def create_snapshot_batch_download_task(
             },
         ],
         steps=["snapshot_download_restore", "snapshot_download_transfer", "snapshot_download_finalize"],
+    )
+    _create_pending_artifact(
+        task=task,
+        directory_id=directory.id,
+        relative_path=",".join(clean_paths),
+        filename=f"snapshot-download-{task.id}.zip",
     )
     _queue_snapshot_download_execution(task_id=task.id)
     return task
@@ -240,6 +494,7 @@ def run_snapshot_download_task(*, task: Task) -> dict[str, Any]:
     directory_id = int(payload.get("source_snapshot_directory_id") or 0)
     path = str(payload.get("path") or "")
     paths = payload.get("paths")
+    artifact = SnapshotDownloadArtifact.objects.filter(task=task).first()
     try:
         task = start_task(task_uuid=task.task_uuid, organization_id=task.organization_id)
         directory = _get_directory(organization_id=task.organization_id, directory_id=directory_id)
@@ -271,18 +526,32 @@ def run_snapshot_download_task(*, task: Task) -> dict[str, Any]:
                 "object_names": selected_names,
             },
         )
+        if artifact is None:
+            raise SnapshotBrowserError("Snapshot download artifact was not prepared.")
         if isinstance(paths, list) and paths:
-            download = _download_batch_as_zip(
-                organization_id=task.organization_id,
-                directory_id=directory_id,
-                paths=[str(item or "") for item in paths],
-                task_id=task.id,
-            )
+            try:
+                download = download_snapshot_file(
+                    organization_id=task.organization_id,
+                    directory_id=directory_id,
+                    path="",
+                    paths=[str(item or "") for item in paths],
+                    upload_artifact=artifact,
+                    wait_timeout_seconds=_download_timeout_seconds(),
+                )
+            except SnapshotArtifactUploadUnsupported:
+                download = _download_batch_as_zip(
+                    organization_id=task.organization_id,
+                    directory_id=directory_id,
+                    paths=[str(item or "") for item in paths],
+                    task_id=task.id,
+                )
         else:
             download = download_snapshot_file(
                 organization_id=task.organization_id,
                 directory_id=directory_id,
                 path=path,
+                upload_artifact=artifact,
+                wait_timeout_seconds=_download_timeout_seconds(),
             )
         if len(download.content) > _max_download_bytes():
             raise SnapshotBrowserError("Snapshot download exceeds the configured size limit.")
@@ -301,12 +570,10 @@ def run_snapshot_download_task(*, task: Task) -> dict[str, Any]:
             progress=40,
             task_progress=70,
         )
-        artifact = _persist_artifact(
-            task=task,
-            directory_id=directory_id,
-            path=path or ",".join(str(item or "") for item in paths or []),
-            download=download,
-        )
+        if download.artifact_id != artifact.id:
+            artifact = _persist_artifact(artifact=artifact, download=download)
+        else:
+            artifact.refresh_from_db()
         _set_download_step_status(
             task=task,
             step_name="snapshot_download_transfer",
@@ -320,6 +587,7 @@ def run_snapshot_download_task(*, task: Task) -> dict[str, Any]:
             "filename": artifact.filename,
             "content_type": artifact.content_type,
             "size_bytes": artifact.size_bytes,
+            "sha256": artifact.sha256,
             "expires_at": artifact.expires_at.isoformat(),
             "object_name": artifact.filename,
         }
@@ -344,26 +612,46 @@ def run_snapshot_download_task(*, task: Task) -> dict[str, Any]:
         )
         return result
     except (SnapshotBrowserError, SnapshotBrowserForbidden, ValidationError) as exc:
-        message = str(exc)
-        failed_step = str(task.current_step or "snapshot_download_restore")
-        failed_progress = _failed_download_progress(failed_step)
-        _set_download_step_status(
+        return _complete_failed_snapshot_download(
             task=task,
-            step_name=failed_step,
-            status=TaskStep.Status.FAILED,
-            progress=100,
-            task_progress=failed_progress,
-            current_step=failed_step,
+            artifact=artifact,
+            message=str(exc),
         )
-        complete_task(
-            task_uuid=task.task_uuid,
-            organization_id=task.organization_id,
-            status=Task.Status.FAILED,
-            progress=failed_progress,
-            error_code="SNAPSHOT_DOWNLOAD_FAILED",
-            error_message=message,
+    except Exception:
+        logger.exception(
+            "snapshot download failed unexpectedly",
+            extra={"task_id": task.id, "artifact_id": getattr(artifact, "id", None)},
         )
-        return {"error": message}
+        return _complete_failed_snapshot_download(
+            task=task,
+            artifact=artifact,
+            message="Snapshot download failed due to an internal error.",
+        )
+
+
+def _complete_failed_snapshot_download(
+    *, task: Task, artifact: SnapshotDownloadArtifact | None, message: str
+) -> dict[str, str]:
+    _fail_pending_artifact(artifact=artifact)
+    failed_step = str(task.current_step or "snapshot_download_restore")
+    failed_progress = _failed_download_progress(failed_step)
+    _set_download_step_status(
+        task=task,
+        step_name=failed_step,
+        status=TaskStep.Status.FAILED,
+        progress=100,
+        task_progress=failed_progress,
+        current_step=failed_step,
+    )
+    complete_task(
+        task_uuid=task.task_uuid,
+        organization_id=task.organization_id,
+        status=Task.Status.FAILED,
+        progress=failed_progress,
+        error_code="SNAPSHOT_DOWNLOAD_FAILED",
+        error_message=message,
+    )
+    return {"error": message}
 
 
 def _download_batch_as_zip(*, organization_id: int, directory_id: int, paths: list[str], task_id: int) -> SnapshotFileDownload:
@@ -378,6 +666,7 @@ def _download_batch_as_zip(*, organization_id: int, directory_id: int, paths: li
                 organization_id=organization_id,
                 directory_id=directory_id,
                 path=clean_path,
+                wait_timeout_seconds=_download_timeout_seconds(),
             )
             if download.content_type == "application/zip":
                 _append_nested_zip(
@@ -441,24 +730,55 @@ def _unique_zip_name(name: str, used_names: set[str]) -> str:
     return candidate
 
 
-def _persist_artifact(*, task: Task, directory_id: int, path: str, download) -> SnapshotDownloadArtifact:
-    filename = _safe_filename(download.filename)
-    task_dir = _artifact_root() / str(task.organization_id) / str(task.task_uuid)
-    task_dir.mkdir(parents=True, exist_ok=True)
-    artifact_path = task_dir / filename
-    artifact_path.write_bytes(download.content)
+def _persist_artifact(*, artifact: SnapshotDownloadArtifact, download) -> SnapshotDownloadArtifact:
+    if len(download.content) > _max_download_bytes():
+        raise SnapshotBrowserError("Snapshot download exceeds the configured size limit.")
+    artifact_path = Path(artifact.storage_path)
+    artifact_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    temporary_path = artifact_path.with_name(f".{artifact_path.name}.legacy.part")
+    temporary_path.write_bytes(download.content)
+    os.chmod(temporary_path, 0o600)
+    checksum = hashlib.sha256(download.content).hexdigest()
     with transaction.atomic():
-        return SnapshotDownloadArtifact.objects.create(
-            task=task,
-            organization_id=task.organization_id,
-            source_snapshot_directory_id=directory_id,
-            relative_path=path,
-            filename=filename,
-            content_type=download.content_type or "application/octet-stream",
-            size_bytes=len(download.content),
-            storage_path=str(artifact_path),
-            expires_at=_expires_at(),
+        locked = SnapshotDownloadArtifact.objects.select_for_update().get(id=artifact.id)
+        if locked.status != SnapshotDownloadArtifact.Status.UPLOADING:
+            temporary_path.unlink(missing_ok=True)
+            raise SnapshotBrowserError("Snapshot download artifact is not accepting content.")
+        os.replace(temporary_path, artifact_path)
+        locked.filename = _safe_filename(download.filename, locked.filename)
+        locked.content_type = download.content_type or "application/octet-stream"
+        locked.size_bytes = len(download.content)
+        locked.sha256 = checksum
+        locked.status = SnapshotDownloadArtifact.Status.READY
+        locked.upload_token_digest = ""
+        locked.save(
+            update_fields=[
+                "filename",
+                "content_type",
+                "size_bytes",
+                "sha256",
+                "status",
+                "upload_token_digest",
+                "updated_at",
+            ]
         )
+        return locked
+
+
+def _fail_pending_artifact(*, artifact: SnapshotDownloadArtifact | None) -> None:
+    if artifact is None:
+        return
+    SnapshotDownloadArtifact.objects.filter(
+        id=artifact.id,
+        status=SnapshotDownloadArtifact.Status.UPLOADING,
+    ).update(
+        status=SnapshotDownloadArtifact.Status.FAILED,
+        upload_token_digest="",
+        updated_at=timezone.now(),
+    )
+    path = Path(artifact.storage_path)
+    for candidate in path.parent.glob(f".{path.name}.*.part") if path.parent.exists() else []:
+        candidate.unlink(missing_ok=True)
 
 
 def get_snapshot_download_artifact(*, organization_id: int, artifact_id: int) -> SnapshotDownloadArtifact | None:
@@ -477,7 +797,11 @@ def cleanup_expired_snapshot_download_artifacts(*, now=None, limit: int = 1000) 
     cutoff = now or timezone.now()
     artifacts = list(
         SnapshotDownloadArtifact.objects.filter(
-            status=SnapshotDownloadArtifact.Status.READY,
+            status__in=[
+                SnapshotDownloadArtifact.Status.UPLOADING,
+                SnapshotDownloadArtifact.Status.READY,
+                SnapshotDownloadArtifact.Status.FAILED,
+            ],
             expires_at__lte=cutoff,
         ).order_by("expires_at", "id")[: max(1, limit)]
     )
@@ -488,7 +812,12 @@ def cleanup_expired_snapshot_download_artifacts(*, now=None, limit: int = 1000) 
                 os.remove(artifact.storage_path)
         except FileNotFoundError:
             pass
+        path = Path(artifact.storage_path)
+        if path.parent.exists():
+            for partial in path.parent.glob(f".{path.name}.*.part"):
+                partial.unlink(missing_ok=True)
         artifact.status = SnapshotDownloadArtifact.Status.EXPIRED
-        artifact.save(update_fields=["status", "updated_at"])
+        artifact.upload_token_digest = ""
+        artifact.save(update_fields=["status", "upload_token_digest", "updated_at"])
         cleaned += 1
     return cleaned

--- a/src/backend/apps/protection/tasks/__init__.py
+++ b/src/backend/apps/protection/tasks/__init__.py
@@ -16,7 +16,7 @@ from .policy_execution import run_backup_policy_maintenance_task
 from .directory_size_estimate import refresh_backup_config_directory_estimates_task
 from .repository_policy import sync_backup_config_repository_policy_task
 from .snapshot_delete import execute_snapshot_delete_task, reconcile_snapshot_delete_tasks_task
-from .snapshot_download import execute_snapshot_download_task
+from .snapshot_download import cleanup_snapshot_download_artifacts, execute_snapshot_download_task
 
 __all__ = [
     "advance_backup_task",
@@ -28,6 +28,7 @@ __all__ = [
     "execute_snapshot_delete_task",
     "reconcile_snapshot_delete_tasks_task",
     "execute_snapshot_download_task",
+    "cleanup_snapshot_download_artifacts",
     "reconcile_backup_tasks_task",
     "reconcile_interrupted_backup_tasks_task",
     "refresh_backup_config_directory_estimates_task",

--- a/src/backend/apps/protection/tasks/snapshot_download.py
+++ b/src/backend/apps/protection/tasks/snapshot_download.py
@@ -5,7 +5,10 @@ from celery import shared_task
 from common.observability.celery_context import logged_celery_task
 
 from apps.task.models import Task
-from apps.protection.services.snapshot_download import run_snapshot_download_task
+from apps.protection.services.snapshot_download import (
+    cleanup_expired_snapshot_download_artifacts,
+    run_snapshot_download_task,
+)
 
 
 @shared_task(
@@ -22,3 +25,12 @@ from apps.protection.services.snapshot_download import run_snapshot_download_tas
 def execute_snapshot_download_task(self, *, task_id: int) -> dict:
     task = Task.objects.get(id=int(task_id))
     return run_snapshot_download_task(task=task)
+
+
+@shared_task(name="apps.protection.tasks.snapshot_download.cleanup_snapshot_download_artifacts")
+@logged_celery_task(
+    name="apps.protection.tasks.snapshot_download.cleanup_snapshot_download_artifacts",
+    trace_keys=(),
+)
+def cleanup_snapshot_download_artifacts(*, limit: int = 1000) -> dict[str, int]:
+    return {"cleaned": cleanup_expired_snapshot_download_artifacts(limit=limit)}

--- a/src/backend/apps/protection/tests/test_snapshot_browser_api.py
+++ b/src/backend/apps/protection/tests/test_snapshot_browser_api.py
@@ -1,13 +1,18 @@
 from __future__ import annotations
 
 import base64
+import hashlib
+import tempfile
 import zipfile
+from datetime import timedelta
 from io import BytesIO
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
-from django.test import TestCase
+from django.test import TestCase, override_settings
+from django.utils import timezone
 from rest_framework import status
 from rest_framework.test import APIClient
 
@@ -17,10 +22,19 @@ from apps.protection.models import (
     BackupConfig,
     BackupSourceSnapshot,
     BackupSourceSnapshotDirectory,
+    SnapshotDownloadArtifact,
 )
 from apps.protection.services.backup_source_snapshot import create_source_snapshot
-from apps.protection.services.snapshot_browser import SnapshotFileDownload
-from apps.protection.services.snapshot_download import run_snapshot_download_task
+from apps.protection.services.snapshot_browser import (
+    SnapshotArtifactUploadUnsupported,
+    SnapshotFileDownload,
+)
+from apps.protection.services.snapshot_download import (
+    _create_pending_artifact,
+    cleanup_expired_snapshot_download_artifacts,
+    prepare_snapshot_artifact_upload,
+    run_snapshot_download_task,
+)
 from apps.storage.repositories.models import Repository
 from apps.task.models import Task, TaskEvent, TaskResource, TaskStep
 
@@ -323,6 +337,9 @@ class SnapshotBrowserApiTests(TestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
         self.assertEqual(response.content, b"hello snapshot")
         self.assertIn("readme.txt", response["Content-Disposition"])
+        kwargs = mock_run_agent_task_sync.call_args.kwargs
+        self.assertIn("repository", kwargs["payload"])
+        self.assertNotIn("repository", kwargs["persisted_payload"])
 
     @patch("apps.protection.services.snapshot_browser.run_agent_task_sync")
     def test_download_empty_snapshot_file(self, mock_run_agent_task_sync):
@@ -345,6 +362,27 @@ class SnapshotBrowserApiTests(TestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
         self.assertEqual(response.content, b"")
         self.assertIn("__init__.py", response["Content-Disposition"])
+
+    @patch("apps.protection.services.snapshot_browser.run_agent_task_sync")
+    def test_download_reports_legacy_agent_result_limit(self, mock_run_agent_task_sync):
+        mock_run_agent_task_sync.return_value = SimpleNamespace(
+            ok=True,
+            timed_out=False,
+            result={
+                "filename": "large.bin",
+                "size_bytes": 1024 * 1024,
+                "result_truncated": True,
+            },
+            task=SimpleNamespace(last_error=""),
+        )
+
+        response = self.client.get(
+            f"/api/v1/protection/backup-source-snapshot-directories/{self.directory.id}/download/?path=large.bin",
+            **self._headers(),
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.content)
+        self.assertIn(b"Upgrade the Agent", response.content)
 
     @patch("apps.protection.services.snapshot_browser.run_agent_task_sync")
     def test_download_root_file_snapshot(self, mock_run_agent_task_sync):
@@ -456,6 +494,7 @@ class SnapshotBrowserApiTests(TestCase):
         with zipfile.ZipFile(nested, "w", compression=zipfile.ZIP_DEFLATED) as archive:
             archive.writestr("guide.txt", b"guide")
         mock_download_snapshot_file.side_effect = [
+            SnapshotArtifactUploadUnsupported("legacy Agent"),
             SnapshotFileDownload(filename="docs.zip", content=nested.getvalue(), content_type="application/zip"),
             SnapshotFileDownload(filename="readme.txt", content=b"hello", content_type="application/octet-stream"),
         ]
@@ -473,6 +512,12 @@ class SnapshotBrowserApiTests(TestCase):
             start=1,
         ):
             TaskStep.objects.create(task=task, step_index=index, step_name=step_name)
+        _create_pending_artifact(
+            task=task,
+            directory_id=self.directory.id,
+            relative_path="docs,readme.txt",
+            filename=f"snapshot-download-{task.id}.zip",
+        )
 
         result = run_snapshot_download_task(task=task)
 
@@ -497,3 +542,83 @@ class SnapshotBrowserApiTests(TestCase):
         with zipfile.ZipFile(artifact.storage_path, "r") as archive:
             self.assertEqual(archive.read("docs/guide.txt"), b"guide")
             self.assertEqual(archive.read("readme.txt"), b"hello")
+
+    @override_settings(PROTECTION_SNAPSHOT_DOWNLOAD_MAX_BYTES=1024)
+    @patch("apps.protection.services.snapshot_download._queue_snapshot_download_execution")
+    def test_agent_streams_snapshot_artifact_with_signed_task_token(self, mock_queue):
+        with tempfile.TemporaryDirectory() as media_root, override_settings(MEDIA_ROOT=media_root):
+            response = self.client.post(
+                f"/api/v1/protection/backup-source-snapshot-directories/{self.directory.id}/download-tasks/",
+                {"path": "readme.txt"},
+                format="json",
+                **self._headers(),
+            )
+            self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.content)
+            artifact = SnapshotDownloadArtifact.objects.get(task__task_uuid=response.data["task_uuid"])
+            Task.objects.filter(id=artifact.task_id).update(status=Task.Status.RUNNING)
+            upload = prepare_snapshot_artifact_upload(artifact=artifact, node_id=self.agent.id)
+            content = b"streamed snapshot content"
+            checksum = hashlib.sha256(content).hexdigest()
+
+            uploaded = self.client.generic(
+                "PUT",
+                upload["path"],
+                data=content,
+                content_type="application/octet-stream",
+                HTTP_AUTHORIZATION=f"Bearer {upload['token']}",
+                HTTP_X_CONTENT_SHA256=checksum,
+                HTTP_X_ARTIFACT_FILENAME="readme.txt",
+            )
+
+            self.assertEqual(uploaded.status_code, status.HTTP_200_OK, uploaded.content)
+            artifact.refresh_from_db()
+            self.assertEqual(artifact.status, SnapshotDownloadArtifact.Status.READY)
+            self.assertEqual(artifact.sha256, checksum)
+            self.assertEqual(artifact.size_bytes, len(content))
+            self.assertEqual(Path(artifact.storage_path).read_bytes(), content)
+            replayed = self.client.generic(
+                "PUT",
+                upload["path"],
+                data=content,
+                content_type="application/octet-stream",
+                HTTP_AUTHORIZATION=f"Bearer {upload['token']}",
+                HTTP_X_CONTENT_SHA256=checksum,
+                HTTP_X_ARTIFACT_FILENAME="readme.txt",
+            )
+            self.assertEqual(replayed.status_code, status.HTTP_200_OK, replayed.content)
+            download_url = self.client.get(
+                f"/api/v1/protection/snapshot-download-artifacts/{artifact.id}/download-url/",
+                **self._headers(),
+            )
+            self.assertEqual(download_url.status_code, status.HTTP_200_OK, download_url.content)
+            downloaded = self.client.get(download_url.data["url"])
+            self.assertEqual(downloaded.status_code, status.HTTP_200_OK)
+            self.assertEqual(b"".join(downloaded.streaming_content), content)
+            mock_queue.assert_called_once()
+
+    def test_cleanup_expires_failed_artifacts_and_partial_files(self):
+        with tempfile.TemporaryDirectory() as media_root, override_settings(MEDIA_ROOT=media_root):
+            task = Task.objects.create(
+                organization_id=self.org.id,
+                task_type=Task.Type.SNAPSHOT_DOWNLOAD,
+                display_name="Expired snapshot download",
+            )
+            artifact = _create_pending_artifact(
+                task=task,
+                directory_id=self.directory.id,
+                relative_path="readme.txt",
+                filename="readme.txt",
+            )
+            artifact.status = SnapshotDownloadArtifact.Status.FAILED
+            artifact.expires_at = timezone.now() - timedelta(seconds=1)
+            artifact.save(update_fields=["status", "expires_at", "updated_at"])
+            path = Path(artifact.storage_path)
+            path.parent.mkdir(parents=True)
+            partial = path.with_name(f".{path.name}.stale.part")
+            partial.write_bytes(b"partial")
+
+            self.assertEqual(cleanup_expired_snapshot_download_artifacts(), 1)
+
+            artifact.refresh_from_db()
+            self.assertEqual(artifact.status, SnapshotDownloadArtifact.Status.EXPIRED)
+            self.assertFalse(partial.exists())

--- a/src/frontend/src/lib/protectionBackupConfigApi.ts
+++ b/src/frontend/src/lib/protectionBackupConfigApi.ts
@@ -490,6 +490,18 @@ export function snapshotDownloadArtifactFileUrl(artifactId: number) {
   return `/api/v1/protection/snapshot-download-artifacts/${artifactId}/file/`
 }
 
+export async function createSnapshotArtifactDownloadUrl(artifactId: number) {
+  const result = unwrapApiPayload<{ url: string }>(
+    await api<unknown>(`/api/v1/protection/snapshot-download-artifacts/${artifactId}/download-url/`, {
+      headers: orgHeaders(),
+    }),
+  )
+  const url = String(result.url || '')
+  return {
+    url: /^(?:https?:)?\/\//.test(url) ? url : `${API_BASE}${url}`,
+  }
+}
+
 export async function downloadSnapshotArtifactFile(artifactId: number) {
   const path = snapshotDownloadArtifactFileUrl(artifactId)
   const res = await fetch(`${API_BASE}${path}`, {

--- a/src/frontend/src/pages/protection/components/FlowBackupSourceDetailDrawer.test.ts
+++ b/src/frontend/src/pages/protection/components/FlowBackupSourceDetailDrawer.test.ts
@@ -129,6 +129,18 @@ describe('FlowBackupSourceDetailDrawer snapshot expansion state', () => {
     expect(loader).not.toContain('selectedSnapshotId.value = null')
   })
 
+  it('hands ready snapshot artifacts to the browser without buffering a Blob', () => {
+    const downloader = sourceBetween(
+      'async function startNativeArtifactDownload',
+      'function closeSnapshotFileBrowser',
+    )
+
+    expect(downloader).toContain('createSnapshotArtifactDownloadUrl(artifactId)')
+    expect(downloader).toContain('anchor.href = result.url')
+    expect(downloader).not.toContain('URL.createObjectURL')
+    expect(downloader).not.toContain('.blob()')
+  })
+
   it('clears cached expansion state when pagination changes', () => {
     const paginationWatcher = sourceBetween(
       '() => [snapshotPagination.page, snapshotPagination.pageSize] as const,',

--- a/src/frontend/src/pages/protection/components/FlowBackupSourceDetailDrawer.vue
+++ b/src/frontend/src/pages/protection/components/FlowBackupSourceDetailDrawer.vue
@@ -1807,17 +1807,6 @@ function snapshotDirectoryIcon(dir: BackupSourceSnapshotDirectory) {
   return snapshotDirectoryKind(dir) === 'file' ? File : Folder
 }
 
-function saveBlob(blob: Blob, filename: string) {
-  const url = URL.createObjectURL(blob)
-  const anchor = document.createElement('a')
-  anchor.href = url
-  anchor.download = filename || 'snapshot-download'
-  document.body.appendChild(anchor)
-  anchor.click()
-  anchor.remove()
-  URL.revokeObjectURL(url)
-}
-
 function snapshotFileFallbackName(dir: BackupSourceSnapshotDirectory) {
   return dir.display_name || dir.source_path.split(/[\\/]/).filter(Boolean).pop() || 'snapshot-file'
 }

--- a/src/frontend/src/pages/protection/components/FlowBackupSourceDetailDrawer.vue
+++ b/src/frontend/src/pages/protection/components/FlowBackupSourceDetailDrawer.vue
@@ -51,10 +51,10 @@ import type {
 } from '../../../lib/protectionBackupConfigApi'
 import {
   browseBackupSnapshotDirectory,
+  createBackupSnapshotDirectoryDownloadTask,
   createBackupSnapshotDirectoryBatchDownloadTask,
+  createSnapshotArtifactDownloadUrl,
   deleteBackupConfig,
-  downloadBackupSnapshotDirectoryFile,
-  downloadSnapshotArtifactFile,
   getBackupSourceSnapshot,
   listBackupSourceSnapshots,
   retryBackupConfigProvision,
@@ -1855,13 +1855,24 @@ async function downloadSelectedSnapshotFile() {
   }
   downloadingSnapshotFile.value = true
   try {
-    const result = await downloadBackupSnapshotDirectoryFile(dir.id, '')
-    saveBlob(result.blob, result.filename || snapshotFileFallbackName(dir))
+    const task = await createBackupSnapshotDirectoryDownloadTask(dir.id, '')
+    const artifactId = await waitForDownloadArtifact(task.task_uuid)
+    await startNativeArtifactDownload(artifactId)
   } catch (err) {
     ElMessage.error({ message: apiErrorMessage(err, t('errors.generic.requestFailed')), grouping: true })
   } finally {
     downloadingSnapshotFile.value = false
   }
+}
+
+async function startNativeArtifactDownload(artifactId: number) {
+  const result = await createSnapshotArtifactDownloadUrl(artifactId)
+  const anchor = document.createElement('a')
+  anchor.href = result.url
+  anchor.rel = 'noopener'
+  document.body.appendChild(anchor)
+  anchor.click()
+  anchor.remove()
 }
 
 function closeSnapshotFileBrowser() {
@@ -2178,15 +2189,7 @@ async function downloadSelectedBrowserPaths() {
   try {
     const task = await createBackupSnapshotDirectoryBatchDownloadTask(selectedSnapshotDirectory.value.id, paths)
     const artifactId = await waitForDownloadArtifact(task.task_uuid)
-    const result = await downloadSnapshotArtifactFile(artifactId)
-    const url = URL.createObjectURL(result.blob)
-    const anchor = document.createElement('a')
-    anchor.href = url
-    anchor.download = result.filename || 'snapshot-download.zip'
-    document.body.appendChild(anchor)
-    anchor.click()
-    anchor.remove()
-    URL.revokeObjectURL(url)
+    await startNativeArtifactDownload(artifactId)
   } catch (err) {
     ElMessage.error({ message: apiErrorMessage(err, t('errors.generic.requestFailed')), grouping: true })
   } finally {


### PR DESCRIPTION
## Summary

Snapshot downloads previously returned file content base64-encoded inside agent task results. This failed for files exceeding the task result size limit, producing a generic 'Something went wrong' error.

This PR replaces the legacy path with a direct agent-to-backend artifact upload pipeline: the backend creates a pending artifact with a signed upload token, the agent restores the snapshot and uploads the content via HTTP PUT with SHA-256 integrity verification, and the frontend downloads through a time-limited signed URL.

## Changes

### Backend
- Add `SnapshotArtifactDownloadUrlView` and `SnapshotArtifactContentView` API endpoints for secure artifact download and upload
- Add `UPLOADING`/`FAILED` artifact statuses, `sha256` and `upload_token_digest` fields to `SnapshotDownloadArtifact` model
- Implement signed upload/download token lifecycle with HMAC verification
- Fall back to legacy base64 path when agent lacks `snapshot_artifact_upload_v1` capability
- Add periodic cleanup Celery task for expired `UPLOADING`/`FAILED` artifacts

### Agent (Go)
- Add `snapshot_artifact_upload_v1` inventory capability
- Implement streaming HTTP PUT upload with SHA-256 integrity verification
- Add bounded ZIP creation with size limit enforcement and symlink filtering
- Convert Kopia snapshot timestamps to RFC 3339 format so the frontend can correctly render them in the user's local timezone

### Frontend
- Replace Blob-based artifact download with native browser download via signed URL
- Remove `URL.createObjectURL` buffering for large files

### Infrastructure
- Add nginx location for artifact content upload with request buffering disabled
- Increase proxy timeout from 600s to 900s for large downloads

Closes: #608