### PR TITLE
feat(deploy): add registry-backed Community online installation

### DIFF
--- a/.github/workflows/enterprise_saas_upgrade.yml
+++ b/.github/workflows/enterprise_saas_upgrade.yml
@@ -1,5 +1,5 @@
-name: HFL - Enterprise SaaS Upgrade
-run-name: Enterprise · ${{ github.event_name == 'push' && github.ref_name || inputs.tag }} · SaaS Upgrade
+name: HFL - Publish Images & Upgrade SaaS
+run-name: Publish · ${{ github.event_name == 'push' && github.ref_name || inputs.tag }} · Images · Enterprise SaaS Upgrade
 
 on:
   push:
@@ -41,12 +41,11 @@ env:
 
 jobs:
   prepare:
-    name: Prepare · Enterprise candidate
+    name: Prepare · Images and Enterprise candidate
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     outputs:
       version: ${{ steps.source.outputs.version }}
-      image_version: ${{ steps.source.outputs.image_version }}
       release_tag: ${{ steps.source.outputs.release_tag }}
       commit: ${{ steps.source.outputs.commit }}
       enterprise_commit: ${{ steps.enterprise.outputs.commit }}
@@ -112,7 +111,6 @@ jobs:
           done
           {
             echo "version=$version"
-            echo "image_version=${version}-ee"
             echo "release_tag=$RELEASE_TAG"
             echo "commit=$commit"
           } >>"$GITHUB_OUTPUT"
@@ -157,6 +155,8 @@ jobs:
       - name: Validate shell and release contracts
         run: |
           bash -n \
+            deploy/online/install.sh \
+            deploy/online/verify-public-images.sh \
             deploy/installer/install.sh \
             release/build-sourcelens.sh \
             release/ci/assemble-saas-candidate.sh \
@@ -167,6 +167,33 @@ jobs:
             .github/scripts/reconcile-saas-ai-model.sh
           ./tools/quality/check-release-contracts.sh
           ./tools/quality/test-saas-registry-delivery.sh
+          ./tools/quality/test-online-community-install.sh
+
+  verify-public-images:
+    name: Verify · Public Community images
+    needs:
+      - prepare
+      - build-hfl-images
+      - build-sourcelens-images
+      - publish-runtime-images
+      - publish-agent-assets
+      - publish-gateway-assets
+      - publish-language-assets
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          persist-credentials: false
+          ref: ${{ needs.prepare.outputs.commit }}
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          pattern: saas-metadata-*
+          path: build/saas-metadata
+          merge-multiple: true
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+      - name: Verify anonymous access and mirror identity
+        run: ./deploy/online/verify-public-images.sh build/saas-metadata
 
   build-hfl-images:
     name: Build · HFL · ${{ matrix.name }}
@@ -177,15 +204,45 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: backend
-            component: hfl-backend
+          - name: Community · Backend
+            edition: community
+            component: community-hfl-backend
+            metadata_component: community-hfl-backend
             repository: hyperfilelens-backend
             dockerfile: deploy/docker/backend.Dockerfile
+            tag_suffix: ""
+            role: community-hyperfilelens
+            with_extension: false
             needs_kopia: true
-          - name: frontend
-            component: hfl-frontend
+          - name: Community · Frontend
+            edition: community
+            component: community-hfl-frontend
+            metadata_component: community-hfl-frontend
             repository: hyperfilelens-frontend
             dockerfile: deploy/docker/frontend.Dockerfile
+            tag_suffix: ""
+            role: community-hyperfilelens
+            with_extension: false
+            needs_kopia: false
+          - name: Enterprise · Backend
+            edition: enterprise
+            component: hfl-backend
+            metadata_component: hfl-backend
+            repository: hyperfilelens-backend
+            dockerfile: deploy/docker/backend.Dockerfile
+            tag_suffix: -ee
+            role: hyperfilelens
+            with_extension: true
+            needs_kopia: true
+          - name: Enterprise · Frontend
+            edition: enterprise
+            component: hfl-frontend
+            metadata_component: hfl-frontend
+            repository: hyperfilelens-frontend
+            dockerfile: deploy/docker/frontend.Dockerfile
+            tag_suffix: -ee
+            role: hyperfilelens
+            with_extension: true
             needs_kopia: false
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
@@ -212,12 +269,15 @@ jobs:
         if: matrix.needs_kopia
         run: ./tools/kopia/prepare.sh --matrix linux:amd64
       - name: Prepare Website artifact
-        if: matrix.component == 'hfl-frontend'
+        if: matrix.repository == 'hyperfilelens-frontend'
         run: >-
           ./website/build.sh --output build/website
           --image-tag "hyperfilelens-website-builder:${GITHUB_RUN_ID}"
           --platform linux/amd64
+      - name: Prepare extension build context
+        run: mkdir -p build/release/extensions
       - name: Materialize Enterprise Extension
+        if: matrix.with_extension
         env:
           RELEASE_TAG: ${{ needs.prepare.outputs.release_tag }}
           ENTERPRISE_COMMIT: ${{ needs.prepare.outputs.enterprise_commit }}
@@ -243,41 +303,41 @@ jobs:
           platforms: linux/amd64
           push: true
           provenance: false
-          tags: ${{ env.REGISTRY_PREFIX }}/${{ matrix.repository }}:${{ needs.prepare.outputs.image_version }}
+          tags: ${{ env.REGISTRY_PREFIX }}/${{ matrix.repository }}:${{ format('{0}{1}', needs.prepare.outputs.version, matrix.tag_suffix) }}
           build-args: |
             KOPIA_BINARY=build/kopia/dist/linux/amd64/kopia
-            IMAGE_VERSION=${{ needs.prepare.outputs.image_version }}
+            IMAGE_VERSION=${{ format('{0}{1}', needs.prepare.outputs.version, matrix.tag_suffix) }}
             IMAGE_REVISION=${{ needs.prepare.outputs.commit }}
             PIP_TIMEOUT=600
             SENTRY_URL=${{ vars.SENTRY_URL }}
             SENTRY_ORG=${{ vars.SENTRY_ORG }}
             SENTRY_FRONTEND_PROJECT=${{ vars.SENTRY_FRONTEND_PROJECT }}
-            SENTRY_RELEASE=hyperfilelens-frontend@${{ needs.prepare.outputs.image_version }}
+            SENTRY_RELEASE=hyperfilelens-frontend@${{ format('{0}{1}', needs.prepare.outputs.version, matrix.tag_suffix) }}
             VITE_SHOW_EULA=false
             HFL_EXTENSIONS=${{ env.HFL_EXTENSIONS }}
-          secrets: ${{ matrix.component == 'hfl-frontend' && secrets.SENTRY_AUTH_TOKEN != '' && format('sentry_auth_token={0}', secrets.SENTRY_AUTH_TOKEN) || '' }}
-          cache-from: type=gha,scope=saas-${{ matrix.component }}
-          cache-to: type=gha,scope=saas-${{ matrix.component }},mode=min
+          secrets: ${{ matrix.repository == 'hyperfilelens-frontend' && secrets.SENTRY_AUTH_TOKEN != '' && format('sentry_auth_token={0}', secrets.SENTRY_AUTH_TOKEN) || '' }}
+          cache-from: type=gha,scope=publish-${{ matrix.edition }}-${{ matrix.repository }}
+          cache-to: type=gha,scope=publish-${{ matrix.edition }}-${{ matrix.repository }},mode=min
       - name: Mirror immutable image to CN
         run: |
           ./release/ci/mirror-saas-image.sh \
-            "$REGISTRY_PREFIX/${{ matrix.repository }}:${{ needs.prepare.outputs.image_version }}" \
+            "$REGISTRY_PREFIX/${{ matrix.repository }}:${{ format('{0}{1}', needs.prepare.outputs.version, matrix.tag_suffix) }}" \
             "${{ steps.build.outputs.digest }}" \
-            "$CN_REGISTRY_PREFIX/${{ matrix.repository }}:${{ needs.prepare.outputs.image_version }}"
+            "$CN_REGISTRY_PREFIX/${{ matrix.repository }}:${{ format('{0}{1}', needs.prepare.outputs.version, matrix.tag_suffix) }}"
       - name: Record immutable metadata
         run: |
           ./release/ci/write-saas-image-metadata.sh \
-            "${{ matrix.component }}" \
-            "$REGISTRY_PREFIX/${{ matrix.repository }}:${{ needs.prepare.outputs.image_version }}" \
-            "$CN_REGISTRY_PREFIX/${{ matrix.repository }}:${{ needs.prepare.outputs.image_version }}" \
+            "${{ matrix.metadata_component }}" \
+            "$REGISTRY_PREFIX/${{ matrix.repository }}:${{ format('{0}{1}', needs.prepare.outputs.version, matrix.tag_suffix) }}" \
+            "$CN_REGISTRY_PREFIX/${{ matrix.repository }}:${{ format('{0}{1}', needs.prepare.outputs.version, matrix.tag_suffix) }}" \
             "${{ steps.build.outputs.digest }}" \
-            "${{ matrix.repository }}:${{ needs.prepare.outputs.image_version }}" \
-            hyperfilelens \
-            "${{ matrix.component }}.json"
+            "${{ matrix.repository }}:${{ format('{0}{1}', needs.prepare.outputs.version, matrix.tag_suffix) }}" \
+            "${{ matrix.role }}" \
+            "${{ matrix.metadata_component }}.json"
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: saas-metadata-${{ matrix.component }}
-          path: ${{ matrix.component }}.json
+          name: saas-metadata-${{ matrix.metadata_component }}
+          path: ${{ matrix.metadata_component }}.json
           retention-days: 3
 
   build-sourcelens-images:
@@ -308,6 +368,9 @@ jobs:
       - name: Build global image
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          # Public online installs address the tested SourceLens bundle with the
+          # HFL tag. The existing Release workflow keeps its compound SL tag.
+          SOURCELENS_DISTRIBUTION_TAG_OVERRIDE: ${{ needs.prepare.outputs.version }}
           SENTRY_URL: ${{ vars.SENTRY_URL }}
           SENTRY_ORG: ${{ vars.SENTRY_ORG }}
           SENTRY_FRONTEND_PROJECT: ${{ vars.SENTRY_FRONTEND_PROJECT }}
@@ -552,22 +615,22 @@ jobs:
           platforms: linux/amd64
           push: true
           provenance: false
-          tags: ${{ env.REGISTRY_PREFIX }}/hyperfilelens-agent-assets:${{ needs.prepare.outputs.image_version }}
+          tags: ${{ env.REGISTRY_PREFIX }}/hyperfilelens-agent-assets:${{ needs.prepare.outputs.version }}
       - name: Mirror immutable asset image to CN
         run: |
           ./release/ci/mirror-saas-image.sh \
-            "$REGISTRY_PREFIX/hyperfilelens-agent-assets:${{ needs.prepare.outputs.image_version }}" \
+            "$REGISTRY_PREFIX/hyperfilelens-agent-assets:${{ needs.prepare.outputs.version }}" \
             "${{ steps.build.outputs.digest }}" \
-            "$CN_REGISTRY_PREFIX/hyperfilelens-agent-assets:${{ needs.prepare.outputs.image_version }}"
+            "$CN_REGISTRY_PREFIX/hyperfilelens-agent-assets:${{ needs.prepare.outputs.version }}"
       - name: Record asset metadata
         shell: bash
         run: |
           ./release/ci/write-saas-image-metadata.sh \
             "agent-assets" \
-            "$REGISTRY_PREFIX/hyperfilelens-agent-assets:${{ needs.prepare.outputs.image_version }}" \
-            "$CN_REGISTRY_PREFIX/hyperfilelens-agent-assets:${{ needs.prepare.outputs.image_version }}" \
+            "$REGISTRY_PREFIX/hyperfilelens-agent-assets:${{ needs.prepare.outputs.version }}" \
+            "$CN_REGISTRY_PREFIX/hyperfilelens-agent-assets:${{ needs.prepare.outputs.version }}" \
             "${{ steps.build.outputs.digest }}" \
-            "hyperfilelens-agent-assets:${{ needs.prepare.outputs.image_version }}" \
+            "hyperfilelens-agent-assets:${{ needs.prepare.outputs.version }}" \
             "agent-assets" \
             "agent-assets.json"
           jq --arg kind agent '. + {asset_kind: $kind}' \
@@ -627,22 +690,22 @@ jobs:
           platforms: linux/amd64
           push: true
           provenance: false
-          tags: ${{ env.REGISTRY_PREFIX }}/hyperfilelens-gateway-assets:${{ needs.prepare.outputs.image_version }}
+          tags: ${{ env.REGISTRY_PREFIX }}/hyperfilelens-gateway-assets:${{ needs.prepare.outputs.version }}
       - name: Mirror immutable asset image to CN
         run: |
           ./release/ci/mirror-saas-image.sh \
-            "$REGISTRY_PREFIX/hyperfilelens-gateway-assets:${{ needs.prepare.outputs.image_version }}" \
+            "$REGISTRY_PREFIX/hyperfilelens-gateway-assets:${{ needs.prepare.outputs.version }}" \
             "${{ steps.build.outputs.digest }}" \
-            "$CN_REGISTRY_PREFIX/hyperfilelens-gateway-assets:${{ needs.prepare.outputs.image_version }}"
+            "$CN_REGISTRY_PREFIX/hyperfilelens-gateway-assets:${{ needs.prepare.outputs.version }}"
       - name: Record asset metadata
         shell: bash
         run: |
           ./release/ci/write-saas-image-metadata.sh \
             "gateway-assets" \
-            "$REGISTRY_PREFIX/hyperfilelens-gateway-assets:${{ needs.prepare.outputs.image_version }}" \
-            "$CN_REGISTRY_PREFIX/hyperfilelens-gateway-assets:${{ needs.prepare.outputs.image_version }}" \
+            "$REGISTRY_PREFIX/hyperfilelens-gateway-assets:${{ needs.prepare.outputs.version }}" \
+            "$CN_REGISTRY_PREFIX/hyperfilelens-gateway-assets:${{ needs.prepare.outputs.version }}" \
             "${{ steps.build.outputs.digest }}" \
-            "hyperfilelens-gateway-assets:${{ needs.prepare.outputs.image_version }}" \
+            "hyperfilelens-gateway-assets:${{ needs.prepare.outputs.version }}" \
             "gateway-assets" \
             "gateway-assets.json"
           jq --arg kind gateway '. + {asset_kind: $kind}' \
@@ -695,22 +758,22 @@ jobs:
           platforms: linux/amd64
           push: true
           provenance: false
-          tags: ${{ env.REGISTRY_PREFIX }}/hyperfilelens-language-assets:${{ needs.prepare.outputs.image_version }}
+          tags: ${{ env.REGISTRY_PREFIX }}/hyperfilelens-language-assets:${{ needs.prepare.outputs.version }}
       - name: Mirror immutable asset image to CN
         run: |
           ./release/ci/mirror-saas-image.sh \
-            "$REGISTRY_PREFIX/hyperfilelens-language-assets:${{ needs.prepare.outputs.image_version }}" \
+            "$REGISTRY_PREFIX/hyperfilelens-language-assets:${{ needs.prepare.outputs.version }}" \
             "${{ steps.build.outputs.digest }}" \
-            "$CN_REGISTRY_PREFIX/hyperfilelens-language-assets:${{ needs.prepare.outputs.image_version }}"
+            "$CN_REGISTRY_PREFIX/hyperfilelens-language-assets:${{ needs.prepare.outputs.version }}"
       - name: Record asset metadata
         shell: bash
         run: |
           ./release/ci/write-saas-image-metadata.sh \
             "language-assets" \
-            "$REGISTRY_PREFIX/hyperfilelens-language-assets:${{ needs.prepare.outputs.image_version }}" \
-            "$CN_REGISTRY_PREFIX/hyperfilelens-language-assets:${{ needs.prepare.outputs.image_version }}" \
+            "$REGISTRY_PREFIX/hyperfilelens-language-assets:${{ needs.prepare.outputs.version }}" \
+            "$CN_REGISTRY_PREFIX/hyperfilelens-language-assets:${{ needs.prepare.outputs.version }}" \
             "${{ steps.build.outputs.digest }}" \
-            "hyperfilelens-language-assets:${{ needs.prepare.outputs.image_version }}" \
+            "hyperfilelens-language-assets:${{ needs.prepare.outputs.version }}" \
             "language-assets" \
             "language-assets.json"
           jq --arg kind language '. + {asset_kind: $kind}' \
@@ -732,6 +795,7 @@ jobs:
       - publish-agent-assets
       - publish-gateway-assets
       - publish-language-assets
+      - verify-public-images
     runs-on: ubuntu-24.04
     timeout-minutes: 45
     steps:

--- a/deploy/installer/install.sh
+++ b/deploy/installer/install.sh
@@ -3891,19 +3891,35 @@ read_sourcelens_installed_fingerprint() {
 }
 
 sourcelens_runtime_matches_bundle() {
-	local bundle_root=$1 version service container_id image
-	version="$(sourcelens_bundle_version "${bundle_root}" 2>/dev/null || true)"
-	[[ -n "${version}" ]] || return 1
+	local bundle_root=$1 service container_id image expected_backend expected_frontend expected
+	read -r expected_backend expected_frontend < <(python3 - "${bundle_root}/BUILD_INFO.json" <<'PY'
+import json
+import pathlib
+import sys
+
+try:
+    build = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+except (OSError, json.JSONDecodeError):
+    raise SystemExit(1)
+images = build.get("images") or {}
+backend = str((images.get("backend") or {}).get("ref") or "")
+frontend = str((images.get("frontend") or {}).get("ref") or "")
+if not backend or not frontend or any(character.isspace() for character in backend + frontend):
+    raise SystemExit(1)
+print(backend, frontend)
+PY
+	) || return 1
 	for service in api worker scheduler web; do
 		# Inspect stopped/restarting containers too. A transient process state is
 		# handled by health/recovery gates and is not itself an identity drift.
 		container_id="$(sourcelens_compose ps --all -q "${service}" 2>/dev/null | head -1)"
 		[[ -n "${container_id}" ]] || return 1
 		image="$(docker inspect --format '{{.Config.Image}}' "${container_id}" 2>/dev/null || true)"
-		case "${image}" in
-		*-sl"${version}" | *-sl"${version}"@*) ;;
-		*) return 1 ;;
+		case "${service}" in
+		api | worker | scheduler) expected="${expected_backend}" ;;
+		web) expected="${expected_frontend}" ;;
 		esac
+		[[ "${image}" == "${expected}" || "${image}" == "${expected}"@* ]] || return 1
 	done
 	return 0
 }

--- a/deploy/online/install.sh
+++ b/deploy/online/install.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# Bootstrap a public Community installation or upgrade from one HFL Git tag.
+set -euo pipefail
+
+GLOBAL_REGISTRY_PREFIX="${HFL_GLOBAL_REGISTRY_PREFIX:-docker.io/oneprolabs}"
+CN_REGISTRY_PREFIX="${HFL_CN_REGISTRY_PREFIX:-registry.cn-beijing.aliyuncs.com/oneprolabs}"
+REGION="${HFL_REGISTRY_REGION:-auto}"
+TAG=""
+SESSION_DIR=""
+
+usage() {
+	cat <<'USAGE'
+Usage: install.sh vX.Y.Z [--region auto|cn|global]
+
+Installs HyperFileLens Community on a new host. Running the command again with
+a newer tag performs the normal managed backup and blue/green upgrade.
+USAGE
+}
+
+fail() {
+	printf '[FAIL] %s\n' "$*" >&2
+	exit 1
+}
+
+cleanup() {
+	local rc=$?
+	trap - EXIT INT TERM
+	if [[ -n "${SESSION_DIR}" && -d "${SESSION_DIR}" ]]; then
+		rm -rf -- "${SESSION_DIR}"
+	fi
+	exit "${rc}"
+}
+
+detect_region() {
+	local timezone=""
+	timezone="$(cat /etc/timezone 2>/dev/null || true)"
+	case "${timezone}" in
+	Asia/Shanghai | Asia/Chongqing | Asia/Harbin | Asia/Urumqi) printf 'cn' ;;
+	*) printf 'global' ;;
+	esac
+}
+
+ensure_prerequisites() {
+	[[ "${EUID}" -eq 0 ]] || fail "run this command through sudo"
+	[[ -f /etc/os-release ]] || fail "missing /etc/os-release"
+	# shellcheck disable=SC1091
+	source /etc/os-release
+	[[ "${ID:-}" == ubuntu ]] || fail "Ubuntu 20.04, 22.04, or 24.04 is required"
+	case "${VERSION_ID:-}" in 20.04 | 22.04 | 24.04) ;; *)
+		fail "Ubuntu 20.04, 22.04, or 24.04 is required"
+		;; esac
+	[[ "$(uname -m)" == x86_64 ]] || fail "linux/amd64 is required"
+
+	local -a missing=()
+	local command
+	for command in ca-certificates curl openssl python3 rsync tar; do
+		case "${command}" in
+		ca-certificates) [[ -f /etc/ssl/certs/ca-certificates.crt ]] || missing+=(ca-certificates) ;;
+		*) command -v "${command}" >/dev/null 2>&1 || missing+=("${command}") ;;
+		esac
+	done
+	if ((${#missing[@]})); then
+		printf '[....] Installing required host tools: %s\n' "${missing[*]}"
+		apt-get update
+		DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends "${missing[@]}"
+	fi
+	command -v docker >/dev/null 2>&1 || fail "Docker Engine is required"
+	docker info >/dev/null 2>&1 || fail "cannot connect to the Docker daemon"
+	docker compose version >/dev/null 2>&1 || fail "Docker Compose V2 is required"
+}
+
+while (($#)); do
+	case "$1" in
+	--region)
+		[[ $# -ge 2 ]] || fail "--region requires auto, cn, or global"
+		REGION=$2
+		shift 2
+		;;
+	-h | --help)
+		usage
+		exit 0
+		;;
+	v[0-9]*.[0-9]*.[0-9]*)
+		[[ -z "${TAG}" ]] || fail "only one HFL tag may be supplied"
+		TAG=$1
+		shift
+		;;
+	*) fail "unknown argument: $1" ;;
+	esac
+done
+
+[[ "${TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+	usage >&2
+	exit 2
+}
+case "${REGION}" in
+auto) REGION="$(detect_region)" ;;
+cn | global) ;;
+*) fail "--region must be auto, cn, or global" ;;
+esac
+
+ensure_prerequisites
+export HFL_GLOBAL_REGISTRY_PREFIX="${GLOBAL_REGISTRY_PREFIX}"
+export HFL_CN_REGISTRY_PREFIX="${CN_REGISTRY_PREFIX}"
+export HFL_REGISTRY_REGION="${REGION}"
+
+SESSION_DIR="$(mktemp -d /var/tmp/hyperfilelens-online.XXXXXX)"
+chmod 0700 "${SESSION_DIR}"
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+archive="${SESSION_DIR}/source.tar.gz"
+source_dir="${SESSION_DIR}/source"
+candidate="${SESSION_DIR}/hyperfilelens-${TAG#v}-online"
+
+printf '[....] Downloading HyperFileLens %s installation contract\n' "${TAG}"
+curl --fail --show-error --location --retry 3 --retry-all-errors \
+	"https://codeload.github.com/oneprolabs/hyperfilelens/tar.gz/refs/tags/${TAG}" \
+	-o "${archive}"
+mkdir -p "${source_dir}"
+tar -xzf "${archive}" -C "${source_dir}" --strip-components=1
+[[ -x "${source_dir}/deploy/online/install.sh" \
+	&& -f "${source_dir}/deploy/online/prepare.py" ]] \
+	|| fail "${TAG} does not provide the online installation contract"
+
+python3 "${source_dir}/deploy/online/prepare.py" \
+	--source-root "${source_dir}" \
+	--version "${TAG}" \
+	--region "${REGION}" \
+	--output "${candidate}"
+
+install_root=/opt/hyperfilelens
+if [[ -e "${install_root}/.env" || -e "${install_root}/MANIFEST.json" ]]; then
+	[[ -f "${install_root}/.env" && -f "${install_root}/MANIFEST.json" ]] \
+		|| fail "${install_root} contains an incomplete installation; recover or remove it before continuing"
+	existing_edition="$(python3 - "${install_root}/MANIFEST.json" <<'PY'
+import json
+import pathlib
+import sys
+
+try:
+    manifest = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+except (OSError, json.JSONDecodeError):
+    raise SystemExit(1)
+print(str(manifest.get("edition") or "community").strip().lower())
+PY
+	)" || fail "the existing installation manifest is invalid"
+	[[ "${existing_edition}" == community ]] \
+		|| fail "this public installer upgrades Community only; the existing edition is ${existing_edition}"
+	printf '[....] Upgrading the existing installation to %s\n' "${TAG}"
+	HFL_REGISTRY_REGION="${REGION}" bash "${candidate}/install.sh" \
+		upgrade --from "${candidate}" --yes --with-sourcelens
+else
+	printf '[....] Installing HyperFileLens Community %s\n' "${TAG}"
+	HFL_REGISTRY_REGION="${REGION}" bash "${candidate}/install.sh" \
+		install --with-sourcelens
+fi

--- a/deploy/online/prepare.py
+++ b/deploy/online/prepare.py
@@ -1,0 +1,632 @@
+#!/usr/bin/env python3
+"""Prepare a registry-backed Community package from one immutable HFL tag."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import json
+import os
+import pathlib
+import re
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from typing import Any
+
+
+VERSION_PATTERN = re.compile(r"[0-9]+\.[0-9]+\.[0-9]+")
+DIGEST_PATTERN = re.compile(r"sha256:[0-9a-f]{64}")
+REVISION_PATTERN = re.compile(r"[0-9a-f]{40}")
+GLOBAL_PREFIX = os.environ.get(
+    "HFL_GLOBAL_REGISTRY_PREFIX", "docker.io/oneprolabs"
+).rstrip("/")
+CN_PREFIX = os.environ.get(
+    "HFL_CN_REGISTRY_PREFIX",
+    "registry.cn-beijing.aliyuncs.com/oneprolabs",
+).rstrip("/")
+
+
+@dataclass(frozen=True)
+class ImageSpec:
+    """Describe one published image and its local runtime identity."""
+
+    component: str
+    role: str
+    repository: str
+    tag: str
+    asset_kind: str = ""
+
+    @property
+    def local_ref(self) -> str:
+        """Return the registry-independent image reference used by Compose."""
+        return f"{self.repository}:{self.tag}"
+
+    def source_ref(self, region: str) -> str:
+        """Return the published source reference for a registry region."""
+        prefix = CN_PREFIX if region == "cn" else GLOBAL_PREFIX
+        return f"{prefix}/{self.repository}:{self.tag}"
+
+
+@dataclass(frozen=True)
+class ResolvedImage:
+    """Hold immutable metadata for one successfully resolved image."""
+
+    spec: ImageSpec
+    digest: str
+
+    def manifest_entry(self) -> dict[str, Any]:
+        """Return the normalized registry delivery manifest entry."""
+        entry: dict[str, Any] = {
+            "component": self.spec.component,
+            "role": self.spec.role,
+            "local_ref": self.spec.local_ref,
+            "digest": self.digest,
+            "platform": "linux/amd64",
+            "sources": [
+                {"region": "cn", "ref": self.spec.source_ref("cn")},
+                {"region": "global", "ref": self.spec.source_ref("global")},
+            ],
+        }
+        if self.spec.asset_kind:
+            entry["asset_kind"] = self.spec.asset_kind
+        return entry
+
+
+def run(
+    command: list[str],
+    *,
+    capture_output: bool = False,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    """Run a subprocess with stable text handling and useful diagnostics."""
+    completed = subprocess.run(
+        command,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE if capture_output else None,
+        stderr=subprocess.STDOUT if capture_output else None,
+    )
+    if check and completed.returncode != 0:
+        output = (completed.stdout or "").strip()
+        detail = f": {output[-1000:]}" if output else ""
+        raise RuntimeError(f"command failed ({' '.join(command)}){detail}")
+    return completed
+
+
+def sha256_file(path: pathlib.Path) -> str:
+    """Return the SHA-256 digest of one file."""
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def sha256_tree(root: pathlib.Path) -> str:
+    """Return a deterministic digest for regular files below a directory."""
+    digest = hashlib.sha256()
+    for path in sorted(
+        candidate for candidate in root.rglob("*") if candidate.is_file()
+    ):
+        relative = path.relative_to(root).as_posix().encode()
+        digest.update(relative)
+        digest.update(b"\0")
+        digest.update(bytes.fromhex(sha256_file(path)))
+    return digest.hexdigest()
+
+
+def replace_env_values(path: pathlib.Path, values: dict[str, str]) -> None:
+    """Replace or append environment keys without evaluating the template."""
+    text = path.read_text(encoding="utf-8")
+    for name, value in values.items():
+        pattern = re.compile(rf"^{re.escape(name)}=.*$", re.MULTILINE)
+        line = f"{name}={value}"
+        if pattern.search(text):
+            text = pattern.sub(line, text, count=1)
+        else:
+            text = text.rstrip() + f"\n{name}={value}\n"
+    path.write_text(text, encoding="utf-8")
+
+
+def copy_runtime_files(
+    source: pathlib.Path, target: pathlib.Path, version: str
+) -> None:
+    """Stage the HFL and SourceLens runtime configuration from the Git tag."""
+    target.mkdir(parents=True)
+    (target / "VERSION").write_text(f"{version}\n", encoding="utf-8")
+    shutil.copy2(source / "deploy/docker-compose.yml", target / "docker-compose.yml")
+    shutil.copy2(source / ".env.example", target / ".env.example")
+    replace_env_values(
+        target / ".env.example",
+        {
+            "APP_VERSION": version,
+            "HFL_PRODUCT_VERSION": version,
+            "HFL_EDITION": "community",
+            "HFL_BACKEND_IMAGE": f"hyperfilelens-backend:{version}",
+            "HFL_FRONTEND_IMAGE": f"hyperfilelens-frontend:{version}",
+            "HFL_GATEWAY_VERSION": version,
+            "HFL_RELEASE_CHANNEL": "release",
+            "AGENT_VERSION": version,
+        },
+    )
+
+    copies = {
+        "deploy/installer/install.sh": "install.sh",
+        "deploy/installer/apply-runtime-config.py": "apply-runtime-config.py",
+        "tools/config/sync_env.py": "sync-env.py",
+        "LICENSE": "LICENSE",
+    }
+    for source_name, target_name in copies.items():
+        shutil.copy2(source / source_name, target / target_name)
+        (target / target_name).chmod(0o755 if target_name != "LICENSE" else 0o644)
+
+    for relative in (
+        "deploy/nginx/certs",
+        "deploy/nginx/snippets",
+        "deploy/blue-green",
+        "deploy/logrotate",
+    ):
+        shutil.copytree(source / relative, target / relative, dirs_exist_ok=True)
+    for name in ("default.conf", "web.conf"):
+        destination = target / "deploy/nginx" / name
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source / "deploy/nginx" / name, destination)
+    (target / "images").mkdir()
+    (target / "host").mkdir()
+    (target / "payload/media").mkdir(parents=True)
+    (target / "payload/language-packs").mkdir(parents=True)
+
+
+def render_sourcelens_compose(
+    template: pathlib.Path,
+    destination: pathlib.Path,
+    version: str,
+) -> None:
+    """Render the shared SourceLens Compose template with HFL-versioned refs."""
+    text = template.read_text(encoding="utf-8")
+    for block in ("EMBED_BACKEND_ENV", "EMBED_LENSNODE_SERVICE"):
+        pattern = re.compile(rf"(?ms)^# HFL_{block}_BEGIN\n(.*?)^# HFL_{block}_END\n")
+        if len(pattern.findall(text)) != 1:
+            raise ValueError(f"SourceLens template has an invalid {block} block")
+        text = pattern.sub("", text)
+    replacements = {
+        "__SOURCELENS_BACKEND_IMAGE__": (f"hyperfilelens-sourcelens-backend:{version}"),
+        "__SOURCELENS_FRONTEND_IMAGE__": (
+            f"hyperfilelens-sourcelens-frontend:{version}"
+        ),
+        "__SOURCELENS_LENSNODE_IMAGE__": (
+            f"hyperfilelens-sourcelens-lensnode:{version}"
+        ),
+        "__SOURCELENS_CONSOLE_BIND_ADDRESS__": "0.0.0.0",
+        "__SOURCELENS_CONSOLE_PORT__": "11445",
+    }
+    for token, value in replacements.items():
+        text = text.replace(token, value)
+    if "__SOURCELENS_" in text or "HFL_EMBED_" in text:
+        raise ValueError("SourceLens Compose template has unresolved markers")
+    destination.write_text(text, encoding="utf-8")
+
+
+def stage_sourcelens(source: pathlib.Path, target: pathlib.Path, version: str) -> None:
+    """Stage the repository-owned SourceLens runtime tree."""
+    online = source / "deploy/online/sourcelens"
+    root = target / "sourcelens"
+    (root / "deploy/nginx/hfl-maintenance").mkdir(parents=True)
+    (root / "deploy/postgresql").mkdir(parents=True)
+    (root / "deploy/sentry").mkdir(parents=True)
+
+    shutil.copy2(online / "env.example", root / ".env.example")
+    run(
+        [
+            sys.executable,
+            str(source / "deploy/installer/sourcelens/patch-env-runtime.py"),
+            str(root / ".env.example"),
+        ]
+    )
+    replace_env_values(
+        root / ".env.example",
+        {
+            "SOURCELENS_CONSOLE_BIND_ADDRESS": "0.0.0.0",
+            "SOURCELENS_CONSOLE_PORT": "11445",
+            "NGINX_HTTPS_PORT": "11445",
+        },
+    )
+    render_sourcelens_compose(
+        source / "deploy/installer/sourcelens/docker-compose.template.yml",
+        root / "docker-compose.yml",
+        version,
+    )
+    shutil.copy2(online / "nginx/default.conf", root / "deploy/nginx/default.conf")
+    shutil.copytree(
+        online / "postgresql", root / "deploy/postgresql", dirs_exist_ok=True
+    )
+
+    runtime_files = {
+        "deploy/installer/sourcelens/install.sh": "install.sh",
+        "deploy/installer/sourcelens/compose-lifecycle.sh": "compose-lifecycle.sh",
+        "deploy/installer/sourcelens/patch-env-runtime.py": "patch-env-runtime.py",
+        "deploy/installer/sourcelens/sync-sentry-runtime.py": "sync-sentry-runtime.py",
+        "deploy/installer/sourcelens/hfl-sentry-loader.js": (
+            "deploy/nginx/hfl-sentry-loader.js"
+        ),
+        "deploy/installer/sourcelens/run-creation-gate-off.conf": (
+            "deploy/nginx/hfl-maintenance/run-creation-gate.conf"
+        ),
+        "deploy/installer/sourcelens/hfl-sentry-sitecustomize.py": (
+            "deploy/sentry/hfl-sentry-sitecustomize.py"
+        ),
+    }
+    for source_name, target_name in runtime_files.items():
+        destination = root / target_name
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source / source_name, destination)
+    for name in (
+        "install.sh",
+        "compose-lifecycle.sh",
+        "patch-env-runtime.py",
+        "sync-sentry-runtime.py",
+    ):
+        (root / name).chmod(0o755)
+    (root / "deploy/nginx/hfl-sentry-config.js").write_text(
+        "window.__HFL_SOURCELENS_SENTRY__ = Object.freeze({ enabled: false })\n",
+        encoding="utf-8",
+    )
+
+
+def image_digest(ref: str) -> str:
+    """Read the immutable repository digest retained by Docker pull."""
+    completed = run(
+        ["docker", "image", "inspect", ref, "--format", "{{json .RepoDigests}}"],
+        capture_output=True,
+    )
+    values = json.loads((completed.stdout or "[]").strip())
+    repository_path = ref.rsplit(":", 1)[0].split("/", 1)[-1]
+    digests = {
+        value.rsplit("@", 1)[-1]
+        for value in values
+        if isinstance(value, str)
+        and "@" in value
+        and value.rsplit("@", 1)[0].endswith(repository_path)
+    }
+    valid = sorted(value for value in digests if DIGEST_PATTERN.fullmatch(value))
+    if len(valid) != 1:
+        raise ValueError(f"image {ref} has ambiguous repository digests: {valid}")
+    return valid[0]
+
+
+def resolve_image(spec: ImageSpec, preferred_region: str) -> ResolvedImage:
+    """Pull one public image with regional fallback and retain its local alias."""
+    fallback = "global" if preferred_region == "cn" else "cn"
+    failures: list[str] = []
+    for region in (preferred_region, fallback):
+        source_ref = spec.source_ref(region)
+        print(f"[....] Pulling {source_ref}", flush=True)
+        completed = run(
+            ["docker", "pull", "--platform", "linux/amd64", source_ref],
+            capture_output=True,
+            check=False,
+        )
+        if completed.returncode != 0:
+            failures.append(f"{source_ref}: {(completed.stdout or '').strip()[-500:]}")
+            continue
+        digest = image_digest(source_ref)
+        run(["docker", "tag", source_ref, spec.local_ref])
+        print(f"[ OK ] Resolved {spec.local_ref}@{digest}", flush=True)
+        return ResolvedImage(spec=spec, digest=digest)
+    raise RuntimeError(
+        f"neither public registry could provide {spec.local_ref}: "
+        + "; ".join(failures)
+    )
+
+
+def image_revision(ref: str) -> str:
+    """Return and validate the source revision embedded in an HFL image."""
+    completed = run(
+        [
+            "docker",
+            "image",
+            "inspect",
+            ref,
+            "--format",
+            '{{index .Config.Labels "org.opencontainers.image.revision"}}',
+        ],
+        capture_output=True,
+    )
+    revision = (completed.stdout or "").strip().lower()
+    if not REVISION_PATTERN.fullmatch(revision):
+        raise ValueError(f"image {ref} has no valid source revision label")
+    return revision
+
+
+def validate_asset_tree(root: pathlib.Path, kind: str) -> None:
+    """Reject links and paths outside the declared asset payload roots."""
+    prefixes = {
+        "agent": (
+            pathlib.PurePosixPath("payload/media/agent-releases"),
+            pathlib.PurePosixPath("payload/media/enroll-bootstrap"),
+        ),
+        "gateway": (pathlib.PurePosixPath("payload/media/gateway-bootstrap"),),
+        "language": (pathlib.PurePosixPath("payload/language-packs"),),
+    }[kind]
+    marker = root / ".asset-kind"
+    if marker.read_text(encoding="utf-8").strip() != kind:
+        raise ValueError(f"{kind} asset image has an invalid marker")
+    for prefix in prefixes:
+        directory = root / prefix
+        if not directory.is_dir() or not any(directory.iterdir()):
+            raise ValueError(f"{kind} asset image is missing {prefix}")
+    allowed_ancestors = {pathlib.PurePosixPath(".asset-kind")}
+    for prefix in prefixes:
+        allowed_ancestors.update(prefix.parents)
+        allowed_ancestors.add(prefix)
+    for path in root.rglob("*"):
+        mode = path.lstat().st_mode
+        if not (stat.S_ISDIR(mode) or stat.S_ISREG(mode)):
+            raise ValueError(f"{kind} asset contains unsupported entry: {path}")
+        relative = pathlib.PurePosixPath(path.relative_to(root).as_posix())
+        if relative in allowed_ancestors:
+            continue
+
+        def is_under(prefix: pathlib.PurePosixPath) -> bool:
+            try:
+                relative.relative_to(prefix)
+            except ValueError:
+                return False
+            return True
+
+        if not any(is_under(prefix) for prefix in prefixes):
+            raise ValueError(f"{kind} asset contains unexpected path: {relative}")
+
+
+def extract_asset(image: ResolvedImage, payload_root: pathlib.Path) -> None:
+    """Copy and validate one scratch asset image into the local package."""
+    kind = image.spec.asset_kind
+    container = run(
+        ["docker", "create", image.spec.local_ref, "/bin/true"],
+        capture_output=True,
+    ).stdout
+    container_id = (container or "").strip()
+    if not container_id:
+        raise RuntimeError(f"could not create {kind} asset container")
+    try:
+        with tempfile.TemporaryDirectory(prefix=f"hfl-{kind}-asset-") as temporary:
+            root = pathlib.Path(temporary)
+            run(
+                [
+                    "docker",
+                    "cp",
+                    f"{container_id}:/opt/hyperfilelens-assets/.",
+                    str(root),
+                ]
+            )
+            validate_asset_tree(root, kind)
+            shutil.copytree(root / "payload", payload_root, dirs_exist_ok=True)
+    finally:
+        run(["docker", "rm", "-f", container_id], check=False)
+
+
+def discard_asset_image(image: ResolvedImage) -> None:
+    """Remove scratch asset tags after their payload has been materialized."""
+    refs = {
+        image.spec.local_ref,
+        image.spec.source_ref("cn"),
+        image.spec.source_ref("global"),
+    }
+    for ref in sorted(refs):
+        run(["docker", "image", "rm", ref], check=False)
+
+
+def write_sourcelens_build_info(
+    source: pathlib.Path,
+    target: pathlib.Path,
+    runtime: list[ResolvedImage],
+) -> dict[str, Any]:
+    """Write the semantic SourceLens bundle identity used by upgrades."""
+    base = json.loads(
+        (source / "deploy/online/sourcelens/runtime.json").read_text(encoding="utf-8")
+    )
+    by_component = {image.spec.component: image for image in runtime}
+    template_root = source / "deploy/online/sourcelens"
+    info = {
+        "enabled": True,
+        "git_url": "https://github.com/oneprolabs/sourcelens.git",
+        "git_ref": base["git_ref"],
+        "git_commit": base["git_commit"],
+        "git_commit_short": base["git_commit"][:7],
+        "version": base["version"],
+        "patchset_sha256": sha256_tree(template_root),
+        "patches": [],
+        "build_adapter_sha256": sha256_file(source / "deploy/online/prepare.py"),
+        "build_compose_file": "docker-compose.standalone.yml",
+        "network": "hyperfilelens-bridge",
+        "install_dir": "/opt/hyperfilelens/sourcelens",
+        "lensnode_image": by_component["sourcelens-lensnode"].spec.local_ref,
+        "embed_local_lensnode": False,
+        "images": {
+            name: {
+                "ref": by_component[f"sourcelens-{name}"].spec.local_ref,
+                "upstream_ref": by_component[f"sourcelens-{name}"].spec.source_ref(
+                    "global"
+                ),
+                "digest": by_component[f"sourcelens-{name}"].digest,
+            }
+            for name in ("backend", "frontend", "lensnode")
+        },
+    }
+    nginx = by_component["sourcelens-nginx"]
+    info["images"]["nginx"] = {
+        "ref": nginx.spec.local_ref,
+        "digest": nginx.digest,
+    }
+    (target / "sourcelens/BUILD_INFO.json").write_text(
+        json.dumps(info, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    return info
+
+
+def write_manifest(
+    target: pathlib.Path,
+    version: str,
+    revision: str,
+    runtime: list[ResolvedImage],
+    assets: list[ResolvedImage],
+    sourcelens: dict[str, Any],
+) -> None:
+    """Write the local immutable installation manifest."""
+    by_component = {image.spec.component: image for image in runtime}
+    images = [
+        {
+            "role": "hyperfilelens",
+            "refs": [
+                by_component["hfl-backend"].spec.local_ref,
+                by_component["hfl-frontend"].spec.local_ref,
+            ],
+            "digests": [
+                by_component["hfl-backend"].digest,
+                by_component["hfl-frontend"].digest,
+            ],
+        }
+    ]
+    images.extend(
+        {
+            "role": image.spec.role,
+            "refs": [image.spec.local_ref],
+            "digests": [image.digest],
+        }
+        for image in runtime
+        if image.spec.component not in {"hfl-backend", "hfl-frontend"}
+    )
+    manifest = {
+        "schema_version": 3,
+        "product": "hyperfilelens",
+        "edition": "community",
+        "channel": "release",
+        "artifact_id": f"v{version}",
+        "version": version,
+        "image_version": version,
+        "built_at": dt.datetime.now(dt.timezone.utc)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z"),
+        "minimum_upgrade_version": "0.1.34",
+        "git_commit": revision,
+        "runtime_images": {
+            "backend": by_component["hfl-backend"].spec.local_ref,
+            "frontend": by_component["hfl-frontend"].spec.local_ref,
+        },
+        "host_runtime": {
+            "os_id": "ubuntu",
+            "os_versions": ["20.04", "22.04", "24.04"],
+            "arch": "amd64",
+            "docker": {
+                "min_engine_version": "24.0.0",
+                "min_compose_version": "2.20.0",
+            },
+        },
+        "sourcelens": sourcelens,
+        "images": images,
+        "delivery": {
+            "mode": "registry",
+            "registry_images": [image.manifest_entry() for image in runtime],
+            "asset_images": [image.manifest_entry() for image in assets],
+        },
+        "artifacts": {"agent_version": version},
+    }
+    (target / "MANIFEST.json").write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--source-root", type=pathlib.Path, required=True)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--region", choices=("cn", "global"), required=True)
+    parser.add_argument("--output", type=pathlib.Path, required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Build a temporary Community package and resolve all public images."""
+    args = parse_args()
+    source = args.source_root.resolve(strict=True)
+    version = args.version[1:] if args.version.startswith("v") else args.version
+    if not VERSION_PATTERN.fullmatch(version):
+        raise ValueError(f"invalid HFL version: {args.version}")
+    target = args.output.resolve()
+    if target.exists() or target.is_symlink():
+        raise ValueError(f"online package output already exists: {target}")
+    target.parent.mkdir(parents=True, exist_ok=True)
+
+    copy_runtime_files(source, target, version)
+    stage_sourcelens(source, target, version)
+
+    runtime_specs = [
+        ImageSpec("hfl-backend", "hyperfilelens", "hyperfilelens-backend", version),
+        ImageSpec("hfl-frontend", "hyperfilelens", "hyperfilelens-frontend", version),
+        ImageSpec(
+            "sourcelens-backend",
+            "sourcelens-backend",
+            "hyperfilelens-sourcelens-backend",
+            version,
+        ),
+        ImageSpec(
+            "sourcelens-frontend",
+            "sourcelens-frontend",
+            "hyperfilelens-sourcelens-frontend",
+            version,
+        ),
+        ImageSpec(
+            "sourcelens-lensnode",
+            "sourcelens-lensnode",
+            "hyperfilelens-sourcelens-lensnode",
+            version,
+        ),
+        ImageSpec(
+            "sourcelens-nginx",
+            "sourcelens-nginx",
+            "hyperfilelens-sourcelens-nginx",
+            "stable-alpine",
+        ),
+        ImageSpec("postgres", "shared", "hyperfilelens-postgres", "17"),
+        ImageSpec("redis", "shared", "hyperfilelens-redis", "alpine"),
+    ]
+    asset_specs = [
+        ImageSpec(
+            f"{kind}-assets",
+            f"{kind}-assets",
+            f"hyperfilelens-{kind}-assets",
+            version,
+            kind,
+        )
+        for kind in ("agent", "gateway", "language")
+    ]
+    runtime = [resolve_image(spec, args.region) for spec in runtime_specs]
+    assets = [resolve_image(spec, args.region) for spec in asset_specs]
+
+    revision = image_revision(f"hyperfilelens-backend:{version}")
+    if image_revision(f"hyperfilelens-frontend:{version}") != revision:
+        raise ValueError("Community backend and frontend revisions do not match")
+    for asset in assets:
+        try:
+            extract_asset(asset, target / "payload")
+        finally:
+            discard_asset_image(asset)
+    sourcelens = write_sourcelens_build_info(source, target, runtime)
+    write_manifest(target, version, revision, runtime, assets, sourcelens)
+    print(f"[ OK ] Prepared Community package: {target}")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (OSError, RuntimeError, ValueError, json.JSONDecodeError) as error:
+        print(f"[FAIL] {error}", file=sys.stderr)
+        raise SystemExit(1) from error

--- a/deploy/online/sourcelens/env.example
+++ b/deploy/online/sourcelens/env.example
@@ -1,0 +1,214 @@
+# SourceLens environment sample.
+# Copy to .env.dev for local Docker development or .env for production.
+# Do not commit real secrets.
+
+# -----------------------------------------------------------------------------
+# Django
+# -----------------------------------------------------------------------------
+SECRET_KEY=change-me
+DJANGO_DEBUG=false
+DJANGO_LOG_LEVEL=INFO
+
+ALLOWED_HOSTS=localhost,127.0.0.1
+CSRF_TRUSTED_ORIGINS=http://localhost:8000,http://127.0.0.1:8000
+CORS_ALLOW_ALL_ORIGINS=false
+CORS_ALLOWED_ORIGINS=http://localhost:3000,http://127.0.0.1:3000
+
+SITE_DOMAIN=localhost:8000
+SITE_NAME=SourceLens
+FRONTEND_URL=http://localhost:3000
+ACCOUNT_DEFAULT_HTTP_PROTOCOL=http
+
+REGISTRATION_TOKEN_EXPIRY_HOURS=24
+PASSWORD_RESET_TIMEOUT=86400
+
+# -----------------------------------------------------------------------------
+# Docker / build
+# -----------------------------------------------------------------------------
+DJANGO_HOST_PORT=8000
+FLOWER_HOST_PORT=5555
+NGINX_HTTP_PORT=10080
+NGINX_HTTPS_PORT=10443
+
+# -----------------------------------------------------------------------------
+# Database
+# -----------------------------------------------------------------------------
+# Docker compose uses the postgresql service name as host.
+DB_ENGINE=postgresql
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=postgres
+POSTGRES_DB=sourcelens
+POSTGRES_HOST=postgresql
+POSTGRES_PORT=5432
+
+# For non-Docker SQLite development, use:
+# DB_ENGINE=sqlite
+# SQLITE_PATH=db.sqlite3
+
+# DATABASE_URL overrides DB_ENGINE when set.
+# DATABASE_URL=postgresql://postgres:postgres@postgresql:5432/sourcelens
+
+# -----------------------------------------------------------------------------
+# Redis / Celery / Cache
+# -----------------------------------------------------------------------------
+REDIS_URL=redis://redis:6379/0
+CELERY_BROKER_URL=redis://redis:6379/0
+CELERY_LOG_LEVEL=INFO
+CELERY_TASK_DEFAULT_QUEUE=sourcelens
+CELERY_WORKER_PREFETCH_MULTIPLIER=1
+CELERY_CONCURRENCY=
+CELERY_MAX_TASKS_PER_CHILD=1000
+CELERY_MAX_MEMORY_PER_CHILD=256000
+
+CACHE_BACKEND=redis
+CACHE_REDIS_URL=redis://redis:6379/1
+BACKEND_CACHE_PATH=/var/cache/sourcelens
+
+# -----------------------------------------------------------------------------
+# Storage
+# -----------------------------------------------------------------------------
+STORAGE_ROOT=/opt/storage
+# Uploaded document metadata lives in Redis for this many seconds. Original
+# files use the same fixed retention and are removed by an hourly cleanup.
+DOCUMENT_ATTACHMENT_TTL_SECONDS=86400
+CHANNEL_LAYER_REDIS_URL=redis://redis:6379/2
+
+# -----------------------------------------------------------------------------
+# LensNode
+# -----------------------------------------------------------------------------
+LENSNODE_NAME=local-dev-lensnode
+LENSNODE_TOKEN=change-me-lensnode-token
+LENSNODE_WORKSPACE_PATH=/workspace
+# Reach the API through nginx, not a color-specific container: under blue/green
+# there is no single "backend-api" host, and nginx always proxies to the active
+# color, so lensnode rides a deploy switch by simply reconnecting. (The compose
+# file also sets LENSNODE_SERVER_URL=http://nginx:80, which derives the
+# deliverable-upload URL the same way.)
+LENSNODE_CONTROL_WS_URL=ws://nginx:80/ws/lens/lensnodes/
+LENSNODE_AI_GATEWAY_URL=http://nginx:80/api/lens/lensnode/ai-gateway/
+# Keep certificate and hostname verification enabled by default. For a private
+# CA, mount its certificate into LensNode and set the container path below.
+LENSNODE_TLS_SKIP_VERIFY=false
+# LENSNODE_TLS_CA_FILE=/etc/sourcelens/ca.crt
+LENSNODE_HEARTBEAT_INTERVAL_S=15
+# HTTP transport timeout for AI Gateway calls, deliverable uploads, and Skill
+# downloads. This does not limit the complete Agent Run.
+LENSNODE_REQUEST_TIMEOUT_S=240
+# Run watchdog: abort when NO gateway activity (heartbeats, tokens,
+# progress) arrives for this long. The gateway heartbeats every ~10s, so
+# this only trips on a dead pipe, never on a quiet-but-alive model call.
+LENSNODE_RUN_IDLE_TIMEOUT_S=180
+# Graceful-drain budget on shutdown/upgrade: a node receiving SIGTERM stops
+# taking new runs and lets in-flight runs finish for up to this long before
+# exiting (only runs still active past it are cancelled). The compose
+# lensnode service's stop_grace_period must stay larger than this.
+LENSNODE_DRAIN_TIMEOUT_S=240
+# Max concurrent runs a single lensnode executes. Each run holds a slot for
+# the full answer duration; raise for more parallelism (avoids long Queued).
+LENSNODE_MAX_CONCURRENT_RUNS=8
+# Fallback budget for commands without a control-plane budget profile.
+LENSNODE_TOKEN_BUDGET_MAX_TOKENS=200000
+# Absolute ceiling for budgets requested by the SourceLens control plane.
+LENSNODE_TOKEN_BUDGET_HARD_MAX_TOKENS=500000
+# The warning ratio asks the model to converge; the fallback reserve forces a
+# tool-free synthesis before the ceiling.
+LENSNODE_TOKEN_BUDGET_FINAL_RESERVE_TOKENS=40000
+LENSNODE_TOKEN_BUDGET_WARN_RATIO=0.8
+# Initial plan generation is coordination work; restore the Assistant's normal
+# reasoning effort immediately after write_todos succeeds.
+LENSNODE_PLANNING_REASONING_EFFORT=none
+# URL MCP connection/discovery and per-call limits.
+LENSNODE_MCP_DISCOVERY_TIMEOUT_S=30
+LENSNODE_MCP_TOOL_TIMEOUT_S=60
+# Defer MCP schemas behind tool_search when the loaded tool count exceeds this.
+LENSNODE_MCP_DEFER_THRESHOLD=12
+# Comma-separated allowlist of stdio MCP commands that may be spawned.
+# Empty means no stdio servers run (fail closed).
+LENSNODE_MCP_STDIO_ALLOWLIST=codegraph
+# Built-in CodeGraph plugin: index the workspace and serve it over stdio MCP.
+LENSNODE_MCP_ENABLE_CODEGRAPH=true
+LENSNODE_CODEGRAPH_COMMAND=codegraph
+LENSNODE_CODEGRAPH_INIT_TIMEOUT_S=300
+# Re-run the planner with a repair prompt after an invalid retrieval plan
+# instead of falling back to bounded keyword search immediately. The repair
+# costs one extra model call per invalid plan; the fallback is fast.
+LENSNODE_PLANNER_REPAIR_ENABLED=false
+
+# -----------------------------------------------------------------------------
+# Admin bootstrap
+# -----------------------------------------------------------------------------
+DJANGO_SUPERUSER_USERNAME=admin
+DJANGO_SUPERUSER_EMAIL=admin@example.com
+DJANGO_SUPERUSER_PASSWORD=adminpassword
+
+# -----------------------------------------------------------------------------
+# Email / OAuth
+# -----------------------------------------------------------------------------
+EMAIL_BACKEND=django.core.mail.backends.smtp.EmailBackend
+EMAIL_HOST=smtp.gmail.com
+EMAIL_PORT=587
+EMAIL_HOST_USER=your-email@example.com
+EMAIL_HOST_PASSWORD=your-app-password
+EMAIL_USE_TLS=true
+EMAIL_USE_SSL=false
+DEFAULT_FROM_EMAIL=noreply@sourcelens.local
+
+GOOGLE_OAUTH_CLIENT_ID=
+GOOGLE_OAUTH_CLIENT_SECRET=
+
+# -----------------------------------------------------------------------------
+# Email verification-code (OTP) login
+# -----------------------------------------------------------------------------
+OTP_CODE_TTL_SECONDS=300
+OTP_MAX_ATTEMPTS=5
+OTP_SEND_COOLDOWN_SECONDS=60
+OTP_SEND_MAX_PER_DAY=10
+OTP_SEND_MAX_PER_IP_HOUR=20
+
+# -----------------------------------------------------------------------------
+# Cloudflare Turnstile
+# -----------------------------------------------------------------------------
+# Keep enabled outside local development.
+TURNSTILE_ENABLED=true
+# Backend secret key (required when enabled outside debug mode).
+TURNSTILE_SECRET_KEY=
+# Frontend widget site key (build-time, VITE_ prefix).
+VITE_TURNSTILE_SITE_KEY=
+
+# -----------------------------------------------------------------------------
+# Sentry
+# -----------------------------------------------------------------------------
+# Backend and LensNode share the following project (same DSN/environment).
+SENTRY_ENABLED=false
+SENTRY_DSN=
+SENTRY_ENVIRONMENT=production
+SENTRY_RELEASE=
+SENTRY_TRACES_SAMPLE_RATE=0.1
+SENTRY_PROFILING_SAMPLE_RATE=0.05
+SENTRY_SEND_DEFAULT_PII=false
+
+# -----------------------------------------------------------------------------
+# Langfuse LLM observability
+# -----------------------------------------------------------------------------
+# Langfuse is enabled only when both keys are non-empty. Leave either key empty
+# to keep the integration disabled. Set LANGFUSE_OTEL_HOST only for a specific
+# Langfuse Cloud region or a self-hosted Langfuse host.
+# Keep LITELLM_OTEL_V2 unset with LiteLLM 1.91.3. Its v2 logger does not close
+# spans for the synchronous SDK calls used by SourceLens.
+LANGFUSE_PUBLIC_KEY=
+LANGFUSE_SECRET_KEY=
+# LANGFUSE_OTEL_HOST=https://<langfuse-host>
+# Add privacy-bounded step summaries to Langfuse observation metadata.
+LANGFUSE_OBSERVATION_SUMMARY_ENABLED=false
+
+# Frontend uses a separate Sentry project (build-time, VITE_ prefix).
+VITE_SENTRY_DSN=
+VITE_SENTRY_ENVIRONMENT=production
+VITE_SENTRY_TRACES_SAMPLE_RATE=0.1
+VITE_SENTRY_SEND_DEFAULT_PII=false
+
+# -----------------------------------------------------------------------------
+# Google Analytics (frontend, build-time)
+# -----------------------------------------------------------------------------
+# GA4 measurement ID, e.g. G-XXXXXXXXXX. Empty disables analytics.
+VITE_GA_ID=

--- a/deploy/online/sourcelens/nginx/default.conf
+++ b/deploy/online/sourcelens/nginx/default.conf
@@ -1,0 +1,293 @@
+include /etc/nginx/hfl-maintenance/run-creation-gate.conf;
+
+# Single-file nginx config for docker-compose.standalone.yml (single-instance,
+# non-blue/green production). Unlike the blue/green prod stack — which mounts
+# the whole conf.d/ directory and swaps a runtime upstream.conf between colors —
+# this proxies straight to the fixed backend-api / frontend service names.
+#
+# The upstreams are resolved via Docker's embedded DNS on each request (set +
+# resolver, not a static upstream block) so a plain `docker compose up -d`
+# recreating backend-api in place is picked up without an nginx reload.
+resolver 127.0.0.11 valid=10s ipv6=off;
+
+# HTTPS server configuration
+server {
+    # HFL-owned upgrade barrier for direct SourceLens Run creation.
+    if ($hfl_sourcelens_run_creation_blocked) {
+        return 503;
+    }
+    listen 443 ssl;
+    server_name localhost;
+
+    ssl_certificate /etc/nginx/certs/tls.crt;
+    ssl_certificate_key /etc/nginx/certs/tls.key;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers HIGH:!aNULL:!MD5;
+    ssl_prefer_server_ciphers on;
+
+    client_max_body_size 100M;
+    set $api_upstream http://backend-api:8000;
+    set $ui_upstream http://web:80;
+
+    gzip on;
+    gzip_vary on;
+    gzip_min_length 1024;
+    gzip_types text/plain text/css text/xml text/javascript application/x-javascript application/xml+rss application/javascript application/json;
+
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-XSS-Protection "1; mode=block" always;
+    add_header X-Accel-Buffering "no" always;
+
+    location /api/ {
+        proxy_buffering off;
+        proxy_cache off;
+        proxy_pass $api_upstream;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_redirect off;
+        proxy_connect_timeout 600s;
+        proxy_send_timeout 600s;
+        proxy_read_timeout 600s;
+    }
+
+    location /ws/ {
+        proxy_pass $api_upstream;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_connect_timeout 600s;
+        proxy_send_timeout 600s;
+        proxy_read_timeout 600s;
+    }
+
+    location ~ ^/(accounts|_allauth)/ {
+        proxy_pass $api_upstream;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_redirect off;
+        proxy_connect_timeout 600s;
+        proxy_send_timeout 600s;
+        proxy_read_timeout 600s;
+    }
+
+    location ~ ^/admin {
+        proxy_pass $api_upstream;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_redirect off;
+        proxy_connect_timeout 600s;
+        proxy_send_timeout 600s;
+        proxy_read_timeout 600s;
+    }
+
+    location /static/ {
+        alias /staticfiles/;
+        autoindex off;
+        expires 30d;
+        add_header Cache-Control "public, immutable";
+    }
+
+    location /media/storage/ {
+        alias /opt/storage/;
+        autoindex off;
+        expires 7d;
+        add_header Cache-Control "public, max-age=604800";
+        add_header X-Content-Type-Options "nosniff";
+    }
+
+    location /health {
+        proxy_pass $api_upstream;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+    }
+
+    location ~ ^/(swagger|redoc|api/schema) {
+        proxy_pass $api_upstream;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-Host $host;
+    }
+
+    # HFL-owned runtime observability adapter; SourceLens source remains unchanged.
+    location = /hfl-sentry-config.js {
+        alias /etc/nginx/hfl-sentry-config.js;
+        add_header Cache-Control "no-store" always;
+    }
+    location = /hfl-sentry-loader.js {
+        alias /etc/nginx/hfl-sentry-loader.js;
+        add_header Cache-Control "no-store" always;
+    }
+
+    location / {
+        proxy_set_header Accept-Encoding "";
+        sub_filter_once on;
+        sub_filter '</head>' '<script src="/hfl-sentry-config.js"></script><script src="/hfl-sentry-loader.js"></script></head>';
+        proxy_pass $ui_upstream;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_redirect off;
+        proxy_connect_timeout 30s;
+        proxy_send_timeout 30s;
+        proxy_read_timeout 30s;
+    }
+}
+
+# HTTP server configuration
+server {
+    # HFL-owned upgrade barrier for direct SourceLens Run creation.
+    if ($hfl_sourcelens_run_creation_blocked) {
+        return 503;
+    }
+    listen 80;
+    server_name localhost;
+
+    client_max_body_size 100M;
+    set $api_upstream http://backend-api:8000;
+    set $ui_upstream http://web:80;
+
+    gzip on;
+    gzip_vary on;
+    gzip_min_length 1024;
+    gzip_types text/plain text/css text/xml text/javascript application/x-javascript application/xml+rss application/javascript application/json;
+
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-XSS-Protection "1; mode=block" always;
+    add_header X-Accel-Buffering "no" always;
+
+    location /api/ {
+        proxy_buffering off;
+        proxy_cache off;
+        proxy_pass $api_upstream;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_redirect off;
+        proxy_connect_timeout 600s;
+        proxy_send_timeout 600s;
+        proxy_read_timeout 600s;
+    }
+
+    location /ws/ {
+        proxy_pass $api_upstream;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_connect_timeout 600s;
+        proxy_send_timeout 600s;
+        proxy_read_timeout 600s;
+    }
+
+    location ~ ^/(accounts|_allauth)/ {
+        proxy_pass $api_upstream;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_redirect off;
+        proxy_connect_timeout 600s;
+        proxy_send_timeout 600s;
+        proxy_read_timeout 600s;
+    }
+
+    location ~ ^/admin {
+        proxy_pass $api_upstream;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_redirect off;
+        proxy_connect_timeout 600s;
+        proxy_send_timeout 600s;
+        proxy_read_timeout 600s;
+    }
+
+    location /static/ {
+        alias /staticfiles/;
+        autoindex off;
+        expires 30d;
+        add_header Cache-Control "public, immutable";
+    }
+
+    location /media/storage/ {
+        alias /opt/storage/;
+        autoindex off;
+        expires 7d;
+        add_header Cache-Control "public, max-age=604800";
+        add_header X-Content-Type-Options "nosniff";
+    }
+
+    location /health {
+        proxy_pass $api_upstream;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location ~ ^/(swagger|redoc|api/schema) {
+        proxy_pass $api_upstream;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $host;
+    }
+
+    # HFL-owned runtime observability adapter; SourceLens source remains unchanged.
+    location = /hfl-sentry-config.js {
+        alias /etc/nginx/hfl-sentry-config.js;
+        add_header Cache-Control "no-store" always;
+    }
+    location = /hfl-sentry-loader.js {
+        alias /etc/nginx/hfl-sentry-loader.js;
+        add_header Cache-Control "no-store" always;
+    }
+
+    location / {
+        proxy_set_header Accept-Encoding "";
+        sub_filter_once on;
+        sub_filter '</head>' '<script src="/hfl-sentry-config.js"></script><script src="/hfl-sentry-loader.js"></script></head>';
+        proxy_pass $ui_upstream;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_redirect off;
+        proxy_connect_timeout 30s;
+        proxy_send_timeout 30s;
+        proxy_read_timeout 30s;
+    }
+}

--- a/deploy/online/sourcelens/postgresql/etc/postgresql.conf
+++ b/deploy/online/sourcelens/postgresql/etc/postgresql.conf
@@ -1,0 +1,168 @@
+# PostgreSQL Configuration File
+# Optimized for: 2 CPU cores, 7.25GB RAM
+# Based on MySQL/MariaDB configuration optimization patterns
+
+# ============================================================================
+# Basic Settings
+# ============================================================================
+# Character encoding (PostgreSQL defaults to UTF8, similar to MySQL utf8mb4)
+# No explicit setting needed - UTF8 is default and fully supports all characters
+
+# Listen addresses
+# Must be '*' to accept connections from other Docker containers
+listen_addresses = '*'
+
+# Maximum number of concurrent connections
+# Reduced for 2-core system (prevents overload)
+# MySQL equivalent: max_connections = 50
+max_connections = 50
+
+# Maximum number of prepared transactions
+# Should be at least as large as max_connections
+max_prepared_transactions = 50
+
+# ============================================================================
+# Memory Settings (Optimized for 7.25GB RAM system)
+# ============================================================================
+
+# Shared memory buffer pool
+# Main cache for data and indexes (similar to MySQL innodb_buffer_pool_size)
+# MySQL equivalent: innodb_buffer_pool_size = 1536M (~20% of total RAM)
+# PostgreSQL recommendation: 25% of RAM, but we match MySQL's conservative 20%
+shared_buffers = 1536MB
+
+# Effective cache size for query planner
+# Helps query planner estimate how much memory is available for disk caching
+# Should be 50-75% of total RAM (we use 75% = 5.4GB)
+effective_cache_size = 5400MB
+
+# Work memory per sort/hash operation per connection
+# MySQL equivalent: tmp_table_size = 32M, max_heap_table_size = 32M
+# For 50 connections: 32MB * 50 = 1600MB max, but only used during sorts/hashes
+work_mem = 32MB
+
+# Maintenance work memory for VACUUM, CREATE INDEX, etc.
+# Should be higher than work_mem but used infrequently
+# MySQL equivalent: larger temp tables for maintenance
+maintenance_work_mem = 256MB
+
+# WAL (Write-Ahead Log) buffers
+# Similar to MySQL innodb_log_file_size but different mechanism
+# MySQL equivalent: innodb_log_file_size = 128M
+wal_buffers = 16MB
+
+# Maximum WAL size before checkpoint forced
+# Allows PostgreSQL to spread out checkpoint writes (similar to MySQL log flush behavior)
+# MySQL equivalent: innodb_flush_log_at_trx_commit = 1
+max_wal_size = 2GB
+min_wal_size = 512MB
+
+# ============================================================================
+# Checkpoint Settings
+# ============================================================================
+# Checkpoint completion target (0.0 - 1.0)
+# Higher values spread checkpoint I/O over longer period
+checkpoint_completion_target = 0.9
+
+# ============================================================================
+# Query Tuning
+# ============================================================================
+# Random page cost (default: 4.0)
+# Lower values favor index scans, higher values favor sequential scans
+# For SSD, lower value is appropriate; for HDD, keep default
+random_page_cost = 1.1
+
+# Effective I/O concurrency
+# Number of concurrent I/O operations expected
+effective_io_concurrency = 200
+
+# ============================================================================
+# Logging Settings
+# ============================================================================
+# Enable logging
+logging_collector = on
+
+# Log directory
+log_directory = '/var/log/postgresql'
+
+# Log filename pattern
+log_filename = 'postgresql-%Y-%m-%d.log'
+
+# Log slow queries (similar to MySQL slow_query_log)
+# MySQL equivalent: slow_query_log = 1, long_query_time = 2
+log_min_duration_statement = 2000  # Log queries slower than 2 seconds (in milliseconds)
+
+# Log connection and disconnection
+log_connections = on
+log_disconnections = on
+
+# Log duration for all statements (useful for monitoring)
+# log_duration = on
+
+# Log lock waits
+log_lock_waits = on
+
+# ============================================================================
+# Networking Settings
+# ============================================================================
+# Note: connect_timeout is a client-side parameter, not a server-side parameter
+# Connection timeout is handled by the client (Django) via connection string options
+
+# Idle in transaction session timeout
+# Close idle transactions after timeout (for long-running tasks)
+# MySQL equivalent: wait_timeout = 1800, interactive_timeout = 1800
+idle_in_transaction_session_timeout = 1800000  # 30 minutes (in milliseconds)
+
+# TCP keepalives
+tcp_keepalives_idle = 600
+tcp_keepalives_interval = 30
+tcp_keepalives_count = 3
+
+# ============================================================================
+# Statement Behavior
+# ============================================================================
+# Statement timeout
+# Prevent queries from running too long (in milliseconds)
+# MySQL equivalent: max_execution_time (per-query timeout)
+statement_timeout = 300000  # 5 minutes
+
+# Lock timeout
+lock_timeout = 0  # No timeout (wait indefinitely)
+
+# ============================================================================
+# Autovacuum Settings
+# ============================================================================
+# Enable autovacuum (PostgreSQL's equivalent of MySQL's automatic maintenance)
+autovacuum = on
+
+# Autovacuum work memory
+autovacuum_work_mem = 128MB
+
+# Autovacuum max workers
+autovacuum_max_workers = 2  # Reduced for 2-core system
+
+# ============================================================================
+# Other Settings
+# ============================================================================
+# Time zone
+timezone = 'UTC'
+
+# Locale
+lc_messages = 'en_US.utf8'
+lc_monetary = 'en_US.utf8'
+lc_numeric = 'en_US.utf8'
+lc_time = 'en_US.utf8'
+
+# Default text search config
+default_text_search_config = 'pg_catalog.english'
+
+# Performance impact settings (similar to MySQL performance_schema = OFF)
+# PostgreSQL doesn't have equivalent, but we can disable some features if not needed
+track_activities = on  # Keep on for monitoring
+track_counts = on      # Keep on for autovacuum
+track_io_timing = off  # Disable if not needed (slight performance improvement)
+track_functions = none # Disable function call tracking if not needed
+
+# Max file descriptor limits (PostgreSQL will warn if too low)
+# Should be set at OS level (ulimit -n), but we note it here
+# Recommended: at least max_connections * 2

--- a/deploy/online/sourcelens/postgresql/initdb.d/000-create-databases.sql
+++ b/deploy/online/sourcelens/postgresql/initdb.d/000-create-databases.sql
@@ -1,0 +1,5 @@
+-- The official PostgreSQL image already creates POSTGRES_DB and grants it
+-- to POSTGRES_USER during initial bootstrap.
+--
+-- Keep this file as a no-op so the initdb.d ordering stays stable without
+-- attempting CREATE DATABASE inside a transaction block.

--- a/deploy/online/sourcelens/postgresql/initdb.d/001-grant-schema-privileges.sh
+++ b/deploy/online/sourcelens/postgresql/initdb.d/001-grant-schema-privileges.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+
+# Grant schema privileges to the superuser (created by POSTGRES_USER)
+# This script uses the POSTGRES_USER environment variable to grant privileges
+# to the correct user, regardless of what name was set
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "${POSTGRES_DB:-sourcelens}" <<-EOSQL
+    -- Grant schema privileges to the superuser
+    GRANT ALL ON SCHEMA public TO "$POSTGRES_USER";
+    ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO "$POSTGRES_USER";
+    ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO "$POSTGRES_USER";
+    ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON FUNCTIONS TO "$POSTGRES_USER";
+EOSQL

--- a/deploy/online/sourcelens/postgresql/initdb.d/002-setup-log-permissions.sh
+++ b/deploy/online/sourcelens/postgresql/initdb.d/002-setup-log-permissions.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e
+
+# Setup log directory permissions for PostgreSQL
+# This script runs before PostgreSQL starts
+
+LOG_DIR="/var/log/postgresql"
+
+# Create log directory if it doesn't exist
+mkdir -p "$LOG_DIR"
+
+# Set ownership to postgres user (UID 999 in PostgreSQL container)
+chown -R postgres:postgres "$LOG_DIR"
+
+# Set permissions
+chmod -R 755 "$LOG_DIR"
+
+echo "PostgreSQL log directory permissions set successfully"

--- a/deploy/online/sourcelens/runtime.json
+++ b/deploy/online/sourcelens/runtime.json
@@ -1,0 +1,5 @@
+{
+  "git_commit": "80ff6ba7d96015f3f65dea6db729b285bf6e4296",
+  "git_ref": "v0.40.0",
+  "version": "0.40.0"
+}

--- a/deploy/online/verify-public-images.sh
+++ b/deploy/online/verify-public-images.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Verify that the complete Community online-install image set is anonymous.
+set -euo pipefail
+
+[[ $# -eq 1 && -d "$1" ]] || {
+	printf 'Usage: %s METADATA_DIR\n' "$0" >&2
+	exit 2
+}
+metadata_dir=$1
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+docker_config="$(mktemp -d)"
+tasks="$(mktemp)"
+trap 'rm -rf "${docker_config}"; rm -f "${tasks}"' EXIT
+
+python3 - "${metadata_dir}" "${root}/deploy/online/sourcelens/runtime.json" >"${tasks}" <<'PY'
+import json
+import pathlib
+import re
+import sys
+
+root = pathlib.Path(sys.argv[1])
+runtime = json.loads(pathlib.Path(sys.argv[2]).read_text(encoding="utf-8"))
+if not re.fullmatch(r"v[0-9]+\.[0-9]+\.[0-9]+", str(runtime.get("git_ref") or "")):
+    raise SystemExit("invalid online SourceLens git_ref")
+if not re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+", str(runtime.get("version") or "")):
+    raise SystemExit("invalid online SourceLens version")
+if runtime["git_ref"] != f"v{runtime['version']}":
+    raise SystemExit("online SourceLens git_ref and version differ")
+if not re.fullmatch(r"[0-9a-f]{40}", str(runtime.get("git_commit") or "")):
+    raise SystemExit("invalid online SourceLens git_commit")
+selected = {}
+sourcelens_components = set()
+for path in sorted(root.glob("*.json")):
+    metadata = json.loads(path.read_text(encoding="utf-8"))
+    component = str(metadata.get("component") or "")
+    if component in {"hfl-backend", "hfl-frontend"}:
+        # The public installer uses Community HFL images, not the EE pair.
+        continue
+    if component.startswith("community-hfl-") or component in {
+        "postgres",
+        "redis",
+        "sourcelens-backend",
+        "sourcelens-frontend",
+        "sourcelens-lensnode",
+        "sourcelens-nginx",
+        "agent-assets",
+        "gateway-assets",
+        "language-assets",
+    }:
+        if component in {
+            "sourcelens-backend",
+            "sourcelens-frontend",
+            "sourcelens-lensnode",
+        }:
+            for field, expected in {
+                "sourcelens_version": runtime["version"],
+                "sourcelens_git_ref": runtime["git_ref"],
+                "sourcelens_git_commit": runtime["git_commit"],
+            }.items():
+                if metadata.get(field) != expected:
+                    raise SystemExit(
+                        f"{component} {field} does not match the online contract"
+                    )
+            sourcelens_components.add(component)
+        digest = str(metadata.get("digest") or "")
+        sources = metadata.get("sources") or []
+        if not re.fullmatch(r"sha256:[0-9a-f]{64}", digest):
+            raise SystemExit(f"invalid public image digest in {path}")
+        regions = {str(source.get("region") or "") for source in sources}
+        if len(sources) != 2 or regions != {"cn", "global"}:
+            raise SystemExit(f"public image sources are incomplete in {path}")
+        for source in sources:
+            ref = str(source.get("ref") or "")
+            selected[ref] = digest
+
+if sourcelens_components != {
+    "sourcelens-backend",
+    "sourcelens-frontend",
+    "sourcelens-lensnode",
+}:
+    raise SystemExit("online SourceLens component metadata is incomplete")
+if len(selected) != 22:
+    raise SystemExit(f"expected 22 regional Community image refs, found {len(selected)}")
+for ref, digest in sorted(selected.items()):
+    print(f"{ref}\t{digest}")
+PY
+
+while IFS=$'\t' read -r ref expected; do
+	[[ -n "${ref}" ]] || continue
+	printf '[....] Anonymous manifest check: %s\n' "${ref}"
+	manifest="$(DOCKER_CONFIG="${docker_config}" timeout 60s \
+		docker buildx imagetools inspect "${ref}" --format '{{json .Manifest}}')"
+	actual="$(python3 -c 'import json,sys; print(json.loads(sys.stdin.read()).get("digest", ""))' \
+		<<<"${manifest}")"
+	[[ "${actual}" == "${expected}" ]] || {
+		printf 'ERROR: public image digest mismatch for %s (%s != %s)\n' \
+			"${ref}" "${actual:-missing}" "${expected}" >&2
+		exit 1
+	}
+	printf '[ OK ] Public image available: %s@%s\n' "${ref}" "${actual}"
+done <"${tasks}"

--- a/release/ci/assemble-saas-candidate.sh
+++ b/release/ci/assemble-saas-candidate.sh
@@ -71,7 +71,8 @@ docker pull --platform linux/amd64 "${NGINX_IMAGE}"
 docker tag "${NGINX_IMAGE}" nginx:stable-alpine
 
 export SOURCELENS_HFL_VERSION="${version}"
-BUILD_SOURCELENS=1 "${ROOT}/release/build-sourcelens.sh" \
+SOURCELENS_DISTRIBUTION_TAG_OVERRIDE="${version}" \
+	BUILD_SOURCELENS=1 "${ROOT}/release/build-sourcelens.sh" \
 	--pkg-root "${pkg_root}" \
 	--images-dir "${images_dir}" \
 	--prebuilt \

--- a/release/ci/build-sourcelens-image.sh
+++ b/release/ci/build-sourcelens-image.sh
@@ -43,13 +43,14 @@ registry_namespace=${registry_prefix#*/}
 hfl_version="$(normalize_artifact_id "${hfl_version}")"
 
 sourcelens_load_config
+SOURCELENS_HFL_VERSION="${hfl_version}"
 sourcelens_resolve_version
 hfl_logging_configure "ci-sourcelens-${component}"
 hfl_logging_start
 trap 'hfl_logging_finish "$?"' EXIT
 
 sourcelens_sync_source
-target_ref="${registry_prefix}/hyperfilelens-sourcelens-${component}:${hfl_version}-sl${SOURCELENS_VERSION}"
+target_ref="${registry_prefix}/hyperfilelens-sourcelens-${component}:${SOURCELENS_DISTRIBUTION_TAG}"
 source_commit="$(git -C "${SOURCELENS_SOURCE_CACHE}" rev-parse HEAD)"
 fingerprint="$({
 	sourcelens_component_build_identity "${component}" "${source_commit}"
@@ -86,7 +87,7 @@ fi
 if [[ "${component}" == "frontend" ]]; then
 	if ! SOURCELENS_BUILD_SOURCE_MAPS=1 \
 		"${ROOT}/release/ci/upload-sourcelens-sourcemaps.sh" \
-		"hyperfilelens-sourcelens-frontend@${hfl_version}-sl${SOURCELENS_VERSION}"; then
+		"hyperfilelens-sourcelens-frontend@${SOURCELENS_DISTRIBUTION_TAG}"; then
 		printf '::warning title=Sentry Source Maps::Bundled SourceLens symbol processing failed; the image build will continue.\n'
 	fi
 fi

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -976,7 +976,9 @@ if grep -F 'image already loaded' "${installer}" >/dev/null; then
 fi
 
 sourcelens_image_builder="${ROOT}/release/ci/build-sourcelens-image.sh"
-grep -F 'target_ref="${registry_prefix}/hyperfilelens-sourcelens-${component}:${hfl_version}-sl${SOURCELENS_VERSION}"' \
+grep -F 'SOURCELENS_HFL_VERSION="${hfl_version}"' \
+	"${sourcelens_image_builder}" >/dev/null
+grep -F 'target_ref="${registry_prefix}/hyperfilelens-sourcelens-${component}:${SOURCELENS_DISTRIBUTION_TAG}"' \
 	"${sourcelens_image_builder}" >/dev/null
 grep -F 'registry prefix must include host and namespace' \
 	"${sourcelens_image_builder}" >/dev/null

--- a/tools/quality/test-online-community-install.sh
+++ b/tools/quality/test-online-community-install.sh
@@ -1,0 +1,268 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+workflow="${ROOT}/.github/workflows/enterprise_saas_upgrade.yml"
+online="${ROOT}/deploy/online"
+tmp="$(mktemp -d)"
+trap 'rm -rf "${tmp}"' EXIT
+export PYTHONDONTWRITEBYTECODE=1
+
+bash -n "${online}/install.sh"
+PYTHONPYCACHEPREFIX="${tmp}/pycache" python3 -m py_compile "${online}/prepare.py"
+
+grep -Fq 'name: HFL - Publish Images & Upgrade SaaS' "${workflow}"
+grep -Fq 'Publish · ${{ github.event_name == '\''push'\'' && github.ref_name || inputs.tag }} · Images · Enterprise SaaS Upgrade' "${workflow}"
+grep -Fq 'name: Community · Backend' "${workflow}"
+grep -Fq 'name: Enterprise · Backend' "${workflow}"
+grep -Fq 'tag_suffix: -ee' "${workflow}"
+grep -Fq 'hyperfilelens-agent-assets:${{ needs.prepare.outputs.version }}' "${workflow}"
+grep -Fq 'hyperfilelens-gateway-assets:${{ needs.prepare.outputs.version }}' "${workflow}"
+grep -Fq 'hyperfilelens-language-assets:${{ needs.prepare.outputs.version }}' "${workflow}"
+grep -Fq 'SOURCELENS_DISTRIBUTION_TAG_OVERRIDE="${version}"' \
+	"${ROOT}/release/ci/assemble-saas-candidate.sh"
+grep -Fq 'SOURCELENS_DISTRIBUTION_TAG_OVERRIDE: ${{ needs.prepare.outputs.version }}' \
+	"${workflow}"
+if grep -E 'hyperfilelens-(agent|gateway|language)-assets:.*image_version' "${workflow}"; then
+	printf 'ERROR: OSS asset images must not use the Enterprise image suffix\n' >&2
+	exit 1
+fi
+
+for file in \
+	sourcelens/env.example \
+	sourcelens/nginx/default.conf \
+	sourcelens/postgresql/etc/postgresql.conf \
+	sourcelens/postgresql/initdb.d/000-create-databases.sql \
+	sourcelens/postgresql/initdb.d/001-grant-schema-privileges.sh \
+	sourcelens/postgresql/initdb.d/002-setup-log-permissions.sh \
+	sourcelens/runtime.json; do
+	[[ -s "${online}/${file}" ]] || {
+		printf 'ERROR: missing online runtime template: %s\n' "${file}" >&2
+		exit 1
+	}
+done
+
+(
+	# shellcheck source=../../tools/sourcelens/common.sh
+	source "${ROOT}/tools/sourcelens/common.sh"
+	sourcelens_load_config
+	SOURCELENS_GIT_REF=v0.40.0
+	SOURCELENS_HFL_VERSION=1.2.3
+	sourcelens_resolve_version
+	[[ "${SOURCELENS_DISTRIBUTION_TAG}" == 1.2.3-sl0.40.0 ]]
+)
+(
+	# shellcheck source=../../tools/sourcelens/common.sh
+	source "${ROOT}/tools/sourcelens/common.sh"
+	sourcelens_load_config
+	SOURCELENS_GIT_REF=v0.40.0
+	SOURCELENS_HFL_VERSION=1.2.3
+	SOURCELENS_DISTRIBUTION_TAG_OVERRIDE=1.2.3
+	sourcelens_resolve_version
+	[[ "${SOURCELENS_DISTRIBUTION_TAG}" == 1.2.3 ]]
+)
+
+python3 - "${ROOT}" <<'PY'
+from __future__ import annotations
+
+import importlib.util
+import json
+import pathlib
+import re
+import tempfile
+import sys
+
+root = pathlib.Path(sys.argv[1])
+module_path = root / "deploy/online/prepare.py"
+spec = importlib.util.spec_from_file_location("hfl_online_prepare", module_path)
+if spec is None or spec.loader is None:
+    raise SystemExit("could not load online prepare module")
+module = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = module
+spec.loader.exec_module(module)
+
+runtime = json.loads(
+    (root / "deploy/online/sourcelens/runtime.json").read_text(encoding="utf-8")
+)
+defaults = (root / "tools/sourcelens/defaults.env").read_text(encoding="utf-8")
+match = re.search(r"SOURCELENS_GIT_REF=.*?(v\d+\.\d+\.\d+)", defaults)
+if match is None or runtime["git_ref"] != match.group(1):
+    raise SystemExit("online SourceLens runtime does not match the HFL default ref")
+
+with tempfile.TemporaryDirectory() as temporary:
+    output = pathlib.Path(temporary) / "docker-compose.yml"
+    module.render_sourcelens_compose(
+        root / "deploy/installer/sourcelens/docker-compose.template.yml",
+        output,
+        "1.2.3",
+    )
+    compose = output.read_text(encoding="utf-8")
+    for component in ("backend", "frontend"):
+        expected = f"hyperfilelens-sourcelens-{component}:1.2.3"
+        if expected not in compose:
+            raise SystemExit(f"rendered SourceLens Compose is missing {expected}")
+    if "__SOURCELENS_" in compose or "HFL_EMBED_" in compose:
+        raise SystemExit("rendered SourceLens Compose retained a template marker")
+
+with tempfile.TemporaryDirectory() as temporary:
+    asset = pathlib.Path(temporary)
+    (asset / ".asset-kind").write_text("language\n", encoding="utf-8")
+    catalogs = asset / "payload/language-packs"
+    catalogs.mkdir(parents=True)
+    (catalogs / "test.tar.gz").write_bytes(b"test")
+    module.validate_asset_tree(asset, "language")
+PY
+
+fake_bin="${tmp}/bin"
+candidate="${tmp}/hyperfilelens-1.2.3-online"
+mkdir -p "${fake_bin}"
+cat >"${fake_bin}/docker" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+digest="sha256:$(printf 'b%.0s' {1..64})"
+revision="$(printf 'c%.0s' {1..40})"
+case "${1:-} ${2:-}" in
+"pull --platform")
+	exit 0
+	;;
+"image inspect")
+	ref=${3:-}
+	format=${5:-}
+	if [[ "${format}" == *RepoDigests* ]]; then
+		printf '["%s@%s"]\n' "${ref%:*}" "${digest}"
+	else
+		printf '%s\n' "${revision}"
+	fi
+	;;
+"buildx imagetools")
+	printf '{"digest":"%s"}\n' "${digest}"
+	;;
+"tag "* | "rm -f" | "image rm")
+	exit 0
+	;;
+"create "*)
+	case "${2:-}" in
+	*agent-assets*) printf 'cid-agent\n' ;;
+	*gateway-assets*) printf 'cid-gateway\n' ;;
+	*language-assets*) printf 'cid-language\n' ;;
+	*) exit 2 ;;
+	esac
+	;;
+"cp "*)
+	source_path=${2:-}
+	target=${3:-}
+	case "${source_path}" in
+	cid-agent:*)
+		mkdir -p \
+			"${target}/payload/media/agent-releases/${HFL_TEST_VERSION}" \
+			"${target}/payload/media/enroll-bootstrap/${HFL_TEST_VERSION}"
+		printf 'agent\n' >"${target}/.asset-kind"
+		printf 'agent\n' >"${target}/payload/media/agent-releases/${HFL_TEST_VERSION}/agent.tar.gz"
+		printf 'installer\n' >"${target}/payload/media/enroll-bootstrap/${HFL_TEST_VERSION}/hfl-installer-linux-amd64.tar.gz"
+		;;
+	cid-gateway:*)
+		root="${target}/payload/media/gateway-bootstrap"
+		mkdir -p "${root}"
+		printf 'gateway\n' >"${target}/.asset-kind"
+		for file in \
+			gateway-bootstrap-linux.sh \
+			gateway-install-lensnode-sidecar.sh \
+			gateway-lifecycle.sh \
+			gateway-install-docker-ubuntu-amd64.sh \
+			hfl-sentry-sitecustomize.py \
+			docker-debs-ubuntu2004-amd64.tar.gz \
+			docker-debs-ubuntu2204-amd64.tar.gz \
+			docker-debs-ubuntu2404-amd64.tar.gz \
+			lensnode-image-linux-amd64.tar.gz; do
+			printf 'gateway\n' >"${root}/${file}"
+		done
+		;;
+	cid-language:*)
+		mkdir -p "${target}/payload/language-packs"
+		printf 'language\n' >"${target}/.asset-kind"
+		printf 'language\n' >"${target}/payload/language-packs/hyperfilelens-lang-zh-hans-${HFL_TEST_VERSION}.tar.gz"
+		;;
+	*) exit 2 ;;
+	esac
+	;;
+*)
+	printf 'unexpected fake docker invocation: %s\n' "$*" >&2
+	exit 2
+	;;
+esac
+SH
+chmod 755 "${fake_bin}/docker"
+
+PATH="${fake_bin}:${PATH}" HFL_TEST_VERSION=1.2.3 \
+	python3 "${online}/prepare.py" \
+		--source-root "${ROOT}" \
+		--version v1.2.3 \
+		--region global \
+		--output "${candidate}"
+
+python3 - "${candidate}/MANIFEST.json" <<'PY'
+import json
+import pathlib
+import sys
+
+manifest = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+assert manifest["edition"] == "community"
+assert manifest["image_version"] == "1.2.3"
+assert manifest["runtime_images"] == {
+    "backend": "hyperfilelens-backend:1.2.3",
+    "frontend": "hyperfilelens-frontend:1.2.3",
+}
+assets = manifest["delivery"]["asset_images"]
+assert {entry["local_ref"] for entry in assets} == {
+    "hyperfilelens-agent-assets:1.2.3",
+    "hyperfilelens-gateway-assets:1.2.3",
+    "hyperfilelens-language-assets:1.2.3",
+}
+assert all(not entry["local_ref"].endswith("-ee") for entry in assets)
+PY
+
+metadata="${tmp}/public-metadata"
+python3 - "${candidate}" "${metadata}" <<'PY'
+import json
+import pathlib
+import sys
+
+candidate = pathlib.Path(sys.argv[1])
+target = pathlib.Path(sys.argv[2])
+target.mkdir()
+manifest = json.loads((candidate / "MANIFEST.json").read_text(encoding="utf-8"))
+sourcelens = json.loads(
+    (candidate / "sourcelens/BUILD_INFO.json").read_text(encoding="utf-8")
+)
+entries = [
+    *(manifest["delivery"]["registry_images"]),
+    *(manifest["delivery"]["asset_images"]),
+]
+for entry in entries:
+    metadata = dict(entry)
+    component = metadata["component"]
+    if component in {"hfl-backend", "hfl-frontend"}:
+        component = f"community-{component}"
+        metadata["component"] = component
+    if component in {
+        "sourcelens-backend",
+        "sourcelens-frontend",
+        "sourcelens-lensnode",
+    }:
+        metadata.update(
+            sourcelens_version=sourcelens["version"],
+            sourcelens_git_ref=sourcelens["git_ref"],
+            sourcelens_git_commit=sourcelens["git_commit"],
+        )
+    (target / f"{component}.json").write_text(
+        json.dumps(metadata) + "\n", encoding="utf-8"
+    )
+PY
+PATH="${fake_bin}:${PATH}" "${online}/verify-public-images.sh" "${metadata}"
+
+# Source only defines functions because install.sh guards main with BASH_SOURCE.
+source "${ROOT}/deploy/installer/install.sh"
+ROOT="${candidate}"
+preflight_package_layout
+validate_publish_artifacts "${candidate}"
+preflight_sourcelens_bundle "${candidate}"

--- a/tools/sourcelens/common.sh
+++ b/tools/sourcelens/common.sh
@@ -83,7 +83,11 @@ sourcelens_resolve_version() {
 	[[ "${SOURCELENS_GIT_REF}" =~ ^v([0-9]+\.[0-9]+\.[0-9]+)$ ]] \
 		|| sourcelens_die "invalid SourceLens release ref: ${SOURCELENS_GIT_REF} (expected vX.Y.Z)" 2
 	SOURCELENS_VERSION="${BASH_REMATCH[1]}"
-	if [[ "${SOURCELENS_HFL_VERSION:-}" =~ ^([0-9]+\.[0-9]+\.[0-9]+|main-[0-9a-f]{7})$ ]]; then
+	if [[ -n "${SOURCELENS_DISTRIBUTION_TAG_OVERRIDE:-}" ]]; then
+		[[ "${SOURCELENS_DISTRIBUTION_TAG_OVERRIDE}" =~ ^([0-9]+\.[0-9]+\.[0-9]+|main-[0-9a-f]{7})$ ]] \
+			|| sourcelens_die "invalid SourceLens distribution tag override" 2
+		SOURCELENS_DISTRIBUTION_TAG="${SOURCELENS_DISTRIBUTION_TAG_OVERRIDE}"
+	elif [[ "${SOURCELENS_HFL_VERSION:-}" =~ ^([0-9]+\.[0-9]+\.[0-9]+|main-[0-9a-f]{7})$ ]]; then
 		SOURCELENS_DISTRIBUTION_TAG="${SOURCELENS_HFL_VERSION}-sl${SOURCELENS_VERSION}"
 	else
 		SOURCELENS_DISTRIBUTION_TAG="${SOURCELENS_VERSION}"


### PR DESCRIPTION
## Summary
- publish Community and Enterprise HFL images from the SaaS image workflow
- add a tag-driven Community online installer backed by public registries
- preserve existing Release image tags while validating mirror and SourceLens identity contracts

## Validation
- release contract checks
- Enterprise release and promotion contract tests
- SaaS registry delivery tests
- Community online installation tests
- CI release assembly, blue/green recovery, and upgrade transaction tests
- Ruff and workflow YAML validation