### PR TITLE
Show compatible Agent upgrade prompts

### DIFF
--- a/src/backend/apps/lens_bridge/api/serializers.py
+++ b/src/backend/apps/lens_bridge/api/serializers.py
@@ -467,6 +467,7 @@ class LensGatewayInsightSerializer(serializers.Serializer):
     owner_username = serializers.CharField(required=False, allow_blank=True)
     owner_organization_id = serializers.IntegerField(required=False, allow_null=True)
     is_platform_default = serializers.BooleanField(required=False)
+    agent_release = serializers.DictField(required=False, allow_null=True)
 
 
 class LensGatewayEnableAiSerializer(serializers.Serializer):

--- a/src/backend/apps/lens_bridge/services/gateway_insights.py
+++ b/src/backend/apps/lens_bridge/services/gateway_insights.py
@@ -8,6 +8,7 @@ from typing import Any
 from apps.lens_bridge.models import LensGatewayLink, LensKnowledgeSource
 from apps.lens_bridge.services import gateway_readiness, provisioning, sl_client
 from apps.node.api.serializers.node import NodeSerializer
+from apps.node.services.internal.agent_upgrade import node_agent_release_status
 from apps.node.services.internal.node_lifecycle import enrich_node_row
 
 _SYSTEM_LENSNODE_NAMES = {"local-dev-lensnode"}
@@ -52,15 +53,21 @@ def _serialize_row(
     sl_node: dict[str, Any],
     link: LensGatewayLink | None,
     user=None,
+    release_targets: dict[tuple[str, str, str, str], str] | None = None,
 ) -> dict[str, Any]:
     sl_uuid = str(sl_node["uuid"])
     sl_status = _sl_status(sl_node.get("status"))
     if link is not None:
         provisioning.apply_gateway_lensnode_snapshot(link, sl_node)
         node = link.gateway
+        enrichment = enrich_node_row(org=node.organization, node=node, user=user)
+        enrichment["agent_release"] = node_agent_release_status(
+            node,
+            target_cache=release_targets,
+        )
         node_payload = NodeSerializer(
             node,
-            context={"enrichments": {node.id: enrich_node_row(org=node.organization, node=node, user=user)}},
+            context={"enrichments": {node.id: enrichment}},
         ).data
         knowledge_source_count = LensKnowledgeSource.objects.filter(gateway=node).count()
         origin = link.origin
@@ -91,6 +98,7 @@ def _serialize_row(
             "deleted_at": None,
             "lifecycle": None,
             "workload": None,
+            "agent_release": None,
         }
         knowledge_source_count = 0
         origin = _origin_for_unlinked(sl_node)
@@ -137,8 +145,15 @@ def _serialize_row(
 def list_admin_gateway_insight_rows(*, user=None) -> list[dict[str, Any]]:
     """All SL-admin LensNodes with optional HFL ownership metadata."""
     links = _link_index()
+    release_targets: dict[tuple[str, str, str, str], str] = {}
     return [
-        _serialize_row(position=index, sl_node=sl_node, link=links.get(str(sl_node["uuid"])), user=user)
+        _serialize_row(
+            position=index,
+            sl_node=sl_node,
+            link=links.get(str(sl_node["uuid"])),
+            user=user,
+            release_targets=release_targets,
+        )
         for index, sl_node in enumerate(_lensnode_rows())
     ]
 
@@ -148,8 +163,15 @@ def list_user_gateway_insight_rows(*, user) -> list[dict[str, Any]]:
     links = _link_index(owner_user=user)
     if not links:
         return []
+    release_targets: dict[tuple[str, str, str, str], str] = {}
     return [
-        _serialize_row(position=index, sl_node=sl_node, link=links.get(str(sl_node["uuid"])), user=user)
+        _serialize_row(
+            position=index,
+            sl_node=sl_node,
+            link=links.get(str(sl_node["uuid"])),
+            user=user,
+            release_targets=release_targets,
+        )
         for index, sl_node in enumerate(_lensnode_rows())
         if str(sl_node["uuid"]) in links
     ]

--- a/src/backend/apps/node/api/serializers/node.py
+++ b/src/backend/apps/node/api/serializers/node.py
@@ -17,6 +17,7 @@ class NodeSerializer(serializers.ModelSerializer):
     lifecycle = serializers.SerializerMethodField(read_only=True)
     workload = serializers.SerializerMethodField(read_only=True)
     associated_repository_count = serializers.SerializerMethodField(read_only=True)
+    agent_release = serializers.SerializerMethodField(read_only=True)
     effective_repository_server_address = serializers.SerializerMethodField(
         read_only=True
     )
@@ -50,6 +51,7 @@ class NodeSerializer(serializers.ModelSerializer):
             "lifecycle",
             "workload",
             "associated_repository_count",
+            "agent_release",
         ]
         read_only_fields = [
             "id",
@@ -67,6 +69,7 @@ class NodeSerializer(serializers.ModelSerializer):
             "lifecycle",
             "workload",
             "associated_repository_count",
+            "agent_release",
         ]
 
     @staticmethod
@@ -99,6 +102,13 @@ class NodeSerializer(serializers.ModelSerializer):
         if isinstance(row, dict):
             return int(row.get("associated_repository_count") or 0)
         return 0
+
+    def get_agent_release(self, obj: Node):
+        enrichments = self.context.get("enrichments") or {}
+        row = enrichments.get(obj.id)
+        if isinstance(row, dict):
+            return row.get("agent_release")
+        return None
 
     @staticmethod
     def get_effective_repository_server_address(obj: Node) -> str | None:

--- a/src/backend/apps/node/api/views/node.py
+++ b/src/backend/apps/node/api/views/node.py
@@ -189,12 +189,19 @@ class NodeViewSet(OrgScopedMixin, SoftDeleteDestroyMixin, viewsets.ModelViewSet)
         return queryset.order_by("name", "id")
 
     def _build_enrichments(self, nodes) -> dict[int, dict]:
+        from apps.node.services.internal.agent_upgrade import node_agent_release_status
+
         enrichments: dict[int, dict] = {}
+        release_targets: dict[tuple[str, str, str, str], str] = {}
         for node in nodes:
             enrichments[node.id] = enrich_node_row(
                 org=self.org,
                 node=node,
                 user=self.request.user,
+            )
+            enrichments[node.id]["agent_release"] = node_agent_release_status(
+                node,
+                target_cache=release_targets,
             )
         repository_counts = count_proxy_repository_bindings(
             organization_id=self.org.id,

--- a/src/backend/apps/node/services/internal/agent_release.py
+++ b/src/backend/apps/node/services/internal/agent_release.py
@@ -243,14 +243,16 @@ def latest_published_agent_version() -> str:
     return preferred or "0.0.0"
 
 
-def resolve_agent_version(
+def latest_compatible_agent_version(
     platform: str,
     arch: str,
     role: str | None = None,
     os_version: str | None = None,
 ) -> str:
-    """Pick newest release dir that contains a dist archive for platform/arch."""
+    """Newest published release that contains this node's exact bundle."""
     root = agent_releases_root()
+    if not root.is_dir():
+        return ""
     preferred = os.getenv("AGENT_VERSION", "").strip()
     if preferred and version_has_dist(
         root,
@@ -276,9 +278,22 @@ def resolve_agent_version(
             os_version=os_version,
         )
     ]
-    if not candidates:
-        return preferred or latest_published_agent_version()
-    if preferred and preferred in candidates:
-        return preferred
     candidates.sort(key=agent_release_sort_key, reverse=True)
-    return candidates[0]
+    return candidates[0] if candidates else ""
+
+
+def resolve_agent_version(
+    platform: str,
+    arch: str,
+    role: str | None = None,
+    os_version: str | None = None,
+) -> str:
+    """Pick newest release dir that contains a dist archive for platform/arch."""
+    preferred = os.getenv("AGENT_VERSION", "").strip()
+    compatible = latest_compatible_agent_version(
+        platform,
+        arch,
+        role,
+        os_version,
+    )
+    return compatible or preferred or latest_published_agent_version()

--- a/src/backend/apps/node/services/internal/agent_upgrade.py
+++ b/src/backend/apps/node/services/internal/agent_upgrade.py
@@ -8,6 +8,7 @@ from apps.node.services.internal.agent_release import (
     UPGRADEABLE_AGENT_ROLES,
     agent_version_compare,
     is_agent_artifact_id,
+    latest_compatible_agent_version,
     parse_semver,
     resolve_agent_version,
 )
@@ -44,6 +45,50 @@ def node_platform_arch(node: Node) -> tuple[str, str]:
 def node_os_version(node: Node) -> str:
     inv = _merged_inventory(node)
     return str(inv.get("os_version") or "").strip()
+
+
+def node_agent_release_status(
+    node: Node,
+    *,
+    target_cache: dict[tuple[str, str, str, str], str] | None = None,
+) -> dict[str, str | bool | None]:
+    """Return read-only compatible release state for console presentation."""
+    platform, arch = node_platform_arch(node)
+    os_version = node_os_version(node)
+    cache_key = (platform, arch, str(node.role), os_version)
+    if target_cache is not None and cache_key in target_cache:
+        target = target_cache[cache_key]
+    else:
+        target = latest_compatible_agent_version(
+            platform,
+            arch,
+            node.role,
+            os_version,
+        )
+        if target_cache is not None:
+            target_cache[cache_key] = target
+
+    current = str(node.version or "").strip()
+    if not current:
+        current = str(_merged_inventory(node).get("agent_version") or "").strip()
+    upgrade_version_allowed = bool(target) and not (
+        parse_semver(current)
+        and parse_semver(target)
+        and agent_version_compare(current, target) > 0
+    )
+    update_available = bool(
+        current
+        and target
+        and is_agent_artifact_id(current)
+        and is_agent_artifact_id(target)
+        and agent_version_compare(current, target) < 0
+    )
+    return {
+        "current_version": current or None,
+        "target_version": target or None,
+        "update_available": update_available,
+        "upgrade_version_allowed": upgrade_version_allowed,
+    }
 
 
 def validate_agent_upgrade(*, node: Node) -> str:

--- a/src/backend/apps/node/tests/test_agent_release.py
+++ b/src/backend/apps/node/tests/test_agent_release.py
@@ -12,6 +12,7 @@ from apps.node.services.internal.agent_release import (
     agent_release_commit,
     agent_version_compare,
     is_main_build,
+    latest_compatible_agent_version,
     latest_published_agent_version,
     resolve_agent_version,
     semver_compare,
@@ -72,6 +73,32 @@ def test_resolve_agent_version_uses_matching_ubuntu_bundle(
     version_dir.mkdir()
     (version_dir / f"hfl-agent-1.0.0-linux-amd64-{suffix}.tar.gz").write_bytes(b"x")
     assert resolve_agent_version("linux", "amd64", "proxy", os_version) == "1.0.0"
+
+
+def test_latest_compatible_agent_version_ignores_newer_incompatible_bundle(
+    releases_root,
+):
+    older = releases_root / "1.0.0"
+    older.mkdir()
+    (older / "hfl-agent-1.0.0-linux-amd64-ubuntu2204.tar.gz").write_bytes(b"x")
+    newer = releases_root / "1.1.0"
+    newer.mkdir()
+    (newer / "hfl-agent-1.1.0-windows-amd64.zip").write_bytes(b"x")
+
+    assert (
+        latest_compatible_agent_version("linux", "amd64", "proxy", "22.04")
+        == "1.0.0"
+    )
+
+
+def test_latest_compatible_agent_version_is_empty_without_exact_bundle(
+    releases_root,
+):
+    version_dir = releases_root / "1.1.0"
+    version_dir.mkdir()
+    (version_dir / "hfl-agent-1.1.0-linux-amd64-ubuntu2404.tar.gz").write_bytes(b"x")
+
+    assert latest_compatible_agent_version("linux", "arm64", "proxy", "24.04") == ""
 
 
 def test_semver_compare_orders_versions():

--- a/src/backend/apps/node/tests/test_node_enrichment_api.py
+++ b/src/backend/apps/node/tests/test_node_enrichment_api.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+from tempfile import TemporaryDirectory
 from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
@@ -50,6 +52,40 @@ class NodeEnrichmentReadOnlyTests(TestCase):
         )
         self.assertEqual(response.status_code, 200)
         mock_advance.assert_not_called()
+
+    def test_list_nodes_reports_compatible_agent_release(self):
+        self.node.role = NodeRole.PROXY
+        self.node.version = "1.0.0"
+        self.node.metadata = {
+            "inventory": {
+                "os": "linux",
+                "arch": "amd64",
+                "os_version": "22.04",
+            }
+        }
+        self.node.save(update_fields=["role", "version", "metadata"])
+
+        with TemporaryDirectory() as media_root:
+            release_dir = Path(media_root) / "agent-releases" / "1.1.0"
+            release_dir.mkdir(parents=True)
+            (
+                release_dir
+                / "hfl-agent-1.1.0-linux-amd64-ubuntu2204.tar.gz"
+            ).write_bytes(b"x")
+            with self.settings(MEDIA_ROOT=media_root):
+                client = APIClient()
+                client.force_authenticate(user=self.user)
+                response = client.get(
+                    "/api/v1/node/nodes/",
+                    HTTP_X_ORG_KEY=self.org.key,
+                )
+
+        self.assertEqual(response.status_code, 200)
+        release = response.data[0]["agent_release"]
+        self.assertEqual(release["current_version"], "1.0.0")
+        self.assertEqual(release["target_version"], "1.1.0")
+        self.assertTrue(release["update_available"])
+        self.assertTrue(release["upgrade_version_allowed"])
 
 
 class NodeLifecycleWatchApiTests(TestCase):

--- a/src/frontend/src/components/node-lifecycle/NodeVersionCell.test.ts
+++ b/src/frontend/src/components/node-lifecycle/NodeVersionCell.test.ts
@@ -1,0 +1,98 @@
+// @vitest-environment jsdom
+
+import { mount } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import { describe, expect, it } from 'vitest'
+import NodeVersionCell from './NodeVersionCell.vue'
+import type { ApiNode } from '../../types/node'
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: {
+    en: {
+      nodesPage: {
+        versionUpgradeAvailable: 'New version',
+        latestVersionTip: 'Latest version: {version}',
+      },
+    },
+  },
+})
+
+const node: ApiNode = {
+  id: 1,
+  organization: 1,
+  name: 'proxy-1',
+  role: 'proxy',
+  status: 'active',
+  version: '0.2.3',
+}
+
+function mountCell(overrides: Record<string, unknown> = {}) {
+  return mount(NodeVersionCell, {
+    props: {
+      node,
+      versionLabel: '0.2.3',
+      targetVersion: '0.2.10',
+      updateAvailable: true,
+      ...overrides,
+    },
+    global: {
+      plugins: [i18n],
+      stubs: {
+        ElTooltip: {
+          template: '<div class="tooltip-stub"><slot /></div>',
+        },
+      },
+    },
+  })
+}
+
+describe('NodeVersionCell', () => {
+  it('shows an accessible update hint for a compatible newer release', () => {
+    const wrapper = mountCell()
+    expect(wrapper.text()).toContain('0.2.3')
+    expect(wrapper.text()).toContain('New version')
+    const hint = wrapper.get('.node-version-cell__hint')
+    expect(hint.classes()).toContain('hfl-table-no-tooltip')
+    expect(hint.attributes('aria-label')).toBe(
+      'Latest version: 0.2.10',
+    )
+  })
+
+  it.each([
+    { updateAvailable: false },
+    { targetVersion: null },
+    { showUpdateHint: false },
+  ])('hides the update hint for %o', (props) => {
+    expect(mountCell(props).find('.node-version-cell__hint').exists()).toBe(false)
+  })
+
+  it('suppresses the hint while the server reports an active upgrade', () => {
+    const upgradingNode: ApiNode = {
+      ...node,
+      lifecycle: {
+        kind: 'upgrade',
+        state: 'upgrading',
+        target_version: '0.2.10',
+      },
+    }
+    const wrapper = mountCell({ node: upgradingNode })
+
+    expect(wrapper.text()).toContain('0.2.3')
+    expect(wrapper.text()).toContain('0.2.10')
+    expect(wrapper.find('.node-version-cell__hint').exists()).toBe(false)
+  })
+
+  it('suppresses the hint for a locally queued upgrade display', () => {
+    const wrapper = mountCell({
+      resolveVersionDisplay: () => ({
+        upgrading: true,
+        versionLabel: '0.2.3',
+        targetVersion: '0.2.10',
+      }),
+    })
+
+    expect(wrapper.find('.node-version-cell__hint').exists()).toBe(false)
+  })
+})

--- a/src/frontend/src/components/node-lifecycle/NodeVersionCell.vue
+++ b/src/frontend/src/components/node-lifecycle/NodeVersionCell.vue
@@ -1,15 +1,27 @@
 <script setup lang="ts">
 import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { TriangleAlert } from 'lucide-vue-next'
+import { ElTooltip } from 'element-plus'
 import type { ApiNode } from '../../types/node'
 
-const props = defineProps<{
+const props = withDefaults(defineProps<{
   node: ApiNode
   versionLabel: string
+  targetVersion?: string | null
+  updateAvailable?: boolean
+  showUpdateHint?: boolean
   resolveVersionDisplay?: (
     node: ApiNode,
     versionLabel: string,
   ) => { upgrading: boolean; versionLabel: string; targetVersion: string }
-}>()
+}>(), {
+  targetVersion: null,
+  showUpdateHint: true,
+  resolveVersionDisplay: undefined,
+})
+
+const { t } = useI18n()
 
 const display = computed(() => {
   if (props.resolveVersionDisplay) {
@@ -25,6 +37,17 @@ const display = computed(() => {
     targetVersion: lc?.target_version || '',
   }
 })
+
+const showsUpdate = computed(() =>
+  props.showUpdateHint !== false
+  && !display.value.upgrading
+  && props.updateAvailable === true
+  && Boolean(props.targetVersion),
+)
+
+const updateLabel = computed(() => t('nodesPage.latestVersionTip', {
+  version: props.targetVersion || '—',
+}))
 </script>
 
 <template>
@@ -41,6 +64,24 @@ const display = computed(() => {
       v-else
       class="node-version-cell__value"
     >{{ display.versionLabel }}</span>
+    <ElTooltip
+      v-if="showsUpdate"
+      :content="updateLabel"
+      placement="top"
+    >
+      <span
+        class="node-version-cell__hint hfl-table-no-tooltip"
+        tabindex="0"
+        :aria-label="updateLabel"
+      >
+        <TriangleAlert
+          :size="14"
+          stroke-width="2.1"
+          aria-hidden="true"
+        />
+        <span>{{ t('nodesPage.versionUpgradeAvailable') }}</span>
+      </span>
+    </ElTooltip>
   </div>
 </template>
 
@@ -64,6 +105,24 @@ const display = computed(() => {
 
 .node-version-cell__arrow {
   display: none;
+}
+
+.node-version-cell__hint {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  max-width: 100%;
+  color: var(--el-color-warning-dark-2);
+  font-size: 12px;
+  line-height: 1.2;
+  cursor: default;
+}
+
+.node-version-cell__hint > span:last-child {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .node-version-cell--upgrading {

--- a/src/frontend/src/lib/lensApi.ts
+++ b/src/frontend/src/lib/lensApi.ts
@@ -272,6 +272,7 @@ export type LensGatewayInsight = {
   sl_last_heartbeat_at?: string | null
   sl_registered_at?: string | null
   sl_tasks?: { name: string; title: string }[]
+  agent_release?: import('../types/node').AgentReleaseStatus | null
 }
 
 export type SlLensnodeTask = {

--- a/src/frontend/src/pages/insight/InsightDataGateways.vue
+++ b/src/frontend/src/pages/insight/InsightDataGateways.vue
@@ -209,7 +209,8 @@ const batchUpgradeDisabled = computed(() => {
 
 function canUpgrade(row: ApiNode) {
   if ((row as InsightGatewayRow).managed_by_hfl === false) return false
-  return canRemoteAgentUpgrade(row.version, latestAgentVersion.value)
+  return row.agent_release?.upgrade_version_allowed
+    ?? canRemoteAgentUpgrade(row.version, latestAgentVersion.value)
 }
 
 function platformLabel(row: ApiNode) {
@@ -987,6 +988,9 @@ onUnmounted(() => {
               <NodeVersionCell
                 :node="row"
                 :version-label="row.version || '—'"
+                :target-version="row.agent_release?.target_version"
+                :update-available="row.agent_release?.update_available"
+                :show-update-hint="row.managed_by_hfl !== false"
                 :resolve-version-display="lifecycleOps.resolveVersionDisplay"
               />
             </template>

--- a/src/frontend/src/pages/node/Nodes.vue
+++ b/src/frontend/src/pages/node/Nodes.vue
@@ -2,7 +2,7 @@
 import { computed, onMounted, reactive, ref, watch } from 'vue'
 import { RouterLink, useRoute, useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
-import { ArrowUpCircle, Plus, RefreshCw, Pencil, ChevronDown, Trash2, TriangleAlert, Search, Wrench } from 'lucide-vue-next'
+import { ArrowUpCircle, Plus, RefreshCw, Pencil, ChevronDown, Trash2, Search, Wrench } from 'lucide-vue-next'
 import { ElCheckbox, ElMessage, type ElTable } from 'element-plus'
 import NodeLifecycleStatusCell from '../../components/node-lifecycle/NodeLifecycleStatusCell.vue'
 import NodeVersionCell from '../../components/node-lifecycle/NodeVersionCell.vue'
@@ -25,7 +25,7 @@ import { apiErrorMessage } from '../../lib/api'
 import { afterOverlayDismiss } from '../../lib/uiDefer'
 import { LIST_ROUTE_REFRESH_KEY, stripListRefreshQuery } from '../../lib/listRouteRefresh'
 import { listNodesPaged, listAllNodes, updateNode, fetchLatestAgentVersion, getNodeBindings, previewNodeOperationsBatch, type NodeBindings } from '../../lib/nodeApi'
-import { canRemoteAgentUpgrade, needsAgentUpgrade } from '../../lib/agentVersion'
+import { canRemoteAgentUpgrade } from '../../lib/agentVersion'
 import { backupSourceLifecycleDisplay } from '../../lib/backupSourceLifecycleDisplay'
 import {
   formatNodeBytes,
@@ -98,8 +98,6 @@ function availabilityTagType(value?: ApiNode['availability']): 'success' | 'dang
 const protectionMenus = useProtectionSideNav()
 
 const nodeMenus = computed(() => protectionMenus.value)
-
-const latestVersion = computed(() => latestAgentVersion.value)
 
 async function loadLatestAgentVersion(signal?: AbortSignal) {
   if (!usesRealNodeList.value) {
@@ -310,15 +308,8 @@ function roleTagType(role: NodeRole | string): 'primary' | 'success' | 'warning'
 }
 
 function canUpgrade(row: ApiNode): boolean {
-  return canRemoteAgentUpgrade(row.version, latestAgentVersion.value)
-}
-
-function needsUpgrade(row: ApiNode): boolean {
-  return needsAgentUpgrade(row.version, latestAgentVersion.value)
-}
-
-function upgradeTargetVersion(row: ApiNode) {
-  return needsUpgrade(row) ? latestVersion.value ?? '—' : '—'
+  return row.agent_release?.upgrade_version_allowed
+    ?? canRemoteAgentUpgrade(row.version, latestAgentVersion.value)
 }
 
 function statusTagType(status: NodeStatus): 'success' | 'info' | 'danger' {
@@ -917,6 +908,8 @@ async function submitRename() {
                   <NodeVersionCell
                     :node="row"
                     :version-label="row.version || '—'"
+                    :target-version="row.agent_release?.target_version"
+                    :update-available="row.agent_release?.update_available"
                     :resolve-version-display="lifecycleOps.resolveVersionDisplay"
                   />
                 </template>
@@ -993,31 +986,14 @@ async function submitRename() {
                     v-if="usesRealNodeList"
                     :node="row"
                     :version-label="row.version || '—'"
+                    :target-version="row.agent_release?.target_version"
+                    :update-available="row.agent_release?.update_available"
                     :resolve-version-display="lifecycleOps.resolveVersionDisplay"
                   />
-                  <div
+                  <span
                     v-else
-                    class="nodes-version-cell"
-                    :class="{ 'nodes-version-cell--stacked': needsUpgrade(row) && latestVersion }"
-                  >
-                    <span
-                      class="nodes-version-cell__value"
-                      :class="{ 'hfl-empty-mark': !row.version }"
-                    >{{ row.version || '—' }}</span>
-                    <ElTooltip
-                      v-if="needsUpgrade(row) && latestVersion"
-                      :content="t('nodesPage.latestVersionTip', { version: upgradeTargetVersion(row) })"
-                      placement="top"
-                    >
-                      <span class="nodes-version-cell__hint">
-                        <TriangleAlert
-                          :size="14"
-                          stroke-width="2.1"
-                        />
-                        <span>{{ t('nodesPage.versionUpgradeAvailable') }}</span>
-                      </span>
-                    </ElTooltip>
-                  </div>
+                    :class="{ 'hfl-empty-mark': !row.version }"
+                  >{{ row.version || '—' }}</span>
                 </template>
               </el-table-column>
             </template>

--- a/src/frontend/src/pages/node/NodesVersionUpgradeHint.test.ts
+++ b/src/frontend/src/pages/node/NodesVersionUpgradeHint.test.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const source = readFileSync(resolve(__dirname, 'Nodes.vue'), 'utf8')
+
+describe('proxy node version upgrade hint wiring', () => {
+  it('passes compatible release state to the shared version cell', () => {
+    expect(source).toContain(':target-version="row.agent_release?.target_version"')
+    expect(source).toContain(':update-available="row.agent_release?.update_available"')
+    expect(source).toContain('row.agent_release?.upgrade_version_allowed')
+    expect(source).toContain('canRemoteAgentUpgrade(row.version, latestAgentVersion.value)')
+    expect(source).not.toContain("t('nodesPage.versionUpgradeAvailable')")
+  })
+})

--- a/src/frontend/src/pages/protection/BackupSources.vue
+++ b/src/frontend/src/pages/protection/BackupSources.vue
@@ -63,7 +63,7 @@ import { buildNasSourceCreatePayload } from '../../lib/nasSourceCreate'
 import { defaultNasMountOptions } from '../../lib/nasMountOptions'
 import { preflightSourceNasCreate, showNasDraftPreflightGuidance } from '../../lib/nasDraftPreflight'
 import { listNodes, listNodesPaged, updateNode, fetchLatestAgentVersion, type EnrollmentOs } from '../../lib/nodeApi'
-import { canRemoteAgentUpgrade, needsAgentUpgrade } from '../../lib/agentVersion'
+import { canRemoteAgentUpgrade } from '../../lib/agentVersion'
 import { backupSourceLifecycleDisplay } from '../../lib/backupSourceLifecycleDisplay'
 import type { ApiNode } from '../../types/node'
 import {
@@ -133,10 +133,10 @@ const listSearchPlaceholder = computed(() => t('protection.listSearch.placeholde
 /* ---------- data ---------- */
 const busy = ref(false)
 const rows = ref<SourceResource[]>([])
+const latestAgentVersion = ref<string | null>(null)
 const stats = ref<SourceStats | null>(null)
 const agentNodes = ref<ApiNode[]>([])
 /** Published agent release from media/agent-releases (upgrade target). */
-const latestAgentVersion = ref<string | null>(null)
 /** Local source rows keyed by agent node — enrichment only (capacity), not host list data. */
 const hostSourceRows = ref<SourceResource[]>([])
 const proxyNodes = ref<ApiNode[]>([])
@@ -731,7 +731,7 @@ function agentPlatformLabel(node: ApiNode) {
 function agentInstalledVersion(node: ApiNode) {
   const source = localSourceByNodeId.value.get(node.id)
   const fromSource = source ? sourceConfigValue(source, 'agent_version') : ''
-  return (fromSource || node.version || '').trim()
+  return (node.version || fromSource || '').trim()
 }
 
 function agentVersion(node: ApiNode) {
@@ -742,20 +742,8 @@ function agentVersion(node: ApiNode) {
 
 
 function agentCanUpgrade(node: ApiNode) {
-  return canRemoteAgentUpgrade(agentInstalledVersion(node), latestAgentVersion.value)
-}
-
-function agentNeedsUpgrade(node: ApiNode): boolean {
-  return needsAgentUpgrade(agentInstalledVersion(node), latestAgentVersion.value)
-}
-
-function agentUpgradeTargetVersion(node: ApiNode) {
-  return agentNeedsUpgrade(node) ? latestAgentVersion.value ?? '—' : '—'
-}
-
-function agentIsUpgrading(node: ApiNode): boolean {
-  const lc = node.lifecycle
-  return lc?.kind === 'upgrade' && ['upgrading', 'restarting', 'verifying', 'queued'].includes(lc.state)
+  return node.agent_release?.upgrade_version_allowed
+    ?? canRemoteAgentUpgrade(agentInstalledVersion(node), latestAgentVersion.value)
 }
 
 function agentOnlineLabel(node: ApiNode) {
@@ -2391,29 +2379,13 @@ onUnmounted(() => {
               min-width="115"
             >
               <template #default="{ row }">
-                <div
-                  class="source-version-cell"
-                  :class="{ 'source-version-cell--stacked': agentNeedsUpgrade(row) && latestAgentVersion }"
-                >
-                  <NodeVersionCell
-                    :node="row"
-                    :version-label="agentVersion(row)"
-                    :resolve-version-display="lifecycleOps.resolveVersionDisplay"
-                  />
-                  <ElTooltip
-                    v-if="agentNeedsUpgrade(row) && latestAgentVersion && !agentIsUpgrading(row)"
-                    :content="t('nodesPage.latestVersionTip', { version: agentUpgradeTargetVersion(row) })"
-                    placement="top"
-                  >
-                    <span class="source-version-cell__hint">
-                      <TriangleAlert
-                        :size="14"
-                        stroke-width="2.1"
-                      />
-                      <span>{{ t('nodesPage.versionUpgradeAvailable') }}</span>
-                    </span>
-                  </ElTooltip>
-                </div>
+                <NodeVersionCell
+                  :node="row"
+                  :version-label="agentVersion(row)"
+                  :target-version="row.agent_release?.target_version"
+                  :update-available="row.agent_release?.update_available"
+                  :resolve-version-display="lifecycleOps.resolveVersionDisplay"
+                />
               </template>
             </el-table-column>
             <el-table-column
@@ -3791,22 +3763,4 @@ onUnmounted(() => {
   max-width: none;
 }
 
-.source-version-cell {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-}
-
-.source-version-cell--stacked {
-  gap: 4px;
-}
-
-.source-version-cell__hint {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  font-size: 12px;
-  color: rgb(180 83 9);
-  cursor: default;
-}
 </style>

--- a/src/frontend/src/types/node.ts
+++ b/src/frontend/src/types/node.ts
@@ -60,6 +60,14 @@ export type ApiNode = {
   lifecycle?: NodeLifecycleInfo | null
   workload?: NodeWorkloadInfo | null
   associated_repository_count?: number
+  agent_release?: AgentReleaseStatus | null
+}
+
+export type AgentReleaseStatus = {
+  current_version: string | null
+  target_version: string | null
+  update_available: boolean
+  upgrade_version_allowed: boolean
 }
 
 export type ApiNodeToken = {


### PR DESCRIPTION
## Summary

- resolve each managed Agent's upgrade target from the published bundle matching its role, platform, architecture, and OS release
- expose compatible release state in node and managed gateway APIs and render one shared accessible upgrade hint across Proxy Hosts, source hosts, and Data Gateways
- preserve mixed-version UI fallback behavior and suppress duplicate table overflow tooltips

## Testing

- `npm run test -- src/components/node-lifecycle/NodeVersionCell.test.ts src/pages/node/NodesVersionUpgradeHint.test.ts`
- `npm run build`
- targeted ESLint for changed frontend files
- `python manage.py test apps.node.tests.test_node_enrichment_api apps.node.tests.test_node_lifecycle apps.node.tests.test_node_operations_api apps.lens_bridge.tests.test_gateway_insights --noinput --keepdb` (53 tests)
- `git diff --check`

Closes #777