### PR TITLE
fix(frontend): restore backup wizard source normalization

### DIFF
--- a/src/frontend/src/composables/useBackupSourcePipeline.test.ts
+++ b/src/frontend/src/composables/useBackupSourcePipeline.test.ts
@@ -2,7 +2,11 @@
 
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { useBackupSourcePipeline } from './useBackupSourcePipeline'
-import { listBackupSelectableSources } from '../lib/sourceApi'
+import {
+  listBackupSelectableSources,
+  revertBackupSourcePipelineStep,
+  setBackupSourcePipelineStep,
+} from '../lib/sourceApi'
 
 vi.mock('../lib/sourceApi', () => ({
   listBackupSelectableSources: vi.fn(),
@@ -10,11 +14,15 @@ vi.mock('../lib/sourceApi', () => ({
   setBackupSourcePipelineStep: vi.fn(),
 }))
 
-vi.mock('./useDemoFlowStep2Sources', () => ({
-  clearLegacyStep2Sources: vi.fn(),
-  isBackupSelectableId: vi.fn(() => true),
-  readLegacyRealStep2Sources: vi.fn(() => []),
-}))
+vi.mock('./useDemoFlowStep2Sources', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./useDemoFlowStep2Sources')>()
+  return {
+    ...actual,
+    clearLegacyStep2Sources: vi.fn(),
+    isBackupSelectableId: vi.fn((id: string) => /^agent:\d+$/.test(id) || /^nas:\d+$/.test(id)),
+    readLegacyRealStep2Sources: vi.fn(() => []),
+  }
+})
 
 afterEach(() => {
   vi.clearAllMocks()
@@ -41,5 +49,25 @@ describe('useBackupSourcePipeline', () => {
     )
     expect(pipeline.pipelineStep2Count.value).toBe(4)
     expect(pipeline.pipelineStep3Count.value).toBe(7)
+  })
+
+  it('normalizes source ids before advancing the pipeline', async () => {
+    vi.mocked(setBackupSourcePipelineStep).mockResolvedValue({ updated: ['nas:37'], step: 2 })
+    vi.mocked(listBackupSelectableSources).mockResolvedValue({ count: 0, results: [] })
+
+    const pipeline = useBackupSourcePipeline()
+    await pipeline.setPipelineStep(['nas:37', 'nas:37', '', 'invalid'], 2)
+
+    expect(setBackupSourcePipelineStep).toHaveBeenCalledWith({ ids: ['nas:37'], step: 2 })
+  })
+
+  it('normalizes source ids before reverting the pipeline', async () => {
+    vi.mocked(revertBackupSourcePipelineStep).mockResolvedValue({ updated: ['agent:27'], target_step: 1 })
+    vi.mocked(listBackupSelectableSources).mockResolvedValue({ count: 0, results: [] })
+
+    const pipeline = useBackupSourcePipeline()
+    await pipeline.revertPipelineStep(['agent:27', 'agent:27', '', 'invalid'], 1)
+
+    expect(revertBackupSourcePipelineStep).toHaveBeenCalledWith({ ids: ['agent:27'], target_step: 1 })
   })
 })

--- a/src/frontend/src/composables/useBackupSourcePipeline.ts
+++ b/src/frontend/src/composables/useBackupSourcePipeline.ts
@@ -9,6 +9,7 @@ import { apiErrorMessage } from '../lib/api'
 import {
   clearLegacyStep2Sources,
   isBackupSelectableId,
+  normalizeSourceIdList,
   readLegacyRealStep2Sources,
 } from './useDemoFlowStep2Sources'
 

--- a/src/frontend/src/composables/useDemoFlowStep2Sources.ts
+++ b/src/frontend/src/composables/useDemoFlowStep2Sources.ts
@@ -1,6 +1,6 @@
 const LEGACY_STEP2_STORAGE_KEY = 'protection-flow-step2-sources'
 
-function normalizeSourceIdList(ids: string[]) {
+export function normalizeSourceIdList(ids: string[]) {
   const seen = new Set<string>()
   return ids.filter((id) => {
     if (!id || seen.has(id)) return false


### PR DESCRIPTION
## Summary

- Restore the source-ID normalization helper used by backup pipeline actions.
- Add behavior coverage for pipeline advance and revert requests.

## Root cause

A reliability refactor removed `normalizeSourceIdList` while leaving both
pipeline action call sites in place. The Backup Wizard therefore raised a
browser `ReferenceError` before sending the Step 1 transition request.

## Validation

- Manual testing: passed
- Frontend targeted Vitest: 4/4 passed
- Changed-file ESLint: passed
- Changed-file TypeScript check: passed
- Production build: passed
- English source check and `git diff --check`: passed

No backend API, database schema, or runtime data changes are included.

Fixes #930
