### PR TITLE
fix(agent): stabilize current-user runtime and path access

### DIFF
--- a/language-packs/packs/zh-hans/frontend/messages.json
+++ b/language-packs/packs/zh-hans/frontend/messages.json
@@ -3825,7 +3825,7 @@
     "installationModeSystem": "系统服务",
     "installationModeUser": "当前用户",
     "installationModeSystemHint": "需要管理员授权安装。用户注销后仍持续运行，可保护系统服务账号有权访问的文件，并持续采集监控数据。",
-    "installationModeUserHint": "无需管理员权限。仅保护当前用户 Home 目录，用户注销后暂停，并在该用户登录期间采集监控数据。",
+    "installationModeUserHint": "无需管理员权限。可保护当前用户有权访问的文件（Linux/macOS 为 Home 目录，Windows 为可访问的本地磁盘），用户注销后暂停，并在登录期间采集监控数据。",
     "osMetaLinux": "主流发行版 · x86_64 或 ARM64",
     "osMetaWindows": "Win 10/11 · Server 2016+ · 仅 64 位",
     "osMetaMacos": "Intel 或 Apple Silicon",

--- a/language-packs/packs/zh-hans/frontend/source-lock.json
+++ b/language-packs/packs/zh-hans/frontend/source-lock.json
@@ -3671,7 +3671,7 @@
   "nodeLifecycle.installationModeSystem": "7accdc46ad039bdfbf89121fdefd554d283a929c7dde42630f1da357bd8c5a84",
   "nodeLifecycle.installationModeUser": "64144b25471810b62da54dd2cc380763640aa32c24156b1c96078e85aee3c3de",
   "nodeLifecycle.installationModeSystemHint": "909f5e4c51657a08a69112b7e454b8459a1091a002fdaede7a6cb201070218f9",
-  "nodeLifecycle.installationModeUserHint": "3868df6623402240a68cd84dc952b753bbc7c3cb045ca9c8ec00bd86db215a32",
+  "nodeLifecycle.installationModeUserHint": "e63a22d66f7ce36ff49cdd83b77d1fba1f2be07719d4c605128a44fa19075521",
   "nodeLifecycle.osMetaLinux": "f4cc958460a22fe8e960707de1fac2a18caa0d56fe9a777c773f69f4b551fd86",
   "nodeLifecycle.osMetaWindows": "f410b99c645ae09604513b5ff4f011ceadef371141bdcf8e40a37d426b9dfc6f",
   "nodeLifecycle.osMetaMacos": "9227745addb13262953422500d9135ed3c3cbc5e82271ca9ba22090e5712c8a4",

--- a/src/agent/internal/engine/engine.go
+++ b/src/agent/internal/engine/engine.go
@@ -7,6 +7,7 @@ import (
 	"io/fs"
 	"log/slog"
 	"os"
+	"runtime"
 	"strings"
 	"sync"
 
@@ -291,7 +292,7 @@ func (e *Engine) applyUserInstallationScope(kind string, payload Payload) (Paylo
 		repositoryType == "proxy_fs" ||
 		strings.HasPrefix(kind, "lens.") ||
 		strings.HasPrefix(kind, "repository.server.") {
-		return payload, fmt.Errorf("user-level Agent supports only local Home protection")
+		return payload, fmt.Errorf("user-level Agent supports only local file protection")
 	}
 	if strings.TrimSpace(payload.ConfigFile) != "" || repositoryConfigFile != "" {
 		return payload, fmt.Errorf("user-level Agent requires Agent-managed repository configuration")
@@ -307,11 +308,22 @@ func (e *Engine) applyUserInstallationScope(kind string, payload Payload) (Paylo
 	path := payload.Path
 	switch kind {
 	case "browse":
-		payload.ListMounts = false
+		// Windows user mode exposes only fixed drives readable by the Agent
+		// identity. Unix user mode intentionally remains rooted at Home.
+		if runtime.GOOS == "windows" {
+			payload.WindowsUserScope = true
+			if payload.ListMounts || path == "" {
+				payload.Path = ""
+				payload.ListMounts = true
+				return payload, nil
+			}
+		} else {
+			payload.ListMounts = false
+		}
 	case "backup", "backup.snapshot.create", "repository.policy.apply",
 		"path.usage", "path.info", "path.size", "path.estimate", "source.path.size":
 		if path == "" {
-			return payload, fmt.Errorf("a path under the current user Home directory is required")
+			return payload, fmt.Errorf("a path available to the current user is required")
 		}
 		if (kind == "backup" || kind == "backup.snapshot.create" ||
 			kind == "repository.policy.apply") && !managedRepository {
@@ -322,7 +334,7 @@ func (e *Engine) applyUserInstallationScope(kind string, payload Payload) (Paylo
 			path = target
 		}
 		if path == "" {
-			return payload, fmt.Errorf("a restore path under the current user Home directory is required")
+			return payload, fmt.Errorf("a restore path available to the current user is required")
 		}
 		if !managedRepository {
 			return payload, fmt.Errorf("user-level Agent requires an Agent-managed repository")
@@ -417,17 +429,20 @@ func (e *Engine) runBrowse(
 	if p.ListMounts || p.Path == "" {
 		root = ""
 		listing, err = svc.ListMountPoints(ctx, explorer.ListOptions{
-			IncludeMetadata: p.IncludeMetadata,
-			Limit:           p.Limit,
-			Cursor:          p.Cursor,
+			IncludeMetadata:  p.IncludeMetadata,
+			Limit:            p.Limit,
+			Cursor:           p.Cursor,
+			LocalFixedOnly:   p.WindowsUserScope,
+			FilterUnreadable: p.WindowsUserScope,
 		})
 	} else {
 		root = explorer.NormalizeMountPath(p.Path)
 		listing, err = svc.ListLocalWithOptions(ctx, root, explorer.ListOptions{
-			DirsOnly:        p.DirsOnly,
-			IncludeMetadata: p.IncludeMetadata,
-			Limit:           p.Limit,
-			Cursor:          p.Cursor,
+			DirsOnly:         p.DirsOnly,
+			IncludeMetadata:  p.IncludeMetadata,
+			Limit:            p.Limit,
+			Cursor:           p.Cursor,
+			FilterUnreadable: p.WindowsUserScope,
 		})
 	}
 	if err != nil {

--- a/src/agent/internal/engine/payload.go
+++ b/src/agent/internal/engine/payload.go
@@ -8,17 +8,18 @@ import (
 
 // Payload is the task.command JSON body from the control plane or CLI.
 type Payload struct {
-	Path            string
-	ConfigFile      string
-	SnapshotID      string
-	Args            []string
-	Env             map[string]string
-	DirsOnly        bool
-	IncludeMetadata bool
-	Limit           int
-	Cursor          string
-	ListMounts      bool
-	Extra           map[string]any
+	Path             string
+	ConfigFile       string
+	SnapshotID       string
+	Args             []string
+	Env              map[string]string
+	DirsOnly         bool
+	IncludeMetadata  bool
+	Limit            int
+	Cursor           string
+	ListMounts       bool
+	WindowsUserScope bool
+	Extra            map[string]any
 }
 
 func ParsePayload(raw map[string]any) Payload {

--- a/src/agent/internal/engine/user_scope_test.go
+++ b/src/agent/internal/engine/user_scope_test.go
@@ -10,12 +10,11 @@ import (
 	"hyperfilelens/agent/internal/model"
 )
 
-func TestUserInstallationScopeDefaultsBrowseToHome(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("test uses Unix HOME semantics")
-	}
+func TestUserInstallationScopeUsesPlatformBrowseRoot(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	if runtime.GOOS != "windows" {
+		t.Setenv("HOME", home)
+	}
 	engine := New(staticConfigProvider{cfg: &model.AgentConfig{
 		InstallationMode: model.InstallationModeUser,
 	}})
@@ -27,7 +26,18 @@ func TestUserInstallationScopeDefaultsBrowseToHome(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if payload.Path != home || payload.ListMounts {
+	if runtime.GOOS == "windows" {
+		if payload.Path != "" || !payload.ListMounts || !payload.WindowsUserScope {
+			t.Fatalf(
+				"Windows browse scope = path %q, list_mounts=%t, user_scope=%t",
+				payload.Path,
+				payload.ListMounts,
+				payload.WindowsUserScope,
+			)
+		}
+		return
+	}
+	if payload.Path != home || payload.ListMounts || payload.WindowsUserScope {
 		t.Fatalf("browse scope = path %q, list_mounts=%t", payload.Path, payload.ListMounts)
 	}
 }

--- a/src/agent/internal/enroll/service_definition_linux.go
+++ b/src/agent/internal/enroll/service_definition_linux.go
@@ -1,0 +1,103 @@
+//go:build linux
+
+package enroll
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"hyperfilelens/agent/internal/platform/atomicfile"
+	"hyperfilelens/agent/internal/platform/vfs"
+)
+
+const userSystemdUnitName = "hyperfilelens-agent.service"
+
+func ensureUserSystemdUnit() error {
+	if !installIsUserLevel() {
+		return nil
+	}
+	installDir, err := vfs.UserInstallDir()
+	if err != nil {
+		return fmt.Errorf("resolve install directory: %w", err)
+	}
+	dataDir, err := vfs.UserDataDir()
+	if err != nil {
+		return fmt.Errorf("resolve data directory: %w", err)
+	}
+	unitPath, err := userSystemdUnitPath()
+	if err != nil {
+		return err
+	}
+	unit, err := renderUserSystemdUnit(installDir, dataDir)
+	if err != nil {
+		return err
+	}
+	if err := atomicfile.Write(unitPath, []byte(unit), 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", unitPath, err)
+	}
+	return nil
+}
+
+func userSystemdUnitPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil || strings.TrimSpace(home) == "" {
+		return "", fmt.Errorf("resolve current user Home directory")
+	}
+	configHome := strings.TrimSpace(os.Getenv("XDG_CONFIG_HOME"))
+	if configHome == "" || !filepath.IsAbs(configHome) {
+		configHome = filepath.Join(home, ".config")
+	}
+	configHome, err = absoluteSystemdPath(configHome)
+	if err != nil {
+		return "", fmt.Errorf("resolve current user config directory: %w", err)
+	}
+	return filepath.Join(configHome, "systemd", "user", userSystemdUnitName), nil
+}
+
+func renderUserSystemdUnit(installDir, dataDir string) (string, error) {
+	installDir, err := absoluteSystemdPath(installDir)
+	if err != nil {
+		return "", fmt.Errorf("install directory: %w", err)
+	}
+	dataDir, err = absoluteSystemdPath(dataDir)
+	if err != nil {
+		return "", fmt.Errorf("data directory: %w", err)
+	}
+	agent := escapeSystemdUnitPath(filepath.Join(installDir, "hfl-agent"))
+	return fmt.Sprintf(`[Unit]
+Description=HyperFileLens Agent (Current User)
+StartLimitIntervalSec=0
+
+[Service]
+Type=simple
+EnvironmentFile=%s
+WorkingDirectory=%s
+ExecStart="%s" run
+Restart=always
+RestartSec=5
+TimeoutStopSec=30
+
+[Install]
+WantedBy=default.target
+`, escapeSystemdUnitPath(filepath.Join(dataDir, "agent.env")), escapeSystemdUnitPath(installDir), agent), nil
+}
+
+func absoluteSystemdPath(path string) (string, error) {
+	path = strings.TrimSpace(path)
+	if path == "" || strings.ContainsAny(path, "\r\n\x00") {
+		return "", fmt.Errorf("path is empty or contains unsupported characters")
+	}
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Clean(absPath), nil
+}
+
+func escapeSystemdUnitPath(path string) string {
+	path = strings.ReplaceAll(path, `\`, `\\`)
+	path = strings.ReplaceAll(path, `"`, `\"`)
+	return strings.ReplaceAll(path, "%", "%%")
+}

--- a/src/agent/internal/enroll/service_definition_linux_test.go
+++ b/src/agent/internal/enroll/service_definition_linux_test.go
@@ -1,0 +1,147 @@
+//go:build linux
+
+package enroll
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestEnsureUserSystemdUnitRepairsStaleDefinition(t *testing.T) {
+	home := t.TempDir()
+	configHome := filepath.Join(home, "config home")
+	stateHome := filepath.Join(home, "state home")
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", configHome)
+	t.Setenv("XDG_STATE_HOME", stateHome)
+	t.Setenv("HFL_INSTALLATION_MODE", "user")
+	installDir := filepath.Join(home, ".local", "lib", "hyperfilelens-agent")
+	dataDir := filepath.Join(stateHome, "hyperfilelens-agent")
+	if err := os.MkdirAll(installDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(dataDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(installDir, "hfl-agent"), []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dataDir, "agent.env"), nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	unitPath := filepath.Join(configHome, "systemd", "user", userSystemdUnitName)
+	if err := os.MkdirAll(filepath.Dir(unitPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(unitPath, []byte("invalid stale unit\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := ensureUserSystemdUnit(); err != nil {
+		t.Fatal(err)
+	}
+
+	raw, err := os.ReadFile(unitPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	unit := string(raw)
+	for _, want := range []string{
+		"EnvironmentFile=" + filepath.Join(dataDir, "agent.env"),
+		"WorkingDirectory=" + installDir,
+		`ExecStart="` + filepath.Join(installDir, "hfl-agent") + `" run`,
+		"WantedBy=default.target",
+	} {
+		if !strings.Contains(unit, want) {
+			t.Fatalf("repaired unit missing %q:\n%s", want, unit)
+		}
+	}
+	if strings.Contains(unit, `EnvironmentFile="`) || strings.Contains(unit, `WorkingDirectory="`) {
+		t.Fatalf("single-path systemd directives must not retain stale quotes:\n%s", unit)
+	}
+	if mode := fileMode(t, unitPath); mode != 0o644 {
+		t.Fatalf("unit mode = %o, want 644", mode)
+	}
+
+	if _, err := exec.LookPath("systemd-analyze"); err == nil {
+		if output, verifyErr := exec.Command("systemd-analyze", "verify", unitPath).CombinedOutput(); verifyErr != nil {
+			t.Fatalf("repaired unit is invalid: %v\n%s\n%s", verifyErr, unit, output)
+		}
+	}
+}
+
+func TestEnsureUserSystemdUnitDoesNotTouchSystemInstall(t *testing.T) {
+	home := t.TempDir()
+	configHome := filepath.Join(home, ".config")
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", configHome)
+	t.Setenv("HFL_INSTALLATION_MODE", "system")
+
+	if err := ensureUserSystemdUnit(); err != nil {
+		t.Fatal(err)
+	}
+	unitPath := filepath.Join(configHome, "systemd", "user", userSystemdUnitName)
+	if _, err := os.Stat(unitPath); !os.IsNotExist(err) {
+		t.Fatalf("system install unexpectedly wrote user unit: %v", err)
+	}
+}
+
+func TestRepairUnitMatchesBundleInstallerTemplate(t *testing.T) {
+	_, currentFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("resolve test source path")
+	}
+	installScript := filepath.Join(
+		filepath.Dir(currentFile),
+		"..", "..", "packaging", "install", "install.sh",
+	)
+	raw, err := os.ReadFile(installScript)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := string(raw)
+	functionStart := strings.Index(body, "install_systemd_unit() {")
+	if functionStart < 0 {
+		t.Fatal("install.sh missing install_systemd_unit")
+	}
+	body = body[functionStart:]
+	marker := `cat >"${UNIT_DST}" <<EOF` + "\n"
+	heredocStart := strings.Index(body, marker)
+	if heredocStart < 0 {
+		t.Fatal("install.sh missing user unit template")
+	}
+	template := body[heredocStart+len(marker):]
+	heredocEnd := strings.Index(template, "\nEOF")
+	if heredocEnd < 0 {
+		t.Fatal("install.sh user unit template is not terminated")
+	}
+	template = template[:heredocEnd]
+
+	installDir := "/home/alice/.local/lib/hyperfilelens-agent"
+	dataDir := "/home/alice/.local/state/hyperfilelens-agent"
+	want := strings.NewReplacer(
+		"${unit_env_file}", filepath.Join(dataDir, "agent.env"),
+		"${unit_working_dir}", installDir,
+		"${unit_agent}", filepath.Join(installDir, "hfl-agent"),
+	).Replace(template) + "\n"
+	got, err := renderUserSystemdUnit(installDir, dataDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Fatalf("repair unit drifted from install.sh template\n--- got ---\n%s--- want ---\n%s", got, want)
+	}
+}
+
+func fileMode(t *testing.T, path string) os.FileMode {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return info.Mode().Perm()
+}

--- a/src/agent/internal/enroll/service_definition_other_unix.go
+++ b/src/agent/internal/enroll/service_definition_other_unix.go
@@ -1,0 +1,7 @@
+//go:build !linux && !windows
+
+package enroll
+
+func ensureUserSystemdUnit() error {
+	return nil
+}

--- a/src/agent/internal/enroll/service_unix.go
+++ b/src/agent/internal/enroll/service_unix.go
@@ -41,6 +41,12 @@ func startSystemd(ctx context.Context) error {
 	if _, err := exec.LookPath("systemctl"); err != nil {
 		return fmt.Errorf("systemctl not found")
 	}
+	// Rebind and repair can start from an older inactive installation without
+	// running the bundle installer again. Recreate the user unit here so a stale
+	// or previously invalid definition cannot survive into the start attempt.
+	if err := ensureUserSystemdUnit(); err != nil {
+		return fmt.Errorf("repair current-user systemd unit: %w", err)
+	}
 	for _, args := range [][]string{
 		{"daemon-reload"},
 		{"enable", "hyperfilelens-agent.service"},

--- a/src/agent/internal/platform/install/install_ps1_test.go
+++ b/src/agent/internal/platform/install/install_ps1_test.go
@@ -92,6 +92,43 @@ func TestInstallPs1UsesFullWindowsIdentityForCurrentUserTask(t *testing.T) {
 	}
 }
 
+func TestInstallPs1RunsCurrentUserAgentThroughHiddenRunner(t *testing.T) {
+	source := readPackagingInstallScript(t)
+	for _, want := range []string{
+		`function Write-HflUserTaskRunner`,
+		`$runner = Join-Path $InstallRoot "run-agent.ps1"`,
+		`$powershellName = if ($PSVersionTable.PSEdition -eq "Core") { "pwsh.exe" } else { "powershell.exe" }`,
+		`$powershell = Join-Path $PSHOME $powershellName`,
+		`-NoProfile -NonInteractive -ExecutionPolicy Bypass -WindowStyle Hidden -File`,
+		"& `$agent run -data-dir `$dataRoot",
+		`Remove-HflInstallFile (Join-Path $InstallRoot "run-agent.ps1")`,
+	} {
+		if !strings.Contains(source, want) {
+			t.Fatalf("install.ps1 hidden current-user runner is missing %q", want)
+		}
+	}
+	installServiceStart := strings.Index(source, "function Install-HflService")
+	if installServiceStart < 0 {
+		t.Fatal("install.ps1 service installer is missing")
+	}
+	userServiceStart := strings.Index(
+		source[installServiceStart:],
+		`if ($InstallationMode -eq "user") {`,
+	)
+	if userServiceStart < 0 {
+		t.Fatal("install.ps1 current-user service branch is missing")
+	}
+	userService := source[installServiceStart+userServiceStart:]
+	systemServiceStart := strings.Index(userService, `$binPath = "`)
+	if systemServiceStart < 0 {
+		t.Fatal("install.ps1 system service branch is missing")
+	}
+	userService = userService[:systemServiceStart]
+	if strings.Contains(userService, "-Execute $ExePath") {
+		t.Fatal("current-user task must not launch the console Agent executable directly")
+	}
+}
+
 func TestInstallPs1UpgradePersistsMissingInstallationMode(t *testing.T) {
 	source := readPackagingInstallScript(t)
 	mergeStart := strings.Index(source, "function Merge-AgentEnv")

--- a/src/agent/internal/platform/vfs/user_scope.go
+++ b/src/agent/internal/platform/vfs/user_scope.go
@@ -30,9 +30,14 @@ func userHomePaths() (declared, canonical string, err error) {
 	return home, filepath.Clean(resolved), nil
 }
 
-// ResolveUserScopedPath resolves path and rejects anything outside Home.
+// ResolveUserScopedPath applies the platform boundary for a user-level Agent.
+// Unix paths remain under Home. Windows paths may use readable local fixed drives.
 // Missing final components are permitted for restore destinations when requested.
 func ResolveUserScopedPath(path string, allowMissing bool) (string, error) {
+	return resolveUserScopedPath(path, allowMissing)
+}
+
+func resolveHomeScopedPath(path string, allowMissing bool) (string, error) {
 	declaredHome, home, err := userHomePaths()
 	if err != nil {
 		return "", err

--- a/src/agent/internal/platform/vfs/user_scope_unix.go
+++ b/src/agent/internal/platform/vfs/user_scope_unix.go
@@ -1,0 +1,7 @@
+//go:build !windows
+
+package vfs
+
+func resolveUserScopedPath(path string, allowMissing bool) (string, error) {
+	return resolveHomeScopedPath(path, allowMissing)
+}

--- a/src/agent/internal/platform/vfs/user_scope_windows.go
+++ b/src/agent/internal/platform/vfs/user_scope_windows.go
@@ -1,0 +1,86 @@
+//go:build windows
+
+package vfs
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/sys/windows"
+)
+
+// resolveUserScopedPath keeps user-mode Windows workloads on local fixed
+// drives and verifies access with the Agent process token. The console must
+// never grant broader access than this local check.
+func resolveUserScopedPath(path string, allowMissing bool) (string, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return UserHome()
+	}
+	if !filepath.IsAbs(path) {
+		home, err := UserHome()
+		if err != nil {
+			return "", err
+		}
+		path = filepath.Join(home, path)
+	}
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return "", fmt.Errorf("resolve path: %w", err)
+	}
+	absPath = filepath.Clean(absPath)
+	if err := requireLocalFixedDrive(absPath); err != nil {
+		return "", err
+	}
+
+	resolved := absPath
+	if allowMissing {
+		resolved, err = resolvePathWithMissingTail(absPath)
+	} else {
+		resolved, err = filepath.EvalSymlinks(absPath)
+	}
+	if err != nil {
+		return "", err
+	}
+	resolved = filepath.Clean(resolved)
+	if err := requireLocalFixedDrive(resolved); err != nil {
+		return "", err
+	}
+	if err := requireReadableExistingPath(resolved); err != nil {
+		return "", err
+	}
+	return resolved, nil
+}
+
+func requireLocalFixedDrive(path string) error {
+	volume := filepath.VolumeName(path)
+	if len(volume) != 2 || volume[1] != ':' {
+		return fmt.Errorf("%w: user-level Agent paths must use a local fixed drive", os.ErrPermission)
+	}
+	root := volume + `\`
+	rootPtr, err := windows.UTF16PtrFromString(root)
+	if err != nil || windows.GetDriveType(rootPtr) != windows.DRIVE_FIXED {
+		return fmt.Errorf("%w: user-level Agent paths must use a local fixed drive", os.ErrPermission)
+	}
+	return nil
+}
+
+func requireReadableExistingPath(path string) error {
+	probe := path
+	for {
+		handle, err := os.Open(probe)
+		if err == nil {
+			return handle.Close()
+		}
+		if !os.IsNotExist(err) {
+			return err
+		}
+		parent := filepath.Dir(probe)
+		if parent == probe {
+			return err
+		}
+		probe = parent
+	}
+}

--- a/src/agent/internal/platform/vfs/user_scope_windows_test.go
+++ b/src/agent/internal/platform/vfs/user_scope_windows_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 )
 
-func TestResolveUserScopedPathWindowsHomeBoundary(t *testing.T) {
+func TestResolveUserScopedPathWindowsAllowsReadableFixedDrivePaths(t *testing.T) {
 	root := t.TempDir()
 	home := filepath.Join(root, "home")
 	outside := filepath.Join(root, "outside")
@@ -42,7 +42,15 @@ func TestResolveUserScopedPathWindowsHomeBoundary(t *testing.T) {
 		t.Fatalf("restore path resolved to %q, want %q", resolved, restoreTarget)
 	}
 
-	if _, err := ResolveUserScopedPath(outside, false); err == nil {
-		t.Fatal("path outside Home should be rejected")
+	resolved, err = ResolveUserScopedPath(outside, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.EqualFold(filepath.Clean(resolved), filepath.Clean(outside)) {
+		t.Fatalf("outside-Home path resolved to %q, want %q", resolved, outside)
+	}
+
+	if _, err := ResolveUserScopedPath(`\\server\share`, false); err == nil {
+		t.Fatal("UNC path should be rejected for a user-level Agent")
 	}
 }

--- a/src/agent/internal/service/explorer/explorer.go
+++ b/src/agent/internal/service/explorer/explorer.go
@@ -25,10 +25,12 @@ type Entry struct {
 
 // ListOptions controls how much data a local listing should collect.
 type ListOptions struct {
-	DirsOnly        bool
-	IncludeMetadata bool
-	Limit           int
-	Cursor          string
+	DirsOnly         bool
+	IncludeMetadata  bool
+	Limit            int
+	Cursor           string
+	LocalFixedOnly   bool
+	FilterUnreadable bool
 }
 
 // ListResult is the bounded local listing response.
@@ -76,6 +78,10 @@ func (s *Service) ListMountPoints(ctx context.Context, opts ListOptions) (ListRe
 	appendEntry := func(mountpoint, device string) bool {
 		mountpoint = normalizeMountPath(mountpoint)
 		if mountpoint == "" || mountpoint == "." {
+			return false
+		}
+		if !mountPointAllowed(mountpoint, opts.LocalFixedOnly) ||
+			(opts.FilterUnreadable && !pathReadable(mountpoint)) {
 			return false
 		}
 		key := mountKey(mountpoint)
@@ -220,13 +226,17 @@ func (s *Service) ListLocalWithOptions(ctx context.Context, path string, opts Li
 			if opts.DirsOnly && !isDir {
 				continue
 			}
+			entryPath := filepath.Join(root, item.Name())
+			if opts.FilterUnreadable && !pathReadable(entryPath) {
+				continue
+			}
 			if matched < offset {
 				matched++
 				continue
 			}
 			e := Entry{
 				Name:  item.Name(),
-				Path:  filepath.Join(root, item.Name()),
+				Path:  entryPath,
 				IsDir: isDir,
 			}
 			if opts.IncludeMetadata {
@@ -251,6 +261,14 @@ func (s *Service) ListLocalWithOptions(ctx context.Context, path string, opts Li
 		}
 	}
 	return ListResult{Entries: out, HasMore: hasMore}, nil
+}
+
+func pathReadable(path string) bool {
+	handle, err := os.Open(path)
+	if err != nil {
+		return false
+	}
+	return handle.Close() == nil
 }
 
 // ListRepository is reserved for Kopia-backed listing (use task payload args today).

--- a/src/agent/internal/service/explorer/explorer_test.go
+++ b/src/agent/internal/service/explorer/explorer_test.go
@@ -145,6 +145,16 @@ func TestListLocalWithOptionsKeepsFilesByDefault(t *testing.T) {
 	}
 }
 
+func TestPathReadableRejectsMissingPath(t *testing.T) {
+	root := t.TempDir()
+	if !pathReadable(root) {
+		t.Fatalf("existing directory should be readable: %s", root)
+	}
+	if pathReadable(filepath.Join(root, "missing")) {
+		t.Fatal("missing path must not be reported as readable")
+	}
+}
+
 func TestListLocalWithOptionsLimit(t *testing.T) {
 	root := t.TempDir()
 	for _, name := range []string{"a", "b", "c"} {

--- a/src/agent/internal/service/explorer/mounts_stub.go
+++ b/src/agent/internal/service/explorer/mounts_stub.go
@@ -2,6 +2,10 @@
 
 package explorer
 
+func mountPointAllowed(_ string, _ bool) bool {
+	return true
+}
+
 func extraMountPoints(seen map[string]struct{}) []string {
 	_ = seen
 	return nil

--- a/src/agent/internal/service/explorer/mounts_windows.go
+++ b/src/agent/internal/service/explorer/mounts_windows.go
@@ -3,10 +3,23 @@
 package explorer
 
 import (
+	"path/filepath"
 	"unicode/utf16"
 
 	"golang.org/x/sys/windows"
 )
+
+func mountPointAllowed(mountpoint string, localFixedOnly bool) bool {
+	if !localFixedOnly {
+		return true
+	}
+	volume := filepath.VolumeName(mountpoint)
+	if len(volume) != 2 || volume[1] != ':' {
+		return false
+	}
+	root, err := windows.UTF16PtrFromString(volume + `\`)
+	return err == nil && windows.GetDriveType(root) == windows.DRIVE_FIXED
+}
 
 func extraMountPoints(seen map[string]struct{}) []string {
 	buf := make([]uint16, 256)

--- a/src/agent/internal/service/explorer/mounts_windows_test.go
+++ b/src/agent/internal/service/explorer/mounts_windows_test.go
@@ -1,0 +1,21 @@
+//go:build windows
+
+package explorer
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestMountPointAllowedKeepsOnlyLocalFixedDrives(t *testing.T) {
+	root := filepath.VolumeName(t.TempDir()) + `\`
+	if !mountPointAllowed(root, true) {
+		t.Fatalf("temporary directory drive should be a local fixed drive: %s", root)
+	}
+	if mountPointAllowed(`\\server\share`, true) {
+		t.Fatal("UNC share must not be exposed by a current-user local-drive listing")
+	}
+	if !mountPointAllowed(`\\server\share`, false) {
+		t.Fatal("system-mode mount discovery should retain its existing behavior")
+	}
+}

--- a/src/agent/packaging/install/install.ps1
+++ b/src/agent/packaging/install/install.ps1
@@ -912,13 +912,46 @@ exit 0
   Write-HflOk "scheduled removal of install directory $target (after install.cmd exits)"
 }
 
+function Write-HflUserTaskRunner {
+  param(
+    [Parameter(Mandatory = $true)][string]$ExePath,
+    [Parameter(Mandatory = $true)][string]$DataRoot
+  )
+  $runner = Join-Path $InstallRoot "run-agent.ps1"
+  $exeEsc = $ExePath.Replace("'", "''")
+  $dataEsc = $DataRoot.Replace("'", "''")
+  $body = @"
+`$ErrorActionPreference = 'Stop'
+`$agent = '$exeEsc'
+`$dataRoot = '$dataEsc'
+try {
+  & `$agent run -data-dir `$dataRoot
+  if (`$null -ne `$LASTEXITCODE) { exit `$LASTEXITCODE }
+  exit 0
+}
+catch {
+  exit 1
+}
+"@
+  Set-Content -LiteralPath $runner -Value $body -Encoding UTF8
+  return $runner
+}
+
 function Install-HflService {
   param([string]$ExePath, [string]$DataRoot, [switch]$NoStart)
   Remove-HflService
   if ($InstallationMode -eq "user") {
+    # Task Scheduler owns the process after installation. A hidden PowerShell
+    # host prevents hfl-agent.exe from opening a console window in the session.
+    $runner = Write-HflUserTaskRunner -ExePath $ExePath -DataRoot $DataRoot
+    $powershellName = if ($PSVersionTable.PSEdition -eq "Core") { "pwsh.exe" } else { "powershell.exe" }
+    $powershell = Join-Path $PSHOME $powershellName
+    if (-not (Test-Path -LiteralPath $powershell)) {
+      throw "Could not resolve the current PowerShell executable for the user task."
+    }
     $action = New-ScheduledTaskAction `
-      -Execute $ExePath `
-      -Argument "run -data-dir `"$DataRoot`""
+      -Execute $powershell `
+      -Argument "-NoProfile -NonInteractive -ExecutionPolicy Bypass -WindowStyle Hidden -File `"$runner`""
     $trigger = New-ScheduledTaskTrigger -AtLogOn -User $CurrentWindowsIdentity
     $principal = New-ScheduledTaskPrincipal `
       -UserId $CurrentWindowsIdentity `
@@ -1431,6 +1464,7 @@ function Invoke-Uninstall {
 
   Remove-HflInstallFile (Join-Path $InstallRoot "hfl-agent.exe")
   Remove-HflInstallFile (Join-Path $InstallRoot "kopia.exe")
+  Remove-HflInstallFile (Join-Path $InstallRoot "run-agent.ps1")
   Remove-HflInstallFile (Join-Path $InstallRoot "install.ps1")
   Remove-HflInstallFile (Join-Path $InstallRoot "uninstall.cmd")
   Remove-HflInstallFile (Join-Path $InstallRoot "MANIFEST.json")

--- a/src/backend/apps/source/services/internal/backup_source_directory.py
+++ b/src/backend/apps/source/services/internal/backup_source_directory.py
@@ -101,13 +101,20 @@ def _clean_path(path: str) -> str:
     return posixpath.normpath(value)
 
 
-def _agent_default_path(node: Node) -> str:
+def _node_os_name(node: Node) -> str:
     metadata = node.metadata if isinstance(node.metadata, dict) else {}
     inventory = (
         metadata.get("inventory") if isinstance(metadata.get("inventory"), dict) else {}
     )
-    os_name = str(inventory.get("os") or node.os_name or "").strip().lower()
-    if "windows" in os_name:
+    return str(inventory.get("os") or node.os_name or "").strip().lower()
+
+
+def _is_windows_node(node: Node) -> bool:
+    return "windows" in _node_os_name(node)
+
+
+def _agent_default_path(node: Node) -> str:
+    if _is_windows_node(node):
         return "C:\\"
     return "/"
 
@@ -373,7 +380,7 @@ def _is_top_level_mount_request(
 ) -> bool:
     if target.source_kind not in ("agent", "proxy"):
         return False
-    if _is_current_user_agent(target.node):
+    if _is_current_user_agent(target.node) and not _is_windows_node(target.node):
         return False
     if cursor:
         return False
@@ -545,14 +552,17 @@ def list_backup_source_directories(
         cursor=cursor,
     )
     if use_mount_listing:
-        cached = _try_cached_mount_listing(
-            organization_id=organization_id,
-            node=target.node,
-            target=target,
-            source_id=source_id,
-        )
-        if cached is not None:
-            return cached
+        # A current-user Windows Agent must enumerate drives with its own
+        # process token. Heartbeat disk inventory may reflect broader access.
+        if not _is_current_user_agent(target.node):
+            cached = _try_cached_mount_listing(
+                organization_id=organization_id,
+                node=target.node,
+                target=target,
+                source_id=source_id,
+            )
+            if cached is not None:
+                return cached
     collect_metadata = (
         bool(include_files) if include_metadata is None else bool(include_metadata)
     )
@@ -660,7 +670,11 @@ def list_backup_source_directories(
     response_entries = entries
     response_has_more = _safe_bool(result.get("has_more"))
     response_next_cursor = str(result.get("next_cursor") or "")
-    if request_root and _is_current_user_agent(target.node):
+    if (
+        request_root
+        and _is_current_user_agent(target.node)
+        and not _is_windows_node(target.node)
+    ):
         home_path = _normalize_mount_path(str(result.get("path") or ""))
         if not home_path:
             raise BackupSourceDirectoryError(
@@ -681,6 +695,19 @@ def list_backup_source_directories(
         response_entries = []
         response_has_more = False
         response_next_cursor = ""
+    elif (
+        request_root
+        and use_mount_listing
+        and response_entries
+        and not response_target.path
+    ):
+        response_target = BrowseTarget(
+            source_kind=target.source_kind,
+            source_ref_id=target.source_ref_id,
+            node=target.node,
+            path=response_entries[0]["path"],
+            root_path=target.root_path,
+        )
     return {
         "source_id": source_id,
         "source_kind": target.source_kind,

--- a/src/backend/apps/source/tests/test_api.py
+++ b/src/backend/apps/source/tests/test_api.py
@@ -1821,7 +1821,7 @@ class SourceResourceApiTests(TestCase):
         "apps.source.services.internal.backup_source_directory._try_cached_mount_listing"
     )
     @patch("apps.source.services.internal.backup_source_directory.run_agent_task_sync")
-    def test_current_user_agent_directory_root_uses_home_not_mounts(
+    def test_current_user_windows_agent_directory_root_uses_accessible_mounts(
         self, mock_run_task, mock_cached_mounts
     ):
         agent = Node.objects.create(
@@ -1833,17 +1833,83 @@ class SourceResourceApiTests(TestCase):
             availability=Node.Availability.ONLINE,
             os_name="windows",
         )
-        home_path = r"C:\Users\alice"
         mock_run_task.return_value = SimpleNamespace(
             timed_out=False,
             ok=True,
             task_id="task-current-user-root",
             result={
+                "entries": [
+                    {
+                        "name": "C:\\",
+                        "path": "C:\\",
+                        "is_dir": True,
+                    },
+                    {
+                        "name": "D:\\",
+                        "path": "D:\\",
+                        "is_dir": True,
+                    },
+                ],
+            },
+            task=SimpleNamespace(last_error=""),
+        )
+
+        resp = self.client.get(
+            f"/api/v1/source/backup-selectable/directories/?source_id=agent:{agent.id}",
+            **self._headers(),
+        )
+
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(resp.data["path"], "")
+        self.assertEqual(resp.data["root_path"], "")
+        self.assertEqual(resp.data["root"]["label"], "C:\\")
+        self.assertEqual(resp.data["root"]["path"], "C:\\")
+        self.assertEqual(
+            [entry["path"] for entry in resp.data["entries"]], ["C:\\", "D:\\"]
+        )
+        self.assertEqual(resp.data["count"], 2)
+        self.assertFalse(resp.data["has_more"])
+        self.assertEqual(resp.data["next_cursor"], "")
+        mock_cached_mounts.assert_not_called()
+        _, kwargs = mock_run_task.call_args
+        self.assertEqual(
+            kwargs["payload"],
+            {
+                "path": "",
+                "list_mounts": True,
+                "dirs_only": True,
+                "include_metadata": False,
+                "limit": 200,
+            },
+        )
+
+    @patch(
+        "apps.source.services.internal.backup_source_directory._try_cached_mount_listing"
+    )
+    @patch("apps.source.services.internal.backup_source_directory.run_agent_task_sync")
+    def test_current_user_linux_agent_directory_root_remains_home_scoped(
+        self, mock_run_task, mock_cached_mounts
+    ):
+        agent = Node.objects.create(
+            organization=self.org,
+            name="current-user-linux-root",
+            role=Node.Role.AGENT,
+            installation_mode=Node.InstallationMode.USER,
+            status=Node.Status.ACTIVE,
+            availability=Node.Availability.ONLINE,
+            os_name="linux",
+        )
+        home_path = "/home/alice"
+        mock_run_task.return_value = SimpleNamespace(
+            timed_out=False,
+            ok=True,
+            task_id="task-current-user-linux-root",
+            result={
                 "path": home_path,
                 "entries": [
                     {
                         "name": "Documents",
-                        "path": rf"{home_path}\Documents",
+                        "path": f"{home_path}/Documents",
                         "is_dir": True,
                     }
                 ],
@@ -1862,9 +1928,6 @@ class SourceResourceApiTests(TestCase):
         self.assertEqual(resp.data["root"]["label"], "Home")
         self.assertEqual(resp.data["root"]["path"], home_path)
         self.assertEqual(resp.data["entries"], [])
-        self.assertEqual(resp.data["count"], 0)
-        self.assertFalse(resp.data["has_more"])
-        self.assertEqual(resp.data["next_cursor"], "")
         mock_cached_mounts.assert_not_called()
         _, kwargs = mock_run_task.call_args
         self.assertEqual(

--- a/src/frontend/src/components/NodeLifecycleCopy.test.ts
+++ b/src/frontend/src/components/NodeLifecycleCopy.test.ts
@@ -30,7 +30,8 @@ describe('Node lifecycle copy', () => {
     expect(locale).toContain('Runs continuously after sign-out')
     expect(locale).toContain('pauses after sign-out')
     expect(locale).toContain('provides continuous monitoring')
-    expect(locale).toContain('provides monitoring while that user is signed in')
+    expect(locale).toContain('accessible local drives on Windows')
+    expect(locale).toContain('provides monitoring while signed in')
     expect(locale).toContain('grant HyperFileLens Agent Full Disk Access in System Settings')
   })
 

--- a/src/frontend/src/lib/backupSourceDirectoryTree.test.ts
+++ b/src/frontend/src/lib/backupSourceDirectoryTree.test.ts
@@ -108,13 +108,12 @@ describe('selectBackupSourceDirectoryTreeEntries', () => {
     })).toEqual(windowsDrives)
   })
 
-  it('uses the Home root for a Current User Windows Agent', () => {
-    const home = { ...root, label: 'Home', path: 'C:\\Users\\alice' }
+  it('keeps accessible drive roots for a Current User Windows Agent', () => {
     expect(selectBackupSourceDirectoryTreeEntries({
       source: { type: 'host', platform: 'windows', installation_mode: 'user' },
       parentPath: '',
-      result: { root: home, entries: windowsDrives },
-    })).toEqual([home])
+      result: { root: windowsDrives[0], entries: windowsDrives },
+    })).toEqual(windowsDrives)
   })
 
   it('returns directory children after a POSIX root is expanded', () => {

--- a/src/frontend/src/lib/backupSourceDirectoryTree.ts
+++ b/src/frontend/src/lib/backupSourceDirectoryTree.ts
@@ -51,7 +51,11 @@ export function shouldUseSingleDirectoryRoot(
 ) {
   if (parentPath || !source) return false
   if (source.type === 'nas') return true
-  if (source.type === 'host' && source.installation_mode === 'user') return true
+  if (
+    source.type === 'host'
+    && source.installation_mode === 'user'
+    && source.platform !== 'windows'
+  ) return true
   return source.type === 'host' && (source.platform === 'linux' || source.platform === 'macos')
 }
 

--- a/src/frontend/src/locales/en.ts
+++ b/src/frontend/src/locales/en.ts
@@ -1705,7 +1705,7 @@ export const en = {
     installationModeSystem: 'System Service',
     installationModeUser: 'Current User',
     installationModeSystemHint: 'Administrator-authorized installation. Runs continuously after sign-out, protects files the system service can access, and provides continuous monitoring.',
-    installationModeUserHint: 'No administrator access required. Protects only the current user Home directory, pauses after sign-out, and provides monitoring while that user is signed in.',
+    installationModeUserHint: 'No administrator access required. Protects files the current user can access (Home on Linux/macOS and accessible local drives on Windows), pauses after sign-out, and provides monitoring while signed in.',
     osMetaLinux: 'Major distros · x86_64 or ARM64',
     osMetaWindows: 'Win 10/11 · Server 2016+ · 64-bit only',
     osMetaMacos: 'Intel or Apple Silicon',


### PR DESCRIPTION
## Summary

- run the Windows Current User Agent through a hidden scheduled-task runner
- expose only readable local fixed drives and revalidate user-scoped browse, backup, and restore paths
- keep Linux and macOS Current User protection Home-scoped
- repair stale Linux current-user systemd unit definitions before enrollment starts the service
- align backend directory responses, frontend tree behavior, product copy, and regression coverage

## Validation

- relevant Go tests
- Go vet for modified Agent packages
- Windows and macOS cross-compilation
- backend directory-boundary tests
- frontend directory-tree tests, type checking, and ESLint
- Ruff and git diff --check

Refs #426
Refs #427