### PR TITLE
fix(agent): verify managed backup rules independent of order

### DIFF
--- a/src/agent/internal/engine/managed_backup_policy.go
+++ b/src/agent/internal/engine/managed_backup_policy.go
@@ -444,15 +444,16 @@ func verifyManagedBackupProtection(
 		result["error_code"] = "BACKUP_PROTECTION_POLICY_VERIFY_FAILED"
 		return result, fmt.Errorf("verify Agent backup boundary policy: invalid Kopia policy response")
 	}
-	if len(policy.Files.Ignore) < len(required) {
-		result["error_code"] = "BACKUP_PROTECTION_POLICY_MISSING"
-		return result, fmt.Errorf("required Agent backup boundary policy is missing")
+	// Kopia de-duplicates and sorts ignore rules when persisting a policy, so
+	// the effective JSON order cannot be compared with the insertion order.
+	applied := make(map[string]struct{}, len(policy.Files.Ignore))
+	for _, pattern := range policy.Files.Ignore {
+		applied[strings.TrimSpace(pattern)] = struct{}{}
 	}
-	protectedOffset := len(policy.Files.Ignore) - len(required)
-	for index, pattern := range required {
-		if strings.TrimSpace(policy.Files.Ignore[protectedOffset+index]) != pattern {
+	for _, pattern := range required {
+		if _, ok := applied[pattern]; !ok {
 			result["error_code"] = "BACKUP_PROTECTION_POLICY_MISSING"
-			return result, fmt.Errorf("required Agent backup boundary policy is not effective")
+			return result, fmt.Errorf("required Agent backup boundary policy is missing")
 		}
 	}
 	if !policy.Files.NoParentDotIgnoreFiles || len(policy.Files.DotIgnoreFiles) != 0 {

--- a/src/agent/internal/engine/managed_backup_policy_test.go
+++ b/src/agent/internal/engine/managed_backup_policy_test.go
@@ -211,24 +211,61 @@ func TestVerifyManagedBackupProtectionRequiresEffectiveKopiaPolicy(t *testing.T)
 	original := runManagedPolicyCommand
 	t.Cleanup(func() { runManagedPolicyCommand = original })
 
-	t.Run("present", func(t *testing.T) {
-		runManagedPolicyCommand = func(
-			context.Context,
-			time.Duration,
-			string,
-			[]string,
-			map[string]string,
-			string,
-		) (process.Result, error) {
-			return process.Result{Stdout: `{"files":{"ignore":["*.tmp","opt/hyperfilelens-agent"],"noParentDotFiles":true}}`}, nil
-		}
-		result, err := verifyManagedBackupProtection(
-			context.Background(), "kopia", "/tmp/repo.config", nil, "/", []string{"opt/hyperfilelens-agent"},
-		)
-		if err != nil || result["system_ignore_policy_verified"] != true {
-			t.Fatalf("expected verified protection, result=%#v err=%v", result, err)
-		}
-	})
+	for _, tc := range []struct {
+		name     string
+		stdout   string
+		required []string
+	}{
+		{
+			name:     "rule-at-start",
+			stdout:   `{"files":{"ignore":["opt/hyperfilelens-agent","*.tmp"],"noParentDotFiles":true}}`,
+			required: []string{"opt/hyperfilelens-agent"},
+		},
+		{
+			name:     "macos-agent-root-after-kopia-sorting",
+			stdout:   `{"files":{"ignore":["*.tmp",".DS_Store","Library/Application Support/HyperFileLens/Agent","Thumbs.db"],"noParentDotFiles":true}}`,
+			required: []string{"Library/Application Support/HyperFileLens/Agent"},
+		},
+		{
+			name:     "rule-at-end",
+			stdout:   `{"files":{"ignore":["*.tmp","opt/hyperfilelens-agent"],"noParentDotFiles":true}}`,
+			required: []string{"opt/hyperfilelens-agent"},
+		},
+		{
+			name:     "linux-system-rules-after-kopia-sorting",
+			stdout:   `{"files":{"ignore":["*.tmp","/dev/","/proc/","/run/","/sys/"],"noParentDotFiles":true}}`,
+			required: []string{"/proc/", "/sys/", "/dev/", "/run/"},
+		},
+		{
+			name:     "windows-case-folded-rules-after-kopia-sorting",
+			stdout:   `{"files":{"ignore":["*.tmp","/[Pp][Aa][Gg][Ee][Ff][Ii][Ll][Ee].[Ss][Yy][Ss]","/[Ss][Ww][Aa][Pp][Ff][Ii][Ll][Ee].[Ss][Yy][Ss]"],"noParentDotFiles":true}}`,
+			required: []string{"/[Ss][Ww][Aa][Pp][Ff][Ii][Ll][Ee].[Ss][Yy][Ss]", "/[Pp][Aa][Gg][Ee][Ff][Ii][Ll][Ee].[Ss][Yy][Ss]"},
+		},
+		{
+			name:     "user-negation-precedes-protected-rule",
+			stdout:   `{"files":{"ignore":["!opt/hyperfilelens-agent","opt/hyperfilelens-agent"],"noParentDotFiles":true}}`,
+			required: []string{"opt/hyperfilelens-agent"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			runManagedPolicyCommand = func(
+				context.Context,
+				time.Duration,
+				string,
+				[]string,
+				map[string]string,
+				string,
+			) (process.Result, error) {
+				return process.Result{Stdout: tc.stdout}, nil
+			}
+			result, err := verifyManagedBackupProtection(
+				context.Background(), "kopia", "/tmp/repo.config", nil, "/", tc.required,
+			)
+			if err != nil || result["system_ignore_policy_verified"] != true {
+				t.Fatalf("expected verified protection, result=%#v err=%v", result, err)
+			}
+		})
+	}
 
 	t.Run("missing", func(t *testing.T) {
 		runManagedPolicyCommand = func(
@@ -239,13 +276,32 @@ func TestVerifyManagedBackupProtectionRequiresEffectiveKopiaPolicy(t *testing.T)
 			map[string]string,
 			string,
 		) (process.Result, error) {
-			return process.Result{Stdout: `{"files":{"ignore":["*.tmp"]}}`}, nil
+			return process.Result{Stdout: `{"files":{"ignore":["/proc/","*.tmp"],"noParentDotFiles":true}}`}, nil
+		}
+		result, err := verifyManagedBackupProtection(
+			context.Background(), "kopia", "/tmp/repo.config", nil, "/", []string{"/proc/", "/run/"},
+		)
+		if err == nil || result["error_code"] != "BACKUP_PROTECTION_POLICY_MISSING" {
+			t.Fatalf("expected missing protection failure, result=%#v err=%v", result, err)
+		}
+	})
+
+	t.Run("similar-rule-is-not-exact", func(t *testing.T) {
+		runManagedPolicyCommand = func(
+			context.Context,
+			time.Duration,
+			string,
+			[]string,
+			map[string]string,
+			string,
+		) (process.Result, error) {
+			return process.Result{Stdout: `{"files":{"ignore":["opt/hyperfilelens-agent-old"],"noParentDotFiles":true}}`}, nil
 		}
 		result, err := verifyManagedBackupProtection(
 			context.Background(), "kopia", "/tmp/repo.config", nil, "/", []string{"opt/hyperfilelens-agent"},
 		)
 		if err == nil || result["error_code"] != "BACKUP_PROTECTION_POLICY_MISSING" {
-			t.Fatalf("expected missing protection failure, result=%#v err=%v", result, err)
+			t.Fatalf("expected exact protection failure, result=%#v err=%v", result, err)
 		}
 	})
 
@@ -265,6 +321,25 @@ func TestVerifyManagedBackupProtectionRequiresEffectiveKopiaPolicy(t *testing.T)
 		)
 		if err == nil || result["error_code"] != "BACKUP_PROTECTION_DOT_IGNORE_ENABLED" {
 			t.Fatalf("expected dot-ignore protection failure, result=%#v err=%v", result, err)
+		}
+	})
+
+	t.Run("dot-ignore-list-not-empty", func(t *testing.T) {
+		runManagedPolicyCommand = func(
+			context.Context,
+			time.Duration,
+			string,
+			[]string,
+			map[string]string,
+			string,
+		) (process.Result, error) {
+			return process.Result{Stdout: `{"files":{"ignore":["opt/hyperfilelens-agent"],"ignoreDotFiles":[".kopiaignore"],"noParentDotFiles":true}}`}, nil
+		}
+		result, err := verifyManagedBackupProtection(
+			context.Background(), "kopia", "/tmp/repo.config", nil, "/", []string{"opt/hyperfilelens-agent"},
+		)
+		if err == nil || result["error_code"] != "BACKUP_PROTECTION_DOT_IGNORE_ENABLED" {
+			t.Fatalf("expected dot-ignore list protection failure, result=%#v err=%v", result, err)
 		}
 	})
 }


### PR DESCRIPTION
## Summary

- verify required managed backup protection rules by exact membership instead of persisted array position
- preserve fail-closed checks for missing system rules and enabled dot-ignore inheritance
- cover Kopia-sorted macOS, Linux, and Windows policy responses

## Root cause

Kopia de-duplicates and sorts ignore rules when persisting a policy. The verification added in #911 incorrectly assumed protected rules would remain at the end of the returned array, causing valid macOS backup policies to fail with `BACKUP_PROTECTION_POLICY_MISSING`.

## Validation

- full Agent test suite
- targeted managed backup policy tests with the race detector
- `go vet ./internal/engine`
- Agent compile-only suite
- macOS and Windows cross-compilation
- `git diff --check`