### PR TITLE
Prevent background storage work from starving interactive workers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -107,6 +107,9 @@ CELERY_TASK_DEFAULT_QUEUE=backend
 # One Worker container uses four prefork processes so Controller-local work and
 # short interactive operations cannot consume all execution capacity.
 CELERY_WORKER_CONCURRENCY=4
+# Maximum Controller-local background storage operations. Defaults to half of
+# CELERY_WORKER_CONCURRENCY and must remain strictly lower than it.
+# CELERY_BACKGROUND_STORAGE_CONCURRENCY=2
 
 # Celery logging threshold.
 CELERY_LOG_LEVEL=INFO
@@ -535,6 +538,10 @@ GOSUMDB=sum.golang.org
 
 # Kopia command timeout in seconds.
 # HFL_KOPIA_TIMEOUT_SECONDS=120
+
+# Maximum time a Controller-local Kopia command waits for another command on
+# the same repository before reporting that the repository is busy.
+# HFL_KOPIA_CONFIG_LOCK_TIMEOUT_SECONDS=10
 
 # Maximum number of timestamped upgrade backup sets to retain.
 # HFL_BACKUP_RETENTION_COUNT=3

--- a/src/backend/apps/storage/apps.py
+++ b/src/backend/apps/storage/apps.py
@@ -12,12 +12,18 @@ class StorageConfig(AppConfig):
 
     def ready(self) -> None:
         # Fail fast on invalid storage task configuration.
-        from apps.storage.conf import repository_health_interval_seconds
+        from apps.storage.conf import (
+            background_storage_concurrency,
+            kopia_config_lock_timeout_seconds,
+            repository_health_interval_seconds,
+        )
         from apps.storage.services.internal.repository_operations import (
             maintenance_settings,
         )
 
         maintenance_settings()
+        background_storage_concurrency()
+        kopia_config_lock_timeout_seconds()
         repository_health_interval_seconds()
 
         # The release baseline must be valid before this process serves requests.

--- a/src/backend/apps/storage/conf.py
+++ b/src/backend/apps/storage/conf.py
@@ -25,6 +25,13 @@ REPOSITORY_HEALTH_INTERVAL_ENV = "STORAGE_REPOSITORY_HEALTH_INTERVAL_SECONDS"
 DEFAULT_REPOSITORY_HEALTH_INTERVAL_SECONDS = 300
 MIN_REPOSITORY_HEALTH_INTERVAL_SECONDS = 60
 
+CELERY_WORKER_CONCURRENCY_ENV = "CELERY_WORKER_CONCURRENCY"
+BACKGROUND_STORAGE_CONCURRENCY_ENV = "CELERY_BACKGROUND_STORAGE_CONCURRENCY"
+DEFAULT_CELERY_WORKER_CONCURRENCY = 4
+
+KOPIA_CONFIG_LOCK_TIMEOUT_ENV = "HFL_KOPIA_CONFIG_LOCK_TIMEOUT_SECONDS"
+DEFAULT_KOPIA_CONFIG_LOCK_TIMEOUT_SECONDS = 10
+
 PROVIDER_CATALOG_MAX_BYTES_ENV = "STORAGE_PROVIDER_CATALOG_MAX_BYTES"
 PROVIDER_CATALOG_MAX_DEPTH_ENV = "STORAGE_PROVIDER_CATALOG_MAX_DEPTH"
 PROVIDER_CATALOG_MAX_PROVIDERS_ENV = "STORAGE_PROVIDER_CATALOG_MAX_PROVIDERS"
@@ -74,6 +81,41 @@ def repository_health_interval_seconds() -> int:
             f"{MIN_REPOSITORY_HEALTH_INTERVAL_SECONDS} seconds."
         )
     return value
+
+
+def background_storage_concurrency() -> int:
+    """Return the shared Controller background-storage execution budget."""
+
+    worker_concurrency = _positive_int_setting(
+        CELERY_WORKER_CONCURRENCY_ENV,
+        DEFAULT_CELERY_WORKER_CONCURRENCY,
+    )
+    if worker_concurrency < 2:
+        raise ImproperlyConfigured(
+            f"{CELERY_WORKER_CONCURRENCY_ENV} must be at least 2 when "
+            "background storage work is enabled."
+        )
+    default_background = max(1, worker_concurrency // 2)
+    background_concurrency = _positive_int_setting(
+        BACKGROUND_STORAGE_CONCURRENCY_ENV,
+        default_background,
+    )
+    if background_concurrency >= worker_concurrency:
+        raise ImproperlyConfigured(
+            f"{BACKGROUND_STORAGE_CONCURRENCY_ENV} must be less than "
+            f"{CELERY_WORKER_CONCURRENCY_ENV}: background="
+            f"{background_concurrency}, worker={worker_concurrency}."
+        )
+    return background_concurrency
+
+
+def kopia_config_lock_timeout_seconds() -> int:
+    """Return the finite wait for one Controller-local Kopia config lock."""
+
+    return _positive_int_setting(
+        KOPIA_CONFIG_LOCK_TIMEOUT_ENV,
+        DEFAULT_KOPIA_CONFIG_LOCK_TIMEOUT_SECONDS,
+    )
 
 
 def _positive_int_setting(name: str, default: int) -> int:

--- a/src/backend/apps/storage/periodic_tasks.py
+++ b/src/backend/apps/storage/periodic_tasks.py
@@ -37,7 +37,12 @@ def register_periodic_tasks():
         args=(),
         # Every run owns a new logical 15-minute history slot. Do not reuse the
         # interactive refresh staleness gate, which is based on completion time.
-        kwargs={"limit": 200, "force": True, "stale_after_seconds": None},
+        kwargs={
+            "limit": 200,
+            "force": True,
+            "stale_after_seconds": None,
+            "background": True,
+        },
         queue=None,
         enabled=True,
         sync_existing_kwargs=True,

--- a/src/backend/apps/storage/services/internal/background_capacity.py
+++ b/src/backend/apps/storage/services/internal/background_capacity.py
@@ -1,0 +1,205 @@
+"""Shared admission control for Controller-local background storage work."""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+import uuid
+from functools import lru_cache
+
+from django.conf import settings
+from redis import Redis
+from redis.exceptions import RedisError
+
+from apps.storage.conf import background_storage_concurrency
+
+logger = logging.getLogger(__name__)
+
+_CAPACITY_KEY = "hfl:storage:background-capacity"
+_LEASE_SECONDS = 120
+_REFRESH_SECONDS = 30
+_REFRESH_RETRY_SECONDS = 5
+_LOCAL_EXPIRY_SAFETY_SECONDS = 2
+
+_ACQUIRE_SCRIPT = """
+local key = KEYS[1]
+local token = ARGV[1]
+local limit = tonumber(ARGV[2])
+local ttl = tonumber(ARGV[3])
+local now = tonumber(redis.call('TIME')[1])
+redis.call('zremrangebyscore', key, '-inf', now)
+if redis.call('zcard', key) >= limit then
+  return 0
+end
+redis.call('zadd', key, now + ttl, token)
+redis.call('expire', key, ttl * 2)
+return 1
+"""
+
+_REFRESH_SCRIPT = """
+local key = KEYS[1]
+local token = ARGV[1]
+local ttl = tonumber(ARGV[2])
+if not redis.call('zscore', key, token) then
+  return 0
+end
+local now = tonumber(redis.call('TIME')[1])
+redis.call('zadd', key, now + ttl, token)
+redis.call('expire', key, ttl * 2)
+return 1
+"""
+
+
+@lru_cache(maxsize=1)
+def _redis_client() -> Redis:
+    return Redis.from_url(
+        settings.CELERY_BROKER_URL,
+        decode_responses=True,
+        socket_connect_timeout=2,
+        socket_timeout=2,
+    )
+
+
+class BackgroundStorageLease:
+    """One renewable, fenced slot in the shared background storage budget."""
+
+    def __init__(
+        self,
+        *,
+        token: str,
+        operation: str,
+        confirmed_at: float | None = None,
+    ) -> None:
+        self.token = token
+        self.operation = operation
+        self._stop = threading.Event()
+        self._lost = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._confirmed_until = (
+            confirmed_at if confirmed_at is not None else time.monotonic()
+        ) + _LEASE_SECONDS - _LOCAL_EXPIRY_SAFETY_SECONDS
+
+    @property
+    def valid(self) -> bool:
+        return not self._lost.is_set()
+
+    def __enter__(self) -> BackgroundStorageLease:
+        self._thread = threading.Thread(
+            target=self._refresh_loop,
+            name=f"storage-background-lease-{self.token[-8:]}",
+            daemon=True,
+        )
+        self._thread.start()
+        return self
+
+    def __exit__(self, _exc_type, _exc, _traceback) -> None:
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=1)
+        self.release()
+
+    def _refresh_loop(self) -> None:
+        delay = _REFRESH_SECONDS
+        while not self._stop.wait(delay):
+            outcome = self._refresh_once()
+            if outcome is True:
+                delay = _REFRESH_SECONDS
+                continue
+            if outcome is False or time.monotonic() >= self._confirmed_until:
+                self._mark_lost()
+                return
+            delay = min(
+                _REFRESH_RETRY_SECONDS,
+                max(0.1, self._confirmed_until - time.monotonic()),
+            )
+
+    def refresh(self) -> bool:
+        """Renew once, returning false for both loss and temporary unavailability."""
+
+        return self._refresh_once() is True
+
+    def _refresh_once(self) -> bool | None:
+        confirmed_at = time.monotonic()
+        try:
+            refreshed = bool(
+                int(
+                    _redis_client().eval(
+                        _REFRESH_SCRIPT,
+                        1,
+                        _CAPACITY_KEY,
+                        self.token,
+                        _LEASE_SECONDS,
+                    )
+                    or 0
+                )
+            )
+        except (RedisError, TypeError, ValueError):
+            logger.warning(
+                "background storage capacity lease refresh failed operation=%s",
+                self.operation,
+            )
+            return None
+        if refreshed:
+            self._confirmed_until = (
+                confirmed_at + _LEASE_SECONDS - _LOCAL_EXPIRY_SAFETY_SECONDS
+            )
+        return refreshed
+
+    def _mark_lost(self) -> None:
+        self._lost.set()
+        logger.error(
+            "background storage capacity lease lost operation=%s token=%s",
+            self.operation,
+            self.token,
+        )
+
+    def release(self) -> bool:
+        try:
+            return bool(_redis_client().zrem(_CAPACITY_KEY, self.token))
+        except RedisError:
+            logger.warning(
+                "background storage capacity lease release failed operation=%s",
+                self.operation,
+            )
+            return False
+
+
+def try_acquire_background_storage_capacity(
+    *, operation: str, identity: str
+) -> BackgroundStorageLease | None:
+    """Acquire without blocking; unavailable coordination fails closed."""
+
+    token = f"{operation}:{identity}:{uuid.uuid4().hex}"
+    acquire_started_at = time.monotonic()
+    try:
+        acquired = int(
+            _redis_client().eval(
+                _ACQUIRE_SCRIPT,
+                1,
+                _CAPACITY_KEY,
+                token,
+                background_storage_concurrency(),
+                _LEASE_SECONDS,
+            )
+            or 0
+        )
+    except (RedisError, TypeError, ValueError):
+        logger.warning(
+            "background storage capacity unavailable operation=%s identity=%s",
+            operation,
+            identity,
+        )
+        return None
+    if acquired != 1:
+        logger.info(
+            "background storage capacity full operation=%s identity=%s",
+            operation,
+            identity,
+        )
+        return None
+    return BackgroundStorageLease(
+        token=token,
+        operation=operation,
+        confirmed_at=acquire_started_at,
+    )

--- a/src/backend/apps/storage/services/internal/kopia_cli.py
+++ b/src/backend/apps/storage/services/internal/kopia_cli.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import Callable
 
 from apps.storage.repositories.models import Repository
+from apps.storage.conf import kopia_config_lock_timeout_seconds
 from apps.storage.services.internal.s3_client import endpoint_for_kopia
 from apps.storage.services.internal.repository_secrets import (
     resolve_repository_secrets,
@@ -36,6 +37,10 @@ class KopiaCliError(Exception):
 
 
 class KopiaRepositoryAlreadyExistsError(KopiaCliError):
+    pass
+
+
+class KopiaRepositoryBusyError(KopiaCliError):
     pass
 
 
@@ -542,7 +547,19 @@ def _repository_config_lock(config_file: Path):
     lock_file = config_file.parent / ".repository.lock"
     lock_file.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
     with lock_file.open("a+", encoding="utf-8") as handle:
-        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        timeout_seconds = kopia_config_lock_timeout_seconds()
+        deadline = time.monotonic() + timeout_seconds
+        while True:
+            try:
+                fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                break
+            except BlockingIOError as exc:
+                if time.monotonic() >= deadline:
+                    raise KopiaRepositoryBusyError(
+                        "Another Controller operation is still using this repository. "
+                        "Please retry after it finishes."
+                    ) from exc
+                time.sleep(0.1)
         handle.truncate(0)
         handle.write(f"{os.getpid()}\n")
         handle.flush()

--- a/src/backend/apps/storage/services/internal/repository_check.py
+++ b/src/backend/apps/storage/services/internal/repository_check.py
@@ -23,6 +23,7 @@ from apps.storage.services.internal.repository_execution_lock import (
 from apps.storage.services.internal.repository_initializer import (
     RepositoryInitializationError,
 )
+from apps.storage.services.internal.kopia_cli import KopiaRepositoryBusyError
 from apps.storage.services.internal.repository_location import (
     invalidate_repository_location_ownership,
 )
@@ -213,7 +214,11 @@ def _run_repository_check_task_locked(*, repository_task_id: int) -> dict[str, A
         )
         return {"status": "success", "repository_task_id": repository_task.id}
     except Exception as exc:
-        if not health_persisted:
+        repository_busy = _exception_chain_contains(
+            exc,
+            KopiaRepositoryBusyError,
+        )
+        if not health_persisted and not repository_busy:
             if is_repository_ownership_failure(exc):
                 invalidate_repository_location_ownership(repository)
             Repository.objects.filter(pk=repository.id).update(
@@ -224,7 +229,13 @@ def _run_repository_check_task_locked(*, repository_task_id: int) -> dict[str, A
         _set_step(task, current_step, TaskStep.Status.FAILED, int(task.progress or 0))
         error_code = "REPOSITORY_CHECK_FAILED"
         message = _safe_error_message(repository, exc)
-        if isinstance(exc, RepositoryInitializationError):
+        if repository_busy:
+            error_code = "STORAGE.REPOSITORY_BUSY"
+            message = (
+                "The repository is busy with another operation. "
+                "Try again after it finishes."
+            )
+        elif isinstance(exc, RepositoryInitializationError):
             failure = classify_s3_validation_error(exc, operation="bucket_access")
             error_code = failure.code
             message = failure.message
@@ -269,6 +280,20 @@ def _safe_error_message(repository: Repository, exc: Exception) -> str:
             extra_values=secret_values_for_scrub(repository, secrets_payload),
         )
     )
+
+
+def _exception_chain_contains(
+    exc: BaseException,
+    expected_type: type[BaseException],
+) -> bool:
+    current: BaseException | None = exc
+    seen: set[int] = set()
+    while current is not None and id(current) not in seen:
+        if isinstance(current, expected_type):
+            return True
+        seen.add(id(current))
+        current = current.__cause__ or current.__context__
+    return False
 
 
 __all__ = [

--- a/src/backend/apps/storage/services/internal/repository_usage.py
+++ b/src/backend/apps/storage/services/internal/repository_usage.py
@@ -5,7 +5,7 @@ import logging
 import re
 from dataclasses import dataclass
 from datetime import timedelta
-from typing import Any
+from typing import Any, Callable
 
 from django.apps import apps
 from django.core.cache import cache
@@ -21,6 +21,7 @@ from apps.storage.repositories.models import (
 )
 from apps.storage.services.internal.kopia_cli import (
     KopiaCliError,
+    KopiaRepositoryBusyError,
     connect_s3_repository,
     content_stats as kopia_content_stats,
 )
@@ -252,6 +253,8 @@ def kopia_repository_estimated_usage_bytes(repository: Repository) -> int | None
         result = kopia_content_stats(repository)
         packed = parse_kopia_content_stats(result.stdout)
         return kopia_estimated_usage_from_packed(packed)
+    except KopiaRepositoryBusyError:
+        raise
     except KopiaCliError as exc:
         logger.info("kopia content stats unavailable for repository %s: %s", repository.id, exc)
         return None
@@ -1119,13 +1122,19 @@ def _sync_repository_usage_candidates(
     *,
     recorded_at=None,
     async_agent_probes: bool = False,
+    should_continue: Callable[[], bool] | None = None,
 ) -> dict[str, Any]:
     attempted = 0
     synced = 0
     snapshots_upserted = 0
     observations_dispatched = 0
     failed_repository_ids: list[int] = []
+    deferred_repository_ids: list[int] = []
+    stopped_early = False
     for repository in repositories:
+        if should_continue is not None and not should_continue():
+            stopped_early = True
+            break
         attempted += 1
         try:
             if async_agent_probes and repository.repo_type in {
@@ -1144,6 +1153,13 @@ def _sync_repository_usage_candidates(
             else:
                 sync_repository_usage(repository, recorded_at=recorded_at)
                 snapshots_upserted += 1
+        except KopiaRepositoryBusyError:
+            deferred_repository_ids.append(repository.id)
+            logger.info(
+                "repository usage sync deferred; repository busy repository_id=%s",
+                repository.id,
+            )
+            continue
         except Exception:
             failed_repository_ids.append(repository.id)
             logger.exception(
@@ -1159,6 +1175,9 @@ def _sync_repository_usage_candidates(
         "repositories_synced": synced,
         "repositories_failed": len(failed_repository_ids),
         "failed_repository_ids": failed_repository_ids,
+        "repositories_deferred": len(deferred_repository_ids),
+        "deferred_repository_ids": deferred_repository_ids,
+        "stopped_early": stopped_early,
         "snapshots_upserted": snapshots_upserted,
         "observations_dispatched": observations_dispatched,
     }
@@ -1174,6 +1193,7 @@ def sync_organization_repositories(
     stale_after_seconds: int | None = None,
     recorded_at=None,
     async_agent_probes: bool = False,
+    should_continue: Callable[[], bool] | None = None,
 ) -> dict[str, Any]:
     ids = _normalize_repository_ids(repository_ids)
     logger.info(
@@ -1197,6 +1217,7 @@ def sync_organization_repositories(
         qs,
         recorded_at=recorded_at,
         async_agent_probes=async_agent_probes,
+        should_continue=should_continue,
     )
     logger.info(
         "repository usage sync org finished org_id=%s repositories_attempted=%s "
@@ -1217,6 +1238,7 @@ def sync_all_repositories(
     stale_after_seconds: int | None = None,
     recorded_at=None,
     async_agent_probes: bool = False,
+    should_continue: Callable[[], bool] | None = None,
 ) -> dict[str, Any]:
     logger.info(
         "repository usage sync all started limit=%s repo_type=%s force=%s stale_after_seconds=%s",
@@ -1235,6 +1257,7 @@ def sync_all_repositories(
         qs,
         recorded_at=recorded_at,
         async_agent_probes=async_agent_probes,
+        should_continue=should_continue,
     )
     logger.info(
         "repository usage sync all finished repositories_attempted=%s "
@@ -1310,6 +1333,7 @@ def enqueue_repository_usage_refresh(
                 "limit": max(1, int(limit or 1)),
                 "force": bool(force),
                 "stale_after_seconds": stale_after_seconds,
+                "background": False,
             }
         )
     except Exception as exc:

--- a/src/backend/apps/storage/tasks.py
+++ b/src/backend/apps/storage/tasks.py
@@ -20,6 +20,10 @@ from apps.storage.repositories.models import (
     RepositoryExecutionTarget,
     RepositoryTask,
 )
+from apps.storage.services.internal.background_capacity import (
+    BackgroundStorageLease,
+    try_acquire_background_storage_capacity,
+)
 from apps.storage.services.internal.repository_location import (
     invalidate_repository_location_ownership,
 )
@@ -41,6 +45,7 @@ from apps.storage.services.internal.kopia_cli import (
     KopiaCliError,
     KopiaControlDecision,
     KopiaExecutionLeaseLost,
+    KopiaRepositoryBusyError,
     run_maintenance,
 )
 from apps.storage.services.internal.repository_access import repository_payload_for_node
@@ -132,7 +137,7 @@ def enqueue_startup_repository_health_checks(sender=None, **_kwargs) -> None:
 @shared_task(name="apps.storage.tasks.reconcile_storage_repositories")
 @logged_celery_task(
     name="apps.storage.tasks.reconcile_storage_repositories",
-    trace_keys=("organization_id", "repo_type", "limit", "force"),
+    trace_keys=("organization_id", "repo_type", "limit", "force", "background"),
 )
 def reconcile_storage_repositories(
     *,
@@ -142,29 +147,67 @@ def reconcile_storage_repositories(
     limit: int = 200,
     force: bool = False,
     stale_after_seconds: int | None = 900,
+    background: bool = False,
 ):
     """Refresh repository capacity and usage metrics for dashboards and alerts."""
-    recorded_at = timezone.now()
-    if organization_id is not None:
-        result = sync_organization_repositories(
-            organization_id=int(organization_id),
-            repository_ids=repository_ids or None,
+    background_lease = None
+    if background:
+        background_lease = try_acquire_background_storage_capacity(
+            operation="repository-usage-sync",
+            identity=str(uuid4()),
+        )
+        if background_lease is None:
+            return {
+                "repositories_scanned": 0,
+                "repositories_synced": 0,
+                "repositories_failed": 0,
+                "failed_repository_ids": [],
+                "repositories_deferred": 0,
+                "deferred_repository_ids": [],
+                "stopped_early": False,
+                "snapshots_upserted": 0,
+                "snapshots_marked_deleted": 0,
+                "observations_dispatched": 0,
+                "status": "deferred_background_capacity",
+            }
+
+    def synchronize() -> dict:
+        recorded_at = timezone.now()
+        if organization_id is not None:
+            return sync_organization_repositories(
+                organization_id=int(organization_id),
+                repository_ids=repository_ids or None,
+                repo_type=repo_type,
+                limit=limit,
+                force=force,
+                stale_after_seconds=stale_after_seconds,
+                recorded_at=recorded_at,
+                async_agent_probes=True,
+                should_continue=(
+                    (lambda: background_lease.valid)
+                    if background_lease is not None
+                    else None
+                ),
+            )
+        return sync_all_repositories(
             repo_type=repo_type,
             limit=limit,
             force=force,
             stale_after_seconds=stale_after_seconds,
             recorded_at=recorded_at,
             async_agent_probes=True,
+            should_continue=(
+                (lambda: background_lease.valid)
+                if background_lease is not None
+                else None
+            ),
         )
+
+    if background_lease is None:
+        result = synchronize()
     else:
-        result = sync_all_repositories(
-            repo_type=repo_type,
-            limit=limit,
-            force=force,
-            stale_after_seconds=stale_after_seconds,
-            recorded_at=recorded_at,
-            async_agent_probes=True,
-        )
+        with background_lease:
+            result = synchronize()
     return {
         "repositories_scanned": result.get(
             "repositories_attempted", result.get("repositories_synced", 0)
@@ -172,6 +215,9 @@ def reconcile_storage_repositories(
         "repositories_synced": result.get("repositories_synced", 0),
         "repositories_failed": result.get("repositories_failed", 0),
         "failed_repository_ids": result.get("failed_repository_ids", []),
+        "repositories_deferred": result.get("repositories_deferred", 0),
+        "deferred_repository_ids": result.get("deferred_repository_ids", []),
+        "stopped_early": bool(result.get("stopped_early", False)),
         "snapshots_upserted": result.get("snapshots_upserted", 0),
         "snapshots_marked_deleted": 0,
         "observations_dispatched": result.get("observations_dispatched", 0),
@@ -250,6 +296,12 @@ def check_storage_repository_health(*, repository_id: int, retry_attempt: int = 
                 "probe_status": "bound_node_offline",
                 "health_failures": repository.health_failures,
             }
+        if repository.repo_type == Repository.Type.S3:
+            if _controller_maintenance_is_running(repository.id):
+                return _deferred_repository_health_result(
+                    repository,
+                    probe_status="deferred_maintenance",
+                )
         try:
             node_tasks = dispatch_automatic_repository_observation(
                 repository=repository,
@@ -270,9 +322,29 @@ def check_storage_repository_health(*, repository_id: int, retry_attempt: int = 
                 "node_task_ids": [str(node_task.id) for node_task in node_tasks],
                 "node_task_id": str(node_tasks[0].id) if node_tasks else "",
             }
+        background_lease = None
+        if repository.repo_type == Repository.Type.S3:
+            background_lease = try_acquire_background_storage_capacity(
+                operation="repository-health",
+                identity=str(repository.id),
+            )
+            if background_lease is None:
+                return _deferred_repository_health_result(
+                    repository,
+                    probe_status="deferred_background_capacity",
+                )
         try:
-            health = probe_repository_health(repository)
+            if background_lease is None:
+                health = probe_repository_health(repository)
+            else:
+                with background_lease:
+                    health = probe_repository_health(repository)
         except Exception as exc:
+            if _exception_chain_contains(exc, KopiaRepositoryBusyError):
+                return _deferred_repository_health_result(
+                    repository,
+                    probe_status="deferred_repository_busy",
+                )
             logger.warning(
                 "repository health check failed repository_id=%s retry_attempt=%s error_type=%s",
                 repository_id,
@@ -321,6 +393,42 @@ def check_storage_repository_health(*, repository_id: int, retry_attempt: int = 
         return {"repository_id": repository_id, "status": health}
     finally:
         cache.delete(lock_key)
+
+
+def _controller_maintenance_is_running(repository_id: int) -> bool:
+    return RepositoryTask.objects.filter(
+        repository_id=repository_id,
+        owner_type=RepositoryExecutionTarget.OwnerType.CONTROLLER,
+        operation_type__in=[
+            RepositoryTask.OperationType.MAINTENANCE_QUICK,
+            RepositoryTask.OperationType.MAINTENANCE_FULL,
+        ],
+        task__status=Task.Status.RUNNING,
+    ).exists()
+
+
+def _deferred_repository_health_result(
+    repository: Repository,
+    *,
+    probe_status: str,
+) -> dict:
+    return {
+        "repository_id": repository.id,
+        "status": repository.health,
+        "probe_status": probe_status,
+        "health_failures": repository.health_failures,
+    }
+
+
+def _exception_chain_contains(exc: Exception, expected_type: type[Exception]) -> bool:
+    current: BaseException | None = exc
+    seen: set[int] = set()
+    while current is not None and id(current) not in seen:
+        if isinstance(current, expected_type):
+            return True
+        seen.add(id(current))
+        current = current.__cause__ or current.__context__
+    return False
 
 
 def _record_repository_health_failure(
@@ -440,12 +548,35 @@ def reconcile_repository_operations(*, limit: int = 100):
 def execute_repository_operation(*, repository_task_id: int):
     task_identity = (
         RepositoryTask.objects.filter(pk=repository_task_id)
-        .values_list("owner_type", "operation_type")
+        .values_list("owner_type", "operation_type", "task__status")
         .first()
     )
     if task_identity is None:
         raise RepositoryTask.DoesNotExist(repository_task_id)
-    owner_type, operation_type = task_identity
+    owner_type, operation_type, task_status = task_identity
+    is_controller_maintenance = (
+        owner_type == RepositoryExecutionTarget.OwnerType.CONTROLLER
+        and operation_type
+        in {
+            RepositoryTask.OperationType.MAINTENANCE_QUICK,
+            RepositoryTask.OperationType.MAINTENANCE_FULL,
+        }
+    )
+    if is_controller_maintenance and task_status == Task.Status.PENDING:
+        background_lease = try_acquire_background_storage_capacity(
+            operation="repository-maintenance",
+            identity=str(repository_task_id),
+        )
+        if background_lease is None:
+            return {
+                "status": "deferred_background_capacity",
+                "repository_task_id": repository_task_id,
+            }
+        with background_lease:
+            return _execute_repository_operation(
+                repository_task_id=repository_task_id,
+                background_lease=background_lease,
+            )
     is_cleanup = operation_type in {
         RepositoryTask.OperationType.CLEANUP_TARGET,
         RepositoryTask.OperationType.CLEANUP_REPOSITORY,
@@ -487,7 +618,11 @@ def execute_repository_operation(*, repository_task_id: int):
             cache.delete(lock_key)
 
 
-def _execute_repository_operation(*, repository_task_id: int):
+def _execute_repository_operation(
+    *,
+    repository_task_id: int,
+    background_lease: BackgroundStorageLease | None = None,
+):
     repository_task = RepositoryTask.objects.select_related(
         "task", "repository", "execution_target"
     ).get(pk=repository_task_id)
@@ -590,6 +725,7 @@ def _execute_repository_operation(*, repository_task_id: int):
             repository_task,
             allow_dispatch=started_now,
             execution_token=execution_token,
+            background_lease=background_lease,
         )
         if operation.waiting:
             return {
@@ -666,6 +802,27 @@ def _execute_repository_operation(*, repository_task_id: int):
             "repository_task_id": repository_task.id,
         }
     except KopiaExecutionLeaseLost:
+        if background_lease is not None and not background_lease.valid:
+            logger.warning(
+                "repository operation background capacity lease lost "
+                "repository_task_id=%s task_uuid=%s",
+                repository_task.id,
+                task.task_uuid,
+            )
+            failed_task = finalize_repository_operation(
+                repository_task_id=repository_task.id,
+                succeeded=False,
+                error_code="BACKGROUND_STORAGE_CAPACITY_LOST",
+                error_message=(
+                    "Controller background storage capacity coordination was lost. "
+                    "The maintenance process was stopped and will be retried."
+                ),
+                expected_execution_token=execution_token,
+            )
+            return {
+                "status": failed_task.status,
+                "repository_task_id": repository_task.id,
+            }
         logger.warning(
             "repository operation execution lease lost repository_task_id=%s task_uuid=%s",
             repository_task.id,
@@ -881,6 +1038,7 @@ def _execute_maintenance(
     *,
     allow_dispatch: bool = True,
     execution_token: UUID | None = None,
+    background_lease: BackgroundStorageLease | None = None,
 ) -> RepositoryAgentOperationResult:
     if repository_task.operation_type not in {
         RepositoryTask.OperationType.MAINTENANCE_QUICK,
@@ -898,6 +1056,10 @@ def _execute_maintenance(
             raise KopiaExecutionLeaseLost(
                 "Controller repository maintenance has no execution lease"
             )
+        if background_lease is None or not background_lease.valid:
+            raise KopiaExecutionLeaseLost(
+                "Controller repository maintenance has no background capacity lease"
+            )
         result = run_maintenance(
             repository_task.repository,
             full=full,
@@ -907,8 +1069,13 @@ def _execute_maintenance(
                 repository_task_id=repository_task.id,
                 execution_token=execution_token,
                 heartbeat_interval_seconds=settings.heartbeat_interval_seconds,
+                background_lease=background_lease,
             ),
         )
+        if not background_lease.valid:
+            raise KopiaExecutionLeaseLost(
+                "Controller repository maintenance background capacity lease was lost"
+            )
         return RepositoryAgentOperationResult(
             waiting=False,
             node_task_id=repository_task.remote_task_id,
@@ -973,11 +1140,14 @@ def _controller_execution_control(
     repository_task_id: int,
     execution_token: UUID,
     heartbeat_interval_seconds: int,
+    background_lease: BackgroundStorageLease,
 ):
     next_heartbeat = time.monotonic() + heartbeat_interval_seconds
 
     def control() -> KopiaControlDecision:
         nonlocal next_heartbeat
+        if not background_lease.valid:
+            return KopiaControlDecision.LOST_LEASE
         state = (
             RepositoryTask.objects.filter(
                 pk=repository_task_id,

--- a/src/backend/apps/storage/tests/test_background_storage_capacity.py
+++ b/src/backend/apps/storage/tests/test_background_storage_capacity.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import os
+from unittest import mock
+from uuid import uuid4
+
+from django.core.exceptions import ImproperlyConfigured
+from django.test import SimpleTestCase
+from redis.exceptions import RedisError
+
+from apps.storage.conf import background_storage_concurrency
+from apps.storage.services.internal.background_capacity import (
+    BackgroundStorageLease,
+    try_acquire_background_storage_capacity,
+)
+from apps.storage.services.internal.kopia_cli import KopiaControlDecision
+from apps.storage.tasks import _controller_execution_control
+
+
+class BackgroundStorageConfigurationTests(SimpleTestCase):
+    def _configured_capacity(self, *, worker: str, background: str | None) -> int:
+        with mock.patch.dict(
+            os.environ,
+            {"CELERY_WORKER_CONCURRENCY": worker},
+            clear=False,
+        ):
+            os.environ.pop("CELERY_BACKGROUND_STORAGE_CONCURRENCY", None)
+            if background is not None:
+                os.environ["CELERY_BACKGROUND_STORAGE_CONCURRENCY"] = background
+            return background_storage_concurrency()
+
+    def test_defaults_to_half_of_worker_concurrency(self):
+        self.assertEqual(self._configured_capacity(worker="4", background=None), 2)
+        self.assertEqual(self._configured_capacity(worker="3", background=None), 1)
+
+    def test_allows_capacity_above_half_but_below_worker_count(self):
+        self.assertEqual(self._configured_capacity(worker="4", background="3"), 3)
+
+    def test_rejects_capacity_that_could_exhaust_every_worker(self):
+        with self.assertRaises(ImproperlyConfigured):
+            self._configured_capacity(worker="4", background="4")
+
+    def test_rejects_single_process_worker_configuration(self):
+        with self.assertRaises(ImproperlyConfigured):
+            self._configured_capacity(worker="1", background=None)
+
+
+class BackgroundStorageLeaseTests(SimpleTestCase):
+    @mock.patch(
+        "apps.storage.services.internal.background_capacity."
+        "background_storage_concurrency",
+        return_value=2,
+    )
+    @mock.patch("apps.storage.services.internal.background_capacity._redis_client")
+    def test_acquires_refreshes_and_releases_fenced_slot(
+        self,
+        redis_client,
+        _capacity,
+    ):
+        client = redis_client.return_value
+        client.eval.return_value = 1
+        client.zrem.return_value = 1
+
+        lease = try_acquire_background_storage_capacity(
+            operation="maintenance",
+            identity="repository-7",
+        )
+
+        self.assertIsInstance(lease, BackgroundStorageLease)
+        self.assertTrue(lease.refresh())
+        self.assertTrue(lease.release())
+        self.assertIn("maintenance:repository-7:", lease.token)
+        client.zrem.assert_called_once_with(
+            "hfl:storage:background-capacity",
+            lease.token,
+        )
+
+    @mock.patch(
+        "apps.storage.services.internal.background_capacity."
+        "background_storage_concurrency",
+        return_value=2,
+    )
+    @mock.patch("apps.storage.services.internal.background_capacity._redis_client")
+    def test_returns_none_when_capacity_is_full(self, redis_client, _capacity):
+        redis_client.return_value.eval.return_value = 0
+
+        lease = try_acquire_background_storage_capacity(
+            operation="health",
+            identity="repository-8",
+        )
+
+        self.assertIsNone(lease)
+
+    def test_lost_capacity_lease_stops_controller_maintenance(self):
+        lease = mock.Mock(valid=False)
+        control = _controller_execution_control(
+            repository_task_id=7,
+            execution_token=uuid4(),
+            heartbeat_interval_seconds=10,
+            background_lease=lease,
+        )
+
+        self.assertEqual(control(), KopiaControlDecision.LOST_LEASE)
+
+    @mock.patch("apps.storage.services.internal.background_capacity._redis_client")
+    def test_temporary_refresh_failure_does_not_immediately_lose_lease(
+        self,
+        redis_client,
+    ):
+        redis_client.return_value.eval.side_effect = RedisError("temporary outage")
+        lease = BackgroundStorageLease(
+            token="maintenance:repository-7:token",
+            operation="maintenance",
+        )
+
+        self.assertIsNone(lease._refresh_once())
+        self.assertTrue(lease.valid)
+
+    @mock.patch("apps.storage.services.internal.background_capacity._redis_client")
+    def test_missing_redis_lease_is_authoritative_loss(self, redis_client):
+        redis_client.return_value.eval.return_value = 0
+        lease = BackgroundStorageLease(
+            token="maintenance:repository-7:token",
+            operation="maintenance",
+        )
+
+        self.assertFalse(lease._refresh_once())
+        lease._mark_lost()
+        self.assertFalse(lease.valid)
+
+    @mock.patch("apps.storage.services.internal.background_capacity._redis_client")
+    def test_coordination_failure_fails_closed(self, redis_client):
+        redis_client.return_value.eval.side_effect = RedisError("unavailable")
+
+        lease = try_acquire_background_storage_capacity(
+            operation="usage",
+            identity="periodic",
+        )
+
+        self.assertIsNone(lease)

--- a/src/backend/apps/storage/tests/test_kopia_config_lock.py
+++ b/src/backend/apps/storage/tests/test_kopia_config_lock.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import mock
+
+from django.test import SimpleTestCase
+
+from apps.storage.services.internal.kopia_cli import (
+    KopiaRepositoryBusyError,
+    _repository_config_lock,
+)
+
+
+class KopiaConfigLockTests(SimpleTestCase):
+    def test_acquires_and_releases_repository_lock(self):
+        with TemporaryDirectory() as temporary_directory:
+            config_file = Path(temporary_directory) / "repository.config"
+
+            with _repository_config_lock(config_file):
+                self.assertTrue((config_file.parent / ".repository.lock").exists())
+
+    @mock.patch(
+        "apps.storage.services.internal.kopia_cli.time.monotonic",
+        side_effect=[0.0, 1.0],
+    )
+    @mock.patch(
+        "apps.storage.services.internal.kopia_cli.fcntl.flock",
+        side_effect=BlockingIOError,
+    )
+    def test_reports_busy_after_finite_wait(self, _flock, _monotonic):
+        with (
+            TemporaryDirectory() as temporary_directory,
+            mock.patch.dict(
+                os.environ,
+                {"HFL_KOPIA_CONFIG_LOCK_TIMEOUT_SECONDS": "1"},
+            ),
+            self.assertRaises(KopiaRepositoryBusyError),
+        ):
+            config_file = Path(temporary_directory) / "repository.config"
+            with _repository_config_lock(config_file):
+                self.fail("busy repository lock must not be acquired")

--- a/src/backend/apps/storage/tests/test_repository_api.py
+++ b/src/backend/apps/storage/tests/test_repository_api.py
@@ -1984,6 +1984,7 @@ class StorageRepositoryApiTests(TestCase):
         self.assertEqual(kwargs["repo_type"], Repository.Type.NAS)
         self.assertEqual(kwargs["limit"], 200)
         self.assertEqual(kwargs["stale_after_seconds"], 900)
+        self.assertFalse(kwargs["background"])
 
     @mock.patch("apps.storage.tasks.reconcile_storage_repositories.apply_async")
     def test_sync_usage_detail_queues_single_repository_refresh(self, apply_async):
@@ -2010,6 +2011,7 @@ class StorageRepositoryApiTests(TestCase):
         self.assertEqual(kwargs["organization_id"], self.org.id)
         self.assertEqual(kwargs["repository_ids"], [repo.id])
         self.assertEqual(kwargs["force"], True)
+        self.assertFalse(kwargs["background"])
 
     @mock.patch("apps.storage.repositories.views.validate_s3_connection")
     def test_validate_s3_connection_returns_buckets(self, validate_s3_connection):

--- a/src/backend/apps/storage/tests/test_repository_health_tasks.py
+++ b/src/backend/apps/storage/tests/test_repository_health_tasks.py
@@ -28,6 +28,7 @@ from apps.storage.services.interface import check_repository
 from apps.storage.services.internal.repository_initializer import (
     RepositoryInitializationError,
 )
+from apps.storage.services.internal.kopia_cli import KopiaRepositoryBusyError
 from apps.storage.services.internal.nas_repository import (
     NASRepositoryError,
     check_proxy_nas_repository,
@@ -174,6 +175,14 @@ class RepositoryHealthTaskTests(TestCase):
             key="health-task-org",
             name="Health Task Org",
         )
+        self.background_lease = mock.MagicMock(valid=True)
+        self.background_lease.__enter__.return_value = self.background_lease
+        background_capacity_patcher = mock.patch(
+            "apps.storage.tasks.try_acquire_background_storage_capacity",
+            return_value=self.background_lease,
+        )
+        self.background_capacity = background_capacity_patcher.start()
+        self.addCleanup(background_capacity_patcher.stop)
 
     def _repository(self, name: str, repo_type: str, **kwargs) -> Repository:
         return Repository.objects.create(
@@ -234,6 +243,85 @@ class RepositoryHealthTaskTests(TestCase):
 
         self.assertTrue(result["locked"])
         cache_delete.assert_not_called()
+
+    @mock.patch(
+        "apps.storage.tasks._controller_maintenance_is_running",
+        return_value=True,
+    )
+    @mock.patch("apps.storage.tasks.cache.delete")
+    @mock.patch("apps.storage.tasks.cache.add", return_value=True)
+    def test_s3_health_defers_while_controller_maintenance_is_running(
+        self,
+        _cache_add,
+        _cache_delete,
+        _maintenance_running,
+    ):
+        repository = self._repository(
+            "s3-maintenance",
+            Repository.Type.S3,
+            s3_bucket="bucket",
+            health_failures=1,
+        )
+
+        result = check_storage_repository_health.run(repository_id=repository.id)
+
+        repository.refresh_from_db()
+        self.assertEqual(result["probe_status"], "deferred_maintenance")
+        self.assertEqual(repository.health, Repository.Health.ONLINE)
+        self.assertEqual(repository.health_failures, 1)
+        self.background_capacity.assert_not_called()
+
+    @mock.patch("apps.storage.tasks.probe_repository_health")
+    @mock.patch("apps.storage.tasks.cache.delete")
+    @mock.patch("apps.storage.tasks.cache.add", return_value=True)
+    def test_s3_health_defers_when_background_capacity_is_full(
+        self,
+        _cache_add,
+        _cache_delete,
+        probe,
+    ):
+        repository = self._repository(
+            "s3-capacity",
+            Repository.Type.S3,
+            s3_bucket="bucket",
+            health_failures=1,
+        )
+        self.background_capacity.return_value = None
+
+        result = check_storage_repository_health.run(repository_id=repository.id)
+
+        repository.refresh_from_db()
+        self.assertEqual(
+            result["probe_status"],
+            "deferred_background_capacity",
+        )
+        self.assertEqual(repository.health_failures, 1)
+        probe.assert_not_called()
+
+    @mock.patch("apps.storage.tasks.probe_repository_health")
+    @mock.patch("apps.storage.tasks.cache.delete")
+    @mock.patch("apps.storage.tasks.cache.add", return_value=True)
+    def test_s3_health_treats_busy_kopia_config_as_deferred(
+        self,
+        _cache_add,
+        _cache_delete,
+        probe,
+    ):
+        repository = self._repository(
+            "s3-busy",
+            Repository.Type.S3,
+            s3_bucket="bucket",
+            health_failures=1,
+        )
+        wrapped = RepositoryInitializationError("repository busy")
+        wrapped.__cause__ = KopiaRepositoryBusyError("repository busy")
+        probe.side_effect = wrapped
+
+        result = check_storage_repository_health.run(repository_id=repository.id)
+
+        repository.refresh_from_db()
+        self.assertEqual(result["probe_status"], "deferred_repository_busy")
+        self.assertEqual(repository.health_failures, 1)
 
     @mock.patch("apps.storage.tasks.dispatch_automatic_repository_observation")
     @mock.patch("apps.storage.tasks.cache.delete")
@@ -403,6 +491,7 @@ class RepositoryHealthTaskTests(TestCase):
         self.assertEqual(result["probe_status"], "dispatched")
         self.assertEqual(result["node_task_id"], "node-task-id")
         synchronous_probe.assert_not_called()
+        self.background_capacity.assert_not_called()
 
     @mock.patch("apps.storage.tasks.cache.delete")
     @mock.patch("apps.storage.tasks.cache.add", return_value=True)
@@ -441,6 +530,7 @@ class RepositoryHealthTaskTests(TestCase):
         self.assertEqual(repository.config, original_config)
         self.assertEqual(repository.capacity_bytes, 1000)
         self.assertEqual(repository.estimated_usage_bytes, 250)
+        self.background_lease.__exit__.assert_called_once()
 
     @mock.patch("apps.storage.tasks.dispatch_repository_health_checks.apply_async")
     def test_worker_ready_enqueues_startup_health_dispatch(self, apply_async):

--- a/src/backend/apps/storage/tests/test_repository_tasks.py
+++ b/src/backend/apps/storage/tests/test_repository_tasks.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from django.contrib.auth import get_user_model
 from django.test import TestCase
@@ -21,6 +21,7 @@ from apps.storage.services.internal.repository_operations import (
     schedule_due_maintenance,
     start_controller_repository_operation,
 )
+from apps.storage.services.internal.kopia_cli import KopiaExecutionLeaseLost
 from apps.storage.services.internal.nas_repository import nas_agent_repository_subdir
 from apps.storage.services.internal.repository_location import (
     mark_repository_location_owned,
@@ -480,6 +481,101 @@ class RepositoryTaskTests(TestCase):
         self.assertIsNone(target.active_task_id)
         self.assertIsNotNone(target.maintenance_state.last_quick_success_at)
         self.assertEqual(target.maintenance_state.consecutive_failures, 0)
+
+    @patch("apps.storage.tasks._execute_repository_operation")
+    @patch("apps.storage.tasks.try_acquire_background_storage_capacity")
+    def test_controller_maintenance_runs_with_background_capacity(
+        self,
+        acquire_capacity,
+        execute_operation,
+    ):
+        discover_repository_execution_targets()
+        repository_task = create_repository_operation_task(
+            target_id=self.repository.execution_targets.get().id,
+            operation_type=RepositoryTask.OperationType.MAINTENANCE_QUICK,
+        )
+        lease = MagicMock(valid=True)
+        lease.__enter__.return_value = lease
+        acquire_capacity.return_value = lease
+        execute_operation.return_value = {"status": Task.Status.SUCCESS}
+
+        result = execute_repository_operation.run(
+            repository_task_id=repository_task.id,
+        )
+
+        self.assertEqual(result["status"], Task.Status.SUCCESS)
+        execute_operation.assert_called_once_with(
+            repository_task_id=repository_task.id,
+            background_lease=lease,
+        )
+        lease.__enter__.assert_called_once()
+        lease.__exit__.assert_called_once()
+
+    @patch("apps.storage.tasks._execute_repository_operation")
+    @patch(
+        "apps.storage.tasks.try_acquire_background_storage_capacity",
+        return_value=None,
+    )
+    def test_controller_maintenance_stays_pending_without_background_capacity(
+        self,
+        _acquire_capacity,
+        execute_operation,
+    ):
+        discover_repository_execution_targets()
+        repository_task = create_repository_operation_task(
+            target_id=self.repository.execution_targets.get().id,
+            operation_type=RepositoryTask.OperationType.MAINTENANCE_QUICK,
+        )
+
+        result = execute_repository_operation.run(
+            repository_task_id=repository_task.id,
+        )
+
+        repository_task.task.refresh_from_db()
+        self.assertEqual(result["status"], "deferred_background_capacity")
+        self.assertEqual(repository_task.task.status, Task.Status.PENDING)
+        execute_operation.assert_not_called()
+
+    @patch("apps.storage.tasks.run_maintenance")
+    @patch("apps.storage.tasks.try_acquire_background_storage_capacity")
+    def test_lost_background_capacity_fails_maintenance_for_normal_retry(
+        self,
+        acquire_capacity,
+        run_maintenance,
+    ):
+        discover_repository_execution_targets()
+        repository_task = create_repository_operation_task(
+            target_id=self.repository.execution_targets.get().id,
+            operation_type=RepositoryTask.OperationType.MAINTENANCE_QUICK,
+        )
+        lease = MagicMock(valid=True)
+        lease.__enter__.return_value = lease
+        acquire_capacity.return_value = lease
+
+        def lose_capacity(*_args, **_kwargs):
+            lease.valid = False
+            raise KopiaExecutionLeaseLost("capacity lease lost")
+
+        run_maintenance.side_effect = lose_capacity
+
+        result = execute_repository_operation.run(
+            repository_task_id=repository_task.id,
+        )
+
+        repository_task.refresh_from_db()
+        repository_task.task.refresh_from_db()
+        repository_task.execution_target.refresh_from_db()
+        self.assertEqual(result["status"], Task.Status.FAILED)
+        self.assertEqual(repository_task.task.status, Task.Status.FAILED)
+        self.assertEqual(
+            repository_task.task.error_code,
+            "BACKGROUND_STORAGE_CAPACITY_LOST",
+        )
+        self.assertIsNone(repository_task.execution_target.active_task_id)
+        self.assertIsNone(repository_task.execution_token)
+        self.assertIsNotNone(
+            repository_task.execution_target.maintenance_state.next_retry_at
+        )
 
     @patch.dict(
         "os.environ",

--- a/src/backend/apps/storage/tests/test_repository_usage.py
+++ b/src/backend/apps/storage/tests/test_repository_usage.py
@@ -15,6 +15,7 @@ from apps.storage.repositories.models import (
     RepositoryLocationClaim,
     RepositoryUsageShard,
 )
+from apps.storage.services.internal.kopia_cli import KopiaRepositoryBusyError
 from apps.storage.services.internal.nas_repository import nas_agent_repository_subdir
 from apps.storage.services.internal.repository_location import (
     mark_repository_location_owned,
@@ -26,6 +27,7 @@ from apps.storage.services.internal.repository_usage import (
     assert_repository_quota_available,
     capacity_bytes_from_config,
     kopia_estimated_usage_from_packed,
+    kopia_repository_estimated_usage_bytes,
     parse_kopia_content_stats,
     sync_all_repositories,
     sync_organization_repositories,
@@ -271,6 +273,20 @@ class RepositoryUsageTests(TestCase):
     def test_kopia_estimated_usage_from_packed(self):
         self.assertEqual(kopia_estimated_usage_from_packed(100), 105)
 
+    @mock.patch(
+        "apps.storage.services.internal.repository_usage.connect_s3_repository",
+        side_effect=KopiaRepositoryBusyError("repository busy"),
+    )
+    def test_s3_usage_preserves_repository_busy_signal(self, _connect):
+        repository = Repository(
+            id=17,
+            repo_type=Repository.Type.S3,
+            status=Repository.Status.CREATED,
+        )
+
+        with self.assertRaises(KopiaRepositoryBusyError):
+            kopia_repository_estimated_usage_bytes(repository)
+
     def test_parse_agent_repo_status_result(self):
         estimated, total, mount_point, usage_error, capacity_error = _parse_agent_repo_status_result(
             {
@@ -514,6 +530,84 @@ class RepositoryUsageTests(TestCase):
         repo.refresh_from_db()
         self.assertEqual(repo.estimated_usage_bytes, 128)
         self.assertEqual(repo.usage_probe_status, Repository.MetricProbeStatus.FAILED)
+
+    @mock.patch(
+        "apps.storage.services.internal.repository_usage."
+        "kopia_repository_estimated_usage_bytes",
+        side_effect=KopiaRepositoryBusyError("repository busy"),
+    )
+    def test_batch_sync_defers_busy_s3_repository_without_changing_metrics(
+        self,
+        _kopia_estimated,
+    ):
+        repo = Repository.objects.create(
+            organization_id=1,
+            name="s3-busy",
+            repo_type=Repository.Type.S3,
+            status=Repository.Status.CREATED,
+            health=Repository.Health.ONLINE,
+            estimated_usage_bytes=128,
+            usage_probe_status=Repository.MetricProbeStatus.SUCCESS,
+            s3_platform=Repository.S3Platform.AWS,
+            s3_bucket="bucket",
+        )
+
+        result = sync_all_repositories(force=True)
+
+        repo.refresh_from_db()
+        self.assertEqual(result["repositories_deferred"], 1)
+        self.assertEqual(result["deferred_repository_ids"], [repo.id])
+        self.assertEqual(result["repositories_failed"], 0)
+        self.assertEqual(repo.estimated_usage_bytes, 128)
+        self.assertEqual(
+            repo.usage_probe_status,
+            Repository.MetricProbeStatus.SUCCESS,
+        )
+
+    @mock.patch(
+        "apps.storage.services.internal.repository_usage."
+        "kopia_repository_estimated_usage_bytes",
+        return_value=256,
+    )
+    def test_batch_sync_stops_at_repository_boundary_when_lease_is_lost(
+        self,
+        _kopia_estimated,
+    ):
+        first = Repository.objects.create(
+            organization_id=1,
+            name="s3-first",
+            repo_type=Repository.Type.S3,
+            status=Repository.Status.CREATED,
+            health=Repository.Health.ONLINE,
+            s3_platform=Repository.S3Platform.AWS,
+            s3_bucket="first-bucket",
+        )
+        second = Repository.objects.create(
+            organization_id=1,
+            name="s3-second",
+            repo_type=Repository.Type.S3,
+            status=Repository.Status.CREATED,
+            health=Repository.Health.ONLINE,
+            s3_platform=Repository.S3Platform.AWS,
+            s3_bucket="second-bucket",
+        )
+        should_continue = mock.Mock(side_effect=[True, False])
+
+        result = sync_all_repositories(
+            force=True,
+            should_continue=should_continue,
+        )
+
+        first.refresh_from_db()
+        second.refresh_from_db()
+        self.assertTrue(result["stopped_early"])
+        self.assertEqual(result["repositories_attempted"], 1)
+        self.assertEqual(result["repositories_synced"], 1)
+        self.assertEqual(first.usage_probe_status, Repository.MetricProbeStatus.SUCCESS)
+        self.assertNotEqual(
+            second.usage_probe_status,
+            Repository.MetricProbeStatus.SUCCESS,
+        )
 
     @mock.patch(
         "apps.storage.services.internal.repository_usage.kopia_repository_estimated_usage_bytes",

--- a/src/backend/apps/storage/tests/test_repository_usage_schedule.py
+++ b/src/backend/apps/storage/tests/test_repository_usage_schedule.py
@@ -4,6 +4,7 @@ from unittest import mock
 from django.test import SimpleTestCase
 
 from apps.storage.periodic_tasks import register_periodic_tasks
+from apps.storage.tasks import reconcile_storage_repositories
 
 
 class RepositoryUsageScheduleTests(SimpleTestCase):
@@ -28,3 +29,42 @@ class RepositoryUsageScheduleTests(SimpleTestCase):
         )
         self.assertTrue(usage_call.kwargs["kwargs"]["force"])
         self.assertIsNone(usage_call.kwargs["kwargs"]["stale_after_seconds"])
+        self.assertTrue(usage_call.kwargs["kwargs"]["background"])
+
+
+class RepositoryUsageCapacityTests(SimpleTestCase):
+    @mock.patch("apps.storage.tasks.sync_all_repositories")
+    @mock.patch(
+        "apps.storage.tasks.try_acquire_background_storage_capacity",
+        return_value=None,
+    )
+    def test_periodic_sync_defers_without_background_capacity(
+        self,
+        _acquire_capacity,
+        sync_all,
+    ):
+        result = reconcile_storage_repositories.run(background=True)
+
+        self.assertEqual(result["status"], "deferred_background_capacity")
+        self.assertEqual(result["repositories_scanned"], 0)
+        sync_all.assert_not_called()
+
+    @mock.patch(
+        "apps.storage.tasks.try_acquire_background_storage_capacity"
+    )
+    @mock.patch("apps.storage.tasks.sync_all_repositories")
+    def test_interactive_sync_does_not_use_background_capacity(
+        self,
+        sync_all,
+        acquire_capacity,
+    ):
+        sync_all.return_value = {
+            "repositories_attempted": 1,
+            "repositories_synced": 1,
+            "repositories_failed": 0,
+        }
+
+        result = reconcile_storage_repositories.run(background=False)
+
+        self.assertEqual(result["repositories_synced"], 1)
+        acquire_capacity.assert_not_called()

--- a/src/backend/apps/storage/tests/test_repository_worker_operations.py
+++ b/src/backend/apps/storage/tests/test_repository_worker_operations.py
@@ -17,6 +17,7 @@ from apps.storage.services.internal.repository_credential_rotation import (
 from apps.storage.services.internal.repository_initializer import (
     RepositoryInitializationError,
 )
+from apps.storage.services.internal.kopia_cli import KopiaRepositoryBusyError
 from apps.task.models import Task, TaskStep
 
 
@@ -99,6 +100,30 @@ class RepositoryWorkerOperationTests(TestCase):
         self.assertEqual(repository_task.task.status, Task.Status.FAILED)
         self.assertNotIn("old-secret", repository_task.task.error_message)
         self.assertIn("******", repository_task.task.error_message)
+
+    @mock.patch(
+        "apps.storage.services.internal.repository_check.probe_repository_health"
+    )
+    def test_manual_check_does_not_mark_busy_repository_offline(self, probe_health):
+        repository = self._s3_repository()
+        repository_task = enqueue_repository_check_task(repository=repository)
+        wrapped = RepositoryInitializationError("repository busy")
+        wrapped.__cause__ = KopiaRepositoryBusyError("repository busy")
+        probe_health.side_effect = wrapped
+
+        result = run_repository_check_task(repository_task_id=repository_task.id)
+
+        repository.refresh_from_db()
+        repository_task.task.refresh_from_db()
+        self.assertEqual(result["status"], "failed")
+        self.assertEqual(result["error_code"], "STORAGE.REPOSITORY_BUSY")
+        self.assertEqual(repository.health, Repository.Health.ONLINE)
+        self.assertIsNone(repository.last_checked_at)
+        self.assertEqual(repository_task.task.status, Task.Status.FAILED)
+        self.assertEqual(
+            repository_task.task.error_code,
+            "STORAGE.REPOSITORY_BUSY",
+        )
 
     def test_repeated_manual_check_reuses_the_active_task(self):
         repository = self._s3_repository()


### PR DESCRIPTION
## Summary

- add Redis-backed admission control for Controller-local background storage operations
- keep scheduled maintenance, health probes, and periodic usage reconciliation below total worker capacity
- stop maintenance safely when its capacity lease is lost and preserve retry scheduling
- report repository lock contention without falsely marking repositories offline
- add bounded Kopia repository-lock waits and regression coverage

## Scope

This change preserves the existing Controller, Agent, Proxy, Kopia, and Data Gateway architecture. Interactive backup, restore, chat, repository creation, credential rotation, and cleanup workflows are not placed behind the background capacity limit.

## Validation

- Storage test suite: 523 passed
- Ruff checks passed
- Python compilation passed
- Release contract checks passed
- Git diff checks passed