### PR TITLE
fix(agent): harden Windows detached lifecycle execution

### DIFF
--- a/src/agent/internal/engine/lifecycle.go
+++ b/src/agent/internal/engine/lifecycle.go
@@ -87,7 +87,9 @@ func (e *Engine) runAgentUpgrade(ctx context.Context, rep ReporterSink, taskID s
 		cfg.InstallationMode == model.InstallationModeUser || cfg.InstallationMode == model.InstallationModeUserContinuous,
 	); err != nil {
 		slog.Warn("detached upgrade schedule failed", "err", err, "upgrade_log", upgradeLog)
-		_ = os.RemoveAll(filepath.Dir(stagedArchive))
+		if !install.ShouldRetainDetachedLifecycleFiles(err) {
+			_ = os.RemoveAll(filepath.Dir(stagedArchive))
+		}
 		return "failed", nil, err.Error()
 	}
 	slog.Info("detached upgrade scheduled", "install_dir", installDir, "archive", stagedArchive, "upgrade_log", upgradeLog)

--- a/src/agent/internal/platform/install/detached_lifecycle_files.go
+++ b/src/agent/internal/platform/install/detached_lifecycle_files.go
@@ -1,0 +1,11 @@
+package install
+
+import "errors"
+
+var errDetachedRunnerMayOwnFiles = errors.New("detached lifecycle runner may own staged files")
+
+// ShouldRetainDetachedLifecycleFiles reports whether a failed launcher may
+// still start later and therefore needs its staged script and package intact.
+func ShouldRetainDetachedLifecycleFiles(err error) bool {
+	return errors.Is(err, errDetachedRunnerMayOwnFiles)
+}

--- a/src/agent/internal/platform/install/detached_lifecycle_files_test.go
+++ b/src/agent/internal/platform/install/detached_lifecycle_files_test.go
@@ -1,0 +1,20 @@
+package install
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestShouldRetainDetachedLifecycleFiles(t *testing.T) {
+	if ShouldRetainDetachedLifecycleFiles(nil) {
+		t.Fatal("nil error must not retain staged files")
+	}
+	if ShouldRetainDetachedLifecycleFiles(errors.New("launcher failed")) {
+		t.Fatal("ordinary launcher errors must not retain staged files")
+	}
+	owned := fmt.Errorf("start detached lifecycle: %w", errDetachedRunnerMayOwnFiles)
+	if !ShouldRetainDetachedLifecycleFiles(owned) {
+		t.Fatal("wrapped staged-file ownership errors must retain files")
+	}
+}

--- a/src/agent/internal/platform/install/detached_run_windows.go
+++ b/src/agent/internal/platform/install/detached_run_windows.go
@@ -15,6 +15,12 @@ import (
 const (
 	windowsCreateNewProcessGroup  = 0x00000200
 	windowsCreateBreakawayFromJob = 0x01000000
+	windowsTaskStaleGraceSeconds  = 30
+)
+
+var (
+	errWindowsTaskRunnerConflict     = errors.New("detached lifecycle runner conflict")
+	errWindowsTaskRunnerStateUnknown = errors.New("detached lifecycle runner state could not be verified")
 )
 
 func psSingleQuote(value string) string {
@@ -36,6 +42,12 @@ func startWindowsDetachedScript(scriptPath string, userInstall bool, logFn func(
 	schedulerErr := scheduleWindowsTaskRunner(scriptPath, userInstall, logFn)
 	if schedulerErr == nil {
 		return nil
+	}
+	if errors.Is(schedulerErr, errWindowsTaskRunnerConflict) ||
+		errors.Is(schedulerErr, errWindowsTaskRunnerStateUnknown) {
+		// Never fall back to a second process while a scheduled task may still
+		// exist. The fallback could race an existing lifecycle runner.
+		return schedulerErr
 	} else if logFn != nil {
 		logFn(fmt.Sprintf("Task Scheduler launch unavailable; trying detached process: %v", schedulerErr))
 	}
@@ -80,22 +92,7 @@ func scheduleWindowsTaskRunner(scriptPath string, userInstall bool, logFn func(s
 	if scriptPath == "" {
 		return fmt.Errorf("script path required")
 	}
-	principal := scheduledTaskPrincipal(userInstall)
-	userInstallFlag := "$false"
-	if userInstall {
-		userInstallFlag = "$true"
-	}
-	bootstrap := fmt.Sprintf(`$userInstall = %s
-$currentSid = [Security.Principal.WindowsIdentity]::GetCurrent().User.Value
-$taskName = if ($userInstall) { "HyperFileLensAgent.User.$currentSid.DetachedRunner" } else { 'HyperFileLensAgent.DetachedRunner' }
-$script = %s
-$actionArgs = "-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File " + [char]34 + $script + [char]34
-$action = New-ScheduledTaskAction -Execute 'powershell.exe' -Argument $actionArgs
-$trigger = New-ScheduledTaskTrigger -Once -At (Get-Date).AddSeconds(5)
-%s
-$settings = New-ScheduledTaskSettingsSet -StartWhenAvailable -ExecutionTimeLimit ([TimeSpan]::Zero)
-Register-ScheduledTask -TaskName $taskName -Action $action -Trigger $trigger -Principal $principal -Settings $settings -Force | Out-Null
-`, userInstallFlag, psSingleQuote(scriptPath), principal)
+	bootstrap := windowsTaskRunnerBootstrap(scriptPath, userInstall)
 	cmd := exec.Command(
 		"powershell.exe",
 		"-NoProfile",
@@ -106,14 +103,178 @@ Register-ScheduledTask -TaskName $taskName -Action $action -Trigger $trigger -Pr
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		if logFn != nil {
-			logFn(fmt.Sprintf("Task Scheduler fallback registration failed: %v (%s)", err, strings.TrimSpace(string(output))))
+			logFn(fmt.Sprintf("Task Scheduler launch failed: %v (%s)", err, strings.TrimSpace(string(output))))
 		}
-		return fmt.Errorf("register one-shot upgrade task: %w", err)
+		return classifyWindowsTaskRunnerError(err, string(output))
 	}
 	if logFn != nil {
-		logFn("registered instance-scoped one-shot Task Scheduler lifecycle runner")
+		if strings.Contains(string(output), "HFL_TASK_START_DEFERRED") {
+			logFn("registered instance-scoped Task Scheduler lifecycle runner; immediate start was unavailable, retaining the one-shot trigger")
+		} else {
+			logFn("registered and started instance-scoped one-shot Task Scheduler lifecycle runner")
+		}
 	}
 	return nil
+}
+
+func classifyWindowsTaskRunnerError(err error, output string) error {
+	detail := strings.TrimSpace(output)
+	if strings.Contains(output, "HFL_DETACHED_RUNNER_CONFLICT") {
+		if strings.Contains(output, "HFL_TASK_REFERENCES_SCRIPT") {
+			return fmt.Errorf("%w: %w: %s", errWindowsTaskRunnerConflict, errDetachedRunnerMayOwnFiles, detail)
+		}
+		return fmt.Errorf("%w: %s", errWindowsTaskRunnerConflict, detail)
+	}
+	if strings.Contains(output, "HFL_TASK_STATE_UNKNOWN") {
+		return fmt.Errorf("%w: %w: %s", errWindowsTaskRunnerStateUnknown, errDetachedRunnerMayOwnFiles, detail)
+	}
+	return fmt.Errorf("register one-shot lifecycle task: %w", err)
+}
+
+func windowsTaskRunnerBootstrap(scriptPath string, userInstall bool) string {
+	userInstallFlag := "$false"
+	if userInstall {
+		userInstallFlag = "$true"
+	}
+	principal := scheduledTaskPrincipal(userInstall)
+	return fmt.Sprintf(`$userInstall = %s
+$currentSid = [Security.Principal.WindowsIdentity]::GetCurrent().User.Value
+$taskName = if ($userInstall) { "HyperFileLensAgent.User.$currentSid.DetachedRunner" } else { 'HyperFileLensAgent.DetachedRunner' }
+$script = %s
+$actionArgs = "-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File " + [char]34 + $script + [char]34
+$action = New-ScheduledTaskAction -Execute 'powershell.exe' -Argument $actionArgs
+$trigger = New-ScheduledTaskTrigger -Once -At (Get-Date).AddSeconds(5)
+%s
+$settings = New-ScheduledTaskSettingsSet -StartWhenAvailable -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -ExecutionTimeLimit ([TimeSpan]::Zero) -MultipleInstances IgnoreNew
+$staleBefore = (Get-Date).AddSeconds(-%d)
+$conflict = $false
+$taskStateUnknown = $false
+$taskReferencesScript = $false
+function Get-HflDetachedRunnerTask {
+  try {
+    $matches = @(Get-ScheduledTask -ErrorAction Stop | Where-Object {
+      $_.TaskName -eq $taskName -and $_.TaskPath -eq '\'
+    })
+  }
+  catch {
+    $script:taskStateUnknown = $true
+    throw "HFL_TASK_STATE_UNKNOWN: could not query task ${taskName}: $($_.Exception.Message)"
+  }
+  if ($matches.Count -gt 1) {
+    $script:taskStateUnknown = $true
+    throw "HFL_TASK_STATE_UNKNOWN: multiple root tasks named $taskName were returned"
+  }
+  if ($matches.Count -eq 1) { return $matches[0] }
+  return $null
+}
+function Get-HflDetachedRunnerTaskInfo {
+  try {
+    return Get-ScheduledTaskInfo -TaskName $taskName -TaskPath '\' -ErrorAction Stop
+  }
+  catch {
+    $script:taskStateUnknown = $true
+    throw "HFL_TASK_STATE_UNKNOWN: could not query task information for ${taskName}: $($_.Exception.Message)"
+  }
+}
+function Test-HflDetachedRunnerTaskAction($task) {
+  if ($null -eq $task) { return $false }
+  $quotedScript = [char]34 + $script + [char]34
+  foreach ($taskAction in @($task.Actions)) {
+    $arguments = [string]$taskAction.Arguments
+    if ($arguments.IndexOf($quotedScript, [System.StringComparison]::OrdinalIgnoreCase) -ge 0) {
+      return $true
+    }
+  }
+  return $false
+}
+try {
+  $existing = Get-HflDetachedRunnerTask
+  if ($null -ne $existing) {
+    $taskReferencesScript = Test-HflDetachedRunnerTaskAction $existing
+    $state = [string]$existing.State
+    if ($state -in @('Running', 'Queued')) {
+      $conflict = $true
+      throw "HFL_DETACHED_RUNNER_CONFLICT: task $taskName is $state"
+    }
+    if ($state -notin @('Ready', 'Disabled')) {
+      $conflict = $true
+      throw "HFL_DETACHED_RUNNER_CONFLICT: task $taskName is $state"
+    }
+    if ($state -eq 'Ready') {
+      # Ready also describes a newly registered task waiting for its trigger.
+      # Reclaim it only after Task Scheduler records a completed run outside
+      # the startup race window. Disabled tasks cannot start and are safe to
+      # replace without relying on prior-run metadata.
+      $taskInfo = Get-HflDetachedRunnerTaskInfo
+      if ($null -eq $taskInfo.LastRunTime -or $taskInfo.LastRunTime.Year -lt 2000 -or $taskInfo.LastRunTime -gt $staleBefore) {
+        $conflict = $true
+        throw "HFL_DETACHED_RUNNER_CONFLICT: task $taskName is ready but has not completed a stale run"
+      }
+    }
+    try {
+      Unregister-ScheduledTask -TaskName $taskName -TaskPath '\' -Confirm:$false -ErrorAction Stop
+    }
+    catch {
+      $conflict = $true
+      throw "HFL_DETACHED_RUNNER_CONFLICT: inactive task $taskName could not be removed: $($_.Exception.Message)"
+    }
+    if ($null -ne (Get-HflDetachedRunnerTask)) {
+      $conflict = $true
+      throw "HFL_DETACHED_RUNNER_CONFLICT: inactive task $taskName still exists after removal"
+    }
+  }
+  try {
+    Register-ScheduledTask -TaskName $taskName -TaskPath '\' -Action $action -Trigger $trigger -Principal $principal -Settings $settings -ErrorAction Stop | Out-Null
+  }
+  catch {
+    $registrationError = $_
+    # A cmdlet failure can be returned after the scheduler accepted the task.
+    # Continue with that task instead of starting a second process.
+    $registered = Get-HflDetachedRunnerTask
+    if ($null -eq $registered) {
+      throw $registrationError
+    }
+    if (-not (Test-HflDetachedRunnerTaskAction $registered)) {
+      $conflict = $true
+      throw "HFL_DETACHED_RUNNER_CONFLICT: task $taskName does not reference the requested lifecycle script"
+    }
+    $taskReferencesScript = $true
+    Write-Output "HFL_TASK_REGISTRATION_CONFIRMED_AFTER_ERROR: $($registrationError.Exception.Message)"
+  }
+  # Start explicitly so the runner is not dependent on the Agent remaining
+  # alive until the one-shot trigger is observed. If this request is
+  # inconclusive, retain the registered trigger instead of launching a second
+  # runner through Start-Process.
+  try {
+    Start-ScheduledTask -TaskName $taskName -TaskPath '\' -ErrorAction Stop
+    Write-Output 'HFL_TASK_STARTED'
+  }
+  catch {
+    $startError = $_
+    $deferred = Get-HflDetachedRunnerTask
+    if ($null -eq $deferred) {
+      throw $startError
+    }
+    if (-not (Test-HflDetachedRunnerTaskAction $deferred)) {
+      $conflict = $true
+      throw "HFL_DETACHED_RUNNER_CONFLICT: deferred task $taskName does not reference the requested lifecycle script"
+    }
+    $taskReferencesScript = $true
+    $deferredState = [string]$deferred.State
+    if ($deferredState -notin @('Ready', 'Running', 'Queued')) {
+      $conflict = $true
+      throw "HFL_DETACHED_RUNNER_CONFLICT: deferred task $taskName cannot run from state $deferredState"
+    }
+    Write-Output "HFL_TASK_START_DEFERRED: $($startError.Exception.Message)"
+  }
+}
+catch {
+  if ($conflict) { Write-Output 'HFL_DETACHED_RUNNER_CONFLICT' }
+  if ($taskStateUnknown) { Write-Output 'HFL_TASK_STATE_UNKNOWN' }
+  if ($taskReferencesScript) { Write-Output 'HFL_TASK_REFERENCES_SCRIPT' }
+  throw
+}
+`, userInstallFlag, psSingleQuote(scriptPath), principal, windowsTaskStaleGraceSeconds)
 }
 
 func scheduledTaskPrincipal(userInstall bool) string {

--- a/src/agent/internal/platform/install/detached_run_windows_test.go
+++ b/src/agent/internal/platform/install/detached_run_windows_test.go
@@ -3,6 +3,9 @@
 package install
 
 import (
+	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -31,5 +34,98 @@ func TestScheduledTaskPrincipalMatchesInstallationMode(t *testing.T) {
 		!strings.Contains(systemPrincipal, "-LogonType ServiceAccount") ||
 		!strings.Contains(systemPrincipal, "-RunLevel Highest") {
 		t.Fatalf("system task principal is not SYSTEM/service-account/highest: %s", systemPrincipal)
+	}
+}
+
+func TestWindowsTaskRunnerBootstrapStartsTaskAndPreventsDuplicateInstances(t *testing.T) {
+	body := windowsTaskRunnerBootstrap(`C:\Temp\run-uninstall.ps1`, true)
+	for _, want := range []string{
+		"Register-ScheduledTask",
+		"Start-ScheduledTask -TaskName $taskName -TaskPath '\\'",
+		"-MultipleInstances IgnoreNew",
+		"-AllowStartIfOnBatteries",
+		"-DontStopIfGoingOnBatteries",
+		"HFL_TASK_STARTED",
+		"HFL_TASK_START_DEFERRED",
+		"HFL_TASK_REGISTRATION_CONFIRMED_AFTER_ERROR",
+		"HFL_TASK_STATE_UNKNOWN",
+		"HFL_TASK_REFERENCES_SCRIPT",
+		"HFL_DETACHED_RUNNER_CONFLICT",
+		"Test-HflDetachedRunnerTaskAction $registered",
+		"Test-HflDetachedRunnerTaskAction $deferred",
+		"$deferredState -notin @('Ready', 'Running', 'Queued')",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("Windows task runner bootstrap missing %q:\n%s", want, body)
+		}
+	}
+}
+
+func TestWindowsTaskRunnerBootstrapParses(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "detached-runner-bootstrap.ps1")
+	body := windowsTaskRunnerBootstrap(`C:\Temp\run-uninstall.ps1`, true)
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write detached runner bootstrap: %v", err)
+	}
+	assertPowerShellParses(t, path)
+}
+
+func TestWindowsDetachedTaskScriptCleanupDecision(t *testing.T) {
+	conflict := classifyWindowsTaskRunnerError(errors.New("exit status 1"), "HFL_DETACHED_RUNNER_CONFLICT")
+	if ShouldRetainDetachedLifecycleFiles(conflict) {
+		t.Fatal("a conflicting task that references another script must not retain the requested script")
+	}
+	owned := classifyWindowsTaskRunnerError(errors.New("exit status 1"), "HFL_DETACHED_RUNNER_CONFLICT HFL_TASK_REFERENCES_SCRIPT")
+	if !ShouldRetainDetachedLifecycleFiles(owned) {
+		t.Fatal("a task that references the requested script must retain it")
+	}
+	unknown := classifyWindowsTaskRunnerError(errors.New("exit status 1"), "HFL_TASK_STATE_UNKNOWN")
+	if !ShouldRetainDetachedLifecycleFiles(unknown) {
+		t.Fatal("an unknown task state must conservatively retain staged files")
+	}
+}
+
+func TestWindowsTaskRunnerBootstrapQueriesTaskStateStrictly(t *testing.T) {
+	body := windowsTaskRunnerBootstrap(`C:\Temp\run-uninstall.ps1`, true)
+	if strings.Contains(body, "Get-ScheduledTask -TaskName $taskName -ErrorAction SilentlyContinue") {
+		t.Fatalf("task lookup must not treat scheduler errors as an absent task:\n%s", body)
+	}
+	for _, want := range []string{
+		"Get-ScheduledTask -ErrorAction Stop",
+		"$_.TaskName -eq $taskName",
+		"$_.TaskPath -eq '\\'",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("strict task lookup missing %q:\n%s", want, body)
+		}
+	}
+	if strings.Contains(body, "Register-ScheduledTask -TaskName $taskName -TaskPath '\\' -Action $action -Trigger $trigger -Principal $principal -Settings $settings -Force") {
+		t.Fatalf("task registration must not force-overwrite a task created after the conflict check:\n%s", body)
+	}
+}
+
+func TestWindowsTaskRunnerBootstrapRetainsTriggerWhenImmediateStartFails(t *testing.T) {
+	body := windowsTaskRunnerBootstrap(`C:\Temp\run-upgrade.ps1`, false)
+	registerAt := strings.Index(body, "    Register-ScheduledTask")
+	startAt := strings.Index(body, "Start-ScheduledTask -TaskName $taskName -TaskPath '\\'")
+	deferredAt := strings.Index(body, "HFL_TASK_START_DEFERRED")
+	if registerAt < 0 || startAt <= registerAt || deferredAt <= startAt {
+		t.Fatalf("task must be registered before explicit start and preserve its trigger on an inconclusive start:\n%s", body)
+	}
+}
+
+func TestWindowsTaskRunnerBootstrapRejectsActiveTask(t *testing.T) {
+	body := windowsTaskRunnerBootstrap(`C:\Temp\run-upgrade.ps1`, true)
+	for _, want := range []string{
+		"if ($state -in @('Running', 'Queued'))",
+		"if ($state -notin @('Ready', 'Disabled'))",
+		"if ($state -eq 'Ready')",
+		"Get-ScheduledTaskInfo -TaskName $taskName -TaskPath '\\' -ErrorAction Stop",
+		"$taskInfo.LastRunTime.Year -lt 2000",
+		"$taskInfo.LastRunTime -gt $staleBefore",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("unsafe task replacement guard missing %q:\n%s", want, body)
+		}
 	}
 }

--- a/src/agent/internal/platform/install/local_uninstall_windows.go
+++ b/src/agent/internal/platform/install/local_uninstall_windows.go
@@ -58,6 +58,7 @@ func ScheduleDetachedUninstall(
 		completion,
 		scriptPath,
 	); err != nil {
+		_ = os.Remove(scriptPath)
 		if logDir != "" {
 			_ = AppendUninstallLog(logDir, fmt.Sprintf("failed to write uninstall script: %v", err))
 		}
@@ -69,6 +70,9 @@ func ScheduleDetachedUninstall(
 		}
 	}
 	if err := startWindowsDetachedScript(scriptPath, userInstall, logFn); err != nil {
+		if !ShouldRetainDetachedLifecycleFiles(err) {
+			_ = os.Remove(scriptPath)
+		}
 		return fmt.Errorf("start detached uninstall: %w", err)
 	}
 	return nil
@@ -485,7 +489,7 @@ try {
 }
 
 Report-UninstallCompletion
-Unregister-ScheduledTask -TaskName $scheduledTaskName -Confirm:$false -ErrorAction SilentlyContinue
+Unregister-ScheduledTask -TaskName $scheduledTaskName -TaskPath '\' -Confirm:$false -ErrorAction SilentlyContinue
 Remove-Item -LiteralPath $PSCommandPath -Force -ErrorAction SilentlyContinue
 if ($cleanupFailures.Count -eq 0) {
   exit 0

--- a/src/agent/internal/platform/install/local_uninstall_windows_test.go
+++ b/src/agent/internal/platform/install/local_uninstall_windows_test.go
@@ -234,6 +234,7 @@ func TestWriteWindowsUserUninstallScriptUsesCurrentUserLifecycle(t *testing.T) {
 		`@('hfl-agent', 'hfl-agent-user-launcher', 'kopia')`,
 		`Get-ScheduledTask -TaskName $runtimeTaskName`,
 		`Unregister-ScheduledTask -TaskName $runtimeTaskName`,
+		`Unregister-ScheduledTask -TaskName $scheduledTaskName -TaskPath '\'`,
 		`Join-Path $env:LOCALAPPDATA 'HyperFileLens\Agent'`,
 		`return $full.Equals($expected, [System.StringComparison]::OrdinalIgnoreCase)`,
 	} {
@@ -268,7 +269,11 @@ func TestWriteWindowsUserUpgradeScriptStopsScheduledTask(t *testing.T) {
 		"Stop-ScheduledTask -TaskName $runtimeTaskName",
 		"$agentRoot = Split-Path -Parent $install",
 		"$scheduledTaskName = if ($userInstall) { \"$runtimeTaskName.DetachedRunner\" }",
-		"Unregister-ScheduledTask -TaskName $scheduledTaskName",
+		"$upgradeSucceeded = $false",
+		"} finally {",
+		"Unregister-ScheduledTask -TaskName $scheduledTaskName -TaskPath '\\'",
+		"if ($null -eq $rc -or $rc -eq 0) { $rc = 1 }",
+		"Set-Content -LiteralPath (Join-Path $pending 'FAILED')",
 	} {
 		if !strings.Contains(text, expected) {
 			t.Fatalf("user upgrade script missing %q", expected)

--- a/src/agent/internal/platform/install/local_upgrade_windows.go
+++ b/src/agent/internal/platform/install/local_upgrade_windows.go
@@ -41,6 +41,7 @@ func ScheduleDetachedUpgrade(
 		userInstall,
 		scriptPath,
 	); err != nil {
+		_ = os.Remove(scriptPath)
 		if logDir != "" {
 			_ = AppendUpgradeLog(logDir, fmt.Sprintf("failed to write upgrade script: %v", err))
 		}
@@ -52,6 +53,9 @@ func ScheduleDetachedUpgrade(
 		}
 	}
 	if err := startWindowsDetachedScript(scriptPath, userInstall, logFn); err != nil {
+		if !ShouldRetainDetachedLifecycleFiles(err) {
+			_ = os.Remove(scriptPath)
+		}
 		logFn(fmt.Sprintf("failed to start detached upgrade script: %v", err))
 		return fmt.Errorf("start detached upgrade: %w", err)
 	}
@@ -88,17 +92,17 @@ function Log([string]$msg) {
 
 Log "detached upgrade script started archive=$archive"
 $ErrorActionPreference = 'Continue'
+$rc = 1
+$upgradeSucceeded = $false
 try {
   Start-Sleep -Seconds $SLEEP_SECONDS
   Log "delay elapsed; running upgrade"
 
   if (-not (Test-Path -LiteralPath $install)) {
-    Log "install.ps1 missing at $install"
-    exit 1
+    throw "install.ps1 missing at $install"
   }
   if (-not (Test-Path -LiteralPath $archive)) {
-    Log "archive missing at $archive"
-    exit 1
+    throw "archive missing at $archive"
   }
 
   Log "running install.ps1 upgrade"
@@ -109,18 +113,24 @@ try {
   }
   $rc = $LASTEXITCODE
   if ($rc -ne 0) {
-    Log "install.ps1 upgrade failed exit=$rc"
-    exit $rc
+    throw "install.ps1 upgrade failed exit=$rc"
   }
+  $upgradeSucceeded = $true
   Log "install.ps1 upgrade succeeded"
-  Remove-Item -Recurse -Force -LiteralPath $pending -ErrorAction SilentlyContinue
-	Unregister-ScheduledTask -TaskName $scheduledTaskName -Confirm:$false -ErrorAction SilentlyContinue
-  Log "detached upgrade script finished"
-  exit 0
 } catch {
   Log "install.ps1 upgrade failed: $($_.Exception.Message)"
-  exit 1
+  if ($null -eq $rc -or $rc -eq 0) { $rc = 1 }
+} finally {
+  Unregister-ScheduledTask -TaskName $scheduledTaskName -TaskPath '\' -Confirm:$false -ErrorAction SilentlyContinue
 }
+
+if ($upgradeSucceeded) {
+  Log "detached upgrade script finished"
+  Remove-Item -Recurse -Force -LiteralPath $pending -ErrorAction SilentlyContinue
+  exit 0
+}
+Set-Content -LiteralPath (Join-Path $pending 'FAILED') -Value 'failed' -Encoding ASCII -ErrorAction SilentlyContinue
+exit $rc
 `,
 		logFile,
 		installScript,

--- a/src/agent/internal/platform/install/staging.go
+++ b/src/agent/internal/platform/install/staging.go
@@ -27,7 +27,9 @@ func StageUpgradeArchive(dataDir, archivePath string) (string, error) {
 		return "", fmt.Errorf("archive path required")
 	}
 	pendingDir := LifecycleUpgradeDir(dataDir)
-	_ = os.RemoveAll(pendingDir)
+	if err := os.RemoveAll(pendingDir); err != nil {
+		return "", fmt.Errorf("clear staged upgrade directory: %w", err)
+	}
 	if err := os.MkdirAll(pendingDir, 0o750); err != nil {
 		return "", err
 	}


### PR DESCRIPTION
## Summary

- start Windows detached upgrade and uninstall runners explicitly through Task Scheduler while retaining the one-shot trigger as a fallback
- prevent duplicate or ambiguous lifecycle runners and preserve staged files only when a scheduled task may still reference them
- record detached upgrade failures durably, clean up temporary tasks precisely, and reject partial staging cleanup

## Root cause

A current-user Agent could terminate with its parent task before the detached uninstall runner completed. The control plane then removed the registration while Windows installation artifacts remained, so enrolling the host into another organization failed with an existing-installation identity mismatch.

## Validation

- `go test ./...`
- `go vet ./...`
- Windows installer and engine test cross-compilation
- Windows Agent cross-build and targeted `go vet`
- Linux Agent cross-build
- `git diff --check`

Fixes #900