### PR TITLE
fix(deploy): dynamically resolve blue-green upstreams

### DIFF
--- a/deploy/blue-green/README.md
+++ b/deploy/blue-green/README.md
@@ -84,6 +84,11 @@ separate lifecycles. The release manifest supplies the Backend and Frontend
 image references, while `HFL_GATEWAY_VERSION` pins the stable Nginx image
 present at first installation (or the first blue/green upgrade). A later
 `install.sh start` therefore cannot unexpectedly replace the public entry.
-Updating that gateway image requires a separately planned entry-layer
-maintenance action; zero-downtime gateway-image replacement requires an
-external load balancer or a host-level dual-entry driver.
+The generated active upstreams use Docker's embedded resolver (`127.0.0.11`)
+and shared Nginx zones, so a continuously running gateway follows address
+changes when Compose recreates the active API or Web pool. Blue/green cutover
+still performs an explicit `nginx -t` and graceful reload so route changes are
+validated before traffic moves. Updating the gateway image itself requires a
+separately planned entry-layer maintenance action; zero-downtime gateway-image
+replacement requires an external load balancer or a host-level dual-entry
+driver.

--- a/deploy/installer/install.sh
+++ b/deploy/installer/install.sh
@@ -992,11 +992,32 @@ render_active_upstreams() {
 	[[ "${api_color}" == "legacy" ]] && api_service="api"
 	cat > "${temporary}" <<EOF
 # Installer-managed execution cache. Do not edit while an upgrade is running.
-upstream hfl_api_http { server ${api_service}:8000; keepalive 32; }
-upstream hfl_api_ws { server ${api_service}:8001; }
-upstream hfl_web_tenant { server web-${web_color}:8080; keepalive 16; }
-upstream hfl_web_ops { server web-${web_color}:8081; keepalive 16; }
-upstream hfl_website { server web-${web_color}:8082; keepalive 8; }
+# Shared zones and Docker DNS resolution let a continuously running gateway
+# follow Compose container recreation without requiring a gateway restart.
+upstream hfl_api_http {
+    zone hfl_api_http 64k;
+    server ${api_service}:8000 resolve;
+    keepalive 32;
+}
+upstream hfl_api_ws {
+    zone hfl_api_ws 64k;
+    server ${api_service}:8001 resolve;
+}
+upstream hfl_web_tenant {
+    zone hfl_web_tenant 64k;
+    server web-${web_color}:8080 resolve;
+    keepalive 16;
+}
+upstream hfl_web_ops {
+    zone hfl_web_ops 64k;
+    server web-${web_color}:8081 resolve;
+    keepalive 16;
+}
+upstream hfl_website {
+    zone hfl_website 64k;
+    server web-${web_color}:8082 resolve;
+    keepalive 8;
+}
 EOF
 	mv "${temporary}" "${output}"
 }

--- a/deploy/nginx/snippets/hfl-active-upstreams.conf
+++ b/deploy/nginx/snippets/hfl-active-upstreams.conf
@@ -1,7 +1,27 @@
 # Installer-managed execution cache. PostgreSQL deployment records can supersede this
-# file when HFL gains a cluster deployment driver.
-upstream hfl_api_http { server api-blue:8000; keepalive 32; }
-upstream hfl_api_ws { server api-blue:8001; }
-upstream hfl_web_tenant { server web-blue:8080; keepalive 16; }
-upstream hfl_web_ops { server web-blue:8081; keepalive 16; }
-upstream hfl_website { server web-blue:8082; keepalive 8; }
+# file when HFL gains a cluster deployment driver. The shared zones and Docker DNS
+# resolver keep service addresses current when Compose recreates a color pool.
+upstream hfl_api_http {
+    zone hfl_api_http 64k;
+    server api-blue:8000 resolve;
+    keepalive 32;
+}
+upstream hfl_api_ws {
+    zone hfl_api_ws 64k;
+    server api-blue:8001 resolve;
+}
+upstream hfl_web_tenant {
+    zone hfl_web_tenant 64k;
+    server web-blue:8080 resolve;
+    keepalive 16;
+}
+upstream hfl_web_ops {
+    zone hfl_web_ops 64k;
+    server web-blue:8081 resolve;
+    keepalive 16;
+}
+upstream hfl_website {
+    zone hfl_website 64k;
+    server web-blue:8082 resolve;
+    keepalive 8;
+}

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -892,8 +892,32 @@ fi
 [[ "$(grep -Fc '${HFL_TENANT_PORT:-11443}:11443' "${release_compose}")" -eq 1 ]]
 grep -F 'include /etc/nginx/snippets/hfl-active-upstreams.conf;' \
 	"${ROOT}/deploy/nginx/default.conf" >/dev/null
-grep -F 'api-blue:8000' \
+grep -F 'resolver 127.0.0.11 valid=10s ipv6=off;' \
+	"${ROOT}/deploy/nginx/default.conf" >/dev/null
+grep -F 'zone hfl_api_http 64k;' \
 	"${ROOT}/deploy/nginx/snippets/hfl-active-upstreams.conf" >/dev/null
+grep -F 'server api-blue:8000 resolve;' \
+	"${ROOT}/deploy/nginx/snippets/hfl-active-upstreams.conf" >/dev/null
+[[ "$(grep -Ec 'server (api-blue|web-blue):[0-9]+ resolve;' \
+	"${ROOT}/deploy/nginx/snippets/hfl-active-upstreams.conf")" -eq 5 ]]
+[[ "$(grep -Fc 'zone hfl_' \
+	"${ROOT}/deploy/nginx/snippets/hfl-active-upstreams.conf")" -eq 5 ]]
+for expected in \
+	'zone hfl_api_http 64k;' \
+	'zone hfl_api_ws 64k;' \
+	'zone hfl_web_tenant 64k;' \
+	'zone hfl_web_ops 64k;' \
+	'zone hfl_website 64k;' \
+	'server ${api_service}:8000 resolve;' \
+	'server ${api_service}:8001 resolve;' \
+	'server web-${web_color}:8080 resolve;' \
+	'server web-${web_color}:8081 resolve;' \
+	'server web-${web_color}:8082 resolve;'; do
+	grep -F "${expected}" "${ROOT}/deploy/installer/install.sh" >/dev/null || {
+		printf 'ERROR: release upstream renderer is missing: %s\n' "${expected}" >&2
+		exit 1
+	}
+done
 grep -F 'location ~ ^/api/v1/lens/copilot/sessions/[0-9]+/attachments/?$ {' \
 	"${ROOT}/deploy/nginx/snippets/hfl-tenant-locations.conf" >/dev/null
 grep -F 'client_max_body_size 26m;' \


### PR DESCRIPTION
## Summary

- make release blue-green API and Web upstreams re-resolve Docker service addresses after container recreation
- preserve the independently pinned stable gateway image and the existing validated reload, health-check, and rollback flow
- enforce the resolver and shared-zone contract in release checks and document the lifecycle boundary

## Validation

- `./tools/quality/check-release-contracts.sh`
- `bash tools/quality/test-nginx-startup-readiness.sh`
- `bash tools/quality/test-blue-green-recovery.sh`
- `bash tools/quality/test-dev-stack-upgrade.sh`
- `git diff --check`