### PR TITLE
feat(storage): add repository quota units

### DIFF
--- a/language-packs/packs/zh-hans/frontend/messages.json
+++ b/language-packs/packs/zh-hans/frontend/messages.json
@@ -4104,6 +4104,7 @@
     "confirmDeleteTitle": "删除存储仓库",
     "confirmDelete": "确定删除仓库「{name}」？",
     "fieldQuota": "存储配额",
+    "quotaUnit": "存储配额单位",
     "phQuota": "0 表示不限制",
     "hintQuota": "用于容量规划和告警，0 表示不限制。",
     "fieldQuotaAlert": "启用配额监控",

--- a/language-packs/packs/zh-hans/frontend/source-lock.json
+++ b/language-packs/packs/zh-hans/frontend/source-lock.json
@@ -4047,6 +4047,7 @@
   "repositoriesPage.confirmDeleteTitle": "29e0dba6a441f51ebe314f70363610c4855ca819df3097f2bfe456c1598a2545",
   "repositoriesPage.confirmDelete": "6cf4cca36cd2756fffc76b957ed5e7188517e3a017d5602642297e4f85a61324",
   "repositoriesPage.fieldQuota": "910a2f6c05017bf4e76a986754e92c57593fc4857815c667faf0de4d84488ba9",
+  "repositoriesPage.quotaUnit": "bc5eddbfdd5a0bb84d12b9dcb99ef218d88a7f4e1045a977d84d33ef73fef623",
   "repositoriesPage.phQuota": "781066c76172ad9a41070652a361a5f2fb7206c84c1845c256d090cbe667179b",
   "repositoriesPage.hintQuota": "8bf84230a99b20244b195709852d0648a166a788ea9a6157af635fd704c91780",
   "repositoriesPage.fieldQuotaAlert": "a42fd2620969926b1a72ed475a8ce8dff6b8917d685e624fa1fafa1b0bbfa879",

--- a/src/backend/apps/storage/repositories/serializers.py
+++ b/src/backend/apps/storage/repositories/serializers.py
@@ -64,6 +64,7 @@ FORBIDDEN_CONFIG_FIELDS = {
 # valid.
 S3_NON_CONNECTION_CONFIG_FIELDS = {
     "quota_gb",
+    "quota_unit",
     "quota_alert_enabled",
     "quota_alert_threshold",
 }
@@ -379,6 +380,10 @@ class RepositoryWriteSerializer(serializers.ModelSerializer):
         if forbidden:
             raise serializers.ValidationError(
                 f"config contains forbidden fields: {', '.join(forbidden)}"
+            )
+        if "quota_unit" in value and value["quota_unit"] not in {"GB", "TB", "PB"}:
+            raise serializers.ValidationError(
+                {"quota_unit": "Storage limit unit must be GB, TB, or PB."}
             )
         if "proxy_repository_server_host" in value:
             value = dict(value)
@@ -858,6 +863,10 @@ class NASRepositoryRepairSerializer(serializers.Serializer):
             raise serializers.ValidationError(
                 "These NAS repository fields cannot be modified: %s"
                 % ", ".join(unsupported)
+            )
+        if "quota_unit" in value and value["quota_unit"] not in {"GB", "TB", "PB"}:
+            raise serializers.ValidationError(
+                {"quota_unit": "Storage limit unit must be GB, TB, or PB."}
             )
         if "proxy_repository_server_host" in value:
             value = dict(value)

--- a/src/backend/apps/storage/services/internal/nas_repair.py
+++ b/src/backend/apps/storage/services/internal/nas_repair.py
@@ -74,6 +74,7 @@ NAS_REPAIR_MUTABLE_CONFIG_FIELDS = frozenset(
     {
         "mount_options",
         "quota_gb",
+        "quota_unit",
         "quota_alert_enabled",
         "quota_alert_threshold",
         "smb_username",

--- a/src/backend/apps/storage/tests/test_nas_repair_api.py
+++ b/src/backend/apps/storage/tests/test_nas_repair_api.py
@@ -168,6 +168,7 @@ class NasRepairApiTests(TestCase):
                 "name": "renamed",
                 "config": {
                     "quota_gb": 200,
+                    "quota_unit": "PB",
                     "mount_options": "rw,soft",
                 },
             },
@@ -178,12 +179,28 @@ class NasRepairApiTests(TestCase):
         repo.refresh_from_db()
         self.assertEqual(repo.name, "renamed")
         self.assertEqual(repo.config["quota_gb"], 200)
+        self.assertEqual(repo.config["quota_unit"], "PB")
         self.assertEqual(repo.config["mount_options"], "rw,soft")
         # Mount options should be replaced, not appended.
         self.assertNotIn("ro,soft", repo.config["mount_options"])
         # No binding happened.
         self.assertFalse(repo.bind_node_id)
         self.assertNotEqual(repo.bind_node_type, Repository.BindNodeType.PROXY)
+
+    def test_repair_rejects_invalid_quota_unit(self):
+        repo = self._make_unbound_nas()
+
+        response = self.client.patch(
+            f"/api/v1/storage/repositories/{repo.id}/repair/",
+            {"config": {"quota_unit": "MB"}},
+            format="json",
+            **self._headers(),
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("quota_unit", str(response.data))
+        repo.refresh_from_db()
+        self.assertNotIn("quota_unit", repo.config)
 
     @mock.patch(
         "apps.storage.services.internal.nas_repair.enqueue_repository_usage_refresh"

--- a/src/backend/apps/storage/tests/test_repository_api.py
+++ b/src/backend/apps/storage/tests/test_repository_api.py
@@ -1137,6 +1137,7 @@ class StorageRepositoryApiTests(TestCase):
                 "name": "legacy-managed-s3-renamed",
                 "config": {
                     "quota_gb": 10,
+                    "quota_unit": "TB",
                     "quota_alert_enabled": True,
                     "quota_alert_threshold": 80,
                 },
@@ -1149,11 +1150,34 @@ class StorageRepositoryApiTests(TestCase):
         repository.refresh_from_db()
         self.assertEqual(repository.name, "legacy-managed-s3-renamed")
         self.assertEqual(repository.config["quota_gb"], 10)
+        self.assertEqual(repository.config["quota_unit"], "TB")
         self.assertEqual(
             repository.config["region"], "legacy-region-no-longer-in-catalog"
         )
         self.assertEqual(repository.config["endpoint"], "obs.legacy.example.com")
         enqueue_usage.assert_called_once()
+
+    def test_repository_update_rejects_invalid_quota_unit(self):
+        repository = Repository.objects.create(
+            organization_id=self.org.id,
+            name="quota-unit-validation",
+            repo_type=Repository.Type.PROXY_FS,
+            status=Repository.Status.CREATED,
+            health=Repository.Health.ONLINE,
+            config={"proxy_node_dir": "/data/repository", "quota_gb": 10},
+        )
+
+        response = self.client.patch(
+            f"/api/v1/storage/repositories/{repository.id}/",
+            {"config": {"quota_gb": 10, "quota_unit": "MB"}},
+            format="json",
+            **self._headers(),
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("quota_unit", str(response.data))
+        repository.refresh_from_db()
+        self.assertNotIn("quota_unit", repository.config)
 
     def test_associated_sources_lists_direct_nas_agent_health(self):
         agent = Node.objects.create(

--- a/src/frontend/src/lib/repositoryCapacityDisplay.ts
+++ b/src/frontend/src/lib/repositoryCapacityDisplay.ts
@@ -4,7 +4,7 @@ export type RepositoryCapacityLike = {
   storage_total_bytes?: number
   storage_used_bytes?: number
   storage_available_bytes?: number
-  config?: { quota_gb?: number | string | null } | null
+  config?: { quota_gb?: number | string | null; quota_unit?: string | null } | null
 }
 
 export function repositoryEffectiveCapacityBytes(row: RepositoryCapacityLike): number {

--- a/src/frontend/src/lib/repositoryQuota.test.ts
+++ b/src/frontend/src/lib/repositoryQuota.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  isValidRepositoryQuotaValue,
+  normalizeRepositoryQuotaUnit,
+  repositoryQuotaDisplay,
+  repositoryQuotaToGb,
+  repositoryQuotaValueFromGb,
+} from './repositoryQuota'
+
+describe('repository quota units', () => {
+  it('normalizes supported units and treats missing or invalid legacy values as GB', () => {
+    expect(normalizeRepositoryQuotaUnit('TB')).toBe('TB')
+    expect(normalizeRepositoryQuotaUnit('pb')).toBe('PB')
+    expect(normalizeRepositoryQuotaUnit(undefined)).toBe('GB')
+    expect(normalizeRepositoryQuotaUnit('MB')).toBe('GB')
+  })
+
+  it('converts the unchanged input value to and from normalized GB', () => {
+    expect(repositoryQuotaToGb(10, 'GB')).toBe(10)
+    expect(repositoryQuotaToGb(10, 'TB')).toBe(10 * 1024)
+    expect(repositoryQuotaToGb(10, 'PB')).toBe(10 * 1024 ** 2)
+    expect(repositoryQuotaValueFromGb(10 * 1024, 'TB')).toBe(10)
+    expect(repositoryQuotaValueFromGb(10 * 1024 ** 2, 'PB')).toBe(10)
+  })
+
+  it('formats persisted units while keeping legacy records in GB', () => {
+    expect(repositoryQuotaDisplay({ quota_gb: 2048, quota_unit: 'TB' })).toBe('2 TB')
+    expect(repositoryQuotaDisplay({ quota_gb: 2048 })).toBe('2048 GB')
+    expect(repositoryQuotaDisplay({ quota_gb: 2048, quota_unit: 'invalid' })).toBe('2048 GB')
+    expect(repositoryQuotaDisplay({ quota_gb: 0, quota_unit: 'PB' })).toBeNull()
+  })
+
+  it('allows zero for unlimited and positive integers only', () => {
+    expect(isValidRepositoryQuotaValue(0)).toBe(true)
+    expect(isValidRepositoryQuotaValue(10)).toBe(true)
+    expect(isValidRepositoryQuotaValue(1.5)).toBe(false)
+    expect(isValidRepositoryQuotaValue(-1)).toBe(false)
+  })
+})

--- a/src/frontend/src/lib/repositoryQuota.ts
+++ b/src/frontend/src/lib/repositoryQuota.ts
@@ -1,0 +1,43 @@
+export const REPOSITORY_QUOTA_UNITS = ['GB', 'TB', 'PB'] as const
+
+export type RepositoryQuotaUnit = typeof REPOSITORY_QUOTA_UNITS[number]
+
+const QUOTA_UNIT_GB_MULTIPLIER: Record<RepositoryQuotaUnit, number> = {
+  GB: 1,
+  TB: 1024,
+  PB: 1024 ** 2,
+}
+
+export function normalizeRepositoryQuotaUnit(value: unknown): RepositoryQuotaUnit {
+  const unit = String(value || '').toUpperCase()
+  return REPOSITORY_QUOTA_UNITS.includes(unit as RepositoryQuotaUnit)
+    ? unit as RepositoryQuotaUnit
+    : 'GB'
+}
+
+export function repositoryQuotaToGb(value: unknown, unit: unknown): number {
+  const amount = Number(value || 0)
+  if (!Number.isFinite(amount) || amount <= 0) return 0
+  return amount * QUOTA_UNIT_GB_MULTIPLIER[normalizeRepositoryQuotaUnit(unit)]
+}
+
+export function repositoryQuotaValueFromGb(quotaGb: unknown, unit: unknown): number {
+  const amount = Number(quotaGb || 0)
+  if (!Number.isFinite(amount) || amount <= 0) return 0
+  return amount / QUOTA_UNIT_GB_MULTIPLIER[normalizeRepositoryQuotaUnit(unit)]
+}
+
+export function repositoryQuotaDisplay(config: {
+  quota_gb?: number | string | null
+  quota_unit?: unknown
+} | null | undefined): string | null {
+  const quotaGb = Number(config?.quota_gb || 0)
+  if (!Number.isFinite(quotaGb) || quotaGb <= 0) return null
+  const unit = normalizeRepositoryQuotaUnit(config?.quota_unit)
+  return `${repositoryQuotaValueFromGb(quotaGb, unit)} ${unit}`
+}
+
+export function isValidRepositoryQuotaValue(value: unknown): boolean {
+  const amount = Number(value || 0)
+  return Number.isInteger(amount) && amount >= 0
+}

--- a/src/frontend/src/lib/storageRepositoryApi.ts
+++ b/src/frontend/src/lib/storageRepositoryApi.ts
@@ -139,6 +139,7 @@ export type StorageRepositoryUpdatePayload = {
     s3_url_style?: 'auto' | 'virtual_hosted' | 'path'
     use_tls?: boolean
     quota_gb?: number
+    quota_unit?: 'GB' | 'TB' | 'PB'
     quota_alert_enabled?: boolean
     quota_alert_threshold?: number
     access_key_id?: string
@@ -160,6 +161,7 @@ export type StorageRepositoryUpdatePayload = {
 export type StorageRepositoryRepairConfig = {
   mount_options?: string
   quota_gb?: number
+  quota_unit?: 'GB' | 'TB' | 'PB'
   quota_alert_enabled?: boolean
   quota_alert_threshold?: number
   smb_username?: string

--- a/src/frontend/src/locales/en.ts
+++ b/src/frontend/src/locales/en.ts
@@ -2107,6 +2107,7 @@ export const en = {
     confirmDeleteTitle: 'Delete Repository',
     confirmDelete: 'Delete repository “{name}”?',
     fieldQuota: 'Storage Quota',
+    quotaUnit: 'Storage limit unit',
     phQuota: '0 means unlimited',
     hintQuota: 'Used for capacity planning and alerting; 0 means unlimited.',
     fieldQuotaAlert: 'Enable Quota Monitoring',

--- a/src/frontend/src/pages/node/AddNasRepository.vue
+++ b/src/frontend/src/pages/node/AddNasRepository.vue
@@ -21,6 +21,11 @@ import { proxyAgentsRoute } from '../../lib/nodeDeployRoutes'
 import type { ApiNode } from '../../types/node'
 import NasProxyTopology from './NasProxyTopology.vue'
 import { useInlineFormValidation } from '../../composables/useInlineFormValidation'
+import {
+  REPOSITORY_QUOTA_UNITS,
+  repositoryQuotaToGb,
+  type RepositoryQuotaUnit,
+} from '../../lib/repositoryQuota'
 
 type NasProtocol = 'smb' | 'nfs'
 
@@ -71,6 +76,7 @@ const nfsExport = ref('')
 /* Step 1: repo info */
 const repoName = ref('')
 const quota = ref(0)
+const quotaUnit = ref<RepositoryQuotaUnit>('GB')
 const enableQuotaAlert = ref(false)
 const quotaAlertThreshold = ref<number | undefined>(undefined)
 const proxyNodeId = ref<number | undefined>(undefined)
@@ -176,7 +182,8 @@ function buildCreatePayload(): StorageRepositoryCreatePayload {
     server_address: protocol.value === 'smb' ? smbHost.value.trim() : nfsHost.value.trim(),
     share_path: protocol.value === 'smb' ? smbShare.value.trim() : nfsExport.value.trim(),
     mount_options: mountOptions.value.trim() || undefined,
-    quota_gb: quota.value || 0,
+    quota_gb: repositoryQuotaToGb(quota.value, quotaUnit.value),
+    quota_unit: quotaUnit.value,
     quota_alert_enabled: enableQuotaAlert.value,
     quota_alert_threshold: enableQuotaAlert.value ? Number(quotaAlertThreshold.value || 0) : 0,
   }
@@ -696,17 +703,28 @@ watch(enableQuotaAlert, (enabled) => {
                     <div class="fullscreen-form-field repository-quota-field">
                       <label class="fullscreen-form-field__label repository-quota-head">{{ t('repositoriesPage.fieldQuota') }}</label>
                       <div class="repository-quota-control">
-                        <div class="repository-quota-number repository-quota-input">
+                        <div class="repository-quota-number repository-quota-input repository-quota-split-input repository-quota-split-input--add">
                           <ElInputNumber
                             v-model="quota"
                             class="repository-quota-number__input"
                             :placeholder="t('repositoriesPage.phQuota')"
                             :min="0"
+                            :precision="0"
+                            :step="1"
                             controls-position="right"
                           />
-                          <div class="repository-quota-number__suffix">
-                            GB
-                          </div>
+                          <ElSelect
+                            v-model="quotaUnit"
+                            class="repository-quota-number__unit"
+                            :aria-label="t('repositoriesPage.quotaUnit')"
+                          >
+                            <ElOption
+                              v-for="unit in REPOSITORY_QUOTA_UNITS"
+                              :key="unit"
+                              :label="unit"
+                              :value="unit"
+                            />
+                          </ElSelect>
                         </div>
                       </div>
                       <p class="fullscreen-form-field__hint">
@@ -833,7 +851,7 @@ watch(enableQuotaAlert, (enabled) => {
                     class="add-form-preview-row__value"
                     :class="{ 'add-form-preview-row__value--highlight': quota > 0 }"
                   >
-                    {{ quota > 0 ? `${quota} GB` : t('addS3Repo.previewUnlimited') }}
+                    {{ quota > 0 ? `${quota} ${quotaUnit}` : t('addS3Repo.previewUnlimited') }}
                   </span>
                 </div>
                 <div class="add-form-preview-row">

--- a/src/frontend/src/pages/node/AddNasRepositoryProxyDecision.test.ts
+++ b/src/frontend/src/pages/node/AddNasRepositoryProxyDecision.test.ts
@@ -144,6 +144,9 @@ describe('AddNasRepository Proxy decision', () => {
       'proxy-alpha (192.168.10.17)',
       'proxy-beta (192.168.10.23)',
       en.addNasRepo.optionNoProxy,
+      'GB',
+      'TB',
+      'PB',
     ])
     expect(wrapper.text()).toContain(en.addNasRepo.hintProxyUndecided)
   })

--- a/src/frontend/src/pages/node/AddProxyFsRepository.vue
+++ b/src/frontend/src/pages/node/AddProxyFsRepository.vue
@@ -17,6 +17,11 @@ import { listAllNodes } from '../../lib/nodeApi'
 import { proxyAgentsRoute } from '../../lib/nodeDeployRoutes'
 import type { ApiNode } from '../../types/node'
 import { useInlineFormValidation } from '../../composables/useInlineFormValidation'
+import {
+  REPOSITORY_QUOTA_UNITS,
+  repositoryQuotaToGb,
+  type RepositoryQuotaUnit,
+} from '../../lib/repositoryQuota'
 
 const { t } = useI18n()
 const router = useRouter()
@@ -38,6 +43,7 @@ const proxyNodeId = ref<number | undefined>(undefined)
 const proxyNodeDir = ref('')
 const repoName = ref('')
 const quota = ref(0)
+const quotaUnit = ref<RepositoryQuotaUnit>('GB')
 const enableQuotaAlert = ref(false)
 const quotaAlertThreshold = ref<number | undefined>(undefined)
 const useTreeSelect = ref(true)
@@ -465,7 +471,8 @@ function buildCreatePayload() {
     bind_node_id: proxyNodeId.value,
     config: {
       proxy_node_base_dir: proxyNodeDir.value.trim(),
-      quota_gb: quota.value || 0,
+      quota_gb: repositoryQuotaToGb(quota.value, quotaUnit.value),
+      quota_unit: quotaUnit.value,
       quota_alert_enabled: enableQuotaAlert.value,
       quota_alert_threshold: enableQuotaAlert.value ? Number(quotaAlertThreshold.value || 0) : 0,
     },
@@ -916,17 +923,28 @@ watch(enableQuotaAlert, (enabled) => {
                   <div class="fullscreen-form-field repository-quota-field">
                     <label class="fullscreen-form-field__label repository-quota-head">{{ t('repositoriesPage.fieldQuota') }}</label>
                     <div class="repository-quota-control">
-                      <div class="repository-quota-number repository-quota-input">
+                      <div class="repository-quota-number repository-quota-input repository-quota-split-input repository-quota-split-input--add">
                         <ElInputNumber
                           v-model="quota"
                           class="repository-quota-number__input"
                           :placeholder="t('repositoriesPage.phQuota')"
                           :min="0"
+                          :precision="0"
+                          :step="1"
                           controls-position="right"
                         />
-                        <div class="repository-quota-number__suffix">
-                          GB
-                        </div>
+                        <ElSelect
+                          v-model="quotaUnit"
+                          class="repository-quota-number__unit"
+                          :aria-label="t('repositoriesPage.quotaUnit')"
+                        >
+                          <ElOption
+                            v-for="unit in REPOSITORY_QUOTA_UNITS"
+                            :key="unit"
+                            :label="unit"
+                            :value="unit"
+                          />
+                        </ElSelect>
                       </div>
                     </div>
                     <p class="fullscreen-form-field__hint">
@@ -1043,7 +1061,7 @@ watch(enableQuotaAlert, (enabled) => {
                     class="add-form-preview-row__value"
                     :class="{ 'add-form-preview-row__value--highlight': quota > 0 }"
                   >
-                    {{ quota > 0 ? `${quota} GB` : t('addS3Repo.previewUnlimited') }}
+                    {{ quota > 0 ? `${quota} ${quotaUnit}` : t('addS3Repo.previewUnlimited') }}
                   </span>
                 </div>
                 <div class="add-form-preview-row">

--- a/src/frontend/src/pages/node/AddS3Repo.vue
+++ b/src/frontend/src/pages/node/AddS3Repo.vue
@@ -19,6 +19,11 @@ import {
 } from '../../lib/s3PlatformDisplay'
 import { buildS3RepositoryName } from '../../lib/s3RepositoryName'
 import {
+  REPOSITORY_QUOTA_UNITS,
+  repositoryQuotaToGb,
+  type RepositoryQuotaUnit,
+} from '../../lib/repositoryQuota'
+import {
   S3_PROVIDER_OPTIONS,
   defaultS3UrlStyle,
   groupS3RegionPresets,
@@ -92,6 +97,7 @@ const authStatus = ref<S3AuthStatus>('idle')
 const authError = ref('')
 const prefix = ref(DEFAULT_S3_OBJECT_PREFIX)
 const quota = ref(0)
+const quotaUnit = ref<RepositoryQuotaUnit>('GB')
 const enableQuotaAlert = ref(false)
 const quotaAlertThreshold = ref(80)
 let bucketSelectLoadAttemptAt = 0
@@ -504,7 +510,8 @@ function buildCreatePayload() {
       secret_access_key: accessKeySecret.value,
       s3_url_style: s3UrlStyle.value,
       use_tls: useTls.value,
-      quota_gb: quota.value || 0,
+      quota_gb: repositoryQuotaToGb(quota.value, quotaUnit.value),
+      quota_unit: quotaUnit.value,
       quota_alert_enabled: enableQuotaAlert.value,
       quota_alert_threshold: enableQuotaAlert.value ? Number(quotaAlertThreshold.value || 0) : 0,
     },
@@ -990,17 +997,28 @@ function handleBack() {
                     <div class="fullscreen-form-field repository-quota-field">
                       <label class="fullscreen-form-field__label repository-quota-head">{{ t('addS3Repo.fieldQuota') }}</label>
                       <div class="repository-quota-control">
-                        <div class="repository-quota-number repository-quota-input">
+                        <div class="repository-quota-number repository-quota-input repository-quota-split-input repository-quota-split-input--add">
                           <ElInputNumber
                             v-model="quota"
                             class="repository-quota-number__input"
                             :placeholder="t('addS3Repo.phQuota')"
                             :min="0"
+                            :precision="0"
+                            :step="1"
                             controls-position="right"
                           />
-                          <div class="repository-quota-number__suffix">
-                            GB
-                          </div>
+                          <ElSelect
+                            v-model="quotaUnit"
+                            class="repository-quota-number__unit"
+                            :aria-label="t('repositoriesPage.quotaUnit')"
+                          >
+                            <ElOption
+                              v-for="unit in REPOSITORY_QUOTA_UNITS"
+                              :key="unit"
+                              :label="unit"
+                              :value="unit"
+                            />
+                          </ElSelect>
                         </div>
                       </div>
                       <p class="fullscreen-form-field__hint">
@@ -1193,7 +1211,7 @@ function handleBack() {
                     class="add-form-preview-row__value"
                     :class="{ 'add-form-preview-row__value--highlight': quota > 0 }"
                   >
-                    {{ quota > 0 ? `${quota} GB` : t('addS3Repo.previewUnlimited') }}
+                    {{ quota > 0 ? `${quota} ${quotaUnit}` : t('addS3Repo.previewUnlimited') }}
                   </span>
                 </div>
                 <div class="add-form-preview-row">

--- a/src/frontend/src/pages/node/EditProxyFsRepo.vue
+++ b/src/frontend/src/pages/node/EditProxyFsRepo.vue
@@ -15,6 +15,13 @@ import {
   type StorageRepository,
 } from '../../lib/storageRepositoryApi'
 import { useInlineFormValidation } from '../../composables/useInlineFormValidation'
+import {
+  REPOSITORY_QUOTA_UNITS,
+  normalizeRepositoryQuotaUnit,
+  repositoryQuotaToGb,
+  repositoryQuotaValueFromGb,
+  type RepositoryQuotaUnit,
+} from '../../lib/repositoryQuota'
 
 const { t } = useI18n()
 const route = useRoute()
@@ -34,12 +41,14 @@ const repo = ref<StorageRepository | null>(null)
 const name = ref('')
 /* quota values read directly from `config` so we can build the PATCH payload */
 const quotaGb = ref(0)
+const quotaUnit = ref<RepositoryQuotaUnit>('GB')
 const quotaAlertEnabled = ref(false)
 const quotaAlertThreshold = ref<number>(80)
 
 /* read-only mirrors for change detection */
 const originName = ref('')
 const originQuotaGb = ref(0)
+const originQuotaUnit = ref<RepositoryQuotaUnit>('GB')
 const originQuotaAlertEnabled = ref(false)
 const originQuotaAlertThreshold = ref(80)
 
@@ -94,6 +103,7 @@ const validQuotaAlertThreshold = computed(() => {
 const dirty = computed(() => {
   if (name.value.trim() !== originName.value) return true
   if (Number(quotaGb.value || 0) !== originQuotaGb.value) return true
+  if (quotaUnit.value !== originQuotaUnit.value) return true
   if (Boolean(quotaAlertEnabled.value) !== originQuotaAlertEnabled.value) return true
   if (quotaAlertEnabled.value && Number(quotaAlertThreshold.value || 0) !== originQuotaAlertThreshold.value) return true
   return false
@@ -152,11 +162,13 @@ async function maybeFetchProxyNode(data: StorageRepository) {
 function hydrate(data: StorageRepository) {
   const cfg = (data.config || {}) as Record<string, unknown>
   name.value = data.name || ''
-  quotaGb.value = Number(cfg.quota_gb || 0)
+  quotaUnit.value = normalizeRepositoryQuotaUnit(cfg.quota_unit)
+  quotaGb.value = repositoryQuotaValueFromGb(cfg.quota_gb, quotaUnit.value)
   quotaAlertEnabled.value = Boolean(cfg.quota_alert_enabled)
   quotaAlertThreshold.value = Number(cfg.quota_alert_threshold || 80)
   originName.value = name.value
   originQuotaGb.value = quotaGb.value
+  originQuotaUnit.value = quotaUnit.value
   originQuotaAlertEnabled.value = quotaAlertEnabled.value
   originQuotaAlertThreshold.value = quotaAlertThreshold.value
 }
@@ -164,7 +176,8 @@ function hydrate(data: StorageRepository) {
 /* ---------- save ---------- */
 function buildPayload() {
   const config: Record<string, unknown> = {
-    quota_gb: Number(quotaGb.value || 0),
+    quota_gb: repositoryQuotaToGb(quotaGb.value, quotaUnit.value),
+    quota_unit: quotaUnit.value,
     quota_alert_enabled: Boolean(quotaAlertEnabled.value),
     quota_alert_threshold: quotaAlertEnabled.value
       ? Number(quotaAlertThreshold.value || 0)
@@ -325,17 +338,28 @@ watch(repositoryId, (id) => {
                     {{ t('repositoriesPage.fieldQuota') }}
                   </label>
                   <div class="add-proxy-fs-quota-control">
-                    <div class="hfl-detail-form-input hfl-detail-form-input--narrow add-proxy-fs-quota-input">
+                    <div class="hfl-detail-form-input hfl-detail-form-input--narrow add-proxy-fs-quota-input repository-quota-split-input repository-quota-split-input--edit">
                       <ElInputNumber
                         v-model="quotaGb"
                         class="hfl-detail-form-input__num"
                         :placeholder="t('repositoriesPage.phQuota')"
                         :min="0"
+                        :precision="0"
+                        :step="1"
                         controls-position="right"
                       />
-                      <div class="hfl-detail-form-input__suffix">
-                        GB
-                      </div>
+                      <ElSelect
+                        v-model="quotaUnit"
+                        class="hfl-detail-form-input__unit"
+                        :aria-label="t('repositoriesPage.quotaUnit')"
+                      >
+                        <ElOption
+                          v-for="unit in REPOSITORY_QUOTA_UNITS"
+                          :key="unit"
+                          :label="unit"
+                          :value="unit"
+                        />
+                      </ElSelect>
                     </div>
                   </div>
                   <p class="fullscreen-form-field__hint">

--- a/src/frontend/src/pages/node/EditS3Repo.vue
+++ b/src/frontend/src/pages/node/EditS3Repo.vue
@@ -23,6 +23,13 @@ import {
   type S3UrlStyle,
 } from '../../lib/s3ProviderProfiles'
 import { useInlineFormValidation } from '../../composables/useInlineFormValidation'
+import {
+  REPOSITORY_QUOTA_UNITS,
+  normalizeRepositoryQuotaUnit,
+  repositoryQuotaToGb,
+  repositoryQuotaValueFromGb,
+  type RepositoryQuotaUnit,
+} from '../../lib/repositoryQuota'
 
 
 const { t } = useI18n()
@@ -53,6 +60,7 @@ const region = ref('')
 const s3UrlStyle = ref<S3UrlStyle>(defaultS3UrlStyle('custom'))
 const useTls = ref(true)
 const quotaGb = ref(0)
+const quotaUnit = ref<RepositoryQuotaUnit>('GB')
 const quotaAlertEnabled = ref(false)
 const quotaAlertThreshold = ref<number>(80)
 
@@ -137,7 +145,8 @@ function hydrate(data: StorageRepository) {
   const loadedUrlStyle = normalizeS3UrlStyle(cfg.s3_url_style, platform.value)
   s3UrlStyle.value = loadedUrlStyle === 'auto' ? 'virtual_hosted' : loadedUrlStyle
   useTls.value = cfg.use_tls !== false
-  quotaGb.value = Number(cfg.quota_gb || 0)
+  quotaUnit.value = normalizeRepositoryQuotaUnit(cfg.quota_unit)
+  quotaGb.value = repositoryQuotaValueFromGb(cfg.quota_gb, quotaUnit.value)
   quotaAlertEnabled.value = Boolean(cfg.quota_alert_enabled)
   quotaAlertThreshold.value = Number(cfg.quota_alert_threshold || 80)
   hasAccessKey.value = Boolean(String(cfg.access_key_id || '').trim())
@@ -172,7 +181,8 @@ function cancelRewriteSecret() {
 
 function buildPayload() {
   const config: Record<string, unknown> = {
-    quota_gb: quotaGb.value || 0,
+    quota_gb: repositoryQuotaToGb(quotaGb.value, quotaUnit.value),
+    quota_unit: quotaUnit.value,
     quota_alert_enabled: quotaAlertEnabled.value,
     quota_alert_threshold: quotaAlertEnabled.value ? Number(quotaAlertThreshold.value || 0) : 0,
   }
@@ -593,17 +603,28 @@ watch(repositoryId, (id) => {
                         {{ t('addS3Repo.fieldQuota') }}
                       </label>
                       <div class="add-s3-quota-pair__control">
-                        <div class="hfl-detail-form-input hfl-detail-form-input--narrow add-s3-quota-pair__input">
+                        <div class="hfl-detail-form-input hfl-detail-form-input--narrow add-s3-quota-pair__input repository-quota-split-input repository-quota-split-input--edit">
                           <ElInputNumber
                             v-model="quotaGb"
                             class="hfl-detail-form-input__num"
                             :placeholder="t('addS3Repo.phQuota')"
                             :min="0"
+                            :precision="0"
+                            :step="1"
                             controls-position="right"
                           />
-                          <div class="hfl-detail-form-input__suffix">
-                            GB
-                          </div>
+                          <ElSelect
+                            v-model="quotaUnit"
+                            class="hfl-detail-form-input__unit"
+                            :aria-label="t('repositoriesPage.quotaUnit')"
+                          >
+                            <ElOption
+                              v-for="unit in REPOSITORY_QUOTA_UNITS"
+                              :key="unit"
+                              :label="unit"
+                              :value="unit"
+                            />
+                          </ElSelect>
                         </div>
                       </div>
                       <p class="fullscreen-form-field__hint">
@@ -811,7 +832,7 @@ watch(repositoryId, (id) => {
                     class="add-form-preview-row__value"
                     :class="{ 'add-form-preview-row__value--highlight': quotaGb > 0 }"
                   >
-                    {{ quotaGb > 0 ? `${quotaGb} GB` : t('addS3Repo.previewUnlimited') }}
+                    {{ quotaGb > 0 ? `${quotaGb} ${quotaUnit}` : t('addS3Repo.previewUnlimited') }}
                   </span>
                 </div>
                 <div class="add-form-preview-row">

--- a/src/frontend/src/pages/node/EditS3RepoSave.test.ts
+++ b/src/frontend/src/pages/node/EditS3RepoSave.test.ts
@@ -97,6 +97,7 @@ describe('EditS3Repo save behavior', () => {
       name: 'Object storage',
       config: {
         quota_gb: 200,
+        quota_unit: 'GB',
         quota_alert_enabled: true,
         quota_alert_threshold: 80,
       },

--- a/src/frontend/src/pages/node/RepairNasRepository.vue
+++ b/src/frontend/src/pages/node/RepairNasRepository.vue
@@ -21,6 +21,13 @@ import { proxyAgentsRoute } from '../../lib/nodeDeployRoutes'
 import type { ApiNode } from '../../types/node'
 import NasProxyTopology from './NasProxyTopology.vue'
 import { useInlineFormValidation } from '../../composables/useInlineFormValidation'
+import {
+  REPOSITORY_QUOTA_UNITS,
+  normalizeRepositoryQuotaUnit,
+  repositoryQuotaToGb,
+  repositoryQuotaValueFromGb,
+  type RepositoryQuotaUnit,
+} from '../../lib/repositoryQuota'
 
 type NasProtocol = 'smb' | 'nfs'
 
@@ -60,6 +67,7 @@ const smbPasswordDraft = ref('')
 const smbDomain = ref('')
 
 const quotaGb = ref(0)
+const quotaUnit = ref<RepositoryQuotaUnit>('GB')
 const quotaAlertEnabled = ref(false)
 const quotaAlertThreshold = ref<number | undefined>(80)
 
@@ -147,7 +155,8 @@ async function loadRepository() {
     smbUsernameDraft.value = ''
     smbPasswordDraft.value = ''
     smbDomain.value = extractConfigString(cfg, 'smb_domain')
-    quotaGb.value = Number(cfg.quota_gb || 0) || 0
+    quotaUnit.value = normalizeRepositoryQuotaUnit(cfg.quota_unit)
+    quotaGb.value = repositoryQuotaValueFromGb(cfg.quota_gb, quotaUnit.value)
     quotaAlertEnabled.value = Boolean(cfg.quota_alert_enabled)
     if (typeof cfg.quota_alert_threshold === 'number') {
       quotaAlertThreshold.value = cfg.quota_alert_threshold
@@ -283,7 +292,8 @@ async function onSubmit() {
   try {
     const config: Record<string, unknown> = {
       mount_options: mountOptionsDraft.value.trim() || undefined,
-      quota_gb: quotaGb.value || 0,
+      quota_gb: repositoryQuotaToGb(quotaGb.value, quotaUnit.value),
+      quota_unit: quotaUnit.value,
       quota_alert_enabled: quotaAlertEnabled.value,
       quota_alert_threshold: quotaAlertEnabled.value
         ? Number(quotaAlertThreshold.value || 0)
@@ -675,17 +685,28 @@ onMounted(async () => {
                       {{ t('repairNasRepo.labelQuota') }}
                     </label>
                     <div class="add-nas-quota-control">
-                      <div class="hfl-detail-form-input hfl-detail-form-input--narrow add-nas-quota-input">
+                      <div class="hfl-detail-form-input hfl-detail-form-input--narrow add-nas-quota-input repository-quota-split-input repository-quota-split-input--edit">
                         <ElInputNumber
                           v-model="quotaGb"
                           class="hfl-detail-form-input__num"
                           :placeholder="t('repairNasRepo.phQuota')"
                           :min="0"
+                          :precision="0"
+                          :step="1"
                           controls-position="right"
                         />
-                        <div class="hfl-detail-form-input__suffix">
-                          GB
-                        </div>
+                        <ElSelect
+                          v-model="quotaUnit"
+                          class="hfl-detail-form-input__unit"
+                          :aria-label="t('repositoriesPage.quotaUnit')"
+                        >
+                          <ElOption
+                            v-for="unit in REPOSITORY_QUOTA_UNITS"
+                            :key="unit"
+                            :label="unit"
+                            :value="unit"
+                          />
+                        </ElSelect>
                       </div>
                     </div>
                   </div>
@@ -924,7 +945,7 @@ onMounted(async () => {
                     class="add-nas-preview-row__value"
                     :class="{ 'add-nas-preview-row__value--highlight': quotaGb > 0 }"
                   >
-                    {{ quotaGb > 0 ? `${quotaGb} GB` : t('addS3Repo.previewUnlimited') }}
+                    {{ quotaGb > 0 ? `${quotaGb} ${quotaUnit}` : t('addS3Repo.previewUnlimited') }}
                   </span>
                 </div>
                 <div class="add-nas-preview-row">

--- a/src/frontend/src/pages/node/Repositories.vue
+++ b/src/frontend/src/pages/node/Repositories.vue
@@ -28,6 +28,7 @@ import RepositoryBackingStorageTooltip from '../../components/RepositoryBackingS
 import RepositoryCapacityConflictAlert from '../../components/RepositoryCapacityConflictAlert.vue'
 import HflBooleanStatusTag from '../../components/HflBooleanStatusTag.vue'
 import { remainingLimitExceedsAvailableStorage, repositoryCapacityParts, repositoryStorageParts } from '../../lib/repositoryCapacityDisplay'
+import { repositoryQuotaDisplay } from '../../lib/repositoryQuota'
 import { lifecycleStatusTagAttrs } from '../../lib/statusTag'
 import { useResponsiveDrawerWidth } from '../../composables/useResponsiveDrawerWidth'
 import { useDrawerTableMaxHeight } from '../../composables/useDrawerTableMaxHeight'
@@ -148,6 +149,7 @@ export type RepositoryConfig = {
   proxy_node_base_dir?: string
   proxy_fs_layout?: string
   quota_gb?: number
+  quota_unit?: string
   quota_alert_enabled?: boolean
   quota_alert_threshold?: number
 }
@@ -475,6 +477,7 @@ function mapApiToRow(r: ApiRepository): RepositoryRow {
         ),
         use_tls: configBoolean(config, 'use_tls') ?? r.use_tls !== false,
         quota_gb: configNumber(config, 'quota_gb') ?? 0,
+        quota_unit: configString(config, 'quota_unit'),
         quota_alert_enabled: configBoolean(config, 'quota_alert_enabled') ?? false,
         quota_alert_threshold: configNumber(config, 'quota_alert_threshold') ?? 0,
       },
@@ -517,6 +520,7 @@ function mapApiToRow(r: ApiRepository): RepositoryRow {
         proxy_fs_layout: configString(config, 'proxy_fs_layout'),
         proxy_repository_server_host: configString(config, 'proxy_repository_server_host'),
         quota_gb: configNumber(config, 'quota_gb') ?? 0,
+        quota_unit: configString(config, 'quota_unit'),
         quota_alert_enabled: configBoolean(config, 'quota_alert_enabled') ?? false,
         quota_alert_threshold: configNumber(config, 'quota_alert_threshold') ?? 0,
       },
@@ -578,6 +582,7 @@ function mapApiToRow(r: ApiRepository): RepositoryRow {
       nfs_export: configString(config, 'nfs_export') || r.nfs_export || (protocol === 'nfs' ? sharePath : ''),
       nfs_options: configString(config, 'nfs_options') || r.nfs_options || configString(config, 'mount_options'),
       quota_gb: configNumber(config, 'quota_gb') ?? 0,
+      quota_unit: configString(config, 'quota_unit'),
       quota_alert_enabled: configBoolean(config, 'quota_alert_enabled') ?? false,
       quota_alert_threshold: configNumber(config, 'quota_alert_threshold') ?? 0,
     },
@@ -1102,15 +1107,11 @@ async function copyDetailText(value: string) {
 }
 
 function s3QuotaLimitLabel(row: RepositoryRow) {
-  const quotaGb = Number(row.config.quota_gb ?? 0)
-  if (quotaGb > 0) return `${quotaGb} GB`
-  return t('repositoriesPage.noConfiguredLimit')
+  return repositoryQuotaDisplay(row.config) || t('repositoriesPage.noConfiguredLimit')
 }
 
 function storageLimitLabel(row: RepositoryRow) {
-  const quotaGb = Number(row.config.quota_gb ?? 0)
-  if (quotaGb > 0) return `${quotaGb} GB`
-  return t('repositoriesPage.noConfiguredLimit')
+  return repositoryQuotaDisplay(row.config) || t('repositoriesPage.noConfiguredLimit')
 }
 
 function quotaMonitoringEnabled(row: RepositoryRow) {

--- a/src/frontend/src/pages/node/RepositoryQuotaUnitUi.test.ts
+++ b/src/frontend/src/pages/node/RepositoryQuotaUnitUi.test.ts
@@ -1,0 +1,60 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const page = (name: string) => readFileSync(resolve(process.cwd(), `src/pages/node/${name}`), 'utf8')
+const quotaStyles = readFileSync(resolve(process.cwd(), 'src/styles/resource-add.css'), 'utf8')
+
+describe('repository quota unit UI coverage', () => {
+  it.each([
+    'AddS3Repo.vue',
+    'AddNasRepository.vue',
+    'AddProxyFsRepository.vue',
+    'EditS3Repo.vue',
+    'EditProxyFsRepo.vue',
+    'RepairNasRepository.vue',
+  ])('provides a persisted unit selector in %s', (file) => {
+    const source = page(file)
+    expect(source).toContain('REPOSITORY_QUOTA_UNITS')
+    expect(source).toContain('v-model="quotaUnit"')
+    expect(source).toContain('repository-quota-split-input')
+    expect(source).toContain('quota_unit: quotaUnit.value')
+    expect(source).toContain(':precision="0"')
+  })
+
+  it.each(['AddS3Repo.vue', 'AddNasRepository.vue', 'AddProxyFsRepository.vue'])('frames the Storage Limit control on %s without changing edit forms', (file) => {
+    expect(page(file)).toContain('repository-quota-split-input--add')
+  })
+
+  it.each(['EditS3Repo.vue', 'EditProxyFsRepo.vue', 'RepairNasRepository.vue'])('rounds the Storage Limit stepper controls on %s', (file) => {
+    expect(page(file)).toContain('repository-quota-split-input--edit')
+  })
+
+  it('uses the shared formatter for all repository detail variants', () => {
+    const source = page('Repositories.vue')
+    expect(source).toContain('repositoryQuotaDisplay(row.config)')
+    expect(source).toContain("quota_unit: configString(config, 'quota_unit')")
+  })
+
+  it('restores the standard background only on the Storage Limit value input', () => {
+    expect(quotaStyles).toContain('> .repository-quota-number__input.el-input-number')
+    expect(quotaStyles).toContain('> .hfl-detail-form-input__num.el-input-number')
+    expect(quotaStyles).toContain('background: var(--el-fill-color-blank) !important;')
+    expect(quotaStyles).not.toContain(
+      '.resource-add-fullscreen .repository-quota-split-input :is(.repository-quota-number__unit, .hfl-detail-form-input__unit)',
+    )
+  })
+
+  it('keeps add-form value and unit fields separate and rounded', () => {
+    expect(quotaStyles).toContain('.repository-quota-split-input--add')
+    expect(quotaStyles).toContain('gap: 8px;')
+    expect(quotaStyles).toContain('border: 0 !important;')
+    expect(quotaStyles).toContain('border-radius: var(--el-border-radius-base) !important;')
+  })
+
+  it('restores matching corners on edit quota stepper buttons', () => {
+    expect(quotaStyles).toContain('.repository-quota-split-input--edit')
+    expect(quotaStyles).toContain('border-top-right-radius: var(--el-border-radius-base) !important;')
+    expect(quotaStyles).toContain('border-bottom-right-radius: var(--el-border-radius-base) !important;')
+  })
+})

--- a/src/frontend/src/styles/resource-add.css
+++ b/src/frontend/src/styles/resource-add.css
@@ -762,6 +762,126 @@ html:not([data-theme='dark']) .resource-add-fullscreen :is(.add-s3-platform-btn:
   white-space: nowrap;
 }
 
+.resource-add-fullscreen .repository-quota-number__unit {
+  flex: 0 0 82px;
+  width: 82px;
+  border-left: 1px solid var(--el-border-color);
+}
+
+.resource-add-fullscreen .repository-quota-number__unit .el-select__wrapper {
+  height: 32px;
+  min-height: 32px;
+  border: none !important;
+  border-radius: 0 !important;
+  box-shadow: none !important;
+  background: transparent !important;
+}
+
+/* Keep the capacity value and unit visually related without fusing them into
+ * one ambiguous control. This follows the split field + unit selector pattern
+ * used by storage and infrastructure consoles. */
+.repository-quota-split-input {
+  width: 248px !important;
+  max-width: 100%;
+  gap: 8px;
+  overflow: visible !important;
+  border: 0 !important;
+  background: transparent !important;
+}
+
+.repository-quota-split-input:focus-within {
+  border-color: transparent !important;
+}
+
+.repository-quota-split-input :is(.repository-quota-number__input, .hfl-detail-form-input__num) {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.repository-quota-split-input :is(.repository-quota-number__input, .hfl-detail-form-input__num) .el-input__wrapper,
+.repository-quota-split-input :is(.repository-quota-number__unit, .hfl-detail-form-input__unit) .el-select__wrapper {
+  border: 0 !important;
+  border-radius: var(--el-border-radius-base) !important;
+  background: var(--el-fill-color-blank) !important;
+  box-shadow: 0 0 0 1px var(--el-border-color) inset, 0 1px 2px rgb(15 23 42 / 4%) !important;
+  transition: box-shadow var(--el-transition-duration-fast);
+}
+
+.repository-quota-split-input :is(.repository-quota-number__input, .hfl-detail-form-input__num):hover .el-input__wrapper,
+.repository-quota-split-input :is(.repository-quota-number__unit, .hfl-detail-form-input__unit):hover .el-select__wrapper {
+  box-shadow: 0 0 0 1px var(--el-border-color-hover) inset, 0 1px 2px rgb(15 23 42 / 4%) !important;
+}
+
+.repository-quota-split-input :is(.repository-quota-number__input, .hfl-detail-form-input__num) .el-input__wrapper.is-focus,
+.repository-quota-split-input :is(.repository-quota-number__unit, .hfl-detail-form-input__unit) .el-select__wrapper.is-focused {
+  box-shadow: 0 0 0 1px var(--el-color-primary) inset, 0 0 0 3px var(--el-color-primary-light-9) !important;
+}
+
+.repository-quota-split-input :is(.repository-quota-number__unit, .hfl-detail-form-input__unit) {
+  flex: 0 0 82px;
+  width: 82px;
+  border-left: 0;
+}
+
+/* Only restore the standard background on the Storage Limit value input.
+ * Keep this selector local so other fields and the unit selector are untouched. */
+.resource-add-fullscreen
+  .repository-quota-split-input
+  > .repository-quota-number__input.el-input-number
+  .el-input__wrapper,
+.resource-add-fullscreen
+  .repository-quota-split-input
+  > .hfl-detail-form-input__num.el-input-number
+  .el-input__wrapper {
+  background: var(--el-fill-color-blank) !important;
+}
+
+/* New-repository forms keep the value and unit as two independent fields,
+ * matching the rounded treatment used by the surrounding Element Plus inputs. */
+.resource-add-fullscreen .repository-quota-split-input--add {
+  width: 248px !important;
+  gap: 8px;
+  overflow: visible !important;
+  border: 0 !important;
+  border-radius: 0 !important;
+  background: transparent !important;
+}
+
+.resource-add-fullscreen .repository-quota-split-input--add:focus-within {
+  border-color: transparent !important;
+}
+
+.resource-add-fullscreen .repository-quota-split-input--add
+  :is(.repository-quota-number__input, .hfl-detail-form-input__num)
+  .el-input__wrapper,
+.resource-add-fullscreen .repository-quota-split-input--add
+  :is(.repository-quota-number__unit, .hfl-detail-form-input__unit)
+  .el-select__wrapper {
+  border: 0 !important;
+  border-radius: var(--el-border-radius-base) !important;
+  background: var(--el-fill-color-blank) !important;
+  box-shadow: 0 0 0 1px var(--el-border-color) inset, 0 1px 2px rgb(15 23 42 / 4%) !important;
+}
+
+.resource-add-fullscreen .repository-quota-split-input--add
+  :is(.repository-quota-number__unit, .hfl-detail-form-input__unit) {
+  border-left: 0;
+}
+
+/* Element Plus exposes the stepper buttons as separate right-edge controls.
+ * Restore their matching corners for the three edit/repair quota fields. */
+.resource-add-fullscreen .repository-quota-split-input--edit
+  .hfl-detail-form-input__num.el-input-number.is-controls-right
+  .el-input-number__increase {
+  border-top-right-radius: var(--el-border-radius-base) !important;
+}
+
+.resource-add-fullscreen .repository-quota-split-input--edit
+  .hfl-detail-form-input__num.el-input-number.is-controls-right
+  .el-input-number__decrease {
+  border-bottom-right-radius: var(--el-border-radius-base) !important;
+}
+
 .resource-add-fullscreen :is(.add-s3-quota-threshold-row, .add-nas-quota-threshold-row, .add-proxy-fs-quota-threshold-row) {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Problem and root cause

Repository storage limits only stored `quota_gb`, so forms and detail views
could only present GB and could not preserve an operator's intended unit.

## Solution

Add persisted GB, TB, and PB unit selection while retaining `quota_gb` as the
canonical value. Legacy and invalid unit values fall back to GB. Align the
add, edit, repair, and detail quota controls with the existing form styling.

## Validation

- Frontend Vitest: 208 files, 1034 tests passed
- Frontend ESLint and production build passed
- Backend storage suite: 415 tests passed
- Focused storage API tests, Ruff, migration drift, and source checks passed
- Manual testing: passed

## Risks and compatibility

No migration is required. Existing configurations without `quota_unit` remain
GB, and `quota_gb` remains the compatible capacity field for current storage
and alert behavior.

Fixes #644
