### PR TITLE
Preserve login locale across authentication

### DIFF
--- a/src/frontend/src/composables/useAuth.ts
+++ b/src/frontend/src/composables/useAuth.ts
@@ -15,6 +15,7 @@ import {
   sessionNoticeMessageKey,
   storeSessionNotice,
 } from '../lib/sessionNotice'
+import { clearLogoutBrowserStorage } from '../lib/logoutStorage'
 
 export interface User {
   id: number
@@ -211,6 +212,7 @@ function hasCompleteAccessProfile(user: User | null): boolean {
 
 // Module-level clearAuth for use by setupAuthGuard
 export function clearAuth() {
+  clearLogoutBrowserStorage()
   currentUser.value = null
   isLoggedIn.value = false
   isLoading.value = false

--- a/src/frontend/src/composables/useLocaleSwitch.test.ts
+++ b/src/frontend/src/composables/useLocaleSwitch.test.ts
@@ -161,4 +161,79 @@ describe('useLocaleSwitch', () => {
     expect(JSON.parse(mocks.api.mock.calls[0]?.[1].body).language).toBe('pt')
     wrapper.unmount()
   })
+
+  it('syncs an explicit pre-login selection even when the active locale already matches', async () => {
+    registerLocale('zh-hans', { nav: { overview: 'Translated overview' } }, ['zh', 'zh-cn'])
+    installedLangPacks.value = [{
+      id: 'zh-hans',
+      display_name: 'Simplified Chinese',
+      frontend_code: 'zh-hans',
+      backend_code: 'zh-hans',
+      aliases: ['zh', 'zh-cn'],
+      version: '0.2.0',
+    }]
+    selectLocale('zh-hans')
+    currentUser.value = {
+      id: 11,
+      email: 'pre-login-locale@example.com',
+      username: 'pre-login-locale',
+      language: 'en',
+    }
+    mocks.api.mockResolvedValue(undefined)
+
+    let localeSwitch: ReturnType<typeof useLocaleSwitch> | undefined
+    const wrapper = mount(defineComponent({
+      setup() {
+        localeSwitch = useLocaleSwitch()
+        return () => h('div')
+      },
+    }), { global: { plugins: [i18n] } })
+
+    expect(localeSwitch?.syncAuthenticatedLocale('zh-hans')).toBe(true)
+
+    await vi.waitFor(() => expect(mocks.api).toHaveBeenCalledTimes(1))
+    expect(i18n.global.locale.value).toBe('zh-hans')
+    expect(currentUser.value?.language).toBe('zh-hans')
+    expect(JSON.parse(mocks.api.mock.calls[0]?.[1].body).language).toBe('zh-hans')
+    wrapper.unmount()
+  })
+
+  it('keeps the explicit locale active when saving the profile preference fails', async () => {
+    registerLocale('zh-hans', { nav: { overview: 'Translated overview' } }, ['zh', 'zh-cn'])
+    installedLangPacks.value = [{
+      id: 'zh-hans',
+      display_name: 'Simplified Chinese',
+      frontend_code: 'zh-hans',
+      backend_code: 'zh-hans',
+      aliases: ['zh', 'zh-cn'],
+      version: '0.2.0',
+    }]
+    currentUser.value = {
+      id: 12,
+      email: 'locale-save-failure@example.com',
+      username: 'locale-save-failure',
+      language: 'en',
+    }
+    const saveError = new Error('save failed')
+    mocks.api.mockRejectedValue(saveError)
+
+    let localeSwitch: ReturnType<typeof useLocaleSwitch> | undefined
+    const wrapper = mount(defineComponent({
+      setup() {
+        localeSwitch = useLocaleSwitch()
+        return () => h('div')
+      },
+    }), { global: { plugins: [i18n] } })
+
+    expect(localeSwitch?.syncAuthenticatedLocale('zh-hans')).toBe(true)
+
+    await vi.waitFor(() => expect(mocks.notifyError).toHaveBeenCalledTimes(1))
+    expect(i18n.global.locale.value).toBe('zh-hans')
+    expect(currentUser.value?.language).toBe('zh-hans')
+    expect(mocks.notifyError).toHaveBeenCalledWith(expect.objectContaining({
+      error: saveError,
+      dedupeKey: 'language-preference-save-failed',
+    }))
+    wrapper.unmount()
+  })
 })

--- a/src/frontend/src/composables/useLocaleSwitch.ts
+++ b/src/frontend/src/composables/useLocaleSwitch.ts
@@ -30,9 +30,7 @@ export function useLocaleSwitch() {
     })),
   )
 
-  function selectLocale(code: string) {
-    if (!canSwitchLocale.value || !getAvailableLocaleCodes().includes(code)) return false
-    if (String(locale.value) === code) return false
+  function applySelectedLocale(code: string) {
     const selected = applyLocale(code)
     const user = currentUser.value
     if (!user) return true
@@ -40,6 +38,10 @@ export function useLocaleSwitch() {
       ? DEFAULT_LOCALE
       : installedLangPacks.value.find((pack) => pack.frontend_code === selected)?.backend_code
     if (!profileLanguage) return true
+    if (user.language === profileLanguage) {
+      setAuthenticatedLocalePreference(profileLanguage)
+      return true
+    }
     currentUser.value = { ...user, language: profileLanguage }
     setAuthenticatedLocalePreference(profileLanguage)
     localePreferenceWriteQueue = localePreferenceWriteQueue.catch(() => undefined).then(async () => {
@@ -63,11 +65,23 @@ export function useLocaleSwitch() {
     return true
   }
 
+  function selectLocale(code: string) {
+    if (!canSwitchLocale.value || !getAvailableLocaleCodes().includes(code)) return false
+    if (String(locale.value) === code) return false
+    return applySelectedLocale(code)
+  }
+
+  function syncAuthenticatedLocale(code: string) {
+    if (!canSwitchLocale.value || !getAvailableLocaleCodes().includes(code)) return false
+    return applySelectedLocale(code)
+  }
+
   return {
     canSwitchLocale,
     currentLocaleLabel,
     localeOptions,
     selectLocale,
+    syncAuthenticatedLocale,
     locale,
   }
 }

--- a/src/frontend/src/i18n.ts
+++ b/src/frontend/src/i18n.ts
@@ -2,7 +2,51 @@ import { createI18n } from 'vue-i18n'
 import { en } from './locales'
 
 export const LANG_STORAGE_KEY = 'hfl.lang'
+export const LOGIN_LOCALE_STORAGE_KEY = 'hfl.login.locale'
+export const LOGIN_LOCALE_PENDING_STORAGE_KEY = 'hfl.login.locale.pending'
 export const DEFAULT_LOCALE = 'en'
+
+let suppressAuthenticatedLocaleApplication = false
+
+export function setAuthenticatedLocaleApplicationSuppressed(suppressed: boolean): void {
+  suppressAuthenticatedLocaleApplication = suppressed
+}
+
+export function getLoginLocaleSelection(): string | null {
+  try {
+    return sessionStorage.getItem(LOGIN_LOCALE_STORAGE_KEY)
+  } catch {
+    return null
+  }
+}
+
+export function setLoginLocaleSelection(code: string): void {
+  try {
+    sessionStorage.setItem(LOGIN_LOCALE_STORAGE_KEY, code)
+  } catch {
+    /* Storage may be unavailable in privacy-restricted browser contexts. */
+  }
+}
+
+export function clearLoginLocaleSelection(): void {
+  try {
+    sessionStorage.removeItem(LOGIN_LOCALE_STORAGE_KEY)
+  } catch {
+    /* Storage may be unavailable in privacy-restricted browser contexts. */
+  }
+}
+
+export function getPendingLoginLocale(): string | null {
+  try { return sessionStorage.getItem(LOGIN_LOCALE_PENDING_STORAGE_KEY) } catch { return null }
+}
+
+export function setPendingLoginLocale(code: string): void {
+  try { sessionStorage.setItem(LOGIN_LOCALE_PENDING_STORAGE_KEY, code) } catch { /* unavailable */ }
+}
+
+export function clearPendingLoginLocale(): void {
+  try { sessionStorage.removeItem(LOGIN_LOCALE_PENDING_STORAGE_KEY) } catch { /* unavailable */ }
+}
 
 let authenticatedLocale: string | null = null
 let languagePacksLoaded = false
@@ -79,7 +123,7 @@ export function selectLocale(code: string): string {
 /** Set the signed-in user's preference without resolving it before packs load. */
 export function setAuthenticatedLocalePreference(code: string | null | undefined): void {
   authenticatedLocale = code?.trim() || null
-  if (languagePacksLoaded) applyPreferredLocale()
+  if (languagePacksLoaded && !suppressAuthenticatedLocaleApplication) applyPreferredLocale()
 }
 
 /** Finish locale startup after all optional message catalogs have been registered. */

--- a/src/frontend/src/lib/logout.ts
+++ b/src/frontend/src/lib/logout.ts
@@ -39,11 +39,6 @@ export async function performLogout(router: Router): Promise<void> {
   } catch (e) {
     logger.warn('logout.ts', 41, 'API call failed, proceeding anyway', e)
   }
-  try {
-    localStorage.clear()
-  } catch {
-    /* ignore */
-  }
   // Clear in-memory auth state before navigation
   clearAuth()
   try {

--- a/src/frontend/src/lib/logoutStorage.test.ts
+++ b/src/frontend/src/lib/logoutStorage.test.ts
@@ -1,0 +1,37 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  LANG_STORAGE_KEY,
+  LOGIN_LOCALE_STORAGE_KEY,
+} from '../i18n'
+import { clearLogoutBrowserStorage } from './logoutStorage'
+
+afterEach(() => {
+  localStorage.clear()
+  sessionStorage.clear()
+})
+
+describe('clearLogoutBrowserStorage', () => {
+  it('preserves only the anonymous language preference', () => {
+    localStorage.setItem(LANG_STORAGE_KEY, 'zh-hans')
+    localStorage.setItem('hfl_org_key', 'org-1')
+    localStorage.setItem('sidebar-collapsed', 'true')
+    localStorage.setItem('theme', 'dark')
+    sessionStorage.setItem(LOGIN_LOCALE_STORAGE_KEY, 'en')
+
+    clearLogoutBrowserStorage()
+
+    expect(localStorage).toHaveLength(1)
+    expect(localStorage.getItem(LANG_STORAGE_KEY)).toBe('zh-hans')
+    expect(sessionStorage.getItem(LOGIN_LOCALE_STORAGE_KEY)).toBeNull()
+  })
+
+  it('does not create a language preference when none existed', () => {
+    localStorage.setItem('hfl_org_key', 'org-1')
+
+    clearLogoutBrowserStorage()
+
+    expect(localStorage).toHaveLength(0)
+  })
+})

--- a/src/frontend/src/lib/logoutStorage.ts
+++ b/src/frontend/src/lib/logoutStorage.ts
@@ -1,0 +1,24 @@
+import {
+  LANG_STORAGE_KEY,
+  clearLoginLocaleSelection,
+  clearPendingLoginLocale,
+} from '../i18n'
+
+/** Clear browser-local user state while retaining the anonymous language preference. */
+export function clearLogoutBrowserStorage(): void {
+  try {
+    const keys = Array.from(
+      { length: localStorage.length },
+      (_, index) => localStorage.key(index),
+    ).filter((key): key is string => Boolean(key))
+
+    for (const key of keys) {
+      if (key !== LANG_STORAGE_KEY) localStorage.removeItem(key)
+    }
+  } catch {
+    /* Storage may be unavailable in privacy-restricted browser contexts. */
+  }
+
+  clearLoginLocaleSelection()
+  clearPendingLoginLocale()
+}

--- a/src/frontend/src/pages/auth/Login.vue
+++ b/src/frontend/src/pages/auth/Login.vue
@@ -9,7 +9,6 @@ import { useAuth, setStoredOrgKey, fetchCurrentUser } from '../../composables/us
 import { useLocaleSwitch } from '../../composables/useLocaleSwitch'
 import {
   clearLoginLocaleSelection,
-  clearPendingLoginLocale,
   setAuthenticatedLocaleApplicationSuppressed,
   setLoginLocaleSelection,
   setPendingLoginLocale,

--- a/src/frontend/src/pages/auth/Login.vue
+++ b/src/frontend/src/pages/auth/Login.vue
@@ -1,11 +1,19 @@
 <script setup lang="ts">
-import { ref, reactive, computed, nextTick, onMounted } from 'vue'
+import { ref, reactive, computed, nextTick, onMounted, onUnmounted } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { ElMessage, ElMessageBox } from 'element-plus'
 import { Mail, Lock, Eye, EyeOff } from 'lucide-vue-next'
 import { api } from '../../lib/api'
 import { useAuth, setStoredOrgKey, fetchCurrentUser } from '../../composables/useAuth'
+import { useLocaleSwitch } from '../../composables/useLocaleSwitch'
+import {
+  clearLoginLocaleSelection,
+  clearPendingLoginLocale,
+  setAuthenticatedLocaleApplicationSuppressed,
+  setLoginLocaleSelection,
+  setPendingLoginLocale,
+} from '../../i18n'
 import { useTurnstileConfig } from '../../composables/useTurnstileConfig'
 import AuthBackdrop from '../../components/auth/AuthBackdrop.vue'
 import AuthBrandPanel from '../../components/auth/AuthBrandPanel.vue'
@@ -27,7 +35,7 @@ const emailSignupEnabled = ref(false)
 const passwordResetAvailable = ref(false)
 const emailCodeLoginAvailable = ref(false)
 const showEula = appConfig.showEula
-const { t } = useI18n()
+const { t, locale } = useI18n()
 const router = useRouter()
 const route = useRoute()
 const sessionNoticeDismissed = ref(false)
@@ -46,6 +54,9 @@ const {
 } = useTurnstileConfig()
 
 const { setUser } = useAuth()
+setAuthenticatedLocaleApplicationSuppressed(true)
+const { syncAuthenticatedLocale } = useLocaleSwitch()
+const explicitlySelectedLocale = ref<string | null>(null)
 const turnstileToken = ref('')
 const turnstileError = ref('')
 const turnstileErrorCode = ref('')
@@ -307,6 +318,14 @@ async function resolveLoginTargetPath(): Promise<string> {
   return resolvePostLoginPath()
 }
 
+function syncExplicitLoginLocale() {
+  const selectedLocale = explicitlySelectedLocale.value
+  if (selectedLocale) {
+    syncAuthenticatedLocale(selectedLocale)
+    clearLoginLocaleSelection()
+  }
+}
+
 async function handleSubmit() {
   if (submitLoading.value) return
 
@@ -379,6 +398,7 @@ async function handleSubmit() {
     if (res.data.user) {
       setUser(res.data.user)
     }
+    syncExplicitLoginLocale()
     trackAppEvent('login', { method: 'email' })
     router.push(await resolveLoginTargetPath())
   } catch (err: unknown) {
@@ -438,6 +458,7 @@ async function completeLoginWithOrg(orgKey: string) {
 
     setStoredOrgKey(orgKey)
     await fetchCurrentUser()
+    syncExplicitLoginLocale()
 
     trackAppEvent('login', { method: 'email' })
     router.push(await resolveLoginTargetPath())
@@ -544,7 +565,9 @@ const canSubmitLogin = computed(() => {
   return true
 })
 
-function handleLocaleChange() {
+function handleLocaleChange(locale: string) {
+  explicitlySelectedLocale.value = locale
+  setLoginLocaleSelection(locale)
   formItems.email.placeholder = t('login.emailPh')
   formItems.password.placeholder = t('login.passwordPh')
 }
@@ -570,8 +593,13 @@ function startGoogleLogin() {
   if (!googleEnabled.value || googleLoading.value) return
   googleLoading.value = true
   setStoredOrgKey('')
+  setPendingLoginLocale(String(locale.value))
   window.location.assign(googleLoginUrl.value)
 }
+
+onUnmounted(() => {
+  setAuthenticatedLocaleApplicationSuppressed(false)
+})
 
 onMounted(async () => {
   turnstileToken.value = ''

--- a/src/frontend/src/pages/auth/LoginTurnstileLifecycle.test.ts
+++ b/src/frontend/src/pages/auth/LoginTurnstileLifecycle.test.ts
@@ -23,6 +23,7 @@ const mocks = vi.hoisted(() => ({
   routerPush: vi.fn(),
   setStoredOrgKey: vi.fn(),
   setUser: vi.fn(),
+  syncAuthenticatedLocale: vi.fn(),
   turnstileBlocked: false,
 }))
 
@@ -40,6 +41,7 @@ vi.mock('../../composables/useLocaleSwitch', () => ({
     currentLocaleLabel: ref('English'),
     localeOptions: ref([{ code: 'en', label: 'English' }]),
     selectLocale: vi.fn(),
+    syncAuthenticatedLocale: mocks.syncAuthenticatedLocale,
   }),
 }))
 
@@ -301,6 +303,78 @@ describe('Login Turnstile lifecycle', () => {
     expect(submit.attributes('disabled')).toBeUndefined()
     expect(emailLoginCalls()).toHaveLength(0)
 
+    wrapper.unmount()
+  })
+
+  it('syncs a language explicitly selected during password sign-in', async () => {
+    const wrapper = await mountLogin(1440)
+    const languageSwitcher = wrapper.getComponent({ name: 'LanguageSwitcher' })
+    const turnstile = wrapper.getComponent(AuthTurnstileFieldStub)
+
+    languageSwitcher.vm.$emit('change', 'zh-hans')
+    await fillCredentials(wrapper)
+    turnstile.vm.$emit('success', 'verified-token')
+    await wrapper.vm.$nextTick()
+    await wrapper.get('button.submit-btn').trigger('click')
+    await flushPromises()
+
+    expect(mocks.setUser).toHaveBeenCalledWith(successfulLoginResponse.data.user)
+    expect(mocks.syncAuthenticatedLocale).toHaveBeenCalledTimes(1)
+    expect(mocks.syncAuthenticatedLocale).toHaveBeenCalledWith('zh-hans')
+    wrapper.unmount()
+  })
+
+  it('does not override the profile language without an explicit login-page selection', async () => {
+    const wrapper = await mountLogin(1440)
+    const turnstile = wrapper.getComponent(AuthTurnstileFieldStub)
+
+    await fillCredentials(wrapper)
+    turnstile.vm.$emit('success', 'verified-token')
+    await wrapper.vm.$nextTick()
+    await wrapper.get('button.submit-btn').trigger('click')
+    await flushPromises()
+
+    expect(mocks.syncAuthenticatedLocale).not.toHaveBeenCalled()
+    wrapper.unmount()
+  })
+
+  it('syncs the explicit language after email-code authentication loads the user', async () => {
+    mocks.fetchDeployProfile.mockResolvedValue({
+      email_signup_enabled: false,
+      email_code_login_available: true,
+      password_reset_available: false,
+    })
+    mocks.fetchCurrentUser.mockResolvedValue({
+      id: 1,
+      email: 'person@example.com',
+      username: 'person',
+      language: 'en',
+    })
+    mocks.api.mockImplementation(async (path: string) => {
+      if (path === '/api/v1/auth/google/config') {
+        return { code: '0000', data: { enabled: false } }
+      }
+      if (path === '/api/v1/auth/org-select') {
+        return { code: '0000', data: {} }
+      }
+      throw new Error(`Unexpected API path: ${path}`)
+    })
+
+    const wrapper = await mountLogin(1440)
+    wrapper.getComponent({ name: 'LanguageSwitcher' }).vm.$emit('change', 'zh-hans')
+    await wrapper.findAll('.login-method-tabs__tab')[1].trigger('click')
+    const emailCodeForm = wrapper.getComponent({ name: 'EmailCodeLoginForm' })
+
+    emailCodeForm.vm.$emit('verified', {
+      available_orgs: [{ org_key: 'org-1', org_name: 'Organization', role: 'member' }],
+    })
+    await flushPromises()
+
+    expect(mocks.fetchCurrentUser).toHaveBeenCalledTimes(1)
+    expect(mocks.syncAuthenticatedLocale).toHaveBeenCalledWith('zh-hans')
+    expect(mocks.fetchCurrentUser.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.syncAuthenticatedLocale.mock.invocationCallOrder[0],
+    )
     wrapper.unmount()
   })
 

--- a/src/frontend/src/pages/auth/OAuthCallback.vue
+++ b/src/frontend/src/pages/auth/OAuthCallback.vue
@@ -1,17 +1,38 @@
 <script setup lang="ts">
-import { onMounted, ref } from 'vue'
+import { onMounted, onUnmounted, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { ElMessage } from 'element-plus'
 
 import { fetchCurrentUser, setStoredOrgKey } from '../../composables/useAuth'
+import { useLocaleSwitch } from '../../composables/useLocaleSwitch'
 import { resolvePostLoginPath } from '../../composables/useDeployProfile'
 import { trackAppEvent } from '../../lib/analytics'
+import {
+  clearLoginLocaleSelection,
+  clearPendingLoginLocale,
+  getLoginLocaleSelection,
+  getPendingLoginLocale,
+} from '../../i18n'
+import { selectLocale } from '../../i18n'
+import { installedLangPacks } from '../../lib/langPacks'
 
 const { t } = useI18n()
 const route = useRoute()
 const router = useRouter()
+const { syncAuthenticatedLocale } = useLocaleSwitch()
 const loading = ref(true)
+let stopLocaleWatch: (() => void) | null = null
+
+function syncPendingLoginLocale() {
+  const selectedLocale = getLoginLocaleSelection()
+  if (!selectedLocale) return true
+  if (!syncAuthenticatedLocale(selectedLocale)) return false
+  clearLoginLocaleSelection()
+  stopLocaleWatch?.()
+  stopLocaleWatch = null
+  return true
+}
 
 onMounted(async () => {
   const orgKey = route.query.org_key
@@ -23,13 +44,27 @@ onMounted(async () => {
   loading.value = false
 
   if (user) {
+    const pendingLocale = getPendingLoginLocale()
+    if (pendingLocale) selectLocale(pendingLocale)
+    if (!syncPendingLoginLocale()) {
+      stopLocaleWatch = watch(installedLangPacks, () => {
+        syncPendingLoginLocale()
+      })
+    }
+    clearPendingLoginLocale()
     trackAppEvent('login', { method: 'google' })
     router.replace(await resolvePostLoginPath())
     return
   }
 
+  clearLoginLocaleSelection()
+  clearPendingLoginLocale()
   ElMessage.error({ message: t('login.googleLoginFailed'), grouping: true })
   router.replace('/login')
+})
+
+onUnmounted(() => {
+  stopLocaleWatch?.()
 })
 </script>
 


### PR DESCRIPTION
## Summary

- Preserve the login page's current locale through password, email-code, and Google sign-in flows.
- Apply an explicit login-page selection to the authenticated profile while keeping the visible locale stable when no selection is made.
- Retain only `hfl.lang` across logout and clear other browser-local authentication state.
- Add regression coverage for locale persistence, OAuth recovery, preference-save failures, and logout cleanup.

Closes #841

## Testing

- `npm test -- --run src/i18n.test.ts src/lib/logoutStorage.test.ts src/composables/useLocaleSwitch.test.ts src/pages/auth/LoginTurnstileLifecycle.test.ts`
- `npm run lint`
- `npm run build`
