### PR TITLE
fix(insight): reconcile legacy multimodal models during upgrades

### DIFF
--- a/deploy/installer/install.sh
+++ b/deploy/installer/install.sh
@@ -4481,6 +4481,27 @@ sync_optional_identity_settings() {
 	fi
 }
 
+repair_existing_multimodal_model() {
+	step "Reconciling the existing multimodal model capability"
+	local output command_status
+	set +e
+	output="$(
+		printf '%s\n' '{"role":"multimodal","repair_existing":true}' \
+			| compose_in_root exec -T "$(active_api_service)" \
+				python manage.py ensure_platform_ai_model 2>&1
+	)"
+	command_status=$?
+	set -e
+	if [[ -n "${output}" ]]; then
+		printf '%s\n' "${output}"
+	fi
+	if [[ "${command_status}" -ne 0 ]]; then
+		warn "Existing multimodal model capability could not be reconciled; core services remain available"
+		return 0
+	fi
+	ok "Existing multimodal model capability reconciled"
+}
+
 # --- Commands ---
 
 cmd_install() {
@@ -4585,6 +4606,7 @@ cmd_install() {
 	fi
 	print_section "[7/8] Preparing platform services"
 	sync_optional_identity_settings
+	repair_existing_multimodal_model
 	ensure_local_platform_gateway
 	prune_agent_release_media
 	ok "Platform configuration and managed services are ready"
@@ -4657,6 +4679,7 @@ cmd_start() {
 	wait_for_hfl_health || die "HyperFileLens failed its startup health gate"
 	wait_for_sourcelens_health || die "bundled SourceLens failed its startup health gate"
 	sync_optional_identity_settings
+	repair_existing_multimodal_model
 	log "Services started"
 	compose_all_profiles ps
 }
@@ -6267,6 +6290,7 @@ cmd_upgrade() {
 	fi
 	record_upgrade_transaction_phase sourcelens_complete
 	sync_optional_identity_settings
+	repair_existing_multimodal_model
 	check_local_platform_gateway_continuity
 	ensure_local_platform_gateway
 	record_upgrade_transaction_phase gateway_verified

--- a/dev/stack.sh
+++ b/dev/stack.sh
@@ -1280,6 +1280,35 @@ sync_optional_identity_settings() {
 	fi
 }
 
+repair_existing_multimodal_model() {
+	local output command_status
+	if [[ "${WITH_SOURCELENS}" -ne 1 ]]; then
+		hfl_log_skip "Existing multimodal model repair is not needed without insight services"
+		return 0
+	fi
+	if ! wait_for_api_healthy; then
+		warn "Skipping existing multimodal model repair because the API is not healthy yet"
+		return 0
+	fi
+
+	log "Reconciling the existing multimodal model capability"
+	set +e
+	output="$(
+		printf '%s\n' '{"role":"multimodal","repair_existing":true}' \
+			| compose exec -T api python manage.py ensure_platform_ai_model 2>&1
+	)"
+	command_status=$?
+	set -e
+	if [[ -n "${output}" ]]; then
+		printf '%s\n' "${output}"
+	fi
+	if [[ "${command_status}" -ne 0 ]]; then
+		warn "Existing multimodal model capability could not be reconciled; the dev stack remains available"
+		return 0
+	fi
+	log "Existing multimodal model capability reconciled"
+}
+
 run_dev_migration_gate() {
 	log "Stopping backend services before database migration"
 	compose stop api worker scheduler
@@ -1320,6 +1349,7 @@ cmd_up() {
 	hfl_log_ok "Hot-reload HyperFileLens services started"
 	hfl_print_section "[6/8] Applying identity and email configuration"
 	sync_optional_identity_settings
+	repair_existing_multimodal_model
 	hfl_print_section "[7/8] Preparing Platform Data Gateway"
 	ensure_local_platform_gateway_dev
 	hfl_print_section "[8/8] Development environment summary"
@@ -1374,6 +1404,7 @@ cmd_restart() {
 	hfl_log_ok "HyperFileLens development services restarted"
 	hfl_print_section "[6/8] Applying identity and email configuration"
 	sync_optional_identity_settings
+	repair_existing_multimodal_model
 	hfl_print_section "[7/8] Preparing Platform Data Gateway"
 	ensure_local_platform_gateway_dev
 	hfl_print_section "[8/8] Development environment summary"

--- a/tools/quality/test-deployment-optional-config.sh
+++ b/tools/quality/test-deployment-optional-config.sh
@@ -246,6 +246,12 @@ assert install.index("apply_runtime_configuration") < install.index("load_images
 assert install.index("apply_runtime_configuration") < install.index("install_bundled_sourcelens")
 assert install.index("wait_for_hfl_health") < install.index("sync_optional_identity_settings")
 assert start.index("wait_for_hfl_health") < start.index("sync_optional_identity_settings")
+assert install.index("sync_optional_identity_settings") < install.index(
+    "repair_existing_multimodal_model"
+)
+assert start.index("sync_optional_identity_settings") < start.index(
+    "repair_existing_multimodal_model"
+)
 assert upgrade.index("apply_upgrade_files") < upgrade.index("apply_runtime_configuration")
 assert upgrade.index("apply_runtime_configuration") < upgrade.index("install_bundled_sourcelens")
 assert upgrade.index("apply_runtime_configuration") < upgrade.index(
@@ -254,7 +260,14 @@ assert upgrade.index("apply_runtime_configuration") < upgrade.index(
 assert upgrade.index("wait_for_services_health") < upgrade.index(
     "sync_optional_identity_settings"
 )
+assert upgrade.index("sync_optional_identity_settings") < upgrade.index(
+    "repair_existing_multimodal_model"
+)
 PY
+
+repair_model_body="$(sed -n '/^repair_existing_multimodal_model()/,/^}/p' "${installer}")"
+grep -F '{"role":"multimodal","repair_existing":true}' <<<"${repair_model_body}" >/dev/null
+grep -F 'ensure_platform_ai_model' <<<"${repair_model_body}" >/dev/null
 
 grep -F 'bash "${package_root}/install.sh" "${install_args[@]}"' \
 	"${remote_deploy}" >/dev/null

--- a/tools/quality/test-dev-stack-upgrade.sh
+++ b/tools/quality/test-dev-stack-upgrade.sh
@@ -164,7 +164,32 @@ for command_body in "${cmd_up_body}" "${cmd_restart_body}"; do
 	[[ -n "${gate_line}" ]]
 	[[ -n "${application_line}" ]]
 	((gate_line < application_line))
+	model_repair_line="$(grep -nF 'repair_existing_multimodal_model' <<<"${command_body}" | cut -d: -f1)"
+	[[ -n "${model_repair_line}" ]]
+	((application_line < model_repair_line))
 done
+repair_model_body="$(sed -n '/^repair_existing_multimodal_model()/,/^}/p' "${ROOT_REPO}/dev/stack.sh")"
+grep -F '{"role":"multimodal","repair_existing":true}' <<<"${repair_model_body}" >/dev/null
+grep -F 'ensure_platform_ai_model' <<<"${repair_model_body}" >/dev/null
+
+# Source upgrades must invoke the idempotent repair through the running API,
+# and a temporarily unavailable insight API must not take down the dev stack.
+model_repair_args="${tmp}/model-repair.args"
+model_repair_input="${tmp}/model-repair.input"
+wait_for_api_healthy() { return 0; }
+compose() {
+	printf '%s\n' "$*" >"${model_repair_args}"
+	cat >"${model_repair_input}"
+}
+WITH_SOURCELENS=1
+repair_existing_multimodal_model >/dev/null
+grep -Fx 'exec -T api python manage.py ensure_platform_ai_model' "${model_repair_args}" >/dev/null
+grep -Fx '{"role":"multimodal","repair_existing":true}' "${model_repair_input}" >/dev/null
+compose() {
+	cat >/dev/null
+	return 42
+}
+repair_existing_multimodal_model >/dev/null
 backend_stop_line="$(grep -nF 'compose stop api worker scheduler' <<<"${run_dev_migration_gate_body}" | cut -d: -f1)"
 data_services_line="$(grep -nF 'compose up -d --wait --no-build --pull never postgres redis' <<<"${run_dev_migration_gate_body}" | cut -d: -f1)"
 migration_line="$(grep -nF 'compose --profile tools run --rm --no-deps migration' <<<"${run_dev_migration_gate_body}" | cut -d: -f1)"


### PR DESCRIPTION
## Summary

- reconcile legacy multimodal model vision capability during development stack startup and restart
- run the same idempotent compatibility repair during offline install, start, and upgrade flows
- preserve core service availability when optional model reconciliation is temporarily unavailable
- add deployment and development upgrade contract coverage

## Validation

- `bash -n dev/stack.sh deploy/installer/install.sh tools/quality/test-dev-stack-upgrade.sh tools/quality/test-deployment-optional-config.sh`
- `bash tools/quality/test-dev-stack-upgrade.sh`
- `bash tools/quality/test-deployment-optional-config.sh`
- `bash tools/quality/check-release-contracts.sh`
- `git diff --check origin/main`