### PR TITLE
fix: harden Agent result ownership and offline NAS setup

### DIFF
--- a/src/agent/internal/enroll/preflight_host.go
+++ b/src/agent/internal/enroll/preflight_host.go
@@ -114,7 +114,7 @@ func checkNASMountHelpers(role string) (ok bool, warning bool, title, detail str
 		return false, true, "NAS mount helpers missing", "need mount.nfs and mount.cifs for role " + role + "; use the matching Ubuntu 20.04, 22.04, or 24.04 offline bundle"
 	}
 	if !kernelModuleAvailable("nls_utf8") {
-		return false, true, "NAS SMB UTF-8 kernel module missing", `install linux-modules-extra-$(uname -r), then run modprobe nls_utf8; SMB mounts can fall back without iocharset`
+		return false, true, "NAS SMB UTF-8 kernel module missing", "the running host kernel does not provide nls_utf8; the offline HyperFileLens package does not download or replace host kernel modules"
 	}
 	return true, false, "NAS mount helpers available", "mount.nfs, mount.cifs, nls_utf8"
 }

--- a/src/agent/packaging/install/install.sh
+++ b/src/agent/packaging/install/install.sh
@@ -1548,27 +1548,33 @@ nas_mount_helpers_ready() {
 	[[ $nfs_ok -eq 1 && $cifs_ok -eq 1 ]]
 }
 
-cifs_utf8_module_ready() {
+cifs_utf8_module_loaded() {
 	if [[ -d /sys/module/nls_utf8 ]]; then
 		return 0
 	fi
 	if [[ -r /proc/modules ]] && awk '$1 == "nls_utf8" { found = 1 } END { exit found ? 0 : 1 }' /proc/modules; then
 		return 0
 	fi
-	if command -v modprobe >/dev/null 2>&1 && modprobe -n nls_utf8 >/dev/null 2>&1; then
-		return 0
-	fi
 	return 1
 }
 
-warn_cifs_utf8_module_missing() {
-	if ! cifs_utf8_module_ready; then
-		log_warn 'SMB iocharset=utf8 support is not available (missing nls_utf8); install linux-modules-extra-$(uname -r), then run: modprobe nls_utf8'
+prepare_cifs_utf8_module() {
+	if cifs_utf8_module_loaded; then
+		return 0
 	fi
+	if command -v modprobe >/dev/null 2>&1 \
+		&& modprobe nls_utf8 >/dev/null 2>&1 \
+		&& cifs_utf8_module_loaded; then
+		log_ok "loaded host kernel module nls_utf8 for SMB UTF-8 filenames"
+		return 0
+	fi
+	log_warn "SMB iocharset=utf8 is unavailable because the running host kernel does not provide nls_utf8; the offline HyperFileLens package does not download or replace host kernel modules"
+	return 0
 }
 
 install_nas_deps() {
 	local role="${1:-}"
+	local package_root="${2:-${BUNDLE_ROOT}}"
 	local arch deps_dir ubuntu_release ubuntu_flavor
 
 	[[ "$(uname -s)" == "Linux" ]] || return 0
@@ -1578,7 +1584,7 @@ install_nas_deps() {
 	esac
 	if nas_mount_helpers_ready; then
 		log_skip "install NAS packages (mount.nfs / mount.cifs already present)"
-		warn_cifs_utf8_module_missing
+		prepare_cifs_utf8_module
 		return 0
 	fi
 
@@ -1607,7 +1613,7 @@ install_nas_deps() {
 		exit 2
 		;;
 	esac
-	deps_dir="${BUNDLE_ROOT}/deps/${ubuntu_flavor}/${arch}"
+	deps_dir="${package_root}/deps/${ubuntu_flavor}/${arch}"
 	if [[ ! -d "${deps_dir}" ]] || ! compgen -G "${deps_dir}/*.deb" >/dev/null; then
 		echo "ERROR: NAS mount helpers missing and bundle has no deps/${ubuntu_flavor}/${arch}/*.deb" >&2
 		echo "Use the hfl-agent archive matching Ubuntu ${ubuntu_release}, or install nfs-common and cifs-utils manually." >&2
@@ -1638,7 +1644,7 @@ install_nas_deps() {
 		log_fail "NAS mount helpers are still missing after installing the Ubuntu ${ubuntu_release} bundled packages (${arch})." 2
 	fi
 	log_ok "NAS mount helpers ready (mount.nfs / mount.cifs)"
-	warn_cifs_utf8_module_missing
+	prepare_cifs_utf8_module
 }
 
 deploy_admin_scripts() {
@@ -2211,9 +2217,9 @@ cmd_upgrade() {
 		log_fail "Downgrade is not supported (${new_ver} < ${prev_ver})." 2
 	fi
 
+	local installed_role gateway_scope
+	installed_role="$(read_env_value "${env_file}" "HFL_NODE_ROLE" || true)"
 	if [[ $QUIET_FOOTER -eq 0 ]]; then
-		local installed_role gateway_scope
-		installed_role="$(read_env_value "${env_file}" "HFL_NODE_ROLE" || true)"
 		gateway_scope="$(read_env_value "${env_file}" "HFL_GATEWAY_SCOPE" || true)"
 		hfl_print_banner "$(hfl_role_display_name "${installed_role}" "${gateway_scope}")" "Upgrade"
 		hfl_print_section "Target"
@@ -2226,6 +2232,7 @@ cmd_upgrade() {
 	fi
 
 	upgrade_preflight "${data_dir}"
+	install_nas_deps "${installed_role}" "${src_root}"
 	# Do not mutate or stop a running legacy service until the requested target
 	# version has passed confirmation and downgrade checks.
 	if [[ "${legacy_upgrade}" -eq 1 ]]; then

--- a/src/backend/apps/node/metrics.py
+++ b/src/backend/apps/node/metrics.py
@@ -20,6 +20,11 @@ TASK_RESULT_RETRANSMISSIONS = Counter(
     "hfl_agent_task_result_retransmissions_total",
     "Task results received after the NodeTask was already terminal.",
 )
+TASK_RESULT_DISPOSITIONS = Counter(
+    "hfl_agent_task_result_dispositions_total",
+    "Final control-plane disposition for Agent task results.",
+    ("disposition",),
+)
 AGENT_WS_DISCONNECTS = Counter(
     "hfl_agent_websocket_disconnects_total",
     "Agent WebSocket disconnects by normalized close code.",

--- a/src/backend/apps/node/tests/test_ws_task_result_ack.py
+++ b/src/backend/apps/node/tests/test_ws_task_result_ack.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import uuid
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
@@ -11,8 +12,16 @@ from django.utils import timezone
 from apps.iam.models import Organization
 from apps.node.models import Node, NodeTask
 from apps.node.ws.node_agent import _MAX_AGENT_UPLINK_BYTES, NodeAgentConsumer
-from apps.node.ws.uplink import trigger_task_result_followup
-from apps.node.ws.wire import TASK_RESULT_ACK_SUBPROTOCOL
+from apps.node.ws.uplink import (
+    TaskResultHandling,
+    _handle_task_result_delivery,
+    trigger_task_result_followup,
+)
+from apps.node.ws.wire import (
+    TASK_RESULT_ACK_SUBPROTOCOL,
+    ParsedUplink,
+    WireType,
+)
 
 
 def _immediate_database_sync_to_async(func):
@@ -94,7 +103,11 @@ class NodeAgentTaskResultAckTests(SimpleTestCase):
         def commit(**kwargs):
             del kwargs
             events.append("commit")
-            return task
+            return TaskResultHandling(
+                task_id=task.id,
+                disposition="accepted",
+                node_task=task,
+            )
 
         def followup(**kwargs):
             del kwargs
@@ -175,7 +188,14 @@ class NodeAgentTaskResultAckTests(SimpleTestCase):
         consumer.send = AsyncMock()
 
         with (
-            patch("apps.node.ws.node_agent.handle_uplink", return_value=task),
+            patch(
+                "apps.node.ws.node_agent.handle_uplink",
+                return_value=TaskResultHandling(
+                    task_id=task.id,
+                    disposition="duplicate",
+                    node_task=task,
+                ),
+            ),
             patch(
                 "apps.node.ws.node_agent.database_sync_to_async",
                 side_effect=_immediate_database_sync_to_async,
@@ -199,6 +219,228 @@ class NodeAgentTaskResultAckTests(SimpleTestCase):
         consumer.send.assert_awaited_once()
         recovery.assert_called_once_with(node_task=task)
         followup.assert_not_called()
+
+    async def test_permanently_discarded_result_is_acked_without_followup(self):
+        task_id = "550e8400-e29b-41d4-a716-446655440000"
+        consumer = NodeAgentConsumer()
+        consumer.node_id = 7
+        consumer.task_result_ack_enabled = True
+        consumer.send = AsyncMock()
+
+        with (
+            patch(
+                "apps.node.ws.node_agent.handle_uplink",
+                return_value=TaskResultHandling(
+                    task_id=task_id,
+                    disposition="discarded_stale_owner",
+                ),
+            ),
+            patch(
+                "apps.node.ws.node_agent.database_sync_to_async",
+                side_effect=_immediate_database_sync_to_async,
+            ),
+            patch("apps.node.ws.node_agent.trigger_task_result_followup") as followup,
+        ):
+            await consumer.receive(
+                text_data=json.dumps(
+                    {
+                        "type": "task.result",
+                        "task_id": task_id,
+                        "status": "success",
+                        "result": {},
+                    }
+                )
+            )
+
+        body = json.loads(consumer.send.await_args.kwargs["text_data"])
+        self.assertEqual(body, {"type": "task.result.ack", "task_id": task_id})
+        followup.assert_not_called()
+
+    async def test_owner_mismatch_is_not_acked_to_agent(self):
+        task_id = "550e8400-e29b-41d4-a716-446655440000"
+        consumer = NodeAgentConsumer()
+        consumer.node_id = 7
+        consumer.task_result_ack_enabled = True
+        consumer.send = AsyncMock()
+
+        with (
+            patch(
+                "apps.node.ws.node_agent.handle_uplink",
+                return_value=TaskResultHandling(
+                    task_id=task_id,
+                    disposition="discarded_owner_mismatch",
+                    acknowledge_agent=False,
+                ),
+            ),
+            patch(
+                "apps.node.ws.node_agent.database_sync_to_async",
+                side_effect=_immediate_database_sync_to_async,
+            ),
+        ):
+            await consumer.receive(
+                text_data=json.dumps(
+                    {
+                        "type": "task.result",
+                        "task_id": task_id,
+                        "status": "success",
+                        "result": {},
+                    }
+                )
+            )
+
+        consumer.send.assert_not_awaited()
+
+
+class NodeTaskResultDispositionTests(TestCase):
+    def setUp(self):
+        self.organization = Organization.objects.create(
+            key="node-task-result-disposition-org",
+            name="Node Task Result Disposition Org",
+        )
+        self.current_node = Node.objects.create(
+            organization=self.organization,
+            name="current-result-agent",
+            role=Node.Role.PROXY,
+            status=Node.Status.ACTIVE,
+            availability=Node.Availability.ONLINE,
+        )
+        self.owner_node = Node.objects.create(
+            organization=self.organization,
+            name="original-result-agent",
+            role=Node.Role.PROXY,
+            status=Node.Status.ACTIVE,
+            availability=Node.Availability.OFFLINE,
+        )
+
+    def _task(self, *, node: Node) -> NodeTask:
+        return NodeTask.objects.create(
+            organization=self.organization,
+            node=node,
+            kind="explorer.list",
+            watchdog_deadline_at=timezone.now(),
+        )
+
+    @staticmethod
+    def _message(task_id: str) -> ParsedUplink:
+        return ParsedUplink(
+            msg_type=WireType.TASK_RESULT,
+            task_id=task_id,
+            status="success",
+            result={"entries": []},
+        )
+
+    @patch("apps.node.ws.uplink.TASK_RESULT_DISPOSITIONS")
+    def test_unknown_task_is_permanently_discarded(self, dispositions):
+        task_id = str(uuid.uuid4())
+
+        handled = _handle_task_result_delivery(
+            node_id=self.current_node.id,
+            message=self._message(task_id),
+        )
+
+        self.assertEqual(handled.task_id, task_id)
+        self.assertEqual(handled.disposition, "discarded_unknown")
+        self.assertIsNone(handled.node_task)
+        dispositions.labels.assert_called_once_with(
+            disposition="discarded_unknown"
+        )
+
+    @patch("apps.node.ws.uplink.TASK_RESULT_DISPOSITIONS")
+    def test_invalid_task_id_is_permanently_discarded(self, dispositions):
+        handled = _handle_task_result_delivery(
+            node_id=self.current_node.id,
+            message=self._message("not-a-uuid"),
+        )
+
+        self.assertEqual(handled.task_id, "not-a-uuid")
+        self.assertEqual(handled.disposition, "discarded_invalid")
+        self.assertIsNone(handled.node_task)
+        dispositions.labels.assert_called_once_with(
+            disposition="discarded_invalid"
+        )
+
+    @patch("apps.node.ws.uplink.TASK_RESULT_DISPOSITIONS")
+    def test_deleted_owner_result_is_permanently_discarded(self, dispositions):
+        task = self._task(node=self.owner_node)
+        self.owner_node.soft_delete()
+
+        handled = _handle_task_result_delivery(
+            node_id=self.current_node.id,
+            message=self._message(str(task.id)),
+        )
+
+        self.assertEqual(handled.disposition, "discarded_stale_owner")
+        task.refresh_from_db()
+        self.assertEqual(task.status, NodeTask.Status.PENDING)
+        dispositions.labels.assert_called_once_with(
+            disposition="discarded_stale_owner"
+        )
+
+    @patch("apps.node.ws.uplink.TASK_RESULT_DISPOSITIONS")
+    def test_deleted_connected_node_result_is_not_applied(self, dispositions):
+        task = self._task(node=self.current_node)
+        node_id = self.current_node.id
+        self.current_node.soft_delete()
+
+        handled = _handle_task_result_delivery(
+            node_id=node_id,
+            message=self._message(str(task.id)),
+        )
+
+        self.assertEqual(handled.disposition, "discarded_stale_owner")
+        task.refresh_from_db()
+        self.assertEqual(task.status, NodeTask.Status.PENDING)
+        dispositions.labels.assert_called_once_with(
+            disposition="discarded_stale_owner"
+        )
+
+    @patch("apps.node.ws.uplink.TASK_RESULT_DISPOSITIONS")
+    def test_active_owner_mismatch_is_not_applied(self, dispositions):
+        task = self._task(node=self.owner_node)
+
+        handled = _handle_task_result_delivery(
+            node_id=self.current_node.id,
+            message=self._message(str(task.id)),
+        )
+
+        self.assertEqual(handled.disposition, "discarded_owner_mismatch")
+        task.refresh_from_db()
+        self.assertEqual(task.status, NodeTask.Status.PENDING)
+        dispositions.labels.assert_called_once_with(
+            disposition="discarded_owner_mismatch"
+        )
+
+    @patch("apps.node.ws.uplink.TASK_RESULT_DISPOSITIONS")
+    def test_soft_deleted_task_is_not_applied(self, dispositions):
+        task = self._task(node=self.current_node)
+        task.soft_delete()
+
+        handled = _handle_task_result_delivery(
+            node_id=self.current_node.id,
+            message=self._message(str(task.id)),
+        )
+
+        self.assertEqual(handled.disposition, "discarded_deleted_task")
+        task.refresh_from_db()
+        self.assertEqual(task.status, NodeTask.Status.PENDING)
+        dispositions.labels.assert_called_once_with(
+            disposition="discarded_deleted_task"
+        )
+
+    @patch("apps.node.ws.uplink.TASK_RESULT_DISPOSITIONS")
+    def test_current_owner_result_is_applied(self, dispositions):
+        task = self._task(node=self.current_node)
+
+        handled = _handle_task_result_delivery(
+            node_id=self.current_node.id,
+            message=self._message(str(task.id)),
+        )
+
+        self.assertEqual(handled.disposition, "accepted")
+        self.assertEqual(handled.node_task.id, task.id)
+        task.refresh_from_db()
+        self.assertEqual(task.status, NodeTask.Status.SUCCESS)
+        dispositions.labels.assert_called_once_with(disposition="accepted")
 
 
 class NodeTaskResultFollowupTests(TestCase):

--- a/src/backend/apps/node/ws/node_agent.py
+++ b/src/backend/apps/node/ws/node_agent.py
@@ -25,6 +25,7 @@ from apps.node.services.internal.agent_ws_auth import validate_agent_ws_credenti
 from apps.node.services.internal.client_ip import resolve_agent_client_ip_from_scope
 from apps.node.ws.groups import agent_group_name, ws_instance_group_name
 from apps.node.ws.uplink import (
+    TaskResultHandling,
     apply_heartbeat_inventory_snapshot,
     handle_uplink,
     on_agent_connected,
@@ -215,7 +216,7 @@ class NodeAgentConsumer(AsyncWebsocketConsumer):
 
         # Task frames drive watchdog + lifecycle; must persist synchronously.
         try:
-            task = await database_sync_to_async(handle_uplink)(
+            handled = await database_sync_to_async(handle_uplink)(
                 node_id=self.node_id,
                 message=message,
             )
@@ -230,21 +231,34 @@ class NodeAgentConsumer(AsyncWebsocketConsumer):
             )
             return
 
-        if message.msg_type != WireType.TASK_RESULT or task is None:
+        if message.msg_type != WireType.TASK_RESULT:
             return
-        if self.task_result_ack_enabled:
+        if not isinstance(handled, TaskResultHandling):
+            AGENT_UPLINK_REJECTED.labels(reason="invalid_result_handling").inc()
+            logger.error(
+                "agent task result handling missing node_id=%s task_id=%s",
+                self.node_id,
+                message.task_id,
+            )
+            return
+        if self.task_result_ack_enabled and handled.acknowledge_agent:
             try:
                 await self.send(
-                    text_data=dumps_wire(task_result_ack_wire(task_id=task.id))
+                    text_data=dumps_wire(
+                        task_result_ack_wire(task_id=handled.task_id)
+                    )
                 )
                 TASK_RESULT_ACK_LATENCY.observe(time.monotonic() - result_received_at)
             except Exception:
                 logger.warning(
                     "agent task result ACK send failed node_id=%s task_id=%s",
                     self.node_id,
-                    task.id,
+                    handled.task_id,
                     exc_info=True,
                 )
+        task = handled.node_task
+        if task is None:
+            return
         if bool(getattr(task, "_result_retransmission_unchanged", False)):
             try:
                 await database_sync_to_async(project_identical_task_result_recovery)(

--- a/src/backend/apps/node/ws/uplink.py
+++ b/src/backend/apps/node/ws/uplink.py
@@ -5,14 +5,16 @@ Agent WebSocket session and uplink for lifecycle and task frames.
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+import uuid
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Literal
 
 from django.db import DatabaseError, transaction
 from django.utils import timezone
 
 from apps.node import conf as node_conf
 from apps.node.models import Node, NodeTask
-from apps.node.metrics import TASK_RESULT_RETRANSMISSIONS
+from apps.node.metrics import TASK_RESULT_DISPOSITIONS, TASK_RESULT_RETRANSMISSIONS
 from apps.node.services.internal import redis_store
 from apps.node.services.internal.agent_log import task_log_context
 from apps.node.services.internal.node_naming import (
@@ -36,6 +38,29 @@ logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from redis import Redis
+
+
+TaskResultDisposition = Literal[
+    "accepted",
+    "duplicate",
+    "discarded_deleted_task",
+    "discarded_invalid",
+    "discarded_owner_mismatch",
+    "discarded_stale_owner",
+    "discarded_unknown",
+]
+
+
+@dataclass(frozen=True)
+class TaskResultHandling:
+    """Final handling decision for one durable Agent task result."""
+
+    task_id: str
+    disposition: TaskResultDisposition
+    node_task: NodeTask | None = None
+    # This is the Agent-facing protocol ACK.  Internal Redis stream entries
+    # are acknowledged separately by the stream consumer.
+    acknowledge_agent: bool = True
 
 
 def on_agent_connected(*, node_id: int, session_id: str, client_ip: str | None = None) -> None:
@@ -139,7 +164,11 @@ def _schedule_lifecycle_advance(
         )
 
 
-def handle_uplink(*, node_id: int, message: ParsedUplink) -> NodeTask | None:
+def handle_uplink(
+    *,
+    node_id: int,
+    message: ParsedUplink,
+) -> NodeTask | TaskResultHandling | None:
     if message.msg_type == WireType.HEARTBEAT:
         _process_heartbeat_followup(node_id=node_id, inventory=message.heartbeat_payload)
         return None
@@ -152,7 +181,7 @@ def handle_uplink(*, node_id: int, message: ParsedUplink) -> NodeTask | None:
         return accept_task(task_id=message.task_id or "", node_id=node_id)
 
     if message.msg_type == WireType.TASK_RESULT:
-        return _handle_task_result(node_id=node_id, message=message)
+        return _handle_task_result_delivery(node_id=node_id, message=message)
     return None
 
 
@@ -318,13 +347,20 @@ def _handle_task_progress(*, node_id: int, message: ParsedUplink) -> None:
         logger.debug("backup advance after progress failed task_id=%s", message.task_id, exc_info=True)
 
 
-def _handle_task_result(*, node_id: int, message: ParsedUplink) -> NodeTask:
+def _handle_task_result(
+    *,
+    node_id: int,
+    message: ParsedUplink,
+    previous_status: str | None = None,
+) -> NodeTask:
     if not message.task_id:
         raise LookupError("task_id is required")
-    previous_status = NodeTask.objects.filter(
-        pk=message.task_id,
-        node_id=node_id,
-    ).values_list("status", flat=True).first()
+    if previous_status is None:
+        previous_status = (
+            NodeTask.objects.filter(pk=message.task_id, node_id=node_id)
+            .values_list("status", flat=True)
+            .first()
+        )
     incoming_status = (message.status or "success").lower()
     is_retransmission = (
         previous_status == NodeTask.Status.SUCCESS
@@ -351,6 +387,114 @@ def _handle_task_result(*, node_id: int, message: ParsedUplink) -> NodeTask:
         task.status,
     )
     return task
+
+
+@transaction.atomic
+def _handle_task_result_delivery(
+    *,
+    node_id: int,
+    message: ParsedUplink,
+) -> TaskResultHandling:
+    """Apply or permanently discard a task result before acknowledging it."""
+
+    if not message.task_id:
+        raise LookupError("task_id is required")
+    try:
+        uuid.UUID(str(message.task_id))
+    except (AttributeError, TypeError, ValueError):
+        return _discard_task_result(
+            node_id=node_id,
+            task_id=str(message.task_id),
+            disposition="discarded_invalid",
+        )
+
+    task = (
+        # Lock only the task row.  Node lifecycle removal locks the Node row
+        # before touching its dependent records; locking both tables here
+        # would invert that order and create an avoidable deadlock.
+        NodeTask.all_objects.select_for_update(of=("self",))
+        .select_related("node")
+        .filter(pk=message.task_id)
+        .first()
+    )
+    if task is None:
+        return _discard_task_result(
+            node_id=node_id,
+            task_id=message.task_id,
+            disposition="discarded_unknown",
+        )
+
+    owner_node_id = int(task.node_id)
+    if task.is_deleted:
+        return _discard_task_result(
+            node_id=node_id,
+            task_id=message.task_id,
+            disposition="discarded_deleted_task",
+            owner_node_id=owner_node_id,
+        )
+
+    if task.node.is_deleted:
+        return _discard_task_result(
+            node_id=node_id,
+            task_id=message.task_id,
+            disposition="discarded_stale_owner",
+            owner_node_id=owner_node_id,
+        )
+
+    if owner_node_id != node_id:
+        # The WebSocket is authenticated for node_id, so this result can
+        # never be applied to the task's immutable owner.  Do not ACK it;
+        # retaining it exposes the routing fault to the Agent retry path.
+        return _discard_task_result(
+            node_id=node_id,
+            task_id=message.task_id,
+            disposition="discarded_owner_mismatch",
+            owner_node_id=owner_node_id,
+            acknowledge_agent=False,
+        )
+
+    task = _handle_task_result(
+        node_id=node_id,
+        message=message,
+        previous_status=task.status,
+    )
+    disposition = (
+        "duplicate"
+        if bool(getattr(task, "_result_retransmission_unchanged", False))
+        else "accepted"
+    )
+    TASK_RESULT_DISPOSITIONS.labels(disposition=disposition).inc()
+    return TaskResultHandling(
+        task_id=message.task_id,
+        disposition=disposition,
+        node_task=task,
+    )
+
+
+def _discard_task_result(
+    *,
+    node_id: int,
+    task_id: str,
+    disposition: TaskResultDisposition,
+    owner_node_id: int | None = None,
+    acknowledge_agent: bool = True,
+) -> TaskResultHandling:
+    """Record a permanent rejection without creating or updating a task."""
+
+    TASK_RESULT_DISPOSITIONS.labels(disposition=disposition).inc()
+    log = logger.warning if disposition == "discarded_owner_mismatch" else logger.info
+    log(
+        "agent task result discarded node_id=%s task_id=%s owner_node_id=%s disposition=%s",
+        node_id,
+        task_id,
+        owner_node_id if owner_node_id is not None else "-",
+        disposition,
+    )
+    return TaskResultHandling(
+        task_id=task_id,
+        disposition=disposition,
+        acknowledge_agent=acknowledge_agent,
+    )
 
 
 def project_identical_task_result_recovery(*, node_task: NodeTask) -> None:


### PR DESCRIPTION
## Summary
- enforce task-result ownership before applying Agent results
- ACK only permanently discardable results while preserving retries for ownership conflicts and transient database errors
- keep offline NAS dependencies self-contained and load nls_utf8 when available
- add regression coverage and result disposition metrics

## Validation
- Ruff and Python compilation checks
- WebSocket task-result ACK tests
- Agent installation and upgrade tests
- Release contract checks

Fixes #833
Fixes #835