### PR TITLE
feat(agent): select installation mode from execution identity

### DIFF
--- a/deploy/bootstrap/agent-bootstrap-linux.sh
+++ b/deploy/bootstrap/agent-bootstrap-linux.sh
@@ -196,6 +196,16 @@ aarch64 | arm64) HFL_ARCH=arm64 ;;
 	;;
 esac
 
+if [[ "${HFL_INSTALLATION_MODE}" == "auto" ]]; then
+	if [[ "$(id -u)" -eq 0 ]]; then
+		export HFL_INSTALLATION_MODE="system"
+		hfl_ok "Execution identity resolved to root; host-level continuous protection will be installed."
+	else
+		export HFL_INSTALLATION_MODE="user_continuous"
+		hfl_ok "Execution identity resolved to $(id -un) (UID $(id -u)); user-level continuous protection will be installed."
+	fi
+fi
+
 if [[ "${HFL_INSTALLATION_MODE}" == "user" || "${HFL_INSTALLATION_MODE}" == "user_continuous" ]]; then
 	if [[ "$(id -u)" -eq 0 ]]; then
 		hfl_fail "User-level installation must run as the current user without sudo." 1

--- a/deploy/bootstrap/agent-bootstrap-macos.sh
+++ b/deploy/bootstrap/agent-bootstrap-macos.sh
@@ -158,6 +158,16 @@ if ! command -v curl >/dev/null 2>&1; then
 	hfl_fail "curl is required but not installed." 2
 fi
 
+if [[ "${HFL_INSTALLATION_MODE}" == "auto" ]]; then
+	if [[ "$(id -u)" -eq 0 ]]; then
+		export HFL_INSTALLATION_MODE="system"
+		hfl_ok "Execution identity resolved to root; host-level continuous protection will be installed."
+	else
+		export HFL_INSTALLATION_MODE="user"
+		hfl_ok "Execution identity resolved to $(id -un) (UID $(id -u)); current-user protection will be installed."
+	fi
+fi
+
 if [[ "${HFL_INSTALLATION_MODE}" == "user" ]]; then
 	if [[ "$(id -u)" -eq 0 ]]; then
 		hfl_fail "User-level installation must run as the current user without sudo." 1

--- a/deploy/bootstrap/agent-bootstrap-windows.ps1
+++ b/deploy/bootstrap/agent-bootstrap-windows.ps1
@@ -77,6 +77,17 @@ $env:HFL_ORG_KEY = "__HFL_ORG_KEY__"
 $env:HFL_NODE_ROLE = "__HFL_NODE_ROLE__"
 $env:HFL_NODE_TOKEN = "__HFL_NODE_TOKEN__"
 $env:HFL_INSTALLATION_MODE = "__HFL_INSTALLATION_MODE__"
+if ($env:HFL_INSTALLATION_MODE -eq "auto") {
+  $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+  if (Test-HflAdmin) {
+    $env:HFL_INSTALLATION_MODE = "system"
+    Write-HflBootstrapLog "OK" "Execution identity resolved to $($identity.Name) in an elevated session; host-level continuous protection will be installed."
+  }
+  else {
+    $env:HFL_INSTALLATION_MODE = "user"
+    Write-HflBootstrapLog "OK" "Execution identity resolved to $($identity.Name) without elevation; current-user protection will be installed."
+  }
+}
 if ($env:HFL_INSTALLATION_MODE -eq "account" -and -not $env:HFL_RUN_AS_USER) {
   # The elevated installer will confirm the selected account. This default is
   # only a convenience for the account that launched the enrollment command.

--- a/language-packs/packs/zh-hans/frontend/messages.json
+++ b/language-packs/packs/zh-hans/frontend/messages.json
@@ -3991,6 +3991,8 @@
     "installLeadWindows": "复制并在普通 {cmd} 或 {powershell} 窗口中运行。所选保护方式需要时，安装程序会请求一次管理员授权",
     "installLeadMacos": "复制到{terminal}并使用 {sudo} 运行。安装后，请在系统设置中授予 HyperFileLens Agent“完全磁盘访问权限”；否则只能保护可读取的文件。",
     "installLeadUser": "以当前用户身份复制并运行命令。请勿使用 sudo 或管理员终端。",
+    "installLeadAutomatic": "使用你希望保护的身份复制并运行命令。在 Linux 上，普通用户安装持续的用户级保护；在 Windows 和 macOS 上，普通用户安装当前用户保护。root 或已提升权限的管理员安装主机级保护。安装程序会明确显示检测到的身份，绝不会静默切换模式。",
+    "installLeadAutomaticMacos": "使用你希望保护的身份复制并运行命令。普通用户安装用户级保护；root 安装主机级保护。安装程序会明确显示检测到的身份，绝不会静默切换模式。安装后，请在系统设置中授予 HyperFileLens Agent“完全磁盘访问权限”；否则只能保护可读取的文件。",
     "installLeadAdministrator": "管理员",
     "installLeadTerminal": "终端",
     "installFlowLabel": "此命令的作用",

--- a/language-packs/packs/zh-hans/frontend/source-lock.json
+++ b/language-packs/packs/zh-hans/frontend/source-lock.json
@@ -3836,6 +3836,8 @@
   "nodeLifecycle.installLeadWindows": "951b468fbb188b68af4fe929f182a19c31c940bfe049b27c813243ec2b61306c",
   "nodeLifecycle.installLeadMacos": "b4a18800cc07680033a6efd64a75bfeabce2c4b372937f5dfbf5300b8b17b2dd",
   "nodeLifecycle.installLeadUser": "9a7b4454be3c9bedd72f4afc00bbee82807750287ff8dc70d274c22011b3f2f9",
+  "nodeLifecycle.installLeadAutomatic": "76e1faa6ce0ec305fdaf48d7796225c2365dc923e946bc4cdccece9abdc2f034",
+  "nodeLifecycle.installLeadAutomaticMacos": "bef1efbac738cb901fdee6524ea44d73b6b76ff3503baff66f417bbb5aa091de",
   "nodeLifecycle.installLeadAdministrator": "cbc554f70533b2817c57562d8157472a794c91ce707833f99b00ccb8f5bde13f",
   "nodeLifecycle.installLeadTerminal": "ccb3afc48bd9a28423a1cc8a85ae3c0feb401b3fb4c4f6360aab35362089452c",
   "nodeLifecycle.installFlowLabel": "b57ad7b3b7d0d3b7130bcdc9b7e312ff3737ccf4ebb0525869ab9f22a59f9785",

--- a/src/agent/internal/enroll/bootstrap_mode_contract_test.go
+++ b/src/agent/internal/enroll/bootstrap_mode_contract_test.go
@@ -1,0 +1,60 @@
+package enroll
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestBootstrapAutomaticModeUsesActualExecutionIdentity(t *testing.T) {
+	tests := map[string][]string{
+		"agent-bootstrap-linux.sh": {
+			`if [[ "${HFL_INSTALLATION_MODE}" == "auto" ]]; then`,
+			`export HFL_INSTALLATION_MODE="user_continuous"`,
+			`export HFL_INSTALLATION_MODE="system"`,
+			"Execution identity resolved",
+		},
+		"agent-bootstrap-macos.sh": {
+			`if [[ "${HFL_INSTALLATION_MODE}" == "auto" ]]; then`,
+			`export HFL_INSTALLATION_MODE="user"`,
+			`export HFL_INSTALLATION_MODE="system"`,
+			"Execution identity resolved",
+		},
+		"agent-bootstrap-windows.ps1": {
+			`HFL_INSTALLATION_MODE -eq "auto"`,
+			`HFL_INSTALLATION_MODE = "user"`,
+			`HFL_INSTALLATION_MODE = "system"`,
+			"Execution identity resolved",
+		},
+	}
+	for name, required := range tests {
+		t.Run(name, func(t *testing.T) {
+			source := readBootstrapSource(t, name)
+			for _, want := range required {
+				if !strings.Contains(source, want) {
+					t.Fatalf("%s missing automatic-mode contract %q", name, want)
+				}
+			}
+		})
+	}
+}
+
+func readBootstrapSource(t *testing.T, name string) string {
+	t.Helper()
+	_, currentFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("resolve test source path")
+	}
+	path := filepath.Join(
+		filepath.Dir(currentFile),
+		"..", "..", "..", "..",
+		"deploy", "bootstrap", name,
+	)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
+}

--- a/src/agent/internal/enroll/install_lock_windows.go
+++ b/src/agent/internal/enroll/install_lock_windows.go
@@ -5,6 +5,7 @@ package enroll
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"golang.org/x/sys/windows"
 
@@ -14,7 +15,14 @@ import (
 func acquireInstallLock(_ context.Context) (func(), error) {
 	mutexName := `Global\HyperFileLensInstaller`
 	if vfs.UserInstallation() {
-		mutexName = `Local\HyperFileLensInstaller`
+		tokenUser, err := windows.GetCurrentProcessToken().GetTokenUser()
+		if err != nil {
+			return nil, fmt.Errorf("resolve current Windows user for installer lock: %w", err)
+		}
+		if tokenUser == nil || tokenUser.User.Sid == nil {
+			return nil, fmt.Errorf("resolve current Windows user for installer lock: SID unavailable")
+		}
+		mutexName = `Global\HyperFileLensInstaller.User.` + tokenUser.User.Sid.String()
 	}
 	name, err := windows.UTF16PtrFromString(mutexName)
 	if err != nil {

--- a/src/agent/internal/enroll/output.go
+++ b/src/agent/internal/enroll/output.go
@@ -477,7 +477,7 @@ func printAgentLifecycleCommands(info SummaryInfo) {
 	if runtime.GOOS == "windows" {
 		command := windowsPowerShellCommand(filepath.Join(info.InstallPath, installerScriptName()))
 		if vfs.UserInstallation() {
-			printSummaryValue("Task status", "schtasks.exe /Query /TN HyperFileLensAgent /FO LIST")
+			printSummaryValue("Task status", `powershell -NoProfile -Command "$sid=[Security.Principal.WindowsIdentity]::GetCurrent().User.Value; Get-ScheduledTask -TaskName ('HyperFileLensAgent.User.'+$sid)"`)
 		} else {
 			printSummaryValue("Service status", "sc.exe query HyperFileLensAgent")
 		}

--- a/src/agent/internal/enroll/preflight.go
+++ b/src/agent/internal/enroll/preflight.go
@@ -30,15 +30,14 @@ type EnvironmentReport struct {
 // RunEnvironmentChecks validates the host and prints user-facing results.
 func RunEnvironmentChecks(ctx context.Context, cfg Config) (*EnvironmentReport, error) {
 	failures := &preflightFailures{}
-	// Existing-install and cross-mode conflicts are deliberately determined
-	// only from local installation markers. Do not make the control plane or a
-	// host fingerprint an installation-admission authority.
+	// Existing-install decisions are deliberately determined only from the
+	// selected installation slot. Machine and per-user slots may coexist; the
+	// control plane and host fingerprint are not installation-admission authorities.
 	report := &EnvironmentReport{
 		Platform: platformDescription(),
 		ArchOK:   supportedRuntimeArch(),
 		Existing: DetectInstallState(),
 	}
-	conflictingInstallPath := ConflictingInstallPath()
 
 	if err := privilegeConstraint(cfg.InstallationMode); err != nil {
 		report.PrivilegesOK = false
@@ -99,14 +98,6 @@ func RunEnvironmentChecks(ctx context.Context, cfg Config) (*EnvironmentReport, 
 			failures.add("Administrator privileges are required", "re-run with sudo or as Administrator", 1)
 		}
 	}
-	if conflictingInstallPath != "" {
-		failures.add(
-			"A different Agent installation mode already exists",
-			conflictingInstallPath+"; uninstall it before changing installation mode",
-			1,
-		)
-	}
-
 	if report.ArchOK {
 		logOKDetail("CPU architecture is supported", runtime.GOARCH)
 	} else {

--- a/src/agent/internal/enroll/state.go
+++ b/src/agent/internal/enroll/state.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"os/user"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -110,41 +109,6 @@ func installedEnvPath() string {
 	return canonical
 }
 
-// ConflictingInstallPath returns the other lifecycle mode installed for the
-// current host account. System installers also inspect the invoking sudo user.
-func ConflictingInstallPath() string {
-	var candidate string
-	if vfs.UserInstallation() {
-		candidate = vfs.SystemInstallDir()
-		if !installMarkersPresent(candidate) {
-			candidate = vfs.LegacySystemInstallDir()
-		}
-	} else {
-		home := ""
-		if sudoUser := strings.TrimSpace(os.Getenv("SUDO_USER")); sudoUser != "" {
-			if account, err := user.Lookup(sudoUser); err == nil {
-				home = account.HomeDir
-			}
-		}
-		if home == "" {
-			home, _ = os.UserHomeDir()
-		}
-		if home != "" {
-			candidate = vfs.UserInstallDirForHome(home)
-			if !installMarkersPresent(candidate) {
-				candidate = vfs.LegacyUserInstallDirForHome(home)
-			}
-		}
-	}
-	if candidate == "" {
-		return ""
-	}
-	if installMarkersPresent(candidate) {
-		return candidate
-	}
-	return ""
-}
-
 func installMarkersPresent(installDir string) bool {
 	paths := []string{}
 	for _, name := range []string{
@@ -232,7 +196,7 @@ func serviceState(ctx context.Context) string {
 				"powershell.exe",
 				"-NoProfile",
 				"-Command",
-				"$task = Get-ScheduledTask -TaskName HyperFileLensAgent -ErrorAction SilentlyContinue; if ($null -eq $task) { exit 1 }; $task.State.ToString()",
+				"$sid = [Security.Principal.WindowsIdentity]::GetCurrent().User.Value; $name = \"HyperFileLensAgent.User.$sid\"; $task = Get-ScheduledTask -TaskName $name -ErrorAction SilentlyContinue; if ($null -eq $task) { exit 1 }; $task.State.ToString()",
 			).CombinedOutput()
 			if err != nil {
 				return "not installed"

--- a/src/agent/internal/enrollmentclient/register.go
+++ b/src/agent/internal/enrollmentclient/register.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"os/user"
 	"strconv"
 	"strings"
 	"time"
@@ -139,19 +140,26 @@ func httpRegisterNode(
 		inventory["mac_address"] = mac
 		inventory["primary_mac_address"] = mac
 	}
+	metadata := map[string]any{
+		"hostname":      hostname,
+		"inventory":     inventory,
+		"install":       "hfl-enroll",
+		"agent_version": agentVersion,
+		"platform":      platform.OSFamily,
+		"arch":          platform.Arch,
+	}
+	if currentUser, userErr := user.Current(); userErr == nil {
+		metadata["runtime_principal"] = map[string]string{
+			"id":   strings.TrimSpace(currentUser.Uid),
+			"name": strings.TrimSpace(currentUser.Username),
+		}
+	}
 	body := map[string]any{
-		"name":    hostname,
-		"role":    string(cfg.Role),
-		"version": agentVersion,
-		"os_name": platform.Description(),
-		"metadata": map[string]any{
-			"hostname":      hostname,
-			"inventory":     inventory,
-			"install":       "hfl-enroll",
-			"agent_version": agentVersion,
-			"platform":      platform.OSFamily,
-			"arch":          platform.Arch,
-		},
+		"name":     hostname,
+		"role":     string(cfg.Role),
+		"version":  agentVersion,
+		"os_name":  platform.Description(),
+		"metadata": metadata,
 	}
 	machineFingerprint, err := identity.MachineFingerprint(ctx)
 	if err != nil {

--- a/src/agent/internal/platform/install/detached_run_windows.go
+++ b/src/agent/internal/platform/install/detached_run_windows.go
@@ -80,9 +80,14 @@ func scheduleWindowsTaskRunner(scriptPath string, userInstall bool, logFn func(s
 	if scriptPath == "" {
 		return fmt.Errorf("script path required")
 	}
-	taskName := "HyperFileLensAgent.DetachedRunner"
 	principal := scheduledTaskPrincipal(userInstall)
-	bootstrap := fmt.Sprintf(`$taskName = %s
+	userInstallFlag := "$false"
+	if userInstall {
+		userInstallFlag = "$true"
+	}
+	bootstrap := fmt.Sprintf(`$userInstall = %s
+$currentSid = [Security.Principal.WindowsIdentity]::GetCurrent().User.Value
+$taskName = if ($userInstall) { "HyperFileLensAgent.User.$currentSid.DetachedRunner" } else { 'HyperFileLensAgent.DetachedRunner' }
 $script = %s
 $actionArgs = "-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File " + [char]34 + $script + [char]34
 $action = New-ScheduledTaskAction -Execute 'powershell.exe' -Argument $actionArgs
@@ -90,7 +95,7 @@ $trigger = New-ScheduledTaskTrigger -Once -At (Get-Date).AddSeconds(5)
 %s
 $settings = New-ScheduledTaskSettingsSet -StartWhenAvailable -ExecutionTimeLimit ([TimeSpan]::Zero)
 Register-ScheduledTask -TaskName $taskName -Action $action -Trigger $trigger -Principal $principal -Settings $settings -Force | Out-Null
-`, psSingleQuote(taskName), psSingleQuote(scriptPath), principal)
+`, userInstallFlag, psSingleQuote(scriptPath), principal)
 	cmd := exec.Command(
 		"powershell.exe",
 		"-NoProfile",
@@ -106,7 +111,7 @@ Register-ScheduledTask -TaskName $taskName -Action $action -Trigger $trigger -Pr
 		return fmt.Errorf("register one-shot upgrade task: %w", err)
 	}
 	if logFn != nil {
-		logFn(fmt.Sprintf("registered one-shot Task Scheduler upgrade runner task=%s", taskName))
+		logFn("registered instance-scoped one-shot Task Scheduler lifecycle runner")
 	}
 	return nil
 }

--- a/src/agent/internal/platform/install/install_ps1_test.go
+++ b/src/agent/internal/platform/install/install_ps1_test.go
@@ -104,6 +104,48 @@ func TestInstallPs1UsesFullWindowsIdentityForCurrentUserTask(t *testing.T) {
 	}
 }
 
+func TestWindowsUserLifecycleIsScopedToTheCurrentInstallation(t *testing.T) {
+	installScript := readPackagingInstallScript(t)
+	for _, want := range []string{
+		`$CurrentWindowsSid = [Security.Principal.WindowsIdentity]::GetCurrent().User.Value`,
+		`"HyperFileLensAgent.User.$CurrentWindowsSid"`,
+		`[System.IO.Path]::GetFullPath($AgentRoot)`,
+	} {
+		if !strings.Contains(installScript, want) {
+			t.Fatalf("install.ps1 missing instance isolation contract %q", want)
+		}
+	}
+	for _, name := range []string{
+		"detached_run_windows.go",
+		"local_upgrade_windows.go",
+		"local_uninstall_windows.go",
+	} {
+		source := readInstallPackageSource(t, name)
+		if !strings.Contains(source, "HyperFileLensAgent.User.$currentSid") {
+			t.Fatalf("%s does not use a SID-scoped lifecycle task", name)
+		}
+		if strings.Contains(source, "Stop-Process -Name") {
+			t.Fatalf("%s contains a machine-global process-name stop", name)
+		}
+	}
+	if strings.Contains(installScript, "Stop-Process -Name") {
+		t.Fatal("install.ps1 contains a machine-global process-name stop")
+	}
+}
+
+func readInstallPackageSource(t *testing.T, name string) string {
+	t.Helper()
+	_, currentFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("resolve test source path")
+	}
+	data, err := os.ReadFile(filepath.Join(filepath.Dir(currentFile), name))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
+}
+
 func TestInstallPs1SupportsSpecifiedUserContinuousTask(t *testing.T) {
 	source := readPackagingInstallScript(t)
 	for _, want := range []string{

--- a/src/agent/internal/platform/install/local_uninstall_windows.go
+++ b/src/agent/internal/platform/install/local_uninstall_windows.go
@@ -107,7 +107,9 @@ $install = %q
 $data = %q
 $keep = %s
 $userInstall = %s
-$scheduledTaskName = 'HyperFileLensAgent.DetachedRunner'
+$currentSid = [Security.Principal.WindowsIdentity]::GetCurrent().User.Value
+$runtimeTaskName = if ($userInstall) { "HyperFileLensAgent.User.$currentSid" } else { 'HyperFileLensAgent' }
+$scheduledTaskName = if ($userInstall) { "$runtimeTaskName.DetachedRunner" } else { 'HyperFileLensAgent.DetachedRunner' }
 $SLEEP_SECONDS = %d
 $callbackUrl = %q
 $callbackToken = %q
@@ -192,12 +194,21 @@ function Start-DeferredRemove([string]$target) {
 function Stop-HflProcessesForUninstall {
   Log "stopping HyperFileLensAgent lifecycle and child processes (pre-uninstall)"
   if ($userInstall) {
-    Stop-ScheduledTask -TaskName HyperFileLensAgent -ErrorAction SilentlyContinue
+    Stop-ScheduledTask -TaskName $runtimeTaskName -ErrorAction SilentlyContinue
   } else {
     Stop-Service -Name HyperFileLensAgent -Force -ErrorAction SilentlyContinue
   }
-  foreach ($procName in @('hfl-agent', 'kopia')) {
-    Stop-Process -Name $procName -Force -ErrorAction SilentlyContinue
+  $agentRoot = $install
+  foreach ($procName in @('hfl-agent', 'hfl-agent-user-launcher', 'kopia')) {
+    Get-Process -Name $procName -ErrorAction SilentlyContinue | Where-Object {
+      try {
+        $_.Path -and [System.IO.Path]::GetFullPath($_.Path).StartsWith(
+          [System.IO.Path]::GetFullPath($agentRoot).TrimEnd('\') + '\',
+          [System.StringComparison]::OrdinalIgnoreCase
+        )
+      }
+      catch { $false }
+    } | Stop-Process -Force -ErrorAction SilentlyContinue
   }
   Start-Sleep -Seconds 3
 }
@@ -237,7 +248,7 @@ function Confirm-UninstallArtifacts {
   Start-Sleep -Seconds 6
   $issues = @()
   if ($userInstall) {
-    if ($null -ne (Get-ScheduledTask -TaskName HyperFileLensAgent -ErrorAction SilentlyContinue)) {
+    if ($null -ne (Get-ScheduledTask -TaskName $runtimeTaskName -ErrorAction SilentlyContinue)) {
       $issues += "HyperFileLensAgent current-user task is still registered"
     }
   } elseif ($null -ne (Get-Service -Name HyperFileLensAgent -ErrorAction SilentlyContinue)) {
@@ -427,7 +438,7 @@ try {
     } else {
       Log "install.cmd and install.ps1 missing; running fallback cleanup"
       if ($userInstall) {
-        Unregister-ScheduledTask -TaskName HyperFileLensAgent -Confirm:$false -ErrorAction SilentlyContinue
+        Unregister-ScheduledTask -TaskName $runtimeTaskName -Confirm:$false -ErrorAction SilentlyContinue
       } else {
         sc.exe delete HyperFileLensAgent 2>$null | Out-Null
       }

--- a/src/agent/internal/platform/install/local_uninstall_windows_test.go
+++ b/src/agent/internal/platform/install/local_uninstall_windows_test.go
@@ -228,9 +228,12 @@ func TestWriteWindowsUserUninstallScriptUsesCurrentUserLifecycle(t *testing.T) {
 	for _, want := range []string{
 		`$userInstall = $true`,
 		`$env:HFL_INSTALLATION_MODE = if ($userInstall) { 'user' } else { 'system' }`,
-		`Stop-ScheduledTask -TaskName HyperFileLensAgent`,
-		`Get-ScheduledTask -TaskName HyperFileLensAgent`,
-		`Unregister-ScheduledTask -TaskName HyperFileLensAgent`,
+		`$runtimeTaskName = if ($userInstall) { "HyperFileLensAgent.User.$currentSid" }`,
+		`Stop-ScheduledTask -TaskName $runtimeTaskName`,
+		`$agentRoot = $install`,
+		`@('hfl-agent', 'hfl-agent-user-launcher', 'kopia')`,
+		`Get-ScheduledTask -TaskName $runtimeTaskName`,
+		`Unregister-ScheduledTask -TaskName $runtimeTaskName`,
 		`Join-Path $env:LOCALAPPDATA 'HyperFileLens\Agent'`,
 		`return $full.Equals($expected, [System.StringComparison]::OrdinalIgnoreCase)`,
 	} {
@@ -261,8 +264,10 @@ func TestWriteWindowsUserUpgradeScriptStopsScheduledTask(t *testing.T) {
 	text := string(body)
 	for _, expected := range []string{
 		"$userInstall = $true",
-		"Stop-ScheduledTask -TaskName HyperFileLensAgent",
-		"$scheduledTaskName = 'HyperFileLensAgent.DetachedRunner'",
+		"$runtimeTaskName = if ($userInstall) { \"HyperFileLensAgent.User.$currentSid\" }",
+		"Stop-ScheduledTask -TaskName $runtimeTaskName",
+		"$agentRoot = Split-Path -Parent $install",
+		"$scheduledTaskName = if ($userInstall) { \"$runtimeTaskName.DetachedRunner\" }",
 		"Unregister-ScheduledTask -TaskName $scheduledTaskName",
 	} {
 		if !strings.Contains(text, expected) {

--- a/src/agent/internal/platform/install/local_upgrade_windows.go
+++ b/src/agent/internal/platform/install/local_upgrade_windows.go
@@ -74,8 +74,10 @@ func writeWindowsUpgradeScript(
 $install = %q
 $archive = %q
 $pending = %q
-$scheduledTaskName = 'HyperFileLensAgent.DetachedRunner'
 $userInstall = %s
+$currentSid = [Security.Principal.WindowsIdentity]::GetCurrent().User.Value
+$runtimeTaskName = if ($userInstall) { "HyperFileLensAgent.User.$currentSid" } else { 'HyperFileLensAgent' }
+$scheduledTaskName = if ($userInstall) { "$runtimeTaskName.DetachedRunner" } else { 'HyperFileLensAgent.DetachedRunner' }
 $SLEEP_SECONDS = %d
 
 New-Item -ItemType Directory -Force -Path (Split-Path -Parent $logFile) | Out-Null
@@ -101,11 +103,22 @@ try {
 
   Log "stopping HyperFileLensAgent before install.ps1 upgrade"
   if ($userInstall) {
-    Stop-ScheduledTask -TaskName HyperFileLensAgent -ErrorAction SilentlyContinue
+    Stop-ScheduledTask -TaskName $runtimeTaskName -ErrorAction SilentlyContinue
   } else {
     Stop-Service -Name HyperFileLensAgent -Force -ErrorAction SilentlyContinue
   }
-  Stop-Process -Name hfl-agent -Force -ErrorAction SilentlyContinue
+  # $install is the full path to install.ps1. Match only processes whose
+  # executable lives below this installation's Agent Root.
+  $agentRoot = Split-Path -Parent $install
+  Get-Process -Name hfl-agent -ErrorAction SilentlyContinue | Where-Object {
+    try {
+      $_.Path -and [System.IO.Path]::GetFullPath($_.Path).StartsWith(
+        [System.IO.Path]::GetFullPath($agentRoot).TrimEnd('\') + '\',
+        [System.StringComparison]::OrdinalIgnoreCase
+      )
+    }
+    catch { $false }
+  } | Stop-Process -Force -ErrorAction SilentlyContinue
   Start-Sleep -Seconds 2
 
   Log "running install.ps1 upgrade"

--- a/src/agent/internal/remote/register_test.go
+++ b/src/agent/internal/remote/register_test.go
@@ -77,6 +77,10 @@ func TestHTTPRegisterNodeIncludesPlatformInventory(t *testing.T) {
 	if !ok {
 		t.Fatalf("metadata=%T", payload["metadata"])
 	}
+	principal, ok := metadata["runtime_principal"].(map[string]any)
+	if !ok || principal["id"] == "" || principal["name"] == "" {
+		t.Errorf("runtime_principal=%v", metadata["runtime_principal"])
+	}
 	inventory, ok := metadata["inventory"].(map[string]any)
 	if !ok {
 		t.Fatalf("inventory=%T", metadata["inventory"])

--- a/src/agent/packaging/install/install.ps1
+++ b/src/agent/packaging/install/install.ps1
@@ -90,9 +90,13 @@ $LifecycleRoot = Join-Path $AgentRoot "lifecycle"
 $BackupRoot = Join-Path $AgentRoot "backup"
 $InstalledVersionFile = Join-Path $AgentRoot "INSTALLED_VERSION"
 $ManifestFile = Join-Path $AgentRoot "MANIFEST.json"
-$TaskName = "HyperFileLensAgent"
 $LifecycleLabel = if ($InstallationMode -eq "user") { "current-user task" } elseif ($InstallationMode -eq "account") { "specified-user task" } else { "Windows service" }
 $CurrentWindowsIdentity = [Security.Principal.WindowsIdentity]::GetCurrent().Name
+$CurrentWindowsSid = [Security.Principal.WindowsIdentity]::GetCurrent().User.Value
+# User installations have independent roots and must also have independent
+# scheduler identities. The machine-slot account task keeps its compatibility
+# name because account and system installations are mutually exclusive.
+$TaskName = if ($InstallationMode -eq "user") { "HyperFileLensAgent.User.$CurrentWindowsSid" } else { "HyperFileLensAgent" }
 $script:LegacyMigrationRoot = ""
 $script:LegacyServiceWasRunning = $false
 if ([string]::IsNullOrWhiteSpace($RunAsUser) -and $env:HFL_RUN_AS_USER) {
@@ -1119,14 +1123,33 @@ function Stop-HflAgentProcesses {
   foreach ($name in @("hfl-agent", "hfl-agent-user-launcher", "kopia")) {
     $deadline = (Get-Date).AddSeconds(20)
     while ((Get-Date) -lt $deadline) {
-      $procs = @(Get-Process -Name $name -ErrorAction SilentlyContinue)
+      $procs = @(Get-Process -Name $name -ErrorAction SilentlyContinue | Where-Object {
+        try {
+          $path = $_.Path
+          -not [string]::IsNullOrWhiteSpace($path) -and
+            [System.IO.Path]::GetFullPath($path).StartsWith(
+              [System.IO.Path]::GetFullPath($AgentRoot).TrimEnd('\') + '\',
+              [System.StringComparison]::OrdinalIgnoreCase
+            )
+        }
+        catch { $false }
+      })
       if ($procs.Count -eq 0) { break }
       foreach ($proc in $procs) {
         Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue
       }
       Start-Sleep -Milliseconds 500
     }
-    if (Get-Process -Name $name -ErrorAction SilentlyContinue) {
+    $remaining = @(Get-Process -Name $name -ErrorAction SilentlyContinue | Where-Object {
+      try {
+        $_.Path -and [System.IO.Path]::GetFullPath($_.Path).StartsWith(
+          [System.IO.Path]::GetFullPath($AgentRoot).TrimEnd('\') + '\',
+          [System.StringComparison]::OrdinalIgnoreCase
+        )
+      }
+      catch { $false }
+    })
+    if ($remaining.Count -gt 0) {
       Write-HflWarn "process $name still running after stop attempts ($Reason)"
     }
     else {
@@ -1137,9 +1160,17 @@ function Stop-HflAgentProcesses {
 
 function Stop-AgentForUpgrade {
   Stop-HflService
-  $proc = Get-Process -Name "hfl-agent" -ErrorAction SilentlyContinue
-  if ($null -ne $proc) {
-    Stop-Process -Name "hfl-agent" -Force -ErrorAction SilentlyContinue
+  $procs = @(Get-Process -Name "hfl-agent" -ErrorAction SilentlyContinue | Where-Object {
+    try {
+      $_.Path -and [System.IO.Path]::GetFullPath($_.Path).StartsWith(
+        [System.IO.Path]::GetFullPath($AgentRoot).TrimEnd('\') + '\',
+        [System.StringComparison]::OrdinalIgnoreCase
+      )
+    }
+    catch { $false }
+  })
+  if ($procs.Count -gt 0) {
+    $procs | Stop-Process -Force -ErrorAction SilentlyContinue
     Start-Sleep -Seconds 2
     Write-HflOk "stopped hfl-agent process (pre-upgrade)"
   }

--- a/src/backend/apps/node/admin.py
+++ b/src/backend/apps/node/admin.py
@@ -43,17 +43,34 @@ class NodeTokenAdmin(admin.ModelAdmin):
         "organization",
         "role",
         "installation_mode",
+        "installation_mode_policy",
+        "target_platform",
         "is_active",
         "note",
         "created_at",
         "expires_at",
         "used_at",
     )
-    list_filter = ("role", "installation_mode", "is_active", "organization")
+    list_filter = (
+        "role",
+        "installation_mode",
+        "installation_mode_policy",
+        "target_platform",
+        "is_active",
+        "organization",
+    )
     search_fields = ("token", "note", "organization__key")
     ordering = ("-created_at", "-id")
 
     def get_readonly_fields(self, request, obj=None):
         if obj is None:
             return ()
-        return ("organization", "token", "role", "installation_mode", "expires_at")
+        return (
+            "organization",
+            "token",
+            "role",
+            "installation_mode",
+            "installation_mode_policy",
+            "target_platform",
+            "expires_at",
+        )

--- a/src/backend/apps/node/api/serializers/node_token.py
+++ b/src/backend/apps/node/api/serializers/node_token.py
@@ -23,6 +23,8 @@ class NodeTokenSerializer(serializers.ModelSerializer):
             "token",
             "role",
             "installation_mode",
+            "installation_mode_policy",
+            "target_platform",
             "note",
             "is_active",
             "created_at",
@@ -41,6 +43,8 @@ class NodeTokenSerializer(serializers.ModelSerializer):
             "token",
             "role",
             "installation_mode",
+            "installation_mode_policy",
+            "target_platform",
             "created_at",
             "updated_at",
             "expires_at",
@@ -78,6 +82,8 @@ class NodeTokenCreateSerializer(serializers.ModelSerializer):
             "org",
             "role",
             "installation_mode",
+            "installation_mode_policy",
+            "target_platform",
             "note",
             "expires_at",
             "is_active",
@@ -102,11 +108,53 @@ class NodeTokenCreateSerializer(serializers.ModelSerializer):
             "installation_mode",
             NodeInstallationMode.SYSTEM,
         )
-        if installation_mode in (
-            NodeInstallationMode.USER,
-            NodeInstallationMode.USER_CONTINUOUS,
-            NodeInstallationMode.ACCOUNT,
-        ) and role != Node.Role.AGENT:
+        policy = attrs.get(
+            "installation_mode_policy",
+            NodeToken.InstallationModePolicy.FIXED,
+        )
+        target_platform = attrs.get("target_platform", "")
+        if policy == NodeToken.InstallationModePolicy.AUTO:
+            if role != Node.Role.AGENT:
+                raise serializers.ValidationError(
+                    {
+                        "installation_mode_policy": (
+                            "Automatic installation mode is only available for Source Agent."
+                        )
+                    }
+                )
+            if target_platform not in NodeToken.TargetPlatform.values:
+                raise serializers.ValidationError(
+                    {
+                        "target_platform": (
+                            "A supported target platform is required for automatic installation mode."
+                        )
+                    }
+                )
+            if "installation_mode" in attrs:
+                raise serializers.ValidationError(
+                    {
+                        "installation_mode": (
+                            "Do not provide a fixed installation mode with automatic selection."
+                        )
+                    }
+                )
+        elif target_platform:
+            raise serializers.ValidationError(
+                {
+                    "target_platform": (
+                        "Target platform is only valid with automatic installation mode."
+                    )
+                }
+            )
+        if (
+            installation_mode
+            in (
+                NodeInstallationMode.USER,
+                NodeInstallationMode.USER_CONTINUOUS,
+                NodeInstallationMode.ACCOUNT,
+            )
+            and role != Node.Role.AGENT
+        ):
             raise serializers.ValidationError(
                 {
                     "installation_mode": (

--- a/src/backend/apps/node/api/views/artifact_release.py
+++ b/src/backend/apps/node/api/views/artifact_release.py
@@ -83,6 +83,21 @@ def _normalize_arch(value: str | None) -> str | None:
     return None
 
 
+def _automatic_token_allows_artifact_platform(
+    token: NodeToken,
+    platform: str | None,
+) -> bool:
+    """Keep automatic enrollment artifacts bound to the selected OS."""
+    if token.installation_mode_policy != NodeToken.InstallationModePolicy.AUTO:
+        return True
+    expected = {
+        NodeToken.TargetPlatform.LINUX: "linux",
+        NodeToken.TargetPlatform.WINDOWS: "windows",
+        NodeToken.TargetPlatform.MACOS: "darwin",
+    }.get(token.target_platform)
+    return bool(expected and platform == expected)
+
+
 def _get_agent_artifact(
     role: str,
     *,
@@ -425,6 +440,17 @@ class AgentReleaseView(APIView):
         )
         if authorization is None:
             return Response({"error": "invalid enrollment token"}, status=401)
+        if (
+            authorization.token is not None
+            and not _automatic_token_allows_artifact_platform(
+                authorization.token,
+                platform,
+            )
+        ):
+            return Response(
+                {"error": "platform does not match enrollment token"},
+                status=status.HTTP_409_CONFLICT,
+            )
 
         artifact = _get_agent_artifact(
             role,

--- a/src/backend/apps/node/api/views/bootstrap.py
+++ b/src/backend/apps/node/api/views/bootstrap.py
@@ -23,7 +23,7 @@ from apps.node.api.views.enrollment_helpers import (
     resolve_bootstrap_enrollment_token,
     token_usable_for_bootstrap,
 )
-from apps.node.models import Node
+from apps.node.models import Node, NodeToken
 from common.deploy.site import enrollment_tls_verify, tenant_public_url
 
 
@@ -137,8 +137,28 @@ def _parse_enrollment_query(
             )
         return Response({"error": "invalid enrollment token"}, status=401)
 
+    platform_by_script_type = {
+        "linux": NodeToken.TargetPlatform.LINUX,
+        "sh": NodeToken.TargetPlatform.LINUX,
+        "darwin": NodeToken.TargetPlatform.MACOS,
+        "macos": NodeToken.TargetPlatform.MACOS,
+        "windows": NodeToken.TargetPlatform.WINDOWS,
+        "windows_ps1": NodeToken.TargetPlatform.WINDOWS,
+        "ps1": NodeToken.TargetPlatform.WINDOWS,
+    }
+    requested_platform = platform_by_script_type.get(script_type)
+    if (
+        token_row.installation_mode_policy == NodeToken.InstallationModePolicy.AUTO
+        and requested_platform != token_row.target_platform
+    ):
+        return _bootstrap_error_response(
+            script_type,
+            "This enrollment link was issued for a different operating system",
+        )
+
     if (
         token_row.installation_mode == Node.InstallationMode.USER_CONTINUOUS
+        and token_row.installation_mode_policy == NodeToken.InstallationModePolicy.FIXED
         and script_type not in ("linux", "sh")
     ):
         return _bootstrap_error_response(
@@ -146,7 +166,12 @@ def _parse_enrollment_query(
             "Linux user-continuous protection requires the Linux installer",
         )
 
-    return org_key, role, token, api_base, token_row.installation_mode
+    installation_mode = (
+        "auto"
+        if token_row.installation_mode_policy == NodeToken.InstallationModePolicy.AUTO
+        else token_row.installation_mode
+    )
+    return org_key, role, token, api_base, installation_mode
 
 
 def _template_values(

--- a/src/backend/apps/node/api/views/node.py
+++ b/src/backend/apps/node/api/views/node.py
@@ -40,7 +40,9 @@ from apps.node.services.internal.node_lifecycle import (
 )
 from apps.node.services.internal.node_naming import (
     is_auto_assigned_node_name,
+    is_automatic_user_node_name,
     resolve_registration_node_name,
+    runtime_principal_name,
     uniquify_node_name,
 )
 from apps.node.services.internal.network_inventory import split_network_from_metadata
@@ -64,6 +66,70 @@ from apps.node.services.internal.enrollment_auth import (
 from apps.source.services.internal.agent_host_sync import sync_agent_source_host
 
 logger = logging.getLogger(__name__)
+
+
+def _reported_platform(payload: dict) -> str:
+    """Return the bounded platform family reported by the enrollment client."""
+
+    def normalize(value: object) -> str:
+        platform = str(value or "").strip().lower()
+        if platform == "darwin":
+            return NodeToken.TargetPlatform.MACOS
+        if platform in NodeToken.TargetPlatform.values:
+            return platform
+        return ""
+
+    metadata = payload.get("metadata")
+    if isinstance(metadata, dict):
+        platform = normalize(metadata.get("platform"))
+        if platform:
+            return platform
+        inventory = metadata.get("inventory")
+        if isinstance(inventory, dict):
+            platform = normalize(inventory.get("os_family"))
+            if platform:
+                return platform
+    os_name = str(payload.get("os_name") or "").strip().lower()
+    if "windows" in os_name:
+        return NodeToken.TargetPlatform.WINDOWS
+    if "darwin" in os_name or "macos" in os_name or "mac os" in os_name:
+        return NodeToken.TargetPlatform.MACOS
+    if "linux" in os_name:
+        return NodeToken.TargetPlatform.LINUX
+    return ""
+
+
+def _token_authorizes_installation_mode(
+    token: NodeToken,
+    mode: str,
+    *,
+    reported_platform: str = "",
+) -> bool:
+    """Validate the final local mode without treating ``auto`` as a Node mode."""
+    if token.installation_mode_policy == NodeToken.InstallationModePolicy.FIXED:
+        return mode == token.installation_mode
+    if token.installation_mode_policy != NodeToken.InstallationModePolicy.AUTO:
+        return False
+    if reported_platform != token.target_platform:
+        return False
+    allowed_by_platform = {
+        NodeToken.TargetPlatform.LINUX: {
+            Node.InstallationMode.USER_CONTINUOUS,
+            Node.InstallationMode.SYSTEM,
+        },
+        NodeToken.TargetPlatform.WINDOWS: {
+            Node.InstallationMode.USER,
+            Node.InstallationMode.SYSTEM,
+        },
+        NodeToken.TargetPlatform.MACOS: {
+            Node.InstallationMode.USER,
+            Node.InstallationMode.SYSTEM,
+        },
+    }
+    return token.role == Node.Role.AGENT and mode in allowed_by_platform.get(
+        token.target_platform,
+        set(),
+    )
 
 
 def health(_request):
@@ -433,7 +499,13 @@ class NodeViewSet(OrgScopedMixin, SoftDeleteDestroyMixin, viewsets.ModelViewSet)
                     status=status.HTTP_401_UNAUTHORIZED,
                 )
             token_row = authorization.token
-            if payload["installation_mode"] != token_row.installation_mode:
+            resolved_installation_mode = payload["installation_mode"]
+            reported_platform = _reported_platform(payload)
+            if not _token_authorizes_installation_mode(
+                token_row,
+                resolved_installation_mode,
+                reported_platform=reported_platform,
+            ):
                 return Response(
                     {"error": "installation mode does not match enrollment token"},
                     status=status.HTTP_409_CONFLICT,
@@ -450,6 +522,15 @@ class NodeViewSet(OrgScopedMixin, SoftDeleteDestroyMixin, viewsets.ModelViewSet)
                     session=session,
                 )
                 token_row = locked_token
+                if not _token_authorizes_installation_mode(
+                    token_row,
+                    resolved_installation_mode,
+                    reported_platform=reported_platform,
+                ):
+                    return Response(
+                        {"error": "installation mode authorization changed"},
+                        status=status.HTTP_409_CONFLICT,
+                    )
                 if session is not None:
                     locked_session = (
                         NodeInstallationSession.objects.select_for_update().get(
@@ -499,7 +580,7 @@ class NodeViewSet(OrgScopedMixin, SoftDeleteDestroyMixin, viewsets.ModelViewSet)
                     )
                 if (
                     node is not None
-                    and node.installation_mode != token_row.installation_mode
+                    and node.installation_mode != resolved_installation_mode
                 ):
                     return Response(
                         {"error": "installation mode is fixed during enrollment"},
@@ -523,7 +604,7 @@ class NodeViewSet(OrgScopedMixin, SoftDeleteDestroyMixin, viewsets.ModelViewSet)
                                     ),
                                 ),
                                 role=payload["role"],
-                                installation_mode=token_row.installation_mode,
+                                installation_mode=resolved_installation_mode,
                                 version=payload.get("version", ""),
                                 os_name=payload.get("os_name", ""),
                                 availability_updated_at=observed_at,
@@ -552,7 +633,7 @@ class NodeViewSet(OrgScopedMixin, SoftDeleteDestroyMixin, viewsets.ModelViewSet)
                         )
                         if node is None:
                             raise
-                        if node.installation_mode != token_row.installation_mode:
+                        if node.installation_mode != resolved_installation_mode:
                             return Response(
                                 {
                                     "error": (
@@ -643,7 +724,35 @@ class NodeViewSet(OrgScopedMixin, SoftDeleteDestroyMixin, viewsets.ModelViewSet)
                 if not identity_in_use:
                     node.installation_id = installation_id
             node.last_seen_at = observed_at
-            if is_auto_assigned_node_name(node.name):
+            if node.installation_mode in (
+                Node.InstallationMode.USER,
+                Node.InstallationMode.USER_CONTINUOUS,
+            ):
+                # User-scoped instances are identified by the runtime
+                # principal. Do not let the ordinary hostname in a heartbeat
+                # erase the account suffix after reconnecting, but preserve a
+                # display name that a console user explicitly assigned.
+                principal = runtime_principal_name(metadata_payload)
+                if principal and (
+                    is_automatic_user_node_name(
+                        name=node.name,
+                        metadata=node.metadata,
+                        node_id=node.id,
+                    )
+                    or is_automatic_user_node_name(
+                        name=node.name,
+                        metadata=metadata_payload,
+                        node_id=node.id,
+                    )
+                ):
+                    next_name = uniquify_node_name(
+                        organization_id=org.id,
+                        name=resolve_registration_node_name(payload=payload),
+                        exclude_node_id=node.id,
+                    )
+                    if next_name != node.name:
+                        node.name = next_name
+            elif is_auto_assigned_node_name(node.name):
                 next_name = resolve_registration_node_name(
                     payload=payload,
                     fallback=node.name,

--- a/src/backend/apps/node/migrations/0019_nodetoken_automatic_installation_mode.py
+++ b/src/backend/apps/node/migrations/0019_nodetoken_automatic_installation_mode.py
@@ -1,0 +1,54 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [("node", "0018_add_user_continuous_mode")]
+
+    operations = [
+        migrations.AddField(
+            model_name="nodetoken",
+            name="installation_mode_policy",
+            field=models.CharField(
+                choices=[("fixed", "Fixed"), ("auto", "Automatic")],
+                db_index=True,
+                default="fixed",
+                help_text=(
+                    "Fixed authorizes installation_mode. Automatic authorizes the "
+                    "platform-specific mode selected from the install process identity."
+                ),
+                max_length=16,
+            ),
+        ),
+        migrations.AddField(
+            model_name="nodetoken",
+            name="target_platform",
+            field=models.CharField(
+                blank=True,
+                choices=[
+                    ("linux", "Linux"),
+                    ("windows", "Windows"),
+                    ("macos", "macOS"),
+                ],
+                default="",
+                help_text="Operating system bound to an automatic source-Agent token.",
+                max_length=16,
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name="nodetoken",
+            constraint=models.CheckConstraint(
+                condition=(
+                    models.Q(
+                        installation_mode_policy="fixed",
+                        target_platform="",
+                    )
+                    | models.Q(
+                        installation_mode_policy="auto",
+                        role="agent",
+                        target_platform__in=["linux", "windows", "macos"],
+                    )
+                ),
+                name="node_token_auto_mode_platform",
+            ),
+        ),
+    ]

--- a/src/backend/apps/node/models/node_token.py
+++ b/src/backend/apps/node/models/node_token.py
@@ -18,6 +18,15 @@ class NodeToken(OrganizationScopedModel):
         LEGACY = "legacy", "Legacy"
         CURRENT = "current", "Current"
 
+    class InstallationModePolicy(models.TextChoices):
+        FIXED = "fixed", "Fixed"
+        AUTO = "auto", "Automatic"
+
+    class TargetPlatform(models.TextChoices):
+        LINUX = "linux", "Linux"
+        WINDOWS = "windows", "Windows"
+        MACOS = "macos", "macOS"
+
     organization = models.ForeignKey(
         "iam.Organization",
         on_delete=models.CASCADE,
@@ -31,6 +40,23 @@ class NodeToken(OrganizationScopedModel):
         default=NodeInstallationMode.SYSTEM,
         db_index=True,
         help_text="Installation and runtime mode authorized by this token.",
+    )
+    installation_mode_policy = models.CharField(
+        max_length=16,
+        choices=InstallationModePolicy.choices,
+        default=InstallationModePolicy.FIXED,
+        db_index=True,
+        help_text=(
+            "Fixed authorizes installation_mode. Automatic authorizes the "
+            "platform-specific mode selected from the install process identity."
+        ),
+    )
+    target_platform = models.CharField(
+        max_length=16,
+        choices=TargetPlatform.choices,
+        blank=True,
+        default="",
+        help_text="Operating system bound to an automatic source-Agent token.",
     )
     note = models.CharField(max_length=200, blank=True, default="")
     is_active = models.BooleanField(default=True, db_index=True)
@@ -67,6 +93,20 @@ class NodeToken(OrganizationScopedModel):
                     | models.Q(role=NodeRole.AGENT)
                 ),
                 name="node_token_user_mode_agent_only",
+            ),
+            models.CheckConstraint(
+                condition=(
+                    models.Q(
+                        installation_mode_policy="fixed",
+                        target_platform="",
+                    )
+                    | models.Q(
+                        installation_mode_policy="auto",
+                        role=NodeRole.AGENT,
+                        target_platform__in=("linux", "windows", "macos"),
+                    )
+                ),
+                name="node_token_auto_mode_platform",
             ),
         ]
 

--- a/src/backend/apps/node/services/internal/node_naming.py
+++ b/src/backend/apps/node/services/internal/node_naming.py
@@ -7,6 +7,14 @@ from typing import Any
 from apps.node.models import Node
 
 _AUTO_NODE_NAMES = frozenset({"", "new-node", "node", "new node"})
+_NODE_NAME_MAX_LENGTH = Node._meta.get_field("name").max_length
+
+
+def _bounded_node_name(value: str, *, suffix: str = "") -> str:
+    value = str(value or "").strip()
+    suffix = str(suffix or "")
+    available = max(0, _NODE_NAME_MAX_LENGTH - len(suffix))
+    return f"{value[:available].rstrip()}{suffix}"
 
 
 def hostname_from_metadata(metadata: dict[str, Any] | None) -> str:
@@ -24,20 +32,66 @@ def hostname_from_metadata(metadata: dict[str, Any] | None) -> str:
     return ""
 
 
+def runtime_principal_name(metadata: dict[str, Any] | None) -> str:
+    if not isinstance(metadata, dict):
+        return ""
+    principal = metadata.get("runtime_principal")
+    if not isinstance(principal, dict):
+        return ""
+    return str(principal.get("name") or "").strip()
+
+
 def is_auto_assigned_node_name(name: str | None) -> bool:
     return str(name or "").strip().lower() in _AUTO_NODE_NAMES
 
 
-def resolve_registration_node_name(*, payload: dict[str, Any], fallback: str = "new-node") -> str:
+def is_automatic_user_node_name(
+    *,
+    name: str | None,
+    metadata: dict[str, Any] | None,
+    node_id: int | None = None,
+) -> bool:
+    """Return whether a user Agent still has a generated display name."""
+    current = str(name or "").strip()
+    if is_auto_assigned_node_name(current):
+        return True
+
+    hostname = hostname_from_metadata(metadata)
+    if not hostname:
+        return False
+    candidates = {_bounded_node_name(hostname)}
+    principal = runtime_principal_name(metadata)
+    if principal:
+        generated = _bounded_node_name(f"{hostname} · {principal}")
+        candidates.add(generated)
+        if node_id is not None:
+            candidates.add(_bounded_node_name(generated, suffix=f"-{node_id}"))
+    return current in candidates
+
+
+def resolve_registration_node_name(
+    *, payload: dict[str, Any], fallback: str = "new-node"
+) -> str:
     """Prefer hostname from registration metadata over placeholder names."""
     meta = payload.get("metadata") if isinstance(payload.get("metadata"), dict) else {}
     hostname = hostname_from_metadata(meta)
+    installation_mode = str(payload.get("installation_mode") or "").strip()
+    principal = runtime_principal_name(meta)
     explicit = str(payload.get("name") or "").strip()
     if hostname:
-        return hostname
+        if (
+            installation_mode
+            in (
+                Node.InstallationMode.USER,
+                Node.InstallationMode.USER_CONTINUOUS,
+            )
+            and principal
+        ):
+            return _bounded_node_name(f"{hostname} · {principal}")
+        return _bounded_node_name(hostname)
     if explicit and not is_auto_assigned_node_name(explicit):
-        return explicit
-    return explicit or fallback
+        return _bounded_node_name(explicit)
+    return _bounded_node_name(explicit or fallback)
 
 
 def resolve_inventory_node_name(*, node: Node, inventory: dict[str, Any]) -> str | None:
@@ -56,6 +110,7 @@ def uniquify_node_name(
     name: str,
     exclude_node_id: int | None = None,
 ) -> str:
+    name = _bounded_node_name(name)
     qs = Node.objects.filter(
         organization_id=organization_id,
         name=name,
@@ -66,5 +121,5 @@ def uniquify_node_name(
     if not qs.exists():
         return name
     if exclude_node_id is not None:
-        return f"{name}-{exclude_node_id}"
+        return _bounded_node_name(name, suffix=f"-{exclude_node_id}")
     return name

--- a/src/backend/apps/node/tests/test_bootstrap.py
+++ b/src/backend/apps/node/tests/test_bootstrap.py
@@ -75,6 +75,34 @@ class BootstrapViewTests(TestCase):
 
         self.assertEqual(values["HFL_INSTALLATION_MODE"], "user")
 
+    def test_automatic_bootstrap_defers_mode_to_local_process_identity(self):
+        self.token_row.installation_mode_policy = NodeToken.InstallationModePolicy.AUTO
+        self.token_row.target_platform = NodeToken.TargetPlatform.LINUX
+        self.token_row.save(
+            update_fields=["installation_mode_policy", "target_platform"]
+        )
+
+        response = self._get("linux")
+
+        self.assertEqual(response.status_code, 200)
+        body = response.content.decode("utf-8")
+        self.assertIn('HFL_INSTALLATION_MODE="auto"', body)
+
+    def test_automatic_bootstrap_rejects_a_different_operating_system(self):
+        self.token_row.installation_mode_policy = NodeToken.InstallationModePolicy.AUTO
+        self.token_row.target_platform = NodeToken.TargetPlatform.LINUX
+        self.token_row.save(
+            update_fields=["installation_mode_policy", "target_platform"]
+        )
+
+        response = self._get("windows")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(
+            "issued for a different operating system",
+            response.content.decode("utf-8"),
+        )
+
     @override_settings(
         HFL_INSECURE_TLS=False,
         FRONTEND_URL="https://console.example",
@@ -112,7 +140,9 @@ class BootstrapViewTests(TestCase):
 
         self.assertEqual(response.status_code, 200)
         body = response.content.decode("utf-8")
-        self.assertIn("Linux user-continuous protection requires the Linux installer", body)
+        self.assertIn(
+            "Linux user-continuous protection requires the Linux installer", body
+        )
 
     @override_settings(
         HFL_INSECURE_TLS=False,

--- a/src/backend/apps/node/tests/test_enrollment_token_reuse.py
+++ b/src/backend/apps/node/tests/test_enrollment_token_reuse.py
@@ -18,6 +18,7 @@ from apps.node.api.views.artifact_release import (
     AgentArtifact,
     AgentReleasesAuthView,
     AgentReleaseView,
+    _automatic_token_allows_artifact_platform,
     _load_release_token,
 )
 from apps.node.api.views.enrollment_helpers import token_usable_for_artifact_download
@@ -45,21 +46,35 @@ class EnrollmentTokenReuseTests(TestCase):
         installation_id: str = "",
         installation_mode: str = NodeInstallationMode.SYSTEM,
         host_fingerprint: str = "",
+        platform: str = "linux",
+        node_id: int | None = None,
+        node_credential: str = "",
     ):
+        payload = {
+            "role": "agent",
+            "name": name,
+            "version": "1.0.0",
+            "os_name": platform,
+            "metadata": {
+                "platform": platform,
+                "hostname": name,
+                "runtime_principal": {
+                    "id": "1001",
+                    "name": "backup-user",
+                },
+            },
+            "installation_id": installation_id,
+            "installation_mode": installation_mode,
+            "host_fingerprint": host_fingerprint,
+        }
+        if node_id is not None:
+            payload["node_id"] = node_id
         request = self.factory.post(
             "/api/v1/node/nodes/heartbeat/",
-            {
-                "role": "agent",
-                "name": name,
-                "version": "1.0.0",
-                "os_name": "linux",
-                "installation_id": installation_id,
-                "installation_mode": installation_mode,
-                "host_fingerprint": host_fingerprint,
-            },
+            payload,
             format="json",
             HTTP_X_ORG_KEY=self.org.key,
-            HTTP_X_NODE_TOKEN=token or self.token_row.token,
+            HTTP_X_NODE_TOKEN=node_credential or token or self.token_row.token,
         )
         return NodeViewSet.as_view({"post": "heartbeat"})(request)
 
@@ -100,6 +115,54 @@ class EnrollmentTokenReuseTests(TestCase):
         self.assertEqual(nodes[1].installation_mode, NodeInstallationMode.USER)
         self.assertEqual(nodes[0].host_fingerprint, fingerprint)
         self.assertEqual(nodes[1].host_fingerprint, fingerprint)
+
+    def test_user_agent_name_keeps_runtime_principal_after_reconnect(self):
+        self.token_row.installation_mode = NodeInstallationMode.USER_CONTINUOUS
+        self.token_row.save(update_fields=["installation_mode"])
+        first = self._heartbeat(
+            name="host-a",
+            installation_id="hfli_user_reconnect",
+            installation_mode=NodeInstallationMode.USER_CONTINUOUS,
+        )
+        self.assertEqual(first.status_code, 200)
+        node = Node.objects.get(pk=first.data["node_id"])
+        self.assertEqual(node.name, "host-a · backup-user")
+
+        second = self._heartbeat(
+            name="host-a",
+            installation_id="hfli_user_reconnect",
+            installation_mode=NodeInstallationMode.USER_CONTINUOUS,
+            node_id=node.id,
+            node_credential=first.data["node_credential"],
+        )
+        self.assertEqual(second.status_code, 200)
+        node.refresh_from_db()
+        self.assertEqual(node.name, "host-a · backup-user")
+
+    def test_user_agent_reconnect_preserves_manual_display_name(self):
+        self.token_row.installation_mode = NodeInstallationMode.USER_CONTINUOUS
+        self.token_row.save(update_fields=["installation_mode"])
+        first = self._heartbeat(
+            name="host-a",
+            installation_id="hfli_user_custom_name",
+            installation_mode=NodeInstallationMode.USER_CONTINUOUS,
+        )
+        self.assertEqual(first.status_code, 200)
+        node = Node.objects.get(pk=first.data["node_id"])
+        node.name = "Finance files"
+        node.save(update_fields=["name", "updated_at"])
+
+        second = self._heartbeat(
+            name="host-a",
+            installation_id="hfli_user_custom_name",
+            installation_mode=NodeInstallationMode.USER_CONTINUOUS,
+            node_id=node.id,
+            node_credential=first.data["node_credential"],
+        )
+
+        self.assertEqual(second.status_code, 200)
+        node.refresh_from_db()
+        self.assertEqual(node.name, "Finance files")
 
     def test_offline_host_record_is_preserved_when_a_new_agent_is_installed(self):
         fingerprint = "c" * 64
@@ -245,6 +308,134 @@ class EnrollmentTokenReuseTests(TestCase):
         row = ser.save(organization=self.org)
 
         self.assertEqual(row.installation_mode, NodeInstallationMode.USER_CONTINUOUS)
+
+    def test_create_serializer_accepts_platform_bound_automatic_source_agent(self):
+        ser = NodeTokenCreateSerializer(
+            data={
+                "role": NodeRole.AGENT,
+                "installation_mode_policy": NodeToken.InstallationModePolicy.AUTO,
+                "target_platform": NodeToken.TargetPlatform.LINUX,
+            }
+        )
+        self.assertTrue(ser.is_valid(), ser.errors)
+
+        row = ser.save(organization=self.org)
+
+        self.assertEqual(
+            row.installation_mode_policy,
+            NodeToken.InstallationModePolicy.AUTO,
+        )
+        self.assertEqual(row.target_platform, NodeToken.TargetPlatform.LINUX)
+
+    def test_automatic_mode_requires_source_agent_and_target_platform(self):
+        for payload in (
+            {
+                "role": NodeRole.AGENT,
+                "installation_mode_policy": NodeToken.InstallationModePolicy.AUTO,
+            },
+            {
+                "role": NodeRole.PROXY,
+                "installation_mode_policy": NodeToken.InstallationModePolicy.AUTO,
+                "target_platform": NodeToken.TargetPlatform.LINUX,
+            },
+        ):
+            with self.subTest(payload=payload):
+                ser = NodeTokenCreateSerializer(data=payload)
+                self.assertFalse(ser.is_valid())
+
+    def test_automatic_token_persists_only_platform_authorized_final_modes(self):
+        allowed_by_platform = {
+            NodeToken.TargetPlatform.LINUX: (
+                NodeInstallationMode.USER_CONTINUOUS,
+                NodeInstallationMode.SYSTEM,
+            ),
+            NodeToken.TargetPlatform.WINDOWS: (
+                NodeInstallationMode.USER,
+                NodeInstallationMode.SYSTEM,
+            ),
+            NodeToken.TargetPlatform.MACOS: (
+                NodeInstallationMode.USER,
+                NodeInstallationMode.SYSTEM,
+            ),
+        }
+        all_modes = set(NodeInstallationMode.values)
+        for platform, allowed_modes in allowed_by_platform.items():
+            for mode in all_modes:
+                with self.subTest(platform=platform, mode=mode):
+                    token = NodeToken.objects.create(
+                        organization=self.org,
+                        role=NodeRole.AGENT,
+                        installation_mode_policy=NodeToken.InstallationModePolicy.AUTO,
+                        target_platform=platform,
+                    )
+                    response = self._heartbeat(
+                        name=f"{platform}-{mode}",
+                        token=token.token,
+                        installation_id=f"hfli-{platform}-{mode}",
+                        installation_mode=mode,
+                        # Go reports runtime.GOOS (darwin), while the public
+                        # enrollment contract uses macos.
+                        platform=("darwin" if platform == "macos" else platform),
+                    )
+                    if mode in allowed_modes:
+                        self.assertEqual(response.status_code, 200)
+                        self.assertEqual(
+                            Node.objects.get(
+                                organization=self.org,
+                                installation_id=f"hfli-{platform}-{mode}",
+                            ).installation_mode,
+                            mode,
+                        )
+                    else:
+                        self.assertEqual(response.status_code, 409)
+
+    def test_automatic_token_rejects_release_for_a_different_platform(self):
+        self.token_row.installation_mode_policy = (
+            NodeToken.InstallationModePolicy.AUTO
+        )
+        self.token_row.target_platform = NodeToken.TargetPlatform.LINUX
+        self.token_row.save(
+            update_fields=["installation_mode_policy", "target_platform"]
+        )
+        request = self.factory.get(
+            "/api/v1/node/enrollment/agent/release",
+            {
+                "org": self.org.key,
+                "role": NodeRole.AGENT,
+                "token": self.token_row.token,
+                "platform": "windows",
+                "arch": "amd64",
+            },
+        )
+
+        response = AgentReleaseView.as_view()(request)
+
+        self.assertEqual(response.status_code, 409)
+        self.assertEqual(
+            response.data["error"],
+            "platform does not match enrollment token",
+        )
+
+    def test_automatic_token_accepts_its_bound_artifact_platform(self):
+        artifact_platform_by_target = {
+            NodeToken.TargetPlatform.LINUX: "linux",
+            NodeToken.TargetPlatform.WINDOWS: "windows",
+            NodeToken.TargetPlatform.MACOS: "darwin",
+        }
+        self.token_row.installation_mode_policy = (
+            NodeToken.InstallationModePolicy.AUTO
+        )
+        for target_platform, artifact_platform in (
+            artifact_platform_by_target.items()
+        ):
+            with self.subTest(target_platform=target_platform):
+                self.token_row.target_platform = target_platform
+                self.assertTrue(
+                    _automatic_token_allows_artifact_platform(
+                        self.token_row,
+                        artifact_platform,
+                    )
+                )
 
     def test_create_serializer_rejects_user_level_infrastructure_role(self):
         for role in (NodeRole.PROXY, NodeRole.GATEWAY):

--- a/src/backend/apps/node/tests/test_node_naming.py
+++ b/src/backend/apps/node/tests/test_node_naming.py
@@ -1,15 +1,26 @@
 """Tests for default node naming on enrollment."""
 
-from django.test import SimpleTestCase
+from django.test import TestCase
 
+from apps.iam.models import Organization
+from apps.node.models import Node
 from apps.node.services.internal.node_naming import (
     hostname_from_metadata,
     is_auto_assigned_node_name,
+    is_automatic_user_node_name,
     resolve_registration_node_name,
+    runtime_principal_name,
+    uniquify_node_name,
 )
 
 
-class NodeNamingTests(SimpleTestCase):
+class NodeNamingTests(TestCase):
+    def setUp(self):
+        self.org = Organization.objects.create(
+            key="node-naming-org",
+            name="Node Naming Org",
+        )
+
     def test_hostname_from_inventory(self):
         meta = {"inventory": {"hostname": "host-a"}}
         self.assertEqual(hostname_from_metadata(meta), "host-a")
@@ -35,6 +46,75 @@ class NodeNamingTests(SimpleTestCase):
             },
         )
         self.assertEqual(name, "custom-label")
+
+    def test_user_install_name_includes_runtime_principal(self):
+        name = resolve_registration_node_name(
+            payload={
+                "name": "host-a",
+                "installation_mode": "user_continuous",
+                "metadata": {
+                    "hostname": "host-a",
+                    "runtime_principal": {
+                        "id": "1001",
+                        "name": "backup-user",
+                    },
+                },
+            },
+        )
+        self.assertEqual(name, "host-a · backup-user")
+
+    def test_runtime_principal_name_ignores_malformed_metadata(self):
+        self.assertEqual(runtime_principal_name({"runtime_principal": "root"}), "")
+
+    def test_user_install_name_is_bounded_to_model_limit(self):
+        name = resolve_registration_node_name(
+            payload={
+                "installation_mode": "user",
+                "metadata": {
+                    "hostname": "h" * 180,
+                    "runtime_principal": {"name": "u" * 80},
+                },
+            }
+        )
+        self.assertEqual(len(name), 200)
+
+    def test_unique_suffix_stays_within_model_limit(self):
+        Node.objects.create(
+            organization=self.org,
+            name="n" * 200,
+            role=Node.Role.AGENT,
+        )
+        name = uniquify_node_name(
+            organization_id=self.org.id,
+            name="n" * 220,
+            exclude_node_id=12345,
+        )
+        self.assertEqual(len(name), 200)
+        self.assertTrue(name.endswith("-12345"))
+
+    def test_generated_user_name_recognizes_collision_suffix(self):
+        self.assertTrue(
+            is_automatic_user_node_name(
+                name="host-a · backup-user-42",
+                metadata={
+                    "hostname": "host-a",
+                    "runtime_principal": {"name": "backup-user"},
+                },
+                node_id=42,
+            )
+        )
+
+    def test_custom_user_name_is_not_treated_as_generated(self):
+        self.assertFalse(
+            is_automatic_user_node_name(
+                name="Finance files",
+                metadata={
+                    "hostname": "host-a",
+                    "runtime_principal": {"name": "backup-user"},
+                },
+                node_id=42,
+            )
+        )
 
     def test_auto_assigned_names(self):
         self.assertTrue(is_auto_assigned_node_name("new-node"))

--- a/src/backend/apps/source/services/internal/agent_host_sync.py
+++ b/src/backend/apps/source/services/internal/agent_host_sync.py
@@ -33,12 +33,24 @@ def _latest_agent_version() -> str:
 
 
 def _agent_platform(node: Node, inv: dict[str, Any]) -> str:
-    raw = str(inv.get("os") or inv.get("platform") or node.os_name or "").strip().lower()
+    raw = (
+        str(inv.get("os") or inv.get("platform") or node.os_name or "").strip().lower()
+    )
     if "darwin" in raw or "mac" in raw:
         return "macos"
     if "windows" in raw or raw in {"win32", "win64"} or raw.startswith("win "):
         return "windows"
     return "linux"
+
+
+def _agent_display_name(node: Node, hostname: str) -> str:
+    """Keep per-user Agent instances distinguishable on the source-host UI."""
+    if node.installation_mode in (
+        Node.InstallationMode.USER,
+        Node.InstallationMode.USER_CONTINUOUS,
+    ):
+        return str(node.name or "").strip() or hostname
+    return hostname or str(node.name or "").strip()
 
 
 def sync_agent_source_host(*, node: Node) -> SourceResource | None:
@@ -84,8 +96,9 @@ def sync_agent_source_host(*, node: Node) -> SourceResource | None:
         resource_type=ResourceType.LOCAL,
     )
     resource = qs.first()
+    display_name = _agent_display_name(node, hostname)
     if resource is None:
-        name = hostname or node.name or f"agent-{node.id}"
+        name = display_name or f"agent-{node.id}"
         if (
             SourceResource.objects.filter(
                 organization_id=node.organization_id,
@@ -132,10 +145,18 @@ def sync_agent_source_host(*, node: Node) -> SourceResource | None:
         "free_size",
         "updated_at",
     ]
-    desired_name = hostname or node.name
+    desired_name = display_name
     if desired_name and (
         is_auto_assigned_node_name(resource.name)
         or resource.name == f"agent-{node.id}"
+        or (
+            node.installation_mode
+            in (
+                Node.InstallationMode.USER,
+                Node.InstallationMode.USER_CONTINUOUS,
+            )
+            and resource.name == hostname
+        )
     ):
         next_name = desired_name
         if (

--- a/src/backend/apps/source/tests/test_api.py
+++ b/src/backend/apps/source/tests/test_api.py
@@ -1386,6 +1386,56 @@ class SourceResourceApiTests(TestCase):
         self.assertIsNotNone(resource)
         self.assertEqual(resource.config["platform"], "macos")
 
+    def test_sync_user_agents_keep_principal_in_source_host_name(self):
+        resources = []
+        for index, principal in enumerate(("backup-a", "backup-b"), start=1):
+            agent = Node.objects.create(
+                organization=self.org,
+                name=f"host-a · {principal}",
+                role=Node.Role.AGENT,
+                installation_mode=Node.InstallationMode.USER_CONTINUOUS,
+                status=Node.Status.ACTIVE,
+                availability=Node.Availability.ONLINE,
+                installation_id=f"hfli-user-{index}",
+                metadata={
+                    "hostname": "host-a",
+                    "runtime_principal": {"id": str(1000 + index), "name": principal},
+                },
+            )
+            resources.append(sync_agent_source_host(node=agent))
+
+        self.assertEqual(
+            [resource.name for resource in resources],
+            ["host-a · backup-a", "host-a · backup-b"],
+        )
+        self.assertEqual(
+            [resource.config["hostname"] for resource in resources],
+            ["host-a", "host-a"],
+        )
+
+    def test_sync_user_agent_upgrades_plain_legacy_source_name(self):
+        agent = Node.objects.create(
+            organization=self.org,
+            name="host-a · backup-user",
+            role=Node.Role.AGENT,
+            installation_mode=Node.InstallationMode.USER,
+            status=Node.Status.ACTIVE,
+            availability=Node.Availability.ONLINE,
+            installation_id="hfli-user-legacy-name",
+            metadata={"hostname": "host-a"},
+        )
+        resource = SourceResource.objects.create(
+            organization=self.org,
+            name="host-a",
+            resource_type="local",
+            bound_node=agent,
+        )
+
+        sync_agent_source_host(node=agent)
+
+        resource.refresh_from_db()
+        self.assertEqual(resource.name, "host-a · backup-user")
+
     def test_sync_agent_source_host_clears_legacy_capacity_while_inventory_pending(
         self,
     ):

--- a/src/frontend/src/components/NodeLifecycleCopy.test.ts
+++ b/src/frontend/src/components/NodeLifecycleCopy.test.ts
@@ -11,7 +11,6 @@ describe('Node lifecycle copy', () => {
     const locale = source('src/locales/en.ts')
 
     expect(locale).toContain("installCommandStep: 'Run the Install Command'")
-    expect(locale).toContain("installationModeStep: 'Select Protection Mode'")
     expect(locale).toContain("installationModeSystem: 'Host files · continuous'")
     expect(locale).toContain("installationModeUser: 'Current user files'")
     expect(locale).toContain("installationModeUserContinuous: 'User files · continuous'")
@@ -20,27 +19,28 @@ describe('Node lifecycle copy', () => {
     expect(locale).toContain('installationModeUserPermission:')
     expect(locale).toContain('installationModeUserContinuousPermission:')
     expect(wizardSource()).toContain("const isNewAgentInstallation = computed(() => props.role === 'agent' && props.nodeId == null)")
-    expect(wizardSource()).toContain("props.role === 'agent' && props.nodeId == null\n    ? defaultInstallationModeForOs(props.os)")
-    expect(wizardSource()).toContain("if (option.value === 'account') return false")
-    expect(wizardSource()).toContain("return option.value === 'user_continuous' || option.value === 'system'")
-    expect(wizardSource()).toContain("return option.value === 'user' || option.value === 'system'")
+    expect(wizardSource()).toContain("? 'nodeLifecycle.installLeadAutomaticMacos'")
+    expect(wizardSource()).toContain(": 'nodeLifecycle.installLeadAutomatic'")
+    expect(wizardSource()).toContain("...(isNewAgentInstallation.value\n              ? {}")
     expect(wizardSource()).toContain("os === 'linux' ? 'user_continuous' : 'user'")
-    expect(wizardSource()).toContain('const defaultMode = defaultInstallationModeForOs(props.os)')
-    expect(wizardSource()).toContain('selectedInstallationMode.value = defaultMode')
-    expect(locale).toContain("installationModeRecommended: 'Recommended'")
+    expect(wizardSource()).not.toContain('selectedInstallationMode')
+    expect(wizardSource()).not.toContain('installationModeOptions')
+    expect(locale).toContain('never changes mode silently')
+    expect(locale).toContain('grant HyperFileLens Agent Full Disk Access')
     expect(locale).toContain("generateInstallCommand: 'Generate install command'")
     expect(locale).toContain('Copy the command and run it in a shell on the target host')
     expect(locale).toContain("installFlowDownload: 'Downloads the small installer and checks the target host'")
     expect(locale).toContain("installFlowInstall: 'Downloads the required components and installs the Agent'")
   })
 
-  it('presents operating system, protection mode, and command as separate install steps', () => {
+  it('presents operating system and command without a protection-mode picker', () => {
     const wizard = source('src/components/NodeLifecycleWizard.vue')
     const locale = source('src/locales/en.ts')
 
     expect(wizard).toMatch(
-      /fullscreen-form-card[\s\S]*?nodeLifecycle\.osStep[\s\S]*?<\/div>\s*\n\s*<div[\s\S]*?fullscreen-form-card[\s\S]*?nodeLifecycle\.installationModeStep[\s\S]*?<\/div>\s*\n\s*<div class="fullscreen-form-card">[\s\S]*?nodeLifecycle\.installCommandStep/,
+      /fullscreen-form-card[\s\S]*?nodeLifecycle\.osStep[\s\S]*?<\/div>\s*\n\s*<div class="fullscreen-form-card">[\s\S]*?nodeLifecycle\.installCommandStep/,
     )
+    expect(wizard).not.toContain("t('nodeLifecycle.installationModeStep')")
     expect(locale).toContain('Continuous, including after sign-out and restart')
     expect(locale).toContain('While this user is signed in')
     expect(locale).toContain('Selected files and folders on this host')
@@ -80,6 +80,15 @@ describe('Node lifecycle copy', () => {
     expect(wizard).toContain('fetchNodeMaintenanceRelease')
     expect(wizard).not.toContain('createNodeToken({ role: props.role')
     expect(wizard).not.toContain('installError.value')
+  })
+
+  it('refreshes maintenance commands when the persisted installation mode changes', () => {
+    const wizard = wizardSource()
+
+    expect(wizard).toMatch(
+      /props\.gatewayScope,\s*props\.installationMode,\s*\] as const/,
+    )
+    expect(wizard).toContain('refreshAll()')
   })
 
   it('shows expiry without host quotas or replacement-command controls', () => {

--- a/src/frontend/src/components/NodeLifecycleWizard.vue
+++ b/src/frontend/src/components/NodeLifecycleWizard.vue
@@ -11,10 +11,6 @@ import {
   Cpu,
   MemoryStick,
   HardDrive,
-  Folder,
-  Clock3,
-  UserRoundCheck,
-  Server,
 } from 'lucide-vue-next'
 import AgentPlatformBrandIcon from './agent-deploy/AgentPlatformBrandIcon.vue'
 import UbuntuBrandIcon from './agent-deploy/UbuntuBrandIcon.vue'
@@ -100,13 +96,10 @@ const serviceAction = ref<'status' | 'start' | 'stop' | 'restart'>(props.initial
 const defaultInstallationModeForOs = (os: EnrollmentOs): NodeInstallationMode => (
   os === 'linux' ? 'user_continuous' : 'user'
 )
-const selectedInstallationMode = ref<NodeInstallationMode>(
-  props.role === 'agent' && props.nodeId == null
-    ? defaultInstallationModeForOs(props.os)
-    : props.installationMode ?? defaultInstallationModeForOs(props.os),
-)
 const effectiveInstallationMode = computed<NodeInstallationMode>(() => (
-  props.role === 'agent' ? selectedInstallationMode.value : 'system'
+  props.role === 'agent'
+    ? props.installationMode ?? defaultInstallationModeForOs(props.os)
+    : 'system'
 ))
 const supportOpen = ref(false)
 const enrollmentTokenId = ref<number | null>(null)
@@ -266,89 +259,14 @@ const osPickerOptions = computed(() => [
   { value: 'macos' as EnrollmentOs, label: t('nodesDeploy.osMacos'), meta: t('nodeLifecycle.osMetaMacos') },
 ])
 
-// Keep service-manager details internal. The available choices describe the
-// protection result and lifecycle boundary; the installer selects the native
-// service mechanism for the chosen operating system.
-//
-// Product exposure is intentionally narrower than backend/installer support:
-// new agent enrollment offers exactly two modes per operating system. The
-// account mode and Linux user mode remain supported for compatibility and
-// existing-node maintenance, but are hidden from the new-install workflow
-// until their product workflows are finalized. Do not remove either mode from
-// shared types or lifecycle implementations when changing this page policy.
 const isNewAgentInstallation = computed(() => props.role === 'agent' && props.nodeId == null)
 
-const installationModeOptions = computed(() => {
-  const options = [
-    {
-      value: 'user' as NodeInstallationMode,
-      icon: Folder,
-      title: t('nodeLifecycle.installationModeUser'),
-      scope: t('nodeLifecycle.installationModeUserScope'),
-      runtimeTag: t('nodeLifecycle.installationModeUserRuntimeTag'),
-      permissionTag: t('nodeLifecycle.installationModeUserPermissionTag'),
-      recommended: defaultInstallationModeForOs(props.os) === 'user',
-    },
-    {
-      value: 'user_continuous' as NodeInstallationMode,
-      icon: Clock3,
-      title: t('nodeLifecycle.installationModeUserContinuous'),
-      scope: t('nodeLifecycle.installationModeUserContinuousScope'),
-      runtimeTag: t('nodeLifecycle.installationModeUserContinuousRuntimeTag'),
-      permissionTag: t('nodeLifecycle.installationModeUserContinuousPermissionTag'),
-      recommended: defaultInstallationModeForOs(props.os) === 'user_continuous',
-    },
-    {
-      value: 'account' as NodeInstallationMode,
-      icon: UserRoundCheck,
-      title: t('nodeLifecycle.installationModeAccount'),
-      scope: t('nodeLifecycle.installationModeAccountScope'),
-      runtimeTag: t('nodeLifecycle.installationModeAccountRuntimeTag'),
-      permissionTag: t('nodeLifecycle.installationModeAccountPermissionTag'),
-      recommended: false,
-    },
-    {
-      value: 'system' as NodeInstallationMode,
-      icon: Server,
-      title: t('nodeLifecycle.installationModeSystem'),
-      scope: t('nodeLifecycle.installationModeSystemScope'),
-      runtimeTag: t('nodeLifecycle.installationModeSystemRuntimeTag'),
-      permissionTag: t('nodeLifecycle.installationModeSystemPermissionTag'),
-      recommended: defaultInstallationModeForOs(props.os) === 'system',
-    },
-  ]
-
-  if (!isNewAgentInstallation.value) {
-    return options.filter((option) => option.value !== 'user_continuous' || props.os === 'linux')
-  }
-
-  return options.filter((option) => {
-    if (option.value === 'account') return false
-    if (props.os === 'linux') {
-      return option.value === 'user_continuous' || option.value === 'system'
-    }
-    return option.value === 'user' || option.value === 'system'
-  })
-})
-
-const selectedInstallationModeTitle = computed(() => (
-  installationModeOptions.value.find((option) => option.value === selectedInstallationMode.value)?.title ?? ''
-))
-
-const selectedInstallationModeHint = computed(() => {
-  if (selectedInstallationMode.value === 'user_continuous') {
-    return t('nodeLifecycle.installationModeUserContinuousHint')
-  }
-  if (selectedInstallationMode.value === 'user') {
-    return t('nodeLifecycle.installationModeUserHint')
-  }
-  if (selectedInstallationMode.value === 'account') {
-    return t('nodeLifecycle.installationModeAccountHint')
-  }
-  return t('nodeLifecycle.installationModeSystemHint')
-})
-
 const installLeadKey = computed(() => {
+  if (isNewAgentInstallation.value) {
+    return props.os === 'macos'
+      ? 'nodeLifecycle.installLeadAutomaticMacos'
+      : 'nodeLifecycle.installLeadAutomatic'
+  }
   if (effectiveInstallationMode.value === 'user' || effectiveInstallationMode.value === 'user_continuous') return 'nodeLifecycle.installLeadUser'
   if (props.os === 'windows') return 'nodeLifecycle.installLeadWindows'
   if (props.os === 'macos') return 'nodeLifecycle.installLeadMacos'
@@ -420,7 +338,9 @@ async function refreshInstallCommand(gen: number) {
         : await issueEnrollmentInstall({
             role: props.role,
             os: props.os,
-            installationMode: effectiveInstallationMode.value,
+            ...(isNewAgentInstallation.value
+              ? {}
+              : { installationMode: effectiveInstallationMode.value }),
             note: `deploy:${props.role}`,
           })
     if (gen !== generation) {
@@ -524,17 +444,17 @@ function refreshAll() {
 }
 
 watch(
-  () => [props.orgKey, props.nodeId, props.role, props.os, props.gatewayScope] as const,
+  () => [
+    props.orgKey,
+    props.nodeId,
+    props.role,
+    props.os,
+    props.gatewayScope,
+    props.installationMode,
+  ] as const,
   () => {
     if (isLinuxOnlyRole(props.role) && props.os !== 'linux') {
       emit('update:os', 'linux')
-    }
-    if (isNewAgentInstallation.value) {
-      const defaultMode = defaultInstallationModeForOs(props.os)
-      if (selectedInstallationMode.value !== defaultMode) {
-        selectedInstallationMode.value = defaultMode
-        return
-      }
     }
     const staleTokenId = enrollmentTokenId.value
     const staleTokenIsPlatform = enrollmentTokenIsPlatform.value
@@ -547,26 +467,6 @@ watch(
   { immediate: true },
 )
 
-watch(
-  () => props.installationMode,
-  (mode) => {
-    if (mode && (!isNewAgentInstallation.value || mode === defaultInstallationModeForOs(props.os))) {
-      selectedInstallationMode.value = mode
-    } else if (isNewAgentInstallation.value) {
-      selectedInstallationMode.value = defaultInstallationModeForOs(props.os)
-    }
-  },
-)
-
-watch(selectedInstallationMode, () => {
-  const staleTokenId = enrollmentTokenId.value
-  const staleTokenIsPlatform = enrollmentTokenIsPlatform.value
-  clearInstallCommand()
-  if (staleTokenId) {
-    void revokeIssuedEnrollment(staleTokenId, staleTokenIsPlatform)
-  }
-  refreshAll()
-})
 
 watch(
   () => props.initialTab,
@@ -948,74 +848,6 @@ defineExpose({ clearInstallCommand })
         </section>
       </div>
 
-      <div
-        v-if="!maintenanceOnly && role === 'agent' && activeTab === 'install'"
-        class="fullscreen-form-card"
-      >
-        <section class="fullscreen-form-section">
-          <h3 class="fullscreen-form-section__title">
-            <span class="fullscreen-form-section__indicator" />
-            {{ t('nodeLifecycle.installationModeStep') }}
-          </h3>
-          <div class="installation-mode-picker">
-            <ElRadioGroup
-              v-model="selectedInstallationMode"
-              class="installation-mode-grid"
-              :aria-label="t('nodeLifecycle.installationModeStep')"
-            >
-              <ElRadio
-                v-for="option in installationModeOptions"
-                :key="option.value"
-                :value="option.value"
-                border
-                :data-mode="option.value"
-                class="installation-mode-card !mr-0"
-              >
-                <span class="installation-mode-card__content">
-                  <span
-                    class="installation-mode-card__icon"
-                    aria-hidden="true"
-                  >
-                    <component
-                      :is="option.icon"
-                      :size="17"
-                      :stroke-width="1.8"
-                    />
-                  </span>
-                  <span class="installation-mode-card__title-row">
-                    <strong class="installation-mode-card__title">{{ option.title }}</strong>
-                    <span
-                      v-if="option.recommended"
-                      class="installation-mode-card__badge"
-                    >
-                      {{ t('nodeLifecycle.installationModeRecommended') }}
-                    </span>
-                  </span>
-                  <span class="installation-mode-card__scope">{{ option.scope }}</span>
-                  <span class="installation-mode-card__meta">
-                    <span>{{ option.runtimeTag }}</span>
-                    <span>{{ option.permissionTag }}</span>
-                  </span>
-                </span>
-              </ElRadio>
-            </ElRadioGroup>
-            <p
-              class="installation-mode-picker__hint"
-              aria-live="polite"
-            >
-              <span
-                class="installation-mode-picker__hint-dot"
-                aria-hidden="true"
-              />
-              <span>
-                <strong>{{ t('nodeLifecycle.installationModeSelected', { mode: selectedInstallationModeTitle }) }}</strong>
-                {{ selectedInstallationModeHint }}
-              </span>
-            </p>
-          </div>
-        </section>
-      </div>
-
       <div class="fullscreen-form-card">
         <section class="fullscreen-form-section">
           <template v-if="installOnly">
@@ -1394,163 +1226,6 @@ defineExpose({ clearInstallCommand })
 
 .node-lifecycle-wizard__options {
   margin-bottom: 12px;
-}
-
-.installation-mode-picker {
-  display: grid;
-  gap: 8px;
-}
-
-.installation-mode-grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 12px;
-  align-items: stretch;
-}
-
-.installation-mode-card {
-  position: relative;
-  display: flex;
-  align-items: flex-start;
-  min-width: 0;
-  min-height: 142px;
-  height: 100%;
-  margin: 0;
-  padding: 14px 14px 13px;
-  white-space: normal;
-}
-
-.installation-mode-card :deep(.el-radio__label) {
-  display: block;
-  min-width: 0;
-  width: 100%;
-  height: 100%;
-  padding-left: 0;
-  white-space: normal;
-}
-
-.installation-mode-card :deep(.el-radio__input) {
-  position: absolute;
-  top: 14px;
-  right: 14px;
-  z-index: 1;
-}
-
-.installation-mode-card__content {
-  display: grid;
-  grid-template-columns: 30px minmax(0, 1fr);
-  grid-template-rows: auto auto 1fr auto;
-  column-gap: 10px;
-  height: 100%;
-  min-width: 0;
-}
-
-.installation-mode-card__icon {
-  display: grid;
-  grid-column: 1;
-  grid-row: 1;
-  width: 30px;
-  height: 30px;
-  place-items: center;
-  border-radius: 8px;
-  background: var(--color-primary-light, #f2f0fe);
-  color: var(--color-primary, #6d5ef6);
-}
-
-.installation-mode-card__title {
-  color: var(--color-text-primary);
-  font-size: 14px;
-  line-height: 1.35;
-}
-
-.installation-mode-card__title-row {
-  display: flex;
-  grid-column: 2;
-  grid-row: 1;
-  align-items: flex-start;
-  justify-content: flex-start;
-  gap: 8px;
-  min-width: 0;
-  padding-right: 24px;
-}
-
-.installation-mode-card__badge {
-  flex: 0 0 auto;
-  padding: 2px 7px;
-  border-radius: 999px;
-  background: var(--color-primary-light, #f2f0fe);
-  color: var(--color-primary, #6d5ef6);
-  font-size: 11px;
-  font-weight: 600;
-  line-height: 1.4;
-}
-
-.installation-mode-card__scope {
-  grid-column: 1 / -1;
-  grid-row: 2;
-  margin-top: 10px;
-  color: var(--color-text-tertiary);
-  font-size: 12px;
-  line-height: 1.5;
-}
-
-.installation-mode-card__meta {
-  display: flex;
-  grid-column: 1 / -1;
-  grid-row: 4;
-  flex-wrap: wrap;
-  gap: 6px;
-  margin-top: auto;
-  padding-top: 12px;
-}
-
-.installation-mode-card__meta span {
-  padding: 4px 7px;
-  border: 1px solid var(--color-border-light);
-  border-radius: 5px;
-  color: var(--color-text-tertiary);
-  font-size: 11px;
-  line-height: 1.2;
-}
-
-@media (max-width: 920px) {
-  .installation-mode-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-}
-
-@media (max-width: 680px) {
-  .installation-mode-grid {
-    grid-template-columns: 1fr;
-  }
-
-  .installation-mode-card {
-    min-height: 0;
-  }
-}
-
-.installation-mode-picker__hint {
-  display: flex;
-  align-items: flex-start;
-  gap: 8px;
-  margin: 0;
-  color: var(--color-text-tertiary);
-  font-size: 12px;
-  line-height: 1.5;
-}
-
-.installation-mode-picker__hint strong {
-  color: var(--color-text-secondary);
-  font-weight: 600;
-}
-
-.installation-mode-picker__hint-dot {
-  flex: 0 0 auto;
-  width: 6px;
-  height: 6px;
-  margin-top: 6px;
-  border-radius: 50%;
-  background: var(--color-primary, #6d5ef6);
 }
 
 .agent-install-wizard--maintenance {

--- a/src/frontend/src/lib/nodeApi.test.ts
+++ b/src/frontend/src/lib/nodeApi.test.ts
@@ -9,6 +9,7 @@ import {
   getGatewayNode,
   fetchNodeMaintenanceRelease,
   issueGatewayEnrollmentInstall,
+  issueEnrollmentInstall,
   issuePlatformGatewayEnrollmentInstall,
   previewNodeOperationsBatch,
   revokePlatformGatewayEnrollment,
@@ -262,12 +263,56 @@ describe('Data Gateway enrollment', () => {
 
     expect(command).toMatch(/^cd \/ && curl --proto '=https' --tlsv1\.2 --fail --silent --show-error --location '/)
     expect(command).toContain('/api/v1/node/enrollment/bootstrap?')
-    expect(command).toContain('| sudo bash -s')
+    expect(command).toContain('| bash -s')
+    expect(command).not.toContain('| sudo bash -s')
     expect(command).not.toContain('--progress-bar')
     expect(command).not.toContain('installer.tar.gz')
     expect(command).not.toContain('mktemp')
     expect(command).not.toContain('WARNING:')
     expect(command.split('\n')).toHaveLength(1)
+  })
+
+  it('keeps infrastructure enrollment elevated when no mode is provided', () => {
+    const command = buildEnrollmentInstallCommand({
+      org: 'tenant-a',
+      role: 'gateway',
+      token: 'token-a',
+      apiBase: 'https://console.example.com',
+      os: 'linux',
+      tlsVerify: true,
+    })
+
+    expect(command).toContain('| sudo bash -s')
+  })
+
+  it('issues a platform-bound automatic token for a new Source Agent', async () => {
+    vi.mocked(api).mockResolvedValue({
+      id: 19,
+      token: 'agent-token',
+      role: 'agent',
+      installation_mode: 'system',
+      installation_mode_policy: 'auto',
+      target_platform: 'linux',
+      is_active: true,
+      status: 'active',
+      tls_verify: true,
+    })
+
+    const result = await issueEnrollmentInstall({ role: 'agent', os: 'linux' })
+
+    expect(vi.mocked(api)).toHaveBeenCalledWith(
+      '/api/v1/node/node-tokens/',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          role: 'agent',
+          installation_mode_policy: 'auto',
+          target_platform: 'linux',
+        }),
+      }),
+    )
+    expect(result.command).toContain('| bash -s')
+    expect(result.command).not.toContain('| sudo bash -s')
   })
 
   it('does not elevate a user-level Linux installation command', () => {

--- a/src/frontend/src/lib/nodeApi.ts
+++ b/src/frontend/src/lib/nodeApi.ts
@@ -448,7 +448,9 @@ function buildWindowsEnrollmentInstallCommand(url: string, tlsVerify: boolean): 
 }
 
 /**
- * POSIX one-liner: curl the rendered bootstrap stub into sudo bash.
+ * POSIX one-liner: curl the rendered bootstrap stub into bash. Automatic
+ * Source Agent enrollment keeps the caller's identity; fixed infrastructure
+ * enrollments still select sudo bash below.
  * The bootstrap script downloads one slim enroll helper and runs install.
  *
  * Moving to / avoids getcwd noise when the caller is sitting in a deleted install dir.
@@ -457,12 +459,18 @@ function buildWindowsEnrollmentInstallCommand(url: string, tlsVerify: boolean): 
 function buildPosixEnrollmentInstallCommand(
   url: string,
   tlsVerify: boolean,
-  installationMode: NodeInstallationMode,
+  installationMode?: NodeInstallationMode,
 ): string {
   const tlsOptions = tlsVerify
     ? "--proto '=https' --tlsv1.2"
     : '-k'
-  const shell = installationMode === 'user' || installationMode === 'user_continuous' ? 'bash -s' : 'sudo bash -s'
+  // An omitted mode is an automatic source-Agent enrollment. Run in the
+  // caller's actual identity so the host can select a mode without silently
+  // elevating or downgrading it. Fixed infrastructure enrollments remain
+  // explicitly system-scoped.
+  const shell = !installationMode || installationMode === 'user' || installationMode === 'user_continuous'
+    ? 'bash -s'
+    : 'sudo bash -s'
   return `cd / && curl ${tlsOptions} --fail --silent --show-error --location '${url}' | ${shell}`
 }
 
@@ -481,10 +489,16 @@ export function buildEnrollmentInstallCommand(params: {
   if (params.os === 'windows') {
     return buildWindowsEnrollmentInstallCommand(url, tlsVerify)
   }
+  // Only a new Source Agent enrollment may infer its mode from the caller.
+  // Preserve the historical elevated default for every infrastructure role
+  // and for any future caller that omits a fixed mode.
+  const installationMode = params.role === 'agent'
+    ? params.installationMode
+    : params.installationMode ?? 'system'
   return buildPosixEnrollmentInstallCommand(
     url,
     tlsVerify,
-    params.installationMode ?? 'system',
+    installationMode,
   )
 }
 
@@ -609,10 +623,17 @@ export async function issueEnrollmentInstall(params: {
   if (!org) {
     throw new Error('Missing organization key')
   }
-  const installationMode = params.installationMode ?? 'system'
+  const automaticMode = params.role === 'agent' && params.installationMode == null
   const row = await createNodeToken({
     role: params.role,
-    installation_mode: installationMode,
+    ...(automaticMode
+      ? {
+          installation_mode_policy: 'auto' as const,
+          target_platform: params.os,
+        }
+      : {
+          installation_mode: params.installationMode ?? 'system',
+        }),
     note: params.note,
   })
   const command = buildEnrollmentInstallCommand({
@@ -620,7 +641,7 @@ export async function issueEnrollmentInstall(params: {
     role: params.role,
     token: row.token,
     os: params.os,
-    installationMode,
+    installationMode: automaticMode ? undefined : params.installationMode ?? 'system',
     tlsVerify: row.tls_verify,
   })
   return {

--- a/src/frontend/src/locales/en.ts
+++ b/src/frontend/src/locales/en.ts
@@ -1868,6 +1868,10 @@ export const en = {
     installLeadMacos:
       'Copy into {terminal} and run with {sudo}. After installation, grant HyperFileLens Agent Full Disk Access in System Settings; otherwise it can protect only readable files.',
     installLeadUser: 'Copy and run the command as the current user. Do not use sudo or an elevated terminal.',
+    installLeadAutomatic:
+      'Copy and run the command using the identity you intend to protect. On Linux, a normal user installs continuous user-level protection; on Windows and macOS, a normal user installs current-user protection. Root or an elevated Administrator installs host-level protection. The installer reports the detected identity and never changes mode silently.',
+    installLeadAutomaticMacos:
+      'Copy and run the command using the identity you intend to protect. A normal user installs user-level protection; root installs host-level protection. The installer reports the detected identity and never changes mode silently. After installation, grant HyperFileLens Agent Full Disk Access in System Settings; otherwise it can protect only readable files.',
     installLeadAdministrator: 'Administrator',
     installLeadTerminal: 'Terminal',
     installFlowLabel: 'What This Command Does',

--- a/src/frontend/src/types/node.ts
+++ b/src/frontend/src/types/node.ts
@@ -68,6 +68,8 @@ export type ApiNodeToken = {
   token: string
   role: NodeRole
   installation_mode: NodeInstallationMode
+  installation_mode_policy?: 'fixed' | 'auto'
+  target_platform?: 'linux' | 'windows' | 'macos' | ''
   note?: string
   is_active: boolean
   created_at?: string
@@ -80,6 +82,8 @@ export type ApiNodeToken = {
 export type CreateNodeTokenBody = {
   role: NodeRole
   installation_mode?: NodeInstallationMode
+  installation_mode_policy?: 'fixed' | 'auto'
+  target_platform?: 'linux' | 'windows' | 'macos'
   note?: string
   expires_at?: string | null
   is_active?: boolean


### PR DESCRIPTION
## Summary

- Simplify Source Agent enrollment so users select only the target operating system.
- Issue platform-bound automatic enrollment tokens and resolve the concrete installation mode from the installers actual execution identity.
- Select user_continuous for non-root Linux, user for non-elevated Windows and macOS, and system for elevated or root execution.
- Keep account mode backend-compatible while hiding it from the new installation flow.
- Reject platform mismatches and prevent automatic mode from being persisted as a concrete node mode.
- Scope Windows user-mode lifecycle operations by user SID while preserving legacy system-installation upgrade compatibility.

## Validation

- Frontend targeted tests, ESLint, TypeScript checks, and production build
- Focused Go tests and Windows amd64 cross-compilation
- Ruff, Python compilation, and Django migration consistency checks
- Language-pack validation and Bash syntax checks
- git diff --check

Django integration tests could not complete because the local PostgreSQL connection timed out; no test assertion failed.

## Related issue

- #425 tracks the remaining macOS validation scope and is not closed by this PR.