### PR TITLE
Harden detached agent upgrade verification

### DIFF
--- a/src/backend/apps/node/services/internal/node_lifecycle.py
+++ b/src/backend/apps/node/services/internal/node_lifecycle.py
@@ -33,7 +33,8 @@ from apps.node.services.internal.agent_upgrade import (
     node_platform_arch,
     validate_agent_upgrade,
 )
-from apps.node.services.internal.node_registry import agent_session_registered, agent_ws_routable
+from apps.node.services.internal import redis_store
+from apps.node.services.internal.node_registry import agent_ws_routable
 from apps.node.services.internal.node_workload import (
     assert_node_available_for_lifecycle,
     assert_node_available_for_removal,
@@ -104,21 +105,23 @@ def _task_progress_phase(task: NodeTask) -> str | None:
 
 
 def _target_version_from_task(task: NodeTask) -> str:
-    result = task.result if isinstance(task.result, dict) else {}
-    target = str(result.get("target_version") or "").strip()
+    payload = task.payload if isinstance(task.payload, dict) else {}
+    target = str(payload.get("target_version") or "").strip()
     if target:
         return target
-    payload = task.payload if isinstance(task.payload, dict) else {}
-    return str(payload.get("target_version") or "").strip()
+    # Older lifecycle rows may not have retained the original payload. Keep
+    # result as a compatibility fallback, never as the preferred authority.
+    result = task.result if isinstance(task.result, dict) else {}
+    return str(result.get("target_version") or "").strip()
 
 
 def _target_commit_from_task(task: NodeTask) -> str:
-    result = task.result if isinstance(task.result, dict) else {}
-    target = str(result.get("target_commit") or "").strip().lower()
+    payload = task.payload if isinstance(task.payload, dict) else {}
+    target = str(payload.get("target_commit") or "").strip().lower()
     if target:
         return target
-    payload = task.payload if isinstance(task.payload, dict) else {}
-    return str(payload.get("target_commit") or "").strip().lower()
+    result = task.result if isinstance(task.result, dict) else {}
+    return str(result.get("target_commit") or "").strip().lower()
 
 
 def _node_installed_version(node: Node) -> str:
@@ -222,6 +225,93 @@ def _version_matches_target(
         return False
     expected_commit = str(target_commit or "").strip().lower()
     return not expected_commit or _node_installed_commit(node) == expected_commit
+
+
+def _strict_build_matches_target(
+    *,
+    node: Node,
+    target_version: str,
+    target_commit: str = "",
+) -> bool:
+    """Require the exact build requested by this lifecycle operation.
+
+    ``_version_matches_target`` intentionally retains its historical
+    compatibility semantics for callers that only need an upgrade ordering
+    check. Detached lifecycle verification is stricter: a newer build is not
+    proof that this particular upgrade completed.
+    """
+    current = _node_installed_version(node)
+    if not target_version or not current or current != target_version:
+        return False
+    expected_commit = str(target_commit or "").strip().lower()
+    return not expected_commit or _node_installed_commit(node) == expected_commit
+
+
+def _current_agent_session(*, node_id: int) -> str | None:
+    return redis_store.get_agent_session(agent_id=node_id)
+
+
+@transaction.atomic
+def record_upgrade_session_observation(
+    *,
+    node_id: int,
+    session_id: str,
+    inventory: bool = False,
+) -> bool:
+    """Persist post-detach session evidence without changing task status.
+
+    The task row is the durable serialization boundary. Redis route state is
+    read separately by verification and is never treated as durable evidence
+    on its own.
+    """
+    session_id = str(session_id or "").strip()
+    if not session_id:
+        return False
+    node = Node.objects.filter(pk=node_id, is_deleted=False).first()
+    if node is None:
+        return False
+    candidate = _running_lifecycle_task(
+        org=node.organization,
+        node=node,
+        kind=LIFECYCLE_KIND_UPGRADE,
+    )
+    if candidate is None:
+        return False
+    task = NodeTask.objects.select_for_update().get(pk=candidate.pk)
+    if task.status not in _ACTIVE_TASK_STATUSES or not _is_detached_lifecycle_task(task):
+        return False
+    result = dict(task.result or {})
+    detached_session = str(result.get("detached_session_id") or "").strip()
+    payload = task.payload if isinstance(task.payload, dict) else {}
+    pre_upgrade_session = str(payload.get("pre_upgrade_session_id") or "").strip()
+    now = timezone.now().isoformat()
+    changed = False
+    if not detached_session:
+        # The session that was connected when the command was dispatched is
+        # the only reliable baseline. Do not infer it from the first event
+        # observed after the Agent has already detached: that event may be the
+        # upgraded session when the old socket's final frame was lost.
+        if not pre_upgrade_session:
+            return False
+        result["detached_session_id"] = pre_upgrade_session
+        result["detached_session_observed_at"] = now
+        detached_session = pre_upgrade_session
+        changed = True
+    if detached_session != session_id:
+        if result.get("reconnect_session_id") != session_id:
+            result["reconnect_session_id"] = session_id
+            result["reconnect_observed_at"] = now
+            result.pop("verify_started_at", None)
+            changed = True
+        if inventory and result.get("inventory_session_id") != session_id:
+            result["inventory_session_id"] = session_id
+            result["inventory_observed_at"] = now
+            result.pop("verify_started_at", None)
+            changed = True
+    if changed:
+        task.result = result
+        task.save(update_fields=["result", "updated_at"])
+    return changed
 
 
 def _is_detached_lifecycle_task(task: NodeTask) -> bool:
@@ -385,17 +475,29 @@ def _clear_upgrade_verify_clock(*, node: Node, task: NodeTask) -> NodeTask:
 def _upgrade_verify_ready(*, node: Node, task: NodeTask) -> bool:
     if not _is_detached_lifecycle_task(task):
         return False
-    if not agent_session_registered(agent_id=node.id):
+    result = task.result if isinstance(task.result, dict) else {}
+    if str(result.get("host_upgrade_status") or "").strip().lower() != "success":
+        return False
+    current_session = _current_agent_session(node_id=node.id)
+    if not current_session or not agent_ws_routable(agent_id=node.id):
         return False
     if node.availability != Node.Availability.ONLINE:
         return False
-    result = task.result if isinstance(task.result, dict) else {}
-    if not result.get("disconnect_observed_at"):
+    detached_session = str(result.get("detached_session_id") or "").strip()
+    reconnect_session = str(result.get("reconnect_session_id") or "").strip()
+    inventory_session = str(result.get("inventory_session_id") or "").strip()
+    if not detached_session or not reconnect_session or not inventory_session:
+        return False
+    if (
+        current_session != reconnect_session
+        or reconnect_session == detached_session
+        or inventory_session != reconnect_session
+    ):
         return False
     target_version = _target_version_from_task(task)
     if not target_version:
         return False
-    return _version_matches_target(
+    return _strict_build_matches_target(
         node=node,
         target_version=target_version,
         target_commit=_target_commit_from_task(task),
@@ -429,12 +531,18 @@ def record_upgrade_disconnect(*, node_id: int) -> bool:
         return True
 
 
+@transaction.atomic
 def _advance_upgrade_verify(*, node: Node, task: NodeTask) -> bool:
     """
     Finalize detached upgrade only after WS + version stayed stable long enough.
 
     Returns True when the task was marked SUCCESS.
     """
+    locked_task = NodeTask.objects.select_for_update().filter(pk=task.pk).first()
+    if locked_task is None:
+        return False
+    task = locked_task
+    node.refresh_from_db()
     if task.kind != _LIFECYCLE_TASK_KINDS[LIFECYCLE_KIND_UPGRADE]:
         return False
     if task.status not in _ACTIVE_TASK_STATUSES:
@@ -500,7 +608,57 @@ def _finalize_upgrade_on_reconnect(*, node: Node, task: NodeTask) -> bool:
     return _advance_upgrade_verify(node=node, task=task)
 
 
+def _upgrade_timeout_failure(*, node: Node, task: NodeTask) -> tuple[str, str]:
+    """Classify a detached upgrade timeout from the final durable evidence."""
+    result = task.result if isinstance(task.result, dict) else {}
+    host_status = str(result.get("host_upgrade_status") or "").strip().lower()
+    if host_status == "failed":
+        return "HOST_UPGRADE_FAILED", str(
+            result.get("host_error") or "Agent failed to upgrade on the host."
+        )
+    if not result.get("reconnect_session_id"):
+        return "AGENT_RECONNECT_TIMEOUT", "Agent did not reconnect after the upgrade."
+    if not result.get("inventory_session_id"):
+        return (
+            "POST_UPGRADE_INVENTORY_TIMEOUT",
+            "Agent reconnected but did not report post-upgrade host information.",
+        )
+    detached_session = str(result.get("detached_session_id") or "").strip()
+    reconnect_session = str(result.get("reconnect_session_id") or "").strip()
+    inventory_session = str(result.get("inventory_session_id") or "").strip()
+    if not detached_session or reconnect_session == detached_session:
+        return (
+            "AGENT_CONNECTION_UNSTABLE",
+            "Agent did not establish a new connection after the upgrade.",
+        )
+    if inventory_session != reconnect_session:
+        return (
+            "POST_UPGRADE_INVENTORY_TIMEOUT",
+            "Agent reconnected, but host information belongs to an older session.",
+        )
+    current_session = _current_agent_session(node_id=node.id)
+    if not current_session or not agent_ws_routable(agent_id=node.id):
+        return "AGENT_NOT_ROUTABLE", "Agent is online in the console but cannot be reached."
+    if current_session != reconnect_session:
+        return "AGENT_CONNECTION_UNSTABLE", "Agent connection remained unstable during verification."
+    target_version = _target_version_from_task(task)
+    target_commit = _target_commit_from_task(task)
+    if not _strict_build_matches_target(
+        node=node,
+        target_version=target_version,
+        target_commit=target_commit,
+    ):
+        return "TARGET_BUILD_MISMATCH", "Agent version or build does not match the upgrade target."
+    return "UPGRADE_VERIFICATION_TIMEOUT", "Upgrade verification timed out."
+
+
+@transaction.atomic
 def _fail_stale_upgrade_task(*, node: Node, task: NodeTask) -> bool:
+    locked_task = NodeTask.objects.select_for_update().filter(pk=task.pk).first()
+    if locked_task is None:
+        return False
+    task = locked_task
+    node.refresh_from_db()
     if task.kind != _LIFECYCLE_TASK_KINDS[LIFECYCLE_KIND_UPGRADE]:
         return False
     if task.status not in _ACTIVE_TASK_STATUSES:
@@ -515,27 +673,28 @@ def _fail_stale_upgrade_task(*, node: Node, task: NodeTask) -> bool:
     ):
         return False
     target_version = _target_version_from_task(task)
-    if target_version and _version_matches_target(
-        node=node,
-        target_version=target_version,
-        target_commit=_target_commit_from_task(task),
-    ):
+    if target_version and _upgrade_verify_ready(node=node, task=task):
         if _advance_upgrade_verify(node=node, task=task):
             return True
-
     from apps.node.services.internal.task import complete_task
 
+    failure_code, failure_message = _upgrade_timeout_failure(node=node, task=task)
+    result = dict(task.result or {})
+    result["failure_code"] = failure_code
+    result["failed_at"] = timezone.now().isoformat()
     complete_task(
         task_id=task.id,
         node_id=node.id,
         status=NodeTask.Status.FAILED,
-        error="Upgrade timed out waiting for agent to reconnect.",
-        result=dict(task.result or {}),
+        error=failure_message,
+        result=result,
+        replace_result=True,
     )
     logger.warning(
-        "node lifecycle upgrade timed out node_id=%s task_id=%s",
+        "node lifecycle upgrade timed out node_id=%s task_id=%s code=%s",
         node.id,
         task.id,
+        failure_code,
     )
     write_audit_log(
         organization=node.organization,
@@ -546,13 +705,14 @@ def _fail_stale_upgrade_task(*, node: Node, task: NodeTask) -> bool:
         resource_id=str(node.id),
         resource_name=node.name,
         result=AuditResult.FAILURE,
-        error_message="Upgrade timed out waiting for agent to reconnect.",
+        error_message=failure_message,
         metadata={
             "kind": LIFECYCLE_KIND_UPGRADE,
             "role": node.role,
             "task_id": str(task.id),
             "target_version": target_version,
             "current_version": _node_installed_version(node),
+            "failure_code": failure_code,
         },
     )
     return True
@@ -597,7 +757,14 @@ def _build_upgrade_timeline(*, node: Node, task: NodeTask) -> list[dict[str, Any
         elif verify_started_at is not None:
             active_phase = "verifying"
         elif detached is not None:
-            active_phase = "restarting"
+            result = task.result if isinstance(task.result, dict) else {}
+            active_phase = (
+                "verification_pending"
+                if result.get("reconnect_session_id")
+                or result.get("inventory_session_id")
+                or result.get("host_upgrade_status") == "success"
+                else "restarting"
+            )
         elif task.dispatched_at is not None:
             active_phase = "upgrading"
         else:
@@ -623,7 +790,7 @@ def _build_upgrade_timeline(*, node: Node, task: NodeTask) -> list[dict[str, Any
                 if active_phase == "upgrading"
                 else (
                     "completed"
-                    if task.dispatched_at or active_phase in ("restarting", "verifying")
+                    if task.dispatched_at or active_phase in ("restarting", "verification_pending", "verifying")
                     or is_success
                     else "pending"
                 )
@@ -638,7 +805,26 @@ def _build_upgrade_timeline(*, node: Node, task: NodeTask) -> list[dict[str, Any
                 if active_phase == "restarting"
                 else (
                     "completed"
-                    if detached and (active_phase == "verifying" or is_success)
+                    if detached
+                    and (active_phase in ("verification_pending", "verifying") or is_success)
+                    else "pending"
+                )
+            ),
+        },
+        {
+            "phase": "verification_pending",
+            "label": "Verification pending",
+            "at": _ts(
+                result.get("reconnect_observed_at")
+                if isinstance(result, dict)
+                else None
+            ),
+            "status": (
+                "active"
+                if active_phase == "verification_pending"
+                else (
+                    "completed"
+                    if active_phase == "verifying" or is_success
                     else "pending"
                 )
             ),
@@ -691,6 +877,7 @@ def _upgrade_lifecycle_payload(
         "kind": LIFECYCLE_KIND_UPGRADE,
         "task_id": str(task.id),
         "target_version": target_version,
+        "target_commit": _target_commit_from_task(task) or None,
         "current_version": current_version,
         "started_at": task.created_at.isoformat() if task.created_at else None,
         "timeline": _build_upgrade_timeline(node=node, task=task),
@@ -699,10 +886,10 @@ def _upgrade_lifecycle_payload(
     if task.status in _ACTIVE_TASK_STATUSES:
         phase = _task_progress_phase(task) or "dispatching"
         if _is_detached_lifecycle_task(task):
-            if agent_session_registered(agent_id=node.id):
+            if agent_ws_routable(agent_id=node.id):
                 if _upgrade_verify_ready(node=node, task=task):
                     return {**base, "state": "verifying", "phase": "waiting_for_version"}
-                return {**base, "state": "upgrading", "phase": phase}
+                return {**base, "state": "verification_pending", "phase": "verification_pending"}
             return {
                 **base,
                 "state": "restarting",
@@ -715,11 +902,13 @@ def _upgrade_lifecycle_payload(
         }
 
     if task.status in {NodeTask.Status.FAILED, NodeTask.Status.TIMEOUT, NodeTask.Status.CANCELED}:
+        result = task.result if isinstance(task.result, dict) else {}
         return {
             **base,
             "state": "failed",
             "phase": "failed",
             "error": task.last_error or task.status,
+            "failure_code": result.get("failure_code") or None,
         }
 
     if task.status != NodeTask.Status.SUCCESS:
@@ -1015,14 +1204,52 @@ def start_node_upgrade(
         role=node.role,
         os_version=node_os_version(node),
     )
+    current_version = _node_installed_version(node)
+    current_commit = _node_installed_commit(node)
+    if (
+        target_commit
+        and current_version
+        and current_commit
+        and current_version == target_version
+        and current_commit == target_commit.lower()
+    ):
+        logger.info(
+            "node lifecycle upgrade skipped; requested build is already installed "
+            "node_id=%s version=%s commit=%s",
+            node.id,
+            target_version,
+            target_commit,
+        )
+        return {
+            "operation_id": None,
+            "task_id": None,
+            "node_id": node.id,
+            "kind": LIFECYCLE_KIND_UPGRADE,
+            "state": "completed",
+            "phase": "already_current",
+            "outcome": "no_op",
+            "target_version": target_version,
+            "target_commit": target_commit,
+            "current_version": current_version,
+        }
     payload = {"target_version": target_version}
     if target_commit:
         payload["target_commit"] = target_commit
+    # Keep the authenticated route that existed before the detached command
+    # in the durable task payload, but never send this internal session ID to
+    # the Agent. It must survive a lost final frame from the old WebSocket and
+    # must never be inferred from a later reconnect event.
+    persisted_payload = {
+        **payload,
+        "pre_upgrade_session_id": redis_store.get_agent_session(agent_id=node.id)
+        or "",
+    }
     handle = run_agent_task_async(
         org=org,
         node_id=node.id,
         kind="agent.upgrade",
         payload=payload,
+        persisted_payload=persisted_payload,
         correlation_type=node_conf.LIFECYCLE_CORRELATION_TYPE,
         correlation_id=_correlation_id(node_id=node.id, kind=LIFECYCLE_KIND_UPGRADE),
     )

--- a/src/backend/apps/node/services/internal/node_registry.py
+++ b/src/backend/apps/node/services/internal/node_registry.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import logging
 
+import redis
 from django.db import transaction
 from django.utils import timezone
 
@@ -82,7 +83,15 @@ def _agent_loc_key_exists(*, agent_id: int) -> bool:
     r = redis_store.get_redis()
     if r is None:
         return True
-    return bool(r.exists(redis_store.agent_loc_key(agent_id)))
+    try:
+        return bool(r.exists(redis_store.agent_loc_key(agent_id)))
+    except redis.RedisError as exc:
+        # Redis availability is unknown; retain the normal reconnect grace
+        # instead of converting a transient read failure into an offline node.
+        logger.warning(
+            "failed to read Agent route lease agent_id=%s: %s", agent_id, exc
+        )
+        return True
 
 
 def agent_session_registered(*, agent_id: int) -> bool:
@@ -102,7 +111,13 @@ def _agent_routable(*, agent_id: int) -> bool:
     client = redis_store.get_redis()
     if client is None:
         return True
-    return bool(client.exists(redis_store.ws_alive_key(ws_instance)))
+    try:
+        return bool(client.exists(redis_store.ws_alive_key(ws_instance)))
+    except redis.RedisError as exc:
+        logger.warning(
+            "failed to read Agent WebSocket lease agent_id=%s: %s", agent_id, exc
+        )
+        return False
 
 
 def _project_bound_repository_availability(

--- a/src/backend/apps/node/services/internal/redis_store.py
+++ b/src/backend/apps/node/services/internal/redis_store.py
@@ -120,7 +120,9 @@ def touch_agent_location(*, agent_id: int) -> None:
     r.expire(agent_loc_key(agent_id), node_conf.AGENT_LOC_TTL_SECONDS)
 
 
-def ensure_agent_location_on_heartbeat(*, agent_id: int, session_id: str) -> None:
+def ensure_agent_location_on_heartbeat(
+    *, agent_id: int, session_id: str
+) -> bool | None:
     """
     Refresh ``agent_loc`` during an open WSS session.
 
@@ -130,23 +132,94 @@ def ensure_agent_location_on_heartbeat(*, agent_id: int, session_id: str) -> Non
     """
     r = get_redis()
     if r is None:
-        return
+        return None
     key = agent_loc_key(agent_id)
-    if r.exists(key):
-        r.expire(key, node_conf.AGENT_LOC_TTL_SECONDS)
-    else:
-        set_agent_location(agent_id=agent_id, session_id=session_id)
+    value = _encode_agent_loc(
+        ws_instance_id=node_conf.WS_INSTANCE_ID,
+        session_id=session_id,
+    )
+    # WATCH makes the ownership check and lease renewal one optimistic
+    # transaction. A newly connected session changing the route between GET
+    # and EXPIRE causes EXEC to abort instead of allowing an old socket to
+    # renew the successor's lease.
+    for _attempt in range(2):
+        try:
+            with r.pipeline() as pipe:
+                pipe.watch(key)
+                raw = pipe.get(key)
+                if raw:
+                    _ws_instance, current_session = _decode_agent_loc(str(raw))
+                    if current_session and current_session != session_id:
+                        pipe.reset()
+                        return False
+                pipe.multi()
+                if raw:
+                    pipe.expire(key, node_conf.AGENT_LOC_TTL_SECONDS)
+                else:
+                    pipe.set(key, value, ex=node_conf.AGENT_LOC_TTL_SECONDS)
+                pipe.execute()
+                return True
+        except redis.WatchError:
+            continue
+        except redis.RedisError as exc:
+            logger.warning(
+                "failed to refresh Agent route agent_id=%s: %s", agent_id, exc
+            )
+            return None
+    return None
+
+
+def is_agent_session_current(*, agent_id: int, session_id: str) -> bool | None:
+    """Return route ownership, or ``None`` when Redis cannot be checked."""
+    session_id = str(session_id or "").strip()
+    if not session_id:
+        return False
+    r = get_redis()
+    if r is None:
+        return None
+    try:
+        raw = r.get(agent_loc_key(agent_id))
+    except redis.RedisError:
+        return None
+    if not raw:
+        return False
+    _ws_instance, current_session = _decode_agent_loc(str(raw))
+    if current_session is None:
+        # Legacy routes stored only the WebSocket instance. They cannot prove
+        # ownership, but must not be treated as proof that this session is
+        # stale during a rolling upgrade of the control plane.
+        return None
+    return current_session == session_id
 
 
 def get_agent_location(*, agent_id: int) -> str | None:
     r = get_redis()
     if r is None:
         return None
-    value = r.get(agent_loc_key(agent_id))
+    try:
+        value = r.get(agent_loc_key(agent_id))
+    except redis.RedisError as exc:
+        logger.warning("failed to read Agent route agent_id=%s: %s", agent_id, exc)
+        return None
     if not value:
         return None
     ws_instance, _session = _decode_agent_loc(str(value))
     return ws_instance
+
+
+def get_agent_session(*, agent_id: int) -> str | None:
+    """Return the authenticated session currently owning an Agent route."""
+    r = get_redis()
+    if r is None:
+        return None
+    try:
+        value = r.get(agent_loc_key(agent_id))
+    except redis.RedisError:
+        return None
+    if not value:
+        return None
+    _ws_instance, session = _decode_agent_loc(str(value))
+    return session
 
 
 def clear_agent_location(*, agent_id: int) -> None:
@@ -252,7 +325,13 @@ def ws_recovery_hold_active() -> bool:
     r = get_redis()
     if r is None:
         return True
-    return bool(r.exists(ws_recovery_hold_key()))
+    try:
+        return bool(r.exists(ws_recovery_hold_key()))
+    except redis.RedisError as exc:
+        # Do not dispatch lifecycle commands while the control-plane route
+        # state cannot be read reliably.
+        logger.warning("failed to read WebSocket recovery hold: %s", exc)
+        return True
 
 
 def clear_ws_recovery_hold() -> bool:

--- a/src/backend/apps/node/services/internal/redis_store.py
+++ b/src/backend/apps/node/services/internal/redis_store.py
@@ -169,12 +169,17 @@ def ensure_agent_location_on_heartbeat(
     return None
 
 
-def is_agent_session_current(*, agent_id: int, session_id: str) -> bool | None:
+def is_agent_session_current(
+    *,
+    agent_id: int,
+    session_id: str,
+    redis_client: redis.Redis | None | _DefaultRedisClient = _DEFAULT_REDIS_CLIENT,
+) -> bool | None:
     """Return route ownership, or ``None`` when Redis cannot be checked."""
     session_id = str(session_id or "").strip()
     if not session_id:
         return False
-    r = get_redis()
+    r = _resolve_redis_client(redis_client)
     if r is None:
         return None
     try:

--- a/src/backend/apps/node/services/internal/task.py
+++ b/src/backend/apps/node/services/internal/task.py
@@ -411,7 +411,13 @@ def _node_ws_routable(*, node_id: int) -> bool:
     client = redis_store.get_redis()
     if client is None:
         return True
-    return bool(client.exists(redis_store.ws_alive_key(ws_instance)))
+    try:
+        return bool(client.exists(redis_store.ws_alive_key(ws_instance)))
+    except redis.RedisError as exc:
+        logger.warning(
+            "failed to read Agent WebSocket lease node_id=%s: %s", node_id, exc
+        )
+        return False
 
 
 def _last_seen_within_task_route_grace(node: Node) -> bool:
@@ -444,6 +450,35 @@ def _is_pre_dispatch_lifecycle_task(task: NodeTask) -> bool:
         and task.accepted_at is None
         and task.delivery_attempt_count == 0
     )
+
+
+def _capture_upgrade_session_baseline(*, task: NodeTask) -> None:
+    """Persist the route session immediately before dispatching an upgrade."""
+    if (
+        task.correlation_type != node_conf.LIFECYCLE_CORRELATION_TYPE
+        or task.kind != "agent.upgrade"
+    ):
+        return
+    payload = task.payload if isinstance(task.payload, dict) else {}
+    session_id = redis_store.get_agent_session(agent_id=task.node_id)
+    if not session_id:
+        # Keep a baseline captured at task creation when Redis is temporarily
+        # unavailable at dispatch time; verification will fail closed if it
+        # cannot establish a trustworthy session transition.
+        return
+    if str(payload.get("pre_upgrade_session_id") or "").strip() == session_id:
+        return
+    updated = NodeTask.objects.filter(
+        pk=task.pk,
+        status=NodeTask.Status.PENDING,
+        accepted_at__isnull=True,
+        dispatched_at__isnull=True,
+    ).update(
+        payload={**payload, "pre_upgrade_session_id": session_id},
+        updated_at=timezone.now(),
+    )
+    if updated:
+        task.payload = {**payload, "pre_upgrade_session_id": session_id}
 
 
 def _node_route_state(*, task: NodeTask) -> _RouteState:
@@ -788,6 +823,22 @@ def deliver_agent_task(
         if route_state == _RouteState.OFFLINE:
             redis_store.clear_agent_location(agent_id=task.node_id)
             raise RuntimeError("agent websocket is not routable")
+        _capture_upgrade_session_baseline(task=task)
+        if (
+            delivery_payload is None
+            and task.correlation_type == node_conf.LIFECYCLE_CORRELATION_TYPE
+            and task.kind == "agent.upgrade"
+            and isinstance(task.payload, dict)
+            and "pre_upgrade_session_id" in task.payload
+        ):
+            # A legacy/plain lifecycle payload may not have a delivery
+            # envelope. The baseline is durable control-plane evidence, never
+            # an Agent command argument; strip it before downlink delivery.
+            delivery_payload = {
+                key: value
+                for key, value in task.payload.items()
+                if key != "pre_upgrade_session_id"
+            }
         logger.info("agent task dispatching %s", ctx)
         dispatched_at = timezone.now()
         if uses_ack:
@@ -1275,6 +1326,52 @@ def complete_task(
     incoming_result = dict(result or {})
     incoming_terminal_status = _incoming_terminal_status(incoming)
     if (
+        _is_lifecycle_correlated_task(task)
+        and task.status == NodeTask.Status.SUCCESS
+        and incoming_terminal_status == NodeTask.Status.SUCCESS
+        and isinstance(task.result, dict)
+        and task.result.get("lifecycle_terminal_sealed")
+    ):
+        # A coordinator-completed lifecycle task is immutable. Late duplicate
+        # success frames are ACKed by the caller without a second stream event.
+        task._result_retransmission_unchanged = True
+        return task
+    if (
+        _is_lifecycle_correlated_task(task)
+        and task.status in {NodeTask.Status.FAILED, NodeTask.Status.TIMEOUT}
+        and incoming_terminal_status == NodeTask.Status.FAILED
+        and isinstance(task.result, dict)
+        and task.result.get("lifecycle_terminal_sealed")
+    ):
+        # Once a lifecycle failure is durably sealed, repeated host failure
+        # frames must not refresh timestamps, duplicate stream events, or
+        # overwrite the classified failure evidence.
+        task._result_retransmission_unchanged = True
+        return task
+    if (
+        _is_lifecycle_correlated_task(task)
+        and task.kind in {"agent.upgrade", "agent.uninstall"}
+        and task.status in {NodeTask.Status.FAILED, NodeTask.Status.TIMEOUT}
+        and incoming_terminal_status == NodeTask.Status.SUCCESS
+        and _task_has_detached_marker(task)
+    ):
+        # A detached lifecycle task is sealed once the coordinator records a
+        # terminal failure. ACK a late Agent result, but retain it only as
+        # diagnostics; never resurrect the audited failure.
+        merged = dict(task.result or {})
+        merged["late_result"] = {
+            "received_at": timezone.now().isoformat(),
+            "status": incoming,
+            "result": incoming_result,
+        }
+        task.result = merged
+        task.save(update_fields=["result", "updated_at"])
+        # The frame is retained for diagnostics and ACKed, but it must not
+        # trigger ordinary task-result follow-up for a lifecycle operation
+        # that has already been durably failed by the coordinator.
+        task._late_result_ignored = True
+        return task
+    if (
         incoming_terminal_status is not None
         and task.status == incoming_terminal_status
         and dict(task.result or {}) == incoming_result
@@ -1362,6 +1459,13 @@ def complete_task(
         task.result = result
     else:
         task.result = _without_delivery_runtime_state(task.result)
+    if (
+        _is_lifecycle_correlated_task(task)
+        and task.kind in {"agent.upgrade", "agent.uninstall"}
+    ):
+        lifecycle_result = dict(task.result or {})
+        lifecycle_result["lifecycle_terminal_sealed"] = True
+        task.result = lifecycle_result
     task.save(
         update_fields=["status", "accepted_at", "result", "last_error", "updated_at"]
     )
@@ -1589,6 +1693,12 @@ def sweep_watchdog_timeouts(
         qs = NodeTask.objects.filter(
             status__in=_ACTIVE_STATUSES,
             watchdog_deadline_at__lt=now,
+        ).exclude(
+            Q(correlation_type=node_conf.LIFECYCLE_CORRELATION_TYPE)
+            & (
+                Q(result__mode="local_detached")
+                | Q(result__last_progress__mode="local_detached")
+            )
         )
     ids = list(
         qs.order_by("watchdog_deadline_at", "pk").values_list("pk", flat=True)[
@@ -1612,6 +1722,11 @@ def sweep_watchdog_timeouts(
                 .first()
             )
             if task is None:
+                continue
+            if _task_has_detached_marker(task):
+                # Detached upgrade/uninstall has an independent durable
+                # lifecycle deadline and coordinator. The generic execution
+                # watchdog must not race it and publish a misleading timeout.
                 continue
             # ACK-capable commands have a separate delivery/acceptance
             # watchdog. The reconciliation sweep owns its bounded deadline

--- a/src/backend/apps/node/tasks/uplink_ingest.py
+++ b/src/backend/apps/node/tasks/uplink_ingest.py
@@ -87,8 +87,8 @@ def process_uplink_payload(self, *, payload: str) -> dict[str, str]:
     parsed = payload_to_parsed(data)
     if parsed is None:
         return {"status": "ignored", "reason": "unparseable"}
-    node_id, message = parsed
-    handle_uplink(node_id=node_id, message=message)
+    node_id, message, session_id = parsed
+    handle_uplink(node_id=node_id, message=message, session_id=session_id)
     return {"status": "ok", "node_id": str(node_id), "msg_type": str(message.msg_type)}
 
 

--- a/src/backend/apps/node/tests/test_agent_task_sync.py
+++ b/src/backend/apps/node/tests/test_agent_task_sync.py
@@ -653,6 +653,49 @@ class AgentTaskDeliveryAndLeaseTests(TestCase):
         self.assertNotIn("plain-secret", str(self.task.payload))
 
     @patch("apps.node.services.internal.task._send_task_command")
+    @patch("apps.node.services.internal.task.redis_store.get_agent_session")
+    @patch("apps.node.services.internal.task.redis_store.get_agent_location")
+    @patch("apps.node.services.internal.task.redis_store.get_redis")
+    def test_plain_upgrade_payload_does_not_leak_session_baseline(
+        self,
+        mock_get_redis,
+        mock_get_agent_location,
+        mock_get_agent_session,
+        mock_send_task_command,
+    ):
+        class RedisClient:
+            def exists(self, key):
+                return key != redis_store.ws_recovery_hold_key()
+
+            def set(self, *_args, **_kwargs):
+                return True
+
+        task = NodeTask.objects.create(
+            organization=self.org,
+            node=self.node,
+            kind="agent.upgrade",
+            status=NodeTask.Status.PENDING,
+            payload={"target_version": "1.2.0"},
+            correlation_type=node_conf.LIFECYCLE_CORRELATION_TYPE,
+            correlation_id=f"upgrade:{self.node.id}",
+            watchdog_deadline_at=timezone.now() + timezone.timedelta(hours=1),
+        )
+        mock_get_agent_location.return_value = "live-ws"
+        mock_get_agent_session.return_value = "session-live"
+        mock_get_redis.return_value = RedisClient()
+
+        def capture(*, task):
+            self.assertNotIn("pre_upgrade_session_id", task.payload)
+
+        mock_send_task_command.side_effect = capture
+
+        delivered = deliver_agent_task(task=task)
+
+        self.assertEqual(delivered.status, NodeTask.Status.RUNNING)
+        task.refresh_from_db()
+        self.assertEqual(task.payload["pre_upgrade_session_id"], "session-live")
+
+    @patch("apps.node.services.internal.task._send_task_command")
     def test_redeliver_terminal_task_is_noop(self, mock_send_task_command):
         self.task.status = NodeTask.Status.SUCCESS
         self.task.save(update_fields=["status"])

--- a/src/backend/apps/node/tests/test_complete_task_idempotency.py
+++ b/src/backend/apps/node/tests/test_complete_task_idempotency.py
@@ -10,6 +10,7 @@ from django.utils import timezone
 from apps.iam.models import Organization
 from apps.node.models import Node, NodeTask
 from apps.node.models.base import NodeRole
+from apps.node import conf as node_conf
 from apps.node.services.internal.task import complete_task
 from apps.node.ws.uplink import _handle_task_result
 from apps.node.ws.wire import ParsedUplink, WireType
@@ -68,6 +69,54 @@ class CompleteTaskIdempotencyTests(TestCase):
         self.assertEqual(updated.result.get("mode"), "local_detached")
         self.assertEqual(updated.result.get("target_version"), "1.2.0")
 
+    def test_detached_upgrade_success_is_evidence_until_lifecycle_verification(self):
+        task = NodeTask.objects.create(
+            organization=self.org,
+            node=self.node,
+            kind="agent.upgrade",
+            correlation_type=node_conf.LIFECYCLE_CORRELATION_TYPE,
+            correlation_id=f"upgrade:{self.node.id}",
+            status=NodeTask.Status.RUNNING,
+            result={"mode": "local_detached", "target_version": "1.2.0"},
+            watchdog_deadline_at=timezone.now(),
+        )
+        message = ParsedUplink(
+            msg_type=WireType.TASK_RESULT,
+            task_id=str(task.id),
+            status="success",
+            result={"repaired_after_restart": True},
+        )
+
+        updated = _handle_task_result(node_id=self.node.id, message=message)
+
+        self.assertEqual(updated.status, NodeTask.Status.RUNNING)
+        self.assertEqual(updated.result["host_upgrade_status"], "success")
+        self.assertNotIn("lifecycle_terminal_sealed", updated.result)
+
+    def test_canceled_upgrade_is_not_classified_as_host_failure(self):
+        task = NodeTask.objects.create(
+            organization=self.org,
+            node=self.node,
+            kind="agent.upgrade",
+            correlation_type=node_conf.LIFECYCLE_CORRELATION_TYPE,
+            correlation_id=f"upgrade:{self.node.id}",
+            status=NodeTask.Status.RUNNING,
+            result={"mode": "local_detached"},
+            watchdog_deadline_at=timezone.now(),
+        )
+        message = ParsedUplink(
+            msg_type=WireType.TASK_RESULT,
+            task_id=str(task.id),
+            status="canceled",
+            result={"reason": "operator requested cancellation"},
+        )
+
+        updated = _handle_task_result(node_id=self.node.id, message=message)
+
+        self.assertEqual(updated.status, NodeTask.Status.CANCELED)
+        self.assertNotIn("host_upgrade_status", updated.result or {})
+        self.assertNotIn("failure_code", updated.result or {})
+
     def test_late_success_upgrades_failed_task_and_clears_error(self):
         self.task.status = NodeTask.Status.FAILED
         self.task.last_error = "Agent went offline during task execution."
@@ -100,6 +149,67 @@ class CompleteTaskIdempotencyTests(TestCase):
         self.assertEqual(updated.status, NodeTask.Status.CANCELED)
         self.assertEqual(updated.last_error, "canceled by user")
         self.assertNotIn("kopia_snapshot_id", updated.result)
+
+    def test_late_detached_upgrade_success_is_sealed_as_diagnostic(self):
+        task = NodeTask.objects.create(
+            organization=self.org,
+            node=self.node,
+            kind="agent.upgrade",
+            correlation_type=node_conf.LIFECYCLE_CORRELATION_TYPE,
+            correlation_id=f"upgrade:{self.node.id}",
+            status=NodeTask.Status.TIMEOUT,
+            last_error="Agent did not reconnect after the upgrade.",
+            result={"mode": "local_detached", "failure_code": "AGENT_RECONNECT_TIMEOUT"},
+            watchdog_deadline_at=timezone.now(),
+        )
+
+        updated = complete_task(
+            task_id=task.id,
+            node_id=self.node.id,
+            status="success",
+            result={"repaired_after_restart": True},
+        )
+
+        self.assertEqual(updated.status, NodeTask.Status.TIMEOUT)
+        self.assertEqual(updated.result["late_result"]["status"], "success")
+        self.assertEqual(updated.last_error, "Agent did not reconnect after the upgrade.")
+        self.assertTrue(getattr(updated, "_late_result_ignored", False))
+
+    def test_sealed_lifecycle_failure_ignores_duplicate_failure(self):
+        task = NodeTask.objects.create(
+            organization=self.org,
+            node=self.node,
+            kind="agent.upgrade",
+            correlation_type=node_conf.LIFECYCLE_CORRELATION_TYPE,
+            correlation_id=f"upgrade:{self.node.id}",
+            status=NodeTask.Status.FAILED,
+            last_error="host installer failed",
+            result={
+                "mode": "local_detached",
+                "failure_code": "HOST_UPGRADE_FAILED",
+                "lifecycle_terminal_sealed": True,
+                "host_result_received_at": "2026-08-26T10:00:00+00:00",
+            },
+            watchdog_deadline_at=timezone.now(),
+        )
+
+        updated = complete_task(
+            task_id=task.id,
+            node_id=self.node.id,
+            status="failed",
+            error="host installer failed",
+            result={
+                "mode": "local_detached",
+                "failure_code": "HOST_UPGRADE_FAILED",
+                "host_result_received_at": "2026-08-26T10:01:00+00:00",
+            },
+        )
+
+        self.assertTrue(getattr(updated, "_result_retransmission_unchanged", False))
+        self.assertEqual(
+            updated.result["host_result_received_at"],
+            "2026-08-26T10:00:00+00:00",
+        )
 
     def test_late_backup_success_requires_snapshot_identity(self):
         task = NodeTask.objects.create(

--- a/src/backend/apps/node/tests/test_network_inventory.py
+++ b/src/backend/apps/node/tests/test_network_inventory.py
@@ -164,6 +164,67 @@ class NodeNetworkInventoryHeartbeatTests(TestCase):
         self.node.refresh_from_db()
         self.assertEqual(str(self.node.ip_address), "10.20.1.10")
 
+    @patch(
+        "apps.node.ws.uplink.redis_store.is_agent_session_current",
+        return_value=False,
+    )
+    def test_superseded_session_inventory_is_ignored(self, _current_session):
+        original_version = self.node.version
+        apply_heartbeat_inventory_snapshot(
+            node_id=self.node.id,
+            session_id="old-session",
+            inventory={
+                "agent_version": "9.9.9",
+                "primary_ip_address": "10.20.1.99",
+            },
+        )
+
+        self.node.refresh_from_db()
+        self.assertEqual(str(self.node.ip_address), "10.20.1.10")
+        self.assertEqual(self.node.version, original_version)
+
+    @patch(
+        "apps.node.ws.uplink.redis_store.is_agent_session_current",
+        return_value=None,
+    )
+    def test_unknown_session_ownership_preserves_liveness_without_inventory(
+        self, _current_session
+    ):
+        original_version = self.node.version
+        apply_heartbeat_inventory_snapshot(
+            node_id=self.node.id,
+            session_id="session-live",
+            inventory={
+                "agent_version": "9.9.9",
+                "primary_ip_address": "10.20.1.99",
+            },
+        )
+
+        self.node.refresh_from_db()
+        self.assertEqual(str(self.node.ip_address), "10.20.1.10")
+        self.assertEqual(self.node.version, original_version)
+        self.assertIsNotNone(self.node.last_seen_at)
+
+    @patch(
+        "apps.monitor.services.internal.node_metrics.ingest_node_monitor_sample"
+    )
+    @patch("apps.node.ws.uplink.redis_store.touch_ws_instance_alive")
+    @patch("apps.node.ws.uplink.redis_store.get_redis", return_value=None)
+    @patch(
+        "apps.node.ws.uplink.redis_store.is_agent_session_current",
+        return_value=None,
+    )
+    def test_queued_unknown_session_does_not_ingest_metrics(
+        self, _current_session, _redis, _touch_alive, ingest_metrics
+    ):
+        _process_heartbeat_followup(
+            node_id=self.node.id,
+            session_id="session-live",
+            inventory={"metrics": {"cpu_percent": 12.0}},
+        )
+
+        ingest_metrics.assert_not_called()
+
     def test_structured_storage_snapshot_clears_legacy_capacity(self):
         self.node.metadata = {
             "inventory": {

--- a/src/backend/apps/node/tests/test_node_lifecycle.py
+++ b/src/backend/apps/node/tests/test_node_lifecycle.py
@@ -14,14 +14,18 @@ from apps.node.exceptions import NodeLifecycleError
 from apps.node.models import Node, NodeTask
 from apps.node.models.base import NodeRole
 from apps.node.services.internal.node_lifecycle import (
+    _target_commit_from_task,
+    _target_version_from_task,
     _version_matches_target,
     advance_node_lifecycle,
     compute_node_lifecycle,
     preview_batch_operations,
     queue_detached_remove_verification,
+    record_upgrade_session_observation,
     start_node_remove,
     start_node_upgrade,
 )
+from apps.node.services.internal.task import _capture_upgrade_session_baseline
 from apps.node.services.internal.task import (
     _RouteState,
     complete_task,
@@ -583,7 +587,7 @@ class NodeLifecycleTests(TestCase):
             correlation_type=node_conf.LIFECYCLE_CORRELATION_TYPE,
             correlation_id=f"upgrade:{self.node.id}",
         )
-        with patch("apps.node.services.internal.node_lifecycle.agent_session_registered", return_value=True):
+        with patch("apps.node.services.internal.node_lifecycle.agent_ws_routable", return_value=True):
             lifecycle = compute_node_lifecycle(org=self.org, node=self.node)
         self.assertIsNone(lifecycle)
 
@@ -638,7 +642,7 @@ class NodeLifecycleTests(TestCase):
             )
         )
 
-    @patch("apps.node.services.internal.node_lifecycle.agent_session_registered", return_value=False)
+    @patch("apps.node.services.internal.node_lifecycle.agent_ws_routable", return_value=False)
     def test_same_version_running_task_not_finalized_on_enrich(self, _session):
         task = NodeTask.objects.create(
             organization=self.org,
@@ -657,8 +661,9 @@ class NodeLifecycleTests(TestCase):
         lifecycle = compute_node_lifecycle(org=self.org, node=self.node)
         self.assertEqual(lifecycle["state"], "restarting")
 
-    @patch("apps.node.services.internal.node_lifecycle.agent_session_registered", return_value=True)
-    def test_same_version_detached_finalizes_after_reconnect(self, _session):
+    @patch("apps.node.services.internal.node_lifecycle._current_agent_session", return_value="new")
+    @patch("apps.node.services.internal.node_lifecycle.agent_ws_routable", return_value=True)
+    def test_same_version_detached_finalizes_after_reconnect(self, _routable, _session):
         stable_seconds = int(node_conf.UPGRADE_STABLE_SECONDS)
         verify_started = timezone.now() - timezone.timedelta(seconds=stable_seconds + 1)
         task = NodeTask.objects.create(
@@ -670,6 +675,10 @@ class NodeLifecycleTests(TestCase):
             result={
                 "target_version": "1.0.0",
                 "mode": "local_detached",
+                "host_upgrade_status": "success",
+                "detached_session_id": "old",
+                "reconnect_session_id": "new",
+                "inventory_session_id": "new",
                 "detached_at": timezone.now().isoformat(),
                 "disconnect_observed_at": timezone.now().isoformat(),
                 "verify_started_at": verify_started.isoformat(),
@@ -682,7 +691,7 @@ class NodeLifecycleTests(TestCase):
         task.refresh_from_db()
         self.assertEqual(task.status, NodeTask.Status.SUCCESS)
 
-    @patch("apps.node.services.internal.node_lifecycle.agent_session_registered", return_value=True)
+    @patch("apps.node.services.internal.node_lifecycle.agent_ws_routable", return_value=True)
     def test_same_version_does_not_verify_before_disconnect(self, _session):
         task = NodeTask.objects.create(
             organization=self.org,
@@ -710,8 +719,9 @@ class NodeLifecycleTests(TestCase):
         self.assertEqual(task.status, NodeTask.Status.RUNNING)
         self.assertNotIn("verify_started_at", task.result or {})
 
-    @patch("apps.node.services.internal.node_lifecycle.agent_session_registered", return_value=True)
-    def test_upgrade_verify_waits_for_stable_window(self, _session):
+    @patch("apps.node.services.internal.node_lifecycle._current_agent_session", return_value="new")
+    @patch("apps.node.services.internal.node_lifecycle.agent_ws_routable", return_value=True)
+    def test_upgrade_verify_waits_for_stable_window(self, _routable, _session):
         task = NodeTask.objects.create(
             organization=self.org,
             node=self.node,
@@ -721,6 +731,10 @@ class NodeLifecycleTests(TestCase):
             result={
                 "target_version": "1.0.0",
                 "mode": "local_detached",
+                "host_upgrade_status": "success",
+                "detached_session_id": "old",
+                "reconnect_session_id": "new",
+                "inventory_session_id": "new",
                 "detached_at": timezone.now().isoformat(),
                 "disconnect_observed_at": timezone.now().isoformat(),
                 "verify_started_at": timezone.now().isoformat(),
@@ -735,8 +749,9 @@ class NodeLifecycleTests(TestCase):
         lifecycle = compute_node_lifecycle(org=self.org, node=self.node)
         self.assertEqual(lifecycle["state"], "verifying")
 
-    @patch("apps.node.services.internal.node_lifecycle.agent_session_registered", return_value=True)
-    def test_upgrade_verify_starts_clock_on_first_stable_reconnect(self, _session):
+    @patch("apps.node.services.internal.node_lifecycle._current_agent_session", return_value="new")
+    @patch("apps.node.services.internal.node_lifecycle.agent_ws_routable", return_value=True)
+    def test_upgrade_verify_starts_clock_on_first_stable_reconnect(self, _routable, _session):
         task = NodeTask.objects.create(
             organization=self.org,
             node=self.node,
@@ -746,6 +761,10 @@ class NodeLifecycleTests(TestCase):
             result={
                 "target_version": "1.0.0",
                 "mode": "local_detached",
+                "host_upgrade_status": "success",
+                "detached_session_id": "old",
+                "reconnect_session_id": "new",
+                "inventory_session_id": "new",
                 "detached_at": timezone.now().isoformat(),
                 "disconnect_observed_at": timezone.now().isoformat(),
             },
@@ -760,7 +779,7 @@ class NodeLifecycleTests(TestCase):
         lifecycle = compute_node_lifecycle(org=self.org, node=self.node)
         self.assertEqual(lifecycle["state"], "verifying")
 
-    @patch("apps.node.services.internal.node_lifecycle.agent_session_registered", return_value=False)
+    @patch("apps.node.services.internal.node_lifecycle.agent_ws_routable", return_value=False)
     def test_upgrade_verify_clears_clock_when_ws_drops(self, _session):
         task = NodeTask.objects.create(
             organization=self.org,
@@ -784,6 +803,109 @@ class NodeLifecycleTests(TestCase):
         self.assertNotIn("verify_started_at", task.result or {})
         lifecycle = compute_node_lifecycle(org=self.org, node=self.node)
         self.assertEqual(lifecycle["state"], "restarting")
+
+    def test_upgrade_session_observation_uses_dispatch_baseline(self):
+        task = NodeTask.objects.create(
+            organization=self.org,
+            node=self.node,
+            kind="agent.upgrade",
+            status=NodeTask.Status.RUNNING,
+            payload={"pre_upgrade_session_id": "old"},
+            result={"mode": "local_detached"},
+            watchdog_deadline_at=timezone.now() + timezone.timedelta(hours=1),
+            correlation_type=node_conf.LIFECYCLE_CORRELATION_TYPE,
+            correlation_id=f"upgrade:{self.node.id}",
+        )
+
+        record_upgrade_session_observation(
+            node_id=self.node.id,
+            session_id="new",
+        )
+        task.refresh_from_db()
+        self.assertEqual(task.result["detached_session_id"], "old")
+        self.assertEqual(task.result["reconnect_session_id"], "new")
+
+        task.result["verify_started_at"] = timezone.now().isoformat()
+        task.save(update_fields=["result"])
+        record_upgrade_session_observation(
+            node_id=self.node.id,
+            session_id="new",
+            inventory=True,
+        )
+        task.refresh_from_db()
+        self.assertEqual(task.result["inventory_session_id"], "new")
+        self.assertNotIn("verify_started_at", task.result)
+
+    def test_upgrade_session_observation_does_not_mutate_terminal_task(self):
+        task = NodeTask.objects.create(
+            organization=self.org,
+            node=self.node,
+            kind="agent.upgrade",
+            status=NodeTask.Status.FAILED,
+            payload={"pre_upgrade_session_id": "old"},
+            result={
+                "mode": "local_detached",
+                "failure_code": "AGENT_RECONNECT_TIMEOUT",
+                "lifecycle_terminal_sealed": True,
+            },
+            watchdog_deadline_at=timezone.now(),
+            correlation_type=node_conf.LIFECYCLE_CORRELATION_TYPE,
+            correlation_id=f"upgrade:{self.node.id}",
+        )
+
+        changed = record_upgrade_session_observation(
+            node_id=self.node.id,
+            session_id="new",
+            inventory=True,
+        )
+
+        task.refresh_from_db()
+        self.assertFalse(changed)
+        self.assertNotIn("reconnect_session_id", task.result or {})
+        self.assertNotIn("inventory_session_id", task.result or {})
+
+    @patch(
+        "apps.node.services.internal.task.redis_store.get_agent_session",
+        return_value="new",
+    )
+    def test_upgrade_dispatch_refreshes_stale_baseline(self, _session):
+        task = NodeTask.objects.create(
+            organization=self.org,
+            node=self.node,
+            kind="agent.upgrade",
+            status=NodeTask.Status.PENDING,
+            payload={"pre_upgrade_session_id": "old"},
+            watchdog_deadline_at=timezone.now() + timezone.timedelta(hours=1),
+            correlation_type=node_conf.LIFECYCLE_CORRELATION_TYPE,
+            correlation_id=f"upgrade:{self.node.id}",
+        )
+
+        _capture_upgrade_session_baseline(task=task)
+
+        task.refresh_from_db()
+        self.assertEqual(task.payload["pre_upgrade_session_id"], "new")
+
+    def test_upgrade_target_identity_comes_from_persisted_payload(self):
+        task = NodeTask.objects.create(
+            organization=self.org,
+            node=self.node,
+            kind="agent.upgrade",
+            status=NodeTask.Status.RUNNING,
+            payload={
+                "target_version": "1.2.0",
+                "target_commit": "a" * 40,
+            },
+            result={
+                "target_version": "9.9.9",
+                "target_commit": "b" * 40,
+            },
+            watchdog_deadline_at=timezone.now() + timezone.timedelta(hours=1),
+            correlation_type=node_conf.LIFECYCLE_CORRELATION_TYPE,
+            correlation_id=f"upgrade:{self.node.id}",
+        )
+
+        self.assertEqual(_target_version_from_task(task), "1.2.0")
+        self.assertEqual(_target_commit_from_task(task), "a" * 40)
 
     @patch("apps.node.services.internal.node_lifecycle.agent_ws_routable", return_value=False)
     def test_remove_does_not_finalize_from_ws_disconnect_alone(self, _routable):

--- a/src/backend/apps/node/tests/test_node_online_status.py
+++ b/src/backend/apps/node/tests/test_node_online_status.py
@@ -25,6 +25,45 @@ from apps.node.ws.uplink import on_agent_connected, on_agent_disconnected
 from apps.storage.repositories.models import Repository
 
 
+class _FakePipeline:
+    def __init__(self, redis_client):
+        self.redis = redis_client
+        self.commands = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, traceback):
+        self.reset()
+
+    def watch(self, key):
+        del key
+
+    def get(self, key):
+        return self.redis.get(key)
+
+    def multi(self):
+        return None
+
+    def expire(self, key, seconds):
+        self.commands.append(("expire", key, seconds))
+
+    def set(self, key, value, ex=None):
+        self.commands.append(("set", key, value, ex))
+
+    def execute(self):
+        for command in self.commands:
+            if command[0] == "expire":
+                self.redis.expire(command[1], command[2])
+            else:
+                self.redis.set(command[1], command[2], ex=command[3])
+        self.commands.clear()
+        return []
+
+    def reset(self):
+        self.commands.clear()
+
+
 class _FakeRedis:
     def __init__(self) -> None:
         self.data: dict[str, str] = {}
@@ -61,6 +100,9 @@ class _FakeRedis:
 
     def expire(self, key: str, ex: int) -> None:
         return None
+
+    def pipeline(self):
+        return _FakePipeline(self)
 
     def scan_iter(self, match: str = "*", count: int = 10):
         prefix = match[:-1] if match.endswith("*") else match
@@ -665,3 +707,16 @@ class AgentNodeOnlineStatusTests(TestCase):
         payload = json.loads(raw)
         self.assertEqual(payload["session"], "session-live")
         self.assertEqual(agent_connection_status(self.node), Node.Availability.ONLINE)
+
+    def test_legacy_route_without_session_is_unknown_not_stale(self):
+        redis_store.set_agent_location(
+            agent_id=self.node.id,
+            ws_instance_id=node_conf.WS_INSTANCE_ID,
+        )
+
+        self.assertIsNone(
+            redis_store.is_agent_session_current(
+                agent_id=self.node.id,
+                session_id="session-live",
+            )
+        )

--- a/src/backend/apps/node/tests/test_ws_task_result_ack.py
+++ b/src/backend/apps/node/tests/test_ws_task_result_ack.py
@@ -220,6 +220,47 @@ class NodeAgentTaskResultAckTests(SimpleTestCase):
         recovery.assert_called_once_with(node_task=task)
         followup.assert_not_called()
 
+    async def test_late_detached_result_is_acked_without_followup(self):
+        task = SimpleNamespace(
+            id="550e8400-e29b-41d4-a716-446655440000",
+            _late_result_ignored=True,
+        )
+        consumer = NodeAgentConsumer()
+        consumer.node_id = 7
+        consumer.task_result_ack_enabled = True
+        consumer.send = AsyncMock()
+
+        with (
+            patch(
+                "apps.node.ws.node_agent.handle_uplink",
+                return_value=TaskResultHandling(
+                    task_id=task.id,
+                    disposition="accepted",
+                    node_task=task,
+                ),
+            ),
+            patch(
+                "apps.node.ws.node_agent.database_sync_to_async",
+                side_effect=_immediate_database_sync_to_async,
+            ),
+            patch("apps.node.ws.node_agent.project_identical_task_result_recovery") as recovery,
+            patch("apps.node.ws.node_agent.trigger_task_result_followup") as followup,
+        ):
+            await consumer.receive(
+                text_data=json.dumps(
+                    {
+                        "type": "task.result",
+                        "task_id": task.id,
+                        "status": "success",
+                        "result": {},
+                    }
+                )
+            )
+
+        consumer.send.assert_awaited_once()
+        recovery.assert_not_called()
+        followup.assert_not_called()
+
     async def test_permanently_discarded_result_is_acked_without_followup(self):
         task_id = "550e8400-e29b-41d4-a716-446655440000"
         consumer = NodeAgentConsumer()
@@ -289,6 +330,40 @@ class NodeAgentTaskResultAckTests(SimpleTestCase):
             )
 
         consumer.send.assert_not_awaited()
+
+    async def test_live_task_frame_recreates_expired_route_before_handling(self):
+        task_id = "550e8400-e29b-41d4-a716-446655440000"
+        consumer = NodeAgentConsumer()
+        consumer.node_id = 7
+        consumer.session_id = "live-session"
+        consumer.task_result_ack_enabled = False
+
+        with (
+            patch(
+                "apps.node.ws.node_agent.touch_agent_session_fast",
+                return_value=True,
+            ) as refresh,
+            patch(
+                "apps.node.ws.node_agent.handle_uplink",
+                return_value=None,
+            ) as handle,
+            patch(
+                "apps.node.ws.node_agent.database_sync_to_async",
+                side_effect=_immediate_database_sync_to_async,
+            ),
+        ):
+            await consumer.receive(
+                text_data=json.dumps(
+                    {
+                        "type": "task.progress",
+                        "task_id": task_id,
+                        "progress": {"percent": 50},
+                    }
+                )
+            )
+
+        refresh.assert_called_once_with(node_id=7, session_id="live-session")
+        self.assertEqual(handle.call_args.kwargs["session_id"], "live-session")
 
 
 class NodeTaskResultDispositionTests(TestCase):

--- a/src/backend/apps/node/ws/node_agent.py
+++ b/src/backend/apps/node/ws/node_agent.py
@@ -33,7 +33,11 @@ from apps.node.ws.uplink import (
     project_identical_task_result_recovery,
     trigger_task_result_followup,
 )
-from apps.node.ws.uplink_queue import enqueue_uplink, touch_heartbeat_fast
+from apps.node.ws.uplink_queue import (
+    enqueue_uplink,
+    touch_agent_session_fast,
+    touch_heartbeat_fast,
+)
 from apps.node.ws.wire import (
     TASK_RESULT_ACK_SUBPROTOCOL,
     WireType,
@@ -200,25 +204,59 @@ class NodeAgentConsumer(AsyncWebsocketConsumer):
             )
 
         if message.msg_type == WireType.HEARTBEAT:
-            await database_sync_to_async(touch_heartbeat_fast)(
+            route_current = await database_sync_to_async(touch_heartbeat_fast)(
                 node_id=self.node_id,
                 session_id=self.session_id,
             )
+            if route_current is False:
+                logger.debug(
+                    "stale Agent heartbeat ignored node_id=%s session=%s",
+                    self.node_id,
+                    self.session_id,
+                )
+                return
             await self.send(text_data=dumps_wire(heartbeat_ack_wire()))
             await database_sync_to_async(apply_heartbeat_inventory_snapshot)(
                 node_id=self.node_id,
                 inventory=message.heartbeat_payload,
+                session_id=self.session_id,
             )
-            await database_sync_to_async(enqueue_uplink)(
-                node_id=self.node_id, message=message
-            )
+            try:
+                await database_sync_to_async(enqueue_uplink)(
+                    node_id=self.node_id,
+                    message=message,
+                    session_id=self.session_id,
+                )
+            except Exception:
+                # The hot path already ACKed the heartbeat and persisted
+                # liveness. Redis stream ingestion is a deferred projection;
+                # a transient broker failure must not tear down this healthy
+                # WebSocket or turn the Agent offline.
+                logger.warning(
+                    "Agent heartbeat follow-up enqueue failed node_id=%s session=%s",
+                    self.node_id,
+                    self.session_id,
+                    exc_info=True,
+                )
             return
 
         # Task frames drive watchdog + lifecycle; must persist synchronously.
+        session_id = getattr(self, "session_id", "")
+        if session_id:
+            # A live socket can outlast the Redis route lease (for example
+            # while heartbeats are delayed). Recreate/renew only this
+            # authenticated session before applying the task frame. A route
+            # owned by a newer socket remains stale and is rejected again by
+            # handle_uplink's authoritative ownership check.
+            await database_sync_to_async(touch_agent_session_fast)(
+                node_id=self.node_id,
+                session_id=session_id,
+            )
         try:
             handled = await database_sync_to_async(handle_uplink)(
                 node_id=self.node_id,
                 message=message,
+                session_id=session_id or None,
             )
         except Exception:
             AGENT_UPLINK_REJECTED.labels(reason="persistence_failed").inc()
@@ -258,6 +296,8 @@ class NodeAgentConsumer(AsyncWebsocketConsumer):
                 )
         task = handled.node_task
         if task is None:
+            return
+        if bool(getattr(task, "_late_result_ignored", False)):
             return
         if bool(getattr(task, "_result_retransmission_unchanged", False)):
             try:

--- a/src/backend/apps/node/ws/uplink.py
+++ b/src/backend/apps/node/ws/uplink.py
@@ -81,7 +81,12 @@ def on_agent_connected(*, node_id: int, session_id: str, client_ip: str | None =
         updates["connection_ip_address"] = client_ip
     Node.objects.filter(pk=node_id).update(**updates)
     record_node_available(node_id=node_id, observed_at=observed_at)
-    _record_upgrade_session(node_id=node_id, session_id=session_id)
+    if route_recorded:
+        _record_upgrade_session(
+            node_id=node_id,
+            session_id=session_id,
+            redis_client=redis_client,
+        )
     try:
         sync_agent_source_host_by_id(node_id=node_id)
     except Exception:
@@ -167,12 +172,24 @@ def _schedule_lifecycle_advance(
 
 
 def _record_upgrade_session(
-    *, node_id: int, session_id: str, inventory: bool = False
+    *,
+    node_id: int,
+    session_id: str,
+    inventory: bool = False,
+    redis_client=None,
 ) -> None:
-    if redis_store.is_agent_session_current(
-        agent_id=node_id,
-        session_id=session_id,
-    ) is not True:
+    if redis_client is None:
+        ownership = redis_store.is_agent_session_current(
+            agent_id=node_id,
+            session_id=session_id,
+        )
+    else:
+        ownership = redis_store.is_agent_session_current(
+            agent_id=node_id,
+            session_id=session_id,
+            redis_client=redis_client,
+        )
+    if ownership is not True:
         logger.debug(
             "stale Agent lifecycle session observation ignored node_id=%s session=%s",
             node_id,

--- a/src/backend/apps/node/ws/uplink.py
+++ b/src/backend/apps/node/ws/uplink.py
@@ -9,6 +9,7 @@ import uuid
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Literal
 
+import redis
 from django.db import DatabaseError, transaction
 from django.utils import timezone
 
@@ -80,6 +81,7 @@ def on_agent_connected(*, node_id: int, session_id: str, client_ip: str | None =
         updates["connection_ip_address"] = client_ip
     Node.objects.filter(pk=node_id).update(**updates)
     record_node_available(node_id=node_id, observed_at=observed_at)
+    _record_upgrade_session(node_id=node_id, session_id=session_id)
     try:
         sync_agent_source_host_by_id(node_id=node_id)
     except Exception:
@@ -164,24 +166,111 @@ def _schedule_lifecycle_advance(
         )
 
 
+def _record_upgrade_session(
+    *, node_id: int, session_id: str, inventory: bool = False
+) -> None:
+    if redis_store.is_agent_session_current(
+        agent_id=node_id,
+        session_id=session_id,
+    ) is not True:
+        logger.debug(
+            "stale Agent lifecycle session observation ignored node_id=%s session=%s",
+            node_id,
+            session_id,
+        )
+        return
+    from apps.node.services.internal.node_lifecycle import (
+        record_upgrade_session_observation,
+    )
+
+    try:
+        changed = record_upgrade_session_observation(
+            node_id=node_id,
+            session_id=session_id,
+            inventory=inventory,
+        )
+        if changed and inventory:
+            logger.debug(
+                "post-upgrade inventory observed node_id=%s session=%s",
+                node_id,
+                session_id,
+            )
+    except DatabaseError:
+        logger.warning(
+            "post-upgrade session observation failed node_id=%s session=%s",
+            node_id,
+            session_id,
+            exc_info=True,
+        )
+
+
 def handle_uplink(
     *,
     node_id: int,
     message: ParsedUplink,
+    session_id: str | None = None,
 ) -> NodeTask | TaskResultHandling | None:
     if message.msg_type == WireType.HEARTBEAT:
-        _process_heartbeat_followup(node_id=node_id, inventory=message.heartbeat_payload)
+        if session_id and redis_store.is_agent_session_current(
+            agent_id=node_id,
+            session_id=session_id,
+        ) is False:
+            logger.debug(
+                "stale queued Agent heartbeat ignored node_id=%s session=%s",
+                node_id,
+                session_id,
+            )
+            return None
+        _process_heartbeat_followup(
+            node_id=node_id,
+            inventory=message.heartbeat_payload,
+            session_id=session_id,
+        )
         return None
 
     if message.msg_type in (WireType.TASK_PROGRESS, WireType.TASK_ALIVE):
-        _handle_task_progress(node_id=node_id, message=message)
+        if session_id and redis_store.is_agent_session_current(
+            agent_id=node_id,
+            session_id=session_id,
+        ) is False:
+            logger.debug(
+                "stale Agent task progress ignored node_id=%s session=%s task_id=%s",
+                node_id,
+                session_id,
+                message.task_id or "",
+            )
+            return None
+        _handle_task_progress(node_id=node_id, message=message, session_id=session_id)
         return None
 
     if message.msg_type == WireType.TASK_ACCEPTED:
+        if session_id and redis_store.is_agent_session_current(
+            agent_id=node_id,
+            session_id=session_id,
+        ) is False:
+            logger.debug(
+                "stale Agent task acceptance ignored node_id=%s session=%s task_id=%s",
+                node_id,
+                session_id,
+                message.task_id or "",
+            )
+            return None
         return accept_task(task_id=message.task_id or "", node_id=node_id)
 
     if message.msg_type == WireType.TASK_RESULT:
-        return _handle_task_result_delivery(node_id=node_id, message=message)
+        if session_id and redis_store.is_agent_session_current(
+            agent_id=node_id,
+            session_id=session_id,
+        ) is False:
+            return _discard_task_result(
+                node_id=node_id,
+                task_id=message.task_id or "",
+                disposition="discarded_stale_owner",
+                acknowledge_agent=False,
+            )
+        return _handle_task_result_delivery(
+            node_id=node_id, message=message, session_id=session_id
+        )
     return None
 
 
@@ -241,11 +330,44 @@ def _persist_heartbeat_snapshot(
     return node
 
 
-def apply_heartbeat_inventory_snapshot(*, node_id: int, inventory: dict | None) -> None:
+def apply_heartbeat_inventory_snapshot(
+    *, node_id: int, inventory: dict | None, session_id: str | None = None
+) -> None:
     """Hot path: persist list/detail inventory fields without waiting for Celery ingest."""
     if not inventory:
         return
+    ownership = (
+        redis_store.is_agent_session_current(
+            agent_id=node_id,
+            session_id=session_id,
+        )
+        if session_id
+        else True
+    )
     observed_at = timezone.now()
+    if ownership is False:
+        # A superseded socket may still deliver a queued heartbeat after a
+        # newer connection owns the route. Its inventory must not overwrite
+        # the newer session's build evidence in PostgreSQL.
+        logger.debug(
+            "stale Agent heartbeat inventory ignored node_id=%s session=%s",
+            node_id,
+            session_id,
+        )
+        return
+    if session_id and ownership is None:
+        # Redis outage is not evidence that this socket is stale. Preserve
+        # liveness, but do not persist session-sensitive inventory until route
+        # ownership can be checked again.
+        node = _persist_heartbeat_snapshot(
+            node_id=node_id,
+            inventory=None,
+            observed_at=observed_at,
+            merge_inventory=False,
+        )
+        if node is not None:
+            record_node_available(node_id=node_id, observed_at=observed_at)
+        return
     node = _persist_heartbeat_snapshot(
         node_id=node_id,
         inventory=inventory,
@@ -255,6 +377,16 @@ def apply_heartbeat_inventory_snapshot(*, node_id: int, inventory: dict | None) 
     if node is None:
         return
     record_node_available(node_id=node_id, observed_at=observed_at)
+    if session_id:
+        _record_upgrade_session(
+            node_id=node_id,
+            session_id=session_id,
+            inventory=True,
+        )
+        _schedule_lifecycle_advance(
+            node_id=node_id,
+            redis_client=redis_store.get_redis(),
+        )
 
 
 def _should_process_full_inventory(*, node_id: int) -> bool:
@@ -262,15 +394,43 @@ def _should_process_full_inventory(*, node_id: int) -> bool:
     if r is None:
         return True
     key = _inventory_throttle_key(node_id=node_id)
-    if r.exists(key):
-        return False
-    r.set(key, "1", ex=max(60, int(node_conf.HEARTBEAT_INVENTORY_MIN_INTERVAL_SECONDS)))
-    return True
+    try:
+        if r.exists(key):
+            return False
+        r.set(
+            key,
+            "1",
+            ex=max(60, int(node_conf.HEARTBEAT_INVENTORY_MIN_INTERVAL_SECONDS)),
+        )
+        return True
+    except redis.RedisError as exc:
+        logger.warning(
+            "heartbeat inventory throttle unavailable node_id=%s: %s", node_id, exc
+        )
+        return True
 
 
-def _process_heartbeat_followup(*, node_id: int, inventory: dict | None = None) -> None:
-    redis_store.touch_agent_location(agent_id=node_id)
+def _process_heartbeat_followup(
+    *, node_id: int, inventory: dict | None = None, session_id: str | None = None
+) -> None:
+    # The WebSocket hot path renews the route with its authenticated session.
+    # A delayed queue item must not refresh a superseded session's lease.
     redis_store.touch_ws_instance_alive()
+    ownership = (
+        redis_store.is_agent_session_current(
+            agent_id=node_id,
+            session_id=session_id,
+        )
+        if session_id
+        else True
+    )
+    if ownership is False:
+        logger.debug(
+            "stale queued Agent heartbeat ignored node_id=%s session=%s",
+            node_id,
+            session_id,
+        )
+        return
     full_inventory = inventory and _should_process_full_inventory(node_id=node_id)
     observed_at = timezone.now()
     node = _persist_heartbeat_snapshot(
@@ -287,7 +447,8 @@ def _process_heartbeat_followup(*, node_id: int, inventory: dict | None = None) 
     record_node_available(node_id=node_id, observed_at=observed_at)
 
     if (
-        full_inventory
+        ownership is True
+        and full_inventory
         and inventory
         and isinstance(inventory.get("metrics"), dict)
         and inventory["metrics"]
@@ -296,14 +457,16 @@ def _process_heartbeat_followup(*, node_id: int, inventory: dict | None = None) 
 
         ingest_node_monitor_sample(node=node, sample=inventory["metrics"])
 
-    if full_inventory:
+    if full_inventory and ownership is True:
         try:
             sync_agent_source_host_by_id(node_id=node_id)
         except Exception:
             logger.debug("agent source-host sync failed node_id=%s", node_id, exc_info=True)
 
 
-def _handle_task_progress(*, node_id: int, message: ParsedUplink) -> None:
+def _handle_task_progress(
+    *, node_id: int, message: ParsedUplink, session_id: str | None = None
+) -> None:
     if not message.task_id:
         return
     try:
@@ -326,6 +489,8 @@ def _handle_task_progress(*, node_id: int, message: ParsedUplink) -> None:
             exc,
         )
         return
+    if session_id and task.kind == "agent.upgrade":
+        _record_upgrade_session(node_id=node_id, session_id=session_id)
     try:
         from apps.protection.services.backup_orchestrator import (
             maybe_trigger_backup_advance,
@@ -347,20 +512,25 @@ def _handle_task_progress(*, node_id: int, message: ParsedUplink) -> None:
         logger.debug("backup advance after progress failed task_id=%s", message.task_id, exc_info=True)
 
 
+@transaction.atomic
 def _handle_task_result(
     *,
     node_id: int,
     message: ParsedUplink,
     previous_status: str | None = None,
+    session_id: str | None = None,
 ) -> NodeTask:
     if not message.task_id:
         raise LookupError("task_id is required")
+    task = (
+        NodeTask.objects.select_for_update()
+        .filter(pk=message.task_id, node_id=node_id)
+        .first()
+    )
+    if task is None:
+        raise LookupError("task not found")
     if previous_status is None:
-        previous_status = (
-            NodeTask.objects.filter(pk=message.task_id, node_id=node_id)
-            .values_list("status", flat=True)
-            .first()
-        )
+        previous_status = task.status
     incoming_status = (message.status or "success").lower()
     is_retransmission = (
         previous_status == NodeTask.Status.SUCCESS
@@ -372,13 +542,92 @@ def _handle_task_result(
         previous_status == NodeTask.Status.CANCELED
         and incoming_status in {"canceled", "cancelled"}
     )
+    incoming_result = dict(message.result or {})
+    lifecycle_upgrade = (
+        task.kind == "agent.upgrade"
+        and task.correlation_type == node_conf.LIFECYCLE_CORRELATION_TYPE
+    )
+    if lifecycle_upgrade and str(incoming_status).lower() in {
+        "success", "succeeded", "ok"
+    }:
+        incoming_result = {
+            **dict(task.result or {}),
+            **incoming_result,
+            "host_upgrade_status": "success",
+            "host_result_received_at": timezone.now().isoformat(),
+        }
+    elif lifecycle_upgrade and incoming_status not in {
+        "running",
+        "canceled",
+        "cancelled",
+    }:
+        incoming_result = {
+            **dict(task.result or {}),
+            **incoming_result,
+            "host_upgrade_status": "failed",
+            "failure_code": "HOST_UPGRADE_FAILED",
+            "host_error": message.error or incoming_status,
+            "host_result_received_at": timezone.now().isoformat(),
+        }
+    persisted_status = message.status or "success"
+    detached_result = dict(task.result or {})
+    detached_mode = str(
+        incoming_result.get("mode")
+        or detached_result.get("mode")
+        or (
+            detached_result.get("last_progress", {}).get("mode")
+            if isinstance(detached_result.get("last_progress"), dict)
+            else ""
+        )
+        or ""
+    ).strip()
+    if (
+        lifecycle_upgrade
+        and task.status in {NodeTask.Status.PENDING, NodeTask.Status.RUNNING}
+        and incoming_status in {"success", "succeeded", "ok"}
+        and detached_mode == "local_detached"
+    ):
+        # Detached host success is evidence, not final lifecycle success. The
+        # coordinator must still validate the new session and inventory.
+        persisted_status = "running"
     task = complete_task(
         task_id=message.task_id,
         node_id=node_id,
-        status=message.status or "success",
-        result=message.result or {},
+        status=persisted_status,
+        result=incoming_result,
         error=message.error,
     )
+    if (
+        lifecycle_upgrade
+        and task.status == NodeTask.Status.FAILED
+        and not (task.result or {}).get("lifecycle_failure_audited")
+    ):
+        from apps.audit.constants import AuditResult
+        from apps.audit.services.interface import write_audit_log
+
+        sealed = dict(task.result or {})
+        sealed["lifecycle_failure_audited"] = True
+        task.result = sealed
+        task.save(update_fields=["result", "updated_at"])
+        node = task.node
+        write_audit_log(
+            organization=node.organization,
+            action="node.lifecycle.upgrade.failed",
+            target_type="node",
+            target_id=str(node.id),
+            resource_type="node",
+            resource_id=str(node.id),
+            resource_name=node.name,
+            result=AuditResult.FAILURE,
+            error_message=task.last_error,
+            metadata={
+                "kind": "upgrade",
+                "task_id": str(task.id),
+                "failure_code": sealed.get("failure_code") or "HOST_UPGRADE_FAILED",
+            },
+        )
+    if session_id and lifecycle_upgrade:
+        _record_upgrade_session(node_id=node_id, session_id=session_id)
     if is_retransmission:
         TASK_RESULT_RETRANSMISSIONS.inc()
     logger.info(
@@ -394,6 +643,7 @@ def _handle_task_result_delivery(
     *,
     node_id: int,
     message: ParsedUplink,
+    session_id: str | None = None,
 ) -> TaskResultHandling:
     """Apply or permanently discard a task result before acknowledging it."""
 
@@ -457,6 +707,7 @@ def _handle_task_result_delivery(
         node_id=node_id,
         message=message,
         previous_status=task.status,
+        session_id=session_id,
     )
     disposition = (
         "duplicate"

--- a/src/backend/apps/node/ws/uplink_queue.py
+++ b/src/backend/apps/node/ws/uplink_queue.py
@@ -49,25 +49,40 @@ def ensure_uplink_stream_group(client=None) -> None:
             raise
 
 
-def touch_heartbeat_fast(*, node_id: int, session_id: str) -> None:
-    """Hot path: refresh Redis routing only (no PostgreSQL)."""
-    redis_store.ensure_agent_location_on_heartbeat(
+def touch_agent_session_fast(*, node_id: int, session_id: str) -> bool | None:
+    """Refresh the authenticated WebSocket route without touching PostgreSQL.
+
+    Heartbeats are the usual caller, but task frames are also received on the
+    same live socket.  Refreshing the lease for every authenticated frame
+    prevents a route key that expired during a long heartbeat gap from making
+    an otherwise healthy task result look stale.
+    """
+    route_current = redis_store.ensure_agent_location_on_heartbeat(
         agent_id=node_id,
         session_id=session_id,
     )
     redis_store.touch_ws_instance_alive()
+    return route_current
+
+
+def touch_heartbeat_fast(*, node_id: int, session_id: str) -> bool | None:
+    """Backward-compatible heartbeat wrapper for the hot-path helper."""
+    return touch_agent_session_fast(node_id=node_id, session_id=session_id)
 
 
 def _serialize_uplink(
     *,
     node_id: int,
     message: ParsedUplink,
+    session_id: str | None = None,
     marker_token: str = "",
 ) -> dict[str, str]:
     payload: dict[str, Any] = {
         "node_id": node_id,
         "msg_type": str(message.msg_type),
     }
+    if session_id:
+        payload["session_id"] = str(session_id)
     if message.msg_type == WireType.HEARTBEAT:
         payload["heartbeat_payload"] = message.heartbeat_payload
     else:
@@ -81,13 +96,19 @@ def _serialize_uplink(
     return {"payload": json.dumps(payload, ensure_ascii=False)}
 
 
-def enqueue_uplink(*, node_id: int, message: ParsedUplink) -> None:
+def enqueue_uplink(
+    *, node_id: int, message: ParsedUplink, session_id: str | None = None
+) -> None:
     r = _redis()
     if r is None:
         from apps.node.tasks.uplink_ingest import process_uplink_payload
 
         process_uplink_payload.delay(
-            payload=_serialize_uplink(node_id=node_id, message=message)["payload"]
+            payload=_serialize_uplink(
+                node_id=node_id,
+                message=message,
+                session_id=session_id,
+            )["payload"]
         )
         return
     ensure_uplink_stream_group(r)
@@ -96,6 +117,7 @@ def enqueue_uplink(*, node_id: int, message: ParsedUplink) -> None:
         fields = _serialize_uplink(
             node_id=node_id,
             message=message,
+            session_id=session_id,
             marker_token=marker_token,
         )
         redis_store.enqueue_uplink_with_activity(
@@ -107,7 +129,10 @@ def enqueue_uplink(*, node_id: int, message: ParsedUplink) -> None:
             marker_token=marker_token,
         )
         return
-    r.xadd(NODE_UPLINK_STREAM, _serialize_uplink(node_id=node_id, message=message))
+    r.xadd(
+        NODE_UPLINK_STREAM,
+        _serialize_uplink(node_id=node_id, message=message, session_id=session_id),
+    )
 
 
 def _deserialize_payload(raw: str) -> dict[str, Any] | None:
@@ -118,7 +143,9 @@ def _deserialize_payload(raw: str) -> dict[str, Any] | None:
     return data if isinstance(data, dict) else None
 
 
-def payload_to_parsed(data: dict[str, Any]) -> tuple[int, ParsedUplink] | None:
+def payload_to_parsed(
+    data: dict[str, Any],
+) -> tuple[int, ParsedUplink, str | None] | None:
     node_id_raw = data.get("node_id")
     if not isinstance(node_id_raw, int):
         try:
@@ -137,23 +164,31 @@ def payload_to_parsed(data: dict[str, Any]) -> tuple[int, ParsedUplink] | None:
     if msg_type == WireType.HEARTBEAT:
         hb = data.get("heartbeat_payload")
         heartbeat_payload = hb if isinstance(hb, dict) else None
-        return node_id, ParsedUplink(
-            msg_type=msg_type, heartbeat_payload=heartbeat_payload
+        return (
+            node_id,
+            ParsedUplink(msg_type=msg_type, heartbeat_payload=heartbeat_payload),
+            str(data.get("session_id") or "") or None,
         )
 
     task_id = data.get("task_id")
     if not task_id:
         return None
-    return node_id, ParsedUplink(
-        msg_type=msg_type,
-        task_id=str(task_id),
-        progress=data.get("progress")
-        if isinstance(data.get("progress"), dict)
-        else None,
-        is_alive=bool(data.get("is_alive")),
-        status=str(data.get("status") or "") or None,
-        result=data.get("result") if isinstance(data.get("result"), dict) else None,
-        error=str(data.get("error") or ""),
+    return (
+        node_id,
+        ParsedUplink(
+            msg_type=msg_type,
+            task_id=str(task_id),
+            progress=data.get("progress")
+            if isinstance(data.get("progress"), dict)
+            else None,
+            is_alive=bool(data.get("is_alive")),
+            status=str(data.get("status") or "") or None,
+            result=data.get("result")
+            if isinstance(data.get("result"), dict)
+            else None,
+            error=str(data.get("error") or ""),
+        ),
+        str(data.get("session_id") or "") or None,
     )
 
 
@@ -301,7 +336,7 @@ def replay_dead_letter_entry(r, *, entry_id: str, fields: dict[str, str]) -> str
     parsed = payload_to_parsed(data) if data is not None else None
     if parsed is None:
         raise ValueError("dead-letter payload is not a valid Agent uplink")
-    _node_id, message = parsed
+    _node_id, message, _session_id = parsed
     ensure_uplink_stream_group(r)
     if message.task_id:
         marker_token = uuid.uuid4().hex
@@ -434,10 +469,14 @@ def drain_uplink_stream(*, count: int | None = None) -> int:
         if parsed is None:
             _acknowledge_entry(r, entry_id=entry_id)
             continue
-        node_id, message = parsed
+        node_id, message, session_id = parsed
         marker_token = str(data.get("marker_token") or "")
         try:
-            handle_uplink(node_id=node_id, message=message)
+            handle_uplink(
+                node_id=node_id,
+                message=message,
+                session_id=session_id,
+            )
         except Exception as exc:
             quarantined, deliveries, age_seconds = _quarantine_failed_entry(
                 r,


### PR DESCRIPTION
## Summary

- require detached upgrade completion to be verified against a new Agent session, current route, post-upgrade inventory, and the exact target build
- isolate uplink evidence by WebSocket session and prevent stale or late frames from changing terminal lifecycle state
- classify detached upgrade timeouts and preserve durable lifecycle evidence
- keep task delivery payloads protected while persisting the server-side upgrade baseline
- prevent the generic watchdog from racing detached lifecycle verification

## Validation

- `ruff check src/backend/apps/node`
- Python `compileall`
- `git diff --check`
- touched-module import smoke test
- WebSocket task-result tests: 10 passed

The full Django database test suite could not reach assertions because PostgreSQL was unavailable in the local environment.

Related issues: #823, #838