### PR TITLE
Preserve Agent build identity during upgrade verification

### DIFF
--- a/src/agent/internal/enroll/install.go
+++ b/src/agent/internal/enroll/install.go
@@ -358,10 +358,14 @@ func finishEnrollment(
 	if err := WriteInstallationID(EnvFilePath(), cfg.InstallationID); err != nil {
 		logFail("Failed to persist the installation identity: "+err.Error(), 5)
 	}
+	buildIdentity, err := installedAgentBuildIdentity(agentVer)
+	if err != nil {
+		logFail("Installed Agent build identity could not be verified: "+err.Error(), 5)
+	}
 	registration, err := enrollmentclient.RegisterNodeHTTP(
 		ctx,
 		agentCfg,
-		agentVer,
+		buildIdentity,
 		existingNodeCredential,
 	)
 	nodeID := registration.NodeID

--- a/src/agent/internal/enroll/package_manifest.go
+++ b/src/agent/internal/enroll/package_manifest.go
@@ -13,11 +13,13 @@ import (
 	"strings"
 
 	"hyperfilelens/agent/internal/model"
+	"hyperfilelens/agent/internal/selfupdate"
 )
 
 type agentPackageManifest struct {
 	Schema          int               `json:"schema"`
 	AgentVersion    string            `json:"agent_version"`
+	AgentCommit     string            `json:"agent_commit"`
 	Platform        string            `json:"platform"`
 	Arch            string            `json:"arch"`
 	BundleFlavor    string            `json:"bundle_flavor"`
@@ -25,22 +27,54 @@ type agentPackageManifest struct {
 	Files           map[string]string `json:"files"`
 }
 
+func installedAgentBuildIdentity(installedVersion string) (selfupdate.BuildIdentity, error) {
+	manifest, err := readAgentPackageManifest(dataDirForAgent())
+	if err != nil {
+		return selfupdate.BuildIdentity{}, err
+	}
+	manifestVersion := strings.TrimSpace(manifest.AgentVersion)
+	manifestCommit := strings.TrimSpace(manifest.AgentCommit)
+	if manifestVersion == "" || manifestCommit == "" {
+		return selfupdate.BuildIdentity{}, fmt.Errorf("installed package manifest is missing the Agent build identity")
+	}
+	installedVersion = strings.TrimPrefix(strings.TrimSpace(installedVersion), "v")
+	if installedVersion != "" && strings.TrimPrefix(manifestVersion, "v") != installedVersion {
+		return selfupdate.BuildIdentity{}, fmt.Errorf(
+			"installed Agent version %s does not match package manifest version %s",
+			installedVersion,
+			manifestVersion,
+		)
+	}
+	return selfupdate.BuildIdentity{Version: manifestVersion, Commit: manifestCommit}, nil
+}
+
+func readAgentPackageManifest(root string) (agentPackageManifest, error) {
+	manifestPath := filepath.Join(root, "MANIFEST.json")
+	raw, err := os.ReadFile(manifestPath)
+	if err != nil {
+		return agentPackageManifest{}, fmt.Errorf("read package manifest: %w", err)
+	}
+	var manifest agentPackageManifest
+	if err := json.Unmarshal(raw, &manifest); err != nil {
+		return agentPackageManifest{}, fmt.Errorf("parse package manifest: %w", err)
+	}
+	return manifest, nil
+}
+
 func validateAgentPackage(root string, role model.Role, expectedVersion string) error {
 	return validateAgentPackageFor(root, runtime.GOOS, runtime.GOARCH, role, expectedVersion)
 }
 
 func validateAgentPackageFor(root, platform, arch string, role model.Role, expectedVersion string) error {
-	manifestPath := filepath.Join(root, "MANIFEST.json")
-	raw, err := os.ReadFile(manifestPath)
+	manifest, err := readAgentPackageManifest(root)
 	if err != nil {
-		return fmt.Errorf("read package manifest: %w", err)
-	}
-	var manifest agentPackageManifest
-	if err := json.Unmarshal(raw, &manifest); err != nil {
-		return fmt.Errorf("parse package manifest: %w", err)
+		return err
 	}
 	if manifest.Schema != 1 {
 		return fmt.Errorf("unsupported package manifest schema %d", manifest.Schema)
+	}
+	if strings.TrimSpace(manifest.AgentVersion) == "" || strings.TrimSpace(manifest.AgentCommit) == "" {
+		return fmt.Errorf("package manifest is missing the Agent build identity")
 	}
 	if manifest.Platform != platform || manifest.Arch != arch {
 		return fmt.Errorf(

--- a/src/agent/internal/enroll/package_manifest_test.go
+++ b/src/agent/internal/enroll/package_manifest_test.go
@@ -49,6 +49,82 @@ func TestValidateAgentPackageRejectsNonStandardSourceHost(t *testing.T) {
 	}
 }
 
+func TestValidateAgentPackageRejectsMissingBuildCommit(t *testing.T) {
+	root := writeTestAgentPackage(t, "linux", "amd64", "standard")
+	manifestPath := filepath.Join(root, "MANIFEST.json")
+	manifest, err := readAgentPackageManifest(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest.AgentCommit = ""
+	raw, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(manifestPath, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := validateAgentPackageFor(root, "linux", "amd64", model.RoleAgent, "1.2.3"); err == nil {
+		t.Fatal("expected missing build commit to be rejected")
+	}
+}
+
+func TestInstalledAgentBuildIdentityUsesOneManifest(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("HFL_DATA_DIR", root)
+	manifest := agentPackageManifest{
+		Schema:       1,
+		AgentVersion: "1.2.3",
+		AgentCommit:  "abc123",
+	}
+	raw, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "MANIFEST.json"), raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	identity, err := installedAgentBuildIdentity("v1.2.3")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if identity.Version != "1.2.3" || identity.Commit != "abc123" {
+		t.Fatalf("identity=%#v", identity)
+	}
+}
+
+func TestInstalledAgentBuildIdentityRejectsMissingManifest(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("HFL_DATA_DIR", root)
+
+	if _, err := installedAgentBuildIdentity("1.2.3"); err == nil {
+		t.Fatal("expected a missing installed manifest to be rejected")
+	}
+}
+
+func TestInstalledAgentBuildIdentityRejectsVersionMismatch(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("HFL_DATA_DIR", root)
+	manifest := agentPackageManifest{
+		Schema:       1,
+		AgentVersion: "1.2.3",
+		AgentCommit:  "abc123",
+	}
+	raw, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "MANIFEST.json"), raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := installedAgentBuildIdentity("1.2.4"); err == nil {
+		t.Fatal("expected installed binary and manifest version mismatch to be rejected")
+	}
+}
+
 func writeTestAgentPackage(t *testing.T, platform, arch, flavor string) string {
 	t.Helper()
 	root := t.TempDir()
@@ -81,6 +157,7 @@ func writeTestAgentPackage(t *testing.T, platform, arch, flavor string) string {
 	manifest := agentPackageManifest{
 		Schema:          1,
 		AgentVersion:    "1.2.3",
+		AgentCommit:     "abc123",
 		Platform:        platform,
 		Arch:            arch,
 		BundleFlavor:    flavor,

--- a/src/agent/internal/enrollmentclient/register.go
+++ b/src/agent/internal/enrollmentclient/register.go
@@ -70,7 +70,15 @@ func EnsureNodeRegistered(ctx context.Context, provider config.Provider, reg Nod
 		return fmt.Errorf("node_id missing; set HFL_NODE_ID or configure HFL_API_BASE, HFL_ORG_KEY, HFL_NODE_TOKEN")
 	}
 
-	result, err := httpRegisterNode(ctx, cfg, base, org, token, selfupdate.Version, "")
+	result, err := httpRegisterNode(
+		ctx,
+		cfg,
+		base,
+		org,
+		token,
+		selfupdate.CurrentBuildIdentity(),
+		"",
+	)
 	if err != nil {
 		return err
 	}
@@ -96,7 +104,7 @@ func EnsureNodeRegistered(ctx context.Context, provider config.Provider, reg Nod
 func RegisterNodeHTTP(
 	ctx context.Context,
 	cfg *model.AgentConfig,
-	agentVersion string,
+	build selfupdate.BuildIdentity,
 	existingNodeCredential string,
 ) (RegistrationResult, error) {
 	base := strings.TrimRight(strings.TrimSpace(cfg.APIBaseURL), "/")
@@ -105,8 +113,10 @@ func RegisterNodeHTTP(
 	if base == "" || org == "" || token == "" {
 		return RegistrationResult{}, fmt.Errorf("HFL_API_BASE, HFL_ORG_KEY, and HFL_NODE_TOKEN required")
 	}
-	if strings.TrimSpace(agentVersion) == "" {
-		agentVersion = selfupdate.Version
+	build.Version = strings.TrimSpace(build.Version)
+	build.Commit = strings.TrimSpace(build.Commit)
+	if build.Version == "" || build.Commit == "" {
+		return RegistrationResult{}, fmt.Errorf("complete Agent build identity required")
 	}
 	return httpRegisterNode(
 		ctx,
@@ -114,7 +124,7 @@ func RegisterNodeHTTP(
 		base,
 		org,
 		token,
-		agentVersion,
+		build,
 		existingNodeCredential,
 	)
 }
@@ -122,13 +132,16 @@ func RegisterNodeHTTP(
 func httpRegisterNode(
 	ctx context.Context,
 	cfg *model.AgentConfig,
-	base, org, token, agentVersion, existingNodeCredential string,
+	base, org, token string,
+	build selfupdate.BuildIdentity,
+	existingNodeCredential string,
 ) (RegistrationResult, error) {
 	hostname, _ := os.Hostname()
 	platform := hostinfo.Collect(ctx)
 	inventory := platform.Inventory()
 	inventory["hostname"] = hostname
-	inventory["agent_version"] = agentVersion
+	inventory["agent_version"] = build.Version
+	inventory["agent_commit"] = build.Commit
 	networkSnapshot := networkinventory.Collect(ctx, base)
 	if addresses := networkSnapshot.IPAddresses(); len(addresses) > 0 {
 		inventory["primary_ip_address"] = networkSnapshot.PrimaryAddress()
@@ -144,10 +157,11 @@ func httpRegisterNode(
 		"hostname":      hostname,
 		"inventory":     inventory,
 		"install":       "hfl-enroll",
-		"agent_version": agentVersion,
+		"agent_version": build.Version,
 		"platform":      platform.OSFamily,
 		"arch":          platform.Arch,
 	}
+	metadata["agent_commit"] = build.Commit
 	if currentUser, userErr := user.Current(); userErr == nil {
 		metadata["runtime_principal"] = map[string]string{
 			"id":   strings.TrimSpace(currentUser.Uid),
@@ -157,7 +171,7 @@ func httpRegisterNode(
 	body := map[string]any{
 		"name":     hostname,
 		"role":     string(cfg.Role),
-		"version":  agentVersion,
+		"version":  build.Version,
 		"os_name":  platform.Description(),
 		"metadata": metadata,
 	}

--- a/src/agent/internal/remote/register.go
+++ b/src/agent/internal/remote/register.go
@@ -6,6 +6,7 @@ import (
 	"hyperfilelens/agent/internal/enrollmentclient"
 	"hyperfilelens/agent/internal/infra/config"
 	"hyperfilelens/agent/internal/model"
+	"hyperfilelens/agent/internal/selfupdate"
 )
 
 // NodeRegistrar persists a control-plane node id after HTTP enrollment.
@@ -23,13 +24,13 @@ func EnsureNodeRegistered(ctx context.Context, provider config.Provider, registr
 func RegisterNodeHTTP(
 	ctx context.Context,
 	cfg *model.AgentConfig,
-	agentVersion string,
+	build selfupdate.BuildIdentity,
 	existingNodeCredential string,
 ) (RegistrationResult, error) {
 	return enrollmentclient.RegisterNodeHTTP(
 		ctx,
 		cfg,
-		agentVersion,
+		build,
 		existingNodeCredential,
 	)
 }

--- a/src/agent/internal/remote/register_test.go
+++ b/src/agent/internal/remote/register_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"hyperfilelens/agent/internal/model"
+	"hyperfilelens/agent/internal/selfupdate"
 )
 
 type credentialRegistrar struct {
@@ -59,7 +60,12 @@ func TestHTTPRegisterNodeIncludesPlatformInventory(t *testing.T) {
 		NodeToken:  "test-token",
 		Role:       model.RoleAgent,
 	}
-	result, err := RegisterNodeHTTP(context.Background(), cfg, "1.2.3", "")
+	result, err := RegisterNodeHTTP(
+		context.Background(),
+		cfg,
+		selfupdate.BuildIdentity{Version: "1.2.3", Commit: "abc123"},
+		"",
+	)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -94,6 +100,12 @@ func TestHTTPRegisterNodeIncludesPlatformInventory(t *testing.T) {
 	}
 	if got := inventory["agent_version"]; got != "1.2.3" {
 		t.Errorf("agent_version=%v", got)
+	}
+	if got := inventory["agent_commit"]; got != "abc123" {
+		t.Errorf("agent_commit=%v", got)
+	}
+	if got := metadata["agent_commit"]; got != "abc123" {
+		t.Errorf("metadata agent_commit=%v", got)
 	}
 }
 
@@ -199,7 +211,7 @@ func TestRegisterNodeHTTPRequestsExistingCredentialReuse(t *testing.T) {
 	result, err := RegisterNodeHTTP(
 		context.Background(),
 		cfg,
-		"1.2.3",
+		selfupdate.BuildIdentity{Version: "1.2.3", Commit: "abc123"},
 		"hfln_existing",
 	)
 	if err != nil {
@@ -210,5 +222,43 @@ func TestRegisterNodeHTTPRequestsExistingCredentialReuse(t *testing.T) {
 	}
 	if payload["existing_node_credential"] != "hfln_existing" {
 		t.Fatalf("existing_node_credential=%v", payload["existing_node_credential"])
+	}
+}
+
+func TestRegisterNodeHTTPRejectsMissingExplicitBuildVersion(t *testing.T) {
+	cfg := &model.AgentConfig{
+		APIBaseURL: "https://console.example.test",
+		OrgKey:     "test-org",
+		NodeToken:  "test-token",
+		Role:       model.RoleAgent,
+	}
+
+	_, err := RegisterNodeHTTP(
+		context.Background(),
+		cfg,
+		selfupdate.BuildIdentity{Commit: "must-not-be-combined-with-helper-version"},
+		"",
+	)
+	if err == nil {
+		t.Fatal("expected a missing explicit build version to be rejected")
+	}
+}
+
+func TestRegisterNodeHTTPRejectsMissingExplicitBuildCommit(t *testing.T) {
+	cfg := &model.AgentConfig{
+		APIBaseURL: "https://console.example.test",
+		OrgKey:     "test-org",
+		NodeToken:  "test-token",
+		Role:       model.RoleAgent,
+	}
+
+	_, err := RegisterNodeHTTP(
+		context.Background(),
+		cfg,
+		selfupdate.BuildIdentity{Version: "1.2.3"},
+		"",
+	)
+	if err == nil {
+		t.Fatal("expected a missing explicit build commit to be rejected")
 	}
 }

--- a/src/agent/internal/selfupdate/check.go
+++ b/src/agent/internal/selfupdate/check.go
@@ -1,10 +1,26 @@
 package selfupdate
 
+import "strings"
+
 // Version is the agent semver or pre-release tag (overridden by -ldflags at link time).
 var Version = "0.1.0"
 
 // Commit is the VCS revision embedded at build time.
 var Commit = "unknown"
+
+// BuildIdentity identifies one exact Agent build.
+type BuildIdentity struct {
+	Version string
+	Commit  string
+}
+
+// CurrentBuildIdentity returns the coherent identity embedded in this binary.
+func CurrentBuildIdentity() BuildIdentity {
+	return BuildIdentity{
+		Version: strings.TrimSpace(Version),
+		Commit:  strings.TrimSpace(Commit),
+	}
+}
 
 // NeedsUpdate reports whether remoteVersion is newer than the running build.
 func NeedsUpdate(remoteVersion string) bool {

--- a/src/backend/apps/node/services/internal/local_platform_gateway.py
+++ b/src/backend/apps/node/services/internal/local_platform_gateway.py
@@ -117,8 +117,27 @@ def registration_metadata(
     token_note: str = "",
     existing_metadata: object = None,
 ) -> dict:
-    """Preserve trusted installer ownership across Agent heartbeats."""
+    """Preserve trusted build and installer metadata across Agent heartbeats."""
     metadata = dict(payload_metadata) if isinstance(payload_metadata, dict) else {}
+    incoming_version, incoming_commit = _metadata_build_identity(metadata)
+    existing_version, existing_commit = _metadata_build_identity(existing_metadata)
+    if (
+        incoming_version
+        and not incoming_commit
+        and incoming_version == existing_version
+        and existing_commit
+    ):
+        _set_metadata_build_identity(
+            metadata,
+            version=incoming_version,
+            commit=existing_commit,
+        )
+    elif incoming_version:
+        _set_metadata_build_identity(
+            metadata,
+            version=incoming_version,
+            commit=incoming_commit,
+        )
     for key in LOCAL_PLATFORM_GATEWAY_METADATA:
         metadata.pop(key, None)
     installer_managed = (
@@ -128,6 +147,47 @@ def registration_metadata(
     if installer_managed:
         metadata.update(LOCAL_PLATFORM_GATEWAY_METADATA)
     return metadata
+
+
+def _metadata_build_identity(metadata: object) -> tuple[str, str]:
+    if not isinstance(metadata, dict):
+        return "", ""
+    inventory = metadata.get("inventory")
+    if isinstance(inventory, dict):
+        version = str(inventory.get("agent_version") or "").strip()
+        if version:
+            # Version and commit are one identity. Never combine an inventory
+            # version with a potentially stale top-level commit.
+            commit = str(inventory.get("agent_commit") or "").strip().lower()
+            return version, commit
+    return (
+        str(metadata.get("agent_version") or "").strip(),
+        str(metadata.get("agent_commit") or "").strip().lower(),
+    )
+
+
+def _set_metadata_build_identity(
+    metadata: dict,
+    *,
+    version: str,
+    commit: str,
+) -> None:
+    metadata["agent_version"] = version
+    if commit:
+        metadata["agent_commit"] = commit
+    else:
+        metadata.pop("agent_commit", None)
+
+    inventory = metadata.get("inventory")
+    if not isinstance(inventory, dict):
+        return
+    inventory = dict(inventory)
+    inventory["agent_version"] = version
+    if commit:
+        inventory["agent_commit"] = commit
+    else:
+        inventory.pop("agent_commit", None)
+    metadata["inventory"] = inventory
 
 
 @transaction.atomic

--- a/src/backend/apps/node/services/internal/node_lifecycle.py
+++ b/src/backend/apps/node/services/internal/node_lifecycle.py
@@ -227,24 +227,25 @@ def _version_matches_target(
     return not expected_commit or _node_installed_commit(node) == expected_commit
 
 
-def _strict_build_matches_target(
+def _task_observed_build_identity(task: NodeTask) -> tuple[str, str]:
+    """Return the build identity captured from this task's new inventory session."""
+    result = task.result if isinstance(task.result, dict) else {}
+    version = str(result.get("observed_agent_version") or "").strip()
+    commit = str(result.get("observed_agent_commit") or "").strip().lower()
+    return version, commit
+
+
+def _task_build_matches_target(
     *,
-    node: Node,
+    task: NodeTask,
     target_version: str,
     target_commit: str = "",
 ) -> bool:
-    """Require the exact build requested by this lifecycle operation.
-
-    ``_version_matches_target`` intentionally retains its historical
-    compatibility semantics for callers that only need an upgrade ordering
-    check. Detached lifecycle verification is stricter: a newer build is not
-    proof that this particular upgrade completed.
-    """
-    current = _node_installed_version(node)
-    if not target_version or not current or current != target_version:
+    current_version, current_commit = _task_observed_build_identity(task)
+    if not target_version or current_version != target_version:
         return False
     expected_commit = str(target_commit or "").strip().lower()
-    return not expected_commit or _node_installed_commit(node) == expected_commit
+    return not expected_commit or current_commit == expected_commit
 
 
 def _current_agent_session(*, node_id: int) -> str | None:
@@ -256,7 +257,7 @@ def record_upgrade_session_observation(
     *,
     node_id: int,
     session_id: str,
-    inventory: bool = False,
+    inventory: dict | None = None,
 ) -> bool:
     """Persist post-detach session evidence without changing task status.
 
@@ -303,11 +304,40 @@ def record_upgrade_session_observation(
             result["reconnect_observed_at"] = now
             result.pop("verify_started_at", None)
             changed = True
-        if inventory and result.get("inventory_session_id") != session_id:
-            result["inventory_session_id"] = session_id
-            result["inventory_observed_at"] = now
-            result.pop("verify_started_at", None)
-            changed = True
+        if inventory is not None:
+            incoming_version = str(inventory.get("agent_version") or "").strip()
+            incoming_commit = str(inventory.get("agent_commit") or "").strip().lower()
+            observed_version = incoming_version
+            observed_commit = incoming_commit
+            if result.get("inventory_session_id") == session_id:
+                previous_version = str(
+                    result.get("observed_agent_version") or ""
+                ).strip()
+                previous_commit = str(
+                    result.get("observed_agent_commit") or ""
+                ).strip().lower()
+                if not incoming_version:
+                    observed_version = previous_version
+                    observed_commit = previous_commit
+                elif incoming_version == previous_version and not incoming_commit:
+                    # Repeated inventory from one process may omit unchanged
+                    # fields. It must not erase complete evidence already
+                    # captured for this exact session and build version.
+                    observed_commit = previous_commit
+            identity_changed = (
+                result.get("inventory_session_id") != session_id
+                or str(result.get("observed_agent_version") or "").strip()
+                != observed_version
+                or str(result.get("observed_agent_commit") or "").strip().lower()
+                != observed_commit
+            )
+            if identity_changed:
+                result["inventory_session_id"] = session_id
+                result["inventory_observed_at"] = now
+                result["observed_agent_version"] = observed_version
+                result["observed_agent_commit"] = observed_commit
+                result.pop("verify_started_at", None)
+                changed = True
     if changed:
         task.result = result
         task.save(update_fields=["result", "updated_at"])
@@ -503,8 +533,8 @@ def _upgrade_verify_ready(*, node: Node, task: NodeTask) -> bool:
     target_version = _target_version_from_task(task)
     if not target_version:
         return False
-    return _strict_build_matches_target(
-        node=node,
+    return _task_build_matches_target(
+        task=task,
         target_version=target_version,
         target_commit=_target_commit_from_task(task),
     )
@@ -655,8 +685,21 @@ def _upgrade_timeout_failure(*, node: Node, task: NodeTask) -> tuple[str, str]:
         return "AGENT_CONNECTION_UNSTABLE", "Agent connection remained unstable during verification."
     target_version = _target_version_from_task(task)
     target_commit = _target_commit_from_task(task)
-    if not _strict_build_matches_target(
-        node=node,
+    observed_version, observed_commit = _task_observed_build_identity(task)
+    if not observed_version:
+        return (
+            "POST_UPGRADE_BUILD_IDENTITY_MISSING",
+            "Agent reconnected but did not report its post-upgrade build identity.",
+        )
+    if observed_version != target_version:
+        return "TARGET_BUILD_MISMATCH", "Agent version does not match the upgrade target."
+    if target_commit and not observed_commit:
+        return (
+            "POST_UPGRADE_BUILD_IDENTITY_MISSING",
+            "Agent reconnected but did not report its post-upgrade build commit.",
+        )
+    if not _task_build_matches_target(
+        task=task,
         target_version=target_version,
         target_commit=target_commit,
     ):

--- a/src/backend/apps/node/tests/test_local_platform_gateway.py
+++ b/src/backend/apps/node/tests/test_local_platform_gateway.py
@@ -69,6 +69,61 @@ class LocalPlatformGatewayConfigTests(SimpleTestCase):
         self.assertEqual(managed["install_key"], LOCAL_PLATFORM_GATEWAY_INSTALL_KEY)
         self.assertEqual(managed["hostname"], "gateway-host")
 
+    def test_registration_metadata_preserves_same_version_commit(self):
+        existing = {
+            "agent_version": "1.2.3",
+            "agent_commit": "ABC123",
+            "inventory": {
+                "agent_version": "1.2.3",
+                "agent_commit": "ABC123",
+            },
+        }
+
+        metadata = registration_metadata(
+            {
+                "agent_version": "1.2.3",
+                "inventory": {"agent_version": "1.2.3"},
+            },
+            existing_metadata=existing,
+        )
+
+        self.assertEqual(metadata["agent_commit"], "abc123")
+        self.assertEqual(metadata["inventory"]["agent_commit"], "abc123")
+
+    def test_registration_metadata_does_not_reuse_commit_for_new_version(self):
+        existing = {
+            "agent_version": "1.2.2",
+            "agent_commit": "old123",
+            "inventory": {
+                "agent_version": "1.2.2",
+                "agent_commit": "old123",
+            },
+        }
+
+        metadata = registration_metadata(
+            {
+                "agent_version": "1.2.3",
+                "inventory": {"agent_version": "1.2.3"},
+            },
+            existing_metadata=existing,
+        )
+
+        self.assertNotIn("agent_commit", metadata)
+        self.assertNotIn("agent_commit", metadata["inventory"])
+
+    def test_registration_metadata_does_not_cross_pair_identity_layers(self):
+        metadata = registration_metadata(
+            {
+                "agent_version": "1.2.2",
+                "agent_commit": "old123",
+                "inventory": {"agent_version": "1.2.3"},
+            }
+        )
+
+        self.assertEqual(metadata["agent_version"], "1.2.3")
+        self.assertNotIn("agent_commit", metadata)
+        self.assertNotIn("agent_commit", metadata["inventory"])
+
 
 @override_settings(FRONTEND_URL="https://console.example.com:11443")
 class LocalPlatformGatewayEnrollmentTests(TestCase):

--- a/src/backend/apps/node/tests/test_node_lifecycle.py
+++ b/src/backend/apps/node/tests/test_node_lifecycle.py
@@ -16,6 +16,7 @@ from apps.node.models.base import NodeRole
 from apps.node.services.internal.node_lifecycle import (
     _target_commit_from_task,
     _target_version_from_task,
+    _upgrade_timeout_failure,
     _version_matches_target,
     advance_node_lifecycle,
     compute_node_lifecycle,
@@ -858,7 +859,7 @@ class NodeLifecycleTests(TestCase):
             node=self.node,
             kind="agent.upgrade",
             status=NodeTask.Status.RUNNING,
-            payload={"target_version": "1.0.0"},
+            payload={"target_version": "1.0.0", "target_commit": "a" * 40},
             result={
                 "target_version": "1.0.0",
                 "mode": "local_detached",
@@ -866,6 +867,8 @@ class NodeLifecycleTests(TestCase):
                 "detached_session_id": "old",
                 "reconnect_session_id": "new",
                 "inventory_session_id": "new",
+                "observed_agent_version": "1.0.0",
+                "observed_agent_commit": "a" * 40,
                 "detached_at": timezone.now().isoformat(),
                 "disconnect_observed_at": timezone.now().isoformat(),
                 "verify_started_at": verify_started.isoformat(),
@@ -922,6 +925,7 @@ class NodeLifecycleTests(TestCase):
                 "detached_session_id": "old",
                 "reconnect_session_id": "new",
                 "inventory_session_id": "new",
+                "observed_agent_version": "1.0.0",
                 "detached_at": timezone.now().isoformat(),
                 "disconnect_observed_at": timezone.now().isoformat(),
                 "verify_started_at": timezone.now().isoformat(),
@@ -952,6 +956,7 @@ class NodeLifecycleTests(TestCase):
                 "detached_session_id": "old",
                 "reconnect_session_id": "new",
                 "inventory_session_id": "new",
+                "observed_agent_version": "1.0.0",
                 "detached_at": timezone.now().isoformat(),
                 "disconnect_observed_at": timezone.now().isoformat(),
             },
@@ -1019,10 +1024,15 @@ class NodeLifecycleTests(TestCase):
         record_upgrade_session_observation(
             node_id=self.node.id,
             session_id="new",
-            inventory=True,
+            inventory={
+                "agent_version": "1.2.0",
+                "agent_commit": "A" * 40,
+            },
         )
         task.refresh_from_db()
         self.assertEqual(task.result["inventory_session_id"], "new")
+        self.assertEqual(task.result["observed_agent_version"], "1.2.0")
+        self.assertEqual(task.result["observed_agent_commit"], "a" * 40)
         self.assertNotIn("verify_started_at", task.result)
 
     def test_repeated_upgrade_session_observation_repairs_stale_node_status(self):
@@ -1037,6 +1047,7 @@ class NodeLifecycleTests(TestCase):
                 "detached_session_id": "old",
                 "reconnect_session_id": "new",
                 "inventory_session_id": "new",
+                "observed_agent_version": "1.0.0",
             },
             watchdog_deadline_at=timezone.now() + timezone.timedelta(hours=1),
             correlation_type=node_conf.LIFECYCLE_CORRELATION_TYPE,
@@ -1048,12 +1059,45 @@ class NodeLifecycleTests(TestCase):
         changed = record_upgrade_session_observation(
             node_id=self.node.id,
             session_id="new",
-            inventory=True,
+            inventory={"agent_version": "1.0.0"},
         )
 
         self.assertFalse(changed)
         self.node.refresh_from_db()
         self.assertEqual(self.node.status, Node.Status.VERIFICATION_PENDING)
+
+    def test_repeated_session_inventory_does_not_erase_build_commit(self):
+        task = NodeTask.objects.create(
+            organization=self.org,
+            node=self.node,
+            kind="agent.upgrade",
+            status=NodeTask.Status.RUNNING,
+            payload={"target_version": "1.2.0", "target_commit": "a" * 40},
+            result={
+                "mode": "local_detached",
+                "host_upgrade_status": "success",
+                "detached_session_id": "old",
+                "reconnect_session_id": "new",
+                "inventory_session_id": "new",
+                "observed_agent_version": "1.2.0",
+                "observed_agent_commit": "a" * 40,
+                "verify_started_at": timezone.now().isoformat(),
+            },
+            watchdog_deadline_at=timezone.now() + timezone.timedelta(hours=1),
+            correlation_type=node_conf.LIFECYCLE_CORRELATION_TYPE,
+            correlation_id=f"upgrade:{self.node.id}",
+        )
+
+        changed = record_upgrade_session_observation(
+            node_id=self.node.id,
+            session_id="new",
+            inventory={"agent_version": "1.2.0"},
+        )
+
+        task.refresh_from_db()
+        self.assertFalse(changed)
+        self.assertEqual(task.result["observed_agent_commit"], "a" * 40)
+        self.assertIn("verify_started_at", task.result)
 
     def test_upgrade_disconnect_projects_restarting(self):
         task = NodeTask.objects.create(
@@ -1100,13 +1144,82 @@ class NodeLifecycleTests(TestCase):
         changed = record_upgrade_session_observation(
             node_id=self.node.id,
             session_id="new",
-            inventory=True,
+            inventory={"agent_version": "1.0.0"},
         )
 
         task.refresh_from_db()
         self.assertFalse(changed)
         self.assertNotIn("reconnect_session_id", task.result or {})
         self.assertNotIn("inventory_session_id", task.result or {})
+
+    def test_upgrade_timeout_reports_missing_session_build_commit(self):
+        task = NodeTask.objects.create(
+            organization=self.org,
+            node=self.node,
+            kind="agent.upgrade",
+            status=NodeTask.Status.RUNNING,
+            payload={"target_version": "1.2.0", "target_commit": "a" * 40},
+            result={
+                "mode": "local_detached",
+                "host_upgrade_status": "success",
+                "detached_session_id": "old",
+                "reconnect_session_id": "new",
+                "inventory_session_id": "new",
+                "observed_agent_version": "1.2.0",
+            },
+            watchdog_deadline_at=timezone.now(),
+            correlation_type=node_conf.LIFECYCLE_CORRELATION_TYPE,
+            correlation_id=f"upgrade:{self.node.id}",
+        )
+
+        with (
+            patch(
+                "apps.node.services.internal.node_lifecycle._current_agent_session",
+                return_value="new",
+            ),
+            patch(
+                "apps.node.services.internal.node_lifecycle.agent_ws_routable",
+                return_value=True,
+            ),
+        ):
+            code, _message = _upgrade_timeout_failure(node=self.node, task=task)
+
+        self.assertEqual(code, "POST_UPGRADE_BUILD_IDENTITY_MISSING")
+
+    def test_upgrade_timeout_reports_explicit_commit_mismatch(self):
+        task = NodeTask.objects.create(
+            organization=self.org,
+            node=self.node,
+            kind="agent.upgrade",
+            status=NodeTask.Status.RUNNING,
+            payload={"target_version": "1.2.0", "target_commit": "a" * 40},
+            result={
+                "mode": "local_detached",
+                "host_upgrade_status": "success",
+                "detached_session_id": "old",
+                "reconnect_session_id": "new",
+                "inventory_session_id": "new",
+                "observed_agent_version": "1.2.0",
+                "observed_agent_commit": "b" * 40,
+            },
+            watchdog_deadline_at=timezone.now(),
+            correlation_type=node_conf.LIFECYCLE_CORRELATION_TYPE,
+            correlation_id=f"upgrade:{self.node.id}",
+        )
+
+        with (
+            patch(
+                "apps.node.services.internal.node_lifecycle._current_agent_session",
+                return_value="new",
+            ),
+            patch(
+                "apps.node.services.internal.node_lifecycle.agent_ws_routable",
+                return_value=True,
+            ),
+        ):
+            code, _message = _upgrade_timeout_failure(node=self.node, task=task)
+
+        self.assertEqual(code, "TARGET_BUILD_MISMATCH")
 
     @patch(
         "apps.node.services.internal.task.redis_store.get_agent_session",

--- a/src/backend/apps/node/ws/uplink.py
+++ b/src/backend/apps/node/ws/uplink.py
@@ -175,7 +175,7 @@ def _record_upgrade_session(
     *,
     node_id: int,
     session_id: str,
-    inventory: bool = False,
+    inventory: dict | None = None,
     redis_client=None,
 ) -> None:
     if redis_client is None:
@@ -206,7 +206,7 @@ def _record_upgrade_session(
             session_id=session_id,
             inventory=inventory,
         )
-        if changed and inventory:
+        if changed and inventory is not None:
             logger.debug(
                 "post-upgrade inventory observed node_id=%s session=%s",
                 node_id,
@@ -398,7 +398,7 @@ def apply_heartbeat_inventory_snapshot(
         _record_upgrade_session(
             node_id=node_id,
             session_id=session_id,
-            inventory=True,
+            inventory=inventory,
         )
         _schedule_lifecycle_advance(
             node_id=node_id,


### PR DESCRIPTION
## Summary

- report a coherent Agent version and commit during HTTP enrollment
- validate installed package build identity from MANIFEST.json
- preserve build metadata across incomplete HTTP heartbeat payloads without cross-pairing versions and commits
- bind detached upgrade verification to the new WebSocket session inventory
- distinguish missing build identity from an explicit target build mismatch
- add regression coverage for session evidence, metadata merging, and manifest validation

## Validation

- Agent: go test ./...
- Agent: go vet ./...
- Agent cross-builds for Windows amd64, macOS amd64/arm64, and Linux arm64
- Backend lifecycle, metadata, and network inventory tests: 91 passed
- Ruff, Python compile, gofmt, and git diff --check

This change does not modify legacy directory migration, download retry behavior, upgrade transaction flow, or database schema.