### PR TITLE
Make backup configuration creation idempotent

### DIFF
--- a/src/backend/apps/protection/api/views/backup_config.py
+++ b/src/backend/apps/protection/api/views/backup_config.py
@@ -27,6 +27,10 @@ from apps.protection import services as protection_services
 from apps.protection.services.directory_size_estimate import (
     backup_config_needs_directory_estimate_refresh,
 )
+from apps.protection.services.backup_config_idempotency import (
+    BackupConfigCreateIdempotencyConflict,
+    execute_idempotent_backup_config_create,
+)
 from apps.protection.tasks.directory_size_estimate import (
     refresh_backup_config_directory_estimates_task,
 )
@@ -55,6 +59,17 @@ def _update_touches_directory_estimate_inputs(data: dict) -> bool:
         field in data
         for field in ("directories", "source_type", "source_ref_id")
     )
+
+
+def _idempotency_key(request) -> str:
+    raw = str(request.headers.get("Idempotency-Key") or "")
+    if not raw:
+        return ""
+    if raw != raw.strip() or len(raw) > 128 or any(ord(char) < 33 or ord(char) > 126 for char in raw):
+        raise ValidationError(
+            {"idempotency_key": "Must be at most 128 visible ASCII characters without surrounding whitespace."}
+        )
+    return raw
 
 
 class BackupConfigViewSet(viewsets.ModelViewSet):
@@ -100,28 +115,52 @@ class BackupConfigViewSet(viewsets.ModelViewSet):
         org = require_org(request)
         serializer = BackupConfigWriteSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
-        try:
-            config = protection_services.backup_config.create_backup_config(
-                organization_id=org.id,
-                data=serializer.validated_data,
-            )
-        except DjangoValidationError as exc:
-            raise _validation_error(exc) from exc
-        if config.status == BackupConfig.Status.ACTIVE:
-            transaction.on_commit(
-                lambda config_id=config.id: sync_backup_config_repository_policy_task.delay(
-                    config_id=config_id
+        idempotency_key = _idempotency_key(request)
+
+        def create_result() -> tuple[BackupConfig, dict, int]:
+            try:
+                config = protection_services.backup_config.create_backup_config(
+                    organization_id=org.id,
+                    data=serializer.validated_data,
                 )
-            )
-            _queue_directory_estimate_precache(config)
-        return Response(
-            BackupConfigDetailSerializer(config).data,
-            status=(
+            except DjangoValidationError as exc:
+                raise _validation_error(exc) from exc
+            if config.status == BackupConfig.Status.ACTIVE:
+                transaction.on_commit(
+                    lambda config_id=config.id: sync_backup_config_repository_policy_task.delay(
+                        config_id=config_id
+                    )
+                )
+                _queue_directory_estimate_precache(config)
+            response_status = (
                 status.HTTP_202_ACCEPTED
                 if config.status == BackupConfig.Status.PROVISIONING
                 else status.HTTP_201_CREATED
-            ),
-        )
+            )
+            return config, dict(BackupConfigDetailSerializer(config).data), response_status
+
+        if not idempotency_key:
+            _config, payload, response_status = create_result()
+            return Response(payload, status=response_status)
+
+        try:
+            result = execute_idempotent_backup_config_create(
+                organization_id=org.id,
+                idempotency_key=idempotency_key,
+                data=dict(serializer.validated_data),
+                create=create_result,
+            )
+        except BackupConfigCreateIdempotencyConflict as exc:
+            return Response(
+                {
+                    "detail": str(exc),
+                    "error_code": "BACKUP_CONFIG.IDEMPOTENCY_CONFLICT",
+                },
+                status=status.HTTP_409_CONFLICT,
+            )
+        response = Response(result.payload, status=result.status_code)
+        response["Idempotency-Replayed"] = "true" if result.replayed else "false"
+        return response
 
     def retrieve(self, request, *args, **kwargs):
         config = self.get_object()

--- a/src/backend/apps/protection/migrations/0023_backup_config_create_request.py
+++ b/src/backend/apps/protection/migrations/0023_backup_config_create_request.py
@@ -1,0 +1,49 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("protection", "0022_snapshot_storage_efficiency"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="BackupConfigCreateRequest",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("organization_id", models.BigIntegerField(db_index=True)),
+                ("idempotency_key", models.CharField(max_length=128)),
+                ("request_digest", models.CharField(max_length=64)),
+                ("response_status", models.PositiveSmallIntegerField(blank=True, null=True)),
+                ("response_payload", models.JSONField(default=dict)),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                (
+                    "backup_config",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="create_requests",
+                        to="protection.backupconfig",
+                    ),
+                ),
+            ],
+            options={
+                "db_table": "protection_backup_config_create_request",
+                "indexes": [
+                    models.Index(
+                        fields=["organization_id", "created_at"],
+                        name="prot_bcfg_create_org_cr_idx",
+                    ),
+                ],
+                "constraints": [
+                    models.UniqueConstraint(
+                        fields=("organization_id", "idempotency_key"),
+                        name="uniq_prot_bcfg_create_org_key",
+                    ),
+                ],
+            },
+        ),
+    ]

--- a/src/backend/apps/protection/models/__init__.py
+++ b/src/backend/apps/protection/models/__init__.py
@@ -2,6 +2,7 @@ from apps.protection.models.backup_config import (
     BackupConfig,
     BackupConfigDirectory,
 )
+from apps.protection.models.backup_config_create_request import BackupConfigCreateRequest
 from apps.protection.models.backup_source_snapshot import (
     BackupSourceSnapshot,
     BackupSourceSnapshotDirectory,
@@ -13,6 +14,7 @@ from apps.protection.models.snapshot_download import SnapshotDownloadArtifact
 __all__ = [
     "BackupConfig",
     "BackupConfigDirectory",
+    "BackupConfigCreateRequest",
     "BackupSourceSnapshot",
     "BackupSourceSnapshotDirectory",
     "BackupPolicy",

--- a/src/backend/apps/protection/models/backup_config_create_request.py
+++ b/src/backend/apps/protection/models/backup_config_create_request.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from django.db import models
+
+
+class BackupConfigCreateRequest(models.Model):
+    """Durable result of one organization-scoped idempotent create request."""
+
+    organization_id = models.BigIntegerField(db_index=True)
+    idempotency_key = models.CharField(max_length=128)
+    request_digest = models.CharField(max_length=64)
+    backup_config = models.ForeignKey(
+        "protection.BackupConfig",
+        blank=True,
+        null=True,
+        on_delete=models.SET_NULL,
+        related_name="create_requests",
+    )
+    response_status = models.PositiveSmallIntegerField(blank=True, null=True)
+    response_payload = models.JSONField(default=dict)
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        db_table = "protection_backup_config_create_request"
+        constraints = [
+            models.UniqueConstraint(
+                fields=["organization_id", "idempotency_key"],
+                name="uniq_prot_bcfg_create_org_key",
+            ),
+        ]
+        indexes = [
+            models.Index(
+                fields=["organization_id", "created_at"],
+                name="prot_bcfg_create_org_cr_idx",
+            ),
+        ]

--- a/src/backend/apps/protection/services/backup_config_idempotency.py
+++ b/src/backend/apps/protection/services/backup_config_idempotency.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Callable
+
+from django.core.serializers.json import DjangoJSONEncoder
+from django.db import IntegrityError, transaction
+
+from apps.protection.models import BackupConfig, BackupConfigCreateRequest
+
+
+class BackupConfigCreateIdempotencyConflict(Exception):
+    pass
+
+
+@dataclass(frozen=True)
+class BackupConfigCreateResult:
+    payload: dict
+    status_code: int
+    replayed: bool
+    backup_config: BackupConfig | None
+
+
+def backup_config_create_request_digest(data: dict) -> str:
+    canonical = json.dumps(
+        data,
+        cls=DjangoJSONEncoder,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _create_or_lock_request(
+    *,
+    organization_id: int,
+    idempotency_key: str,
+    request_digest: str,
+) -> tuple[BackupConfigCreateRequest, bool]:
+    try:
+        with transaction.atomic():
+            return (
+                BackupConfigCreateRequest.objects.create(
+                    organization_id=organization_id,
+                    idempotency_key=idempotency_key,
+                    request_digest=request_digest,
+                ),
+                True,
+            )
+    except IntegrityError:
+        return (
+            BackupConfigCreateRequest.objects.select_for_update().get(
+                organization_id=organization_id,
+                idempotency_key=idempotency_key,
+            ),
+            False,
+        )
+
+
+def execute_idempotent_backup_config_create(
+    *,
+    organization_id: int,
+    idempotency_key: str,
+    data: dict,
+    create: Callable[[], tuple[BackupConfig, dict, int]],
+) -> BackupConfigCreateResult:
+    request_digest = backup_config_create_request_digest(data)
+    with transaction.atomic():
+        request_record, created = _create_or_lock_request(
+            organization_id=organization_id,
+            idempotency_key=idempotency_key,
+            request_digest=request_digest,
+        )
+        if request_record.request_digest != request_digest:
+            raise BackupConfigCreateIdempotencyConflict(
+                "This idempotency key is already bound to a different backup configuration request."
+            )
+        if not created:
+            if request_record.response_status is None or not request_record.response_payload:
+                raise RuntimeError("idempotent backup configuration request has no durable result")
+            return BackupConfigCreateResult(
+                payload=dict(request_record.response_payload),
+                status_code=int(request_record.response_status),
+                replayed=True,
+                backup_config=request_record.backup_config,
+            )
+
+        config, payload, status_code = create()
+        request_record.backup_config = config
+        request_record.response_payload = payload
+        request_record.response_status = status_code
+        request_record.save(
+            update_fields=[
+                "backup_config",
+                "response_payload",
+                "response_status",
+                "updated_at",
+            ]
+        )
+        return BackupConfigCreateResult(
+            payload=payload,
+            status_code=status_code,
+            replayed=False,
+            backup_config=config,
+        )

--- a/src/backend/apps/protection/tests/test_backup_config_api.py
+++ b/src/backend/apps/protection/tests/test_backup_config_api.py
@@ -13,6 +13,7 @@ from apps.iam.models import Membership, Organization
 from apps.node.models import Node, NodeTask
 from apps.protection.models import (
     BackupConfig,
+    BackupConfigCreateRequest,
     BackupConfigDirectory,
     BackupPolicy,
     BackupSourceSnapshot,
@@ -385,6 +386,216 @@ class ProtectionBackupConfigApiTests(TestCase):
         )
         self.assertEqual(step2_after.status_code, status.HTTP_200_OK)
         self.assertNotIn(source_key, {row["id"] for row in step2_after.data["results"]})
+
+    def test_create_backup_config_idempotent_replay_returns_original_result(self):
+        headers = {**self._headers(), "HTTP_IDEMPOTENCY_KEY": "backup-config-agent-1"}
+
+        first = self.client.post(
+            "/api/v1/protection/backup-configs/",
+            self._payload(),
+            format="json",
+            **headers,
+        )
+        second = self.client.post(
+            "/api/v1/protection/backup-configs/",
+            self._payload(),
+            format="json",
+            **headers,
+        )
+
+        self.assertEqual(first.status_code, status.HTTP_201_CREATED, first.content)
+        self.assertEqual(second.status_code, status.HTTP_201_CREATED, second.content)
+        self.assertEqual(first.data, second.data)
+        self.assertEqual(first.headers["Idempotency-Replayed"], "false")
+        self.assertEqual(second.headers["Idempotency-Replayed"], "true")
+        self.assertEqual(BackupConfig.objects.count(), 1)
+        request_record = BackupConfigCreateRequest.objects.get(
+            organization_id=self.org.id,
+            idempotency_key="backup-config-agent-1",
+        )
+        self.assertEqual(request_record.backup_config_id, first.data["id"])
+        self.assertEqual(request_record.response_status, status.HTTP_201_CREATED)
+
+    def test_create_backup_config_rejects_idempotency_key_payload_conflict(self):
+        headers = {**self._headers(), "HTTP_IDEMPOTENCY_KEY": "backup-config-conflict"}
+        first = self.client.post(
+            "/api/v1/protection/backup-configs/",
+            self._payload(),
+            format="json",
+            **headers,
+        )
+        conflicting_payload = self._payload(name="Different config")
+
+        second = self.client.post(
+            "/api/v1/protection/backup-configs/",
+            conflicting_payload,
+            format="json",
+            **headers,
+        )
+
+        self.assertEqual(first.status_code, status.HTTP_201_CREATED, first.content)
+        self.assertEqual(second.status_code, status.HTTP_409_CONFLICT, second.content)
+        self.assertEqual(
+            second.data["error_code"],
+            "BACKUP_CONFIG.IDEMPOTENCY_CONFLICT",
+        )
+        self.assertEqual(BackupConfig.objects.count(), 1)
+
+    def test_failed_create_does_not_consume_idempotency_key(self):
+        headers = {**self._headers(), "HTTP_IDEMPOTENCY_KEY": "backup-config-retry"}
+        invalid_payload = self._payload()
+        invalid_payload["repository_id"] = 999999
+
+        failed = self.client.post(
+            "/api/v1/protection/backup-configs/",
+            invalid_payload,
+            format="json",
+            **headers,
+        )
+        succeeded = self.client.post(
+            "/api/v1/protection/backup-configs/",
+            self._payload(),
+            format="json",
+            **headers,
+        )
+
+        self.assertEqual(failed.status_code, status.HTTP_400_BAD_REQUEST, failed.content)
+        self.assertEqual(succeeded.status_code, status.HTTP_201_CREATED, succeeded.content)
+        self.assertEqual(
+            BackupConfigCreateRequest.objects.filter(
+                organization_id=self.org.id,
+                idempotency_key="backup-config-retry",
+            ).count(),
+            1,
+        )
+
+    def test_create_without_idempotency_key_preserves_legacy_behavior(self):
+        response = self.client.post(
+            "/api/v1/protection/backup-configs/",
+            self._payload(),
+            format="json",
+            **self._headers(),
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.content)
+        self.assertFalse(BackupConfigCreateRequest.objects.exists())
+
+    def test_direct_nas_idempotent_replay_does_not_duplicate_provision_task(self):
+        repository = self._direct_nas_repository(name="idempotent-direct-nas")
+        payload = self._payload(name="Idempotent Direct NAS")
+        payload["repository_id"] = repository.id
+        headers = {**self._headers(), "HTTP_IDEMPOTENCY_KEY": "backup-config-direct-nas"}
+
+        first = self.client.post(
+            "/api/v1/protection/backup-configs/",
+            payload,
+            format="json",
+            **headers,
+        )
+        BackupConfig.objects.filter(id=first.data["id"]).update(
+            status=BackupConfig.Status.ACTIVE
+        )
+        second = self.client.post(
+            "/api/v1/protection/backup-configs/",
+            payload,
+            format="json",
+            **headers,
+        )
+
+        self.assertEqual(first.status_code, status.HTTP_202_ACCEPTED, first.content)
+        self.assertEqual(second.status_code, status.HTTP_202_ACCEPTED, second.content)
+        self.assertEqual(first.data, second.data)
+        self.assertEqual(second.data["status"], BackupConfig.Status.PROVISIONING)
+        self.assertEqual(
+            BackupConfig.objects.get(id=first.data["id"]).status,
+            BackupConfig.Status.ACTIVE,
+        )
+        self.assertEqual(BackupConfig.objects.count(), 1)
+        self.assertEqual(
+            Task.objects.filter(task_type=Task.Type.BACKUP_CONFIG_PROVISION).count(),
+            1,
+        )
+
+    def test_backup_config_idempotency_key_is_isolated_by_organization(self):
+        other_org = Organization.objects.create(
+            key="backup-config-other-org",
+            name="Backup Config Other Org",
+        )
+        Membership.objects.create(
+            user=self.user,
+            organization=other_org,
+            role=Membership.Role.ADMIN,
+        )
+        other_agent = Node.objects.create(
+            organization=other_org,
+            name="other-agent",
+            role=Node.Role.AGENT,
+            status=Node.Status.ACTIVE,
+            availability=Node.Availability.ONLINE,
+            ip_address="10.0.0.99",
+            os_name="linux",
+            metadata={"inventory": {"capabilities": ["repository_ownership_v1"]}},
+        )
+        other_repository = Repository.objects.create(
+            organization_id=other_org.id,
+            name="other-repository",
+            repo_type=Repository.Type.S3,
+            status=Repository.Status.CREATED,
+            health=Repository.Health.ONLINE,
+            s3_platform=Repository.S3Platform.CUSTOM,
+            s3_bucket="other-backup-config-bucket",
+            config={
+                "endpoint": "s3.example.internal:9000",
+                "region": "cn-test-1",
+                "prefix": "kopia/other",
+                "access_key_id": "ak-test",
+                "secret_access_key": "sk-test",
+                "kopia_password": "123456",
+                "use_tls": False,
+            },
+        )
+        self._mark_repository_owned(other_repository)
+        key_header = {"HTTP_IDEMPOTENCY_KEY": "shared-across-organizations"}
+
+        first = self.client.post(
+            "/api/v1/protection/backup-configs/",
+            self._payload(),
+            format="json",
+            **self._headers(),
+            **key_header,
+        )
+        second = self.client.post(
+            "/api/v1/protection/backup-configs/",
+            {
+                **self._payload(source_ref_id=other_agent.id, name="Other org config"),
+                "repository_id": other_repository.id,
+            },
+            format="json",
+            HTTP_X_ORG_KEY=other_org.key,
+            **key_header,
+        )
+
+        self.assertEqual(first.status_code, status.HTTP_201_CREATED, first.content)
+        self.assertEqual(second.status_code, status.HTTP_201_CREATED, second.content)
+        self.assertEqual(
+            BackupConfigCreateRequest.objects.filter(
+                idempotency_key="shared-across-organizations"
+            ).count(),
+            2,
+        )
+
+    def test_create_backup_config_rejects_invalid_idempotency_key(self):
+        response = self.client.post(
+            "/api/v1/protection/backup-configs/",
+            self._payload(),
+            format="json",
+            **self._headers(),
+            HTTP_IDEMPOTENCY_KEY="x" * 129,
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertFalse(BackupConfig.objects.exists())
+        self.assertFalse(BackupConfigCreateRequest.objects.exists())
 
     def test_distinct_s3_endpoints_require_explicit_selection(self):
         repository = self._distinct_endpoint_repository()

--- a/src/backend/apps/protection/tests/test_backup_config_idempotency.py
+++ b/src/backend/apps/protection/tests/test_backup_config_idempotency.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import threading
+import time
+
+from django.db import close_old_connections
+from django.test import TransactionTestCase
+
+from apps.protection.models import BackupConfig, BackupConfigCreateRequest
+from apps.protection.services.backup_config_idempotency import (
+    execute_idempotent_backup_config_create,
+)
+
+
+class BackupConfigCreateIdempotencyConcurrencyTests(TransactionTestCase):
+    reset_sequences = True
+
+    def test_concurrent_same_key_executes_create_once(self):
+        config = BackupConfig.objects.create(
+            organization_id=901,
+            name="Concurrent idempotency config",
+            source_type="agent",
+            source_ref_id=902,
+            repository_id=903,
+            repository_endpoint_type=BackupConfig.RepositoryEndpointType.EXTERNAL,
+            compression_level=BackupConfig.CompressionLevel.BALANCED,
+            recovery_plan_enabled=False,
+        )
+        callback_entered = threading.Event()
+        release_callback = threading.Event()
+        callback_count = 0
+        callback_lock = threading.Lock()
+        results = []
+        errors = []
+
+        def create_result():
+            nonlocal callback_count
+            with callback_lock:
+                callback_count += 1
+            callback_entered.set()
+            release_callback.wait(timeout=5)
+            return config, {"id": config.id, "status": "active"}, 201
+
+        def execute():
+            close_old_connections()
+            try:
+                results.append(
+                    execute_idempotent_backup_config_create(
+                        organization_id=901,
+                        idempotency_key="concurrent-create",
+                        data={"source_type": "agent", "source_ref_id": 902},
+                        create=create_result,
+                    )
+                )
+            except Exception as exc:  # pragma: no cover - asserted below
+                errors.append(exc)
+            finally:
+                close_old_connections()
+
+        first = threading.Thread(target=execute)
+        second = threading.Thread(target=execute)
+        first.start()
+        self.assertTrue(callback_entered.wait(timeout=5))
+        second.start()
+        time.sleep(0.2)
+        self.assertEqual(callback_count, 1)
+        release_callback.set()
+        first.join(timeout=5)
+        second.join(timeout=5)
+
+        self.assertFalse(first.is_alive())
+        self.assertFalse(second.is_alive())
+        self.assertEqual(errors, [])
+        self.assertEqual(callback_count, 1)
+        self.assertEqual(len(results), 2)
+        self.assertEqual(sorted(result.replayed for result in results), [False, True])
+        self.assertEqual(
+            BackupConfigCreateRequest.objects.filter(
+                organization_id=901,
+                idempotency_key="concurrent-create",
+            ).count(),
+            1,
+        )

--- a/src/frontend/src/lib/protectionBackupConfigApi.test.ts
+++ b/src/frontend/src/lib/protectionBackupConfigApi.test.ts
@@ -1,10 +1,16 @@
 // @vitest-environment jsdom
 
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
+  createBackupConfig,
   InvalidCompressionLevelError,
   parseCompressionLevel,
 } from './protectionBackupConfigApi'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
 
 describe('parseCompressionLevel', () => {
   it.each(['none', 'balanced', 'high'] as const)('accepts %s', (value) => {
@@ -13,5 +19,44 @@ describe('parseCompressionLevel', () => {
 
   it.each(['', 'best', 'zstd', null, undefined])('rejects unexpected value %s', (value) => {
     expect(() => parseCompressionLevel(value)).toThrow(InvalidCompressionLevelError)
+  })
+})
+
+describe('createBackupConfig', () => {
+  it('sends the caller idempotency key', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      id: 32,
+      name: 'Config',
+      remark: '',
+      source_type: 'agent',
+      source_ref_id: 12,
+      repository_id: 7,
+      repository_endpoint_type: 'external',
+      backup_policy_id: null,
+      file_filter_rule_id: null,
+      directory_count: 1,
+      compression_level: 'balanced',
+      status: 'active',
+      recovery_plan_enabled: false,
+      directories: [],
+      recovery_plans: [],
+      created_at: '2026-08-24T00:00:00Z',
+      updated_at: '2026-08-24T00:00:00Z',
+    }), {
+      status: 201,
+      headers: { 'Content-Type': 'application/json' },
+    }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await createBackupConfig({
+      name: 'Config',
+      source_type: 'agent',
+      source_ref_id: 12,
+      repository_id: 7,
+      directories: [{ path: '/data' }],
+    }, 'backup-config:agent:12:test-key')
+
+    const headers = new Headers(fetchMock.mock.calls[0][1]?.headers)
+    expect(headers.get('Idempotency-Key')).toBe('backup-config:agent:12:test-key')
   })
 })

--- a/src/frontend/src/lib/protectionBackupConfigApi.ts
+++ b/src/frontend/src/lib/protectionBackupConfigApi.ts
@@ -346,7 +346,7 @@ export function parseSourceRefId(sourceId: string): number {
 }
 
 /** Create a backup config. */
-export async function createBackupConfig(payload: BackupConfigCreatePayload) {
+export async function createBackupConfig(payload: BackupConfigCreatePayload, idempotencyKey = '') {
   logger.info('protectionBackupConfigApi.ts', 269, 'backup config create', {
     source_type: payload.source_type,
     source_ref_id: payload.source_ref_id,
@@ -358,7 +358,10 @@ export async function createBackupConfig(payload: BackupConfigCreatePayload) {
     await api<unknown>(`${configBase}/`, {
       method: 'POST',
       body: JSON.stringify(payload),
-      headers: orgHeaders(),
+      headers: {
+        ...orgHeaders(),
+        ...(idempotencyKey ? { 'Idempotency-Key': idempotencyKey } : {}),
+      },
     }),
   ))
 }

--- a/src/frontend/src/pages/protection/BackupConfigurationFastTransition.test.ts
+++ b/src/frontend/src/pages/protection/BackupConfigurationFastTransition.test.ts
@@ -18,10 +18,11 @@ describe('backup configuration fast transition', () => {
   it('uses the authoritative create response without repeating the pipeline update', () => {
     const create = sourceBetween(wizard, 'async function runCreateBackup', 'function editableGroupPayloads')
 
-    expect(create).toContain('const created = await createBackupConfig(apiPayload)')
+    expect(create).toContain('const created = await createBackupConfig(apiPayload, createIdempotencyKey(backup.source.id))')
     expect(create).toContain('createdItems.push({ sourceId: backup.source.id, config: created })')
     expect(create).not.toContain('setPipelineStep(')
     expect(wizard).not.toContain('useBackupSourcePipeline')
+    expect(wizard).toContain('const existing = createIdempotencyKeys.value[sourceId]')
   })
 
   it('enters Step 3 before starting non-blocking reconciliation', () => {
@@ -51,6 +52,7 @@ describe('backup configuration fast transition', () => {
     expect(create).toContain("emit('createPartial', { items: createdItems })")
     expect(create).toContain("errorCode === 'NETWORK.UNAVAILABLE' || errorCode === 'NETWORK.TIMEOUT'")
     expect(create).toContain("createItemStates.value[backup.source.id] = 'unknown'")
+    expect(create).not.toContain("createItemStates.value[sourceId] === 'unknown'")
     expect(create).toContain('normalizedError.status === 401 || normalizedError.status === 403')
     expect(create).toContain("createItemStates.value[sourceId] = 'not_attempted'")
     expect(wizard).toContain("emit('editCompleted', { sourceIds: editedSourceIds })")

--- a/src/frontend/src/pages/protection/BackupCreateWizard.vue
+++ b/src/frontend/src/pages/protection/BackupCreateWizard.vue
@@ -1207,6 +1207,18 @@ const createPhase = ref<'form' | 'waiting' | 'done'>('form')
 const createSubmissionActive = computed(() => createPhase.value === 'waiting')
 type CreateItemState = 'pending' | 'creating' | 'success' | 'failed' | 'unknown' | 'not_attempted'
 const createItemStates = ref<Record<string, CreateItemState>>({})
+const createIdempotencyKeys = ref<Record<string, string>>({})
+
+function createIdempotencyKey(sourceId: string) {
+  const existing = createIdempotencyKeys.value[sourceId]
+  if (existing) return existing
+  const nonce = typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+    ? crypto.randomUUID()
+    : `${Date.now()}-${Math.random().toString(36).slice(2)}`
+  const key = `backup-config:${nonce}`
+  createIdempotencyKeys.value[sourceId] = key
+  return key
+}
 const createBootstrapping = ref(true)
 const editorWaitingText = computed(() => {
   if (createBootstrapping.value) {
@@ -5540,10 +5552,6 @@ async function runCreateBackup() {
   const payload = buildCreateBackupPayload()
   const groupMap = new Map(wizardSourceGroups.value.map((group) => [group.key, group]))
   const payloadSourceIds = payload.backups.map((backup) => backup.source.id)
-  if (payloadSourceIds.some((sourceId) => createItemStates.value[sourceId] === 'unknown')) {
-    ElMessage.warning({ message: t('protection.backupsPage.createFailed'), grouping: true })
-    return
-  }
   createItemStates.value = Object.fromEntries(payloadSourceIds.map((sourceId) => [sourceId, 'pending']))
 
   createPhase.value = 'waiting'
@@ -5614,7 +5622,7 @@ async function runCreateBackup() {
     }
 
     try {
-      const created = await createBackupConfig(apiPayload)
+      const created = await createBackupConfig(apiPayload, createIdempotencyKey(backup.source.id))
       hasProvisioning = hasProvisioning || created.status === 'provisioning'
       createdItems.push({ sourceId: backup.source.id, config: created })
       createItemStates.value[backup.source.id] = 'success'
@@ -5830,6 +5838,7 @@ watch(createOpen, (v) => {
     editConfigs.value = []
     editSection.value = null
     createItemStates.value = {}
+    createIdempotencyKeys.value = {}
     closeValidationPopover()
   }
 })


### PR DESCRIPTION
## Summary

- persist organization-scoped idempotency keys, canonical request digests, and original backup configuration create responses
- replay completed Agent and Direct NAS creates without duplicate configurations or provisioning tasks, while rejecting key reuse with a different payload
- generate stable per-source keys in the backup wizard so unknown network outcomes can be retried safely
- preserve existing behavior for clients that omit `Idempotency-Key`

## Testing

- `docker compose exec -T -e SECURE_SSL_REDIRECT=false api python manage.py test --keepdb apps.protection.tests.test_backup_config_idempotency apps.protection.tests.test_backup_config_api.ProtectionBackupConfigApiTests` (80 passed)
- `docker compose exec -T api python manage.py check`
- `docker compose exec -T api python manage.py makemigrations --check --dry-run`
- `npm test -- --run src/lib/protectionBackupConfigApi.test.ts src/pages/protection/BackupConfigurationFastTransition.test.ts` (14 passed)
- `npm run lint`
- `npm run build`
- manually verified initial create, same-key replay, payload conflict, Direct NAS replay, and no-key compatibility

Closes #771