### PR TITLE
fix(agent): NAS unmount lifecycle - retry with force lazy detach and lease coordination (#535)

### DIFF
--- a/src/agent/internal/engine/engine.go
+++ b/src/agent/internal/engine/engine.go
@@ -28,11 +28,25 @@ type Engine struct {
 	activeKill            func()
 	repositoryServerMu    sync.Mutex
 	repositoryServerPorts map[int]struct{}
+	nasLeaseOnce          sync.Once
+	nasLeaseCoordinator   *NASLeaseCoordinator
 }
 
 // New returns an engine that reads config from provider on each command.
 func New(provider config.Provider) *Engine {
-	return &Engine{provider: provider}
+	return NewWithNASLeaseCoordinator(provider, nil)
+}
+
+// NewWithNASLeaseCoordinator returns an engine sharing mount lifetime leases
+// with other task-scoped engines in the same Agent process.
+func NewWithNASLeaseCoordinator(
+	provider config.Provider,
+	coordinator *NASLeaseCoordinator,
+) *Engine {
+	if coordinator == nil {
+		coordinator = NewNASLeaseCoordinator()
+	}
+	return &Engine{provider: provider, nasLeaseCoordinator: coordinator}
 }
 
 func (e *Engine) current() *model.AgentConfig {
@@ -50,6 +64,18 @@ func (e *Engine) Run(ctx context.Context, cmd Command, sink ExecutionSink) Resul
 
 	kind := NormalizeKind(cmd.Kind)
 	p := ParsePayload(cmd.Payload)
+	leasePaths := nasLeasePaths(p)
+	if len(leasePaths) > 0 {
+		release, leaseErr := e.nasLeases().acquire(
+			ctx,
+			leasePaths,
+			needsExclusiveNASLease(kind, p),
+		)
+		if leaseErr != nil {
+			return Result{Status: "failed", Error: "canceled"}
+		}
+		defer release()
+	}
 	rep := ReporterSink{Sink: sink, TaskID: cmd.ID}
 	nodeID := e.current().NodeID
 	slog.InfoContext(ctx, "engine task started", "node_id", nodeID, "task_id", cmd.ID, "kind", kind)
@@ -230,6 +256,15 @@ func (e *Engine) Run(ctx context.Context, cmd Command, sink ExecutionSink) Resul
 		slog.WarnContext(ctx, "engine task finished", "node_id", nodeID, "task_id", cmd.ID, "kind", kind, "status", status, "err", errMsg)
 	}
 	return Result{Status: status, Result: result, Error: errMsg}
+}
+
+func (e *Engine) nasLeases() *nasLeaseRegistry {
+	e.nasLeaseOnce.Do(func() {
+		if e.nasLeaseCoordinator == nil {
+			e.nasLeaseCoordinator = NewNASLeaseCoordinator()
+		}
+	})
+	return e.nasLeaseCoordinator.registry()
 }
 
 func (e *Engine) kopiaBin(ctx context.Context) (string, error) {

--- a/src/agent/internal/engine/nas_handlers.go
+++ b/src/agent/internal/engine/nas_handlers.go
@@ -196,15 +196,38 @@ func (e *Engine) runNasUnmount(ctx context.Context, p Payload) (string, map[stri
 		return "failed", nil, "mount_point is required"
 	}
 	logNasTask(ctx, "unmount_start", "", nas.Spec{MountPoint: mountPoint}, "mount_point", mountPoint)
-	if err := nas.NewService().Unmount(ctx, mountPoint); err != nil {
+	forceCleanup, _ := payloadBoolValue(p.Extra["force_cleanup"])
+	cleanup, err := nas.NewService().UnmountWithOptions(
+		ctx,
+		mountPoint,
+		nas.UnmountOptions{Force: forceCleanup},
+	)
+	if err != nil {
 		logNasTask(ctx, "unmount_failed", "", nas.Spec{MountPoint: mountPoint}, "err", err.Error())
 		return "failed", nil, err.Error()
 	}
-	logNasTask(ctx, "unmount_ok", "", nas.Spec{MountPoint: mountPoint})
-	return "success", map[string]any{
-		"mount_point":  mountPoint,
-		"mount_status": "unmounted",
-	}, ""
+	logNasTask(
+		ctx,
+		"unmount_ok",
+		"",
+		nas.Spec{MountPoint: mountPoint},
+		"attempts",
+		cleanup.Attempts,
+		"lazy_unmount",
+		cleanup.LazyUnmount,
+		"cleanup_complete",
+		cleanup.CleanupComplete,
+	)
+	result := map[string]any{
+		"mount_point":        mountPoint,
+		"mount_status":       "unmounted",
+		"cleanup_complete":   cleanup.CleanupComplete,
+		"lazy_unmount":       cleanup.LazyUnmount,
+		"unmount_attempts":   cleanup.Attempts,
+		"retained_resources": cleanup.RetainedResources,
+		"warnings":           cleanup.Warnings,
+	}
+	return "success", result, ""
 }
 
 func (e *Engine) runNasTest(ctx context.Context, p Payload) (string, map[string]any, string) {

--- a/src/agent/internal/engine/nas_lease.go
+++ b/src/agent/internal/engine/nas_lease.go
@@ -1,0 +1,246 @@
+package engine
+
+import (
+	"context"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"sync"
+
+	"hyperfilelens/agent/internal/service/nas"
+)
+
+type nasLeaseEntry struct {
+	mu      sync.Mutex
+	readers int
+	writer  bool
+	waiters []*nasLeaseWaiter
+	refs    int
+}
+
+type nasLeaseWaiter struct {
+	exclusive bool
+	ready     chan struct{}
+	granted   bool
+}
+
+type nasLeaseRegistry struct {
+	mu      sync.Mutex
+	entries map[string]*nasLeaseEntry
+}
+
+// NASLeaseCoordinator owns Agent-process mount lifetime leases. WebSocket
+// tasks use separate Engine instances but share one coordinator.
+type NASLeaseCoordinator struct {
+	once     sync.Once
+	nasLease *nasLeaseRegistry
+}
+
+// NewNASLeaseCoordinator returns a mount lifetime coordinator for one Agent.
+func NewNASLeaseCoordinator() *NASLeaseCoordinator {
+	return &NASLeaseCoordinator{nasLease: newNASLeaseRegistry()}
+}
+
+func (c *NASLeaseCoordinator) registry() *nasLeaseRegistry {
+	c.once.Do(func() {
+		if c.nasLease == nil {
+			c.nasLease = newNASLeaseRegistry()
+		}
+	})
+	return c.nasLease
+}
+
+func newNASLeaseRegistry() *nasLeaseRegistry {
+	return &nasLeaseRegistry{entries: make(map[string]*nasLeaseEntry)}
+}
+
+// acquire coordinates physical mount lifetime inside one Agent process.  It is
+// deliberately local: controller task state remains authoritative, while this
+// lease closes the race between users of a mount and nas.unmount.
+func (r *nasLeaseRegistry) acquire(ctx context.Context, paths []string, exclusive bool) (func(), error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	paths = normalizedLeasePaths(paths)
+	if len(paths) == 0 {
+		return func() {}, nil
+	}
+
+	r.mu.Lock()
+	entries := make([]*nasLeaseEntry, 0, len(paths))
+	for _, path := range paths {
+		entry := r.entries[path]
+		if entry == nil {
+			entry = &nasLeaseEntry{}
+			r.entries[path] = entry
+		}
+		entry.refs++
+		entries = append(entries, entry)
+	}
+	r.mu.Unlock()
+
+	acquired := make([]*nasLeaseEntry, 0, len(entries))
+	for _, entry := range entries {
+		if err := entry.acquire(ctx, exclusive); err != nil {
+			for index := len(acquired) - 1; index >= 0; index-- {
+				acquired[index].release(exclusive)
+			}
+			r.releaseEntries(paths, entries)
+			return nil, err
+		}
+		acquired = append(acquired, entry)
+	}
+
+	return func() {
+		for index := len(entries) - 1; index >= 0; index-- {
+			entries[index].release(exclusive)
+		}
+		r.releaseEntries(paths, entries)
+	}, nil
+}
+
+func (e *nasLeaseEntry) acquire(ctx context.Context, exclusive bool) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	waiter := &nasLeaseWaiter{exclusive: exclusive, ready: make(chan struct{})}
+	e.mu.Lock()
+	if e.canAcquireImmediately(exclusive) {
+		e.grant(waiter)
+	} else {
+		e.waiters = append(e.waiters, waiter)
+	}
+	e.mu.Unlock()
+
+	select {
+	case <-waiter.ready:
+		return nil
+	case <-ctx.Done():
+		e.mu.Lock()
+		if waiter.granted {
+			e.releaseGranted(exclusive)
+		} else {
+			for index, candidate := range e.waiters {
+				if candidate == waiter {
+					e.waiters = append(e.waiters[:index], e.waiters[index+1:]...)
+					break
+				}
+			}
+			e.grantWaiters()
+		}
+		e.mu.Unlock()
+		return ctx.Err()
+	}
+}
+
+func (e *nasLeaseEntry) canAcquireImmediately(exclusive bool) bool {
+	if e.writer || len(e.waiters) > 0 {
+		return false
+	}
+	return !exclusive || e.readers == 0
+}
+
+func (e *nasLeaseEntry) grant(waiter *nasLeaseWaiter) {
+	waiter.granted = true
+	if waiter.exclusive {
+		e.writer = true
+	} else {
+		e.readers++
+	}
+	close(waiter.ready)
+}
+
+func (e *nasLeaseEntry) release(exclusive bool) {
+	e.mu.Lock()
+	e.releaseGranted(exclusive)
+	e.mu.Unlock()
+}
+
+func (e *nasLeaseEntry) releaseGranted(exclusive bool) {
+	if exclusive {
+		e.writer = false
+	} else {
+		e.readers--
+	}
+	e.grantWaiters()
+}
+
+func (e *nasLeaseEntry) grantWaiters() {
+	if e.writer || len(e.waiters) == 0 {
+		return
+	}
+	if e.waiters[0].exclusive {
+		if e.readers != 0 {
+			return
+		}
+		waiter := e.waiters[0]
+		e.waiters = e.waiters[1:]
+		e.grant(waiter)
+		return
+	}
+	for len(e.waiters) > 0 && !e.waiters[0].exclusive {
+		waiter := e.waiters[0]
+		e.waiters = e.waiters[1:]
+		e.grant(waiter)
+	}
+}
+
+func (r *nasLeaseRegistry) releaseEntries(paths []string, entries []*nasLeaseEntry) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for index, path := range paths {
+		entry := entries[index]
+		entry.refs--
+		if entry.refs == 0 && r.entries[path] == entry {
+			delete(r.entries, path)
+		}
+	}
+}
+
+func normalizedLeasePaths(paths []string) []string {
+	seen := make(map[string]struct{}, len(paths))
+	result := make([]string, 0, len(paths))
+	for _, raw := range paths {
+		path := filepath.Clean(strings.TrimSpace(raw))
+		if path == "" || path == "." {
+			continue
+		}
+		if runtime.GOOS == "windows" {
+			path = strings.ToLower(path)
+		}
+		if _, exists := seen[path]; exists {
+			continue
+		}
+		seen[path] = struct{}{}
+		result = append(result, path)
+	}
+	sort.Strings(result)
+	return result
+}
+
+func nasLeasePaths(p Payload) []string {
+	paths := []string{}
+	if mountPoint := stringValue(p.Extra["mount_point"]); mountPoint != "" {
+		paths = append(paths, nas.ResolvedMountPoint(mountPoint))
+	}
+	if spec, ok, err := parseNASSpec(p.Extra["nas"]); err == nil && ok {
+		paths = append(paths, spec.MountPoint)
+	}
+	if raw, ok := p.Extra["repository"].(map[string]any); ok {
+		if nested, ok := raw["nas"].(map[string]any); ok {
+			if spec, present, err := parseNASSpec(nested); err == nil && present {
+				paths = append(paths, spec.MountPoint)
+			}
+		}
+	}
+	return normalizedLeasePaths(paths)
+}
+
+func needsExclusiveNASLease(kind string, p Payload) bool {
+	if kind == "nas.unmount" || kind == "nas.mount" || kind == "repository.operation" {
+		return true
+	}
+	cleanupAfterTest, _ := payloadBoolValue(p.Extra["cleanup_after_test"])
+	return kind == "nas.test" && cleanupAfterTest
+}

--- a/src/agent/internal/engine/nas_lease_test.go
+++ b/src/agent/internal/engine/nas_lease_test.go
@@ -1,0 +1,214 @@
+package engine
+
+import (
+	"context"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"hyperfilelens/agent/internal/platform/vfs"
+)
+
+func TestNASLeaseExclusiveWaitsForActiveReader(t *testing.T) {
+	registry := newNASLeaseRegistry()
+	releaseReader, err := registry.acquire(context.Background(), []string{"/managed/source"}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	acquired := make(chan func(), 1)
+	go func() {
+		release, acquireErr := registry.acquire(context.Background(), []string{"/managed/source"}, true)
+		if acquireErr == nil {
+			acquired <- release
+		}
+	}()
+
+	select {
+	case release := <-acquired:
+		release()
+		t.Fatal("exclusive lease acquired while a reader was active")
+	case <-time.After(30 * time.Millisecond):
+	}
+
+	releaseReader()
+	select {
+	case release := <-acquired:
+		release()
+	case <-time.After(time.Second):
+		t.Fatal("exclusive lease did not acquire after reader released")
+	}
+}
+
+func TestTaskScopedEnginesShareNASLeaseCoordinator(t *testing.T) {
+	coordinator := NewNASLeaseCoordinator()
+	first := NewWithNASLeaseCoordinator(nil, coordinator)
+	second := NewWithNASLeaseCoordinator(nil, coordinator)
+	if first.nasLeases() != second.nasLeases() {
+		t.Fatal("task-scoped engines do not share the Agent NAS lease registry")
+	}
+}
+
+func TestZeroValueEngineInitializesNASLeasesSafely(t *testing.T) {
+	engine := &Engine{}
+	registries := make(chan *nasLeaseRegistry, 16)
+	var workers sync.WaitGroup
+	for range 16 {
+		workers.Add(1)
+		go func() {
+			defer workers.Done()
+			registries <- engine.nasLeases()
+		}()
+	}
+	workers.Wait()
+	close(registries)
+
+	var first *nasLeaseRegistry
+	for registry := range registries {
+		if first == nil {
+			first = registry
+			continue
+		}
+		if registry != first {
+			t.Fatal("zero-value Engine initialized more than one lease registry")
+		}
+	}
+}
+
+func TestNASLeaseWaitHonorsContextCancellation(t *testing.T) {
+	registry := newNASLeaseRegistry()
+	releaseReader, err := registry.acquire(context.Background(), []string{"/managed/source"}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer releaseReader()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	canceled := make(chan error, 1)
+	go func() {
+		_, acquireErr := registry.acquire(ctx, []string{"/managed/source"}, true)
+		canceled <- acquireErr
+	}()
+	cancel()
+
+	select {
+	case acquireErr := <-canceled:
+		if acquireErr != context.Canceled {
+			t.Fatalf("acquire error=%v", acquireErr)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("lease wait did not stop after context cancellation")
+	}
+}
+
+func TestNASLeaseWriterIsNotStarvedByNewReaders(t *testing.T) {
+	registry := newNASLeaseRegistry()
+	releaseFirstReader, err := registry.acquire(context.Background(), []string{"/managed/source"}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	order := make(chan string, 2)
+	releases := make(chan func(), 2)
+	go func() {
+		release, acquireErr := registry.acquire(context.Background(), []string{"/managed/source"}, true)
+		if acquireErr == nil {
+			order <- "writer"
+			releases <- release
+		}
+	}()
+	waitForNASLeaseWaiters(t, registry, "/managed/source", 1)
+	go func() {
+		release, acquireErr := registry.acquire(context.Background(), []string{"/managed/source"}, false)
+		if acquireErr == nil {
+			order <- "reader"
+			releases <- release
+		}
+	}()
+
+	releaseFirstReader()
+	select {
+	case first := <-order:
+		if first != "writer" {
+			t.Fatalf("first lease=%s want=writer", first)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("writer did not acquire")
+	}
+	(<-releases)()
+	select {
+	case second := <-order:
+		if second != "reader" {
+			t.Fatalf("second lease=%s want=reader", second)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("reader did not acquire after writer")
+	}
+	(<-releases)()
+}
+
+func waitForNASLeaseWaiters(
+	t *testing.T,
+	registry *nasLeaseRegistry,
+	path string,
+	want int,
+) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		registry.mu.Lock()
+		entry := registry.entries[path]
+		registry.mu.Unlock()
+		if entry != nil {
+			entry.mu.Lock()
+			count := len(entry.waiters)
+			entry.mu.Unlock()
+			if count >= want {
+				return
+			}
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("lease waiters did not reach %d", want)
+}
+
+func TestNASLeasePathsIncludeSourceAndNASRepository(t *testing.T) {
+	dataDir := t.TempDir()
+	t.Setenv("HFL_DATA_DIR", dataDir)
+	sourceMount := filepath.Join(vfs.MountCustomDir(dataDir), "source")
+	targetMount := filepath.Join(vfs.MountCustomDir(dataDir), "target")
+	payload := Payload{Extra: map[string]any{
+		"nas": map[string]any{
+			"protocol": "nfs", "server": "192.0.2.10", "export_path": "/source", "mount_point": sourceMount,
+		},
+		"repository": map[string]any{
+			"type": "nas",
+			"nas": map[string]any{
+				"protocol": "nfs", "server": "192.0.2.20", "export_path": "/target", "mount_point": targetMount,
+			},
+		},
+	}}
+
+	paths := nasLeasePaths(payload)
+	want := normalizedLeasePaths([]string{sourceMount, targetMount})
+	if len(paths) != 2 || paths[0] != want[0] || paths[1] != want[1] {
+		t.Fatalf("lease paths=%v", paths)
+	}
+}
+
+func TestNASLeasePathsIncludeFlatNASPayload(t *testing.T) {
+	dataDir := t.TempDir()
+	t.Setenv("HFL_DATA_DIR", dataDir)
+	mountPoint := filepath.Join(vfs.MountCustomDir(dataDir), "source")
+	payload := Payload{Extra: map[string]any{
+		"resource_id": 7,
+		"protocol":    "nfs",
+		"mount_point": mountPoint,
+	}}
+
+	paths := nasLeasePaths(payload)
+	if len(paths) != 1 || paths[0] != mountPoint {
+		t.Fatalf("lease paths=%v want=[%s]", paths, mountPoint)
+	}
+}

--- a/src/agent/internal/service/nas/mount_unix.go
+++ b/src/agent/internal/service/nas/mount_unix.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
+	"strconv"
 	"strings"
 
 	"log/slog"
@@ -100,6 +102,10 @@ func unescapeProcMount(value string) string {
 		`\134`, `\`,
 	)
 	return replacer.Replace(value)
+}
+
+func hasUnmountWork(mountPoint string) bool {
+	return isMounted(mountPoint)
 }
 
 func mountShare(ctx context.Context, spec Spec) error {
@@ -314,6 +320,126 @@ func unmountShare(ctx context.Context, mountPoint string) error {
 		return fmt.Errorf("unmount NAS share: %s", msg)
 	}
 	return nil
+}
+
+func lazyUnmountShare(ctx context.Context, mountPoint string) error {
+	res, runErr := process.Run(ctx, "umount", []string{"-l", mountPoint}, nil, "")
+	if runErr != nil {
+		msg := strings.TrimSpace(res.Stderr)
+		if msg == "" {
+			msg = runErr.Error()
+		}
+		return fmt.Errorf("lazy unmount NAS share: %s", msg)
+	}
+	return nil
+}
+
+func unmountBusyDetails(mountPoint string) string {
+	mountPoint = filepath.Clean(mountPoint)
+	details := nestedMountDetails(mountPoint)
+	procEntries, err := os.ReadDir("/proc")
+	if err != nil {
+		return strings.Join(details, ", ")
+	}
+	for _, entry := range procEntries {
+		if !entry.IsDir() {
+			continue
+		}
+		pid, parseErr := strconv.Atoi(entry.Name())
+		if parseErr != nil || pid <= 0 {
+			continue
+		}
+		procRoot := filepath.Join("/proc", entry.Name())
+		for _, reference := range []string{"cwd", "root"} {
+			target, readErr := os.Readlink(filepath.Join(procRoot, reference))
+			if readErr == nil && pathWithinMount(target, mountPoint) {
+				details = append(details, processReferenceDetail(procRoot, pid, reference))
+				break
+			}
+		}
+		if len(details) >= 8 {
+			break
+		}
+		fdEntries, readErr := os.ReadDir(filepath.Join(procRoot, "fd"))
+		if readErr != nil {
+			continue
+		}
+		for _, fd := range fdEntries {
+			target, linkErr := os.Readlink(filepath.Join(procRoot, "fd", fd.Name()))
+			if linkErr == nil && pathWithinMount(strings.TrimSuffix(target, " (deleted)"), mountPoint) {
+				details = append(details, processReferenceDetail(procRoot, pid, "fd:"+fd.Name()))
+				break
+			}
+		}
+		if len(details) >= 8 {
+			break
+		}
+	}
+	sort.Strings(details)
+	if len(details) > 12 {
+		details = details[:12]
+	}
+	return strings.Join(details, ", ")
+}
+
+func nestedMountDetails(mountPoint string) []string {
+	raw, err := os.ReadFile("/proc/self/mountinfo")
+	if err != nil {
+		return nil
+	}
+	return parseNestedMountDetails(string(raw), mountPoint)
+}
+
+func parseNestedMountDetails(raw string, mountPoint string) []string {
+	mountPoint = filepath.Clean(mountPoint)
+	details := []string{}
+	seen := map[string]struct{}{}
+	for line := range strings.SplitSeq(raw, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 5 {
+			continue
+		}
+		child := filepath.Clean(unescapeMountInfoPath(fields[4]))
+		if child == mountPoint || !pathWithinMount(child, mountPoint) {
+			continue
+		}
+		detail := fmt.Sprintf("nested_mount=%s", child)
+		if _, exists := seen[detail]; exists {
+			continue
+		}
+		seen[detail] = struct{}{}
+		details = append(details, detail)
+	}
+	sort.Strings(details)
+	return details
+}
+
+func unescapeMountInfoPath(path string) string {
+	return strings.NewReplacer(
+		`\040`, " ",
+		`\011`, "\t",
+		`\012`, "\n",
+		`\134`, `\`,
+	).Replace(path)
+}
+
+func pathWithinMount(path string, mountPoint string) bool {
+	path = filepath.Clean(path)
+	if path == mountPoint {
+		return true
+	}
+	rel, err := filepath.Rel(mountPoint, path)
+	return err == nil && rel != "." && rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator))
+}
+
+func processReferenceDetail(procRoot string, pid int, reference string) string {
+	name := "unknown"
+	if raw, err := os.ReadFile(filepath.Join(procRoot, "comm")); err == nil {
+		if value := strings.TrimSpace(string(raw)); value != "" {
+			name = value
+		}
+	}
+	return fmt.Sprintf("pid=%d command=%s reference=%s", pid, name, reference)
 }
 
 func writeSMBCredentials(spec Spec) (string, error) {

--- a/src/agent/internal/service/nas/mount_unix_test.go
+++ b/src/agent/internal/service/nas/mount_unix_test.go
@@ -4,6 +4,7 @@ package nas
 
 import (
 	"fmt"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -81,6 +82,21 @@ func TestIsBusyMountErrorDetectsCIFSError16(t *testing.T) {
 	res := process.Result{Stderr: "mount error(16): Device or resource busy"}
 	if !isBusyMountError(res, fmt.Errorf("exit 32")) {
 		t.Fatal("expected CIFS error 16 to be treated as busy")
+	}
+}
+
+func TestParseNestedMountDetails(t *testing.T) {
+	raw := `31 24 0:27 / /opt/hfl/data/mounts/sources/7 rw - nfs server:/source rw
+32 31 0:28 / /opt/hfl/data/mounts/sources/7/nested rw - nfs server:/nested rw
+33 31 0:29 / /opt/hfl/data/mounts/sources/7/folder\040with\040spaces rw - nfs server:/spaces rw
+34 24 0:30 / /opt/hfl/data/mounts/sources/70 rw - nfs server:/other rw`
+	want := []string{
+		"nested_mount=/opt/hfl/data/mounts/sources/7/folder with spaces",
+		"nested_mount=/opt/hfl/data/mounts/sources/7/nested",
+	}
+	got := parseNestedMountDetails(raw, "/opt/hfl/data/mounts/sources/7")
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("parseNestedMountDetails()=%v want=%v", got, want)
 	}
 }
 

--- a/src/agent/internal/service/nas/mount_windows.go
+++ b/src/agent/internal/service/nas/mount_windows.go
@@ -5,10 +5,12 @@ package nas
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"hyperfilelens/agent/internal/platform/process"
 )
@@ -19,34 +21,122 @@ type windowsMountMeta struct {
 	Junction string `json:"junction"`
 }
 
+// Drive letters are host-wide resources, so allocation and mapping must be
+// serialized even when different NAS mount points are otherwise independent.
+var windowsDriveAllocation = newWindowsDriveAllocationLock()
+
+const windowsMountCommandTimeout = 30 * time.Second
+
+func newWindowsDriveAllocationLock() chan struct{} {
+	lock := make(chan struct{}, 1)
+	lock <- struct{}{}
+	return lock
+}
+
+func lockWindowsDriveAllocation(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-windowsDriveAllocation:
+		return nil
+	}
+}
+
+func unlockWindowsDriveAllocation() {
+	windowsDriveAllocation <- struct{}{}
+}
+
 func mountMetaPath(mountPoint string) string {
+	return mountPoint + ".hfl-nas-mount.json"
+}
+
+func legacyMountMetaPath(mountPoint string) string {
 	return filepath.Join(mountPoint, ".hfl-nas-mount.json")
 }
 
-func readMountMeta(mountPoint string) (windowsMountMeta, bool) {
-	data, err := os.ReadFile(mountMetaPath(mountPoint))
-	if err != nil {
-		return windowsMountMeta{}, false
+func readMountMeta(mountPoint string) (windowsMountMeta, string, bool, error) {
+	for _, path := range []string{mountMetaPath(mountPoint), legacyMountMetaPath(mountPoint)} {
+		data, err := os.ReadFile(path)
+		if os.IsNotExist(err) {
+			continue
+		}
+		if err != nil {
+			return windowsMountMeta{}, path, false, err
+		}
+		var meta windowsMountMeta
+		if err := json.Unmarshal(data, &meta); err != nil {
+			return windowsMountMeta{}, path, false, fmt.Errorf("decode metadata: %w", err)
+		}
+		if err := validateWindowsMountMeta(mountPoint, &meta); err != nil {
+			return windowsMountMeta{}, path, false, err
+		}
+		return meta, path, true, nil
 	}
-	var meta windowsMountMeta
-	if err := json.Unmarshal(data, &meta); err != nil {
-		return windowsMountMeta{}, false
+	return windowsMountMeta{}, "", false, nil
+}
+
+func validateWindowsMountMeta(mountPoint string, meta *windowsMountMeta) error {
+	if meta == nil {
+		return fmt.Errorf("metadata is empty")
 	}
-	if strings.TrimSpace(meta.Drive) == "" || strings.TrimSpace(meta.Junction) == "" {
-		return windowsMountMeta{}, false
+	drive := strings.ToUpper(strings.TrimSpace(meta.Drive))
+	if len(drive) != 2 || drive[0] < 'A' || drive[0] > 'Z' || drive[1] != ':' {
+		return fmt.Errorf("metadata drive is invalid")
 	}
-	return meta, true
+	remote := strings.TrimSpace(meta.Remote)
+	if !strings.HasPrefix(remote, `\\`) {
+		return fmt.Errorf("metadata remote is invalid")
+	}
+	wantJunction := filepath.Clean(mountPoint)
+	gotJunction := filepath.Clean(strings.TrimSpace(meta.Junction))
+	if !strings.EqualFold(gotJunction, wantJunction) {
+		return fmt.Errorf("metadata junction does not match managed mount point")
+	}
+	meta.Drive = drive
+	meta.Remote = remote
+	meta.Junction = wantJunction
+	return nil
 }
 
 func writeMountMeta(mountPoint string, meta windowsMountMeta) error {
-	if err := os.MkdirAll(mountPoint, 0o755); err != nil {
+	path := mountMetaPath(mountPoint)
+	directory := filepath.Dir(path)
+	if err := os.MkdirAll(directory, 0o755); err != nil {
 		return err
 	}
 	data, err := json.Marshal(meta)
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(mountMetaPath(mountPoint), data, 0o600)
+	if _, err := os.Lstat(path); err == nil {
+		return fmt.Errorf("SMB mount metadata already exists")
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+	temporary, err := os.CreateTemp(directory, filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return err
+	}
+	temporaryPath := temporary.Name()
+	defer os.Remove(temporaryPath)
+	if _, err := temporary.Write(data); err != nil {
+		_ = temporary.Close()
+		return err
+	}
+	if err := temporary.Sync(); err != nil {
+		_ = temporary.Close()
+		return err
+	}
+	if err := temporary.Close(); err != nil {
+		return err
+	}
+	return os.Rename(temporaryPath, path)
 }
 
 func isMounted(mountPoint string) bool {
@@ -54,19 +144,36 @@ func isMounted(mountPoint string) bool {
 	if mountPoint == "" {
 		return false
 	}
-	meta, ok := readMountMeta(mountPoint)
-	if !ok {
+	meta, _, ok, err := readMountMeta(mountPoint)
+	if err != nil || !ok {
 		return false
 	}
 	if _, err := os.Stat(meta.Junction); err != nil {
 		return false
 	}
-	return netUseShowsDrive(meta.Drive)
+	_, mapped, err := netUseDriveState(context.Background(), meta.Drive)
+	if err != nil || !mapped {
+		return false
+	}
+	details, err := netUseDriveDetails(context.Background(), meta.Drive)
+	return err == nil && netUseOutputMatchesRemote(details, meta.Drive, meta.Remote)
+}
+
+func hasUnmountWork(mountPoint string) bool {
+	mountPoint = ResolvedMountPoint(mountPoint)
+	if mountPoint == "" {
+		return false
+	}
+	_, _, ok, err := readMountMeta(mountPoint)
+	// A sidecar represents Agent-owned cleanup work even when the drive or
+	// junction is disconnected. Invalid metadata is fenced as well so it is
+	// not mistaken for completed cleanup or overwritten by a remount.
+	return ok || err != nil
 }
 
 func validateMountedShare(spec Spec) error {
-	meta, ok := readMountMeta(spec.MountPoint)
-	if !ok {
+	meta, _, ok, err := readMountMeta(spec.MountPoint)
+	if err != nil || !ok {
 		return &MountSourceMismatchError{Expected: expectedWindowsRemote(spec), Actual: "unmounted"}
 	}
 	expected := expectedWindowsRemote(spec)
@@ -103,15 +210,42 @@ func mountShare(ctx context.Context, spec Spec) error {
 }
 
 func mountSMB(ctx context.Context, spec Spec) error {
-	remote := expectedWindowsRemote(spec)
+	if err := lockWindowsDriveAllocation(ctx); err != nil {
+		return err
+	}
+	defer unlockWindowsDriveAllocation()
+	if isMounted(spec.MountPoint) {
+		return nil
+	}
+	if hasUnmountWork(spec.MountPoint) {
+		return fmt.Errorf("SMB mount cleanup is still required")
+	}
+
+	sharePath := strings.Trim(spec.Share, "/\\")
+	remote := fmt.Sprintf(`\\%s\%s`, spec.Server, sharePath)
+	junction := spec.MountPoint
+	if err := os.MkdirAll(filepath.Dir(junction), 0o755); err != nil {
+		return fmt.Errorf("create mount parent: %w", err)
+	}
 	user := spec.Username
 	if spec.Domain != "" {
 		user = spec.Domain + `\` + spec.Username
 	}
 
-	drive, err := pickAvailableDriveLetter()
+	drive, err := pickAvailableDriveLetter(ctx)
 	if err != nil {
 		return err
+	}
+	meta := windowsMountMeta{
+		Drive:    drive,
+		Remote:   remote,
+		Junction: junction,
+	}
+	// Persist intent before changing Windows network state. If the Agent exits
+	// after this point, the sidecar gives the next run enough information to
+	// remove an incomplete mapping safely.
+	if err := writeMountMeta(junction, meta); err != nil {
+		return fmt.Errorf("record SMB mount metadata: %w", err)
 	}
 	args := []string{
 		"use",
@@ -121,66 +255,192 @@ func mountSMB(ctx context.Context, spec Spec) error {
 		"/user:" + user,
 		"/persistent:no",
 	}
-	res, runErr := process.Run(ctx, "net", args, nil, "")
+	res, runErr := runWindowsMountCommand(ctx, "net", args)
 	if runErr != nil {
 		msg := strings.TrimSpace(res.Stderr + "\n" + res.Stdout)
 		if msg == "" {
 			msg = runErr.Error()
 		}
-		return fmt.Errorf("mount SMB share: %s", msg)
+		return mountAttemptError(
+			fmt.Errorf("mount SMB share: %s", msg),
+			rollbackSMBMountAttempt(ctx, junction, drive, remote, false),
+		)
 	}
 
-	junction := spec.MountPoint
-	if err := os.MkdirAll(filepath.Dir(junction), 0o755); err != nil {
-		_ = netUseDelete(ctx, drive)
-		return fmt.Errorf("create mount parent: %w", err)
-	}
 	if _, err := os.Stat(junction); err == nil {
-		_ = os.Remove(junction)
+		if err := os.Remove(junction); err != nil {
+			return mountAttemptError(
+				localUnmountCleanupError(
+					fmt.Errorf("remove existing SMB junction: %w", err),
+				),
+				rollbackSMBMountAttempt(ctx, junction, drive, remote, false),
+			)
+		}
+	} else if !os.IsNotExist(err) {
+		return mountAttemptError(
+			fmt.Errorf("inspect existing SMB junction: %w", err),
+			rollbackSMBMountAttempt(ctx, junction, drive, remote, false),
+		)
 	}
 	linkArgs := []string{"/c", "mklink", "/J", junction, drive + `\`}
-	linkRes, linkErr := process.Run(ctx, "cmd", linkArgs, nil, "")
+	linkRes, linkErr := runWindowsMountCommand(ctx, "cmd", linkArgs)
 	if linkErr != nil {
-		_ = netUseDelete(ctx, drive)
 		msg := strings.TrimSpace(linkRes.Stderr + "\n" + linkRes.Stdout)
 		if msg == "" {
 			msg = linkErr.Error()
 		}
-		return fmt.Errorf("create SMB junction: %s", msg)
-	}
-	meta := windowsMountMeta{
-		Drive:    drive,
-		Remote:   remote,
-		Junction: junction,
-	}
-	if err := writeMountMeta(junction, meta); err != nil {
-		_ = netUseDelete(ctx, drive)
-		return fmt.Errorf("record SMB mount metadata: %w", err)
+		return mountAttemptError(
+			fmt.Errorf("create SMB junction: %s", msg),
+			rollbackSMBMountAttempt(ctx, junction, drive, remote, true),
+		)
 	}
 	return nil
 }
 
+func rollbackSMBMountAttempt(
+	ctx context.Context,
+	mountPoint string,
+	drive string,
+	remote string,
+	removeJunction bool,
+) error {
+	cleanupErrors := []error{}
+	output, mapped, err := netUseDriveState(ctx, drive)
+	if err != nil {
+		return fmt.Errorf("inspect drive %s: %w", drive, err)
+	}
+	if mapped {
+		output, err = netUseDriveDetails(ctx, drive)
+		if err != nil {
+			return fmt.Errorf("inspect mapped drive %s: %w", drive, err)
+		}
+		if !netUseOutputMatchesRemote(output, drive, remote) {
+			return fmt.Errorf("drive %s no longer maps to the attempted NAS share", drive)
+		}
+		if err := netUseDelete(ctx, drive); err != nil {
+			return err
+		}
+		_, mapped, err = netUseDriveState(ctx, drive)
+		if err != nil {
+			return fmt.Errorf("verify drive %s cleanup: %w", drive, err)
+		}
+		if mapped {
+			return fmt.Errorf("drive %s remains mapped", drive)
+		}
+	}
+	if removeJunction {
+		if err := os.Remove(mountPoint); err != nil && !os.IsNotExist(err) {
+			cleanupErrors = append(cleanupErrors, fmt.Errorf("remove SMB junction: %w", err))
+		}
+	}
+	if len(cleanupErrors) == 0 {
+		if err := os.Remove(mountMetaPath(mountPoint)); err != nil && !os.IsNotExist(err) {
+			cleanupErrors = append(cleanupErrors, fmt.Errorf("remove SMB mount metadata: %w", err))
+		}
+	}
+	return errors.Join(cleanupErrors...)
+}
+
+func mountAttemptError(primary error, rollback error) error {
+	if rollback == nil {
+		return primary
+	}
+	return fmt.Errorf("%w; rollback cleanup failed: %v", primary, rollback)
+}
+
 func unmountShare(ctx context.Context, mountPoint string) error {
+	if err := lockWindowsDriveAllocation(ctx); err != nil {
+		return err
+	}
+	defer unlockWindowsDriveAllocation()
+
 	mountPoint = ResolvedMountPoint(mountPoint)
 	if mountPoint == "" {
 		return fmt.Errorf("mount_point is required")
 	}
-	meta, ok := readMountMeta(mountPoint)
+	meta, metaPath, ok, err := readMountMeta(mountPoint)
+	if err != nil {
+		return localUnmountCleanupError(fmt.Errorf("read SMB mount metadata: %w", err))
+	}
 	if !ok {
 		return nil
 	}
-	if _, err := os.Stat(meta.Junction); err == nil {
-		_ = os.Remove(meta.Junction)
+	if metaPath == legacyMountMetaPath(mountPoint) {
+		if err := writeMountMeta(mountPoint, meta); err != nil {
+			return localUnmountCleanupError(
+				fmt.Errorf("migrate SMB mount metadata: %w", err),
+			)
+		}
+		// The legacy marker lives inside the remote share. Once local cleanup
+		// responsibility is durably migrated, an old read-only marker must not
+		// prevent the Agent from releasing the drive and junction.
+		_ = os.Remove(metaPath)
+		metaPath = mountMetaPath(mountPoint)
 	}
-	_ = netUseDelete(ctx, meta.Drive)
-	_ = os.Remove(mountMetaPath(mountPoint))
+	output, mapped, stateErr := netUseDriveState(ctx, meta.Drive)
+	if stateErr != nil {
+		return localUnmountCleanupError(
+			fmt.Errorf("inspect drive %s: %w", meta.Drive, stateErr),
+		)
+	}
+	if mapped {
+		output, stateErr = netUseDriveDetails(ctx, meta.Drive)
+		if stateErr != nil {
+			return localUnmountCleanupError(
+				fmt.Errorf("inspect mapped drive %s: %w", meta.Drive, stateErr),
+			)
+		}
+		if !netUseOutputMatchesRemote(output, meta.Drive, meta.Remote) {
+			return localUnmountCleanupError(
+				fmt.Errorf(
+					"refusing to unmount drive %s because it no longer maps to the managed NAS share",
+					meta.Drive,
+				),
+			)
+		}
+		if err := netUseDelete(ctx, meta.Drive); err != nil {
+			return err
+		}
+		_, mapped, stateErr = netUseDriveState(ctx, meta.Drive)
+		if stateErr != nil {
+			return localUnmountCleanupError(
+				fmt.Errorf("verify drive %s cleanup: %w", meta.Drive, stateErr),
+			)
+		}
+		if mapped {
+			return fmt.Errorf("unmount NAS share: drive %s remains mapped", meta.Drive)
+		}
+	}
+	if err := os.Remove(meta.Junction); err != nil && !os.IsNotExist(err) {
+		return localUnmountCleanupError(fmt.Errorf("remove SMB junction: %w", err))
+	}
+	if err := os.Remove(metaPath); err != nil && !os.IsNotExist(err) {
+		return localUnmountCleanupError(
+			fmt.Errorf("remove SMB mount metadata: %w", err),
+		)
+	}
 	return nil
 }
 
-func pickAvailableDriveLetter() (string, error) {
+func lazyUnmountShare(ctx context.Context, mountPoint string) error {
+	return fmt.Errorf("lazy unmount is not supported on Windows")
+}
+
+func unmountBusyDetails(_ string) string {
+	return ""
+}
+
+func pickAvailableDriveLetter(ctx context.Context) (string, error) {
+	output, err := netUseMappingsOutput(ctx)
+	if err != nil {
+		return "", fmt.Errorf("list Windows network drives: %w", err)
+	}
 	for letter := 'Z'; letter >= 'D'; letter-- {
 		drive := fmt.Sprintf("%c:", letter)
-		if _, err := os.Stat(drive + `\`); err != nil {
+		if netUseOutputShowsDrive(output, drive) {
+			continue
+		}
+		if _, err := os.Stat(drive + `\`); os.IsNotExist(err) {
 			return drive, nil
 		}
 	}
@@ -208,9 +468,72 @@ func netUseRemote(drive string) (string, bool) {
 	return parseNetUseRemote(text)
 }
 
+func netUseMappingsOutput(ctx context.Context) (string, error) {
+	res, err := runWindowsMountCommand(ctx, "net", []string{"use"})
+	if err != nil {
+		message := strings.TrimSpace(res.Stderr + "\n" + res.Stdout)
+		if message == "" {
+			message = err.Error()
+		}
+		return "", fmt.Errorf("query Windows network mappings: %s", message)
+	}
+	return res.Stdout + res.Stderr, nil
+}
+
+func netUseDriveState(ctx context.Context, drive string) (string, bool, error) {
+	output, err := netUseMappingsOutput(ctx)
+	if err != nil {
+		return "", false, err
+	}
+	return output, netUseOutputShowsDrive(output, drive), nil
+}
+
+func netUseDriveDetails(ctx context.Context, drive string) (string, error) {
+	res, err := runWindowsMountCommand(ctx, "net", []string{"use", drive})
+	if err != nil {
+		message := strings.TrimSpace(res.Stderr + "\n" + res.Stdout)
+		if message == "" {
+			message = err.Error()
+		}
+		return "", fmt.Errorf("query Windows network drive: %s", message)
+	}
+	return res.Stdout + res.Stderr, nil
+}
+
+func netUseOutputMatchesRemote(output string, drive string, remote string) bool {
+	if !netUseOutputShowsDrive(output, drive) {
+		return false
+	}
+	want := strings.TrimRight(strings.TrimSpace(remote), `/\`)
+	for line := range strings.SplitSeq(output, "\n") {
+		start := strings.Index(line, `\\`)
+		if start < 0 {
+			continue
+		}
+		candidate := strings.TrimRight(strings.TrimSpace(line[start:]), `/\`)
+		if strings.EqualFold(candidate, want) {
+			return true
+		}
+	}
+	return false
+}
+
+func netUseOutputShowsDrive(output string, drive string) bool {
+	drive = strings.TrimSpace(drive)
+	if drive == "" {
+		return false
+	}
+	for _, field := range strings.Fields(output) {
+		if strings.EqualFold(field, drive) {
+			return true
+		}
+	}
+	return false
+}
+
 func netUseDelete(ctx context.Context, drive string) error {
 	args := []string{"use", drive, "/delete", "/y"}
-	res, runErr := process.Run(ctx, "net", args, nil, "")
+	res, runErr := runWindowsMountCommand(ctx, "net", args)
 	if runErr != nil {
 		msg := strings.TrimSpace(res.Stderr + "\n" + res.Stdout)
 		if msg == "" {
@@ -219,4 +542,17 @@ func netUseDelete(ctx context.Context, drive string) error {
 		return fmt.Errorf("unmount NAS share: %s", msg)
 	}
 	return nil
+}
+
+func runWindowsMountCommand(
+	ctx context.Context,
+	bin string,
+	args []string,
+) (process.Result, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	commandCtx, cancel := context.WithTimeout(ctx, windowsMountCommandTimeout)
+	defer cancel()
+	return process.Run(commandCtx, bin, args, nil, "")
 }

--- a/src/agent/internal/service/nas/mount_windows_test.go
+++ b/src/agent/internal/service/nas/mount_windows_test.go
@@ -1,0 +1,145 @@
+//go:build windows
+
+package nas
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWindowsDriveAllocationWaitHonorsCancellation(t *testing.T) {
+	if err := lockWindowsDriveAllocation(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	defer unlockWindowsDriveAllocation()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := lockWindowsDriveAllocation(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("lockWindowsDriveAllocation() error = %v", err)
+	}
+}
+
+func TestWindowsMountMetadataUsesLocalSidecar(t *testing.T) {
+	mountPoint := filepath.Join(t.TempDir(), "source-17")
+	meta := windowsMountMeta{
+		Drive:    "Z:",
+		Remote:   `\\server\share`,
+		Junction: mountPoint,
+	}
+
+	if err := writeMountMeta(mountPoint, meta); err != nil {
+		t.Fatalf("writeMountMeta() error = %v", err)
+	}
+	if _, err := os.Stat(mountPoint); !os.IsNotExist(err) {
+		t.Fatalf("metadata write created or touched mount point: %v", err)
+	}
+	got, path, ok, err := readMountMeta(mountPoint)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || path != mountMetaPath(mountPoint) || got != meta {
+		t.Fatalf("readMountMeta() = %#v, %q, %v", got, path, ok)
+	}
+	if isMounted(mountPoint) {
+		t.Fatal("sidecar without a live junction was reported as mounted")
+	}
+	if !hasUnmountWork(mountPoint) {
+		t.Fatal("sidecar was not retained as Agent-owned cleanup work")
+	}
+}
+
+func TestWindowsMountMetadataReadsLegacyLocation(t *testing.T) {
+	mountPoint := filepath.Join(t.TempDir(), "source-18")
+	if err := os.MkdirAll(mountPoint, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	want := windowsMountMeta{
+		Drive:    "Y:",
+		Remote:   `\\server\share`,
+		Junction: mountPoint,
+	}
+	legacy, err := json.Marshal(want)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(legacyMountMetaPath(mountPoint), legacy, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	meta, path, ok, err := readMountMeta(mountPoint)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || path != legacyMountMetaPath(mountPoint) || meta != want {
+		t.Fatalf("readMountMeta() = %#v, %q, %v", meta, path, ok)
+	}
+}
+
+func TestWindowsMountMetadataDoesNotOverwriteOwnedState(t *testing.T) {
+	mountPoint := filepath.Join(t.TempDir(), "source-20")
+	meta := windowsMountMeta{
+		Drive:    "W:",
+		Remote:   `\\server\share`,
+		Junction: mountPoint,
+	}
+	if err := writeMountMeta(mountPoint, meta); err != nil {
+		t.Fatal(err)
+	}
+
+	replacement := meta
+	replacement.Drive = "V:"
+	if err := writeMountMeta(mountPoint, replacement); err == nil {
+		t.Fatal("writeMountMeta() overwrote existing Agent-owned state")
+	}
+	got, _, ok, err := readMountMeta(mountPoint)
+	if err != nil || !ok || got != meta {
+		t.Fatalf("readMountMeta() = %#v, %v, %v", got, ok, err)
+	}
+}
+
+func TestWindowsMountMetadataRejectsAnotherJunction(t *testing.T) {
+	mountPoint := filepath.Join(t.TempDir(), "source-19")
+	want := windowsMountMeta{
+		Drive:    "X:",
+		Remote:   `\\server\share`,
+		Junction: filepath.Join(t.TempDir(), "not-the-managed-mount"),
+	}
+	data, err := json.Marshal(want)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(mountMetaPath(mountPoint), data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, _, _, err := readMountMeta(mountPoint); err == nil {
+		t.Fatal("readMountMeta() accepted metadata for another junction")
+	}
+}
+
+func TestNetUseOutputShowsManagedDriveAndRemote(t *testing.T) {
+	output := `Local name        Z:
+Remote name       \\server\share`
+	if !netUseOutputShowsDrive(output, "z:") {
+		t.Fatal("net use output did not identify the managed drive")
+	}
+	if !netUseOutputMatchesRemote(output, "z:", `\\server\share`) {
+		t.Fatal("net use output did not match the managed remote")
+	}
+	if netUseOutputMatchesRemote(output, "z:", `\\server\other`) {
+		t.Fatal("net use output matched another remote")
+	}
+	prefixOutput := `Local name        Z:
+Remote name       \\server\share-archive`
+	if netUseOutputMatchesRemote(prefixOutput, "z:", `\\server\share`) {
+		t.Fatal("net use output matched a different share with the same prefix")
+	}
+	if netUseOutputShowsDrive("Remote name \\\\server\\z:archive", "z:") {
+		t.Fatal("net use output mistook remote text for a local drive")
+	}
+}

--- a/src/agent/internal/service/nas/service.go
+++ b/src/agent/internal/service/nas/service.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"hyperfilelens/agent/internal/platform/disk"
 	"hyperfilelens/agent/internal/platform/vfs"
@@ -37,17 +38,69 @@ type SpaceInfo struct {
 	FreeBytes  uint64
 }
 
+// UnmountOptions controls how an Agent-owned NAS mount is released.
+type UnmountOptions struct {
+	Force bool
+}
+
+// UnmountResult reports whether cleanup detached the mount while retaining
+// local references or mount-directory residue.
+type UnmountResult struct {
+	Attempts          int
+	CleanupComplete   bool
+	LazyUnmount       bool
+	RetainedResources []string
+	Warnings          []string
+}
+
+type unmountLocalCleanupError struct {
+	err error
+}
+
+func (e *unmountLocalCleanupError) Error() string {
+	return e.err.Error()
+}
+
+func (e *unmountLocalCleanupError) Unwrap() error {
+	return e.err
+}
+
+func localUnmountCleanupError(err error) error {
+	return &unmountLocalCleanupError{err: err}
+}
+
+func isLocalUnmountCleanupError(err error) bool {
+	var cleanupErr *unmountLocalCleanupError
+	return errors.As(err, &cleanupErr)
+}
+
+const unmountAttempts = 3
+
 // Service mounts and validates NAS shares on the local host.
-type Service struct{}
+type Service struct {
+	isMountedFn      func(string) bool
+	hasUnmountWorkFn func(string) bool
+	unmountFn        func(context.Context, string) error
+	lazyUnmountFn    func(context.Context, string) error
+	removeMountDirFn func(string) error
+	retryWaitFn      func(context.Context, time.Duration) error
+}
 
 func NewService() *Service {
-	return &Service{}
+	return &Service{
+		isMountedFn:      isMounted,
+		hasUnmountWorkFn: hasUnmountWork,
+		unmountFn:        unmountShare,
+		lazyUnmountFn:    lazyUnmountShare,
+		removeMountDirFn: removeManagedMountDirectory,
+		retryWaitFn:      waitUnmountRetry,
+	}
 }
 
 // IsMounted reports whether mountPoint is an active filesystem mount.
 func (s *Service) IsMounted(mountPoint string) bool {
 	mountPoint = ResolvedMountPoint(mountPoint)
-	return mountPoint != "" && isMounted(mountPoint)
+	return mountPoint != "" && s.isMounted(mountPoint)
 }
 
 // CleanupUnmountedMountPoint removes an empty managed mount-point directory.
@@ -58,7 +111,7 @@ func (s *Service) CleanupUnmountedMountPoint(mountPoint string) (bool, error) {
 	if mountPoint == "" {
 		return false, fmt.Errorf("invalid mount_point")
 	}
-	if isMounted(mountPoint) {
+	if s.hasUnmountWork(mountPoint) {
 		return false, nil
 	}
 	entries, err := os.ReadDir(mountPoint)
@@ -68,7 +121,7 @@ func (s *Service) CleanupUnmountedMountPoint(mountPoint string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	if len(entries) != 0 || isMounted(mountPoint) {
+	if len(entries) != 0 || s.hasUnmountWork(mountPoint) {
 		return false, nil
 	}
 	if err := removeManagedMountDirectory(mountPoint); err != nil {
@@ -86,7 +139,7 @@ func (s *Service) EnsureMounted(ctx context.Context, spec Spec) error {
 	if spec.MountPoint == "" {
 		return fmt.Errorf("invalid mount_point")
 	}
-	if isMounted(spec.MountPoint) {
+	if s.isMounted(spec.MountPoint) {
 		return validateMountedShare(spec)
 	}
 	if _, err := s.Mount(ctx, spec); err != nil {
@@ -104,6 +157,14 @@ func (s *Service) Mount(ctx context.Context, spec Spec) (SpaceInfo, error) {
 	if spec.MountPoint == "" {
 		return SpaceInfo{}, fmt.Errorf("invalid mount_point")
 	}
+	if s.isMounted(spec.MountPoint) {
+		return s.spaceInfo(spec.MountPoint)
+	}
+	if s.hasUnmountWork(spec.MountPoint) {
+		if _, err := s.UnmountWithOptions(ctx, spec.MountPoint, UnmountOptions{}); err != nil {
+			return SpaceInfo{}, fmt.Errorf("cleanup stale mount state: %w", err)
+		}
+	}
 	if err := mountShare(ctx, spec); err != nil {
 		return SpaceInfo{}, err
 	}
@@ -116,25 +177,149 @@ func (s *Service) Mount(ctx context.Context, spec Spec) (SpaceInfo, error) {
 
 // Unmount removes the NAS mount from the local host.
 func (s *Service) Unmount(ctx context.Context, mountPoint string) error {
+	_, err := s.UnmountWithOptions(ctx, mountPoint, UnmountOptions{})
+	return err
+}
+
+// UnmountWithOptions releases a managed mount with bounded retries. Force mode
+// may lazily detach a busy Linux mount, but it never kills unknown processes.
+func (s *Service) UnmountWithOptions(
+	ctx context.Context,
+	mountPoint string,
+	options UnmountOptions,
+) (UnmountResult, error) {
+	result := UnmountResult{CleanupComplete: true}
 	if err := ctx.Err(); err != nil {
-		return err
+		return result, err
 	}
 	mountPoint = ResolvedMountPoint(mountPoint)
 	if mountPoint == "" {
-		return fmt.Errorf("invalid mount_point")
+		return result, fmt.Errorf("invalid mount_point")
 	}
-	if isMounted(mountPoint) {
-		if err := unmountShare(ctx, mountPoint); err != nil {
-			return err
+	if s.hasUnmountWork(mountPoint) {
+		var unmountErr error
+		for attempt := 1; attempt <= unmountAttempts; attempt++ {
+			result.Attempts = attempt
+			unmountErr = s.unmount(ctx, mountPoint)
+			// The live mount table is authoritative. The command can report an
+			// error after the kernel has already detached the mount.
+			if !s.hasUnmountWork(mountPoint) && !isLocalUnmountCleanupError(unmountErr) {
+				unmountErr = nil
+				break
+			}
+			if unmountErr == nil {
+				unmountErr = fmt.Errorf("mount point remains active after unmount")
+			}
+			if !isBusyUnmountError(unmountErr) || attempt == unmountAttempts {
+				break
+			}
+			if err := s.waitUnmountRetry(ctx, time.Duration(attempt)*200*time.Millisecond); err != nil {
+				return result, err
+			}
 		}
-		if isMounted(mountPoint) {
-			return fmt.Errorf("mount point remains active after unmount")
+		if unmountErr != nil {
+			if !options.Force || !isBusyUnmountError(unmountErr) {
+				return result, withUnmountDiagnostics(mountPoint, unmountErr)
+			}
+			details := strings.TrimSpace(unmountBusyDetails(mountPoint))
+			if err := s.lazyUnmount(ctx, mountPoint); err != nil {
+				return result, withUnmountDiagnostics(mountPoint, err)
+			}
+			warning := "The managed NAS mount was lazily detached because local references remained."
+			if details != "" {
+				warning += " Active references: " + details + "."
+			}
+			result.CleanupComplete = false
+			result.LazyUnmount = true
+			result.RetainedResources = append(result.RetainedResources, "nas_mount_reference")
+			result.Warnings = append(result.Warnings, warning)
+		}
+		if s.hasUnmountWork(mountPoint) {
+			return result, fmt.Errorf("mount point remains active after unmount")
 		}
 	}
-	if err := removeManagedMountDirectory(mountPoint); err != nil {
-		return fmt.Errorf("cleanup mount directory: %w", err)
+	if err := s.removeMountDirectory(mountPoint); err != nil {
+		if !options.Force {
+			return result, fmt.Errorf("cleanup mount directory: %w", err)
+		}
+		result.CleanupComplete = false
+		result.RetainedResources = append(result.RetainedResources, "nas_mount_directory")
+		result.Warnings = append(result.Warnings, "The managed NAS mount directory requires later cleanup.")
 	}
-	return nil
+	return result, nil
+}
+
+func (s *Service) isMounted(mountPoint string) bool {
+	if s != nil && s.isMountedFn != nil {
+		return s.isMountedFn(mountPoint)
+	}
+	return isMounted(mountPoint)
+}
+
+func (s *Service) hasUnmountWork(mountPoint string) bool {
+	if s != nil && s.hasUnmountWorkFn != nil {
+		return s.hasUnmountWorkFn(mountPoint)
+	}
+	return hasUnmountWork(mountPoint)
+}
+
+func (s *Service) unmount(ctx context.Context, mountPoint string) error {
+	if s != nil && s.unmountFn != nil {
+		return s.unmountFn(ctx, mountPoint)
+	}
+	return unmountShare(ctx, mountPoint)
+}
+
+func (s *Service) lazyUnmount(ctx context.Context, mountPoint string) error {
+	if s != nil && s.lazyUnmountFn != nil {
+		return s.lazyUnmountFn(ctx, mountPoint)
+	}
+	return lazyUnmountShare(ctx, mountPoint)
+}
+
+func (s *Service) removeMountDirectory(mountPoint string) error {
+	if s != nil && s.removeMountDirFn != nil {
+		return s.removeMountDirFn(mountPoint)
+	}
+	return removeManagedMountDirectory(mountPoint)
+}
+
+func (s *Service) waitUnmountRetry(ctx context.Context, delay time.Duration) error {
+	if s != nil && s.retryWaitFn != nil {
+		return s.retryWaitFn(ctx, delay)
+	}
+	return waitUnmountRetry(ctx, delay)
+}
+
+func waitUnmountRetry(ctx context.Context, delay time.Duration) error {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func isBusyUnmountError(err error) bool {
+	if err == nil {
+		return false
+	}
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "device is busy") ||
+		strings.Contains(message, "device or resource busy") ||
+		strings.Contains(message, "target is busy") ||
+		strings.Contains(message, "mount point remains active") ||
+		strings.Contains(message, "resource busy")
+}
+
+func withUnmountDiagnostics(mountPoint string, err error) error {
+	details := strings.TrimSpace(unmountBusyDetails(mountPoint))
+	if details == "" {
+		return err
+	}
+	return fmt.Errorf("%w; active references: %s", err, details)
 }
 
 func removeManagedMountDirectory(mountPoint string) error {

--- a/src/agent/internal/service/nas/service_test.go
+++ b/src/agent/internal/service/nas/service_test.go
@@ -2,13 +2,32 @@ package nas
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"hyperfilelens/agent/internal/platform/vfs"
 )
+
+func unmountTestService(
+	mounted *bool,
+	unmount func(context.Context, string) error,
+	lazy func(context.Context, string) error,
+) *Service {
+	return &Service{
+		isMountedFn:      func(string) bool { return *mounted },
+		hasUnmountWorkFn: func(string) bool { return *mounted },
+		unmountFn:        unmount,
+		lazyUnmountFn:    lazy,
+		removeMountDirFn: func(string) error {
+			return nil
+		},
+		retryWaitFn: func(context.Context, time.Duration) error { return nil },
+	}
+}
 
 func managedTestMountPoint(t *testing.T, leaf string) string {
 	t.Helper()
@@ -103,5 +122,191 @@ func TestParseNetUseRemote(t *testing.T) {
 				t.Fatalf("parseNetUseRemote() = (%q, %t), want (%q, %t)", got, ok, test.want, test.ok)
 			}
 		})
+	}
+}
+
+func TestUnmountRetriesTransientBusyMount(t *testing.T) {
+	mounted := true
+	attempts := 0
+	service := unmountTestService(
+		&mounted,
+		func(context.Context, string) error {
+			attempts++
+			if attempts < 3 {
+				return errors.New("device is busy")
+			}
+			mounted = false
+			return nil
+		},
+		func(context.Context, string) error { return errors.New("unexpected lazy unmount") },
+	)
+
+	result, err := service.UnmountWithOptions(
+		context.Background(),
+		managedTestMountPoint(t, "15"),
+		UnmountOptions{},
+	)
+
+	if err != nil {
+		t.Fatalf("UnmountWithOptions() error = %v", err)
+	}
+	if result.Attempts != 3 || result.LazyUnmount || !result.CleanupComplete {
+		t.Fatalf("unexpected result: %#v", result)
+	}
+}
+
+func TestForceUnmountLazilyDetachesPersistentBusyMount(t *testing.T) {
+	mounted := true
+	lazyCalls := 0
+	service := unmountTestService(
+		&mounted,
+		func(context.Context, string) error { return errors.New("device is busy") },
+		func(context.Context, string) error {
+			lazyCalls++
+			mounted = false
+			return nil
+		},
+	)
+
+	result, err := service.UnmountWithOptions(
+		context.Background(),
+		managedTestMountPoint(t, "16"),
+		UnmountOptions{Force: true},
+	)
+
+	if err != nil {
+		t.Fatalf("UnmountWithOptions() error = %v", err)
+	}
+	if lazyCalls != 1 || !result.LazyUnmount || result.CleanupComplete {
+		t.Fatalf("unexpected result: %#v lazy_calls=%d", result, lazyCalls)
+	}
+	if len(result.RetainedResources) != 1 || len(result.Warnings) != 1 {
+		t.Fatalf("force cleanup residue missing: %#v", result)
+	}
+}
+
+func TestUnmountTrustsDetachedStateWhenCommandReportsError(t *testing.T) {
+	mounted := true
+	attempts := 0
+	service := unmountTestService(
+		&mounted,
+		func(context.Context, string) error {
+			attempts++
+			mounted = false
+			return errors.New("umount process exited after detaching the mount")
+		},
+		func(context.Context, string) error { return errors.New("unexpected lazy unmount") },
+	)
+
+	result, err := service.UnmountWithOptions(
+		context.Background(),
+		managedTestMountPoint(t, "18"),
+		UnmountOptions{},
+	)
+
+	if err != nil {
+		t.Fatalf("UnmountWithOptions() error = %v", err)
+	}
+	if attempts != 1 || result.Attempts != 1 || !result.CleanupComplete {
+		t.Fatalf("unexpected result: %#v attempts=%d", result, attempts)
+	}
+}
+
+func TestUnmountPreservesLocalCleanupErrorAfterDetach(t *testing.T) {
+	mounted := true
+	service := unmountTestService(
+		&mounted,
+		func(context.Context, string) error {
+			mounted = false
+			return localUnmountCleanupError(errors.New("remove SMB junction: access denied"))
+		},
+		func(context.Context, string) error { return errors.New("unexpected lazy unmount") },
+	)
+
+	_, err := service.UnmountWithOptions(
+		context.Background(),
+		managedTestMountPoint(t, "19"),
+		UnmountOptions{},
+	)
+
+	if err == nil || !strings.Contains(err.Error(), "remove SMB junction") {
+		t.Fatalf("UnmountWithOptions() error = %v", err)
+	}
+}
+
+func TestUnmountCleansOwnedStateWhenMountIsNotLive(t *testing.T) {
+	pending := true
+	unmountCalls := 0
+	service := &Service{
+		isMountedFn:      func(string) bool { return false },
+		hasUnmountWorkFn: func(string) bool { return pending },
+		unmountFn: func(context.Context, string) error {
+			unmountCalls++
+			pending = false
+			return nil
+		},
+		removeMountDirFn: func(string) error { return nil },
+		retryWaitFn:      func(context.Context, time.Duration) error { return nil },
+	}
+
+	result, err := service.UnmountWithOptions(
+		context.Background(),
+		managedTestMountPoint(t, "20"),
+		UnmountOptions{},
+	)
+
+	if err != nil {
+		t.Fatalf("UnmountWithOptions() error = %v", err)
+	}
+	if unmountCalls != 1 || result.Attempts != 1 || !result.CleanupComplete {
+		t.Fatalf("unexpected result: %#v unmount_calls=%d", result, unmountCalls)
+	}
+}
+
+func TestCleanupUnmountedMountPointPreservesOwnedCleanupState(t *testing.T) {
+	mountPoint := managedTestMountPoint(t, "21")
+	if err := os.MkdirAll(mountPoint, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	service := &Service{
+		isMountedFn:      func(string) bool { return false },
+		hasUnmountWorkFn: func(string) bool { return true },
+	}
+
+	removed, err := service.CleanupUnmountedMountPoint(mountPoint)
+
+	if err != nil || removed {
+		t.Fatalf("CleanupUnmountedMountPoint() = %v, %v", removed, err)
+	}
+	if _, err := os.Stat(mountPoint); err != nil {
+		t.Fatalf("owned mount state was removed: %v", err)
+	}
+}
+
+func TestStrictUnmountReturnsPersistentBusyFailure(t *testing.T) {
+	mounted := true
+	service := unmountTestService(
+		&mounted,
+		func(context.Context, string) error { return errors.New("device is busy") },
+		func(context.Context, string) error { return nil },
+	)
+
+	result, err := service.UnmountWithOptions(
+		context.Background(),
+		managedTestMountPoint(t, "17"),
+		UnmountOptions{},
+	)
+
+	if err == nil || !strings.Contains(err.Error(), "device is busy") {
+		t.Fatalf("UnmountWithOptions() error = %v", err)
+	}
+	if result.Attempts != unmountAttempts || result.LazyUnmount {
+		t.Fatalf("unexpected result: %#v", result)
+	}
+}
+
+func TestBusyUnmountErrorRecognizesTargetBusy(t *testing.T) {
+	if !isBusyUnmountError(errors.New("umount: target is busy")) {
+		t.Fatal("target-is-busy error was not recognized")
 	}
 }

--- a/src/agent/internal/wire/handler.go
+++ b/src/agent/internal/wire/handler.go
@@ -21,6 +21,7 @@ type Handler struct {
 	tracker           *controller.Tracker
 	tasks             *database.TaskRepo
 	snapshotScheduler *controller.Scheduler
+	nasLeases         *engine.NASLeaseCoordinator
 	resultAckEnabled  atomic.Bool
 }
 
@@ -52,6 +53,7 @@ func NewHandler(
 		tracker:           tracker,
 		tasks:             tasks,
 		snapshotScheduler: snapshotScheduler,
+		nasLeases:         engine.NewNASLeaseCoordinator(),
 	}
 }
 
@@ -215,7 +217,7 @@ func (h *Handler) runTask(ctx context.Context, sink Sender, cmd *TaskCommand) {
 
 	logging.InfoTask(taskCtx, "task execution started", cmd.NodeID, cmd.TaskID, cmd.Kind)
 
-	eng := engine.New(h.provider)
+	eng := engine.NewWithNASLeaseCoordinator(h.provider, h.nasLeases)
 
 	now := time.Now().UTC()
 

--- a/src/backend/apps/source/constants.py
+++ b/src/backend/apps/source/constants.py
@@ -78,6 +78,11 @@ class ResourceStatus:
         (REMOVED, "Removed"),
     )
 
+    # Removal is an operational fence, not another availability result.  A
+    # failed deregistration stays fenced until the operator explicitly retries
+    # cleanup or restores the source to service.
+    REMOVAL_FENCED = frozenset({REMOVING, REMOVE_FAILED, REMOVED})
+
 
 class SelectableSourceKind:
     AGENT = "agent"

--- a/src/backend/apps/source/services/interface.py
+++ b/src/backend/apps/source/services/interface.py
@@ -24,6 +24,7 @@ from apps.source.models import SourceResource
 from apps.source.selectors.interface import source_resource_by_id, source_resources_queryset
 from apps.source.services.internal.connection import (
     apply_connection_test_result_if_current,
+    best_effort_unmount_on_proxy,
     mount_resource as _mount_resource,
     schedule_remount_after_proxy_change,
     run_connection_test,
@@ -358,15 +359,20 @@ def delete_source_resource(*, resource: SourceResource, user, force: bool = Fals
 
 def test_resource_connection(*, resource: SourceResource) -> dict:
     probe_token = uuid4()
-    resource.connection_test_status = ConnectionTestStatus.RUNNING
-    resource.connection_probe_token = probe_token
-    resource.save(
-        update_fields=[
-            "connection_test_status",
-            "connection_probe_token",
-            "updated_at",
-        ]
+    claimed = (
+        SourceResource.all_objects.filter(pk=resource.id, is_deleted=False)
+        .exclude(status__in=ResourceStatus.REMOVAL_FENCED)
+        .update(
+            connection_test_status=ConnectionTestStatus.RUNNING,
+            connection_probe_token=probe_token,
+            updated_at=timezone.now(),
+        )
     )
+    if not claimed:
+        return {
+            "success": False,
+            "message": "Connection testing is unavailable while this source is being removed.",
+        }
     if resource.resource_type == ResourceType.NAS:
         sync_pipeline_projection(
             organization_id=resource.organization_id,
@@ -384,12 +390,21 @@ def test_resource_connection(*, resource: SourceResource) -> dict:
             "success": False,
             "message": "Connection test failed unexpectedly. Try again.",
         }
-    current, _skip_reason = apply_connection_test_result_if_current(
+    current, skip_reason = apply_connection_test_result_if_current(
         resource_id=resource.id,
         probe_token=probe_token,
         result=result,
     )
     if current is None:
+        if skip_reason in {
+            "source_deleted",
+            "source_removing",
+        }:
+            best_effort_unmount_on_proxy(
+                resource=resource,
+                node_id=int(resource.bound_node_id or 0),
+                force=True,
+            )
         return {**public_connection_result(result), "stale": True}
     return public_connection_result(result)
 
@@ -557,5 +572,5 @@ def mount_resource(*, resource: SourceResource) -> dict:
     return _mount_resource(resource)
 
 
-def unmount_resource(*, resource: SourceResource) -> dict:
-    return _unmount_resource(resource)
+def unmount_resource(*, resource: SourceResource, force: bool = False) -> dict:
+    return _unmount_resource(resource, force=force)

--- a/src/backend/apps/source/services/internal/backup_source_delete.py
+++ b/src/backend/apps/source/services/internal/backup_source_delete.py
@@ -1300,6 +1300,8 @@ def _set_source_nas_removal_status(
     ).update(
         status=status,
         status_message=message[:2000],
+        connection_test_status=ConnectionTestStatus.IDLE,
+        connection_probe_token=None,
         updated_at=timezone.now(),
     )
 
@@ -2427,6 +2429,7 @@ def _execute_source_unregister_work(
                 force=force,
                 reasons=reasons,
                 warnings=warnings,
+                unregister_task=unregister_task,
             )
             _renew_unregister_execution_lease(
                 task=unregister_task,
@@ -3870,18 +3873,87 @@ def _cleanup_download_artifacts(*, organization_id: int, config_ids: list[int]) 
     return count
 
 
+def _nas_unmount_retained_warning(
+    *,
+    ctx: SourceDeleteContext,
+    result: dict[str, Any],
+) -> DeleteWarning | None:
+    """Normalize Agent NAS residue into the source unregister result."""
+    resource = ctx.nas_resource
+    if resource is None or bool(result.get("cleanup_complete", True)):
+        return None
+
+    detail = "NAS mount was detached with retained local references."
+    raw_warnings = result.get("warnings")
+    if isinstance(raw_warnings, list) and raw_warnings:
+        detail = str(raw_warnings[0] or detail)
+    retained_resources = []
+    for retained in result.get("retained_resources") or []:
+        retained_name = str(retained or "").strip()
+        if retained_name == "nas_mount_reference":
+            retained_name = f"source_nas_mount:{resource.id}"
+        elif retained_name == "nas_mount_directory":
+            retained_name = f"source_nas_mount_directory:{resource.id}"
+        elif retained_name:
+            retained_name = f"source_nas:{resource.id}:{retained_name}"
+        if retained_name:
+            retained_resources.append(retained_name)
+    return DeleteWarning(
+        code="nas_umount_retained",
+        detail=detail,
+        source_id=ctx.selectable_id,
+        source_name=ctx.display_name,
+        retained_resources=tuple(
+            retained_resources or [f"source_nas_mount:{resource.id}"]
+        ),
+    )
+
+
+def _recent_nas_unmount_residue_warnings(
+    *,
+    ctx: SourceDeleteContext,
+    unregister_task: Task,
+) -> list[DeleteWarning]:
+    """Return residue reported by concurrent compensating unmount tasks."""
+    resource = ctx.nas_resource
+    if resource is None or resource.bound_node_id is None:
+        return []
+    results = (
+        NodeTask.objects.filter(
+            organization_id=resource.organization_id,
+            node_id=resource.bound_node_id,
+            kind="nas.unmount",
+            correlation_type="source.unmount",
+            correlation_id=str(resource.id),
+            status=NodeTask.Status.SUCCESS,
+            created_at__gte=unregister_task.created_at,
+        )
+        .order_by("created_at", "id")
+        .values_list("result", flat=True)
+    )
+    warnings: list[DeleteWarning] = []
+    for result in results:
+        if not isinstance(result, dict):
+            continue
+        warning = _nas_unmount_retained_warning(ctx=ctx, result=result)
+        if warning is not None:
+            warnings.append(warning)
+    return warnings
+
+
 def _strict_nas_umount(
     *,
     ctx: SourceDeleteContext,
     force: bool,
     reasons: list[DeleteReason],
     warnings: list[DeleteWarning],
+    unregister_task: Task,
 ) -> dict[str, Any]:
     resource = ctx.nas_resource
     if resource is None:
         return {"skipped": True}
     try:
-        result = unmount_resource(resource=resource)
+        result = unmount_resource(resource=resource, force=force)
     except Exception as exc:
         logger.exception(
             "Backup source NAS unmount raised source=%s resource=%s",
@@ -3893,6 +3965,27 @@ def _strict_nas_umount(
             "message": (f"NAS unmount failed unexpectedly ({exc.__class__.__name__})."),
         }
     if result.get("success"):
+        warning = _nas_unmount_retained_warning(ctx=ctx, result=result)
+        if warning is not None:
+            if not force:
+                reasons.append(
+                    DeleteReason(
+                        code=warning.code,
+                        detail=warning.detail,
+                        source_id=warning.source_id,
+                        source_name=warning.source_name,
+                    )
+                )
+                return {"failed": True}
+            if warning not in warnings:
+                warnings.append(warning)
+        if force:
+            for residue_warning in _recent_nas_unmount_residue_warnings(
+                ctx=ctx,
+                unregister_task=unregister_task,
+            ):
+                if residue_warning not in warnings:
+                    warnings.append(residue_warning)
         return {"success": True}
     message = str(result.get("message") or "NAS unmount failed.")
     failure_code = (
@@ -4239,11 +4332,17 @@ def _finalize_single_source_delete(
         warning.code in {"nas_umount_failed", "mount_directory_cleanup_failed"}
         for warning in warnings
     )
-    retained_resources = (
-        [ctx.nas_resource.effective_mount_point()]
-        if nas_unmount_failed and ctx.nas_resource is not None
-        else []
-    )
+    retained_resources: list[str] = []
+    if nas_unmount_failed and ctx.nas_resource is not None:
+        if any(warning.code == "nas_umount_failed" for warning in warnings):
+            retained_resources.append(f"source_nas_mount:{ctx.nas_resource.id}")
+        if any(
+            warning.code == "mount_directory_cleanup_failed"
+            for warning in warnings
+        ):
+            retained_resources.append(
+                f"source_nas_mount_directory:{ctx.nas_resource.id}"
+            )
 
     return {
         "source_id": ctx.selectable_id,

--- a/src/backend/apps/source/services/internal/connection.py
+++ b/src/backend/apps/source/services/internal/connection.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import threading
+from typing import Any
 from uuid import UUID
 
 from django.db import transaction
@@ -153,7 +154,8 @@ def run_connection_test(
             resource.id if resource else payload.get("resource_id"),
             message[:500],
         )
-        result = outcome.result if isinstance(outcome.result, dict) else {}
+        raw_result = getattr(outcome, "result", None)
+        result = raw_result if isinstance(raw_result, dict) else {}
         details = {"storage_type": rtype, "protocol": payload.get("protocol")}
         for key in ("charset", "kernel", "cleanup_status", "mount_status"):
             if key in result:
@@ -253,7 +255,7 @@ def apply_connection_test_result_if_current(
         )
         if resource is None or resource.is_deleted:
             return None, "source_deleted"
-        if resource.status in {ResourceStatus.REMOVING, ResourceStatus.REMOVED}:
+        if resource.status in ResourceStatus.REMOVAL_FENCED:
             return None, "source_removing"
         if require_mount and not resource.requires_mount:
             return None, "mount_not_required"
@@ -269,11 +271,102 @@ def apply_connection_test_result_if_current(
         return resource, ""
 
 
+def _source_removal_fenced(resource_id: int) -> bool:
+    state = (
+        SourceResource.all_objects.filter(pk=resource_id)
+        .values_list("status", "is_deleted")
+        .first()
+    )
+    return (
+        state is None
+        or bool(state[1])
+        or state[0] in ResourceStatus.REMOVAL_FENCED
+    )
+
+
+def _source_removal_force_requested(resource: SourceResource) -> bool:
+    """Return the cleanup mode selected by the latest source unregister task."""
+    from apps.task.models import Task
+
+    source_id = f"nas:{resource.id}"
+    task = (
+        Task.objects.filter(
+            organization_id=resource.organization_id,
+            task_type=Task.Type.SOURCE_UNREGISTER,
+            request_payload__source_ids__contains=[source_id],
+        )
+        .order_by("-created_at", "-id")
+        .only("request_payload")
+        .first()
+    )
+    if task is None or not isinstance(task.request_payload, dict):
+        # Legacy fenced rows may predate durable unregister tasks. Preserve the
+        # existing best-effort behavior for those rows.
+        return True
+    return bool(task.request_payload.get("force"))
+
+
+def _compensate_mount_if_removal_fenced(resource: SourceResource) -> bool:
+    if not _source_removal_fenced(resource.id):
+        return False
+    best_effort_unmount_on_proxy(
+        resource=resource,
+        node_id=int(resource.bound_node_id or 0),
+        force=_source_removal_force_requested(resource),
+    )
+    return True
+
+
+def _apply_mount_success_if_not_fenced(
+    resource: SourceResource,
+    result: dict[str, Any],
+) -> SourceResource | None:
+    """Apply a mount result while holding the same row used by removal."""
+    with transaction.atomic():
+        current = (
+            SourceResource.all_objects.select_for_update()
+            .filter(pk=resource.id, is_deleted=False)
+            .first()
+        )
+        if current is None or current.status in ResourceStatus.REMOVAL_FENCED:
+            return None
+        apply_mount_success(current, result)
+        return current
+
+
+def _apply_mount_failure_if_not_fenced(
+    resource: SourceResource,
+    message: str,
+    *,
+    availability_confirmed: bool,
+) -> bool:
+    """Apply a mount failure only while removal has not claimed the source."""
+    with transaction.atomic():
+        current = (
+            SourceResource.all_objects.select_for_update()
+            .filter(pk=resource.id, is_deleted=False)
+            .first()
+        )
+        if current is None or current.status in ResourceStatus.REMOVAL_FENCED:
+            return False
+        apply_mount_failure(
+            current,
+            message,
+            availability_confirmed=availability_confirmed,
+        )
+        return True
+
+
 def mount_resource(resource: SourceResource) -> dict:
     if not resource.requires_mount:
         return {
             "success": False,
             "message": f"{resource.resource_type} does not require mounting.",
+        }
+    if _source_removal_fenced(resource.id):
+        return {
+            "success": False,
+            "message": "Mounting is unavailable while this source is being removed.",
         }
     validation_error = _validate_proxy_node(resource.bound_node, resource=resource)
     if validation_error:
@@ -297,7 +390,12 @@ def mount_resource(resource: SourceResource) -> dict:
     )
     if outcome.timed_out:
         message = "Mount timed out on the proxy agent."
-        apply_mount_failure(resource, message, availability_confirmed=False)
+        if not _apply_mount_failure_if_not_fenced(
+            resource,
+            message,
+            availability_confirmed=False,
+        ):
+            _compensate_mount_if_removal_fenced(resource)
         return {"success": False, "message": message}
     if not outcome.ok:
         message = explain_nas_mount_point_error(
@@ -305,45 +403,62 @@ def mount_resource(resource: SourceResource) -> dict:
             agent_message=_task_error_message(outcome),
             payload_mount_point=str(payload.get("mount_point") or ""),
         )
-        apply_mount_failure(
+        if not _apply_mount_failure_if_not_fenced(
             resource,
             message,
             availability_confirmed=confirmed_agent_failure(outcome),
-        )
+        ):
+            _compensate_mount_if_removal_fenced(resource)
         result = {"success": False, "message": message}
         if error_code := task_error_code(outcome):
             result["error_code"] = error_code
         return result
 
     result = outcome.result if isinstance(outcome.result, dict) else {}
-    apply_mount_success(resource, result)
+    mounted_resource = _apply_mount_success_if_not_fenced(resource, result)
+    if mounted_resource is None:
+        _compensate_mount_if_removal_fenced(resource)
+        return {
+            "success": False,
+            "message": "Mount result was discarded because this source is being removed.",
+            "stale": True,
+        }
     logger.info(
         "source mount ok node_id=%s resource_id=%s mount_point=%s",
         resource.bound_node_id,
         resource.id,
-        resource.mount_point,
+        mounted_resource.mount_point,
     )
     return {
         "success": True,
         "message": "Resource mounted successfully",
-        "mount_point": resource.mount_point,
+        "mount_point": mounted_resource.mount_point,
     }
 
 
-def best_effort_unmount_on_proxy(*, resource: SourceResource, node_id: int) -> None:
-    """Best-effort NAS unmount on a proxy that no longer owns the source binding."""
+def best_effort_unmount_on_proxy(
+    *,
+    resource: SourceResource,
+    node_id: int,
+    force: bool = False,
+) -> dict[str, object]:
+    """Compensate a stale NAS mount on the selected proxy."""
 
     if not resource.requires_mount:
-        return
+        return {"success": True, "skipped": True}
     node = Node.objects.filter(
         id=node_id,
         organization_id=resource.organization_id,
         is_deleted=False,
     ).first()
     if node is None:
-        return
+        return {"success": False, "message": "Proxy node not found."}
 
     payload = build_nas_agent_payload(resource=resource)
+    if force and _source_removal_fenced(resource.id):
+        force = _source_removal_force_requested(resource)
+    if force:
+        payload["force_cleanup"] = True
     try:
         outcome = dispatch_nas_agent_task(
             node=node,
@@ -354,19 +469,43 @@ def best_effort_unmount_on_proxy(*, resource: SourceResource, node_id: int) -> N
             wait_timeout_seconds=60,
         )
         if outcome.timed_out or not outcome.ok:
+            message = _task_error_message(outcome)
             logger.warning(
-                "source NAS unmount on old proxy failed resource_id=%s node_id=%s error=%s",
+                "compensating source NAS unmount failed resource_id=%s node_id=%s error=%s",
                 resource.id,
                 node_id,
-                _task_error_message(outcome),
+                message,
             )
+            return {"success": False, "message": message}
+        raw_result = getattr(outcome, "result", None)
+        result = raw_result if isinstance(raw_result, dict) else {}
+        response: dict[str, object] = {"success": True}
+        for key in (
+            "cleanup_complete",
+            "lazy_unmount",
+            "retained_resources",
+            "warnings",
+        ):
+            if key in result:
+                response[key] = result[key]
+        if not bool(result.get("cleanup_complete", True)):
+            logger.warning(
+                "compensating source NAS unmount retained resources "
+                "resource_id=%s node_id=%s retained_resources=%s warnings=%s",
+                resource.id,
+                node_id,
+                result.get("retained_resources") or [],
+                result.get("warnings") or [],
+            )
+        return response
     except Exception:
         logger.warning(
-            "source NAS unmount on old proxy failed resource_id=%s node_id=%s",
+            "compensating source NAS unmount failed resource_id=%s node_id=%s",
             resource.id,
             node_id,
             exc_info=True,
         )
+        return {"success": False, "message": "Compensating NAS unmount failed."}
 
 
 def remount_after_proxy_change(
@@ -448,12 +587,14 @@ def _unmount_old_proxy_after_commit(*, resource_id: int, old_node_id: int) -> No
     best_effort_unmount_on_proxy(resource=resource, node_id=old_node_id)
 
 
-def unmount_resource(resource: SourceResource) -> dict:
+def unmount_resource(resource: SourceResource, *, force: bool = False) -> dict:
     validation_error = _validate_proxy_node(resource.bound_node, resource=resource)
     if validation_error:
         return {"success": False, "message": validation_error}
 
     payload = build_nas_agent_payload(resource=resource)
+    if force:
+        payload["force_cleanup"] = True
     logger.info(
         "source unmount start node_id=%s resource_id=%s mount_point=%s",
         resource.bound_node_id,
@@ -479,4 +620,14 @@ def unmount_resource(resource: SourceResource) -> dict:
         resource.bound_node_id,
         resource.id,
     )
-    return {"success": True, "message": "Resource unmounted successfully"}
+    response = {"success": True, "message": "Resource unmounted successfully"}
+    if isinstance(outcome.result, dict):
+        for key in (
+            "cleanup_complete",
+            "lazy_unmount",
+            "retained_resources",
+            "warnings",
+        ):
+            if key in outcome.result:
+                response[key] = outcome.result[key]
+    return response

--- a/src/backend/apps/source/tasks/connection_probe.py
+++ b/src/backend/apps/source/tasks/connection_probe.py
@@ -22,6 +22,7 @@ from apps.source import conf as source_conf
 from apps.source.models import SourceResource
 from apps.source.services.internal.connection import (
     apply_connection_test_result_if_current,
+    best_effort_unmount_on_proxy,
     run_connection_test,
 )
 
@@ -41,7 +42,7 @@ def _probe_target(
     resource = SourceResource.all_objects.filter(pk=resource_id).first()
     if resource is None or resource.is_deleted:
         return None, "source_deleted"
-    if resource.status in {ResourceStatus.REMOVING, ResourceStatus.REMOVED}:
+    if resource.status in ResourceStatus.REMOVAL_FENCED:
         return None, "source_removing"
     if resource.resource_type not in ResourceType.REQUIRES_MOUNT:
         return None, "mount_not_required"
@@ -83,16 +84,25 @@ def run_source_resource_capacity_probe(
             return {"status": "discarded", "reason": skip_reason}
         return {"status": "failed", "reason": "proxy_offline"}
 
-    SourceResource.all_objects.filter(
+    claimed = SourceResource.all_objects.filter(
         pk=resource.id,
         connection_probe_token=probe_token,
-    ).update(
+        is_deleted=False,
+    ).exclude(status__in=ResourceStatus.REMOVAL_FENCED).update(
         connection_test_status=ConnectionTestStatus.RUNNING,
         status=ResourceStatus.PROBING,
         updated_at=timezone.now(),
     )
+    if not claimed:
+        _, skip_reason = _probe_target(
+            resource_id=resource_id,
+            probe_token=probe_token,
+            expected_bound_node_id=expected_bound_node_id,
+        )
+        return {"status": "skipped", "reason": skip_reason or "source_changed"}
 
-    result = run_connection_test(resource=resource)
+    probe_resource = resource
+    result = run_connection_test(resource=probe_resource)
 
     # The remote call may wait for up to 180 seconds. Lock and re-read the row
     # before applying the result so an edit, rebind, or delete wins the race.
@@ -104,6 +114,15 @@ def run_source_resource_capacity_probe(
         result=result,
     )
     if resource is None:
+        if skip_reason in {
+            "source_deleted",
+            "source_removing",
+        }:
+            best_effort_unmount_on_proxy(
+                resource=probe_resource,
+                node_id=expected_bound_node_id,
+                force=True,
+            )
         return {"status": "discarded", "reason": skip_reason}
     return {
         "status": "success" if result.get("success") else "failed",
@@ -239,7 +258,7 @@ def _queue_availability_probe(
         )
         if resource is None:
             return False
-        if resource.status in {ResourceStatus.REMOVING, ResourceStatus.REMOVED}:
+        if resource.status in ResourceStatus.REMOVAL_FENCED:
             return False
         if resource.connection_test_status in ConnectionTestStatus.ACTIVE:
             return False
@@ -298,7 +317,7 @@ def queue_source_availability_probes_for_proxy(
             is_deleted=False,
         )
         .exclude(connection_test_status__in=ConnectionTestStatus.ACTIVE)
-        .exclude(status__in={ResourceStatus.REMOVING, ResourceStatus.REMOVED})
+        .exclude(status__in=ResourceStatus.REMOVAL_FENCED)
         .order_by("availability_updated_at", "id")
         .values_list("id", flat=True)[:batch_size]
     )
@@ -344,7 +363,7 @@ def reconcile_source_availability(*, limit: int | None = None) -> dict[str, int]
             resource_type__in=ResourceType.REQUIRES_MOUNT,
             is_deleted=False,
         )
-        .exclude(status__in={ResourceStatus.REMOVING, ResourceStatus.REMOVED})
+        .exclude(status__in=ResourceStatus.REMOVAL_FENCED)
         .filter(
             Q(
                 availability_updated_at__lte=refresh_cutoff,

--- a/src/backend/apps/source/tests/test_api.py
+++ b/src/backend/apps/source/tests/test_api.py
@@ -3162,6 +3162,8 @@ class BackupSourceBulkDeleteTests(TestCase):
             },
             mount_status="mounted",
             bound_node=proxy,
+            connection_test_status="success",
+            connection_probe_token=uuid4(),
         )
         SourceBackupPipelineEntry.objects.create(
             organization=self.org,
@@ -3187,6 +3189,10 @@ class BackupSourceBulkDeleteTests(TestCase):
             response.content,
         )
         self.assertEqual(response.data["reasons"][0]["code"], "nas_umount_failed")
+        resource.refresh_from_db()
+        self.assertEqual(resource.status, "remove_failed")
+        self.assertEqual(resource.connection_test_status, "idle")
+        self.assertIsNone(resource.connection_probe_token)
         task = Task.objects.get(task_type=Task.Type.SOURCE_UNREGISTER)
         task.refresh_from_db()
         resource.refresh_from_db()

--- a/src/backend/apps/source/tests/test_backup_source_delete_snapshots.py
+++ b/src/backend/apps/source/tests/test_backup_source_delete_snapshots.py
@@ -16,7 +16,7 @@ from apps.audit.models import AuditLog
 from apps.audit.services.interface import write_audit_log as persist_audit_log
 from apps.iam.models import Membership, Organization
 from apps.node import agent_paths
-from apps.node.models import Node
+from apps.node.models import Node, NodeTask
 from apps.protection.models import (
     BackupConfig,
     BackupConfigDirectory,
@@ -752,9 +752,141 @@ class BackupSourceDeleteSnapshotTaskTests(TestCase):
         )
         self.assertEqual(
             result["retained_resources"],
-            [self.resource.effective_mount_point()],
+            [f"source_nas_mount:{self.resource.id}"],
         )
         self.assertTrue(self.resource.is_deleted)
+
+    @patch(
+        "apps.source.services.internal.backup_source_delete.unmount_resource",
+        return_value={
+            "success": True,
+            "cleanup_complete": False,
+            "retained_resources": [
+                "nas_mount_reference",
+                "nas_mount_directory",
+            ],
+            "warnings": ["The NAS mount was lazily detached."],
+        },
+    )
+    def test_force_nas_unmount_namespaces_agent_residue(self, _unmount_resource):
+        self.snapshot.status = self.snapshot.Status.DELETED
+        self.snapshot.save(update_fields=["status", "updated_at"])
+
+        result = delete_backup_sources(
+            org=self.org,
+            ids=[f"nas:{self.resource.id}"],
+            force=True,
+            user=self.user,
+        )
+
+        self.assertEqual(result["result"], "partial_success")
+        self.assertIn(
+            f"source_nas_mount:{self.resource.id}",
+            result["retained_resources"],
+        )
+        self.assertIn(
+            f"source_nas_mount_directory:{self.resource.id}",
+            result["retained_resources"],
+        )
+
+    @patch(
+        "apps.source.services.internal.backup_source_delete.unmount_resource",
+        return_value={
+            "success": True,
+            "cleanup_complete": False,
+            "retained_resources": ["nas_mount_reference"],
+            "warnings": ["The NAS mount still has local references."],
+        },
+    )
+    def test_strict_nas_unmount_rejects_success_with_residue(
+        self,
+        _unmount_resource,
+    ):
+        self.snapshot.status = self.snapshot.Status.DELETED
+        self.snapshot.save(update_fields=["status", "updated_at"])
+
+        with self.assertRaises(BackupSourceDeleteFailed) as raised:
+            delete_backup_sources(
+                org=self.org,
+                ids=[f"nas:{self.resource.id}"],
+                force=False,
+                user=self.user,
+            )
+
+        self.resource.refresh_from_db()
+        self.assertEqual(raised.exception.reasons[0].code, "nas_umount_retained")
+        self.assertFalse(self.resource.is_deleted)
+
+    @patch(
+        "apps.source.services.internal.backup_source_delete.unmount_resource"
+    )
+    def test_force_nas_unmount_merges_compensating_task_residue(
+        self,
+        unmount_resource,
+    ):
+        self.snapshot.status = self.snapshot.Status.DELETED
+        self.snapshot.save(update_fields=["status", "updated_at"])
+
+        def complete_with_compensation_residue(**_kwargs):
+            NodeTask.objects.create(
+                organization=self.org,
+                requesting_organization_id=self.org.id,
+                node=self.proxy,
+                kind="nas.unmount",
+                correlation_type="source.unmount",
+                correlation_id=str(self.resource.id),
+                status=NodeTask.Status.SUCCESS,
+                result={
+                    "cleanup_complete": False,
+                    "retained_resources": ["nas_mount_reference"],
+                    "warnings": ["The NAS mount was lazily detached."],
+                },
+                watchdog_deadline_at=timezone.now(),
+            )
+            return {"success": True, "cleanup_complete": True}
+
+        unmount_resource.side_effect = complete_with_compensation_residue
+
+        result = delete_backup_sources(
+            org=self.org,
+            ids=[f"nas:{self.resource.id}"],
+            force=True,
+            user=self.user,
+        )
+
+        self.assertEqual(result["result"], "partial_success")
+        self.assertFalse(result["cleanup_complete"])
+        self.assertEqual(
+            result["retained_resources"],
+            [f"source_nas_mount:{self.resource.id}"],
+        )
+
+    @patch(
+        "apps.source.services.internal.backup_source_delete.unmount_resource",
+        return_value={
+            "success": False,
+            "message": "cleanup mount directory: directory not empty",
+        },
+    )
+    def test_force_nas_directory_failure_uses_stable_residue_id(
+        self,
+        _unmount_resource,
+    ):
+        self.snapshot.status = self.snapshot.Status.DELETED
+        self.snapshot.save(update_fields=["status", "updated_at"])
+
+        result = delete_backup_sources(
+            org=self.org,
+            ids=[f"nas:{self.resource.id}"],
+            force=True,
+            user=self.user,
+        )
+
+        self.assertEqual(result["result"], "partial_success")
+        self.assertEqual(
+            result["retained_resources"],
+            [f"source_nas_mount_directory:{self.resource.id}"],
+        )
 
     @patch(
         "apps.source.services.internal.backup_source_delete.unmount_resource",

--- a/src/backend/apps/source/tests/test_connection_probe.py
+++ b/src/backend/apps/source/tests/test_connection_probe.py
@@ -13,8 +13,10 @@ from apps.source.services.internal.availability import (
     confirmed_agent_failure,
     project_node_availability,
 )
+from apps.source.services.internal.connection import best_effort_unmount_on_proxy
 from apps.source.services.interface import (
     bind_node,
+    mount_resource,
     test_resource_connection,
     update_source_resource,
 )
@@ -24,6 +26,7 @@ from apps.source.tasks.connection_probe import (
     reconcile_stale_source_connection_probes,
     run_source_resource_capacity_probe,
 )
+from apps.task.models import Task
 
 
 class SourceConnectionProbeTests(TestCase):
@@ -119,8 +122,15 @@ class SourceConnectionProbeTests(TestCase):
         self.assertEqual(self.resource.total_size, 0)
         self.assertIsNone(self.resource.last_connection_test)
 
+    @mock.patch(
+        "apps.source.tasks.connection_probe.best_effort_unmount_on_proxy"
+    )
     @mock.patch("apps.source.tasks.connection_probe.run_connection_test")
-    def test_probe_discards_result_after_source_delete(self, run_test):
+    def test_probe_discards_result_after_source_delete(
+        self,
+        run_test,
+        best_effort_unmount,
+    ):
         def delete_source(**_kwargs):
             SourceResource.objects.get(pk=self.resource.id).soft_delete()
             return {"success": True, "message": "Connection test successful"}
@@ -140,6 +150,388 @@ class SourceConnectionProbeTests(TestCase):
         )
         self.assertTrue(deleted.is_deleted)
         self.assertEqual(deleted.total_size, 0)
+        best_effort_unmount.assert_called_once_with(
+            resource=mock.ANY,
+            node_id=self.proxy.id,
+            force=True,
+        )
+
+    @mock.patch(
+        "apps.source.tasks.connection_probe.best_effort_unmount_on_proxy"
+    )
+    @mock.patch("apps.source.tasks.connection_probe.run_connection_test")
+    def test_probe_success_racing_removal_is_compensated(
+        self,
+        run_test,
+        best_effort_unmount,
+    ):
+        def remove_source(**_kwargs):
+            SourceResource.objects.filter(pk=self.resource.id).update(
+                status="removing",
+            )
+            return {"success": True, "message": "Connection test successful"}
+
+        run_test.side_effect = remove_source
+
+        result = run_source_resource_capacity_probe(
+            resource_id=self.resource.id,
+            probe_token=str(self.probe_token),
+            expected_bound_node_id=self.proxy.id,
+        )
+
+        self.assertEqual(
+            result,
+            {"status": "discarded", "reason": "source_removing"},
+        )
+        best_effort_unmount.assert_called_once_with(
+            resource=mock.ANY,
+            node_id=self.proxy.id,
+            force=True,
+        )
+
+    @mock.patch(
+        "apps.source.tasks.connection_probe.best_effort_unmount_on_proxy"
+    )
+    @mock.patch("apps.source.tasks.connection_probe.run_connection_test")
+    def test_probe_failure_racing_removal_is_compensated(
+        self,
+        run_test,
+        best_effort_unmount,
+    ):
+        def remove_source(**_kwargs):
+            SourceResource.objects.filter(pk=self.resource.id).update(
+                status="removing",
+            )
+            return {"success": False, "message": "Capacity read failed"}
+
+        run_test.side_effect = remove_source
+
+        result = run_source_resource_capacity_probe(
+            resource_id=self.resource.id,
+            probe_token=str(self.probe_token),
+            expected_bound_node_id=self.proxy.id,
+        )
+
+        self.assertEqual(
+            result,
+            {"status": "discarded", "reason": "source_removing"},
+        )
+        best_effort_unmount.assert_called_once_with(
+            resource=mock.ANY,
+            node_id=self.proxy.id,
+            force=True,
+        )
+
+    @mock.patch("apps.source.tasks.connection_probe.run_connection_test")
+    def test_probe_skips_remove_failed_source(self, run_test):
+        SourceResource.objects.filter(pk=self.resource.id).update(
+            status="remove_failed",
+        )
+
+        result = run_source_resource_capacity_probe(
+            resource_id=self.resource.id,
+            probe_token=str(self.probe_token),
+            expected_bound_node_id=self.proxy.id,
+        )
+
+        self.assertEqual(result, {"status": "skipped", "reason": "source_removing"})
+        run_test.assert_not_called()
+
+    @mock.patch("apps.source.tasks.connection_probe.run_connection_test")
+    def test_probe_claim_cannot_overwrite_removing_fence(self, run_test):
+        from apps.source.tasks import connection_probe
+
+        original_target = connection_probe._probe_target
+
+        def fence_after_read(**kwargs):
+            resource, reason = original_target(**kwargs)
+            SourceResource.objects.filter(pk=self.resource.id).update(
+                status="removing",
+            )
+            return resource, reason
+
+        with mock.patch(
+            "apps.source.tasks.connection_probe._probe_target",
+            side_effect=fence_after_read,
+        ):
+            result = run_source_resource_capacity_probe(
+                resource_id=self.resource.id,
+                probe_token=str(self.probe_token),
+                expected_bound_node_id=self.proxy.id,
+            )
+
+        self.assertEqual(result, {"status": "skipped", "reason": "source_removing"})
+        self.resource.refresh_from_db()
+        self.assertEqual(self.resource.status, "removing")
+        run_test.assert_not_called()
+
+    @mock.patch("apps.source.tasks.connection_probe.run_connection_test")
+    def test_probe_claim_reports_source_change_race(self, run_test):
+        from apps.source.tasks import connection_probe
+
+        original_target = connection_probe._probe_target
+        calls = 0
+
+        def change_after_read(**kwargs):
+            nonlocal calls
+            calls += 1
+            resource, reason = original_target(**kwargs)
+            if calls == 1:
+                SourceResource.objects.filter(pk=self.resource.id).update(
+                    connection_probe_token=uuid4(),
+                )
+            return resource, reason
+
+        with mock.patch(
+            "apps.source.tasks.connection_probe._probe_target",
+            side_effect=change_after_read,
+        ):
+            result = run_source_resource_capacity_probe(
+                resource_id=self.resource.id,
+                probe_token=str(self.probe_token),
+                expected_bound_node_id=self.proxy.id,
+            )
+
+        self.assertEqual(result, {"status": "skipped", "reason": "source_changed"})
+        run_test.assert_not_called()
+
+    @mock.patch("apps.source.services.interface.run_connection_test")
+    def test_manual_probe_does_not_cross_removal_fence(self, run_test):
+        SourceResource.objects.filter(pk=self.resource.id).update(
+            status="remove_failed",
+        )
+
+        result = test_resource_connection(resource=self.resource)
+
+        self.assertFalse(result["success"])
+        self.assertIn("being removed", result["message"])
+        run_test.assert_not_called()
+
+    @mock.patch("apps.source.services.interface.best_effort_unmount_on_proxy")
+    @mock.patch("apps.source.services.interface.run_connection_test")
+    def test_manual_probe_failure_racing_removal_is_compensated(
+        self,
+        run_test,
+        best_effort_unmount,
+    ):
+        def remove_source(**_kwargs):
+            SourceResource.objects.filter(pk=self.resource.id).update(
+                status="removing",
+            )
+            return {"success": False, "message": "Capacity read failed"}
+
+        run_test.side_effect = remove_source
+
+        result = test_resource_connection(resource=self.resource)
+
+        self.assertFalse(result["success"])
+        self.assertTrue(result["stale"])
+        best_effort_unmount.assert_called_once_with(
+            resource=self.resource,
+            node_id=self.proxy.id,
+            force=True,
+        )
+
+    @mock.patch("apps.source.services.internal.connection.dispatch_nas_agent_task")
+    def test_manual_mount_does_not_cross_removal_fence(self, dispatch_task):
+        SourceResource.objects.filter(pk=self.resource.id).update(
+            status="remove_failed",
+        )
+
+        result = mount_resource(resource=self.resource)
+
+        self.assertFalse(result["success"])
+        self.assertIn("being removed", result["message"])
+        dispatch_task.assert_not_called()
+
+    @mock.patch(
+        "apps.source.services.internal.connection.best_effort_unmount_on_proxy"
+    )
+    @mock.patch("apps.source.services.internal.connection.dispatch_nas_agent_task")
+    def test_mount_success_racing_removal_is_compensated(
+        self,
+        dispatch_task,
+        best_effort_unmount,
+    ):
+        def fence_during_mount(**_kwargs):
+            SourceResource.objects.filter(pk=self.resource.id).update(
+                status="removing",
+            )
+            return SimpleNamespace(timed_out=False, ok=True, result={})
+
+        dispatch_task.side_effect = fence_during_mount
+
+        result = mount_resource(resource=self.resource)
+
+        self.assertFalse(result["success"])
+        self.assertTrue(result["stale"])
+        best_effort_unmount.assert_called_once_with(
+            resource=self.resource,
+            node_id=self.proxy.id,
+            force=True,
+        )
+
+    @mock.patch(
+        "apps.source.services.internal.connection.best_effort_unmount_on_proxy"
+    )
+    @mock.patch("apps.source.services.internal.connection.dispatch_nas_agent_task")
+    def test_mount_failure_racing_removal_is_compensated(
+        self,
+        dispatch_task,
+        best_effort_unmount,
+    ):
+        def fence_during_mount(**_kwargs):
+            SourceResource.objects.filter(pk=self.resource.id).update(
+                status="removing",
+            )
+            return SimpleNamespace(
+                timed_out=False,
+                ok=False,
+                result={},
+                task=SimpleNamespace(last_error="Capacity read failed", status="failed"),
+                stream_message=None,
+            )
+
+        dispatch_task.side_effect = fence_during_mount
+
+        result = mount_resource(resource=self.resource)
+
+        self.assertFalse(result["success"])
+        best_effort_unmount.assert_called_once_with(
+            resource=self.resource,
+            node_id=self.proxy.id,
+            force=True,
+        )
+
+    @mock.patch(
+        "apps.source.services.internal.connection.best_effort_unmount_on_proxy"
+    )
+    @mock.patch("apps.source.services.internal.connection.dispatch_nas_agent_task")
+    def test_mount_timeout_racing_removal_is_compensated(
+        self,
+        dispatch_task,
+        best_effort_unmount,
+    ):
+        def fence_during_mount(**_kwargs):
+            Task.objects.create(
+                organization_id=self.org.id,
+                task_type=Task.Type.SOURCE_UNREGISTER,
+                status=Task.Status.RUNNING,
+                request_payload={
+                    "source_ids": [f"nas:{self.resource.id}"],
+                    "force": False,
+                },
+            )
+            SourceResource.objects.filter(pk=self.resource.id).update(
+                status="removing",
+            )
+            return SimpleNamespace(timed_out=True, ok=False)
+
+        dispatch_task.side_effect = fence_during_mount
+
+        result = mount_resource(resource=self.resource)
+
+        self.assertFalse(result["success"])
+        best_effort_unmount.assert_called_once_with(
+            resource=self.resource,
+            node_id=self.proxy.id,
+            force=False,
+        )
+
+    @mock.patch(
+        "apps.source.services.internal.connection.best_effort_unmount_on_proxy"
+    )
+    @mock.patch("apps.source.services.internal.connection.dispatch_nas_agent_task")
+    def test_mount_timeout_without_removal_does_not_force_cleanup(
+        self,
+        dispatch_task,
+        best_effort_unmount,
+    ):
+        dispatch_task.return_value = SimpleNamespace(timed_out=True, ok=False)
+
+        result = mount_resource(resource=self.resource)
+
+        self.assertFalse(result["success"])
+        best_effort_unmount.assert_not_called()
+        self.resource.refresh_from_db()
+        self.assertEqual(self.resource.mount_status, "error")
+
+    @mock.patch("apps.source.services.internal.connection.dispatch_nas_agent_task")
+    def test_removal_compensation_requests_force_cleanup(self, dispatch_task):
+        dispatch_task.return_value = SimpleNamespace(timed_out=False, ok=True)
+
+        best_effort_unmount_on_proxy(
+            resource=self.resource,
+            node_id=self.proxy.id,
+            force=True,
+        )
+
+        self.assertTrue(dispatch_task.call_args.kwargs["payload"]["force_cleanup"])
+
+    @mock.patch("apps.source.services.internal.connection.dispatch_nas_agent_task")
+    def test_regular_proxy_cleanup_does_not_request_force_cleanup(self, dispatch_task):
+        dispatch_task.return_value = SimpleNamespace(timed_out=False, ok=True)
+
+        best_effort_unmount_on_proxy(
+            resource=self.resource,
+            node_id=self.proxy.id,
+        )
+
+        self.assertNotIn("force_cleanup", dispatch_task.call_args.kwargs["payload"])
+
+    @mock.patch("apps.source.services.internal.connection.dispatch_nas_agent_task")
+    def test_strict_removal_compensation_does_not_request_force_cleanup(
+        self,
+        dispatch_task,
+    ):
+        Task.objects.create(
+            organization_id=self.org.id,
+            task_type=Task.Type.SOURCE_UNREGISTER,
+            status=Task.Status.RUNNING,
+            request_payload={
+                "source_ids": [f"nas:{self.resource.id}"],
+                "force": False,
+            },
+        )
+        SourceResource.objects.filter(pk=self.resource.id).update(status="removing")
+        dispatch_task.return_value = SimpleNamespace(
+            timed_out=False,
+            ok=True,
+            result={"cleanup_complete": True},
+        )
+
+        best_effort_unmount_on_proxy(
+            resource=self.resource,
+            node_id=self.proxy.id,
+            force=True,
+        )
+
+        self.assertNotIn("force_cleanup", dispatch_task.call_args.kwargs["payload"])
+
+    @mock.patch("apps.source.services.internal.connection.dispatch_nas_agent_task")
+    def test_compensating_force_cleanup_returns_retained_resources(self, dispatch_task):
+        dispatch_task.return_value = SimpleNamespace(
+            timed_out=False,
+            ok=True,
+            result={
+                "cleanup_complete": False,
+                "retained_resources": ["nas_mount_reference"],
+                "warnings": ["The NAS mount was lazily detached."],
+            },
+        )
+
+        result = best_effort_unmount_on_proxy(
+            resource=self.resource,
+            node_id=self.proxy.id,
+            force=True,
+        )
+
+        self.assertTrue(result["success"])
+        self.assertFalse(result["cleanup_complete"])
+        self.assertEqual(
+            result["retained_resources"],
+            ["nas_mount_reference"],
+        )
 
     @mock.patch("apps.source.tasks.connection_probe.run_connection_test")
     def test_probe_skips_when_proxy_is_offline(self, run_test):

--- a/src/backend/apps/source/tests/test_remote_transaction_boundaries.py
+++ b/src/backend/apps/source/tests/test_remote_transaction_boundaries.py
@@ -103,7 +103,7 @@ class SourceRemoteTransactionBoundaryTests(TransactionTestCase):
         )
         resource_id = resource.id
 
-        def perform_unmount(*, resource):
+        def perform_unmount(*, resource, force):
             self.assertFalse(connection.in_atomic_block)
             self.assertEqual(resource.id, resource_id)
             return {"success": True, "message": "Unmounted"}
@@ -117,4 +117,4 @@ class SourceRemoteTransactionBoundaryTests(TransactionTestCase):
 
         self.assertEqual(result["result"], "success")
         self.assertTrue(SourceResource.all_objects.get(pk=resource.id).is_deleted)
-        unmount.assert_called_once()
+        unmount.assert_called_once_with(resource=resource, force=False)


### PR DESCRIPTION
## Summary

Fixes the NAS unmount lifecycle (issue #535): unmounts that fail due to transient busy conditions previously surfaced as persistent failures and left mount residue behind. This change adds bounded retry with force lazy detach and coordinates concurrent NAS operations to prevent lease conflicts.

## Changes

**Agent — retry with force lazy detach (`service.go`, `mount_unix.go`, `mount_windows.go`)**
- `UnmountWithOptions` now retries up to 3 times on busy-only errors; the live mount table is authoritative for success.
- Force mode uses lazy detach (`umount -l`) and degrades residue-directory cleanup to a warning instead of failing the task.
- Busy diagnostics collect offending process cwd/root/fd references (capped at 8 processes / 12 entries) and nested mount details to aid triage.
- Windows: drive-letter allocation lock, SMB mount metadata written atomically (double path + tempfile), and `isMounted` checks meta + junction + mapped drive + remote match.

**Agent — lease coordination (`nas_lease.go`)**
- `NASLeaseCoordinator` serializes NAS mount/unmount/cleanup operations per path with write-prioritized RW locks, sorted acquisition to avoid deadlock, rollback on failure, and ctx-cancellation release.
- Engine acquires exclusive leases for `nas.unmount` / `nas.mount` / `repository.operation` / `nas.test` / `cleanup_after_test` and shared leases for `backup`.

**Backend — removal isolation (`connection.py`, `connection_probe.py`, `backup_source_delete.py`)**
- `REMOVAL_FENCED` (incl. `REMOVE_FAILED`) isolates all NAS unmount paths while a source removal is pending.
- Compensation unmount consults the latest unregister task before honoring `force`.
- Recent unmount residue warnings are correlated via `correlation_type=source.unmount` so the post-removal cleanup can retain them.

## Tests
- New: `nas_lease_test.go` (exclusive wait, shared coordinator, zero-value engine, ctx cancel, writer starvation, path extraction), `mount_windows_test.go` (meta ownership, parse logic, unmount cleanup).
- Updated: `service_test.go` (busy/retry/force semantics, `net use` parsing), `mount_unix_test.go` (nested mount diagnostics).
- Verified locally: `go build`, `go vet`, `go test -race` (engine + nas), Windows cross-compile, backend `compileall`.