### PR TITLE
fix(storage): enforce repository storage quota

### DIFF
--- a/language-packs/packs/zh-hans/frontend/messages.json
+++ b/language-packs/packs/zh-hans/frontend/messages.json
@@ -61,6 +61,7 @@
       "agentNasMountFailed": "NAS 挂载失败，请检查连接设置",
       "agentTaskFailed": "Agent 任务失败，请稍后重试",
       "backupQuotaExceeded": "备份配额已用尽，请升级订阅后重试",
+      "backupRepositoryQuotaExceeded": "该备份仓库已达到配置的存储配额。请释放仓库空间或提高存储配额后重试。",
       "backupAlreadyRunning": "该备份源的备份正在启动或运行。请先停止备份或等待其完成，再继续操作。",
       "restoreAlreadyRunning": "该备份源已有恢复任务正在运行",
       "storageRepositoryOperationNotCancellable": "只能取消控制器管理的 S3 维护任务。",

--- a/language-packs/packs/zh-hans/frontend/source-lock.json
+++ b/language-packs/packs/zh-hans/frontend/source-lock.json
@@ -91,6 +91,7 @@
   "errors.codes.smbCharsetUnavailable": "8793d9ad38cd43ed8f1293919f092eac4f987fb9ff1120016af238d323432f3c",
   "errors.codes.agentTaskFailed": "cc11ff8d4f894bd4e4f58cbdb609fcfcde18aa37b1f95521d60efb545fe48e0a",
   "errors.codes.backupQuotaExceeded": "554ed2cf3a2d763191d4cf65095ff4eb560768b6fef4ff55ff43745e0ef4a49f",
+  "errors.codes.backupRepositoryQuotaExceeded": "783b44f747aec0e3c5a6834c61cef110a3ff939b92178d2b9781e621a3b5ae59",
   "errors.codes.subscriptionQuotaExceeded": "9caa3d7e43c054ba8f2b103bc2fe4c91e26f0a0ee9ed8d8c1f9b74d7b219d78d",
   "errors.codes.subscriptionQuotaExceededMeter": "e4c55d6c762a416055c1751c91ccb47dfe36505a48c1f425538ea0a224f394a4",
   "errors.codes.subscriptionQuotaExceededInstance": "7f628c504ac2a9ad7f1cb0ba1d686c69e35e4002b86d0c092622c3739095fc0e",

--- a/src/backend/apps/protection/services/backup_orchestrator.py
+++ b/src/backend/apps/protection/services/backup_orchestrator.py
@@ -49,7 +49,10 @@ from apps.storage.services.internal.repository_access import (
     explicit_repository_server_host,
     resolve_repository_reader,
 )
-from apps.storage.services.internal.repository_usage import enqueue_repository_usage_refresh
+from apps.storage.services.internal.repository_usage import (
+    assert_repository_quota_available,
+    enqueue_repository_usage_refresh,
+)
 from apps.task.models import Task, TaskEvent, TaskStep
 from apps.task.services.interface import append_task_step_event, complete_task, start_task
 from apps.task.signals import task_updated
@@ -2047,9 +2050,14 @@ def advance_backup(
             source_ref_id=source_snapshot.source_ref_id,
             repository_id=config.repository_id,
         )
+        repository = Repository.objects.select_for_update().get(
+            organization_id=organization_id,
+            id=repository.id,
+        )
+        assert_repository_quota_available(repository)
         runtime_policy = backup_runtime_policy_payload(source_snapshot.policy_snapshot)
     except Exception as exc:
-        error_code = "BACKUP_PRECHECK_FAILED"
+        error_code = getattr(exc, "code", "BACKUP_PRECHECK_FAILED")
         error_message = str(exc)
         mark_source_snapshot_failed(
             source_snapshot=source_snapshot,

--- a/src/backend/apps/protection/services/backup_task.py
+++ b/src/backend/apps/protection/services/backup_task.py
@@ -58,6 +58,9 @@ from apps.storage.services.internal.repository_workload import (
     RepositoryWorkload,
     lock_repositories_for_workload,
 )
+from apps.storage.services.internal.repository_usage import (
+    assert_repository_quota_available,
+)
 from apps.task.models import Task, TaskResource, TaskStep
 from apps.task.services.interface import (
     append_task_step_event,
@@ -77,6 +80,7 @@ _DEFAULT_DIRECTORY_WAIT_TIMEOUT_SECONDS = 3600
 _BACKUP_EXECUTION_LOCK_TTL_BUFFER_SECONDS = 600
 _BACKUP_EXECUTION_LOCK_VALUE = "running"
 _QUOTA_EXCEEDED_ERROR_CODE = "SUBSCRIPTION.QUOTA_EXCEEDED"
+_REPOSITORY_QUOTA_EXCEEDED_ERROR_CODE = "BACKUP.REPOSITORY_QUOTA_EXCEEDED"
 _TASK_TERMINAL_STATUSES = {
     Task.Status.SUCCESS,
     Task.Status.FAILED,
@@ -97,7 +101,27 @@ _DIRECTORY_TERMINAL_STATUSES = {
 
 
 def _is_global_backup_admission_error(exc: Exception) -> bool:
-    return isinstance(exc, AppError) and exc.code == _QUOTA_EXCEEDED_ERROR_CODE
+    return isinstance(exc, AppError) and exc.code in {
+        _QUOTA_EXCEEDED_ERROR_CODE,
+        _REPOSITORY_QUOTA_EXCEEDED_ERROR_CODE,
+    }
+
+
+def _should_raise_backup_admission_error(
+    exc: Exception,
+    *,
+    trigger_type: str,
+) -> bool:
+    if not _is_global_backup_admission_error(exc):
+        return False
+    if (
+        isinstance(exc, AppError)
+        and exc.code == _REPOSITORY_QUOTA_EXCEEDED_ERROR_CODE
+        and str(trigger_type).strip().lower()
+        == BackupSourceSnapshot.TriggerType.SCHEDULE
+    ):
+        return False
+    return True
 
 
 logger = logging.getLogger(__name__)
@@ -786,6 +810,11 @@ def start_backup_tasks(
                     # the write first and retain the quota lock until durable
                     # ownership facts commit.
                     with transaction.atomic():
+                        locked_repository = Repository.objects.select_for_update().get(
+                            organization_id=organization_id,
+                            id=repository.id,
+                        )
+                        assert_repository_quota_available(locked_repository)
                         enforce_license_quota(
                             organization,
                             "max_storage_gb",
@@ -802,7 +831,10 @@ def start_backup_tasks(
                 # backup because configured path contents can change without a
                 # config edit. Never block the Backup Now request on path.size.
             except (ValidationError, AppError) as exc:
-                if _is_global_backup_admission_error(exc):
+                if _should_raise_backup_admission_error(
+                    exc,
+                    trigger_type=trigger_type,
+                ):
                     raise
                 skipped_count += 1
                 results.append(
@@ -819,6 +851,12 @@ def start_backup_tasks(
                             if isinstance(exc, AppError)
                             and exc.code == "RESTORE.ALREADY_RUNNING"
                             else "failed"
+                        ),
+                        **(
+                            {"error_code": exc.code}
+                            if isinstance(exc, AppError)
+                            and exc.code == _REPOSITORY_QUOTA_EXCEEDED_ERROR_CODE
+                            else {}
                         ),
                         "message": (
                             _validation_message(exc)
@@ -900,6 +938,11 @@ def start_backup_tasks(
                                 "max_storage_gb",
                                 additional=0,
                             )
+                        locked_repository = Repository.objects.select_for_update().get(
+                            organization_id=organization_id,
+                            id=locked_config.repository_id,
+                        )
+                        assert_repository_quota_available(locked_repository)
                         lock_repositories_for_workload(
                             organization_id=organization_id,
                             repository_ids=[locked_config.repository_id],
@@ -1032,7 +1075,10 @@ def start_backup_tasks(
                         "message": "A backup task for this source and backup config is already running.",
                     }
             except (ValidationError, AppError) as exc:
-                if _is_global_backup_admission_error(exc):
+                if _should_raise_backup_admission_error(
+                    exc,
+                    trigger_type=trigger_type,
+                ):
                     raise
                 skipped_count += 1
                 results.append(
@@ -1049,6 +1095,12 @@ def start_backup_tasks(
                             if isinstance(exc, AppError)
                             and exc.code == "RESTORE.ALREADY_RUNNING"
                             else "failed"
+                        ),
+                        **(
+                            {"error_code": exc.code}
+                            if isinstance(exc, AppError)
+                            and exc.code == _REPOSITORY_QUOTA_EXCEEDED_ERROR_CODE
+                            else {}
                         ),
                         "message": (
                             _validation_message(exc)
@@ -1389,6 +1441,9 @@ def extract_kopia_failure_message(
             or "error connecting to repository" in lower
             or lower.startswith("error:")
             or "quota exceeded" in lower
+            or "enospc" in lower
+            or "no space left" in lower
+            or "storage limit reached" in lower
             or "unable to get policy tree" in lower
             or "policy not found" in lower
             or "unable to open" in lower
@@ -1437,10 +1492,19 @@ def public_repository_failure_message(message: str) -> str:
     """Return an actionable repository error without backend implementation details."""
     text = re.sub(r"https?://\S+", "", str(message or "")).strip()
     lower = text.lower()
-    if "quota exceeded" in lower:
+    if any(
+        marker in lower
+        for marker in (
+            "quota exceeded",
+            "enospc",
+            "no space left",
+            "storage limit reached",
+        )
+    ):
         return (
-            "Backup repository quota exceeded. Free storage or increase the "
-            "repository quota before retrying."
+            "The underlying storage rejected the backup because its capacity "
+            "or provider-side quota was reached. Free space or increase the "
+            "quota on the NAS or object-storage platform, then retry."
         )
     if "not initialized" in lower:
         return "Backup repository is not initialized. Initialize or repair the repository before retrying."

--- a/src/backend/apps/protection/tests/test_backup_task_api.py
+++ b/src/backend/apps/protection/tests/test_backup_task_api.py
@@ -41,6 +41,7 @@ from apps.protection.services.backup_task import (
     _repository_runtime_payload,
     reconcile_interrupted_backup_tasks,
     run_backup_task,
+    start_backup_tasks,
 )
 from apps.protection.services.progress.orchestrated_progress import (
     BACKUP_TRANSFER_END,
@@ -401,6 +402,115 @@ class ProtectionBackupTaskApiTests(TestCase):
             additional=0,
         )
 
+    @patch("apps.protection.services.backup_task._queue_backup_execution")
+    def test_start_backup_task_api_stops_new_write_when_repository_quota_is_full(
+        self,
+        queue_backup,
+    ):
+        self.repository.config = {**self.repository.config, "quota_gb": 1}
+        self.repository.estimated_usage_bytes = 1 * 1024**3
+        self.repository.usage_probe_status = Repository.MetricProbeStatus.SUCCESS
+        self.repository.usage_last_success_at = timezone.now()
+        self.repository.save(
+            update_fields=[
+                "config",
+                "estimated_usage_bytes",
+                "usage_probe_status",
+                "usage_last_success_at",
+                "updated_at",
+            ]
+        )
+        self.repository.refresh_from_db()
+        self.assertEqual(self.repository.config["quota_gb"], 1)
+        self.assertEqual(self.repository.usage_probe_status, Repository.MetricProbeStatus.SUCCESS)
+        self.assertEqual(self.repository.estimated_usage_bytes, 1 * 1024**3)
+
+        response = self.client.post(
+            "/api/v1/protection/backup-tasks/",
+            {
+                "source_ids": [f"agent:{self.agent.id}"],
+                "trigger_type": "manual",
+            },
+            format="json",
+            **self._headers(),
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(
+            response.data["data"]["error_code"],
+            "BACKUP.REPOSITORY_QUOTA_EXCEEDED",
+        )
+        self.assertIn("configured Storage Quota", response.data["data"]["title"])
+        queue_backup.assert_not_called()
+
+    @patch("apps.protection.services.backup_task._queue_backup_execution")
+    def test_scheduled_backup_records_repository_quota_rejection_without_task(
+        self,
+        queue_backup,
+    ):
+        self.repository.config = {**self.repository.config, "quota_gb": 1}
+        self.repository.estimated_usage_bytes = 2 * 1024**3
+        self.repository.usage_probe_status = Repository.MetricProbeStatus.SUCCESS
+        self.repository.usage_last_success_at = timezone.now()
+        self.repository.save(
+            update_fields=[
+                "config",
+                "estimated_usage_bytes",
+                "usage_probe_status",
+                "usage_last_success_at",
+                "updated_at",
+            ]
+        )
+
+        result = start_backup_tasks(
+            organization_id=self.org.id,
+            source_ids=[f"agent:{self.agent.id}"],
+            trigger_type=BackupSourceSnapshot.TriggerType.SCHEDULE,
+            idempotency_key="scheduled-repository-quota-full",
+        )
+
+        self.assertEqual(result["created_count"], 0)
+        self.assertEqual(result["skipped_count"], 1)
+        self.assertEqual(result["results"][0]["status"], "failed")
+        self.assertEqual(
+            result["results"][0]["error_code"],
+            "BACKUP.REPOSITORY_QUOTA_EXCEEDED",
+        )
+        self.assertIn("configured Storage Quota", result["results"][0]["message"])
+        self.assertFalse(Task.objects.filter(task_type=Task.Type.BACKUP).exists())
+        queue_backup.assert_not_called()
+
+    def test_backup_execution_rechecks_repository_quota_before_write(self):
+        task, snapshot = self._create_backup_task_and_snapshot(
+            idempotency_key="repository-quota-queued-recheck",
+        )
+        self.repository.config = {**self.repository.config, "quota_gb": 1}
+        self.repository.estimated_usage_bytes = 1 * 1024**3
+        self.repository.usage_probe_status = Repository.MetricProbeStatus.SUCCESS
+        self.repository.usage_last_success_at = timezone.now()
+        self.repository.save(
+            update_fields=[
+                "config",
+                "estimated_usage_bytes",
+                "usage_probe_status",
+                "usage_last_success_at",
+                "updated_at",
+            ]
+        )
+
+        result = run_backup_task(
+            organization_id=self.org.id,
+            task_uuid=str(task.task_uuid),
+            source_snapshot_id=snapshot.id,
+        )
+
+        self.assertEqual(result["status"], Task.Status.FAILED)
+        task.refresh_from_db()
+        snapshot.refresh_from_db()
+        self.assertEqual(task.error_code, "BACKUP.REPOSITORY_QUOTA_EXCEEDED")
+        self.assertEqual(snapshot.error_code, "BACKUP.REPOSITORY_QUOTA_EXCEEDED")
+        self.assertIn("configured Storage Quota", snapshot.error_message)
+
     @patch("apps.protection.services.directory_size_estimate.run_agent_task_sync")
     @patch("apps.protection.services.backup_task._queue_backup_execution")
     @patch(
@@ -704,6 +814,19 @@ class ProtectionBackupTaskApiTests(TestCase):
                 format="json",
                 **self._headers(),
             )
+        self.repository.config = {**self.repository.config, "quota_gb": 1}
+        self.repository.estimated_usage_bytes = 1024**3
+        self.repository.usage_probe_status = Repository.MetricProbeStatus.SUCCESS
+        self.repository.usage_last_success_at = timezone.now()
+        self.repository.save(
+            update_fields=[
+                "config",
+                "estimated_usage_bytes",
+                "usage_probe_status",
+                "usage_last_success_at",
+                "updated_at",
+            ]
+        )
         with patch(
             "apps.subscription.services.interface.enforce_license_quota",
             side_effect=AppError(
@@ -2028,8 +2151,9 @@ class ProtectionBackupTaskApiTests(TestCase):
         self.assertEqual(row.status, BackupSourceSnapshotDirectory.Status.FAILED)
         self.assertEqual(row.error_code, "POLICY_APPLY_FAILED")
         expected_message = (
-            "Backup repository quota exceeded. Free storage or increase the "
-            "repository quota before retrying."
+            "The underlying storage rejected the backup because its capacity "
+            "or provider-side quota was reached. Free space or increase the "
+            "quota on the NAS or object-storage platform, then retry."
         )
         self.assertEqual(row.error_message, expected_message)
         snapshot.refresh_from_db()

--- a/src/backend/apps/protection/tests/test_backup_task_concurrency.py
+++ b/src/backend/apps/protection/tests/test_backup_task_concurrency.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 from django.db import close_old_connections, connection
 from django.test import TransactionTestCase
+from django.utils import timezone
 
 from apps.iam.models import Organization
 from apps.node.models import Node
@@ -133,6 +134,62 @@ class BackupTaskConcurrencyTests(TransactionTestCase):
             ).count(),
             1,
         )
+
+    def test_simultaneous_starts_both_observe_full_repository_quota(self):
+        self.repository.config = {**self.repository.config, "quota_gb": 1}
+        self.repository.estimated_usage_bytes = 1024**3
+        self.repository.usage_probe_status = Repository.MetricProbeStatus.SUCCESS
+        self.repository.usage_last_success_at = timezone.now()
+        self.repository.save(
+            update_fields=[
+                "config",
+                "estimated_usage_bytes",
+                "usage_probe_status",
+                "usage_last_success_at",
+                "updated_at",
+            ]
+        )
+        barrier = threading.Barrier(2)
+        outcomes: queue.Queue[str] = queue.Queue()
+        errors: queue.Queue[BaseException] = queue.Queue()
+
+        def start(idempotency_key: str) -> None:
+            close_old_connections()
+            try:
+                barrier.wait(timeout=5)
+                start_backup_tasks(
+                    organization_id=self.org.id,
+                    source_ids=[f"agent:{self.agent.id}"],
+                    trigger_type="manual",
+                    idempotency_key=idempotency_key,
+                )
+            except AppError as exc:
+                outcomes.put(exc.code)
+            except BaseException as exc:  # pragma: no cover - surfaced below
+                errors.put(exc)
+            finally:
+                close_old_connections()
+
+        threads = [
+            threading.Thread(target=start, args=("quota-full-a",)),
+            threading.Thread(target=start, args=("quota-full-b",)),
+        ]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=10)
+
+        if not errors.empty():
+            raise errors.get()
+        self.assertEqual(outcomes.qsize(), 2)
+        self.assertEqual(
+            [outcomes.get(), outcomes.get()],
+            [
+                "BACKUP.REPOSITORY_QUOTA_EXCEEDED",
+                "BACKUP.REPOSITORY_QUOTA_EXCEEDED",
+            ],
+        )
+        self.assertFalse(Task.objects.filter(task_type=Task.Type.BACKUP).exists())
 
     def test_backup_start_is_blocked_by_active_source_unregister(self):
         unregister_task = Task.objects.create(

--- a/src/backend/apps/protection/tests/test_kopia_progress.py
+++ b/src/backend/apps/protection/tests/test_kopia_progress.py
@@ -438,9 +438,27 @@ class KopiaFailureMessageTests(SimpleTestCase):
         self.assertNotIn("Epoch range-compaction", message)
         self.assertEqual(
             public_repository_failure_message(message),
-            "Backup repository quota exceeded. Free storage or increase the "
-            "repository quota before retrying.",
+            "The underlying storage rejected the backup because its capacity "
+            "or provider-side quota was reached. Free space or increase the "
+            "quota on the NAS or object-storage platform, then retry.",
         )
+
+    def test_public_repository_failure_message_classifies_provider_capacity_markers(self):
+        from apps.protection.services.backup_task import (
+            extract_kopia_failure_message,
+            public_repository_failure_message,
+        )
+
+        for marker in ("ENOSPC", "no space left on device", "storage limit reached"):
+            with self.subTest(marker=marker):
+                extracted = extract_kopia_failure_message(
+                    {"stderr_tail": f"write failed: {marker}", "exit_code": 1},
+                    last_error="exit 1: exit status 1",
+                )
+                self.assertIn(marker, extracted)
+                public_message = public_repository_failure_message(extracted)
+                self.assertIn("underlying storage", public_message)
+                self.assertIn("NAS or object-storage platform", public_message)
 
     def test_extract_kopia_failure_message_prefers_fatal_errors(self):
         from apps.protection.services.backup_task import extract_kopia_failure_message

--- a/src/backend/apps/storage/services/internal/repository_usage.py
+++ b/src/backend/apps/storage/services/internal/repository_usage.py
@@ -24,6 +24,7 @@ from apps.storage.services.internal.kopia_cli import (
     connect_s3_repository,
     content_stats as kopia_content_stats,
 )
+from common.errors import AppError
 
 logger = logging.getLogger(__name__)
 
@@ -31,6 +32,11 @@ _GB = 1024**3
 _KOPIA_ESTIMATED_USAGE_FACTOR = 1.05
 _USAGE_REFRESH_DEDUP_TTL_SECONDS = 60
 _DEFAULT_STALE_AFTER_SECONDS = 900
+_REPOSITORY_QUOTA_ERROR_CODE = "BACKUP.REPOSITORY_QUOTA_EXCEEDED"
+_REPOSITORY_QUOTA_MESSAGE = (
+    "This backup repository has reached its configured Storage Quota. "
+    "Free repository space or increase Storage Quota before retrying."
+)
 _SIZE_RE = re.compile(
     r"(?P<key>total\s*packed|packed|total\s*size|total\s*bytes|size|used|total)\s*[:=]\s*(?P<num>[\d.,]+)\s*(?P<unit>[KMGT]?B)?",
     re.IGNORECASE,
@@ -118,6 +124,54 @@ def capacity_bytes_from_config(config: dict | None) -> int:
     if quota_gb <= 0:
         return 0
     return int(quota_gb * _GB)
+
+
+def assert_repository_quota_available(
+    repository: Repository,
+    *,
+    now=None,
+    stale_after_seconds: int | None = _DEFAULT_STALE_AFTER_SECONDS,
+) -> None:
+    """Reject new backup writes when a trusted repository observation is full.
+
+    Repository usage is collected asynchronously.  A missing, failed, or stale
+    observation therefore fails open so a transient metrics outage does not
+    block every backup; the next successful observation will restore admission
+    enforcement.  Callers that admit a write must lock the repository row in
+    their transaction before invoking this helper.
+    """
+    limit = capacity_bytes_from_config(repository.config)
+    if limit <= 0:
+        return None
+    if repository.usage_probe_status != Repository.MetricProbeStatus.SUCCESS:
+        return None
+    checked_at = repository.usage_last_success_at
+    if checked_at is None:
+        return None
+    current_time = now or timezone.now()
+    if stale_after_seconds is not None:
+        try:
+            stale_after = int(stale_after_seconds)
+        except (TypeError, ValueError):
+            stale_after = _DEFAULT_STALE_AFTER_SECONDS
+        if stale_after >= 0 and current_time - checked_at > timedelta(seconds=stale_after):
+            return None
+    used = max(0, int(repository.estimated_usage_bytes or 0))
+    if used < limit:
+        return None
+    raise AppError(
+        code=_REPOSITORY_QUOTA_ERROR_CODE,
+        status=403,
+        title=_REPOSITORY_QUOTA_MESSAGE,
+        diagnostic=_REPOSITORY_QUOTA_MESSAGE,
+        meta={
+            "quota_type": "repository.quota_gb",
+            "repository_id": repository.id,
+            "limit_bytes": limit,
+            "used_bytes": used,
+            "scope": "repository",
+        },
+    )
 
 
 def apply_capacity_from_config(repository: Repository) -> bool:

--- a/src/backend/apps/storage/tests/test_repository_usage.py
+++ b/src/backend/apps/storage/tests/test_repository_usage.py
@@ -5,6 +5,7 @@ from django.core.exceptions import ValidationError
 from django.test import TestCase
 from django.utils import timezone
 
+from common.errors import AppError
 from apps.iam.models import Organization
 from apps.node.models import Node
 from apps.node.agent_paths import repository_mount_point
@@ -22,6 +23,7 @@ from apps.storage.services.internal.repository_location import (
 from apps.storage.services.internal.repository_usage import (
     RepositoryUsageProbeResult,
     _parse_agent_repo_status_result,
+    assert_repository_quota_available,
     capacity_bytes_from_config,
     kopia_estimated_usage_from_packed,
     parse_kopia_content_stats,
@@ -55,6 +57,76 @@ class RepositoryUsageTests(TestCase):
         self.assertEqual(capacity_bytes_from_config({"quota_gb": 10}), 10 * 1024**3)
         self.assertEqual(capacity_bytes_from_config({"quota_gb": 0}), 0)
         self.assertEqual(capacity_bytes_from_config(None), 0)
+
+    def test_repository_quota_rejects_full_fresh_observation(self):
+        repository = Repository(
+            id=798,
+            config={"quota_gb": 1},
+            estimated_usage_bytes=1024**3,
+            usage_probe_status=Repository.MetricProbeStatus.SUCCESS,
+            usage_last_success_at=timezone.now(),
+        )
+
+        with self.assertRaisesMessage(
+            AppError,
+            "configured Storage Quota",
+        ) as context:
+            assert_repository_quota_available(repository)
+
+        self.assertEqual(context.exception.code, "BACKUP.REPOSITORY_QUOTA_EXCEEDED")
+
+    def test_repository_quota_fails_open_for_stale_observation(self):
+        repository = Repository(
+            config={"quota_gb": 1},
+            estimated_usage_bytes=2 * 1024**3,
+            usage_probe_status=Repository.MetricProbeStatus.SUCCESS,
+            usage_last_success_at=timezone.now() - timedelta(minutes=16),
+        )
+
+        assert_repository_quota_available(repository)
+
+    def test_repository_quota_allows_unlimited_under_limit_and_unknown_usage(self):
+        now = timezone.now()
+        cases = (
+            {
+                "name": "unlimited",
+                "config": {"quota_gb": 0},
+                "used": 2 * 1024**3,
+                "status": Repository.MetricProbeStatus.SUCCESS,
+                "checked_at": now,
+            },
+            {
+                "name": "under limit",
+                "config": {"quota_gb": 2},
+                "used": 1024**3,
+                "status": Repository.MetricProbeStatus.SUCCESS,
+                "checked_at": now,
+            },
+            {
+                "name": "failed probe",
+                "config": {"quota_gb": 1},
+                "used": 2 * 1024**3,
+                "status": Repository.MetricProbeStatus.FAILED,
+                "checked_at": now,
+            },
+            {
+                "name": "missing successful observation",
+                "config": {"quota_gb": 1},
+                "used": 2 * 1024**3,
+                "status": Repository.MetricProbeStatus.SUCCESS,
+                "checked_at": None,
+            },
+        )
+
+        for case in cases:
+            with self.subTest(case["name"]):
+                repository = Repository(
+                    config=case["config"],
+                    estimated_usage_bytes=case["used"],
+                    usage_probe_status=case["status"],
+                    usage_last_success_at=case["checked_at"],
+                )
+                assert_repository_quota_available(repository, now=now)
 
     @mock.patch(
         "apps.storage.services.internal.repository_usage.sync_repository_usage"

--- a/src/frontend/src/lib/errors/registry.ts
+++ b/src/frontend/src/lib/errors/registry.ts
@@ -47,6 +47,7 @@ export const ERROR_CODE_I18N_KEYS: Record<string, string> = {
   'SMB_CHARSET_UNAVAILABLE': 'errors.codes.smbCharsetUnavailable',
   'AGENT.TASK_FAILED': 'errors.codes.agentTaskFailed',
   'BACKUP.QUOTA_EXCEEDED': 'errors.codes.backupQuotaExceeded',
+  'BACKUP.REPOSITORY_QUOTA_EXCEEDED': 'errors.codes.backupRepositoryQuotaExceeded',
   'SUBSCRIPTION.QUOTA_EXCEEDED': 'errors.codes.subscriptionQuotaExceeded',
   'SUBSCRIPTION.QUOTA_USAGE_UNAVAILABLE': 'errors.codes.subscriptionQuotaUsageUnavailable',
   'BACKUP.ALREADY_RUNNING': 'errors.codes.backupAlreadyRunning',
@@ -99,6 +100,8 @@ export const ERROR_CODE_FALLBACK_EN: Record<string, string> = {
   'SMB_CHARSET_UNAVAILABLE': 'SMB UTF-8 filename support is unavailable on the Proxy Host. Install the matching kernel extra-modules package, then remount the share.',
   'AGENT.TASK_FAILED': 'Agent task failed. Please try again.',
   'BACKUP.QUOTA_EXCEEDED': 'Backup quota exceeded. Upgrade your subscription and try again.',
+  'BACKUP.REPOSITORY_QUOTA_EXCEEDED':
+    'This backup repository has reached its configured Storage Quota. Free repository space or increase Storage Quota before retrying.',
   'SUBSCRIPTION.QUOTA_EXCEEDED':
     'Organization quota is full. Contact your platform administrator to raise limits.',
   'SUBSCRIPTION.QUOTA_USAGE_UNAVAILABLE':

--- a/src/frontend/src/lib/errors/resolver.quota.test.ts
+++ b/src/frontend/src/lib/errors/resolver.quota.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest'
 import { resolveErrorMessage, resolveErrorMessageI18n } from './resolver'
 
 const messages: Record<string, string> = {
+  'errors.codes.backupRepositoryQuotaExceeded':
+    'This repository reached its configured storage quota.',
   'errors.codes.subscriptionQuotaExceeded':
     'Organization quota is full. Contact your platform administrator to raise limits.',
   'errors.codes.subscriptionQuotaExceededMeter':
@@ -25,6 +27,30 @@ function t(key: string, params?: Record<string, unknown>) {
 }
 
 describe('subscription quota error messages', () => {
+  it('maps repository quota errors through the registry', () => {
+    const message = resolveErrorMessageI18n(
+      {
+        status: 403,
+        errorCode: 'BACKUP.REPOSITORY_QUOTA_EXCEEDED',
+        message: 'internal diagnostic',
+      },
+      t,
+    )
+
+    expect(message).toBe('This repository reached its configured storage quota.')
+    expect(message).not.toContain('internal diagnostic')
+  })
+
+  it('uses the repository quota English fallback without a translator', () => {
+    expect(
+      resolveErrorMessage({
+        status: 403,
+        errorCode: 'BACKUP.REPOSITORY_QUOTA_EXCEEDED',
+        message: 'blocked',
+      }),
+    ).toContain('configured Storage Quota')
+  })
+
   it('uses organization meter copy when scope is organization', () => {
     const message = resolveErrorMessageI18n(
       {

--- a/src/frontend/src/locales/en.ts
+++ b/src/frontend/src/locales/en.ts
@@ -109,6 +109,8 @@ export const en = {
       smbCharsetUnavailable: 'SMB UTF-8 filename support is unavailable on the Proxy Host. Install the matching kernel extra-modules package, then remount the share.',
       agentTaskFailed: 'Agent task failed. Please try again.',
       backupQuotaExceeded: 'Backup quota exceeded. Upgrade your subscription and try again.',
+      backupRepositoryQuotaExceeded:
+        'This backup repository has reached its configured Storage Quota. Free repository space or increase Storage Quota before retrying.',
       subscriptionQuotaExceeded:
         'Organization quota is full. Contact your platform administrator to raise limits.',
       subscriptionQuotaExceededMeter:


### PR DESCRIPTION
## Summary

- enforce configured repository Storage Quota before creating backup writes
- recheck queued backups before repository preparation and persist a dedicated error code
- distinguish HFL quota admission from NAS, filesystem, and object-storage capacity errors
- add English and Simplified Chinese guidance plus backend and frontend regressions

## Validation

- Targeted storage and protection backend tests: 115 passed
- Community affected backend packages: 852 passed
- Community frontend suite: 1,268 passed
- Frontend targeted tests, lint, production builds, and language-pack builder: passed
- Migration drift, Ruff, source-language, compile, and diff checks: passed
- Manual testing: passed
- Optional complete Community backend suite: skipped by explicit request

## Operational behavior

Repository quota admission uses successful usage observations no older than 15
minutes. Missing, failed, or stale usage observations fail open so a metrics
outage does not block all backups. Existing running backups are not cancelled.

Fixes #798
