### PR TITLE
fix(agent): wait for launchd service unload

### DIFF
--- a/src/agent/internal/platform/install/install_sh_launchd_test.go
+++ b/src/agent/internal/platform/install/install_sh_launchd_test.go
@@ -1,0 +1,154 @@
+//go:build !windows
+
+package install
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestInstallShellWaitsForLaunchdUnload(t *testing.T) {
+	body := readPackagingInstallShell(t)
+	functions := shellFunction(t, body, "wait_for_launchd_unload") + "\n" +
+		shellFunction(t, body, "stop_launchd_service")
+
+	tests := []struct {
+		name       string
+		launchctl  string
+		wantStatus int
+		wantOutput string
+	}{
+		{
+			name: "delayed unload succeeds",
+			launchctl: `
+launchctl() {
+	case "$1" in
+	print)
+		PRINT_COUNT=$((PRINT_COUNT + 1))
+		[[ "${PRINT_COUNT}" -lt 4 ]]
+		;;
+	bootout) return 0 ;;
+	esac
+}`,
+			wantOutput: "OK:stopped launchd service com.hyperfilelens.agent",
+		},
+		{
+			name: "primary bootout falls back to plist",
+			launchctl: `
+launchctl() {
+	case "$1" in
+	print)
+		PRINT_COUNT=$((PRINT_COUNT + 1))
+		[[ "${PRINT_COUNT}" -eq 1 ]]
+		;;
+	bootout)
+		BOOTOUT_COUNT=$((BOOTOUT_COUNT + 1))
+		[[ "$#" -eq 3 ]]
+		;;
+	esac
+}`,
+			wantOutput: "BOOTOUT_COUNT=2",
+		},
+		{
+			name: "already unloaded is idempotent",
+			launchctl: `
+launchctl() {
+	case "$1" in
+	print) return 1 ;;
+	bootout) return 99 ;;
+	esac
+}`,
+			wantOutput: "SKIP:stop launchd com.hyperfilelens.agent (not loaded)",
+		},
+		{
+			name: "both bootout forms fail closed",
+			launchctl: `
+launchctl() {
+	case "$1" in
+	print) return 0 ;;
+	bootout)
+		BOOTOUT_COUNT=$((BOOTOUT_COUNT + 1))
+		return 1
+		;;
+	esac
+}`,
+			wantStatus: 2,
+			wantOutput: "could not be stopped; upgrade was aborted before deployment",
+		},
+		{
+			name: "unload timeout fails closed",
+			launchctl: `
+launchctl() {
+	case "$1" in
+	print) return 0 ;;
+	bootout) return 0 ;;
+	esac
+}`,
+			wantStatus: 2,
+			wantOutput: "did not unload within 1 seconds; upgrade was aborted before deployment",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			script := fmt.Sprintf(`
+set -euo pipefail
+LAUNCHD_DOMAIN=gui/501
+LAUNCHD_LABEL=com.hyperfilelens.agent
+LAUNCHD_PLIST=/tmp/com.hyperfilelens.agent.plist
+UPGRADE_TRANSACTION_ACTIVE=1
+HFL_LAUNCHD_UNLOAD_TIMEOUT_SECONDS=1
+PRINT_COUNT=0
+BOOTOUT_COUNT=0
+log_ok() { printf 'OK:%%s\n' "$1"; }
+log_skip() { printf 'SKIP:%%s\n' "$1"; }
+log_warn() { printf 'WARN:%%s\n' "$1"; }
+log_fail() { printf 'FAIL:%%s\n' "$1" >&2; exit "${2:-1}"; }
+sleep() { command sleep 0.01; }
+%s
+%s
+stop_launchd_service
+printf 'PRINT_COUNT=%%s\nBOOTOUT_COUNT=%%s\n' "${PRINT_COUNT}" "${BOOTOUT_COUNT}"
+`, functions, tt.launchctl)
+			cmd := exec.Command("bash", "-c", script)
+			output, err := cmd.CombinedOutput()
+			status := 0
+			if err != nil {
+				var ok bool
+				status, ok = shellExitStatus(err)
+				if !ok {
+					t.Fatalf("run launchd harness: %v\n%s", err, output)
+				}
+			}
+			if status != tt.wantStatus {
+				t.Fatalf("exit status = %d, want %d\n%s", status, tt.wantStatus, output)
+			}
+			if !strings.Contains(string(output), tt.wantOutput) {
+				t.Fatalf("output missing %q:\n%s", tt.wantOutput, output)
+			}
+		})
+	}
+}
+
+func shellFunction(t *testing.T, body, name string) string {
+	t.Helper()
+	start := strings.Index(body, name+"() {")
+	if start < 0 {
+		t.Fatalf("install.sh missing %s", name)
+	}
+	end := strings.Index(body[start:], "\n}\n")
+	if end < 0 {
+		t.Fatalf("install.sh function %s has no end", name)
+	}
+	return body[start : start+end+2]
+}
+
+func shellExitStatus(err error) (int, bool) {
+	exitError, ok := err.(*exec.ExitError)
+	if !ok {
+		return 0, false
+	}
+	return exitError.ExitCode(), true
+}

--- a/src/agent/packaging/install/install.sh
+++ b/src/agent/packaging/install/install.sh
@@ -562,7 +562,24 @@ launchd_service_status_line() {
 	fi
 }
 
+wait_for_launchd_unload() {
+	local timeout="${1:-10}"
+	local attempts=0 max_attempts=$((timeout * 10))
+	while launchctl print "${LAUNCHD_DOMAIN}/${LAUNCHD_LABEL}" >/dev/null 2>&1; do
+		attempts=$((attempts + 1))
+		if [[ "${attempts}" -ge "${max_attempts}" ]]; then
+			return 1
+		fi
+		sleep 0.1
+	done
+	return 0
+}
+
 stop_launchd_service() {
+	local unload_timeout="${HFL_LAUNCHD_UNLOAD_TIMEOUT_SECONDS:-10}"
+	[[ "${unload_timeout}" =~ ^[0-9]+$ \
+		&& "${unload_timeout}" -gt 0 \
+		&& "${unload_timeout}" -le 60 ]] || unload_timeout=10
 	if launchctl print "${LAUNCHD_DOMAIN}/${LAUNCHD_LABEL}" >/dev/null 2>&1; then
 		if ! launchctl bootout "${LAUNCHD_DOMAIN}/${LAUNCHD_LABEL}" 2>/dev/null \
 			&& ! launchctl bootout "${LAUNCHD_DOMAIN}" "${LAUNCHD_PLIST}" 2>/dev/null; then
@@ -571,11 +588,12 @@ stop_launchd_service() {
 			fi
 			log_warn "launchd service ${LAUNCHD_LABEL} could not be stopped"
 		fi
-		if launchctl print "${LAUNCHD_DOMAIN}/${LAUNCHD_LABEL}" >/dev/null 2>&1; then
+		if ! wait_for_launchd_unload "${unload_timeout}"; then
 			if [[ "${UPGRADE_TRANSACTION_ACTIVE}" -eq 1 ]]; then
-				log_fail "launchd service ${LAUNCHD_LABEL} is still loaded; upgrade was aborted before deployment." 2
+				log_fail "launchd service ${LAUNCHD_LABEL} did not unload within ${unload_timeout} seconds; upgrade was aborted before deployment." 2
 			fi
-			log_warn "launchd service ${LAUNCHD_LABEL} is still loaded"
+			log_warn "launchd service ${LAUNCHD_LABEL} did not unload within ${unload_timeout} seconds"
+			return 1
 		fi
 		log_ok "stopped launchd service ${LAUNCHD_LABEL}"
 	else


### PR DESCRIPTION
## Problem and root cause

macOS `launchctl bootout` removes the Agent service asynchronously. The
installer immediately queried `launchctl print`, occasionally observing the
service during teardown and aborting upgrades with `still loaded`.

## Solution

Poll for the launchd job to disappear after a successful bootout, preserving
the label-first command and plist fallback. The wait is bounded to 10 seconds
by default (configurable up to 60 seconds); timeout remains fail-closed before
deployment and keeps rollback behavior intact. Behavioral regression tests cover
delayed unload, fallback, idempotence, bootout failure, and timeout.

## Validation

- `bash -n src/agent/packaging/install/install.sh`
- `go test ./internal/platform/install -count=1`
- `git diff --check`
- `python3 tools/quality/check-english-source.py`
- `./tools/quality/check-release-contracts.sh`
- Linux full Agent suite is baseline-equivalent; four environment-dependent
  tests fail identically on clean `origin/main`.
- Manual testing: passed on `mini.local · ghw`.
- Optional Community backend suite: skipped by explicit user request.

## Risks and compatibility

Only macOS launchd lifecycle handling changes. Linux systemd, Windows, APIs,
schemas, and data behavior are unchanged. The bounded wait may add brief delay
to lifecycle operations while preventing false upgrade failures.

Fixes #932
