### PR TITLE
Allow concurrent backup and restore

### DIFF
--- a/language-packs/packs/zh-hans/frontend/messages.json
+++ b/language-packs/packs/zh-hans/frontend/messages.json
@@ -1031,6 +1031,8 @@
       "msgPickRecoveryDir": "请选择一个恢复目录",
       "msgRecoverySubmitted": "恢复任务已提交",
       "msgRecoveryPlanSubmitted": "已按恢复计划提交恢复任务",
+      "msgRecoveryPartialSubmitted": "已提交 {done} 个恢复任务；{failed} 个提交失败。",
+      "msgRestoreAcceptedRefreshFailed": "恢复请求已受理，但暂时无法刷新最新状态。在状态恢复前，冲突的恢复操作将保持禁用。",
       "msgRecoveryPlanUnavailable": "当前没有可执行的恢复计划配置。",
       "recoveryPlanMissingTitle": "未配置恢复计划",
       "recoveryPlanMissingDesc": "该主机未配置恢复计划。执行恢复计划时将跳过该主机。",

--- a/language-packs/packs/zh-hans/frontend/source-lock.json
+++ b/language-packs/packs/zh-hans/frontend/source-lock.json
@@ -1136,6 +1136,8 @@
   "protection.backupsPage.msgPickRecoveryDir": "626d20f9b1e8b6f52bc973b4c7ad8bb71eb698095debe30776c4f986a6a1ad1d",
   "protection.backupsPage.msgRecoverySubmitted": "9f2d3f4e1e293684635fad187f873c1a2908c13bb8834d502ce60229ff5bd909",
   "protection.backupsPage.msgRecoveryPlanSubmitted": "24aeea54e63018e8e2d2d44a5f9e12964aa1817d19af1e68f4afb16df7a2da23",
+  "protection.backupsPage.msgRecoveryPartialSubmitted": "0de3f70171317671029a9f07369ad633f36b9dbb1d643619fe8a921d94941c68",
+  "protection.backupsPage.msgRestoreAcceptedRefreshFailed": "281517027b41a7ad7d94d1a9058feebe9f1fc7635bbe49b3d2556fc5b5970c6d",
   "protection.backupsPage.msgRecoveryPlanUnavailable": "b5bcffdfa7befde520b1de4c3d19f3d35ec801709ae71ea10b7829cef382e6eb",
   "protection.backupsPage.recoveryPlanMissingTitle": "eb5a15429d0e3af2eaa878e56f790c3588dcdfe8072d9786a7ad7a05d0d7a3e0",
   "protection.backupsPage.recoveryPlanMissingDesc": "942fd857938ec7775fcda667729bfddc8ecf891b5a15a9c616e1f3a2f7d5a73c",

--- a/src/backend/apps/protection/services/backup_config.py
+++ b/src/backend/apps/protection/services/backup_config.py
@@ -1864,22 +1864,38 @@ def update_backup_config(
         sorted(data.keys()),
     )
     preflight_payload = _config_payload(data, current=config)
-    source_identities = [
-        (config.source_type, int(config.source_ref_id)),
+    identity_or_endpoint_changed = any(
         (
-            str(preflight_payload["source_type"]),
-            int(preflight_payload["source_ref_id"]),
-        ),
-    ]
-    from apps.source.services.internal.source_operation_fence import (
-        assert_no_active_backup_for_sources,
-    )
-
-    with transaction.atomic():
-        assert_no_active_backup_for_sources(
-            organization_id=config.organization_id,
-            sources=source_identities,
+            str(preflight_payload["source_type"]) != str(config.source_type),
+            int(preflight_payload["source_ref_id"]) != int(config.source_ref_id),
+            str(preflight_payload["repository_endpoint_type"])
+            != str(config.repository_endpoint_type),
         )
+    )
+    if identity_or_endpoint_changed:
+        from apps.source.services.internal.source_operation_fence import (
+            assert_no_active_backup_for_sources,
+            assert_no_active_restore_for_source,
+        )
+
+        with transaction.atomic():
+            identity_sources = [
+                (config.source_type, int(config.source_ref_id)),
+                (
+                    str(preflight_payload["source_type"]),
+                    int(preflight_payload["source_ref_id"]),
+                ),
+            ]
+            assert_no_active_backup_for_sources(
+                organization_id=config.organization_id,
+                sources=identity_sources,
+            )
+            for source_type, source_ref_id in sorted(set(identity_sources)):
+                assert_no_active_restore_for_source(
+                    organization_id=config.organization_id,
+                    source_type=source_type,
+                    source_ref_id=source_ref_id,
+                )
     if _should_initialize_direct_nas_repository(
         current=config, payload=preflight_payload
     ):
@@ -1891,10 +1907,24 @@ def update_backup_config(
         )
 
     with transaction.atomic():
-        assert_no_active_backup_for_sources(
-            organization_id=config.organization_id,
-            sources=source_identities,
-        )
+        if identity_or_endpoint_changed:
+            identity_sources = [
+                (config.source_type, int(config.source_ref_id)),
+                (
+                    str(preflight_payload["source_type"]),
+                    int(preflight_payload["source_ref_id"]),
+                ),
+            ]
+            assert_no_active_backup_for_sources(
+                organization_id=config.organization_id,
+                sources=identity_sources,
+            )
+            for source_type, source_ref_id in sorted(set(identity_sources)):
+                assert_no_active_restore_for_source(
+                    organization_id=config.organization_id,
+                    source_type=source_type,
+                    source_ref_id=source_ref_id,
+                )
         config = BackupConfig.objects.select_for_update().get(pk=config.pk)
         requested_repository_id = int(data.get("repository_id") or config.repository_id)
         if requested_repository_id != config.repository_id:

--- a/src/backend/apps/protection/services/backup_orchestrator.py
+++ b/src/backend/apps/protection/services/backup_orchestrator.py
@@ -37,6 +37,7 @@ from apps.protection.services.backup_source_snapshot import (
     record_source_snapshot_directory_result,
     refresh_source_snapshot_summary,
     set_source_snapshot_started,
+    snapshot_config_directories,
 )
 from apps.protection.services.kopia_snapshot_delete import normalize_kopia_snapshot_id
 from apps.protection.services.backup_runtime_policy import backup_runtime_policy_payload
@@ -830,7 +831,10 @@ def _prepare_directory_policies(
 ) -> bool:
     bt = _bt()
     for directory in directories:
-        source_path = bt._clean_path(directory.path)
+        directory_id = int(getattr(directory, "backup_config_dir_id", directory.id))
+        source_path = bt._clean_path(
+            getattr(directory, "source_path", None) or directory.path
+        )
         path_type = str(getattr(directory, "path_type", "") or "unknown")
         agent_source_path = source_path
         if execution_target.root_path:
@@ -839,12 +843,12 @@ def _prepare_directory_policies(
             agent_source_path = to_mount_path(execution_target.root_path, source_path)
         directory_row = BackupSourceSnapshotDirectory.objects.filter(
             source_snapshot=source_snapshot,
-            backup_config_dir_id=directory.id,
+            backup_config_dir_id=directory_id,
         ).first()
         if directory_row is None:
             directory_row = record_source_snapshot_directory_result(
                 source_snapshot=source_snapshot,
-                backup_config_dir_id=directory.id,
+                backup_config_dir_id=directory_id,
                 source_path=source_path,
                 path_type=path_type,
                 display_name=directory.display_name,
@@ -856,7 +860,7 @@ def _prepare_directory_policies(
                 step_name="kopia_snapshot",
                 message="Starting directory snapshot",
                 metadata={
-                    "backup_config_dir_id": directory.id,
+                    "backup_config_dir_id": directory_id,
                     "source_path": source_path,
                     "object_name": source_path,
                 },
@@ -866,7 +870,7 @@ def _prepare_directory_policies(
         if execution_target.root_path and not bt._is_subpath(execution_target.root_path, agent_source_path):
             record_source_snapshot_directory_result(
                 source_snapshot=source_snapshot,
-                backup_config_dir_id=directory.id,
+                backup_config_dir_id=directory_id,
                 source_path=source_path,
                 path_type=path_type,
                 display_name=directory.display_name,
@@ -2048,10 +2052,14 @@ def advance_backup(
 
     try:
         config = get_backup_config_for_snapshot(source_snapshot=source_snapshot)
-        directories = backup_config_directories(
-            backup_config_id=config.id,
-            organization_id=organization_id,
-        )
+        directories = snapshot_config_directories(source_snapshot=source_snapshot)
+        if not directories:
+            # Legacy snapshots created before directory configuration was
+            # captured fall back to the current config for compatibility.
+            directories = backup_config_directories(
+                backup_config_id=config.id,
+                organization_id=organization_id,
+            )
         if not directories:
             raise ValidationError({"directories": "Backup config has no directories."})
         execution_target = bt._resolve_execution_target(source_snapshot=source_snapshot)
@@ -2238,7 +2246,10 @@ def advance_backup(
     ).exists()
 
     for index, directory in enumerate(directories, start=1):
-        source_path = bt._clean_path(directory.path)
+        directory_id = int(getattr(directory, "backup_config_dir_id", directory.id))
+        source_path = bt._clean_path(
+            getattr(directory, "source_path", None) or directory.path
+        )
         path_type = str(getattr(directory, "path_type", "") or "unknown")
         agent_source_path = source_path
         if execution_target.root_path:
@@ -2248,7 +2259,7 @@ def advance_backup(
 
         directory_row = BackupSourceSnapshotDirectory.objects.filter(
             source_snapshot=source_snapshot,
-            backup_config_dir_id=directory.id,
+            backup_config_dir_id=directory_id,
         ).first()
 
         if directory_row is not None and directory_row.status in _DIRECTORY_TERMINAL:
@@ -2257,7 +2268,7 @@ def advance_backup(
         if serial and prior_failed:
             record_source_snapshot_directory_result(
                 source_snapshot=source_snapshot,
-                backup_config_dir_id=directory.id,
+                backup_config_dir_id=directory_id,
                 source_path=source_path,
                 path_type=path_type,
                 display_name=directory.display_name,
@@ -2272,7 +2283,7 @@ def advance_backup(
         if execution_target.root_path and not bt._is_subpath(execution_target.root_path, agent_source_path):
             record_source_snapshot_directory_result(
                 source_snapshot=source_snapshot,
-                backup_config_dir_id=directory.id,
+                backup_config_dir_id=directory_id,
                 source_path=source_path,
                 path_type=path_type,
                 display_name=directory.display_name,
@@ -2287,7 +2298,7 @@ def advance_backup(
         if directory_row is None:
             directory_row = record_source_snapshot_directory_result(
                 source_snapshot=source_snapshot,
-                backup_config_dir_id=directory.id,
+                backup_config_dir_id=directory_id,
                 source_path=source_path,
                 path_type=path_type,
                 display_name=directory.display_name,
@@ -2299,7 +2310,7 @@ def advance_backup(
                 step_name="kopia_snapshot",
                 message="Starting directory snapshot",
                 metadata={
-                    "backup_config_dir_id": directory.id,
+                    "backup_config_dir_id": directory_id,
                     "source_path": source_path,
                     "object_name": source_path,
                 },

--- a/src/backend/apps/protection/services/backup_source_snapshot.py
+++ b/src/backend/apps/protection/services/backup_source_snapshot.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import uuid
+from dataclasses import dataclass
 from typing import Any
 
 from django.core.exceptions import ValidationError
@@ -23,6 +24,14 @@ _TERMINAL_DIRECTORY_STATUSES = {
     BackupSourceSnapshotDirectory.Status.CANCELLED,
     BackupSourceSnapshotDirectory.Status.DELETED,
 }
+
+
+@dataclass(frozen=True)
+class SnapshotDirectoryConfig:
+    id: int
+    path: str
+    path_type: str
+    display_name: str
 
 
 def _snapshot_uid() -> str:
@@ -108,6 +117,17 @@ def create_source_snapshot(
     ).first()
     if repository is None:
         raise ValidationError({"repository_id": "Repository not found."})
+    config_directories = list(config.directories.order_by("sort_order", "id"))
+    snapshot_metadata = dict(metadata or {})
+    snapshot_metadata["config_directories"] = [
+        {
+            "id": directory.id,
+            "path": directory.path,
+            "path_type": directory.path_type,
+            "display_name": directory.display_name,
+        }
+        for directory in config_directories
+    ]
     return BackupSourceSnapshot.objects.create(
         organization_id=organization_id,
         snapshot_uid=str(snapshot_uid or _snapshot_uid()).strip(),
@@ -123,7 +143,7 @@ def create_source_snapshot(
         started_at=started_at,
         finished_at=finished_at,
         directory_count=max(0, int(directory_count)),
-        metadata=metadata or {},
+        metadata=snapshot_metadata,
         policy_snapshot=policy_snapshot,
     )
 
@@ -323,6 +343,35 @@ def backup_config_directories(*, backup_config_id: int, organization_id: int) ->
             backup_config_id=backup_config_id,
         ).order_by("sort_order", "id")
     )
+
+
+def snapshot_config_directories(
+    *, source_snapshot: BackupSourceSnapshot
+) -> list[SnapshotDirectoryConfig]:
+    metadata = source_snapshot.metadata if isinstance(source_snapshot.metadata, dict) else {}
+    values = metadata.get("config_directories")
+    if not isinstance(values, list):
+        return []
+    directories: list[SnapshotDirectoryConfig] = []
+    for value in values:
+        if not isinstance(value, dict):
+            continue
+        try:
+            directory_id = int(value.get("id") or 0)
+        except (TypeError, ValueError):
+            continue
+        path = str(value.get("path") or "").strip()
+        if directory_id <= 0 or not path:
+            continue
+        directories.append(
+            SnapshotDirectoryConfig(
+                id=directory_id,
+                path=path,
+                path_type=str(value.get("path_type") or "unknown"),
+                display_name=str(value.get("display_name") or ""),
+            )
+        )
+    return directories
 
 
 def get_backup_config_for_snapshot(*, source_snapshot: BackupSourceSnapshot) -> BackupConfig:

--- a/src/backend/apps/protection/services/backup_task.py
+++ b/src/backend/apps/protection/services/backup_task.py
@@ -69,7 +69,12 @@ from apps.task.services.interface import (
 )
 from common.errors import AppError
 
-_ACTIVE_TASK_STATUSES = {Task.Status.PENDING, Task.Status.RUNNING}
+_ACTIVE_TASK_STATUSES = {
+    Task.Status.PENDING,
+    Task.Status.WAITING,
+    Task.Status.BLOCKED,
+    Task.Status.RUNNING,
+}
 _TASK_TRIGGER_MAP = {
     BackupSourceSnapshot.TriggerType.MANUAL: Task.TriggerType.MANUAL,
     BackupSourceSnapshot.TriggerType.SCHEDULE: Task.TriggerType.SYSTEM,
@@ -481,6 +486,27 @@ def find_active_backup_task(
             and int(payload.get("backup_config_id") or 0) == backup_config_id
         ):
             return task
+    from apps.source.services.internal.source_operation_fence import (
+        product_task_is_stopping,
+    )
+
+    cancelled_tasks = Task.objects.filter(
+        organization_id=organization_id,
+        task_type=Task.Type.BACKUP,
+        status=Task.Status.CANCELLED,
+    ).order_by("-created_at", "-id")
+    for task in cancelled_tasks:
+        payload = task.request_payload if isinstance(task.request_payload, dict) else {}
+        if (
+            str(payload.get("source_type") or "") == source_type
+            and int(payload.get("source_ref_id") or 0) == source_ref_id
+            and int(payload.get("backup_config_id") or 0) == backup_config_id
+            and product_task_is_stopping(
+                organization_id=organization_id,
+                task=task,
+            )
+        ):
+            return task
     return None
 
 
@@ -773,16 +799,10 @@ def start_backup_tasks(
             try:
                 with transaction.atomic():
                     from apps.source.services.internal.source_operation_fence import (
-                        assert_no_active_restore_for_source,
                         assert_source_product_operation_allowed,
                     )
 
                     assert_source_product_operation_allowed(
-                        organization_id=organization_id,
-                        source_type=source.source_type,
-                        source_ref_id=source.source_ref_id,
-                    )
-                    assert_no_active_restore_for_source(
                         organization_id=organization_id,
                         source_type=source.source_type,
                         source_ref_id=source.source_ref_id,
@@ -883,16 +903,10 @@ def start_backup_tasks(
             try:
                 with transaction.atomic():
                     from apps.source.services.internal.source_operation_fence import (
-                        assert_no_active_restore_for_source,
                         assert_source_product_operation_allowed,
                     )
 
                     assert_source_product_operation_allowed(
-                        organization_id=organization_id,
-                        source_type=source.source_type,
-                        source_ref_id=source.source_ref_id,
-                    )
-                    assert_no_active_restore_for_source(
                         organization_id=organization_id,
                         source_type=source.source_type,
                         source_ref_id=source.source_ref_id,

--- a/src/backend/apps/protection/tests/test_backup_config_api.py
+++ b/src/backend/apps/protection/tests/test_backup_config_api.py
@@ -844,6 +844,115 @@ class ProtectionBackupConfigApiTests(TestCase):
         self.assertEqual(allowed.status_code, status.HTTP_200_OK, allowed.content)
         self.assertEqual(allowed.data["repository_endpoint_type"], "external")
 
+    def test_backup_paths_can_change_while_backup_is_active(self):
+        create = self.client.post(
+            "/api/v1/protection/backup-configs/",
+            self._payload(name="Active backup editable config"),
+            format="json",
+            **self._headers(),
+        )
+        self.assertEqual(create.status_code, status.HTTP_201_CREATED, create.content)
+        config_id = create.data["id"]
+        Task.objects.create(
+            organization_id=self.org.id,
+            task_type=Task.Type.BACKUP,
+            status=Task.Status.RUNNING,
+            display_name="Active editable backup",
+            request_payload={
+                "source_type": "agent",
+                "source_ref_id": self.agent.id,
+                "backup_config_id": config_id,
+            },
+        )
+
+        response = self.client.patch(
+            f"/api/v1/protection/backup-configs/{config_id}/",
+            {
+                "name": "Updated during backup",
+                "directories": [{"path": "/data/next-backup"}],
+            },
+            format="json",
+            **self._headers(),
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+        self.assertEqual(response.data["name"], "Updated during backup")
+        self.assertEqual(response.data["directories"][0]["path"], "/data/next-backup")
+
+    def test_backup_paths_can_change_while_restore_is_active(self):
+        create = self.client.post(
+            "/api/v1/protection/backup-configs/",
+            self._payload(name="Active restore editable config"),
+            format="json",
+            **self._headers(),
+        )
+        self.assertEqual(create.status_code, status.HTTP_201_CREATED, create.content)
+        config_id = create.data["id"]
+        task = Task.objects.create(
+            organization_id=self.org.id,
+            task_type=Task.Type.RESTORE,
+            status=Task.Status.RUNNING,
+            display_name="Active restore during config edit",
+        )
+        TaskResource.objects.create(
+            task=task,
+            resource_type=TaskResource.Type.BACKUP_SOURCE,
+            resource_subtype="agent",
+            resource_id=self.agent.id,
+        )
+
+        response = self.client.patch(
+            f"/api/v1/protection/backup-configs/{config_id}/",
+            {"directories": [{"path": "/data/after-restore"}]},
+            format="json",
+            **self._headers(),
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+        self.assertEqual(
+            response.data["directories"][0]["path"], "/data/after-restore"
+        )
+
+    def test_backup_source_identity_cannot_change_while_restore_is_active(self):
+        create = self.client.post(
+            "/api/v1/protection/backup-configs/",
+            self._payload(name="Restore identity fenced config"),
+            format="json",
+            **self._headers(),
+        )
+        self.assertEqual(create.status_code, status.HTTP_201_CREATED, create.content)
+        other_agent = Node.objects.create(
+            organization=self.org,
+            name="restore-identity-target",
+            role=Node.Role.AGENT,
+            status=Node.Status.ACTIVE,
+            availability=Node.Availability.ONLINE,
+        )
+        task = Task.objects.create(
+            organization_id=self.org.id,
+            task_type=Task.Type.RESTORE,
+            status=Task.Status.RUNNING,
+            display_name="Restore blocks source identity edit",
+        )
+        TaskResource.objects.create(
+            task=task,
+            resource_type=TaskResource.Type.BACKUP_SOURCE,
+            resource_subtype="agent",
+            resource_id=self.agent.id,
+        )
+
+        response = self.client.patch(
+            f"/api/v1/protection/backup-configs/{create.data['id']}/",
+            {"source_ref_id": other_agent.id},
+            format="json",
+            **self._headers(),
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_409_CONFLICT, response.content)
+        problem = response.data["data"]
+        self.assertEqual(problem["code"], "RESTORE.ALREADY_RUNNING")
+        self.assertEqual(problem["meta"]["task_uuid"], str(task.task_uuid))
+
     def test_backup_config_compression_defaults_and_updates_strictly(self):
         payload = self._payload(name="Default compression config")
         payload.pop("compression_level")

--- a/src/backend/apps/protection/tests/test_backup_task_api.py
+++ b/src/backend/apps/protection/tests/test_backup_task_api.py
@@ -887,7 +887,72 @@ class ProtectionBackupTaskApiTests(TestCase):
         self.assertEqual(response.data["created_count"], 0)
         self.assertEqual(response.data["results"][0]["status"], "conflict")
 
-    def test_start_backup_task_api_rejects_active_restore(self):
+    def test_start_backup_task_api_rejects_waiting_and_blocked_duplicates(self):
+        for task_status in (Task.Status.WAITING, Task.Status.BLOCKED):
+            with self.subTest(task_status=task_status):
+                task = Task.objects.create(
+                    organization_id=self.org.id,
+                    task_type=Task.Type.BACKUP,
+                    display_name=f"{task_status} backup",
+                    status=task_status,
+                    trigger_type=Task.TriggerType.MANUAL,
+                    request_payload={
+                        "source_type": "agent",
+                        "source_ref_id": self.agent.id,
+                        "backup_config_id": self.config.id,
+                        "repository_id": self.repository.id,
+                    },
+                )
+
+                response = self.client.post(
+                    "/api/v1/protection/backup-tasks/",
+                    {"source_ids": [f"agent:{self.agent.id}"]},
+                    format="json",
+                    **self._headers(),
+                )
+
+                self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+                self.assertEqual(response.data["created_count"], 0)
+                self.assertEqual(response.data["results"][0]["status"], "conflict")
+                task.delete()
+
+    def test_start_backup_task_api_rejects_stopping_duplicate(self):
+        task = Task.objects.create(
+            organization_id=self.org.id,
+            task_type=Task.Type.BACKUP,
+            display_name="Stopping backup",
+            status=Task.Status.CANCELLED,
+            trigger_type=Task.TriggerType.MANUAL,
+            request_payload={
+                "source_type": "agent",
+                "source_ref_id": self.agent.id,
+                "backup_config_id": self.config.id,
+                "repository_id": self.repository.id,
+            },
+        )
+        NodeTask.objects.create(
+            organization=self.org,
+            node=self.agent,
+            kind="backup.run",
+            correlation_type=protection_conf.PROTECTION_BACKUP_CORRELATION_TYPE,
+            correlation_id=str(task.task_uuid),
+            status=NodeTask.Status.RUNNING,
+            cancel_requested_at=timezone.now(),
+            watchdog_deadline_at=timezone.now() + timezone.timedelta(hours=1),
+        )
+
+        response = self.client.post(
+            "/api/v1/protection/backup-tasks/",
+            {"source_ids": [f"agent:{self.agent.id}"]},
+            format="json",
+            **self._headers(),
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data["created_count"], 0)
+        self.assertEqual(response.data["results"][0]["status"], "conflict")
+
+    def test_start_backup_task_api_allows_active_restore(self):
         restore_task = Task.objects.create(
             organization_id=self.org.id,
             task_type=Task.Type.RESTORE,
@@ -913,15 +978,9 @@ class ProtectionBackupTaskApiTests(TestCase):
         self.assertEqual(
             response.status_code, status.HTTP_201_CREATED, response.content
         )
-        self.assertEqual(response.data["created_count"], 0)
-        self.assertEqual(response.data["skipped_count"], 1)
-        result = response.data["results"][0]
-        self.assertEqual(result["status"], "conflict")
-        self.assertIn("restore task is active", result["message"].lower())
-        self.assertFalse(
-            Task.objects.filter(task_type=Task.Type.BACKUP).exists()
-        )
-        self.assertFalse(BackupSourceSnapshot.objects.exists())
+        self.assertEqual(response.data["created_count"], 1)
+        self.assertTrue(Task.objects.filter(task_type=Task.Type.BACKUP).exists())
+        self.assertTrue(BackupSourceSnapshot.objects.exists())
 
     @patch(
         "apps.protection.services.backup_orchestrator.enqueue_repository_usage_refresh"
@@ -966,6 +1025,9 @@ class ProtectionBackupTaskApiTests(TestCase):
             idempotency_key="test-run-backup-task",
             directory_count=1,
         )
+        BackupConfigDirectory.objects.filter(backup_config=self.config).update(
+            path="/data/changed-after-acceptance"
+        )
         mock_run_agent_task_async.side_effect = self._mock_run_agent_task_async(
             [self._async_outcome(kopia_snapshot_id="kopia-snap-1")]
         )
@@ -978,6 +1040,11 @@ class ProtectionBackupTaskApiTests(TestCase):
         self.assertEqual(task.status, Task.Status.SUCCESS)
         self.assertEqual(snapshot.status, BackupSourceSnapshot.Status.AVAILABLE)
         self.assertEqual(directory.kopia_snapshot_id, "kopia-snap-1")
+        self.assertEqual(directory.source_path, "/data/projects")
+        self.assertEqual(
+            mock_run_agent_task_async.call_args.kwargs["payload"]["source_path"],
+            "/data/projects",
+        )
         self.assertEqual(
             directory.status, BackupSourceSnapshotDirectory.Status.AVAILABLE
         )

--- a/src/backend/apps/restore/migrations/0008_user_restore_idempotency.py
+++ b/src/backend/apps/restore/migrations/0008_user_restore_idempotency.py
@@ -1,0 +1,49 @@
+from django.db import migrations, models
+from django.db.models import Count
+
+
+def clear_duplicate_user_restore_keys(apps, schema_editor):
+    RestoreRecord = apps.get_model("restore", "RestoreRecord")
+    duplicate_keys = (
+        RestoreRecord.objects.filter(purpose="user_data")
+        .exclude(idempotency_key="")
+        .values("organization_id", "purpose", "idempotency_key")
+        .annotate(total=Count("id"))
+        .filter(total__gt=1)
+    )
+    for duplicate in duplicate_keys.iterator():
+        records = RestoreRecord.objects.filter(
+            organization_id=duplicate["organization_id"],
+            purpose=duplicate["purpose"],
+            idempotency_key=duplicate["idempotency_key"],
+        ).order_by("created_at", "id")
+        duplicate_ids = list(records.values_list("id", flat=True)[1:])
+        if duplicate_ids:
+            RestoreRecord.objects.filter(id__in=duplicate_ids).update(
+                idempotency_key=""
+            )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("restore", "0007_direct_nas_mount_lease"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            clear_duplicate_user_restore_keys,
+            migrations.RunPython.noop,
+        ),
+        migrations.RemoveConstraint(
+            model_name="restorerecord",
+            name="uniq_restore_org_purpose_idem",
+        ),
+        migrations.AddConstraint(
+            model_name="restorerecord",
+            constraint=models.UniqueConstraint(
+                condition=~models.Q(idempotency_key=""),
+                fields=("organization_id", "purpose", "idempotency_key"),
+                name="uniq_restore_org_purpose_idem",
+            ),
+        ),
+    ]

--- a/src/backend/apps/restore/models/restore_record.py
+++ b/src/backend/apps/restore/models/restore_record.py
@@ -79,10 +79,7 @@ class RestoreRecord(models.Model):
             ),
             models.UniqueConstraint(
                 fields=["organization_id", "purpose", "idempotency_key"],
-                condition=(
-                    models.Q(purpose="lens_workspace")
-                    & ~models.Q(idempotency_key="")
-                ),
+                condition=~models.Q(idempotency_key=""),
                 name="uniq_restore_org_purpose_idem",
             ),
             models.CheckConstraint(

--- a/src/backend/apps/restore/services/interface.py
+++ b/src/backend/apps/restore/services/interface.py
@@ -108,15 +108,6 @@ _ACTIVE_NODE_STATUSES = frozenset({NodeTask.Status.PENDING, NodeTask.Status.RUNN
 @transaction.atomic
 def create_restore_plan(*, organization_id: int, data: dict[str, Any]) -> RestorePlan:
     payload = _plan_payload(organization_id=organization_id, data=data)
-    from apps.source.services.internal.source_operation_fence import (
-        assert_no_active_backup_for_source,
-    )
-
-    assert_no_active_backup_for_source(
-        organization_id=organization_id,
-        source_type=payload["source_type"],
-        source_ref_id=int(payload["source_ref_id"]),
-    )
     _validate_restore_plan_configuration(
         organization_id=organization_id, payload=payload
     )
@@ -141,17 +132,6 @@ def update_restore_plan(*, plan: RestorePlan, data: dict[str, Any]) -> RestorePl
     }
     merged.update(data)
     payload = _plan_payload(organization_id=plan.organization_id, data=merged)
-    from apps.source.services.internal.source_operation_fence import (
-        assert_no_active_backup_for_sources,
-    )
-
-    assert_no_active_backup_for_sources(
-        organization_id=plan.organization_id,
-        sources=[
-            (plan.source_type, int(plan.source_ref_id)),
-            (payload["source_type"], int(payload["source_ref_id"])),
-        ],
-    )
     _validate_restore_plan_configuration(
         organization_id=plan.organization_id, payload=payload, exclude_plan_id=plan.id
     )
@@ -163,15 +143,6 @@ def update_restore_plan(*, plan: RestorePlan, data: dict[str, Any]) -> RestorePl
 
 @transaction.atomic
 def delete_restore_plan(*, plan: RestorePlan) -> dict[str, Any]:
-    from apps.source.services.internal.source_operation_fence import (
-        assert_no_active_backup_for_source,
-    )
-
-    assert_no_active_backup_for_source(
-        organization_id=plan.organization_id,
-        source_type=plan.source_type,
-        source_ref_id=int(plan.source_ref_id),
-    )
     plan_id = int(plan.id)
     plan.delete()
     return {"deleted": True, "id": plan_id}
@@ -212,11 +183,6 @@ def run_restore_plan(
                 "source_snapshot_id": "No restorable source snapshot found for restore plan."
             }
         )
-    _ensure_no_active_restore_for_source(
-        organization_id=organization_id,
-        source_type=plan.source_type,
-        source_ref_id=int(plan.source_ref_id),
-    )
     item_inputs = _restore_plan_item_inputs(
         organization_id=organization_id,
         snapshot=snapshot,
@@ -244,6 +210,7 @@ def run_restore_plan(
             "idempotency_key": idempotency_key or "",
         },
         created_by_id=user_id,
+        idempotency_key=str(idempotency_key or ""),
     )
     logger.info(
         "restore plan run ok plan_id=%s restore_record_id=%s restore_uid=%s task_uuid=%s",
@@ -267,11 +234,6 @@ def run_restore_plans_for_source(
 ) -> list[RestoreRecord]:
     source_type = _choice({"source_type": source_type}, "source_type", SOURCE_TYPES)
     source_ref_id = int(source_ref_id)
-    _ensure_no_active_restore_for_source(
-        organization_id=organization_id,
-        source_type=source_type,
-        source_ref_id=source_ref_id,
-    )
     plans = list(
         RestorePlan.objects.filter(
             organization_id=organization_id,
@@ -361,6 +323,7 @@ def run_restore_plans_for_source(
                     "idempotency_key": idempotency_key or "",
                 },
                 created_by_id=user_id,
+                idempotency_key=str(idempotency_key or ""),
             )
         )
     return records
@@ -384,11 +347,6 @@ def run_restore_plan_batch(
     ).first()
     if config is None:
         raise ValidationError({"backup_config_id": "Backup config not found."})
-    _ensure_no_active_restore_for_source(
-        organization_id=organization_id,
-        source_type=config.source_type,
-        source_ref_id=int(config.source_ref_id),
-    )
     plans = list(
         RestorePlan.objects.filter(
             organization_id=organization_id,
@@ -457,6 +415,7 @@ def run_restore_plan_batch(
             "idempotency_key": str(data.get("idempotency_key") or ""),
         },
         created_by_id=user_id,
+        idempotency_key=str(data.get("idempotency_key") or ""),
     )
 
 
@@ -557,12 +516,6 @@ def _create_manual_restore_record(
         raise ValidationError(
             {"source_snapshot_id": "Source snapshot does not match restore source."}
         )
-    _ensure_no_active_restore_for_source(
-        organization_id=organization_id,
-        source_type=source_type,
-        source_ref_id=source_ref_id,
-        purpose=purpose,
-    )
     items = data.get("items")
     if not isinstance(items, list) or not items:
         raise ValidationError({"items": "At least one restore item is required."})
@@ -736,6 +689,100 @@ def create_lens_workspace_restore_record(
         return existing
 
 
+def _restore_item_signature(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    keys = (
+        "source_snapshot_directory_id",
+        "backup_config_dir_id",
+        "repository_id",
+        "kopia_snapshot_id",
+        "source_path",
+        "source_path_type",
+        "selected_paths",
+        "target_path",
+        "target_path_semantics",
+        "conflict_mode",
+    )
+    return [{key: item.get(key) for key in keys} for item in items]
+
+
+def _idempotent_restore_record(
+    *,
+    organization_id: int,
+    purpose: str,
+    idempotency_key: str,
+    source_mode: str,
+    plan_id: int | None,
+    source_type: str,
+    source_ref_id: int,
+    backup_config_id: int | None,
+    source_snapshot_id: int,
+    target_type: str,
+    target_ref_id: int,
+    target_path: str,
+    scope: str,
+    conflict_mode: str,
+    request_payload: dict[str, Any],
+    directories: list[dict[str, Any]],
+) -> RestoreRecord | None:
+    if not idempotency_key:
+        return None
+    existing = (
+        RestoreRecord.objects.select_for_update()
+        .filter(
+            organization_id=organization_id,
+            purpose=purpose,
+            idempotency_key=idempotency_key,
+        )
+        .first()
+    )
+    if existing is None:
+        return None
+    expected = (
+        source_mode,
+        plan_id,
+        source_type,
+        int(source_ref_id),
+        backup_config_id,
+        int(source_snapshot_id),
+        target_type,
+        int(target_ref_id),
+        target_path,
+        scope,
+        conflict_mode,
+        request_payload,
+        _restore_item_signature(directories),
+    )
+    expanded = (
+        existing.expanded_payload
+        if isinstance(existing.expanded_payload, dict)
+        else {}
+    )
+    actual = (
+        existing.source_mode,
+        existing.plan_id,
+        existing.source_type,
+        int(existing.source_ref_id),
+        existing.backup_config_id,
+        int(existing.source_snapshot_id),
+        existing.target_type,
+        int(existing.target_ref_id),
+        existing.target_path,
+        existing.scope,
+        existing.conflict_mode,
+        existing.request_payload,
+        _restore_item_signature(expanded.get("items", [])),
+    )
+    if actual != expected:
+        raise ValidationError(
+            {
+                "idempotency_key": (
+                    "Idempotency key is bound to another restore request."
+                )
+            }
+        )
+    return existing
+
+
 def _create_restore_record(
     *,
     organization_id: int,
@@ -780,16 +827,47 @@ def _create_restore_record(
         is_deleted=False,
     ).exists():
         raise ValidationError({"target_ref_id": "Restore execution node not found."})
-    _ensure_no_active_restore_for_source(
+    from apps.source.services.internal.source_operation_fence import (
+        assert_source_product_operation_allowed,
+    )
+
+    assert_source_product_operation_allowed(
         organization_id=organization_id,
         source_type=source_type,
         source_ref_id=source_ref_id,
-        purpose=purpose,
     )
     directories = _expanded_directories(
         organization_id=organization_id,
         source_snapshot=source_snapshot,
         item_inputs=item_inputs,
+    )
+    normalized_idempotency_key = str(idempotency_key or "").strip()
+    idempotency_lookup = {
+        "organization_id": organization_id,
+        "purpose": purpose,
+        "idempotency_key": normalized_idempotency_key,
+        "source_mode": source_mode,
+        "plan_id": plan_id,
+        "source_type": source_type,
+        "source_ref_id": source_ref_id,
+        "backup_config_id": backup_config_id,
+        "source_snapshot_id": source_snapshot.id,
+        "target_type": target_type,
+        "target_ref_id": target_ref_id,
+        "target_path": target_path,
+        "scope": scope,
+        "conflict_mode": conflict_mode,
+        "request_payload": request_payload,
+        "directories": directories,
+    }
+    existing = _idempotent_restore_record(**idempotency_lookup)
+    if existing is not None:
+        return existing
+    _ensure_no_active_restore_for_source(
+        organization_id=organization_id,
+        source_type=source_type,
+        source_ref_id=source_ref_id,
+        purpose=purpose,
     )
     repository_ids = sorted(
         {int(directory["repository_id"]) for directory in directories}
@@ -837,31 +915,45 @@ def _create_restore_record(
         ],
         steps=["prepare_restore", "dispatch_agent", "restore", "finalize"],
     )
-    record = RestoreRecord.objects.create(
-        organization_id=organization_id,
-        requesting_organization_id=requesting_organization_id or organization_id,
-        target_execution_organization_id=target_execution_organization_id,
-        target_execution_node_id=target_execution_node_id,
-        purpose=purpose,
-        idempotency_key=idempotency_key,
-        workspace_binding_id=workspace_binding_id,
-        restore_uid=restore_uid,
-        source_mode=source_mode,
-        plan_id=plan_id,
-        task_id=task.id,
-        task_uuid=task.task_uuid,
-        source_type=source_type,
-        source_ref_id=source_ref_id,
-        backup_config_id=backup_config_id,
-        source_snapshot_id=source_snapshot.id,
-        target_type=target_type,
-        target_ref_id=target_ref_id,
-        target_path=target_path,
-        scope=scope,
-        conflict_mode=conflict_mode,
-        request_payload=request_payload,
-        created_by_id=created_by_id,
-    )
+    try:
+        # Keep the uniqueness violation inside a savepoint so an exact
+        # concurrent replay can reuse the committed winner. The provisional
+        # task is removed below before returning that winner.
+        with transaction.atomic():
+            record = RestoreRecord.objects.create(
+                organization_id=organization_id,
+                requesting_organization_id=requesting_organization_id
+                or organization_id,
+                target_execution_organization_id=target_execution_organization_id,
+                target_execution_node_id=target_execution_node_id,
+                purpose=purpose,
+                idempotency_key=normalized_idempotency_key,
+                workspace_binding_id=workspace_binding_id,
+                restore_uid=restore_uid,
+                source_mode=source_mode,
+                plan_id=plan_id,
+                task_id=task.id,
+                task_uuid=task.task_uuid,
+                source_type=source_type,
+                source_ref_id=source_ref_id,
+                backup_config_id=backup_config_id,
+                source_snapshot_id=source_snapshot.id,
+                target_type=target_type,
+                target_ref_id=target_ref_id,
+                target_path=target_path,
+                scope=scope,
+                conflict_mode=conflict_mode,
+                request_payload=request_payload,
+                created_by_id=created_by_id,
+            )
+    except IntegrityError:
+        if not normalized_idempotency_key:
+            raise
+        task.delete()
+        existing = _idempotent_restore_record(**idempotency_lookup)
+        if existing is None:
+            raise
+        return existing
     items = [
         RestoreRecordItem(
             organization_id=organization_id,
@@ -1491,7 +1583,7 @@ def _active_restore_task_for_source(
         .order_by()
         .values("task_id")
     )
-    return (
+    active = (
         Task.objects.filter(
             organization_id=organization_id,
             task_type=Task.Type.RESTORE,
@@ -1504,6 +1596,20 @@ def _active_restore_task_for_source(
         .order_by("created_at", "id")
         .first()
     )
+    if active is not None:
+        return active
+    cancelled = Task.objects.filter(
+        organization_id=organization_id,
+        task_type=Task.Type.RESTORE,
+        status=Task.Status.CANCELLED,
+        resources__resource_type=TaskResource.Type.BACKUP_SOURCE,
+        resources__resource_subtype=source_type,
+        resources__resource_id=source_ref_id,
+    ).exclude(id__in=insight_restore_task_ids).order_by("created_at", "id")
+    for task in cancelled:
+        if restore_task_is_stopping(task=task):
+            return task
+    return None
 
 
 def _ensure_no_active_restore_for_source(
@@ -1514,16 +1620,10 @@ def _ensure_no_active_restore_for_source(
     purpose: str = RestoreRecord.Purpose.USER_DATA,
 ) -> None:
     from apps.source.services.internal.source_operation_fence import (
-        assert_no_active_backup_for_source,
         assert_source_product_operation_allowed,
     )
 
     assert_source_product_operation_allowed(
-        organization_id=organization_id,
-        source_type=source_type,
-        source_ref_id=source_ref_id,
-    )
-    assert_no_active_backup_for_source(
         organization_id=organization_id,
         source_type=source_type,
         source_ref_id=source_ref_id,
@@ -1537,6 +1637,11 @@ def _ensure_no_active_restore_for_source(
     )
     if active_task is None:
         return
+    active_status = (
+        "stopping"
+        if restore_task_is_stopping(task=active_task)
+        else active_task.status
+    )
     record = (
         RestoreRecord.objects.filter(
             organization_id=organization_id,
@@ -1556,7 +1661,7 @@ def _ensure_no_active_restore_for_source(
             "task_id": active_task.id,
             "restore_record_id": record.id if record is not None else None,
             "display_name": active_task.display_name,
-            "status": active_task.status,
+            "status": active_status,
             "source_type": source_type,
             "source_ref_id": source_ref_id,
             "created_at": active_task.created_at.isoformat()

--- a/src/backend/apps/restore/tests/test_restore_api.py
+++ b/src/backend/apps/restore/tests/test_restore_api.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError
+from django.db import IntegrityError
 from django.test import TestCase
 from django.utils import timezone
 from rest_framework import status
@@ -1056,12 +1057,12 @@ class RestoreApiTests(TestCase):
         self.assertEqual(listing.data["count"], 1)
         self.assertEqual(listing.data["results"][0]["id"], plan_id)
 
-    def test_restore_plan_mutations_are_blocked_while_backup_is_active(self):
+    def test_restore_plan_mutations_are_allowed_while_backup_is_active(self):
         plan = RestorePlan.objects.create(
             organization_id=self.org.id,
             **self._plan_payload(),
         )
-        task = self._active_backup_task()
+        self._active_backup_task()
 
         create = self.client.post(
             "/api/v1/restore/plans/",
@@ -1080,18 +1081,50 @@ class RestoreApiTests(TestCase):
             **self._headers(),
         )
 
-        self._assert_backup_already_running(create, task)
-        self._assert_backup_already_running(patch_response, task)
-        self._assert_backup_already_running(delete, task)
-        plan.refresh_from_db()
-        self.assertEqual(plan.restore_dir, "/restore/data")
+        self.assertEqual(create.status_code, status.HTTP_201_CREATED, create.content)
+        self.assertEqual(
+            patch_response.status_code, status.HTTP_200_OK, patch_response.content
+        )
+        self.assertEqual(delete.status_code, status.HTTP_200_OK, delete.content)
+        self.assertFalse(RestorePlan.objects.filter(id=plan.id).exists())
 
-    def test_restore_run_is_blocked_while_backup_is_active(self):
+    def test_restore_plan_mutations_are_allowed_while_restore_is_active(self):
         plan = RestorePlan.objects.create(
             organization_id=self.org.id,
             **self._plan_payload(),
         )
-        task = self._active_backup_task(status_value=Task.Status.PENDING)
+        self._active_restore_task()
+
+        create = self.client.post(
+            "/api/v1/restore/plans/",
+            {**self._plan_payload(), "restore_dir": "/restore/other"},
+            format="json",
+            **self._headers(),
+        )
+        patch_response = self.client.patch(
+            f"/api/v1/restore/plans/{plan.id}/",
+            {"restore_dir": "/restore/updated"},
+            format="json",
+            **self._headers(),
+        )
+        delete = self.client.delete(
+            f"/api/v1/restore/plans/{plan.id}/",
+            **self._headers(),
+        )
+
+        self.assertEqual(create.status_code, status.HTTP_201_CREATED, create.content)
+        self.assertEqual(
+            patch_response.status_code, status.HTTP_200_OK, patch_response.content
+        )
+        self.assertEqual(delete.status_code, status.HTTP_200_OK, delete.content)
+        self.assertFalse(RestorePlan.objects.filter(id=plan.id).exists())
+
+    def test_restore_run_is_allowed_while_backup_is_active(self):
+        plan = RestorePlan.objects.create(
+            organization_id=self.org.id,
+            **self._plan_payload(),
+        )
+        self._active_backup_task(status_value=Task.Status.PENDING)
 
         plan_run = self.client.post(
             f"/api/v1/restore/plans/{plan.id}/run/",
@@ -1099,6 +1132,11 @@ class RestoreApiTests(TestCase):
             format="json",
             **self._headers(),
         )
+        self.assertEqual(
+            plan_run.status_code, status.HTTP_201_CREATED, plan_run.content
+        )
+        plan_record = RestoreRecord.objects.get(id=plan_run.data["restore_record_id"])
+        Task.objects.filter(id=plan_record.task_id).update(status=Task.Status.SUCCESS)
         manual_run = self.client.post(
             "/api/v1/restore/records/",
             self._manual_restore_payload(),
@@ -1106,11 +1144,12 @@ class RestoreApiTests(TestCase):
             **self._headers(),
         )
 
-        self._assert_backup_already_running(plan_run, task)
-        self._assert_backup_already_running(manual_run, task)
-        self.assertEqual(RestoreRecord.objects.count(), 0)
+        self.assertEqual(
+            manual_run.status_code, status.HTTP_201_CREATED, manual_run.content
+        )
+        self.assertEqual(RestoreRecord.objects.count(), 2)
 
-    def test_restore_run_is_blocked_while_backup_is_stopping(self):
+    def test_restore_run_is_allowed_while_backup_is_stopping(self):
         plan = RestorePlan.objects.create(
             organization_id=self.org.id,
             **self._plan_payload(),
@@ -1133,6 +1172,11 @@ class RestoreApiTests(TestCase):
             format="json",
             **self._headers(),
         )
+        self.assertEqual(
+            plan_run.status_code, status.HTTP_201_CREATED, plan_run.content
+        )
+        plan_record = RestoreRecord.objects.get(id=plan_run.data["restore_record_id"])
+        Task.objects.filter(id=plan_record.task_id).update(status=Task.Status.SUCCESS)
         manual_run = self.client.post(
             "/api/v1/restore/records/",
             self._manual_restore_payload(),
@@ -1140,11 +1184,10 @@ class RestoreApiTests(TestCase):
             **self._headers(),
         )
 
-        self._assert_backup_already_running(plan_run, task)
-        self._assert_backup_already_running(manual_run, task)
-        self.assertEqual(plan_run.data["data"]["meta"]["status"], "stopping")
-        self.assertEqual(manual_run.data["data"]["meta"]["status"], "stopping")
-        self.assertEqual(RestoreRecord.objects.count(), 0)
+        self.assertEqual(
+            manual_run.status_code, status.HTTP_201_CREATED, manual_run.content
+        )
+        self.assertEqual(RestoreRecord.objects.count(), 2)
 
     def test_create_restore_plan_accepts_zero_sort_order_and_nested_source_path(self):
         payload = self._plan_payload()
@@ -2663,6 +2706,92 @@ class RestoreApiTests(TestCase):
         self._assert_restore_already_running(create, active_task)
         self.assertFalse(RestoreRecord.objects.exists())
 
+    def test_create_manual_restore_record_rejects_same_source_stopping_restore(self):
+        active_task = self._active_restore_task(status_value=Task.Status.CANCELLED)
+        record = RestoreRecord.objects.create(
+            organization_id=self.org.id,
+            requesting_organization_id=self.org.id,
+            target_execution_organization_id=self.org.id,
+            target_execution_node_id=self.target.id,
+            restore_uid="rst-stopping-source",
+            source_mode=RestoreRecord.SourceMode.MANUAL,
+            task_id=active_task.id,
+            task_uuid=active_task.task_uuid,
+            source_type="agent",
+            source_ref_id=self.agent.id,
+            backup_config_id=self.config.id,
+            source_snapshot_id=self.snapshot.id,
+            target_type="agent",
+            target_ref_id=self.target.id,
+            target_path="/restore/stopping",
+            scope=RestoreRecord.Scope.PATHS,
+            conflict_mode=RestoreRecord.ConflictMode.SKIP,
+        )
+        NodeTask.objects.create(
+            organization=self.org,
+            node=self.target,
+            kind="restore.run",
+            correlation_type="restore.record",
+            correlation_id=str(active_task.task_uuid),
+            status=NodeTask.Status.RUNNING,
+            payload={"restore_record_id": record.id},
+            watchdog_deadline_at=timezone.now() + timezone.timedelta(hours=1),
+        )
+
+        create = self.client.post(
+            "/api/v1/restore/records/",
+            self._manual_restore_payload(),
+            format="json",
+            **self._headers(),
+        )
+
+        self._assert_restore_already_running(create, active_task)
+        self.assertEqual(create.data["data"]["meta"]["status"], "stopping")
+        self.assertEqual(RestoreRecord.objects.count(), 1)
+
+    def test_backup_selectable_reports_restore_stopping(self):
+        active_task = self._active_restore_task(status_value=Task.Status.CANCELLED)
+        record = RestoreRecord.objects.create(
+            organization_id=self.org.id,
+            requesting_organization_id=self.org.id,
+            target_execution_organization_id=self.org.id,
+            target_execution_node_id=self.target.id,
+            restore_uid="rst-runtime-stopping",
+            source_mode=RestoreRecord.SourceMode.MANUAL,
+            task_id=active_task.id,
+            task_uuid=active_task.task_uuid,
+            source_type="agent",
+            source_ref_id=self.agent.id,
+            backup_config_id=self.config.id,
+            source_snapshot_id=self.snapshot.id,
+            target_type="agent",
+            target_ref_id=self.target.id,
+            target_path="/restore/stopping",
+            scope=RestoreRecord.Scope.PATHS,
+            conflict_mode=RestoreRecord.ConflictMode.SKIP,
+        )
+        NodeTask.objects.create(
+            organization=self.org,
+            node=self.target,
+            kind="restore.run",
+            correlation_type="restore.record",
+            correlation_id=str(active_task.task_uuid),
+            status=NodeTask.Status.RUNNING,
+            payload={"restore_record_id": record.id},
+            watchdog_deadline_at=timezone.now() + timezone.timedelta(hours=1),
+        )
+
+        response = self.client.get(
+            f"/api/v1/source/backup-selectable/?ids=agent:{self.agent.id}&expand=runtime",
+            **self._headers(),
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+        runtime = response.data["results"][0]["runtime"]["restore"]
+        self.assertTrue(runtime["stopping"])
+        self.assertFalse(runtime["cancelled"])
+        self.assertEqual(runtime["latest_task"]["status"], Task.Status.CANCELLED)
+
     def test_create_manual_restore_record_ignores_terminal_same_source_restore(self):
         self._active_restore_task(status_value=Task.Status.CANCELLED)
 
@@ -2675,6 +2804,105 @@ class RestoreApiTests(TestCase):
 
         self.assertEqual(create.status_code, status.HTTP_201_CREATED, create.content)
         self.assertEqual(RestoreRecord.objects.count(), 1)
+
+    def test_manual_restore_idempotency_replays_the_created_record(self):
+        payload = {
+            **self._manual_restore_payload(),
+            "idempotency_key": "manual-restore-replay",
+        }
+
+        first = self.client.post(
+            "/api/v1/restore/records/",
+            payload,
+            format="json",
+            **self._headers(),
+        )
+        second = self.client.post(
+            "/api/v1/restore/records/",
+            payload,
+            format="json",
+            **self._headers(),
+        )
+
+        self.assertEqual(first.status_code, status.HTTP_201_CREATED, first.content)
+        self.assertEqual(second.status_code, status.HTTP_201_CREATED, second.content)
+        self.assertEqual(second.data["restore_record_id"], first.data["restore_record_id"])
+        self.assertEqual(second.data["task_uuid"], first.data["task_uuid"])
+        self.assertEqual(RestoreRecord.objects.count(), 1)
+
+    def test_manual_restore_idempotency_rejects_changed_payload(self):
+        payload = {
+            **self._manual_restore_payload(),
+            "idempotency_key": "manual-restore-conflict",
+        }
+        first = self.client.post(
+            "/api/v1/restore/records/",
+            payload,
+            format="json",
+            **self._headers(),
+        )
+
+        conflict = self.client.post(
+            "/api/v1/restore/records/",
+            {**payload, "target_path": "/restore/changed"},
+            format="json",
+            **self._headers(),
+        )
+
+        self.assertEqual(first.status_code, status.HTTP_201_CREATED, first.content)
+        self.assertEqual(conflict.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("idempotency_key", str(conflict.data))
+        self.assertEqual(RestoreRecord.objects.count(), 1)
+
+    def test_manual_restore_idempotency_recovers_concurrent_insert_race(self):
+        payload = {
+            **self._manual_restore_payload(),
+            "idempotency_key": "manual-restore-race",
+        }
+        first = self.client.post(
+            "/api/v1/restore/records/",
+            payload,
+            format="json",
+            **self._headers(),
+        )
+        self.assertEqual(first.status_code, status.HTTP_201_CREATED, first.content)
+        existing = RestoreRecord.objects.get(pk=first.data["restore_record_id"])
+        Task.objects.filter(pk=existing.task_id).update(status=Task.Status.SUCCESS)
+        task_count = Task.objects.count()
+        real_idempotency_lookup = restore_service._idempotent_restore_record
+        lookup_count = 0
+
+        def delayed_idempotency_lookup(**kwargs):
+            nonlocal lookup_count
+            lookup_count += 1
+            if lookup_count == 1:
+                return None
+            return real_idempotency_lookup(**kwargs)
+
+        with (
+            patch.object(
+                restore_service,
+                "_idempotent_restore_record",
+                side_effect=delayed_idempotency_lookup,
+            ),
+            patch.object(
+                RestoreRecord.objects,
+                "create",
+                side_effect=IntegrityError("duplicate idempotency key"),
+            ),
+        ):
+            replay = self.client.post(
+                "/api/v1/restore/records/",
+                payload,
+                format="json",
+                **self._headers(),
+            )
+
+        self.assertEqual(replay.status_code, status.HTTP_201_CREATED, replay.content)
+        self.assertEqual(replay.data["restore_record_id"], existing.id)
+        self.assertEqual(str(replay.data["task_uuid"]), str(existing.task_uuid))
+        self.assertEqual(RestoreRecord.objects.count(), 1)
+        self.assertEqual(Task.objects.count(), task_count)
 
     def test_create_manual_restore_record_allows_different_source_restore(self):
         self._active_restore_task(
@@ -2770,6 +2998,39 @@ class RestoreApiTests(TestCase):
 
         self._assert_restore_already_running(run, active_task)
         self.assertFalse(RestoreRecord.objects.exists())
+
+    def test_run_restore_plan_batch_replays_idempotency_key(self):
+        RestorePlan.objects.create(
+            organization_id=self.org.id,
+            **self._plan_payload(),
+        )
+        payload = {
+            "backup_config_id": self.config.id,
+            "target_type": "agent",
+            "target_ref_id": self.target.id,
+            "restore_dir": "/restore/data",
+            "conflict_mode": "overwrite",
+            "source_snapshot_id": self.snapshot.id,
+            "idempotency_key": "plan-batch-replay",
+        }
+
+        first = self.client.post(
+            "/api/v1/restore/plans/run-batch/",
+            payload,
+            format="json",
+            **self._headers(),
+        )
+        second = self.client.post(
+            "/api/v1/restore/plans/run-batch/",
+            payload,
+            format="json",
+            **self._headers(),
+        )
+
+        self.assertEqual(first.status_code, status.HTTP_201_CREATED, first.content)
+        self.assertEqual(second.status_code, status.HTTP_201_CREATED, second.content)
+        self.assertEqual(second.data["restore_record_id"], first.data["restore_record_id"])
+        self.assertEqual(RestoreRecord.objects.count(), 1)
 
     def test_create_manual_restore_record_accepts_partial_snapshot(self):
         self.snapshot.status = BackupSourceSnapshot.Status.PARTIAL

--- a/src/backend/apps/source/services/internal/backup_selectable.py
+++ b/src/backend/apps/source/services/internal/backup_selectable.py
@@ -814,7 +814,14 @@ def _attach_runtime_expansion(
         )
         .filter(_task_resource_filters_for_items(items))
         .filter(
-            Q(status__in=[Task.Status.PENDING, Task.Status.RUNNING])
+            Q(
+                status__in=[
+                    Task.Status.PENDING,
+                    Task.Status.WAITING,
+                    Task.Status.BLOCKED,
+                    Task.Status.RUNNING,
+                ]
+            )
             | Q(created_at__gte=timezone.now() - timedelta(days=30))
         )
         .prefetch_related("resources")
@@ -857,18 +864,27 @@ def _attach_runtime_expansion(
         key = _item_key(item)
         runtime = _empty_runtime()
         backup_tasks_for_source = backup_tasks_by_source.get(key, [])
-        running_backup = [
+        active_backup = [
             task
             for task in backup_tasks_for_source
-            if task.status in (Task.Status.PENDING, Task.Status.RUNNING)
+            if task.status
+            in (
+                Task.Status.PENDING,
+                Task.Status.WAITING,
+                Task.Status.BLOCKED,
+                Task.Status.RUNNING,
+            )
         ]
         from apps.node.services.internal.task_offline_reconcile import (
             product_task_blocks_cleanup,
             task_execution_state,
         )
 
-        running_backup = [
-            task for task in running_backup if product_task_blocks_cleanup(task=task)
+        active_backup = [
+            task
+            for task in active_backup
+            if task.status in (Task.Status.WAITING, Task.Status.BLOCKED)
+            or product_task_blocks_cleanup(task=task)
         ]
         latest_backup_task = (
             backup_tasks_for_source[0] if backup_tasks_for_source else None
@@ -881,12 +897,12 @@ def _attach_runtime_expansion(
                 pk=int(item.get("ref_id") or 0),
                 organization_id=organization_id,
             ).first()
-        if running_backup:
+        if active_backup:
             runtime["backup"]["running"] = True
-            runtime["backup"]["running_count"] = len(running_backup)
-            primary_task = running_backup[0]
+            runtime["backup"]["running_count"] = len(active_backup)
+            primary_task = active_backup[0]
             runtime["backup"]["progress"] = max(
-                _number(task.progress) for task in running_backup
+                _number(task.progress) for task in active_backup
             )
             runtime["backup"]["execution_state"] = task_execution_state(
                 node=execution_node,
@@ -915,7 +931,7 @@ def _attach_runtime_expansion(
                 pass
         runtime["backup"]["total"] = len(backup_tasks_for_source)
         backup_stopping = (
-            not running_backup
+            not active_backup
             and latest_backup_task is not None
             and product_task_is_stopping(
                 organization_id=organization_id, task=latest_backup_task
@@ -923,13 +939,13 @@ def _attach_runtime_expansion(
         )
         runtime["backup"]["stopping"] = backup_stopping
         runtime["backup"]["cancelled"] = (
-            not running_backup
+            not active_backup
             and not backup_stopping
             and latest_backup_task is not None
             and latest_backup_task.status == Task.Status.CANCELLED
         )
         runtime["backup"]["failed"] = (
-            not running_backup
+            not active_backup
             and not backup_stopping
             and latest_backup_task is not None
             and latest_backup_task.status in (Task.Status.FAILED, Task.Status.TIMEOUT)
@@ -1014,9 +1030,7 @@ def _attach_runtime_expansion(
             not running_restore
             and latest_restore_pair is not None
             and latest_restore_pair[1] is not None
-            and product_task_is_stopping(
-                organization_id=organization_id, task=latest_restore_pair[1]
-            )
+            and _restore_task_is_stopping(latest_restore_pair[1])
         )
         runtime["restore"]["stopping"] = restore_stopping
         runtime["restore"]["cancelled"] = (
@@ -1039,6 +1053,14 @@ def _attach_runtime_expansion(
                 or record.created_at
             )
         item["runtime"] = runtime
+
+
+def _restore_task_is_stopping(task: Task) -> bool:
+    # Import lazily to keep the source catalog independent from restore service
+    # initialization while using the restore-specific NodeTask correlation.
+    from apps.restore.services.interface import restore_task_is_stopping
+
+    return restore_task_is_stopping(task=task)
 
 
 def _attach_expansions(

--- a/src/backend/apps/source/services/internal/source_operation_fence.py
+++ b/src/backend/apps/source/services/internal/source_operation_fence.py
@@ -191,6 +191,30 @@ def active_source_restore_task(
             for resource in task.resources.all()
         ):
             return task
+    cancelled_tasks = (
+        Task.objects.filter(
+            organization_id=organization_id,
+            task_type__in=RESTORE_TASK_TYPES,
+            status=Task.Status.CANCELLED,
+        )
+        .prefetch_related("resources")
+        .order_by("created_at", "id")
+    )
+    from apps.restore.services.interface import restore_task_is_stopping
+
+    for task in cancelled_tasks:
+        if not restore_task_is_stopping(task=task):
+            continue
+        if any(
+            resource.resource_type == TaskResource.Type.BACKUP_SOURCE
+            and int(resource.resource_id) == int(source_ref_id)
+            and (
+                resource.resource_subtype == source_type
+                or (source_type == "agent" and not resource.resource_subtype)
+            )
+            for resource in task.resources.all()
+        ):
+            return task
     return None
 
 
@@ -283,6 +307,11 @@ def assert_no_active_restore_for_source(
     )
     if blocker is None:
         return
+    from apps.restore.services.interface import restore_task_is_stopping
+
+    blocker_status = (
+        "stopping" if restore_task_is_stopping(task=blocker) else blocker.status
+    )
     raise AppError(
         code="RESTORE.ALREADY_RUNNING",
         status=409,
@@ -297,7 +326,7 @@ def assert_no_active_restore_for_source(
             "task_id": blocker.id,
             "task_type": blocker.task_type,
             "display_name": blocker.display_name,
-            "status": blocker.status,
+            "status": blocker_status,
             "source_type": source_type,
             "source_ref_id": source_ref_id,
             "created_at": blocker.created_at.isoformat()

--- a/src/backend/apps/source/tests/test_api.py
+++ b/src/backend/apps/source/tests/test_api.py
@@ -1167,6 +1167,46 @@ class SourceResourceApiTests(TestCase):
         self.assertEqual(runtime["progress"], 35)
         self.assertEqual(runtime["latest_task"]["id"], running_task.id)
 
+    def test_backup_selectable_runtime_treats_waiting_and_blocked_backup_as_active(
+        self,
+    ):
+        for index, task_status in enumerate(
+            (Task.Status.WAITING, Task.Status.BLOCKED), start=1
+        ):
+            with self.subTest(task_status=task_status):
+                agent = Node.objects.create(
+                    organization=self.org,
+                    name=f"agent-runtime-{task_status}",
+                    role=Node.Role.AGENT,
+                    status=Node.Status.ACTIVE,
+                    availability=Node.Availability.ONLINE,
+                    ip_address=f"10.0.1.{index}",
+                )
+                task = Task.objects.create(
+                    organization_id=self.org.id,
+                    task_type=Task.Type.BACKUP,
+                    display_name=f"Backup {task_status} source",
+                    status=task_status,
+                    trigger_type=Task.TriggerType.MANUAL,
+                )
+                TaskResource.objects.create(
+                    task=task,
+                    resource_type=TaskResource.Type.BACKUP_SOURCE,
+                    resource_subtype="agent",
+                    resource_id=agent.id,
+                )
+
+                response = self.client.get(
+                    f"/api/v1/source/backup-selectable/?ids=agent:{agent.id}&expand=runtime",
+                    **self._headers(),
+                )
+
+                self.assertEqual(response.status_code, status.HTTP_200_OK)
+                runtime = response.data["results"][0]["runtime"]["backup"]
+                self.assertTrue(runtime["running"])
+                self.assertEqual(runtime["running_count"], 1)
+                self.assertEqual(runtime["latest_task"]["id"], task.id)
+
     def test_backup_selectable_runtime_excludes_insight_workspace_restore(self):
         agent = Node.objects.create(
             organization=self.org,

--- a/src/frontend/src/components/auth/EmailCodeLoginForm.test.ts
+++ b/src/frontend/src/components/auth/EmailCodeLoginForm.test.ts
@@ -3,7 +3,7 @@
 import { flushPromises, mount } from '@vue/test-utils'
 import ElementPlus from 'element-plus'
 import { createI18n } from 'vue-i18n'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { en } from '../../locales/en'
 import EmailCodeLoginForm from './EmailCodeLoginForm.vue'
@@ -41,6 +41,14 @@ function mountForm(initialEmail = '') {
 
 describe('EmailCodeLoginForm', () => {
   beforeEach(() => {
+    vi.spyOn(globalThis.crypto.subtle, 'digest').mockImplementation(async (_algorithm, data) => {
+      const input = new Uint8Array(data as ArrayBuffer)
+      const digest = new Uint8Array(32)
+      input.forEach((byte, index) => {
+        digest[index % digest.length] ^= byte
+      })
+      return digest.buffer
+    })
     sessionStorage.clear()
     mocks.send.mockReset().mockResolvedValue({
       code: '0000',
@@ -54,6 +62,10 @@ describe('EmailCodeLoginForm', () => {
     mocks.notifyError.mockReset()
     mocks.notifySuccess.mockReset()
     mocks.notifyWarning.mockReset()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
   })
 
   it('keeps the requested email editable, shows a success toast, and starts the cooldown', async () => {

--- a/src/frontend/src/composables/useRestoreTaskLifecycle.test.ts
+++ b/src/frontend/src/composables/useRestoreTaskLifecycle.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { RestoreCreateResult } from '../lib/restoreApi'
+import {
+  isExplicitRestoreCancelRejection,
+  runRestoreJobsSequentially,
+  useRestoreTaskLifecycle,
+} from './useRestoreTaskLifecycle'
+
+function restoreResult(taskUuid: string, restoreRecordId = 1): RestoreCreateResult {
+  return {
+    restore_record_id: restoreRecordId,
+    restore_uid: `restore-${restoreRecordId}`,
+    task_id: restoreRecordId,
+    task_uuid: taskUuid,
+    status: 'pending',
+    source_snapshot_id: restoreRecordId,
+    item_count: 1,
+  }
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (error: unknown) => void
+  const promise = new Promise<T>((onResolve, onReject) => {
+    resolve = onResolve
+    reject = onReject
+  })
+  return { promise, resolve, reject }
+}
+
+describe('restore task lifecycle', () => {
+  it('keeps an accepted restore active across missing and stale observations', () => {
+    const lifecycle = useRestoreTaskLifecycle(() => 100)
+    lifecycle.accept('agent:1', restoreResult('task-1'))
+
+    lifecycle.reconcile([])
+    lifecycle.reconcile([{ taskUuid: 'older-task', status: 'success' }])
+
+    expect(lifecycle.get('agent:1')).toMatchObject({
+      taskUuid: 'task-1',
+      phase: 'accepted',
+      acceptedAt: 100,
+    })
+  })
+
+  it('converges only when the same task UUID becomes running or terminal', () => {
+    const lifecycle = useRestoreTaskLifecycle()
+    lifecycle.accept('agent:1', restoreResult('task-1'))
+
+    lifecycle.reconcile([{ taskUuid: 'task-1', status: 'running' }])
+    expect(lifecycle.get('agent:1')?.phase).toBe('running')
+
+    lifecycle.reconcile([{ taskUuid: 'task-1', status: 'success' }])
+    expect(lifecycle.get('agent:1')).toBeNull()
+  })
+
+  it('does not clear stopping when a stale running status arrives', () => {
+    const lifecycle = useRestoreTaskLifecycle()
+    lifecycle.accept('agent:1', restoreResult('task-1'))
+    lifecycle.markStopping('agent:1', 'task-1')
+
+    lifecycle.reconcile([{ taskUuid: 'task-1', status: 'running' }])
+    expect(lifecycle.get('agent:1')?.phase).toBe('stopping')
+
+    lifecycle.reconcile([{ taskUuid: 'task-1', status: 'cancelled', stopping: true }])
+    expect(lifecycle.get('agent:1')?.phase).toBe('stopping')
+
+    lifecycle.reconcile([{ taskUuid: 'task-1', status: 'cancelled', stopping: false }])
+    expect(lifecycle.get('agent:1')).toBeNull()
+  })
+
+  it('treats cancelled without Agent authority as an unknown stopping state', () => {
+    const lifecycle = useRestoreTaskLifecycle()
+    lifecycle.accept('agent:1', restoreResult('task-1'))
+
+    lifecycle.reconcile([{ taskUuid: 'task-1', status: 'cancelled' }])
+
+    expect(lifecycle.get('agent:1')?.phase).toBe('stopping')
+  })
+
+  it('returns to running only after an explicit cancel rejection', () => {
+    const lifecycle = useRestoreTaskLifecycle()
+    lifecycle.accept('agent:1', restoreResult('task-1'))
+    lifecycle.markStopping('agent:1', 'task-1')
+
+    // A timeout or network-unknown path performs no rollback.
+    expect(lifecycle.get('agent:1')?.phase).toBe('stopping')
+
+    lifecycle.rejectStopping('agent:1', 'task-1')
+    expect(lifecycle.get('agent:1')?.phase).toBe('running')
+  })
+
+  it('tracks multiple sources independently and exposes stale accepted work', () => {
+    let now = 100
+    const lifecycle = useRestoreTaskLifecycle(() => now)
+    lifecycle.accept('agent:1', restoreResult('task-1'))
+    now = 200
+    lifecycle.accept('nas:2', restoreResult('task-2', 2))
+    now = 250
+
+    expect(lifecycle.staleEntries(100).map((entry) => entry.sourceId)).toEqual(['agent:1'])
+    lifecycle.reconcile([{ taskUuid: 'task-1', status: 'failed' }])
+    expect(lifecycle.isActive('agent:1')).toBe(false)
+    expect(lifecycle.isActive('nas:2')).toBe(true)
+  })
+})
+
+describe('restore cancel rejection classification', () => {
+  it('rolls back only explicit business rejections', () => {
+    expect(isExplicitRestoreCancelRejection({ status: 409, errorCode: 'RESTORE.NOT_RUNNING' })).toBe(true)
+    expect(isExplicitRestoreCancelRejection({ status: 422, errorCode: 'VALIDATION.ERROR' })).toBe(true)
+    expect(isExplicitRestoreCancelRejection({ status: 500, errorCode: 'SERVER.ERROR' })).toBe(false)
+    expect(isExplicitRestoreCancelRejection({ status: 504, errorCode: 'GATEWAY.TIMEOUT' })).toBe(false)
+    expect(isExplicitRestoreCancelRejection({ status: 0, errorCode: 'NETWORK.UNAVAILABLE' })).toBe(false)
+    expect(isExplicitRestoreCancelRejection({ status: 404, errorCode: 'TASK.NOT_FOUND' })).toBe(false)
+  })
+})
+
+describe('restore submission batches', () => {
+  it('publishes accepted state as soon as each delayed POST resolves', async () => {
+    const first = deferred<RestoreCreateResult>()
+    const second = deferred<RestoreCreateResult>()
+    const accepted = vi.fn()
+    const submission = runRestoreJobsSequentially([
+      { sourceId: 'agent:1', run: () => first.promise },
+      { sourceId: 'agent:2', run: () => second.promise },
+    ], accepted)
+
+    first.resolve(restoreResult('task-1'))
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(accepted).toHaveBeenCalledTimes(1)
+
+    second.resolve(restoreResult('task-2', 2))
+    await expect(submission).resolves.toMatchObject({
+      succeeded: [{ sourceId: 'agent:1' }, { sourceId: 'agent:2' }],
+      failed: [],
+    })
+  })
+
+  it('continues after a failure and reports partial success', async () => {
+    const error = new Error('first failed')
+    const accepted = vi.fn()
+    const result = await runRestoreJobsSequentially([
+      { sourceId: 'agent:1', run: async () => { throw error } },
+      { sourceId: 'agent:2', run: async () => restoreResult('task-2', 2) },
+    ], accepted)
+
+    expect(result.failed).toEqual([{ sourceId: 'agent:1', error }])
+    expect(result.succeeded).toHaveLength(1)
+    expect(accepted).toHaveBeenCalledWith(expect.objectContaining({ sourceId: 'agent:2' }))
+  })
+
+  it('does not submit a second restore after the same source succeeds', async () => {
+    const duplicate = vi.fn(async () => restoreResult('task-duplicate', 2))
+    const result = await runRestoreJobsSequentially([
+      { sourceId: 'agent:1', run: async () => restoreResult('task-1') },
+      { sourceId: 'agent:1', run: duplicate },
+    ], () => undefined)
+
+    expect(duplicate).not.toHaveBeenCalled()
+    expect(result.skippedSourceIds).toEqual(['agent:1'])
+  })
+
+  it('keeps all-failure batches distinguishable from accepted work', async () => {
+    const result = await runRestoreJobsSequentially([
+      { sourceId: 'agent:1', run: async () => { throw new Error('one') } },
+      { sourceId: 'agent:2', run: async () => { throw new Error('two') } },
+    ], () => undefined)
+
+    expect(result.succeeded).toHaveLength(0)
+    expect(result.failed).toHaveLength(2)
+  })
+})

--- a/src/frontend/src/composables/useRestoreTaskLifecycle.ts
+++ b/src/frontend/src/composables/useRestoreTaskLifecycle.ts
@@ -1,0 +1,186 @@
+import { ref } from 'vue'
+import type { RestoreCreateResult } from '../lib/restoreApi'
+
+export type RestoreTaskLifecyclePhase = 'accepted' | 'running' | 'stopping'
+
+export type RestoreTaskLifecycleEntry = {
+  sourceId: string
+  taskUuid: string
+  restoreRecordId: number
+  acceptedAt: number
+  phase: RestoreTaskLifecyclePhase
+}
+
+export type RestoreTaskObservation = {
+  taskUuid: string
+  status: string
+  stopping?: boolean
+}
+
+const ACTIVE_TASK_STATUSES = new Set(['pending', 'queued', 'running', 'stopping'])
+const TERMINAL_TASK_STATUSES = new Set(['success', 'completed', 'done', 'failed', 'cancelled', 'timeout'])
+
+function normalizedTaskStatus(status: string) {
+  return String(status || '').trim().toLowerCase()
+}
+
+export function useRestoreTaskLifecycle(now: () => number = Date.now) {
+  const entries = ref<Record<string, RestoreTaskLifecycleEntry>>({})
+
+  function get(sourceId: string) {
+    return entries.value[sourceId] ?? null
+  }
+
+  function accept(sourceId: string, result: RestoreCreateResult) {
+    entries.value = {
+      ...entries.value,
+      [sourceId]: {
+        sourceId,
+        taskUuid: result.task_uuid,
+        restoreRecordId: result.restore_record_id,
+        acceptedAt: now(),
+        phase: 'accepted',
+      },
+    }
+  }
+
+  function markStopping(sourceId: string, taskUuid: string) {
+    const current = get(sourceId)
+    entries.value = {
+      ...entries.value,
+      [sourceId]: {
+        sourceId,
+        taskUuid,
+        restoreRecordId: current?.taskUuid === taskUuid ? current.restoreRecordId : 0,
+        acceptedAt: current?.taskUuid === taskUuid ? current.acceptedAt : now(),
+        phase: 'stopping',
+      },
+    }
+  }
+
+  function rejectStopping(sourceId: string, taskUuid: string) {
+    const current = get(sourceId)
+    if (!current || current.taskUuid !== taskUuid || current.phase !== 'stopping') return
+    entries.value = {
+      ...entries.value,
+      [sourceId]: { ...current, phase: 'running' },
+    }
+  }
+
+  function clear(sourceId: string, taskUuid?: string) {
+    const current = get(sourceId)
+    if (!current || (taskUuid && current.taskUuid !== taskUuid)) return
+    const next = { ...entries.value }
+    delete next[sourceId]
+    entries.value = next
+  }
+
+  function reconcile(observations: RestoreTaskObservation[]) {
+    if (!observations.length) return
+    const byUuid = new Map(observations.map((item) => [item.taskUuid, {
+      status: normalizedTaskStatus(item.status),
+      stopping: item.stopping,
+    }]))
+    const next = { ...entries.value }
+    let changed = false
+    for (const [sourceId, entry] of Object.entries(entries.value)) {
+      const observation = byUuid.get(entry.taskUuid)
+      if (!observation) continue
+      const { status, stopping } = observation
+      if (status === 'cancelled' && stopping !== false) {
+        if (entry.phase !== 'stopping') {
+          next[sourceId] = { ...entry, phase: 'stopping' }
+          changed = true
+        }
+        continue
+      }
+      if (TERMINAL_TASK_STATUSES.has(status)) {
+        delete next[sourceId]
+        changed = true
+        continue
+      }
+      if (ACTIVE_TASK_STATUSES.has(status) && entry.phase !== 'stopping' && entry.phase !== 'running') {
+        next[sourceId] = { ...entry, phase: 'running' }
+        changed = true
+      }
+    }
+    if (changed) entries.value = next
+  }
+
+  function isActive(sourceId: string) {
+    return get(sourceId) !== null
+  }
+
+  function isStopping(sourceId: string) {
+    return get(sourceId)?.phase === 'stopping'
+  }
+
+  function staleEntries(maxAgeMs: number) {
+    const cutoff = now() - maxAgeMs
+    return Object.values(entries.value).filter((entry) => entry.acceptedAt <= cutoff)
+  }
+
+  return {
+    entries,
+    get,
+    accept,
+    markStopping,
+    rejectStopping,
+    clear,
+    reconcile,
+    isActive,
+    isStopping,
+    staleEntries,
+  }
+}
+
+export function isExplicitRestoreCancelRejection(error: {
+  status?: number
+  errorCode?: string
+}) {
+  const status = Number(error.status || 0)
+  if (![400, 403, 405, 409, 422].includes(status)) return false
+  return error.errorCode !== 'CLIENT.ABORTED'
+}
+
+export type RestoreSubmissionJob = {
+  sourceId: string
+  run: () => Promise<RestoreCreateResult>
+}
+
+export type RestoreSubmissionSuccess = {
+  sourceId: string
+  result: RestoreCreateResult
+}
+
+export type RestoreSubmissionFailure = {
+  sourceId: string
+  error: unknown
+}
+
+export async function runRestoreJobsSequentially(
+  jobs: RestoreSubmissionJob[],
+  onAccepted: (success: RestoreSubmissionSuccess) => void,
+) {
+  const succeeded: RestoreSubmissionSuccess[] = []
+  const failed: RestoreSubmissionFailure[] = []
+  const skippedSourceIds: string[] = []
+  const acceptedSourceIds = new Set<string>()
+
+  for (const job of jobs) {
+    if (acceptedSourceIds.has(job.sourceId)) {
+      skippedSourceIds.push(job.sourceId)
+      continue
+    }
+    try {
+      const success = { sourceId: job.sourceId, result: await job.run() }
+      succeeded.push(success)
+      acceptedSourceIds.add(job.sourceId)
+      onAccepted(success)
+    } catch (error) {
+      failed.push({ sourceId: job.sourceId, error })
+    }
+  }
+
+  return { succeeded, failed, skippedSourceIds }
+}

--- a/src/frontend/src/locales/enProtectionPages.ts
+++ b/src/frontend/src/locales/enProtectionPages.ts
@@ -727,6 +727,9 @@ export const enProtectionPages = {
     msgPickRecoveryDir: 'Select a restore directory.',
     msgRecoverySubmitted: 'Restore task submitted.',
     msgRecoveryPlanSubmitted: 'Restore task submitted from the restore plan.',
+    msgRecoveryPartialSubmitted: '{done} restore task(s) submitted; {failed} failed to submit.',
+    msgRestoreAcceptedRefreshFailed:
+      'The restore request was accepted, but its latest status could not be refreshed. Conflicting restore actions remain disabled while status is reconciled.',
     msgRecoveryPlanUnavailable: 'No runnable restore plan is available right now.',
     recoveryPlanMissingTitle: 'No Restore Plan Configured',
     recoveryPlanMissingDesc: 'No restore plan is configured for this host. This host will be skipped when running restore plans.',

--- a/src/frontend/src/pages/protection/DataProtection.vue
+++ b/src/frontend/src/pages/protection/DataProtection.vue
@@ -73,6 +73,12 @@ import { useDrawerTableMaxHeight } from '../../composables/useDrawerTableMaxHeig
 import { usePageRequestScope } from '../../composables/usePageRequestScope'
 import { useRestoreTargetCatalog } from '../../composables/useRestoreTargetCatalog'
 import {
+  isExplicitRestoreCancelRejection,
+  runRestoreJobsSequentially,
+  useRestoreTaskLifecycle,
+  type RestoreSubmissionJob,
+} from '../../composables/useRestoreTaskLifecycle'
+import {
   useProtectionDemoStore,
   type DemoBackup,
   type DemoPathType,
@@ -142,7 +148,11 @@ import {
   type StorageRepository,
 } from '../../lib/storageRepositoryApi'
 import { storageRepositoryLocation } from '../../lib/storageRepositoryDisplay'
-import { startProtectionBackupTasks, cancelProtectionBackupTask } from '../../lib/protectionBackupTaskApi'
+import {
+  startProtectionBackupTasks,
+  cancelProtectionBackupTask,
+  type StartBackupTaskResultItem,
+} from '../../lib/protectionBackupTaskApi'
 import { backupStartResultMessage } from '../../lib/protectionBackupTaskPresentation'
 import { cancelProtectionRestoreTask } from '../../lib/protectionRestoreTaskApi'
 import {
@@ -183,6 +193,7 @@ import {
   backupTargetValidationFailureSummary,
 } from '../../lib/protectionBackupTargetValidationDetails'
 import type { BackupTargetValidationResult } from '../../lib/protectionBackupTargetValidationApi'
+import { notifySuccess, notifyWarning } from '../../lib/notify'
 import { buildGeneratedNasMountDir, buildGeneratedNasName } from '../../lib/nasMountPath'
 import type { ApiNode } from '../../types/node'
 import Modal from '../../components/Modal.vue'
@@ -326,6 +337,7 @@ function reconcileWizardPendingOps() {
 
 const store = useProtectionDemoStore()
 const pageRequests = usePageRequestScope()
+const restoreTaskLifecycle = useRestoreTaskLifecycle()
 
 function showApiError(err: unknown, fallback?: string) {
   const message = apiErrorMessage(err, fallback)
@@ -419,12 +431,6 @@ async function handleRestoreAlreadyRunning(err: unknown): Promise<boolean> {
     return true
   }
   return true
-}
-
-async function runRestoreJobsSequentially(jobs: Array<() => Promise<unknown>>) {
-  for (const job of jobs) {
-    await job()
-  }
 }
 
 const {
@@ -549,6 +555,7 @@ async function refreshBackupConfigs(
     restoreRecordRows.value = restoreRecords.results
     syncRealBackupConfigsToDemoStore(details, snapshots.results)
     syncRestoreRecordsToFlowTasks(restoreRecords.results, restoreTasks.results)
+    reconcileRestoreTaskLifecycle()
     return true
   } catch (e) {
     if (pageRequests.isAbortError(e)) throw e
@@ -802,6 +809,21 @@ function restoreRecordIsRunning(record: RestoreRecord) {
   return restoreRecordFlowStatus(record, restoreRecordTaskRow(record, restoreTaskRows.value)) === 'running'
 }
 
+function reconcileRestoreTaskLifecycle() {
+  const observations = new Map<string, string>()
+  for (const task of restoreTaskRows.value) {
+    if (task.task_uuid) observations.set(task.task_uuid, task.status)
+  }
+  for (const record of restoreRecordRows.value) {
+    const status = String(record.task_summary?.status || '')
+    if (record.task_uuid && status) observations.set(record.task_uuid, status)
+  }
+  restoreTaskLifecycle.reconcile(
+    [...observations].map(([taskUuid, status]) => ({ taskUuid, status })),
+  )
+  clearFinishedRestoreReconcileTimers()
+}
+
 async function refreshRestoreRecords(sourceId: string, signal?: AbortSignal) {
   const endpoint = parseEndpointUiId(sourceId)
   if (!endpoint || endpoint.type === 'proxy') return
@@ -820,6 +842,7 @@ async function refreshRestoreRecords(sourceId: string, signal?: AbortSignal) {
     ...records.results,
   ]
   syncRestoreRecordsToFlowTasks(restoreRecordRows.value, restoreTaskRows.value)
+  reconcileRestoreTaskLifecycle()
 }
 
 async function refreshStep3RuntimeRows(signal?: AbortSignal) {
@@ -850,6 +873,7 @@ async function refreshStep3RuntimeRows(signal?: AbortSignal) {
   restoreTaskRows.value = expandedTasks(rows, 'restore')
   restoreRecordRows.value = expandedRestoreRecords(rows)
   syncRestoreRecordsToFlowTasks(restoreRecordRows.value, restoreTaskRows.value)
+  reconcileRestoreTaskLifecycle()
 }
 
 function normalizeSourceIdList(ids: string[]) {
@@ -1409,6 +1433,7 @@ function syncExpandedStep3Rows(rows: FlowSourceRow[]) {
   restoreTaskRows.value = expandedTasks(rows, 'restore')
   restoreRecordRows.value = expandedRestoreRecords(rows)
   syncRestoreRecordsToFlowTasks(restoreRecordRows.value, restoreTaskRows.value)
+  reconcileRestoreTaskLifecycle()
   if (configs.length) syncRealBackupConfigsToDemoStore(configs, backupSnapshotRows.value)
   return configs
 }
@@ -1835,9 +1860,15 @@ function startBackupForSource(sourceId: string) {
 function openRecoveryWithBackupIds(backupIds: string[]) {
   if (!backupIds.length) {
     ElMessage.warning({ message: t('protection.backupsPage.msgPickBackupForRecovery'), grouping: true })
-    return
+    return false
   }
-  void restoreTargetCatalog.ensureByIds(backupIds.map(backupSourceHostId).filter(Boolean))
+  const sourceIds = normalizeSourceIdList(backupIds.map(backupSourceHostId).filter(Boolean))
+  if (sourceIds.some((sourceId) => sourceRestoreRuntime(sourceId).running || runtimeStopping(sourceId, 'restore'))) {
+    ElMessage.warning({ message: t('protection.backupsPage.msgRestoreAlreadyRunning'), grouping: true })
+    return false
+  }
+  beginRecoverySubmissionSession()
+  void restoreTargetCatalog.ensureByIds(sourceIds)
   invalidateRecoverySnapshotLists(backupIds)
   recTargetValidationResults.value = {}
   recOpen.value = true
@@ -1867,6 +1898,7 @@ function openRecoveryWithBackupIds(backupIds: string[]) {
   recDirStepInitialized.value = false
   recExpandedRecConfirmHostIds.value = []
   recBatchHostDirPrefix.value = ''
+  return true
 }
 
 function openRecoveryForSource(sourceId: string) {
@@ -1876,19 +1908,10 @@ function openRecoveryForSource(sourceId: string) {
       ? activeFlowSource.value
       : flowSourceRowById(sourceId) ?? flowRowFromSourceId(sourceId)
   if (row) step3SourceSelection.value = [row]
-  if (sourceHasActiveBackup(sourceId)) {
-    ElMessage.info({ message: t('protection.backupsPage.msgBackupActiveBlocksActions'), grouping: true })
-    return
-  }
   openRecoveryWithBackupIds(backupIds)
 }
 
 async function openSnapshotRestore(payload: { snapshotId: number }) {
-  const sourceId = activeFlowSource.value?.id || ''
-  if (sourceId && sourceHasActiveBackup(sourceId)) {
-    ElMessage.info({ message: t('protection.backupsPage.msgBackupActiveBlocksActions'), grouping: true })
-    return
-  }
   await router.push({
     name: 'protection-snapshot-restore',
     params: { snapshotId: String(payload.snapshotId) },
@@ -2724,6 +2747,7 @@ onMounted(async () => {
 
 onUnmounted(() => {
   stopStep3AutoRefresh()
+  stopRestoreTaskReconcileTimers()
   stopUnregisterTaskPolls()
   cancelFlowStepRequests(0)
   cancelFlowStepRequests(1)
@@ -2869,10 +2893,6 @@ function openBackupConfigEditFromStep3(section: BackupConfigEditSection) {
     ElMessage.warning({ message: t('protection.backupsPage.msgSelectConfiguredSourceForStep3'), grouping: true })
     return
   }
-  if (sources.some((source) => sourceHasActiveBackup(source.id))) {
-    ElMessage.info({ message: t('protection.backupsPage.msgBackupActiveBlocksActions'), grouping: true })
-    return
-  }
   if (sources.some((source) => sourceResetRunning(source.id))) {
     ElMessage.warning({ message: t('protection.backupsPage.msgResetBackupConfigRunning'), grouping: true })
     return
@@ -2998,7 +3018,12 @@ function sourceBackupRuntime(sourceId: string) {
     }
   }
   const tasks = tasksForBackupConfigIds(sourceBackupConfigIds(sourceId))
-  const running = tasks.filter((task) => task.status === 'running' || task.status === 'pending')
+  const running = tasks.filter((task) => (
+    task.status === 'running'
+    || task.status === 'pending'
+    || task.status === 'waiting'
+    || task.status === 'blocked'
+  ))
   if (running.length) {
     const progress = Math.max(...running.map((task) => Number(task.progress || 0)))
     const primary = running[0]
@@ -3172,6 +3197,7 @@ function latestRestoreTaskForSource(sourceId: string) {
 
 function sourceRestoreRuntime(sourceId: string) {
   const runtime = runtimeSection(sourceId, 'restore')
+  const trackedTask = restoreTaskLifecycle.get(sourceId)
   const executionState = String(runtime.execution_state || '').trim() || null
   const transferProgress = withExecutionState(
     isTransferProgress(runtime.transfer_progress)
@@ -3202,16 +3228,80 @@ function sourceRestoreRuntime(sourceId: string) {
   }
   if (Object.keys(runtime).length) {
     return {
-      running: runtimeBool(runtime.running),
+      running: runtimeBool(runtime.running) || Boolean(trackedTask),
       failed: runtimeFailed(runtime),
       progress: runtimeNumber(runtime.progress),
-      transferProgress,
+      transferProgress: transferProgress || (trackedTask ? {
+        label_key: 'protection.taskProgress.restore.estimating',
+        phase: 'estimating',
+        show_metrics: false,
+      } : null),
       executionState,
     }
   }
   const latest = latestRestoreRecordForSource(sourceId)
   const failed = latest ? restoreRecordFlowStatus(latest, restoreRecordTaskRow(latest, restoreTaskRows.value)) === 'failed' : false
-  return { running: false, failed, progress: 0, transferProgress: null }
+  return {
+    running: Boolean(trackedTask),
+    failed,
+    progress: 0,
+    transferProgress: trackedTask ? {
+      label_key: 'protection.taskProgress.restore.estimating',
+      phase: 'estimating',
+      show_metrics: false,
+    } : null,
+  }
+}
+
+const RESTORE_TASK_RECONCILE_MS = 15000
+const restoreTaskReconcileTimers = new Map<string, number>()
+
+function clearFinishedRestoreReconcileTimers() {
+  for (const [taskUuid, timer] of restoreTaskReconcileTimers) {
+    const stillTracked = Object.values(restoreTaskLifecycle.entries.value)
+      .some((entry) => entry.taskUuid === taskUuid)
+    if (stillTracked) continue
+    window.clearTimeout(timer)
+    restoreTaskReconcileTimers.delete(taskUuid)
+  }
+}
+
+function stopRestoreTaskReconcileTimers() {
+  for (const timer of restoreTaskReconcileTimers.values()) window.clearTimeout(timer)
+  restoreTaskReconcileTimers.clear()
+}
+
+function scheduleRestoreTaskReconciliation(sourceId: string, taskUuid: string) {
+  const previous = restoreTaskReconcileTimers.get(taskUuid)
+  if (previous) window.clearTimeout(previous)
+  const timer = window.setTimeout(async () => {
+    restoreTaskReconcileTimers.delete(taskUuid)
+    try {
+      const task = await getTask(taskUuid)
+      restoreTaskLifecycle.reconcile([{ taskUuid, status: task.status }])
+      if (task.status === 'cancelled') await refreshRecoverySourceRuntime([sourceId])
+    } catch (error) {
+      // A timeout or network failure is an unknown outcome. Keep the local
+      // fence and retry targeted reconciliation instead of allowing a duplicate.
+      if (toApiError(error).status === 404) {
+        try {
+          const records = await listRestoreRecords({
+            page: 1,
+            page_size: 1,
+            task_uuid: taskUuid,
+          })
+          if (!records.results.length) restoreTaskLifecycle.clear(sourceId, taskUuid)
+          else await refreshRecoverySourceRuntime([sourceId])
+        } catch {
+          // Keep the fence when the fallback authority is also unavailable.
+        }
+      }
+    } finally {
+      const current = restoreTaskLifecycle.get(sourceId)
+      if (current?.taskUuid === taskUuid) scheduleRestoreTaskReconciliation(sourceId, taskUuid)
+    }
+  }, RESTORE_TASK_RECONCILE_MS)
+  restoreTaskReconcileTimers.set(taskUuid, timer)
 }
 
 type SourceStopKind = 'backup' | 'restore'
@@ -3236,7 +3326,12 @@ function readSourceStopOptimistic(sourceId: string, kind: SourceStopKind) {
   return row
 }
 
-function markSourceStopPhase(sourceId: string, kind: SourceStopKind) {
+function markSourceStopPhase(sourceId: string, kind: SourceStopKind, taskUuid = '') {
+  if (kind === 'restore' && taskUuid) {
+    restoreTaskLifecycle.markStopping(sourceId, taskUuid)
+    scheduleRestoreTaskReconciliation(sourceId, taskUuid)
+    return
+  }
   sourceStopOptimistic.value = {
     ...sourceStopOptimistic.value,
     [sourceStopKey(sourceId, kind)]: {
@@ -3248,6 +3343,11 @@ function markSourceStopPhase(sourceId: string, kind: SourceStopKind) {
 }
 
 function clearSourceStopPhase(sourceId: string, kind: SourceStopKind) {
+  if (kind === 'restore') {
+    const current = restoreTaskLifecycle.get(sourceId)
+    if (current) restoreTaskLifecycle.rejectStopping(sourceId, current.taskUuid)
+    return
+  }
   const key = sourceStopKey(sourceId, kind)
   if (!sourceStopOptimistic.value[key]) return
   const next = { ...sourceStopOptimistic.value }
@@ -3258,11 +3358,29 @@ function clearSourceStopPhase(sourceId: string, kind: SourceStopKind) {
 function runtimeStopping(sourceId: string, kind: SourceStopKind) {
   const runtime = runtimeSection(sourceId, kind)
   if (runtimeBool(runtime.stopping)) return true
+  if (kind === 'restore' && restoreTaskLifecycle.isStopping(sourceId)) return true
   return readSourceStopOptimistic(sourceId, kind)?.phase === 'stopping'
 }
 
 function syncSourceStopOptimisticFromRuntime(sourceId: string, kind: SourceStopKind) {
   const runtime = runtimeSection(sourceId, kind)
+  if (kind === 'restore') {
+    const latestTask = recordValue(runtime.latest_task)
+    const taskUuid = String(latestTask.task_uuid || '')
+    const status = String(latestTask.status || '')
+    if (taskUuid && status) {
+      restoreTaskLifecycle.reconcile([{
+        taskUuid,
+        status,
+        stopping: runtimeBool(runtime.stopping),
+      }])
+    }
+    const current = restoreTaskLifecycle.get(sourceId)
+    if (runtimeBool(runtime.stopping) && current && (!taskUuid || taskUuid === current.taskUuid)) {
+      restoreTaskLifecycle.markStopping(sourceId, current.taskUuid)
+    }
+    return
+  }
   if (runtimeBool(runtime.running) || runtimeBool(runtime.cancelled)) {
     clearSourceStopPhase(sourceId, kind)
     return
@@ -3278,6 +3396,8 @@ function runningBackupTaskForSource(sourceId: string) {
 }
 
 function runningRestoreTaskForSource(sourceId: string) {
+  const tracked = restoreTaskLifecycle.get(sourceId)
+  if (tracked?.taskUuid) return { task_uuid: tracked.taskUuid } as TaskRow
   for (const record of restoreRecordsForSource(sourceId)) {
     if (!restoreRecordIsRunning(record)) continue
     const task = restoreRecordTaskRow(record, restoreTaskRows.value)
@@ -3294,8 +3414,8 @@ function sourceBackupCellPhase(sourceId: string): 'running' | 'stopping' | 'term
 }
 
 function sourceRestoreCellPhase(sourceId: string): 'running' | 'stopping' | 'terminal' {
-  if (sourceRestoreRuntime(sourceId).running) return 'running'
   if (runtimeStopping(sourceId, 'restore')) return 'stopping'
+  if (sourceRestoreRuntime(sourceId).running) return 'running'
   return 'terminal'
 }
 
@@ -4522,21 +4642,38 @@ async function submitDisplayNameEdit() {
 }
 
 const startBackupSubmitting = ref(false)
-const backupStartAwaitingRuntimeSourceIds = ref(new Set<string>())
+const backupStartAwaitingRuntimeTasks = ref(new Map<string, Set<string>>())
 
-function markBackupStartAwaitingRuntime(sourceIds: string[]) {
-  if (!sourceIds.length) return
-  backupStartAwaitingRuntimeSourceIds.value = new Set([
-    ...backupStartAwaitingRuntimeSourceIds.value,
-    ...sourceIds,
-  ])
+function markBackupStartAwaitingRuntime(results: StartBackupTaskResultItem[]) {
+  const created = results.filter((item) => item.status === 'created' && item.task_uuid)
+  if (!created.length) return
+  const next = new Map(backupStartAwaitingRuntimeTasks.value)
+  created.forEach((item) => {
+    const sourceId = endpointUiId(item.source_type, item.source_ref_id)
+    const taskUuids = new Set(next.get(sourceId) || [])
+    taskUuids.add(String(item.task_uuid))
+    next.set(sourceId, taskUuids)
+  })
+  backupStartAwaitingRuntimeTasks.value = next
 }
 
 function reconcileBackupStartAwaitingRuntime(refreshedSourceIds: string[]) {
-  if (!refreshedSourceIds.length || backupStartAwaitingRuntimeSourceIds.value.size === 0) return
-  const next = new Set(backupStartAwaitingRuntimeSourceIds.value)
-  refreshedSourceIds.forEach((sourceId) => next.delete(sourceId))
-  backupStartAwaitingRuntimeSourceIds.value = next
+  if (!refreshedSourceIds.length || backupStartAwaitingRuntimeTasks.value.size === 0) return
+  const next = new Map(backupStartAwaitingRuntimeTasks.value)
+  refreshedSourceIds.forEach((sourceId) => {
+    const acceptedTaskUuids = next.get(sourceId)
+    if (!acceptedTaskUuids) return
+    const runtime = runtimeSection(sourceId, 'backup')
+    if (runtimeBool(runtime.running) || runtimeBool(runtime.stopping)) {
+      next.delete(sourceId)
+      return
+    }
+    const latestTaskUuid = String(recordValue(runtime.latest_task).task_uuid || '')
+    if (latestTaskUuid && acceptedTaskUuids.has(latestTaskUuid)) {
+      next.delete(sourceId)
+    }
+  })
+  backupStartAwaitingRuntimeTasks.value = next
 }
 
 function sourceRuntimeHasActiveBackup(sourceId: string) {
@@ -4545,7 +4682,7 @@ function sourceRuntimeHasActiveBackup(sourceId: string) {
 
 function sourceHasActiveBackup(sourceId: string) {
   return startBackupSubmitting.value
-    || backupStartAwaitingRuntimeSourceIds.value.has(sourceId)
+    || backupStartAwaitingRuntimeTasks.value.has(sourceId)
     || sourceRuntimeHasActiveBackup(sourceId)
 }
 
@@ -4574,7 +4711,7 @@ const step3LifecycleActionsEnabled = computed(() => {
   return true
 })
 const step3SelectionEditable = computed(() =>
-  step3LifecycleActionsEnabled.value && !step3SelectionHasActiveBackup.value,
+  step3LifecycleActionsEnabled.value,
 )
 function sourceHasRunningBackupOrRestore(sourceId: string) {
   return sourceHasActiveBackup(sourceId)
@@ -4585,6 +4722,11 @@ function sourceHasRunningBackupOrRestore(sourceId: string) {
 function selectionHasRunningBackupOrRestore(sourceIds: string[]) {
   return sourceIds.some(sourceHasRunningBackupOrRestore)
 }
+
+const step3ResetEnabled = computed(() =>
+  step3SelectionEditable.value
+  && !step3SourceSelection.value.some((row) => sourceHasRunningBackupOrRestore(row.id)),
+)
 
 const step1UnregisterEnabled = computed(() => {
   if (selectedSourceIds.value.length === 0) return false
@@ -4604,7 +4746,9 @@ const step3CanStopBackup = computed(() =>
   step3SourceSelection.value.some((row) => sourceBackupRuntime(row.id).running),
 )
 const step3CanStopRestore = computed(() =>
-  step3SourceSelection.value.some((row) => sourceRestoreRuntime(row.id).running),
+  step3SourceSelection.value.some((row) =>
+    sourceRestoreRuntime(row.id).running && !runtimeStopping(row.id, 'restore'),
+  ),
 )
 const step3StopActionBusy = ref(false)
 const selectedRecoverableSourceRows = computed(() =>
@@ -4612,7 +4756,6 @@ const selectedRecoverableSourceRows = computed(() =>
 )
 const recoveryToolbarEnabled = computed(() => {
   if (selectedRecoverableSourceRows.value.length === 0) return false
-  if (step3SelectionHasActiveBackup.value) return false
   return !selectedRecoverableSourceRows.value.some((row) =>
     sourceRestoreRuntime(row.id).running || runtimeStopping(row.id, 'restore'),
   )
@@ -4634,7 +4777,7 @@ function step3StopBackupConfirmItems(): ProtectionStopConfirmItem[] {
 
 function step3StopRestoreConfirmItems(): ProtectionStopConfirmItem[] {
   return step3SourceSelection.value
-    .filter((row) => sourceRestoreRuntime(row.id).running)
+    .filter((row) => sourceRestoreRuntime(row.id).running && !runtimeStopping(row.id, 'restore'))
     .map((row) => {
       const record = restoreRecordsForSource(row.id).find(restoreRecordIsRunning)
       return {
@@ -4717,22 +4860,44 @@ async function stopSelectedRestoreTasks() {
   }
   step3StopActionBusy.value = true
   let stopped = 0
+  const errors: unknown[] = []
+  const stoppedSourceIds: string[] = []
   try {
-    const targets = step3SourceSelection.value.filter((row) => sourceRestoreRuntime(row.id).running)
+    const targets = step3SourceSelection.value.filter((row) => (
+      sourceRestoreRuntime(row.id).running && !runtimeStopping(row.id, 'restore')
+    ))
     for (const row of targets) {
       const task = runningRestoreTaskForSource(row.id)
       if (!task?.task_uuid) continue
-      markSourceStopPhase(row.id, 'restore')
-      await cancelProtectionRestoreTask(task.task_uuid)
-      stopped += 1
+      markSourceStopPhase(row.id, 'restore', task.task_uuid)
+      try {
+        await cancelProtectionRestoreTask(task.task_uuid)
+        stopped += 1
+        stoppedSourceIds.push(row.id)
+      } catch (error) {
+        errors.push(error)
+        if (isExplicitRestoreCancelRejection(toApiError(error))) {
+          restoreTaskLifecycle.rejectStopping(row.id, task.task_uuid)
+        }
+      }
     }
-    await refreshStep3AfterMoreAction()
-    for (const row of targets) syncSourceStopOptimisticFromRuntime(row.id, 'restore')
     if (stopped > 0) {
-      ElMessage.success({ message: t('protection.backupsPage.msgStopRestoreRequested', { n: stopped }), grouping: true })
+      notifySuccess({
+        message: t('protection.backupsPage.msgStopRestoreRequested', { n: stopped }),
+        dedupeKey: `restore-stop-requested:${stoppedSourceIds.sort().join(',')}`,
+      })
     }
-  } catch (err) {
-    showApiError(err, 'Failed to stop restore task')
+    if (errors.length) showApiError(errors[0], 'Failed to stop restore task')
+    void refreshRecoverySourceRuntime(targets.map((row) => row.id))
+      .then(() => {
+        for (const row of targets) syncSourceStopOptimisticFromRuntime(row.id, 'restore')
+      })
+      .catch(() => {
+        notifyWarning({
+          message: t('protection.backupsPage.msgRestoreAcceptedRefreshFailed'),
+          dedupeKey: 'restore-stop-refresh-failed',
+        })
+      })
   } finally {
     step3StopActionBusy.value = false
   }
@@ -4796,11 +4961,7 @@ async function startSelectedBackupTasks() {
       return
     }
     const result = await startProtectionBackupTasks(startBackupTaskPayloadForSources(runnableSources))
-    markBackupStartAwaitingRuntime(
-      result.results
-        .filter((item) => item.status === 'created')
-        .map((item) => endpointUiId(item.source_type, item.source_ref_id)),
-    )
+    markBackupStartAwaitingRuntime(result.results)
     try {
       await refreshStep3State()
     } catch {
@@ -5700,6 +5861,26 @@ const recSubmitting = ref(false)
 const recTargetValidating = ref(false)
 const recTargetValidationResults = ref<Record<string, BackupTargetValidationResult>>({})
 let recTargetValidationController: AbortController | null = null
+const recoverySubmissionSessionId = ref('')
+
+function beginRecoverySubmissionSession() {
+  recoverySubmissionSessionId.value = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`
+}
+
+function restorePayloadHash(value: unknown) {
+  const text = JSON.stringify(value)
+  let hash = 2166136261
+  for (let index = 0; index < text.length; index += 1) {
+    hash ^= text.charCodeAt(index)
+    hash = Math.imul(hash, 16777619)
+  }
+  return (hash >>> 0).toString(36)
+}
+
+function restoreIdempotencyKey(mode: 'plan' | 'manual', payload: unknown) {
+  if (!recoverySubmissionSessionId.value) beginRecoverySubmissionSession()
+  return `restore-${mode}-${recoverySubmissionSessionId.value}-${restorePayloadHash(payload)}`
+}
 const recBackupIds = ref<string[]>([])
 const recSnapshotMap = ref<Record<string, string>>({})
 const recoverySnapshotDetails = ref(new Map<number, BackupSourceSnapshot>())
@@ -5878,6 +6059,10 @@ async function initializeFixedSnapshotRestore() {
     }
     fixedRestoreSnapshot.value = detail
     const sourceId = endpointUiId(detail.source_type, Number(detail.source_ref_id))
+    await refreshRecoverySourceRuntime([sourceId])
+    if (sourceRestoreRuntime(sourceId).running || runtimeStopping(sourceId, 'restore')) {
+      throw new Error(t('protection.backupsPage.msgRestoreAlreadyRunning'))
+    }
     await restoreTargetCatalog.ensureByIds([sourceId])
     rememberSelectableRows(restoreTargetCatalog.allRecords.value.map(mapBackupSelectableToFlowRow))
 
@@ -5891,7 +6076,9 @@ async function initializeFixedSnapshotRestore() {
     backupSnapshotRows.value = mergeSnapshotListItems(backupSnapshotRows.value, [detail])
     syncRealBackupConfigsToDemoStore([...backupConfigDetailById.value.values()], backupSnapshotRows.value)
     const backupId = realBackupId(config.id)
-    openRecoveryWithBackupIds([backupId])
+    if (!openRecoveryWithBackupIds([backupId])) {
+      throw new Error(t('protection.backupsPage.msgRestoreAlreadyRunning'))
+    }
     mergeRecoverySnapshotDetail(detail)
     const snapshotState = recoverySnapshotListState(`${detail.source_type}:${detail.source_ref_id}`)
     snapshotState.items = mergeSnapshotListItems(snapshotState.items, [detail])
@@ -6192,10 +6379,6 @@ async function openRecovery() {
   if (recoveryOpening.value) return
   if (!step3SourceSelection.value.length) {
     ElMessage.warning({ message: t('protection.backupsPage.msgSelectSourcesToRecover'), grouping: true })
-    return
-  }
-  if (step3SelectionHasActiveBackup.value) {
-    ElMessage.info({ message: t('protection.backupsPage.msgBackupActiveBlocksActions'), grouping: true })
     return
   }
   if (step3SourceSelection.value.some((row) => sourceRestoreRuntime(row.id).running || runtimeStopping(row.id, 'restore'))) {
@@ -9350,7 +9533,7 @@ function buildManualRestorePayload(draft: RecoveryTaskDraft): RestoreRecordCreat
   const firstTargetPath = (items[0] as NonNullable<(typeof items)[number]> | undefined)?.target_path || draft.destPath || ''
   if (!firstTargetPath) return null
   const wholeSnapshot = draft.dirs.every((dir) => dir.scope === 'snapshot')
-  return {
+  const payload: RestoreRecordCreatePayload = {
     source_snapshot_id: snapshotId,
     source_type: sourceEndpoint.type as 'agent' | 'nas',
     source_ref_id: sourceEndpoint.refId,
@@ -9360,8 +9543,9 @@ function buildManualRestorePayload(draft: RecoveryTaskDraft): RestoreRecordCreat
     scope: wholeSnapshot ? 'snapshot' : 'paths',
     conflict_mode: draft.conflictPolicy,
     items: items as RestoreRecordCreatePayload['items'],
-    idempotency_key: `restore-${draft.backupId}-${Date.now()}`,
   }
+  payload.idempotency_key = restoreIdempotencyKey('manual', payload)
+  return payload
 }
 
 function manualRecoveryDraftProblemNames(drafts: RecoveryTaskDraft[]) {
@@ -9379,12 +9563,6 @@ function manualRecoveryDraftProblemNames(drafts: RecoveryTaskDraft[]) {
   return [...names.values()].slice(0, 5).join(', ') + (names.size > 5 ? `, +${names.size - 5}` : '')
 }
 
-function recoverySourceIds() {
-  return [...new Set(recBackupIds.value.map(backupSourceHostId).filter(Boolean))]
-}
-
-const recoveryHasActiveBackup = computed(() => recoverySourceIds().some(sourceHasActiveBackup))
-
 async function refreshRecoverySourceRuntime(sourceIds: string[]) {
   if (!sourceIds.length) return
   const list = await listBackupSelectableSources({
@@ -9394,25 +9572,49 @@ async function refreshRecoverySourceRuntime(sourceIds: string[]) {
     expand: STEP3_EXPAND,
   })
   const rows = list.results.map(mapBackupSelectableToFlowRow)
+  const refreshedById = new Map(rows.map((row) => [row.id, row]))
+  const mergeRows = (current: FlowSourceRow[]) => current.map((row) => refreshedById.get(row.id) || row)
+  backupSelectableRows.value = mergeRows(backupSelectableRows.value)
+  step2SelectableRows.value = mergeRows(step2SelectableRows.value)
+  step3SelectableRows.value = mergeRows(step3SelectableRows.value)
   rememberSelectableRows(rows)
   reconcileBackupStartAwaitingRuntime(rows.map((row) => row.id))
-}
-
-async function recoveryBlockedByActiveBackup() {
-  const sourceIds = recoverySourceIds()
-  if (sourceIds.some(sourceHasActiveBackup)) return true
-  await refreshRecoverySourceRuntime(sourceIds)
-  return sourceIds.some(sourceRuntimeHasActiveBackup)
+  const refreshedSourceIds = new Set(rows.map((row) => row.id))
+  const refreshedTasks = expandedTasks(rows, 'restore')
+  const refreshedTaskUuids = new Set(refreshedTasks.map((task) => task.task_uuid))
+  restoreTaskRows.value = [
+    ...restoreTaskRows.value.filter((task) => !refreshedTaskUuids.has(task.task_uuid)),
+    ...refreshedTasks,
+  ]
+  restoreRecordRows.value = [
+    ...restoreRecordRows.value.filter((record) => (
+      !refreshedSourceIds.has(endpointUiId(record.source_type, record.source_ref_id))
+    )),
+    ...expandedRestoreRecords(rows),
+  ]
+  syncRestoreRecordsToFlowTasks(restoreRecordRows.value, restoreTaskRows.value)
+  const observations = rows.flatMap((row) => {
+    const restoreRuntime = recordValue(recordValue(row.runtime).restore)
+    const task = restoreRuntime.latest_task
+    if (!task || typeof task !== 'object') return []
+    const taskRow = task as TaskRow
+    return taskRow.task_uuid && taskRow.status
+      ? [{
+          taskUuid: taskRow.task_uuid,
+          status: taskRow.status,
+          stopping: runtimeBool(restoreRuntime.stopping),
+        }]
+      : []
+  })
+  restoreTaskLifecycle.reconcile(observations)
+  clearFinishedRestoreReconcileTimers()
 }
 
 async function runRecovery(mode: 'plan' | 'manual' = 'manual') {
   if (recSubmitting.value) return
   recSubmitting.value = true
   try {
-    if (await recoveryBlockedByActiveBackup()) {
-      ElMessage.info({ message: t('protection.backupsPage.msgBackupActiveBlocksActions'), grouping: true })
-      return
-    }
+    let jobs: RestoreSubmissionJob[] = []
     if (mode === 'plan') {
       try {
         await ensureRecoveryPlanSnapshotDefaults()
@@ -9441,17 +9643,23 @@ async function runRecovery(mode: 'plan' | 'manual' = 'manual') {
         ElMessage.warning({ message: t('protection.backupsPage.msgPickSnapshotForRecovery'), grouping: true })
         return
       }
-      await runRestoreJobsSequentially(
-        runnablePlans.map((plan) => () => runRestorePlanBatch({
-          backup_config_id: Number(plan.backupConfigId),
-          target_type: (plan.targetType || 'agent') as RestoreEndpointType,
-          target_ref_id: Number(plan.targetRefId),
-          restore_dir: plan.restoreDir || plan.customSubdir,
-          conflict_mode: plan.conflictPolicy,
-          source_snapshot_id: Number(plan.snapshotId),
-          idempotency_key: `restore-plan-${plan.backupConfigId}-${plan.snapshotId}-${Date.now()}`,
-        })),
-      )
+      jobs = runnablePlans.map((plan) => ({
+        sourceId: backupSourceHostId(plan.backupId),
+        run: () => {
+          const payload = {
+            backup_config_id: Number(plan.backupConfigId),
+            target_type: (plan.targetType || 'agent') as RestoreEndpointType,
+            target_ref_id: Number(plan.targetRefId),
+            restore_dir: plan.restoreDir || plan.customSubdir,
+            conflict_mode: plan.conflictPolicy,
+            source_snapshot_id: Number(plan.snapshotId),
+          }
+          return runRestorePlanBatch({
+            ...payload,
+            idempotency_key: restoreIdempotencyKey('plan', payload),
+          })
+        },
+      }))
     } else {
       const drafts = recoveryTaskDrafts(mode)
       if (!drafts.length) {
@@ -9479,30 +9687,73 @@ async function runRecovery(mode: 'plan' | 'manual' = 'manual') {
         ElMessage.warning({ message: t('protection.backupsPage.msgSnapshotNoDirsAvailable'), grouping: true })
         return
       }
-      await runRestoreJobsSequentially(
-        (payloads as RestoreRecordCreatePayload[]).map((payload) => () => createRestoreRecord(payload)),
-      )
+      jobs = (payloads as RestoreRecordCreatePayload[]).map((payload) => ({
+        sourceId: endpointUiId(payload.source_type, payload.source_ref_id),
+        run: () => createRestoreRecord(payload),
+      }))
     }
+
+    const sourceIds = normalizeSourceIdList(jobs.map((job) => job.sourceId))
+    if (sourceIds.some((sourceId) => sourceRestoreRuntime(sourceId).running || runtimeStopping(sourceId, 'restore'))) {
+      ElMessage.warning({ message: t('protection.backupsPage.msgRestoreAlreadyRunning'), grouping: true })
+      return
+    }
+
+    const outcome = await runRestoreJobsSequentially(jobs, ({ sourceId, result }) => {
+      restoreTaskLifecycle.accept(sourceId, result)
+      scheduleRestoreTaskReconciliation(sourceId, result.task_uuid)
+    })
+
+    if (!outcome.succeeded.length) {
+      const errors = outcome.failed.map((item) => item.error)
+      const error = errors.find((item) => restoreAlreadyRunningMeta(item))
+        || errors.find((item) => toApiError(item).errorCode === BACKUP_ALREADY_RUNNING_CODE)
+        || errors[0]
+      if (!error) return
+      if (await handleRestoreAlreadyRunning(error)) return
+      if (await handleBackupAlreadyRunning(
+        error,
+        () => refreshRecoverySourceRuntime(sourceIds),
+      )) return
+      showApiErrorI18n(error, t('errors.generic.requestFailed'))
+      return
+    }
+
+    const submittedSourceIds = normalizeSourceIdList(outcome.succeeded.map((item) => item.sourceId))
     if (isFixedSnapshotRestore.value) {
       fixedRestoreDirty.value = false
-      ElMessage.success({ message: t('protection.backupsPage.msgRecoverySubmitted'), grouping: true })
-      await leaveFixedRestore()
+      notifySuccess({
+        message: t('protection.backupsPage.msgRecoverySubmitted'),
+        dedupeKey: `restore-submitted:${submittedSourceIds.join(',')}`,
+      })
+      void leaveFixedRestore()
       return
     }
     recOpen.value = false
-    await refreshBackupConfigs()
-    ElMessage.success(
-      mode === 'plan'
-        ? t('protection.backupsPage.msgRecoveryPlanSubmitted')
-        : t('protection.backupsPage.msgRecoverySubmitted'),
-    )
-  } catch (e) {
-    if (await handleRestoreAlreadyRunning(e)) return
-    if (await handleBackupAlreadyRunning(
-      e,
-      () => refreshRecoverySourceRuntime(recoverySourceIds()),
-    )) return
-    showApiErrorI18n(e, t('errors.generic.requestFailed'))
+    if (outcome.failed.length) {
+      notifyWarning({
+        message: t('protection.backupsPage.msgRecoveryPartialSubmitted', {
+          done: outcome.succeeded.length,
+          failed: outcome.failed.length,
+        }),
+        dedupeKey: `restore-partial:${submittedSourceIds.join(',')}`,
+      })
+    } else {
+      notifySuccess({
+        message: mode === 'plan'
+          ? t('protection.backupsPage.msgRecoveryPlanSubmitted')
+          : t('protection.backupsPage.msgRecoverySubmitted'),
+        dedupeKey: `restore-submitted:${submittedSourceIds.join(',')}`,
+      })
+    }
+    void refreshRecoverySourceRuntime(submittedSourceIds).catch(() => {
+      notifyWarning({
+        message: t('protection.backupsPage.msgRestoreAcceptedRefreshFailed'),
+        dedupeKey: `restore-refresh-failed:${submittedSourceIds.join(',')}`,
+      })
+    })
+  } catch (error) {
+    showApiErrorI18n(error, t('errors.generic.requestFailed'))
   } finally {
     recSubmitting.value = false
   }
@@ -9836,9 +10087,7 @@ async function runRecovery(mode: 'plan' | 'manual' = 'manual') {
                 </template>
                 <template v-else>
                   <ElTooltip
-                    :content="step3SelectionHasActiveBackup
-                      ? t('protection.backupsPage.msgBackupActiveBlocksActions')
-                      : t('protection.backupsPage.btnStartBackupCloudHint')"
+                    :content="t('protection.backupsPage.btnStartBackupCloudHint')"
                     placement="bottom"
                     :show-after="300"
                     :hide-after="0"
@@ -9861,9 +10110,7 @@ async function runRecovery(mode: 'plan' | 'manual' = 'manual') {
                     </span>
                   </ElTooltip>
                   <ElTooltip
-                    :content="step3SelectionHasActiveBackup
-                      ? t('protection.backupsPage.msgBackupActiveBlocksActions')
-                      : t('protection.backupsPage.btnRecover')"
+                    :content="t('protection.backupsPage.btnRecover')"
                     placement="bottom"
                     :show-after="300"
                     :hide-after="0"
@@ -9913,9 +10160,6 @@ async function runRecovery(mode: 'plan' | 'manual' = 'manual') {
                         </ElDropdownItem>
                         <ElDropdownItem
                           divided
-                          :title="step3SelectionHasActiveBackup
-                            ? t('protection.backupsPage.msgBackupActiveBlocksActions')
-                            : undefined"
                           :disabled="!step3SelectionEditable"
                           @click="openBackupConfigEditFromStep3('paths')"
                         >
@@ -9928,9 +10172,6 @@ async function runRecovery(mode: 'plan' | 'manual' = 'manual') {
                           </span>
                         </ElDropdownItem>
                         <ElDropdownItem
-                          :title="step3SelectionHasActiveBackup
-                            ? t('protection.backupsPage.msgBackupActiveBlocksActions')
-                            : undefined"
                           :disabled="!step3SelectionEditable"
                           @click="openBackupConfigEditFromStep3('policy')"
                         >
@@ -9943,9 +10184,6 @@ async function runRecovery(mode: 'plan' | 'manual' = 'manual') {
                           </span>
                         </ElDropdownItem>
                         <ElDropdownItem
-                          :title="step3SelectionHasActiveBackup
-                            ? t('protection.backupsPage.msgBackupActiveBlocksActions')
-                            : undefined"
                           :disabled="!step3SelectionEditable"
                           @click="openBackupConfigEditFromStep3('recovery')"
                         >
@@ -9984,10 +10222,7 @@ async function runRecovery(mode: 'plan' | 'manual' = 'manual') {
                         </ElDropdownItem>
                         <ElDropdownItem
                           divided
-                          :title="step3SelectionHasActiveBackup
-                            ? t('protection.backupsPage.msgBackupActiveBlocksActions')
-                            : undefined"
-                          :disabled="!step3SelectionEditable"
+                          :disabled="!step3ResetEnabled"
                           @click="revertSelectedSourcesFromStep3"
                         >
                           <span class="el-dropdown-menu__item-content">
@@ -10000,9 +10235,6 @@ async function runRecovery(mode: 'plan' | 'manual' = 'manual') {
                         </ElDropdownItem>
                         <ElDropdownItem
                           class="el-dropdown-menu__item--danger"
-                          :title="step3SelectionHasActiveBackup
-                            ? t('protection.backupsPage.msgBackupActiveBlocksActions')
-                            : undefined"
                           :disabled="!step3UnregisterEnabled"
                           @click="deleteSelectedSourcesFromStep3"
                         >
@@ -11887,7 +12119,9 @@ async function runRecovery(mode: 'plan' | 'manual' = 'manual') {
           :file-filters="fileFilterById"
           :backup-snapshots="backupSnapshotRows"
           :backup-tasks="flowSourceDetailOpen ? sourceRelatedTaskRows : EMPTY_TASK_ROWS"
-          :restore-blocked-by-backup="activeFlowSource ? sourceHasActiveBackup(activeFlowSource.id) : false"
+          :restore-blocked-by-restore="activeFlowSource
+            ? sourceRestoreRuntime(activeFlowSource.id).running || runtimeStopping(activeFlowSource.id, 'restore')
+            : false"
           @closed="onFlowSourceDetailClosed"
           @start-backup="startBackupForSource"
           @recover="openRecoveryForSource"
@@ -14005,7 +14239,7 @@ async function runRecovery(mode: 'plan' | 'manual' = 'manual') {
                 <ElButton
                   type="primary"
                   class="hfl-btn-with-icon"
-                  :disabled="!selectedRecoveryPlans.length || recoveryHasActiveBackup"
+                  :disabled="!selectedRecoveryPlans.length"
                   :loading="recSubmitting"
                   @click="confirmRecoveryEntry"
                 >
@@ -14055,7 +14289,6 @@ async function runRecovery(mode: 'plan' | 'manual' = 'manual') {
                   v-else
                   type="primary"
                   class="hfl-btn-with-icon"
-                  :disabled="recoveryHasActiveBackup"
                   :loading="recSubmitting"
                   @click="runRecovery"
                 >

--- a/src/frontend/src/pages/protection/DataProtectionStep3MoreActions.test.ts
+++ b/src/frontend/src/pages/protection/DataProtectionStep3MoreActions.test.ts
@@ -28,13 +28,13 @@ describe('backup wizard step 3 More Actions refresh', () => {
     expect(page).not.toContain('const step2PendingCount = computed(() => step2SelectableCount.value)')
   })
 
-  it('blocks conflicting source actions while a selected backup is active', () => {
+  it('keeps duplicate backups fenced while allowing restore/config concurrency', () => {
     const gating = sourceBetween(
       'const startBackupSubmitting',
       'const step3CanStopBackup',
     )
     const startBackup = functionSource('startSelectedBackupTasks', 'flowRowsForSourceIds')
-    const openRecovery = functionSource('openRecovery', 'currentRecBackup')
+    const openRecovery = sourceBetween('async function openRecovery()', 'function currentRecBackup')
     const openRecoveryForSource = functionSource('openRecoveryForSource', 'openSnapshotRestore')
     const editConfig = functionSource('openBackupConfigEditFromStep3', 'onBackupConfigEditPickSelected')
     const resetConfig = functionSource('resetSelectedBackupConfigurations', 'confirmResetBackupConfiguration')
@@ -42,30 +42,29 @@ describe('backup wizard step 3 More Actions refresh', () => {
     const runRecovery = sourceBetween('async function runRecovery', '</script>')
 
     expect(gating).toContain("sourceBackupRuntime(sourceId).running || runtimeStopping(sourceId, 'backup')")
-    expect(gating).toContain('backupStartAwaitingRuntimeSourceIds')
-    expect(gating).toContain('backupStartAwaitingRuntimeSourceIds.value.has(sourceId)')
+    expect(gating).toContain('backupStartAwaitingRuntimeTasks')
+    expect(gating).toContain('backupStartAwaitingRuntimeTasks.value.has(sourceId)')
     expect(gating).toContain('const step3SelectionHasActiveBackup = computed')
     expect(gating).toContain('if (step3SelectionHasActiveBackup.value) return false')
-    expect(gating).toContain('step3LifecycleActionsEnabled.value && !step3SelectionHasActiveBackup.value')
+    expect(gating).toContain('step3LifecycleActionsEnabled.value,')
     expect(gating).toContain("|| runtimeStopping(sourceId, 'restore')")
     expect(startBackup).toContain('sources.some((source) => sourceHasActiveBackup(source.id))')
     expect(startBackup).toContain('sources.some((source) => sourceRuntimeHasActiveBackup(source.id))')
-    expect(openRecovery).toContain('if (step3SelectionHasActiveBackup.value)')
-    expect(openRecoveryForSource).toContain('if (sourceHasActiveBackup(sourceId))')
-    expect(editConfig).toContain('sources.some((source) => sourceHasActiveBackup(source.id))')
+    expect(openRecovery).not.toContain('if (step3SelectionHasActiveBackup.value)')
+    expect(openRecoveryForSource).not.toContain('if (sourceHasActiveBackup(sourceId))')
+    expect(editConfig).not.toContain('sources.some((source) => sourceHasActiveBackup(source.id))')
+    expect(gating).toContain('const step3ResetEnabled = computed')
     expect(resetConfig).toContain('sources.some((source) => sourceHasActiveBackup(source.id))')
     expect(confirmReset).toContain('await handleBackupAlreadyRunning(')
     expect(confirmReset).not.toContain('void refreshStep3AfterMoreAction')
-    expect(startBackup).toContain(".filter((item) => item.status === 'created')")
+    expect(startBackup).toContain('markBackupStartAwaitingRuntime(result.results)')
     expect(startBackup).toContain('markBackupStartAwaitingRuntime')
     expect(startBackup).toContain("t('protection.backupsPage.msgStartBackupAcceptedRefreshFailed')")
-    expect(runRecovery).toContain('await recoveryBlockedByActiveBackup()')
     expect(runRecovery).toContain('await handleBackupAlreadyRunning(')
-    expect(runRecovery).toContain('refreshRecoverySourceRuntime(recoverySourceIds())')
+    expect(runRecovery).toContain('refreshRecoverySourceRuntime(sourceIds)')
     expect(page).toContain('async function refreshRecoverySourceRuntime(sourceIds: string[])')
-    expect(page).toContain('const recoveryHasActiveBackup = computed')
-    expect(page).toContain(':disabled="!selectedRecoveryPlans.length || recoveryHasActiveBackup"')
-    expect(page).toContain(':disabled="recoveryHasActiveBackup"')
+    expect(page).not.toContain('const recoveryHasActiveBackup = computed')
+    expect(page).not.toContain('recoveryBlockedByActiveBackup')
     expect(page).toContain('expand: STEP3_EXPAND')
     expect(page).toContain("t('protection.backupsPage.msgBackupActiveBlocksActions')")
     expect(protectionLocale).toContain("msgBackupActiveBlocksActions:")
@@ -90,6 +89,9 @@ describe('backup wizard step 3 More Actions refresh', () => {
     expect(loader).toContain('reconcileBackupStartAwaitingRuntime(rows.map((row) => row.id))')
     expect(gating).toContain('function markBackupStartAwaitingRuntime')
     expect(gating).toContain('function reconcileBackupStartAwaitingRuntime')
+    expect(gating).toContain('runtimeBool(runtime.running) || runtimeBool(runtime.stopping)')
+    expect(gating).toContain('acceptedTaskUuids.has(latestTaskUuid)')
+    expect(gating).not.toContain('refreshedSourceIds.forEach((sourceId) => next.delete(sourceId))')
   })
 
   it('disables policy-step detail popovers while a configuration selector is open', () => {
@@ -221,14 +223,57 @@ describe('backup wizard step 3 More Actions refresh', () => {
     expect(handler.indexOf('enterStartBackupStep')).toBeLessThan(handler.indexOf('reconcileCreatedBackupConfigs'))
   })
 
-  it('reloads the full step 3 list state after stopping backup or restore tasks', () => {
+  it('keeps backup refresh synchronous and restore refresh in the background after stopping', () => {
     const stopBackup = functionSource('stopSelectedBackupTasks', 'stopSelectedRestoreTasks')
     const stopRestore = functionSource('stopSelectedRestoreTasks', 'onBackupTaskSelection')
 
     expect(stopBackup).toContain('await refreshStep3AfterMoreAction()')
-    expect(stopRestore).toContain('await refreshStep3AfterMoreAction()')
+    expect(stopRestore).toContain('void refreshRecoverySourceRuntime(')
+    expect(stopRestore).not.toContain('await refreshRecoverySourceRuntime(')
+    expect(stopRestore.indexOf('notifySuccess({')).toBeLessThan(stopRestore.indexOf('void refreshRecoverySourceRuntime('))
     expect(stopBackup).not.toContain('await refreshStep3State()')
     expect(stopRestore).not.toContain('await refreshStep3State()')
+  })
+
+  it('publishes restore acceptance before background reconciliation', () => {
+    const runRecovery = sourceBetween('async function runRecovery', '</script>')
+    const runtime = functionSource('sourceRestoreRuntime', 'clearFinishedRestoreReconcileTimers')
+    const openRecovery = functionSource('openRecoveryWithBackupIds', 'openRecoveryForSource')
+
+    expect(runRecovery).toContain('restoreTaskLifecycle.accept(sourceId, result)')
+    expect(runRecovery).toContain('scheduleRestoreTaskReconciliation(sourceId, result.task_uuid)')
+    expect(runRecovery).toContain('recOpen.value = false')
+    expect(runRecovery).toContain('void refreshRecoverySourceRuntime(submittedSourceIds)')
+    expect(runRecovery).not.toContain('await refreshBackupConfigs()')
+    expect(runRecovery.indexOf('recOpen.value = false')).toBeLessThan(
+      runRecovery.indexOf('void refreshRecoverySourceRuntime(submittedSourceIds)'),
+    )
+    expect(runtime).toContain('running: runtimeBool(runtime.running) || Boolean(trackedTask)')
+    expect(openRecovery).toContain("runtimeStopping(sourceId, 'restore')")
+  })
+
+  it('keeps restore stopping fenced until the matching task reaches a terminal status', () => {
+    const stopRestore = functionSource('stopSelectedRestoreTasks', 'onBackupTaskSelection')
+    const syncStop = functionSource('syncSourceStopOptimisticFromRuntime', 'runningBackupTaskForSource')
+    const restoreBranch = syncStop.slice(0, syncStop.indexOf("  if (runtimeBool(runtime.running)"))
+
+    expect(stopRestore).toContain("markSourceStopPhase(row.id, 'restore', task.task_uuid)")
+    expect(stopRestore).toContain('restoreTaskLifecycle.rejectStopping(row.id, task.task_uuid)')
+    expect(stopRestore).toContain('if (isExplicitRestoreCancelRejection(toApiError(error)))')
+    expect(syncStop).toContain('restoreTaskLifecycle.reconcile([{')
+    expect(syncStop).toContain('stopping: runtimeBool(runtime.stopping)')
+    expect(restoreBranch).not.toContain("runtimeBool(runtime.running) || runtimeBool(runtime.cancelled)")
+  })
+
+  it('reuses stable restore idempotency keys for the same wizard request', () => {
+    const runRecovery = sourceBetween('async function runRecovery', '</script>')
+    const manualPayload = functionSource('buildManualRestorePayload', 'manualRecoveryDraftProblemNames')
+
+    expect(page).toContain("function restoreIdempotencyKey(mode: 'plan' | 'manual', payload: unknown)")
+    expect(runRecovery).toContain("idempotency_key: restoreIdempotencyKey('plan', payload)")
+    expect(manualPayload).toContain("restoreIdempotencyKey('manual', payload)")
+    expect(runRecovery).not.toContain('idempotency_key: `restore-plan-')
+    expect(manualPayload).not.toContain('Date.now()')
   })
 
   it('reloads and clears stale selection after reset or unregister succeeds', () => {

--- a/src/frontend/src/pages/protection/components/FlowBackupSourceDetailDrawer.test.ts
+++ b/src/frontend/src/pages/protection/components/FlowBackupSourceDetailDrawer.test.ts
@@ -127,15 +127,16 @@ describe('FlowBackupSourceDetailDrawer snapshot expansion state', () => {
     expect(loader).toContain('started_to: startedRange.to')
   })
 
-  it('blocks snapshot restore actions while the source backup is active', () => {
+  it('allows snapshot restore actions while the source backup is active', () => {
     const restoreGuard = sourceBetween(
       'function canRestoreSnapshot(row: BackupSourceSnapshot)',
       'function onSnapshotExpandChange',
     )
 
-    expect(drawer).toContain('restoreBlockedByBackup?: boolean')
-    expect(restoreGuard).toContain('!props.restoreBlockedByBackup && isSnapshotRestorable(row)')
-    expect(restoreGuard).toContain("t('protection.backupsPage.msgBackupActiveBlocksActions')")
+    expect(drawer).not.toContain('restoreBlockedByBackup?: boolean')
+    expect(drawer).toContain('restoreBlockedByRestore?: boolean')
+    expect(restoreGuard).toContain('!props.restoreBlockedByRestore && isSnapshotRestorable(row)')
+    expect(restoreGuard).not.toContain('restoreBlockedByBackup')
   })
 
   it('shows storage metrics without the reference explanation header', () => {

--- a/src/frontend/src/pages/protection/components/FlowBackupSourceDetailDrawer.vue
+++ b/src/frontend/src/pages/protection/components/FlowBackupSourceDetailDrawer.vue
@@ -200,7 +200,7 @@ const props = withDefaults(
     fileFilters?: Map<number, FileFilterRule>
     backupSnapshots?: BackupSourceSnapshot[]
     backupTasks?: TaskRow[]
-    restoreBlockedByBackup?: boolean
+    restoreBlockedByRestore?: boolean
   }>(),
   {
     drawerSize: '720px',
@@ -218,7 +218,7 @@ const props = withDefaults(
     fileFilters: () => new Map<number, FileFilterRule>(),
     backupSnapshots: () => [],
     backupTasks: () => [],
-    restoreBlockedByBackup: false,
+    restoreBlockedByRestore: false,
   },
 )
 
@@ -2017,12 +2017,12 @@ function toggleSnapshot(row: BackupSourceSnapshot) {
 }
 
 function canRestoreSnapshot(row: BackupSourceSnapshot) {
-  return !props.restoreBlockedByBackup && isSnapshotRestorable(row)
+  return !props.restoreBlockedByRestore && isSnapshotRestorable(row)
 }
 
 function snapshotRestoreDisabledReason(row: BackupSourceSnapshot) {
-  if (props.restoreBlockedByBackup) {
-    return t('protection.backupsPage.msgBackupActiveBlocksActions')
+  if (props.restoreBlockedByRestore) {
+    return t('protection.backupsPage.msgRestoreAlreadyRunning')
   }
   const status = String(row.status || '').toLowerCase()
   if (status !== 'available' && status !== 'partial') {


### PR DESCRIPTION
## Summary
- Allow backup and restore execution to overlap while preserving duplicate, stopping, and source-control fences
- Snapshot backup and restore inputs so active tasks are unaffected by later configuration edits
- Harden restore cancellation, idempotent submission, runtime reconciliation, and frontend action state

Closes #808

## Testing
- Backend focused and compatibility suites: 220 passed
- Frontend protection/lifecycle suites: 100 passed
- `npm run build`
- ESLint
- Python compileall
- Django migration check
- `git diff --check`