### PR TITLE
Raise SourceLens API and LensNode memory limits to 2 GiB

### DIFF
--- a/deploy/bootstrap/gateway-install-lensnode-sidecar.sh
+++ b/deploy/bootstrap/gateway-install-lensnode-sidecar.sh
@@ -308,7 +308,7 @@ ${sentry_volume_block}
     tmpfs:
       # Hide the host Agent's same-filesystem deletion quarantine from LensNode.
       - ${HFL_GATEWAY_TRASH_ROOT}:mode=0700
-    mem_limit: 1536m
+    mem_limit: 2g
     cpus: 0.50
 EOF
 	)

--- a/deploy/installer/sourcelens/docker-compose.template.yml
+++ b/deploy/installer/sourcelens/docker-compose.template.yml
@@ -39,7 +39,7 @@ services:
       redis:
         condition: service_healthy
     command: gunicorn
-    mem_limit: 1g
+    mem_limit: 2g
     cpus: 0.50
     healthcheck:
       test: ["CMD", "curl", "-f", "http://127.0.0.1:8000/health"]
@@ -141,7 +141,7 @@ services:
     depends_on:
       api:
         condition: service_healthy
-    mem_limit: 1536m
+    mem_limit: 2g
     cpus: 0.50
 # HFL_EMBED_LENSNODE_SERVICE_END
 

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -1595,6 +1595,11 @@ for resource in \
 	grep -F "${resource}" "${ROOT}/deploy/docker-compose.yml" \
 		"${ROOT}/deploy/installer/sourcelens/docker-compose.template.yml" >/dev/null
 done
+sourcelens_compose_template="${ROOT}/deploy/installer/sourcelens/docker-compose.template.yml"
+[[ "$(grep -Fc '    mem_limit: 2g' "${sourcelens_compose_template}" || true)" -eq 2 ]] \
+	|| { printf 'ERROR: bundled SourceLens API and LensNode must both use a 2 GiB limit\n' >&2; exit 1; }
+grep -F '    mem_limit: 2g' \
+	"${ROOT}/deploy/bootstrap/gateway-install-lensnode-sidecar.sh" >/dev/null
 if grep -E 'mem_limit: (64|320|384|448)m|cpus: (0\.05|0\.10|0\.15|0\.20|0\.30)' \
 	"${ROOT}/deploy/docker-compose.yml" \
 	"${ROOT}/deploy/installer/sourcelens/docker-compose.template.yml" \


### PR DESCRIPTION
## Summary

- raise the bundled SourceLens API memory limit from 1 GiB to 2 GiB
- raise embedded and Data Gateway LensNode limits to 2 GiB
- enforce the unified memory contract in release checks

## Validation

- shell syntax checks
- `git diff --check`
- rendered SourceLens Compose validation
- release contract checks

This change does not modify HFL business logic, backup/recovery flows, concurrency, CPU limits, or SourceLens versioning.