### PR TITLE
Fix backup wizard pending count

### DIFF
--- a/src/frontend/src/pages/protection/DataProtection.vue
+++ b/src/frontend/src/pages/protection/DataProtection.vue
@@ -1677,9 +1677,12 @@ const step3SourceList = computed(() => {
 
 const step3ReadyCount = computed(() => step3SelectableCount.value)
 
-const step2PendingCount = computed(() => step2SelectableCount.value)
+// The wizard summary represents the organization-wide pipeline state. Keep it
+// separate from step2SelectableCount, which is the filtered API count used by
+// the Step 2 table pager.
+const step2GlobalPendingCount = computed(() => pipelineStep2Count.value)
 
-const step2AllSourcesConfigured = computed(() => step2PendingCount.value === 0 && step3ReadyCount.value > 0)
+const step2AllSourcesConfigured = computed(() => step2GlobalPendingCount.value === 0 && step3ReadyCount.value > 0)
 
 const step3TableRef = ref<InstanceType<typeof ElTable> | null>(null)
 const step3SourceSelection = ref<FlowSourceRow[]>([])
@@ -9298,7 +9301,7 @@ async function runRecovery(mode: 'plan' | 'manual' = 'manual') {
                   aria-hidden="true"
                 />
                 <span class="dp-flow-card__meta-text">
-                  {{ t('protection.backupsPage.flowStepBackupMetricPending', { n: step2PendingCount }) }}
+                  {{ t('protection.backupsPage.flowStepBackupMetricPending', { n: step2GlobalPendingCount }) }}
                 </span>
               </div>
             </div>

--- a/src/frontend/src/pages/protection/DataProtectionStep2Counts.test.ts
+++ b/src/frontend/src/pages/protection/DataProtectionStep2Counts.test.ts
@@ -1,0 +1,22 @@
+import { computed, nextTick, ref } from 'vue'
+import { describe, expect, it } from 'vitest'
+
+describe('backup wizard step 2 count semantics', () => {
+  it('updates the global pending summary without changing the filtered table count', async () => {
+    const pipelineStep2Count = ref(1)
+    const step2SelectableCount = ref(1)
+    const step2GlobalPendingCount = computed(() => pipelineStep2Count.value)
+
+    pipelineStep2Count.value = 0
+    await nextTick()
+
+    expect(step2GlobalPendingCount.value).toBe(0)
+    expect(step2SelectableCount.value).toBe(1)
+
+    step2SelectableCount.value = 0
+    await nextTick()
+
+    expect(step2GlobalPendingCount.value).toBe(0)
+    expect(step2SelectableCount.value).toBe(0)
+  })
+})

--- a/src/frontend/src/pages/protection/DataProtectionStep3MoreActions.test.ts
+++ b/src/frontend/src/pages/protection/DataProtectionStep3MoreActions.test.ts
@@ -20,6 +20,14 @@ function functionSource(name: string, nextName: string) {
 }
 
 describe('backup wizard step 3 More Actions refresh', () => {
+  it('keeps the global Step 2 pending summary separate from filtered table pagination', () => {
+    expect(page).toContain('const step2GlobalPendingCount = computed(() => pipelineStep2Count.value)')
+    expect(page).toContain('step2GlobalPendingCount.value === 0 && step3ReadyCount.value > 0')
+    expect(page).toContain("flowStepBackupMetricPending', { n: step2GlobalPendingCount }")
+    expect(page).toContain(':total="flowMainStep === 1 ? step2SelectableCount : filteredStep2SourceList.length"')
+    expect(page).not.toContain('const step2PendingCount = computed(() => step2SelectableCount.value)')
+  })
+
   it('blocks conflicting source actions while a selected backup is active', () => {
     const gating = sourceBetween(
       'const startBackupSubmitting',


### PR DESCRIPTION
## Summary

- Use the organization-wide pipeline count for the Step 2 pending summary
- Keep filtered Step 2 table pagination counts independent
- Add regression coverage for the split count semantics

Closes #706

## Testing

- Vitest targeted protection tests: 24 passed
- vue-tsc --noEmit
- ESLint for the added regression test