### PR TITLE
feat(install): add regional online source fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,30 @@ logical PostgreSQL dumps, Redis persistence, configuration, and deployment
 metadata. It retains the latest three valid sets. A backup can also be created
 manually with `sudo ./install.sh backup`.
 
+### Community online installation
+
+For a supported Ubuntu 20.04/22.04/24.04 amd64 host with Docker Engine and
+Compose V2 already installed, install a pinned Community release with one
+command. Global users should use GitHub and Docker Hub:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/oneprolabs/hyperfilelens/vX.Y.Z/deploy/online/install.sh \
+  | sudo bash -s -- vX.Y.Z --region global --download-source github --yes
+```
+
+Users in mainland China can use the public Gitee source and Alibaba Cloud
+image mirror:
+
+```bash
+curl -fsSL https://gitee.com/oneprolabs/hyperfilelens/raw/vX.Y.Z/deploy/online/install.sh \
+  | sudo bash -s -- vX.Y.Z --region cn --download-source gitee --yes
+```
+
+With `--download-source auto`, the installer prefers Gitee in China and
+GitHub elsewhere, then falls back to the other public source. `--yes` enables
+non-interactive execution. The online installer is Community-only; Enterprise
+continues to use the existing Enterprise delivery workflow.
+
 ## Quick Start
 
 Start the complete hot-reload development environment from the repository

--- a/deploy/installer/install.sh
+++ b/deploy/installer/install.sh
@@ -77,6 +77,7 @@ Options:
   install:
     --with-sourcelens       Install bundled SourceLens (default when sourcelens/ is present)
     --hfl-only              Skip bundled SourceLens even when sourcelens/ is present
+    --yes                   Non-interactive compatibility flag (install has no confirmation prompt)
     --direct-host HOST      Direct listener host or IP used for local access URLs
     --public-url URL        Optional canonical browser origin; invalid values only warn
     --admin-public-url URL  Optional Admin Console browser origin; invalid values only warn
@@ -4488,6 +4489,7 @@ cmd_install() {
 		case "$1" in
 		--with-sourcelens) sourcelens_mode=1 ;;
 		--hfl-only) sourcelens_mode=0 ;;
+		--yes) ;; # Fresh installation has no confirmation prompt; accept automation parity with upgrade.
 		--direct-host) [[ $# -ge 2 && -n "${2:-}" ]] || die "--direct-host requires a value" 2; PUBLIC_HOST="$2"; shift ;;
 		--public-url) [[ $# -ge 2 ]] || die "--public-url requires a value" 2; PUBLIC_URL="$2"; shift ;;
 		--admin-public-url) [[ $# -ge 2 ]] || die "--admin-public-url requires a value" 2; ADMIN_PUBLIC_URL="$2"; shift ;;

--- a/deploy/online/install.sh
+++ b/deploy/online/install.sh
@@ -5,15 +5,22 @@ set -euo pipefail
 GLOBAL_REGISTRY_PREFIX="${HFL_GLOBAL_REGISTRY_PREFIX:-docker.io/oneprolabs}"
 CN_REGISTRY_PREFIX="${HFL_CN_REGISTRY_PREFIX:-registry.cn-beijing.aliyuncs.com/oneprolabs}"
 REGION="${HFL_REGISTRY_REGION:-auto}"
+DOWNLOAD_SOURCE="${HFL_DOWNLOAD_SOURCE:-auto}"
+ASSUME_YES=0
 TAG=""
 SESSION_DIR=""
 
 usage() {
 	cat <<'USAGE'
-Usage: install.sh vX.Y.Z [--region auto|cn|global]
+Usage: install.sh vX.Y.Z [--region auto|cn|global] [--download-source auto|github|gitee] [--yes]
 
 Installs HyperFileLens Community on a new host. Running the command again with
 a newer tag performs the normal managed backup and blue/green upgrade.
+
+--region selects the preferred public image registry. --download-source selects
+the GitHub or Gitee source archive; auto uses Gitee first in China and GitHub
+first elsewhere, with the other source as a fallback. --yes enables
+non-interactive installation and upgrade.
 USAGE
 }
 
@@ -76,6 +83,15 @@ while (($#)); do
 		REGION=$2
 		shift 2
 		;;
+	--download-source)
+		[[ $# -ge 2 ]] || fail "--download-source requires auto, github, or gitee"
+		DOWNLOAD_SOURCE=$2
+		shift 2
+		;;
+	--yes)
+		ASSUME_YES=1
+		shift
+		;;
 	-h | --help)
 		usage
 		exit 0
@@ -98,6 +114,10 @@ auto) REGION="$(detect_region)" ;;
 cn | global) ;;
 *) fail "--region must be auto, cn, or global" ;;
 esac
+case "${DOWNLOAD_SOURCE}" in
+auto | github | gitee) ;;
+*) fail "--download-source must be auto, github, or gitee" ;;
+esac
 
 ensure_prerequisites
 export HFL_GLOBAL_REGISTRY_PREFIX="${GLOBAL_REGISTRY_PREFIX}"
@@ -113,15 +133,53 @@ archive="${SESSION_DIR}/source.tar.gz"
 source_dir="${SESSION_DIR}/source"
 candidate="${SESSION_DIR}/hyperfilelens-${TAG#v}-online"
 
-printf '[....] Downloading HyperFileLens %s installation contract\n' "${TAG}"
-curl --fail --show-error --location --retry 3 --retry-all-errors \
-	"https://codeload.github.com/oneprolabs/hyperfilelens/tar.gz/refs/tags/${TAG}" \
-	-o "${archive}"
-mkdir -p "${source_dir}"
-tar -xzf "${archive}" -C "${source_dir}" --strip-components=1
-[[ -x "${source_dir}/deploy/online/install.sh" \
-	&& -f "${source_dir}/deploy/online/prepare.py" ]] \
-	|| fail "${TAG} does not provide the online installation contract"
+download_source_archive() {
+	local source url
+	local -a sources=()
+	case "${DOWNLOAD_SOURCE}" in
+	auto)
+		if [[ "${REGION}" == cn ]]; then
+			sources=(gitee github)
+		else
+			sources=(github gitee)
+		fi
+		;;
+	github | gitee) sources=("${DOWNLOAD_SOURCE}") ;;
+	esac
+
+	for source in "${sources[@]}"; do
+		case "${source}" in
+		github)
+			url="https://codeload.github.com/oneprolabs/hyperfilelens/tar.gz/refs/tags/${TAG}"
+			;;
+		gitee)
+			url="https://gitee.com/oneprolabs/hyperfilelens/repository/archive/${TAG}.tar.gz"
+			;;
+		esac
+		printf '[....] Downloading %s installation contract from %s\n' "${TAG}" "${source}"
+		rm -rf -- "${source_dir}"
+		rm -f -- "${archive}"
+		if ! curl --fail --show-error --location --retry 3 --retry-all-errors \
+			--connect-timeout 15 --max-time 300 "${url}" -o "${archive}"; then
+			printf '[WARN] %s installation contract download failed; trying the next source\n' \
+				"${source}" >&2
+			continue
+		fi
+		mkdir -p "${source_dir}"
+		if ! tar -xzf "${archive}" -C "${source_dir}" --strip-components=1 \
+			|| [[ ! -x "${source_dir}/deploy/online/install.sh" ]] \
+			|| [[ ! -f "${source_dir}/deploy/online/prepare.py" ]]; then
+			printf '[WARN] %s archive does not provide the online installation contract; trying the next source\n' \
+				"${source}" >&2
+			continue
+		fi
+		printf '[ OK ] Downloaded installation contract from %s\n' "${source}"
+		return 0
+	done
+	fail "could not download ${TAG} installation contract from the selected source(s)"
+}
+
+download_source_archive
 
 python3 "${source_dir}/deploy/online/prepare.py" \
 	--source-root "${source_dir}" \
@@ -152,6 +210,7 @@ PY
 		upgrade --from "${candidate}" --yes --with-sourcelens
 else
 	printf '[....] Installing HyperFileLens Community %s\n' "${TAG}"
-	HFL_REGISTRY_REGION="${REGION}" bash "${candidate}/install.sh" \
-		install --with-sourcelens
+	install_args=(install --with-sourcelens)
+	((ASSUME_YES == 1)) && install_args+=(--yes)
+	HFL_REGISTRY_REGION="${REGION}" bash "${candidate}/install.sh" "${install_args[@]}"
 fi

--- a/tools/quality/test-online-community-install.sh
+++ b/tools/quality/test-online-community-install.sh
@@ -11,6 +11,18 @@ export PYTHONDONTWRITEBYTECODE=1
 bash -n "${online}/install.sh"
 PYTHONPYCACHEPREFIX="${tmp}/pycache" python3 -m py_compile "${online}/prepare.py"
 
+help_output="$("${online}/install.sh" --help)"
+grep -Fq -- '--download-source auto|github|gitee' <<<"${help_output}"
+grep -Fq -- '--yes' <<<"${help_output}"
+grep -Fq 'https://codeload.github.com/oneprolabs/hyperfilelens/tar.gz/refs/tags/${TAG}' \
+	"${online}/install.sh"
+grep -Fq 'https://gitee.com/oneprolabs/hyperfilelens/repository/archive/${TAG}.tar.gz' \
+	"${online}/install.sh"
+grep -Fq 'sources=(gitee github)' "${online}/install.sh"
+grep -Fq 'sources=(github gitee)' "${online}/install.sh"
+grep -Fq -- '--yes                   Non-interactive compatibility flag' \
+	"${ROOT}/deploy/installer/install.sh"
+
 grep -Fq 'name: HFL - Publish Images & Upgrade SaaS' "${workflow}"
 grep -Fq 'Publish · ${{ github.event_name == '\''push'\'' && github.ref_name || inputs.tag }} · Images · Enterprise SaaS Upgrade' "${workflow}"
 grep -Fq 'name: Community · Backend' "${workflow}"

--- a/website/zh/docs/getting-started/install.md
+++ b/website/zh/docs/getting-started/install.md
@@ -9,14 +9,25 @@ HyperFileLens Community 支持在线安装和完整离线 Release 包安装。�
 
 ## 在线安装
 
-在线安装适合可以访问 GitHub 和公开镜像仓库的 Ubuntu amd64 主机。将示例中的 `vX.Y.Z` 替换为准备安装的正式 Release 标签：
+在线安装适合已安装 Docker Engine 和 Compose V2 的 Ubuntu 20.04、22.04 或 24.04 amd64 主机。将示例中的 `vX.Y.Z` 替换为准备安装的正式 Release 标签。
+
+海外环境使用 GitHub 和 Docker Hub：
 
 ```bash
-curl -fLO https://raw.githubusercontent.com/oneprolabs/hyperfilelens/vX.Y.Z/deploy/online/install.sh
-sudo bash install.sh vX.Y.Z --region auto
+curl -fsSL https://raw.githubusercontent.com/oneprolabs/hyperfilelens/vX.Y.Z/deploy/online/install.sh \
+  | sudo bash -s -- vX.Y.Z --region global --download-source github --yes
 ```
 
-安装程序会检查系统、Docker 和 Compose，准备与该标签一致的安装内容，并将运行目录写入 `/opt/hyperfilelens`。中国大陆网络环境可显式使用 `--region cn`，其他地区可使用 `--region global`。
+中国大陆环境使用 Gitee 和阿里云镜像：
+
+```bash
+curl -fsSL https://gitee.com/oneprolabs/hyperfilelens/raw/vX.Y.Z/deploy/online/install.sh \
+  | sudo bash -s -- vX.Y.Z --region cn --download-source gitee --yes
+```
+
+`--region` 选择 Docker 镜像区域；`--download-source` 选择安装文件来源。使用 `auto` 时，中国区优先 Gitee，其他地区优先 GitHub，失败后自动尝试另一个公开源。Gitee 仓库和镜像均为公开资源，不需要账号或 Token。`--yes` 表示非交互执行，适合脚本和自动升级。
+
+安装程序会检查系统、Docker 和 Compose，准备与该标签一致的安装内容，并将运行目录写入 `/opt/hyperfilelens`。它只安装或升级 Community，不会把 Enterprise 安装转换为 Community。
 
 ## 离线安装
 
@@ -61,4 +72,3 @@ sudo /opt/hyperfilelens/install.sh lang-pack list
 ::: warning 不要跳过
 不要把安装终端输出、`.env`、访问令牌或客户环境地址复制到公开 Issue 和截图中。提交问题时仅提供已脱敏的错误编号、版本和必要日志片段。
 :::
-


### PR DESCRIPTION
## Summary
- add GitHub/Gitee source selection and regional fallback to the Community online installer
- add explicit `--yes` non-interactive compatibility for online installation and upgrades
- document one-command global and China installation paths
- extend online installation contract coverage

## Validation
- `bash -n deploy/online/install.sh deploy/installer/install.sh tools/quality/test-online-community-install.sh`
- `bash tools/quality/test-online-community-install.sh`
- `bash tools/quality/check-release-contracts.sh`
- `bash tools/quality/test-saas-registry-delivery.sh`
- `bash tools/quality/test-ci-release-assembly.sh`
- `git diff --check`

Related to #709.