### PR TITLE
fix(insight): speed up chat selection and polish file picker

### DIFF
--- a/src/frontend/src/composables/useCopilotSelectionPreview.ts
+++ b/src/frontend/src/composables/useCopilotSelectionPreview.ts
@@ -35,7 +35,10 @@ type PreviewOptions = {
   scopes: ComputedRef<CopilotSelectionScope[]>
 }
 
-const POLL_MS = 1_000
+// Check once immediately after dispatch, then use a short bounded backoff.
+// The Reader task is asynchronous, but a completed task should not add an
+// unnecessary full second to the user's selection flow.
+const POLL_DELAYS_MS = [250, 400, 650, 1_000]
 const MAX_POLLS = 120
 const RETRY_DELAYS_MS = [0, 2_000, 5_000, 15_000]
 const REQUEST_RETRY_DELAYS_MS = [0, 2_000, 5_000, 15_000]
@@ -255,8 +258,11 @@ export function useCopilotSelectionPreview(options: PreviewOptions) {
           error: 'Selected data calculation is taking longer than expected.',
         }
       }
+      if (polls > 0) {
+        const delay = POLL_DELAYS_MS[Math.min(polls - 1, POLL_DELAYS_MS.length - 1)]
+        await sleep(delay, signal)
+      }
       polls += 1
-      await sleep(POLL_MS, signal)
       current = await fetchTaskWithRetry(current.task_id, signal)
     }
     return current

--- a/src/frontend/src/composables/useKnowledgeSourceForm.ts
+++ b/src/frontend/src/composables/useKnowledgeSourceForm.ts
@@ -113,6 +113,9 @@ export function useKnowledgeSourceForm(
   let backupScopeBlurSequence = 0
   let scopeDisposed = false
   const snapshotBrowseControllers = new Set<AbortController>()
+  type SnapshotBrowseResult = Awaited<ReturnType<typeof browseCopilotSnapshotDirectory>>
+  const snapshotBrowseCache = new Map<string, SnapshotBrowseResult>()
+  const SNAPSHOT_BROWSE_CACHE_LIMIT = 64
   const openBackupScopePickerId = ref<string | null>(null)
   const backupScopeTreeRevision = ref(0)
   const backupScopeBrowseLoading = ref(false)
@@ -136,18 +139,37 @@ export function useKnowledgeSourceForm(
     const gatewayLinkId = snapshotReaderGatewayLinkId.value
     if (!snapshotId) throw new Error('Select a backup snapshot before browsing files.')
     if (!gatewayLinkId) throw new Error('Select an available Data Gateway before browsing files.')
+    const path = params.path || ''
+    const limit = Math.max(1, Math.min(params.limit || 500, 500))
+    const cacheKey = [snapshotId, gatewayLinkId, directoryId, path, limit].join(':')
+    const cached = snapshotBrowseCache.get(cacheKey)
+    if (cached) return cached
     const controller = new AbortController()
     snapshotBrowseControllers.add(controller)
     try {
-      return await browseCopilotSnapshotDirectory(
+      const result = await browseCopilotSnapshotDirectory(
         directoryId,
         {
           ...params,
+          path,
+          limit,
           backupSourceSnapshotId: snapshotId,
           gatewayLinkId,
         },
         controller.signal,
       )
+      snapshotBrowseCache.set(cacheKey, result)
+      while (snapshotBrowseCache.size > SNAPSHOT_BROWSE_CACHE_LIMIT) {
+        const oldest = snapshotBrowseCache.keys().next().value
+        if (oldest == null) break
+        snapshotBrowseCache.delete(oldest)
+      }
+      return result
+    } catch (error) {
+      // Do not retain failed or canceled browse attempts; a later expansion
+      // can make a fresh request after the Reader recovers.
+      snapshotBrowseCache.delete(cacheKey)
+      throw error
     } finally {
       snapshotBrowseControllers.delete(controller)
     }

--- a/src/frontend/src/lib/lensApi.ts
+++ b/src/frontend/src/lib/lensApi.ts
@@ -6,7 +6,9 @@ import type { BackupSnapshotBrowserEntry } from './protectionBackupConfigApi'
 import { asList, unwrapApiPayload } from './parse'
 
 const API_BASE = import.meta.env.VITE_API_BASE?.toString() || ''
-const COPILOT_SNAPSHOT_BROWSE_POLL_MS = 500
+// The first read is immediate; bounded backoff keeps the picker responsive
+// without continuously polling a busy Reader.
+const COPILOT_SNAPSHOT_BROWSE_POLL_DELAYS_MS = [150, 300, 500]
 const COPILOT_SNAPSHOT_BROWSE_MAX_POLLS = 240
 
 export type LensApiScope = 'tenant' | 'platform'
@@ -1094,22 +1096,30 @@ export async function browseCopilotSnapshotDirectory(
         retryable: true,
       }
     }
+    if (polls > 0) {
+      const delay = COPILOT_SNAPSHOT_BROWSE_POLL_DELAYS_MS[
+        Math.min(polls - 1, COPILOT_SNAPSHOT_BROWSE_POLL_DELAYS_MS.length - 1)
+      ]
+      await new Promise<void>((resolve, reject) => {
+        if (signal?.aborted) {
+          reject(new DOMException('Aborted', 'AbortError'))
+          return
+        }
+        const onAbort = () => {
+          window.clearTimeout(timer)
+          reject(new DOMException('Aborted', 'AbortError'))
+        }
+        const timer = window.setTimeout(() => {
+          signal?.removeEventListener('abort', onAbort)
+          resolve()
+        }, delay)
+        signal?.addEventListener('abort', onAbort, { once: true })
+      })
+    }
     polls += 1
-    await new Promise<void>((resolve, reject) => {
-      if (signal?.aborted) {
-        reject(new DOMException('Aborted', 'AbortError'))
-        return
-      }
-      const onAbort = () => {
-        window.clearTimeout(timer)
-        reject(new DOMException('Aborted', 'AbortError'))
-      }
-      const timer = window.setTimeout(() => {
-        signal?.removeEventListener('abort', onAbort)
-        resolve()
-      }, COPILOT_SNAPSHOT_BROWSE_POLL_MS)
-      signal?.addEventListener('abort', onAbort, { once: true })
-    })
+    if (signal?.aborted) {
+      throw new DOMException('Aborted', 'AbortError')
+    }
     task = await fetchCopilotSnapshotBrowse(task.task_id, signal)
   }
   if (task.status !== 'success') {

--- a/src/frontend/src/pages/insight/NewCopilotChat.vue
+++ b/src/frontend/src/pages/insight/NewCopilotChat.vue
@@ -553,8 +553,9 @@ onBeforeUnmount(() => backupScopeResizeObserver?.disconnect())
                         :visible="isBackupScopePickerOpen(scopeEntry.id)"
                         trigger="click"
                         placement="bottom-start"
+                        :fallback-placements="['top-start', 'bottom-end', 'top-end']"
                         :width="backupScopePickerWidth"
-                        popper-class="ks-backup-scope-popover"
+                        popper-class="new-chat-scope-popover"
                         @update:visible="(open) => setBackupScopePickerOpen(scopeEntry.id, open)"
                       >
                         <template #reference>
@@ -608,9 +609,13 @@ onBeforeUnmount(() => backupScopeResizeObserver?.disconnect())
                                   class="hfl-dir-tree-node__icon hfl-dir-tree-node__icon--file"
                                 />
                                 <div class="hfl-dir-tree-node__text">
-                                  <span class="hfl-dir-tree-node__label">{{ data.label }}</span><span
+                                  <span
+                                    class="hfl-dir-tree-node__label"
+                                    :title="data.label"
+                                  >{{ data.label }}</span><span
                                     v-if="data.path"
                                     class="hfl-dir-tree-node__path"
+                                    :title="data.path"
                                   >{{ data.path }}</span>
                                 </div>
                                 <span
@@ -986,6 +991,25 @@ onBeforeUnmount(() => backupScopeResizeObserver?.disconnect())
 .new-chat-gateway-option__status { display: inline-flex; flex: 0 0 auto; align-items: center; gap: 6px; color: #00b42a; font-size: 12px; font-weight: 600; }
 .new-chat-gateway-option__dot { width: 7px; height: 7px; border-radius: 50%; background: currentColor; box-shadow: 0 0 0 3px rgba(0, 180, 42, .12); }
 :global(.new-chat-gateway-select-popper .el-select-dropdown__wrap) { max-height: 220px; }
+:global(.new-chat-scope-popover.el-popper) {
+  box-sizing: border-box;
+  max-width: calc(100vw - 24px);
+  padding: 8px;
+}
+:global(.new-chat-scope-popover .hfl-dir-tree) {
+  max-height: min(36vh, 300px);
+  overflow-x: hidden;
+}
+:global(.new-chat-scope-popover .el-tree-node__content) { min-width: 0; }
+:global(.new-chat-scope-popover .hfl-dir-tree-node__text) { overflow: hidden; }
+:global(.new-chat-scope-popover .hfl-dir-tree-node__label),
+:global(.new-chat-scope-popover .hfl-dir-tree-node__path) {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow-wrap: normal;
+}
 @media (max-width: 900px) {
   .new-chat-grid { grid-template-columns: 1fr; }
   .new-chat-scope-stack__header { display: none; }


### PR DESCRIPTION
## Summary
- reduce artificial polling latency when calculating Chat selections
- cache successful snapshot directory reads within the current form
- prevent long file names and paths from overlapping file sizes
- constrain and reposition the Chat file picker popover

## Validation
- Targeted frontend tests: 50 passed on the source worktree
- ESLint and TypeScript checks passed

Related: #205