### PR TITLE
fix(restore): clean up direct NAS mounts after insight chats

### DIFF
--- a/src/agent/internal/remote/inventory.go
+++ b/src/agent/internal/remote/inventory.go
@@ -76,6 +76,7 @@ func SendInventory(
 			"snapshot_artifact_upload_v1",
 			"snapshot_scope_resolve_v1",
 			"insight_safe_restore_v1",
+			"nas_mount_lifecycle_v1",
 			"network_inventory_v1",
 			"repository_server_port_range_v1",
 			"detached_uninstall_v2",

--- a/src/backend/apps/node/services/capabilities.py
+++ b/src/backend/apps/node/services/capabilities.py
@@ -7,6 +7,7 @@ from collections.abc import Iterable
 from apps.node.models import Node
 
 REPOSITORY_OWNERSHIP_CAPABILITY = "repository_ownership_v1"
+NAS_MOUNT_LIFECYCLE_CAPABILITY = "nas_mount_lifecycle_v1"
 
 
 def node_capabilities(node: Node) -> frozenset[str]:
@@ -46,6 +47,7 @@ def node_supports_capability(node: Node, capability: str) -> bool:
 
 
 __all__ = [
+    "NAS_MOUNT_LIFECYCLE_CAPABILITY",
     "REPOSITORY_OWNERSHIP_CAPABILITY",
     "missing_node_capabilities",
     "node_capabilities",

--- a/src/backend/apps/restore/conf.py
+++ b/src/backend/apps/restore/conf.py
@@ -1,0 +1,13 @@
+"""Runtime settings for direct NAS mount cleanup."""
+
+from project.settings.env import env_int
+
+
+DIRECT_NAS_MOUNT_CLEANUP_GRACE_SECONDS = max(
+    0,
+    env_int("INSIGHT_DIRECT_NAS_MOUNT_CLEANUP_GRACE_SECONDS", 600),
+)
+DIRECT_NAS_MOUNT_CLEANUP_RETRY_SECONDS = max(
+    30,
+    env_int("INSIGHT_DIRECT_NAS_MOUNT_CLEANUP_RETRY_SECONDS", 300),
+)

--- a/src/backend/apps/restore/migrations/0007_direct_nas_mount_lease.py
+++ b/src/backend/apps/restore/migrations/0007_direct_nas_mount_lease.py
@@ -1,0 +1,134 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+    dependencies = [("restore", "0006_restore_item_terminal_projection")]
+
+    operations = [
+        migrations.CreateModel(
+            name="DirectNASMount",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("execution_organization_id", models.BigIntegerField(db_index=True)),
+                ("requesting_organization_id", models.BigIntegerField(db_index=True)),
+                ("repository_id", models.BigIntegerField(db_index=True)),
+                ("reader_node_id", models.BigIntegerField(db_index=True)),
+                ("mount_point", models.CharField(max_length=1000)),
+                ("mount_key", models.CharField(max_length=64)),
+                (
+                    "cleanup_node_task_id",
+                    models.UUIDField(blank=True, db_index=True, null=True),
+                ),
+                (
+                    "cleanup_after",
+                    models.DateTimeField(blank=True, db_index=True, null=True),
+                ),
+                ("last_error", models.TextField(blank=True, default="")),
+                ("created_at", models.DateTimeField(auto_now_add=True, db_index=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+            ],
+            options={"db_table": "restore_direct_nas_mount"},
+        ),
+        migrations.CreateModel(
+            name="DirectNASMountLease",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("organization_id", models.BigIntegerField(db_index=True)),
+                (
+                    "status",
+                    models.CharField(
+                        choices=[
+                            ("active", "Active"),
+                            ("released", "Released"),
+                            ("cleanup_pending", "Cleanup pending"),
+                        ],
+                        db_index=True,
+                        default="active",
+                        max_length=24,
+                    ),
+                ),
+                (
+                    "cleanup_node_task_id",
+                    models.UUIDField(blank=True, db_index=True, null=True),
+                ),
+                ("released_at", models.DateTimeField(blank=True, null=True)),
+                ("last_error", models.TextField(blank=True, default="")),
+                ("created_at", models.DateTimeField(auto_now_add=True, db_index=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                (
+                    "mount",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="leases",
+                        to="restore.directnasmount",
+                    ),
+                ),
+                (
+                    "restore_record",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="direct_nas_mount_leases",
+                        to="restore.restorerecord",
+                    ),
+                ),
+            ],
+            options={"db_table": "restore_direct_nas_mount_lease"},
+        ),
+        migrations.AddConstraint(
+            model_name="directnasmount",
+            constraint=models.UniqueConstraint(
+                fields=(
+                    "execution_organization_id",
+                    "repository_id",
+                    "reader_node_id",
+                    "mount_key",
+                ),
+                name="uniq_restore_direct_nas_mount",
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="directnasmount",
+            index=models.Index(
+                fields=["reader_node_id", "repository_id"],
+                name="rst_nas_mount_node_repo_idx",
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name="directnasmountlease",
+            constraint=models.UniqueConstraint(
+                fields=("restore_record", "mount"),
+                name="uniq_restore_direct_nas_lease",
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="directnasmountlease",
+            index=models.Index(
+                fields=["mount", "status"],
+                name="rst_nas_lease_mount_status_idx",
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="directnasmountlease",
+            index=models.Index(
+                fields=["restore_record", "status"],
+                name="rst_nas_lease_rec_status_idx",
+            ),
+        ),
+    ]

--- a/src/backend/apps/restore/models/__init__.py
+++ b/src/backend/apps/restore/models/__init__.py
@@ -1,4 +1,15 @@
 from apps.restore.models.restore_plan import RestorePlan
-from apps.restore.models.restore_record import RestoreRecord, RestoreRecordItem
+from apps.restore.models.restore_record import (
+    DirectNASMount,
+    DirectNASMountLease,
+    RestoreRecord,
+    RestoreRecordItem,
+)
 
-__all__ = ["RestorePlan", "RestoreRecord", "RestoreRecordItem"]
+__all__ = [
+    "DirectNASMount",
+    "DirectNASMountLease",
+    "RestorePlan",
+    "RestoreRecord",
+    "RestoreRecordItem",
+]

--- a/src/backend/apps/restore/models/restore_record.py
+++ b/src/backend/apps/restore/models/restore_record.py
@@ -160,3 +160,99 @@ class RestoreRecordItem(models.Model):
 
     def __str__(self) -> str:
         return f"{self.restore_record_id}:{self.source_snapshot_directory_id}"
+
+
+class DirectNASMount(models.Model):
+    """Control-plane aggregate for one Agent-local NAS mount identity."""
+
+    execution_organization_id = models.BigIntegerField(db_index=True)
+    requesting_organization_id = models.BigIntegerField(db_index=True)
+    repository_id = models.BigIntegerField(db_index=True)
+    reader_node_id = models.BigIntegerField(db_index=True)
+    mount_point = models.CharField(max_length=1000)
+    mount_key = models.CharField(max_length=64)
+    cleanup_node_task_id = models.UUIDField(blank=True, null=True, db_index=True)
+    cleanup_after = models.DateTimeField(blank=True, null=True, db_index=True)
+    last_error = models.TextField(blank=True, default="")
+    created_at = models.DateTimeField(auto_now_add=True, db_index=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        db_table = "restore_direct_nas_mount"
+        constraints = [
+            models.UniqueConstraint(
+                fields=[
+                    "execution_organization_id",
+                    "repository_id",
+                    "reader_node_id",
+                    "mount_key",
+                ],
+                name="uniq_restore_direct_nas_mount",
+            ),
+        ]
+        indexes = [
+            models.Index(
+                fields=["reader_node_id", "repository_id"],
+                name="rst_nas_mount_node_repo_idx",
+            ),
+        ]
+
+    def __str__(self) -> str:
+        return f"{self.reader_node_id}:{self.repository_id}:{self.mount_point}"
+
+
+class DirectNASMountLease(models.Model):
+    """One Chat restore's use of a directly mounted NAS repository."""
+
+    class Status(models.TextChoices):
+        ACTIVE = "active", "Active"
+        RELEASED = "released", "Released"
+        CLEANUP_PENDING = "cleanup_pending", "Cleanup pending"
+
+    organization_id = models.BigIntegerField(db_index=True)
+    restore_record = models.ForeignKey(
+        RestoreRecord,
+        on_delete=models.CASCADE,
+        related_name="direct_nas_mount_leases",
+    )
+    mount = models.ForeignKey(
+        DirectNASMount,
+        on_delete=models.CASCADE,
+        related_name="leases",
+    )
+    status = models.CharField(
+        max_length=24,
+        choices=Status.choices,
+        default=Status.ACTIVE,
+        db_index=True,
+    )
+    cleanup_node_task_id = models.UUIDField(blank=True, null=True, db_index=True)
+    released_at = models.DateTimeField(blank=True, null=True)
+    last_error = models.TextField(blank=True, default="")
+    created_at = models.DateTimeField(auto_now_add=True, db_index=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        db_table = "restore_direct_nas_mount_lease"
+        constraints = [
+            models.UniqueConstraint(
+                fields=[
+                    "restore_record",
+                    "mount",
+                ],
+                name="uniq_restore_direct_nas_lease",
+            ),
+        ]
+        indexes = [
+            models.Index(
+                fields=["mount", "status"],
+                name="rst_nas_lease_mount_status_idx",
+            ),
+            models.Index(
+                fields=["restore_record", "status"],
+                name="rst_nas_lease_rec_status_idx",
+            ),
+        ]
+
+    def __str__(self) -> str:
+        return f"{self.mount_id}:{self.restore_record_id}:{self.status}"

--- a/src/backend/apps/restore/periodic_tasks.py
+++ b/src/backend/apps/restore/periodic_tasks.py
@@ -13,3 +13,12 @@ def register_periodic_tasks() -> None:
         queue=None,
         enabled=True,
     )
+    TASK_REGISTRY.add(
+        name="restore_reconcile_direct_nas_mounts",
+        task="apps.restore.tasks.reconcile_direct_nas_mounts",
+        schedule=60,
+        args=(),
+        kwargs={"limit": 200},
+        queue=None,
+        enabled=True,
+    )

--- a/src/backend/apps/restore/services/direct_nas_mounts.py
+++ b/src/backend/apps/restore/services/direct_nas_mounts.py
@@ -1,0 +1,517 @@
+"""Lifecycle for Chat restores that mount an unbound NAS on a Data Gateway."""
+
+from __future__ import annotations
+
+import logging
+from datetime import timedelta
+from hashlib import sha256
+from typing import Any
+from uuid import UUID
+
+from django.db import transaction
+from django.db.models import Exists, OuterRef, Q
+from django.utils import timezone
+
+from apps.node.models import Node, NodeTask
+from apps.node.services.capabilities import (
+    NAS_MOUNT_LIFECYCLE_CAPABILITY,
+    node_supports_capability,
+)
+from apps.node.services.interface import run_agent_task_async
+from apps.restore import conf
+from apps.restore.models import DirectNASMount, DirectNASMountLease, RestoreRecord
+from apps.storage.repositories.models import Repository
+from apps.task.models import Task
+from apps.task.services.interface import TERMINAL_STATUSES
+
+
+logger = logging.getLogger(__name__)
+_CLEANUP_CORRELATION = "restore.direct_nas_mount_cleanup"
+_UPGRADE_REQUIRED_ERROR = (
+    "Upgrade the Data Gateway Agent to enable safe NAS mount cleanup."
+)
+_TERMINAL_NODE_STATUSES = {
+    NodeTask.Status.SUCCESS,
+    NodeTask.Status.FAILED,
+    NodeTask.Status.TIMEOUT,
+    NodeTask.Status.CANCELED,
+}
+
+
+def acquire_for_restore(
+    *,
+    record: RestoreRecord,
+    repository: Repository,
+    reader_node_id: int,
+    access_mode: str,
+    repository_payload: dict[str, Any],
+) -> DirectNASMountLease | None:
+    """Record one direct Data Gateway NAS read; Proxy reads are excluded.
+
+    The aggregate row is the database lock for the physical mount identity.
+    A lease belongs to one restore record, while multiple Chat restores on the
+    same Agent share the aggregate and therefore share one physical mount.
+    """
+
+    mount_point = _direct_mount_point(
+        record=record,
+        repository=repository,
+        reader_node_id=reader_node_id,
+        access_mode=access_mode,
+        repository_payload=repository_payload,
+    )
+    if not mount_point:
+        return None
+
+    with transaction.atomic():
+        mount_key = sha256(mount_point.encode("utf-8")).hexdigest()
+        mount, _ = DirectNASMount.objects.get_or_create(
+            execution_organization_id=record.target_execution_organization_id,
+            repository_id=repository.id,
+            reader_node_id=reader_node_id,
+            mount_key=mount_key,
+            defaults={
+                "requesting_organization_id": record.requesting_organization_id,
+                "mount_point": mount_point,
+            },
+        )
+        mount = DirectNASMount.objects.select_for_update().get(pk=mount.pk)
+        if mount.mount_point != mount_point:
+            raise RuntimeError("Direct NAS mount identity collision.")
+        mount_update_fields: list[str] = []
+        if mount.requesting_organization_id != record.requesting_organization_id:
+            mount.requesting_organization_id = record.requesting_organization_id
+            mount_update_fields.append("requesting_organization_id")
+        # Cancel only a cleanup that has not been dispatched. An in-flight
+        # unmount remains authoritative and the Agent's NAS lease serializes
+        # it with this new reader, preventing duplicate cleanup commands.
+        if mount.cleanup_node_task_id is None and mount.cleanup_after is not None:
+            mount.cleanup_after = None
+            mount.last_error = ""
+            mount_update_fields.extend(["cleanup_after", "last_error"])
+        if mount_update_fields:
+            mount.save(
+                update_fields=list(dict.fromkeys([*mount_update_fields, "updated_at"]))
+            )
+        lease, _ = DirectNASMountLease.objects.update_or_create(
+            restore_record=record,
+            mount=mount,
+            defaults={
+                "organization_id": record.organization_id,
+                "status": DirectNASMountLease.Status.ACTIVE,
+                "cleanup_node_task_id": None,
+                "released_at": None,
+                "last_error": "",
+            },
+        )
+    return lease
+
+
+def requires_lease_for_restore(
+    *,
+    record: RestoreRecord,
+    repository: Repository,
+    reader_node_id: int,
+    access_mode: str,
+    repository_payload: dict[str, Any],
+) -> bool:
+    """Return whether dispatch must atomically create a direct NAS lease."""
+
+    return bool(
+        _direct_mount_point(
+            record=record,
+            repository=repository,
+            reader_node_id=reader_node_id,
+            access_mode=access_mode,
+            repository_payload=repository_payload,
+        )
+    )
+
+
+def _direct_mount_point(
+    *,
+    record: RestoreRecord,
+    repository: Repository,
+    reader_node_id: int,
+    access_mode: str,
+    repository_payload: dict[str, Any],
+) -> str:
+    if (
+        record.purpose != RestoreRecord.Purpose.LENS_WORKSPACE
+        or repository.repo_type != Repository.Type.NAS
+        or repository.bind_node_type == Repository.BindNodeType.PROXY
+        or access_mode != "fallback_node"
+        or int(reader_node_id) != int(record.target_execution_node_id)
+    ):
+        return ""
+    nas = repository_payload.get("nas")
+    return str(nas.get("mount_point") if isinstance(nas, dict) else "").strip()
+
+
+def release_for_record(*, record: RestoreRecord) -> int:
+    """Release a record's references and schedule cleanup when unused."""
+
+    now = timezone.now()
+    with transaction.atomic():
+        lease_rows = list(
+            DirectNASMountLease.objects.filter(
+                restore_record_id=record.id,
+                status=DirectNASMountLease.Status.ACTIVE,
+            ).values("id", "mount_id")
+        )
+        if not lease_rows:
+            return 0
+        mount_ids = sorted({int(row["mount_id"]) for row in lease_rows})
+        mounts = {
+            mount.id: mount
+            for mount in DirectNASMount.objects.select_for_update()
+            .filter(id__in=mount_ids)
+            .order_by("id")
+        }
+        released = DirectNASMountLease.objects.filter(
+            id__in=[row["id"] for row in lease_rows],
+            status=DirectNASMountLease.Status.ACTIVE,
+        ).update(
+            status=DirectNASMountLease.Status.RELEASED,
+            released_at=now,
+            last_error="",
+            updated_at=now,
+        )
+        for mount_id, mount in mounts.items():
+            if DirectNASMountLease.objects.filter(
+                mount_id=mount_id,
+                status=DirectNASMountLease.Status.ACTIVE,
+            ).exists():
+                continue
+            if mount.cleanup_node_task_id is not None:
+                continue
+            mount.cleanup_after = now + timedelta(
+                seconds=conf.DIRECT_NAS_MOUNT_CLEANUP_GRACE_SECONDS
+            )
+            mount.last_error = ""
+            mount.save(
+                update_fields=[
+                    "cleanup_after",
+                    "last_error",
+                    "updated_at",
+                ]
+            )
+    return released
+
+
+def reconcile(*, limit: int = 200) -> dict[str, int]:
+    """Release orphaned leases and converge due unmount commands."""
+
+    batch_size = max(1, int(limit))
+    released = _release_terminal_record_leases(limit=batch_size)
+    orphaned = _schedule_unreferenced_mounts(limit=batch_size)
+    completed, retried = _reconcile_cleanup_tasks(limit=batch_size)
+    dispatched = _dispatch_due_cleanups(limit=batch_size)
+    return {
+        "released": released,
+        "orphaned": orphaned,
+        "completed": completed,
+        "retried": retried,
+        "dispatched": dispatched,
+    }
+
+
+def _release_terminal_record_leases(*, limit: int) -> int:
+    existing_task_ids = Task.objects.values("id")
+    terminal_task_ids = Task.objects.filter(
+        status__in=TERMINAL_STATUSES,
+    ).values("id")
+    record_ids = list(
+        DirectNASMountLease.objects.filter(
+            status=DirectNASMountLease.Status.ACTIVE,
+        )
+        .filter(
+            Q(restore_record__task_id__in=terminal_task_ids)
+            | ~Q(restore_record__task_id__in=existing_task_ids)
+        )
+        .order_by()
+        .values_list("restore_record_id", flat=True)
+        .distinct()[:limit]
+    )
+    released = 0
+    for record_id in record_ids:
+        record = RestoreRecord.objects.filter(pk=record_id).first()
+        if record is not None:
+            released += release_for_record(record=record)
+    return released
+
+
+def _schedule_unreferenced_mounts(*, limit: int) -> int:
+    """Schedule aggregates whose RestoreRecord leases were removed."""
+
+    lease_exists = DirectNASMountLease.objects.filter(mount_id=OuterRef("pk"))
+    mount_ids = list(
+        DirectNASMount.objects.annotate(has_lease=Exists(lease_exists))
+        .filter(
+            has_lease=False,
+            cleanup_node_task_id__isnull=True,
+            cleanup_after__isnull=True,
+        )
+        .order_by("updated_at", "id")
+        .values_list("id", flat=True)[:limit]
+    )
+    scheduled = 0
+    for mount_id in mount_ids:
+        with transaction.atomic():
+            mount = (
+                DirectNASMount.objects.select_for_update()
+                .filter(
+                    pk=mount_id,
+                    cleanup_node_task_id__isnull=True,
+                    cleanup_after__isnull=True,
+                )
+                .first()
+            )
+            if (
+                mount is None
+                or DirectNASMountLease.objects.filter(mount_id=mount_id).exists()
+            ):
+                continue
+            mount.cleanup_after = timezone.now() + timedelta(
+                seconds=conf.DIRECT_NAS_MOUNT_CLEANUP_GRACE_SECONDS
+            )
+            mount.last_error = ""
+            mount.save(update_fields=["cleanup_after", "last_error", "updated_at"])
+            scheduled += 1
+    return scheduled
+
+
+def _reconcile_cleanup_tasks(*, limit: int) -> tuple[int, int]:
+    existing_cleanup_task_ids = NodeTask.objects.values("id")
+    terminal_cleanup_task_ids = NodeTask.objects.filter(
+        status__in=_TERMINAL_NODE_STATUSES,
+    ).values("id")
+    pending = list(
+        DirectNASMount.objects.filter(cleanup_node_task_id__isnull=False)
+        .filter(
+            Q(cleanup_node_task_id__in=terminal_cleanup_task_ids)
+            | ~Q(cleanup_node_task_id__in=existing_cleanup_task_ids)
+        )
+        .order_by("updated_at", "id")
+        .values_list("id", "cleanup_node_task_id")[:limit]
+    )
+    completed = 0
+    retried = 0
+    for mount_id, cleanup_task_id in pending:
+        node_task = NodeTask.objects.filter(pk=cleanup_task_id).first()
+        if node_task is None:
+            retried += _retry_missing_cleanup_task(
+                mount_id=int(mount_id),
+                cleanup_task_id=cleanup_task_id,
+            )
+            continue
+        if node_task.status not in _TERMINAL_NODE_STATUSES:
+            continue
+        if node_task.status == NodeTask.Status.SUCCESS:
+            completed += _complete_cleanup_task(
+                mount_id=int(mount_id),
+                cleanup_task_id=cleanup_task_id,
+            )
+        else:
+            retried += _retry_failed_cleanup_task(
+                mount_id=int(mount_id),
+                cleanup_task_id=cleanup_task_id,
+                error=node_task.last_error or "NAS mount cleanup failed.",
+            )
+    return completed, retried
+
+
+@transaction.atomic
+def _complete_cleanup_task(*, mount_id: int, cleanup_task_id: UUID) -> int:
+    """Converge one successful unmount and remove obsolete lease state."""
+
+    mount = DirectNASMount.objects.select_for_update().filter(pk=mount_id).first()
+    if mount is None or mount.cleanup_node_task_id != cleanup_task_id:
+        return 0
+    leases = DirectNASMountLease.objects.select_for_update().filter(mount_id=mount_id)
+    has_active = leases.filter(status=DirectNASMountLease.Status.ACTIVE).exists()
+    leases.exclude(status=DirectNASMountLease.Status.ACTIVE).delete()
+    if not has_active:
+        mount.delete()
+        return 1
+    mount.cleanup_node_task_id = None
+    mount.cleanup_after = None
+    mount.last_error = ""
+    mount.save(
+        update_fields=[
+            "cleanup_node_task_id",
+            "cleanup_after",
+            "last_error",
+            "updated_at",
+        ]
+    )
+    return 1
+
+
+@transaction.atomic
+def _retry_failed_cleanup_task(
+    *,
+    mount_id: int,
+    cleanup_task_id: UUID,
+    error: str,
+) -> int:
+    """Return one failed unmount to bounded retry state."""
+
+    mount = DirectNASMount.objects.select_for_update().filter(pk=mount_id).first()
+    if mount is None or mount.cleanup_node_task_id != cleanup_task_id:
+        return 0
+    now = timezone.now()
+    DirectNASMountLease.objects.filter(
+        mount_id=mount_id,
+        cleanup_node_task_id=cleanup_task_id,
+        status=DirectNASMountLease.Status.CLEANUP_PENDING,
+    ).update(
+        status=DirectNASMountLease.Status.RELEASED,
+        cleanup_node_task_id=None,
+        last_error=error[:2000],
+        updated_at=now,
+    )
+    has_active = DirectNASMountLease.objects.filter(
+        mount_id=mount_id,
+        status=DirectNASMountLease.Status.ACTIVE,
+    ).exists()
+    mount.cleanup_node_task_id = None
+    mount.cleanup_after = (
+        None
+        if has_active
+        else now + timedelta(seconds=conf.DIRECT_NAS_MOUNT_CLEANUP_RETRY_SECONDS)
+    )
+    mount.last_error = error[:2000]
+    mount.save(
+        update_fields=[
+            "cleanup_node_task_id",
+            "cleanup_after",
+            "last_error",
+            "updated_at",
+        ]
+    )
+    return 1
+
+
+def _dispatch_due_cleanups(*, limit: int) -> int:
+    now = timezone.now()
+    mount_ids = list(
+        DirectNASMount.objects.filter(
+            cleanup_node_task_id__isnull=True,
+            cleanup_after__lte=now,
+        )
+        .order_by("cleanup_after", "id")
+        .values_list("id", flat=True)[:limit]
+    )
+    dispatched = 0
+    for mount_id in mount_ids:
+        try:
+            if _dispatch_group(mount_id=int(mount_id)):
+                dispatched += 1
+        except Exception as exc:
+            logger.exception(
+                "direct NAS mount cleanup dispatch failed mount_id=%s", mount_id
+            )
+            _defer_cleanup_dispatch(mount_id=int(mount_id), error=str(exc))
+    return dispatched
+
+
+def _retry_missing_cleanup_task(*, mount_id: int, cleanup_task_id: UUID) -> int:
+    """Recover when a referenced NodeTask was removed with its Agent."""
+
+    return _retry_failed_cleanup_task(
+        mount_id=mount_id,
+        cleanup_task_id=cleanup_task_id,
+        error="NAS mount cleanup task record is unavailable.",
+    )
+
+
+@transaction.atomic
+def _defer_cleanup_dispatch(*, mount_id: int, error: str) -> None:
+    mount = DirectNASMount.objects.select_for_update().filter(pk=mount_id).first()
+    if mount is None or mount.cleanup_node_task_id is not None:
+        return
+    has_active = DirectNASMountLease.objects.filter(
+        mount=mount,
+        status=DirectNASMountLease.Status.ACTIVE,
+    ).exists()
+    mount.cleanup_after = (
+        None
+        if has_active
+        else timezone.now()
+        + timedelta(seconds=conf.DIRECT_NAS_MOUNT_CLEANUP_RETRY_SECONDS)
+    )
+    mount.last_error = (error or "NAS mount cleanup dispatch failed.")[:2000]
+    mount.save(update_fields=["cleanup_after", "last_error", "updated_at"])
+
+
+@transaction.atomic
+def _dispatch_group(*, mount_id: int) -> bool:
+    mount = DirectNASMount.objects.select_for_update().filter(pk=mount_id).first()
+    if mount is None or mount.cleanup_node_task_id is not None:
+        return False
+    if mount.cleanup_after is None or mount.cleanup_after > timezone.now():
+        return False
+    if DirectNASMountLease.objects.filter(
+        mount=mount,
+        status=DirectNASMountLease.Status.ACTIVE,
+    ).exists():
+        return False
+    node = (
+        Node.objects.filter(
+            id=mount.reader_node_id,
+            organization_id=mount.execution_organization_id,
+            is_deleted=False,
+        )
+        .only("metadata")
+        .first()
+    )
+    if node is None:
+        _defer_locked_mount(mount=mount, error="Data Gateway Agent is unavailable.")
+        return False
+    if not node_supports_capability(node, NAS_MOUNT_LIFECYCLE_CAPABILITY):
+        _defer_locked_mount(mount=mount, error=_UPGRADE_REQUIRED_ERROR)
+        return False
+    rows = list(
+        DirectNASMountLease.objects.select_for_update().filter(
+            mount=mount,
+            status=DirectNASMountLease.Status.RELEASED,
+        )
+    )
+    handle = run_agent_task_async(
+        organization_id=mount.execution_organization_id,
+        node_id=mount.reader_node_id,
+        kind="nas.unmount",
+        payload={"mount_point": mount.mount_point},
+        correlation_type=_CLEANUP_CORRELATION,
+        correlation_id=f"mount:{mount.id}",
+        requesting_organization_id=mount.requesting_organization_id,
+    )
+    DirectNASMountLease.objects.filter(id__in=[row.id for row in rows]).update(
+        status=DirectNASMountLease.Status.CLEANUP_PENDING,
+        cleanup_node_task_id=handle.task.id,
+        last_error="",
+        updated_at=timezone.now(),
+    )
+    mount.cleanup_node_task_id = handle.task.id
+    mount.cleanup_after = None
+    mount.last_error = ""
+    mount.save(
+        update_fields=[
+            "cleanup_node_task_id",
+            "cleanup_after",
+            "last_error",
+            "updated_at",
+        ]
+    )
+    return True
+
+
+def _defer_locked_mount(*, mount: DirectNASMount, error: str) -> None:
+    """Defer a locked aggregate without creating a NodeTask."""
+
+    mount.cleanup_after = timezone.now() + timedelta(
+        seconds=conf.DIRECT_NAS_MOUNT_CLEANUP_RETRY_SECONDS
+    )
+    mount.last_error = error[:2000]
+    mount.save(update_fields=["cleanup_after", "last_error", "updated_at"])

--- a/src/backend/apps/restore/services/interface.py
+++ b/src/backend/apps/restore/services/interface.py
@@ -5,6 +5,7 @@ import logging
 import ntpath
 import posixpath
 import secrets
+from contextlib import nullcontext
 from decimal import Decimal
 from typing import Any
 from uuid import uuid4
@@ -1876,46 +1877,73 @@ def _dispatch_restore_items(
                     **payload,
                     "nas": scrub_source_secrets(payload["nas"]),
                 }
-            handle = run_agent_task_async(
-                organization_id=record.target_execution_organization_id,
-                node_id=node.id,
-                kind="restore.run",
-                payload=payload,
-                persisted_payload=(persisted_payload if target_nas_payload else None),
-                correlation_type="restore.record",
-                correlation_id=str(record.task_uuid),
-                requesting_organization_id=record.requesting_organization_id,
+            from apps.restore.services.direct_nas_mounts import (
+                acquire_for_restore,
+                requires_lease_for_restore,
             )
-            log_agent_dispatch(
-                "restore item",
-                node_id=node.id,
-                kind="restore.run",
-                correlation_type="restore.record",
-                correlation_id=str(record.task_uuid),
-                restore_record_item_id=item.id,
-                node_task_id=str(handle.task.id),
-                kopia_snapshot_id=item.kopia_snapshot_id,
+
+            # Keep the durable lease, NodeTask and item projection in one
+            # transaction. Agent delivery is registered with on_commit(), so
+            # the restore cannot start before its control-plane lease exists.
+            lease_required = requires_lease_for_restore(
+                record=record,
+                repository=repository,
+                reader_node_id=repository_access.node.id,
+                access_mode=repository_access.mode,
+                repository_payload=repository_access.repository_payload,
             )
-            item.node_task_id = handle.task.id
-            item.status = RestoreRecordItem.Status.RUNNING
-            item.save(update_fields=["node_task_id", "status", "updated_at"])
-            append_task_step_event(
-                task=task,
-                step_name="dispatch_agent",
-                message="Restore item dispatched to agent",
-                metadata={
-                    "restore_record_item_id": item.id,
-                    "node_task_id": str(handle.task.id),
-                    "target_node_id": node.id,
-                    "repository_reader_node_id": repository_access.node.id,
-                    "restore_transfer_mode": payload["restore_transfer_mode"],
-                    "kopia_snapshot_id": item.kopia_snapshot_id,
-                    "source_path": item.source_path,
-                    "target_path": item.target_path,
-                    "object_id": item.kopia_snapshot_id,
-                    "object_name": item.source_path,
-                },
-            )
+            dispatch_scope = transaction.atomic() if lease_required else nullcontext()
+            with dispatch_scope:
+                handle = run_agent_task_async(
+                    organization_id=record.target_execution_organization_id,
+                    node_id=node.id,
+                    kind="restore.run",
+                    payload=payload,
+                    persisted_payload=(
+                        persisted_payload if target_nas_payload else None
+                    ),
+                    correlation_type="restore.record",
+                    correlation_id=str(record.task_uuid),
+                    requesting_organization_id=record.requesting_organization_id,
+                )
+                if lease_required:
+                    acquire_for_restore(
+                        record=record,
+                        repository=repository,
+                        reader_node_id=repository_access.node.id,
+                        access_mode=repository_access.mode,
+                        repository_payload=repository_access.repository_payload,
+                    )
+                log_agent_dispatch(
+                    "restore item",
+                    node_id=node.id,
+                    kind="restore.run",
+                    correlation_type="restore.record",
+                    correlation_id=str(record.task_uuid),
+                    restore_record_item_id=item.id,
+                    node_task_id=str(handle.task.id),
+                    kopia_snapshot_id=item.kopia_snapshot_id,
+                )
+                item.node_task_id = handle.task.id
+                item.status = RestoreRecordItem.Status.RUNNING
+                item.save(update_fields=["node_task_id", "status", "updated_at"])
+                append_task_step_event(
+                    task=task,
+                    step_name="dispatch_agent",
+                    message="Restore item dispatched to agent",
+                    metadata={
+                        "restore_record_item_id": item.id,
+                        "node_task_id": str(handle.task.id),
+                        "target_node_id": node.id,
+                        "repository_reader_node_id": repository_access.node.id,
+                        "restore_transfer_mode": payload["restore_transfer_mode"],
+                        "kopia_snapshot_id": item.kopia_snapshot_id,
+                        "source_path": item.source_path,
+                        "target_path": item.target_path,
+                        "object_id": item.kopia_snapshot_id,
+                        "object_name": item.source_path,
+                    },
+                )
         _set_step_status(
             task=task,
             step_name="dispatch_agent",
@@ -2003,6 +2031,9 @@ def _dispatch_restore_items(
             error_code="RESTORE_DISPATCH_FAILED",
             error_message=error_message,
         )
+        from apps.restore.services.direct_nas_mounts import release_for_record
+
+        release_for_record(record=record)
         stop_restore_repository_servers(task=task)
         raise
 
@@ -2379,6 +2410,10 @@ def cancel_restore(
                 task.task_uuid,
             )
 
+    if record is not None:
+        from apps.restore.services.direct_nas_mounts import release_for_record
+
+        release_for_record(record=record)
     stop_restore_repository_servers(task=task)
 
     append_task_step_event(

--- a/src/backend/apps/restore/signals.py
+++ b/src/backend/apps/restore/signals.py
@@ -405,7 +405,9 @@ def _finalize_record_if_done(*, record: RestoreRecord, product_task: Task) -> No
         return
     normalize_restore_task_type(record=record, task=product_task)
     from apps.restore.services.interface import stop_restore_repository_servers
+    from apps.restore.services.direct_nas_mounts import release_for_record
 
+    release_for_record(record=record)
     stop_restore_repository_servers(task=product_task)
     failed = [
         status for status in statuses if status != RestoreRecordItem.Status.SUCCESS

--- a/src/backend/apps/restore/tasks.py
+++ b/src/backend/apps/restore/tasks.py
@@ -1,8 +1,16 @@
 from celery import shared_task
 
 from apps.restore.services.reconciliation import reconcile_restore_node_task_projections
+from apps.restore.services.direct_nas_mounts import (
+    reconcile as reconcile_direct_nas_mounts,
+)
 
 
 @shared_task(name="apps.restore.tasks.reconcile_restore_node_task_projections")
 def reconcile_restore_node_task_projections_task(*, limit: int = 200) -> dict[str, int]:
     return reconcile_restore_node_task_projections(limit=limit)
+
+
+@shared_task(name="apps.restore.tasks.reconcile_direct_nas_mounts")
+def reconcile_direct_nas_mounts_task(*, limit: int = 200) -> dict[str, int]:
+    return reconcile_direct_nas_mounts(limit=limit)

--- a/src/backend/apps/restore/tests/test_direct_nas_mounts.py
+++ b/src/backend/apps/restore/tests/test_direct_nas_mounts.py
@@ -1,0 +1,534 @@
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from django.test import TestCase
+from django.utils import timezone
+
+from apps.iam.models import Organization
+from apps.node.models import Node, NodeTask
+from apps.node.services.capabilities import NAS_MOUNT_LIFECYCLE_CAPABILITY
+from apps.restore import conf
+from apps.restore.models import DirectNASMount, DirectNASMountLease, RestoreRecord
+from apps.restore.services import direct_nas_mounts
+from apps.storage.repositories.models import Repository
+from apps.task.models import Task
+
+
+class DirectNASMountLifecycleTests(TestCase):
+    def setUp(self) -> None:
+        self.organization = Organization.objects.create(
+            key="direct-nas-mount-tests",
+            name="Direct NAS mount tests",
+        )
+        self.gateway = Node.objects.create(
+            organization=self.organization,
+            name="Gateway 1",
+            role=Node.Role.GATEWAY,
+            status=Node.Status.ACTIVE,
+            availability=Node.Availability.ONLINE,
+            metadata={"inventory": {"capabilities": [NAS_MOUNT_LIFECYCLE_CAPABILITY]}},
+        )
+        self.other_gateway = Node.objects.create(
+            organization=self.organization,
+            name="Gateway 2",
+            role=Node.Role.GATEWAY,
+            status=Node.Status.ACTIVE,
+            availability=Node.Availability.ONLINE,
+            metadata={"inventory": {"capabilities": [NAS_MOUNT_LIFECYCLE_CAPABILITY]}},
+        )
+        self.repository = Repository.objects.create(
+            organization_id=self.organization.id,
+            name="Direct NAS",
+            repo_type=Repository.Type.NAS,
+            nas_protocol=Repository.NasProtocol.NFS,
+            status=Repository.Status.CREATED,
+        )
+        self._sequence = 0
+
+    def _record(
+        self,
+        *,
+        node_id: int | None = None,
+        status: str = Task.Status.RUNNING,
+    ) -> RestoreRecord:
+        self._sequence += 1
+        resolved_node_id = node_id or self.gateway.id
+        task = Task.objects.create(
+            organization_id=self.organization.id,
+            task_type=Task.Type.INSIGHT_WORKSPACE_RESTORE,
+            display_name=f"Chat restore {self._sequence}",
+            status=status,
+        )
+        return RestoreRecord.objects.create(
+            organization_id=self.organization.id,
+            requesting_organization_id=self.organization.id,
+            target_execution_organization_id=self.organization.id,
+            target_execution_node_id=resolved_node_id,
+            purpose=RestoreRecord.Purpose.LENS_WORKSPACE,
+            idempotency_key=f"chat-{self._sequence}",
+            workspace_binding_id=1000 + self._sequence,
+            restore_uid=f"restore-{self._sequence}",
+            source_mode=RestoreRecord.SourceMode.MANUAL,
+            task_id=task.id,
+            task_uuid=task.task_uuid,
+            source_type=RestoreRecord.EndpointType.AGENT,
+            source_ref_id=301,
+            source_snapshot_id=401,
+            target_type=RestoreRecord.EndpointType.AGENT,
+            target_ref_id=resolved_node_id,
+            target_path=f"/chat/{self._sequence}",
+            scope=RestoreRecord.Scope.PATHS,
+            conflict_mode=RestoreRecord.ConflictMode.OVERWRITE,
+        )
+
+    @staticmethod
+    def _payload(mount_point: str = "/var/lib/hfl/repositories/1") -> dict:
+        return {"nas": {"mount_point": mount_point}}
+
+    def _acquire(
+        self,
+        record: RestoreRecord,
+        *,
+        repository: Repository | None = None,
+        node_id: int | None = None,
+        mount_point: str = "/var/lib/hfl/repositories/1",
+        access_mode: str = "fallback_node",
+    ) -> DirectNASMountLease | None:
+        return direct_nas_mounts.acquire_for_restore(
+            record=record,
+            repository=repository or self.repository,
+            reader_node_id=node_id or record.target_execution_node_id,
+            access_mode=access_mode,
+            repository_payload=self._payload(mount_point),
+        )
+
+    def test_same_gateway_repository_and_mount_share_one_aggregate(self) -> None:
+        first = self._acquire(self._record())
+        second = self._acquire(self._record())
+
+        self.assertIsNotNone(first)
+        self.assertIsNotNone(second)
+        self.assertEqual(first.mount_id, second.mount_id)
+        self.assertEqual(DirectNASMount.objects.count(), 1)
+        self.assertEqual(DirectNASMountLease.objects.count(), 2)
+
+    def test_mount_preserves_restore_requesting_organization(self) -> None:
+        requesting_organization = Organization.objects.create(
+            key="direct-nas-requesting-org",
+            name="Direct NAS requesting org",
+        )
+        record = self._record()
+        record.requesting_organization_id = requesting_organization.id
+        record.save(update_fields=["requesting_organization_id", "updated_at"])
+
+        lease = self._acquire(record)
+
+        self.assertIsNotNone(lease)
+        self.assertEqual(
+            lease.mount.requesting_organization_id,
+            requesting_organization.id,
+        )
+
+    def test_different_gateways_have_independent_mount_aggregates(self) -> None:
+        first = self._acquire(
+            self._record(node_id=self.gateway.id),
+            mount_point=f"/var/lib/hfl/node-{self.gateway.id}/repositories/1",
+        )
+        second = self._acquire(
+            self._record(node_id=self.other_gateway.id),
+            mount_point=f"/var/lib/hfl/node-{self.other_gateway.id}/repositories/1",
+        )
+
+        self.assertIsNotNone(first)
+        self.assertIsNotNone(second)
+        self.assertNotEqual(first.mount_id, second.mount_id)
+        self.assertEqual(DirectNASMount.objects.count(), 2)
+
+    def test_non_chat_non_nas_and_proxy_access_are_excluded(self) -> None:
+        user_record = self._record()
+        user_record.purpose = RestoreRecord.Purpose.USER_DATA
+        user_record.workspace_binding_id = None
+        user_record.idempotency_key = ""
+        user_record.save(
+            update_fields=[
+                "purpose",
+                "workspace_binding_id",
+                "idempotency_key",
+                "updated_at",
+            ]
+        )
+        self.assertIsNone(self._acquire(user_record))
+
+        chat_record = self._record()
+        s3 = Repository.objects.create(
+            organization_id=self.organization.id,
+            name="S3",
+            repo_type=Repository.Type.S3,
+            status=Repository.Status.CREATED,
+        )
+        self.assertIsNone(self._acquire(chat_record, repository=s3))
+
+        self.repository.bind_node_type = Repository.BindNodeType.PROXY
+        self.repository.bind_node_id = 999
+        self.repository.save(
+            update_fields=["bind_node_type", "bind_node_id", "updated_at"]
+        )
+        self.assertIsNone(
+            self._acquire(
+                self._record(),
+                repository=self.repository,
+                access_mode="bound_proxy",
+            )
+        )
+        self.assertEqual(DirectNASMount.objects.count(), 0)
+
+    @patch.object(conf, "DIRECT_NAS_MOUNT_CLEANUP_GRACE_SECONDS", 0)
+    @patch("apps.restore.services.direct_nas_mounts.run_agent_task_async")
+    def test_last_release_dispatches_one_shared_unmount(self, dispatch) -> None:
+        dispatch.return_value = SimpleNamespace(task=SimpleNamespace(id=uuid.uuid4()))
+        first_record = self._record()
+        second_record = self._record()
+        first = self._acquire(first_record)
+        second = self._acquire(second_record)
+        self.assertIsNotNone(first)
+        self.assertIsNotNone(second)
+
+        direct_nas_mounts.release_for_record(record=first_record)
+        self.assertIsNone(DirectNASMount.objects.get().cleanup_after)
+        self.assertEqual(direct_nas_mounts._dispatch_due_cleanups(limit=10), 0)
+
+        direct_nas_mounts.release_for_record(record=second_record)
+        self.assertEqual(direct_nas_mounts._dispatch_due_cleanups(limit=10), 1)
+        dispatch.assert_called_once()
+        self.assertEqual(dispatch.call_args.kwargs["node_id"], self.gateway.id)
+        self.assertEqual(dispatch.call_args.kwargs["kind"], "nas.unmount")
+        self.assertEqual(
+            dispatch.call_args.kwargs["payload"],
+            {"mount_point": "/var/lib/hfl/repositories/1"},
+        )
+        self.assertEqual(
+            DirectNASMountLease.objects.filter(
+                status=DirectNASMountLease.Status.CLEANUP_PENDING
+            ).count(),
+            2,
+        )
+
+        cleanup_task_id = dispatch.return_value.task.id
+        NodeTask.objects.create(
+            id=cleanup_task_id,
+            organization=self.organization,
+            requesting_organization_id=self.organization.id,
+            node=self.gateway,
+            kind="nas.unmount",
+            status=NodeTask.Status.SUCCESS,
+            watchdog_deadline_at=timezone.now(),
+        )
+        self.assertEqual(
+            direct_nas_mounts._reconcile_cleanup_tasks(limit=10),
+            (1, 0),
+        )
+        self.assertFalse(DirectNASMount.objects.exists())
+        self.assertFalse(DirectNASMountLease.objects.exists())
+
+    @patch.object(conf, "DIRECT_NAS_MOUNT_CLEANUP_GRACE_SECONDS", 0)
+    @patch("apps.restore.services.direct_nas_mounts.run_agent_task_async")
+    def test_different_gateways_dispatch_independent_unmounts(self, dispatch) -> None:
+        dispatch.side_effect = [
+            SimpleNamespace(task=SimpleNamespace(id=uuid.uuid4())),
+            SimpleNamespace(task=SimpleNamespace(id=uuid.uuid4())),
+        ]
+        first_record = self._record(node_id=self.gateway.id)
+        second_record = self._record(node_id=self.other_gateway.id)
+        self._acquire(
+            first_record,
+            mount_point=f"/var/lib/hfl/node-{self.gateway.id}/repositories/1",
+        )
+        self._acquire(
+            second_record,
+            mount_point=f"/var/lib/hfl/node-{self.other_gateway.id}/repositories/1",
+        )
+        direct_nas_mounts.release_for_record(record=first_record)
+        direct_nas_mounts.release_for_record(record=second_record)
+
+        self.assertEqual(direct_nas_mounts._dispatch_due_cleanups(limit=10), 2)
+        self.assertEqual(
+            {call.kwargs["node_id"] for call in dispatch.call_args_list},
+            {self.gateway.id, self.other_gateway.id},
+        )
+
+    @patch.object(conf, "DIRECT_NAS_MOUNT_CLEANUP_GRACE_SECONDS", 0)
+    @patch("apps.restore.services.direct_nas_mounts.run_agent_task_async")
+    def test_new_lease_preserves_single_in_flight_cleanup(self, dispatch) -> None:
+        cleanup_task_id = uuid.uuid4()
+        dispatch.return_value = SimpleNamespace(
+            task=SimpleNamespace(id=cleanup_task_id)
+        )
+        first_record = self._record()
+        self._acquire(first_record)
+        direct_nas_mounts.release_for_record(record=first_record)
+        self.assertEqual(direct_nas_mounts._dispatch_due_cleanups(limit=10), 1)
+
+        second_record = self._record()
+        second = self._acquire(second_record)
+        self.assertIsNotNone(second)
+        mount = second.mount
+        mount.refresh_from_db()
+        self.assertEqual(mount.cleanup_node_task_id, cleanup_task_id)
+        self.assertIsNone(mount.cleanup_after)
+        self.assertEqual(second.status, DirectNASMountLease.Status.ACTIVE)
+        self.assertEqual(
+            DirectNASMountLease.objects.filter(
+                mount=mount,
+                cleanup_node_task_id=cleanup_task_id,
+                status=DirectNASMountLease.Status.CLEANUP_PENDING,
+            ).count(),
+            1,
+        )
+
+        dispatch.assert_called_once()
+        NodeTask.objects.create(
+            id=cleanup_task_id,
+            organization=self.organization,
+            requesting_organization_id=self.organization.id,
+            node=self.gateway,
+            kind="nas.unmount",
+            status=NodeTask.Status.SUCCESS,
+            watchdog_deadline_at=timezone.now(),
+        )
+
+        completed, retried = direct_nas_mounts._reconcile_cleanup_tasks(limit=10)
+
+        self.assertEqual((completed, retried), (1, 0))
+        mount.refresh_from_db()
+        second.refresh_from_db()
+        self.assertIsNone(mount.cleanup_node_task_id)
+        self.assertEqual(second.status, DirectNASMountLease.Status.ACTIVE)
+        self.assertEqual(DirectNASMountLease.objects.filter(mount=mount).count(), 1)
+
+        direct_nas_mounts.release_for_record(record=second_record)
+        mount.refresh_from_db()
+        self.assertIsNotNone(mount.cleanup_after)
+
+    def test_new_lease_cancels_cleanup_during_grace_period(self) -> None:
+        first_record = self._record()
+        first = self._acquire(first_record)
+        self.assertIsNotNone(first)
+        direct_nas_mounts.release_for_record(record=first_record)
+        first.mount.refresh_from_db()
+        self.assertIsNotNone(first.mount.cleanup_after)
+
+        second_record = self._record()
+        second = self._acquire(second_record)
+
+        self.assertIsNotNone(second)
+        second.mount.refresh_from_db()
+        self.assertEqual(second.mount_id, first.mount_id)
+        self.assertIsNone(second.mount.cleanup_after)
+        self.assertEqual(second.mount.last_error, "")
+
+    @patch.object(conf, "DIRECT_NAS_MOUNT_CLEANUP_GRACE_SECONDS", 0)
+    def test_reconciler_releases_terminal_orphan(self) -> None:
+        record = self._record(status=Task.Status.FAILED)
+        lease = self._acquire(record)
+        self.assertIsNotNone(lease)
+
+        released = direct_nas_mounts._release_terminal_record_leases(limit=10)
+
+        self.assertEqual(released, 1)
+        lease.refresh_from_db()
+        lease.mount.refresh_from_db()
+        self.assertEqual(lease.status, DirectNASMountLease.Status.RELEASED)
+        self.assertLessEqual(lease.mount.cleanup_after, timezone.now())
+
+    @patch.object(conf, "DIRECT_NAS_MOUNT_CLEANUP_GRACE_SECONDS", 0)
+    def test_reconciler_releases_lease_when_product_task_is_missing(self) -> None:
+        record = self._record()
+        lease = self._acquire(record)
+        self.assertIsNotNone(lease)
+        Task.objects.filter(pk=record.task_id).delete()
+
+        released = direct_nas_mounts._release_terminal_record_leases(limit=10)
+
+        self.assertEqual(released, 1)
+        lease.refresh_from_db()
+        lease.mount.refresh_from_db()
+        self.assertEqual(lease.status, DirectNASMountLease.Status.RELEASED)
+        self.assertLessEqual(lease.mount.cleanup_after, timezone.now())
+
+    @patch.object(conf, "DIRECT_NAS_MOUNT_CLEANUP_GRACE_SECONDS", 0)
+    @patch("apps.restore.services.direct_nas_mounts.run_agent_task_async")
+    def test_restore_record_delete_keeps_mount_cleanup_authoritative(
+        self, dispatch
+    ) -> None:
+        cleanup_task_id = uuid.uuid4()
+        dispatch.return_value = SimpleNamespace(
+            task=SimpleNamespace(id=cleanup_task_id)
+        )
+        record = self._record()
+        lease = self._acquire(record)
+        self.assertIsNotNone(lease)
+        mount_id = lease.mount_id
+        direct_nas_mounts.release_for_record(record=record)
+        self.assertEqual(direct_nas_mounts._dispatch_due_cleanups(limit=10), 1)
+
+        record.delete()
+        self.assertFalse(DirectNASMountLease.objects.filter(mount_id=mount_id).exists())
+        NodeTask.objects.create(
+            id=cleanup_task_id,
+            organization=self.organization,
+            requesting_organization_id=self.organization.id,
+            node=self.gateway,
+            kind="nas.unmount",
+            status=NodeTask.Status.SUCCESS,
+            watchdog_deadline_at=timezone.now(),
+        )
+
+        self.assertEqual(
+            direct_nas_mounts._reconcile_cleanup_tasks(limit=10),
+            (1, 0),
+        )
+        self.assertFalse(DirectNASMount.objects.filter(pk=mount_id).exists())
+
+    @patch.object(conf, "DIRECT_NAS_MOUNT_CLEANUP_GRACE_SECONDS", 0)
+    @patch("apps.restore.services.direct_nas_mounts.run_agent_task_async")
+    def test_orphan_mount_without_leases_is_scheduled_and_unmounted(
+        self, dispatch
+    ) -> None:
+        dispatch.return_value = SimpleNamespace(task=SimpleNamespace(id=uuid.uuid4()))
+        record = self._record()
+        lease = self._acquire(record)
+        self.assertIsNotNone(lease)
+        mount_id = lease.mount_id
+        record.delete()
+
+        self.assertEqual(direct_nas_mounts._schedule_unreferenced_mounts(limit=10), 1)
+        mount = DirectNASMount.objects.get(pk=mount_id)
+        self.assertLessEqual(mount.cleanup_after, timezone.now())
+        self.assertEqual(direct_nas_mounts._dispatch_due_cleanups(limit=10), 1)
+        dispatch.assert_called_once_with(
+            organization_id=self.organization.id,
+            node_id=self.gateway.id,
+            kind="nas.unmount",
+            payload={"mount_point": "/var/lib/hfl/repositories/1"},
+            correlation_type="restore.direct_nas_mount_cleanup",
+            correlation_id=f"mount:{mount_id}",
+            requesting_organization_id=self.organization.id,
+        )
+
+    @patch.object(conf, "DIRECT_NAS_MOUNT_CLEANUP_GRACE_SECONDS", 0)
+    @patch.object(conf, "DIRECT_NAS_MOUNT_CLEANUP_RETRY_SECONDS", 30)
+    @patch("apps.restore.services.direct_nas_mounts.run_agent_task_async")
+    def test_old_agent_defers_automatic_unmount_until_upgrade(self, dispatch) -> None:
+        self.gateway.metadata = {"inventory": {"capabilities": []}}
+        self.gateway.save(update_fields=["metadata", "updated_at"])
+        record = self._record()
+        lease = self._acquire(record)
+        self.assertIsNotNone(lease)
+        direct_nas_mounts.release_for_record(record=record)
+        before = timezone.now()
+
+        self.assertEqual(direct_nas_mounts._dispatch_due_cleanups(limit=10), 0)
+
+        dispatch.assert_not_called()
+        lease.mount.refresh_from_db()
+        self.assertGreater(lease.mount.cleanup_after, before)
+        self.assertIn("Upgrade", lease.mount.last_error)
+
+        self.gateway.metadata = {
+            "inventory": {"capabilities": [NAS_MOUNT_LIFECYCLE_CAPABILITY]}
+        }
+        self.gateway.save(update_fields=["metadata", "updated_at"])
+        lease.mount.cleanup_after = timezone.now()
+        lease.mount.save(update_fields=["cleanup_after", "updated_at"])
+        dispatch.return_value = SimpleNamespace(task=SimpleNamespace(id=uuid.uuid4()))
+
+        self.assertEqual(direct_nas_mounts._dispatch_due_cleanups(limit=10), 1)
+        dispatch.assert_called_once()
+
+    @patch.object(conf, "DIRECT_NAS_MOUNT_CLEANUP_RETRY_SECONDS", 30)
+    def test_failed_cleanup_is_retried_after_backoff(self) -> None:
+        record = self._record()
+        lease = self._acquire(record)
+        self.assertIsNotNone(lease)
+        cleanup_task_id = uuid.uuid4()
+        now = timezone.now()
+        lease.status = DirectNASMountLease.Status.CLEANUP_PENDING
+        lease.cleanup_node_task_id = cleanup_task_id
+        lease.save(
+            update_fields=[
+                "status",
+                "cleanup_node_task_id",
+                "updated_at",
+            ]
+        )
+        mount = lease.mount
+        mount.cleanup_node_task_id = cleanup_task_id
+        mount.cleanup_after = None
+        mount.save(
+            update_fields=["cleanup_node_task_id", "cleanup_after", "updated_at"]
+        )
+        NodeTask.objects.create(
+            id=cleanup_task_id,
+            organization=self.organization,
+            requesting_organization_id=self.organization.id,
+            node=self.gateway,
+            kind="nas.unmount",
+            status=NodeTask.Status.FAILED,
+            watchdog_deadline_at=now,
+            last_error="mount is busy",
+        )
+
+        completed, retried = direct_nas_mounts._reconcile_cleanup_tasks(limit=10)
+
+        self.assertEqual((completed, retried), (0, 1))
+        lease.refresh_from_db()
+        mount.refresh_from_db()
+        self.assertEqual(lease.status, DirectNASMountLease.Status.RELEASED)
+        self.assertIsNone(mount.cleanup_node_task_id)
+        self.assertGreater(mount.cleanup_after, now)
+        self.assertEqual(mount.last_error, "mount is busy")
+
+    @patch.object(conf, "DIRECT_NAS_MOUNT_CLEANUP_GRACE_SECONDS", 0)
+    @patch.object(conf, "DIRECT_NAS_MOUNT_CLEANUP_RETRY_SECONDS", 30)
+    @patch("apps.restore.services.direct_nas_mounts.run_agent_task_async")
+    def test_cleanup_dispatch_failure_uses_backoff(self, dispatch) -> None:
+        dispatch.side_effect = RuntimeError("gateway is offline")
+        record = self._record()
+        lease = self._acquire(record)
+        self.assertIsNotNone(lease)
+        direct_nas_mounts.release_for_record(record=record)
+        before = timezone.now()
+
+        self.assertEqual(direct_nas_mounts._dispatch_due_cleanups(limit=10), 0)
+
+        mount = lease.mount
+        mount.refresh_from_db()
+        self.assertIsNone(mount.cleanup_node_task_id)
+        self.assertGreater(mount.cleanup_after, before)
+        self.assertEqual(mount.last_error, "gateway is offline")
+
+    @patch.object(conf, "DIRECT_NAS_MOUNT_CLEANUP_GRACE_SECONDS", 0)
+    @patch.object(conf, "DIRECT_NAS_MOUNT_CLEANUP_RETRY_SECONDS", 30)
+    @patch("apps.restore.services.direct_nas_mounts.run_agent_task_async")
+    def test_missing_cleanup_task_is_recovered(self, dispatch) -> None:
+        cleanup_task_id = uuid.uuid4()
+        dispatch.return_value = SimpleNamespace(
+            task=SimpleNamespace(id=cleanup_task_id)
+        )
+        record = self._record()
+        lease = self._acquire(record)
+        self.assertIsNotNone(lease)
+        direct_nas_mounts.release_for_record(record=record)
+        self.assertEqual(direct_nas_mounts._dispatch_due_cleanups(limit=10), 1)
+
+        completed, retried = direct_nas_mounts._reconcile_cleanup_tasks(limit=10)
+
+        self.assertEqual((completed, retried), (0, 1))
+        lease.refresh_from_db()
+        lease.mount.refresh_from_db()
+        self.assertEqual(lease.status, DirectNASMountLease.Status.RELEASED)
+        self.assertIsNone(lease.mount.cleanup_node_task_id)
+        self.assertGreater(lease.mount.cleanup_after, timezone.now())


### PR DESCRIPTION
## Summary
- Track direct NAS mounts used by Insight Chat restores with aggregated mount records and per-restore leases.
- Release leases on Chat completion, cancellation, dispatch failure, and orphaned restore records.
- Reconcile and retry NAS unmount tasks safely, including concurrent Chats on the same Data Gateway.
- Gate automatic cleanup on the Data Gateway Agent capability while preserving compatibility with older Agents.

## Scope
- Applies only to unbound NAS repositories read directly by Data Gateway Agents for Insight Chat restores.
- Does not change ordinary business restore flows, Proxy-bound NAS repositories, S3 repositories, or SourceLens behavior.

## Validation
- Full Restore test suite: 103 passed.
- Direct NAS mount lifecycle tests: 16 passed.
- Ruff, Django system checks, migration checks, and Go NAS lease tests passed.