### PR TITLE
Adjust frontend spacing and typography

### DIFF
--- a/src/frontend/src/components/backupSourceFlowActionDialog.css
+++ b/src/frontend/src/components/backupSourceFlowActionDialog.css
@@ -71,7 +71,7 @@
   align-items: center;
   justify-content: flex-end;
   gap: 8px;
-  padding: 10px 20px;
+  padding: 10px 20px 18px;
   margin: 0;
   border-top: 1px solid var(--el-border-color-extra-light, rgba(15, 23, 42, 0.06));
   background: var(--el-fill-color-blank, #fafafa);

--- a/src/frontend/src/pages/auth/Login.vue
+++ b/src/frontend/src/pages/auth/Login.vue
@@ -944,7 +944,7 @@ onMounted(async () => {
 
 .login-box-title__copy {
   min-width: 0;
-  font-size: 18px;
+  font-size: 17px;
   line-height: 1.35;
   overflow-wrap: normal;
 }


### PR DESCRIPTION
## Summary

- Add bottom breathing room to backup action dialogs
- Slightly reduce the login title size for compact layout

## Testing

- Style-only update; no functional code changes