### PR TITLE
Harden Agent lifecycle cleanup and host selection state

### DIFF
--- a/deploy/bootstrap/agent-bootstrap-windows.ps1
+++ b/deploy/bootstrap/agent-bootstrap-windows.ps1
@@ -107,7 +107,10 @@ function Get-HflEnrollmentBinary {
     [Parameter(Mandatory = $true)][string]$OutFile
   )
   $skipCert = ($env:HFL_INSECURE_TLS -ne '0')
-  $partial = "$OutFile.part"
+  # Keep the incomplete PE away from an executable-looking suffix. Windows
+  # Defender may inspect a partially written .exe and classify the download
+  # before it is complete; only the final atomic rename should use .exe.
+  $partial = "$OutFile.download"
   $started = [DateTime]::UtcNow
   Remove-Item -Force -LiteralPath $partial -ErrorAction SilentlyContinue
 
@@ -216,8 +219,8 @@ finally {
   if (Test-Path -LiteralPath $bin) {
     Remove-Item -Force -LiteralPath $bin -ErrorAction SilentlyContinue
   }
-  if (Test-Path -LiteralPath "$bin.part") {
-    Remove-Item -Force -LiteralPath "$bin.part" -ErrorAction SilentlyContinue
+  if (Test-Path -LiteralPath "$bin.download") {
+    Remove-Item -Force -LiteralPath "$bin.download" -ErrorAction SilentlyContinue
   }
 }
 exit $exitCode

--- a/src/agent/internal/platform/install/local_uninstall_windows.go
+++ b/src/agent/internal/platform/install/local_uninstall_windows.go
@@ -384,9 +384,11 @@ try {
     if (Test-Path -LiteralPath $installCmd) {
       Log "running install.cmd uninstall"
       $cmdLine = '"' + $installCmd + '" uninstall'
-      if ($keep -eq '0') {
-        $cmdLine += ' -PurgeAll'
-      }
+      # The detached runner owns final data-root removal.  Do not pass
+      # -PurgeAll to the nested installer: deleting the data root while the
+      # nested PowerShell process still owns uninstall.log can return exit=1
+      # on Windows even after the Agent binaries were removed.  The outer
+      # runner removes the validated data root after this process exits.
       Push-Location $env:TEMP
       try {
         $proc = Start-Process -FilePath 'cmd.exe' -ArgumentList '/c', $cmdLine -Wait -PassThru -WindowStyle Hidden
@@ -405,9 +407,8 @@ try {
     } elseif (Test-Path -LiteralPath $installPs1) {
       Log "install.cmd missing; running install.ps1 uninstall fallback"
       $uninstallArgs = @('-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', $installPs1, 'uninstall')
-      if ($keep -eq '0') {
-        $uninstallArgs += '-PurgeAll'
-      }
+      # Keep data-root removal in the detached runner for the same reason as
+      # the install.cmd path above.
       Push-Location $env:TEMP
       try {
         $proc = Start-Process -FilePath 'powershell.exe' -ArgumentList $uninstallArgs -Wait -PassThru -WindowStyle Hidden

--- a/src/agent/internal/platform/install/local_uninstall_windows_test.go
+++ b/src/agent/internal/platform/install/local_uninstall_windows_test.go
@@ -40,7 +40,6 @@ func TestWriteWindowsUninstallScriptUsesUninstallLogAndInstallPs1(t *testing.T) 
 	for _, want := range []string{
 		`$logFile = ` + fmt.Sprintf("%q", UninstallLogPath(logDir)),
 		`install.cmd uninstall`,
-		`-PurgeAll`,
 		`Stop-HflProcessesForUninstall`,
 		`Start-Sleep -Seconds 3`,
 		`Remove-InstallDirectoryResidue`,
@@ -82,6 +81,10 @@ func TestWriteWindowsUninstallScriptUsesUninstallLogAndInstallPs1(t *testing.T) 
 	}
 	if strings.Contains(body, ".install.out") {
 		t.Fatalf("script must not reference separate install output log:\n%s", body)
+	}
+	if strings.Contains(body, `$cmdLine += ' -PurgeAll'`) ||
+		strings.Contains(body, `$uninstallArgs += '-PurgeAll'`) {
+		t.Fatalf("nested Windows uninstall must leave final data-root removal to the detached runner:\n%s", body)
 	}
 	if strings.Contains(body, `$KeepFlag -eq '0'`) {
 		t.Fatalf("general artifact verification must run before final data cleanup:\n%s", body)

--- a/src/frontend/src/pages/protection/BackupSources.vue
+++ b/src/frontend/src/pages/protection/BackupSources.vue
@@ -2272,6 +2272,7 @@ onUnmounted(() => {
               type="selection"
               width="35"
               fixed="left"
+              reserve-selection
             />
             <el-table-column
               :label="t('protection.sourceResources.colName')"

--- a/src/frontend/src/pages/protection/ProductionSitesAvailability.test.ts
+++ b/src/frontend/src/pages/protection/ProductionSitesAvailability.test.ts
@@ -42,6 +42,11 @@ describe('Production Sites availability presentation', () => {
     ])).toBe(true)
   })
 
+  it('preserves selected hosts while lifecycle polling refreshes the table', () => {
+    expect(hostTable).toContain('reserve-selection')
+    expect(list).toContain('row-key="id"')
+  })
+
   it('places NAS lifecycle status immediately after name and keeps connectivity before registration', () => {
     expect(ordered(nasTable, [
       'colName',


### PR DESCRIPTION
## Summary
- avoid Windows Defender scanning incomplete enrollment downloads as executable files
- keep Windows detached uninstall cleanup reliable without nested data-root deletion
- preserve selected hosts when the host table refreshes

## Validation
- Go Agent install package tests
- Windows cross-compilation
- Frontend Vitest and ESLint
- Release contract checks

No issue-specific changes are included in this PR.