### PR TITLE
Fix Element Plus popper arrows

### DIFF
--- a/src/frontend/src/components/LanguageSwitcher.vue
+++ b/src/frontend/src/components/LanguageSwitcher.vue
@@ -268,7 +268,6 @@ function handleVisibleChange(visible: boolean) {
 .hfl-language-switcher-popper.el-popper {
   min-width: 180px;
   padding: 6px !important;
-  overflow: hidden;
   background: #272633 !important;
   border: 1px solid rgba(255, 255, 255, 0.14) !important;
   border-radius: 10px !important;

--- a/src/frontend/src/styles/element-plus-date-picker.css
+++ b/src/frontend/src/styles/element-plus-date-picker.css
@@ -4,7 +4,6 @@
 .el-picker__popper.el-popper {
   border: 1px solid var(--color-border, #d9d9d9) !important;
   border-radius: var(--radius-lg, 14px) !important;
-  overflow: hidden;
   background: var(--el-popper-bg, var(--el-bg-color-overlay, #fff)) !important;
   box-shadow:
     0px 5px 5px -3px rgba(0, 0, 0, .2),

--- a/src/frontend/src/styles/element-plus-popper.css
+++ b/src/frontend/src/styles/element-plus-popper.css
@@ -21,19 +21,28 @@
   border-radius: 10px !important;
 }
 
-.el-popper:not(.is-pure),
-.el-select__popper.el-popper,
-.el-dropdown__popper.el-popper,
-.el-picker__popper.el-popper,
-.el-popover.el-popper,
-.el-tooltip__popper.el-popper,
-.el-cascader__dropdown.el-popper,
-.el-table-filter,
-.kb-filter-popover.el-popper,
-.create-recovery-path-popover.el-popper,
-.dp-source-task-select-popper.el-popper,
-.nav-dropdown-popover.el-popper {
-  overflow: hidden;
+/* Element Plus positions .el-popper__arrow just outside the popper boundary.
+   Keep the root visible so the arrow is neither clipped nor visually offset. */
+.el-popper {
+  overflow: visible;
+}
+
+/* Keep Element Plus' bordered arrow geometry, but clip the rotated square to
+   the half that belongs outside the popper. Negative insets preserve its tip. */
+.el-popper[data-popper-placement^='bottom'] > .el-popper__arrow {
+  clip-path: inset(-3px 0 5px 0);
+}
+
+.el-popper[data-popper-placement^='top'] > .el-popper__arrow {
+  clip-path: inset(5px 0 -3px 0);
+}
+
+.el-popper[data-popper-placement^='left'] > .el-popper__arrow {
+  clip-path: inset(0 -3px 0 5px);
+}
+
+.el-popper[data-popper-placement^='right'] > .el-popper__arrow {
+  clip-path: inset(0 5px 0 -3px);
 }
 
 .el-select-dropdown,
@@ -45,6 +54,7 @@
 .el-time-panel,
 .el-table-filter__content {
   border-radius: inherit !important;
+  overflow: hidden;
 }
 
 .el-dropdown__popper.el-popper .el-dropdown-menu,

--- a/src/frontend/src/styles/element-plus-table.css
+++ b/src/frontend/src/styles/element-plus-table.css
@@ -126,7 +126,6 @@
 .el-popover.el-popper,
 .el-tooltip__popper.el-popper {
   border-radius: 10px !important;
-  overflow: hidden;
 }
 
 .el-select-dropdown,
@@ -800,7 +799,6 @@
 .el-popper:not(.hfl-pagination-size-popper) {
   min-width: 140px !important;
   border-radius: 10px !important;
-  overflow: hidden;
   box-shadow: 0px 5px 5px -3px rgba(0, 0, 0, .2), 0px 3px 14px 2px rgba(0, 0, 0, .12), 0px 8px 10px 1px rgba(0, 0, 0, .14) !important;
 }
 
@@ -809,7 +807,6 @@
   min-width: unset !important;
   font-size: 12px;
   border-radius: var(--el-border-radius-base, 8px) !important;
-  overflow: hidden;
   box-shadow: 0px 5px 5px -3px rgba(0, 0, 0, .2), 0px 3px 14px 2px rgba(0, 0, 0, .12), 0px 8px 10px 1px rgba(0, 0, 0, .14) !important;
 }
 

--- a/src/frontend/src/styles/elementPlusPopperArrow.test.ts
+++ b/src/frontend/src/styles/elementPlusPopperArrow.test.ts
@@ -1,0 +1,47 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const source = (path: string) => readFileSync(resolve(process.cwd(), path), 'utf8')
+const sharedStyles = source('src/styles/element-plus-popper.css')
+const tableStyles = source('src/styles/element-plus-table.css')
+const datePickerStyles = source('src/styles/element-plus-date-picker.css')
+const navigationStyles = source('src/styles/nav-dropdown-panel.css')
+const languageSwitcher = source('src/components/LanguageSwitcher.vue')
+
+describe('Element Plus popper arrows', () => {
+  it('does not clip arrows at the popper root', () => {
+    expect(sharedStyles).toMatch(/\.el-popper\s*{[^}]*overflow:\s*visible;/s)
+    expect(tableStyles).not.toMatch(
+      /\.el-popper:not\(\.hfl-pagination-size-popper\)\s*{[^}]*overflow:\s*hidden;/s,
+    )
+    expect(datePickerStyles).not.toMatch(
+      /\.el-picker__popper\.el-popper\s*{[^}]*overflow:\s*hidden;/s,
+    )
+    expect(navigationStyles).not.toMatch(
+      /\.nav-dropdown-popover\.el-popper\s*{[^}]*overflow:\s*hidden;/s,
+    )
+    expect(languageSwitcher).not.toMatch(
+      /\.hfl-language-switcher-popper\.el-popper\s*{[^}]*overflow:\s*hidden;/s,
+    )
+  })
+
+  it('keeps clipping on inner menu and panel content', () => {
+    expect(sharedStyles).toMatch(
+      /\.el-dropdown-menu,[\s\S]*?\.el-table-filter__content\s*{[^}]*overflow:\s*hidden;/,
+    )
+    expect(navigationStyles).toMatch(/\.nav-dropdown-panel\s*{[^}]*overflow:\s*hidden;/s)
+  })
+
+  it('clips the bordered arrow to its exposed triangular half', () => {
+    expect(sharedStyles).toMatch(
+      /\[data-popper-placement\^='bottom'\][\s\S]*?clip-path:\s*inset\(-3px 0 5px 0\)/,
+    )
+    expect(sharedStyles).toMatch(
+      /\[data-popper-placement\^='top'\][\s\S]*?clip-path:\s*inset\(5px 0 -3px 0\)/,
+    )
+    expect(languageSwitcher).toMatch(
+      /\.hfl-language-switcher-popper\.el-popper \.el-popper__arrow::before\s*{[^}]*background:\s*#272633\s*!important;/s,
+    )
+  })
+})

--- a/src/frontend/src/styles/nav-dropdown-panel.css
+++ b/src/frontend/src/styles/nav-dropdown-panel.css
@@ -3,7 +3,6 @@
 .nav-dropdown-popover.el-popper {
   max-width: calc(100vw - 24px);
   padding: 0 !important;
-  overflow: hidden;
   border: 1px solid var(--color-border-light, #e4e7ed) !important;
   border-radius: 10px !important;
   background: #fff !important;


### PR DESCRIPTION
## Summary

- Keep Element Plus Popper roots visible so `.el-popper__arrow` can extend beyond the overlay boundary.
- Clip only the exposed half of the native bordered arrow for all Popper placements.
- Preserve rounded clipping on inner menus and panels, including the language switcher, date pickers, and dropdown content.
- Add regression coverage for shared Popper styles and theme-specific arrow styling.

## Testing

- `cd src/frontend && npm test -- elementPlusPopperArrow.test.ts`
- `cd src/frontend && npm run build`

Closes #723
