### PR TITLE
fix(storage): support Alibaba OSS repository cleanup

### DIFF
--- a/src/agent/go.mod
+++ b/src/agent/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.43.5
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.35
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.107.1
+	github.com/aws/smithy-go v1.27.7
 	github.com/getsentry/sentry-go v0.38.0
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
@@ -28,7 +29,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.29 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.36 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.37 // indirect
-	github.com/aws/smithy-go v1.27.7 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/ebitengine/purego v0.10.0 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect

--- a/src/agent/internal/engine/s3_cleanup.go
+++ b/src/agent/internal/engine/s3_cleanup.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -14,6 +15,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/aws/smithy-go"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
 )
 
 const (
@@ -29,6 +32,7 @@ type s3CleanupClient interface {
 	AbortMultipartUpload(context.Context, *s3.AbortMultipartUploadInput, ...func(*s3.Options)) (*s3.AbortMultipartUploadOutput, error)
 	ListObjectVersions(context.Context, *s3.ListObjectVersionsInput, ...func(*s3.Options)) (*s3.ListObjectVersionsOutput, error)
 	DeleteObjects(context.Context, *s3.DeleteObjectsInput, ...func(*s3.Options)) (*s3.DeleteObjectsOutput, error)
+	DeleteObject(context.Context, *s3.DeleteObjectInput, ...func(*s3.Options)) (*s3.DeleteObjectOutput, error)
 	DeleteBucket(context.Context, *s3.DeleteBucketInput, ...func(*s3.Options)) (*s3.DeleteBucketOutput, error)
 }
 
@@ -727,12 +731,71 @@ func deleteS3ObjectIdentifiers(ctx context.Context, client s3CleanupClient, buck
 		output, err := client.DeleteObjects(ctx, &s3.DeleteObjectsInput{
 			Bucket: aws.String(bucket),
 			Delete: &types.Delete{Objects: entries[start:end], Quiet: aws.Bool(true)},
-		})
+		}, addS3DeleteObjectsContentMD5)
 		if err != nil {
+			if isS3BatchDeleteCompatibilityError(err) {
+				if fallbackErr := deleteS3ObjectIdentifiersIndividually(
+					ctx,
+					client,
+					bucket,
+					entries[start:end],
+				); fallbackErr != nil {
+					return fallbackErr
+				}
+				continue
+			}
 			return fmt.Errorf("unable to delete S3 objects: %w", err)
 		}
 		if len(output.Errors) > 0 {
 			return fmt.Errorf("unable to delete S3 objects: %s", aws.ToString(output.Errors[0].Code))
+		}
+	}
+	return nil
+}
+
+func addS3DeleteObjectsContentMD5(options *s3.Options) {
+	// AWS accepts its newer flexible checksum, while Alibaba OSS requires the
+	// original S3 Content-MD5 header for multi-object deletion. Send both so
+	// the same request remains portable across S3-compatible providers.
+	options.APIOptions = append(
+		options.APIOptions,
+		smithyhttp.AddContentChecksumMiddleware,
+	)
+}
+
+func isS3BatchDeleteCompatibilityError(err error) bool {
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) {
+		return false
+	}
+	switch strings.TrimSpace(apiErr.ErrorCode()) {
+	case "MissingArgument", "MissingContentMD5", "NotImplemented", "UnsupportedArgument", "UnsupportedOperation":
+		return true
+	default:
+		return false
+	}
+}
+
+func deleteS3ObjectIdentifiersIndividually(
+	ctx context.Context,
+	client s3CleanupClient,
+	bucket string,
+	entries []types.ObjectIdentifier,
+) error {
+	for _, entry := range entries {
+		key := strings.TrimSpace(aws.ToString(entry.Key))
+		if key == "" {
+			return fmt.Errorf("unable to delete S3 object: object key is missing")
+		}
+		input := &s3.DeleteObjectInput{
+			Bucket: aws.String(bucket),
+			Key:    aws.String(key),
+		}
+		if versionID := strings.TrimSpace(aws.ToString(entry.VersionId)); versionID != "" {
+			input.VersionId = aws.String(versionID)
+		}
+		if _, err := client.DeleteObject(ctx, input); err != nil {
+			return fmt.Errorf("unable to delete S3 object %q: %w", key, err)
 		}
 	}
 	return nil

--- a/src/agent/internal/engine/s3_cleanup_test.go
+++ b/src/agent/internal/engine/s3_cleanup_test.go
@@ -2,14 +2,19 @@ package engine
 
 import (
 	"context"
+	"crypto/md5"
+	"encoding/base64"
 	"errors"
 	"io"
+	"net/http"
 	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/aws/smithy-go"
 )
 
 type fakeS3CleanupClient struct {
@@ -19,6 +24,7 @@ type fakeS3CleanupClient struct {
 	abortUpload   func(*s3.AbortMultipartUploadInput) (*s3.AbortMultipartUploadOutput, error)
 	listVersions  func(*s3.ListObjectVersionsInput) (*s3.ListObjectVersionsOutput, error)
 	deleteObjects func(*s3.DeleteObjectsInput) (*s3.DeleteObjectsOutput, error)
+	deleteObject  func(*s3.DeleteObjectInput) (*s3.DeleteObjectOutput, error)
 	deleteBucket  func(*s3.DeleteBucketInput) (*s3.DeleteBucketOutput, error)
 }
 
@@ -46,8 +52,107 @@ func (f *fakeS3CleanupClient) DeleteObjects(_ context.Context, input *s3.DeleteO
 	return f.deleteObjects(input)
 }
 
+func (f *fakeS3CleanupClient) DeleteObject(_ context.Context, input *s3.DeleteObjectInput, _ ...func(*s3.Options)) (*s3.DeleteObjectOutput, error) {
+	return f.deleteObject(input)
+}
+
 func (f *fakeS3CleanupClient) DeleteBucket(_ context.Context, input *s3.DeleteBucketInput, _ ...func(*s3.Options)) (*s3.DeleteBucketOutput, error) {
 	return f.deleteBucket(input)
+}
+
+type s3CleanupRoundTripper func(*http.Request) (*http.Response, error)
+
+func (fn s3CleanupRoundTripper) RoundTrip(request *http.Request) (*http.Response, error) {
+	return fn(request)
+}
+
+func TestDeleteObjectsAddsContentMD5ForS3Compatibility(t *testing.T) {
+	var requestBody []byte
+	var contentMD5 string
+	transport := s3CleanupRoundTripper(func(request *http.Request) (*http.Response, error) {
+		var err error
+		requestBody, err = io.ReadAll(request.Body)
+		if err != nil {
+			t.Fatalf("read DeleteObjects request body: %v", err)
+		}
+		contentMD5 = request.Header.Get("Content-MD5")
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/xml"}},
+			Body:       io.NopCloser(strings.NewReader("<DeleteResult/>")),
+			Request:    request,
+		}, nil
+	})
+	client := s3.New(s3.Options{
+		BaseEndpoint: aws.String("https://s3.example.test"),
+		Region:       "oss-cn-beijing",
+		UsePathStyle: true,
+		HTTPClient:   &http.Client{Transport: transport},
+		Credentials: credentials.NewStaticCredentialsProvider(
+			"access-key",
+			"secret-key",
+			"",
+		),
+	})
+
+	_, err := client.DeleteObjects(context.Background(), &s3.DeleteObjectsInput{
+		Bucket: aws.String("bucket"),
+		Delete: &types.Delete{
+			Objects: []types.ObjectIdentifier{{Key: aws.String("repo/object")}},
+			Quiet:   aws.Bool(true),
+		},
+	}, addS3DeleteObjectsContentMD5)
+
+	if err != nil {
+		t.Fatalf("DeleteObjects returned error: %v", err)
+	}
+	checksum := md5.Sum(requestBody)
+	want := base64.StdEncoding.EncodeToString(checksum[:])
+	if contentMD5 != want {
+		t.Fatalf("Content-MD5 = %q, want %q for body %q", contentMD5, want, requestBody)
+	}
+}
+
+func TestDeleteObjectIdentifiersFallsBackForAlibabaMissingArgument(t *testing.T) {
+	var deleted []*s3.DeleteObjectInput
+	client := &fakeS3CleanupClient{
+		deleteObjects: func(_ *s3.DeleteObjectsInput) (*s3.DeleteObjectsOutput, error) {
+			return nil, &smithy.GenericAPIError{
+				Code:    "MissingArgument",
+				Message: "Missing Some Required Arguments.",
+			}
+		},
+		deleteObject: func(input *s3.DeleteObjectInput) (*s3.DeleteObjectOutput, error) {
+			deleted = append(deleted, input)
+			return &s3.DeleteObjectOutput{}, nil
+		},
+	}
+
+	err := deleteS3ObjectIdentifiers(
+		context.Background(),
+		client,
+		"bucket",
+		[]types.ObjectIdentifier{
+			{Key: aws.String("repo/current")},
+			{Key: aws.String("repo/versioned"), VersionId: aws.String("version-1")},
+		},
+	)
+
+	if err != nil {
+		t.Fatalf("deleteS3ObjectIdentifiers returned error: %v", err)
+	}
+	if len(deleted) != 2 {
+		t.Fatalf("individual delete count = %d, want 2", len(deleted))
+	}
+	if got := aws.ToString(deleted[0].Key); got != "repo/current" {
+		t.Fatalf("first object key = %q", got)
+	}
+	if deleted[0].VersionId != nil {
+		t.Fatalf("current object unexpectedly has VersionId %q", aws.ToString(deleted[0].VersionId))
+	}
+	if got := aws.ToString(deleted[1].VersionId); got != "version-1" {
+		t.Fatalf("versioned object VersionId = %q", got)
+	}
 }
 
 func TestVerifyS3CleanupOwnershipRejectsMissingMarker(t *testing.T) {

--- a/src/agent/internal/remote/inventory.go
+++ b/src/agent/internal/remote/inventory.go
@@ -53,6 +53,7 @@ func SendInventory(
 			"repository_cleanup_v2",
 			"repository_cleanup_ownership_v1",
 			"repository_cleanup_s3_v1",
+			"repository_cleanup_s3_md5_v2",
 			"repository_ownership_v1",
 			"backup_prepared_snapshot_v1",
 			"backup_operation_reconcile_v1",

--- a/src/backend/apps/storage/provider_catalog/cloud_validation.py
+++ b/src/backend/apps/storage/provider_catalog/cloud_validation.py
@@ -26,6 +26,10 @@ from apps.storage.conf import provider_validation_region_timeout_seconds
 from apps.storage.provider_catalog.credentials import ProviderCredentials
 from apps.storage.provider_catalog.models import StorageProviderRegionValidation
 from apps.storage.provider_catalog.security import validate_managed_endpoint_network
+from apps.storage.s3_compat import (
+    is_s3_batch_delete_compatibility_error,
+    register_s3_delete_objects_compatibility,
+)
 
 
 OWNERSHIP_KEY = ".hyperfilelens-validation/ownership-v1.json"
@@ -85,7 +89,7 @@ def _bucket_name(context: RegionValidationContext) -> str:
 
 def _s3_client(context: RegionValidationContext):
     style = "virtual" if context.region["s3_url_style"] == "virtual_hosted" else "path"
-    return boto3.client(
+    client = boto3.client(
         "s3",
         endpoint_url=f"https://{context.region['external_endpoint']}",
         region_name=context.region["id"],
@@ -103,6 +107,8 @@ def _s3_client(context: RegionValidationContext):
             response_checksum_validation="when_required",
         ),
     )
+    register_s3_delete_objects_compatibility(client)
+    return client
 
 
 def _error_code(exc: ClientError) -> str:
@@ -219,10 +225,17 @@ def _chunks(items: list[dict], size: int = 1000):
 
 def _delete_entries(client, bucket_name: str, entries: list[dict]) -> None:
     for batch in _chunks(entries):
-        response = client.delete_objects(
-            Bucket=bucket_name,
-            Delete={"Objects": batch, "Quiet": True},
-        )
+        try:
+            response = client.delete_objects(
+                Bucket=bucket_name,
+                Delete={"Objects": batch, "Quiet": True},
+            )
+        except ClientError as exc:
+            if not is_s3_batch_delete_compatibility_error(exc):
+                raise
+            for entry in batch:
+                client.delete_object(Bucket=bucket_name, **entry)
+            continue
         if response.get("Errors"):
             raise ProviderRegionValidationError(
                 "BUCKET_CLEANUP_FAILED",

--- a/src/backend/apps/storage/s3_compat.py
+++ b/src/backend/apps/storage/s3_compat.py
@@ -1,0 +1,75 @@
+"""Compatibility helpers shared by S3-compatible storage clients."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+from typing import Any
+
+from botocore.exceptions import ClientError
+
+
+_BATCH_DELETE_COMPATIBILITY_ERROR_CODES = frozenset(
+    {
+        "MissingArgument",
+        "MissingContentMD5",
+        "NotImplemented",
+        "UnsupportedArgument",
+        "UnsupportedOperation",
+    }
+)
+
+
+def _serialized_request_body(body: Any) -> bytes:
+    if body is None:
+        return b""
+    if isinstance(body, str):
+        return body.encode("utf-8")
+    if isinstance(body, (bytes, bytearray, memoryview)):
+        return bytes(body)
+
+    position = body.tell()
+    try:
+        body.seek(0)
+        payload = body.read()
+    finally:
+        body.seek(position)
+    if isinstance(payload, str):
+        return payload.encode("utf-8")
+    if isinstance(payload, (bytes, bytearray, memoryview)):
+        return bytes(payload)
+    raise TypeError("S3 request body must be bytes or a seekable binary stream.")
+
+
+def _add_delete_objects_content_md5(request: Any, **_kwargs: Any) -> None:
+    """Add the checksum required by the common DeleteObjects protocol."""
+
+    if request.headers.get("Content-MD5"):
+        return
+    payload = _serialized_request_body(request.body)
+    request.headers["Content-MD5"] = base64.b64encode(
+        hashlib.md5(payload, usedforsecurity=False).digest()
+    ).decode("ascii")
+
+
+def register_s3_delete_objects_compatibility(client: Any) -> None:
+    """Register portable DeleteObjects request handling on an S3 client."""
+
+    client.meta.events.register(
+        "before-sign.s3.DeleteObjects",
+        _add_delete_objects_content_md5,
+        unique_id="hfl-delete-objects-content-md5",
+    )
+
+
+def is_s3_batch_delete_compatibility_error(exc: ClientError) -> bool:
+    """Return whether exact single-object deletion is a safe fallback."""
+
+    code = str(exc.response.get("Error", {}).get("Code") or "").strip()
+    return code in _BATCH_DELETE_COMPATIBILITY_ERROR_CODES
+
+
+__all__ = [
+    "is_s3_batch_delete_compatibility_error",
+    "register_s3_delete_objects_compatibility",
+]

--- a/src/backend/apps/storage/services/internal/repository_cleanup.py
+++ b/src/backend/apps/storage/services/internal/repository_cleanup.py
@@ -15,6 +15,7 @@ from apps.audit.constants import AuditAction, AuditResult, AuditResourceType
 from apps.audit.services.interface import write_audit_log
 from apps.iam.models import Organization
 from apps.node.models import Node, NodeTask
+from apps.node.services.capabilities import node_capabilities
 from apps.storage.repositories.models import (
     Credential,
     Repository,
@@ -1946,7 +1947,11 @@ def _select_s3_cleanup_agent(repository_task: RepositoryTask) -> Node | None:
             is_deleted=False,
         )
     )
-    eligible = [node for node in candidates if _node_has_s3_cleanup(node)]
+    eligible = [
+        node
+        for node in candidates
+        if _node_has_s3_cleanup(node, platform=repository.s3_platform)
+    ]
     if selected_id:
         selected_any = Node.objects.filter(
             id=selected_id,
@@ -1986,15 +1991,14 @@ def _select_s3_cleanup_agent(repository_task: RepositoryTask) -> Node | None:
     return eligible[0]
 
 
-def _node_has_s3_cleanup(node: Node) -> bool:
-    metadata = node.metadata if isinstance(node.metadata, dict) else {}
-    inventory = (
-        metadata.get("inventory") if isinstance(metadata.get("inventory"), dict) else {}
+def _node_has_s3_cleanup(node: Node, *, platform: str = "") -> bool:
+    capabilities = node_capabilities(node)
+    if str(platform or "").strip().lower() == Repository.S3Platform.ALIYUN:
+        return "repository_cleanup_s3_md5_v2" in capabilities
+    return (
+        "repository_cleanup_s3_v1" in capabilities
+        or "repository_cleanup_s3_md5_v2" in capabilities
     )
-    capabilities = metadata.get("capabilities")
-    if not isinstance(capabilities, list):
-        capabilities = inventory.get("capabilities")
-    return isinstance(capabilities, list) and "repository_cleanup_s3_v1" in capabilities
 
 
 def _task_payload(task: Task) -> dict[str, Any]:

--- a/src/backend/apps/storage/services/internal/s3_client.py
+++ b/src/backend/apps/storage/services/internal/s3_client.py
@@ -13,6 +13,10 @@ from botocore.client import Config
 from botocore.exceptions import BotoCoreError, ClientError, ParamValidationError
 from botocore.regions import EndpointResolverBuiltins
 
+from apps.storage.s3_compat import (
+    is_s3_batch_delete_compatibility_error,
+    register_s3_delete_objects_compatibility,
+)
 from apps.storage.services.internal.s3_url_style import boto3_s3_addressing_style
 
 
@@ -1148,7 +1152,7 @@ def _delete_s3_entries(*, client, bucket: str, entries: list[dict]) -> None:
             Delete={"Objects": entries, "Quiet": True},
         )
     except ClientError as exc:
-        if not _should_fallback_from_batch_delete(exc):
+        if not is_s3_batch_delete_compatibility_error(exc):
             raise
         for entry in entries:
             client.delete_object(Bucket=bucket, **entry)
@@ -1300,13 +1304,6 @@ def _s3_list_object_version_pages(*, client, bucket: str, prefix: str):
             )
             return
         raise
-
-
-def _should_fallback_from_batch_delete(exc: ClientError) -> bool:
-    return (
-        _is_unsupported_s3_header_error(exc)
-        or _client_error_code(exc) == "MissingContentMD5"
-    )
 
 
 def _verify_s3_prefix_empty(*, client, bucket: str, prefix: str) -> None:
@@ -1697,7 +1694,7 @@ def _client(
         request_checksum_calculation="when_required",
         response_checksum_validation="when_required",
     )
-    return boto3.client(
+    client = boto3.client(
         "s3",
         endpoint_url=endpoint_url,
         region_name=normalized_region,
@@ -1707,6 +1704,12 @@ def _client(
         verify=endpoint_url.startswith("https://"),
         config=config,
     )
+    # DeleteObjects requires Content-MD5 across the common S3 compatibility
+    # baseline. Newer Botocore versions send CRC32 instead, which AWS accepts
+    # but Alibaba OSS reports as MissingArgument. Add MD5 before SigV4 signing
+    # while retaining Botocore's checksum for providers that support it.
+    register_s3_delete_objects_compatibility(client)
+    return client
 
 
 def _create_bucket_configuration(region: str | None) -> dict[str, str] | None:

--- a/src/backend/apps/storage/tests/test_provider_catalog_validation.py
+++ b/src/backend/apps/storage/tests/test_provider_catalog_validation.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import copy
 import json
 from datetime import timedelta
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, call, patch
 
 from django.contrib.auth.models import User
 from django.core.cache import cache
@@ -486,12 +486,54 @@ class ProviderBucketOwnershipTests(SimpleTestCase):
             region=region,
             credentials=ProviderCredentials("access", "secret"),
         )
-        with patch("apps.storage.provider_catalog.cloud_validation.boto3.client") as client:
-            cloud_validation._s3_client(context)
+        built_client = Mock()
+        with (
+            patch(
+                "apps.storage.provider_catalog.cloud_validation.boto3.client",
+                return_value=built_client,
+            ) as client_factory,
+            patch(
+                "apps.storage.provider_catalog.cloud_validation."
+                "register_s3_delete_objects_compatibility"
+            ) as register_compatibility,
+        ):
+            result = cloud_validation._s3_client(context)
+
+        self.assertIs(result, built_client)
+        self.assertEqual(
+            client_factory.call_args.kwargs["endpoint_url"],
+            f"https://{region['external_endpoint']}",
+        )
+        register_compatibility.assert_called_once_with(built_client)
+
+    def test_validation_cleanup_falls_back_to_exact_object_deletion(self):
+        client = Mock()
+        client.delete_objects.side_effect = cloud_validation.ClientError(
+            {
+                "Error": {
+                    "Code": "MissingArgument",
+                    "Message": "Missing Some Required Arguments.",
+                }
+            },
+            "DeleteObjects",
+        )
+        entries = [
+            {"Key": "validation/object"},
+            {"Key": "validation/versioned", "VersionId": "version-1"},
+        ]
+
+        cloud_validation._delete_entries(client, "validation-bucket", entries)
 
         self.assertEqual(
-            client.call_args.kwargs["endpoint_url"],
-            f"https://{region['external_endpoint']}",
+            client.delete_object.call_args_list,
+            [
+                call(Bucket="validation-bucket", Key="validation/object"),
+                call(
+                    Bucket="validation-bucket",
+                    Key="validation/versioned",
+                    VersionId="version-1",
+                ),
+            ],
         )
 
     def test_bucket_is_not_deleted_when_cryptographic_proof_does_not_match(self):

--- a/src/backend/apps/storage/tests/test_repository_cleanup.py
+++ b/src/backend/apps/storage/tests/test_repository_cleanup.py
@@ -1038,6 +1038,109 @@ class RepositoryCleanupTests(TestCase):
         self.assertNotIn("secret_access_key", call["persisted_payload"])
 
     @mock.patch(
+        "apps.storage.services.internal.repository_cleanup.delete_s3_bucket_if_empty"
+    )
+    @mock.patch(
+        "apps.storage.services.internal.repository_cleanup.delete_s3_prefix",
+        return_value={"bucket": "cleanup-bucket", "prefix": "managed/repository/"},
+    )
+    @mock.patch(
+        "apps.storage.services.internal.repository_cleanup.verify_s3_repository_deletion_ownership"
+    )
+    @mock.patch("apps.storage.services.internal.repository_cleanup.check_s3_repository")
+    @mock.patch(
+        "apps.storage.services.internal.repository_cleanup.resolve_or_dispatch_repository_agent_operation"
+    )
+    def test_aliyun_cleanup_skips_legacy_agent_without_md5_capability(
+        self,
+        dispatch_agent,
+        _check_repository,
+        verify_owner,
+        controller_delete,
+        delete_bucket,
+    ):
+        repository = self._s3_repository("aliyun-legacy-agent")
+        repository.s3_platform = Repository.S3Platform.ALIYUN
+        repository.save(update_fields=["s3_platform", "updated_at"])
+        Node.objects.create(
+            organization=self.org,
+            name="legacy-s3-cleanup-agent",
+            role=Node.Role.AGENT,
+            status=Node.Status.ACTIVE,
+            availability=Node.Availability.ONLINE,
+            metadata={"inventory": {"capabilities": ["repository_cleanup_s3_v1"]}},
+        )
+        repository_task = create_repository_cleanup_task(
+            repository=repository,
+            dispatch=False,
+        )
+
+        result = run_repository_cleanup_task(repository_task_id=repository_task.id)
+
+        self.assertEqual(result["status"], "success", result)
+        self.assertEqual(result["executor"], "controller")
+        dispatch_agent.assert_not_called()
+        controller_delete.assert_called_once()
+        delete_bucket.assert_not_called()
+        self.assertEqual(verify_owner.call_count, 2)
+
+    @mock.patch("apps.storage.services.internal.repository_cleanup.delete_s3_prefix")
+    @mock.patch(
+        "apps.storage.services.internal.repository_cleanup.verify_s3_repository_deletion_ownership"
+    )
+    @mock.patch("apps.storage.services.internal.repository_cleanup.check_s3_repository")
+    @mock.patch(
+        "apps.storage.services.internal.repository_cleanup.resolve_or_dispatch_repository_agent_operation",
+        return_value=RepositoryAgentOperationResult(
+            waiting=False,
+            node_task_id=None,
+            result={
+                "ownership_verified": True,
+                "physical_cleanup": "deleted",
+                "scope": "s3_prefix",
+                "cleanup_complete": True,
+            },
+        ),
+    )
+    def test_aliyun_cleanup_prefers_agent_with_md5_capability(
+        self,
+        dispatch_agent,
+        _check_repository,
+        _verify_owner,
+        controller_delete,
+    ):
+        repository = self._s3_repository("aliyun-md5-agent")
+        repository.s3_platform = Repository.S3Platform.ALIYUN
+        repository.save(update_fields=["s3_platform", "updated_at"])
+        agent = Node.objects.create(
+            organization=self.org,
+            name="md5-s3-cleanup-agent",
+            role=Node.Role.AGENT,
+            status=Node.Status.ACTIVE,
+            availability=Node.Availability.ONLINE,
+            metadata={
+                "capabilities": ["repository_cleanup_s3_v1"],
+                "inventory": {
+                    "capabilities": [
+                        "repository_cleanup_s3_v1",
+                        "repository_cleanup_s3_md5_v2",
+                    ]
+                }
+            },
+        )
+        repository_task = create_repository_cleanup_task(
+            repository=repository,
+            dispatch=False,
+        )
+
+        result = run_repository_cleanup_task(repository_task_id=repository_task.id)
+
+        self.assertEqual(result["status"], "success", result)
+        self.assertEqual(result["executor"], "agent")
+        self.assertEqual(dispatch_agent.call_args.kwargs["node"].id, agent.id)
+        controller_delete.assert_not_called()
+
+    @mock.patch(
         "apps.storage.services.internal.repository_cleanup.verify_s3_repository_deletion_ownership",
         side_effect=AssertionError("must not re-authorize a completed Agent cleanup"),
     )

--- a/src/backend/apps/storage/tests/test_s3_cleanup.py
+++ b/src/backend/apps/storage/tests/test_s3_cleanup.py
@@ -1,3 +1,5 @@
+import base64
+import hashlib
 import io
 import json
 from unittest import mock
@@ -7,6 +9,7 @@ from django.test import SimpleTestCase
 
 from apps.storage.services.internal.s3_client import (
     S3ClientError,
+    _client,
     delete_s3_bucket_if_empty,
     delete_s3_prefix,
     s3_prefix_has_any_state,
@@ -93,6 +96,47 @@ class S3PrefixCleanupTests(SimpleTestCase):
         client.list_objects_v2.return_value = {}
         client.list_multipart_uploads.return_value = {}
         return client
+
+    def test_delete_objects_request_contains_content_md5_for_serialized_body(self):
+        client = _client(
+            endpoint="https://s3.example.test",
+            region="us-east-1",
+            access_key_id="access-key",
+            secret_access_key="secret-key",
+            s3_url_style="path",
+            use_tls=True,
+            timeout_seconds=1,
+        )
+        captured = {}
+
+        class RequestCaptured(Exception):
+            pass
+
+        def capture_request(request, **_kwargs):
+            captured["body"] = bytes(request.body)
+            captured["content_md5"] = request.headers.get("Content-MD5")
+            raise RequestCaptured
+
+        client.meta.events.register(
+            "before-send.s3.DeleteObjects",
+            capture_request,
+            unique_id="test-capture-delete-objects-request",
+        )
+        try:
+            with self.assertRaises(RequestCaptured):
+                client.delete_objects(
+                    Bucket="bucket",
+                    Delete={"Objects": [{"Key": "repo/object"}], "Quiet": True},
+                )
+        finally:
+            client.close()
+
+        expected = base64.b64encode(
+            hashlib.md5(captured["body"], usedforsecurity=False).digest()
+        )
+        if isinstance(captured["content_md5"], str):
+            expected = expected.decode("ascii")
+        self.assertEqual(captured["content_md5"], expected)
 
     @mock.patch("apps.storage.services.internal.s3_client._client")
     def test_deletes_versions_markers_objects_and_uploads_under_normalized_prefix(
@@ -252,6 +296,10 @@ class S3PrefixCleanupTests(SimpleTestCase):
             (
                 "MissingContentMD5",
                 "Missing required header for this request: Content-Md5.",
+            ),
+            (
+                "MissingArgument",
+                "Missing Some Required Arguments.",
             ),
         )
         for code, message in errors:


### PR DESCRIPTION
## Summary

- add Content-MD5 compatibility for multi-object deletion in the Controller and Agent
- fall back to exact single-object deletion for incompatible S3 implementations
- route Alibaba OSS cleanup away from legacy Agents while preserving Agent-first execution for capable versions
- share the compatibility contract with Provider Catalog validation cleanup

## Safety

- preserve repository ownership verification and prefix boundaries
- retain marker-last deletion and fail-closed handling for unknown remote outcomes
- preserve exact object keys and version IDs during fallback

## Tests

- Django storage test suite: 469 tests passed
- Go test suite: passed
- Go vet: passed
- Ruff and diff checks: passed

Fixes #732