### PR TITLE
Harden Chat cleanup lifecycle

### DIFF
--- a/src/agent/internal/engine/lens_prepare.go
+++ b/src/agent/internal/engine/lens_prepare.go
@@ -8,11 +8,18 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 )
 
 const lensWorkspaceIdentityKind = "managed_restore"
+
+const (
+	lensWorkspaceTombstoneRetiring = "retiring"
+	lensWorkspaceTombstoneRetired  = "retired"
+	lensWorkspaceLockTimeout       = 30 * time.Second
+)
 
 var removeLensWorkspaceTrash = os.RemoveAll
 
@@ -25,14 +32,27 @@ type lensWorkspaceIdentity struct {
 	WorkspaceKind        string `json:"workspace_kind"`
 }
 
+type lensWorkspaceTombstone struct {
+	Version       int                   `json:"version"`
+	State         string                `json:"state"`
+	Identity      lensWorkspaceIdentity `json:"identity"`
+	WorkspacePath string                `json:"workspace_path"`
+	CreatedAt     string                `json:"created_at"`
+	UpdatedAt     string                `json:"updated_at"`
+}
+
 type lensWorkspacePaths struct {
-	Root         string
-	Workspace    string
-	MetadataRoot string
-	IdentityRoot string
-	Identity     string
-	TrashRoot    string
-	Trash        string
+	Root          string
+	Workspace     string
+	MetadataRoot  string
+	IdentityRoot  string
+	Identity      string
+	TombstoneRoot string
+	Tombstone     string
+	LockRoot      string
+	Lock          string
+	TrashRoot     string
+	Trash         string
 }
 
 func lensWorkspaceIdentityFromPayload(p Payload) (lensWorkspaceIdentity, error) {
@@ -86,23 +106,35 @@ func resolveLensWorkspacePaths(path, workspaceRoot, workspaceUID string) (lensWo
 	}
 	metadataRoot := filepath.Join(filepath.Dir(cleanRoot), ".hyperfilelens")
 	identityRoot := filepath.Join(metadataRoot, "identities")
+	tombstoneRoot := filepath.Join(metadataRoot, "tombstones")
+	lockRoot := filepath.Join(metadataRoot, "locks")
 	// Quarantine must stay below the workspace root so rename remains atomic
 	// when the workspace root is a dedicated filesystem mount.
 	trashRoot := filepath.Join(cleanRoot, lensWorkspaceTrashDirectory)
 	return lensWorkspacePaths{
-		Root:         cleanRoot,
-		Workspace:    cleanPath,
-		MetadataRoot: metadataRoot,
-		IdentityRoot: identityRoot,
-		Identity:     filepath.Join(identityRoot, workspaceUID+".json"),
-		TrashRoot:    trashRoot,
-		Trash:        filepath.Join(trashRoot, workspaceUID),
+		Root:          cleanRoot,
+		Workspace:     cleanPath,
+		MetadataRoot:  metadataRoot,
+		IdentityRoot:  identityRoot,
+		Identity:      filepath.Join(identityRoot, workspaceUID+".json"),
+		TombstoneRoot: tombstoneRoot,
+		Tombstone:     filepath.Join(tombstoneRoot, workspaceUID+".json"),
+		LockRoot:      lockRoot,
+		Lock:          filepath.Join(lockRoot, workspaceUID+".lock"),
+		TrashRoot:     trashRoot,
+		Trash:         filepath.Join(trashRoot, workspaceUID),
 	}, nil
 }
 
 func ensureLensMetadataLayout(paths lensWorkspacePaths) error {
 	base := filepath.Dir(paths.Root)
-	for _, path := range []string{paths.MetadataRoot, paths.IdentityRoot, paths.TrashRoot} {
+	for _, path := range []string{
+		paths.MetadataRoot,
+		paths.IdentityRoot,
+		paths.TombstoneRoot,
+		paths.LockRoot,
+		paths.TrashRoot,
+	} {
 		if _, _, err := secureEnsureDirectory(path, base, 0o700); err != nil {
 			return fmt.Errorf("create protected gateway metadata: %w", err)
 		}
@@ -111,6 +143,100 @@ func ensureLensMetadataLayout(paths lensWorkspacePaths) error {
 		}
 	}
 	return nil
+}
+
+func readLensWorkspaceTombstone(path string) (lensWorkspaceTombstone, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return lensWorkspaceTombstone{}, err
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+		return lensWorkspaceTombstone{}, errors.New("managed workspace tombstone is not a regular file")
+	}
+	encoded, err := os.ReadFile(path)
+	if err != nil {
+		return lensWorkspaceTombstone{}, err
+	}
+	var tombstone lensWorkspaceTombstone
+	if err := json.Unmarshal(encoded, &tombstone); err != nil {
+		return lensWorkspaceTombstone{}, errors.New("managed workspace tombstone is invalid")
+	}
+	if tombstone.Version != 1 ||
+		(tombstone.State != lensWorkspaceTombstoneRetiring && tombstone.State != lensWorkspaceTombstoneRetired) {
+		return lensWorkspaceTombstone{}, errors.New("managed workspace tombstone has an unsupported state")
+	}
+	return tombstone, nil
+}
+
+func validateLensWorkspaceTombstone(
+	tombstone lensWorkspaceTombstone,
+	identity lensWorkspaceIdentity,
+	workspacePath string,
+) error {
+	if tombstone.Identity != identity || tombstone.WorkspacePath != workspacePath {
+		return errors.New("managed workspace tombstone identity does not match")
+	}
+	return nil
+}
+
+func writeLensWorkspaceTombstone(
+	path string,
+	tombstone lensWorkspaceTombstone,
+) error {
+	encoded, err := json.Marshal(tombstone)
+	if err != nil {
+		return err
+	}
+	file, err := os.CreateTemp(filepath.Dir(path), ".workspace-tombstone-*")
+	if err != nil {
+		return err
+	}
+	temporary := file.Name()
+	complete := false
+	defer func() {
+		_ = file.Close()
+		if !complete {
+			_ = os.Remove(temporary)
+		}
+	}()
+	if err := file.Chmod(0o600); err != nil {
+		return err
+	}
+	if _, err := file.Write(encoded); err != nil {
+		return err
+	}
+	if err := file.Sync(); err != nil {
+		return err
+	}
+	if err := file.Close(); err != nil {
+		return err
+	}
+	if err := replaceLensWorkspaceTombstone(temporary, path); err != nil {
+		return err
+	}
+	complete = true
+	return nil
+}
+
+func newLensWorkspaceTombstone(
+	identity lensWorkspaceIdentity,
+	workspacePath string,
+	state string,
+	existing *lensWorkspaceTombstone,
+) lensWorkspaceTombstone {
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	createdAt := now
+	if existing != nil && existing.CreatedAt != "" {
+		createdAt = existing.CreatedAt
+	}
+	return lensWorkspaceTombstone{
+		Version:       1,
+		State:         state,
+		Identity:      identity,
+		WorkspacePath: workspacePath,
+		CreatedAt:     createdAt,
+		UpdatedAt:     now,
+	}
 }
 
 func readLensWorkspaceIdentity(identityPath string) (lensWorkspaceIdentity, error) {
@@ -242,47 +368,69 @@ func (e *Engine) runLensKsPrepare(ctx context.Context, p Payload) (string, map[s
 	if err := ensureLensMetadataLayout(paths); err != nil {
 		return "failed", nil, err.Error()
 	}
-	existing, err := readLensWorkspaceIdentity(paths.Identity)
-	if err == nil {
-		if existing != identity {
-			return "failed", nil, "managed workspace identity does not match"
-		}
-		cleanPath, created, ensureErr := secureEnsureDirectory(
-			paths.Workspace,
-			paths.Root,
-			0o755,
-		)
-		if ensureErr != nil {
-			return "failed", nil, ensureErr.Error()
-		}
-		return "success", map[string]any{"path": cleanPath, "created": created}, ""
-	}
-	if !os.IsNotExist(err) {
-		return "failed", nil, err.Error()
-	}
-	if _, statErr := os.Lstat(paths.Workspace); statErr == nil {
-		return "failed", nil, "refusing to claim an existing workspace without identity"
-	} else if !os.IsNotExist(statErr) {
-		return "failed", nil, statErr.Error()
-	}
-	// The durable identity is the creation journal. If the process exits before
-	// the directory is created, a retry can safely complete the matching claim.
-	if err := writeLensWorkspaceIdentity(paths.Identity, identity); err != nil {
-		if os.IsExist(err) {
-			existing, readErr := readLensWorkspaceIdentity(paths.Identity)
-			if readErr != nil || existing != identity {
-				return "failed", nil, "managed workspace identity does not match"
+	lockContext, cancel := context.WithTimeout(ctx, lensWorkspaceLockTimeout)
+	defer cancel()
+	var result map[string]any
+	err = withLensWorkspaceLock(lockContext, paths.Lock, func() error {
+		tombstone, tombstoneErr := readLensWorkspaceTombstone(paths.Tombstone)
+		if tombstoneErr == nil {
+			if err := validateLensWorkspaceTombstone(tombstone, identity, paths.Workspace); err != nil {
+				return err
 			}
-		} else {
-			return "failed", nil, err.Error()
+			return errors.New("managed workspace UID has been retired")
 		}
-	}
-	cleanPath, created, err := secureEnsureDirectory(paths.Workspace, paths.Root, 0o755)
+		if !os.IsNotExist(tombstoneErr) {
+			return tombstoneErr
+		}
+
+		existing, identityErr := readLensWorkspaceIdentity(paths.Identity)
+		if identityErr == nil {
+			if existing != identity {
+				return errors.New("managed workspace identity does not match")
+			}
+			cleanPath, created, ensureErr := secureEnsureDirectory(
+				paths.Workspace,
+				paths.Root,
+				0o755,
+			)
+			if ensureErr != nil {
+				return ensureErr
+			}
+			result = map[string]any{"path": cleanPath, "created": created}
+			return nil
+		}
+		if !os.IsNotExist(identityErr) {
+			return identityErr
+		}
+		if _, statErr := os.Lstat(paths.Workspace); statErr == nil {
+			return errors.New("refusing to claim an existing workspace without identity")
+		} else if !os.IsNotExist(statErr) {
+			return statErr
+		}
+		// The durable identity is the creation journal. If the process exits before
+		// the directory is created, a retry can safely complete the matching claim.
+		if err := writeLensWorkspaceIdentity(paths.Identity, identity); err != nil {
+			if os.IsExist(err) {
+				existing, readErr := readLensWorkspaceIdentity(paths.Identity)
+				if readErr != nil || existing != identity {
+					return errors.New("managed workspace identity does not match")
+				}
+			} else {
+				return err
+			}
+		}
+		cleanPath, created, ensureErr := secureEnsureDirectory(paths.Workspace, paths.Root, 0o755)
+		if ensureErr != nil {
+			// Keep the matching identity as a recovery journal for the next retry.
+			return ensureErr
+		}
+		result = map[string]any{"path": cleanPath, "created": created}
+		return nil
+	})
 	if err != nil {
-		// Keep the matching identity as a recovery journal for the next retry.
 		return "failed", nil, err.Error()
 	}
-	return "success", map[string]any{"path": cleanPath, "created": created}, ""
+	return "success", result, ""
 }
 
 func (e *Engine) runLensKsCleanup(ctx context.Context, p Payload) (string, map[string]any, string) {
@@ -297,50 +445,130 @@ func (e *Engine) runLensKsCleanup(ctx context.Context, p Payload) (string, map[s
 	if err != nil {
 		return "failed", nil, err.Error()
 	}
-	workspaceMissing := pathMissing(paths.Workspace)
-	trashMissing := pathMissing(paths.Trash)
-	identityMissing := pathMissing(paths.Identity)
-	if workspaceMissing && trashMissing && identityMissing {
-		return "success", map[string]any{"path": paths.Workspace, "removed": false}, ""
-	}
-	if err := validateLensWorkspaceIdentity(paths.Identity, identity); err != nil {
-		return "failed", nil, err.Error()
-	}
 	if err := ensureLensMetadataLayout(paths); err != nil {
 		return "failed", nil, err.Error()
 	}
+	lockContext, cancel := context.WithTimeout(ctx, lensWorkspaceLockTimeout)
+	defer cancel()
+	removed := false
+	alreadyRetired := false
+	err = withLensWorkspaceLock(lockContext, paths.Lock, func() error {
+		workspaceMissing := pathMissing(paths.Workspace)
+		trashMissing := pathMissing(paths.Trash)
+		identityMissing := pathMissing(paths.Identity)
 
-	workspaceExists := !workspaceMissing
-	trashExists := !trashMissing
-	if workspaceExists && trashExists {
-		return "failed", nil, "managed workspace and trash both exist"
+		tombstone, tombstoneErr := readLensWorkspaceTombstone(paths.Tombstone)
+		if tombstoneErr == nil {
+			if err := validateLensWorkspaceTombstone(tombstone, identity, paths.Workspace); err != nil {
+				return err
+			}
+			if tombstone.State == lensWorkspaceTombstoneRetired {
+				if !workspaceMissing || !trashMissing || !identityMissing {
+					return errors.New("retired managed workspace has unexpected artifacts")
+				}
+				alreadyRetired = true
+				return nil
+			}
+			if tombstone.State != lensWorkspaceTombstoneRetiring {
+				return errors.New("managed workspace tombstone has an unsupported state")
+			}
+		} else if !os.IsNotExist(tombstoneErr) {
+			return tombstoneErr
+		}
+
+		if !identityMissing {
+			if err := validateLensWorkspaceIdentity(paths.Identity, identity); err != nil {
+				return err
+			}
+		} else if !workspaceMissing || !trashMissing {
+			return errors.New("managed workspace identity is missing or invalid")
+		}
+
+		retiring := newLensWorkspaceTombstone(
+			identity,
+			paths.Workspace,
+			lensWorkspaceTombstoneRetiring,
+			&tombstone,
+		)
+		if err := writeLensWorkspaceTombstone(paths.Tombstone, retiring); err != nil {
+			return err
+		}
+
+		workspaceExists := !workspaceMissing
+		trashExists := !trashMissing
+		if workspaceExists && trashExists {
+			return errors.New("managed workspace and trash both exist")
+		}
+		if workspaceExists {
+			fd, _, openErr := secureOpenDirectory(paths.Workspace, paths.Root, false, uint64(os.O_RDONLY))
+			if openErr != nil {
+				return openErr
+			}
+			workspaceDirectory := secureDirectoryFile(fd, paths.Workspace)
+			if workspaceDirectory == nil {
+				return errors.New("restricted Data Gateway filesystem operations require Linux")
+			}
+			_ = workspaceDirectory.Close()
+			if err := os.Rename(paths.Workspace, paths.Trash); err != nil {
+				return err
+			}
+			trashExists = true
+		}
+		removed = workspaceExists || trashExists
+		return nil
+	})
+	if err != nil {
+		return "failed", nil, err.Error()
 	}
-	if workspaceExists {
-		fd, _, openErr := secureOpenDirectory(paths.Workspace, paths.Root, false, uint64(os.O_RDONLY))
-		if openErr != nil {
-			return "failed", nil, openErr.Error()
-		}
-		workspaceDirectory := secureDirectoryFile(fd, paths.Workspace)
-		if workspaceDirectory == nil {
-			return "failed", nil, "restricted Data Gateway filesystem operations require Linux"
-		}
-		_ = workspaceDirectory.Close()
-		if err := os.Rename(paths.Workspace, paths.Trash); err != nil {
-			return "failed", nil, err.Error()
-		}
-		trashExists = true
+	if alreadyRetired {
+		return "success", map[string]any{"path": paths.Workspace, "removed": false}, ""
 	}
-	if trashExists {
+	// Removing a potentially large workspace must not hold the lifecycle lock.
+	// The retiring tombstone already prevents every late prepare from claiming it.
+	if !pathMissing(paths.Trash) {
 		if err := removeLensWorkspaceTrash(paths.Trash); err != nil {
-			// The external identity intentionally survives partial deletion so a
+			// Identity and the retiring tombstone survive partial deletion so a
 			// retry can safely finish removing the quarantined workspace.
 			return "failed", nil, err.Error()
 		}
 	}
-	if err := os.Remove(paths.Identity); err != nil && !os.IsNotExist(err) {
+	finalLockContext, finalCancel := context.WithTimeout(ctx, lensWorkspaceLockTimeout)
+	defer finalCancel()
+	err = withLensWorkspaceLock(finalLockContext, paths.Lock, func() error {
+		finalTombstone, tombstoneErr := readLensWorkspaceTombstone(paths.Tombstone)
+		if tombstoneErr != nil {
+			return tombstoneErr
+		}
+		if err := validateLensWorkspaceTombstone(finalTombstone, identity, paths.Workspace); err != nil {
+			return err
+		}
+		if finalTombstone.State == lensWorkspaceTombstoneRetired {
+			if !pathMissing(paths.Workspace) || !pathMissing(paths.Trash) || !pathMissing(paths.Identity) {
+				return errors.New("retired managed workspace has unexpected artifacts")
+			}
+			return nil
+		}
+		if finalTombstone.State != lensWorkspaceTombstoneRetiring {
+			return errors.New("managed workspace tombstone has an unsupported state")
+		}
+		if !pathMissing(paths.Workspace) || !pathMissing(paths.Trash) {
+			return errors.New("managed workspace cleanup is incomplete")
+		}
+		if err := os.Remove(paths.Identity); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+		retiredTombstone := newLensWorkspaceTombstone(
+			identity,
+			paths.Workspace,
+			lensWorkspaceTombstoneRetired,
+			&finalTombstone,
+		)
+		return writeLensWorkspaceTombstone(paths.Tombstone, retiredTombstone)
+	})
+	if err != nil {
 		return "failed", nil, err.Error()
 	}
-	return "success", map[string]any{"path": paths.Workspace, "removed": workspaceExists || trashExists}, ""
+	return "success", map[string]any{"path": paths.Workspace, "removed": removed}, ""
 }
 
 func pathMissing(path string) bool {

--- a/src/agent/internal/engine/lens_prepare_test.go
+++ b/src/agent/internal/engine/lens_prepare_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 const testWorkspaceUID = "de240f46-eccd-4e4b-868f-b1f504fbe67b"
@@ -25,6 +26,10 @@ func testIdentityPath(root, workspaceUID string) string {
 
 func testTrashPath(root, workspaceUID string) string {
 	return filepath.Join(root, ".hyperfilelens-trash", workspaceUID)
+}
+
+func testTombstonePath(root, workspaceUID string) string {
+	return filepath.Join(filepath.Dir(root), ".hyperfilelens", "tombstones", workspaceUID+".json")
 }
 
 func TestLensWorkspaceTrashStaysInsideWorkspaceFilesystem(t *testing.T) {
@@ -464,6 +469,7 @@ func TestRunLensKsCleanupRetriesAfterPartialTrashRemoval(t *testing.T) {
 		t.Fatal(err)
 	}
 	originalRemove := removeLensWorkspaceTrash
+	t.Cleanup(func() { removeLensWorkspaceTrash = originalRemove })
 	removeLensWorkspaceTrash = func(path string) error {
 		if err := os.Remove(filepath.Join(path, "data.txt")); err != nil {
 			return err
@@ -475,6 +481,13 @@ func TestRunLensKsCleanupRetriesAfterPartialTrashRemoval(t *testing.T) {
 	if status != "failed" {
 		t.Fatalf("expected injected failure, got %q", status)
 	}
+	tombstone, err := readLensWorkspaceTombstone(testTombstonePath(root, testWorkspaceUID))
+	if err != nil || tombstone.State != lensWorkspaceTombstoneRetiring {
+		t.Fatalf("expected durable retiring tombstone, tombstone=%+v err=%v", tombstone, err)
+	}
+	if prepareStatus, _, _ := New(nil).runLensKsPrepare(context.Background(), payload); prepareStatus != "failed" {
+		t.Fatalf("late prepare must be rejected while cleanup is retiring, status=%q", prepareStatus)
+	}
 	if _, err := os.Stat(testIdentityPath(root, testWorkspaceUID)); err != nil {
 		t.Fatalf("identity must survive partial removal: %v", err)
 	}
@@ -484,5 +497,95 @@ func TestRunLensKsCleanupRetriesAfterPartialTrashRemoval(t *testing.T) {
 	}
 	if _, err := os.Stat(testIdentityPath(root, testWorkspaceUID)); !os.IsNotExist(err) {
 		t.Fatalf("identity should be removed last, err=%v", err)
+	}
+	tombstone, err = readLensWorkspaceTombstone(testTombstonePath(root, testWorkspaceUID))
+	if err != nil || tombstone.State != lensWorkspaceTombstoneRetired {
+		t.Fatalf("expected durable retired tombstone, tombstone=%+v err=%v", tombstone, err)
+	}
+	if status, _, errMsg := New(nil).runLensKsCleanup(context.Background(), payload); status != "success" {
+		t.Fatalf("repeated cleanup must be idempotent, status=%q err=%q", status, errMsg)
+	}
+	if status, _, _ := New(nil).runLensKsPrepare(context.Background(), payload); status != "failed" {
+		t.Fatalf("retired UID must survive Agent restart and reject prepare, status=%q", status)
+	}
+}
+
+func TestLensWorkspaceLifecycleLockSerializesPrepareAndCleanup(t *testing.T) {
+	root := newLensTestRoot(t)
+	target := filepath.Join(root, "tenant-61-ks-locked")
+	payload := Payload{
+		Path: target,
+		Extra: map[string]any{
+			"workspace_root":         root,
+			"workspace_uid":          testWorkspaceUID,
+			"tenant_organization_id": 61,
+			"gateway_link_id":        7,
+			"knowledge_source_id":    42,
+			"workspace_kind":         "managed_restore",
+		},
+	}
+	engine := New(nil)
+	if status, _, errMsg := engine.runLensKsPrepare(context.Background(), payload); status != "success" {
+		t.Fatalf("prepare status=%q err=%q", status, errMsg)
+	}
+	enteredRemoval := make(chan struct{})
+	allowRemoval := make(chan struct{})
+	originalRemove := removeLensWorkspaceTrash
+	removeLensWorkspaceTrash = func(path string) error {
+		close(enteredRemoval)
+		<-allowRemoval
+		return originalRemove(path)
+	}
+	t.Cleanup(func() { removeLensWorkspaceTrash = originalRemove })
+
+	cleanupDone := make(chan string, 1)
+	go func() {
+		status, _, _ := engine.runLensKsCleanup(context.Background(), payload)
+		cleanupDone <- status
+	}()
+	<-enteredRemoval
+	prepareDone := make(chan string, 1)
+	go func() {
+		status, _, _ := engine.runLensKsPrepare(context.Background(), payload)
+		prepareDone <- status
+	}()
+	if status := <-prepareDone; status != "failed" {
+		t.Fatalf("late prepare must observe retiring tombstone, status=%q", status)
+	}
+	close(allowRemoval)
+	if status := <-cleanupDone; status != "success" {
+		t.Fatalf("cleanup status=%q", status)
+	}
+}
+
+func TestLensWorkspaceLifecycleLockHonorsContext(t *testing.T) {
+	lockPath := filepath.Join(t.TempDir(), "workspace.lock")
+	lockHeld := make(chan struct{})
+	releaseLock := make(chan struct{})
+	firstDone := make(chan error, 1)
+	go func() {
+		firstDone <- withLensWorkspaceLock(
+			context.Background(),
+			lockPath,
+			func() error {
+				close(lockHeld)
+				<-releaseLock
+				return nil
+			},
+		)
+	}()
+	<-lockHeld
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	err := withLensWorkspaceLock(ctx, lockPath, func() error {
+		t.Fatal("second action must not run while the UID lock is held")
+		return nil
+	})
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected lock deadline, got %v", err)
+	}
+	close(releaseLock)
+	if err := <-firstDone; err != nil {
+		t.Fatalf("first lock action failed: %v", err)
 	}
 }

--- a/src/agent/internal/engine/lens_workspace_lock.go
+++ b/src/agent/internal/engine/lens_workspace_lock.go
@@ -1,0 +1,22 @@
+package engine
+
+import "context"
+
+func withLensWorkspaceLock(
+	ctx context.Context,
+	lockPath string,
+	action func() error,
+) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	unlock, err := acquireLensWorkspaceFileLock(ctx, lockPath)
+	if err != nil {
+		return err
+	}
+	defer unlock()
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return action()
+}

--- a/src/agent/internal/engine/lens_workspace_lock_unix.go
+++ b/src/agent/internal/engine/lens_workspace_lock_unix.go
@@ -1,0 +1,56 @@
+//go:build !windows
+
+package engine
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+	"time"
+)
+
+func acquireLensWorkspaceFileLock(
+	ctx context.Context,
+	lockPath string,
+) (func(), error) {
+	file, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return func() {}, fmt.Errorf("open managed workspace lock: %w", err)
+	}
+	for {
+		err = syscall.Flock(int(file.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+		if err == nil {
+			return func() {
+				_ = syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
+				_ = file.Close()
+			}, nil
+		}
+		if !errors.Is(err, syscall.EWOULDBLOCK) && !errors.Is(err, syscall.EAGAIN) {
+			_ = file.Close()
+			return func() {}, fmt.Errorf("lock managed workspace lifecycle: %w", err)
+		}
+		timer := time.NewTimer(100 * time.Millisecond)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			_ = file.Close()
+			return func() {}, fmt.Errorf("lock managed workspace lifecycle: %w", ctx.Err())
+		case <-timer.C:
+		}
+	}
+}
+
+func replaceLensWorkspaceTombstone(temporary, destination string) error {
+	if err := os.Rename(temporary, destination); err != nil {
+		return err
+	}
+	directory, err := os.Open(filepath.Dir(destination))
+	if err != nil {
+		return err
+	}
+	defer directory.Close()
+	return directory.Sync()
+}

--- a/src/agent/internal/engine/lens_workspace_lock_windows.go
+++ b/src/agent/internal/engine/lens_workspace_lock_windows.go
@@ -1,0 +1,74 @@
+//go:build windows
+
+package engine
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
+	"golang.org/x/sys/windows"
+)
+
+func acquireLensWorkspaceFileLock(
+	ctx context.Context,
+	lockPath string,
+) (func(), error) {
+	file, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return func() {}, fmt.Errorf("open managed workspace lock: %w", err)
+	}
+	overlapped := new(windows.Overlapped)
+	for {
+		err = windows.LockFileEx(
+			windows.Handle(file.Fd()),
+			windows.LOCKFILE_EXCLUSIVE_LOCK|windows.LOCKFILE_FAIL_IMMEDIATELY,
+			0,
+			1,
+			0,
+			overlapped,
+		)
+		if err == nil {
+			return func() {
+				_ = windows.UnlockFileEx(
+					windows.Handle(file.Fd()),
+					0,
+					1,
+					0,
+					overlapped,
+				)
+				_ = file.Close()
+			}, nil
+		}
+		if !errors.Is(err, windows.ERROR_LOCK_VIOLATION) {
+			_ = file.Close()
+			return func() {}, fmt.Errorf("lock managed workspace lifecycle: %w", err)
+		}
+		timer := time.NewTimer(100 * time.Millisecond)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			_ = file.Close()
+			return func() {}, fmt.Errorf("lock managed workspace lifecycle: %w", ctx.Err())
+		case <-timer.C:
+		}
+	}
+}
+
+func replaceLensWorkspaceTombstone(temporary, destination string) error {
+	from, err := windows.UTF16PtrFromString(temporary)
+	if err != nil {
+		return err
+	}
+	to, err := windows.UTF16PtrFromString(destination)
+	if err != nil {
+		return err
+	}
+	return windows.MoveFileEx(
+		from,
+		to,
+		windows.MOVEFILE_REPLACE_EXISTING|windows.MOVEFILE_WRITE_THROUGH,
+	)
+}

--- a/src/backend/apps/lens_bridge/management/commands/resume_blocked_chat_cleanup.py
+++ b/src/backend/apps/lens_bridge/management/commands/resume_blocked_chat_cleanup.py
@@ -1,4 +1,4 @@
-"""Resume one blocked Chat cleanup through an audited operator confirmation."""
+"""Resume blocked Chat or orphan KS cleanup after operator confirmation."""
 
 from __future__ import annotations
 
@@ -9,73 +9,172 @@ from django.db import transaction
 from django.utils import timezone
 
 from apps.lens_bridge.models import LensKnowledgeSource, LensSessionLink
-from apps.lens_bridge.services import sl_client
+from apps.lens_bridge.services import sl_client, teardown_blocking
+
+
+def _conversion_blocked(blocking: dict[str, object]) -> bool:
+    return bool(
+        str(blocking.get("reason") or "") == "conversion_stop_unconfirmed"
+        or str(blocking.get("task_id") or "").strip()
+    )
+
+
+def _require_matching_blocked_task(
+    blocking: dict[str, object],
+    task_id: str,
+) -> None:
+    blocked_task_id = str(blocking.get("task_id") or "").strip()
+    if blocked_task_id and blocked_task_id != task_id:
+        raise CommandError(
+            "SourceLens task id does not match the recorded blocking condition."
+        )
 
 
 class Command(BaseCommand):
     help = (
-        "Resume one blocked Chat cleanup after an operator has independently "
-        "confirmed that its LensNode conversion executor stopped."
+        "Resume one blocked Chat or orphan Knowledge Source cleanup after an "
+        "operator confirms the recorded blocking condition has been resolved."
     )
 
     def add_arguments(self, parser):
-        parser.add_argument("--session-id", type=int, required=True)
-        parser.add_argument("--source-lens-task-id", required=True)
+        target = parser.add_mutually_exclusive_group(required=True)
+        target.add_argument("--session-id", type=int)
+        target.add_argument("--knowledge-source-id", type=int)
+        parser.add_argument("--source-lens-task-id")
         parser.add_argument("--reason", required=True)
         parser.add_argument(
             "--confirm-executor-stopped",
             action="store_true",
             help="Required acknowledgement that the old executor no longer runs.",
         )
+        parser.add_argument(
+            "--confirm-retry",
+            action="store_true",
+            help=(
+                "Required acknowledgement when resuming a non-conversion "
+                "cleanup after its underlying fault was corrected."
+            ),
+        )
 
     def handle(self, *args, **options):
-        if not options["confirm_executor_stopped"]:
-            raise CommandError(
-                "Refusing to resume cleanup without --confirm-executor-stopped."
-            )
         task_id = str(options["source_lens_task_id"] or "").strip()
         reason = str(options["reason"] or "").strip()
-        if not task_id or not reason:
-            raise CommandError("SourceLens task id and reason are required.")
+        if not reason:
+            raise CommandError("Reason is required.")
+        if task_id:
+            if not options["confirm_executor_stopped"]:
+                raise CommandError(
+                    "Refusing to resume cleanup without "
+                    "--confirm-executor-stopped."
+                )
+            remote_task = sl_client.get_task_by_id(task_id)
+            if remote_task is None:
+                raise CommandError(
+                    "SourceLens task was not found; cleanup remains blocked."
+                )
+            remote_status = str(remote_task.get("status") or "").upper()
+            returned_task_id = str(remote_task.get("task_id") or "").strip()
+            if returned_task_id != task_id:
+                raise CommandError(
+                    "SourceLens did not return the exact requested task identity."
+                )
+            if remote_status not in {"FAILURE", "REVOKED"}:
+                raise CommandError(
+                    f"SourceLens task is {remote_status or 'UNKNOWN'}, not terminal."
+                )
+        else:
+            if not options.get("confirm_retry"):
+                raise CommandError(
+                    "Refusing to resume non-conversion cleanup without "
+                    "--confirm-retry."
+                )
+            remote_status = ""
 
-        remote_task = sl_client.get_task_by_id(task_id)
-        if remote_task is None:
-            raise CommandError("SourceLens task was not found; cleanup remains blocked.")
-        remote_status = str(remote_task.get("status") or "").upper()
-        returned_task_id = str(remote_task.get("task_id") or "").strip()
-        if returned_task_id != task_id:
-            raise CommandError(
-                "SourceLens did not return the exact requested task identity."
+        knowledge_source_id = options.get("knowledge_source_id")
+        if knowledge_source_id is not None:
+            self._resume_knowledge_source_cleanup(
+                knowledge_source_id=int(knowledge_source_id),
+                task_id=task_id,
+                remote_status=remote_status,
+                reason=reason,
             )
-        if remote_status not in {"FAILURE", "REVOKED"}:
-            raise CommandError(
-                f"SourceLens task is {remote_status or 'UNKNOWN'}, not terminal."
-            )
+            return
+
+        session_id = options.get("session_id")
+        if session_id is None:
+            raise CommandError("Chat session id is required.")
 
         with transaction.atomic():
             session = (
                 LensSessionLink.objects.select_for_update()
-                .select_related("knowledge_source")
-                .filter(pk=options["session_id"])
+                .filter(pk=session_id)
                 .first()
             )
             if session is None:
                 raise CommandError("Chat session was not found.")
             if session.cleanup_status != LensSessionLink.CleanupStatus.BLOCKED:
                 raise CommandError("Chat cleanup is not blocked.")
-            knowledge_source = session.knowledge_source
-            if knowledge_source is None:
+            teardown_state = dict(session.teardown_state_json or {})
+            blocking = teardown_state.get("blocking")
+            blocking = blocking if isinstance(blocking, dict) else {}
+            session_conversion_blocked = _conversion_blocked(blocking)
+            if not task_id and session_conversion_blocked:
+                raise CommandError(
+                    "Conversion cleanup requires --source-lens-task-id and "
+                    "--confirm-executor-stopped."
+                )
+            knowledge_source_id = session.knowledge_source_id
+            if task_id and knowledge_source_id is None:
                 raise CommandError("Blocked Chat has no Knowledge Source.")
 
-            knowledge_source = LensKnowledgeSource.all_objects.select_for_update().get(
-                pk=knowledge_source.pk
-            )
-            sync_state = dict(knowledge_source.sync_state_json or {})
-            conversion = dict(sync_state.get("conversion") or {})
-            recorded_task_id = str(conversion.get("task_id") or "").strip()
-            if recorded_task_id != task_id:
+            knowledge_source = None
+            if knowledge_source_id is not None:
+                knowledge_source = (
+                    LensKnowledgeSource.all_objects.select_for_update()
+                    .filter(pk=knowledge_source_id)
+                    .first()
+                )
+            if task_id and knowledge_source is None:
+                raise CommandError("Blocked Chat Knowledge Source was not found.")
+            if (
+                knowledge_source is not None
+                and session.knowledge_source_id != knowledge_source.id
+            ):
                 raise CommandError(
-                    "SourceLens task id does not match the blocked Knowledge Source."
+                    "Blocked Chat Knowledge Source changed during recovery."
+                )
+            knowledge_source_blocking: dict[str, object] = {}
+            if knowledge_source is not None:
+                knowledge_source_state = dict(
+                    knowledge_source.teardown_state_json or {}
+                )
+                candidate_blocking = knowledge_source_state.get("blocking")
+                knowledge_source_blocking = (
+                    candidate_blocking
+                    if isinstance(candidate_blocking, dict)
+                    else {}
+                )
+            knowledge_source_conversion_blocked = _conversion_blocked(
+                knowledge_source_blocking
+            )
+            conversion_blocked = (
+                session_conversion_blocked
+                or knowledge_source_conversion_blocked
+            )
+            if task_id:
+                if not conversion_blocked:
+                    raise CommandError(
+                        "Cleanup is not blocked on SourceLens conversion stop."
+                    )
+                _require_matching_blocked_task(blocking, task_id)
+                _require_matching_blocked_task(
+                    knowledge_source_blocking,
+                    task_id,
+                )
+            elif conversion_blocked:
+                raise CommandError(
+                    "Conversion cleanup requires --source-lens-task-id and "
+                    "--confirm-executor-stopped."
                 )
 
             confirmation = {
@@ -84,28 +183,29 @@ class Command(BaseCommand):
                 "remote_status": remote_status,
                 "operator": getpass.getuser(),
                 "reason": reason[:1000],
+                "blocking_reason": str(blocking.get("reason") or ""),
                 "confirmed_at": timezone.now().isoformat(),
             }
-            conversion["manual_stop_confirmation"] = confirmation
-            sync_state["conversion"] = conversion
-            knowledge_source.sync_state_json = sync_state
-            knowledge_source.teardown_next_retry_at = None
-            knowledge_source.status_detail = (
-                "Conversion stop was confirmed; cleanup is queued."
-            )
-            knowledge_source.save(
-                update_fields=[
-                    "sync_state_json",
-                    "teardown_next_retry_at",
-                    "status_detail",
-                    "updated_at",
-                ]
-            )
+            if knowledge_source is not None and (
+                task_id
+                or "blocking" in (knowledge_source.teardown_state_json or {})
+            ):
+                self._resume_locked_knowledge_source(
+                    knowledge_source,
+                    task_id=task_id,
+                    confirmation=confirmation,
+                )
 
-            teardown_state = dict(session.teardown_state_json or {})
-            teardown_state["manual_stop_confirmation"] = confirmation
+            teardown_state.pop("blocking", None)
+            confirmation_key = (
+                "manual_stop_confirmation"
+                if task_id
+                else "manual_cleanup_confirmation"
+            )
+            teardown_state[confirmation_key] = confirmation
             session.teardown_state_json = teardown_state
             session.cleanup_status = LensSessionLink.CleanupStatus.PENDING
+            session.teardown_attempts = 0
             session.teardown_claim_token = None
             session.teardown_claimed_at = None
             session.teardown_next_retry_at = None
@@ -113,6 +213,7 @@ class Command(BaseCommand):
                 update_fields=[
                     "teardown_state_json",
                     "cleanup_status",
+                    "teardown_attempts",
                     "teardown_claim_token",
                     "teardown_claimed_at",
                     "teardown_next_retry_at",
@@ -132,4 +233,140 @@ class Command(BaseCommand):
             self.style.SUCCESS(
                 f"Queued audited cleanup recovery for Chat {session.id}."
             )
+        )
+
+    def _resume_knowledge_source_cleanup(
+        self,
+        *,
+        knowledge_source_id: int,
+        task_id: str,
+        remote_status: str,
+        reason: str,
+    ) -> None:
+        """Resume an orphan KS whose bounded retry budget was exhausted."""
+
+        with transaction.atomic():
+            knowledge_source = (
+                LensKnowledgeSource.all_objects.select_for_update()
+                .filter(pk=knowledge_source_id)
+                .first()
+            )
+            if knowledge_source is None:
+                raise CommandError("Knowledge Source was not found.")
+            if (
+                knowledge_source.lifecycle_status
+                != LensKnowledgeSource.LifecycleStatus.DELETING
+            ):
+                raise CommandError("Knowledge Source cleanup is not pending.")
+            if knowledge_source.session_links.exclude(
+                lifecycle_status=LensSessionLink.LifecycleStatus.DELETED
+            ).exists():
+                raise CommandError(
+                    "Knowledge Source still belongs to a Chat; resume the Chat "
+                    "cleanup by session id."
+                )
+
+            teardown_state = dict(
+                knowledge_source.teardown_state_json or {}
+            )
+            blocking = teardown_state.get("blocking")
+            blocking = blocking if isinstance(blocking, dict) else {}
+            conversion_blocked = _conversion_blocked(blocking)
+            if task_id:
+                if not conversion_blocked:
+                    raise CommandError(
+                        "Knowledge Source is not blocked on conversion stop."
+                    )
+                _require_matching_blocked_task(blocking, task_id)
+            elif conversion_blocked:
+                raise CommandError(
+                    "Conversion cleanup requires --source-lens-task-id and "
+                    "--confirm-executor-stopped."
+                )
+            elif not teardown_blocking.intervention_required(teardown_state):
+                raise CommandError(
+                    "Knowledge Source cleanup does not require operator "
+                    "intervention."
+                )
+
+            confirmation = {
+                "confirmed": True,
+                "task_id": task_id,
+                "remote_status": remote_status,
+                "operator": getpass.getuser(),
+                "reason": reason[:1000],
+                "blocking_reason": str(blocking.get("reason") or ""),
+                "confirmed_at": timezone.now().isoformat(),
+            }
+            self._resume_locked_knowledge_source(
+                knowledge_source,
+                task_id=task_id,
+                confirmation=confirmation,
+            )
+
+            from apps.lens_bridge.services.knowledge_source_teardown import (
+                _queue_teardown,
+            )
+
+            transaction.on_commit(
+                lambda: _queue_teardown(knowledge_source.id)
+            )
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                "Queued audited cleanup recovery for Knowledge Source "
+                f"{knowledge_source.id}."
+            )
+        )
+
+    @staticmethod
+    def _resume_locked_knowledge_source(
+        knowledge_source: LensKnowledgeSource,
+        *,
+        task_id: str,
+        confirmation: dict,
+    ) -> None:
+        """Reset one locked KS after its blocking condition was confirmed."""
+
+        sync_state = dict(knowledge_source.sync_state_json or {})
+        conversion = dict(sync_state.get("conversion") or {})
+        recorded_task_id = str(conversion.get("task_id") or "").strip()
+        if task_id and recorded_task_id != task_id:
+            raise CommandError(
+                "SourceLens task id does not match the blocked Knowledge Source."
+            )
+        if task_id:
+            conversion["manual_stop_confirmation"] = confirmation
+            sync_state["conversion"] = conversion
+            knowledge_source.sync_state_json = sync_state
+
+        teardown_state = dict(knowledge_source.teardown_state_json or {})
+        teardown_state.pop("blocking", None)
+        confirmation_key = (
+            "manual_stop_confirmation"
+            if task_id
+            else "manual_cleanup_confirmation"
+        )
+        teardown_state[confirmation_key] = confirmation
+        knowledge_source.teardown_state_json = teardown_state
+        knowledge_source.teardown_attempts = 0
+        knowledge_source.teardown_claim_token = None
+        knowledge_source.teardown_claimed_at = None
+        knowledge_source.teardown_next_retry_at = None
+        knowledge_source.status_detail = (
+            "Conversion stop was confirmed; cleanup is queued."
+            if task_id
+            else "Cleanup recovery was confirmed and queued."
+        )
+        knowledge_source.save(
+            update_fields=[
+                "sync_state_json",
+                "teardown_state_json",
+                "teardown_attempts",
+                "teardown_claim_token",
+                "teardown_claimed_at",
+                "teardown_next_retry_at",
+                "status_detail",
+                "updated_at",
+            ]
         )

--- a/src/backend/apps/lens_bridge/services/chat_lifecycle.py
+++ b/src/backend/apps/lens_bridge/services/chat_lifecycle.py
@@ -35,6 +35,7 @@ from apps.lens_bridge.services import (
     platform_lens,
     provisioning,
     sl_client,
+    teardown_blocking,
 )
 from apps.lens_bridge.services.chat_binding import _grant_assistant_to_chat_user
 from apps.lens_bridge.services.chat_lifecycle_errors import (
@@ -1949,12 +1950,17 @@ def _orphan_knowledge_source_needs_enqueue(knowledge_source_id: int) -> bool:
             "lifecycle_status",
             "teardown_claimed_at",
             "teardown_next_retry_at",
+            "teardown_state_json",
         )
         .first()
     )
     if knowledge_source is None:
         return False
     if knowledge_source.lifecycle_status == LensKnowledgeSource.LifecycleStatus.DELETED:
+        return False
+    if teardown_blocking.intervention_required(
+        knowledge_source.teardown_state_json
+    ):
         return False
     if (
         knowledge_source.teardown_claimed_at
@@ -2221,6 +2227,8 @@ def _claim_copilot_chat_teardown(session_link_id: int) -> tuple[str | None, str]
             return None, str(link.lifecycle_status)
         if link.cleanup_status == LensSessionLink.CleanupStatus.COMPLETE:
             return None, "complete"
+        if teardown_blocking.intervention_required(link.teardown_state_json):
+            return None, "intervention_required"
         if link.teardown_claimed_at and link.teardown_claimed_at > now - timedelta(
             seconds=TEARDOWN_CLAIM_TTL_SECONDS
         ):
@@ -2438,6 +2446,8 @@ def run_copilot_chat_teardown(*, session_link_id: int) -> dict[str, Any]:
     failed_assistant_uuids: list[uuid_lib.UUID] = []
     ks = link.knowledge_source
     cleanup_waiting_for_conversion_stop = False
+    workspace_intervention_required = False
+    workspace_blocking: dict[str, Any] = {}
     assistant_uuids: set[uuid_lib.UUID] = set()
     if session_cleanup_complete:
         try:
@@ -2562,6 +2572,15 @@ def run_copilot_chat_teardown(*, session_link_id: int) -> dict[str, Any]:
                 .first()
                 or {}
             )
+            if isinstance(latest_ks_teardown_state, dict):
+                candidate_blocking = latest_ks_teardown_state.get("blocking")
+                if isinstance(candidate_blocking, dict):
+                    workspace_blocking = candidate_blocking
+                workspace_intervention_required = (
+                    teardown_blocking.intervention_required(
+                        latest_ks_teardown_state
+                    )
+                )
             cleanup_waiting_for_conversion_stop = bool(
                 isinstance(latest_ks_teardown_state, dict)
                 and (
@@ -2588,7 +2607,46 @@ def run_copilot_chat_teardown(*, session_link_id: int) -> dict[str, Any]:
         )
 
     reset_for_retry = teardown_intent == _TEARDOWN_INTENT_RESET_FOR_RETRY
-    cleanup_blocked = cleanup_waiting_for_conversion_stop
+    blocking: dict[str, Any] = {}
+    if critical_errors:
+        if workspace_blocking:
+            blocking_reason = str(
+                workspace_blocking.get("reason")
+                or "conversion_stop_unconfirmed"
+            )
+            blocking_task_id = str(workspace_blocking.get("task_id") or "")
+            blocking_remote_status = str(
+                workspace_blocking.get("remote_status") or ""
+            )
+            blocking_stop_source = str(
+                workspace_blocking.get("stop_confirmation_source") or ""
+            )
+        else:
+            # Exception messages may contain transient details. Use the stable
+            # step prefix for the retry fingerprint and retain full details in
+            # lifecycle_error.
+            blocking_reason = str(critical_errors[0].split(":", 1)[0])[:300]
+            blocking_task_id = ""
+            blocking_remote_status = ""
+            blocking_stop_source = ""
+        if workspace_intervention_required and workspace_blocking:
+            blocking = dict(workspace_blocking)
+            teardown_state["blocking"] = blocking
+        else:
+            teardown_state, blocking = teardown_blocking.record_blocking(
+                teardown_state,
+                reason=blocking_reason,
+                task_id=blocking_task_id,
+                gateway_link_id=link.gateway_link_id,
+                remote_status=blocking_remote_status,
+                stop_confirmation_source=blocking_stop_source,
+            )
+    else:
+        teardown_state = teardown_blocking.clear_blocking(teardown_state)
+    intervention_required = bool(blocking.get("intervention_required"))
+    cleanup_blocked = (
+        cleanup_waiting_for_conversion_stop or intervention_required
+    )
     if critical_errors:
         link.lifecycle_status = (
             LensSessionLink.LifecycleStatus.FAILED
@@ -2607,9 +2665,13 @@ def run_copilot_chat_teardown(*, session_link_id: int) -> dict[str, Any]:
             else LensSessionLink.CleanupStatus.PENDING
         )
         link.provision_detail = (
-            "Cleanup is waiting for SourceLens to confirm conversion has stopped."
-            if cleanup_blocked
-            else "Chat cleanup is incomplete and will be retried."
+            "Chat cleanup requires operator intervention."
+            if intervention_required
+            else (
+                "Cleanup is waiting for SourceLens to confirm conversion has stopped."
+                if cleanup_waiting_for_conversion_stop
+                else "Chat cleanup is incomplete and will be retried."
+            )
         )
         link.lifecycle_error = "; ".join([*critical_errors, *warnings])[:2000]
         link.lifecycle_error_state_json = lifecycle_error_state_from_exception(
@@ -2644,9 +2706,13 @@ def run_copilot_chat_teardown(*, session_link_id: int) -> dict[str, Any]:
     link.teardown_state_json = teardown_state
     link.teardown_claim_token = None
     link.teardown_claimed_at = None
-    if cleanup_blocked:
-        link.teardown_next_retry_at = timezone.now() + timedelta(minutes=5)
-    elif not critical_errors:
+    if critical_errors:
+        link.teardown_next_retry_at = (
+            None
+            if intervention_required
+            else next_retry_at(int(blocking["consecutive_attempts"]))
+        )
+    else:
         link.teardown_next_retry_at = None
     slot_generation = (
         LensGatewayChatSlot.objects.filter(session_link_id=link.id)
@@ -2688,6 +2754,19 @@ def run_copilot_chat_teardown(*, session_link_id: int) -> dict[str, Any]:
     if updated != 1:
         raise ChatTeardownIncompleteError("Chat teardown lease was lost.")
     if critical_errors:
+        logger.warning(
+            "chat teardown blocked chat_id=%s knowledge_source_id=%s "
+            "gateway_link_id=%s task_id=%s remote_status=%s reason=%s "
+            "attempts=%s intervention_required=%s",
+            link.id,
+            ks.id if ks is not None else None,
+            link.gateway_link_id,
+            blocking.get("task_id"),
+            blocking.get("remote_status"),
+            blocking.get("reason"),
+            blocking.get("consecutive_attempts"),
+            intervention_required,
+        )
         raise ChatTeardownIncompleteError("; ".join(critical_errors))
     if slot_generation is not None:
         gateway_chat_queue.release_chat_prepare_slot(

--- a/src/backend/apps/lens_bridge/services/knowledge_source_teardown.py
+++ b/src/backend/apps/lens_bridge/services/knowledge_source_teardown.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import uuid
 from datetime import timedelta
 from typing import Any
@@ -15,7 +16,12 @@ from apps.lens_bridge.models import (
     LensSessionLink,
     LensWorkspaceBinding,
 )
-from apps.lens_bridge.services import assistant_access, managed_datasource, sl_client
+from apps.lens_bridge.services import (
+    assistant_access,
+    managed_datasource,
+    sl_client,
+    teardown_blocking,
+)
 from apps.lens_bridge.services.teardown_claims import (
     TEARDOWN_CLAIM_TTL_SECONDS,
     next_retry_at,
@@ -28,6 +34,9 @@ class KnowledgeSourceTeardownIncompleteError(RuntimeError):
 
 class KnowledgeSourceTeardownBusyError(RuntimeError):
     """Raised when another worker owns the Knowledge Source lease."""
+
+
+logger = logging.getLogger(__name__)
 
 
 def _session_links_blocking_ks_teardown(
@@ -119,6 +128,10 @@ def _claim(knowledge_source_id: int) -> tuple[str | None, str]:
             return None, "missing"
         if knowledge_source.lifecycle_status == LensKnowledgeSource.LifecycleStatus.DELETED:
             return None, "deleted"
+        if teardown_blocking.intervention_required(
+            knowledge_source.teardown_state_json
+        ):
+            return None, "intervention_required"
         if (
             knowledge_source.teardown_claimed_at
             and knowledge_source.teardown_claimed_at
@@ -274,6 +287,8 @@ def run_knowledge_source_teardown(
     if knowledge_source is None:
         return {"knowledge_source_id": knowledge_source_id, "status": "missing"}
     state = dict(knowledge_source.teardown_state_json or {})
+    stop_assessment: managed_datasource.ConversionStopAssessment | None = None
+    blocking_step = "validate_gateway_workload"
     try:
         from apps.node.services.internal.node_workload import (
             get_node_workload_blockers,
@@ -283,6 +298,7 @@ def run_knowledge_source_teardown(
             raise ValidationError(
                 {"knowledge_source": "Data gateway restore work is still stopping."}
             )
+        blocking_step = "validate_chat_ownership"
         if _session_links_blocking_ks_teardown(
             knowledge_source,
             owner_session_link_id=owner_session_link_id,
@@ -292,13 +308,15 @@ def run_knowledge_source_teardown(
             )
 
         if knowledge_source.sl_datasource_uuid:
+            blocking_step = "cancel_conversion"
             _renew(knowledge_source.id, claim_token)
             sl_client.cancel_managed_datasource_conversion(
                 str(knowledge_source.sl_datasource_uuid)
             )
-            if not managed_datasource.conversion_stop_confirmed(
+            stop_assessment = managed_datasource.assess_conversion_stop(
                 knowledge_source
-            ):
+            )
+            if not stop_assessment.confirmed:
                 _save_step(
                     knowledge_source.id,
                     claim_token,
@@ -319,6 +337,7 @@ def run_knowledge_source_teardown(
 
         from apps.lens_bridge.services.assistants import _delete_sl_assistant
 
+        blocking_step = "delete_assistants"
         assistant_uuids = {
             link.sl_assistant_uuid
             for link in knowledge_source.assistant_links.filter(is_deleted=False).only(
@@ -347,6 +366,7 @@ def run_knowledge_source_teardown(
         )
 
         if knowledge_source.sl_datasource_uuid:
+            blocking_step = "delete_datasource"
             _renew(knowledge_source.id, claim_token)
             sl_client.delete_managed_datasource(
                 str(knowledge_source.sl_datasource_uuid)
@@ -364,6 +384,7 @@ def run_knowledge_source_teardown(
             status="success",
         )
 
+        blocking_step = "cleanup_workspace"
         cleanup_knowledge_source_workspace(
             knowledge_source,
             claim_token=claim_token,
@@ -375,6 +396,7 @@ def run_knowledge_source_teardown(
             "cleanup_workspace",
             status="success",
         )
+        state = teardown_blocking.clear_blocking(state)
         now = timezone.now()
         updated = LensKnowledgeSource.all_objects.filter(
             pk=knowledge_source.id,
@@ -404,13 +426,60 @@ def run_knowledge_source_teardown(
             status="retry",
             error=str(exc),
         )
+        if stop_assessment is not None and not stop_assessment.confirmed:
+            blocking_reason = "conversion_stop_unconfirmed"
+            task_id = stop_assessment.task_id
+            remote_status = stop_assessment.remote_status
+            stop_confirmation_source = (
+                stop_assessment.stop_confirmation_source
+            )
+        else:
+            # The stage is stable across retries but changes when teardown
+            # makes substantive progress. Full exception details remain in
+            # the step journal.
+            blocking_reason = blocking_step
+            task_id = ""
+            remote_status = ""
+            stop_confirmation_source = ""
+        state, blocking = teardown_blocking.record_blocking(
+            state,
+            reason=blocking_reason,
+            task_id=task_id,
+            gateway_link_id=knowledge_source.gateway_link_id,
+            remote_status=remote_status,
+            stop_confirmation_source=stop_confirmation_source,
+        )
+        requires_intervention = bool(blocking["intervention_required"])
+        retry_at = (
+            None
+            if requires_intervention
+            else next_retry_at(int(blocking["consecutive_attempts"]))
+        )
         LensKnowledgeSource.all_objects.filter(
             pk=knowledge_source.id,
             teardown_claim_token=claim_token,
         ).update(
-            status_detail="Knowledge source cleanup is incomplete and will be retried.",
+            status_detail=(
+                "Knowledge source cleanup requires operator intervention."
+                if requires_intervention
+                else "Knowledge source cleanup is incomplete and will be retried."
+            ),
             teardown_claim_token=None,
             teardown_claimed_at=None,
+            teardown_next_retry_at=retry_at,
+            teardown_state_json=state,
             updated_at=timezone.now(),
+        )
+        logger.warning(
+            "knowledge source teardown blocked ks_id=%s gateway_link_id=%s "
+            "task_id=%s remote_status=%s reason=%s attempts=%s "
+            "intervention_required=%s",
+            knowledge_source.id,
+            knowledge_source.gateway_link_id,
+            task_id,
+            remote_status,
+            blocking_reason,
+            blocking["consecutive_attempts"],
+            requires_intervention,
         )
         raise KnowledgeSourceTeardownIncompleteError(str(exc)) from exc

--- a/src/backend/apps/lens_bridge/services/managed_datasource.py
+++ b/src/backend/apps/lens_bridge/services/managed_datasource.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 import uuid
+from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import Any, Callable
 
@@ -412,18 +413,29 @@ def _final_callback_acknowledged(task: dict[str, Any]) -> bool:
     )
 
 
-def conversion_stop_confirmed(ks: LensKnowledgeSource) -> bool:
-    """Return whether SourceLens proves the LensNode conversion has stopped."""
+@dataclass(frozen=True)
+class ConversionStopAssessment:
+    """SourceLens evidence used to fence destructive workspace cleanup."""
+
+    confirmed: bool
+    task_id: str = ""
+    remote_status: str = ""
+    stop_confirmation_source: str = ""
+    reason: str = ""
+
+
+def assess_conversion_stop(ks: LensKnowledgeSource) -> ConversionStopAssessment:
+    """Return SourceLens' durable proof that a conversion executor stopped."""
 
     conversion_state = (ks.sync_state_json or {}).get("conversion")
     if not isinstance(conversion_state, dict):
-        return True
+        return ConversionStopAssessment(True, reason="no_conversion")
     task_id = str(conversion_state.get("task_id") or "").strip()
     if not task_id:
         if str(conversion_state.get("status") or "").upper() != "STARTING":
-            return True
+            return ConversionStopAssessment(True, reason="no_dispatched_task")
         if not ks.sl_datasource_uuid:
-            return False
+            return ConversionStopAssessment(False, reason="unresolved_start")
         task = _recover_started_conversion(
             datasource_uuid=str(ks.sl_datasource_uuid),
             state=conversion_state,
@@ -431,10 +443,10 @@ def conversion_stop_confirmed(ks: LensKnowledgeSource) -> bool:
         if task is None:
             # An empty list/cancel probe can race an in-flight conversion POST.
             # Only an operation-key lookup or a final callback can prove safety.
-            return False
+            return ConversionStopAssessment(False, reason="unresolved_start")
         task_id = str(task.get("task_id") or "").strip()
         if not task_id:
-            return False
+            return ConversionStopAssessment(False, reason="unresolved_start")
         conversion_state["task_id"] = task_id
         conversion_state["task_execution_id"] = task.get("id")
         conversion_state["status"] = str(task.get("status") or "PENDING")
@@ -445,31 +457,106 @@ def conversion_stop_confirmed(ks: LensKnowledgeSource) -> bool:
         task = None
     task = task or sl_client.get_task_by_id(task_id)
     if task is None:
-        return False
-    status = str(task.get("status") or "")
+        return ConversionStopAssessment(
+            False,
+            task_id=task_id,
+            reason="remote_task_missing",
+        )
+    returned_task_id = str(task.get("task_id") or "").strip()
+    if returned_task_id != task_id:
+        return ConversionStopAssessment(
+            False,
+            task_id=task_id,
+            remote_status=str(task.get("status") or "").upper(),
+            reason="remote_task_identity_mismatch",
+        )
+    status = str(task.get("status") or "").upper()
     if status == "SUCCESS":
-        return True
+        return ConversionStopAssessment(
+            True,
+            task_id=task_id,
+            remote_status=status,
+            reason="conversion_completed",
+        )
     if status not in {"FAILURE", "REVOKED"}:
-        return False
+        return ConversionStopAssessment(
+            False,
+            task_id=task_id,
+            remote_status=status,
+            reason="conversion_still_running",
+        )
     manual_confirmation = conversion_state.get("manual_stop_confirmation")
     if (
         isinstance(manual_confirmation, dict)
         and manual_confirmation.get("confirmed") is True
         and str(manual_confirmation.get("task_id") or "") == task_id
     ):
-        return True
+        return ConversionStopAssessment(
+            True,
+            task_id=task_id,
+            remote_status=status,
+            stop_confirmation_source="operator",
+            reason="manual_stop_confirmation",
+        )
     metadata = (
         task.get("metadata") if isinstance(task.get("metadata"), dict) else {}
     )
-    if not metadata.get("datasource_conversion_request_id"):
-        return True
+    completion_source = str(metadata.get("completion_source") or "").strip()
+    stop_source = str(metadata.get("stop_confirmation_source") or "").strip()
+    if stop_source == "queued_before_dispatch":
+        return ConversionStopAssessment(
+            True,
+            task_id=task_id,
+            remote_status=status,
+            stop_confirmation_source=stop_source,
+            reason="queued_before_dispatch",
+        )
+    if (
+        completion_source == "lensnode_callback"
+        and stop_source == "lensnode_callback"
+    ):
+        return ConversionStopAssessment(
+            True,
+            task_id=task_id,
+            remote_status=status,
+            stop_confirmation_source=stop_source,
+            reason="lensnode_callback",
+        )
+    if _final_callback_acknowledged(task):
+        return ConversionStopAssessment(
+            True,
+            task_id=task_id,
+            remote_status=status,
+            stop_confirmation_source="legacy_callback_timestamp",
+            reason="legacy_callback_timestamp",
+        )
     if not (
         metadata.get("timeout_cancelled_at")
         or metadata.get("manual_revoked_at")
     ):
-        # A normal LensNode failure is itself the final callback.
-        return "conversion_summary" in metadata
-    return _final_callback_acknowledged(task)
+        # Older SourceLens versions exposed the completed conversion summary
+        # before adding explicit callback provenance.
+        if status == "FAILURE" and "conversion_summary" in metadata:
+            return ConversionStopAssessment(
+                True,
+                task_id=task_id,
+                remote_status=status,
+                stop_confirmation_source="legacy_conversion_summary",
+                reason="legacy_conversion_summary",
+            )
+    return ConversionStopAssessment(
+        False,
+        task_id=task_id,
+        remote_status=status,
+        stop_confirmation_source=stop_source,
+        reason="terminal_stop_unconfirmed",
+    )
+
+
+def conversion_stop_confirmed(ks: LensKnowledgeSource) -> bool:
+    """Return whether SourceLens proves the LensNode conversion has stopped."""
+
+    return assess_conversion_stop(ks).confirmed
 
 
 def convert_documents(

--- a/src/backend/apps/lens_bridge/services/teardown_blocking.py
+++ b/src/backend/apps/lens_bridge/services/teardown_blocking.py
@@ -1,0 +1,108 @@
+"""Bounded retry state for durable Chat and Knowledge Source cleanup."""
+
+from __future__ import annotations
+
+import hashlib
+from datetime import datetime
+from typing import Any
+
+from django.conf import settings
+from django.utils import timezone
+from django.utils.dateparse import parse_datetime
+
+INTERVENTION_ATTEMPT_THRESHOLD = max(
+    1,
+    int(getattr(settings, "LENS_TEARDOWN_INTERVENTION_ATTEMPTS", 12)),
+)
+INTERVENTION_AGE_SECONDS = max(
+    60,
+    int(getattr(settings, "LENS_TEARDOWN_INTERVENTION_SECONDS", 6 * 3600)),
+)
+
+
+def intervention_required(state: dict[str, Any] | None) -> bool:
+    blocking = (state or {}).get("blocking")
+    return bool(
+        isinstance(blocking, dict)
+        and blocking.get("intervention_required") is True
+    )
+
+
+def clear_blocking(state: dict[str, Any] | None) -> dict[str, Any]:
+    updated = dict(state or {})
+    updated.pop("blocking", None)
+    return updated
+
+
+def _fingerprint(
+    *,
+    reason: str,
+    task_id: str,
+    gateway_link_id: int | None,
+    remote_status: str,
+) -> str:
+    material = "\x00".join(
+        [reason, task_id, str(gateway_link_id or ""), remote_status]
+    )
+    return hashlib.sha256(material.encode("utf-8")).hexdigest()
+
+
+def _aware_timestamp(value: Any) -> datetime | None:
+    parsed = parse_datetime(str(value or ""))
+    if parsed is None:
+        return None
+    if timezone.is_naive(parsed):
+        return timezone.make_aware(parsed, timezone.get_current_timezone())
+    return parsed
+
+
+def record_blocking(
+    state: dict[str, Any] | None,
+    *,
+    reason: str,
+    task_id: str = "",
+    gateway_link_id: int | None = None,
+    remote_status: str = "",
+    stop_confirmation_source: str = "",
+    now: datetime | None = None,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Record one stable blocking condition and decide operator intervention."""
+
+    now = now or timezone.now()
+    updated = dict(state or {})
+    previous = updated.get("blocking")
+    previous = previous if isinstance(previous, dict) else {}
+    fingerprint = _fingerprint(
+        reason=reason,
+        task_id=task_id,
+        gateway_link_id=gateway_link_id,
+        remote_status=remote_status,
+    )
+    same_condition = previous.get("fingerprint") == fingerprint
+    first_seen = (
+        _aware_timestamp(previous.get("first_seen_at")) if same_condition else None
+    ) or now
+    attempts = (
+        int(previous.get("consecutive_attempts") or 0) + 1
+        if same_condition
+        else 1
+    )
+    elapsed_seconds = max(0, int((now - first_seen).total_seconds()))
+    requires_intervention = (
+        attempts >= INTERVENTION_ATTEMPT_THRESHOLD
+        and elapsed_seconds >= INTERVENTION_AGE_SECONDS
+    )
+    blocking = {
+        "reason": reason,
+        "fingerprint": fingerprint,
+        "task_id": task_id,
+        "gateway_link_id": gateway_link_id,
+        "remote_status": remote_status,
+        "stop_confirmation_source": stop_confirmation_source,
+        "first_seen_at": first_seen.isoformat(),
+        "last_seen_at": now.isoformat(),
+        "consecutive_attempts": attempts,
+        "intervention_required": requires_intervention,
+    }
+    updated["blocking"] = blocking
+    return updated, blocking

--- a/src/backend/apps/lens_bridge/tasks/chat_lifecycle.py
+++ b/src/backend/apps/lens_bridge/tasks/chat_lifecycle.py
@@ -204,6 +204,14 @@ def reconcile_lens_resource_teardowns_task(*, limit: int = 100) -> dict:
             )
         )
         .filter(
+            Q(
+                teardown_state_json__blocking__intervention_required__isnull=True
+            )
+            | Q(
+                teardown_state_json__blocking__intervention_required=False
+            )
+        )
+        .filter(
             Q(teardown_next_retry_at__isnull=True)
             | Q(teardown_next_retry_at__lte=now)
         )

--- a/src/backend/apps/lens_bridge/tasks/knowledge_source_teardown.py
+++ b/src/backend/apps/lens_bridge/tasks/knowledge_source_teardown.py
@@ -74,6 +74,14 @@ def due_knowledge_source_teardown_ids(
             lifecycle_status=LensKnowledgeSource.LifecycleStatus.DELETING,
         )
         .filter(
+            Q(
+                teardown_state_json__blocking__intervention_required__isnull=True
+            )
+            | Q(
+                teardown_state_json__blocking__intervention_required=False
+            )
+        )
+        .filter(
             Q(teardown_next_retry_at__isnull=True)
             | Q(teardown_next_retry_at__lte=now)
         )

--- a/src/backend/apps/lens_bridge/tests/test_chat_teardown.py
+++ b/src/backend/apps/lens_bridge/tests/test_chat_teardown.py
@@ -12,6 +12,7 @@ from django.utils import timezone
 from apps.iam.models import Organization
 from apps.lens_bridge.models import (
     LensAssistantLink,
+    LensGatewayChatSlot,
     LensGatewayLink,
     LensKnowledgeSource,
     LensSessionLink,
@@ -21,6 +22,7 @@ from apps.lens_bridge.services import (
     assistant_access,
     chat_lifecycle,
     knowledge_source_teardown,
+    managed_datasource,
     sl_client,
 )
 from apps.lens_bridge.tasks.chat_lifecycle import (
@@ -202,6 +204,14 @@ class CopilotChatTeardownTests(TestCase):
         )
         self.session.lifecycle_status = LensSessionLink.LifecycleStatus.DELETING
         self.session.save(update_fields=["lifecycle_status", "updated_at"])
+        LensGatewayChatSlot.objects.create(
+            gateway_link=self.gateway_link,
+            slot_number=1,
+            session_link=self.session,
+            session_generation=self.session.provision_generation,
+            acquired_at=timezone.now(),
+            heartbeat_at=timezone.now(),
+        )
 
         result = chat_lifecycle.run_copilot_chat_teardown(
             session_link_id=self.session.id
@@ -220,6 +230,11 @@ class CopilotChatTeardownTests(TestCase):
         self.assertEqual(
             self.workspace_binding.state,
             LensWorkspaceBinding.State.DELETED,
+        )
+        self.assertFalse(
+            LensGatewayChatSlot.objects.filter(
+                session_link=self.session
+            ).exists()
         )
         self.assertEqual(run_agent_task.call_args.kwargs["kind"], "lens.ks.cleanup")
 
@@ -294,6 +309,14 @@ class CopilotChatTeardownTests(TestCase):
                 "updated_at",
             ]
         )
+        LensGatewayChatSlot.objects.create(
+            gateway_link=self.gateway_link,
+            slot_number=1,
+            session_link=self.session,
+            session_generation=self.session.provision_generation,
+            acquired_at=timezone.now(),
+            heartbeat_at=timezone.now(),
+        )
 
         result = chat_lifecycle.run_copilot_chat_teardown(
             session_link_id=self.session.id
@@ -308,6 +331,11 @@ class CopilotChatTeardownTests(TestCase):
         self.assertEqual(self.session.status, LensSessionLink.Status.ACTIVE)
         self.assertIsNone(self.session.knowledge_source_id)
         self.assertIn("LensNode was unavailable", self.session.lifecycle_error)
+        self.assertFalse(
+            LensGatewayChatSlot.objects.filter(
+                session_link=self.session
+            ).exists()
+        )
 
     @mock.patch("apps.lens_bridge.services.assistant_access.soft_delete_assistant_link")
     @mock.patch("apps.lens_bridge.services.assistants._delete_sl_assistant")
@@ -343,7 +371,14 @@ class CopilotChatTeardownTests(TestCase):
                 pk=self.knowledge_source.id
             ).update(
                 teardown_state_json={
-                    "cancel_conversion": {"status": "waiting"}
+                    "cancel_conversion": {"status": "waiting"},
+                    "blocking": {
+                        "reason": "conversion_stop_unconfirmed",
+                        "task_id": "convert-1",
+                        "gateway_link_id": self.gateway_link.id,
+                        "remote_status": "CANCELLING",
+                        "intervention_required": False,
+                    },
                 }
             )
             raise knowledge_source_teardown.KnowledgeSourceTeardownIncompleteError(
@@ -372,6 +407,90 @@ class CopilotChatTeardownTests(TestCase):
         self.assertEqual(
             self.workspace_binding.state,
             LensWorkspaceBinding.State.READY,
+        )
+        self.assertEqual(
+            self.session.teardown_state_json["blocking"]["reason"],
+            "conversion_stop_unconfirmed",
+        )
+        self.assertEqual(
+            self.session.teardown_state_json["blocking"]["task_id"],
+            "convert-1",
+        )
+
+    @mock.patch("apps.lens_bridge.services.assistant_access.soft_delete_assistant_link")
+    @mock.patch("apps.lens_bridge.services.assistants._delete_sl_assistant")
+    @mock.patch("apps.lens_bridge.services.chat_lifecycle.sl_client.request_json")
+    def test_knowledge_source_intervention_stops_chat_cleanup_retries(
+        self,
+        request_json,
+        _delete_assistant,
+        _soft_delete_assistant,
+    ):
+        request_json.side_effect = self._not_found()
+        self.session.lifecycle_status = LensSessionLink.LifecycleStatus.DELETING
+        self.session.cleanup_intent = LensSessionLink.CleanupIntent.DELETE_SESSION
+        self.session.cleanup_status = LensSessionLink.CleanupStatus.PENDING
+        self.session.save(
+            update_fields=[
+                "lifecycle_status",
+                "cleanup_intent",
+                "cleanup_status",
+                "updated_at",
+            ]
+        )
+        LensGatewayChatSlot.objects.create(
+            gateway_link=self.gateway_link,
+            slot_number=1,
+            session_link=self.session,
+            session_generation=self.session.provision_generation,
+            acquired_at=timezone.now(),
+            heartbeat_at=timezone.now(),
+        )
+
+        blocking = {
+            "reason": "cleanup_workspace",
+            "fingerprint": "stable-workspace-failure",
+            "task_id": "",
+            "gateway_link_id": self.gateway_link.id,
+            "remote_status": "",
+            "stop_confirmation_source": "",
+            "first_seen_at": timezone.now().isoformat(),
+            "last_seen_at": timezone.now().isoformat(),
+            "consecutive_attempts": 12,
+            "intervention_required": True,
+        }
+
+        def require_intervention(**_kwargs):
+            LensKnowledgeSource.all_objects.filter(
+                pk=self.knowledge_source.id
+            ).update(teardown_state_json={"blocking": blocking})
+            raise knowledge_source_teardown.KnowledgeSourceTeardownIncompleteError(
+                "Workspace cleanup requires operator intervention."
+            )
+
+        with mock.patch(
+            "apps.lens_bridge.services.knowledge_source_teardown."
+            "run_knowledge_source_teardown",
+            side_effect=require_intervention,
+        ), self.assertRaises(chat_lifecycle.ChatTeardownIncompleteError):
+            chat_lifecycle.run_copilot_chat_teardown(
+                session_link_id=self.session.id
+            )
+
+        self.session.refresh_from_db()
+        self.assertEqual(
+            self.session.cleanup_status,
+            LensSessionLink.CleanupStatus.BLOCKED,
+        )
+        self.assertIsNone(self.session.teardown_next_retry_at)
+        self.assertEqual(
+            self.session.teardown_state_json["blocking"],
+            blocking,
+        )
+        self.assertTrue(
+            LensGatewayChatSlot.objects.filter(
+                session_link=self.session
+            ).exists()
         )
 
     @mock.patch(
@@ -1398,6 +1517,44 @@ class CopilotChatTeardownTests(TestCase):
         )
         self.assertEqual(delay.call_count, 2)
 
+    @mock.patch(
+        "apps.lens_bridge.tasks.knowledge_source_teardown."
+        "execute_knowledge_source_teardown_task.delay"
+    )
+    @mock.patch(
+        "apps.lens_bridge.tasks.chat_lifecycle."
+        "execute_copilot_chat_teardown_task.delay"
+    )
+    def test_teardown_reconciler_skips_operator_intervention(
+        self,
+        chat_delay,
+        ks_delay,
+    ):
+        self.session.lifecycle_status = LensSessionLink.LifecycleStatus.DELETING
+        self.session.cleanup_intent = LensSessionLink.CleanupIntent.DELETE_SESSION
+        self.session.cleanup_status = LensSessionLink.CleanupStatus.BLOCKED
+        self.session.teardown_next_retry_at = None
+        self.session.teardown_state_json = {
+            "intent": "delete_session",
+            "blocking": {"intervention_required": True},
+        }
+        self.session.save(
+            update_fields=[
+                "lifecycle_status",
+                "cleanup_intent",
+                "cleanup_status",
+                "teardown_next_retry_at",
+                "teardown_state_json",
+                "updated_at",
+            ]
+        )
+
+        result = reconcile_lens_resource_teardowns_task(limit=10)
+
+        self.assertEqual(result["queued"], 0)
+        chat_delay.assert_not_called()
+        ks_delay.assert_not_called()
+
     @mock.patch("apps.node.services.internal.agent_task.run_agent_task_sync")
     @mock.patch("apps.lens_bridge.services.assistant_access.soft_delete_assistant_link")
     @mock.patch("apps.lens_bridge.services.assistants._delete_sl_assistant")
@@ -1701,8 +1858,13 @@ class CopilotChatTeardownTests(TestCase):
 
     @mock.patch(
         "apps.lens_bridge.services.knowledge_source_teardown."
-        "managed_datasource.conversion_stop_confirmed",
-        return_value=False,
+        "managed_datasource.assess_conversion_stop",
+        return_value=managed_datasource.ConversionStopAssessment(
+            False,
+            task_id="convert-1",
+            remote_status="CANCELLING",
+            reason="conversion_still_running",
+        ),
     )
     @mock.patch(
         "apps.lens_bridge.services.knowledge_source_teardown."

--- a/src/backend/apps/lens_bridge/tests/test_knowledge_source_teardown.py
+++ b/src/backend/apps/lens_bridge/tests/test_knowledge_source_teardown.py
@@ -1,5 +1,6 @@
 import threading
 from concurrent.futures import ThreadPoolExecutor
+from datetime import timedelta
 from unittest import mock
 
 from django.contrib.auth import get_user_model
@@ -16,10 +17,13 @@ from apps.lens_bridge.models import (
     LensSessionLink,
     LensWorkspaceBinding,
 )
-from apps.lens_bridge.services import knowledge_source_teardown
+from apps.lens_bridge.services import knowledge_source_teardown, teardown_blocking
 from apps.node.models import Node
 from apps.lens_bridge.tasks.chat_lifecycle import (
     reconcile_lens_resource_teardowns_task,
+)
+from apps.lens_bridge.tasks.knowledge_source_teardown import (
+    due_knowledge_source_teardown_ids,
 )
 
 
@@ -264,6 +268,71 @@ class KnowledgeSourceDeleteApiTests(TestCase):
         )
 
         self.assertEqual(result["status"], "deleted")
+
+    @mock.patch.object(teardown_blocking, "INTERVENTION_ATTEMPT_THRESHOLD", 2)
+    @mock.patch.object(teardown_blocking, "INTERVENTION_AGE_SECONDS", 1)
+    @mock.patch(
+        "apps.node.services.internal.node_workload.get_node_workload_blockers",
+        return_value=[mock.MagicMock(code="restore_active")],
+    )
+    def test_persistent_blocker_stops_reconciler_until_operator_recovery(
+        self,
+        _blockers,
+    ):
+        self.knowledge_source.lifecycle_status = (
+            LensKnowledgeSource.LifecycleStatus.DELETING
+        )
+        self.knowledge_source.save(
+            update_fields=[
+                "lifecycle_status",
+                "updated_at",
+            ]
+        )
+
+        with self.assertRaises(
+            knowledge_source_teardown.KnowledgeSourceTeardownIncompleteError
+        ):
+            knowledge_source_teardown.run_knowledge_source_teardown(
+                knowledge_source_id=self.knowledge_source.id
+            )
+
+        self.knowledge_source.refresh_from_db()
+        state = dict(self.knowledge_source.teardown_state_json)
+        state["blocking"]["first_seen_at"] = (
+            timezone.now() - timedelta(seconds=2)
+        ).isoformat()
+        self.knowledge_source.teardown_state_json = state
+        self.knowledge_source.teardown_next_retry_at = timezone.now()
+        self.knowledge_source.save(
+            update_fields=[
+                "teardown_state_json",
+                "teardown_next_retry_at",
+                "updated_at",
+            ]
+        )
+
+        with self.assertRaises(
+            knowledge_source_teardown.KnowledgeSourceTeardownIncompleteError
+        ):
+            knowledge_source_teardown.run_knowledge_source_teardown(
+                knowledge_source_id=self.knowledge_source.id
+            )
+
+        self.knowledge_source.refresh_from_db()
+        self.assertEqual(
+            self.knowledge_source.teardown_state_json["blocking"]["reason"],
+            "validate_gateway_workload",
+        )
+        self.assertTrue(
+            self.knowledge_source.teardown_state_json["blocking"][
+                "intervention_required"
+            ]
+        )
+        self.assertIsNone(self.knowledge_source.teardown_next_retry_at)
+        self.assertNotIn(
+            self.knowledge_source.id,
+            due_knowledge_source_teardown_ids(limit=10),
+        )
 
 
 class KnowledgeSourceTeardownConcurrencyTests(TransactionTestCase):

--- a/src/backend/apps/lens_bridge/tests/test_managed_datasource.py
+++ b/src/backend/apps/lens_bridge/tests/test_managed_datasource.py
@@ -190,10 +190,77 @@ class ManagedDatasourceTests(SimpleTestCase):
         get_task.return_value = {
             "task_id": "convert-1",
             "status": "REVOKED",
-            "metadata": {"manual_revoked_at": "2026-08-03T04:00:00Z"},
+            "metadata": {
+                "manual_revoked_at": "2026-08-03T04:00:00Z",
+                "stop_confirmation_source": "queued_before_dispatch",
+            },
         }
 
         self.assertTrue(
+            managed_datasource.conversion_stop_confirmed(knowledge_source)
+        )
+
+    @patch("apps.lens_bridge.services.managed_datasource.sl_client.get_task_by_id")
+    def test_plain_revoked_task_does_not_confirm_stop(self, get_task):
+        knowledge_source = self._knowledge_source()
+        knowledge_source.sync_state_json = {
+            "conversion": {"task_id": "convert-1"}
+        }
+        get_task.return_value = {
+            "task_id": "convert-1",
+            "status": "REVOKED",
+            "metadata": {},
+        }
+
+        self.assertFalse(
+            managed_datasource.conversion_stop_confirmed(knowledge_source)
+        )
+
+    @patch("apps.lens_bridge.services.managed_datasource.sl_client.get_task_by_id")
+    def test_lensnode_callback_contract_confirms_stop(self, get_task):
+        knowledge_source = self._knowledge_source()
+        knowledge_source.sync_state_json = {
+            "conversion": {"task_id": "convert-1"}
+        }
+        for status in ("REVOKED", "FAILURE"):
+            with self.subTest(status=status):
+                get_task.return_value = {
+                    "task_id": "convert-1",
+                    "status": status,
+                    "metadata": {
+                        "completion_source": "lensnode_callback",
+                        "stop_confirmation_source": "lensnode_callback",
+                    },
+                }
+
+                assessment = managed_datasource.assess_conversion_stop(
+                    knowledge_source
+                )
+
+                self.assertTrue(assessment.confirmed)
+                self.assertEqual(assessment.task_id, "convert-1")
+                self.assertEqual(assessment.remote_status, status)
+                self.assertEqual(
+                    assessment.stop_confirmation_source,
+                    "lensnode_callback",
+                )
+
+    @patch("apps.lens_bridge.services.managed_datasource.sl_client.get_task_by_id")
+    def test_partial_lensnode_callback_contract_does_not_confirm_stop(
+        self,
+        get_task,
+    ):
+        knowledge_source = self._knowledge_source()
+        knowledge_source.sync_state_json = {
+            "conversion": {"task_id": "convert-1"}
+        }
+        get_task.return_value = {
+            "task_id": "convert-1",
+            "status": "FAILURE",
+            "metadata": {"stop_confirmation_source": "lensnode_callback"},
+        }
+
+        self.assertFalse(
             managed_datasource.conversion_stop_confirmed(knowledge_source)
         )
 
@@ -236,6 +303,26 @@ class ManagedDatasourceTests(SimpleTestCase):
         self.assertFalse(
             managed_datasource.conversion_stop_confirmed(knowledge_source)
         )
+
+    @patch("apps.lens_bridge.services.managed_datasource.sl_client.get_task_by_id")
+    def test_mismatched_remote_task_does_not_prove_conversion_stopped(
+        self,
+        get_task,
+    ):
+        knowledge_source = self._knowledge_source()
+        knowledge_source.sync_state_json = {
+            "conversion": {"task_id": "convert-1"}
+        }
+        get_task.return_value = {
+            "task_id": "different-task",
+            "status": "SUCCESS",
+            "metadata": {},
+        }
+
+        assessment = managed_datasource.assess_conversion_stop(knowledge_source)
+
+        self.assertFalse(assessment.confirmed)
+        self.assertEqual(assessment.reason, "remote_task_identity_mismatch")
 
     @patch(
         "apps.lens_bridge.services.managed_datasource."
@@ -547,7 +634,9 @@ class ManagedDatasourceTests(SimpleTestCase):
         get_task.return_value = {
             "task_id": "convert-1",
             "status": "FAILURE",
-            "metadata": {},
+            "metadata": {
+                "stop_confirmation_source": "queued_before_dispatch",
+            },
         }
 
         self.assertTrue(

--- a/src/backend/apps/lens_bridge/tests/test_resume_blocked_chat_cleanup_command.py
+++ b/src/backend/apps/lens_bridge/tests/test_resume_blocked_chat_cleanup_command.py
@@ -1,9 +1,17 @@
 from unittest.mock import patch
 
+from django.contrib.auth import get_user_model
 from django.core.management.base import CommandError
-from django.test import SimpleTestCase
+from django.test import SimpleTestCase, TestCase
 
+from apps.iam.models import Organization
 from apps.lens_bridge.management.commands.resume_blocked_chat_cleanup import Command
+from apps.lens_bridge.models import (
+    LensGatewayLink,
+    LensKnowledgeSource,
+    LensSessionLink,
+)
+from apps.node.models import Node
 
 
 class ResumeBlockedChatCleanupCommandTests(SimpleTestCase):
@@ -61,3 +69,412 @@ class ResumeBlockedChatCleanupCommandTests(SimpleTestCase):
             Command().handle(**self._options())
 
         get_task.assert_called_once_with("convert-1")
+
+
+class ResumeBlockedChatCleanupDatabaseTests(TestCase):
+    def setUp(self):
+        self.tenant = Organization.objects.create(
+            key="cleanup-recovery-tenant",
+            name="Cleanup recovery tenant",
+        )
+        self.platform_org = Organization.objects.create(
+            key="cleanup-recovery-platform",
+            name="Cleanup recovery platform",
+        )
+        self.user = get_user_model().objects.create_user(
+            username="cleanup-recovery@example.test",
+            email="cleanup-recovery@example.test",
+        )
+        self.gateway = Node.objects.create(
+            organization=self.platform_org,
+            name="cleanup-recovery-gateway",
+            role=Node.Role.GATEWAY,
+            status=Node.Status.ACTIVE,
+            availability=Node.Availability.ONLINE,
+        )
+        self.gateway_link = LensGatewayLink.objects.create(
+            organization=self.platform_org,
+            gateway=self.gateway,
+            scope=LensGatewayLink.GatewayScope.PLATFORM,
+            origin=LensGatewayLink.Origin.PLATFORM,
+            workspace_root="/workspace/platform/data",
+        )
+        self.knowledge_source = LensKnowledgeSource.objects.create(
+            organization=self.tenant,
+            name="Blocked workspace",
+            gateway=self.gateway,
+            gateway_link=self.gateway_link,
+            backup_source_snapshot_id=11,
+            source_path="/data",
+            workspace_path_on_lensnode="/workspace/platform/data/blocked",
+            created_by=self.user,
+            lifecycle_status=LensKnowledgeSource.LifecycleStatus.DELETING,
+            sync_state_json={
+                "conversion": {"task_id": "convert-1", "status": "REVOKED"}
+            },
+            teardown_state_json={
+                "blocking": {
+                    "intervention_required": True,
+                    "task_id": "convert-1",
+                }
+            },
+            teardown_attempts=99,
+        )
+        self.session = LensSessionLink.objects.create(
+            organization=self.tenant,
+            hfl_user=self.user,
+            gateway_link=self.gateway_link,
+            knowledge_source=self.knowledge_source,
+            lifecycle_status=LensSessionLink.LifecycleStatus.DELETING,
+            cleanup_intent=LensSessionLink.CleanupIntent.DELETE_SESSION,
+            cleanup_status=LensSessionLink.CleanupStatus.BLOCKED,
+            teardown_state_json={
+                "intent": "delete_session",
+                "blocking": {
+                    "intervention_required": True,
+                    "task_id": "convert-1",
+                },
+            },
+            teardown_attempts=99,
+        )
+
+    @patch(
+        "apps.lens_bridge.services.chat_lifecycle._queue_teardown_or_record_error"
+    )
+    @patch(
+        "apps.lens_bridge.management.commands.resume_blocked_chat_cleanup."
+        "sl_client.get_task_by_id",
+        return_value={"task_id": "convert-1", "status": "REVOKED"},
+    )
+    def test_resume_locks_nullable_relationships_separately_and_requeues(
+        self,
+        _get_task,
+        queue_teardown,
+    ):
+        with self.captureOnCommitCallbacks(execute=True):
+            Command().handle(
+                session_id=self.session.id,
+                source_lens_task_id="convert-1",
+                reason="Executor stop verified from the gateway.",
+                confirm_executor_stopped=True,
+            )
+
+        self.session.refresh_from_db()
+        self.knowledge_source.refresh_from_db()
+        self.assertEqual(
+            self.session.cleanup_status,
+            LensSessionLink.CleanupStatus.PENDING,
+        )
+        self.assertEqual(self.session.teardown_attempts, 0)
+        self.assertNotIn("blocking", self.session.teardown_state_json)
+        self.assertEqual(self.knowledge_source.teardown_attempts, 0)
+        self.assertNotIn(
+            "blocking",
+            self.knowledge_source.teardown_state_json,
+        )
+        self.assertTrue(
+            self.knowledge_source.sync_state_json["conversion"][
+                "manual_stop_confirmation"
+            ]["confirmed"]
+        )
+        queue_teardown.assert_called_once_with(self.session.id)
+
+    @patch(
+        "apps.lens_bridge.management.commands.resume_blocked_chat_cleanup."
+        "sl_client.get_task_by_id",
+        return_value={"task_id": "different-task", "status": "REVOKED"},
+    )
+    def test_resume_rejects_a_different_remote_task(self, _get_task):
+        with self.assertRaisesRegex(CommandError, "exact requested task identity"):
+            Command().handle(
+                session_id=self.session.id,
+                source_lens_task_id="convert-1",
+                reason="Executor stop verified from the gateway.",
+                confirm_executor_stopped=True,
+            )
+
+    @patch(
+        "apps.lens_bridge.management.commands.resume_blocked_chat_cleanup."
+        "sl_client.get_task_by_id",
+        return_value={"task_id": "convert-1", "status": "REVOKED"},
+    )
+    def test_resume_rejects_task_mismatched_with_blocking_record(self, _get_task):
+        self.session.teardown_state_json = {
+            "intent": "delete_session",
+            "blocking": {
+                "reason": "conversion_stop_unconfirmed",
+                "task_id": "different-task",
+                "intervention_required": True,
+            },
+        }
+        self.session.save(
+            update_fields=["teardown_state_json", "updated_at"]
+        )
+
+        with self.assertRaisesRegex(CommandError, "recorded blocking condition"):
+            Command().handle(
+                session_id=self.session.id,
+                source_lens_task_id="convert-1",
+                reason="Executor stop verified from the gateway.",
+                confirm_executor_stopped=True,
+            )
+
+    @patch(
+        "apps.lens_bridge.management.commands.resume_blocked_chat_cleanup."
+        "sl_client.get_task_by_id",
+        return_value={"task_id": "convert-1", "status": "REVOKED"},
+    )
+    def test_nonconversion_block_rejects_an_unrelated_task(self, _get_task):
+        nonconversion_blocking = {
+            "reason": "cleanup_workspace",
+            "intervention_required": True,
+        }
+        self.session.teardown_state_json = {
+            "intent": "delete_session",
+            "blocking": nonconversion_blocking,
+        }
+        self.session.save(
+            update_fields=["teardown_state_json", "updated_at"]
+        )
+        self.knowledge_source.teardown_state_json = {
+            "blocking": nonconversion_blocking,
+        }
+        self.knowledge_source.save(
+            update_fields=["teardown_state_json", "updated_at"]
+        )
+
+        with self.assertRaisesRegex(CommandError, "not blocked"):
+            Command().handle(
+                session_id=self.session.id,
+                source_lens_task_id="convert-1",
+                reason="Retrying a non-conversion cleanup.",
+                confirm_executor_stopped=True,
+            )
+
+    @patch(
+        "apps.lens_bridge.services.chat_lifecycle._queue_teardown_or_record_error"
+    )
+    @patch(
+        "apps.lens_bridge.management.commands.resume_blocked_chat_cleanup."
+        "sl_client.get_task_by_id"
+    )
+    def test_resume_nonconversion_cleanup_without_a_knowledge_source(
+        self,
+        get_task,
+        queue_teardown,
+    ):
+        session = LensSessionLink.objects.create(
+            organization=self.tenant,
+            hfl_user=self.user,
+            gateway_link=self.gateway_link,
+            lifecycle_status=LensSessionLink.LifecycleStatus.DELETING,
+            cleanup_intent=LensSessionLink.CleanupIntent.DELETE_SESSION,
+            cleanup_status=LensSessionLink.CleanupStatus.BLOCKED,
+            teardown_state_json={
+                "intent": "delete_session",
+                "blocking": {
+                    "reason": "revoke_shares: temporary failure",
+                    "intervention_required": True,
+                },
+            },
+            teardown_attempts=99,
+        )
+
+        with self.captureOnCommitCallbacks(execute=True):
+            Command().handle(
+                session_id=session.id,
+                source_lens_task_id="",
+                reason="The sharing service has recovered.",
+                confirm_executor_stopped=False,
+                confirm_retry=True,
+            )
+
+        session.refresh_from_db()
+        self.assertEqual(
+            session.cleanup_status,
+            LensSessionLink.CleanupStatus.PENDING,
+        )
+        self.assertEqual(session.teardown_attempts, 0)
+        self.assertNotIn("blocking", session.teardown_state_json)
+        self.assertIn(
+            "manual_cleanup_confirmation",
+            session.teardown_state_json,
+        )
+        get_task.assert_not_called()
+        queue_teardown.assert_called_once_with(session.id)
+
+    def test_nonconversion_confirmation_cannot_bypass_conversion_fence(self):
+        with self.assertRaisesRegex(CommandError, "Conversion cleanup requires"):
+            Command().handle(
+                session_id=self.session.id,
+                source_lens_task_id="",
+                reason="Retry requested without conversion proof.",
+                confirm_executor_stopped=False,
+                confirm_retry=True,
+            )
+
+    def test_chat_recovery_does_not_clear_knowledge_source_conversion_fence(self):
+        self.session.teardown_state_json = {
+            "intent": "delete_session",
+            "blocking": {
+                "reason": "delete_session",
+                "intervention_required": True,
+            },
+        }
+        self.session.save(
+            update_fields=["teardown_state_json", "updated_at"]
+        )
+
+        with self.assertRaisesRegex(CommandError, "Conversion cleanup requires"):
+            Command().handle(
+                session_id=self.session.id,
+                source_lens_task_id="",
+                reason="Retry requested for the session cleanup.",
+                confirm_executor_stopped=False,
+                confirm_retry=True,
+            )
+
+        self.knowledge_source.refresh_from_db()
+        self.assertIn("blocking", self.knowledge_source.teardown_state_json)
+
+    @patch(
+        "apps.lens_bridge.services.knowledge_source_teardown._queue_teardown"
+    )
+    def test_resume_orphan_knowledge_source_cleanup(self, queue_teardown):
+        orphan = LensKnowledgeSource.objects.create(
+            organization=self.tenant,
+            name="Orphaned blocked workspace",
+            gateway=self.gateway,
+            gateway_link=self.gateway_link,
+            source_path="/data/orphaned",
+            created_by=self.user,
+            lifecycle_status=LensKnowledgeSource.LifecycleStatus.DELETING,
+            teardown_state_json={
+                "blocking": {
+                    "reason": "cleanup_workspace",
+                    "intervention_required": True,
+                }
+            },
+            teardown_attempts=99,
+        )
+
+        with self.captureOnCommitCallbacks(execute=True):
+            Command().handle(
+                knowledge_source_id=orphan.id,
+                source_lens_task_id="",
+                reason="The Data Gateway filesystem was repaired.",
+                confirm_executor_stopped=False,
+                confirm_retry=True,
+            )
+
+        orphan.refresh_from_db()
+        self.assertEqual(orphan.teardown_attempts, 0)
+        self.assertNotIn("blocking", orphan.teardown_state_json)
+        self.assertIn(
+            "manual_cleanup_confirmation",
+            orphan.teardown_state_json,
+        )
+        queue_teardown.assert_called_once_with(orphan.id)
+
+    def test_knowledge_source_target_rejects_an_attached_chat(self):
+        self.knowledge_source.teardown_state_json = {
+            "blocking": {
+                "reason": "cleanup_workspace",
+                "intervention_required": True,
+            }
+        }
+        self.knowledge_source.save(
+            update_fields=["teardown_state_json", "updated_at"]
+        )
+
+        with self.assertRaisesRegex(CommandError, "still belongs to a Chat"):
+            Command().handle(
+                knowledge_source_id=self.knowledge_source.id,
+                source_lens_task_id="",
+                reason="Retry requested for the attached workspace.",
+                confirm_executor_stopped=False,
+                confirm_retry=True,
+            )
+
+    def test_orphan_knowledge_source_cannot_bypass_conversion_fence(self):
+        orphan = LensKnowledgeSource.objects.create(
+            organization=self.tenant,
+            name="Orphaned conversion workspace",
+            gateway=self.gateway,
+            gateway_link=self.gateway_link,
+            source_path="/data/orphaned-conversion",
+            created_by=self.user,
+            lifecycle_status=LensKnowledgeSource.LifecycleStatus.DELETING,
+            sync_state_json={
+                "conversion": {"task_id": "orphan-convert-1"}
+            },
+            teardown_state_json={
+                "blocking": {
+                    "reason": "conversion_stop_unconfirmed",
+                    "task_id": "orphan-convert-1",
+                    "intervention_required": True,
+                }
+            },
+        )
+
+        with self.assertRaisesRegex(CommandError, "Conversion cleanup requires"):
+            Command().handle(
+                knowledge_source_id=orphan.id,
+                source_lens_task_id="",
+                reason="Retry requested without conversion proof.",
+                confirm_executor_stopped=False,
+                confirm_retry=True,
+            )
+
+    @patch(
+        "apps.lens_bridge.services.knowledge_source_teardown._queue_teardown"
+    )
+    @patch(
+        "apps.lens_bridge.management.commands.resume_blocked_chat_cleanup."
+        "sl_client.get_task_by_id",
+        return_value={"task_id": "orphan-convert-1", "status": "REVOKED"},
+    )
+    def test_resume_orphan_conversion_cleanup(
+        self,
+        _get_task,
+        queue_teardown,
+    ):
+        orphan = LensKnowledgeSource.objects.create(
+            organization=self.tenant,
+            name="Orphaned conversion recovery",
+            gateway=self.gateway,
+            gateway_link=self.gateway_link,
+            source_path="/data/orphaned-conversion-recovery",
+            created_by=self.user,
+            lifecycle_status=LensKnowledgeSource.LifecycleStatus.DELETING,
+            sync_state_json={
+                "conversion": {"task_id": "orphan-convert-1"}
+            },
+            teardown_state_json={
+                "blocking": {
+                    "reason": "conversion_stop_unconfirmed",
+                    "task_id": "orphan-convert-1",
+                    "intervention_required": True,
+                }
+            },
+            teardown_attempts=99,
+        )
+
+        with self.captureOnCommitCallbacks(execute=True):
+            Command().handle(
+                knowledge_source_id=orphan.id,
+                source_lens_task_id="orphan-convert-1",
+                reason="Executor stop verified from the gateway.",
+                confirm_executor_stopped=True,
+                confirm_retry=False,
+            )
+
+        orphan.refresh_from_db()
+        self.assertEqual(orphan.teardown_attempts, 0)
+        self.assertNotIn("blocking", orphan.teardown_state_json)
+        self.assertTrue(
+            orphan.sync_state_json["conversion"][
+                "manual_stop_confirmation"
+            ]["confirmed"]
+        )
+        queue_teardown.assert_called_once_with(orphan.id)

--- a/src/backend/apps/lens_bridge/tests/test_teardown_blocking.py
+++ b/src/backend/apps/lens_bridge/tests/test_teardown_blocking.py
@@ -1,0 +1,97 @@
+from datetime import timedelta
+from unittest.mock import patch
+
+from django.test import SimpleTestCase
+from django.utils import timezone
+
+from apps.lens_bridge.services import teardown_blocking
+
+
+class TeardownBlockingTests(SimpleTestCase):
+    @patch.object(teardown_blocking, "INTERVENTION_ATTEMPT_THRESHOLD", 3)
+    @patch.object(teardown_blocking, "INTERVENTION_AGE_SECONDS", 60)
+    def test_same_condition_eventually_requires_intervention(self):
+        started = timezone.now()
+        state, first = teardown_blocking.record_blocking(
+            {},
+            reason="conversion_stop_unconfirmed",
+            task_id="convert-1",
+            gateway_link_id=7,
+            remote_status="CANCELLING",
+            now=started,
+        )
+        state, second = teardown_blocking.record_blocking(
+            state,
+            reason="conversion_stop_unconfirmed",
+            task_id="convert-1",
+            gateway_link_id=7,
+            remote_status="CANCELLING",
+            now=started + timedelta(seconds=30),
+        )
+        state, third = teardown_blocking.record_blocking(
+            state,
+            reason="conversion_stop_unconfirmed",
+            task_id="convert-1",
+            gateway_link_id=7,
+            remote_status="CANCELLING",
+            now=started + timedelta(seconds=60),
+        )
+
+        self.assertFalse(first["intervention_required"])
+        self.assertFalse(second["intervention_required"])
+        self.assertTrue(third["intervention_required"])
+        self.assertEqual(third["consecutive_attempts"], 3)
+
+    def test_progress_resets_the_blocking_budget(self):
+        started = timezone.now()
+        state, _ = teardown_blocking.record_blocking(
+            {},
+            reason="conversion_stop_unconfirmed",
+            task_id="convert-1",
+            gateway_link_id=7,
+            remote_status="CANCELLING",
+            now=started,
+        )
+
+        _, progressed = teardown_blocking.record_blocking(
+            state,
+            reason="conversion_stop_unconfirmed",
+            task_id="convert-1",
+            gateway_link_id=7,
+            remote_status="REVOKED",
+            now=started + timedelta(hours=1),
+        )
+
+        self.assertEqual(progressed["consecutive_attempts"], 1)
+        self.assertEqual(
+            progressed["first_seen_at"],
+            (started + timedelta(hours=1)).isoformat(),
+        )
+
+    def test_gateway_identity_is_part_of_the_blocking_condition(self):
+        now = timezone.now()
+        state, _ = teardown_blocking.record_blocking(
+            {},
+            reason="workspace_cleanup",
+            gateway_link_id=7,
+            now=now,
+        )
+
+        _, moved = teardown_blocking.record_blocking(
+            state,
+            reason="workspace_cleanup",
+            gateway_link_id=8,
+            now=now + timedelta(minutes=1),
+        )
+
+        self.assertEqual(moved["consecutive_attempts"], 1)
+
+    def test_clear_blocking_preserves_other_teardown_state(self):
+        state = teardown_blocking.clear_blocking(
+            {
+                "intent": "delete_session",
+                "blocking": {"intervention_required": True},
+            }
+        )
+
+        self.assertEqual(state, {"intent": "delete_session"})


### PR DESCRIPTION
## Summary

- align destructive cleanup with SourceLens v0.47.9 conversion-stop confirmation metadata while preserving legacy evidence
- retain Chat preparation slots and workspaces until teardown is fully confirmed, with bounded retries and audited operator recovery
- serialize Agent workspace prepare and cleanup by workspace UID and reject late prepare tasks through durable tombstones
- fix nullable relationship locking in the cleanup recovery command and add PostgreSQL-backed lifecycle coverage

## Validation

- full Community Django suite: 2,202 tests passed, 2 skipped
- focused PostgreSQL lifecycle tests: 98 passed
- Agent `go test ./...` and focused race tests
- Go vet and Windows/macOS cross-builds
- backend Ruff and Python compile checks
- Django migration consistency check
- gofmt and `git diff --check`

## Related

- Follow-up hardening for #593; this PR does not reopen or automatically close the issue.