### PR TITLE
Retry undispatched lifecycle tasks during Agent reconnects

### DIFF
--- a/src/backend/apps/node/services/internal/task.py
+++ b/src/backend/apps/node/services/internal/task.py
@@ -64,6 +64,7 @@ _ACK_DURABLE_TASKS = frozenset(
         ("storage.repository_health", "repo.status"),
     }
 )
+_LIFECYCLE_PRE_DISPATCH_KINDS = frozenset({"agent.upgrade", "agent.uninstall"})
 
 
 @dataclass(frozen=True)
@@ -388,6 +389,22 @@ def _task_within_route_grace(task: NodeTask) -> bool:
     return timezone.now() - task.created_at < grace
 
 
+def _is_pre_dispatch_lifecycle_task(task: NodeTask) -> bool:
+    """Return whether a lifecycle command is still safe to retry.
+
+    Before the command is sent, retrying after a short WebSocket flap cannot
+    duplicate an Agent operation.  Once delivery starts, detached upgrade and
+    uninstall commands must retain their existing fail-closed semantics.
+    """
+    return (
+        task.correlation_type == node_conf.LIFECYCLE_CORRELATION_TYPE
+        and task.kind in _LIFECYCLE_PRE_DISPATCH_KINDS
+        and task.dispatched_at is None
+        and task.accepted_at is None
+        and task.delivery_attempt_count == 0
+    )
+
+
 def _node_route_state(*, task: NodeTask) -> _RouteState:
     node = task.node
     if node.role not in (NodeRole.AGENT, NodeRole.PROXY):
@@ -396,6 +413,11 @@ def _node_route_state(*, task: NodeTask) -> _RouteState:
         return _RouteState.RECONNECTING
     if _node_ws_routable(node_id=node.id):
         return _RouteState.ONLINE
+    # A lifecycle command has not reached the Agent yet.  Keep it pending for
+    # the existing 30-second route grace even if the node status projection has
+    # already crossed from Online to Offline during a brief reconnect flap.
+    if _is_pre_dispatch_lifecycle_task(task) and _task_within_route_grace(task):
+        return _RouteState.RECONNECTING
     if (
         node.availability == Node.Availability.ONLINE
         and _last_seen_within_task_route_grace(node)

--- a/src/backend/apps/node/tests/test_agent_task_sync.py
+++ b/src/backend/apps/node/tests/test_agent_task_sync.py
@@ -472,6 +472,119 @@ class AgentTaskDeliveryAndLeaseTests(TestCase):
         mock_clear_agent_location.assert_called_once_with(agent_id=self.node.id)
         mock_push_task_stream.assert_called_once()
 
+    @patch("apps.node.services.internal.task._schedule_agent_task_redelivery")
+    @patch("apps.node.services.internal.task.redis_store.get_agent_location")
+    @patch("apps.node.services.internal.task.redis_store.get_redis")
+    def test_lifecycle_delivery_waits_through_short_offline_flap(
+        self,
+        mock_get_redis,
+        mock_get_agent_location,
+        mock_schedule_redelivery,
+    ):
+        class RedisClient:
+            def exists(self, key):
+                return False
+
+            def set(self, *args, **kwargs):
+                return True
+
+        NodeTask.objects.filter(pk=self.task.pk).update(
+            kind="agent.upgrade",
+            correlation_type=node_conf.LIFECYCLE_CORRELATION_TYPE,
+            status=NodeTask.Status.PENDING,
+        )
+        self.node.availability = Node.Availability.OFFLINE
+        self.node.save(update_fields=["availability"])
+        self.task.refresh_from_db()
+        mock_get_agent_location.return_value = "stale-ws"
+        mock_get_redis.return_value = RedisClient()
+
+        task = deliver_agent_task(task=self.task)
+
+        self.assertEqual(task.status, NodeTask.Status.PENDING)
+        self.assertEqual(task.last_error, "agent websocket is reconnecting")
+        mock_schedule_redelivery.assert_called_once_with(task=task)
+
+    @patch("apps.node.services.internal.task.redis_store.push_task_stream")
+    @patch("apps.node.services.internal.task.redis_store.clear_agent_location")
+    @patch("apps.node.services.internal.task.redis_store.get_agent_location")
+    @patch("apps.node.services.internal.task.redis_store.get_redis")
+    def test_lifecycle_delivery_fails_after_pre_dispatch_route_grace(
+        self,
+        mock_get_redis,
+        mock_get_agent_location,
+        mock_clear_agent_location,
+        mock_push_task_stream,
+    ):
+        class RedisClient:
+            def exists(self, key):
+                return False
+
+            def set(self, *args, **kwargs):
+                return True
+
+        NodeTask.objects.filter(pk=self.task.pk).update(
+            kind="agent.upgrade",
+            correlation_type=node_conf.LIFECYCLE_CORRELATION_TYPE,
+            status=NodeTask.Status.PENDING,
+            created_at=timezone.now()
+            - timezone.timedelta(
+                seconds=node_conf.TASK_ROUTE_RECONNECT_GRACE_SECONDS + 1
+            ),
+        )
+        self.node.availability = Node.Availability.OFFLINE
+        self.node.save(update_fields=["availability"])
+        self.task.refresh_from_db()
+        mock_get_agent_location.return_value = "stale-ws"
+        mock_get_redis.return_value = RedisClient()
+
+        task = deliver_agent_task(task=self.task)
+
+        self.assertEqual(task.status, NodeTask.Status.FAILED)
+        self.assertEqual(task.last_error, "agent websocket is not routable")
+        mock_clear_agent_location.assert_called_once_with(agent_id=self.node.id)
+        mock_push_task_stream.assert_called_once()
+
+    @patch("apps.node.services.internal.task._schedule_agent_task_redelivery")
+    @patch("apps.node.services.internal.task.redis_store.push_task_stream")
+    @patch("apps.node.services.internal.task.redis_store.clear_agent_location")
+    @patch("apps.node.services.internal.task.redis_store.get_agent_location")
+    @patch("apps.node.services.internal.task.redis_store.get_redis")
+    def test_lifecycle_delivery_never_retries_after_command_was_sent(
+        self,
+        mock_get_redis,
+        mock_get_agent_location,
+        mock_clear_agent_location,
+        mock_push_task_stream,
+        mock_schedule_redelivery,
+    ):
+        class RedisClient:
+            def exists(self, key):
+                return False
+
+            def set(self, *args, **kwargs):
+                return True
+
+        NodeTask.objects.filter(pk=self.task.pk).update(
+            kind="agent.upgrade",
+            correlation_type=node_conf.LIFECYCLE_CORRELATION_TYPE,
+            status=NodeTask.Status.PENDING,
+            dispatched_at=timezone.now(),
+            delivery_attempt_count=1,
+        )
+        self.node.availability = Node.Availability.OFFLINE
+        self.node.save(update_fields=["availability"])
+        self.task.refresh_from_db()
+        mock_get_agent_location.return_value = "stale-ws"
+        mock_get_redis.return_value = RedisClient()
+
+        task = deliver_agent_task(task=self.task)
+
+        self.assertEqual(task.status, NodeTask.Status.FAILED)
+        mock_clear_agent_location.assert_called_once_with(agent_id=self.node.id)
+        mock_push_task_stream.assert_called_once()
+        mock_schedule_redelivery.assert_not_called()
+
     @patch("apps.node.services.internal.task._send_task_command")
     @patch("apps.node.services.internal.task.redis_store.get_agent_location")
     @patch("apps.node.services.internal.task.redis_store.get_redis")


### PR DESCRIPTION
## Summary
- Keep undispatched Agent upgrade and uninstall tasks pending during a short WebSocket reconnect flap.
- Retry only within the existing 30-second route grace window.
- Preserve fail-closed behavior after dispatch and prevent duplicate detached operations.

## Validation
- Ran all 350 tests in apps.node.tests.
- Ran the focused Agent task delivery tests.
- Ruff and Python compilation checks passed.

## Scope
This is a backend reliability reinforcement. It does not change the Worker, Agent, ACK protocol, or detached lifecycle state machine.