### PR TITLE
Surface backup target validation errors

### DIFF
--- a/src/backend/apps/protection/services/backup_task.py
+++ b/src/backend/apps/protection/services/backup_task.py
@@ -683,6 +683,29 @@ def start_backup_tasks(
         for config in configs:
             if config.status != BackupConfig.Status.ACTIVE:
                 skipped_count += 1
+                provisioning_error_code = (
+                    str(config.provisioning_error_code or "").strip() or None
+                )
+                if config.status == BackupConfig.Status.PROVISIONING:
+                    status_message = "Target storage validation is still running."
+                    provisioning_error_code = None
+                elif config.status == BackupConfig.Status.PROVISION_FAILED:
+                    provisioning_error_message = str(
+                        config.provisioning_error_message or ""
+                    ).strip()
+                    status_message = (
+                        provisioning_error_message
+                        or (
+                            "Target storage validation failed. Resolve the issue "
+                            "and retry validation."
+                        )
+                    )
+                else:
+                    provisioning_error_code = None
+                    status_message = (
+                        "Target storage validation failed. Resolve the issue "
+                        "and retry validation."
+                    )
                 results.append(
                     {
                         "source_type": source.source_type,
@@ -693,11 +716,8 @@ def start_backup_tasks(
                         "source_snapshot_id": None,
                         "source_snapshot_status": None,
                         "status": "skipped",
-                        "message": (
-                            "Target storage validation is still running."
-                            if config.status == BackupConfig.Status.PROVISIONING
-                            else "Target storage validation failed. Resolve the issue and retry validation."
-                        ),
+                        "error_code": provisioning_error_code,
+                        "message": status_message,
                     }
                 )
                 continue

--- a/src/backend/apps/protection/tests/test_backup_task_api.py
+++ b/src/backend/apps/protection/tests/test_backup_task_api.py
@@ -131,6 +131,36 @@ class ProtectionBackupTaskApiTests(TestCase):
     def _headers(self):
         return {"HTTP_X_ORG_KEY": self.org.key}
 
+    def test_start_backup_task_returns_storage_validation_error(self):
+        BackupConfig.objects.filter(id=self.config.id).update(
+            status=BackupConfig.Status.PROVISION_FAILED,
+            provisioning_error_code="NAS_REPOSITORY_READ_ONLY",
+            provisioning_error_message=(
+                "NAS repository is mounted read-only. Enable write access and "
+                "retry storage validation."
+            ),
+        )
+
+        response = self.client.post(
+            "/api/v1/protection/backup-tasks/",
+            {
+                "source_ids": [f"agent:{self.agent.id}"],
+                "trigger_type": "manual",
+            },
+            format="json",
+            **self._headers(),
+        )
+
+        self.assertEqual(
+            response.status_code, status.HTTP_201_CREATED, response.content
+        )
+        self.assertEqual(response.data["created_count"], 0)
+        result = response.data["results"][0]
+        self.assertEqual(result["status"], "skipped")
+        self.assertEqual(result["error_code"], "NAS_REPOSITORY_READ_ONLY")
+        self.assertIn("mounted read-only", result["message"])
+        self.assertFalse(BackupSourceSnapshot.objects.exists())
+
     @patch("apps.protection.tasks.backup.advance_backup_task.delay")
     def test_policy_prepare_result_immediately_queues_backup_advance(self, mock_delay):
         task, snapshot = self._create_backup_task_and_snapshot(

--- a/src/frontend/src/lib/protectionBackupTaskApi.ts
+++ b/src/frontend/src/lib/protectionBackupTaskApi.ts
@@ -25,6 +25,7 @@ export type StartBackupTaskResultItem = {
   source_snapshot_id: number | null
   source_snapshot_status: string | null
   status: 'created' | 'skipped' | 'conflict' | 'failed'
+  error_code?: string | null
   message: string
 }
 

--- a/src/frontend/src/lib/protectionBackupTaskPresentation.test.ts
+++ b/src/frontend/src/lib/protectionBackupTaskPresentation.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import { backupStartResultMessage } from './protectionBackupTaskPresentation'
+
+const t = (key: string) => `translated:${key}`
+
+describe('backup start result presentation', () => {
+  it('localizes known storage validation errors', () => {
+    expect(
+      backupStartResultMessage(
+        {
+          error_code: 'NAS_REPOSITORY_READ_ONLY',
+          message: 'NAS repository is mounted read-only.',
+        },
+        t,
+      ),
+    ).toBe('translated:protection.backupsPage.provisionStatusReadOnly')
+  })
+
+  it('keeps the backend message for unknown errors', () => {
+    expect(
+      backupStartResultMessage(
+        { error_code: 'REPOSITORY_PROVISION_FAILED', message: 'Try again later.' },
+        t,
+      ),
+    ).toBe('Try again later.')
+  })
+
+  it('keeps the same ownership guidance as the configuration drawer', () => {
+    expect(
+      backupStartResultMessage(
+        { error_code: 'AGENT_PROTOCOL_INVALID', message: 'Agent protocol mismatch.' },
+        t,
+      ),
+    ).toBe('translated:protection.backupsPage.provisionStatusOwnershipConflict')
+  })
+})

--- a/src/frontend/src/lib/protectionBackupTaskPresentation.ts
+++ b/src/frontend/src/lib/protectionBackupTaskPresentation.ts
@@ -1,0 +1,20 @@
+import type { StartBackupTaskResultItem } from './protectionBackupTaskApi'
+
+type Translate = (key: string) => string
+
+const validationErrorLocaleKeys: Record<string, string> = {
+  AGENT_UPGRADE_REQUIRED: 'protection.backupsPage.provisionStatusUpgradeRequired',
+  NAS_REPOSITORY_READ_ONLY: 'protection.backupsPage.provisionStatusReadOnly',
+  NAS_REPOSITORY_WRITE_DENIED: 'protection.backupsPage.provisionStatusWriteDenied',
+  NAS_MOUNT_SOURCE_MISMATCH: 'protection.backupsPage.provisionStatusMountMismatch',
+  REPOSITORY_OWNERSHIP_INVALID: 'protection.backupsPage.provisionStatusOwnershipConflict',
+  AGENT_PROTOCOL_INVALID: 'protection.backupsPage.provisionStatusOwnershipConflict',
+}
+
+export function backupStartResultMessage(
+  result: Pick<StartBackupTaskResultItem, 'error_code' | 'message'>,
+  t: Translate,
+) {
+  const key = validationErrorLocaleKeys[String(result.error_code || '').trim()]
+  return key ? t(key) : result.message
+}

--- a/src/frontend/src/pages/protection/DataProtection.vue
+++ b/src/frontend/src/pages/protection/DataProtection.vue
@@ -142,6 +142,7 @@ import {
 } from '../../lib/storageRepositoryApi'
 import { storageRepositoryLocation } from '../../lib/storageRepositoryDisplay'
 import { startProtectionBackupTasks, cancelProtectionBackupTask } from '../../lib/protectionBackupTaskApi'
+import { backupStartResultMessage } from '../../lib/protectionBackupTaskPresentation'
 import { cancelProtectionRestoreTask } from '../../lib/protectionRestoreTaskApi'
 import {
   type ProtectionStopConfirmItem,
@@ -4771,7 +4772,7 @@ async function startSelectedBackupTasks() {
     }
     const failed = result.results.find((item) => item.status === 'failed' || item.status === 'skipped')
     if (failed?.message) {
-      ElMessage.warning({ message: failed.message, grouping: true })
+      ElMessage.warning({ message: backupStartResultMessage(failed, t), grouping: true })
       return
     }
     ElMessage.warning({ message: t('protection.backupsPage.msgSourceNoBackupConfig'), grouping: true })


### PR DESCRIPTION
## Summary
- return stored target-validation error codes and diagnostics when backup start is skipped
- localize known validation failures in the Data Protection UI while preserving unknown diagnostics
- add backend and frontend regression coverage for read-only NAS targets

## Validation
- `git diff --check`
- Python compile check
- `vue-tsc --noEmit`
- 7 related Vitest tests passed

## Notes
- No Agent, NAS mount, database schema, or storage lifecycle behavior changes
- Full Django integration test execution requires an available PostgreSQL test database