### PR TITLE
Support Ubuntu 20.04 curl in the online installer

### DIFF
--- a/deploy/online/install.sh
+++ b/deploy/online/install.sh
@@ -22,6 +22,7 @@ INSTALL_ACTION="Install"
 MAX_TAG_PAGES=100
 ONLINE_LOG_FILE=""
 ONLINE_INTERACTIVE=0
+CURL_RETRY_ARGS=()
 
 usage() {
 	cat <<'USAGE'
@@ -201,13 +202,43 @@ PY
 		|| fail "this public installer upgrades Community only; the existing edition is ${existing_edition}"
 }
 
+configure_curl_retry_options() {
+	local version_output curl_version="unknown"
+	version_output="$(curl --version 2>/dev/null || true)"
+	version_output="${version_output%%$'\n'*}"
+	if [[ "${version_output}" =~ ^curl[[:space:]]+([^[:space:]]+) ]]; then
+		curl_version="${BASH_REMATCH[1]}"
+	fi
+
+	CURL_RETRY_ARGS=(--retry 3 --retry-delay 2)
+	if curl --retry-all-errors --version >/dev/null 2>&1; then
+		CURL_RETRY_ARGS+=(--retry-all-errors)
+	elif curl --retry-connrefused --version >/dev/null 2>&1; then
+		CURL_RETRY_ARGS+=(--retry-connrefused)
+		printf '[INFO] curl %s detected; using Ubuntu-compatible retry options.\n' \
+			"${curl_version}"
+	else
+		printf '[WARN] curl %s lacks enhanced retry options; using standard retries.\n' \
+			"${curl_version}"
+	fi
+}
+
 download_file() {
 	local url=$1
 	local output=$2
 	local max_time=${3:-120}
-	curl --fail --show-error --silent --location \
-		--retry 3 --retry-all-errors --connect-timeout 15 --max-time "${max_time}" \
-		-H 'Cache-Control: no-cache' "${url}" -o "${output}"
+	local partial="${output}.part"
+	rm -f -- "${partial}"
+	if curl --fail --show-error --silent --location \
+		"${CURL_RETRY_ARGS[@]}" \
+		--connect-timeout 15 --max-time "${max_time}" \
+		-H 'Cache-Control: no-cache' "${url}" -o "${partial}"; then
+		if mv -f -- "${partial}" "${output}"; then
+			return 0
+		fi
+	fi
+	rm -f -- "${partial}"
+	return 1
 }
 
 fail_with_tag_guidance() {
@@ -449,6 +480,7 @@ trap 'exit 143' TERM
 
 install_host_tools
 inspect_existing_installation
+configure_curl_retry_options
 resolve_tag
 print_target
 confirm_installation

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -4,6 +4,17 @@ set -euo pipefail
 umask 022
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+online_installer="${ROOT}/deploy/online/install.sh"
+
+grep -F 'configure_curl_retry_options()' "${online_installer}" >/dev/null
+grep -F 'curl --retry-all-errors --version' "${online_installer}" >/dev/null
+grep -F 'curl --retry-connrefused --version' "${online_installer}" >/dev/null
+grep -F 'CURL_RETRY_ARGS=(--retry 3 --retry-delay 2)' "${online_installer}" >/dev/null
+grep -F 'local partial="${output}.part"' "${online_installer}" >/dev/null
+if grep -F -- '--retry 3 --retry-all-errors' "${online_installer}" >/dev/null; then
+	printf 'ERROR: online installer unconditionally requires curl --retry-all-errors\n' >&2
+	exit 1
+fi
 
 grep -F './tools/quality/test-docker-image-digest-alias.sh' \
 	"${ROOT}/.github/workflows/release_pipeline.yml" >/dev/null

--- a/tools/quality/test-online-community-install.sh
+++ b/tools/quality/test-online-community-install.sh
@@ -209,7 +209,46 @@ cat >"${fake_bin}/curl" <<'SH'
 set -euo pipefail
 output=""
 url=""
+original_args=("$@")
 [[ -z "${HFL_TEST_CURL_MARKER:-}" ]] || touch "${HFL_TEST_CURL_MARKER}"
+if [[ -n "${HFL_TEST_CURL_LOG:-}" ]]; then
+	printf '%q ' "${original_args[@]}" >>"${HFL_TEST_CURL_LOG}"
+	printf '\n' >>"${HFL_TEST_CURL_LOG}"
+fi
+case "${1:-} ${2:-}" in
+"--retry-all-errors --version")
+	if [[ "${HFL_TEST_CURL_SUPPORT_RETRY_ALL_ERRORS:-1}" == "1" ]]; then
+		printf 'curl 8.5.0 test-build\n'
+		exit 0
+	fi
+	printf 'curl: option --retry-all-errors: is unknown\n' >&2
+	exit 2
+	;;
+"--retry-connrefused --version")
+	if [[ "${HFL_TEST_CURL_SUPPORT_RETRY_CONNREFUSED:-1}" == "1" ]]; then
+		printf 'curl 7.68.0 test-build\n'
+		exit 0
+	fi
+	printf 'curl: option --retry-connrefused: is unknown\n' >&2
+	exit 2
+	;;
+"--version ")
+	if [[ "${HFL_TEST_CURL_SUPPORT_RETRY_ALL_ERRORS:-1}" == "1" ]]; then
+		printf 'curl 8.5.0 test-build\n'
+	else
+		printf 'curl 7.68.0 test-build\n'
+	fi
+	exit 0
+	;;
+esac
+if [[ "${HFL_TEST_CURL_SUPPORT_RETRY_ALL_ERRORS:-1}" != "1" ]]; then
+	for argument in "${original_args[@]}"; do
+		if [[ "${argument}" == "--retry-all-errors" ]]; then
+			printf 'curl: option --retry-all-errors: is unknown\n' >&2
+			exit 2
+		fi
+	done
+fi
 while (($#)); do
 	case "$1" in
 	-o)
@@ -223,6 +262,14 @@ while (($#)); do
 	*) shift ;;
 	esac
 done
+if [[ "${HFL_TEST_CURL_PARTIAL_FAIL:-0}" == "1" && -n "${output}" ]]; then
+	printf 'partial response\n' >"${output}"
+	exit 28
+fi
+if [[ -n "${HFL_TEST_CURL_PAYLOAD:-}" && -n "${output}" ]]; then
+	printf '%s\n' "${HFL_TEST_CURL_PAYLOAD}" >"${output}"
+	exit 0
+fi
 if [[ "${url}" == *'/tags?'* && -n "${output}" ]]; then
 	page=1
 	if [[ "${url}" =~ [\?\&]page=([0-9]+) ]]; then
@@ -334,6 +381,46 @@ esac
 SH
 chmod 755 "${fake_bin}/curl" "${fake_bin}/docker"
 
+online_functions="${tmp}/online-install-functions.sh"
+python3 - "${online}/install.sh" "${online_functions}" <<'PY'
+import pathlib
+import sys
+
+source = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
+marker = "\nwhile (($#)); do\n"
+if source.count(marker) != 1:
+    raise SystemExit("online installer entrypoint marker is ambiguous")
+pathlib.Path(sys.argv[2]).write_text(source.split(marker, 1)[0], encoding="utf-8")
+PY
+atomic_target="${tmp}/atomic-download.json"
+printf 'preserved response\n' >"${atomic_target}"
+if (
+	export PATH="${fake_bin}:${PATH}"
+	export HFL_TEST_CURL_PARTIAL_FAIL=1
+	# shellcheck disable=SC1090
+	source "${online_functions}"
+	configure_curl_retry_options
+	download_file "https://example.test/partial" "${atomic_target}"
+); then
+	printf 'ERROR: interrupted online download unexpectedly succeeded\n' >&2
+	exit 1
+fi
+grep -Fxq 'preserved response' "${atomic_target}"
+[[ ! -e "${atomic_target}.part" ]] || {
+	printf 'ERROR: interrupted online download replaced the target or retained a partial artifact\n' >&2
+	exit 1
+}
+(
+	export PATH="${fake_bin}:${PATH}"
+	export HFL_TEST_CURL_PAYLOAD='complete response'
+	# shellcheck disable=SC1090
+	source "${online_functions}"
+	configure_curl_retry_options
+	download_file "https://example.test/complete" "${atomic_target}"
+)
+grep -Fxq 'complete response' "${atomic_target}"
+[[ ! -e "${atomic_target}.part" ]]
+
 test_install_root="${tmp}/community-install"
 test_installer="${tmp}/online-install.sh"
 python3 - "${online}/install.sh" "${test_installer}" "${test_install_root}" "${tmp}" <<'PY'
@@ -399,7 +486,9 @@ grep -Fq 'this public installer upgrades Community only' "${enterprise_log}" || 
 }
 
 latest_log="${tmp}/latest-tag.log"
+modern_curl_log="${tmp}/curl-modern.log"
 if PATH="${fake_bin}:${PATH}" HFL_TEST_TAG_FIXTURE="${tag_fixture}" \
+	HFL_TEST_CURL_LOG="${modern_curl_log}" \
 	"${test_installer}" --mirror global --yes >"${latest_log}" 2>&1; then
 	printf 'ERROR: fake online install unexpectedly succeeded\n' >&2
 	exit 1
@@ -417,6 +506,37 @@ grep -Fq "Log file       ${latest_session_log}" "${latest_log}"
 grep -Fq 'recent fallback tags: v1.2.11, v1.2.10, v1.2.9, v1.2.8, v1.2.7, v1.2.6, v1.2.5, v1.2.4, v1.2.3, v1.2.2' \
 	"${latest_log}"
 grep -Fq 'recommended retry: --mirror global --tag v1.2.11' "${latest_log}"
+grep -v -- '--version' "${modern_curl_log}" \
+	| grep -F -- '--retry-all-errors' >/dev/null
+if grep -Fq 'using Ubuntu-compatible retry options' "${latest_log}"; then
+	printf 'ERROR: modern curl unexpectedly selected compatibility retry mode\n' >&2
+	exit 1
+fi
+
+compatible_log="${tmp}/curl-7.68-install.log"
+compatible_curl_log="${tmp}/curl-7.68-args.log"
+if PATH="${fake_bin}:${PATH}" HFL_TEST_TAG_FIXTURE="${tag_fixture}" \
+	HFL_TEST_CURL_SUPPORT_RETRY_ALL_ERRORS=0 \
+	HFL_TEST_CURL_LOG="${compatible_curl_log}" \
+	"${test_installer}" --mirror global --yes >"${compatible_log}" 2>&1; then
+	printf 'ERROR: fake curl 7.68 online install unexpectedly succeeded\n' >&2
+	exit 1
+fi
+grep -Fq '[INFO] curl 7.68.0 detected; using Ubuntu-compatible retry options.' \
+	"${compatible_log}"
+grep -Fq '[....] Downloading v1.2.12 installation contract from GitHub' \
+	"${compatible_log}"
+grep -v -- '--version' "${compatible_curl_log}" \
+	| grep -F -- '--retry-connrefused' >/dev/null
+if grep -v -- '--version' "${compatible_curl_log}" \
+	| grep -F -- '--retry-all-errors' >/dev/null; then
+	printf 'ERROR: curl 7.68 downloads received --retry-all-errors\n' >&2
+	exit 1
+fi
+if grep -Fq 'option --retry-all-errors: is unknown' "${compatible_log}"; then
+	printf 'ERROR: curl capability probing leaked an unsupported-option error\n' >&2
+	exit 1
+fi
 
 missing_log="${tmp}/missing-tag.log"
 if PATH="${fake_bin}:${PATH}" HFL_TEST_TAG_FIXTURE="${tag_fixture}" \


### PR DESCRIPTION
## Summary

- select retry options by curl capability so Ubuntu 20.04 curl 7.68 remains supported
- retain enhanced retries on modern curl and fall back safely on older clients
- stage downloads through partial files and atomically promote successful results
- cover modern, Ubuntu-compatible, legacy, and interrupted-download paths

## Validation

- `bash tools/quality/test-online-community-install.sh`
- `bash tools/quality/check-release-contracts.sh`
- `bash tools/quality/test-bootstrap-download-progress.sh`
- `bash tools/quality/test-bootstrap-curl-tls-nounset.sh`
- Bash syntax, Ruff, Python compile, and diff checks