### PR TITLE
fix(agent): keep reinstallation local and repair user service setup

### DIFF
--- a/src/agent/internal/enroll/preflight.go
+++ b/src/agent/internal/enroll/preflight.go
@@ -30,6 +30,9 @@ type EnvironmentReport struct {
 // RunEnvironmentChecks validates the host and prints user-facing results.
 func RunEnvironmentChecks(ctx context.Context, cfg Config) (*EnvironmentReport, error) {
 	failures := &preflightFailures{}
+	// Existing-install and cross-mode conflicts are deliberately determined
+	// only from local installation markers. Do not make the control plane or a
+	// host fingerprint an installation-admission authority.
 	report := &EnvironmentReport{
 		Platform: platformDescription(),
 		ArchOK:   supportedRuntimeArch(),

--- a/src/agent/internal/platform/install/install_ps1_test.go
+++ b/src/agent/internal/platform/install/install_ps1_test.go
@@ -132,8 +132,11 @@ func TestInstallPs1RetiresIdentityBeforeRemovingAgent(t *testing.T) {
 	if strings.Index(source, retire) > strings.Index(source, remove) {
 		t.Fatal("install.ps1 removes hfl-agent before retiring installation identity")
 	}
-	if !strings.Contains(source, "remove the old console record before reinstalling or changing run mode") {
-		t.Fatal("install.ps1 does not explain the retired installation identity")
+	if !strings.Contains(source, "the existing console record is preserved and the next installation will register a new record") {
+		t.Fatal("install.ps1 does not explain that local uninstall preserves the console record")
+	}
+	if strings.Contains(source, "remove the old console record") {
+		t.Fatal("install.ps1 must not require local uninstall to change the console record")
 	}
 	if !strings.Contains(source, "-KeepInstallationIdentity") {
 		t.Fatal("install.ps1 missing incomplete-install rollback flag")

--- a/src/agent/internal/platform/install/install_sh_test.go
+++ b/src/agent/internal/platform/install/install_sh_test.go
@@ -4,6 +4,7 @@ package install
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -36,8 +37,11 @@ func TestInstallShellRetiresIdentityBeforeRemovingAgent(t *testing.T) {
 	if strings.Index(body, retire) > strings.Index(body, remove) {
 		t.Fatal("install.sh removes hfl-agent before retiring installation identity")
 	}
-	if !strings.Contains(body, "remove the old console record before reinstalling or changing run mode") {
-		t.Fatal("install.sh does not explain the retired installation identity")
+	if !strings.Contains(body, "the existing console record is preserved and the next installation will register a new record") {
+		t.Fatal("install.sh does not explain that local uninstall preserves the console record")
+	}
+	if strings.Contains(body, "remove the old console record") {
+		t.Fatal("install.sh must not require local uninstall to change the console record")
 	}
 	if !strings.Contains(body, "--keep-installation-identity") {
 		t.Fatal("install.sh missing incomplete-install rollback flag")
@@ -57,8 +61,8 @@ func TestInstallShellDefinesUserLifecycleForLinuxAndMacOS(t *testing.T) {
 		`loginctl is required to verify that current-user mode stops after sign-out.`,
 		`WantedBy=default.target`,
 		`Description=HyperFileLens Agent (Current User)`,
-		`EnvironmentFile="${unit_env_file}"`,
-		`WorkingDirectory="${unit_working_dir}"`,
+		`EnvironmentFile=${unit_env_file}`,
+		`WorkingDirectory=${unit_working_dir}`,
 		`ExecStart="${unit_agent}" run`,
 		`systemd_escape_unit_value`,
 		`An active macOS user session is required for user-level installation.`,
@@ -67,6 +71,50 @@ func TestInstallShellDefinesUserLifecycleForLinuxAndMacOS(t *testing.T) {
 		if !strings.Contains(body, want) {
 			t.Fatalf("install.sh missing user lifecycle rule %q", want)
 		}
+	}
+}
+
+func TestUserSystemdUnitTemplateIsValid(t *testing.T) {
+	if _, err := exec.LookPath("systemd-analyze"); err != nil {
+		t.Skip("systemd-analyze is not available")
+	}
+
+	body := readPackagingInstallShell(t)
+	functionStart := strings.Index(body, "install_systemd_unit() {")
+	if functionStart < 0 {
+		t.Fatal("install.sh missing install_systemd_unit")
+	}
+	body = body[functionStart:]
+	heredocStart := strings.Index(body, `cat >"${UNIT_DST}" <<EOF`+"\n")
+	if heredocStart < 0 {
+		t.Fatal("install.sh missing user systemd unit template")
+	}
+	template := body[heredocStart+len(`cat >"${UNIT_DST}" <<EOF`)+1:]
+	heredocEnd := strings.Index(template, "\nEOF")
+	if heredocEnd < 0 {
+		t.Fatal("install.sh user systemd unit template is not terminated")
+	}
+	template = template[:heredocEnd]
+
+	workingDir := filepath.Join(t.TempDir(), "agent home")
+	if err := os.MkdirAll(workingDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	envFile := filepath.Join(workingDir, "agent.env")
+	if err := os.WriteFile(envFile, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	unit := strings.NewReplacer(
+		"${unit_env_file}", envFile,
+		"${unit_working_dir}", workingDir,
+		"${unit_agent}", "/bin/true",
+	).Replace(template)
+	unitPath := filepath.Join(t.TempDir(), "hyperfilelens-agent.service")
+	if err := os.WriteFile(unitPath, []byte(unit), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if output, err := exec.Command("systemd-analyze", "verify", unitPath).CombinedOutput(); err != nil {
+		t.Fatalf("invalid user systemd unit:\n%s\n%s", unit, output)
 	}
 }
 

--- a/src/agent/internal/platform/install/local_uninstall_unix.go
+++ b/src/agent/internal/platform/install/local_uninstall_unix.go
@@ -502,7 +502,7 @@ if [[ "$KEEP_DATA" == "1" ]]; then
     AGENT_ARTIFACTS_FAILED=1
     exit 1
   fi
-	log "retired installation identity; remove the old console record before reinstalling or changing run mode"
+	log "retired installation identity; the existing console record is preserved and the next installation will register a new record"
 fi
 
 for target in "$INSTALL_DIR/hfl-agent" "$INSTALL_DIR/kopia" "$INSTALL_DIR/run-agent.sh" "$INSTALL_DIR/INSTALLED_VERSION" "$INSTALL_DIR/install.sh" "$INSTALL_DIR/MANIFEST.json"; do

--- a/src/agent/internal/platform/install/local_uninstall_unix_test.go
+++ b/src/agent/internal/platform/install/local_uninstall_unix_test.go
@@ -97,6 +97,12 @@ func TestWriteUnixUninstallScriptIncludesLogFile(t *testing.T) {
 	if !strings.Contains(body, `config retire-installation --data-dir "$DATA_DIR"`) {
 		t.Fatalf("script must retire installation identity when data is preserved:\n%s", body)
 	}
+	if !strings.Contains(body, "the existing console record is preserved and the next installation will register a new record") {
+		t.Fatalf("script must preserve the console record during local uninstall:\n%s", body)
+	}
+	if strings.Contains(body, "remove the old console record") {
+		t.Fatalf("script must not require local uninstall to change the console record:\n%s", body)
+	}
 	unmountAt := strings.Index(body, `unmount_agent_mounts "$DATA_DIR"`)
 	stopAt := strings.Index(body, `hfl_systemctl stop "$SERVICE_NAME"`)
 	retireAt := strings.Index(body, `config retire-installation --data-dir "$DATA_DIR"`)

--- a/src/agent/internal/platform/install/local_uninstall_windows.go
+++ b/src/agent/internal/platform/install/local_uninstall_windows.go
@@ -361,7 +361,7 @@ try {
       if ($LASTEXITCODE -ne 0) {
         throw "hfl-agent exited with code $LASTEXITCODE"
       }
-      Log "retired installation identity; remove the old console record before reinstalling or changing run mode"
+      Log "retired installation identity; the existing console record is preserved and the next installation will register a new record"
     } catch {
       Add-CleanupFailure -code 'installation_identity_retirement_failed' -detail $_.Exception.Message -retained @('installation_identity')
       throw

--- a/src/agent/internal/platform/install/local_uninstall_windows_test.go
+++ b/src/agent/internal/platform/install/local_uninstall_windows_test.go
@@ -183,6 +183,12 @@ func TestWriteWindowsUninstallScriptKeepDataSkipsPurgeAll(t *testing.T) {
 	if !strings.Contains(text, `config retire-installation --data-dir $data`) {
 		t.Fatalf("keep_data script does not retire installation identity:\n%s", text)
 	}
+	if !strings.Contains(text, "the existing console record is preserved and the next installation will register a new record") {
+		t.Fatalf("keep_data script must preserve the console record during local uninstall:\n%s", text)
+	}
+	if strings.Contains(text, "remove the old console record") {
+		t.Fatalf("keep_data script must not require local uninstall to change the console record:\n%s", text)
+	}
 	assertOrdered(t, text,
 		`config retire-installation --data-dir $data`,
 		`if ($keep -eq '0') {`,

--- a/src/agent/packaging/install/install.ps1
+++ b/src/agent/packaging/install/install.ps1
@@ -1423,7 +1423,7 @@ function Invoke-Uninstall {
     if ($LASTEXITCODE -ne 0) {
       throw "Failed to retire the local installation identity; Agent files and data were preserved for retry."
     }
-    Write-HflOk "Local installation identity retired; remove the old console record before reinstalling or changing run mode."
+    Write-HflOk "Local installation identity retired; the existing console record is preserved and the next installation will register a new record."
   }
   elseif ($KeepInstallationIdentity) {
     Write-HflSkip "installation identity preserved for install retry"

--- a/src/agent/packaging/install/install.sh
+++ b/src/agent/packaging/install/install.sh
@@ -1267,8 +1267,8 @@ StartLimitIntervalSec=0
 
 [Service]
 Type=simple
-EnvironmentFile="${unit_env_file}"
-WorkingDirectory="${unit_working_dir}"
+EnvironmentFile=${unit_env_file}
+WorkingDirectory=${unit_working_dir}
 ExecStart="${unit_agent}" run
 Restart=always
 RestartSec=5
@@ -1819,7 +1819,7 @@ retire_installation_identity() {
 		"${agent_bin}" config retire-installation --data-dir "${data_dir}"; then
 		log_fail "Failed to retire the local installation identity; Agent files and data were preserved for retry." 1
 	fi
-	log_ok "Local installation identity retired; remove the old console record before reinstalling or changing run mode."
+	log_ok "Local installation identity retired; the existing console record is preserved and the next installation will register a new record."
 }
 
 uninstall_gateway_sidecar_if_needed() {

--- a/src/backend/apps/node/api/views/node.py
+++ b/src/backend/apps/node/api/views/node.py
@@ -70,19 +70,6 @@ def health(_request):
     return JsonResponse({"app": "node", "status": "ok"})
 
 
-def _host_install_conflict_response() -> Response:
-    return Response(
-        {
-            "error": (
-                "another Agent installation record already exists for this host; "
-                "uninstall the existing Agent and remove its console record before "
-                "installing again or changing run mode"
-            )
-        },
-        status=status.HTTP_409_CONFLICT,
-    )
-
-
 class NodeViewSet(OrgScopedMixin, SoftDeleteDestroyMixin, viewsets.ModelViewSet):
     org_scoped_skip_actions = ("heartbeat",)
 
@@ -497,6 +484,10 @@ class NodeViewSet(OrgScopedMixin, SoftDeleteDestroyMixin, viewsets.ModelViewSet)
                     )
                 node = None
                 if installation_id:
+                    # The installation identity is authoritative; the host
+                    # fingerprint is non-unique correlation metadata. A fresh
+                    # local installation must create a new Node even when an
+                    # older record has the same host fingerprint.
                     node = (
                         Node.objects.select_for_update()
                         .filter(
@@ -506,23 +497,6 @@ class NodeViewSet(OrgScopedMixin, SoftDeleteDestroyMixin, viewsets.ModelViewSet)
                         )
                         .first()
                     )
-                if host_fingerprint:
-                    conflicting_host = (
-                        Node.objects.select_for_update()
-                        .filter(host_fingerprint=host_fingerprint)
-                        .exclude(pk=node.pk if node is not None else None)
-                        .first()
-                    )
-                    if conflicting_host is not None:
-                        return _host_install_conflict_response()
-                    if node is not None and node.host_fingerprint not in (
-                        "",
-                        host_fingerprint,
-                    ):
-                        return Response(
-                            {"error": "installation identity belongs to another host"},
-                            status=status.HTTP_409_CONFLICT,
-                        )
                 if (
                     node is not None
                     and node.installation_mode != token_row.installation_mode
@@ -566,12 +540,6 @@ class NodeViewSet(OrgScopedMixin, SoftDeleteDestroyMixin, viewsets.ModelViewSet)
                             )
                     except IntegrityError:
                         if not installation_id:
-                            if host_fingerprint and (
-                                Node.objects.select_for_update()
-                                .filter(host_fingerprint=host_fingerprint)
-                                .exists()
-                            ):
-                                return _host_install_conflict_response()
                             raise
                         node = (
                             Node.objects.select_for_update()
@@ -583,12 +551,6 @@ class NodeViewSet(OrgScopedMixin, SoftDeleteDestroyMixin, viewsets.ModelViewSet)
                             .first()
                         )
                         if node is None:
-                            if host_fingerprint and (
-                                Node.objects.select_for_update()
-                                .filter(host_fingerprint=host_fingerprint)
-                                .exists()
-                            ):
-                                return _host_install_conflict_response()
                             raise
                         if node.installation_mode != token_row.installation_mode:
                             return Response(
@@ -599,26 +561,6 @@ class NodeViewSet(OrgScopedMixin, SoftDeleteDestroyMixin, viewsets.ModelViewSet)
                                 },
                                 status=status.HTTP_409_CONFLICT,
                             )
-                        if host_fingerprint and node.host_fingerprint not in (
-                            "",
-                            host_fingerprint,
-                        ):
-                            return Response(
-                                {
-                                    "error": (
-                                        "installation identity belongs to another host"
-                                    )
-                                },
-                                status=status.HTTP_409_CONFLICT,
-                            )
-                        if (
-                            host_fingerprint
-                            and Node.objects.select_for_update()
-                            .filter(host_fingerprint=host_fingerprint)
-                            .exclude(pk=node.pk)
-                            .exists()
-                        ):
-                            return _host_install_conflict_response()
                         created_node = False
                     else:
                         unique_name = uniquify_node_name(
@@ -630,12 +572,8 @@ class NodeViewSet(OrgScopedMixin, SoftDeleteDestroyMixin, viewsets.ModelViewSet)
                             node.name = unique_name
                             node.save(update_fields=["name", "updated_at"])
                 if host_fingerprint and not node.host_fingerprint:
-                    try:
-                        with transaction.atomic():
-                            node.host_fingerprint = host_fingerprint
-                            node.save(update_fields=["host_fingerprint", "updated_at"])
-                    except IntegrityError:
-                        return _host_install_conflict_response()
+                    node.host_fingerprint = host_fingerprint
+                    node.save(update_fields=["host_fingerprint", "updated_at"])
                 credential_reused = bool(
                     not created_node
                     and existing_node_credential
@@ -685,18 +623,6 @@ class NodeViewSet(OrgScopedMixin, SoftDeleteDestroyMixin, viewsets.ModelViewSet)
                     {"error": "installation mode is fixed during enrollment"},
                     status=status.HTTP_409_CONFLICT,
                 )
-            if host_fingerprint:
-                if node.host_fingerprint not in ("", host_fingerprint):
-                    return Response(
-                        {"error": "installation identity belongs to another host"},
-                        status=status.HTTP_409_CONFLICT,
-                    )
-                if (
-                    Node.objects.filter(host_fingerprint=host_fingerprint)
-                    .exclude(pk=node.pk)
-                    .exists()
-                ):
-                    return _host_install_conflict_response()
             if legacy_token is not None:
                 token_row = legacy_token
                 node_credential = issue_node_credential(
@@ -746,18 +672,7 @@ class NodeViewSet(OrgScopedMixin, SoftDeleteDestroyMixin, viewsets.ModelViewSet)
                 node.connection_ip_address = client_ip
             if host_fingerprint and not node.host_fingerprint:
                 node.host_fingerprint = host_fingerprint
-            try:
-                with transaction.atomic():
-                    node.save()
-            except IntegrityError:
-                if (
-                    host_fingerprint
-                    and Node.objects.filter(host_fingerprint=host_fingerprint)
-                    .exclude(pk=node.pk)
-                    .exists()
-                ):
-                    return _host_install_conflict_response()
-                raise
+            node.save()
         else:
             return Response(
                 {"error": "node not found; enrollment token required"},

--- a/src/backend/apps/node/migrations/0016_allow_reinstalled_host_records.py
+++ b/src/backend/apps/node/migrations/0016_allow_reinstalled_host_records.py
@@ -1,0 +1,30 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("node", "0015_node_installation_mode"),
+    ]
+
+    operations = [
+        # Reinstallation preserves old console records, so multiple records
+        # may intentionally correlate to the same physical host.
+        migrations.RemoveConstraint(
+            model_name="node",
+            name="node_unique_active_host_fingerprint",
+        ),
+        migrations.AlterField(
+            model_name="node",
+            name="host_fingerprint",
+            field=models.CharField(
+                blank=True,
+                db_index=True,
+                default="",
+                help_text=(
+                    "Non-authoritative product-scoped digest used only for host "
+                    "correlation; duplicate values are expected after reinstallation."
+                ),
+                max_length=64,
+            ),
+        ),
+    ]

--- a/src/backend/apps/node/models/node.py
+++ b/src/backend/apps/node/models/node.py
@@ -54,7 +54,10 @@ class Node(OrganizationScopedModel):
         blank=True,
         default="",
         db_index=True,
-        help_text="Product-scoped digest used to prevent duplicate host installations.",
+        help_text=(
+            "Non-authoritative product-scoped digest used only for host correlation; "
+            "duplicate values are expected after reinstallation."
+        ),
     )
     ip_address = models.GenericIPAddressField(
         blank=True,
@@ -116,6 +119,8 @@ class Node(OrganizationScopedModel):
             ),
         ]
         constraints = [
+            # host_fingerprint is deliberately not unique: each fresh local
+            # installation keeps the old Node and creates a new record.
             models.CheckConstraint(
                 condition=(
                     models.Q(installation_mode=NodeInstallationMode.SYSTEM)
@@ -127,11 +132,6 @@ class Node(OrganizationScopedModel):
                 fields=["organization", "role", "installation_id"],
                 condition=models.Q(is_deleted=False) & ~models.Q(installation_id=""),
                 name="node_unique_installation_identity",
-            ),
-            models.UniqueConstraint(
-                fields=["host_fingerprint"],
-                condition=models.Q(is_deleted=False) & ~models.Q(host_fingerprint=""),
-                name="node_unique_active_host_fingerprint",
             ),
         ]
 

--- a/src/backend/apps/node/tests/test_enrollment_token_reuse.py
+++ b/src/backend/apps/node/tests/test_enrollment_token_reuse.py
@@ -74,7 +74,7 @@ class EnrollmentTokenReuseTests(TestCase):
         self.assertIsNotNone(self.token_row.used_at)
         self.assertEqual(Node.objects.filter(organization=self.org).count(), 2)
 
-    def test_host_fingerprint_prevents_a_second_installation(self):
+    def test_new_installation_on_same_host_creates_a_new_node(self):
         fingerprint = "a" * 64
         first = self._heartbeat(
             name="host-a",
@@ -92,11 +92,16 @@ class EnrollmentTokenReuseTests(TestCase):
             host_fingerprint=fingerprint,
         )
 
-        self.assertEqual(second.status_code, 409)
-        self.assertIn("remove its console record", second.data["error"])
-        self.assertEqual(Node.objects.filter(organization=self.org).count(), 1)
+        self.assertEqual(second.status_code, 200)
+        self.assertNotEqual(first.data["node_id"], second.data["node_id"])
+        nodes = list(Node.objects.filter(organization=self.org).order_by("id"))
+        self.assertEqual(len(nodes), 2)
+        self.assertEqual(nodes[0].installation_mode, NodeInstallationMode.SYSTEM)
+        self.assertEqual(nodes[1].installation_mode, NodeInstallationMode.USER)
+        self.assertEqual(nodes[0].host_fingerprint, fingerprint)
+        self.assertEqual(nodes[1].host_fingerprint, fingerprint)
 
-    def test_offline_host_must_be_uninstalled_before_changing_mode(self):
+    def test_offline_host_record_is_preserved_when_a_new_agent_is_installed(self):
         fingerprint = "c" * 64
         first = self._heartbeat(
             name="host-a",
@@ -118,14 +123,24 @@ class EnrollmentTokenReuseTests(TestCase):
             host_fingerprint=fingerprint,
         )
 
-        self.assertEqual(replacement.status_code, 409)
-        self.assertEqual(Node.objects.filter(organization=self.org).count(), 1)
+        self.assertEqual(replacement.status_code, 200)
+        self.assertEqual(Node.objects.filter(organization=self.org).count(), 2)
         node.refresh_from_db()
         self.assertEqual(node.installation_id, "hfli_host_a")
         self.assertEqual(node.installation_mode, NodeInstallationMode.SYSTEM)
+        self.assertEqual(node.availability, Node.Availability.OFFLINE)
         self.assertTrue(validate_node_credential(node, first_credential, touch=False))
+        replacement_node = Node.objects.get(pk=replacement.data["node_id"])
+        self.assertEqual(
+            replacement_node.installation_id,
+            "hfli_host_a_user",
+        )
+        self.assertEqual(
+            replacement_node.installation_mode,
+            NodeInstallationMode.USER,
+        )
 
-    def test_database_rejects_duplicate_active_host_fingerprint(self):
+    def test_database_allows_duplicate_active_host_fingerprint(self):
         fingerprint = "b" * 64
         Node.objects.create(
             organization=self.org,
@@ -134,13 +149,17 @@ class EnrollmentTokenReuseTests(TestCase):
             host_fingerprint=fingerprint,
         )
 
-        with self.assertRaises(IntegrityError), transaction.atomic():
-            Node.objects.create(
-                organization=self.org,
-                name="host-b",
-                role=NodeRole.AGENT,
-                host_fingerprint=fingerprint,
-            )
+        Node.objects.create(
+            organization=self.org,
+            name="host-b",
+            role=NodeRole.AGENT,
+            host_fingerprint=fingerprint,
+        )
+
+        self.assertEqual(
+            Node.objects.filter(host_fingerprint=fingerprint).count(),
+            2,
+        )
 
     @mock.patch(
         "apps.node.api.views.node.sync_agent_source_host",


### PR DESCRIPTION
## Summary

- make local installation identity authoritative while preserving previous console records after reinstall
- keep host fingerprints as non-unique correlation metadata and enforce duplicate-install checks locally
- fix Linux current-user systemd unit path syntax and align local uninstall messaging across platforms
- add regression coverage for reinstallation semantics, console-record preservation, and generated systemd units

## Validation

- go test ./...
- python manage.py test apps.node.tests (339 tests)
- ruff check for modified backend files
- python manage.py makemigrations --check --dry-run
- bash -n src/agent/packaging/install/install.sh
- systemd-analyze verify for the generated current-user unit
- git diff --check

Refs #427