### PR TITLE
Polish online Community installation logging

### DIFF
--- a/deploy/installer/install.sh
+++ b/deploy/installer/install.sh
@@ -64,6 +64,7 @@ LOCAL_PLATFORM_AGENT_LEGACY_INSTALL_DIR="/opt/hyperfilelens-agent"
 LOCAL_PLATFORM_AGENT_LEGACY_DATA_DIR="/var/lib/hyperfilelens-agent"
 LOCAL_PLATFORM_LENSNODE_ENV_FILE="/etc/hyperfilelens/lensnode.env"
 LOCAL_PLATFORM_LENSNODE_IMAGE="hyperfilelens-sourcelens-lensnode:latest"
+LOCAL_PLATFORM_GATEWAY_VERIFIED=0
 
 usage() {
 	cat <<'USAGE'
@@ -227,7 +228,9 @@ timestamp_log_stream() {
 	local log_file=$1 line timestamp
 	local TZ=UTC
 	export TZ
-	sed $'s/\033\[[0-9;]*m//g' | while IFS= read -r line || [[ -n "${line}" ]]; do
+	# Strip all CSI terminal controls (colour, cursor movement, erase-line)
+	# from durable logs while preserving the original stream on the terminal.
+	sed $'s/\033\[[0-9;?]*[ -/]*[@-~]//g' | while IFS= read -r line || [[ -n "${line}" ]]; do
 		printf -v timestamp '%(%Y-%m-%dT%H:%M:%S.000Z)T' -1
 		printf '[%s] %s\n' "${timestamp}" "${line}" >>"${log_file}"
 	done
@@ -250,6 +253,12 @@ configure_logging() {
 		;;
 	*) safe_action=operation ;;
 	esac
+	if [[ "${HFL_PARENT_LOGGING:-0}" == "1" ]]; then
+		[[ "${HFL_ONLINE_CHILD:-0}" == "1" \
+			&& -n "${LOG_FILE}" && -f "${LOG_FILE}" && ! -L "${LOG_FILE}" ]] \
+			|| die "parent session did not provide a valid log file"
+		return 0
+	fi
 	stamp="$(date -u +%Y%m%dT%H%M%SZ)"
 	if [[ -z "${LOG_FILE}" ]]; then
 		LOG_FILE="${INSTALL_DIR}/logs/${safe_action}-${stamp}-$$.log"
@@ -3589,6 +3598,17 @@ print_console_access_summary() {
 		print_value "Insight network" "${HFL_BRIDGE_NETWORK} (private)"
 	fi
 
+	if [[ "${HFL_ONLINE_CHILD:-0}" == "1" ]]; then
+		print_platform_gateway_summary "${host}" "${tenant_port}"
+	fi
+
+	print_section "Published resources"
+	print_value "Agent packages" "https://${host}:${tenant_port}/media/agent-releases/"
+	print_value "AI engine" "https://${host}:${tenant_port}/media/gateway-bootstrap/lensnode-image-linux-amd64.tar.gz"
+	if [[ -d "${ROOT}/data/language-packs" ]]; then
+		print_value "Language packs" "${ROOT}/data/language-packs"
+	fi
+
 	if [[ "${seed}" == "1" ]]; then
 		SESSION_WARNINGS+=("Change all default passwords after the first login.")
 	fi
@@ -3602,6 +3622,48 @@ print_console_access_summary() {
 	print_value "Backup" "sudo ${ROOT}/install.sh backup"
 	print_value "Upgrade" "sudo ${ROOT}/install.sh upgrade --from /path/to/new-release.tar.gz"
 	print_value "Uninstall" "sudo ${ROOT}/install.sh uninstall"
+}
+
+print_platform_gateway_summary() {
+	local host=$1 tenant_port=$2
+	local node_id organization version service container_id ai_engine console_state
+	local_platform_gateway_agent_is_managed || return 0
+	node_id="$(read_agent_env_value HFL_NODE_ID)"
+	organization="$(read_agent_env_value HFL_ORG_KEY)"
+	organization="${organization#__}"
+	organization="${organization%__}"
+	version="$(local_platform_gateway_installed_agent_version)"
+	service="$(systemctl is-active hyperfilelens-agent.service 2>/dev/null || true)"
+	[[ -n "${service}" ]] || service="unknown"
+	container_id="$(docker ps -aq --no-trunc \
+		--filter 'label=com.hyperfilelens.managed=true' \
+		--filter 'label=com.hyperfilelens.component=gateway-lensnode' \
+		--filter 'label=com.docker.compose.project=hyperfilelens-gateway' \
+		--filter 'label=com.docker.compose.service=lensnode' 2>/dev/null | head -1)" \
+		|| container_id=""
+	ai_engine="unknown"
+	if [[ -n "${container_id}" ]]; then
+		ai_engine="$(docker inspect --format '{{.State.Status}}' "${container_id}" 2>/dev/null || true)"
+		[[ -n "${ai_engine}" ]] || ai_engine="unknown"
+	fi
+	console_state="not verified by this command"
+	[[ "${LOCAL_PLATFORM_GATEWAY_VERIFIED}" -eq 0 ]] || console_state="online"
+
+	print_section "Platform Data Gateway"
+	print_value "Role" "Private Data Gateway"
+	print_value "Organization" "${organization:-platform_lens}"
+	print_value "Node ID" "${node_id:-unknown}"
+	print_value "Agent version" "${version:-unknown}"
+	print_value "Agent service" "${service}"
+	print_value "AI engine" "${ai_engine}"
+	print_value "Console state" "${console_state}"
+	print_value "Console" "https://${host}:${tenant_port}/"
+	print_value "Agent root" "${LOCAL_PLATFORM_AGENT_DATA_DIR}"
+	print_value "Binaries" "${LOCAL_PLATFORM_AGENT_INSTALL_DIR}"
+	print_value "Config" "${LOCAL_PLATFORM_AGENT_DATA_DIR}/config"
+	print_value "Data" "${LOCAL_PLATFORM_AGENT_DATA_DIR}/data"
+	print_value "Logs" "${LOCAL_PLATFORM_AGENT_DATA_DIR}/logs"
+	print_value "Install log" "${LOCAL_PLATFORM_AGENT_DATA_DIR}/logs/install.log"
 }
 
 package_has_sourcelens() {
@@ -4341,6 +4403,7 @@ wait_for_local_platform_gateway_readiness() {
 	deadline=$((SECONDS + timeout_seconds))
 	while true; do
 		if local_platform_gateway_readiness_once; then
+			LOCAL_PLATFORM_GATEWAY_VERIFIED=1
 			ok "Installer-managed platform Gateway is online and usable"
 			return 0
 		fi
@@ -4553,6 +4616,7 @@ print("\t".join([*(str(payload[key]).strip() for key in required), node_ids]))
 		HFL_WSS_URL="${wss_url}" \
 		HFL_INSECURE_TLS=1 \
 		HFL_FORCE_SIDECAR_INSTALL=1 \
+		HFL_PARENT_SESSION="${HFL_ONLINE_CHILD:-0}" \
 		HFL_NO_BANNER=1 \
 		"${helper}" gateway-install --yes --no-banner
 	desired_version="$(read_version)"
@@ -4647,19 +4711,21 @@ cmd_install() {
 	if [[ "$(read_channel_from_dir "${source_root}")" == "main" && "${allow_main_build}" -ne 1 ]]; then
 		die "main channel packages require --allow-main-build"
 	fi
-	print_section "Target"
-	print_value "Version" "${version}"
-	print_value "Edition" "$(display_edition_from_dir "${source_root}")"
-	print_value "Package" "${source_root}"
-	print_value "Install path" "${INSTALL_DIR}"
-	print_value "Platform" "$(uname -s | tr '[:upper:]' '[:lower:]')/$(uname -m)"
-	case "${sourcelens_mode}" in
-	0) print_value "Insight" "skipped by command option" ;;
-	1) print_value "Insight" "bundled installation requested" ;;
-	*) print_value "Insight" "selected by runtime configuration" ;;
-	esac
-	print_value "Data Gateway" "auto-deploy when enabled"
-	print_value "Log file" "${LOG_FILE}"
+	if [[ "${HFL_ONLINE_CHILD:-0}" != "1" ]]; then
+		print_section "Target"
+		print_value "Version" "${version}"
+		print_value "Edition" "$(display_edition_from_dir "${source_root}")"
+		print_value "Package" "${source_root}"
+		print_value "Install path" "${INSTALL_DIR}"
+		print_value "Platform" "$(uname -s | tr '[:upper:]' '[:lower:]')/$(uname -m)"
+		case "${sourcelens_mode}" in
+		0) print_value "Insight" "skipped by command option" ;;
+		1) print_value "Insight" "bundled installation requested" ;;
+		*) print_value "Insight" "selected by runtime configuration" ;;
+		esac
+		print_value "Data Gateway" "auto-deploy when enabled"
+		print_value "Log file" "${LOG_FILE}"
+	fi
 
 	print_section "[1/8] Staging and validating release package"
 	init_install_root
@@ -6187,11 +6253,13 @@ cmd_upgrade() {
 	preflight_package_layout 0
 	warn_host_resources
 	cur_version="$(read_version)"
-	print_section "Target"
-	print_value "Current" "${cur_version} ($(display_edition_from_dir "${ROOT}"))"
-	print_value "Package" "${from}"
-	print_value "Install path" "${ROOT}"
-	print_value "Log file" "${LOG_FILE}"
+	if [[ "${HFL_ONLINE_CHILD:-0}" != "1" ]]; then
+		print_section "Target"
+		print_value "Current" "${cur_version} ($(display_edition_from_dir "${ROOT}"))"
+		print_value "Package" "${from}"
+		print_value "Install path" "${ROOT}"
+		print_value "Log file" "${LOG_FILE}"
+	fi
 
 	trap cleanup_upgrade_and_finish EXIT
 	artifact_sha="${UPGRADE_ARTIFACT_SHA256:-}"
@@ -6490,7 +6558,8 @@ main() {
 	platform-gateway) banner_title="HyperFileLens Platform Data Gateway" ;;
 	lang-pack) banner_title="HyperFileLens Language Pack Manager" ;;
 	esac
-	[[ -t 2 ]] && INTERACTIVE_SESSION=1 || true
+	[[ -t 2 || "${HFL_PARENT_INTERACTIVE:-0}" == "1" ]] \
+		&& INTERACTIVE_SESSION=1 || true
 	SESSION_ACTION="${requested_cmd}"
 	configure_logging "${requested_cmd}"
 	SESSION_STARTED=1

--- a/deploy/online/install.sh
+++ b/deploy/online/install.sh
@@ -20,6 +20,8 @@ RECENT_TAGS=""
 INSTALL_ROOT="/opt/hyperfilelens"
 INSTALL_ACTION="Install"
 MAX_TAG_PAGES=100
+ONLINE_LOG_FILE=""
+ONLINE_INTERACTIVE=0
 
 usage() {
 	cat <<'USAGE'
@@ -38,6 +40,77 @@ USAGE
 fail() {
 	printf '[FAIL] %s\n' "$*" >&2
 	exit 1
+}
+
+print_banner() {
+	cat <<'BANNER'
+ _   _                       _____ _ _      _
+| | | |_   _ _ __   ___ _ _|  ___(_) | ___| |    ___ _ __  ___
+| |_| | | | | '_ \ / _ \ '__| |_  | | |/ _ \ |   / _ \ '_ \/ __|
+|  _  | |_| | |_) |  __/ |  |  _| | | |  __/ |__|  __/ | | \__ \
+|_| |_|\__, | .__/ \___|_|  |_|   |_|_|\___|_____\___|_| |_|___/
+       |___/|_|                     INSTALLER
+BANNER
+	printf '\n%s\n%s\n' 'HyperFileLens Community Online Installer' '----------------------------------------------------------------'
+}
+
+timestamp_log_stream() {
+	local log_file=$1 line timestamp
+	local TZ=UTC
+	export TZ
+	# Strip all CSI terminal controls (colour, cursor movement, erase-line)
+	# before persisting output; the live terminal still receives the original
+	# stream through tee.
+	sed $'s/\033\[[0-9;?]*[ -/]*[@-~]//g' | while IFS= read -r line || [[ -n "${line}" ]]; do
+		printf -v timestamp '%(%Y-%m-%dT%H:%M:%S.000Z)T' -1
+		printf '[%s] %s\n' "${timestamp}" "${line}" >>"${log_file}"
+	done
+}
+
+capture_log_stream() {
+	local log_file=$1 console_fd=$2
+	tee "/dev/fd/${console_fd}" \
+		| tr '\r' '\n' \
+		| timestamp_log_stream "${log_file}"
+}
+
+configure_logging() {
+	local stamp
+	[[ -t 1 || -t 2 ]] && ONLINE_INTERACTIVE=1 || true
+	stamp="$(date -u +%Y%m%dT%H%M%SZ)"
+	ONLINE_LOG_FILE="${INSTALL_ROOT}/logs/install-${stamp}-$$.log"
+	mkdir -p "$(dirname "${ONLINE_LOG_FILE}")" \
+		|| fail "could not create the online installation log directory"
+	[[ ! -L "${ONLINE_LOG_FILE}" ]] \
+		|| fail "refusing to write the online installation log through a symbolic link"
+	touch "${ONLINE_LOG_FILE}" \
+		|| fail "could not create the online installation log"
+	chmod 600 "${ONLINE_LOG_FILE}" \
+		|| fail "could not secure the online installation log"
+	exec 3>&1
+	exec 4>&2
+	exec > >(capture_log_stream "${ONLINE_LOG_FILE}" 3) \
+		2> >(capture_log_stream "${ONLINE_LOG_FILE}" 4)
+}
+
+print_target() {
+	# Keep the online bootstrap target separate from the child package installer.
+	# The child runs in parent-session mode and therefore does not print another
+	# banner or duplicate Target block.
+	# shellcheck disable=SC1091
+	source /etc/os-release
+	cat <<EOF
+
+Target
+  Version        ${TAG}
+  Edition        Community
+  Action         ${INSTALL_ACTION}
+  Source         ${SOURCE_NAME}
+  Registry       ${REGISTRY_NAME}
+  Install path   ${INSTALL_ROOT}
+  Platform       ${PRETTY_NAME:-Ubuntu} · linux/amd64
+  Log file       ${ONLINE_LOG_FILE}
+EOF
 }
 
 cleanup() {
@@ -284,11 +357,6 @@ PY
 
 confirm_installation() {
 	local answer=""
-	printf '\nSelected tag: %s\n' "${TAG}"
-	printf 'Download source: %s\n' "${SOURCE_NAME}"
-	printf 'Image registry: %s\n' "${REGISTRY_NAME}"
-	printf 'Install directory: %s\n' "${INSTALL_ROOT}"
-	printf 'Action: %s\n\n' "${INSTALL_ACTION}"
 	((ASSUME_YES == 1)) && return 0
 	[[ -r /dev/tty ]] \
 		|| fail "interactive confirmation requires a terminal; use --yes only for automation"
@@ -370,6 +438,8 @@ done
 	|| fail "--tag must use vX.Y.Z; choose a published version with --mirror cn|global --tag vX.Y.Z"
 configure_mirror
 check_host
+configure_logging
+print_banner
 
 SESSION_DIR="$(mktemp -d /var/tmp/hyperfilelens-online.XXXXXX)"
 chmod 0700 "${SESSION_DIR}"
@@ -380,12 +450,16 @@ trap 'exit 143' TERM
 install_host_tools
 inspect_existing_installation
 resolve_tag
+print_target
 confirm_installation
 download_source_archive
+
+printf '\n[....] Preparing release images and installation assets\n'
 
 export HFL_GLOBAL_REGISTRY_PREFIX="${GLOBAL_REGISTRY_PREFIX}"
 export HFL_CN_REGISTRY_PREFIX="${CN_REGISTRY_PREFIX}"
 export HFL_REGISTRY_REGION="${REGION}"
+export HFL_ONLINE_NATIVE_PROGRESS="${ONLINE_INTERACTIVE}"
 candidate="${SESSION_DIR}/hyperfilelens-${RELEASE_VERSION}-online"
 if ! python3 "${SESSION_DIR}/source/deploy/online/prepare.py" \
 	--source-root "${SESSION_DIR}/source" \
@@ -397,13 +471,18 @@ fi
 if ! verify_candidate_release; then
 	fail_with_tag_guidance "Community tag ${TAG} failed release identity validation"
 fi
+printf '[ OK ] Release images and installation assets are ready\n'
 
 if [[ "${INSTALL_ACTION}" == Upgrade ]]; then
 	printf '[....] Upgrading the existing installation to %s\n' "${TAG}"
-	HFL_REGISTRY_REGION="${REGION}" bash "${candidate}/install.sh" \
+	HFL_REGISTRY_REGION="${REGION}" HFL_ONLINE_CHILD=1 HFL_PARENT_LOGGING=1 \
+		HFL_PARENT_INTERACTIVE="${ONLINE_INTERACTIVE}" HFL_LOG_FILE="${ONLINE_LOG_FILE}" \
+		HFL_NO_BANNER=1 bash "${candidate}/install.sh" \
 		upgrade --from "${candidate}" --yes --with-sourcelens
 else
 	printf '[....] Installing HyperFileLens Community %s\n' "${TAG}"
-	HFL_REGISTRY_REGION="${REGION}" bash "${candidate}/install.sh" \
+	HFL_REGISTRY_REGION="${REGION}" HFL_ONLINE_CHILD=1 HFL_PARENT_LOGGING=1 \
+		HFL_PARENT_INTERACTIVE="${ONLINE_INTERACTIVE}" HFL_LOG_FILE="${ONLINE_LOG_FILE}" \
+		HFL_NO_BANNER=1 bash "${candidate}/install.sh" \
 		install --with-sourcelens --yes
 fi

--- a/deploy/online/prepare.py
+++ b/deploy/online/prepare.py
@@ -5,10 +5,12 @@ from __future__ import annotations
 
 import argparse
 import datetime as dt
+import errno
 import hashlib
 import json
 import os
 import pathlib
+import pty
 import re
 import shutil
 import stat
@@ -96,6 +98,61 @@ def run(
         detail = f": {output[-1000:]}" if output else ""
         raise RuntimeError(f"command failed ({' '.join(command)}){detail}")
     return completed
+
+
+def run_with_native_progress(command: list[str]) -> subprocess.CompletedProcess[str]:
+    """Run a command through a PTY while relaying its native progress output."""
+    if os.environ.get("HFL_ONLINE_NATIVE_PROGRESS") != "1":
+        completed = run(command, capture_output=True, check=False)
+        if completed.stdout:
+            sys.stdout.write(completed.stdout)
+            sys.stdout.flush()
+        return completed
+
+    master_fd, slave_fd = pty.openpty()
+    output_tail = bytearray()
+    try:
+        process = subprocess.Popen(  # pylint: disable=consider-using-with
+            command,
+            stdin=subprocess.DEVNULL,
+            stdout=slave_fd,
+            stderr=slave_fd,
+        )
+    except OSError:
+        os.close(master_fd)
+        raise
+    finally:
+        os.close(slave_fd)
+
+    try:
+        try:
+            while True:
+                try:
+                    chunk = os.read(master_fd, 64 * 1024)
+                except OSError as error:
+                    if error.errno == errno.EIO:
+                        break
+                    raise
+                if not chunk:
+                    break
+                sys.stdout.buffer.write(chunk)
+                sys.stdout.buffer.flush()
+                output_tail.extend(chunk)
+                if len(output_tail) > 16 * 1024:
+                    del output_tail[: len(output_tail) - 16 * 1024]
+        finally:
+            os.close(master_fd)
+    except (BrokenPipeError, OSError):
+        if process.poll() is None:
+            process.terminate()
+        process.wait()
+        raise
+
+    return subprocess.CompletedProcess(
+        command,
+        process.wait(),
+        stdout=output_tail.decode("utf-8", errors="replace"),
+    )
 
 
 def sha256_file(path: pathlib.Path) -> str:
@@ -307,24 +364,42 @@ def image_digest(ref: str) -> str:
     return valid[0]
 
 
-def resolve_image(spec: ImageSpec, preferred_region: str) -> ResolvedImage:
+def resolve_image(
+    spec: ImageSpec,
+    preferred_region: str,
+    position: int,
+    total: int,
+) -> ResolvedImage:
     """Pull one public image with regional fallback and retain its local alias."""
     fallback = "global" if preferred_region == "cn" else "cn"
     failures: list[str] = []
+    image_kind = "release asset image" if spec.asset_kind else "runtime image"
     for region in (preferred_region, fallback):
         source_ref = spec.source_ref(region)
-        print(f"[....] Pulling {source_ref}", flush=True)
-        completed = run(
-            ["docker", "pull", "--platform", "linux/amd64", source_ref],
-            capture_output=True,
-            check=False,
+        print(
+            f"[....] Pulling {image_kind} ({position}/{total}): {source_ref}",
+            flush=True,
+        )
+        # A PTY preserves Docker's familiar live renderer. The online parent
+        # mirrors the relayed stream into its durable, timestamped session log.
+        completed = run_with_native_progress(
+            ["docker", "pull", "--platform", "linux/amd64", source_ref]
         )
         if completed.returncode != 0:
-            failures.append(f"{source_ref}: {(completed.stdout or '').strip()[-500:]}")
+            detail = re.sub(
+                r"\x1b\[[0-9;?]*[ -/]*[@-~]",
+                "",
+                completed.stdout or "",
+            ).replace("\r", "\n").strip()
+            if detail:
+                detail = detail[-500:]
+            else:
+                detail = f"docker pull exited with status {completed.returncode}"
+            failures.append(f"{source_ref}: {detail}")
             continue
         digest = image_digest(source_ref)
         run(["docker", "tag", source_ref, spec.local_ref])
-        print(f"[ OK ] Resolved {spec.local_ref}@{digest}", flush=True)
+        print(f"[ OK ] {image_kind.title()} ready: {spec.local_ref}@{digest}", flush=True)
         return ResolvedImage(spec=spec, digest=digest)
     raise RuntimeError(
         f"neither public registry could provide {spec.local_ref}: "
@@ -410,12 +485,29 @@ def extract_asset(image: ResolvedImage, payload_root: pathlib.Path) -> None:
                     "cp",
                     f"{container_id}:/opt/hyperfilelens-assets/.",
                     str(root),
-                ]
+                ],
+                capture_output=True,
             )
             validate_asset_tree(root, kind)
             shutil.copytree(root / "payload", payload_root, dirs_exist_ok=True)
     finally:
-        run(["docker", "rm", "-f", container_id], check=False)
+        completed = run(
+            ["docker", "rm", "-f", container_id],
+            capture_output=True,
+            check=False,
+        )
+        cleanup_output = (completed.stdout or "").strip()
+        if (
+            completed.returncode != 0
+            and cleanup_output
+            and "No such container" not in cleanup_output
+        ):
+            print(
+                f"[WARN] Could not remove temporary {kind} asset container: "
+                f"{cleanup_output[-500:]}",
+                file=sys.stderr,
+                flush=True,
+            )
 
 
 def discard_asset_image(image: ResolvedImage) -> None:
@@ -426,7 +518,22 @@ def discard_asset_image(image: ResolvedImage) -> None:
         image.spec.source_ref("global"),
     }
     for ref in sorted(refs):
-        run(["docker", "image", "rm", ref], check=False)
+        completed = run(
+            ["docker", "image", "rm", ref], capture_output=True, check=False
+        )
+        if completed.returncode == 0:
+            continue
+        output = (completed.stdout or "").strip()
+        # A tag can legitimately be absent after Docker has removed an alias
+        # while cleaning the scratch image.  Keep that expected condition
+        # quiet, but retain unusual cleanup failures in the session output.
+        if output and "No such image" not in output:
+            print(
+                f"[WARN] Could not remove temporary {image.spec.asset_kind} "
+                f"asset image {ref}: {output[-500:]}",
+                file=sys.stderr,
+                flush=True,
+            )
 
 
 def write_sourcelens_build_info(
@@ -615,17 +722,32 @@ def main() -> int:
         )
         for kind in ("agent", "gateway", "language")
     ]
-    runtime = [resolve_image(spec, args.region) for spec in runtime_specs]
-    assets = [resolve_image(spec, args.region) for spec in asset_specs]
+    runtime = [
+        resolve_image(spec, args.region, position, len(runtime_specs))
+        for position, spec in enumerate(runtime_specs, start=1)
+    ]
+    print(f"[ OK ] Runtime images are ready: {len(runtime)} images", flush=True)
+    assets = [
+        resolve_image(spec, args.region, position, len(asset_specs))
+        for position, spec in enumerate(asset_specs, start=1)
+    ]
 
     revision = image_revision(f"hyperfilelens-backend:{version}")
     if image_revision(f"hyperfilelens-frontend:{version}") != revision:
         raise ValueError("Community backend and frontend revisions do not match")
+    asset_labels = {
+        "agent": "Agent packages",
+        "gateway": "Data Gateway packages",
+        "language": "Language packs",
+    }
     for asset in assets:
+        label = asset_labels[asset.spec.asset_kind]
+        print(f"[....] Preparing {label}", flush=True)
         try:
             extract_asset(asset, target / "payload")
         finally:
             discard_asset_image(asset)
+        print(f"[ OK ] {label} are ready", flush=True)
     sourcelens = write_sourcelens_build_info(source, target, runtime)
     write_manifest(target, version, revision, runtime, assets, sourcelens)
     print(f"[ OK ] Prepared Community package: {target}")

--- a/src/agent/internal/enroll/command_logging.go
+++ b/src/agent/internal/enroll/command_logging.go
@@ -227,6 +227,18 @@ func activeInstallLogPath() string {
 	return capture.sink.path
 }
 
+func writeCommandLogOnly(content string) {
+	commandLogState.Lock()
+	capture := commandLogState.current
+	commandLogState.Unlock()
+	if capture == nil || content == "" {
+		return
+	}
+	stream := &commandLogStream{sink: capture.sink}
+	_, _ = stream.Write([]byte(content))
+	stream.close()
+}
+
 func commandStdout() *os.File {
 	commandLogState.Lock()
 	capture := commandLogState.current

--- a/src/agent/internal/enroll/output.go
+++ b/src/agent/internal/enroll/output.go
@@ -332,6 +332,20 @@ func printEnrollmentContext(
 		})
 		return
 	}
+	if parentSession() {
+		var detail strings.Builder
+		fmt.Fprintln(&detail, "Target")
+		printSummaryValueTo(&detail, "Console", consoleURL)
+		printSummaryValueTo(&detail, "Organization", orgKey)
+		printSummaryValueTo(&detail, "Role", displayRole)
+		printSummaryValueTo(&detail, "Hostname", hostname)
+		printSummaryValueTo(&detail, "Platform", platform)
+		fmt.Fprintln(&detail)
+		fmt.Fprintln(&detail, "Preflight checks")
+		writeCommandLogOnly(detail.String())
+		printPhase("Platform Data Gateway preflight checks")
+		return
+	}
 	printBanner(displayRole)
 	fmt.Fprintln(os.Stdout)
 	fmt.Fprintln(os.Stdout, "Target")
@@ -445,6 +459,32 @@ func printEnrollmentSuccess(info SummaryInfo) {
 		})
 		return
 	}
+	if parentSession() {
+		var detail strings.Builder
+		fmt.Fprintln(&detail, strings.Repeat("=", 64))
+		fmt.Fprintln(&detail, "Installation completed successfully")
+		fmt.Fprintln(&detail, strings.Repeat("=", 64))
+		fmt.Fprintln(&detail)
+		fmt.Fprintln(&detail, "Installation summary")
+		printSummaryValueTo(&detail, "Role", info.Role)
+		printSummaryValueTo(&detail, "Node ID", info.NodeID)
+		printSummaryValueTo(&detail, "Agent version", info.Version)
+		printSummaryValueTo(&detail, "Service state", info.Service)
+		printSummaryValueTo(&detail, "AI engine", info.LensNode)
+		printSummaryValueTo(&detail, "Console state", "online")
+		printSummaryValueTo(&detail, "Agent root", info.DataPath)
+		printSummaryValueTo(&detail, "Binaries", info.InstallPath)
+		printSummaryValueTo(&detail, "Config", filepath.Join(info.DataPath, "config"))
+		printSummaryValueTo(&detail, "Log file", info.LogPath)
+		fmt.Fprintln(&detail)
+		fmt.Fprintln(&detail, "Next step")
+		fmt.Fprintln(&detail, "  Open HyperFileLens and configure the data sources available")
+		fmt.Fprintln(&detail, "  through this Gateway.")
+		fmt.Fprintln(&detail)
+		writeAgentLifecycleCommands(&detail, info)
+		writeCommandLogOnly(detail.String())
+		return
+	}
 	printResultRule(os.Stdout, "Installation completed successfully", ansiGreen)
 	fmt.Fprintln(os.Stdout)
 	fmt.Fprintln(os.Stdout, "Installation summary")
@@ -472,18 +512,22 @@ func printEnrollmentSuccess(info SummaryInfo) {
 }
 
 func printAgentLifecycleCommands(info SummaryInfo) {
-	fmt.Fprintln(os.Stdout, "Useful commands")
-	printSummaryValue("CLI path", filepath.Join(info.InstallPath, installerScriptName()))
+	writeAgentLifecycleCommands(os.Stdout, info)
+}
+
+func writeAgentLifecycleCommands(writer io.Writer, info SummaryInfo) {
+	fmt.Fprintln(writer, "Useful commands")
+	printSummaryValueTo(writer, "CLI path", filepath.Join(info.InstallPath, installerScriptName()))
 	if runtime.GOOS == "windows" {
 		command := windowsPowerShellCommand(filepath.Join(info.InstallPath, installerScriptName()))
 		if vfs.UserInstallation() {
-			printSummaryValue("Task status", `powershell -NoProfile -Command "$sid=[Security.Principal.WindowsIdentity]::GetCurrent().User.Value; Get-ScheduledTask -TaskName ('HyperFileLensAgent.User.'+$sid)"`)
+			printSummaryValueTo(writer, "Task status", `powershell -NoProfile -Command "$sid=[Security.Principal.WindowsIdentity]::GetCurrent().User.Value; Get-ScheduledTask -TaskName ('HyperFileLensAgent.User.'+$sid)"`)
 		} else {
-			printSummaryValue("Service status", "sc.exe query HyperFileLensAgent")
+			printSummaryValueTo(writer, "Service status", "sc.exe query HyperFileLensAgent")
 		}
-		printSummaryValue("Agent status", command+" status")
-		printSummaryValue("Uninstall", command+" uninstall")
-		printSummaryValue("Purge all", command+" uninstall -PurgeAll")
+		printSummaryValueTo(writer, "Agent status", command+" status")
+		printSummaryValueTo(writer, "Uninstall", command+" uninstall")
+		printSummaryValueTo(writer, "Purge all", command+" uninstall -PurgeAll")
 		return
 	}
 
@@ -499,14 +543,14 @@ func printAgentLifecycleCommands(info SummaryInfo) {
 	} else {
 		lifecycleStatus = "systemctl status hyperfilelens-agent"
 	}
-	printSummaryValue("Service status", lifecycleStatus)
+	printSummaryValueTo(writer, "Service status", lifecycleStatus)
 	command := strconv.Quote(filepath.Join(info.InstallPath, installerScriptName()))
 	if !vfs.UserInstallation() {
 		command = "sudo " + command
 	}
-	printSummaryValue("Agent status", command+" status")
-	printSummaryValue("Uninstall", command+" uninstall")
-	printSummaryValue("Purge all", command+" uninstall --purge-all")
+	printSummaryValueTo(writer, "Agent status", command+" status")
+	printSummaryValueTo(writer, "Uninstall", command+" uninstall")
+	printSummaryValueTo(writer, "Purge all", command+" uninstall --purge-all")
 }
 
 // windowsPowerShellCommand returns a copyable PowerShell invocation for a
@@ -543,10 +587,14 @@ func printResultRule(writer io.Writer, title, color string) {
 }
 
 func printSummaryValue(label, value string) {
+	printSummaryValueTo(os.Stdout, label, value)
+}
+
+func printSummaryValueTo(writer io.Writer, label, value string) {
 	if strings.TrimSpace(value) == "" {
 		return
 	}
-	fmt.Fprintf(os.Stdout, "  %-13s %s\n", label, value)
+	fmt.Fprintf(writer, "  %-13s %s\n", label, value)
 }
 
 func installLogPath() string {
@@ -555,6 +603,10 @@ func installLogPath() string {
 
 func jsonOutput() bool {
 	return strings.EqualFold(strings.TrimSpace(os.Getenv("HFL_OUTPUT")), "json")
+}
+
+func parentSession() bool {
+	return os.Getenv("HFL_PARENT_SESSION") == "1"
 }
 
 func emitJSON(writer io.Writer, payload map[string]any) {

--- a/src/agent/internal/enroll/output_test.go
+++ b/src/agent/internal/enroll/output_test.go
@@ -4,8 +4,11 @@ import (
 	"errors"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"hyperfilelens/agent/internal/model"
 )
 
 func TestJoinDetail(t *testing.T) {
@@ -185,6 +188,108 @@ func TestPrintCommandFailureForKeepsJSONResultTypeCompatible(t *testing.T) {
 	for _, expected := range []string{`"type":"install_result"`, `"operation":"uninstall"`} {
 		if !strings.Contains(output, expected) {
 			t.Fatalf("JSON failure output does not contain %q: %s", expected, output)
+		}
+	}
+}
+
+func TestParentSessionKeepsAgentDetailInLogAndCondensesTerminal(t *testing.T) {
+	t.Setenv("HFL_OUTPUT", "plain")
+	t.Setenv("HFL_PARENT_SESSION", "1")
+	logPath := filepath.Join(t.TempDir(), "logs", "install.log")
+	useTestInstallLogPath(t, logPath)
+
+	previousStdout := os.Stdout
+	terminalRead, terminalWrite, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = terminalWrite
+	finish := StartCommandLogging()
+	commitInstallLog()
+	printEnrollmentContext(
+		"https://127.0.0.1:11443",
+		"__platform_lens__",
+		model.RoleGateway,
+		"linux/amd64",
+		"test-host",
+	)
+	printEnrollmentSuccess(SummaryInfo{
+		Role:        "Private Data Gateway",
+		NodeID:      "17",
+		Version:     "1.2.3",
+		Service:     "active",
+		LensNode:    "active",
+		InstallPath: "/opt/hyperfilelens-agent/bin",
+		DataPath:    "/opt/hyperfilelens-agent",
+		LogPath:     logPath,
+	})
+	finish()
+	os.Stdout = previousStdout
+	if err := terminalWrite.Close(); err != nil {
+		t.Fatal(err)
+	}
+	terminalContent, err := io.ReadAll(terminalRead)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = terminalRead.Close()
+
+	terminal := string(terminalContent)
+	if !strings.Contains(terminal, "Platform Data Gateway preflight checks") {
+		t.Fatalf("parent terminal omitted the Gateway phase: %s", terminal)
+	}
+	for _, unexpected := range []string{"Target\n", "Installation summary"} {
+		if strings.Contains(terminal, unexpected) {
+			t.Fatalf("parent terminal contains nested %q: %s", unexpected, terminal)
+		}
+	}
+
+	logged, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, expected := range []string{
+		"Target",
+		"Preflight checks",
+		"Installation completed successfully",
+		"Installation summary",
+		"Useful commands",
+	} {
+		if !strings.Contains(string(logged), expected) {
+			t.Fatalf("Agent log omitted %q: %s", expected, logged)
+		}
+	}
+}
+
+func TestDirectSessionStillPrintsAgentContext(t *testing.T) {
+	t.Setenv("HFL_OUTPUT", "plain")
+	t.Setenv("HFL_NO_BANNER", "1")
+	previousStdout := os.Stdout
+	readPipe, writePipe, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = writePipe
+	printEnrollmentContext(
+		"https://console.example",
+		"example-org",
+		model.RoleAgent,
+		"linux/amd64",
+		"source-host",
+	)
+	os.Stdout = previousStdout
+	if err := writePipe.Close(); err != nil {
+		t.Fatal(err)
+	}
+	content, err := io.ReadAll(readPipe)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = readPipe.Close()
+	output := string(content)
+	for _, expected := range []string{"Target", "example-org", "Preflight checks"} {
+		if !strings.Contains(output, expected) {
+			t.Fatalf("direct Agent output omitted %q: %s", expected, output)
 		}
 	}
 }

--- a/tools/quality/test-online-community-install.sh
+++ b/tools/quality/test-online-community-install.sh
@@ -42,6 +42,20 @@ grep -Fq 'tag_suffix: -ee' "${workflow}"
 grep -Fq 'hyperfilelens-agent-assets:${{ needs.prepare.outputs.version }}' "${workflow}"
 grep -Fq 'hyperfilelens-gateway-assets:${{ needs.prepare.outputs.version }}' "${workflow}"
 grep -Fq 'hyperfilelens-language-assets:${{ needs.prepare.outputs.version }}' "${workflow}"
+
+installer="${ROOT}/deploy/installer/install.sh"
+[[ "$(grep -Fc 'if [[ "${HFL_ONLINE_CHILD:-0}" != "1" ]]; then' "${installer}")" -eq 2 ]]
+for summary_contract in \
+	'print_section "Platform Data Gateway"' \
+	'print_section "Published resources"' \
+	'print_value "Agent version"' \
+	'print_value "Agent service"' \
+	'print_value "Console state"' \
+	'print_value "Data" "${LOCAL_PLATFORM_AGENT_DATA_DIR}/data"' \
+	'print_value "Logs" "${LOCAL_PLATFORM_AGENT_DATA_DIR}/logs"' \
+	'print_value "Install log"'; do
+	grep -Fq "${summary_contract}" "${installer}"
+done
 if grep -Eq 'publish-community-channel|community-channel|git push origin HEAD:main' "${workflow}"; then
 	printf 'ERROR: SaaS workflow must not manage a separate Community channel branch\n' >&2
 	exit 1
@@ -237,6 +251,11 @@ case "${1:-} ${2:-}" in
 	exit 0
 	;;
 "pull --platform")
+	printf '\rDocker native pull progress: %s\n' "${4:-unknown}"
+	if [[ "${HFL_TEST_DOCKER_PULL_FAIL:-0}" == "1" ]]; then
+		printf 'registry rejected test image: access denied\n' >&2
+		exit 23
+	fi
 	exit 0
 	;;
 "image inspect")
@@ -251,7 +270,15 @@ case "${1:-} ${2:-}" in
 "buildx imagetools")
 	printf '{"digest":"%s"}\n' "${digest}"
 	;;
-"tag "* | "rm -f" | "image rm")
+"image rm")
+	printf 'Untagged: %s\n' "${3:-unknown}"
+	exit 0
+	;;
+"rm -f")
+	printf '%s\n' "${3:-temporary-container}"
+	exit 0
+	;;
+"tag "*)
 	exit 0
 	;;
 "create "*)
@@ -309,7 +336,7 @@ chmod 755 "${fake_bin}/curl" "${fake_bin}/docker"
 
 test_install_root="${tmp}/community-install"
 test_installer="${tmp}/online-install.sh"
-python3 - "${online}/install.sh" "${test_installer}" "${test_install_root}" <<'PY'
+python3 - "${online}/install.sh" "${test_installer}" "${test_install_root}" "${tmp}" <<'PY'
 import pathlib
 import sys
 
@@ -319,6 +346,9 @@ replacements = {
     '[[ "${EUID}" -eq 0 ]] || fail "run this command through sudo"': ":",
     "\ninstall_host_tools\ninspect_existing_installation\n": (
         "\n:\ninspect_existing_installation\n"
+    ),
+    'SESSION_DIR="$(mktemp -d /var/tmp/hyperfilelens-online.XXXXXX)"': (
+        f'SESSION_DIR="$(mktemp -d "{sys.argv[4]}/online-session.XXXXXX")"'
     ),
 }
 for old, new in replacements.items():
@@ -374,10 +404,16 @@ if PATH="${fake_bin}:${PATH}" HFL_TEST_TAG_FIXTURE="${tag_fixture}" \
 	printf 'ERROR: fake online install unexpectedly succeeded\n' >&2
 	exit 1
 fi
-grep -Fq 'Selected tag: v1.2.12' "${latest_log}" || {
+grep -Fq 'Version        v1.2.12' "${latest_log}" || {
 	cat "${latest_log}" >&2
 	exit 1
 }
+latest_session_log="$(find "${test_install_root}/logs" -maxdepth 1 -type f \
+	-name 'install-*.log' -print -quit)"
+[[ -n "${latest_session_log}" ]]
+grep -Fq 'HyperFileLens Community Online Installer' "${latest_session_log}"
+grep -Fq 'Resolving Community tags from GitHub' "${latest_session_log}"
+grep -Fq "Log file       ${latest_session_log}" "${latest_log}"
 grep -Fq 'recent fallback tags: v1.2.11, v1.2.10, v1.2.9, v1.2.8, v1.2.7, v1.2.6, v1.2.5, v1.2.4, v1.2.3, v1.2.2' \
 	"${latest_log}"
 grep -Fq 'recommended retry: --mirror global --tag v1.2.11' "${latest_log}"
@@ -402,7 +438,7 @@ if PATH="${fake_bin}:${PATH}" \
 	printf 'ERROR: fake paginated online install unexpectedly succeeded\n' >&2
 	exit 1
 fi
-grep -Fq 'Selected tag: v2.0.0' "${pagination_log}" || {
+grep -Fq 'Version        v2.0.0' "${pagination_log}" || {
 	cat "${pagination_log}" >&2
 	exit 1
 }
@@ -417,12 +453,39 @@ if PATH="${fake_bin}:${PATH}" \
 fi
 grep -Fq 'repeated page 2' "${repeated_page_log}"
 
+prepare_log="${tmp}/prepare.log"
 PATH="${fake_bin}:${PATH}" HFL_TEST_VERSION=1.2.3 \
+	HFL_ONLINE_NATIVE_PROGRESS=1 \
 	python3 "${online}/prepare.py" \
 		--source-root "${ROOT}" \
 		--version v1.2.3 \
 		--region global \
-		--output "${candidate}"
+		--output "${candidate}" >"${prepare_log}" 2>&1
+grep -F 'Docker native pull progress:' "${prepare_log}" >/dev/null
+if grep -F 'Untagged:' "${prepare_log}" >/dev/null; then
+	printf 'ERROR: temporary asset image cleanup leaked into online output\n' >&2
+	exit 1
+fi
+if grep -F 'cid-' "${prepare_log}" >/dev/null; then
+	printf 'ERROR: temporary asset container cleanup leaked into online output\n' >&2
+	exit 1
+fi
+failed_prepare_log="${tmp}/prepare-failed.log"
+if PATH="${fake_bin}:${PATH}" HFL_TEST_VERSION=1.2.3 \
+	HFL_ONLINE_NATIVE_PROGRESS=1 HFL_TEST_DOCKER_PULL_FAIL=1 \
+	python3 "${online}/prepare.py" \
+		--source-root "${ROOT}" \
+		--version v1.2.3 \
+		--region global \
+		--output "${tmp}/failed-candidate" \
+		>"${failed_prepare_log}" 2>&1; then
+	printf 'ERROR: failed Docker pulls unexpectedly prepared an online package\n' >&2
+	exit 1
+fi
+grep -Fq 'registry rejected test image: access denied' "${failed_prepare_log}"
+grep -Fq 'docker.io/oneprolabs/hyperfilelens-backend:1.2.3' "${failed_prepare_log}"
+grep -Fq 'registry.cn-beijing.aliyuncs.com/oneprolabs/hyperfilelens-backend:1.2.3' \
+	"${failed_prepare_log}"
 [[ -r "${candidate}/payload/runtime/compose-runtime.sh" ]]
 [[ ! -x "${candidate}/payload/runtime/compose-runtime.sh" ]]
 "${candidate}/install.sh" --help >/dev/null


### PR DESCRIPTION
## Summary

- add a unified online Community installer banner, target details, and durable session logs
- preserve native Docker pull progress while keeping failure diagnostics and clean persisted logs
- coordinate parent and Agent installer output to avoid duplicated terminal sections
- include Platform Data Gateway paths and runtime state in the online installation summary
- add regression coverage for online preparation, parent-session Agent output, and cleanup behavior

## Validation

- `bash tools/quality/test-online-community-install.sh`
- lifecycle, Agent installer, Platform Gateway, upgrade transaction, and backup retention contract tests
- `go test ./internal/enroll/...`
- shell/Python syntax checks, Ruff, and `git diff --check`

The full Go suite is otherwise unchanged; the restricted sandbox prevents IPv6 httptest listeners.