### PR TITLE
fix: raise container memory limits for worker/api/lensnode to prevent OOM

### DIFF
--- a/deploy/bootstrap/gateway-install-lensnode-sidecar.sh
+++ b/deploy/bootstrap/gateway-install-lensnode-sidecar.sh
@@ -259,7 +259,7 @@ ${sentry_volume_block}
     tmpfs:
       # Hide the host Agent's same-filesystem deletion quarantine from LensNode.
       - ${HFL_GATEWAY_TRASH_ROOT}:mode=0700
-    mem_limit: 512m
+    mem_limit: 1536m
     cpus: 0.50
 EOF
 	)

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -114,7 +114,7 @@ services:
         condition: service_healthy
     command: worker
     stop_grace_period: 600s
-    mem_limit: 512m
+    mem_limit: 1g
     cpus: 0.50
     healthcheck:
       test:

--- a/deploy/installer/sourcelens/docker-compose.template.yml
+++ b/deploy/installer/sourcelens/docker-compose.template.yml
@@ -38,7 +38,7 @@ services:
       redis:
         condition: service_healthy
     command: gunicorn
-    mem_limit: 512m
+    mem_limit: 1g
     cpus: 0.50
     healthcheck:
       test: ["CMD", "curl", "-f", "http://127.0.0.1:8000/health"]
@@ -137,7 +137,7 @@ services:
     depends_on:
       api:
         condition: service_healthy
-    mem_limit: 512m
+    mem_limit: 1536m
     cpus: 0.50
 # HFL_EMBED_LENSNODE_SERVICE_END
 


### PR DESCRIPTION
## Background

Production hit repeated OOM kills on Aug 18-19 (30+ total). Three containers kept being killed under the 512 MiB limit:

| Container | Killed process | Root cause |
|---|---|---|
| `hyperfilelens-worker-1` (EE worker) | kopia + celery | celery baseline ~440MB (3 processes) + kopia subprocess 160-260MB exceeded 512 MiB |
| `hyperfilelens-sourcelens-api-1` | uvicorn (--workers 1) | single-process base ~250MB + LensNode WebSocket report spikes pushed to ~500MB |
| LensNode (lensnode) | lensnode | restoring 2.3GB workspace + embedding/codegraph rebuild, V8 RSS 376MB+ |

The same limits were already applied to production as a stopgap and verified. This PR bakes the adjustment into the codebase so it applies to all environments.

## Changes

| File | Service | Change |
|---|---|---|
| `deploy/docker-compose.yml` | EE `worker` | `512m` -> `1g` |
| `deploy/installer/sourcelens/docker-compose.template.yml` | sourcelens `api` (gunicorn) | `512m` -> `1g` |
| same | `local-lensnode` | `512m` -> `1536m` |
| `deploy/bootstrap/gateway-install-lensnode-sidecar.sh` | `lensnode` (gateway embedded path) | `512m` -> `1536m` |

## Unchanged (with rationale)

- sourcelens `worker` (celery): stays `512m` - observed peak only 264MB, has `--max-memory-per-child=256000`, 0 OOM kills
- Other services (nginx/redis/postgres/scheduler etc.) untouched

## Compliance

- Illegal `mem_limit` values `(64|320|384|448)m` check passes; `1g`/`1536m` are not in the rejection list
- `128m/256m/512m` still present on other services, satisfying release contract required values