### PR TITLE
feat(website): feature Community online installation on homepage

### DIFF
--- a/website/.vitepress/theme/HomeLanding.vue
+++ b/website/.vitepress/theme/HomeLanding.vue
@@ -33,6 +33,8 @@ const loginUrl = computed(() => `${appOrigin.value || '#'}${appOrigin.value ? '/
 
 const githubUrl = 'https://github.com/HyperBDR/hyperfilelens'
 const sourceLensUrl = 'https://github.com/HyperBDR/sourcelens'
+const communityInstallGuideUrl = 'https://github.com/oneprolabs/hyperfilelens#community-online-installation'
+const communityVersion = 'v0.2.8'
 
 function openApp(event: MouseEvent, placement: WebsiteOpenAppPlacement) {
   const target = loginUrl.value
@@ -234,12 +236,12 @@ function openApp(event: MouseEvent, placement: WebsiteOpenAppPlacement) {
       <section id="open-source" class="open-source-section" aria-labelledby="open-source-title">
         <div class="open-source-grid">
           <div class="open-source-copy">
-            <p class="section-kicker dark-kicker">Open Source</p>
-            <h2 id="open-source-title">Private deployment. Full control.</h2>
-            <p>HyperFileLens and the AI engine behind it are both fully open source. Review the architecture, follow development, or contribute directly on GitHub.</p>
+            <p class="section-kicker dark-kicker">Community</p>
+            <h2 id="open-source-title">Open source. One-command install.</h2>
+            <p>Run the Community edition on Ubuntu with Docker in one command. Global users use GitHub and Docker Hub; users in mainland China use Gitee and Alibaba Cloud.</p>
             <div class="open-source-callout">
               <svg aria-hidden="true"><use href="#icon-check" /></svg>
-              <p>No vendor lock-in — bring your own S3-compatible storage and your own AI model or API key, self-hosted or hosted. Switch anytime.</p>
+              <p>Community is free and open source — bring your own S3-compatible storage and AI model or API key, then move to Enterprise when you need commercial governance.</p>
             </div>
             <div class="open-source-actions">
               <a class="button button-light" :href="githubUrl"><svg aria-hidden="true"><use href="#icon-github" /></svg>View on GitHub</a>
@@ -247,19 +249,18 @@ function openApp(event: MouseEvent, placement: WebsiteOpenAppPlacement) {
             </div>
             <div class="open-source-links">
               <a class="source-link" :href="sourceLensUrl"><svg aria-hidden="true"><use href="#icon-github" /></svg>AI engine repo</a>
-              <a class="source-link" :href="`${githubUrl}/releases`">Browse releases <svg aria-hidden="true"><use href="#icon-arrow" /></svg></a>
+              <a class="source-link" :href="communityInstallGuideUrl">Installation guide <svg aria-hidden="true"><use href="#icon-arrow" /></svg></a>
             </div>
             <p class="beta-note">HyperFileLens is currently in public beta.</p>
           </div>
-          <div class="terminal-card" aria-label="Example HyperFileLens deployment command">
-            <div class="terminal-bar"><span><i></i><i></i><i></i></span><b>deploy · bash</b></div>
-            <pre><code><span class="terminal-comment"># Complete offline release bundle</span>
-<span class="terminal-prompt">$</span> tar -xzf hyperfilelens-release.tar.gz
-<span class="terminal-prompt">$</span> cd hyperfilelens
-<span class="terminal-prompt">$</span> sudo ./install.sh install
+          <div class="terminal-card" aria-label="Example Community online installation command">
+            <div class="terminal-bar"><span><i></i><i></i><i></i></span><b>install · bash</b></div>
+            <pre><code><span class="terminal-comment"># Community online install · {{ communityVersion }}</span>
+<span class="terminal-prompt">$</span> curl -fsSL https://raw.githubusercontent.com/oneprolabs/hyperfilelens/{{ communityVersion }}/deploy/online/install.sh \
+  | sudo bash -s -- {{ communityVersion }} --region global --download-source github --yes
 
 <span class="terminal-success">✓</span> Environment validated
-<span class="terminal-success">✓</span> Images loaded locally
+<span class="terminal-success">✓</span> Public images pulled
 <span class="terminal-success">✓</span> HyperFileLens is ready</code></pre>
           </div>
         </div>

--- a/website/.vitepress/theme/HomeLandingZh.vue
+++ b/website/.vitepress/theme/HomeLandingZh.vue
@@ -33,6 +33,7 @@ const loginUrl = computed(() => `${appOrigin.value || '#'}${appOrigin.value ? '/
 
 const githubUrl = 'https://github.com/HyperBDR/hyperfilelens'
 const sourceLensUrl = 'https://github.com/HyperBDR/sourcelens'
+const communityVersion = 'v0.2.8'
 
 function openApp(event: MouseEvent, placement: WebsiteOpenAppPlacement) {
   const target = loginUrl.value
@@ -235,12 +236,12 @@ function openApp(event: MouseEvent, placement: WebsiteOpenAppPlacement) {
       <section id="open-source" class="open-source-section" aria-labelledby="open-source-title">
         <div class="open-source-grid">
           <div class="open-source-copy">
-            <p class="section-kicker dark-kicker">开源</p>
-            <h2 id="open-source-title">私有部署 自主可控</h2>
-            <p>HyperFileLens 和背后的 AI 引擎全部开源。你可以查看架构设计、跟进开发进度，或者直接在 GitHub 上参与贡献。</p>
+            <p class="section-kicker dark-kicker">社区版</p>
+            <h2 id="open-source-title">开源社区版 一条命令部署</h2>
+            <p>在安装了 Docker 的 Ubuntu 主机上一条命令运行 Community。海外使用 GitHub 和 Docker Hub，中国大陆使用 Gitee 和阿里云。</p>
             <div class="open-source-callout">
               <svg aria-hidden="true"><use href="#icon-check" /></svg>
-              <p>不绑定任何厂商——自带 S3 兼容存储，自带 AI 模型或 API Key，自托管或托管部署都行，随时可以换。</p>
+              <p>社区版免费开源——自带 S3 兼容存储和 AI 模型或 API Key；需要企业治理能力时，再升级到企业版。</p>
             </div>
             <div class="open-source-actions">
               <a class="button button-light" :href="githubUrl"><svg aria-hidden="true"><use href="#icon-github" /></svg>查看 GitHub 仓库</a>
@@ -248,19 +249,18 @@ function openApp(event: MouseEvent, placement: WebsiteOpenAppPlacement) {
             </div>
             <div class="open-source-links">
               <a class="source-link" :href="sourceLensUrl"><svg aria-hidden="true"><use href="#icon-github" /></svg>AI 引擎仓库</a>
-              <a class="source-link" :href="`${githubUrl}/releases`">查看发布版本 <svg aria-hidden="true"><use href="#icon-arrow" /></svg></a>
+              <a class="source-link" href="/zh/docs/getting-started/install">安装指南 <svg aria-hidden="true"><use href="#icon-arrow" /></svg></a>
             </div>
             <p class="beta-note">HyperFileLens 目前处于公测阶段。</p>
           </div>
-          <div class="terminal-card" aria-label="HyperFileLens 部署命令示例">
-            <div class="terminal-bar"><span><i></i><i></i><i></i></span><b>部署 · bash</b></div>
-            <pre><code><span class="terminal-comment"># 完整离线安装包</span>
-<span class="terminal-prompt">$</span> tar -xzf hyperfilelens-release.tar.gz
-<span class="terminal-prompt">$</span> cd hyperfilelens
-<span class="terminal-prompt">$</span> sudo ./install.sh install
+          <div class="terminal-card" aria-label="Community 在线安装命令示例">
+            <div class="terminal-bar"><span><i></i><i></i><i></i></span><b>安装 · bash</b></div>
+            <pre><code><span class="terminal-comment"># Community 在线安装 · {{ communityVersion }}</span>
+<span class="terminal-prompt">$</span> curl -fsSL https://gitee.com/oneprolabs/hyperfilelens/raw/{{ communityVersion }}/deploy/online/install.sh \
+  | sudo bash -s -- {{ communityVersion }} --region cn --download-source gitee --yes
 
 <span class="terminal-success">✓</span> 环境校验通过
-<span class="terminal-success">✓</span> 镜像已加载到本地
+<span class="terminal-success">✓</span> 已拉取公开镜像
 <span class="terminal-success">✓</span> HyperFileLens 已就绪</code></pre>
           </div>
         </div>

--- a/website/.vitepress/theme/custom.css
+++ b/website/.vitepress/theme/custom.css
@@ -133,7 +133,7 @@ h1 span { color: var(--hfl-blue); }
 .terminal-bar i:nth-child(2) { background: #dcb65d; }
 .terminal-bar i:last-child { background: #56b78f; }
 .terminal-bar b { color: #71829b; font-size: 9px; font-weight: 600; }
-.terminal-card pre { min-height: 315px; margin: 0; padding: 39px 42px; color: #c8d4e5; font: 13px/1.9 "SFMono-Regular", Consolas, "Liberation Mono", monospace; white-space: pre-wrap; }
+.terminal-card pre { min-height: 315px; margin: 0; padding: 39px 42px; color: #c8d4e5; font: 13px/1.9 "SFMono-Regular", Consolas, "Liberation Mono", monospace; white-space: pre-wrap; overflow-wrap: anywhere; }
 .terminal-comment { color: #8190a6; }
 .terminal-prompt { color: #5da1ff; }
 .terminal-success { color: #49d5b9; }


### PR DESCRIPTION
## Summary
- replace the offline Release example on both homepages with Community one-command online installation
- use GitHub/Docker Hub on the English homepage and Gitee/Alibaba Cloud on the Chinese homepage
- route installation links to the matching language guidance
- allow long installation commands to wrap without clipping on desktop or mobile

## Validation
- `npm run build`
- `git diff --check`
- anonymous HTTP checks for the GitHub installer and installation guide
- visual checks at 1280px and 375px for both locales

Related to #709.