### PR TITLE
fix(protection): clean up failed physical snapshots

### DIFF
--- a/src/backend/apps/protection/services/backup_orchestrator.py
+++ b/src/backend/apps/protection/services/backup_orchestrator.py
@@ -1575,12 +1575,12 @@ def _observe_running_directory(
             if not node_online:
                 return
     if node_task.status in _NODE_TASK_TERMINAL:
-        if node_task.status == NodeTask.Status.SUCCESS:
-            snapshot_id, size_bytes, file_count, dir_count, stats = (
-                bt._extract_snapshot_metrics(
-                    node_task.result if isinstance(node_task.result, dict) else {}
-                )
+        snapshot_id, size_bytes, file_count, dir_count, stats = (
+            bt._extract_snapshot_metrics(
+                node_task.result if isinstance(node_task.result, dict) else {}
             )
+        )
+        if node_task.status == NodeTask.Status.SUCCESS:
             if not snapshot_id:
                 record_source_snapshot_directory_result(
                     source_snapshot=source_snapshot,
@@ -1785,6 +1785,11 @@ def _observe_running_directory(
                 display_name=directory_row.display_name,
                 repository_id=directory_row.repository_id,
                 status=directory_status,
+                kopia_snapshot_id=snapshot_id,
+                size_bytes=size_bytes,
+                file_count=file_count,
+                dir_count=dir_count,
+                stats=stats,
                 error_code=error_code,
                 error_message=error_message,
             )

--- a/src/backend/apps/protection/services/policy_execution.py
+++ b/src/backend/apps/protection/services/policy_execution.py
@@ -379,10 +379,43 @@ def retention_delete_candidates_for_config(
     return [snapshot for snapshot in snapshots if int(snapshot.id) not in keep_ids]
 
 
+def failed_snapshot_delete_candidates_for_config(
+    *,
+    config: BackupConfig,
+    policy: BackupPolicy,
+) -> list[BackupSourceSnapshot]:
+    retention = policy.retention if isinstance(policy.retention, dict) else {}
+    if not retention.get("enabled", False):
+        return []
+    return list(
+        BackupSourceSnapshot.objects.filter(
+            organization_id=config.organization_id,
+            source_type=config.source_type,
+            source_ref_id=config.source_ref_id,
+            backup_config_id=config.id,
+            deleted_at__isnull=True,
+            status=BackupSourceSnapshot.Status.FAILED,
+        ).order_by("finished_at", "created_at", "id")
+    )
+
+
 def apply_retention_policies(*, now=None, limit: int = 100) -> dict[str, int]:
     created = 0
     skipped = 0
     for config, policy in _policy_configs():
+        for snapshot in failed_snapshot_delete_candidates_for_config(
+            config=config,
+            policy=policy,
+        )[: max(1, int(limit))]:
+            with transaction.atomic():
+                task = create_and_queue_snapshot_delete_task(
+                    source_snapshot=snapshot,
+                    trigger_type=Task.TriggerType.SYSTEM,
+                )
+            if task.status in {Task.Status.PENDING, Task.Status.RUNNING}:
+                created += 1
+            else:
+                skipped += 1
         for snapshot in retention_delete_candidates_for_config(
             config=config,
             policy=policy,

--- a/src/backend/apps/protection/tests/test_backup_config_api.py
+++ b/src/backend/apps/protection/tests/test_backup_config_api.py
@@ -2817,7 +2817,7 @@ class ProtectionBackupConfigApiTests(TestCase):
             task_id=backup_task.id,
             task_uuid=backup_task.task_uuid,
             idempotency_key="reset-service-source",
-            status=BackupSourceSnapshot.Status.AVAILABLE,
+            status=BackupSourceSnapshot.Status.FAILED,
             directory_count=1,
         )
         BackupSourceSnapshotDirectory.objects.create(
@@ -2828,7 +2828,9 @@ class ProtectionBackupConfigApiTests(TestCase):
             source_path="/data",
             repository_id=self.repository.id,
             kopia_snapshot_id="reset-kopia-1",
-            status=BackupSourceSnapshotDirectory.Status.AVAILABLE,
+            status=BackupSourceSnapshotDirectory.Status.FAILED,
+            error_code="KOPIA_SNAPSHOT_FATAL",
+            error_message="permission denied",
         )
         reset_task = Task.objects.create(
             organization_id=self.org.id,

--- a/src/backend/apps/protection/tests/test_backup_task_api.py
+++ b/src/backend/apps/protection/tests/test_backup_task_api.py
@@ -1957,6 +1957,55 @@ class ProtectionBackupTaskApiTests(TestCase):
             [1, 2],
         )
 
+    def test_failed_directory_persists_returned_kopia_snapshot_id(self):
+        task, snapshot = self._create_backup_task_and_snapshot(
+            idempotency_key="test-failed-kopia-id-persistence",
+        )
+        config_directory = self.config.directories.first()
+        directory = BackupSourceSnapshotDirectory.objects.create(
+            source_snapshot=snapshot,
+            organization_id=self.org.id,
+            backup_config_id=self.config.id,
+            backup_config_dir_id=config_directory.id,
+            source_path=config_directory.path,
+            repository_id=self.repository.id,
+            status=BackupSourceSnapshotDirectory.Status.RUNNING,
+        )
+        node_task = NodeTask.objects.create(
+            organization=self.org,
+            node=self.agent,
+            kind="backup.run",
+            correlation_type=protection_conf.PROTECTION_BACKUP_CORRELATION_TYPE,
+            correlation_id=str(task.task_uuid),
+            payload={"backup_config_dir_id": config_directory.id},
+            result={
+                "kopia_snapshot_id": "failed-physical-snapshot",
+                "size_bytes": 1024,
+                "file_count": 4,
+                "dir_count": 2,
+            },
+            status=NodeTask.Status.FAILED,
+            last_error="permission denied",
+            watchdog_deadline_at=timezone.now(),
+        )
+
+        _observe_running_directory(
+            task=task,
+            source_snapshot=snapshot,
+            directory_row=directory,
+            node_task=node_task,
+            directory_index=1,
+            total_dirs=1,
+            node_online=True,
+        )
+
+        directory.refresh_from_db()
+        self.assertEqual(directory.status, BackupSourceSnapshotDirectory.Status.FAILED)
+        self.assertEqual(directory.kopia_snapshot_id, "failed-physical-snapshot")
+        self.assertEqual(directory.size_bytes, 1024)
+        self.assertEqual(directory.file_count, 4)
+        self.assertEqual(directory.dir_count, 2)
+
     @patch(
         "apps.protection.services.backup_orchestrator.effective_agent_node_status",
         return_value=Node.Availability.ONLINE,

--- a/src/backend/apps/protection/tests/test_policy_execution.py
+++ b/src/backend/apps/protection/tests/test_policy_execution.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
+from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
 from django.test import TestCase
@@ -12,7 +13,9 @@ from apps.protection.models import BackupConfig, BackupPolicy, BackupSourceSnaps
 from apps.protection.services.backup_source_snapshot import create_source_snapshot
 from apps.protection.services.policy_execution import (
     _schedule_fire_key,
+    apply_retention_policies,
     cron_matches_now,
+    failed_snapshot_delete_candidates_for_config,
     retention_delete_candidates_for_config,
     schedule_matches_now,
 )
@@ -261,3 +264,46 @@ class PolicyExecutionTests(TestCase):
 
         self.assertEqual([snapshot.id for snapshot in candidates], [old.id])
         self.assertNotIn(latest.id, [snapshot.id for snapshot in candidates])
+
+    @patch("apps.protection.services.policy_execution._policy_configs")
+    @patch(
+        "apps.protection.services.policy_execution.create_and_queue_snapshot_delete_task"
+    )
+    def test_retention_schedules_failed_snapshots_before_normal_candidates(
+        self, create_delete, policy_configs
+    ):
+        now = timezone.now()
+        failed = self._snapshot("failed-logical", now - timedelta(days=4))
+        failed.status = BackupSourceSnapshot.Status.FAILED
+        failed.save(update_fields=["status", "updated_at"])
+        old = self._snapshot("old-logical-for-order", now - timedelta(days=3))
+        self._snapshot("latest-logical-for-order", now - timedelta(hours=1))
+        policy_configs.return_value = [(self.config, self.policy)]
+        create_delete.return_value.status = "pending"
+
+        result = apply_retention_policies(now=now)
+
+        self.assertEqual(result, {"retention_tasks": 2, "skipped": 0})
+        self.assertEqual(
+            [call.kwargs["source_snapshot"].id for call in create_delete.call_args_list],
+            [failed.id, old.id],
+        )
+
+    def test_failed_candidates_exclude_in_flight_and_normal_snapshots(self):
+        now = timezone.now()
+        failed = self._snapshot("failed-candidate", now - timedelta(days=2))
+        failed.status = BackupSourceSnapshot.Status.FAILED
+        failed.save(update_fields=["status", "updated_at"])
+        creating = self._snapshot("creating-not-candidate", now - timedelta(days=3))
+        creating.status = BackupSourceSnapshot.Status.CREATING
+        creating.save(update_fields=["status", "updated_at"])
+        available = self._snapshot("available-not-failed", now - timedelta(days=4))
+
+        candidates = failed_snapshot_delete_candidates_for_config(
+            config=self.config,
+            policy=self.policy,
+        )
+
+        self.assertEqual([snapshot.id for snapshot in candidates], [failed.id])
+        self.assertNotIn(creating.id, [snapshot.id for snapshot in candidates])
+        self.assertNotIn(available.id, [snapshot.id for snapshot in candidates])

--- a/src/backend/apps/source/tests/test_api.py
+++ b/src/backend/apps/source/tests/test_api.py
@@ -19,6 +19,7 @@ from apps.protection.models import (
     BackupConfigDirectory,
     BackupPolicy,
     BackupSourceSnapshot,
+    BackupSourceSnapshotDirectory,
     FileFilterRule,
 )
 from apps.restore.models import RestorePlan, RestoreRecord
@@ -35,6 +36,8 @@ from apps.task.models import Task, TaskResource, TaskStep
 from apps.task.services.interface import complete_task
 from apps.source.services.internal.backup_source_delete import (
     _create_source_unregister_task,
+    _delete_repository_snapshots,
+    _resolve_context,
     _set_source_nas_removal_status,
     _set_unregister_step,
     reconcile_stuck_source_unregister_tasks,
@@ -3389,6 +3392,66 @@ class BackupSourceBulkDeleteTests(TestCase):
         )
         self.agent.refresh_from_db()
         self.assertFalse(self.agent.is_deleted)
+
+    @patch(
+        "apps.source.services.internal.backup_source_delete._snapshot_delete_strict",
+        return_value=(True, None),
+    )
+    def test_deregister_deletes_failed_physical_snapshots(self, delete_snapshot):
+        repository = Repository.objects.create(
+            organization_id=self.org.id,
+            name="failed-snapshot-deregister-repo",
+            repo_type=Repository.Type.S3,
+            status=Repository.Status.CREATED,
+            health=Repository.Health.ONLINE,
+            s3_bucket="failed-snapshot-deregister",
+        )
+        config = BackupConfig.objects.create(
+            organization_id=self.org.id,
+            name="failed-snapshot-deregister",
+            source_type="agent",
+            source_ref_id=self.agent.id,
+            repository_id=repository.id,
+        )
+        snapshot = BackupSourceSnapshot.objects.create(
+            organization_id=self.org.id,
+            snapshot_uid="failed-snapshot-deregister",
+            idempotency_key="failed-snapshot-deregister-idempotency",
+            source_type="agent",
+            source_ref_id=self.agent.id,
+            backup_config_id=config.id,
+            repository_id=repository.id,
+            task_id=1,
+            status=BackupSourceSnapshot.Status.FAILED,
+        )
+        BackupSourceSnapshotDirectory.objects.create(
+            source_snapshot=snapshot,
+            organization_id=self.org.id,
+            backup_config_id=config.id,
+            backup_config_dir_id=1,
+            source_path="/data",
+            repository_id=config.repository_id,
+            kopia_snapshot_id="failed-deregister-physical-id",
+            status=BackupSourceSnapshotDirectory.Status.FAILED,
+            error_code="KOPIA_SNAPSHOT_FATAL",
+            error_message="permission denied",
+        )
+        ctx = _resolve_context(
+            organization_id=self.org.id,
+            selectable_id=f"agent:{self.agent.id}",
+        )
+        self.assertIsNotNone(ctx)
+
+        result = _delete_repository_snapshots(
+            organization_id=self.org.id,
+            ctx=ctx,
+            force=False,
+            reasons=[],
+            warnings=[],
+        )
+
+        self.assertEqual(result["snapshots_purged"], 1)
+        delete_snapshot.assert_called_once_with(source_snapshot=snapshot)
 
     def test_snapshot_delete_fails_unregister_without_deferred_task(self):
         snapshot_task = Task.objects.create(


### PR DESCRIPTION
## Problem and root cause

Kopia can return a physical snapshot ID together with a terminal backup
failure. The failed-result projection discarded that ID, so retention and
source cleanup could not identify the repository snapshot. Failed logical
snapshots were also excluded from retention processing.

## Solution

- Persist physical snapshot IDs and available metrics for terminal failed
  backup results while keeping their logical status failed.
- Schedule failed snapshot deletion before calculating normal available and
  partial retention candidates.
- Exercise the existing all-status Reset Config and Deregister Source cleanup
  paths with failed physical snapshot regressions.

## Validation

- Targeted Django regressions: 13 passed.
- Protection backend suite: 369 passed.
- Backend Ruff: passed.
- Migration drift check: passed.
- English source boundary and `git diff --check`: passed.
- Manual testing: passed.
- Optional complete Community backend suite: skipped at user request.

## Risks and compatibility

The change uses the existing snapshot deletion locking, physical confirmation,
and `DELETE_FAILED` retry behavior. Failed snapshots do not participate in
normal retention buckets, and in-flight snapshots are excluded from failed
cleanup candidates. No schema or API migration is required.

Fixes #917
