### PR TITLE
Align compact top navigation controls

### DIFF
--- a/src/frontend/src/app/layout/PrimaryNavigationIcons.test.ts
+++ b/src/frontend/src/app/layout/PrimaryNavigationIcons.test.ts
@@ -62,6 +62,15 @@ describe('primary navigation icons', () => {
     )
   })
 
+  it('keeps the timezone label and offset on a single line', () => {
+    expect(topNavSource).toMatch(
+      /\.timezone-display\s*\{[\s\S]*?white-space:\s*nowrap/,
+    )
+    expect(topNavSource).toMatch(
+      /\.timezone-display\s*\{[\s\S]*?gap:\s*4px/,
+    )
+  })
+
   it('uses a compact desktop layout before switching to the mobile drawer', () => {
     expect(topNavSource).toMatch(
       /@media \(min-width: 1024px\) and \(max-width: 1439\.98px\)[\s\S]*?\.nav-item\s*{[\s\S]*?min-width:\s*0[\s\S]*?padding-right:\s*8px/,
@@ -71,6 +80,9 @@ describe('primary navigation icons', () => {
     )
     expect(topNavSource).toMatch(
       /\.top-nav \.platform-ops-entry svg\s*{[\s\S]*?width:\s*18px[\s\S]*?height:\s*18px/,
+    )
+    expect(topNavSource).toMatch(
+      /\.top-nav \.platform-ops-entry:hover,[\s\S]*?background:\s*var\(--icon-btn-hover-bg,[\s\S]*?color:\s*var\(--icon-btn-hover-color/,
     )
     expect(topNavSource).toContain(':aria-label="t(\'nav.platformOps\')"')
   })

--- a/src/frontend/src/app/layout/TopNav.vue
+++ b/src/frontend/src/app/layout/TopNav.vue
@@ -123,7 +123,7 @@ function handleNavClick(event: MouseEvent, to: string) {
         <span>{{ t('nav.platformOps') }}</span>
       </a>
 
-      <div class="icon-btn alerts-btn">
+      <div class="alerts-btn">
         <NavNotificationPopover />
       </div>
 
@@ -278,25 +278,6 @@ function handleNavClick(event: MouseEvent, to: string) {
   gap: 4px;
 }
 
-.icon-btn {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 4px;
-  height: 32px;
-  width: 32px;
-  padding: 0;
-  color: var(--icon-btn-color, #aeb2c5);
-  border-radius: 6px;
-  cursor: pointer;
-  text-decoration: none;
-  border: none;
-  background: transparent;
-  font-size: 13px;
-  transition: all 150ms ease;
-  margin: 0;
-}
-
 .timezone-display {
   height: 32px;
   padding: 0 10px;
@@ -304,17 +285,14 @@ function handleNavClick(event: MouseEvent, to: string) {
   font-size: 13px;
   font-weight: 500;
   line-height: 1.5;
+  white-space: nowrap;
   color: var(--tz-color, #c9cdd4);
   display: flex;
   align-items: center;
+  gap: 4px;
   border-radius: 10px;
   background: var(--tz-bg, rgba(255, 255, 255, 0.06));
   border: 1px solid var(--tz-border, rgba(255, 255, 255, 0.12));
-}
-
-.icon-btn:hover {
-  background: var(--icon-btn-hover-bg, rgba(255, 255, 255, 0.08)) !important;
-  color: var(--icon-btn-hover-color, #E2E2E2) !important;
 }
 
 .alerts-btn {
@@ -415,7 +393,6 @@ function handleNavClick(event: MouseEvent, to: string) {
     min-width: 0;
   }
 
-  .icon-btn,
   .alerts-btn {
     width: 44px;
     height: 44px;

--- a/src/frontend/src/components/LanguageSwitcher.vue
+++ b/src/frontend/src/components/LanguageSwitcher.vue
@@ -56,6 +56,7 @@ function handleVisibleChange(visible: boolean) {
     <button
       type="button"
       class="language-switcher__trigger"
+      :title="ariaLabel"
       :aria-label="ariaLabel"
       aria-haspopup="menu"
       :aria-expanded="dropdownOpen"
@@ -260,6 +261,42 @@ function handleVisibleChange(visible: boolean) {
 @media (max-width: 540px) {
   .language-switcher--auth .language-switcher__trigger {
     padding-inline: 7px;
+  }
+}
+
+@media (min-width: 1024px) and (max-width: 1439.98px) {
+  .language-switcher--navigation .language-switcher__trigger {
+    width: 32px;
+    min-height: 32px;
+    justify-content: center;
+    padding: 0;
+    background: transparent;
+    border-color: transparent;
+    border-radius: 6px;
+    color: var(--icon-btn-color, #aeb2c5);
+  }
+
+  .language-switcher--navigation .language-switcher__trigger:hover,
+  .language-switcher--navigation .language-switcher__trigger:focus-visible {
+    background: var(--icon-btn-hover-bg, rgba(255, 255, 255, 0.08));
+    border-color: transparent;
+    color: var(--icon-btn-hover-color, #E2E2E2);
+  }
+
+  .language-switcher--navigation .language-switcher__trigger:focus-visible {
+    outline: 2px solid var(--color-primary, #6D5EF6);
+    outline-offset: 2px;
+  }
+
+  .language-switcher--navigation .language-switcher__globe {
+    width: 18px;
+    height: 18px;
+    opacity: 1;
+  }
+
+  .language-switcher--navigation .language-switcher__trigger .language-switcher__current,
+  .language-switcher--navigation .language-switcher__trigger .language-switcher__chevron {
+    display: none;
   }
 }
 </style>

--- a/src/frontend/src/components/MobileHeaderUtilities.test.ts
+++ b/src/frontend/src/components/MobileHeaderUtilities.test.ts
@@ -40,11 +40,32 @@ describe('mobile header utilities', () => {
     expect(languageSwitcher).toMatch(
       /\.language-switcher--navigation \.language-switcher__trigger,[\s\S]*?border-color:\s*var\(--tz-border/,
     )
+    expect(languageSwitcher).toContain(':title="ariaLabel"')
     expect(login).toMatch(
       /\.login-box-title\s*{[\s\S]*?grid-template-columns:\s*minmax\(0, 1fr\) auto;[\s\S]*?align-items:\s*center/,
     )
     expect(register).toMatch(
       /\.register-box-title\s*{[\s\S]*?grid-template-columns:\s*minmax\(0, 1fr\) auto;[\s\S]*?align-items:\s*center/,
+    )
+  })
+
+  it('compacts only the interactive navigation language switcher below 1440px', () => {
+    expect(languageSwitcher).toMatch(
+      /@media \(min-width: 1024px\) and \(max-width: 1439\.98px\)[\s\S]*?\.language-switcher--navigation \.language-switcher__trigger\s*\{[\s\S]*?width:\s*32px;[\s\S]*?justify-content:\s*center;[\s\S]*?padding:\s*0;/,
+    )
+    expect(languageSwitcher).toMatch(
+      /@media \(min-width: 1024px\) and \(max-width: 1439\.98px\)[\s\S]*?\.language-switcher__current,[\s\S]*?\.language-switcher--navigation \.language-switcher__trigger \.language-switcher__chevron\s*\{[\s\S]*?display:\s*none;/,
+    )
+  })
+
+  it('uses consistent hover and focus feedback for compact utility icons', () => {
+    expect(topNav).toContain('<div class="alerts-btn">')
+    expect(topNav).not.toContain('<div class="icon-btn alerts-btn">')
+    expect(languageSwitcher).toMatch(
+      /@media \(min-width: 1024px\) and \(max-width: 1439\.98px\)[\s\S]*?\.language-switcher--navigation \.language-switcher__trigger:hover,[\s\S]*?background:\s*var\(--icon-btn-hover-bg,[\s\S]*?color:\s*var\(--icon-btn-hover-color/,
+    )
+    expect(languageSwitcher).toMatch(
+      /@media \(min-width: 1024px\) and \(max-width: 1439\.98px\)[\s\S]*?\.language-switcher--navigation \.language-switcher__globe\s*\{[\s\S]*?width:\s*18px;[\s\S]*?height:\s*18px;[\s\S]*?opacity:\s*1;/,
     )
   })
 

--- a/src/frontend/src/components/NavNotificationPopover.vue
+++ b/src/frontend/src/components/NavNotificationPopover.vue
@@ -300,9 +300,26 @@ onUnmounted(() => {
     color 0.15s ease;
 }
 
-.nav-notification-trigger:hover {
+.nav-notification-trigger:hover,
+.nav-notification-trigger:focus-visible {
   background: var(--icon-btn-hover-bg, rgba(255, 255, 255, 0.08));
   color: var(--nav-notification-hover-color, #fff);
+}
+
+.nav-notification-trigger:focus-visible {
+  outline: 2px solid var(--color-primary, #6D5EF6);
+  outline-offset: 2px;
+}
+
+@media (min-width: 1024px) and (max-width: 1439.98px) {
+  .nav-notification-trigger {
+    color: var(--icon-btn-color, #aeb2c5);
+  }
+
+  .nav-notification-trigger:hover,
+  .nav-notification-trigger:focus-visible {
+    color: var(--icon-btn-hover-color, #E2E2E2);
+  }
 }
 
 @media (max-width: 1023.98px) {


### PR DESCRIPTION
## Summary

- keep the Time Zone label and UTC offset on one line with explicit spacing
- compact the language selector to a Globe icon between 1024px and 1439.98px
- unify compact Platform Ops, notification, and language icon hover and focus feedback

## Testing

- `npm run test -- src/components/MobileHeaderUtilities.test.ts src/components/NavNotificationPopover.test.ts src/components/LanguageSwitcher.test.ts src/app/layout/PrimaryNavigationIcons.test.ts`
- `npm run build`
- `npm run lint -- --quiet`
- `git diff --check origin/main...HEAD`

Closes #852