### PR TITLE
fix(release): align online SourceLens port contract

### DIFF
--- a/deploy/online/sourcelens/env.example
+++ b/deploy/online/sourcelens/env.example
@@ -28,7 +28,7 @@ PASSWORD_RESET_TIMEOUT=86400
 DJANGO_HOST_PORT=8000
 FLOWER_HOST_PORT=5555
 NGINX_HTTP_PORT=10080
-NGINX_HTTPS_PORT=10443
+NGINX_HTTPS_PORT=11445
 
 # -----------------------------------------------------------------------------
 # Database

--- a/tools/quality/test-online-community-install.sh
+++ b/tools/quality/test-online-community-install.sh
@@ -40,7 +40,13 @@ for file in \
 		printf 'ERROR: missing online runtime template: %s\n' "${file}" >&2
 		exit 1
 	}
-done
+	done
+
+grep -Fq 'NGINX_HTTPS_PORT=11445' "${online}/sourcelens/env.example"
+if grep -Eq '104(42|43|44|45|46)' "${online}/sourcelens/env.example"; then
+	printf 'ERROR: online SourceLens template references a legacy HFL public port\n' >&2
+	exit 1
+fi
 
 (
 	# shellcheck source=../../tools/sourcelens/common.sh


### PR DESCRIPTION
## Summary
- align the tracked online SourceLens HTTPS template with the HFL 11445 port contract
- add a regression check that rejects legacy 104xx public ports

## Validation
- release contract checks
- SaaS registry delivery tests
- Community online installation tests