### PR TITLE
Improve gateway image download resilience

### DIFF
--- a/src/agent/internal/enroll/download_progress.go
+++ b/src/agent/internal/enroll/download_progress.go
@@ -154,6 +154,42 @@ func downloadWithProgress(
 	return nil
 }
 
+func downloadResumableWithProgress(
+	ctx context.Context,
+	rawURL string,
+	destPath string,
+	label string,
+) error {
+	display := newDownloadProgressDisplay(label)
+	err := platforminstall.DownloadURLResumableWithProgress(
+		ctx,
+		rawURL,
+		destPath,
+		display.report,
+		func(attempt, maxAttempts int, delay time.Duration, retryErr error, resumeBytes int64) {
+			display.abort()
+			logWarn(fmt.Sprintf("%s download interrupted: %v", label, retryErr))
+			if resumeBytes > 0 {
+				logInfo(fmt.Sprintf(
+					"Retrying in %s (attempt %d/%d); resuming from %s",
+					formatElapsed(delay), attempt+1, maxAttempts, formatByteCount(resumeBytes),
+				))
+				return
+			}
+			logInfo(fmt.Sprintf(
+				"Retrying in %s (attempt %d/%d); restarting from byte zero",
+				formatElapsed(delay), attempt+1, maxAttempts,
+			))
+		},
+	)
+	if err != nil {
+		display.abort()
+		return err
+	}
+	display.success()
+	return nil
+}
+
 func formatDownloadProgress(progress platforminstall.DownloadProgress) string {
 	downloaded := formatByteCount(progress.DownloadedBytes)
 	elapsed := formatElapsed(progress.Elapsed)

--- a/src/agent/internal/enroll/sidecar_install_unix.go
+++ b/src/agent/internal/enroll/sidecar_install_unix.go
@@ -536,7 +536,7 @@ func ensureLensnodeImage(ctx context.Context, cfg Config) error {
 	url := strings.TrimRight(cfg.APIBase, "/") + "/media/gateway-bootstrap/" + lensnodeImageArchive
 	archivePath := filepath.Join(workDir, lensnodeImageArchive)
 	logStep("Downloading AI engine container image bundle.")
-	if err := downloadWithProgress(ctx, url, archivePath, "AI engine image bundle"); err != nil {
+	if err := downloadResumableWithProgress(ctx, url, archivePath, "AI engine image bundle"); err != nil {
 		return fmt.Errorf("download AI engine image bundle: %w", err)
 	}
 

--- a/src/agent/internal/platform/install/download.go
+++ b/src/agent/internal/platform/install/download.go
@@ -5,11 +5,14 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math/rand/v2"
 	"net"
 	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"sync/atomic"
 	"time"
 )
@@ -26,12 +29,17 @@ var (
 	// ErrDownloadSizeMismatch identifies a truncated response with a declared
 	// Content-Length. A fresh URL may make a later transfer succeed.
 	ErrDownloadSizeMismatch = errors.New("download size mismatch")
+	// ErrDownloadRangeRejected identifies a resume response that cannot safely
+	// be appended to the existing partial file.
+	ErrDownloadRangeRejected = errors.New("download range rejected")
 )
 
 // DownloadHTTPError retains the response status without retaining a signed URL.
 type DownloadHTTPError struct {
-	StatusCode int
-	Status     string
+	StatusCode    int
+	Status        string
+	retryAfter    time.Duration
+	hasRetryAfter bool
 }
 
 func (err *DownloadHTTPError) Error() string {
@@ -97,11 +105,222 @@ func downloadURLWithSettings(
 	interval time.Duration,
 	idleTimeout time.Duration,
 ) error {
+	return downloadURLAttempt(ctx, rawURL, destPath, reporter, interval, idleTimeout, false, nil)
+}
+
+// DownloadRetryNotice describes one retry of a resumable download.
+type DownloadRetryNotice func(attempt, maxAttempts int, delay time.Duration, err error, resumeBytes int64)
+
+type downloadResumeValidator struct {
+	etag         string
+	lastModified string
+	totalBytes   int64
+	started      time.Time
+}
+
+// DownloadURLResumableWithProgress retries transient failures while preserving
+// a partial file in the current process and resuming it when the server agrees.
+// The destination is still promoted atomically only after a complete response.
+func DownloadURLResumableWithProgress(
+	ctx context.Context,
+	rawURL string,
+	destPath string,
+	reporter ProgressReporter,
+	retryNotice DownloadRetryNotice,
+) error {
+	return downloadURLResumableWithSettings(
+		ctx,
+		rawURL,
+		destPath,
+		reporter,
+		retryNotice,
+		defaultDownloadProgressInterval,
+		defaultDownloadIdleTimeout,
+	)
+}
+
+func downloadURLResumableWithSettings(
+	ctx context.Context,
+	rawURL string,
+	destPath string,
+	reporter ProgressReporter,
+	retryNotice DownloadRetryNotice,
+	interval time.Duration,
+	idleTimeout time.Duration,
+) error {
+	return downloadURLResumableWithPolicy(
+		ctx,
+		rawURL,
+		destPath,
+		reporter,
+		retryNotice,
+		interval,
+		idleTimeout,
+		[]time.Duration{5 * time.Second, 15 * time.Second, 30 * time.Second},
+	)
+}
+
+func downloadURLResumableWithPolicy(
+	ctx context.Context,
+	rawURL string,
+	destPath string,
+	reporter ProgressReporter,
+	retryNotice DownloadRetryNotice,
+	interval time.Duration,
+	idleTimeout time.Duration,
+	delays []time.Duration,
+) error {
+	const maxAttempts = 4
+	partPath := destPath + ".part"
+	if err := removePartialDownload(partPath); err != nil {
+		return fmt.Errorf("remove stale partial download: %w", err)
+	}
+	validator := &downloadResumeValidator{totalBytes: -1, started: time.Now()}
+	var lastErr error
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		if err := ctx.Err(); err != nil {
+			return cleanupPartialDownload(partPath, err)
+		}
+		err := downloadURLAttempt(ctx, rawURL, destPath, reporter, interval, idleTimeout, true, validator)
+		if err == nil {
+			return nil
+		}
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return cleanupPartialDownload(partPath, ctxErr)
+		}
+		lastErr = err
+		if !isResumableDownloadError(err) || attempt == maxAttempts {
+			result := err
+			if attempt == maxAttempts && isResumableDownloadError(err) {
+				result = fmt.Errorf("download failed after %d attempts: %w", maxAttempts, err)
+			}
+			return cleanupPartialDownload(partPath, result)
+		}
+		var httpErr *DownloadHTTPError
+		if errors.Is(err, ErrDownloadRangeRejected) ||
+			(errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusRequestedRangeNotSatisfiable) {
+			if cleanupErr := removePartialDownload(partPath); cleanupErr != nil {
+				return errors.Join(err, fmt.Errorf("reset partial download: %w", cleanupErr))
+			}
+		}
+		resumeBytes := partialDownloadSize(destPath)
+		delay := 0 * time.Second
+		if attempt-1 < len(delays) {
+			delay = jitteredRetryDelay(delays[attempt-1])
+		}
+		if httpRetryDelay := downloadRetryAfter(err); httpRetryDelay > 0 {
+			delay = httpRetryDelay
+		}
+		if retryNotice != nil {
+			retryNotice(attempt, maxAttempts, delay, err, resumeBytes)
+		}
+		if err := waitWithContext(ctx, delay); err != nil {
+			return cleanupPartialDownload(partPath, err)
+		}
+	}
+	return lastErr
+}
+
+func removePartialDownload(partPath string) error {
+	err := os.Remove(partPath)
+	if err == nil || errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	return err
+}
+
+func cleanupPartialDownload(partPath string, result error) error {
+	if cleanupErr := removePartialDownload(partPath); cleanupErr != nil {
+		return errors.Join(result, fmt.Errorf("remove partial download: %w", cleanupErr))
+	}
+	return result
+}
+
+func jitteredRetryDelay(delay time.Duration) time.Duration {
+	if delay <= 0 {
+		return 0
+	}
+	limit := delay / 5
+	if limit <= 0 {
+		return delay
+	}
+	return delay - limit + time.Duration(rand.Int64N(int64(2*limit)+1))
+}
+
+func downloadRetryAfter(err error) time.Duration {
+	var httpErr *DownloadHTTPError
+	if !errors.As(err, &httpErr) ||
+		(httpErr.StatusCode != http.StatusTooManyRequests && httpErr.StatusCode != http.StatusServiceUnavailable) ||
+		!httpErr.hasRetryAfter {
+		return 0
+	}
+	return min(max(httpErr.retryAfter, 5*time.Second), 120*time.Second)
+}
+
+func isResumableDownloadError(err error) bool {
+	if IsRetryableDownloadError(err) || errors.Is(err, ErrDownloadRangeRejected) {
+		return true
+	}
+	var httpErr *DownloadHTTPError
+	if !errors.As(err, &httpErr) {
+		return false
+	}
+	return httpErr.StatusCode == http.StatusRequestedRangeNotSatisfiable ||
+		(httpErr.StatusCode >= 500 && httpErr.StatusCode < 600)
+}
+
+func waitWithContext(ctx context.Context, delay time.Duration) error {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func partialDownloadSize(destPath string) int64 {
+	info, err := os.Stat(destPath + ".part")
+	if err != nil || !info.Mode().IsRegular() {
+		return 0
+	}
+	return info.Size()
+}
+
+func downloadURLAttempt(
+	ctx context.Context,
+	rawURL string,
+	destPath string,
+	reporter ProgressReporter,
+	interval time.Duration,
+	idleTimeout time.Duration,
+	resume bool,
+	validator *downloadResumeValidator,
+) error {
 	downloadCtx, cancel := context.WithCancelCause(ctx)
 	defer cancel(nil)
 	req, err := http.NewRequestWithContext(downloadCtx, http.MethodGet, rawURL, nil)
 	if err != nil {
 		return fmt.Errorf("create download request: %w", sanitizeDownloadError(err))
+	}
+	partPath := destPath + ".part"
+	resumeBytes := int64(0)
+	if resume {
+		resumeBytes = partialDownloadSize(destPath)
+		if resumeBytes > 0 {
+			req.Header.Set("Range", "bytes="+strconv.FormatInt(resumeBytes, 10)+"-")
+			if validator != nil {
+				if validator.etag != "" {
+					req.Header.Set("If-Range", validator.etag)
+				} else if validator.lastModified != "" {
+					req.Header.Set("If-Range", validator.lastModified)
+				}
+			}
+		}
+	}
+	if resume {
+		req.Header.Set("Accept-Encoding", "identity")
 	}
 	client := downloadHTTPClient()
 	resp, err := client.Do(req)
@@ -110,38 +329,113 @@ func downloadURLWithSettings(
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return &DownloadHTTPError{StatusCode: resp.StatusCode, Status: resp.Status}
+		retryAfter, hasRetryAfter := parseRetryAfter(resp.Header.Get("Retry-After"), time.Now())
+		return &DownloadHTTPError{
+			StatusCode:    resp.StatusCode,
+			Status:        resp.Status,
+			retryAfter:    retryAfter,
+			hasRetryAfter: hasRetryAfter,
+		}
+	}
+	if resume {
+		if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusPartialContent {
+			return ErrDownloadRangeRejected
+		}
+		if resumeBytes == 0 && resp.StatusCode != http.StatusOK {
+			return ErrDownloadRangeRejected
+		}
+	}
+	if validator != nil {
+		if resumeBytes == 0 || resp.StatusCode == http.StatusOK {
+			validator.etag = resp.Header.Get("ETag")
+			validator.lastModified = resp.Header.Get("Last-Modified")
+			validator.totalBytes = resp.ContentLength
+		} else if resp.StatusCode == http.StatusPartialContent &&
+			validator.etag != "" && resp.Header.Get("ETag") != "" &&
+			resp.Header.Get("ETag") != validator.etag {
+			return ErrDownloadRangeRejected
+		} else if resp.StatusCode == http.StatusPartialContent &&
+			validator.etag == "" && validator.lastModified != "" &&
+			resp.Header.Get("Last-Modified") != "" &&
+			resp.Header.Get("Last-Modified") != validator.lastModified {
+			return ErrDownloadRangeRejected
+		}
 	}
 	if err := os.MkdirAll(filepath.Dir(destPath), 0o755); err != nil {
 		return err
 	}
 
-	partPath := destPath + ".part"
-	if err := os.Remove(partPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+	appendMode := resumeBytes > 0 && resp.StatusCode == http.StatusPartialContent
+	var rangeEnd, rangeTotal int64
+	if appendMode {
+		start, end, total, ok := parseContentRange(resp.Header.Get("Content-Range"))
+		if !ok || start != resumeBytes || total < 0 {
+			return ErrDownloadRangeRejected
+		}
+		if validator != nil {
+			if validator.totalBytes >= 0 && validator.totalBytes != total {
+				return ErrDownloadRangeRejected
+			}
+			validator.totalBytes = total
+		}
+		rangeEnd = end
+		rangeTotal = total
+		if resp.ContentLength >= 0 && resp.ContentLength != end-start+1 {
+			return ErrDownloadRangeRejected
+		}
+	} else if err := os.Remove(partPath); err != nil && !errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("remove stale partial download: %w", err)
 	}
-	file, err := os.OpenFile(partPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	progressBase := int64(0)
+	if appendMode {
+		progressBase = resumeBytes
+	}
+	flags := os.O_WRONLY
+	if appendMode {
+		flags |= os.O_APPEND
+	} else {
+		flags |= os.O_CREATE | os.O_EXCL
+	}
+	file, err := os.OpenFile(partPath, flags, 0o600)
 	if err != nil {
 		return err
+	}
+	if appendMode {
+		info, statErr := file.Stat()
+		if statErr != nil {
+			_ = file.Close()
+			return statErr
+		}
+		if !info.Mode().IsRegular() || info.Size() != resumeBytes {
+			_ = file.Close()
+			return ErrDownloadRangeRejected
+		}
 	}
 	completed := false
 	defer func() {
 		_ = file.Close()
-		if !completed {
+		if !completed && !resume {
 			_ = os.Remove(partPath)
 		}
 	}()
 
 	started := time.Now()
+	progressStarted := started
+	if validator != nil && !validator.started.IsZero() {
+		progressStarted = validator.started
+	}
 	var downloaded atomic.Int64
+	downloaded.Store(progressBase)
 	var lastByteAt atomic.Int64
 	lastByteAt.Store(started.UnixNano())
 	stopProgress := startDownloadProgress(
 		reporter,
 		&downloaded,
 		&lastByteAt,
-		resp.ContentLength,
+		totalDownloadLength(resp, progressBase, appendMode),
+		progressStarted,
 		started,
+		progressBase,
 		interval,
 	)
 	stopIdleWatchdog := startDownloadIdleWatchdog(
@@ -173,6 +467,28 @@ func downloadURLWithSettings(
 			resp.ContentLength,
 		)
 	}
+	if appendMode {
+		expected := rangeEnd - resumeBytes + 1
+		if written != expected {
+			if written > expected {
+				return ErrDownloadRangeRejected
+			}
+			return fmt.Errorf(
+				"%w: received %d bytes, expected %d",
+				ErrDownloadSizeMismatch,
+				written,
+				expected,
+			)
+		}
+		if actual := resumeBytes + written; actual != rangeTotal {
+			return fmt.Errorf(
+				"%w: received %d bytes, expected %d",
+				ErrDownloadSizeMismatch,
+				actual,
+				rangeTotal,
+			)
+		}
+	}
 	if err := file.Close(); err != nil {
 		return err
 	}
@@ -182,6 +498,73 @@ func downloadURLWithSettings(
 	completed = true
 	stopProgress(true)
 	return nil
+}
+
+func parseRetryAfter(value string, now time.Time) (time.Duration, bool) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return 0, false
+	}
+	if seconds, err := strconv.ParseInt(value, 10, 64); err == nil {
+		if seconds < 0 {
+			return 0, false
+		}
+		const maxDuration = time.Duration(1<<63 - 1)
+		if seconds > int64(maxDuration/time.Second) {
+			return maxDuration, true
+		}
+		return time.Duration(seconds) * time.Second, true
+	}
+	when, err := http.ParseTime(value)
+	if err != nil {
+		return 0, false
+	}
+	if !when.After(now) {
+		return 0, true
+	}
+	return when.Sub(now), true
+}
+
+func totalDownloadLength(resp *http.Response, resumeBytes int64, appendMode bool) int64 {
+	if !appendMode {
+		return resp.ContentLength
+	}
+	_, _, total, ok := parseContentRange(resp.Header.Get("Content-Range"))
+	if ok && total >= 0 {
+		return total
+	}
+	if resp.ContentLength >= 0 {
+		return resumeBytes + resp.ContentLength
+	}
+	return -1
+}
+
+func parseContentRange(value string) (start, end, total int64, ok bool) {
+	parts := strings.Fields(strings.TrimSpace(value))
+	if len(parts) != 2 || parts[0] != "bytes" {
+		return 0, 0, 0, false
+	}
+	rangeAndTotal := strings.SplitN(parts[1], "/", 2)
+	if len(rangeAndTotal) != 2 {
+		return 0, 0, 0, false
+	}
+	bounds := strings.SplitN(rangeAndTotal[0], "-", 2)
+	if len(bounds) != 2 {
+		return 0, 0, 0, false
+	}
+	start, err1 := strconv.ParseInt(bounds[0], 10, 64)
+	end, err2 := strconv.ParseInt(bounds[1], 10, 64)
+	if err1 != nil || err2 != nil || start < 0 || end < start {
+		return 0, 0, 0, false
+	}
+	if rangeAndTotal[1] == "*" {
+		return start, end, -1, true
+	}
+	total, err := strconv.ParseInt(rangeAndTotal[1], 10, 64)
+	if err != nil || total <= end {
+		return 0, 0, 0, false
+	}
+	return start, end, total, true
 }
 
 type byteCounter struct {
@@ -245,7 +628,9 @@ func startDownloadProgress(
 	downloaded *atomic.Int64,
 	lastByteAt *atomic.Int64,
 	total int64,
-	started time.Time,
+	progressStarted time.Time,
+	attemptStarted time.Time,
+	initialBytes int64,
 	interval time.Duration,
 ) func(completed bool) {
 	if reporter == nil {
@@ -260,8 +645,8 @@ func startDownloadProgress(
 		defer close(stopped)
 		ticker := time.NewTicker(interval)
 		defer ticker.Stop()
-		lastBytes := int64(0)
-		lastAt := started
+		lastBytes := initialBytes
+		lastAt := attemptStarted
 		for {
 			select {
 			case now := <-ticker.C:
@@ -278,7 +663,7 @@ func startDownloadProgress(
 				reporter(DownloadProgress{
 					DownloadedBytes: current,
 					TotalBytes:      total,
-					Elapsed:         now.Sub(started),
+					Elapsed:         now.Sub(progressStarted),
 					Idle:            idle,
 					BytesPerSecond:  rate,
 				})
@@ -298,7 +683,7 @@ func startDownloadProgress(
 		if !completed {
 			return
 		}
-		elapsed := time.Since(started)
+		elapsed := time.Since(progressStarted)
 		current := downloaded.Load()
 		rate := float64(0)
 		if elapsed > 0 {
@@ -320,7 +705,9 @@ func IsRetryableDownloadError(err error) bool {
 	if err == nil || errors.Is(err, context.Canceled) {
 		return false
 	}
-	if errors.Is(err, ErrDownloadNoProgress) || errors.Is(err, ErrDownloadSizeMismatch) || errors.Is(err, io.ErrUnexpectedEOF) {
+	if errors.Is(err, ErrDownloadNoProgress) ||
+		errors.Is(err, ErrDownloadSizeMismatch) ||
+		errors.Is(err, io.ErrUnexpectedEOF) {
 		return true
 	}
 	var httpErr *DownloadHTTPError

--- a/src/agent/internal/platform/install/download_test.go
+++ b/src/agent/internal/platform/install/download_test.go
@@ -10,8 +10,10 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -124,6 +126,26 @@ func TestDownloadURLWithProgressUnknownLength(t *testing.T) {
 	}
 	if !final.Completed || final.TotalBytes != -1 || final.DownloadedBytes == 0 {
 		t.Fatalf("unexpected final progress: %#v", final)
+	}
+}
+
+func TestDownloadURLPreservesExistingSuccessful2xxBehavior(t *testing.T) {
+	t.Setenv("HFL_INSECURE_TLS", "0")
+	payload := []byte("created download")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Length", strconv.Itoa(len(payload)))
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write(payload)
+	}))
+	defer server.Close()
+
+	destination := filepath.Join(t.TempDir(), "artifact")
+	if err := DownloadURL(context.Background(), server.URL, destination); err != nil {
+		t.Fatalf("ordinary 2xx download failed: %v", err)
+	}
+	got, err := os.ReadFile(destination)
+	if err != nil || !bytes.Equal(got, payload) {
+		t.Fatalf("downloaded content = %q, err = %v", got, err)
 	}
 }
 
@@ -244,6 +266,8 @@ func TestRetryableDownloadErrors(t *testing.T) {
 		{name: "truncated", err: ErrDownloadSizeMismatch, want: true},
 		{name: "rate limited", err: &DownloadHTTPError{StatusCode: 429, Status: "429 Too Many Requests"}, want: true},
 		{name: "server unavailable", err: &DownloadHTTPError{StatusCode: 503, Status: "503 Service Unavailable"}, want: true},
+		{name: "range rejected stays local to resumable downloads", err: ErrDownloadRangeRejected, want: false},
+		{name: "range unsatisfied stays local to resumable downloads", err: &DownloadHTTPError{StatusCode: 416, Status: "416 Range Not Satisfiable"}, want: false},
 		{name: "not implemented", err: &DownloadHTTPError{StatusCode: 501, Status: "501 Not Implemented"}, want: false},
 		{name: "permanent network error", err: permanentNetworkError{}, want: false},
 		{name: "temporary network error", err: temporaryNetworkError{}, want: true},
@@ -258,6 +282,21 @@ func TestRetryableDownloadErrors(t *testing.T) {
 				t.Fatalf("IsRetryableDownloadError(%v) = %t, want %t", test.err, got, test.want)
 			}
 		})
+	}
+}
+
+func TestResumableDownloadErrorClassificationStaysLocal(t *testing.T) {
+	for _, err := range []error{
+		ErrDownloadRangeRejected,
+		&DownloadHTTPError{StatusCode: http.StatusRequestedRangeNotSatisfiable, Status: "416 Range Not Satisfiable"},
+		&DownloadHTTPError{StatusCode: http.StatusNotImplemented, Status: "501 Not Implemented"},
+	} {
+		if !isResumableDownloadError(err) {
+			t.Fatalf("resumable download error %v was not retryable", err)
+		}
+		if IsRetryableDownloadError(err) {
+			t.Fatalf("resumable-only error %v changed ordinary download classification", err)
+		}
 	}
 }
 
@@ -322,6 +361,651 @@ func TestDownloadURLPreservesDestinationAndRemovesPartialOnFailure(t *testing.T)
 	}
 	if _, statErr := os.Stat(destination + ".part"); !os.IsNotExist(statErr) {
 		t.Fatalf("partial file was not removed: %v", statErr)
+	}
+}
+
+func TestResumableDownloadContinuesAfterUnexpectedEOF(t *testing.T) {
+	t.Setenv("HFL_INSECURE_TLS", "0")
+	payload := bytes.Repeat([]byte("resumable-download-"), 32)
+	cut := len(payload) / 2
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		switch requests.Add(1) {
+		case 1:
+			w.Header().Set("Content-Length", strconv.Itoa(len(payload)))
+			_, _ = w.Write(payload[:cut])
+		case 2:
+			if got := request.Header.Get("Range"); got != "bytes="+strconv.Itoa(cut)+"-" {
+				t.Errorf("resume Range = %q, want bytes=%d-", got, cut)
+			}
+			w.Header().Set("Content-Length", strconv.Itoa(len(payload)-cut))
+			w.Header().Set("Content-Range", "bytes "+strconv.Itoa(cut)+"-"+strconv.Itoa(len(payload)-1)+"/"+strconv.Itoa(len(payload)))
+			w.WriteHeader(http.StatusPartialContent)
+			_, _ = w.Write(payload[cut:])
+		default:
+			t.Errorf("unexpected request %d", requests.Load())
+		}
+	}))
+	defer server.Close()
+
+	destination := filepath.Join(t.TempDir(), "artifact")
+	err := downloadURLResumableWithPolicy(
+		context.Background(), server.URL, destination, nil, nil,
+		time.Millisecond, time.Second, []time.Duration{0, 0, 0},
+	)
+	if err != nil {
+		t.Fatalf("resumable download failed: %v", err)
+	}
+	got, err := os.ReadFile(destination)
+	if err != nil {
+		t.Fatalf("read destination: %v", err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatal("resumed content does not match payload")
+	}
+	if _, err := os.Stat(destination + ".part"); !os.IsNotExist(err) {
+		t.Fatalf("partial file was not removed: %v", err)
+	}
+}
+
+func TestDownloadURLResumableWithProgressPublicEntryPoint(t *testing.T) {
+	t.Setenv("HFL_INSECURE_TLS", "0")
+	payload := []byte("public-resumable-entry-point")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Length", strconv.Itoa(len(payload)))
+		_, _ = w.Write(payload)
+	}))
+	defer server.Close()
+
+	destination := filepath.Join(t.TempDir(), "artifact")
+	var final DownloadProgress
+	retryNotices := 0
+	err := DownloadURLResumableWithProgress(
+		context.Background(), server.URL, destination,
+		func(progress DownloadProgress) {
+			if progress.Completed {
+				final = progress
+			}
+		},
+		func(_, _ int, _ time.Duration, _ error, _ int64) { retryNotices++ },
+	)
+	if err != nil {
+		t.Fatalf("public resumable download failed: %v", err)
+	}
+	got, readErr := os.ReadFile(destination)
+	if readErr != nil || !bytes.Equal(got, payload) {
+		t.Fatalf("downloaded content = %q, err = %v", got, readErr)
+	}
+	if !final.Completed || final.DownloadedBytes != int64(len(payload)) || retryNotices != 0 {
+		t.Fatalf("final progress = %#v, retry notices = %d", final, retryNotices)
+	}
+}
+
+func TestResumableDownloadDiscardsPartialFromPreviousProcess(t *testing.T) {
+	t.Setenv("HFL_INSECURE_TLS", "0")
+	payload := []byte("complete-current-download")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		if got := request.Header.Get("Range"); got != "" {
+			t.Errorf("initial request reused stale partial file with Range %q", got)
+		}
+		w.Header().Set("Content-Length", strconv.Itoa(len(payload)))
+		_, _ = w.Write(payload)
+	}))
+	defer server.Close()
+
+	destination := filepath.Join(t.TempDir(), "artifact")
+	if err := os.WriteFile(destination+".part", []byte("stale-partial"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	err := downloadURLResumableWithPolicy(
+		context.Background(), server.URL, destination, nil, nil,
+		time.Millisecond, time.Second, []time.Duration{0, 0, 0},
+	)
+	if err != nil {
+		t.Fatalf("download failed: %v", err)
+	}
+	got, readErr := os.ReadFile(destination)
+	if readErr != nil || !bytes.Equal(got, payload) {
+		t.Fatalf("downloaded content = %q, err = %v", got, readErr)
+	}
+}
+
+func TestResumableDownloadRestartsWhenServerIgnoresRange(t *testing.T) {
+	t.Setenv("HFL_INSECURE_TLS", "0")
+	payload := []byte("complete response after restart")
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		if requests.Add(1) == 1 {
+			w.Header().Set("Content-Length", strconv.Itoa(len(payload)))
+			_, _ = w.Write(payload[:8])
+			return
+		}
+		if request.Header.Get("Range") == "" {
+			t.Error("retry did not attempt to resume the partial file")
+		}
+		w.Header().Set("Content-Length", strconv.Itoa(len(payload)))
+		_, _ = w.Write(payload)
+	}))
+	defer server.Close()
+
+	destination := filepath.Join(t.TempDir(), "artifact")
+	var final DownloadProgress
+	err := downloadURLResumableWithPolicy(
+		context.Background(), server.URL, destination, func(progress DownloadProgress) {
+			if progress.Completed {
+				final = progress
+			}
+		}, nil,
+		time.Millisecond, time.Second, []time.Duration{0, 0, 0},
+	)
+	if err != nil {
+		t.Fatalf("restart download failed: %v", err)
+	}
+	got, err := os.ReadFile(destination)
+	if err != nil || !bytes.Equal(got, payload) {
+		t.Fatalf("downloaded content = %q, err = %v", got, err)
+	}
+	if final.DownloadedBytes != int64(len(payload)) || final.TotalBytes != int64(len(payload)) {
+		t.Fatalf("restart progress retained partial bytes: %#v", final)
+	}
+}
+
+func TestResumableDownloadRejectsUnexpectedSuccessfulStatus(t *testing.T) {
+	t.Setenv("HFL_INSECURE_TLS", "0")
+	payload := []byte("restart-after-unexpected-status")
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		switch requests.Add(1) {
+		case 1:
+			w.Header().Set("Content-Length", strconv.Itoa(len(payload)))
+			_, _ = w.Write(payload[:8])
+		case 2:
+			if request.Header.Get("Range") == "" {
+				t.Error("second request did not attempt to resume")
+			}
+			w.WriteHeader(http.StatusNoContent)
+		case 3:
+			if request.Header.Get("Range") != "" {
+				t.Error("unexpected 2xx response did not reset the partial download")
+			}
+			w.Header().Set("Content-Length", strconv.Itoa(len(payload)))
+			_, _ = w.Write(payload)
+		default:
+			t.Errorf("unexpected request %d", requests.Load())
+		}
+	}))
+	defer server.Close()
+
+	destination := filepath.Join(t.TempDir(), "artifact")
+	err := downloadURLResumableWithPolicy(
+		context.Background(), server.URL, destination, nil, nil,
+		time.Millisecond, time.Second, []time.Duration{0, 0, 0},
+	)
+	if err != nil {
+		t.Fatalf("download after unexpected 2xx failed: %v", err)
+	}
+	got, _ := os.ReadFile(destination)
+	if !bytes.Equal(got, payload) {
+		t.Fatalf("downloaded content = %q", got)
+	}
+}
+
+func TestResumableDownloadRejectsMismatchedContentRange(t *testing.T) {
+	t.Setenv("HFL_INSECURE_TLS", "0")
+	payload := []byte("content-range-must-match")
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		switch requests.Add(1) {
+		case 1:
+			w.Header().Set("Content-Length", strconv.Itoa(len(payload)))
+			_, _ = w.Write(payload[:8])
+		case 2:
+			w.Header().Set("Content-Range", "bytes 9-"+strconv.Itoa(len(payload)-1)+"/"+strconv.Itoa(len(payload)))
+			w.WriteHeader(http.StatusPartialContent)
+			_, _ = w.Write(payload[9:])
+		case 3:
+			if request.Header.Get("Range") != "" {
+				t.Error("mismatched range did not clear the partial download")
+			}
+			w.Header().Set("Content-Length", strconv.Itoa(len(payload)))
+			_, _ = w.Write(payload)
+		default:
+			t.Errorf("unexpected request %d", requests.Load())
+		}
+	}))
+	defer server.Close()
+
+	destination := filepath.Join(t.TempDir(), "artifact")
+	err := downloadURLResumableWithPolicy(
+		context.Background(), server.URL, destination, nil, nil,
+		time.Millisecond, time.Second, []time.Duration{0, 0, 0},
+	)
+	if err != nil {
+		t.Fatalf("download after mismatched range failed: %v", err)
+	}
+	got, _ := os.ReadFile(destination)
+	if !bytes.Equal(got, payload) {
+		t.Fatalf("downloaded content = %q", got)
+	}
+}
+
+func TestResumableDownloadRejectsContentRangeLengthMismatch(t *testing.T) {
+	t.Setenv("HFL_INSECURE_TLS", "0")
+	payload := []byte("range-length-must-match")
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		switch requests.Add(1) {
+		case 1:
+			w.Header().Set("Content-Length", strconv.Itoa(len(payload)))
+			_, _ = w.Write(payload[:6])
+		case 2:
+			// The declared range has one fewer byte than Content-Length. It
+			// must not be appended to the existing partial file.
+			w.Header().Set("Content-Length", strconv.Itoa(len(payload)-6))
+			w.Header().Set("Content-Range", "bytes 6-"+strconv.Itoa(len(payload)-2)+"/"+strconv.Itoa(len(payload)))
+			w.WriteHeader(http.StatusPartialContent)
+			_, _ = w.Write(payload[6:])
+		case 3:
+			if request.Header.Get("Range") != "" {
+				t.Error("invalid range response did not clear the partial download")
+			}
+			w.Header().Set("Content-Length", strconv.Itoa(len(payload)))
+			_, _ = w.Write(payload)
+		default:
+			t.Errorf("unexpected request %d", requests.Load())
+		}
+	}))
+	defer server.Close()
+
+	destination := filepath.Join(t.TempDir(), "artifact")
+	err := downloadURLResumableWithPolicy(
+		context.Background(), server.URL, destination, nil, nil,
+		time.Millisecond, time.Second, []time.Duration{0, 0, 0},
+	)
+	if err != nil {
+		t.Fatalf("download after invalid range response failed: %v", err)
+	}
+	got, _ := os.ReadFile(destination)
+	if !bytes.Equal(got, payload) {
+		t.Fatalf("downloaded content = %q", got)
+	}
+}
+
+func TestResumableDownloadRejectsUnknownContentRangeTotal(t *testing.T) {
+	t.Setenv("HFL_INSECURE_TLS", "0")
+	payload := []byte("range-total-must-be-known")
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		switch requests.Add(1) {
+		case 1:
+			w.Header().Set("Content-Length", strconv.Itoa(len(payload)))
+			_, _ = w.Write(payload[:6])
+		case 2:
+			w.Header().Set("Content-Length", "6")
+			w.Header().Set("Content-Range", "bytes 6-11/*")
+			w.WriteHeader(http.StatusPartialContent)
+			_, _ = w.Write(payload[6:12])
+		case 3:
+			if request.Header.Get("Range") != "" {
+				t.Error("unknown range total did not clear the partial download")
+			}
+			w.Header().Set("Content-Length", strconv.Itoa(len(payload)))
+			_, _ = w.Write(payload)
+		default:
+			t.Errorf("unexpected request %d", requests.Load())
+		}
+	}))
+	defer server.Close()
+
+	destination := filepath.Join(t.TempDir(), "artifact")
+	err := downloadURLResumableWithPolicy(
+		context.Background(), server.URL, destination, nil, nil,
+		time.Millisecond, time.Second, []time.Duration{0, 0, 0},
+	)
+	if err != nil {
+		t.Fatalf("download after unknown range total failed: %v", err)
+	}
+	got, _ := os.ReadFile(destination)
+	if !bytes.Equal(got, payload) {
+		t.Fatalf("downloaded content = %q", got)
+	}
+}
+
+func TestResumableDownloadRejectsChangedTotalLength(t *testing.T) {
+	t.Setenv("HFL_INSECURE_TLS", "0")
+	firstPayload := []byte("original-resource")
+	replacement := []byte("replacement-resource-is-longer")
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		switch requests.Add(1) {
+		case 1:
+			w.Header().Set("Content-Length", strconv.Itoa(len(firstPayload)))
+			_, _ = w.Write(firstPayload[:6])
+		case 2:
+			w.Header().Set("Content-Length", strconv.Itoa(len(replacement)-6))
+			w.Header().Set("Content-Range", "bytes 6-"+strconv.Itoa(len(replacement)-1)+"/"+strconv.Itoa(len(replacement)))
+			w.WriteHeader(http.StatusPartialContent)
+			_, _ = w.Write(replacement[6:])
+		case 3:
+			if request.Header.Get("Range") != "" {
+				t.Error("changed total length did not clear the partial download")
+			}
+			w.Header().Set("Content-Length", strconv.Itoa(len(replacement)))
+			_, _ = w.Write(replacement)
+		default:
+			t.Errorf("unexpected request %d", requests.Load())
+		}
+	}))
+	defer server.Close()
+
+	destination := filepath.Join(t.TempDir(), "artifact")
+	err := downloadURLResumableWithPolicy(
+		context.Background(), server.URL, destination, nil, nil,
+		time.Millisecond, time.Second, []time.Duration{0, 0, 0},
+	)
+	if err != nil {
+		t.Fatalf("download after total-length change failed: %v", err)
+	}
+	got, _ := os.ReadFile(destination)
+	if !bytes.Equal(got, replacement) {
+		t.Fatalf("downloaded content = %q", got)
+	}
+}
+
+func TestResumableDownloadRestartsAfterRangeNotSatisfiable(t *testing.T) {
+	t.Setenv("HFL_INSECURE_TLS", "0")
+	payload := []byte("restart-after-416")
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		switch requests.Add(1) {
+		case 1:
+			w.Header().Set("Content-Length", strconv.Itoa(len(payload)))
+			_, _ = w.Write(payload[:7])
+		case 2:
+			if request.Header.Get("Range") == "" {
+				t.Error("second request did not attempt a resume")
+			}
+			http.Error(w, "range unavailable", http.StatusRequestedRangeNotSatisfiable)
+		case 3:
+			if request.Header.Get("Range") != "" {
+				t.Error("416 response did not reset the partial download")
+			}
+			w.Header().Set("Content-Length", strconv.Itoa(len(payload)))
+			_, _ = w.Write(payload)
+		}
+	}))
+	defer server.Close()
+
+	destination := filepath.Join(t.TempDir(), "artifact")
+	err := downloadURLResumableWithPolicy(
+		context.Background(), server.URL, destination, nil, nil,
+		time.Millisecond, time.Second, []time.Duration{0, 0, 0},
+	)
+	if err != nil {
+		t.Fatalf("download after 416 failed: %v", err)
+	}
+	got, _ := os.ReadFile(destination)
+	if !bytes.Equal(got, payload) {
+		t.Fatalf("downloaded content = %q", got)
+	}
+}
+
+func TestResumableDownloadRejectsChangedETag(t *testing.T) {
+	t.Setenv("HFL_INSECURE_TLS", "0")
+	payload := []byte("new-resource-version")
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		switch requests.Add(1) {
+		case 1:
+			w.Header().Set("ETag", `"v1"`)
+			w.Header().Set("Content-Length", strconv.Itoa(len(payload)))
+			_, _ = w.Write(payload[:6])
+		case 2:
+			if got := request.Header.Get("If-Range"); got != `"v1"` {
+				t.Errorf("If-Range = %q", got)
+			}
+			w.Header().Set("ETag", `"v2"`)
+			w.Header().Set("Content-Range", "bytes 6-"+strconv.Itoa(len(payload)-1)+"/"+strconv.Itoa(len(payload)))
+			w.WriteHeader(http.StatusPartialContent)
+			_, _ = w.Write(payload[6:])
+		case 3:
+			if request.Header.Get("Range") != "" {
+				t.Error("changed ETag did not reset the partial download")
+			}
+			w.Header().Set("ETag", `"v2"`)
+			w.Header().Set("Content-Length", strconv.Itoa(len(payload)))
+			_, _ = w.Write(payload)
+		}
+	}))
+	defer server.Close()
+
+	destination := filepath.Join(t.TempDir(), "artifact")
+	err := downloadURLResumableWithPolicy(
+		context.Background(), server.URL, destination, nil, nil,
+		time.Millisecond, time.Second, []time.Duration{0, 0, 0},
+	)
+	if err != nil {
+		t.Fatalf("download after ETag change failed: %v", err)
+	}
+	got, _ := os.ReadFile(destination)
+	if !bytes.Equal(got, payload) {
+		t.Fatalf("downloaded content = %q", got)
+	}
+}
+
+func TestResumableDownloadRejectsUnexpectedInitialPartialResponse(t *testing.T) {
+	t.Setenv("HFL_INSECURE_TLS", "0")
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		w.Header().Set("Content-Range", "bytes 0-3/8")
+		w.WriteHeader(http.StatusPartialContent)
+		_, _ = w.Write([]byte("half"))
+	}))
+	defer server.Close()
+
+	destination := filepath.Join(t.TempDir(), "artifact")
+	err := downloadURLResumableWithPolicy(
+		context.Background(), server.URL, destination, nil, nil,
+		time.Millisecond, time.Second, []time.Duration{0, 0, 0},
+	)
+	if !errors.Is(err, ErrDownloadRangeRejected) || requests.Load() != 4 {
+		t.Fatalf("error = %v, requests = %d", err, requests.Load())
+	}
+	for _, path := range []string{destination, destination + ".part"} {
+		if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
+			t.Fatalf("unexpected download artifact %s: %v", path, statErr)
+		}
+	}
+}
+
+func TestResumableDownloadDoesNotRetryPermanentHTTPError(t *testing.T) {
+	t.Setenv("HFL_INSECURE_TLS", "0")
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		http.Error(w, "forbidden", http.StatusForbidden)
+	}))
+	defer server.Close()
+
+	err := downloadURLResumableWithPolicy(
+		context.Background(), server.URL, filepath.Join(t.TempDir(), "artifact"), nil, nil,
+		time.Millisecond, time.Second, []time.Duration{0, 0, 0},
+	)
+	if err == nil || requests.Load() != 1 {
+		t.Fatalf("error = %v, requests = %d", err, requests.Load())
+	}
+}
+
+func TestResumableDownloadCancellationStopsRetryWait(t *testing.T) {
+	t.Setenv("HFL_INSECURE_TLS", "0")
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		http.Error(w, "unavailable", http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	destination := filepath.Join(t.TempDir(), "artifact")
+	err := downloadURLResumableWithPolicy(
+		ctx, server.URL, destination, nil,
+		func(_, _ int, _ time.Duration, _ error, _ int64) { cancel() },
+		time.Millisecond, time.Second, []time.Duration{time.Hour, time.Hour, time.Hour},
+	)
+	if !errors.Is(err, context.Canceled) || requests.Load() != 1 {
+		t.Fatalf("error = %v, requests = %d", err, requests.Load())
+	}
+	if _, statErr := os.Stat(destination + ".part"); !os.IsNotExist(statErr) {
+		t.Fatalf("partial file was not removed: %v", statErr)
+	}
+}
+
+func TestResumableDownloadDoesNotRetryExpiredContext(t *testing.T) {
+	t.Setenv("HFL_INSECURE_TLS", "0")
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		requests.Add(1)
+		w.Header().Set("Content-Length", "1024")
+		w.WriteHeader(http.StatusOK)
+		w.(http.Flusher).Flush()
+		<-request.Context().Done()
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
+	defer cancel()
+	destination := filepath.Join(t.TempDir(), "artifact")
+	retryNotices := 0
+	err := downloadURLResumableWithPolicy(
+		ctx, server.URL, destination, nil,
+		func(_, _ int, _ time.Duration, _ error, _ int64) { retryNotices++ },
+		time.Millisecond, time.Second, []time.Duration{time.Hour, time.Hour, time.Hour},
+	)
+	if !errors.Is(err, context.DeadlineExceeded) || requests.Load() != 1 || retryNotices != 0 {
+		t.Fatalf("error = %v, requests = %d, retry notices = %d", err, requests.Load(), retryNotices)
+	}
+	if _, statErr := os.Stat(destination + ".part"); !os.IsNotExist(statErr) {
+		t.Fatalf("partial file was not removed: %v", statErr)
+	}
+}
+
+func TestResumableDownloadCleansPartialAfterRetryExhaustion(t *testing.T) {
+	t.Setenv("HFL_INSECURE_TLS", "0")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Length", "100")
+		_, _ = w.Write([]byte("partial"))
+	}))
+	defer server.Close()
+
+	destination := filepath.Join(t.TempDir(), "artifact")
+	if err := os.WriteFile(destination, []byte("existing-good-copy"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	err := downloadURLResumableWithPolicy(
+		context.Background(), server.URL, destination, nil, nil,
+		time.Millisecond, time.Second, []time.Duration{0, 0, 0},
+	)
+	if err == nil || !strings.Contains(err.Error(), "after 4 attempts") {
+		t.Fatalf("download error = %v", err)
+	}
+	got, _ := os.ReadFile(destination)
+	if string(got) != "existing-good-copy" {
+		t.Fatalf("existing destination was replaced: %q", got)
+	}
+	if _, statErr := os.Stat(destination + ".part"); !os.IsNotExist(statErr) {
+		t.Fatalf("partial file was not removed: %v", statErr)
+	}
+}
+
+func TestPartialCleanupFailurePreservesOriginalError(t *testing.T) {
+	partPath := filepath.Join(t.TempDir(), "artifact.part")
+	if err := os.Mkdir(partPath, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(partPath, "child"), []byte("occupied"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	original := errors.New("download failed")
+	err := cleanupPartialDownload(partPath, original)
+	if !errors.Is(err, original) {
+		t.Fatalf("cleanup error lost original failure: %v", err)
+	}
+	if !strings.Contains(err.Error(), "remove partial download") {
+		t.Fatalf("cleanup failure was not reported: %v", err)
+	}
+}
+
+func TestRetryDelayPolicy(t *testing.T) {
+	for range 100 {
+		delay := jitteredRetryDelay(15 * time.Second)
+		if delay < 12*time.Second || delay > 18*time.Second {
+			t.Fatalf("jittered delay = %s", delay)
+		}
+	}
+	for _, test := range []struct {
+		value string
+		want  time.Duration
+	}{
+		{value: "0", want: 5 * time.Second},
+		{value: "2", want: 5 * time.Second},
+		{value: "60", want: 60 * time.Second},
+		{value: "300", want: 120 * time.Second},
+	} {
+		retryAfter, hasRetryAfter := parseRetryAfter(test.value, time.Now())
+		err := &DownloadHTTPError{
+			StatusCode:    http.StatusTooManyRequests,
+			Status:        "429 Too Many Requests",
+			retryAfter:    retryAfter,
+			hasRetryAfter: hasRetryAfter,
+		}
+		if got := downloadRetryAfter(err); got != test.want {
+			t.Fatalf("Retry-After %q = %s, want %s", test.value, got, test.want)
+		}
+	}
+	now := time.Date(2026, time.August, 31, 12, 0, 0, 0, time.UTC)
+	retryAt := now.Add(90 * time.Second).Format(http.TimeFormat)
+	if got, ok := parseRetryAfter(retryAt, now); !ok || got != 90*time.Second {
+		t.Fatalf("Retry-After date = %s, want 1m30s", got)
+	}
+	pastRetryAt := now.Add(-time.Minute).Format(http.TimeFormat)
+	pastDelay, pastValid := parseRetryAfter(pastRetryAt, now)
+	if got := downloadRetryAfter(&DownloadHTTPError{
+		StatusCode:    http.StatusTooManyRequests,
+		Status:        "429 Too Many Requests",
+		retryAfter:    pastDelay,
+		hasRetryAfter: pastValid,
+	}); got != 5*time.Second {
+		t.Fatalf("past Retry-After date = %s, want 5s", got)
+	}
+	oversized, valid := parseRetryAfter("999999999999999999", now)
+	if got := downloadRetryAfter(&DownloadHTTPError{
+		StatusCode:    http.StatusServiceUnavailable,
+		Status:        "503 Service Unavailable",
+		retryAfter:    oversized,
+		hasRetryAfter: valid,
+	}); got != 120*time.Second {
+		t.Fatalf("oversized Retry-After = %s, want 2m0s", got)
+	}
+}
+
+func TestResumedProgressRateExcludesExistingBytes(t *testing.T) {
+	var downloaded atomic.Int64
+	var lastByteAt atomic.Int64
+	initial := int64(100 * 1024 * 1024)
+	downloaded.Store(initial)
+	lastByteAt.Store(time.Now().UnixNano())
+	events := make(chan DownloadProgress, 2)
+	stop := startDownloadProgress(
+		func(progress DownloadProgress) { events <- progress },
+		&downloaded, &lastByteAt, initial*2,
+		time.Now().Add(-time.Second), time.Now(), initial, 5*time.Millisecond,
+	)
+	event := <-events
+	stop(false)
+	if event.BytesPerSecond != 0 {
+		t.Fatalf("resumed progress rate included existing bytes: %.0f", event.BytesPerSecond)
 	}
 }
 


### PR DESCRIPTION
## Summary

- retry transient AI engine image bundle download failures with bounded backoff, jitter, and Retry-After support
- resume interrupted transfers safely with validated Range, If-Range, ETag, Last-Modified, and content-length handling
- preserve atomic destination replacement, clean partial artifacts, and report retry-aware progress without changing normal Agent downloads
- cover resume, restart, cancellation, cleanup, HTTP status, validator, and progress edge cases

## Validation

- `go test -count=1 ./...`
- `go vet ./...`
- targeted race tests for resumable downloads
- repeated targeted download tests
- full Agent cross-compilation checks for Windows amd64 and Linux arm64
- `git diff --check`