### PR TITLE
fix(frontend): prevent quota monitoring status text from wrapping mid-word

### DIFF
--- a/src/frontend/src/pages/node/RepairNasRepository.vue
+++ b/src/frontend/src/pages/node/RepairNasRepository.vue
@@ -1635,7 +1635,7 @@ onMounted(async () => {
   font-weight: 500;
   color: rgb(30 41 59);
   text-align: right;
-  word-break: break-all;
+  overflow-wrap: break-word;
 }
 
 .add-nas-preview-row__value--empty {

--- a/src/frontend/src/styles/resource-add.css
+++ b/src/frontend/src/styles/resource-add.css
@@ -1151,7 +1151,7 @@ html:not([data-theme='dark']) .resource-add-fullscreen :is(.add-s3-platform-btn:
 
 .resource-add-fullscreen .add-form-preview-row__value {
   min-width: 0;
-  overflow-wrap: anywhere;
+  overflow-wrap: break-word;
   color: #1d2129;
   font-size: 13px;
   font-weight: 500;
@@ -1749,7 +1749,7 @@ html:not([data-theme='dark']) .fullscreen-form-icon-btn:not(.hfl-refresh-button)
 
 .add-form-preview-row__value {
   min-width: 0;
-  overflow-wrap: anywhere;
+  overflow-wrap: break-word;
   color: var(--color-text-title, #303133);
   font-size: 13px;
   font-weight: 500;


### PR DESCRIPTION
## Summary

Fixes #626 — On the Edit NAS Repository screen (English interface), the 'Enable Quota Monitoring' status text 'Enabled (80%)' was incorrectly wrapping across two lines as 'Enabled (8' / '0%)'.

## Root Cause

Two CSS properties were forcing text to break at arbitrary character positions:

- `RepairNasRepository.vue`: `word-break: break-all` on `.add-nas-preview-row__value`
- `resource-add.css`: `overflow-wrap: anywhere` on `.add-form-preview-row__value` (2 occurrences)

## Fix

Replaced both with `overflow-wrap: break-word`, which only breaks at word boundaries when necessary. This keeps short status labels like 'Enabled (80%)' intact while still allowing long path values to wrap normally.

## Affected Pages

- Edit NAS Repository
- Add NAS Repository
- Edit S3 Repository
- Add S3 Repository
- Edit Proxy FS Repository