### PR TITLE
fix(protection): restore backup progress metrics

### DIFF
--- a/language-packs/packs/es/frontend/messages.json
+++ b/language-packs/packs/es/frontend/messages.json
@@ -494,6 +494,7 @@
       "etaHours": "Quedan {n} h",
       "etaHoursMinutes": "Quedan {h} h {m} min",
       "hashSpeed": "Analizando: {speed}",
+      "processingSpeed": "Velocidad de procesamiento: {speed}",
       "uploadSpeed": "Subir: {speed}",
       "transfer": {
         "hashedOnly": "Realizando copia de seguridad",

--- a/language-packs/packs/es/frontend/source-lock.json
+++ b/language-packs/packs/es/frontend/source-lock.json
@@ -446,6 +446,7 @@
   "protection.taskProgress.etaHours": "64676ec292a124a2667b0da4da5b76d2d4246467e54dde562d9e1dc7c2e3d031",
   "protection.taskProgress.etaHoursMinutes": "ca3d47af227dfa1c7426cfd20ec8379ac310c309ae22ecb3d617ed7c1f058212",
   "protection.taskProgress.hashSpeed": "bed8688d753e85d7903561d7a461b36de32e1065822951bd95a60cb5cce58813",
+  "protection.taskProgress.processingSpeed": "0aa5e6efaf51e9bf5ea91483e21c51d023de6552dcabd3d42f922d3e21abe2bf",
   "protection.taskProgress.uploadSpeed": "2842ec216a22cd7bb84926aaee4ae2dc9a5f1d39f0eb25ec19b568c2648168a1",
   "protection.taskProgress.transfer.hashedOnly": "6a6336ba76326bbad2a40c0e8e393b11fcf99f50b2fa9dcd335e64b0d3bbf4f8",
   "protection.taskProgress.transfer.uploadedAndHashed": "6a6336ba76326bbad2a40c0e8e393b11fcf99f50b2fa9dcd335e64b0d3bbf4f8",

--- a/language-packs/packs/zh-hans/frontend/messages.json
+++ b/language-packs/packs/zh-hans/frontend/messages.json
@@ -461,6 +461,7 @@
       "etaMinutes": "{n} 分钟",
       "etaHoursMinutes": "{h} 小时 {m} 分钟",
       "hashSpeed": "扫描速度：{speed}",
+      "processingSpeed": "处理速度：{speed}",
       "uploadSpeed": "上传速度：{speed}",
       "transfer": {
         "hashedOnly": "正在备份",

--- a/language-packs/packs/zh-hans/frontend/source-lock.json
+++ b/language-packs/packs/zh-hans/frontend/source-lock.json
@@ -446,6 +446,7 @@
   "protection.taskProgress.etaHours": "64676ec292a124a2667b0da4da5b76d2d4246467e54dde562d9e1dc7c2e3d031",
   "protection.taskProgress.etaHoursMinutes": "ca3d47af227dfa1c7426cfd20ec8379ac310c309ae22ecb3d617ed7c1f058212",
   "protection.taskProgress.hashSpeed": "bed8688d753e85d7903561d7a461b36de32e1065822951bd95a60cb5cce58813",
+  "protection.taskProgress.processingSpeed": "0aa5e6efaf51e9bf5ea91483e21c51d023de6552dcabd3d42f922d3e21abe2bf",
   "protection.taskProgress.uploadSpeed": "2842ec216a22cd7bb84926aaee4ae2dc9a5f1d39f0eb25ec19b568c2648168a1",
   "protection.taskProgress.transfer.hashedOnly": "6a6336ba76326bbad2a40c0e8e393b11fcf99f50b2fa9dcd335e64b0d3bbf4f8",
   "protection.taskProgress.transfer.uploadedAndHashed": "6a6336ba76326bbad2a40c0e8e393b11fcf99f50b2fa9dcd335e64b0d3bbf4f8",

--- a/src/backend/apps/protection/services/progress/aggregator.py
+++ b/src/backend/apps/protection/services/progress/aggregator.py
@@ -68,7 +68,10 @@ def aggregate_lanes(lanes: list[dict[str, Any]]) -> dict[str, Any]:
         uploaded_bytes += int(normalized.get("uploaded_bytes") or 0)
         uploaded_count += int(normalized.get("uploaded_count") or 0)
         hashed_count += int(normalized.get("hashed_count") or 0)
-        estimated_bytes += int(normalized.get("estimated_bytes") or 0)
+        lane_estimated = int(normalized.get("estimated_bytes") or 0)
+        if total_known_lane and total is not None:
+            lane_estimated = max(lane_estimated, int(total))
+        estimated_bytes += lane_estimated
         lane_processed = int(normalized.get("processed_count") or 0)
         lane_total_count = int(normalized.get("total_count") or 0)
         if status in (_ACTIVE_STATUSES | _DONE_STATUSES) and normalized.get("is_transfer"):

--- a/src/backend/apps/protection/services/progress/step3_progress.py
+++ b/src/backend/apps/protection/services/progress/step3_progress.py
@@ -390,10 +390,17 @@ def enrich_step3_backup_transfer(
         kopia_total_locked = estimated_bytes
 
     if schema_version >= 2:
-        effective_total = _int(aggregate.get("bytes_total")) if aggregate.get("bytes_total_known") else 0
+        # Schema-v2 reports the logical estimate independently from lane
+        # completeness. Keep a usable aggregate estimate visible while one
+        # lane is still sampling, without treating it as an exact total.
+        effective_total = (
+            _int(aggregate.get("bytes_total"))
+            if aggregate.get("bytes_total_known")
+            else estimated_bytes
+        )
         switch_latched = effective_total > 0
         kopia_total_locked = effective_total
-        merged["bytes_total_estimated"] = False
+        merged["bytes_total_estimated"] = not bool(aggregate.get("bytes_total_known"))
     elif switch_latched:
         effective_total = estimated_bytes if estimated_bytes > 0 else kopia_total_locked
         if not bool(aggregate.get("bytes_total_known")) and kopia_total_locked > 0:

--- a/src/backend/apps/protection/tests/test_kopia_progress.py
+++ b/src/backend/apps/protection/tests/test_kopia_progress.py
@@ -64,6 +64,46 @@ class KopiaProgressAggregatorTests(SimpleTestCase):
         self.assertEqual(aggregate["upload_speed_bps"], 3_000_000)
         self.assertEqual(aggregate["eta_seconds"], 1500)
 
+    def test_partial_estimate_includes_completed_lane_total(self):
+        aggregate = aggregate_lanes([
+            {
+                "id": "completed",
+                "status": "success",
+                "progress": {
+                    "progress_schema_version": 2,
+                    "bytes_done": 500,
+                    "processed_bytes": 500,
+                    "bytes_total": 500,
+                    "bytes_total_known": True,
+                    "estimated_bytes": 0,
+                    "is_transfer": True,
+                },
+            },
+            {
+                "id": "running",
+                "status": "running",
+                "progress": {
+                    "progress_schema_version": 2,
+                    "bytes_done": 200,
+                    "processed_bytes": 200,
+                    "bytes_total": 300,
+                    "bytes_total_known": True,
+                    "estimated_bytes": 300,
+                    "is_transfer": True,
+                },
+            },
+            {
+                "id": "pending",
+                "status": "pending",
+                "progress": {},
+            },
+        ])
+
+        self.assertEqual(aggregate["processed_bytes"], 700)
+        self.assertEqual(aggregate["estimated_bytes"], 800)
+        self.assertFalse(aggregate["bytes_total_known"])
+        self.assertIsNone(aggregate["bytes_total"])
+
     def test_completed_restore_lane_retains_final_item_counts(self):
         lanes = [
             {

--- a/src/backend/apps/protection/tests/test_step3_progress.py
+++ b/src/backend/apps/protection/tests/test_step3_progress.py
@@ -310,6 +310,29 @@ class Step3ProgressTests(SimpleTestCase):
         self.assertIsNone(transfer.get("step3_display_percent"))
         self.assertIsNone(transfer.get("eta_seconds"))
 
+    def test_schema_v2_uses_partial_lane_estimate_for_progress_and_eta(self):
+        transfer = enrich_step3_backup_transfer(
+            transfer={"phase": "transferring"},
+            previous={},
+            aggregate={
+                "progress_schema_version": 2,
+                "processed_bytes": 495 * 1024 * 1024,
+                "bytes_done": 495 * 1024 * 1024,
+                "estimated_bytes": 715 * 1024 * 1024,
+                "bytes_total": None,
+                "bytes_total_known": False,
+                "processing_speed_bps": 18 * 1024 * 1024,
+            },
+            du_total=0,
+        )
+
+        self.assertEqual(transfer["bytes_total"], 715 * 1024 * 1024)
+        self.assertTrue(transfer["bytes_total_known"])
+        self.assertTrue(transfer["bytes_total_estimated"])
+        self.assertAlmostEqual(transfer["step3_display_percent"], 100 * 495 / 715, places=2)
+        self.assertEqual(transfer["eta_seconds"], 12)
+        self.assertEqual(transfer["eta_source"], "step3")
+
     def test_backup_hides_eta_without_reliable_speed(self):
         transfer = enrich_step3_backup_transfer(
             transfer={"phase": "transferring", "eta_seconds": 33},

--- a/src/frontend/src/lib/kopiaProgress.test.ts
+++ b/src/frontend/src/lib/kopiaProgress.test.ts
@@ -9,6 +9,7 @@ const t = (key: string, args?: Record<string, unknown>) => {
   if (key.endsWith('bytesProcessedCapacity')) return `Processed: ${args?.done} / ${args?.total}`
   if (key.endsWith('bytesProcessed')) return `Processed: ${args?.size}`
   if (key.endsWith('hashSpeed')) return `Scanning: ${args?.speed}`
+  if (key.endsWith('processingSpeed')) return `Processing speed: ${args?.speed}`
   if (key.endsWith('uploadSpeed')) return `Upload: ${args?.speed}`
   if (key.endsWith('etaSeconds')) return `${args?.n}s left`
   return key
@@ -66,6 +67,15 @@ describe('transferSpeedParts', () => {
     })).toEqual(['Scanning: 375 MB/s'])
   })
 
+  it('uses processed-byte throughput for backup progress', () => {
+    expect(transferSpeedParts(t, {
+      phase: 'transferring',
+      progress_schema_version: 2,
+      processing_speed_bps: 19_293_000,
+      upload_speed_bps: 5_740_000,
+    })).toEqual(['18.4 MB/s'])
+  })
+
   it('does not display an unclassified legacy speed', () => {
     expect(transferSpeedParts(t, {
       phase: 'transferring',
@@ -80,22 +90,22 @@ describe('transferSpeedParts', () => {
     }, { allowUnclassifiedSpeed: true })).toEqual(['488 KB/s'])
   })
 
-  it('labels physical upload speed and preserves a fresh zero sample', () => {
+  it('does not expose physical upload speed for backup progress', () => {
     expect(transferSpeedParts(t, {
       phase: 'transferring',
       progress_schema_version: 2,
       upload_speed_bps: 0,
-    })).toEqual(['Upload: 0 B/s'])
+    })).toEqual([])
     expect(formatSpeedBps(null)).toBeNull()
   })
 
-  it('does not present processing throughput as upload speed for schema v2', () => {
+  it('presents schema-v2 processing throughput with its own label', () => {
     expect(transferSpeedParts(t, {
       phase: 'transferring',
       progress_schema_version: 2,
       processing_speed_bps: 393_000_000,
       hash_speed_bps: 393_000_000,
-    })).toEqual([])
+    }, { labelProcessingSpeed: true })).toEqual(['Processing speed: 375 MB/s'])
   })
 
   it('hides ETA while finalizing', () => {

--- a/src/frontend/src/lib/kopiaProgress.ts
+++ b/src/frontend/src/lib/kopiaProgress.ts
@@ -257,6 +257,7 @@ export function shouldShowTransferMetrics(transfer?: TransferProgress | null): b
 
 type TransferMetricOptions = {
   allowUnclassifiedSpeed?: boolean
+  labelProcessingSpeed?: boolean
 }
 
 export function transferSpeedParts(
@@ -265,12 +266,16 @@ export function transferSpeedParts(
   options: TransferMetricOptions = {},
 ): string[] {
   if (!transfer) return []
+  const isRestore = String(transfer.label_key || '').includes('taskProgress.restore.')
+  const processingSpeed = formatSpeedBps(transfer.processing_speed_bps)
+  if (processingSpeed && !isRestore) {
+    return options.labelProcessingSpeed
+      ? [t('protection.taskProgress.processingSpeed', { speed: processingSpeed })]
+      : [processingSpeed]
+  }
   const uploadSpeed = formatSpeedBps(transfer.upload_speed_bps)
   if (uploadSpeed) {
-    const isRestore = String(transfer.label_key || '').includes('taskProgress.restore.')
-    return isRestore
-      ? [uploadSpeed]
-      : [t('protection.taskProgress.uploadSpeed', { speed: uploadSpeed })]
+    return isRestore ? [uploadSpeed] : []
   }
   if (Number(transfer.progress_schema_version || 1) >= 2) return []
   const hashSpeed = formatSpeedBps(transfer.hash_speed_bps)

--- a/src/frontend/src/locales/enProtectionPages.ts
+++ b/src/frontend/src/locales/enProtectionPages.ts
@@ -12,6 +12,7 @@ export const enProtectionPages = {
     etaHours: '{n}h left',
     etaHoursMinutes: '{h}h {m}m left',
     hashSpeed: 'Scanning: {speed}',
+    processingSpeed: 'Processing speed: {speed}',
     uploadSpeed: 'Upload: {speed}',
     transfer: {
       hashedOnly: 'Backing up',

--- a/src/frontend/src/pages/protection/components/TaskProgressCell.test.ts
+++ b/src/frontend/src/pages/protection/components/TaskProgressCell.test.ts
@@ -23,6 +23,7 @@ const i18n = createI18n({
           bytesCapacityRef: 'Transferred: {done} / source data: {total}',
           etaMinutes: '{n} min left',
           hashSpeed: 'Scanning: {speed}',
+          processingSpeed: 'Processing speed: {speed}',
           uploadSpeed: 'Upload: {speed}',
           transfer: {
             hashedOnly: 'Backing up',
@@ -65,6 +66,7 @@ function mountCell(
         bytes_total: 322_000_000_000,
         bytes_total_known: true,
         bytes_total_reference: true,
+        processing_speed_bps: 19_293_000,
         upload_speed_bps: 5_740_000,
         eta_seconds: 900,
         step3_display_percent: 0.28,
@@ -142,11 +144,12 @@ describe('TaskProgressCell', () => {
       bytes_total: null,
       bytes_total_known: false,
       upload_speed_bps: null,
+      processing_speed_bps: null,
       speed_bps: 393_000_000,
       hash_speed_bps: 393_000_000,
       eta_seconds: null,
     })
-    const expectedTitle = 'Backing up\nScanning: 375 MB/s'
+    const expectedTitle = 'Scanning: 375 MB/s'
 
     expect(wrapper.get('.task-progress-cell__metric-line').text()).toBe('Scanning: 375 MB/s')
     expect(wrapper.get('.task-progress-cell__label-text').attributes('data-table-overflow-title')).toBe(expectedTitle)
@@ -157,7 +160,7 @@ describe('TaskProgressCell', () => {
     const wrapper = mountCell(59.1)
     const line = wrapper.get('.task-progress-cell__metric-line')
 
-    expect(line.text()).toBe('Processed: 858 MB / 300 GB · Upload: 5.47 MB/s · 15 min left')
+    expect(line.text()).toBe('Processed: 858 MB / 300 GB · 18.4 MB/s · 15 min left')
     expect(line.element.children).toHaveLength(0)
 
     const source = readFileSync(resolve(process.cwd(), 'src/pages/protection/components/TaskProgressCell.vue'), 'utf8')
@@ -168,9 +171,8 @@ describe('TaskProgressCell', () => {
     const wrapper = mountCell(59.1)
 
     expect(wrapper.get('.task-progress-cell__metric-line').attributes('data-table-overflow-title')).toBe([
-      'Backing up',
       'Processed: 858 MB / 300 GB',
-      'Upload: 5.47 MB/s',
+      'Processing speed: 18.4 MB/s',
       '15 min left',
     ].join('\n'))
   })

--- a/src/frontend/src/pages/protection/components/TaskProgressCell.vue
+++ b/src/frontend/src/pages/protection/components/TaskProgressCell.vue
@@ -74,7 +74,12 @@ const metricParts = computed(() => {
   return transferMetricParts(t, props.transferProgress)
 })
 const metricLine = computed(() => metricParts.value.join(' · '))
-const overflowTitle = computed(() => [orchestrationLabel.value, ...metricParts.value].filter(Boolean).join('\n'))
+const overflowTitle = computed(() => {
+  if (!metricParts.value.length) return ''
+  return transferMetricParts(t, props.transferProgress, { labelProcessingSpeed: true })
+    .filter(Boolean)
+    .join('\n')
+})
 const labelTitle = computed(() => {
   const label = orchestrationLabel.value
   return label.length > 48 ? label : undefined


### PR DESCRIPTION
## Problem and root cause

Schema-v2 backup progress keeps logical processed bytes separate from physical
uploaded bytes, but the backend discarded the aggregate estimate whenever any
lane lacked an exact total. The task cell consequently lost percentage and ETA
and exposed physical upload throughput as the primary speed, which was
ambiguous for backup processing.

## Solution

- Preserve completed and known lane totals in the aggregate estimate, then use
  the schema-v2 estimate for processed-byte percentage and ETA while exact lane
  totals are incomplete.
- Present processed-byte throughput in the compact task row and label it as
  processing speed in the multiline tooltip.
- Keep physical upload metrics available for diagnostics and restore behavior,
  while removing them from the primary backup progress presentation.
- Add English, Spanish, and Simplified Chinese locale coverage and regressions
  for partial-lane aggregation, ETA, compact metrics, and tooltip content.

## Validation

- Targeted Django progress tests: 44 passed
- Changed backend Ruff checks: passed
- Affected protection suite: 362 tests; one unchanged test failure was
  baseline-equivalent to canonical `a07d6549`
- Frontend Vitest: 246 files, 1337 tests passed
- Frontend ESLint: 0 errors; 3 pre-existing warnings in an unchanged file
- Type-checked frontend production build: passed
- Language-pack Linux build and four runtime translation tests: passed
- Agent Kopia progress package tests: passed
- Source boundary and diff checks: passed
- Manual testing: passed
- Optional complete Community backend suite: skipped at the tester's request

## Risks and compatibility

Estimated totals may continue to refine while lanes are sampled, but processed
bytes, percentage, processing speed, and ETA remain in the same logical byte
domain. Upload fields remain compatible for diagnostics and restore consumers.
Backup source paths, source scope, and policy behavior are unchanged.

Fixes #895
