### PR TITLE
fix(protection): report repository quota failures

### DIFF
--- a/src/backend/apps/protection/services/backup_task.py
+++ b/src/backend/apps/protection/services/backup_task.py
@@ -1337,14 +1337,34 @@ def extract_kopia_failure_message(
         text = str(result.get(key) or "").strip()
         if text:
             chunks.append(text)
-    for nested_key in (
+
+    nested_keys = [
+        "policy_reset",
+        "policy_apply",
         "snapshot_create",
         "repository_create",
         "repository_connect",
         "repository_status",
-    ):
+    ]
+    policy_phase = str(result.get("policy_phase") or "").strip().lower()
+    phase_key = f"policy_{policy_phase}"
+    if phase_key in nested_keys:
+        nested_keys.remove(phase_key)
+        nested_keys.insert(0, phase_key)
+
+    for nested_key in nested_keys:
         nested = result.get(nested_key)
         if not isinstance(nested, dict):
+            continue
+        try:
+            exit_code = int(nested.get("exit_code", 0))
+        except (TypeError, ValueError):
+            exit_code = 0
+        if (
+            nested_key == "repository_status"
+            and "exit_code" in nested
+            and exit_code == 0
+        ):
             continue
         for key in ("stderr", "stderr_tail", "stdout", "stdout_tail"):
             text = str(nested.get(key) or "").strip()
@@ -1368,6 +1388,7 @@ def extract_kopia_failure_message(
             or "failed to open repository" in lower
             or "error connecting to repository" in lower
             or lower.startswith("error:")
+            or "quota exceeded" in lower
             or "unable to get policy tree" in lower
             or "policy not found" in lower
             or "unable to open" in lower
@@ -1416,6 +1437,11 @@ def public_repository_failure_message(message: str) -> str:
     """Return an actionable repository error without backend implementation details."""
     text = re.sub(r"https?://\S+", "", str(message or "")).strip()
     lower = text.lower()
+    if "quota exceeded" in lower:
+        return (
+            "Backup repository quota exceeded. Free storage or increase the "
+            "repository quota before retrying."
+        )
     if "not initialized" in lower:
         return "Backup repository is not initialized. Initialize or repair the repository before retrying."
     if "repository is not connected" in lower or "not connected" in lower:

--- a/src/backend/apps/protection/tests/test_backup_task_api.py
+++ b/src/backend/apps/protection/tests/test_backup_task_api.py
@@ -1977,10 +1977,21 @@ class ProtectionBackupTaskApiTests(TestCase):
             kopia_snapshot_id="",
             result={
                 "error_code": "POLICY_APPLY_FAILED",
-                "policy_phase": "apply",
-                "stderr_tail": "policy apply failed",
+                "policy_phase": "reset",
+                "policy_reset": {
+                    "stderr_tail": (
+                        "unable to write diagnostics blob despite 10 retries: "
+                        "Bucket quota exceeded\n"
+                        "error flushing writer: unable to write session marker"
+                    ),
+                    "exit_code": 1,
+                },
+                "repository_status": {
+                    "stdout_tail": "Epoch range-compaction every: 7 epochs",
+                    "exit_code": 0,
+                },
             },
-            last_error="policy apply failed",
+            last_error="reset backup policy: exit 1: exit status 1",
         )
         mock_run_agent_task_async.side_effect = self._mock_run_agent_task_async(
             [failed_policy, failed_policy]
@@ -2016,6 +2027,16 @@ class ProtectionBackupTaskApiTests(TestCase):
         self.assertEqual(final["status"], Task.Status.FAILED)
         self.assertEqual(row.status, BackupSourceSnapshotDirectory.Status.FAILED)
         self.assertEqual(row.error_code, "POLICY_APPLY_FAILED")
+        expected_message = (
+            "Backup repository quota exceeded. Free storage or increase the "
+            "repository quota before retrying."
+        )
+        self.assertEqual(row.error_message, expected_message)
+        snapshot.refresh_from_db()
+        task.refresh_from_db()
+        self.assertEqual(snapshot.error_message, expected_message)
+        self.assertEqual(task.error_message, expected_message)
+        self.assertNotIn("Epoch range-compaction", task.error_message)
         self.assertEqual(
             [attempt.payload["policy_attempt"] for attempt in attempts], [1, 2]
         )

--- a/src/backend/apps/protection/tests/test_kopia_progress.py
+++ b/src/backend/apps/protection/tests/test_kopia_progress.py
@@ -406,6 +406,42 @@ class KopiaProgressDisplayTests(SimpleTestCase):
 
 
 class KopiaFailureMessageTests(SimpleTestCase):
+    def test_extract_kopia_failure_message_prefers_failed_policy_over_status(self):
+        from apps.protection.services.backup_task import (
+            extract_kopia_failure_message,
+            public_repository_failure_message,
+        )
+
+        result = {
+            "error_code": "POLICY_APPLY_FAILED",
+            "policy_phase": "reset",
+            "policy_reset": {
+                "stderr_tail": (
+                    "Setting policy for root@jlb35:/opt/hyperfilelens-agent\n"
+                    "unable to write diagnostics blob despite 10 retries: "
+                    "Bucket quota exceeded\n"
+                    "error flushing writer: unable to write session marker"
+                ),
+                "exit_code": 1,
+            },
+            "repository_status": {
+                "stdout_tail": "Epoch range-compaction every: 7 epochs",
+                "exit_code": 0,
+            },
+        }
+
+        message = extract_kopia_failure_message(
+            result, last_error="reset backup policy: exit 1: exit status 1"
+        )
+
+        self.assertIn("Bucket quota exceeded", message)
+        self.assertNotIn("Epoch range-compaction", message)
+        self.assertEqual(
+            public_repository_failure_message(message),
+            "Backup repository quota exceeded. Free storage or increase the "
+            "repository quota before retrying.",
+        )
+
     def test_extract_kopia_failure_message_prefers_fatal_errors(self):
         from apps.protection.services.backup_task import extract_kopia_failure_message
 


### PR DESCRIPTION
## Problem and root cause

Backup policy preparation failures could display a successful Kopia repository
status line, such as `Epoch range-compaction every: 7 epochs`, instead of the
actual command error. The failure extractor did not inspect the structured
`policy_reset` and `policy_apply` results and allowed successful repository
status output to become the fallback message.

In the reported environment, MinIO rejected writes because the target bucket
quota was exhausted, but that actionable cause was hidden from the task and
snapshot error details.

## Solution

Prioritize the structured backup policy command for the reported policy phase,
and ignore successful repository status output when selecting a failure
message. Recognize quota-exceeded diagnostics and project a concise,
secret-safe instruction to free storage or increase the repository quota.

Add regression coverage for the production-shaped Agent result and verify that
the corrected message reaches the directory snapshot, logical snapshot, and
parent backup task.

## Validation

- Targeted Django tests: 7 passed
- Ruff on changed Python files: passed
- `git diff --check`: passed
- English source-boundary check: passed
- Full backend Ruff: passed
- Migration drift check: no changes detected
- Full Community Django suite: 2024 passed, 4 skipped
- Manual testing: passed

## Risks and compatibility

This changes only the selected human-readable failure message for existing
Agent result payloads. It does not change schemas, task payloads, API shapes,
repository quotas, or MinIO configuration. Agent and frontend checks are not
applicable because their source and contracts are unchanged.

Fixes #797
