### PR TITLE
Fix scoped shared form styles

### DIFF
--- a/src/frontend/src/pages/insight/AiModelFormPage.vue
+++ b/src/frontend/src/pages/insight/AiModelFormPage.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import '../../styles/fullscreen-form-styles'
 import { computed, onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { lensModelsPath } from '../../lib/lensEngineRoutes'
@@ -310,8 +311,6 @@ onMounted(() => {
   </div>
 </template>
 
-<style src="../../styles/fullscreen-form-shell.css"></style>
-<style src="../../styles/resource-add.css"></style>
 <style scoped>
 .ai-model-form-fullscreen .fullscreen-form-page {
   min-height: calc(var(--app-viewport-height) - var(--app-header-height));

--- a/src/frontend/src/pages/insight/KnowledgeSourceFormPage.vue
+++ b/src/frontend/src/pages/insight/KnowledgeSourceFormPage.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import '../../styles/fullscreen-form-styles'
 import { computed, nextTick, onMounted, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { lensKnowledgePath } from '../../lib/lensEngineRoutes'
@@ -845,8 +846,6 @@ onMounted(() => {
   </div>
 </template>
 
-<style src="../../styles/fullscreen-form-shell.css"></style>
-<style src="../../styles/resource-add.css"></style>
 <style scoped>
 .ks-form-fullscreen .fullscreen-form-page {
   display: flex;

--- a/src/frontend/src/pages/insight/NewCopilotChat.vue
+++ b/src/frontend/src/pages/insight/NewCopilotChat.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import '../../styles/fullscreen-form-styles'
 import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import {
@@ -727,8 +728,6 @@ onBeforeUnmount(() => backupScopeResizeObserver?.disconnect())
   </div>
 </template>
 
-<style src="../../styles/fullscreen-form-shell.css"></style>
-<style src="../../styles/resource-add.css"></style>
 <style scoped>
 .new-copilot-chat-page { padding-bottom: 104px; }
 .new-copilot-chat-page .fullscreen-form-main { scroll-padding: 16px 0 32px; }

--- a/src/frontend/src/pages/node/AddNasRepository.vue
+++ b/src/frontend/src/pages/node/AddNasRepository.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import '../../styles/fullscreen-form-styles'
 import { computed, onMounted, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
@@ -1526,6 +1527,3 @@ watch(enableQuotaAlert, (enabled) => {
 
 }
 </style>
-
-<style src="../../styles/fullscreen-form-shell.css"></style>
-<style src="../../styles/resource-add.css"></style>

--- a/src/frontend/src/pages/node/AddProxyFsRepository.vue
+++ b/src/frontend/src/pages/node/AddProxyFsRepository.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import '../../styles/fullscreen-form-styles'
 import { computed, nextTick, onMounted, reactive, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
@@ -1501,6 +1502,3 @@ watch(enableQuotaAlert, (enabled) => {
   }
 }
 </style>
-
-<style src="../../styles/fullscreen-form-shell.css"></style>
-<style src="../../styles/resource-add.css"></style>

--- a/src/frontend/src/pages/node/AddS3Repo.vue
+++ b/src/frontend/src/pages/node/AddS3Repo.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import '../../styles/fullscreen-form-styles'
 import { ref, computed, onMounted, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
@@ -1943,6 +1944,3 @@ function handleBack() {
   border: 0;
 }
 </style>
-
-<style src="../../styles/fullscreen-form-shell.css"></style>
-<style src="../../styles/resource-add.css"></style>

--- a/src/frontend/src/pages/node/EditProxyFsRepo.vue
+++ b/src/frontend/src/pages/node/EditProxyFsRepo.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import '../../styles/fullscreen-form-styles'
 /**
  * --------------------------------------------------------------------------
  */
@@ -427,8 +428,6 @@ watch(repositoryId, (id) => {
   </div>
 </template>
 
-<style src="../../styles/fullscreen-form-shell.css"></style>
-<style src="../../styles/resource-add.css"></style>
 <style scoped>
 .edit-proxy-fs-locked-badge {
   display: inline-flex;

--- a/src/frontend/src/pages/node/EditS3Repo.vue
+++ b/src/frontend/src/pages/node/EditS3Repo.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import '../../styles/fullscreen-form-styles'
 import { computed, onMounted, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
@@ -901,8 +902,6 @@ watch(repositoryId, (id) => {
   </div>
 </template>
 
-<style src="../../styles/fullscreen-form-shell.css"></style>
-<style src="../../styles/resource-add.css"></style>
 <style scoped>
 /* Override add-s3 layout paddings to suit edit page; reuse add-s3-platform-btn styling */
 .edit-s3-page .fullscreen-form-main { padding-bottom: 0; }

--- a/src/frontend/src/pages/node/NodesDeploy.vue
+++ b/src/frontend/src/pages/node/NodesDeploy.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import '../../styles/fullscreen-form-styles'
 import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
@@ -163,7 +164,5 @@ function handleBack() {
   </Teleport>
 </template>
 
-<style src="../../styles/fullscreen-form-shell.css"></style>
-<style src="../../styles/resource-add.css"></style>
 <style src="../../styles/source-deploy-ui.css"></style>
 <style src="../../styles/agent-install-wizard.css"></style>

--- a/src/frontend/src/pages/node/RepairNasRepository.vue
+++ b/src/frontend/src/pages/node/RepairNasRepository.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import '../../styles/fullscreen-form-styles'
 import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
@@ -1876,6 +1877,3 @@ onMounted(async () => {
 
 }
 </style>
-
-<style src="../../styles/fullscreen-form-shell.css"></style>
-<style src="../../styles/resource-add.css"></style>

--- a/src/frontend/src/pages/ops/AlertPolicyEditorPage.vue
+++ b/src/frontend/src/pages/ops/AlertPolicyEditorPage.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import '../../styles/fullscreen-form-styles'
 import { computed, nextTick, onMounted, reactive, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
@@ -1515,6 +1516,4 @@ onMounted(async () => {
   </div>
 </template>
 
-<style src="../../styles/fullscreen-form-shell.css"></style>
-<style src="../../styles/resource-add.css"></style>
 <style src="../../styles/alert-policy-editor.css"></style>

--- a/src/frontend/src/pages/ops/NotificationChannelEditorPage.vue
+++ b/src/frontend/src/pages/ops/NotificationChannelEditorPage.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import '../../styles/fullscreen-form-styles'
 import { computed, nextTick, onMounted, reactive, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
@@ -844,6 +845,3 @@ watch(() => form.type, () => {
     </div>
   </div>
 </template>
-
-<style src="../../styles/fullscreen-form-shell.css"></style>
-<style src="../../styles/resource-add.css"></style>

--- a/src/frontend/src/pages/protection/BackupCreateWizard.vue
+++ b/src/frontend/src/pages/protection/BackupCreateWizard.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import '../../styles/fullscreen-form-styles'
 import { computed, defineComponent, h, nextTick, onMounted, onUnmounted, reactive, ref, watch, type Component } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
@@ -10419,8 +10420,6 @@ function preserveShallowestPathOrder(paths: string[]) {
   </component>
 </template>
 
-<style src="../../styles/fullscreen-form-shell.css"></style>
-<style src="../../styles/resource-add.css"></style>
 <style src="../../styles/source-deploy-ui.css"></style>
 <style src="../../styles/agent-install-wizard.css"></style>
 <style scoped>

--- a/src/frontend/src/pages/protection/BackupSources.vue
+++ b/src/frontend/src/pages/protection/BackupSources.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import '../../styles/fullscreen-form-styles'
 import { computed, nextTick, onMounted, onUnmounted, reactive, ref, toRef, watch } from 'vue'
 import { RouterLink, useRoute, useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
@@ -3138,8 +3139,6 @@ onUnmounted(() => {
   </ModulePage>
 </template>
 
-<style src="../../styles/fullscreen-form-shell.css"></style>
-<style src="../../styles/resource-add.css"></style>
 <style src="../../styles/source-deploy-ui.css"></style>
 <style src="../../styles/agent-install-wizard.css"></style>
 <style scoped>

--- a/src/frontend/src/pages/protection/DataProtection.vue
+++ b/src/frontend/src/pages/protection/DataProtection.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import '../../styles/fullscreen-form-styles'
 import { computed, defineAsyncComponent, h, nextTick, onMounted, onUnmounted, reactive, ref, watch } from 'vue'
 import { onBeforeRouteLeave, useRoute, useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
@@ -13931,8 +13932,6 @@ async function runRecovery(mode: 'plan' | 'manual' = 'manual') {
   </ModulePage>
 </template>
 
-<style src="../../styles/fullscreen-form-shell.css"></style>
-<style src="../../styles/resource-add.css"></style>
 <style src="../../styles/source-deploy-ui.css"></style>
 <style src="../../styles/agent-install-wizard.css"></style>
 <style scoped>

--- a/src/frontend/src/pages/protection/PolicyEditorPage.vue
+++ b/src/frontend/src/pages/protection/PolicyEditorPage.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import '../../styles/fullscreen-form-styles'
 import { computed, onMounted, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
@@ -508,8 +509,6 @@ onMounted(() => {
   </div>
 </template>
 
-<style src="../../styles/fullscreen-form-shell.css"></style>
-<style src="../../styles/resource-add.css"></style>
 <style src="../../styles/policy-editor-page.css"></style>
 <style scoped>
 .policy-editor-fullscreen .policy-section-nested {

--- a/src/frontend/src/platform-ops/pages/engine/PlatformGatewayAdd.vue
+++ b/src/frontend/src/platform-ops/pages/engine/PlatformGatewayAdd.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import '../../../styles/fullscreen-form-styles'
 import { computed, onMounted, onUnmounted, ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
@@ -154,7 +155,5 @@ onUnmounted(() => {
   />
 </template>
 
-<style src="../../../styles/fullscreen-form-shell.css"></style>
-<style src="../../../styles/resource-add.css"></style>
 <style src="../../../styles/source-deploy-ui.css"></style>
 <style src="../../../styles/agent-install-wizard.css"></style>

--- a/src/frontend/src/styles/fullscreen-form-styles.ts
+++ b/src/frontend/src/styles/fullscreen-form-styles.ts
@@ -1,0 +1,2 @@
+import './fullscreen-form-shell.css'
+import './resource-add.css'

--- a/src/frontend/src/styles/fullscreenFormStyleOwnership.test.ts
+++ b/src/frontend/src/styles/fullscreenFormStyleOwnership.test.ts
@@ -1,0 +1,61 @@
+import { readdirSync, readFileSync } from 'node:fs'
+import { relative, resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const sourceRoot = resolve(process.cwd(), 'src')
+const sharedStyleEntry = resolve(sourceRoot, 'styles/fullscreen-form-styles.ts')
+
+function vueSourcesBelow(directory: string): string[] {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const path = resolve(directory, entry.name)
+    if (entry.isDirectory()) return vueSourcesBelow(path)
+    return path.endsWith('.vue') ? [path] : []
+  })
+}
+
+describe('fullscreen form style ownership', () => {
+  it('loads shared fullscreen form styles through an unscoped script entry', () => {
+    expect(readFileSync(sharedStyleEntry, 'utf8')).toBe([
+      "import './fullscreen-form-shell.css'",
+      "import './resource-add.css'",
+      '',
+    ].join('\n'))
+  })
+
+  it('does not process shared global styles through Vue style blocks', () => {
+    const externalStylePattern = /<style[^>]+src=["'][^"']*(?:fullscreen-form-shell|resource-add)\.css["'][^>]*>/
+    const offenders = vueSourcesBelow(sourceRoot)
+      .filter((file) => externalStylePattern.test(readFileSync(file, 'utf8')))
+      .map((file) => relative(sourceRoot, file))
+      .sort()
+
+    expect(offenders).toEqual([])
+  })
+
+  it('keeps every migrated consumer on the route-loadable shared entry', () => {
+    const consumers = vueSourcesBelow(sourceRoot)
+      .filter((file) => readFileSync(file, 'utf8').includes("styles/fullscreen-form-styles'"))
+      .map((file) => relative(sourceRoot, file))
+      .sort()
+
+    expect(consumers).toEqual([
+      'pages/insight/AiModelFormPage.vue',
+      'pages/insight/KnowledgeSourceFormPage.vue',
+      'pages/insight/NewCopilotChat.vue',
+      'pages/node/AddNasRepository.vue',
+      'pages/node/AddProxyFsRepository.vue',
+      'pages/node/AddS3Repo.vue',
+      'pages/node/EditProxyFsRepo.vue',
+      'pages/node/EditS3Repo.vue',
+      'pages/node/NodesDeploy.vue',
+      'pages/node/RepairNasRepository.vue',
+      'pages/ops/AlertPolicyEditorPage.vue',
+      'pages/ops/NotificationChannelEditorPage.vue',
+      'pages/protection/BackupCreateWizard.vue',
+      'pages/protection/BackupSources.vue',
+      'pages/protection/DataProtection.vue',
+      'pages/protection/PolicyEditorPage.vue',
+      'platform-ops/pages/engine/PlatformGatewayAdd.vue',
+    ])
+  })
+})


### PR DESCRIPTION
## Summary

- load fullscreen form styles through a shared unscoped script entry
- migrate all existing consumers away from repeated SFC `style src` imports
- prevent production CSS extraction from attaching an unrelated Vue scope identifier
- add regression coverage for shared style ownership and migrated consumers

## Testing

- `npm run test` (223 files, 1155 tests)
- `npm run lint`
- `npm run build`
- verified the production build emits one `resource-add-*.css` asset
- verified the S3 platform grid selector is emitted without a `data-v-*` qualifier
- verified the Add S3 layout in the development environment through the backup configuration workflow

`npm run build` retains the existing Vite warnings about the mixed static/dynamic router import and large chunks.

Closes #708
