### PR TITLE
feat(analytics): add privacy-safe page taxonomy

### DIFF
--- a/language-packs/packs/es/frontend/messages.json
+++ b/language-packs/packs/es/frontend/messages.json
@@ -1,4 +1,11 @@
 {
+  "analytics": {
+    "pages": {
+      "backupDetails": "Detalles de la copia de seguridad",
+      "snapshotDetails": "Detalles de la instantánea",
+      "restore": "Restaurar"
+    }
+  },
   "common": {
     "confirm": "Aceptar",
     "confirmDelete": "Confirmar eliminación",

--- a/language-packs/packs/es/frontend/source-lock.json
+++ b/language-packs/packs/es/frontend/source-lock.json
@@ -1,4 +1,7 @@
 {
+  "analytics.pages.backupDetails": "40d071d8d9a5a0e791fd2b1a0b26e442566f8c022041ddb2078f4a8ffd7c2a10",
+  "analytics.pages.snapshotDetails": "84d583d66a5de63a812ec8d96da3626c7866eff986d62176d955a5d27cbe833f",
+  "analytics.pages.restore": "9fb92d5ac48a197b0499952ff25f2e8a84937831504f23569b5b8ad549a4334d",
   "common.confirm": "98c4922bb641c65c7a30b7bcafdf230b9b00b6693631c56146ab25b2786ee4a3",
   "common.confirmDelete": "25141577458dc98eb388c6652e945322c5385a2f836e8af57e50090faff862f2",
   "common.delete": "b26de372b4b0eaac60202884a72db98a6be6e9036e785ea867ea01c5f7921098",

--- a/language-packs/packs/zh-hans/frontend/messages.json
+++ b/language-packs/packs/zh-hans/frontend/messages.json
@@ -1,4 +1,11 @@
 {
+  "analytics": {
+    "pages": {
+      "backupDetails": "备份详情",
+      "snapshotDetails": "快照详情",
+      "restore": "恢复"
+    }
+  },
   "common": {
     "confirm": "确定",
     "confirmDelete": "确认删除",

--- a/language-packs/packs/zh-hans/frontend/source-lock.json
+++ b/language-packs/packs/zh-hans/frontend/source-lock.json
@@ -1,4 +1,7 @@
 {
+  "analytics.pages.backupDetails": "40d071d8d9a5a0e791fd2b1a0b26e442566f8c022041ddb2078f4a8ffd7c2a10",
+  "analytics.pages.snapshotDetails": "84d583d66a5de63a812ec8d96da3626c7866eff986d62176d955a5d27cbe833f",
+  "analytics.pages.restore": "9fb92d5ac48a197b0499952ff25f2e8a84937831504f23569b5b8ad549a4334d",
   "common.confirm": "98c4922bb641c65c7a30b7bcafdf230b9b00b6693631c56146ab25b2786ee4a3",
   "common.confirmDelete": "25141577458dc98eb388c6652e945322c5385a2f836e8af57e50090faff862f2",
   "common.delete": "b26de372b4b0eaac60202884a72db98a6be6e9036e785ea867ea01c5f7921098",

--- a/src/frontend/src/lib/analytics.test.ts
+++ b/src/frontend/src/lib/analytics.test.ts
@@ -19,12 +19,17 @@ function dataLayerCommands(): unknown[][] {
   ))
 }
 
-async function loadAnalytics(measurementId = '') {
+async function loadAnalytics(
+  measurementId = '',
+  surface: 'tenant' | 'admin' = 'tenant',
+  activate = true,
+) {
   vi.resetModules()
-  window.__HFL_APP_CONFIG__ = { gaMeasurementId: measurementId }
+  window.__HFL_APP_CONFIG__ = { gaMeasurementId: measurementId, sentrySurface: surface }
   const afterEach = vi.fn()
   const analytics = await import('./analytics')
   analytics.initAppAnalytics({ afterEach } as unknown as Router)
+  if (activate) analytics.activateAppAnalytics()
   return { analytics, afterEach }
 }
 
@@ -33,6 +38,7 @@ afterEach(() => {
   delete window.__HFL_APP_CONFIG__
   delete window.dataLayer
   delete window.gtag
+  document.title = 'HyperFileLens'
   vi.restoreAllMocks()
 })
 
@@ -76,7 +82,11 @@ describe('runtime Google Analytics', () => {
       ['event', 'page_view', expect.objectContaining({
         page_location: `${window.location.origin}/protection/backups/:backupId`,
         page_path: '/protection/backups/:backupId',
-        page_title: 'HyperFileLens',
+        page_title: 'Backup Details | HyperFileLens Console',
+        page_key: 'protection.backup_detail',
+        page_group: 'protection',
+        page_surface: 'console',
+        ui_language: 'en',
       })],
     ]))
     expect(JSON.stringify(window.dataLayer)).not.toContain('customer-backup')
@@ -91,8 +101,140 @@ describe('runtime Google Analytics', () => {
         method: 'email',
         page_location: `${window.location.origin}/protection/backups/:backupId`,
         page_path: '/protection/backups/:backupId',
+        page_key: 'protection.backup_detail',
       }),
     ])
     expect(JSON.stringify(dataLayerCommands())).not.toContain('person@example.com')
+  })
+
+  it('normalizes controlled sidebar query values to business pages', async () => {
+    const { analytics } = await loadAnalytics('G-0RX9GZJCWF')
+    expect(analytics.analyticsPageMetadata({
+      ...route('/protection/backup-sources?tab=host', '/protection/backup-sources'),
+      query: { tab: 'host' },
+    } as RouteLocationNormalizedLoaded))
+      .toMatchObject({
+        pageKey: 'protection.source_hosts',
+        pagePath: '/protection/source-hosts',
+      })
+    expect(analytics.analyticsPageMetadata({
+      ...route('/protection/backup-sources?tab=nas', '/protection/backup-sources'),
+      query: { tab: 'nas' },
+    } as RouteLocationNormalizedLoaded)).toMatchObject({
+      pageKey: 'protection.source_nas',
+      pagePath: '/protection/source-nas',
+    })
+    expect(analytics.analyticsPageMetadata(
+      route('/node/repositories', '/node/repositories'),
+    )).toMatchObject({
+      pageKey: 'protection.object_storage',
+      pagePath: '/protection/object-storage',
+    })
+    expect(analytics.analyticsPageMetadata({
+      ...route('/protection/policies?tab=unknown', '/protection/policies'),
+      query: { tab: 'unknown' },
+    } as RouteLocationNormalizedLoaded)).toMatchObject({
+      pageKey: 'protection.backup_policies',
+      pagePath: '/protection/backup-policies',
+    })
+    expect(analytics.analyticsPageMetadata(
+      route('/node/snapshots', '/node/snapshots'),
+    )).toMatchObject({
+      pageKey: 'protection.snapshots',
+      pageGroup: 'protection',
+      pagePath: '/node/snapshots',
+    })
+  })
+
+  it('keeps secondary pages in their top-level product groups', async () => {
+    const { analytics } = await loadAnalytics('G-0RX9GZJCWF')
+    expect(analytics.analyticsPageMetadata(route(
+      '/insight/copilot/new',
+      '/',
+      'insight/copilot/new',
+    ))).toMatchObject({
+      pageKey: 'insight.ai_copilot',
+      pageGroup: 'insights',
+    })
+    expect(analytics.analyticsPageMetadata(route(
+      '/ops/alerts/rules/customer-rule/edit',
+      '/',
+      'ops/alerts/rules/:id/edit',
+    ))).toMatchObject({
+      pageKey: 'operations.alert_rules',
+      pageGroup: 'operations',
+      pagePath: '/ops/alerts/rules/:id/edit',
+    })
+  })
+
+  it('does not report Admin Console pages unless explicitly enabled', async () => {
+    const { afterEach } = await loadAnalytics('G-0RX9GZJCWF', 'admin')
+    expect(afterEach).not.toHaveBeenCalled()
+    expect(document.querySelector('script[data-hfl-google-analytics]')).toBeNull()
+  })
+
+  it('consumes extension-declared Admin metadata without exposing resource IDs', async () => {
+    const { analytics, afterEach } = await loadAnalytics('G-0RX9GZJCWF')
+    const declaredRoute = {
+      ...route('/platform-ops/orgs/secret-org', '/platform-ops', 'orgs/:id'),
+      matched: [
+        { path: '/platform-ops' },
+        {
+          path: 'orgs/:id',
+          meta: {
+            analytics: {
+              pageKey: 'platform.organization_detail',
+              pageGroup: 'platform',
+              pageSurface: 'admin',
+              titleKey: 'platformOps.orgs.detailTitle',
+            },
+          },
+        },
+      ],
+    } as RouteLocationNormalizedLoaded
+    expect(analytics.analyticsPageMetadata(declaredRoute)).toMatchObject({
+      pageKey: 'platform.organization_detail',
+      pageSurface: 'admin',
+      pagePath: '/platform-ops/orgs/:id',
+    })
+    const hook = afterEach.mock.calls[0]?.[0] as (to: RouteLocationNormalizedLoaded) => void
+    hook(declaredRoute)
+    expect(JSON.stringify(window.dataLayer)).not.toContain('secret-org')
+  })
+
+  it('does not duplicate a page view and never exposes an unmatched path', async () => {
+    const { analytics, afterEach } = await loadAnalytics('G-0RX9GZJCWF')
+    const hook = afterEach.mock.calls[0]?.[0] as (to: RouteLocationNormalizedLoaded) => void
+    const overview = route('/', '/')
+    hook(overview)
+    hook(overview)
+    expect(dataLayerCommands().filter((command) => (
+      command[0] === 'event' && command[1] === 'page_view'
+    ))).toHaveLength(1)
+
+    const unknown = analytics.analyticsPageMetadata(route('/private/customer-resource'))
+    expect(unknown).toMatchObject({ pageKey: 'route.other', pagePath: '/other' })
+    expect(JSON.stringify(unknown)).not.toContain('customer-resource')
+
+    const unknownAdmin = analytics.analyticsPageMetadata(route(
+      '/platform-ops/orgs/secret-org',
+      '/platform-ops',
+      'orgs/:id/unknown',
+    ))
+    expect(unknownAdmin).toMatchObject({
+      pageKey: 'route.other',
+      pageSurface: 'admin',
+      pagePath: '/other',
+    })
+    expect(JSON.stringify(unknownAdmin)).not.toContain('secret-org')
+  })
+
+  it('holds the first page view until locale startup is complete', async () => {
+    const { analytics, afterEach } = await loadAnalytics('G-0RX9GZJCWF', 'tenant', false)
+    const hook = afterEach.mock.calls[0]?.[0] as (to: RouteLocationNormalizedLoaded) => void
+    hook(route('/', '/'))
+    expect(dataLayerCommands().some((command) => command[1] === 'page_view')).toBe(false)
+    analytics.activateAppAnalytics()
+    expect(dataLayerCommands().filter((command) => command[1] === 'page_view')).toHaveLength(1)
   })
 })

--- a/src/frontend/src/lib/analytics.ts
+++ b/src/frontend/src/lib/analytics.ts
@@ -1,8 +1,20 @@
-import type { RouteLocationNormalizedLoaded, Router } from 'vue-router'
+import type { LocationQuery, RouteLocationNormalizedLoaded, Router } from 'vue-router'
+import { i18n } from '../i18n'
 
 type GoogleTag = (...args: unknown[]) => void
 type AppAnalyticsEvent = 'login' | 'sign_up' | 'sign_up_started'
 type AppAnalyticsParameters = { method: 'email' | 'google' }
+
+export type AnalyticsPageSurface = 'console' | 'admin'
+
+export interface AnalyticsPageMetadata {
+  pageKey: string
+  pageGroup: string
+  pageSurface: AnalyticsPageSurface
+  pagePath: string
+  titleKey: string
+  title: string
+}
 
 declare global {
   interface Window {
@@ -15,9 +27,15 @@ const GA4_MEASUREMENT_ID = /^G-[A-Z0-9]+$/
 const GOOGLE_TAG_SCRIPT = 'script[data-hfl-google-analytics]'
 
 let activeMeasurementId = ''
-let activePagePath = '/'
+let activePage: AnalyticsPageMetadata | null = null
+let lastTrackedPageSignature = ''
+let localeObserver: MutationObserver | null = null
+let pageTrackingReady = false
+let pendingPage: AnalyticsPageMetadata | null = null
+let analyticsRouter: Router | null = null
 
 function configuredMeasurementId(): string {
+  if (window.__HFL_APP_CONFIG__?.sentrySurface === 'admin') return ''
   return String(window.__HFL_APP_CONFIG__?.gaMeasurementId || '').trim()
 }
 
@@ -33,6 +51,172 @@ function sanitizedReferrer(): string {
 }
 
 export function analyticsRoutePath(
+  route: Pick<RouteLocationNormalizedLoaded, 'matched' | 'path'> & { query?: LocationQuery },
+): string {
+  return normalizeRoutePath(analyticsRouteTemplate(route), route.query)
+}
+
+function queryValue(query: LocationQuery | undefined, key: string): string {
+  const value = query?.[key]
+  if (Array.isArray(value)) return String(value[0] || '')
+  return String(value || '')
+}
+
+function normalizeRoutePath(path: string, query: LocationQuery | undefined): string {
+  if (path === '/protection/backup-sources') {
+    return queryValue(query, 'tab') === 'nas'
+      ? '/protection/source-nas'
+      : '/protection/source-hosts'
+  }
+  if (path === '/node/repositories') {
+    const tab = queryValue(query, 'tab')
+    if (tab === 'nas') return '/protection/target-nas'
+    if (tab === 'proxy_fs') return '/protection/local-disks'
+    return '/protection/object-storage'
+  }
+  if (path === '/protection/policies') {
+    return queryValue(query, 'tab') === 'filter'
+      ? '/protection/file-filters'
+      : '/protection/backup-policies'
+  }
+  if (path === '/protection/backups') {
+    const step = queryValue(query, 'step')
+    if (step && ['source', 'backup-config', 'start-backup'].includes(step)) {
+      return `/protection/backup-wizard/${step}`
+    }
+  }
+  return path
+}
+
+function currentUiLanguage(): string {
+  return String(i18n.global.locale.value || 'en').toLowerCase()
+}
+
+function titleForPage(titleKey: string): string {
+  if (!titleKey) return 'Page'
+  const translated = String(i18n.global.t(titleKey)).trim()
+  return translated && translated !== titleKey ? translated : 'Page'
+}
+
+function pageMetadata(
+  pageKey: string,
+  pageGroup: string,
+  pageSurface: AnalyticsPageSurface,
+  pagePath: string,
+  titleKey: string,
+): AnalyticsPageMetadata {
+  const suffix = pageSurface === 'admin'
+    ? 'HyperFileLens Admin Console'
+    : 'HyperFileLens Console'
+  return {
+    pageKey,
+    pageGroup,
+    pageSurface,
+    pagePath,
+    titleKey,
+    title: `${titleForPage(titleKey)} | ${suffix}`,
+  }
+}
+
+function routeDeclaredPageMetadata(
+  route: Pick<RouteLocationNormalizedLoaded, 'matched' | 'path'>,
+): AnalyticsPageMetadata | null {
+  for (const record of [...route.matched].reverse()) {
+    const declared = record.meta?.analytics
+    if (!declared || typeof declared !== 'object') continue
+    const pageKey = String((declared as Record<string, unknown>).pageKey || '').trim()
+    if (!pageKey) continue
+    const pageGroup = String((declared as Record<string, unknown>).pageGroup || 'other').trim()
+    const titleKey = String((declared as Record<string, unknown>).titleKey || '').trim()
+    const pageSurface = (declared as Record<string, unknown>).pageSurface === 'admin' ? 'admin' : 'console'
+    return pageMetadata(pageKey, pageGroup, pageSurface, analyticsRouteTemplate(route), titleKey)
+  }
+  return null
+}
+
+export function analyticsPageMetadata(
+  route: Pick<RouteLocationNormalizedLoaded, 'matched' | 'path'> & { query?: LocationQuery },
+): AnalyticsPageMetadata {
+  const rawPath = analyticsRouteTemplate(route)
+  const pagePath = normalizeRoutePath(rawPath, route.query)
+  const declaredPage = routeDeclaredPageMetadata(route)
+  if (declaredPage) return { ...declaredPage, pagePath }
+  if (rawPath.startsWith('/platform-ops')) {
+    // Extension routes must declare their own metadata. Keep undeclared admin
+    // paths in the same privacy-safe fallback as every other unknown route.
+    return pageMetadata('route.other', 'platform', 'admin', '/other', 'platformOps.nav.title')
+  }
+  if (pagePath === '/') {
+    return pageMetadata('overview.dashboard', 'overview', 'console', pagePath, 'nav.overview')
+  }
+  const staticPages: Record<string, [string, string, string]> = {
+    '/protection/backups': ['protection.backup_wizard', 'protection', 'protection.side.dataProtection'],
+    '/protection/backup-wizard/source': ['protection.backup_wizard', 'protection', 'protection.side.dataProtection'],
+    '/protection/backup-wizard/backup-config': ['protection.backup_wizard', 'protection', 'protection.side.dataProtection'],
+    '/protection/backup-wizard/start-backup': ['protection.backup_wizard', 'protection', 'protection.side.dataProtection'],
+    '/protection/source-hosts': ['protection.source_hosts', 'protection', 'protection.side.sourceHosts'],
+    '/protection/source-nas': ['protection.source_nas', 'protection', 'protection.side.sourceNas'],
+    '/node/agents': ['protection.proxy_hosts', 'protection', 'protection.side.sourceAgents'],
+    '/node/snapshots': ['protection.snapshots', 'protection', 'protection.side.snapshots'],
+    '/protection/object-storage': ['protection.object_storage', 'protection', 'protection.side.objectStorage'],
+    '/protection/target-nas': ['protection.target_nas', 'protection', 'repositoriesPage.tabNas'],
+    '/protection/local-disks': ['protection.local_disks', 'protection', 'protection.side.standaloneDisks'],
+    '/protection/backup-policies': ['protection.backup_policies', 'protection', 'protection.side.backupPolicies'],
+    '/protection/file-filters': ['protection.file_filters', 'protection', 'protection.side.fileFilterRules'],
+    '/insight/copilot': ['insight.ai_copilot', 'insights', 'insight.side.copilot'],
+    '/insight/copilot/new': ['insight.ai_copilot', 'insights', 'insight.side.copilot'],
+    '/insight/copilot/shared': ['insight.ai_copilot', 'insights', 'insight.side.copilot'],
+    '/insight/gateways': ['insight.data_gateways', 'insights', 'insight.side.dataGateway'],
+    '/insight/usage': ['insight.usage', 'insights', 'insight.side.usage'],
+    '/node/organization': ['configuration.organization', 'configuration', 'settings.nav.organizationHub'],
+    '/node/members': ['configuration.members', 'configuration', 'settings.nav.members'],
+    '/node/subscription': ['configuration.subscription', 'configuration', 'settings.nav.subscription'],
+    '/ops/health': ['operations.operational_health', 'operations', 'ops.nav.operationalHealth'],
+    '/ops/alerts': ['operations.alerts', 'operations', 'ops.nav.alerts'],
+    '/ops/alerts/rules': ['operations.alert_rules', 'operations', 'ops.nav.alertRules'],
+    '/ops/channels': ['operations.notification_channels', 'operations', 'ops.nav.notificationChannels'],
+    '/ops/delivery-history': ['operations.delivery_history', 'operations', 'ops.nav.deliveryHistory'],
+    '/ops/tasks': ['operations.tasks', 'operations', 'ops.task.sideTasks'],
+    '/ops/audit-logs': ['operations.audit_logs', 'operations', 'ops.task.sideAudit'],
+    '/account/profile': ['account.profile', 'account', 'account.pageProfileTitle'],
+    '/account/notifications': ['account.notifications', 'account', 'account.pageNotificationsTitle'],
+    '/search': ['global.search', 'global', 'nav.searchPlaceholder'],
+    '/login': ['auth.login', 'auth', 'login.btnSubmit'],
+    '/register': ['auth.register', 'auth', 'register.welcomeTitle'],
+    '/auth/oauth/callback': ['auth.oauth_callback', 'auth', 'login.googleBtn'],
+    '/auth/oauth/error': ['auth.oauth_error', 'auth', 'login.googleErrorTitle'],
+  }
+  const staticPage = staticPages[pagePath]
+  if (staticPage) return pageMetadata(staticPage[0], staticPage[1], 'console', pagePath, staticPage[2])
+  const prefixPages: Array<[string, string, string, string]> = [
+    ['/protection/backups/create', 'protection.backup_wizard', 'protection', 'protection.side.dataProtection'],
+    ['/protection/policies/create', 'protection.backup_policies', 'protection', 'protection.side.backupPolicies'],
+    ['/protection/policies/', 'protection.backup_policies', 'protection', 'protection.side.backupPolicies'],
+    ['/protection/file-filter-rules/help', 'protection.file_filters', 'protection', 'protection.side.fileFilterRules'],
+    ['/node/repositories/s3/', 'protection.object_storage', 'protection', 'protection.side.objectStorage'],
+    ['/node/repositories/nas/', 'protection.target_nas', 'protection', 'repositoriesPage.tabNas'],
+    ['/node/repositories/proxy-fs/', 'protection.local_disks', 'protection', 'protection.side.standaloneDisks'],
+    ['/node/nodes/deploy', 'protection.node_deployment', 'protection', 'nodesDeploy.pageTitle'],
+    ['/ops/alerts/rules/', 'operations.alert_rules', 'operations', 'ops.nav.alertRules'],
+    ['/ops/channels/', 'operations.notification_channels', 'operations', 'ops.nav.notificationChannels'],
+  ]
+  const prefixedPage = prefixPages.find(([prefix]) => rawPath.startsWith(prefix))
+  if (prefixedPage) {
+    return pageMetadata(prefixedPage[1], prefixedPage[2], 'console', pagePath, prefixedPage[3])
+  }
+  if (rawPath.includes('/protection/backups/:backupId/snapshots/:snapshotId')) {
+    return pageMetadata('protection.snapshot_detail', 'protection', 'console', rawPath, 'analytics.pages.snapshotDetails')
+  }
+  if (rawPath.includes('/protection/backups/:backupId')) {
+    return pageMetadata('protection.backup_detail', 'protection', 'console', rawPath, 'analytics.pages.backupDetails')
+  }
+  if (rawPath.includes('/protection/restore/snapshots/:snapshotId')) {
+    return pageMetadata('protection.restore', 'protection', 'console', rawPath, 'analytics.pages.restore')
+  }
+  return pageMetadata('route.other', 'other', 'console', '/other', 'nav.navigation')
+}
+
+function analyticsRouteTemplate(
   route: Pick<RouteLocationNormalizedLoaded, 'matched' | 'path'>,
 ): string {
   const matchedPath = route.matched.reduce((path, record) => {
@@ -45,14 +229,28 @@ export function analyticsRoutePath(
   return path.startsWith('/') ? path : `/${path}`
 }
 
-function trackPageView(path: string): void {
+function trackPageView(page: AnalyticsPageMetadata): void {
   if (!activeMeasurementId || !window.gtag) return
-  activePagePath = path
+  const locale = currentUiLanguage()
+  const signature = `${page.pageSurface}|${page.pageKey}|${page.pagePath}`
+  activePage = page
+  document.title = page.title
+  if (!pageTrackingReady) {
+    pendingPage = page
+    return
+  }
+  pendingPage = null
+  if (signature === lastTrackedPageSignature) return
+  lastTrackedPageSignature = signature
   window.gtag('event', 'page_view', {
-    page_location: `${window.location.origin}${path}`,
-    page_path: path,
+    page_location: `${window.location.origin}${page.pagePath}`,
+    page_path: page.pagePath,
     page_referrer: sanitizedReferrer(),
-    page_title: 'HyperFileLens',
+    page_title: activePage.title,
+    page_key: activePage.pageKey,
+    page_group: activePage.pageGroup,
+    page_surface: activePage.pageSurface,
+    ui_language: locale,
   })
 }
 
@@ -61,12 +259,19 @@ export function trackAppEvent(
   parameters: AppAnalyticsParameters,
 ): void {
   if (!activeMeasurementId || !window.gtag) return
+  const page = activePage
   window.gtag('event', name, {
     ...parameters,
-    page_location: `${window.location.origin}${activePagePath}`,
-    page_path: activePagePath,
+    page_location: `${window.location.origin}${page?.pagePath || '/'}`,
+    page_path: page?.pagePath || '/',
     page_referrer: sanitizedReferrer(),
-    page_title: 'HyperFileLens',
+    page_title: page?.title || 'HyperFileLens Console',
+    ...(page ? {
+      page_key: page.pageKey,
+      page_group: page.pageGroup,
+      page_surface: page.pageSurface,
+      ui_language: currentUiLanguage(),
+    } : {}),
   })
 }
 
@@ -79,6 +284,10 @@ function installGoogleTag(measurementId: string): boolean {
   if (activeMeasurementId === measurementId) return true
 
   activeMeasurementId = measurementId
+  activePage = null
+  lastTrackedPageSignature = ''
+  pageTrackingReady = false
+  pendingPage = null
   window.dataLayer = window.dataLayer || []
   // Google Tag distinguishes its Arguments command object from a normal Array.
   window.gtag = function gtag() {
@@ -100,5 +309,26 @@ function installGoogleTag(measurementId: string): boolean {
 
 export function initAppAnalytics(router: Router): void {
   if (!installGoogleTag(configuredMeasurementId())) return
-  router.afterEach((route) => trackPageView(analyticsRoutePath(route)))
+  analyticsRouter = router
+  router.afterEach((route) => trackPageView(analyticsPageMetadata(route)))
+  const currentRoute = router.currentRoute?.value
+  if (currentRoute?.matched.length) trackPageView(analyticsPageMetadata(currentRoute))
+  if (typeof MutationObserver !== 'undefined' && !localeObserver) {
+    localeObserver = new MutationObserver(() => {
+      const currentRoute = router.currentRoute?.value
+      if (currentRoute) trackPageView(analyticsPageMetadata(currentRoute))
+    })
+    localeObserver.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['lang'],
+    })
+  }
+}
+
+/** Release the latest pending page view after optional language packs select the UI locale. */
+export function activateAppAnalytics(): void {
+  const currentRoute = analyticsRouter?.currentRoute?.value
+  if (currentRoute?.matched.length) pendingPage = analyticsPageMetadata(currentRoute)
+  pageTrackingReady = true
+  if (pendingPage) trackPageView(pendingPage)
 }

--- a/src/frontend/src/locales/en.ts
+++ b/src/frontend/src/locales/en.ts
@@ -2,6 +2,13 @@
 import { enProtectionPages } from './enProtectionPages'
 
 export const en = {
+  analytics: {
+    pages: {
+      backupDetails: 'Backup Details',
+      snapshotDetails: 'Snapshot Details',
+      restore: 'Restore',
+    },
+  },
   common: {
     confirm: 'OK',
     confirmDelete: 'Confirm Delete',

--- a/src/frontend/src/main.ts
+++ b/src/frontend/src/main.ts
@@ -23,7 +23,7 @@ import { setupElementPlus } from './plugins/element-plus'
 import { setLocale } from './lib/api'
 import { setupAuthGuard, setupSessionWatchdog } from './composables/useAuth'
 import { initSentry } from './lib/sentry'
-import { initAppAnalytics } from './lib/analytics'
+import { activateAppAnalytics, initAppAnalytics } from './lib/analytics'
 
 async function bootstrap() {
   const app = createApp(App)
@@ -43,6 +43,7 @@ async function bootstrap() {
 
   void loadInstalledLangPacks().then(() => {
     resolveLocaleAfterPacksLoaded()
+    activateAppAnalytics()
   })
 }
 

--- a/src/frontend/src/platform-ops/routes.ts
+++ b/src/frontend/src/platform-ops/routes.ts
@@ -10,16 +10,19 @@ export const platformOpsRoutes = [
   {
     path: 'platform/email',
     name: 'PlatformOpsSettingsEmail',
+    meta: { analytics: { pageKey: 'platform.email', pageGroup: 'platform', pageSurface: 'admin', titleKey: 'platformOps.settings.emailTitle' } },
     component: lazyRoute(() => import('./pages/platform/settings/EmailSettings.vue')),
   },
   {
     path: 'platform/authentication',
     name: 'PlatformOpsAuthentication',
+    meta: { analytics: { pageKey: 'platform.authentication', pageGroup: 'platform', pageSurface: 'admin', titleKey: 'platformOps.settings.identityTitle' } },
     component: lazyRoute(() => import('./pages/platform/settings/IdentitySettings.vue')),
   },
   {
     path: 'platform/runtime-environment',
     name: 'PlatformOpsRuntimeEnvironment',
+    meta: { analytics: { pageKey: 'platform.runtime_environment', pageGroup: 'platform', pageSurface: 'admin', titleKey: 'platformOps.settings.environmentTitle' } },
     component: lazyRoute(() => import('./pages/platform/settings/EnvironmentSettings.vue')),
   },
   { path: 'platform/settings/email', redirect: '/platform-ops/platform/email' },
@@ -34,14 +37,17 @@ export const platformOpsRoutes = [
       { path: '', redirect: '/platform-ops/engine/ai-settings' },
       {
         path: 'ai-settings',
+        meta: { analytics: { pageKey: 'platform.ai_models', pageGroup: 'platform', pageSurface: 'admin', titleKey: 'platformOps.nav.engineModels' } },
         component: lazyRoute(() => import('../pages/insight/InsightAiSettings.vue')),
       },
       {
         path: 'ai-settings/add',
+        meta: { analytics: { pageKey: 'platform.ai_models', pageGroup: 'platform', pageSurface: 'admin', titleKey: 'platformOps.nav.engineModels' } },
         component: lazyRoute(() => import('../pages/insight/AiModelFormPage.vue')),
       },
       {
         path: 'ai-settings/:uuid/edit',
+        meta: { analytics: { pageKey: 'platform.ai_models', pageGroup: 'platform', pageSurface: 'admin', titleKey: 'platformOps.nav.engineModels' } },
         component: lazyRoute(() => import('../pages/insight/AiModelFormPage.vue')),
       },
       // Community bookmarks for the removed gateways menu → AI Models.

--- a/website/.vitepress/theme/analytics.ts
+++ b/website/.vitepress/theme/analytics.ts
@@ -26,6 +26,37 @@ let activeMeasurementId = ''
 let activePagePath = '/'
 let lastTrackedPagePath = ''
 
+function websitePageMetadata(path: string) {
+  const isDocs = /^\/(?:en|zh)(?:-[^/]+)?\/docs(?:\/|$)/.test(path)
+  const locale = path.startsWith('/zh') ? 'zh' : 'en'
+  const relative = path.replace(/^\/(?:en|zh)(?:-[^/]+)?\//, '').replace(/^docs\/?/, '')
+  const slug = relative.replace(/\/$/, '').replace(/[^a-zA-Z0-9/_-]+/g, '_') || 'home'
+  let pageGroup = 'home'
+  if (isDocs) {
+    if (/^(?:getting-started|$)/.test(relative)) pageGroup = 'quick_start'
+    else if (/^(?:product|backup-restore|insights)/.test(relative)) pageGroup = 'product_usage'
+    else if (/^deployment/.test(relative)) pageGroup = 'deployment_operations'
+    else pageGroup = 'help_center'
+  }
+  const pageKey = isDocs
+    ? `docs.${slug === 'home' ? 'quick_start' : slug.replace(/[/-]+/g, '.')}`
+    : 'website.home'
+  return { pageKey, pageGroup, pageSurface: isDocs ? 'docs' : 'website', locale }
+}
+
+function websitePageTitle(path: string, isDocs: boolean): string {
+  const current = document.title.trim()
+  if (isDocs && current && current !== 'HyperFileLens') {
+    const base = current.replace(/\s*\|\s*HyperFileLens(?: Docs)?\s*$/i, '').trim()
+    if (base) return `${base} | HyperFileLens Docs`
+  }
+  if (isDocs) return 'Documentation | HyperFileLens Docs'
+  // Keep the source publication English-only. The locale is reported separately
+  // in ui_language, while VitePress supplies the localized document title when
+  // one exists.
+  return 'Home | HyperFileLens'
+}
+
 function sanitizedPath(value: string): string {
   try {
     const parsed = new URL(value, window.location.origin)
@@ -82,20 +113,34 @@ export function trackWebsitePageView(value: string): void {
   if (path === lastTrackedPagePath) return
   lastTrackedPagePath = path
   activePagePath = path
+  const metadata = websitePageMetadata(path)
+  const isDocs = metadata.pageSurface === 'docs'
+  const pageTitle = websitePageTitle(path, isDocs)
+  document.title = pageTitle
   window.gtag('event', 'page_view', {
     page_location: `${window.location.origin}${path}`,
     page_path: path,
     page_referrer: sanitizedReferrer(),
-    page_title: 'HyperFileLens Website',
+    page_title: pageTitle,
+    page_key: metadata.pageKey,
+    page_group: metadata.pageGroup,
+    page_surface: metadata.pageSurface,
+    ui_language: metadata.locale,
   })
 }
 
 function websiteEventContext() {
+  const metadata = websitePageMetadata(activePagePath)
+  const isDocs = metadata.pageSurface === 'docs'
   return {
     page_location: `${window.location.origin}${activePagePath}`,
     page_path: activePagePath,
     page_referrer: sanitizedReferrer(),
-    page_title: 'HyperFileLens Website',
+    page_title: websitePageTitle(activePagePath, isDocs),
+    page_key: metadata.pageKey,
+    page_group: metadata.pageGroup,
+    page_surface: metadata.pageSurface,
+    ui_language: metadata.locale,
   }
 }
 

--- a/website/.vitepress/theme/index.ts
+++ b/website/.vitepress/theme/index.ts
@@ -1,5 +1,6 @@
 import type { Theme } from 'vitepress'
 import DefaultTheme from 'vitepress/theme'
+import { nextTick } from 'vue'
 import Layout from './Layout.vue'
 import './custom.css'
 import './docs.css'
@@ -230,7 +231,10 @@ export default {
   enhanceApp({ router }) {
     if (typeof window === 'undefined') return
     initWebsiteAnalytics()
-    router.onAfterRouteChange = (to) => {
+    router.onAfterRouteChange = async (to) => {
+      // VitePress updates document.title from reactive page data. Wait for that
+      // update before deriving the title used in the analytics event.
+      await nextTick()
       trackWebsitePageView(to)
       enhanceDocPage(to)
     }


### PR DESCRIPTION
## Summary

- add consistent GA4 page metadata for the website, documentation, and application console
- classify pages by product surface and top-level capability without exposing resource identifiers
- defer the first application page view until optional language packs resolve, while preserving event tracking
- keep Admin Console analytics disabled and add privacy-safe fallback handling for undeclared routes
- cover enterprise-declared routes through the Host analytics contract

## Validation

- Analytics tests: 9 passed
- Vue type check and production frontend build passed
- Website build passed
- English source boundary check passed
- git diff --check passed

## Related

- Enterprise route metadata is provided by the companion hyperfilelens-ee pull request.