### PR TITLE
fix(node): prevent upgrade lifecycle from sticking at verifying after success (#639)

### DIFF
--- a/src/backend/apps/node/services/internal/node_lifecycle.py
+++ b/src/backend/apps/node/services/internal/node_lifecycle.py
@@ -540,14 +540,11 @@ def _upgrade_lifecycle_payload(
     if task.status != NodeTask.Status.SUCCESS:
         return None
 
-    if target_version and _version_matches_target(
-        node=node,
-        target_version=target_version,
-        target_commit=_target_commit_from_task(task),
-    ):
-        return None
-
-    return {**base, "state": "verifying", "phase": "waiting_for_version"}
+    # Upgrade completed successfully — no lifecycle to report.
+    # The version was already verified by _advance_upgrade_verify before
+    # marking the task SUCCESS; a redundant check here risks false
+    # negatives that leave the lifecycle stuck at "verifying" (#639).
+    return None
 
 
 def _remove_lifecycle_payload(

--- a/src/backend/apps/node/tests/test_node_lifecycle.py
+++ b/src/backend/apps/node/tests/test_node_lifecycle.py
@@ -500,7 +500,7 @@ class NodeLifecycleTests(TestCase):
         """Lifecycle is always cleared on SUCCESS — version was already verified
         by _advance_upgrade_verify before marking the task SUCCESS. A redundant
         post-SUCCESS version check risks false negatives (#639)."""
-        task = NodeTask.objects.create(
+        NodeTask.objects.create(
             organization=self.org,
             node=self.node,
             kind="agent.upgrade",

--- a/src/backend/apps/node/tests/test_node_lifecycle.py
+++ b/src/backend/apps/node/tests/test_node_lifecycle.py
@@ -496,7 +496,10 @@ class NodeLifecycleTests(TestCase):
         self.assertEqual(len(preview["eligible"]), 1)
         self.assertEqual(preview["eligible"][0]["target_version"], "1.2.0")
 
-    def test_compute_upgrade_verifying_state(self):
+    def test_upgrade_success_clears_lifecycle_when_version_differs(self):
+        """Lifecycle is always cleared on SUCCESS — version was already verified
+        by _advance_upgrade_verify before marking the task SUCCESS. A redundant
+        post-SUCCESS version check risks false negatives (#639)."""
         task = NodeTask.objects.create(
             organization=self.org,
             node=self.node,
@@ -509,9 +512,7 @@ class NodeLifecycleTests(TestCase):
         )
         with patch("apps.node.services.internal.node_lifecycle.agent_session_registered", return_value=True):
             lifecycle = compute_node_lifecycle(org=self.org, node=self.node)
-        self.assertIsNotNone(lifecycle)
-        self.assertEqual(lifecycle["state"], "verifying")
-        self.assertEqual(lifecycle["task_id"], str(task.id))
+        self.assertIsNone(lifecycle)
 
     @patch("apps.node.services.internal.node_lifecycle.agent_ws_routable", return_value=False)
     def test_upgrade_success_clears_when_version_matches_despite_stale_ws(self, _routable):


### PR DESCRIPTION
## Summary

Fixes #639: upgrade lifecycle state stuck at "verifying" after the upgrade has actually completed.

## Root Cause

In `_upgrade_lifecycle_payload`, when `task.status == SUCCESS`, the code performed a redundant `_version_matches_target` check. If this check returned a false negative, the lifecycle state would remain `"verifying"` even though:

- `_advance_upgrade_verify` had already verified the version matched before marking the task SUCCESS
- `_build_upgrade_timeline` correctly showed all phases as completed

This caused the table to display:
- Lifecycle Status: "Verifying" (incorrect)
- Version column: "0.1.0→0.1.1" (stale upgrade arrow)
- Timeline in drawer: all steps completed (correct)

## Fix

Remove the redundant post-SUCCESS `_version_matches_target` check. When the task is SUCCESS, the upgrade is complete — the lifecycle should always return `None` (no active lifecycle).

The version was already verified at the right time by `_advance_upgrade_verify` via `_upgrade_verify_ready`. A second check in `_upgrade_lifecycle_payload` only introduces a race condition with no benefit.

## Changes

| File | Change |
|------|--------|
| `src/backend/apps/node/services/internal/node_lifecycle.py` | Remove redundant `_version_matches_target` guard in `_upgrade_lifecycle_payload` success path |