### PR TITLE
fix(frontend): prevent target repository type counts from resetting when switching filters (#605)

### DIFF
--- a/src/frontend/src/pages/protection/BackupCreateWizard.vue
+++ b/src/frontend/src/pages/protection/BackupCreateWizard.vue
@@ -7536,6 +7536,7 @@ function preserveShallowestPathOrder(paths: string[]) {
                   v-model:nas-mode="batchNasTargetMode"
                   :model-value="batchTargetPicker.targetId"
                   :targets="targetOptionsForBatch()"
+                  :all-targets="selectableTargets"
                   :selected-target="batchSelectedTarget"
                   :repo-type-options="repoTypeOptions"
                   :target-placeholder="t('protection.backupsPage.phSearchTargets')"

--- a/src/frontend/src/pages/protection/components/TargetRepositoryPicker.vue
+++ b/src/frontend/src/pages/protection/components/TargetRepositoryPicker.vue
@@ -43,6 +43,7 @@ const props = withDefaults(defineProps<{
   repoType: string
   nasMode?: NasTargetMode
   targets: TargetRepositoryItem[]
+  allTargets?: TargetRepositoryItem[]
   selectedTarget?: TargetRepositoryItem | null
   repoTypeOptions: string[]
   targetPlaceholder: string
@@ -55,6 +56,7 @@ const props = withDefaults(defineProps<{
   refreshing?: boolean
   refreshTitle?: string
 }>(), {
+  allTargets: () => [],
   nasMode: 'per_directory_repo',
   selectedTarget: null,
   teleported: true,
@@ -153,8 +155,9 @@ function isRepoTypeFilterChecked(value: string): boolean {
 }
 
 function repoTypeFilterCount(value: string): number {
-  if (value === ALL_REPO_TYPE_VALUE) return props.targets.length
-  return props.targets.filter((target) => target.repoType === value).length
+  const source = props.allTargets && props.allTargets.length > 0 ? props.allTargets : props.targets
+  if (value === ALL_REPO_TYPE_VALUE) return source.length
+  return source.filter((target) => target.repoType === value).length
 }
 
 function clearTargetSearch() {


### PR DESCRIPTION
## Summary

Fixed a bug where selecting a repository type filter (e.g., Object Storage or Local Disk) in the Select Target Repository dialog incorrectly reset the counts for other types (NAS and All) to zero.

## Root Cause

The `TargetRepositoryPicker` component computed per-type counts from `props.targets`, but the parent `BackupCreateWizard` was already passing a pre-filtered list (filtered by the active `repoType`). When the user selected a type with zero repositories, the filtered list became empty, causing all counts to show zero.

## Fix

- Added an `allTargets` prop to `TargetRepositoryPicker` for receiving the full unfiltered list
- `repoTypeFilterCount` now uses `allTargets` (when available) instead of the filtered `targets` for count computation
- `BackupCreateWizard` passes `selectableTargets` as `all-targets` to the picker

## Changes

- `src/frontend/src/pages/protection/components/TargetRepositoryPicker.vue` — added `allTargets` prop, updated count logic
- `src/frontend/src/pages/protection/BackupCreateWizard.vue` — passes full unfiltered list via `all-targets`

Fixes #605