### PR TITLE
Align login session alert colors

### DIFF
--- a/src/frontend/src/pages/auth/Login.vue
+++ b/src/frontend/src/pages/auth/Login.vue
@@ -96,6 +96,12 @@ const sessionNoticeMessage = computed(() => {
   return key ? t(key) : ''
 })
 
+const sessionNoticeTone = computed(() => (
+  sessionNoticeReason.value === 'TOKEN_EXPIRED' || sessionNoticeReason.value === 'REFRESH_EXPIRED'
+    ? 'info'
+    : 'warning'
+))
+
 function dismissSessionNotice() {
   sessionNoticeDismissed.value = true
 }
@@ -625,7 +631,8 @@ onMounted(async () => {
           <ElAlert
             v-if="sessionNoticeMessage"
             class="session-alert"
-            type="warning"
+            :class="`session-alert--${sessionNoticeTone}`"
+            :type="sessionNoticeTone"
             :title="sessionNoticeMessage"
             show-icon
             :closable="true"
@@ -1024,14 +1031,33 @@ onMounted(async () => {
 
 .session-alert {
   --el-alert-padding: 10px 12px;
+  --session-alert-accent: var(--color-brand-violet-soft);
+  --session-alert-background: color-mix(in srgb, var(--color-primary) 14%, transparent);
+  --session-alert-border: color-mix(in srgb, var(--color-brand-violet-soft) 34%, transparent);
+  --session-alert-text: color-mix(in srgb, var(--color-brand-violet-soft) 18%, white);
+  background-color: var(--session-alert-background);
+  border: 1px solid var(--session-alert-border);
   border-radius: var(--radius-card);
   line-height: 1.4;
   position: relative;
   padding-right: 42px;
 }
 
+.session-alert--warning {
+  --session-alert-accent: color-mix(in srgb, var(--color-warning) 68%, white);
+  --session-alert-background: color-mix(in srgb, var(--color-warning) 13%, transparent);
+  --session-alert-border: color-mix(in srgb, var(--color-warning) 36%, transparent);
+  --session-alert-text: color-mix(in srgb, var(--color-warning) 18%, white);
+}
+
 .session-alert :deep(.el-alert__title) {
+  color: var(--session-alert-text);
+  font-weight: 500;
   line-height: 20px;
+}
+
+.session-alert :deep(.el-alert__icon) {
+  color: var(--session-alert-accent);
 }
 
 .session-alert :deep(.el-alert__close-btn) {
@@ -1043,14 +1069,15 @@ onMounted(async () => {
   align-items: center;
   justify-content: center;
   border-radius: 4px;
+  color: color-mix(in srgb, var(--session-alert-text) 72%, transparent);
   transform: translateY(-50%);
   transition: background-color 0.2s, color 0.2s;
 }
 
 .session-alert :deep(.el-alert__close-btn:hover),
 .session-alert :deep(.el-alert__close-btn:focus-visible) {
-  background: rgba(245, 158, 11, 0.16);
-  color: #d97706;
+  background-color: color-mix(in srgb, var(--session-alert-accent) 16%, transparent);
+  color: var(--session-alert-text);
 }
 
 /* Shared input styles */

--- a/src/frontend/src/pages/auth/LoginTurnstileLifecycle.test.ts
+++ b/src/frontend/src/pages/auth/LoginTurnstileLifecycle.test.ts
@@ -196,14 +196,29 @@ describe('Login Turnstile lifecycle', () => {
     expect(storeSessionNotice('TOKEN_REUSED')).toBe(true)
 
     const firstMount = await mountLogin(1440)
-    expect(firstMount.get('.session-alert').text()).toContain(
+    const securityNotice = firstMount.get('.session-alert')
+    expect(securityNotice.text()).toContain(
       'Unusual sign-in activity. Sign in again.',
     )
+    expect(securityNotice.classes()).toContain('session-alert--warning')
+    expect(firstMount.getComponent({ name: 'ElAlert' }).props('type')).toBe('warning')
     firstMount.unmount()
 
     const replayMount = await mountLogin(1440)
     expect(replayMount.find('.session-alert').exists()).toBe(false)
     replayMount.unmount()
+  })
+
+  it('uses the brand information tone for routine session expiry', async () => {
+    expect(storeSessionNotice('TOKEN_EXPIRED')).toBe(true)
+
+    const wrapper = await mountLogin(1440)
+    const expiryNotice = wrapper.get('.session-alert')
+
+    expect(expiryNotice.text()).toContain('Sign-in expired. Sign in again.')
+    expect(expiryNotice.classes()).toContain('session-alert--info')
+    expect(wrapper.getComponent({ name: 'ElAlert' }).props('type')).toBe('info')
+    wrapper.unmount()
   })
 
   it('keeps the password tab selected when Turnstile is blocked', async () => {


### PR DESCRIPTION
## Summary

- Align routine session-expiry notices with the dark HyperFileLens brand palette
- Preserve stronger warning emphasis for security-related session invalidation
- Add regression coverage for info and warning alert tone selection

Closes #832

## Testing

- `npm run test -- --run src/pages/auth/LoginTurnstileLifecycle.test.ts`
- `npx eslint src/pages/auth/Login.vue src/pages/auth/LoginTurnstileLifecycle.test.ts`
- `npm run build`
- `git diff --check`