### PR TITLE
Fix snapshot browser time zones

### DIFF
--- a/src/agent/internal/engine/managed_backup.go
+++ b/src/agent/internal/engine/managed_backup.go
@@ -3663,36 +3663,100 @@ func truncateSnapshotBrowseError(value string, limit int) string {
 }
 
 // formatModTimeUTC parses a time string from Kopia output and returns it as
-// RFC 3339 (ISO 8601) in UTC. Kopia snapshot timestamps are always UTC but
-// the ls -l output omits the timezone indicator, causing frontends to
-// misinterpret them as local time.
+// RFC 3339 (ISO 8601) in UTC. Kopia formats ls -l timestamps in the Agent's
+// local timezone, including ambiguous abbreviations such as CST, so named
+// zones must be resolved against that same local timezone.
 func formatModTimeUTC(raw string) string {
+	return formatModTimeUTCInLocation(raw, time.Local)
+}
+
+func formatModTimeUTCInLocation(raw string, local *time.Location) string {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {
 		return ""
 	}
-	// Strip trailing " UTC" / " UTC" that some Kopia JSON outputs append.
-	utcStripped := strings.TrimSuffix(raw, " UTC")
-	utcStripped = strings.TrimSuffix(utcStripped, " UTC")
-	utcStripped = strings.TrimSpace(utcStripped)
-	formats := []string{
+	if local == nil {
+		local = time.Local
+	}
+	for _, layout := range []string{
+		time.RFC3339Nano,
+		"2006-01-02 15:04:05.999999999 -07:00",
+		"2006-01-02 15:04:05.999999999 -0700",
+	} {
+		if parsed, err := time.Parse(layout, raw); err == nil {
+			return parsed.UTC().Format(time.RFC3339)
+		}
+	}
+	for _, layout := range []string{
+		"Jan 2 2006 MST",
+		"Jan 2 15:04 MST",
+		"Jan 2 15:04:05 MST",
+		"2006-01-02 15:04:05 MST",
+		"2006-01-02T15:04:05 MST",
+	} {
+		parsed, err := time.ParseInLocation(layout, raw, local)
+		if err != nil {
+			continue
+		}
+		year := parsed.Year()
+		if year == 0 {
+			year = time.Now().In(local).Year()
+		}
+		inputZone := strings.Fields(raw)
+		if len(inputZone) > 0 && (strings.EqualFold(inputZone[len(inputZone)-1], "UTC") ||
+			strings.EqualFold(inputZone[len(inputZone)-1], "GMT")) {
+			return time.Date(
+				year,
+				parsed.Month(),
+				parsed.Day(),
+				parsed.Hour(),
+				parsed.Minute(),
+				parsed.Second(),
+				parsed.Nanosecond(),
+				time.UTC,
+			).Format(time.RFC3339)
+		}
+		localTime := time.Date(
+			year,
+			parsed.Month(),
+			parsed.Day(),
+			parsed.Hour(),
+			parsed.Minute(),
+			parsed.Second(),
+			parsed.Nanosecond(),
+			local,
+		)
+		localZone, _ := localTime.Zone()
+		if len(inputZone) == 0 || !strings.EqualFold(inputZone[len(inputZone)-1], localZone) {
+			continue
+		}
+		return localTime.UTC().Format(time.RFC3339)
+	}
+	for _, layout := range []string{
 		"Jan 2 2006",
 		"Jan 2 15:04",
 		"Jan 2 15:04:05",
 		"2006-01-02 15:04:05",
 		"2006-01-02T15:04:05",
-		time.RFC3339,
-	}
-	for _, layout := range formats {
-		t, err := time.Parse(layout, utcStripped)
+	} {
+		parsed, err := time.ParseInLocation(layout, raw, local)
 		if err != nil {
 			continue
 		}
-		year := t.Year()
+		year := parsed.Year()
 		if year == 0 {
-			year = time.Now().Year()
+			year = time.Now().In(local).Year()
 		}
-		return time.Date(year, t.Month(), t.Day(), t.Hour(), t.Minute(), t.Second(), t.Nanosecond(), time.UTC).Format(time.RFC3339)
+		return time.Date(
+			year,
+			parsed.Month(),
+			parsed.Day(),
+			parsed.Hour(),
+			parsed.Minute(),
+			parsed.Second(),
+			parsed.Nanosecond(),
+			local,
+		).UTC().Format(time.RFC3339)
 	}
 	return raw
 }

--- a/src/agent/internal/engine/managed_backup_test.go
+++ b/src/agent/internal/engine/managed_backup_test.go
@@ -1361,6 +1361,59 @@ func TestParseSnapshotBrowseOutputHandlesKopiaModeAndNestedPath(t *testing.T) {
 	}
 }
 
+func TestParseSnapshotBrowseOutputNormalizesCSTModifiedTimes(t *testing.T) {
+	shanghai, err := time.LoadLocation("Asia/Shanghai")
+	if err != nil {
+		t.Fatal(err)
+	}
+	previousLocal := time.Local
+	time.Local = shanghai
+	t.Cleanup(func() { time.Local = previousLocal })
+
+	for name, stdout := range map[string]string{
+		"json": `[{"name":"restore-check.txt","type":"file","modified_at":"2026-08-27 15:35:25 CST"}]`,
+		"text": `-rw-r--r-- 76 2026-08-27 15:35:25 CST object-id restore-check.txt`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			rows := parseSnapshotBrowseOutput(stdout, "", "snapshot-1")
+			if len(rows) != 1 {
+				t.Fatalf("rows = %d, want 1", len(rows))
+			}
+			if got := rows[0]["modified_at"]; got != "2026-08-27T07:35:25Z" {
+				t.Fatalf("modified_at = %v, want 2026-08-27T07:35:25Z", got)
+			}
+		})
+	}
+}
+
+func TestFormatModTimeUTCPreservesInstants(t *testing.T) {
+	shanghai, err := time.LoadLocation("Asia/Shanghai")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, test := range []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{name: "RFC3339 UTC", raw: "2026-08-27T07:35:25Z", want: "2026-08-27T07:35:25Z"},
+		{name: "RFC3339 offset", raw: "2026-08-27T15:35:25+08:00", want: "2026-08-27T07:35:25Z"},
+		{name: "explicit UTC", raw: "2026-08-27 07:35:25 UTC", want: "2026-08-27T07:35:25Z"},
+		{name: "local abbreviation", raw: "2026-08-27 15:35:25 CST", want: "2026-08-27T07:35:25Z"},
+		{name: "timezone omitted", raw: "2026-08-27 15:35:25", want: "2026-08-27T07:35:25Z"},
+		{name: "short local time", raw: "Aug 27 15:35", want: "2026-08-27T07:35:00Z"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := formatModTimeUTCInLocation(test.raw, shanghai); got != test.want {
+				t.Fatalf("formatModTimeUTCInLocation(%q) = %q, want %q", test.raw, got, test.want)
+			}
+		})
+	}
+	if got := formatModTimeUTCInLocation("2026-08-27 15:35:25 CST", time.UTC); got != "2026-08-27 15:35:25 CST" {
+		t.Fatalf("ambiguous non-local zone must be preserved, got %q", got)
+	}
+}
+
 func TestSnapshotScopeRecursiveLinesProduceTrustedTotals(t *testing.T) {
 	stdout := `drwx------            5 2026-08-12 11:15:59 CST object-dir sub/
 -rw-------            5 2026-08-12 11:15:59 CST object-file sub/b.txt
@@ -1535,7 +1588,7 @@ func TestSnapshotScopeSelectionIgnoresOtherEntries(t *testing.T) {
 	if selection.pathType != "file" || selection.sizeBytes != 42 {
 		t.Fatalf("unexpected selected file summary: %#v", selection)
 	}
-	if selection.modifiedAt != "2026-08-12 11:15:59 CST" {
+	if selection.modifiedAt != formatModTimeUTC("2026-08-12 11:15:59 CST") {
 		t.Fatalf("unexpected selected file timestamp: %#v", selection)
 	}
 }


### PR DESCRIPTION
## Summary

- normalize Kopia snapshot browser timestamps from JSON and text output
- resolve local timezone abbreviations against the Agent timezone without guessing mismatched abbreviations
- preserve RFC 3339 offsets and handle timezone-omitted short formats
- add regression coverage for CST, UTC, numeric offsets, and local timestamp formats

## Testing

- `go test ./internal/engine -count=1`
- `go vet ./internal/engine`
- `git diff --check origin/main...HEAD`

Closes #887