### PR TITLE
fix(frontend): prevent white screen when clearing S3 bucket selector (#678)

### DIFF
--- a/src/frontend/src/lib/s3RepositoryName.ts
+++ b/src/frontend/src/lib/s3RepositoryName.ts
@@ -1,6 +1,6 @@
 export function buildS3RepositoryName(platformName: string | undefined, bucket: string): string {
   const prefix = (platformName || '').trim()
-  const bucketName = bucket.trim()
+  const bucketName = (bucket || '').trim()
   if (!prefix) return ''
   return bucketName ? `${prefix}(${bucketName})` : prefix
 }

--- a/src/frontend/src/pages/node/AddS3Repo.vue
+++ b/src/frontend/src/pages/node/AddS3Repo.vue
@@ -160,8 +160,13 @@ function buildAutoRepoName(): string {
 function syncAutoRepoName() {
   if (repoNameManuallyEdited.value) return
   syncingRepoName = true
-  repoName.value = buildAutoRepoName()
-  syncingRepoName = false
+  try {
+    repoName.value = buildAutoRepoName()
+  } catch (err) {
+    console.error('Failed to sync auto repo name:', err)
+  } finally {
+    syncingRepoName = false
+  }
 }
 
 function onRepoNameInput() {
@@ -932,6 +937,7 @@ function handleBack() {
                           @focus="loadBucketsForSelect"
                           @visible-change="(open) => open && loadBucketsForSelect()"
                           @change="clearFieldError('bucket')"
+                          @clear="bucket = ''"
                         >
                           <ElOption
                             v-for="item in bucketSelectOptions"


### PR DESCRIPTION
## Summary

Fixes #678 — When a user clicks the X (clear) button on the bucket name ElSelect while configuring an S3 storage repository, the component crashes and shows a white screen.

## Root Cause

Element Plus's `ElSelect` with `clearable` sets the v-model to `undefined` when cleared, instead of an empty string. This triggers a watcher that calls `buildS3RepositoryName`, which calls `bucket.trim()` on `undefined`, throwing a `TypeError` that crashes the Vue component.

## Changes

1. **s3RepositoryName.ts** — Defend `bucket` parameter with `(bucket || '')`, consistent with the existing defense on `platformName`
2. **AddS3Repo.vue** — Wrap `syncAutoRepoName` watcher callback in try/catch to prevent any future watcher errors from crashing the component
3. **AddS3Repo.vue** — Add `@clear="bucket = ''"` handler on the ElSelect to ensure the cleared value is an empty string rather than undefined