### PR TITLE
Fix repository cleanup coordination with health probes

### DIFF
--- a/src/backend/apps/storage/services/internal/repository_cleanup.py
+++ b/src/backend/apps/storage/services/internal/repository_cleanup.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+import logging
 import os
 import shutil
 from pathlib import Path
 from typing import Any, Iterable
 
 from django.apps import apps
+from django.core.cache import cache
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.db import transaction
 from django.db.models import Q
@@ -15,6 +17,7 @@ from apps.audit.constants import AuditAction, AuditResult, AuditResourceType
 from apps.audit.services.interface import write_audit_log
 from apps.iam.models import Organization
 from apps.node.models import Node, NodeTask
+from apps.node.services.interface import cancel_agent_task
 from apps.node.services.capabilities import node_capabilities
 from apps.storage.repositories.models import (
     Credential,
@@ -58,6 +61,9 @@ from apps.storage.services.internal.repository_initializer import (
     RepositoryInitializationError,
     check_s3_repository,
 )
+from apps.storage.services.internal.repository_health import (
+    repository_health_lock_key,
+)
 from apps.storage.services.internal.repository_ownership import (
     RepositoryOwnershipMarkerMissingError,
     ownership_payload_for_node,
@@ -89,9 +95,14 @@ from apps.task.services.recovery import (
 )
 
 
+logger = logging.getLogger(__name__)
+
+
 ACTIVE_TASK_STATUSES = (Task.Status.PENDING, Task.Status.RUNNING)
+_AUTOMATIC_HEALTH_PROBE_CANCEL_RETRY_SECONDS = 30
 CLEANUP_STEPS = (
     "check_cleanup_dependencies",
+    "waiting_for_system_probe",
     "verify_cleanup_owner",
     "prepare_cleanup_target",
     "delete_physical_repository",
@@ -109,6 +120,67 @@ class RepositoryCleanupBlocked(ValidationError):
     def __init__(self, preflight: dict[str, Any]):
         super().__init__("Repository cleanup is blocked.")
         self.preflight = preflight
+
+
+def _is_automatic_repository_health_probe(
+    *, node_task: NodeTask, repository: Repository
+) -> bool:
+    """Return whether a NodeTask is the system probe we may coordinate.
+
+    A task named ``repo.status`` is not sufficient evidence: users and older
+    versions can create the same command for a real repository operation.  All
+    persisted identity fields must agree before cleanup is allowed to cancel
+    it automatically.
+    """
+    payload = node_task.payload if isinstance(node_task.payload, dict) else {}
+    return bool(
+        node_task.kind == "repo.status"
+        and node_task.correlation_type == "storage.repository_health"
+        and str(node_task.correlation_id or "") == str(repository.id)
+        and payload.get("automatic_health_probe") is True
+        and str(payload.get("repository_id") or "") == str(repository.id)
+    )
+
+
+def _active_automatic_repository_health_probes(
+    *, repository: Repository
+) -> list[NodeTask]:
+    """List only active, explicitly identified automatic health probes."""
+    candidates = (
+        NodeTask.objects.filter(
+            organization_id=repository.organization_id,
+            status__in=[NodeTask.Status.PENDING, NodeTask.Status.RUNNING],
+            kind="repo.status",
+            correlation_type="storage.repository_health",
+            correlation_id=str(repository.id),
+        )
+        .select_related("node")
+        .order_by("created_at", "id")
+    )
+    return [
+        task
+        for task in candidates
+        if _is_automatic_repository_health_probe(
+            node_task=task,
+            repository=repository,
+        )
+    ]
+
+
+def _controller_repository_health_probe_active(
+    *, repository: Repository
+) -> bool:
+    """Return whether the synchronous Controller health probe still holds."""
+    try:
+        return cache.get(repository_health_lock_key(repository.id)) is not None
+    except Exception:
+        # Redis availability is not evidence that the probe stopped. Keep the
+        # cleanup fail-closed and let the durable retry proceed after recovery.
+        logger.exception(
+            "failed to read repository health lock repository_id=%s",
+            repository.id,
+        )
+        return True
 
 
 def repository_active_task_blockers(
@@ -134,6 +206,18 @@ def repository_active_task_blockers(
         )
     remaining = max(0, 50 - len(blockers))
     if remaining:
+        automatic_probe_filter = (
+            Q(
+                kind="repo.status",
+                correlation_type="storage.repository_health",
+                correlation_id=str(repository.id),
+                payload__automatic_health_probe=True,
+            )
+            & (
+                Q(payload__repository_id=repository.id)
+                | Q(payload__repository_id=str(repository.id))
+            )
+        )
         active_node_tasks = (
             NodeTask.objects.filter(
                 organization_id=repository.organization_id,
@@ -151,9 +235,18 @@ def repository_active_task_blockers(
                 | Q(payload__repository__id=repository.id)
                 | Q(payload__repository__id=str(repository.id))
             )
+            .exclude(automatic_probe_filter)
+            .select_related("node")
             .order_by("-created_at", "-id")[:remaining]
         )
         for node_task in active_node_tasks:
+            if _is_automatic_repository_health_probe(
+                node_task=node_task,
+                repository=repository,
+            ):
+                # System health probes are coordinated by the cleanup task;
+                # all user/data operations remain hard blockers below.
+                continue
             blockers.append(
                 {
                     "code": "active_repository_node_task",
@@ -163,8 +256,17 @@ def repository_active_task_blockers(
                     ),
                     "node_task_id": str(node_task.id),
                     "node_task_kind": node_task.kind,
+                    "node_id": node_task.node_id,
+                    "node_name": node_task.node.name,
+                    "node_address": str(
+                        node_task.node.ip_address
+                        or node_task.node.connection_ip_address
+                        or ""
+                    ),
                 }
             )
+            if len(blockers) >= 50:
+                break
     return blockers
 
 
@@ -341,6 +443,42 @@ def repository_cleanup_preflight(
             ignored_task_ids=ignored,
         )
     )
+
+    automatic_probes = _active_automatic_repository_health_probes(
+        repository=repository
+    )
+    controller_probe_active = _controller_repository_health_probe_active(
+        repository=repository
+    )
+    controller_probe_only = controller_probe_active and not automatic_probes
+    if automatic_probes or controller_probe_only:
+        warnings.append(
+            {
+                "code": "automatic_repository_health_probe",
+                "detail": (
+                    f"{len(automatic_probes) + int(controller_probe_only)} "
+                    "background repository health check(s) "
+                    "will be stopped before physical cleanup."
+                ),
+                "count": len(automatic_probes) + int(controller_probe_only),
+                "node_task_ids": [str(item.id) for item in automatic_probes],
+                "tasks": [
+                    {
+                        "node_task_id": str(item.id),
+                        "node_id": item.node_id,
+                        "node_name": item.node.name,
+                        "node_address": str(
+                            item.node.ip_address
+                            or item.node.connection_ip_address
+                            or ""
+                        ),
+                        "status": item.status,
+                    }
+                    for item in automatic_probes
+                ],
+                "controller_probe_active": controller_probe_active,
+            }
+        )
 
     active_cleanup = (
         _logical_cleanup_tasks(repository)
@@ -647,6 +785,89 @@ def create_direct_nas_target_cleanup_task(
         return repository_task
 
 
+def _wait_for_automatic_repository_health_probes(
+    *, repository_task: RepositoryTask, task: Task
+) -> dict[str, Any] | None:
+    """Cancel background probes and schedule a non-blocking follow-up.
+
+    The cleanup worker must never sleep while an Agent acknowledges a cancel
+    request.  Returning ``waiting`` leaves the durable parent task running;
+    the delayed idempotent advance (and the existing reconciliation sweep)
+    resumes it after the Agent reaches a terminal state.
+    """
+    probes = _active_automatic_repository_health_probes(
+        repository=repository_task.repository
+    )
+    controller_probe_active = _controller_repository_health_probe_active(
+        repository=repository_task.repository
+    )
+    if not probes and not controller_probe_active:
+        if task.current_step == "waiting_for_system_probe":
+            _set_cleanup_step(
+                task,
+                "waiting_for_system_probe",
+                TaskStep.Status.SUCCESS,
+                max(10, int(task.progress or 0)),
+            )
+        return None
+
+    for probe in probes:
+        try:
+            cancel_agent_task(
+                task_id=probe.id,
+                reason="Repository cleanup is stopping the background health probe.",
+            )
+        except Exception:
+            # A transient control-plane failure must keep cleanup in the
+            # waiting state; it must never turn into an implicit permission to
+            # delete while the probe may still be using the repository.
+            logger.exception(
+                "failed to cancel automatic repository health probe node_task_id=%s",
+                probe.id,
+            )
+
+    _set_cleanup_step(
+        task,
+        "waiting_for_system_probe",
+        TaskStep.Status.RUNNING,
+        min(7, max(5, int(task.progress or 0))),
+    )
+    append_task_event(
+        task=task,
+        step=task.steps.filter(step_name="waiting_for_system_probe").first(),
+        level=TaskEvent.Level.INFO,
+        message="Waiting for background repository health probes to stop",
+        metadata={
+            "node_task_ids": [str(probe.id) for probe in probes],
+            "node_ids": [probe.node_id for probe in probes],
+            "controller_probe_active": controller_probe_active,
+            "retry_after_seconds": _AUTOMATIC_HEALTH_PROBE_CANCEL_RETRY_SECONDS,
+        },
+    )
+    from apps.storage.tasks import execute_repository_operation
+
+    try:
+        execute_repository_operation.apply_async(
+            kwargs={"repository_task_id": repository_task.id},
+            countdown=_AUTOMATIC_HEALTH_PROBE_CANCEL_RETRY_SECONDS,
+        )
+    except Exception:
+        # The durable parent remains RUNNING so the existing repository
+        # reconciliation sweep can requeue it when the broker recovers.
+        logger.exception(
+            "failed to schedule repository cleanup probe follow-up repository_task_id=%s",
+            repository_task.id,
+        )
+    return {
+        "status": "waiting",
+        "repository_task_id": repository_task.id,
+        "waiting_for": "automatic_repository_health_probe",
+        "node_task_ids": [str(probe.id) for probe in probes],
+        "controller_probe_active": controller_probe_active,
+        "retry_after_seconds": _AUTOMATIC_HEALTH_PROBE_CANCEL_RETRY_SECONDS,
+    }
+
+
 def run_repository_cleanup_task(*, repository_task_id: int) -> dict[str, Any]:
     repository_task = RepositoryTask.objects.select_related(
         "task",
@@ -697,6 +918,12 @@ def run_repository_cleanup_task(*, repository_task_id: int) -> dict[str, Any]:
         }
 
     try:
+        probe_wait = _wait_for_automatic_repository_health_probes(
+            repository_task=repository_task,
+            task=task,
+        )
+        if probe_wait is not None:
+            return probe_wait
         resuming_physical_delete = (
             not started_now
             and task.current_step == "delete_physical_repository"

--- a/src/backend/apps/storage/services/internal/repository_health.py
+++ b/src/backend/apps/storage/services/internal/repository_health.py
@@ -77,6 +77,11 @@ logger = logging.getLogger(__name__)
 REPOSITORY_HEALTH_PROBE_CORRELATION_TYPE = "storage.repository_health"
 
 
+def repository_health_lock_key(repository_id: int) -> str:
+    """Return the shared cache lock key for one health probe generation."""
+    return f"storage:repository-health:repository:{int(repository_id)}"
+
+
 class _AgentProbeState(StrEnum):
     ONLINE = "online"
     CONFIRMED_FAILURE = "confirmed_failure"
@@ -197,18 +202,27 @@ def dispatch_automatic_repository_observation(
                     payload__include_usage=include_usage,
                 ).order_by("created_at", "id")
             )
-        current = Repository.objects.filter(
-            pk=repository.id,
-            organization_id=repository.organization_id,
-            status=Repository.Status.CREATED,
-        ).first()
-        if current is None:
-            return []
-        return _dispatch_automatic_repository_observation_locked(
-            repository=current,
-            retry_attempt=retry_attempt,
-            include_usage=include_usage,
-        )
+        # Serialize the final eligibility check with Repository cleanup. A
+        # health sweep may have read CREATED just before cleanup changes the
+        # row to REMOVING; the row lock prevents it from creating a late probe
+        # after cleanup has passed its coordination gate.
+        with transaction.atomic():
+            current = (
+                Repository.objects.select_for_update()
+                .filter(
+                    pk=repository.id,
+                    organization_id=repository.organization_id,
+                    status=Repository.Status.CREATED,
+                )
+                .first()
+            )
+            if current is None:
+                return []
+            return _dispatch_automatic_repository_observation_locked(
+                repository=current,
+                retry_attempt=retry_attempt,
+                include_usage=include_usage,
+            )
 
 
 def _dispatch_automatic_repository_observation_locked(

--- a/src/backend/apps/storage/tasks.py
+++ b/src/backend/apps/storage/tasks.py
@@ -25,6 +25,7 @@ from apps.storage.services.internal.repository_health import (
     dispatch_automatic_repository_observation,
     is_repository_ownership_failure,
     probe_repository_health,
+    repository_health_lock_key,
 )
 from apps.storage.services.internal.repository_errors import (
     is_repository_health_transport_unconfirmed,
@@ -78,7 +79,7 @@ _REPOSITORY_OPERATION_CONFLICT_RETRY_SECONDS = 3
 
 
 def _repository_health_lock(repository_id: int) -> str:
-    return f"storage:repository-health:repository:{int(repository_id)}"
+    return repository_health_lock_key(repository_id)
 
 
 def _repository_health_startup_dispatch_lock() -> str:

--- a/src/backend/apps/storage/tests/test_repository_cleanup.py
+++ b/src/backend/apps/storage/tests/test_repository_cleanup.py
@@ -1,3 +1,4 @@
+from datetime import timedelta
 from unittest import mock
 
 from django.contrib.auth import get_user_model
@@ -126,6 +127,141 @@ class RepositoryCleanupTests(TestCase):
             ]
         )
         return claim
+
+    def _automatic_health_probe(self, repository: Repository) -> NodeTask:
+        node = Node.objects.create(
+            organization=self.org,
+            name="cleanup-health-proxy",
+            role=Node.Role.PROXY,
+            status=Node.Status.ACTIVE,
+            availability=Node.Availability.ONLINE,
+        )
+        return NodeTask.objects.create(
+            organization=self.org,
+            requesting_organization_id=self.org.id,
+            node=node,
+            kind="repo.status",
+            correlation_type="storage.repository_health",
+            correlation_id=str(repository.id),
+            payload={
+                "automatic_health_probe": True,
+                "repository_id": repository.id,
+            },
+            status=NodeTask.Status.RUNNING,
+            watchdog_deadline_at=timezone.now() + timedelta(minutes=5),
+        )
+
+    def test_automatic_health_probe_is_coordinated_not_a_hard_blocker(self):
+        repository = self._s3_repository(name="automatic-probe-cleanup")
+        probe = self._automatic_health_probe(repository)
+
+        preflight = repository_cleanup_preflight(repository=repository)
+
+        self.assertTrue(preflight["allowed"])
+        warning = next(
+            item
+            for item in preflight["warnings"]
+            if item["code"] == "automatic_repository_health_probe"
+        )
+        self.assertEqual(warning["node_task_ids"], [str(probe.id)])
+
+    def test_unidentified_repo_status_remains_a_hard_blocker(self):
+        repository = self._s3_repository(name="manual-probe-cleanup")
+        node = Node.objects.create(
+            organization=self.org,
+            name="manual-check-proxy",
+            role=Node.Role.PROXY,
+            status=Node.Status.ACTIVE,
+            availability=Node.Availability.ONLINE,
+        )
+        NodeTask.objects.create(
+            organization=self.org,
+            requesting_organization_id=self.org.id,
+            node=node,
+            kind="repo.status",
+            correlation_type="storage_repository",
+            correlation_id=str(repository.id),
+            payload={"repository_id": repository.id},
+            status=NodeTask.Status.RUNNING,
+            watchdog_deadline_at=timezone.now() + timedelta(minutes=5),
+        )
+
+        preflight = repository_cleanup_preflight(repository=repository)
+
+        self.assertFalse(preflight["allowed"])
+        self.assertTrue(
+            any(
+                blocker["code"] == "active_repository_node_task"
+                for blocker in preflight["blockers"]
+            )
+        )
+
+    @mock.patch("apps.storage.tasks.execute_repository_operation.apply_async")
+    @mock.patch(
+        "apps.storage.services.internal.repository_cleanup._execute_physical_cleanup"
+    )
+    @mock.patch(
+        "apps.storage.services.internal.repository_cleanup.cancel_agent_task"
+    )
+    def test_cleanup_waits_for_automatic_probe_without_running_physical_delete(
+        self,
+        cancel_agent_task_mock,
+        execute_physical_cleanup_mock,
+        apply_async_mock,
+    ):
+        repository = self._s3_repository(name="wait-for-probe-cleanup")
+        probe = self._automatic_health_probe(repository)
+        repository_task = create_repository_cleanup_task(
+            repository=repository,
+            dispatch=False,
+        )
+
+        result = run_repository_cleanup_task(repository_task_id=repository_task.id)
+
+        self.assertEqual(result["status"], "waiting")
+        self.assertEqual(
+            result["waiting_for"], "automatic_repository_health_probe"
+        )
+        cancel_agent_task_mock.assert_called_once_with(
+            task_id=probe.id,
+            reason="Repository cleanup is stopping the background health probe.",
+        )
+        apply_async_mock.assert_called_once_with(
+            kwargs={"repository_task_id": repository_task.id},
+            countdown=30,
+        )
+        execute_physical_cleanup_mock.assert_not_called()
+
+    @mock.patch("apps.storage.tasks.execute_repository_operation.apply_async")
+    @mock.patch(
+        "apps.storage.services.internal.repository_cleanup._execute_physical_cleanup"
+    )
+    @mock.patch(
+        "apps.storage.services.internal.repository_cleanup.cache.get",
+        return_value="health-probe-lock",
+    )
+    def test_cleanup_waits_for_controller_health_probe(
+        self,
+        cache_get_mock,
+        execute_physical_cleanup_mock,
+        apply_async_mock,
+    ):
+        repository = self._s3_repository(name="wait-for-controller-probe")
+        repository_task = create_repository_cleanup_task(
+            repository=repository,
+            dispatch=False,
+        )
+
+        result = run_repository_cleanup_task(repository_task_id=repository_task.id)
+
+        self.assertEqual(result["status"], "waiting")
+        self.assertTrue(result["controller_probe_active"])
+        cache_get_mock.assert_called()
+        apply_async_mock.assert_called_once_with(
+            kwargs={"repository_task_id": repository_task.id},
+            countdown=30,
+        )
+        execute_physical_cleanup_mock.assert_not_called()
 
     def test_initialization_in_progress_is_never_treated_as_unused_storage(self):
         repository = Repository.objects.create(

--- a/src/backend/apps/storage/tests/test_repository_health_tasks.py
+++ b/src/backend/apps/storage/tests/test_repository_health_tasks.py
@@ -1061,6 +1061,23 @@ class AutomaticDirectNASObservationTests(TestCase):
     @mock.patch(
         "apps.storage.services.internal.repository_health.run_agent_task_async"
     )
+    def test_removing_repository_does_not_dispatch_a_late_observation(self, run_async):
+        self._node("removing-repository-agent")
+        Repository.objects.filter(pk=self.repository.id).update(
+            status=Repository.Status.REMOVING,
+        )
+
+        tasks = dispatch_automatic_repository_observation(
+            repository=self.repository,
+            include_usage=True,
+        )
+
+        self.assertEqual(tasks, [])
+        run_async.assert_not_called()
+
+    @mock.patch(
+        "apps.storage.services.internal.repository_health.run_agent_task_async"
+    )
     def test_dispatches_one_durable_task_per_node_without_persisting_secrets(
         self,
         run_async,


### PR DESCRIPTION
## Summary
- coordinate repository cleanup with explicitly identified automatic health probes
- keep real repository operations as hard blockers, including Force Cleanup
- prevent late health probe dispatch after a repository enters REMOVING
- keep API and workers non-blocking while cancellation is pending

## Validation
- ruff check
- Python compilation
- Django system check
- full Django tests require PostgreSQL connectivity

Closes #780