### PR TITLE
Make local Agent upgrades transactional and recoverable

### DIFF
--- a/src/agent/internal/cli/root.go
+++ b/src/agent/internal/cli/root.go
@@ -6,7 +6,10 @@ import (
 	"os"
 	"strings"
 
+	"hyperfilelens/agent/internal/enroll"
 	"hyperfilelens/agent/internal/infra/config"
+	"hyperfilelens/agent/internal/infra/database"
+	"hyperfilelens/agent/internal/model"
 	"hyperfilelens/agent/internal/selfupdate"
 )
 
@@ -28,6 +31,10 @@ func Run(args []string) error {
 			selfupdate.Commit,
 		)
 		return nil
+	case "package":
+		return runPackage(args[1:])
+	case "database":
+		return runDatabase(args[1:])
 	case "config":
 		return config.RunCLI(context.Background(), args[1:])
 	case "tasks":
@@ -45,12 +52,71 @@ func Run(args []string) error {
 	}
 }
 
+func runDatabase(args []string) error {
+	if len(args) < 1 || args[0] != "backup" {
+		return fmt.Errorf("usage: hfl-agent database backup --source <agent.db> --destination <agent.db>")
+	}
+	var source, destination string
+	for i := 1; i < len(args); i++ {
+		if i+1 >= len(args) {
+			return fmt.Errorf("database backup option %q requires a value", args[i])
+		}
+		switch args[i] {
+		case "--source":
+			source = args[i+1]
+		case "--destination":
+			destination = args[i+1]
+		default:
+			return fmt.Errorf("unknown database backup option %q", args[i])
+		}
+		i++
+	}
+	if strings.TrimSpace(source) == "" || strings.TrimSpace(destination) == "" {
+		return fmt.Errorf("database backup requires --source and --destination")
+	}
+	return database.Backup(context.Background(), source, destination)
+}
+
+func runPackage(args []string) error {
+	if len(args) < 1 || args[0] != "verify" {
+		return fmt.Errorf("usage: hfl-agent package verify --root <directory> [--role agent|proxy|gateway] [--version <version>]")
+	}
+	var root, version, roleValue string
+	roleValue = "agent"
+	for i := 1; i < len(args); i++ {
+		if i+1 >= len(args) {
+			return fmt.Errorf("package verify option %q requires a value", args[i])
+		}
+		switch args[i] {
+		case "--root":
+			root = args[i+1]
+		case "--role":
+			roleValue = args[i+1]
+		case "--version":
+			version = args[i+1]
+		default:
+			return fmt.Errorf("unknown package verify option %q", args[i])
+		}
+		i++
+	}
+	if strings.TrimSpace(root) == "" {
+		return fmt.Errorf("package verify requires --root <directory>")
+	}
+	role := model.Role(strings.TrimSpace(roleValue))
+	if role != model.RoleAgent && role != model.RoleProxy && role != model.RoleGateway {
+		return fmt.Errorf("unsupported package role %q", roleValue)
+	}
+	return enroll.ValidateAgentPackage(root, role, version)
+}
+
 func printRootHelp() {
 	const help = `HyperFileLens Agent CLI
 
 Usage:
   hfl-agent run [flags]             Run agent daemon (WebSocket control plane)
   hfl-agent version                 Print version and exit
+  hfl-agent package verify          Verify a release package manifest and checksums
+  hfl-agent database backup         Create a consistent local database backup
   hfl-agent help                    Show this help
   hfl-agent config show|set|paths   Manage hot-reloadable configuration
   hfl-agent fs ls [path]            List local directory entries
@@ -131,7 +197,7 @@ func parseWireStatus(s string) (string, error) {
 // IsSubcommand reports whether arg is a CLI subcommand (not daemon flags).
 func IsSubcommand(arg string) bool {
 	switch arg {
-	case "help", "-h", "--help", "version", "config", "tasks", "fs", "snapshot", "restore", "repo":
+	case "help", "-h", "--help", "version", "package", "database", "config", "tasks", "fs", "snapshot", "restore", "repo":
 		return true
 	default:
 		return false

--- a/src/agent/internal/cli/root_test.go
+++ b/src/agent/internal/cli/root_test.go
@@ -7,3 +7,36 @@ func TestVersionIsARealSubcommand(t *testing.T) {
 		t.Fatal("version must be dispatched as a short-lived CLI command")
 	}
 }
+
+func TestPackageIsARealSubcommand(t *testing.T) {
+	if !IsSubcommand("package") {
+		t.Fatal("package must be dispatched as a short-lived CLI command")
+	}
+}
+
+func TestDatabaseIsARealSubcommand(t *testing.T) {
+	if !IsSubcommand("database") {
+		t.Fatal("database must be dispatched as a short-lived CLI command")
+	}
+}
+
+func TestDatabaseBackupRequiresBothPaths(t *testing.T) {
+	err := runDatabase([]string{"backup", "--source", "agent.db"})
+	if err == nil || err.Error() != "database backup requires --source and --destination" {
+		t.Fatalf("runDatabase() error = %v", err)
+	}
+}
+
+func TestPackageVerifyRequiresRoot(t *testing.T) {
+	err := runPackage([]string{"verify", "--role", "agent"})
+	if err == nil || err.Error() != "package verify requires --root <directory>" {
+		t.Fatalf("runPackage() error = %v", err)
+	}
+}
+
+func TestPackageVerifyRejectsUnknownRole(t *testing.T) {
+	err := runPackage([]string{"verify", "--root", t.TempDir(), "--role", "unknown"})
+	if err == nil || err.Error() != `unsupported package role "unknown"` {
+		t.Fatalf("runPackage() error = %v", err)
+	}
+}

--- a/src/agent/internal/enroll/package_manifest.go
+++ b/src/agent/internal/enroll/package_manifest.go
@@ -65,6 +65,13 @@ func validateAgentPackage(root string, role model.Role, expectedVersion string) 
 	return validateAgentPackageFor(root, runtime.GOOS, runtime.GOARCH, role, expectedVersion)
 }
 
+// ValidateAgentPackage verifies a release directory before an installer stops
+// the currently running Agent.  Keeping the verifier in the Agent binary means
+// enrollment and local upgrades use the same manifest contract.
+func ValidateAgentPackage(root string, role model.Role, expectedVersion string) error {
+	return validateAgentPackage(root, role, expectedVersion)
+}
+
 func validateAgentPackageFor(root, platform, arch string, role model.Role, expectedVersion string) error {
 	manifest, err := readAgentPackageManifest(root)
 	if err != nil {

--- a/src/agent/internal/enroll/service_unix.go
+++ b/src/agent/internal/enroll/service_unix.go
@@ -13,6 +13,7 @@ import (
 
 	"hyperfilelens/agent/internal/model"
 	"hyperfilelens/agent/internal/platform/install"
+	"hyperfilelens/agent/internal/platform/vfs"
 )
 
 // StartInstalledService enables and starts the platform service after enrollment.
@@ -47,6 +48,16 @@ func startSystemd(ctx context.Context) error {
 	// or previously invalid definition cannot survive into the start attempt.
 	if err := ensureUserSystemdUnit(); err != nil {
 		return fmt.Errorf("repair current-user systemd unit: %w", err)
+	}
+	// A bundle upgrade intentionally stages with --no-restart so enrollment can
+	// refresh credentials before the new Agent reconnects. Route that one start
+	// through the lifecycle script: it performs the local health check and only
+	// then commits the retained rollback transaction.
+	statePath := install.LifecycleUpgradeStatePath(vfs.DefaultAgentDataDir())
+	if _, err := os.Stat(statePath); err == nil {
+		return startUnixScript(ctx, "start")
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("inspect pending upgrade state: %w", err)
 	}
 	for _, args := range [][]string{
 		{"daemon-reload"},

--- a/src/agent/internal/enroll/service_windows.go
+++ b/src/agent/internal/enroll/service_windows.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"hyperfilelens/agent/internal/platform/install"
+	"hyperfilelens/agent/internal/platform/vfs"
 )
 
 // StartInstalledService registers and starts HyperFileLensAgent after enrollment.
@@ -27,12 +28,27 @@ func startWindowsService(ctx context.Context) error {
 	installRoot := install.DefaultInstallDir()
 	agentBin := filepath.Join(installRoot, "hfl-agent.exe")
 	installScript := filepath.Join(installRoot, "install.ps1")
+	pendingInstallScript := installScript + ".pending"
 
 	if _, err := os.Stat(agentBin); err != nil {
 		return fmt.Errorf("agent binary missing at %s", agentBin)
 	}
 	if _, err := os.Stat(installScript); err != nil {
 		return fmt.Errorf("agent installer missing at %s", installScript)
+	}
+	// PowerShell may defer replacing its own script until the upgrade process
+	// exits. During enrollment's immediate post-upgrade start, use that verified
+	// target script when a durable transaction is awaiting health confirmation;
+	// otherwise the previous release could start the service without committing
+	// or rolling back the staged upgrade.
+	if _, err := os.Stat(install.LifecycleUpgradeStatePath(vfs.DefaultAgentDataDir())); err == nil {
+		if _, pendingErr := os.Stat(pendingInstallScript); pendingErr == nil {
+			installScript = pendingInstallScript
+		} else if !os.IsNotExist(pendingErr) {
+			return fmt.Errorf("inspect pending Windows Agent installer: %w", pendingErr)
+		}
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("inspect pending Windows Agent upgrade: %w", err)
 	}
 	cmd := exec.CommandContext(
 		ctx,

--- a/src/agent/internal/infra/database/backup.go
+++ b/src/agent/internal/infra/database/backup.go
@@ -1,0 +1,74 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// Backup creates a transactionally consistent, standalone SQLite database.
+// SQLite's VACUUM INTO reads one database snapshot even while the Agent keeps
+// writing in WAL mode, so installers do not need to race-copy db/wal/shm files.
+func Backup(ctx context.Context, source, destination string) (retErr error) {
+	source = filepath.Clean(source)
+	destination = filepath.Clean(destination)
+	if source == destination {
+		return fmt.Errorf("database backup source and destination must differ")
+	}
+	info, err := os.Stat(source)
+	if err != nil {
+		return fmt.Errorf("stat source database: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("source database is not a regular file: %s", source)
+	}
+	if _, err := os.Stat(destination); err == nil {
+		return fmt.Errorf("database backup destination already exists: %s", destination)
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("inspect database backup destination: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(destination), 0o700); err != nil {
+		return fmt.Errorf("create database backup directory: %w", err)
+	}
+
+	dsn := fmt.Sprintf("file:%s?mode=ro&_pragma=busy_timeout(5000)", source)
+	conn, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		return fmt.Errorf("open source database: %w", err)
+	}
+	conn.SetMaxOpenConns(1)
+	defer func() {
+		if closeErr := conn.Close(); retErr == nil && closeErr != nil {
+			retErr = fmt.Errorf("close source database: %w", closeErr)
+		}
+		if retErr != nil {
+			_ = os.Remove(destination)
+		}
+	}()
+
+	if _, err := conn.ExecContext(ctx, "VACUUM INTO ?", destination); err != nil {
+		return fmt.Errorf("create consistent database backup: %w", err)
+	}
+	if err := verifyBackup(ctx, destination); err != nil {
+		return err
+	}
+	return nil
+}
+
+func verifyBackup(ctx context.Context, path string) error {
+	conn, err := sql.Open("sqlite", fmt.Sprintf("file:%s?mode=ro", path))
+	if err != nil {
+		return fmt.Errorf("open database backup for verification: %w", err)
+	}
+	defer conn.Close()
+	var result string
+	if err := conn.QueryRowContext(ctx, "PRAGMA quick_check").Scan(&result); err != nil {
+		return fmt.Errorf("verify database backup: %w", err)
+	}
+	if result != "ok" {
+		return fmt.Errorf("verify database backup: quick_check returned %q", result)
+	}
+	return nil
+}

--- a/src/agent/internal/infra/database/backup_test.go
+++ b/src/agent/internal/infra/database/backup_test.go
@@ -1,0 +1,51 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+)
+
+func TestBackupIncludesCommittedWALData(t *testing.T) {
+	ctx := context.Background()
+	source := filepath.Join(t.TempDir(), "agent.db")
+	db, err := Open(ctx, source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	if _, err := db.conn.ExecContext(ctx, `INSERT INTO tasks (id, created_at, updated_at) VALUES ('backup-test', 'now', 'now')`); err != nil {
+		t.Fatal(err)
+	}
+
+	destination := filepath.Join(t.TempDir(), "rollback", "agent.db")
+	if err := Backup(ctx, source, destination); err != nil {
+		t.Fatal(err)
+	}
+	copyDB, err := sql.Open("sqlite", "file:"+destination+"?mode=ro")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer copyDB.Close()
+	var count int
+	if err := copyDB.QueryRowContext(ctx, `SELECT COUNT(*) FROM tasks WHERE id = 'backup-test'`).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 {
+		t.Fatalf("backup task count = %d, want 1", count)
+	}
+}
+
+func TestBackupRejectsExistingDestination(t *testing.T) {
+	ctx := context.Background()
+	source := filepath.Join(t.TempDir(), "agent.db")
+	db, err := Open(ctx, source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = db.Close()
+	if err := Backup(ctx, source, source); err == nil {
+		t.Fatal("Backup() accepted identical source and destination")
+	}
+}

--- a/src/agent/internal/platform/install/install_ps1_test.go
+++ b/src/agent/internal/platform/install/install_ps1_test.go
@@ -201,7 +201,7 @@ func TestInstallPs1RunsCurrentUserAgentThroughWindowlessLauncher(t *testing.T) {
 		`$runner = Join-Path $InstallRoot "hfl-agent-user-launcher.exe"`,
 		`-Execute $runner`,
 		"-Argument \"-data-dir `\"$DataRoot`\"\"",
-		`Copy-Item -Force -Path $srcLauncher -Destination (Join-Path $InstallRoot "hfl-agent-user-launcher.exe")`,
+		`Copy-HflFileAtomically -Source $srcLauncher -Destination (Join-Path $InstallRoot "hfl-agent-user-launcher.exe")`,
 		`Remove-HflInstallFile (Join-Path $InstallRoot "hfl-agent-user-launcher.exe")`,
 		`Remove-HflInstallFile (Join-Path $InstallRoot "run-agent.ps1")`,
 	} {
@@ -304,6 +304,81 @@ func TestInstallPs1UpgradeRollbackUsesModeAwareLifecycle(t *testing.T) {
 	}
 	if strings.Contains(rollback, "Start-Service -Name $ServiceName") {
 		t.Fatal("upgrade rollback must not hard-code the Windows service lifecycle")
+	}
+}
+
+func TestInstallPs1UpgradeKeepsRollbackUntilLocalHealth(t *testing.T) {
+	source := readPackagingInstallScript(t)
+	for _, want := range []string{
+		"Verify-HflUpgradePackage",
+		"agent.db-wal",
+		"agent.db-shm",
+		"Restore-AgentState",
+		"Restore-RollbackServiceDefinition",
+		"Restore-HflLifecycleStartupPolicy",
+		"Enable-HflLifecycleForRollbackStart",
+		"Test-HflLocalUpgradeHealth",
+		"upgrade-state.json",
+		"process_started_at_ticks",
+		"Upgrade state snapshot failed",
+		"Upgrade failed: $OriginalError. Rollback also failed",
+		"-Yes",
+		"awaiting_restart",
+		"upgrade-verification",
+		"database backup --source $sourceDatabase --destination $snapshotDatabase",
+		`@("deploying", "deployed", "migrating", "migrated", "configuring_service", "rolling_back")`,
+	} {
+		if !strings.Contains(source, want) {
+			t.Fatalf("install.ps1 upgrade transaction is missing %q", want)
+		}
+	}
+	upgradeStart := strings.Index(source, "function Invoke-Upgrade {")
+	if upgradeStart < 0 {
+		t.Fatal("install.ps1 is missing Invoke-Upgrade")
+	}
+	upgrade := source[upgradeStart:]
+	if strings.Index(upgrade, "Backup-AgentConfigAndDb -DataRoot $dataRoot -PreviousVersion $prevVer -SrcRoot $srcRoot") > strings.Index(upgrade, "Stop-AgentForUpgrade") {
+		t.Fatal("install.ps1 must create its consistent database snapshot before stopping the Agent")
+	}
+	deployStart := strings.Index(source, "function Deploy-Binaries {")
+	if deployStart < 0 {
+		t.Fatal("install.ps1 is missing Deploy-Binaries")
+	}
+	deploy := source[deployStart:]
+	if strings.Index(deploy, "Deploy-AdminScripts -SrcRoot $SrcRoot") > strings.Index(deploy, "Copy-HflFileAtomically -Source $srcAgent") {
+		t.Fatal("install.ps1 must stage the recovery-capable lifecycle script before replacing the Agent binary")
+	}
+	if strings.Index(upgrade, "Remove-UpgradeRollback -DataRoot $dataRoot") < strings.Index(upgrade, "Test-HflLocalUpgradeHealth -DataRoot $dataRoot -ExpectedVersion $newVer") {
+		t.Fatal("install.ps1 must not remove rollback before local health verification")
+	}
+	if !strings.Contains(source, `tasks list --data-dir $DataRoot --limit 1`) {
+		t.Fatal("install.ps1 local health check must use supported long-form Agent CLI flags")
+	}
+	if !strings.Contains(upgrade, "Restore-HflLifecycleStartupPolicy -DataRoot $dataRoot") {
+		t.Fatal("install.ps1 upgrade must preserve the previous service or task startup policy")
+	}
+	if strings.Index(source, `process_started_at_ticks`) > strings.Index(source, `Set-Content -LiteralPath (Join-Path $lock "pid") -Value $PID`) {
+		t.Fatal("install.ps1 must publish the lifecycle lock PID after owner metadata")
+	}
+	rollbackStart := strings.Index(source, "function Invoke-HflUpgradeRollback")
+	if rollbackStart < 0 {
+		t.Fatal("install.ps1 is missing Invoke-HflUpgradeRollback")
+	}
+	rollback := source[rollbackStart:]
+	enableIndex := strings.Index(rollback, "Enable-HflLifecycleForRollbackStart")
+	startIndex := strings.Index(rollback, "Start-HflServiceOnly")
+	policyIndex := strings.Index(rollback, "Restore-HflLifecycleStartupPolicy -DataRoot $DataRoot")
+	if enableIndex < 0 || startIndex < enableIndex || policyIndex < startIndex {
+		t.Fatal("install.ps1 rollback must allow the old lifecycle to start before restoring its disabled policy")
+	}
+	recoveryStart := strings.Index(source, `{ $_ -in @("stopping", "service_stopped", "snapshotting", "state_snapshotted") }`)
+	if recoveryStart < 0 {
+		t.Fatal("install.ps1 is missing pre-deployment interruption recovery")
+	}
+	recovery := source[recoveryStart:]
+	if strings.Index(recovery, "Enable-HflLifecycleForRollbackStart") > strings.Index(recovery, "Start-HflServiceOnly") ||
+		strings.Index(recovery, "Restore-HflLifecycleStartupPolicy -DataRoot $DataRoot") < strings.Index(recovery, "Start-HflServiceOnly") {
+		t.Fatal("install.ps1 interrupted recovery must start the old lifecycle before restoring its disabled policy")
 	}
 }
 

--- a/src/agent/internal/platform/install/install_sh_test.go
+++ b/src/agent/internal/platform/install/install_sh_test.go
@@ -231,6 +231,85 @@ func TestInstallShellCleansPartiallyMigratedSystemRootAfterHealthCheck(t *testin
 	}
 }
 
+func TestInstallShellUpgradeKeepsRollbackUntilLocalHealth(t *testing.T) {
+	body := readPackagingInstallShell(t)
+	for _, want := range []string{
+		`verify_upgrade_package`,
+		`agent.db-wal`,
+		`agent.db-shm`,
+		`restore_upgrade_state`,
+		`restore_upgrade_service_definition`,
+		`upgrade_health_check`,
+		`upgrade-state.json`,
+		`pending upgrade state is unreadable`,
+		`cleanup_upgrade_rollback "${data_dir}"`,
+		`local health check passed`,
+		`Upgrade failed; rollback also failed`,
+		`acquire_lifecycle_lock`,
+		`process_started_at`,
+		`process_start_marker()`,
+		`upgrade-verification`,
+		`awaiting_restart`,
+		`database backup --source "${db_source}" --destination "${snapshot}/data/agent.db"`,
+		`install_file_atomically "$src_script" "${INSTALL_DIR}/install.sh" 755`,
+		`deploying|deployed|migrating|migrated|configuring_service|rolling_back`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("install.sh upgrade transaction is missing %q", want)
+		}
+	}
+	// Recovery of an interrupted transaction may clean an older snapshot before
+	// the new transaction starts. Restrict the ordering assertion to cmd_upgrade
+	// itself so that path does not look like premature cleanup of the active
+	// upgrade.
+	start := strings.Index(body, "cmd_upgrade() {")
+	if start < 0 {
+		t.Fatal("install.sh missing cmd_upgrade")
+	}
+	end := strings.Index(body[start:], "\ncollect_agent_mount_points() {")
+	if end < 0 {
+		t.Fatal("install.sh cmd_upgrade boundary is missing")
+	}
+	upgradeBody := body[start : start+end]
+	if strings.Index(upgradeBody, `backup_agent_config_and_db "${data_dir}" "${prev_ver}" "${src_root}"`) > strings.Index(upgradeBody, `stop_service`) {
+		t.Fatal("install.sh must create its consistent database snapshot before stopping the Agent")
+	}
+	deployStart := strings.Index(body, "deploy_binaries() {")
+	if deployStart < 0 {
+		t.Fatal("install.sh missing deploy_binaries")
+	}
+	deployBody := body[deployStart:]
+	if strings.Index(deployBody, `deploy_admin_scripts "${src_root}"`) > strings.Index(deployBody, `install_file_atomically "$agent_bin"`) {
+		t.Fatal("install.sh must install the recovery-capable lifecycle script before replacing the Agent binary")
+	}
+	healthIndex := strings.Index(upgradeBody, `upgrade_health_check "${data_dir}" "${new_ver}"`)
+	cleanupIndex := strings.LastIndex(upgradeBody, `cleanup_upgrade_rollback "${data_dir}"`)
+	if healthIndex < 0 || cleanupIndex < healthIndex {
+		t.Fatal("install.sh must not remove rollback before local health verification")
+	}
+	if !strings.Contains(upgradeBody, "start_service_only") {
+		t.Fatal("install.sh upgrade must restart an active Agent without changing its systemd enable policy")
+	}
+	startOnly := strings.Index(body, "start_service_only() {")
+	if startOnly < 0 {
+		t.Fatal("install.sh is missing start_service_only")
+	}
+	startOnlyEnd := strings.Index(body[startOnly:], "\n}\n")
+	if startOnlyEnd < 0 {
+		t.Fatal("install.sh start_service_only has no end")
+	}
+	startOnlyBody := body[startOnly : startOnly+startOnlyEnd]
+	if !strings.Contains(startOnlyBody, "hfl_systemctl daemon-reload") {
+		t.Fatal("install.sh start_service_only must reload systemd before starting a rewritten unit")
+	}
+	if !strings.Contains(body, `if [[ -f "${state_file}" ]]; then`) {
+		t.Fatal("install.sh lifecycle commands must recover an existing state file even when its phase is unreadable")
+	}
+	if strings.Index(body, `process_started_at`) > strings.Index(body, `printf '%s\n' "$$" >"${lock_dir}/pid"`) {
+		t.Fatal("install.sh must publish the lifecycle lock PID after owner metadata")
+	}
+}
+
 func TestInstallShellKeepsSpecifiedUserOutOfUserManager(t *testing.T) {
 	body := readPackagingInstallShell(t)
 	start := strings.Index(body, "hfl_systemctl() {")

--- a/src/agent/internal/platform/install/layout.go
+++ b/src/agent/internal/platform/install/layout.go
@@ -15,6 +15,7 @@ const (
 	runtimeWorkspace   = "workspace"
 	lifecycleUpgrade   = "upgrade"
 	lifecycleUninstall = "uninstall"
+	upgradeStateFile   = "upgrade-state.json"
 )
 
 // BackupRollbackBinDir is the fixed rollback snapshot for install-dir binaries.
@@ -50,6 +51,11 @@ func LifecycleUpgradeDir(dataDir string) string {
 // LifecycleUninstallDir holds detached uninstall runner.
 func LifecycleUninstallDir(dataDir string) string {
 	return filepath.Join(strings.TrimSpace(dataDir), dirLifecycle, lifecycleUninstall)
+}
+
+// LifecycleUpgradeStatePath records the durable local upgrade transaction.
+func LifecycleUpgradeStatePath(dataDir string) string {
+	return filepath.Join(strings.TrimSpace(dataDir), dirLifecycle, upgradeStateFile)
 }
 
 // LifecycleUpgradeFailedPath is written when detached upgrade fails.

--- a/src/agent/internal/platform/install/layout_test.go
+++ b/src/agent/internal/platform/install/layout_test.go
@@ -17,6 +17,9 @@ func TestUpgradeArtifactsStayUnderRollbackDirectory(t *testing.T) {
 	if got, want := BackupRollbackBinDir(root), root+"/backup/rollback/bin"; got != want {
 		t.Fatalf("binary rollback path = %q, want %q", got, want)
 	}
+	if got, want := LifecycleUpgradeStatePath(root), root+"/lifecycle/upgrade-state.json"; got != want {
+		t.Fatalf("upgrade state path = %q, want %q", got, want)
+	}
 	if got, want := vfs.AgentDatabasePath(root), root+"/data/agent.db"; got != want {
 		t.Fatalf("database path = %q, want %q", got, want)
 	}

--- a/src/agent/internal/platform/install/local_upgrade_windows.go
+++ b/src/agent/internal/platform/install/local_upgrade_windows.go
@@ -101,28 +101,8 @@ try {
     exit 1
   }
 
-  Log "stopping HyperFileLensAgent before install.ps1 upgrade"
-  if ($userInstall) {
-    Stop-ScheduledTask -TaskName $runtimeTaskName -ErrorAction SilentlyContinue
-  } else {
-    Stop-Service -Name HyperFileLensAgent -Force -ErrorAction SilentlyContinue
-  }
-  # $install is the full path to install.ps1. Match only processes whose
-  # executable lives below this installation's Agent Root.
-  $agentRoot = Split-Path -Parent $install
-  Get-Process -Name hfl-agent -ErrorAction SilentlyContinue | Where-Object {
-    try {
-      $_.Path -and [System.IO.Path]::GetFullPath($_.Path).StartsWith(
-        [System.IO.Path]::GetFullPath($agentRoot).TrimEnd('\') + '\',
-        [System.StringComparison]::OrdinalIgnoreCase
-      )
-    }
-    catch { $false }
-  } | Stop-Process -Force -ErrorAction SilentlyContinue
-  Start-Sleep -Seconds 2
-
   Log "running install.ps1 upgrade"
-  $upgradeArgs = @('-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', $install, 'upgrade', '-From', $archive, '-QuietFooter')
+  $upgradeArgs = @('-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', $install, 'upgrade', '-From', $archive, '-Yes', '-QuietFooter')
   & powershell.exe @upgradeArgs 2>&1 | ForEach-Object {
     $line = ($_.ToString()).TrimEnd()
     if ($line) { Log "install.ps1> $line" }

--- a/src/agent/packaging/install/install.ps1
+++ b/src/agent/packaging/install/install.ps1
@@ -34,6 +34,7 @@ param(
   [switch]$AgentOnly,
   [switch]$KopiaOnly,
   [switch]$NoRestart,
+  [switch]$Yes,
   [switch]$Help,
   [switch]$QuietFooter
 )
@@ -99,6 +100,16 @@ $CurrentWindowsSid = [Security.Principal.WindowsIdentity]::GetCurrent().User.Val
 $TaskName = if ($InstallationMode -eq "user") { "HyperFileLensAgent.User.$CurrentWindowsSid" } else { "HyperFileLensAgent" }
 $script:LegacyMigrationRoot = ""
 $script:LegacyServiceWasRunning = $false
+$script:UpgradeTransactionActive = $false
+$script:UpgradeStateSnapshotReady = $false
+$script:UpgradeDeploymentStarted = $false
+$script:UpgradeStopAttempted = $false
+$script:UpgradeLifecycleWasRunning = $false
+$script:UpgradeOperationStateCreated = $false
+$script:UpgradePreviousVersion = "unknown"
+$script:UpgradeTargetVersion = "unknown"
+$script:LifecycleLockPath = ""
+$script:UpgradeStatePath = ""
 if ([string]::IsNullOrWhiteSpace($RunAsUser) -and $env:HFL_RUN_AS_USER) {
   $RunAsUser = $env:HFL_RUN_AS_USER.Trim()
 }
@@ -142,6 +153,101 @@ function Ensure-HflAgentLayout {
     (Join-Path $Root "backup\legacy")
   )
   New-Item -ItemType Directory -Force -Path $directories | Out-Null
+}
+
+function Acquire-HflLifecycleLock {
+  param([Parameter(Mandatory = $true)][string]$DataRoot, [Parameter(Mandatory = $true)][string]$Operation)
+  $lock = Join-Path (Get-HflLifecycleRoot $DataRoot) "install.lock"
+  New-Item -ItemType Directory -Force -Path (Get-HflLifecycleRoot $DataRoot) | Out-Null
+  try {
+    New-Item -ItemType Directory -Path $lock -ErrorAction Stop | Out-Null
+  }
+  catch {
+    $pidPath = Join-Path $lock "pid"
+    $owner = 0
+	for ($attempt = 0; $attempt -lt 5 -and -not (Test-Path -LiteralPath $pidPath); $attempt++) {
+	  Start-Sleep -Milliseconds 100
+	}
+    if (Test-Path -LiteralPath $pidPath) { [int]::TryParse((Get-Content -Raw -LiteralPath $pidPath), [ref]$owner) | Out-Null }
+	$ownerProcess = if ($owner -gt 0) { Get-Process -Id $owner -ErrorAction SilentlyContinue } else { $null }
+    if ($null -ne $ownerProcess) {
+	  $recordedStart = ""
+	  $startPath = Join-Path $lock "process_started_at_ticks"
+	  if (Test-Path -LiteralPath $startPath) { $recordedStart = (Get-Content -Raw -LiteralPath $startPath).Trim() }
+	  $actualStart = try { $ownerProcess.StartTime.ToUniversalTime().Ticks.ToString() } catch { "" }
+	  if (-not $recordedStart -or -not $actualStart -or $recordedStart -eq $actualStart) {
+	    throw "Another Agent lifecycle operation is already running (PID $owner)."
+	  }
+    }
+    Remove-Item -Recurse -Force -LiteralPath $lock -ErrorAction SilentlyContinue
+    New-Item -ItemType Directory -Path $lock -ErrorAction Stop | Out-Null
+  }
+  $script:LifecycleLockPath = $lock
+  try {
+	$processStart = (Get-Process -Id $PID -ErrorAction Stop).StartTime.ToUniversalTime().Ticks.ToString()
+	Set-Content -LiteralPath (Join-Path $lock "process_started_at_ticks") -Value $processStart -Encoding ASCII
+    Set-Content -LiteralPath (Join-Path $lock "operation") -Value $Operation -Encoding ASCII
+    Set-Content -LiteralPath (Join-Path $lock "started_at") -Value ([DateTime]::UtcNow.ToString('o')) -Encoding ASCII
+    Set-Content -LiteralPath (Join-Path $lock "target_version") -Value "unknown" -Encoding ASCII
+    Set-Content -LiteralPath (Join-Path $lock "target_commit") -Value "unknown" -Encoding ASCII
+	# Publish the PID last: seeing pid means all owner identity metadata exists.
+	Set-Content -LiteralPath (Join-Path $lock "pid") -Value $PID -Encoding ASCII
+  }
+  catch {
+    Remove-Item -Recurse -Force -LiteralPath $lock -ErrorAction SilentlyContinue
+    $script:LifecycleLockPath = ""
+    throw
+  }
+}
+
+function Update-HflLifecycleLockTarget {
+  param([Parameter(Mandatory = $true)][string]$Version, [string]$Manifest = $ManifestFile)
+  if (-not $script:LifecycleLockPath -or -not (Test-Path -LiteralPath $script:LifecycleLockPath)) { return }
+  $commit = "unknown"
+  if (Test-Path -LiteralPath $Manifest) {
+    try {
+      $value = [string](Get-Content -Raw -LiteralPath $Manifest | ConvertFrom-Json).agent_commit
+      if (-not [string]::IsNullOrWhiteSpace($value)) { $commit = $value }
+    }
+    catch { }
+  }
+  Set-Content -LiteralPath (Join-Path $script:LifecycleLockPath "target_version") -Value $Version -Encoding ASCII
+  Set-Content -LiteralPath (Join-Path $script:LifecycleLockPath "target_commit") -Value $commit -Encoding ASCII
+}
+
+function Release-HflLifecycleLock {
+  if ($script:LifecycleLockPath) {
+    Remove-Item -Recurse -Force -LiteralPath $script:LifecycleLockPath -ErrorAction SilentlyContinue
+    $script:LifecycleLockPath = ""
+  }
+}
+
+function Write-HflUpgradeState {
+  param([Parameter(Mandatory = $true)][string]$DataRoot, [Parameter(Mandatory = $true)][string]$Phase)
+  $statePath = Join-Path (Get-HflLifecycleRoot $DataRoot) "upgrade-state.json"
+  $state = [ordered]@{
+    phase = $Phase
+    operation = "upgrade"
+    pid = $PID
+    previous_version = $script:UpgradePreviousVersion
+    target_version = $script:UpgradeTargetVersion
+    installation_mode = $InstallationMode
+    lifecycle_was_running = $script:UpgradeLifecycleWasRunning
+    state_snapshot_ready = $script:UpgradeStateSnapshotReady
+    deployment_started = $script:UpgradeDeploymentStarted
+    updated_at = [DateTime]::UtcNow.ToString('o')
+  }
+  $tempPath = "$statePath.tmp"
+  $script:UpgradeStatePath = $statePath
+  $state | ConvertTo-Json -Compress | Set-Content -LiteralPath $tempPath -Encoding UTF8
+  Move-Item -Force -LiteralPath $tempPath -Destination $statePath
+}
+
+function Clear-HflUpgradeState {
+  if ($script:UpgradeStatePath) {
+    Remove-Item -Force -LiteralPath $script:UpgradeStatePath -ErrorAction SilentlyContinue
+    $script:UpgradeStatePath = ""
+  }
 }
 
 function Assert-HflInstallationIdentity {
@@ -190,6 +296,7 @@ Options:
 
   upgrade:
     -From PATH           Path to new package directory or hfl-agent-*.zip (required)
+    -Yes                  Non-interactive: continue when target version equals installed version
                           Extracts to DATA_DIR/runtime/workspace, merges missing config/agent.env keys,
                           migrates agent.db schema, overwrites binaries; removes workspace on success
 
@@ -458,9 +565,9 @@ function Write-HflFooter {
       }
     }
     'upgrade' {
-      Write-HflDisplayLine "Upgrade completed successfully"
+      Write-HflDisplayLine ($(if ($NoRestart) { "Upgrade staged; restart and verification are pending" } else { "Upgrade completed successfully" }))
       Write-HflDisplayLine ("=" * 64)
-      Write-HflDisplayLine "  HyperFileLens Agent upgraded successfully."
+      Write-HflDisplayLine ($(if ($NoRestart) { "  Rollback data is retained until local health verification completes." } else { "  HyperFileLens Agent upgraded successfully." }))
       if ($ApiBase) {
         Write-Host ""
         Write-HflDisplayLine "  Console: $($ApiBase.TrimEnd('/'))"
@@ -561,6 +668,70 @@ function Test-AgentPackageRoot {
     (Test-Path -LiteralPath (Join-Path $Root "bin\hfl-agent-user-launcher.exe"))
 }
 
+function Compare-HflVersion {
+  param([string]$Left, [string]$Right)
+  $leftText = if ($null -eq $Left) { "" } else { $Left.Trim() }
+  $rightText = if ($null -eq $Right) { "" } else { $Right.Trim() }
+  $leftText = $leftText.TrimStart('v')
+  $rightText = $rightText.TrimStart('v')
+  if ($leftText -match '^main-[0-9a-f]{7}$' -or $rightText -match '^main-[0-9a-f]{7}$') {
+    if ($leftText -eq $rightText) { return 0 }
+    return $null
+  }
+  $leftParts = $leftText -split '\.'
+  $rightParts = $rightText -split '\.'
+  if ($leftParts.Count -ne 3 -or $rightParts.Count -ne 3 -or
+      ($leftParts | Where-Object { $_ -notmatch '^\d+$' }) -or
+      ($rightParts | Where-Object { $_ -notmatch '^\d+$' })) { return $null }
+  for ($i = 0; $i -lt 3; $i++) {
+    $leftNumber = [int]$leftParts[$i]
+    $rightNumber = [int]$rightParts[$i]
+    if ($leftNumber -lt $rightNumber) { return -1 }
+    if ($leftNumber -gt $rightNumber) { return 1 }
+  }
+  return 0
+}
+
+function Confirm-HflSameVersionUpgrade {
+  param([Parameter(Mandatory = $true)][string]$Version)
+  if ($Yes) {
+    Write-HflWarn "new package version matches current ($Version); continuing upgrade (-Yes)"
+    return
+  }
+  if ([Environment]::UserInteractive -and -not $QuietFooter) {
+    $answer = Read-Host "Package version is already $Version. Continue upgrade? [y/N]"
+    if ($answer -match '^(?i:y|yes)$') { return }
+  }
+  throw "Same-version upgrade requires interactive confirmation or -Yes."
+}
+
+function Verify-HflUpgradePackage {
+  param(
+    [Parameter(Mandatory = $true)][string]$Root,
+    [Parameter(Mandatory = $true)][string]$RoleName,
+    [Parameter(Mandatory = $true)][string]$Version
+  )
+  $targetVerifier = Join-Path $Root "bin\hfl-agent.exe"
+  if (-not (Test-Path -LiteralPath $targetVerifier)) { throw "Upgrade package verifier is missing: $targetVerifier" }
+  $verifier = $targetVerifier
+  $installedVerifier = Join-Path $InstallRoot "hfl-agent.exe"
+  if (Test-Path -LiteralPath $installedVerifier) {
+    $installedHelp = (& $installedVerifier help 2>&1 | Out-String)
+    if ($LASTEXITCODE -eq 0 -and $installedHelp -match 'package verify') {
+      # Once this verifier is installed, use the trusted current Agent for all
+      # later upgrades. The target binary is only the compatibility bridge from
+      # releases that predate the package-verify command.
+      $verifier = $installedVerifier
+    }
+  }
+  $verifyOutput = (& $verifier package verify --root $Root --role $RoleName --version $Version 2>&1 | Out-String).Trim()
+  if ($LASTEXITCODE -ne 0) {
+    $detail = if ($verifyOutput) { ": $verifyOutput" } else { "" }
+    throw "Upgrade package manifest and checksum validation failed$detail"
+  }
+  Write-HflOk "upgrade package manifest and checksums verified"
+}
+
 function Get-UpgradeWorkspace {
   param([Parameter(Mandatory = $true)][string]$DataRoot)
   return Join-Path (Get-HflRuntimeRoot $DataRoot) "workspace"
@@ -604,54 +775,72 @@ function Resolve-UpgradeSource {
 function Backup-AgentConfigAndDb {
   param(
     [Parameter(Mandatory = $true)][string]$DataRoot,
-    [string]$PreviousVersion = "unknown"
+    [string]$PreviousVersion = "unknown",
+    [Parameter(Mandatory = $true)][string]$SrcRoot
   )
   $stateDir = Join-Path (Get-HflBackupRoot $DataRoot) "rollback"
 	$archive = Join-Path $stateDir "latest.zip"
 	$meta = Join-Path $stateDir "meta.json"
 	$names = @(
-	  @{ Source = (Join-Path (Get-HflConfigRoot $DataRoot) "agent.env"); Archive = "config-agent.env" },
-	  @{ Source = (Join-Path (Get-HflDataStoreRoot $DataRoot) "agent.db"); Archive = "data-agent.db" },
-	  @{ Source = (Join-Path (Get-HflDataStoreRoot $DataRoot) "agent.db-wal"); Archive = "data-agent.db-wal" },
-	  @{ Source = (Join-Path (Get-HflDataStoreRoot $DataRoot) "agent.db-shm"); Archive = "data-agent.db-shm" }
+	  @{ Source = (Join-Path (Get-HflConfigRoot $DataRoot) "agent.env"); Archive = "config\agent.env" },
+	  @{ Source = (Join-Path (Get-HflConfigRoot $DataRoot) "config.json"); Archive = "config\config.json" }
 	)
 	$items = @()
 	foreach ($entry in $names) {
 		if (Test-Path -LiteralPath $entry.Source) { $items += $entry }
   }
   New-Item -ItemType Directory -Force -Path $stateDir | Out-Null
-  if ($items.Count -eq 0) {
-    Write-HflSkip "backup agent.env/agent.db (nothing to back up)"
-    return
-  }
-  $tempDir = Join-Path $env:TEMP "hfl-agent-backup-$(Get-Date -Format 'yyyyMMdd-HHmmss')"
+	$sourceDatabase = Join-Path (Get-HflDataStoreRoot $DataRoot) "agent.db"
+	  if ($items.Count -eq 0 -and -not (Test-Path -LiteralPath $sourceDatabase)) { throw "Upgrade state snapshot could not be created: no configuration or database state was found." }
+  $tempDir = Join-Path $env:TEMP ("hfl-agent-backup-{0}" -f ([Guid]::NewGuid().ToString('N')))
   New-Item -ItemType Directory -Force -Path $tempDir | Out-Null
 	  try {
 	    foreach ($entry in $items) {
-			Copy-Item -LiteralPath $entry.Source -Destination (Join-Path $tempDir $entry.Archive) -Force
+	      $destination = Join-Path $tempDir $entry.Archive
+	      New-Item -ItemType Directory -Force -Path (Split-Path -Parent $destination) | Out-Null
+			Copy-Item -LiteralPath $entry.Source -Destination $destination -Force
 	    }
+	if (Test-Path -LiteralPath $sourceDatabase) {
+	  $snapshotDatabase = Join-Path $tempDir "data\agent.db"
+	  New-Item -ItemType Directory -Force -Path (Split-Path -Parent $snapshotDatabase) | Out-Null
+	  $backupAgent = Join-Path $SrcRoot "bin\hfl-agent.exe"
+	  & $backupAgent database backup --source $sourceDatabase --destination $snapshotDatabase
+	  if ($LASTEXITCODE -ne 0) { throw "consistent SQLite backup failed (exit $LASTEXITCODE)" }
+	}
     Compress-Archive -Path (Join-Path $tempDir '*') -DestinationPath $archive -Force
-    Write-HflOk "backed up agent.env/agent.db -> $archive"
+    Write-HflOk "backed up Agent configuration and consistent SQLite state -> $archive"
     $createdAt = [DateTime]::UtcNow.ToString('yyyy-MM-ddTHH:mm:ssZ')
-    @"
-{
-  "created_at": "$createdAt",
-  "previous_version": "$PreviousVersion",
-  "state_archive": "backup/rollback/latest.zip"
-}
-"@ | Set-Content -LiteralPath $meta -Encoding UTF8
+    [ordered]@{
+      created_at = $createdAt
+      previous_version = $PreviousVersion
+      installation_mode = $InstallationMode
+      service_name = $ServiceName
+      state_archive = "backup/rollback/latest.zip"
+    } | ConvertTo-Json | Set-Content -LiteralPath $meta -Encoding UTF8
     Write-HflOk "wrote $meta"
   }
-  catch {
-    Write-HflWarn "backup agent.env/agent.db failed (agent may still be running): $($_.Exception.Message)"
-    Write-HflWarn "backup skipped; continuing upgrade"
-  }
+	  catch { throw "Upgrade state snapshot failed: $($_.Exception.Message)" }
   finally {
     Remove-Item -Recurse -Force -LiteralPath $tempDir -ErrorAction SilentlyContinue
   }
 }
 
 $script:UpgradeBinBackup = ""
+
+function Backup-RollbackServiceDefinition {
+  param([Parameter(Mandatory = $true)][string]$DataRoot)
+  $serviceDir = Join-Path (Join-Path (Get-HflBackupRoot $DataRoot) "rollback") "service"
+  New-Item -ItemType Directory -Force -Path $serviceDir | Out-Null
+  if ($InstallationMode -eq "system") {
+    $service = Get-CimInstance Win32_Service -Filter "Name='$ServiceName'" -ErrorAction SilentlyContinue
+    if ($null -eq $service) { New-Item -ItemType File -Force -Path (Join-Path $serviceDir "service.absent") | Out-Null }
+    else { $service | Select-Object Name,PathName,StartMode,StartName,DisplayName,Description | ConvertTo-Json | Set-Content -LiteralPath (Join-Path $serviceDir "service.json") -Encoding UTF8 }
+  }
+  elseif (Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue) {
+    Export-ScheduledTask -TaskName $TaskName | Set-Content -LiteralPath (Join-Path $serviceDir "task.xml") -Encoding UTF8
+  }
+  else { New-Item -ItemType File -Force -Path (Join-Path $serviceDir "task.absent") | Out-Null }
+}
 
 function Backup-RollbackBinaries {
   param([Parameter(Mandatory = $true)][string]$DataRoot)
@@ -661,15 +850,16 @@ function Backup-RollbackBinaries {
     Remove-Item -Recurse -Force -LiteralPath $rollbackRoot
   }
   New-Item -ItemType Directory -Force -Path $script:UpgradeBinBackup | Out-Null
-	foreach ($name in @("hfl-agent.exe", "hfl-agent-user-launcher.exe", "kopia.exe")) {
+	foreach ($name in @("hfl-agent.exe", "hfl-agent-user-launcher.exe", "kopia.exe", "install.ps1", "install.cmd", "uninstall.cmd", "run-agent.ps1")) {
 		$src = Join-Path $InstallRoot $name
     if (Test-Path -LiteralPath $src) {
       Copy-Item -LiteralPath $src -Destination (Join-Path $script:UpgradeBinBackup $name) -Force
 	}
+	  }
 	foreach ($path in @($ManifestFile, $InstalledVersionFile)) {
 		if (Test-Path -LiteralPath $path) { Copy-Item -LiteralPath $path -Destination (Join-Path $script:UpgradeBinBackup (Split-Path -Leaf $path)) -Force }
 	}
-  }
+	Backup-RollbackServiceDefinition -DataRoot $DataRoot
   Write-HflOk "backed up binaries -> $($script:UpgradeBinBackup)"
 }
 
@@ -677,26 +867,311 @@ function Restore-RollbackBinaries {
   if ([string]::IsNullOrWhiteSpace($script:UpgradeBinBackup) -or -not (Test-Path -LiteralPath $script:UpgradeBinBackup)) {
     return
   }
-	foreach ($name in @("hfl-agent.exe", "hfl-agent-user-launcher.exe", "kopia.exe")) {
-    $src = Join-Path $script:UpgradeBinBackup $name
-    if (Test-Path -LiteralPath $src) {
-      Copy-Item -LiteralPath $src -Destination (Join-Path $InstallRoot $name) -Force
+	foreach ($name in @("hfl-agent.exe", "hfl-agent-user-launcher.exe", "kopia.exe", "install.ps1", "install.cmd", "uninstall.cmd", "run-agent.ps1")) {
+	    $src = Join-Path $script:UpgradeBinBackup $name
+	    $destination = Join-Path $InstallRoot $name
+	    if (Test-Path -LiteralPath $src) {
+	      if ($name -eq "install.ps1" -and $MyInvocation.PSCommandPath -and ((Get-FullPathOrSelf $destination) -eq (Get-FullPathOrSelf $MyInvocation.PSCommandPath))) {
+	        Copy-Item -LiteralPath $src -Destination "$destination.pending" -Force
+	        Register-DeferredFileMove -Source "$destination.pending" -Destination $destination
+	      }
+	      elseif ($name -eq "install.cmd") {
+	        Copy-Item -LiteralPath $src -Destination "$destination.pending" -Force
+	        Register-DeferredFileMove -Source "$destination.pending" -Destination $destination
+	      }
+	      else { Copy-HflFileAtomically -Source $src -Destination $destination }
+	    }
+	    elseif ($name -notin @("install.ps1", "install.cmd")) {
+	      Remove-Item -Force -LiteralPath $destination -ErrorAction SilentlyContinue
+	    }
 	}
 	foreach ($entry in @(@{ Name = "MANIFEST.json"; Target = $ManifestFile }, @{ Name = "INSTALLED_VERSION"; Target = $InstalledVersionFile })) {
 		$src = Join-Path $script:UpgradeBinBackup $entry.Name
-		if (Test-Path -LiteralPath $src) { Copy-Item -LiteralPath $src -Destination $entry.Target -Force }
+		if (Test-Path -LiteralPath $src) { Copy-HflFileAtomically -Source $src -Destination $entry.Target }
 	}
-  }
   Write-HflWarn "restored binaries from $($script:UpgradeBinBackup)"
+}
+
+function Restore-AgentState {
+  param([Parameter(Mandatory = $true)][string]$DataRoot)
+  $archive = Join-Path (Join-Path (Get-HflBackupRoot $DataRoot) "rollback") "latest.zip"
+  if (-not (Test-Path -LiteralPath $archive)) { throw "rollback state archive is missing: $archive" }
+  $temp = Join-Path $env:TEMP ("hfl-agent-restore-{0}" -f ([Guid]::NewGuid().ToString('N')))
+  New-Item -ItemType Directory -Force -Path $temp | Out-Null
+  try {
+    Expand-Archive -LiteralPath $archive -DestinationPath $temp -Force
+    if (-not (Test-Path -LiteralPath (Join-Path $temp "config\agent.env")) -and
+        -not (Test-Path -LiteralPath (Join-Path $temp "data\agent.db"))) {
+      throw "rollback state archive contains neither Agent configuration nor database state"
+    }
+    foreach ($name in @("config\agent.env", "config\config.json", "data\agent.db")) {
+      $source = Join-Path $temp $name
+      $destination = Join-Path $DataRoot $name
+      if (Test-Path -LiteralPath $source) {
+        New-Item -ItemType Directory -Force -Path (Split-Path -Parent $destination) | Out-Null
+        Copy-HflFileAtomically -Source $source -Destination $destination
+      }
+      else { Remove-Item -Force -LiteralPath $destination -ErrorAction SilentlyContinue }
+    }
+    # The online SQLite backup is standalone; stale WAL/SHM files from the
+    # failed target must not be paired with it.
+    Remove-Item -Force -LiteralPath (Join-Path (Get-HflDataStoreRoot $DataRoot) "agent.db-wal") -ErrorAction SilentlyContinue
+    Remove-Item -Force -LiteralPath (Join-Path (Get-HflDataStoreRoot $DataRoot) "agent.db-shm") -ErrorAction SilentlyContinue
+  } finally { Remove-Item -Recurse -Force -LiteralPath $temp -ErrorAction SilentlyContinue }
+  Write-HflWarn "restored Agent configuration and database state from $archive"
+}
+
+function Restore-RollbackServiceDefinition {
+  param([Parameter(Mandatory = $true)][string]$DataRoot)
+  $serviceDir = Join-Path (Join-Path (Get-HflBackupRoot $DataRoot) "rollback") "service"
+  if ($InstallationMode -eq "system") {
+    Remove-HflService
+    $serviceSnapshot = Join-Path $serviceDir "service.json"
+    if (Test-Path -LiteralPath $serviceSnapshot) {
+      Install-HflService -ExePath (Join-Path $InstallRoot "hfl-agent.exe") -DataRoot $DataRoot -NoStart
+    }
+  } else {
+    if (Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue) {
+      Stop-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
+      Unregister-ScheduledTask -TaskName $TaskName -Confirm:$false -ErrorAction SilentlyContinue
+    }
+    $taskXml = Join-Path $serviceDir "task.xml"
+    if (Test-Path -LiteralPath $taskXml) {
+      Register-ScheduledTask -TaskName $TaskName -Xml (Get-Content -Raw -LiteralPath $taskXml) -Force | Out-Null
+    }
+  }
+}
+
+function Enable-HflLifecycleForRollbackStart {
+  if ($InstallationMode -eq "system") {
+    # A service that was disabled after being manually started cannot be
+    # started again until its startup type is temporarily relaxed.
+    Set-Service -Name $ServiceName -StartupType Manual
+    return
+  }
+  Enable-ScheduledTask -TaskName $TaskName | Out-Null
+}
+
+function Restore-HflLifecycleStartupPolicy {
+  param([Parameter(Mandatory = $true)][string]$DataRoot)
+  $serviceDir = Join-Path (Join-Path (Get-HflBackupRoot $DataRoot) "rollback") "service"
+  if ($InstallationMode -eq "system") {
+    $serviceSnapshot = Join-Path $serviceDir "service.json"
+    if (-not (Test-Path -LiteralPath $serviceSnapshot)) { return }
+    $previousStartMode = [string]((Get-Content -Raw -LiteralPath $serviceSnapshot | ConvertFrom-Json).StartMode)
+    switch ($previousStartMode.ToLowerInvariant()) {
+      "auto" { Set-Service -Name $ServiceName -StartupType Automatic }
+      "manual" { Set-Service -Name $ServiceName -StartupType Manual }
+      "disabled" { Set-Service -Name $ServiceName -StartupType Disabled }
+    }
+    return
+  }
+
+  $taskSnapshot = Join-Path $serviceDir "task.xml"
+  if (-not (Test-Path -LiteralPath $taskSnapshot)) { return }
+  [xml]$taskXml = Get-Content -Raw -LiteralPath $taskSnapshot
+  $enabledNode = $taskXml.SelectSingleNode("//*[local-name()='Settings']/*[local-name()='Enabled']")
+  if ($null -ne $enabledNode -and $enabledNode.InnerText.Trim().ToLowerInvariant() -eq "false") {
+    Disable-ScheduledTask -TaskName $TaskName | Out-Null
+  }
+}
+
+function Test-HflLocalUpgradeHealth {
+  param(
+    [Parameter(Mandatory = $true)][string]$DataRoot,
+    [Parameter(Mandatory = $true)][string]$ExpectedVersion,
+    [switch]$SkipLifecycle
+  )
+  $manifest = Get-Content -Raw -LiteralPath $ManifestFile | ConvertFrom-Json
+  $expectedCommit = [string]$manifest.agent_commit
+  if ([string]::IsNullOrWhiteSpace($expectedCommit)) { return $false }
+  $identity = (& (Join-Path $InstallRoot "hfl-agent.exe") version 2>&1 | Out-String).Trim()
+  if ($LASTEXITCODE -ne 0 -or $identity -notmatch '^hyperfilelens-agent\s+(\S+)\s+\(([^)]+)\)$') { return $false }
+  $actualVersion = $Matches[1].TrimStart('v')
+  $actualCommit = $Matches[2]
+  if ($actualVersion -ne $ExpectedVersion.TrimStart('v') -or $actualCommit -ne $expectedCommit) { return $false }
+  & (Join-Path $InstallRoot "hfl-agent.exe") tasks list --data-dir $DataRoot --limit 1 *> $null
+  if ($LASTEXITCODE -ne 0) { return $false }
+  if ($NoService -or $SkipLifecycle) { return $true }
+  $stable = 0; $lastPid = 0
+  while ($stable -lt 10) {
+    if ($InstallationMode -eq "system") {
+      $service = Get-Service -Name $ServiceName -ErrorAction SilentlyContinue
+      if ($null -eq $service -or $service.Status -ne "Running") { return $false }
+      $processId = [int](Get-CimInstance Win32_Service -Filter "Name='$ServiceName'" -ErrorAction SilentlyContinue).ProcessId
+    } else {
+      $task = Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
+      if ($null -eq $task -or $task.State -ne "Running") { return $false }
+      $processId = [int]((Get-Process -Name hfl-agent -ErrorAction SilentlyContinue | Where-Object { $_.Path -and (Get-FullPathOrSelf $_.Path).StartsWith((Get-FullPathOrSelf $AgentRoot).TrimEnd('\') + '\', [System.StringComparison]::OrdinalIgnoreCase) } | Select-Object -First 1).Id)
+    }
+    if ($processId -le 0) { return $false }
+    $process = Get-Process -Id $processId -ErrorAction SilentlyContinue
+    if ($null -eq $process -or -not $process.Path -or (Get-FullPathOrSelf $process.Path) -ne (Get-FullPathOrSelf (Join-Path $InstallRoot "hfl-agent.exe"))) { return $false }
+    if ($lastPid -ne 0 -and $lastPid -ne $processId) { return $false }
+    $lastPid = $processId; $stable++; Start-Sleep -Seconds 1
+  }
+  Write-HflOk "local health check passed ($ExpectedVersion, $expectedCommit; stable ${stable}s)"
+  return $true
+}
+
+function Invoke-HflUpgradeRollback {
+  param(
+    [Parameter(Mandatory = $true)][string]$DataRoot,
+    [Parameter(Mandatory = $true)][string]$PreviousVersion,
+    [Parameter(Mandatory = $true)][string]$OriginalError,
+    [switch]$LegacyUpgrade,
+    [switch]$ReturnAfterRollback
+  )
+  $script:UpgradeTransactionActive = $false
+  try { Write-HflUpgradeState -DataRoot $DataRoot -Phase "rolling_back" }
+  catch { Write-HflWarn "could not persist rolling_back state: $($_.Exception.Message)" }
+  Write-HflWarn "upgrade failed: $OriginalError; attempting rollback"
+  $rollbackErrors = @()
+  if ($script:UpgradeDeploymentStarted) {
+    $canRestore = $true
+    try { Stop-AgentForUpgrade }
+    catch {
+      $canRestore = $false
+      $rollbackErrors += "stop: $($_.Exception.Message)"
+    }
+    if ($canRestore) {
+      try { Restore-RollbackBinaries } catch { $rollbackErrors += "binaries: $($_.Exception.Message)" }
+      if ($script:UpgradeStateSnapshotReady) {
+        try { Restore-AgentState -DataRoot $DataRoot } catch { $rollbackErrors += "state: $($_.Exception.Message)" }
+      }
+      try { Restore-RollbackServiceDefinition -DataRoot $DataRoot } catch { $rollbackErrors += "service definition: $($_.Exception.Message)" }
+    }
+  }
+	if (-not $NoService -and -not $LegacyUpgrade) {
+	  if ($script:UpgradeLifecycleWasRunning) {
+	    try {
+	      Enable-HflLifecycleForRollbackStart
+	      Start-HflServiceOnly
+	    }
+	    catch { $rollbackErrors += "service start: $($_.Exception.Message)" }
+	  }
+	  try { Restore-HflLifecycleStartupPolicy -DataRoot $DataRoot }
+	  catch { $rollbackErrors += "startup policy: $($_.Exception.Message)" }
+  }
+  if (-not $LegacyUpgrade -and -not (Test-HflLocalUpgradeHealth -DataRoot $DataRoot -ExpectedVersion $PreviousVersion -SkipLifecycle:(-not $script:UpgradeLifecycleWasRunning))) {
+    $rollbackErrors += "old Agent local health verification failed"
+  }
+  if ($rollbackErrors.Count -gt 0) {
+    try { Write-HflUpgradeState -DataRoot $DataRoot -Phase "rollback_failed" }
+    catch { $rollbackErrors += "persist rollback failure state: $($_.Exception.Message)" }
+    throw "Upgrade failed: $OriginalError. Rollback also failed: $($rollbackErrors -join '; ')"
+  }
+  # The rollback copy is only needed while restoring or validating the old
+  # Agent. Once rollback health checks pass, remove it so a later invocation
+  # cannot mistake an old snapshot for an interrupted transaction.
+  $rollbackStatePersisted = $true
+  try { Write-HflUpgradeState -DataRoot $DataRoot -Phase "rolled_back" }
+  catch {
+    $rollbackStatePersisted = $false
+    Write-HflWarn "rollback completed, but its state could not be persisted; rollback data was retained: $($_.Exception.Message)"
+  }
+  if ($rollbackStatePersisted) { Remove-UpgradeRollback -DataRoot $DataRoot }
+  Write-HflWarn "upgrade failed; rollback completed successfully"
+  if ($ReturnAfterRollback) { return }
+  throw "Upgrade failed: $OriginalError. Rollback completed successfully."
+}
+
+function Restore-HflInterruptedUpgrade {
+  param(
+    [Parameter(Mandatory = $true)][string]$DataRoot,
+    [Parameter(Mandatory = $true)]$State,
+    [switch]$ForStart
+  )
+  $phase = [string]$State.phase
+  $script:UpgradeStatePath = Join-Path (Get-HflLifecycleRoot $DataRoot) "upgrade-state.json"
+  $script:UpgradePreviousVersion = [string]$State.previous_version
+  $script:UpgradeTargetVersion = [string]$State.target_version
+  $script:UpgradeLifecycleWasRunning = [bool]$State.lifecycle_was_running
+  $script:UpgradeStateSnapshotReady = [bool]$State.state_snapshot_ready
+  $script:UpgradeDeploymentStarted = [bool]$State.deployment_started
+  $script:UpgradeBinBackup = Join-Path (Get-HflBackupRoot $DataRoot) "rollback\bin"
+  switch ($phase) {
+    { $_ -in @("committed", "rolled_back") } {
+      Remove-UpgradeRollback -DataRoot $DataRoot
+      Clear-HflUpgradeState
+      return $false
+    }
+    { $_ -in @("preparing", "package_resolved") } {
+      Write-HflWarn "discarding incomplete pre-deployment upgrade state ($phase)"
+      Remove-Item -Recurse -Force -LiteralPath (Join-Path (Get-HflBackupRoot $DataRoot) "rollback") -ErrorAction SilentlyContinue
+      Clear-HflUpgradeState
+      return $false
+    }
+    "rollback_failed" {
+      throw "The previous upgrade and rollback both failed. Preserve backup\rollback and resolve the recorded failure before retrying."
+    }
+    "awaiting_restart" {
+      if ($ForStart) { return $true }
+      throw "A staged upgrade is awaiting restart and verification. Run install.cmd start before starting another upgrade."
+    }
+    { $_ -in @("stopping", "service_stopped", "snapshotting", "state_snapshotted") } {
+      Write-HflWarn "recovering interrupted upgrade before binary deployment ($phase)"
+	  if ($script:UpgradeLifecycleWasRunning -and -not $NoService) {
+	    try {
+	      Enable-HflLifecycleForRollbackStart
+	      Start-HflServiceOnly
+	    }
+	    finally { Restore-HflLifecycleStartupPolicy -DataRoot $DataRoot }
+	  }
+      if (-not (Test-HflLocalUpgradeHealth -DataRoot $DataRoot -ExpectedVersion $script:UpgradePreviousVersion -SkipLifecycle:(-not $script:UpgradeLifecycleWasRunning))) {
+        throw "Interrupted upgrade recovery could not verify the previous Agent."
+      }
+      Remove-UpgradeRollback -DataRoot $DataRoot
+      Clear-HflUpgradeState
+      return $false
+    }
+    { $_ -in @("starting_service", "service_started", "healthy") } {
+      if (Test-HflLocalUpgradeHealth -DataRoot $DataRoot -ExpectedVersion $script:UpgradeTargetVersion -SkipLifecycle:(-not $script:UpgradeLifecycleWasRunning)) {
+        Write-HflWarn "finalizing an interrupted upgrade after target health verification ($phase)"
+        Write-HflUpgradeState -DataRoot $DataRoot -Phase "committed"
+        Remove-UpgradeRollback -DataRoot $DataRoot
+        Clear-HflUpgradeState
+        return $false
+      }
+      Invoke-HflUpgradeRollback -DataRoot $DataRoot -PreviousVersion $script:UpgradePreviousVersion -OriginalError "upgrade process was interrupted during $phase" -ReturnAfterRollback
+      Clear-HflUpgradeState
+      return $false
+    }
+    { $_ -in @("deploying", "deployed", "migrating", "migrated", "configuring_service", "rolling_back") } {
+      Write-HflWarn "rolling back interrupted upgrade transaction ($phase)"
+      $script:UpgradeDeploymentStarted = $true
+      Invoke-HflUpgradeRollback -DataRoot $DataRoot -PreviousVersion $script:UpgradePreviousVersion -OriginalError "upgrade process was interrupted during $phase" -ReturnAfterRollback
+      Clear-HflUpgradeState
+      return $false
+    }
+    default {
+      throw "Unknown interrupted upgrade phase '$phase'; preserve backup\rollback for manual recovery."
+    }
+  }
 }
 
 function Remove-UpgradeRollback {
   param([Parameter(Mandatory = $true)][string]$DataRoot)
-	$rollback = Join-Path (Get-HflBackupRoot $DataRoot) "rollback"
+  $rollback = Join-Path (Get-HflBackupRoot $DataRoot) "rollback"
   if (Test-Path -LiteralPath $rollback) {
-    Remove-Item -Recurse -Force -LiteralPath $rollback
-    Write-HflOk "removed $rollback (upgrade succeeded; state snapshot retained)"
+    try {
+      Remove-Item -Recurse -Force -LiteralPath $rollback
+      Write-HflOk "removed $rollback after local health confirmation"
+    }
+    catch {
+      Write-HflWarn "local health verification passed, but rollback cleanup was deferred: $($_.Exception.Message)"
+    }
   }
+}
+
+function Test-HflLifecycleRunning {
+  if ($NoService) { return $false }
+  if ($InstallationMode -eq "system") {
+    $service = Get-Service -Name $ServiceName -ErrorAction SilentlyContinue
+    return ($null -ne $service -and $service.Status -eq "Running")
+  }
+  $task = Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
+  return ($null -ne $task -and $task.State -eq "Running")
 }
 
 function Merge-AgentEnv {
@@ -833,7 +1308,7 @@ function Update-AgentDb {
     Write-HflOk "agent.db schema upgraded (if needed)"
   }
   else {
-    Write-HflWarn "agent.db migration check failed (service start may retry)"
+    throw "agent.db migration check failed; the upgraded Agent was not started."
   }
 }
 
@@ -1174,6 +1649,17 @@ function Stop-AgentForUpgrade {
     Start-Sleep -Seconds 2
     Write-HflOk "stopped hfl-agent process (pre-upgrade)"
   }
+  $remaining = @(Get-Process -Name "hfl-agent" -ErrorAction SilentlyContinue | Where-Object {
+    try {
+      $_.Path -and (Get-FullPathOrSelf $_.Path).StartsWith((Get-FullPathOrSelf $AgentRoot).TrimEnd('\') + '\', [System.StringComparison]::OrdinalIgnoreCase)
+    }
+    catch { $false }
+  })
+  if ($remaining.Count -gt 0) { throw "hfl-agent process did not stop before upgrade" }
+  if ($InstallationMode -eq "system") {
+    $service = Get-Service -Name $ServiceName -ErrorAction SilentlyContinue
+    if ($null -ne $service -and $service.Status -ne "Stopped") { throw "Windows service did not stop before upgrade" }
+  }
 }
 
 function Remove-HflService {
@@ -1398,6 +1884,51 @@ function Start-HflServiceOnly {
 
 function Invoke-Start {
   Assert-HflInstalled
+  $dataRoot = Get-ResolvedDataRoot -Override ""
+  $statePath = Join-Path (Get-HflLifecycleRoot $dataRoot) "upgrade-state.json"
+  $pendingState = $null
+  if (Test-Path -LiteralPath $statePath) {
+    $pendingState = Get-Content -Raw -LiteralPath $statePath | ConvertFrom-Json
+  }
+  if ($null -ne $pendingState) {
+    Acquire-HflLifecycleLock -DataRoot $dataRoot -Operation "upgrade-verification"
+    try {
+      $stagedStart = Restore-HflInterruptedUpgrade -DataRoot $dataRoot -State $pendingState -ForStart
+      if ($stagedStart) {
+        if ([string]::IsNullOrWhiteSpace($script:UpgradeTargetVersion)) {
+          throw "Pending upgrade state is missing its target version ($statePath)."
+        }
+        $script:UpgradeDeploymentStarted = $true
+        $script:UpgradeStopAttempted = $true
+        $script:UpgradeTransactionActive = $true
+        Write-HflBanner "start staged upgrade"
+        Write-HflSection "Actions"
+        try {
+          Write-HflUpgradeState -DataRoot $dataRoot -Phase "starting_service"
+          Start-HflServiceOnly
+          Write-HflUpgradeState -DataRoot $dataRoot -Phase "service_started"
+          if (-not (Test-HflLocalUpgradeHealth -DataRoot $dataRoot -ExpectedVersion $script:UpgradeTargetVersion)) {
+            throw "the staged Agent failed local health verification"
+          }
+        }
+        catch {
+          Invoke-HflUpgradeRollback -DataRoot $dataRoot -PreviousVersion $script:UpgradePreviousVersion -OriginalError $_.Exception.Message
+        }
+        $script:UpgradeTransactionActive = $false
+        Write-HflUpgradeState -DataRoot $dataRoot -Phase "committed"
+        Remove-UpgradeRollback -DataRoot $dataRoot
+        Clear-HflUpgradeState
+        Write-HflSection "Summary"
+        Write-HflSummaryLine "Status" "upgrade committed"
+        Write-HflSummaryLine "Version" $script:UpgradeTargetVersion
+        Write-Host ""
+        return
+      }
+    }
+    finally { Release-HflLifecycleLock }
+  }
+  Acquire-HflLifecycleLock -DataRoot $dataRoot -Operation "start"
+  try {
   Write-HflBanner "start"
   Write-HflSection "Actions"
   Start-HflServiceOnly
@@ -1406,10 +1937,15 @@ function Invoke-Start {
   Write-Host ""
   Write-Host "Done."
   Write-Host ""
+  }
+  finally { Release-HflLifecycleLock }
 }
 
 function Invoke-Stop {
   Assert-HflInstalled
+  $dataRoot = Get-ResolvedDataRoot -Override ""
+  Acquire-HflLifecycleLock -DataRoot $dataRoot -Operation "stop"
+  try {
   Write-HflBanner "stop"
   Write-HflSection "Actions"
   Stop-HflService
@@ -1418,10 +1954,21 @@ function Invoke-Stop {
   Write-Host ""
   Write-Host "Done."
   Write-Host ""
+  }
+  finally { Release-HflLifecycleLock }
 }
 
 function Invoke-Restart {
   Assert-HflInstalled
+  $dataRoot = Get-ResolvedDataRoot -Override ""
+  $statePath = Join-Path (Get-HflLifecycleRoot $dataRoot) "upgrade-state.json"
+  if (Test-Path -LiteralPath $statePath) {
+    $state = Get-Content -Raw -LiteralPath $statePath | ConvertFrom-Json
+    Invoke-Start
+    return
+  }
+  Acquire-HflLifecycleLock -DataRoot $dataRoot -Operation "restart"
+  try {
   Write-HflBanner "restart"
   Write-HflSection "Actions"
   Stop-HflService
@@ -1431,6 +1978,8 @@ function Invoke-Restart {
   Write-Host ""
   Write-Host "Done."
   Write-Host ""
+  }
+  finally { Release-HflLifecycleLock }
 }
 
 function Deploy-AdminScripts {
@@ -1462,14 +2011,14 @@ endlocal & exit /b %EC%
   $srcUninstall = Join-Path $SrcRoot "uninstall.cmd"
   $destUninstall = Join-Path $InstallRoot "uninstall.cmd"
   if (Test-Path -LiteralPath $srcUninstall) {
-    Copy-Item -Force -Path $srcUninstall -Destination $destUninstall
+    Copy-HflFileAtomically -Source $srcUninstall -Destination $destUninstall
   }
   else {
     throw "Missing bundle uninstaller: $srcUninstall"
   }
   Write-HflOk "deployed $destUninstall"
   if (Test-Path -LiteralPath $srcManifest) {
-    Copy-Item -Force -Path $srcManifest -Destination $ManifestFile
+    Copy-HflFileAtomically -Source $srcManifest -Destination $ManifestFile
     Write-HflOk "deployed $ManifestFile"
   }
 }
@@ -1484,13 +2033,28 @@ function Register-DeferredFileMove {
     [Parameter(Mandatory = $true)][string]$Source,
     [Parameter(Mandatory = $true)][string]$Destination
   )
+  $sourceEscaped = $Source.Replace("'", "''")
+  $destinationEscaped = $Destination.Replace("'", "''")
   $cmd = @"
 Start-Sleep -Seconds 2
-Move-Item -LiteralPath '$Source' -Destination '$Destination' -Force
+Move-Item -LiteralPath '$sourceEscaped' -Destination '$destinationEscaped' -Force
 "@
   Start-Process -FilePath 'powershell.exe' `
     -ArgumentList @('-NoProfile', '-WindowStyle', 'Hidden', '-ExecutionPolicy', 'Bypass', '-Command', $cmd) `
     | Out-Null
+}
+
+function Copy-HflFileAtomically {
+  param(
+    [Parameter(Mandatory = $true)][string]$Source,
+    [Parameter(Mandatory = $true)][string]$Destination
+  )
+  $temporary = "$Destination.new.$([Guid]::NewGuid().ToString('N'))"
+  try {
+    Copy-Item -Force -LiteralPath $Source -Destination $temporary
+    Move-Item -Force -LiteralPath $temporary -Destination $Destination
+  }
+  finally { Remove-Item -Force -LiteralPath $temporary -ErrorAction SilentlyContinue }
 }
 
 function Deploy-InstallerFile {
@@ -1507,7 +2071,7 @@ function Deploy-InstallerFile {
     Write-HflOk "staged $Destination replacement (applied after upgrade exits)"
     return
   }
-  Copy-Item -Force -LiteralPath $Source -Destination $Destination
+  Copy-HflFileAtomically -Source $Source -Destination $Destination
   Write-HflOk "deployed $Destination"
 }
 
@@ -1538,19 +2102,27 @@ function Deploy-Binaries {
   $deployAgent = -not $KopiaOnly.IsPresent
   $deployKopia = -not $AgentOnly.IsPresent
   $ver = Get-BundleVersionFrom -Root $SrcRoot
+  # Stage the verified recovery-capable lifecycle script before replacing the
+  # executables. A process interruption during deployment then leaves an entry
+  # point that understands upgrade-state.json and can resume rollback.
+  Deploy-AdminScripts -SrcRoot $SrcRoot
   if ($deployAgent) {
-    Copy-Item -Force -Path $srcAgent -Destination (Join-Path $InstallRoot "hfl-agent.exe")
+    Copy-HflFileAtomically -Source $srcAgent -Destination (Join-Path $InstallRoot "hfl-agent.exe")
     Write-HflOk "deployed $(Join-Path $InstallRoot 'hfl-agent.exe') ($ver)"
-    Copy-Item -Force -Path $srcLauncher -Destination (Join-Path $InstallRoot "hfl-agent-user-launcher.exe")
+    Copy-HflFileAtomically -Source $srcLauncher -Destination (Join-Path $InstallRoot "hfl-agent-user-launcher.exe")
     Write-HflOk "deployed $(Join-Path $InstallRoot 'hfl-agent-user-launcher.exe')"
   }
   if ($deployKopia) {
-    Copy-Item -Force -Path $srcKopia -Destination (Join-Path $InstallRoot "kopia.exe")
+    Copy-HflFileAtomically -Source $srcKopia -Destination (Join-Path $InstallRoot "kopia.exe")
     Write-HflOk "deployed $(Join-Path $InstallRoot 'kopia.exe')"
   }
-  Set-Content -Path $InstalledVersionFile -Value $ver -Encoding UTF8
+  $versionTemp = "$InstalledVersionFile.new.$([Guid]::NewGuid().ToString('N'))"
+  try {
+    Set-Content -LiteralPath $versionTemp -Value $ver -Encoding UTF8
+    Move-Item -Force -LiteralPath $versionTemp -Destination $InstalledVersionFile
+  }
+  finally { Remove-Item -Force -LiteralPath $versionTemp -ErrorAction SilentlyContinue }
   Write-HflOk "wrote $InstalledVersionFile ($ver)"
-  Deploy-AdminScripts -SrcRoot $SrcRoot
 }
 
 function Set-HflEnvLine {
@@ -1757,6 +2329,12 @@ function Invoke-Upgrade {
   if (-not $From) {
     throw "upgrade requires -From <directory-or.zip>"
   }
+  if ($AgentOnly -or $KopiaOnly) {
+    throw "Transactional upgrade requires the complete Agent package; -AgentOnly and -KopiaOnly are not supported."
+  }
+  if ($NoService -and $NoRestart) {
+    throw "-NoRestart cannot be combined with -NoService because there is no managed lifecycle to complete deferred verification."
+  }
 
   $null = Get-HflSupportedArchitecture
   $dataRoot = if ($legacyUpgrade) { $DefaultDataRoot } else { Get-ResolvedDataRoot -Override $DataDir }
@@ -1773,14 +2351,43 @@ function Invoke-Upgrade {
   $upgradeSucceeded = $false
   Start-HflInstallLog -DataRoot $dataRoot
   try {
+    Acquire-HflLifecycleLock -DataRoot $dataRoot -Operation "upgrade"
+    $existingStatePath = Join-Path (Get-HflLifecycleRoot $dataRoot) "upgrade-state.json"
+    if (Test-Path -LiteralPath $existingStatePath) {
+      $existingState = Get-Content -Raw -LiteralPath $existingStatePath | ConvertFrom-Json
+      $null = Restore-HflInterruptedUpgrade -DataRoot $dataRoot -State $existingState
+      $prevVer = "unknown"
+      if (Test-Path -LiteralPath $InstalledVersionFile) {
+        $prevVer = (Get-Content -LiteralPath $InstalledVersionFile -Raw).Trim()
+      }
+    }
     if ($legacyUpgrade) {
       Invoke-LegacyMigration
     }
     $srcRoot = Resolve-UpgradeSource -Path $From -DataRoot $dataRoot
     $newVer = Get-BundleVersionFrom -Root $srcRoot
+	$script:UpgradeLifecycleWasRunning = $false
+	$script:UpgradeStateSnapshotReady = $false
+	$script:UpgradeDeploymentStarted = $false
+	$script:UpgradeStopAttempted = $false
+    $script:UpgradePreviousVersion = $prevVer
+    $script:UpgradeTargetVersion = $newVer
+    $script:UpgradeOperationStateCreated = $true
+    Write-HflUpgradeState -DataRoot $dataRoot -Phase "package_resolved"
+
+    $installedRole = Read-HflEnvValue -EnvFile $envFile -Key "HFL_NODE_ROLE"
+    $versionComparison = Compare-HflVersion -Left $newVer -Right $prevVer
+    if ($newVer -eq $prevVer -and $newVer -ne "unknown") {
+      Confirm-HflSameVersionUpgrade -Version $prevVer
+    }
+    elseif ($null -ne $versionComparison -and $versionComparison -lt 0 -and $prevVer -ne "unknown" -and $newVer -ne "unknown") {
+      throw "Downgrade is not supported ($newVer < $prevVer)."
+    }
+    $effectiveRole = if ($installedRole) { $installedRole } else { "agent" }
+    Verify-HflUpgradePackage -Root $srcRoot -RoleName $effectiveRole -Version $newVer
+    Update-HflLifecycleLockTarget -Version $newVer -Manifest (Join-Path $srcRoot "MANIFEST.json")
 
     if (-not $QuietFooter) {
-      $installedRole = Read-HflEnvValue -EnvFile $envFile -Key "HFL_NODE_ROLE"
       Write-HflBanner "upgrade $prevVer -> $newVer" -RoleName (Get-HflRoleDisplayName -Value $installedRole)
       Write-HflSection "Target"
       Write-HflSummaryLine "Current version" $prevVer
@@ -1793,40 +2400,82 @@ function Invoke-Upgrade {
       Write-HflSection "Upgrading Agent"
     }
 
-    Backup-RollbackBinaries -DataRoot $dataRoot
+    $script:UpgradeStateSnapshotReady = $false
+    $script:UpgradeDeploymentStarted = $false
+    $script:UpgradeStopAttempted = $false
+  $script:UpgradeLifecycleWasRunning = Test-HflLifecycleRunning
+  Backup-RollbackBinaries -DataRoot $dataRoot
+    $script:UpgradePreviousVersion = $prevVer
+    $script:UpgradeTargetVersion = $newVer
+    $script:UpgradeTransactionActive = $true
     try {
+      Write-HflUpgradeState -DataRoot $dataRoot -Phase "snapshotting"
+      Backup-AgentConfigAndDb -DataRoot $dataRoot -PreviousVersion $prevVer -SrcRoot $srcRoot
+      $script:UpgradeStateSnapshotReady = $true
+      Write-HflUpgradeState -DataRoot $dataRoot -Phase "state_snapshotted"
+      # Capture configuration and SQLite sidecar files before stopping the
+      # Agent. A stop failure must remain non-destructive, while a later
+      # deployment failure still has a complete rollback snapshot.
+      $script:UpgradeStopAttempted = $true
+      Write-HflUpgradeState -DataRoot $dataRoot -Phase "stopping"
       Stop-AgentForUpgrade
-      Backup-AgentConfigAndDb -DataRoot $dataRoot -PreviousVersion $prevVer
+      Write-HflUpgradeState -DataRoot $dataRoot -Phase "service_stopped"
+      $script:UpgradeDeploymentStarted = $true
+      Write-HflUpgradeState -DataRoot $dataRoot -Phase "deploying"
       Deploy-Binaries -SrcRoot $srcRoot
+      Write-HflUpgradeState -DataRoot $dataRoot -Phase "deployed"
       Merge-AgentEnv -EnvFile $envFile -DataRoot $dataRoot
+      Write-HflUpgradeState -DataRoot $dataRoot -Phase "migrating"
       Update-AgentDb -DataRoot $dataRoot
+      Write-HflUpgradeState -DataRoot $dataRoot -Phase "migrated"
 
       if (-not $NoService) {
-        Install-HflService -ExePath (Join-Path $InstallRoot "hfl-agent.exe") -DataRoot $dataRoot -NoStart:$NoRestart
+        Write-HflUpgradeState -DataRoot $dataRoot -Phase "configuring_service"
+        if (-not $NoRestart -and $script:UpgradeLifecycleWasRunning) {
+          Write-HflUpgradeState -DataRoot $dataRoot -Phase "starting_service"
+        }
+        Install-HflService `
+          -ExePath (Join-Path $InstallRoot "hfl-agent.exe") `
+          -DataRoot $dataRoot `
+          -NoStart:($NoRestart -or -not $script:UpgradeLifecycleWasRunning)
+        # Re-registering uses the product defaults. Preserve the pre-upgrade
+        # policy so a manually started disabled Agent does not become automatic.
+        Restore-HflLifecycleStartupPolicy -DataRoot $dataRoot
       }
+
+      if (-not $NoRestart -and -not (Test-HflLocalUpgradeHealth -DataRoot $dataRoot -ExpectedVersion $newVer -SkipLifecycle:(-not $script:UpgradeLifecycleWasRunning))) {
+        throw "new Agent failed local health verification after upgrade"
+      }
+      if (-not $NoRestart) { Write-HflUpgradeState -DataRoot $dataRoot -Phase "healthy" }
     }
     catch {
-      Write-HflWarn "upgrade failed: $($_.Exception.Message); attempting rollback"
-      Restore-RollbackBinaries
-      if (-not $NoService -and -not $legacyUpgrade) {
-        try {
-          Start-HflServiceOnly
-        }
-        catch { }
-      }
-      throw
+      $originalError = $_.Exception.Message
+      Invoke-HflUpgradeRollback -DataRoot $dataRoot -PreviousVersion $prevVer -OriginalError $originalError -LegacyUpgrade:$legacyUpgrade
     }
 
-    Remove-UpgradeRollback -DataRoot $dataRoot
+    $script:UpgradeTransactionActive = $false
+    if ($NoRestart) {
+      Write-HflUpgradeState -DataRoot $dataRoot -Phase "awaiting_restart"
+    } else {
+      Write-HflUpgradeState -DataRoot $dataRoot -Phase "committed"
+      Remove-UpgradeRollback -DataRoot $dataRoot
+      Clear-HflUpgradeState
+    }
     $upgradeSucceeded = $true
   }
   catch {
     Restore-LegacyServiceOnFailure
     Write-HflLog -Level 'FAIL ' -Message "Upgrade failed: $($_.Exception.Message)"
+    if ($script:UpgradeOperationStateCreated -and -not $script:UpgradeStopAttempted) {
+      Clear-HflUpgradeState
+      Remove-UpgradeRollback -DataRoot $dataRoot
+    }
     throw
   }
   finally {
-    Remove-UpgradeWorkspace -Workspace $workspace
+    try { Remove-UpgradeWorkspace -Workspace $workspace }
+    catch { Write-HflWarn "upgrade workspace cleanup was deferred: $($_.Exception.Message)" }
+    finally { Release-HflLifecycleLock }
     if (-not $upgradeSucceeded) {
       Stop-HflInstallLog -ExitCode 1
     }
@@ -1844,11 +2493,15 @@ function Invoke-Upgrade {
     Complete-LegacyMigration
   }
   Write-HflSection "Verifying"
-  if (-not $NoService) {
+  if ($NoRestart) {
+    Write-HflSkip "Agent restart and local health verification are pending by request"
+    Write-HflWarn "Rollback data is retained until the staged upgrade is started and verified."
+  }
+  elseif (-not $NoService) {
     Write-HflOk "Agent managed startup is $(Get-HflServiceStatusLine)"
   }
   Write-HflSection "Upgrade summary"
-  Write-HflSummaryLine "Status" "upgraded"
+  Write-HflSummaryLine "Status" ($(if ($NoRestart) { "staged (verification pending)" } else { "upgraded" }))
   Write-HflSummaryLine "Version" (Get-BundleVersionFrom -Root $InstallRoot)
   if (-not $NoService) {
     Write-HflSummaryLine "Lifecycle" "$ServiceName ($(Get-HflServiceStatusLine))"
@@ -1872,6 +2525,7 @@ function Invoke-Uninstall {
   }
   Start-HflUninstallLog -DataRoot $dataRoot
   try {
+  Acquire-HflLifecycleLock -DataRoot $dataRoot -Operation "uninstall"
 
   Write-HflBanner "uninstall" -RoleName $displayRole
   Write-HflSection "Target"
@@ -1962,9 +2616,11 @@ function Invoke-Uninstall {
   Write-HflSummaryLine "Status" "uninstalled"
   Write-HflSummaryLine "Console record" "not changed by local uninstall"
   Write-HflFooter -Outcome uninstall
+  Release-HflLifecycleLock
   Stop-HflUninstallLog -ExitCode 0
   }
   catch {
+    Release-HflLifecycleLock
     Write-HflLog -Level 'FAIL ' -Message "Uninstallation failed: $($_.Exception.Message)"
     Stop-HflUninstallLog -ExitCode 1
     throw

--- a/src/agent/packaging/install/install.sh
+++ b/src/agent/packaging/install/install.sh
@@ -5,7 +5,7 @@
 # After install, lifecycle scripts are copied into the selected installation
 # directory for local upgrade, status, and uninstall operations.
 
-set -euo pipefail
+set -Eeuo pipefail
 
 BUNDLE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 INSTALLATION_MODE="${HFL_INSTALLATION_MODE:-}"
@@ -205,8 +205,19 @@ HFL_DETAIL_LOG_PID=""
 HFL_FAILURE_REPORTED=0
 HFL_FAILURE_MARKER=""
 HFL_LOG_FINALIZING=0
+HFL_LIFECYCLE_LOCK_DIR=""
+UPGRADE_STATE_FILE=""
 UPGRADE_FROM=""
 UPGRADE_YES=0
+UPGRADE_TRANSACTION_ACTIVE=0
+UPGRADE_PREVIOUS_VERSION="unknown"
+UPGRADE_TARGET_VERSION="unknown"
+UPGRADE_STATE_SNAPSHOT_READY=0
+UPGRADE_DEPLOYMENT_STARTED=0
+UPGRADE_STOP_ATTEMPTED=0
+UPGRADE_SERVICE_WAS_ACTIVE=0
+UPGRADE_SERVICE_WAS_ENABLED=0
+UPGRADE_CURRENT_PHASE="preparing"
 
 # Preserve the caller's terminal while command stdout/stderr is mirrored to a
 # timestamped detail log during install, upgrade, and uninstall operations.
@@ -553,9 +564,19 @@ launchd_service_status_line() {
 
 stop_launchd_service() {
 	if launchctl print "${LAUNCHD_DOMAIN}/${LAUNCHD_LABEL}" >/dev/null 2>&1; then
-		launchctl bootout "${LAUNCHD_DOMAIN}/${LAUNCHD_LABEL}" 2>/dev/null \
-			|| launchctl bootout "${LAUNCHD_DOMAIN}" "${LAUNCHD_PLIST}" 2>/dev/null \
-			|| true
+		if ! launchctl bootout "${LAUNCHD_DOMAIN}/${LAUNCHD_LABEL}" 2>/dev/null \
+			&& ! launchctl bootout "${LAUNCHD_DOMAIN}" "${LAUNCHD_PLIST}" 2>/dev/null; then
+			if [[ "${UPGRADE_TRANSACTION_ACTIVE}" -eq 1 ]]; then
+				log_fail "launchd service ${LAUNCHD_LABEL} could not be stopped; upgrade was aborted before deployment." 2
+			fi
+			log_warn "launchd service ${LAUNCHD_LABEL} could not be stopped"
+		fi
+		if launchctl print "${LAUNCHD_DOMAIN}/${LAUNCHD_LABEL}" >/dev/null 2>&1; then
+			if [[ "${UPGRADE_TRANSACTION_ACTIVE}" -eq 1 ]]; then
+				log_fail "launchd service ${LAUNCHD_LABEL} is still loaded; upgrade was aborted before deployment." 2
+			fi
+			log_warn "launchd service ${LAUNCHD_LABEL} is still loaded"
+		fi
 		log_ok "stopped launchd service ${LAUNCHD_LABEL}"
 	else
 		log_skip "stop launchd ${LAUNCHD_LABEL} (not loaded)"
@@ -690,7 +711,190 @@ log_fail() {
 		: >"${HFL_FAILURE_MARKER}" 2>/dev/null || true
 	fi
 	_hfl_emit_raw "FAIL " "${message}"
+	if [[ "${UPGRADE_TRANSACTION_ACTIVE}" -eq 1 ]]; then
+		upgrade_rollback_on_error "${code}"
+	fi
 	exit "${code}"
+}
+
+process_start_marker() {
+	local pid="$1" marker=""
+	if [[ -r "/proc/${pid}/stat" ]]; then
+		# Linux procfs exposes a monotonic start-time tick count. Strip the
+		# command name first because it may contain spaces in parentheses.
+		marker="$(sed 's/^[^)]*) //' "/proc/${pid}/stat" 2>/dev/null | awk '{print $20}' || true)"
+	fi
+	if [[ -z "${marker}" ]] && command -v ps >/dev/null 2>&1; then
+		marker="$(LC_ALL=C ps -p "${pid}" -o lstart= 2>/dev/null | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' || true)"
+	fi
+	printf '%s' "${marker}"
+}
+
+acquire_lifecycle_lock() {
+	local data_dir="$1" operation="$2" lock_dir="$(agent_lifecycle_dir "${data_dir}")/install.lock" pid_file
+	local owner_pid="" recorded_start="" actual_start="" attempt
+	mkdir -p "$(agent_lifecycle_dir "${data_dir}")"
+	if ! mkdir "${lock_dir}" 2>/dev/null; then
+		pid_file="${lock_dir}/pid"
+		# mkdir is the atomic ownership step, but the owner needs a moment to
+		# persist its metadata. Do not erase a newly created lock in that window.
+		for attempt in 1 2 3 4 5; do
+			[[ -r "${pid_file}" ]] && break
+			sleep 0.1
+		done
+		owner_pid="$(cat "${pid_file}" 2>/dev/null || true)"
+		if [[ "${owner_pid}" =~ ^[0-9]+$ ]] && kill -0 "${owner_pid}" 2>/dev/null; then
+			recorded_start="$(cat "${lock_dir}/process_started_at" 2>/dev/null || true)"
+			actual_start="$(process_start_marker "${owner_pid}")"
+			# Locks created without an owner-start marker are treated
+			# conservatively. For current locks, a mismatched marker proves that
+			# the PID was reused after the lifecycle owner exited.
+			if [[ -z "${recorded_start}" || -z "${actual_start}" || "${recorded_start}" == "${actual_start}" ]]; then
+				log_fail "Another Agent lifecycle operation is already running (operation lock: ${lock_dir})." 2
+			fi
+		fi
+		rm -rf "${lock_dir}"
+		mkdir "${lock_dir}" || log_fail "Unable to acquire Agent lifecycle operation lock ${lock_dir}." 2
+	fi
+	HFL_LIFECYCLE_LOCK_DIR="${lock_dir}"
+	if ! {
+		process_start_marker "$$" >"${lock_dir}/process_started_at" \
+			&& printf '%s\n' "${operation}" >"${lock_dir}/operation" \
+			&& printf '%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >"${lock_dir}/started_at" \
+			&& printf '%s\n' "unknown" >"${lock_dir}/target_version" \
+			&& printf '%s\n' "unknown" >"${lock_dir}/target_commit" \
+			&& printf '%s\n' "$$" >"${lock_dir}/pid"
+	}; then
+		rm -rf "${lock_dir}" 2>/dev/null || true
+		HFL_LIFECYCLE_LOCK_DIR=""
+		log_fail "Unable to persist Agent lifecycle operation lock metadata (${lock_dir})." 2
+	fi
+}
+
+update_lifecycle_lock_target() {
+	local version="$1" manifest="${2:-${MANIFEST_FILE}}" commit="unknown"
+	[[ -n "${HFL_LIFECYCLE_LOCK_DIR}" && -d "${HFL_LIFECYCLE_LOCK_DIR}" ]] || return 0
+	if [[ -f "${manifest}" ]]; then
+		commit="$(grep -E '"agent_commit"[[:space:]]*:' "${manifest}" | head -n1 | sed -n 's/.*"agent_commit"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')"
+		[[ -n "${commit}" ]] || commit="unknown"
+	fi
+	printf '%s\n' "${version}" >"${HFL_LIFECYCLE_LOCK_DIR}/target_version"
+	printf '%s\n' "${commit}" >"${HFL_LIFECYCLE_LOCK_DIR}/target_commit"
+}
+
+release_lifecycle_lock() {
+	if [[ -n "${HFL_LIFECYCLE_LOCK_DIR}" ]]; then
+		rm -rf "${HFL_LIFECYCLE_LOCK_DIR}" 2>/dev/null || true
+		HFL_LIFECYCLE_LOCK_DIR=""
+	fi
+}
+
+write_upgrade_state() {
+	local data_dir="$1" phase="$2" file="$(agent_lifecycle_dir "${data_dir}")/upgrade-state.json" temporary
+	mkdir -p "$(dirname "${file}")"
+	UPGRADE_STATE_FILE="${file}"
+	UPGRADE_CURRENT_PHASE="${phase}"
+	temporary="${file}.tmp.$$"
+	cat >"${temporary}" <<EOF
+{"phase":"${phase}","operation":"upgrade","pid":$$,"previous_version":"${UPGRADE_PREVIOUS_VERSION}","target_version":"${UPGRADE_TARGET_VERSION}","installation_mode":"${INSTALLATION_MODE}","lifecycle_was_running":${UPGRADE_SERVICE_WAS_ACTIVE},"lifecycle_was_enabled":${UPGRADE_SERVICE_WAS_ENABLED},"state_snapshot_ready":${UPGRADE_STATE_SNAPSHOT_READY},"deployment_started":${UPGRADE_DEPLOYMENT_STARTED},"updated_at":"$(date -u +%Y-%m-%dT%H:%M:%SZ)"}
+EOF
+	mv -f "${temporary}" "${file}"
+}
+
+clear_upgrade_state() {
+	[[ -n "${UPGRADE_STATE_FILE}" ]] && rm -f "${UPGRADE_STATE_FILE}" 2>/dev/null || true
+}
+
+upgrade_state_value() {
+	local file="$1" key="$2"
+	sed -n "s/.*\"${key}\":\"\([^\"]*\)\".*/\1/p" "${file}" 2>/dev/null | head -n1
+}
+
+upgrade_state_flag() {
+	local file="$1" key="$2" value
+	value="$(sed -n "s/.*\"${key}\":\([01]\).*/\1/p" "${file}" 2>/dev/null | head -n1)"
+	[[ "${value}" == "1" ]] && printf '1' || printf '0'
+}
+
+load_upgrade_state() {
+	local data_dir="$1" file="$(agent_lifecycle_dir "${data_dir}")/upgrade-state.json"
+	UPGRADE_STATE_FILE="${file}"
+	UPGRADE_CURRENT_PHASE="$(upgrade_state_value "${file}" phase || true)"
+	UPGRADE_PREVIOUS_VERSION="$(upgrade_state_value "${file}" previous_version || true)"
+	UPGRADE_TARGET_VERSION="$(upgrade_state_value "${file}" target_version || true)"
+	UPGRADE_SERVICE_WAS_ACTIVE="$(upgrade_state_flag "${file}" lifecycle_was_running)"
+	UPGRADE_SERVICE_WAS_ENABLED="$(upgrade_state_flag "${file}" lifecycle_was_enabled)"
+	UPGRADE_STATE_SNAPSHOT_READY="$(upgrade_state_flag "${file}" state_snapshot_ready)"
+	UPGRADE_DEPLOYMENT_STARTED="$(upgrade_state_flag "${file}" deployment_started)"
+	UPGRADE_BIN_BACKUP="$(agent_backup_dir "${data_dir}")/rollback/bin"
+}
+
+recover_interrupted_upgrade() {
+	local data_dir="$1" intent="${2:-upgrade}" phase state_file
+	state_file="$(agent_lifecycle_dir "${data_dir}")/upgrade-state.json"
+	load_upgrade_state "${data_dir}"
+	phase="${UPGRADE_CURRENT_PHASE}"
+	if [[ -z "${phase}" ]]; then
+		[[ -f "${state_file}" ]] || return 0
+		log_fail "The pending upgrade state is unreadable (${state_file}); rollback data was preserved for recovery." 70
+	fi
+	case "${phase}" in
+	committed|rolled_back)
+		cleanup_upgrade_rollback "${data_dir}"
+		clear_upgrade_state
+		return 0
+		;;
+	preparing|package_resolved)
+		log_warn "discarding incomplete pre-deployment upgrade state (${phase})"
+		rm -rf "$(agent_backup_dir "${data_dir}")/rollback" 2>/dev/null || true
+		clear_upgrade_state
+		return 0
+		;;
+	rollback_failed)
+		log_fail "The previous upgrade and rollback both failed. Preserve $(agent_backup_dir "${data_dir}")/rollback and resolve the recorded failure before retrying." 2
+		;;
+	awaiting_restart)
+		[[ "${intent}" == "start" ]] && return 2
+		log_fail "A staged upgrade is awaiting restart and verification. Run ${INSTALL_DIR}/install.sh start before starting another upgrade." 2
+		;;
+	stopping|service_stopped|snapshotting|state_snapshotted)
+		log_warn "recovering interrupted upgrade before binary deployment (${phase})"
+		if [[ "${UPGRADE_SERVICE_WAS_ACTIVE}" -eq 1 ]] && agent_manages_service; then
+			(start_service_only) || log_fail "Interrupted upgrade recovery could not restart the previous Agent service." 70
+		fi
+		upgrade_health_check "${data_dir}" "${UPGRADE_PREVIOUS_VERSION}" "${UPGRADE_SERVICE_WAS_ACTIVE}" \
+			|| log_fail "Interrupted upgrade recovery could not verify the previous Agent." 70
+		cleanup_upgrade_rollback "${data_dir}"
+		clear_upgrade_state
+		return 0
+		;;
+	starting_service|service_started|healthy)
+		if upgrade_health_check "${data_dir}" "${UPGRADE_TARGET_VERSION}" "${UPGRADE_SERVICE_WAS_ACTIVE}"; then
+			log_warn "finalizing an interrupted upgrade after target health verification (${phase})"
+			write_upgrade_state "${data_dir}" "committed"
+			cleanup_upgrade_rollback "${data_dir}"
+			clear_upgrade_state
+			return 0
+		fi
+		log_warn "rolling back interrupted upgrade transaction (${phase})"
+		UPGRADE_STOP_ATTEMPTED=1
+		UPGRADE_DEPLOYMENT_STARTED=1
+		if upgrade_rollback_on_error 0; then :; fi
+		clear_upgrade_state
+		return 0
+		;;
+	deploying|deployed|migrating|migrated|configuring_service|rolling_back)
+		log_warn "rolling back interrupted upgrade transaction (${phase})"
+		UPGRADE_STOP_ATTEMPTED=1
+		UPGRADE_DEPLOYMENT_STARTED=1
+		if upgrade_rollback_on_error 0; then :; fi
+		clear_upgrade_state
+		return 0
+		;;
+	*)
+		log_fail "Unknown interrupted upgrade phase ${phase}; preserve $(agent_backup_dir "${data_dir}")/rollback for manual recovery." 70
+		;;
+	esac
 }
 
 hfl_detail_log_stream() {
@@ -896,12 +1100,17 @@ hfl_print_install_success() {
 hfl_print_upgrade_success() {
 	local version="$1" service="$2" data_dir="$3"
 	hfl_print_section "Verifying"
-	if [[ "${service}" == "not restarted" ]]; then
+	if [[ "${service}" == not\ restarted* ]]; then
 		log_skip "Agent service was not restarted by request."
+		log_warn "Local health verification is pending; rollback data was retained."
 	else
 		log_ok "Agent service is ${service}."
 	fi
-	hfl_print_result "Upgrade completed successfully"
+	if [[ "${service}" == not\ restarted* ]]; then
+		hfl_print_result "Upgrade staged; restart and verification are pending"
+	else
+		hfl_print_result "Upgrade completed successfully"
+	fi
 	hfl_print_section "Upgrade summary"
 	hfl_print_value "Agent version" "${version}"
 	hfl_print_value "Service state" "${service}"
@@ -974,6 +1183,22 @@ assert_agent_package_root() {
 	fi
 }
 
+verify_upgrade_package() {
+	local root="$1" role="$2" version="$3" target_verifier="${root}/bin/hfl-agent" verifier output
+	[[ -x "${target_verifier}" ]] || log_fail "Upgrade package verifier is missing: ${target_verifier}." 2
+	verifier="${target_verifier}"
+	if [[ -x "${INSTALL_DIR}/hfl-agent" ]] \
+		&& "${INSTALL_DIR}/hfl-agent" help 2>/dev/null | grep -q 'package verify'; then
+		# Prefer the trusted currently installed Agent after the first release that
+		# includes this command. The target binary bridges upgrades from older builds.
+		verifier="${INSTALL_DIR}/hfl-agent"
+	fi
+	if ! output="$("${verifier}" package verify --root "${root}" --role "${role:-agent}" --version "${version}" 2>&1)"; then
+		log_fail "Upgrade package validation failed; the current Agent was not stopped${output:+: ${output}}." 2
+	fi
+	log_ok "upgrade package manifest and checksums verified"
+}
+
 upgrade_workspace_dir() {
 	local data_dir="$1"
 	echo "$(agent_runtime_dir "${data_dir}")/workspace"
@@ -982,8 +1207,11 @@ upgrade_workspace_dir() {
 cleanup_upgrade_workspace() {
 	local ws="$1"
 	if [[ -d "${ws}" ]]; then
-		rm -rf "${ws}"
-		log_ok "removed ${ws}"
+		if rm -rf "${ws}"; then
+			log_ok "removed ${ws}"
+		else
+			log_warn "upgrade workspace cleanup was deferred (${ws})"
+		fi
 	fi
 }
 
@@ -1020,23 +1248,51 @@ prepare_upgrade_source() {
 backup_agent_config_and_db() {
 	local data_dir="$1"
 	local prev_ver="${2:-unknown}"
+	local src_root="$3"
 	local state_dir="$(agent_backup_dir "${data_dir}")/rollback"
 	local archive="${state_dir}/latest.tar.gz"
 	local meta="${state_dir}/meta.json"
-	local -a items=()
+	local snapshot temporary db_source verifier backup_ok=1
 	mkdir -p "${state_dir}"
-	[[ -f "$(agent_config_dir "${data_dir}")/agent.env" ]] && items+=("config/agent.env")
-	[[ -f "$(agent_data_store_dir "${data_dir}")/agent.db" ]] && items+=("data/agent.db")
-	if ((${#items[@]} == 0)); then
-		log_skip "backup agent.env/agent.db (nothing to back up)"
-		return 0
+	snapshot="$(mktemp -d "${state_dir}/snapshot.XXXXXX")" \
+		|| log_fail "Upgrade state snapshot workspace could not be created." 2
+	mkdir -p "${snapshot}/config" "${snapshot}/data" || backup_ok=0
+	[[ ! -f "$(agent_config_dir "${data_dir}")/agent.env" ]] \
+		|| cp -p "$(agent_config_dir "${data_dir}")/agent.env" "${snapshot}/config/agent.env" \
+		|| backup_ok=0
+	[[ ! -f "$(agent_config_json "${data_dir}")" ]] \
+		|| cp -p "$(agent_config_json "${data_dir}")" "${snapshot}/config/config.json" \
+		|| backup_ok=0
+	db_source="$(agent_data_store_dir "${data_dir}")/agent.db"
+	verifier="${src_root}/bin/hfl-agent"
+	if [[ -f "${db_source}" ]]; then
+		"${verifier}" database backup --source "${db_source}" --destination "${snapshot}/data/agent.db" \
+			|| backup_ok=0
+		[[ ! -f "${snapshot}/data/agent.db" ]] || chmod 600 "${snapshot}/data/agent.db" || backup_ok=0
 	fi
-	tar -czf "${archive}" -C "${data_dir}" "${items[@]}"
-	log_ok "backed up agent.env/agent.db -> ${archive}"
+	if [[ ! -f "${snapshot}/config/agent.env" && ! -f "${snapshot}/data/agent.db" ]]; then
+		backup_ok=0
+	fi
+	if [[ "${backup_ok}" -ne 1 ]]; then
+		rm -rf "${snapshot}" 2>/dev/null || true
+		log_fail "Upgrade state snapshot could not be created or verified; the current Agent was not stopped." 2
+	fi
+	temporary="${state_dir}/state.tar.gz.tmp"
+	rm -f "${temporary}"
+	if ! tar -czf "${temporary}" -C "${snapshot}" .; then
+		rm -rf "${snapshot}" "${temporary}" 2>/dev/null || true
+		log_fail "Upgrade state snapshot archive could not be created." 2
+	fi
+	rm -rf "${snapshot}"
+	mv -f "${temporary}" "${archive}"
+	chmod 600 "${archive}"
+	log_ok "backed up Agent configuration and consistent SQLite state -> ${archive}"
 	cat >"${meta}" <<EOF
 {
   "created_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
   "previous_version": "${prev_ver}",
+  "installation_mode": "${INSTALLATION_MODE}",
+  "service_name": "$(service_display_name)",
   "state_archive": "backup/rollback/latest.tar.gz"
 }
 EOF
@@ -1045,8 +1301,6 @@ EOF
 
 UPGRADE_MIN_FREE_MB="${HFL_UPGRADE_MIN_FREE_MB:-512}"
 UPGRADE_BIN_BACKUP=""
-UPGRADE_SERVICE_STOPPED=0
-
 upgrade_preflight() {
 	local data_dir="$1"
 	local free_mb
@@ -1071,34 +1325,212 @@ backup_upgrade_binaries() {
 	UPGRADE_BIN_BACKUP="$(agent_backup_dir "${data_dir}")/rollback/bin"
 	rm -rf "$(agent_backup_dir "${data_dir}")/rollback"
 	mkdir -p "${UPGRADE_BIN_BACKUP}"
-	[[ -f "${INSTALL_DIR}/hfl-agent" ]] && cp -a "${INSTALL_DIR}/hfl-agent" "${UPGRADE_BIN_BACKUP}/"
-	[[ -f "${INSTALL_DIR}/kopia" ]] && cp -a "${INSTALL_DIR}/kopia" "${UPGRADE_BIN_BACKUP}/"
+	local entry
+	for entry in hfl-agent kopia install.sh run-agent.sh; do
+		[[ -e "${INSTALL_DIR}/${entry}" ]] && cp -a "${INSTALL_DIR}/${entry}" "${UPGRADE_BIN_BACKUP}/"
+	done
 	[[ -f "${MANIFEST_FILE}" ]] && cp -a "${MANIFEST_FILE}" "${UPGRADE_BIN_BACKUP}/"
 	[[ -f "${INSTALLED_VERSION_FILE}" ]] && cp -a "${INSTALLED_VERSION_FILE}" "${UPGRADE_BIN_BACKUP}/"
 	[[ -d "${INSTALL_DIR}/libexec" ]] && cp -a "${INSTALL_DIR}/libexec" "${UPGRADE_BIN_BACKUP}/"
+	backup_upgrade_service_definition "${data_dir}"
 	log_ok "backed up binaries -> ${UPGRADE_BIN_BACKUP}"
+}
+
+backup_upgrade_service_definition() {
+	local data_dir="$1" service_dir="$(agent_backup_dir "${data_dir}")/rollback/service"
+	mkdir -p "${service_dir}"
+	if agent_uses_launchd; then
+		if [[ -f "${LAUNCHD_PLIST}" ]]; then
+			cp -a "${LAUNCHD_PLIST}" "${service_dir}/launchd.plist"
+		else
+			: >"${service_dir}/launchd.plist.absent"
+		fi
+	else
+		if [[ -f "${UNIT_DST}" ]]; then
+			cp -a "${UNIT_DST}" "${service_dir}/hyperfilelens-agent.service"
+		else
+			: >"${service_dir}/hyperfilelens-agent.service.absent"
+		fi
+		if [[ -f "${GATEWAY_RESOURCE_DROPIN}" ]]; then
+			cp -a "${GATEWAY_RESOURCE_DROPIN}" "${service_dir}/20-gateway-resources.conf"
+		else
+			: >"${service_dir}/20-gateway-resources.conf.absent"
+		fi
+	fi
 }
 
 restore_upgrade_binaries() {
 	[[ -n "${UPGRADE_BIN_BACKUP}" && -d "${UPGRADE_BIN_BACKUP}" ]] || return 0
-	[[ -f "${UPGRADE_BIN_BACKUP}/hfl-agent" ]] && cp -a "${UPGRADE_BIN_BACKUP}/hfl-agent" "${INSTALL_DIR}/"
-	[[ -f "${UPGRADE_BIN_BACKUP}/kopia" ]] && cp -a "${UPGRADE_BIN_BACKUP}/kopia" "${INSTALL_DIR}/"
-	[[ -f "${UPGRADE_BIN_BACKUP}/MANIFEST.json" ]] && cp -a "${UPGRADE_BIN_BACKUP}/MANIFEST.json" "${MANIFEST_FILE}"
-	[[ -f "${UPGRADE_BIN_BACKUP}/INSTALLED_VERSION" ]] && cp -a "${UPGRADE_BIN_BACKUP}/INSTALLED_VERSION" "${INSTALLED_VERSION_FILE}"
-	rm -rf "${INSTALL_DIR}/libexec"
+	local entry
+	for entry in hfl-agent kopia install.sh run-agent.sh; do
+		if [[ -e "${UPGRADE_BIN_BACKUP}/${entry}" ]]; then
+			copy_file_atomically "${UPGRADE_BIN_BACKUP}/${entry}" "${INSTALL_DIR}/${entry}" || return 1
+		else
+			rm -f "${INSTALL_DIR}/${entry}" || return 1
+		fi
+	done
+	if [[ -f "${UPGRADE_BIN_BACKUP}/MANIFEST.json" ]]; then
+		copy_file_atomically "${UPGRADE_BIN_BACKUP}/MANIFEST.json" "${MANIFEST_FILE}" || return 1
+	fi
+	if [[ -f "${UPGRADE_BIN_BACKUP}/INSTALLED_VERSION" ]]; then
+		copy_file_atomically "${UPGRADE_BIN_BACKUP}/INSTALLED_VERSION" "${INSTALLED_VERSION_FILE}" || return 1
+	fi
+	rm -rf "${INSTALL_DIR}/libexec" || return 1
 	if [[ -d "${UPGRADE_BIN_BACKUP}/libexec" ]]; then
-		cp -a "${UPGRADE_BIN_BACKUP}/libexec" "${INSTALL_DIR}/"
+		cp -a "${UPGRADE_BIN_BACKUP}/libexec" "${INSTALL_DIR}/" || return 1
 	fi
 	log_warn "restored binaries from ${UPGRADE_BIN_BACKUP}"
 }
 
+copy_file_atomically() {
+	local source="$1" destination="$2" temporary="${destination}.rollback.$$"
+	rm -f "${temporary}"
+	if ! cp -a "${source}" "${temporary}"; then
+		rm -f "${temporary}" 2>/dev/null || true
+		return 1
+	fi
+	if ! mv -f "${temporary}" "${destination}"; then
+		rm -f "${temporary}" 2>/dev/null || true
+		return 1
+	fi
+}
+
+restore_upgrade_state() {
+	local data_dir="$1" rollback="$(agent_backup_dir "${data_dir}")/rollback"
+	local archive="${rollback}/latest.tar.gz" staging="${rollback}/restore.$$" relative destination
+	[[ -f "${archive}" ]] || return 1
+	rm -rf "${staging}" || return 1
+	mkdir -p "${staging}" || return 1
+	if ! tar -xzf "${archive}" -C "${staging}"; then
+		rm -rf "${staging}" 2>/dev/null || true
+		return 1
+	fi
+	if [[ ! -f "${staging}/config/agent.env" && ! -f "${staging}/data/agent.db" ]]; then
+		rm -rf "${staging}" 2>/dev/null || true
+		return 1
+	fi
+	for relative in config/agent.env config/config.json data/agent.db; do
+		destination="${data_dir}/${relative}"
+		if [[ -f "${staging}/${relative}" ]]; then
+			copy_file_atomically "${staging}/${relative}" "${destination}" || {
+				rm -rf "${staging}" 2>/dev/null || true
+				return 1
+			}
+		else
+			rm -f "${destination}" || return 1
+		fi
+	done
+	# The online SQLite backup is a complete standalone database. Remove any
+	# sidecars from the failed target before the restored Agent opens it.
+	rm -f "$(agent_data_store_dir "${data_dir}")/agent.db-wal" \
+		"$(agent_data_store_dir "${data_dir}")/agent.db-shm" || return 1
+	rm -rf "${staging}"
+	log_warn "restored Agent configuration and database state from ${archive}"
+}
+
+restore_upgrade_service_definition() {
+	local data_dir="$1" service_dir="$(agent_backup_dir "${data_dir}")/rollback/service"
+	if agent_uses_launchd; then
+		stop_launchd_service || true
+		rm -f "${LAUNCHD_PLIST}" || return 1
+		if [[ -f "${service_dir}/launchd.plist" ]]; then
+			mkdir -p "$(dirname "${LAUNCHD_PLIST}")" || return 1
+			cp -a "${service_dir}/launchd.plist" "${LAUNCHD_PLIST}" || return 1
+		fi
+	else
+		hfl_systemctl stop hyperfilelens-agent.service 2>/dev/null || true
+		rm -f "${UNIT_DST}" "${GATEWAY_RESOURCE_DROPIN}" || return 1
+		if [[ -f "${service_dir}/hyperfilelens-agent.service" ]]; then
+			mkdir -p "$(dirname "${UNIT_DST}")" || return 1
+			cp -a "${service_dir}/hyperfilelens-agent.service" "${UNIT_DST}" || return 1
+		fi
+		if [[ -f "${service_dir}/20-gateway-resources.conf" ]]; then
+			mkdir -p "$(dirname "${GATEWAY_RESOURCE_DROPIN}")" || return 1
+			cp -a "${service_dir}/20-gateway-resources.conf" "${GATEWAY_RESOURCE_DROPIN}" || return 1
+		fi
+		hfl_systemctl daemon-reload 2>/dev/null || return 1
+	fi
+}
+
+upgrade_health_check() {
+	local data_dir="$1" expected_version="$2" require_service="${3:-1}" expected_commit="" actual="" pid="" command="" stable=0
+	local identity_re='^hyperfilelens-agent[[:space:]]+([^[:space:]]+)[[:space:]]+\(([^)]*)\)$'
+	expected_commit="$(grep -E '"agent_commit"[[:space:]]*:' "${MANIFEST_FILE}" 2>/dev/null | head -n1 | sed -n 's/.*"agent_commit"[[:space:]]*:[[:space:]]*"\([0-9A-Fa-f]*\)".*/\1/p')"
+	[[ -n "${expected_commit}" ]] || { log_warn "local health check: target manifest has no agent_commit"; return 1; }
+	actual="$("${INSTALL_DIR}/hfl-agent" version 2>/dev/null)" || { log_warn "local health check: Agent version command failed"; return 1; }
+	[[ "${actual}" =~ ${identity_re} ]] || {
+		log_warn "local health check: Agent returned an invalid build identity"; return 1;
+	}
+	local actual_version="${BASH_REMATCH[1]#v}" actual_commit="${BASH_REMATCH[2]}"
+	[[ "${actual_version}" == "${expected_version#v}" && "${actual_commit}" == "${expected_commit}" ]] || {
+		log_warn "local health check: running build identity does not match ${expected_version} (${expected_commit})"; return 1;
+	}
+	"${INSTALL_DIR}/hfl-agent" tasks list --data-dir "${data_dir}" --limit 1 >/dev/null 2>&1 || {
+		log_warn "local health check: Agent database could not be opened"; return 1;
+	}
+	if [[ "${require_service}" -eq 0 ]] || ! agent_manages_service; then return 0; fi
+	local seconds="${HFL_UPGRADE_HEALTH_SECONDS:-10}"
+	[[ "${seconds}" =~ ^[0-9]+$ && "${seconds}" -ge 2 ]] || seconds=10
+	while ((stable < seconds)); do
+		if agent_uses_launchd; then
+			launchctl print "${LAUNCHD_DOMAIN}/${LAUNCHD_LABEL}" >/dev/null 2>&1 || return 1
+			pid="$(launchctl print "${LAUNCHD_DOMAIN}/${LAUNCHD_LABEL}" 2>/dev/null | awk -F'= ' '/pid =/{print $2; exit}' | tr -d ' ;')"
+		else
+			hfl_systemctl is-active hyperfilelens-agent.service >/dev/null 2>&1 || return 1
+			pid="$(hfl_systemctl show hyperfilelens-agent.service -p MainPID 2>/dev/null | sed -n 's/^MainPID=//p')"
+		fi
+		[[ "${pid}" =~ ^[0-9]+$ && "${pid}" -gt 0 ]] || return 1
+		if [[ "$(uname -s)" == "Linux" ]]; then
+			[[ "$(readlink "/proc/${pid}/exe" 2>/dev/null || true)" == "${INSTALL_DIR}/hfl-agent" ]] || return 1
+		else
+			command="$(ps -p "${pid}" -o command= 2>/dev/null || true)"
+			[[ "${command}" == *"${INSTALL_DIR}/hfl-agent"* ]] || return 1
+		fi
+		stable=$((stable + 1))
+		sleep 1
+	done
+	log_ok "local health check passed (${expected_version}, ${expected_commit}; stable ${stable}s)"
+}
+
 upgrade_rollback_on_error() {
-	local rc=$?
-	if [[ "${UPGRADE_SERVICE_STOPPED}" -eq 1 ]]; then
-		log_warn "upgrade failed (exit=${rc}); attempting rollback"
-		restore_upgrade_binaries || true
-		if agent_manages_service; then
-			start_service || true
+	local rc="${1:-$?}" failed_phase="${UPGRADE_CURRENT_PHASE}"
+	if [[ "${UPGRADE_STOP_ATTEMPTED}" -eq 1 ]]; then
+		UPGRADE_TRANSACTION_ACTIVE=0
+		trap - ERR
+		write_upgrade_state "${DATA_DIR}" "rolling_back" || log_warn "could not persist rolling_back state"
+		log_warn "upgrade failed during ${failed_phase} (exit=${rc}); attempting rollback"
+		local rollback_ok=1
+		if [[ "${UPGRADE_DEPLOYMENT_STARTED}" -eq 1 ]]; then
+			local can_restore=1
+			(stop_service) >/dev/null 2>&1 || { rollback_ok=0; can_restore=0; }
+			if [[ "${can_restore}" -eq 1 ]]; then
+				(restore_upgrade_binaries) || rollback_ok=0
+				if [[ "${UPGRADE_STATE_SNAPSHOT_READY}" -eq 1 ]]; then
+					(restore_upgrade_state "${DATA_DIR}") || rollback_ok=0
+				fi
+				(restore_upgrade_service_definition "${DATA_DIR}") || rollback_ok=0
+			fi
+		fi
+		if [[ "${UPGRADE_SERVICE_WAS_ACTIVE}" -eq 1 ]] && agent_manages_service; then
+			(start_service) >/dev/null 2>&1 || rollback_ok=0
+		fi
+		if [[ "${UPGRADE_SERVICE_WAS_ENABLED}" -eq 0 ]] && agent_manages_service && agent_uses_systemd; then
+			hfl_systemctl disable hyperfilelens-agent.service >/dev/null 2>&1 || rollback_ok=0
+		fi
+		if ! upgrade_health_check "${DATA_DIR}" "${UPGRADE_PREVIOUS_VERSION}" "${UPGRADE_SERVICE_WAS_ACTIVE}"; then rollback_ok=0; fi
+		if [[ "${rollback_ok}" -eq 1 ]]; then
+			# A stop/snapshot failure can happen before deployment starts. The
+			# rollback directory is still only a transient safety copy in that
+			# case; do not leave it to be mistaken for an active transaction.
+			if write_upgrade_state "${DATA_DIR}" "rolled_back"; then
+				cleanup_upgrade_rollback "${DATA_DIR}"
+			else
+				log_warn "rollback completed, but its state could not be persisted; rollback data was retained"
+			fi
+			log_warn "upgrade failed; rollback completed successfully"
+		else
+			write_upgrade_state "${DATA_DIR}" "rollback_failed" || true
+			log_fail "Upgrade failed; rollback also failed. Rollback data was retained under $(agent_backup_dir "${DATA_DIR}")/rollback." 70
 		fi
 	fi
 	return "${rc}"
@@ -1108,8 +1540,11 @@ cleanup_upgrade_rollback() {
 	local data_dir="$1"
 	local rollback="$(agent_backup_dir "${data_dir}")/rollback"
 	if [[ -d "${rollback}" ]]; then
-		rm -rf "${rollback}"
-		log_ok "removed ${rollback} (upgrade succeeded; state snapshot retained)"
+		if rm -rf "${rollback}"; then
+			log_ok "removed ${rollback} after local health confirmation"
+		else
+			log_warn "local health verification passed, but rollback cleanup was deferred (${rollback})"
+		fi
 	fi
 }
 
@@ -1181,7 +1616,7 @@ migrate_agent_db() {
 	if "${agent}" tasks list --data-dir "${data_dir}" --limit 1 >/dev/null 2>&1; then
 		log_ok "agent.db schema upgraded (if needed)"
 	else
-		log_warn "agent.db migration check failed (service start may retry)"
+		log_fail "agent.db migration check failed; the upgraded Agent was not started." 2
 	fi
 }
 
@@ -1653,16 +2088,30 @@ deploy_admin_scripts() {
 	local src_manifest="${src_root}/MANIFEST.json"
 	local src_gateway_lifecycle="${src_root}/libexec/gateway-lifecycle.sh"
 	[[ -f "$src_script" ]] || log_fail "Missing bundle installer: ${src_script}." 2
-	install -m 755 "$src_script" "${INSTALL_DIR}/install.sh"
+	install_file_atomically "$src_script" "${INSTALL_DIR}/install.sh" 755
 	log_ok "deployed ${INSTALL_DIR}/install.sh"
 	if [[ -f "$src_manifest" ]]; then
-		install -m 644 "$src_manifest" "${MANIFEST_FILE}"
+		install_file_atomically "$src_manifest" "${MANIFEST_FILE}" 644
 		log_ok "deployed ${MANIFEST_FILE}"
 	fi
 	if [[ "$(uname -s)" == "Linux" && -f "${src_gateway_lifecycle}" ]]; then
 		install -d -m 755 "${INSTALL_DIR}/libexec"
-		install -m 755 "${src_gateway_lifecycle}" "${GATEWAY_LIFECYCLE_SCRIPT}"
+		install_file_atomically "${src_gateway_lifecycle}" "${GATEWAY_LIFECYCLE_SCRIPT}" 755
 		log_ok "deployed ${GATEWAY_LIFECYCLE_SCRIPT}"
+	fi
+}
+
+install_file_atomically() {
+	local source="$1" destination="$2" mode="$3" temporary="${destination}.new.$$"
+	mkdir -p "$(dirname "${destination}")"
+	rm -f "${temporary}"
+	if ! install -m "${mode}" "${source}" "${temporary}"; then
+		rm -f "${temporary}" 2>/dev/null || true
+		return 1
+	fi
+	if ! mv -f "${temporary}" "${destination}"; then
+		rm -f "${temporary}" 2>/dev/null || true
+		return 1
 	fi
 }
 
@@ -1675,20 +2124,24 @@ deploy_binaries() {
 	if [[ $KOPIA_ONLY -eq 1 ]]; then deploy_agent=0; fi
 
 	mkdir -p "${INSTALL_DIR}"
+	# Put the verified recovery-capable lifecycle script in place first. If the
+	# process is interrupted while replacing binaries, the next local lifecycle
+	# command can understand upgrade-state.json and resume rollback.
+	deploy_admin_scripts "${src_root}"
 	if [[ $deploy_agent -eq 1 ]]; then
 		[[ -f "$agent_bin" ]] || log_fail "Missing bundle binary: ${agent_bin}." 2
-		install -m 755 "$agent_bin" "${INSTALL_DIR}/hfl-agent"
+		install_file_atomically "$agent_bin" "${INSTALL_DIR}/hfl-agent" 755
 		log_ok "deployed ${INSTALL_DIR}/hfl-agent ($(bundle_version_from "${src_root}"))"
 	fi
 	if [[ $deploy_kopia -eq 1 ]]; then
 		[[ -f "$kopia_bin" ]] || log_fail "Missing bundle binary: ${kopia_bin}." 2
-		install -m 755 "$kopia_bin" "${INSTALL_DIR}/kopia"
+		install_file_atomically "$kopia_bin" "${INSTALL_DIR}/kopia" 755
 		log_ok "deployed ${INSTALL_DIR}/kopia"
 	fi
 	ver="$(bundle_version_from "${src_root}")"
-	echo "$ver" >"${INSTALLED_VERSION_FILE}"
+	printf '%s\n' "$ver" >"${INSTALLED_VERSION_FILE}.new.$$"
+	mv -f "${INSTALLED_VERSION_FILE}.new.$$" "${INSTALLED_VERSION_FILE}"
 	log_ok "wrote ${INSTALLED_VERSION_FILE} (${ver})"
-	deploy_admin_scripts "${src_root}"
 }
 
 write_agent_env() {
@@ -1883,6 +2336,9 @@ stop_service() {
 				hfl_systemctl kill --signal=SIGKILL hyperfilelens-agent.service 2>/dev/null || true
 				sleep 1
 			fi
+			if hfl_systemctl is-active hyperfilelens-agent.service >/dev/null 2>&1; then
+				log_fail "Agent service did not stop; upgrade was aborted before deployment." 2
+			fi
 			log_ok "stopped service hyperfilelens-agent.service"
 			;;
 		*)
@@ -1971,6 +2427,10 @@ start_service_only() {
 	if ! agent_uses_systemd; then
 		log_fail "Systemd is not available on this host." 2
 	fi
+	# The upgrade path rewrites the unit and any drop-ins before restoring the
+	# previous running state. Reload systemd explicitly so start never uses a
+	# stale unit definition from its manager cache.
+	hfl_systemctl daemon-reload
 	hfl_systemctl start hyperfilelens-agent.service
 	log_ok "started service hyperfilelens-agent.service ($(service_status_line))"
 }
@@ -2152,6 +2612,9 @@ cmd_upgrade() {
 	require_service_manager
 
 	[[ -n "${UPGRADE_FROM}" ]] || log_fail "Upgrade requires --from <directory-or.tar.gz>." 2
+	if [[ "${AGENT_ONLY}" -eq 1 || "${KOPIA_ONLY}" -eq 1 ]]; then
+		log_fail "Transactional upgrade requires the complete Agent package; --agent-only and --kopia-only are not supported." 2
+	fi
 
 	local legacy_upgrade=0 legacy_residue=0
 	if ! is_installed && legacy_layout_present; then
@@ -2198,15 +2661,39 @@ cmd_upgrade() {
 	elif [[ "${legacy_upgrade}" -eq 1 && -f "${LEGACY_INSTALL_DIR}/INSTALLED_VERSION" ]]; then
 		prev_ver="$(tr -d ' \t\r\n' <"${LEGACY_INSTALL_DIR}/INSTALLED_VERSION")"
 	fi
+	UPGRADE_PREVIOUS_VERSION="${prev_ver}"
+	UPGRADE_TARGET_VERSION="unknown"
 	begin_install_log "${data_dir}" "upgrade"
 	trap 'finish_install_log $?' RETURN
 
 	# EXIT traps run after this function's local variables leave scope. Use a
 	# default expansion so a failure before workspace assignment cannot trigger
 	# a secondary `set -u` error and hide the original upgrade failure.
-	trap 'rc=$?; cleanup_upgrade_workspace "${upgrade_ws:-}"; hfl_finalize_active_log "$rc"' EXIT
+	acquire_lifecycle_lock "${data_dir}" "upgrade"
+	# Keep log finalization installed while recovering an older transaction or
+	# resolving the package; these steps can fail before the main transaction
+	# cleanup trap is installed below.
+	trap 'rc=$?; release_lifecycle_lock; hfl_finalize_active_log "$rc"' EXIT
+	recover_interrupted_upgrade "${data_dir}" "upgrade"
+	prev_ver="unknown"
+	if [[ -f "${INSTALLED_VERSION_FILE}" ]]; then
+		prev_ver="$(tr -d ' \t\r\n' <"${INSTALLED_VERSION_FILE}")"
+	elif [[ "${legacy_upgrade}" -eq 1 && -f "${LEGACY_INSTALL_DIR}/INSTALLED_VERSION" ]]; then
+		prev_ver="$(tr -d ' \t\r\n' <"${LEGACY_INSTALL_DIR}/INSTALLED_VERSION")"
+	fi
+	UPGRADE_PREVIOUS_VERSION="${prev_ver}"
+	UPGRADE_TARGET_VERSION="unknown"
+	UPGRADE_SERVICE_WAS_ACTIVE=0
+	UPGRADE_SERVICE_WAS_ENABLED=0
+	UPGRADE_STATE_SNAPSHOT_READY=0
+	UPGRADE_DEPLOYMENT_STARTED=0
+	UPGRADE_STOP_ATTEMPTED=0
+	write_upgrade_state "${data_dir}" "preparing"
+	trap 'rc=$?; if [[ "$rc" -ne 0 && "${UPGRADE_STOP_ATTEMPTED}" -eq 0 ]]; then clear_upgrade_state; cleanup_upgrade_rollback "${data_dir}"; fi; cleanup_upgrade_workspace "${upgrade_ws:-}"; release_lifecycle_lock; hfl_finalize_active_log "$rc"' EXIT
 	src_root="$(prepare_upgrade_source "${UPGRADE_FROM}" "${data_dir}")"
 	new_ver="$(bundle_version_from "${src_root}")"
+	UPGRADE_TARGET_VERSION="${new_ver}"
+	write_upgrade_state "${data_dir}" "package_resolved"
 
 	if [[ "${new_ver}" == "${prev_ver}" ]]; then
 		confirm_same_version_upgrade "${prev_ver}"
@@ -2219,6 +2706,8 @@ cmd_upgrade() {
 
 	local installed_role gateway_scope
 	installed_role="$(read_env_value "${env_file}" "HFL_NODE_ROLE" || true)"
+	verify_upgrade_package "${src_root}" "${installed_role:-agent}" "${new_ver}"
+	update_lifecycle_lock_target "${new_ver}" "${src_root}/MANIFEST.json"
 	if [[ $QUIET_FOOTER -eq 0 ]]; then
 		gateway_scope="$(read_env_value "${env_file}" "HFL_GATEWAY_SCOPE" || true)"
 		hfl_print_banner "$(hfl_role_display_name "${installed_role}" "${gateway_scope}")" "Upgrade"
@@ -2242,15 +2731,44 @@ cmd_upgrade() {
 	fi
 	hfl_print_section "Upgrading Agent"
 	backup_upgrade_binaries "${data_dir}"
+	UPGRADE_STATE_SNAPSHOT_READY=0
+	UPGRADE_DEPLOYMENT_STARTED=0
+	UPGRADE_STOP_ATTEMPTED=0
+	UPGRADE_SERVICE_WAS_ACTIVE=0
+	if agent_manages_service; then
+		if agent_uses_launchd; then
+			launchctl print "${LAUNCHD_DOMAIN}/${LAUNCHD_LABEL}" >/dev/null 2>&1 && UPGRADE_SERVICE_WAS_ACTIVE=1
+		elif hfl_systemctl is-active hyperfilelens-agent.service >/dev/null 2>&1; then
+			UPGRADE_SERVICE_WAS_ACTIVE=1
+		fi
+		if agent_uses_systemd && hfl_systemctl is-enabled hyperfilelens-agent.service >/dev/null 2>&1; then
+			UPGRADE_SERVICE_WAS_ENABLED=1
+		fi
+	fi
+	UPGRADE_TRANSACTION_ACTIVE=1
 	trap upgrade_rollback_on_error ERR
 
+	write_upgrade_state "${data_dir}" "snapshotting"
+	backup_agent_config_and_db "${data_dir}" "${prev_ver}" "${src_root}"
+	UPGRADE_STATE_SNAPSHOT_READY=1
+	write_upgrade_state "${data_dir}" "state_snapshotted"
+	# All rollback state is captured before touching the running Agent. This
+	# keeps a stop failure non-destructive and preserves a standalone consistent
+	# SQLite snapshot for any later deployment failure.
+	UPGRADE_STOP_ATTEMPTED=1
+	write_upgrade_state "${data_dir}" "stopping"
 	stop_service
-	UPGRADE_SERVICE_STOPPED=1
-	backup_agent_config_and_db "${data_dir}" "${prev_ver}"
+	write_upgrade_state "${data_dir}" "service_stopped"
+	UPGRADE_DEPLOYMENT_STARTED=1
+	write_upgrade_state "${data_dir}" "deploying"
 	deploy_binaries "${src_root}"
+	write_upgrade_state "${data_dir}" "deployed"
 	merge_agent_env "${env_file}" "${data_dir}"
+	write_upgrade_state "${data_dir}" "migrating"
 	migrate_agent_db "${data_dir}"
+	write_upgrade_state "${data_dir}" "migrated"
 
+	write_upgrade_state "${data_dir}" "configuring_service"
 	if agent_uses_launchd; then
 		write_run_agent_script "${env_file}"
 		install_launchd_plist "${env_file}"
@@ -2258,25 +2776,38 @@ cmd_upgrade() {
 		install_systemd_unit_logged "${env_file}" "${src_root}"
 	fi
 
-	trap - ERR
-	UPGRADE_SERVICE_STOPPED=0
-
-	cleanup_upgrade_workspace "${upgrade_ws}"
-	cleanup_upgrade_rollback "${data_dir}"
-	trap - EXIT
-
 	if [[ $NO_RESTART -eq 1 ]]; then
+		write_upgrade_state "${data_dir}" "awaiting_restart"
+		UPGRADE_TRANSACTION_ACTIVE=0
+		trap - ERR
+		cleanup_upgrade_workspace "${upgrade_ws}"
 		if [[ $QUIET_FOOTER -eq 0 ]]; then
 			log_skip "Service $(service_display_name) was not restarted (--no-restart)."
-			hfl_print_upgrade_success "${new_ver}" "not restarted" "${data_dir}"
+			log_warn "Rollback snapshot retained until the upgraded Agent is started and verified."
+			hfl_print_upgrade_success "${new_ver}" "not restarted; verification pending" "${data_dir}"
 		fi
 		return 0
 	fi
 
-	if agent_manages_service; then
-		start_service
-		cleanup_legacy_layout
+	if [[ "${UPGRADE_SERVICE_WAS_ACTIVE}" -eq 1 ]] && agent_manages_service; then
+		write_upgrade_state "${data_dir}" "starting_service"
+		# Restore the previous running state without changing the systemd enable
+		# policy. A manually started disabled unit must remain disabled.
+		start_service_only
 	fi
+	write_upgrade_state "${data_dir}" "service_started"
+	if ! upgrade_health_check "${data_dir}" "${new_ver}" "${UPGRADE_SERVICE_WAS_ACTIVE}"; then
+		upgrade_rollback_on_error 1
+		return 1
+	fi
+	UPGRADE_TRANSACTION_ACTIVE=0
+	trap - ERR
+	write_upgrade_state "${data_dir}" "healthy"
+	cleanup_upgrade_workspace "${upgrade_ws}"
+	cleanup_legacy_layout
+	write_upgrade_state "${data_dir}" "committed"
+	cleanup_upgrade_rollback "${data_dir}"
+	clear_upgrade_state
 	# The upgrade command may have been launched by the previous release's
 	# installer. That old process has just deployed the new installer, so run
 	# the new reconciliation command once to clean legacy paths on the first
@@ -2464,8 +2995,10 @@ cmd_uninstall() {
 		&& ! data_dir_allowed_for_removal "${resolved_data}"; then
 		log_fail "Refusing purge-all for unexpected data directory ${resolved_data}." 2
 	fi
+	acquire_lifecycle_lock "${resolved_data}" "uninstall"
+	trap 'release_lifecycle_lock' EXIT
 	begin_uninstall_log "${resolved_data}"
-	trap 'hfl_finalize_active_log $?' EXIT
+	trap 'rc=$?; release_lifecycle_lock; hfl_finalize_active_log "$rc"' EXIT
 
 	local installed_role gateway_scope node_id installed_version data_policy
 	installed_role="$(read_env_value "${env_file}" "HFL_NODE_ROLE" || true)"
@@ -2562,6 +3095,7 @@ cmd_uninstall() {
 		hfl_print_value "Log file" "$(agent_logs_dir "${resolved_data}")/uninstall.log"
 	fi
 	finish_uninstall_log 0
+	release_lifecycle_lock
 	trap - EXIT
 }
 
@@ -2595,28 +3129,96 @@ cmd_status() {
 cmd_start() {
 	require_root
 	require_agent_installed
+	local data_dir state_file phase
+	data_dir="$(resolve_data_dir)"
+	state_file="$(agent_lifecycle_dir "${data_dir}")/upgrade-state.json"
+	phase="$(upgrade_state_value "${state_file}" phase || true)"
+	if [[ -f "${state_file}" ]]; then
+		DATA_DIR="${data_dir}"
+		acquire_lifecycle_lock "${data_dir}" "upgrade-verification"
+		trap 'release_lifecycle_lock' EXIT
+		local recovery_rc=0
+		if recover_interrupted_upgrade "${data_dir}" "start"; then
+			:
+		else
+			recovery_rc=$?
+			[[ "${recovery_rc}" -eq 2 ]] || return "${recovery_rc}"
+		fi
+		phase="${UPGRADE_CURRENT_PHASE}"
+	fi
+	if [[ "${phase}" == "awaiting_restart" ]]; then
+		[[ -n "${UPGRADE_PREVIOUS_VERSION}" ]] || UPGRADE_PREVIOUS_VERSION="unknown"
+		[[ -n "${UPGRADE_TARGET_VERSION}" ]] || log_fail "Pending upgrade state is missing its target version (${state_file})." 2
+		UPGRADE_DEPLOYMENT_STARTED=1
+		UPGRADE_STOP_ATTEMPTED=1
+		UPGRADE_TRANSACTION_ACTIVE=1
+		trap upgrade_rollback_on_error ERR
+		log_step "Starting the staged Agent upgrade for local health verification."
+		write_upgrade_state "${data_dir}" "starting_service"
+		start_service_only
+		write_upgrade_state "${data_dir}" "service_started"
+		if ! upgrade_health_check "${data_dir}" "${UPGRADE_TARGET_VERSION}"; then
+			if upgrade_rollback_on_error 1; then :; fi
+			log_fail "The staged Agent failed local health verification; the previous version was restored." 1
+		fi
+		UPGRADE_TRANSACTION_ACTIVE=0
+		trap - ERR
+		write_upgrade_state "${data_dir}" "committed"
+		cleanup_upgrade_rollback "${data_dir}"
+		clear_upgrade_state
+		release_lifecycle_lock
+		trap - EXIT
+		log_ok "Staged upgrade to ${UPGRADE_TARGET_VERSION} passed local health verification."
+		return 0
+	fi
+	if [[ -n "${phase}" ]]; then
+		release_lifecycle_lock
+		trap - EXIT
+	fi
+	acquire_lifecycle_lock "${data_dir}" "start"
+	trap 'release_lifecycle_lock' EXIT
 	log_step "Starting $(service_display_name)."
 	start_service_only
 	log_ok "Service $(service_display_name) is $(service_status_line)."
+	release_lifecycle_lock
+	trap - EXIT
 }
 
 cmd_stop() {
 	require_root
 	require_agent_installed
+	local data_dir
+	data_dir="$(resolve_data_dir)"
+	acquire_lifecycle_lock "${data_dir}" "stop"
+	trap 'release_lifecycle_lock' EXIT
 	log_step "Stopping $(service_display_name)."
 	stop_service
 	log_ok "Service $(service_display_name) is $(service_status_line)."
+	release_lifecycle_lock
+	trap - EXIT
 }
 
 cmd_restart() {
 	require_root
 	require_agent_installed
+	local data_dir state_file phase
+	data_dir="$(resolve_data_dir)"
+	state_file="$(agent_lifecycle_dir "${data_dir}")/upgrade-state.json"
+	phase="$(upgrade_state_value "${state_file}" phase || true)"
+	if [[ -f "${state_file}" ]]; then
+		cmd_start
+		return 0
+	fi
+	acquire_lifecycle_lock "${data_dir}" "restart"
+	trap 'release_lifecycle_lock' EXIT
 	log_step "Restarting $(service_display_name)."
 	stop_service
 	if agent_manages_service; then
 		start_service_only
 	fi
 	log_ok "Service $(service_display_name) is $(service_status_line)."
+	release_lifecycle_lock
+	trap - EXIT
 }
 
 case "$CMD" in


### PR DESCRIPTION
## Summary

- validate complete Agent packages and create consistent SQLite snapshots before stopping the current Agent
- preserve binaries, configuration, database state, service definitions, and startup policy until the target build passes local health verification
- serialize lifecycle operations, recover interrupted upgrades, and report rollback failures explicitly across Linux, macOS, and Windows
- route staged enrollment upgrades through the verified lifecycle completion path and align Windows version policy

## Validation

- `go test ./...`
- `go vet ./...`
- Bash syntax and Git whitespace checks
- Windows amd64 Agent, enrollment helper, and user launcher builds
- macOS amd64 and arm64 Agent and enrollment helper builds
- PowerShell parser validation

## Issue scope

Related to #847. This change hardens upgrades between releases that use the unified Agent Root. It does not expand support for migrating historical pre-unified directory layouts.