### PR TITLE
fix(agent): bootstrap upgrades with staged installer

### DIFF
--- a/src/agent/internal/engine/lifecycle.go
+++ b/src/agent/internal/engine/lifecycle.go
@@ -16,6 +16,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"hyperfilelens/agent/internal/enroll"
 	"hyperfilelens/agent/internal/model"
 	"hyperfilelens/agent/internal/platform/install"
 	"hyperfilelens/agent/internal/platform/release"
@@ -48,7 +49,7 @@ func (e *Engine) runAgentUpgrade(ctx context.Context, rep ReporterSink, taskID s
 	if e.current().InstallationMode == model.InstallationModeAccount {
 		return "failed", nil, "specified-user continuous protection requires administrator authorization for upgrade; run the generated local administrator command"
 	}
-	archivePath, targetVersion, workDir, err := e.prepareUpgradeBundle(ctx, rep, taskID, p)
+	archivePath, targetVersion, workDir, bundleRoot, err := e.prepareUpgradeBundle(ctx, rep, taskID, p)
 	if err != nil {
 		var failure *upgradePreparationError
 		if errors.As(err, &failure) {
@@ -74,6 +75,10 @@ func (e *Engine) runAgentUpgrade(ctx context.Context, rep ReporterSink, taskID s
 	if err != nil {
 		return "failed", nil, err.Error()
 	}
+	stagedInstaller, err := install.StageUpgradeInstaller(dataDir, bundleRoot)
+	if err != nil {
+		return "failed", nil, err.Error()
+	}
 
 	_ = sendProgress(ctx, rep, taskID, map[string]any{
 		"phase":       "upgrade",
@@ -81,8 +86,8 @@ func (e *Engine) runAgentUpgrade(ctx context.Context, rep ReporterSink, taskID s
 		"upgrade_log": upgradeLog,
 	})
 	if err := install.ScheduleDetachedUpgrade(
-		installDir,
 		stagedArchive,
+		stagedInstaller,
 		logDir,
 		cfg.InstallationMode == model.InstallationModeUser || cfg.InstallationMode == model.InstallationModeUserContinuous,
 	); err != nil {
@@ -192,7 +197,7 @@ func runBundleUninstall(ctx context.Context, bundleRoot string, keepData bool) e
 	return nil
 }
 
-func (e *Engine) prepareUpgradeBundle(ctx context.Context, rep ReporterSink, taskID string, p Payload) (archivePath, targetVersion, workDir string, err error) {
+func (e *Engine) prepareUpgradeBundle(ctx context.Context, rep ReporterSink, taskID string, p Payload) (archivePath, targetVersion, workDir, bundleRoot string, err error) {
 	cfg := e.current()
 	initialDownloadURL := payloadStringValue(p.Extra["download_url"])
 	targetVersion = payloadStringValue(p.Extra["target_version"])
@@ -207,10 +212,10 @@ func (e *Engine) prepareUpgradeBundle(ctx context.Context, rep ReporterSink, tas
 
 	workDir = install.RuntimeDownloadDir(dataDir)
 	if err := os.RemoveAll(workDir); err != nil {
-		return "", "", "", err
+		return "", "", "", "", err
 	}
 	if err := os.MkdirAll(workDir, 0o750); err != nil {
-		return "", "", "", err
+		return "", "", "", "", err
 	}
 
 	ext := ".tar.gz"
@@ -228,19 +233,24 @@ func (e *Engine) prepareUpgradeBundle(ctx context.Context, rep ReporterSink, tas
 		archivePath,
 	); err != nil {
 		os.RemoveAll(workDir)
-		return "", "", "", err
+		return "", "", "", "", err
 	}
 
 	extractDir := filepath.Join(workDir, "extract")
 	if err := install.ExtractArchive(ctx, archivePath, extractDir); err != nil {
 		os.RemoveAll(workDir)
-		return "", "", "", err
+		return "", "", "", "", err
 	}
-	if _, err := install.FindBundleRoot(extractDir); err != nil {
+	bundleRoot, err = install.FindBundleRoot(extractDir)
+	if err != nil {
 		os.RemoveAll(workDir)
-		return "", "", "", err
+		return "", "", "", "", err
 	}
-	return archivePath, targetVersion, workDir, nil
+	if err := enroll.ValidateAgentPackage(bundleRoot, cfg.Role, targetVersion); err != nil {
+		os.RemoveAll(workDir)
+		return "", "", "", "", fmt.Errorf("upgrade package validation: %w", err)
+	}
+	return archivePath, targetVersion, workDir, bundleRoot, nil
 }
 
 func (e *Engine) downloadUpgradeBundle(

--- a/src/agent/internal/platform/install/detached_run_unix_test.go
+++ b/src/agent/internal/platform/install/detached_run_unix_test.go
@@ -123,8 +123,8 @@ func TestUnixUserUpgradeScriptUsesUserLifecycleForRecovery(t *testing.T) {
 	dir := t.TempDir()
 	scriptPath := filepath.Join(dir, "run-upgrade.sh")
 	err := writeUnixUpgradeScript(
-		filepath.Join(dir, "install"),
 		filepath.Join(dir, "package.tar.gz"),
+		filepath.Join(dir, "installer", "install.sh"),
 		filepath.Join(dir, "logs"),
 		true,
 		scriptPath,

--- a/src/agent/internal/platform/install/local_upgrade_unix.go
+++ b/src/agent/internal/platform/install/local_upgrade_unix.go
@@ -14,15 +14,15 @@ const upgradeDelaySecond = 5
 // ScheduleDetachedUpgrade runs install.sh upgrade after a short delay so the agent
 // can report task.result before stop_service terminates the process.
 func ScheduleDetachedUpgrade(
-	installDir, archivePath, logDir string,
+	archivePath, installerPath, logDir string,
 	userInstall bool,
 ) error {
-	installDir = strings.TrimSpace(installDir)
 	if archivePath = strings.TrimSpace(archivePath); archivePath == "" {
 		return fmt.Errorf("upgrade archive path required")
 	}
-	if installDir == "" {
-		installDir = DefaultInstallDir()
+	installerPath = strings.TrimSpace(installerPath)
+	if installerPath == "" {
+		return fmt.Errorf("upgrade installer path required")
 	}
 	logDir = resolveUpgradeLogDir("", logDir)
 	if logDir != "" {
@@ -31,8 +31,8 @@ func ScheduleDetachedUpgrade(
 	pendingDir := filepath.Dir(archivePath)
 	scriptPath := filepath.Join(pendingDir, pendingUpgradeRunnerName)
 	if err := writeUnixUpgradeScript(
-		installDir,
 		archivePath,
+		installerPath,
 		logDir,
 		userInstall,
 		scriptPath,
@@ -59,11 +59,10 @@ func ScheduleDetachedUpgrade(
 }
 
 func writeUnixUpgradeScript(
-	installDir, archivePath, logDir string,
+	archivePath, installerPath, logDir string,
 	userInstall bool,
 	scriptPath string,
 ) error {
-	installScript := filepath.Join(installDir, "install.sh")
 	logFile := UpgradeLogPath(logDir)
 	pendingDir := filepath.Dir(archivePath)
 	userInstallFlag := "0"
@@ -143,7 +142,7 @@ echo "failed" > "$PENDING_DIR/FAILED"
 exit "$rc"
 `,
 		archivePath,
-		installScript,
+		installerPath,
 		logFile,
 		pendingDir,
 		userInstallFlag,

--- a/src/agent/internal/platform/install/local_upgrade_windows.go
+++ b/src/agent/internal/platform/install/local_upgrade_windows.go
@@ -17,16 +17,16 @@ const (
 // ScheduleDetachedUpgrade runs install.ps1 upgrade after a short delay so the agent
 // can report task.result before the service stops.
 func ScheduleDetachedUpgrade(
-	installDir, archivePath, logDir string,
+	archivePath, installerPath, logDir string,
 	userInstall bool,
 ) error {
-	installDir = strings.TrimSpace(installDir)
-	if installDir == "" {
-		installDir = DefaultInstallDir()
-	}
 	archivePath = strings.TrimSpace(archivePath)
 	if archivePath == "" {
 		return fmt.Errorf("upgrade archive path required")
+	}
+	installerPath = strings.TrimSpace(installerPath)
+	if installerPath == "" {
+		return fmt.Errorf("upgrade installer path required")
 	}
 	logDir = resolveUpgradeLogDir("", logDir)
 	if logDir != "" {
@@ -35,8 +35,8 @@ func ScheduleDetachedUpgrade(
 	pendingDir := filepath.Dir(archivePath)
 	scriptPath := filepath.Join(pendingDir, windowsUpgradeRunnerName)
 	if err := writeWindowsUpgradeScript(
-		installDir,
 		archivePath,
+		installerPath,
 		logDir,
 		userInstall,
 		scriptPath,
@@ -63,11 +63,10 @@ func ScheduleDetachedUpgrade(
 }
 
 func writeWindowsUpgradeScript(
-	installDir, archivePath, logDir string,
+	archivePath, installerPath, logDir string,
 	userInstall bool,
 	scriptPath string,
 ) error {
-	installScript := filepath.Join(installDir, "install.ps1")
 	logFile := UpgradeLogPath(logDir)
 	pendingDir := filepath.Dir(archivePath)
 	userInstallFlag := "$false"
@@ -133,7 +132,7 @@ Set-Content -LiteralPath (Join-Path $pending 'FAILED') -Value 'failed' -Encoding
 exit $rc
 `,
 		logFile,
-		installScript,
+		installerPath,
 		archivePath,
 		pendingDir,
 		userInstallFlag,

--- a/src/agent/internal/platform/install/staging.go
+++ b/src/agent/internal/platform/install/staging.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 )
 
@@ -35,6 +36,38 @@ func StageUpgradeArchive(dataDir, archivePath string) (string, error) {
 	}
 	dest := StagedUpgradePackagePath(dataDir, archivePath)
 	if err := copyFile(archivePath, dest); err != nil {
+		return "", err
+	}
+	return dest, nil
+}
+
+// StageUpgradeInstaller copies the validated bundle installer alongside the
+// archive so the detached runner can bootstrap the upgrade with new logic.
+func StageUpgradeInstaller(dataDir, bundleRoot string) (string, error) {
+	dataDir = strings.TrimSpace(dataDir)
+	bundleRoot = strings.TrimSpace(bundleRoot)
+	if dataDir == "" || bundleRoot == "" {
+		return "", fmt.Errorf("data dir and bundle root required to stage upgrade installer")
+	}
+	name := "install.sh"
+	if runtime.GOOS == "windows" {
+		name = "install.ps1"
+	}
+	src := filepath.Join(bundleRoot, name)
+	if runtime.GOOS == "windows" {
+		src = filepath.Join(bundleRoot, "install.ps1")
+	}
+	if _, err := os.Stat(src); err != nil {
+		return "", fmt.Errorf("validated upgrade installer missing: %w", err)
+	}
+	dest := filepath.Join(LifecycleUpgradeDir(dataDir), "installer", name)
+	if err := os.MkdirAll(filepath.Dir(dest), 0o750); err != nil {
+		return "", err
+	}
+	if err := copyFile(src, dest); err != nil {
+		return "", fmt.Errorf("stage upgrade installer: %w", err)
+	}
+	if err := os.Chmod(dest, 0o700); err != nil {
 		return "", err
 	}
 	return dest, nil

--- a/src/agent/internal/platform/install/staging_test.go
+++ b/src/agent/internal/platform/install/staging_test.go
@@ -1,6 +1,36 @@
 package install
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestStageUpgradeInstallerUsesValidatedBundleScript(t *testing.T) {
+	dataDir := t.TempDir()
+	bundleRoot := filepath.Join(t.TempDir(), "hfl-agent-0.2.14-darwin-arm64")
+	if err := os.MkdirAll(bundleRoot, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	src := filepath.Join(bundleRoot, "install.sh")
+	if err := os.WriteFile(src, []byte("#!/bin/sh\necho new-installer\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	dest, err := StageUpgradeInstaller(dataDir, bundleRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := filepath.Join(LifecycleUpgradeDir(dataDir), "installer", "install.sh"); dest != want {
+		t.Fatalf("destination = %q, want %q", dest, want)
+	}
+	body, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(body) != "#!/bin/sh\necho new-installer\n" {
+		t.Fatalf("staged installer content = %q", body)
+	}
+}
 
 func TestStagedPackageFilename(t *testing.T) {
 	tests := map[string]string{


### PR DESCRIPTION
## Problem and root cause

The previous launchd fix was present in the downloaded release, but the
detached upgrade runner invoked the older installer already installed on the
machine. Upgrades therefore continued to fail before the new launchd logic
could run.

## Solution

Validate the extracted release manifest before stopping the running Agent,
stage its installer alongside the archive, and pass that staged path to Unix
and Windows detached runners. Missing staged installers fail closed without a
fallback to the old installer.

## Validation

- `go test ./internal/platform/install -run 'TestStageUpgradeInstaller|TestUnixUserUpgradeScriptUsesUserLifecycleForRecovery|TestStagedPackageFilename' -count=1`
- `go test ./internal/engine -run 'TestNonExistent' -count=1` (compile check)
- `git diff --check`
- `python3 tools/quality/check-english-source.py`
- Manual testing: passed on `mini.local · ghw` with the new upgrade package.
- Optional Community backend suite: skipped by explicit user request.

## Risks and compatibility

The change affects only detached Agent upgrade bootstrap and package
validation. Existing launchd lifecycle protection is retained; Linux service,
Windows service behavior, APIs, schemas, and stored data remain compatible.

Fixes #932
