### PR TITLE
fix(system-task): recover backup tasks after agent restarts via operation-tagged reconciliation

### DIFF
--- a/src/agent/internal/engine/managed_backup.go
+++ b/src/agent/internal/engine/managed_backup.go
@@ -38,6 +38,8 @@ const (
 	managedRepositoryFSOperationTimeout  = 30 * time.Second
 	managedRepositoryKopiaCommandTimeout = 2 * time.Minute
 	kopiaEstimatedUsageFactor            = 1.05
+	backupOperationTagKey                = "hfl-operation"
+	backupOperationIDMaxLength           = 128
 	repositoryAlreadyExistsCode          = "STORAGE.REPOSITORY_ALREADY_EXISTS"
 	repositoryAlreadyExistsMessage       = "A Kopia repository already exists at the selected location. Import is not supported in this version. Choose a different storage location."
 	nasRepositoryWriteDeniedCode         = "NAS_REPOSITORY_WRITE_DENIED"
@@ -90,6 +92,7 @@ type repositoryOwnership struct {
 
 var (
 	kopiaS3URLStyleCapabilities sync.Map
+	backupOperationIDPattern    = regexp.MustCompile(`^[A-Za-z0-9._-]+$`)
 )
 
 func parseRepositorySpec(raw any) (repositorySpec, bool, error) {
@@ -1229,6 +1232,10 @@ func (e *Engine) runManagedBackup(
 	if prepErr != "" {
 		return "failed", result, prepErr
 	}
+	if operationErr := attachManagedBackupOperation(result, p); operationErr != nil {
+		result["error_code"] = "BACKUP_OPERATION_ID_INVALID"
+		return "failed", result, operationErr.Error()
+	}
 	return runPreparedManagedBackup(ctx, rep, taskID, bin, configFile, env, p.Path, policySpec, result)
 }
 
@@ -1278,6 +1285,49 @@ func (e *Engine) runManagedPolicyApply(
 
 var runManagedSnapshotCommand = process.RunStreaming
 
+var runManagedSnapshotReconcileCommand = func(
+	ctx context.Context,
+	bin string,
+	args []string,
+	env map[string]string,
+	stdin string,
+) (process.Result, error) {
+	return runProcessWithTimeout(
+		ctx,
+		managedRepositoryKopiaCommandTimeout,
+		bin,
+		args,
+		env,
+		stdin,
+	)
+}
+
+func managedBackupOperationID(p Payload) (string, error) {
+	operationID := payloadStringValue(p.Extra["operation_id"])
+	if operationID == "" {
+		return "", nil
+	}
+	if len(operationID) > backupOperationIDMaxLength || !backupOperationIDPattern.MatchString(operationID) {
+		return "", fmt.Errorf("invalid backup operation id")
+	}
+	return operationID, nil
+}
+
+func attachManagedBackupOperation(result map[string]any, p Payload) error {
+	operationID, err := managedBackupOperationID(p)
+	if err != nil {
+		return err
+	}
+	if operationID == "" {
+		return nil
+	}
+	result["operation_id"] = operationID
+	if attempt, ok := payloadIntValue(p.Extra["operation_attempt"]); ok && attempt > 0 {
+		result["operation_attempt"] = attempt
+	}
+	return nil
+}
+
 func (e *Engine) runManagedPreparedSnapshot(
 	ctx context.Context,
 	rep ReporterSink,
@@ -1303,6 +1353,10 @@ func (e *Engine) runManagedPreparedSnapshot(
 	)
 	if prepErr != "" {
 		return "failed", result, prepErr
+	}
+	if operationErr := attachManagedBackupOperation(result, p); operationErr != nil {
+		result["error_code"] = "BACKUP_OPERATION_ID_INVALID"
+		return "failed", result, operationErr.Error()
 	}
 	releaseSessionLock, sessionLockErr := repositorySessionLockFor(repository, configFile).acquireRead(ctx)
 	if sessionLockErr != nil {
@@ -1365,7 +1419,44 @@ func runPreparedManagedSnapshot(
 		map[string]any{"source_path": sourcePath},
 	))
 
-	snapshotArgs := managedBackupSnapshotArgs(configFile, sourcePath)
+	operationID := payloadStringValue(result["operation_id"])
+	operationAttempt, hasOperationAttempt := payloadIntValue(result["operation_attempt"])
+	shouldReconcileOperation := operationID != "" && (!hasOperationAttempt || operationAttempt > 1)
+	if shouldReconcileOperation {
+		reconcileResult, existingSnapshot, matchCount, reconcileErr := findManagedSnapshotByOperation(
+			ctx,
+			bin,
+			configFile,
+			env,
+			operationID,
+		)
+		result["snapshot_reconcile"] = commandResult(reconcileResult)
+		if reconcileErr != nil {
+			result["error_code"] = "KOPIA_SNAPSHOT_RECONCILE_FAILED"
+			return "failed", result, reconcileErr.Error()
+		}
+		if existingSnapshot != nil {
+			for key, value := range snapshotResultFromParsed(existingSnapshot) {
+				result[key] = value
+			}
+			result["snapshot_reconciled"] = true
+			result["snapshot_reconcile_match_count"] = matchCount
+			_ = sendProgress(ctx, rep, taskID, map[string]any{
+				"phase":             "kopia_transfer",
+				"kopia_phase":       "snapshot_created",
+				"kopia_percent":     100,
+				"percent":           100,
+				"bytes_done":        int64(1),
+				"bytes_total":       int64(1),
+				"bytes_total_known": true,
+				"kopia_snapshot_id": stringValue(result["kopia_snapshot_id"]),
+				"reconciled":        true,
+			})
+			return "success", result, ""
+		}
+	}
+
+	snapshotArgs := managedBackupSnapshotArgs(configFile, sourcePath, operationID)
 	progressState := newKopiaProgressReporter()
 	runCtx, cancelRun := context.WithCancel(ctx)
 	stallSeconds := kopiaProgressStallSeconds()
@@ -1390,6 +1481,7 @@ func runPreparedManagedSnapshot(
 	}
 	if runErr != nil {
 		if stalled {
+			result["error_code"] = "KOPIA_PROGRESS_STALL"
 			return "failed", result, "kopia progress stall"
 		}
 		if managedSnapshotPolicyNotFound(res) {
@@ -1418,16 +1510,82 @@ func managedSnapshotPolicyNotFound(res process.Result) bool {
 	return strings.Contains(output, "unable to get policy tree") || strings.Contains(output, "policy not found")
 }
 
-func managedBackupSnapshotArgs(configFile string, sourcePath string) []string {
-	return []string{
+func managedBackupSnapshotArgs(configFile string, sourcePath string, operationID string) []string {
+	args := []string{
 		"--config-file=" + configFile,
 		"--progress",
 		"--progress-estimation-type=classic",
 		"snapshot",
 		"create",
 		sourcePath,
+	}
+	if operationID != "" {
+		args = append(args, "--tags="+backupOperationTagKey+":"+operationID)
+	}
+	return append(args, "--json")
+}
+
+func managedSnapshotReconcileArgs(configFile string, operationID string) []string {
+	return []string{
+		"--config-file=" + configFile,
+		"snapshot",
+		"list",
+		"--all",
+		"--max-results=100",
+		"--tags=" + backupOperationTagKey + ":" + operationID,
 		"--json",
 	}
+}
+
+func findManagedSnapshotByOperation(
+	ctx context.Context,
+	bin string,
+	configFile string,
+	env map[string]string,
+	operationID string,
+) (process.Result, map[string]any, int, error) {
+	args := managedSnapshotReconcileArgs(configFile, operationID)
+	res, runErr := runManagedSnapshotReconcileCommand(ctx, bin, args, env, "")
+	if runErr != nil {
+		return res, nil, 0, fmt.Errorf("snapshot reconciliation failed: %w", runErr)
+	}
+	parsed, ok := decodeJSONLoose(strings.TrimSpace(res.Stdout))
+	if !ok {
+		return res, nil, 0, fmt.Errorf("snapshot reconciliation returned invalid JSON")
+	}
+	rows, ok := parsed.([]any)
+	if !ok {
+		return res, nil, 0, fmt.Errorf("snapshot reconciliation returned an invalid result")
+	}
+
+	var selected map[string]any
+	var selectedEnd time.Time
+	matchCount := 0
+	for _, raw := range rows {
+		row, rowOK := raw.(map[string]any)
+		if !rowOK || !managedSnapshotHasOperation(row, operationID) {
+			continue
+		}
+		if findStringKey(row, "id", "snapshot_id", "snapshotID", "kopia_snapshot_id") == "" {
+			return res, nil, matchCount, fmt.Errorf("snapshot reconciliation returned a snapshot without identity")
+		}
+		matchCount++
+		endTime, _ := time.Parse(time.RFC3339Nano, payloadStringValue(row["endTime"]))
+		if selected == nil || endTime.After(selectedEnd) {
+			selected = row
+			selectedEnd = endTime
+		}
+	}
+	return res, selected, matchCount, nil
+}
+
+func managedSnapshotHasOperation(snapshot map[string]any, operationID string) bool {
+	tags, ok := snapshot["tags"].(map[string]any)
+	if !ok {
+		return false
+	}
+	return payloadStringValue(tags["tag:"+backupOperationTagKey]) == operationID ||
+		payloadStringValue(tags[backupOperationTagKey]) == operationID
 }
 
 func (e *Engine) runManagedSnapshotDelete(
@@ -3675,6 +3833,10 @@ func parseSnapshotOutput(stdout string) map[string]any {
 	if !ok {
 		return nil
 	}
+	return snapshotResultFromParsed(parsed)
+}
+
+func snapshotResultFromParsed(parsed any) map[string]any {
 	result := map[string]any{
 		"snapshot": parsed,
 	}

--- a/src/agent/internal/engine/managed_backup_test.go
+++ b/src/agent/internal/engine/managed_backup_test.go
@@ -966,7 +966,7 @@ func mustNASSpec(t *testing.T, raw map[string]any) *nassvc.Spec {
 }
 
 func TestManagedBackupSnapshotArgsAvoidUnsupportedProgressIntervalFlag(t *testing.T) {
-	args := managedBackupSnapshotArgs("/tmp/repo.config", "/tmp/source")
+	args := managedBackupSnapshotArgs("/tmp/repo.config", "/tmp/source", "operation-123")
 
 	if slices.Contains(args, "--progress-interval=3s") {
 		t.Fatalf("snapshot args must not include unsupported --progress-interval flag: %#v", args)
@@ -977,8 +977,11 @@ func TestManagedBackupSnapshotArgsAvoidUnsupportedProgressIntervalFlag(t *testin
 	if !slices.Contains(args, "--json") {
 		t.Fatalf("expected snapshot args to include --json: %#v", args)
 	}
-	if got := args[len(args)-2]; got != "/tmp/source" {
-		t.Fatalf("expected source path before --json, got %q in %#v", got, args)
+	if !slices.Contains(args, "--tags=hfl-operation:operation-123") {
+		t.Fatalf("expected snapshot args to include operation tag: %#v", args)
+	}
+	if got := args[len(args)-3]; got != "/tmp/source" {
+		t.Fatalf("expected source path before tag and --json, got %q in %#v", got, args)
 	}
 }
 

--- a/src/agent/internal/engine/repository_session_lock_test.go
+++ b/src/agent/internal/engine/repository_session_lock_test.go
@@ -3,6 +3,8 @@ package engine
 import (
 	"context"
 	"errors"
+	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -161,5 +163,207 @@ func TestPreparedSnapshotKeepsSingleBoundedCommandSummary(t *testing.T) {
 	}
 	if command["stdout_total_bytes"] != int64(512*1024) || command["stderr_truncated"] != true {
 		t.Fatalf("output bounds metadata missing: %#v", command)
+	}
+}
+
+func TestPreparedSnapshotAdoptsExistingOperationBeforeCreating(t *testing.T) {
+	originalReconcileRunner := runManagedSnapshotReconcileCommand
+	originalSnapshotRunner := runManagedSnapshotCommand
+	t.Cleanup(func() {
+		runManagedSnapshotReconcileCommand = originalReconcileRunner
+		runManagedSnapshotCommand = originalSnapshotRunner
+	})
+	runManagedSnapshotReconcileCommand = func(
+		context.Context,
+		string,
+		[]string,
+		map[string]string,
+		string,
+	) (process.Result, error) {
+		return process.Result{Stdout: `[
+			{"id":"snapshot-existing","endTime":"2026-08-20T10:00:00Z","stats":{"totalSize":42,"fileCount":3,"dirCount":1},"tags":{"tag:hfl-operation":"operation-123"}}
+		]`}, nil
+	}
+	snapshotCalls := 0
+	runManagedSnapshotCommand = func(
+		context.Context,
+		string,
+		[]string,
+		map[string]string,
+		string,
+		process.OutputLineHandler,
+	) (process.Result, error) {
+		snapshotCalls++
+		return process.Result{}, nil
+	}
+
+	status, result, message := runPreparedManagedSnapshot(
+		t.Context(), ReporterSink{}, "prepared-reconcile", "kopia", "/tmp/reconcile.config",
+		nil, "/data", map[string]any{"operation_id": "operation-123", "operation_attempt": 2},
+	)
+
+	if status != "success" || message != "" {
+		t.Fatalf("status=%q message=%q result=%#v", status, message, result)
+	}
+	if snapshotCalls != 0 {
+		t.Fatalf("snapshot create ran %d times after reconciliation", snapshotCalls)
+	}
+	if result["kopia_snapshot_id"] != "snapshot-existing" || result["snapshot_reconciled"] != true {
+		t.Fatalf("existing snapshot was not adopted: %#v", result)
+	}
+	if result["size_bytes"] != int64(42) || result["file_count"] != int64(3) {
+		t.Fatalf("existing snapshot metrics were not adopted: %#v", result)
+	}
+}
+
+func TestPreparedSnapshotFirstAttemptTagsWithoutReconcileRead(t *testing.T) {
+	originalReconcileRunner := runManagedSnapshotReconcileCommand
+	originalSnapshotRunner := runManagedSnapshotCommand
+	t.Cleanup(func() {
+		runManagedSnapshotReconcileCommand = originalReconcileRunner
+		runManagedSnapshotCommand = originalSnapshotRunner
+	})
+	runManagedSnapshotReconcileCommand = func(
+		context.Context,
+		string,
+		[]string,
+		map[string]string,
+		string,
+	) (process.Result, error) {
+		t.Fatal("first backup attempt must not add a repository reconciliation read")
+		return process.Result{}, nil
+	}
+	createCalls := 0
+	runManagedSnapshotCommand = func(
+		_ context.Context,
+		_ string,
+		args []string,
+		_ map[string]string,
+		_ string,
+		_ process.OutputLineHandler,
+	) (process.Result, error) {
+		createCalls++
+		if !slices.Contains(args, "--tags=hfl-operation:operation-123") {
+			t.Fatalf("first attempt did not tag the snapshot: %#v", args)
+		}
+		return process.Result{Stdout: `{"id":"snapshot-created"}`}, nil
+	}
+
+	status, result, message := runPreparedManagedSnapshot(
+		t.Context(), ReporterSink{}, "prepared-first-attempt", "kopia", "/tmp/reconcile.config",
+		nil, "/data", map[string]any{"operation_id": "operation-123", "operation_attempt": 1},
+	)
+
+	if status != "success" || message != "" {
+		t.Fatalf("status=%q message=%q result=%#v", status, message, result)
+	}
+	if createCalls != 1 || result["kopia_snapshot_id"] != "snapshot-created" {
+		t.Fatalf("first attempt did not create exactly one tagged snapshot: %#v", result)
+	}
+}
+
+func TestPreparedSnapshotAdoptsNewestExistingOperationMatch(t *testing.T) {
+	originalReconcileRunner := runManagedSnapshotReconcileCommand
+	originalSnapshotRunner := runManagedSnapshotCommand
+	t.Cleanup(func() {
+		runManagedSnapshotReconcileCommand = originalReconcileRunner
+		runManagedSnapshotCommand = originalSnapshotRunner
+	})
+	runManagedSnapshotReconcileCommand = func(
+		context.Context,
+		string,
+		[]string,
+		map[string]string,
+		string,
+	) (process.Result, error) {
+		return process.Result{Stdout: `[
+			{"id":"snapshot-older","endTime":"2026-08-20T09:00:00Z","tags":{"tag:hfl-operation":"operation-123"}},
+			{"id":"snapshot-newest","endTime":"2026-08-20T11:00:00Z","tags":{"tag:hfl-operation":"operation-123"}},
+			{"id":"snapshot-other","endTime":"2026-08-20T12:00:00Z","tags":{"tag:hfl-operation":"operation-other"}}
+		]`}, nil
+	}
+	runManagedSnapshotCommand = func(
+		context.Context,
+		string,
+		[]string,
+		map[string]string,
+		string,
+		process.OutputLineHandler,
+	) (process.Result, error) {
+		t.Fatal("snapshot create must not run when an operation match exists")
+		return process.Result{}, nil
+	}
+
+	status, result, message := runPreparedManagedSnapshot(
+		t.Context(), ReporterSink{}, "prepared-reconcile-newest", "kopia", "/tmp/reconcile.config",
+		nil, "/data", map[string]any{"operation_id": "operation-123"},
+	)
+
+	if status != "success" || message != "" {
+		t.Fatalf("status=%q message=%q result=%#v", status, message, result)
+	}
+	if result["kopia_snapshot_id"] != "snapshot-newest" {
+		t.Fatalf("newest matching snapshot was not adopted: %#v", result)
+	}
+	if result["snapshot_reconcile_match_count"] != 2 {
+		t.Fatalf("unexpected operation match count: %#v", result)
+	}
+}
+
+func TestPreparedSnapshotFailsClosedWhenOperationCannotBeReconciled(t *testing.T) {
+	originalReconcileRunner := runManagedSnapshotReconcileCommand
+	originalSnapshotRunner := runManagedSnapshotCommand
+	t.Cleanup(func() {
+		runManagedSnapshotReconcileCommand = originalReconcileRunner
+		runManagedSnapshotCommand = originalSnapshotRunner
+	})
+	runManagedSnapshotReconcileCommand = func(
+		context.Context,
+		string,
+		[]string,
+		map[string]string,
+		string,
+	) (process.Result, error) {
+		return process.Result{ExitCode: 1}, errors.New("repository unavailable")
+	}
+	snapshotCalls := 0
+	runManagedSnapshotCommand = func(
+		context.Context,
+		string,
+		[]string,
+		map[string]string,
+		string,
+		process.OutputLineHandler,
+	) (process.Result, error) {
+		snapshotCalls++
+		return process.Result{}, nil
+	}
+
+	status, result, message := runPreparedManagedSnapshot(
+		t.Context(), ReporterSink{}, "prepared-reconcile-failed", "kopia", "/tmp/reconcile.config",
+		nil, "/data", map[string]any{"operation_id": "operation-123"},
+	)
+
+	if status != "failed" || !strings.Contains(message, "snapshot reconciliation failed") {
+		t.Fatalf("status=%q message=%q result=%#v", status, message, result)
+	}
+	if snapshotCalls != 0 {
+		t.Fatalf("snapshot create ran %d times after failed reconciliation", snapshotCalls)
+	}
+	if result["error_code"] != "KOPIA_SNAPSHOT_RECONCILE_FAILED" {
+		t.Fatalf("structured reconciliation error missing: %#v", result)
+	}
+}
+
+func TestManagedBackupOperationIDRejectsUnsafeValues(t *testing.T) {
+	for _, operationID := range []string{
+		"operation:with-colon",
+		"operation with spaces",
+		strings.Repeat("a", backupOperationIDMaxLength+1),
+	} {
+		_, err := managedBackupOperationID(Payload{Extra: map[string]any{"operation_id": operationID}})
+		if err == nil {
+			t.Fatalf("unsafe operation id was accepted: %q", operationID)
+		}
 	}
 }

--- a/src/agent/internal/remote/inventory.go
+++ b/src/agent/internal/remote/inventory.go
@@ -55,6 +55,7 @@ func SendInventory(
 			"repository_cleanup_s3_v1",
 			"repository_ownership_v1",
 			"backup_prepared_snapshot_v1",
+			"backup_operation_reconcile_v1",
 			"snapshot_browse_v1",
 			"snapshot_artifact_upload_v1",
 			"snapshot_scope_resolve_v1",

--- a/src/backend/apps/protection/conf.py
+++ b/src/backend/apps/protection/conf.py
@@ -37,8 +37,8 @@ PROTECTION_BACKUP_SUBSTANTIVE_STALL_WARN_SECONDS = env_int(
     "PROTECTION_BACKUP_SUBSTANTIVE_STALL_WARN_SECONDS",
     1800,
 )
-# Deprecated: substantive progress stalls are warning-only. Agent activity leases
-# and the Agent-side Kopia watchdog are responsible for terminating dead work.
+# Agent-side Kopia watchdog is the primary stall terminator. This longer control
+# plane deadline is a final safety net for old Agents or failed local watchdogs.
 PROTECTION_BACKUP_SUBSTANTIVE_STALL_FAIL_SECONDS = env_int(
     "PROTECTION_BACKUP_SUBSTANTIVE_STALL_FAIL_SECONDS",
     7200,
@@ -54,6 +54,10 @@ PROTECTION_BACKUP_LATE_SUCCESS_ADOPT_SECONDS = env_int(
 PROTECTION_BACKUP_REATTACH_GRACE_SECONDS = env_int(
     "PROTECTION_BACKUP_REATTACH_GRACE_SECONDS",
     900,
+)
+PROTECTION_BACKUP_CAPABILITY_SYNC_GRACE_SECONDS = env_int(
+    "PROTECTION_BACKUP_CAPABILITY_SYNC_GRACE_SECONDS",
+    120,
 )
 PROTECTION_BACKUP_DISABLE_SHORT_WATCHDOG = env_bool(
     "PROTECTION_BACKUP_DISABLE_SHORT_WATCHDOG",

--- a/src/backend/apps/protection/services/backup_orchestrator.py
+++ b/src/backend/apps/protection/services/backup_orchestrator.py
@@ -60,6 +60,7 @@ logger = logging.getLogger(__name__)
 _BACKUP_PROTOCOL_LEGACY = "legacy_parallel"
 _BACKUP_PROTOCOL_PREPARED = "prepared_snapshot_v1"
 _BACKUP_PREPARED_CAPABILITY = "backup_prepared_snapshot_v1"
+_BACKUP_OPERATION_RECONCILE_CAPABILITY = "backup_operation_reconcile_v1"
 
 _NODE_TASK_TERMINAL = frozenset(
     {
@@ -115,6 +116,8 @@ def _node_task_error_code(node_task: NodeTask) -> tuple[str, str]:
             return "RESULT_ACK_TIMEOUT", last_error or "Agent result acknowledgement timed out."
         return "WATCHDOG_STALL", last_error or "Agent task watchdog timed out."
     if node_task.status == NodeTask.Status.CANCELED:
+        if "progress stall" in lower or "kopia_progress_stall" in lower:
+            return "KOPIA_PROGRESS_STALL", last_error
         return "USER_CANCELLED", last_error or "Backup canceled."
     if "agent restarted before task completed" in lower:
         return "AGENT_RESTARTED", last_error
@@ -124,10 +127,21 @@ def _node_task_error_code(node_task: NodeTask) -> tuple[str, str]:
         return "KOPIA_SIGNAL_KILLED", last_error or "Kopia process was killed."
     if node_task.status == NodeTask.Status.FAILED:
         result = node_task.result if isinstance(node_task.result, dict) else {}
-        if str(result.get("error_code") or "") == "KOPIA_POLICY_NOT_FOUND":
+        structured_error = str(result.get("error_code") or "")
+        if structured_error == "KOPIA_SNAPSHOT_RECONCILE_FAILED":
+            return (
+                "KOPIA_SNAPSHOT_RECONCILE_FAILED",
+                "The existing backup result could not be verified safely. Retry after checking repository availability.",
+            )
+        if structured_error == "BACKUP_OPERATION_ID_INVALID":
+            return (
+                "BACKUP_OPERATION_ID_INVALID",
+                "The backup execution identity is invalid. Start a new backup task.",
+            )
+        if structured_error == "KOPIA_POLICY_NOT_FOUND":
             message = bt.extract_kopia_failure_message(result, last_error=last_error)
             return "KOPIA_POLICY_NOT_FOUND", (message or "Kopia policy not found.")[:2000]
-        if str(result.get("error_code") or "") == "POLICY_APPLY_FAILED":
+        if structured_error == "POLICY_APPLY_FAILED":
             phase = str(result.get("policy_phase") or "apply")
             message = bt.extract_kopia_failure_message(result, last_error=last_error)
             public_message = bt.public_repository_failure_message(message)
@@ -817,6 +831,8 @@ def _dispatch_directory_backup(
     task_kind: str = "backup.run",
 ) -> None:
     bt = _bt()
+    operation_id = f"{task.task_uuid}-{directory_row.backup_config_dir_id}"
+    operation_attempt = int(directory_row.retry_count or 0) + 1
     existing = _get_node_task_for_directory(
         directory=directory_row,
         organization_id=task.organization_id,
@@ -905,6 +921,8 @@ def _dispatch_directory_backup(
             file_filter_payload=file_filter_payload if task_kind == "backup.run" else None,
             backup_policy_payload=backup_policy_payload if task_kind == "backup.run" else None,
             compression_payload=compression_payload if task_kind == "backup.run" else None,
+            operation_id=operation_id,
+            operation_attempt=operation_attempt,
         ),
         correlation_type=protection_conf.PROTECTION_BACKUP_CORRELATION_TYPE,
         correlation_id=str(task.task_uuid),
@@ -940,6 +958,8 @@ def _dispatch_directory_backup(
             "repository_type": repository.repo_type,
             "orchestrator": True,
             "task_kind": task_kind,
+            "operation_id": operation_id,
+            "operation_attempt": operation_attempt,
             "object_name": source_path,
         },
     )
@@ -1050,6 +1070,7 @@ def _handle_directory_stall(
         return False
     elapsed = (now - reference).total_seconds()
     warn_seconds = protection_conf.PROTECTION_BACKUP_SUBSTANTIVE_STALL_WARN_SECONDS
+    fail_seconds = protection_conf.PROTECTION_BACKUP_SUBSTANTIVE_STALL_FAIL_SECONDS
     if elapsed >= warn_seconds and directory_row.stall_warned_at is None:
         directory_row.stall_warned_at = now
         directory_row.save(update_fields=["stall_warned_at", "updated_at"])
@@ -1065,11 +1086,44 @@ def _handle_directory_stall(
                 "object_name": directory_row.source_path,
             },
         )
-    # A lack of changing Kopia counters is diagnostic, not proof that the
-    # process is dead (large small-file trees can spend a long time walking and
-    # reading metadata). The NodeTask activity lease and Agent-side Kopia
-    # watchdog own termination decisions.
-    return False
+    if elapsed < fail_seconds:
+        return False
+    if directory_row.cancel_requested_at is None:
+        directory_row.cancel_requested_at = now
+        directory_row.save(update_fields=["cancel_requested_at", "updated_at"])
+        cancel_agent_task(task_id=node_task.id, reason="kopia progress stall")
+        return False
+    grace = protection_conf.PROTECTION_BACKUP_CANCEL_GRACE_SECONDS
+    if (now - directory_row.cancel_requested_at).total_seconds() < grace:
+        return False
+    error_code = "KOPIA_PROGRESS_STALL"
+    error_message = f"No substantive backup progress for {int(elapsed)} seconds."
+    record_source_snapshot_directory_result(
+        source_snapshot=directory_row.source_snapshot,
+        backup_config_dir_id=directory_row.backup_config_dir_id,
+        source_path=directory_row.source_path,
+        path_type=directory_row.path_type,
+        display_name=directory_row.display_name,
+        repository_id=directory_row.repository_id,
+        status=BackupSourceSnapshotDirectory.Status.FAILED,
+        error_code=error_code,
+        error_message=error_message,
+    )
+    append_task_step_event(
+        task=task,
+        step_name="kopia_snapshot",
+        level=TaskEvent.Level.ERROR,
+        message="Directory backup failed",
+        metadata={
+            "backup_config_dir_id": directory_row.backup_config_dir_id,
+            "source_path": directory_row.source_path,
+            "node_task_id": str(node_task.id),
+            "error_code": error_code,
+            "error_message": error_message,
+            "object_name": directory_row.source_path,
+        },
+    )
+    return True
 
 
 _STALE_DIRECTORY_FAILURE_CODES = frozenset(
@@ -1391,10 +1445,103 @@ def _observe_running_directory(
                 and node_task.status != NodeTask.Status.CANCELED
                 and int(directory_row.retry_count or 0) < 1
             ):
+                retry_node = Node.objects.filter(pk=node_task.node_id).only("metadata").first()
+                supports_safe_retry = (
+                    retry_node is not None
+                    and _BACKUP_OPERATION_RECONCILE_CAPABILITY
+                    in _node_capabilities(retry_node)
+                )
+                if not supports_safe_retry:
+                    grace_seconds = max(
+                        0,
+                        protection_conf.PROTECTION_BACKUP_CAPABILITY_SYNC_GRACE_SECONDS,
+                    )
+                    terminal_age = (timezone.now() - node_task.updated_at).total_seconds()
+                    if terminal_age < grace_seconds:
+                        pending_code = "AGENT_RESTART_CAPABILITY_PENDING"
+                        if directory_row.error_code != pending_code:
+                            directory_row.error_code = pending_code
+                            directory_row.error_message = (
+                                "Waiting for the reconnected Agent to report backup retry capabilities."
+                            )
+                            directory_row.save(
+                                update_fields=[
+                                    "error_code",
+                                    "error_message",
+                                    "updated_at",
+                                ]
+                            )
+                            append_task_step_event(
+                                task=task,
+                                step_name="kopia_snapshot",
+                                level=TaskEvent.Level.WARN,
+                                message="Waiting for Agent capability sync",
+                                metadata={
+                                    "backup_config_dir_id": directory_row.backup_config_dir_id,
+                                    "previous_node_task_id": str(node_task.id),
+                                    "required_capability": _BACKUP_OPERATION_RECONCILE_CAPABILITY,
+                                    "source_path": directory_row.source_path,
+                                    "object_name": directory_row.source_path,
+                                },
+                            )
+                        return
+                    error_code = "AGENT_UPGRADE_REQUIRED"
+                    error_message = (
+                        "Upgrade the Agent before retrying this backup so an existing "
+                        "snapshot can be verified safely."
+                    )
+                else:
+                    directory_row.status = BackupSourceSnapshotDirectory.Status.PENDING
+                    directory_row.node_task_id = None
+                    directory_row.retry_count = int(directory_row.retry_count or 0) + 1
+                    directory_row.error_code = "AGENT_RESTART_RECOVERY_PENDING"
+                    directory_row.error_message = error_message
+                    directory_row.dispatched_at = None
+                    directory_row.last_substantive_progress_at = None
+                    directory_row.last_progress_snapshot = {}
+                    directory_row.last_progress_sample = {}
+                    directory_row.cancel_requested_at = None
+                    directory_row.stall_warned_at = None
+                    directory_row.save(
+                        update_fields=[
+                            "status",
+                            "node_task_id",
+                            "retry_count",
+                            "error_code",
+                            "error_message",
+                            "dispatched_at",
+                            "last_substantive_progress_at",
+                            "last_progress_snapshot",
+                            "last_progress_sample",
+                            "cancel_requested_at",
+                            "stall_warned_at",
+                            "updated_at",
+                        ]
+                    )
+                    append_task_step_event(
+                        task=task,
+                        step_name="kopia_snapshot",
+                        level=TaskEvent.Level.WARN,
+                        message="Backup execution retry queued after Agent restart",
+                        metadata={
+                            "backup_config_dir_id": directory_row.backup_config_dir_id,
+                            "previous_node_task_id": str(node_task.id),
+                            "retry_count": directory_row.retry_count,
+                            "error_code": error_code,
+                            "source_path": directory_row.source_path,
+                            "object_name": directory_row.source_path,
+                        },
+                    )
+                    return
+            if (
+                error_code == "KOPIA_POLICY_NOT_FOUND"
+                and node_task.status != NodeTask.Status.CANCELED
+                and int(directory_row.retry_count or 0) < 1
+            ):
                 directory_row.status = BackupSourceSnapshotDirectory.Status.PENDING
                 directory_row.node_task_id = None
                 directory_row.retry_count = int(directory_row.retry_count or 0) + 1
-                directory_row.error_code = "AGENT_RESTART_RECOVERY_PENDING"
+                directory_row.error_code = "KOPIA_POLICY_REPAIR_PENDING"
                 directory_row.error_message = error_message
                 directory_row.dispatched_at = None
                 directory_row.last_substantive_progress_at = None
@@ -1422,43 +1569,6 @@ def _observe_running_directory(
                     task=task,
                     step_name="kopia_snapshot",
                     level=TaskEvent.Level.WARN,
-                    message="Backup execution retry queued after Agent restart",
-                    metadata={
-                        "backup_config_dir_id": directory_row.backup_config_dir_id,
-                        "previous_node_task_id": str(node_task.id),
-                        "retry_count": directory_row.retry_count,
-                        "error_code": error_code,
-                        "source_path": directory_row.source_path,
-                        "object_name": directory_row.source_path,
-                    },
-                )
-                return
-            if (
-                error_code == "KOPIA_POLICY_NOT_FOUND"
-                and node_task.status != NodeTask.Status.CANCELED
-                and int(directory_row.retry_count or 0) < 1
-            ):
-                directory_row.status = BackupSourceSnapshotDirectory.Status.PENDING
-                directory_row.node_task_id = None
-                directory_row.retry_count = int(directory_row.retry_count or 0) + 1
-                directory_row.error_code = "KOPIA_POLICY_REPAIR_PENDING"
-                directory_row.error_message = error_message
-                directory_row.dispatched_at = None
-                directory_row.save(
-                    update_fields=[
-                        "status",
-                        "node_task_id",
-                        "retry_count",
-                        "error_code",
-                        "error_message",
-                        "dispatched_at",
-                        "updated_at",
-                    ]
-                )
-                append_task_step_event(
-                    task=task,
-                    step_name="kopia_snapshot",
-                    level=TaskEvent.Level.WARN,
                     message="Directory policy repair queued after parallel upload batch",
                     metadata={
                         "backup_config_dir_id": directory_row.backup_config_dir_id,
@@ -1469,6 +1579,11 @@ def _observe_running_directory(
                     },
                 )
                 return
+            directory_status = (
+                BackupSourceSnapshotDirectory.Status.CANCELLED
+                if error_code == "USER_CANCELLED"
+                else BackupSourceSnapshotDirectory.Status.FAILED
+            )
             record_source_snapshot_directory_result(
                 source_snapshot=source_snapshot,
                 backup_config_dir_id=directory_row.backup_config_dir_id,
@@ -1476,9 +1591,7 @@ def _observe_running_directory(
                 path_type=directory_row.path_type,
                 display_name=directory_row.display_name,
                 repository_id=directory_row.repository_id,
-                status=BackupSourceSnapshotDirectory.Status.FAILED
-                if node_task.status != NodeTask.Status.CANCELED
-                else BackupSourceSnapshotDirectory.Status.CANCELLED,
+                status=directory_status,
                 error_code=error_code,
                 error_message=error_message,
             )
@@ -2129,8 +2242,22 @@ def advance_backup(
                 dispatch_kind = "backup.run"
                 directory_row.error_code = ""
                 directory_row.error_message = ""
+                directory_row.last_substantive_progress_at = None
+                directory_row.last_progress_snapshot = {}
+                directory_row.last_progress_sample = {}
+                directory_row.cancel_requested_at = None
+                directory_row.stall_warned_at = None
                 directory_row.save(
-                    update_fields=["error_code", "error_message", "updated_at"]
+                    update_fields=[
+                        "error_code",
+                        "error_message",
+                        "last_substantive_progress_at",
+                        "last_progress_snapshot",
+                        "last_progress_sample",
+                        "cancel_requested_at",
+                        "stall_warned_at",
+                        "updated_at",
+                    ]
                 )
             _dispatch_directory_backup(
                 task=task,
@@ -2995,6 +3122,8 @@ def retry_backup_directory(
     directory_row.adopted_late_result = False
     directory_row.dispatched_at = None
     directory_row.last_substantive_progress_at = None
+    directory_row.last_progress_snapshot = {}
+    directory_row.last_progress_sample = {}
     directory_row.save()
     if task.status in _TASK_TERMINAL:
         from apps.task.services.interface import retry_task

--- a/src/backend/apps/protection/services/backup_task.py
+++ b/src/backend/apps/protection/services/backup_task.py
@@ -1096,6 +1096,8 @@ def _agent_backup_payload(
     file_filter_payload: dict[str, Any] | None = None,
     backup_policy_payload: dict[str, Any] | None = None,
     compression_payload: dict[str, Any] | None = None,
+    operation_id: str = "",
+    operation_attempt: int = 0,
 ) -> dict[str, Any]:
     payload = {
         "source_path": source_path,
@@ -1110,6 +1112,10 @@ def _agent_backup_payload(
         payload["backup_policy"] = backup_policy_payload
     if compression_payload:
         payload["compression"] = compression_payload
+    if operation_id:
+        payload["operation_id"] = operation_id
+    if operation_attempt > 0:
+        payload["operation_attempt"] = operation_attempt
     return payload
 
 

--- a/src/backend/apps/protection/tests/test_backup_task_api.py
+++ b/src/backend/apps/protection/tests/test_backup_task_api.py
@@ -21,7 +21,10 @@ from apps.protection.models import (
 from apps.protection.services.backup_source_snapshot import create_source_snapshot
 from apps.node.services.internal.agent_task import AgentTaskHandle
 from apps.protection.services.backup_orchestrator import (
+    _get_node_task_for_directory,
     _handle_directory_stall,
+    _node_task_error_code,
+    _observe_running_directory,
     _reconcile_pending_backup_queue,
     _repository_public_host,
     cancel_backup,
@@ -1113,7 +1116,7 @@ class ProtectionBackupTaskApiTests(TestCase):
         )
 
     @patch("apps.protection.services.backup_orchestrator.cancel_agent_task")
-    def test_substantive_stall_warns_without_canceling_snapshot(self, mock_cancel):
+    def test_substantive_stall_warns_before_final_deadline(self, mock_cancel):
         task, snapshot = self._create_backup_task_and_snapshot(
             idempotency_key="test-stall-warning-only",
         )
@@ -1128,7 +1131,7 @@ class ProtectionBackupTaskApiTests(TestCase):
             repository_id=self.repository.id,
         )
         directory.status = BackupSourceSnapshotDirectory.Status.RUNNING
-        directory.dispatched_at = timezone.now() - timezone.timedelta(hours=3)
+        directory.dispatched_at = timezone.now() - timezone.timedelta(hours=1)
         directory.save(update_fields=["status", "dispatched_at", "updated_at"])
         node_task = NodeTask.objects.create(
             organization=self.org,
@@ -1177,6 +1180,155 @@ class ProtectionBackupTaskApiTests(TestCase):
             ).count(),
             1,
         )
+
+    @patch("apps.protection.services.backup_orchestrator.cancel_agent_task")
+    def test_substantive_stall_requests_cancel_once_at_final_deadline(self, mock_cancel):
+        task, snapshot = self._create_backup_task_and_snapshot(
+            idempotency_key="test-stall-final-deadline",
+        )
+        directory_config = self.config.directories.first()
+        directory = BackupSourceSnapshotDirectory.objects.create(
+            source_snapshot=snapshot,
+            organization_id=self.org.id,
+            backup_config_id=self.config.id,
+            backup_config_dir_id=directory_config.id,
+            source_path=directory_config.path,
+            display_name=directory_config.display_name,
+            repository_id=self.repository.id,
+            status=BackupSourceSnapshotDirectory.Status.RUNNING,
+            dispatched_at=timezone.now() - timezone.timedelta(hours=3),
+        )
+        node_task = NodeTask.objects.create(
+            organization=self.org,
+            node=self.agent,
+            kind="backup.snapshot.create",
+            correlation_type=protection_conf.PROTECTION_BACKUP_CORRELATION_TYPE,
+            correlation_id=str(task.task_uuid),
+            status=NodeTask.Status.RUNNING,
+            watchdog_deadline_at=timezone.now()
+            + timezone.timedelta(
+                seconds=protection_conf.PROTECTION_BACKUP_ACTIVITY_LEASE_SECONDS
+            ),
+        )
+
+        for _ in range(2):
+            self.assertFalse(
+                _handle_directory_stall(
+                    task=task,
+                    directory_row=directory,
+                    node_task=node_task,
+                    node_online=True,
+                )
+            )
+
+        directory.refresh_from_db()
+        self.assertIsNotNone(directory.cancel_requested_at)
+        mock_cancel.assert_called_once_with(
+            task_id=node_task.id,
+            reason="kopia progress stall",
+        )
+
+    @patch("apps.protection.services.backup_orchestrator.cancel_agent_task")
+    def test_substantive_stall_fails_after_cancel_grace(self, mock_cancel):
+        task, snapshot = self._create_backup_task_and_snapshot(
+            idempotency_key="test-stall-cancel-grace",
+        )
+        directory_config = self.config.directories.first()
+        directory = BackupSourceSnapshotDirectory.objects.create(
+            source_snapshot=snapshot,
+            organization_id=self.org.id,
+            backup_config_id=self.config.id,
+            backup_config_dir_id=directory_config.id,
+            source_path=directory_config.path,
+            display_name=directory_config.display_name,
+            repository_id=self.repository.id,
+            status=BackupSourceSnapshotDirectory.Status.RUNNING,
+            dispatched_at=timezone.now() - timezone.timedelta(hours=3),
+            cancel_requested_at=timezone.now()
+            - timezone.timedelta(
+                seconds=protection_conf.PROTECTION_BACKUP_CANCEL_GRACE_SECONDS + 1
+            ),
+        )
+        node_task = NodeTask.objects.create(
+            organization=self.org,
+            node=self.agent,
+            kind="backup.snapshot.create",
+            correlation_type=protection_conf.PROTECTION_BACKUP_CORRELATION_TYPE,
+            correlation_id=str(task.task_uuid),
+            status=NodeTask.Status.RUNNING,
+            watchdog_deadline_at=timezone.now()
+            + timezone.timedelta(
+                seconds=protection_conf.PROTECTION_BACKUP_ACTIVITY_LEASE_SECONDS
+            ),
+        )
+
+        self.assertTrue(
+            _handle_directory_stall(
+                task=task,
+                directory_row=directory,
+                node_task=node_task,
+                node_online=True,
+            )
+        )
+
+        directory.refresh_from_db()
+        self.assertEqual(directory.status, BackupSourceSnapshotDirectory.Status.FAILED)
+        self.assertEqual(directory.error_code, "KOPIA_PROGRESS_STALL")
+        mock_cancel.assert_not_called()
+
+    def test_system_stall_cancel_is_not_reported_as_user_cancel(self):
+        node_task = NodeTask.objects.create(
+            organization=self.org,
+            node=self.agent,
+            kind="backup.snapshot.create",
+            status=NodeTask.Status.CANCELED,
+            last_error="kopia progress stall",
+            watchdog_deadline_at=timezone.now(),
+        )
+
+        error_code, error_message = _node_task_error_code(node_task)
+
+        self.assertEqual(error_code, "KOPIA_PROGRESS_STALL")
+        self.assertEqual(error_message, "kopia progress stall")
+
+    def test_system_stall_cancel_projects_directory_as_failed(self):
+        task, snapshot = self._create_backup_task_and_snapshot(
+            idempotency_key="test-system-stall-cancel-projection",
+        )
+        directory_config = self.config.directories.first()
+        node_task = NodeTask.objects.create(
+            organization=self.org,
+            node=self.agent,
+            kind="backup.snapshot.create",
+            status=NodeTask.Status.CANCELED,
+            last_error="kopia progress stall",
+            watchdog_deadline_at=timezone.now(),
+        )
+        directory = BackupSourceSnapshotDirectory.objects.create(
+            source_snapshot=snapshot,
+            organization_id=self.org.id,
+            backup_config_id=self.config.id,
+            backup_config_dir_id=directory_config.id,
+            source_path=directory_config.path,
+            display_name=directory_config.display_name,
+            repository_id=self.repository.id,
+            status=BackupSourceSnapshotDirectory.Status.RUNNING,
+            node_task_id=node_task.id,
+        )
+
+        _observe_running_directory(
+            task=task,
+            source_snapshot=snapshot,
+            directory_row=directory,
+            node_task=node_task,
+            directory_index=1,
+            total_dirs=1,
+            node_online=True,
+        )
+
+        directory.refresh_from_db()
+        self.assertEqual(directory.status, BackupSourceSnapshotDirectory.Status.FAILED)
+        self.assertEqual(directory.error_code, "KOPIA_PROGRESS_STALL")
 
     def test_file_count_progress_refreshes_substantive_activity_only_on_change(self):
         from apps.protection.services.progress.backup_runtime import (
@@ -1365,6 +1517,20 @@ class ProtectionBackupTaskApiTests(TestCase):
         )
 
         result = self._run_orchestrated_backup(task=task, snapshot=snapshot)
+        waiting_directory = BackupSourceSnapshotDirectory.objects.get(
+            source_snapshot=snapshot
+        )
+        self.assertEqual(result["status"], Task.Status.RUNNING)
+        self.assertEqual(
+            waiting_directory.error_code,
+            "AGENT_RESTART_CAPABILITY_PENDING",
+        )
+
+        self.agent.metadata = {
+            "inventory": {"capabilities": ["backup_operation_reconcile_v1"]}
+        }
+        self.agent.save(update_fields=["metadata", "updated_at"])
+        result = self._run_orchestrated_backup(task=task, snapshot=snapshot)
         if result["status"] == Task.Status.RUNNING:
             result = self._run_orchestrated_backup(task=task, snapshot=snapshot)
 
@@ -1388,6 +1554,121 @@ class ProtectionBackupTaskApiTests(TestCase):
         self.assertTrue(
             all(row.correlation_id == str(task.task_uuid) for row in attempts)
         )
+        expected_operation_id = f"{task.task_uuid}-{directory.backup_config_dir_id}"
+        self.assertEqual(
+            [row.payload.get("operation_id") for row in attempts],
+            [expected_operation_id, expected_operation_id],
+        )
+        self.assertEqual(
+            [row.payload.get("operation_attempt") for row in attempts],
+            [1, 2],
+        )
+
+    @patch(
+        "apps.protection.services.backup_orchestrator.effective_agent_node_status",
+        return_value=Node.Availability.ONLINE,
+    )
+    @patch("apps.protection.services.backup_orchestrator.run_agent_task_async")
+    def test_agent_restart_retry_requires_operation_reconcile_capability(
+        self, mock_run_agent_task_async, _online
+    ):
+        task, snapshot = self._create_backup_task_and_snapshot(
+            idempotency_key="test-agent-restart-upgrade-required",
+        )
+        mock_run_agent_task_async.side_effect = self._mock_run_agent_task_async(
+            [
+                {
+                    "status": NodeTask.Status.FAILED,
+                    "result": {},
+                    "last_error": "agent restarted before task completed",
+                }
+            ]
+        )
+
+        result = self._run_orchestrated_backup(task=task, snapshot=snapshot)
+        directory = BackupSourceSnapshotDirectory.objects.get(source_snapshot=snapshot)
+        attempts = NodeTask.objects.filter(
+            correlation_type=protection_conf.PROTECTION_BACKUP_CORRELATION_TYPE,
+            correlation_id=str(task.task_uuid),
+            kind="backup.run",
+        )
+        self.assertEqual(result["status"], Task.Status.RUNNING)
+        self.assertEqual(
+            directory.error_code,
+            "AGENT_RESTART_CAPABILITY_PENDING",
+        )
+        failed_attempt = attempts.get()
+        NodeTask.objects.filter(pk=failed_attempt.pk).update(
+            updated_at=timezone.now()
+            - timezone.timedelta(
+                seconds=(
+                    protection_conf.PROTECTION_BACKUP_CAPABILITY_SYNC_GRACE_SECONDS
+                    + 1
+                )
+            )
+        )
+
+        result = self._run_orchestrated_backup(task=task, snapshot=snapshot)
+        directory.refresh_from_db()
+        self.assertEqual(result["status"], Task.Status.FAILED)
+        self.assertEqual(directory.status, BackupSourceSnapshotDirectory.Status.FAILED)
+        self.assertEqual(directory.error_code, "AGENT_UPGRADE_REQUIRED")
+        self.assertIn("Upgrade the Agent", directory.error_message)
+        self.assertEqual(attempts.count(), 1)
+
+    def test_current_attempt_fence_ignores_previous_attempt_late_success(self):
+        task, snapshot = self._create_backup_task_and_snapshot(
+            idempotency_key="test-late-success-attempt-fence",
+        )
+        directory_config = self.config.directories.first()
+        previous = NodeTask.objects.create(
+            organization=self.org,
+            node=self.agent,
+            kind="backup.run",
+            correlation_type=protection_conf.PROTECTION_BACKUP_CORRELATION_TYPE,
+            correlation_id=str(task.task_uuid),
+            payload={"backup_config_dir_id": directory_config.id, "operation_attempt": 1},
+            status=NodeTask.Status.SUCCESS,
+            result={"kopia_snapshot_id": "late-previous-snapshot"},
+            watchdog_deadline_at=timezone.now(),
+        )
+        current = NodeTask.objects.create(
+            organization=self.org,
+            node=self.agent,
+            kind="backup.run",
+            correlation_type=protection_conf.PROTECTION_BACKUP_CORRELATION_TYPE,
+            correlation_id=str(task.task_uuid),
+            payload={"backup_config_dir_id": directory_config.id, "operation_attempt": 2},
+            status=NodeTask.Status.RUNNING,
+            watchdog_deadline_at=timezone.now()
+            + timezone.timedelta(
+                seconds=protection_conf.PROTECTION_BACKUP_ACTIVITY_LEASE_SECONDS
+            ),
+        )
+        directory = BackupSourceSnapshotDirectory.objects.create(
+            source_snapshot=snapshot,
+            organization_id=self.org.id,
+            backup_config_id=self.config.id,
+            backup_config_dir_id=directory_config.id,
+            source_path=directory_config.path,
+            display_name=directory_config.display_name,
+            repository_id=self.repository.id,
+            status=BackupSourceSnapshotDirectory.Status.RUNNING,
+            node_task_id=current.id,
+            retry_count=1,
+        )
+
+        selected = _get_node_task_for_directory(
+            directory=directory,
+            organization_id=self.org.id,
+            task_uuid=str(task.task_uuid),
+            node_id=self.agent.id,
+        )
+
+        self.assertEqual(selected.id, current.id)
+        self.assertNotEqual(selected.id, previous.id)
+        directory.refresh_from_db()
+        self.assertIsNone(directory.kopia_snapshot_id)
 
     @patch(
         "apps.protection.services.backup_orchestrator.effective_agent_node_status",
@@ -1669,6 +1950,29 @@ class ProtectionBackupTaskApiTests(TestCase):
         self._run_orchestrated_backup(task=task, snapshot=snapshot)
         self._run_orchestrated_backup(task=task, snapshot=snapshot)
 
+        repair_pending = BackupSourceSnapshotDirectory.objects.get(
+            source_snapshot=snapshot,
+            backup_config_dir_id=self.config.directories.order_by("sort_order")
+            .first()
+            .id,
+        )
+        old_runtime_at = timezone.now() - timezone.timedelta(hours=3)
+        repair_pending.last_substantive_progress_at = old_runtime_at
+        repair_pending.last_progress_snapshot = {"percent": 60}
+        repair_pending.last_progress_sample = {"percent": 60}
+        repair_pending.cancel_requested_at = old_runtime_at
+        repair_pending.stall_warned_at = old_runtime_at
+        repair_pending.save(
+            update_fields=[
+                "last_substantive_progress_at",
+                "last_progress_snapshot",
+                "last_progress_sample",
+                "cancel_requested_at",
+                "stall_warned_at",
+                "updated_at",
+            ]
+        )
+
         sibling = NodeTask.objects.get(
             kind="backup.snapshot.create",
             payload__backup_config_dir_id=second_config_directory.id,
@@ -1693,6 +1997,11 @@ class ProtectionBackupTaskApiTests(TestCase):
         self.assertEqual(snapshot.status, BackupSourceSnapshot.Status.AVAILABLE)
         self.assertEqual(repaired.kopia_snapshot_id, "repaired-snapshot")
         self.assertEqual(repaired.retry_count, 1)
+        self.assertIsNone(repaired.last_substantive_progress_at)
+        self.assertNotEqual(repaired.last_progress_snapshot, {"percent": 60})
+        self.assertNotEqual(repaired.last_progress_sample, {"percent": 60})
+        self.assertIsNone(repaired.cancel_requested_at)
+        self.assertIsNone(repaired.stall_warned_at)
         self.assertEqual(
             [call.kwargs["kind"] for call in mock_run_agent_task_async.call_args_list],
             [


### PR DESCRIPTION
## Summary

Improves resilience of backup tasks when a managed agent restarts mid-task (or the connection stalls). Backup operations are now tagged with a dedup key on the snapshot side, so the orchestrator can reconcile and deduplicate snapshots idempotently after recovery instead of failing or double-writing.

## Changes

- **Agent** (`src/agent/internal/engine`):
  - Tag managed backup operations with an operation key used for post-restart reconciliation
  - Retry in a controlled way on `AGENT_RESTARTED` instead of marking the task as irrecoverable
  - Extra tests for dedup, restart recovery, and repository session-lock edge cases
- **Backend** (`src/backend/apps/protection`):
  - Persist and reuse operation tags across retries in `backup_orchestrator.py` / `backup_task.py`
  - Refined error codes so task state reporting is clearer after agent recovery
  - Configuration flag added in `conf.py`
  - Coverage in `test_backup_task_api.py`

## Test Plan

- `go test ./internal/engine/...` (agent) — passed locally
- Backend protection task API tests included and updated

## Related Issue

Closes #118