### PR TITLE
fix(agent): exclude Windows dump stack runtime file

### DIFF
--- a/src/agent/internal/engine/agent_path_boundary_test.go
+++ b/src/agent/internal/engine/agent_path_boundary_test.go
@@ -99,8 +99,55 @@ func TestSystemBackupBoundaryLoadsAdditionalConfiguredPaths(t *testing.T) {
 }
 
 func TestCaseFoldSystemIgnorePattern(t *testing.T) {
-	if got := caseFoldSystemIgnorePattern("/System Volume Information/"); got != "/[Ss][Yy][Ss][Tt][Ee][Mm] [Vv][Oo][Ll][Uu][Mm][Ee] [Ii][Nn][Ff][Oo][Rr][Mm][Aa][Tt][Ii][Oo][Nn]/" {
-		t.Fatalf("case-folded system pattern = %q", got)
+	for _, tc := range []struct {
+		name    string
+		pattern string
+		want    string
+	}{
+		{
+			name:    "system-volume-information",
+			pattern: "/System Volume Information/",
+			want:    "/[Ss][Yy][Ss][Tt][Ee][Mm] [Vv][Oo][Ll][Uu][Mm][Ee] [Ii][Nn][Ff][Oo][Rr][Mm][Aa][Tt][Ii][Oo][Nn]/",
+		},
+		{
+			name:    "dump-stack-log",
+			pattern: "/DumpStack.log.tmp",
+			want:    "/[Dd][Uu][Mm][Pp][Ss][Tt][Aa][Cc][Kk].[Ll][Oo][Gg].[Tt][Mm][Pp]",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := caseFoldSystemIgnorePattern(tc.pattern); got != tc.want {
+				t.Fatalf("case-folded system pattern = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestWindowsSystemBackupBoundaryIncludesRootDumpStackFile(t *testing.T) {
+	root := t.TempDir()
+	want := filepath.Join(root, "DumpStack.log.tmp")
+	for _, candidate := range windowsSystemBackupBoundaryCandidates(root) {
+		if candidate.path != want {
+			continue
+		}
+		if candidate.directory || !candidate.caseInsensitive {
+			t.Fatalf("DumpStack boundary must be a case-insensitive file: %#v", candidate)
+		}
+		return
+	}
+	t.Fatalf("missing Windows DumpStack boundary %q", want)
+}
+
+func TestRootedSystemIgnorePatternAnchorsDumpStackFile(t *testing.T) {
+	source := filepath.Join(string(filepath.Separator), "volume")
+	protected := filepath.Join(source, "DumpStack.log.tmp")
+	got, err := rootedSystemIgnorePattern(source, protected, false, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "/[Dd][Uu][Mm][Pp][Ss][Tt][Aa][Cc][Kk].[Ll][Oo][Gg].[Tt][Mm][Pp]"
+	if got != want {
+		t.Fatalf("rooted system pattern = %q, want %q", got, want)
 	}
 }
 

--- a/src/agent/internal/engine/system_backup_boundary.go
+++ b/src/agent/internal/engine/system_backup_boundary.go
@@ -26,8 +26,8 @@ type systemBackupBoundaryCandidate struct {
 }
 
 // systemBackupBoundaryCandidates returns only operating-system runtime paths
-// that cannot be restored as ordinary user data. It intentionally does not
-// include caches, logs, temporary directories, or user-owned paths.
+// that cannot be restored as ordinary user data. General caches, logs,
+// temporary directories, and user-owned paths are intentionally not included.
 func systemBackupBoundaryCandidates(sourcePath string) []systemBackupBoundaryCandidate {
 	switch runtime.GOOS {
 	case "linux":
@@ -51,14 +51,19 @@ func systemBackupBoundaryCandidates(sourcePath string) []systemBackupBoundaryCan
 			return nil
 		}
 		root := filepath.Clean(volume + string(filepath.Separator))
-		return []systemBackupBoundaryCandidate{
-			{path: filepath.Join(root, "System Volume Information"), directory: true, caseInsensitive: true},
-			{path: filepath.Join(root, "pagefile.sys"), caseInsensitive: true},
-			{path: filepath.Join(root, "hiberfil.sys"), caseInsensitive: true},
-			{path: filepath.Join(root, "swapfile.sys"), caseInsensitive: true},
-		}
+		return windowsSystemBackupBoundaryCandidates(root)
 	default:
 		return nil
+	}
+}
+
+func windowsSystemBackupBoundaryCandidates(root string) []systemBackupBoundaryCandidate {
+	return []systemBackupBoundaryCandidate{
+		{path: filepath.Join(root, "System Volume Information"), directory: true, caseInsensitive: true},
+		{path: filepath.Join(root, "DumpStack.log.tmp"), caseInsensitive: true},
+		{path: filepath.Join(root, "pagefile.sys"), caseInsensitive: true},
+		{path: filepath.Join(root, "hiberfil.sys"), caseInsensitive: true},
+		{path: filepath.Join(root, "swapfile.sys"), caseInsensitive: true},
 	}
 }
 


### PR DESCRIPTION
## Summary

- exclude the volume-root `DumpStack.log.tmp` Windows runtime file from managed backups
- preserve root anchoring and case-insensitive matching without excluding same-named user files in subdirectories
- retain strict failures for all other unreadable user data

## Root cause

A production backup of a Windows volume failed after scanning more than 155 GB because Windows held `DumpStack.log.tmp` open as an operating-system runtime file. The existing system boundary already excludes other non-restorable Windows runtime paths, but did not include this file.

## Scope

This change only extends the existing Agent system backup boundary. It does not change the Controller, database, UI, Worker, repository flow, or general unreadable-file policy.

## Validation

- full Agent test suite
- targeted system boundary tests
- targeted race detector tests
- `go vet ./internal/engine`
- Windows and macOS cross-compilation
- `git diff --check`