### PR TITLE
fix(storage): harden repository operations and credential validation

### DIFF
--- a/language-packs/packs/zh-hans/frontend/messages.json
+++ b/language-packs/packs/zh-hans/frontend/messages.json
@@ -4181,6 +4181,7 @@
       "credentialMask": "已保存的密钥,如需更换请点击「重写」",
       "saving": "正在保存…",
       "savingAndVerifying": "验证鉴权并保存…",
+      "verificationContinues": "凭据验证仍在后台运行。再次编辑此仓库前，请在任务页面查看最终结果。",
       "verifyingAuth": "正在验证鉴权信息…",
       "verifySuccess": "鉴权验证通过,可访问 Bucket {bucket}",
       "verifyFailed": "鉴权验证失败,无法访问 Bucket",

--- a/language-packs/packs/zh-hans/frontend/source-lock.json
+++ b/language-packs/packs/zh-hans/frontend/source-lock.json
@@ -4109,6 +4109,7 @@
   "repositoriesPage.editS3Repo.credentialMask": "75db0dd9e3762cc61cf833f189c450ebe8dec4f50ac007ff0fce39be46617c1a",
   "repositoriesPage.editS3Repo.saving": "4e65400e023b52a32ff8464e0df26b7428dae0c6d38c272e2a4529fc9c37c5b6",
   "repositoriesPage.editS3Repo.savingAndVerifying": "bfb42c0c97fbae0abbd44c130fa59d776b5c4a016382f9c3cfa535335c5448d0",
+  "repositoriesPage.editS3Repo.verificationContinues": "70563cf0874ff2f9157c4916318d4228feb43e6b998b0fcf1195f0639fa30d7d",
   "repositoriesPage.editS3Repo.verifyingAuth": "6f26c0f7812af440671eb20763421015a28d1f7011509f0e1d19fd282dcc5162",
   "repositoriesPage.editS3Repo.verifySuccess": "02df401f651b5ae98dd56bcb593dc90651b5ee3ef27e0cf29c8d3f74ad0cdb07",
   "repositoriesPage.editS3Repo.verifyFailed": "ef0173e774d44783bb08e60c870d7fbe2dc65ede2d717034bbe692155319524a",

--- a/src/backend/apps/storage/migrations/0019_repository_credential_rotation.py
+++ b/src/backend/apps/storage/migrations/0019_repository_credential_rotation.py
@@ -1,0 +1,29 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("storage", "0018_repair_bound_nas_location_owners"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="repositorytask",
+            name="operation_type",
+            field=models.CharField(
+                choices=[
+                    ("maintenance.quick", "Quick maintenance"),
+                    ("maintenance.full", "Full maintenance"),
+                    ("cleanup.target", "Delete subrepository"),
+                    ("cleanup.repository", "Delete repository"),
+                    ("check", "Check"),
+                    ("credential.rotate", "Update Credentials"),
+                    ("create.repository", "Create repository"),
+                    ("repair.bind", "Bind proxy"),
+                    ("repair.remount", "Remount repository"),
+                ],
+                db_index=True,
+                max_length=64,
+            ),
+        ),
+    ]

--- a/src/backend/apps/storage/repositories/models.py
+++ b/src/backend/apps/storage/repositories/models.py
@@ -436,6 +436,7 @@ class RepositoryTask(models.Model):
         CLEANUP_TARGET = "cleanup.target", "Delete subrepository"
         CLEANUP_REPOSITORY = "cleanup.repository", "Delete repository"
         CHECK = "check", "Check"
+        CREDENTIAL_ROTATE = "credential.rotate", "Update Credentials"
         CREATE_REPOSITORY = "create.repository", "Create repository"
         REPAIR_BIND = "repair.bind", "Bind proxy"
         REPAIR_REMOUNT = "repair.remount", "Remount repository"

--- a/src/backend/apps/storage/repositories/serializers.py
+++ b/src/backend/apps/storage/repositories/serializers.py
@@ -19,6 +19,7 @@ from apps.storage.services.internal.repository_access import (
     repository_uses_bound_proxy,
 )
 from apps.storage.services.internal.repository_secrets import (
+    SECRET_CONFIG_FIELDS,
     credential_hint,
     sanitize_repository_config,
 )
@@ -399,7 +400,17 @@ class RepositoryWriteSerializer(serializers.ModelSerializer):
 
     def validate(self, attrs):
         instance = self.instance
-        incoming_config = attrs.get("config") or {}
+        incoming_config = dict(attrs.get("config") or {})
+        inline_secrets = {
+            key: incoming_config.pop(key)
+            for key in SECRET_CONFIG_FIELDS
+            if key in incoming_config
+        }
+        if inline_secrets:
+            credential_payload = dict(inline_secrets)
+            credential_payload.update(attrs.get("credential_payload") or {})
+            attrs["credential_payload"] = credential_payload
+            attrs["config"] = incoming_config
         if instance is not None and self.context.get("request_action") in {
             "update",
             "partial_update",
@@ -788,12 +799,21 @@ class RepositoryWriteSerializer(serializers.ModelSerializer):
         )
 
     def update(self, instance, validated_data):
+        request = self.context.get("request")
+        requested_by = getattr(request, "user", None) if request is not None else None
         credential_payload = validated_data.get("credential_payload")
         incoming_config = validated_data.get("config")
         if credential_payload is None and isinstance(incoming_config, dict):
             if any(
                 key in incoming_config
-                for key in ("secret_access_key", "smb_password", "kopia_password")
+                for key in (
+                    "access_key_id",
+                    "secret_access_key",
+                    "kopia_password",
+                    "s3_url_style",
+                    "use_tls",
+                    "smb_password",
+                )
             ):
                 credential_payload = {}
         return update_repository(
@@ -806,6 +826,7 @@ class RepositoryWriteSerializer(serializers.ModelSerializer):
             bind_node_type=validated_data.get("bind_node_type"),
             bind_node_id=validated_data.get("bind_node_id"),
             credential_payload=credential_payload,
+            requested_by=requested_by,
         )
 
 

--- a/src/backend/apps/storage/repositories/views.py
+++ b/src/backend/apps/storage/repositories/views.py
@@ -42,7 +42,10 @@ from apps.storage.selectors.interface import (
     get_effective_storage_provider,
     list_repositories,
 )
-from apps.storage.services.interface import check_repository, retry_repository_create
+from apps.storage.services.interface import retry_repository_create
+from apps.storage.services.internal.repository_check import (
+    enqueue_repository_check_task,
+)
 from apps.storage.services.internal.nas_repair import (
     NASRepositoryBusyError,
     repair_nas_repository,
@@ -510,6 +513,19 @@ class RepositoryViewSet(viewsets.ModelViewSet):
         serializer.is_valid(raise_exception=True)
         repository = serializer.save()
         out = RepositorySerializer(repository, context=self.get_serializer_context())
+        credential_rotation = getattr(
+            repository,
+            "credential_rotation_task",
+            None,
+        )
+        if credential_rotation is not None:
+            return Response(
+                {
+                    "repository": out.data,
+                    "task": TaskSerializer(credential_rotation.task).data,
+                },
+                status=status.HTTP_202_ACCEPTED,
+            )
         return Response(out.data, status=status.HTTP_200_OK)
 
     def destroy(self, request, *args, **kwargs):
@@ -672,15 +688,20 @@ class RepositoryViewSet(viewsets.ModelViewSet):
 
     @action(detail=True, methods=["post"])
     def check(self, request, pk=None):
-        repository = check_repository(repository=self.get_object())
+        repository = self.get_object()
+        try:
+            repository_task = enqueue_repository_check_task(
+                repository=repository,
+                requested_by=request.user,
+            )
+        except DjangoValidationError as exc:
+            raise ValidationError(_django_validation_detail(exc)) from exc
         return Response(
             {
                 "repository": RepositorySerializer(repository).data,
-                "health": repository.health,
-                "task_id": None,
-                "message": "",
+                "task": TaskSerializer(repository_task.task).data,
             },
-            status=status.HTTP_200_OK,
+            status=status.HTTP_202_ACCEPTED,
         )
 
     @action(detail=True, methods=["post"], url_path="retry-initialization")

--- a/src/backend/apps/storage/services/interface.py
+++ b/src/backend/apps/storage/services/interface.py
@@ -331,8 +331,27 @@ def update_repository(
     bind_node_type: str | None = None,
     bind_node_id: int | None = None,
     credential_payload: dict | None = None,
+    requested_by=None,
 ) -> Repository:
     _validate_repository_update_status(repository)
+    if repository.repo_type == Repository.Type.S3 and credential_payload is not None:
+        from apps.storage.services.internal.repository_credential_rotation import (
+            enqueue_repository_credential_rotation,
+        )
+
+        try:
+            repository_task = enqueue_repository_credential_rotation(
+                repository=repository,
+                name=name,
+                config=config,
+                credential_payload=credential_payload,
+                requested_by=requested_by,
+            )
+        except ValidationError as exc:
+            raise DRFValidationError({"detail": exc.messages}) from exc
+        repository.credential_rotation_task = repository_task
+        return repository
+
     with transaction.atomic():
         repository = Repository.objects.select_for_update().get(
             pk=repository.id,

--- a/src/backend/apps/storage/services/internal/kopia_cli.py
+++ b/src/backend/apps/storage/services/internal/kopia_cli.py
@@ -47,6 +47,16 @@ class KopiaExecutionLeaseLost(KopiaCliError):
     pass
 
 
+class KopiaProcessTerminatedError(KopiaCliError):
+    """Kopia exited because an external signal terminated the process."""
+
+    def __init__(self, *, signal_number: int):
+        self.signal_number = int(signal_number)
+        super().__init__(
+            f"Kopia process was terminated by signal {self.signal_number}."
+        )
+
+
 class KopiaControlDecision(StrEnum):
     CONTINUE = "continue"
     CANCEL = "cancel"
@@ -373,6 +383,10 @@ def _run_repository_command_unlocked(
             stdout,
             stderr,
         )
+        if result.returncode < 0:
+            raise KopiaProcessTerminatedError(
+                signal_number=abs(result.returncode),
+            )
         if result.returncode == 0 and args[:3] in (
             ["repository", "create", "s3"],
             ["repository", "connect", "s3"],

--- a/src/backend/apps/storage/services/internal/repository_agent_operation.py
+++ b/src/backend/apps/storage/services/internal/repository_agent_operation.py
@@ -110,6 +110,69 @@ def _related_node_task(
     )
 
 
+def resolve_existing_repository_agent_operation(
+    *,
+    repository_task: RepositoryTask,
+    correlation_type: str,
+    timeout_seconds: int,
+) -> RepositoryAgentOperationResult | None:
+    """Resolve one already-dispatched Agent operation without dispatching.
+
+    A destructive parent must observe the durable child task through every
+    state transition. Querying terminal and in-flight states separately leaves
+    a race where the Agent can delete ownership evidence between queries.
+    """
+    remote_query = NodeTask.objects.filter(
+        organization_id=repository_task.repository.organization_id,
+        kind="repository.operation",
+        correlation_type=correlation_type,
+        correlation_id=str(repository_task.task.task_uuid),
+    )
+    if repository_task.remote_task_id:
+        remote_query = remote_query.filter(pk=repository_task.remote_task_id)
+    node_task = remote_query.order_by("-created_at", "-id").first()
+    if node_task is None:
+        if repository_task.remote_task_id:
+            raise RepositoryAgentOperationStateUnknown(
+                "The durable Agent task referenced by the repository operation "
+                "could not be found."
+            )
+        return None
+
+    payload = node_task.payload if isinstance(node_task.payload, dict) else {}
+    if (
+        str(payload.get("repository_id") or "") != str(repository_task.repository_id)
+        or payload.get("operation_type") != repository_task.operation_type
+    ):
+        raise RepositoryAgentOperationStateUnknown(
+            "The durable Agent task does not match this repository operation."
+        )
+
+    recovered = repository_task.remote_task_id is None
+    if repository_task.remote_task_id != node_task.id:
+        RepositoryTask.objects.filter(pk=repository_task.id).update(
+            remote_task_id=node_task.id
+        )
+        repository_task.remote_task_id = node_task.id
+    if recovered:
+        record_recovery_decision(
+            task=repository_task.task,
+            plan=RecoveryPlan(
+                decision=RecoveryDecision.RESUME,
+                reason="Recovered the durable Agent task after control-plane interruption.",
+                evidence={
+                    "node_task_id": str(node_task.id),
+                    "node_task_status": node_task.status,
+                    "correlation_type": correlation_type,
+                },
+            ),
+        )
+    return _resolve_node_task_result(
+        node_task=node_task,
+        timeout_seconds=timeout_seconds,
+    )
+
+
 def resolve_or_dispatch_repository_agent_operation(
     *,
     repository_task: RepositoryTask,
@@ -162,6 +225,17 @@ def resolve_or_dispatch_repository_agent_operation(
             ),
         )
 
+    return _resolve_node_task_result(
+        node_task=node_task,
+        timeout_seconds=timeout_seconds,
+    )
+
+
+def _resolve_node_task_result(
+    *,
+    node_task: NodeTask,
+    timeout_seconds: int,
+) -> RepositoryAgentOperationResult:
     if node_task.status in {NodeTask.Status.PENDING, NodeTask.Status.RUNNING}:
         deadline = node_task.created_at + timedelta(
             seconds=max(1, int(timeout_seconds))

--- a/src/backend/apps/storage/services/internal/repository_check.py
+++ b/src/backend/apps/storage/services/internal/repository_check.py
@@ -1,0 +1,278 @@
+"""Durable, Worker-owned repository health checks."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from django.core.exceptions import ValidationError
+from django.db import transaction
+from django.utils import timezone
+
+from apps.storage.repositories.models import (
+    Repository,
+    RepositoryExecutionTarget,
+    RepositoryTask,
+)
+from apps.storage.services.internal.repository_health import (
+    is_repository_ownership_failure,
+    probe_repository_health,
+)
+from apps.storage.services.internal.repository_execution_lock import (
+    repository_execution_lock,
+)
+from apps.storage.services.internal.repository_initializer import (
+    RepositoryInitializationError,
+)
+from apps.storage.services.internal.repository_location import (
+    invalidate_repository_location_ownership,
+)
+from apps.storage.services.internal.repository_secrets import (
+    resolve_repository_secrets,
+    scrub_secrets,
+    secret_values_for_scrub,
+)
+from apps.storage.services.internal.repository_usage import sync_repository_usage
+from apps.storage.services.internal.s3_validation_errors import (
+    classify_s3_validation_error,
+)
+from apps.task.models import Task, TaskResource, TaskStep
+from apps.task.services.interface import complete_task, create_task, start_task
+
+
+CHECK_STEPS = (
+    "check_storage_access",
+    "verify_repository",
+    "refresh_repository_usage",
+    "finalize_repository_check",
+)
+_ACTIVE_STATUSES = (Task.Status.PENDING, Task.Status.RUNNING)
+
+
+def active_repository_check_task(repository: Repository) -> RepositoryTask | None:
+    return (
+        RepositoryTask.objects.filter(
+            repository=repository,
+            operation_type=RepositoryTask.OperationType.CHECK,
+            task__status__in=_ACTIVE_STATUSES,
+        )
+        .select_related("task")
+        .order_by("-created_at", "-id")
+        .first()
+    )
+
+
+def enqueue_repository_check_task(
+    *,
+    repository: Repository,
+    requested_by=None,
+) -> RepositoryTask:
+    """Accept one idempotent repository check and dispatch it after commit."""
+    active = active_repository_check_task(repository)
+    if active is not None:
+        return active
+
+    with transaction.atomic():
+        locked = Repository.objects.select_for_update().get(
+            pk=repository.id,
+            organization_id=repository.organization_id,
+        )
+        active = active_repository_check_task(locked)
+        if active is not None:
+            return active
+        conflicting = (
+            RepositoryTask.objects.filter(
+                repository=locked,
+                task__status__in=_ACTIVE_STATUSES,
+            )
+            .select_related("task")
+            .order_by("created_at", "id")
+            .first()
+        )
+        if conflicting is not None:
+            raise ValidationError(
+                "Repository already has an active operation. Wait for it to finish."
+            )
+        if locked.status != Repository.Status.CREATED:
+            raise ValidationError("Only a created repository can be checked.")
+
+        task = create_task(
+            organization_id=locked.organization_id,
+            task_type=Task.Type.REPOSITORY_OPERATION,
+            display_name=f"Check Repository · {locked.name}",
+            trigger_type=Task.TriggerType.MANUAL,
+            request_payload={
+                "repository_id": locked.id,
+                "operation_type": RepositoryTask.OperationType.CHECK,
+            },
+            resources=[
+                {
+                    "resource_type": TaskResource.Type.REPOSITORY,
+                    "resource_id": locked.id,
+                    "is_primary": True,
+                }
+            ],
+            steps=list(CHECK_STEPS),
+        )
+        repository_task = RepositoryTask.objects.create(
+            task=task,
+            repository=locked,
+            operation_type=RepositoryTask.OperationType.CHECK,
+            owner_type=RepositoryExecutionTarget.OwnerType.CONTROLLER,
+            owner_identity="hfl-check@worker",
+            requested_by_id=getattr(requested_by, "id", None),
+        )
+        transaction.on_commit(
+            lambda: _dispatch_repository_operation(repository_task.id)
+        )
+        return repository_task
+
+
+def run_repository_check_task(*, repository_task_id: int) -> dict[str, Any]:
+    """Run a repository check in the Worker and persist its visible result."""
+    with repository_execution_lock(
+        operation="repository-check",
+        operation_id=repository_task_id,
+    ) as acquired:
+        if not acquired:
+            return {
+                "status": "locked",
+                "repository_task_id": repository_task_id,
+                "idempotent": True,
+            }
+        return _run_repository_check_task_locked(
+            repository_task_id=repository_task_id
+        )
+
+
+def _run_repository_check_task_locked(*, repository_task_id: int) -> dict[str, Any]:
+    repository_task = RepositoryTask.objects.select_related("task", "repository").get(
+        pk=repository_task_id
+    )
+    task = repository_task.task
+    if repository_task.operation_type != RepositoryTask.OperationType.CHECK:
+        raise ValidationError("Repository task is not a check operation.")
+    if task.status in {
+        Task.Status.SUCCESS,
+        Task.Status.FAILED,
+        Task.Status.CANCELLED,
+        Task.Status.TIMEOUT,
+    }:
+        return task.result_payload or {"status": task.status}
+    if task.status == Task.Status.PENDING:
+        start_task(task_uuid=task.task_uuid, organization_id=task.organization_id)
+
+    repository = repository_task.repository
+    health_persisted = False
+    try:
+        _set_step(task, "check_storage_access", TaskStep.Status.RUNNING, 10)
+        health = probe_repository_health(repository)
+        _set_step(task, "check_storage_access", TaskStep.Status.SUCCESS, 35)
+        _set_step(task, "verify_repository", TaskStep.Status.SUCCESS, 60)
+
+        repository.health = health
+        repository.health_failures = 0
+        repository.last_checked_at = timezone.now()
+        repository.save(
+            update_fields=[
+                "health",
+                "health_failures",
+                "last_checked_at",
+                "updated_at",
+            ]
+        )
+        health_persisted = True
+        _set_step(
+            task,
+            "refresh_repository_usage",
+            TaskStep.Status.RUNNING,
+            75,
+        )
+        sync_repository_usage(repository)
+        _set_step(
+            task,
+            "refresh_repository_usage",
+            TaskStep.Status.SUCCESS,
+            95,
+        )
+        _set_step(
+            task,
+            "finalize_repository_check",
+            TaskStep.Status.SUCCESS,
+            100,
+        )
+        complete_task(
+            task_uuid=task.task_uuid,
+            organization_id=task.organization_id,
+            status=Task.Status.SUCCESS,
+            result_payload={
+                "status": "success",
+                "repository_id": repository.id,
+                "health": repository.health,
+                "last_checked_at": repository.last_checked_at.isoformat(),
+            },
+        )
+        return {"status": "success", "repository_task_id": repository_task.id}
+    except Exception as exc:
+        if not health_persisted:
+            if is_repository_ownership_failure(exc):
+                invalidate_repository_location_ownership(repository)
+            Repository.objects.filter(pk=repository.id).update(
+                health=Repository.Health.OFFLINE,
+                last_checked_at=timezone.now(),
+            )
+        current_step = task.current_step or CHECK_STEPS[0]
+        _set_step(task, current_step, TaskStep.Status.FAILED, int(task.progress or 0))
+        error_code = "REPOSITORY_CHECK_FAILED"
+        message = _safe_error_message(repository, exc)
+        if isinstance(exc, RepositoryInitializationError):
+            failure = classify_s3_validation_error(exc, operation="bucket_access")
+            error_code = failure.code
+            message = failure.message
+        complete_task(
+            task_uuid=task.task_uuid,
+            organization_id=task.organization_id,
+            status=Task.Status.FAILED,
+            progress=int(task.progress or 0),
+            error_code=error_code,
+            error_message=message,
+        )
+        return {
+            "status": "failed",
+            "repository_task_id": repository_task.id,
+            "error_code": error_code,
+            "error": message,
+        }
+
+
+def _set_step(task: Task, step_name: str, status: str, progress: int) -> None:
+    from apps.storage.services.internal.repository_operations import set_task_step
+
+    set_task_step(task, step_name, status=status, progress=progress)
+
+
+def _dispatch_repository_operation(repository_task_id: int) -> None:
+    from apps.storage.tasks import execute_repository_operation
+
+    execute_repository_operation.apply_async(
+        kwargs={"repository_task_id": repository_task_id}
+    )
+
+
+def _safe_error_message(repository: Repository, exc: Exception) -> str:
+    try:
+        secrets_payload = resolve_repository_secrets(repository)
+    except Exception:
+        secrets_payload = {}
+    return str(
+        scrub_secrets(
+            str(exc),
+            extra_values=secret_values_for_scrub(repository, secrets_payload),
+        )
+    )
+
+
+__all__ = [
+    "active_repository_check_task",
+    "enqueue_repository_check_task",
+    "run_repository_check_task",
+]

--- a/src/backend/apps/storage/services/internal/repository_cleanup.py
+++ b/src/backend/apps/storage/services/internal/repository_cleanup.py
@@ -31,6 +31,7 @@ from apps.storage.services.internal.repository_agent_operation import (
     RepositoryAgentOperationError,
     RepositoryAgentOperationResult,
     RepositoryAgentOperationStateUnknown,
+    resolve_existing_repository_agent_operation,
     resolve_or_dispatch_repository_agent_operation,
 )
 from apps.storage.services.internal.repository_secrets import (
@@ -1586,15 +1587,35 @@ def _execute_s3_repository_cleanup_locked(
     """Advance S3 cleanup while holding the cross-Controller execution fence."""
     repository = repository_task.repository
     task = repository_task.task
-    # A Controller restart may happen after the Agent has deleted the marker
-    # and all physical objects, but before the parent task persisted its
-    # terminal state.  Resolve the durable child result first so that this
-    # already-completed operation is not mistaken for an ownership failure.
-    completed_agent_result = _completed_s3_agent_cleanup_result(repository_task)
-    if completed_agent_result is not None:
-        _remove_controller_repository_state(repository.id)
-        completed_agent_result.setdefault("executor", "agent")
-        return completed_agent_result
+    # Resolve one durable child snapshot before reading ownership state. The
+    # Agent may legitimately delete the marker while its task is still
+    # running, so terminal and in-flight states must never be queried
+    # separately.
+    try:
+        existing_operation = resolve_existing_repository_agent_operation(
+            repository_task=repository_task,
+            correlation_type="repository_cleanup",
+            timeout_seconds=21600,
+        )
+    except RepositoryAgentOperationStateUnknown:
+        raise
+    except RepositoryAgentOperationError as exc:
+        result = exc.result
+        if result.get("failure_class") == "ownership":
+            raise ValidationError(
+                result.get("error")
+                or str(exc)
+                or "S3 repository ownership could not be verified."
+            ) from exc
+        _persist_s3_cleanup_agent_attempted(task, result=result)
+    else:
+        if existing_operation is not None:
+            if existing_operation.waiting:
+                return existing_operation
+            result = _validated_s3_agent_cleanup_result(existing_operation.result)
+            _remove_controller_repository_state(repository.id)
+            result.setdefault("executor", "agent")
+            return result
     # The ownership marker is the destructive-operation authority. A healthy
     # Kopia connection is needed only to adopt a legacy repository that has no
     # marker yet; a damaged but correctly owned repository must remain
@@ -1646,11 +1667,7 @@ def _execute_s3_repository_cleanup_locked(
         else:
             if operation.waiting:
                 return operation
-            result = dict(operation.result or {})
-            if not result.get("cleanup_complete", False):
-                raise ValidationError(
-                    "S3 Agent cleanup did not prove that the repository prefix is empty."
-                )
+            result = _validated_s3_agent_cleanup_result(operation.result)
             _remove_controller_repository_state(repository.id)
             result.setdefault("executor", "agent")
             return result
@@ -1697,51 +1714,22 @@ def _execute_s3_repository_cleanup_locked(
     }
 
 
-def _completed_s3_agent_cleanup_result(
-    repository_task: RepositoryTask,
-) -> dict[str, Any] | None:
-    """Return a durable successful Agent result for an interrupted parent.
-
-    The remote task is scoped to this repository operation and organization;
-    only the Agent's explicit, complete S3 cleanup attestation is accepted.
-    This is an idempotency/recovery path, not a new authorization path: a
-    fresh cleanup still performs the Controller ownership proof before dispatch.
-    """
-    remote_task_id = repository_task.remote_task_id
-    remote_query = NodeTask.objects.filter(
-        organization_id=repository_task.repository.organization_id,
-        kind="repository.operation",
-        correlation_type="repository_cleanup",
-        correlation_id=str(repository_task.task.task_uuid),
-        status=NodeTask.Status.SUCCESS,
-    )
-    if remote_task_id:
-        remote_query = remote_query.filter(pk=remote_task_id)
-    remote = remote_query.order_by("-created_at", "-id").first()
-    if (
-        remote is None
-        or not isinstance(remote.payload, dict)
-        or not isinstance(remote.result, dict)
-    ):
-        return None
-    persisted_repository_id = _positive_int(remote.payload.get("repository_id"))
-    if persisted_repository_id != repository_task.repository_id:
-        return None
-    if remote.payload.get("operation_type") != repository_task.operation_type:
-        return None
-    result = dict(remote.result)
+def _validated_s3_agent_cleanup_result(result_payload: object) -> dict[str, Any]:
+    """Validate the Agent's terminal attestation before finalizing cleanup."""
+    if not isinstance(result_payload, dict):
+        raise RepositoryAgentOperationStateUnknown(
+            "S3 Agent cleanup returned an invalid terminal result."
+        )
+    result = dict(result_payload)
     if not (
         result.get("ownership_verified") is True
         and result.get("cleanup_complete") is True
         and result.get("physical_cleanup") == "deleted"
         and result.get("scope") == "s3_prefix"
     ):
-        return None
-    if repository_task.remote_task_id != remote.id:
-        RepositoryTask.objects.filter(pk=repository_task.id).update(
-            remote_task_id=remote.id
+        raise RepositoryAgentOperationStateUnknown(
+            "S3 Agent cleanup did not provide a complete deletion attestation."
         )
-        repository_task.remote_task_id = remote.id
     return result
 
 

--- a/src/backend/apps/storage/services/internal/repository_credential_rotation.py
+++ b/src/backend/apps/storage/services/internal/repository_credential_rotation.py
@@ -1,0 +1,466 @@
+"""Durable S3 credential verification and atomic activation."""
+
+from __future__ import annotations
+
+from copy import copy
+from typing import Any
+
+from django.core.exceptions import ValidationError
+from django.db import transaction
+
+from apps.storage.repositories.models import (
+    Credential,
+    Repository,
+    RepositoryExecutionTarget,
+    RepositoryTask,
+)
+from apps.storage.services.internal.repository_initializer import (
+    RepositoryInitializationError,
+    check_s3_repository,
+)
+from apps.storage.services.internal.repository_execution_lock import (
+    repository_execution_lock,
+)
+from apps.storage.services.internal.repository_secrets import (
+    SECRET_CONFIG_FIELDS,
+    build_credential_metadata,
+    build_secret_payload,
+    resolve_repository_secrets,
+    sanitize_repository_config,
+    scrub_secrets,
+    secret_values_for_scrub,
+)
+from apps.storage.services.internal.repository_usage import (
+    enqueue_repository_usage_refresh,
+)
+from apps.storage.services.internal.s3_validation_errors import (
+    classify_s3_validation_error,
+)
+from apps.task.models import Task, TaskResource, TaskStep
+from apps.task.services.interface import complete_task, create_task, start_task
+
+
+ROTATION_STEPS = (
+    "prepare_candidate_credentials",
+    "verify_storage_access",
+    "verify_repository_identity",
+    "activate_credentials",
+)
+_ACTIVE_STATUSES = (Task.Status.PENDING, Task.Status.RUNNING)
+_ROTATION_METADATA_KEY = "repository_credential_rotation"
+
+
+def enqueue_repository_credential_rotation(
+    *,
+    repository: Repository,
+    name: str | None,
+    config: dict | None,
+    credential_payload: dict,
+    requested_by=None,
+) -> RepositoryTask:
+    """Stage encrypted credentials and enqueue deep verification."""
+    if repository.repo_type != Repository.Type.S3:
+        raise ValidationError("Credential rotation is only supported for S3.")
+
+    with transaction.atomic():
+        locked = Repository.objects.select_for_update().get(
+            pk=repository.id,
+            organization_id=repository.organization_id,
+        )
+        conflicting = (
+            RepositoryTask.objects.filter(
+                repository=locked,
+                task__status__in=_ACTIVE_STATUSES,
+            )
+            .select_related("task")
+            .order_by("created_at", "id")
+            .first()
+        )
+        if conflicting is not None:
+            raise ValidationError(
+                "Repository already has an active operation. Wait for it to finish."
+            )
+        if locked.status != Repository.Status.CREATED:
+            raise ValidationError(
+                "Only a created repository can update its credentials."
+            )
+
+        incoming_config = dict(config or {})
+        merged_config = {**(locked.config or {}), **incoming_config}
+        candidate_credential_payload = dict(credential_payload or {})
+        for key in SECRET_CONFIG_FIELDS:
+            if key not in candidate_credential_payload and key in incoming_config:
+                candidate_credential_payload[key] = incoming_config[key]
+        desired_config = sanitize_repository_config(merged_config)
+        candidate = _create_candidate_credential(
+            repository=locked,
+            desired_name=name if name is not None else locked.name,
+            desired_config=desired_config,
+            credential_payload=candidate_credential_payload,
+        )
+        task = create_task(
+            organization_id=locked.organization_id,
+            task_type=Task.Type.REPOSITORY_OPERATION,
+            display_name=f"Update Credentials · {locked.name}",
+            trigger_type=Task.TriggerType.MANUAL,
+            request_payload={
+                "repository_id": locked.id,
+                "operation_type": RepositoryTask.OperationType.CREDENTIAL_ROTATE,
+                "candidate_credential_id": candidate.id,
+            },
+            resources=[
+                {
+                    "resource_type": TaskResource.Type.REPOSITORY,
+                    "resource_id": locked.id,
+                    "is_primary": True,
+                }
+            ],
+            steps=list(ROTATION_STEPS),
+        )
+        repository_task = RepositoryTask.objects.create(
+            task=task,
+            repository=locked,
+            operation_type=RepositoryTask.OperationType.CREDENTIAL_ROTATE,
+            owner_type=RepositoryExecutionTarget.OwnerType.CONTROLLER,
+            owner_identity="hfl-credential-rotation@worker",
+            requested_by_id=getattr(requested_by, "id", None),
+        )
+        transaction.on_commit(
+            lambda: _dispatch_repository_operation(repository_task.id)
+        )
+        return repository_task
+
+
+def run_repository_credential_rotation_task(
+    *,
+    repository_task_id: int,
+) -> dict[str, Any]:
+    """Verify a candidate credential and atomically make it authoritative."""
+    with repository_execution_lock(
+        operation="repository-credential-rotation",
+        operation_id=repository_task_id,
+    ) as acquired:
+        if not acquired:
+            return {
+                "status": "locked",
+                "repository_task_id": repository_task_id,
+                "idempotent": True,
+            }
+        return _run_repository_credential_rotation_task_locked(
+            repository_task_id=repository_task_id
+        )
+
+
+def _run_repository_credential_rotation_task_locked(
+    *,
+    repository_task_id: int,
+) -> dict[str, Any]:
+    repository_task = RepositoryTask.objects.select_related("task", "repository").get(
+        pk=repository_task_id
+    )
+    task = repository_task.task
+    if repository_task.operation_type != RepositoryTask.OperationType.CREDENTIAL_ROTATE:
+        raise ValidationError("Repository task is not a credential rotation.")
+    if task.status in {
+        Task.Status.SUCCESS,
+        Task.Status.FAILED,
+        Task.Status.CANCELLED,
+        Task.Status.TIMEOUT,
+    }:
+        return task.result_payload or {"status": task.status}
+    if task.status == Task.Status.PENDING:
+        start_task(task_uuid=task.task_uuid, organization_id=task.organization_id)
+
+    repository = repository_task.repository
+    candidate_id = int((task.request_payload or {}).get("candidate_credential_id") or 0)
+    candidate = Credential.objects.filter(
+        id=candidate_id,
+        organization_id=repository.organization_id,
+        credential_type=Credential.Type.S3,
+    ).first()
+    if repository.credential_id == candidate_id and candidate is not None:
+        return _complete_rotation_success(repository_task)
+    if candidate is None:
+        return _complete_rotation_failure(
+            repository_task,
+            error_code="REPOSITORY_CREDENTIAL_CANDIDATE_MISSING",
+            message="Candidate repository credentials are unavailable.",
+        )
+
+    secrets_payload: dict = {}
+    try:
+        secrets_payload = candidate.get_secret_payload()
+        metadata = _rotation_metadata(candidate, repository=repository)
+        _set_step(
+            task,
+            "prepare_candidate_credentials",
+            TaskStep.Status.SUCCESS,
+            20,
+        )
+        candidate_repository = copy(repository)
+        candidate_repository.name = metadata["name"]
+        candidate_repository.config = metadata["config"]
+        candidate_repository.credential_id = candidate.id
+
+        _set_step(task, "verify_storage_access", TaskStep.Status.RUNNING, 35)
+        check_s3_repository(
+            candidate_repository,
+            # The existing physical ownership marker is the authority for a
+            # credential rotation. Do not mutate the database namespace with
+            # candidate credentials before that proof succeeds.
+            refresh_namespace=False,
+            adopt_legacy_ownership=False,
+        )
+        _set_step(task, "verify_storage_access", TaskStep.Status.SUCCESS, 65)
+        _set_step(
+            task,
+            "verify_repository_identity",
+            TaskStep.Status.SUCCESS,
+            80,
+        )
+        _set_step(task, "activate_credentials", TaskStep.Status.RUNNING, 90)
+        with transaction.atomic():
+            locked = Repository.objects.select_for_update().get(
+                pk=repository.id,
+                organization_id=repository.organization_id,
+            )
+            expected_credential_id = metadata["expected_credential_id"]
+            if locked.credential_id == candidate.id:
+                pass
+            elif locked.credential_id != expected_credential_id:
+                raise ValidationError(
+                    "Repository credentials changed while verification was running."
+                )
+            elif (
+                locked.name != metadata["expected_name"]
+                or sanitize_repository_config(locked.config)
+                != metadata["expected_config"]
+            ):
+                raise ValidationError(
+                    "Repository settings changed while verification was running. "
+                    "Review the latest settings and try again."
+                )
+            else:
+                previous_credential_id = locked.credential_id
+                locked.name = metadata["name"]
+                locked.config = metadata["config"]
+                locked.credential_id = candidate.id
+                locked.save(
+                    update_fields=[
+                        "name",
+                        "config",
+                        "credential_id",
+                        "updated_at",
+                    ]
+                )
+                candidate_metadata = (
+                    dict(candidate.metadata)
+                    if isinstance(candidate.metadata, dict)
+                    else {}
+                )
+                candidate_metadata.pop(_ROTATION_METADATA_KEY, None)
+                Credential.objects.filter(
+                    id=candidate.id,
+                    organization_id=locked.organization_id,
+                ).update(metadata=candidate_metadata)
+                _delete_unused_credential(
+                    organization_id=locked.organization_id,
+                    credential_id=previous_credential_id,
+                )
+    except Exception as exc:
+        if isinstance(exc, RepositoryInitializationError):
+            failure = classify_s3_validation_error(exc, operation="bucket_access")
+            error_code = failure.code
+            message = failure.message
+        else:
+            error_code = "REPOSITORY_CREDENTIAL_ROTATION_FAILED"
+            message = str(exc)
+        safe_message = str(
+            scrub_secrets(
+                message,
+                extra_values=secret_values_for_scrub(
+                    repository,
+                    secrets_payload,
+                ),
+            )
+        )
+        live_credential_id = (
+            Repository.objects.filter(
+                pk=repository.id,
+                organization_id=repository.organization_id,
+            )
+            .values_list("credential_id", flat=True)
+            .first()
+        )
+        if live_credential_id != candidate.id:
+            candidate.delete()
+        return _complete_rotation_failure(
+            repository_task,
+            error_code=error_code,
+            message=safe_message,
+        )
+    # Credential activation is already authoritative. If task finalization is
+    # interrupted, leave the candidate intact so the durable retry path can
+    # observe the live credential and converge to success.
+    _set_step(task, "activate_credentials", TaskStep.Status.SUCCESS, 100)
+    return _complete_rotation_success(repository_task)
+
+
+def _create_candidate_credential(
+    *,
+    repository: Repository,
+    desired_name: str,
+    desired_config: dict,
+    credential_payload: dict,
+) -> Credential:
+    existing_secrets = resolve_repository_secrets(repository)
+    secret_payload = build_secret_payload(
+        repository_type=repository.repo_type,
+        config=desired_config,
+        credential_payload=credential_payload,
+        existing_secrets=existing_secrets,
+    )
+    metadata = build_credential_metadata(
+        repository_type=repository.repo_type,
+        config=desired_config,
+        credential_payload=credential_payload,
+    )
+    metadata[_ROTATION_METADATA_KEY] = {
+        "repository_id": repository.id,
+        "expected_credential_id": repository.credential_id,
+        "expected_name": repository.name,
+        "expected_config": sanitize_repository_config(repository.config),
+        "name": str(desired_name).strip(),
+        "config": desired_config,
+    }
+    candidate = Credential(
+        organization_id=repository.organization_id,
+        credential_type=Credential.Type.S3,
+        metadata=metadata,
+    )
+    candidate.set_secret_payload(secret_payload)
+    candidate.save()
+    return candidate
+
+
+def _rotation_metadata(
+    candidate: Credential,
+    *,
+    repository: Repository,
+) -> dict[str, Any]:
+    metadata = candidate.metadata if isinstance(candidate.metadata, dict) else {}
+    rotation = metadata.get(_ROTATION_METADATA_KEY)
+    if not isinstance(rotation, dict):
+        raise ValidationError("Candidate repository credentials are invalid.")
+    if int(rotation.get("repository_id") or 0) != repository.id:
+        raise ValidationError("Candidate credentials belong to another repository.")
+    config = rotation.get("config")
+    expected_config = rotation.get("expected_config")
+    if not isinstance(config, dict) or not isinstance(expected_config, dict):
+        raise ValidationError("Candidate repository configuration is invalid.")
+    return {
+        "expected_credential_id": rotation.get("expected_credential_id"),
+        "expected_name": str(rotation.get("expected_name") or repository.name),
+        "expected_config": sanitize_repository_config(expected_config),
+        "name": str(rotation.get("name") or repository.name).strip(),
+        "config": sanitize_repository_config(config),
+    }
+
+
+def _complete_rotation_success(repository_task: RepositoryTask) -> dict[str, Any]:
+    repository_task.repository.refresh_from_db()
+    _converge_rotation_steps_success(repository_task.task)
+    complete_task(
+        task_uuid=repository_task.task.task_uuid,
+        organization_id=repository_task.task.organization_id,
+        status=Task.Status.SUCCESS,
+        result_payload={
+            "status": "success",
+            "repository_id": repository_task.repository_id,
+            "credential_updated": True,
+        },
+    )
+    enqueue_repository_usage_refresh(
+        organization_id=repository_task.repository.organization_id,
+        repository_ids=[repository_task.repository_id],
+        force=True,
+        trigger="storage.repository.credential_rotation",
+    )
+    return {"status": "success", "repository_task_id": repository_task.id}
+
+
+def _converge_rotation_steps_success(task: Task) -> None:
+    """Make recovery and normal completion expose one terminal step state."""
+    TaskStep.objects.filter(
+        task=task,
+        step_name__in=ROTATION_STEPS,
+    ).exclude(status=TaskStep.Status.SUCCESS).update(
+        status=TaskStep.Status.SUCCESS,
+        progress=100,
+    )
+    task.current_step = ROTATION_STEPS[-1]
+    task.progress = 100
+    task.save(update_fields=["current_step", "progress", "updated_at"])
+
+
+def _complete_rotation_failure(
+    repository_task: RepositoryTask,
+    *,
+    error_code: str,
+    message: str,
+) -> dict[str, Any]:
+    task = repository_task.task
+    current_step = task.current_step or ROTATION_STEPS[0]
+    _set_step(task, current_step, TaskStep.Status.FAILED, int(task.progress or 0))
+    complete_task(
+        task_uuid=task.task_uuid,
+        organization_id=task.organization_id,
+        status=Task.Status.FAILED,
+        progress=int(task.progress or 0),
+        error_code=error_code,
+        error_message=message,
+    )
+    return {
+        "status": "failed",
+        "repository_task_id": repository_task.id,
+        "error_code": error_code,
+        "error": message,
+    }
+
+
+def _delete_unused_credential(
+    *,
+    organization_id: int,
+    credential_id: int | None,
+) -> None:
+    if not credential_id:
+        return
+    if Repository.objects.filter(
+        organization_id=organization_id,
+        credential_id=credential_id,
+    ).exists():
+        return
+    Credential.objects.filter(
+        organization_id=organization_id,
+        id=credential_id,
+    ).delete()
+
+
+def _set_step(task: Task, step_name: str, status: str, progress: int) -> None:
+    from apps.storage.services.internal.repository_operations import set_task_step
+
+    set_task_step(task, step_name, status=status, progress=progress)
+
+
+def _dispatch_repository_operation(repository_task_id: int) -> None:
+    from apps.storage.tasks import execute_repository_operation
+
+    execute_repository_operation.apply_async(
+        kwargs={"repository_task_id": repository_task_id}
+    )
+
+
+__all__ = [
+    "enqueue_repository_credential_rotation",
+    "run_repository_credential_rotation_task",
+]

--- a/src/backend/apps/storage/services/internal/s3_validation_errors.py
+++ b/src/backend/apps/storage/services/internal/s3_validation_errors.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import signal
 from dataclasses import dataclass
 
 from botocore.exceptions import (
@@ -14,6 +15,8 @@ from botocore.exceptions import (
 )
 
 from common.errors import AppError
+
+from apps.storage.services.internal.kopia_cli import KopiaProcessTerminatedError
 
 
 @dataclass(frozen=True, slots=True)
@@ -66,6 +69,26 @@ def classify_s3_validation_error(
 ) -> S3ValidationFailure:
     chain = list(_exception_chain(exc))
     error_code = next((code for item in chain if (code := _client_error_code(item))), "")
+
+    terminated = next(
+        (item for item in chain if isinstance(item, KopiaProcessTerminatedError)),
+        None,
+    )
+    if terminated is not None:
+        signal_number = terminated.signal_number
+        if signal_number == signal.SIGKILL:
+            return S3ValidationFailure(
+                "STORAGE.RUNTIME_RESOURCE_EXHAUSTED",
+                "Repository initialization was interrupted by insufficient system resources. Try again, and contact the platform administrator if the problem continues.",
+                retryable=True,
+                diagnostic=f"kopia_signal={signal_number}",
+            )
+        return S3ValidationFailure(
+            "STORAGE.OPERATION_INTERRUPTED",
+            "Repository initialization was interrupted before it completed. Try again.",
+            retryable=True,
+            diagnostic=f"kopia_signal={signal_number}",
+        )
 
     if error_code in _CREDENTIAL_CODES or any(
         isinstance(item, (NoCredentialsError, PartialCredentialsError)) for item in chain

--- a/src/backend/apps/storage/tasks.py
+++ b/src/backend/apps/storage/tasks.py
@@ -331,15 +331,17 @@ def execute_repository_operation(*, repository_task_id: int):
         RepositoryTask.OperationType.CLEANUP_TARGET,
         RepositoryTask.OperationType.CLEANUP_REPOSITORY,
     }
-    is_create = operation_type in {
+    uses_controller_workflow_lock = operation_type in {
         RepositoryTask.OperationType.CREATE_REPOSITORY,
         RepositoryTask.OperationType.REPAIR_BIND,
         RepositoryTask.OperationType.REPAIR_REMOUNT,
+        RepositoryTask.OperationType.CHECK,
+        RepositoryTask.OperationType.CREDENTIAL_ROTATE,
     }
     if (
         owner_type == RepositoryExecutionTarget.OwnerType.CONTROLLER
         and not is_cleanup
-        and not is_create
+        and not uses_controller_workflow_lock
     ):
         return _execute_repository_operation(repository_task_id=repository_task_id)
 
@@ -370,6 +372,20 @@ def _execute_repository_operation(*, repository_task_id: int):
     repository_task = RepositoryTask.objects.select_related(
         "task", "repository", "execution_target"
     ).get(pk=repository_task_id)
+    if repository_task.operation_type == RepositoryTask.OperationType.CHECK:
+        from apps.storage.services.internal.repository_check import (
+            run_repository_check_task,
+        )
+
+        return run_repository_check_task(repository_task_id=repository_task.id)
+    if repository_task.operation_type == RepositoryTask.OperationType.CREDENTIAL_ROTATE:
+        from apps.storage.services.internal.repository_credential_rotation import (
+            run_repository_credential_rotation_task,
+        )
+
+        return run_repository_credential_rotation_task(
+            repository_task_id=repository_task.id
+        )
     if repository_task.operation_type in {
         RepositoryTask.OperationType.CREATE_REPOSITORY,
         RepositoryTask.OperationType.REPAIR_BIND,

--- a/src/backend/apps/storage/tests/test_kopia_maintenance.py
+++ b/src/backend/apps/storage/tests/test_kopia_maintenance.py
@@ -12,6 +12,7 @@ from apps.storage.services.internal.kopia_cli import (
     KopiaCliCancelled,
     KopiaCliError,
     KopiaControlDecision,
+    KopiaProcessTerminatedError,
     KopiaRepositoryAlreadyExistsError,
     _connection_fingerprint_file,
     _invalidate_changed_s3_connection,
@@ -333,6 +334,35 @@ class KopiaMaintenanceCommandTests(SimpleTestCase):
         popen.assert_called_once()
         self.assertTrue(popen.call_args.kwargs["start_new_session"])
         killpg.assert_called_once_with(4321, signal.SIGTERM)
+
+    @patch("apps.storage.services.internal.kopia_cli._environment", return_value={})
+    @patch("apps.storage.services.internal.kopia_cli._invalidate_changed_s3_connection")
+    @patch(
+        "apps.storage.services.internal.kopia_cli._kopia_path",
+        return_value="/usr/bin/kopia",
+    )
+    @patch("apps.storage.services.internal.kopia_cli.subprocess.Popen")
+    def test_signal_terminated_process_has_a_distinct_error(
+        self,
+        popen,
+        _kopia_path,
+        _invalidate,
+        _environment,
+    ):
+        process = popen.return_value
+        process.returncode = -signal.SIGKILL
+        process.communicate.return_value = ("", "")
+        process.poll.return_value = -signal.SIGKILL
+
+        with self.assertRaises(KopiaProcessTerminatedError) as raised:
+            _run_repository_command_unlocked(
+                Repository(id=52, repo_type=Repository.Type.S3),
+                ["repository", "status"],
+                timeout_seconds=300,
+                config_file=Path("/tmp/kopia-signal-test.config"),
+            )
+
+        self.assertEqual(raised.exception.signal_number, signal.SIGKILL)
 
     @patch("apps.storage.services.internal.kopia_cli.os.killpg")
     def test_process_group_escalates_to_sigkill(self, killpg):

--- a/src/backend/apps/storage/tests/test_repository_api.py
+++ b/src/backend/apps/storage/tests/test_repository_api.py
@@ -28,6 +28,9 @@ from apps.storage.services.internal.nas_repository import (
     nas_repository_payload,
 )
 from apps.storage.services.internal.repository_access import repository_payload_for_node
+from apps.storage.services.internal.repository_credential_rotation import (
+    run_repository_credential_rotation_task,
+)
 from apps.storage.services.internal.repository_secrets import (
     build_repository_runtime_payload,
 )
@@ -972,7 +975,7 @@ class StorageRepositoryApiTests(TestCase):
         repository.refresh_from_db()
         self.assertEqual(repository.config["region"], "us-east-1")
 
-    def test_s3_repository_cannot_change_access_key_identity(self):
+    def test_s3_access_key_change_is_staged_without_changing_live_identity(self):
         repository = Repository.objects.create(
             organization_id=self.org.id,
             name="immutable-s3-account",
@@ -1002,9 +1005,16 @@ class StorageRepositoryApiTests(TestCase):
             **self._headers(),
         )
 
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
         repository.refresh_from_db()
         self.assertEqual(repository.config["access_key_id"], "AKIA_ORIGINAL")
+        self.assertTrue(
+            RepositoryTask.objects.filter(
+                repository=repository,
+                operation_type=RepositoryTask.OperationType.CREDENTIAL_ROTATE,
+                task__status=Task.Status.PENDING,
+            ).exists()
+        )
 
     def test_repository_binding_can_only_change_through_repair_workflow(self):
         repository = Repository.objects.create(
@@ -1713,7 +1723,9 @@ class StorageRepositoryApiTests(TestCase):
                 "config": {"proxy_node_dir": "/data/repository"},
             }
         )
-        self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED, response.content)
+        self.assertEqual(
+            response.status_code, status.HTTP_202_ACCEPTED, response.content
+        )
 
         repository = Repository.objects.get(name="local-disk-upgrade-required")
         result = self._run_create_task(repository)
@@ -2278,3 +2290,125 @@ class StorageRepositoryApiTests(TestCase):
             response.status_code, status.HTTP_409_CONFLICT, response.content
         )
         self.assertTrue(Repository.objects.filter(id=repo.id).exists())
+
+    @mock.patch("apps.storage.tasks.execute_repository_operation.apply_async")
+    def test_manual_repository_check_returns_a_worker_task(self, dispatch):
+        repository = Repository.objects.create(
+            organization_id=self.org.id,
+            name="manual-check",
+            repo_type=Repository.Type.S3,
+            status=Repository.Status.CREATED,
+            health=Repository.Health.ONLINE,
+            s3_platform=Repository.S3Platform.CUSTOM,
+            s3_bucket="manual-check-bucket",
+            config={
+                "endpoint": "s3.example.test",
+                "prefix": "hfl/",
+                "access_key_id": "manual-check-key",
+            },
+        )
+
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.post(
+                f"/api/v1/storage/repositories/{repository.id}/check/",
+                {},
+                format="json",
+                **self._headers(),
+            )
+
+        self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
+        repository_task = RepositoryTask.objects.get(
+            repository=repository,
+            operation_type=RepositoryTask.OperationType.CHECK,
+        )
+        self.assertEqual(
+            response.data["task"]["task_uuid"],
+            str(repository_task.task.task_uuid),
+        )
+        dispatch.assert_called_once_with(
+            kwargs={"repository_task_id": repository_task.id}
+        )
+
+    @mock.patch("apps.storage.tasks.execute_repository_operation.apply_async")
+    def test_s3_credential_update_stages_then_activates_new_secret(
+        self,
+        dispatch,
+    ):
+        credential = Credential(
+            organization_id=self.org.id,
+            credential_type=Credential.Type.S3,
+        )
+        credential.set_secret_payload(
+            {
+                "secret_access_key": "old-secret",
+                "kopia_password": "repository-password",
+            }
+        )
+        credential.save()
+        repository = Repository.objects.create(
+            organization_id=self.org.id,
+            name="credential-update",
+            repo_type=Repository.Type.S3,
+            status=Repository.Status.CREATED,
+            health=Repository.Health.ONLINE,
+            credential_id=credential.id,
+            s3_platform=Repository.S3Platform.CUSTOM,
+            s3_bucket="credential-update-bucket",
+            config={
+                "endpoint": "s3.example.test",
+                "region": "us-east-1",
+                "prefix": "hfl/",
+                "access_key_id": "old-access-key",
+                "s3_url_style": "path",
+                "use_tls": True,
+            },
+        )
+
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.patch(
+                f"/api/v1/storage/repositories/{repository.id}/",
+                {
+                    "config": {
+                        "access_key_id": "new-access-key",
+                        "secret_access_key": "new-secret",
+                    }
+                },
+                format="json",
+                **self._headers(),
+            )
+
+        self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
+        repository.refresh_from_db()
+        self.assertEqual(repository.credential_id, credential.id)
+        self.assertEqual(repository.config["access_key_id"], "old-access-key")
+        repository_task = RepositoryTask.objects.get(
+            repository=repository,
+            operation_type=RepositoryTask.OperationType.CREDENTIAL_ROTATE,
+        )
+        self.assertEqual(
+            response.data["task"]["task_uuid"],
+            str(repository_task.task.task_uuid),
+        )
+        self.assertNotIn("new-secret", str(response.data))
+        self.assertNotIn("new-secret", str(repository_task.task.request_payload))
+        dispatch.assert_called_once_with(
+            kwargs={"repository_task_id": repository_task.id}
+        )
+
+        with mock.patch(
+            "apps.storage.services.internal.repository_credential_rotation.check_s3_repository"
+        ), mock.patch(
+            "apps.storage.services.internal.repository_credential_rotation.enqueue_repository_usage_refresh"
+        ):
+            result = run_repository_credential_rotation_task(
+                repository_task_id=repository_task.id
+            )
+
+        self.assertEqual(result["status"], "success")
+        repository.refresh_from_db()
+        self.assertNotEqual(repository.credential_id, credential.id)
+        active_secret = Credential.objects.get(
+            id=repository.credential_id
+        ).get_secret_payload()
+        self.assertEqual(active_secret["secret_access_key"], "new-secret")
+        self.assertNotIn("secret_access_key", repository.config)

--- a/src/backend/apps/storage/tests/test_repository_cleanup.py
+++ b/src/backend/apps/storage/tests/test_repository_cleanup.py
@@ -920,6 +920,7 @@ class RepositoryCleanupTests(TestCase):
             waiting=False,
             node_task_id=None,
             result={
+                "ownership_verified": True,
                 "physical_cleanup": "deleted",
                 "scope": "s3_prefix",
                 "cleanup_complete": True,
@@ -1008,6 +1009,12 @@ class RepositoryCleanupTests(TestCase):
         )
         repository_task.remote_task_id = node_task.id
         repository_task.save(update_fields=["remote_task_id", "updated_at"])
+        repository_task.task.status = Task.Status.RUNNING
+        repository_task.task.current_step = "delete_physical_repository"
+        repository_task.task.progress = 40
+        repository_task.task.save(
+            update_fields=["status", "current_step", "progress", "updated_at"]
+        )
 
         result = run_repository_cleanup_task(repository_task_id=repository_task.id)
 
@@ -1016,6 +1023,107 @@ class RepositoryCleanupTests(TestCase):
         repository.refresh_from_db()
         self.assertEqual(repository.status, Repository.Status.REMOVED)
         dispatch_agent.assert_not_called()
+        verify_owner.assert_not_called()
+
+    @mock.patch(
+        "apps.storage.services.internal.repository_cleanup.verify_s3_repository_deletion_ownership",
+        side_effect=AssertionError(
+            "must not inspect a marker while Agent cleanup runs"
+        ),
+    )
+    def test_s3_cleanup_waits_for_running_agent_before_reading_marker(
+        self,
+        verify_owner,
+    ):
+        repository = self._s3_repository("agent-running-window")
+        repository_task = create_repository_cleanup_task(
+            repository=repository,
+            dispatch=False,
+        )
+        node = Node.objects.create(
+            organization=self.org,
+            name="running-s3-agent",
+            role=Node.Role.AGENT,
+            status=Node.Status.ACTIVE,
+            availability=Node.Availability.ONLINE,
+        )
+        node_task = NodeTask.objects.create(
+            organization=self.org,
+            node=node,
+            correlation_type="repository_cleanup",
+            correlation_id=str(repository_task.task.task_uuid),
+            kind="repository.operation",
+            status=NodeTask.Status.RUNNING,
+            payload={
+                "repository_id": repository.id,
+                "operation_type": repository_task.operation_type,
+            },
+            watchdog_deadline_at=timezone.now(),
+        )
+        repository_task.remote_task_id = node_task.id
+        repository_task.save(update_fields=["remote_task_id", "updated_at"])
+
+        repository_task.task.status = Task.Status.RUNNING
+        repository_task.task.current_step = "delete_physical_repository"
+        repository_task.task.progress = 40
+        repository_task.task.save(
+            update_fields=["status", "current_step", "progress", "updated_at"]
+        )
+
+        result = run_repository_cleanup_task(repository_task_id=repository_task.id)
+
+        self.assertEqual(result["status"], "waiting")
+        self.assertEqual(result["remote_task_id"], str(node_task.id))
+        repository.refresh_from_db()
+        self.assertEqual(repository.status, Repository.Status.REMOVING)
+        verify_owner.assert_not_called()
+
+    @mock.patch(
+        "apps.storage.services.internal.repository_cleanup.verify_s3_repository_deletion_ownership",
+        side_effect=AssertionError("malformed Agent proof must fail closed"),
+    )
+    def test_s3_cleanup_rejects_malformed_success_without_reading_marker(
+        self,
+        verify_owner,
+    ):
+        repository = self._s3_repository("agent-malformed-success")
+        repository_task = create_repository_cleanup_task(
+            repository=repository,
+            dispatch=False,
+        )
+        node = Node.objects.create(
+            organization=self.org,
+            name="malformed-s3-agent",
+            role=Node.Role.AGENT,
+            status=Node.Status.ACTIVE,
+            availability=Node.Availability.ONLINE,
+        )
+        node_task = NodeTask.objects.create(
+            organization=self.org,
+            node=node,
+            correlation_type="repository_cleanup",
+            correlation_id=str(repository_task.task.task_uuid),
+            kind="repository.operation",
+            status=NodeTask.Status.SUCCESS,
+            payload={
+                "repository_id": repository.id,
+                "operation_type": repository_task.operation_type,
+            },
+            result={"cleanup_complete": True},
+            watchdog_deadline_at=timezone.now(),
+        )
+        repository_task.remote_task_id = node_task.id
+        repository_task.save(update_fields=["remote_task_id", "updated_at"])
+
+        result = run_repository_cleanup_task(repository_task_id=repository_task.id)
+
+        self.assertEqual(result["status"], "failed")
+        self.assertIsNotNone(result["replacement_task_uuid"])
+        repository.refresh_from_db()
+        # An untrusted terminal attestation cannot prove whether physical
+        # deletion happened. Keep the repository in its in-progress state and
+        # require recovery instead of authorizing another executor.
+        self.assertEqual(repository.status, Repository.Status.REMOVING)
         verify_owner.assert_not_called()
 
     @mock.patch(
@@ -1067,7 +1175,7 @@ class RepositoryCleanupTests(TestCase):
         self.assertEqual(result["status"], "failed")
         repository_task.refresh_from_db()
         self.assertIsNone(repository_task.remote_task_id)
-        verify_owner.assert_called_once()
+        verify_owner.assert_not_called()
         self.assertNotEqual(repository_task.remote_task_id, node_task.id)
 
     @mock.patch(

--- a/src/backend/apps/storage/tests/test_repository_worker_operations.py
+++ b/src/backend/apps/storage/tests/test_repository_worker_operations.py
@@ -1,0 +1,415 @@
+from unittest import mock
+
+from django.core.exceptions import ValidationError
+from django.test import TestCase
+
+from apps.iam.models import Organization
+from apps.storage.repositories.models import Credential, Repository
+from apps.storage.services.internal import repository_credential_rotation
+from apps.storage.services.internal.repository_check import (
+    enqueue_repository_check_task,
+    run_repository_check_task,
+)
+from apps.storage.services.internal.repository_credential_rotation import (
+    enqueue_repository_credential_rotation,
+    run_repository_credential_rotation_task,
+)
+from apps.storage.services.internal.repository_initializer import (
+    RepositoryInitializationError,
+)
+from apps.task.models import Task, TaskStep
+
+
+class RepositoryWorkerOperationTests(TestCase):
+    def setUp(self):
+        self.organization = Organization.objects.create(
+            key="repository-worker-operations",
+            name="Repository Worker Operations",
+        )
+
+    def _s3_repository(self, *, secret: str = "old-secret") -> Repository:
+        credential = Credential(
+            organization_id=self.organization.id,
+            credential_type=Credential.Type.S3,
+        )
+        credential.set_secret_payload(
+            {
+                "secret_access_key": secret,
+                "kopia_password": "repository-password",
+            }
+        )
+        credential.save()
+        return Repository.objects.create(
+            organization_id=self.organization.id,
+            name="Worker-owned S3",
+            repo_type=Repository.Type.S3,
+            status=Repository.Status.CREATED,
+            health=Repository.Health.ONLINE,
+            credential_id=credential.id,
+            s3_platform=Repository.S3Platform.CUSTOM,
+            s3_bucket="worker-test-bucket",
+            config={
+                "endpoint": "s3.example.test",
+                "region": "us-east-1",
+                "prefix": "hfl/",
+                "access_key_id": "old-access-key",
+                "s3_url_style": "path",
+                "use_tls": True,
+            },
+        )
+
+    @mock.patch("apps.storage.services.internal.repository_check.sync_repository_usage")
+    @mock.patch(
+        "apps.storage.services.internal.repository_check.probe_repository_health",
+        return_value=Repository.Health.ONLINE,
+    )
+    def test_manual_check_runs_as_a_durable_worker_operation(
+        self,
+        probe_health,
+        sync_usage,
+    ):
+        repository = self._s3_repository()
+        repository_task = enqueue_repository_check_task(repository=repository)
+
+        result = run_repository_check_task(repository_task_id=repository_task.id)
+
+        repository.refresh_from_db()
+        repository_task.task.refresh_from_db()
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(repository.health, Repository.Health.ONLINE)
+        self.assertIsNotNone(repository.last_checked_at)
+        self.assertEqual(repository_task.task.status, Task.Status.SUCCESS)
+        probe_health.assert_called_once_with(repository_task.repository)
+        sync_usage.assert_called_once()
+
+    @mock.patch(
+        "apps.storage.services.internal.repository_check.probe_repository_health",
+        side_effect=RuntimeError("probe failed with old-secret"),
+    )
+    def test_manual_check_persists_a_safe_visible_failure(self, _probe_health):
+        repository = self._s3_repository(secret="old-secret")
+        repository_task = enqueue_repository_check_task(repository=repository)
+
+        result = run_repository_check_task(repository_task_id=repository_task.id)
+
+        repository.refresh_from_db()
+        repository_task.task.refresh_from_db()
+        self.assertEqual(result["status"], "failed")
+        self.assertEqual(repository.health, Repository.Health.OFFLINE)
+        self.assertEqual(repository_task.task.status, Task.Status.FAILED)
+        self.assertNotIn("old-secret", repository_task.task.error_message)
+        self.assertIn("******", repository_task.task.error_message)
+
+    def test_repeated_manual_check_reuses_the_active_task(self):
+        repository = self._s3_repository()
+
+        first = enqueue_repository_check_task(repository=repository)
+        second = enqueue_repository_check_task(repository=repository)
+
+        self.assertEqual(first.id, second.id)
+
+    @mock.patch(
+        "apps.storage.services.internal.repository_check.sync_repository_usage",
+        side_effect=RuntimeError("usage refresh failed"),
+    )
+    @mock.patch(
+        "apps.storage.services.internal.repository_check.probe_repository_health",
+        return_value=Repository.Health.ONLINE,
+    )
+    def test_usage_failure_does_not_overwrite_successful_connectivity(
+        self,
+        _probe_health,
+        _sync_usage,
+    ):
+        repository = self._s3_repository()
+        repository_task = enqueue_repository_check_task(repository=repository)
+
+        result = run_repository_check_task(repository_task_id=repository_task.id)
+
+        repository.refresh_from_db()
+        repository_task.task.refresh_from_db()
+        self.assertEqual(result["status"], "failed")
+        self.assertEqual(repository.health, Repository.Health.ONLINE)
+        self.assertEqual(repository_task.task.status, Task.Status.FAILED)
+
+    @mock.patch(
+        "apps.storage.services.internal.repository_credential_rotation.enqueue_repository_usage_refresh"
+    )
+    @mock.patch(
+        "apps.storage.services.internal.repository_credential_rotation.check_s3_repository"
+    )
+    def test_s3_credentials_activate_only_after_worker_verification(
+        self,
+        check_repository,
+        enqueue_usage,
+    ):
+        repository = self._s3_repository()
+        previous_credential_id = repository.credential_id
+        repository_task = enqueue_repository_credential_rotation(
+            repository=repository,
+            name="Renamed after verification",
+            config={"access_key_id": "new-access-key", "use_tls": False},
+            credential_payload={"secret_access_key": "new-secret"},
+        )
+        candidate_id = repository_task.task.request_payload["candidate_credential_id"]
+
+        repository.refresh_from_db()
+        self.assertEqual(repository.credential_id, previous_credential_id)
+        result = run_repository_credential_rotation_task(
+            repository_task_id=repository_task.id
+        )
+
+        repository.refresh_from_db()
+        repository_task.task.refresh_from_db()
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(repository_task.task.status, Task.Status.SUCCESS)
+        self.assertEqual(repository.credential_id, candidate_id)
+        self.assertEqual(repository.name, "Renamed after verification")
+        self.assertEqual(repository.config["access_key_id"], "new-access-key")
+        self.assertFalse(repository.config["use_tls"])
+        self.assertFalse(Credential.objects.filter(id=previous_credential_id).exists())
+        self.assertNotIn(
+            "repository_credential_rotation",
+            Credential.objects.get(id=candidate_id).metadata,
+        )
+        checked_repository = check_repository.call_args.args[0]
+        self.assertEqual(checked_repository.credential_id, candidate_id)
+        self.assertFalse(check_repository.call_args.kwargs["refresh_namespace"])
+        enqueue_usage.assert_called_once()
+
+    @mock.patch(
+        "apps.storage.services.internal.repository_credential_rotation.enqueue_repository_usage_refresh"
+    )
+    @mock.patch(
+        "apps.storage.services.internal.repository_credential_rotation.check_s3_repository"
+    )
+    def test_legacy_config_secrets_can_be_rotated_without_losing_kopia_password(
+        self,
+        _check_repository,
+        _enqueue_usage,
+    ):
+        repository = Repository.objects.create(
+            organization_id=self.organization.id,
+            name="Legacy S3",
+            repo_type=Repository.Type.S3,
+            status=Repository.Status.CREATED,
+            health=Repository.Health.ONLINE,
+            s3_platform=Repository.S3Platform.CUSTOM,
+            s3_bucket="legacy-bucket",
+            config={
+                "endpoint": "s3.example.test",
+                "prefix": "hfl/",
+                "access_key_id": "legacy-access-key",
+                "secret_access_key": "legacy-secret",
+                "kopia_password": "legacy-kopia-password",
+                "s3_url_style": "path",
+            },
+        )
+        repository_task = enqueue_repository_credential_rotation(
+            repository=repository,
+            name=repository.name,
+            config={},
+            credential_payload={"secret_access_key": "new-secret"},
+        )
+
+        result = run_repository_credential_rotation_task(
+            repository_task_id=repository_task.id
+        )
+
+        repository.refresh_from_db()
+        self.assertEqual(result["status"], "success")
+        self.assertIsNotNone(repository.credential_id)
+        self.assertNotIn("secret_access_key", repository.config)
+        self.assertNotIn("kopia_password", repository.config)
+        secrets = Credential.objects.get(id=repository.credential_id).get_secret_payload()
+        self.assertEqual(secrets["secret_access_key"], "new-secret")
+        self.assertEqual(secrets["kopia_password"], "legacy-kopia-password")
+
+    @mock.patch(
+        "apps.storage.services.internal.repository_credential_rotation.check_s3_repository",
+        side_effect=RepositoryInitializationError("new-secret was rejected"),
+    )
+    def test_failed_rotation_keeps_old_credentials_and_removes_candidate(
+        self,
+        _check_repository,
+    ):
+        repository = self._s3_repository()
+        previous_credential_id = repository.credential_id
+        repository_task = enqueue_repository_credential_rotation(
+            repository=repository,
+            name=repository.name,
+            config={"access_key_id": "new-access-key"},
+            credential_payload={"secret_access_key": "new-secret"},
+        )
+        candidate_id = repository_task.task.request_payload["candidate_credential_id"]
+
+        result = run_repository_credential_rotation_task(
+            repository_task_id=repository_task.id
+        )
+
+        repository.refresh_from_db()
+        repository_task.task.refresh_from_db()
+        self.assertEqual(result["status"], "failed")
+        self.assertEqual(repository_task.task.status, Task.Status.FAILED)
+        self.assertEqual(repository.credential_id, previous_credential_id)
+        self.assertTrue(Credential.objects.filter(id=previous_credential_id).exists())
+        self.assertFalse(Credential.objects.filter(id=candidate_id).exists())
+        self.assertNotIn("new-secret", repository_task.task.error_message)
+
+    @mock.patch(
+        "apps.storage.services.internal.repository_credential_rotation.check_s3_repository"
+    )
+    def test_finalization_interruption_does_not_delete_activated_credentials(
+        self,
+        _check_repository,
+    ):
+        repository = self._s3_repository()
+        repository_task = enqueue_repository_credential_rotation(
+            repository=repository,
+            name=repository.name,
+            config={},
+            credential_payload={"secret_access_key": "new-secret"},
+        )
+        candidate_id = repository_task.task.request_payload["candidate_credential_id"]
+
+        with mock.patch(
+            "apps.storage.services.internal.repository_credential_rotation._complete_rotation_success",
+            side_effect=RuntimeError("worker interrupted during finalization"),
+        ):
+            with self.assertRaisesMessage(RuntimeError, "worker interrupted"):
+                run_repository_credential_rotation_task(
+                    repository_task_id=repository_task.id
+                )
+
+        repository.refresh_from_db()
+        self.assertEqual(repository.credential_id, candidate_id)
+        self.assertTrue(Credential.objects.filter(id=candidate_id).exists())
+
+    @mock.patch(
+        "apps.storage.services.internal.repository_credential_rotation.enqueue_repository_usage_refresh"
+    )
+    @mock.patch(
+        "apps.storage.services.internal.repository_credential_rotation.check_s3_repository"
+    )
+    def test_recovery_converges_steps_after_credential_activation(
+        self,
+        _check_repository,
+        _enqueue_usage,
+    ):
+        repository = self._s3_repository()
+        repository_task = enqueue_repository_credential_rotation(
+            repository=repository,
+            name=repository.name,
+            config={},
+            credential_payload={"secret_access_key": "new-secret"},
+        )
+
+        original_set_step = repository_credential_rotation._set_step
+
+        def interrupt_after_activation(task, step_name, status, progress):
+            if (
+                step_name == "activate_credentials"
+                and status == TaskStep.Status.SUCCESS
+                and progress == 100
+            ):
+                raise RuntimeError("worker interrupted after credential activation")
+            return original_set_step(task, step_name, status, progress)
+
+        with mock.patch.object(
+            repository_credential_rotation,
+            "_set_step",
+            side_effect=interrupt_after_activation,
+        ):
+            with self.assertRaisesMessage(RuntimeError, "worker interrupted"):
+                run_repository_credential_rotation_task(
+                    repository_task_id=repository_task.id
+                )
+
+        result = run_repository_credential_rotation_task(
+            repository_task_id=repository_task.id
+        )
+
+        repository_task.task.refresh_from_db()
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(repository_task.task.status, Task.Status.SUCCESS)
+        self.assertFalse(
+            repository_task.task.steps.exclude(
+                status=TaskStep.Status.SUCCESS
+            ).exists()
+        )
+
+    @mock.patch(
+        "apps.storage.services.internal.repository_credential_rotation.check_s3_repository"
+    )
+    def test_concurrent_settings_change_is_not_overwritten(
+        self,
+        _check_repository,
+    ):
+        repository = self._s3_repository()
+        previous_credential_id = repository.credential_id
+        repository_task = enqueue_repository_credential_rotation(
+            repository=repository,
+            name="Candidate name",
+            config={"quota_gb": 10},
+            credential_payload={"secret_access_key": "new-secret"},
+        )
+        Repository.objects.filter(pk=repository.id).update(
+            name="Concurrent name",
+            config={**repository.config, "quota_gb": 20},
+        )
+
+        result = run_repository_credential_rotation_task(
+            repository_task_id=repository_task.id
+        )
+
+        repository.refresh_from_db()
+        repository_task.task.refresh_from_db()
+        self.assertEqual(result["status"], "failed")
+        self.assertEqual(repository_task.task.status, Task.Status.FAILED)
+        self.assertEqual(repository.name, "Concurrent name")
+        self.assertEqual(repository.config["quota_gb"], 20)
+        self.assertEqual(repository.credential_id, previous_credential_id)
+
+    def test_second_rotation_is_rejected_while_first_is_active(self):
+        repository = self._s3_repository()
+        enqueue_repository_credential_rotation(
+            repository=repository,
+            name=repository.name,
+            config={},
+            credential_payload={"secret_access_key": "first-secret"},
+        )
+
+        with self.assertRaisesMessage(ValidationError, "active operation"):
+            enqueue_repository_credential_rotation(
+                repository=repository,
+                name=repository.name,
+                config={},
+                credential_payload={"secret_access_key": "second-secret"},
+            )
+
+    def test_candidate_decryption_failure_finishes_task_and_keeps_old_credentials(self):
+        repository = self._s3_repository()
+        previous_credential_id = repository.credential_id
+        repository_task = enqueue_repository_credential_rotation(
+            repository=repository,
+            name=repository.name,
+            config={},
+            credential_payload={"secret_access_key": "new-secret"},
+        )
+        candidate_id = repository_task.task.request_payload["candidate_credential_id"]
+
+        with mock.patch.object(
+            Credential,
+            "get_secret_payload",
+            side_effect=ValueError("candidate cannot be decrypted"),
+        ):
+            result = run_repository_credential_rotation_task(
+                repository_task_id=repository_task.id
+            )
+
+        repository.refresh_from_db()
+        repository_task.task.refresh_from_db()
+        self.assertEqual(result["status"], "failed")
+        self.assertEqual(repository_task.task.status, Task.Status.FAILED)
+        self.assertEqual(repository.credential_id, previous_credential_id)
+        self.assertFalse(Credential.objects.filter(id=candidate_id).exists())

--- a/src/backend/apps/storage/tests/test_s3_validation_errors.py
+++ b/src/backend/apps/storage/tests/test_s3_validation_errors.py
@@ -3,6 +3,7 @@ from django.test import SimpleTestCase
 from botocore.exceptions import ClientError, EndpointConnectionError, SSLError
 
 from apps.storage.services.internal.s3_client import S3ClientError
+from apps.storage.services.internal.kopia_cli import KopiaProcessTerminatedError
 from apps.storage.services.internal.s3_validation_errors import (
     classify_s3_validation_error,
     s3_validation_app_error,
@@ -104,3 +105,22 @@ class S3ValidationErrorTests(SimpleTestCase):
         self.assertNotIn("AKIA_SECRET", failure.message)
         self.assertNotIn("super-secret", failure.message)
         self.assertEqual(failure.diagnostic, "")
+
+    def test_sigkill_is_reported_as_retryable_resource_exhaustion(self):
+        failure = classify_s3_validation_error(
+            KopiaProcessTerminatedError(signal_number=9),
+            operation="bucket_access",
+        )
+
+        self.assertEqual(failure.code, "STORAGE.RUNTIME_RESOURCE_EXHAUSTED")
+        self.assertTrue(failure.retryable)
+        self.assertEqual(failure.diagnostic, "kopia_signal=9")
+
+    def test_other_signal_is_reported_as_retryable_interruption(self):
+        failure = classify_s3_validation_error(
+            KopiaProcessTerminatedError(signal_number=15),
+            operation="bucket_access",
+        )
+
+        self.assertEqual(failure.code, "STORAGE.OPERATION_INTERRUPTED")
+        self.assertTrue(failure.retryable)

--- a/src/frontend/src/lib/storageRepositoryApi.ts
+++ b/src/frontend/src/lib/storageRepositoryApi.ts
@@ -149,6 +149,11 @@ export type StorageRepositoryUpdatePayload = {
   }
 }
 
+export type StorageRepositoryUpdateResult = {
+  repository: StorageRepository
+  task: TaskRow | null
+}
+
 /**
  * PATCH payload for the NAS repair endpoint.
  *   - `name`                : rename the repository
@@ -403,15 +408,19 @@ export function storageRepositoryCreateErrorMessage(
 export async function updateStorageRepository(
   id: number,
   payload: StorageRepositoryUpdatePayload,
-) {
+): Promise<StorageRepositoryUpdateResult> {
   logger.info('storageRepositoryApi.ts', 173, 'storage repository update', { repository_id: id, fields: Object.keys(payload) })
-  return unwrapApiPayload<StorageRepository>(
+  const result = unwrapApiPayload<StorageRepository | { repository: StorageRepository, task: TaskRow }>(
     await api<unknown>(`${repositoryBase}/${id}/`, {
       method: 'PATCH',
       body: JSON.stringify(payload),
       headers: orgHeaders(),
     }),
   )
+  if ('repository' in result) {
+    return { repository: result.repository, task: result.task }
+  }
+  return { repository: result, task: null }
 }
 
 /**

--- a/src/frontend/src/locales/en.ts
+++ b/src/frontend/src/locales/en.ts
@@ -2187,6 +2187,7 @@ export const en = {
     credentialMask: 'Saved credentials. Click Rewrite to replace them.',
     saving: 'Saving…',
     savingAndVerifying: 'Verifying and saving…',
+    verificationContinues: 'Credential verification is still running in the background. Check Tasks for the final result before editing this repository again.',
     verifyingAuth: 'Verifying access…',
     verifySuccess: 'Access verified for bucket {bucket}',
     verifyFailed: 'Access verification failed',

--- a/src/frontend/src/pages/node/EditS3Repo.vue
+++ b/src/frontend/src/pages/node/EditS3Repo.vue
@@ -10,6 +10,7 @@ import {
   verifyStorageRepositoryAccess,
   type StorageRepository,
 } from '../../lib/storageRepositoryApi'
+import { getTask, type TaskRow } from '../../lib/taskApi'
 import {
   s3EndpointDisplay,
   s3PlatformLabelKey,
@@ -278,7 +279,20 @@ async function onSave() {
   busy.value = true
   savingPhase.value = 'saving'
   try {
-    await updateStorageRepository(repositoryId.value, buildPayload())
+    const result = await updateStorageRepository(repositoryId.value, buildPayload())
+    const task = rotationTaskFromUpdateResult(result)
+    if (task) {
+      savingPhase.value = 'verifying'
+      const completed = await waitForCredentialRotation(task)
+      if (!completed) {
+        ElMessage.warning({
+          message: t('repositoriesPage.editS3Repo.verificationContinues'),
+          grouping: true,
+        })
+        router.push({ path: '/node/repositories', query: { tab: 's3' } })
+        return
+      }
+    }
     ElMessage.success({ message: t('repositoriesPage.editS3Repo.msgUpdated'), grouping: true })
     router.push({ path: '/node/repositories', query: { tab: 's3' } })
   } catch (err) {
@@ -290,6 +304,31 @@ async function onSave() {
     busy.value = false
     savingPhase.value = null
   }
+}
+
+function rotationTaskFromUpdateResult(result: unknown): TaskRow | null {
+  if (!result || typeof result !== 'object' || !('task' in result)) return null
+  const task = (result as { task?: TaskRow | null }).task
+  return task && task.task_uuid ? task : null
+}
+
+async function waitForCredentialRotation(initialTask: TaskRow): Promise<boolean> {
+  let task = initialTask
+  for (let attempt = 0; attempt < 180; attempt += 1) {
+    if (task.status === 'success') return true
+    if (['failed', 'timeout', 'cancelled', 'canceled'].includes(task.status)) {
+      throw new Error(
+        task.error_message || t('repositoriesPage.editS3Repo.saveFailed'),
+      )
+    }
+    await new Promise(resolve => window.setTimeout(resolve, 1000))
+    try {
+      task = await getTask(task.task_uuid)
+    } catch {
+      return false
+    }
+  }
+  return false
 }
 
 function handleBack() {

--- a/src/frontend/src/pages/node/EditS3RepoSave.test.ts
+++ b/src/frontend/src/pages/node/EditS3RepoSave.test.ts
@@ -12,6 +12,7 @@ const mocks = vi.hoisted(() => ({
   getStorageRepository: vi.fn(),
   updateStorageRepository: vi.fn(),
   verifyStorageRepositoryAccess: vi.fn(),
+  getTask: vi.fn(),
   routerPush: vi.fn(),
 }))
 
@@ -23,6 +24,10 @@ vi.mock('../../lib/storageRepositoryApi', () => ({
 
 vi.mock('../../lib/api', () => ({
   apiErrorMessage: (error: { message?: string }, fallback: string) => error?.message || fallback,
+}))
+
+vi.mock('../../lib/taskApi', () => ({
+  getTask: mocks.getTask,
 }))
 
 vi.mock('vue-router', async (importOriginal) => ({
@@ -80,6 +85,7 @@ function saveButton(wrapper: ReturnType<typeof mount>) {
 
 describe('EditS3Repo save behavior', () => {
   beforeEach(() => {
+    vi.useRealTimers()
     vi.clearAllMocks()
     mocks.getStorageRepository.mockResolvedValue(repository)
     mocks.updateStorageRepository.mockResolvedValue(repository)
@@ -119,5 +125,99 @@ describe('EditS3Repo save behavior', () => {
     })
     expect(wrapper.find('.edit-s3-verify-dialog').exists()).toBe(false)
     wrapper.unmount()
+  })
+
+  it('accepts a completed credential verification task before leaving the page', async () => {
+    mocks.updateStorageRepository.mockResolvedValue({
+      repository,
+      task: { task_uuid: 'credential-task', status: 'success' },
+    })
+    const successMessage = vi.spyOn(ElMessage, 'success').mockImplementation(() => undefined as never)
+    const wrapper = await mountForm()
+
+    await saveButton(wrapper).trigger('click')
+    await flushPromises()
+
+    expect(mocks.getTask).not.toHaveBeenCalled()
+    expect(successMessage).toHaveBeenCalled()
+    expect(mocks.routerPush).toHaveBeenCalledWith({ path: '/node/repositories', query: { tab: 's3' } })
+    wrapper.unmount()
+  })
+
+  it('shows the worker verification error and stays on the edit page', async () => {
+    mocks.updateStorageRepository.mockResolvedValue({
+      repository,
+      task: {
+        task_uuid: 'credential-task',
+        status: 'failed',
+        error_message: 'The new credentials cannot open this repository.',
+      },
+    })
+    const errorMessage = vi.spyOn(ElMessage, 'error').mockImplementation(() => undefined as never)
+    const wrapper = await mountForm()
+
+    await saveButton(wrapper).trigger('click')
+    await flushPromises()
+
+    expect(errorMessage).toHaveBeenCalledWith({
+      message: 'The new credentials cannot open this repository.',
+      grouping: true,
+    })
+    expect(mocks.routerPush).not.toHaveBeenCalled()
+    wrapper.unmount()
+  })
+
+  it('reports a still-running verification task without claiming the save failed', async () => {
+    mocks.updateStorageRepository.mockResolvedValue({
+      repository,
+      task: { task_uuid: 'credential-task', status: 'pending' },
+    })
+    mocks.getTask.mockResolvedValue({
+      task_uuid: 'credential-task',
+      status: 'running',
+    })
+    const warningMessage = vi.spyOn(ElMessage, 'warning').mockImplementation(() => undefined as never)
+    const errorMessage = vi.spyOn(ElMessage, 'error').mockImplementation(() => undefined as never)
+    const wrapper = await mountForm()
+    vi.useFakeTimers()
+
+    await saveButton(wrapper).trigger('click')
+    await vi.advanceTimersByTimeAsync(180_000)
+    await flushPromises()
+
+    expect(mocks.getTask).toHaveBeenCalledTimes(180)
+    expect(warningMessage).toHaveBeenCalledWith({
+      message: en.repositoriesPage.editS3Repo.verificationContinues,
+      grouping: true,
+    })
+    expect(errorMessage).not.toHaveBeenCalled()
+    expect(mocks.routerPush).toHaveBeenCalledWith({ path: '/node/repositories', query: { tab: 's3' } })
+    wrapper.unmount()
+    vi.useRealTimers()
+  })
+
+  it('keeps a verification task pending when task polling is interrupted', async () => {
+    mocks.updateStorageRepository.mockResolvedValue({
+      repository,
+      task: { task_uuid: 'credential-task', status: 'pending' },
+    })
+    mocks.getTask.mockRejectedValue(new Error('Temporary network failure'))
+    const warningMessage = vi.spyOn(ElMessage, 'warning').mockImplementation(() => undefined as never)
+    const errorMessage = vi.spyOn(ElMessage, 'error').mockImplementation(() => undefined as never)
+    const wrapper = await mountForm()
+    vi.useFakeTimers()
+
+    await saveButton(wrapper).trigger('click')
+    await vi.advanceTimersByTimeAsync(1_000)
+    await flushPromises()
+
+    expect(warningMessage).toHaveBeenCalledWith({
+      message: en.repositoriesPage.editS3Repo.verificationContinues,
+      grouping: true,
+    })
+    expect(errorMessage).not.toHaveBeenCalled()
+    expect(mocks.routerPush).toHaveBeenCalledWith({ path: '/node/repositories', query: { tab: 's3' } })
+    wrapper.unmount()
+    vi.useRealTimers()
   })
 })


### PR DESCRIPTION
## Summary

- move manual repository checks and S3 credential verification to durable Worker tasks
- activate validated candidate credentials atomically while preserving legacy secret compatibility
- harden Agent/Controller cleanup recovery, ownership-marker handling, and Kopia interruption reporting
- return task-based feedback to the UI without exposing secrets in repository config, task payloads, or API responses

## Validation

- 139 backend tests passed
- 6 frontend tests passed
- TypeScript, ESLint, Ruff, Django migration checks, and `git diff --check` passed

Fixes #677