### PR TITLE
Rename maintenance menu entry

### DIFF
--- a/src/frontend/src/components/NodeMaintenanceIntegration.test.ts
+++ b/src/frontend/src/components/NodeMaintenanceIntegration.test.ts
@@ -23,7 +23,7 @@ describe('node maintenance UI integration', () => {
     const drawer = source('src/pages/insight/InsightGatewayDetailDrawer.vue')
 
     expect(list).toContain(":gateway-scope=\"isPlatformEngine ? 'platform' : 'user'\"")
-    expect(list).toContain("t('nodeLifecycle.maintenanceCommands')")
+    expect(list).toContain("t('nodeLifecycle.maintenance')")
     expect(drawer).toContain("getGatewayNode(id, props.gatewayScope === 'platform' ? 'platform' : 'tenant'")
   })
 

--- a/src/frontend/src/pages/insight/InsightDataGateways.vue
+++ b/src/frontend/src/pages/insight/InsightDataGateways.vue
@@ -721,7 +721,7 @@ onUnmounted(() => {
                       :size="14"
                       class="shrink-0"
                     />
-                    <span>{{ t('nodeLifecycle.maintenanceCommands') }}</span>
+                    <span>{{ t('nodeLifecycle.maintenance') }}</span>
                   </span>
                 </ElDropdownItem>
                 <ElDropdownItem

--- a/src/frontend/src/pages/node/Nodes.vue
+++ b/src/frontend/src/pages/node/Nodes.vue
@@ -673,7 +673,7 @@ async function submitRename() {
                       :size="14"
                       class="shrink-0"
                     />
-                    <span>{{ t('nodeLifecycle.maintenanceCommands') }}</span>
+                    <span>{{ t('nodeLifecycle.maintenance') }}</span>
                   </span>
                 </ElDropdownItem>
                 <ElDropdownItem

--- a/src/frontend/src/pages/protection/BackupSources.vue
+++ b/src/frontend/src/pages/protection/BackupSources.vue
@@ -2091,7 +2091,7 @@ onUnmounted(() => {
                       :size="14"
                       class="shrink-0"
                     />
-                    <span>{{ t('nodeLifecycle.maintenanceCommands') }}</span>
+                    <span>{{ t('nodeLifecycle.maintenance') }}</span>
                   </span>
                 </ElDropdownItem>
                 <ElDropdownItem


### PR DESCRIPTION
## Summary

- rename the Agent lifecycle dropdown entry to `Maintenance` in English
- use the existing `维护` translation for the Chinese locale
- keep the lifecycle panel title and commands unchanged
- update the corresponding frontend integration assertion

## Validation

- NodeMaintenanceIntegration.test.ts (6 tests)
- ESLint on changed files
- git diff --check

Note: the full frontend suite still has an unrelated existing failure in `EditS3RepoSave.test.ts`.