### PR TITLE
Speed backup wizard transition

### DIFF
--- a/src/frontend/src/pages/protection/BackupConfigCreateWizard.vue
+++ b/src/frontend/src/pages/protection/BackupConfigCreateWizard.vue
@@ -34,10 +34,12 @@ const props = withDefaults(defineProps<{
   goToStartBackupLabel: string
   bootstrapping?: boolean
   busy?: boolean
+  canClose?: boolean
   animated?: boolean
   showSteps?: boolean
 }>(), {
   animated: true,
+  canClose: true,
   showSteps: true,
 })
 
@@ -96,6 +98,7 @@ watch(
           <button
             type="button"
             class="fullscreen-form-header__back"
+            :disabled="!canClose"
             @click="emit('close')"
           >
             <ArrowLeft

--- a/src/frontend/src/pages/protection/BackupConfigurationFastTransition.test.ts
+++ b/src/frontend/src/pages/protection/BackupConfigurationFastTransition.test.ts
@@ -1,0 +1,68 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const page = readFileSync(resolve(process.cwd(), 'src/pages/protection/DataProtection.vue'), 'utf8')
+const wizard = readFileSync(resolve(process.cwd(), 'src/pages/protection/BackupCreateWizard.vue'), 'utf8')
+const shell = readFileSync(resolve(process.cwd(), 'src/pages/protection/BackupConfigCreateWizard.vue'), 'utf8')
+
+function sourceBetween(source: string, startMarker: string, endMarker: string) {
+  const start = source.indexOf(startMarker)
+  const end = source.indexOf(endMarker, start + 1)
+  expect(start).toBeGreaterThan(-1)
+  expect(end).toBeGreaterThan(start)
+  return source.slice(start, end)
+}
+
+describe('backup configuration fast transition', () => {
+  it('uses the authoritative create response without repeating the pipeline update', () => {
+    const create = sourceBetween(wizard, 'async function runCreateBackup', 'function editableGroupPayloads')
+
+    expect(create).toContain('const created = await createBackupConfig(apiPayload)')
+    expect(create).toContain('createdItems.push({ sourceId: backup.source.id, config: created })')
+    expect(create).not.toContain('setPipelineStep(')
+    expect(wizard).not.toContain('useBackupSourcePipeline')
+  })
+
+  it('enters Step 3 before starting non-blocking reconciliation', () => {
+    const complete = sourceBetween(page, 'function finishCreateAndGoToStep3', 'function onCreateBackupPartial')
+    const enter = complete.indexOf('enterStartBackupStep')
+    const reconcile = complete.indexOf('reconcileCreatedBackupConfigs')
+
+    expect(enter).toBeGreaterThan(-1)
+    expect(reconcile).toBeGreaterThan(enter)
+    expect(complete).not.toContain('await refreshStep3AfterMoreAction')
+    expect(page).toContain('skipNextFlowStepRefresh = flowMainStep.value !== 2')
+    expect(page).toContain('if (skipNextFlowStepRefresh)')
+  })
+
+  it('preserves successful state when background reconciliation fails', () => {
+    const refresh = sourceBetween(page, 'async function refreshBackupConfigs(', 'function displayNameForSource')
+    const reconcile = sourceBetween(page, 'function reconcileCreatedBackupConfigs', 'function finishCreateAndGoToStep3')
+
+    expect(refresh).toContain('if (!options.preserveOnError)')
+    expect(reconcile).toContain('preserveConfigOnError: true')
+    expect(reconcile).toContain('preserveExpandedState: true')
+  })
+
+  it('keeps partial successes and separates create from edit outcomes', () => {
+    const create = sourceBetween(wizard, 'async function runCreateBackup', 'function editableGroupPayloads')
+
+    expect(create).toContain("emit('createPartial', { items: createdItems })")
+    expect(create).toContain("errorCode === 'NETWORK.UNAVAILABLE' || errorCode === 'NETWORK.TIMEOUT'")
+    expect(create).toContain("createItemStates.value[backup.source.id] = 'unknown'")
+    expect(create).toContain('normalizedError.status === 401 || normalizedError.status === 403')
+    expect(create).toContain("createItemStates.value[sourceId] = 'not_attempted'")
+    expect(wizard).toContain("emit('editCompleted', { sourceIds: editedSourceIds })")
+    expect(page).toContain('@create-partial="onCreateBackupPartial"')
+  })
+
+  it('blocks closing and starting backup while creation or provisioning is unresolved', () => {
+    expect(shell).toContain(':disabled="!canClose"')
+    expect(wizard).toContain('onBeforeRouteLeave(() => !createSubmissionActive.value)')
+    expect(wizard).toContain("window.addEventListener('beforeunload', preventUnloadDuringCreate)")
+    expect(page).toContain("String(config.status || '').toLowerCase() === 'active'")
+    expect(page).toContain(':disabled="!step3StartBackupEnabled || startBackupSubmitting || step3StopActionBusy"')
+    expect(page).toContain('if (runnableSources.length !== sources.length)')
+  })
+})

--- a/src/frontend/src/pages/protection/BackupCreateWizard.vue
+++ b/src/frontend/src/pages/protection/BackupCreateWizard.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import '../../styles/fullscreen-form-styles'
 import { computed, defineComponent, h, nextTick, onMounted, onUnmounted, reactive, ref, watch, type Component } from 'vue'
-import { useRoute, useRouter } from 'vue-router'
+import { onBeforeRouteLeave, useRoute, useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import {
   Plus,
@@ -105,7 +105,6 @@ import {
   shouldAutoExpandRefreshedDirectory,
 } from '../../lib/backupSourceDirectoryTree'
 import { restoreDirectoryBrowseSourceId } from '../../lib/restoreDirectoryTarget'
-import { useBackupSourcePipeline } from '../../composables/useBackupSourcePipeline'
 import {
   createBackupPolicy,
   createFileFilterRule,
@@ -193,7 +192,9 @@ const props = withDefaults(defineProps<{
 })
 const emit = defineEmits<{
   closed: []
-  completed: [sourceIds: string[]]
+  createCompleted: [payload: { items: Array<{ sourceId: string; config: BackupConfigDetail }> }]
+  createPartial: [payload: { items: Array<{ sourceId: string; config: BackupConfigDetail }> }]
+  editCompleted: [payload: { sourceIds: string[] }]
   conflict: [payload: { sourceIds: string[] }]
   ready: []
 }>()
@@ -228,7 +229,6 @@ const bindProxyLeadItems = computed(() => [
 ])
 const store = useProtectionDemoStore()
 const STEP2_SOURCES_STORAGE_KEY = 'protection-create-wizard-step2-sources'
-const { setPipelineStep } = useBackupSourcePipeline()
 
 function nasRepairMountOptionsHref(repositoryId: number) {
   return router.resolve(buildNasRepairMountOptionsPath(repositoryId)).href
@@ -571,10 +571,10 @@ function sourceHasBackupConfig(sourceId: string) {
   return isRealSourceId(sourceId)
 }
 
-const lastCreatedSourceIds = ref<string[]>([])
+const lastCreatedConfigs = ref<BackupConfigDetail[]>([])
 
-function finishCreateAndGoToStep3(sourceIds?: string[]) {
-  const focusIds = (sourceIds ?? lastCreatedSourceIds.value).filter((id) => sourceHasBackupConfig(id))
+function finishCreateAndGoToStep3(items: Array<{ sourceId: string; config: BackupConfigDetail }>) {
+  const focusIds = items.map((item) => item.sourceId).filter((id) => sourceHasBackupConfig(id))
   if (focusIds.length > 0) {
     const idSet = new Set(focusIds)
     step1Selection.value = step1Selection.value.filter((id) => !idSet.has(id))
@@ -582,7 +582,7 @@ function finishCreateAndGoToStep3(sourceIds?: string[]) {
   }
   createOpen.value = false
   if (props.embedded) {
-    emit('completed', focusIds)
+    emit('createCompleted', { items })
     return
   }
   if (typeof sessionStorage !== 'undefined') {
@@ -592,7 +592,10 @@ function finishCreateAndGoToStep3(sourceIds?: string[]) {
 }
 
 function goToStartBackupFromCreate() {
-  finishCreateAndGoToStep3()
+  finishCreateAndGoToStep3(lastCreatedConfigs.value.map((config) => ({
+    sourceId: `${config.source_type}:${config.source_ref_id}`,
+    config,
+  })))
 }
 
 type BackupPathType = 'directory' | 'file' | 'unknown'
@@ -1201,6 +1204,9 @@ watch(addPolicyForm, () => {
   clearAddPolicyError('retention')
 }, { deep: true })
 const createPhase = ref<'form' | 'waiting' | 'done'>('form')
+const createSubmissionActive = computed(() => createPhase.value === 'waiting')
+type CreateItemState = 'pending' | 'creating' | 'success' | 'failed' | 'unknown' | 'not_attempted'
+const createItemStates = ref<Record<string, CreateItemState>>({})
 const createBootstrapping = ref(true)
 const editorWaitingText = computed(() => {
   if (createBootstrapping.value) {
@@ -3214,7 +3220,16 @@ async function openEditConfigs(configIds: number[], section: BackupConfigEditSec
   }
 }
 
+function preventUnloadDuringCreate(event: BeforeUnloadEvent) {
+  if (!createSubmissionActive.value) return
+  event.preventDefault()
+  event.returnValue = ''
+}
+
+onBeforeRouteLeave(() => !createSubmissionActive.value)
+
 onMounted(async () => {
+  if (typeof window !== 'undefined') window.addEventListener('beforeunload', preventUnloadDuringCreate)
   try {
     const catalog = await fetchStorageProviderCatalog()
     addTargetS3CatalogProviders.value = catalog.providers.filter((provider) => provider.enabled)
@@ -3288,6 +3303,7 @@ onMounted(async () => {
 
 onUnmounted(() => {
   cancelTargetValidation()
+  if (typeof window !== 'undefined') window.removeEventListener('beforeunload', preventUnloadDuringCreate)
   if (typeof document !== 'undefined') document.body.style.overflow = ''
 })
 
@@ -4384,6 +4400,7 @@ watch(
 )
 
 function closeCreate() {
+  if (createSubmissionActive.value) return
   cancelTargetValidation()
   if (props.embedded) {
     createOpen.value = false
@@ -5522,15 +5539,23 @@ async function runCreateBackup() {
   }
   const payload = buildCreateBackupPayload()
   const groupMap = new Map(wizardSourceGroups.value.map((group) => [group.key, group]))
+  const payloadSourceIds = payload.backups.map((backup) => backup.source.id)
+  if (payloadSourceIds.some((sourceId) => createItemStates.value[sourceId] === 'unknown')) {
+    ElMessage.warning({ message: t('protection.backupsPage.createFailed'), grouping: true })
+    return
+  }
+  createItemStates.value = Object.fromEntries(payloadSourceIds.map((sourceId) => [sourceId, 'pending']))
 
   createPhase.value = 'waiting'
-  let allSuccess = true
   let hasProvisioning = false
-  const configuredSourceIds: string[] = []
+  const createdItems: Array<{ sourceId: string; config: BackupConfigDetail }> = []
+  let failedCount = 0
+  let stoppedAfterUnknownResult = false
 
   for (const backup of payload.backups) {
     const group = groupMap.get(backup.key)
     if (!group) continue
+    createItemStates.value[backup.source.id] = 'creating'
 
     const sourceRefId = parseSourceRefId(backup.source.id)
     const repositoryId = parseInt(backup.targetId, 10) || 0
@@ -5591,30 +5616,49 @@ async function runCreateBackup() {
     try {
       const created = await createBackupConfig(apiPayload)
       hasProvisioning = hasProvisioning || created.status === 'provisioning'
-      configuredSourceIds.push(backup.source.id)
+      createdItems.push({ sourceId: backup.source.id, config: created })
+      createItemStates.value[backup.source.id] = 'success'
     } catch (e) {
-      allSuccess = false
+      failedCount += 1
       logger.error('BackupCreateWizard.vue', 4285, 'Failed to create backup config', e)
       showBackupConfigCreateError(e, backup.name, repositoryId)
-      break
+      const normalizedError = normalizeThrownError(e)
+      const errorCode = normalizedError.errorCode
+      if (errorCode === 'NETWORK.UNAVAILABLE' || errorCode === 'NETWORK.TIMEOUT') {
+        createItemStates.value[backup.source.id] = 'unknown'
+        stoppedAfterUnknownResult = true
+        break
+      }
+      createItemStates.value[backup.source.id] = 'failed'
+      if (normalizedError.status === 401 || normalizedError.status === 403) break
     }
   }
+  for (const sourceId of payloadSourceIds) {
+    if (createItemStates.value[sourceId] === 'pending') createItemStates.value[sourceId] = 'not_attempted'
+  }
 
+  const configuredSourceIds = createdItems.map((item) => item.sourceId)
+  if (configuredSourceIds.length > 0) {
+    const configured = new Set(configuredSourceIds)
+    step1Selection.value = step1Selection.value.filter((id) => !configured.has(id))
+    step2Sources.value = step2Sources.value.filter((id) => !configured.has(id))
+    lastCreatedConfigs.value = createdItems.map((item) => item.config)
+  }
+
+  const allSuccess = failedCount === 0 && !stoppedAfterUnknownResult && createdItems.length === payload.backups.length
   if (allSuccess) {
-    if (configuredSourceIds.length > 0) {
-      await setPipelineStep(configuredSourceIds, 3)
-      step2Sources.value = step2Sources.value.filter((id) => !configuredSourceIds.includes(id))
-    }
     ElMessage.success({
       message: hasProvisioning
         ? t('protection.backupsPage.createProvisioning')
         : t('protection.backupsPage.createSuccess'),
       grouping: true,
     })
-    lastCreatedSourceIds.value = configuredSourceIds
     createPhase.value = 'done'
-    nextTick(() => finishCreateAndGoToStep3(configuredSourceIds))
+    nextTick(() => finishCreateAndGoToStep3(createdItems))
   } else {
+    if (createdItems.length > 0 && props.embedded) {
+      emit('createPartial', { items: createdItems })
+    }
     createPhase.value = 'form'
   }
 }
@@ -5755,7 +5799,7 @@ async function runEditBackupConfig() {
     }
     ElMessage.success({ message: t('protection.backupsPage.msgSaveEditDemo'), grouping: true })
     if (props.embedded) {
-      emit('completed', editedSourceIds)
+      emit('editCompleted', { sourceIds: editedSourceIds })
       return
     }
     closeCreate()
@@ -5785,6 +5829,7 @@ watch(createOpen, (v) => {
     createCompletedSteps.value = new Set()
     editConfigs.value = []
     editSection.value = null
+    createItemStates.value = {}
     closeValidationPopover()
   }
 })
@@ -5885,6 +5930,7 @@ function preserveShallowestPathOrder(paths: string[]) {
       :waiting-text="editorWaitingText"
       :bootstrapping="createBootstrapping"
       :busy="targetValidationInProgress"
+      :can-close="!createSubmissionActive"
       :animated="!embedded"
       :result-title="t('protection.backupsPage.resultCreateTitle')"
       :result-subtitle="t('protection.backupsPage.resultCreateSub')"

--- a/src/frontend/src/pages/protection/DataProtection.vue
+++ b/src/frontend/src/pages/protection/DataProtection.vue
@@ -475,7 +475,10 @@ function parseEndpointUiId(id: string): { type: 'agent' | 'nas' | 'proxy'; refId
   return { type, refId }
 }
 
-async function refreshBackupConfigs(signal?: AbortSignal): Promise<boolean> {
+async function refreshBackupConfigs(
+  signal?: AbortSignal,
+  options: { preserveOnError?: boolean } = {},
+): Promise<boolean> {
   try {
     const result = await listBackupConfigs({ page: 1, page_size: 200 }, { signal })
     backupConfigRows.value = result.results
@@ -547,15 +550,17 @@ async function refreshBackupConfigs(signal?: AbortSignal): Promise<boolean> {
         : apiErrorMessage(e, t('protection.backupsPage.backupConfigLoadFailed')),
       grouping: true,
     })
-    backupConfigRows.value = []
-    backupConfigSourceIds.value = new Set()
-    backupConfigDetailById.value = new Map()
-    backupSnapshotRows.value = []
-    backupTaskRows.value = []
-    resetTaskRows.value = []
-    provisionTaskRows.value = []
-    restoreTaskRows.value = []
-    restoreRecordRows.value = []
+    if (!options.preserveOnError) {
+      backupConfigRows.value = []
+      backupConfigSourceIds.value = new Set()
+      backupConfigDetailById.value = new Map()
+      backupSnapshotRows.value = []
+      backupTaskRows.value = []
+      resetTaskRows.value = []
+      provisionTaskRows.value = []
+      restoreTaskRows.value = []
+      restoreRecordRows.value = []
+    }
     return false
   }
 }
@@ -1484,7 +1489,7 @@ async function loadStep2Selectable(options: { signal?: AbortSignal } = {}) {
   rememberSelectableRows(rows)
 }
 
-async function loadStep3Selectable(options: { signal?: AbortSignal } = {}) {
+async function loadStep3Selectable(options: { signal?: AbortSignal; syncExpanded?: boolean } = {}) {
   const signal = options.signal
   const list = await listBackupSelectableSources({
     page: flowStep2Pager.page,
@@ -1510,8 +1515,10 @@ async function loadStep3Selectable(options: { signal?: AbortSignal } = {}) {
   step3SelectableCount.value = list.count
   rememberSelectableRows(rows)
   reconcileBackupStartAwaitingRuntime(rows.map((row) => row.id))
-  const configs = syncExpandedStep3Rows(rows)
-  await ensureRepositoryDetailsForConfigs(configs, signal)
+  if (options.syncExpanded !== false) {
+    const configs = syncExpandedStep3Rows(rows)
+    await ensureRepositoryDetailsForConfigs(configs, signal)
+  }
 }
 
 async function refreshStep3State(signal?: AbortSignal) {
@@ -1984,7 +1991,6 @@ function enterStartBackupStep(opts?: { requireReady?: boolean; focusIds?: string
   }
 }
 
-const lastCreatedSourceIds = ref<string[]>([])
 const setupDrCreateOpen = ref(false)
 const setupDrOpening = ref(false)
 const setupDrCreateSources = ref<string[]>([])
@@ -2000,12 +2006,15 @@ function closeCreate() {
   setupDrEditSection.value = undefined
 }
 
-async function loadStep3SelectableWithPageClamp(signal?: AbortSignal) {
-  await loadStep3Selectable({ signal })
+async function loadStep3SelectableWithPageClamp(
+  signal?: AbortSignal,
+  options: { syncExpanded?: boolean } = {},
+) {
+  await loadStep3Selectable({ signal, syncExpanded: options.syncExpanded })
   const maxPage = Math.max(1, Math.ceil(step3SelectableCount.value / flowStep2Pager.pageSize) || 1)
   if (flowStep2Pager.page <= maxPage) return
   flowStep2Pager.page = maxPage
-  await loadStep3Selectable({ signal })
+  await loadStep3Selectable({ signal, syncExpanded: options.syncExpanded })
 }
 
 function latestStep3SourceRow(sourceId: string) {
@@ -2018,6 +2027,9 @@ async function refreshStep3AfterMoreAction(options: {
   focusIds?: string[]
   preserveSelection?: boolean
   closeMissingDetail?: boolean
+  showLoading?: boolean
+  preserveConfigOnError?: boolean
+  preserveExpandedState?: boolean
 } = {}) {
   const scope = flowStepScope(2)
   const signal = pageRequests.nextSignal(scope)
@@ -2026,15 +2038,17 @@ async function refreshStep3AfterMoreAction(options: {
   const selectedSourceIds = options.preserveSelection === false
     ? []
     : step3SourceSelection.value.map((row) => row.id)
-  const showLoading = flowMainStep.value === 2
+  const showLoading = options.showLoading ?? flowMainStep.value === 2
   step3ActionRefreshInFlight = true
   if (showLoading) setFlowStepDataLoading(2, true)
   try {
     await refreshPipelineStep2PlusIds(signal)
     if (!pageRequests.isCurrentSignal(scope, signal)) return []
-    await loadStep3SelectableWithPageClamp(signal)
+    await loadStep3SelectableWithPageClamp(signal, {
+      syncExpanded: options.preserveExpandedState !== true,
+    })
     if (!pageRequests.isCurrentSignal(scope, signal)) return []
-    await refreshBackupConfigs(signal)
+    await refreshBackupConfigs(signal, { preserveOnError: options.preserveConfigOnError })
     if (!pageRequests.isCurrentSignal(scope, signal)) return []
 
     if (activeSourceId) {
@@ -2069,21 +2083,64 @@ async function refreshStep3AfterMoreAction(options: {
   }
 }
 
-async function finishCreateAndGoToStep3(sourceIds?: string[]) {
-  const requestedFocusIds = sourceIds ?? lastCreatedSourceIds.value
-  closeCreate()
-  const focusIds = await refreshStep3AfterMoreAction({ focusIds: requestedFocusIds })
-  if (focusIds.length > 0) {
-    const idSet = new Set(focusIds)
-    step1Selection.value = step1Selection.value.filter((id) => !idSet.has(id))
+type BackupCreateResultPayload = {
+  items: Array<{ sourceId: string; config: BackupConfigDetail }>
+}
+
+function mergeCreatedBackupConfigs({ items }: BackupCreateResultPayload) {
+  if (!items.length) return []
+  const sourceIds = normalizeSourceIdList(items.map((item) => item.sourceId))
+  const configsById = new Map(backupConfigRows.value.map((config) => [config.id, config]))
+  const detailsById = new Map(backupConfigDetailById.value)
+  for (const { config } of items) {
+    configsById.set(config.id, config)
+    detailsById.set(config.id, config)
   }
-  nextTick(() => {
-    if (focusIds.length > 0) {
-      enterStartBackupStep({ focusIds, refresh: false })
-      return
-    }
-    enterStartBackupStep({ refresh: false })
+  backupConfigRows.value = Array.from(configsById.values())
+  backupConfigDetailById.value = detailsById
+  backupConfigSourceIds.value = new Set([
+    ...backupConfigSourceIds.value,
+    ...sourceIds,
+  ])
+  pipelineStep2Ids.value = pipelineStep2Ids.value.filter((id) => !sourceIds.includes(id))
+  pipelineStep3Ids.value = normalizeSourceIdList([...pipelineStep3Ids.value, ...sourceIds])
+  pipelineStep2Count.value = pipelineStep2Ids.value.length
+  pipelineStep3Count.value = pipelineStep3Ids.value.length
+  syncRealBackupConfigsToDemoStore(items.map((item) => item.config), backupSnapshotRows.value)
+  return sourceIds
+}
+
+let skipNextFlowStepRefresh = false
+
+function reconcileCreatedBackupConfigs(sourceIds: string[]) {
+  void refreshStep3AfterMoreAction({
+    focusIds: sourceIds,
+    showLoading: false,
+    preserveConfigOnError: true,
+    preserveExpandedState: true,
+  }).catch((err) => {
+    if (!pageRequests.isAbortError(err)) showApiError(err)
   })
+}
+
+function finishCreateAndGoToStep3(payload: BackupCreateResultPayload) {
+  const sourceIds = mergeCreatedBackupConfigs(payload)
+  closeCreate()
+  const idSet = new Set(sourceIds)
+  step1Selection.value = step1Selection.value.filter((id) => !idSet.has(id))
+  skipNextFlowStepRefresh = flowMainStep.value !== 2
+  enterStartBackupStep({ focusIds: sourceIds, refresh: false })
+  reconcileCreatedBackupConfigs(sourceIds)
+}
+
+function onCreateBackupPartial(payload: BackupCreateResultPayload) {
+  mergeCreatedBackupConfigs(payload)
+  void refreshPipelineStep2PlusIds().catch(showApiError)
+}
+
+function onEditBackupCompleted(payload: { sourceIds: string[] }) {
+  closeCreate()
+  reconcileCreatedBackupConfigs(payload.sourceIds)
 }
 
 
@@ -2551,7 +2608,11 @@ watch(flowMainStep, (step) => {
   nextTick(() => {
     updateFlowTableMaxHeight()
     if (!flowBootstrapping.value) {
-      void refreshFlowStepData(step)
+      if (skipNextFlowStepRefresh) {
+        skipNextFlowStepRefresh = false
+      } else {
+        void refreshFlowStepData(step)
+      }
     }
     if (step === 0) syncSourceTableSelection()
     if (step === 1) syncStep2TableSelection()
@@ -2932,6 +2993,10 @@ function sourceProvisionState(sourceId: string): 'provisioning' | 'provision_fai
   if (configs.some((config) => config.status === 'provision_failed')) return 'provision_failed'
   if (configs.some((config) => config.status === 'provisioning')) return 'provisioning'
   return ''
+}
+
+function sourceHasRunnableBackupConfig(sourceId: string) {
+  return sourceBackupConfigs(sourceId).some((config) => String(config.status || '').toLowerCase() === 'active')
 }
 
 function sourceProvisionStatusLabel(sourceId: string) {
@@ -4060,6 +4125,7 @@ let step3ActionRefreshInFlight = false
 let step3ActionRefreshSeq = 0
 
 function hasRunningStep3Tasks() {
+  if (pendingResetPipelineSourceIds.value.length > 0) return true
   return step3SourceList.value.some((row) =>
     sourceBackupRuntime(row.id).running
     || sourceProvisionState(row.id) === 'provisioning'
@@ -4441,6 +4507,10 @@ const step3SourceActionsEnabled = computed(() => {
   if (step3SelectionHasActiveBackup.value) return false
   return step3SourceSelection.value.some((row) => flowSourceCanOperate(row))
 })
+const step3StartBackupEnabled = computed(() =>
+  step3SourceActionsEnabled.value
+  && step3SourceSelection.value.every((row) => sourceHasRunnableBackupConfig(row.id)),
+)
 const step3LifecycleActionsEnabled = computed(() => {
   if (!step3SourceSelection.value.length) return false
   if (step3SourceSelection.value.some((row) => sourceResetRunning(row.id))) return false
@@ -4668,8 +4738,8 @@ async function startSelectedBackupTasks() {
       ElMessage.info({ message: t('protection.backupsPage.msgBackupActiveBlocksActions'), grouping: true })
       return
     }
-    const runnableSources = sources.filter((source) => sourceHasBackupConfig(source.id))
-    if (!runnableSources.length) {
+    const runnableSources = sources.filter((source) => sourceHasRunnableBackupConfig(source.id))
+    if (runnableSources.length !== sources.length) {
       ElMessage.warning({ message: t('protection.backupsPage.msgSourceNoBackupConfig'), grouping: true })
       return
     }
@@ -9518,7 +9588,7 @@ async function runRecovery(mode: 'plan' | 'manual' = 'manual') {
                         type="primary"
                         plain
                         class="hfl-btn-with-icon dp-flow-step3-action-btn shrink-0"
-                        :disabled="!step3SourceActionsEnabled || startBackupSubmitting || step3StopActionBusy"
+                        :disabled="!step3StartBackupEnabled || startBackupSubmitting || step3StopActionBusy"
                         :loading="startBackupSubmitting"
                         @click="startSelectedBackupTasks"
                       >
@@ -13845,7 +13915,9 @@ async function runRecovery(mode: 'plan' | 'manual' = 'manual') {
       :initial-edit-section="setupDrEditSection"
       @ready="setupDrOpening = false"
       @closed="closeCreate"
-      @completed="finishCreateAndGoToStep3"
+      @create-completed="finishCreateAndGoToStep3"
+      @create-partial="onCreateBackupPartial"
+      @edit-completed="onEditBackupCompleted"
       @conflict="onBackupSourceConflict"
     />
     <Teleport to="body">

--- a/src/frontend/src/pages/protection/DataProtectionResetBackupConfigList.test.ts
+++ b/src/frontend/src/pages/protection/DataProtectionResetBackupConfigList.test.ts
@@ -56,9 +56,17 @@ describe('backup wizard reset → Backup Configuration list (#362)', () => {
     expect(refreshStep3).not.toContain('step3Ids')
   })
 
+  it('keeps Step 3 auto-refresh active while reset pipeline sources are tracked', () => {
+    const refresh = sourceBetween(
+      'function hasRunningStep3Tasks()',
+      'function stopStep3AutoRefresh',
+    )
+    expect(refresh).toContain('if (pendingResetPipelineSourceIds.value.length > 0) return true')
+  })
+
   it('returns false from refreshBackupConfigs soft-failure so reset completion is not inferred', () => {
     const refreshConfigs = sourceBetween(
-      'async function refreshBackupConfigs(signal?: AbortSignal): Promise<boolean> {',
+      'async function refreshBackupConfigs(',
       'function displayNameForSource(type: string, refId: number, fallback: string)',
     )
     expect(refreshConfigs).toContain('return true')

--- a/src/frontend/src/pages/protection/DataProtectionStep3MoreActions.test.ts
+++ b/src/frontend/src/pages/protection/DataProtectionStep3MoreActions.test.ts
@@ -202,21 +202,22 @@ describe('backup wizard step 3 More Actions refresh', () => {
     expect(toolbarRefresh).not.toContain('loadStep3Selectable({ signal: signal ?? undefined })')
   })
 
-  it('reloads the full step 3 list state after backup configuration edits complete', () => {
+  it('separates create and edit completion while reconciling Step 3 in the background', () => {
     const editStart = wizard.indexOf('async function runEditBackupConfig')
     const editEnd = wizard.indexOf('function submitCreateWizard', editStart)
     const editHandler = wizard.slice(editStart, editEnd)
     const handler = sourceBetween(
-      'async function finishCreateAndGoToStep3',
-      'const addSourceOpen',
+      'function finishCreateAndGoToStep3',
+      'function onCreateBackupPartial',
     )
 
     expect(editStart).toBeGreaterThan(-1)
     expect(editEnd).toBeGreaterThan(editStart)
-    expect(editHandler).toContain('emit(\'completed\', editedSourceIds)')
+    expect(editHandler).toContain("emit('editCompleted', { sourceIds: editedSourceIds })")
     expect(editHandler).toContain('`${config.source_type}:${config.source_ref_id}`')
-    expect(page).toContain('@completed="finishCreateAndGoToStep3"')
-    expect(handler).toContain('await refreshStep3AfterMoreAction({ focusIds: requestedFocusIds })')
+    expect(page).toContain('@create-completed="finishCreateAndGoToStep3"')
+    expect(page).toContain('@edit-completed="onEditBackupCompleted"')
+    expect(handler.indexOf('enterStartBackupStep')).toBeLessThan(handler.indexOf('reconcileCreatedBackupConfigs'))
   })
 
   it('reloads the full step 3 list state after stopping backup or restore tasks', () => {
@@ -261,8 +262,8 @@ describe('backup wizard step 3 More Actions refresh', () => {
     expect(refresh).toContain('pageRequests.nextSignal(scope)')
     expect(refresh).toContain('refreshPipelineStep2PlusIds(signal)')
     expect(refresh).not.toContain('refreshPipelineStep3Ids(signal)')
-    expect(refresh).toContain('await loadStep3SelectableWithPageClamp(signal)')
-    expect(refresh).toContain('await refreshBackupConfigs(signal)')
+    expect(refresh).toContain('await loadStep3SelectableWithPageClamp(signal, {')
+    expect(refresh).toContain('await refreshBackupConfigs(signal, { preserveOnError: options.preserveConfigOnError })')
     expect(refresh).toContain('pageRequests.isCurrentSignal(scope, signal)')
     expect(refresh).toContain('syncStep3TableSelection()')
   })


### PR DESCRIPTION
## Summary

- Enter Start Backup immediately from authoritative backup configuration responses
- Reconcile Step 3 state in one non-blocking refresh path without clearing successful data on refresh failure
- Preserve multi-source partial outcomes and block unresolved or provisioning configurations from starting backups
- Keep reset pipeline polling active until Step 2 and Step 3 counts converge
- Add regression coverage for fast transitions, refresh failures, and reset count updates

Closes #734

## Testing

- `npx vitest run src/pages/protection/BackupConfigurationFastTransition.test.ts src/pages/protection/DataProtectionResetBackupConfigList.test.ts src/pages/protection/DataProtectionStep3MoreActions.test.ts src/pages/protection/DataProtectionFlowNavigation.test.ts src/pages/protection/DataProtectionStep2Counts.test.ts`
- `npx vue-tsc --noEmit`
- `npm run lint`
- `npm run build`