### PR TITLE
Fix Agent upgrade preflight and recovery

### DIFF
--- a/src/agent/internal/enroll/install.go
+++ b/src/agent/internal/enroll/install.go
@@ -89,7 +89,7 @@ func RunInstall(ctx context.Context, opts InstallOptions) error {
 	configCommitted := false
 	var stagedConfig enrollmentEnvSnapshot
 	configStaged := false
-	restartAfterConfigRestore := false
+	restoreRunningService := false
 	defer func() {
 		if sessionCompleted {
 			return
@@ -113,9 +113,13 @@ func RunInstall(ctx context.Context, opts InstallOptions) error {
 			return
 		}
 		logOK("Original Agent configuration was restored.")
-		if restartAfterConfigRestore {
+		if restoreRunningService {
 			restartCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
 			defer cancel()
+			if !shouldRecoverServiceAfterConfigRestore(restoreRunningService, serviceState(restartCtx)) {
+				logOK("Agent service remained active; no restart was required after configuration restore.")
+				return
+			}
 			if restartErr := RestartInstalledService(restartCtx); restartErr != nil {
 				logWarn("Agent service could not be restarted with the restored configuration: " + restartErr.Error())
 				return
@@ -212,7 +216,10 @@ func RunInstall(ctx context.Context, opts InstallOptions) error {
 
 	case ActionUpgrade, ActionReinstall:
 		stageExistingConfig()
-		restartAfterConfigRestore = true
+		// Preserve the service state that existed before enrollment. The upgrade
+		// script owns transactional stop/rollback; only recover here when a
+		// previously healthy service is no longer running after a later failure.
+		restoreRunningService = state.ServiceHealthy()
 		dl := plan.DownloadURL
 		releaseVer := plan.ReleaseVersion
 		if dl == "" {
@@ -269,6 +276,10 @@ func RunInstall(ctx context.Context, opts InstallOptions) error {
 
 	logFail("Unsupported reinstall action.", 3)
 	return nil
+}
+
+func shouldRecoverServiceAfterConfigRestore(wasRunning bool, currentState string) bool {
+	return wasRunning && !isServiceHealthy(currentState)
 }
 
 func runExplicitUninstall(ctx context.Context, cfg Config, opts InstallOptions) error {

--- a/src/agent/internal/enroll/plan_test.go
+++ b/src/agent/internal/enroll/plan_test.go
@@ -38,6 +38,27 @@ func TestIsServiceHealthy(t *testing.T) {
 	}
 }
 
+func TestShouldRecoverServiceAfterConfigRestore(t *testing.T) {
+	tests := []struct {
+		name        string
+		wasRunning  bool
+		current     string
+		wantRecover bool
+	}{
+		{name: "running service remains active", wasRunning: true, current: "active", wantRecover: false},
+		{name: "running service became inactive", wasRunning: true, current: "inactive", wantRecover: true},
+		{name: "inactive service stays inactive", wasRunning: false, current: "inactive", wantRecover: false},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := shouldRecoverServiceAfterConfigRestore(test.wasRunning, test.current)
+			if got != test.wantRecover {
+				t.Fatalf("shouldRecoverServiceAfterConfigRestore(%v, %q) = %v, want %v", test.wasRunning, test.current, got, test.wantRecover)
+			}
+		})
+	}
+}
+
 func TestPlanReinstallCrossOrg(t *testing.T) {
 	plan, err := PlanReinstall(t.Context(), Config{OrgKey: "org-b"}, InstallState{
 		Installed: true,

--- a/src/agent/internal/platform/install/install_sh_test.go
+++ b/src/agent/internal/platform/install/install_sh_test.go
@@ -310,6 +310,38 @@ func TestInstallShellUpgradeKeepsRollbackUntilLocalHealth(t *testing.T) {
 	}
 }
 
+func TestInstallShellInitializesDependentUpgradeLocalsInOrder(t *testing.T) {
+	body := readPackagingInstallShell(t)
+	for _, unsafeDeclaration := range []string{
+		`local data_dir="$1" operation="$2" lock_dir=`,
+		`local data_dir="$1" phase="$2" file=`,
+		`local data_dir="$1" file=`,
+		`local root="$1" role="$2" version="$3" target_verifier=`,
+		`local data_dir="$1" service_dir=`,
+		`local source="$1" destination="$2" temporary=`,
+		`local data_dir="$1" rollback=`,
+		`local source="$1" destination="$2" mode="$3" temporary=`,
+	} {
+		if strings.Contains(body, unsafeDeclaration) {
+			t.Fatalf("install.sh must not expand a local in the same declaration that initializes it under set -u: %s", unsafeDeclaration)
+		}
+	}
+	for _, want := range []string{
+		`local lock_dir="$(agent_lifecycle_dir "${data_dir}")/install.lock"`,
+		`local file="$(agent_lifecycle_dir "${data_dir}")/upgrade-state.json"`,
+		`local root="$1" role="$2" version="$3" verifier output`,
+		`local target_verifier="${root}/bin/hfl-agent"`,
+		`local service_dir="$(agent_backup_dir "${data_dir}")/rollback/service"`,
+		`local temporary="${destination}.rollback.$$"`,
+		`local rollback="$(agent_backup_dir "${data_dir}")/rollback"`,
+		`local temporary="${destination}.new.$$"`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("install.sh ordered upgrade local initialization missing %q", want)
+		}
+	}
+}
+
 func TestInstallShellKeepsSpecifiedUserOutOfUserManager(t *testing.T) {
 	body := readPackagingInstallShell(t)
 	start := strings.Index(body, "hfl_systemctl() {")

--- a/src/agent/packaging/install/install.sh
+++ b/src/agent/packaging/install/install.sh
@@ -731,7 +731,8 @@ process_start_marker() {
 }
 
 acquire_lifecycle_lock() {
-	local data_dir="$1" operation="$2" lock_dir="$(agent_lifecycle_dir "${data_dir}")/install.lock" pid_file
+	local data_dir="$1" operation="$2" pid_file
+	local lock_dir="$(agent_lifecycle_dir "${data_dir}")/install.lock"
 	local owner_pid="" recorded_start="" actual_start="" attempt
 	mkdir -p "$(agent_lifecycle_dir "${data_dir}")"
 	if ! mkdir "${lock_dir}" 2>/dev/null; then
@@ -790,7 +791,8 @@ release_lifecycle_lock() {
 }
 
 write_upgrade_state() {
-	local data_dir="$1" phase="$2" file="$(agent_lifecycle_dir "${data_dir}")/upgrade-state.json" temporary
+	local data_dir="$1" phase="$2" temporary
+	local file="$(agent_lifecycle_dir "${data_dir}")/upgrade-state.json"
 	mkdir -p "$(dirname "${file}")"
 	UPGRADE_STATE_FILE="${file}"
 	UPGRADE_CURRENT_PHASE="${phase}"
@@ -817,7 +819,8 @@ upgrade_state_flag() {
 }
 
 load_upgrade_state() {
-	local data_dir="$1" file="$(agent_lifecycle_dir "${data_dir}")/upgrade-state.json"
+	local data_dir="$1"
+	local file="$(agent_lifecycle_dir "${data_dir}")/upgrade-state.json"
 	UPGRADE_STATE_FILE="${file}"
 	UPGRADE_CURRENT_PHASE="$(upgrade_state_value "${file}" phase || true)"
 	UPGRADE_PREVIOUS_VERSION="$(upgrade_state_value "${file}" previous_version || true)"
@@ -1184,7 +1187,8 @@ assert_agent_package_root() {
 }
 
 verify_upgrade_package() {
-	local root="$1" role="$2" version="$3" target_verifier="${root}/bin/hfl-agent" verifier output
+	local root="$1" role="$2" version="$3" verifier output
+	local target_verifier="${root}/bin/hfl-agent"
 	[[ -x "${target_verifier}" ]] || log_fail "Upgrade package verifier is missing: ${target_verifier}." 2
 	verifier="${target_verifier}"
 	if [[ -x "${INSTALL_DIR}/hfl-agent" ]] \
@@ -1337,7 +1341,8 @@ backup_upgrade_binaries() {
 }
 
 backup_upgrade_service_definition() {
-	local data_dir="$1" service_dir="$(agent_backup_dir "${data_dir}")/rollback/service"
+	local data_dir="$1"
+	local service_dir="$(agent_backup_dir "${data_dir}")/rollback/service"
 	mkdir -p "${service_dir}"
 	if agent_uses_launchd; then
 		if [[ -f "${LAUNCHD_PLIST}" ]]; then
@@ -1383,7 +1388,8 @@ restore_upgrade_binaries() {
 }
 
 copy_file_atomically() {
-	local source="$1" destination="$2" temporary="${destination}.rollback.$$"
+	local source="$1" destination="$2"
+	local temporary="${destination}.rollback.$$"
 	rm -f "${temporary}"
 	if ! cp -a "${source}" "${temporary}"; then
 		rm -f "${temporary}" 2>/dev/null || true
@@ -1396,7 +1402,8 @@ copy_file_atomically() {
 }
 
 restore_upgrade_state() {
-	local data_dir="$1" rollback="$(agent_backup_dir "${data_dir}")/rollback"
+	local data_dir="$1"
+	local rollback="$(agent_backup_dir "${data_dir}")/rollback"
 	local archive="${rollback}/latest.tar.gz" staging="${rollback}/restore.$$" relative destination
 	[[ -f "${archive}" ]] || return 1
 	rm -rf "${staging}" || return 1
@@ -1429,7 +1436,8 @@ restore_upgrade_state() {
 }
 
 restore_upgrade_service_definition() {
-	local data_dir="$1" service_dir="$(agent_backup_dir "${data_dir}")/rollback/service"
+	local data_dir="$1"
+	local service_dir="$(agent_backup_dir "${data_dir}")/rollback/service"
 	if agent_uses_launchd; then
 		stop_launchd_service || true
 		rm -f "${LAUNCHD_PLIST}" || return 1
@@ -2102,7 +2110,8 @@ deploy_admin_scripts() {
 }
 
 install_file_atomically() {
-	local source="$1" destination="$2" mode="$3" temporary="${destination}.new.$$"
+	local source="$1" destination="$2" mode="$3"
+	local temporary="${destination}.new.$$"
 	mkdir -p "$(dirname "${destination}")"
 	rm -f "${temporary}"
 	if ! install -m "${mode}" "${source}" "${temporary}"; then


### PR DESCRIPTION
## Summary

- fix the Agent installer upgrade verifier under Bash `set -u`
- harden related upgrade-state local initialization paths
- recover the Agent service only when it was running before the failed operation and is no longer healthy
- add regression coverage for installer initialization and service-state recovery

## Validation

- `go test ./internal/platform/install ./internal/enroll`
- `go vet ./internal/platform/install ./internal/enroll`
- `bash -n src/agent/packaging/install/install.sh`
- `bash tools/quality/test-agent-installer-output.sh`
- `git diff --check`