### PR TITLE
fix(storage): bound legacy repository initialization tasks

### DIFF
--- a/src/backend/apps/node/services/internal/task.py
+++ b/src/backend/apps/node/services/internal/task.py
@@ -155,10 +155,11 @@ def _is_source_nas_probe(*, correlation_type: str, kind: str) -> bool:
 
 
 def _is_repository_initialize_task(*, correlation_type: str, kind: str) -> bool:
-    return (
-        correlation_type in {"repository_create", "protection.backup_config"}
-        and kind == "repo.initialize"
-    )
+    return kind == "repo.initialize" and correlation_type in {
+        "repository_create",
+        "protection.backup_config",
+        "storage_repository",
+    }
 
 
 def _source_nas_probe_deadline(*, accepted_at: datetime) -> datetime:

--- a/src/backend/apps/node/tests/test_backup_task_watchdog.py
+++ b/src/backend/apps/node/tests/test_backup_task_watchdog.py
@@ -96,19 +96,25 @@ class BackupTaskWatchdogTests(SimpleTestCase):
     def test_repository_initialization_uses_dedicated_watchdog(self):
         started_at = timezone.now()
 
-        deadline = _initial_watchdog_deadline(
-            correlation_type="repository_create",
-            kind="repo.initialize",
-            from_time=started_at,
-        )
+        for correlation_type in (
+            "repository_create",
+            "protection.backup_config",
+            "storage_repository",
+        ):
+            with self.subTest(correlation_type=correlation_type):
+                deadline = _initial_watchdog_deadline(
+                    correlation_type=correlation_type,
+                    kind="repo.initialize",
+                    from_time=started_at,
+                )
 
-        self.assertEqual(
-            deadline,
-            started_at
-            + timezone.timedelta(
-                seconds=node_conf.REPOSITORY_INITIALIZE_WATCHDOG_SECONDS
-            ),
-        )
+                self.assertEqual(
+                    deadline,
+                    started_at
+                    + timezone.timedelta(
+                        seconds=node_conf.REPOSITORY_INITIALIZE_WATCHDOG_SECONDS
+                    ),
+                )
 
     def test_snapshot_delete_uses_long_remote_watchdog(self):
         started_at = timezone.now()

--- a/src/backend/apps/node/tests/test_task_command_ack.py
+++ b/src/backend/apps/node/tests/test_task_command_ack.py
@@ -288,13 +288,44 @@ class TaskCommandAckTests(TestCase):
 
     @patch("apps.node.services.internal.task.redis_store.set_task_info")
     @patch("apps.node.services.internal.task.redis_store.push_task_stream")
-    def test_legacy_repository_initialize_uses_dispatch_start(
+    def test_repository_initialize_uses_dispatch_start(
         self, _push, _set_info
     ):
         dispatched_at = timezone.now() - timezone.timedelta(seconds=20)
         task = self.task(
             kind="repo.initialize",
             correlation_type="repository_create",
+            correlation_id="repository-task",
+            status=NodeTask.Status.RUNNING,
+            dispatched_at=dispatched_at,
+            accepted_at=None,
+            last_progress_at=dispatched_at,
+            watchdog_deadline_at=timezone.now() - timezone.timedelta(seconds=1),
+        )
+
+        renewed = record_task_progress(
+            task_id=task.id,
+            node_id=self.node.id,
+            progress={"phase": "running"},
+        )
+
+        self.assertEqual(
+            renewed.watchdog_deadline_at,
+            dispatched_at
+            + timezone.timedelta(
+                seconds=node_conf.REPOSITORY_INITIALIZE_WATCHDOG_SECONDS
+            ),
+        )
+
+    @patch("apps.node.services.internal.task.redis_store.set_task_info")
+    @patch("apps.node.services.internal.task.redis_store.push_task_stream")
+    def test_legacy_repository_initialize_uses_dispatch_start(
+        self, _push, _set_info
+    ):
+        dispatched_at = timezone.now() - timezone.timedelta(seconds=20)
+        task = self.task(
+            kind="repo.initialize",
+            correlation_type="storage_repository",
             correlation_id="legacy-repository-task",
             status=NodeTask.Status.RUNNING,
             dispatched_at=dispatched_at,


### PR DESCRIPTION
## Summary
- apply the bounded repository-initialization watchdog to legacy `storage_repository` tasks
- prevent legacy Agent liveness frames from extending stalled initialization indefinitely
- preserve current durable delivery, ownership verification, and physical cleanup safety boundaries

## Validation
- `apps.node.tests`: 377 passed
- `apps.storage.tests.test_repository_cleanup`: 53 passed
- focused repository watchdog tests: 40 passed
- Ruff, Python compilation, and `git diff --check` passed

Fixes #827