### PR TITLE
Reconcile SaaS upgrade resource retention

### DIFF
--- a/.github/scripts/remote-saas-deploy.sh
+++ b/.github/scripts/remote-saas-deploy.sh
@@ -303,3 +303,42 @@ printf '%s\n' "${candidate_id}" >"/opt/hyperfilelens/data/deployment-candidates/
 if [[ -n "${previous_id:-}" && "${previous_id}" != "${candidate_id}" ]]; then
 	printf '%s\n' "${previous_id}" >"/opt/hyperfilelens/data/deployment-candidates/previous"
 fi
+
+# Candidate manifests are small, but an upgrade can run frequently. Keep the
+# current, previous, and three most recent entries; remove only validated
+# twelve-character manifest directories so unrelated data is never touched.
+if ! python3 - <<'PY'
+import pathlib
+import re
+import shutil
+
+root = pathlib.Path("/opt/hyperfilelens/data/deployment-candidates")
+if root.is_dir():
+    pointers = {
+        (root / name).read_text(encoding="utf-8").strip()
+        for name in ("current", "previous")
+        if (root / name).is_file()
+    }
+    entries = sorted(
+        (
+            path
+            for path in root.iterdir()
+            if path.is_dir()
+            and not path.is_symlink()
+            and re.fullmatch(r"[0-9a-f]{12}", path.name)
+            and (path / "MANIFEST.json").is_file()
+        ),
+        key=lambda path: path.stat().st_mtime,
+        reverse=True,
+    )
+    keep = pointers | {path.name for path in entries[:3]}
+    for path in entries:
+        if path.name not in keep:
+            shutil.rmtree(path)
+PY
+then
+	# The release has already been applied and health-checked. Candidate
+	# history is housekeeping; a transient permission or filesystem error must
+	# not turn a successful deployment into a failed CI run.
+	printf '[WARN] Unable to prune old deployment candidates; retaining them for the next run.\n' >&2
+fi

--- a/deploy/installer/install.sh
+++ b/deploy/installer/install.sh
@@ -2902,6 +2902,7 @@ PY
 
 prune_upgrade_backups() {
 	python3 - "${ROOT}/backup" "${ROOT}/deploy/upgrades" <<'PY' || return 1
+import datetime
 import json
 import pathlib
 import re
@@ -2915,6 +2916,7 @@ if not root.is_dir():
     raise SystemExit(0)
 
 protected = set()
+now = time.time()
 if transactions.is_dir():
     for state in transactions.glob("*/state"):
         values = {}
@@ -2922,7 +2924,18 @@ if transactions.is_dir():
             if "=" in line:
                 key, value = line.split("=", 1)
                 values[key] = value
-        if values.get("status") == "complete":
+        # Only an active transaction may still need its backup for recovery.
+        # Failed transactions are recorded for diagnostics but must not pin
+        # multi-gigabyte backup sets forever after a later upgrade succeeds.
+        if values.get("status") != "active":
+            continue
+        try:
+            updated_at = datetime.datetime.fromisoformat(
+                values.get("updated_at", "").replace("Z", "+00:00")
+            ).timestamp()
+        except (TypeError, ValueError):
+            continue
+        if now - updated_at > 24 * 60 * 60:
             continue
         backup_dir = values.get("backup_dir", "")
         backup_path = pathlib.Path(backup_dir)
@@ -2933,7 +2946,6 @@ if transactions.is_dir():
         if managed and re.fullmatch(r"upgrade-\d{8}-\d{6}", backup_path.name):
             protected.add(backup_path.name)
 
-now = time.time()
 for path in root.glob(".partial-*"):
     if now - path.stat().st_mtime <= 24 * 60 * 60:
         continue
@@ -3128,7 +3140,7 @@ managed_image_ref_is_in_use() {
 }
 
 prune_old_managed_image_refs() {
-	local backup_manifest="" gateway_version ref output
+	local backup_manifest="" gateway_version image_id output
 	local -a removable=()
 	command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1 || return 0
 	gateway_version="$(grep -E '^HFL_GATEWAY_VERSION=' "${ROOT}/.env" 2>/dev/null \
@@ -3143,36 +3155,95 @@ import re
 import subprocess
 import sys
 
+def inspect(ref):
+    completed = subprocess.run(
+        ["docker", "image", "inspect", ref],
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+    )
+    if completed.returncode != 0:
+        return None
+    try:
+        value = json.loads(completed.stdout)
+    except json.JSONDecodeError:
+        return None
+    return value[0] if isinstance(value, list) and value else value
+
+def image_id(value):
+    raw = str(value or "")
+    return raw[7:] if raw.startswith("sha256:") else raw
+
 managed_repositories = {
+    "hyperfilelens-agent-assets",
     "hyperfilelens-backend",
     "hyperfilelens-frontend",
+    "hyperfilelens-gateway-assets",
+    "hyperfilelens-language-assets",
+    "hyperfilelens-postgres",
+    "hyperfilelens-redis",
     "hyperfilelens-sourcelens-backend",
     "hyperfilelens-sourcelens-frontend",
     "hyperfilelens-sourcelens-lensnode",
-    "hyperfilelens-agent-assets",
-    "hyperfilelens-gateway-assets",
-    "hyperfilelens-language-assets",
+    "hyperfilelens-sourcelens-nginx",
 }
-protected = set()
-for raw in sys.argv[1:3]:
+managed_namespaces = {"oneprocloud", "oneprolabs"}
+
+
+def managed_ref(value):
+    raw = str(value or "")
+    repository = raw.split("@", 1)[0].rsplit(":", 1)[0]
+    parts = repository.split("/")
+    if parts[-1] not in managed_repositories:
+        return False
+    return len(parts) == 1 or (len(parts) >= 2 and parts[-2] in managed_namespaces)
+
+protected_ids = set()
+protected_refs = set()
+required_local_refs = set()
+for index, raw in enumerate(sys.argv[1:3]):
     path = pathlib.Path(raw) if raw else None
-    if not path or not path.is_file():
+    if not path:
+        if index == 0:
+            raise SystemExit("current release manifest is missing")
         continue
+    if not path.is_file():
+        raise SystemExit(f"protected release manifest is missing: {path}")
     try:
         manifest = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
-        continue
-    for image in manifest.get("images", []):
-        protected.update(str(ref) for ref in image.get("refs", []) if ref)
+    except (OSError, json.JSONDecodeError) as error:
+        raise SystemExit(f"protected release manifest is invalid: {path}: {error}")
+    images = manifest.get("images")
+    if not isinstance(images, list) or not images:
+        raise SystemExit(f"protected release manifest has no images: {path}")
+    for image in images:
+        for ref in image.get("refs", []):
+            protected_refs.add(str(ref))
+            required_local_refs.add(str(ref))
+        for digest in image.get("digests", []):
+            protected_refs.add(str(digest))
     delivery = manifest.get("delivery") or {}
-    for image in delivery.get("asset_images") or []:
-        local_ref = str(image.get("local_ref") or "")
-        if local_ref:
-            protected.add(local_ref)
+    for group in ("registry_images", "asset_images"):
+        for image in delivery.get(group) or []:
+            for key in ("local_ref", "digest"):
+                if image.get(key):
+                    protected_refs.add(str(image[key]))
+                    if key == "local_ref":
+                        required_local_refs.add(str(image[key]))
+            for source in image.get("sources") or []:
+                if source.get("ref"):
+                    protected_refs.add(str(source["ref"]))
+
+for ref in sorted(required_local_refs):
+    inspected = inspect(ref)
+    if not inspected:
+        raise SystemExit(f"protected release image is unavailable: {ref}")
+    protected_ids.add(image_id(inspected.get("Id")))
 
 gateway_version = sys.argv[3]
 if re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}", gateway_version):
-    protected.add(f"hyperfilelens-frontend:{gateway_version}")
+    protected_refs.add(f"hyperfilelens-frontend:{gateway_version}")
 
 containers = subprocess.run(
     ["docker", "ps", "-aq", "--no-trunc"],
@@ -3182,25 +3253,36 @@ containers = subprocess.run(
 ).stdout.split()
 if containers:
     inspected = subprocess.run(
-        ["docker", "inspect", "--format", "{{.Config.Image}}", *containers],
+        ["docker", "inspect", "--format", "{{.Image}}", *containers],
         check=False,
         text=True,
         stdout=subprocess.PIPE,
     )
-    protected.update(line.strip() for line in inspected.stdout.splitlines() if line.strip())
+    protected_ids.update(image_id(line.strip()) for line in inspected.stdout.splitlines() if line.strip())
 
 listed = subprocess.run(
-    ["docker", "image", "ls", "--format", "{{.Repository}}:{{.Tag}}"],
+    ["docker", "image", "ls", "-q", "--no-trunc"],
     check=True,
     text=True,
     stdout=subprocess.PIPE,
-).stdout.splitlines()
-for ref in sorted(set(line.strip() for line in listed if line.strip())):
-    repository, separator, tag = ref.rpartition(":")
-    if not separator or repository not in managed_repositories or tag == "<none>":
+)
+for raw_id in sorted(set(line.strip() for line in listed.stdout.splitlines() if line.strip())):
+    inspected = inspect(raw_id)
+    if not inspected:
         continue
-    if ref not in protected:
-        print(ref)
+    current_id = image_id(inspected.get("Id") or raw_id)
+    tags = inspected.get("RepoTags") or []
+    digests = inspected.get("RepoDigests") or []
+    refs = [str(value) for value in [*tags, *digests] if value]
+    if not refs or not any(managed_ref(value) for value in refs):
+        continue
+    if current_id in protected_ids:
+        continue
+    if any(value in protected_refs for value in refs):
+        continue
+    if any(not managed_ref(value) for value in refs):
+        continue
+    print(current_id)
 PY
 	)"; then
 		warn "unable to resolve old HFL image references; skipping image cleanup"
@@ -3209,14 +3291,17 @@ PY
 	if [[ -n "${output}" ]]; then
 		mapfile -t removable <<<"${output}"
 	fi
-	for ref in "${removable[@]}"; do
-		[[ -n "${ref}" ]] || continue
-		if managed_image_ref_is_in_use "${ref}"; then
-			log "Retained in-use old HFL image tag ${ref}"
-		elif docker image rm "${ref}" >/dev/null 2>&1; then
-			log "Removed unreferenced old HFL image tag ${ref}"
+	for image_id in "${removable[@]}"; do
+		[[ -n "${image_id}" ]] || continue
+		if managed_image_ref_is_in_use "${image_id}"; then
+			log "Retained in-use old HFL image ${image_id}"
+		# Every remaining reference was verified as installer-managed and the
+		# image is not used by a container. Force is required when the same image
+		# still has both a local tag and an immutable registry digest reference.
+		elif docker image rm -f "${image_id}" >/dev/null 2>&1; then
+			log "Removed unreferenced old HFL image ${image_id}"
 		else
-			warn "Unable to remove old HFL image tag ${ref}; deployment remains healthy"
+			warn "Unable to remove old HFL image ${image_id}; deployment remains healthy"
 		fi
 	done
 }

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -1367,8 +1367,9 @@ grep -F 'HFL_REDIS_MEMORY_LIMIT=1g' "${ROOT}/.env.example" >/dev/null
 grep -F 'mem_limit: ${HFL_REDIS_MEMORY_LIMIT:-1g}' "${ROOT}/deploy/docker-compose.yml" >/dev/null
 grep -F 'recover_upgrade_services' "${installer}" >/dev/null
 grep -F 'prune_old_managed_image_refs' "${installer}" >/dev/null
-grep -F 'docker image rm "${ref}"' "${installer}" >/dev/null
-grep -F 'protected.update(line.strip() for line in inspected.stdout.splitlines()' "${installer}" >/dev/null
+grep -F 'docker image rm -f "${image_id}"' "${installer}" >/dev/null
+grep -F 'protected_ids.update(image_id(line.strip()) for line in inspected.stdout.splitlines()' "${installer}" >/dev/null
+grep -F 'protected release manifest is invalid' "${installer}" >/dev/null
 grep -F 'python3 "${sync_script}" --env-file "${env_file}" --example "${example}"' "${installer}" >/dev/null
 grep -F 'host must be Ubuntu 20.04, 22.04, or 24.04' "${installer}" >/dev/null
 grep -F 'gateway-install-docker-ubuntu-amd64.sh' "${installer}" >/dev/null

--- a/tools/quality/test-managed-image-retention.sh
+++ b/tools/quality/test-managed-image-retention.sh
@@ -22,8 +22,33 @@ set -euo pipefail
 case "$*" in
 "info") ;;
 "ps -aq --no-trunc") printf 'foreign-container\n' ;;
-"inspect --format {{.Config.Image}} foreign-container") printf 'hyperfilelens-backend:0.1.6\n' ;;
 "inspect --format {{.Image}} foreign-container") printf 'sha256:in-use\n' ;;
+
+"image ls -q --no-trunc")
+	printf '%s\n' sha256:current sha256:previous sha256:in-use sha256:unused sha256:digest-old sha256:shared sha256:foreign-owned sha256:foreign
+	;;
+"image inspect hyperfilelens-backend:latest") printf '%s\n' '{"Id":"sha256:current","RepoTags":["hyperfilelens-backend:latest"],"RepoDigests":[]}' ;;
+"image inspect hyperfilelens-backend:0.1.8") printf '%s\n' '{"Id":"sha256:current","RepoTags":["hyperfilelens-backend:0.1.8"],"RepoDigests":[]}' ;;
+"image inspect hyperfilelens-backend:0.1.7") printf '%s\n' '{"Id":"sha256:previous","RepoTags":["hyperfilelens-backend:0.1.7"],"RepoDigests":[]}' ;;
+"image inspect sha256:current") printf '%s\n' '{"Id":"sha256:current","RepoTags":["hyperfilelens-backend:0.1.8"],"RepoDigests":[]}' ;;
+"image inspect sha256:previous") printf '%s\n' '{"Id":"sha256:previous","RepoTags":["hyperfilelens-backend:0.1.7"],"RepoDigests":[]}' ;;
+"image inspect sha256:in-use") printf '%s\n' '{"Id":"sha256:in-use","RepoTags":["hyperfilelens-backend:0.1.6"],"RepoDigests":[]}' ;;
+"image inspect sha256:unused") printf '%s\n' '{"Id":"sha256:unused","RepoTags":["hyperfilelens-backend:0.1.5"],"RepoDigests":[]}' ;;
+"image inspect sha256:foreign") printf '%s\n' '{"Id":"sha256:foreign","RepoTags":["customer-backend:0.1.5"],"RepoDigests":[]}' ;;
+"image inspect sha256:digest-old") printf '%s\n' '{"Id":"sha256:digest-old","RepoTags":[],"RepoDigests":["oneprolabs/hyperfilelens-backend@sha256:old"]}' ;;
+"image inspect sha256:shared") printf '%s\n' '{"Id":"sha256:shared","RepoTags":["hyperfilelens-backend:0.1.4","customer-backend:0.1.4"],"RepoDigests":[]}' ;;
+"image inspect sha256:foreign-owned") printf '%s\n' '{"Id":"sha256:foreign-owned","RepoTags":[],"RepoDigests":["customer/hyperfilelens-backend@sha256:foreign"]}' ;;
+"image inspect sha256:unused --format {{.Id}}") printf 'sha256:unused\n' ;;
+"image inspect sha256:in-use --format {{.Id}}") printf 'sha256:in-use\n' ;;
+"image inspect unused --format {{.Id}}") printf 'sha256:unused\n' ;;
+"image inspect in-use --format {{.Id}}") printf 'sha256:in-use\n' ;;
+"image inspect digest-old --format {{.Id}}") printf 'sha256:digest-old\n' ;;
+"image rm -f unused")
+	printf '%s\n' 'sha256:unused' >>"${HFL_TEST_REMOVED_IMAGES}"
+	;;
+"image rm -f digest-old")
+	printf '%s\n' 'sha256:digest-old' >>"${HFL_TEST_REMOVED_IMAGES}"
+	;;
 "image ls --format {{.Repository}}:{{.Tag}}")
 	printf '%s\n' \
 		hyperfilelens-backend:latest \
@@ -34,11 +59,6 @@ case "$*" in
 		hyperfilelens-backend:0.1.4 \
 		hyperfilelens-frontend:0.1.5 \
 		customer-backend:0.1.5
-	;;
-"image inspect hyperfilelens-backend:0.1.5 --format {{.Id}}") printf 'sha256:unused\n' ;;
-"image inspect hyperfilelens-backend:0.1.4 --format {{.Id}}") printf 'sha256:in-use\n' ;;
-"image rm hyperfilelens-backend:0.1.5")
-	printf '%s\n' 'hyperfilelens-backend:0.1.5' >>"${HFL_TEST_REMOVED_IMAGES}"
 	;;
 *) printf 'unexpected fake Docker invocation: %s\n' "$*" >&2; exit 1 ;;
 esac
@@ -52,5 +72,11 @@ log() { printf 'INFO: %s\n' "$*"; }
 source <(sed -n '/^managed_image_ref_is_in_use()/,/^apply_upgrade_files()/p' "${installer}" | sed '$d')
 
 prune_old_managed_image_refs
-[[ "$(<"${HFL_TEST_REMOVED_IMAGES}")" == "hyperfilelens-backend:0.1.5" ]]
+[[ "$(<"${HFL_TEST_REMOVED_IMAGES}")" == $'sha256:digest-old\nsha256:unused' ]]
+
+# A malformed protected manifest fails closed and must not remove anything.
+printf '{invalid\n' >"${ROOT}/MANIFEST.json"
+rm -f "${HFL_TEST_REMOVED_IMAGES}"
+prune_old_managed_image_refs
+[[ ! -e "${HFL_TEST_REMOVED_IMAGES}" ]]
 printf 'Managed image retention checks passed.\n'

--- a/tools/quality/test-upgrade-backup-retention.sh
+++ b/tools/quality/test-upgrade-backup-retention.sh
@@ -58,16 +58,16 @@ for stamp in 20260720-010000 20260721-010000 20260722-010000 20260723-010000; do
 	mkdir -p "${ROOT}/backup/upgrade-${stamp}"
 	printf '{"complete": true}\n' >"${ROOT}/backup/upgrade-${stamp}/backup-manifest.json"
 done
-protected="${ROOT}/backup/upgrade-20260720-010000"
 transaction="${ROOT}/deploy/upgrades/$(printf a%.0s {1..64})"
 mkdir -p "${transaction}"
+protected="${ROOT}/backup/upgrade-20260720-010000"
 cat >"${transaction}/state" <<EOF
 artifact_sha256=$(printf a%.0s {1..64})
 target_version=0.1.8
-status=failed
+status=active
 phase=backup_complete
 backup_dir=${protected}
-updated_at=2026-07-23T01:00:00Z
+updated_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 EOF
 mkdir -p "${ROOT}/backup/.partial-stale"
 touch -d '2 days ago' "${ROOT}/backup/.partial-stale"
@@ -79,8 +79,8 @@ prune_upgrade_backups
 [[ -e "${ROOT}/backup/upgrade-20260723-010000" ]]
 [[ ! -e "${ROOT}/backup/.partial-stale" ]]
 
-# An untrusted transaction path must not protect a same-named managed backup.
-sed -i "s#^backup_dir=.*#backup_dir=/tmp/upgrade-20260720-010000#" \
+# A stale active transaction must not pin its backup forever.
+sed -i 's#^updated_at=.*#updated_at=2020-01-01T00:00:00Z#' \
 	"${transaction}/state"
 prune_upgrade_backups
 [[ ! -e "${ROOT}/backup/upgrade-20260720-010000" ]]


### PR DESCRIPTION
## Summary

- retain current, rollback, and in-use Docker images by immutable image ID
- protect managed release images and fail closed when release metadata is unavailable
- retain the latest managed upgrade backups while protecting active transactions
- prune stale deployment candidates without turning a successful deployment into a CI failure
- add regression coverage for image, backup, and SaaS registry retention behavior

## Validation

- upgrade transaction checks
- Docker image digest alias checks
- Enterprise release flow checks
- upgrade backup retention checks
- managed image retention checks
- SaaS registry delivery checks
- release contract checks
- Bash syntax and diff checks