### PR TITLE
fix(agent): suppress Windows user Agent console

### DIFF
--- a/src/agent/internal/platform/install/install_ps1_test.go
+++ b/src/agent/internal/platform/install/install_ps1_test.go
@@ -100,7 +100,11 @@ func TestInstallPs1RunsCurrentUserAgentThroughHiddenRunner(t *testing.T) {
 		`$powershellName = if ($PSVersionTable.PSEdition -eq "Core") { "pwsh.exe" } else { "powershell.exe" }`,
 		`$powershell = Join-Path $PSHOME $powershellName`,
 		`-NoProfile -NonInteractive -ExecutionPolicy Bypass -WindowStyle Hidden -File`,
-		"& `$agent run -data-dir `$dataRoot",
+		"`$startInfo = New-Object System.Diagnostics.ProcessStartInfo",
+		"`$startInfo.UseShellExecute = `$false",
+		"`$startInfo.CreateNoWindow = `$true",
+		"`$startInfo.WindowStyle = [System.Diagnostics.ProcessWindowStyle]::Hidden",
+		"[System.Diagnostics.Process]::Start(`$startInfo)",
 		`Remove-HflInstallFile (Join-Path $InstallRoot "run-agent.ps1")`,
 	} {
 		if !strings.Contains(source, want) {
@@ -126,6 +130,9 @@ func TestInstallPs1RunsCurrentUserAgentThroughHiddenRunner(t *testing.T) {
 	userService = userService[:systemServiceStart]
 	if strings.Contains(userService, "-Execute $ExePath") {
 		t.Fatal("current-user task must not launch the console Agent executable directly")
+	}
+	if strings.Contains(source, "& `$agent run -data-dir `$dataRoot") {
+		t.Fatal("hidden runner must create the Agent with CreateNoWindow")
 	}
 }
 

--- a/src/agent/packaging/install/install.ps1
+++ b/src/agent/packaging/install/install.ps1
@@ -925,9 +925,19 @@ function Write-HflUserTaskRunner {
 `$agent = '$exeEsc'
 `$dataRoot = '$dataEsc'
 try {
-  & `$agent run -data-dir `$dataRoot
-  if (`$null -ne `$LASTEXITCODE) { exit `$LASTEXITCODE }
-  exit 0
+  # Hiding powershell.exe alone is insufficient when Windows Terminal is the
+  # default console host: the console Agent can still receive a new window.
+  # CreateNoWindow applies to the Agent process itself.
+  `$startInfo = New-Object System.Diagnostics.ProcessStartInfo
+  `$startInfo.FileName = `$agent
+  `$startInfo.Arguments = 'run -data-dir "' + `$dataRoot + '"'
+  `$startInfo.UseShellExecute = `$false
+  `$startInfo.CreateNoWindow = `$true
+  `$startInfo.WindowStyle = [System.Diagnostics.ProcessWindowStyle]::Hidden
+  `$process = [System.Diagnostics.Process]::Start(`$startInfo)
+  if (`$null -eq `$process) { exit 1 }
+  `$process.WaitForExit()
+  exit `$process.ExitCode
 }
 catch {
   exit 1
@@ -941,8 +951,8 @@ function Install-HflService {
   param([string]$ExePath, [string]$DataRoot, [switch]$NoStart)
   Remove-HflService
   if ($InstallationMode -eq "user") {
-    # Task Scheduler owns the process after installation. A hidden PowerShell
-    # host prevents hfl-agent.exe from opening a console window in the session.
+    # Task Scheduler owns the process after installation. The hidden runner
+    # creates the console Agent without allocating an interactive window.
     $runner = Write-HflUserTaskRunner -ExePath $ExePath -DataRoot $DataRoot
     $powershellName = if ($PSVersionTable.PSEdition -eq "Core") { "pwsh.exe" } else { "powershell.exe" }
     $powershell = Join-Path $PSHOME $powershellName


### PR DESCRIPTION
## Summary

- start the Windows Current User Agent with ProcessStartInfo.CreateNoWindow instead of relying only on a hidden PowerShell parent
- preserve scheduled-task ownership, restart behavior, and file-based Agent logging
- add an installer contract test that prevents direct console-process invocation from returning

## Validation

- Windows PowerShell parser check
- live Windows Current User scheduled-task validation: task running, Agent MainWindowHandle is 0
- Go installer tests
- Go vet
- git diff --check

Follow-up to #749.
Refs #426
Refs #427