### PR TITLE
Temporarily hide the Insight Usage page

### DIFF
--- a/src/frontend/src/composables/useInsightSideNav.test.ts
+++ b/src/frontend/src/composables/useInsightSideNav.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { useInsightSideNav } from './useInsightSideNav'
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}))
+
+describe('useInsightSideNav', () => {
+  it('keeps the temporarily hidden Usage page out of the sidebar', () => {
+    const paths = useInsightSideNav().value
+      .flatMap((group) => group.children || [])
+      .map((item) => item.to)
+
+    expect(paths).toContain('/insight/copilot')
+    expect(paths).toContain('/insight/gateways')
+    expect(paths).not.toContain('/insight/usage')
+  })
+})

--- a/src/frontend/src/composables/useInsightSideNav.ts
+++ b/src/frontend/src/composables/useInsightSideNav.ts
@@ -1,6 +1,6 @@
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { ChartNoAxesCombined, MessageSquare } from 'lucide-vue-next'
+import { MessageSquare } from 'lucide-vue-next'
 import type { MenuItem } from '../components/ModulePage.vue'
 import { dataGatewaySidebarIcon } from '../lib/resourceIcons'
 
@@ -17,11 +17,8 @@ export function useInsightSideNav() {
     {
       label: t('insight.side.groupDataGateways'),
       children: [
-        {
-          label: t('insight.side.usage'),
-          to: '/insight/usage',
-          icon: ChartNoAxesCombined,
-        },
+        // Insight Usage is temporarily hidden. Do not delete its page or API implementation.
+        // To restore it, add the /insight/usage menu item here and re-enable its route.
         {
           label: t('insight.side.dataGateway'),
           to: '/insight/gateways',

--- a/src/frontend/src/router/index.ts
+++ b/src/frontend/src/router/index.ts
@@ -112,10 +112,8 @@ export const router = createRouter({
           component: lazyRoute(() => import('../pages/insight/NewCopilotChat.vue')),
           meta: fullscreenRouteMeta,
         },
-        {
-          path: 'insight/usage',
-          component: lazyRoute(() => import('../pages/insight/InsightUsage.vue')),
-        },
+        // Insight Usage is temporarily hidden. Keep InsightUsage.vue and its API implementation.
+        // To restore it, register /insight/usage here and restore its side-navigation item.
         {
           path: 'insight/gateways',
           component: lazyRoute(() => import('../pages/insight/InsightGateways.vue')),

--- a/src/frontend/src/router/insightUsageVisibility.test.ts
+++ b/src/frontend/src/router/insightUsageVisibility.test.ts
@@ -1,0 +1,19 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it } from 'vitest'
+
+import { router } from './index'
+
+describe('Insight Usage visibility', () => {
+  it('does not register the temporarily hidden Usage page route', () => {
+    const paths = router.getRoutes().map((route) => route.path)
+
+    expect(paths).not.toContain('/insight/usage')
+  })
+
+  it('redirects direct Usage links to the Insight home page', async () => {
+    await router.push('/insight/usage')
+
+    expect(router.currentRoute.value.fullPath).toBe('/insight/copilot')
+  })
+})


### PR DESCRIPTION
## Summary

- remove the Insight Usage entry from the tenant sidebar
- unregister the Usage route so direct links fall back to Insight Chat without mounting the page or issuing Usage API requests
- retain the Usage page, API implementation, translations, and reporting logic for future restoration
- document the restoration steps in the relevant frontend code
- add regression coverage for sidebar visibility and direct-route behavior

## Validation

- targeted Vitest suite
- ESLint for changed files
- TypeScript type checking
- production frontend build
- git diff --check