### PR TITLE
docs: open documentation links in new tabs

### DIFF
--- a/website/.vitepress/theme/HomeLanding.vue
+++ b/website/.vitepress/theme/HomeLanding.vue
@@ -136,7 +136,7 @@ function openApp(event: MouseEvent, placement: WebsiteOpenAppPlacement) {
         <nav aria-label="Main navigation">
           <a href="#use-cases">Use Cases</a>
           <a href="#how-it-works">How It Works</a>
-          <a href="/en/docs/">User Docs</a>
+          <a href="/en/docs/" target="_blank" rel="noopener noreferrer">Documentation</a>
           <a href="#open-source">Open Source</a>
           <a href="#contact">Contact</a>
         </nav>

--- a/website/.vitepress/theme/HomeLandingZh.vue
+++ b/website/.vitepress/theme/HomeLandingZh.vue
@@ -135,7 +135,7 @@ function openApp(event: MouseEvent, placement: WebsiteOpenAppPlacement) {
         <nav aria-label="主导航">
           <a href="#use-cases">使用场景</a>
           <a href="#how-it-works">工作原理</a>
-          <a href="/zh/docs/">用户文档</a>
+          <a href="/zh/docs/" target="_blank" rel="noopener noreferrer">文档</a>
           <a href="#open-source">开源</a>
           <a href="#contact">联系我们</a>
         </nav>


### PR DESCRIPTION
## Summary

- rename the Chinese homepage navigation entry from `用户文档` to `文档`
- rename the English homepage navigation entry from `User Docs` to `Documentation`
- open both documentation entries in a new browser tab so the product homepage remains available
- add `noopener noreferrer` to the new-tab links

## Validation

- `npm run build`
- `python3 tools/quality/check-english-source.py`
- `git diff --check`