### PR TITLE
fix(saas-deploy): make asset validation compatible with Python 3.8

### DIFF
--- a/.github/scripts/remote-saas-deploy.sh
+++ b/.github/scripts/remote-saas-deploy.sh
@@ -234,7 +234,7 @@ prefixes = {
 }[kind]
 ancestors = {pathlib.PurePosixPath(".asset-kind")}
 for prefix in prefixes:
-    ancestors.update(prefix.parents[:-1])
+    ancestors.update(list(prefix.parents)[:-1])
     ancestors.add(prefix)
 
 seen_prefixes = set()


### PR DESCRIPTION
## Problem

The `HFL - Enterprise SaaS Upgrade` workflow failed on PROD while TEST passed (run `32265945416`). The `Deploy · PROD` job failed 53s in, at the `Upgrade target from Candidate` step, while running the asset validation heredoc in `.github/scripts/remote-saas-deploy.sh`:

```
File "<stdin>", line 18, in <module>
File "/usr/lib/python3.8/pathlib.py", line 620, in __getitem__
    if idx < 0 or idx >= len(self):
TypeError: '<' not supported between instances of 'slice' and 'int'
```

## Root cause

`pathlib.Path.parents` did not support slice access until Python 3.9 (its `_PathParents.__getitem__` only accepted int indexes in 3.8). Line 237 used `prefix.parents[:-1]`, so the validation crashed on the PROD host (system Python 3.8) while the TEST host (Python >= 3.9) succeeded.

## Fix

Wrap `parents` in `list()` before slicing — `list(prefix.parents)[:-1]` — which is semantically identical on Python 3.8 and 3.9+.

## Verification

- Grepped the script for other `parents` usages and other 3.8-incompatible syntax (walrus, match/case, etc.): none.
- Behavior is identical across Python 3.8/3.9+: excludes the final ancestor (`.`) and keeps intermediate ancestor dirs for the allowlist.