### PR TITLE
fix(node): harden agent task delivery and reconnect recovery

### DIFF
--- a/src/backend/apps/node/conf.py
+++ b/src/backend/apps/node/conf.py
@@ -85,6 +85,13 @@ WS_INSTANCE_KEEPALIVE_INTERVAL_SECONDS = env_int(
 LIFECYCLE_ADVANCE_INTERVAL_SECONDS = env_int(
     "NODE_LIFECYCLE_ADVANCE_INTERVAL_SECONDS", 2
 )
+# WebSocket connect/disconnect callbacks are edge-triggered.  Coalesce bursts
+# from a flapping Agent into one lifecycle wake-up; the periodic sweep remains
+# the durable fallback for events that arrive while Redis is unavailable.
+LIFECYCLE_EVENT_COALESCE_SECONDS = env_int(
+    "NODE_LIFECYCLE_EVENT_COALESCE_SECONDS",
+    _AGENT_HEARTBEAT_SECONDS,
+)
 HEARTBEAT_INVENTORY_MIN_INTERVAL_SECONDS = env_int(
     "NODE_HEARTBEAT_INVENTORY_MIN_INTERVAL_SECONDS",
     300,

--- a/src/backend/apps/node/services/internal/redis_store.py
+++ b/src/backend/apps/node/services/internal/redis_store.py
@@ -25,6 +25,21 @@ logger = logging.getLogger(__name__)
 _client: redis.Redis | None = None
 
 
+class _DefaultRedisClient:
+    """Sentinel requesting the lazily initialized process Redis client."""
+
+
+_DEFAULT_REDIS_CLIENT = _DefaultRedisClient()
+
+
+def _resolve_redis_client(
+    client: redis.Redis | None | _DefaultRedisClient,
+) -> redis.Redis | None:
+    if isinstance(client, _DefaultRedisClient):
+        return get_redis()
+    return client
+
+
 def _broker_url() -> str:
     return getattr(settings, "CELERY_BROKER_URL", "redis://redis:6379/0")
 
@@ -78,17 +93,24 @@ def set_agent_location(
     agent_id: int,
     ws_instance_id: str | None = None,
     session_id: str | None = None,
-) -> None:
-    r = get_redis()
+    redis_client: redis.Redis | None | _DefaultRedisClient = _DEFAULT_REDIS_CLIENT,
+) -> bool:
+    """Record the current WebSocket route and report whether Redis accepted it."""
+    r = _resolve_redis_client(redis_client)
     if r is None:
-        return
+        return False
     ws_id = ws_instance_id or node_conf.WS_INSTANCE_ID
     value = (
         _encode_agent_loc(ws_instance_id=ws_id, session_id=session_id)
         if session_id
         else ws_id
     )
-    r.set(agent_loc_key(agent_id), value, ex=node_conf.AGENT_LOC_TTL_SECONDS)
+    try:
+        r.set(agent_loc_key(agent_id), value, ex=node_conf.AGENT_LOC_TTL_SECONDS)
+        return True
+    except redis.RedisError as exc:
+        logger.warning("failed to record Agent route agent_id=%s: %s", agent_id, exc)
+        return False
 
 
 def touch_agent_location(*, agent_id: int) -> None:
@@ -173,32 +195,37 @@ def clear_agent_location_if_session(
     *,
     agent_id: int,
     session_id: str,
+    redis_client: redis.Redis | None | _DefaultRedisClient = _DEFAULT_REDIS_CLIENT,
 ) -> bool:
     """
     Remove ``agent_loc`` when it still belongs to ``session_id``.
 
     Returns True when this session owned the key (or Redis is unavailable).
     """
-    r = get_redis()
+    r = _resolve_redis_client(redis_client)
     if r is None:
         return True
     key = agent_loc_key(agent_id)
-    result = r.eval(
-        """
-        local raw = redis.call('get', KEYS[1])
-        if not raw then return 1 end
-        local decoded, payload = pcall(cjson.decode, raw)
-        if decoded and type(payload) == 'table' and payload['session'] then
-            if tostring(payload['session']) ~= ARGV[1] then return 0 end
-        end
-        redis.call('del', KEYS[1])
-        return 1
-        """,
-        1,
-        key,
-        session_id,
-    )
-    return bool(result)
+    try:
+        result = r.eval(
+            """
+            local raw = redis.call('get', KEYS[1])
+            if not raw then return 1 end
+            local decoded, payload = pcall(cjson.decode, raw)
+            if decoded and type(payload) == 'table' and payload['session'] then
+                if tostring(payload['session']) ~= ARGV[1] then return 0 end
+            end
+            redis.call('del', KEYS[1])
+            return 1
+            """,
+            1,
+            key,
+            session_id,
+        )
+        return bool(result)
+    except redis.RedisError as exc:
+        logger.warning("failed to clear Agent route agent_id=%s: %s", agent_id, exc)
+        return True
 
 
 def ws_alive_key(ws_instance_id: str) -> str:
@@ -260,12 +287,18 @@ def offline_task_finalization_ready() -> bool:
     return has_live_ws_instance() and not ws_recovery_hold_active()
 
 
-def touch_ws_instance_alive() -> None:
-    r = get_redis()
+def touch_ws_instance_alive(
+    *,
+    redis_client: redis.Redis | None | _DefaultRedisClient = _DEFAULT_REDIS_CLIENT,
+) -> None:
+    r = _resolve_redis_client(redis_client)
     if r is None:
         return
     ws_id = node_conf.WS_INSTANCE_ID
-    r.set(ws_alive_key(ws_id), "1", ex=node_conf.WS_INSTANCE_ALIVE_TTL_SECONDS)
+    try:
+        r.set(ws_alive_key(ws_id), "1", ex=node_conf.WS_INSTANCE_ALIVE_TTL_SECONDS)
+    except redis.RedisError as exc:
+        logger.warning("failed to renew WebSocket instance lease: %s", exc)
 
 
 def task_stream_key(task_id: str) -> str:
@@ -288,6 +321,44 @@ def task_uplink_activity_key(task_id: str) -> str:
 def periodic_lease_key(name: str) -> str:
     """Return the Redis key used to coalesce one periodic task family."""
     return f"periodic_lease:{name}"
+
+
+def lifecycle_advance_event_key(*, node_id: int) -> str:
+    """Return the short-lived coalescing key for one Node lifecycle wake-up."""
+    return f"node_lifecycle_event:{int(node_id)}"
+
+
+def claim_lifecycle_advance_event(
+    *,
+    node_id: int,
+    redis_client: redis.Redis | None | _DefaultRedisClient = _DEFAULT_REDIS_CLIENT,
+) -> bool:
+    """Claim one lifecycle wake-up for a flapping node.
+
+    Redis also backs the Celery broker, so an unavailable connection fails
+    closed instead of creating an enqueue/log storm.  PostgreSQL keeps the
+    lifecycle state durable, and the periodic sweep resumes it after Redis
+    recovery.  Redis coalesces duplicate callbacks atomically while healthy.
+    """
+    r = _resolve_redis_client(redis_client)
+    if r is None:
+        return False
+    try:
+        return bool(
+            r.set(
+                lifecycle_advance_event_key(node_id=node_id),
+                "1",
+                nx=True,
+                ex=max(1, int(node_conf.LIFECYCLE_EVENT_COALESCE_SECONDS)),
+            )
+        )
+    except redis.RedisError as exc:
+        logger.warning(
+            "lifecycle event coalescing unavailable node_id=%s: %s",
+            node_id,
+            exc,
+        )
+        return False
 
 
 @dataclass
@@ -684,18 +755,27 @@ def set_task_info(
     r = get_redis()
     if r is None:
         return
-    r.set(
-        task_info_key(task_id),
-        json.dumps(data, ensure_ascii=False),
-        ex=max(60, int(ttl_seconds)),
-    )
+    try:
+        r.set(
+            task_info_key(task_id),
+            json.dumps(data, ensure_ascii=False),
+            ex=max(60, int(ttl_seconds)),
+        )
+    except redis.RedisError as exc:
+        # PostgreSQL is authoritative. A missing hot projection only adds a
+        # polling interval and must not roll back durable task state.
+        logger.warning("task info projection failed task=%s: %s", task_id, exc)
 
 
 def get_task_info(*, task_id: str) -> dict[str, Any] | None:
     r = get_redis()
     if r is None:
         return None
-    raw = r.get(task_info_key(task_id))
+    try:
+        raw = r.get(task_info_key(task_id))
+    except redis.RedisError as exc:
+        logger.warning("task info projection unavailable task=%s: %s", task_id, exc)
+        return None
     if not raw:
         return None
     try:

--- a/src/backend/apps/node/services/internal/task.py
+++ b/src/backend/apps/node/services/internal/task.py
@@ -12,8 +12,10 @@ from datetime import datetime
 from enum import StrEnum
 from typing import TYPE_CHECKING, Any
 
+import redis
+from channels.exceptions import ChannelFull, InvalidChannelLayerError, MessageTooLarge
 from django.db import transaction
-from django.db.models import F, QuerySet
+from django.db.models import F, Q, QuerySet
 from django.utils import timezone
 
 from apps.iam.models import Organization
@@ -40,6 +42,17 @@ _TERMINAL_STATUSES = frozenset(
 )
 _TASK_COMMAND_ACK_CAPABILITY = "task_command_ack_v1"
 _DELIVERY_SECRET_KEY = "_delivery_secret"
+_DELIVERY_PROTOCOL_KEY = "_delivery_protocol"
+_DELIVERY_PROTOCOL_ACK = "command_ack_v1"
+_DELIVERY_PROTOCOL_LEGACY = "legacy"
+_DOWNLINK_ERRORS = (
+    RuntimeError,
+    OSError,
+    redis.RedisError,
+    ChannelFull,
+    InvalidChannelLayerError,
+    MessageTooLarge,
+)
 _ACK_BACKUP_TASKS = frozenset(
     {
         ("protection.backup", "backup.run"),
@@ -101,7 +114,9 @@ def _watchdog_deadline(*, from_time: datetime | None = None) -> datetime:
     return base + timezone.timedelta(seconds=node_conf.TASK_WATCHDOG_SECONDS)
 
 
-def _protection_backup_watchdog_deadline(*, from_time: datetime | None = None) -> datetime:
+def _protection_backup_watchdog_deadline(
+    *, from_time: datetime | None = None
+) -> datetime:
     from apps.protection import conf as protection_conf
 
     base = from_time or timezone.now()
@@ -110,9 +125,13 @@ def _protection_backup_watchdog_deadline(*, from_time: datetime | None = None) -
     )
 
 
-def _lifecycle_detached_watchdog_deadline(*, from_time: datetime | None = None) -> datetime:
+def _lifecycle_detached_watchdog_deadline(
+    *, from_time: datetime | None = None
+) -> datetime:
     base = from_time or timezone.now()
-    return base + timezone.timedelta(seconds=node_conf.LIFECYCLE_DETACHED_TIMEOUT_SECONDS)
+    return base + timezone.timedelta(
+        seconds=node_conf.LIFECYCLE_DETACHED_TIMEOUT_SECONDS
+    )
 
 
 def _is_protection_backup_task(task: NodeTask) -> bool:
@@ -135,11 +154,67 @@ def _node_capabilities(node: Node) -> set[str]:
 
 
 def task_uses_command_ack(task: NodeTask) -> bool:
-    """Gate the new delivery protocol to backup work on capable Agents."""
-    return (
-        (task.correlation_type, task.kind) in _ACK_BACKUP_TASKS
-        and _TASK_COMMAND_ACK_CAPABILITY in _node_capabilities(task.node)
-    )
+    """Return the immutable delivery protocol selected for this task.
+
+    Agent capabilities may disappear temporarily during reconnects or change
+    after an upgrade.  Once a command has been sent with durable ACK semantics,
+    its PostgreSQL record must retain those semantics for reconciliation.
+    """
+    if (task.correlation_type, task.kind) not in _ACK_BACKUP_TASKS:
+        return False
+    result = task.result if isinstance(task.result, dict) else {}
+    selected = str(result.get(_DELIVERY_PROTOCOL_KEY) or "")
+    if selected == _DELIVERY_PROTOCOL_ACK:
+        return True
+    if selected == _DELIVERY_PROTOCOL_LEGACY:
+        return False
+    # Backward compatibility for ACK commands dispatched before protocol
+    # selection was persisted. Legacy commands transition to RUNNING in the
+    # same write as their first delivery, so a dispatched PENDING task is ACK.
+    if (
+        task.status == NodeTask.Status.PENDING
+        and task.accepted_at is None
+        and task.delivery_attempt_count > 0
+    ):
+        return True
+    return _TASK_COMMAND_ACK_CAPABILITY in _node_capabilities(task.node)
+
+
+def _persist_delivery_protocol(*, task: NodeTask) -> bool:
+    """Select the delivery protocol once and persist it without a migration."""
+    if (task.correlation_type, task.kind) not in _ACK_BACKUP_TASKS:
+        return False
+    with transaction.atomic():
+        locked = (
+            NodeTask.objects.select_for_update().select_related("node").get(pk=task.pk)
+        )
+        task.status = locked.status
+        task.accepted_at = locked.accepted_at
+        if locked.status != NodeTask.Status.PENDING or locked.accepted_at is not None:
+            task.result = locked.result
+            return False
+        result = dict(locked.result or {})
+        selected = str(result.get(_DELIVERY_PROTOCOL_KEY) or "")
+        if selected not in {_DELIVERY_PROTOCOL_ACK, _DELIVERY_PROTOCOL_LEGACY}:
+            uses_ack = (
+                locked.delivery_attempt_count > 0
+                or _TASK_COMMAND_ACK_CAPABILITY in _node_capabilities(locked.node)
+            )
+            selected = _DELIVERY_PROTOCOL_ACK if uses_ack else _DELIVERY_PROTOCOL_LEGACY
+            result[_DELIVERY_PROTOCOL_KEY] = selected
+            locked.result = result
+            if uses_ack:
+                locked.watchdog_deadline_at = timezone.now() + timezone.timedelta(
+                    seconds=max(1, node_conf.TASK_COMMAND_ACK_MAX_AGE_SECONDS)
+                )
+                update_fields = ["result", "watchdog_deadline_at", "updated_at"]
+            else:
+                update_fields = ["result", "updated_at"]
+            locked.save(update_fields=update_fields)
+        task.result = locked.result
+        task.watchdog_deadline_at = locked.watchdog_deadline_at
+        task.delivery_attempt_count = locked.delivery_attempt_count
+        return selected == _DELIVERY_PROTOCOL_ACK
 
 
 def _substantive_backup_progress(progress: dict[str, Any] | None) -> bool:
@@ -148,7 +223,9 @@ def _substantive_backup_progress(progress: dict[str, Any] | None) -> bool:
     for key in ("hashed_bytes", "uploaded_bytes", "kopia_percent", "percent"):
         if progress.get(key) not in (None, ""):
             return True
-    phase = str(progress.get("kopia_phase") or progress.get("phase") or "").strip().lower()
+    phase = (
+        str(progress.get("kopia_phase") or progress.get("phase") or "").strip().lower()
+    )
     return phase in {
         "hashing",
         "uploading",
@@ -244,7 +321,9 @@ def _merge_progress_into_result(
         merged["detached_at"] = now.isoformat()
 
 
-def _apply_detached_running_state(*, task: NodeTask, merged: dict[str, Any], now: datetime) -> list[str]:
+def _apply_detached_running_state(
+    *, task: NodeTask, merged: dict[str, Any], now: datetime
+) -> list[str]:
     extra_fields: list[str] = []
     if str(merged.get("mode") or "").strip() != "local_detached":
         return extra_fields
@@ -276,12 +355,16 @@ def _node_ws_routable(*, node_id: int) -> bool:
 def _last_seen_within_task_route_grace(node: Node) -> bool:
     if not node.last_seen_at:
         return False
-    grace = timezone.timedelta(seconds=max(0, int(node_conf.NODE_RECONNECT_GRACE_SECONDS)))
+    grace = timezone.timedelta(
+        seconds=max(0, int(node_conf.NODE_RECONNECT_GRACE_SECONDS))
+    )
     return timezone.now() - node.last_seen_at < grace
 
 
 def _task_within_route_grace(task: NodeTask) -> bool:
-    grace = timezone.timedelta(seconds=max(0, int(node_conf.TASK_ROUTE_RECONNECT_GRACE_SECONDS)))
+    grace = timezone.timedelta(
+        seconds=max(0, int(node_conf.TASK_ROUTE_RECONNECT_GRACE_SECONDS))
+    )
     return timezone.now() - task.created_at < grace
 
 
@@ -314,17 +397,13 @@ def _sync_task_info(task: NodeTask) -> None:
                 "correlation_type": task.correlation_type,
                 "correlation_id": task.correlation_id,
                 "last_progress_at": (
-                    task.last_progress_at.isoformat()
-                    if task.last_progress_at
-                    else None
+                    task.last_progress_at.isoformat() if task.last_progress_at else None
                 ),
                 "accepted_at": (
                     task.accepted_at.isoformat() if task.accepted_at else None
                 ),
                 "last_delivery_at": (
-                    task.last_delivery_at.isoformat()
-                    if task.last_delivery_at
-                    else None
+                    task.last_delivery_at.isoformat() if task.last_delivery_at else None
                 ),
                 "delivery_attempt_count": task.delivery_attempt_count,
                 "watchdog_deadline_at": task.watchdog_deadline_at.isoformat(),
@@ -349,7 +428,11 @@ def project_node_lifecycle_task(*, node_task: NodeTask) -> None:
             if node_task.status == NodeTask.Status.SUCCESS
             else Node.Status.UPGRADE_FAILED
         )
-        updated = Node.objects.filter(pk=node_task.node_id).exclude(status=status).update(status=status)
+        updated = (
+            Node.objects.filter(pk=node_task.node_id)
+            .exclude(status=status)
+            .update(status=status)
+        )
         if updated:
             _sync_agent_source_pipeline_status(node_id=node_task.node_id)
         return
@@ -362,7 +445,11 @@ def project_node_lifecycle_task(*, node_task: NodeTask) -> None:
         if node_task.status == NodeTask.Status.SUCCESS
         else Node.Status.DEREGISTRATION_FAILED
     )
-    updated = Node.objects.filter(pk=node_task.node_id).exclude(status=status).update(status=status)
+    updated = (
+        Node.objects.filter(pk=node_task.node_id)
+        .exclude(status=status)
+        .update(status=status)
+    )
     if updated:
         _sync_agent_source_pipeline_status(node_id=node_task.node_id)
     if payload.get("source_unregister_task_id"):
@@ -382,11 +469,15 @@ def project_node_lifecycle_task(*, node_task: NodeTask) -> None:
 
 def _sync_agent_source_pipeline_status(*, node_id: int) -> None:
     """Refresh the Backup Wizard read model after a Node lifecycle transition."""
-    node = Node.objects.filter(pk=node_id, role=NodeRole.AGENT, is_deleted=False).first()
+    node = Node.objects.filter(
+        pk=node_id, role=NodeRole.AGENT, is_deleted=False
+    ).first()
     if node is None:
         return
     try:
-        from apps.source.services.internal.source_pipeline import sync_pipeline_projection
+        from apps.source.services.internal.source_pipeline import (
+            sync_pipeline_projection,
+        )
 
         sync_pipeline_projection(
             organization_id=node.organization_id,
@@ -419,9 +510,41 @@ def _schedule_agent_task_redelivery(*, task: NodeTask) -> None:
     )
 
 
+def _delivery_diagnostic_error_code(reason: str) -> str:
+    normalized_reason = reason.lower()
+    if "reconnecting" in normalized_reason:
+        return "AGENT_CONNECTION_UNSTABLE"
+    if "not routable" in normalized_reason or (
+        "agent" in normalized_reason and "unavailable" in normalized_reason
+    ):
+        return "AGENT_UNAVAILABLE"
+    return "AGENT_DELIVERY_FAILED"
+
+
+def _without_delivery_runtime_state(result: dict[str, Any] | None) -> dict[str, Any]:
+    merged = dict(result or {})
+    if merged.get("diagnostic_error_code") in {
+        "AGENT_CONNECTION_UNSTABLE",
+        "AGENT_UNAVAILABLE",
+        "AGENT_DELIVERY_FAILED",
+    }:
+        merged.pop("diagnostic_error_code", None)
+    merged.pop(_DELIVERY_PROTOCOL_KEY, None)
+    return merged
+
+
 def _mark_task_reconnecting(*, task: NodeTask) -> NodeTask:
-    updated = NodeTask.objects.filter(pk=task.pk, status=NodeTask.Status.PENDING).update(
+    task.refresh_from_db()
+    if task.status != NodeTask.Status.PENDING:
+        _sync_task_info(task)
+        return task
+    result = dict(task.result or {})
+    result["diagnostic_error_code"] = "AGENT_CONNECTION_UNSTABLE"
+    updated = NodeTask.objects.filter(
+        pk=task.pk, status=NodeTask.Status.PENDING
+    ).update(
         last_error="agent websocket is reconnecting",
+        result=result,
         updated_at=timezone.now(),
     )
     task.refresh_from_db()
@@ -429,10 +552,20 @@ def _mark_task_reconnecting(*, task: NodeTask) -> NodeTask:
         _sync_task_info(task)
         return task
     _sync_task_info(task)
-    try:
-        _schedule_agent_task_redelivery(task=task)
-    except Exception:
-        logger.warning("failed to schedule agent task redelivery task_id=%s", task.id, exc_info=True)
+    # Durable ACK commands are retried by the coalesced PostgreSQL
+    # reconciliation sweep. Scheduling a one-second Celery chain as well would
+    # amplify a flapping Agent into avoidable broker traffic. Legacy commands
+    # still need the one-shot chain because they are not reconciliation
+    # candidates.
+    if not task_uses_command_ack(task):
+        try:
+            _schedule_agent_task_redelivery(task=task)
+        except Exception:
+            logger.warning(
+                "failed to schedule agent task redelivery task_id=%s",
+                task.id,
+                exc_info=True,
+            )
     logger.info(
         "agent task delivery delayed while websocket reconnects task_id=%s node_id=%s kind=%s",
         task.id,
@@ -443,12 +576,24 @@ def _mark_task_reconnecting(*, task: NodeTask) -> NodeTask:
 
 
 def _fail_task_delivery(*, task: NodeTask, reason: str) -> NodeTask:
-    NodeTask.objects.filter(pk=task.pk).update(
+    result = _without_delivery_runtime_state(task.result)
+    result["diagnostic_error_code"] = _delivery_diagnostic_error_code(reason)
+    updated = NodeTask.objects.filter(
+        pk=task.pk,
+        status=NodeTask.Status.PENDING,
+        accepted_at__isnull=True,
+    ).update(
         status=NodeTask.Status.FAILED,
         last_error=reason[:2000],
+        result=result,
         updated_at=timezone.now(),
     )
     task.refresh_from_db()
+    if updated == 0:
+        # A transport error can be ambiguous: the command may have reached a
+        # legacy Agent and completed before Channels reported the failure.
+        # Preserve the newer PostgreSQL state and its existing projection.
+        return task
     _sync_task_info(task)
     redis_store.push_task_stream(
         task_id=str(task.id),
@@ -502,9 +647,19 @@ def create_agent_task(
     return task
 
 
-def deliver_agent_task(*, task: NodeTask, delivery_payload: dict | None = None) -> NodeTask:
-    """Send ``task.command``; ACK-capable backup tasks remain pending until accepted."""
-    if task.status != NodeTask.Status.PENDING:
+def deliver_agent_task(
+    *,
+    task: NodeTask,
+    delivery_payload: dict | None = None,
+    allow_ack_redelivery: bool = False,
+) -> NodeTask:
+    """Send ``task.command`` while preserving the selected delivery protocol.
+
+    ACK-capable backup tasks remain pending until accepted. Their retries are
+    rejected by default so only the bounded PostgreSQL reconciliation sweep
+    can opt into redelivery.
+    """
+    if task.status != NodeTask.Status.PENDING or task.accepted_at is not None:
         return task
     ctx = task_log_context(
         node_id=task.node_id,
@@ -513,7 +668,14 @@ def deliver_agent_task(*, task: NodeTask, delivery_payload: dict | None = None) 
         correlation_type=task.correlation_type,
         correlation_id=task.correlation_id,
     )
-    uses_ack = task_uses_command_ack(task)
+    uses_ack = _persist_delivery_protocol(task=task)
+    if task.status != NodeTask.Status.PENDING or task.accepted_at is not None:
+        return task
+    if uses_ack and task.delivery_attempt_count > 0 and not allow_ack_redelivery:
+        # ACK retries have one owner: the bounded PostgreSQL reconciliation
+        # sweep. Backup orchestration may observe PENDING repeatedly, but must
+        # not turn those observations into an unbounded delivery loop.
+        return task
     try:
         ephemeral_delivery_payload = delivery_payload is not None
         if delivery_payload is None:
@@ -539,9 +701,18 @@ def deliver_agent_task(*, task: NodeTask, delivery_payload: dict | None = None) 
             }
             if task.dispatched_at is None:
                 delivery_updates["dispatched_at"] = dispatched_at
-            NodeTask.objects.filter(
-                pk=task.pk, status=NodeTask.Status.PENDING
+            delivery_claimed = NodeTask.objects.filter(
+                pk=task.pk,
+                status=NodeTask.Status.PENDING,
+                accepted_at__isnull=True,
+                delivery_attempt_count=task.delivery_attempt_count,
             ).update(**delivery_updates)
+            if delivery_claimed == 0:
+                # Another dispatcher claimed this attempt, or the Agent
+                # accepted/completed it after protocol selection. Preserve the
+                # newer PostgreSQL state and do not emit a duplicate command.
+                task.refresh_from_db()
+                return task
         if delivery_payload is None:
             _send_task_command(task=task)
         else:
@@ -552,7 +723,12 @@ def deliver_agent_task(*, task: NodeTask, delivery_payload: dict | None = None) 
             finally:
                 task.payload = persisted_payload
         if not uses_ack:
-            NodeTask.objects.filter(pk=task.pk).update(
+            completed_delivery_result = _without_delivery_runtime_state(task.result)
+            NodeTask.objects.filter(
+                pk=task.pk,
+                status=NodeTask.Status.PENDING,
+                accepted_at__isnull=True,
+            ).update(
                 status=NodeTask.Status.RUNNING,
                 dispatched_at=dispatched_at,
                 last_delivery_at=dispatched_at,
@@ -563,19 +739,23 @@ def deliver_agent_task(*, task: NodeTask, delivery_payload: dict | None = None) 
                     from_time=dispatched_at,
                     kind=task.kind,
                 ),
+                result=completed_delivery_result,
             )
         task.refresh_from_db()
         _sync_task_info(task)
         logger.info("agent task dispatched %s status=%s", ctx, task.status)
-    except (RuntimeError, OSError) as exc:
+    except _DOWNLINK_ERRORS as exc:
         logger.warning(
             "agent task dispatch failed %s error=%s",
             ctx,
             str(exc)[:500],
         )
         if uses_ack:
+            result = dict(task.result or {})
+            result["diagnostic_error_code"] = _delivery_diagnostic_error_code(str(exc))
             NodeTask.objects.filter(pk=task.pk, status=NodeTask.Status.PENDING).update(
                 last_error=str(exc)[:2000],
+                result=result,
                 updated_at=timezone.now(),
             )
             task.refresh_from_db()
@@ -589,9 +769,7 @@ def deliver_agent_task(*, task: NodeTask, delivery_payload: dict | None = None) 
 def accept_task(*, task_id: uuid.UUID | str, node_id: int) -> NodeTask:
     """Persist Agent's durable command acceptance without reviving terminal work."""
     task = (
-        NodeTask.objects.select_for_update()
-        .filter(pk=task_id, node_id=node_id)
-        .first()
+        NodeTask.objects.select_for_update().filter(pk=task_id, node_id=node_id).first()
     )
     if task is None:
         raise LookupError("task not found")
@@ -607,6 +785,7 @@ def accept_task(*, task_id: uuid.UUID | str, node_id: int) -> NodeTask:
         kind=task.kind,
     )
     task.last_error = ""
+    task.result = _without_delivery_runtime_state(task.result)
     task.save(
         update_fields=[
             "status",
@@ -614,6 +793,7 @@ def accept_task(*, task_id: uuid.UUID | str, node_id: int) -> NodeTask:
             "last_progress_at",
             "watchdog_deadline_at",
             "last_error",
+            "result",
             "updated_at",
         ]
     )
@@ -626,11 +806,7 @@ def accept_task(*, task_id: uuid.UUID | str, node_id: int) -> NodeTask:
 
 
 def redeliver_pending_agent_task(*, task_id: uuid.UUID | str) -> NodeTask | None:
-    task = (
-        NodeTask.objects.select_related("node")
-        .filter(pk=task_id)
-        .first()
-    )
+    task = NodeTask.objects.select_related("node").filter(pk=task_id).first()
     if task is None:
         return None
     if task.status != NodeTask.Status.PENDING:
@@ -654,18 +830,27 @@ def redeliver_pending_agent_task(*, task_id: uuid.UUID | str) -> NodeTask | None
     return delivered
 
 
-def _timeout_unaccepted_task(*, task_id: uuid.UUID | str) -> bool:
+def _timeout_unaccepted_task(
+    *,
+    task_id: uuid.UUID | str,
+    error_code: str = "AGENT_ACK_TIMEOUT",
+    message: str = "Agent did not durably accept task.command",
+) -> bool:
     with transaction.atomic():
         task = (
             NodeTask.objects.select_for_update()
-            .filter(pk=task_id, status=NodeTask.Status.PENDING, accepted_at__isnull=True)
+            .filter(
+                pk=task_id, status=NodeTask.Status.PENDING, accepted_at__isnull=True
+            )
             .first()
         )
         if task is None:
             return False
         task.status = NodeTask.Status.TIMEOUT
-        task.last_error = "AGENT_ACK_TIMEOUT: Agent did not durably accept task.command"
+        task.last_error = f"{error_code}: {message}"
         result = dict(task.result or {})
+        result.pop(_DELIVERY_PROTOCOL_KEY, None)
+        result["diagnostic_error_code"] = error_code
         result["delivery_timeout_sealed"] = True
         result["delivery_attempt_count"] = task.delivery_attempt_count
         task.result = result
@@ -693,46 +878,100 @@ def _timeout_unaccepted_task(*, task_id: uuid.UUID | str) -> bool:
 
 def reconcile_unaccepted_agent_tasks(*, limit: int = 200) -> dict[str, int | bool]:
     """Retry ACK-capable backup commands with the original NodeTask identity."""
-    if redis_store.ws_recovery_hold_active():
-        return {"candidates": 0, "redelivered": 0, "timed_out": 0, "recovery_hold": True}
-
     now = timezone.now()
-    ack_wait = timezone.timedelta(seconds=max(1, node_conf.TASK_COMMAND_ACK_TIMEOUT_SECONDS))
-    max_age = timezone.timedelta(seconds=max(1, node_conf.TASK_COMMAND_ACK_MAX_AGE_SECONDS))
+    ack_wait = timezone.timedelta(
+        seconds=max(1, node_conf.TASK_COMMAND_ACK_TIMEOUT_SECONDS)
+    )
+    max_age = timezone.timedelta(
+        seconds=max(1, node_conf.TASK_COMMAND_ACK_MAX_AGE_SECONDS)
+    )
     max_attempts = 1 + max(0, node_conf.TASK_COMMAND_ACK_MAX_RETRIES)
-    candidates = list(
-        NodeTask.objects.select_related("node")
-        .filter(
-            status=NodeTask.Status.PENDING,
-            accepted_at__isnull=True,
-            kind__in=["repository.policy.apply", "backup.snapshot.create", "backup.run"],
+    ack_task_filter = Q()
+    for correlation_type, kind in _ACK_BACKUP_TASKS:
+        ack_task_filter |= Q(correlation_type=correlation_type, kind=kind)
+    protocol_lookup = f"result__{_DELIVERY_PROTOCOL_KEY}"
+    candidate_query = NodeTask.objects.filter(
+        ack_task_filter,
+        status=NodeTask.Status.PENDING,
+        accepted_at__isnull=True,
+    ).filter(
+        # Keep only an explicit legacy selection out of later ACK sweeps.
+        # Missing or unknown values must be reclassified so malformed or
+        # future metadata cannot leave a capable task pending forever.
+        ~Q(result__has_key=_DELIVERY_PROTOCOL_KEY)
+        | (
+            Q(result__has_key=_DELIVERY_PROTOCOL_KEY)
+            & ~Q(**{protocol_lookup: _DELIVERY_PROTOCOL_LEGACY})
         )
-        .order_by("created_at", "id")[: max(1, int(limit))]
+    )
+    recovery_hold = redis_store.ws_recovery_hold_active()
+    if recovery_hold:
+        # Refresh every already-selected ACK command, not only the first
+        # reconciliation page. Markerless, never-dispatched work may belong to
+        # a legacy Agent and must retain its original watchdog semantics.
+        # This makes a blue/green deployment a bounded pause while the Redis
+        # hold TTL prevents an unbounded extension after recovery.
+        # Refresh only after half of the bounded window is consumed. A long
+        # Redis outage therefore causes at most one bulk write per half-window
+        # instead of rewriting every pending row on each 15-second tick.
+        candidate_query.filter(
+            Q(**{protocol_lookup: _DELIVERY_PROTOCOL_ACK})
+            | Q(delivery_attempt_count__gt=0),
+            watchdog_deadline_at__lt=now + (max_age / 2),
+        ).update(
+            watchdog_deadline_at=now + max_age,
+            updated_at=now,
+        )
+        return {
+            "candidates": 0,
+            "redelivered": 0,
+            "timed_out": 0,
+            "recovery_hold": True,
+        }
+    candidates = list(
+        candidate_query.select_related("node").order_by("created_at", "id")[
+            : max(1, int(limit))
+        ]
     )
     redelivered = 0
     timed_out = 0
     considered = 0
     for task in candidates:
-        if not task_uses_command_ack(task):
+        if not _persist_delivery_protocol(task=task):
             continue
         considered += 1
-        if _node_route_state(task=task) != _RouteState.ONLINE:
+        route_state = _node_route_state(task=task)
+        if task.watchdog_deadline_at <= now:
+            if route_state == _RouteState.ONLINE:
+                error_code = "AGENT_ACK_TIMEOUT"
+                message = "Agent did not durably accept task.command"
+            elif (
+                task.node.availability == Node.Availability.ONLINE
+                and _last_seen_within_task_route_grace(task.node)
+            ):
+                error_code = "AGENT_CONNECTION_UNSTABLE"
+                message = "Agent connection remained unstable during delivery"
+            else:
+                error_code = "AGENT_UNAVAILABLE"
+                message = "Agent remained unavailable during delivery"
+            if _timeout_unaccepted_task(
+                task_id=task.id,
+                error_code=error_code,
+                message=message,
+            ):
+                timed_out += 1
             continue
-        age = now - (task.dispatched_at or task.created_at)
+        if route_state != _RouteState.ONLINE:
+            continue
         since_delivery = now - (task.last_delivery_at or task.created_at)
         if since_delivery < ack_wait:
             continue
-        # Recovery/offline holds do not consume the delivery lifetime. The
-        # hard-age guard therefore only seals after all delivery attempts were
-        # actually consumed.
-        if task.delivery_attempt_count >= max_attempts and (
-            since_delivery >= ack_wait or age >= max_age
-        ):
+        if task.delivery_attempt_count >= max_attempts and since_delivery >= ack_wait:
             if _timeout_unaccepted_task(task_id=task.id):
                 timed_out += 1
             continue
         previous_attempts = task.delivery_attempt_count
-        delivered = deliver_agent_task(task=task)
+        delivered = deliver_agent_task(task=task, allow_ack_redelivery=True)
         if delivered.delivery_attempt_count > previous_attempts:
             redelivered += 1
     return {
@@ -780,9 +1019,7 @@ def record_task_progress(
     alive: bool = False,
 ) -> NodeTask:
     task = (
-        NodeTask.objects.select_for_update()
-        .filter(pk=task_id, node_id=node_id)
-        .first()
+        NodeTask.objects.select_for_update().filter(pk=task_id, node_id=node_id).first()
     )
     if task is None:
         raise LookupError("task not found")
@@ -794,6 +1031,7 @@ def record_task_progress(
     task.status = NodeTask.Status.RUNNING
     task.accepted_at = task.accepted_at or now
     task.last_progress_at = now
+    task.result = _without_delivery_runtime_state(task.result)
     if _is_protection_backup_task(task):
         # task.alive and generic task.progress frames prove that the Agent's
         # execution goroutine is still running. Renew the activity lease even
@@ -809,14 +1047,26 @@ def record_task_progress(
         ]
     else:
         task.watchdog_deadline_at = _watchdog_deadline(from_time=now)
-        update_fields = ["status", "accepted_at", "last_progress_at", "watchdog_deadline_at", "result", "updated_at"]
+        update_fields = [
+            "status",
+            "accepted_at",
+            "last_progress_at",
+            "watchdog_deadline_at",
+            "result",
+            "updated_at",
+        ]
     if progress:
         merged = dict(task.result or {})
-        _merge_progress_into_result(task=task, progress=progress, merged=merged, now=now)
+        _merge_progress_into_result(
+            task=task, progress=progress, merged=merged, now=now
+        )
         task.result = merged
         if _task_has_detached_marker(task):
             update_fields = list(
-                dict.fromkeys(update_fields + _apply_detached_running_state(task=task, merged=merged, now=now))
+                dict.fromkeys(
+                    update_fields
+                    + _apply_detached_running_state(task=task, merged=merged, now=now)
+                )
             )
     task.save(update_fields=update_fields)
     _sync_task_info(task)
@@ -842,9 +1092,7 @@ def complete_task(
     replace_result: bool = False,
 ) -> NodeTask:
     task = (
-        NodeTask.objects.select_for_update()
-        .filter(pk=task_id, node_id=node_id)
-        .first()
+        NodeTask.objects.select_for_update().filter(pk=task_id, node_id=node_id).first()
     )
     if task is None:
         raise LookupError("task not found")
@@ -854,7 +1102,11 @@ def complete_task(
         task.status in {NodeTask.Status.FAILED, NodeTask.Status.TIMEOUT}
         and incoming in {"success", "succeeded", "ok"}
         and _is_protection_backup_task(task)
-        and not str((result or {}).get("kopia_snapshot_id") or (result or {}).get("snapshot_id") or "").strip()
+        and not str(
+            (result or {}).get("kopia_snapshot_id")
+            or (result or {}).get("snapshot_id")
+            or ""
+        ).strip()
     ):
         logger.warning(
             "late backup success ignored without snapshot identity %s",
@@ -911,7 +1163,7 @@ def complete_task(
         if replace_result:
             merged = dict(result or {})
         else:
-            merged = dict(task.result or {})
+            merged = _without_delivery_runtime_state(task.result)
             if result:
                 merged.update(result)
         task.result = merged
@@ -920,7 +1172,10 @@ def complete_task(
         update_fields = ["status", "accepted_at", "result", "last_error", "updated_at"]
         if _task_has_detached_marker(task):
             update_fields = list(
-                dict.fromkeys(update_fields + _apply_detached_running_state(task=task, merged=merged, now=now))
+                dict.fromkeys(
+                    update_fields
+                    + _apply_detached_running_state(task=task, merged=merged, now=now)
+                )
             )
         task.save(update_fields=update_fields)
         _sync_task_info(task)
@@ -947,7 +1202,11 @@ def complete_task(
 
     if result:
         task.result = result
-    task.save(update_fields=["status", "accepted_at", "result", "last_error", "updated_at"])
+    else:
+        task.result = _without_delivery_runtime_state(task.result)
+    task.save(
+        update_fields=["status", "accepted_at", "result", "last_error", "updated_at"]
+    )
     _sync_task_info(task)
     redis_store.push_task_stream(
         task_id=str(task.id),
@@ -956,7 +1215,12 @@ def complete_task(
     if task.status == NodeTask.Status.SUCCESS:
         logger.info("agent task completed %s status=%s", ctx, task.status)
     elif task.status == NodeTask.Status.CANCELED:
-        logger.info("agent task canceled %s status=%s error=%s", ctx, task.status, task.last_error[:200])
+        logger.info(
+            "agent task canceled %s status=%s error=%s",
+            ctx,
+            task.status,
+            task.last_error[:200],
+        )
     else:
         logger.warning(
             "agent task failed %s status=%s error=%s",
@@ -983,9 +1247,10 @@ def _terminal_error_matches(*, task: NodeTask, incoming: str, error: str) -> boo
         return existing == "" and str(error or "") == ""
     if task.status == NodeTask.Status.CANCELED:
         candidate = str(error or "").strip().lower()
-        return candidate in {"", "canceled", "cancelled"} or existing == str(
-            error or ""
-        )[:2000]
+        return (
+            candidate in {"", "canceled", "cancelled"}
+            or existing == str(error or "")[:2000]
+        )
     return existing == str(error or incoming)[:2000]
 
 
@@ -1020,7 +1285,9 @@ def cancel_task(
         task.cancel_requested_at = now
     merged["cancel_requested_at"] = task.cancel_requested_at.isoformat()
     task.result = merged
-    task.save(update_fields=["result", "last_error", "cancel_requested_at", "updated_at"])
+    task.save(
+        update_fields=["result", "last_error", "cancel_requested_at", "updated_at"]
+    )
     _send_cancel_command(task=task)
     _sync_task_info(task)
     redis_store.push_task_stream(
@@ -1119,7 +1386,7 @@ def _send_cancel_command(*, task: NodeTask) -> None:
 
     try:
         send_task_cancel(task=task)
-    except (RuntimeError, OSError) as exc:
+    except _DOWNLINK_ERRORS as exc:
         logger.warning("cancel send failed task=%s: %s", task.id, exc)
 
 
@@ -1146,14 +1413,18 @@ def fail_active_tasks_for_node(*, node_id: int, reason: str) -> int:
             task_id=str(task.id),
             message=_terminal_stream_message(task),
         )
-        from apps.node.services.internal.task_offline_reconcile import sync_platform_tasks_for_node_task
+        from apps.node.services.internal.task_offline_reconcile import (
+            sync_platform_tasks_for_node_task,
+        )
 
         sync_platform_tasks_for_node_task(node_task=task)
         count += 1
     return count
 
 
-def sweep_watchdog_timeouts(*, queryset: QuerySet[NodeTask] | None = None, limit: int = 500) -> int:
+def sweep_watchdog_timeouts(
+    *, queryset: QuerySet[NodeTask] | None = None, limit: int = 500
+) -> int:
     now = timezone.now()
     qs = queryset
     if qs is None:
@@ -1162,7 +1433,9 @@ def sweep_watchdog_timeouts(*, queryset: QuerySet[NodeTask] | None = None, limit
             watchdog_deadline_at__lt=now,
         )
     ids = list(
-        qs.order_by("watchdog_deadline_at", "pk").values_list("pk", flat=True)[: int(limit)]
+        qs.order_by("watchdog_deadline_at", "pk").values_list("pk", flat=True)[
+            : int(limit)
+        ]
     )
     uplink_activities = redis_store.get_task_uplink_activities(
         task_ids=[str(task_id) for task_id in ids]
@@ -1181,6 +1454,16 @@ def sweep_watchdog_timeouts(*, queryset: QuerySet[NodeTask] | None = None, limit
                 .first()
             )
             if task is None:
+                continue
+            # ACK-capable commands have a separate delivery/acceptance
+            # watchdog. The reconciliation sweep owns its bounded deadline
+            # and structured terminal reason; the execution watchdog must not
+            # turn queue wait into a false WATCHDOG_STALL.
+            if (
+                task.status == NodeTask.Status.PENDING
+                and task.accepted_at is None
+                and (task.delivery_attempt_count > 0 or task_uses_command_ack(task))
+            ):
                 continue
             uplink_activity = uplink_activities.get(str(task.id))
             try:
@@ -1240,7 +1523,9 @@ def sweep_watchdog_timeouts(*, queryset: QuerySet[NodeTask] | None = None, limit
                 task_id=str(task.id),
                 message=_terminal_stream_message(task),
             )
-            from apps.node.services.internal.task_offline_reconcile import sync_platform_tasks_for_node_task
+            from apps.node.services.internal.task_offline_reconcile import (
+                sync_platform_tasks_for_node_task,
+            )
 
             sync_platform_tasks_for_node_task(node_task=task)
             marked += 1

--- a/src/backend/apps/node/tests/test_node_online_status.py
+++ b/src/backend/apps/node/tests/test_node_online_status.py
@@ -30,8 +30,18 @@ class _FakeRedis:
     def ping(self) -> bool:
         return True
 
-    def set(self, key: str, value: str, ex: int | None = None) -> None:
+    def set(
+        self,
+        key: str,
+        value: str,
+        ex: int | None = None,
+        nx: bool = False,
+    ) -> bool:
+        del ex
+        if nx and key in self.data:
+            return False
         self.data[key] = value
+        return True
 
     def get(self, key: str) -> str | None:
         return self.data.get(key)
@@ -88,16 +98,16 @@ class AgentNodeOnlineStatusTests(TestCase):
         )
         self.redis = _FakeRedis()
         self._redis_patcher = self._patch_redis(self.redis)
-        self._redis_patcher.start()
+        self._get_redis = self._redis_patcher.start()
         self.addCleanup(self._redis_patcher.stop)
         redis_store._client = None
         from unittest.mock import patch
 
-        self._lifecycle_delay = patch(
-            "apps.node.tasks.lifecycle.advance_node_lifecycle_for_node.delay",
+        self._lifecycle_enqueue_patcher = patch(
+            "apps.node.tasks.lifecycle.advance_node_lifecycle_for_node.apply_async",
         )
-        self._lifecycle_delay.start()
-        self.addCleanup(self._lifecycle_delay.stop)
+        self._lifecycle_enqueue = self._lifecycle_enqueue_patcher.start()
+        self.addCleanup(self._lifecycle_enqueue_patcher.stop)
 
     @staticmethod
     def _patch_redis(fake: _FakeRedis):
@@ -163,6 +173,66 @@ class AgentNodeOnlineStatusTests(TestCase):
             effective_agent_node_status(self.node),
             Node.Availability.ONLINE,
         )
+
+    def test_flapping_agent_coalesces_lifecycle_wakeups(self):
+        """A connect/disconnect burst schedules one lifecycle wake-up per node."""
+        self._mark_ws_alive()
+        on_agent_connected(node_id=self.node.id, session_id="session-a")
+        on_agent_disconnected(node_id=self.node.id, session_id="session-a")
+
+        self._lifecycle_enqueue.assert_called_once_with(
+            kwargs={"node_id": self.node.id},
+            expires=node_conf.LIFECYCLE_ADVANCE_EXPIRE_SECONDS,
+        )
+        self.assertTrue(
+            self.redis.exists(
+                redis_store.lifecycle_advance_event_key(node_id=self.node.id)
+            )
+        )
+
+    def test_connect_reuses_one_redis_lookup_for_route_and_wakeup(self):
+        self._get_redis.reset_mock()
+
+        on_agent_connected(node_id=self.node.id, session_id="session-a")
+
+        self._get_redis.assert_called_once_with()
+
+    def test_redis_route_write_failure_does_not_break_connect_callback(self):
+        from redis.exceptions import ConnectionError as RedisConnectionError
+        from unittest.mock import patch
+
+        with patch.object(
+            self.redis,
+            "set",
+            side_effect=RedisConnectionError("redis unavailable"),
+        ):
+            on_agent_connected(node_id=self.node.id, session_id="session-a")
+
+        self.node.refresh_from_db()
+        self.assertEqual(self.node.availability, Node.Availability.ONLINE)
+        self._lifecycle_enqueue.assert_not_called()
+
+    def test_lifecycle_enqueue_failure_does_not_break_ws_callback(self):
+        self._lifecycle_enqueue.side_effect = RuntimeError("broker unavailable")
+
+        on_agent_connected(node_id=self.node.id, session_id="session-a")
+
+        self.node.refresh_from_db()
+        self.assertEqual(self.node.availability, Node.Availability.ONLINE)
+        self.assertEqual(self._lifecycle_enqueue.call_count, 1)
+
+    def test_redis_outage_defers_lifecycle_wakeup_to_periodic_sweep(self):
+        from unittest.mock import patch
+
+        with patch(
+            "apps.node.services.internal.redis_store.get_redis",
+            return_value=None,
+        ):
+            claimed = redis_store.claim_lifecycle_advance_event(
+                node_id=self.node.id
+            )
+
+        self.assertFalse(claimed)
 
     def test_ws_disconnect_effective_offline_after_grace(self):
         self._mark_ws_alive()

--- a/src/backend/apps/node/tests/test_periodic_task_coalescing.py
+++ b/src/backend/apps/node/tests/test_periodic_task_coalescing.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 from unittest.mock import Mock
 
 from django.test import SimpleTestCase
+from redis.exceptions import ConnectionError as RedisConnectionError
 
 from apps.node import conf as node_conf
 from apps.node.services.internal import redis_store
@@ -144,7 +145,10 @@ class PeriodicTaskCoalescingTests(SimpleTestCase):
 
         self.assertGreaterEqual(redis.eval.call_count, 2)
 
-    @patch("apps.node.services.internal.redis_store._broker_url", return_value="redis://test")
+    @patch(
+        "apps.node.services.internal.redis_store._broker_url",
+        return_value="redis://test",
+    )
     @patch("apps.node.services.internal.redis_store.redis.Redis.from_url")
     def test_failed_ping_does_not_cache_unverified_client(
         self,
@@ -201,3 +205,16 @@ class PeriodicTaskCoalescingTests(SimpleTestCase):
         self.assertNotIn("two", result)
         redis.pipeline.assert_called_once_with(transaction=False)
         self.assertEqual(pipeline.get.call_count, 2)
+
+    @patch("apps.node.services.internal.redis_store.get_redis")
+    def test_task_info_projection_fails_open_during_redis_outage(
+        self, get_redis
+    ) -> None:
+        redis = Mock()
+        redis.set.side_effect = RedisConnectionError("redis unavailable")
+        redis.get.side_effect = RedisConnectionError("redis unavailable")
+        get_redis.return_value = redis
+
+        redis_store.set_task_info(task_id="task-1", data={"status": "running"})
+
+        self.assertIsNone(redis_store.get_task_info(task_id="task-1"))

--- a/src/backend/apps/node/tests/test_task_command_ack.py
+++ b/src/backend/apps/node/tests/test_task_command_ack.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 from django.test import TestCase
 from django.utils import timezone
+from redis.exceptions import ConnectionError as RedisConnectionError
 
 from apps.iam.models import Organization
 from apps.node.models import Node, NodeTask
@@ -11,6 +12,7 @@ from apps.protection import conf as protection_conf
 from apps.node.services.internal.task import (
     _RouteState,
     accept_task,
+    cancel_task,
     complete_task,
     deliver_agent_task,
     reconcile_unaccepted_agent_tasks,
@@ -26,7 +28,8 @@ class TaskCommandAckTests(TestCase):
             organization=self.org,
             name="ack-agent",
             role=Node.Role.AGENT,
-            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
+            status=Node.Status.ACTIVE,
+            availability=Node.Availability.ONLINE,
             last_seen_at=timezone.now(),
             metadata={"inventory": {"capabilities": ["task_command_ack_v1"]}},
         )
@@ -46,7 +49,10 @@ class TaskCommandAckTests(TestCase):
 
     @patch("apps.node.services.internal.task.redis_store.set_task_info")
     @patch("apps.node.services.internal.task._send_task_command")
-    @patch("apps.node.services.internal.task._node_route_state", return_value=_RouteState.ONLINE)
+    @patch(
+        "apps.node.services.internal.task._node_route_state",
+        return_value=_RouteState.ONLINE,
+    )
     def test_ack_capable_delivery_remains_pending_until_accepted(
         self, _route, send_command, _set_info
     ):
@@ -61,6 +67,50 @@ class TaskCommandAckTests(TestCase):
         accepted = accept_task(task_id=task.id, node_id=self.node.id)
         self.assertEqual(accepted.status, NodeTask.Status.RUNNING)
         self.assertIsNotNone(accepted.accepted_at)
+
+    @patch("apps.node.services.internal.task.redis_store.set_task_info")
+    @patch("apps.node.services.internal.task._send_task_command")
+    @patch(
+        "apps.node.services.internal.task._node_route_state",
+        return_value=_RouteState.ONLINE,
+    )
+    def test_repeated_orchestrator_observation_does_not_redeliver_ack_task(
+        self, _route, send_command, _set_info
+    ):
+        task = deliver_agent_task(task=self.task())
+
+        observed_again = deliver_agent_task(task=task)
+
+        self.assertEqual(observed_again.status, NodeTask.Status.PENDING)
+        self.assertEqual(observed_again.delivery_attempt_count, 1)
+        self.assertEqual(send_command.call_count, 1)
+
+    @patch("apps.node.services.internal.task.redis_store.set_task_info")
+    @patch("apps.node.services.internal.task._send_task_command")
+    @patch(
+        "apps.node.services.internal.task._node_route_state",
+        return_value=_RouteState.ONLINE,
+    )
+    @patch("apps.node.services.internal.task._persist_delivery_protocol")
+    def test_acceptance_race_prevents_duplicate_ack_delivery(
+        self, select_protocol, _route, send_command, _set_info
+    ):
+        task = self.task()
+
+        def accept_before_delivery(*, task):
+            NodeTask.objects.filter(pk=task.pk).update(
+                status=NodeTask.Status.RUNNING,
+                accepted_at=timezone.now(),
+            )
+            return True
+
+        select_protocol.side_effect = accept_before_delivery
+
+        delivered = deliver_agent_task(task=task)
+
+        self.assertEqual(delivered.status, NodeTask.Status.RUNNING)
+        self.assertIsNotNone(delivered.accepted_at)
+        send_command.assert_not_called()
 
     @patch("apps.node.services.internal.task.redis_store.set_task_info")
     @patch("apps.node.services.internal.task.redis_store.push_task_stream")
@@ -113,6 +163,153 @@ class TaskCommandAckTests(TestCase):
             protection_conf.PROTECTION_BACKUP_ACTIVITY_LEASE_SECONDS,
         )
 
+    @patch(
+        "apps.node.services.internal.task.redis_store.get_task_uplink_activities",
+        return_value={},
+    )
+    def test_pending_ack_task_is_not_execution_watchdog_timeout(self, _uplink_activity):
+        task = self.task(
+            watchdog_deadline_at=timezone.now() - timezone.timedelta(seconds=1),
+        )
+
+        marked = sweep_watchdog_timeouts(
+            queryset=NodeTask.objects.filter(pk=task.pk),
+        )
+
+        task.refresh_from_db()
+        self.assertEqual(marked, 0)
+        self.assertEqual(task.status, NodeTask.Status.PENDING)
+        self.assertLess(task.watchdog_deadline_at, timezone.now())
+
+    @patch(
+        "apps.node.services.internal.task.redis_store.get_task_uplink_activities",
+        return_value={},
+    )
+    def test_dispatched_ack_task_keeps_delivery_watchdog_after_capability_change(
+        self, _uplink_activity
+    ):
+        task = self.task(
+            delivery_attempt_count=1,
+            watchdog_deadline_at=timezone.now() - timezone.timedelta(seconds=1),
+        )
+        self.node.metadata = {"inventory": {"capabilities": []}}
+        self.node.save(update_fields=["metadata", "updated_at"])
+
+        marked = sweep_watchdog_timeouts(
+            queryset=NodeTask.objects.filter(pk=task.pk),
+        )
+
+        task.refresh_from_db()
+        self.assertEqual(marked, 0)
+        self.assertEqual(task.status, NodeTask.Status.PENDING)
+
+    @patch(
+        "apps.node.services.internal.task.redis_store.ws_recovery_hold_active",
+        return_value=False,
+    )
+    @patch("apps.node.services.internal.task.redis_store.set_task_info")
+    @patch("apps.node.services.internal.task._send_task_command")
+    @patch(
+        "apps.node.services.internal.task._node_route_state",
+        return_value=_RouteState.ONLINE,
+    )
+    def test_selected_ack_protocol_survives_capability_loss(
+        self, _route, _send_command, _set_info, _hold
+    ):
+        old = timezone.now() - timezone.timedelta(seconds=60)
+        task = deliver_agent_task(task=self.task())
+        self.assertEqual(task.result["_delivery_protocol"], "command_ack_v1")
+
+        self.node.metadata = {"inventory": {"capabilities": []}}
+        self.node.save(update_fields=["metadata", "updated_at"])
+        NodeTask.objects.filter(pk=task.pk).update(last_delivery_at=old)
+
+        summary = reconcile_unaccepted_agent_tasks(limit=10)
+
+        task.refresh_from_db()
+        self.assertEqual(summary["redelivered"], 1)
+        self.assertEqual(task.delivery_attempt_count, 2)
+
+    @patch(
+        "apps.node.services.internal.task.redis_store.ws_recovery_hold_active",
+        return_value=False,
+    )
+    @patch("apps.node.services.internal.task.redis_store.set_task_info")
+    @patch("apps.node.services.internal.task._send_task_command")
+    @patch(
+        "apps.node.services.internal.task._node_route_state",
+        return_value=_RouteState.ONLINE,
+    )
+    def test_legacy_candidate_does_not_starve_ack_reconciliation(
+        self, _route, _send_command, _set_info, _hold
+    ):
+        self.task(
+            correlation_id="legacy-task",
+            result={"_delivery_protocol": "legacy"},
+        )
+        ack_task = self.task(
+            correlation_id="ack-task",
+            result={"_delivery_protocol": "command_ack_v1"},
+            last_delivery_at=timezone.now() - timezone.timedelta(seconds=60),
+        )
+
+        summary = reconcile_unaccepted_agent_tasks(limit=1)
+
+        ack_task.refresh_from_db()
+        self.assertEqual(summary["candidates"], 1)
+        self.assertEqual(summary["redelivered"], 1)
+        self.assertEqual(ack_task.delivery_attempt_count, 1)
+
+    @patch(
+        "apps.node.services.internal.task.redis_store.ws_recovery_hold_active",
+        return_value=False,
+    )
+    def test_unknown_delivery_protocol_is_reclassified_instead_of_stranded(
+        self, _hold
+    ):
+        task = self.task(result={"_delivery_protocol": "future-protocol"})
+
+        summary = reconcile_unaccepted_agent_tasks(limit=10)
+
+        task.refresh_from_db()
+        self.assertEqual(summary["candidates"], 1)
+        self.assertEqual(task.result["_delivery_protocol"], "command_ack_v1")
+
+    @patch(
+        "apps.node.services.internal.task.redis_store.ws_recovery_hold_active",
+        return_value=True,
+    )
+    def test_recovery_hold_does_not_extend_unrelated_same_kind_task(self, _hold):
+        expired = timezone.now() - timezone.timedelta(seconds=1)
+        unrelated = self.task(
+            correlation_type="unrelated.workflow",
+            result={"_delivery_protocol": "command_ack_v1"},
+            watchdog_deadline_at=expired,
+        )
+
+        summary = reconcile_unaccepted_agent_tasks(limit=10)
+
+        unrelated.refresh_from_db()
+        self.assertTrue(summary["recovery_hold"])
+        self.assertEqual(unrelated.watchdog_deadline_at, expired)
+
+    @patch(
+        "apps.node.services.internal.task.redis_store.ws_recovery_hold_active",
+        return_value=True,
+    )
+    def test_recovery_hold_does_not_extend_unselected_legacy_candidate(self, _hold):
+        expired = timezone.now() - timezone.timedelta(seconds=1)
+        legacy = self.task(
+            correlation_id="unselected-legacy-task",
+            watchdog_deadline_at=expired,
+        )
+
+        summary = reconcile_unaccepted_agent_tasks(limit=10)
+
+        legacy.refresh_from_db()
+        self.assertTrue(summary["recovery_hold"])
+        self.assertEqual(legacy.watchdog_deadline_at, expired)
+
     @patch("apps.node.services.internal.task._send_cancel_command")
     @patch(
         "apps.node.services.internal.task_offline_reconcile.sync_platform_tasks_for_node_task"
@@ -151,10 +348,16 @@ class TaskCommandAckTests(TestCase):
         self.assertEqual(task.last_error, "watchdog timeout (no progress)")
         send_cancel.assert_called_once()
 
-    @patch("apps.node.services.internal.task.redis_store.ws_recovery_hold_active", return_value=False)
+    @patch(
+        "apps.node.services.internal.task.redis_store.ws_recovery_hold_active",
+        return_value=False,
+    )
     @patch("apps.node.services.internal.task.redis_store.set_task_info")
     @patch("apps.node.services.internal.task._send_task_command")
-    @patch("apps.node.services.internal.task._node_route_state", return_value=_RouteState.ONLINE)
+    @patch(
+        "apps.node.services.internal.task._node_route_state",
+        return_value=_RouteState.ONLINE,
+    )
     def test_retry_reuses_exact_node_task_id(
         self, _route, send_command, _set_info, _hold
     ):
@@ -172,19 +375,80 @@ class TaskCommandAckTests(TestCase):
         self.assertEqual(task.delivery_attempt_count, 2)
         self.assertEqual(send_command.call_args.kwargs["task"].id, task.id)
 
-    @patch("apps.node.services.internal.task.redis_store.ws_recovery_hold_active", return_value=True)
+    @patch(
+        "apps.node.services.internal.task.redis_store.ws_recovery_hold_active",
+        return_value=True,
+    )
     @patch("apps.node.services.internal.task._send_task_command")
     def test_recovery_hold_does_not_consume_retry(self, send_command, _hold):
-        task = self.task(delivery_attempt_count=1)
+        expired = timezone.now() - timezone.timedelta(seconds=1)
+        task = self.task(
+            delivery_attempt_count=1,
+            result={"_delivery_protocol": "command_ack_v1"},
+            watchdog_deadline_at=expired,
+        )
         summary = reconcile_unaccepted_agent_tasks(limit=10)
         task.refresh_from_db()
         self.assertTrue(summary["recovery_hold"])
         self.assertEqual(task.delivery_attempt_count, 1)
+        self.assertGreater(task.watchdog_deadline_at, timezone.now())
         send_command.assert_not_called()
+
+    @patch(
+        "apps.node.services.internal.task.redis_store.ws_recovery_hold_active",
+        return_value=False,
+    )
+    @patch("apps.node.services.internal.task.redis_store.set_task_info")
+    @patch("apps.node.services.internal.task.redis_store.push_task_stream")
+    @patch("apps.node.services.internal.task._send_cancel_command")
+    @patch(
+        "apps.node.services.internal.task._node_route_state",
+        return_value=_RouteState.RECONNECTING,
+    )
+    @patch(
+        "apps.node.services.internal.task_offline_reconcile.sync_platform_tasks_for_node_task"
+    )
+    def test_persistently_reconnecting_agent_has_bounded_delivery_wait(
+        self, sync_parent, _route, _cancel, _push, _set_info, _hold
+    ):
+        task = self.task(
+            result={"_delivery_protocol": "command_ack_v1"},
+            watchdog_deadline_at=timezone.now() - timezone.timedelta(seconds=1),
+        )
+
+        summary = reconcile_unaccepted_agent_tasks(limit=10)
+
+        task.refresh_from_db()
+        self.assertEqual(summary["timed_out"], 1)
+        self.assertEqual(task.status, NodeTask.Status.TIMEOUT)
+        self.assertEqual(
+            task.result["diagnostic_error_code"],
+            "AGENT_CONNECTION_UNSTABLE",
+        )
+        self.assertNotIn("_delivery_protocol", task.result)
+        sync_parent.assert_called_once()
 
     @patch("apps.node.services.internal.task._schedule_agent_task_redelivery")
     @patch("apps.node.services.internal.task.redis_store.set_task_info")
-    @patch("apps.node.services.internal.task.redis_store.ws_recovery_hold_active", return_value=True)
+    @patch(
+        "apps.node.services.internal.task._node_route_state",
+        return_value=_RouteState.RECONNECTING,
+    )
+    def test_reconnecting_ack_task_relies_on_coalesced_reconciliation(
+        self, _route, _set_info, schedule_redelivery
+    ):
+        task = deliver_agent_task(task=self.task())
+
+        self.assertEqual(task.status, NodeTask.Status.PENDING)
+        self.assertEqual(task.result["_delivery_protocol"], "command_ack_v1")
+        schedule_redelivery.assert_not_called()
+
+    @patch("apps.node.services.internal.task._schedule_agent_task_redelivery")
+    @patch("apps.node.services.internal.task.redis_store.set_task_info")
+    @patch(
+        "apps.node.services.internal.task.redis_store.ws_recovery_hold_active",
+        return_value=True,
+    )
     @patch("apps.node.services.internal.task._send_task_command")
     def test_recovery_hold_delays_legacy_first_delivery(
         self, send_command, _hold, _set_info, schedule_redelivery
@@ -196,15 +460,82 @@ class TaskCommandAckTests(TestCase):
         self.assertEqual(task.status, NodeTask.Status.PENDING)
         self.assertEqual(task.delivery_attempt_count, 0)
         self.assertEqual(task.last_error, "agent websocket is reconnecting")
+        self.assertEqual(
+            task.result["diagnostic_error_code"],
+            "AGENT_CONNECTION_UNSTABLE",
+        )
         send_command.assert_not_called()
         schedule_redelivery.assert_called_once()
 
-    @patch("apps.node.services.internal.task.redis_store.ws_recovery_hold_active", return_value=False)
+    @patch("apps.node.services.internal.task.redis_store.set_task_info")
+    @patch(
+        "apps.node.services.internal.task._node_route_state",
+        return_value=_RouteState.OFFLINE,
+    )
+    def test_unroutable_ack_delivery_records_structured_diagnostic(
+        self, _route, _set_info
+    ):
+        task = deliver_agent_task(task=self.task())
+
+        self.assertEqual(task.status, NodeTask.Status.PENDING)
+        self.assertEqual(task.last_error, "agent websocket is not routable")
+        self.assertEqual(
+            task.result["diagnostic_error_code"],
+            "AGENT_UNAVAILABLE",
+        )
+
+        accepted = accept_task(task_id=task.id, node_id=self.node.id)
+        self.assertEqual(accepted.status, NodeTask.Status.RUNNING)
+        self.assertNotIn("diagnostic_error_code", accepted.result)
+
+    @patch("apps.node.services.internal.task.redis_store.set_task_info")
+    @patch(
+        "apps.node.services.internal.task._node_route_state",
+        return_value=_RouteState.ONLINE,
+    )
+    @patch(
+        "apps.node.services.internal.task._send_task_command",
+        side_effect=RedisConnectionError("redis unavailable"),
+    )
+    def test_redis_downlink_failure_remains_durable_pending_ack(
+        self, _send, _route, _set_info
+    ):
+        task = deliver_agent_task(task=self.task())
+
+        self.assertEqual(task.status, NodeTask.Status.PENDING)
+        self.assertEqual(task.delivery_attempt_count, 1)
+        self.assertEqual(task.result["diagnostic_error_code"], "AGENT_DELIVERY_FAILED")
+
+    @patch("apps.node.services.internal.task.redis_store.set_task_info")
+    @patch("apps.node.services.internal.task.redis_store.push_task_stream")
+    @patch(
+        "apps.node.ws.downlink.send_task_cancel",
+        side_effect=RedisConnectionError("redis unavailable"),
+    )
+    def test_redis_cancel_failure_does_not_roll_back_terminal_state(
+        self, _send_cancel, _push, _set_info
+    ):
+        task = cancel_task(task_id=self.task().id, reason="user canceled")
+
+        self.assertIsNotNone(task)
+        self.assertEqual(task.status, NodeTask.Status.CANCELED)
+        task.refresh_from_db()
+        self.assertEqual(task.status, NodeTask.Status.CANCELED)
+
+    @patch(
+        "apps.node.services.internal.task.redis_store.ws_recovery_hold_active",
+        return_value=False,
+    )
     @patch("apps.node.services.internal.task.redis_store.set_task_info")
     @patch("apps.node.services.internal.task.redis_store.push_task_stream")
     @patch("apps.node.services.internal.task._send_cancel_command")
-    @patch("apps.node.services.internal.task._node_route_state", return_value=_RouteState.ONLINE)
-    @patch("apps.node.services.internal.task_offline_reconcile.sync_platform_tasks_for_node_task")
+    @patch(
+        "apps.node.services.internal.task._node_route_state",
+        return_value=_RouteState.ONLINE,
+    )
+    @patch(
+        "apps.node.services.internal.task_offline_reconcile.sync_platform_tasks_for_node_task"
+    )
     def test_retry_exhaustion_seals_timeout_against_late_result(
         self, sync_parent, _route, _cancel, _push, _set_info, _hold
     ):
@@ -233,10 +564,71 @@ class TaskCommandAckTests(TestCase):
 
     @patch("apps.node.services.internal.task.redis_store.set_task_info")
     @patch("apps.node.services.internal.task._send_task_command")
-    @patch("apps.node.services.internal.task._node_route_state", return_value=_RouteState.ONLINE)
+    @patch(
+        "apps.node.services.internal.task._node_route_state",
+        return_value=_RouteState.ONLINE,
+    )
     def test_legacy_agent_keeps_send_then_running(self, _route, _send, _set_info):
         self.node.metadata = {"inventory": {"capabilities": []}}
         self.node.save(update_fields=["metadata", "updated_at"])
         task = deliver_agent_task(task=self.task())
         self.assertEqual(task.status, NodeTask.Status.RUNNING)
         self.assertIsNone(task.accepted_at)
+        self.assertNotIn("_delivery_protocol", task.result)
+
+    @patch("apps.node.services.internal.task.redis_store.set_task_info")
+    @patch(
+        "apps.node.services.internal.task._node_route_state",
+        return_value=_RouteState.ONLINE,
+    )
+    def test_legacy_delivery_does_not_overwrite_fast_terminal_result(
+        self, _route, _set_info
+    ):
+        self.node.metadata = {"inventory": {"capabilities": []}}
+        self.node.save(update_fields=["metadata", "updated_at"])
+        task = self.task()
+
+        def complete_during_send(*, task):
+            NodeTask.objects.filter(pk=task.pk).update(
+                status=NodeTask.Status.SUCCESS,
+                accepted_at=timezone.now(),
+                result={"completed": True},
+            )
+
+        with patch(
+            "apps.node.services.internal.task._send_task_command",
+            side_effect=complete_during_send,
+        ):
+            delivered = deliver_agent_task(task=task)
+
+        self.assertEqual(delivered.status, NodeTask.Status.SUCCESS)
+        self.assertEqual(delivered.result, {"completed": True})
+
+    @patch("apps.node.services.internal.task.redis_store.set_task_info")
+    @patch(
+        "apps.node.services.internal.task._node_route_state",
+        return_value=_RouteState.ONLINE,
+    )
+    def test_legacy_transport_error_does_not_overwrite_fast_terminal_result(
+        self, _route, _set_info
+    ):
+        self.node.metadata = {"inventory": {"capabilities": []}}
+        self.node.save(update_fields=["metadata", "updated_at"])
+        task = self.task()
+
+        def complete_then_raise(*, task):
+            NodeTask.objects.filter(pk=task.pk).update(
+                status=NodeTask.Status.SUCCESS,
+                accepted_at=timezone.now(),
+                result={"completed": True},
+            )
+            raise RedisConnectionError("ambiguous transport failure")
+
+        with patch(
+            "apps.node.services.internal.task._send_task_command",
+            side_effect=complete_then_raise,
+        ):
+            delivered = deliver_agent_task(task=task)
+
+        self.assertEqual(delivered.status, NodeTask.Status.SUCCESS)
+        self.assertEqual(delivered.result, {"completed": True})

--- a/src/backend/apps/node/ws/uplink.py
+++ b/src/backend/apps/node/ws/uplink.py
@@ -5,6 +5,7 @@ Agent WebSocket session and uplink for lifecycle and task frames.
 from __future__ import annotations
 
 import logging
+from typing import TYPE_CHECKING
 
 from django.db import DatabaseError, transaction
 from django.utils import timezone
@@ -33,10 +34,19 @@ from apps.source.services.internal.agent_host_sync import sync_agent_source_host
 
 logger = logging.getLogger(__name__)
 
+if TYPE_CHECKING:
+    from redis import Redis
+
 
 def on_agent_connected(*, node_id: int, session_id: str, client_ip: str | None = None) -> None:
-    redis_store.set_agent_location(agent_id=node_id, session_id=session_id)
-    redis_store.touch_ws_instance_alive()
+    redis_client = redis_store.get_redis()
+    route_recorded = redis_store.set_agent_location(
+        agent_id=node_id,
+        session_id=session_id,
+        redis_client=redis_client,
+    )
+    if route_recorded:
+        redis_store.touch_ws_instance_alive(redis_client=redis_client)
     observed_at = timezone.now()
     updates: dict = {
         "last_seen_at": observed_at,
@@ -55,13 +65,18 @@ def on_agent_connected(*, node_id: int, session_id: str, client_ip: str | None =
         session_id,
         client_ip or "-",
     )
-    _schedule_lifecycle_advance(node_id=node_id)
+    _schedule_lifecycle_advance(
+        node_id=node_id,
+        redis_client=redis_client if route_recorded else None,
+    )
 
 
 def on_agent_disconnected(*, node_id: int, session_id: str) -> None:
+    redis_client = redis_store.get_redis()
     if not redis_store.clear_agent_location_if_session(
         agent_id=node_id,
         session_id=session_id,
+        redis_client=redis_client,
     ):
         logger.info(
             "agent ws disconnected ignored (superseded session) node_id=%s session=%s",
@@ -89,13 +104,39 @@ def on_agent_disconnected(*, node_id: int, session_id: str) -> None:
             node_id,
             exc_info=True,
         )
-    _schedule_lifecycle_advance(node_id=node_id)
+    _schedule_lifecycle_advance(node_id=node_id, redis_client=redis_client)
 
 
-def _schedule_lifecycle_advance(*, node_id: int) -> None:
+def _schedule_lifecycle_advance(
+    *,
+    node_id: int,
+    redis_client: Redis | None,
+) -> None:
+    if not redis_store.claim_lifecycle_advance_event(
+        node_id=int(node_id),
+        redis_client=redis_client,
+    ):
+        logger.debug(
+            "Agent lifecycle wake-up coalesced or deferred node_id=%s",
+            node_id,
+        )
+        return
     from apps.node.tasks.lifecycle import advance_node_lifecycle_for_node
 
-    advance_node_lifecycle_for_node.delay(node_id=int(node_id))
+    try:
+        advance_node_lifecycle_for_node.apply_async(
+            kwargs={"node_id": int(node_id)},
+            expires=node_conf.LIFECYCLE_ADVANCE_EXPIRE_SECONDS,
+        )
+    except Exception:
+        # Connection state is authoritative in Redis/PostgreSQL and the
+        # periodic lifecycle sweep will retry after broker recovery.  A
+        # disposable wake-up must never tear down a healthy WebSocket.
+        logger.warning(
+            "failed to enqueue Agent lifecycle wake-up node_id=%s",
+            node_id,
+            exc_info=True,
+        )
 
 
 def handle_uplink(*, node_id: int, message: ParsedUplink) -> NodeTask | None:

--- a/src/backend/apps/protection/services/backup_orchestrator.py
+++ b/src/backend/apps/protection/services/backup_orchestrator.py
@@ -21,7 +21,6 @@ from apps.node.models import Node, NodeTask
 from apps.node.services.internal.node_registry import effective_agent_node_status
 from apps.node.services.interface import (
     cancel_agent_task,
-    deliver_agent_task,
     redeliver_pending_agent_task,
     run_agent_task_async,
 )
@@ -95,6 +94,24 @@ _DIRECTORY_IN_PROGRESS = frozenset(
     }
 )
 
+_DELIVERY_DIAGNOSTIC_MESSAGES = {
+    "AGENT_ACK_TIMEOUT": (
+        "The Agent did not acknowledge the backup command. Check Agent "
+        "connectivity and version, then retry."
+    ),
+    "AGENT_CONNECTION_UNSTABLE": (
+        "The Agent connection remained unstable. Check the Agent service, "
+        "host disk, and network, then retry."
+    ),
+    "AGENT_UNAVAILABLE": (
+        "The Agent is unavailable. Bring the Agent online, then retry."
+    ),
+    "AGENT_DELIVERY_FAILED": (
+        "The backup command could not be delivered. Check platform and Agent "
+        "connectivity, then retry."
+    ),
+}
+
 
 def _bt():
     from apps.protection.services import backup_task as backup_task_module
@@ -106,13 +123,29 @@ def _directory_in_progress(status: str) -> bool:
     return str(status or "").strip().lower() in _DIRECTORY_IN_PROGRESS
 
 
+def _redeliver_pending_node_task_after_commit(*, node_task: NodeTask) -> None:
+    """Resume persisted work only after the orchestration transaction commits."""
+    task_id = str(node_task.id)
+    transaction.on_commit(
+        lambda bound_task_id=task_id: redeliver_pending_agent_task(
+            task_id=bound_task_id
+        )
+    )
+
+
 def _node_task_error_code(node_task: NodeTask) -> tuple[str, str]:
     bt = _bt()
     last_error = str(node_task.last_error or "").strip()
     lower = last_error.lower()
+    result = node_task.result if isinstance(node_task.result, dict) else {}
+    diagnostic_error = str(result.get("diagnostic_error_code") or "")
+    if (
+        node_task.status in {NodeTask.Status.FAILED, NodeTask.Status.TIMEOUT}
+        and diagnostic_error in _DELIVERY_DIAGNOSTIC_MESSAGES
+    ):
+        return diagnostic_error, _DELIVERY_DIAGNOSTIC_MESSAGES[diagnostic_error]
     if node_task.status == NodeTask.Status.TIMEOUT:
-        result = node_task.result if isinstance(node_task.result, dict) else {}
-        if str(result.get("diagnostic_error_code") or "") == "RESULT_ACK_TIMEOUT":
+        if diagnostic_error == "RESULT_ACK_TIMEOUT":
             return "RESULT_ACK_TIMEOUT", last_error or "Agent result acknowledgement timed out."
         return "WATCHDOG_STALL", last_error or "Agent task watchdog timed out."
     if node_task.status == NodeTask.Status.CANCELED:
@@ -126,7 +159,6 @@ def _node_task_error_code(node_task: NodeTask) -> tuple[str, str]:
     if "signal" in lower or "sigkill" in lower or "exit 137" in lower or "exit 9" in lower:
         return "KOPIA_SIGNAL_KILLED", last_error or "Kopia process was killed."
     if node_task.status == NodeTask.Status.FAILED:
-        result = node_task.result if isinstance(node_task.result, dict) else {}
         structured_error = str(result.get("error_code") or "")
         if structured_error == "KOPIA_SNAPSHOT_RECONCILE_FAILED":
             return (
@@ -441,7 +473,7 @@ def _ensure_repository_server_payload(
                     }
                 )
             if node_task.status == NodeTask.Status.PENDING:
-                deliver_agent_task(task=node_task)
+                _redeliver_pending_node_task_after_commit(node_task=node_task)
             return None
 
     public_host, public_host_source = _repository_public_host(repository=repository, node=repository_node)
@@ -558,7 +590,7 @@ def _ensure_source_repository_probe(
                     }
                 )
             if node_task.status == NodeTask.Status.PENDING:
-                deliver_agent_task(task=node_task)
+                _redeliver_pending_node_task_after_commit(node_task=node_task)
             return False
 
     handle = run_agent_task_async(
@@ -605,7 +637,10 @@ def _mark_policy_prepare_failed(
     node_task: NodeTask,
 ) -> None:
     error_code, error_message = _node_task_error_code(node_task)
-    if error_code != "POLICY_APPLY_FAILED":
+    if (
+        error_code != "POLICY_APPLY_FAILED"
+        and error_code not in _DELIVERY_DIAGNOSTIC_MESSAGES
+    ):
         error_code = "POLICY_APPLY_FAILED"
     record_source_snapshot_directory_result(
         source_snapshot=source_snapshot,
@@ -667,7 +702,7 @@ def _ensure_directory_policy_prepared(
         return "prepared"
     if latest is not None and latest.status not in _NODE_TASK_TERMINAL:
         if latest.status == NodeTask.Status.PENDING:
-            deliver_agent_task(task=latest)
+            _redeliver_pending_node_task_after_commit(node_task=latest)
         return "waiting"
 
     max_attempts = 1 + max(0, protection_conf.PROTECTION_BACKUP_POLICY_PREPARE_MAX_RETRIES)
@@ -901,7 +936,7 @@ def _dispatch_directory_backup(
             update_fields=["status", "node_task_id", "dispatched_at", "updated_at"]
         )
         if existing.status == NodeTask.Status.PENDING:
-            deliver_agent_task(task=existing)
+            _redeliver_pending_node_task_after_commit(node_task=existing)
         return
 
     ensure_snapshot_repository_locator(
@@ -1432,14 +1467,19 @@ def _observe_running_directory(
                     },
                 )
         else:
-            if not node_online and node_task.status in {
-                NodeTask.Status.FAILED,
-                NodeTask.Status.TIMEOUT,
-            }:
+            error_code, error_message = _node_task_error_code(node_task)
+            if (
+                error_code not in _DELIVERY_DIAGNOSTIC_MESSAGES
+                and not node_online
+                and node_task.status in {
+                    NodeTask.Status.FAILED,
+                    NodeTask.Status.TIMEOUT,
+                }
+            ):
                 error_code = "AGENT_OFFLINE"
-                error_message = str(node_task.last_error or "Agent went offline during backup.")
-            else:
-                error_code, error_message = _node_task_error_code(node_task)
+                error_message = str(
+                    node_task.last_error or "Agent went offline during backup."
+                )
             if (
                 error_code == "AGENT_RESTARTED"
                 and node_task.status != NodeTask.Status.CANCELED
@@ -1619,7 +1659,7 @@ def _observe_running_directory(
         pending_limit = protection_conf.PROTECTION_BACKUP_DISPATCH_PENDING_SECONDS
         if node_task.status == NodeTask.Status.PENDING and directory_row.dispatched_at:
             if (timezone.now() - directory_row.dispatched_at).total_seconds() > pending_limit:
-                redeliver_pending_agent_task(task_id=node_task.id)
+                _redeliver_pending_node_task_after_commit(node_task=node_task)
         if node_task.status == NodeTask.Status.RUNNING:
             _handle_directory_stall(
                 task=task,

--- a/src/backend/apps/protection/tests/test_backup_orchestrator_errors.py
+++ b/src/backend/apps/protection/tests/test_backup_orchestrator_errors.py
@@ -1,10 +1,35 @@
+import uuid
+from unittest.mock import patch
+
 from django.test import SimpleTestCase
 
 from apps.node.models import NodeTask
-from apps.protection.services.backup_orchestrator import _node_task_error_code
+from apps.protection.services.backup_orchestrator import (
+    _node_task_error_code,
+    _redeliver_pending_node_task_after_commit,
+)
 
 
 class BackupOrchestratorErrorCodeTests(SimpleTestCase):
+    def test_pending_task_resume_runs_after_commit(self):
+        node_task = NodeTask(id=uuid.uuid4())
+
+        with (
+            patch(
+                "apps.protection.services.backup_orchestrator.transaction.on_commit"
+            ) as on_commit,
+            patch(
+                "apps.protection.services.backup_orchestrator.redeliver_pending_agent_task"
+            ) as redeliver,
+        ):
+            _redeliver_pending_node_task_after_commit(node_task=node_task)
+
+            redeliver.assert_not_called()
+            callback = on_commit.call_args.args[0]
+            callback()
+
+        redeliver.assert_called_once_with(task_id=str(node_task.id))
+
     def test_result_ack_timeout_is_preserved(self):
         task = NodeTask(
             status=NodeTask.Status.TIMEOUT,
@@ -16,3 +41,27 @@ class BackupOrchestratorErrorCodeTests(SimpleTestCase):
             _node_task_error_code(task),
             ("RESULT_ACK_TIMEOUT", "result acknowledgement timeout"),
         )
+
+    def test_agent_connection_diagnostic_is_not_projected_as_watchdog_stall(self):
+        task = NodeTask(
+            status=NodeTask.Status.TIMEOUT,
+            last_error="AGENT_CONNECTION_UNSTABLE: reconnecting",
+            result={"diagnostic_error_code": "AGENT_CONNECTION_UNSTABLE"},
+        )
+
+        error_code, message = _node_task_error_code(task)
+
+        self.assertEqual(error_code, "AGENT_CONNECTION_UNSTABLE")
+        self.assertIn("connection remained unstable", message)
+
+    def test_failed_delivery_diagnostic_is_preserved(self):
+        task = NodeTask(
+            status=NodeTask.Status.FAILED,
+            last_error="agent websocket is not routable",
+            result={"diagnostic_error_code": "AGENT_UNAVAILABLE"},
+        )
+
+        error_code, message = _node_task_error_code(task)
+
+        self.assertEqual(error_code, "AGENT_UNAVAILABLE")
+        self.assertIn("Bring the Agent online", message)


### PR DESCRIPTION
## Summary
- coalesce lifecycle wake-ups from flapping Agent WebSocket sessions and fail safely when Redis or the broker is unavailable
- persist the selected command delivery protocol, bound ACK retries, and preserve PostgreSQL as the authoritative task state
- move backup redelivery outside orchestration transactions and preserve newer terminal results across ambiguous legacy transport failures
- project clear delivery diagnostics for unstable, unavailable, and unacknowledged Agents

## Validation
- 324 Node tests passed
- 95 targeted Node and backup orchestration tests passed again after rebasing onto the latest main
- Ruff and git diff checks passed
- 50 of 51 backup task API tests passed; the remaining storage-exhaustion 403-versus-201 assertion is an existing main-branch baseline mismatch unrelated to this PR

Addresses #713
Related to #118