### PR TITLE
fix: harden macOS Agent lifecycle and projections

### DIFF
--- a/src/agent/internal/platform/disk/aggregate.go
+++ b/src/agent/internal/platform/disk/aggregate.go
@@ -120,7 +120,7 @@ func summarizeStoragePartitions(parts []disk.PartitionStat, readUsage usageReade
 			key = networkStorageKey(part.Fstype, device, mountPoint)
 			target = network
 		} else {
-			key = localStorageKey(localStorageIdentity(mountPoint, device), mountPoint)
+			key = localStorageKey(localStorageIdentity(part.Fstype, mountPoint, device), mountPoint)
 		}
 		if key == "" {
 			continue
@@ -262,6 +262,13 @@ func isSystemOnlyMount(mountPoint string) bool {
 		return false
 	}
 	clean := filepath.Clean(mountPoint)
+	if runtime.GOOS == "darwin" && strings.HasPrefix(clean, "/System/Volumes/") {
+		// Data is the user-visible writable APFS volume. The remaining mounts
+		// are macOS implementation/reserved volumes and are not independent
+		// host capacity available to HyperFileLens.
+		return clean != "/System/Volumes/Data" &&
+			!strings.HasPrefix(clean, "/System/Volumes/Data/")
+	}
 	return clean == "/boot" || strings.HasPrefix(clean, "/boot/")
 }
 

--- a/src/agent/internal/platform/disk/aggregate_test.go
+++ b/src/agent/internal/platform/disk/aggregate_test.go
@@ -30,6 +30,14 @@ func TestNormalizeMountpoint(t *testing.T) {
 	if got := normalizeMountpoint("/"); got != "/" {
 		t.Fatalf("normalizeMountpoint(\"/\") = %q, want \"/\"", got)
 	}
+	if runtime.GOOS == "darwin" {
+		if !isSystemOnlyMount("/System/Volumes/Preboot") {
+			t.Fatal("Darwin Preboot volume must not count as host capacity")
+		}
+		if isSystemOnlyMount("/System/Volumes/Data") {
+			t.Fatal("Darwin Data volume must remain eligible for host capacity")
+		}
+	}
 }
 
 func TestHostStorageUsage(t *testing.T) {
@@ -111,6 +119,34 @@ func TestSummarizeStoragePartitionsDeduplicatesLocalBindMountsByDevice(t *testin
 	}
 	if len(inventory.LocalPools[0].MountPoints) != 2 {
 		t.Fatalf("local mount count = %d, want 2", len(inventory.LocalPools[0].MountPoints))
+	}
+}
+
+func TestSummarizeStoragePartitionsDeduplicatesDarwinAPFSVolumes(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("APFS device identity is Darwin-specific")
+	}
+	parts := []disk.PartitionStat{
+		{Device: "/dev/disk3s1s1", Mountpoint: "/", Fstype: "apfs"},
+		{Device: "/dev/disk3s2", Mountpoint: "/System/Volumes/Preboot", Fstype: "apfs"},
+		{Device: "/dev/disk3s5", Mountpoint: "/System/Volumes/Data", Fstype: "apfs"},
+		{Device: "/dev/disk3s6", Mountpoint: "/System/Volumes/VM", Fstype: "apfs"},
+	}
+	inventory := summarizeStoragePartitions(parts, func(string) (*disk.UsageStat, error) {
+		return &disk.UsageStat{Total: 245, Used: 212, Free: 33}, nil
+	})
+	if len(inventory.LocalPools) != 1 {
+		t.Fatalf("local pool count = %d, want 1: %#v", len(inventory.LocalPools), inventory.LocalPools)
+	}
+	pool := inventory.LocalPools[0]
+	if pool.Key != "local:device:/dev/disk3" {
+		t.Fatalf("APFS pool key = %q, want local:device:/dev/disk3", pool.Key)
+	}
+	if len(pool.MountPoints) != 2 {
+		t.Fatalf("APFS user-visible mount count = %d, want 2", len(pool.MountPoints))
+	}
+	if pool.TotalBytes != 245 || pool.UsedBytes != 212 || pool.FreeBytes != 33 {
+		t.Fatalf("APFS capacity must be counted once: %#v", pool)
 	}
 }
 

--- a/src/agent/internal/platform/disk/remote_mount_unix.go
+++ b/src/agent/internal/platform/disk/remote_mount_unix.go
@@ -2,7 +2,13 @@
 
 package disk
 
-import "github.com/shirou/gopsutil/v4/disk"
+import (
+	"regexp"
+	"runtime"
+	"strings"
+
+	"github.com/shirou/gopsutil/v4/disk"
+)
 
 func localStoragePartitions() ([]disk.PartitionStat, error) {
 	return disk.Partitions(true)
@@ -16,6 +22,16 @@ func remoteStorageDevice(_ string, device string) string {
 	return device
 }
 
-func localStorageIdentity(_ string, device string) string {
+var darwinAPFSVolumeDevice = regexp.MustCompile(`^(/dev/disk[0-9]+)s[0-9]+(?:s[0-9]+)*$`)
+
+func localStorageIdentity(fsType string, _ string, device string) string {
+	// APFS exposes each system/data/preboot/VM volume as a separate device
+	// path, although they share one container and one capacity snapshot. Use
+	// the parent disk as the identity so the container is counted once.
+	if runtime.GOOS == "darwin" && strings.EqualFold(strings.TrimSpace(fsType), "apfs") {
+		if match := darwinAPFSVolumeDevice.FindStringSubmatch(strings.TrimSpace(device)); len(match) == 2 {
+			return match[1]
+		}
+	}
 	return device
 }

--- a/src/agent/internal/platform/disk/remote_mount_windows.go
+++ b/src/agent/internal/platform/disk/remote_mount_windows.go
@@ -184,7 +184,7 @@ func remoteStorageDevice(mountPoint string, device string) string {
 	return device
 }
 
-func localStorageIdentity(mountPoint string, device string) string {
+func localStorageIdentity(_ string, mountPoint string, device string) string {
 	clean := strings.TrimSpace(strings.ReplaceAll(mountPoint, "/", `\`))
 	if clean == "" {
 		return device

--- a/src/agent/internal/platform/install/detached_run_unix.go
+++ b/src/agent/internal/platform/install/detached_run_unix.go
@@ -4,7 +4,9 @@ package install
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"syscall"
@@ -30,7 +32,7 @@ func startDetachedShellScript(
 		}
 	}
 	if runtime.GOOS == "darwin" {
-		return startDarwinDetachedScript(scriptPath, log)
+		return startDarwinDetachedScript(scriptPath, userInstall, log)
 	}
 	return startSetsidScript(scriptPath, log)
 }
@@ -39,29 +41,91 @@ func shellSingleQuote(value string) string {
 	return "'" + strings.ReplaceAll(value, "'", "'\\''") + "'"
 }
 
-func startDarwinDetachedScript(scriptPath string, log func(string)) error {
-	// launchctl bootout can terminate descendants of the LaunchDaemon job; nohup+background
-	// detaches before install.sh stop runs.
-	cmd := exec.Command(
-		"bash",
-		"-c",
-		fmt.Sprintf("nohup bash %s </dev/null >/dev/null 2>&1 &", shellSingleQuote(scriptPath)),
-	)
-	if err := cmd.Start(); err != nil {
-		if log != nil {
-			log(fmt.Sprintf("failed to start detached script: %v", err))
+type darwinLaunchdJob struct {
+	domain    string
+	label     string
+	plistDir  string
+	plistPath string
+	dirMode   os.FileMode
+	fileMode  os.FileMode
+}
+
+func startDarwinDetachedScript(scriptPath string, userInstall bool, log func(string)) error {
+	home := ""
+	if userInstall {
+		var err error
+		home, err = os.UserHomeDir()
+		if err != nil {
+			return fmt.Errorf("resolve user home for detached script: %w", err)
 		}
-		return fmt.Errorf("start detached script: %w", err)
 	}
-	go func() {
-		err := cmd.Wait()
+	job := newDarwinLaunchdJob(userInstall, os.Geteuid(), home, time.Now().UnixNano())
+	if err := os.MkdirAll(job.plistDir, job.dirMode); err != nil {
+		return fmt.Errorf("create detached launchd directory: %w", err)
+	}
+	plist := darwinLaunchdPlist(job, scriptPath)
+	if err := os.WriteFile(job.plistPath, []byte(plist), job.fileMode); err != nil {
+		return fmt.Errorf("write detached launchd plist: %w", err)
+	}
+	cmd := exec.Command("launchctl", darwinLaunchctlBootstrapArgs(job)...)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		_ = os.Remove(job.plistPath)
 		if log != nil {
-			if err != nil {
-				log(fmt.Sprintf("detached launcher exited with error: %v", err))
-			}
+			log(fmt.Sprintf("launchctl bootstrap failed: %v (%s)", err, strings.TrimSpace(string(out))))
 		}
-	}()
+		return fmt.Errorf("launchctl bootstrap: %w", err)
+	}
+	if log != nil {
+		log(fmt.Sprintf("started independent launchd job %s in %s", job.label, job.domain))
+	}
 	return nil
+}
+
+func darwinLaunchctlBootstrapArgs(job darwinLaunchdJob) []string {
+	return []string{"bootstrap", job.domain, job.plistPath}
+}
+
+func newDarwinLaunchdJob(userInstall bool, uid int, home string, nonce int64) darwinLaunchdJob {
+	job := darwinLaunchdJob{
+		domain:   "system",
+		label:    fmt.Sprintf("com.hyperfilelens.lifecycle-%d", nonce),
+		plistDir: "/Library/LaunchDaemons",
+		dirMode:  0o755,
+		fileMode: 0o644,
+	}
+	if userInstall {
+		job.domain = fmt.Sprintf("gui/%d", uid)
+		job.plistDir = filepath.Join(home, "Library", "LaunchAgents")
+		job.dirMode = 0o700
+		job.fileMode = 0o600
+	}
+	job.plistPath = filepath.Join(job.plistDir, job.label+".plist")
+	return job
+}
+
+func darwinLaunchdPlist(job darwinLaunchdJob, scriptPath string) string {
+	// Run the lifecycle script in an independent launchd job. nohup only
+	// detaches from a terminal; it does not survive bootout of the parent job.
+	// Remove the plist before bootout because bootout terminates this wrapper.
+	command := fmt.Sprintf("/bin/bash %s; rc=$?; rm -f %s; launchctl bootout %s >/dev/null 2>&1 || true; exit $rc",
+		shellSingleQuote(scriptPath), shellSingleQuote(job.plistPath), shellSingleQuote(job.domain+"/"+job.label))
+	return fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+<key>Label</key><string>%s</string>
+<key>ProgramArguments</key><array><string>/bin/bash</string><string>-c</string><string>%s</string></array>
+<key>RunAtLoad</key><true/>
+<key>KeepAlive</key><false/>
+</dict></plist>
+`, plistXML(job.label), plistXML(command))
+}
+
+func plistXML(value string) string {
+	value = strings.ReplaceAll(value, "&", "&amp;")
+	value = strings.ReplaceAll(value, "<", "&lt;")
+	value = strings.ReplaceAll(value, ">", "&gt;")
+	value = strings.ReplaceAll(value, "\"", "&quot;")
+	return value
 }
 
 func startLinuxTransientScript(

--- a/src/agent/internal/platform/install/detached_run_unix_test.go
+++ b/src/agent/internal/platform/install/detached_run_unix_test.go
@@ -3,6 +3,8 @@
 package install
 
 import (
+	"encoding/xml"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -10,6 +12,64 @@ import (
 	"strings"
 	"testing"
 )
+
+func TestDarwinUserLaunchdJobPreservesUserDomainAndPermissions(t *testing.T) {
+	job := newDarwinLaunchdJob(true, 501, "/Users/ghw", 123)
+	if job.domain != "gui/501" {
+		t.Fatalf("domain = %q, want gui/501", job.domain)
+	}
+	wantPath := "/Users/ghw/Library/LaunchAgents/com.hyperfilelens.lifecycle-123.plist"
+	if job.plistPath != wantPath {
+		t.Fatalf("plistPath = %q, want %q", job.plistPath, wantPath)
+	}
+	if job.dirMode != 0o700 || job.fileMode != 0o600 {
+		t.Fatalf("user modes = %o/%o, want 700/600", job.dirMode, job.fileMode)
+	}
+	wantArgs := []string{"bootstrap", "gui/501", wantPath}
+	if args := darwinLaunchctlBootstrapArgs(job); !slices.Equal(args, wantArgs) {
+		t.Fatalf("launchctl args = %q, want %q", args, wantArgs)
+	}
+}
+
+func TestDarwinSystemLaunchdJobUsesSystemDomain(t *testing.T) {
+	job := newDarwinLaunchdJob(false, 501, "/Users/ignored", 456)
+	if job.domain != "system" {
+		t.Fatalf("domain = %q, want system", job.domain)
+	}
+	if job.plistPath != "/Library/LaunchDaemons/com.hyperfilelens.lifecycle-456.plist" {
+		t.Fatalf("unexpected plistPath: %q", job.plistPath)
+	}
+	if job.dirMode != 0o755 || job.fileMode != 0o644 {
+		t.Fatalf("system modes = %o/%o, want 755/644", job.dirMode, job.fileMode)
+	}
+}
+
+func TestDarwinLaunchdPlistIsValidAndDoesNotChangeUser(t *testing.T) {
+	job := newDarwinLaunchdJob(true, 501, "/Users/ghw", 123)
+	plist := darwinLaunchdPlist(job, "/tmp/upgrade & uninstall's runner.sh")
+	decoder := xml.NewDecoder(strings.NewReader(plist))
+	for {
+		if _, err := decoder.Token(); err != nil {
+			if err == io.EOF {
+				break
+			}
+			t.Fatalf("invalid plist XML: %v\n%s", err, plist)
+		}
+	}
+	for _, expected := range []string{
+		"<string>com.hyperfilelens.lifecycle-123</string>",
+		"launchctl bootout 'gui/501/com.hyperfilelens.lifecycle-123'",
+		"rm -f '/Users/ghw/Library/LaunchAgents/com.hyperfilelens.lifecycle-123.plist'",
+		"/tmp/upgrade &amp; uninstall'\\''s runner.sh",
+	} {
+		if !strings.Contains(plist, expected) {
+			t.Fatalf("launchd plist missing %q:\n%s", expected, plist)
+		}
+	}
+	if strings.Contains(plist, "<key>UserName</key>") {
+		t.Fatal("user lifecycle job must inherit its gui domain identity, not override UserName")
+	}
+}
 
 func TestShellSingleQuote(t *testing.T) {
 	got := shellSingleQuote("/var/lib/hyperfilelens-agent/lifecycle/upgrade/run-upgrade.sh")

--- a/src/agent/internal/platform/install/local_uninstall_unix.go
+++ b/src/agent/internal/platform/install/local_uninstall_unix.go
@@ -313,8 +313,10 @@ report_uninstall_completion() {
     failure_items+=('{"code":"detached_uninstall_failed","detail":"Detached uninstall exited before all cleanup steps completed."}')
     retained_items+=('"agent_installation_or_managed_mounts"')
   fi
-  failures="[$(IFS=,; echo "${failure_items[*]}")]"
-  retained="[$(IFS=,; echo "${retained_items[*]}")]"
+  # Bash 3.2 with set -u treats expansion of an empty local array as an
+  # unbound variable. Preserve valid empty JSON arrays in that case.
+  failures="[$(IFS=,; echo "${failure_items[*]-}")]"
+  retained="[$(IFS=,; echo "${retained_items[*]-}")]"
   [[ "$rc" -eq 0 && "$CLEANUP_FAILED" -eq 0 ]] || {
     complete="false"
   }

--- a/src/agent/internal/platform/install/local_uninstall_unix_test.go
+++ b/src/agent/internal/platform/install/local_uninstall_unix_test.go
@@ -75,6 +75,11 @@ func TestWriteUnixUninstallScriptIncludesLogFile(t *testing.T) {
 			t.Fatalf("script should report structured cleanup residue %q:\n%s", want, body)
 		}
 	}
+	for _, want := range []string{`${failure_items[*]-}`, `${retained_items[*]-}`} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("script must safely expand empty arrays under macOS Bash 3.2 set -u: missing %q", want)
+		}
+	}
 	if strings.Contains(body, `gateway sidecar uninstall reported errors; continuing agent uninstall`) {
 		t.Fatalf("script must not remove the Agent after LensNode removal fails:\n%s", body)
 	}
@@ -155,11 +160,14 @@ func TestWriteUnixUserUninstallScriptUsesUserLifecycle(t *testing.T) {
 		t.Fatal(err)
 	}
 	text := string(body)
+	trustedInstallRoot, err := vfs.UserInstallDir()
+	if err != nil {
+		t.Fatal(err)
+	}
 	for _, expected := range []string{
 		"USER_INSTALL=1",
 		"systemctl --user",
 		filepath.Join(home, ".config", "systemd", "user", unixServiceUnit),
-		fmt.Sprintf("USER_INSTALL_ROOT=%q", filepath.Join(home, ".local", "share", "hyperfilelens-agent", "bin")),
 		`is_managed_install_path()`,
 		`"$path" == "$USER_INSTALL_ROOT"`,
 		`is_managed_data_path()`,
@@ -168,6 +176,9 @@ func TestWriteUnixUserUninstallScriptUsesUserLifecycle(t *testing.T) {
 		if !strings.Contains(text, expected) {
 			t.Fatalf("user uninstall script missing %q", expected)
 		}
+	}
+	if !strings.Contains(text, fmt.Sprintf("USER_INSTALL_ROOT=%q", trustedInstallRoot)) {
+		t.Fatal("user uninstall script must use the trusted default install root")
 	}
 	for _, unexpected := range []string{
 		`"$path" == "$USER_HOME"/*`,
@@ -209,7 +220,10 @@ func TestWriteUnixUserUninstallScriptDoesNotTrustConfiguredExternalDataDir(t *te
 		t.Fatal(err)
 	}
 	text := string(body)
-	trustedDefault := filepath.Join(home, ".local", "share", "hyperfilelens-agent")
+	trustedDefault, err := vfs.UserDataDir()
+	if err != nil {
+		t.Fatal(err)
+	}
 	if !strings.Contains(text, fmt.Sprintf("DEFAULT_DATA_ROOT=%q", trustedDefault)) {
 		t.Fatalf("script must use trusted default data root %q", trustedDefault)
 	}
@@ -319,7 +333,12 @@ func TestCanonicalRemovalPathResolvesIntermediateSymlinkOnly(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if want := filepath.Join(outside, "data"); resolved != want {
+	resolvedOutside, err := filepath.EvalSymlinks(outside)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(resolvedOutside, "data")
+	if resolved != want {
 		t.Fatalf("intermediate symlink resolved to %q, want %q", resolved, want)
 	}
 
@@ -331,7 +350,17 @@ func TestCanonicalRemovalPathResolvesIntermediateSymlinkOnly(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if resolved != finalLink {
+	resolvedFinalLink := filepath.Join(resolvedHomePath(t, root), "inside", "final-link")
+	if resolved != finalLink && resolved != resolvedFinalLink {
 		t.Fatalf("final symlink resolved to %q, want link path %q", resolved, finalLink)
 	}
+}
+
+func resolvedHomePath(t *testing.T, path string) string {
+	t.Helper()
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return resolved
 }

--- a/src/agent/internal/platform/install/managed_mounts_unix.go
+++ b/src/agent/internal/platform/install/managed_mounts_unix.go
@@ -75,7 +75,10 @@ unmount_agent_mounts() {
   local -a points=() remaining=()
   local point failed=0
 
-  mapfile -t points < <(
+  # macOS ships Bash 3.2, which does not provide mapfile/readarray.
+  while IFS= read -r point; do
+    [[ -n "$point" ]] && points+=("$point")
+  done < <(
     collect_agent_mount_points "$mounts_root" | sort -u | sort_mount_points_deepest_first
   )
   if [[ ${#points[@]} -eq 0 ]]; then
@@ -89,7 +92,9 @@ unmount_agent_mounts() {
     try_umount_point "$mounts_root" "$point" || failed=1
   done
 
-  mapfile -t remaining < <(
+  while IFS= read -r point; do
+    [[ -n "$point" ]] && remaining+=("$point")
+  done < <(
     collect_agent_mount_points "$mounts_root" | sort -u | sort_mount_points_deepest_first
   )
   if [[ ${#remaining[@]} -gt 0 ]]; then

--- a/src/agent/internal/platform/install/managed_mounts_unix_test.go
+++ b/src/agent/internal/platform/install/managed_mounts_unix_test.go
@@ -6,11 +6,16 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
 
 func TestUnixManagedMountCleanupUnmountsDeepestFirst(t *testing.T) {
+	if strings.Contains(unixManagedMountCleanupScript, "mapfile -t") ||
+		strings.Contains(unixManagedMountCleanupScript, "readarray -t") {
+		t.Fatal("managed mount cleanup must remain compatible with macOS Bash 3.2")
+	}
 	result := runUnixManagedMountCleanupTest(t, `
 last="${@: -1}"
 printf '%s\n' "$*" >>"$HFL_TEST_UMOUNT_LOG"
@@ -31,6 +36,9 @@ mv "$HFL_TEST_MOUNT_STATE.tmp" "$HFL_TEST_MOUNT_STATE"
 }
 
 func TestUnixManagedMountCleanupLazyUnmountsBusyMount(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("lazy unmount is a Linux-only fallback")
+	}
 	result := runUnixManagedMountCleanupTest(t, `
 last="${@: -1}"
 printf '%s\n' "$*" >>"$HFL_TEST_UMOUNT_LOG"

--- a/src/backend/apps/node/services/internal/node_lifecycle.py
+++ b/src/backend/apps/node/services/internal/node_lifecycle.py
@@ -311,6 +311,12 @@ def record_upgrade_session_observation(
     if changed:
         task.result = result
         task.save(update_fields=["result", "updated_at"])
+    # Re-project even when this session was already observed. Repeated
+    # inventory/heartbeat events are the repair path for a stale Node or
+    # Backup Wizard status left by an interrupted deployment or worker.
+    from apps.node.services.internal.task import project_node_lifecycle_task
+
+    project_node_lifecycle_task(node_task=task)
     return changed
 
 
@@ -528,6 +534,12 @@ def record_upgrade_disconnect(*, node_id: int) -> bool:
         result.pop("verify_started_at", None)
         task.result = result
         task.save(update_fields=["result", "updated_at"])
+        from apps.node.services.internal.task import project_node_lifecycle_task
+
+        project_node_lifecycle_task(
+            node_task=task,
+            status_override=Node.Status.RESTARTING,
+        )
         return True
 
 
@@ -1083,16 +1095,20 @@ def queue_detached_remove_verification(*, node_task: NodeTask) -> bool:
 
 def compute_node_lifecycle(*, org: Organization, node: Node) -> dict[str, Any] | None:
     remove_task = _latest_lifecycle_task(org=org, node=node, kind=LIFECYCLE_KIND_REMOVE)
-    if remove_task is not None:
-        payload = _remove_lifecycle_payload(node=node, task=remove_task)
-        if payload is not None:
-            return payload
-
     upgrade_task = _latest_lifecycle_task(org=org, node=node, kind=LIFECYCLE_KIND_UPGRADE)
-    if upgrade_task is not None:
-        return _upgrade_lifecycle_payload(org=org, node=node, task=upgrade_task)
+    candidates = [task for task in (remove_task, upgrade_task) if task is not None]
+    if not candidates:
+        return None
 
-    return None
+    # Present the most recently started lifecycle operation. A terminal remove
+    # failure must not mask a later upgrade, and a successful later upgrade
+    # must not fall back to that stale failure when its payload is intentionally
+    # empty. Use created_at rather than updated_at so a delayed callback for an
+    # older operation cannot take precedence over a newer operation.
+    latest = max(candidates, key=lambda task: (task.created_at, str(task.pk)))
+    if latest.kind == _LIFECYCLE_TASK_KINDS[LIFECYCLE_KIND_REMOVE]:
+        return _remove_lifecycle_payload(node=node, task=latest)
+    return _upgrade_lifecycle_payload(org=org, node=node, task=latest)
 
 
 def advance_node_lifecycle(
@@ -1220,6 +1236,9 @@ def start_node_upgrade(
             target_version,
             target_commit,
         )
+        from apps.node.services.internal.task import _update_node_lifecycle_status
+
+        _update_node_lifecycle_status(node_id=node.id, status=Node.Status.ACTIVE)
         return {
             "operation_id": None,
             "task_id": None,

--- a/src/backend/apps/node/services/internal/task.py
+++ b/src/backend/apps/node/services/internal/task.py
@@ -533,43 +533,74 @@ def _sync_task_info(task: NodeTask) -> None:
         project_node_lifecycle_task(node_task=task)
 
 
-def project_node_lifecycle_task(*, node_task: NodeTask) -> None:
+def _upgrade_node_status(*, node_task: NodeTask) -> str:
+    if node_task.status == NodeTask.Status.SUCCESS:
+        return Node.Status.ACTIVE
+    if node_task.status not in {NodeTask.Status.PENDING, NodeTask.Status.RUNNING}:
+        return Node.Status.UPGRADE_FAILED
+    if node_task.status == NodeTask.Status.PENDING:
+        return Node.Status.UPGRADING
+
+    result = node_task.result if isinstance(node_task.result, dict) else {}
+    progress = result.get("last_progress")
+    detached = str(result.get("mode") or "").strip() == "local_detached" or (
+        isinstance(progress, dict)
+        and str(progress.get("mode") or "").strip() == "local_detached"
+    )
+    if not detached:
+        return Node.Status.UPGRADING
+    if result.get("verify_started_at"):
+        return Node.Status.VERIFYING
+    if result.get("reconnect_session_id") or result.get("inventory_session_id"):
+        return Node.Status.VERIFICATION_PENDING
+    return Node.Status.RESTARTING
+
+
+def _update_node_lifecycle_status(*, node_id: int, status: str) -> None:
+    Node.objects.filter(pk=node_id).exclude(status=status).update(status=status)
+    # Always refresh the read model.  The Node row may already contain the
+    # expected status while the Backup Wizard projection is stale (for
+    # example after a worker restart or a missed transaction callback).
+    _sync_agent_source_pipeline_status(node_id=node_id)
+
+
+def project_node_lifecycle_task(
+    *,
+    node_task: NodeTask,
+    status_override: str | None = None,
+) -> None:
     """Project lifecycle task progress into the persisted Node state machine."""
     payload = node_task.payload if isinstance(node_task.payload, dict) else {}
     if node_task.correlation_type != node_conf.LIFECYCLE_CORRELATION_TYPE:
         return
+    latest_id = (
+        NodeTask.objects.filter(
+            node_id=node_task.node_id,
+            correlation_type=node_conf.LIFECYCLE_CORRELATION_TYPE,
+            kind__in=("agent.upgrade", "agent.uninstall"),
+        )
+        .order_by("-created_at", "-pk")
+        .values_list("pk", flat=True)
+        .first()
+    )
+    if latest_id != node_task.pk:
+        return
     if node_task.kind == "agent.upgrade":
-        status = (
-            Node.Status.UPGRADING
-            if node_task.status in {NodeTask.Status.PENDING, NodeTask.Status.RUNNING}
-            else Node.Status.ACTIVE
-            if node_task.status == NodeTask.Status.SUCCESS
-            else Node.Status.UPGRADE_FAILED
+        _update_node_lifecycle_status(
+            node_id=node_task.node_id,
+            status=status_override or _upgrade_node_status(node_task=node_task),
         )
-        updated = (
-            Node.objects.filter(pk=node_task.node_id)
-            .exclude(status=status)
-            .update(status=status)
-        )
-        if updated:
-            _sync_agent_source_pipeline_status(node_id=node_task.node_id)
         return
     if node_task.kind != "agent.uninstall":
         return
-    status = (
+    status = status_override or (
         Node.Status.REMOVING
         if node_task.status in {NodeTask.Status.PENDING, NodeTask.Status.RUNNING}
         else Node.Status.CLEANING_UP
         if node_task.status == NodeTask.Status.SUCCESS
         else Node.Status.DEREGISTRATION_FAILED
     )
-    updated = (
-        Node.objects.filter(pk=node_task.node_id)
-        .exclude(status=status)
-        .update(status=status)
-    )
-    if updated:
-        _sync_agent_source_pipeline_status(node_id=node_task.node_id)
+    _update_node_lifecycle_status(node_id=node_task.node_id, status=status)
     if payload.get("source_unregister_task_id"):
         return
     try:

--- a/src/backend/apps/node/tests/test_node_lifecycle.py
+++ b/src/backend/apps/node/tests/test_node_lifecycle.py
@@ -21,6 +21,7 @@ from apps.node.services.internal.node_lifecycle import (
     compute_node_lifecycle,
     preview_batch_operations,
     queue_detached_remove_verification,
+    record_upgrade_disconnect,
     record_upgrade_session_observation,
     start_node_remove,
     start_node_upgrade,
@@ -94,6 +95,73 @@ class NodeLifecycleTests(TestCase):
                 self.assertEqual(self.node.availability, Node.Availability.ONLINE)
                 self.node.status = Node.Status.ACTIVE
                 self.node.save(update_fields=["status", "updated_at"])
+
+    def test_upgrade_task_projects_all_detailed_node_statuses(self):
+        task = NodeTask.objects.create(
+            organization=self.org,
+            node=self.node,
+            kind="agent.upgrade",
+            status=NodeTask.Status.RUNNING,
+            watchdog_deadline_at=timezone.now() + timezone.timedelta(hours=1),
+            correlation_type=node_conf.LIFECYCLE_CORRELATION_TYPE,
+            correlation_id=f"upgrade:{self.node.id}",
+        )
+        cases = (
+            ({}, Node.Status.UPGRADING),
+            (
+                {"mode": "local_detached", "detached_at": timezone.now().isoformat()},
+                Node.Status.RESTARTING,
+            ),
+            (
+                {
+                    "mode": "local_detached",
+                    "detached_at": timezone.now().isoformat(),
+                    "reconnect_session_id": "new",
+                },
+                Node.Status.VERIFICATION_PENDING,
+            ),
+            (
+                {
+                    "mode": "local_detached",
+                    "detached_at": timezone.now().isoformat(),
+                    "reconnect_session_id": "new",
+                    "verify_started_at": timezone.now().isoformat(),
+                },
+                Node.Status.VERIFYING,
+            ),
+        )
+        for result, expected in cases:
+            with self.subTest(expected=expected):
+                task.result = result
+                task.save(update_fields=["result", "updated_at"])
+                project_node_lifecycle_task(node_task=task)
+                self.node.refresh_from_db()
+                self.assertEqual(self.node.status, expected)
+
+    def test_older_lifecycle_task_cannot_overwrite_newer_operation_status(self):
+        old_remove = NodeTask.objects.create(
+            organization=self.org,
+            node=self.node,
+            kind="agent.uninstall",
+            status=NodeTask.Status.FAILED,
+            watchdog_deadline_at=timezone.now(),
+            correlation_type=node_conf.LIFECYCLE_CORRELATION_TYPE,
+            correlation_id=f"remove:{self.node.id}",
+        )
+        new_upgrade = NodeTask.objects.create(
+            organization=self.org,
+            node=self.node,
+            kind="agent.upgrade",
+            status=NodeTask.Status.RUNNING,
+            watchdog_deadline_at=timezone.now() + timezone.timedelta(hours=1),
+            correlation_type=node_conf.LIFECYCLE_CORRELATION_TYPE,
+            correlation_id=f"upgrade:{self.node.id}",
+        )
+        project_node_lifecycle_task(node_task=new_upgrade)
+        project_node_lifecycle_task(node_task=old_remove)
+
+        self.node.refresh_from_db()
+        self.assertEqual(self.node.status, Node.Status.UPGRADING)
 
     def test_upgrade_is_blocked_by_active_source_unregister(self):
         self._create_active_source_unregister()
@@ -442,6 +510,44 @@ class NodeLifecycleTests(TestCase):
         self.assertEqual(result["state"], "upgrading")
         self.assertEqual(result["target_version"], "1.2.0")
 
+    @patch(
+        "apps.node.services.internal.node_lifecycle.agent_release_commit",
+        return_value="a" * 40,
+    )
+    @patch(
+        "apps.node.services.internal.node_lifecycle.validate_agent_upgrade",
+        return_value="1.0.0",
+    )
+    def test_already_current_upgrade_repairs_stale_failure_status(
+        self,
+        _validate,
+        _release_commit,
+    ):
+        from apps.source.constants import SelectableSourceKind
+        from apps.source.services.internal.source_pipeline import ensure_pipeline_entry
+
+        self.node.status = Node.Status.DEREGISTRATION_FAILED
+        self.node.metadata = {
+            "inventory": {
+                "agent_version": "1.0.0",
+                "agent_commit": "a" * 40,
+            }
+        }
+        self.node.save(update_fields=["status", "metadata", "updated_at"])
+        entry = ensure_pipeline_entry(
+            organization_id=self.org.id,
+            source_kind=SelectableSourceKind.AGENT,
+            ref_id=self.node.id,
+        )
+
+        result = start_node_upgrade(org=self.org, node=self.node, user=self.user)
+
+        self.assertEqual(result["outcome"], "no_op")
+        self.node.refresh_from_db()
+        entry.refresh_from_db()
+        self.assertEqual(self.node.status, Node.Status.ACTIVE)
+        self.assertEqual(entry.source_status, Node.Status.ACTIVE)
+
     @patch("apps.node.services.internal.node_workload.get_node_workload_blockers")
     def test_upgrade_blocked_by_workload(self, mock_blockers):
         from apps.node.services.internal.node_workload import NodeWorkloadBlocker
@@ -590,6 +696,87 @@ class NodeLifecycleTests(TestCase):
         with patch("apps.node.services.internal.node_lifecycle.agent_ws_routable", return_value=True):
             lifecycle = compute_node_lifecycle(org=self.org, node=self.node)
         self.assertIsNone(lifecycle)
+
+    def test_newer_running_upgrade_replaces_stale_deregistration_failure(self):
+        NodeTask.objects.create(
+            organization=self.org,
+            node=self.node,
+            kind="agent.uninstall",
+            status=NodeTask.Status.FAILED,
+            last_error="Detached uninstall failed.",
+            watchdog_deadline_at=timezone.now(),
+            correlation_type=node_conf.LIFECYCLE_CORRELATION_TYPE,
+            correlation_id=f"remove:{self.node.id}",
+        )
+        upgrade = NodeTask.objects.create(
+            organization=self.org,
+            node=self.node,
+            kind="agent.upgrade",
+            status=NodeTask.Status.RUNNING,
+            payload={"target_version": "1.2.0"},
+            watchdog_deadline_at=timezone.now() + timezone.timedelta(hours=1),
+            correlation_type=node_conf.LIFECYCLE_CORRELATION_TYPE,
+            correlation_id=f"upgrade:{self.node.id}",
+        )
+
+        lifecycle = compute_node_lifecycle(org=self.org, node=self.node)
+
+        self.assertEqual(lifecycle["kind"], "upgrade")
+        self.assertEqual(lifecycle["state"], "upgrading")
+        self.assertEqual(lifecycle["task_id"], str(upgrade.id))
+
+    def test_successful_newer_upgrade_does_not_reveal_stale_remove_failure(self):
+        NodeTask.objects.create(
+            organization=self.org,
+            node=self.node,
+            kind="agent.uninstall",
+            status=NodeTask.Status.FAILED,
+            last_error="Detached uninstall failed.",
+            watchdog_deadline_at=timezone.now(),
+            correlation_type=node_conf.LIFECYCLE_CORRELATION_TYPE,
+            correlation_id=f"remove:{self.node.id}",
+        )
+        NodeTask.objects.create(
+            organization=self.org,
+            node=self.node,
+            kind="agent.upgrade",
+            status=NodeTask.Status.SUCCESS,
+            result={"target_version": "1.2.0", "mode": "local_detached"},
+            watchdog_deadline_at=timezone.now(),
+            correlation_type=node_conf.LIFECYCLE_CORRELATION_TYPE,
+            correlation_id=f"upgrade:{self.node.id}",
+        )
+
+        lifecycle = compute_node_lifecycle(org=self.org, node=self.node)
+
+        self.assertIsNone(lifecycle)
+
+    def test_newer_remove_replaces_stale_upgrade_failure(self):
+        NodeTask.objects.create(
+            organization=self.org,
+            node=self.node,
+            kind="agent.upgrade",
+            status=NodeTask.Status.FAILED,
+            last_error="Upgrade failed.",
+            watchdog_deadline_at=timezone.now(),
+            correlation_type=node_conf.LIFECYCLE_CORRELATION_TYPE,
+            correlation_id=f"upgrade:{self.node.id}",
+        )
+        remove = NodeTask.objects.create(
+            organization=self.org,
+            node=self.node,
+            kind="agent.uninstall",
+            status=NodeTask.Status.RUNNING,
+            watchdog_deadline_at=timezone.now() + timezone.timedelta(hours=1),
+            correlation_type=node_conf.LIFECYCLE_CORRELATION_TYPE,
+            correlation_id=f"remove:{self.node.id}",
+        )
+
+        lifecycle = compute_node_lifecycle(org=self.org, node=self.node)
+
+        self.assertEqual(lifecycle["kind"], "remove")
+        self.assertEqual(lifecycle["state"], "removing")
+        self.assertEqual(lifecycle["task_id"], str(remove.id))
 
     @patch("apps.node.services.internal.node_lifecycle.agent_ws_routable", return_value=False)
     def test_upgrade_success_clears_when_version_matches_despite_stale_ws(self, _routable):
@@ -824,6 +1011,8 @@ class NodeLifecycleTests(TestCase):
         task.refresh_from_db()
         self.assertEqual(task.result["detached_session_id"], "old")
         self.assertEqual(task.result["reconnect_session_id"], "new")
+        self.node.refresh_from_db()
+        self.assertEqual(self.node.status, Node.Status.VERIFICATION_PENDING)
 
         task.result["verify_started_at"] = timezone.now().isoformat()
         task.save(update_fields=["result"])
@@ -835,6 +1024,61 @@ class NodeLifecycleTests(TestCase):
         task.refresh_from_db()
         self.assertEqual(task.result["inventory_session_id"], "new")
         self.assertNotIn("verify_started_at", task.result)
+
+    def test_repeated_upgrade_session_observation_repairs_stale_node_status(self):
+        NodeTask.objects.create(
+            organization=self.org,
+            node=self.node,
+            kind="agent.upgrade",
+            status=NodeTask.Status.RUNNING,
+            payload={"pre_upgrade_session_id": "old"},
+            result={
+                "mode": "local_detached",
+                "detached_session_id": "old",
+                "reconnect_session_id": "new",
+                "inventory_session_id": "new",
+            },
+            watchdog_deadline_at=timezone.now() + timezone.timedelta(hours=1),
+            correlation_type=node_conf.LIFECYCLE_CORRELATION_TYPE,
+            correlation_id=f"upgrade:{self.node.id}",
+        )
+        self.node.status = Node.Status.UPGRADING
+        self.node.save(update_fields=["status", "updated_at"])
+
+        changed = record_upgrade_session_observation(
+            node_id=self.node.id,
+            session_id="new",
+            inventory=True,
+        )
+
+        self.assertFalse(changed)
+        self.node.refresh_from_db()
+        self.assertEqual(self.node.status, Node.Status.VERIFICATION_PENDING)
+
+    def test_upgrade_disconnect_projects_restarting(self):
+        task = NodeTask.objects.create(
+            organization=self.org,
+            node=self.node,
+            kind="agent.upgrade",
+            status=NodeTask.Status.RUNNING,
+            result={
+                "mode": "local_detached",
+                "reconnect_session_id": "new",
+                "inventory_session_id": "new",
+                "verify_started_at": timezone.now().isoformat(),
+            },
+            watchdog_deadline_at=timezone.now() + timezone.timedelta(hours=1),
+            correlation_type=node_conf.LIFECYCLE_CORRELATION_TYPE,
+            correlation_id=f"upgrade:{self.node.id}",
+        )
+
+        changed = record_upgrade_disconnect(node_id=self.node.id)
+
+        self.assertTrue(changed)
+        task.refresh_from_db()
+        self.assertNotIn("verify_started_at", task.result)
+        self.node.refresh_from_db()
+        self.assertEqual(self.node.status, Node.Status.RESTARTING)
 
     def test_upgrade_session_observation_does_not_mutate_terminal_task(self):
         task = NodeTask.objects.create(

--- a/src/backend/apps/source/tests/test_source_pipeline_projection.py
+++ b/src/backend/apps/source/tests/test_source_pipeline_projection.py
@@ -104,6 +104,60 @@ class SourcePipelineProjectionTests(TestCase):
         self.assertEqual(entry.source_status, Node.Status.UPGRADE_FAILED)
         self.assertEqual(entry.source_availability, Node.Availability.ONLINE)
 
+    def test_upgrade_phases_refresh_backup_wizard_pipeline_status(self):
+        entry = ensure_pipeline_entry(
+            organization_id=self.org.id,
+            source_kind=SelectableSourceKind.AGENT,
+            ref_id=self.agent.id,
+        )
+        task = NodeTask.objects.create(
+            organization=self.org,
+            node=self.agent,
+            kind="agent.upgrade",
+            status=NodeTask.Status.PENDING,
+            watchdog_deadline_at=self.agent.created_at,
+            correlation_type=node_conf.LIFECYCLE_CORRELATION_TYPE,
+            correlation_id=f"upgrade:{self.agent.id}",
+        )
+        phases = (
+            (
+                {"mode": "local_detached", "detached_at": self.agent.created_at.isoformat()},
+                Node.Status.RESTARTING,
+            ),
+            (
+                {
+                    "mode": "local_detached",
+                    "detached_at": self.agent.created_at.isoformat(),
+                    "reconnect_session_id": "new",
+                    "inventory_session_id": "new",
+                },
+                Node.Status.VERIFICATION_PENDING,
+            ),
+            (
+                {
+                    "mode": "local_detached",
+                    "detached_at": self.agent.created_at.isoformat(),
+                    "reconnect_session_id": "new",
+                    "inventory_session_id": "new",
+                    "verify_started_at": self.agent.created_at.isoformat(),
+                },
+                Node.Status.VERIFYING,
+            ),
+        )
+        for result, expected in phases:
+            with self.subTest(expected=expected):
+                complete_node_task(
+                    task_id=task.id,
+                    node_id=self.agent.id,
+                    status=NodeTask.Status.RUNNING,
+                    result=result,
+                    replace_result=True,
+                )
+                self.agent.refresh_from_db()
+                entry.refresh_from_db()
+                self.assertEqual(self.agent.status, expected)
+                self.assertEqual(entry.source_status, expected)
+
     def test_nas_without_proxy_projects_empty_identity_and_offline(self):
         source = SourceResource.objects.create(
             organization=self.org,

--- a/src/backend/apps/storage/repositories/serializers.py
+++ b/src/backend/apps/storage/repositories/serializers.py
@@ -114,6 +114,30 @@ def normalize_s3_object_prefix(value: object) -> str:
     return cleaned + "/"
 
 
+class RepositoryListSerializer(serializers.ListSerializer):
+    def to_representation(self, data):
+        items = list(data)
+        node_ids = {item.bind_node_id for item in items if item.bind_node_id}
+        nodes = Node.objects.filter(id__in=node_ids).in_bulk() if node_ids else {}
+        alert_ids = [str(item.id) for item in items]
+        organization_id = self.context.get("organization_id") or (
+            items[0].organization_id if items else None
+        )
+        alerts = {}
+        for alert in AlertRecord.objects.filter(
+            organization_id=organization_id,
+            resource_type="backup_repository",
+            resource_id__in=alert_ids,
+            status__in=["pending", "firing", "acknowledged"],
+            policy_id__isnull=False,
+        ).order_by("-last_triggered_at"):
+            alerts.setdefault(alert.resource_id, alert)
+        for item in items:
+            item._list_bind_node = nodes.get(item.bind_node_id)
+            item._list_quota_alert = alerts.get(str(item.id))
+        return super().to_representation(items)
+
+
 class RepositorySerializer(serializers.ModelSerializer):
     config = serializers.SerializerMethodField()
     credential_hint = serializers.SerializerMethodField()
@@ -125,9 +149,11 @@ class RepositorySerializer(serializers.ModelSerializer):
     initialization_state = serializers.SerializerMethodField()
     initialized_target_count = serializers.SerializerMethodField()
     quota_alert = serializers.SerializerMethodField()
+    associated_source_count = serializers.IntegerField(read_only=True, default=0)
 
     class Meta:
         model = Repository
+        list_serializer_class = RepositoryListSerializer
         fields = [
             "id",
             "organization_id",
@@ -173,17 +199,20 @@ class RepositorySerializer(serializers.ModelSerializer):
             "initialization_state",
             "initialized_target_count",
             "quota_alert",
+            "associated_source_count",
         ]
         read_only_fields = fields
 
     def get_quota_alert(self, obj):
-        alert = AlertRecord.objects.filter(
-            organization_id=obj.organization_id,
-            resource_type="backup_repository",
-            resource_id=str(obj.id),
-            status__in=["pending", "firing", "acknowledged"],
-            policy_id__isnull=False,
-        ).order_by("-last_triggered_at").first()
+        alert = getattr(obj, "_list_quota_alert", None)
+        if not hasattr(obj, "_list_quota_alert"):
+            alert = AlertRecord.objects.filter(
+                organization_id=obj.organization_id,
+                resource_type="backup_repository",
+                resource_id=str(obj.id),
+                status__in=["pending", "firing", "acknowledged"],
+                policy_id__isnull=False,
+            ).order_by("-last_triggered_at").first()
         if not alert:
             return None
         metadata = alert.metadata or {}
@@ -201,12 +230,14 @@ class RepositorySerializer(serializers.ModelSerializer):
     def get_bind_node_display_name(self, obj: Repository) -> str | None:
         if not (obj.bind_node_id and obj.bind_node_type):
             return None
-        node = (
-            Node.objects.filter(id=obj.bind_node_id)
-            .values_list("name", flat=True)
-            .first()
-        )
-        return node
+        node = getattr(obj, "_list_bind_node", None)
+        if not hasattr(obj, "_list_bind_node"):
+            node = (
+                Node.objects.filter(id=obj.bind_node_id)
+                .values_list("name", flat=True)
+                .first()
+            )
+        return node.name if isinstance(node, Node) else node
 
     def get_config(self, obj: Repository) -> dict:
         return sanitize_repository_config(
@@ -219,12 +250,14 @@ class RepositorySerializer(serializers.ModelSerializer):
     def get_bind_node_ip(self, obj: Repository) -> str | None:
         if not (obj.bind_node_id and obj.bind_node_type):
             return None
-        node = (
-            Node.objects.filter(id=obj.bind_node_id)
-            .values_list("ip_address", flat=True)
-            .first()
-        )
-        return node
+        node = getattr(obj, "_list_bind_node", None)
+        if not hasattr(obj, "_list_bind_node"):
+            node = (
+                Node.objects.filter(id=obj.bind_node_id)
+                .values_list("ip_address", flat=True)
+                .first()
+            )
+        return node.ip_address if isinstance(node, Node) else node
 
     def get_cross_proxy_access(self, obj: Repository) -> dict:
         if not repository_uses_bound_proxy(obj):
@@ -241,12 +274,20 @@ class RepositorySerializer(serializers.ModelSerializer):
                 "host": None,
                 "reason": "feature_disabled",
             }
-        node = Node.objects.filter(
-            id=obj.bind_node_id,
-            organization_id=obj.organization_id,
-            role=NodeRole.PROXY,
-            is_deleted=False,
-        ).first()
+        node = getattr(obj, "_list_bind_node", None)
+        if not hasattr(obj, "_list_bind_node"):
+            node = Node.objects.filter(
+                id=obj.bind_node_id,
+                organization_id=obj.organization_id,
+                role=NodeRole.PROXY,
+                is_deleted=False,
+            ).first()
+        elif node is not None and (
+            node.organization_id != obj.organization_id
+            or node.role != NodeRole.PROXY
+            or node.is_deleted
+        ):
+            node = None
         if node is None:
             return {
                 "enabled": True,

--- a/src/backend/apps/storage/repositories/views.py
+++ b/src/backend/apps/storage/repositories/views.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 from uuid import UUID
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.http import JsonResponse
-from django.db.models import Q
+from django.db.models import Count, IntegerField, OuterRef, Q, Subquery, Value
+from django.db.models.functions import Coalesce
 from django.utils.dateparse import parse_datetime
 from rest_framework import status, viewsets
 from rest_framework.decorators import action
@@ -482,6 +483,20 @@ class RepositoryViewSet(viewsets.ModelViewSet):
             health=self.request.query_params.get("health") or None,
             search=self.request.query_params.get("search") or None,
             search_field=self.request.query_params.get("search_field") or None,
+        )
+        associated_sources = (
+            BackupConfig.objects.filter(
+                organization_id=organization_id,
+                repository_id=OuterRef("pk"),
+            )
+            .values("repository_id")
+            .annotate(total=Count("id"))
+            .values("total")
+        )
+        queryset = queryset.annotate(
+            associated_source_count=Coalesce(
+                Subquery(associated_sources, output_field=IntegerField()), Value(0)
+            )
         )
         if not self.request.query_params.get("status"):
             queryset = queryset.filter(

--- a/src/backend/apps/storage/tests/test_repository_api.py
+++ b/src/backend/apps/storage/tests/test_repository_api.py
@@ -2278,6 +2278,45 @@ class StorageRepositoryApiTests(TestCase):
         rows = response.data["data"]["list"]
         self.assertNotIn(repo.id, [row["id"] for row in rows])
 
+    def test_repository_list_includes_tenant_scoped_associated_source_count(self):
+        repo = Repository.objects.create(
+            organization_id=self.org.id,
+            name="direct-nas-with-sources",
+            repo_type=Repository.Type.NAS,
+            status=Repository.Status.CREATED,
+            health=Repository.Health.ONLINE,
+            nas_protocol=Repository.NasProtocol.NFS,
+            config={"server_address": "10.0.0.20", "share_path": "/backup"},
+        )
+        for source_ref_id in (101, 102):
+            BackupConfig.objects.create(
+                organization_id=self.org.id,
+                name=f"source-{source_ref_id}",
+                source_type="agent",
+                source_ref_id=source_ref_id,
+                repository_id=repo.id,
+            )
+        other_org = Organization.objects.create(
+            key="storage-count-other-org", name="Storage Count Other Org"
+        )
+        BackupConfig.objects.create(
+            organization_id=other_org.id,
+            name="other-tenant-source",
+            source_type="agent",
+            source_ref_id=103,
+            repository_id=repo.id,
+        )
+
+        response = self.client.get(
+            "/api/v1/storage/repositories/?repo_type=nas",
+            **self._headers(),
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        rows = response.data["data"]["list"]
+        row = next(item for item in rows if item["id"] == repo.id)
+        self.assertEqual(row["associated_source_count"], 2)
+
     def test_delete_repository_with_backup_configs_is_rejected(self):
         repo = Repository.objects.create(
             organization_id=self.org.id,

--- a/src/frontend/src/lib/storageRepositoryApi.ts
+++ b/src/frontend/src/lib/storageRepositoryApi.ts
@@ -48,6 +48,7 @@ export type StorageRepository = {
   health_failures?: number
   initialization_state?: StorageRepositoryInitializationState | string
   initialized_target_count?: number
+  associated_source_count?: number
   config?: Record<string, unknown>
   credential_id?: number | null
   s3_platform?: StorageRepositoryS3Platform | string | null

--- a/src/frontend/src/pages/node/Repositories.vue
+++ b/src/frontend/src/pages/node/Repositories.vue
@@ -89,6 +89,7 @@ export type RepositoryRow = {
   health: RepoHealth
   initialization_state: RepositoryInitializationState
   initialized_target_count: number
+  associated_source_count: number
   capacity_bytes: number
   estimated_usage_bytes: number
   physical_usage_bytes?: number | null
@@ -180,6 +181,7 @@ type ApiRepository = {
   health_failures?: number
   initialization_state?: RepositoryInitializationState
   initialized_target_count?: number
+  associated_source_count?: number
   credential_id?: number | null
   s3_platform?: string | null
   s3_bucket?: string | null
@@ -402,6 +404,7 @@ function mapApiToRow(r: ApiRepository): RepositoryRow {
   const organizationId = r.organization_id ?? r.organization ?? 0
   const initializationState = r.initialization_state || 'unverified'
   const initializedTargetCount = Number(r.initialized_target_count || 0)
+  const associatedSourceCount = Number(r.associated_source_count || 0)
   const bucket = r.s3_bucket || configString(config, 'bucket') || r.name
   const prefix = configString(config, 'prefix')
   const mountPath = configString(config, 'mount_path') || r.mount_path || ''
@@ -459,6 +462,7 @@ function mapApiToRow(r: ApiRepository): RepositoryRow {
       health,
       initialization_state: initializationState,
       initialized_target_count: initializedTargetCount,
+      associated_source_count: associatedSourceCount,
       capacity_bytes: r.capacity_bytes,
       estimated_usage_bytes: r.estimated_usage_bytes,
       physical_usage_bytes: r.physical_usage_bytes ?? null,
@@ -510,6 +514,7 @@ function mapApiToRow(r: ApiRepository): RepositoryRow {
       health,
       initialization_state: initializationState,
       initialized_target_count: initializedTargetCount,
+      associated_source_count: associatedSourceCount,
       capacity_bytes: r.capacity_bytes,
       estimated_usage_bytes: r.estimated_usage_bytes,
       physical_usage_bytes: r.physical_usage_bytes ?? null,
@@ -555,6 +560,7 @@ function mapApiToRow(r: ApiRepository): RepositoryRow {
     health,
     initialization_state: initializationState,
     initialized_target_count: initializedTargetCount,
+    associated_source_count: associatedSourceCount,
     capacity_bytes: r.capacity_bytes,
     estimated_usage_bytes: r.estimated_usage_bytes,
     physical_usage_bytes: r.physical_usage_bytes ?? null,
@@ -720,7 +726,6 @@ const {
 const repositoryTaskDetailOpen = ref(false)
 const repositoryTaskDetailUuid = ref('')
 let repositoryTasksPollTimer: ReturnType<typeof setInterval> | undefined
-const rowAssociatedSourceCounts = ref<Record<number, number>>({})
 const { drawerSize, updateDrawerWidth, bindDrawerResize, unbindDrawerResize } = useResponsiveDrawerWidth()
 const { drawerSize: nestedDrawerSize } = useResponsiveDrawerWidth(2)
 const repositoryTaskDetailDrawerSize = computed(() => {
@@ -1569,7 +1574,7 @@ async function loadAssociatedSources(row = detailRow.value) {
 }
 
 function associatedSourceCountForRow(row: RepositoryRow) {
-  return rowAssociatedSourceCounts.value[row.id] || 0
+  return row.associated_source_count
 }
 
 function proxyBindTipItems(row: RepositoryRow) {
@@ -1581,27 +1586,6 @@ function proxyBindTipItems(row: RepositoryRow) {
     ]
   }
   return bindProxyLeadItems.value
-}
-
-async function loadUnboundNasAssociatedSourceCounts(list: RepositoryRow[], signal?: AbortSignal) {
-  const targets = list.filter((row) => row.kind === 'nas' && !hasBoundProxy(row))
-  if (!targets.length) {
-    rowAssociatedSourceCounts.value = {}
-    return
-  }
-  const entries = await Promise.all(targets.map(async (row) => {
-    try {
-      const result = await listStorageRepositoryAssociatedSources(row.id, {
-        page: 1,
-        page_size: 1,
-      }, { signal })
-      return [row.id, result.count] as const
-    } catch {
-      return [row.id, 0] as const
-    }
-  }))
-  if (signal?.aborted) return
-  rowAssociatedSourceCounts.value = Object.fromEntries(entries)
 }
 
 function onDetailTabChange(name: string | number) {
@@ -2451,12 +2435,10 @@ async function load() {
     const mappedRows = list.results.map(mapApiToRow)
     rows.value = mappedRows
     repositoryTotal.value = list.count
-    await loadUnboundNasAssociatedSourceCounts(mappedRows, signal)
   } catch (err) {
     if (pageRequests.isAbortError(err)) return
     rows.value = []
     repositoryTotal.value = 0
-    rowAssociatedSourceCounts.value = {}
     repositoryListError.value = apiErrorMessage(err)
     ElMessage.error({ message: repositoryListError.value, grouping: true })
   } finally {

--- a/src/frontend/src/pages/protection/BackupCreateWizard.vue
+++ b/src/frontend/src/pages/protection/BackupCreateWizard.vue
@@ -8810,21 +8810,6 @@ function preserveShallowestPathOrder(paths: string[]) {
                                 />
                                 <span class="create-recovery-plan-mapping__text">{{ recoveryDirPlanTargetSummary(dirPlan) }}</span>
                               </span>
-                              <span
-                                v-if="recoveryDirPlanRestoredPaths(group, dirPlan).length"
-                                class="create-recovery-result-path-hint create-recovery-result-path-hint--inline"
-                              >
-                                <FolderOpen
-                                  :size="12"
-                                  class="create-recovery-result-path-hint__icon"
-                                />
-                                <span class="create-recovery-result-path-hint__label">{{ recoveryDirPlanRestoredPathLabel(recoveryDirPlanRestoredPaths(group, dirPlan).length) }}:</span>
-                                <code
-                                  v-for="path in recoveryDirPlanRestoredPaths(group, dirPlan)"
-                                  :key="path"
-                                  class="create-recovery-result-path-hint__path"
-                                >{{ path }}</code>
-                              </span>
                             </template>
                             <span
                               v-else
@@ -9409,21 +9394,6 @@ function preserveShallowestPathOrder(paths: string[]) {
                                     class="create-recovery-plan-mapping__text"
                                     :title="recoveryDirPlanTargetSummary(dirPlan)"
                                   >{{ recoveryDirPlanTargetSummary(dirPlan) }}</span>
-                                </span>
-                                <span
-                                  v-if="recoveryDirPlanRestoredPaths(row.recoveryGroup.group, dirPlan).length"
-                                  class="create-recovery-result-path-hint create-recovery-result-path-hint--inline"
-                                >
-                                  <FolderOpen
-                                    :size="12"
-                                    class="create-recovery-result-path-hint__icon"
-                                  />
-                                  <span class="create-recovery-result-path-hint__label">{{ recoveryDirPlanRestoredPathLabel(recoveryDirPlanRestoredPaths(row.recoveryGroup.group, dirPlan).length) }}:</span>
-                                  <code
-                                    v-for="path in recoveryDirPlanRestoredPaths(row.recoveryGroup.group, dirPlan)"
-                                    :key="path"
-                                    class="create-recovery-result-path-hint__path"
-                                  >{{ path }}</code>
                                 </span>
                               </template>
                               <span
@@ -12752,8 +12722,6 @@ function preserveShallowestPathOrder(paths: string[]) {
 }
 
 .create-recovery-plan-cell--wrap .create-recovery-plan-cell__policy-text,
-.create-recovery-plan-cell--wrap .create-recovery-plan-mapping__text,
-.create-recovery-plan-cell--wrap .create-recovery-plan-mapping__pending,
 .create-recovery-plan-cell--review .create-recovery-plan-cell__policy-text,
 .create-recovery-plan-cell--review .create-recovery-plan-mapping__text,
 .create-recovery-plan-cell--review .create-recovery-plan-mapping__pending {
@@ -12764,14 +12732,12 @@ function preserveShallowestPathOrder(paths: string[]) {
   overflow-wrap: break-word;
 }
 
-/* List: source → on first row; restore path uses full width below with hanging indent. */
+/* List: each mapping stays on one line; the dedicated popover contains the full values. */
 .create-recovery-plan-cell--wrap .create-recovery-plan-mapping {
   display: grid;
-  grid-template-columns: max-content auto minmax(0, 1fr);
-  grid-template-rows: auto auto;
-  align-items: start;
+  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+  align-items: center;
   column-gap: 6px;
-  row-gap: 4px;
 }
 
 .create-recovery-plan-cell--wrap .create-recovery-plan-mapping > .create-recovery-plan-mapping__endpoint:not(.create-recovery-plan-mapping__endpoint--target) {
@@ -12791,19 +12757,21 @@ function preserveShallowestPathOrder(paths: string[]) {
 }
 
 .create-recovery-plan-cell--wrap .create-recovery-plan-mapping__endpoint--target {
-  grid-column: 1 / -1;
-  grid-row: 2;
-  display: grid;
-  grid-template-columns: auto minmax(0, 1fr);
-  align-items: start;
+  grid-column: 3;
+  grid-row: 1;
+  display: inline-flex;
+  align-items: center;
   gap: 5px;
   min-width: 0;
 }
 
 .create-recovery-plan-cell--wrap .create-recovery-plan-mapping__text {
-  display: block;
+  display: inline-block;
   min-width: 0;
-  max-width: none;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .create-recovery-plan-cell--review .create-recovery-plan-mapping {

--- a/src/frontend/src/pages/protection/BackupCreateWizardRestorePlanLayout.test.ts
+++ b/src/frontend/src/pages/protection/BackupCreateWizardRestorePlanLayout.test.ts
@@ -64,11 +64,18 @@ describe('BackupCreateWizard restore plan layout', () => {
     expect(compactWizardSource).toContain('class="create-recovery-plan-action hfl-table-no-tooltip"')
   })
 
-  it('shows the final restored path for each configured mapping and in the confirmation summary', () => {
+  it('shows the final restored path only below the Configure Restore Plan editor', () => {
     expect(wizardSource).toContain('function recoveryDirPlanRestoredPaths(')
     expect(compactWizardSource).toContain('class="create-recovery-result-path-hint"')
-    expect(compactWizardSource).toContain('class="create-recovery-result-path-hint create-recovery-result-path-hint--inline"')
-    expect(compactWizardSource).toContain('recoveryDirPlanRestoredPaths(row.recoveryGroup.group, dirPlan)')
+    expect(compactWizardSource).not.toContain('class="create-recovery-result-path-hint create-recovery-result-path-hint--inline"')
+  })
+
+  it('keeps Restore Plan list mappings on one truncated line without default overflow tooltips', () => {
+    expect(wizardSource).toContain('/* List: each mapping stays on one line; the dedicated popover contains the full values. */')
+    expect(wizardSource).toContain('grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);')
+    expect(wizardSource).toContain('.create-recovery-plan-cell--wrap .create-recovery-plan-mapping__endpoint--target {\n  grid-column: 3;')
+    expect(wizardSource).toContain('text-overflow: ellipsis;')
+    expect(compactWizardSource).toContain('class-name="hfl-table-no-tooltip"')
   })
 
   it('disables Windows and macOS restore targets for unbound NAS repositories', () => {


### PR DESCRIPTION
## Problem and root cause

macOS Agent lifecycle work could outlive its invoking process without a reliable independent job boundary, while cleanup scripts assumed newer Bash behavior and did not fully account for APFS layout. Lifecycle task projections could also expose stale Node and backup-source state, and repository lists required redundant per-row source-count requests.

## Solution

- Run detached macOS lifecycle operations as independent launchd jobs with safe plist ownership, escaping, and cleanup.
- Keep uninstall and mount cleanup compatible with macOS Bash 3.2, and deduplicate APFS capacity by physical container while excluding reserved system volumes.
- Project the newest lifecycle task consistently into Node and backup-source status, including repeated observations and detached upgrade phases.
- Return tenant-scoped associated-source counts in repository list responses and consume them directly in the frontend.

## Validation

- Manual testing passed for the final tested tree.
- Affected Agent packages passed: `go test ./internal/platform/disk ./internal/platform/install`.
- Targeted Django Node, Source, and Storage suites passed: 137 tests. Ruff and migration drift checks passed.
- Targeted frontend regression tests passed: 8 tests. ESLint completed with zero errors and three existing warnings; production build passed.
- Full frontend suite retains the same unchanged `EmailCodeLoginForm.test.ts` assertion failure reproduced on canonical `origin/main` (`3a5c1edf`).
- Linux Agent CI-parity validation was unavailable locally because Docker Hub timed out during the Go image TLS handshake; affected macOS Agent packages passed.
- The optional complete Community backend suite was skipped at the user’s request.

## Risks and compatibility

The changes touch macOS lifecycle execution, disk accounting, backend projections, and frontend list contracts. Platform-specific and affected-component tests cover these boundaries; API additions are additive, and cleanup remains compatible with the Bash version shipped by macOS.

Fixes #874