### PR TITLE
Preserve Agent capabilities across heartbeat updates

### DIFF
--- a/src/backend/apps/node/api/views/node.py
+++ b/src/backend/apps/node/api/views/node.py
@@ -693,6 +693,8 @@ class NodeViewSet(OrgScopedMixin, SoftDeleteDestroyMixin, viewsets.ModelViewSet)
                     sync_agent_source_host(node=node)
                     new_agent_registered = True
         elif node is not None:
+            # Authenticate before taking the Node row lock. Credential hashing
+            # must not block WebSocket inventory persistence for invalid calls.
             legacy_token = None
             credential_valid = validate_node_credential(node, node_token)
             if not credential_valid:
@@ -706,89 +708,105 @@ class NodeViewSet(OrgScopedMixin, SoftDeleteDestroyMixin, viewsets.ModelViewSet)
                     {"error": "invalid node credential"},
                     status=status.HTTP_401_UNAUTHORIZED,
                 )
-            if payload["installation_mode"] != node.installation_mode:
-                return Response(
-                    {"error": "installation mode is fixed during enrollment"},
-                    status=status.HTTP_409_CONFLICT,
+            existing_node_id = node.pk
+            with transaction.atomic():
+                # WebSocket inventory writes lock the same row. Re-read the
+                # latest metadata under that lock so an HTTP registration
+                # refresh cannot overwrite a concurrently reported inventory.
+                node = (
+                    list_nodes(organization=org)
+                    .select_for_update()
+                    .filter(pk=existing_node_id)
+                    .first()
                 )
-            if legacy_token is not None:
-                token_row = legacy_token
-                node_credential = issue_node_credential(
-                    node=node,
-                    enrollment_token=legacy_token,
-                    installation_id=installation_id or node.installation_id,
-                )
-            if installation_id and not node.installation_id:
-                identity_in_use = (
-                    Node.objects.filter(
-                        organization=org,
-                        role=node.role,
-                        installation_id=installation_id,
+                if node is None:
+                    return Response(
+                        {"error": "node not found; enrollment token required"},
+                        status=status.HTTP_404_NOT_FOUND,
                     )
-                    .exclude(pk=node.pk)
-                    .exists()
-                )
-                if not identity_in_use:
-                    node.installation_id = installation_id
-            node.last_seen_at = observed_at
-            if node.installation_mode in (
-                Node.InstallationMode.USER,
-                Node.InstallationMode.USER_CONTINUOUS,
-            ):
-                # User-scoped instances are identified by the runtime
-                # principal. Do not let the ordinary hostname in a heartbeat
-                # erase the account suffix after reconnecting, but preserve a
-                # display name that a console user explicitly assigned.
-                principal = runtime_principal_name(metadata_payload)
-                if principal and (
-                    is_automatic_user_node_name(
-                        name=node.name,
-                        metadata=node.metadata,
-                        node_id=node.id,
+                if payload["installation_mode"] != node.installation_mode:
+                    return Response(
+                        {"error": "installation mode is fixed during enrollment"},
+                        status=status.HTTP_409_CONFLICT,
                     )
-                    or is_automatic_user_node_name(
-                        name=node.name,
-                        metadata=metadata_payload,
-                        node_id=node.id,
+                if legacy_token is not None:
+                    token_row = legacy_token
+                    node_credential = issue_node_credential(
+                        node=node,
+                        enrollment_token=legacy_token,
+                        installation_id=installation_id or node.installation_id,
                     )
+                if installation_id and not node.installation_id:
+                    identity_in_use = (
+                        Node.objects.filter(
+                            organization=org,
+                            role=node.role,
+                            installation_id=installation_id,
+                        )
+                        .exclude(pk=node.pk)
+                        .exists()
+                    )
+                    if not identity_in_use:
+                        node.installation_id = installation_id
+                node.last_seen_at = observed_at
+                if node.installation_mode in (
+                    Node.InstallationMode.USER,
+                    Node.InstallationMode.USER_CONTINUOUS,
                 ):
+                    # User-scoped instances are identified by the runtime
+                    # principal. Do not let the ordinary hostname in a heartbeat
+                    # erase the account suffix after reconnecting, but preserve a
+                    # display name that a console user explicitly assigned.
+                    principal = runtime_principal_name(metadata_payload)
+                    if principal and (
+                        is_automatic_user_node_name(
+                            name=node.name,
+                            metadata=node.metadata,
+                            node_id=node.id,
+                        )
+                        or is_automatic_user_node_name(
+                            name=node.name,
+                            metadata=metadata_payload,
+                            node_id=node.id,
+                        )
+                    ):
+                        next_name = uniquify_node_name(
+                            organization_id=org.id,
+                            name=resolve_registration_node_name(payload=payload),
+                            exclude_node_id=node.id,
+                        )
+                        if next_name != node.name:
+                            node.name = next_name
+                elif is_auto_assigned_node_name(node.name):
+                    next_name = resolve_registration_node_name(
+                        payload=payload,
+                        fallback=node.name,
+                    )
                     next_name = uniquify_node_name(
                         organization_id=org.id,
-                        name=resolve_registration_node_name(payload=payload),
+                        name=next_name,
                         exclude_node_id=node.id,
                     )
                     if next_name != node.name:
                         node.name = next_name
-            elif is_auto_assigned_node_name(node.name):
-                next_name = resolve_registration_node_name(
-                    payload=payload,
-                    fallback=node.name,
-                )
-                next_name = uniquify_node_name(
-                    organization_id=org.id,
-                    name=next_name,
-                    exclude_node_id=node.id,
-                )
-                if next_name != node.name:
-                    node.name = next_name
-            elif payload.get("name"):
-                node.name = payload.get("name")
-            node.version = payload.get("version", node.version)
-            node.os_name = payload.get("os_name", node.os_name)
-            if "metadata" in payload:
-                node.metadata = registration_metadata(
-                    metadata_payload,
-                    existing_metadata=node.metadata,
-                )
-                if network_state.primary_ip_address:
-                    node.ip_address = network_state.primary_ip_address
-                if network_state.inventory is not None:
-                    node.network_inventory = network_state.inventory
-            if client_ip:
-                node.connection_ip_address = client_ip
-            if host_fingerprint and not node.host_fingerprint:
-                node.host_fingerprint = host_fingerprint
-            node.save()
+                elif payload.get("name"):
+                    node.name = payload.get("name")
+                node.version = payload.get("version", node.version)
+                node.os_name = payload.get("os_name", node.os_name)
+                if "metadata" in payload:
+                    node.metadata = registration_metadata(
+                        metadata_payload,
+                        existing_metadata=node.metadata,
+                    )
+                    if network_state.primary_ip_address:
+                        node.ip_address = network_state.primary_ip_address
+                    if network_state.inventory is not None:
+                        node.network_inventory = network_state.inventory
+                if client_ip:
+                    node.connection_ip_address = client_ip
+                if host_fingerprint and not node.host_fingerprint:
+                    node.host_fingerprint = host_fingerprint
+                node.save()
         else:
             return Response(
                 {"error": "node not found; enrollment token required"},

--- a/src/backend/apps/node/services/internal/local_platform_gateway.py
+++ b/src/backend/apps/node/services/internal/local_platform_gateway.py
@@ -121,6 +121,18 @@ def registration_metadata(
     metadata = dict(payload_metadata) if isinstance(payload_metadata, dict) else {}
     incoming_version, incoming_commit = _metadata_build_identity(metadata)
     existing_version, existing_commit = _metadata_build_identity(existing_metadata)
+    incoming_capabilities_present, incoming_capabilities = _metadata_capabilities(
+        metadata
+    )
+    existing_capabilities_present, existing_capabilities = _metadata_capabilities(
+        existing_metadata
+    )
+    same_complete_build = bool(
+        incoming_version
+        and incoming_commit
+        and incoming_version == existing_version
+        and incoming_commit == existing_commit
+    )
     if (
         incoming_version
         and not incoming_commit
@@ -138,6 +150,20 @@ def registration_metadata(
             version=incoming_version,
             commit=incoming_commit,
         )
+    if incoming_capabilities_present:
+        if incoming_capabilities is None:
+            _remove_metadata_capabilities(metadata)
+        else:
+            _set_metadata_capabilities(metadata, incoming_capabilities)
+    elif (
+        same_complete_build
+        and existing_capabilities_present
+        and existing_capabilities is not None
+    ):
+        # Older Agents refresh durable HTTP registration without repeating the
+        # WebSocket capability inventory. Preserve it only for the exact same
+        # build so capabilities can never leak across an upgrade.
+        _set_metadata_capabilities(metadata, existing_capabilities)
     for key in LOCAL_PLATFORM_GATEWAY_METADATA:
         metadata.pop(key, None)
     installer_managed = (
@@ -187,6 +213,53 @@ def _set_metadata_build_identity(
         inventory["agent_commit"] = commit
     else:
         inventory.pop("agent_commit", None)
+    metadata["inventory"] = inventory
+
+
+def _metadata_capabilities(metadata: object) -> tuple[bool, list[str] | None]:
+    """Return whether capabilities were reported and their normalized values."""
+    if not isinstance(metadata, dict):
+        return False, None
+    inventory = metadata.get("inventory")
+    if isinstance(inventory, dict) and "capabilities" in inventory:
+        raw = inventory.get("capabilities")
+    elif "capabilities" in metadata:
+        raw = metadata.get("capabilities")
+    else:
+        return False, None
+    if not isinstance(raw, list):
+        return True, None
+    values: list[str] = []
+    seen: set[str] = set()
+    for item in raw:
+        value = str(item or "").strip()
+        if not value or value in seen:
+            continue
+        seen.add(value)
+        values.append(value)
+    return True, values
+
+
+def _set_metadata_capabilities(metadata: dict, capabilities: list[str]) -> None:
+    """Store capabilities in canonical inventory metadata when available."""
+    inventory = metadata.get("inventory")
+    if isinstance(inventory, dict):
+        inventory = dict(inventory)
+        inventory["capabilities"] = list(capabilities)
+        metadata["inventory"] = inventory
+        metadata.pop("capabilities", None)
+        return
+    metadata["capabilities"] = list(capabilities)
+
+
+def _remove_metadata_capabilities(metadata: dict) -> None:
+    """Remove malformed capabilities from both current and legacy locations."""
+    metadata.pop("capabilities", None)
+    inventory = metadata.get("inventory")
+    if not isinstance(inventory, dict):
+        return
+    inventory = dict(inventory)
+    inventory.pop("capabilities", None)
     metadata["inventory"] = inventory
 
 

--- a/src/backend/apps/node/tests/test_enrollment_token_reuse.py
+++ b/src/backend/apps/node/tests/test_enrollment_token_reuse.py
@@ -49,6 +49,7 @@ class EnrollmentTokenReuseTests(TestCase):
         platform: str = "linux",
         node_id: int | None = None,
         node_credential: str = "",
+        inventory: dict | None = None,
     ):
         payload = {
             "role": "agent",
@@ -67,6 +68,8 @@ class EnrollmentTokenReuseTests(TestCase):
             "installation_mode": installation_mode,
             "host_fingerprint": host_fingerprint,
         }
+        if inventory is not None:
+            payload["metadata"]["inventory"] = inventory
         if node_id is not None:
             payload["node_id"] = node_id
         request = self.factory.post(
@@ -77,6 +80,40 @@ class EnrollmentTokenReuseTests(TestCase):
             HTTP_X_NODE_TOKEN=node_credential or token or self.token_row.token,
         )
         return NodeViewSet.as_view({"post": "heartbeat"})(request)
+
+    def test_existing_node_heartbeat_preserves_same_build_ws_capabilities(self):
+        registered = self._heartbeat(
+            name="host-a",
+            installation_id="hfli_host_a",
+        )
+        self.assertEqual(registered.status_code, 200)
+        node = Node.objects.get(pk=registered.data["node_id"])
+        node.metadata = {
+            "inventory": {
+                "agent_version": "0.2.12",
+                "agent_commit": "build123",
+                "capabilities": ["detached_uninstall_v2"],
+            }
+        }
+        node.save(update_fields=["metadata", "updated_at"])
+
+        refreshed = self._heartbeat(
+            name="host-a",
+            installation_id="hfli_host_a",
+            node_id=node.id,
+            node_credential=registered.data["node_credential"],
+            inventory={
+                "agent_version": "0.2.12",
+                "agent_commit": "build123",
+            },
+        )
+
+        self.assertEqual(refreshed.status_code, 200)
+        node.refresh_from_db()
+        self.assertEqual(
+            node.metadata["inventory"]["capabilities"],
+            ["detached_uninstall_v2"],
+        )
 
     def test_same_token_registers_multiple_nodes(self):
         first = self._heartbeat(name="host-a")

--- a/src/backend/apps/node/tests/test_local_platform_gateway.py
+++ b/src/backend/apps/node/tests/test_local_platform_gateway.py
@@ -124,6 +124,89 @@ class LocalPlatformGatewayConfigTests(SimpleTestCase):
         self.assertNotIn("agent_commit", metadata)
         self.assertNotIn("agent_commit", metadata["inventory"])
 
+    def test_registration_metadata_preserves_same_build_capabilities(self):
+        existing = {
+            "inventory": {
+                "agent_version": "0.2.12",
+                "agent_commit": "build123",
+                "capabilities": ["detached_uninstall_v2"],
+            }
+        }
+
+        metadata = registration_metadata(
+            {
+                "inventory": {
+                    "agent_version": "0.2.12",
+                    "agent_commit": "BUILD123",
+                }
+            },
+            existing_metadata=existing,
+        )
+
+        self.assertEqual(
+            metadata["inventory"]["capabilities"],
+            ["detached_uninstall_v2"],
+        )
+
+    def test_registration_metadata_does_not_reuse_capabilities_across_builds(self):
+        existing = {
+            "inventory": {
+                "agent_version": "0.2.12",
+                "agent_commit": "old123",
+                "capabilities": ["detached_uninstall_v2"],
+            }
+        }
+
+        metadata = registration_metadata(
+            {
+                "inventory": {
+                    "agent_version": "0.2.12",
+                    "agent_commit": "new123",
+                }
+            },
+            existing_metadata=existing,
+        )
+
+        self.assertNotIn("capabilities", metadata["inventory"])
+
+    def test_registration_metadata_does_not_reuse_capabilities_without_commit(self):
+        existing = {
+            "inventory": {
+                "agent_version": "0.2.12",
+                "agent_commit": "build123",
+                "capabilities": ["detached_uninstall_v2"],
+            }
+        }
+
+        metadata = registration_metadata(
+            {"inventory": {"agent_version": "0.2.12"}},
+            existing_metadata=existing,
+        )
+
+        self.assertNotIn("capabilities", metadata["inventory"])
+
+    def test_registration_metadata_honors_explicit_empty_capabilities(self):
+        existing = {
+            "inventory": {
+                "agent_version": "0.2.12",
+                "agent_commit": "build123",
+                "capabilities": ["detached_uninstall_v2"],
+            }
+        }
+
+        metadata = registration_metadata(
+            {
+                "inventory": {
+                    "agent_version": "0.2.12",
+                    "agent_commit": "build123",
+                    "capabilities": [],
+                }
+            },
+            existing_metadata=existing,
+        )
+
+        self.assertEqual(metadata["inventory"]["capabilities"], [])
+
 
 @override_settings(FRONTEND_URL="https://console.example.com:11443")
 class LocalPlatformGatewayEnrollmentTests(TestCase):


### PR DESCRIPTION
## Summary

- preserve Agent capabilities when an older HTTP registration omits them for the same build
- serialize existing-node registration updates with WebSocket inventory writes
- prevent capabilities from being reused across different or incomplete builds
- add regression coverage for same-build, changed-build, missing-commit, and explicit-empty capability payloads

## Validation

- focused node registration tests: 53 passed
- installation session, network inventory, and client IP tests: 41 passed
- full node test suite: 434 passed
- Ruff check passed
- git diff --check passed

No database migration or Agent binary changes are included.