### PR TITLE
Fence active backup source operations

### DIFF
--- a/language-packs/packs/zh-hans/frontend/messages.json
+++ b/language-packs/packs/zh-hans/frontend/messages.json
@@ -59,7 +59,7 @@
       "agentNasMountFailed": "NAS 挂载失败，请检查连接设置",
       "agentTaskFailed": "Agent 任务失败，请稍后重试",
       "backupQuotaExceeded": "备份配额已用尽，请升级订阅后重试",
-      "backupAlreadyRunning": "该备份源已有任务正在运行",
+      "backupAlreadyRunning": "该备份源的备份正在启动或运行。请先停止备份或等待其完成，再继续操作。",
       "restoreAlreadyRunning": "该备份源已有恢复任务正在运行",
       "storageRepositoryOperationNotCancellable": "只能取消控制器管理的 S3 维护任务。",
       "storageRepositoryOperationNotActive": "本次维护任务已经完成。刷新即可查看其最新状态。",

--- a/language-packs/packs/zh-hans/frontend/source-lock.json
+++ b/language-packs/packs/zh-hans/frontend/source-lock.json
@@ -93,7 +93,7 @@
   "errors.codes.subscriptionQuotaExceededInstance": "7f628c504ac2a9ad7f1cb0ba1d686c69e35e4002b86d0c092622c3739095fc0e",
   "errors.codes.subscriptionQuotaExceededInstanceMeter": "f2abc8a6a66b8dc7cce20472185e81ce385fc9107f536ab66627eb170d36e427",
   "errors.codes.subscriptionQuotaExceededGateway": "4f8344bbd55f0cdfe8a16bea23e5296c7f6b1d4099f5a02e37f62f29dd480658",
-  "errors.codes.backupAlreadyRunning": "4cc9cada290776d88d98499e10fcba928670b637570d8dadc8378877f84ca1b4",
+  "errors.codes.backupAlreadyRunning": "f37ed00420cd9f4ccf8aef7042c458233f2c8c5cdaaf32ca311179bdafb5289a",
   "errors.codes.restoreAlreadyRunning": "c9f99280daa4f7b845b9c0c92af4017ead98f0e44cfb5b20184da6374ea059b9",
   "feedback.toast.copy": "4f60d1e142affa9c95598f06cc5fd65a39395ea317819d200f25e466661ccc7c",
   "feedback.toast.copied": "07e04484867c17d3626164b546b3b5dc0c965de9895c5ae9b2031bfae10bdec7",

--- a/src/backend/apps/node/tests/test_node_api_org_scoping.py
+++ b/src/backend/apps/node/tests/test_node_api_org_scoping.py
@@ -7,6 +7,7 @@ from rest_framework.test import APITestCase
 from apps.iam.services.registration_service import provision_registered_user_tenant
 from apps.node.models import Node, NodeTask, NodeToken
 from apps.node.models.base import NodeRole
+from apps.task.models import Task, TaskResource
 
 User = get_user_model()
 
@@ -57,6 +58,33 @@ class NodeApiOrgScopingTests(APITestCase):
             HTTP_X_ORG_KEY=self.org_a.key,
         )
         self.assertEqual(detail.status_code, status.HTTP_200_OK)
+
+    def test_node_display_name_can_change_while_backup_is_active(self):
+        backup_task = Task.objects.create(
+            organization_id=self.org_a.id,
+            task_type=Task.Type.BACKUP,
+            display_name="Active backup",
+            status=Task.Status.RUNNING,
+        )
+        TaskResource.objects.create(
+            task=backup_task,
+            resource_type=TaskResource.Type.BACKUP_SOURCE,
+            resource_subtype="agent",
+            resource_id=self.node_a.id,
+            is_primary=True,
+        )
+        self.client.force_authenticate(user=self.user_a)
+
+        response = self.client.patch(
+            reverse("node-detail", kwargs={"pk": self.node_a.id}),
+            {"name": "agent-a-renamed"},
+            format="json",
+            HTTP_X_ORG_KEY=self.org_a.key,
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.node_a.refresh_from_db()
+        self.assertEqual(self.node_a.name, "agent-a-renamed")
 
     def test_node_list_is_scoped_to_x_org_key(self):
         self.client.force_authenticate(user=self.user_a)

--- a/src/backend/apps/protection/services/backup_config_reset.py
+++ b/src/backend/apps/protection/services/backup_config_reset.py
@@ -320,6 +320,7 @@ def _reset_block_message(
     return ""
 
 
+@transaction.atomic
 def create_reset_tasks_for_sources(
     *,
     organization_id: int,
@@ -328,6 +329,20 @@ def create_reset_tasks_for_sources(
 ) -> dict[str, Any]:
     if confirmation != "RESET":
         raise ValidationError({"confirmation": "Type RESET exactly to confirm reset."})
+    parsed_sources = [
+        parsed
+        for source_id in source_ids
+        if (parsed := _source_from_id(source_id)) is not None
+    ]
+    if parsed_sources:
+        from apps.source.services.internal.source_operation_fence import (
+            assert_no_active_backup_for_sources,
+        )
+
+        assert_no_active_backup_for_sources(
+            organization_id=organization_id,
+            sources=parsed_sources,
+        )
     results: list[dict[str, Any]] = []
     for source_id in source_ids:
         parsed = _source_from_id(source_id)

--- a/src/backend/apps/protection/tests/test_backup_config_api.py
+++ b/src/backend/apps/protection/tests/test_backup_config_api.py
@@ -2100,6 +2100,99 @@ class ProtectionBackupConfigApiTests(TestCase):
         self.assertEqual(str(config.reset_task_uuid), str(task.task_uuid))
         delay.assert_not_called()
 
+    def test_reset_backup_config_rejects_active_backup_before_creating_task(self):
+        create = self.client.post(
+            "/api/v1/protection/backup-configs/",
+            self._payload(name="Reset blocked by active backup"),
+            format="json",
+            **self._headers(),
+        )
+        self.assertEqual(create.status_code, status.HTTP_201_CREATED, create.content)
+        backup_task = Task.objects.create(
+            organization_id=self.org.id,
+            task_type=Task.Type.BACKUP,
+            display_name="Active backup",
+            status=Task.Status.PENDING,
+        )
+        TaskResource.objects.create(
+            task=backup_task,
+            resource_type=TaskResource.Type.BACKUP_SOURCE,
+            resource_subtype="agent",
+            resource_id=self.agent.id,
+            is_primary=True,
+        )
+
+        for active_status in (
+            Task.Status.PENDING,
+            Task.Status.WAITING,
+            Task.Status.BLOCKED,
+            Task.Status.RUNNING,
+        ):
+            with self.subTest(active_status=active_status):
+                Task.objects.filter(pk=backup_task.pk).update(status=active_status)
+                response = self.client.post(
+                    "/api/v1/protection/backup-configs/reset/",
+                    {
+                        "source_ids": [f"agent:{self.agent.id}"],
+                        "confirmation": "RESET",
+                    },
+                    format="json",
+                    **self._headers(),
+                )
+
+                self.assertEqual(response.status_code, status.HTTP_409_CONFLICT)
+                problem = response.data["data"]
+                self.assertEqual(problem["code"], "BACKUP.ALREADY_RUNNING")
+                self.assertEqual(
+                    problem["meta"]["task_uuid"], str(backup_task.task_uuid)
+                )
+                self.assertEqual(problem["meta"]["task_type"], Task.Type.BACKUP)
+                self.assertEqual(problem["meta"]["status"], active_status)
+                self.assertEqual(problem["meta"]["source_type"], "agent")
+                self.assertEqual(problem["meta"]["source_ref_id"], self.agent.id)
+                self.assertFalse(
+                    Task.objects.filter(
+                        task_type=Task.Type.BACKUP_CONFIG_RESET
+                    ).exists()
+                )
+
+        Task.objects.filter(pk=backup_task.pk).update(status=Task.Status.CANCELLED)
+        node_task = NodeTask.objects.create(
+            organization=self.org,
+            node=self.agent,
+            kind="backup.run",
+            correlation_type="protection.backup",
+            correlation_id=str(backup_task.task_uuid),
+            status=NodeTask.Status.RUNNING,
+            cancel_requested_at=timezone.now(),
+            watchdog_deadline_at=timezone.now() + timedelta(hours=2),
+        )
+        with mock.patch("apps.node.conf.TASK_CANCEL_GRACE_SECONDS", 300):
+            stopping = self.client.post(
+                "/api/v1/protection/backup-configs/reset/",
+                {
+                    "source_ids": [f"agent:{self.agent.id}"],
+                    "confirmation": "RESET",
+                },
+                format="json",
+                **self._headers(),
+            )
+            self.assertEqual(stopping.status_code, status.HTTP_409_CONFLICT)
+            self.assertEqual(stopping.data["data"]["meta"]["status"], "stopping")
+
+            node_task.cancel_requested_at = timezone.now() - timedelta(seconds=301)
+            node_task.save(update_fields=["cancel_requested_at", "updated_at"])
+            finished = self.client.post(
+                "/api/v1/protection/backup-configs/reset/",
+                {
+                    "source_ids": [f"agent:{self.agent.id}"],
+                    "confirmation": "RESET",
+                },
+                format="json",
+                **self._headers(),
+            )
+            self.assertEqual(finished.status_code, status.HTTP_202_ACCEPTED)
+
     @mock.patch(
         "apps.protection.tasks.backup_config_reset.execute_backup_config_reset_task.delay"
     )

--- a/src/backend/apps/protection/tests/test_backup_task_concurrency.py
+++ b/src/backend/apps/protection/tests/test_backup_task_concurrency.py
@@ -15,6 +15,7 @@ from apps.protection.models import (
     BackupSourceSnapshot,
 )
 from apps.protection.services.backup_task import start_backup_tasks
+from apps.protection.services.backup_config_reset import create_reset_tasks_for_sources
 from apps.source.models import SourceBackupPipelineEntry
 from apps.storage.repositories.models import Repository
 from apps.storage.services.internal.repository_location import (
@@ -23,6 +24,7 @@ from apps.storage.services.internal.repository_location import (
     reserve_repository_location,
 )
 from apps.task.models import Task, TaskResource
+from common.errors import AppError
 
 
 class BackupTaskConcurrencyTests(TransactionTestCase):
@@ -160,6 +162,74 @@ class BackupTaskConcurrencyTests(TransactionTestCase):
             result["results"][0]["message"],
         )
         self.assertFalse(Task.objects.filter(task_type=Task.Type.BACKUP).exists())
+
+    def test_simultaneous_backup_and_reset_create_one_operation(self):
+        barrier = threading.Barrier(2)
+        outcomes: queue.Queue[str] = queue.Queue()
+        errors: queue.Queue[BaseException] = queue.Queue()
+
+        def start_backup() -> None:
+            close_old_connections()
+            try:
+                barrier.wait(timeout=5)
+                result = start_backup_tasks(
+                    organization_id=self.org.id,
+                    source_ids=[f"agent:{self.agent.id}"],
+                    trigger_type="manual",
+                    idempotency_key="backup-reset-race",
+                )
+                status_value = result["results"][0]["status"]
+                outcomes.put("created" if status_value == "created" else "conflict")
+            except BaseException as exc:  # pragma: no cover - surfaced below
+                errors.put(exc)
+            finally:
+                close_old_connections()
+
+        def reset_config() -> None:
+            close_old_connections()
+            try:
+                barrier.wait(timeout=5)
+                result = create_reset_tasks_for_sources(
+                    organization_id=self.org.id,
+                    source_ids=[f"agent:{self.agent.id}"],
+                    confirmation="RESET",
+                )
+                outcomes.put("created" if result["created_count"] == 1 else "conflict")
+            except AppError as exc:
+                if exc.code != "BACKUP.ALREADY_RUNNING":
+                    errors.put(exc)
+                else:
+                    outcomes.put("conflict")
+            except BaseException as exc:  # pragma: no cover - surfaced below
+                errors.put(exc)
+            finally:
+                close_old_connections()
+
+        with (
+            patch("apps.protection.services.backup_task._queue_backup_execution"),
+            patch(
+                "apps.protection.services.backup_config_reset.queue_backup_config_reset_task"
+            ),
+        ):
+            threads = [
+                threading.Thread(target=start_backup),
+                threading.Thread(target=reset_config),
+            ]
+            for thread in threads:
+                thread.start()
+            for thread in threads:
+                thread.join(timeout=10)
+
+        if not errors.empty():
+            raise errors.get()
+        self.assertEqual(outcomes.qsize(), 2)
+        self.assertEqual(sorted(outcomes.get() for _ in range(2)), ["conflict", "created"])
+        self.assertEqual(
+            Task.objects.filter(
+                task_type__in=(Task.Type.BACKUP, Task.Type.BACKUP_CONFIG_RESET)
+            ).count(),
+            1,
+        )
 
     def test_backup_start_revalidates_repository_before_task_creation(self):
         self.repository.status = Repository.Status.REMOVING

--- a/src/backend/apps/restore/tests/test_restore_api.py
+++ b/src/backend/apps/restore/tests/test_restore_api.py
@@ -948,6 +948,42 @@ class RestoreApiTests(TestCase):
         self._assert_backup_already_running(manual_run, task)
         self.assertEqual(RestoreRecord.objects.count(), 0)
 
+    def test_restore_run_is_blocked_while_backup_is_stopping(self):
+        plan = RestorePlan.objects.create(
+            organization_id=self.org.id,
+            **self._plan_payload(),
+        )
+        task = self._active_backup_task(status_value=Task.Status.CANCELLED)
+        NodeTask.objects.create(
+            organization=self.org,
+            node=self.agent,
+            kind="backup.run",
+            correlation_type="protection.backup",
+            correlation_id=str(task.task_uuid),
+            status=NodeTask.Status.RUNNING,
+            cancel_requested_at=timezone.now(),
+            watchdog_deadline_at=timezone.now() + timezone.timedelta(hours=2),
+        )
+
+        plan_run = self.client.post(
+            f"/api/v1/restore/plans/{plan.id}/run/",
+            {},
+            format="json",
+            **self._headers(),
+        )
+        manual_run = self.client.post(
+            "/api/v1/restore/records/",
+            self._manual_restore_payload(),
+            format="json",
+            **self._headers(),
+        )
+
+        self._assert_backup_already_running(plan_run, task)
+        self._assert_backup_already_running(manual_run, task)
+        self.assertEqual(plan_run.data["data"]["meta"]["status"], "stopping")
+        self.assertEqual(manual_run.data["data"]["meta"]["status"], "stopping")
+        self.assertEqual(RestoreRecord.objects.count(), 0)
+
     def test_create_restore_plan_accepts_zero_sort_order_and_nested_source_path(self):
         payload = self._plan_payload()
         payload["source_path"] = "/data/subdir"

--- a/src/backend/apps/source/services/internal/backup_selectable.py
+++ b/src/backend/apps/source/services/internal/backup_selectable.py
@@ -7,7 +7,7 @@ import ipaddress
 import logging
 import time
 from collections import defaultdict
-from datetime import datetime, timedelta, timezone as datetime_timezone
+from datetime import datetime, timezone as datetime_timezone
 from decimal import Decimal
 from typing import Any
 
@@ -15,7 +15,6 @@ from django.conf import settings
 from django.db.models import Exists, OuterRef, Q, QuerySet
 from django.utils import timezone
 
-from apps.node import conf as node_conf
 from apps.node.models import Node, NodeTask
 from apps.node.models.base import NodeRole
 from apps.protection.models import (
@@ -52,6 +51,9 @@ from apps.source.services.internal.source_pipeline import (
     attach_pipeline_steps,
     filter_items_by_pipeline_step,
     load_pipeline_step_map,
+)
+from apps.source.services.internal.source_operation_fence import (
+    product_task_is_stopping,
 )
 from apps.storage.models import Repository
 from apps.task.models import Task, TaskResource
@@ -747,20 +749,6 @@ def _restore_record_status(record: RestoreRecord, task: Task | None) -> str:
     return "running"
 
 
-def _product_task_is_stopping(*, organization_id: int, task: Task | None) -> bool:
-    if task is None or task.status != Task.Status.CANCELLED:
-        return False
-    cutoff = timezone.now() - timedelta(
-        seconds=max(1, int(node_conf.TASK_CANCEL_GRACE_SECONDS))
-    )
-    return NodeTask.objects.filter(
-        organization_id=organization_id,
-        correlation_id=str(task.task_uuid),
-        status__in=(NodeTask.Status.PENDING, NodeTask.Status.RUNNING),
-        cancel_requested_at__gt=cutoff,
-    ).exists()
-
-
 def _attach_runtime_expansion(
     *, organization_id: int, items: list[dict[str, Any]]
 ) -> None:
@@ -901,7 +889,7 @@ def _attach_runtime_expansion(
         backup_stopping = (
             not running_backup
             and latest_backup_task is not None
-            and _product_task_is_stopping(
+            and product_task_is_stopping(
                 organization_id=organization_id, task=latest_backup_task
             )
         )
@@ -998,7 +986,7 @@ def _attach_runtime_expansion(
             not running_restore
             and latest_restore_pair is not None
             and latest_restore_pair[1] is not None
-            and _product_task_is_stopping(
+            and product_task_is_stopping(
                 organization_id=organization_id, task=latest_restore_pair[1]
             )
         )

--- a/src/backend/apps/source/services/internal/backup_selectable.py
+++ b/src/backend/apps/source/services/internal/backup_selectable.py
@@ -7,7 +7,7 @@ import ipaddress
 import logging
 import time
 from collections import defaultdict
-from datetime import datetime, timezone as datetime_timezone
+from datetime import datetime, timedelta, timezone as datetime_timezone
 from decimal import Decimal
 from typing import Any
 
@@ -15,7 +15,7 @@ from django.conf import settings
 from django.db.models import Exists, OuterRef, Q, QuerySet
 from django.utils import timezone
 
-from apps.node.models import Node, NodeTask
+from apps.node.models import Node
 from apps.node.models.base import NodeRole
 from apps.protection.models import (
     BackupConfig,

--- a/src/backend/apps/source/services/internal/backup_source_delete.py
+++ b/src/backend/apps/source/services/internal/backup_source_delete.py
@@ -2939,6 +2939,37 @@ def queue_delete_backup_sources(
         )
         if existing_group_uuid is not None:
             operation_group_uuid = existing_group_uuid
+        sources_to_guard: list[tuple[str, int]] = []
+        for selectable_id in normalized:
+            task_idempotency_key = idempotency_keys.get(selectable_id)
+            if (
+                task_idempotency_key
+                and idempotent_tasks.get(task_idempotency_key) is not None
+            ):
+                continue
+            ctx = _resolve_context(
+                organization_id=org.id,
+                selectable_id=selectable_id,
+            )
+            if ctx is None:
+                continue
+            existing = _active_unregister_task_for_source(
+                organization_id=org.id,
+                source_type=ctx.source_type,
+                source_ref_id=ctx.source_ref_id,
+            )
+            if existing is not None and not _is_legacy_deferred_unregister(existing):
+                continue
+            sources_to_guard.append((ctx.source_type, ctx.source_ref_id))
+        if sources_to_guard:
+            from apps.source.services.internal.source_operation_fence import (
+                assert_no_active_backup_for_sources,
+            )
+
+            assert_no_active_backup_for_sources(
+                organization_id=org.id,
+                sources=sources_to_guard,
+            )
         for selectable_id in normalized:
             task_idempotency_key = idempotency_keys.get(selectable_id)
             if task_idempotency_key:

--- a/src/backend/apps/source/services/internal/source_operation_fence.py
+++ b/src/backend/apps/source/services/internal/source_operation_fence.py
@@ -2,11 +2,18 @@
 
 from __future__ import annotations
 
+from datetime import timedelta
+from uuid import UUID
+
 from django.core.exceptions import ValidationError
+from django.db.models import Q
+from django.utils import timezone
 
 from common.errors import AppError
-from apps.node.models import Node
+from apps.node import conf as node_conf
+from apps.node.models import Node, NodeTask
 from apps.node.models.base import NodeRole
+from apps.protection import conf as protection_conf
 from apps.source.constants import ResourceType
 from apps.source.models import SourceResource
 from apps.task.constants import RESTORE_TASK_TYPES
@@ -23,6 +30,29 @@ _SOURCE_CONTROL_TASK_TYPES = {
     Task.Type.BACKUP_CONFIG_RESET,
     Task.Type.SOURCE_UNREGISTER,
 }
+_BACKUP_NODE_TASK_CORRELATION_TYPES = {
+    protection_conf.PROTECTION_BACKUP_CORRELATION_TYPE,
+    protection_conf.PROTECTION_BACKUP_POLICY_PREPARE_CORRELATION_TYPE,
+}
+
+
+def _stopping_backup_task_uuids(*, organization_id: int) -> list[UUID]:
+    cutoff = timezone.now() - timedelta(
+        seconds=max(1, int(node_conf.TASK_CANCEL_GRACE_SECONDS))
+    )
+    values = NodeTask.objects.filter(
+        organization_id=organization_id,
+        correlation_type__in=_BACKUP_NODE_TASK_CORRELATION_TYPES,
+        status__in=(NodeTask.Status.PENDING, NodeTask.Status.RUNNING),
+        cancel_requested_at__gt=cutoff,
+    ).values_list("correlation_id", flat=True)
+    task_uuids: list[UUID] = []
+    for value in values:
+        try:
+            task_uuids.append(UUID(str(value)))
+        except (TypeError, ValueError, AttributeError):
+            continue
+    return task_uuids
 
 
 def lock_source_identity(
@@ -79,16 +109,20 @@ def active_source_backup_task(
     source_type: str,
     source_ref_id: int,
 ) -> Task | None:
-    """Return an active Backup task owning one Source.
+    """Return an active or cancel-grace Backup task owning one Source.
 
     The request-payload fallback preserves compatibility with historical tasks
     created before backup-source TaskResource rows were consistently attached.
     """
+    stopping_task_uuids = _stopping_backup_task_uuids(
+        organization_id=organization_id
+    )
     tasks = (
         Task.objects.filter(
+            Q(status__in=_ACTIVE_STATUSES)
+            | Q(status=Task.Status.CANCELLED, task_uuid__in=stopping_task_uuids),
             organization_id=organization_id,
             task_type=Task.Type.BACKUP,
-            status__in=_ACTIVE_STATUSES,
         )
         .prefetch_related("resources")
         .order_by("created_at", "id")
@@ -112,6 +146,22 @@ def active_source_backup_task(
         ):
             return task
     return None
+
+
+def product_task_is_stopping(*, organization_id: int, task: Task | None) -> bool:
+    """Return whether a cancelled product task is still within cancel grace."""
+    if task is None or task.status != Task.Status.CANCELLED:
+        return False
+    cutoff = timezone.now() - timedelta(
+        seconds=max(1, int(node_conf.TASK_CANCEL_GRACE_SECONDS))
+    )
+    return NodeTask.objects.filter(
+        organization_id=organization_id,
+        correlation_type__in=_BACKUP_NODE_TASK_CORRELATION_TYPES,
+        correlation_id=str(task.task_uuid),
+        status__in=(NodeTask.Status.PENDING, NodeTask.Status.RUNNING),
+        cancel_requested_at__gt=cutoff,
+    ).exists()
 
 
 def active_source_restore_task(
@@ -149,7 +199,7 @@ def assert_no_active_backup_for_sources(
     organization_id: int,
     sources: list[tuple[str, int]],
 ) -> None:
-    """Fence configuration and restore mutations against active backups."""
+    """Fence conflicting source mutations against active or stopping backups."""
     identities = sorted(
         {
             (str(source_type), int(source_ref_id))
@@ -170,13 +220,21 @@ def assert_no_active_backup_for_sources(
         )
         if blocker is None:
             continue
+        blocker_status = (
+            "stopping"
+            if product_task_is_stopping(
+                organization_id=organization_id,
+                task=blocker,
+            )
+            else blocker.status
+        )
         raise AppError(
             code="BACKUP.ALREADY_RUNNING",
             status=409,
             title="Backup already running",
             diagnostic=(
                 "A backup task is active for this source. Stop it or wait for "
-                "it to finish before restoring or changing backup configuration."
+                "it to finish before continuing."
             ),
             retryable=False,
             meta={
@@ -184,7 +242,7 @@ def assert_no_active_backup_for_sources(
                 "task_id": blocker.id,
                 "task_type": blocker.task_type,
                 "display_name": blocker.display_name,
-                "status": blocker.status,
+                "status": blocker_status,
                 "source_type": source_type,
                 "source_ref_id": source_ref_id,
                 "created_at": blocker.created_at.isoformat()
@@ -290,4 +348,5 @@ __all__ = [
     "assert_no_active_restore_for_source",
     "assert_source_product_operation_allowed",
     "lock_source_identity",
+    "product_task_is_stopping",
 ]

--- a/src/backend/apps/source/tests/test_api.py
+++ b/src/backend/apps/source/tests/test_api.py
@@ -2942,21 +2942,17 @@ class BackupSourceBulkDeleteTests(TestCase):
         )
 
         self.assertEqual(
-            response.status_code, status.HTTP_202_ACCEPTED, response.content
+            response.status_code, status.HTTP_409_CONFLICT, response.content
         )
-        unregister_task = Task.objects.get(task_type=Task.Type.SOURCE_UNREGISTER)
-        self.assertEqual(unregister_task.status, Task.Status.FAILED)
-        self.assertEqual(
-            unregister_task.result_payload["reasons"][0]["code"], "running_tasks"
+        problem = response.data["data"]
+        self.assertEqual(problem["code"], "BACKUP.ALREADY_RUNNING")
+        self.assertEqual(problem["meta"]["task_uuid"], str(backup_task.task_uuid))
+        self.assertEqual(problem["meta"]["task_type"], Task.Type.BACKUP)
+        self.assertFalse(
+            Task.objects.filter(task_type=Task.Type.SOURCE_UNREGISTER).exists()
         )
-        self.assertEqual(response.data["task_uuid"], str(unregister_task.task_uuid))
         self.agent.refresh_from_db()
         self.assertFalse(self.agent.is_deleted)
-
-        complete_task(task_uuid=backup_task.task_uuid, organization_id=self.org.id)
-        reconcile_stuck_source_unregister_tasks()
-        unregister_task.refresh_from_db()
-        self.assertEqual(unregister_task.status, Task.Status.FAILED)
 
     def test_snapshot_delete_fails_unregister_without_deferred_task(self):
         snapshot_task = Task.objects.create(

--- a/src/backend/apps/source/tests/test_api.py
+++ b/src/backend/apps/source/tests/test_api.py
@@ -138,6 +138,43 @@ class SourceResourceApiTests(TestCase):
         self.assertEqual(row["bound_node_status"], Node.Status.ACTIVE)
         self.assertEqual(row["bound_node_availability"], Node.Availability.ONLINE)
 
+    def test_nas_display_name_can_change_while_backup_is_active(self):
+        resource = SourceResource.objects.create(
+            organization=self.org,
+            name="nas-before-rename",
+            resource_type="nas",
+            config={
+                "protocol": "nfs",
+                "server": "192.168.88.10",
+                "export_path": "/data",
+            },
+            bound_node=self.node,
+        )
+        backup_task = Task.objects.create(
+            organization_id=self.org.id,
+            task_type=Task.Type.BACKUP,
+            display_name="Active NAS backup",
+            status=Task.Status.RUNNING,
+        )
+        TaskResource.objects.create(
+            task=backup_task,
+            resource_type=TaskResource.Type.BACKUP_SOURCE,
+            resource_subtype="nas",
+            resource_id=resource.id,
+            is_primary=True,
+        )
+
+        response = self.client.patch(
+            f"/api/v1/source/resources/{resource.id}/",
+            {"name": "nas-after-rename"},
+            format="json",
+            **self._headers(),
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        resource.refresh_from_db()
+        self.assertEqual(resource.name, "nas-after-rename")
+
     def test_list_search_matches_nas_fields(self):
         SourceResource.objects.create(
             organization=self.org,
@@ -2349,6 +2386,180 @@ class BackupSourceBulkDeleteTests(TestCase):
         self.assertEqual(
             Task.objects.filter(task_type=Task.Type.SOURCE_UNREGISTER).count(),
             1,
+        )
+
+    def test_bulk_delete_rejects_active_backup_before_creating_task(self):
+        source_id = f"agent:{self.agent.id}"
+        backup_task = Task.objects.create(
+            organization_id=self.org.id,
+            task_type=Task.Type.BACKUP,
+            display_name="Active backup",
+            status=Task.Status.RUNNING,
+        )
+        TaskResource.objects.create(
+            task=backup_task,
+            resource_type=TaskResource.Type.BACKUP_SOURCE,
+            resource_subtype="agent",
+            resource_id=self.agent.id,
+            is_primary=True,
+        )
+
+        response = self.client.post(
+            "/api/v1/source/backup-selectable/bulk-delete/",
+            {
+                "ids": [source_id],
+                "force": False,
+                "confirmation": "DEREGISTER",
+            },
+            format="json",
+            **self._headers(),
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_409_CONFLICT)
+        problem = response.data["data"]
+        self.assertEqual(problem["code"], "BACKUP.ALREADY_RUNNING")
+        self.assertEqual(problem["meta"]["task_uuid"], str(backup_task.task_uuid))
+        self.assertEqual(problem["meta"]["task_type"], Task.Type.BACKUP)
+        self.assertEqual(problem["meta"]["source_type"], "agent")
+        self.assertEqual(problem["meta"]["source_ref_id"], self.agent.id)
+        self.assertFalse(
+            Task.objects.filter(task_type=Task.Type.SOURCE_UNREGISTER).exists()
+        )
+
+    def test_bulk_delete_rejects_backup_during_cancel_grace(self):
+        source_id = f"agent:{self.agent.id}"
+        backup_task = Task.objects.create(
+            organization_id=self.org.id,
+            task_type=Task.Type.BACKUP,
+            display_name="Stopping backup",
+            status=Task.Status.CANCELLED,
+        )
+        TaskResource.objects.create(
+            task=backup_task,
+            resource_type=TaskResource.Type.BACKUP_SOURCE,
+            resource_subtype="agent",
+            resource_id=self.agent.id,
+            is_primary=True,
+        )
+        NodeTask.objects.create(
+            organization=self.org,
+            node=self.agent,
+            kind="backup.run",
+            correlation_type="protection.backup",
+            correlation_id=str(backup_task.task_uuid),
+            status=NodeTask.Status.RUNNING,
+            cancel_requested_at=timezone.now(),
+            watchdog_deadline_at=timezone.now() + timedelta(hours=2),
+        )
+
+        response = self.client.post(
+            "/api/v1/source/backup-selectable/bulk-delete/",
+            {
+                "ids": [source_id],
+                "force": False,
+                "confirmation": "DEREGISTER",
+            },
+            format="json",
+            **self._headers(),
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_409_CONFLICT)
+        problem = response.data["data"]
+        self.assertEqual(problem["code"], "BACKUP.ALREADY_RUNNING")
+        self.assertEqual(problem["meta"]["task_uuid"], str(backup_task.task_uuid))
+        self.assertEqual(problem["meta"]["status"], "stopping")
+        self.assertFalse(
+            Task.objects.filter(task_type=Task.Type.SOURCE_UNREGISTER).exists()
+        )
+
+    def test_bulk_delete_rejects_mixed_selection_before_creating_any_task(self):
+        second_agent = Node.objects.create(
+            organization=self.org,
+            name="agent-offline-mixed-backup-conflict",
+            role=Node.Role.AGENT,
+            status=Node.Status.ACTIVE,
+            availability=Node.Availability.OFFLINE,
+        )
+        backup_task = Task.objects.create(
+            organization_id=self.org.id,
+            task_type=Task.Type.BACKUP,
+            display_name="Active backup",
+            status=Task.Status.RUNNING,
+        )
+        TaskResource.objects.create(
+            task=backup_task,
+            resource_type=TaskResource.Type.BACKUP_SOURCE,
+            resource_subtype="agent",
+            resource_id=self.agent.id,
+            is_primary=True,
+        )
+
+        response = self.client.post(
+            "/api/v1/source/backup-selectable/bulk-delete/",
+            {
+                "ids": [
+                    f"agent:{self.agent.id}",
+                    f"agent:{second_agent.id}",
+                ],
+                "force": False,
+                "confirmation": "DEREGISTER",
+            },
+            format="json",
+            **self._headers(),
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_409_CONFLICT)
+        self.assertEqual(response.data["data"]["code"], "BACKUP.ALREADY_RUNNING")
+        self.assertEqual(
+            response.data["data"]["meta"]["task_uuid"], str(backup_task.task_uuid)
+        )
+        self.assertFalse(
+            Task.objects.filter(task_type=Task.Type.SOURCE_UNREGISTER).exists()
+        )
+
+    def test_bulk_delete_idempotent_replay_precedes_new_backup_conflict(self):
+        source_id = f"agent:{self.agent.id}"
+        payload = {
+            "ids": [source_id],
+            "force": False,
+            "confirmation": "DEREGISTER",
+        }
+        headers = {
+            **self._headers(),
+            "HTTP_IDEMPOTENCY_KEY": "unregister-before-backup",
+        }
+        first = self.client.post(
+            "/api/v1/source/backup-selectable/bulk-delete/",
+            payload,
+            format="json",
+            **headers,
+        )
+        backup_task = Task.objects.create(
+            organization_id=self.org.id,
+            task_type=Task.Type.BACKUP,
+            display_name="Late active backup",
+            status=Task.Status.RUNNING,
+        )
+        TaskResource.objects.create(
+            task=backup_task,
+            resource_type=TaskResource.Type.BACKUP_SOURCE,
+            resource_subtype="agent",
+            resource_id=self.agent.id,
+            is_primary=True,
+        )
+
+        replay = self.client.post(
+            "/api/v1/source/backup-selectable/bulk-delete/",
+            payload,
+            format="json",
+            **headers,
+        )
+
+        self.assertEqual(first.status_code, status.HTTP_202_ACCEPTED)
+        self.assertEqual(replay.status_code, status.HTTP_202_ACCEPTED)
+        self.assertEqual(replay.data["task_uuid"], first.data["task_uuid"])
+        self.assertEqual(
+            Task.objects.filter(task_type=Task.Type.SOURCE_UNREGISTER).count(), 1
         )
 
     @override_settings(SOURCE_UNREGISTER_EAGER=False)

--- a/src/backend/apps/source/tests/test_backup_selectable_stopping.py
+++ b/src/backend/apps/source/tests/test_backup_selectable_stopping.py
@@ -5,11 +5,15 @@ from unittest.mock import patch
 from django.test import TestCase
 from django.utils import timezone
 
+from common.errors import AppError
 from apps.iam.models import Organization
 from apps.node.models import Node, NodeTask
 from apps.node.models.base import NodeRole
-from apps.source.services.internal.backup_selectable import _product_task_is_stopping
-from apps.task.models import Task
+from apps.source.services.internal.source_operation_fence import (
+    assert_no_active_backup_for_source,
+    product_task_is_stopping,
+)
+from apps.task.models import Task, TaskResource
 
 
 class ProductTaskStoppingTests(TestCase):
@@ -25,6 +29,13 @@ class ProductTaskStoppingTests(TestCase):
             task_type=Task.Type.BACKUP,
             display_name="Backup",
             status=Task.Status.CANCELLED,
+        )
+        TaskResource.objects.create(
+            task=self.task,
+            resource_type=TaskResource.Type.BACKUP_SOURCE,
+            resource_subtype="agent",
+            resource_id=self.node.id,
+            is_primary=True,
         )
 
     def create_node_task(self, *, age_seconds: int, cancel_requested: bool = True):
@@ -47,18 +58,59 @@ class ProductTaskStoppingTests(TestCase):
         self.create_node_task(age_seconds=299)
         with patch("apps.node.conf.TASK_CANCEL_GRACE_SECONDS", 300):
             self.assertTrue(
-                _product_task_is_stopping(organization_id=self.org.id, task=self.task)
+                product_task_is_stopping(organization_id=self.org.id, task=self.task)
             )
 
     def test_stopped_at_or_after_cancel_grace(self):
         self.create_node_task(age_seconds=301)
         with patch("apps.node.conf.TASK_CANCEL_GRACE_SECONDS", 300):
             self.assertFalse(
-                _product_task_is_stopping(organization_id=self.org.id, task=self.task)
+                product_task_is_stopping(organization_id=self.org.id, task=self.task)
             )
 
     def test_active_task_without_cancel_request_is_not_stopping(self):
         self.create_node_task(age_seconds=0, cancel_requested=False)
         self.assertFalse(
-            _product_task_is_stopping(organization_id=self.org.id, task=self.task)
+            product_task_is_stopping(organization_id=self.org.id, task=self.task)
+        )
+
+    def test_source_fence_blocks_until_cancel_grace_expires(self):
+        node_task = self.create_node_task(age_seconds=299)
+        with patch("apps.node.conf.TASK_CANCEL_GRACE_SECONDS", 300):
+            with self.assertRaises(AppError) as raised:
+                assert_no_active_backup_for_source(
+                    organization_id=self.org.id,
+                    source_type="agent",
+                    source_ref_id=self.node.id,
+                )
+            self.assertEqual(raised.exception.code, "BACKUP.ALREADY_RUNNING")
+            self.assertEqual(raised.exception.status, 409)
+            self.assertEqual(raised.exception.meta["status"], "stopping")
+
+            node_task.cancel_requested_at = timezone.now() - timezone.timedelta(
+                seconds=301
+            )
+            node_task.save(update_fields=["cancel_requested_at", "updated_at"])
+            assert_no_active_backup_for_source(
+                organization_id=self.org.id,
+                source_type="agent",
+                source_ref_id=self.node.id,
+            )
+
+    def test_source_fence_ignores_malformed_backup_correlation_id(self):
+        NodeTask.objects.create(
+            organization=self.org,
+            node=self.node,
+            kind="backup.run",
+            correlation_type="protection.backup",
+            correlation_id="not-a-task-uuid",
+            status=NodeTask.Status.RUNNING,
+            cancel_requested_at=timezone.now(),
+            watchdog_deadline_at=timezone.now() + timezone.timedelta(hours=2),
+        )
+
+        assert_no_active_backup_for_source(
+            organization_id=self.org.id,
+            source_type="agent",
+            source_ref_id=self.node.id,
         )

--- a/src/frontend/src/components/BackupSourceDeleteDialog.vue
+++ b/src/frontend/src/components/BackupSourceDeleteDialog.vue
@@ -8,6 +8,7 @@ import {
   type BackupSourceUnregisterDisplayRow,
 } from '../lib/backupSourceUnregisterDialog'
 import type { ErrorDetailsPayload } from '../lib/errors/details'
+import { toApiError } from '../lib/errors/normalizer'
 import {
   bulkDeleteBackupSources,
   parseBackupSourceDeleteError,
@@ -49,6 +50,7 @@ const emit = defineEmits<{
     rejected?: BackupSourceDeleteResult['rejected']
     accepted?: boolean
   }): void
+  (e: 'conflict', payload: { sourceIds: string[] }): void
 }>()
 
 const { t } = useI18n()
@@ -212,6 +214,9 @@ async function confirmDelete() {
       accepted: Boolean(result.accepted),
     })
   } catch (err: unknown) {
+    if (toApiError(err).errorCode === 'BACKUP.ALREADY_RUNNING') {
+      emit('conflict', { sourceIds })
+    }
     const parsed = parseBackupSourceDeleteError(err)
     submitErrorReasons.value = parsed.reasons
     const failuresBySourceMap = unregisterSyncFailuresBySource({

--- a/src/frontend/src/components/BackupSourceStep3DeleteDialog.vue
+++ b/src/frontend/src/components/BackupSourceStep3DeleteDialog.vue
@@ -8,6 +8,7 @@ import {
   type BackupSourceUnregisterDisplayRow,
 } from '../lib/backupSourceUnregisterDialog'
 import type { ErrorDetailsPayload } from '../lib/errors/details'
+import { toApiError } from '../lib/errors/normalizer'
 import {
   bulkDeleteBackupSources,
   parseBackupSourceDeleteError,
@@ -48,6 +49,7 @@ const emit = defineEmits<{
     rejected?: BackupSourceDeleteResult['rejected']
     accepted?: boolean
   }): void
+  (e: 'conflict', payload: { sourceIds: string[] }): void
 }>()
 
 const { t } = useI18n()
@@ -211,6 +213,9 @@ async function confirmDelete() {
       accepted: Boolean(result.accepted),
     })
   } catch (err: unknown) {
+    if (toApiError(err).errorCode === 'BACKUP.ALREADY_RUNNING') {
+      emit('conflict', { sourceIds })
+    }
     const parsed = parseBackupSourceDeleteError(err)
     submitErrorReasons.value = parsed.reasons
     const failuresBySourceMap = unregisterSyncFailuresBySource({

--- a/src/frontend/src/components/BackupSourceUnregisterDialogs.test.ts
+++ b/src/frontend/src/components/BackupSourceUnregisterDialogs.test.ts
@@ -239,6 +239,34 @@ describe.each([
     wrapper.unmount()
   })
 
+  it('emits an active-backup conflict and refreshes preflight', async () => {
+    preflightDeleteBackupSources
+      .mockResolvedValueOnce(successfulPreflight)
+      .mockResolvedValueOnce({
+        risks: [],
+        blocking: [{ code: 'running_tasks', detail: 'Backup is running.' }],
+        strict_may_fail: true,
+        delete_disabled: true,
+      })
+    bulkDeleteBackupSources.mockRejectedValue({
+      status: 409,
+      message: 'Backup already running',
+      errorCode: 'BACKUP.ALREADY_RUNNING',
+      meta: { task_uuid: 'backup-task-uuid' },
+    })
+    const wrapper = mountDialog(component)
+    await flushPromises()
+
+    await wrapper.get('[data-test="strict-confirmation"]').trigger('click')
+    await wrapper.get('[data-test="confirm-delete"]').trigger('click')
+    await flushPromises()
+
+    expect(wrapper.emitted('conflict')).toEqual([[{ sourceIds: ['agent:25'] }]])
+    expect(preflightDeleteBackupSources).toHaveBeenCalledTimes(2)
+    expect(wrapper.get('[data-test="preflight-disabled"]').text()).toBe('true')
+    wrapper.unmount()
+  })
+
   it('clears the Strict confirmation when switching to Force', async () => {
     preflightDeleteBackupSources.mockResolvedValue(successfulPreflight)
     const wrapper = mountDialog(component)

--- a/src/frontend/src/lib/errors/registry.ts
+++ b/src/frontend/src/lib/errors/registry.ts
@@ -94,7 +94,7 @@ export const ERROR_CODE_FALLBACK_EN: Record<string, string> = {
   'BACKUP.QUOTA_EXCEEDED': 'Backup quota exceeded. Upgrade your subscription and try again.',
   'SUBSCRIPTION.QUOTA_EXCEEDED':
     'Organization quota is full. Contact your platform administrator to raise limits.',
-  'BACKUP.ALREADY_RUNNING': 'A backup is already running for this source.',
+  'BACKUP.ALREADY_RUNNING': 'A backup is starting or running for this source. Stop it or wait for it to finish before continuing.',
   'RESTORE.ALREADY_RUNNING': 'A restore task is already running for this source.',
 }
 

--- a/src/frontend/src/lib/sourceApi.test.ts
+++ b/src/frontend/src/lib/sourceApi.test.ts
@@ -1,7 +1,12 @@
 // @vitest-environment jsdom
 
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { listBackupSelectableSources, productionSourceSummary, testSourceDraft } from './sourceApi'
+import {
+  bulkDeleteBackupSources,
+  listBackupSelectableSources,
+  productionSourceSummary,
+  testSourceDraft,
+} from './sourceApi'
 
 
 afterEach(() => {
@@ -98,6 +103,45 @@ describe('productionSourceSummary', () => {
 
     const url = new URL(String(fetchMock.mock.calls[0][0]), window.location.origin)
     expect(url.pathname).toBe('/api/v1/source/resources/production-summary/')
+  })
+})
+
+describe('bulkDeleteBackupSources', () => {
+  it('preserves a structured active-backup conflict for the caller', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      code: 409,
+      message: 'Backup already running',
+      data: {
+        title: 'Backup already running',
+        status: 409,
+        code: 'BACKUP.ALREADY_RUNNING',
+        meta: {
+          task_uuid: 'backup-task-uuid',
+          task_type: 'backup',
+          status: 'running',
+          source_type: 'agent',
+          source_ref_id: 25,
+        },
+      },
+    }), {
+      status: 409,
+      headers: { 'Content-Type': 'application/json' },
+    })))
+
+    await expect(bulkDeleteBackupSources(
+      ['agent:25'],
+      false,
+      'DEREGISTER',
+      'source-unregister:test',
+    )).rejects.toMatchObject({
+      status: 409,
+      errorCode: 'BACKUP.ALREADY_RUNNING',
+      meta: {
+        task_uuid: 'backup-task-uuid',
+        source_type: 'agent',
+        source_ref_id: 25,
+      },
+    })
   })
 })
 

--- a/src/frontend/src/lib/sourceApi.ts
+++ b/src/frontend/src/lib/sourceApi.ts
@@ -484,27 +484,16 @@ export async function bulkDeleteBackupSources(
   confirmation = '',
   idempotencyKey = '',
 ) {
-  try {
-    return unwrapApiPayload<BackupSourceDeleteResult>(
-      await api<unknown>(`${backupSelectableBase}/bulk-delete/`, {
-        method: 'POST',
-        body: JSON.stringify({ ids, force, confirmation }),
-        headers: {
-          ...orgHeaders(),
-          ...(idempotencyKey ? { 'Idempotency-Key': idempotencyKey } : {}),
-        },
-      }),
-    )
-  } catch (err: unknown) {
-    const parsed = parseBackupSourceDeleteError(err)
-    const error = new Error(parsed.message) as Error & {
-      reasons?: BackupSourceDeleteReason[]
-      hint?: string
-    }
-    error.reasons = parsed.reasons
-    error.hint = parsed.hint
-    throw error
-  }
+  return unwrapApiPayload<BackupSourceDeleteResult>(
+    await api<unknown>(`${backupSelectableBase}/bulk-delete/`, {
+      method: 'POST',
+      body: JSON.stringify({ ids, force, confirmation }),
+      headers: {
+        ...orgHeaders(),
+        ...(idempotencyKey ? { 'Idempotency-Key': idempotencyKey } : {}),
+      },
+    }),
+  )
 }
 
 export async function deleteSourceResource(id: number, force = false): Promise<SourceDeleteResult> {

--- a/src/frontend/src/lib/unregisterFailureDetails.test.ts
+++ b/src/frontend/src/lib/unregisterFailureDetails.test.ts
@@ -48,6 +48,36 @@ describe('unregisterFailureToErrorDetails', () => {
     ]))
   })
 
+  it('localizes a structured active-backup conflict', () => {
+    const details = unregisterFailureToErrorDetails({
+      t,
+      sourceId: 'agent:1',
+      sourceName: 'linux-32',
+      apiError: {
+        status: 409,
+        message: 'Backup already running',
+        errorCode: 'BACKUP.ALREADY_RUNNING',
+        meta: {
+          task_uuid: 'backup-task-uuid',
+          source_type: 'agent',
+          source_ref_id: 1,
+        },
+      },
+    })
+
+    expect(details.errorCode).toBe('BACKUP.ALREADY_RUNNING')
+    expect(details.summary).toBe(
+      'A backup is starting or running for this source. Stop it or wait for it to finish before continuing.',
+    )
+    expect(details.reasons).toEqual([details.summary])
+    expect(details.summary).not.toContain('backup-task-uuid')
+    expect(details.rawDetail).toMatchObject({
+      task_uuid: 'backup-task-uuid',
+      blocking_source_type: 'agent',
+      blocking_source_ref_id: 1,
+    })
+  })
+
   it('maps async task cleanup residue and retained resources', () => {
     const details = unregisterFailureToErrorDetails({
       t,

--- a/src/frontend/src/lib/unregisterFailureDetails.ts
+++ b/src/frontend/src/lib/unregisterFailureDetails.ts
@@ -1,8 +1,10 @@
 import type { ComposerTranslation } from 'vue-i18n'
 
+import { apiErrorMessageI18n } from './api'
 import { unregisterReasonLabel } from './backupSourceUnregisterDialog'
 import type { ErrorDetailsPayload } from './errors/details'
 import { openErrorDetails } from './errors/details'
+import { toApiError } from './errors/normalizer'
 import { notifyError, notifyWarning } from './notify'
 import {
   parseBackupSourceDeleteError,
@@ -118,32 +120,44 @@ export function unregisterFailureToErrorDetails(input: {
 
   if (input.apiError != null) {
     const parsed = parseBackupSourceDeleteError(input.apiError)
+    const apiError = toApiError(input.apiError)
+    const meta = apiError.meta || {}
+    const structuredErrorCode = apiError.status > 0 ? apiError.errorCode : undefined
+    const displayMessage = structuredErrorCode
+      ? apiErrorMessageI18n(input.apiError, t, fallback)
+      : (parsed.message || fallback)
     const scopedReasons = reasonsForUnregisterSource(parsed.reasons, input.sourceId)
     const reasons = uniqueStrings([
       ...scopedReasons.map((reason) => unregisterReasonLabel(reason, t)),
       // Prefer scoped reason text; keep API message only when it adds signal.
-      scopedReasons.length ? '' : parsed.message,
+      scopedReasons.length ? '' : displayMessage,
     ])
     const resolutions = uniqueStrings([
       parsed.hint,
       t('protection.backupsPage.unregisterFailureRetryHint'),
     ])
-    const summary = source
+    let summary = source
       ? t('protection.backupsPage.unregisterFailureSummaryNamed', { name: source })
-      : (reasons[0] || parsed.message || fallback)
+      : (reasons[0] || displayMessage || fallback)
+    if (structuredErrorCode === 'BACKUP.ALREADY_RUNNING') summary = displayMessage
     return {
       title: t('protection.backupsPage.unregisterFailureTitle'),
       summary,
       issue: summary,
-      errorCode: undefined,
-      reasons: reasons.length ? reasons : [parsed.message || fallback],
+      errorCode: structuredErrorCode,
+      reasons: reasons.length ? reasons : [displayMessage || fallback],
       resolutions,
       rawDetail: {
         source_id: input.sourceId,
         source_name: input.sourceName,
+        task_uuid: String(meta.task_uuid || '').trim() || undefined,
+        task_type: String(meta.task_type || '').trim() || undefined,
+        task_status: String(meta.status || '').trim() || undefined,
+        blocking_source_type: String(meta.source_type || '').trim() || undefined,
+        blocking_source_ref_id: Number(meta.source_ref_id || 0) || undefined,
         hint: parsed.hint,
         reasons: scopedReasons,
-        message: parsed.message,
+        message: displayMessage,
       },
     }
   }

--- a/src/frontend/src/locales/en.ts
+++ b/src/frontend/src/locales/en.ts
@@ -116,7 +116,7 @@ export const en = {
         'Shared instance {meter} capacity is full. Contact your platform administrator to raise the deployment grant or free capacity from other organizations.',
       subscriptionQuotaExceededGateway:
         'This Public Data Gateway is at capacity. Contact your platform administrator to raise the workspace limit on this gateway.',
-      backupAlreadyRunning: 'A backup is already running for this source.',
+      backupAlreadyRunning: 'A backup is starting or running for this source. Stop it or wait for it to finish before continuing.',
       restoreAlreadyRunning: 'A restore task is already running for this source.',
     },
   },

--- a/src/frontend/src/pages/protection/BackupCreateWizard.vue
+++ b/src/frontend/src/pages/protection/BackupCreateWizard.vue
@@ -193,6 +193,7 @@ const props = withDefaults(defineProps<{
 const emit = defineEmits<{
   closed: []
   completed: [sourceIds: string[]]
+  conflict: [payload: { sourceIds: string[] }]
   ready: []
 }>()
 const EmbeddedWizardShell = defineComponent({
@@ -5731,6 +5732,9 @@ async function runEditBackupConfig() {
   const step = editStepForSection(section)
   if (createStep.value !== step) createStep.value = step
   if (!validateCreateStep(step)) return
+  const editedSourceIds = normalizeSourceIdList(editables.map(({ config }) =>
+    `${config.source_type}:${config.source_ref_id}`,
+  ))
   createPhase.value = 'waiting'
   try {
     for (const { backup, group, config } of editables) {
@@ -5748,9 +5752,6 @@ async function runEditBackupConfig() {
         await syncEditRecoveryPlans(config, backup, group)
       }
     }
-    const editedSourceIds = normalizeSourceIdList(editables.map(({ config }) =>
-      `${config.source_type}:${config.source_ref_id}`,
-    ))
     ElMessage.success({ message: t('protection.backupsPage.msgSaveEditDemo'), grouping: true })
     if (props.embedded) {
       emit('completed', editedSourceIds)
@@ -5759,7 +5760,10 @@ async function runEditBackupConfig() {
     closeCreate()
   } catch (err) {
     createPhase.value = 'form'
-    ElMessage.error({ message: apiErrorMessage(err, editorFailureText.value), grouping: true })
+    ElMessage.error({ message: apiErrorMessageI18n(err, t, editorFailureText.value), grouping: true })
+    if (normalizeThrownError(err).errorCode === 'BACKUP.ALREADY_RUNNING') {
+      emit('conflict', { sourceIds: editedSourceIds })
+    }
   }
 }
 

--- a/src/frontend/src/pages/protection/DataProtection.vue
+++ b/src/frontend/src/pages/protection/DataProtection.vue
@@ -331,6 +331,23 @@ function showApiErrorI18n(err: unknown, fallback: string) {
 }
 
 const RESTORE_ALREADY_RUNNING_CODE = 'RESTORE.ALREADY_RUNNING'
+const BACKUP_ALREADY_RUNNING_CODE = 'BACKUP.ALREADY_RUNNING'
+
+async function handleBackupAlreadyRunning(
+  err: unknown,
+  refresh?: () => Promise<unknown>,
+): Promise<boolean> {
+  if (toApiError(err).errorCode !== BACKUP_ALREADY_RUNNING_CODE) return false
+  showApiErrorI18n(err, t('protection.backupsPage.msgBackupActiveBlocksActions'))
+  if (refresh) {
+    try {
+      await refresh()
+    } catch {
+      // The conflict remains authoritative even if best-effort runtime refresh fails.
+    }
+  }
+  return true
+}
 
 type RestoreAlreadyRunningMeta = {
   taskUuid: string
@@ -5233,7 +5250,11 @@ async function confirmResetBackupConfiguration() {
     resetBackupConfigConfirmText.value = ''
     ElMessage.success({ message: t('protection.backupsPage.msgResetBackupConfigQueued', { n: result.created_count }), grouping: true })
   } catch (err) {
-    showApiError(err, 'Failed to reset backup configuration')
+    if (await handleBackupAlreadyRunning(
+      err,
+      () => refreshStep3AfterMoreAction({ preserveSelection: true }),
+    )) return
+    showApiErrorI18n(err, t('protection.backupsPage.resetStatusFailed'))
   } finally {
     resetBackupFromStep3Submitting.value = false
   }
@@ -5469,6 +5490,10 @@ function deleteSelectedSourcesFromStep3() {
     step3SourceSelection.value.map((row) => row.id),
     step3SourceSelection.value,
   )
+}
+
+function onBackupSourceConflict() {
+  void refreshFlowStepData(flowMainStep.value, { showLoading: false })
 }
 
 function revertSelectedSourcesFromStep3() {
@@ -9139,7 +9164,11 @@ async function runRecovery(mode: 'plan' | 'manual' = 'manual') {
     )
   } catch (e) {
     if (await handleRestoreAlreadyRunning(e)) return
-    showApiError(e)
+    if (await handleBackupAlreadyRunning(
+      e,
+      () => refreshRecoverySourceRuntime(recoverySourceIds()),
+    )) return
+    showApiErrorI18n(e, t('errors.generic.requestFailed'))
   } finally {
     recSubmitting.value = false
   }
@@ -13746,6 +13775,7 @@ async function runRecovery(mode: 'plan' | 'manual' = 'manual') {
       :show-snapshots="backupSourceDeleteShowSnapshots"
       :previous-failure-details="backupSourceDeletePreviousFailure"
       @deleted="onBackupSourcesDeleted"
+      @conflict="onBackupSourceConflict"
     />
     <BackupSourceStep3DeleteDialog
       v-if="backupSourceStep3DeleteDialogOpen"
@@ -13754,6 +13784,7 @@ async function runRecovery(mode: 'plan' | 'manual' = 'manual') {
       :sources="backupSourceDeleteRows"
       :previous-failure-details="backupSourceDeletePreviousFailure"
       @deleted="onBackupSourcesDeleted"
+      @conflict="onBackupSourceConflict"
     />
     <DangerConfirmDialog
       v-if="deleteRestoreTasksDialogOpen"
@@ -13811,6 +13842,7 @@ async function runRecovery(mode: 'plan' | 'manual' = 'manual') {
       @ready="setupDrOpening = false"
       @closed="closeCreate"
       @completed="finishCreateAndGoToStep3"
+      @conflict="onBackupSourceConflict"
     />
     <Teleport to="body">
       <div

--- a/src/frontend/src/pages/protection/DataProtectionStep3MoreActions.test.ts
+++ b/src/frontend/src/pages/protection/DataProtectionStep3MoreActions.test.ts
@@ -30,6 +30,7 @@ describe('backup wizard step 3 More Actions refresh', () => {
     const openRecoveryForSource = functionSource('openRecoveryForSource', 'openSnapshotRestore')
     const editConfig = functionSource('openBackupConfigEditFromStep3', 'onBackupConfigEditPickSelected')
     const resetConfig = functionSource('resetSelectedBackupConfigurations', 'confirmResetBackupConfiguration')
+    const confirmReset = functionSource('confirmResetBackupConfiguration', 'onBackupSourcesDeleted')
     const runRecovery = sourceBetween('async function runRecovery', '</script>')
 
     expect(gating).toContain("sourceBackupRuntime(sourceId).running || runtimeStopping(sourceId, 'backup')")
@@ -45,10 +46,14 @@ describe('backup wizard step 3 More Actions refresh', () => {
     expect(openRecoveryForSource).toContain('if (sourceHasActiveBackup(sourceId))')
     expect(editConfig).toContain('sources.some((source) => sourceHasActiveBackup(source.id))')
     expect(resetConfig).toContain('sources.some((source) => sourceHasActiveBackup(source.id))')
+    expect(confirmReset).toContain('await handleBackupAlreadyRunning(')
+    expect(confirmReset).not.toContain('void refreshStep3AfterMoreAction')
     expect(startBackup).toContain(".filter((item) => item.status === 'created')")
     expect(startBackup).toContain('markBackupStartAwaitingRuntime')
     expect(startBackup).toContain("t('protection.backupsPage.msgStartBackupAcceptedRefreshFailed')")
     expect(runRecovery).toContain('await recoveryBlockedByActiveBackup()')
+    expect(runRecovery).toContain('await handleBackupAlreadyRunning(')
+    expect(runRecovery).toContain('refreshRecoverySourceRuntime(recoverySourceIds())')
     expect(page).toContain('async function refreshRecoverySourceRuntime(sourceIds: string[])')
     expect(page).toContain('const recoveryHasActiveBackup = computed')
     expect(page).toContain(':disabled="!selectedRecoveryPlans.length || recoveryHasActiveBackup"')
@@ -57,6 +62,17 @@ describe('backup wizard step 3 More Actions refresh', () => {
     expect(page).toContain("t('protection.backupsPage.msgBackupActiveBlocksActions')")
     expect(protectionLocale).toContain("msgBackupActiveBlocksActions:")
     expect(protectionLocale).toContain('A backup is starting or running for a selected source.')
+  })
+
+  it('keeps stop and display-name actions available during an active backup', () => {
+    const displayNameGate = sourceBetween(
+      'const step3DisplayNameEditEnabled',
+      'function openDisplayNameEditor',
+    )
+    const stopGate = sourceBetween('const step3CanStopBackup', 'const step3CanStopRestore')
+
+    expect(displayNameGate).not.toContain('step3SelectionHasActiveBackup')
+    expect(stopGate).toContain('sourceBackupRuntime(row.id).running')
   })
 
   it('keeps accepted backups fenced until refreshed runtime is available', () => {
@@ -137,7 +153,9 @@ describe('backup wizard step 3 More Actions refresh', () => {
     expect(editHandler).toContain('const step = editStepForSection(section)')
     expect(editHandler).toContain('if (createStep.value !== step) createStep.value = step')
     expect(editHandler).toContain('if (!validateCreateStep(step)) return')
-    expect(editHandler).toContain('apiErrorMessage(err, editorFailureText.value)')
+    expect(editHandler).toContain('apiErrorMessageI18n(err, t, editorFailureText.value)')
+    expect(editHandler).toContain("normalizeThrownError(err).errorCode === 'BACKUP.ALREADY_RUNNING'")
+    expect(editHandler).toContain("emit('conflict', { sourceIds: editedSourceIds })")
     expect(protectionLocale).toContain("editFailed: 'Failed to save backup configuration'")
     expect(protectionLocale).toContain("msgEditConfigUnavailable: 'No editable backup configuration is available. Refresh the page and try again.'")
   })


### PR DESCRIPTION
## Summary

- reject configuration, restore, reset, and deregistration requests while a backup is active or stopping
- preserve deregistration idempotency and return structured blocking task metadata
- localize stale-state conflicts, refresh console runtime state, and keep display-name edits available
- cover cancel grace, mixed selections, concurrency, restore, and direct API requests

## Testing

- backend affected API and concurrency test suites
- frontend targeted Vitest suites
- `npm run lint`
- `npm run build`
- Simplified Chinese language-pack contract build
- `git diff --check`

Closes #699