### PR TITLE
fix(frontend): center status cards and remove double border in backup config wizard (#609)

### DIFF
--- a/src/frontend/src/pages/protection/BackupConfigCreateWizard.vue
+++ b/src/frontend/src/pages/protection/BackupConfigCreateWizard.vue
@@ -159,42 +159,46 @@ watch(
 
             <div
               v-else-if="phase === 'waiting'"
-              class="fullscreen-form-card py-10 text-center"
+              class="create-backup-step-body dp-process-page create-backup-loading-pane"
             >
-              <el-progress
-                :percentage="66"
-                :indeterminate="true"
-                status="warning"
-                class="mb-4"
-              />
-              <p class="text-slate-600">
-                {{ waitingText }}
-              </p>
+              <div class="fullscreen-form-card create-backup-status-card py-10 text-center">
+                <el-progress
+                  :percentage="66"
+                  :indeterminate="true"
+                  status="warning"
+                  class="mb-4"
+                />
+                <p class="text-slate-600">
+                  {{ waitingText }}
+                </p>
+              </div>
             </div>
 
             <div
               v-else
-              class="fullscreen-form-card py-8 text-center space-y-4"
+              class="create-backup-step-body dp-process-page create-backup-loading-pane"
             >
-              <el-result
-                icon="success"
-                :title="resultTitle"
-                :sub-title="resultSubtitle"
-              >
-                <template #extra>
-                  <div class="flex flex-wrap items-center justify-center gap-2">
-                    <ElButton
-                      type="primary"
-                      @click="emit('close')"
-                    >
-                      {{ closeLabel }}
-                    </ElButton>
-                    <ElButton @click="emit('goToStartBackup')">
-                      {{ goToStartBackupLabel }}
-                    </ElButton>
-                  </div>
-                </template>
-              </el-result>
+              <div class="fullscreen-form-card create-backup-status-card py-8 text-center space-y-4">
+                <el-result
+                  icon="success"
+                  :title="resultTitle"
+                  :sub-title="resultSubtitle"
+                >
+                  <template #extra>
+                    <div class="flex flex-wrap items-center justify-center gap-2">
+                      <ElButton
+                        type="primary"
+                        @click="emit('close')"
+                      >
+                        {{ closeLabel }}
+                      </ElButton>
+                      <ElButton @click="emit('goToStartBackup')">
+                        {{ goToStartBackupLabel }}
+                      </ElButton>
+                    </div>
+                  </template>
+                </el-result>
+              </div>
             </div>
           </main>
         </div>
@@ -321,6 +325,12 @@ watch(
   margin: 0 auto;
   padding: 40px 32px;
   text-align: center;
+}
+
+.create-backup-status-card {
+  border: none;
+  box-shadow: none;
+  background: transparent;
 }
 
 .create-backup-footer__inner,


### PR DESCRIPTION
## Summary

Fixes #609 — resolves a UI layout issue in the backup configuration wizard where the waiting and done phase status cards were not vertically centered and had a redundant double-border effect.

## Changes

- Wrap the `waiting` and `done` phase cards in `create-backup-loading-pane` wrapper for vertical centering (consistent with the existing `bootstrapping` phase)
- Add `create-backup-status-card` scoped CSS class to strip `border`, `box-shadow`, and `background` from the inner card, letting content blend into the outer container

## Before / After

**Before:** Card sits at top of area with large blank space below; inner card border creates a double-border effect against the outer container.

**After:** Card is vertically centered; inner card is borderless and blends seamlessly into the outer container.

## Verification

- [ ] Open the Create Backup Configuration wizard and confirm the config
- [ ] Verify the "Saving backup configuration..." waiting card is vertically centered
- [ ] Verify the success result card is also vertically centered
- [ ] Verify the form phase and bootstrapping phase are unaffected