### PR TITLE
fix(agent): replace Windows user runner with windowless launcher

### DIFF
--- a/src/agent/cmd/useragentlauncher/main.go
+++ b/src/agent/cmd/useragentlauncher/main.go
@@ -1,0 +1,18 @@
+package main
+
+import "os"
+
+func main() {
+	dataDir, ok := parseDataDir(os.Args[1:])
+	if !ok {
+		os.Exit(2)
+	}
+	os.Exit(runAgent(dataDir))
+}
+
+func parseDataDir(args []string) (string, bool) {
+	if len(args) != 2 || args[0] != "-data-dir" || args[1] == "" {
+		return "", false
+	}
+	return args[1], true
+}

--- a/src/agent/cmd/useragentlauncher/main_test.go
+++ b/src/agent/cmd/useragentlauncher/main_test.go
@@ -1,0 +1,25 @@
+package main
+
+import "testing"
+
+func TestParseDataDir(t *testing.T) {
+	path := `C:\Users\operator\AppData\Local\HyperFileLens\AgentData`
+	got, ok := parseDataDir([]string{"-data-dir", path})
+	if !ok || got != path {
+		t.Fatalf("parseDataDir() = %q, %v; want %q, true", got, ok, path)
+	}
+}
+
+func TestParseDataDirRejectsInvalidArguments(t *testing.T) {
+	for _, args := range [][]string{
+		nil,
+		{"-data-dir"},
+		{"-data-dir", ""},
+		{"--data-dir", `C:\data`},
+		{"-data-dir", `C:\data`, "extra"},
+	} {
+		if _, ok := parseDataDir(args); ok {
+			t.Fatalf("parseDataDir(%q) unexpectedly succeeded", args)
+		}
+	}
+}

--- a/src/agent/cmd/useragentlauncher/run_other.go
+++ b/src/agent/cmd/useragentlauncher/run_other.go
@@ -1,0 +1,7 @@
+//go:build !windows
+
+package main
+
+func runAgent(string) int {
+	return 1
+}

--- a/src/agent/cmd/useragentlauncher/run_windows.go
+++ b/src/agent/cmd/useragentlauncher/run_windows.go
@@ -1,0 +1,90 @@
+//go:build windows
+
+package main
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+// runAgent keeps the current-user Agent attached to the scheduled task without
+// allocating a console. The launcher owns a kill-on-close job so stopping the
+// task, signing out, or terminating the launcher cannot orphan the Agent.
+func runAgent(dataDir string) int {
+	launcherPath, err := os.Executable()
+	if err != nil {
+		return 1
+	}
+	agentPath := filepath.Join(filepath.Dir(launcherPath), "hfl-agent.exe")
+	if _, err := os.Stat(agentPath); err != nil {
+		return 1
+	}
+
+	job, err := createKillOnCloseJob()
+	if err != nil {
+		return 1
+	}
+	defer windows.CloseHandle(job)
+
+	cmd := exec.Command(agentPath, "run", "-data-dir", dataDir)
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		CreationFlags: windows.CREATE_NO_WINDOW,
+		HideWindow:    true,
+	}
+	if err := cmd.Start(); err != nil {
+		return 1
+	}
+	if err := assignProcessToJob(job, uint32(cmd.Process.Pid)); err != nil {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		return 1
+	}
+
+	err = cmd.Wait()
+	if err == nil {
+		return 0
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) && exitErr.ExitCode() >= 0 {
+		return exitErr.ExitCode()
+	}
+	return 1
+}
+
+func createKillOnCloseJob() (windows.Handle, error) {
+	job, err := windows.CreateJobObject(nil, nil)
+	if err != nil {
+		return 0, err
+	}
+	info := windows.JOBOBJECT_EXTENDED_LIMIT_INFORMATION{}
+	info.BasicLimitInformation.LimitFlags = windows.JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+	if _, err := windows.SetInformationJobObject(
+		job,
+		windows.JobObjectExtendedLimitInformation,
+		uintptr(unsafe.Pointer(&info)),
+		uint32(unsafe.Sizeof(info)),
+	); err != nil {
+		windows.CloseHandle(job)
+		return 0, err
+	}
+	return job, nil
+}
+
+func assignProcessToJob(job windows.Handle, pid uint32) error {
+	process, err := windows.OpenProcess(
+		windows.PROCESS_SET_QUOTA|windows.PROCESS_TERMINATE,
+		false,
+		pid,
+	)
+	if err != nil {
+		return err
+	}
+	defer windows.CloseHandle(process)
+	return windows.AssignProcessToJobObject(job, process)
+}

--- a/src/agent/internal/enroll/package_manifest.go
+++ b/src/agent/internal/enroll/package_manifest.go
@@ -60,7 +60,13 @@ func validateAgentPackageFor(root, platform, arch string, role model.Role, expec
 
 	required := []string{"bin/hfl-agent", "bin/kopia"}
 	if platform == "windows" {
-		required = []string{"bin/hfl-agent.exe", "bin/kopia.exe", "install.ps1", "install.cmd"}
+		required = []string{
+			"bin/hfl-agent.exe",
+			"bin/hfl-agent-user-launcher.exe",
+			"bin/kopia.exe",
+			"install.ps1",
+			"install.cmd",
+		}
 	} else {
 		required = append(required, "install.sh")
 	}

--- a/src/agent/internal/enroll/package_manifest_test.go
+++ b/src/agent/internal/enroll/package_manifest_test.go
@@ -56,6 +56,7 @@ func writeTestAgentPackage(t *testing.T, platform, arch, flavor string) string {
 	kopiaName := "bin/kopia"
 	if platform == "windows" {
 		files["bin/hfl-agent.exe"] = []byte("agent")
+		files["bin/hfl-agent-user-launcher.exe"] = []byte("launcher")
 		files["bin/kopia.exe"] = []byte("kopia")
 		files["install.ps1"] = []byte("# installer\n")
 		files["install.cmd"] = []byte("@echo off\r\n")

--- a/src/agent/internal/platform/install/install_ps1_test.go
+++ b/src/agent/internal/platform/install/install_ps1_test.go
@@ -92,23 +92,18 @@ func TestInstallPs1UsesFullWindowsIdentityForCurrentUserTask(t *testing.T) {
 	}
 }
 
-func TestInstallPs1RunsCurrentUserAgentThroughHiddenRunner(t *testing.T) {
+func TestInstallPs1RunsCurrentUserAgentThroughWindowlessLauncher(t *testing.T) {
 	source := readPackagingInstallScript(t)
 	for _, want := range []string{
-		`function Write-HflUserTaskRunner`,
-		`$runner = Join-Path $InstallRoot "run-agent.ps1"`,
-		`$powershellName = if ($PSVersionTable.PSEdition -eq "Core") { "pwsh.exe" } else { "powershell.exe" }`,
-		`$powershell = Join-Path $PSHOME $powershellName`,
-		`-NoProfile -NonInteractive -ExecutionPolicy Bypass -WindowStyle Hidden -File`,
-		"`$startInfo = New-Object System.Diagnostics.ProcessStartInfo",
-		"`$startInfo.UseShellExecute = `$false",
-		"`$startInfo.CreateNoWindow = `$true",
-		"`$startInfo.WindowStyle = [System.Diagnostics.ProcessWindowStyle]::Hidden",
-		"[System.Diagnostics.Process]::Start(`$startInfo)",
+		`$runner = Join-Path $InstallRoot "hfl-agent-user-launcher.exe"`,
+		`-Execute $runner`,
+		"-Argument \"-data-dir `\"$DataRoot`\"\"",
+		`Copy-Item -Force -Path $srcLauncher -Destination (Join-Path $InstallRoot "hfl-agent-user-launcher.exe")`,
+		`Remove-HflInstallFile (Join-Path $InstallRoot "hfl-agent-user-launcher.exe")`,
 		`Remove-HflInstallFile (Join-Path $InstallRoot "run-agent.ps1")`,
 	} {
 		if !strings.Contains(source, want) {
-			t.Fatalf("install.ps1 hidden current-user runner is missing %q", want)
+			t.Fatalf("install.ps1 current-user launcher is missing %q", want)
 		}
 	}
 	installServiceStart := strings.Index(source, "function Install-HflService")
@@ -128,11 +123,11 @@ func TestInstallPs1RunsCurrentUserAgentThroughHiddenRunner(t *testing.T) {
 		t.Fatal("install.ps1 system service branch is missing")
 	}
 	userService = userService[:systemServiceStart]
-	if strings.Contains(userService, "-Execute $ExePath") {
-		t.Fatal("current-user task must not launch the console Agent executable directly")
+	if strings.Contains(userService, "powershell.exe") || strings.Contains(userService, "$powershell") {
+		t.Fatal("current-user task must not keep a console PowerShell runner alive")
 	}
-	if strings.Contains(source, "& `$agent run -data-dir `$dataRoot") {
-		t.Fatal("hidden runner must create the Agent with CreateNoWindow")
+	if strings.Contains(source, "function Write-HflUserTaskRunner") {
+		t.Fatal("legacy PowerShell current-user runner must not be generated")
 	}
 }
 

--- a/src/agent/packaging/install/install.ps1
+++ b/src/agent/packaging/install/install.ps1
@@ -452,6 +452,7 @@ function Read-HflEnvValue {
 
 function Test-BundleLayout {
   return (Test-Path -LiteralPath (Join-Path $BundleRoot "bin\hfl-agent.exe")) -and
+    (Test-Path -LiteralPath (Join-Path $BundleRoot "bin\hfl-agent-user-launcher.exe")) -and
     (Test-Path -LiteralPath (Join-Path $BundleRoot "bin\kopia.exe"))
 }
 
@@ -477,7 +478,8 @@ function Test-AgentPackageRoot {
   param([Parameter(Mandatory = $true)][string]$Root)
   return (Test-Path -LiteralPath (Join-Path $Root "MANIFEST.json")) -and
     (Test-Path -LiteralPath (Join-Path $Root "install.ps1")) -and
-    (Test-Path -LiteralPath (Join-Path $Root "bin\hfl-agent.exe"))
+    (Test-Path -LiteralPath (Join-Path $Root "bin\hfl-agent.exe")) -and
+    (Test-Path -LiteralPath (Join-Path $Root "bin\hfl-agent-user-launcher.exe"))
 }
 
 function Get-UpgradeWorkspace {
@@ -576,7 +578,7 @@ function Backup-RollbackBinaries {
     Remove-Item -Recurse -Force -LiteralPath $rollbackRoot
   }
   New-Item -ItemType Directory -Force -Path $script:UpgradeBinBackup | Out-Null
-  foreach ($name in @("hfl-agent.exe", "kopia.exe", "MANIFEST.json", "INSTALLED_VERSION")) {
+  foreach ($name in @("hfl-agent.exe", "hfl-agent-user-launcher.exe", "kopia.exe", "MANIFEST.json", "INSTALLED_VERSION")) {
     $src = Join-Path $InstallRoot $name
     if (Test-Path -LiteralPath $src) {
       Copy-Item -LiteralPath $src -Destination (Join-Path $script:UpgradeBinBackup $name) -Force
@@ -589,7 +591,7 @@ function Restore-RollbackBinaries {
   if ([string]::IsNullOrWhiteSpace($script:UpgradeBinBackup) -or -not (Test-Path -LiteralPath $script:UpgradeBinBackup)) {
     return
   }
-  foreach ($name in @("hfl-agent.exe", "kopia.exe", "MANIFEST.json", "INSTALLED_VERSION")) {
+  foreach ($name in @("hfl-agent.exe", "hfl-agent-user-launcher.exe", "kopia.exe", "MANIFEST.json", "INSTALLED_VERSION")) {
     $src = Join-Path $script:UpgradeBinBackup $name
     if (Test-Path -LiteralPath $src) {
       Copy-Item -LiteralPath $src -Destination (Join-Path $InstallRoot $name) -Force
@@ -789,7 +791,7 @@ function Stop-HflService {
 
 function Stop-HflAgentProcesses {
   param([string]$Reason = "uninstall")
-  foreach ($name in @("hfl-agent", "kopia")) {
+  foreach ($name in @("hfl-agent", "hfl-agent-user-launcher", "kopia")) {
     $deadline = (Get-Date).AddSeconds(20)
     while ((Get-Date) -lt $deadline) {
       $procs = @(Get-Process -Name $name -ErrorAction SilentlyContinue)
@@ -912,56 +914,19 @@ exit 0
   Write-HflOk "scheduled removal of install directory $target (after install.cmd exits)"
 }
 
-function Write-HflUserTaskRunner {
-  param(
-    [Parameter(Mandatory = $true)][string]$ExePath,
-    [Parameter(Mandatory = $true)][string]$DataRoot
-  )
-  $runner = Join-Path $InstallRoot "run-agent.ps1"
-  $exeEsc = $ExePath.Replace("'", "''")
-  $dataEsc = $DataRoot.Replace("'", "''")
-  $body = @"
-`$ErrorActionPreference = 'Stop'
-`$agent = '$exeEsc'
-`$dataRoot = '$dataEsc'
-try {
-  # Hiding powershell.exe alone is insufficient when Windows Terminal is the
-  # default console host: the console Agent can still receive a new window.
-  # CreateNoWindow applies to the Agent process itself.
-  `$startInfo = New-Object System.Diagnostics.ProcessStartInfo
-  `$startInfo.FileName = `$agent
-  `$startInfo.Arguments = 'run -data-dir "' + `$dataRoot + '"'
-  `$startInfo.UseShellExecute = `$false
-  `$startInfo.CreateNoWindow = `$true
-  `$startInfo.WindowStyle = [System.Diagnostics.ProcessWindowStyle]::Hidden
-  `$process = [System.Diagnostics.Process]::Start(`$startInfo)
-  if (`$null -eq `$process) { exit 1 }
-  `$process.WaitForExit()
-  exit `$process.ExitCode
-}
-catch {
-  exit 1
-}
-"@
-  Set-Content -LiteralPath $runner -Value $body -Encoding UTF8
-  return $runner
-}
-
 function Install-HflService {
   param([string]$ExePath, [string]$DataRoot, [switch]$NoStart)
   Remove-HflService
   if ($InstallationMode -eq "user") {
-    # Task Scheduler owns the process after installation. The hidden runner
-    # creates the console Agent without allocating an interactive window.
-    $runner = Write-HflUserTaskRunner -ExePath $ExePath -DataRoot $DataRoot
-    $powershellName = if ($PSVersionTable.PSEdition -eq "Core") { "pwsh.exe" } else { "powershell.exe" }
-    $powershell = Join-Path $PSHOME $powershellName
-    if (-not (Test-Path -LiteralPath $powershell)) {
-      throw "Could not resolve the current PowerShell executable for the user task."
+    # A dedicated GUI-subsystem launcher keeps the task and Agent windowless.
+    # PowerShell cannot reliably suppress its console under Windows Terminal.
+    $runner = Join-Path $InstallRoot "hfl-agent-user-launcher.exe"
+    if (-not (Test-Path -LiteralPath $runner)) {
+      throw "Current-user Agent launcher is missing: $runner"
     }
     $action = New-ScheduledTaskAction `
-      -Execute $powershell `
-      -Argument "-NoProfile -NonInteractive -ExecutionPolicy Bypass -WindowStyle Hidden -File `"$runner`""
+      -Execute $runner `
+      -Argument "-data-dir `"$DataRoot`""
     $trigger = New-ScheduledTaskTrigger -AtLogOn -User $CurrentWindowsIdentity
     $principal = New-ScheduledTaskPrincipal `
       -UserId $CurrentWindowsIdentity `
@@ -1160,6 +1125,7 @@ function Deploy-InstallerFile {
 function Deploy-Binaries {
   param([string]$SrcRoot = $BundleRoot)
   $srcAgent = Join-Path $SrcRoot "bin\hfl-agent.exe"
+  $srcLauncher = Join-Path $SrcRoot "bin\hfl-agent-user-launcher.exe"
   $srcKopia = Join-Path $SrcRoot "bin\kopia.exe"
   if (-not (Test-Path -LiteralPath $srcAgent)) {
     if (Test-InstalledScriptLocation) {
@@ -1173,6 +1139,12 @@ function Deploy-Binaries {
     }
     throw "Missing bundle kopia: $srcKopia"
   }
+  if (-not (Test-Path -LiteralPath $srcLauncher)) {
+    if (Test-InstalledScriptLocation) {
+      throw "Missing current-user Agent launcher: $srcLauncher. Run upgrade -From <package.zip>, or use remote agent.upgrade."
+    }
+    throw "Missing current-user Agent launcher: $srcLauncher"
+  }
   New-Item -ItemType Directory -Force -Path $InstallRoot | Out-Null
   $deployAgent = -not $KopiaOnly.IsPresent
   $deployKopia = -not $AgentOnly.IsPresent
@@ -1180,6 +1152,8 @@ function Deploy-Binaries {
   if ($deployAgent) {
     Copy-Item -Force -Path $srcAgent -Destination (Join-Path $InstallRoot "hfl-agent.exe")
     Write-HflOk "deployed $(Join-Path $InstallRoot 'hfl-agent.exe') ($ver)"
+    Copy-Item -Force -Path $srcLauncher -Destination (Join-Path $InstallRoot "hfl-agent-user-launcher.exe")
+    Write-HflOk "deployed $(Join-Path $InstallRoot 'hfl-agent-user-launcher.exe')"
   }
   if ($deployKopia) {
     Copy-Item -Force -Path $srcKopia -Destination (Join-Path $InstallRoot "kopia.exe")
@@ -1473,6 +1447,7 @@ function Invoke-Uninstall {
   }
 
   Remove-HflInstallFile (Join-Path $InstallRoot "hfl-agent.exe")
+  Remove-HflInstallFile (Join-Path $InstallRoot "hfl-agent-user-launcher.exe")
   Remove-HflInstallFile (Join-Path $InstallRoot "kopia.exe")
   Remove-HflInstallFile (Join-Path $InstallRoot "run-agent.ps1")
   Remove-HflInstallFile (Join-Path $InstallRoot "install.ps1")

--- a/src/agent/scripts/build.sh
+++ b/src/agent/scripts/build.sh
@@ -92,8 +92,9 @@ usage() {
 Usage: ./src/agent/scripts/build.sh [--release|--clean|--clean-all] [options]
 
 Purpose:
-  Cross-compile hfl-agent and hfl-enroll from local Go source. This script does
-  not fetch Kopia, run tests, or assemble customer-facing archives.
+  Cross-compile hfl-agent, hfl-enroll, and the Windows current-user launcher
+  from local Go source. This script does not fetch Kopia, run tests, or
+  assemble customer-facing archives.
 
 Modes (default: --release):
   --release              Build the configured platform matrix
@@ -105,6 +106,7 @@ Inputs:
 
 Outputs:
   build/agent/<version>/<os>/<arch>/hfl-agent-*
+  build/agent/<version>/windows/<arch>/hfl-agent-user-launcher-*.exe
   build/agent/<version>/<os>/<arch>/hfl-enroll-*
   build/agent/<version>/BUILD_INFO.json
 
@@ -266,7 +268,7 @@ build_release() {
 	cd "${AGENT_ROOT}"
 	mkdir -p "${WORK_ROOT}"
 	local ldflags="-s -w -X hyperfilelens/agent/internal/selfupdate.Version=${AGENT_VERSION} -X hyperfilelens/agent/internal/selfupdate.Commit=${COMMIT}"
-	local item goos goarch name enroll_name dir
+	local item goos goarch name enroll_name launcher_name dir
 
 	for item in ${MATRIX}; do
 		IFS=: read -r goos goarch <<<"${item}"
@@ -280,6 +282,16 @@ build_release() {
 			log_fail "Failed to build hfl-agent for ${goos}/${goarch}"
 		fi
 		log_ok "Built ${dir}/${name}"
+		if [[ "${goos}" == windows ]]; then
+			launcher_name="hfl-agent-user-launcher-${goos}-${goarch}.exe"
+			log_step "Building hfl-agent-user-launcher for ${goos}/${goarch}"
+			if ! GOOS="${goos}" GOARCH="${goarch}" CGO_ENABLED=0 \
+				go build -buildvcs=false -trimpath -ldflags "-s -w -H=windowsgui" \
+				-o "${dir}/${launcher_name}" ./cmd/useragentlauncher; then
+				log_fail "Failed to build hfl-agent-user-launcher for ${goos}/${goarch}"
+			fi
+			log_ok "Built ${dir}/${launcher_name}"
+		fi
 
 		enroll_name="hfl-enroll-${goos}-${goarch}"
 		[[ "${goos}" == windows ]] && enroll_name+=".exe"

--- a/src/agent/scripts/package.sh
+++ b/src/agent/scripts/package.sh
@@ -107,6 +107,7 @@ Inputs:
   build/kopia/KOPIA_INFO.json
   build/kopia/dist/<os>/<arch>/kopia[.exe]
   build/agent/<version>/<os>/<arch>/hfl-agent-*
+  build/agent/<version>/windows/<arch>/hfl-agent-user-launcher-*.exe
   build/dependencies/agent/ubuntu-{20.04,22.04,24.04}/<arch>/MANIFEST.json
   src/agent/packaging/
 
@@ -344,6 +345,10 @@ def agent_binary_name(goos: str, goarch: str) -> str:
     return f"hfl-agent-{goos}-{goarch}{suffix}"
 
 
+def user_launcher_binary_name(goos: str, goarch: str) -> str:
+    return f"hfl-agent-user-launcher-{goos}-{goarch}.exe"
+
+
 def package_name(goos: str, goarch: str, flavor: str = "standard") -> str:
     name = f"hfl-agent-{version}-{goos}-{goarch}"
     if flavor in {"ubuntu2004", "ubuntu2204", "ubuntu2404"}:
@@ -422,6 +427,15 @@ def assemble_standard(goos: str, goarch: str, kopia_info: dict) -> None:
         kopia_destination = bin_dir / ("kopia.exe" if goos == "windows" else "kopia")
         shutil.copy2(agent_source, agent_destination)
         executable(agent_destination)
+        if goos == "windows":
+            launcher_source = platform_dir / user_launcher_binary_name(goos, goarch)
+            if not launcher_source.is_file():
+                raise PrerequisiteError(
+                    f"missing current-user launcher: {launcher_source}"
+                )
+            launcher_destination = bin_dir / "hfl-agent-user-launcher.exe"
+            shutil.copy2(launcher_source, launcher_destination)
+            executable(launcher_destination)
         shutil.copy2(kopia_source, kopia_destination)
         executable(kopia_destination)
 


### PR DESCRIPTION
Fixes the remaining visible console window in Windows Current User mode after PR #750. The scheduled task now launches a dedicated Windows GUI helper instead of a long-running PowerShell process. The helper starts the Agent without a console, propagates its exit code, and owns a kill-on-close Job Object so task stop and sign-out cannot orphan the Agent.\n\nValidation:\n- Full Agent unit test suite passes\n- Windows PowerShell installer parser passes\n- Windows GUI PE subsystem verified\n- Live Windows task start/stop verified with zero visible window handles and no orphan processes\n\nRelated: #426 #427