### PR TITLE
fix(protection): preserve completed restore progress

### DIFF
--- a/src/backend/apps/protection/services/progress/aggregator.py
+++ b/src/backend/apps/protection/services/progress/aggregator.py
@@ -71,9 +71,10 @@ def aggregate_lanes(lanes: list[dict[str, Any]]) -> dict[str, Any]:
         estimated_bytes += int(normalized.get("estimated_bytes") or 0)
         lane_processed = int(normalized.get("processed_count") or 0)
         lane_total_count = int(normalized.get("total_count") or 0)
-        if status in _ACTIVE_STATUSES and normalized.get("is_transfer"):
+        if status in (_ACTIVE_STATUSES | _DONE_STATUSES) and normalized.get("is_transfer"):
             processed_count = max(processed_count, lane_processed)
             total_count = max(total_count, lane_total_count)
+        if status in _ACTIVE_STATUSES and normalized.get("is_transfer"):
             lane_path_index = normalized.get("path_index")
             lane_path_total = normalized.get("path_total")
             if lane_path_index is not None:

--- a/src/backend/apps/protection/tests/test_kopia_progress.py
+++ b/src/backend/apps/protection/tests/test_kopia_progress.py
@@ -58,6 +58,36 @@ class KopiaProgressAggregatorTests(SimpleTestCase):
         self.assertEqual(aggregate["upload_speed_bps"], 3_000_000)
         self.assertEqual(aggregate["eta_seconds"], 1500)
 
+    def test_completed_restore_lane_retains_final_item_counts(self):
+        lanes = [
+            {
+                "id": "1",
+                "name": "/data",
+                "status": "success",
+                "progress": normalize_lane_progress(
+                    progress={
+                        "phase": "kopia_transfer",
+                        "kopia_phase": "restoring",
+                        "processed_bytes": 649_000_000,
+                        "bytes_total": 649_000_000,
+                        "bytes_total_known": True,
+                        "processed_count": 263,
+                        "total_count": 263,
+                        "speed_bps": 5_000_000,
+                    },
+                    status="success",
+                ),
+            },
+        ]
+
+        aggregate = aggregate_lanes(lanes)
+
+        self.assertEqual(aggregate["processed_count"], 263)
+        self.assertEqual(aggregate["total_count"], 263)
+        self.assertEqual(aggregate["bytes_done"], 649_000_000)
+        self.assertIsNone(aggregate["speed_bps"])
+        self.assertIsNone(aggregate["eta_seconds"])
+
     def test_schema_v2_3ec_uses_processed_bytes_for_progress(self):
         processed = 3_478_373_863
         estimated = 4_130_621_356

--- a/src/frontend/src/pages/protection/RestoreRecordNavigation.test.ts
+++ b/src/frontend/src/pages/protection/RestoreRecordNavigation.test.ts
@@ -56,7 +56,9 @@ describe('restore record contextual navigation', () => {
   })
 
   it('shows runtime metrics with an explicit unavailable fallback', () => {
-    expect(drawer).toContain('restoreRecordRuntimeMetricParts(t, restoreRecordRuntime(record))')
+    expect(drawer).toContain('restoreRecordRuntimeMetricParts(')
+    expect(drawer).toContain('restoreRecordRuntime(record)')
+    expect(drawer).toContain('restoreRecordTaskStatus(record)')
     expect(drawer).toContain("t('protection.backupsPage.flowRestoreRecordMetricsUnavailable')")
     expect(drawer).toContain('@click.stop="openTaskDetailByUuid(row.task_uuid)"')
   })

--- a/src/frontend/src/pages/protection/components/FlowBackupSourceDetailDrawer.vue
+++ b/src/frontend/src/pages/protection/components/FlowBackupSourceDetailDrawer.vue
@@ -1108,7 +1108,11 @@ function restoreRecordRuntimeLoading(record: RestoreRecord) {
 }
 
 function restoreRecordMetrics(record: RestoreRecord) {
-  return restoreRecordRuntimeMetricParts(t, restoreRecordRuntime(record))
+  return restoreRecordRuntimeMetricParts(
+    t,
+    restoreRecordRuntime(record),
+    restoreRecordTaskStatus(record),
+  )
 }
 
 async function loadRestoreRecordRuntime(record: RestoreRecord) {

--- a/src/frontend/src/pages/protection/components/restoreRecordDisplay.test.ts
+++ b/src/frontend/src/pages/protection/components/restoreRecordDisplay.test.ts
@@ -119,4 +119,39 @@ describe('restore record display', () => {
       transfer_progress: { phase: 'done' },
     })).toEqual([])
   })
+
+  it('hides total-only metrics for a successful restore', () => {
+    expect(restoreRecordRuntimeMetricParts((key) => key, {
+      transfer_progress: {
+        phase: 'done',
+        processed_count: 0,
+        total_count: 263,
+        bytes_done: 0,
+        bytes_total: 649_000_000,
+        bytes_total_known: true,
+      },
+    }, 'success')).toEqual([])
+  })
+
+  it('keeps valid final metrics for a successful restore', () => {
+    const t = (key: string, args?: Record<string, unknown>) => {
+      if (key.endsWith('flowRestoreRecordItemsProgress')) return `${args?.done} / ${args?.total} items processed`
+      if (key.endsWith('bytesCapacity')) return `${args?.done} / ${args?.total}`
+      return key
+    }
+
+    expect(restoreRecordRuntimeMetricParts(t, {
+      transfer_progress: {
+        phase: 'done',
+        processed_count: 263,
+        total_count: 263,
+        bytes_done: 649_000_000,
+        bytes_total: 649_000_000,
+        bytes_total_known: true,
+      },
+    }, 'success')).toEqual([
+      '263 / 263 items processed',
+      '649 MB / 649 MB',
+    ])
+  })
 })

--- a/src/frontend/src/pages/protection/components/restoreRecordDisplay.ts
+++ b/src/frontend/src/pages/protection/components/restoreRecordDisplay.ts
@@ -1,6 +1,7 @@
 import type { RestoreRecord, RestoreRecordItem } from '../../../lib/restoreApi'
 import {
   formatCount,
+  transferCapacityText,
   transferMetricParts,
   type TaskRuntimePayload,
   type TransferProgress,
@@ -77,6 +78,7 @@ function positiveCount(value: number | null | undefined) {
 export function restoreRecordRuntimeMetricParts(
   t: TranslateFn,
   runtime?: TaskRuntimePayload | null,
+  taskStatus = '',
 ): string[] {
   const transfer = runtime?.transfer_progress
   if (!transfer) return []
@@ -84,6 +86,26 @@ export function restoreRecordRuntimeMetricParts(
   const parts: string[] = []
   const processed = positiveCount(transfer.processed_count)
   const total = positiveCount(transfer.total_count)
+  const status = String(taskStatus).trim().toLowerCase()
+  const completed = ['success', 'succeeded', 'completed'].includes(status)
+  if (completed) {
+    if (processed > 0) {
+      parts.push(total > 0
+        ? t('protection.backupsPage.flowRestoreRecordItemsProgress', {
+            done: formatCount(processed),
+            total: formatCount(total),
+          })
+        : t('protection.backupsPage.flowRestoreRecordItemsProcessed', {
+            n: formatCount(processed),
+          }))
+    }
+    const processedBytes = Number(transfer.processed_bytes ?? transfer.bytes_done ?? 0)
+    if (Number.isFinite(processedBytes) && processedBytes > 0) {
+      const capacity = transferCapacityText(t, transfer as TransferProgress)
+      if (capacity) parts.push(capacity)
+    }
+    return parts
+  }
   if (total > 0) {
     parts.push(t('protection.backupsPage.flowRestoreRecordItemsProgress', {
       done: formatCount(processed),


### PR DESCRIPTION
## Summary

- retain observed restore item counters after transfer lanes complete
- keep speed, ETA, and active path data limited to active transfer lanes
- show an unavailable fallback for successful legacy records that only carry
  snapshot totals instead of presenting fabricated zero progress
- preserve live zero progress and valid completed item and byte metrics

## Validation

- Backend targeted restore progress tests: 29 passed
- Backend Community suite: 1,836 passed, 2 skipped
- Frontend targeted restore display/navigation tests: 19 passed
- Frontend Community suite: 1,138 passed
- Backend Ruff and frontend ESLint: passed
- Frontend production build: passed
- Language-pack build and contract tests: passed
- English source boundary and diff checks: passed
- Manual testing: passed

Fixes #731
