### PR TITLE
feat(dev): unify development lifecycle logs

### DIFF
--- a/dev/sourcelens.sh
+++ b/dev/sourcelens.sh
@@ -198,6 +198,13 @@ require_docker() {
 	docker info >/dev/null 2>&1 || sourcelens_die "docker daemon is not reachable"
 }
 
+sourcelens_compose_logged() {
+	local status=0
+	sourcelens_dev_compose "$@" 2>&1 | tr '\r' '\n' | hfl_log_output_line docker \
+		|| status="${PIPESTATUS[0]}"
+	return "${status}"
+}
+
 cmd_prepare() {
 	require_docker
 	hfl_docker_validate_pull_settings "${SOURCELENS_DOCKER_PULL_TIMEOUT}" \
@@ -224,7 +231,7 @@ cmd_up() {
 	sourcelens_ensure_shared_network
 	sourcelens_log "Starting SourceLens stack (project=${SOURCELENS_COMPOSE_PROJECT})"
 	hfl_compose_command_with_exit_event_recovery \
-		sourcelens_dev_compose up -d --pull never --remove-orphans
+		sourcelens_compose_logged up -d --pull never --remove-orphans
 	sourcelens_ensure_database_initialized
 	if command -v curl >/dev/null 2>&1; then
 		sourcelens_wait_for_health || true
@@ -239,7 +246,7 @@ cmd_down() {
 		return 0
 	}
 	sourcelens_log "Stopping SourceLens stack (project=${SOURCELENS_COMPOSE_PROJECT})"
-	hfl_compose_command_with_exit_event_recovery sourcelens_dev_compose down
+	hfl_compose_command_with_exit_event_recovery sourcelens_compose_logged down
 }
 
 main() {

--- a/dev/stack.sh
+++ b/dev/stack.sh
@@ -381,6 +381,16 @@ compose() {
 	)
 }
 
+# Stream human-facing Docker/Compose output through the same status envelope as
+# the Agent installer. Command substitutions continue to use compose() so
+# machine-readable values are never prefixed or altered.
+compose_logged() {
+	local status=0
+	compose "$@" 2>&1 | tr '\r' '\n' | hfl_log_output_line docker \
+		|| status="${PIPESTATUS[0]}"
+	return "${status}"
+}
+
 ensure_bridge_network() {
 	local network="hyperfilelens-bridge"
 	if docker network inspect "${network}" >/dev/null 2>&1; then
@@ -597,7 +607,7 @@ prepare_website_static() {
 refresh_website_web_mount() {
 	[[ "${WEBSITE_ARTIFACT_REBUILT}" -eq 1 ]] || return 0
 	log "Website artifact directory replaced; recreating Web to refresh its bind mount"
-	compose up -d --no-deps --no-build --pull never --force-recreate web
+	compose_logged up -d --no-deps --no-build --pull never --force-recreate web
 }
 
 build_dev_images() {
@@ -623,9 +633,9 @@ build_dev_images() {
 			|| die "backend development image is missing or stale in offline mode"
 		log "Building backend development dependency image"
 		if [[ "${force}" -eq 1 ]]; then
-			compose build --no-cache worker
+			compose_logged build --no-cache worker
 		else
-			compose build worker
+			compose_logged build worker
 		fi
 		cache_update backend-image "${backend_fingerprint}"
 	else
@@ -638,9 +648,9 @@ build_dev_images() {
 			|| die "frontend development image is missing or stale in offline mode"
 		log "Building frontend development dependency image"
 		if [[ "${force}" -eq 1 ]]; then
-			compose build --no-cache web
+			compose_logged build --no-cache web
 		else
-			compose build web
+			compose_logged build web
 		fi
 		cache_update frontend-image "${frontend_fingerprint}"
 	else
@@ -1311,15 +1321,15 @@ repair_existing_multimodal_model() {
 
 run_dev_migration_gate() {
 	log "Stopping backend services before database migration"
-	compose stop api worker scheduler
+	compose_logged stop api worker scheduler
 	log "Starting development data services"
-	compose up -d --wait --no-build --pull never postgres redis
+	compose_logged up -d --wait --no-build --pull never postgres redis
 	log "Applying backend database migrations"
-	compose --profile tools run --rm --no-deps migration
+	compose_logged --profile tools run --rm --no-deps migration
 }
 
 cmd_up() {
-	hfl_print_section "[1/8] Checking development environment"
+	hfl_log_step "[1/8] Checking development environment"
 	apply_mirror_env_defaults
 	require_dev_build_tools
 	ensure_env_file
@@ -1329,30 +1339,30 @@ cmd_up() {
 	verify_amd64_runtime
 	ensure_bridge_network
 	hfl_log_ok "Development tools, runtime images, and shared network are ready"
-	hfl_print_section "[2/8] Preparing insight services"
+	hfl_log_step "[2/8] Preparing insight services"
 	prepare_sourcelens_dev 0
 	if [[ "${WITH_SOURCELENS}" -eq 1 ]]; then
 		hfl_log_ok "Insight services are prepared"
 	else
 		hfl_log_skip "Insight services are disabled for this run"
 	fi
-	hfl_print_section "[3/8] Preparing HyperFileLens artifacts and images"
+	hfl_log_step "[3/8] Preparing HyperFileLens artifacts and images"
 	prepare_dev 0
 	hfl_log_ok "HyperFileLens development artifacts and images are ready"
-	hfl_print_section "[4/8] Applying database migrations"
+	hfl_log_step "[4/8] Applying database migrations"
 	run_dev_migration_gate
 	hfl_log_ok "Database migrations and singleton initialization completed"
-	hfl_print_section "[5/8] Starting development services"
+	hfl_log_step "[5/8] Starting development services"
 	log "Starting hot-reload HFL stack from explicitly prepared images"
-	compose up -d --no-build --pull never --remove-orphans
+	compose_logged up -d --no-build --pull never --remove-orphans
 	refresh_website_web_mount
 	hfl_log_ok "Hot-reload HyperFileLens services started"
-	hfl_print_section "[6/8] Applying identity and email configuration"
+	hfl_log_step "[6/8] Applying identity and email configuration"
 	sync_optional_identity_settings
 	repair_existing_multimodal_model
-	hfl_print_section "[7/8] Preparing Platform Data Gateway"
+	hfl_log_step "[7/8] Preparing Platform Data Gateway"
 	ensure_local_platform_gateway_dev
-	hfl_print_section "[8/8] Development environment summary"
+	hfl_log_step "[8/8] Development environment summary"
 	print_urls
 }
 
@@ -1360,7 +1370,7 @@ cmd_down() {
 	require_docker
 	[[ -f "${ROOT}/.env" ]] || warn ".env missing; using compose defaults where applicable"
 	log "Stopping stack: docker compose down"
-	compose down
+	compose_logged down
 	stop_sourcelens_dev
 	log "Stopped"
 }
@@ -1368,7 +1378,7 @@ cmd_down() {
 cmd_restart() {
 	local force=$1
 
-	hfl_print_section "[1/8] Checking development environment"
+	hfl_log_step "[1/8] Checking development environment"
 	apply_mirror_env_defaults
 	require_dev_build_tools
 	ensure_env_file
@@ -1378,36 +1388,36 @@ cmd_restart() {
 	verify_amd64_runtime
 	ensure_bridge_network
 	hfl_log_ok "Development tools, runtime images, and shared network are ready"
-	hfl_print_section "[2/8] Preparing insight services"
+	hfl_log_step "[2/8] Preparing insight services"
 	prepare_sourcelens_dev "${force}"
 	if [[ "${WITH_SOURCELENS}" -eq 1 ]]; then
 		hfl_log_ok "Insight services are prepared"
 	else
 		hfl_log_skip "Insight services are disabled for this run"
 	fi
-	hfl_print_section "[3/8] Preparing HyperFileLens artifacts and images"
+	hfl_log_step "[3/8] Preparing HyperFileLens artifacts and images"
 	prepare_dev "${force}"
 	hfl_log_ok "HyperFileLens development artifacts and images are ready"
-	hfl_print_section "[4/8] Applying database migrations"
+	hfl_log_step "[4/8] Applying database migrations"
 	run_dev_migration_gate
 	hfl_log_ok "Database migrations and singleton initialization completed"
-	hfl_print_section "[5/8] Restarting development services"
+	hfl_log_step "[5/8] Restarting development services"
 
 	if [[ "${force}" -eq 1 ]]; then
 		log "Force restart: recreating services from freshly rebuilt images"
-		compose up -d --no-build --pull never --force-recreate --remove-orphans
+		compose_logged up -d --no-build --pull never --force-recreate --remove-orphans
 	else
 		log "Restarting only services whose image or configuration changed"
-		compose up -d --no-build --pull never --remove-orphans
+		compose_logged up -d --no-build --pull never --remove-orphans
 		refresh_website_web_mount
 	fi
 	hfl_log_ok "HyperFileLens development services restarted"
-	hfl_print_section "[6/8] Applying identity and email configuration"
+	hfl_log_step "[6/8] Applying identity and email configuration"
 	sync_optional_identity_settings
 	repair_existing_multimodal_model
-	hfl_print_section "[7/8] Preparing Platform Data Gateway"
+	hfl_log_step "[7/8] Preparing Platform Data Gateway"
 	ensure_local_platform_gateway_dev
-	hfl_print_section "[8/8] Development environment summary"
+	hfl_log_step "[8/8] Development environment summary"
 	print_urls
 }
 
@@ -1500,7 +1510,7 @@ cmd_doctor() {
 clean_runtime() {
 	require_docker
 	ensure_env_file
-	compose down --volumes --remove-orphans || true
+	compose_logged down --volumes --remove-orphans || true
 	if [[ -x "${ROOT}/dev/sourcelens.sh" ]]; then
 		"${ROOT}/dev/sourcelens.sh" down || true
 	fi
@@ -1758,7 +1768,7 @@ main() {
 		print_config
 		return 0
 	fi
-	HFL_LOG_TERMINAL_TIMESTAMPS=0
+	HFL_LOG_TERMINAL_TIMESTAMPS=1
 	HFL_LOG_SESSION_MESSAGES=0
 	HFL_LOG_CAPTURE_STDOUT=1
 	export HFL_LOG_TERMINAL_TIMESTAMPS HFL_LOG_SESSION_MESSAGES \

--- a/src/agent/scripts/build.sh
+++ b/src/agent/scripts/build.sh
@@ -9,6 +9,8 @@ AGENT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 REPO_ROOT="$(cd "${AGENT_ROOT}/../.." && pwd)"
 # shellcheck source=../../../tools/lib/version.sh
 source "${REPO_ROOT}/tools/lib/version.sh"
+# shellcheck source=../../../tools/lib/logging.sh
+source "${REPO_ROOT}/tools/lib/logging.sh"
 
 DEFAULT_MATRIX="linux:amd64 linux:arm64 darwin:amd64 darwin:arm64 windows:amd64"
 MODE="release"
@@ -40,7 +42,8 @@ _hfl_emit_raw() {
 	local level=$1 tag
 	shift
 	if [[ "${HFL_LOG_TERMINAL_TIMESTAMPS:-1}" == "1" ]]; then
-		printf '[%s] [%s] %s\n' "$(hfl_now)" "${level}" "$(hfl_finish_sentence "$@")" >&2
+		HFL_LOG_COMPONENT=agent \
+			hfl_log_emit "${level// /}" "$(hfl_finish_sentence "$@")"
 	else
 		case "${level// /}" in
 		INFO) tag='INFO ' ;;

--- a/src/agent/scripts/fetch-deps.sh
+++ b/src/agent/scripts/fetch-deps.sh
@@ -10,6 +10,8 @@ REPO_ROOT="$(cd "${AGENT_ROOT}/../.." && pwd)"
 source "${REPO_ROOT}/tools/lib/version.sh"
 # shellcheck source=../../../tools/kopia/common.sh
 source "${REPO_ROOT}/tools/kopia/common.sh"
+# shellcheck source=../../../tools/lib/logging.sh
+source "${REPO_ROOT}/tools/lib/logging.sh"
 kopia_load_config
 
 DEFAULT_MATRIX="linux:amd64 linux:arm64 darwin:amd64 darwin:arm64 windows:amd64"
@@ -35,7 +37,8 @@ _hfl_emit_raw() {
 	local level=$1 tag
 	shift
 	if [[ "${HFL_LOG_TERMINAL_TIMESTAMPS:-1}" == "1" ]]; then
-		printf '[%s] [%s] %s\n' "$(hfl_now)" "${level}" "$(hfl_finish_sentence "$@")" >&2
+		HFL_LOG_COMPONENT=agent \
+			hfl_log_emit "${level// /}" "$(hfl_finish_sentence "$@")"
 	else
 		case "${level// /}" in
 		INFO) tag='INFO ' ;;

--- a/src/agent/scripts/package.sh
+++ b/src/agent/scripts/package.sh
@@ -10,6 +10,8 @@ AGENT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 REPO_ROOT="$(cd "${AGENT_ROOT}/../.." && pwd)"
 # shellcheck source=../../../tools/lib/version.sh
 source "${REPO_ROOT}/tools/lib/version.sh"
+# shellcheck source=../../../tools/lib/logging.sh
+source "${REPO_ROOT}/tools/lib/logging.sh"
 
 DEFAULT_MATRIX="linux:amd64 linux:arm64 darwin:amd64 darwin:arm64 windows:amd64"
 BUNDLE="${AGENT_BUNDLE:-all}"
@@ -40,7 +42,8 @@ _hfl_emit_raw() {
 	local level=$1 tag
 	shift
 	if [[ "${HFL_LOG_TERMINAL_TIMESTAMPS:-1}" == "1" ]]; then
-		printf '[%s] [%s] %s\n' "$(hfl_now)" "${level}" "$(hfl_finish_sentence "$@")" >&2
+		HFL_LOG_COMPONENT=agent \
+			hfl_log_emit "${level// /}" "$(hfl_finish_sentence "$@")"
 	else
 		case "${level// /}" in
 		INFO) tag='INFO ' ;;

--- a/tools/lib/logging.sh
+++ b/tools/lib/logging.sh
@@ -13,29 +13,90 @@ HFL_LOG_TERMINAL_TIMESTAMPS="${HFL_LOG_TERMINAL_TIMESTAMPS:-1}"
 HFL_PARENT_SESSION="${HFL_PARENT_SESSION:-0}"
 HFL_LOG_SESSION_MESSAGES="${HFL_LOG_SESSION_MESSAGES:-1}"
 HFL_LOG_CAPTURE_STDOUT="${HFL_LOG_CAPTURE_STDOUT:-0}"
+HFL_LOG_COLOR="${HFL_LOG_COLOR:-auto}"
+export HFL_LOG_COLOR
 HFL_LOG_SESSION_STARTED=0
 
 hfl_log_timestamp() {
 	date -u '+%Y-%m-%dT%H:%M:%S.000Z'
 }
 
+hfl_log_component_name() {
+	local component="${HFL_LOG_COMPONENT:-hfl}"
+	case "${component}" in
+	dev*) printf '%s' "dev" ;;
+	docker*) printf '%s' "docker" ;;
+	sourcelens* | sl*) printf '%s' "sourcelens" ;;
+	agent*) printf '%s' "agent" ;;
+	gateway*) printf '%s' "gateway" ;;
+	*) printf '%s' "${component}" ;;
+	esac
+}
+
+hfl_log_status_token() {
+	case "${1}" in
+	OK | ' OK ' | ' OK  ') printf '%s' ' OK ' ;;
+	STEP | ....) printf '%s' '....' ;;
+	WARN) printf '%s' 'WARN' ;;
+	FAIL | ERROR) printf '%s' 'FAIL' ;;
+	SKIP) printf '%s' 'SKIP' ;;
+	OUT | 'OUT ') printf '%s' 'OUT ' ;;
+	INFO) printf '%s' 'INFO' ;;
+	DEBUG) printf '%s' 'DBG ' ;;
+	*) printf '%s' "${1}" ;;
+	esac
+}
+
+hfl_log_color_enabled() {
+	[[ "${HFL_LOG_COLOR}" != "0" && -z "${NO_COLOR:-}" ]] || return 1
+	if [[ "${HFL_LOG_COLOR}" == "1" || "${HFL_LOG_COLOR}" == "always" ]]; then
+		return 0
+	fi
+	# Respect terminals that explicitly advertise that ANSI styling is not
+	# supported. This keeps piped/non-interactive output portable even when the
+	# caller has inherited a terminal descriptor from a parent process.
+	[[ "${TERM:-}" != "dumb" ]] || return 1
+	# Dev logging mirrors stderr through a process substitution, so the live
+	# terminal is kept on fd 4. Fall back to stderr for standalone callers.
+	[[ -t 4 || -t 2 ]]
+}
+
+hfl_log_color_status() {
+	local token="$1"
+	if ! hfl_log_color_enabled; then
+		printf '%s' "${token}"
+		return 0
+	fi
+	case "${token}" in
+	' OK ') printf '\033[32m%s\033[0m' "${token}" ;;
+	'....') printf '\033[35m%s\033[0m' "${token}" ;;
+	WARN) printf '\033[33m%s\033[0m' "${token}" ;;
+	FAIL) printf '\033[31m%s\033[0m' "${token}" ;;
+	SKIP | INFO) printf '\033[36m%s\033[0m' "${token}" ;;
+	*) printf '%s' "${token}" ;;
+	esac
+}
+
 hfl_log_emit() {
-	local level=$1 tag
+	local level=$1 tag component legacy_tag
 	shift
+	tag="$(hfl_log_status_token "${level}")"
+	component="$(hfl_log_component_name)"
 	if [[ "${HFL_LOG_TERMINAL_TIMESTAMPS}" == "1" ]]; then
-		printf '[%s] [%-5s] %s\n' "$(hfl_log_timestamp)" "${level}" "$*" >&2
+		printf '[%s] [%s] [%s] %s\n' \
+			"$(hfl_log_timestamp)" "$(hfl_log_color_status "${tag}")" "${component}" "$*" >&2
 	else
 		case "${level}" in
-		INFO) tag='INFO ' ;;
-		STEP) tag='....' ;;
-		OK) tag=' OK ' ;;
-		WARN) tag='WARN' ;;
-		SKIP) tag='SKIP' ;;
-		ERROR | FAIL) tag='FAIL' ;;
-		DEBUG) tag='DEBUG' ;;
-		*) tag="${level}" ;;
+		INFO) legacy_tag='INFO ' ;;
+		STEP | ....) legacy_tag='....' ;;
+		OK | ' OK ' | ' OK  ') legacy_tag=' OK ' ;;
+		WARN) legacy_tag='WARN' ;;
+		SKIP) legacy_tag='SKIP' ;;
+		ERROR | FAIL) legacy_tag='FAIL' ;;
+		DEBUG) legacy_tag='DEBUG' ;;
+		*) legacy_tag="${tag}" ;;
 		esac
-		printf '[%s] %s\n' "${tag}" "$*" >&2
+		printf '[%s] %s\n' "${legacy_tag}" "$*" >&2
 	fi
 }
 
@@ -49,6 +110,29 @@ hfl_log_debug() {
 	hfl_log_emit DEBUG "$@"
 }
 hfl_log_fail() { hfl_log_emit FAIL "$@"; }
+
+hfl_log_output_line() {
+	local source="${1:-${HFL_LOG_COMPONENT:-hfl}}" line
+	while IFS= read -r line || [[ -n "${line}" ]]; do
+		# Keep the live stream readable; blank separators carry no diagnostic
+		# information and are already represented by the timestamp sequence.
+		[[ -n "${line}" ]] || continue
+		hfl_log_emit_with_component 'OUT ' "${source}" "${line}"
+	done
+}
+
+hfl_log_emit_with_component() {
+	local level="$1" component="$2" message="$3" tag legacy_tag
+	tag="$(hfl_log_status_token "${level}")"
+	if [[ "${HFL_LOG_TERMINAL_TIMESTAMPS}" == "1" ]]; then
+		printf '[%s] [%s] [%s] %s\n' \
+			"$(hfl_log_timestamp)" "$(hfl_log_color_status "${tag}")" "${component}" "${message}" >&2
+	else
+		legacy_tag="${tag}"
+		[[ "${level}" == "INFO" ]] && legacy_tag='INFO '
+		printf '[%s] %s\n' "${legacy_tag}" "${message}" >&2
+	fi
+}
 
 hfl_die() {
 	local message=${1:-"operation failed"}
@@ -64,10 +148,19 @@ hfl_require_value() {
 }
 
 hfl_log_timestamp_stream() {
-	local log_file=$1 line timestamp
+	local log_file=$1 line timestamp structured_prefix
 	local TZ=UTC
 	export TZ
-	while IFS= read -r line || [[ -n "${line}" ]]; do
+	structured_prefix='^\[[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\.000Z\] \[[^]]+\] \[[^]]+\] '
+	# Strip ANSI once for the whole stream rather than spawning sed once per
+	# line during large Docker/BuildKit logs.
+	sed $'s/\\033\\[[0-9;]*m//g' | while IFS= read -r line || [[ -n "${line}" ]]; do
+		# Structured terminal lines already carry their own timestamp. Do not
+		# prepend a second timestamp when the capture stream mirrors them.
+		if [[ "${line}" =~ ${structured_prefix} ]]; then
+			printf '%s\n' "${line}" >>"${log_file}"
+			continue
+		fi
 		printf -v timestamp '%(%Y-%m-%dT%H:%M:%S.000Z)T' -1
 		printf '[%s] %s\n' "${timestamp}" "${line}" >>"${log_file}"
 	done

--- a/tools/quality/test-lifecycle-output-contract.sh
+++ b/tools/quality/test-lifecycle-output-contract.sh
@@ -108,6 +108,32 @@ grep -E '^\[[0-9]{4}-[0-9]{2}-[0-9]{2}T.*\] progress-one$' \
 grep -E '^\[[0-9]{4}-[0-9]{2}-[0-9]{2}T.*\] progress-two$' \
 	"${capture_log}" >/dev/null
 
+# Timestamped output follows the Agent installer contract: status is the
+# fixed-width field immediately after the timestamp, followed by a compact
+# component name. ANSI styling is disabled in persisted/captured output.
+timestamp_output="$({
+	source "${ROOT_REPO}/tools/lib/logging.sh"
+	export HFL_LOG_TERMINAL_TIMESTAMPS=1 HFL_LOG_COMPONENT=sourcelens-dev HFL_LOG_COLOR=0
+	hfl_log_step "Preparing SourceLens"
+	hfl_log_emit_with_component 'OUT ' docker 'Container sourcelens-api Started'
+	hfl_log_ok "Insight services are prepared"
+} 2>&1)"
+grep -E '^\[[0-9]{4}-[0-9]{2}-[0-9]{2}T.*\] \[\.\.\.\.\] \[sourcelens\] Preparing SourceLens$' <<<"${timestamp_output}" >/dev/null
+grep -E '^\[[0-9]{4}-[0-9]{2}-[0-9]{2}T.*\] \[OUT \] \[docker\] Container sourcelens-api Started$' <<<"${timestamp_output}" >/dev/null
+grep -E '^\[[0-9]{4}-[0-9]{2}-[0-9]{2}T.*\] \[ OK \] \[sourcelens\] Insight services are prepared$' <<<"${timestamp_output}" >/dev/null
+
+# A terminal that declares itself as dumb must not receive ANSI styling in
+# auto mode. Explicit HFL_LOG_COLOR=1/always remains an opt-in override.
+dumb_color_result="$({
+	TERM=dumb HFL_LOG_COLOR=auto source "${ROOT_REPO}/tools/lib/logging.sh"
+	if hfl_log_color_enabled; then
+		printf 'enabled'
+	else
+		printf 'disabled'
+	fi
+} 2>/dev/null)"
+[[ "${dumb_color_result}" == "disabled" ]]
+
 failure_log="${fixture}/dev-failure.log"
 failure_stderr="${fixture}/dev-failure.stderr"
 set +e


### PR DESCRIPTION
## Summary
- standardize Dev, SourceLens, Docker Compose, and Agent output as timestamped status records
- preserve native command diagnostics and exit codes while adding component context
- support color-aware terminal output with safe non-color fallbacks and structured session logs

## Validation
- `bash tools/quality/test-lifecycle-output-contract.sh`
- `bash tools/quality/test-agent-installer-output.sh`
- `bash tools/quality/test-compose-lifecycle-reconcile.sh`
- `bash -n` for all changed shell scripts
- `git diff --check`

No production or `main` branch changes were made.