### PR TITLE
fix(ci): retry transient registry mirror failures

### DIFF
--- a/release/ci/mirror-saas-image.sh
+++ b/release/ci/mirror-saas-image.sh
@@ -14,13 +14,108 @@ destination_ref=$3
 [[ "${digest}" =~ ^sha256:[0-9a-f]{64}$ ]]
 
 source_repository=${source_ref%:*}
-docker buildx imagetools create \
-	--prefer-index=false \
-	--tag "${destination_ref}" \
-	"${source_repository}@${digest}"
+attempts=5
+base_delay=${HFL_REGISTRY_MIRROR_RETRY_BASE_SECONDS:-5}
+jitter_max=${HFL_REGISTRY_MIRROR_RETRY_JITTER_SECONDS:-3}
+[[ "${base_delay}" =~ ^[0-9]+$ && "${jitter_max}" =~ ^[0-9]+$ ]] || {
+	printf 'ERROR: registry mirror retry timing must use non-negative integers\n' >&2
+	exit 2
+}
 
-manifest_json="$(docker buildx imagetools inspect \
-	"${destination_ref}" --format '{{json .Manifest}}')"
+copy_log="$(mktemp)"
+inspect_log="$(mktemp)"
+inspect_output="$(mktemp)"
+trap 'rm -f "${copy_log}" "${inspect_log}" "${inspect_output}"' EXIT
+
+mirror_error_is_retryable() {
+	grep -Eiq \
+		'too many requests|(status|response|http)[^[:cntrl:]]*(408|429|500|502|503|504)|request timeout|timeout|deadline exceeded|connection (reset|refused)|unexpected eof|tls handshake timeout|temporary failure|i/o timeout|network is unreachable|no such host' \
+		"$@"
+}
+
+wait_before_retry() {
+	local failed_attempt=$1
+	local operation=$2
+	local delay jitter wait_seconds
+
+	delay=$((base_delay * (1 << (failed_attempt - 1))))
+	((delay <= 40)) || delay=40
+	jitter=0
+	((jitter_max == 0)) || jitter=$((RANDOM % (jitter_max + 1)))
+	wait_seconds=$((delay + jitter))
+	printf 'WARN: temporary registry %s failure; retrying in %ss\n' \
+		"${operation}" "${wait_seconds}" >&2
+	sleep "${wait_seconds}"
+}
+
+copy_status=1
+for ((attempt = 1; attempt <= attempts; attempt++)); do
+	: >"${copy_log}"
+	printf '[....] Mirroring image (attempt %s/%s): %s -> %s\n' \
+		"${attempt}" "${attempts}" "${source_repository}@${digest}" "${destination_ref}"
+	if docker buildx imagetools create \
+		--prefer-index=false \
+		--tag "${destination_ref}" \
+		"${source_repository}@${digest}" 2>&1 | tee "${copy_log}"; then
+		pipeline_status=("${PIPESTATUS[@]}")
+	else
+		pipeline_status=("${PIPESTATUS[@]}")
+	fi
+	copy_status=${pipeline_status[0]:-1}
+	tee_status=${pipeline_status[1]:-1}
+	if ((tee_status != 0)); then
+		printf 'ERROR: failed to record registry mirror output\n' >&2
+		exit "${tee_status}"
+	fi
+	if ((copy_status == 0)); then
+		break
+	fi
+	if ! mirror_error_is_retryable "${copy_log}"; then
+		printf 'ERROR: registry mirror failed with a non-retryable error\n' >&2
+		exit "${copy_status}"
+	fi
+	if ((attempt == attempts)); then
+		break
+	fi
+	wait_before_retry "${attempt}" mirror
+done
+((copy_status == 0)) || {
+	printf 'ERROR: registry mirror failed after %s attempts\n' "${attempts}" >&2
+	exit "${copy_status}"
+}
+
+manifest_json=
+inspect_status=1
+for ((attempt = 1; attempt <= attempts; attempt++)); do
+	: >"${inspect_log}"
+	: >"${inspect_output}"
+	printf '[....] Verifying mirrored image (attempt %s/%s): %s\n' \
+		"${attempt}" "${attempts}" "${destination_ref}"
+	if docker buildx imagetools inspect \
+		"${destination_ref}" --format '{{json .Manifest}}' \
+		>"${inspect_output}" 2>"${inspect_log}"; then
+		inspect_status=0
+		manifest_json="$(<"${inspect_output}")"
+		break
+	else
+		inspect_status=$?
+	fi
+	[[ ! -s "${inspect_output}" ]] || cat "${inspect_output}" >&2
+	[[ ! -s "${inspect_log}" ]] || cat "${inspect_log}" >&2
+	if ! mirror_error_is_retryable "${inspect_output}" "${inspect_log}"; then
+		printf 'ERROR: registry mirror verification failed with a non-retryable error\n' >&2
+		exit "${inspect_status}"
+	fi
+	if ((attempt == attempts)); then
+		break
+	fi
+	wait_before_retry "${attempt}" verification
+done
+((inspect_status == 0)) || {
+	printf 'ERROR: registry mirror verification failed after %s attempts\n' \
+		"${attempts}" >&2
+	exit "${inspect_status}"
+}
 destination_digest="$(jq -r '.digest // empty' <<<"${manifest_json}")"
 [[ "${destination_digest}" == "${digest}" ]] || {
 	printf 'ERROR: mirrored digest mismatch: source=%s destination=%s\n' \

--- a/tools/quality/test-saas-registry-delivery.sh
+++ b/tools/quality/test-saas-registry-delivery.sh
@@ -69,6 +69,9 @@ package_root="${tmp}/candidate"
 fake_bin="${tmp}/bin"
 tag_marker="${tmp}/tagged"
 pull_marker="${tmp}/pulls"
+mirror_marker="${tmp}/mirror-attempts"
+mirror_sleep_marker="${tmp}/mirror-sleeps"
+mirror_inspect_marker="${tmp}/mirror-inspect-attempts"
 mkdir -p "${package_root}" "${fake_bin}"
 revision="$(printf 'b%.0s' {1..40})"
 python3 - "${package_root}/MANIFEST.json" "${digest}" "${revision}" <<'PY'
@@ -99,8 +102,50 @@ case "${1:-} ${2:-}" in
 	case "${3:-}" in
 	create)
 		[[ "$*" == *"${HFL_TEST_DIGEST}"* ]]
+		count=0
+		[[ ! -f "${HFL_TEST_MIRROR_MARKER}" ]] \
+			|| count="$(cat "${HFL_TEST_MIRROR_MARKER}")"
+		count=$((count + 1))
+		printf '%s\n' "${count}" >"${HFL_TEST_MIRROR_MARKER}"
+		case "${HFL_TEST_MIRROR_MODE:-success}" in
+		flaky429 | always429)
+			if [[ "${count}" -lt 3 ]]; then
+				printf 'unexpected status from HEAD request: 429 Too Many Requests\n' >&2
+				exit 1
+			fi
+			if [[ "${HFL_TEST_MIRROR_MODE}" == always429 ]]; then
+				printf 'unexpected status from HEAD request: 429 Too Many Requests\n' >&2
+				exit 1
+			fi
+			;;
+		fatal403)
+			printf 'unexpected status from HEAD request: 403 Forbidden\n' >&2
+			exit 1
+			;;
+		success) ;;
+		*) exit 2 ;;
+		esac
 		;;
 	inspect)
+		count=0
+		[[ ! -f "${HFL_TEST_MIRROR_INSPECT_MARKER}" ]] \
+			|| count="$(cat "${HFL_TEST_MIRROR_INSPECT_MARKER}")"
+		count=$((count + 1))
+		printf '%s\n' "${count}" >"${HFL_TEST_MIRROR_INSPECT_MARKER}"
+		case "${HFL_TEST_MIRROR_INSPECT_MODE:-success}" in
+		flaky429)
+			if [[ "${count}" -lt 3 ]]; then
+				printf 'unexpected status from HEAD request: 429 Too Many Requests\n' >&2
+				exit 1
+			fi
+			;;
+		fatal403)
+			printf 'unexpected status from HEAD request: 403 Forbidden\n' >&2
+			exit 1
+			;;
+		success) ;;
+		*) exit 2 ;;
+		esac
 		printf '{"digest":"%s"}\n' "${HFL_TEST_DIGEST}"
 		;;
 	*) exit 2 ;;
@@ -135,6 +180,20 @@ case "${1:-} ${2:-}" in
 esac
 SH
 chmod 755 "${fake_bin}/docker"
+cat >"${fake_bin}/sleep" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+[[ $# -eq 1 ]]
+printf '%s\n' "$1" >>"${HFL_TEST_MIRROR_SLEEP_MARKER}"
+SH
+chmod 755 "${fake_bin}/sleep"
+cat >"${fake_bin}/tee" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+/usr/bin/tee "$@"
+[[ "${HFL_TEST_MIRROR_TEE_FAIL:-0}" != 1 ]] || exit 9
+SH
+chmod 755 "${fake_bin}/tee"
 cat >"${fake_bin}/ssh" <<'SH'
 #!/usr/bin/env bash
 set -euo pipefail
@@ -155,13 +214,87 @@ SH
 chmod 755 "${fake_bin}/ssh"
 export HFL_TEST_TAG_MARKER="${tag_marker}"
 export HFL_TEST_PULL_MARKER="${pull_marker}"
+export HFL_TEST_MIRROR_MARKER="${mirror_marker}"
+export HFL_TEST_MIRROR_SLEEP_MARKER="${mirror_sleep_marker}"
+export HFL_TEST_MIRROR_INSPECT_MARKER="${mirror_inspect_marker}"
 export HFL_TEST_REVISION="${revision}"
 export HFL_TEST_DIGEST="${digest}"
 export PATH="${fake_bin}:${PATH}"
-"${ROOT}/release/ci/mirror-saas-image.sh" \
+HFL_REGISTRY_MIRROR_RETRY_BASE_SECONDS=0 \
+	HFL_REGISTRY_MIRROR_RETRY_JITTER_SECONDS=0 \
+	"${ROOT}/release/ci/mirror-saas-image.sh" \
 	docker.io/example/hyperfilelens-backend:1.0.0-ee \
 	"${digest}" \
 	registry.example.cn/example/hyperfilelens-backend:1.0.0-ee
+[[ "$(cat "${mirror_marker}")" -eq 1 ]]
+[[ "$(cat "${mirror_inspect_marker}")" -eq 1 ]]
+
+printf '0\n' >"${mirror_marker}"
+HFL_TEST_MIRROR_MODE=flaky429 \
+	HFL_REGISTRY_MIRROR_RETRY_BASE_SECONDS=0 \
+	HFL_REGISTRY_MIRROR_RETRY_JITTER_SECONDS=0 \
+	"${ROOT}/release/ci/mirror-saas-image.sh" \
+		docker.io/example/hyperfilelens-backend:1.0.0-ee \
+		"${digest}" \
+		registry.example.cn/example/hyperfilelens-backend:1.0.0-ee
+[[ "$(cat "${mirror_marker}")" -eq 3 ]]
+
+printf '0\n' >"${mirror_marker}"
+: >"${mirror_sleep_marker}"
+if HFL_TEST_MIRROR_MODE=always429 \
+	HFL_REGISTRY_MIRROR_RETRY_JITTER_SECONDS=0 \
+	"${ROOT}/release/ci/mirror-saas-image.sh" \
+		docker.io/example/hyperfilelens-backend:1.0.0-ee \
+		"${digest}" \
+		registry.example.cn/example/hyperfilelens-backend:1.0.0-ee \
+		>/dev/null 2>&1; then
+	printf 'ERROR: registry mirror accepted five consecutive rate-limit failures\n' >&2
+	exit 1
+fi
+[[ "$(cat "${mirror_marker}")" -eq 5 ]]
+[[ "$(paste -sd, "${mirror_sleep_marker}")" == 5,10,20,40 ]]
+
+printf '0\n' >"${mirror_marker}"
+if HFL_TEST_MIRROR_MODE=fatal403 \
+	HFL_REGISTRY_MIRROR_RETRY_BASE_SECONDS=0 \
+	HFL_REGISTRY_MIRROR_RETRY_JITTER_SECONDS=0 \
+	"${ROOT}/release/ci/mirror-saas-image.sh" \
+		docker.io/example/hyperfilelens-backend:1.0.0-ee \
+		"${digest}" \
+		registry.example.cn/example/hyperfilelens-backend:1.0.0-ee \
+		>/dev/null 2>&1; then
+	printf 'ERROR: registry mirror retried a non-retryable authorization failure\n' >&2
+	exit 1
+fi
+[[ "$(cat "${mirror_marker}")" -eq 1 ]]
+
+printf '0\n' >"${mirror_marker}"
+printf '0\n' >"${mirror_inspect_marker}"
+HFL_TEST_MIRROR_INSPECT_MODE=flaky429 \
+	HFL_REGISTRY_MIRROR_RETRY_BASE_SECONDS=0 \
+	HFL_REGISTRY_MIRROR_RETRY_JITTER_SECONDS=0 \
+	"${ROOT}/release/ci/mirror-saas-image.sh" \
+		docker.io/example/hyperfilelens-backend:1.0.0-ee \
+		"${digest}" \
+		registry.example.cn/example/hyperfilelens-backend:1.0.0-ee
+[[ "$(cat "${mirror_marker}")" -eq 1 ]]
+[[ "$(cat "${mirror_inspect_marker}")" -eq 3 ]]
+
+printf '0\n' >"${mirror_marker}"
+printf '0\n' >"${mirror_inspect_marker}"
+if HFL_TEST_MIRROR_TEE_FAIL=1 \
+	HFL_REGISTRY_MIRROR_RETRY_BASE_SECONDS=0 \
+	HFL_REGISTRY_MIRROR_RETRY_JITTER_SECONDS=0 \
+	"${ROOT}/release/ci/mirror-saas-image.sh" \
+		docker.io/example/hyperfilelens-backend:1.0.0-ee \
+		"${digest}" \
+		registry.example.cn/example/hyperfilelens-backend:1.0.0-ee \
+		>/dev/null 2>&1; then
+	printf 'ERROR: registry mirror ignored a logging pipeline failure\n' >&2
+	exit 1
+fi
+[[ "$(cat "${mirror_marker}")" -eq 1 ]]
+[[ "$(cat "${mirror_inspect_marker}")" -eq 0 ]]
 source "${ROOT}/deploy/installer/install.sh"
 HFL_TEST_FAIL_REGION=cn HFL_REGISTRY_REGION=cn \
 	load_images_from_manifest 0 "${package_root}"


### PR DESCRIPTION
## Summary
- retry transient registry mirror copy failures with bounded exponential backoff and jitter
- retry transient post-copy digest verification failures
- fail safely when registry output logging fails
- cover rate limiting, authorization failures, verification retries, and retry timing in contract tests

## Tests
- `bash tools/quality/test-saas-registry-delivery.sh`
- `bash tools/quality/check-release-contracts.sh`
- `bash tools/quality/test-online-community-install.sh`
- `bash tools/quality/test-ci-release-assembly.sh`
- `bash -n release/ci/mirror-saas-image.sh tools/quality/test-saas-registry-delivery.sh`
- `git diff --check`