### PR TITLE
Improve Community online installation channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,26 +96,34 @@ manually with `sudo ./install.sh backup`.
 ### Community online installation
 
 For a supported Ubuntu 20.04/22.04/24.04 amd64 host with Docker Engine and
-Compose V2 already installed, install a pinned Community release with one
-command. Global users should use GitHub and Docker Hub:
+Compose V2 already installed, install the latest Community tag
+with one command. The installer adds only its small host-tool prerequisites
+(Python, rsync, tar, OpenSSL, and CA certificates) through the Ubuntu package
+manager. Global users should use GitHub and Docker Hub:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/oneprolabs/hyperfilelens/vX.Y.Z/deploy/online/install.sh \
-  | sudo bash -s -- vX.Y.Z --region global --download-source github --yes
+curl -fsSL https://raw.githubusercontent.com/oneprolabs/hyperfilelens/main/deploy/online/install.sh \
+  | sudo bash -s -- --mirror global
 ```
 
 Users in mainland China can use the public Gitee source and Alibaba Cloud
 image mirror:
 
 ```bash
-curl -fsSL https://gitee.com/oneprolabs/hyperfilelens/raw/vX.Y.Z/deploy/online/install.sh \
-  | sudo bash -s -- vX.Y.Z --region cn --download-source gitee --yes
+curl -fsSL https://gitee.com/oneprolabs/hyperfilelens/raw/main/deploy/online/install.sh \
+  | sudo bash -s -- --mirror cn
 ```
 
-With `--download-source auto`, the installer prefers Gitee in China and
-GitHub elsewhere, then falls back to the other public source. `--yes` enables
-non-interactive execution. The online installer is Community-only; Enterprise
-continues to use the existing Enterprise delivery workflow.
+The installer resolves the latest semantic version tag from the selected
+source and asks for confirmation before installation or upgrade. Use
+`--tag vX.Y.Z` to select a specific version and `--yes` only for
+non-interactive automation. The old positional tag, `--region`, and
+`--download-source` forms are not supported. The online installer is
+Community-only; Enterprise continues to use the existing Enterprise delivery
+workflow. Before changing an installation, it verifies that the selected tag's
+images, assets, and source revision are complete and consistent. If the latest
+or selected tag is unavailable, it prints up to ten recent available tags and
+the exact `--mirror ... --tag vX.Y.Z` form to use instead.
 
 ## Quick Start
 

--- a/deploy/online/install.sh
+++ b/deploy/online/install.sh
@@ -1,26 +1,37 @@
 #!/usr/bin/env bash
-# Bootstrap a public Community installation or upgrade from one HFL Git tag.
+# Bootstrap a verified public Community installation or upgrade.
 set -euo pipefail
 
-GLOBAL_REGISTRY_PREFIX="${HFL_GLOBAL_REGISTRY_PREFIX:-docker.io/oneprolabs}"
-CN_REGISTRY_PREFIX="${HFL_CN_REGISTRY_PREFIX:-registry.cn-beijing.aliyuncs.com/oneprolabs}"
-REGION="${HFL_REGISTRY_REGION:-auto}"
-DOWNLOAD_SOURCE="${HFL_DOWNLOAD_SOURCE:-auto}"
-ASSUME_YES=0
+DEFAULT_GLOBAL_REGISTRY_PREFIX="docker.io/oneprolabs"
+DEFAULT_CN_REGISTRY_PREFIX="registry.cn-beijing.aliyuncs.com/oneprolabs"
+GLOBAL_REGISTRY_PREFIX="${HFL_GLOBAL_REGISTRY_PREFIX:-${DEFAULT_GLOBAL_REGISTRY_PREFIX}}"
+CN_REGISTRY_PREFIX="${HFL_CN_REGISTRY_PREFIX:-${DEFAULT_CN_REGISTRY_PREFIX}}"
+MIRROR=""
 TAG=""
+ASSUME_YES=0
 SESSION_DIR=""
+SOURCE_NAME=""
+REGION=""
+TAGS_API_URL=""
+REGISTRY_NAME=""
+RELEASE_VERSION=""
+RELEASE_COMMIT=""
+RECENT_TAGS=""
+INSTALL_ROOT="/opt/hyperfilelens"
+INSTALL_ACTION="Install"
+MAX_TAG_PAGES=100
 
 usage() {
 	cat <<'USAGE'
-Usage: install.sh vX.Y.Z [--region auto|cn|global] [--download-source auto|github|gitee] [--yes]
+Usage: install.sh --mirror cn|global [--tag vX.Y.Z] [--yes]
 
-Installs HyperFileLens Community on a new host. Running the command again with
-a newer tag performs the normal managed backup and blue/green upgrade.
+Installs the latest HyperFileLens Community tag on a new host.
+Running the command again upgrades an existing Community installation through
+the normal managed backup and blue/green lifecycle.
 
---region selects the preferred public image registry. --download-source selects
-the GitHub or Gitee source archive; auto uses Gitee first in China and GitHub
-first elsewhere, with the other source as a fallback. --yes enables
-non-interactive installation and upgrade.
+--mirror cn|global     Select Gitee + Alibaba Cloud or GitHub + Docker Hub
+--tag vX.Y.Z           Install one specific Community tag
+--yes                  Skip the interactive confirmation (automation only)
 USAGE
 }
 
@@ -38,16 +49,12 @@ cleanup() {
 	exit "${rc}"
 }
 
-detect_region() {
-	local timezone=""
-	timezone="$(cat /etc/timezone 2>/dev/null || true)"
-	case "${timezone}" in
-	Asia/Shanghai | Asia/Chongqing | Asia/Harbin | Asia/Urumqi) printf 'cn' ;;
-	*) printf 'global' ;;
-	esac
+require_value() {
+	[[ $# -ge 2 && -n "${2:-}" && "${2:0:1}" != "-" ]] \
+		|| fail "$1 requires a value"
 }
 
-ensure_prerequisites() {
+check_host() {
 	[[ "${EUID}" -eq 0 ]] || fail "run this command through sudo"
 	[[ -f /etc/os-release ]] || fail "missing /etc/os-release"
 	# shellcheck disable=SC1091
@@ -57,10 +64,16 @@ ensure_prerequisites() {
 		fail "Ubuntu 20.04, 22.04, or 24.04 is required"
 		;; esac
 	[[ "$(uname -m)" == x86_64 ]] || fail "linux/amd64 is required"
+	command -v curl >/dev/null 2>&1 || fail "curl is required to start the online installer"
+	command -v docker >/dev/null 2>&1 || fail "Docker Engine is required"
+	docker info >/dev/null 2>&1 || fail "cannot connect to the Docker daemon"
+	docker compose version >/dev/null 2>&1 || fail "Docker Compose V2 is required"
+}
 
+install_host_tools() {
 	local -a missing=()
 	local command
-	for command in ca-certificates curl openssl python3 rsync tar; do
+	for command in ca-certificates openssl python3 rsync tar; do
 		case "${command}" in
 		ca-certificates) [[ -f /etc/ssl/certs/ca-certificates.crt ]] || missing+=(ca-certificates) ;;
 		*) command -v "${command}" >/dev/null 2>&1 || missing+=("${command}") ;;
@@ -71,127 +84,35 @@ ensure_prerequisites() {
 		apt-get update
 		DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends "${missing[@]}"
 	fi
-	command -v docker >/dev/null 2>&1 || fail "Docker Engine is required"
-	docker info >/dev/null 2>&1 || fail "cannot connect to the Docker daemon"
-	docker compose version >/dev/null 2>&1 || fail "Docker Compose V2 is required"
 }
 
-while (($#)); do
-	case "$1" in
-	--region)
-		[[ $# -ge 2 ]] || fail "--region requires auto, cn, or global"
-		REGION=$2
-		shift 2
+configure_mirror() {
+	case "${MIRROR}" in
+	cn)
+		SOURCE_NAME="Gitee"
+		REGION="cn"
+		TAGS_API_URL="https://gitee.com/api/v5/repos/oneprolabs/hyperfilelens/tags?per_page=100&page=1"
+		REGISTRY_NAME="Alibaba Cloud"
 		;;
-	--download-source)
-		[[ $# -ge 2 ]] || fail "--download-source requires auto, github, or gitee"
-		DOWNLOAD_SOURCE=$2
-		shift 2
+	global)
+		SOURCE_NAME="GitHub"
+		REGION="global"
+		TAGS_API_URL="https://api.github.com/repos/oneprolabs/hyperfilelens/tags?per_page=100&page=1"
+		REGISTRY_NAME="Docker Hub"
 		;;
-	--yes)
-		ASSUME_YES=1
-		shift
-		;;
-	-h | --help)
-		usage
-		exit 0
-		;;
-	v[0-9]*.[0-9]*.[0-9]*)
-		[[ -z "${TAG}" ]] || fail "only one HFL tag may be supplied"
-		TAG=$1
-		shift
-		;;
-	*) fail "unknown argument: $1" ;;
+	*) fail "--mirror must be cn or global" ;;
 	esac
-done
-
-[[ "${TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
-	usage >&2
-	exit 2
 }
-case "${REGION}" in
-auto) REGION="$(detect_region)" ;;
-cn | global) ;;
-*) fail "--region must be auto, cn, or global" ;;
-esac
-case "${DOWNLOAD_SOURCE}" in
-auto | github | gitee) ;;
-*) fail "--download-source must be auto, github, or gitee" ;;
-esac
 
-ensure_prerequisites
-export HFL_GLOBAL_REGISTRY_PREFIX="${GLOBAL_REGISTRY_PREFIX}"
-export HFL_CN_REGISTRY_PREFIX="${CN_REGISTRY_PREFIX}"
-export HFL_REGISTRY_REGION="${REGION}"
-
-SESSION_DIR="$(mktemp -d /var/tmp/hyperfilelens-online.XXXXXX)"
-chmod 0700 "${SESSION_DIR}"
-trap cleanup EXIT
-trap 'exit 130' INT
-trap 'exit 143' TERM
-archive="${SESSION_DIR}/source.tar.gz"
-source_dir="${SESSION_DIR}/source"
-candidate="${SESSION_DIR}/hyperfilelens-${TAG#v}-online"
-
-download_source_archive() {
-	local source url
-	local -a sources=()
-	case "${DOWNLOAD_SOURCE}" in
-	auto)
-		if [[ "${REGION}" == cn ]]; then
-			sources=(gitee github)
-		else
-			sources=(github gitee)
-		fi
-		;;
-	github | gitee) sources=("${DOWNLOAD_SOURCE}") ;;
-	esac
-
-	for source in "${sources[@]}"; do
-		case "${source}" in
-		github)
-			url="https://codeload.github.com/oneprolabs/hyperfilelens/tar.gz/refs/tags/${TAG}"
-			;;
-		gitee)
-			url="https://gitee.com/oneprolabs/hyperfilelens/repository/archive/${TAG}.tar.gz"
-			;;
-		esac
-		printf '[....] Downloading %s installation contract from %s\n' "${TAG}" "${source}"
-		rm -rf -- "${source_dir}"
-		rm -f -- "${archive}"
-		if ! curl --fail --show-error --location --retry 3 --retry-all-errors \
-			--connect-timeout 15 --max-time 300 "${url}" -o "${archive}"; then
-			printf '[WARN] %s installation contract download failed; trying the next source\n' \
-				"${source}" >&2
-			continue
-		fi
-		mkdir -p "${source_dir}"
-		if ! tar -xzf "${archive}" -C "${source_dir}" --strip-components=1 \
-			|| [[ ! -x "${source_dir}/deploy/online/install.sh" ]] \
-			|| [[ ! -f "${source_dir}/deploy/online/prepare.py" ]]; then
-			printf '[WARN] %s archive does not provide the online installation contract; trying the next source\n' \
-				"${source}" >&2
-			continue
-		fi
-		printf '[ OK ] Downloaded installation contract from %s\n' "${source}"
+inspect_existing_installation() {
+	local existing_edition
+	if [[ ! -e "${INSTALL_ROOT}/.env" && ! -e "${INSTALL_ROOT}/MANIFEST.json" ]]; then
 		return 0
-	done
-	fail "could not download ${TAG} installation contract from the selected source(s)"
-}
-
-download_source_archive
-
-python3 "${source_dir}/deploy/online/prepare.py" \
-	--source-root "${source_dir}" \
-	--version "${TAG}" \
-	--region "${REGION}" \
-	--output "${candidate}"
-
-install_root=/opt/hyperfilelens
-if [[ -e "${install_root}/.env" || -e "${install_root}/MANIFEST.json" ]]; then
-	[[ -f "${install_root}/.env" && -f "${install_root}/MANIFEST.json" ]] \
-		|| fail "${install_root} contains an incomplete installation; recover or remove it before continuing"
-	existing_edition="$(python3 - "${install_root}/MANIFEST.json" <<'PY'
+	fi
+	INSTALL_ACTION="Upgrade"
+	[[ -f "${INSTALL_ROOT}/.env" && -f "${INSTALL_ROOT}/MANIFEST.json" ]] \
+		|| fail "${INSTALL_ROOT} contains an incomplete installation; recover or remove it before continuing"
+	existing_edition="$(python3 - "${INSTALL_ROOT}/MANIFEST.json" <<'PY'
 import json
 import pathlib
 import sys
@@ -205,12 +126,284 @@ PY
 	)" || fail "the existing installation manifest is invalid"
 	[[ "${existing_edition}" == community ]] \
 		|| fail "this public installer upgrades Community only; the existing edition is ${existing_edition}"
+}
+
+download_file() {
+	local url=$1
+	local output=$2
+	local max_time=${3:-120}
+	curl --fail --show-error --silent --location \
+		--retry 3 --retry-all-errors --connect-timeout 15 --max-time "${max_time}" \
+		-H 'Cache-Control: no-cache' "${url}" -o "${output}"
+}
+
+fail_with_tag_guidance() {
+	local reason=$1
+	local recommended_tag
+	if [[ -z "${RECENT_TAGS}" ]]; then
+		fail "${reason}; no fallback tags are available; retry later or use --mirror cn or --mirror global"
+	fi
+	recommended_tag="${RECENT_TAGS%%,*}"
+	fail "${reason}; recent fallback tags: ${RECENT_TAGS}; recommended retry: --mirror ${MIRROR} --tag ${recommended_tag}"
+}
+
+tag_page_url() {
+	local page=$1
+	printf '%s' "${TAGS_API_URL%page=1}page=${page}"
+}
+
+resolve_tag() {
+	local parsed requested_tag page count page_url page_fingerprint
+	local -a values=()
+	local -A seen_page_fingerprints=()
+	requested_tag="${TAG}"
+	printf '[....] Resolving Community tags from %s\n' "${SOURCE_NAME}"
+	page=1
+	while :; do
+		page_url="$(tag_page_url "${page}")"
+		if ! download_file "${page_url}" "${SESSION_DIR}/tag-page-${page}.json"; then
+			fail "could not read Community tags from ${SOURCE_NAME}; retry later or use --mirror cn or --mirror global"
+		fi
+		if ! read -r count page_fingerprint < <(python3 - "${SESSION_DIR}/tag-page-${page}.json" <<'PY'
+import hashlib
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+try:
+    raw = path.read_bytes()
+    payload = json.loads(raw)
+except (OSError, json.JSONDecodeError):
+    raise SystemExit(1)
+if not isinstance(payload, list):
+    raise SystemExit(1)
+print(len(payload), hashlib.sha256(raw).hexdigest())
+PY
+		); then
+			fail "the Community tag response from ${SOURCE_NAME} is invalid"
+		fi
+		if [[ -n "${seen_page_fingerprints[${page_fingerprint}]:-}" ]]; then
+			fail "the Community tag response from ${SOURCE_NAME} repeated page ${page}; retry later"
+		fi
+		seen_page_fingerprints["${page_fingerprint}"]=1
+		if ((page == 1)); then
+			cp "${SESSION_DIR}/tag-page-${page}.json" "${SESSION_DIR}/tags.json"
+		else
+			if ! python3 - "${SESSION_DIR}/tags.json" "${SESSION_DIR}/tag-page-${page}.json" <<'PY'
+import json
+import pathlib
+import sys
+
+target = pathlib.Path(sys.argv[1])
+current = json.loads(target.read_text(encoding="utf-8"))
+additional = json.loads(pathlib.Path(sys.argv[2]).read_text(encoding="utf-8"))
+if not isinstance(current, list) or not isinstance(additional, list):
+    raise SystemExit(1)
+target.write_text(json.dumps(current + additional), encoding="utf-8")
+PY
+			then
+				fail "the Community tag response from ${SOURCE_NAME} is invalid"
+			fi
+		fi
+		((count < 100)) && break
+		if ((page >= MAX_TAG_PAGES)); then
+			fail "the Community tag catalog from ${SOURCE_NAME} exceeds ${MAX_TAG_PAGES} pages"
+		fi
+		page=$((page + 1))
+	done
+
+	if ! parsed="$(python3 - "${SESSION_DIR}/tags.json" "${requested_tag}" <<'PY'
+import json
+import pathlib
+import re
+import sys
+
+path = pathlib.Path(sys.argv[1])
+requested = sys.argv[2]
+try:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+except (OSError, json.JSONDecodeError) as exc:
+    raise SystemExit(f"invalid tag response: {exc}")
+if not isinstance(payload, list):
+    raise SystemExit("tag response is not a list")
+
+tags = {}
+for entry in payload:
+    if not isinstance(entry, dict):
+        continue
+    tag = str(entry.get("name") or "")
+    commit_info = entry.get("commit")
+    commit = str(commit_info.get("sha") or "").lower() if isinstance(commit_info, dict) else ""
+    if not re.fullmatch(r"v[0-9]+\.[0-9]+\.[0-9]+", tag):
+        continue
+    if not re.fullmatch(r"[0-9a-f]{40}", commit):
+        continue
+    if tag in tags and tags[tag] != commit:
+        raise SystemExit(f"tag {tag} resolves to multiple commits")
+    tags[tag] = commit
+
+ordered = sorted(
+    tags,
+    key=lambda value: tuple(int(part) for part in value[1:].split(".")),
+    reverse=True,
+)
+if not ordered:
+    raise SystemExit("tag response contains no semantic release tags")
+
+selected = requested if requested in tags else (ordered[0] if not requested else "")
+if selected:
+    selected_version = tuple(int(part) for part in selected[1:].split("."))
+    fallback = [
+        tag
+        for tag in ordered
+        if tuple(int(part) for part in tag[1:].split(".")) < selected_version
+    ][:10]
+else:
+    fallback = ordered[:10]
+
+print(selected or "-")
+print(selected[1:] if selected else "-")
+print(tags.get(selected, "-") if selected else "-")
+print(", ".join(fallback) or "-")
+PY
+	)"; then
+		fail "the Community tag response from ${SOURCE_NAME} is invalid"
+	fi
+	mapfile -t values <<<"${parsed}"
+	[[ "${#values[@]}" -eq 4 ]] || fail "the Community tag response from ${SOURCE_NAME} is incomplete"
+	RECENT_TAGS="${values[3]}"
+	[[ "${RECENT_TAGS}" != - ]] || RECENT_TAGS=""
+	if [[ -n "${requested_tag}" && "${values[0]}" == - ]]; then
+		fail_with_tag_guidance "Community tag ${requested_tag} does not exist on ${SOURCE_NAME}"
+	fi
+	TAG="${values[0]}"
+	RELEASE_VERSION="${values[1]}"
+	RELEASE_COMMIT="${values[2]}"
+}
+
+confirm_installation() {
+	local answer=""
+	printf '\nSelected tag: %s\n' "${TAG}"
+	printf 'Download source: %s\n' "${SOURCE_NAME}"
+	printf 'Image registry: %s\n' "${REGISTRY_NAME}"
+	printf 'Install directory: %s\n' "${INSTALL_ROOT}"
+	printf 'Action: %s\n\n' "${INSTALL_ACTION}"
+	((ASSUME_YES == 1)) && return 0
+	[[ -r /dev/tty ]] \
+		|| fail "interactive confirmation requires a terminal; use --yes only for automation"
+	read -r -p 'Continue? [y/N] ' answer </dev/tty
+	case "${answer}" in y | Y | yes | YES | Yes) ;; *) fail "installation cancelled" ;; esac
+}
+
+download_source_archive() {
+	local url
+	case "${MIRROR}" in
+	global) url="https://codeload.github.com/oneprolabs/hyperfilelens/tar.gz/${RELEASE_COMMIT}" ;;
+	cn) url="https://gitee.com/oneprolabs/hyperfilelens/repository/archive/${RELEASE_COMMIT}.tar.gz" ;;
+	esac
+	printf '[....] Downloading %s installation contract from %s (commit %s)\n' \
+		"${TAG}" "${SOURCE_NAME}" "${RELEASE_COMMIT:0:12}"
+	if ! download_file "${url}" "${SESSION_DIR}/source.tar.gz" 300; then
+		fail_with_tag_guidance "Community release ${TAG} cannot be downloaded from ${SOURCE_NAME}"
+	fi
+	mkdir -p "${SESSION_DIR}/source"
+	tar -xzf "${SESSION_DIR}/source.tar.gz" -C "${SESSION_DIR}/source" --strip-components=1 \
+		|| fail_with_tag_guidance "Community tag ${TAG} installation contract could not be extracted"
+	[[ -x "${SESSION_DIR}/source/deploy/online/install.sh" \
+		&& -f "${SESSION_DIR}/source/deploy/online/prepare.py" ]] \
+		|| fail_with_tag_guidance "Community tag ${TAG} does not provide the online installation contract"
+	printf '[ OK ] Downloaded installation contract from %s\n' "${SOURCE_NAME}"
+}
+
+verify_candidate_release() {
+	python3 - "${candidate}/MANIFEST.json" "${TAG}" "${RELEASE_COMMIT}" <<'PY'
+import json
+import pathlib
+import re
+import sys
+
+path = pathlib.Path(sys.argv[1])
+expected_tag = sys.argv[2]
+expected_commit = sys.argv[3]
+try:
+    manifest = json.loads(path.read_text(encoding="utf-8"))
+except (OSError, json.JSONDecodeError) as exc:
+    raise SystemExit(f"prepared Community manifest is invalid: {exc}")
+version = str(manifest.get("version") or "")
+commit = str(manifest.get("git_commit") or "").lower()
+if expected_tag != f"v{version}":
+    raise SystemExit("prepared Community version does not match the published release")
+if not re.fullmatch(r"[0-9a-f]{40}", commit) or commit != expected_commit:
+    raise SystemExit("prepared Community image revision does not match the published release")
+if manifest.get("edition") != "community" or manifest.get("channel") != "release":
+    raise SystemExit("prepared package is not a Community release")
+PY
+}
+
+while (($#)); do
+	case "$1" in
+	--mirror)
+		require_value "$@"
+		MIRROR=$2
+		shift 2
+		;;
+	--tag)
+		require_value "$@"
+		[[ -z "${TAG}" ]] || fail "--tag may only be supplied once"
+		TAG=$2
+		shift 2
+		;;
+	--yes)
+		ASSUME_YES=1
+		shift
+		;;
+	-h | --help)
+		usage
+		exit 0
+		;;
+	*) fail "unknown argument: $1" ;;
+	esac
+done
+
+[[ -z "${TAG}" || "${TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] \
+	|| fail "--tag must use vX.Y.Z; choose a published version with --mirror cn|global --tag vX.Y.Z"
+configure_mirror
+check_host
+
+SESSION_DIR="$(mktemp -d /var/tmp/hyperfilelens-online.XXXXXX)"
+chmod 0700 "${SESSION_DIR}"
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+install_host_tools
+inspect_existing_installation
+resolve_tag
+confirm_installation
+download_source_archive
+
+export HFL_GLOBAL_REGISTRY_PREFIX="${GLOBAL_REGISTRY_PREFIX}"
+export HFL_CN_REGISTRY_PREFIX="${CN_REGISTRY_PREFIX}"
+export HFL_REGISTRY_REGION="${REGION}"
+candidate="${SESSION_DIR}/hyperfilelens-${RELEASE_VERSION}-online"
+if ! python3 "${SESSION_DIR}/source/deploy/online/prepare.py" \
+	--source-root "${SESSION_DIR}/source" \
+	--version "${TAG}" \
+	--region "${REGION}" \
+	--output "${candidate}"; then
+	fail_with_tag_guidance "Community tag ${TAG} is incomplete or unavailable"
+fi
+if ! verify_candidate_release; then
+	fail_with_tag_guidance "Community tag ${TAG} failed release identity validation"
+fi
+
+if [[ "${INSTALL_ACTION}" == Upgrade ]]; then
 	printf '[....] Upgrading the existing installation to %s\n' "${TAG}"
 	HFL_REGISTRY_REGION="${REGION}" bash "${candidate}/install.sh" \
 		upgrade --from "${candidate}" --yes --with-sourcelens
 else
 	printf '[....] Installing HyperFileLens Community %s\n' "${TAG}"
-	install_args=(install --with-sourcelens)
-	((ASSUME_YES == 1)) && install_args+=(--yes)
-	HFL_REGISTRY_REGION="${REGION}" bash "${candidate}/install.sh" "${install_args[@]}"
+	HFL_REGISTRY_REGION="${REGION}" bash "${candidate}/install.sh" \
+		install --with-sourcelens --yes
 fi

--- a/tools/quality/test-online-community-install.sh
+++ b/tools/quality/test-online-community-install.sh
@@ -12,14 +12,24 @@ bash -n "${online}/install.sh"
 PYTHONPYCACHEPREFIX="${tmp}/pycache" python3 -m py_compile "${online}/prepare.py"
 
 help_output="$("${online}/install.sh" --help)"
-grep -Fq -- '--download-source auto|github|gitee' <<<"${help_output}"
+grep -Fq -- '--mirror cn|global' <<<"${help_output}"
+grep -Fq -- '--tag vX.Y.Z' <<<"${help_output}"
 grep -Fq -- '--yes' <<<"${help_output}"
-grep -Fq 'https://codeload.github.com/oneprolabs/hyperfilelens/tar.gz/refs/tags/${TAG}' \
+if grep -Eq -- '--region|--download-source|install\.sh vX\.Y\.Z' <<<"${help_output}"; then
+	printf 'ERROR: online installer exposes a retired public argument\n' >&2
+	exit 1
+fi
+grep -Fq 'https://codeload.github.com/oneprolabs/hyperfilelens/tar.gz/${RELEASE_COMMIT}' \
 	"${online}/install.sh"
-grep -Fq 'https://gitee.com/oneprolabs/hyperfilelens/repository/archive/${TAG}.tar.gz' \
+grep -Fq 'https://gitee.com/oneprolabs/hyperfilelens/repository/archive/${RELEASE_COMMIT}.tar.gz' \
 	"${online}/install.sh"
-grep -Fq 'sources=(gitee github)' "${online}/install.sh"
-grep -Fq 'sources=(github gitee)' "${online}/install.sh"
+grep -Fq 'api.github.com/repos/oneprolabs/hyperfilelens/tags?per_page=100&page=1' \
+	"${online}/install.sh"
+grep -Fq 'gitee.com/api/v5/repos/oneprolabs/hyperfilelens/tags?per_page=100&page=1' \
+	"${online}/install.sh"
+grep -Fq 'recent fallback tags:' "${online}/install.sh"
+grep -Fq 'prepared Community image revision does not match the published release' \
+	"${online}/install.sh"
 grep -Fq -- '--yes                   Non-interactive compatibility flag' \
 	"${ROOT}/deploy/installer/install.sh"
 
@@ -31,6 +41,10 @@ grep -Fq 'tag_suffix: -ee' "${workflow}"
 grep -Fq 'hyperfilelens-agent-assets:${{ needs.prepare.outputs.version }}' "${workflow}"
 grep -Fq 'hyperfilelens-gateway-assets:${{ needs.prepare.outputs.version }}' "${workflow}"
 grep -Fq 'hyperfilelens-language-assets:${{ needs.prepare.outputs.version }}' "${workflow}"
+if grep -Eq 'publish-community-channel|community-channel|git push origin HEAD:main' "${workflow}"; then
+	printf 'ERROR: SaaS workflow must not manage a separate Community channel branch\n' >&2
+	exit 1
+fi
 grep -Fq 'SOURCELENS_DISTRIBUTION_TAG_OVERRIDE="${version}"' \
 	"${ROOT}/release/ci/assemble-saas-candidate.sh"
 grep -Fq 'SOURCELENS_DISTRIBUTION_TAG_OVERRIDE: ${{ needs.prepare.outputs.version }}' \
@@ -142,12 +156,82 @@ PY
 fake_bin="${tmp}/bin"
 candidate="${tmp}/hyperfilelens-1.2.3-online"
 mkdir -p "${fake_bin}"
+tag_fixture="${tmp}/tags.json"
+tag_page_one_fixture="${tmp}/tags-page-1.json"
+tag_page_two_fixture="${tmp}/tags-page-2.json"
+python3 - "${tag_fixture}" <<'PY'
+import json
+import pathlib
+import sys
+
+tags = [
+    {
+        "name": f"v1.2.{version}",
+        "commit": {"sha": f"{version:x}" * 40},
+    }
+    for version in range(1, 13)
+]
+pathlib.Path(sys.argv[1]).write_text(json.dumps(tags), encoding="utf-8")
+PY
+python3 - "${tag_page_one_fixture}" "${tag_page_two_fixture}" <<'PY'
+import json
+import pathlib
+import sys
+
+first = [
+    {"name": f"v1.0.{version}", "commit": {"sha": f"{version:040x}"}}
+    for version in range(1, 101)
+]
+second = [{"name": "v2.0.0", "commit": {"sha": "f" * 40}}]
+pathlib.Path(sys.argv[1]).write_text(json.dumps(first), encoding="utf-8")
+pathlib.Path(sys.argv[2]).write_text(json.dumps(second), encoding="utf-8")
+PY
+cat >"${fake_bin}/curl" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+output=""
+url=""
+[[ -z "${HFL_TEST_CURL_MARKER:-}" ]] || touch "${HFL_TEST_CURL_MARKER}"
+while (($#)); do
+	case "$1" in
+	-o)
+		output=${2:-}
+		shift 2
+		;;
+	http://* | https://*)
+		url=$1
+		shift
+		;;
+	*) shift ;;
+	esac
+done
+if [[ "${url}" == *'/tags?'* && -n "${output}" ]]; then
+	page=1
+	if [[ "${url}" =~ [\?\&]page=([0-9]+) ]]; then
+		page=${BASH_REMATCH[1]}
+	fi
+	page_fixture_name="HFL_TEST_TAG_FIXTURE_PAGE_${page}"
+	page_fixture=${!page_fixture_name:-}
+	if [[ -n "${page_fixture}" ]]; then
+		cp "${page_fixture}" "${output}"
+	elif ((page == 1)); then
+		cp "${HFL_TEST_TAG_FIXTURE}" "${output}"
+	else
+		printf '[]\n' >"${output}"
+	fi
+	exit 0
+fi
+exit 22
+SH
 cat >"${fake_bin}/docker" <<'SH'
 #!/usr/bin/env bash
 set -euo pipefail
 digest="sha256:$(printf 'b%.0s' {1..64})"
 revision="$(printf 'c%.0s' {1..40})"
 case "${1:-} ${2:-}" in
+"info " | "compose version")
+	exit 0
+	;;
 "pull --platform")
 	exit 0
 	;;
@@ -217,7 +301,87 @@ case "${1:-} ${2:-}" in
 	;;
 esac
 SH
-chmod 755 "${fake_bin}/docker"
+chmod 755 "${fake_bin}/curl" "${fake_bin}/docker"
+
+enterprise_root="${tmp}/enterprise-install"
+mkdir -p "${enterprise_root}"
+printf 'HFL_EDITION=enterprise\n' >"${enterprise_root}/.env"
+printf '{"edition":"enterprise"}\n' >"${enterprise_root}/MANIFEST.json"
+enterprise_installer="${tmp}/enterprise-rejection-install.sh"
+python3 - "${online}/install.sh" "${enterprise_installer}" "${enterprise_root}" <<'PY'
+import pathlib
+import sys
+
+source = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
+source = source.replace(
+    'INSTALL_ROOT="/opt/hyperfilelens"',
+    f'INSTALL_ROOT="{sys.argv[3]}"',
+    1,
+)
+pathlib.Path(sys.argv[2]).write_text(source, encoding="utf-8")
+PY
+chmod 755 "${enterprise_installer}"
+enterprise_log="${tmp}/enterprise-rejection.log"
+curl_marker="${tmp}/enterprise-curl-called"
+if PATH="${fake_bin}:${PATH}" HFL_TEST_CURL_MARKER="${curl_marker}" \
+	"${enterprise_installer}" --mirror global --yes >"${enterprise_log}" 2>&1; then
+	printf 'ERROR: Community installer accepted an Enterprise installation\n' >&2
+	exit 1
+fi
+grep -Fq 'this public installer upgrades Community only' "${enterprise_log}"
+[[ ! -e "${curl_marker}" ]] || {
+	printf 'ERROR: Community installer contacted the release source before rejecting Enterprise\n' >&2
+	exit 1
+}
+
+latest_log="${tmp}/latest-tag.log"
+if PATH="${fake_bin}:${PATH}" HFL_TEST_TAG_FIXTURE="${tag_fixture}" \
+	"${online}/install.sh" --mirror global --yes >"${latest_log}" 2>&1; then
+	printf 'ERROR: fake online install unexpectedly succeeded\n' >&2
+	exit 1
+fi
+grep -Fq 'Selected tag: v1.2.12' "${latest_log}" || {
+	cat "${latest_log}" >&2
+	exit 1
+}
+grep -Fq 'recent fallback tags: v1.2.11, v1.2.10, v1.2.9, v1.2.8, v1.2.7, v1.2.6, v1.2.5, v1.2.4, v1.2.3, v1.2.2' \
+	"${latest_log}"
+grep -Fq 'recommended retry: --mirror global --tag v1.2.11' "${latest_log}"
+
+missing_log="${tmp}/missing-tag.log"
+if PATH="${fake_bin}:${PATH}" HFL_TEST_TAG_FIXTURE="${tag_fixture}" \
+	"${online}/install.sh" --mirror global --tag v9.9.9 --yes \
+	>"${missing_log}" 2>&1; then
+	printf 'ERROR: missing online tag unexpectedly succeeded\n' >&2
+	exit 1
+fi
+grep -Fq 'Community tag v9.9.9 does not exist on GitHub' "${missing_log}"
+grep -Fq 'recent fallback tags: v1.2.12, v1.2.11, v1.2.10, v1.2.9, v1.2.8, v1.2.7, v1.2.6, v1.2.5, v1.2.4, v1.2.3' \
+	"${missing_log}"
+grep -Fq 'recommended retry: --mirror global --tag v1.2.12' "${missing_log}"
+
+pagination_log="${tmp}/pagination.log"
+if PATH="${fake_bin}:${PATH}" \
+	HFL_TEST_TAG_FIXTURE="${tag_page_one_fixture}" \
+	HFL_TEST_TAG_FIXTURE_PAGE_2="${tag_page_two_fixture}" \
+	"${online}/install.sh" --mirror global --yes >"${pagination_log}" 2>&1; then
+	printf 'ERROR: fake paginated online install unexpectedly succeeded\n' >&2
+	exit 1
+fi
+grep -Fq 'Selected tag: v2.0.0' "${pagination_log}" || {
+	cat "${pagination_log}" >&2
+	exit 1
+}
+
+repeated_page_log="${tmp}/repeated-page.log"
+if PATH="${fake_bin}:${PATH}" \
+	HFL_TEST_TAG_FIXTURE="${tag_page_one_fixture}" \
+	HFL_TEST_TAG_FIXTURE_PAGE_2="${tag_page_one_fixture}" \
+	"${online}/install.sh" --mirror global --yes >"${repeated_page_log}" 2>&1; then
+	printf 'ERROR: repeated tag page unexpectedly succeeded\n' >&2
+	exit 1
+fi
+grep -Fq 'repeated page 2' "${repeated_page_log}"
 
 PATH="${fake_bin}:${PATH}" HFL_TEST_VERSION=1.2.3 \
 	python3 "${online}/prepare.py" \

--- a/website/.vitepress/theme/HomeLanding.vue
+++ b/website/.vitepress/theme/HomeLanding.vue
@@ -34,14 +34,10 @@ const loginUrl = computed(() => `${appOrigin.value || '#'}${appOrigin.value ? '/
 const githubUrl = 'https://github.com/HyperBDR/hyperfilelens'
 const sourceLensUrl = 'https://github.com/HyperBDR/sourcelens'
 const communityInstallGuideUrl = 'https://github.com/oneprolabs/hyperfilelens#community-online-installation'
-const communityVersion = 'v0.2.8'
 const installCommand = [
   'curl -fsSL \\',
-  `  https://gitee.com/oneprolabs/hyperfilelens/raw/${communityVersion}/deploy/online/install.sh \\`,
-  `  | sudo bash -s -- ${communityVersion} \\`,
-  '      --region cn \\',
-  '      --download-source gitee \\',
-  '      --yes',
+  '  https://raw.githubusercontent.com/oneprolabs/hyperfilelens/main/deploy/online/install.sh \\',
+  '  | sudo bash -s -- --mirror global',
 ].join('\n')
 const copied = ref(false)
 let copyResetTimer: number | undefined
@@ -276,7 +272,7 @@ function openApp(event: MouseEvent, placement: WebsiteOpenAppPlacement) {
           <div class="open-source-copy">
             <p class="section-kicker dark-kicker">Community</p>
             <h2 id="open-source-title">Open source.<br />One-command install.</h2>
-            <p>Run the Community edition on an Ubuntu host with Docker in one command. The current public installer is hosted on Gitee.</p>
+            <p>Install the latest Community tag on an Ubuntu host with Docker. The installer verifies its images and assets before changing the host.</p>
             <div class="open-source-callout">
               <svg aria-hidden="true"><use href="#icon-check" /></svg>
               <p>Community is free and open source, with S3-compatible storage and an AI model or API key. Enterprise capabilities will be available in a later release.</p>
@@ -294,7 +290,7 @@ function openApp(event: MouseEvent, placement: WebsiteOpenAppPlacement) {
           <div class="terminal-card" aria-label="Community online installation command">
             <div class="terminal-bar">
               <span class="terminal-lights" aria-hidden="true"><i></i><i></i><i></i></span>
-              <div class="terminal-title"><strong>Community</strong><span>{{ communityVersion }}</span></div>
+              <div class="terminal-title"><strong>Community</strong><span>Latest tag</span></div>
               <button
                 type="button"
                 class="copy-command"
@@ -307,7 +303,7 @@ function openApp(event: MouseEvent, placement: WebsiteOpenAppPlacement) {
             </div>
             <div class="terminal-body">
               <p class="terminal-context">Run on an Ubuntu host</p>
-              <pre><code><span class="terminal-comment"># Community online install · {{ communityVersion }}</span>
+              <pre><code><span class="terminal-comment"># Install the latest Community tag</span>
 <span class="terminal-prompt">$</span> {{ installCommand }}</code></pre>
             </div>
             <div class="terminal-summary">

--- a/website/.vitepress/theme/HomeLandingZh.vue
+++ b/website/.vitepress/theme/HomeLandingZh.vue
@@ -33,14 +33,10 @@ const loginUrl = computed(() => `${appOrigin.value || '#'}${appOrigin.value ? '/
 
 const githubUrl = 'https://github.com/HyperBDR/hyperfilelens'
 const sourceLensUrl = 'https://github.com/HyperBDR/sourcelens'
-const communityVersion = 'v0.2.8'
 const installCommand = [
   'curl -fsSL \\',
-  `  https://gitee.com/oneprolabs/hyperfilelens/raw/${communityVersion}/deploy/online/install.sh \\`,
-  `  | sudo bash -s -- ${communityVersion} \\`,
-  '      --region cn \\',
-  '      --download-source gitee \\',
-  '      --yes',
+  '  https://gitee.com/oneprolabs/hyperfilelens/raw/main/deploy/online/install.sh \\',
+  '  | sudo bash -s -- --mirror cn',
 ].join('\n')
 const copied = ref(false)
 let copyResetTimer: number | undefined
@@ -275,7 +271,7 @@ function openApp(event: MouseEvent, placement: WebsiteOpenAppPlacement) {
           <div class="open-source-copy">
             <p class="section-kicker dark-kicker">社区版</p>
             <h2 id="open-source-title">开源社区版 一条命令部署</h2>
-            <p>在安装了 Docker 的 Ubuntu 主机上一条命令运行 Community。当前提供稳定的 Gitee 在线安装入口。</p>
+            <p>在安装了 Docker 的 Ubuntu 主机上安装最新 Community Tag，安装程序会先校验镜像和资产，国内通过 Gitee 和阿里云镜像交付。</p>
             <div class="open-source-callout">
               <svg aria-hidden="true"><use href="#icon-check" /></svg>
               <p>社区版免费开源，自带 S3 兼容存储和 AI 模型或 API Key；企业版能力将在后续版本提供。</p>
@@ -293,7 +289,7 @@ function openApp(event: MouseEvent, placement: WebsiteOpenAppPlacement) {
           <div class="terminal-card" aria-label="Community 在线安装命令">
             <div class="terminal-bar">
               <span class="terminal-lights" aria-hidden="true"><i></i><i></i><i></i></span>
-              <div class="terminal-title"><strong>Community</strong><span>{{ communityVersion }}</span></div>
+              <div class="terminal-title"><strong>Community</strong><span>最新 Tag</span></div>
               <button
                 type="button"
                 class="copy-command"
@@ -306,7 +302,7 @@ function openApp(event: MouseEvent, placement: WebsiteOpenAppPlacement) {
             </div>
             <div class="terminal-body">
               <p class="terminal-context">在 Ubuntu 主机上运行</p>
-              <pre><code><span class="terminal-comment"># 在线安装 Community · {{ communityVersion }}</span>
+              <pre><code><span class="terminal-comment"># 安装最新 Community Tag</span>
 <span class="terminal-prompt">$</span> {{ installCommand }}</code></pre>
             </div>
             <div class="terminal-summary">

--- a/website/zh/docs/getting-started/install.md
+++ b/website/zh/docs/getting-started/install.md
@@ -1,11 +1,11 @@
 ---
 title: 安装 Community
-description: 使用当前公开安装方式部署 HyperFileLens Community v0.2.8。
+description: 使用公开在线安装方式部署最新 HyperFileLens Community Tag。
 ---
 
 # 安装 Community
 
-如果希望在自己的环境中运行 HyperFileLens，请安装 Community。当前公开版本为 `v0.2.8`，使用下面的在线安装方式。
+如果希望在自己的环境中运行 HyperFileLens，请使用下面的在线安装方式部署最新 Community Tag。
 
 ## 安装前准备
 
@@ -14,6 +14,9 @@ description: 使用当前公开安装方式部署 HyperFileLens Community v0.2.8
 - 能够访问 Gitee、镜像仓库和产品运行所需的网络地址。
 - 具备 `sudo` 权限，并为 `/opt/hyperfilelens` 和容器数据预留足够空间。
 
+安装程序会通过 Ubuntu 软件源补齐 Python、rsync、tar、OpenSSL 和 CA
+证书等少量运行所需工具；Docker Engine 和 Compose V2 需要预先安装。
+
 详细要求请查看[系统要求](/zh/docs/deployment/requirements)。
 
 ## 执行安装
@@ -21,11 +24,23 @@ description: 使用当前公开安装方式部署 HyperFileLens Community v0.2.8
 在准备好的主机上运行：
 
 ```bash
-curl -fsSL https://gitee.com/oneprolabs/hyperfilelens/raw/v0.2.8/deploy/online/install.sh \
-  | sudo bash -s -- v0.2.8 --region cn --download-source gitee --yes
+curl -fsSL https://gitee.com/oneprolabs/hyperfilelens/raw/main/deploy/online/install.sh \
+  | sudo bash -s -- --mirror cn
 ```
 
-该命令从 Gitee 获取 `v0.2.8` 安装内容，并使用中国大陆镜像来源部署 Community。不要把版本替换为未发布分支或浮动标签。
+安装程序从 Gitee 读取最新的语义化版本 Tag，并使用阿里云公共镜像。执行安装或升级前，会显示实际版本、下载来源和镜像仓库并等待确认；正式修改产品安装前还会校验该版本的镜像、资产和代码提交是否完整一致。
+
+如需安装一个已经发布的固定版本，可显式指定：
+
+```bash
+curl -fsSL https://gitee.com/oneprolabs/hyperfilelens/raw/main/deploy/online/install.sh \
+  | sudo bash -s -- --mirror cn --tag vX.Y.Z
+```
+
+自动化场景可以额外传入 `--yes` 跳过确认；普通交互安装不建议使用。
+如果最新 Tag 不完整，或指定的 Tag 不存在、源码或镜像不可用，安装程序会列出最多
+10 个最近可用的 Tag，并提示正确的 `--mirror ... --tag vX.Y.Z` 用法。程序不会自动降级，
+由用户明确选择需要重试的版本。
 
 ## 确认安装结果
 


### PR DESCRIPTION
## Summary

- resolve the latest or requested Community semantic tag from GitHub or Gitee
- download the tag commit, validate release identity, and provide recent fallback tags
- protect Enterprise and incomplete installations before release downloads
- add bounded pagination and repeated-page detection for tag APIs
- update Community installation commands and documentation
- preserve the existing SaaS workflow and add contract coverage for the installer paths

## Validation

- Bash syntax checks
- Python compilation, Ruff, and format checks
- Community online installation contract tests
- Enterprise rejection, pagination, and repeated-page tests
- Release contract checks
- VitePress website build
- git diff --check