### PR TITLE
Fix PDF content negotiation for Insight Chat downloads

### DIFF
--- a/src/backend/apps/lens_bridge/api/negotiation.py
+++ b/src/backend/apps/lens_bridge/api/negotiation.py
@@ -1,0 +1,56 @@
+"""Content negotiation helpers for binary SourceLens proxy endpoints."""
+
+from __future__ import annotations
+
+from rest_framework.exceptions import NotAcceptable
+from rest_framework.negotiation import DefaultContentNegotiation
+
+
+class PDFDownloadContentNegotiation(DefaultContentNegotiation):
+    """Accept PDF download requests while retaining JSON error rendering.
+
+    The endpoint returns a Django ``StreamingHttpResponse`` on success, so no
+    renderer is needed for the PDF bytes themselves.  DRF still performs
+    content negotiation before the action runs, however.  When a client asks
+    specifically for ``application/pdf``, fall back to the normal JSON
+    renderer for error responses instead of rejecting the request with 406.
+    """
+
+    def select_renderer(self, request, renderers, format_suffix=None):
+        try:
+            return super().select_renderer(request, renderers, format_suffix)
+        except NotAcceptable:
+            if not self._requests_pdf(request):
+                raise
+            json_renderer = next(
+                (
+                    renderer
+                    for renderer in renderers
+                    if renderer.media_type == "application/json"
+                ),
+                None,
+            )
+            if json_renderer is None:
+                raise
+            return json_renderer, json_renderer.media_type
+
+    @staticmethod
+    def _requests_pdf(request) -> bool:
+        """Return whether the client explicitly accepts PDF with q > 0."""
+
+        for token in request.META.get("HTTP_ACCEPT", "*/*").split(","):
+            media_type, *parameters = token.strip().lower().split(";")
+            if media_type.strip() != "application/pdf":
+                continue
+            quality = 1.0
+            for parameter in parameters:
+                key, separator, value = parameter.strip().partition("=")
+                if separator and key == "q":
+                    try:
+                        quality = float(value)
+                    except ValueError:
+                        quality = 0.0
+                    break
+            if quality > 0:
+                return True
+        return False

--- a/src/backend/apps/lens_bridge/api/views.py
+++ b/src/backend/apps/lens_bridge/api/views.py
@@ -21,6 +21,7 @@ from apps.iam.permissions_org import (
     IsOrgWriter,
     get_membership,
 )
+from apps.lens_bridge.api.negotiation import PDFDownloadContentNegotiation
 from apps.lens_bridge.api.serializers import (
     LensAdmissionPreviewSerializer,
     LensChatBindingEnsureSerializer,
@@ -1738,6 +1739,7 @@ class LensCopilotSessionViewSet(OrgScopedMixin, viewsets.ViewSet):
         detail=True,
         methods=["get"],
         url_path=r"runs/(?P<run_uuid>[0-9a-fA-F-]+)/pdf",
+        content_negotiation_class=PDFDownloadContentNegotiation,
     )
     def run_pdf(self, request, pk=None, run_uuid=None):
         """Stream SourceLens' PDF for an answer owned by this HFL chat."""

--- a/src/backend/apps/lens_bridge/tests/test_copilot_sessions.py
+++ b/src/backend/apps/lens_bridge/tests/test_copilot_sessions.py
@@ -912,6 +912,7 @@ class CopilotSessionApiTests(TestCase):
                 "lens-copilot-session-run-pdf",
                 kwargs={"pk": self.session.pk, "run_uuid": run_uuid},
             ),
+            HTTP_ACCEPT="application/pdf",
             HTTP_X_ORG_KEY=self.org.key,
         )
 
@@ -939,11 +940,60 @@ class CopilotSessionApiTests(TestCase):
                 "lens-copilot-session-run-pdf",
                 kwargs={"pk": self.session.pk, "run_uuid": uuid.uuid4()},
             ),
+            HTTP_ACCEPT="application/pdf",
             HTTP_X_ORG_KEY=self.org.key,
         )
 
         self.assertEqual(response.status_code, 404)
+        self.assertEqual(response["Content-Type"], "application/json")
         stream_binary.assert_not_called()
+
+    @patch("apps.lens_bridge.api.views.sl_client.stream_binary")
+    @patch("apps.lens_bridge.api.views.sl_client.request_json")
+    def test_answer_pdf_upstream_error_is_json(
+        self,
+        request_json,
+        stream_binary,
+    ):
+        self._mark_session_ready()
+        run_uuid = uuid.uuid4()
+        request_json.return_value = [
+            {
+                "uuid": str(uuid.uuid4()),
+                "role": "assistant",
+                "run": str(run_uuid),
+                "content": "Answer",
+            }
+        ]
+        stream_binary.side_effect = sl_client.LensBridgeUnavailable()
+
+        response = self.client.get(
+            reverse(
+                "lens-copilot-session-run-pdf",
+                kwargs={"pk": self.session.pk, "run_uuid": run_uuid},
+            ),
+            HTTP_ACCEPT="application/pdf",
+            HTTP_X_ORG_KEY=self.org.key,
+        )
+
+        self.assertEqual(response.status_code, 503)
+        self.assertEqual(response["Content-Type"], "application/json")
+        stream_binary.assert_called_once_with(
+            f"/api/lens/runs/{run_uuid}/pdf/",
+            hfl_user=self.user,
+        )
+
+    def test_pdf_content_negotiation_is_limited_to_the_download_action(self):
+        response = self.client.get(
+            reverse(
+                "lens-copilot-session-sync",
+                kwargs={"pk": self.session.pk},
+            ),
+            HTTP_ACCEPT="application/pdf",
+            HTTP_X_ORG_KEY=self.org.key,
+        )
+
+        self.assertEqual(response.status_code, 406)
 
     @patch("apps.lens_bridge.api.views.sl_client.stream_sse")
     def test_run_stream_requires_the_run_bound_to_the_session(self, stream_sse):


### PR DESCRIPTION
## Summary

- accept `application/pdf` requests on the HFL Insight Chat PDF proxy
- preserve JSON error responses and keep the change scoped to the PDF action
- add regression coverage for successful downloads, upstream failures, unauthorized runs, and non-PDF endpoint isolation

## Validation

- full `apps.lens_bridge.tests.test_copilot_sessions` module: 56 passed
- targeted PDF regression tests: passed
- Ruff: passed
- Django system check: passed
- `git diff --check`: passed

This change keeps PDF generation and streaming owned by SourceLens and does not modify backup, restore, Chat lifecycle, or database behavior.