### PR TITLE
Validate peeled SourceLens runtime commits

### DIFF
--- a/.github/workflows/enterprise_saas_upgrade.yml
+++ b/.github/workflows/enterprise_saas_upgrade.yml
@@ -168,6 +168,8 @@ jobs:
           ./tools/quality/check-release-contracts.sh
           ./tools/quality/test-saas-registry-delivery.sh
           ./tools/quality/test-online-community-install.sh
+          ./tools/quality/test-sourcelens-runtime-contract.sh
+          ./tools/sourcelens/update-runtime-contract.sh --check
 
   verify-public-images:
     name: Verify · Public Community images

--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -111,6 +111,10 @@ jobs:
           python-version: "3.12"
       - name: Check English source boundary
         run: python3 tools/quality/check-english-source.py
+      - name: Check SourceLens runtime contract
+        run: |
+          ./tools/quality/test-sourcelens-runtime-contract.sh
+          ./tools/sourcelens/update-runtime-contract.sh --check
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: "22"

--- a/.github/workflows/release_pipeline.yml
+++ b/.github/workflows/release_pipeline.yml
@@ -451,6 +451,8 @@ jobs:
           ./tools/quality/test-nginx-startup-readiness.sh
           ./tools/quality/test-sourcelens-runtime-sync.sh
           ./tools/quality/test-sourcelens-runtime-fingerprint.sh
+          ./tools/quality/test-sourcelens-runtime-contract.sh
+          ./tools/sourcelens/update-runtime-contract.sh --check
           ./tools/quality/test-redis-rdb-preflight.sh
           ./tools/quality/test-agent-release-retention.sh
           ./tools/quality/test-managed-image-retention.sh

--- a/deploy/online/sourcelens/runtime.json
+++ b/deploy/online/sourcelens/runtime.json
@@ -1,5 +1,5 @@
 {
-  "git_commit": "3f16494b269c4fbe37a5acd4bdaca3962cdd8a0e",
+  "git_commit": "accb97757382391a05a566497b6e37dd6a2ea847",
   "git_ref": "v0.47.6",
   "version": "0.47.6"
 }

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -430,6 +430,14 @@ grep -F 'CODEGRAPH_REGISTRY: ${NPM_REGISTRY:-https://registry.npmjs.org}' \
 
 grep -F '# SourceLens v0.47.6 requires no HFL functional patches.' \
 	"${ROOT}/tools/sourcelens/patches/series" >/dev/null
+[[ -x "${ROOT}/tools/sourcelens/update-runtime-contract.sh" ]]
+[[ -x "${ROOT}/tools/quality/test-sourcelens-runtime-contract.sh" ]]
+grep -F 'sourcelens_verify_runtime_contract "${SOURCELENS_SOURCE_CACHE}"' \
+	"${ROOT}/tools/sourcelens/common.sh" >/dev/null
+for workflow in pr_checks.yml release_pipeline.yml enterprise_saas_upgrade.yml; do
+	grep -F './tools/sourcelens/update-runtime-contract.sh --check' \
+		"${ROOT}/.github/workflows/${workflow}" >/dev/null
+done
 [[ -f "${ROOT}/tools/sourcelens/patches/retired/lensnode-tls-v0.4.0.patch" ]]
 if [[ -e "${ROOT}/deploy/installer/sourcelens/lensnode-tls.patch" \
 	|| -e "${ROOT}/tools/sourcelens/lensnode-patch.sh" ]]; then

--- a/tools/quality/test-lifecycle-output-contract.sh
+++ b/tools/quality/test-lifecycle-output-contract.sh
@@ -139,7 +139,7 @@ grep -F 'npm config set fetch-retries 5' "${ROOT_REPO}/tools/sourcelens/common.s
 # record remains one complete line, with no truncation or repeated prefix.
 wrapped_terminal="${fixture}/wrapped-terminal.log"
 wrapped_session="${fixture}/wrapped-session.log"
-wrapped_message='[2026-08-23T02:43:53.000Z] [INFO] [sourcelens] SourceLens app images already built; compose build skipped; source_stamp=v3:0.47.6:3f16494b269c4fbe37a5acd4bdaca3962cdd8a0e:6e8dbf651a5a7ea7709fe7c6f810978b5aa051de441a1a1da4f44e81346dda47'
+wrapped_message='[2026-08-23T02:43:53.000Z] [INFO] [sourcelens] SourceLens app images already built; compose build skipped; source_stamp=v3:0.47.6:accb97757382391a05a566497b6e37dd6a2ea847:6e8dbf651a5a7ea7709fe7c6f810978b5aa051de441a1a1da4f44e81346dda47'
 HFL_LOG_TERMINAL_WRAP_COLUMNS=70 HFL_WRAPPED_MESSAGE="${wrapped_message}" \
 	bash -c '
 set -euo pipefail

--- a/tools/quality/test-sourcelens-runtime-contract.sh
+++ b/tools/quality/test-sourcelens-runtime-contract.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+temporary="$(mktemp -d)"
+trap 'rm -rf "${temporary}"' EXIT
+repository="${temporary}/source"
+git init --quiet "${repository}"
+git -C "${repository}" config user.name "Runtime Contract Test"
+git -C "${repository}" config user.email "runtime-contract@example.invalid"
+printf 'fixture\n' >"${repository}/fixture.txt"
+git -C "${repository}" add fixture.txt
+git -C "${repository}" commit --quiet -m "Create fixture"
+commit="$(git -C "${repository}" rev-parse HEAD)"
+git -C "${repository}" tag v1.2.3
+git -C "${repository}" tag -a v1.2.4 -m "Annotated fixture"
+tag_object="$(git -C "${repository}" rev-parse v1.2.4)"
+[[ "${tag_object}" != "${commit}" ]]
+
+# A same-named branch must never shadow the release tag used by the contract.
+git -C "${repository}" switch --quiet --detach "${commit}"
+git -C "${repository}" switch --quiet -c v1.2.4
+printf 'branch-only\n' >"${repository}/fixture.txt"
+git -C "${repository}" add fixture.txt
+git -C "${repository}" commit --quiet -m "Diverge same-named branch"
+branch_commit="$(git -C "${repository}" rev-parse HEAD)"
+[[ "${branch_commit}" != "${commit}" ]]
+git -C "${repository}" switch --quiet --detach "${commit}"
+
+lightweight_contract="${temporary}/lightweight.json"
+annotated_contract="${temporary}/annotated.json"
+"${ROOT}/tools/sourcelens/update-runtime-contract.sh" v1.2.3 \
+	--git-url "${repository}" --output "${lightweight_contract}"
+"${ROOT}/tools/sourcelens/update-runtime-contract.sh" v1.2.4 \
+	--git-url "${repository}" --output "${annotated_contract}"
+"${ROOT}/tools/sourcelens/update-runtime-contract.sh" --check \
+	--git-url "${repository}" --output "${annotated_contract}"
+python3 - "${lightweight_contract}" "${annotated_contract}" "${commit}" <<'PY'
+import json
+import pathlib
+import sys
+
+expected = sys.argv[3]
+for name in sys.argv[1:3]:
+    contract = json.loads(pathlib.Path(name).read_text(encoding="utf-8"))
+    assert contract["git_commit"] == expected
+PY
+
+# shellcheck source=../sourcelens/common.sh
+source "${ROOT}/tools/sourcelens/common.sh"
+SOURCELENS_GIT_REF=v1.2.4
+SOURCELENS_VERSION=1.2.4
+SOURCELENS_RUNTIME_CONTRACT_FILE="${annotated_contract}"
+sourcelens_verify_runtime_contract "${repository}"
+
+branch_checkout="${temporary}/branch-checkout"
+git clone --quiet "${repository}" "${branch_checkout}"
+git -C "${branch_checkout}" checkout --quiet -b v1.2.4 "${branch_commit}"
+if (sourcelens_verify_runtime_contract "${branch_checkout}") >/dev/null 2>&1; then
+	printf 'ERROR: checkout validation accepted a same-named branch instead of the release tag\n' >&2
+	exit 1
+fi
+
+python3 - "${annotated_contract}" "${tag_object}" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+contract = json.loads(path.read_text(encoding="utf-8"))
+contract["git_commit"] = sys.argv[2]
+path.write_text(json.dumps(contract, indent=2) + "\n", encoding="utf-8")
+PY
+if "${ROOT}/tools/sourcelens/update-runtime-contract.sh" --check \
+	--git-url "${repository}" --output "${annotated_contract}" >/dev/null 2>&1; then
+	printf 'ERROR: annotated tag object was accepted as the SourceLens source commit\n' >&2
+	exit 1
+fi
+
+if (sourcelens_verify_runtime_contract "${repository}") >/dev/null 2>&1; then
+	printf 'ERROR: checkout validation accepted an annotated tag object as the source commit\n' >&2
+	exit 1
+fi
+
+printf 'SourceLens runtime contract checks passed.\n'

--- a/tools/sourcelens/common.sh
+++ b/tools/sourcelens/common.sh
@@ -19,6 +19,7 @@ SOURCELENS_DATA_DIR="${HFL_ROOT}/data/sourcelens"
 SOURCELENS_DEV_ENV_FILE="${SOURCELENS_DATA_DIR}/config/.env"
 SOURCELENS_BUILD_ENV_FILE="${HFL_ROOT}/tools/sourcelens/defaults.env"
 SOURCELENS_PATCH_ROOT="${HFL_ROOT}/tools/sourcelens/patches"
+SOURCELENS_RUNTIME_CONTRACT_FILE="${SOURCELENS_RUNTIME_CONTRACT_FILE:-${HFL_ROOT}/deploy/online/sourcelens/runtime.json}"
 SOURCELENS_COMPOSE_PROJECT="${SOURCELENS_COMPOSE_PROJECT:-hyperfilelens-sourcelens}"
 SOURCELENS_SHARED_NETWORK="hyperfilelens-bridge"
 
@@ -367,6 +368,56 @@ sourcelens_ensure_tls_certs() {
 	chmod 600 "${key}"
 }
 
+sourcelens_verify_runtime_contract() {
+	local source_dir=${1:-${SOURCELENS_SOURCE_CACHE}}
+	local contract_ref contract_version contract_commit actual_commit resolved_commit
+	[[ -f "${SOURCELENS_RUNTIME_CONTRACT_FILE}" ]] \
+		|| sourcelens_die "missing SourceLens runtime contract: ${SOURCELENS_RUNTIME_CONTRACT_FILE#${HFL_ROOT}/}"
+	IFS=$'\t' read -r contract_ref contract_version contract_commit < <(
+		python3 - "${SOURCELENS_RUNTIME_CONTRACT_FILE}" <<'PY'
+import json
+import pathlib
+import re
+import sys
+
+path = pathlib.Path(sys.argv[1])
+try:
+    contract = json.loads(path.read_text(encoding="utf-8"))
+except (OSError, json.JSONDecodeError) as exc:
+    raise SystemExit(f"invalid SourceLens runtime contract: {exc}") from exc
+
+git_ref = str(contract.get("git_ref") or "")
+version = str(contract.get("version") or "")
+git_commit = str(contract.get("git_commit") or "")
+if not re.fullmatch(r"v[0-9]+\.[0-9]+\.[0-9]+", git_ref):
+    raise SystemExit("SourceLens runtime contract has an invalid git_ref")
+if not re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+", version):
+    raise SystemExit("SourceLens runtime contract has an invalid version")
+if git_ref != f"v{version}":
+    raise SystemExit("SourceLens runtime contract git_ref and version differ")
+if not re.fullmatch(r"[0-9a-f]{40}", git_commit):
+    raise SystemExit("SourceLens runtime contract has an invalid git_commit")
+print(git_ref, version, git_commit, sep="\t")
+PY
+	) || sourcelens_die "SourceLens runtime contract validation failed"
+
+	if [[ "${SOURCELENS_GIT_REF}" != "${contract_ref}" ]]; then
+		sourcelens_log "SourceLens ref ${SOURCELENS_GIT_REF} is an explicit unlocked override; runtime contract is ${contract_ref}"
+		return 0
+	fi
+	[[ "${SOURCELENS_VERSION}" == "${contract_version}" ]] \
+		|| sourcelens_die "SourceLens resolved version does not match the runtime contract"
+	actual_commit="$(git -C "${source_dir}" rev-parse HEAD 2>/dev/null)" \
+		|| sourcelens_die "cannot resolve the checked-out SourceLens commit"
+	resolved_commit="$(git -C "${source_dir}" rev-parse "refs/tags/${contract_ref}^{commit}" 2>/dev/null)" \
+		|| sourcelens_die "cannot peel SourceLens ref ${contract_ref} to a commit"
+	[[ "${actual_commit}" == "${resolved_commit}" ]] \
+		|| sourcelens_die "checked-out SourceLens commit does not match ${contract_ref}"
+	[[ "${contract_commit}" == "${resolved_commit}" ]] \
+		|| sourcelens_die "SourceLens runtime contract git_commit must be the peeled commit for ${contract_ref}"
+	sourcelens_log "Verified SourceLens runtime contract (${contract_ref} @ ${contract_commit:0:12})"
+}
+
 sourcelens_sync_source() {
 	command -v git >/dev/null 2>&1 || sourcelens_die "git not found (required to fetch SourceLens)"
 	if sourcelens_git_needs_github_token && [[ -z "${GITHUB_TOKEN:-}" ]]; then
@@ -411,6 +462,7 @@ sourcelens_sync_source() {
 		else
 			sourcelens_git_output_command sourcelens_git checkout "${SOURCELENS_GIT_REF}"
 		fi
+		sourcelens_verify_runtime_contract "${SOURCELENS_SOURCE_CACHE}"
 		sourcelens_sync_submodules
 		sourcelens_git_output_command sourcelens_git submodule foreach --recursive \
 			'git reset --hard HEAD >/dev/null && git clean -fdx >/dev/null'

--- a/tools/sourcelens/update-runtime-contract.sh
+++ b/tools/sourcelens/update-runtime-contract.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# Resolve a SourceLens release tag to its peeled commit and update the runtime lock.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HFL_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+# shellcheck source=defaults.env
+source "${SCRIPT_DIR}/defaults.env"
+
+usage() {
+	cat <<'USAGE'
+Usage: tools/sourcelens/update-runtime-contract.sh [TAG] [options]
+
+Options:
+  --check        Verify the existing contract without modifying it
+  --git-url URL  Resolve TAG from this Git repository
+  --output FILE  Write the runtime contract to FILE
+
+TAG is required when updating and is read from the contract with --check.
+The default contract is deploy/online/sourcelens/runtime.json.
+USAGE
+}
+
+mode=update
+git_ref=""
+git_url="${SOURCELENS_GIT_URL}"
+output="${HFL_ROOT}/deploy/online/sourcelens/runtime.json"
+
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+	--check)
+		mode=check
+		shift
+		;;
+	--git-url)
+		[[ $# -ge 2 && -n "${2:-}" ]] || { printf 'ERROR: --git-url requires a value\n' >&2; exit 2; }
+		git_url=$2
+		shift 2
+		;;
+	--output)
+		[[ $# -ge 2 && -n "${2:-}" ]] || { printf 'ERROR: --output requires a value\n' >&2; exit 2; }
+		output=$2
+		shift 2
+		;;
+	-h | --help)
+		usage
+		exit 0
+		;;
+	*)
+		if [[ -z "${git_ref}" && "$1" != -* ]]; then
+			git_ref=$1
+			shift
+		else
+			printf 'ERROR: unsupported option: %s\n' "$1" >&2
+			exit 2
+		fi
+		;;
+	esac
+done
+
+if [[ "${mode}" == "check" && -z "${git_ref}" ]]; then
+	git_ref="$(python3 - "${output}" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+try:
+    print(json.loads(path.read_text(encoding="utf-8")).get("git_ref") or "")
+except (OSError, json.JSONDecodeError) as exc:
+    raise SystemExit(f"invalid SourceLens runtime contract: {exc}") from exc
+PY
+	)"
+fi
+[[ "${git_ref}" =~ ^v([0-9]+\.[0-9]+\.[0-9]+)$ ]] || {
+	printf 'ERROR: SourceLens TAG must use vX.Y.Z format\n' >&2
+	exit 2
+}
+version=${BASH_REMATCH[1]}
+command -v git >/dev/null 2>&1 || {
+	printf 'ERROR: git is required to resolve the SourceLens runtime contract\n' >&2
+	exit 2
+}
+if ! command -v timeout >/dev/null 2>&1 \
+	|| ! timeout --foreground 1s true >/dev/null 2>&1; then
+	printf 'ERROR: GNU timeout with --foreground is required to resolve the SourceLens runtime contract\n' >&2
+	exit 2
+fi
+temporary="$(mktemp -d "${TMPDIR:-/tmp}/hfl-sourcelens-contract.XXXXXX")"
+trap 'rm -rf "${temporary}"' EXIT
+git -C "${temporary}" init --bare --quiet
+fetch_timeout_seconds="${SOURCELENS_CONTRACT_GIT_TIMEOUT_SECONDS:-60}"
+fetch_attempts="${SOURCELENS_CONTRACT_GIT_ATTEMPTS:-3}"
+[[ "${fetch_timeout_seconds}" =~ ^[1-9][0-9]*$ && "${fetch_attempts}" =~ ^[1-9][0-9]*$ ]] || {
+	printf 'ERROR: SourceLens contract Git timeout and attempts must be positive integers\n' >&2
+	exit 2
+}
+fetch_succeeded=0
+for attempt in $(seq 1 "${fetch_attempts}"); do
+	if timeout --foreground --kill-after=5s "${fetch_timeout_seconds}s" \
+		env GIT_TERMINAL_PROMPT=0 \
+		git -C "${temporary}" fetch --quiet --force --depth=1 \
+		"${git_url}" "refs/tags/${git_ref}"; then
+		fetch_succeeded=1
+		break
+	fi
+	printf 'WARN: SourceLens tag resolution failed or timed out (attempt %s/%s)\n' \
+		"${attempt}" "${fetch_attempts}" >&2
+	if [[ "${attempt}" -lt "${fetch_attempts}" ]]; then
+		sleep 2
+	fi
+done
+[[ "${fetch_succeeded}" -eq 1 ]] || {
+	printf 'ERROR: could not resolve SourceLens tag %s from %s\n' "${git_ref}" "${git_url}" >&2
+	exit 1
+}
+git_commit="$(git -C "${temporary}" rev-parse 'FETCH_HEAD^{commit}')"
+[[ "${git_commit}" =~ ^[0-9a-f]{40}$ ]] || {
+	printf 'ERROR: %s did not resolve to a commit\n' "${git_ref}" >&2
+	exit 1
+}
+
+if [[ "${mode}" == "update" ]]; then
+	mkdir -p "$(dirname "${output}")"
+fi
+python3 - "${mode}" "${output}" "${git_ref}" "${version}" "${git_commit}" <<'PY'
+import json
+import os
+import pathlib
+import sys
+import tempfile
+
+mode = sys.argv[1]
+output = pathlib.Path(sys.argv[2])
+payload = {
+    "git_commit": sys.argv[5],
+    "git_ref": sys.argv[3],
+    "version": sys.argv[4],
+}
+if mode == "check":
+    try:
+        actual = json.loads(output.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise SystemExit(f"invalid SourceLens runtime contract: {exc}") from exc
+    if actual != payload:
+        differences = sorted(set(actual) | set(payload), key=str)
+        differences = [name for name in differences if actual.get(name) != payload.get(name)]
+        raise SystemExit(
+            "SourceLens runtime contract differs from the peeled tag identity: "
+            + ", ".join(differences)
+        )
+    raise SystemExit(0)
+
+descriptor, temporary = tempfile.mkstemp(prefix=f".{output.name}.", dir=output.parent)
+try:
+    os.fchmod(descriptor, 0o644)
+    with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+        json.dump(payload, stream, indent=2)
+        stream.write("\n")
+    os.replace(temporary, output)
+finally:
+    if os.path.exists(temporary):
+        os.unlink(temporary)
+PY
+if [[ "${mode}" == "check" ]]; then
+	printf 'Verified %s: %s @ %s\n' "${output}" "${git_ref}" "${git_commit}"
+else
+	printf 'Updated %s: %s @ %s\n' "${output}" "${git_ref}" "${git_commit}"
+fi


### PR DESCRIPTION
## Summary

- lock SourceLens v0.47.6 to its peeled source commit instead of the annotated tag object
- validate the runtime contract immediately after checkout and reject ambiguous release identities
- add an atomic contract updater with bounded remote verification
- enforce the contract in pull request, release, and SaaS quality gates

## Validation

- SourceLens runtime contract regression tests
- release contract checks
- lifecycle output contract checks
- shell syntax checks
- workflow YAML parsing
- git diff checks