### PR TITLE
Harden system backup boundaries and managed Kopia policies

### DIFF
--- a/src/agent/internal/engine/agent_path_boundary.go
+++ b/src/agent/internal/engine/agent_path_boundary.go
@@ -77,6 +77,19 @@ func newBackupPathBoundary(cfg *model.AgentConfig, sourcePath string, nasSource 
 			root,
 		)
 	}
+	systemPatterns, systemExclusions, forbiddenSystemPath, systemErr := systemBackupBoundaryRules(b.agentRoot, path)
+	if systemErr != nil {
+		return backupPathBoundary{}, systemErr
+	}
+	if forbiddenSystemPath != "" {
+		return backupPathBoundary{}, fmt.Errorf(
+			"%w: backup source must not be inside protected system path %q",
+			errAgentPathForbidden,
+			forbiddenSystemPath,
+		)
+	}
+	b.ignorePatterns = append(b.ignorePatterns, systemPatterns...)
+	b.excludedPaths = append(b.excludedPaths, systemExclusions...)
 	// When backing up a parent (for example / or a user's home), exclude the
 	// complete Agent root. This keeps all internal subdirectories protected,
 	// including mounts/repositories and future layout additions.
@@ -93,8 +106,8 @@ func newBackupPathBoundary(cfg *model.AgentConfig, sourcePath string, nasSource 
 		// Kopia excludes the directory entry and its entire subtree when the
 		// directory path itself is ignored. A trailing /** leaves an empty Agent
 		// root entry in the snapshot and is therefore intentionally not used.
-		b.ignorePatterns = []string{normalizeIgnorePattern(rel)}
-		b.excludedPaths = []string{b.agentRoot}
+		b.ignorePatterns = append(b.ignorePatterns, normalizeIgnorePattern(rel))
+		b.excludedPaths = append(b.excludedPaths, b.agentRoot)
 	}
 	return b, nil
 }

--- a/src/agent/internal/engine/agent_path_boundary_test.go
+++ b/src/agent/internal/engine/agent_path_boundary_test.go
@@ -2,9 +2,11 @@ package engine
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"testing"
 
 	"hyperfilelens/agent/internal/model"
@@ -23,6 +25,82 @@ func TestBackupPathBoundaryRejectsAgentRootAndRepositoryMount(t *testing.T) {
 	repository := filepath.Join(root, "mounts", "repositories", "repo-1")
 	if _, err := newBackupPathBoundary(cfg, repository, true, repository); err == nil {
 		t.Fatal("expected a task payload to be unable to authorize a repository mount")
+	}
+}
+
+func TestSystemBackupBoundaryRulesAreRootAnchored(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("Linux system boundary rules")
+	}
+	patterns, exclusions, forbidden, err := systemBackupBoundaryRules(t.TempDir(), string(filepath.Separator))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if forbidden != "" {
+		t.Fatalf("unexpected forbidden path %q", forbidden)
+	}
+	for _, want := range []string{"/proc/", "/sys/", "/dev/", "/run/"} {
+		if !slices.Contains(patterns, want) {
+			t.Fatalf("missing root-anchored system rule %q in %#v", want, patterns)
+		}
+	}
+	if len(exclusions) != 4 {
+		t.Fatalf("unexpected system exclusions %#v", exclusions)
+	}
+}
+
+func TestBackupPathBoundaryRejectsSystemRuntimeSource(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("Linux system boundary rules")
+	}
+	if _, err := newBackupPathBoundary(&model.AgentConfig{AgentRoot: t.TempDir()}, "/proc", false); !errors.Is(err, errAgentPathForbidden) {
+		t.Fatalf("expected protected system source rejection, got %v", err)
+	}
+}
+
+func TestSystemBackupBoundaryDoesNotMatchUnrelatedDirectoryNames(t *testing.T) {
+	root := t.TempDir()
+	source := filepath.Join(root, "data")
+	if err := os.MkdirAll(source, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	patterns, exclusions, forbidden, err := systemBackupBoundaryRules(filepath.Join(root, "agent"), source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if forbidden != "" || len(patterns) != 0 || len(exclusions) != 0 {
+		t.Fatalf("unrelated source received system exclusions: patterns=%#v exclusions=%#v forbidden=%q", patterns, exclusions, forbidden)
+	}
+}
+
+func TestSystemBackupBoundaryLoadsAdditionalConfiguredPaths(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("Linux system boundary rules")
+	}
+	base := t.TempDir()
+	agentRoot := filepath.Join(base, "agent")
+	if err := os.MkdirAll(vfs.AgentConfigDir(agentRoot), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(vfs.AgentConfigDir(agentRoot), systemBackupBoundaryConfigName),
+		[]byte(`{"schema_version":1,"additional_paths":["`+filepath.Join(base, "runtime")+`"]}`),
+		0o600,
+	); err != nil {
+		t.Fatal(err)
+	}
+	patterns, exclusions, forbidden, err := systemBackupBoundaryRules(agentRoot, base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if forbidden != "" || !slices.Contains(patterns, "/runtime/") {
+		t.Fatalf("configured system boundary missing: patterns=%#v exclusions=%#v forbidden=%q", patterns, exclusions, forbidden)
+	}
+}
+
+func TestCaseFoldSystemIgnorePattern(t *testing.T) {
+	if got := caseFoldSystemIgnorePattern("/System Volume Information/"); got != "/[Ss][Yy][Ss][Tt][Ee][Mm] [Vv][Oo][Ll][Uu][Mm][Ee] [Ii][Nn][Ff][Oo][Rr][Mm][Aa][Tt][Ii][Oo][Nn]/" {
+		t.Fatalf("case-folded system pattern = %q", got)
 	}
 }
 

--- a/src/agent/internal/engine/managed_backup_policy.go
+++ b/src/agent/internal/engine/managed_backup_policy.go
@@ -246,8 +246,8 @@ func normalizeExtensions(values []string) ([]string, error) {
 	return result, nil
 }
 
-func managedBackupPolicyResetArgs(configFile string, sourcePath string) []string {
-	return []string{
+func managedBackupPolicyResetArgs(configFile string, sourcePath string, disableDotIgnore bool) []string {
+	args := []string{
 		"--config-file=" + configFile,
 		"policy",
 		"set",
@@ -255,8 +255,13 @@ func managedBackupPolicyResetArgs(configFile string, sourcePath string) []string
 		"--clear-dot-ignore",
 		"--clear-only-compress",
 		"--clear-never-compress",
-		sourcePath,
 	}
+	if disableDotIgnore {
+		args = append(args, "--disable-dot-ignore")
+	} else {
+		args = append(args, "--enable-dot-ignore")
+	}
+	return append(args, sourcePath)
 }
 
 func managedBackupPolicyApplyArgs(configFile string, sourcePath string, spec managedBackupPolicySpec, protectedPatterns ...[]string) []string {
@@ -311,7 +316,7 @@ func applyManagedBackupPolicy(
 ) (map[string]any, error) {
 	result := map[string]any{"compression_level": spec.CompressionLevel}
 	protected := protectedPatternValues(protectedPatterns...)
-	resetArgs := managedBackupPolicyResetArgs(configFile, sourcePath)
+	resetArgs := managedBackupPolicyResetArgs(configFile, sourcePath, len(protected) > 0)
 	resetResult, resetErr := runManagedPolicyCommand(ctx, managedRepositoryKopiaCommandTimeout, bin, resetArgs, env, "")
 	resetCommandResult := commandResult(resetResult)
 	resetCommandResult["command_summary"] = map[string]any{
@@ -370,12 +375,19 @@ func protectedPatternValues(values ...[]string) []string {
 }
 
 func managedIgnorePatterns(userPatterns []string, protectedPatterns ...[]string) []string {
-	values := append(protectedPatternValues(protectedPatterns...), userPatterns...)
-	seen := make(map[string]struct{}, len(values))
-	out := make([]string, 0, len(values))
-	for _, value := range values {
+	protected := protectedPatternValues(protectedPatterns...)
+	protectedSet := make(map[string]struct{}, len(protected))
+	for _, value := range protected {
+		protectedSet[value] = struct{}{}
+	}
+	seen := make(map[string]struct{}, len(userPatterns))
+	out := make([]string, 0, len(userPatterns)+len(protected))
+	for _, value := range userPatterns {
 		value = strings.TrimSpace(value)
 		if value == "" {
+			continue
+		}
+		if _, protectedValue := protectedSet[value]; protectedValue {
 			continue
 		}
 		if _, ok := seen[value]; ok {
@@ -384,7 +396,7 @@ func managedIgnorePatterns(userPatterns []string, protectedPatterns ...[]string)
 		seen[value] = struct{}{}
 		out = append(out, value)
 	}
-	return out
+	return append(out, protected...)
 }
 
 func verifyManagedBackupProtection(
@@ -423,22 +435,29 @@ func verifyManagedBackupProtection(
 	}
 	var policy struct {
 		Files struct {
-			Ignore []string `json:"ignore"`
+			Ignore                 []string `json:"ignore"`
+			DotIgnoreFiles         []string `json:"ignoreDotFiles"`
+			NoParentDotIgnoreFiles bool     `json:"noParentDotFiles"`
 		} `json:"files"`
 	}
 	if err := json.Unmarshal([]byte(res.Stdout), &policy); err != nil {
 		result["error_code"] = "BACKUP_PROTECTION_POLICY_VERIFY_FAILED"
 		return result, fmt.Errorf("verify Agent backup boundary policy: invalid Kopia policy response")
 	}
-	applied := make(map[string]struct{}, len(policy.Files.Ignore))
-	for _, pattern := range policy.Files.Ignore {
-		applied[strings.TrimSpace(pattern)] = struct{}{}
+	if len(policy.Files.Ignore) < len(required) {
+		result["error_code"] = "BACKUP_PROTECTION_POLICY_MISSING"
+		return result, fmt.Errorf("required Agent backup boundary policy is missing")
 	}
-	for _, pattern := range required {
-		if _, ok := applied[pattern]; !ok {
+	protectedOffset := len(policy.Files.Ignore) - len(required)
+	for index, pattern := range required {
+		if strings.TrimSpace(policy.Files.Ignore[protectedOffset+index]) != pattern {
 			result["error_code"] = "BACKUP_PROTECTION_POLICY_MISSING"
-			return result, fmt.Errorf("required Agent backup boundary policy is missing")
+			return result, fmt.Errorf("required Agent backup boundary policy is not effective")
 		}
+	}
+	if !policy.Files.NoParentDotIgnoreFiles || len(policy.Files.DotIgnoreFiles) != 0 {
+		result["error_code"] = "BACKUP_PROTECTION_DOT_IGNORE_ENABLED"
+		return result, fmt.Errorf("source dot-ignore inheritance is enabled for managed backup")
 	}
 	result["system_ignore_policy_verified"] = true
 	return result, nil

--- a/src/agent/internal/engine/managed_backup_policy_test.go
+++ b/src/agent/internal/engine/managed_backup_policy_test.go
@@ -65,8 +65,8 @@ func TestManagedBackupPolicyUsesSeparateResetAndApplyArgs(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	resetArgs := managedBackupPolicyResetArgs("/tmp/repo.config", "/data/projects")
-	if !slices.Contains(resetArgs, "--clear-ignore") || !slices.Contains(resetArgs, "--clear-never-compress") {
+	resetArgs := managedBackupPolicyResetArgs("/tmp/repo.config", "/data/projects", true)
+	if !slices.Contains(resetArgs, "--clear-ignore") || !slices.Contains(resetArgs, "--clear-never-compress") || !slices.Contains(resetArgs, "--disable-dot-ignore") {
 		t.Fatalf("expected list resets: %#v", resetArgs)
 	}
 	if slices.Contains(resetArgs, "--add-ignore=*.tmp") {
@@ -102,9 +102,16 @@ func TestManagedBackupPolicyUsesSeparateResetAndApplyArgs(t *testing.T) {
 	if got := applyArgs[len(applyArgs)-1]; got != "/data/projects" {
 		t.Fatalf("expected source path target, got %q", got)
 	}
+	ordinaryResetArgs := managedBackupPolicyResetArgs("/tmp/repo.config", "/data/projects", false)
+	if slices.Contains(ordinaryResetArgs, "--disable-dot-ignore") {
+		t.Fatalf("ordinary managed backup must preserve dot-ignore behavior: %#v", ordinaryResetArgs)
+	}
+	if !slices.Contains(ordinaryResetArgs, "--enable-dot-ignore") {
+		t.Fatalf("ordinary managed backup must restore dot-ignore inheritance: %#v", ordinaryResetArgs)
+	}
 }
 
-func TestManagedBackupPolicyKeepsSystemIgnoreAheadOfUserRules(t *testing.T) {
+func TestManagedBackupPolicyKeepsSystemIgnoreAfterUserRules(t *testing.T) {
 	spec, err := parseManagedBackupPolicy(balancedManagedPolicyPayload())
 	if err != nil {
 		t.Fatal(err)
@@ -121,11 +128,36 @@ func TestManagedBackupPolicyKeepsSystemIgnoreAheadOfUserRules(t *testing.T) {
 			ignores = append(ignores, strings.TrimPrefix(arg, "--add-ignore="))
 		}
 	}
-	if len(ignores) == 0 || ignores[0] != "opt/hyperfilelens-agent" {
-		t.Fatalf("system boundary must be the first ignore rule: %#v", ignores)
+	if len(ignores) == 0 || ignores[len(ignores)-1] != "opt/hyperfilelens-agent" {
+		t.Fatalf("system boundary must be the last ignore rule: %#v", ignores)
 	}
-	if strings.HasSuffix(ignores[0], "/**") {
+	if strings.HasSuffix(ignores[len(ignores)-1], "/**") {
 		t.Fatalf("system boundary must exclude the directory entry itself: %#v", ignores)
+	}
+}
+
+func TestManagedBackupPolicyKeepsProtectedRuleAfterUserDuplicate(t *testing.T) {
+	spec, err := parseManagedBackupPolicy(balancedManagedPolicyPayload())
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The control-plane payload may contain the same protected rule. It must
+	// not consume the mandatory final copy during de-duplication.
+	spec.IgnorePatterns = []string{"opt/hyperfilelens-agent", "!opt/hyperfilelens-agent"}
+	args := managedBackupPolicyApplyArgs(
+		"/tmp/repo.config",
+		"/",
+		spec,
+		[]string{"opt/hyperfilelens-agent"},
+	)
+	var ignores []string
+	for _, arg := range args {
+		if strings.HasPrefix(arg, "--add-ignore=") {
+			ignores = append(ignores, strings.TrimPrefix(arg, "--add-ignore="))
+		}
+	}
+	if len(ignores) < 2 || ignores[len(ignores)-1] != "opt/hyperfilelens-agent" || ignores[len(ignores)-2] != "!opt/hyperfilelens-agent" {
+		t.Fatalf("protected rule must remain the final rule after user duplicates: %#v", ignores)
 	}
 }
 
@@ -188,7 +220,7 @@ func TestVerifyManagedBackupProtectionRequiresEffectiveKopiaPolicy(t *testing.T)
 			map[string]string,
 			string,
 		) (process.Result, error) {
-			return process.Result{Stdout: `{"files":{"ignore":["opt/hyperfilelens-agent","*.tmp"]}}`}, nil
+			return process.Result{Stdout: `{"files":{"ignore":["*.tmp","opt/hyperfilelens-agent"],"noParentDotFiles":true}}`}, nil
 		}
 		result, err := verifyManagedBackupProtection(
 			context.Background(), "kopia", "/tmp/repo.config", nil, "/", []string{"opt/hyperfilelens-agent"},
@@ -214,6 +246,25 @@ func TestVerifyManagedBackupProtectionRequiresEffectiveKopiaPolicy(t *testing.T)
 		)
 		if err == nil || result["error_code"] != "BACKUP_PROTECTION_POLICY_MISSING" {
 			t.Fatalf("expected missing protection failure, result=%#v err=%v", result, err)
+		}
+	})
+
+	t.Run("dot-ignore-enabled", func(t *testing.T) {
+		runManagedPolicyCommand = func(
+			context.Context,
+			time.Duration,
+			string,
+			[]string,
+			map[string]string,
+			string,
+		) (process.Result, error) {
+			return process.Result{Stdout: `{"files":{"ignore":["opt/hyperfilelens-agent"]}}`}, nil
+		}
+		result, err := verifyManagedBackupProtection(
+			context.Background(), "kopia", "/tmp/repo.config", nil, "/", []string{"opt/hyperfilelens-agent"},
+		)
+		if err == nil || result["error_code"] != "BACKUP_PROTECTION_DOT_IGNORE_ENABLED" {
+			t.Fatalf("expected dot-ignore protection failure, result=%#v err=%v", result, err)
 		}
 	})
 }

--- a/src/agent/internal/engine/system_backup_boundary.go
+++ b/src/agent/internal/engine/system_backup_boundary.go
@@ -1,0 +1,166 @@
+package engine
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"hyperfilelens/agent/internal/platform/vfs"
+)
+
+const systemBackupBoundaryConfigName = "system-backup-boundaries.json"
+
+type systemBackupBoundaryConfig struct {
+	SchemaVersion   int      `json:"schema_version"`
+	AdditionalPaths []string `json:"additional_paths"`
+}
+
+type systemBackupBoundaryCandidate struct {
+	path            string
+	directory       bool
+	caseInsensitive bool
+}
+
+// systemBackupBoundaryCandidates returns only operating-system runtime paths
+// that cannot be restored as ordinary user data. It intentionally does not
+// include caches, logs, temporary directories, or user-owned paths.
+func systemBackupBoundaryCandidates(sourcePath string) []systemBackupBoundaryCandidate {
+	switch runtime.GOOS {
+	case "linux":
+		return []systemBackupBoundaryCandidate{
+			{path: "/proc", directory: true},
+			{path: "/sys", directory: true},
+			{path: "/dev", directory: true},
+			{path: "/run", directory: true},
+		}
+	case "darwin":
+		return []systemBackupBoundaryCandidate{
+			{path: "/.vol", directory: true},
+			{path: "/dev", directory: true},
+			{path: "/private/var/run", directory: true},
+			{path: "/private/var/vm", directory: true},
+			{path: "/System/Volumes/VM", directory: true},
+		}
+	case "windows":
+		volume := filepath.VolumeName(sourcePath)
+		if volume == "" {
+			return nil
+		}
+		root := filepath.Clean(volume + string(filepath.Separator))
+		return []systemBackupBoundaryCandidate{
+			{path: filepath.Join(root, "System Volume Information"), directory: true, caseInsensitive: true},
+			{path: filepath.Join(root, "pagefile.sys"), caseInsensitive: true},
+			{path: filepath.Join(root, "hiberfil.sys"), caseInsensitive: true},
+			{path: filepath.Join(root, "swapfile.sys"), caseInsensitive: true},
+		}
+	default:
+		return nil
+	}
+}
+
+func loadAdditionalSystemBackupBoundaryPaths(agentRoot string) []systemBackupBoundaryCandidate {
+	configPath := filepath.Join(vfs.AgentConfigDir(agentRoot), systemBackupBoundaryConfigName)
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			slog.Warn("system backup boundary config unavailable", "path", configPath, "err", err)
+		}
+		return nil
+	}
+
+	var cfg systemBackupBoundaryConfig
+	decoder := json.NewDecoder(strings.NewReader(string(data)))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&cfg); err != nil {
+		slog.Warn("system backup boundary config invalid; using built-in rules", "path", configPath, "err", err)
+		return nil
+	}
+	if cfg.SchemaVersion != 1 {
+		slog.Warn("system backup boundary config version unsupported; using built-in rules", "path", configPath, "schema_version", cfg.SchemaVersion)
+		return nil
+	}
+
+	result := make([]systemBackupBoundaryCandidate, 0, len(cfg.AdditionalPaths))
+	for _, rawPath := range cfg.AdditionalPaths {
+		path := strings.TrimSpace(rawPath)
+		if path == "" || !filepath.IsAbs(path) {
+			slog.Warn("system backup boundary config path ignored; path must be absolute", "path", rawPath)
+			continue
+		}
+		result = append(result, systemBackupBoundaryCandidate{path: path, directory: true})
+	}
+	return result
+}
+
+func rootedSystemIgnorePattern(sourcePath, protectedPath string, directory, caseInsensitive bool) (string, error) {
+	rel, err := filepath.Rel(sourcePath, protectedPath)
+	if err != nil || rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel) {
+		return "", fmt.Errorf("protected path %q is not below source %q", protectedPath, sourcePath)
+	}
+	pattern := "/" + strings.Trim(filepath.ToSlash(filepath.Clean(rel)), "/")
+	if caseInsensitive {
+		pattern = caseFoldSystemIgnorePattern(pattern)
+	}
+	if directory {
+		pattern += "/"
+	}
+	return pattern, nil
+}
+
+func caseFoldSystemIgnorePattern(pattern string) string {
+	var result strings.Builder
+	for _, ch := range pattern {
+		switch {
+		case ch >= 'a' && ch <= 'z':
+			result.WriteByte('[')
+			result.WriteByte(byte(ch - ('a' - 'A')))
+			result.WriteByte(byte(ch))
+			result.WriteByte(']')
+		case ch >= 'A' && ch <= 'Z':
+			result.WriteByte('[')
+			result.WriteByte(byte(ch))
+			result.WriteByte(byte(ch + ('a' - 'A')))
+			result.WriteByte(']')
+		default:
+			result.WriteRune(ch)
+		}
+	}
+	return result.String()
+}
+
+func systemBackupBoundaryRules(agentRoot, sourcePath string) (patterns, exclusions []string, forbiddenPath string, err error) {
+	candidates := append(systemBackupBoundaryCandidates(sourcePath), loadAdditionalSystemBackupBoundaryPaths(agentRoot)...)
+	seen := make(map[string]struct{}, len(candidates))
+	for _, candidate := range candidates {
+		protectedPath, canonicalErr := canonicalPath(candidate.path)
+		if canonicalErr != nil {
+			return nil, nil, "", fmt.Errorf("resolve system backup boundary %q: %w", candidate.path, canonicalErr)
+		}
+		key := protectedPath
+		if runtime.GOOS == "windows" {
+			key = strings.ToLower(key)
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+
+		if isWithin(sourcePath, protectedPath) {
+			return nil, nil, protectedPath, nil
+		}
+		if !isWithin(protectedPath, sourcePath) {
+			continue
+		}
+		pattern, patternErr := rootedSystemIgnorePattern(sourcePath, protectedPath, candidate.directory, candidate.caseInsensitive)
+		if patternErr != nil {
+			return nil, nil, "", patternErr
+		}
+		patterns = append(patterns, pattern)
+		exclusions = append(exclusions, protectedPath)
+	}
+	return patterns, exclusions, "", nil
+}

--- a/src/agent/internal/platform/pathsize/pathsize_test.go
+++ b/src/agent/internal/platform/pathsize/pathsize_test.go
@@ -27,6 +27,27 @@ func TestEstimateWithExclusionsSkipsProtectedDirectory(t *testing.T) {
 	}
 }
 
+func TestEstimateWithExclusionsKeepsNestedDirectoryWithSameName(t *testing.T) {
+	root := t.TempDir()
+	protected := filepath.Join(root, "proc")
+	nested := filepath.Join(root, "data", "proc")
+	if err := os.MkdirAll(protected, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeSizeFile(t, filepath.Join(protected, "system.bin"), 101)
+	writeSizeFile(t, filepath.Join(nested, "user.bin"), 7)
+	size, err := EstimateWithExclusions(root, "directory", []string{protected})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if size != 7 {
+		t.Fatalf("expected same-named user directory to remain included, got %d", size)
+	}
+}
+
 func TestWalkBytesDoesNotHideUnrelatedTraversalErrors(t *testing.T) {
 	root := t.TempDir()
 	missing := filepath.Join(root, "missing")

--- a/src/agent/scripts/package.sh
+++ b/src/agent/scripts/package.sh
@@ -341,6 +341,12 @@ def validate_kopia_info() -> dict:
     missing = [entry for entry in matrix if entry not in files]
     if missing:
         raise PrerequisiteError(f"KOPIA_INFO.json is missing matrix entries: {' '.join(missing)}")
+    features = info.get("features")
+    if not isinstance(features, dict) or features.get("hfl_managed_dot_ignore_v1") is not True:
+        raise PrerequisiteError(
+            "KOPIA_INFO.json is missing the HFL managed dot-ignore capability; "
+            "prepare Kopia in build mode before packaging an Agent"
+        )
     return info
 
 

--- a/tools/kopia/common.sh
+++ b/tools/kopia/common.sh
@@ -17,6 +17,7 @@ KOPIA_INFO_FILE="${KOPIA_BUILD_DIR}/KOPIA_INFO.json"
 KOPIA_PATCH_FILES=(
 	"${KOPIA_TOOLS_DIR}/patches/0001-add-s3-url-style.patch"
 	"${KOPIA_TOOLS_DIR}/patches/0002-add-structured-progress.patch"
+	"${KOPIA_TOOLS_DIR}/patches/0003-disable-managed-dot-ignore.patch"
 )
 KOPIA_DEFAULT_MATRIX="linux:amd64 linux:arm64 darwin:amd64 darwin:arm64 windows:amd64"
 

--- a/tools/kopia/patches/0003-disable-managed-dot-ignore.patch
+++ b/tools/kopia/patches/0003-disable-managed-dot-ignore.patch
@@ -1,0 +1,135 @@
+diff --git a/cli/command_policy_set_files.go b/cli/command_policy_set_files.go
+index 3cdf7d23..ffe2b30f 100644
+--- a/cli/command_policy_set_files.go
++++ b/cli/command_policy_set_files.go
+@@ -16,10 +16,12 @@ type policyFilesFlags struct {
+ 	policySetClearIgnore  bool
+ 
+ 	// Dot-ignore files to look at.
+-	policySetAddDotIgnore    []string
++	policySetAddDotIgnore     []string
+ 	policySetRemoveDotIgnore []string
+-	policySetClearDotIgnore  bool
+-	policySetMaxFileSize     string
++	policySetClearDotIgnore   bool
++	policySetDisableDotIgnore bool
++	policySetEnableDotIgnore  bool
++	policySetMaxFileSize      string
+ 
+ 	// Ignore other mounted filesystems.
+ 	policyOneFileSystem string
+@@ -37,6 +39,8 @@ func (c *policyFilesFlags) setup(cmd *kingpin.CmdClause) {
+ 	cmd.Flag("add-dot-ignore", "List of paths to add to the dot-ignore list").PlaceHolder("FILENAME").StringsVar(&c.policySetAddDotIgnore)
+ 	cmd.Flag("remove-dot-ignore", "List of paths to remove from the dot-ignore list").PlaceHolder("FILENAME").StringsVar(&c.policySetRemoveDotIgnore)
+ 	cmd.Flag("clear-dot-ignore", "Clear list of paths in the dot-ignore list").BoolVar(&c.policySetClearDotIgnore)
++	cmd.Flag("disable-dot-ignore", "Disable dot-ignore files for this policy").BoolVar(&c.policySetDisableDotIgnore)
++	cmd.Flag("enable-dot-ignore", "Enable dot-ignore files for this policy").BoolVar(&c.policySetEnableDotIgnore)
+ 	cmd.Flag("max-file-size", "Exclude files above given size").PlaceHolder("N").StringVar(&c.policySetMaxFileSize)
+ 
+ 	// Ignore other mounted filesystems.
+@@ -51,6 +55,14 @@ func (c *policyFilesFlags) setFilesPolicyFromFlags(ctx context.Context, fp *poli
+ 	}
+ 
+ 	applyPolicyStringList(ctx, "dot-ignore filenames", &fp.DotIgnoreFiles, c.policySetAddDotIgnore, c.policySetRemoveDotIgnore, c.policySetClearDotIgnore, changeCount)
++	if c.policySetDisableDotIgnore {
++		*changeCount++
++		fp.NoParentDotIgnoreFiles = true
++	}
++	if c.policySetEnableDotIgnore {
++		*changeCount++
++		fp.NoParentDotIgnoreFiles = false
++	}
+ 	applyPolicyStringList(ctx, "ignore rules", &fp.IgnoreRules, c.policySetAddIgnore, c.policySetRemoveIgnore, c.policySetClearIgnore, changeCount)
+ 
+ 	if err := applyPolicyBoolPtr(ctx, "ignore cache dirs", &fp.IgnoreCacheDirectories, c.policyIgnoreCacheDirs, changeCount); err != nil {
+diff --git a/fs/ignorefs/ignorefs_test.go b/fs/ignorefs/ignorefs_test.go
+index 3b58780c..1b6289d6 100644
+--- a/fs/ignorefs/ignorefs_test.go
++++ b/fs/ignorefs/ignorefs_test.go
+@@ -3,6 +3,7 @@
+ import (
+ 	"bytes"
+ 	"context"
++	"slices"
+ 	"sort"
+ 	"testing"
+ 
+@@ -575,6 +576,31 @@ func TestIgnoreFS(t *testing.T) {
+ 	}
+ }
+ 
++func TestNoParentDotIgnoreFilesCannotReincludePolicyExcludedPath(t *testing.T) {
++	root := mockfs.NewDirectory()
++	root.AddFileLines(".kopiaignore", []string{"!/protected/"}, 0)
++	root.AddDir("protected", 0).AddFile("data", dummyFileContents, 0)
++	root.AddDir("data", 0).AddDir("protected", 0).AddFile("user", dummyFileContents, 0)
++	root.AddFile("included", dummyFileContents, 0)
++	tree := policy.BuildTree(map[string]*policy.Policy{
++		".": {
++			FilesPolicy: policy.FilesPolicy{
++				IgnoreRules:            []string{"/protected/"},
++				NoParentDotIgnoreFiles: true,
++			},
++		},
++	}, policy.DefaultPolicy)
++
++	ifs := ignorefs.New(root, tree)
++	got := walkTree(t, ifs)
++	if slices.Contains(got, "./protected/") || slices.Contains(got, "./protected/data") {
++		t.Fatalf("policy-excluded path was re-included by dot-ignore: %#v", got)
++	}
++	if !slices.Contains(got, "./.kopiaignore") || !slices.Contains(got, "./included") || !slices.Contains(got, "./data/protected/user") {
++		t.Fatalf("unexpected files after disabling dot-ignore inheritance: %#v", got)
++	}
++}
++
+ func addAndSubtractFiles(original, added, removed []string) []string {
+ 	m := map[string]bool{}
+ 	for _, ri := range removed {
+diff --git a/snapshot/policy/files_policy.go b/snapshot/policy/files_policy.go
+index bfacc8a6..5b62f041 100644
+--- a/snapshot/policy/files_policy.go
++++ b/snapshot/policy/files_policy.go
+@@ -26,10 +26,12 @@ type FilesPolicyDefinition struct {
+ 
+ // Merge applies default values from the provided policy.
+ func (p *FilesPolicy) Merge(src FilesPolicy, def *FilesPolicyDefinition, si snapshot.SourceInfo) {
++	if !p.NoParentDotIgnoreFiles {
++		mergeStringsReplace(&p.DotIgnoreFiles, src.DotIgnoreFiles, &def.DotIgnoreFiles, si)
++	}
++	mergeBool(&p.NoParentDotIgnoreFiles, src.NoParentDotIgnoreFiles, &def.NoParentDotIgnoreFiles, si)
+ 	mergeStringList(&p.IgnoreRules, src.IgnoreRules, &def.IgnoreRules, si)
+ 	mergeBool(&p.NoParentIgnoreRules, src.NoParentIgnoreRules, &def.NoParentIgnoreRules, si)
+-	mergeStringsReplace(&p.DotIgnoreFiles, src.DotIgnoreFiles, &def.DotIgnoreFiles, si)
+-	mergeBool(&p.NoParentDotIgnoreFiles, src.NoParentDotIgnoreFiles, &def.NoParentDotIgnoreFiles, si)
+ 	mergeOptionalBool(&p.IgnoreCacheDirectories, src.IgnoreCacheDirectories, &def.IgnoreCacheDirectories, si)
+ 	mergeInt64(&p.MaxFileSize, src.MaxFileSize, &def.MaxFileSize, si)
+ 	mergeOptionalBool(&p.OneFileSystem, src.OneFileSystem, &def.OneFileSystem, si)
+diff --git a/snapshot/policy/policy_merge_test.go b/snapshot/policy/policy_merge_test.go
+index 3fd150ca..39b6e193 100644
+--- a/snapshot/policy/policy_merge_test.go
++++ b/snapshot/policy/policy_merge_test.go
+@@ -342,3 +342,23 @@ func TestPolicyMergeTimesOfDayIncludingParents(t *testing.T) {
+ 
+ 	require.Equal(t, want.String(), result.String())
+ }
++func TestNoParentDotIgnoreFilesPreventsDefaultDotIgnoreInheritance(t *testing.T) {
++	merged, _ := policy.MergePolicies([]*policy.Policy{{
++		FilesPolicy: policy.FilesPolicy{NoParentDotIgnoreFiles: true},
++	}}, snapshot.SourceInfo{})
++	if len(merged.FilesPolicy.DotIgnoreFiles) != 0 {
++		t.Fatalf("dot-ignore files inherited despite NoParentDotIgnoreFiles: %#v", merged.FilesPolicy.DotIgnoreFiles)
++	}
++}
++
++func TestNoParentDotIgnoreFilesKeepsLocalDotIgnoreFiles(t *testing.T) {
++	merged, _ := policy.MergePolicies([]*policy.Policy{{
++		FilesPolicy: policy.FilesPolicy{
++			DotIgnoreFiles:         []string{".customignore"},
++			NoParentDotIgnoreFiles: true,
++		},
++	}}, snapshot.SourceInfo{})
++	if len(merged.FilesPolicy.DotIgnoreFiles) != 1 || merged.FilesPolicy.DotIgnoreFiles[0] != ".customignore" {
++		t.Fatalf("local dot-ignore files were lost: %#v", merged.FilesPolicy.DotIgnoreFiles)
++	}
++}

--- a/tools/kopia/prepare.sh
+++ b/tools/kopia/prepare.sh
@@ -260,6 +260,12 @@ build_matrix() {
 		cd "${KOPIA_SOURCE_DIR}"
 		GOTOOLCHAIN="go${KOPIA_GO_VERSION}" go test ./cli -run '^TestHFLStructuredProgress$'
 	)
+	log "Testing the Kopia managed dot-ignore patch"
+	(
+		cd "${KOPIA_SOURCE_DIR}"
+		GOTOOLCHAIN="go${KOPIA_GO_VERSION}" go test ./snapshot/policy ./fs/ignorefs \
+			-run '^Test(NoParentDotIgnoreFiles|PolicyMerge)'
+	)
 
 	local build_info patch_short entry goos goarch output
 	patch_short="${KOPIA_PATCH_SHA256:0:12}"
@@ -428,6 +434,7 @@ payload = {
     "features": {
         "s3_url_style": os.environ["MODE"] == "build",
         "hfl_structured_progress_v2": os.environ["MODE"] == "build",
+        "hfl_managed_dot_ignore_v1": os.environ["MODE"] == "build",
     },
     "files": files,
     "built_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
@@ -464,7 +471,7 @@ EOF
 		KOPIA_PATCH_SHA256="$(patch_set_sha256)"
 		KOPIA_PATCH_NAMES="$(patch_names)"
 		KOPIA_PATCH_DIGESTS="$(patch_digests)"
-		KOPIA_BUILD_PROFILE="cgo-disabled,trimpath,strip,embedded-html-ui,hfl-buildinfo-v2,s3-patch-tests-v1,structured-progress-v2-tests-v1"
+		KOPIA_BUILD_PROFILE="cgo-disabled,trimpath,strip,embedded-html-ui,hfl-buildinfo-v2,s3-patch-tests-v1,structured-progress-v2-tests-v1,managed-dot-ignore-v1"
 	else
 		KOPIA_PATCH_SHA256=""
 		KOPIA_PATCH_NAMES=""

--- a/tools/quality/test-kopia-build-config.sh
+++ b/tools/quality/test-kopia-build-config.sh
@@ -148,10 +148,14 @@ grep -F 'ProcessedBytes   int64' \
 	"${ROOT}/tools/kopia/patches/0002-add-structured-progress.patch" >/dev/null
 grep -F 'c.svc.getProgress().Complete()' \
 	"${ROOT}/tools/kopia/patches/0002-add-structured-progress.patch" >/dev/null
+grep -F 'policySetDisableDotIgnore' \
+	"${ROOT}/tools/kopia/patches/0003-disable-managed-dot-ignore.patch" >/dev/null
+grep -F 'NoParentDotIgnoreFiles' \
+	"${ROOT}/tools/kopia/patches/0003-disable-managed-dot-ignore.patch" >/dev/null
 
-[[ "${#KOPIA_PATCH_FILES[@]}" -eq 2 ]]
+[[ "${#KOPIA_PATCH_FILES[@]}" -eq 3 ]]
 patch_set_digest="$(patch_set_sha256)"
 [[ "${patch_set_digest}" =~ ^[0-9a-f]{64}$ ]]
-[[ "$(patch_names)" == '0001-add-s3-url-style.patch 0002-add-structured-progress.patch ' ]]
+[[ "$(patch_names)" == '0001-add-s3-url-style.patch 0002-add-structured-progress.patch 0003-disable-managed-dot-ignore.patch ' ]]
 
 printf 'Kopia build configuration checks passed.\n'


### PR DESCRIPTION
## Summary

- enforce minimal operating-system backup boundaries for Linux, macOS, and Windows
- keep the Agent root protected while preserving explicitly bound NAS sources
- prevent inherited dot-ignore files from re-including protected paths
- preserve ordinary .kopiaignore behavior for unprotected sources
- require the managed Kopia capability during Agent packaging
- add path-size and policy regression coverage plus build validation

## Validation

- Agent targeted tests and full compile-only test suite
- Agent go vet and Windows/macOS cross-compilation
- Kopia policy and ignorefs targeted tests
- clean application of all Kopia patches
- shell syntax and diff checks