### PR TITLE
fix(dev): recover SourceLens container recreate races

### DIFF
--- a/deploy/installer/sourcelens/compose-lifecycle.sh
+++ b/deploy/installer/sourcelens/compose-lifecycle.sh
@@ -36,7 +36,24 @@ hfl_compose_exit_event_container_ids() {
 		| sort -u
 }
 
-hfl_compose_wait_for_container_exit_events() {
+hfl_compose_running_container_ids() {
+	local error_file=$1
+	grep -E \
+		'cannot remove container "?[0-9a-f]{12,64}"?: container is running: stop the container before removing or force remove' \
+		"${error_file}" \
+		| sed -E 's/.*cannot remove container "?([0-9a-f]{12,64})"?:.*/\1/' \
+		| sort -u
+}
+
+hfl_compose_recovery_container_ids() {
+	local error_file=$1
+	{
+		hfl_compose_exit_event_container_ids "${error_file}"
+		hfl_compose_running_container_ids "${error_file}"
+	} | sort -u
+}
+
+hfl_compose_wait_for_container_stop() {
 	local container_ids=$1
 	local wait_seconds="${HFL_COMPOSE_EXIT_EVENT_WAIT_SECONDS:-60}"
 	local poll_seconds="${HFL_COMPOSE_EXIT_EVENT_POLL_SECONDS:-2}"
@@ -134,15 +151,15 @@ hfl_compose_command_with_exit_event_recovery() {
 		return 0
 	fi
 
-	container_ids="$(hfl_compose_exit_event_container_ids "${error_file}" || true)"
+	container_ids="$(hfl_compose_recovery_container_ids "${error_file}" || true)"
 	rm -f -- "${error_file}"
 	if [[ -z "${container_ids}" ]]; then
 		return "${status}"
 	fi
 
 	hfl_compose_lifecycle_warn \
-		"Docker delayed a container exit event; waiting only for the affected container before one Compose retry"
-	if ! hfl_compose_wait_for_container_exit_events "${container_ids}"; then
+		"Docker delayed a container stop; waiting only for the affected container before one Compose retry"
+	if ! hfl_compose_wait_for_container_stop "${container_ids}"; then
 		return "${status}"
 	fi
 

--- a/deploy/installer/sourcelens/docker-compose.template.yml
+++ b/deploy/installer/sourcelens/docker-compose.template.yml
@@ -7,6 +7,7 @@ services:
     image: __SOURCELENS_BACKEND_IMAGE__
     pull_policy: never
     restart: unless-stopped
+    stop_grace_period: 60s
     env_file:
       - ./.env
     environment:

--- a/tools/quality/test-compose-lifecycle-reconcile.sh
+++ b/tools/quality/test-compose-lifecycle-reconcile.sh
@@ -90,6 +90,15 @@ compose_transient_then_failure() {
 	return 23
 }
 
+compose_running_then_success() {
+	increment_compose_count
+	if [[ "$(cat "${TMP}/compose-count")" -eq 1 ]]; then
+		printf 'Error response from daemon: cannot remove container "abcdef1234567890": container is running: stop the container before removing or force remove\n' >&2
+		return 1
+	fi
+	printf 'compose reconciled\n'
+}
+
 reset_case() {
 	rm -f "${TMP}/compose-count" "${HFL_TEST_DOCKER_COUNT_FILE}"
 }
@@ -124,6 +133,12 @@ fi
 reset_case
 export HFL_TEST_DOCKER_MODE=stopped
 hfl_compose_command_with_exit_event_recovery compose_transient_then_success up -d
+[[ "$(cat "${TMP}/compose-count")" == "2" ]]
+[[ "$(cat "${HFL_TEST_DOCKER_COUNT_FILE}")" == "1" ]]
+
+reset_case
+export HFL_TEST_DOCKER_MODE=stopped
+hfl_compose_command_with_exit_event_recovery compose_running_then_success up -d
 [[ "$(cat "${TMP}/compose-count")" == "2" ]]
 [[ "$(cat "${HFL_TEST_DOCKER_COUNT_FILE}")" == "1" ]]
 


### PR DESCRIPTION
## Summary
- allow the SourceLens API container to stop gracefully during upgrades
- recover once from Docker compose errors caused by a still-running container
- add regression coverage for the container recreation race

## Validation
- Compose lifecycle reconciliation checks
- SourceLens release contract checks
- blue/green recovery checks
- Bash syntax checks
- git diff --check