### PR TITLE
Fix transient source pipeline projection conflicts

### DIFF
--- a/src/backend/apps/source/services/interface.py
+++ b/src/backend/apps/source/services/interface.py
@@ -38,7 +38,6 @@ from apps.source.services.internal.validators import validate_resource_payload
 from apps.source.services.internal.source_pipeline import (
     delete_pipeline_entry,
     ensure_pipeline_entry,
-    sync_pipeline_projection,
 )
 from apps.source.services.internal.source_credentials import (
     merge_source_credentials,
@@ -48,6 +47,23 @@ from apps.source.services.internal.source_credentials import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _queue_nas_pipeline_projection_after_commit(
+    *, organization_id: int, resource_id: int
+) -> None:
+    """Queue a NAS read-model refresh after the source transaction commits."""
+    from apps.source.tasks.pipeline import queue_source_pipeline_projection
+
+    transaction.on_commit(
+        lambda organization_id=int(organization_id), resource_id=int(resource_id): (
+            queue_source_pipeline_projection(
+                organization_id=organization_id,
+                source_kind=SelectableSourceKind.NAS,
+                ref_id=resource_id,
+            )
+        )
+    )
 
 
 def _node_agent_data_dir(node: Node) -> str | None:
@@ -325,10 +341,9 @@ def update_source_resource(
     )
     resource.save()
     if resource.resource_type == ResourceType.NAS:
-        sync_pipeline_projection(
+        _queue_nas_pipeline_projection_after_commit(
             organization_id=resource.organization_id,
-            source_kind=SelectableSourceKind.NAS,
-            ref_id=resource.id,
+            resource_id=resource.id,
         )
     if bound_node_changed and resource.resource_type in ResourceType.REQUIRES_MOUNT and resource.bound_node:
         _queue_remount_after_proxy_binding(
@@ -410,10 +425,9 @@ def test_resource_connection(*, resource: SourceResource) -> dict:
         )
         resource = current
     if resource.resource_type == ResourceType.NAS:
-        sync_pipeline_projection(
+        _queue_nas_pipeline_projection_after_commit(
             organization_id=resource.organization_id,
-            source_kind=SelectableSourceKind.NAS,
-            ref_id=resource.id,
+            resource_id=resource.id,
         )
     validation_mount_point = agent_paths.source_validation_mount_point(
         str(probe_token),
@@ -525,10 +539,9 @@ def bind_node(*, resource: SourceResource, node_id: int) -> dict:
         ]
     )
     if resource.resource_type == ResourceType.NAS:
-        sync_pipeline_projection(
+        _queue_nas_pipeline_projection_after_commit(
             organization_id=resource.organization_id,
-            source_kind=SelectableSourceKind.NAS,
-            ref_id=resource.id,
+            resource_id=resource.id,
         )
     if resource.resource_type in ResourceType.REQUIRES_MOUNT:
         _queue_remount_after_proxy_binding(

--- a/src/backend/apps/source/services/internal/connection.py
+++ b/src/backend/apps/source/services/internal/connection.py
@@ -270,14 +270,6 @@ def apply_connection_test_result(resource: SourceResource, result: dict) -> None
             resource.mount_error = ""
     apply_result_availability(resource=resource, result=result)
     resource.save()
-    if resource.resource_type == ResourceType.NAS:
-        from apps.source.services.internal.source_pipeline import sync_pipeline_projection
-
-        sync_pipeline_projection(
-            organization_id=resource.organization_id,
-            source_kind="nas",
-            ref_id=resource.id,
-        )
 
 
 def apply_connection_test_result_if_current(
@@ -310,7 +302,32 @@ def apply_connection_test_result_if_current(
         if str(resource.connection_probe_token or "") != str(probe_token or ""):
             return None, "source_changed"
         apply_connection_test_result(resource, result)
+        if resource.resource_type == ResourceType.NAS:
+            # The source row is locked in this transaction. Queue the pipeline
+            # projection only after commit so it can acquire locks in the
+            # canonical Node -> Source order without retaining this Source lock.
+            organization_id = int(resource.organization_id)
+            resource_id = int(resource.id)
+            transaction.on_commit(
+                lambda organization_id=organization_id, resource_id=resource_id: (
+                    _queue_source_pipeline_projection(
+                        organization_id=organization_id,
+                        resource_id=resource_id,
+                    )
+                )
+            )
         return resource, ""
+
+
+def _queue_source_pipeline_projection(*, organization_id: int, resource_id: int) -> None:
+    """Queue a committed NAS projection without affecting the source result."""
+    from apps.source.tasks.pipeline import queue_source_pipeline_projection
+
+    queue_source_pipeline_projection(
+        organization_id=organization_id,
+        source_kind="nas",
+        ref_id=resource_id,
+    )
 
 
 def _source_removal_fenced(resource_id: int) -> bool:

--- a/src/backend/apps/source/services/internal/source_pipeline.py
+++ b/src/backend/apps/source/services/internal/source_pipeline.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
-from django.db import transaction
+import logging
+import time
+
+from django.db import OperationalError, transaction
 from django.utils import timezone
 
 from apps.node.models import Node
@@ -13,6 +16,60 @@ from apps.source.services.internal.selectable_ids import parse_selectable_id
 from apps.source.services.internal.source_pipeline_projection import (
     build_source_projection,
 )
+
+logger = logging.getLogger(__name__)
+
+
+_PROJECTION_RETRYABLE_PG_CODES = {"40P01", "40001"}
+_PROJECTION_MAX_RETRIES = 3
+
+
+def _is_retryable_projection_error(error: BaseException) -> bool:
+    """Return whether PostgreSQL rejected a projection for a transient reason."""
+    current: BaseException | None = error
+    while current is not None:
+        if (
+            getattr(current, "pgcode", None) in _PROJECTION_RETRYABLE_PG_CODES
+            or getattr(current, "sqlstate", None) in _PROJECTION_RETRYABLE_PG_CODES
+        ):
+            return True
+        current = current.__cause__ or current.__context__
+    message = str(error).lower()
+    return "deadlock detected" in message or "could not serialize" in message
+
+
+def sync_pipeline_projection_with_retry(
+    *,
+    organization_id: int,
+    source_kind: str,
+    ref_id: int,
+    minimum_step: int = PipelineStep.SOURCE_POOL,
+    max_retries: int = _PROJECTION_MAX_RETRIES,
+) -> SourceBackupPipelineEntry | None:
+    """Run an idempotent projection with bounded retry for transient DB conflicts."""
+    attempts = max(1, int(max_retries))
+    for attempt in range(attempts):
+        try:
+            return sync_pipeline_projection(
+                organization_id=organization_id,
+                source_kind=source_kind,
+                ref_id=ref_id,
+                minimum_step=minimum_step,
+            )
+        except OperationalError as exc:
+            if not _is_retryable_projection_error(exc) or attempt + 1 >= attempts:
+                raise
+            logger.warning(
+                "retrying source pipeline projection after transient database conflict "
+                "organization_id=%s source_kind=%s ref_id=%s attempt=%s",
+                organization_id,
+                source_kind,
+                ref_id,
+                attempt + 1,
+                exc_info=True,
+            )
+            time.sleep(0.05 * (attempt + 1))
+    return None
 
 
 def _selectable_key(source_kind: str, ref_id: int) -> str:
@@ -354,7 +411,7 @@ def reconcile_pipeline_projections(*, limit: int = 200) -> dict[str, int]:
             .values_list("organization_id", "id")[:remaining]
         )
     repaired = sum(
-        sync_pipeline_projection(
+        sync_pipeline_projection_with_retry(
             organization_id=organization_id,
             source_kind=source_kind,
             ref_id=ref_id,

--- a/src/backend/apps/source/tasks/__init__.py
+++ b/src/backend/apps/source/tasks/__init__.py
@@ -13,7 +13,11 @@ from .source_unregister import (
     reconcile_stuck_source_unregister_tasks_task,
     reevaluate_source_unregister_task_task,
 )
-from .pipeline import reconcile_source_pipeline_task
+from .pipeline import (
+    queue_source_pipeline_projection,
+    reconcile_source_pipeline_task,
+    sync_source_pipeline_projection_task,
+)
 
 __all__ = [
     "execute_source_unregister_task",
@@ -24,6 +28,8 @@ __all__ = [
     "reconcile_stale_source_connection_probes_task",
     "reconcile_source_availability_task",
     "reconcile_source_pipeline_task",
+    "sync_source_pipeline_projection_task",
+    "queue_source_pipeline_projection",
     "reconcile_stuck_source_unregister_tasks_task",
     "reevaluate_source_unregister_task_task",
 ]

--- a/src/backend/apps/source/tasks/pipeline.py
+++ b/src/backend/apps/source/tasks/pipeline.py
@@ -1,8 +1,94 @@
-"""Periodic repair for the source backup Pipeline read model."""
+"""Durable and periodic repair for the source backup Pipeline read model."""
+
+import logging
 
 from celery import shared_task
+from django.db import OperationalError
 
-from apps.source.services.internal.source_pipeline import reconcile_pipeline_projections
+from apps.source.services.internal.source_pipeline import (
+    _is_retryable_projection_error,
+    reconcile_pipeline_projections,
+    sync_pipeline_projection_with_retry,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@shared_task(
+    bind=True,
+    max_retries=3,
+    name="apps.source.tasks.pipeline.sync_source_pipeline_projection_task",
+)
+def sync_source_pipeline_projection_task(
+    self,
+    *,
+    organization_id: int,
+    source_kind: str,
+    ref_id: int,
+) -> dict[str, object]:
+    """Refresh one source projection after its authoritative state commits."""
+    try:
+        entry = sync_pipeline_projection_with_retry(
+            organization_id=int(organization_id),
+            source_kind=str(source_kind),
+            ref_id=int(ref_id),
+            max_retries=1,
+        )
+    except OperationalError as exc:
+        if not _is_retryable_projection_error(exc):
+            logger.exception(
+                "source pipeline projection failed with non-retryable database error "
+                "organization_id=%s source_kind=%s ref_id=%s",
+                organization_id,
+                source_kind,
+                ref_id,
+            )
+            return {"status": "failed", "reason": "projection_error"}
+        retries = int(getattr(self.request, "retries", 0) or 0)
+        if retries < self.max_retries:
+            raise self.retry(exc=exc, countdown=2 ** retries)
+        logger.exception(
+            "source pipeline projection exhausted retries organization_id=%s "
+            "source_kind=%s ref_id=%s",
+            organization_id,
+            source_kind,
+            ref_id,
+        )
+        return {"status": "failed", "reason": "projection_error"}
+    except Exception:
+        logger.exception(
+            "source pipeline projection failed organization_id=%s source_kind=%s "
+            "ref_id=%s",
+            organization_id,
+            source_kind,
+            ref_id,
+        )
+        return {"status": "failed", "reason": "projection_error"}
+    return {"status": "updated" if entry is not None else "skipped"}
+
+
+def queue_source_pipeline_projection(
+    *, organization_id: int, source_kind: str, ref_id: int
+) -> bool:
+    """Queue a projection without turning a committed source result into an API error."""
+    try:
+        sync_source_pipeline_projection_task.apply_async(
+            kwargs={
+                "organization_id": int(organization_id),
+                "source_kind": str(source_kind),
+                "ref_id": int(ref_id),
+            }
+        )
+    except Exception:
+        logger.exception(
+            "source pipeline projection enqueue failed organization_id=%s "
+            "source_kind=%s ref_id=%s",
+            organization_id,
+            source_kind,
+            ref_id,
+        )
+        return False
+    return True
 
 
 @shared_task(name="apps.source.tasks.pipeline.reconcile_source_pipeline_task")

--- a/src/backend/apps/source/tests/test_connection_probe.py
+++ b/src/backend/apps/source/tests/test_connection_probe.py
@@ -132,6 +132,24 @@ class SourceConnectionProbeTests(TestCase):
         self.assertEqual(self.resource.availability, "online")
         self.assertIsNotNone(self.resource.availability_updated_at)
 
+    @mock.patch("apps.source.tasks.pipeline.queue_source_pipeline_projection")
+    def test_probe_result_queues_pipeline_projection_after_source_commit(
+        self, queue_projection
+    ):
+        node_task = self._probe_node_task()
+        node_task.status = NodeTask.Status.SUCCESS
+        node_task.result = {"space_info": {"total_bytes": 1000}}
+        node_task.save(update_fields=["status", "result", "updated_at"])
+
+        with self.captureOnCommitCallbacks(execute=True):
+            self.assertTrue(project_source_connection_probe(node_task=node_task))
+
+        queue_projection.assert_called_once_with(
+            organization_id=self.org.id,
+            source_kind="nas",
+            ref_id=self.resource.id,
+        )
+
     @mock.patch(
         "apps.source.tasks.connection_probe.dispatch_nas_agent_task_async",
         side_effect=RuntimeError("broker unavailable"),

--- a/src/backend/apps/source/tests/test_source_pipeline_projection.py
+++ b/src/backend/apps/source/tests/test_source_pipeline_projection.py
@@ -1,7 +1,9 @@
 from io import StringIO
+from unittest import mock
 
 from django.core.management import call_command
 from django.core.management.base import CommandError
+from django.db import OperationalError
 from django.test import TestCase
 
 from apps.iam.models import Organization
@@ -15,6 +17,7 @@ from apps.source.services.internal.source_pipeline import (
     ensure_pipeline_entry,
     reconcile_pipeline_projections,
     revert_backup_flow_sources,
+    sync_pipeline_projection_with_retry,
 )
 from apps.task.models import Task, TaskResource
 from apps.task.services.interface import complete_task, create_task, start_task
@@ -34,6 +37,27 @@ class SourcePipelineProjectionTests(TestCase):
             connection_ip_address="198.51.100.10",
             metadata={"inventory": {"hostname": "agent-reported"}},
         )
+
+    @mock.patch("apps.source.services.internal.source_pipeline.time.sleep")
+    @mock.patch("apps.source.services.internal.source_pipeline.sync_pipeline_projection")
+    def test_projection_retries_transient_database_deadlock(
+        self, sync_projection, sleep
+    ):
+        expected = object()
+        sync_projection.side_effect = [
+            OperationalError("deadlock detected"),
+            expected,
+        ]
+
+        result = sync_pipeline_projection_with_retry(
+            organization_id=self.org.id,
+            source_kind=SelectableSourceKind.AGENT,
+            ref_id=self.agent.id,
+        )
+
+        self.assertIs(result, expected)
+        self.assertEqual(sync_projection.call_count, 2)
+        sleep.assert_called_once_with(0.05)
 
     def test_agent_projection_uses_hostname_and_connection_ip_fallback(self):
         entry = ensure_pipeline_entry(


### PR DESCRIPTION
## Summary
- commit authoritative NAS probe results before refreshing the backup Pipeline read model
- enqueue idempotent Pipeline projection work after transaction commit
- retry transient PostgreSQL deadlock and serialization conflicts with periodic reconciliation as the final fallback

## Validation
- 2,069 backend tests passed; 4 skipped
- full backend Ruff checks passed
- Django migration check passed
- git diff validation passed

Fixes #801