### PR TITLE
fix(source): sync task settings and Agent mount roots

### DIFF
--- a/src/backend/apps/source/models/source_resource.py
+++ b/src/backend/apps/source/models/source_resource.py
@@ -121,20 +121,29 @@ class SourceResource(OrganizationScopedModel):
     def requires_mount(self) -> bool:
         return self.resource_type in ResourceType.REQUIRES_MOUNT
 
+    def agent_data_dir(self) -> str | None:
+        """Return the bound proxy's advertised Agent data root, if known."""
+        node = self.bound_node
+        metadata = node.metadata if node and isinstance(node.metadata, dict) else {}
+        inventory = metadata.get("inventory") if isinstance(metadata, dict) else {}
+        root_path = inventory.get("root_path") if isinstance(inventory, dict) else ""
+        return str(root_path or "").strip() or None
+
     def effective_mount_point(self) -> str:
+        data_dir = self.agent_data_dir()
         config_path = str((self.config or {}).get("path") or "").strip()
         if config_path:
             try:
-                return agent_paths.require_agent_mount_path(config_path)
+                return agent_paths.require_agent_mount_path(config_path, data_dir=data_dir)
             except ValueError:
                 pass
         stored = str(self.mount_point or "").strip()
         if stored:
             try:
-                return agent_paths.require_agent_mount_path(stored)
+                return agent_paths.require_agent_mount_path(stored, data_dir=data_dir)
             except ValueError:
                 pass
-        return agent_paths.source_mount_point(self.id)
+        return agent_paths.source_mount_point(self.id, data_dir=data_dir)
 
     def resolved_credentials(self) -> dict:
         from apps.source.services.internal.source_credentials import (

--- a/src/backend/apps/source/services/interface.py
+++ b/src/backend/apps/source/services/interface.py
@@ -49,6 +49,14 @@ from apps.source.services.internal.source_credentials import (
 logger = logging.getLogger(__name__)
 
 
+def _node_agent_data_dir(node: Node) -> str | None:
+    metadata = node.metadata if isinstance(node.metadata, dict) else {}
+    inventory = metadata.get("inventory")
+    if not isinstance(inventory, dict):
+        return None
+    return str(inventory.get("root_path") or "").strip() or None
+
+
 def _cancel_active_connection_probe(resource: SourceResource) -> None:
     if resource.connection_test_status not in ConnectionTestStatus.ACTIVE:
         return
@@ -427,6 +435,7 @@ def test_draft_connection(
     validation_mount_point = agent_paths.source_validation_mount_point(
         str(uuid4()),
         node.id,
+        data_dir=_node_agent_data_dir(node),
     )
     return public_connection_result(run_connection_test(
         bound_node=node,

--- a/src/backend/apps/source/tests/test_source_mount_point.py
+++ b/src/backend/apps/source/tests/test_source_mount_point.py
@@ -19,6 +19,7 @@ from apps.source.services.internal.nas_agent import (
     build_nas_agent_payload,
     dispatch_nas_agent_task,
 )
+from apps.source.services.interface import test_draft_connection
 
 MOUNTS_ROOT = agent_paths.agent_mounts_dir()
 
@@ -79,6 +80,85 @@ class SourceMountPointResolutionTests(SimpleTestCase):
         )
         payload = build_nas_agent_payload(resource=resource)
         self.assertEqual(payload["mount_point"], agent_paths.source_mount_point(15))
+
+    def test_build_payload_uses_bound_proxy_agent_root(self):
+        node = Node(
+            metadata={"inventory": {"root_path": "/var/lib/hyperfilelens-agent"}},
+        )
+        resource = SourceResource(
+            id=32,
+            bound_node=node,
+            config={
+                "protocol": "nfs",
+                "server": "192.168.8.82",
+                "export_path": "/nfs-share1",
+            },
+        )
+        payload = build_nas_agent_payload(resource=resource)
+        self.assertEqual(
+            payload["mount_point"],
+            agent_paths.source_mount_point(
+                32, data_dir="/var/lib/hyperfilelens-agent"
+            ),
+        )
+
+    def test_invalid_bound_proxy_inventory_uses_default_agent_root(self):
+        resource = SourceResource(
+            id=33,
+            bound_node=Node(metadata={"inventory": "legacy-value"}),
+            config={"protocol": "nfs"},
+        )
+
+        self.assertEqual(
+            resource.effective_mount_point(),
+            agent_paths.source_mount_point(33),
+        )
+
+
+class DraftConnectionMountPointTests(SimpleTestCase):
+    @mock.patch("apps.source.services.interface.run_connection_test")
+    @mock.patch("apps.source.services.interface.Node.objects.filter")
+    def test_uses_bound_proxy_agent_root(self, node_filter, run_connection_test):
+        node_filter.return_value.first.return_value = SimpleNamespace(
+            id=17,
+            role=NodeRole.PROXY,
+            metadata={"inventory": {"root_path": "/var/lib/hfl-agent"}},
+        )
+        run_connection_test.return_value = {"success": True}
+
+        result = test_draft_connection(
+            organization_id=3,
+            bound_node_id=17,
+            resource_type=ResourceType.NAS,
+        )
+
+        self.assertTrue(result["success"])
+        mount_point = run_connection_test.call_args.kwargs["mount_point_override"]
+        self.assertTrue(mount_point.startswith("/var/lib/hfl-agent/mounts/"))
+
+    @mock.patch("apps.source.services.interface.run_connection_test")
+    @mock.patch("apps.source.services.interface.Node.objects.filter")
+    def test_invalid_inventory_uses_default_agent_root(
+        self,
+        node_filter,
+        run_connection_test,
+    ):
+        node_filter.return_value.first.return_value = SimpleNamespace(
+            id=18,
+            role=NodeRole.PROXY,
+            metadata={"inventory": ["legacy-value"]},
+        )
+        run_connection_test.return_value = {"success": True}
+
+        result = test_draft_connection(
+            organization_id=3,
+            bound_node_id=18,
+            resource_type=ResourceType.NAS,
+        )
+
+        self.assertTrue(result["success"])
+        mount_point = run_connection_test.call_args.kwargs["mount_point_override"]
+        self.assertTrue(mount_point.startswith(agent_paths.agent_mounts_dir()))
 
 
 class ExplainNasMountPointErrorTests(SimpleTestCase):

--- a/src/backend/apps/storage/periodic_tasks.py
+++ b/src/backend/apps/storage/periodic_tasks.py
@@ -40,6 +40,7 @@ def register_periodic_tasks():
         kwargs={"limit": 200, "force": True, "stale_after_seconds": None},
         queue=None,
         enabled=True,
+        sync_existing_kwargs=True,
     )
     TASK_REGISTRY.add(
         name="storage_reconcile_repository_operations",

--- a/src/backend/common/scheduling/registry.py
+++ b/src/backend/common/scheduling/registry.py
@@ -82,6 +82,7 @@ class TaskRegistry:
         enabled: bool = True,
         expire_seconds: int | None = None,
         coalesce_wakeup: bool = True,
+        sync_existing_kwargs: bool = False,
     ) -> None:
         if expire_seconds is not None and int(expire_seconds) < 1:
             raise ValueError("expire_seconds must be positive when configured")
@@ -96,6 +97,7 @@ class TaskRegistry:
                 int(expire_seconds) if expire_seconds is not None else None
             ),
             "coalesce_wakeup": bool(coalesce_wakeup),
+            "sync_existing_kwargs": bool(sync_existing_kwargs),
         }
 
     def _apply_one(self, name: str, entry: dict) -> bool:
@@ -147,6 +149,12 @@ class TaskRegistry:
                 headers.get(PERIODIC_WAKEUP_COALESCE_HEADER)
                 is not expected_coalescing
             )
+            kwargs_changed = (
+                entry["sync_existing_kwargs"]
+                and obj.kwargs != defaults["kwargs"]
+            )
+            if kwargs_changed:
+                obj.kwargs = defaults["kwargs"]
             if headers_changed:
                 headers[PERIODIC_WAKEUP_COALESCE_HEADER] = expected_coalescing
                 obj.headers = json.dumps(headers)
@@ -155,10 +163,12 @@ class TaskRegistry:
                 expire_seconds is not None
                 and obj.expire_seconds != expire_seconds
             )
-            if not headers_changed and not expiry_changed:
+            if not headers_changed and not expiry_changed and not kwargs_changed:
                 logger.debug("Periodic task exists, skipping update: %s", name)
                 return False
             update_fields = ["headers"] if headers_changed else []
+            if kwargs_changed:
+                update_fields.append("kwargs")
             if expiry_changed:
                 obj.expire_seconds = expire_seconds
                 update_fields.append("expire_seconds")

--- a/src/backend/common/tests/test_scheduling_registry.py
+++ b/src/backend/common/tests/test_scheduling_registry.py
@@ -97,6 +97,53 @@ class TaskRegistryTests(TestCase):
         task = PeriodicTask.objects.get(name="test_non_coalesced_task")
         self.assertFalse(json.loads(task.headers)[PERIODIC_WAKEUP_COALESCE_HEADER])
 
+    def test_sync_existing_kwargs_updates_code_managed_definition(self) -> None:
+        registry = TaskRegistry()
+        registry.add(
+            name="test_sync_kwargs",
+            task="tests.sync-kwargs",
+            schedule=10,
+            kwargs={"force": False},
+            sync_existing_kwargs=True,
+        )
+        registry.apply()
+        PeriodicTask.objects.filter(name="test_sync_kwargs").update(
+            kwargs=json.dumps({"force": True}),
+        )
+
+        registry.add(
+            name="test_sync_kwargs",
+            task="tests.sync-kwargs",
+            schedule=10,
+            kwargs={"force": False, "stale_after_seconds": None},
+            sync_existing_kwargs=True,
+        )
+        registry.apply()
+
+        task = PeriodicTask.objects.get(name="test_sync_kwargs")
+        self.assertEqual(
+            json.loads(task.kwargs),
+            {"force": False, "stale_after_seconds": None},
+        )
+
+    def test_existing_kwargs_are_preserved_without_explicit_sync(self) -> None:
+        registry = TaskRegistry()
+        registry.add(
+            name="test_preserve_kwargs",
+            task="tests.preserve-kwargs",
+            schedule=10,
+            kwargs={"force": False},
+        )
+        registry.apply()
+        PeriodicTask.objects.filter(name="test_preserve_kwargs").update(
+            kwargs=json.dumps({"operator": "custom"}),
+        )
+
+        registry.apply()
+
+        task = PeriodicTask.objects.get(name="test_preserve_kwargs")
+        self.assertEqual(json.loads(task.kwargs), {"operator": "custom"})
+
     def test_expiry_must_be_positive(self) -> None:
         registry = TaskRegistry()
 


### PR DESCRIPTION
## Problem

Existing Celery Beat entries did not receive updated kwargs from
code-managed periodic task definitions. In addition, Backup Source NAS mount
and draft-validation paths ignored the bound Proxy Agent's advertised data
root, which could target the wrong path on non-default Agent installations.

## Root cause

`TaskRegistry` reconciled headers and expiry but intentionally left existing
kwargs untouched, and Source Resource path consumers did not read
`metadata.inventory.root_path` from the bound Node.

## Solution

- Add opt-in synchronization for existing periodic-task kwargs and enable it
  for repository usage reconciliation.
- Resolve stored and canonical Backup Source mount paths using the bound Agent
  inventory root.
- Use the same root for draft connection validation.
- Preserve operator-custom kwargs for tasks that do not opt into sync and fall
  back to the default Agent root for missing or malformed inventory metadata.

## Validation

- Focused backend tests: 21 passed.
- Full affected Source, Storage, and scheduling suites: 724 passed.
- Changed-file Ruff passed.
- Django migration drift check passed with no changes detected.
- English-source boundary and `git diff --check` passed.
- Manual testing: passed.

Frontend, Agent, language-pack, and Enterprise checks are not applicable
because no files or contracts in those components changed.

Fixes #775
