### PR TITLE
ci: refine workflow run names

### DIFF
--- a/.github/workflows/community_release.yml
+++ b/.github/workflows/community_release.yml
@@ -1,5 +1,5 @@
 name: HFL - Community Release & Deploy
-run-name: Community · ${{ inputs.tag }} · Release & deploy
+run-name: Community · ${{ inputs.tag }} · Release & Deploy
 
 on:
   workflow_dispatch:

--- a/.github/workflows/enterprise_prod_promotion.yml
+++ b/.github/workflows/enterprise_prod_promotion.yml
@@ -1,5 +1,5 @@
 name: HFL - Enterprise PROD Promotion
-run-name: PROD · ${{ inputs.tag }} · Promote
+run-name: Enterprise · ${{ inputs.tag }} · PROD Promotion
 
 on:
   workflow_dispatch:

--- a/.github/workflows/enterprise_release.yml
+++ b/.github/workflows/enterprise_release.yml
@@ -1,5 +1,5 @@
 name: HFL - Enterprise Release & Deploy
-run-name: Enterprise · ${{ inputs.tag }} · Build & deploy
+run-name: Enterprise · ${{ inputs.tag }} · Release & Deploy
 
 on:
   workflow_dispatch:

--- a/.github/workflows/enterprise_saas_upgrade.yml
+++ b/.github/workflows/enterprise_saas_upgrade.yml
@@ -1,5 +1,5 @@
 name: HFL - Enterprise SaaS Upgrade
-run-name: Enterprise SaaS · ${{ github.event_name == 'push' && github.ref_name || inputs.tag }} · Registry upgrade
+run-name: Enterprise SaaS · ${{ github.event_name == 'push' && github.ref_name || inputs.tag }} · Upgrade
 
 on:
   push:

--- a/.github/workflows/enterprise_saas_upgrade.yml
+++ b/.github/workflows/enterprise_saas_upgrade.yml
@@ -1,5 +1,5 @@
 name: HFL - Enterprise SaaS Upgrade
-run-name: Enterprise SaaS · ${{ github.event_name == 'push' && github.ref_name || inputs.tag }} · Upgrade
+run-name: Enterprise · ${{ github.event_name == 'push' && github.ref_name || inputs.tag }} · SaaS Upgrade
 
 on:
   push:

--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -1,4 +1,5 @@
 name: HFL - PR Checks
+run-name: "PR Checks · #${{ github.event.pull_request.number }} · ${{ github.event.pull_request.title }}"
 
 on:
   pull_request:


### PR DESCRIPTION
Tidy up the run titles shown in the Actions page:

- `enterprise_saas_upgrade.yml`: `Registry upgrade` -> `Upgrade`. The workflow actually runs the full flow including `Deploy · TEST` and `Deploy · PROD`, so `Registry upgrade` was misleading (packaging is a means, upgrading is the goal).
- `pr_checks.yml`: add `run-name` so runs show `PR Checks · #<number> · <title>` instead of falling back to the commit message.
- Quote the PR run-name: a leading `#` after a space is treated as a YAML comment, which truncated the title.