### PR TITLE
fix(protection): prioritize backup execution

### DIFF
--- a/src/backend/apps/protection/services/backup_task.py
+++ b/src/backend/apps/protection/services/backup_task.py
@@ -923,6 +923,22 @@ def start_backup_tasks(
                             metadata={"task_display_name": task.display_name},
                         )
 
+                        # Queue the latency-sensitive backup orchestration before
+                        # the optional directory-size refresh. Both tasks share
+                        # the default Celery worker pool, while a size refresh
+                        # may legitimately run for several minutes. Registering
+                        # it first can occupy the worker pool and leave the
+                        # newly-created backup pending even though no backup is
+                        # running.
+                        transaction.on_commit(
+                            lambda org_id=organization_id,
+                            task_uuid=str(task.task_uuid),
+                            snapshot_id=snapshot.id: _queue_backup_execution(
+                                organization_id=org_id,
+                                task_uuid=task_uuid,
+                                source_snapshot_id=snapshot_id,
+                            )
+                        )
                         from apps.protection.tasks.directory_size_estimate import (
                             refresh_backup_config_directory_estimates_task,
                         )
@@ -935,15 +951,6 @@ def start_backup_tasks(
                                 config_id=config_id,
                                 force_refresh=True,
                                 task_uuid=task_uuid,
-                            )
-                        )
-                        transaction.on_commit(
-                            lambda org_id=organization_id,
-                            task_uuid=str(task.task_uuid),
-                            snapshot_id=snapshot.id: _queue_backup_execution(
-                                organization_id=org_id,
-                                task_uuid=task_uuid,
-                                source_snapshot_id=snapshot_id,
                             )
                         )
             except IntegrityError:

--- a/src/backend/apps/protection/tests/test_backup_task_api.py
+++ b/src/backend/apps/protection/tests/test_backup_task_api.py
@@ -377,12 +377,18 @@ class ProtectionBackupTaskApiTests(TestCase):
         "apps.protection.tasks.directory_size_estimate."
         "refresh_backup_config_directory_estimates_task.delay"
     )
-    def test_start_backup_task_does_not_sync_directory_size_estimate(
+    def test_start_backup_task_prioritizes_execution_before_size_estimate(
         self,
         mock_size_refresh,
         mock_queue,
         mock_path_size,
     ):
+        queued_operations = []
+        mock_queue.side_effect = lambda **_kwargs: queued_operations.append("backup")
+        mock_size_refresh.side_effect = lambda **_kwargs: queued_operations.append(
+            "size_estimate"
+        )
+
         with self.captureOnCommitCallbacks(execute=True):
             response = self.client.post(
                 "/api/v1/protection/backup-tasks/",
@@ -401,6 +407,7 @@ class ProtectionBackupTaskApiTests(TestCase):
         mock_queue.assert_called_once()
         mock_size_refresh.assert_called_once()
         mock_path_size.assert_not_called()
+        self.assertEqual(queued_operations, ["backup", "size_estimate"])
 
     @patch("apps.protection.services.backup_task._queue_backup_execution")
     def test_start_backup_task_api_accepts_backup_config_ids_without_source_ids(


### PR DESCRIPTION
## Problem and root cause

Starting a backup registered a forced directory-size refresh before the backup
orchestration callback. Both operations use the shared default Celery worker
pool, and a size refresh can run for several minutes. With limited worker
concurrency, refresh tasks could occupy every worker and leave newly created
backups queued even when no other backup was running.

## Solution

Register the latency-sensitive backup orchestration callback before the
optional directory-size refresh. The refresh remains asynchronous and retains
its existing behavior, while backup dispatch can enter the shared queue first.

Add a regression test that executes transaction commit callbacks and verifies
the backup operation is enqueued before the size estimate.

## Validation

- Issue-targeted callback-order regression: passed
- Affected `ProtectionBackupTaskApiTests`: 47 relevant tests passed
- Ruff on both changed Python files: passed
- Git diff whitespace check: passed
- English source boundary check: passed
- Full Community Protection suite: baseline-equivalent; the same four unrelated
  failures were reproduced on canonical `origin/main` at
  `018ce24d8f7ccf8cee2c67b9102faa9650ddbfbd`
- Post-sync product retesting: skipped because the rebase onto the latest
  `origin/main` completed without conflicts and preserved the Issue patch
- Manual testing: passed

## Risks and compatibility

The change only reorders two existing asynchronous callbacks. It does not alter
the size-estimation implementation, backup data model, API contract, or stored
data. The regression test protects the scheduling priority invariant.

Fixes #695
