### PR TITLE
fix: prevent result congestion from marking repositories offline

### DIFF
--- a/src/agent/internal/app/agent.go
+++ b/src/agent/internal/app/agent.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"math/rand"
 	"os"
 	"strings"
 	"sync"
@@ -363,33 +362,22 @@ func (a *Agent) gatewayObservabilityLoop(ctx context.Context) {
 	}
 }
 
-func taskResultOutboxRetryDelay(attempt int) time.Duration {
-	bases := []time.Duration{time.Second, 4 * time.Second, 16 * time.Second, 30 * time.Second}
-	base := 60 * time.Second
-	if attempt >= 0 && attempt < len(bases) {
-		base = bases[attempt]
-	}
-	jitter := time.Duration(rand.Int63n(int64(base/5 + 1)))
-	if rand.Intn(2) == 0 {
-		return base - jitter
-	}
-	return base + jitter
-}
-
 func (a *Agent) taskResultOutboxLoop(ctx context.Context) {
-	for attempt := 0; ; attempt++ {
-		timer := time.NewTimer(taskResultOutboxRetryDelay(attempt))
+	for {
+		timer := time.NewTimer(wire.ResultOutboxPollInterval())
 		select {
 		case <-ctx.Done():
 			timer.Stop()
 			return
+		case <-a.wire.ResultOutboxWake():
+			timer.Stop()
 		case <-timer.C:
 		}
 		if a.wire == nil || a.connector == nil || !a.wire.TaskResultAckEnabled() {
 			return
 		}
 		if err := a.wire.FlushUnreportedResults(ctx, a.connector); err != nil {
-			slog.Warn("task.result outbox retry failed", "attempt", attempt+1, "err", err)
+			slog.Warn("task.result outbox flush failed", "err", err)
 		}
 	}
 }

--- a/src/agent/internal/cli/tasks.go
+++ b/src/agent/internal/cli/tasks.go
@@ -334,7 +334,7 @@ func tasksFlush(ctx context.Context, args []string) error {
 	}
 	defer rt.close()
 
-	pending, err := rt.tasks.ListUnreported(ctx)
+	pending, err := rt.tasks.ListUnreported(ctx, 0)
 	if err != nil {
 		return err
 	}

--- a/src/agent/internal/infra/database/tasks.go
+++ b/src/agent/internal/infra/database/tasks.go
@@ -597,14 +597,54 @@ func isTerminal(s model.TaskStatus) bool {
 	}
 }
 
-// ListUnreported returns tasks whose terminal result has not been sent upstream.
-func (r *TaskRepo) ListUnreported(ctx context.Context) ([]model.Task, error) {
-	rows, err := r.db.conn.QueryContext(ctx, `
+// ListUnreported returns terminal results that still require upstream acknowledgement.
+// A positive limit mixes recent and oldest rows so live failures are not trapped
+// behind a historical backlog while the oldest backlog continues to drain.
+func (r *TaskRepo) ListUnreported(ctx context.Context, limit int) ([]model.Task, error) {
+	if limit <= 0 {
+		return r.listUnreportedOrdered(ctx, "ASC", 0)
+	}
+	recentLimit := max(1, limit/4)
+	oldestLimit := max(0, limit-recentLimit)
+	recent, err := r.listUnreportedOrdered(ctx, "DESC", recentLimit)
+	if err != nil {
+		return nil, err
+	}
+	oldest, err := r.listUnreportedOrdered(ctx, "ASC", oldestLimit)
+	if err != nil {
+		return nil, err
+	}
+	seen := make(map[string]struct{}, limit)
+	out := make([]model.Task, 0, limit)
+	for _, task := range append(recent, oldest...) {
+		if _, exists := seen[task.ID]; exists {
+			continue
+		}
+		seen[task.ID] = struct{}{}
+		out = append(out, task)
+		if len(out) == limit {
+			break
+		}
+	}
+	return out, nil
+}
+
+func (r *TaskRepo) listUnreportedOrdered(ctx context.Context, order string, limit int) ([]model.Task, error) {
+	query := `
 SELECT id, job_id, kind, payload, status, result, error, started_at, finished_at
 FROM tasks
 WHERE result_reported=0 AND status IN (?, ?, ?)
-ORDER BY updated_at ASC
-`, string(model.TaskStatusFailed), string(model.TaskStatusCancelled), string(model.TaskStatusSucceeded))
+ORDER BY updated_at ` + order
+	if limit > 0 {
+		query += fmt.Sprintf(" LIMIT %d", limit)
+	}
+	rows, err := r.db.conn.QueryContext(
+		ctx,
+		query,
+		string(model.TaskStatusFailed),
+		string(model.TaskStatusCancelled),
+		string(model.TaskStatusSucceeded),
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/src/agent/internal/infra/database/tasks_test.go
+++ b/src/agent/internal/infra/database/tasks_test.go
@@ -1,8 +1,10 @@
 package database
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 	"time"
 
@@ -254,7 +256,7 @@ func TestTaskRepoRepairAndFlush(t *testing.T) {
 		t.Fatalf("status = %q", repaired[0].Status)
 	}
 
-	unreported, err := repo.ListUnreported(ctx)
+	unreported, err := repo.ListUnreported(ctx, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -265,7 +267,7 @@ func TestTaskRepoRepairAndFlush(t *testing.T) {
 	if err := repo.MarkResultReported(ctx, "task-1"); err != nil {
 		t.Fatal(err)
 	}
-	unreported, err = repo.ListUnreported(ctx)
+	unreported, err = repo.ListUnreported(ctx, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -326,12 +328,53 @@ func TestTaskRepoFinish(t *testing.T) {
 	if err := repo.Finish(ctx, "t2", model.TaskStatusSucceeded, map[string]any{"pong": true}, ""); err != nil {
 		t.Fatal(err)
 	}
-	pending, err := repo.ListUnreported(ctx)
+	pending, err := repo.ListUnreported(ctx, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(pending) != 1 || pending[0].Status != model.TaskStatusSucceeded {
 		t.Fatalf("pending = %+v", pending)
+	}
+}
+
+func TestTaskRepoListUnreportedMixesRecentAndOldestWithinLimit(t *testing.T) {
+	ctx := t.Context()
+	db, err := Open(ctx, filepath.Join(t.TempDir(), "agent.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	repo := NewTaskRepo(db)
+	base := time.Date(2026, time.August, 20, 1, 0, 0, 0, time.UTC)
+	for i := 0; i < 12; i++ {
+		taskID := fmt.Sprintf("task-%02d", i)
+		if err := repo.RecordCommand(ctx, RecordInput{TaskID: taskID, Kind: "backup.run"}); err != nil {
+			t.Fatal(err)
+		}
+		if err := repo.Finish(ctx, taskID, model.TaskStatusSucceeded, map[string]any{"index": i}, ""); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := db.conn.ExecContext(
+			ctx,
+			"UPDATE tasks SET updated_at=? WHERE id=?",
+			formatTime(base.Add(time.Duration(i)*time.Second)),
+			taskID,
+		); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	pending, err := repo.ListUnreported(ctx, 8)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := make([]string, 0, len(pending))
+	for _, task := range pending {
+		got = append(got, task.ID)
+	}
+	want := []string{"task-11", "task-10", "task-00", "task-01", "task-02", "task-03", "task-04", "task-05"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("mixed pending IDs = %v, want %v", got, want)
 	}
 }
 

--- a/src/agent/internal/remote/connector.go
+++ b/src/agent/internal/remote/connector.go
@@ -291,12 +291,6 @@ func (c *Connector) connectOnce(
 		slog.Info("websocket reconnected", "node_id", nodeID)
 	}
 
-	if onConnected != nil {
-		if hookErr := onConnected(sessionCtx); hookErr != nil {
-			slog.Warn("websocket onConnected hook failed", "err", hookErr)
-		}
-	}
-
 	done := make(chan struct{})
 	sessionErr := make(chan error, 1)
 
@@ -326,6 +320,15 @@ func (c *Connector) connectOnce(
 			}
 		}
 	}()
+
+	// Start the read loop before the connection hook. The hook can flush a
+	// bounded result window, and peers are allowed to ACK those frames
+	// immediately while the hook continues its reconnect work.
+	if onConnected != nil {
+		if hookErr := onConnected(sessionCtx); hookErr != nil {
+			slog.Warn("websocket onConnected hook failed", "err", hookErr)
+		}
+	}
 
 	var loopErr error
 	select {

--- a/src/agent/internal/remote/connector_test.go
+++ b/src/agent/internal/remote/connector_test.go
@@ -2,6 +2,7 @@ package remote
 
 import (
 	"context"
+	"errors"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -193,6 +194,54 @@ func TestConnectorNegotiatesTaskResultAckSubprotocol(t *testing.T) {
 	}, false)
 	if !<-negotiated {
 		t.Fatal("server did not negotiate task result ACK subprotocol")
+	}
+}
+
+func TestConnectorReadsFramesWhileOnConnectedHookRuns(t *testing.T) {
+	upgrader := websocket.Upgrader{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade: %v", err)
+			return
+		}
+		defer conn.Close()
+		if err := conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"task.result.ack","task_id":"task-1"}`)); err != nil {
+			t.Errorf("write frame: %v", err)
+			return
+		}
+		_, _, _ = conn.ReadMessage()
+	}))
+	defer server.Close()
+
+	connector := NewConnector(staticProvider{cfg: &model.AgentConfig{
+		WSSURL:    "ws" + strings.TrimPrefix(server.URL, "http"),
+		NodeID:    "1",
+		NodeToken: "token",
+	}})
+	connector.heartbeatInterval = time.Hour
+	messageRead := make(chan struct{})
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	err, _ := connector.connectOnce(
+		ctx,
+		func(context.Context, []byte) error {
+			close(messageRead)
+			return nil
+		},
+		func(context.Context) error {
+			select {
+			case <-messageRead:
+				cancel()
+				return nil
+			case <-time.After(250 * time.Millisecond):
+				return errors.New("read loop did not run during onConnected hook")
+			}
+		},
+		false,
+	)
+	if err != context.Canceled {
+		t.Fatalf("connectOnce() error = %v, want context.Canceled", err)
 	}
 }
 

--- a/src/agent/internal/wire/handler.go
+++ b/src/agent/internal/wire/handler.go
@@ -23,18 +23,129 @@ type Handler struct {
 	snapshotScheduler *controller.Scheduler
 	nasLeases         *engine.NASLeaseCoordinator
 	resultAckEnabled  atomic.Bool
+	resultMu          sync.Mutex
+	resultInFlight    map[string]resultDelivery
+	resultWake        chan struct{}
+}
+
+const resultOutboxWindow = 32
+
+var (
+	resultOutboxRetryBase = 30 * time.Second
+	resultOutboxRetryMax  = 5 * time.Minute
+)
+
+type resultDelivery struct {
+	attempts int
+	deadline time.Time
 }
 
 // SetTaskResultAckEnabled selects ACK mode for the current WebSocket session.
 func (h *Handler) SetTaskResultAckEnabled(enabled bool) {
 	if h != nil {
 		h.resultAckEnabled.Store(enabled)
+		h.resultMu.Lock()
+		clear(h.resultInFlight)
+		h.resultMu.Unlock()
 	}
 }
 
 // TaskResultAckEnabled reports whether task.result requires a control-plane ACK.
 func (h *Handler) TaskResultAckEnabled() bool {
 	return h != nil && h.resultAckEnabled.Load()
+}
+
+// ResultOutboxWake reports ACK-driven capacity becoming available.
+func (h *Handler) ResultOutboxWake() <-chan struct{} {
+	if h == nil {
+		return nil
+	}
+	return h.resultWake
+}
+
+// ResultOutboxPollInterval bounds how long an expired delivery waits for retry.
+func ResultOutboxPollInterval() time.Duration {
+	return resultOutboxRetryBase
+}
+
+func resultRetryDelay(attempt int) time.Duration {
+	if attempt < 1 {
+		attempt = 1
+	}
+	delay := resultOutboxRetryBase
+	for i := 1; i < attempt && delay < resultOutboxRetryMax; i++ {
+		delay *= 2
+		if delay >= resultOutboxRetryMax {
+			return resultOutboxRetryMax
+		}
+	}
+	return delay
+}
+
+func (h *Handler) reserveResultDelivery(taskID string) bool {
+	if h == nil || taskID == "" || !h.TaskResultAckEnabled() {
+		return true
+	}
+	now := time.Now()
+	h.resultMu.Lock()
+	defer h.resultMu.Unlock()
+	if delivery, exists := h.resultInFlight[taskID]; exists && delivery.deadline.After(now) {
+		return false
+	}
+	active := 0
+	for _, delivery := range h.resultInFlight {
+		if delivery.deadline.After(now) {
+			active++
+		}
+	}
+	if active >= resultOutboxWindow {
+		return false
+	}
+	delivery := h.resultInFlight[taskID]
+	delivery.attempts++
+	delivery.deadline = now.Add(resultRetryDelay(delivery.attempts))
+	h.resultInFlight[taskID] = delivery
+	return true
+}
+
+func (h *Handler) releaseResultDelivery(taskID string) {
+	if h == nil || taskID == "" {
+		return
+	}
+	h.resultMu.Lock()
+	delete(h.resultInFlight, taskID)
+	h.resultMu.Unlock()
+}
+
+func (h *Handler) acknowledgeResultDelivery(taskID string) {
+	h.releaseResultDelivery(taskID)
+	select {
+	case h.resultWake <- struct{}{}:
+	default:
+	}
+}
+
+func (h *Handler) sendLiveTaskResult(
+	ctx context.Context,
+	sink Sender,
+	taskID string,
+	status string,
+	result map[string]any,
+	errMsg string,
+) error {
+	if h.TaskResultAckEnabled() && !h.reserveResultDelivery(taskID) {
+		return nil
+	}
+	if err := SendTaskResult(ctx, sink, taskID, status, result, errMsg); err != nil {
+		if h.TaskResultAckEnabled() {
+			h.releaseResultDelivery(taskID)
+		}
+		return err
+	}
+	if h.tasks != nil && !h.TaskResultAckEnabled() {
+		return h.tasks.MarkResultReported(ctx, taskID)
+	}
+	return nil
 }
 
 // NewHandler returns a protocol handler bound to config, tracker, and local task storage.
@@ -54,6 +165,8 @@ func NewHandler(
 		tasks:             tasks,
 		snapshotScheduler: snapshotScheduler,
 		nasLeases:         engine.NewNASLeaseCoordinator(),
+		resultInFlight:    make(map[string]resultDelivery),
+		resultWake:        make(chan struct{}, 1),
 	}
 }
 
@@ -89,7 +202,7 @@ func (h *Handler) Handle(ctx context.Context, raw []byte, sink Sender) error {
 			}
 			shouldRun = inserted
 			if !inserted && persisted.Status != model.TaskStatusRunning && persisted.Status != model.TaskStatusPending {
-				_ = SendTaskResult(ctx, sink, persisted.ID, database.WireStatus(persisted.Status), persisted.Result, persisted.Error)
+				_ = h.sendLiveTaskResult(ctx, sink, persisted.ID, database.WireStatus(persisted.Status), persisted.Result, persisted.Error)
 				return nil
 			}
 		}
@@ -131,6 +244,7 @@ func (h *Handler) Handle(ctx context.Context, raw []byte, sink Sender) error {
 			slog.Warn("persist task.result ack failed", "task_id", dl.TaskResultAck.TaskID, "err", err)
 			return nil
 		}
+		h.acknowledgeResultDelivery(dl.TaskResultAck.TaskID)
 		slog.Info("task.result acknowledged", "task_id", dl.TaskResultAck.TaskID)
 		return nil
 	default:
@@ -146,17 +260,27 @@ func (h *Handler) FlushUnreportedResults(ctx context.Context, sink Sender) error
 	if h.tasks == nil || sink == nil {
 		return nil
 	}
-	pending, err := h.tasks.ListUnreported(ctx)
+	limit := 0
+	if h.TaskResultAckEnabled() {
+		limit = resultOutboxWindow
+	}
+	pending, err := h.tasks.ListUnreported(ctx, limit)
 	if err != nil {
 		return err
 	}
 	for _, task := range pending {
+		if h.TaskResultAckEnabled() && !h.reserveResultDelivery(task.ID) {
+			continue
+		}
 		wireStatus := database.WireStatus(task.Status)
 		errMsg := task.Error
 		if errMsg == "" && wireStatus == "failed" {
 			errMsg = string(task.Status)
 		}
 		if err := SendTaskResult(ctx, sink, task.ID, wireStatus, task.Result, errMsg); err != nil {
+			if h.TaskResultAckEnabled() {
+				h.releaseResultDelivery(task.ID)
+			}
 			slog.Warn("flush task.result failed", "task_id", task.ID, "err", err)
 			continue
 		}
@@ -258,7 +382,7 @@ func (h *Handler) runTask(ctx context.Context, sink Sender, cmd *TaskCommand) {
 						persistCtx, cmd.TaskID, model.TaskStatusCancelled, nil, "canceled",
 					)
 				}
-				_ = SendTaskResult(persistCtx, sink, cmd.TaskID, "failed", nil, "canceled")
+				_ = h.sendLiveTaskResult(persistCtx, sink, cmd.TaskID, "failed", nil, "canceled")
 				return
 			}
 			logging.InfoTask(
@@ -321,10 +445,8 @@ func (h *Handler) runTask(ctx context.Context, sink Sender, cmd *TaskCommand) {
 				slog.Warn("persist running task failed", "task_id", cmd.TaskID, "err", err)
 			}
 		}
-		if err := SendTaskResult(taskCtx, sink, cmd.TaskID, status, result, errMsg); err != nil {
+		if err := h.sendLiveTaskResult(taskCtx, sink, cmd.TaskID, status, result, errMsg); err != nil {
 			slog.Warn("send task.result failed", "task_id", cmd.TaskID, "err", err)
-		} else if h.tasks != nil && !h.TaskResultAckEnabled() {
-			_ = h.tasks.MarkResultReported(taskCtx, cmd.TaskID)
 		}
 		return
 	}
@@ -361,10 +483,8 @@ func (h *Handler) runTask(ctx context.Context, sink Sender, cmd *TaskCommand) {
 		}
 	}
 
-	if err := SendTaskResult(persistCtx, sink, cmd.TaskID, status, result, errMsg); err != nil {
+	if err := h.sendLiveTaskResult(persistCtx, sink, cmd.TaskID, status, result, errMsg); err != nil {
 		slog.Warn("send task.result failed", "task_id", cmd.TaskID, "err", err)
-	} else if h.tasks != nil && !h.TaskResultAckEnabled() {
-		_ = h.tasks.MarkResultReported(persistCtx, cmd.TaskID)
 	}
 }
 

--- a/src/agent/internal/wire/handler_ack_test.go
+++ b/src/agent/internal/wire/handler_ack_test.go
@@ -3,6 +3,7 @@ package wire
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"path/filepath"
 	"testing"
 	"time"
@@ -49,7 +50,7 @@ func TestFlushUnreportedWaitsForAckInAckMode(t *testing.T) {
 	if len(sender.frames) != 1 {
 		t.Fatalf("frames = %d, want 1", len(sender.frames))
 	}
-	pending, err := repo.ListUnreported(t.Context())
+	pending, err := repo.ListUnreported(t.Context(), 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -63,7 +64,7 @@ func TestFlushUnreportedWaitsForAckInAckMode(t *testing.T) {
 	); err != nil {
 		t.Fatal(err)
 	}
-	pending, err = repo.ListUnreported(t.Context())
+	pending, err = repo.ListUnreported(t.Context(), 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -88,8 +89,19 @@ func TestFlushUnreportedRetransmitsIdenticalResultUntilAck(t *testing.T) {
 	if err := handler.FlushUnreportedResults(t.Context(), sender); err != nil {
 		t.Fatal(err)
 	}
+	if len(sender.frames) != 1 {
+		t.Fatalf("frames before retry deadline = %d, want 1", len(sender.frames))
+	}
+	handler.resultMu.Lock()
+	delivery := handler.resultInFlight["task-1"]
+	delivery.deadline = time.Now().Add(-time.Second)
+	handler.resultInFlight["task-1"] = delivery
+	handler.resultMu.Unlock()
+	if err := handler.FlushUnreportedResults(t.Context(), sender); err != nil {
+		t.Fatal(err)
+	}
 	if len(sender.frames) != 2 {
-		t.Fatalf("frames = %d, want 2", len(sender.frames))
+		t.Fatalf("frames after retry deadline = %d, want 2", len(sender.frames))
 	}
 	first, err := json.Marshal(sender.frames[0])
 	if err != nil {
@@ -104,13 +116,78 @@ func TestFlushUnreportedRetransmitsIdenticalResultUntilAck(t *testing.T) {
 	}
 }
 
+func TestFlushUnreportedBoundsAckWindowAndRefillsAfterAck(t *testing.T) {
+	ctx := t.Context()
+	db, err := database.Open(ctx, filepath.Join(t.TempDir(), "agent.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	repo := database.NewTaskRepo(db)
+	const pendingTaskCount = 101
+	for i := 0; i < pendingTaskCount; i++ {
+		taskID := fmt.Sprintf("task-%03d", i)
+		if err := repo.RecordCommand(ctx, database.RecordInput{TaskID: taskID, Kind: "backup.run"}); err != nil {
+			t.Fatal(err)
+		}
+		if err := repo.Finish(ctx, taskID, model.TaskStatusSucceeded, map[string]any{"index": i}, ""); err != nil {
+			t.Fatal(err)
+		}
+	}
+	handler := NewHandler(nil, controller.NewTracker(), repo)
+	handler.SetTaskResultAckEnabled(true)
+	sender := &captureSender{}
+	if err := handler.FlushUnreportedResults(ctx, sender); err != nil {
+		t.Fatal(err)
+	}
+	if len(sender.frames) != resultOutboxWindow {
+		t.Fatalf("initial frames = %d, want %d", len(sender.frames), resultOutboxWindow)
+	}
+	first := sender.frames[0].(TaskResult)
+	if err := handler.Handle(
+		ctx,
+		[]byte(fmt.Sprintf(`{"type":"task.result.ack","task_id":%q}`, first.TaskID)),
+		sender,
+	); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-handler.ResultOutboxWake():
+	default:
+		t.Fatal("ACK did not wake result outbox")
+	}
+	if err := handler.FlushUnreportedResults(ctx, sender); err != nil {
+		t.Fatal(err)
+	}
+	if len(sender.frames) != resultOutboxWindow+1 {
+		t.Fatalf("frames after ACK refill = %d, want %d", len(sender.frames), resultOutboxWindow+1)
+	}
+}
+
+func TestLiveTaskResultSharesAckWindowWithOutbox(t *testing.T) {
+	handler, _ := newFinishedTaskHandler(t)
+	handler.SetTaskResultAckEnabled(true)
+	sender := &captureSender{}
+	if err := handler.sendLiveTaskResult(
+		t.Context(), sender, "task-1", "success", map[string]any{"kopia_snapshot_id": "snap-1"}, "",
+	); err != nil {
+		t.Fatal(err)
+	}
+	if err := handler.FlushUnreportedResults(t.Context(), sender); err != nil {
+		t.Fatal(err)
+	}
+	if len(sender.frames) != 1 {
+		t.Fatalf("frames = %d, want live result without periodic duplicate", len(sender.frames))
+	}
+}
+
 func TestFlushUnreportedKeepsLegacyMarkOnWrite(t *testing.T) {
 	handler, repo := newFinishedTaskHandler(t)
 	handler.SetTaskResultAckEnabled(false)
 	if err := handler.FlushUnreportedResults(t.Context(), &captureSender{}); err != nil {
 		t.Fatal(err)
 	}
-	pending, err := repo.ListUnreported(t.Context())
+	pending, err := repo.ListUnreported(t.Context(), 0)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/src/backend/apps/node/services/internal/task.py
+++ b/src/backend/apps/node/services/internal/task.py
@@ -862,6 +862,24 @@ def complete_task(
         )
         return task
 
+    incoming_result = dict(result or {})
+    incoming_terminal_status = _incoming_terminal_status(incoming)
+    if (
+        incoming_terminal_status is not None
+        and task.status == incoming_terminal_status
+        and dict(task.result or {}) == incoming_result
+        and _terminal_error_matches(
+            task=task,
+            incoming=incoming,
+            error=error,
+        )
+    ):
+        # This is a byte-semantically identical replay of a result already
+        # committed. Keep a transient marker for the WebSocket consumer so it
+        # can ACK durable receipt without repeating streams or domain follow-up.
+        task._result_retransmission_unchanged = True
+        return task
+
     if task.status in _TERMINAL_STATUSES:
         if isinstance(task.result, dict) and task.result.get("delivery_timeout_sealed"):
             return task
@@ -947,6 +965,28 @@ def complete_task(
             (task.last_error or error or terminal)[:500],
         )
     return task
+
+
+def _incoming_terminal_status(incoming: str) -> str | None:
+    if incoming == "running":
+        return None
+    if incoming in {"success", "succeeded", "ok"}:
+        return NodeTask.Status.SUCCESS
+    if incoming in {"canceled", "cancelled"}:
+        return NodeTask.Status.CANCELED
+    return NodeTask.Status.FAILED
+
+
+def _terminal_error_matches(*, task: NodeTask, incoming: str, error: str) -> bool:
+    existing = str(task.last_error or "")
+    if task.status == NodeTask.Status.SUCCESS:
+        return existing == "" and str(error or "") == ""
+    if task.status == NodeTask.Status.CANCELED:
+        candidate = str(error or "").strip().lower()
+        return candidate in {"", "canceled", "cancelled"} or existing == str(
+            error or ""
+        )[:2000]
+    return existing == str(error or incoming)[:2000]
 
 
 @transaction.atomic

--- a/src/backend/apps/node/tests/test_complete_task_idempotency.py
+++ b/src/backend/apps/node/tests/test_complete_task_idempotency.py
@@ -160,3 +160,26 @@ class CompleteTaskIdempotencyTests(TestCase):
         self.assertEqual(updated.status, NodeTask.Status.SUCCESS)
         self.assertEqual(updated.result["kopia_snapshot_id"], "snapshot-repeat")
         metric.inc.assert_called_once_with()
+
+    @patch("apps.node.services.internal.task.redis_store.push_task_stream")
+    @patch("apps.node.services.internal.task._sync_task_info")
+    @patch("apps.node.ws.uplink.TASK_RESULT_RETRANSMISSIONS")
+    def test_identical_terminal_retransmission_skips_duplicate_writes_and_streams(
+        self,
+        metric,
+        sync_task_info,
+        push_task_stream,
+    ):
+        message = ParsedUplink(
+            msg_type=WireType.TASK_RESULT,
+            task_id=str(self.task.id),
+            status="success",
+            result={"mode": "local_detached"},
+        )
+
+        updated = _handle_task_result(node_id=self.node.id, message=message)
+
+        self.assertTrue(updated._result_retransmission_unchanged)
+        sync_task_info.assert_not_called()
+        push_task_stream.assert_not_called()
+        metric.inc.assert_called_once_with()

--- a/src/backend/apps/node/tests/test_ws_task_result_ack.py
+++ b/src/backend/apps/node/tests/test_ws_task_result_ack.py
@@ -159,3 +159,39 @@ class NodeAgentTaskResultAckTests(SimpleTestCase):
 
         consumer.send.assert_not_awaited()
         followup.assert_not_called()
+
+    async def test_identical_retransmission_is_acked_without_followup(self):
+        task = SimpleNamespace(
+            id="550e8400-e29b-41d4-a716-446655440000",
+            _result_retransmission_unchanged=True,
+        )
+        consumer = NodeAgentConsumer()
+        consumer.node_id = 7
+        consumer.task_result_ack_enabled = True
+        consumer.send = AsyncMock()
+
+        with (
+            patch("apps.node.ws.node_agent.handle_uplink", return_value=task),
+            patch(
+                "apps.node.ws.node_agent.database_sync_to_async",
+                side_effect=_immediate_database_sync_to_async,
+            ),
+            patch(
+                "apps.node.ws.node_agent.project_identical_task_result_recovery"
+            ) as recovery,
+            patch("apps.node.ws.node_agent.trigger_task_result_followup") as followup,
+        ):
+            await consumer.receive(
+                text_data=json.dumps(
+                    {
+                        "type": "task.result",
+                        "task_id": task.id,
+                        "status": "success",
+                        "result": {},
+                    }
+                )
+            )
+
+        consumer.send.assert_awaited_once()
+        recovery.assert_called_once_with(node_task=task)
+        followup.assert_not_called()

--- a/src/backend/apps/node/ws/node_agent.py
+++ b/src/backend/apps/node/ws/node_agent.py
@@ -29,6 +29,7 @@ from apps.node.ws.uplink import (
     handle_uplink,
     on_agent_connected,
     on_agent_disconnected,
+    project_identical_task_result_recovery,
     trigger_task_result_followup,
 )
 from apps.node.ws.uplink_queue import enqueue_uplink, touch_heartbeat_fast
@@ -244,6 +245,18 @@ class NodeAgentConsumer(AsyncWebsocketConsumer):
                     task.id,
                     exc_info=True,
                 )
+        if bool(getattr(task, "_result_retransmission_unchanged", False)):
+            try:
+                await database_sync_to_async(project_identical_task_result_recovery)(
+                    node_task=task
+                )
+            except Exception:
+                logger.exception(
+                    "repository health retransmission projection failed node_id=%s task_id=%s",
+                    self.node_id,
+                    task.id,
+                )
+            return
         try:
             await database_sync_to_async(trigger_task_result_followup)(
                 node_task_id=task.id

--- a/src/backend/apps/node/ws/uplink.py
+++ b/src/backend/apps/node/ws/uplink.py
@@ -312,11 +312,29 @@ def _handle_task_result(*, node_id: int, message: ParsedUplink) -> NodeTask:
     return task
 
 
+def project_identical_task_result_recovery(*, node_task: NodeTask) -> None:
+    """Apply only idempotent health recovery for an unchanged terminal replay."""
+
+    from apps.storage.services.internal.repository_health import (
+        project_repository_health_from_agent_result,
+    )
+
+    project_repository_health_from_agent_result(node_task=node_task)
+
+
 def trigger_task_result_followup(*, node_task_id) -> None:
     """Run domain follow-up after NodeTask commit/ACK; periodic jobs remain the fallback."""
     task = NodeTask.objects.filter(pk=node_task_id).first()
     if task is None:
         return
+    try:
+        from apps.storage.services.internal.repository_health import (
+            project_repository_health_from_agent_result,
+        )
+
+        project_repository_health_from_agent_result(node_task=task)
+    except Exception:
+        logger.exception("repository health result projection failed task_id=%s", task.id)
     try:
         from apps.node.services.internal.node_lifecycle import (
             queue_detached_remove_verification,

--- a/src/backend/apps/storage/services/internal/nas_repository.py
+++ b/src/backend/apps/storage/services/internal/nas_repository.py
@@ -23,6 +23,8 @@ from apps.storage.repositories.models import RepositoryLocationClaim
 from apps.storage.services.internal.repository_errors import (
     REPOSITORY_ALREADY_EXISTS_MESSAGE,
     RepositoryAlreadyExistsError,
+    RepositoryHealthTransportUnconfirmed,
+    agent_task_transport_unconfirmed,
     agent_repository_failure_message,
     agent_result_has_repository_conflict,
 )
@@ -189,7 +191,12 @@ def _run_proxy_nas_repository_task(
     health_only: bool = False,
     adopt_legacy_ownership: bool = True,
 ):
-    node = validate_proxy_for_repository(repository)
+    try:
+        node = validate_proxy_for_repository(repository)
+    except ValidationError as exc:
+        if health_only:
+            raise RepositoryHealthTransportUnconfirmed(str(exc)) from exc
+        raise
     supports_ownership = node_supports_capability(
         node,
         REPOSITORY_OWNERSHIP_CAPABILITY,
@@ -247,6 +254,8 @@ def _run_proxy_nas_repository_task(
             correlation_id=str(repository.id),
             repository_id=repository.id,
         )
+        if health_only:
+            raise RepositoryHealthTransportUnconfirmed(str(exc)) from exc
         raise NASRepositoryError(str(exc)) from exc
     log_agent_outcome(
         log_scope,
@@ -257,6 +266,10 @@ def _run_proxy_nas_repository_task(
         correlation_id=str(repository.id),
         repository_id=repository.id,
     )
+    if agent_task_transport_unconfirmed(outcome):
+        raise RepositoryHealthTransportUnconfirmed(
+            "Agent repository probe did not return a terminal result."
+        )
     if outcome.task.status != "success":
         if agent_result_has_repository_conflict(outcome.result):
             raise RepositoryAlreadyExistsError(REPOSITORY_ALREADY_EXISTS_MESSAGE)

--- a/src/backend/apps/storage/services/internal/proxy_fs_repository.py
+++ b/src/backend/apps/storage/services/internal/proxy_fs_repository.py
@@ -33,6 +33,8 @@ from apps.storage.repositories.models import Repository, RepositoryLocationClaim
 from apps.storage.services.internal.repository_errors import (
     REPOSITORY_ALREADY_EXISTS_MESSAGE,
     RepositoryAlreadyExistsError,
+    RepositoryHealthTransportUnconfirmed,
+    agent_task_transport_unconfirmed,
     agent_repository_failure_message,
     agent_result_has_repository_conflict,
 )
@@ -181,7 +183,12 @@ def _run_proxy_fs_repository_task(
 ):
     """Run a strict initialize or connect-only probe on the bound Proxy."""
 
-    node = validate_proxy_for_proxy_fs(repository)
+    try:
+        node = validate_proxy_for_proxy_fs(repository)
+    except ValidationError as exc:
+        if health_only:
+            raise RepositoryHealthTransportUnconfirmed(str(exc)) from exc
+        raise
     supports_ownership = node_supports_capability(
         node,
         REPOSITORY_OWNERSHIP_CAPABILITY,
@@ -235,6 +242,8 @@ def _run_proxy_fs_repository_task(
             correlation_id=str(repository.id),
             repository_id=repository.id,
         )
+        if health_only:
+            raise RepositoryHealthTransportUnconfirmed(str(exc)) from exc
         raise ProxyFSRepositoryError(str(exc)) from exc
     log_agent_outcome(
         log_scope,
@@ -245,6 +254,10 @@ def _run_proxy_fs_repository_task(
         correlation_id=str(repository.id),
         repository_id=repository.id,
     )
+    if agent_task_transport_unconfirmed(outcome):
+        raise RepositoryHealthTransportUnconfirmed(
+            "Agent repository probe did not return a terminal result."
+        )
     if outcome.task.status != "success":
         if agent_result_has_repository_conflict(outcome.result):
             raise RepositoryAlreadyExistsError(REPOSITORY_ALREADY_EXISTS_MESSAGE)

--- a/src/backend/apps/storage/services/internal/repository_errors.py
+++ b/src/backend/apps/storage/services/internal/repository_errors.py
@@ -9,10 +9,52 @@ REPOSITORY_ALREADY_EXISTS_MESSAGE = (
     "A Kopia repository already exists at the selected location. "
     "Import is not supported in this version. Choose a different storage location."
 )
+AGENT_TASK_TRANSPORT_UNCONFIRMED_CODE = "AGENT_TASK_TRANSPORT_UNCONFIRMED"
 
 
 class RepositoryAlreadyExistsError(RuntimeError):
     """Raised when strict repository initialization finds an existing repository."""
+
+
+class RepositoryHealthTransportUnconfirmed(RuntimeError):
+    """Raised when an Agent probe has no authoritative repository outcome."""
+
+    error_code = AGENT_TASK_TRANSPORT_UNCONFIRMED_CODE
+
+
+def agent_task_transport_unconfirmed(outcome: Any) -> bool:
+    """Return whether an Agent outcome only proves delivery/wait uncertainty."""
+
+    if getattr(outcome, "timed_out", False) is True:
+        return True
+    task = getattr(outcome, "task", None)
+    status = str(getattr(task, "status", "") or "").strip().lower()
+    if status in {"pending", "running", "timeout"}:
+        return True
+    if status in {"failed", "canceled", "cancelled"}:
+        accepted_at = getattr(task, "accepted_at", None)
+        result = getattr(outcome, "result", None)
+        if accepted_at is None and not result:
+            return True
+    return False
+
+
+def is_repository_health_transport_unconfirmed(exc: BaseException) -> bool:
+    """Inspect an exception chain for an unconfirmed Agent health probe."""
+
+    seen: set[int] = set()
+    current: BaseException | None = exc
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        if isinstance(current, RepositoryHealthTransportUnconfirmed):
+            return True
+        if (
+            str(getattr(current, "error_code", "") or "").strip()
+            == AGENT_TASK_TRANSPORT_UNCONFIRMED_CODE
+        ):
+            return True
+        current = current.__cause__ or current.__context__
+    return False
 
 
 _REPOSITORY_CONFLICT_MARKERS = (

--- a/src/backend/apps/storage/services/internal/repository_health.py
+++ b/src/backend/apps/storage/services/internal/repository_health.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from enum import StrEnum
 
 from django.apps import apps
 from django.core.exceptions import ValidationError
@@ -30,6 +31,10 @@ from apps.storage.services.internal.proxy_fs_repository import (
     check_proxy_fs_repository,
 )
 from apps.storage.services.internal.repository_initializer import check_s3_repository
+from apps.storage.services.internal.repository_errors import (
+    RepositoryHealthTransportUnconfirmed,
+    agent_task_transport_unconfirmed,
+)
 from apps.storage.services.internal.repository_location import (
     invalidate_repository_location_ownership,
     mark_repository_location_ownership_verified,
@@ -41,6 +46,12 @@ from apps.storage.services.internal.repository_ownership import (
 
 
 logger = logging.getLogger(__name__)
+
+
+class _AgentProbeState(StrEnum):
+    ONLINE = "online"
+    CONFIRMED_FAILURE = "confirmed_failure"
+    TRANSPORT_UNKNOWN = "transport_unknown"
 
 
 def is_repository_ownership_failure(exc: Exception) -> bool:
@@ -57,6 +68,71 @@ def is_repository_ownership_failure(exc: Exception) -> bool:
             return True
         current = current.__cause__ or current.__context__
     return False
+
+
+def project_repository_health_from_agent_result(*, node_task) -> bool:
+    """Project a current successful ``repo.status`` result back to repository health."""
+
+    if (
+        str(getattr(node_task, "kind", "") or "") != "repo.status"
+        or str(getattr(node_task, "correlation_type", "") or "")
+        != "storage_repository"
+        or str(getattr(node_task, "status", "") or "") != "success"
+    ):
+        return False
+    correlation_id = str(getattr(node_task, "correlation_id", "") or "").strip()
+    if not correlation_id.isdigit():
+        return False
+    repository = Repository.objects.filter(
+        pk=int(correlation_id),
+        organization_id=node_task.organization_id,
+        status=Repository.Status.CREATED,
+        updated_at__lte=node_task.created_at,
+    ).first()
+    if repository is None:
+        return False
+
+    current_scope = Repository.objects.filter(
+        pk=repository.id,
+        organization_id=node_task.organization_id,
+        status=Repository.Status.CREATED,
+        updated_at=repository.updated_at,
+    )
+    if repository.repo_type == Repository.Type.PROXY_FS or (
+        repository.repo_type == Repository.Type.NAS
+        and repository.bind_node_type == Repository.BindNodeType.PROXY
+    ):
+        if (
+            repository.bind_node_type != Repository.BindNodeType.PROXY
+            or repository.bind_node_id != node_task.node_id
+        ):
+            return False
+        current_scope = current_scope.filter(
+            bind_node_type=Repository.BindNodeType.PROXY,
+            bind_node_id=node_task.node_id,
+        )
+    elif (
+        repository.repo_type == Repository.Type.NAS
+        and not repository.bind_node_type
+        and not repository.bind_node_id
+    ):
+        _has_associations, _has_claims, nodes = _unbound_nas_execution_nodes(
+            repository
+        )
+        if node_task.node_id not in {node.id for node in nodes}:
+            return False
+        current_scope = current_scope.filter(
+            bind_node_type__isnull=True,
+            bind_node_id__isnull=True,
+        )
+    else:
+        return False
+    return bool(
+        current_scope.update(
+            health=Repository.Health.ONLINE,
+            health_failures=0,
+        )
+    )
 
 
 def probe_repository_health(repository: Repository) -> str:
@@ -102,15 +178,24 @@ def probe_unbound_nas_repository_health(
     if not has_associations or not has_claimed_locations:
         return Repository.Health.UNVERIFIED
 
+    transport_unknown = not nodes
     for node in nodes:
         if node.availability != Node.Availability.ONLINE:
+            transport_unknown = True
             continue
-        if _probe_unbound_nas_from_node(
+        probe_state = _probe_unbound_nas_from_node(
             repository=repository,
             node=node,
             adopt_legacy_ownership=adopt_legacy_ownership,
-        ):
+        )
+        if probe_state == _AgentProbeState.ONLINE:
             return Repository.Health.ONLINE
+        if probe_state == _AgentProbeState.TRANSPORT_UNKNOWN:
+            transport_unknown = True
+    if transport_unknown:
+        raise RepositoryHealthTransportUnconfirmed(
+            "No associated execution node returned an authoritative repository result."
+        )
     return Repository.Health.OFFLINE
 
 
@@ -198,7 +283,7 @@ def _probe_unbound_nas_from_node(
     repository: Repository,
     node: Node,
     adopt_legacy_ownership: bool = True,
-) -> bool:
+) -> _AgentProbeState:
     log_scope = "storage direct nas health probe"
     payload = {
         "repository": nas_repository_payload(
@@ -255,7 +340,7 @@ def _probe_unbound_nas_from_node(
             node.id,
             type(exc).__name__,
         )
-        return False
+        return _AgentProbeState.TRANSPORT_UNKNOWN
 
     log_agent_outcome(
         log_scope,
@@ -266,6 +351,8 @@ def _probe_unbound_nas_from_node(
         correlation_id=str(repository.id),
         repository_id=repository.id,
     )
+    if agent_task_transport_unconfirmed(outcome):
+        return _AgentProbeState.TRANSPORT_UNKNOWN
     if outcome.task.status != "success":
         result = outcome.result if isinstance(outcome.result, dict) else {}
         if result.get("error_code") == "REPOSITORY_OWNERSHIP_INVALID":
@@ -274,7 +361,7 @@ def _probe_unbound_nas_from_node(
                 owner_node_id=node.id,
                 repository_subdir=nas_agent_repository_subdir(node.id),
             )
-        return False
+        return _AgentProbeState.CONFIRMED_FAILURE
     if not (
         isinstance(outcome.result, dict)
         and outcome.result.get("ownership_verified") is True
@@ -285,15 +372,17 @@ def _probe_unbound_nas_from_node(
                 repository.id,
                 node.id,
             )
-            return False
-        return repository_has_legacy_location(
+            return _AgentProbeState.CONFIRMED_FAILURE
+        if repository_has_legacy_location(
             repository,
             owner_node_id=node.id,
             repository_subdir=nas_agent_repository_subdir(node.id),
-        )
+        ):
+            return _AgentProbeState.ONLINE
+        return _AgentProbeState.CONFIRMED_FAILURE
     mark_repository_location_ownership_verified(
         repository,
         owner_node_id=node.id,
         repository_subdir=nas_agent_repository_subdir(node.id),
     )
-    return True
+    return _AgentProbeState.ONLINE

--- a/src/backend/apps/storage/tasks.py
+++ b/src/backend/apps/storage/tasks.py
@@ -23,6 +23,9 @@ from apps.storage.services.internal.repository_health import (
     is_repository_ownership_failure,
     probe_repository_health,
 )
+from apps.storage.services.internal.repository_errors import (
+    is_repository_health_transport_unconfirmed,
+)
 from apps.storage.services.internal.repository_usage import (
     sync_all_repositories,
     sync_organization_repositories,
@@ -204,6 +207,13 @@ def check_storage_repository_health(*, repository_id: int, retry_attempt: int = 
                     retry_attempt=retry_attempt,
                     fail_immediately=True,
                 )
+            if is_repository_health_transport_unconfirmed(exc):
+                return {
+                    "repository_id": repository_id,
+                    "status": repository.health,
+                    "probe_status": "transport_unknown",
+                    "health_failures": repository.health_failures,
+                }
             return _record_repository_health_failure(
                 repository=repository,
                 retry_attempt=retry_attempt,

--- a/src/backend/apps/storage/tests/test_repository_health_tasks.py
+++ b/src/backend/apps/storage/tests/test_repository_health_tasks.py
@@ -10,7 +10,7 @@ from django.utils import timezone
 from rest_framework.exceptions import ValidationError as DRFValidationError
 
 from apps.iam.models import Organization
-from apps.node.models import Node
+from apps.node.models import Node, NodeTask
 from apps.protection.models import BackupConfig
 from apps.source.constants import ResourceType
 from apps.source.models import SourceResource
@@ -28,8 +28,12 @@ from apps.storage.services.internal.nas_repository import (
     nas_proxy_repository_subdir,
 )
 from apps.storage.services.internal.repository_health import (
+    project_repository_health_from_agent_result,
     probe_repository_health,
     probe_unbound_nas_repository_health,
+)
+from apps.storage.services.internal.repository_errors import (
+    RepositoryHealthTransportUnconfirmed,
 )
 from apps.storage.services.internal.repository_location import (
     mark_repository_location_owned,
@@ -247,6 +251,38 @@ class RepositoryHealthTaskTests(TestCase):
         self.assertEqual(result["status"], Repository.Health.OFFLINE)
         self.assertEqual(repository.health, Repository.Health.OFFLINE)
         self.assertEqual(repository.health_failures, 2)
+
+    @mock.patch("apps.storage.tasks.check_storage_repository_health.apply_async")
+    @mock.patch("apps.storage.tasks.cache.delete")
+    @mock.patch("apps.storage.tasks.cache.add", return_value=True)
+    @mock.patch(
+        "apps.storage.tasks.probe_repository_health",
+        side_effect=RepositoryHealthTransportUnconfirmed("result ACK congested"),
+    )
+    def test_transport_unknown_preserves_health_without_retry(
+        self,
+        _probe,
+        _cache_add,
+        _cache_delete,
+        apply_async,
+    ):
+        repository = self._repository(
+            "local",
+            Repository.Type.PROXY_FS,
+            health=Repository.Health.ONLINE,
+            health_failures=1,
+            bind_node_type=Repository.BindNodeType.PROXY,
+            bind_node_id=10,
+        )
+
+        result = check_storage_repository_health.run(repository_id=repository.id)
+
+        repository.refresh_from_db()
+        self.assertEqual(result["status"], Repository.Health.ONLINE)
+        self.assertEqual(result["probe_status"], "transport_unknown")
+        self.assertEqual(repository.health, Repository.Health.ONLINE)
+        self.assertEqual(repository.health_failures, 1)
+        apply_async.assert_not_called()
 
     @mock.patch("apps.storage.tasks.cache.delete")
     @mock.patch("apps.storage.tasks.cache.add", return_value=True)
@@ -586,10 +622,28 @@ class UnboundNASRepositoryHealthTests(TestCase):
         agent = self._node("agent-a", online=False)
         self._agent_config(agent, name="agent-config")
 
-        health = probe_unbound_nas_repository_health(self.repository)
-
-        self.assertEqual(health, Repository.Health.OFFLINE)
+        with self.assertRaises(RepositoryHealthTransportUnconfirmed):
+            probe_unbound_nas_repository_health(self.repository)
         run_agent.assert_not_called()
+
+    @mock.patch("apps.storage.services.internal.repository_health.run_agent_task_sync")
+    def test_timed_out_execution_path_is_transport_unknown(self, run_agent):
+        agent = self._node("agent-timeout")
+        self._agent_config(agent, name="agent-timeout-config")
+        run_agent.return_value = mock.Mock(
+            task=mock.Mock(
+                id="node-task-timeout",
+                status="timeout",
+                last_error="watchdog timeout (no progress)",
+                accepted_at=timezone.now(),
+            ),
+            result={},
+            timed_out=False,
+            ok=False,
+        )
+
+        with self.assertRaises(RepositoryHealthTransportUnconfirmed):
+            probe_unbound_nas_repository_health(self.repository)
 
     @mock.patch("apps.storage.services.internal.repository_health.run_agent_task_sync")
     def test_residual_location_is_rechecked_without_ownership_adoption(self, run_agent):
@@ -614,6 +668,64 @@ class UnboundNASRepositoryHealthTests(TestCase):
             run_agent.call_args.kwargs["payload"]["allow_ownership_adoption"]
         )
 
+
+class RepositoryHealthResultProjectionTests(TestCase):
+    def setUp(self):
+        self.organization = Organization.objects.create(
+            key="repository-health-projection-org",
+            name="Repository Health Projection Org",
+        )
+        self.proxy = Node.objects.create(
+            organization=self.organization,
+            name="projection-proxy",
+            role=Node.Role.PROXY,
+            status=Node.Status.ACTIVE,
+            availability=Node.Availability.ONLINE,
+        )
+        self.repository = Repository.objects.create(
+            organization_id=self.organization.id,
+            name="projection-local",
+            repo_type=Repository.Type.PROXY_FS,
+            status=Repository.Status.CREATED,
+            health=Repository.Health.OFFLINE,
+            health_failures=2,
+            bind_node_type=Repository.BindNodeType.PROXY,
+            bind_node_id=self.proxy.id,
+        )
+
+    def _repo_status_task(self) -> NodeTask:
+        return NodeTask.objects.create(
+            organization=self.organization,
+            node=self.proxy,
+            kind="repo.status",
+            correlation_type="storage_repository",
+            correlation_id=str(self.repository.id),
+            status=NodeTask.Status.SUCCESS,
+            result={"ownership_verified": True},
+            watchdog_deadline_at=timezone.now(),
+        )
+
+    def test_current_late_success_restores_online_health(self):
+        task = self._repo_status_task()
+
+        projected = project_repository_health_from_agent_result(node_task=task)
+
+        self.assertTrue(projected)
+        self.repository.refresh_from_db()
+        self.assertEqual(self.repository.health, Repository.Health.ONLINE)
+        self.assertEqual(self.repository.health_failures, 0)
+
+    def test_stale_result_after_repository_configuration_change_is_ignored(self):
+        task = self._repo_status_task()
+        self.repository.config = {"proxy_node_dir": "/new-location"}
+        self.repository.save(update_fields=["config", "updated_at"])
+
+        projected = project_repository_health_from_agent_result(node_task=task)
+
+        self.assertFalse(projected)
+        self.repository.refresh_from_db()
+        self.assertEqual(self.repository.health, Repository.Health.OFFLINE)
+        self.assertEqual(self.repository.health_failures, 2)
 
 class RepositoryHealthProbeTests(TestCase):
     def setUp(self):


### PR DESCRIPTION
## Problem and root cause

Unbounded Agent result replay could monopolize a reconnected WebSocket while
the control plane repeatedly processed already-durable terminal results. Live
task progress and repository probes could then reach watchdog or delivery
timeouts even though the repository remained accessible. Repository health
treated those transport uncertainties as confirmed storage failures, allowing
two congested probes to mark an active repository offline.

## Solution

- Bound ACK-mode result delivery to a 32-item in-flight window with per-result
  retry deadlines, ACK-driven refill, and mixed recent/old backlog selection.
- Start WebSocket readers before reconnect replay and share the delivery window
  between live and persisted terminal results.
- ACK identical durable terminal retransmissions without rewriting task state,
  republishing task streams, or repeating general domain follow-up.
- Distinguish unconfirmed transport outcomes from Agent-confirmed repository
  failures, including direct NAS aggregation across execution nodes.
- Restore repository health from a late successful `repo.status` result only
  when organization, binding, owner, and repository generation still match.

## Validation

- Agent targeted packages: passed
  (`internal/infra/database`, `internal/wire`, `internal/remote`, `internal/app`).
- Backend targeted regressions: 45 tests passed.
- Backend Ruff and migration drift checks: passed.
- Full Backend suite: 1,746 tests passed, 2 skipped.
- Full Agent suite: baseline-equivalent to canonical
  `85333a62682042f053d7bb18d30c5dee3e4a53c5`. macOS reports the same
  Linux-only protected-filesystem, mount-containment, and lazy-unmount
  failures; the Linux container reports the same unchanged
  `internal/service/explorer/TestListMountPoints` failure when no mount point
  is exposed. All affected packages passed in Linux.
- `git diff --check`: passed.
- English source boundary: all changed paths passed; the repository-wide
  checker still reports pre-existing CJK content in unchanged Website files.
- Manual testing: passed.

## Risks and compatibility

The wire frames, ACK subprotocol, public health enum, database schema, and
dependencies are unchanged. The control-plane classification is safe to deploy
before upgrading older Agents and prevents transport uncertainty from causing
false Offline transitions. Confirmed repository failures still use the
existing two-failure threshold, and ownership-invalid results remain immediate.

Fixes #689
